### PR TITLE
Honors/non-honors courses in grade and prof commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -43,6 +44,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/bot/cogs/grades_cog/assets/2014_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2014_Fall.csv
@@ -1,3047 +1,3047 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1010,001,Survey of Art & Arch,0.44,0.42,0.11,0.0,0.0,0.0,0.0,0.02,beth ann lauritis,
-AAH,2050,001,Art History and Theo,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.04,beth ann lauritis,
-AAH,2100,400,Intro to Art and Arc,0.23,0.42,0.12,0.12,0.08,0.0,0.0,0.04,lydia jane dorsey,
-AAH,2100,401,Intro to Art and Arc,0.45,0.34,0.14,0.07,0.0,0.0,0.0,0.0,lydia jane dorsey,
-AAH,2100,402,Intro to Art and Arc,0.28,0.4,0.16,0.08,0.0,0.0,0.0,0.08,lydia jane dorsey,
-AAH,2100,403,Intro to Art and Arc,0.39,0.43,0.0,0.04,0.07,0.0,0.0,0.07,lydia jane dorsey,
-AAH,3050,001,Contemporary Art His,0.6,0.2,0.13,0.0,0.0,0.0,0.0,0.07,andrea feeser,
-ACCT,2010,001,Financial Accounting,0.04,0.22,0.3,0.02,0.15,0.0,0.0,0.26,philip maiberger,
-ACCT,2010,002,Financial Accounting,0.13,0.3,0.28,0.09,0.04,0.0,0.0,0.17,philip maiberger,
-ACCT,2010,003,Financial Accounting,0.19,0.22,0.22,0.08,0.1,0.0,0.0,0.18,suzanne pearse,
-ACCT,2010,004,Financial Accounting,0.3,0.3,0.2,0.05,0.07,0.0,0.0,0.09,suzanne pearse,
-ACCT,2010,005,Fin Acct Concepts (H,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True
-ACCT,2010,006,Financial Accounting,0.24,0.33,0.24,0.07,0.05,0.0,0.0,0.07,annieka philo,
-ACCT,2010,007,Financial Accounting,0.24,0.27,0.11,0.08,0.16,0.0,0.0,0.14,lydia lan schleifer,
-ACCT,2010,008,Financial Accounting,0.24,0.33,0.14,0.04,0.1,0.0,0.0,0.14,lydia lan schleifer,
-ACCT,2010,009,Financial Accounting,0.12,0.34,0.24,0.07,0.1,0.0,0.0,0.12,annieka philo,
-ACCT,2010,010,Financial Accounting,0.26,0.13,0.26,0.08,0.05,0.0,0.0,0.23,lydia lan schleifer,
-ACCT,2010,011,Financial Accounting,0.2,0.18,0.25,0.15,0.05,0.0,0.0,0.18,james mil kohlmeyer,
-ACCT,2010,012,Financial Accounting,0.27,0.24,0.27,0.12,0.02,0.0,0.0,0.07,james mil kohlmeyer,
-ACCT,2010,013,Financial Accounting,0.19,0.43,0.16,0.1,0.03,0.0,0.0,0.09,the estate  guffey,
-ACCT,2010,014,Financial Accounting,0.09,0.31,0.2,0.13,0.09,0.0,0.0,0.19,jeffrey mcmillan,
-ACCT,2010,015,Financial Accounting,0.03,0.28,0.23,0.15,0.17,0.0,0.0,0.13,james mil kohlmeyer,
-ACCT,2020,001,Managerial Accountin,0.18,0.31,0.2,0.06,0.08,0.0,0.0,0.18,henry anderson,
-ACCT,2020,002,Managerial Accountin,0.23,0.28,0.19,0.04,0.09,0.0,0.0,0.17,henry anderson,
-ACCT,2020,003,Managerial Accountin,0.17,0.37,0.25,0.1,0.06,0.0,0.0,0.06,annieka philo,
-ACCT,2020,004,Managerial Accountin,0.24,0.27,0.25,0.12,0.08,0.0,0.0,0.04,annieka philo,
-ACCT,2020,006,Managerial Accountin,0.57,0.22,0.14,0.0,0.02,0.0,0.0,0.06,sarah martin,
-ACCT,2020,007,Managerial Accountin,0.14,0.21,0.31,0.03,0.12,0.0,0.0,0.21,henry anderson,
-ACCT,2020,008,Managerial Accountin,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,sarah martin,
-ACCT,2040,001,Accounting Procedure,0.53,0.25,0.08,0.02,0.02,0.0,0.0,0.11,jeffrey mcmillan,
-ACCT,2040,002,Accounting Procedure,0.37,0.25,0.14,0.02,0.03,0.0,0.0,0.19,jeffrey mcmillan,
-ACCT,3030,001,Cost Accounting,0.31,0.24,0.28,0.0,0.03,0.0,0.0,0.14,henry anderson,
-ACCT,3030,002,Cost Accounting,0.22,0.35,0.22,0.05,0.11,0.0,0.0,0.05,henry anderson,
-ACCT,3030,003,Cost Accounting,0.38,0.28,0.23,0.0,0.05,0.0,0.0,0.05,robin radtke,
-ACCT,3030,005,Cost Accounting,0.28,0.35,0.13,0.03,0.1,0.0,0.0,0.13,robin radtke,
-ACCT,3110,001,Intermed Financial A,0.5,0.31,0.13,0.06,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3110,002,Intermed Financial A,0.51,0.36,0.05,0.03,0.03,0.0,0.0,0.03,terry daniel knause,
-ACCT,3110,003,Intermed Financial A,0.38,0.23,0.28,0.05,0.0,0.0,0.0,0.05,terry daniel knause,
-ACCT,3110,005,Intermed Financial A,0.35,0.32,0.19,0.05,0.0,0.0,0.0,0.08,terry daniel knause,
-ACCT,3120,001,Intermed Financial A,0.03,0.18,0.41,0.21,0.09,0.0,0.0,0.09,brian todd carver,
-ACCT,3120,002,Intermed Financial A,0.17,0.3,0.26,0.09,0.07,0.0,0.0,0.11,suzanne pearse,
-ACCT,3120,003,Intermed Financial A,0.05,0.18,0.37,0.18,0.08,0.0,0.0,0.13,brian todd carver,
-ACCT,3120,004,Intermed Financial A,0.09,0.31,0.36,0.16,0.02,0.0,0.0,0.07,suzanne pearse,
-ACCT,3130,001,Intermed Financial A,0.17,0.42,0.42,0.0,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3130,002,Intermed Financial A,0.19,0.47,0.22,0.06,0.0,0.0,0.0,0.06, russell madray,
-ACCT,3130,003,Intermed Financial A,0.21,0.47,0.24,0.0,0.05,0.0,0.0,0.03, russell madray,
-ACCT,3130,005,Intermed Financial A,0.18,0.24,0.42,0.05,0.05,0.0,0.0,0.05, russell madray,
-ACCT,3220,001,Accounting Informati,0.21,0.26,0.31,0.08,0.05,0.0,0.0,0.1,philip maiberger,
-ACCT,3220,002,Accounting Informati,0.15,0.41,0.08,0.13,0.08,0.0,0.0,0.15,philip maiberger,
-ACCT,3220,003,Accounting Informati,0.2,0.55,0.15,0.0,0.05,0.0,0.0,0.05,nancy lee harp,
-ACCT,4040,002,Individual Taxation,0.36,0.36,0.24,0.02,0.0,0.0,0.0,0.02,derek dalton,
-ACCT,4040,003,Individual Taxation,0.1,0.44,0.28,0.03,0.05,0.0,0.0,0.1,derek dalton,
-ACCT,4080,001,Retire & Estate Plan,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,john hine,
-ACCT,4100,001,Reporting and Mgmt C,0.34,0.42,0.18,0.03,0.0,0.0,0.0,0.03,sally kathr widener,
-ACCT,4100,002,Reporting and Mgmt C,0.57,0.3,0.04,0.04,0.04,0.0,0.0,0.0,sally kathr widener,
-ACCT,4150,001,Auditing,0.06,0.34,0.38,0.19,0.03,0.0,0.0,0.0,carl hollingsworth,
-ACCT,4150,002,Auditing,0.32,0.42,0.1,0.06,0.03,0.0,0.0,0.06,carl hollingsworth,
-ACCT,8510,001,Tax Research,0.25,0.59,0.16,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8510,002,Tax Research,0.06,0.79,0.12,0.0,0.03,0.0,0.0,0.0,thomas dickens,
-ACCT,8530,001,Adv Acct Problems,0.52,0.36,0.09,0.0,0.0,0.0,0.0,0.03,ralph welton,
-ACCT,8530,002,Adv Acct Problems,0.48,0.42,0.03,0.0,0.06,0.0,0.0,0.0,ralph welton,
-ACCT,8550,001,Gov't and Nonprofit,0.59,0.35,0.03,0.0,0.03,0.0,0.0,0.0,james barnes,
-ACCT,8550,002,Gov't and Nonprofit,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8630,001,Forensics Analysis,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,james irving,
-ACCT,8630,002,Forensics Analysis,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,james irving,
-ACCT,8630,003,Forensics Analysis,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,james irving,
-ACCT,8730,001,Intl/Spec Tax Topic,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,judson jahn,
-ACCT,8730,002,Intl/Spec Tax Topic,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,judson jahn,
-AGED,1020,001,Freshman Seminar,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,christina mel leard,
-AGED,2010,001,Intro to Agric Educ,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,2040,001,App Ag Calculations,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,3030,001,Ag Ed Mech Tech,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,3650,001,Multiculturalism in,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,alex byrd,
-AGED,4010,001,Instr Methods Ag Ed,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,thomas dobbins,
-AGED,4010,001,Instr Methods Ag Ed,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,
-AGED,4030,001,Prin Adult/Ext Ed,0.55,0.1,0.2,0.0,0.05,0.0,0.0,0.1,freddie waltz,
-AGED,4230,400,Curriculum,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,
-AGED,6010,001,Instr Methods Ag Ed,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,kevin layfield,
-AGED,6010,001,Instr Methods Ag Ed,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,thomas dobbins,
-AGM,1010,001,Intro Ag Mech & Bus,0.64,0.25,0.07,0.02,0.02,0.0,0.0,0.0,hunter massey,
-AGM,2050,001,Prin of Fabrication,0.15,0.52,0.28,0.01,0.01,0.0,0.0,0.01,hunter massey,
-AGM,2060,001,Machinery Mgt,0.15,0.4,0.3,0.15,0.0,0.0,0.0,0.0,hunter massey,
-AGM,2190,001,Agribuxiness and Foo,0.24,0.45,0.29,0.02,0.0,0.0,0.0,0.0,wilder ferreira,
-AGM,2210,001,Land Measurements,0.44,0.4,0.12,0.01,0.03,0.0,0.0,0.0,charles privette,
-AGM,3010,001,Soil Water Conserv,0.29,0.41,0.14,0.1,0.06,0.0,0.0,0.0,calvin sawyer,
-AGM,3190,001,Agribusiness Decisio,0.38,0.28,0.22,0.13,0.0,0.0,0.0,0.0,wilder ferreira,
-AGM,4050,001,Env Cont in Anim Str,0.38,0.56,0.05,0.0,0.0,0.0,0.0,0.0,john chastain,
-AGM,4060,001,Mech & Hydraulic Sys,0.42,0.45,0.12,0.0,0.0,0.0,0.0,0.0,young han,
-AGM,4600,001,Electrical Systems,0.42,0.52,0.06,0.0,0.0,0.0,0.0,0.0,young han,
-AL,3490,400,Principles of Coachi,0.36,0.4,0.12,0.04,0.0,0.0,0.0,0.08,deborah cadorette,
-AL,3490,401,Principles of Coachi,0.52,0.33,0.15,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,402,Principles of Coachi,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,
-AL,3490,403,Principles of Coachi,0.41,0.35,0.0,0.18,0.06,0.0,0.0,0.0,clyde keith connor,
-AL,3500,400,Sci Basis I/Ex Phy,0.22,0.44,0.26,0.04,0.04,0.0,0.0,0.0,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.28,0.12,0.16,0.32,0.08,0.0,0.0,0.04,michael godfrey,
-AL,3520,400,Kinesiology,0.29,0.21,0.21,0.14,0.14,0.0,0.0,0.0,michael godfrey,
-AL,3530,400,Athletic Injuries,0.16,0.47,0.21,0.11,0.05,0.0,0.0,0.0,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.15,0.25,0.15,0.35,0.1,0.0,0.0,0.0,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical,0.43,0.25,0.18,0.07,0.04,0.0,0.0,0.04,clyde keith connor,
-AL,3610,400,Admin/Org of Athleti,0.73,0.19,0.04,0.0,0.04,0.0,0.0,0.0,henry oates,
-AL,3610,401,Admin/Org of Athleti,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,Admin/Org of Athleti,0.8,0.12,0.0,0.0,0.04,0.0,0.0,0.04,henry oates,
-AL,3620,400,Psychology of Coachi,0.28,0.28,0.24,0.12,0.04,0.0,0.0,0.04,natalie anne carter,
-AL,3620,401,Psychology of Coachi,0.24,0.2,0.44,0.12,0.0,0.0,0.0,0.0,natalie anne carter,
-AL,3740,400,Coaching Football,0.67,0.07,0.0,0.19,0.0,0.0,0.0,0.07,edmond fry,
-AL,3760,400,Coaching Strength/Co,0.79,0.08,0.04,0.08,0.0,0.0,0.0,0.0,edmond fry,
-AL,3760,401,Coaching Strength/Co,0.42,0.21,0.05,0.16,0.05,0.0,0.0,0.11,edmond fry,
-AL,4380,400,Coach & Athlete in E,0.5,0.14,0.29,0.07,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,8490,400,Athletic Leadership,0.52,0.35,0.04,0.0,0.04,0.0,0.0,0.04,michael godfrey,
-ANTH,2010,001,Intro Anthropology,0.07,0.17,0.32,0.19,0.08,0.0,0.0,0.18,john coggeshall,
-ANTH,2010,001,Introduction to Anth,0.07,0.17,0.32,0.19,0.08,0.0,0.0,0.18,john coggeshall,
-ANTH,2010,002,Intro Anthropology,0.15,0.21,0.29,0.21,0.08,0.0,0.0,0.06,john coggeshall,
-ANTH,2010,002,Introduction to Anth,0.15,0.21,0.29,0.21,0.08,0.0,0.0,0.06,john coggeshall,
-ANTH,2010,003,Introduction to Anth,0.24,0.59,0.08,0.04,0.02,0.0,0.0,0.02,katherine weisensee,
-ANTH,2010,003,Intro Anthropology,0.24,0.59,0.08,0.04,0.02,0.0,0.0,0.02,katherine weisensee,
-ANTH,2010,004,Introduction to Anth,0.17,0.44,0.18,0.07,0.0,0.0,0.0,0.15,melissa vogel,
-ANTH,2010,004,Intro Anthropology,0.17,0.44,0.18,0.07,0.0,0.0,0.0,0.15,melissa vogel,
-ANTH,2010,005,Introduction to Anth,0.29,0.4,0.18,0.0,0.04,0.0,0.0,0.09,lisa rapaport,
-ANTH,2010,005,Intro Anthropology,0.29,0.4,0.18,0.0,0.04,0.0,0.0,0.09,lisa rapaport,
-ANTH,3010,001,Cultural Anthropolog,0.18,0.35,0.24,0.06,0.06,0.0,0.0,0.12,john coggeshall,
-ANTH,3320,001,World Archaeology,0.21,0.32,0.21,0.16,0.05,0.0,0.0,0.05,melissa vogel,
-ANTH,3510,001,Biological Anthropol,0.2,0.53,0.13,0.0,0.0,0.0,0.0,0.13,lisa rapaport,
-ANTH,3530,001,Forensic Anthropolog,0.3,0.57,0.09,0.04,0.0,0.0,0.0,0.0,katherine weisensee,
-ANTH,4660,001,Evolution of Human B,0.4,0.3,0.1,0.0,0.0,0.0,0.0,0.2,lisa rapaport,
-ANTH,4960,003,Creative Inquiry,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,sharon nagy,
-APEC,2020,001,Agric Economics,0.28,0.3,0.33,0.03,0.04,0.0,0.0,0.01,webb smathers,
-APEC,2020,002,Agric Economics,0.14,0.28,0.28,0.17,0.0,0.0,0.0,0.14,david brian willis,
-APEC,2050,001,Agric and Society,0.3,0.47,0.23,0.0,0.0,0.0,0.0,0.0,michael vassalos,
-APEC,2570,001,Nat Res Env Econ,0.15,0.27,0.3,0.12,0.05,0.0,0.0,0.12,david brian willis,
-APEC,3020,001,Econ of Farm Mgt,0.31,0.37,0.31,0.0,0.0,0.0,0.0,0.0,michael vassalos,
-APEC,3090,001,Econ Agric Marketing,0.73,0.09,0.16,0.0,0.0,0.0,0.0,0.02,yuliya val bolotova,
-APEC,3510,001,Prin of Advertising,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,webb smathers,
-APEC,3610,001,Int Health Care Econ,0.47,0.41,0.06,0.06,0.0,0.0,0.0,0.0,khoa dang truong,
-APEC,4900,002,CAFLS Plus Prof. Dev,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,thomas scott,
-ARAB,1010,001,Elementary Arabic I,0.59,0.18,0.0,0.0,0.0,0.0,0.0,0.24,sulafa abou-samra,
-ARCH,1010,001,Intro to Arch,0.56,0.36,0.03,0.0,0.01,0.0,0.0,0.05,sal hambright-belue,
-ARCH,2040,001,Hist of Modern Arch,0.38,0.25,0.35,0.03,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
-ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,2510,002,Arch Foundations I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,2510,002,Arch Foundations I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
-ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
-ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
-ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,annemarie jacques,
-ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,annemarie jacques,
-ARCH,2700,001,Structures I,0.42,0.33,0.08,0.08,0.08,0.0,0.0,0.0,dustin gra albright,
-ARCH,3510,001,Studio Clemson,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,robert john hogan,
-ARCH,3510,002,Studio Clemson,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,3510,002,Studio Clemson,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,robert john hogan,
-ARCH,3510,003,Studio Clemson,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,robert john hogan,
-ARCH,3510,003,Studio Clemson,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,criss mills,
-ARCH,3530,001,Studio Genoa,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,3540,001,Studio Barcelona,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,3540,001,Studio Barcelona,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4010,001,Arch Portfolio,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,martha skinner,
-ARCH,4010,002,Arch Portfolio,0.33,0.29,0.29,0.05,0.0,0.0,0.0,0.05,arash soleimani,
-ARCH,4120,001,History Research,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,4120,002,History Research,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4120,002,History Research,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4140,001,Design Seminar,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,4160,002,Field Studies,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4160,002,Field Studies,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,6290,002,Arch Graphics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lloyd bray,
-ARCH,6850,001,H/Th: Arch+Health,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8210,001,Research Methods,0.63,0.35,0.0,0.0,0.0,0.0,0.0,0.03,dina battisto,
-ARCH,8410,001,Arch Studio I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,
-ARCH,8410,002,Arch Studio I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,junichi satoh,
-ARCH,8510,001,Design Studio III,0.09,0.82,0.0,0.0,0.0,0.0,0.0,0.09,ulrike ann-so heine,
-ARCH,8510,001,Design Studio III,0.09,0.82,0.0,0.0,0.0,0.0,0.0,0.09,dustin gra albright,
-ARCH,8510,002,Design Studio III,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
-ARCH,8510,003,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
-ARCH,8510,003,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8510,004,Design Studio III,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
-ARCH,8510,004,Design Studio III,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,8600,001,History/Theory I,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,ufuk ersoy,
-ARCH,8720,001,Production & Assemb,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,daniel nevi harding,
-ARCH,8720,001,Production & Assemb,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02, franco santa cruz,
-ARCH,8790,002,Digtial Manufacturin,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,
-ARCH,8810,001,Pro Practice Survey,0.64,0.33,0.0,0.0,0.0,0.0,0.0,0.03,katherin schwennsen,
-ARCH,8890,001,Mentorship,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,
-ARCH,8950,001,A+H Studio: Projects,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ARCH,8950,001,A+H Studio: Projects,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ART,1050,001,Foundation Drawing I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,
-ART,1510,001,Foundations Art I,0.8,0.07,0.07,0.07,0.0,0.0,0.0,0.0,alexandra giannell,
-ART,2070,001,Beginning Painting,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,hilary erin siber,
-ART,2110,001,Begin Printmaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,laken grace bridges,
-ART,2130,001,Begin Photography,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,anderson wrangle,
-ART,2170,001,Beginning Ceramics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,nina jeanette kawar,
-ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,
-ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
-ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,david detrich,
-ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david detrich,
-ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,
-ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
-ART,8210,001,Visual Narrative,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
-AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,christopher mann,
-AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,stacey dean wiggins,
-AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,steven price jordan,
-AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,steven price jordan,
-AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher mann,
-AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,stacey dean wiggins,
-AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,stacey dean wiggins,
-AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,christopher mann,
-AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,steven price jordan,
-AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,
-AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,
-AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steven price jordan,
-AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,steven price jordan,
-AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,christopher mann,
-AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,
-AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,
-AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,steven price jordan,
-AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,
-ASL,1010,003,Am Sign Lang I,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,joseph paul may,
-ASL,2010,001,Am Sign Lang II,0.28,0.44,0.28,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,2010,002,Am Sign Lang II,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,2020,001,Am Sign Lang II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,3000,001,Fingerspelling & Num,0.23,0.46,0.23,0.08,0.0,0.0,0.0,0.0,joseph paul may,
-ASTR,1010,001,SolarSystem Astr,0.42,0.36,0.17,0.0,0.01,0.0,0.0,0.04,phillip flower,
-ASTR,1010,002,Solar System Astr,0.5,0.28,0.17,0.01,0.01,0.0,0.0,0.04,phillip flower,
-ASTR,1010,003,Solar System Astr,0.45,0.34,0.17,0.0,0.02,0.0,0.0,0.02,phillip flower,
-ASTR,1030,001,Solar Systm Astr Lab,0.67,0.17,0.0,0.04,0.04,0.0,0.0,0.08,mark leising,
-ASTR,1030,002,Solar Systm Astr Lab,0.28,0.52,0.08,0.0,0.04,0.0,0.0,0.08,mark leising,
-ASTR,1030,003,Solar Systm Astr Lab,0.57,0.26,0.09,0.0,0.0,0.0,0.0,0.09,mark leising,
-ASTR,1030,004,Solar Systm Astr Lab,0.62,0.27,0.04,0.0,0.08,0.0,0.0,0.0,mark leising,
-ASTR,1030,005,Solar Systm Astr Lab,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1030,006,Solar Systm Astr Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1030,007,Solar Systm Astr Lab,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1030,008,Solar Systm Astr Lab,0.48,0.28,0.04,0.0,0.16,0.0,0.0,0.04,mark leising,
-ASTR,1030,009,Solar Systm Astr Lab,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,mark leising,
-AUD,1850,001,Intro to Audio Tech,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUD,2800,001,Sound Reinforcement,0.2,0.27,0.33,0.07,0.07,0.0,0.0,0.07,kenneth moore,
-AUD,3800,001,Audio Engineering I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUE,8270,005,Auto Cntrl Sys Des,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,beshah ayalew,
-AUE,8330,003,Auto Manuf Proc Devl,0.42,0.39,0.15,0.0,0.03,0.0,0.0,0.01,fadi kama abu-farha,
-AUE,8350,100,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,john david smith,
-AUE,8350,100,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,simona onori,
-AUE,8670,001,Veh Manuf Proc I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8800,002,Vehicle Project Mngt,0.81,0.18,0.0,0.0,0.0,0.0,0.0,0.01,imtiaz ul haque,
-AUE,8810,003,Automotive Systems O,0.18,0.79,0.01,0.0,0.0,0.0,0.0,0.01,paul venhovens,
-AUE,8810,003,Automotive Systems O,0.18,0.79,0.01,0.0,0.0,0.0,0.0,0.01,johnell brooks,
-AUE,8830,009,Applied Integration,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,johnell brooks,
-AUE,8830,009,Applied Integration,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,
-AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,douglas feldmaier,
-AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,michael messman,
-AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,imtiaz ul haque,
-AUE,8930,013,Engine Analysis,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8930,014,Automotive Composite,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,david wil schmueser,
-AUE,8930,014,Automotive Composite,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,srikanth pilla,
-AUE,8930,017,Hybrid,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,simona onori,
-AUE,8930,018,Adv IC Engine Concep,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,zoran filipi,
-AUE,8930,019,Innov & Sys Entrepre,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,
-AVS,1000,001,Orientation to Avs,0.84,0.14,0.01,0.0,0.0,0.0,0.0,0.02,johanna joh lascano,
-AVS,1500,001,Intro Animal Science,0.18,0.41,0.3,0.03,0.03,0.0,0.0,0.05,heather walker dunn,
-AVS,1500,002,Intro Animal Science,0.2,0.49,0.25,0.05,0.0,0.0,0.0,0.01,brian bolt,
-AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,brian bolt,
-AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,richelle lor miller,
-AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,anna rebecca baxley,
-AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,heather walker dunn,
-AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,heather walker dunn,
-AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,brian bolt,
-AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,anna rebecca baxley,
-AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,richelle lor miller,
-AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,brian bolt,
-AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
-AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
-AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,brian bolt,
-AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,brian bolt,
-AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
-AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,heather walker dunn,
-AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,brian bolt,
-AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,anna rebecca baxley,
-AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,richelle lor miller,
-AVS,2010,001,Poultry Techniques,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,2030,001,Dairy Sci Techniques,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.02,heather walker dunn,
-AVS,2040,001,Horse Care Technique,0.52,0.3,0.13,0.04,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,2050,001,Horsemanship Techniq,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,meredith donaldson,
-AVS,2050,001,Horsemanship Techniq,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
-AVS,2060,001,Swine Techniques,0.59,0.33,0.08,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,2110,001,Meat Processing Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,brian bolt,
-AVS,2110,001,Meat Processing Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3010,001,Anat & Phys Dom Ani,0.34,0.32,0.2,0.08,0.05,0.0,0.0,0.01,glenn birrenkott,
-AVS,3010,400,Anat & Phys Dom Ani,0.27,0.45,0.23,0.0,0.05,0.0,0.0,0.0,glenn birrenkott,
-AVS,3020,001,Livestk Sel Eval I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3090,001,Equine Evaluation,0.49,0.37,0.05,0.07,0.0,0.0,0.0,0.02,kristine lan vernon,
-AVS,3100,001,Animal Health,0.47,0.26,0.11,0.03,0.0,0.0,0.0,0.14,richard bruner,
-AVS,3700,001,Prin Animal Nutr,0.24,0.25,0.16,0.24,0.1,0.0,0.0,0.02,nathan long,
-AVS,4000,001,AVS Professional Dev,0.69,0.2,0.03,0.03,0.06,0.0,0.0,0.0,james ro strickland,
-AVS,4000,001,AVS Professional Dev,0.69,0.2,0.03,0.03,0.06,0.0,0.0,0.0,johanna joh lascano,
-AVS,4060,001,Seminars & Relat Top,0.79,0.18,0.0,0.04,0.0,0.0,0.0,0.0,johanna joh lascano,
-AVS,4060,001,Seminars & Relat Top,0.79,0.18,0.0,0.04,0.0,0.0,0.0,0.0,james ro strickland,
-AVS,4060,002,Seminars & Relat Top,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,james ro strickland,
-AVS,4060,002,Seminars & Relat Top,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
-AVS,4150,001,Contemp Issues Avs,0.1,0.38,0.38,0.06,0.03,0.0,0.0,0.05,peter skewes,
-AVS,4160,001,Equine Exercise Phys,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,kristine lan vernon,
-AVS,4700,001,Anim Genetics,0.71,0.2,0.06,0.04,0.0,0.0,0.0,0.0,brian bolt,
-AVS,8080,400,Monogastric Nutritio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,
-AVS,8200,001,Graduate Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,
-BCHM,1030,001,Careers in Bioch/Gen,0.87,0.1,0.04,0.0,0.0,0.0,0.0,0.0,alison starr-moss,
-BCHM,3050,001,Essen Elements Bioch,0.2,0.32,0.2,0.12,0.03,0.0,0.0,0.12,srik chandrasekaran,
-BCHM,3050,002,Essen Elements Bioch,0.26,0.32,0.22,0.11,0.04,0.0,0.0,0.04,srik chandrasekaran,
-BCHM,4060,001,Physiological Chem,0.53,0.26,0.13,0.02,0.02,0.0,0.0,0.04,ashby burges bodine,
-BCHM,4310,001,Phys App to Bioch,0.22,0.27,0.27,0.14,0.03,0.0,0.0,0.08,weiguo cao,
-BCHM,4310,002,Phys App to Bioch (H,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True
-BCHM,4330,001,Gen Bioch Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,
-BCHM,4330,002,Gen Bioch Lab I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,weiguo cao,
-BCHM,4400,001,Bioinformatics,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
-BCHM,4430,001,Mol Basis Disease,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,kerry smith,
-BCHM,4430,001,Mol Basis Disease,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james morris,
-BE,2120,001,Fundamentals of Bios,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,3200,001,Principles & Prac of,0.45,0.32,0.18,0.05,0.0,0.0,0.0,0.0,tom owino,
-BE,4100,001,Biological Kinetics,0.4,0.3,0.25,0.05,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,4150,001,Instr & Control Be,0.27,0.41,0.23,0.05,0.05,0.0,0.0,0.0,yi zheng,
-BE,4280,001,Biochem Engr,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,terry walker,
-BE,4740,001,B E Design/Proj Mgt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4750,001,B E Capstone Design,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,
-BE,4750,001,B E Capstone Design,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BIOE,2010,001,Intro Biomed Engr,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,charles webb,
-BIOE,2010,001,Intro Biomed Engr,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,frank alexis,
-BIOE,2010,002,Intro Biomed Engr,0.59,0.34,0.03,0.0,0.02,0.0,0.0,0.02,charles webb,
-BIOE,2010,002,Intro Biomed Engr,0.59,0.34,0.03,0.0,0.02,0.0,0.0,0.02,frank alexis,
-BIOE,3020,001,Biomaterials,0.49,0.3,0.15,0.0,0.02,0.0,0.0,0.04,vladimir vla reukov,
-BIOE,3200,001,Biomechanics,0.58,0.31,0.08,0.02,0.0,0.0,0.0,0.02,lisa benson,
-BIOE,3210,001,Biofluid Mechanics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,zhi gao,
-BIOE,3700,001,Bioinst & Imaging,0.67,0.3,0.02,0.0,0.0,0.0,0.0,0.02,delphine dean,
-BIOE,3700,002,Bioinst & Imaging,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,david kwartowitz,
-BIOE,4010,001,Bio E Design Theory,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4030,001,Applied Bio E Design,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,jorge iva rodriguez,
-BIOE,4030,001,Applied Bio E Design,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,jeremy mercuri,
-BIOE,4120,001,Orthopaedic Engr and,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,melinda harman,
-BIOE,4400,001,Biotech for Bio E,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,sarah harcum,
-BIOE,4510,007,CI Fr/Sr Design and,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,jorge iva rodriguez,
-BIOE,4510,007,CI Fr/Sr Design and,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john desjardins,
-BIOE,4510,022,CI- Mobile Health Ap,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,vladimir vla reukov,
-BIOE,4510,022,CI- Mobile Health Ap,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,ilya mark safro,
-BIOE,4510,029,CI- The DEN,0.74,0.0,0.0,0.0,0.0,0.0,0.0,0.26,john desjardins,
-BIOE,6120,001,Orthopaedic Engr & P,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,melinda harman,
-BIOE,6150,001,Research Principles,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.02,sarah harcum,
-BIOE,6400,001,Biotech for Bio E,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,sarah harcum,
-BIOE,8010,001,Bio Materials,0.33,0.64,0.02,0.0,0.0,0.0,0.0,0.0,robert latour,
-BIOE,8140,401,Medical Dev Commerci,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
-BIOE,8140,401,Medical Dev Commerci,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew ray gevaert,
-BIOE,8200,001,Structl Biomechanics,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,hai yao,
-BIOL,1010,001,Frontiers in Biology,0.68,0.21,0.06,0.02,0.02,0.0,0.0,0.01,robert edwa ballard,
-BIOL,1010,001,Frontiers in Biology,0.68,0.21,0.06,0.02,0.02,0.0,0.0,0.01,michael childress,
-BIOL,1030,001,General Biology I,0.25,0.24,0.27,0.07,0.09,0.0,0.0,0.09,nora espinoza,
-BIOL,1030,002,General Biology I,0.49,0.29,0.14,0.02,0.02,0.0,0.0,0.03,renea chri hardwick,
-BIOL,1030,004,General Biology I,0.15,0.16,0.3,0.13,0.15,0.0,0.0,0.11,salvatore sparace,
-BIOL,1030,005,General Biology I,0.17,0.27,0.25,0.18,0.05,0.0,0.0,0.07,matthew turnbull,
-BIOL,1030,006,General Biology I,0.26,0.38,0.21,0.08,0.05,0.0,0.0,0.02,kristi ja whitehead,
-BIOL,1030,007,General Biology I (H,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
-BIOL,1030,008,General Biology I,0.29,0.25,0.25,0.11,0.03,0.0,0.0,0.07,william surver,
-BIOL,1050,001,General Biology Lab,0.41,0.36,0.09,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,002,General Biology Lab,0.45,0.32,0.05,0.0,0.14,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,003,General Biology Lab,0.45,0.23,0.18,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,004,General Biology Lab,0.36,0.32,0.14,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,005,General Biology Lab,0.59,0.23,0.05,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,006,General Biology Lab,0.23,0.5,0.14,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,007,General Biology Lab,0.36,0.27,0.05,0.09,0.09,0.0,0.0,0.14,tafadzwa kaisa,
-BIOL,1050,008,General Biology Lab,0.55,0.23,0.14,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,009,General Biology Lab,0.3,0.3,0.1,0.05,0.1,0.0,0.0,0.15,tafadzwa kaisa,
-BIOL,1050,010,General Biology Lab,0.26,0.39,0.22,0.0,0.09,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,011,General Biology Lab,0.38,0.21,0.25,0.08,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,012,General Biology Lab,0.33,0.38,0.13,0.0,0.08,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,013,General Biology Lab,0.68,0.14,0.05,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,014,General Biology Lab,0.32,0.41,0.18,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,015,General Biology Lab,0.29,0.48,0.1,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,016,General Biology Lab,0.42,0.42,0.04,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,017,General Biology Lab,0.5,0.36,0.0,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,018,General Biology Lab,0.32,0.41,0.23,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,019,General Biology Lab,0.43,0.35,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,020,General Biology Lab,0.39,0.3,0.17,0.0,0.04,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,021,General Biology Lab,0.43,0.17,0.13,0.09,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,022,General Biology Lab,0.5,0.36,0.09,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,023,General Biology Lab,0.5,0.2,0.1,0.05,0.05,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1050,024,General Biology Lab,0.37,0.37,0.05,0.16,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,025,General Biology Lab,0.36,0.36,0.23,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,026,General Biology Lab,0.52,0.22,0.22,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,027,General Biology Lab,0.27,0.55,0.09,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,028,General Biology Lab,0.64,0.23,0.14,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,029,General Biology Lab,0.36,0.5,0.05,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,030,General Biology Lab,0.5,0.32,0.0,0.0,0.0,0.0,0.0,0.18,tafadzwa kaisa,
-BIOL,1050,031,General Biology Lab,0.32,0.23,0.27,0.05,0.0,0.0,0.0,0.14,tafadzwa kaisa,
-BIOL,1050,032,General Biology Lab,0.38,0.24,0.1,0.0,0.14,0.0,0.0,0.14,tafadzwa kaisa,
-BIOL,1050,033,General Biology Lab,0.42,0.16,0.0,0.05,0.16,0.0,0.0,0.21,tafadzwa kaisa,
-BIOL,1050,034,General Biology Lab,0.52,0.3,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,036,General Biology Lab,0.42,0.25,0.13,0.04,0.13,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,037,General Biology Lab,0.62,0.29,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,038,General Biology Lab,0.33,0.48,0.14,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,039,General Biology Lab,0.48,0.24,0.1,0.05,0.05,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1050,040,General Biology Lab,0.64,0.18,0.05,0.09,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,041,General Biology Lab,0.48,0.29,0.1,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,042,General Biology Lab,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,043,General Biology Lab,0.33,0.38,0.14,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,044,General Biology Lab,0.45,0.36,0.0,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,046,General Biology Lab,0.38,0.42,0.13,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1090,001,Intro to Life Sci,0.82,0.13,0.04,0.02,0.0,0.0,0.0,0.0,renea chri hardwick,
-BIOL,1100,001,Prin of Biology I,0.12,0.4,0.25,0.1,0.03,0.0,0.0,0.09,robert kosinski,
-BIOL,1100,003,Prin of Biology I,0.4,0.35,0.16,0.02,0.03,0.0,0.0,0.04,dylan dittrich-reed,
-BIOL,1100,004,Prin of Biology I (H,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,dylan dittrich-reed,True
-BIOL,1200,001,Biological Inq Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,002,Biological Inq Lab,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,003,Biological Inq Lab,0.35,0.55,0.0,0.0,0.0,0.0,0.0,0.1, christine minor,
-BIOL,1200,004,Biological Inq Lab,0.4,0.35,0.15,0.05,0.0,0.0,0.0,0.05, christine minor,
-BIOL,1200,005,Biological Inq Lab,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,006,Biological Inq Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,007,Biological Inq Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,
-BIOL,1200,008,Biological Inq Lab,0.33,0.44,0.11,0.06,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1200,010,Biological Inq Lab,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,
-BIOL,1200,011,Biological Inq Lab,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,012,Biological Inq Lab,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,013,Biological Inq Lab,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,014,Biological Inq Lab,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,015,Biological Inq Lab,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,016,Biological Inq Lab,0.5,0.38,0.06,0.0,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1220,001,Keys to Biodiversity,0.24,0.4,0.24,0.07,0.02,0.0,0.0,0.02,kalan ickes,
-BIOL,1230,001,Keys to Human Biol,0.22,0.44,0.23,0.08,0.02,0.0,0.0,0.01, christine minor,
-BIOL,1230,002,Keys to Human Biol,0.33,0.43,0.17,0.07,0.01,0.0,0.0,0.0, christine minor,
-BIOL,2000,002,Biology in the News,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0, christine minor,
-BIOL,2000,009,Biology in the News,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,douglas bielenberg,
-BIOL,2000,010,Biology in the News,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,
-BIOL,2040,001,"Environ, Energy and",0.29,0.32,0.25,0.03,0.04,0.0,0.0,0.07,john jenkins hains,
-BIOL,2220,001,Human Anat and Physi,0.22,0.38,0.24,0.09,0.04,0.0,0.0,0.04,john cummings,
-BIOL,2220,002,Human Anat and Physi,0.19,0.37,0.24,0.11,0.02,0.0,0.0,0.05,john cummings,
-BIOL,3030,001,Vertebrate Biology,0.29,0.29,0.2,0.14,0.04,0.0,0.0,0.03,richard blob,
-BIOL,3030,002,Vertebrate Biology (,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True
-BIOL,3040,001,Biology of Plants,0.12,0.34,0.36,0.09,0.06,0.0,0.0,0.03,robert edwa ballard,
-BIOL,3070,001,Vertebrate Biology L,0.5,0.4,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,002,Vertebrate Biology L,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,003,Vertebrate Biology L,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,004,Vertebrate Biology L,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,richard blob,
-BIOL,3070,005,Vertebrate Biology L,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,006,Vertebrate Biology L,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,007,Vertebrate Biology L,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,008,Vertebrate Biology L,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,009,Vertebrate Biology L,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,010,Vertebrate Biology L,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,011,Vertebrate Biology L,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,012,Vertebrate Biology L,0.55,0.4,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,013,Vertebrate Biology L,0.55,0.35,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3080,001,Biology of Plants Pr,0.63,0.21,0.05,0.05,0.05,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3080,002,Biology of Plants Pr,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3080,003,Biology of Plants Pr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3080,004,Biology of Plants Pr,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,robert edwa ballard,
-BIOL,3150,001,Functional Human Ana,0.25,0.46,0.19,0.04,0.01,0.0,0.0,0.05,tamara mcnutt-scott,
-BIOL,3200,001,Field Botany,0.19,0.37,0.24,0.09,0.07,0.0,0.0,0.04,timothy spira,
-BIOL,3350,001,Evolutionary Biology,0.27,0.46,0.11,0.06,0.04,0.0,0.0,0.04,margaret ptacek,
-BIOL,3510,001,Biological Anthropol,0.42,0.33,0.08,0.0,0.17,0.0,0.0,0.0,lisa rapaport,
-BIOL,3530,001,Forensic Anthrolpolo,0.31,0.38,0.15,0.08,0.08,0.0,0.0,0.0,katherine weisensee,
-BIOL,4340,001,Biological Chem Lab,0.15,0.23,0.38,0.08,0.0,0.0,0.0,0.15,salvatore sparace,
-BIOL,4340,003,Biological Chem Lab,0.17,0.5,0.08,0.25,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,004,Biological Chem Lab,0.17,0.42,0.25,0.08,0.08,0.0,0.0,0.0,salvatore sparace,
-BIOL,4410,001,Ecology,0.25,0.44,0.19,0.09,0.01,0.0,0.0,0.02,david tonkyn,
-BIOL,4430,001,Freshwater Ecology,0.56,0.29,0.13,0.0,0.0,0.0,0.0,0.02,john jenkins hains,
-BIOL,4450,001,Ecology Laboratory (,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,david tonkyn,
-BIOL,4450,002,Ecology Laboratory (,0.36,0.36,0.18,0.0,0.0,0.0,0.0,0.09,david tonkyn,
-BIOL,4450,003,Ecology Laboratory (,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
-BIOL,4450,004,Ecology Laboratory (,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david tonkyn,
-BIOL,4610,001,Cell Biology,0.38,0.3,0.11,0.11,0.0,0.0,0.0,0.1,lesly temesvari,
-BIOL,4610,002,Cell Biology (HON),0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True
-BIOL,4610,003,Cell Biology,0.91,0.06,0.01,0.01,0.01,0.0,0.0,0.0,susan carol chapman,
-BIOL,4610,004,Cell Biology (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True
-BIOL,4620,001,Cell Biology Lab (Le,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4620,003,Cell Biology Lab (Le,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4620,004,Cell Biology Lab (Le,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4620,005,Cell Biology Lab (Le,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4620,006,Cell Biology Lab (Le,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4620,007,Cell Biology Lab (Le,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,david feliciano,
-BIOL,4620,008,Cell Biology Lab (Le,0.27,0.33,0.4,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4620,010,Cell Biology Lab (Le,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4620,011,Cell Biology Lab (Le,0.36,0.43,0.0,0.07,0.07,0.0,0.0,0.07,david feliciano,
-BIOL,4660,001,Evolution of Human B,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,lisa rapaport,
-BIOL,4670,001,Principles of Hemato,0.88,0.05,0.05,0.0,0.0,0.0,0.0,0.02,vincent gallicchio,
-BIOL,4750,001,Comparative Physiolo,0.3,0.43,0.14,0.0,0.08,0.0,0.0,0.05,michael sears,
-BIOL,4760,003,Comparative Physiolo,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael sears,
-BIOL,4930,002,Adv Cancer Research,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,wen chen,
-BIOL,4940,001,Aging Stress Induced,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,min cao,
-BIOL,4940,001,Aging Stress Induced,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,yuqing dong,
-BIOL,4940,007,Popular Science Jour,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,steven katz,
-BIOL,4940,007,Popular Science Jour,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
-BIOL,4960,004,MARINE MICRO,0.27,0.33,0.27,0.13,0.0,0.0,0.0,0.0,john michael henson,
-BIOL,8200,001,Community Ecology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,saara dewalt,
-BIOL,8400,001,Understanding Biolog,0.83,0.1,0.01,0.0,0.02,0.0,0.0,0.03,michael childress,
-BIOL,8420,001,Understand Cellular,0.57,0.31,0.06,0.0,0.04,0.0,0.0,0.02,david feliciano,
-BIOL,8440,001,Understanding the Hu,0.65,0.29,0.03,0.0,0.02,0.0,0.0,0.0,heidi lynn jordan,
-BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,sandy edge,
-BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,michael giebner,
-BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,michael giebner,
-BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,sandy edge,
-BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,michael giebner,
-BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,sandy edge,
-BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,sandy edge,
-BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,edward bar de iulio,
-BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,michael giebner,
-BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,sandy edge,
-BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,michael giebner,
-BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,sandy edge,
-BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,michael giebner,
-BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,william ern tumblin,
-BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,sandy edge,
-BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,michael giebner,
-BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
-BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,michael giebner,
-BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,sandy edge,
-BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
-BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,michael giebner,
-BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,sandy edge,
-BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
-BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,sandy edge,
-BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,michael giebner,
-BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,sandy edge,
-BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,michael giebner,
-BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,michael giebner,
-BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,sandy edge,
-BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,sandy edge,
-BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,michael giebner,
-BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,sandy edge,
-BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,michael giebner,
-BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,edward bar de iulio,
-BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,michael giebner,
-BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,sandy edge,
-BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,sandy edge,
-BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,michael giebner,
-BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,michael giebner,
-BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,sandy edge,
-BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,edward bar de iulio,
-BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,renee hebert,
-BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,michael giebner,
-BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,edward bar de iulio,
-BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,sandy edge,
-BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,renee hebert,
-BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,michael giebner,
-BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,sandy edge,
-BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,renee hebert,
-BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,edward bar de iulio,
-BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,michael giebner,
-BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,
-BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,sandy edge,
-CE,2010,002,Statics,0.32,0.25,0.25,0.07,0.0,0.0,0.0,0.11,qiushi chen,
-CE,2010,003,Statics,0.24,0.24,0.29,0.05,0.13,0.0,0.0,0.05,scott schiff,
-CE,2010,004,Statics,0.2,0.29,0.22,0.02,0.07,0.0,0.0,0.2,melissa sternhagen,
-CE,2010,005,Statics,0.24,0.29,0.2,0.07,0.02,0.0,0.0,0.18,melissa sternhagen,
-CE,2010,006,Statics,0.4,0.23,0.14,0.05,0.07,0.0,0.0,0.12,nighat yasmin,
-CE,2010,007,Statics,0.38,0.3,0.19,0.03,0.03,0.0,0.0,0.08,weichiang pang,
-CE,2060,001,Structural Mechanics,0.14,0.16,0.51,0.08,0.06,0.0,0.0,0.04,bryant nielson,
-CE,2080,002,Dynamics,0.16,0.24,0.24,0.18,0.08,0.0,0.0,0.11,melissa sternhagen,
-CE,2080,004,Dynamics,0.05,0.3,0.35,0.15,0.1,0.0,0.0,0.05,melissa sternhagen,
-CE,2550,001,Geomatics,0.32,0.38,0.24,0.01,0.01,0.0,0.0,0.04,wayne sarasua,
-CE,3010,001,Structural Analysis,0.3,0.43,0.11,0.0,0.14,0.0,0.0,0.03,stephen csernak,
-CE,3010,002,Structural Analysis,0.21,0.31,0.34,0.06,0.06,0.0,0.0,0.02,bryant nielson,
-CE,3110,001,Transportation Engr,0.74,0.17,0.04,0.02,0.02,0.0,0.0,0.0,jennifer ogle,
-CE,3210,001,Geotechnical Enginee,0.31,0.46,0.15,0.0,0.06,0.0,0.0,0.02,qiushi chen,
-CE,3310,001,Constr Engr & Mgmnt,0.41,0.42,0.09,0.04,0.04,0.0,0.0,0.0,james burati,
-CE,3410,001,Intro to Fluid Mech,0.19,0.38,0.26,0.11,0.04,0.0,0.0,0.02,nigel gregory kaye,
-CE,3410,002,Intro to Fluid Mech,0.17,0.31,0.28,0.09,0.07,0.0,0.0,0.07,abdul khan,
-CE,3420,001,Hydraulics & Hydro,0.38,0.4,0.13,0.05,0.05,0.0,0.0,0.0,ashok mishra,
-CE,3510,001,Civil Engineering Ma,0.34,0.5,0.1,0.02,0.04,0.0,0.0,0.0,ami esmaeilpoursaee,
-CE,3510,002,Civil Engineering Ma,0.38,0.32,0.21,0.03,0.06,0.0,0.0,0.0,bradley putman,
-CE,3520,001,Econ Eval of Proj,0.37,0.33,0.12,0.08,0.08,0.0,0.0,0.01,yongxi huang,
-CE,3530,001,Professional Seminar,0.79,0.13,0.08,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,4060,001,Struct Steel Design,0.21,0.32,0.28,0.17,0.02,0.0,0.0,0.0,stephen csernak,
-CE,4080,001,Struct Loads & Sys,0.22,0.5,0.06,0.17,0.06,0.0,0.0,0.0,bryant nielson,
-CE,4100,001,Traffic Engr Oper,0.06,0.5,0.22,0.22,0.0,0.0,0.0,0.0,yongxi huang,
-CE,4240,001,Earth Slopes & Struc,0.24,0.42,0.24,0.05,0.03,0.0,0.0,0.03,nadara ravichandran,
-CE,4340,001,Const Est Proj Cont,0.61,0.32,0.05,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,4360,001,Sustainable Constr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,
-CE,4390,001,Con Eqpmt Sel & Main,0.56,0.34,0.07,0.0,0.02,0.0,0.0,0.0,james burati,
-CE,4430,001,Water Resources Engr,0.45,0.09,0.36,0.0,0.0,0.0,0.0,0.09,abdul khan,
-CE,4560,001,Pave Design & Constr,0.37,0.42,0.17,0.03,0.0,0.0,0.0,0.02,bradley putman,
-CE,4590,001,Capstone Design Proj,0.25,0.57,0.1,0.08,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4820,001,Groundwater & Contam,0.42,0.25,0.17,0.0,0.0,0.0,0.0,0.17,lawrence murdoch,
-CE,4990,052,C I in Civil Engr/CE,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,jennifer ogle,
-CE,6080,001,Struct Loads & Sys,0.42,0.46,0.13,0.0,0.0,0.0,0.0,0.0,bryant nielson,
-CE,6100,001,Traffic Engr Oper,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yongxi huang,
-CE,6240,001,Earth Slopes & Struc,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,6360,001,Sustainable Constr,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,leidy klotz,
-CE,8020,001,Adv R/C Design,0.4,0.58,0.0,0.0,0.0,0.0,0.0,0.03,scott schiff,
-CE,8060,001,Dyn Analys of Struc,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
-CE,8210,001,Advanced Soil Mech,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,8220,001,Foundation Engr,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,8540,001,Travl Demnd Forecast,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
-CE,8930,005,Connected Vehicle Te,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,mashrur chowdhury,
-CH,1010,001,General Chemistry,0.25,0.37,0.21,0.12,0.05,0.0,0.0,0.01,dennis taylor,
-CH,1010,002,General Chemistry,0.09,0.42,0.27,0.09,0.08,0.0,0.0,0.04,ava kreider-mueller,
-CH,1010,003,General Chemistry,0.23,0.39,0.2,0.08,0.06,0.0,0.0,0.05,dennis taylor,
-CH,1010,004,General Chemistry,0.24,0.31,0.2,0.14,0.04,0.0,0.0,0.07,dennis taylor,
-CH,1010,005,General Chemistry,0.11,0.29,0.32,0.15,0.11,0.0,0.0,0.02,ava kreider-mueller,
-CH,1010,006,General Chemistry,0.22,0.36,0.18,0.1,0.11,0.0,0.0,0.02,thomas hickman,
-CH,1010,007,General Chemistry,0.22,0.38,0.23,0.08,0.08,0.0,0.0,0.01,thomas hickman,
-CH,1010,008,General Chemistry,0.2,0.34,0.24,0.06,0.1,0.0,0.0,0.06,kenneth wi rillings,
-CH,1010,009,General Chemistry,0.13,0.32,0.26,0.12,0.1,0.0,0.0,0.06,ava kreider-mueller,
-CH,1010,010,General Chemistry,0.19,0.24,0.21,0.18,0.16,0.0,0.0,0.03,christopher wilson,
-CH,1010,011,General Chemistry,0.22,0.37,0.23,0.09,0.03,0.0,0.0,0.06,tania issa houjeiry,
-CH,1010,012,General Chemistry,0.11,0.27,0.28,0.2,0.09,0.0,0.0,0.05,christopher wilson,
-CH,1010,013,General Chemistry,0.18,0.29,0.3,0.08,0.11,0.0,0.0,0.04,olt geiculescu,
-CH,1010,014,General Chemistry,0.23,0.39,0.24,0.09,0.02,0.0,0.0,0.03,dennis taylor,
-CH,1010,015,General Chemistry: M,0.34,0.31,0.22,0.06,0.06,0.0,0.0,0.0,tania issa houjeiry,
-CH,1010,016,General Chemistry (R,0.2,0.45,0.26,0.03,0.03,0.0,0.0,0.03,tania issa houjeiry,
-CH,1010,017,General Chemistry (R,0.15,0.43,0.27,0.07,0.05,0.0,0.0,0.03,kenneth wi rillings,
-CH,1010,018,General Chemistry (R,0.17,0.44,0.25,0.07,0.04,0.0,0.0,0.03,kenneth wi rillings,
-CH,1010,019,General Chemistry: C,0.32,0.39,0.19,0.08,0.0,0.0,0.0,0.01,kenneth christensen,
-CH,1010,051,General Chemistry (H,0.68,0.29,0.02,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True
-CH,1010,052,General Chemistry (H,0.58,0.39,0.0,0.03,0.0,0.0,0.0,0.0,joseph stu thrasher,True
-CH,1020,001,General Chemistry,0.32,0.26,0.27,0.09,0.02,0.0,0.0,0.03,stephe schvaneveldt,
-CH,1020,002,General Chemistry,0.28,0.32,0.19,0.09,0.05,0.0,0.0,0.07,stephe schvaneveldt,
-CH,1020,003,General Chemistry,0.24,0.24,0.25,0.17,0.03,0.0,0.0,0.07,stephe schvaneveldt,
-CH,1020,400,General Chemistry (O,0.11,0.24,0.27,0.16,0.11,0.0,0.0,0.11,stephe schvaneveldt,
-CH,1050,001,Chem in Context I,0.26,0.56,0.17,0.02,0.0,0.0,0.0,0.0,olt geiculescu,
-CH,1050,002,Chem in Context I,0.41,0.47,0.06,0.02,0.03,0.0,0.0,0.02,olt geiculescu,
-CH,1410,001,Chem Orientation,0.72,0.2,0.06,0.0,0.0,0.0,0.0,0.02,stephen creager,
-CH,2010,001,Survey of Organic Ch,0.44,0.32,0.08,0.03,0.04,0.0,0.0,0.08,thomas hickman,
-CH,2010,002,Survey of Organic Ch,0.45,0.37,0.12,0.03,0.0,0.0,0.0,0.04,thomas hickman,
-CH,2020,001,Surv of Organic Chem,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2020,009,Surv of Organic Chem,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
-CH,2020,010,Surv of Organic Chem,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,
-CH,2020,011,Surv of Organic Chem,0.53,0.2,0.07,0.0,0.0,0.0,0.0,0.2,sean 'connor,
-CH,2020,012,Surv of Organic Chem,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2230,001,Organic Chemistry,0.09,0.2,0.31,0.12,0.11,0.0,0.0,0.17,dev priya arya,
-CH,2230,002,Organic Chemistry,0.35,0.29,0.18,0.08,0.03,0.0,0.0,0.07,rhett smith,
-CH,2230,003,Organic Chemistry,0.3,0.34,0.19,0.04,0.1,0.0,0.0,0.02,jacob schroeder,
-CH,2230,004,Organic Chemistry,0.2,0.28,0.24,0.17,0.03,0.0,0.0,0.07,modi wetzler,
-CH,2230,005,Organic Chemistry,0.26,0.3,0.25,0.09,0.03,0.0,0.0,0.07,modi wetzler,
-CH,2230,006,Organic Chemistry,0.38,0.34,0.21,0.02,0.01,0.0,0.0,0.04,tania issa houjeiry,
-CH,2230,007,Organic Chemistry,0.37,0.36,0.15,0.06,0.01,0.0,0.0,0.05,jacob schroeder,
-CH,2240,001,Organic Chemistry,0.31,0.3,0.22,0.09,0.02,0.0,0.0,0.06,jacob schroeder,
-CH,2240,002,Organic Chemistry,0.3,0.37,0.21,0.05,0.05,0.0,0.0,0.02,jacob schroeder,
-CH,2270,001,Organic Chem Lab,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,
-CH,2270,002,Organic Chem Lab,0.81,0.06,0.06,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2270,007,Organic Chem Lab,0.6,0.07,0.07,0.0,0.0,0.0,0.0,0.27,sean 'connor,
-CH,2270,011,Organic Chem Lab,0.69,0.13,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,
-CH,2270,014,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,015,Organic Chem Lab,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,016,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,017,Organic Chem Lab,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,019,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,020,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,023,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,024,Organic Chem Lab,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,026,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,028,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,029,Organic Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,030,Organic Chem Lab,0.44,0.5,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2270,031,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,032,Organic Chem Lab,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,033,Organic Chem Lab,0.55,0.09,0.09,0.18,0.0,0.0,0.0,0.09,sean 'connor,
-CH,2270,034,Organic Chem Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,sean 'connor,
-CH,2270,035,Organic Chem Lab,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,036,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,037,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,038,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
-CH,2280,004,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
-CH,2280,007,Organic Chem Lab,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
-CH,3130,001,Quantitative Analys,0.4,0.33,0.1,0.07,0.02,0.0,0.0,0.07,stephen creager,
-CH,3150,002,Quant Analysis Lab,0.36,0.36,0.09,0.09,0.09,0.0,0.0,0.0,jeffrey natha anker,
-CH,3300,001,Intro to Phys Chem,0.41,0.37,0.18,0.0,0.0,0.0,0.0,0.04,brian dominy,
-CH,3310,001,Physical Chemistry,0.27,0.25,0.35,0.08,0.02,0.0,0.0,0.02,jason mcneill,
-CH,3320,001,Physical Chemistry,0.2,0.3,0.1,0.2,0.0,0.0,0.0,0.2,arkady kholodenko,
-CH,3390,001,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,
-CH,3390,005,Physical Chem Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,
-CH,4010,001,Organometallic Chemi,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,andrew gre tennyson,
-CH,4020,001,Inorganic Chemistry,0.2,0.73,0.07,0.0,0.0,0.0,0.0,0.0,joseph kolis,
-CH,8070,001,Chem Trans Elem,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
-CH,8120,001,Spectrochemical Anal,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,george chumanov,
-CH,8150,001,Mass Spectrometry,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,richard marcus,
-CH,8210,001,Organic Chem I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, karl dieter,
-CH,8300,001,Fund Phys Chem,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,
-CH,8340,001,Stat Thermodynamics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,
-CH,8410,001,N M R Spectroscopy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,alek kitaygorodskiy,
-CH,8510,002,Grad Student Seminar,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey natha anker,
-CHE,2110,001,Intro to Chem Eng,0.23,0.24,0.18,0.03,0.26,0.0,0.0,0.06,rachel getman,
-CHE,2110,002,Intro to Chem Eng,0.19,0.23,0.26,0.02,0.23,0.0,0.0,0.08,rachel getman,
-CHE,3070,001,Unit Ops Lab I,0.14,0.6,0.21,0.02,0.0,0.0,0.0,0.02,christopher norfolk,
-CHE,3070,001,Unit Ops Lab I,0.14,0.6,0.21,0.02,0.0,0.0,0.0,0.02,mark thies,
-CHE,3190,001,Engr Materials,0.11,0.32,0.39,0.14,0.05,0.0,0.0,0.0,antho guiseppi-elie,
-CHE,4070,001,Unit Op Lab II,0.16,0.84,0.0,0.0,0.0,0.0,0.0,0.0,scott husson,
-CHE,4310,001,Process Design I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,4500,001,Chem Reaction Engr,0.17,0.34,0.34,0.09,0.06,0.0,0.0,0.0,mark alan blenner,
-CHE,8030,001,Advanced Transport,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,douglas hirt,
-CHE,8040,001,Ch E Thermodynamics,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
-CHE,8050,001,Ch E Kinetics,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,mark roberts,
-CHE,8140,002,Numerical Methods,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,joseph scott,
-CHIN,1010,001,Elementary Chinese,0.44,0.06,0.19,0.0,0.0,0.0,0.0,0.31,yanming an,
-CHIN,4010,001,Pre-Modern Chinese L,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,yanming an,
-COM,1500,001,Intro to Human Com,0.66,0.29,0.01,0.01,0.02,0.0,0.0,0.01,eddie smith,
-COM,1500,002,Introduction  to Hum,0.65,0.24,0.06,0.01,0.01,0.0,0.0,0.03,daniel lelan fecher,
-COM,1500,003,Intro to Human Com,0.69,0.26,0.02,0.01,0.01,0.0,0.0,0.01,eddie smith,
-COM,1500,004,Intro to Human Com,0.64,0.29,0.05,0.0,0.01,0.0,0.0,0.01,marianne her glaser,
-COM,1500,005,Intro to Human Com,0.71,0.22,0.05,0.0,0.01,0.0,0.0,0.01,marianne her glaser,
-COM,1500,006,Intro to Human Com,0.65,0.25,0.04,0.0,0.01,0.0,0.0,0.05,marianne her glaser,
-COM,1500,007,Intro to Human Com,0.4,0.47,0.06,0.02,0.01,0.0,0.0,0.03,daniel lelan fecher,
-COM,2010,001,Intr to Comm Studies,0.51,0.39,0.1,0.0,0.0,0.0,0.0,0.0,brenden kendall,
-COM,2500,001,Public Speaking,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,brandon boatwright,
-COM,2500,002,Public Speaking,0.11,0.58,0.16,0.0,0.11,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,003,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,004,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,005,Public Speaking,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,006,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,
-COM,2500,007,Public Speaking,0.37,0.42,0.16,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,008,Public Speaking,0.68,0.11,0.0,0.05,0.05,0.0,0.0,0.11,jumah patrici taweh,
-COM,2500,009,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,010,Public Speaking,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,
-COM,2500,011,Public Speaking,0.5,0.39,0.0,0.06,0.0,0.0,0.0,0.06,pauline matthey,
-COM,2500,012,Public Speaking,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,marilyn denise pugh,
-COM,2500,013,Public Speaking,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,014,Public Speaking,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,015,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,016,Public Speaking,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,katharin schoonover,
-COM,2500,017,Public Speaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,the estate  geddes,
-COM,2500,018,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
-COM,2500,019,Public Speaking,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,pauline matthey,
-COM,2500,020,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,021,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,022,Public Speaking,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,023,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,024,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,025,Public Speaking (HON,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,True
-COM,2500,026,Public Speaking (HON,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True
-COM,2500,400,Public Speaking,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,401,Public Speaking,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alexis zachar davis,
-COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,403,Public Speaking,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
-COM,3010,001,Comm Theory,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,3020,001,Mass Comm Theory,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3070,001,Public Comm of Sts,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,david travers scott,
-COM,3080,001,Pub Comm & Pop Cult,0.28,0.4,0.18,0.04,0.02,0.0,0.0,0.08,chenjerai kumanyika,
-COM,3100,001,Quant Comm Methods,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,3110,001,Qual Comm Methods,0.37,0.47,0.0,0.0,0.05,0.0,0.0,0.11,chenjerai kumanyika,
-COM,3210,001,Comm Across Media Pl,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian mullen,
-COM,3220,001,Communication Design,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,lori marlise pindar,
-COM,3250,001,Survey of Sports Com,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,3250,002,Survey of Sports Com,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,3260,001,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3260,002,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3480,001,Interpersonal Comm,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,melinda ra weathers,
-COM,3550,001,Principles of Pr,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3550,002,Principles of Pr,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3660,001,EP: Advertising & Me,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,william reynolds,
-COM,3660,002,EP: Building the Bra,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,andrew mendelsohn,
-COM,3660,003,Live Broadcast Prod.,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,michael rodgers,
-COM,4300,001,Legal Communication,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
-COM,4700,001,Comm & Health,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,4800,001,Intercultural Comm,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,andrew stephen pyle,
-COM,8010,001,Communication Theory,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,8030,001,Comm Technology Stud,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
-COM,8100,001,Comm Research Method,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,darren linvill,
-CPSC,1010,001,Computer Science I,0.24,0.12,0.24,0.08,0.18,0.0,0.0,0.13,catherine hochrine,
-CPSC,1010,003,Computer Science I,0.75,0.11,0.02,0.0,0.02,0.0,0.0,0.09,lauren elizab dukes,
-CPSC,1010,004,Computer Science I,0.15,0.13,0.18,0.13,0.21,0.0,0.0,0.21,pradip srimani,
-CPSC,1020,001,Computer Science II,0.36,0.36,0.07,0.02,0.02,0.0,0.0,0.18,catherine hochrine,
-CPSC,1040,001,Intro Computer Prog,0.24,0.56,0.0,0.08,0.08,0.0,0.0,0.04,kenneth alle weaver,
-CPSC,1110,001,Intro to Programming,0.58,0.28,0.08,0.03,0.03,0.0,0.0,0.03,patrick sterling,
-CPSC,1110,002,Intro to Programming,0.52,0.31,0.07,0.0,0.1,0.0,0.0,0.0,patrick sterling,
-CPSC,1110,003,Intro to Programming,0.64,0.19,0.07,0.02,0.05,0.0,0.0,0.02,patrick sterling,
-CPSC,1110,004,Intro to Programming,0.87,0.07,0.02,0.0,0.04,0.0,0.0,0.0,toni bloodwor pence,
-CPSC,2070,001,Discrete Structures,0.13,0.29,0.28,0.1,0.04,0.0,0.0,0.15,roy pargas,
-CPSC,2100,001,Progrmng Methodology,0.54,0.13,0.1,0.06,0.1,0.0,0.0,0.08,rose lowe,
-CPSC,2120,001,Algs/Data Structures,0.28,0.28,0.23,0.02,0.06,0.0,0.0,0.12,brian christop dean,
-CPSC,2150,001,Software Dev Fndtns,0.35,0.28,0.23,0.05,0.05,0.0,0.0,0.05,blair madiso durkee,
-CPSC,2150,002,Software Dev Fndtns,0.21,0.31,0.33,0.05,0.05,0.0,0.0,0.05,catherine hochrine,
-CPSC,2200,001,Microcomputer Appl,0.32,0.42,0.16,0.0,0.11,0.0,0.0,0.0,renee lambert,
-CPSC,2200,002,Microcomputer Appl,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,patrick sterling,
-CPSC,2310,001,Intro Computer Org,0.22,0.35,0.24,0.05,0.14,0.0,0.0,0.0,rose lowe,
-CPSC,2310,002,Intro Computer Org,0.41,0.24,0.21,0.03,0.09,0.0,0.0,0.03,rose lowe,
-CPSC,2910,001,Prof Issues I,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,james jones,
-CPSC,2910,002,Prof Issues I,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,james jones,
-CPSC,2910,003,Prof Issues I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,james jones,
-CPSC,2910,004,Prof Issues I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
-CPSC,2910,006,Prof Issues I,0.6,0.0,0.2,0.0,0.1,0.0,0.0,0.1,renee lambert,
-CPSC,2910,008,Prof Issues I,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,renee lambert,
-CPSC,3220,001,Intro to Operating S,0.23,0.21,0.14,0.04,0.12,0.0,0.0,0.26,jacob sorber,
-CPSC,3300,001,Computer Systems Org,0.32,0.25,0.22,0.03,0.1,0.0,0.0,0.08,mark smotherman,
-CPSC,3500,001,Foundatns of Com Sci,0.22,0.27,0.22,0.08,0.1,0.0,0.0,0.12,ilya mark safro,
-CPSC,3520,001,Programming Systems,0.25,0.31,0.19,0.03,0.19,0.0,0.0,0.03,robert schalkoff,
-CPSC,3600,001,Network Programming,0.19,0.33,0.22,0.04,0.11,0.0,0.0,0.11,sekou lionel remy,
-CPSC,3620,001,Dist & Cluster Compu,0.36,0.3,0.18,0.09,0.06,0.0,0.0,0.0,amy apon,
-CPSC,3620,001,Dist & Cluster Compu,0.36,0.3,0.18,0.09,0.06,0.0,0.0,0.0,linh bao ngo,
-CPSC,3710,001,Systems Analysis,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-CPSC,3720,001,Software Engineering,0.32,0.35,0.29,0.0,0.0,0.0,0.0,0.03,murali sitaraman,
-CPSC,3720,002,Software Engineering,0.15,0.35,0.35,0.09,0.03,0.0,0.0,0.03,stephen schaub,
-CPSC,3990,002,AdvCI Proc Gen Game,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,brian malloy,
-CPSC,4040,001,Cmptr Graphics Image,0.5,0.23,0.14,0.0,0.14,0.0,0.0,0.0,joshua levine,
-CPSC,4060,001,Gpu Computation,0.3,0.0,0.3,0.1,0.3,0.0,0.0,0.0,robert geist,
-CPSC,4110,001,Virtual Reality Syst,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
-CPSC,4200,001,Computer Security Pr,0.32,0.36,0.18,0.05,0.05,0.0,0.0,0.05,pradip srimani,
-CPSC,4620,001,Database Management,0.29,0.5,0.18,0.0,0.0,0.0,0.0,0.04,feng luo,
-CPSC,4810,016,Programming Team,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian christop dean,
-CPSC,4910,001,Prof  Issues II,0.95,0.04,0.0,0.0,0.0,0.0,0.0,0.02,james jones,
-CPSC,6040,001,Cptr Graphics Image,0.65,0.2,0.05,0.0,0.05,0.0,0.0,0.05,joshua levine,
-CPSC,6060,001,Gpu Computation,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,robert geist,
-CPSC,6110,001,Virtual Reality Syst,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
-CPSC,6620,001,Database Management,0.33,0.63,0.0,0.0,0.0,0.0,0.0,0.04,feng luo,
-CPSC,8070,001,3d Model Animation,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-CPSC,8200,001,Parallel Architechtu,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,pradip srimani,
-CPSC,8270,001,Translation of Progr,0.86,0.05,0.1,0.0,0.0,0.0,0.0,0.0,brian malloy,
-CPSC,8380,001,Adv Data Structures,0.23,0.09,0.09,0.0,0.45,0.0,0.0,0.14,sandra hedetniemi,
-CPSC,8450,001,Bioinfo Algorithms,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,
-CPSC,8510,001,Soft Sys Data Comm,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,james martin,
-CPSC,8700,001,O O Software Design,0.64,0.28,0.05,0.0,0.0,0.0,0.0,0.03,brian malloy,
-CPSC,8720,002,Software Spec & Desi,0.34,0.45,0.17,0.0,0.0,0.0,0.0,0.03,john mcgregor,
-CPSC,8770,001,Biometric Systems,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,damon woodard,
-CPSC,8810,001,Data Visualization,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,joshua levine,
-CRP,8000,001,Human Settlement,0.51,0.37,0.12,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-CRP,8000,001,Human Settlement,0.51,0.37,0.12,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
-CRP,8010,001,Planning Process & L,0.26,0.7,0.0,0.0,0.0,0.0,0.0,0.04,caitlin dyckman,
-CRP,8020,001,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
-CRP,8030,001,Quant Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
-CRP,8030,001,Quant Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
-CRP,8060,001,Urban Systems,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,timothy green,
-CRP,8580,002,Research Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy green,
-CSM,1000,001,Intro to Construct,0.2,0.63,0.13,0.04,0.02,0.0,0.0,0.0,joseph wintz,
-CSM,2010,001,Structures I,0.27,0.41,0.14,0.14,0.0,0.0,0.0,0.05,shima clarke,
-CSM,2010,002,Structures I,0.23,0.27,0.32,0.05,0.05,0.0,0.0,0.09,shima clarke,
-CSM,2030,001,Mats & Meth of Const,0.19,0.67,0.15,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,2030,002,Mats & Meth of Const,0.21,0.54,0.17,0.08,0.0,0.0,0.0,0.0,jason lucas,
-CSM,3030,001,Soils & Foundations,0.27,0.47,0.13,0.13,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,3030,002,Soils & Foundations,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,3040,001,Envir Systems I,0.33,0.43,0.24,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3040,002,Envir Systems I,0.32,0.47,0.05,0.11,0.05,0.0,0.0,0.0,joseph mich burgett,
-CSM,3510,001,Const Estimating,0.29,0.48,0.14,0.1,0.0,0.0,0.0,0.0,james packer smith,
-CSM,3510,002,Const Estimating,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,james packer smith,
-CSM,4110,001,Safety in Bldg Const,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,david devita,
-CSM,4500,001,Construction Intern,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CSM,4530,001,Const Proj Mgmt,0.08,0.6,0.32,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,4530,002,Const Proj Mgmt,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,4610,001,Const Econ Seminar,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4610,002,Const Econ Seminar,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,6550,001,Adverse Relations,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,joseph wintz,
-CSM,8520,001,Const Mgmt Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,shima clarke,
-CSM,8600,001,Constr Finan Plan &,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8600,400,Constr Finan Plan &,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8630,001,Adv Plan/Sched,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8630,400,Adv Plan/Sched,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8660,001,Role in Development,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CU,1000,001,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.01,jeffrey appling,
-CU,1000,001,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.01,mary mcp von kaenel,
-CU,1000,002,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.01,jeffrey appling,
-CU,1000,002,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.01,mary mcp von kaenel,
-CU,1000,003,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,jeffrey appling,
-CU,1000,003,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,mary mcp von kaenel,
-CU,1000,004,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.84,0.15,0.02,jeffrey appling,
-CU,1000,004,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.84,0.15,0.02,mary mcp von kaenel,
-CU,1000,005,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.03,0.01,jeffrey appling,
-CU,1000,006,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.02,0.01,jeffrey appling,
-CU,1000,007,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,
-CU,1000,008,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,
-CU,1000,009,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey appling,
-CU,1000,010,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,jeffrey appling,
-CU,1000,011,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,
-CU,1000,012,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.05,0.01,jeffrey appling,
-CU,1000,013,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.01,jeffrey appling,
-CU,1000,014,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.89,0.1,0.01,jeffrey appling,
-CU,1010,001,Univ Success Skills,0.43,0.17,0.26,0.0,0.04,0.0,0.0,0.09,deborah ann vaughn,
-CU,1010,002,Univ Success Skills,0.35,0.39,0.09,0.09,0.04,0.0,0.0,0.04,rise jean sheriff,
-CU,1010,003,Univ Success Skills,0.44,0.36,0.08,0.04,0.08,0.0,0.0,0.0,cecelia hamby,
-CU,1010,005,Univ Success Skills,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,robert dav brackett,
-DANC,1600,001,Ballet Dance I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,cheryl hosler,
-DPA,3070,001,Method 3d Production,0.43,0.3,0.04,0.04,0.13,0.0,0.0,0.04,virginia ba nearing,
-DPA,4000,001,Tech Foundations I,0.08,0.17,0.33,0.0,0.08,0.0,0.0,0.33,christina sop joerg,
-DPA,6000,001,Tech Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-DPA,8600,001,Production Studio,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,
-ECE,2010,001,Logic & Comp Device,0.16,0.3,0.28,0.13,0.09,0.0,0.0,0.05,william reid,
-ECE,2010,002,Logic & Comp Device,0.62,0.24,0.1,0.0,0.05,0.0,0.0,0.0,william reid,True
-ECE,2020,001,Electric Circuits I,0.18,0.22,0.29,0.17,0.07,0.0,0.0,0.07,william harrell,
-ECE,2020,002,Electric Circuits I,0.73,0.13,0.0,0.07,0.0,0.0,0.0,0.07,apoorva dee kapadia,True
-ECE,2070,001,Basic Electrical Eng,0.85,0.09,0.02,0.02,0.01,0.0,0.0,0.02,sung- kim,
-ECE,2070,002,Basic Electrical Eng,0.4,0.23,0.13,0.1,0.08,0.0,0.0,0.06,surya sharma,
-ECE,2070,003,Basic Electrical Eng,0.55,0.36,0.07,0.0,0.0,0.0,0.0,0.02,liang dong,
-ECE,2080,001,Electrical Engineeri,0.85,0.05,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2080,002,Electrical Engineeri,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,
-ECE,2080,010,Electrical Engineeri,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2080,011,Electrical Engineeri,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2080,012,Electrical Engineeri,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,william harrell,
-ECE,2080,013,Electrical Engineeri,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,
-ECE,2090,001,Logic Lab,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,william harrell,
-ECE,2090,003,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,william harrell,
-ECE,2090,006,Logic Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2090,014,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,william harrell,
-ECE,2110,002,Elec Engr Lab I,0.65,0.15,0.0,0.0,0.05,0.0,0.0,0.15,william harrell,
-ECE,2110,003,Elec Engr Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2110,004,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,william harrell,
-ECE,2110,005,Elec Engr Lab I,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,william harrell,
-ECE,2110,006,Elec Engr Lab I,0.8,0.05,0.05,0.0,0.0,0.0,0.0,0.1,william harrell,
-ECE,2110,008,Elec Engr Lab I,0.8,0.0,0.05,0.0,0.0,0.0,0.0,0.15,william harrell,
-ECE,2110,009,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,
-ECE,2110,010,Elec Engr Lab I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2220,001,Syst Prog Concept,0.22,0.24,0.14,0.06,0.12,0.0,0.0,0.22,harlan russell,
-ECE,2230,001,Comp Sys Eng,0.11,0.41,0.17,0.13,0.07,0.0,0.0,0.11,harlan russell,
-ECE,2620,001,Elec Circuits II,0.47,0.25,0.25,0.02,0.02,0.0,0.0,0.0,michael bridgwood,
-ECE,2720,001,Comp Organization,0.22,0.29,0.24,0.12,0.14,0.0,0.0,0.0,william reid,
-ECE,2730,001,Computer Org Lab,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2730,002,Computer Org Lab,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2730,003,Computer Org Lab,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,3110,001,Electrical Engineeri,0.75,0.06,0.06,0.0,0.0,0.0,0.0,0.13,william harrell,
-ECE,3110,002,Electrical Engineeri,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,william harrell,
-ECE,3110,003,Electrical Engineeri,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,
-ECE,3110,007,Electrical Engineeri,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,3120,001,Electrical Engineeri,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,3170,001,Rand Signal Analysis,0.25,0.51,0.18,0.02,0.04,0.0,0.0,0.02,stephen hubbard,
-ECE,3200,001,Electronics I,0.34,0.36,0.15,0.07,0.05,0.0,0.0,0.03,stephen hubbard,
-ECE,3210,001,Electronics II,0.2,0.2,0.41,0.11,0.05,0.0,0.0,0.02,stephen hubbard,
-ECE,3220,001,Intro Operating Sys,0.3,0.1,0.05,0.15,0.3,0.0,0.0,0.1,jacob sorber,
-ECE,3270,001,Dig Comp Design,0.11,0.21,0.18,0.14,0.25,0.0,0.0,0.11,melissa crawl smith,
-ECE,3300,001,Signals & Systems,0.23,0.29,0.21,0.11,0.1,0.0,0.0,0.05,carl baum,
-ECE,3300,002,Signals & Systems (H,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
-ECE,3520,001,Programming Systems,0.13,0.31,0.25,0.0,0.19,0.0,0.0,0.13,robert schalkoff,
-ECE,3600,001,Elect Power Engr,0.18,0.26,0.26,0.08,0.19,0.0,0.0,0.03,andrew donal clarke,
-ECE,3710,001,Microcontr Interface,0.38,0.25,0.29,0.03,0.01,0.0,0.0,0.03,william reid,
-ECE,3800,001,Electromagnetics,0.41,0.17,0.11,0.1,0.14,0.0,0.0,0.07,anthony martin,
-ECE,3810,001,Field Waves & Ckts,0.33,0.35,0.23,0.05,0.05,0.0,0.0,0.0,anthony martin,
-ECE,4090,001,Cont & Discrete Sys,0.56,0.31,0.12,0.0,0.0,0.0,0.0,0.02,apoorva dee kapadia,
-ECE,4180,001,Power Syst Analysis,0.48,0.22,0.3,0.0,0.0,0.0,0.0,0.0,elham makram,
-ECE,4270,001,Communications Sys,0.23,0.35,0.28,0.08,0.03,0.0,0.0,0.04,madhabi manandhar,
-ECE,4290,001,Organiz of Compu,0.29,0.36,0.29,0.07,0.0,0.0,0.0,0.0,hai ying shen,
-ECE,4420,001,Knowledge Engr,0.38,0.31,0.08,0.08,0.0,0.0,0.0,0.15,robert schalkoff,
-ECE,4490,001,Comp Ntwrk Security,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,richard brooks,
-ECE,4610,001,Fundamentals of Sola,0.73,0.18,0.07,0.0,0.0,0.0,0.0,0.02,rajendra singh,
-ECE,4730,001,Intro Parallel Sys,0.48,0.14,0.33,0.0,0.0,0.0,0.0,0.05,walter ligon,
-ECE,4930,003,Power Electronics,0.36,0.27,0.36,0.0,0.0,0.0,0.0,0.0,keith corzine,
-ECE,4950,001,Int Sys Design I,0.81,0.18,0.0,0.0,0.0,0.0,0.0,0.01,apoorva dee kapadia,
-ECE,4960,001,Int Sys Design II,0.37,0.57,0.06,0.0,0.0,0.0,0.0,0.0,richard groff,
-ECE,6040,001,Semiconductor Device,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,6420,001,Knowledge Engr,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,robert schalkoff,
-ECE,6670,001,Intro to Dig Sig Pro,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,john gowdy,
-ECE,6730,001,Intro Parallel Sys,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,walter ligon,
-ECE,6930,001,Intro to Computer Vi,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,adam hoover,
-ECE,6930,004,Optoelectronics and,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,lin zhu,
-ECE,8010,001,Analysis of Lin Sys,0.47,0.37,0.17,0.0,0.0,0.0,0.0,0.0,richard groff,
-ECE,8180,001,Rand Proc Appl Engr,0.38,0.38,0.19,0.0,0.0,0.0,0.0,0.06,carl baum,
-ECE,8470,400,Digital Image Proc,0.43,0.37,0.1,0.0,0.0,0.0,0.0,0.1,stanley birchfield,
-ECE,8540,001,Analysis of Tracking,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,adam hoover,
-ECE,8930,005,CMOS RFIC,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,
-ECE,8930,006,Computing Frontiers,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,
-ECE,9910,032,Doctoral Dissertatio,0.0,0.0,0.0,0.0,0.0,0.44,0.56,0.0,hai ying shen,
-ECON,2000,001,Economic Concepts,0.21,0.42,0.05,0.13,0.03,0.0,0.0,0.16,mallika garg,
-ECON,2000,002,Economic Concepts,0.21,0.46,0.1,0.13,0.03,0.0,0.0,0.08,mallika garg,
-ECON,2000,003,Economic Concepts,0.3,0.4,0.16,0.09,0.02,0.0,0.0,0.02,miren ivankovic,
-ECON,2110,001,Principles of Microe,0.33,0.44,0.17,0.0,0.06,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,002,Principles of Microe,0.17,0.28,0.33,0.11,0.06,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,003,Principles of Microe,0.15,0.45,0.15,0.15,0.0,0.0,0.0,0.1,frederick hanssen,
-ECON,2110,004,Principles of Microe,0.26,0.16,0.37,0.16,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,005,Principles of Microe,0.21,0.42,0.26,0.0,0.0,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,006,Principles of Microe,0.16,0.42,0.26,0.16,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,007,Principles of Microe,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,008,Principles of Microe,0.21,0.16,0.21,0.11,0.0,0.0,0.0,0.32,frederick hanssen,
-ECON,2110,009,Principles of Microe,0.05,0.32,0.32,0.16,0.05,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,010,Principles of Microe,0.16,0.42,0.21,0.11,0.05,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,011,Principles of Microe,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,012,Principles of Microe,0.05,0.37,0.26,0.05,0.0,0.0,0.0,0.26,frederick hanssen,
-ECON,2110,013,Principles of Microe,0.32,0.42,0.16,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,014,Principles of Microe,0.05,0.53,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,015,Principles of Microe,0.16,0.53,0.21,0.0,0.05,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,016,Principles of Microe,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,017,Principles of Microe,0.26,0.32,0.21,0.05,0.0,0.0,0.0,0.16,frederick hanssen,
-ECON,2110,018,Principles of Microe,0.16,0.32,0.32,0.11,0.05,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,019,Principles of Microe,0.11,0.61,0.06,0.0,0.17,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,020,Principles of Microe,0.28,0.41,0.19,0.08,0.03,0.0,0.0,0.01,alexander fiore,
-ECON,2110,021,Principles of Microe,0.26,0.33,0.3,0.08,0.01,0.0,0.0,0.01,timothy andr bersak,
-ECON,2110,022,Principles of Microe,0.29,0.43,0.2,0.02,0.0,0.0,0.0,0.06,robert dew tollison,
-ECON,2110,023,Principles of Microe,0.13,0.45,0.25,0.08,0.05,0.0,0.0,0.05,timothy jay bacon,
-ECON,2110,024,Principles of Microe,0.26,0.36,0.25,0.1,0.02,0.0,0.0,0.02,adam millsap,
-ECON,2110,025,Principles of Microe,0.28,0.33,0.23,0.13,0.0,0.0,0.0,0.03,timothy andr bersak,
-ECON,2110,026,Principles of Microe,0.35,0.33,0.18,0.03,0.08,0.0,0.0,0.05,miren ivankovic,
-ECON,2110,031,Principles of Microe,0.31,0.31,0.23,0.14,0.01,0.0,0.0,0.0,adam millsap,
-ECON,2110,032,Principles of Microe,0.26,0.28,0.31,0.07,0.04,0.0,0.0,0.04,andew swanson,
-ECON,2110,033,Principles of Microe,0.29,0.34,0.18,0.11,0.05,0.0,0.0,0.03,alexander fiore,
-ECON,2110,034,Principles of Microe,0.31,0.36,0.29,0.02,0.0,0.0,0.0,0.02,amanda caitlin kerr,
-ECON,2110,035,Principles of Microe,0.43,0.38,0.18,0.03,0.0,0.0,0.0,0.0,andew swanson,
-ECON,2110,036,Principles of Microe,0.58,0.13,0.08,0.0,0.0,0.0,0.0,0.21,patrick warren,True
-ECON,2110,038,Principles of Microe,0.24,0.31,0.24,0.05,0.07,0.0,0.0,0.1,timothy jay bacon,
-ECON,2120,001,Principles of Macro,0.12,0.17,0.38,0.14,0.05,0.0,0.0,0.14,ralph charles allen,
-ECON,2120,002,Principles of Macro,0.24,0.33,0.26,0.02,0.07,0.0,0.0,0.09,peter david lorenz,
-ECON,2120,003,Principles of Macro,0.2,0.3,0.2,0.05,0.08,0.0,0.0,0.18,ralph charles allen,
-ECON,2120,004,Principles of Macro,0.16,0.42,0.24,0.07,0.02,0.0,0.0,0.09,peter david lorenz,
-ECON,2120,005,Principles of Macro,0.29,0.38,0.18,0.12,0.0,0.0,0.0,0.03,yukun sun,
-ECON,2120,006,Principles of Macro,0.2,0.43,0.23,0.07,0.07,0.0,0.0,0.0,yukun sun,
-ECON,2120,007,Principles of Macro,0.23,0.48,0.18,0.03,0.05,0.0,0.0,0.05,danielle zanzalari,
-ECON,2120,008,Principles of Macro,0.26,0.38,0.23,0.08,0.05,0.0,0.0,0.0,anne anders,
-ECON,3020,001,Money and Banking,0.25,0.19,0.25,0.14,0.03,0.0,0.0,0.14,danielle zanzalari,
-ECON,3060,001,Managerial Economics,0.38,0.46,0.04,0.04,0.04,0.0,0.0,0.04,jacob burgdorf,
-ECON,3100,001,International Econ,0.2,0.37,0.16,0.12,0.02,0.0,0.0,0.14,ayse mujde erdogan,
-ECON,3140,001,Intermediate Micro,0.16,0.3,0.27,0.14,0.0,0.0,0.0,0.14,robert kennet fleck,
-ECON,3140,002,Intermediate Micro,0.27,0.29,0.17,0.08,0.06,0.0,0.0,0.13,molly espey,
-ECON,3140,003,Intermediate Micro,0.24,0.27,0.22,0.08,0.08,0.0,0.0,0.1,robert kennet fleck,
-ECON,3150,001,Intermediate Macro,0.33,0.22,0.31,0.0,0.06,0.0,0.0,0.08,sergey vla mityakov,
-ECON,3150,002,Intermediate Macro,0.15,0.35,0.28,0.11,0.02,0.0,0.0,0.09,ayse mujde erdogan,
-ECON,3190,001,Environmental Econ,0.22,0.43,0.22,0.08,0.0,0.0,0.0,0.05,molly espey,
-ECON,3600,001,Public Choice,0.18,0.58,0.2,0.0,0.03,0.0,0.0,0.03,robert dew tollison,
-ECON,3970,001,Creative Inq in Econ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,scott baier,
-ECON,3970,001,Creative Inq in Econ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,raymond sauer,
-ECON,3970,003,Creative Inq in Econ,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,scott baier,
-ECON,3970,003,Creative Inq in Econ,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,raymond sauer,
-ECON,4020,001,Law and Economics,0.26,0.43,0.12,0.05,0.05,0.0,0.0,0.1,howard ne bodenhorn,
-ECON,4040,001,Comp Econ Systems,0.27,0.33,0.2,0.0,0.07,0.0,0.0,0.13,dar litsukova-bokar,
-ECON,4050,001,Intro to Econometric,0.33,0.31,0.19,0.02,0.05,0.0,0.0,0.1,jaqueline oliveira,
-ECON,4050,005,Intro to Econometric,0.42,0.08,0.08,0.08,0.17,0.0,0.0,0.17,scott barkowski,
-ECON,4100,001,Economic Development,0.28,0.36,0.16,0.0,0.04,0.0,0.0,0.16,robert tamura,
-ECON,4120,001,International Micro,0.5,0.38,0.06,0.0,0.03,0.0,0.0,0.03,scott baier,
-ECON,4220,001,Monetary Economics,0.37,0.59,0.04,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
-ECON,4230,001,Economics of Health,0.17,0.39,0.22,0.11,0.06,0.0,0.0,0.06,daniel patri miller,
-ECON,4240,001,Organization of Ind,0.41,0.35,0.18,0.0,0.06,0.0,0.0,0.0,daniel patri miller,
-ECON,4350,001,Family Economics,0.44,0.16,0.2,0.0,0.16,0.0,0.0,0.04,jaqueline oliveira,
-ECON,8010,001,Microeconomic Theory,0.33,0.38,0.29,0.0,0.0,0.0,0.0,0.0,william dougan,
-ECON,8040,001,Applied Math Econ,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,curtis simon,
-ECON,8060,001,Econometrics I,0.12,0.52,0.28,0.0,0.0,0.0,0.0,0.08,paul wayne wilson,
-ECON,8230,001,Microecon Pub Pol,0.35,0.47,0.18,0.0,0.0,0.0,0.0,0.0,scott templeton,
-ECON,8260,001,Econ Theory of Govt,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,
-ECON,8550,001,Financial Economics,0.54,0.15,0.0,0.0,0.08,0.0,0.0,0.23,sergey vla mityakov,
-ED,1050,003,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,patrick womac,
-ED,1050,008,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,rory phil tannebaum,
-ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen mich moysey,
-ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david matthew boyer,
-ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,penelope mar vargas,
-ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,
-ED,3970,012,Creative Inquiry in,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,joseph benedic ryan,
-ED,3970,012,Creative Inquiry in,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,deborah cadorette,
-ED,8380,402,Short Stories for Te,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,lienne federico,
-ED,8380,506,Literacy Lessons for,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,vicki steadman,
-ED,8380,510,Literacy Lessons for,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jennifer adams,
-ED,8380,511,Literacy Lessons for,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,jean ridley,
-EDC,3900,001,Skills for Stu Leads,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,mary price,
-EDC,3900,001,Skills for Stu Leads,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,lloyd john  graham,
-EDC,3900,002,Skills for Stu Leads,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
-EDC,3900,002,Skills for Stu Leads,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,8030,001,Stu Dev in Hi Ed,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
-EDC,8040,001,Theories Student Dev,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,
-EDC,8040,002,Theories Student Dev,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,
-EDC,8050,001,Clinical Mh Couns,0.91,0.05,0.0,0.0,0.05,0.0,0.0,0.0,david scott,
-EDC,8440,001,Stu Affairs Intern,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,kristin walker,
-EDC,8440,001,Stu Affairs Intern,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,tony cawthon,
-EDEC,3000,001,Found Early Chld Ed,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,
-EDEC,4400,001,Early Childhood Engl,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEL,3100,002,Arts in Ele School,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,alison eliz leonard,
-EDEL,3210,001,Pe for the Elem Tchr,0.71,0.2,0.06,0.03,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4010,002,Elem Field Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ann marie liebel,
-EDEL,4510,002,Elem Methods in Scie,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
-EDEL,4870,002,Ele Meth Soc Studies,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDF,3010,001,Principles of Americ,0.59,0.29,0.05,0.0,0.05,0.0,0.0,0.02,suzanne rosenblith,
-EDF,3010,002,Principles of Americ,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,robert green,
-EDF,3010,004,Principles of Americ,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDF,3020,001,Educ Psych,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,meihua qian,
-EDF,3020,002,Educ Psych,0.23,0.57,0.06,0.11,0.0,0.0,0.0,0.03,penelope mar vargas,
-EDF,3020,003,Educ Psych,0.16,0.58,0.16,0.06,0.03,0.0,0.0,0.0,penelope mar vargas,
-EDF,3080,001,Classroom Assessment,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,
-EDF,3080,002,Classroom Assessment,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,deborah switzer,
-EDF,3200,001,History of US Educat,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,robert green,
-EDF,3340,001,Child Growth and Dev,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
-EDF,3350,002,Adol Growth & Dev,0.52,0.39,0.0,0.04,0.0,0.0,0.0,0.04,david barrett,
-EDF,4800,001,Digital Media & Lear,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,ryan visser,
-EDF,4800,003,Digital Media & Lear,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,004,Digital Media & Lear,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,ryan visser,
-EDF,6900,001,Classroom Management,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,alicia farr clinger,
-EDF,8010,001,Human Growth and Dev,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jeromy blake snider,
-EDF,8080,001,Ed Tests and Measure,0.5,0.33,0.04,0.0,0.08,0.0,0.0,0.04,william fisk,
-EDF,8080,500,Ed Tests and Measure,0.7,0.1,0.05,0.0,0.1,0.0,0.0,0.05,deborah switzer,
-EDF,8710,500,Cultural Diversity i,0.7,0.05,0.0,0.0,0.25,0.0,0.0,0.0,sus cridland-hughes,
-EDF,9770,001,Multi Regress Ed Res,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david barrett,
-EDF,9790,001,Qualitative Research,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,david matthew boyer,
-EDL,7150,501,Sch & Comm Relations,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,frederick buskey,
-EDL,8390,503,Research in Ed L,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,
-EDL,8550,001,App Res & Eval in He,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michelle boettcher,
-EDL,9000,400,Prin Edu Leadership,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,james satterfield,
-EDL,9100,400,Intro Phd Seminar,0.59,0.18,0.0,0.0,0.0,0.0,0.0,0.24,jane lindle,
-EDLT,4590,001,Teaching Reading Gra,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4600,001,Teaching Reading Gra,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
-EDLT,4610,001,Content Area Rdg: 2-,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,4610,002,Content Area Rdg: 2-,0.63,0.19,0.13,0.06,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,4980,002,Secondary Content Ar,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,corrie leigh martin,
-EDLT,8100,500,Foundations: Reading,0.42,0.17,0.0,0.0,0.0,0.0,0.0,0.42,susan kin fullerton,
-EDLT,8640,400,Teaching Secondary S,0.71,0.07,0.07,0.0,0.14,0.0,0.0,0.0,corrie leigh martin,
-EDLT,8640,500,Teaching Secondary S,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8800,506,Reading Recovery Tea,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,
-EDLT,8800,511,Reading Recovery Tea,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,
-EDLT,8820,502,Read Recovery Practi,0.0,0.82,0.09,0.0,0.0,0.0,0.0,0.09,mia francesc riddle,
-EDLT,8820,506,Read Recovery Practi,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,
-EDLT,8820,511,Read Recovery Practi,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,
-EDML,8410,401,Adv Middle School Cu,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lienne federico,
-EDSC,2260,001,Pr Apprch to Sec Alg,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,stacy megan che,
-EDSC,3240,001,Practicum Sec Engl,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,amy tali hallenbeck,
-EDSC,4260,001,Tchng Sec Math,0.56,0.25,0.13,0.0,0.06,0.0,0.0,0.0,dennis aminie kombe,
-EDSC,8610,001,Mthds & Strt Seconda,0.64,0.09,0.0,0.0,0.27,0.0,0.0,0.0,michelle patri cook,
-EDSP,3700,002,Intro to Special Ed,0.83,0.07,0.07,0.0,0.03,0.0,0.0,0.0,robin parks ennis,
-EDSP,3700,003,Intro to Special Ed,0.69,0.26,0.06,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,
-EDSP,3700,004,Intro to Special Ed,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,angelo vespe,
-EDSP,3720,001,Char & Instr Individ,0.9,0.0,0.05,0.0,0.05,0.0,0.0,0.0,catherine griffith,
-EDSP,3740,001,Char & Strat Emot/Be,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,robin parks ennis,
-EDSP,4920,001,Math Inst Ind W/Dis,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,pamela stecker,
-EDSP,4930,001,Clsrm/Beh Mgmt Sp Ed,0.75,0.13,0.08,0.0,0.0,0.0,0.0,0.04,joseph benedic ryan,
-EDSP,4940,001,Tchg Rdg Mild Dis,0.71,0.13,0.13,0.0,0.0,0.0,0.0,0.04,sara moo mackiewicz,
-EDSP,4970,001,Sec Meth Ind W/Dis,0.75,0.13,0.04,0.04,0.0,0.0,0.0,0.04,martha hodge,
-EDSP,8530,001,Legal/Pol Issu Sp Ed,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,antonis katsiyannis,
-EES,2010,001,Environ Engr Fundame,0.33,0.39,0.22,0.03,0.03,0.0,0.0,0.0,david freedman,
-EES,3030,001,Water Treatment Syst,0.3,0.57,0.14,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3040,001,Wastewater Treatment,0.35,0.54,0.11,0.0,0.0,0.0,0.0,0.0,david freedman,
-EES,3050,001,Water/Wastewater Tre,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3050,001,Water/Wastewater Tre,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,david freedman,
-EES,3050,002,Water/Wastewater Tre,0.55,0.25,0.15,0.05,0.0,0.0,0.0,0.0,david freedman,
-EES,3050,002,Water/Wastewater Tre,0.55,0.25,0.15,0.05,0.0,0.0,0.0,0.0,david allen ladner,
-EES,4010,001,Environmental Engr,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,elizabeth carraway,
-EES,4010,002,Environmental Engr,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,mark schlautman,
-EES,4300,001,Air Pollution Engine,0.2,0.44,0.32,0.02,0.02,0.0,0.0,0.0,thomas overcamp,
-EES,4800,001,Environmental Risk A,0.24,0.28,0.28,0.1,0.07,0.0,0.0,0.03,timothy devol,
-EES,4860,001,Environmental Sustai,0.53,0.39,0.05,0.0,0.03,0.0,0.0,0.0,michael anthon dale,
-EES,6100,001,Environ Radiation Pr,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,
-EES,6800,001,Environmental Risk A,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,timothy devol,
-EES,8020,001,Environ Eng Prin,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,thomas overcamp,
-EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tanju karanfil,
-EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,thomas overcamp,
-EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,
-EES,8430,001,Environmental Chem,0.53,0.42,0.0,0.0,0.03,0.0,0.0,0.03,elizabeth carraway,
-EES,8510,001,Biol Prin Envir Engr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
-ELE,3010,001,Intro to Entre,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-ELE,3010,003,Intro to Entre,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
-ELE,4010,001,Exec Lead & Entr II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
-ENGL,1030,001,Accelerated Composit,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katrina torbert,
-ENGL,1030,002,Accelerated Comp,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,lauren taylo stukes,
-ENGL,1030,003,Accelerated Composit,0.21,0.37,0.21,0.11,0.0,0.0,0.0,0.11,chelsea mari clarey,
-ENGL,1030,004,Accelerated Composit,0.37,0.26,0.26,0.11,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,1030,005,Accelerated Composit,0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,1030,006,Accelerated Composit,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,chelsea mari clarey,
-ENGL,1030,007,Accelerated Composit,0.26,0.63,0.0,0.05,0.05,0.0,0.0,0.0,leslie ann salley,
-ENGL,1030,008,Accelerated Composit,0.42,0.21,0.21,0.05,0.0,0.0,0.0,0.11,joshua wood,
-ENGL,1030,009,Accelerated Composit,0.72,0.11,0.11,0.0,0.06,0.0,0.0,0.0,sarah ashto wickham,
-ENGL,1030,010,Accelerated Composit,0.16,0.58,0.16,0.0,0.11,0.0,0.0,0.0,leslie ann salley,
-ENGL,1030,011,Accelerated Composit,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,1030,012,Accelerated Composit,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,molly brian collins,
-ENGL,1030,013,Accelerated Composit,0.05,0.53,0.11,0.05,0.16,0.0,0.0,0.11,leslie ann salley,
-ENGL,1030,014,Accelerated Composit,0.44,0.28,0.22,0.06,0.0,0.0,0.0,0.0,justin all holliday,
-ENGL,1030,015,Accelerated Composit,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,molly brian collins,
-ENGL,1030,016,Accelerated Composit,0.61,0.06,0.11,0.0,0.17,0.0,0.0,0.06,joshua wood,
-ENGL,1030,017,Accelerated Composit,0.26,0.32,0.21,0.16,0.05,0.0,0.0,0.0,leslie ann salley,
-ENGL,1030,018,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,matthew mar russell,
-ENGL,1030,019,Accelerated Composit,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,joshua rya newberry,
-ENGL,1030,021,Accelerated Composit,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,
-ENGL,1030,022,Accelerated Composit,0.83,0.0,0.06,0.06,0.0,0.0,0.0,0.06,daniel frank,
-ENGL,1030,023,Accelerated Composit,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,matthew jose osborn,
-ENGL,1030,024,Accelerated Composit,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,matthew mar russell,
-ENGL,1030,025,Accelerated Composit,0.16,0.63,0.05,0.05,0.05,0.0,0.0,0.05,justin all holliday,
-ENGL,1030,026,Accelerated Composit,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,1030,027,Accelerated Composit,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,matthew jose osborn,
-ENGL,1030,028,Accelerated Composit,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,katherine hanzalik,
-ENGL,1030,029,Accelerated Composit,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,jarrod keit thacker,
-ENGL,1030,030,Accelerated Composit,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,kristen gay,
-ENGL,1030,031,Accelerated Composit,0.53,0.32,0.05,0.11,0.0,0.0,0.0,0.0,adrian carson,
-ENGL,1030,032,Accelerated Composit,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,hannah conl vaughan,
-ENGL,1030,033,Accelerated Composit,0.68,0.16,0.05,0.0,0.05,0.0,0.0,0.05,katherine elrick,
-ENGL,1030,034,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,
-ENGL,1030,035,Accelerated Composit,0.74,0.16,0.0,0.0,0.0,0.0,0.0,0.11,judith roxanne ball,
-ENGL,1030,036,Accelerated Composit,0.63,0.16,0.0,0.05,0.16,0.0,0.0,0.0,kristen gay,
-ENGL,1030,037,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,sarah ashto wickham,
-ENGL,1030,038,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,dustin cleag mosley,
-ENGL,1030,039,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,joshua rya newberry,
-ENGL,1030,040,Accelerated Composit,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,
-ENGL,1030,041,Accelerated Composit,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,katrina torbert,
-ENGL,1030,042,Accelerated Composit,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,katherine hanzalik,
-ENGL,1030,043,Accelerated Composit,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,1030,044,Accelerated Composit,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,daniel frank,
-ENGL,1030,045,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,adrian carson,
-ENGL,1030,046,Accelerated Composit,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,hannah conl vaughan,
-ENGL,1030,047,Accelerated Composit,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,katherine elrick,
-ENGL,1030,048,Accelerated Composit,0.26,0.42,0.21,0.0,0.11,0.0,0.0,0.0,lauren taylo stukes,
-ENGL,1030,049,Accelerated Composit,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,mari elena ramler,
-ENGL,1030,050,Accelerated Composit,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,dustin cleag mosley,
-ENGL,1030,051,Accelerated Composit,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,carlisle an sargent,
-ENGL,1030,052,Accelerated Composit,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,heathe christiansen,
-ENGL,1030,053,Accelerated Composit,0.63,0.32,0.0,0.05,0.0,0.0,0.0,0.0,stephanie mic heath,
-ENGL,1030,054,Accelerated Composit,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,allen swords,
-ENGL,1030,055,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,carlisle an sargent,
-ENGL,1030,056,Accelerated Composit,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,judith roxanne ball,
-ENGL,1030,057,Accelerated Composit,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,
-ENGL,1030,058,Accelerated Composit,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,hayley ren zertuche,
-ENGL,1030,059,Accelerated Composit,0.56,0.28,0.06,0.0,0.06,0.0,0.0,0.06,andrew mar barrocas,
-ENGL,1030,060,Accelerated Composit,0.29,0.41,0.12,0.06,0.12,0.0,0.0,0.0,hayley ren zertuche,
-ENGL,1030,061,Accelerated Composit,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sarah kath melchers,
-ENGL,1030,062,Accelerated Composit,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,mari elena ramler,
-ENGL,1030,063,Accelerated Composit,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,stephanie mic heath,
-ENGL,1030,064,Accelerated Composit,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,
-ENGL,1030,065,Accelerated Composit,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,sarah kath melchers,
-ENGL,1030,067,Accelerated Composit,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
-ENGL,1030,068,Accelerated Composit,0.69,0.08,0.15,0.0,0.08,0.0,0.0,0.0,eda ozyesilpinar,
-ENGL,1030,069,Accelerated Composit,0.63,0.25,0.0,0.0,0.13,0.0,0.0,0.0,eda ozyesilpinar,
-ENGL,1030,500,Accelerated Composit,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,1030,501,Accelerated Composit,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,john conway,
-ENGL,2120,001,World Literature (MA,0.65,0.2,0.1,0.05,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,2120,002,World Literature (MA,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,andrew lemons,
-ENGL,2120,004,World Literature,0.66,0.21,0.07,0.0,0.0,0.0,0.0,0.07,lucian ghita,
-ENGL,2120,005,World Literature,0.71,0.11,0.04,0.0,0.04,0.0,0.0,0.11,david stubblefield,
-ENGL,2120,006,World Literature,0.22,0.48,0.11,0.0,0.0,0.0,0.0,0.19,karen kettnich,
-ENGL,2120,007,World Literature,0.36,0.32,0.14,0.11,0.0,0.0,0.0,0.07,karen kettnich,
-ENGL,2120,008,World Literature,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,lucian ghita,
-ENGL,2120,009,World Literature,0.35,0.46,0.12,0.0,0.04,0.0,0.0,0.04,andrew mathas,
-ENGL,2120,010,World Literature,0.15,0.5,0.12,0.08,0.04,0.0,0.0,0.12,david charles foltz,
-ENGL,2120,011,World Literature,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,allen swords,
-ENGL,2120,012,World Literature,0.62,0.34,0.03,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2120,013,World Literature,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,2120,014,World Literature,0.07,0.3,0.27,0.1,0.1,0.0,0.0,0.17,david charles foltz,
-ENGL,2120,015,World Literature,0.64,0.14,0.04,0.11,0.07,0.0,0.0,0.0,lauren woolbright,
-ENGL,2120,016,World Literature,0.61,0.18,0.07,0.04,0.07,0.0,0.0,0.04,lauren woolbright,
-ENGL,2120,018,World Literature,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2130,001,British Literature,0.82,0.11,0.04,0.04,0.0,0.0,0.0,0.0,sherri teres allred,
-ENGL,2130,002,British Literature,0.31,0.41,0.14,0.03,0.07,0.0,0.0,0.03,elizabeth stansell,
-ENGL,2130,003,British Literature,0.38,0.38,0.17,0.0,0.03,0.0,0.0,0.03,elizabeth stansell,
-ENGL,2130,004,British Literature,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,april susanne pelt,
-ENGL,2130,005,British Literature,0.82,0.11,0.0,0.0,0.0,0.0,0.0,0.07,april susanne pelt,
-ENGL,2130,007,British Literature,0.59,0.24,0.07,0.03,0.03,0.0,0.0,0.03,lucian ghita,
-ENGL,2130,009,British Literature,0.81,0.07,0.0,0.07,0.0,0.0,0.0,0.04,april susanne pelt,
-ENGL,2130,010,British Literature,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,april susanne pelt,
-ENGL,2130,011,British Literature,0.46,0.25,0.07,0.07,0.04,0.0,0.0,0.11,lucian ghita,
-ENGL,2130,012,British Literature,0.71,0.11,0.07,0.04,0.0,0.0,0.0,0.07,sherri teres allred,
-ENGL,2140,001,American Literature,0.48,0.45,0.0,0.0,0.07,0.0,0.0,0.0,melody fowl shirley,
-ENGL,2140,002,American Literature,0.39,0.25,0.29,0.04,0.04,0.0,0.0,0.0,melody fowl shirley,
-ENGL,2140,003,American Literature,0.14,0.36,0.36,0.0,0.09,0.0,0.0,0.05,barbara ramirez,
-ENGL,2140,005,American Literature,0.38,0.46,0.12,0.0,0.0,0.0,0.0,0.04,william stanton,
-ENGL,2140,006,American Literature,0.59,0.24,0.05,0.02,0.0,0.0,0.0,0.09, barton palmer,
-ENGL,2140,007,American Literature,0.34,0.52,0.03,0.07,0.0,0.0,0.0,0.03,john logan pursley,
-ENGL,2140,008,American Literature,0.44,0.3,0.19,0.0,0.04,0.0,0.0,0.04,william stanton,
-ENGL,2140,009,American Literature,0.14,0.41,0.17,0.07,0.17,0.0,0.0,0.03,john logan pursley,
-ENGL,2140,014,American Literature,0.18,0.39,0.25,0.07,0.07,0.0,0.0,0.04,meredith mccarroll,
-ENGL,2140,100,American Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,meredith mccarroll,True
-ENGL,2150,001,Lit in 20th-21st Cen,0.07,0.67,0.19,0.0,0.0,0.0,0.0,0.07,amy monaghan,
-ENGL,2150,002,Lit in 20th-21st Cen,0.0,0.62,0.35,0.0,0.0,0.0,0.0,0.04,amy monaghan,
-ENGL,2150,003,Lit in 20th-21st Cen,0.17,0.55,0.14,0.03,0.03,0.0,0.0,0.07,sarah lauro,
-ENGL,2150,004,Lit in 20th-21st Cen,0.18,0.54,0.18,0.04,0.04,0.0,0.0,0.04,joshua nei waggoner,
-ENGL,2150,005,Lit in 20th-21st Cen,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,sarah lauro,
-ENGL,2150,006,Lit in 20th-21st Cen,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,william pulley,
-ENGL,2150,007,Lit in 20th-21st Cen,0.25,0.46,0.25,0.0,0.04,0.0,0.0,0.0,david charles foltz,
-ENGL,2150,008,Lit in 20th-21st Cen,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,alexander kudera,
-ENGL,2150,010,Lit in 20th-21st Cen,0.59,0.34,0.03,0.0,0.03,0.0,0.0,0.0,john morgenstern,
-ENGL,2150,011,Lit in 20th-21st Cen,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,john morgenstern,
-ENGL,2150,012,Lit in 20th-21st Cen,0.25,0.54,0.11,0.04,0.04,0.0,0.0,0.04,joshua nei waggoner,
-ENGL,2150,015,Lit in 20th-21st Cen,0.41,0.34,0.17,0.03,0.0,0.0,0.0,0.03,lindsay carr thomas,
-ENGL,2150,016,Lit in 20th-21st Cen,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
-ENGL,2150,017,Lit in 20th-21st Cen,0.41,0.41,0.19,0.0,0.0,0.0,0.0,0.0,joshua nei waggoner,
-ENGL,2150,019,Lit in 20th-21st Cen,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,david charles foltz,
-ENGL,2150,020,Lit in 20th-21st Cen,0.56,0.4,0.0,0.0,0.0,0.0,0.0,0.04,garry bertholf,
-ENGL,2150,021,Lit in 20th-21st Cen,0.05,0.45,0.36,0.0,0.0,0.0,0.0,0.14,amy monaghan,
-ENGL,2150,100,20th - 21st Century,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sarah lauro,True
-ENGL,3000,001,Professional Develop,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,cameron fa bushnell,
-ENGL,3040,002,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3040,003,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3040,004,Business Writing,0.33,0.44,0.17,0.0,0.0,0.0,0.0,0.06,megan no macalystre,
-ENGL,3040,005,Business Writing,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,
-ENGL,3040,011,Business Writing,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,sean williams,
-ENGL,3040,012,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexander kudera,
-ENGL,3040,013,Business Writing,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,sherri teres allred,
-ENGL,3040,015,Business Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
-ENGL,3040,016,Business Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alexander kudera,
-ENGL,3100,001,Crit Writ Lit,0.44,0.22,0.17,0.0,0.0,0.0,0.0,0.17,david sweene coombs,
-ENGL,3100,002,Crit Writ Lit,0.26,0.37,0.21,0.0,0.05,0.0,0.0,0.11,erin marina goss,
-ENGL,3100,003,Crit Writ Lit,0.14,0.62,0.14,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,
-ENGL,3120,001,Advanced Composition,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3120,002,Advanced Composition,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,001,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,002,Technical Writing,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,
-ENGL,3140,003,Technical Writing,0.29,0.29,0.12,0.06,0.06,0.0,0.0,0.18,katalin beck,
-ENGL,3140,004,Technical Writing,0.63,0.16,0.05,0.0,0.05,0.0,0.0,0.11,matthew schilleman,
-ENGL,3140,005,Technical Writing,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,meg woosley-goodman,
-ENGL,3140,006,Technical Writing,0.44,0.19,0.13,0.06,0.0,0.0,0.0,0.19,meg woosley-goodman,
-ENGL,3140,008,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,
-ENGL,3140,009,Technical Writing,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,010,Technical Writing,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,3140,011,Technical Writing,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,david stubblefield,
-ENGL,3140,012,Technical Writing,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,katalin beck,
-ENGL,3140,013,Technical Writing,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,014,Technical Writing,0.29,0.53,0.06,0.12,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,015,Technical Writing,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,meg woosley-goodman,
-ENGL,3140,016,Technical Writing,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,018,Technical Writing,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,megan eatman,
-ENGL,3140,019,Technical Writing,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,meg woosley-goodman,
-ENGL,3140,020,Technical Writing,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,021,Technical Writing,0.39,0.28,0.11,0.0,0.06,0.0,0.0,0.17,matthew schilleman,
-ENGL,3140,400,Technical Writing (O,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,3140,401,Technical Writing (O,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,3150,003,Sci Writing & Comm,0.12,0.76,0.06,0.0,0.0,0.0,0.0,0.06,barbara ramirez,
-ENGL,3150,400,Sci Writing & Comm (,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,401,Sci Writing & Comm (,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,402,Sci Writing & Comm,0.53,0.13,0.07,0.2,0.07,0.0,0.0,0.0,carleton dew salley,
-ENGL,3320,001,Visual Communication,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,megan eatman,
-ENGL,3450,001,Structure of Fiction,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,3450,002,Structure of Fiction,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,3460,002,Structure of Poetry,0.58,0.16,0.0,0.0,0.21,0.0,0.0,0.05,sharon kathl nalley,
-ENGL,3480,001,Structure Screenplay,0.72,0.17,0.06,0.0,0.06,0.0,0.0,0.0,joshua nei waggoner,
-ENGL,3490,001,Tech/Pop Imagination,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,matthew schilleman,
-ENGL,3530,001,Ethnic Am Lit,0.06,0.44,0.19,0.13,0.13,0.0,0.0,0.06,kimberly manganelli,
-ENGL,3560,001,Science Fiction,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,lindsay carr thomas,
-ENGL,3570,001,Film,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3570,002,Film,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,agnieszka skrodzka,
-ENGL,3570,003,Film,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06, barton palmer,
-ENGL,3800,001,Women Writers,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,3850,001,Children's Lit,0.22,0.56,0.17,0.0,0.06,0.0,0.0,0.0,megan no macalystre,
-ENGL,3960,001,Brit Lit Survey I,0.3,0.35,0.3,0.0,0.0,0.0,0.0,0.05,brian mcgrath,
-ENGL,3960,002,Brit Lit Survey I,0.15,0.45,0.35,0.05,0.0,0.0,0.0,0.0,brian mcgrath,
-ENGL,3960,003,Brit Lit Survey I,0.15,0.4,0.35,0.05,0.0,0.0,0.0,0.05,brian mcgrath,
-ENGL,3970,001,Brit Lit Survey II,0.13,0.27,0.47,0.0,0.0,0.0,0.0,0.13,wayne chapman,
-ENGL,3980,001,Amer Lit Survey I,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,jonathan beec field,
-ENGL,3980,002,Amer Lit Survey I,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,rhondda robi thomas,
-ENGL,4030,001,Classics in Trans,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,4110,001,Shakespeare,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4110,002,Shakespeare,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4140,001,Milton,0.08,0.69,0.15,0.0,0.0,0.0,0.0,0.08,lee morrissey,
-ENGL,4180,001,English Novel,0.47,0.4,0.0,0.0,0.13,0.0,0.0,0.0,david sweene coombs,
-ENGL,4210,001,Amer Lit 1800-1899,0.27,0.45,0.09,0.0,0.09,0.0,0.0,0.09,dominic mastroianni,
-ENGL,4310,001,Modern Poetry,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,wayne chapman,
-ENGL,4340,001,Environmental Lit,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,sean morey,
-ENGL,4350,001,Literary Criticism,0.35,0.41,0.18,0.06,0.0,0.0,0.0,0.0,dominic mastroianni,
-ENGL,4420,001,Cultural Studies,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,garry bertholf,
-ENGL,4750,001,Writing for Media,0.39,0.39,0.11,0.06,0.0,0.0,0.0,0.06,gabriel and hankins,
-ENGL,4780,001,Digital Literacy,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,gabriel and hankins,
-ENGL,4820,001,Afr Am Lit to 1920,0.2,0.3,0.3,0.1,0.1,0.0,0.0,0.0,rhondda robi thomas,
-ENGL,4910,001,Classical Rhetoric,0.19,0.44,0.38,0.0,0.0,0.0,0.0,0.0,brian mcgrath,
-ENGL,4960,001,Senior Seminar,0.36,0.43,0.07,0.0,0.07,0.0,0.0,0.07,jonathan beec field,
-ENGL,4960,002,Senior Seminar,0.1,0.4,0.3,0.1,0.0,0.0,0.0,0.1,lee morrissey,
-ENGL,4960,003,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william stockton,
-ENGL,8000,001,Introduction to Rese,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,
-ENGL,8100,001,Literary Criticism &,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,angela naimou,
-ENGL,8310,002,Special Topics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,agnieszka skrodzka,
-ENGL,8520,001,Rhetoric & Prof Comm,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharon howard,
-ENGR,1050,005,Engr Discip & Skills,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,elizabeth stephan,True
-ENGR,1050,005,Engr Discip & Skills,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,john minor,True
-ENGR,1050,007,Engr Discip & Skills,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1050,007,Engr Discip & Skills,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
-ENGR,1050,009,Engr Discipline & Sk,0.27,0.33,0.2,0.07,0.05,0.0,0.0,0.08,elizabeth stephan,
-ENGR,1050,009,Engr Discipline & Sk,0.27,0.33,0.2,0.07,0.05,0.0,0.0,0.08,john minor,
-ENGR,1050,011,Engr Discipline & Sk,0.27,0.3,0.18,0.06,0.05,0.0,0.0,0.14,elizabeth stephan,
-ENGR,1050,011,Engr Discipline & Sk,0.27,0.3,0.18,0.06,0.05,0.0,0.0,0.14,ashley childers,
-ENGR,1050,013,Engr Discipl & Skill,0.3,0.46,0.15,0.04,0.0,0.0,0.0,0.04,elizabeth stephan,
-ENGR,1050,013,Engr Discipl & Skill,0.3,0.46,0.15,0.04,0.0,0.0,0.0,0.04,john minor,
-ENGR,1050,015,Engr Discipl & Skill,0.28,0.23,0.43,0.02,0.02,0.0,0.0,0.02,christopher norfolk,
-ENGR,1050,015,Engr Discipl & Skill,0.28,0.23,0.43,0.02,0.02,0.0,0.0,0.02,elizabeth stephan,
-ENGR,1050,017,Engr Discipline & Sk,0.23,0.31,0.25,0.08,0.08,0.0,0.0,0.05,william martin,
-ENGR,1050,017,Engr Discipline & Sk,0.23,0.31,0.25,0.08,0.08,0.0,0.0,0.05,elizabeth stephan,
-ENGR,1050,019,Engr Discipline & Sk,0.21,0.27,0.24,0.05,0.1,0.0,0.0,0.14,steven brandon,
-ENGR,1050,019,Engr Discipline & Sk,0.21,0.27,0.24,0.05,0.1,0.0,0.0,0.14,elizabeth stephan,
-ENGR,1050,021,Engr Discipline & Sk,0.24,0.41,0.24,0.03,0.02,0.0,0.0,0.06,elizabeth stephan,
-ENGR,1050,021,Engr Discipline & Sk,0.24,0.41,0.24,0.03,0.02,0.0,0.0,0.06,ashley childers,
-ENGR,1050,025,Engr Discipline & Sk,0.17,0.38,0.24,0.05,0.05,0.0,0.0,0.12,sarah grigg,
-ENGR,1050,025,Engr Discipline & Sk,0.17,0.38,0.24,0.05,0.05,0.0,0.0,0.12,elizabeth stephan,
-ENGR,1050,027,Engr Discipline & Sk,0.26,0.3,0.24,0.03,0.14,0.0,0.0,0.03,elizabeth stephan,
-ENGR,1050,027,Engr Discipline & Sk,0.26,0.3,0.24,0.03,0.14,0.0,0.0,0.03,john minor,
-ENGR,1050,029,Engr Discipline & Sk,0.22,0.29,0.22,0.11,0.02,0.0,0.0,0.14,elizabeth stephan,
-ENGR,1050,029,Engr Discipline & Sk,0.22,0.29,0.22,0.11,0.02,0.0,0.0,0.14,david ewing,
-ENGR,1050,031,Engr Discipline & Sk,0.23,0.41,0.21,0.02,0.05,0.0,0.0,0.09,william martin,
-ENGR,1050,031,Engr Discipline & Sk,0.23,0.41,0.21,0.02,0.05,0.0,0.0,0.09,elizabeth stephan,
-ENGR,1050,033,Engr Discipline & Sk,0.22,0.32,0.21,0.11,0.03,0.0,0.0,0.11,matthew kent miller,
-ENGR,1050,033,Engr Discipline & Sk,0.22,0.32,0.21,0.11,0.03,0.0,0.0,0.11,elizabeth stephan,
-ENGR,1050,034,Engr Discipl & Skill,0.38,0.36,0.09,0.09,0.04,0.0,0.0,0.04,elizabeth stephan,
-ENGR,1050,034,Engr Discipl & Skill,0.38,0.36,0.09,0.09,0.04,0.0,0.0,0.04,steven brandon,
-ENGR,1050,050,Engr Discip & Skills,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1050,050,Engr Discip & Skills,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
-ENGR,1050,056,Engr Discipl & Skill,0.2,0.38,0.16,0.02,0.02,0.0,0.0,0.22,elizabeth stephan,
-ENGR,1050,056,Engr Discipl & Skill,0.2,0.38,0.16,0.02,0.02,0.0,0.0,0.22,john minor,
-ENGR,1050,058,Engr Discipl & Skill,0.37,0.33,0.16,0.05,0.0,0.0,0.0,0.09,elizabeth stephan,
-ENGR,1050,058,Engr Discipl & Skill,0.37,0.33,0.16,0.05,0.0,0.0,0.0,0.09,john minor,
-ENGR,1050,060,Engr Discipl & Skill,0.27,0.31,0.27,0.04,0.02,0.0,0.0,0.09,william martin,
-ENGR,1050,060,Engr Discipl & Skill,0.27,0.31,0.27,0.04,0.02,0.0,0.0,0.09,elizabeth stephan,
-ENGR,1050,062,Engr Discipl & Skill,0.23,0.45,0.16,0.05,0.02,0.0,0.0,0.09,elizabeth stephan,
-ENGR,1050,062,Engr Discipl & Skill,0.23,0.45,0.16,0.05,0.02,0.0,0.0,0.09,christopher norfolk,
-ENGR,1050,064,Engr Discipl & Skill,0.17,0.57,0.09,0.09,0.02,0.0,0.0,0.06,steven brandon,
-ENGR,1050,064,Engr Discipl & Skill,0.17,0.57,0.09,0.09,0.02,0.0,0.0,0.06,elizabeth stephan,
-ENGR,1050,111,Engr Discipline & Sk,0.08,0.33,0.35,0.08,0.15,0.0,0.0,0.02,elizabeth stephan,
-ENGR,1050,111,Engr Discipline & Sk,0.08,0.33,0.35,0.08,0.15,0.0,0.0,0.02,john minor,
-ENGR,1050,112,Engr Discip & Skills,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
-ENGR,1050,112,Engr Discip & Skills,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True
-ENGR,1050,113,Engr Discipline & Sk,0.15,0.24,0.26,0.13,0.19,0.0,0.0,0.03,elizabeth stephan,
-ENGR,1050,113,Engr Discipline & Sk,0.15,0.24,0.26,0.13,0.19,0.0,0.0,0.03,richard watkins,
-ENGR,1050,117,Engr Discipline & Sk,0.15,0.26,0.29,0.08,0.1,0.0,0.0,0.13,elizabeth stephan,
-ENGR,1050,119,Engr Discipline & Sk,0.27,0.32,0.17,0.02,0.03,0.0,0.0,0.19,matthew kent miller,
-ENGR,1050,119,Engr Discipline & Sk,0.27,0.32,0.17,0.02,0.03,0.0,0.0,0.19,elizabeth stephan,
-ENGR,1050,400,Engr Discipline & Sk,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,elizabeth stephan,
-ENGR,1050,400,Engr Discipline & Sk,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,elizabeth stephan,
-ENGR,1060,005,Engr Discip & Skills,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1060,005,Engr Discip & Skills,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,elizabeth stephan,True
-ENGR,1060,007,Engr Discip & Skills,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
-ENGR,1060,007,Engr Discip & Skills,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1060,009,Engr Discipline & Sk,0.02,0.17,0.29,0.14,0.06,0.0,0.0,0.31,elizabeth stephan,
-ENGR,1060,011,Engr Discipline & Sk,0.17,0.28,0.34,0.06,0.02,0.0,0.0,0.13,elizabeth stephan,
-ENGR,1060,011,Engr Discipline & Sk,0.17,0.28,0.34,0.06,0.02,0.0,0.0,0.13,ashley childers,
-ENGR,1060,012,Engr Discip & Skills,0.05,0.33,0.4,0.1,0.0,0.0,0.0,0.12,elizabeth stephan,
-ENGR,1060,012,Engr Discip & Skills,0.05,0.33,0.4,0.1,0.0,0.0,0.0,0.12,john minor,
-ENGR,1060,013,Engr Discip & Skills,0.07,0.3,0.36,0.11,0.11,0.0,0.0,0.05,elizabeth stephan,
-ENGR,1060,013,Engr Discip & Skills,0.07,0.3,0.36,0.11,0.11,0.0,0.0,0.05,christopher norfolk,
-ENGR,1060,014,Engr Discipline & Sk,0.15,0.35,0.2,0.2,0.05,0.0,0.0,0.05,william park,
-ENGR,1060,014,Engr Discipline & Sk,0.15,0.35,0.2,0.2,0.05,0.0,0.0,0.05,elizabeth stephan,
-ENGR,1060,016,Engr Discipline & Sk,0.21,0.42,0.32,0.0,0.05,0.0,0.0,0.0,john minor,
-ENGR,1060,016,Engr Discipline & Sk,0.21,0.42,0.32,0.0,0.05,0.0,0.0,0.0,elizabeth stephan,
-ENGR,1060,017,Engr Discipline & Sk,0.14,0.26,0.3,0.14,0.04,0.0,0.0,0.12,elizabeth stephan,
-ENGR,1060,017,Engr Discipline & Sk,0.14,0.26,0.3,0.14,0.04,0.0,0.0,0.12,william martin,
-ENGR,1060,019,Engr Discipline & Sk,0.11,0.26,0.24,0.15,0.09,0.0,0.0,0.15,steven brandon,
-ENGR,1060,019,Engr Discipline & Sk,0.11,0.26,0.24,0.15,0.09,0.0,0.0,0.15,elizabeth stephan,
-ENGR,1060,021,Engr Discipline & Sk,0.17,0.24,0.28,0.19,0.04,0.0,0.0,0.09,elizabeth stephan,
-ENGR,1060,021,Engr Discipline & Sk,0.17,0.24,0.28,0.19,0.04,0.0,0.0,0.09,ashley childers,
-ENGR,1060,025,Engr Discipline & Sk,0.12,0.27,0.22,0.12,0.1,0.0,0.0,0.18,sarah grigg,
-ENGR,1060,025,Engr Discipline & Sk,0.12,0.27,0.22,0.12,0.1,0.0,0.0,0.18,elizabeth stephan,
-ENGR,1060,027,Engr Discipline & Sk,0.1,0.31,0.31,0.19,0.06,0.0,0.0,0.04,john minor,
-ENGR,1060,027,Engr Discipline & Sk,0.1,0.31,0.31,0.19,0.06,0.0,0.0,0.04,elizabeth stephan,
-ENGR,1060,029,Engr Discipline & Sk,0.16,0.23,0.35,0.14,0.07,0.0,0.0,0.05,david ewing,
-ENGR,1060,029,Engr Discipline & Sk,0.16,0.23,0.35,0.14,0.07,0.0,0.0,0.05,elizabeth stephan,
-ENGR,1060,031,Engr Discipline & Sk,0.07,0.25,0.36,0.14,0.11,0.0,0.0,0.07,elizabeth stephan,
-ENGR,1060,031,Engr Discipline & Sk,0.07,0.25,0.36,0.14,0.11,0.0,0.0,0.07,william martin,
-ENGR,1060,050,Engr Discip & Skills,0.59,0.28,0.03,0.03,0.0,0.0,0.0,0.07,elizabeth stephan,True
-ENGR,1060,050,Engr Discip & Skills,0.59,0.28,0.03,0.03,0.0,0.0,0.0,0.07,john minor,True
-ENGR,1060,052,Engr Discip & Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1060,052,Engr Discip & Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
-ENGR,1060,056,Engr Discip & Skills,0.06,0.48,0.21,0.12,0.0,0.0,0.0,0.12,elizabeth stephan,
-ENGR,1060,056,Engr Discip & Skills,0.06,0.48,0.21,0.12,0.0,0.0,0.0,0.12,john minor,
-ENGR,1060,058,Engr Discip & Skills,0.16,0.43,0.3,0.03,0.0,0.0,0.0,0.08,john minor,
-ENGR,1060,058,Engr Discip & Skills,0.16,0.43,0.3,0.03,0.0,0.0,0.0,0.08,elizabeth stephan,
-ENGR,1060,060,Engr Discip & Skills,0.03,0.38,0.24,0.19,0.05,0.0,0.0,0.11,elizabeth stephan,
-ENGR,1060,060,Engr Discip & Skills,0.03,0.38,0.24,0.19,0.05,0.0,0.0,0.11,william martin,
-ENGR,1060,062,Engr Discip & Skills,0.05,0.32,0.41,0.08,0.08,0.0,0.0,0.05,elizabeth stephan,
-ENGR,1060,062,Engr Discip & Skills,0.05,0.32,0.41,0.08,0.08,0.0,0.0,0.05,christopher norfolk,
-ENGR,1060,064,Engr Discip & Skills,0.08,0.53,0.18,0.13,0.03,0.0,0.0,0.05,elizabeth stephan,
-ENGR,1060,064,Engr Discip & Skills,0.08,0.53,0.18,0.13,0.03,0.0,0.0,0.05,steven brandon,
-ENGR,1060,066,Engr Discipline & Sk,0.1,0.27,0.31,0.12,0.06,0.0,0.0,0.14,matthew kent miller,
-ENGR,1060,066,Engr Discipline & Sk,0.1,0.27,0.31,0.12,0.06,0.0,0.0,0.14,elizabeth stephan,
-ENGR,1060,112,Engr Discip & Skills,0.53,0.4,0.03,0.0,0.0,0.0,0.0,0.03,steven brandon,True
-ENGR,1060,112,Engr Discip & Skills,0.53,0.4,0.03,0.0,0.0,0.0,0.0,0.03,elizabeth stephan,True
-ENGR,1060,117,Engr Discipline & Sk,0.0,0.21,0.23,0.23,0.16,0.0,0.0,0.16,elizabeth stephan,
-ENGR,1060,119,Engr Discipline & Sk,0.06,0.31,0.25,0.17,0.06,0.0,0.0,0.15,elizabeth stephan,
-ENGR,1060,119,Engr Discipline & Sk,0.06,0.31,0.25,0.17,0.06,0.0,0.0,0.15,matthew kent miller,
-ENGR,1060,170,Engr Discip & Skills,0.11,0.47,0.24,0.11,0.03,0.0,0.0,0.05,steven brandon,
-ENGR,1060,170,Engr Discip & Skills,0.11,0.47,0.24,0.11,0.03,0.0,0.0,0.05,elizabeth stephan,
-ENGR,1070,012,Programming & Prob S,0.08,0.19,0.29,0.16,0.08,0.0,0.0,0.19,david ewing,
-ENGR,1070,012,Programming & Prob S,0.08,0.19,0.29,0.16,0.08,0.0,0.0,0.19,john minor,
-ENGR,1070,018,Programming & Prob S,0.05,0.16,0.25,0.23,0.13,0.0,0.0,0.19,john minor,
-ENGR,1070,018,Programming & Prob S,0.05,0.16,0.25,0.23,0.13,0.0,0.0,0.19,david ewing,
-ENGR,1070,020,Programming & Prob S,0.02,0.14,0.34,0.16,0.2,0.0,0.0,0.14,william park,
-ENGR,1070,020,Programming & Prob S,0.02,0.14,0.34,0.16,0.2,0.0,0.0,0.14,david ewing,
-ENGR,1070,022,Program and Problem,0.02,0.2,0.24,0.11,0.22,0.0,0.0,0.22,william park,
-ENGR,1070,022,Program and Problem,0.02,0.2,0.24,0.11,0.22,0.0,0.0,0.22,david ewing,
-ENGR,1070,072,Program & Prob Solvi,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,david ewing,True
-ENGR,1070,072,Program & Prob Solvi,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1080,018,Programming & Prob S,0.09,0.12,0.39,0.24,0.09,0.0,0.0,0.06,david ewing,
-ENGR,1080,018,Programming & Prob S,0.09,0.12,0.39,0.24,0.09,0.0,0.0,0.06,john minor,
-ENGR,1080,020,Programming & Prob S,0.24,0.18,0.33,0.15,0.09,0.0,0.0,0.0,john minor,
-ENGR,1080,020,Programming & Prob S,0.24,0.18,0.33,0.15,0.09,0.0,0.0,0.0,david ewing,
-ENGR,1080,022,Programming & Prob S,0.28,0.22,0.25,0.13,0.13,0.0,0.0,0.0,david ewing,
-ENGR,1080,022,Programming & Prob S,0.28,0.22,0.25,0.13,0.13,0.0,0.0,0.0,william park,
-ENGR,1080,056,Program/Prob Solving,0.04,0.43,0.13,0.13,0.26,0.0,0.0,0.0,william park,
-ENGR,1080,056,Program/Prob Solving,0.04,0.43,0.13,0.13,0.26,0.0,0.0,0.0,david ewing,
-ENGR,1080,072,Program/Prob Solving,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,david ewing,True
-ENGR,1080,072,Program/Prob Solving,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1090,020,Prog/Problem Solving,0.28,0.48,0.2,0.03,0.0,0.0,0.0,0.03,david ewing,
-ENGR,1090,020,Prog/Problem Solving,0.28,0.48,0.2,0.03,0.0,0.0,0.0,0.03,john minor,
-ENGR,1090,024,Prog/Problem Solving,0.36,0.43,0.19,0.02,0.0,0.0,0.0,0.0,david ewing,
-ENGR,1090,024,Prog/Problem Solving,0.36,0.43,0.19,0.02,0.0,0.0,0.0,0.0,john minor,
-ENGR,1090,028,Prog/Problem Solving,0.43,0.33,0.17,0.07,0.0,0.0,0.0,0.0,david ewing,
-ENGR,1090,056,Prog/Problem Solv Ap,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1090,056,Prog/Problem Solv Ap,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,david ewing,True
-ENGR,1900,013,CI in ENGR Architect,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
-ENGR,1900,013,CI in ENGR Architect,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,1900,014,CI in ENGR Public Po,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,jonathan maier,
-ENGR,1900,014,CI in ENGR Public Po,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,christopher norfolk,
-ENGR,1900,017,CI  in ENGR What ENG,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,bradley putman,
-ENGR,1900,017,CI  in ENGR What ENG,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,jonathan maier,
-ENGR,1900,077,CI in ENGR Huan Powe,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,jonathan maier,
-ENGR,1900,077,CI in ENGR Huan Powe,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,gregory mocko,
-ENGR,2080,023,Engr Graphics & Mach,0.43,0.2,0.2,0.04,0.06,0.0,0.0,0.07,john minor,
-ENGR,2080,023,Engr Graphics & Mach,0.43,0.2,0.2,0.04,0.06,0.0,0.0,0.07,sarah grigg,
-ENGR,2080,028,Engr Graphics & Mach,0.3,0.39,0.11,0.01,0.09,0.0,0.0,0.09,sarah grigg,
-ENGR,2080,028,Engr Graphics & Mach,0.3,0.39,0.11,0.01,0.09,0.0,0.0,0.09,john minor,
-ENGR,2080,030,Engr Graphics & Mach,0.41,0.3,0.16,0.05,0.0,0.0,0.0,0.09,sarah grigg,
-ENGR,2080,030,Engr Graphics & Mach,0.41,0.3,0.16,0.05,0.0,0.0,0.0,0.09,john minor,
-ENGR,2080,053,Engr Graphics & Mach,0.28,0.32,0.19,0.02,0.11,0.0,0.0,0.09,sarah grigg,
-ENGR,2080,053,Engr Graphics & Mach,0.28,0.32,0.19,0.02,0.11,0.0,0.0,0.09,john minor,
-ENGR,2080,055,Engr Graphics & Mach,0.38,0.28,0.23,0.04,0.04,0.0,0.0,0.02,jonathan maier,
-ENGR,2080,055,Engr Graphics & Mach,0.38,0.28,0.23,0.04,0.04,0.0,0.0,0.02,sarah grigg,
-ENGR,2100,032,CAD & Engineering Ap,0.43,0.34,0.09,0.05,0.02,0.0,0.0,0.07,john minor,
-ENGR,2100,032,CAD & Engineering Ap,0.43,0.34,0.09,0.05,0.02,0.0,0.0,0.07,nighat yasmin,
-ENGR,2100,036,CAD & Engineering Ap,0.5,0.18,0.11,0.02,0.07,0.0,0.0,0.11,nighat yasmin,
-ENGR,2100,036,CAD & Engineering Ap,0.5,0.18,0.11,0.02,0.07,0.0,0.0,0.11,john minor,
-ENGR,2100,040,CAD & Engineering Ap,0.4,0.35,0.1,0.03,0.13,0.0,0.0,0.0,john minor,
-ENGR,2100,040,CAD & Engineering Ap,0.4,0.35,0.1,0.03,0.13,0.0,0.0,0.0,nighat yasmin,
-ENGR,2100,044,CAD & Engineering Ap,0.43,0.26,0.22,0.02,0.0,0.0,0.0,0.07,john minor,
-ENGR,2100,044,CAD & Engineering Ap,0.43,0.26,0.22,0.02,0.0,0.0,0.0,0.07,william martin,
-ENR,1010,001,Intro to Envir & Nat,0.7,0.17,0.06,0.02,0.04,0.0,0.0,0.02,alan johnson,
-ENR,1010,001,Intro Env & Nat Rs I,0.7,0.17,0.06,0.02,0.04,0.0,0.0,0.02,alan johnson,
-ENR,1010,002,Intro to Envir & Nat,0.65,0.12,0.1,0.06,0.04,0.0,0.0,0.02,alan johnson,
-ENR,4290,001,Environ Law & Policy,0.47,0.38,0.09,0.03,0.03,0.0,0.0,0.0,alan johnson,
-ENSP,2000,001,Intro Environ Sci,0.67,0.22,0.08,0.0,0.0,0.0,0.0,0.02,scott brame,
-ENSP,2000,002,Intro Environ Sci,0.66,0.28,0.04,0.0,0.02,0.0,0.0,0.0,minory nammouz,
-ENSP,2000,003,Intro Environ Sci,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,4000,001,Studies in En Sp,0.68,0.14,0.09,0.05,0.05,0.0,0.0,0.0,margaret thompson,
-ENT,2000,001,Six-Legged Science,0.71,0.13,0.08,0.0,0.0,0.0,0.0,0.08,suellen pometto,
-ENT,2010,001,Selected Topics,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,joseph culin,
-ENT,3010,001,Insect Biology & Div,0.33,0.33,0.17,0.0,0.17,0.0,0.0,0.0,eric benson,
-ESED,8000,001,Seminar in Engr & Sc,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,julie patric martin,
-ESED,8000,001,Seminar in Engr & Sc,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,karen ann high,
-ESED,8200,001,Teaching Undergrad E,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,karen ann high,
-ESED,8200,001,Teaching Undergrad E,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,
-ESED,8750,001,Curr Issues in STEM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,
-ESED,8750,001,Curr Issues in STEM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,karen ann high,
-ETOX,4300,001,Toxicology,0.18,0.45,0.18,0.0,0.0,0.0,0.0,0.18,peter van den hurk,
-ETOX,6300,001,Toxicology,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,peter van den hurk,
-FCS,8130,003,Research Methods in,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,natallia ser sianko,
-FCS,8130,003,Research Methods in,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,
-FDSC,1010,001,Intro to Food Sci &,0.69,0.25,0.02,0.01,0.04,0.0,0.0,0.0,rita haliena,
-FDSC,1010,001,Intro to Food Sci &,0.69,0.25,0.02,0.01,0.04,0.0,0.0,0.0,aubrey dean coffee,
-FDSC,3010,001,Food Regulations,0.75,0.2,0.0,0.03,0.0,0.0,0.0,0.03,julie kat northcutt,
-FDSC,3060,001,Institutional Foodse,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,
-FDSC,3070,001,Restaurant Food Serv,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,margaret condrasky,
-FDSC,4010,001,Food Chem I,0.78,0.16,0.03,0.01,0.0,0.0,0.0,0.01,ronnie thomas,
-FDSC,4040,001,Food Prsv & Process,0.28,0.51,0.18,0.03,0.0,0.0,0.0,0.0,julie kat northcutt,
-FDSC,4070,001,Quantity Food Produc,0.43,0.49,0.06,0.01,0.0,0.0,0.0,0.01,heather batt,
-FDSC,4170,001,Seminar,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,aubrey dean coffee,
-FDSC,4300,001,Dairy Process & Sant,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-FDSC,8120,001,Microbial Food Syst,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,xiuping jiang,
-FIN,3040,001,Risk & Insurance,0.0,0.38,0.38,0.08,0.15,0.0,0.0,0.0,kerri mcmillan,
-FIN,3040,002,Risk & Insurance,0.21,0.32,0.34,0.11,0.0,0.0,0.0,0.03,kerri mcmillan,
-FIN,3050,001,Investment Analysis,0.16,0.47,0.23,0.09,0.0,0.0,0.0,0.05,kerri mcmillan,
-FIN,3050,002,Investment Analysis,0.22,0.41,0.27,0.07,0.02,0.0,0.0,0.02,kerri mcmillan,
-FIN,3050,003,Investment Analysis,0.1,0.26,0.19,0.1,0.07,0.0,0.0,0.28,john alexander,
-FIN,3060,002,Corporation Finance,0.11,0.19,0.53,0.08,0.03,0.0,0.0,0.06,john harris,
-FIN,3060,003,Corporation Finance,0.08,0.57,0.28,0.06,0.0,0.0,0.0,0.02,neil waller,
-FIN,3060,004,Corporation Finance,0.23,0.48,0.15,0.08,0.03,0.0,0.0,0.05,john harris,
-FIN,3060,005,Corporation Finance,0.08,0.62,0.23,0.08,0.0,0.0,0.0,0.0,neil waller,
-FIN,3060,006,Corporation Finance,0.07,0.2,0.49,0.07,0.05,0.0,0.0,0.12,john harris,
-FIN,3060,007,Corporation Finance,0.16,0.51,0.24,0.08,0.0,0.0,0.0,0.02,neil waller,
-FIN,3060,008,Corporation Finance,0.28,0.3,0.07,0.17,0.09,0.0,0.0,0.09,william hol johnson,
-FIN,3060,009,Corporation Finance,0.22,0.38,0.25,0.0,0.03,0.0,0.0,0.13,john harris,
-FIN,3060,010,Corporation Finance,0.28,0.2,0.28,0.13,0.03,0.0,0.0,0.1,william hol johnson,
-FIN,3060,011,Corporation Finance,0.3,0.28,0.17,0.11,0.06,0.0,0.0,0.09,william hol johnson,
-FIN,3070,001,Prin of Real Estate,0.15,0.4,0.32,0.09,0.02,0.0,0.0,0.02,thomas springer,
-FIN,3070,002,Prin of Real Estate,0.15,0.44,0.33,0.04,0.04,0.0,0.0,0.0,thomas springer,
-FIN,3080,001,Fin Inst & Mkts,0.23,0.37,0.2,0.13,0.03,0.0,0.0,0.03,daniel thoma greene,
-FIN,3080,002,Fin Inst & Mkts,0.13,0.3,0.4,0.08,0.08,0.0,0.0,0.03,michael spivey,
-FIN,3080,003,Fin Inst & Mkts,0.21,0.36,0.29,0.07,0.02,0.0,0.0,0.05,michael spivey,
-FIN,3110,001,Financial Management,0.17,0.26,0.33,0.17,0.0,0.0,0.0,0.07,jared daniel smith,
-FIN,3110,002,Financial Management,0.17,0.34,0.37,0.07,0.05,0.0,0.0,0.0,jared daniel smith,
-FIN,3110,003,Financial Management,0.3,0.34,0.16,0.11,0.05,0.0,0.0,0.05,fei xie,
-FIN,3110,004,Financial Management,0.3,0.43,0.18,0.02,0.02,0.0,0.0,0.05,fei xie,
-FIN,3120,001,Financial Mgt II,0.09,0.31,0.38,0.16,0.0,0.0,0.0,0.06,lyudmila chernykh,
-FIN,3120,002,Financial Mgt II,0.32,0.38,0.22,0.05,0.0,0.0,0.0,0.03,lyudmila chernykh,
-FIN,3120,003,Financial Mgt II,0.53,0.19,0.16,0.02,0.02,0.0,0.0,0.07,melvin stith,
-FIN,3120,004,Financial Mgt II,0.72,0.11,0.15,0.02,0.0,0.0,0.0,0.0,melvin stith,
-FIN,4020,001,Corporate Valuation,0.35,0.28,0.25,0.13,0.0,0.0,0.0,0.0,angela morgan,
-FIN,4020,003,Corporate Valuation,0.07,0.4,0.38,0.1,0.02,0.0,0.0,0.02,angela morgan,
-FIN,4050,001,Port Mgt and Theory,0.14,0.18,0.39,0.14,0.0,0.0,0.0,0.14,john alexander,
-FIN,4060,001,Derivatives Analysis,0.21,0.38,0.25,0.04,0.04,0.0,0.0,0.08,george bra lockhart,
-FIN,4110,001,Int Fin Mgt,0.25,0.33,0.3,0.05,0.03,0.0,0.0,0.05,tilan tang,
-FIN,4110,002,Int Fin Mgt,0.47,0.16,0.16,0.05,0.05,0.0,0.0,0.11,tilan tang,
-FIN,4170,001,Real Estate Finance,0.36,0.36,0.27,0.0,0.0,0.0,0.0,0.0,neil waller,
-FNR,2040,001,Soil Information Sys,0.72,0.22,0.03,0.02,0.0,0.0,0.0,0.02,elena mikhailova,
-FOR,2050,001,Dendrology,0.25,0.31,0.19,0.16,0.09,0.0,0.0,0.0,donald hagan,
-FOR,2050,002,Dendrology,0.18,0.24,0.35,0.24,0.0,0.0,0.0,0.0,donald hagan,
-FOR,2050,003,Dendrology,0.31,0.23,0.2,0.11,0.09,0.0,0.0,0.06,donald hagan,
-FOR,2210,001,Forest Biology,0.46,0.4,0.09,0.02,0.01,0.0,0.0,0.01,patrick mcmillan,
-FOR,3020,001,Forest Biometrics,0.41,0.23,0.18,0.14,0.05,0.0,0.0,0.0,lawrence gering,
-FOR,3040,001,Forest Res Econ,0.38,0.24,0.24,0.11,0.03,0.0,0.0,0.0,john edward hatcher,
-FOR,4100,001,Harvesting Processes,0.36,0.27,0.27,0.09,0.0,0.0,0.0,0.0,greg yarrow,
-FOR,4130,001,Int Forest Pest Mgmt,0.22,0.39,0.3,0.09,0.0,0.0,0.0,0.0,robert bellinger,
-FOR,4130,001,Int Forest Pest Mgmt,0.22,0.39,0.3,0.09,0.0,0.0,0.0,0.0,julia loui kerrigan,
-FOR,4160,001,For Pol and Adm,0.45,0.4,0.14,0.02,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4170,001,For Res Mgt and Reg,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,john edward hatcher,
-FOR,4310,001,Mgt for Recreation,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
-FOR,4340,001,GIS for Landscape Pl,0.5,0.46,0.02,0.0,0.02,0.0,0.0,0.0,christopher post,
-FOR,4930,200,Wildland and Prescri,0.45,0.34,0.0,0.0,0.07,0.0,0.0,0.14,donald hagan,
-FR,1010,001,Elementary French,0.74,0.16,0.0,0.05,0.05,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,1020,001,Elementary French,0.75,0.15,0.0,0.05,0.0,0.0,0.0,0.05,amy lyn grif sawyer,
-FR,1020,002,Elementary French,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,1020,003,Elementary French,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,julian hamil killey,
-FR,2010,001,Intermediate French,0.56,0.22,0.11,0.06,0.0,0.0,0.0,0.06,joseph mai,
-FR,2010,002,Intermediate French,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,kenneth dav widgren,
-FR,2010,003,Intermediate French,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,2010,004,Intermediate French,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,julian hamil killey,
-FR,2020,001,Intermediate French,0.85,0.0,0.1,0.0,0.0,0.0,0.0,0.05,amy lyn grif sawyer,
-FR,2020,002,Intermediate French,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
-FR,2020,003,Intermediate French,0.35,0.29,0.24,0.0,0.0,0.0,0.0,0.12,kenneth dav widgren,
-FR,3040,001,French Short Story,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,eric touya,
-FR,3050,001,Int Fr Con & Comp I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,3070,001,French Civilization,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,4160,001,Fr for Intl Trade II,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,eric touya,
-GC,1010,001,Orientation to G C,0.78,0.14,0.08,0.0,0.0,0.0,0.0,0.0,rebecca suza edlein,
-GC,1010,002,Orientation to G C,0.8,0.1,0.04,0.02,0.02,0.0,0.0,0.02,kern cox,
-GC,1020,001,Comp Art & Cad Found,0.42,0.35,0.15,0.04,0.04,0.0,0.0,0.0,charles tabor weiss,
-GC,1020,002,Comp Art & Cad Found,0.52,0.45,0.0,0.0,0.0,0.0,0.0,0.03,nona woolbright,
-GC,1020,003,Comp Art & Cad Found,0.62,0.31,0.0,0.0,0.07,0.0,0.0,0.0,nona woolbright,
-GC,1020,004,Comp Art & Cad Found,0.42,0.38,0.12,0.0,0.08,0.0,0.0,0.0,carol jones,
-GC,1030,001,G C I for Pkgsc,0.29,0.38,0.24,0.05,0.0,0.0,0.0,0.05,john jacobs,
-GC,1040,001,Graphic Com I,0.56,0.29,0.09,0.0,0.03,0.0,0.0,0.03,rebecca suza edlein,
-GC,1040,001,Graphic Communicatio,0.56,0.29,0.09,0.0,0.03,0.0,0.0,0.03,rebecca suza edlein,
-GC,1990,003,Cr Inquiry in G C I-,0.86,0.05,0.0,0.0,0.05,0.0,0.0,0.05,janice ann lay,
-GC,2070,001,Graphic Communicatio,0.5,0.38,0.09,0.0,0.03,0.0,0.0,0.0,patrick gee rose,
-GC,3400,001,Digital Img & Emedia,0.6,0.29,0.07,0.02,0.02,0.0,0.0,0.0,erica black walker,
-GC,4060,001,Package and Specialt,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,kern cox,
-GC,4400,001,Commercial Printing,0.29,0.67,0.0,0.0,0.04,0.0,0.0,0.0,eric weisenmiller,
-GC,4400,002,Commercial Printing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,
-GC,4440,001,Current Dev in G C,0.38,0.47,0.09,0.03,0.03,0.0,0.0,0.0,liam henry 'hara,
-GC,4460,001,Ink & Substrates,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,liam henry 'hara,
-GC,4460,002,Ink & Substrates,0.08,0.31,0.23,0.23,0.15,0.0,0.0,0.0,liam henry 'hara,
-GC,4480,001,Plan and Cont Print,0.5,0.33,0.13,0.03,0.0,0.0,0.0,0.0,john leininger,
-GC,4900,230,G C Selected Topics-,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,john leininger,
-GC,6900,002,G C Selected Topics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,
-GEN,1030,001,Careers in Bioch/Gen,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,alison starr-moss,
-GEN,3000,001,Fundamental Genetics,0.28,0.3,0.18,0.14,0.01,0.0,0.0,0.09,kate leanne wi tsai,
-GEN,3000,002,Fundamental Genetics,0.34,0.37,0.19,0.05,0.01,0.0,0.0,0.04,kate leanne wi tsai,
-GEN,3020,001,Molecular & General,0.23,0.37,0.25,0.06,0.04,0.0,0.0,0.06,liangjiang wang,
-GEN,3020,001,Molecular & General,0.23,0.37,0.25,0.06,0.04,0.0,0.0,0.06,lukasz kozubowski,
-GEN,3020,002,Molec & General Gene,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,True
-GEN,3020,002,Molec & General Gene,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,True
-GEN,3030,001,Molec & General Gene,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,liangjiang wang,
-GEN,3030,001,Molec & General Gene,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,
-GEN,3030,002,Molec & General Gene,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,lukasz kozubowski,
-GEN,3030,002,Mol Gen Genet Lab,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,lukasz kozubowski,
-GEN,3030,002,Molec & General Gene,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,liangjiang wang,
-GEN,3030,002,Mol Gen Genet Lab,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,liangjiang wang,
-GEN,3030,003,Molec & General Gene,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,
-GEN,3030,003,Molec & General Gene,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,
-GEN,3030,004,Molec & General Gene,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lukasz kozubowski,
-GEN,3030,004,Mol Gen Genet Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lukasz kozubowski,
-GEN,3030,004,Molec & General Gene,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,liangjiang wang,
-GEN,3030,004,Mol Gen Genet Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,liangjiang wang,
-GEN,4200,001,Molecular Genetics &,0.33,0.33,0.26,0.0,0.0,0.0,0.0,0.07,julia frugoli,
-GEN,4200,002,Molecular Genetics &,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True
-GEN,4210,002,Mol Gen Gene Reg Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,
-GEN,4210,003,Mol Gen Gene Reg Lab,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,julia frugoli,
-GEN,4210,004,Mol Gen Gene Reg Lab,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,julia frugoli,
-GEN,4400,001,Bioinformatics,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
-GEN,4500,001,Comparative Genetics,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,leigh anne clark,
-GEN,6400,001,Bioinformatics,0.63,0.25,0.0,0.0,0.13,0.0,0.0,0.0,frank alexan feltus,
-GEN,8140,001,Advanced Genetics,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kate leanne wi tsai,
-GEOG,1010,001,Intro to Geography,0.33,0.33,0.23,0.1,0.03,0.0,0.0,0.0,christa smith,
-GEOG,1030,001,World Regional Geog,0.76,0.14,0.03,0.02,0.02,0.0,0.0,0.02,lance forres howard,
-GEOG,1030,002,World Regional Geog,0.35,0.35,0.2,0.05,0.0,0.0,0.0,0.05,william churc terry,
-GEOG,1030,003,World Regional Geog,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,david doran,
-GEOG,1030,004,World Regional Geog,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david doran,
-GEOG,3400,001,Geog of Latin Amer,0.27,0.27,0.36,0.0,0.09,0.0,0.0,0.0,william churc terry,
-GEOL,1010,001,Physical Geology,0.18,0.29,0.21,0.15,0.07,0.0,0.0,0.09,alan coulson,
-GEOL,1010,002,Physical Geology,0.26,0.28,0.22,0.11,0.06,0.0,0.0,0.07,alan coulson,
-GEOL,1010,003,Physical Geology,0.37,0.35,0.24,0.04,0.0,0.0,0.0,0.0,stephen mich moysey,
-GEOL,1030,001,Physical Geol Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,002,Physical Geol Lab,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,003,Physical Geol Lab,0.09,0.22,0.39,0.13,0.13,0.0,0.0,0.04,alan coulson,
-GEOL,1030,004,Physical Geol Lab,0.63,0.25,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,005,Physical Geol Lab,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,006,Physical Geol Lab,0.17,0.52,0.17,0.09,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,007,Physical Geol Lab,0.21,0.46,0.17,0.0,0.0,0.0,0.0,0.17,alan coulson,
-GEOL,1030,008,Physical Geol Lab,0.25,0.63,0.04,0.0,0.04,0.0,0.0,0.04,alan coulson,
-GEOL,1030,009,Physical Geol Lab,0.13,0.38,0.25,0.04,0.0,0.0,0.0,0.21,alan coulson,
-GEOL,1030,010,Physical Geol Lab,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,012,Physical Geol Lab,0.13,0.43,0.22,0.13,0.0,0.0,0.0,0.09,alan coulson,
-GEOL,2050,001,Mineralogy & Intro P,0.4,0.27,0.2,0.0,0.13,0.0,0.0,0.0,lin shuller-nickles,
-GEOL,2070,001,Min & Intro Pet Lab,0.21,0.5,0.14,0.07,0.07,0.0,0.0,0.0,alan coulson,
-GEOL,2700,001,Sustainable Water,0.82,0.04,0.07,0.0,0.04,0.0,0.0,0.04,stephen mich moysey,
-GEOL,3000,001,Environmental Geol,0.41,0.38,0.15,0.06,0.0,0.0,0.0,0.0,scott brame,
-GEOL,4110,008,CI - Community Outre,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,john robert wagner,
-GEOL,6150,001,Analysis Geological,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
-GEOL,8060,001,Aquifer Charact,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james castle,
-GEOL,8090,001,Subsurface Remed Mod,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ronald falta,
-GER,1010,001,Elementary German,0.32,0.37,0.16,0.0,0.05,0.0,0.0,0.11, lee ferrell,
-GER,1010,002,Elementary German,0.11,0.32,0.16,0.32,0.05,0.0,0.0,0.05, lee ferrell,
-GER,1010,003,Elementary German,0.24,0.18,0.24,0.06,0.06,0.0,0.0,0.24, lee ferrell,
-GER,1020,001,Elementary German,0.29,0.21,0.14,0.07,0.0,0.0,0.0,0.29, lee ferrell,
-GER,1020,003,Elementary German,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,2010,001,Intermediate German,0.33,0.4,0.07,0.0,0.07,0.0,0.0,0.13,gabriela stoicea,
-GER,2010,002,Intermediate German,0.22,0.33,0.17,0.17,0.0,0.0,0.0,0.11,johannes schmidt,
-GER,2020,001,Intermediate German,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,3050,001,Ger Conv & Comp,0.53,0.24,0.06,0.12,0.0,0.06,0.0,0.0,oswald harris king,
-GER,3690,001,German WWI Literatur,0.42,0.42,0.0,0.17,0.0,0.0,0.0,0.0,johannes schmidt,
-HCC,8310,001,Fundamentals of Hcc,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shaundra daily,
-HCC,8810,001,Research Methods in,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
-HEHD,4100,001,Lead Beh & Civic En,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,katelyn mcc radford,
-HEHD,8000,400,Youth Dev Theories,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kellye rembert,
-HEHD,8050,001,Yth Dev in Families,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
-HEHD,8050,001,Yth Dev in Families,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,william quinn,
-HEHD,8060,230,Diverse Society,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,william quinn,
-HEHD,8060,230,Diverse Society,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,keith george diem,
-HIST,1010,001,Hist of the U S,0.12,0.55,0.24,0.0,0.06,0.0,0.0,0.03,james brad jeffries,
-HIST,1010,002,Hist of the U S,0.31,0.26,0.29,0.11,0.0,0.0,0.0,0.03,lee brady wilson,
-HIST,1020,002,Hist of the U S,0.23,0.23,0.12,0.04,0.0,0.0,0.0,0.38,maribel morey,
-HIST,1240,001,Environmental Hist,0.24,0.37,0.25,0.03,0.03,0.0,0.0,0.07,james brad jeffries,
-HIST,1720,001,The West and the Wor,0.39,0.26,0.16,0.12,0.03,0.0,0.0,0.03,james burns,
-HIST,1720,002,The West and the Wor,0.33,0.36,0.19,0.05,0.02,0.0,0.0,0.05,steven marks,
-HIST,1730,001,The West and the Wor,0.3,0.33,0.17,0.05,0.06,0.0,0.0,0.09,richard saunders,
-HIST,1730,002,The West and the Wor,0.32,0.38,0.13,0.03,0.08,0.0,0.0,0.05, alan grubb,
-HIST,2990,001,Historian's Craft,0.47,0.2,0.13,0.0,0.07,0.0,0.0,0.13,michael silvestri,
-HIST,2990,003,Historian's Craft,0.59,0.24,0.06,0.06,0.0,0.0,0.0,0.06,rachel anne moore,
-HIST,3000,001,Hist Colonial Amer,0.3,0.49,0.14,0.03,0.05,0.0,0.0,0.0,lee brady wilson,
-HIST,3030,001,Civil War & Recon,0.21,0.49,0.13,0.03,0.1,0.0,0.0,0.05,paul chris anderson,
-HIST,3040,001,Indus & Progr Era,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0, roger grant,
-HIST,3220,001,History of Technolog,0.37,0.33,0.13,0.03,0.1,0.0,0.0,0.03,pamela mack,
-HIST,3280,001,US Legal History to,0.17,0.17,0.1,0.0,0.07,0.0,0.0,0.5,maribel morey,
-HIST,3300,001,Hist of Mod China,0.31,0.23,0.38,0.0,0.08,0.0,0.0,0.0,edwin moise,
-HIST,3400,001,Latin America I,0.48,0.38,0.1,0.0,0.02,0.0,0.0,0.02,rachel anne moore,
-HIST,3550,001,Roman World,0.35,0.48,0.06,0.0,0.03,0.0,0.0,0.06,elizabeth carney,
-HIST,3610,001,History of Britain t,0.42,0.36,0.12,0.03,0.06,0.0,0.0,0.0,caroline dunn clark,
-HIST,3630,001,Britain Since 1688,0.37,0.26,0.21,0.05,0.05,0.0,0.0,0.05,stephani barczewski,
-HIST,3700,001,Medieval History,0.41,0.31,0.09,0.06,0.06,0.0,0.0,0.06,caroline dunn clark,
-HIST,3720,001,Renaissance,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,thomas kuehn,
-HIST,3810,001,Germany Since 1918,0.2,0.47,0.13,0.0,0.2,0.0,0.0,0.0,michael meng,
-HIST,3850,001,Imperial Russia,0.3,0.37,0.11,0.11,0.07,0.0,0.0,0.04,steven marks,
-HIST,3900,001,Mod Mil Hist,0.09,0.41,0.41,0.0,0.05,0.0,0.0,0.05,edwin moise,
-HIST,4090,001,Jfk Assassination,0.42,0.38,0.1,0.0,0.08,0.0,0.0,0.02,richard saunders,
-HIST,4140,001,Study of Hist Museum,0.6,0.07,0.27,0.0,0.07,0.0,0.0,0.0,leslie white,
-HIST,4710,001,Studies in Mod Europ,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,michael meng,
-HIST,4870,001,World War II,0.2,0.57,0.07,0.09,0.04,0.0,0.0,0.04,john andrew,
-HIST,4900,002,Film and Local Histo,0.45,0.45,0.0,0.09,0.0,0.0,0.0,0.0,james burns,
-HIST,4900,003,HIST & GEOG Disney P,0.31,0.44,0.13,0.13,0.0,0.0,0.0,0.0,stephani barczewski,
-HIST,4900,003,HIST & GEOG Disney P,0.31,0.44,0.13,0.13,0.0,0.0,0.0,0.0,christa smith,
-HIST,4930,001,Slavery & Film,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,abel bartley,
-HIST,4940,001,Europe's Dictators,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,amit bein,
-HIST,8000,002,Major Probs SO Histo,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,john andrew,
-HLTH,2020,001,Introduction to Publ,0.31,0.62,0.0,0.08,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,002,Introduction to Publ,0.56,0.33,0.08,0.03,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,003,Introduction to Publ,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,004,Introduction to Publ,0.39,0.45,0.11,0.05,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,005,Introduction to Publ,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,006,Introduction to Publ,0.53,0.35,0.06,0.0,0.06,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2030,001,Health Care Sys,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,lee alden crandall,
-HLTH,2030,002,Health Care Sys,0.68,0.28,0.0,0.0,0.03,0.0,0.0,0.03,ralph stewart welsh,
-HLTH,2030,400,Health Care Sys,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ralph stewart welsh,
-HLTH,2400,001,Deter of Hlth Behav,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.03,sarah griffin,
-HLTH,2400,002,Deter of Hlth Behav,0.36,0.49,0.09,0.0,0.0,0.0,0.0,0.06,sarah griffin,
-HLTH,2980,001,Human Hlth & Disease,0.6,0.33,0.05,0.0,0.0,0.0,0.0,0.02,deborah alma falta,
-HLTH,2980,002,Human Hlth & Disease,0.53,0.44,0.0,0.0,0.0,0.0,0.0,0.03,deborah alma falta,
-HLTH,3030,001,Public Health Comm,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,debra mitch charles,
-HLTH,3400,001,Hlth Prom Prog Plan,0.47,0.32,0.18,0.0,0.0,0.0,0.0,0.03,joel edwar williams,
-HLTH,3610,001,Int Health Care Econ,0.5,0.28,0.17,0.0,0.0,0.0,0.0,0.06,khoa dang truong,
-HLTH,3800,001,Epidemiology,0.19,0.6,0.15,0.04,0.0,0.0,0.0,0.02,hugh spitler,
-HLTH,3800,002,Epidemiology,0.16,0.64,0.2,0.0,0.0,0.0,0.0,0.0,hugh spitler,
-HLTH,3800,400,Epidemiology,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,deborah alma falta,
-HLTH,3980,001,Hlth Appraisal Sklls,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4150,001,Obesity & Eating Dis,0.57,0.34,0.06,0.0,0.0,0.0,0.0,0.03,karen kemper,
-HLTH,4190,001,Health Sci Internshi,0.21,0.58,0.12,0.06,0.03,0.0,0.0,0.0,kathleen meyer,
-HLTH,4200,001,Hlth Science Intern,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4400,001,Manag Hlth Serv Org,0.19,0.67,0.15,0.0,0.0,0.0,0.0,0.0,frederic fraizer,
-HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,ronald gimbel,
-HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,rachel mayo,
-HLTH,4750,001,Hlthcr Oper Mgmt Res,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,
-HLTH,4900,001,Res Eval St Pub Hlth,0.57,0.19,0.14,0.05,0.0,0.0,0.0,0.05,khoa dang truong,
-HLTH,4900,002,Res Eval St Pub Hlth,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,lingling zhang,
-HON,1900,001,Holocaust Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True
-HON,1900,002,Amer Lit & Global Co,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,angela naimou,True
-HON,1920,001,Positively Human,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,june pilcher,True
-HON,1940,001,Scientific Skepticis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey appling,True
-HON,2020,001,Stress in Health and,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,True
-HON,2030,001,Music/Politics:Blues,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,True
-HON,2200,001,Midterm Elections,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey allen fine,True
-HON,2200,002,The Modern Israeli S,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,colin pearce,True
-HON,2220,001,Science/Literaure in,0.64,0.27,0.0,0.09,0.0,0.0,0.0,0.0,gabriela stoicea,True
-HORT,1010,001,Horticulture,0.63,0.31,0.07,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HORT,2100,001,Growing Fall Plants,0.33,0.17,0.17,0.17,0.0,0.0,0.0,0.17,samarakoon basnagala,
-HORT,2120,001,Turfgrass Culture,0.55,0.43,0.0,0.0,0.03,0.0,0.0,0.0,haibo liu,
-HORT,2130,001,Turf Culture Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,donald garrett,
-HORT,2130,002,Turf Culture Lab,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,donald garrett,
-HORT,3030,001,Landscape Plants,0.36,0.32,0.17,0.03,0.07,0.0,0.0,0.05,robert polomski,
-HORT,3080,001,Sust Landscape Des,0.63,0.23,0.07,0.05,0.0,0.0,0.0,0.02,ellen anita vincent,
-HORT,3090,001,Sust Landsc Des Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,harry harritos,
-HORT,4090,001,Senior Capstone Cour,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,ellen anita vincent,
-HORT,4120,001,Adv Turfgrass Mgt,0.3,0.3,0.2,0.0,0.0,0.0,0.0,0.2,lambert mccarty,
-HORT,4330,001,Turf Weed Management,0.29,0.41,0.24,0.0,0.0,0.0,0.0,0.06,ted whitwell,
-HP,8030,001,Building Tech and Pa,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amalia leifeste,
-HP,8070,400,American Architectur,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,carter lee hudgins,
-HP,8090,400,Historical Research,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,katherine pemberton,
-HP,8190,001,"Investig, Docum, Con",0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,amalia leifeste,
-HP,8190,001,"Investig, Docum, Con",0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,kristopher king,
-HRD,8200,400,Human Perform Improv,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,cynthia sims,
-HRD,8200,401,Human Perform Improv,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,cynthia sims,
-HRD,8200,402,Human Perform Improv,0.71,0.0,0.14,0.0,0.0,0.0,0.0,0.14,cynthia sims,
-HRD,8200,403,Human Perform Improv,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,cynthia sims,
-HRD,8200,405,Human Perform Improv,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,cynthia sims,
-HRD,8200,406,Human Perform Improv,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,cynthia sims,
-HRD,8300,400,Concepts of H R D,0.38,0.38,0.13,0.0,0.0,0.0,0.0,0.13,eileen newmark,
-HRD,8300,401,Concepts of H R D,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,eileen newmark,
-HRD,8300,402,Concepts of H R D,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,eileen newmark,
-HRD,8300,403,Concepts of H R D,0.2,0.7,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,
-HRD,8300,404,Concepts of H R D,0.5,0.25,0.13,0.0,0.13,0.0,0.0,0.0,eileen newmark,
-HRD,8300,405,Concepts of H R D,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
-HRD,8300,406,Concepts of H R D,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
-HRD,8300,407,Concepts of H R D,0.63,0.13,0.0,0.0,0.0,0.0,0.0,0.25,eileen newmark,
-HRD,8450,402,Needs Assess Ed/Ind,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,russell marion,
-HRD,8600,404,Instruc Mat Devel,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,philip mcgee,
-HRD,8600,405,Instruc Mat Devel,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,
-HRD,8600,406,Instruc Mat Devel,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,
-IE,2000,001,Soph Seminar in I E,0.53,0.26,0.12,0.06,0.02,0.0,0.0,0.01,brian melloy,
-IE,2010,001,Systems Design I,0.4,0.47,0.1,0.0,0.03,0.0,0.0,0.0,joel greenstein,
-IE,2010,002,Systems Design I,0.37,0.43,0.17,0.0,0.0,0.0,0.0,0.03,joel greenstein,
-IE,2010,003,Systems Design I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
-IE,2800,001,Deterministic Operat,0.18,0.34,0.2,0.13,0.11,0.0,0.0,0.04,jonathan cole smith,
-IE,2800,002,Deterministic Operat,0.38,0.37,0.13,0.06,0.04,0.0,0.0,0.02,amin khademi,
-IE,3600,001,Industrial Apps of P,0.3,0.33,0.23,0.08,0.05,0.0,0.0,0.01,mary elizabeth kurz,
-IE,3680,001,Prof Practice in I E,0.87,0.08,0.02,0.01,0.01,0.0,0.0,0.01,brian melloy,
-IE,3860,001,Prod Plan & Cont,0.38,0.46,0.08,0.0,0.04,0.0,0.0,0.04,robert james riggs,
-IE,4020,003,Creative Inq Res,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,anand gramopadhye,
-IE,4400,001,Decision Support Sys,0.47,0.29,0.08,0.05,0.03,0.0,0.0,0.08,sandra dun eksioglu,
-IE,4400,002,Decision Support Sys,0.33,0.42,0.14,0.07,0.02,0.0,0.0,0.02,mary elizabeth kurz,
-IE,4560,001,Supply Chain Design,0.2,0.59,0.12,0.0,0.1,0.0,0.0,0.0,william ferrell,
-IE,4610,001,Quality Engineering,0.3,0.35,0.28,0.05,0.0,0.0,0.0,0.01,byung rae cho,
-IE,4650,001,Facilities Planning,0.26,0.53,0.18,0.02,0.0,0.0,0.0,0.01,brian melloy,
-IE,4820,001,Systems Modeling,0.32,0.47,0.19,0.01,0.0,0.0,0.0,0.01,kevin taaffe,
-IE,4910,001,Investigating Human,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,sara lu riggs,
-IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,sandra dun eksioglu,
-IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,sandra dun eksioglu,
-IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,kap chalil madathil,
-IE,6400,001,Decision Support Sys,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,
-IE,6560,001,Supply Chain Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,
-IE,6910,001,Selected Topics-I E,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,sara lu riggs,
-IE,8000,001,Human Factors Eng,0.11,0.75,0.13,0.0,0.01,0.0,0.0,0.0,david neyens,
-IE,8030,001,Engr Optimization an,0.23,0.39,0.26,0.0,0.06,0.0,0.0,0.06,scott jenning mason,
-IE,8090,001,Model Sys Under Risk,0.23,0.43,0.25,0.0,0.05,0.0,0.0,0.04,burak eksioglu,
-IE,8510,001,Data Coll Anl Interp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabeth kurz,
-IE,8530,001,Foundations of Qual,0.84,0.14,0.02,0.0,0.0,0.0,0.0,0.0,byung rae cho,
-IE,8550,001,Capital Projects Sc,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
-IE,8870,001,Model Logist Behav S,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
-INT,1010,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.91,0.06,0.03,troy nunamaker,
-INT,1020,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.88,0.11,0.01,troy nunamaker,
-INT,1030,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.85,0.11,0.04,troy nunamaker,
-IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,meredith fan wilson,
-IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,laura padfiel braun,
-IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,sharon nagy,
-IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,uttiyo raychaudhuri,
-ITAL,1010,001,Elementary Italian,0.47,0.11,0.11,0.0,0.11,0.0,0.0,0.21,luca barattoni,
-ITAL,1010,002,Elementary Italian,0.74,0.11,0.16,0.0,0.0,0.0,0.0,0.0,luca barattoni,
-ITAL,1010,003,Elementary Italian,0.32,0.42,0.11,0.05,0.11,0.0,0.0,0.0,valentina lombardi,
-ITAL,1010,004,Elementary Italian,0.5,0.25,0.0,0.0,0.13,0.0,0.0,0.13,valentina lombardi,
-ITAL,1020,001,Elementary Italian,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-ITAL,2010,001,Intermediate Italian,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,2010,002,Intermediate Italian,0.35,0.47,0.18,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,2020,001,Intermediate Italian,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,barbara zaczek,
-JAPN,1010,001,Elementary Japanese,0.42,0.32,0.11,0.0,0.11,0.0,0.0,0.05,toshiko kishimoto,
-JAPN,1010,002,Elementary Japanese,0.42,0.21,0.11,0.05,0.05,0.0,0.0,0.16,toshiko kishimoto,
-JAPN,2010,001,Intermed Japanese,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,toshiko joerger,
-JAPN,3050,001,Japanese Conv & Comp,0.5,0.25,0.17,0.0,0.0,0.0,0.0,0.08,toshiko kishimoto,
-JAPN,4010,001,Japan Lit in Trans,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,kenneth jeff knight,
-LANG,2540,001,Introduction to Worl,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,joseph mai,
-LANG,3710,001,Language and Culture,0.3,0.2,0.3,0.0,0.0,0.0,0.0,0.2,yanhua zhang,
-LARC,1150,001,Intro Landscape Arch,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,
-LARC,1280,001,Technical Graphics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
-LARC,1510,001,Basic Design I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
-LARC,3620,001,Design Impl II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,
-LARC,4280,001,Comput Aided Design,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,shan jiang,
-LARC,4530,001,Key Issues in Larch,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
-LARC,8500,001,Grad Colloquium,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,
-LAW,3220,001,Legal Env of Bus,0.14,0.61,0.24,0.01,0.01,0.0,0.0,0.0,judson jahn,
-LAW,3220,002,Legal Env of Bus,0.47,0.41,0.11,0.01,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,003,Legal Env of Bus (HO,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,frances edwards,True
-LAW,3220,004,Legal Env of Bus,0.06,0.42,0.21,0.12,0.03,0.0,0.0,0.15,virgini ward-vaughn,
-LAW,3220,005,Legal Env of Bus,0.06,0.45,0.23,0.13,0.06,0.0,0.0,0.06,virgini ward-vaughn,
-LAW,3220,006,Legal Env of Bus,0.23,0.26,0.32,0.13,0.0,0.0,0.0,0.06,virgini ward-vaughn,
-LAW,3220,007,Legal Env of Bus,0.29,0.24,0.29,0.1,0.05,0.0,0.0,0.05,virgini ward-vaughn,
-LAW,3220,009,Legal Env of Bus,0.51,0.39,0.1,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,010,Legal Env of Bus,0.42,0.38,0.16,0.05,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,011,Legal Env of Bus,0.18,0.46,0.19,0.1,0.0,0.0,0.0,0.06,kenneth toussaint,
-LAW,3220,012,Legal Env of Bus,0.33,0.51,0.15,0.01,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3330,001,Real Estate Law,0.1,0.52,0.2,0.06,0.0,0.0,0.0,0.12,michael bra burrell,
-LAW,4050,001,Construction Law,0.88,0.07,0.0,0.0,0.0,0.0,0.0,0.05,frances edwards,
-LIT,1270,001,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,eric touya,
-LS,1000,002,Therapeutic Yoga,0.63,0.11,0.0,0.05,0.0,0.0,0.0,0.21,ranjanbala dil amin,
-LS,1000,007,Photography,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,sarah elizab mudder,
-LS,1000,008,Intro to Volleyball,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,kelly lynn ator,
-LS,1000,013,Introduction to Sals,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,malik lewis baxter,
-LS,1130,001,Wood Carving,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,edwin eugene riggs,
-LS,1410,001,Top Rope Climbing,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,scott evan lipscomb,
-LS,1410,002,Top Rope Climbing,0.75,0.06,0.0,0.0,0.13,0.0,0.0,0.06,scott evan lipscomb,
-LS,1410,004,Top Rope Climbing,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott evan lipscomb,
-LS,1410,005,Top Rope Climbing,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,scott evan lipscomb,
-LS,1410,006,Top Rope Climbing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott evan lipscomb,
-LS,1560,001,Riflery,0.73,0.0,0.0,0.0,0.0,0.0,0.0,0.27,hubert cox,
-LS,1560,005,Riflery,0.73,0.09,0.0,0.0,0.0,0.0,0.0,0.18,hubert cox,
-LS,1560,007,Riflery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,herbert strickland,
-LS,1570,003,Shotgun Sports,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,charles flint,
-LS,1580,002,Archery,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,herbert strickland,
-LS,1580,003,Archery,0.71,0.07,0.07,0.0,0.0,0.0,0.0,0.14,herbert strickland,
-LS,1580,005,Archery,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,herbert strickland,
-LS,1640,001,Whitewater Kayaking,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,earl wade shealy,
-LS,1640,002,Whitewater Kayaking,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,robert taylor,
-LS,1750,002,Fly Fishing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael watts,
-LS,1850,003,Bowling,0.93,0.0,0.03,0.0,0.03,0.0,0.0,0.0,megan elizabet cato,
-LS,1870,002,Frisbee Sports,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,craig goodman,
-LS,1890,002,Tennis,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jennifer jo garrity,
-LS,1940,002,Racquetball,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,
-LS,1980,002,Golf,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jason jordan,
-LS,2100,001,Learn to Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,matthew lee krabbe,
-LS,2110,001,Introduction to Bell,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,stephanie pack,
-LS,2190,003,Country West Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,
-LS,2200,001,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,broadus fleming,
-LS,2200,004,Shag,0.78,0.0,0.0,0.0,0.04,0.0,0.0,0.17,broadus fleming,
-LS,2200,005,Shag,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,
-LS,2200,006,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,broadus fleming,
-LS,2200,009,Shag,0.74,0.0,0.0,0.0,0.0,0.0,0.0,0.26,matthew lee krabbe,
-LS,2210,002,Intermediate Shag,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,matthew lee krabbe,
-LS,2270,002,Intro to Swing Dance,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,
-LS,2320,001,Core Training,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,diane moreno,
-LS,2320,005,Core Training,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,2350,001,Basic Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,
-LS,2350,002,Basic Yoga,0.77,0.09,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,
-LS,2350,003,Basic Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,
-LS,2350,005,Basic Yoga,0.81,0.0,0.1,0.05,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2350,006,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2350,007,Basic Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2360,001,Power/Ashtanga Yoga,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
-LS,2360,002,Power/Ashtanga Yoga,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
-LS,2370,001,Kripalu Yoga,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,
-LS,2370,002,Kripalu Yoga,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,
-LS,2370,003,Kripalu Yoga,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,ashley austi lester,
-LS,2420,003,Meditation and Relax,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,jenefer nadenicek,
-LS,2420,006,Meditation and Relax,0.71,0.21,0.04,0.0,0.04,0.0,0.0,0.0,ani reina-nunnelley,
-LS,2420,007,Meditation and Relax,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
-LS,2450,003,Pilates,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,melanie ivey job,
-LS,2500,001,Marathon Training,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,john walston dunn,
-LS,2510,002,Running & Jogging,0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,corey dou brookover,
-LS,2660,001,Hapkido,0.79,0.04,0.0,0.04,0.0,0.0,0.0,0.13,kelly smith,
-LS,2700,001,Sports Officiating,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher war cox,
-LS,2780,002,Wilderness First Aid,0.73,0.09,0.0,0.0,0.0,0.0,0.0,0.18,emily grace turke,
-MATH,1010,001,Essen Math for Infor,0.27,0.33,0.21,0.12,0.06,0.0,0.0,0.0,judith cottingham,
-MATH,1010,002,Essen Math for Infor,0.25,0.33,0.25,0.0,0.08,0.0,0.0,0.08,qijun he,
-MATH,1010,003,Essen Math for Infor,0.23,0.38,0.31,0.0,0.08,0.0,0.0,0.0,paran rebeka norton,
-MATH,1010,004,Essen Math for Infor,0.39,0.33,0.17,0.06,0.06,0.0,0.0,0.0,merle glick,
-MATH,1010,005,Essen Math for Infor,0.32,0.37,0.11,0.05,0.11,0.0,0.0,0.05,paran rebeka norton,
-MATH,1010,006,Essen Math for Infor,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,vito capuano,
-MATH,1010,007,Essen Math for Infor,0.29,0.47,0.12,0.06,0.0,0.0,0.0,0.06,qijun he,
-MATH,1010,009,Essen Math for Infor,0.5,0.11,0.22,0.0,0.11,0.0,0.0,0.06,vito capuano,
-MATH,1010,010,Essen Math for Infor,0.65,0.12,0.12,0.06,0.0,0.0,0.0,0.06,merle glick,
-MATH,1010,011,Essen Math for Infor,0.39,0.33,0.14,0.11,0.03,0.0,0.0,0.0,judith cottingham,
-MATH,1010,012,Essen Math for Infor,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,megan elizabet ryan,
-MATH,1010,014,Essen Math for Infor,0.25,0.42,0.17,0.0,0.17,0.0,0.0,0.0,megan elizabet ryan,
-MATH,1010,015,Essen Math for Infor,0.0,0.31,0.38,0.23,0.0,0.0,0.0,0.08,sergey charnyi,
-MATH,1010,113,Essen Math for Infor,0.4,0.23,0.2,0.03,0.07,0.0,0.0,0.07,marilyn reba,
-MATH,1010,113,Essen Math for Infor,0.4,0.23,0.2,0.03,0.07,0.0,0.0,0.07,meredith nicol burr,
-MATH,1020,001,Intro to Mathematica,0.17,0.17,0.22,0.17,0.22,0.0,0.0,0.06,tony thanh nguyen,
-MATH,1020,002,Intro to Mathematica,0.0,0.26,0.32,0.16,0.16,0.0,0.0,0.11, morales hernandez,
-MATH,1020,003,Intro to Mathematica,0.06,0.18,0.29,0.29,0.18,0.0,0.0,0.0,"rodriguez esperanza,",
-MATH,1020,004,Intro to Mathematica,0.24,0.41,0.24,0.0,0.06,0.0,0.0,0.06,margaret milliken,
-MATH,1020,005,Intro to Mathematica,0.28,0.33,0.28,0.0,0.06,0.0,0.0,0.06,amy christine grady,
-MATH,1020,006,Intro to Mathematica,0.37,0.17,0.26,0.11,0.06,0.0,0.0,0.03,warren adams,
-MATH,1020,007,Intro to Mathematica,0.21,0.26,0.37,0.0,0.16,0.0,0.0,0.0,tony thanh nguyen,
-MATH,1020,008,Intro to Mathematica,0.26,0.42,0.21,0.05,0.0,0.0,0.0,0.05,kevin wayne dettman,
-MATH,1020,009,Intro to Mathematica,0.32,0.47,0.05,0.11,0.0,0.0,0.0,0.05,"rodriguez esperanza,",
-MATH,1020,010,Intro to Mathematica,0.3,0.35,0.15,0.1,0.1,0.0,0.0,0.0,yisu jia,
-MATH,1020,011,Intro to Mathematica,0.29,0.35,0.18,0.0,0.12,0.0,0.0,0.06,mengying xiao,
-MATH,1020,012,Intro to Mathematica,0.22,0.19,0.22,0.14,0.19,0.0,0.0,0.03,abigail bowers,
-MATH,1020,013,Intro to Mathematica,0.26,0.31,0.26,0.06,0.06,0.0,0.0,0.06,randy davidson,
-MATH,1020,014,Intro to Mathematica,0.33,0.28,0.14,0.03,0.19,0.0,0.0,0.03,abigail bowers,
-MATH,1020,015,Intro to Mathematica,0.32,0.21,0.21,0.05,0.16,0.0,0.0,0.05, morales hernandez,
-MATH,1020,016,Intro to Mathematica,0.21,0.26,0.32,0.16,0.05,0.0,0.0,0.0,isaac justus,
-MATH,1020,017,Intro to Mathematica,0.32,0.05,0.37,0.11,0.11,0.0,0.0,0.05,margaret milliken,
-MATH,1020,018,Intro to Mathematica,0.33,0.28,0.17,0.11,0.06,0.0,0.0,0.06,thanh thien to,
-MATH,1020,019,Intro to Mathematica,0.32,0.32,0.05,0.05,0.26,0.0,0.0,0.0,david james rea,
-MATH,1020,020,Intro to Mathematica,0.35,0.18,0.18,0.18,0.06,0.0,0.0,0.06,liu zhu,
-MATH,1020,021,Intro to Mathematica,0.22,0.44,0.06,0.06,0.22,0.0,0.0,0.0,isaac justus,
-MATH,1020,022,Intro to Mathematica,0.32,0.11,0.21,0.05,0.21,0.0,0.0,0.11,amy christine grady,
-MATH,1020,023,Intro to Mathematica,0.29,0.12,0.41,0.0,0.06,0.0,0.0,0.12,thanh thien to,
-MATH,1020,024,Intro to Mathematica,0.35,0.35,0.06,0.06,0.12,0.0,0.0,0.06,liu zhu,
-MATH,1020,025,Intro to Mathematica,0.0,0.41,0.12,0.24,0.06,0.0,0.0,0.18,mengying xiao,
-MATH,1020,026,Intro to Mathematica,0.22,0.17,0.22,0.17,0.17,0.0,0.0,0.06,trevor scot vilardi,
-MATH,1020,027,Intro to Mathematica,0.32,0.26,0.21,0.05,0.16,0.0,0.0,0.0,luke marti giberson,
-MATH,1020,028,Intro to Mathematica,0.33,0.22,0.0,0.17,0.17,0.0,0.0,0.11,david james rea,
-MATH,1020,029,Intro to Mathematica,0.21,0.24,0.26,0.21,0.09,0.0,0.0,0.0, erwin walker,
-MATH,1020,030,Intro to Mathematica,0.42,0.31,0.08,0.08,0.11,0.0,0.0,0.0,randy davidson,
-MATH,1020,031,Intro to Mathematica,0.06,0.53,0.24,0.06,0.06,0.0,0.0,0.06,samuel jose shesman,
-MATH,1020,032,Intro to Mathematica,0.06,0.29,0.35,0.0,0.18,0.0,0.0,0.12,kevin wayne dettman,
-MATH,1020,033,Intro to Mathematica,0.12,0.29,0.29,0.18,0.12,0.0,0.0,0.0,trevor scot vilardi,
-MATH,1020,034,Intro to Mathematica,0.11,0.37,0.16,0.11,0.21,0.0,0.0,0.05,abigail bowers,
-MATH,1020,035,Intro to Mathematica,0.22,0.38,0.25,0.13,0.0,0.0,0.0,0.03, erwin walker,
-MATH,1020,036,Intro to Mathematica,0.27,0.36,0.09,0.06,0.15,0.0,0.0,0.06,abigail bowers,
-MATH,1020,037,Intro to Mathematica,0.33,0.33,0.06,0.11,0.17,0.0,0.0,0.0,luke marti giberson,
-MATH,1020,038,Intro to Mathematica,0.17,0.22,0.33,0.06,0.11,0.0,0.0,0.11,yisu jia,
-MATH,1040,001,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.68,0.27,0.05,donna simms,
-MATH,1040,002,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.56,0.27,0.18,jennifer mari hanna,
-MATH,1040,003,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.44,0.42,0.14,abdullah al mamun,
-MATH,1040,004,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.64,0.24,0.11,jennifer mari hanna,
-MATH,1040,005,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.44,0.44,0.12,christa con johnson,
-MATH,1040,006,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.51,0.36,0.13,jennifer mari hanna,
-MATH,1040,007,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.38,0.53,0.09,fiona may knoll,
-MATH,1040,008,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.56,0.33,0.11,jason to hedetniemi,
-MATH,1040,009,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.33,0.65,0.02,jason lee joyner,
-MATH,1040,010,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.45,0.47,0.08,christa con johnson,
-MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.67,0.29,0.04,eliza dar gallagher,
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.64,0.34,0.02,eliza dar gallagher,
-MATH,1060,001,Calculus of One Vari,0.32,0.27,0.18,0.09,0.05,0.0,0.0,0.09,charity watson,
-MATH,1060,002,Calculus of One Vari,0.02,0.3,0.3,0.09,0.17,0.0,0.0,0.13,javier ruiz ramirez,
-MATH,1060,003,Calculus of One Vari,0.17,0.33,0.19,0.06,0.11,0.0,0.0,0.14,allen anderso guest,
-MATH,1060,004,Calculus of One Vari,0.34,0.09,0.29,0.11,0.09,0.0,0.0,0.09,allen anderso guest,
-MATH,1060,005,Calculus of One Vari,0.36,0.38,0.1,0.05,0.07,0.0,0.0,0.05,charity watson,
-MATH,1060,006,Calculus of One Vari,0.15,0.42,0.23,0.06,0.06,0.0,0.0,0.08,meredith nicol burr,
-MATH,1060,007,Calculus of One Vari,0.27,0.41,0.16,0.05,0.07,0.0,0.0,0.05,charity watson,
-MATH,1060,008,Calculus of One Vari,0.2,0.32,0.2,0.1,0.14,0.0,0.0,0.04,sherry biggers,
-MATH,1060,009,Calculus of One Vari,0.24,0.22,0.24,0.08,0.08,0.0,0.0,0.14,meredith nicol burr,
-MATH,1060,010,Calculus of One Vari,0.27,0.41,0.14,0.05,0.11,0.0,0.0,0.02,honghai xu,
-MATH,1060,011,Calculus of One Vari,0.17,0.27,0.25,0.1,0.13,0.0,0.0,0.08,charles johnson,
-MATH,1060,012,Calculus of One Vari,0.19,0.27,0.21,0.15,0.08,0.0,0.0,0.1,sherry biggers,
-MATH,1060,013,Calculus of One Vari,0.13,0.17,0.17,0.15,0.15,0.0,0.0,0.25,stefan adam bock,
-MATH,1060,014,Calculus of One Vari,0.22,0.35,0.18,0.07,0.07,0.0,0.0,0.11,audrey nico devries,
-MATH,1060,015,Calculus of One Vari,0.2,0.27,0.27,0.12,0.1,0.0,0.0,0.04,rachel eli grotheer,
-MATH,1060,016,Calculus of One Vari,0.28,0.19,0.14,0.12,0.09,0.0,0.0,0.19,charles johnson,
-MATH,1060,017,Calculus of One Vari,0.1,0.38,0.24,0.02,0.12,0.0,0.0,0.14,charles johnson,
-MATH,1060,018,Calculus of One Vari,0.11,0.38,0.13,0.09,0.11,0.0,0.0,0.19,sherry biggers,
-MATH,1060,019,Calculus of One Vari,0.31,0.28,0.19,0.03,0.17,0.0,0.0,0.03,marilyn reba,
-MATH,1060,020,Calculus of One Vari,0.23,0.25,0.27,0.05,0.09,0.0,0.0,0.11,rebecca ramos,
-MATH,1060,100,Calc of One Variable,0.42,0.33,0.0,0.08,0.0,0.0,0.0,0.17,james ba coykendall,True
-MATH,1060,201,Calculus of One Vari,0.43,0.21,0.14,0.0,0.21,0.0,0.0,0.0,james peterson,
-MATH,1060,202,Calculus of One Vari,0.67,0.06,0.22,0.0,0.06,0.0,0.0,0.0,james peterson,
-MATH,1070,001,Differen and Integra,0.08,0.23,0.38,0.18,0.13,0.0,0.0,0.03,donna simms,
-MATH,1080,001,Calculus of One Vari,0.1,0.2,0.15,0.03,0.33,0.0,0.0,0.2,sarah eliz anderson,
-MATH,1080,002,Calculus of One Vari,0.08,0.18,0.18,0.05,0.18,0.0,0.0,0.33,terri johnson,
-MATH,1080,003,Calculus of One Vari,0.11,0.14,0.22,0.03,0.19,0.0,0.0,0.31,dania moham zantout,
-MATH,1080,004,Calculus of One Vari,0.08,0.16,0.05,0.24,0.16,0.0,0.0,0.32,beth novick,
-MATH,1080,005,Calculus of One Vari,0.05,0.13,0.1,0.08,0.43,0.0,0.0,0.23,terri johnson,
-MATH,1080,006,Calculus of One Vari,0.22,0.17,0.22,0.12,0.1,0.0,0.0,0.17,dania moham zantout,
-MATH,1080,007,Calculus of One Vari,0.07,0.07,0.1,0.12,0.37,0.0,0.0,0.27,karyn muir,
-MATH,1080,008,Calculus of One Vari,0.14,0.17,0.24,0.12,0.19,0.0,0.0,0.14,anastasia br wilson,
-MATH,1080,009,Calculus of One Vari,0.0,0.08,0.18,0.05,0.54,0.0,0.0,0.15,beth novick,
-MATH,1080,010,Calculus of One Vari,0.11,0.27,0.14,0.05,0.3,0.0,0.0,0.14,shih-wei chao,
-MATH,1080,011,Calculus of One Vari,0.27,0.21,0.18,0.12,0.03,0.0,0.0,0.18,dania moham zantout,
-MATH,1080,100,Calc of One Variable,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,james brown,True
-MATH,1150,001,Contemp Math for Ele,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1150,002,Contemp Math for Ele,0.59,0.31,0.09,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1160,001,Contemp Math for Ele,0.8,0.1,0.07,0.03,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,1990,400,Problem Solving in M,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,marion hanna,
-MATH,2060,001,Calculus of Several,0.16,0.27,0.25,0.11,0.18,0.0,0.0,0.02,minerva rios-adams,
-MATH,2060,002,Calculus of Several,0.26,0.21,0.21,0.07,0.14,0.0,0.0,0.12,gretchen matthews,
-MATH,2060,003,Calculus of Several,0.32,0.42,0.13,0.05,0.03,0.0,0.0,0.05,xin liu,
-MATH,2060,004,Calculus of Several,0.22,0.22,0.3,0.17,0.04,0.0,0.0,0.04,chanseok park,
-MATH,2060,005,Calculus of Several,0.51,0.22,0.18,0.02,0.07,0.0,0.0,0.0,qingshan chen,
-MATH,2060,006,Calculus of Several,0.09,0.03,0.36,0.03,0.21,0.0,0.0,0.27,eleanor jenkins,
-MATH,2060,007,Calculus of Several,0.38,0.31,0.11,0.04,0.11,0.0,0.0,0.04,minerva rios-adams,
-MATH,2060,008,Calculus of Several,0.14,0.28,0.14,0.08,0.22,0.0,0.0,0.14,gretchen matthews,
-MATH,2060,009,Calculus of Several,0.16,0.32,0.25,0.09,0.14,0.0,0.0,0.05,minerva rios-adams,
-MATH,2060,010,Calculus of Several,0.12,0.18,0.24,0.15,0.26,0.0,0.0,0.06,shari prevost,
-MATH,2060,011,Calculus of Several,0.53,0.22,0.1,0.08,0.02,0.0,0.0,0.04,martin joha schmoll,
-MATH,2060,012,Calculus of Several,0.2,0.28,0.28,0.11,0.11,0.0,0.0,0.02,timothy ch teitloff,
-MATH,2060,013,Calculus of Several,0.13,0.44,0.33,0.0,0.09,0.0,0.0,0.0,brian fralix,
-MATH,2060,014,Calculus of Several,0.29,0.29,0.16,0.08,0.11,0.0,0.0,0.08,gretchen matthews,
-MATH,2060,015,Calculus of Several,0.49,0.27,0.14,0.0,0.08,0.0,0.0,0.03,sofya alekseeva,
-MATH,2060,016,Calculus of Several,0.51,0.25,0.18,0.02,0.02,0.0,0.0,0.02,shitao liu,
-MATH,2060,017,Calculus of Several,0.33,0.47,0.17,0.0,0.03,0.0,0.0,0.0,irina viktorova,
-MATH,2060,018,Calculus of Several,0.28,0.21,0.19,0.09,0.23,0.0,0.0,0.0,timothy ch teitloff,
-MATH,2060,019,Calculus of Several,0.42,0.37,0.18,0.0,0.0,0.0,0.0,0.03,irina viktorova,
-MATH,2060,020,Calculus of Several,0.19,0.36,0.19,0.17,0.08,0.0,0.0,0.0,nathan jos adelgren,
-MATH,2060,021,Calculus of Several,0.26,0.36,0.25,0.04,0.04,0.0,0.0,0.06,timothy ch teitloff,
-MATH,2060,022,Calculus of Several,0.57,0.23,0.11,0.03,0.06,0.0,0.0,0.0,sofya alekseeva,
-MATH,2060,100,Calc of Several Vars,0.4,0.4,0.0,0.05,0.0,0.0,0.0,0.15,shari prevost,True
-MATH,2070,001,Multivariable Calcul,0.16,0.21,0.32,0.05,0.21,0.0,0.0,0.05,alistair bentley,
-MATH,2070,002,Multivariable Calcul,0.18,0.12,0.29,0.12,0.06,0.0,0.0,0.24,elaine ma sotherden,
-MATH,2070,003,Multivariable Calcul,0.28,0.22,0.17,0.06,0.17,0.0,0.0,0.11,kara ail stasikelis,
-MATH,2070,004,Multivariable Calcul,0.24,0.24,0.12,0.03,0.18,0.0,0.0,0.18,hui xue,
-MATH,2070,005,Multivariable Calcul,0.27,0.18,0.18,0.0,0.09,0.0,0.0,0.27,elaine ma sotherden,
-MATH,2070,006,Multivariable Calcul,0.21,0.21,0.32,0.11,0.11,0.0,0.0,0.05,alistair bentley,
-MATH,2070,007,Multivariable Calcul,0.06,0.28,0.28,0.0,0.22,0.0,0.0,0.17,saba za alkaseasbeh,
-MATH,2070,008,Multivariable Calcul,0.2,0.23,0.14,0.14,0.2,0.0,0.0,0.09,judith irene mcknew,
-MATH,2070,009,Multivariable Calcul,0.32,0.11,0.11,0.21,0.21,0.0,0.0,0.05,kara ail stasikelis,
-MATH,2070,010,Multivariable Calcul,0.22,0.22,0.11,0.11,0.28,0.0,0.0,0.06, ushijima-mwesigwa,
-MATH,2070,011,Multivariable Calcul,0.12,0.36,0.15,0.15,0.06,0.0,0.0,0.15,judith irene mcknew,
-MATH,2070,012,Multivariable Calcul,0.09,0.11,0.26,0.17,0.17,0.0,0.0,0.2,saba za alkaseasbeh,
-MATH,2070,013,Multivariable Calcul,0.29,0.24,0.35,0.06,0.0,0.0,0.0,0.06,liem nguyen,
-MATH,2070,014,Multivariable Calcul,0.06,0.61,0.17,0.0,0.11,0.0,0.0,0.06,garrett dranichak,
-MATH,2070,015,Multivariable Calcul,0.22,0.33,0.22,0.0,0.11,0.0,0.0,0.11,liem nguyen,
-MATH,2070,016,Multivariable Calcul,0.33,0.22,0.17,0.06,0.17,0.0,0.0,0.06, ushijima-mwesigwa,
-MATH,2070,017,Multivariable Calcul,0.17,0.5,0.11,0.0,0.11,0.0,0.0,0.11,grady mcgowa thomas,
-MATH,2070,018,Multivariable Calcul,0.2,0.13,0.13,0.2,0.27,0.0,0.0,0.07,garrett dranichak,
-MATH,2070,019,Multivariable Calcul,0.12,0.18,0.35,0.0,0.35,0.0,0.0,0.0,grady mcgowa thomas,
-MATH,2070,020,Multivariable Calcul,0.33,0.17,0.08,0.08,0.08,0.0,0.0,0.25,saba za alkaseasbeh,
-MATH,2080,001,Intro to Ordin Diff,0.36,0.21,0.27,0.03,0.06,0.0,0.0,0.06,peter kiessler,
-MATH,2080,002,Intro to Ordin Diff,0.33,0.31,0.14,0.03,0.11,0.0,0.0,0.08,timothy fra parrott,
-MATH,2080,003,Intro to Ordin Diff,0.08,0.23,0.23,0.08,0.23,0.0,0.0,0.15,shari prevost,
-MATH,2080,004,Intro to Ordin Diff,0.06,0.31,0.25,0.06,0.19,0.0,0.0,0.13,julie lassiter,
-MATH,2080,005,Intro to Ordin Diff,0.47,0.11,0.22,0.03,0.11,0.0,0.0,0.06,timothy fra parrott,
-MATH,2080,006,Intro to Ordin Diff,0.13,0.19,0.23,0.06,0.16,0.0,0.0,0.23,julie lassiter,
-MATH,2080,007,Intro to Ordin Diff,0.28,0.22,0.22,0.11,0.08,0.0,0.0,0.08,timothy fra parrott,
-MATH,2080,008,Intro to Ordin Diff,0.68,0.24,0.05,0.0,0.03,0.0,0.0,0.0,irina viktorova,
-MATH,2080,009,Intro to Ordin Diff,0.29,0.29,0.29,0.0,0.11,0.0,0.0,0.03,brandon gra goodell,
-MATH,2080,100,Intro to Ordin Diff,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True
-MATH,2160,001,Geometry for Elem Sc,0.63,0.26,0.0,0.07,0.04,0.0,0.0,0.0,allison stoddard,
-MATH,2160,002,Geometry for Elem Sc,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,2500,001,Intro to Mathematica,0.8,0.11,0.06,0.0,0.0,0.0,0.0,0.03,daniel warner,
-MATH,3020,001,Stat for Science & E,0.29,0.29,0.29,0.14,0.0,0.0,0.0,0.0,yanbo xia,
-MATH,3020,002,Stat for Science & E,0.21,0.35,0.24,0.0,0.06,0.0,0.0,0.15,calvin williams,
-MATH,3020,003,Stat for Science & E,0.09,0.41,0.29,0.0,0.0,0.0,0.0,0.21,calvin williams,
-MATH,3020,004,Stat for Science & E,0.67,0.0,0.07,0.0,0.07,0.0,0.0,0.2,yanbo xia,
-MATH,3020,005,Stat for Science & E,0.46,0.23,0.21,0.08,0.0,0.0,0.0,0.03,michael thom finney,
-MATH,3020,006,Stat for Science & E,0.45,0.26,0.13,0.0,0.08,0.0,0.0,0.08,christopher mcmahan,
-MATH,3020,007,Stat for Science & E,0.76,0.18,0.0,0.0,0.03,0.0,0.0,0.03,dominique morgan,
-MATH,3110,001,Linear Algebra,0.13,0.21,0.21,0.13,0.21,0.0,0.0,0.13,mishko mitkovski,
-MATH,3110,002,Linear Algebra,0.35,0.16,0.16,0.06,0.1,0.0,0.0,0.16,xuhong gao,
-MATH,3110,003,Linear Algebra,0.21,0.21,0.21,0.14,0.1,0.0,0.0,0.14,felice manganiello,
-MATH,3110,004,Linear Algebra,0.49,0.2,0.11,0.06,0.09,0.0,0.0,0.06,xiaoqian sun,
-MATH,3110,005,Linear Algebra,0.3,0.33,0.18,0.09,0.06,0.0,0.0,0.03,svetlan poznanovikj,
-MATH,3110,100,Linear Algebra (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,True
-MATH,3160,001,Prob Solving for Mat,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,3190,001,Introduction to Proo,0.57,0.17,0.04,0.0,0.17,0.0,0.0,0.04,michael adam burr,
-MATH,3190,002,Introduction to Proo,0.54,0.08,0.31,0.0,0.0,0.0,0.0,0.08,michael adam burr,
-MATH,3600,001,Intermediate Math Co,0.4,0.27,0.07,0.03,0.13,0.0,0.0,0.1,neil calkin,
-MATH,3650,001,Numerical Mthds for,0.14,0.24,0.24,0.21,0.1,0.0,0.0,0.07,christopher cox,
-MATH,3650,002,Numerical Mthds for,0.12,0.24,0.21,0.12,0.06,0.0,0.0,0.24,christopher cox,
-MATH,3650,003,Numerical Mthds for,0.32,0.44,0.12,0.03,0.03,0.0,0.0,0.06,timo johann heister,
-MATH,3650,004,Numerical Mthds for,0.17,0.26,0.29,0.09,0.06,0.0,0.0,0.14,vincent ervin,
-MATH,3990,001,CI in Mathematical S,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-MATH,3990,001,CI in Mathematical S,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,laura jane shick,
-MATH,4000,001,Theory of Probabilit,0.48,0.08,0.28,0.04,0.12,0.0,0.0,0.0,derek brown,
-MATH,4000,002,Theory of Probabilit,0.44,0.15,0.24,0.06,0.03,0.0,0.0,0.09,yingbo li,
-MATH,4070,001,Regress & Time-Serie,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,4120,001,Intro to Modern Alge,0.08,0.17,0.5,0.08,0.08,0.0,0.0,0.08,xuhong gao,
-MATH,4120,002,Intro to Modern Alge,0.3,0.3,0.13,0.17,0.1,0.0,0.0,0.0,kevin james,
-MATH,4190,001,Discrete Math Struct,0.48,0.3,0.09,0.12,0.0,0.0,0.0,0.0,beth novick,
-MATH,4310,001,Theory of Interest,0.53,0.24,0.06,0.06,0.06,0.0,0.0,0.06, erwin walker,
-MATH,4340,001,Adv Engineering Math,0.17,0.2,0.23,0.07,0.07,0.0,0.0,0.27,eleanor jenkins,
-MATH,4340,002,Adv Engineering Math,0.15,0.35,0.18,0.06,0.03,0.0,0.0,0.24,hyesuk lee,
-MATH,4400,001,Linear Programming,0.41,0.23,0.18,0.05,0.09,0.0,0.0,0.05,akshay sunil gupte,
-MATH,4530,001,Advanced Calculus I,0.18,0.53,0.18,0.03,0.03,0.0,0.0,0.06,taufiquar rahm khan,
-MATH,4540,001,Advanced Calculus II,0.15,0.46,0.31,0.08,0.0,0.0,0.0,0.0,taufiquar rahm khan,
-MATH,6120,001,Intro to Modern Alge,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,kevin james,
-MATH,6340,001,Adv Engineering Math,0.34,0.41,0.15,0.0,0.05,0.0,0.0,0.05,vincent ervin,
-MATH,6530,001,Advanced Calculus I,0.14,0.57,0.14,0.0,0.0,0.0,0.0,0.14,taufiquar rahm khan,
-MATH,8000,001,Probability,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
-MATH,8010,001,General Linear Hypot,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,xiaoqian sun,
-MATH,8040,001,Statistical Inferenc,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,
-MATH,8050,001,Data Analysis,0.73,0.18,0.05,0.0,0.0,0.0,0.0,0.05,derek brown,
-MATH,8100,001,Mathematical Program,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,matthew saltzman,
-MATH,8120,001,Discrete Optimizatio,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
-MATH,8140,001,Network Flow Program,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,warren adams,
-MATH,8170,001,Stochastic Mod in Op,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,peter kiessler,
-MATH,8190,001,Multicriteria Optimi,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,
-MATH,8210,001,Linear Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,
-MATH,8230,001,Complex Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,
-MATH,8510,001,Abstract Algebra I,0.57,0.14,0.14,0.0,0.0,0.0,0.0,0.14,felice manganiello,
-MATH,8530,001,Matrix Analysis,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,james brown,
-MATH,8550,001,Combinatorial Analys,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,
-MATH,8600,001,Intro to Scientific,0.46,0.23,0.08,0.0,0.0,0.0,0.0,0.23,timo johann heister,
-MATH,8610,001,Advanced Numerical A,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
-MATH,8650,001,Data Structures,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel warner,
-MATH,8840,001,Statistics for Exper,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-MATH,9810,001,Sel Top in Math Stat,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,yingbo li,
-MATH,9830,001,Sel Top in Computati,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,qingshan chen,
-MBA,8030,001,Stat Analy of Bus Op,0.46,0.43,0.09,0.0,0.03,0.0,0.0,0.0,yuhong he,
-MBA,8060,001,Operations Mgt,0.31,0.51,0.07,0.0,0.02,0.0,0.0,0.09, sridharan,
-MBA,8070,001,Financial Management,0.45,0.32,0.05,0.0,0.05,0.0,0.0,0.14,ramon tolb franklin,
-MBA,8090,001,Org Beh & Hum Res Mg,0.55,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8090,002,Org Beh & Hum Res Mg,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8190,001,Intro to Acc and Fin,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,
-MBA,8190,001,Intro to Acc and Fin,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,william hol johnson,
-MBA,8290,001,Marketing Foundation,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,gary hunter,
-MBA,8330,001,Real Estate Investmt,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,
-MBA,8350,001,Investment Mgmt,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,uma sridharan,
-MBA,8360,001,Real Estate Principl,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
-MBA,8370,001,Legal Environ of Bus,0.39,0.43,0.16,0.0,0.0,0.0,0.0,0.02,judson jahn,
-MBA,8400,001,Entrepreneurship & V,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
-MBA,8420,001,R E Valuation,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,charles benja stone,
-MBA,8430,001,Entrepreneurial Acco,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
-MBA,8440,001,Entrepreneurial Law,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,melinda davis lux,
-MBA,8450,001,Tech & Innova Mgt,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8480,001,Entrpr Mkting & Digi,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MBA,8490,005,Entrepreneurial Strg,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8510,001,Bus Operations & Log,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MBA,8540,001,Mgrl Accounting,0.34,0.57,0.03,0.0,0.03,0.0,0.0,0.03,charles ellio davis,
-MBA,8590,001,Mgr Decision Model,0.47,0.22,0.13,0.0,0.09,0.0,0.0,0.09,sara elizabet yoder,
-MBA,8590,002,Mgr Decision Model,0.72,0.09,0.07,0.0,0.02,0.0,0.0,0.11,mark mcknew,
-MBA,8600,001,Advanced Marketing S,0.34,0.55,0.11,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8600,002,Advanced Marketing S,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8610,001,Information Systems,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MBA,8620,001,Managerial Economics,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,scott templeton,
-MBA,8620,002,Managerial Economics,0.72,0.23,0.04,0.0,0.0,0.0,0.0,0.0,stephen knec layton,
-MBA,8700,001,Strategic Management,0.55,0.43,0.02,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
-MBA,8990,002,Creativity,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,
-MBA,8990,003,International Busine,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,judson jahn,
-ME,2000,001,Sophomore Seminar,0.89,0.08,0.01,0.0,0.01,0.0,0.0,0.01,todd schweisinger,
-ME,2010,001,Statics & Dynamics,0.07,0.11,0.2,0.17,0.37,0.0,0.0,0.09,sherrill biggers,
-ME,2010,002,Statics & Dynamics,0.18,0.21,0.23,0.09,0.21,0.0,0.0,0.07,paul joseph,
-ME,2010,003,Statics & Dynamics,0.02,0.14,0.14,0.08,0.45,0.0,0.0,0.16,kalyan chakr katuri,
-ME,2030,001,Founda Th/Fl Syst,0.3,0.47,0.16,0.03,0.04,0.0,0.0,0.0,david zumbrunnen,
-ME,2040,001,Mechanics of Materia,0.15,0.38,0.34,0.08,0.05,0.0,0.0,0.0,michael porter,
-ME,2040,002,Mechanics of Materia,0.11,0.21,0.52,0.08,0.04,0.0,0.0,0.03,huijuan zhao,
-ME,2220,001,Mech Engr Lab I,0.19,0.44,0.38,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,002,Mech Engr Lab I,0.22,0.5,0.22,0.0,0.06,0.0,0.0,0.0,todd schweisinger,
-ME,2220,003,Mech Engr Lab I,0.15,0.75,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,005,Mech Engr Lab I,0.35,0.45,0.2,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,006,Mech Engr Lab I,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,todd schweisinger,
-ME,2220,007,Mech Engr Lab I,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3000,001,Junior Honors Semina,0.0,0.0,0.0,0.0,0.0,0.91,0.0,0.09,paul joseph,True
-ME,3030,002,Thermodynamics,0.31,0.4,0.2,0.07,0.0,0.0,0.0,0.02,richard miller,
-ME,3030,003,Thermodynamics,0.06,0.13,0.31,0.16,0.22,0.0,0.0,0.11,john saylor,
-ME,3040,001,Heat Transfer,0.19,0.26,0.32,0.14,0.03,0.0,0.0,0.06,jay ochterbeck,
-ME,3050,001,Model/an Dy Syst,0.21,0.32,0.3,0.02,0.06,0.0,0.0,0.09,mohammed fari daqaq,
-ME,3050,002,Model/an Dy Syst,0.12,0.67,0.18,0.03,0.0,0.0,0.0,0.0,yue wang,
-ME,3060,002,Fund Machine Design,0.26,0.43,0.2,0.07,0.0,0.0,0.0,0.04,todd schweisinger,
-ME,3060,003,Fund Machine Design,0.26,0.47,0.15,0.0,0.06,0.0,0.0,0.06,oliver myers,
-ME,3070,001,Found of Mechanical,0.32,0.42,0.12,0.04,0.04,0.0,0.0,0.06,lonny thompson,
-ME,3070,002,Found of Mechanical,0.09,0.56,0.29,0.06,0.0,0.0,0.0,0.0,gregory mocko,
-ME,3080,001,Fluid Mechanics,0.05,0.14,0.52,0.14,0.05,0.0,0.0,0.1,jean-marc delhaye,
-ME,3080,002,Fluid Mechanics,0.16,0.34,0.41,0.07,0.0,0.0,0.0,0.01,xiangchun xuan,
-ME,3080,003,Fluid Mechanics,0.38,0.28,0.26,0.03,0.05,0.0,0.0,0.0,marija vukicevic,
-ME,3120,001,Manuf Processes,0.5,0.38,0.05,0.02,0.0,0.0,0.0,0.05,hong seok choi,
-ME,3120,002,Manuf Processes,0.18,0.47,0.22,0.08,0.06,0.0,0.0,0.0,rod martinez-duarte,
-ME,3330,001,Mech Engr Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,002,Mech Engr Lab II,0.31,0.5,0.0,0.06,0.0,0.0,0.0,0.13,todd schweisinger,
-ME,3330,003,Mech Engr Lab II,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,004,Mech Engr Lab II,0.19,0.5,0.19,0.0,0.0,0.0,0.0,0.13,todd schweisinger,
-ME,3330,005,Mech Engr Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,006,Mech Engr Lab II,0.08,0.85,0.0,0.0,0.0,0.0,0.0,0.08,todd schweisinger,
-ME,3330,007,Mech Engr Lab II,0.13,0.56,0.31,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,008,Mech Engr Lab II,0.19,0.56,0.13,0.0,0.0,0.0,0.0,0.13,todd schweisinger,
-ME,4000,001,Senior Seminar,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03, ramasubramanian,
-ME,4010,001,Mech Engr Design,0.41,0.38,0.12,0.08,0.0,0.0,0.0,0.01,joshua summers,
-ME,4020,001,Intern in Engr Des,0.0,0.58,0.42,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,002,Intern in Engr Des,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,ethan kung,
-ME,4020,002,Intern in Engr Des,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,kalyan chakr katuri,
-ME,4020,004,Intern in Engr Des,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,4020,005,Intern in Engr Des,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
-ME,4030,001,Control Dynamic Syst,0.33,0.31,0.24,0.08,0.0,0.0,0.0,0.03,ardalan vahidi,
-ME,4180,001,F E A in M E Design,0.29,0.5,0.08,0.05,0.05,0.0,0.0,0.03,gang li,
-ME,4200,001,Ener Sources/Utiliz,0.26,0.54,0.2,0.0,0.0,0.0,0.0,0.0,david zumbrunnen,
-ME,4210,001,Intro to Comp Flow,0.38,0.19,0.27,0.12,0.0,0.0,0.0,0.04,chenning tong,
-ME,4400,001,Matls for Aggr Envir,0.58,0.33,0.04,0.04,0.0,0.0,0.0,0.0,mica grujicic,
-ME,4440,001,Mech Engr Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,004,Mech Engr Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4540,001,Design of Machine El,0.36,0.24,0.24,0.08,0.04,0.0,0.0,0.04,paul jeffrey meyer,
-ME,6210,001,Intro to Comp Flow,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,chenning tong,
-ME,6540,001,Des Machine Elements,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,
-ME,6930,001,Selected Topics Me:T,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,8010,001,Found of Fluid Mech,0.26,0.22,0.44,0.0,0.04,0.0,0.0,0.04,richard figliola,
-ME,8100,001,Macroscopic Thermo,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,jay ochterbeck,
-ME,8140,001,Turb Bound Layer,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,
-ME,8180,001,Intro to Fin Ele Ana,0.76,0.18,0.03,0.0,0.01,0.0,0.0,0.01,lonny thompson,
-ME,8230,001,Control Systems,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,8370,001,Theory of Elast I,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
-ME,8430,001,Advanced Dynamics,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,phanin tallapragada,
-ME,8460,001,Inter Dynamics,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,mohammed fari daqaq,
-ME,8700,001,Adv Design Methods,0.47,0.26,0.21,0.0,0.03,0.0,0.0,0.03,georges fadel,
-ME,8710,001,Engr Optimization,0.57,0.34,0.04,0.0,0.02,0.0,0.0,0.04,georges fadel,
-ME,8930,027,ME SpecTopic - Optim,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,ardalan vahidi,
-MGT,2010,001,Principles of Mgt,0.31,0.37,0.21,0.05,0.06,0.0,0.0,0.01,katherine clark,
-MGT,2010,002,Principles of Mgt,0.38,0.32,0.15,0.06,0.05,0.0,0.0,0.06,katherine clark,
-MGT,2010,003,Principles of Mgt,0.36,0.36,0.19,0.03,0.04,0.0,0.0,0.01,katherine clark,
-MGT,2010,004,Principles of Mgt,0.11,0.27,0.42,0.07,0.03,0.0,0.0,0.1,katherine clark,
-MGT,2010,005,Principles of Mgt,0.31,0.41,0.14,0.06,0.0,0.0,0.0,0.08,tina robbins,
-MGT,2010,006,Principles of Mgt,0.29,0.36,0.23,0.02,0.04,0.0,0.0,0.06,tina robbins,
-MGT,2010,007,Principles of Mgt,0.25,0.37,0.22,0.06,0.07,0.0,0.0,0.02,tina robbins,
-MGT,2010,008,Principles of Mgt,0.25,0.32,0.19,0.07,0.09,0.0,0.0,0.09,tina robbins,
-MGT,2010,009,Principles of Mgt(HO,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,tina robbins,True
-MGT,2180,125,Management PC Applic,0.44,0.41,0.12,0.01,0.01,0.0,0.0,0.01, sridharan,
-MGT,2180,125,Management PC Applic,0.44,0.41,0.12,0.01,0.01,0.0,0.0,0.01,ryan toole,
-MGT,2180,200,Management PC Applic,0.43,0.34,0.14,0.02,0.0,0.0,0.0,0.07, sridharan,
-MGT,2180,200,Management PC Applic,0.43,0.34,0.14,0.02,0.0,0.0,0.0,0.07,ryan toole,
-MGT,2180,230,Management PC Applic,0.57,0.34,0.05,0.01,0.0,0.0,0.0,0.03, sridharan,
-MGT,2180,230,Management PC Applic,0.57,0.34,0.05,0.01,0.0,0.0,0.0,0.03,ryan toole,
-MGT,2180,905,Management PC Applic,0.47,0.34,0.11,0.02,0.02,0.0,0.0,0.04,ryan toole,
-MGT,2180,905,Management PC Applic,0.47,0.34,0.11,0.02,0.02,0.0,0.0,0.04, sridharan,
-MGT,3070,001,Human Resource Manag,0.19,0.68,0.06,0.0,0.03,0.0,0.0,0.03,kristin dam scott,
-MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,
-MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,
-MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,katherine clark,
-MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03, sridharan,
-MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,katherine clark,
-MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,marvin monroe ward,
-MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,marvin monroe ward,
-MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,marvin monroe ward,
-MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,marvin monroe ward,
-MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,katherine clark,
-MGT,3070,006,Human Resource Manag,0.28,0.44,0.15,0.05,0.05,0.0,0.0,0.03,michael cole,
-MGT,3070,007,Human Resource Manag,0.41,0.51,0.05,0.0,0.03,0.0,0.0,0.0,michael cole,
-MGT,3100,001,Intermed Business St,0.15,0.3,0.13,0.08,0.23,0.0,0.0,0.13,sara elizabet yoder,
-MGT,3100,002,Intermed Business St,0.23,0.23,0.3,0.08,0.08,0.0,0.0,0.1,sara elizabet yoder,
-MGT,3100,003,Intermed Business St,0.39,0.14,0.25,0.14,0.06,0.0,0.0,0.03,sara elizabet yoder,
-MGT,3100,005,Intermed Business St,0.28,0.28,0.25,0.13,0.0,0.0,0.0,0.08,zachary mo leffakis,
-MGT,3100,006,Intermed Business St,0.55,0.3,0.13,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3100,007,Intermed Business St,0.44,0.36,0.11,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3100,008,Intermed Business St,0.33,0.23,0.26,0.03,0.03,0.0,0.0,0.13,zachary mo leffakis,
-MGT,3100,009,Intermed Business St,0.07,0.27,0.17,0.07,0.05,0.0,0.0,0.37,niratc tungtisanont,
-MGT,3100,011,Intermed Business St,0.27,0.4,0.17,0.0,0.07,0.0,0.0,0.1,yuhong he,
-MGT,3100,B,Intermed Business St,0.29,0.44,0.15,0.07,0.05,0.0,0.0,0.0,james walsh,
-MGT,3120,001,Decision Models for,0.29,0.15,0.44,0.07,0.05,0.0,0.0,0.0,mark mcknew,
-MGT,3120,002,Decision Models for,0.09,0.49,0.29,0.0,0.11,0.0,0.0,0.02,mark mcknew,
-MGT,3120,003,Decision Models for,0.18,0.42,0.33,0.02,0.04,0.0,0.0,0.0,mark mcknew,
-MGT,3150,001,New Venture Creation,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
-MGT,3180,001,Mgt of Info Systems,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,heshan sun,
-MGT,3180,002,Mgt of Info Systems,0.45,0.45,0.08,0.0,0.0,0.0,0.0,0.03,heshan sun,
-MGT,3180,003,Mgt of Info Systems,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,dan jiang,
-MGT,3180,004,Mgt of Info Systems,0.3,0.45,0.08,0.03,0.15,0.0,0.0,0.0,tina marie esposito,
-MGT,3900,001,Ops Mgt,0.19,0.58,0.14,0.03,0.0,0.0,0.0,0.06,yunsik choi,
-MGT,3900,002,Ops Mgt,0.44,0.36,0.15,0.0,0.05,0.0,0.0,0.0,qiong chen,
-MGT,3900,003,Ops Mgt,0.33,0.51,0.13,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3900,004,Ops Mgt,0.23,0.5,0.25,0.03,0.0,0.0,0.0,0.0,jerry kermi bilbrey,
-MGT,3900,005,Ops Mgt,0.18,0.48,0.33,0.03,0.0,0.0,0.0,0.0,yann ferrand,
-MGT,3900,006,Ops Mgt,0.16,0.29,0.23,0.0,0.1,0.0,0.0,0.23,qiong chen,
-MGT,3900,007,Ops Mgt,0.3,0.41,0.24,0.03,0.03,0.0,0.0,0.0,remi charpin,
-MGT,4000,001,Mgt of Org Beh,0.2,0.57,0.23,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,002,Mgt of Org Beh,0.25,0.5,0.2,0.0,0.0,0.0,0.0,0.05,michael cole,
-MGT,4000,003,Mgt of Org Beh,0.15,0.48,0.33,0.03,0.03,0.0,0.0,0.0,philip roth,
-MGT,4000,004,Mgt of Org Beh,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MGT,4020,001,Ops Pln and Ctl,0.06,0.69,0.25,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4020,002,Ops Pln and Ctl,0.15,0.69,0.08,0.08,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4030,001,Bus Intelligence & A,0.23,0.46,0.23,0.0,0.08,0.0,0.0,0.0,siyuan li,
-MGT,4080,001,Lean Operations,0.09,0.45,0.45,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MGT,4110,001,Project Management,0.21,0.53,0.18,0.0,0.03,0.0,0.0,0.05,russell purvis,
-MGT,4120,001,Supplier Management,0.04,0.64,0.28,0.04,0.0,0.0,0.0,0.0,shouqiang wang,
-MGT,4150,001,Business Strategy,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,002,Business Strategy,0.19,0.52,0.29,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
-MGT,4150,003,Business Strategy,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,004,Business Strategy,0.37,0.45,0.08,0.0,0.11,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,006,Business Strategy,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,007,Business Strategy,0.17,0.46,0.32,0.02,0.0,0.0,0.0,0.02,jason wayne ridge,
-MGT,4150,008,Business Strategy,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,
-MGT,4150,009,Business Strategy,0.27,0.51,0.11,0.05,0.0,0.0,0.0,0.05,amy elizabet ingram,
-MGT,4160,001,Special Topics Hr,0.44,0.44,0.08,0.03,0.0,0.0,0.0,0.0,kristin dam scott,
-MGT,4230,001,Intern Bus Mgt,0.19,0.31,0.44,0.03,0.03,0.0,0.0,0.0,wayne stewart,
-MGT,4230,002,Intern Bus Mgt,0.24,0.26,0.38,0.06,0.06,0.0,0.0,0.0,wayne stewart,
-MGT,4230,003,Intern Bus Mgt,0.0,0.49,0.4,0.06,0.06,0.0,0.0,0.0,janis miller,
-MGT,4230,004,Intern Bus Mgt,0.1,0.51,0.29,0.03,0.02,0.0,0.0,0.05,janis miller,
-MGT,4240,001,Global Supply Chain,0.2,0.63,0.09,0.03,0.0,0.0,0.0,0.06,yann ferrand,
-MGT,4270,001,Managing Improvement,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MGT,4300,001,Statistical Modeling,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,jerry kermi bilbrey,
-MGT,4310,001,Emp Rights & Resp,0.18,0.58,0.2,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,
-MGT,4350,001,Pers Interviewing,0.33,0.38,0.2,0.1,0.0,0.0,0.0,0.0,philip roth,
-MGT,4520,001,Business Analysis,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jackie patri london,
-MGT,4550,001,Emerging I T Trends,0.39,0.53,0.06,0.0,0.0,0.0,0.0,0.03,jason thatcher,
-MGT,4560,001,Business Info Mgt,0.33,0.25,0.33,0.08,0.0,0.0,0.0,0.0,siyuan li,
-MGT,8690,001,Project Mgt,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-MGT,9050,001,Research Methods,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,varun grover,
-MHA,7210,001,Hlth Care Del Sys,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
-MICR,1010,001,Microbes & Hum Aff,0.58,0.21,0.12,0.02,0.06,0.0,0.0,0.01,michael childress,
-MICR,1010,001,Microbes & Hum Aff,0.58,0.21,0.12,0.02,0.06,0.0,0.0,0.01,thomas hughes,
-MICR,2050,001,Introductory Micro,0.42,0.42,0.15,0.0,0.0,0.0,0.0,0.01,john abercrombie,
-MICR,3050,001,General Microbiology,0.53,0.25,0.16,0.06,0.0,0.0,0.0,0.01,krista barr rudolph,
-MICR,3050,002,General Microbiology,0.32,0.46,0.17,0.04,0.0,0.0,0.0,0.02,krista barr rudolph,
-MICR,4010,001,Microbial Diversity,0.17,0.32,0.2,0.15,0.05,0.0,0.0,0.12,barbara campbell,
-MICR,4050,001,Adv Microbial Ecol o,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4140,001,Basic Immunology,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,yanzhang wei,
-MICR,4150,001,Microbial Genetics,0.25,0.31,0.25,0.17,0.02,0.0,0.0,0.0,min cao,
-MICR,4250,001,Microbial Gen Lab,0.71,0.14,0.0,0.14,0.0,0.0,0.0,0.0,min cao,
-MICR,4250,002,Microbial Gen Lab,0.68,0.18,0.14,0.0,0.0,0.0,0.0,0.0,min cao,
-MKT,3010,001,Prin of Marketing,0.21,0.59,0.17,0.02,0.0,0.0,0.0,0.01,james gaubert,
-MKT,3010,002,Prin of Marketing,0.15,0.44,0.3,0.07,0.04,0.0,0.0,0.0,carter wil mcelveen,
-MKT,3010,003,Prin of Marketing,0.25,0.47,0.21,0.05,0.02,0.0,0.0,0.01,carter wil mcelveen,
-MKT,3010,004,Prin of Marketing,0.28,0.42,0.28,0.02,0.0,0.0,0.0,0.0,carter wil mcelveen,
-MKT,3010,005,Prin of Marketing,0.15,0.41,0.29,0.08,0.03,0.0,0.0,0.03,amanda cooper fine,
-MKT,3010,006,Prin of Marketing,0.16,0.48,0.24,0.08,0.02,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,007,Prin of Marketing,0.21,0.39,0.33,0.05,0.01,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,008,Prin of Marketing,0.33,0.42,0.15,0.03,0.06,0.0,0.0,0.0,patricia knowles,
-MKT,3020,001,Consumer Behavior,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,002,Consumer Behavior,0.43,0.45,0.11,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,003,Consumer Behavior,0.36,0.5,0.1,0.02,0.02,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3020,004,Consumer Behavior,0.4,0.34,0.24,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3210,001,Sports Marketing,0.43,0.43,0.11,0.0,0.0,0.0,0.0,0.04,delancy bennett,
-MKT,4200,001,Professional Selling,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,gary hunter,
-MKT,4200,002,Professional Selling,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,003,Professional Selling,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,jesse moore,
-MKT,4200,004,Professional Selling,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,ryan mullins,
-MKT,4230,001,Promotional Strategy,0.2,0.44,0.31,0.02,0.02,0.0,0.0,0.0,patricia knowles,
-MKT,4240,001,Sales Management,0.32,0.58,0.03,0.0,0.0,0.0,0.0,0.06,ryan mullins,
-MKT,4260,001,Business-to-Business,0.24,0.53,0.2,0.0,0.0,0.0,0.0,0.02,james gaubert,
-MKT,4270,001,International Mktg,0.27,0.58,0.11,0.04,0.0,0.0,0.0,0.0,roger gomes,
-MKT,4270,002,International Mktg,0.24,0.46,0.22,0.07,0.0,0.0,0.0,0.02,roger gomes,
-MKT,4270,003,International Mktg,0.16,0.64,0.14,0.07,0.0,0.0,0.0,0.0,roger gomes,
-MKT,4270,004,International Mktg,0.19,0.53,0.19,0.0,0.0,0.0,0.0,0.08,thomas poehlman,
-MKT,4280,001,Services Marketing,0.23,0.44,0.33,0.0,0.0,0.0,0.0,0.0,stephen grove,
-MKT,4280,002,Services Marketing,0.05,0.74,0.21,0.0,0.0,0.0,0.0,0.0,stephen grove,
-MKT,4310,001,Marketing Research,0.18,0.5,0.27,0.05,0.0,0.0,0.0,0.0,peter weathers,
-MKT,4310,002,Marketing Research,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,003,Marketing Research,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,004,Marketing Research,0.16,0.72,0.08,0.0,0.0,0.0,0.0,0.04,william kilbourne,
-MKT,4430,001,Advertising Strategy,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,
-MKT,4450,001,Macromarketing,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
-MKT,4500,001,Strategic Mktg Mgt,0.14,0.62,0.24,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,002,Strategic Mktg Mgt,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,4500,003,Strategic Mktg Mgt,0.16,0.76,0.08,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4950,001,Marketing Metrics,0.23,0.46,0.23,0.08,0.0,0.0,0.0,0.0,peter weathers,
-MKT,8610,001,Marketing Research,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,christopher hopkins,
-MKT,8630,001,Buyer Behavior,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,thomas poehlman,
-ML,1010,001,Leadership Fund I,0.72,0.16,0.0,0.0,0.0,0.0,0.0,0.12,robert rozetar,
-ML,1010,001,Leadership Fund I,0.72,0.16,0.0,0.0,0.0,0.0,0.0,0.12,joe luis medrano,
-ML,1010,002,Leadership Fund I,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,robert rozetar,
-ML,1010,002,Leadership Fund I,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,joe luis medrano,
-ML,2010,001,Leadership Develop I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,
-ML,2010,001,Leadership Develop I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,rene romo,
-ML,2010,002,Leadership Develop I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,rene romo,
-ML,2010,002,Leadership Develop I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,
-ML,3010,001,Adv Leadership I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jason danie bielski,
-ML,3010,001,Adv Leadership I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,
-ML,3010,002,Adv Leadership I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,
-ML,3010,002,Adv Leadership I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jason danie bielski,
-ML,4010,001,Org Leadership I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
-ML,4010,001,Org Leadership I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,phillip ale andrews,
-ML,4010,003,Org Leadership I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,phillip ale andrews,
-ML,4010,003,Org Leadership I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
-MSE,2100,001,Intro to Mat Science,0.4,0.33,0.16,0.05,0.03,0.0,0.0,0.03,eric skaar,
-MSE,2100,002,Intro to Mat Science,0.31,0.36,0.17,0.06,0.04,0.0,0.0,0.06,kyle brinkman,
-MSE,2100,003,Intro to Mat Science,0.25,0.38,0.19,0.07,0.02,0.0,0.0,0.09,eric skaar,
-MSE,2100,004,Intro to Mat Science,0.33,0.4,0.14,0.03,0.04,0.0,0.0,0.05,eric skaar,
-MSE,3190,001,Materials Proc I,0.14,0.36,0.36,0.09,0.05,0.0,0.0,0.0,henry rack,
-MSE,3190,002,Materials Proc I,0.45,0.43,0.11,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,
-MSE,3190,002,Materials Proc I,0.45,0.43,0.11,0.0,0.0,0.0,0.0,0.0,olin mefford,
-MSE,3260,001,Thermo of Materials,0.26,0.5,0.18,0.03,0.0,0.0,0.0,0.03,gary lickfield,
-MSE,3260,002,Thermo of Materials,0.09,0.41,0.38,0.06,0.0,0.0,0.0,0.06,gary lickfield,
-MSE,3270,001,Transport Phenomena,0.77,0.16,0.06,0.0,0.01,0.0,0.0,0.01,konstantin kornev,
-MSE,3270,002,Transport Phenomena,0.47,0.35,0.09,0.09,0.0,0.0,0.0,0.0,fei peng,
-MSE,4020,001,Solid State Material,0.28,0.44,0.28,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,4130,001,Noncrystalline Mater,0.57,0.21,0.21,0.0,0.0,0.0,0.0,0.0,herbert david leigh,
-MSE,4150,001,Polymer Sc Engr,0.3,0.34,0.21,0.06,0.06,0.0,0.0,0.04,marek urban,
-MSE,4150,002,Polymer Sc Engr,0.35,0.35,0.15,0.11,0.01,0.0,0.0,0.02,olin mefford,
-MSE,4410,001,Mfg Laboratory,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,
-MSE,4550,001,Polymer Fiber Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,olin mefford,
-MSE,4550,002,Polymer Fiber Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,olin mefford,
-MSE,4580,001,Surf Phen in Ms&E,0.21,0.29,0.14,0.29,0.07,0.0,0.0,0.0,konstantin kornev,
-MSE,4610,001,Polymer & Fiber Mate,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,
-MSE,8010,001,Grad Sem in Material,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,
-MSE,8010,001,Grad Sem in Material,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
-MSE,8200,001,Def Mech in Solids,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,marian kennedy,
-MSE,8270,001,Kin of Phase Tran,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,
-MSE,8520,001,Polymer Science II,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,igor luzinov,
-MUSC,1110,001,Beginning Class Guit,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,david stevenson,
-MUSC,1420,001,Music Theory I,0.58,0.08,0.25,0.0,0.08,0.0,0.0,0.0,david conley,
-MUSC,1420,002,Music Theory I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,david conley,
-MUSC,2100,001,Music in West World,0.58,0.32,0.03,0.03,0.0,0.0,0.0,0.03,eric lapin,
-MUSC,2100,002,Music in West World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,lisa sain odom,
-MUSC,2100,003,Music in West World,0.84,0.1,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,2100,004,Music in West World,0.52,0.13,0.19,0.1,0.06,0.0,0.0,0.0,linda li-bleuel,
-MUSC,2100,005,Music in West World,0.83,0.1,0.05,0.0,0.02,0.0,0.0,0.0,timothy ra hurlburt,
-MUSC,2100,006,Music in West World,0.6,0.23,0.03,0.0,0.0,0.0,0.0,0.13,rhea beth jacobus,
-MUSC,2100,007,Music in West World,0.76,0.17,0.0,0.0,0.03,0.0,0.0,0.03,rhea beth jacobus,
-MUSC,2100,008,Music in West World,0.66,0.25,0.06,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
-MUSC,2100,009,Music in West World,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,evan michael jacobi,
-MUSC,2100,010,Music in West World,0.84,0.0,0.16,0.0,0.0,0.0,0.0,0.0,linda dzuris,
-MUSC,2100,012,Music in West World,0.52,0.35,0.1,0.0,0.0,0.0,0.0,0.03,lea kibler,
-MUSC,3080,001,Surv of Broadway I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey christmas,
-MUSC,3110,001,Hist of Amer Music,0.56,0.28,0.13,0.0,0.03,0.0,0.0,0.0,ned hosler,
-MUSC,3120,001,History of Jazz,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,3130,001,Hist of Rock & Roll,0.46,0.39,0.07,0.04,0.0,0.0,0.0,0.04,hamilton altstatt,
-MUSC,3170,001,Hist of Country Mus,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,ned hosler,
-MUSC,3180,001,Hist of Audio Tech,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,
-MUSC,3420,001,Women's Breakout Ens,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,david conley,
-MUSC,3610,001,Marching Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.01,timothy ra hurlburt,
-MUSC,3610,001,Marching Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
-MUSC,3630,001,Jazz Ensemble,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,timothy ra hurlburt,
-MUSC,3700,001,Clemson University S,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,justin durham,
-MUSC,3720,001,Men's Glee,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,david conley,
-MUSC,4150,001,Music Hist to 1750,0.29,0.18,0.29,0.12,0.12,0.0,0.0,0.0,justin durham,
-NPL,3000,001,Nonprofit Leadership,0.7,0.15,0.04,0.0,0.0,0.0,0.0,0.11,tracy diane lamb,
-NPL,3000,002,Nonprofit Leadership,0.72,0.12,0.04,0.0,0.08,0.0,0.0,0.04,tracy diane lamb,
-NURS,1020,001,Nrsg Success Skills,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,kristin goodenow,
-NURS,1400,001,Comp App Hlth Care,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
-NURS,3030,001,Nursing of Adults,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,corinne croc harmon,
-NURS,3030,001,Nursing of Adults,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,
-NURS,3040,001,Pathophysiology,0.52,0.46,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
-NURS,3040,400,Pathophysiology,0.43,0.38,0.1,0.0,0.05,0.0,0.0,0.05,catherine si murton,
-NURS,3040,401,Pathophysiology,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-NURS,3050,001,Psychosocial Nursing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
-NURS,3100,001,Health Assessment,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3100,400,Health Assessment,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.05,jason thrift,
-NURS,3120,001,Foundations of Nurs,0.25,0.65,0.08,0.0,0.0,0.0,0.0,0.02,angela pye,
-NURS,3120,400,Foundations of Nurs,0.14,0.81,0.0,0.0,0.0,0.0,0.0,0.05,wanda leigh taylor,
-NURS,3190,400,Health Assessment fo,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,
-NURS,3200,400,Prof in Nurs,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,mary steck,
-NURS,3230,400,Gerontology Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,tawny jenn mcintosh,
-NURS,3300,002,Research in Nursing,0.91,0.05,0.05,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,3330,400,Health Care Genetics,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,
-NURS,3400,001,Pharmther Nursing,0.43,0.43,0.06,0.06,0.02,0.0,0.0,0.02,catherine si murton,
-NURS,3400,400,Pharmther Nursing,0.29,0.52,0.05,0.05,0.05,0.0,0.0,0.05,catherine si murton,
-NURS,4010,001,Mental Health Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NURS,4030,200,Complex Nursing of A,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
-NURS,4030,230,Complex Nursing of A,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
-NURS,4100,001,Lead Mgt Practicum,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,
-NURS,4100,001,Lead Mgt Practicum,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,portia botchway,
-NURS,4100,400,Lead Mgt Practicum,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,
-NURS,4100,400,Lead Mgt Practicum,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,portia botchway,
-NURS,4110,001,Nursing of Children,0.66,0.29,0.05,0.0,0.0,0.0,0.0,0.0,heide temples,
-NURS,4120,001,Nurs Women and Fam,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4150,001,Comm Hlth Nursing,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,jackie gillespie,
-NURS,8050,400,Pharmaco Adv Nurs,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8060,400,Advan Assessment for,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,
-NURS,8060,400,Advan Assessment for,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,
-NURS,8090,400,Pathophysiology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
-NURS,8090,400,Pathophysiology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,julia eggert,
-NURS,8190,400,Developing Family,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8190,400,Developing Family,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,
-NURS,8200,400,Child & Adol Nursing,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,heide temples,
-NUTR,2030,001,Intro Princ of Human,0.42,0.34,0.15,0.02,0.02,0.0,0.0,0.04,deborah an hutcheon,
-NUTR,2050,001,Nutr for Nurs Prof,0.66,0.31,0.02,0.01,0.0,0.0,0.0,0.0,deborah an hutcheon,
-NUTR,2160,001,Evidence-Based Nutri,0.73,0.19,0.03,0.0,0.0,0.0,0.0,0.05,angela fraser,
-NUTR,4190,001,Professional Dev in,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,
-NUTR,4240,001,Medical Nutr Thera I,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,rita haliena,
-NUTR,4510,001,Human Nutrition,0.39,0.44,0.11,0.05,0.02,0.0,0.0,0.0,vivian haley-zitlin,
-PA,1010,001,Intro to Perf Arts,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,david hartmann,
-PA,1030,001,Portfolio I,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,linda dzuris,
-PA,2010,001,Career Planning and,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,ned hosler,
-PA,2790,001,Perf Arts Pract I,0.86,0.0,0.09,0.0,0.05,0.0,0.0,0.0,kenneth moore,
-PA,2800,001,Perf Arts Pract II,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,kenneth moore,
-PA,3010,001,Prin of Arts Admin,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,paul buyer,
-PADM,7020,400,Research Methods,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
-PADM,8220,400,Public Policy Proces,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,mark daniel mellott,
-PADM,8290,400,Public Financial Man,0.4,0.47,0.0,0.0,0.0,0.0,0.0,0.13,robert frager,
-PADM,8510,400,Emergency Management,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,steven batson,
-PADM,8680,400,Local Government Adm,0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,alfred bundrick,
-PADM,8780,404,COMMUNICATIONS FOR P,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,scott schmidt,
-PAS,3010,001,Pan African Studies,0.48,0.3,0.15,0.04,0.0,0.0,0.0,0.02,abel bartley,
-PDBE,8010,001,Advanced Theory in E,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
-PDBE,8010,001,Advanced Theory in E,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
-PES,1040,001,Introduction to Plan,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,paula agudelo,
-PES,2020,001,Soils,0.19,0.41,0.33,0.03,0.03,0.0,0.0,0.01,dara michelle park,
-PES,4850,001,Environmental Soil C,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
-PHIL,1010,001,Intro to Phil Prob,0.76,0.15,0.06,0.0,0.03,0.0,0.0,0.0,david stegall,
-PHIL,1010,002,Intro to Phil Prob,0.71,0.09,0.09,0.0,0.0,0.0,0.0,0.12,david stegall,
-PHIL,1010,003,Intro to Phil Prob,0.37,0.34,0.26,0.0,0.0,0.0,0.0,0.03,christopher grau,
-PHIL,1020,001,Intro to Logic,0.14,0.74,0.09,0.0,0.0,0.0,0.0,0.03,kelly smith,
-PHIL,1020,002,Intro to Logic,0.09,0.76,0.15,0.0,0.0,0.0,0.0,0.0,kelly smith,
-PHIL,1020,003,Intro to Logic,0.67,0.21,0.03,0.06,0.03,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,004,Intro to Logic,0.83,0.13,0.0,0.03,0.0,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,005,Intro to Logic,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,gregory scott moss,
-PHIL,1020,006,Intro to Logic,0.74,0.09,0.06,0.0,0.0,0.0,0.0,0.12,gregory scott moss,
-PHIL,1020,007,Intro to Logic,0.64,0.27,0.0,0.06,0.0,0.0,0.0,0.03,gregory scott moss,
-PHIL,1030,001,Intro to Ethics (HON,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True
-PHIL,1030,002,Intro to Ethics,0.29,0.29,0.17,0.14,0.09,0.0,0.0,0.03,jennifer ingle,
-PHIL,1030,003,Intro to Ethics,0.47,0.44,0.03,0.0,0.0,0.0,0.0,0.06,michael hal hannen,
-PHIL,1030,004,Intro to Ethics,0.14,0.51,0.29,0.06,0.0,0.0,0.0,0.0,jennifer ingle,
-PHIL,1030,005,Intro to Ethics,0.24,0.52,0.09,0.0,0.06,0.0,0.0,0.09,charles starkey,
-PHIL,1030,006,Intro to Ethics,0.51,0.34,0.03,0.03,0.03,0.0,0.0,0.06,ryan lake,
-PHIL,1030,008,Intro to Ethics,0.33,0.43,0.19,0.0,0.05,0.0,0.0,0.0,ryan lake,
-PHIL,1030,009,Intro to Ethics,0.51,0.37,0.09,0.0,0.0,0.0,0.0,0.03,ryan lake,
-PHIL,3030,001,Phil of Religion,0.5,0.36,0.0,0.07,0.0,0.0,0.0,0.07,gregory scott moss,
-PHIL,3040,001,Moral Philosophy,0.19,0.38,0.19,0.0,0.13,0.0,0.0,0.13,charles starkey,
-PHIL,3050,001,Existentialism,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,david stegall,
-PHIL,3150,001,Ancient Philosophy,0.18,0.43,0.25,0.07,0.07,0.0,0.0,0.0,stephen satris,
-PHIL,3160,001,Mod Phil,0.61,0.3,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
-PHIL,3170,001,19th-Century Philoso,0.15,0.27,0.27,0.06,0.09,0.0,0.0,0.15,william maker,
-PHIL,3200,001,Soc and Pol Phil,0.28,0.44,0.16,0.0,0.08,0.0,0.0,0.04,todd may,
-PHIL,3260,001,Science and Values,0.36,0.48,0.06,0.0,0.03,0.0,0.0,0.06,andrew garnar,
-PHIL,3260,002,Science and Values,0.41,0.38,0.15,0.0,0.03,0.0,0.0,0.03,andrew garnar,
-PHIL,3260,003,Science and Values,0.49,0.49,0.0,0.0,0.03,0.0,0.0,0.0,andrew garnar,
-PHIL,3430,001,Phil of Law,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,david stegall,
-PHIL,3440,001,Business Ethics,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,david stegall,
-PHIL,3450,001,Environmental Ethics,0.42,0.21,0.06,0.12,0.12,0.0,0.0,0.06,jennifer ingle,
-PHIL,3490,001,Gender and Sexuality,0.33,0.48,0.04,0.0,0.07,0.0,0.0,0.07,diane perpich,
-PHIL,3550,001,Phil Mind & Cog Sci,0.4,0.4,0.1,0.0,0.0,0.0,0.0,0.1,andrew garnar,
-PHIL,3990,001,Philosophy Portfolio,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,kelly smith,
-PHIL,4020,001,Topics in Philosophy,0.41,0.41,0.12,0.0,0.06,0.0,0.0,0.0,todd may,
-PHIL,4020,002,Topics in Philosophy,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,candice delmas,
-PHIL,4750,001,Philosophy of Film,0.27,0.45,0.09,0.09,0.0,0.0,0.0,0.09,christopher grau,
-PHSC,1180,001,Intro Phys & Astro,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,001,Physics With Cal I,0.31,0.3,0.23,0.06,0.05,0.0,0.0,0.04,lih-sin the,
-PHYS,1220,002,Physics With Cal I,0.2,0.28,0.26,0.15,0.07,0.0,0.0,0.04,lih-sin the,
-PHYS,1220,004,Phys W/Cal I (MAJ ON,0.28,0.39,0.11,0.11,0.0,0.0,0.0,0.11,murray daw,
-PHYS,1240,001,Physics Lab I,0.06,0.83,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,
-PHYS,1240,002,Physics Lab I,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,003,Physics Lab I,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,004,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,005,Physics Lab I,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,006,Physics Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,007,Physics Lab I,0.27,0.67,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,1240,008,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,009,Physics Lab I,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,010,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,011,Physics Lab I,0.06,0.82,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
-PHYS,1240,012,Physics Lab I,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,013,Physics Lab I,0.19,0.63,0.13,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,014,Physics Lab I,0.06,0.63,0.19,0.0,0.06,0.0,0.0,0.06,jerry hester,
-PHYS,1240,016,Physics Lab I,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,1240,017,Physics Lab I,0.29,0.64,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,2070,001,General Physics I,0.42,0.35,0.16,0.04,0.01,0.0,0.0,0.02,amy liann pope,
-PHYS,2070,002,General Physics I,0.52,0.33,0.09,0.02,0.01,0.0,0.0,0.02,amy liann pope,
-PHYS,2070,003,General Physics I,0.34,0.28,0.22,0.07,0.06,0.0,0.0,0.03,pooja puneet,
-PHYS,2080,001,General Physics II,0.42,0.37,0.12,0.04,0.04,0.0,0.0,0.03,pooja puneet,
-PHYS,2090,001,Gen Phys Lab I,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,002,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,003,Gen Phys Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,004,Gen Phys Lab I,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,005,Gen Phys Lab I,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,006,Gen Phys Lab I,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,007,Gen Phys Lab I,0.68,0.23,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,008,Gen Phys Lab I,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,009,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,010,Gen Phys Lab I,0.55,0.27,0.14,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,011,Gen Phys Lab I,0.38,0.42,0.17,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,012,Gen Phys Lab I,0.57,0.35,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,013,Gen Phys Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,014,Gen Phys Lab I,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,015,Gen Phys Lab I,0.26,0.57,0.09,0.0,0.0,0.0,0.0,0.09,jerry hester,
-PHYS,2090,016,Gen Phys Lab I,0.5,0.27,0.18,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,017,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,018,Gen Phys Lab I,0.55,0.41,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,019,Gen Phys Lab I,0.14,0.64,0.23,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,020,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,021,Gen Phys Lab I,0.18,0.59,0.09,0.0,0.0,0.0,0.0,0.14,jerry hester,
-PHYS,2090,022,Gen Phys Lab I,0.43,0.43,0.09,0.04,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,023,Gen Phys Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,024,Gen Phys Lab I,0.55,0.23,0.14,0.0,0.0,0.0,0.0,0.09,jerry hester,
-PHYS,2100,001,Gen Phys Lab II,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,002,Gen Phys Lab II,0.33,0.54,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,003,Gen Phys Lab II,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,004,Gen Phys Lab II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,006,Gen Phys Lab II,0.3,0.52,0.04,0.0,0.0,0.0,0.0,0.13,jerry hester,
-PHYS,2100,007,Gen Phys Lab II,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,008,Gen Phys Lab II,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2210,001,Physics With Cal II,0.2,0.5,0.21,0.06,0.02,0.0,0.0,0.01,jason stratfo brown,
-PHYS,2210,002,Physics With Cal II,0.27,0.52,0.16,0.03,0.02,0.0,0.0,0.0,jason stratfo brown,
-PHYS,2210,003,Physics With Cal II,0.35,0.46,0.12,0.03,0.02,0.0,0.0,0.02,jason stratfo brown,
-PHYS,2210,004,Physics With Cal II,0.24,0.47,0.2,0.05,0.02,0.0,0.0,0.02,lih-sin the,
-PHYS,2210,007,Physics With Cal II,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,sean brittain,True
-PHYS,2220,001,Phys With Cal III,0.28,0.5,0.11,0.06,0.06,0.0,0.0,0.0,jian he,
-PHYS,2230,001,Physics Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,002,Physics Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,003,Physics Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,004,Physics Lab II,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,005,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,006,Physics Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,007,Physics Lab II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,009,Physics Lab II,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,010,Physics Lab II,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,011,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,012,Physics Lab II,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,013,Physics Lab II,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,016,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,017,Physics Lab II,0.27,0.6,0.07,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,2450,001,Physics of Climate,0.23,0.41,0.11,0.03,0.01,0.0,0.0,0.21,john meriwether,
-PHYS,3000,001,Intro to Research,0.82,0.05,0.05,0.05,0.05,0.0,0.0,0.0,terry tritt,
-PHYS,3000,001,Intro to Research,0.82,0.05,0.05,0.05,0.05,0.0,0.0,0.0,jens oberheide,
-PHYS,3110,001,Methods Theor Phys,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,feng ding,
-PHYS,3210,001,Mechanics I,0.11,0.32,0.05,0.16,0.11,0.0,0.0,0.26,gerald lehmacher,
-PHYS,3250,001,Exper Physics I,0.28,0.67,0.0,0.0,0.0,0.0,0.0,0.06,hye jung kang,
-PHYS,3250,001,Exper Physics I,0.28,0.67,0.0,0.0,0.0,0.0,0.0,0.06,chad sosolik,
-PHYS,4420,001,Electromagnetics II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,endre andras takacs,
-PHYS,4550,001,Quantum Physics I,0.08,0.67,0.25,0.0,0.0,0.0,0.0,0.0,antony valentini,
-PHYS,6520,001,Int to Nuclear Phys,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jeremy king,
-PHYS,6550,001,Quantum Physics I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,antony valentini,
-PHYS,8110,001,Meth of Theor Phys I,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-PHYS,8210,001,Classical Mech I,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
-PHYS,8750,007,Intro to Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jens oberheide,
-PHYS,8750,007,Intro to Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,terry tritt,
-PHYS,9510,001,Quantum Mech I,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
-PKSC,1010,001,Pkgsc Orientation,0.81,0.08,0.06,0.05,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,1020,001,Intro to Pkg Sci,0.05,0.36,0.4,0.12,0.06,0.0,0.0,0.0,heather batt,
-PKSC,2020,001,Packaging Mtl & Mfg,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2040,001,Container Systems,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2200,001,Product & Pkg Design,0.69,0.23,0.06,0.0,0.0,0.0,0.0,0.02,william aaro snyder,
-PKSC,4010,001,Pkg Machinery,0.33,0.41,0.22,0.04,0.0,0.0,0.0,0.0,anthony lou pometto,
-PKSC,4030,001,Pkg Career Prep,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4040,001,Mech Prop & Prot Pkg,0.21,0.29,0.29,0.09,0.08,0.0,0.0,0.03,gregory batt,
-PKSC,4160,001,Appl Polymers in Pkg,0.09,0.44,0.35,0.07,0.02,0.0,0.0,0.02,duncan darby,
-PKSC,4200,001,Pkg Design & Dev,0.56,0.41,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4540,001,Prod Pkg Evl Lab,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,gregory batt,
-PKSC,4540,002,Prod Pkg Evl Lab,0.13,0.5,0.25,0.06,0.06,0.0,0.0,0.0,gregory batt,
-PKSC,4540,003,Prod Pkg Evl Lab,0.13,0.31,0.38,0.0,0.06,0.0,0.0,0.13,gregory batt,
-PKSC,4540,004,Prod Pkg Evl Lab,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4540,005,Prod Pkg Evl Lab,0.25,0.33,0.17,0.0,0.25,0.0,0.0,0.0,gregory batt,
-PKSC,4640,001,Fd & Hc Pkg Systems,0.3,0.63,0.03,0.03,0.0,0.0,0.0,0.0,kay cooksey,
-PLPA,3100,001,Principles of Plant,0.15,0.65,0.15,0.05,0.0,0.0,0.0,0.0,steven nye jeffers,
-POSC,1010,001,Amer National Govt,0.16,0.3,0.24,0.18,0.02,0.0,0.0,0.1,joseph earl stewart,
-POSC,1010,002,Amer National Govt,0.27,0.29,0.27,0.07,0.05,0.0,0.0,0.05,jeffrey scott peake,
-POSC,1010,003,Amer National Govt,0.13,0.51,0.18,0.07,0.04,0.0,0.0,0.07,laura olson,
-POSC,1020,001,Intro Intl Relations,0.15,0.42,0.25,0.02,0.04,0.0,0.0,0.11,aron geo tannenbaum,
-POSC,1020,002,Intro Intl Relations,0.11,0.53,0.29,0.02,0.02,0.0,0.0,0.04,lydia loui lundgren,
-POSC,1020,003,Intro Intl Relations,0.14,0.49,0.22,0.04,0.01,0.0,0.0,0.09,colin pearce,
-POSC,1030,001,Intro to Political T,0.09,0.35,0.33,0.13,0.04,0.0,0.0,0.07,james woodard,
-POSC,1030,002,Intro to Political T,0.22,0.51,0.12,0.0,0.02,0.0,0.0,0.12,jeremy fortier,
-POSC,1040,001,Intro Compar Pol,0.21,0.38,0.35,0.03,0.0,0.0,0.0,0.03,xiaobo hu,
-POSC,1040,002,Intro Compar Pol,0.17,0.56,0.21,0.04,0.02,0.0,0.0,0.0,katherine am curtis,
-POSC,1990,001,Intro Pol Sci,0.44,0.27,0.14,0.04,0.09,0.0,0.0,0.02,meredith petersheim,
-POSC,3020,001,State and Loc Gov,0.13,0.6,0.17,0.0,0.07,0.0,0.0,0.03,bruce ransom,
-POSC,3110,001,Model United Nations,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,xiaobo hu,
-POSC,3120,001,State Student Leg,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michael cunningham,
-POSC,3410,001,Quant Meth in Pol Sc,0.31,0.31,0.08,0.15,0.15,0.0,0.0,0.0,steven vince miller,
-POSC,3610,001,Intl Pol in Crisis,0.21,0.46,0.1,0.02,0.19,0.0,0.0,0.02,steven vince miller,
-POSC,3620,001,Intl Organizations,0.27,0.38,0.15,0.08,0.04,0.0,0.0,0.08,lydia loui lundgren,
-POSC,3630,001,Us Foreign Policy,0.31,0.54,0.12,0.0,0.0,0.0,0.0,0.04,vladimir matic,
-POSC,3710,001,European Politics,0.34,0.56,0.09,0.0,0.0,0.0,0.0,0.0,vladimir matic,
-POSC,4030,001,United States Congre,0.22,0.36,0.2,0.13,0.07,0.0,0.0,0.02,jeffrey allen fine,
-POSC,4210,001,Public Policy,0.27,0.09,0.27,0.09,0.09,0.0,0.0,0.18,adam warber,
-POSC,4230,001,Urban Politics,0.1,0.7,0.1,0.0,0.0,0.0,0.0,0.1,bruce ransom,
-POSC,4360,001,Law Courts Politics,0.28,0.46,0.23,0.03,0.0,0.0,0.0,0.0,joseph earl stewart,
-POSC,4370,001,Constitut Law: Right,0.47,0.43,0.07,0.0,0.03,0.0,0.0,0.0,daniel frost,
-POSC,4380,001,Constitut Law: Struc,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,
-POSC,4420,001,Pol Parties & Elect,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,laura olson,
-POSC,4500,001,Classical & Modern L,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,brandon turner,
-POSC,4550,001,Pol Thght of America,0.24,0.55,0.19,0.02,0.0,0.0,0.0,0.0, bradley thompson,
-POSC,4560,001,Diplomacy,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,vladimir matic,
-POSC,4710,001,Russian Politics,0.5,0.32,0.05,0.05,0.05,0.0,0.0,0.05,aron geo tannenbaum,
-POSC,4760,001,Middle East Politics,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,vladimir matic,
-POSC,4890,002,WWII: Ideol. in Worl,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,james woodard,
-POSC,4890,003,International Law,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,katherine am curtis,
-PRTM,1950,002,Pro Golf Management,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,herbert chancellor,
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,denise mar anderson,
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,teresa walto tucker,
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,francis mcguire,
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,elizabeth baldwin,
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,robert brookover,
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,elizabeth baldwin,
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,denise mar anderson,
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,teresa walto tucker,
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,robert brookover,
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,francis mcguire,
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,herbert chancellor,
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,robert brookover,
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,francis mcguire,
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,denise mar anderson,
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,elizabeth baldwin,
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,teresa walto tucker,
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,herbert chancellor,
-PRTM,2950,001,Pro Golf Management,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3070,002,Facility Operations,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,craig goodman,
-PRTM,3200,001,Recreation Policy,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,bernard mwe kitheka,
-PRTM,3220,001,Facilitation Techniq,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,
-PRTM,3240,001,Assessment & Plannin,0.83,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3250,001,Global Persp in Rec,0.55,0.18,0.24,0.0,0.03,0.0,0.0,0.0,skye arthur-banning,
-PRTM,3300,001,Visit Ser & Interp,0.36,0.43,0.14,0.07,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,3430,001,Spl Asp of Tourist B,0.35,0.6,0.05,0.0,0.0,0.0,0.0,0.0,william norman,
-PRTM,3430,002,Spl Asp of Tourist B,0.4,0.45,0.08,0.05,0.03,0.0,0.0,0.0,william norman,
-PRTM,3450,001,Tourism Management,0.43,0.32,0.17,0.05,0.03,0.0,0.0,0.0,lauren duffy,
-PRTM,3530,002,Foundations of Camp,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,gwynn powell,
-PRTM,3920,001,Special Event Manage,0.79,0.1,0.04,0.04,0.02,0.0,0.0,0.02,kenneth backman,
-PRTM,3920,002,Special Event Manage,0.81,0.13,0.02,0.0,0.02,0.0,0.0,0.02,kenneth backman,
-PRTM,3950,001,PGM Seminar III,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3950,001,PGM Seminar III,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,3980,003,Creative Inquiry in,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,kellie aman walters,
-PRTM,3980,011,Creative Inquiry in,0.76,0.0,0.0,0.0,0.0,0.0,0.0,0.24,skye arthur-banning,
-PRTM,4030,001,Elem of Rec/Pk Plan,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
-PRTM,4070,001,Pers Admin in PRTM,0.32,0.38,0.18,0.12,0.0,0.0,0.0,0.0,daniel mor anderson,
-PRTM,4470,001,Perspect Intl Travel,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,lauren duffy,
-PRTM,4550,001,Adv Program Planning,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,4830,001,Golf Club Mgt & Ops,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,4950,001,Pro Golf Management,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,4950,001,Pro Golf Management,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,4980,001,Creative Inquiry in,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
-PRTM,4980,007,Creative Inquiry in,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,denise mar anderson,
-PRTM,4980,009,Creative Inquiry in,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,leslie conrad,
-PRTM,4980,009,Creative Inquiry in,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,8010,002,Phil Found of PRTM,0.57,0.22,0.13,0.0,0.09,0.0,0.0,0.0,dorothy schmalz,
-PRTM,8080,001,Behavioral Aspects,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,8220,002,Strateg Planning in,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,
-PRTM,8560,001,Heritage Tourism,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,
-PRTM,9000,004,The Politics of Scie,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,gary edward machlis,
-PSYC,2010,001,Intro to Psychology,0.27,0.34,0.25,0.08,0.04,0.0,0.0,0.02,edwin brainerd,
-PSYC,2010,002,Intro to Psychology,0.33,0.34,0.21,0.08,0.02,0.0,0.0,0.03,jo anne jorgensen,
-PSYC,2010,003,Intro to Psychology,0.51,0.25,0.15,0.04,0.01,0.0,0.0,0.03,chong hyon pak,
-PSYC,2010,004,Intro to Psychology,0.25,0.45,0.2,0.0,0.0,0.0,0.0,0.1,fred switzer,
-PSYC,2010,005,Intro to Psychology,0.27,0.43,0.14,0.04,0.03,0.0,0.0,0.09,mary taylor,
-PSYC,2010,006,Intro to Psychology,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,christopher pagano,True
-PSYC,2010,104,Intro to Psychology,0.33,0.47,0.16,0.0,0.02,0.0,0.0,0.02,fred switzer,
-PSYC,2020,001,Intro Psychology Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,2020,002,Intro Psychology Lab,0.76,0.06,0.0,0.06,0.12,0.0,0.0,0.0,eric mckibben,
-PSYC,2020,003,Intro Psychology Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,2020,004,Intro Psychology Lab,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,eric mckibben,
-PSYC,2020,005,Intro Psychology Lab,0.79,0.13,0.04,0.04,0.0,0.0,0.0,0.0,lauren elizab ellis,
-PSYC,2020,006,Intro Psychology Lab,0.81,0.1,0.05,0.05,0.0,0.0,0.0,0.0,hannah jeann murphy,
-PSYC,3060,001,Human Sexual Beh,0.54,0.22,0.13,0.06,0.04,0.0,0.0,0.02,bruce michael king,
-PSYC,3090,100,Intro Exp Psych,0.25,0.39,0.2,0.05,0.05,0.0,0.0,0.07,jennifer bai bisson,
-PSYC,3090,200,Intro Exp Psych,0.33,0.42,0.09,0.08,0.03,0.0,0.0,0.05,patrick rosopa,
-PSYC,3100,100,Advanced Experimenta,0.32,0.42,0.21,0.0,0.05,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimenta,0.76,0.06,0.06,0.0,0.12,0.0,0.0,0.0,robert campbell,
-PSYC,3100,300,Advanced Experimenta,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3100,400,Advanced Experimenta,0.78,0.06,0.0,0.06,0.06,0.0,0.0,0.06,alice miche brawley,
-PSYC,3100,500,Advanced Experimenta,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,allison lei wallace,
-PSYC,3100,600,Advanced Experimenta,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,3240,001,Physiological Psych,0.33,0.34,0.14,0.07,0.07,0.0,0.0,0.04,claudio cantalupo,
-PSYC,3240,002,Physiological Psych,0.25,0.41,0.16,0.1,0.07,0.0,0.0,0.0,june pilcher,
-PSYC,3330,001,Cognitive Psych,0.64,0.2,0.09,0.06,0.0,0.0,0.0,0.01,paul steven merritt,
-PSYC,3330,002,Cognitive Psych,0.72,0.13,0.12,0.01,0.0,0.0,0.0,0.01,paul steven merritt,
-PSYC,3340,001,Cognitive Psych Lab,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,phillip weis jasper,
-PSYC,3340,002,Cognitive Psych Lab,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,ashley ann sewall,
-PSYC,3400,001,Lifespan Development,0.26,0.31,0.26,0.11,0.01,0.0,0.0,0.04,pamela alley,
-PSYC,3520,001,Social Psychology,0.34,0.4,0.2,0.06,0.0,0.0,0.0,0.0,jo anne jorgensen,
-PSYC,3520,002,Social Psychology,0.32,0.39,0.24,0.03,0.0,0.0,0.0,0.01,jo anne jorgensen,
-PSYC,3520,003,Social Psychology (H,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
-PSYC,3640,001,Industrial Psych,0.56,0.31,0.09,0.01,0.03,0.0,0.0,0.0,eric mckibben,
-PSYC,3680,001,Organizational Psych,0.38,0.38,0.14,0.07,0.03,0.0,0.0,0.0,thomas britt,
-PSYC,3690,001,Leadership in Orgs,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.01,eric mckibben,
-PSYC,3830,001,Abnormal Psychology,0.29,0.26,0.23,0.17,0.06,0.0,0.0,0.0,pamela alley,
-PSYC,3830,002,Abnormal Psychology,0.42,0.39,0.14,0.06,0.0,0.0,0.0,0.0,pamela alley,
-PSYC,3830,003,Abnormal Psychology,0.37,0.34,0.18,0.08,0.0,0.0,0.0,0.03,heidi marie zinzow,
-PSYC,4080,001,Women and Psychology,0.5,0.25,0.17,0.04,0.0,0.0,0.0,0.04,robin mari kowalski,
-PSYC,4150,001,Systems and Theories,0.38,0.22,0.09,0.19,0.06,0.0,0.0,0.06,edwin brainerd,
-PSYC,4150,002,Systems and Theories,0.33,0.43,0.13,0.1,0.0,0.0,0.0,0.0,edwin brainerd,
-PSYC,4220,001,Perception,0.19,0.15,0.22,0.33,0.07,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4220,002,Perception,0.27,0.5,0.12,0.04,0.04,0.0,0.0,0.04,christopher pagano,
-PSYC,4430,001,Infant & Child Dev,0.58,0.31,0.12,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,4430,002,Infant & Child Dev,0.44,0.33,0.15,0.0,0.0,0.0,0.0,0.07,sarah mae sanborn,
-PSYC,4560,001,Psychophysiology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,eric muth,
-PSYC,4710,001,Psych of Testing,0.85,0.08,0.0,0.0,0.04,0.0,0.0,0.04,larry alton pace,
-PSYC,4800,001,Health Psychology,0.48,0.24,0.24,0.0,0.0,0.0,0.0,0.04,james mccubbin,
-PSYC,4880,002,Psychotherapy,0.84,0.04,0.04,0.0,0.04,0.0,0.0,0.04,cynthia pury,
-PSYC,4890,001,Psychology of Music,0.48,0.36,0.08,0.0,0.0,0.0,0.0,0.08,claudio cantalupo,
-PSYC,4890,001,Psychology of Music,0.48,0.36,0.08,0.0,0.0,0.0,0.0,0.08,robert campbell,
-PSYC,4890,002,Teamwork In 21st Cen,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,marissa leig porter,
-PSYC,4920,001,Senior Laboratory,0.75,0.13,0.06,0.0,0.06,0.0,0.0,0.0,amelia jea kinsella,
-PSYC,4920,002,Senior Laboratory,0.8,0.08,0.08,0.0,0.0,0.0,0.0,0.04,amelia jea kinsella,
-PSYC,4920,003,Senior Laboratory,0.76,0.14,0.0,0.05,0.0,0.0,0.0,0.05,jessica anne stahl,
-PSYC,4920,004,Senior Laboratory,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jessica anne stahl,
-PSYC,4930,001,Pract Clinical Psych,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,
-PSYC,8100,001,Research Design I,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0, dewayne moore,
-PSYC,8220,001,Percept & Perform,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard tyrrell,
-PSYC,8330,001,Adv Cog Psych,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,leo gugerty,
-PSYC,8350,001,Adv Human Factors,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,leo gugerty,
-PSYC,8680,001,Leadership in Orgs,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,patrick raymark,
-PSYC,8730,001,SEM in App Psych,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0, dewayne moore,
-PSYC,8990,003,Training & Dev,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,marissa leig porter,
-RCID,8130,002,Special Topics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
-RED,8000,001,Real Estate Dvlpment,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-RED,8160,001,Preservation Feasibi,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-REL,1010,001,Intro to Religion,0.18,0.35,0.12,0.06,0.12,0.0,0.0,0.18,peter cohen,
-REL,1010,002,Intro to Religion,0.07,0.27,0.33,0.2,0.07,0.0,0.0,0.07,peter cohen,
-REL,1010,004,Intro to Religion,0.09,0.33,0.24,0.18,0.09,0.0,0.0,0.06,peter cohen,
-REL,1020,002,World Religions,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,robert stephens,
-REL,1020,003,World Religions,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,robert stephens,
-REL,1020,004,World Religions,0.5,0.29,0.18,0.04,0.0,0.0,0.0,0.0,robert stephens,
-REL,1020,005,World Religions,0.58,0.27,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,
-REL,3010,001,Old Testament,0.44,0.38,0.16,0.0,0.03,0.0,0.0,0.0,steven grosby,
-REL,3020,001,New Testament Lit,0.39,0.52,0.06,0.03,0.0,0.0,0.0,0.0,benjamin white,
-REL,3100,002,History of Religion,0.19,0.38,0.13,0.06,0.06,0.0,0.0,0.19,james brad jeffries,
-REL,3120,001,Hinduism,0.71,0.14,0.04,0.0,0.0,0.0,0.0,0.11,robert stephens,
-REL,3150,001,Islam,0.35,0.42,0.13,0.03,0.06,0.0,0.0,0.0,mashal saif,
-REL,4010,001,Stud Biblical Litera,0.53,0.27,0.0,0.0,0.0,0.0,0.0,0.2,steven grosby,
-RS,3010,001,Rural Sociology,0.26,0.44,0.26,0.0,0.0,0.0,0.0,0.04,kenneth robinson,
-RUSS,1010,001,Elementary Russian,0.46,0.23,0.08,0.08,0.08,0.0,0.0,0.08,joan bridgwood,
-SOC,2010,003,Introduction to Soci,0.37,0.29,0.24,0.05,0.03,0.0,0.0,0.01,stephani southworth,
-SOC,2010,004,Introduction to Soci,0.16,0.51,0.18,0.09,0.04,0.0,0.0,0.02,mary louise barr,
-SOC,2010,007,Introduction to Soci,0.37,0.41,0.13,0.04,0.02,0.0,0.0,0.02,stephani southworth,
-SOC,2010,009,Introduction to Soci,0.21,0.51,0.23,0.0,0.04,0.0,0.0,0.0,stephani southworth,
-SOC,2010,010,Introduction to Soci,0.47,0.43,0.08,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,011,Introduction to Soci,0.41,0.35,0.2,0.02,0.0,0.0,0.0,0.02,jennifer le holland,
-SOC,2010,012,Introduction to Soci,0.54,0.33,0.08,0.0,0.0,0.0,0.0,0.04,jennifer le holland,
-SOC,2010,013,Introduction to Soci,0.37,0.43,0.15,0.04,0.0,0.0,0.0,0.0,stephani southworth,
-SOC,2010,014,Introduction to Soci,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
-SOC,2010,015,Introduction to Soci,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
-SOC,2010,016,Introduction to Soci,0.52,0.45,0.02,0.0,0.0,0.0,0.0,0.01,jeffrey edwards,
-SOC,2010,018,Introduction to Soci,0.34,0.3,0.21,0.11,0.02,0.0,0.0,0.02,mary louise barr,
-SOC,2010,019,Introduction to Soci,0.39,0.5,0.08,0.03,0.0,0.0,0.0,0.0,mary louise barr,
-SOC,2010,020,Introduction to Soci,0.21,0.37,0.31,0.07,0.01,0.0,0.0,0.02,mary louise barr,
-SOC,2050,001,Sociology Lab,0.64,0.0,0.06,0.0,0.19,0.0,0.0,0.11,brenda vander mey,
-SOC,2050,002,Sociology Lab,0.71,0.0,0.0,0.06,0.18,0.0,0.0,0.06,brenda vander mey,
-SOC,3020,001,Research Methods I,0.17,0.42,0.25,0.14,0.0,0.0,0.0,0.03,andrew whitehead,
-SOC,3040,001,Research Methods II,0.3,0.33,0.13,0.2,0.03,0.0,0.0,0.0,ye luo,
-SOC,3600,001,Class & Poverty,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,william wentworth,
-SOC,3880,001,Criminal Justice,0.15,0.44,0.38,0.02,0.0,0.0,0.0,0.0,margaret tina britz,
-SOC,3890,001,Criminology,0.2,0.2,0.22,0.12,0.17,0.0,0.0,0.1,william white,
-SOC,3910,001,Soc of Deviance,0.15,0.39,0.26,0.09,0.04,0.0,0.0,0.07,william white,
-SOC,3920,001,Juvenile Delinquency,0.25,0.29,0.23,0.1,0.08,0.0,0.0,0.04,william white,
-SOC,3940,001,Soc Mental Illness,0.57,0.26,0.13,0.0,0.0,0.0,0.0,0.04,douglas sturkie,
-SOC,3970,001,Substance Abuse,0.63,0.24,0.08,0.0,0.0,0.0,0.0,0.04,jeffrey edwards,
-SOC,4030,001,"Technol, Environment",0.26,0.37,0.21,0.05,0.11,0.0,0.0,0.0, catherine mobley,
-SOC,4040,001,Soc Theory,0.35,0.32,0.18,0.06,0.06,0.0,0.0,0.03,william wentworth,
-SOC,4140,001,Policy&Social Change,0.34,0.59,0.07,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,4320,001,Soc of Religion,0.43,0.24,0.16,0.12,0.04,0.0,0.0,0.0,andrew whitehead,
-SOC,4330,001,Global Social Change,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,william haller,
-SOC,4440,001,Sociology of Educ,0.18,0.43,0.14,0.11,0.0,0.0,0.0,0.14,stephani southworth,
-SOC,4600,001,Race & Ethnicity,0.52,0.24,0.24,0.0,0.0,0.0,0.0,0.0,brenda vander mey,
-SOC,4680,001,Criminal Evidence,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
-SOC,4970,001,Senior Lab,0.44,0.12,0.36,0.0,0.08,0.0,0.0,0.0,brenda vander mey,
-SOC,8030,001,Sur Dsgn App Res Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,
-SOC,8300,001,Human Systems Dev,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,ellen granberg,
-SPAN,1010,001,Elementary Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1010,002,Elementary Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1010,003,Elementary Spanish,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1020,001,Elementary Spanish,0.17,0.44,0.17,0.0,0.0,0.0,0.0,0.22,roger simpson,
-SPAN,1020,002,Elementary Spanish,0.22,0.44,0.11,0.11,0.06,0.0,0.0,0.06,roger simpson,
-SPAN,1020,003,Elementary Spanish,0.44,0.39,0.11,0.06,0.0,0.0,0.0,0.0,roger simpson,
-SPAN,1020,004,Elementary Spanish,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,roger simpson,
-SPAN,1020,005,Elementary Spanish,0.21,0.37,0.21,0.05,0.05,0.0,0.0,0.11,roger simpson,
-SPAN,1020,006,Elementary Spanish,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,cathy robison,
-SPAN,1020,007,Elementary Spanish,0.4,0.33,0.2,0.0,0.0,0.0,0.0,0.07,cathy robison,
-SPAN,1020,008,Elementary Spanish,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,ricardo tremolada,
-SPAN,1020,009,Elementary Spanish,0.44,0.33,0.06,0.0,0.0,0.0,0.0,0.17,ricardo tremolada,
-SPAN,1020,010,Elementary Spanish,0.35,0.41,0.24,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,1020,011,Elementary Spanish,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,1020,012,Elementary Spanish,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
-SPAN,1020,013,Elementary Spanish,0.61,0.0,0.28,0.06,0.06,0.0,0.0,0.0,allison ann hinds,
-SPAN,1020,014,Elementary Spanish,0.41,0.29,0.06,0.06,0.0,0.0,0.0,0.18,allison ann hinds,
-SPAN,1020,015,Elementary Spanish,0.44,0.19,0.06,0.19,0.0,0.0,0.0,0.13,ricardo tremolada,
-SPAN,2010,001,Intermediate Spanish,0.26,0.26,0.32,0.11,0.0,0.0,0.0,0.05,cathy robison,
-SPAN,2010,002,Intermediate Spanish,0.13,0.56,0.06,0.06,0.0,0.0,0.0,0.19,cathy robison,
-SPAN,2010,003,Intermediate Spanish,0.33,0.28,0.33,0.0,0.0,0.0,0.0,0.06,maureen zamora,
-SPAN,2010,004,Intermediate Spanish,0.37,0.26,0.16,0.0,0.05,0.0,0.0,0.16,ellory schmucker,
-SPAN,2010,005,Intermediate Spanish,0.46,0.23,0.15,0.15,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2010,007,Intermediate Spanish,0.13,0.4,0.27,0.13,0.0,0.0,0.0,0.07,heidi montes,
-SPAN,2010,008,Intermediate Spanish,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2010,009,Intermediate Spanish,0.35,0.41,0.18,0.0,0.06,0.0,0.0,0.0,ricardo tremolada,
-SPAN,2010,010,Intermediate Spanish,0.39,0.28,0.11,0.22,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,011,Intermediate Spanish,0.0,0.31,0.38,0.15,0.08,0.0,0.0,0.08,melva margu persico,
-SPAN,2010,013,Intermediate Spanish,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,ze cruz valderramos,
-SPAN,2010,014,Intermediate Spanish,0.33,0.5,0.06,0.0,0.06,0.0,0.0,0.06,maureen zamora,
-SPAN,2010,015,Intermediate Spanish,0.37,0.42,0.05,0.0,0.05,0.0,0.0,0.11,ricardo tremolada,
-SPAN,2010,016,Intermediate Spanish,0.28,0.56,0.17,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,
-SPAN,2010,017,Intermediate Spanish,0.44,0.19,0.19,0.13,0.06,0.0,0.0,0.0,maureen zamora,
-SPAN,2010,018,Intermediate Spanish,0.29,0.24,0.29,0.12,0.0,0.0,0.0,0.06,kari daus carson,
-SPAN,2010,022,Intermediate Spanish,0.31,0.31,0.19,0.0,0.06,0.0,0.0,0.13,heidi montes,
-SPAN,2010,023,Intermediate Spanish,0.07,0.5,0.21,0.07,0.0,0.0,0.0,0.14,maureen zamora,
-SPAN,2010,024,Intermediate Spanish,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,allison ann hinds,
-SPAN,2020,001,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,002,Intermediate Spanish,0.22,0.28,0.28,0.11,0.06,0.0,0.0,0.06,melva margu persico,
-SPAN,2020,003,Intermediate Spanish,0.33,0.11,0.39,0.17,0.0,0.0,0.0,0.0,kari daus carson,
-SPAN,2020,004,Intermediate Spanish,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,005,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2020,006,Intermediate Spanish,0.37,0.37,0.16,0.11,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2020,007,Intermediate Spanish,0.24,0.41,0.12,0.06,0.0,0.0,0.0,0.18,melva margu persico,
-SPAN,2020,008,Intermediate Spanish,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,2020,009,Intermediate Spanish,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,ellory schmucker,
-SPAN,2020,010,Intermediate Spanish,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,011,Intermediate Spanish,0.32,0.42,0.11,0.11,0.0,0.0,0.0,0.05,kari daus carson,
-SPAN,2020,012,Intermediate Spanish,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,juana martin-armas,
-SPAN,2020,013,Intermediate Spanish,0.22,0.61,0.11,0.06,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,3020,001,Int Spn Gram & Comp,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
-SPAN,3050,002,Int Con Comp Span I,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,raquel anido,
-SPAN,3050,003,Int Con Comp Span I,0.32,0.42,0.16,0.0,0.0,0.0,0.0,0.11,raquel anido,
-SPAN,3080,001,Hispanic World: La,0.63,0.21,0.0,0.0,0.05,0.0,0.0,0.11,george palacios,
-SPAN,3080,002,Hispanic World: La,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,tiffany dawn miller,
-SPAN,3090,001,Intro to Span Phont,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,daniel smith,
-SPAN,3110,001,Surv Span-Amer Lit,0.13,0.4,0.2,0.07,0.13,0.0,0.0,0.07,tiffany dawn miller,
-SPAN,3130,001,Span Lit Survey I,0.2,0.4,0.13,0.0,0.0,0.0,0.0,0.27,mon rojas-de-massei,
-SPAN,3130,002,Span Lit Survey I,0.27,0.4,0.2,0.07,0.0,0.0,0.0,0.07,mon rojas-de-massei,
-SPAN,3140,001,Hispanic Linguistics,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
-SPAN,3180,001,Span Through Culture,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,george palacios,
-SPAN,4030,001,Span Amer Wom Writer,0.3,0.4,0.1,0.0,0.2,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,4060,001,Narrative Fiction,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,mon rojas-de-massei,
-SPAN,4060,002,Narrative Fiction,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,
-SPAN,4070,001,Hispanic Film,0.5,0.31,0.06,0.06,0.0,0.0,0.0,0.06,raquel anido,
-SPAN,4190,001,Health & Hisp Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-STAT,2220,001,Statistics in Everyd,0.33,0.36,0.25,0.04,0.0,0.0,0.0,0.02,ros martinez-dawson,
-STAT,2220,002,Statistics in Everyd,0.36,0.28,0.23,0.08,0.02,0.0,0.0,0.04,james espey,
-STAT,2220,003,Statistics in Everyd,0.35,0.33,0.21,0.1,0.02,0.0,0.0,0.0,april thomas,
-STAT,2220,004,Statistics in Everyd,0.41,0.48,0.09,0.0,0.0,0.0,0.0,0.02,benjamin sharp,
-STAT,2220,005,Statistics in Everyd,0.37,0.29,0.31,0.02,0.02,0.0,0.0,0.0,james espey,
-STAT,2220,006,Statistics in Everyd,0.39,0.28,0.33,0.0,0.0,0.0,0.0,0.0,christopher wilson,
-STAT,2220,007,Statistics in Everyd,0.28,0.5,0.17,0.06,0.0,0.0,0.0,0.0,christopher wilson,
-STAT,2300,001,Statistical Methods,0.37,0.29,0.14,0.13,0.04,0.0,0.0,0.03,richard stev dubsky,
-STAT,2300,002,Statistical Methods,0.46,0.29,0.16,0.05,0.0,0.0,0.0,0.04,richard stev dubsky,
-STAT,2300,003,Statistical Methods,0.48,0.27,0.11,0.04,0.07,0.0,0.0,0.02,ros martinez-dawson,
-STAT,2300,004,Statistical Methods,0.38,0.32,0.13,0.08,0.09,0.0,0.0,0.01,christy jenki brown,
-STAT,2300,005,Statistical Methods,0.3,0.33,0.28,0.06,0.0,0.0,0.0,0.04,christy jenki brown,
-STAT,2300,006,Statistical Methods,0.35,0.29,0.24,0.05,0.03,0.0,0.0,0.03,jun luo,
-STAT,2300,008,Statistical Methods,0.46,0.35,0.12,0.03,0.02,0.0,0.0,0.02,richard stev dubsky,
-STAT,2300,009,Statistical Methods,0.42,0.31,0.14,0.07,0.01,0.0,0.0,0.04,christy jenki brown,
-STAT,3090,001,Introductory Busines,0.16,0.32,0.16,0.14,0.14,0.0,0.0,0.08,paul james cubre,
-STAT,3090,002,Introductory Busines,0.05,0.42,0.37,0.11,0.05,0.0,0.0,0.0,emily marie nystrom,
-STAT,3090,003,Introductory Busines,0.11,0.22,0.44,0.0,0.17,0.0,0.0,0.06,ziwen cheng,
-STAT,3090,004,Introductory Busines,0.48,0.32,0.14,0.05,0.02,0.0,0.0,0.0,lucas waddell,
-STAT,3090,005,Introductory Busines,0.33,0.26,0.33,0.0,0.05,0.0,0.0,0.05,gary fellers,
-STAT,3090,006,Introductory Busines,0.21,0.32,0.26,0.11,0.11,0.0,0.0,0.0,emily marie nystrom,
-STAT,3090,007,Introductory Busines,0.16,0.53,0.16,0.11,0.0,0.0,0.0,0.05,janie caro mcdonald,
-STAT,3090,008,Introductory Busines,0.3,0.32,0.25,0.05,0.07,0.0,0.0,0.02,gary fellers,
-STAT,3090,009,Introductory Busines,0.22,0.39,0.11,0.11,0.06,0.0,0.0,0.11,hewa priyadarshani,
-STAT,3090,010,Introductory Busines,0.32,0.43,0.11,0.05,0.07,0.0,0.0,0.02,gary fellers,
-STAT,3090,011,Introductory Busines,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,janie caro mcdonald,
-STAT,3090,012,Introductory Busines,0.2,0.6,0.14,0.03,0.03,0.0,0.0,0.0,margaret mar wiecek,
-STAT,3090,013,Introductory Busines,0.27,0.36,0.24,0.04,0.07,0.0,0.0,0.02,gary fellers,
-STAT,3090,014,Introductory Busines,0.15,0.46,0.23,0.0,0.15,0.0,0.0,0.0,ziwen cheng,
-STAT,3090,015,Introductory Busines,0.16,0.42,0.11,0.26,0.05,0.0,0.0,0.0,tao yang,
-STAT,3090,016,Introductory Busines,0.26,0.32,0.11,0.11,0.05,0.0,0.0,0.16,tao yang,
-STAT,3090,017,Introductory Busines,0.22,0.39,0.22,0.11,0.06,0.0,0.0,0.0,hewa priyadarshani,
-STAT,3090,018,Introductory Busines,0.29,0.56,0.08,0.04,0.02,0.0,0.0,0.0,jennifer van dyken,
-STAT,3090,019,Introductory Busines,0.3,0.36,0.16,0.11,0.0,0.0,0.0,0.07,laura jane shick,
-STAT,3090,020,Introductory Busines,0.11,0.41,0.25,0.09,0.09,0.0,0.0,0.05,laura jane shick,
-STAT,4020,001,Intro to Statistical,0.56,0.22,0.17,0.06,0.0,0.0,0.0,0.0,julia lynn sharp,
-STAT,4110,001,Stat Mthds for Proce,0.39,0.39,0.17,0.06,0.0,0.0,0.0,0.0,james rieck,
-STAT,4110,002,Stat Mthds for Proce,0.19,0.29,0.26,0.13,0.13,0.0,0.0,0.0,patrick gerard,
-STAT,8010,001,Statistical Methods,0.48,0.43,0.04,0.0,0.0,0.0,0.0,0.04,william bridges,
-STAT,8010,003,Statistical Methods,0.39,0.29,0.16,0.0,0.13,0.0,0.0,0.03,james rieck,
-STAT,8010,004,Statistical Methods,0.31,0.26,0.31,0.0,0.06,0.0,0.0,0.06,julia lynn sharp,
-STAT,8020,001,Statistical Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-STAT,8020,001,Statistical Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,8050,001,Design & Anlys of Ex,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STS,1010,001,Survey of S T S,0.46,0.41,0.05,0.0,0.03,0.0,0.0,0.05,elizabeth stansell,
-STS,1010,002,Survey of S T S,0.36,0.39,0.22,0.03,0.0,0.0,0.0,0.0,thomas oberdan,
-STS,1010,003,Survey of S T S,0.89,0.08,0.0,0.0,0.03,0.0,0.0,0.0,scott brame,
-STS,1010,005,Survey of S T S,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,thomas oberdan,
-STS,1010,006,Survey of S T S,0.44,0.28,0.14,0.03,0.06,0.0,0.0,0.06,sarah mae cooper,
-STS,1010,007,Survey of S T S,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,annah kamugiz amani,
-STS,1010,008,Survey of S T S,0.27,0.45,0.15,0.03,0.0,0.0,0.0,0.09,david charles foltz,
-STS,1010,009,Survey of S T S,0.4,0.46,0.11,0.0,0.03,0.0,0.0,0.0,allison ann hinds,
-STS,1010,010,Survey of S T S,0.57,0.21,0.14,0.0,0.07,0.0,0.0,0.0,thomas oberdan,
-STS,1010,020,Survey of S T S,0.19,0.47,0.25,0.03,0.0,0.0,0.0,0.06,thomas oberdan,
-STS,2150,001,Crit Appr to Tech Re,0.32,0.32,0.27,0.05,0.0,0.0,0.0,0.05,thomas oberdan,
-THEA,2100,001,Theatre Appreciation,0.53,0.34,0.06,0.0,0.0,0.0,0.0,0.06,richard st. peter,
-THEA,2100,003,Theatre Appreciation,0.65,0.16,0.1,0.03,0.06,0.0,0.0,0.0,kendra lyne johnson,
-THEA,2100,004,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,
-THEA,2100,005,Theatre Appreciation,0.44,0.38,0.13,0.03,0.0,0.0,0.0,0.03,carol collins,
-THEA,2100,006,Theatre Appreciation,0.52,0.26,0.1,0.03,0.03,0.0,0.0,0.06,jason adkins,
-THEA,2780,001,Acting I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,
-THEA,3170,001,African-Amer Thea I,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,kendra lyne johnson,
-THEA,4720,001,Improvisation,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,
-THEA,6870,001,Stage Lighting I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
-WFB,3000,001,Wildlife Biology,0.36,0.43,0.11,0.07,0.02,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3000,002,Wildlife Biology,0.4,0.35,0.16,0.04,0.05,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3010,001,Wildlife Biology Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,
-WFB,3010,002,Wildlife Biology Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,4100,001,Wildlife Mgmt Tech,0.62,0.31,0.04,0.0,0.04,0.0,0.0,0.0,james davis,
-WFB,4100,002,Wildlife Mgmt Tech,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,james davis,
-WFB,4120,002,Wildlife Management,0.4,0.4,0.13,0.04,0.0,0.0,0.0,0.02,greg yarrow,
-WFB,4120,002,Wildlife Management,0.4,0.4,0.13,0.04,0.0,0.0,0.0,0.02,david sco jachowski,
-WFB,4180,001,Fishery Conservation,0.59,0.23,0.14,0.0,0.0,0.0,0.0,0.05,yoichiro kanno,
-WFB,4500,001,Aquaculture,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,
-WFB,4600,001,Warmwat Fish Disease,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,
-WFB,8610,200,Analysis of Ecologic,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,russell barrett,
-WS,1030,001,Women Global Perspec,0.75,0.14,0.06,0.06,0.0,0.0,0.0,0.0,saadiqa kumanyika,
-WS,2300,001,Women and Leadership,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,saadiqa kumanyika,
-WS,3010,001,Intro Women's Studie,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth ros adams,
-WS,3010,002,Intro Women's Studie,0.47,0.34,0.03,0.13,0.0,0.0,0.0,0.03,elizabeth ros adams,
-YDP,3000,400,Youth Development in,0.43,0.36,0.14,0.0,0.07,0.0,0.0,0.0,barry garst,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1010,001,Survey of Art & Arch,0.44,0.42,0.11,0.0,0.0,0.0,0.0,0.02,beth ann lauritis,,AAH-1010,2014
+AAH,2050,001,Art History and Theo,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.04,beth ann lauritis,,AAH-2050,2014
+AAH,2100,400,Intro to Art and Arc,0.23,0.42,0.12,0.12,0.08,0.0,0.0,0.04,lydia jane dorsey,,AAH-2100,2014
+AAH,2100,401,Intro to Art and Arc,0.45,0.34,0.14,0.07,0.0,0.0,0.0,0.0,lydia jane dorsey,,AAH-2100,2014
+AAH,2100,402,Intro to Art and Arc,0.28,0.4,0.16,0.08,0.0,0.0,0.0,0.08,lydia jane dorsey,,AAH-2100,2014
+AAH,2100,403,Intro to Art and Arc,0.39,0.43,0.0,0.04,0.07,0.0,0.0,0.07,lydia jane dorsey,,AAH-2100,2014
+AAH,3050,001,Contemporary Art His,0.6,0.2,0.13,0.0,0.0,0.0,0.0,0.07,andrea feeser,,AAH-3050,2014
+ACCT,2010,001,Financial Accounting,0.04,0.22,0.3,0.02,0.15,0.0,0.0,0.26,philip maiberger,,ACCT-2010,2014
+ACCT,2010,002,Financial Accounting,0.13,0.3,0.28,0.09,0.04,0.0,0.0,0.17,philip maiberger,,ACCT-2010,2014
+ACCT,2010,003,Financial Accounting,0.19,0.22,0.22,0.08,0.1,0.0,0.0,0.18,suzanne pearse,,ACCT-2010,2014
+ACCT,2010,004,Financial Accounting,0.3,0.3,0.2,0.05,0.07,0.0,0.0,0.09,suzanne pearse,,ACCT-2010,2014
+ACCT,2010,005,Fin Acct Concepts (H,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True,ACCT-2010,2014
+ACCT,2010,006,Financial Accounting,0.24,0.33,0.24,0.07,0.05,0.0,0.0,0.07,annieka philo,,ACCT-2010,2014
+ACCT,2010,007,Financial Accounting,0.24,0.27,0.11,0.08,0.16,0.0,0.0,0.14,lydia lan schleifer,,ACCT-2010,2014
+ACCT,2010,008,Financial Accounting,0.24,0.33,0.14,0.04,0.1,0.0,0.0,0.14,lydia lan schleifer,,ACCT-2010,2014
+ACCT,2010,009,Financial Accounting,0.12,0.34,0.24,0.07,0.1,0.0,0.0,0.12,annieka philo,,ACCT-2010,2014
+ACCT,2010,010,Financial Accounting,0.26,0.13,0.26,0.08,0.05,0.0,0.0,0.23,lydia lan schleifer,,ACCT-2010,2014
+ACCT,2010,011,Financial Accounting,0.2,0.18,0.25,0.15,0.05,0.0,0.0,0.18,james mil kohlmeyer,,ACCT-2010,2014
+ACCT,2010,012,Financial Accounting,0.27,0.24,0.27,0.12,0.02,0.0,0.0,0.07,james mil kohlmeyer,,ACCT-2010,2014
+ACCT,2010,013,Financial Accounting,0.19,0.43,0.16,0.1,0.03,0.0,0.0,0.09,the estate  guffey,,ACCT-2010,2014
+ACCT,2010,014,Financial Accounting,0.09,0.31,0.2,0.13,0.09,0.0,0.0,0.19,jeffrey mcmillan,,ACCT-2010,2014
+ACCT,2010,015,Financial Accounting,0.03,0.28,0.23,0.15,0.17,0.0,0.0,0.13,james mil kohlmeyer,,ACCT-2010,2014
+ACCT,2020,001,Managerial Accountin,0.18,0.31,0.2,0.06,0.08,0.0,0.0,0.18,henry anderson,,ACCT-2020,2014
+ACCT,2020,002,Managerial Accountin,0.23,0.28,0.19,0.04,0.09,0.0,0.0,0.17,henry anderson,,ACCT-2020,2014
+ACCT,2020,003,Managerial Accountin,0.17,0.37,0.25,0.1,0.06,0.0,0.0,0.06,annieka philo,,ACCT-2020,2014
+ACCT,2020,004,Managerial Accountin,0.24,0.27,0.25,0.12,0.08,0.0,0.0,0.04,annieka philo,,ACCT-2020,2014
+ACCT,2020,006,Managerial Accountin,0.57,0.22,0.14,0.0,0.02,0.0,0.0,0.06,sarah martin,,ACCT-2020,2014
+ACCT,2020,007,Managerial Accountin,0.14,0.21,0.31,0.03,0.12,0.0,0.0,0.21,henry anderson,,ACCT-2020,2014
+ACCT,2020,008,Managerial Accountin,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,sarah martin,,ACCT-2020,2014
+ACCT,2040,001,Accounting Procedure,0.53,0.25,0.08,0.02,0.02,0.0,0.0,0.11,jeffrey mcmillan,,ACCT-2040,2014
+ACCT,2040,002,Accounting Procedure,0.37,0.25,0.14,0.02,0.03,0.0,0.0,0.19,jeffrey mcmillan,,ACCT-2040,2014
+ACCT,3030,001,Cost Accounting,0.31,0.24,0.28,0.0,0.03,0.0,0.0,0.14,henry anderson,,ACCT-3030,2014
+ACCT,3030,002,Cost Accounting,0.22,0.35,0.22,0.05,0.11,0.0,0.0,0.05,henry anderson,,ACCT-3030,2014
+ACCT,3030,003,Cost Accounting,0.38,0.28,0.23,0.0,0.05,0.0,0.0,0.05,robin radtke,,ACCT-3030,2014
+ACCT,3030,005,Cost Accounting,0.28,0.35,0.13,0.03,0.1,0.0,0.0,0.13,robin radtke,,ACCT-3030,2014
+ACCT,3110,001,Intermed Financial A,0.5,0.31,0.13,0.06,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3110,2014
+ACCT,3110,002,Intermed Financial A,0.51,0.36,0.05,0.03,0.03,0.0,0.0,0.03,terry daniel knause,,ACCT-3110,2014
+ACCT,3110,003,Intermed Financial A,0.38,0.23,0.28,0.05,0.0,0.0,0.0,0.05,terry daniel knause,,ACCT-3110,2014
+ACCT,3110,005,Intermed Financial A,0.35,0.32,0.19,0.05,0.0,0.0,0.0,0.08,terry daniel knause,,ACCT-3110,2014
+ACCT,3120,001,Intermed Financial A,0.03,0.18,0.41,0.21,0.09,0.0,0.0,0.09,brian todd carver,,ACCT-3120,2014
+ACCT,3120,002,Intermed Financial A,0.17,0.3,0.26,0.09,0.07,0.0,0.0,0.11,suzanne pearse,,ACCT-3120,2014
+ACCT,3120,003,Intermed Financial A,0.05,0.18,0.37,0.18,0.08,0.0,0.0,0.13,brian todd carver,,ACCT-3120,2014
+ACCT,3120,004,Intermed Financial A,0.09,0.31,0.36,0.16,0.02,0.0,0.0,0.07,suzanne pearse,,ACCT-3120,2014
+ACCT,3130,001,Intermed Financial A,0.17,0.42,0.42,0.0,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2014
+ACCT,3130,002,Intermed Financial A,0.19,0.47,0.22,0.06,0.0,0.0,0.0,0.06, russell madray,,ACCT-3130,2014
+ACCT,3130,003,Intermed Financial A,0.21,0.47,0.24,0.0,0.05,0.0,0.0,0.03, russell madray,,ACCT-3130,2014
+ACCT,3130,005,Intermed Financial A,0.18,0.24,0.42,0.05,0.05,0.0,0.0,0.05, russell madray,,ACCT-3130,2014
+ACCT,3220,001,Accounting Informati,0.21,0.26,0.31,0.08,0.05,0.0,0.0,0.1,philip maiberger,,ACCT-3220,2014
+ACCT,3220,002,Accounting Informati,0.15,0.41,0.08,0.13,0.08,0.0,0.0,0.15,philip maiberger,,ACCT-3220,2014
+ACCT,3220,003,Accounting Informati,0.2,0.55,0.15,0.0,0.05,0.0,0.0,0.05,nancy lee harp,,ACCT-3220,2014
+ACCT,4040,002,Individual Taxation,0.36,0.36,0.24,0.02,0.0,0.0,0.0,0.02,derek dalton,,ACCT-4040,2014
+ACCT,4040,003,Individual Taxation,0.1,0.44,0.28,0.03,0.05,0.0,0.0,0.1,derek dalton,,ACCT-4040,2014
+ACCT,4080,001,Retire & Estate Plan,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,john hine,,ACCT-4080,2014
+ACCT,4100,001,Reporting and Mgmt C,0.34,0.42,0.18,0.03,0.0,0.0,0.0,0.03,sally kathr widener,,ACCT-4100,2014
+ACCT,4100,002,Reporting and Mgmt C,0.57,0.3,0.04,0.04,0.04,0.0,0.0,0.0,sally kathr widener,,ACCT-4100,2014
+ACCT,4150,001,Auditing,0.06,0.34,0.38,0.19,0.03,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2014
+ACCT,4150,002,Auditing,0.32,0.42,0.1,0.06,0.03,0.0,0.0,0.06,carl hollingsworth,,ACCT-4150,2014
+ACCT,8510,001,Tax Research,0.25,0.59,0.16,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2014
+ACCT,8510,002,Tax Research,0.06,0.79,0.12,0.0,0.03,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2014
+ACCT,8530,001,Adv Acct Problems,0.52,0.36,0.09,0.0,0.0,0.0,0.0,0.03,ralph welton,,ACCT-8530,2014
+ACCT,8530,002,Adv Acct Problems,0.48,0.42,0.03,0.0,0.06,0.0,0.0,0.0,ralph welton,,ACCT-8530,2014
+ACCT,8550,001,Gov't and Nonprofit,0.59,0.35,0.03,0.0,0.03,0.0,0.0,0.0,james barnes,,ACCT-8550,2014
+ACCT,8550,002,Gov't and Nonprofit,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2014
+ACCT,8630,001,Forensics Analysis,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,james irving,,ACCT-8630,2014
+ACCT,8630,002,Forensics Analysis,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,james irving,,ACCT-8630,2014
+ACCT,8630,003,Forensics Analysis,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,james irving,,ACCT-8630,2014
+ACCT,8730,001,Intl/Spec Tax Topic,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,judson jahn,,ACCT-8730,2014
+ACCT,8730,002,Intl/Spec Tax Topic,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,judson jahn,,ACCT-8730,2014
+AGED,1020,001,Freshman Seminar,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,christina mel leard,,AGED-1020,2014
+AGED,2010,001,Intro to Agric Educ,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2010,2014
+AGED,2040,001,App Ag Calculations,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2040,2014
+AGED,3030,001,Ag Ed Mech Tech,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-3030,2014
+AGED,3650,001,Multiculturalism in,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,alex byrd,,AGED-3650,2014
+AGED,4010,001,Instr Methods Ag Ed,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,thomas dobbins,,AGED-4010,2014
+AGED,4010,001,Instr Methods Ag Ed,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,,AGED-4010,2014
+AGED,4030,001,Prin Adult/Ext Ed,0.55,0.1,0.2,0.0,0.05,0.0,0.0,0.1,freddie waltz,,AGED-4030,2014
+AGED,4230,400,Curriculum,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,,AGED-4230,2014
+AGED,6010,001,Instr Methods Ag Ed,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,kevin layfield,,AGED-6010,2014
+AGED,6010,001,Instr Methods Ag Ed,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,thomas dobbins,,AGED-6010,2014
+AGM,1010,001,Intro Ag Mech & Bus,0.64,0.25,0.07,0.02,0.02,0.0,0.0,0.0,hunter massey,,AGM-1010,2014
+AGM,2050,001,Prin of Fabrication,0.15,0.52,0.28,0.01,0.01,0.0,0.0,0.01,hunter massey,,AGM-2050,2014
+AGM,2060,001,Machinery Mgt,0.15,0.4,0.3,0.15,0.0,0.0,0.0,0.0,hunter massey,,AGM-2060,2014
+AGM,2190,001,Agribuxiness and Foo,0.24,0.45,0.29,0.02,0.0,0.0,0.0,0.0,wilder ferreira,,AGM-2190,2014
+AGM,2210,001,Land Measurements,0.44,0.4,0.12,0.01,0.03,0.0,0.0,0.0,charles privette,,AGM-2210,2014
+AGM,3010,001,Soil Water Conserv,0.29,0.41,0.14,0.1,0.06,0.0,0.0,0.0,calvin sawyer,,AGM-3010,2014
+AGM,3190,001,Agribusiness Decisio,0.38,0.28,0.22,0.13,0.0,0.0,0.0,0.0,wilder ferreira,,AGM-3190,2014
+AGM,4050,001,Env Cont in Anim Str,0.38,0.56,0.05,0.0,0.0,0.0,0.0,0.0,john chastain,,AGM-4050,2014
+AGM,4060,001,Mech & Hydraulic Sys,0.42,0.45,0.12,0.0,0.0,0.0,0.0,0.0,young han,,AGM-4060,2014
+AGM,4600,001,Electrical Systems,0.42,0.52,0.06,0.0,0.0,0.0,0.0,0.0,young han,,AGM-4600,2014
+AL,3490,400,Principles of Coachi,0.36,0.4,0.12,0.04,0.0,0.0,0.0,0.08,deborah cadorette,,AL-3490,2014
+AL,3490,401,Principles of Coachi,0.52,0.33,0.15,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2014
+AL,3490,402,Principles of Coachi,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,,AL-3490,2014
+AL,3490,403,Principles of Coachi,0.41,0.35,0.0,0.18,0.06,0.0,0.0,0.0,clyde keith connor,,AL-3490,2014
+AL,3500,400,Sci Basis I/Ex Phy,0.22,0.44,0.26,0.04,0.04,0.0,0.0,0.0,michael godfrey,,AL-3500,2014
+AL,3500,401,Sci Basis I/Ex Phy,0.28,0.12,0.16,0.32,0.08,0.0,0.0,0.04,michael godfrey,,AL-3500,2014
+AL,3520,400,Kinesiology,0.29,0.21,0.21,0.14,0.14,0.0,0.0,0.0,michael godfrey,,AL-3520,2014
+AL,3530,400,Athletic Injuries,0.16,0.47,0.21,0.11,0.05,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2014
+AL,3530,401,Athletic Injuries,0.15,0.25,0.15,0.35,0.1,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2014
+AL,3600,400,Hgh Sch Athl Ethical,0.43,0.25,0.18,0.07,0.04,0.0,0.0,0.04,clyde keith connor,,AL-3600,2014
+AL,3610,400,Admin/Org of Athleti,0.73,0.19,0.04,0.0,0.04,0.0,0.0,0.0,henry oates,,AL-3610,2014
+AL,3610,401,Admin/Org of Athleti,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2014
+AL,3610,402,Admin/Org of Athleti,0.8,0.12,0.0,0.0,0.04,0.0,0.0,0.04,henry oates,,AL-3610,2014
+AL,3620,400,Psychology of Coachi,0.28,0.28,0.24,0.12,0.04,0.0,0.0,0.04,natalie anne carter,,AL-3620,2014
+AL,3620,401,Psychology of Coachi,0.24,0.2,0.44,0.12,0.0,0.0,0.0,0.0,natalie anne carter,,AL-3620,2014
+AL,3740,400,Coaching Football,0.67,0.07,0.0,0.19,0.0,0.0,0.0,0.07,edmond fry,,AL-3740,2014
+AL,3760,400,Coaching Strength/Co,0.79,0.08,0.04,0.08,0.0,0.0,0.0,0.0,edmond fry,,AL-3760,2014
+AL,3760,401,Coaching Strength/Co,0.42,0.21,0.05,0.16,0.05,0.0,0.0,0.11,edmond fry,,AL-3760,2014
+AL,4380,400,Coach & Athlete in E,0.5,0.14,0.29,0.07,0.0,0.0,0.0,0.0,deborah cadorette,,AL-4380,2014
+AL,8490,400,Athletic Leadership,0.52,0.35,0.04,0.0,0.04,0.0,0.0,0.04,michael godfrey,,AL-8490,2014
+ANTH,2010,001,Intro Anthropology,0.07,0.17,0.32,0.19,0.08,0.0,0.0,0.18,john coggeshall,,ANTH-2010,2014
+ANTH,2010,001,Introduction to Anth,0.07,0.17,0.32,0.19,0.08,0.0,0.0,0.18,john coggeshall,,ANTH-2010,2014
+ANTH,2010,002,Intro Anthropology,0.15,0.21,0.29,0.21,0.08,0.0,0.0,0.06,john coggeshall,,ANTH-2010,2014
+ANTH,2010,002,Introduction to Anth,0.15,0.21,0.29,0.21,0.08,0.0,0.0,0.06,john coggeshall,,ANTH-2010,2014
+ANTH,2010,003,Introduction to Anth,0.24,0.59,0.08,0.04,0.02,0.0,0.0,0.02,katherine weisensee,,ANTH-2010,2014
+ANTH,2010,003,Intro Anthropology,0.24,0.59,0.08,0.04,0.02,0.0,0.0,0.02,katherine weisensee,,ANTH-2010,2014
+ANTH,2010,004,Introduction to Anth,0.17,0.44,0.18,0.07,0.0,0.0,0.0,0.15,melissa vogel,,ANTH-2010,2014
+ANTH,2010,004,Intro Anthropology,0.17,0.44,0.18,0.07,0.0,0.0,0.0,0.15,melissa vogel,,ANTH-2010,2014
+ANTH,2010,005,Introduction to Anth,0.29,0.4,0.18,0.0,0.04,0.0,0.0,0.09,lisa rapaport,,ANTH-2010,2014
+ANTH,2010,005,Intro Anthropology,0.29,0.4,0.18,0.0,0.04,0.0,0.0,0.09,lisa rapaport,,ANTH-2010,2014
+ANTH,3010,001,Cultural Anthropolog,0.18,0.35,0.24,0.06,0.06,0.0,0.0,0.12,john coggeshall,,ANTH-3010,2014
+ANTH,3320,001,World Archaeology,0.21,0.32,0.21,0.16,0.05,0.0,0.0,0.05,melissa vogel,,ANTH-3320,2014
+ANTH,3510,001,Biological Anthropol,0.2,0.53,0.13,0.0,0.0,0.0,0.0,0.13,lisa rapaport,,ANTH-3510,2014
+ANTH,3530,001,Forensic Anthropolog,0.3,0.57,0.09,0.04,0.0,0.0,0.0,0.0,katherine weisensee,,ANTH-3530,2014
+ANTH,4660,001,Evolution of Human B,0.4,0.3,0.1,0.0,0.0,0.0,0.0,0.2,lisa rapaport,,ANTH-4660,2014
+ANTH,4960,003,Creative Inquiry,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,sharon nagy,,ANTH-4960,2014
+APEC,2020,001,Agric Economics,0.28,0.3,0.33,0.03,0.04,0.0,0.0,0.01,webb smathers,,APEC-2020,2014
+APEC,2020,002,Agric Economics,0.14,0.28,0.28,0.17,0.0,0.0,0.0,0.14,david brian willis,,APEC-2020,2014
+APEC,2050,001,Agric and Society,0.3,0.47,0.23,0.0,0.0,0.0,0.0,0.0,michael vassalos,,APEC-2050,2014
+APEC,2570,001,Nat Res Env Econ,0.15,0.27,0.3,0.12,0.05,0.0,0.0,0.12,david brian willis,,APEC-2570,2014
+APEC,3020,001,Econ of Farm Mgt,0.31,0.37,0.31,0.0,0.0,0.0,0.0,0.0,michael vassalos,,APEC-3020,2014
+APEC,3090,001,Econ Agric Marketing,0.73,0.09,0.16,0.0,0.0,0.0,0.0,0.02,yuliya val bolotova,,APEC-3090,2014
+APEC,3510,001,Prin of Advertising,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,webb smathers,,APEC-3510,2014
+APEC,3610,001,Int Health Care Econ,0.47,0.41,0.06,0.06,0.0,0.0,0.0,0.0,khoa dang truong,,APEC-3610,2014
+APEC,4900,002,CAFLS Plus Prof. Dev,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,thomas scott,,APEC-4900,2014
+ARAB,1010,001,Elementary Arabic I,0.59,0.18,0.0,0.0,0.0,0.0,0.0,0.24,sulafa abou-samra,,ARAB-1010,2014
+ARCH,1010,001,Intro to Arch,0.56,0.36,0.03,0.0,0.01,0.0,0.0,0.05,sal hambright-belue,,ARCH-1010,2014
+ARCH,2040,001,Hist of Modern Arch,0.38,0.25,0.35,0.03,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-2040,2014
+ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-2510,2014
+ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,marianne her glaser,,ARCH-2510,2014
+ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-2510,2014
+ARCH,2510,002,Arch Foundations I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-2510,2014
+ARCH,2510,002,Arch Foundations I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,marianne her glaser,,ARCH-2510,2014
+ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2510,2014
+ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2510,2014
+ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,marianne her glaser,,ARCH-2510,2014
+ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,marianne her glaser,,ARCH-2510,2014
+ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,annemarie jacques,,ARCH-2510,2014
+ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,annemarie jacques,,ARCH-2510,2014
+ARCH,2700,001,Structures I,0.42,0.33,0.08,0.08,0.08,0.0,0.0,0.0,dustin gra albright,,ARCH-2700,2014
+ARCH,3510,001,Studio Clemson,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,robert john hogan,,ARCH-3510,2014
+ARCH,3510,002,Studio Clemson,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-3510,2014
+ARCH,3510,002,Studio Clemson,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,robert john hogan,,ARCH-3510,2014
+ARCH,3510,003,Studio Clemson,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,robert john hogan,,ARCH-3510,2014
+ARCH,3510,003,Studio Clemson,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,criss mills,,ARCH-3510,2014
+ARCH,3530,001,Studio Genoa,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-3530,2014
+ARCH,3540,001,Studio Barcelona,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-3540,2014
+ARCH,3540,001,Studio Barcelona,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-3540,2014
+ARCH,4010,001,Arch Portfolio,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,martha skinner,,ARCH-4010,2014
+ARCH,4010,002,Arch Portfolio,0.33,0.29,0.29,0.05,0.0,0.0,0.0,0.05,arash soleimani,,ARCH-4010,2014
+ARCH,4120,001,History Research,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-4120,2014
+ARCH,4120,002,History Research,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4120,2014
+ARCH,4120,002,History Research,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-4120,2014
+ARCH,4140,001,Design Seminar,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-4140,2014
+ARCH,4160,002,Field Studies,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4160,2014
+ARCH,4160,002,Field Studies,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-4160,2014
+ARCH,6290,002,Arch Graphics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lloyd bray,,ARCH-6290,2014
+ARCH,6850,001,H/Th: Arch+Health,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-6850,2014
+ARCH,8210,001,Research Methods,0.63,0.35,0.0,0.0,0.0,0.0,0.0,0.03,dina battisto,,ARCH-8210,2014
+ARCH,8410,001,Arch Studio I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,,ARCH-8410,2014
+ARCH,8410,002,Arch Studio I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,junichi satoh,,ARCH-8410,2014
+ARCH,8510,001,Design Studio III,0.09,0.82,0.0,0.0,0.0,0.0,0.0,0.09,ulrike ann-so heine,,ARCH-8510,2014
+ARCH,8510,001,Design Studio III,0.09,0.82,0.0,0.0,0.0,0.0,0.0,0.09,dustin gra albright,,ARCH-8510,2014
+ARCH,8510,002,Design Studio III,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,,ARCH-8510,2014
+ARCH,8510,003,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,,ARCH-8510,2014
+ARCH,8510,003,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8510,2014
+ARCH,8510,004,Design Studio III,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,dustin gra albright,,ARCH-8510,2014
+ARCH,8510,004,Design Studio III,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-8510,2014
+ARCH,8600,001,History/Theory I,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,ufuk ersoy,,ARCH-8600,2014
+ARCH,8720,001,Production & Assemb,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,daniel nevi harding,,ARCH-8720,2014
+ARCH,8720,001,Production & Assemb,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02, franco santa cruz,,ARCH-8720,2014
+ARCH,8790,002,Digtial Manufacturin,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,,ARCH-8790,2014
+ARCH,8810,001,Pro Practice Survey,0.64,0.33,0.0,0.0,0.0,0.0,0.0,0.03,katherin schwennsen,,ARCH-8810,2014
+ARCH,8890,001,Mentorship,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,,ARCH-8890,2014
+ARCH,8950,001,A+H Studio: Projects,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-8950,2014
+ARCH,8950,001,A+H Studio: Projects,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8950,2014
+ART,1050,001,Foundation Drawing I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,,ART-1050,2014
+ART,1510,001,Foundations Art I,0.8,0.07,0.07,0.07,0.0,0.0,0.0,0.0,alexandra giannell,,ART-1510,2014
+ART,2070,001,Beginning Painting,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,hilary erin siber,,ART-2070,2014
+ART,2110,001,Begin Printmaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,laken grace bridges,,ART-2110,2014
+ART,2130,001,Begin Photography,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,anderson wrangle,,ART-2130,2014
+ART,2170,001,Beginning Ceramics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,nina jeanette kawar,,ART-2170,2014
+ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,,ART-3550,2014
+ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,,ART-3550,2014
+ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,david detrich,,ART-3550,2014
+ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david detrich,,ART-4550,2014
+ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,,ART-4550,2014
+ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,,ART-4550,2014
+ART,8210,001,Visual Narrative,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,,ART-8210,2014
+AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,christopher mann,,AS-1090,2014
+AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,stacey dean wiggins,,AS-1090,2014
+AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,steven price jordan,,AS-1090,2014
+AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,steven price jordan,,AS-1090,2014
+AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher mann,,AS-1090,2014
+AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,stacey dean wiggins,,AS-1090,2014
+AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,stacey dean wiggins,,AS-1090,2014
+AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,christopher mann,,AS-1090,2014
+AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,steven price jordan,,AS-1090,2014
+AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,,AS-1090,2014
+AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,,AS-1090,2014
+AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steven price jordan,,AS-1090,2014
+AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,steven price jordan,,AS-2090,2014
+AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,christopher mann,,AS-2090,2014
+AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,,AS-2090,2014
+AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,,AS-2090,2014
+AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,steven price jordan,,AS-2090,2014
+AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,,AS-2090,2014
+ASL,1010,003,Am Sign Lang I,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,joseph paul may,,ASL-1010,2014
+ASL,2010,001,Am Sign Lang II,0.28,0.44,0.28,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-2010,2014
+ASL,2010,002,Am Sign Lang II,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-2010,2014
+ASL,2020,001,Am Sign Lang II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-2020,2014
+ASL,3000,001,Fingerspelling & Num,0.23,0.46,0.23,0.08,0.0,0.0,0.0,0.0,joseph paul may,,ASL-3000,2014
+ASTR,1010,001,SolarSystem Astr,0.42,0.36,0.17,0.0,0.01,0.0,0.0,0.04,phillip flower,,ASTR-1010,2014
+ASTR,1010,002,Solar System Astr,0.5,0.28,0.17,0.01,0.01,0.0,0.0,0.04,phillip flower,,ASTR-1010,2014
+ASTR,1010,003,Solar System Astr,0.45,0.34,0.17,0.0,0.02,0.0,0.0,0.02,phillip flower,,ASTR-1010,2014
+ASTR,1030,001,Solar Systm Astr Lab,0.67,0.17,0.0,0.04,0.04,0.0,0.0,0.08,mark leising,,ASTR-1030,2014
+ASTR,1030,002,Solar Systm Astr Lab,0.28,0.52,0.08,0.0,0.04,0.0,0.0,0.08,mark leising,,ASTR-1030,2014
+ASTR,1030,003,Solar Systm Astr Lab,0.57,0.26,0.09,0.0,0.0,0.0,0.0,0.09,mark leising,,ASTR-1030,2014
+ASTR,1030,004,Solar Systm Astr Lab,0.62,0.27,0.04,0.0,0.08,0.0,0.0,0.0,mark leising,,ASTR-1030,2014
+ASTR,1030,005,Solar Systm Astr Lab,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,,ASTR-1030,2014
+ASTR,1030,006,Solar Systm Astr Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,,ASTR-1030,2014
+ASTR,1030,007,Solar Systm Astr Lab,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,mark leising,,ASTR-1030,2014
+ASTR,1030,008,Solar Systm Astr Lab,0.48,0.28,0.04,0.0,0.16,0.0,0.0,0.04,mark leising,,ASTR-1030,2014
+ASTR,1030,009,Solar Systm Astr Lab,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,mark leising,,ASTR-1030,2014
+AUD,1850,001,Intro to Audio Tech,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-1850,2014
+AUD,2800,001,Sound Reinforcement,0.2,0.27,0.33,0.07,0.07,0.0,0.0,0.07,kenneth moore,,AUD-2800,2014
+AUD,3800,001,Audio Engineering I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-3800,2014
+AUE,8270,005,Auto Cntrl Sys Des,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,beshah ayalew,,AUE-8270,2014
+AUE,8330,003,Auto Manuf Proc Devl,0.42,0.39,0.15,0.0,0.03,0.0,0.0,0.01,fadi kama abu-farha,,AUE-8330,2014
+AUE,8350,100,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,john david smith,,AUE-8350,2014
+AUE,8350,100,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,simona onori,,AUE-8350,2014
+AUE,8670,001,Veh Manuf Proc I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8670,2014
+AUE,8800,002,Vehicle Project Mngt,0.81,0.18,0.0,0.0,0.0,0.0,0.0,0.01,imtiaz ul haque,,AUE-8800,2014
+AUE,8810,003,Automotive Systems O,0.18,0.79,0.01,0.0,0.0,0.0,0.0,0.01,paul venhovens,,AUE-8810,2014
+AUE,8810,003,Automotive Systems O,0.18,0.79,0.01,0.0,0.0,0.0,0.0,0.01,johnell brooks,,AUE-8810,2014
+AUE,8830,009,Applied Integration,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,johnell brooks,,AUE-8830,2014
+AUE,8830,009,Applied Integration,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,,AUE-8830,2014
+AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,douglas feldmaier,,AUE-8870,2014
+AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,michael messman,,AUE-8870,2014
+AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,imtiaz ul haque,,AUE-8870,2014
+AUE,8930,013,Engine Analysis,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8930,2014
+AUE,8930,014,Automotive Composite,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,david wil schmueser,,AUE-8930,2014
+AUE,8930,014,Automotive Composite,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,srikanth pilla,,AUE-8930,2014
+AUE,8930,017,Hybrid,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,simona onori,,AUE-8930,2014
+AUE,8930,018,Adv IC Engine Concep,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,zoran filipi,,AUE-8930,2014
+AUE,8930,019,Innov & Sys Entrepre,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,,AUE-8930,2014
+AVS,1000,001,Orientation to Avs,0.84,0.14,0.01,0.0,0.0,0.0,0.0,0.02,johanna joh lascano,,AVS-1000,2014
+AVS,1500,001,Intro Animal Science,0.18,0.41,0.3,0.03,0.03,0.0,0.0,0.05,heather walker dunn,,AVS-1500,2014
+AVS,1500,002,Intro Animal Science,0.2,0.49,0.25,0.05,0.0,0.0,0.0,0.01,brian bolt,,AVS-1500,2014
+AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,brian bolt,,AVS-1510,2014
+AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,richelle lor miller,,AVS-1510,2014
+AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,anna rebecca baxley,,AVS-1510,2014
+AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,heather walker dunn,,AVS-1510,2014
+AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,heather walker dunn,,AVS-1510,2014
+AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,brian bolt,,AVS-1510,2014
+AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,anna rebecca baxley,,AVS-1510,2014
+AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,richelle lor miller,,AVS-1510,2014
+AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-1510,2014
+AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-1510,2014
+AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,brian bolt,,AVS-1510,2014
+AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,,AVS-1510,2014
+AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-1510,2014
+AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,,AVS-1510,2014
+AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,brian bolt,,AVS-1510,2014
+AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-1510,2014
+AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-1510,2014
+AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-1510,2014
+AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,brian bolt,,AVS-1510,2014
+AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,,AVS-1510,2014
+AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,heather walker dunn,,AVS-1510,2014
+AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,brian bolt,,AVS-1510,2014
+AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,anna rebecca baxley,,AVS-1510,2014
+AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,richelle lor miller,,AVS-1510,2014
+AVS,2010,001,Poultry Techniques,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-2010,2014
+AVS,2030,001,Dairy Sci Techniques,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.02,heather walker dunn,,AVS-2030,2014
+AVS,2040,001,Horse Care Technique,0.52,0.3,0.13,0.04,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-2040,2014
+AVS,2050,001,Horsemanship Techniq,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,meredith donaldson,,AVS-2050,2014
+AVS,2050,001,Horsemanship Techniq,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,,AVS-2050,2014
+AVS,2060,001,Swine Techniques,0.59,0.33,0.08,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-2060,2014
+AVS,2110,001,Meat Processing Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,brian bolt,,AVS-2110,2014
+AVS,2110,001,Meat Processing Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-2110,2014
+AVS,3010,001,Anat & Phys Dom Ani,0.34,0.32,0.2,0.08,0.05,0.0,0.0,0.01,glenn birrenkott,,AVS-3010,2014
+AVS,3010,400,Anat & Phys Dom Ani,0.27,0.45,0.23,0.0,0.05,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2014
+AVS,3020,001,Livestk Sel Eval I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-3020,2014
+AVS,3090,001,Equine Evaluation,0.49,0.37,0.05,0.07,0.0,0.0,0.0,0.02,kristine lan vernon,,AVS-3090,2014
+AVS,3100,001,Animal Health,0.47,0.26,0.11,0.03,0.0,0.0,0.0,0.14,richard bruner,,AVS-3100,2014
+AVS,3700,001,Prin Animal Nutr,0.24,0.25,0.16,0.24,0.1,0.0,0.0,0.02,nathan long,,AVS-3700,2014
+AVS,4000,001,AVS Professional Dev,0.69,0.2,0.03,0.03,0.06,0.0,0.0,0.0,james ro strickland,,AVS-4000,2014
+AVS,4000,001,AVS Professional Dev,0.69,0.2,0.03,0.03,0.06,0.0,0.0,0.0,johanna joh lascano,,AVS-4000,2014
+AVS,4060,001,Seminars & Relat Top,0.79,0.18,0.0,0.04,0.0,0.0,0.0,0.0,johanna joh lascano,,AVS-4060,2014
+AVS,4060,001,Seminars & Relat Top,0.79,0.18,0.0,0.04,0.0,0.0,0.0,0.0,james ro strickland,,AVS-4060,2014
+AVS,4060,002,Seminars & Relat Top,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,james ro strickland,,AVS-4060,2014
+AVS,4060,002,Seminars & Relat Top,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,,AVS-4060,2014
+AVS,4150,001,Contemp Issues Avs,0.1,0.38,0.38,0.06,0.03,0.0,0.0,0.05,peter skewes,,AVS-4150,2014
+AVS,4160,001,Equine Exercise Phys,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,kristine lan vernon,,AVS-4160,2014
+AVS,4700,001,Anim Genetics,0.71,0.2,0.06,0.04,0.0,0.0,0.0,0.0,brian bolt,,AVS-4700,2014
+AVS,8080,400,Monogastric Nutritio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,,AVS-8080,2014
+AVS,8200,001,Graduate Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,,AVS-8200,2014
+BCHM,1030,001,Careers in Bioch/Gen,0.87,0.1,0.04,0.0,0.0,0.0,0.0,0.0,alison starr-moss,,BCHM-1030,2014
+BCHM,3050,001,Essen Elements Bioch,0.2,0.32,0.2,0.12,0.03,0.0,0.0,0.12,srik chandrasekaran,,BCHM-3050,2014
+BCHM,3050,002,Essen Elements Bioch,0.26,0.32,0.22,0.11,0.04,0.0,0.0,0.04,srik chandrasekaran,,BCHM-3050,2014
+BCHM,4060,001,Physiological Chem,0.53,0.26,0.13,0.02,0.02,0.0,0.0,0.04,ashby burges bodine,,BCHM-4060,2014
+BCHM,4310,001,Phys App to Bioch,0.22,0.27,0.27,0.14,0.03,0.0,0.0,0.08,weiguo cao,,BCHM-4310,2014
+BCHM,4310,002,Phys App to Bioch (H,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True,BCHM-4310,2014
+BCHM,4330,001,Gen Bioch Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,,BCHM-4330,2014
+BCHM,4330,002,Gen Bioch Lab I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,weiguo cao,,BCHM-4330,2014
+BCHM,4400,001,Bioinformatics,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,,BCHM-4400,2014
+BCHM,4430,001,Mol Basis Disease,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,kerry smith,,BCHM-4430,2014
+BCHM,4430,001,Mol Basis Disease,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james morris,,BCHM-4430,2014
+BE,2120,001,Fundamentals of Bios,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-2120,2014
+BE,3200,001,Principles & Prac of,0.45,0.32,0.18,0.05,0.0,0.0,0.0,0.0,tom owino,,BE-3200,2014
+BE,4100,001,Biological Kinetics,0.4,0.3,0.25,0.05,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4100,2014
+BE,4150,001,Instr & Control Be,0.27,0.41,0.23,0.05,0.05,0.0,0.0,0.0,yi zheng,,BE-4150,2014
+BE,4280,001,Biochem Engr,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4280,2014
+BE,4740,001,B E Design/Proj Mgt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-4740,2014
+BE,4750,001,B E Capstone Design,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4750,2014
+BE,4750,001,B E Capstone Design,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4750,2014
+BIOE,2010,001,Intro Biomed Engr,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,charles webb,,BIOE-2010,2014
+BIOE,2010,001,Intro Biomed Engr,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,frank alexis,,BIOE-2010,2014
+BIOE,2010,002,Intro Biomed Engr,0.59,0.34,0.03,0.0,0.02,0.0,0.0,0.02,charles webb,,BIOE-2010,2014
+BIOE,2010,002,Intro Biomed Engr,0.59,0.34,0.03,0.0,0.02,0.0,0.0,0.02,frank alexis,,BIOE-2010,2014
+BIOE,3020,001,Biomaterials,0.49,0.3,0.15,0.0,0.02,0.0,0.0,0.04,vladimir vla reukov,,BIOE-3020,2014
+BIOE,3200,001,Biomechanics,0.58,0.31,0.08,0.02,0.0,0.0,0.0,0.02,lisa benson,,BIOE-3200,2014
+BIOE,3210,001,Biofluid Mechanics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,zhi gao,,BIOE-3210,2014
+BIOE,3700,001,Bioinst & Imaging,0.67,0.3,0.02,0.0,0.0,0.0,0.0,0.02,delphine dean,,BIOE-3700,2014
+BIOE,3700,002,Bioinst & Imaging,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,david kwartowitz,,BIOE-3700,2014
+BIOE,4010,001,Bio E Design Theory,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4010,2014
+BIOE,4030,001,Applied Bio E Design,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,jorge iva rodriguez,,BIOE-4030,2014
+BIOE,4030,001,Applied Bio E Design,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,jeremy mercuri,,BIOE-4030,2014
+BIOE,4120,001,Orthopaedic Engr and,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,melinda harman,,BIOE-4120,2014
+BIOE,4400,001,Biotech for Bio E,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,sarah harcum,,BIOE-4400,2014
+BIOE,4510,007,CI Fr/Sr Design and,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,jorge iva rodriguez,,BIOE-4510,2014
+BIOE,4510,007,CI Fr/Sr Design and,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john desjardins,,BIOE-4510,2014
+BIOE,4510,022,CI- Mobile Health Ap,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,vladimir vla reukov,,BIOE-4510,2014
+BIOE,4510,022,CI- Mobile Health Ap,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,ilya mark safro,,BIOE-4510,2014
+BIOE,4510,029,CI- The DEN,0.74,0.0,0.0,0.0,0.0,0.0,0.0,0.26,john desjardins,,BIOE-4510,2014
+BIOE,6120,001,Orthopaedic Engr & P,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,melinda harman,,BIOE-6120,2014
+BIOE,6150,001,Research Principles,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.02,sarah harcum,,BIOE-6150,2014
+BIOE,6400,001,Biotech for Bio E,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,sarah harcum,,BIOE-6400,2014
+BIOE,8010,001,Bio Materials,0.33,0.64,0.02,0.0,0.0,0.0,0.0,0.0,robert latour,,BIOE-8010,2014
+BIOE,8140,401,Medical Dev Commerci,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,,BIOE-8140,2014
+BIOE,8140,401,Medical Dev Commerci,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew ray gevaert,,BIOE-8140,2014
+BIOE,8200,001,Structl Biomechanics,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,hai yao,,BIOE-8200,2014
+BIOL,1010,001,Frontiers in Biology,0.68,0.21,0.06,0.02,0.02,0.0,0.0,0.01,robert edwa ballard,,BIOL-1010,2014
+BIOL,1010,001,Frontiers in Biology,0.68,0.21,0.06,0.02,0.02,0.0,0.0,0.01,michael childress,,BIOL-1010,2014
+BIOL,1030,001,General Biology I,0.25,0.24,0.27,0.07,0.09,0.0,0.0,0.09,nora espinoza,,BIOL-1030,2014
+BIOL,1030,002,General Biology I,0.49,0.29,0.14,0.02,0.02,0.0,0.0,0.03,renea chri hardwick,,BIOL-1030,2014
+BIOL,1030,004,General Biology I,0.15,0.16,0.3,0.13,0.15,0.0,0.0,0.11,salvatore sparace,,BIOL-1030,2014
+BIOL,1030,005,General Biology I,0.17,0.27,0.25,0.18,0.05,0.0,0.0,0.07,matthew turnbull,,BIOL-1030,2014
+BIOL,1030,006,General Biology I,0.26,0.38,0.21,0.08,0.05,0.0,0.0,0.02,kristi ja whitehead,,BIOL-1030,2014
+BIOL,1030,007,General Biology I (H,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,nora espinoza,True,BIOL-1030,2014
+BIOL,1030,008,General Biology I,0.29,0.25,0.25,0.11,0.03,0.0,0.0,0.07,william surver,,BIOL-1030,2014
+BIOL,1050,001,General Biology Lab,0.41,0.36,0.09,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,002,General Biology Lab,0.45,0.32,0.05,0.0,0.14,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,003,General Biology Lab,0.45,0.23,0.18,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,004,General Biology Lab,0.36,0.32,0.14,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,005,General Biology Lab,0.59,0.23,0.05,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,006,General Biology Lab,0.23,0.5,0.14,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,007,General Biology Lab,0.36,0.27,0.05,0.09,0.09,0.0,0.0,0.14,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,008,General Biology Lab,0.55,0.23,0.14,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,009,General Biology Lab,0.3,0.3,0.1,0.05,0.1,0.0,0.0,0.15,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,010,General Biology Lab,0.26,0.39,0.22,0.0,0.09,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,011,General Biology Lab,0.38,0.21,0.25,0.08,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,012,General Biology Lab,0.33,0.38,0.13,0.0,0.08,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,013,General Biology Lab,0.68,0.14,0.05,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,014,General Biology Lab,0.32,0.41,0.18,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,015,General Biology Lab,0.29,0.48,0.1,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,016,General Biology Lab,0.42,0.42,0.04,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,017,General Biology Lab,0.5,0.36,0.0,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,018,General Biology Lab,0.32,0.41,0.23,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,019,General Biology Lab,0.43,0.35,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,020,General Biology Lab,0.39,0.3,0.17,0.0,0.04,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,021,General Biology Lab,0.43,0.17,0.13,0.09,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,022,General Biology Lab,0.5,0.36,0.09,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,023,General Biology Lab,0.5,0.2,0.1,0.05,0.05,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,024,General Biology Lab,0.37,0.37,0.05,0.16,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,025,General Biology Lab,0.36,0.36,0.23,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,026,General Biology Lab,0.52,0.22,0.22,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,027,General Biology Lab,0.27,0.55,0.09,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,028,General Biology Lab,0.64,0.23,0.14,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,029,General Biology Lab,0.36,0.5,0.05,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,030,General Biology Lab,0.5,0.32,0.0,0.0,0.0,0.0,0.0,0.18,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,031,General Biology Lab,0.32,0.23,0.27,0.05,0.0,0.0,0.0,0.14,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,032,General Biology Lab,0.38,0.24,0.1,0.0,0.14,0.0,0.0,0.14,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,033,General Biology Lab,0.42,0.16,0.0,0.05,0.16,0.0,0.0,0.21,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,034,General Biology Lab,0.52,0.3,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,036,General Biology Lab,0.42,0.25,0.13,0.04,0.13,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,037,General Biology Lab,0.62,0.29,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,038,General Biology Lab,0.33,0.48,0.14,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,039,General Biology Lab,0.48,0.24,0.1,0.05,0.05,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,040,General Biology Lab,0.64,0.18,0.05,0.09,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,041,General Biology Lab,0.48,0.29,0.1,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,042,General Biology Lab,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,043,General Biology Lab,0.33,0.38,0.14,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,044,General Biology Lab,0.45,0.36,0.0,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1050,046,General Biology Lab,0.38,0.42,0.13,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2014
+BIOL,1090,001,Intro to Life Sci,0.82,0.13,0.04,0.02,0.0,0.0,0.0,0.0,renea chri hardwick,,BIOL-1090,2014
+BIOL,1100,001,Prin of Biology I,0.12,0.4,0.25,0.1,0.03,0.0,0.0,0.09,robert kosinski,,BIOL-1100,2014
+BIOL,1100,003,Prin of Biology I,0.4,0.35,0.16,0.02,0.03,0.0,0.0,0.04,dylan dittrich-reed,,BIOL-1100,2014
+BIOL,1100,004,Prin of Biology I (H,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,dylan dittrich-reed,True,BIOL-1100,2014
+BIOL,1200,001,Biological Inq Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,002,Biological Inq Lab,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,003,Biological Inq Lab,0.35,0.55,0.0,0.0,0.0,0.0,0.0,0.1, christine minor,,BIOL-1200,2014
+BIOL,1200,004,Biological Inq Lab,0.4,0.35,0.15,0.05,0.0,0.0,0.0,0.05, christine minor,,BIOL-1200,2014
+BIOL,1200,005,Biological Inq Lab,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,006,Biological Inq Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,007,Biological Inq Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,,BIOL-1200,2014
+BIOL,1200,008,Biological Inq Lab,0.33,0.44,0.11,0.06,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2014
+BIOL,1200,010,Biological Inq Lab,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,,BIOL-1200,2014
+BIOL,1200,011,Biological Inq Lab,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,012,Biological Inq Lab,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,013,Biological Inq Lab,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,014,Biological Inq Lab,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,015,Biological Inq Lab,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,016,Biological Inq Lab,0.5,0.38,0.06,0.0,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2014
+BIOL,1220,001,Keys to Biodiversity,0.24,0.4,0.24,0.07,0.02,0.0,0.0,0.02,kalan ickes,,BIOL-1220,2014
+BIOL,1230,001,Keys to Human Biol,0.22,0.44,0.23,0.08,0.02,0.0,0.0,0.01, christine minor,,BIOL-1230,2014
+BIOL,1230,002,Keys to Human Biol,0.33,0.43,0.17,0.07,0.01,0.0,0.0,0.0, christine minor,,BIOL-1230,2014
+BIOL,2000,002,Biology in the News,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0, christine minor,,BIOL-2000,2014
+BIOL,2000,009,Biology in the News,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,douglas bielenberg,,BIOL-2000,2014
+BIOL,2000,010,Biology in the News,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,,BIOL-2000,2014
+BIOL,2040,001,"Environ, Energy and",0.29,0.32,0.25,0.03,0.04,0.0,0.0,0.07,john jenkins hains,,BIOL-2040,2014
+BIOL,2220,001,Human Anat and Physi,0.22,0.38,0.24,0.09,0.04,0.0,0.0,0.04,john cummings,,BIOL-2220,2014
+BIOL,2220,002,Human Anat and Physi,0.19,0.37,0.24,0.11,0.02,0.0,0.0,0.05,john cummings,,BIOL-2220,2014
+BIOL,3030,001,Vertebrate Biology,0.29,0.29,0.2,0.14,0.04,0.0,0.0,0.03,richard blob,,BIOL-3030,2014
+BIOL,3030,002,Vertebrate Biology (,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True,BIOL-3030,2014
+BIOL,3040,001,Biology of Plants,0.12,0.34,0.36,0.09,0.06,0.0,0.0,0.03,robert edwa ballard,,BIOL-3040,2014
+BIOL,3070,001,Vertebrate Biology L,0.5,0.4,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3070,002,Vertebrate Biology L,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3070,003,Vertebrate Biology L,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3070,004,Vertebrate Biology L,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,richard blob,,BIOL-3070,2014
+BIOL,3070,005,Vertebrate Biology L,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2014
+BIOL,3070,006,Vertebrate Biology L,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3070,007,Vertebrate Biology L,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3070,008,Vertebrate Biology L,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2014
+BIOL,3070,009,Vertebrate Biology L,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2014
+BIOL,3070,010,Vertebrate Biology L,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3070,011,Vertebrate Biology L,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3070,012,Vertebrate Biology L,0.55,0.4,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3070,013,Vertebrate Biology L,0.55,0.35,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2014
+BIOL,3080,001,Biology of Plants Pr,0.63,0.21,0.05,0.05,0.05,0.0,0.0,0.0,robert edwa ballard,,BIOL-3080,2014
+BIOL,3080,002,Biology of Plants Pr,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,robert edwa ballard,,BIOL-3080,2014
+BIOL,3080,003,Biology of Plants Pr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,robert edwa ballard,,BIOL-3080,2014
+BIOL,3080,004,Biology of Plants Pr,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,robert edwa ballard,,BIOL-3080,2014
+BIOL,3150,001,Functional Human Ana,0.25,0.46,0.19,0.04,0.01,0.0,0.0,0.05,tamara mcnutt-scott,,BIOL-3150,2014
+BIOL,3200,001,Field Botany,0.19,0.37,0.24,0.09,0.07,0.0,0.0,0.04,timothy spira,,BIOL-3200,2014
+BIOL,3350,001,Evolutionary Biology,0.27,0.46,0.11,0.06,0.04,0.0,0.0,0.04,margaret ptacek,,BIOL-3350,2014
+BIOL,3510,001,Biological Anthropol,0.42,0.33,0.08,0.0,0.17,0.0,0.0,0.0,lisa rapaport,,BIOL-3510,2014
+BIOL,3530,001,Forensic Anthrolpolo,0.31,0.38,0.15,0.08,0.08,0.0,0.0,0.0,katherine weisensee,,BIOL-3530,2014
+BIOL,4340,001,Biological Chem Lab,0.15,0.23,0.38,0.08,0.0,0.0,0.0,0.15,salvatore sparace,,BIOL-4340,2014
+BIOL,4340,003,Biological Chem Lab,0.17,0.5,0.08,0.25,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2014
+BIOL,4340,004,Biological Chem Lab,0.17,0.42,0.25,0.08,0.08,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2014
+BIOL,4410,001,Ecology,0.25,0.44,0.19,0.09,0.01,0.0,0.0,0.02,david tonkyn,,BIOL-4410,2014
+BIOL,4430,001,Freshwater Ecology,0.56,0.29,0.13,0.0,0.0,0.0,0.0,0.02,john jenkins hains,,BIOL-4430,2014
+BIOL,4450,001,Ecology Laboratory (,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,david tonkyn,,BIOL-4450,2014
+BIOL,4450,002,Ecology Laboratory (,0.36,0.36,0.18,0.0,0.0,0.0,0.0,0.09,david tonkyn,,BIOL-4450,2014
+BIOL,4450,003,Ecology Laboratory (,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,,BIOL-4450,2014
+BIOL,4450,004,Ecology Laboratory (,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david tonkyn,,BIOL-4450,2014
+BIOL,4610,001,Cell Biology,0.38,0.3,0.11,0.11,0.0,0.0,0.0,0.1,lesly temesvari,,BIOL-4610,2014
+BIOL,4610,002,Cell Biology (HON),0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True,BIOL-4610,2014
+BIOL,4610,003,Cell Biology,0.91,0.06,0.01,0.01,0.01,0.0,0.0,0.0,susan carol chapman,,BIOL-4610,2014
+BIOL,4610,004,Cell Biology (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True,BIOL-4610,2014
+BIOL,4620,001,Cell Biology Lab (Le,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4620,2014
+BIOL,4620,003,Cell Biology Lab (Le,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4620,2014
+BIOL,4620,004,Cell Biology Lab (Le,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4620,2014
+BIOL,4620,005,Cell Biology Lab (Le,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4620,2014
+BIOL,4620,006,Cell Biology Lab (Le,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4620,2014
+BIOL,4620,007,Cell Biology Lab (Le,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,david feliciano,,BIOL-4620,2014
+BIOL,4620,008,Cell Biology Lab (Le,0.27,0.33,0.4,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4620,2014
+BIOL,4620,010,Cell Biology Lab (Le,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4620,2014
+BIOL,4620,011,Cell Biology Lab (Le,0.36,0.43,0.0,0.07,0.07,0.0,0.0,0.07,david feliciano,,BIOL-4620,2014
+BIOL,4660,001,Evolution of Human B,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,lisa rapaport,,BIOL-4660,2014
+BIOL,4670,001,Principles of Hemato,0.88,0.05,0.05,0.0,0.0,0.0,0.0,0.02,vincent gallicchio,,BIOL-4670,2014
+BIOL,4750,001,Comparative Physiolo,0.3,0.43,0.14,0.0,0.08,0.0,0.0,0.05,michael sears,,BIOL-4750,2014
+BIOL,4760,003,Comparative Physiolo,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael sears,,BIOL-4760,2014
+BIOL,4930,002,Adv Cancer Research,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,wen chen,,BIOL-4930,2014
+BIOL,4940,001,Aging Stress Induced,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,min cao,,BIOL-4940,2014
+BIOL,4940,001,Aging Stress Induced,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,yuqing dong,,BIOL-4940,2014
+BIOL,4940,007,Popular Science Jour,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,steven katz,,BIOL-4940,2014
+BIOL,4940,007,Popular Science Jour,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,,BIOL-4940,2014
+BIOL,4960,004,MARINE MICRO,0.27,0.33,0.27,0.13,0.0,0.0,0.0,0.0,john michael henson,,BIOL-4960,2014
+BIOL,8200,001,Community Ecology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,saara dewalt,,BIOL-8200,2014
+BIOL,8400,001,Understanding Biolog,0.83,0.1,0.01,0.0,0.02,0.0,0.0,0.03,michael childress,,BIOL-8400,2014
+BIOL,8420,001,Understand Cellular,0.57,0.31,0.06,0.0,0.04,0.0,0.0,0.02,david feliciano,,BIOL-8420,2014
+BIOL,8440,001,Understanding the Hu,0.65,0.29,0.03,0.0,0.02,0.0,0.0,0.0,heidi lynn jordan,,BIOL-8440,2014
+BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,sandy edge,,BUS-1010,2014
+BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2014
+BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,michael giebner,,BUS-1010,2014
+BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2014
+BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,michael giebner,,BUS-1010,2014
+BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,sandy edge,,BUS-1010,2014
+BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,michael giebner,,BUS-1010,2014
+BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2014
+BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,sandy edge,,BUS-1010,2014
+BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,sandy edge,,BUS-1010,2014
+BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,edward bar de iulio,,BUS-1010,2014
+BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,michael giebner,,BUS-1010,2014
+BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2014
+BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,sandy edge,,BUS-1010,2014
+BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,michael giebner,,BUS-1010,2014
+BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,sandy edge,,BUS-1010,2014
+BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2014
+BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,michael giebner,,BUS-1010,2014
+BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,william ern tumblin,,BUS-1010,2014
+BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2014
+BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,sandy edge,,BUS-1010,2014
+BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2014
+BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,michael giebner,,BUS-1010,2014
+BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,william ern tumblin,,BUS-1010,2014
+BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2014
+BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,michael giebner,,BUS-1010,2014
+BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,sandy edge,,BUS-1010,2014
+BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,,BUS-1010,2014
+BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2014
+BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,michael giebner,,BUS-1010,2014
+BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2014
+BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,sandy edge,,BUS-1010,2014
+BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,william ern tumblin,,BUS-1010,2014
+BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2014
+BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2014
+BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2014
+BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2014
+BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,sandy edge,,BUS-1010,2014
+BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,michael giebner,,BUS-1010,2014
+BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,edward bar de iulio,,BUS-1010,2014
+BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,michael giebner,,BUS-1010,2014
+BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,sandy edge,,BUS-1010,2014
+BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,edward bar de iulio,,BUS-1010,2014
+BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,renee hebert,,BUS-1010,2014
+BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,michael giebner,,BUS-1010,2014
+BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,edward bar de iulio,,BUS-1010,2014
+BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,sandy edge,,BUS-1010,2014
+BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,renee hebert,,BUS-1010,2014
+BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,michael giebner,,BUS-1010,2014
+BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,sandy edge,,BUS-1010,2014
+BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,renee hebert,,BUS-1010,2014
+BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,edward bar de iulio,,BUS-1010,2014
+BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,,BUS-1010,2014
+BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2014
+BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2014
+CE,2010,002,Statics,0.32,0.25,0.25,0.07,0.0,0.0,0.0,0.11,qiushi chen,,CE-2010,2014
+CE,2010,003,Statics,0.24,0.24,0.29,0.05,0.13,0.0,0.0,0.05,scott schiff,,CE-2010,2014
+CE,2010,004,Statics,0.2,0.29,0.22,0.02,0.07,0.0,0.0,0.2,melissa sternhagen,,CE-2010,2014
+CE,2010,005,Statics,0.24,0.29,0.2,0.07,0.02,0.0,0.0,0.18,melissa sternhagen,,CE-2010,2014
+CE,2010,006,Statics,0.4,0.23,0.14,0.05,0.07,0.0,0.0,0.12,nighat yasmin,,CE-2010,2014
+CE,2010,007,Statics,0.38,0.3,0.19,0.03,0.03,0.0,0.0,0.08,weichiang pang,,CE-2010,2014
+CE,2060,001,Structural Mechanics,0.14,0.16,0.51,0.08,0.06,0.0,0.0,0.04,bryant nielson,,CE-2060,2014
+CE,2080,002,Dynamics,0.16,0.24,0.24,0.18,0.08,0.0,0.0,0.11,melissa sternhagen,,CE-2080,2014
+CE,2080,004,Dynamics,0.05,0.3,0.35,0.15,0.1,0.0,0.0,0.05,melissa sternhagen,,CE-2080,2014
+CE,2550,001,Geomatics,0.32,0.38,0.24,0.01,0.01,0.0,0.0,0.04,wayne sarasua,,CE-2550,2014
+CE,3010,001,Structural Analysis,0.3,0.43,0.11,0.0,0.14,0.0,0.0,0.03,stephen csernak,,CE-3010,2014
+CE,3010,002,Structural Analysis,0.21,0.31,0.34,0.06,0.06,0.0,0.0,0.02,bryant nielson,,CE-3010,2014
+CE,3110,001,Transportation Engr,0.74,0.17,0.04,0.02,0.02,0.0,0.0,0.0,jennifer ogle,,CE-3110,2014
+CE,3210,001,Geotechnical Enginee,0.31,0.46,0.15,0.0,0.06,0.0,0.0,0.02,qiushi chen,,CE-3210,2014
+CE,3310,001,Constr Engr & Mgmnt,0.41,0.42,0.09,0.04,0.04,0.0,0.0,0.0,james burati,,CE-3310,2014
+CE,3410,001,Intro to Fluid Mech,0.19,0.38,0.26,0.11,0.04,0.0,0.0,0.02,nigel gregory kaye,,CE-3410,2014
+CE,3410,002,Intro to Fluid Mech,0.17,0.31,0.28,0.09,0.07,0.0,0.0,0.07,abdul khan,,CE-3410,2014
+CE,3420,001,Hydraulics & Hydro,0.38,0.4,0.13,0.05,0.05,0.0,0.0,0.0,ashok mishra,,CE-3420,2014
+CE,3510,001,Civil Engineering Ma,0.34,0.5,0.1,0.02,0.04,0.0,0.0,0.0,ami esmaeilpoursaee,,CE-3510,2014
+CE,3510,002,Civil Engineering Ma,0.38,0.32,0.21,0.03,0.06,0.0,0.0,0.0,bradley putman,,CE-3510,2014
+CE,3520,001,Econ Eval of Proj,0.37,0.33,0.12,0.08,0.08,0.0,0.0,0.01,yongxi huang,,CE-3520,2014
+CE,3530,001,Professional Seminar,0.79,0.13,0.08,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-3530,2014
+CE,4060,001,Struct Steel Design,0.21,0.32,0.28,0.17,0.02,0.0,0.0,0.0,stephen csernak,,CE-4060,2014
+CE,4080,001,Struct Loads & Sys,0.22,0.5,0.06,0.17,0.06,0.0,0.0,0.0,bryant nielson,,CE-4080,2014
+CE,4100,001,Traffic Engr Oper,0.06,0.5,0.22,0.22,0.0,0.0,0.0,0.0,yongxi huang,,CE-4100,2014
+CE,4240,001,Earth Slopes & Struc,0.24,0.42,0.24,0.05,0.03,0.0,0.0,0.03,nadara ravichandran,,CE-4240,2014
+CE,4340,001,Const Est Proj Cont,0.61,0.32,0.05,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4340,2014
+CE,4360,001,Sustainable Constr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,,CE-4360,2014
+CE,4390,001,Con Eqpmt Sel & Main,0.56,0.34,0.07,0.0,0.02,0.0,0.0,0.0,james burati,,CE-4390,2014
+CE,4430,001,Water Resources Engr,0.45,0.09,0.36,0.0,0.0,0.0,0.0,0.09,abdul khan,,CE-4430,2014
+CE,4560,001,Pave Design & Constr,0.37,0.42,0.17,0.03,0.0,0.0,0.0,0.02,bradley putman,,CE-4560,2014
+CE,4590,001,Capstone Design Proj,0.25,0.57,0.1,0.08,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2014
+CE,4820,001,Groundwater & Contam,0.42,0.25,0.17,0.0,0.0,0.0,0.0,0.17,lawrence murdoch,,CE-4820,2014
+CE,4990,052,C I in Civil Engr/CE,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,jennifer ogle,,CE-4990,2014
+CE,6080,001,Struct Loads & Sys,0.42,0.46,0.13,0.0,0.0,0.0,0.0,0.0,bryant nielson,,CE-6080,2014
+CE,6100,001,Traffic Engr Oper,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yongxi huang,,CE-6100,2014
+CE,6240,001,Earth Slopes & Struc,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-6240,2014
+CE,6360,001,Sustainable Constr,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,leidy klotz,,CE-6360,2014
+CE,8020,001,Adv R/C Design,0.4,0.58,0.0,0.0,0.0,0.0,0.0,0.03,scott schiff,,CE-8020,2014
+CE,8060,001,Dyn Analys of Struc,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,,CE-8060,2014
+CE,8210,001,Advanced Soil Mech,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-8210,2014
+CE,8220,001,Foundation Engr,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-8220,2014
+CE,8540,001,Travl Demnd Forecast,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,wayne sarasua,,CE-8540,2014
+CE,8930,005,Connected Vehicle Te,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,mashrur chowdhury,,CE-8930,2014
+CH,1010,001,General Chemistry,0.25,0.37,0.21,0.12,0.05,0.0,0.0,0.01,dennis taylor,,CH-1010,2014
+CH,1010,002,General Chemistry,0.09,0.42,0.27,0.09,0.08,0.0,0.0,0.04,ava kreider-mueller,,CH-1010,2014
+CH,1010,003,General Chemistry,0.23,0.39,0.2,0.08,0.06,0.0,0.0,0.05,dennis taylor,,CH-1010,2014
+CH,1010,004,General Chemistry,0.24,0.31,0.2,0.14,0.04,0.0,0.0,0.07,dennis taylor,,CH-1010,2014
+CH,1010,005,General Chemistry,0.11,0.29,0.32,0.15,0.11,0.0,0.0,0.02,ava kreider-mueller,,CH-1010,2014
+CH,1010,006,General Chemistry,0.22,0.36,0.18,0.1,0.11,0.0,0.0,0.02,thomas hickman,,CH-1010,2014
+CH,1010,007,General Chemistry,0.22,0.38,0.23,0.08,0.08,0.0,0.0,0.01,thomas hickman,,CH-1010,2014
+CH,1010,008,General Chemistry,0.2,0.34,0.24,0.06,0.1,0.0,0.0,0.06,kenneth wi rillings,,CH-1010,2014
+CH,1010,009,General Chemistry,0.13,0.32,0.26,0.12,0.1,0.0,0.0,0.06,ava kreider-mueller,,CH-1010,2014
+CH,1010,010,General Chemistry,0.19,0.24,0.21,0.18,0.16,0.0,0.0,0.03,christopher wilson,,CH-1010,2014
+CH,1010,011,General Chemistry,0.22,0.37,0.23,0.09,0.03,0.0,0.0,0.06,tania issa houjeiry,,CH-1010,2014
+CH,1010,012,General Chemistry,0.11,0.27,0.28,0.2,0.09,0.0,0.0,0.05,christopher wilson,,CH-1010,2014
+CH,1010,013,General Chemistry,0.18,0.29,0.3,0.08,0.11,0.0,0.0,0.04,olt geiculescu,,CH-1010,2014
+CH,1010,014,General Chemistry,0.23,0.39,0.24,0.09,0.02,0.0,0.0,0.03,dennis taylor,,CH-1010,2014
+CH,1010,015,General Chemistry: M,0.34,0.31,0.22,0.06,0.06,0.0,0.0,0.0,tania issa houjeiry,,CH-1010,2014
+CH,1010,016,General Chemistry (R,0.2,0.45,0.26,0.03,0.03,0.0,0.0,0.03,tania issa houjeiry,,CH-1010,2014
+CH,1010,017,General Chemistry (R,0.15,0.43,0.27,0.07,0.05,0.0,0.0,0.03,kenneth wi rillings,,CH-1010,2014
+CH,1010,018,General Chemistry (R,0.17,0.44,0.25,0.07,0.04,0.0,0.0,0.03,kenneth wi rillings,,CH-1010,2014
+CH,1010,019,General Chemistry: C,0.32,0.39,0.19,0.08,0.0,0.0,0.0,0.01,kenneth christensen,,CH-1010,2014
+CH,1010,051,General Chemistry (H,0.68,0.29,0.02,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True,CH-1010,2014
+CH,1010,052,General Chemistry (H,0.58,0.39,0.0,0.03,0.0,0.0,0.0,0.0,joseph stu thrasher,True,CH-1010,2014
+CH,1020,001,General Chemistry,0.32,0.26,0.27,0.09,0.02,0.0,0.0,0.03,stephe schvaneveldt,,CH-1020,2014
+CH,1020,002,General Chemistry,0.28,0.32,0.19,0.09,0.05,0.0,0.0,0.07,stephe schvaneveldt,,CH-1020,2014
+CH,1020,003,General Chemistry,0.24,0.24,0.25,0.17,0.03,0.0,0.0,0.07,stephe schvaneveldt,,CH-1020,2014
+CH,1020,400,General Chemistry (O,0.11,0.24,0.27,0.16,0.11,0.0,0.0,0.11,stephe schvaneveldt,,CH-1020,2014
+CH,1050,001,Chem in Context I,0.26,0.56,0.17,0.02,0.0,0.0,0.0,0.0,olt geiculescu,,CH-1050,2014
+CH,1050,002,Chem in Context I,0.41,0.47,0.06,0.02,0.03,0.0,0.0,0.02,olt geiculescu,,CH-1050,2014
+CH,1410,001,Chem Orientation,0.72,0.2,0.06,0.0,0.0,0.0,0.0,0.02,stephen creager,,CH-1410,2014
+CH,2010,001,Survey of Organic Ch,0.44,0.32,0.08,0.03,0.04,0.0,0.0,0.08,thomas hickman,,CH-2010,2014
+CH,2010,002,Survey of Organic Ch,0.45,0.37,0.12,0.03,0.0,0.0,0.0,0.04,thomas hickman,,CH-2010,2014
+CH,2020,001,Surv of Organic Chem,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2020,2014
+CH,2020,009,Surv of Organic Chem,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,,CH-2020,2014
+CH,2020,010,Surv of Organic Chem,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,,CH-2020,2014
+CH,2020,011,Surv of Organic Chem,0.53,0.2,0.07,0.0,0.0,0.0,0.0,0.2,sean 'connor,,CH-2020,2014
+CH,2020,012,Surv of Organic Chem,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2020,2014
+CH,2230,001,Organic Chemistry,0.09,0.2,0.31,0.12,0.11,0.0,0.0,0.17,dev priya arya,,CH-2230,2014
+CH,2230,002,Organic Chemistry,0.35,0.29,0.18,0.08,0.03,0.0,0.0,0.07,rhett smith,,CH-2230,2014
+CH,2230,003,Organic Chemistry,0.3,0.34,0.19,0.04,0.1,0.0,0.0,0.02,jacob schroeder,,CH-2230,2014
+CH,2230,004,Organic Chemistry,0.2,0.28,0.24,0.17,0.03,0.0,0.0,0.07,modi wetzler,,CH-2230,2014
+CH,2230,005,Organic Chemistry,0.26,0.3,0.25,0.09,0.03,0.0,0.0,0.07,modi wetzler,,CH-2230,2014
+CH,2230,006,Organic Chemistry,0.38,0.34,0.21,0.02,0.01,0.0,0.0,0.04,tania issa houjeiry,,CH-2230,2014
+CH,2230,007,Organic Chemistry,0.37,0.36,0.15,0.06,0.01,0.0,0.0,0.05,jacob schroeder,,CH-2230,2014
+CH,2240,001,Organic Chemistry,0.31,0.3,0.22,0.09,0.02,0.0,0.0,0.06,jacob schroeder,,CH-2240,2014
+CH,2240,002,Organic Chemistry,0.3,0.37,0.21,0.05,0.05,0.0,0.0,0.02,jacob schroeder,,CH-2240,2014
+CH,2270,001,Organic Chem Lab,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,,CH-2270,2014
+CH,2270,002,Organic Chem Lab,0.81,0.06,0.06,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,007,Organic Chem Lab,0.6,0.07,0.07,0.0,0.0,0.0,0.0,0.27,sean 'connor,,CH-2270,2014
+CH,2270,011,Organic Chem Lab,0.69,0.13,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,,CH-2270,2014
+CH,2270,014,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,015,Organic Chem Lab,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,016,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2014
+CH,2270,017,Organic Chem Lab,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2014
+CH,2270,019,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,020,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2014
+CH,2270,023,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,024,Organic Chem Lab,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,026,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,028,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,029,Organic Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,030,Organic Chem Lab,0.44,0.5,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,031,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,032,Organic Chem Lab,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2014
+CH,2270,033,Organic Chem Lab,0.55,0.09,0.09,0.18,0.0,0.0,0.0,0.09,sean 'connor,,CH-2270,2014
+CH,2270,034,Organic Chem Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,sean 'connor,,CH-2270,2014
+CH,2270,035,Organic Chem Lab,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2014
+CH,2270,036,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2014
+CH,2270,037,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,038,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,,CH-2270,2014
+CH,2280,004,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,,CH-2280,2014
+CH,2280,007,Organic Chem Lab,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,,CH-2280,2014
+CH,3130,001,Quantitative Analys,0.4,0.33,0.1,0.07,0.02,0.0,0.0,0.07,stephen creager,,CH-3130,2014
+CH,3150,002,Quant Analysis Lab,0.36,0.36,0.09,0.09,0.09,0.0,0.0,0.0,jeffrey natha anker,,CH-3150,2014
+CH,3300,001,Intro to Phys Chem,0.41,0.37,0.18,0.0,0.0,0.0,0.0,0.04,brian dominy,,CH-3300,2014
+CH,3310,001,Physical Chemistry,0.27,0.25,0.35,0.08,0.02,0.0,0.0,0.02,jason mcneill,,CH-3310,2014
+CH,3320,001,Physical Chemistry,0.2,0.3,0.1,0.2,0.0,0.0,0.0,0.2,arkady kholodenko,,CH-3320,2014
+CH,3390,001,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,,CH-3390,2014
+CH,3390,005,Physical Chem Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,,CH-3390,2014
+CH,4010,001,Organometallic Chemi,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,andrew gre tennyson,,CH-4010,2014
+CH,4020,001,Inorganic Chemistry,0.2,0.73,0.07,0.0,0.0,0.0,0.0,0.0,joseph kolis,,CH-4020,2014
+CH,8070,001,Chem Trans Elem,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,,CH-8070,2014
+CH,8120,001,Spectrochemical Anal,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,george chumanov,,CH-8120,2014
+CH,8150,001,Mass Spectrometry,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,richard marcus,,CH-8150,2014
+CH,8210,001,Organic Chem I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, karl dieter,,CH-8210,2014
+CH,8300,001,Fund Phys Chem,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,,CH-8300,2014
+CH,8340,001,Stat Thermodynamics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,,CH-8340,2014
+CH,8410,001,N M R Spectroscopy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,alek kitaygorodskiy,,CH-8410,2014
+CH,8510,002,Grad Student Seminar,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey natha anker,,CH-8510,2014
+CHE,2110,001,Intro to Chem Eng,0.23,0.24,0.18,0.03,0.26,0.0,0.0,0.06,rachel getman,,CHE-2110,2014
+CHE,2110,002,Intro to Chem Eng,0.19,0.23,0.26,0.02,0.23,0.0,0.0,0.08,rachel getman,,CHE-2110,2014
+CHE,3070,001,Unit Ops Lab I,0.14,0.6,0.21,0.02,0.0,0.0,0.0,0.02,christopher norfolk,,CHE-3070,2014
+CHE,3070,001,Unit Ops Lab I,0.14,0.6,0.21,0.02,0.0,0.0,0.0,0.02,mark thies,,CHE-3070,2014
+CHE,3190,001,Engr Materials,0.11,0.32,0.39,0.14,0.05,0.0,0.0,0.0,antho guiseppi-elie,,CHE-3190,2014
+CHE,4070,001,Unit Op Lab II,0.16,0.84,0.0,0.0,0.0,0.0,0.0,0.0,scott husson,,CHE-4070,2014
+CHE,4310,001,Process Design I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4310,2014
+CHE,4500,001,Chem Reaction Engr,0.17,0.34,0.34,0.09,0.06,0.0,0.0,0.0,mark alan blenner,,CHE-4500,2014
+CHE,8030,001,Advanced Transport,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,douglas hirt,,CHE-8030,2014
+CHE,8040,001,Ch E Thermodynamics,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,sapna sarupria,,CHE-8040,2014
+CHE,8050,001,Ch E Kinetics,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,mark roberts,,CHE-8050,2014
+CHE,8140,002,Numerical Methods,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,joseph scott,,CHE-8140,2014
+CHIN,1010,001,Elementary Chinese,0.44,0.06,0.19,0.0,0.0,0.0,0.0,0.31,yanming an,,CHIN-1010,2014
+CHIN,4010,001,Pre-Modern Chinese L,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,yanming an,,CHIN-4010,2014
+COM,1500,001,Intro to Human Com,0.66,0.29,0.01,0.01,0.02,0.0,0.0,0.01,eddie smith,,COM-1500,2014
+COM,1500,002,Introduction  to Hum,0.65,0.24,0.06,0.01,0.01,0.0,0.0,0.03,daniel lelan fecher,,COM-1500,2014
+COM,1500,003,Intro to Human Com,0.69,0.26,0.02,0.01,0.01,0.0,0.0,0.01,eddie smith,,COM-1500,2014
+COM,1500,004,Intro to Human Com,0.64,0.29,0.05,0.0,0.01,0.0,0.0,0.01,marianne her glaser,,COM-1500,2014
+COM,1500,005,Intro to Human Com,0.71,0.22,0.05,0.0,0.01,0.0,0.0,0.01,marianne her glaser,,COM-1500,2014
+COM,1500,006,Intro to Human Com,0.65,0.25,0.04,0.0,0.01,0.0,0.0,0.05,marianne her glaser,,COM-1500,2014
+COM,1500,007,Intro to Human Com,0.4,0.47,0.06,0.02,0.01,0.0,0.0,0.03,daniel lelan fecher,,COM-1500,2014
+COM,2010,001,Intr to Comm Studies,0.51,0.39,0.1,0.0,0.0,0.0,0.0,0.0,brenden kendall,,COM-2010,2014
+COM,2500,001,Public Speaking,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,brandon boatwright,,COM-2500,2014
+COM,2500,002,Public Speaking,0.11,0.58,0.16,0.0,0.11,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2014
+COM,2500,003,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2014
+COM,2500,004,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2014
+COM,2500,005,Public Speaking,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2014
+COM,2500,006,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,,COM-2500,2014
+COM,2500,007,Public Speaking,0.37,0.42,0.16,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2014
+COM,2500,008,Public Speaking,0.68,0.11,0.0,0.05,0.05,0.0,0.0,0.11,jumah patrici taweh,,COM-2500,2014
+COM,2500,009,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2014
+COM,2500,010,Public Speaking,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,,COM-2500,2014
+COM,2500,011,Public Speaking,0.5,0.39,0.0,0.06,0.0,0.0,0.0,0.06,pauline matthey,,COM-2500,2014
+COM,2500,012,Public Speaking,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,marilyn denise pugh,,COM-2500,2014
+COM,2500,013,Public Speaking,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2014
+COM,2500,014,Public Speaking,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2014
+COM,2500,015,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2014
+COM,2500,016,Public Speaking,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,katharin schoonover,,COM-2500,2014
+COM,2500,017,Public Speaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,the estate  geddes,,COM-2500,2014
+COM,2500,018,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,,COM-2500,2014
+COM,2500,019,Public Speaking,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,pauline matthey,,COM-2500,2014
+COM,2500,020,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2014
+COM,2500,021,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2014
+COM,2500,022,Public Speaking,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2014
+COM,2500,023,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2014
+COM,2500,024,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2014
+COM,2500,025,Public Speaking (HON,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,True,COM-2500,2014
+COM,2500,026,Public Speaking (HON,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True,COM-2500,2014
+COM,2500,400,Public Speaking,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2014
+COM,2500,401,Public Speaking,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alexis zachar davis,,COM-2500,2014
+COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2014
+COM,2500,403,Public Speaking,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,,COM-2500,2014
+COM,3010,001,Comm Theory,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-3010,2014
+COM,3020,001,Mass Comm Theory,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3020,2014
+COM,3070,001,Public Comm of Sts,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,david travers scott,,COM-3070,2014
+COM,3080,001,Pub Comm & Pop Cult,0.28,0.4,0.18,0.04,0.02,0.0,0.0,0.08,chenjerai kumanyika,,COM-3080,2014
+COM,3100,001,Quant Comm Methods,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-3100,2014
+COM,3110,001,Qual Comm Methods,0.37,0.47,0.0,0.0,0.05,0.0,0.0,0.11,chenjerai kumanyika,,COM-3110,2014
+COM,3210,001,Comm Across Media Pl,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian mullen,,COM-3210,2014
+COM,3220,001,Communication Design,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,lori marlise pindar,,COM-3220,2014
+COM,3250,001,Survey of Sports Com,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-3250,2014
+COM,3250,002,Survey of Sports Com,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-3250,2014
+COM,3260,001,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2014
+COM,3260,002,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2014
+COM,3480,001,Interpersonal Comm,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,melinda ra weathers,,COM-3480,2014
+COM,3550,001,Principles of Pr,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3550,2014
+COM,3550,002,Principles of Pr,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3550,2014
+COM,3660,001,EP: Advertising & Me,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,william reynolds,,COM-3660,2014
+COM,3660,002,EP: Building the Bra,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,andrew mendelsohn,,COM-3660,2014
+COM,3660,003,Live Broadcast Prod.,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,michael rodgers,,COM-3660,2014
+COM,4300,001,Legal Communication,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,,COM-4300,2014
+COM,4700,001,Comm & Health,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4700,2014
+COM,4800,001,Intercultural Comm,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,andrew stephen pyle,,COM-4800,2014
+COM,8010,001,Communication Theory,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-8010,2014
+COM,8030,001,Comm Technology Stud,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,,COM-8030,2014
+COM,8100,001,Comm Research Method,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-8100,2014
+CPSC,1010,001,Computer Science I,0.24,0.12,0.24,0.08,0.18,0.0,0.0,0.13,catherine hochrine,,CPSC-1010,2014
+CPSC,1010,003,Computer Science I,0.75,0.11,0.02,0.0,0.02,0.0,0.0,0.09,lauren elizab dukes,,CPSC-1010,2014
+CPSC,1010,004,Computer Science I,0.15,0.13,0.18,0.13,0.21,0.0,0.0,0.21,pradip srimani,,CPSC-1010,2014
+CPSC,1020,001,Computer Science II,0.36,0.36,0.07,0.02,0.02,0.0,0.0,0.18,catherine hochrine,,CPSC-1020,2014
+CPSC,1040,001,Intro Computer Prog,0.24,0.56,0.0,0.08,0.08,0.0,0.0,0.04,kenneth alle weaver,,CPSC-1040,2014
+CPSC,1110,001,Intro to Programming,0.58,0.28,0.08,0.03,0.03,0.0,0.0,0.03,patrick sterling,,CPSC-1110,2014
+CPSC,1110,002,Intro to Programming,0.52,0.31,0.07,0.0,0.1,0.0,0.0,0.0,patrick sterling,,CPSC-1110,2014
+CPSC,1110,003,Intro to Programming,0.64,0.19,0.07,0.02,0.05,0.0,0.0,0.02,patrick sterling,,CPSC-1110,2014
+CPSC,1110,004,Intro to Programming,0.87,0.07,0.02,0.0,0.04,0.0,0.0,0.0,toni bloodwor pence,,CPSC-1110,2014
+CPSC,2070,001,Discrete Structures,0.13,0.29,0.28,0.1,0.04,0.0,0.0,0.15,roy pargas,,CPSC-2070,2014
+CPSC,2100,001,Progrmng Methodology,0.54,0.13,0.1,0.06,0.1,0.0,0.0,0.08,rose lowe,,CPSC-2100,2014
+CPSC,2120,001,Algs/Data Structures,0.28,0.28,0.23,0.02,0.06,0.0,0.0,0.12,brian christop dean,,CPSC-2120,2014
+CPSC,2150,001,Software Dev Fndtns,0.35,0.28,0.23,0.05,0.05,0.0,0.0,0.05,blair madiso durkee,,CPSC-2150,2014
+CPSC,2150,002,Software Dev Fndtns,0.21,0.31,0.33,0.05,0.05,0.0,0.0,0.05,catherine hochrine,,CPSC-2150,2014
+CPSC,2200,001,Microcomputer Appl,0.32,0.42,0.16,0.0,0.11,0.0,0.0,0.0,renee lambert,,CPSC-2200,2014
+CPSC,2200,002,Microcomputer Appl,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,patrick sterling,,CPSC-2200,2014
+CPSC,2310,001,Intro Computer Org,0.22,0.35,0.24,0.05,0.14,0.0,0.0,0.0,rose lowe,,CPSC-2310,2014
+CPSC,2310,002,Intro Computer Org,0.41,0.24,0.21,0.03,0.09,0.0,0.0,0.03,rose lowe,,CPSC-2310,2014
+CPSC,2910,001,Prof Issues I,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,james jones,,CPSC-2910,2014
+CPSC,2910,002,Prof Issues I,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,james jones,,CPSC-2910,2014
+CPSC,2910,003,Prof Issues I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,james jones,,CPSC-2910,2014
+CPSC,2910,004,Prof Issues I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james jones,,CPSC-2910,2014
+CPSC,2910,006,Prof Issues I,0.6,0.0,0.2,0.0,0.1,0.0,0.0,0.1,renee lambert,,CPSC-2910,2014
+CPSC,2910,008,Prof Issues I,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,renee lambert,,CPSC-2910,2014
+CPSC,3220,001,Intro to Operating S,0.23,0.21,0.14,0.04,0.12,0.0,0.0,0.26,jacob sorber,,CPSC-3220,2014
+CPSC,3300,001,Computer Systems Org,0.32,0.25,0.22,0.03,0.1,0.0,0.0,0.08,mark smotherman,,CPSC-3300,2014
+CPSC,3500,001,Foundatns of Com Sci,0.22,0.27,0.22,0.08,0.1,0.0,0.0,0.12,ilya mark safro,,CPSC-3500,2014
+CPSC,3520,001,Programming Systems,0.25,0.31,0.19,0.03,0.19,0.0,0.0,0.03,robert schalkoff,,CPSC-3520,2014
+CPSC,3600,001,Network Programming,0.19,0.33,0.22,0.04,0.11,0.0,0.0,0.11,sekou lionel remy,,CPSC-3600,2014
+CPSC,3620,001,Dist & Cluster Compu,0.36,0.3,0.18,0.09,0.06,0.0,0.0,0.0,amy apon,,CPSC-3620,2014
+CPSC,3620,001,Dist & Cluster Compu,0.36,0.3,0.18,0.09,0.06,0.0,0.0,0.0,linh bao ngo,,CPSC-3620,2014
+CPSC,3710,001,Systems Analysis,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,john mcgregor,,CPSC-3710,2014
+CPSC,3720,001,Software Engineering,0.32,0.35,0.29,0.0,0.0,0.0,0.0,0.03,murali sitaraman,,CPSC-3720,2014
+CPSC,3720,002,Software Engineering,0.15,0.35,0.35,0.09,0.03,0.0,0.0,0.03,stephen schaub,,CPSC-3720,2014
+CPSC,3990,002,AdvCI Proc Gen Game,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,brian malloy,,CPSC-3990,2014
+CPSC,4040,001,Cmptr Graphics Image,0.5,0.23,0.14,0.0,0.14,0.0,0.0,0.0,joshua levine,,CPSC-4040,2014
+CPSC,4060,001,Gpu Computation,0.3,0.0,0.3,0.1,0.3,0.0,0.0,0.0,robert geist,,CPSC-4060,2014
+CPSC,4110,001,Virtual Reality Syst,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,,CPSC-4110,2014
+CPSC,4200,001,Computer Security Pr,0.32,0.36,0.18,0.05,0.05,0.0,0.0,0.05,pradip srimani,,CPSC-4200,2014
+CPSC,4620,001,Database Management,0.29,0.5,0.18,0.0,0.0,0.0,0.0,0.04,feng luo,,CPSC-4620,2014
+CPSC,4810,016,Programming Team,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian christop dean,,CPSC-4810,2014
+CPSC,4910,001,Prof  Issues II,0.95,0.04,0.0,0.0,0.0,0.0,0.0,0.02,james jones,,CPSC-4910,2014
+CPSC,6040,001,Cptr Graphics Image,0.65,0.2,0.05,0.0,0.05,0.0,0.0,0.05,joshua levine,,CPSC-6040,2014
+CPSC,6060,001,Gpu Computation,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,robert geist,,CPSC-6060,2014
+CPSC,6110,001,Virtual Reality Syst,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,,CPSC-6110,2014
+CPSC,6620,001,Database Management,0.33,0.63,0.0,0.0,0.0,0.0,0.0,0.04,feng luo,,CPSC-6620,2014
+CPSC,8070,001,3d Model Animation,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,CPSC-8070,2014
+CPSC,8200,001,Parallel Architechtu,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,pradip srimani,,CPSC-8200,2014
+CPSC,8270,001,Translation of Progr,0.86,0.05,0.1,0.0,0.0,0.0,0.0,0.0,brian malloy,,CPSC-8270,2014
+CPSC,8380,001,Adv Data Structures,0.23,0.09,0.09,0.0,0.45,0.0,0.0,0.14,sandra hedetniemi,,CPSC-8380,2014
+CPSC,8450,001,Bioinfo Algorithms,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,,CPSC-8450,2014
+CPSC,8510,001,Soft Sys Data Comm,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,james martin,,CPSC-8510,2014
+CPSC,8700,001,O O Software Design,0.64,0.28,0.05,0.0,0.0,0.0,0.0,0.03,brian malloy,,CPSC-8700,2014
+CPSC,8720,002,Software Spec & Desi,0.34,0.45,0.17,0.0,0.0,0.0,0.0,0.03,john mcgregor,,CPSC-8720,2014
+CPSC,8770,001,Biometric Systems,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,damon woodard,,CPSC-8770,2014
+CPSC,8810,001,Data Visualization,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,joshua levine,,CPSC-8810,2014
+CRP,8000,001,Human Settlement,0.51,0.37,0.12,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,CRP-8000,2014
+CRP,8000,001,Human Settlement,0.51,0.37,0.12,0.0,0.0,0.0,0.0,0.0,john terrenc farris,,CRP-8000,2014
+CRP,8010,001,Planning Process & L,0.26,0.7,0.0,0.0,0.0,0.0,0.0,0.04,caitlin dyckman,,CRP-8010,2014
+CRP,8020,001,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,,CRP-8020,2014
+CRP,8030,001,Quant Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,,CRP-8030,2014
+CRP,8030,001,Quant Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,,CRP-8030,2014
+CRP,8060,001,Urban Systems,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,timothy green,,CRP-8060,2014
+CRP,8580,002,Research Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy green,,CRP-8580,2014
+CSM,1000,001,Intro to Construct,0.2,0.63,0.13,0.04,0.02,0.0,0.0,0.0,joseph wintz,,CSM-1000,2014
+CSM,2010,001,Structures I,0.27,0.41,0.14,0.14,0.0,0.0,0.0,0.05,shima clarke,,CSM-2010,2014
+CSM,2010,002,Structures I,0.23,0.27,0.32,0.05,0.05,0.0,0.0,0.09,shima clarke,,CSM-2010,2014
+CSM,2030,001,Mats & Meth of Const,0.19,0.67,0.15,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-2030,2014
+CSM,2030,002,Mats & Meth of Const,0.21,0.54,0.17,0.08,0.0,0.0,0.0,0.0,jason lucas,,CSM-2030,2014
+CSM,3030,001,Soils & Foundations,0.27,0.47,0.13,0.13,0.0,0.0,0.0,0.0,joseph wintz,,CSM-3030,2014
+CSM,3030,002,Soils & Foundations,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-3030,2014
+CSM,3040,001,Envir Systems I,0.33,0.43,0.24,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2014
+CSM,3040,002,Envir Systems I,0.32,0.47,0.05,0.11,0.05,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2014
+CSM,3510,001,Const Estimating,0.29,0.48,0.14,0.1,0.0,0.0,0.0,0.0,james packer smith,,CSM-3510,2014
+CSM,3510,002,Const Estimating,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,james packer smith,,CSM-3510,2014
+CSM,4110,001,Safety in Bldg Const,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,david devita,,CSM-4110,2014
+CSM,4500,001,Construction Intern,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-4500,2014
+CSM,4530,001,Const Proj Mgmt,0.08,0.6,0.32,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-4530,2014
+CSM,4530,002,Const Proj Mgmt,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-4530,2014
+CSM,4610,001,Const Econ Seminar,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4610,2014
+CSM,4610,002,Const Econ Seminar,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4610,2014
+CSM,6550,001,Adverse Relations,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,joseph wintz,,CSM-6550,2014
+CSM,8520,001,Const Mgmt Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,shima clarke,,CSM-8520,2014
+CSM,8600,001,Constr Finan Plan &,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8600,2014
+CSM,8600,400,Constr Finan Plan &,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8600,2014
+CSM,8630,001,Adv Plan/Sched,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-8630,2014
+CSM,8630,400,Adv Plan/Sched,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-8630,2014
+CSM,8660,001,Role in Development,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8660,2014
+CU,1000,001,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.01,jeffrey appling,,CU-1000,2014
+CU,1000,001,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.01,mary mcp von kaenel,,CU-1000,2014
+CU,1000,002,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.01,jeffrey appling,,CU-1000,2014
+CU,1000,002,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.01,mary mcp von kaenel,,CU-1000,2014
+CU,1000,003,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,jeffrey appling,,CU-1000,2014
+CU,1000,003,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,mary mcp von kaenel,,CU-1000,2014
+CU,1000,004,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.84,0.15,0.02,jeffrey appling,,CU-1000,2014
+CU,1000,004,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.84,0.15,0.02,mary mcp von kaenel,,CU-1000,2014
+CU,1000,005,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.03,0.01,jeffrey appling,,CU-1000,2014
+CU,1000,006,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.02,0.01,jeffrey appling,,CU-1000,2014
+CU,1000,007,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,,CU-1000,2014
+CU,1000,008,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,,CU-1000,2014
+CU,1000,009,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey appling,,CU-1000,2014
+CU,1000,010,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,jeffrey appling,,CU-1000,2014
+CU,1000,011,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,,CU-1000,2014
+CU,1000,012,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.05,0.01,jeffrey appling,,CU-1000,2014
+CU,1000,013,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.01,jeffrey appling,,CU-1000,2014
+CU,1000,014,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.89,0.1,0.01,jeffrey appling,,CU-1000,2014
+CU,1010,001,Univ Success Skills,0.43,0.17,0.26,0.0,0.04,0.0,0.0,0.09,deborah ann vaughn,,CU-1010,2014
+CU,1010,002,Univ Success Skills,0.35,0.39,0.09,0.09,0.04,0.0,0.0,0.04,rise jean sheriff,,CU-1010,2014
+CU,1010,003,Univ Success Skills,0.44,0.36,0.08,0.04,0.08,0.0,0.0,0.0,cecelia hamby,,CU-1010,2014
+CU,1010,005,Univ Success Skills,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,robert dav brackett,,CU-1010,2014
+DANC,1600,001,Ballet Dance I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,cheryl hosler,,DANC-1600,2014
+DPA,3070,001,Method 3d Production,0.43,0.3,0.04,0.04,0.13,0.0,0.0,0.04,virginia ba nearing,,DPA-3070,2014
+DPA,4000,001,Tech Foundations I,0.08,0.17,0.33,0.0,0.08,0.0,0.0,0.33,christina sop joerg,,DPA-4000,2014
+DPA,6000,001,Tech Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,DPA-6000,2014
+DPA,8600,001,Production Studio,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,,DPA-8600,2014
+ECE,2010,001,Logic & Comp Device,0.16,0.3,0.28,0.13,0.09,0.0,0.0,0.05,william reid,,ECE-2010,2014
+ECE,2010,002,Logic & Comp Device,0.62,0.24,0.1,0.0,0.05,0.0,0.0,0.0,william reid,True,ECE-2010,2014
+ECE,2020,001,Electric Circuits I,0.18,0.22,0.29,0.17,0.07,0.0,0.0,0.07,william harrell,,ECE-2020,2014
+ECE,2020,002,Electric Circuits I,0.73,0.13,0.0,0.07,0.0,0.0,0.0,0.07,apoorva dee kapadia,True,ECE-2020,2014
+ECE,2070,001,Basic Electrical Eng,0.85,0.09,0.02,0.02,0.01,0.0,0.0,0.02,sung- kim,,ECE-2070,2014
+ECE,2070,002,Basic Electrical Eng,0.4,0.23,0.13,0.1,0.08,0.0,0.0,0.06,surya sharma,,ECE-2070,2014
+ECE,2070,003,Basic Electrical Eng,0.55,0.36,0.07,0.0,0.0,0.0,0.0,0.02,liang dong,,ECE-2070,2014
+ECE,2080,001,Electrical Engineeri,0.85,0.05,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2080,2014
+ECE,2080,002,Electrical Engineeri,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,,ECE-2080,2014
+ECE,2080,010,Electrical Engineeri,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2080,2014
+ECE,2080,011,Electrical Engineeri,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2080,2014
+ECE,2080,012,Electrical Engineeri,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,william harrell,,ECE-2080,2014
+ECE,2080,013,Electrical Engineeri,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,,ECE-2080,2014
+ECE,2090,001,Logic Lab,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,william harrell,,ECE-2090,2014
+ECE,2090,003,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,william harrell,,ECE-2090,2014
+ECE,2090,006,Logic Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2090,2014
+ECE,2090,014,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,william harrell,,ECE-2090,2014
+ECE,2110,002,Elec Engr Lab I,0.65,0.15,0.0,0.0,0.05,0.0,0.0,0.15,william harrell,,ECE-2110,2014
+ECE,2110,003,Elec Engr Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2110,2014
+ECE,2110,004,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,william harrell,,ECE-2110,2014
+ECE,2110,005,Elec Engr Lab I,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,william harrell,,ECE-2110,2014
+ECE,2110,006,Elec Engr Lab I,0.8,0.05,0.05,0.0,0.0,0.0,0.0,0.1,william harrell,,ECE-2110,2014
+ECE,2110,008,Elec Engr Lab I,0.8,0.0,0.05,0.0,0.0,0.0,0.0,0.15,william harrell,,ECE-2110,2014
+ECE,2110,009,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,,ECE-2110,2014
+ECE,2110,010,Elec Engr Lab I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2110,2014
+ECE,2220,001,Syst Prog Concept,0.22,0.24,0.14,0.06,0.12,0.0,0.0,0.22,harlan russell,,ECE-2220,2014
+ECE,2230,001,Comp Sys Eng,0.11,0.41,0.17,0.13,0.07,0.0,0.0,0.11,harlan russell,,ECE-2230,2014
+ECE,2620,001,Elec Circuits II,0.47,0.25,0.25,0.02,0.02,0.0,0.0,0.0,michael bridgwood,,ECE-2620,2014
+ECE,2720,001,Comp Organization,0.22,0.29,0.24,0.12,0.14,0.0,0.0,0.0,william reid,,ECE-2720,2014
+ECE,2730,001,Computer Org Lab,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2730,2014
+ECE,2730,002,Computer Org Lab,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2730,2014
+ECE,2730,003,Computer Org Lab,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2730,2014
+ECE,3110,001,Electrical Engineeri,0.75,0.06,0.06,0.0,0.0,0.0,0.0,0.13,william harrell,,ECE-3110,2014
+ECE,3110,002,Electrical Engineeri,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,william harrell,,ECE-3110,2014
+ECE,3110,003,Electrical Engineeri,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,,ECE-3110,2014
+ECE,3110,007,Electrical Engineeri,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-3110,2014
+ECE,3120,001,Electrical Engineeri,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-3120,2014
+ECE,3170,001,Rand Signal Analysis,0.25,0.51,0.18,0.02,0.04,0.0,0.0,0.02,stephen hubbard,,ECE-3170,2014
+ECE,3200,001,Electronics I,0.34,0.36,0.15,0.07,0.05,0.0,0.0,0.03,stephen hubbard,,ECE-3200,2014
+ECE,3210,001,Electronics II,0.2,0.2,0.41,0.11,0.05,0.0,0.0,0.02,stephen hubbard,,ECE-3210,2014
+ECE,3220,001,Intro Operating Sys,0.3,0.1,0.05,0.15,0.3,0.0,0.0,0.1,jacob sorber,,ECE-3220,2014
+ECE,3270,001,Dig Comp Design,0.11,0.21,0.18,0.14,0.25,0.0,0.0,0.11,melissa crawl smith,,ECE-3270,2014
+ECE,3300,001,Signals & Systems,0.23,0.29,0.21,0.11,0.1,0.0,0.0,0.05,carl baum,,ECE-3300,2014
+ECE,3300,002,Signals & Systems (H,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True,ECE-3300,2014
+ECE,3520,001,Programming Systems,0.13,0.31,0.25,0.0,0.19,0.0,0.0,0.13,robert schalkoff,,ECE-3520,2014
+ECE,3600,001,Elect Power Engr,0.18,0.26,0.26,0.08,0.19,0.0,0.0,0.03,andrew donal clarke,,ECE-3600,2014
+ECE,3710,001,Microcontr Interface,0.38,0.25,0.29,0.03,0.01,0.0,0.0,0.03,william reid,,ECE-3710,2014
+ECE,3800,001,Electromagnetics,0.41,0.17,0.11,0.1,0.14,0.0,0.0,0.07,anthony martin,,ECE-3800,2014
+ECE,3810,001,Field Waves & Ckts,0.33,0.35,0.23,0.05,0.05,0.0,0.0,0.0,anthony martin,,ECE-3810,2014
+ECE,4090,001,Cont & Discrete Sys,0.56,0.31,0.12,0.0,0.0,0.0,0.0,0.02,apoorva dee kapadia,,ECE-4090,2014
+ECE,4180,001,Power Syst Analysis,0.48,0.22,0.3,0.0,0.0,0.0,0.0,0.0,elham makram,,ECE-4180,2014
+ECE,4270,001,Communications Sys,0.23,0.35,0.28,0.08,0.03,0.0,0.0,0.04,madhabi manandhar,,ECE-4270,2014
+ECE,4290,001,Organiz of Compu,0.29,0.36,0.29,0.07,0.0,0.0,0.0,0.0,hai ying shen,,ECE-4290,2014
+ECE,4420,001,Knowledge Engr,0.38,0.31,0.08,0.08,0.0,0.0,0.0,0.15,robert schalkoff,,ECE-4420,2014
+ECE,4490,001,Comp Ntwrk Security,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,richard brooks,,ECE-4490,2014
+ECE,4610,001,Fundamentals of Sola,0.73,0.18,0.07,0.0,0.0,0.0,0.0,0.02,rajendra singh,,ECE-4610,2014
+ECE,4730,001,Intro Parallel Sys,0.48,0.14,0.33,0.0,0.0,0.0,0.0,0.05,walter ligon,,ECE-4730,2014
+ECE,4930,003,Power Electronics,0.36,0.27,0.36,0.0,0.0,0.0,0.0,0.0,keith corzine,,ECE-4930,2014
+ECE,4950,001,Int Sys Design I,0.81,0.18,0.0,0.0,0.0,0.0,0.0,0.01,apoorva dee kapadia,,ECE-4950,2014
+ECE,4960,001,Int Sys Design II,0.37,0.57,0.06,0.0,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2014
+ECE,6040,001,Semiconductor Device,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-6040,2014
+ECE,6420,001,Knowledge Engr,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,robert schalkoff,,ECE-6420,2014
+ECE,6670,001,Intro to Dig Sig Pro,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,john gowdy,,ECE-6670,2014
+ECE,6730,001,Intro Parallel Sys,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,walter ligon,,ECE-6730,2014
+ECE,6930,001,Intro to Computer Vi,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,adam hoover,,ECE-6930,2014
+ECE,6930,004,Optoelectronics and,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,lin zhu,,ECE-6930,2014
+ECE,8010,001,Analysis of Lin Sys,0.47,0.37,0.17,0.0,0.0,0.0,0.0,0.0,richard groff,,ECE-8010,2014
+ECE,8180,001,Rand Proc Appl Engr,0.38,0.38,0.19,0.0,0.0,0.0,0.0,0.06,carl baum,,ECE-8180,2014
+ECE,8470,400,Digital Image Proc,0.43,0.37,0.1,0.0,0.0,0.0,0.0,0.1,stanley birchfield,,ECE-8470,2014
+ECE,8540,001,Analysis of Tracking,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,adam hoover,,ECE-8540,2014
+ECE,8930,005,CMOS RFIC,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,,ECE-8930,2014
+ECE,8930,006,Computing Frontiers,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,,ECE-8930,2014
+ECE,9910,032,Doctoral Dissertatio,0.0,0.0,0.0,0.0,0.0,0.44,0.56,0.0,hai ying shen,,ECE-9910,2014
+ECON,2000,001,Economic Concepts,0.21,0.42,0.05,0.13,0.03,0.0,0.0,0.16,mallika garg,,ECON-2000,2014
+ECON,2000,002,Economic Concepts,0.21,0.46,0.1,0.13,0.03,0.0,0.0,0.08,mallika garg,,ECON-2000,2014
+ECON,2000,003,Economic Concepts,0.3,0.4,0.16,0.09,0.02,0.0,0.0,0.02,miren ivankovic,,ECON-2000,2014
+ECON,2110,001,Principles of Microe,0.33,0.44,0.17,0.0,0.06,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2014
+ECON,2110,002,Principles of Microe,0.17,0.28,0.33,0.11,0.06,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2014
+ECON,2110,003,Principles of Microe,0.15,0.45,0.15,0.15,0.0,0.0,0.0,0.1,frederick hanssen,,ECON-2110,2014
+ECON,2110,004,Principles of Microe,0.26,0.16,0.37,0.16,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2014
+ECON,2110,005,Principles of Microe,0.21,0.42,0.26,0.0,0.0,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2014
+ECON,2110,006,Principles of Microe,0.16,0.42,0.26,0.16,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2014
+ECON,2110,007,Principles of Microe,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2014
+ECON,2110,008,Principles of Microe,0.21,0.16,0.21,0.11,0.0,0.0,0.0,0.32,frederick hanssen,,ECON-2110,2014
+ECON,2110,009,Principles of Microe,0.05,0.32,0.32,0.16,0.05,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2014
+ECON,2110,010,Principles of Microe,0.16,0.42,0.21,0.11,0.05,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2014
+ECON,2110,011,Principles of Microe,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2014
+ECON,2110,012,Principles of Microe,0.05,0.37,0.26,0.05,0.0,0.0,0.0,0.26,frederick hanssen,,ECON-2110,2014
+ECON,2110,013,Principles of Microe,0.32,0.42,0.16,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2014
+ECON,2110,014,Principles of Microe,0.05,0.53,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2014
+ECON,2110,015,Principles of Microe,0.16,0.53,0.21,0.0,0.05,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2014
+ECON,2110,016,Principles of Microe,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2014
+ECON,2110,017,Principles of Microe,0.26,0.32,0.21,0.05,0.0,0.0,0.0,0.16,frederick hanssen,,ECON-2110,2014
+ECON,2110,018,Principles of Microe,0.16,0.32,0.32,0.11,0.05,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2014
+ECON,2110,019,Principles of Microe,0.11,0.61,0.06,0.0,0.17,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2014
+ECON,2110,020,Principles of Microe,0.28,0.41,0.19,0.08,0.03,0.0,0.0,0.01,alexander fiore,,ECON-2110,2014
+ECON,2110,021,Principles of Microe,0.26,0.33,0.3,0.08,0.01,0.0,0.0,0.01,timothy andr bersak,,ECON-2110,2014
+ECON,2110,022,Principles of Microe,0.29,0.43,0.2,0.02,0.0,0.0,0.0,0.06,robert dew tollison,,ECON-2110,2014
+ECON,2110,023,Principles of Microe,0.13,0.45,0.25,0.08,0.05,0.0,0.0,0.05,timothy jay bacon,,ECON-2110,2014
+ECON,2110,024,Principles of Microe,0.26,0.36,0.25,0.1,0.02,0.0,0.0,0.02,adam millsap,,ECON-2110,2014
+ECON,2110,025,Principles of Microe,0.28,0.33,0.23,0.13,0.0,0.0,0.0,0.03,timothy andr bersak,,ECON-2110,2014
+ECON,2110,026,Principles of Microe,0.35,0.33,0.18,0.03,0.08,0.0,0.0,0.05,miren ivankovic,,ECON-2110,2014
+ECON,2110,031,Principles of Microe,0.31,0.31,0.23,0.14,0.01,0.0,0.0,0.0,adam millsap,,ECON-2110,2014
+ECON,2110,032,Principles of Microe,0.26,0.28,0.31,0.07,0.04,0.0,0.0,0.04,andew swanson,,ECON-2110,2014
+ECON,2110,033,Principles of Microe,0.29,0.34,0.18,0.11,0.05,0.0,0.0,0.03,alexander fiore,,ECON-2110,2014
+ECON,2110,034,Principles of Microe,0.31,0.36,0.29,0.02,0.0,0.0,0.0,0.02,amanda caitlin kerr,,ECON-2110,2014
+ECON,2110,035,Principles of Microe,0.43,0.38,0.18,0.03,0.0,0.0,0.0,0.0,andew swanson,,ECON-2110,2014
+ECON,2110,036,Principles of Microe,0.58,0.13,0.08,0.0,0.0,0.0,0.0,0.21,patrick warren,True,ECON-2110,2014
+ECON,2110,038,Principles of Microe,0.24,0.31,0.24,0.05,0.07,0.0,0.0,0.1,timothy jay bacon,,ECON-2110,2014
+ECON,2120,001,Principles of Macro,0.12,0.17,0.38,0.14,0.05,0.0,0.0,0.14,ralph charles allen,,ECON-2120,2014
+ECON,2120,002,Principles of Macro,0.24,0.33,0.26,0.02,0.07,0.0,0.0,0.09,peter david lorenz,,ECON-2120,2014
+ECON,2120,003,Principles of Macro,0.2,0.3,0.2,0.05,0.08,0.0,0.0,0.18,ralph charles allen,,ECON-2120,2014
+ECON,2120,004,Principles of Macro,0.16,0.42,0.24,0.07,0.02,0.0,0.0,0.09,peter david lorenz,,ECON-2120,2014
+ECON,2120,005,Principles of Macro,0.29,0.38,0.18,0.12,0.0,0.0,0.0,0.03,yukun sun,,ECON-2120,2014
+ECON,2120,006,Principles of Macro,0.2,0.43,0.23,0.07,0.07,0.0,0.0,0.0,yukun sun,,ECON-2120,2014
+ECON,2120,007,Principles of Macro,0.23,0.48,0.18,0.03,0.05,0.0,0.0,0.05,danielle zanzalari,,ECON-2120,2014
+ECON,2120,008,Principles of Macro,0.26,0.38,0.23,0.08,0.05,0.0,0.0,0.0,anne anders,,ECON-2120,2014
+ECON,3020,001,Money and Banking,0.25,0.19,0.25,0.14,0.03,0.0,0.0,0.14,danielle zanzalari,,ECON-3020,2014
+ECON,3060,001,Managerial Economics,0.38,0.46,0.04,0.04,0.04,0.0,0.0,0.04,jacob burgdorf,,ECON-3060,2014
+ECON,3100,001,International Econ,0.2,0.37,0.16,0.12,0.02,0.0,0.0,0.14,ayse mujde erdogan,,ECON-3100,2014
+ECON,3140,001,Intermediate Micro,0.16,0.3,0.27,0.14,0.0,0.0,0.0,0.14,robert kennet fleck,,ECON-3140,2014
+ECON,3140,002,Intermediate Micro,0.27,0.29,0.17,0.08,0.06,0.0,0.0,0.13,molly espey,,ECON-3140,2014
+ECON,3140,003,Intermediate Micro,0.24,0.27,0.22,0.08,0.08,0.0,0.0,0.1,robert kennet fleck,,ECON-3140,2014
+ECON,3150,001,Intermediate Macro,0.33,0.22,0.31,0.0,0.06,0.0,0.0,0.08,sergey vla mityakov,,ECON-3150,2014
+ECON,3150,002,Intermediate Macro,0.15,0.35,0.28,0.11,0.02,0.0,0.0,0.09,ayse mujde erdogan,,ECON-3150,2014
+ECON,3190,001,Environmental Econ,0.22,0.43,0.22,0.08,0.0,0.0,0.0,0.05,molly espey,,ECON-3190,2014
+ECON,3600,001,Public Choice,0.18,0.58,0.2,0.0,0.03,0.0,0.0,0.03,robert dew tollison,,ECON-3600,2014
+ECON,3970,001,Creative Inq in Econ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,scott baier,,ECON-3970,2014
+ECON,3970,001,Creative Inq in Econ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,raymond sauer,,ECON-3970,2014
+ECON,3970,003,Creative Inq in Econ,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,scott baier,,ECON-3970,2014
+ECON,3970,003,Creative Inq in Econ,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,raymond sauer,,ECON-3970,2014
+ECON,4020,001,Law and Economics,0.26,0.43,0.12,0.05,0.05,0.0,0.0,0.1,howard ne bodenhorn,,ECON-4020,2014
+ECON,4040,001,Comp Econ Systems,0.27,0.33,0.2,0.0,0.07,0.0,0.0,0.13,dar litsukova-bokar,,ECON-4040,2014
+ECON,4050,001,Intro to Econometric,0.33,0.31,0.19,0.02,0.05,0.0,0.0,0.1,jaqueline oliveira,,ECON-4050,2014
+ECON,4050,005,Intro to Econometric,0.42,0.08,0.08,0.08,0.17,0.0,0.0,0.17,scott barkowski,,ECON-4050,2014
+ECON,4100,001,Economic Development,0.28,0.36,0.16,0.0,0.04,0.0,0.0,0.16,robert tamura,,ECON-4100,2014
+ECON,4120,001,International Micro,0.5,0.38,0.06,0.0,0.03,0.0,0.0,0.03,scott baier,,ECON-4120,2014
+ECON,4220,001,Monetary Economics,0.37,0.59,0.04,0.0,0.0,0.0,0.0,0.0,gerald dwyer,,ECON-4220,2014
+ECON,4230,001,Economics of Health,0.17,0.39,0.22,0.11,0.06,0.0,0.0,0.06,daniel patri miller,,ECON-4230,2014
+ECON,4240,001,Organization of Ind,0.41,0.35,0.18,0.0,0.06,0.0,0.0,0.0,daniel patri miller,,ECON-4240,2014
+ECON,4350,001,Family Economics,0.44,0.16,0.2,0.0,0.16,0.0,0.0,0.04,jaqueline oliveira,,ECON-4350,2014
+ECON,8010,001,Microeconomic Theory,0.33,0.38,0.29,0.0,0.0,0.0,0.0,0.0,william dougan,,ECON-8010,2014
+ECON,8040,001,Applied Math Econ,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,curtis simon,,ECON-8040,2014
+ECON,8060,001,Econometrics I,0.12,0.52,0.28,0.0,0.0,0.0,0.0,0.08,paul wayne wilson,,ECON-8060,2014
+ECON,8230,001,Microecon Pub Pol,0.35,0.47,0.18,0.0,0.0,0.0,0.0,0.0,scott templeton,,ECON-8230,2014
+ECON,8260,001,Econ Theory of Govt,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,,ECON-8260,2014
+ECON,8550,001,Financial Economics,0.54,0.15,0.0,0.0,0.08,0.0,0.0,0.23,sergey vla mityakov,,ECON-8550,2014
+ED,1050,003,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,patrick womac,,ED-1050,2014
+ED,1050,008,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,rory phil tannebaum,,ED-1050,2014
+ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen mich moysey,,ED-3970,2014
+ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david matthew boyer,,ED-3970,2014
+ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,penelope mar vargas,,ED-3970,2014
+ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,,ED-3970,2014
+ED,3970,012,Creative Inquiry in,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,joseph benedic ryan,,ED-3970,2014
+ED,3970,012,Creative Inquiry in,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,deborah cadorette,,ED-3970,2014
+ED,8380,402,Short Stories for Te,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,lienne federico,,ED-8380,2014
+ED,8380,506,Literacy Lessons for,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,vicki steadman,,ED-8380,2014
+ED,8380,510,Literacy Lessons for,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jennifer adams,,ED-8380,2014
+ED,8380,511,Literacy Lessons for,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,jean ridley,,ED-8380,2014
+EDC,3900,001,Skills for Stu Leads,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,mary price,,EDC-3900,2014
+EDC,3900,001,Skills for Stu Leads,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,lloyd john  graham,,EDC-3900,2014
+EDC,3900,002,Skills for Stu Leads,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mary price,,EDC-3900,2014
+EDC,3900,002,Skills for Stu Leads,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2014
+EDC,8030,001,Stu Dev in Hi Ed,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,,EDC-8030,2014
+EDC,8040,001,Theories Student Dev,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,,EDC-8040,2014
+EDC,8040,002,Theories Student Dev,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,,EDC-8040,2014
+EDC,8050,001,Clinical Mh Couns,0.91,0.05,0.0,0.0,0.05,0.0,0.0,0.0,david scott,,EDC-8050,2014
+EDC,8440,001,Stu Affairs Intern,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,kristin walker,,EDC-8440,2014
+EDC,8440,001,Stu Affairs Intern,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,tony cawthon,,EDC-8440,2014
+EDEC,3000,001,Found Early Chld Ed,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,,EDEC-3000,2014
+EDEC,4400,001,Early Childhood Engl,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-4400,2014
+EDEL,3100,002,Arts in Ele School,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,alison eliz leonard,,EDEL-3100,2014
+EDEL,3210,001,Pe for the Elem Tchr,0.71,0.2,0.06,0.03,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2014
+EDEL,4010,002,Elem Field Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ann marie liebel,,EDEL-4010,2014
+EDEL,4510,002,Elem Methods in Scie,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,,EDEL-4510,2014
+EDEL,4870,002,Ele Meth Soc Studies,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,melinda spearman,,EDEL-4870,2014
+EDF,3010,001,Principles of Americ,0.59,0.29,0.05,0.0,0.05,0.0,0.0,0.02,suzanne rosenblith,,EDF-3010,2014
+EDF,3010,002,Principles of Americ,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,robert green,,EDF-3010,2014
+EDF,3010,004,Principles of Americ,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,melinda spearman,,EDF-3010,2014
+EDF,3020,001,Educ Psych,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,meihua qian,,EDF-3020,2014
+EDF,3020,002,Educ Psych,0.23,0.57,0.06,0.11,0.0,0.0,0.0,0.03,penelope mar vargas,,EDF-3020,2014
+EDF,3020,003,Educ Psych,0.16,0.58,0.16,0.06,0.03,0.0,0.0,0.0,penelope mar vargas,,EDF-3020,2014
+EDF,3080,001,Classroom Assessment,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,,EDF-3080,2014
+EDF,3080,002,Classroom Assessment,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,deborah switzer,,EDF-3080,2014
+EDF,3200,001,History of US Educat,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,robert green,,EDF-3200,2014
+EDF,3340,001,Child Growth and Dev,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,,EDF-3340,2014
+EDF,3350,002,Adol Growth & Dev,0.52,0.39,0.0,0.04,0.0,0.0,0.0,0.04,david barrett,,EDF-3350,2014
+EDF,4800,001,Digital Media & Lear,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,ryan visser,,EDF-4800,2014
+EDF,4800,003,Digital Media & Lear,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2014
+EDF,4800,004,Digital Media & Lear,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2014
+EDF,6900,001,Classroom Management,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,alicia farr clinger,,EDF-6900,2014
+EDF,8010,001,Human Growth and Dev,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jeromy blake snider,,EDF-8010,2014
+EDF,8080,001,Ed Tests and Measure,0.5,0.33,0.04,0.0,0.08,0.0,0.0,0.04,william fisk,,EDF-8080,2014
+EDF,8080,500,Ed Tests and Measure,0.7,0.1,0.05,0.0,0.1,0.0,0.0,0.05,deborah switzer,,EDF-8080,2014
+EDF,8710,500,Cultural Diversity i,0.7,0.05,0.0,0.0,0.25,0.0,0.0,0.0,sus cridland-hughes,,EDF-8710,2014
+EDF,9770,001,Multi Regress Ed Res,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david barrett,,EDF-9770,2014
+EDF,9790,001,Qualitative Research,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,david matthew boyer,,EDF-9790,2014
+EDL,7150,501,Sch & Comm Relations,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,frederick buskey,,EDL-7150,2014
+EDL,8390,503,Research in Ed L,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,,EDL-8390,2014
+EDL,8550,001,App Res & Eval in He,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michelle boettcher,,EDL-8550,2014
+EDL,9000,400,Prin Edu Leadership,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,james satterfield,,EDL-9000,2014
+EDL,9100,400,Intro Phd Seminar,0.59,0.18,0.0,0.0,0.0,0.0,0.0,0.24,jane lindle,,EDL-9100,2014
+EDLT,4590,001,Teaching Reading Gra,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4590,2014
+EDLT,4600,001,Teaching Reading Gra,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,,EDLT-4600,2014
+EDLT,4610,001,Content Area Rdg: 2-,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-4610,2014
+EDLT,4610,002,Content Area Rdg: 2-,0.63,0.19,0.13,0.06,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-4610,2014
+EDLT,4980,002,Secondary Content Ar,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,corrie leigh martin,,EDLT-4980,2014
+EDLT,8100,500,Foundations: Reading,0.42,0.17,0.0,0.0,0.0,0.0,0.0,0.42,susan kin fullerton,,EDLT-8100,2014
+EDLT,8640,400,Teaching Secondary S,0.71,0.07,0.07,0.0,0.14,0.0,0.0,0.0,corrie leigh martin,,EDLT-8640,2014
+EDLT,8640,500,Teaching Secondary S,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8640,2014
+EDLT,8800,506,Reading Recovery Tea,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,,EDLT-8800,2014
+EDLT,8800,511,Reading Recovery Tea,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,,EDLT-8800,2014
+EDLT,8820,502,Read Recovery Practi,0.0,0.82,0.09,0.0,0.0,0.0,0.0,0.09,mia francesc riddle,,EDLT-8820,2014
+EDLT,8820,506,Read Recovery Practi,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,,EDLT-8820,2014
+EDLT,8820,511,Read Recovery Practi,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,,EDLT-8820,2014
+EDML,8410,401,Adv Middle School Cu,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lienne federico,,EDML-8410,2014
+EDSC,2260,001,Pr Apprch to Sec Alg,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,stacy megan che,,EDSC-2260,2014
+EDSC,3240,001,Practicum Sec Engl,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,amy tali hallenbeck,,EDSC-3240,2014
+EDSC,4260,001,Tchng Sec Math,0.56,0.25,0.13,0.0,0.06,0.0,0.0,0.0,dennis aminie kombe,,EDSC-4260,2014
+EDSC,8610,001,Mthds & Strt Seconda,0.64,0.09,0.0,0.0,0.27,0.0,0.0,0.0,michelle patri cook,,EDSC-8610,2014
+EDSP,3700,002,Intro to Special Ed,0.83,0.07,0.07,0.0,0.03,0.0,0.0,0.0,robin parks ennis,,EDSP-3700,2014
+EDSP,3700,003,Intro to Special Ed,0.69,0.26,0.06,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,,EDSP-3700,2014
+EDSP,3700,004,Intro to Special Ed,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,angelo vespe,,EDSP-3700,2014
+EDSP,3720,001,Char & Instr Individ,0.9,0.0,0.05,0.0,0.05,0.0,0.0,0.0,catherine griffith,,EDSP-3720,2014
+EDSP,3740,001,Char & Strat Emot/Be,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,robin parks ennis,,EDSP-3740,2014
+EDSP,4920,001,Math Inst Ind W/Dis,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,pamela stecker,,EDSP-4920,2014
+EDSP,4930,001,Clsrm/Beh Mgmt Sp Ed,0.75,0.13,0.08,0.0,0.0,0.0,0.0,0.04,joseph benedic ryan,,EDSP-4930,2014
+EDSP,4940,001,Tchg Rdg Mild Dis,0.71,0.13,0.13,0.0,0.0,0.0,0.0,0.04,sara moo mackiewicz,,EDSP-4940,2014
+EDSP,4970,001,Sec Meth Ind W/Dis,0.75,0.13,0.04,0.04,0.0,0.0,0.0,0.04,martha hodge,,EDSP-4970,2014
+EDSP,8530,001,Legal/Pol Issu Sp Ed,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,antonis katsiyannis,,EDSP-8530,2014
+EES,2010,001,Environ Engr Fundame,0.33,0.39,0.22,0.03,0.03,0.0,0.0,0.0,david freedman,,EES-2010,2014
+EES,3030,001,Water Treatment Syst,0.3,0.57,0.14,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3030,2014
+EES,3040,001,Wastewater Treatment,0.35,0.54,0.11,0.0,0.0,0.0,0.0,0.0,david freedman,,EES-3040,2014
+EES,3050,001,Water/Wastewater Tre,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2014
+EES,3050,001,Water/Wastewater Tre,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,david freedman,,EES-3050,2014
+EES,3050,002,Water/Wastewater Tre,0.55,0.25,0.15,0.05,0.0,0.0,0.0,0.0,david freedman,,EES-3050,2014
+EES,3050,002,Water/Wastewater Tre,0.55,0.25,0.15,0.05,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2014
+EES,4010,001,Environmental Engr,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,elizabeth carraway,,EES-4010,2014
+EES,4010,002,Environmental Engr,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,mark schlautman,,EES-4010,2014
+EES,4300,001,Air Pollution Engine,0.2,0.44,0.32,0.02,0.02,0.0,0.0,0.0,thomas overcamp,,EES-4300,2014
+EES,4800,001,Environmental Risk A,0.24,0.28,0.28,0.1,0.07,0.0,0.0,0.03,timothy devol,,EES-4800,2014
+EES,4860,001,Environmental Sustai,0.53,0.39,0.05,0.0,0.03,0.0,0.0,0.0,michael anthon dale,,EES-4860,2014
+EES,6100,001,Environ Radiation Pr,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,,EES-6100,2014
+EES,6800,001,Environmental Risk A,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,timothy devol,,EES-6800,2014
+EES,8020,001,Environ Eng Prin,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,thomas overcamp,,EES-8020,2014
+EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tanju karanfil,,EES-8060,2014
+EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,thomas overcamp,,EES-8060,2014
+EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,,EES-8060,2014
+EES,8430,001,Environmental Chem,0.53,0.42,0.0,0.0,0.03,0.0,0.0,0.03,elizabeth carraway,,EES-8430,2014
+EES,8510,001,Biol Prin Envir Engr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,,EES-8510,2014
+ELE,3010,001,Intro to Entre,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,ELE-3010,2014
+ELE,3010,003,Intro to Entre,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,,ELE-3010,2014
+ELE,4010,001,Exec Lead & Entr II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,,ELE-4010,2014
+ENGL,1030,001,Accelerated Composit,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katrina torbert,,ENGL-1030,2014
+ENGL,1030,002,Accelerated Comp,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,lauren taylo stukes,,ENGL-1030,2014
+ENGL,1030,003,Accelerated Composit,0.21,0.37,0.21,0.11,0.0,0.0,0.0,0.11,chelsea mari clarey,,ENGL-1030,2014
+ENGL,1030,004,Accelerated Composit,0.37,0.26,0.26,0.11,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-1030,2014
+ENGL,1030,005,Accelerated Composit,0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-1030,2014
+ENGL,1030,006,Accelerated Composit,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,chelsea mari clarey,,ENGL-1030,2014
+ENGL,1030,007,Accelerated Composit,0.26,0.63,0.0,0.05,0.05,0.0,0.0,0.0,leslie ann salley,,ENGL-1030,2014
+ENGL,1030,008,Accelerated Composit,0.42,0.21,0.21,0.05,0.0,0.0,0.0,0.11,joshua wood,,ENGL-1030,2014
+ENGL,1030,009,Accelerated Composit,0.72,0.11,0.11,0.0,0.06,0.0,0.0,0.0,sarah ashto wickham,,ENGL-1030,2014
+ENGL,1030,010,Accelerated Composit,0.16,0.58,0.16,0.0,0.11,0.0,0.0,0.0,leslie ann salley,,ENGL-1030,2014
+ENGL,1030,011,Accelerated Composit,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-1030,2014
+ENGL,1030,012,Accelerated Composit,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,molly brian collins,,ENGL-1030,2014
+ENGL,1030,013,Accelerated Composit,0.05,0.53,0.11,0.05,0.16,0.0,0.0,0.11,leslie ann salley,,ENGL-1030,2014
+ENGL,1030,014,Accelerated Composit,0.44,0.28,0.22,0.06,0.0,0.0,0.0,0.0,justin all holliday,,ENGL-1030,2014
+ENGL,1030,015,Accelerated Composit,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,molly brian collins,,ENGL-1030,2014
+ENGL,1030,016,Accelerated Composit,0.61,0.06,0.11,0.0,0.17,0.0,0.0,0.06,joshua wood,,ENGL-1030,2014
+ENGL,1030,017,Accelerated Composit,0.26,0.32,0.21,0.16,0.05,0.0,0.0,0.0,leslie ann salley,,ENGL-1030,2014
+ENGL,1030,018,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,matthew mar russell,,ENGL-1030,2014
+ENGL,1030,019,Accelerated Composit,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,joshua rya newberry,,ENGL-1030,2014
+ENGL,1030,021,Accelerated Composit,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,,ENGL-1030,2014
+ENGL,1030,022,Accelerated Composit,0.83,0.0,0.06,0.06,0.0,0.0,0.0,0.06,daniel frank,,ENGL-1030,2014
+ENGL,1030,023,Accelerated Composit,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,matthew jose osborn,,ENGL-1030,2014
+ENGL,1030,024,Accelerated Composit,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,matthew mar russell,,ENGL-1030,2014
+ENGL,1030,025,Accelerated Composit,0.16,0.63,0.05,0.05,0.05,0.0,0.0,0.05,justin all holliday,,ENGL-1030,2014
+ENGL,1030,026,Accelerated Composit,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2014
+ENGL,1030,027,Accelerated Composit,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,matthew jose osborn,,ENGL-1030,2014
+ENGL,1030,028,Accelerated Composit,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,katherine hanzalik,,ENGL-1030,2014
+ENGL,1030,029,Accelerated Composit,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,jarrod keit thacker,,ENGL-1030,2014
+ENGL,1030,030,Accelerated Composit,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,kristen gay,,ENGL-1030,2014
+ENGL,1030,031,Accelerated Composit,0.53,0.32,0.05,0.11,0.0,0.0,0.0,0.0,adrian carson,,ENGL-1030,2014
+ENGL,1030,032,Accelerated Composit,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,hannah conl vaughan,,ENGL-1030,2014
+ENGL,1030,033,Accelerated Composit,0.68,0.16,0.05,0.0,0.05,0.0,0.0,0.05,katherine elrick,,ENGL-1030,2014
+ENGL,1030,034,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,,ENGL-1030,2014
+ENGL,1030,035,Accelerated Composit,0.74,0.16,0.0,0.0,0.0,0.0,0.0,0.11,judith roxanne ball,,ENGL-1030,2014
+ENGL,1030,036,Accelerated Composit,0.63,0.16,0.0,0.05,0.16,0.0,0.0,0.0,kristen gay,,ENGL-1030,2014
+ENGL,1030,037,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,sarah ashto wickham,,ENGL-1030,2014
+ENGL,1030,038,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,dustin cleag mosley,,ENGL-1030,2014
+ENGL,1030,039,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,joshua rya newberry,,ENGL-1030,2014
+ENGL,1030,040,Accelerated Composit,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,,ENGL-1030,2014
+ENGL,1030,041,Accelerated Composit,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,katrina torbert,,ENGL-1030,2014
+ENGL,1030,042,Accelerated Composit,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,katherine hanzalik,,ENGL-1030,2014
+ENGL,1030,043,Accelerated Composit,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2014
+ENGL,1030,044,Accelerated Composit,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,daniel frank,,ENGL-1030,2014
+ENGL,1030,045,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,adrian carson,,ENGL-1030,2014
+ENGL,1030,046,Accelerated Composit,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,hannah conl vaughan,,ENGL-1030,2014
+ENGL,1030,047,Accelerated Composit,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,katherine elrick,,ENGL-1030,2014
+ENGL,1030,048,Accelerated Composit,0.26,0.42,0.21,0.0,0.11,0.0,0.0,0.0,lauren taylo stukes,,ENGL-1030,2014
+ENGL,1030,049,Accelerated Composit,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,mari elena ramler,,ENGL-1030,2014
+ENGL,1030,050,Accelerated Composit,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,dustin cleag mosley,,ENGL-1030,2014
+ENGL,1030,051,Accelerated Composit,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,carlisle an sargent,,ENGL-1030,2014
+ENGL,1030,052,Accelerated Composit,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,heathe christiansen,,ENGL-1030,2014
+ENGL,1030,053,Accelerated Composit,0.63,0.32,0.0,0.05,0.0,0.0,0.0,0.0,stephanie mic heath,,ENGL-1030,2014
+ENGL,1030,054,Accelerated Composit,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,allen swords,,ENGL-1030,2014
+ENGL,1030,055,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,carlisle an sargent,,ENGL-1030,2014
+ENGL,1030,056,Accelerated Composit,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,judith roxanne ball,,ENGL-1030,2014
+ENGL,1030,057,Accelerated Composit,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,,ENGL-1030,2014
+ENGL,1030,058,Accelerated Composit,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,hayley ren zertuche,,ENGL-1030,2014
+ENGL,1030,059,Accelerated Composit,0.56,0.28,0.06,0.0,0.06,0.0,0.0,0.06,andrew mar barrocas,,ENGL-1030,2014
+ENGL,1030,060,Accelerated Composit,0.29,0.41,0.12,0.06,0.12,0.0,0.0,0.0,hayley ren zertuche,,ENGL-1030,2014
+ENGL,1030,061,Accelerated Composit,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sarah kath melchers,,ENGL-1030,2014
+ENGL,1030,062,Accelerated Composit,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,mari elena ramler,,ENGL-1030,2014
+ENGL,1030,063,Accelerated Composit,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,stephanie mic heath,,ENGL-1030,2014
+ENGL,1030,064,Accelerated Composit,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,,ENGL-1030,2014
+ENGL,1030,065,Accelerated Composit,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,sarah kath melchers,,ENGL-1030,2014
+ENGL,1030,067,Accelerated Composit,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,,ENGL-1030,2014
+ENGL,1030,068,Accelerated Composit,0.69,0.08,0.15,0.0,0.08,0.0,0.0,0.0,eda ozyesilpinar,,ENGL-1030,2014
+ENGL,1030,069,Accelerated Composit,0.63,0.25,0.0,0.0,0.13,0.0,0.0,0.0,eda ozyesilpinar,,ENGL-1030,2014
+ENGL,1030,500,Accelerated Composit,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-1030,2014
+ENGL,1030,501,Accelerated Composit,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,john conway,,ENGL-1030,2014
+ENGL,2120,001,World Literature (MA,0.65,0.2,0.1,0.05,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-2120,2014
+ENGL,2120,002,World Literature (MA,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,andrew lemons,,ENGL-2120,2014
+ENGL,2120,004,World Literature,0.66,0.21,0.07,0.0,0.0,0.0,0.0,0.07,lucian ghita,,ENGL-2120,2014
+ENGL,2120,005,World Literature,0.71,0.11,0.04,0.0,0.04,0.0,0.0,0.11,david stubblefield,,ENGL-2120,2014
+ENGL,2120,006,World Literature,0.22,0.48,0.11,0.0,0.0,0.0,0.0,0.19,karen kettnich,,ENGL-2120,2014
+ENGL,2120,007,World Literature,0.36,0.32,0.14,0.11,0.0,0.0,0.0,0.07,karen kettnich,,ENGL-2120,2014
+ENGL,2120,008,World Literature,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,lucian ghita,,ENGL-2120,2014
+ENGL,2120,009,World Literature,0.35,0.46,0.12,0.0,0.04,0.0,0.0,0.04,andrew mathas,,ENGL-2120,2014
+ENGL,2120,010,World Literature,0.15,0.5,0.12,0.08,0.04,0.0,0.0,0.12,david charles foltz,,ENGL-2120,2014
+ENGL,2120,011,World Literature,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,allen swords,,ENGL-2120,2014
+ENGL,2120,012,World Literature,0.62,0.34,0.03,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2120,2014
+ENGL,2120,013,World Literature,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-2120,2014
+ENGL,2120,014,World Literature,0.07,0.3,0.27,0.1,0.1,0.0,0.0,0.17,david charles foltz,,ENGL-2120,2014
+ENGL,2120,015,World Literature,0.64,0.14,0.04,0.11,0.07,0.0,0.0,0.0,lauren woolbright,,ENGL-2120,2014
+ENGL,2120,016,World Literature,0.61,0.18,0.07,0.04,0.07,0.0,0.0,0.04,lauren woolbright,,ENGL-2120,2014
+ENGL,2120,018,World Literature,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2120,2014
+ENGL,2130,001,British Literature,0.82,0.11,0.04,0.04,0.0,0.0,0.0,0.0,sherri teres allred,,ENGL-2130,2014
+ENGL,2130,002,British Literature,0.31,0.41,0.14,0.03,0.07,0.0,0.0,0.03,elizabeth stansell,,ENGL-2130,2014
+ENGL,2130,003,British Literature,0.38,0.38,0.17,0.0,0.03,0.0,0.0,0.03,elizabeth stansell,,ENGL-2130,2014
+ENGL,2130,004,British Literature,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,april susanne pelt,,ENGL-2130,2014
+ENGL,2130,005,British Literature,0.82,0.11,0.0,0.0,0.0,0.0,0.0,0.07,april susanne pelt,,ENGL-2130,2014
+ENGL,2130,007,British Literature,0.59,0.24,0.07,0.03,0.03,0.0,0.0,0.03,lucian ghita,,ENGL-2130,2014
+ENGL,2130,009,British Literature,0.81,0.07,0.0,0.07,0.0,0.0,0.0,0.04,april susanne pelt,,ENGL-2130,2014
+ENGL,2130,010,British Literature,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,april susanne pelt,,ENGL-2130,2014
+ENGL,2130,011,British Literature,0.46,0.25,0.07,0.07,0.04,0.0,0.0,0.11,lucian ghita,,ENGL-2130,2014
+ENGL,2130,012,British Literature,0.71,0.11,0.07,0.04,0.0,0.0,0.0,0.07,sherri teres allred,,ENGL-2130,2014
+ENGL,2140,001,American Literature,0.48,0.45,0.0,0.0,0.07,0.0,0.0,0.0,melody fowl shirley,,ENGL-2140,2014
+ENGL,2140,002,American Literature,0.39,0.25,0.29,0.04,0.04,0.0,0.0,0.0,melody fowl shirley,,ENGL-2140,2014
+ENGL,2140,003,American Literature,0.14,0.36,0.36,0.0,0.09,0.0,0.0,0.05,barbara ramirez,,ENGL-2140,2014
+ENGL,2140,005,American Literature,0.38,0.46,0.12,0.0,0.0,0.0,0.0,0.04,william stanton,,ENGL-2140,2014
+ENGL,2140,006,American Literature,0.59,0.24,0.05,0.02,0.0,0.0,0.0,0.09, barton palmer,,ENGL-2140,2014
+ENGL,2140,007,American Literature,0.34,0.52,0.03,0.07,0.0,0.0,0.0,0.03,john logan pursley,,ENGL-2140,2014
+ENGL,2140,008,American Literature,0.44,0.3,0.19,0.0,0.04,0.0,0.0,0.04,william stanton,,ENGL-2140,2014
+ENGL,2140,009,American Literature,0.14,0.41,0.17,0.07,0.17,0.0,0.0,0.03,john logan pursley,,ENGL-2140,2014
+ENGL,2140,014,American Literature,0.18,0.39,0.25,0.07,0.07,0.0,0.0,0.04,meredith mccarroll,,ENGL-2140,2014
+ENGL,2140,100,American Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,meredith mccarroll,True,ENGL-2140,2014
+ENGL,2150,001,Lit in 20th-21st Cen,0.07,0.67,0.19,0.0,0.0,0.0,0.0,0.07,amy monaghan,,ENGL-2150,2014
+ENGL,2150,002,Lit in 20th-21st Cen,0.0,0.62,0.35,0.0,0.0,0.0,0.0,0.04,amy monaghan,,ENGL-2150,2014
+ENGL,2150,003,Lit in 20th-21st Cen,0.17,0.55,0.14,0.03,0.03,0.0,0.0,0.07,sarah lauro,,ENGL-2150,2014
+ENGL,2150,004,Lit in 20th-21st Cen,0.18,0.54,0.18,0.04,0.04,0.0,0.0,0.04,joshua nei waggoner,,ENGL-2150,2014
+ENGL,2150,005,Lit in 20th-21st Cen,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,sarah lauro,,ENGL-2150,2014
+ENGL,2150,006,Lit in 20th-21st Cen,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,william pulley,,ENGL-2150,2014
+ENGL,2150,007,Lit in 20th-21st Cen,0.25,0.46,0.25,0.0,0.04,0.0,0.0,0.0,david charles foltz,,ENGL-2150,2014
+ENGL,2150,008,Lit in 20th-21st Cen,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,alexander kudera,,ENGL-2150,2014
+ENGL,2150,010,Lit in 20th-21st Cen,0.59,0.34,0.03,0.0,0.03,0.0,0.0,0.0,john morgenstern,,ENGL-2150,2014
+ENGL,2150,011,Lit in 20th-21st Cen,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,john morgenstern,,ENGL-2150,2014
+ENGL,2150,012,Lit in 20th-21st Cen,0.25,0.54,0.11,0.04,0.04,0.0,0.0,0.04,joshua nei waggoner,,ENGL-2150,2014
+ENGL,2150,015,Lit in 20th-21st Cen,0.41,0.34,0.17,0.03,0.0,0.0,0.0,0.03,lindsay carr thomas,,ENGL-2150,2014
+ENGL,2150,016,Lit in 20th-21st Cen,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,,ENGL-2150,2014
+ENGL,2150,017,Lit in 20th-21st Cen,0.41,0.41,0.19,0.0,0.0,0.0,0.0,0.0,joshua nei waggoner,,ENGL-2150,2014
+ENGL,2150,019,Lit in 20th-21st Cen,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,david charles foltz,,ENGL-2150,2014
+ENGL,2150,020,Lit in 20th-21st Cen,0.56,0.4,0.0,0.0,0.0,0.0,0.0,0.04,garry bertholf,,ENGL-2150,2014
+ENGL,2150,021,Lit in 20th-21st Cen,0.05,0.45,0.36,0.0,0.0,0.0,0.0,0.14,amy monaghan,,ENGL-2150,2014
+ENGL,2150,100,20th - 21st Century,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sarah lauro,True,ENGL-2150,2014
+ENGL,3000,001,Professional Develop,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,cameron fa bushnell,,ENGL-3000,2014
+ENGL,3040,002,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3040,2014
+ENGL,3040,003,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3040,2014
+ENGL,3040,004,Business Writing,0.33,0.44,0.17,0.0,0.0,0.0,0.0,0.06,megan no macalystre,,ENGL-3040,2014
+ENGL,3040,005,Business Writing,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,,ENGL-3040,2014
+ENGL,3040,011,Business Writing,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,sean williams,,ENGL-3040,2014
+ENGL,3040,012,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexander kudera,,ENGL-3040,2014
+ENGL,3040,013,Business Writing,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,sherri teres allred,,ENGL-3040,2014
+ENGL,3040,015,Business Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,,ENGL-3040,2014
+ENGL,3040,016,Business Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alexander kudera,,ENGL-3040,2014
+ENGL,3100,001,Crit Writ Lit,0.44,0.22,0.17,0.0,0.0,0.0,0.0,0.17,david sweene coombs,,ENGL-3100,2014
+ENGL,3100,002,Crit Writ Lit,0.26,0.37,0.21,0.0,0.05,0.0,0.0,0.11,erin marina goss,,ENGL-3100,2014
+ENGL,3100,003,Crit Writ Lit,0.14,0.62,0.14,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,,ENGL-3100,2014
+ENGL,3120,001,Advanced Composition,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2014
+ENGL,3120,002,Advanced Composition,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2014
+ENGL,3140,001,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2014
+ENGL,3140,002,Technical Writing,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,,ENGL-3140,2014
+ENGL,3140,003,Technical Writing,0.29,0.29,0.12,0.06,0.06,0.0,0.0,0.18,katalin beck,,ENGL-3140,2014
+ENGL,3140,004,Technical Writing,0.63,0.16,0.05,0.0,0.05,0.0,0.0,0.11,matthew schilleman,,ENGL-3140,2014
+ENGL,3140,005,Technical Writing,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,meg woosley-goodman,,ENGL-3140,2014
+ENGL,3140,006,Technical Writing,0.44,0.19,0.13,0.06,0.0,0.0,0.0,0.19,meg woosley-goodman,,ENGL-3140,2014
+ENGL,3140,008,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,,ENGL-3140,2014
+ENGL,3140,009,Technical Writing,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2014
+ENGL,3140,010,Technical Writing,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-3140,2014
+ENGL,3140,011,Technical Writing,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,david stubblefield,,ENGL-3140,2014
+ENGL,3140,012,Technical Writing,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,katalin beck,,ENGL-3140,2014
+ENGL,3140,013,Technical Writing,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2014
+ENGL,3140,014,Technical Writing,0.29,0.53,0.06,0.12,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2014
+ENGL,3140,015,Technical Writing,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,meg woosley-goodman,,ENGL-3140,2014
+ENGL,3140,016,Technical Writing,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2014
+ENGL,3140,018,Technical Writing,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,megan eatman,,ENGL-3140,2014
+ENGL,3140,019,Technical Writing,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,meg woosley-goodman,,ENGL-3140,2014
+ENGL,3140,020,Technical Writing,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2014
+ENGL,3140,021,Technical Writing,0.39,0.28,0.11,0.0,0.06,0.0,0.0,0.17,matthew schilleman,,ENGL-3140,2014
+ENGL,3140,400,Technical Writing (O,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-3140,2014
+ENGL,3140,401,Technical Writing (O,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-3140,2014
+ENGL,3150,003,Sci Writing & Comm,0.12,0.76,0.06,0.0,0.0,0.0,0.0,0.06,barbara ramirez,,ENGL-3150,2014
+ENGL,3150,400,Sci Writing & Comm (,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2014
+ENGL,3150,401,Sci Writing & Comm (,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2014
+ENGL,3150,402,Sci Writing & Comm,0.53,0.13,0.07,0.2,0.07,0.0,0.0,0.0,carleton dew salley,,ENGL-3150,2014
+ENGL,3320,001,Visual Communication,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,megan eatman,,ENGL-3320,2014
+ENGL,3450,001,Structure of Fiction,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-3450,2014
+ENGL,3450,002,Structure of Fiction,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-3450,2014
+ENGL,3460,002,Structure of Poetry,0.58,0.16,0.0,0.0,0.21,0.0,0.0,0.05,sharon kathl nalley,,ENGL-3460,2014
+ENGL,3480,001,Structure Screenplay,0.72,0.17,0.06,0.0,0.06,0.0,0.0,0.0,joshua nei waggoner,,ENGL-3480,2014
+ENGL,3490,001,Tech/Pop Imagination,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,matthew schilleman,,ENGL-3490,2014
+ENGL,3530,001,Ethnic Am Lit,0.06,0.44,0.19,0.13,0.13,0.0,0.0,0.06,kimberly manganelli,,ENGL-3530,2014
+ENGL,3560,001,Science Fiction,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,lindsay carr thomas,,ENGL-3560,2014
+ENGL,3570,001,Film,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2014
+ENGL,3570,002,Film,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,agnieszka skrodzka,,ENGL-3570,2014
+ENGL,3570,003,Film,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06, barton palmer,,ENGL-3570,2014
+ENGL,3800,001,Women Writers,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-3800,2014
+ENGL,3850,001,Children's Lit,0.22,0.56,0.17,0.0,0.06,0.0,0.0,0.0,megan no macalystre,,ENGL-3850,2014
+ENGL,3960,001,Brit Lit Survey I,0.3,0.35,0.3,0.0,0.0,0.0,0.0,0.05,brian mcgrath,,ENGL-3960,2014
+ENGL,3960,002,Brit Lit Survey I,0.15,0.45,0.35,0.05,0.0,0.0,0.0,0.0,brian mcgrath,,ENGL-3960,2014
+ENGL,3960,003,Brit Lit Survey I,0.15,0.4,0.35,0.05,0.0,0.0,0.0,0.05,brian mcgrath,,ENGL-3960,2014
+ENGL,3970,001,Brit Lit Survey II,0.13,0.27,0.47,0.0,0.0,0.0,0.0,0.13,wayne chapman,,ENGL-3970,2014
+ENGL,3980,001,Amer Lit Survey I,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,jonathan beec field,,ENGL-3980,2014
+ENGL,3980,002,Amer Lit Survey I,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,rhondda robi thomas,,ENGL-3980,2014
+ENGL,4030,001,Classics in Trans,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-4030,2014
+ENGL,4110,001,Shakespeare,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4110,2014
+ENGL,4110,002,Shakespeare,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4110,2014
+ENGL,4140,001,Milton,0.08,0.69,0.15,0.0,0.0,0.0,0.0,0.08,lee morrissey,,ENGL-4140,2014
+ENGL,4180,001,English Novel,0.47,0.4,0.0,0.0,0.13,0.0,0.0,0.0,david sweene coombs,,ENGL-4180,2014
+ENGL,4210,001,Amer Lit 1800-1899,0.27,0.45,0.09,0.0,0.09,0.0,0.0,0.09,dominic mastroianni,,ENGL-4210,2014
+ENGL,4310,001,Modern Poetry,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,wayne chapman,,ENGL-4310,2014
+ENGL,4340,001,Environmental Lit,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,sean morey,,ENGL-4340,2014
+ENGL,4350,001,Literary Criticism,0.35,0.41,0.18,0.06,0.0,0.0,0.0,0.0,dominic mastroianni,,ENGL-4350,2014
+ENGL,4420,001,Cultural Studies,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,garry bertholf,,ENGL-4420,2014
+ENGL,4750,001,Writing for Media,0.39,0.39,0.11,0.06,0.0,0.0,0.0,0.06,gabriel and hankins,,ENGL-4750,2014
+ENGL,4780,001,Digital Literacy,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,gabriel and hankins,,ENGL-4780,2014
+ENGL,4820,001,Afr Am Lit to 1920,0.2,0.3,0.3,0.1,0.1,0.0,0.0,0.0,rhondda robi thomas,,ENGL-4820,2014
+ENGL,4910,001,Classical Rhetoric,0.19,0.44,0.38,0.0,0.0,0.0,0.0,0.0,brian mcgrath,,ENGL-4910,2014
+ENGL,4960,001,Senior Seminar,0.36,0.43,0.07,0.0,0.07,0.0,0.0,0.07,jonathan beec field,,ENGL-4960,2014
+ENGL,4960,002,Senior Seminar,0.1,0.4,0.3,0.1,0.0,0.0,0.0,0.1,lee morrissey,,ENGL-4960,2014
+ENGL,4960,003,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william stockton,,ENGL-4960,2014
+ENGL,8000,001,Introduction to Rese,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,,ENGL-8000,2014
+ENGL,8100,001,Literary Criticism &,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,angela naimou,,ENGL-8100,2014
+ENGL,8310,002,Special Topics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,agnieszka skrodzka,,ENGL-8310,2014
+ENGL,8520,001,Rhetoric & Prof Comm,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharon howard,,ENGL-8520,2014
+ENGR,1050,005,Engr Discip & Skills,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,elizabeth stephan,True,ENGR-1050,2014
+ENGR,1050,005,Engr Discip & Skills,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,john minor,True,ENGR-1050,2014
+ENGR,1050,007,Engr Discip & Skills,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,john minor,True,ENGR-1050,2014
+ENGR,1050,007,Engr Discip & Skills,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True,ENGR-1050,2014
+ENGR,1050,009,Engr Discipline & Sk,0.27,0.33,0.2,0.07,0.05,0.0,0.0,0.08,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,009,Engr Discipline & Sk,0.27,0.33,0.2,0.07,0.05,0.0,0.0,0.08,john minor,,ENGR-1050,2014
+ENGR,1050,011,Engr Discipline & Sk,0.27,0.3,0.18,0.06,0.05,0.0,0.0,0.14,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,011,Engr Discipline & Sk,0.27,0.3,0.18,0.06,0.05,0.0,0.0,0.14,ashley childers,,ENGR-1050,2014
+ENGR,1050,013,Engr Discipl & Skill,0.3,0.46,0.15,0.04,0.0,0.0,0.0,0.04,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,013,Engr Discipl & Skill,0.3,0.46,0.15,0.04,0.0,0.0,0.0,0.04,john minor,,ENGR-1050,2014
+ENGR,1050,015,Engr Discipl & Skill,0.28,0.23,0.43,0.02,0.02,0.0,0.0,0.02,christopher norfolk,,ENGR-1050,2014
+ENGR,1050,015,Engr Discipl & Skill,0.28,0.23,0.43,0.02,0.02,0.0,0.0,0.02,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,017,Engr Discipline & Sk,0.23,0.31,0.25,0.08,0.08,0.0,0.0,0.05,william martin,,ENGR-1050,2014
+ENGR,1050,017,Engr Discipline & Sk,0.23,0.31,0.25,0.08,0.08,0.0,0.0,0.05,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,019,Engr Discipline & Sk,0.21,0.27,0.24,0.05,0.1,0.0,0.0,0.14,steven brandon,,ENGR-1050,2014
+ENGR,1050,019,Engr Discipline & Sk,0.21,0.27,0.24,0.05,0.1,0.0,0.0,0.14,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,021,Engr Discipline & Sk,0.24,0.41,0.24,0.03,0.02,0.0,0.0,0.06,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,021,Engr Discipline & Sk,0.24,0.41,0.24,0.03,0.02,0.0,0.0,0.06,ashley childers,,ENGR-1050,2014
+ENGR,1050,025,Engr Discipline & Sk,0.17,0.38,0.24,0.05,0.05,0.0,0.0,0.12,sarah grigg,,ENGR-1050,2014
+ENGR,1050,025,Engr Discipline & Sk,0.17,0.38,0.24,0.05,0.05,0.0,0.0,0.12,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,027,Engr Discipline & Sk,0.26,0.3,0.24,0.03,0.14,0.0,0.0,0.03,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,027,Engr Discipline & Sk,0.26,0.3,0.24,0.03,0.14,0.0,0.0,0.03,john minor,,ENGR-1050,2014
+ENGR,1050,029,Engr Discipline & Sk,0.22,0.29,0.22,0.11,0.02,0.0,0.0,0.14,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,029,Engr Discipline & Sk,0.22,0.29,0.22,0.11,0.02,0.0,0.0,0.14,david ewing,,ENGR-1050,2014
+ENGR,1050,031,Engr Discipline & Sk,0.23,0.41,0.21,0.02,0.05,0.0,0.0,0.09,william martin,,ENGR-1050,2014
+ENGR,1050,031,Engr Discipline & Sk,0.23,0.41,0.21,0.02,0.05,0.0,0.0,0.09,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,033,Engr Discipline & Sk,0.22,0.32,0.21,0.11,0.03,0.0,0.0,0.11,matthew kent miller,,ENGR-1050,2014
+ENGR,1050,033,Engr Discipline & Sk,0.22,0.32,0.21,0.11,0.03,0.0,0.0,0.11,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,034,Engr Discipl & Skill,0.38,0.36,0.09,0.09,0.04,0.0,0.0,0.04,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,034,Engr Discipl & Skill,0.38,0.36,0.09,0.09,0.04,0.0,0.0,0.04,steven brandon,,ENGR-1050,2014
+ENGR,1050,050,Engr Discip & Skills,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,john minor,True,ENGR-1050,2014
+ENGR,1050,050,Engr Discip & Skills,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True,ENGR-1050,2014
+ENGR,1050,056,Engr Discipl & Skill,0.2,0.38,0.16,0.02,0.02,0.0,0.0,0.22,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,056,Engr Discipl & Skill,0.2,0.38,0.16,0.02,0.02,0.0,0.0,0.22,john minor,,ENGR-1050,2014
+ENGR,1050,058,Engr Discipl & Skill,0.37,0.33,0.16,0.05,0.0,0.0,0.0,0.09,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,058,Engr Discipl & Skill,0.37,0.33,0.16,0.05,0.0,0.0,0.0,0.09,john minor,,ENGR-1050,2014
+ENGR,1050,060,Engr Discipl & Skill,0.27,0.31,0.27,0.04,0.02,0.0,0.0,0.09,william martin,,ENGR-1050,2014
+ENGR,1050,060,Engr Discipl & Skill,0.27,0.31,0.27,0.04,0.02,0.0,0.0,0.09,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,062,Engr Discipl & Skill,0.23,0.45,0.16,0.05,0.02,0.0,0.0,0.09,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,062,Engr Discipl & Skill,0.23,0.45,0.16,0.05,0.02,0.0,0.0,0.09,christopher norfolk,,ENGR-1050,2014
+ENGR,1050,064,Engr Discipl & Skill,0.17,0.57,0.09,0.09,0.02,0.0,0.0,0.06,steven brandon,,ENGR-1050,2014
+ENGR,1050,064,Engr Discipl & Skill,0.17,0.57,0.09,0.09,0.02,0.0,0.0,0.06,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,111,Engr Discipline & Sk,0.08,0.33,0.35,0.08,0.15,0.0,0.0,0.02,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,111,Engr Discipline & Sk,0.08,0.33,0.35,0.08,0.15,0.0,0.0,0.02,john minor,,ENGR-1050,2014
+ENGR,1050,112,Engr Discip & Skills,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True,ENGR-1050,2014
+ENGR,1050,112,Engr Discip & Skills,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True,ENGR-1050,2014
+ENGR,1050,113,Engr Discipline & Sk,0.15,0.24,0.26,0.13,0.19,0.0,0.0,0.03,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,113,Engr Discipline & Sk,0.15,0.24,0.26,0.13,0.19,0.0,0.0,0.03,richard watkins,,ENGR-1050,2014
+ENGR,1050,117,Engr Discipline & Sk,0.15,0.26,0.29,0.08,0.1,0.0,0.0,0.13,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,119,Engr Discipline & Sk,0.27,0.32,0.17,0.02,0.03,0.0,0.0,0.19,matthew kent miller,,ENGR-1050,2014
+ENGR,1050,119,Engr Discipline & Sk,0.27,0.32,0.17,0.02,0.03,0.0,0.0,0.19,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,400,Engr Discipline & Sk,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,elizabeth stephan,,ENGR-1050,2014
+ENGR,1050,400,Engr Discipline & Sk,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,elizabeth stephan,,ENGR-1050,2014
+ENGR,1060,005,Engr Discip & Skills,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,john minor,True,ENGR-1060,2014
+ENGR,1060,005,Engr Discip & Skills,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,elizabeth stephan,True,ENGR-1060,2014
+ENGR,1060,007,Engr Discip & Skills,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True,ENGR-1060,2014
+ENGR,1060,007,Engr Discip & Skills,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True,ENGR-1060,2014
+ENGR,1060,009,Engr Discipline & Sk,0.02,0.17,0.29,0.14,0.06,0.0,0.0,0.31,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,011,Engr Discipline & Sk,0.17,0.28,0.34,0.06,0.02,0.0,0.0,0.13,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,011,Engr Discipline & Sk,0.17,0.28,0.34,0.06,0.02,0.0,0.0,0.13,ashley childers,,ENGR-1060,2014
+ENGR,1060,012,Engr Discip & Skills,0.05,0.33,0.4,0.1,0.0,0.0,0.0,0.12,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,012,Engr Discip & Skills,0.05,0.33,0.4,0.1,0.0,0.0,0.0,0.12,john minor,,ENGR-1060,2014
+ENGR,1060,013,Engr Discip & Skills,0.07,0.3,0.36,0.11,0.11,0.0,0.0,0.05,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,013,Engr Discip & Skills,0.07,0.3,0.36,0.11,0.11,0.0,0.0,0.05,christopher norfolk,,ENGR-1060,2014
+ENGR,1060,014,Engr Discipline & Sk,0.15,0.35,0.2,0.2,0.05,0.0,0.0,0.05,william park,,ENGR-1060,2014
+ENGR,1060,014,Engr Discipline & Sk,0.15,0.35,0.2,0.2,0.05,0.0,0.0,0.05,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,016,Engr Discipline & Sk,0.21,0.42,0.32,0.0,0.05,0.0,0.0,0.0,john minor,,ENGR-1060,2014
+ENGR,1060,016,Engr Discipline & Sk,0.21,0.42,0.32,0.0,0.05,0.0,0.0,0.0,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,017,Engr Discipline & Sk,0.14,0.26,0.3,0.14,0.04,0.0,0.0,0.12,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,017,Engr Discipline & Sk,0.14,0.26,0.3,0.14,0.04,0.0,0.0,0.12,william martin,,ENGR-1060,2014
+ENGR,1060,019,Engr Discipline & Sk,0.11,0.26,0.24,0.15,0.09,0.0,0.0,0.15,steven brandon,,ENGR-1060,2014
+ENGR,1060,019,Engr Discipline & Sk,0.11,0.26,0.24,0.15,0.09,0.0,0.0,0.15,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,021,Engr Discipline & Sk,0.17,0.24,0.28,0.19,0.04,0.0,0.0,0.09,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,021,Engr Discipline & Sk,0.17,0.24,0.28,0.19,0.04,0.0,0.0,0.09,ashley childers,,ENGR-1060,2014
+ENGR,1060,025,Engr Discipline & Sk,0.12,0.27,0.22,0.12,0.1,0.0,0.0,0.18,sarah grigg,,ENGR-1060,2014
+ENGR,1060,025,Engr Discipline & Sk,0.12,0.27,0.22,0.12,0.1,0.0,0.0,0.18,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,027,Engr Discipline & Sk,0.1,0.31,0.31,0.19,0.06,0.0,0.0,0.04,john minor,,ENGR-1060,2014
+ENGR,1060,027,Engr Discipline & Sk,0.1,0.31,0.31,0.19,0.06,0.0,0.0,0.04,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,029,Engr Discipline & Sk,0.16,0.23,0.35,0.14,0.07,0.0,0.0,0.05,david ewing,,ENGR-1060,2014
+ENGR,1060,029,Engr Discipline & Sk,0.16,0.23,0.35,0.14,0.07,0.0,0.0,0.05,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,031,Engr Discipline & Sk,0.07,0.25,0.36,0.14,0.11,0.0,0.0,0.07,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,031,Engr Discipline & Sk,0.07,0.25,0.36,0.14,0.11,0.0,0.0,0.07,william martin,,ENGR-1060,2014
+ENGR,1060,050,Engr Discip & Skills,0.59,0.28,0.03,0.03,0.0,0.0,0.0,0.07,elizabeth stephan,True,ENGR-1060,2014
+ENGR,1060,050,Engr Discip & Skills,0.59,0.28,0.03,0.03,0.0,0.0,0.0,0.07,john minor,True,ENGR-1060,2014
+ENGR,1060,052,Engr Discip & Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True,ENGR-1060,2014
+ENGR,1060,052,Engr Discip & Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True,ENGR-1060,2014
+ENGR,1060,056,Engr Discip & Skills,0.06,0.48,0.21,0.12,0.0,0.0,0.0,0.12,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,056,Engr Discip & Skills,0.06,0.48,0.21,0.12,0.0,0.0,0.0,0.12,john minor,,ENGR-1060,2014
+ENGR,1060,058,Engr Discip & Skills,0.16,0.43,0.3,0.03,0.0,0.0,0.0,0.08,john minor,,ENGR-1060,2014
+ENGR,1060,058,Engr Discip & Skills,0.16,0.43,0.3,0.03,0.0,0.0,0.0,0.08,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,060,Engr Discip & Skills,0.03,0.38,0.24,0.19,0.05,0.0,0.0,0.11,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,060,Engr Discip & Skills,0.03,0.38,0.24,0.19,0.05,0.0,0.0,0.11,william martin,,ENGR-1060,2014
+ENGR,1060,062,Engr Discip & Skills,0.05,0.32,0.41,0.08,0.08,0.0,0.0,0.05,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,062,Engr Discip & Skills,0.05,0.32,0.41,0.08,0.08,0.0,0.0,0.05,christopher norfolk,,ENGR-1060,2014
+ENGR,1060,064,Engr Discip & Skills,0.08,0.53,0.18,0.13,0.03,0.0,0.0,0.05,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,064,Engr Discip & Skills,0.08,0.53,0.18,0.13,0.03,0.0,0.0,0.05,steven brandon,,ENGR-1060,2014
+ENGR,1060,066,Engr Discipline & Sk,0.1,0.27,0.31,0.12,0.06,0.0,0.0,0.14,matthew kent miller,,ENGR-1060,2014
+ENGR,1060,066,Engr Discipline & Sk,0.1,0.27,0.31,0.12,0.06,0.0,0.0,0.14,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,112,Engr Discip & Skills,0.53,0.4,0.03,0.0,0.0,0.0,0.0,0.03,steven brandon,True,ENGR-1060,2014
+ENGR,1060,112,Engr Discip & Skills,0.53,0.4,0.03,0.0,0.0,0.0,0.0,0.03,elizabeth stephan,True,ENGR-1060,2014
+ENGR,1060,117,Engr Discipline & Sk,0.0,0.21,0.23,0.23,0.16,0.0,0.0,0.16,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,119,Engr Discipline & Sk,0.06,0.31,0.25,0.17,0.06,0.0,0.0,0.15,elizabeth stephan,,ENGR-1060,2014
+ENGR,1060,119,Engr Discipline & Sk,0.06,0.31,0.25,0.17,0.06,0.0,0.0,0.15,matthew kent miller,,ENGR-1060,2014
+ENGR,1060,170,Engr Discip & Skills,0.11,0.47,0.24,0.11,0.03,0.0,0.0,0.05,steven brandon,,ENGR-1060,2014
+ENGR,1060,170,Engr Discip & Skills,0.11,0.47,0.24,0.11,0.03,0.0,0.0,0.05,elizabeth stephan,,ENGR-1060,2014
+ENGR,1070,012,Programming & Prob S,0.08,0.19,0.29,0.16,0.08,0.0,0.0,0.19,david ewing,,ENGR-1070,2014
+ENGR,1070,012,Programming & Prob S,0.08,0.19,0.29,0.16,0.08,0.0,0.0,0.19,john minor,,ENGR-1070,2014
+ENGR,1070,018,Programming & Prob S,0.05,0.16,0.25,0.23,0.13,0.0,0.0,0.19,john minor,,ENGR-1070,2014
+ENGR,1070,018,Programming & Prob S,0.05,0.16,0.25,0.23,0.13,0.0,0.0,0.19,david ewing,,ENGR-1070,2014
+ENGR,1070,020,Programming & Prob S,0.02,0.14,0.34,0.16,0.2,0.0,0.0,0.14,william park,,ENGR-1070,2014
+ENGR,1070,020,Programming & Prob S,0.02,0.14,0.34,0.16,0.2,0.0,0.0,0.14,david ewing,,ENGR-1070,2014
+ENGR,1070,022,Program and Problem,0.02,0.2,0.24,0.11,0.22,0.0,0.0,0.22,william park,,ENGR-1070,2014
+ENGR,1070,022,Program and Problem,0.02,0.2,0.24,0.11,0.22,0.0,0.0,0.22,david ewing,,ENGR-1070,2014
+ENGR,1070,072,Program & Prob Solvi,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,david ewing,True,ENGR-1070,2014
+ENGR,1070,072,Program & Prob Solvi,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,john minor,True,ENGR-1070,2014
+ENGR,1080,018,Programming & Prob S,0.09,0.12,0.39,0.24,0.09,0.0,0.0,0.06,david ewing,,ENGR-1080,2014
+ENGR,1080,018,Programming & Prob S,0.09,0.12,0.39,0.24,0.09,0.0,0.0,0.06,john minor,,ENGR-1080,2014
+ENGR,1080,020,Programming & Prob S,0.24,0.18,0.33,0.15,0.09,0.0,0.0,0.0,john minor,,ENGR-1080,2014
+ENGR,1080,020,Programming & Prob S,0.24,0.18,0.33,0.15,0.09,0.0,0.0,0.0,david ewing,,ENGR-1080,2014
+ENGR,1080,022,Programming & Prob S,0.28,0.22,0.25,0.13,0.13,0.0,0.0,0.0,david ewing,,ENGR-1080,2014
+ENGR,1080,022,Programming & Prob S,0.28,0.22,0.25,0.13,0.13,0.0,0.0,0.0,william park,,ENGR-1080,2014
+ENGR,1080,056,Program/Prob Solving,0.04,0.43,0.13,0.13,0.26,0.0,0.0,0.0,william park,,ENGR-1080,2014
+ENGR,1080,056,Program/Prob Solving,0.04,0.43,0.13,0.13,0.26,0.0,0.0,0.0,david ewing,,ENGR-1080,2014
+ENGR,1080,072,Program/Prob Solving,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,david ewing,True,ENGR-1080,2014
+ENGR,1080,072,Program/Prob Solving,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True,ENGR-1080,2014
+ENGR,1090,020,Prog/Problem Solving,0.28,0.48,0.2,0.03,0.0,0.0,0.0,0.03,david ewing,,ENGR-1090,2014
+ENGR,1090,020,Prog/Problem Solving,0.28,0.48,0.2,0.03,0.0,0.0,0.0,0.03,john minor,,ENGR-1090,2014
+ENGR,1090,024,Prog/Problem Solving,0.36,0.43,0.19,0.02,0.0,0.0,0.0,0.0,david ewing,,ENGR-1090,2014
+ENGR,1090,024,Prog/Problem Solving,0.36,0.43,0.19,0.02,0.0,0.0,0.0,0.0,john minor,,ENGR-1090,2014
+ENGR,1090,028,Prog/Problem Solving,0.43,0.33,0.17,0.07,0.0,0.0,0.0,0.0,david ewing,,ENGR-1090,2014
+ENGR,1090,056,Prog/Problem Solv Ap,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True,ENGR-1090,2014
+ENGR,1090,056,Prog/Problem Solv Ap,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,david ewing,True,ENGR-1090,2014
+ENGR,1900,013,CI in ENGR Architect,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christopher norfolk,,ENGR-1900,2014
+ENGR,1900,013,CI in ENGR Architect,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1900,2014
+ENGR,1900,014,CI in ENGR Public Po,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,jonathan maier,,ENGR-1900,2014
+ENGR,1900,014,CI in ENGR Public Po,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,christopher norfolk,,ENGR-1900,2014
+ENGR,1900,017,CI  in ENGR What ENG,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,bradley putman,,ENGR-1900,2014
+ENGR,1900,017,CI  in ENGR What ENG,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,jonathan maier,,ENGR-1900,2014
+ENGR,1900,077,CI in ENGR Huan Powe,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,jonathan maier,,ENGR-1900,2014
+ENGR,1900,077,CI in ENGR Huan Powe,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,gregory mocko,,ENGR-1900,2014
+ENGR,2080,023,Engr Graphics & Mach,0.43,0.2,0.2,0.04,0.06,0.0,0.0,0.07,john minor,,ENGR-2080,2014
+ENGR,2080,023,Engr Graphics & Mach,0.43,0.2,0.2,0.04,0.06,0.0,0.0,0.07,sarah grigg,,ENGR-2080,2014
+ENGR,2080,028,Engr Graphics & Mach,0.3,0.39,0.11,0.01,0.09,0.0,0.0,0.09,sarah grigg,,ENGR-2080,2014
+ENGR,2080,028,Engr Graphics & Mach,0.3,0.39,0.11,0.01,0.09,0.0,0.0,0.09,john minor,,ENGR-2080,2014
+ENGR,2080,030,Engr Graphics & Mach,0.41,0.3,0.16,0.05,0.0,0.0,0.0,0.09,sarah grigg,,ENGR-2080,2014
+ENGR,2080,030,Engr Graphics & Mach,0.41,0.3,0.16,0.05,0.0,0.0,0.0,0.09,john minor,,ENGR-2080,2014
+ENGR,2080,053,Engr Graphics & Mach,0.28,0.32,0.19,0.02,0.11,0.0,0.0,0.09,sarah grigg,,ENGR-2080,2014
+ENGR,2080,053,Engr Graphics & Mach,0.28,0.32,0.19,0.02,0.11,0.0,0.0,0.09,john minor,,ENGR-2080,2014
+ENGR,2080,055,Engr Graphics & Mach,0.38,0.28,0.23,0.04,0.04,0.0,0.0,0.02,jonathan maier,,ENGR-2080,2014
+ENGR,2080,055,Engr Graphics & Mach,0.38,0.28,0.23,0.04,0.04,0.0,0.0,0.02,sarah grigg,,ENGR-2080,2014
+ENGR,2100,032,CAD & Engineering Ap,0.43,0.34,0.09,0.05,0.02,0.0,0.0,0.07,john minor,,ENGR-2100,2014
+ENGR,2100,032,CAD & Engineering Ap,0.43,0.34,0.09,0.05,0.02,0.0,0.0,0.07,nighat yasmin,,ENGR-2100,2014
+ENGR,2100,036,CAD & Engineering Ap,0.5,0.18,0.11,0.02,0.07,0.0,0.0,0.11,nighat yasmin,,ENGR-2100,2014
+ENGR,2100,036,CAD & Engineering Ap,0.5,0.18,0.11,0.02,0.07,0.0,0.0,0.11,john minor,,ENGR-2100,2014
+ENGR,2100,040,CAD & Engineering Ap,0.4,0.35,0.1,0.03,0.13,0.0,0.0,0.0,john minor,,ENGR-2100,2014
+ENGR,2100,040,CAD & Engineering Ap,0.4,0.35,0.1,0.03,0.13,0.0,0.0,0.0,nighat yasmin,,ENGR-2100,2014
+ENGR,2100,044,CAD & Engineering Ap,0.43,0.26,0.22,0.02,0.0,0.0,0.0,0.07,john minor,,ENGR-2100,2014
+ENGR,2100,044,CAD & Engineering Ap,0.43,0.26,0.22,0.02,0.0,0.0,0.0,0.07,william martin,,ENGR-2100,2014
+ENR,1010,001,Intro to Envir & Nat,0.7,0.17,0.06,0.02,0.04,0.0,0.0,0.02,alan johnson,,ENR-1010,2014
+ENR,1010,001,Intro Env & Nat Rs I,0.7,0.17,0.06,0.02,0.04,0.0,0.0,0.02,alan johnson,,ENR-1010,2014
+ENR,1010,002,Intro to Envir & Nat,0.65,0.12,0.1,0.06,0.04,0.0,0.0,0.02,alan johnson,,ENR-1010,2014
+ENR,4290,001,Environ Law & Policy,0.47,0.38,0.09,0.03,0.03,0.0,0.0,0.0,alan johnson,,ENR-4290,2014
+ENSP,2000,001,Intro Environ Sci,0.67,0.22,0.08,0.0,0.0,0.0,0.0,0.02,scott brame,,ENSP-2000,2014
+ENSP,2000,002,Intro Environ Sci,0.66,0.28,0.04,0.0,0.02,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2014
+ENSP,2000,003,Intro Environ Sci,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2014
+ENSP,4000,001,Studies in En Sp,0.68,0.14,0.09,0.05,0.05,0.0,0.0,0.0,margaret thompson,,ENSP-4000,2014
+ENT,2000,001,Six-Legged Science,0.71,0.13,0.08,0.0,0.0,0.0,0.0,0.08,suellen pometto,,ENT-2000,2014
+ENT,2010,001,Selected Topics,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,joseph culin,,ENT-2010,2014
+ENT,3010,001,Insect Biology & Div,0.33,0.33,0.17,0.0,0.17,0.0,0.0,0.0,eric benson,,ENT-3010,2014
+ESED,8000,001,Seminar in Engr & Sc,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,julie patric martin,,ESED-8000,2014
+ESED,8000,001,Seminar in Engr & Sc,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,karen ann high,,ESED-8000,2014
+ESED,8200,001,Teaching Undergrad E,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,karen ann high,,ESED-8200,2014
+ESED,8200,001,Teaching Undergrad E,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,,ESED-8200,2014
+ESED,8750,001,Curr Issues in STEM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,,ESED-8750,2014
+ESED,8750,001,Curr Issues in STEM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,karen ann high,,ESED-8750,2014
+ETOX,4300,001,Toxicology,0.18,0.45,0.18,0.0,0.0,0.0,0.0,0.18,peter van den hurk,,ETOX-4300,2014
+ETOX,6300,001,Toxicology,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,peter van den hurk,,ETOX-6300,2014
+FCS,8130,003,Research Methods in,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,natallia ser sianko,,FCS-8130,2014
+FCS,8130,003,Research Methods in,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,,FCS-8130,2014
+FDSC,1010,001,Intro to Food Sci &,0.69,0.25,0.02,0.01,0.04,0.0,0.0,0.0,rita haliena,,FDSC-1010,2014
+FDSC,1010,001,Intro to Food Sci &,0.69,0.25,0.02,0.01,0.04,0.0,0.0,0.0,aubrey dean coffee,,FDSC-1010,2014
+FDSC,3010,001,Food Regulations,0.75,0.2,0.0,0.03,0.0,0.0,0.0,0.03,julie kat northcutt,,FDSC-3010,2014
+FDSC,3060,001,Institutional Foodse,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,,FDSC-3060,2014
+FDSC,3070,001,Restaurant Food Serv,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,margaret condrasky,,FDSC-3070,2014
+FDSC,4010,001,Food Chem I,0.78,0.16,0.03,0.01,0.0,0.0,0.0,0.01,ronnie thomas,,FDSC-4010,2014
+FDSC,4040,001,Food Prsv & Process,0.28,0.51,0.18,0.03,0.0,0.0,0.0,0.0,julie kat northcutt,,FDSC-4040,2014
+FDSC,4070,001,Quantity Food Produc,0.43,0.49,0.06,0.01,0.0,0.0,0.0,0.01,heather batt,,FDSC-4070,2014
+FDSC,4170,001,Seminar,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,aubrey dean coffee,,FDSC-4170,2014
+FDSC,4300,001,Dairy Process & Sant,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-4300,2014
+FDSC,8120,001,Microbial Food Syst,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,xiuping jiang,,FDSC-8120,2014
+FIN,3040,001,Risk & Insurance,0.0,0.38,0.38,0.08,0.15,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2014
+FIN,3040,002,Risk & Insurance,0.21,0.32,0.34,0.11,0.0,0.0,0.0,0.03,kerri mcmillan,,FIN-3040,2014
+FIN,3050,001,Investment Analysis,0.16,0.47,0.23,0.09,0.0,0.0,0.0,0.05,kerri mcmillan,,FIN-3050,2014
+FIN,3050,002,Investment Analysis,0.22,0.41,0.27,0.07,0.02,0.0,0.0,0.02,kerri mcmillan,,FIN-3050,2014
+FIN,3050,003,Investment Analysis,0.1,0.26,0.19,0.1,0.07,0.0,0.0,0.28,john alexander,,FIN-3050,2014
+FIN,3060,002,Corporation Finance,0.11,0.19,0.53,0.08,0.03,0.0,0.0,0.06,john harris,,FIN-3060,2014
+FIN,3060,003,Corporation Finance,0.08,0.57,0.28,0.06,0.0,0.0,0.0,0.02,neil waller,,FIN-3060,2014
+FIN,3060,004,Corporation Finance,0.23,0.48,0.15,0.08,0.03,0.0,0.0,0.05,john harris,,FIN-3060,2014
+FIN,3060,005,Corporation Finance,0.08,0.62,0.23,0.08,0.0,0.0,0.0,0.0,neil waller,,FIN-3060,2014
+FIN,3060,006,Corporation Finance,0.07,0.2,0.49,0.07,0.05,0.0,0.0,0.12,john harris,,FIN-3060,2014
+FIN,3060,007,Corporation Finance,0.16,0.51,0.24,0.08,0.0,0.0,0.0,0.02,neil waller,,FIN-3060,2014
+FIN,3060,008,Corporation Finance,0.28,0.3,0.07,0.17,0.09,0.0,0.0,0.09,william hol johnson,,FIN-3060,2014
+FIN,3060,009,Corporation Finance,0.22,0.38,0.25,0.0,0.03,0.0,0.0,0.13,john harris,,FIN-3060,2014
+FIN,3060,010,Corporation Finance,0.28,0.2,0.28,0.13,0.03,0.0,0.0,0.1,william hol johnson,,FIN-3060,2014
+FIN,3060,011,Corporation Finance,0.3,0.28,0.17,0.11,0.06,0.0,0.0,0.09,william hol johnson,,FIN-3060,2014
+FIN,3070,001,Prin of Real Estate,0.15,0.4,0.32,0.09,0.02,0.0,0.0,0.02,thomas springer,,FIN-3070,2014
+FIN,3070,002,Prin of Real Estate,0.15,0.44,0.33,0.04,0.04,0.0,0.0,0.0,thomas springer,,FIN-3070,2014
+FIN,3080,001,Fin Inst & Mkts,0.23,0.37,0.2,0.13,0.03,0.0,0.0,0.03,daniel thoma greene,,FIN-3080,2014
+FIN,3080,002,Fin Inst & Mkts,0.13,0.3,0.4,0.08,0.08,0.0,0.0,0.03,michael spivey,,FIN-3080,2014
+FIN,3080,003,Fin Inst & Mkts,0.21,0.36,0.29,0.07,0.02,0.0,0.0,0.05,michael spivey,,FIN-3080,2014
+FIN,3110,001,Financial Management,0.17,0.26,0.33,0.17,0.0,0.0,0.0,0.07,jared daniel smith,,FIN-3110,2014
+FIN,3110,002,Financial Management,0.17,0.34,0.37,0.07,0.05,0.0,0.0,0.0,jared daniel smith,,FIN-3110,2014
+FIN,3110,003,Financial Management,0.3,0.34,0.16,0.11,0.05,0.0,0.0,0.05,fei xie,,FIN-3110,2014
+FIN,3110,004,Financial Management,0.3,0.43,0.18,0.02,0.02,0.0,0.0,0.05,fei xie,,FIN-3110,2014
+FIN,3120,001,Financial Mgt II,0.09,0.31,0.38,0.16,0.0,0.0,0.0,0.06,lyudmila chernykh,,FIN-3120,2014
+FIN,3120,002,Financial Mgt II,0.32,0.38,0.22,0.05,0.0,0.0,0.0,0.03,lyudmila chernykh,,FIN-3120,2014
+FIN,3120,003,Financial Mgt II,0.53,0.19,0.16,0.02,0.02,0.0,0.0,0.07,melvin stith,,FIN-3120,2014
+FIN,3120,004,Financial Mgt II,0.72,0.11,0.15,0.02,0.0,0.0,0.0,0.0,melvin stith,,FIN-3120,2014
+FIN,4020,001,Corporate Valuation,0.35,0.28,0.25,0.13,0.0,0.0,0.0,0.0,angela morgan,,FIN-4020,2014
+FIN,4020,003,Corporate Valuation,0.07,0.4,0.38,0.1,0.02,0.0,0.0,0.02,angela morgan,,FIN-4020,2014
+FIN,4050,001,Port Mgt and Theory,0.14,0.18,0.39,0.14,0.0,0.0,0.0,0.14,john alexander,,FIN-4050,2014
+FIN,4060,001,Derivatives Analysis,0.21,0.38,0.25,0.04,0.04,0.0,0.0,0.08,george bra lockhart,,FIN-4060,2014
+FIN,4110,001,Int Fin Mgt,0.25,0.33,0.3,0.05,0.03,0.0,0.0,0.05,tilan tang,,FIN-4110,2014
+FIN,4110,002,Int Fin Mgt,0.47,0.16,0.16,0.05,0.05,0.0,0.0,0.11,tilan tang,,FIN-4110,2014
+FIN,4170,001,Real Estate Finance,0.36,0.36,0.27,0.0,0.0,0.0,0.0,0.0,neil waller,,FIN-4170,2014
+FNR,2040,001,Soil Information Sys,0.72,0.22,0.03,0.02,0.0,0.0,0.0,0.02,elena mikhailova,,FNR-2040,2014
+FOR,2050,001,Dendrology,0.25,0.31,0.19,0.16,0.09,0.0,0.0,0.0,donald hagan,,FOR-2050,2014
+FOR,2050,002,Dendrology,0.18,0.24,0.35,0.24,0.0,0.0,0.0,0.0,donald hagan,,FOR-2050,2014
+FOR,2050,003,Dendrology,0.31,0.23,0.2,0.11,0.09,0.0,0.0,0.06,donald hagan,,FOR-2050,2014
+FOR,2210,001,Forest Biology,0.46,0.4,0.09,0.02,0.01,0.0,0.0,0.01,patrick mcmillan,,FOR-2210,2014
+FOR,3020,001,Forest Biometrics,0.41,0.23,0.18,0.14,0.05,0.0,0.0,0.0,lawrence gering,,FOR-3020,2014
+FOR,3040,001,Forest Res Econ,0.38,0.24,0.24,0.11,0.03,0.0,0.0,0.0,john edward hatcher,,FOR-3040,2014
+FOR,4100,001,Harvesting Processes,0.36,0.27,0.27,0.09,0.0,0.0,0.0,0.0,greg yarrow,,FOR-4100,2014
+FOR,4130,001,Int Forest Pest Mgmt,0.22,0.39,0.3,0.09,0.0,0.0,0.0,0.0,robert bellinger,,FOR-4130,2014
+FOR,4130,001,Int Forest Pest Mgmt,0.22,0.39,0.3,0.09,0.0,0.0,0.0,0.0,julia loui kerrigan,,FOR-4130,2014
+FOR,4160,001,For Pol and Adm,0.45,0.4,0.14,0.02,0.0,0.0,0.0,0.0,thomas straka,,FOR-4160,2014
+FOR,4170,001,For Res Mgt and Reg,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,john edward hatcher,,FOR-4170,2014
+FOR,4310,001,Mgt for Recreation,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert baxte powell,,FOR-4310,2014
+FOR,4340,001,GIS for Landscape Pl,0.5,0.46,0.02,0.0,0.02,0.0,0.0,0.0,christopher post,,FOR-4340,2014
+FOR,4930,200,Wildland and Prescri,0.45,0.34,0.0,0.0,0.07,0.0,0.0,0.14,donald hagan,,FOR-4930,2014
+FR,1010,001,Elementary French,0.74,0.16,0.0,0.05,0.05,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1010,2014
+FR,1020,001,Elementary French,0.75,0.15,0.0,0.05,0.0,0.0,0.0,0.05,amy lyn grif sawyer,,FR-1020,2014
+FR,1020,002,Elementary French,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2014
+FR,1020,003,Elementary French,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,julian hamil killey,,FR-1020,2014
+FR,2010,001,Intermediate French,0.56,0.22,0.11,0.06,0.0,0.0,0.0,0.06,joseph mai,,FR-2010,2014
+FR,2010,002,Intermediate French,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,kenneth dav widgren,,FR-2010,2014
+FR,2010,003,Intermediate French,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-2010,2014
+FR,2010,004,Intermediate French,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,julian hamil killey,,FR-2010,2014
+FR,2020,001,Intermediate French,0.85,0.0,0.1,0.0,0.0,0.0,0.0,0.05,amy lyn grif sawyer,,FR-2020,2014
+FR,2020,002,Intermediate French,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,,FR-2020,2014
+FR,2020,003,Intermediate French,0.35,0.29,0.24,0.0,0.0,0.0,0.0,0.12,kenneth dav widgren,,FR-2020,2014
+FR,3040,001,French Short Story,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,eric touya,,FR-3040,2014
+FR,3050,001,Int Fr Con & Comp I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-3050,2014
+FR,3070,001,French Civilization,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-3070,2014
+FR,4160,001,Fr for Intl Trade II,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,eric touya,,FR-4160,2014
+GC,1010,001,Orientation to G C,0.78,0.14,0.08,0.0,0.0,0.0,0.0,0.0,rebecca suza edlein,,GC-1010,2014
+GC,1010,002,Orientation to G C,0.8,0.1,0.04,0.02,0.02,0.0,0.0,0.02,kern cox,,GC-1010,2014
+GC,1020,001,Comp Art & Cad Found,0.42,0.35,0.15,0.04,0.04,0.0,0.0,0.0,charles tabor weiss,,GC-1020,2014
+GC,1020,002,Comp Art & Cad Found,0.52,0.45,0.0,0.0,0.0,0.0,0.0,0.03,nona woolbright,,GC-1020,2014
+GC,1020,003,Comp Art & Cad Found,0.62,0.31,0.0,0.0,0.07,0.0,0.0,0.0,nona woolbright,,GC-1020,2014
+GC,1020,004,Comp Art & Cad Found,0.42,0.38,0.12,0.0,0.08,0.0,0.0,0.0,carol jones,,GC-1020,2014
+GC,1030,001,G C I for Pkgsc,0.29,0.38,0.24,0.05,0.0,0.0,0.0,0.05,john jacobs,,GC-1030,2014
+GC,1040,001,Graphic Com I,0.56,0.29,0.09,0.0,0.03,0.0,0.0,0.03,rebecca suza edlein,,GC-1040,2014
+GC,1040,001,Graphic Communicatio,0.56,0.29,0.09,0.0,0.03,0.0,0.0,0.03,rebecca suza edlein,,GC-1040,2014
+GC,1990,003,Cr Inquiry in G C I-,0.86,0.05,0.0,0.0,0.05,0.0,0.0,0.05,janice ann lay,,GC-1990,2014
+GC,2070,001,Graphic Communicatio,0.5,0.38,0.09,0.0,0.03,0.0,0.0,0.0,patrick gee rose,,GC-2070,2014
+GC,3400,001,Digital Img & Emedia,0.6,0.29,0.07,0.02,0.02,0.0,0.0,0.0,erica black walker,,GC-3400,2014
+GC,4060,001,Package and Specialt,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,kern cox,,GC-4060,2014
+GC,4400,001,Commercial Printing,0.29,0.67,0.0,0.0,0.04,0.0,0.0,0.0,eric weisenmiller,,GC-4400,2014
+GC,4400,002,Commercial Printing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,,GC-4400,2014
+GC,4440,001,Current Dev in G C,0.38,0.47,0.09,0.03,0.03,0.0,0.0,0.0,liam henry 'hara,,GC-4440,2014
+GC,4460,001,Ink & Substrates,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,liam henry 'hara,,GC-4460,2014
+GC,4460,002,Ink & Substrates,0.08,0.31,0.23,0.23,0.15,0.0,0.0,0.0,liam henry 'hara,,GC-4460,2014
+GC,4480,001,Plan and Cont Print,0.5,0.33,0.13,0.03,0.0,0.0,0.0,0.0,john leininger,,GC-4480,2014
+GC,4900,230,G C Selected Topics-,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,john leininger,,GC-4900,2014
+GC,6900,002,G C Selected Topics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,,GC-6900,2014
+GEN,1030,001,Careers in Bioch/Gen,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,alison starr-moss,,GEN-1030,2014
+GEN,3000,001,Fundamental Genetics,0.28,0.3,0.18,0.14,0.01,0.0,0.0,0.09,kate leanne wi tsai,,GEN-3000,2014
+GEN,3000,002,Fundamental Genetics,0.34,0.37,0.19,0.05,0.01,0.0,0.0,0.04,kate leanne wi tsai,,GEN-3000,2014
+GEN,3020,001,Molecular & General,0.23,0.37,0.25,0.06,0.04,0.0,0.0,0.06,liangjiang wang,,GEN-3020,2014
+GEN,3020,001,Molecular & General,0.23,0.37,0.25,0.06,0.04,0.0,0.0,0.06,lukasz kozubowski,,GEN-3020,2014
+GEN,3020,002,Molec & General Gene,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,True,GEN-3020,2014
+GEN,3020,002,Molec & General Gene,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,True,GEN-3020,2014
+GEN,3030,001,Molec & General Gene,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,liangjiang wang,,GEN-3030,2014
+GEN,3030,001,Molec & General Gene,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,,GEN-3030,2014
+GEN,3030,002,Molec & General Gene,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,lukasz kozubowski,,GEN-3030,2014
+GEN,3030,002,Mol Gen Genet Lab,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,lukasz kozubowski,,GEN-3030,2014
+GEN,3030,002,Molec & General Gene,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,liangjiang wang,,GEN-3030,2014
+GEN,3030,002,Mol Gen Genet Lab,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,liangjiang wang,,GEN-3030,2014
+GEN,3030,003,Molec & General Gene,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,,GEN-3030,2014
+GEN,3030,003,Molec & General Gene,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,,GEN-3030,2014
+GEN,3030,004,Molec & General Gene,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lukasz kozubowski,,GEN-3030,2014
+GEN,3030,004,Mol Gen Genet Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lukasz kozubowski,,GEN-3030,2014
+GEN,3030,004,Molec & General Gene,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,liangjiang wang,,GEN-3030,2014
+GEN,3030,004,Mol Gen Genet Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,liangjiang wang,,GEN-3030,2014
+GEN,4200,001,Molecular Genetics &,0.33,0.33,0.26,0.0,0.0,0.0,0.0,0.07,julia frugoli,,GEN-4200,2014
+GEN,4200,002,Molecular Genetics &,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True,GEN-4200,2014
+GEN,4210,002,Mol Gen Gene Reg Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,,GEN-4210,2014
+GEN,4210,003,Mol Gen Gene Reg Lab,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,julia frugoli,,GEN-4210,2014
+GEN,4210,004,Mol Gen Gene Reg Lab,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,julia frugoli,,GEN-4210,2014
+GEN,4400,001,Bioinformatics,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,,GEN-4400,2014
+GEN,4500,001,Comparative Genetics,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,leigh anne clark,,GEN-4500,2014
+GEN,6400,001,Bioinformatics,0.63,0.25,0.0,0.0,0.13,0.0,0.0,0.0,frank alexan feltus,,GEN-6400,2014
+GEN,8140,001,Advanced Genetics,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kate leanne wi tsai,,GEN-8140,2014
+GEOG,1010,001,Intro to Geography,0.33,0.33,0.23,0.1,0.03,0.0,0.0,0.0,christa smith,,GEOG-1010,2014
+GEOG,1030,001,World Regional Geog,0.76,0.14,0.03,0.02,0.02,0.0,0.0,0.02,lance forres howard,,GEOG-1030,2014
+GEOG,1030,002,World Regional Geog,0.35,0.35,0.2,0.05,0.0,0.0,0.0,0.05,william churc terry,,GEOG-1030,2014
+GEOG,1030,003,World Regional Geog,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,david doran,,GEOG-1030,2014
+GEOG,1030,004,World Regional Geog,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david doran,,GEOG-1030,2014
+GEOG,3400,001,Geog of Latin Amer,0.27,0.27,0.36,0.0,0.09,0.0,0.0,0.0,william churc terry,,GEOG-3400,2014
+GEOL,1010,001,Physical Geology,0.18,0.29,0.21,0.15,0.07,0.0,0.0,0.09,alan coulson,,GEOL-1010,2014
+GEOL,1010,002,Physical Geology,0.26,0.28,0.22,0.11,0.06,0.0,0.0,0.07,alan coulson,,GEOL-1010,2014
+GEOL,1010,003,Physical Geology,0.37,0.35,0.24,0.04,0.0,0.0,0.0,0.0,stephen mich moysey,,GEOL-1010,2014
+GEOL,1030,001,Physical Geol Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2014
+GEOL,1030,002,Physical Geol Lab,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,003,Physical Geol Lab,0.09,0.22,0.39,0.13,0.13,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,004,Physical Geol Lab,0.63,0.25,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2014
+GEOL,1030,005,Physical Geol Lab,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2014
+GEOL,1030,006,Physical Geol Lab,0.17,0.52,0.17,0.09,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,007,Physical Geol Lab,0.21,0.46,0.17,0.0,0.0,0.0,0.0,0.17,alan coulson,,GEOL-1030,2014
+GEOL,1030,008,Physical Geol Lab,0.25,0.63,0.04,0.0,0.04,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,009,Physical Geol Lab,0.13,0.38,0.25,0.04,0.0,0.0,0.0,0.21,alan coulson,,GEOL-1030,2014
+GEOL,1030,010,Physical Geol Lab,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2014
+GEOL,1030,012,Physical Geol Lab,0.13,0.43,0.22,0.13,0.0,0.0,0.0,0.09,alan coulson,,GEOL-1030,2014
+GEOL,2050,001,Mineralogy & Intro P,0.4,0.27,0.2,0.0,0.13,0.0,0.0,0.0,lin shuller-nickles,,GEOL-2050,2014
+GEOL,2070,001,Min & Intro Pet Lab,0.21,0.5,0.14,0.07,0.07,0.0,0.0,0.0,alan coulson,,GEOL-2070,2014
+GEOL,2700,001,Sustainable Water,0.82,0.04,0.07,0.0,0.04,0.0,0.0,0.04,stephen mich moysey,,GEOL-2700,2014
+GEOL,3000,001,Environmental Geol,0.41,0.38,0.15,0.06,0.0,0.0,0.0,0.0,scott brame,,GEOL-3000,2014
+GEOL,4110,008,CI - Community Outre,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,john robert wagner,,GEOL-4110,2014
+GEOL,6150,001,Analysis Geological,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,,GEOL-6150,2014
+GEOL,8060,001,Aquifer Charact,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james castle,,GEOL-8060,2014
+GEOL,8090,001,Subsurface Remed Mod,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ronald falta,,GEOL-8090,2014
+GER,1010,001,Elementary German,0.32,0.37,0.16,0.0,0.05,0.0,0.0,0.11, lee ferrell,,GER-1010,2014
+GER,1010,002,Elementary German,0.11,0.32,0.16,0.32,0.05,0.0,0.0,0.05, lee ferrell,,GER-1010,2014
+GER,1010,003,Elementary German,0.24,0.18,0.24,0.06,0.06,0.0,0.0,0.24, lee ferrell,,GER-1010,2014
+GER,1020,001,Elementary German,0.29,0.21,0.14,0.07,0.0,0.0,0.0,0.29, lee ferrell,,GER-1020,2014
+GER,1020,003,Elementary German,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-1020,2014
+GER,2010,001,Intermediate German,0.33,0.4,0.07,0.0,0.07,0.0,0.0,0.13,gabriela stoicea,,GER-2010,2014
+GER,2010,002,Intermediate German,0.22,0.33,0.17,0.17,0.0,0.0,0.0,0.11,johannes schmidt,,GER-2010,2014
+GER,2020,001,Intermediate German,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-2020,2014
+GER,3050,001,Ger Conv & Comp,0.53,0.24,0.06,0.12,0.0,0.06,0.0,0.0,oswald harris king,,GER-3050,2014
+GER,3690,001,German WWI Literatur,0.42,0.42,0.0,0.17,0.0,0.0,0.0,0.0,johannes schmidt,,GER-3690,2014
+HCC,8310,001,Fundamentals of Hcc,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shaundra daily,,HCC-8310,2014
+HCC,8810,001,Research Methods in,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,,HCC-8810,2014
+HEHD,4100,001,Lead Beh & Civic En,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,katelyn mcc radford,,HEHD-4100,2014
+HEHD,8000,400,Youth Dev Theories,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kellye rembert,,HEHD-8000,2014
+HEHD,8050,001,Yth Dev in Families,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,,HEHD-8050,2014
+HEHD,8050,001,Yth Dev in Families,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,william quinn,,HEHD-8050,2014
+HEHD,8060,230,Diverse Society,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,william quinn,,HEHD-8060,2014
+HEHD,8060,230,Diverse Society,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,keith george diem,,HEHD-8060,2014
+HIST,1010,001,Hist of the U S,0.12,0.55,0.24,0.0,0.06,0.0,0.0,0.03,james brad jeffries,,HIST-1010,2014
+HIST,1010,002,Hist of the U S,0.31,0.26,0.29,0.11,0.0,0.0,0.0,0.03,lee brady wilson,,HIST-1010,2014
+HIST,1020,002,Hist of the U S,0.23,0.23,0.12,0.04,0.0,0.0,0.0,0.38,maribel morey,,HIST-1020,2014
+HIST,1240,001,Environmental Hist,0.24,0.37,0.25,0.03,0.03,0.0,0.0,0.07,james brad jeffries,,HIST-1240,2014
+HIST,1720,001,The West and the Wor,0.39,0.26,0.16,0.12,0.03,0.0,0.0,0.03,james burns,,HIST-1720,2014
+HIST,1720,002,The West and the Wor,0.33,0.36,0.19,0.05,0.02,0.0,0.0,0.05,steven marks,,HIST-1720,2014
+HIST,1730,001,The West and the Wor,0.3,0.33,0.17,0.05,0.06,0.0,0.0,0.09,richard saunders,,HIST-1730,2014
+HIST,1730,002,The West and the Wor,0.32,0.38,0.13,0.03,0.08,0.0,0.0,0.05, alan grubb,,HIST-1730,2014
+HIST,2990,001,Historian's Craft,0.47,0.2,0.13,0.0,0.07,0.0,0.0,0.13,michael silvestri,,HIST-2990,2014
+HIST,2990,003,Historian's Craft,0.59,0.24,0.06,0.06,0.0,0.0,0.0,0.06,rachel anne moore,,HIST-2990,2014
+HIST,3000,001,Hist Colonial Amer,0.3,0.49,0.14,0.03,0.05,0.0,0.0,0.0,lee brady wilson,,HIST-3000,2014
+HIST,3030,001,Civil War & Recon,0.21,0.49,0.13,0.03,0.1,0.0,0.0,0.05,paul chris anderson,,HIST-3030,2014
+HIST,3040,001,Indus & Progr Era,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0, roger grant,,HIST-3040,2014
+HIST,3220,001,History of Technolog,0.37,0.33,0.13,0.03,0.1,0.0,0.0,0.03,pamela mack,,HIST-3220,2014
+HIST,3280,001,US Legal History to,0.17,0.17,0.1,0.0,0.07,0.0,0.0,0.5,maribel morey,,HIST-3280,2014
+HIST,3300,001,Hist of Mod China,0.31,0.23,0.38,0.0,0.08,0.0,0.0,0.0,edwin moise,,HIST-3300,2014
+HIST,3400,001,Latin America I,0.48,0.38,0.1,0.0,0.02,0.0,0.0,0.02,rachel anne moore,,HIST-3400,2014
+HIST,3550,001,Roman World,0.35,0.48,0.06,0.0,0.03,0.0,0.0,0.06,elizabeth carney,,HIST-3550,2014
+HIST,3610,001,History of Britain t,0.42,0.36,0.12,0.03,0.06,0.0,0.0,0.0,caroline dunn clark,,HIST-3610,2014
+HIST,3630,001,Britain Since 1688,0.37,0.26,0.21,0.05,0.05,0.0,0.0,0.05,stephani barczewski,,HIST-3630,2014
+HIST,3700,001,Medieval History,0.41,0.31,0.09,0.06,0.06,0.0,0.0,0.06,caroline dunn clark,,HIST-3700,2014
+HIST,3720,001,Renaissance,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,thomas kuehn,,HIST-3720,2014
+HIST,3810,001,Germany Since 1918,0.2,0.47,0.13,0.0,0.2,0.0,0.0,0.0,michael meng,,HIST-3810,2014
+HIST,3850,001,Imperial Russia,0.3,0.37,0.11,0.11,0.07,0.0,0.0,0.04,steven marks,,HIST-3850,2014
+HIST,3900,001,Mod Mil Hist,0.09,0.41,0.41,0.0,0.05,0.0,0.0,0.05,edwin moise,,HIST-3900,2014
+HIST,4090,001,Jfk Assassination,0.42,0.38,0.1,0.0,0.08,0.0,0.0,0.02,richard saunders,,HIST-4090,2014
+HIST,4140,001,Study of Hist Museum,0.6,0.07,0.27,0.0,0.07,0.0,0.0,0.0,leslie white,,HIST-4140,2014
+HIST,4710,001,Studies in Mod Europ,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,michael meng,,HIST-4710,2014
+HIST,4870,001,World War II,0.2,0.57,0.07,0.09,0.04,0.0,0.0,0.04,john andrew,,HIST-4870,2014
+HIST,4900,002,Film and Local Histo,0.45,0.45,0.0,0.09,0.0,0.0,0.0,0.0,james burns,,HIST-4900,2014
+HIST,4900,003,HIST & GEOG Disney P,0.31,0.44,0.13,0.13,0.0,0.0,0.0,0.0,stephani barczewski,,HIST-4900,2014
+HIST,4900,003,HIST & GEOG Disney P,0.31,0.44,0.13,0.13,0.0,0.0,0.0,0.0,christa smith,,HIST-4900,2014
+HIST,4930,001,Slavery & Film,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,abel bartley,,HIST-4930,2014
+HIST,4940,001,Europe's Dictators,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,amit bein,,HIST-4940,2014
+HIST,8000,002,Major Probs SO Histo,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,john andrew,,HIST-8000,2014
+HLTH,2020,001,Introduction to Publ,0.31,0.62,0.0,0.08,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2014
+HLTH,2020,002,Introduction to Publ,0.56,0.33,0.08,0.03,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2014
+HLTH,2020,003,Introduction to Publ,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2014
+HLTH,2020,004,Introduction to Publ,0.39,0.45,0.11,0.05,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2014
+HLTH,2020,005,Introduction to Publ,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2014
+HLTH,2020,006,Introduction to Publ,0.53,0.35,0.06,0.0,0.06,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2014
+HLTH,2030,001,Health Care Sys,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,lee alden crandall,,HLTH-2030,2014
+HLTH,2030,002,Health Care Sys,0.68,0.28,0.0,0.0,0.03,0.0,0.0,0.03,ralph stewart welsh,,HLTH-2030,2014
+HLTH,2030,400,Health Care Sys,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ralph stewart welsh,,HLTH-2030,2014
+HLTH,2400,001,Deter of Hlth Behav,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.03,sarah griffin,,HLTH-2400,2014
+HLTH,2400,002,Deter of Hlth Behav,0.36,0.49,0.09,0.0,0.0,0.0,0.0,0.06,sarah griffin,,HLTH-2400,2014
+HLTH,2980,001,Human Hlth & Disease,0.6,0.33,0.05,0.0,0.0,0.0,0.0,0.02,deborah alma falta,,HLTH-2980,2014
+HLTH,2980,002,Human Hlth & Disease,0.53,0.44,0.0,0.0,0.0,0.0,0.0,0.03,deborah alma falta,,HLTH-2980,2014
+HLTH,3030,001,Public Health Comm,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,debra mitch charles,,HLTH-3030,2014
+HLTH,3400,001,Hlth Prom Prog Plan,0.47,0.32,0.18,0.0,0.0,0.0,0.0,0.03,joel edwar williams,,HLTH-3400,2014
+HLTH,3610,001,Int Health Care Econ,0.5,0.28,0.17,0.0,0.0,0.0,0.0,0.06,khoa dang truong,,HLTH-3610,2014
+HLTH,3800,001,Epidemiology,0.19,0.6,0.15,0.04,0.0,0.0,0.0,0.02,hugh spitler,,HLTH-3800,2014
+HLTH,3800,002,Epidemiology,0.16,0.64,0.2,0.0,0.0,0.0,0.0,0.0,hugh spitler,,HLTH-3800,2014
+HLTH,3800,400,Epidemiology,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,deborah alma falta,,HLTH-3800,2014
+HLTH,3980,001,Hlth Appraisal Sklls,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2014
+HLTH,4150,001,Obesity & Eating Dis,0.57,0.34,0.06,0.0,0.0,0.0,0.0,0.03,karen kemper,,HLTH-4150,2014
+HLTH,4190,001,Health Sci Internshi,0.21,0.58,0.12,0.06,0.03,0.0,0.0,0.0,kathleen meyer,,HLTH-4190,2014
+HLTH,4200,001,Hlth Science Intern,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2014
+HLTH,4400,001,Manag Hlth Serv Org,0.19,0.67,0.15,0.0,0.0,0.0,0.0,0.0,frederic fraizer,,HLTH-4400,2014
+HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,ronald gimbel,,HLTH-4700,2014
+HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,,HLTH-4700,2014
+HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,rachel mayo,,HLTH-4700,2014
+HLTH,4750,001,Hlthcr Oper Mgmt Res,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,,HLTH-4750,2014
+HLTH,4900,001,Res Eval St Pub Hlth,0.57,0.19,0.14,0.05,0.0,0.0,0.0,0.05,khoa dang truong,,HLTH-4900,2014
+HLTH,4900,002,Res Eval St Pub Hlth,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,lingling zhang,,HLTH-4900,2014
+HON,1900,001,Holocaust Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True,HON-1900,2014
+HON,1900,002,Amer Lit & Global Co,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,angela naimou,True,HON-1900,2014
+HON,1920,001,Positively Human,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,june pilcher,True,HON-1920,2014
+HON,1940,001,Scientific Skepticis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey appling,True,HON-1940,2014
+HON,2020,001,Stress in Health and,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,True,HON-2020,2014
+HON,2030,001,Music/Politics:Blues,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,True,HON-2030,2014
+HON,2200,001,Midterm Elections,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey allen fine,True,HON-2200,2014
+HON,2200,002,The Modern Israeli S,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,colin pearce,True,HON-2200,2014
+HON,2220,001,Science/Literaure in,0.64,0.27,0.0,0.09,0.0,0.0,0.0,0.0,gabriela stoicea,True,HON-2220,2014
+HORT,1010,001,Horticulture,0.63,0.31,0.07,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-1010,2014
+HORT,2100,001,Growing Fall Plants,0.33,0.17,0.17,0.17,0.0,0.0,0.0,0.17,samarakoon basnagala,,HORT-2100,2014
+HORT,2120,001,Turfgrass Culture,0.55,0.43,0.0,0.0,0.03,0.0,0.0,0.0,haibo liu,,HORT-2120,2014
+HORT,2130,001,Turf Culture Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,donald garrett,,HORT-2130,2014
+HORT,2130,002,Turf Culture Lab,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,donald garrett,,HORT-2130,2014
+HORT,3030,001,Landscape Plants,0.36,0.32,0.17,0.03,0.07,0.0,0.0,0.05,robert polomski,,HORT-3030,2014
+HORT,3080,001,Sust Landscape Des,0.63,0.23,0.07,0.05,0.0,0.0,0.0,0.02,ellen anita vincent,,HORT-3080,2014
+HORT,3090,001,Sust Landsc Des Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,harry harritos,,HORT-3090,2014
+HORT,4090,001,Senior Capstone Cour,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,ellen anita vincent,,HORT-4090,2014
+HORT,4120,001,Adv Turfgrass Mgt,0.3,0.3,0.2,0.0,0.0,0.0,0.0,0.2,lambert mccarty,,HORT-4120,2014
+HORT,4330,001,Turf Weed Management,0.29,0.41,0.24,0.0,0.0,0.0,0.0,0.06,ted whitwell,,HORT-4330,2014
+HP,8030,001,Building Tech and Pa,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amalia leifeste,,HP-8030,2014
+HP,8070,400,American Architectur,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,carter lee hudgins,,HP-8070,2014
+HP,8090,400,Historical Research,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,katherine pemberton,,HP-8090,2014
+HP,8190,001,"Investig, Docum, Con",0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,amalia leifeste,,HP-8190,2014
+HP,8190,001,"Investig, Docum, Con",0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,kristopher king,,HP-8190,2014
+HRD,8200,400,Human Perform Improv,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,cynthia sims,,HRD-8200,2014
+HRD,8200,401,Human Perform Improv,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,cynthia sims,,HRD-8200,2014
+HRD,8200,402,Human Perform Improv,0.71,0.0,0.14,0.0,0.0,0.0,0.0,0.14,cynthia sims,,HRD-8200,2014
+HRD,8200,403,Human Perform Improv,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,cynthia sims,,HRD-8200,2014
+HRD,8200,405,Human Perform Improv,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,cynthia sims,,HRD-8200,2014
+HRD,8200,406,Human Perform Improv,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,cynthia sims,,HRD-8200,2014
+HRD,8300,400,Concepts of H R D,0.38,0.38,0.13,0.0,0.0,0.0,0.0,0.13,eileen newmark,,HRD-8300,2014
+HRD,8300,401,Concepts of H R D,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,eileen newmark,,HRD-8300,2014
+HRD,8300,402,Concepts of H R D,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,eileen newmark,,HRD-8300,2014
+HRD,8300,403,Concepts of H R D,0.2,0.7,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,,HRD-8300,2014
+HRD,8300,404,Concepts of H R D,0.5,0.25,0.13,0.0,0.13,0.0,0.0,0.0,eileen newmark,,HRD-8300,2014
+HRD,8300,405,Concepts of H R D,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,,HRD-8300,2014
+HRD,8300,406,Concepts of H R D,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,,HRD-8300,2014
+HRD,8300,407,Concepts of H R D,0.63,0.13,0.0,0.0,0.0,0.0,0.0,0.25,eileen newmark,,HRD-8300,2014
+HRD,8450,402,Needs Assess Ed/Ind,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,russell marion,,HRD-8450,2014
+HRD,8600,404,Instruc Mat Devel,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,philip mcgee,,HRD-8600,2014
+HRD,8600,405,Instruc Mat Devel,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,,HRD-8600,2014
+HRD,8600,406,Instruc Mat Devel,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,,HRD-8600,2014
+IE,2000,001,Soph Seminar in I E,0.53,0.26,0.12,0.06,0.02,0.0,0.0,0.01,brian melloy,,IE-2000,2014
+IE,2010,001,Systems Design I,0.4,0.47,0.1,0.0,0.03,0.0,0.0,0.0,joel greenstein,,IE-2010,2014
+IE,2010,002,Systems Design I,0.37,0.43,0.17,0.0,0.0,0.0,0.0,0.03,joel greenstein,,IE-2010,2014
+IE,2010,003,Systems Design I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,,IE-2010,2014
+IE,2800,001,Deterministic Operat,0.18,0.34,0.2,0.13,0.11,0.0,0.0,0.04,jonathan cole smith,,IE-2800,2014
+IE,2800,002,Deterministic Operat,0.38,0.37,0.13,0.06,0.04,0.0,0.0,0.02,amin khademi,,IE-2800,2014
+IE,3600,001,Industrial Apps of P,0.3,0.33,0.23,0.08,0.05,0.0,0.0,0.01,mary elizabeth kurz,,IE-3600,2014
+IE,3680,001,Prof Practice in I E,0.87,0.08,0.02,0.01,0.01,0.0,0.0,0.01,brian melloy,,IE-3680,2014
+IE,3860,001,Prod Plan & Cont,0.38,0.46,0.08,0.0,0.04,0.0,0.0,0.04,robert james riggs,,IE-3860,2014
+IE,4020,003,Creative Inq Res,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,anand gramopadhye,,IE-4020,2014
+IE,4400,001,Decision Support Sys,0.47,0.29,0.08,0.05,0.03,0.0,0.0,0.08,sandra dun eksioglu,,IE-4400,2014
+IE,4400,002,Decision Support Sys,0.33,0.42,0.14,0.07,0.02,0.0,0.0,0.02,mary elizabeth kurz,,IE-4400,2014
+IE,4560,001,Supply Chain Design,0.2,0.59,0.12,0.0,0.1,0.0,0.0,0.0,william ferrell,,IE-4560,2014
+IE,4610,001,Quality Engineering,0.3,0.35,0.28,0.05,0.0,0.0,0.0,0.01,byung rae cho,,IE-4610,2014
+IE,4650,001,Facilities Planning,0.26,0.53,0.18,0.02,0.0,0.0,0.0,0.01,brian melloy,,IE-4650,2014
+IE,4820,001,Systems Modeling,0.32,0.47,0.19,0.01,0.0,0.0,0.0,0.01,kevin taaffe,,IE-4820,2014
+IE,4910,001,Investigating Human,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,sara lu riggs,,IE-4910,2014
+IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,sandra dun eksioglu,,IE-4910,2014
+IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,sandra dun eksioglu,,IE-4910,2014
+IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,kap chalil madathil,,IE-4910,2014
+IE,6400,001,Decision Support Sys,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,,IE-6400,2014
+IE,6560,001,Supply Chain Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,,IE-6560,2014
+IE,6910,001,Selected Topics-I E,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,sara lu riggs,,IE-6910,2014
+IE,8000,001,Human Factors Eng,0.11,0.75,0.13,0.0,0.01,0.0,0.0,0.0,david neyens,,IE-8000,2014
+IE,8030,001,Engr Optimization an,0.23,0.39,0.26,0.0,0.06,0.0,0.0,0.06,scott jenning mason,,IE-8030,2014
+IE,8090,001,Model Sys Under Risk,0.23,0.43,0.25,0.0,0.05,0.0,0.0,0.04,burak eksioglu,,IE-8090,2014
+IE,8510,001,Data Coll Anl Interp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabeth kurz,,IE-8510,2014
+IE,8530,001,Foundations of Qual,0.84,0.14,0.02,0.0,0.0,0.0,0.0,0.0,byung rae cho,,IE-8530,2014
+IE,8550,001,Capital Projects Sc,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,kevin taaffe,,IE-8550,2014
+IE,8870,001,Model Logist Behav S,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,,IE-8870,2014
+INT,1010,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.91,0.06,0.03,troy nunamaker,,INT-1010,2014
+INT,1020,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.88,0.11,0.01,troy nunamaker,,INT-1020,2014
+INT,1030,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.85,0.11,0.04,troy nunamaker,,INT-1030,2014
+IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,meredith fan wilson,,IS-1010,2014
+IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,laura padfiel braun,,IS-1010,2014
+IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,sharon nagy,,IS-1010,2014
+IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,uttiyo raychaudhuri,,IS-1010,2014
+ITAL,1010,001,Elementary Italian,0.47,0.11,0.11,0.0,0.11,0.0,0.0,0.21,luca barattoni,,ITAL-1010,2014
+ITAL,1010,002,Elementary Italian,0.74,0.11,0.16,0.0,0.0,0.0,0.0,0.0,luca barattoni,,ITAL-1010,2014
+ITAL,1010,003,Elementary Italian,0.32,0.42,0.11,0.05,0.11,0.0,0.0,0.0,valentina lombardi,,ITAL-1010,2014
+ITAL,1010,004,Elementary Italian,0.5,0.25,0.0,0.0,0.13,0.0,0.0,0.13,valentina lombardi,,ITAL-1010,2014
+ITAL,1020,001,Elementary Italian,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-1020,2014
+ITAL,2010,001,Intermediate Italian,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2010,2014
+ITAL,2010,002,Intermediate Italian,0.35,0.47,0.18,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2010,2014
+ITAL,2020,001,Intermediate Italian,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,barbara zaczek,,ITAL-2020,2014
+JAPN,1010,001,Elementary Japanese,0.42,0.32,0.11,0.0,0.11,0.0,0.0,0.05,toshiko kishimoto,,JAPN-1010,2014
+JAPN,1010,002,Elementary Japanese,0.42,0.21,0.11,0.05,0.05,0.0,0.0,0.16,toshiko kishimoto,,JAPN-1010,2014
+JAPN,2010,001,Intermed Japanese,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,toshiko joerger,,JAPN-2010,2014
+JAPN,3050,001,Japanese Conv & Comp,0.5,0.25,0.17,0.0,0.0,0.0,0.0,0.08,toshiko kishimoto,,JAPN-3050,2014
+JAPN,4010,001,Japan Lit in Trans,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,kenneth jeff knight,,JAPN-4010,2014
+LANG,2540,001,Introduction to Worl,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,joseph mai,,LANG-2540,2014
+LANG,3710,001,Language and Culture,0.3,0.2,0.3,0.0,0.0,0.0,0.0,0.2,yanhua zhang,,LANG-3710,2014
+LARC,1150,001,Intro Landscape Arch,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,,LARC-1150,2014
+LARC,1280,001,Technical Graphics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,,LARC-1280,2014
+LARC,1510,001,Basic Design I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,,LARC-1510,2014
+LARC,3620,001,Design Impl II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,,LARC-3620,2014
+LARC,4280,001,Comput Aided Design,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,shan jiang,,LARC-4280,2014
+LARC,4530,001,Key Issues in Larch,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,,LARC-4530,2014
+LARC,8500,001,Grad Colloquium,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,,LARC-8500,2014
+LAW,3220,001,Legal Env of Bus,0.14,0.61,0.24,0.01,0.01,0.0,0.0,0.0,judson jahn,,LAW-3220,2014
+LAW,3220,002,Legal Env of Bus,0.47,0.41,0.11,0.01,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2014
+LAW,3220,003,Legal Env of Bus (HO,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,frances edwards,True,LAW-3220,2014
+LAW,3220,004,Legal Env of Bus,0.06,0.42,0.21,0.12,0.03,0.0,0.0,0.15,virgini ward-vaughn,,LAW-3220,2014
+LAW,3220,005,Legal Env of Bus,0.06,0.45,0.23,0.13,0.06,0.0,0.0,0.06,virgini ward-vaughn,,LAW-3220,2014
+LAW,3220,006,Legal Env of Bus,0.23,0.26,0.32,0.13,0.0,0.0,0.0,0.06,virgini ward-vaughn,,LAW-3220,2014
+LAW,3220,007,Legal Env of Bus,0.29,0.24,0.29,0.1,0.05,0.0,0.0,0.05,virgini ward-vaughn,,LAW-3220,2014
+LAW,3220,009,Legal Env of Bus,0.51,0.39,0.1,0.0,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2014
+LAW,3220,010,Legal Env of Bus,0.42,0.38,0.16,0.05,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2014
+LAW,3220,011,Legal Env of Bus,0.18,0.46,0.19,0.1,0.0,0.0,0.0,0.06,kenneth toussaint,,LAW-3220,2014
+LAW,3220,012,Legal Env of Bus,0.33,0.51,0.15,0.01,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2014
+LAW,3330,001,Real Estate Law,0.1,0.52,0.2,0.06,0.0,0.0,0.0,0.12,michael bra burrell,,LAW-3330,2014
+LAW,4050,001,Construction Law,0.88,0.07,0.0,0.0,0.0,0.0,0.0,0.05,frances edwards,,LAW-4050,2014
+LIT,1270,001,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,eric touya,,LIT-1270,2014
+LS,1000,002,Therapeutic Yoga,0.63,0.11,0.0,0.05,0.0,0.0,0.0,0.21,ranjanbala dil amin,,LS-1000,2014
+LS,1000,007,Photography,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,sarah elizab mudder,,LS-1000,2014
+LS,1000,008,Intro to Volleyball,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,kelly lynn ator,,LS-1000,2014
+LS,1000,013,Introduction to Sals,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,malik lewis baxter,,LS-1000,2014
+LS,1130,001,Wood Carving,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,edwin eugene riggs,,LS-1130,2014
+LS,1410,001,Top Rope Climbing,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,scott evan lipscomb,,LS-1410,2014
+LS,1410,002,Top Rope Climbing,0.75,0.06,0.0,0.0,0.13,0.0,0.0,0.06,scott evan lipscomb,,LS-1410,2014
+LS,1410,004,Top Rope Climbing,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott evan lipscomb,,LS-1410,2014
+LS,1410,005,Top Rope Climbing,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,scott evan lipscomb,,LS-1410,2014
+LS,1410,006,Top Rope Climbing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott evan lipscomb,,LS-1410,2014
+LS,1560,001,Riflery,0.73,0.0,0.0,0.0,0.0,0.0,0.0,0.27,hubert cox,,LS-1560,2014
+LS,1560,005,Riflery,0.73,0.09,0.0,0.0,0.0,0.0,0.0,0.18,hubert cox,,LS-1560,2014
+LS,1560,007,Riflery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,herbert strickland,,LS-1560,2014
+LS,1570,003,Shotgun Sports,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,charles flint,,LS-1570,2014
+LS,1580,002,Archery,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,herbert strickland,,LS-1580,2014
+LS,1580,003,Archery,0.71,0.07,0.07,0.0,0.0,0.0,0.0,0.14,herbert strickland,,LS-1580,2014
+LS,1580,005,Archery,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,herbert strickland,,LS-1580,2014
+LS,1640,001,Whitewater Kayaking,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,earl wade shealy,,LS-1640,2014
+LS,1640,002,Whitewater Kayaking,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,robert taylor,,LS-1640,2014
+LS,1750,002,Fly Fishing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael watts,,LS-1750,2014
+LS,1850,003,Bowling,0.93,0.0,0.03,0.0,0.03,0.0,0.0,0.0,megan elizabet cato,,LS-1850,2014
+LS,1870,002,Frisbee Sports,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,craig goodman,,LS-1870,2014
+LS,1890,002,Tennis,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jennifer jo garrity,,LS-1890,2014
+LS,1940,002,Racquetball,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,,LS-1940,2014
+LS,1980,002,Golf,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jason jordan,,LS-1980,2014
+LS,2100,001,Learn to Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,matthew lee krabbe,,LS-2100,2014
+LS,2110,001,Introduction to Bell,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,stephanie pack,,LS-2110,2014
+LS,2190,003,Country West Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,,LS-2190,2014
+LS,2200,001,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,broadus fleming,,LS-2200,2014
+LS,2200,004,Shag,0.78,0.0,0.0,0.0,0.04,0.0,0.0,0.17,broadus fleming,,LS-2200,2014
+LS,2200,005,Shag,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,,LS-2200,2014
+LS,2200,006,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,broadus fleming,,LS-2200,2014
+LS,2200,009,Shag,0.74,0.0,0.0,0.0,0.0,0.0,0.0,0.26,matthew lee krabbe,,LS-2200,2014
+LS,2210,002,Intermediate Shag,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,matthew lee krabbe,,LS-2210,2014
+LS,2270,002,Intro to Swing Dance,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,,LS-2270,2014
+LS,2320,001,Core Training,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,diane moreno,,LS-2320,2014
+LS,2320,005,Core Training,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-2320,2014
+LS,2350,001,Basic Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,,LS-2350,2014
+LS,2350,002,Basic Yoga,0.77,0.09,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,,LS-2350,2014
+LS,2350,003,Basic Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,,LS-2350,2014
+LS,2350,005,Basic Yoga,0.81,0.0,0.1,0.05,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2350,2014
+LS,2350,006,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2014
+LS,2350,007,Basic Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2014
+LS,2360,001,Power/Ashtanga Yoga,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,,LS-2360,2014
+LS,2360,002,Power/Ashtanga Yoga,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,,LS-2360,2014
+LS,2370,001,Kripalu Yoga,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,,LS-2370,2014
+LS,2370,002,Kripalu Yoga,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,,LS-2370,2014
+LS,2370,003,Kripalu Yoga,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,ashley austi lester,,LS-2370,2014
+LS,2420,003,Meditation and Relax,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,jenefer nadenicek,,LS-2420,2014
+LS,2420,006,Meditation and Relax,0.71,0.21,0.04,0.0,0.04,0.0,0.0,0.0,ani reina-nunnelley,,LS-2420,2014
+LS,2420,007,Meditation and Relax,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,,LS-2420,2014
+LS,2450,003,Pilates,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,melanie ivey job,,LS-2450,2014
+LS,2500,001,Marathon Training,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,john walston dunn,,LS-2500,2014
+LS,2510,002,Running & Jogging,0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,corey dou brookover,,LS-2510,2014
+LS,2660,001,Hapkido,0.79,0.04,0.0,0.04,0.0,0.0,0.0,0.13,kelly smith,,LS-2660,2014
+LS,2700,001,Sports Officiating,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher war cox,,LS-2700,2014
+LS,2780,002,Wilderness First Aid,0.73,0.09,0.0,0.0,0.0,0.0,0.0,0.18,emily grace turke,,LS-2780,2014
+MATH,1010,001,Essen Math for Infor,0.27,0.33,0.21,0.12,0.06,0.0,0.0,0.0,judith cottingham,,MATH-1010,2014
+MATH,1010,002,Essen Math for Infor,0.25,0.33,0.25,0.0,0.08,0.0,0.0,0.08,qijun he,,MATH-1010,2014
+MATH,1010,003,Essen Math for Infor,0.23,0.38,0.31,0.0,0.08,0.0,0.0,0.0,paran rebeka norton,,MATH-1010,2014
+MATH,1010,004,Essen Math for Infor,0.39,0.33,0.17,0.06,0.06,0.0,0.0,0.0,merle glick,,MATH-1010,2014
+MATH,1010,005,Essen Math for Infor,0.32,0.37,0.11,0.05,0.11,0.0,0.0,0.05,paran rebeka norton,,MATH-1010,2014
+MATH,1010,006,Essen Math for Infor,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,vito capuano,,MATH-1010,2014
+MATH,1010,007,Essen Math for Infor,0.29,0.47,0.12,0.06,0.0,0.0,0.0,0.06,qijun he,,MATH-1010,2014
+MATH,1010,009,Essen Math for Infor,0.5,0.11,0.22,0.0,0.11,0.0,0.0,0.06,vito capuano,,MATH-1010,2014
+MATH,1010,010,Essen Math for Infor,0.65,0.12,0.12,0.06,0.0,0.0,0.0,0.06,merle glick,,MATH-1010,2014
+MATH,1010,011,Essen Math for Infor,0.39,0.33,0.14,0.11,0.03,0.0,0.0,0.0,judith cottingham,,MATH-1010,2014
+MATH,1010,012,Essen Math for Infor,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,megan elizabet ryan,,MATH-1010,2014
+MATH,1010,014,Essen Math for Infor,0.25,0.42,0.17,0.0,0.17,0.0,0.0,0.0,megan elizabet ryan,,MATH-1010,2014
+MATH,1010,015,Essen Math for Infor,0.0,0.31,0.38,0.23,0.0,0.0,0.0,0.08,sergey charnyi,,MATH-1010,2014
+MATH,1010,113,Essen Math for Infor,0.4,0.23,0.2,0.03,0.07,0.0,0.0,0.07,marilyn reba,,MATH-1010,2014
+MATH,1010,113,Essen Math for Infor,0.4,0.23,0.2,0.03,0.07,0.0,0.0,0.07,meredith nicol burr,,MATH-1010,2014
+MATH,1020,001,Intro to Mathematica,0.17,0.17,0.22,0.17,0.22,0.0,0.0,0.06,tony thanh nguyen,,MATH-1020,2014
+MATH,1020,002,Intro to Mathematica,0.0,0.26,0.32,0.16,0.16,0.0,0.0,0.11, morales hernandez,,MATH-1020,2014
+MATH,1020,003,Intro to Mathematica,0.06,0.18,0.29,0.29,0.18,0.0,0.0,0.0,"rodriguez esperanza,",,MATH-1020,2014
+MATH,1020,004,Intro to Mathematica,0.24,0.41,0.24,0.0,0.06,0.0,0.0,0.06,margaret milliken,,MATH-1020,2014
+MATH,1020,005,Intro to Mathematica,0.28,0.33,0.28,0.0,0.06,0.0,0.0,0.06,amy christine grady,,MATH-1020,2014
+MATH,1020,006,Intro to Mathematica,0.37,0.17,0.26,0.11,0.06,0.0,0.0,0.03,warren adams,,MATH-1020,2014
+MATH,1020,007,Intro to Mathematica,0.21,0.26,0.37,0.0,0.16,0.0,0.0,0.0,tony thanh nguyen,,MATH-1020,2014
+MATH,1020,008,Intro to Mathematica,0.26,0.42,0.21,0.05,0.0,0.0,0.0,0.05,kevin wayne dettman,,MATH-1020,2014
+MATH,1020,009,Intro to Mathematica,0.32,0.47,0.05,0.11,0.0,0.0,0.0,0.05,"rodriguez esperanza,",,MATH-1020,2014
+MATH,1020,010,Intro to Mathematica,0.3,0.35,0.15,0.1,0.1,0.0,0.0,0.0,yisu jia,,MATH-1020,2014
+MATH,1020,011,Intro to Mathematica,0.29,0.35,0.18,0.0,0.12,0.0,0.0,0.06,mengying xiao,,MATH-1020,2014
+MATH,1020,012,Intro to Mathematica,0.22,0.19,0.22,0.14,0.19,0.0,0.0,0.03,abigail bowers,,MATH-1020,2014
+MATH,1020,013,Intro to Mathematica,0.26,0.31,0.26,0.06,0.06,0.0,0.0,0.06,randy davidson,,MATH-1020,2014
+MATH,1020,014,Intro to Mathematica,0.33,0.28,0.14,0.03,0.19,0.0,0.0,0.03,abigail bowers,,MATH-1020,2014
+MATH,1020,015,Intro to Mathematica,0.32,0.21,0.21,0.05,0.16,0.0,0.0,0.05, morales hernandez,,MATH-1020,2014
+MATH,1020,016,Intro to Mathematica,0.21,0.26,0.32,0.16,0.05,0.0,0.0,0.0,isaac justus,,MATH-1020,2014
+MATH,1020,017,Intro to Mathematica,0.32,0.05,0.37,0.11,0.11,0.0,0.0,0.05,margaret milliken,,MATH-1020,2014
+MATH,1020,018,Intro to Mathematica,0.33,0.28,0.17,0.11,0.06,0.0,0.0,0.06,thanh thien to,,MATH-1020,2014
+MATH,1020,019,Intro to Mathematica,0.32,0.32,0.05,0.05,0.26,0.0,0.0,0.0,david james rea,,MATH-1020,2014
+MATH,1020,020,Intro to Mathematica,0.35,0.18,0.18,0.18,0.06,0.0,0.0,0.06,liu zhu,,MATH-1020,2014
+MATH,1020,021,Intro to Mathematica,0.22,0.44,0.06,0.06,0.22,0.0,0.0,0.0,isaac justus,,MATH-1020,2014
+MATH,1020,022,Intro to Mathematica,0.32,0.11,0.21,0.05,0.21,0.0,0.0,0.11,amy christine grady,,MATH-1020,2014
+MATH,1020,023,Intro to Mathematica,0.29,0.12,0.41,0.0,0.06,0.0,0.0,0.12,thanh thien to,,MATH-1020,2014
+MATH,1020,024,Intro to Mathematica,0.35,0.35,0.06,0.06,0.12,0.0,0.0,0.06,liu zhu,,MATH-1020,2014
+MATH,1020,025,Intro to Mathematica,0.0,0.41,0.12,0.24,0.06,0.0,0.0,0.18,mengying xiao,,MATH-1020,2014
+MATH,1020,026,Intro to Mathematica,0.22,0.17,0.22,0.17,0.17,0.0,0.0,0.06,trevor scot vilardi,,MATH-1020,2014
+MATH,1020,027,Intro to Mathematica,0.32,0.26,0.21,0.05,0.16,0.0,0.0,0.0,luke marti giberson,,MATH-1020,2014
+MATH,1020,028,Intro to Mathematica,0.33,0.22,0.0,0.17,0.17,0.0,0.0,0.11,david james rea,,MATH-1020,2014
+MATH,1020,029,Intro to Mathematica,0.21,0.24,0.26,0.21,0.09,0.0,0.0,0.0, erwin walker,,MATH-1020,2014
+MATH,1020,030,Intro to Mathematica,0.42,0.31,0.08,0.08,0.11,0.0,0.0,0.0,randy davidson,,MATH-1020,2014
+MATH,1020,031,Intro to Mathematica,0.06,0.53,0.24,0.06,0.06,0.0,0.0,0.06,samuel jose shesman,,MATH-1020,2014
+MATH,1020,032,Intro to Mathematica,0.06,0.29,0.35,0.0,0.18,0.0,0.0,0.12,kevin wayne dettman,,MATH-1020,2014
+MATH,1020,033,Intro to Mathematica,0.12,0.29,0.29,0.18,0.12,0.0,0.0,0.0,trevor scot vilardi,,MATH-1020,2014
+MATH,1020,034,Intro to Mathematica,0.11,0.37,0.16,0.11,0.21,0.0,0.0,0.05,abigail bowers,,MATH-1020,2014
+MATH,1020,035,Intro to Mathematica,0.22,0.38,0.25,0.13,0.0,0.0,0.0,0.03, erwin walker,,MATH-1020,2014
+MATH,1020,036,Intro to Mathematica,0.27,0.36,0.09,0.06,0.15,0.0,0.0,0.06,abigail bowers,,MATH-1020,2014
+MATH,1020,037,Intro to Mathematica,0.33,0.33,0.06,0.11,0.17,0.0,0.0,0.0,luke marti giberson,,MATH-1020,2014
+MATH,1020,038,Intro to Mathematica,0.17,0.22,0.33,0.06,0.11,0.0,0.0,0.11,yisu jia,,MATH-1020,2014
+MATH,1040,001,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.68,0.27,0.05,donna simms,,MATH-1040,2014
+MATH,1040,002,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.56,0.27,0.18,jennifer mari hanna,,MATH-1040,2014
+MATH,1040,003,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.44,0.42,0.14,abdullah al mamun,,MATH-1040,2014
+MATH,1040,004,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.64,0.24,0.11,jennifer mari hanna,,MATH-1040,2014
+MATH,1040,005,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.44,0.44,0.12,christa con johnson,,MATH-1040,2014
+MATH,1040,006,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.51,0.36,0.13,jennifer mari hanna,,MATH-1040,2014
+MATH,1040,007,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.38,0.53,0.09,fiona may knoll,,MATH-1040,2014
+MATH,1040,008,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.56,0.33,0.11,jason to hedetniemi,,MATH-1040,2014
+MATH,1040,009,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.33,0.65,0.02,jason lee joyner,,MATH-1040,2014
+MATH,1040,010,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.45,0.47,0.08,christa con johnson,,MATH-1040,2014
+MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.67,0.29,0.04,eliza dar gallagher,,MATH-1050,2014
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.64,0.34,0.02,eliza dar gallagher,,MATH-1050,2014
+MATH,1060,001,Calculus of One Vari,0.32,0.27,0.18,0.09,0.05,0.0,0.0,0.09,charity watson,,MATH-1060,2014
+MATH,1060,002,Calculus of One Vari,0.02,0.3,0.3,0.09,0.17,0.0,0.0,0.13,javier ruiz ramirez,,MATH-1060,2014
+MATH,1060,003,Calculus of One Vari,0.17,0.33,0.19,0.06,0.11,0.0,0.0,0.14,allen anderso guest,,MATH-1060,2014
+MATH,1060,004,Calculus of One Vari,0.34,0.09,0.29,0.11,0.09,0.0,0.0,0.09,allen anderso guest,,MATH-1060,2014
+MATH,1060,005,Calculus of One Vari,0.36,0.38,0.1,0.05,0.07,0.0,0.0,0.05,charity watson,,MATH-1060,2014
+MATH,1060,006,Calculus of One Vari,0.15,0.42,0.23,0.06,0.06,0.0,0.0,0.08,meredith nicol burr,,MATH-1060,2014
+MATH,1060,007,Calculus of One Vari,0.27,0.41,0.16,0.05,0.07,0.0,0.0,0.05,charity watson,,MATH-1060,2014
+MATH,1060,008,Calculus of One Vari,0.2,0.32,0.2,0.1,0.14,0.0,0.0,0.04,sherry biggers,,MATH-1060,2014
+MATH,1060,009,Calculus of One Vari,0.24,0.22,0.24,0.08,0.08,0.0,0.0,0.14,meredith nicol burr,,MATH-1060,2014
+MATH,1060,010,Calculus of One Vari,0.27,0.41,0.14,0.05,0.11,0.0,0.0,0.02,honghai xu,,MATH-1060,2014
+MATH,1060,011,Calculus of One Vari,0.17,0.27,0.25,0.1,0.13,0.0,0.0,0.08,charles johnson,,MATH-1060,2014
+MATH,1060,012,Calculus of One Vari,0.19,0.27,0.21,0.15,0.08,0.0,0.0,0.1,sherry biggers,,MATH-1060,2014
+MATH,1060,013,Calculus of One Vari,0.13,0.17,0.17,0.15,0.15,0.0,0.0,0.25,stefan adam bock,,MATH-1060,2014
+MATH,1060,014,Calculus of One Vari,0.22,0.35,0.18,0.07,0.07,0.0,0.0,0.11,audrey nico devries,,MATH-1060,2014
+MATH,1060,015,Calculus of One Vari,0.2,0.27,0.27,0.12,0.1,0.0,0.0,0.04,rachel eli grotheer,,MATH-1060,2014
+MATH,1060,016,Calculus of One Vari,0.28,0.19,0.14,0.12,0.09,0.0,0.0,0.19,charles johnson,,MATH-1060,2014
+MATH,1060,017,Calculus of One Vari,0.1,0.38,0.24,0.02,0.12,0.0,0.0,0.14,charles johnson,,MATH-1060,2014
+MATH,1060,018,Calculus of One Vari,0.11,0.38,0.13,0.09,0.11,0.0,0.0,0.19,sherry biggers,,MATH-1060,2014
+MATH,1060,019,Calculus of One Vari,0.31,0.28,0.19,0.03,0.17,0.0,0.0,0.03,marilyn reba,,MATH-1060,2014
+MATH,1060,020,Calculus of One Vari,0.23,0.25,0.27,0.05,0.09,0.0,0.0,0.11,rebecca ramos,,MATH-1060,2014
+MATH,1060,100,Calc of One Variable,0.42,0.33,0.0,0.08,0.0,0.0,0.0,0.17,james ba coykendall,True,MATH-1060,2014
+MATH,1060,201,Calculus of One Vari,0.43,0.21,0.14,0.0,0.21,0.0,0.0,0.0,james peterson,,MATH-1060,2014
+MATH,1060,202,Calculus of One Vari,0.67,0.06,0.22,0.0,0.06,0.0,0.0,0.0,james peterson,,MATH-1060,2014
+MATH,1070,001,Differen and Integra,0.08,0.23,0.38,0.18,0.13,0.0,0.0,0.03,donna simms,,MATH-1070,2014
+MATH,1080,001,Calculus of One Vari,0.1,0.2,0.15,0.03,0.33,0.0,0.0,0.2,sarah eliz anderson,,MATH-1080,2014
+MATH,1080,002,Calculus of One Vari,0.08,0.18,0.18,0.05,0.18,0.0,0.0,0.33,terri johnson,,MATH-1080,2014
+MATH,1080,003,Calculus of One Vari,0.11,0.14,0.22,0.03,0.19,0.0,0.0,0.31,dania moham zantout,,MATH-1080,2014
+MATH,1080,004,Calculus of One Vari,0.08,0.16,0.05,0.24,0.16,0.0,0.0,0.32,beth novick,,MATH-1080,2014
+MATH,1080,005,Calculus of One Vari,0.05,0.13,0.1,0.08,0.43,0.0,0.0,0.23,terri johnson,,MATH-1080,2014
+MATH,1080,006,Calculus of One Vari,0.22,0.17,0.22,0.12,0.1,0.0,0.0,0.17,dania moham zantout,,MATH-1080,2014
+MATH,1080,007,Calculus of One Vari,0.07,0.07,0.1,0.12,0.37,0.0,0.0,0.27,karyn muir,,MATH-1080,2014
+MATH,1080,008,Calculus of One Vari,0.14,0.17,0.24,0.12,0.19,0.0,0.0,0.14,anastasia br wilson,,MATH-1080,2014
+MATH,1080,009,Calculus of One Vari,0.0,0.08,0.18,0.05,0.54,0.0,0.0,0.15,beth novick,,MATH-1080,2014
+MATH,1080,010,Calculus of One Vari,0.11,0.27,0.14,0.05,0.3,0.0,0.0,0.14,shih-wei chao,,MATH-1080,2014
+MATH,1080,011,Calculus of One Vari,0.27,0.21,0.18,0.12,0.03,0.0,0.0,0.18,dania moham zantout,,MATH-1080,2014
+MATH,1080,100,Calc of One Variable,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,james brown,True,MATH-1080,2014
+MATH,1150,001,Contemp Math for Ele,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1150,2014
+MATH,1150,002,Contemp Math for Ele,0.59,0.31,0.09,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1150,2014
+MATH,1160,001,Contemp Math for Ele,0.8,0.1,0.07,0.03,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-1160,2014
+MATH,1990,400,Problem Solving in M,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,marion hanna,,MATH-1990,2014
+MATH,2060,001,Calculus of Several,0.16,0.27,0.25,0.11,0.18,0.0,0.0,0.02,minerva rios-adams,,MATH-2060,2014
+MATH,2060,002,Calculus of Several,0.26,0.21,0.21,0.07,0.14,0.0,0.0,0.12,gretchen matthews,,MATH-2060,2014
+MATH,2060,003,Calculus of Several,0.32,0.42,0.13,0.05,0.03,0.0,0.0,0.05,xin liu,,MATH-2060,2014
+MATH,2060,004,Calculus of Several,0.22,0.22,0.3,0.17,0.04,0.0,0.0,0.04,chanseok park,,MATH-2060,2014
+MATH,2060,005,Calculus of Several,0.51,0.22,0.18,0.02,0.07,0.0,0.0,0.0,qingshan chen,,MATH-2060,2014
+MATH,2060,006,Calculus of Several,0.09,0.03,0.36,0.03,0.21,0.0,0.0,0.27,eleanor jenkins,,MATH-2060,2014
+MATH,2060,007,Calculus of Several,0.38,0.31,0.11,0.04,0.11,0.0,0.0,0.04,minerva rios-adams,,MATH-2060,2014
+MATH,2060,008,Calculus of Several,0.14,0.28,0.14,0.08,0.22,0.0,0.0,0.14,gretchen matthews,,MATH-2060,2014
+MATH,2060,009,Calculus of Several,0.16,0.32,0.25,0.09,0.14,0.0,0.0,0.05,minerva rios-adams,,MATH-2060,2014
+MATH,2060,010,Calculus of Several,0.12,0.18,0.24,0.15,0.26,0.0,0.0,0.06,shari prevost,,MATH-2060,2014
+MATH,2060,011,Calculus of Several,0.53,0.22,0.1,0.08,0.02,0.0,0.0,0.04,martin joha schmoll,,MATH-2060,2014
+MATH,2060,012,Calculus of Several,0.2,0.28,0.28,0.11,0.11,0.0,0.0,0.02,timothy ch teitloff,,MATH-2060,2014
+MATH,2060,013,Calculus of Several,0.13,0.44,0.33,0.0,0.09,0.0,0.0,0.0,brian fralix,,MATH-2060,2014
+MATH,2060,014,Calculus of Several,0.29,0.29,0.16,0.08,0.11,0.0,0.0,0.08,gretchen matthews,,MATH-2060,2014
+MATH,2060,015,Calculus of Several,0.49,0.27,0.14,0.0,0.08,0.0,0.0,0.03,sofya alekseeva,,MATH-2060,2014
+MATH,2060,016,Calculus of Several,0.51,0.25,0.18,0.02,0.02,0.0,0.0,0.02,shitao liu,,MATH-2060,2014
+MATH,2060,017,Calculus of Several,0.33,0.47,0.17,0.0,0.03,0.0,0.0,0.0,irina viktorova,,MATH-2060,2014
+MATH,2060,018,Calculus of Several,0.28,0.21,0.19,0.09,0.23,0.0,0.0,0.0,timothy ch teitloff,,MATH-2060,2014
+MATH,2060,019,Calculus of Several,0.42,0.37,0.18,0.0,0.0,0.0,0.0,0.03,irina viktorova,,MATH-2060,2014
+MATH,2060,020,Calculus of Several,0.19,0.36,0.19,0.17,0.08,0.0,0.0,0.0,nathan jos adelgren,,MATH-2060,2014
+MATH,2060,021,Calculus of Several,0.26,0.36,0.25,0.04,0.04,0.0,0.0,0.06,timothy ch teitloff,,MATH-2060,2014
+MATH,2060,022,Calculus of Several,0.57,0.23,0.11,0.03,0.06,0.0,0.0,0.0,sofya alekseeva,,MATH-2060,2014
+MATH,2060,100,Calc of Several Vars,0.4,0.4,0.0,0.05,0.0,0.0,0.0,0.15,shari prevost,True,MATH-2060,2014
+MATH,2070,001,Multivariable Calcul,0.16,0.21,0.32,0.05,0.21,0.0,0.0,0.05,alistair bentley,,MATH-2070,2014
+MATH,2070,002,Multivariable Calcul,0.18,0.12,0.29,0.12,0.06,0.0,0.0,0.24,elaine ma sotherden,,MATH-2070,2014
+MATH,2070,003,Multivariable Calcul,0.28,0.22,0.17,0.06,0.17,0.0,0.0,0.11,kara ail stasikelis,,MATH-2070,2014
+MATH,2070,004,Multivariable Calcul,0.24,0.24,0.12,0.03,0.18,0.0,0.0,0.18,hui xue,,MATH-2070,2014
+MATH,2070,005,Multivariable Calcul,0.27,0.18,0.18,0.0,0.09,0.0,0.0,0.27,elaine ma sotherden,,MATH-2070,2014
+MATH,2070,006,Multivariable Calcul,0.21,0.21,0.32,0.11,0.11,0.0,0.0,0.05,alistair bentley,,MATH-2070,2014
+MATH,2070,007,Multivariable Calcul,0.06,0.28,0.28,0.0,0.22,0.0,0.0,0.17,saba za alkaseasbeh,,MATH-2070,2014
+MATH,2070,008,Multivariable Calcul,0.2,0.23,0.14,0.14,0.2,0.0,0.0,0.09,judith irene mcknew,,MATH-2070,2014
+MATH,2070,009,Multivariable Calcul,0.32,0.11,0.11,0.21,0.21,0.0,0.0,0.05,kara ail stasikelis,,MATH-2070,2014
+MATH,2070,010,Multivariable Calcul,0.22,0.22,0.11,0.11,0.28,0.0,0.0,0.06, ushijima-mwesigwa,,MATH-2070,2014
+MATH,2070,011,Multivariable Calcul,0.12,0.36,0.15,0.15,0.06,0.0,0.0,0.15,judith irene mcknew,,MATH-2070,2014
+MATH,2070,012,Multivariable Calcul,0.09,0.11,0.26,0.17,0.17,0.0,0.0,0.2,saba za alkaseasbeh,,MATH-2070,2014
+MATH,2070,013,Multivariable Calcul,0.29,0.24,0.35,0.06,0.0,0.0,0.0,0.06,liem nguyen,,MATH-2070,2014
+MATH,2070,014,Multivariable Calcul,0.06,0.61,0.17,0.0,0.11,0.0,0.0,0.06,garrett dranichak,,MATH-2070,2014
+MATH,2070,015,Multivariable Calcul,0.22,0.33,0.22,0.0,0.11,0.0,0.0,0.11,liem nguyen,,MATH-2070,2014
+MATH,2070,016,Multivariable Calcul,0.33,0.22,0.17,0.06,0.17,0.0,0.0,0.06, ushijima-mwesigwa,,MATH-2070,2014
+MATH,2070,017,Multivariable Calcul,0.17,0.5,0.11,0.0,0.11,0.0,0.0,0.11,grady mcgowa thomas,,MATH-2070,2014
+MATH,2070,018,Multivariable Calcul,0.2,0.13,0.13,0.2,0.27,0.0,0.0,0.07,garrett dranichak,,MATH-2070,2014
+MATH,2070,019,Multivariable Calcul,0.12,0.18,0.35,0.0,0.35,0.0,0.0,0.0,grady mcgowa thomas,,MATH-2070,2014
+MATH,2070,020,Multivariable Calcul,0.33,0.17,0.08,0.08,0.08,0.0,0.0,0.25,saba za alkaseasbeh,,MATH-2070,2014
+MATH,2080,001,Intro to Ordin Diff,0.36,0.21,0.27,0.03,0.06,0.0,0.0,0.06,peter kiessler,,MATH-2080,2014
+MATH,2080,002,Intro to Ordin Diff,0.33,0.31,0.14,0.03,0.11,0.0,0.0,0.08,timothy fra parrott,,MATH-2080,2014
+MATH,2080,003,Intro to Ordin Diff,0.08,0.23,0.23,0.08,0.23,0.0,0.0,0.15,shari prevost,,MATH-2080,2014
+MATH,2080,004,Intro to Ordin Diff,0.06,0.31,0.25,0.06,0.19,0.0,0.0,0.13,julie lassiter,,MATH-2080,2014
+MATH,2080,005,Intro to Ordin Diff,0.47,0.11,0.22,0.03,0.11,0.0,0.0,0.06,timothy fra parrott,,MATH-2080,2014
+MATH,2080,006,Intro to Ordin Diff,0.13,0.19,0.23,0.06,0.16,0.0,0.0,0.23,julie lassiter,,MATH-2080,2014
+MATH,2080,007,Intro to Ordin Diff,0.28,0.22,0.22,0.11,0.08,0.0,0.0,0.08,timothy fra parrott,,MATH-2080,2014
+MATH,2080,008,Intro to Ordin Diff,0.68,0.24,0.05,0.0,0.03,0.0,0.0,0.0,irina viktorova,,MATH-2080,2014
+MATH,2080,009,Intro to Ordin Diff,0.29,0.29,0.29,0.0,0.11,0.0,0.0,0.03,brandon gra goodell,,MATH-2080,2014
+MATH,2080,100,Intro to Ordin Diff,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True,MATH-2080,2014
+MATH,2160,001,Geometry for Elem Sc,0.63,0.26,0.0,0.07,0.04,0.0,0.0,0.0,allison stoddard,,MATH-2160,2014
+MATH,2160,002,Geometry for Elem Sc,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-2160,2014
+MATH,2500,001,Intro to Mathematica,0.8,0.11,0.06,0.0,0.0,0.0,0.0,0.03,daniel warner,,MATH-2500,2014
+MATH,3020,001,Stat for Science & E,0.29,0.29,0.29,0.14,0.0,0.0,0.0,0.0,yanbo xia,,MATH-3020,2014
+MATH,3020,002,Stat for Science & E,0.21,0.35,0.24,0.0,0.06,0.0,0.0,0.15,calvin williams,,MATH-3020,2014
+MATH,3020,003,Stat for Science & E,0.09,0.41,0.29,0.0,0.0,0.0,0.0,0.21,calvin williams,,MATH-3020,2014
+MATH,3020,004,Stat for Science & E,0.67,0.0,0.07,0.0,0.07,0.0,0.0,0.2,yanbo xia,,MATH-3020,2014
+MATH,3020,005,Stat for Science & E,0.46,0.23,0.21,0.08,0.0,0.0,0.0,0.03,michael thom finney,,MATH-3020,2014
+MATH,3020,006,Stat for Science & E,0.45,0.26,0.13,0.0,0.08,0.0,0.0,0.08,christopher mcmahan,,MATH-3020,2014
+MATH,3020,007,Stat for Science & E,0.76,0.18,0.0,0.0,0.03,0.0,0.0,0.03,dominique morgan,,MATH-3020,2014
+MATH,3110,001,Linear Algebra,0.13,0.21,0.21,0.13,0.21,0.0,0.0,0.13,mishko mitkovski,,MATH-3110,2014
+MATH,3110,002,Linear Algebra,0.35,0.16,0.16,0.06,0.1,0.0,0.0,0.16,xuhong gao,,MATH-3110,2014
+MATH,3110,003,Linear Algebra,0.21,0.21,0.21,0.14,0.1,0.0,0.0,0.14,felice manganiello,,MATH-3110,2014
+MATH,3110,004,Linear Algebra,0.49,0.2,0.11,0.06,0.09,0.0,0.0,0.06,xiaoqian sun,,MATH-3110,2014
+MATH,3110,005,Linear Algebra,0.3,0.33,0.18,0.09,0.06,0.0,0.0,0.03,svetlan poznanovikj,,MATH-3110,2014
+MATH,3110,100,Linear Algebra (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,True,MATH-3110,2014
+MATH,3160,001,Prob Solving for Mat,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-3160,2014
+MATH,3190,001,Introduction to Proo,0.57,0.17,0.04,0.0,0.17,0.0,0.0,0.04,michael adam burr,,MATH-3190,2014
+MATH,3190,002,Introduction to Proo,0.54,0.08,0.31,0.0,0.0,0.0,0.0,0.08,michael adam burr,,MATH-3190,2014
+MATH,3600,001,Intermediate Math Co,0.4,0.27,0.07,0.03,0.13,0.0,0.0,0.1,neil calkin,,MATH-3600,2014
+MATH,3650,001,Numerical Mthds for,0.14,0.24,0.24,0.21,0.1,0.0,0.0,0.07,christopher cox,,MATH-3650,2014
+MATH,3650,002,Numerical Mthds for,0.12,0.24,0.21,0.12,0.06,0.0,0.0,0.24,christopher cox,,MATH-3650,2014
+MATH,3650,003,Numerical Mthds for,0.32,0.44,0.12,0.03,0.03,0.0,0.0,0.06,timo johann heister,,MATH-3650,2014
+MATH,3650,004,Numerical Mthds for,0.17,0.26,0.29,0.09,0.06,0.0,0.0,0.14,vincent ervin,,MATH-3650,2014
+MATH,3990,001,CI in Mathematical S,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,MATH-3990,2014
+MATH,3990,001,CI in Mathematical S,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,laura jane shick,,MATH-3990,2014
+MATH,4000,001,Theory of Probabilit,0.48,0.08,0.28,0.04,0.12,0.0,0.0,0.0,derek brown,,MATH-4000,2014
+MATH,4000,002,Theory of Probabilit,0.44,0.15,0.24,0.06,0.03,0.0,0.0,0.09,yingbo li,,MATH-4000,2014
+MATH,4070,001,Regress & Time-Serie,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-4070,2014
+MATH,4120,001,Intro to Modern Alge,0.08,0.17,0.5,0.08,0.08,0.0,0.0,0.08,xuhong gao,,MATH-4120,2014
+MATH,4120,002,Intro to Modern Alge,0.3,0.3,0.13,0.17,0.1,0.0,0.0,0.0,kevin james,,MATH-4120,2014
+MATH,4190,001,Discrete Math Struct,0.48,0.3,0.09,0.12,0.0,0.0,0.0,0.0,beth novick,,MATH-4190,2014
+MATH,4310,001,Theory of Interest,0.53,0.24,0.06,0.06,0.06,0.0,0.0,0.06, erwin walker,,MATH-4310,2014
+MATH,4340,001,Adv Engineering Math,0.17,0.2,0.23,0.07,0.07,0.0,0.0,0.27,eleanor jenkins,,MATH-4340,2014
+MATH,4340,002,Adv Engineering Math,0.15,0.35,0.18,0.06,0.03,0.0,0.0,0.24,hyesuk lee,,MATH-4340,2014
+MATH,4400,001,Linear Programming,0.41,0.23,0.18,0.05,0.09,0.0,0.0,0.05,akshay sunil gupte,,MATH-4400,2014
+MATH,4530,001,Advanced Calculus I,0.18,0.53,0.18,0.03,0.03,0.0,0.0,0.06,taufiquar rahm khan,,MATH-4530,2014
+MATH,4540,001,Advanced Calculus II,0.15,0.46,0.31,0.08,0.0,0.0,0.0,0.0,taufiquar rahm khan,,MATH-4540,2014
+MATH,6120,001,Intro to Modern Alge,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,kevin james,,MATH-6120,2014
+MATH,6340,001,Adv Engineering Math,0.34,0.41,0.15,0.0,0.05,0.0,0.0,0.05,vincent ervin,,MATH-6340,2014
+MATH,6530,001,Advanced Calculus I,0.14,0.57,0.14,0.0,0.0,0.0,0.0,0.14,taufiquar rahm khan,,MATH-6530,2014
+MATH,8000,001,Probability,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,,MATH-8000,2014
+MATH,8010,001,General Linear Hypot,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,xiaoqian sun,,MATH-8010,2014
+MATH,8040,001,Statistical Inferenc,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,,MATH-8040,2014
+MATH,8050,001,Data Analysis,0.73,0.18,0.05,0.0,0.0,0.0,0.0,0.05,derek brown,,MATH-8050,2014
+MATH,8100,001,Mathematical Program,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,matthew saltzman,,MATH-8100,2014
+MATH,8120,001,Discrete Optimizatio,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,,MATH-8120,2014
+MATH,8140,001,Network Flow Program,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,warren adams,,MATH-8140,2014
+MATH,8170,001,Stochastic Mod in Op,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,peter kiessler,,MATH-8170,2014
+MATH,8190,001,Multicriteria Optimi,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,,MATH-8190,2014
+MATH,8210,001,Linear Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,,MATH-8210,2014
+MATH,8230,001,Complex Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,,MATH-8230,2014
+MATH,8510,001,Abstract Algebra I,0.57,0.14,0.14,0.0,0.0,0.0,0.0,0.14,felice manganiello,,MATH-8510,2014
+MATH,8530,001,Matrix Analysis,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,james brown,,MATH-8530,2014
+MATH,8550,001,Combinatorial Analys,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,,MATH-8550,2014
+MATH,8600,001,Intro to Scientific,0.46,0.23,0.08,0.0,0.0,0.0,0.0,0.23,timo johann heister,,MATH-8600,2014
+MATH,8610,001,Advanced Numerical A,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,hyesuk lee,,MATH-8610,2014
+MATH,8650,001,Data Structures,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel warner,,MATH-8650,2014
+MATH,8840,001,Statistics for Exper,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,,MATH-8840,2014
+MATH,9810,001,Sel Top in Math Stat,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,yingbo li,,MATH-9810,2014
+MATH,9830,001,Sel Top in Computati,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,qingshan chen,,MATH-9830,2014
+MBA,8030,001,Stat Analy of Bus Op,0.46,0.43,0.09,0.0,0.03,0.0,0.0,0.0,yuhong he,,MBA-8030,2014
+MBA,8060,001,Operations Mgt,0.31,0.51,0.07,0.0,0.02,0.0,0.0,0.09, sridharan,,MBA-8060,2014
+MBA,8070,001,Financial Management,0.45,0.32,0.05,0.0,0.05,0.0,0.0,0.14,ramon tolb franklin,,MBA-8070,2014
+MBA,8090,001,Org Beh & Hum Res Mg,0.55,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2014
+MBA,8090,002,Org Beh & Hum Res Mg,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2014
+MBA,8190,001,Intro to Acc and Fin,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,,MBA-8190,2014
+MBA,8190,001,Intro to Acc and Fin,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,william hol johnson,,MBA-8190,2014
+MBA,8290,001,Marketing Foundation,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,gary hunter,,MBA-8290,2014
+MBA,8330,001,Real Estate Investmt,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,,MBA-8330,2014
+MBA,8350,001,Investment Mgmt,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,uma sridharan,,MBA-8350,2014
+MBA,8360,001,Real Estate Principl,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,,MBA-8360,2014
+MBA,8370,001,Legal Environ of Bus,0.39,0.43,0.16,0.0,0.0,0.0,0.0,0.02,judson jahn,,MBA-8370,2014
+MBA,8400,001,Entrepreneurship & V,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,,MBA-8400,2014
+MBA,8420,001,R E Valuation,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,charles benja stone,,MBA-8420,2014
+MBA,8430,001,Entrepreneurial Acco,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,sally kathr widener,,MBA-8430,2014
+MBA,8440,001,Entrepreneurial Law,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,melinda davis lux,,MBA-8440,2014
+MBA,8450,001,Tech & Innova Mgt,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8450,2014
+MBA,8480,001,Entrpr Mkting & Digi,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MBA-8480,2014
+MBA,8490,005,Entrepreneurial Strg,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8490,2014
+MBA,8510,001,Bus Operations & Log,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MBA-8510,2014
+MBA,8540,001,Mgrl Accounting,0.34,0.57,0.03,0.0,0.03,0.0,0.0,0.03,charles ellio davis,,MBA-8540,2014
+MBA,8590,001,Mgr Decision Model,0.47,0.22,0.13,0.0,0.09,0.0,0.0,0.09,sara elizabet yoder,,MBA-8590,2014
+MBA,8590,002,Mgr Decision Model,0.72,0.09,0.07,0.0,0.02,0.0,0.0,0.11,mark mcknew,,MBA-8590,2014
+MBA,8600,001,Advanced Marketing S,0.34,0.55,0.11,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2014
+MBA,8600,002,Advanced Marketing S,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2014
+MBA,8610,001,Information Systems,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MBA-8610,2014
+MBA,8620,001,Managerial Economics,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,scott templeton,,MBA-8620,2014
+MBA,8620,002,Managerial Economics,0.72,0.23,0.04,0.0,0.0,0.0,0.0,0.0,stephen knec layton,,MBA-8620,2014
+MBA,8700,001,Strategic Management,0.55,0.43,0.02,0.0,0.0,0.0,0.0,0.0,peter gianiodis,,MBA-8700,2014
+MBA,8990,002,Creativity,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,,MBA-8990,2014
+MBA,8990,003,International Busine,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8990,2014
+ME,2000,001,Sophomore Seminar,0.89,0.08,0.01,0.0,0.01,0.0,0.0,0.01,todd schweisinger,,ME-2000,2014
+ME,2010,001,Statics & Dynamics,0.07,0.11,0.2,0.17,0.37,0.0,0.0,0.09,sherrill biggers,,ME-2010,2014
+ME,2010,002,Statics & Dynamics,0.18,0.21,0.23,0.09,0.21,0.0,0.0,0.07,paul joseph,,ME-2010,2014
+ME,2010,003,Statics & Dynamics,0.02,0.14,0.14,0.08,0.45,0.0,0.0,0.16,kalyan chakr katuri,,ME-2010,2014
+ME,2030,001,Founda Th/Fl Syst,0.3,0.47,0.16,0.03,0.04,0.0,0.0,0.0,david zumbrunnen,,ME-2030,2014
+ME,2040,001,Mechanics of Materia,0.15,0.38,0.34,0.08,0.05,0.0,0.0,0.0,michael porter,,ME-2040,2014
+ME,2040,002,Mechanics of Materia,0.11,0.21,0.52,0.08,0.04,0.0,0.0,0.03,huijuan zhao,,ME-2040,2014
+ME,2220,001,Mech Engr Lab I,0.19,0.44,0.38,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,002,Mech Engr Lab I,0.22,0.5,0.22,0.0,0.06,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,003,Mech Engr Lab I,0.15,0.75,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,005,Mech Engr Lab I,0.35,0.45,0.2,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,006,Mech Engr Lab I,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,007,Mech Engr Lab I,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,3000,001,Junior Honors Semina,0.0,0.0,0.0,0.0,0.0,0.91,0.0,0.09,paul joseph,True,ME-3000,2014
+ME,3030,002,Thermodynamics,0.31,0.4,0.2,0.07,0.0,0.0,0.0,0.02,richard miller,,ME-3030,2014
+ME,3030,003,Thermodynamics,0.06,0.13,0.31,0.16,0.22,0.0,0.0,0.11,john saylor,,ME-3030,2014
+ME,3040,001,Heat Transfer,0.19,0.26,0.32,0.14,0.03,0.0,0.0,0.06,jay ochterbeck,,ME-3040,2014
+ME,3050,001,Model/an Dy Syst,0.21,0.32,0.3,0.02,0.06,0.0,0.0,0.09,mohammed fari daqaq,,ME-3050,2014
+ME,3050,002,Model/an Dy Syst,0.12,0.67,0.18,0.03,0.0,0.0,0.0,0.0,yue wang,,ME-3050,2014
+ME,3060,002,Fund Machine Design,0.26,0.43,0.2,0.07,0.0,0.0,0.0,0.04,todd schweisinger,,ME-3060,2014
+ME,3060,003,Fund Machine Design,0.26,0.47,0.15,0.0,0.06,0.0,0.0,0.06,oliver myers,,ME-3060,2014
+ME,3070,001,Found of Mechanical,0.32,0.42,0.12,0.04,0.04,0.0,0.0,0.06,lonny thompson,,ME-3070,2014
+ME,3070,002,Found of Mechanical,0.09,0.56,0.29,0.06,0.0,0.0,0.0,0.0,gregory mocko,,ME-3070,2014
+ME,3080,001,Fluid Mechanics,0.05,0.14,0.52,0.14,0.05,0.0,0.0,0.1,jean-marc delhaye,,ME-3080,2014
+ME,3080,002,Fluid Mechanics,0.16,0.34,0.41,0.07,0.0,0.0,0.0,0.01,xiangchun xuan,,ME-3080,2014
+ME,3080,003,Fluid Mechanics,0.38,0.28,0.26,0.03,0.05,0.0,0.0,0.0,marija vukicevic,,ME-3080,2014
+ME,3120,001,Manuf Processes,0.5,0.38,0.05,0.02,0.0,0.0,0.0,0.05,hong seok choi,,ME-3120,2014
+ME,3120,002,Manuf Processes,0.18,0.47,0.22,0.08,0.06,0.0,0.0,0.0,rod martinez-duarte,,ME-3120,2014
+ME,3330,001,Mech Engr Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,3330,002,Mech Engr Lab II,0.31,0.5,0.0,0.06,0.0,0.0,0.0,0.13,todd schweisinger,,ME-3330,2014
+ME,3330,003,Mech Engr Lab II,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,3330,004,Mech Engr Lab II,0.19,0.5,0.19,0.0,0.0,0.0,0.0,0.13,todd schweisinger,,ME-3330,2014
+ME,3330,005,Mech Engr Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,3330,006,Mech Engr Lab II,0.08,0.85,0.0,0.0,0.0,0.0,0.0,0.08,todd schweisinger,,ME-3330,2014
+ME,3330,007,Mech Engr Lab II,0.13,0.56,0.31,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,3330,008,Mech Engr Lab II,0.19,0.56,0.13,0.0,0.0,0.0,0.0,0.13,todd schweisinger,,ME-3330,2014
+ME,4000,001,Senior Seminar,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03, ramasubramanian,,ME-4000,2014
+ME,4010,001,Mech Engr Design,0.41,0.38,0.12,0.08,0.0,0.0,0.0,0.01,joshua summers,,ME-4010,2014
+ME,4020,001,Intern in Engr Des,0.0,0.58,0.42,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2014
+ME,4020,002,Intern in Engr Des,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,ethan kung,,ME-4020,2014
+ME,4020,002,Intern in Engr Des,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,kalyan chakr katuri,,ME-4020,2014
+ME,4020,004,Intern in Engr Des,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-4020,2014
+ME,4020,005,Intern in Engr Des,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,,ME-4020,2014
+ME,4030,001,Control Dynamic Syst,0.33,0.31,0.24,0.08,0.0,0.0,0.0,0.03,ardalan vahidi,,ME-4030,2014
+ME,4180,001,F E A in M E Design,0.29,0.5,0.08,0.05,0.05,0.0,0.0,0.03,gang li,,ME-4180,2014
+ME,4200,001,Ener Sources/Utiliz,0.26,0.54,0.2,0.0,0.0,0.0,0.0,0.0,david zumbrunnen,,ME-4200,2014
+ME,4210,001,Intro to Comp Flow,0.38,0.19,0.27,0.12,0.0,0.0,0.0,0.04,chenning tong,,ME-4210,2014
+ME,4400,001,Matls for Aggr Envir,0.58,0.33,0.04,0.04,0.0,0.0,0.0,0.0,mica grujicic,,ME-4400,2014
+ME,4440,001,Mech Engr Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2014
+ME,4440,004,Mech Engr Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2014
+ME,4540,001,Design of Machine El,0.36,0.24,0.24,0.08,0.04,0.0,0.0,0.04,paul jeffrey meyer,,ME-4540,2014
+ME,6210,001,Intro to Comp Flow,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,chenning tong,,ME-6210,2014
+ME,6540,001,Des Machine Elements,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,,ME-6540,2014
+ME,6930,001,Selected Topics Me:T,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-6930,2014
+ME,8010,001,Found of Fluid Mech,0.26,0.22,0.44,0.0,0.04,0.0,0.0,0.04,richard figliola,,ME-8010,2014
+ME,8100,001,Macroscopic Thermo,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,jay ochterbeck,,ME-8100,2014
+ME,8140,001,Turb Bound Layer,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,,ME-8140,2014
+ME,8180,001,Intro to Fin Ele Ana,0.76,0.18,0.03,0.0,0.01,0.0,0.0,0.01,lonny thompson,,ME-8180,2014
+ME,8230,001,Control Systems,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-8230,2014
+ME,8370,001,Theory of Elast I,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,,ME-8370,2014
+ME,8430,001,Advanced Dynamics,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,phanin tallapragada,,ME-8430,2014
+ME,8460,001,Inter Dynamics,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,mohammed fari daqaq,,ME-8460,2014
+ME,8700,001,Adv Design Methods,0.47,0.26,0.21,0.0,0.03,0.0,0.0,0.03,georges fadel,,ME-8700,2014
+ME,8710,001,Engr Optimization,0.57,0.34,0.04,0.0,0.02,0.0,0.0,0.04,georges fadel,,ME-8710,2014
+ME,8930,027,ME SpecTopic - Optim,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,ardalan vahidi,,ME-8930,2014
+MGT,2010,001,Principles of Mgt,0.31,0.37,0.21,0.05,0.06,0.0,0.0,0.01,katherine clark,,MGT-2010,2014
+MGT,2010,002,Principles of Mgt,0.38,0.32,0.15,0.06,0.05,0.0,0.0,0.06,katherine clark,,MGT-2010,2014
+MGT,2010,003,Principles of Mgt,0.36,0.36,0.19,0.03,0.04,0.0,0.0,0.01,katherine clark,,MGT-2010,2014
+MGT,2010,004,Principles of Mgt,0.11,0.27,0.42,0.07,0.03,0.0,0.0,0.1,katherine clark,,MGT-2010,2014
+MGT,2010,005,Principles of Mgt,0.31,0.41,0.14,0.06,0.0,0.0,0.0,0.08,tina robbins,,MGT-2010,2014
+MGT,2010,006,Principles of Mgt,0.29,0.36,0.23,0.02,0.04,0.0,0.0,0.06,tina robbins,,MGT-2010,2014
+MGT,2010,007,Principles of Mgt,0.25,0.37,0.22,0.06,0.07,0.0,0.0,0.02,tina robbins,,MGT-2010,2014
+MGT,2010,008,Principles of Mgt,0.25,0.32,0.19,0.07,0.09,0.0,0.0,0.09,tina robbins,,MGT-2010,2014
+MGT,2010,009,Principles of Mgt(HO,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,tina robbins,True,MGT-2010,2014
+MGT,2180,125,Management PC Applic,0.44,0.41,0.12,0.01,0.01,0.0,0.0,0.01, sridharan,,MGT-2180,2014
+MGT,2180,125,Management PC Applic,0.44,0.41,0.12,0.01,0.01,0.0,0.0,0.01,ryan toole,,MGT-2180,2014
+MGT,2180,200,Management PC Applic,0.43,0.34,0.14,0.02,0.0,0.0,0.0,0.07, sridharan,,MGT-2180,2014
+MGT,2180,200,Management PC Applic,0.43,0.34,0.14,0.02,0.0,0.0,0.0,0.07,ryan toole,,MGT-2180,2014
+MGT,2180,230,Management PC Applic,0.57,0.34,0.05,0.01,0.0,0.0,0.0,0.03, sridharan,,MGT-2180,2014
+MGT,2180,230,Management PC Applic,0.57,0.34,0.05,0.01,0.0,0.0,0.0,0.03,ryan toole,,MGT-2180,2014
+MGT,2180,905,Management PC Applic,0.47,0.34,0.11,0.02,0.02,0.0,0.0,0.04,ryan toole,,MGT-2180,2014
+MGT,2180,905,Management PC Applic,0.47,0.34,0.11,0.02,0.02,0.0,0.0,0.04, sridharan,,MGT-2180,2014
+MGT,3070,001,Human Resource Manag,0.19,0.68,0.06,0.0,0.03,0.0,0.0,0.03,kristin dam scott,,MGT-3070,2014
+MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,,MGT-3070,2014
+MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,,MGT-3070,2014
+MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,katherine clark,,MGT-3070,2014
+MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03, sridharan,,MGT-3070,2014
+MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,katherine clark,,MGT-3070,2014
+MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,marvin monroe ward,,MGT-3070,2014
+MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,marvin monroe ward,,MGT-3070,2014
+MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,marvin monroe ward,,MGT-3070,2014
+MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,marvin monroe ward,,MGT-3070,2014
+MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,katherine clark,,MGT-3070,2014
+MGT,3070,006,Human Resource Manag,0.28,0.44,0.15,0.05,0.05,0.0,0.0,0.03,michael cole,,MGT-3070,2014
+MGT,3070,007,Human Resource Manag,0.41,0.51,0.05,0.0,0.03,0.0,0.0,0.0,michael cole,,MGT-3070,2014
+MGT,3100,001,Intermed Business St,0.15,0.3,0.13,0.08,0.23,0.0,0.0,0.13,sara elizabet yoder,,MGT-3100,2014
+MGT,3100,002,Intermed Business St,0.23,0.23,0.3,0.08,0.08,0.0,0.0,0.1,sara elizabet yoder,,MGT-3100,2014
+MGT,3100,003,Intermed Business St,0.39,0.14,0.25,0.14,0.06,0.0,0.0,0.03,sara elizabet yoder,,MGT-3100,2014
+MGT,3100,005,Intermed Business St,0.28,0.28,0.25,0.13,0.0,0.0,0.0,0.08,zachary mo leffakis,,MGT-3100,2014
+MGT,3100,006,Intermed Business St,0.55,0.3,0.13,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3100,2014
+MGT,3100,007,Intermed Business St,0.44,0.36,0.11,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3100,2014
+MGT,3100,008,Intermed Business St,0.33,0.23,0.26,0.03,0.03,0.0,0.0,0.13,zachary mo leffakis,,MGT-3100,2014
+MGT,3100,009,Intermed Business St,0.07,0.27,0.17,0.07,0.05,0.0,0.0,0.37,niratc tungtisanont,,MGT-3100,2014
+MGT,3100,011,Intermed Business St,0.27,0.4,0.17,0.0,0.07,0.0,0.0,0.1,yuhong he,,MGT-3100,2014
+MGT,3100,B,Intermed Business St,0.29,0.44,0.15,0.07,0.05,0.0,0.0,0.0,james walsh,,MGT-3100,2014
+MGT,3120,001,Decision Models for,0.29,0.15,0.44,0.07,0.05,0.0,0.0,0.0,mark mcknew,,MGT-3120,2014
+MGT,3120,002,Decision Models for,0.09,0.49,0.29,0.0,0.11,0.0,0.0,0.02,mark mcknew,,MGT-3120,2014
+MGT,3120,003,Decision Models for,0.18,0.42,0.33,0.02,0.04,0.0,0.0,0.0,mark mcknew,,MGT-3120,2014
+MGT,3150,001,New Venture Creation,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,,MGT-3150,2014
+MGT,3180,001,Mgt of Info Systems,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,heshan sun,,MGT-3180,2014
+MGT,3180,002,Mgt of Info Systems,0.45,0.45,0.08,0.0,0.0,0.0,0.0,0.03,heshan sun,,MGT-3180,2014
+MGT,3180,003,Mgt of Info Systems,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,dan jiang,,MGT-3180,2014
+MGT,3180,004,Mgt of Info Systems,0.3,0.45,0.08,0.03,0.15,0.0,0.0,0.0,tina marie esposito,,MGT-3180,2014
+MGT,3900,001,Ops Mgt,0.19,0.58,0.14,0.03,0.0,0.0,0.0,0.06,yunsik choi,,MGT-3900,2014
+MGT,3900,002,Ops Mgt,0.44,0.36,0.15,0.0,0.05,0.0,0.0,0.0,qiong chen,,MGT-3900,2014
+MGT,3900,003,Ops Mgt,0.33,0.51,0.13,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3900,2014
+MGT,3900,004,Ops Mgt,0.23,0.5,0.25,0.03,0.0,0.0,0.0,0.0,jerry kermi bilbrey,,MGT-3900,2014
+MGT,3900,005,Ops Mgt,0.18,0.48,0.33,0.03,0.0,0.0,0.0,0.0,yann ferrand,,MGT-3900,2014
+MGT,3900,006,Ops Mgt,0.16,0.29,0.23,0.0,0.1,0.0,0.0,0.23,qiong chen,,MGT-3900,2014
+MGT,3900,007,Ops Mgt,0.3,0.41,0.24,0.03,0.03,0.0,0.0,0.0,remi charpin,,MGT-3900,2014
+MGT,4000,001,Mgt of Org Beh,0.2,0.57,0.23,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2014
+MGT,4000,002,Mgt of Org Beh,0.25,0.5,0.2,0.0,0.0,0.0,0.0,0.05,michael cole,,MGT-4000,2014
+MGT,4000,003,Mgt of Org Beh,0.15,0.48,0.33,0.03,0.03,0.0,0.0,0.0,philip roth,,MGT-4000,2014
+MGT,4000,004,Mgt of Org Beh,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MGT-4000,2014
+MGT,4020,001,Ops Pln and Ctl,0.06,0.69,0.25,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4020,2014
+MGT,4020,002,Ops Pln and Ctl,0.15,0.69,0.08,0.08,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4020,2014
+MGT,4030,001,Bus Intelligence & A,0.23,0.46,0.23,0.0,0.08,0.0,0.0,0.0,siyuan li,,MGT-4030,2014
+MGT,4080,001,Lean Operations,0.09,0.45,0.45,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MGT-4080,2014
+MGT,4110,001,Project Management,0.21,0.53,0.18,0.0,0.03,0.0,0.0,0.05,russell purvis,,MGT-4110,2014
+MGT,4120,001,Supplier Management,0.04,0.64,0.28,0.04,0.0,0.0,0.0,0.0,shouqiang wang,,MGT-4120,2014
+MGT,4150,001,Business Strategy,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2014
+MGT,4150,002,Business Strategy,0.19,0.52,0.29,0.0,0.0,0.0,0.0,0.0,peter gianiodis,,MGT-4150,2014
+MGT,4150,003,Business Strategy,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2014
+MGT,4150,004,Business Strategy,0.37,0.45,0.08,0.0,0.11,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2014
+MGT,4150,006,Business Strategy,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2014
+MGT,4150,007,Business Strategy,0.17,0.46,0.32,0.02,0.0,0.0,0.0,0.02,jason wayne ridge,,MGT-4150,2014
+MGT,4150,008,Business Strategy,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,,MGT-4150,2014
+MGT,4150,009,Business Strategy,0.27,0.51,0.11,0.05,0.0,0.0,0.0,0.05,amy elizabet ingram,,MGT-4150,2014
+MGT,4160,001,Special Topics Hr,0.44,0.44,0.08,0.03,0.0,0.0,0.0,0.0,kristin dam scott,,MGT-4160,2014
+MGT,4230,001,Intern Bus Mgt,0.19,0.31,0.44,0.03,0.03,0.0,0.0,0.0,wayne stewart,,MGT-4230,2014
+MGT,4230,002,Intern Bus Mgt,0.24,0.26,0.38,0.06,0.06,0.0,0.0,0.0,wayne stewart,,MGT-4230,2014
+MGT,4230,003,Intern Bus Mgt,0.0,0.49,0.4,0.06,0.06,0.0,0.0,0.0,janis miller,,MGT-4230,2014
+MGT,4230,004,Intern Bus Mgt,0.1,0.51,0.29,0.03,0.02,0.0,0.0,0.05,janis miller,,MGT-4230,2014
+MGT,4240,001,Global Supply Chain,0.2,0.63,0.09,0.03,0.0,0.0,0.0,0.06,yann ferrand,,MGT-4240,2014
+MGT,4270,001,Managing Improvement,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MGT-4270,2014
+MGT,4300,001,Statistical Modeling,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,jerry kermi bilbrey,,MGT-4300,2014
+MGT,4310,001,Emp Rights & Resp,0.18,0.58,0.2,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,,MGT-4310,2014
+MGT,4350,001,Pers Interviewing,0.33,0.38,0.2,0.1,0.0,0.0,0.0,0.0,philip roth,,MGT-4350,2014
+MGT,4520,001,Business Analysis,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jackie patri london,,MGT-4520,2014
+MGT,4550,001,Emerging I T Trends,0.39,0.53,0.06,0.0,0.0,0.0,0.0,0.03,jason thatcher,,MGT-4550,2014
+MGT,4560,001,Business Info Mgt,0.33,0.25,0.33,0.08,0.0,0.0,0.0,0.0,siyuan li,,MGT-4560,2014
+MGT,8690,001,Project Mgt,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,MGT-8690,2014
+MGT,9050,001,Research Methods,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,varun grover,,MGT-9050,2014
+MHA,7210,001,Hlth Care Del Sys,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,,MHA-7210,2014
+MICR,1010,001,Microbes & Hum Aff,0.58,0.21,0.12,0.02,0.06,0.0,0.0,0.01,michael childress,,MICR-1010,2014
+MICR,1010,001,Microbes & Hum Aff,0.58,0.21,0.12,0.02,0.06,0.0,0.0,0.01,thomas hughes,,MICR-1010,2014
+MICR,2050,001,Introductory Micro,0.42,0.42,0.15,0.0,0.0,0.0,0.0,0.01,john abercrombie,,MICR-2050,2014
+MICR,3050,001,General Microbiology,0.53,0.25,0.16,0.06,0.0,0.0,0.0,0.01,krista barr rudolph,,MICR-3050,2014
+MICR,3050,002,General Microbiology,0.32,0.46,0.17,0.04,0.0,0.0,0.0,0.02,krista barr rudolph,,MICR-3050,2014
+MICR,4010,001,Microbial Diversity,0.17,0.32,0.2,0.15,0.05,0.0,0.0,0.12,barbara campbell,,MICR-4010,2014
+MICR,4050,001,Adv Microbial Ecol o,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4050,2014
+MICR,4140,001,Basic Immunology,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,yanzhang wei,,MICR-4140,2014
+MICR,4150,001,Microbial Genetics,0.25,0.31,0.25,0.17,0.02,0.0,0.0,0.0,min cao,,MICR-4150,2014
+MICR,4250,001,Microbial Gen Lab,0.71,0.14,0.0,0.14,0.0,0.0,0.0,0.0,min cao,,MICR-4250,2014
+MICR,4250,002,Microbial Gen Lab,0.68,0.18,0.14,0.0,0.0,0.0,0.0,0.0,min cao,,MICR-4250,2014
+MKT,3010,001,Prin of Marketing,0.21,0.59,0.17,0.02,0.0,0.0,0.0,0.01,james gaubert,,MKT-3010,2014
+MKT,3010,002,Prin of Marketing,0.15,0.44,0.3,0.07,0.04,0.0,0.0,0.0,carter wil mcelveen,,MKT-3010,2014
+MKT,3010,003,Prin of Marketing,0.25,0.47,0.21,0.05,0.02,0.0,0.0,0.01,carter wil mcelveen,,MKT-3010,2014
+MKT,3010,004,Prin of Marketing,0.28,0.42,0.28,0.02,0.0,0.0,0.0,0.0,carter wil mcelveen,,MKT-3010,2014
+MKT,3010,005,Prin of Marketing,0.15,0.41,0.29,0.08,0.03,0.0,0.0,0.03,amanda cooper fine,,MKT-3010,2014
+MKT,3010,006,Prin of Marketing,0.16,0.48,0.24,0.08,0.02,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2014
+MKT,3010,007,Prin of Marketing,0.21,0.39,0.33,0.05,0.01,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2014
+MKT,3010,008,Prin of Marketing,0.33,0.42,0.15,0.03,0.06,0.0,0.0,0.0,patricia knowles,,MKT-3010,2014
+MKT,3020,001,Consumer Behavior,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2014
+MKT,3020,002,Consumer Behavior,0.43,0.45,0.11,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2014
+MKT,3020,003,Consumer Behavior,0.36,0.5,0.1,0.02,0.02,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2014
+MKT,3020,004,Consumer Behavior,0.4,0.34,0.24,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2014
+MKT,3210,001,Sports Marketing,0.43,0.43,0.11,0.0,0.0,0.0,0.0,0.04,delancy bennett,,MKT-3210,2014
+MKT,4200,001,Professional Selling,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,gary hunter,,MKT-4200,2014
+MKT,4200,002,Professional Selling,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2014
+MKT,4200,003,Professional Selling,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,jesse moore,,MKT-4200,2014
+MKT,4200,004,Professional Selling,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,ryan mullins,,MKT-4200,2014
+MKT,4230,001,Promotional Strategy,0.2,0.44,0.31,0.02,0.02,0.0,0.0,0.0,patricia knowles,,MKT-4230,2014
+MKT,4240,001,Sales Management,0.32,0.58,0.03,0.0,0.0,0.0,0.0,0.06,ryan mullins,,MKT-4240,2014
+MKT,4260,001,Business-to-Business,0.24,0.53,0.2,0.0,0.0,0.0,0.0,0.02,james gaubert,,MKT-4260,2014
+MKT,4270,001,International Mktg,0.27,0.58,0.11,0.04,0.0,0.0,0.0,0.0,roger gomes,,MKT-4270,2014
+MKT,4270,002,International Mktg,0.24,0.46,0.22,0.07,0.0,0.0,0.0,0.02,roger gomes,,MKT-4270,2014
+MKT,4270,003,International Mktg,0.16,0.64,0.14,0.07,0.0,0.0,0.0,0.0,roger gomes,,MKT-4270,2014
+MKT,4270,004,International Mktg,0.19,0.53,0.19,0.0,0.0,0.0,0.0,0.08,thomas poehlman,,MKT-4270,2014
+MKT,4280,001,Services Marketing,0.23,0.44,0.33,0.0,0.0,0.0,0.0,0.0,stephen grove,,MKT-4280,2014
+MKT,4280,002,Services Marketing,0.05,0.74,0.21,0.0,0.0,0.0,0.0,0.0,stephen grove,,MKT-4280,2014
+MKT,4310,001,Marketing Research,0.18,0.5,0.27,0.05,0.0,0.0,0.0,0.0,peter weathers,,MKT-4310,2014
+MKT,4310,002,Marketing Research,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2014
+MKT,4310,003,Marketing Research,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2014
+MKT,4310,004,Marketing Research,0.16,0.72,0.08,0.0,0.0,0.0,0.0,0.04,william kilbourne,,MKT-4310,2014
+MKT,4430,001,Advertising Strategy,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,,MKT-4430,2014
+MKT,4450,001,Macromarketing,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,,MKT-4450,2014
+MKT,4500,001,Strategic Mktg Mgt,0.14,0.62,0.24,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2014
+MKT,4500,002,Strategic Mktg Mgt,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-4500,2014
+MKT,4500,003,Strategic Mktg Mgt,0.16,0.76,0.08,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2014
+MKT,4950,001,Marketing Metrics,0.23,0.46,0.23,0.08,0.0,0.0,0.0,0.0,peter weathers,,MKT-4950,2014
+MKT,8610,001,Marketing Research,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,christopher hopkins,,MKT-8610,2014
+MKT,8630,001,Buyer Behavior,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,thomas poehlman,,MKT-8630,2014
+ML,1010,001,Leadership Fund I,0.72,0.16,0.0,0.0,0.0,0.0,0.0,0.12,robert rozetar,,ML-1010,2014
+ML,1010,001,Leadership Fund I,0.72,0.16,0.0,0.0,0.0,0.0,0.0,0.12,joe luis medrano,,ML-1010,2014
+ML,1010,002,Leadership Fund I,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,robert rozetar,,ML-1010,2014
+ML,1010,002,Leadership Fund I,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,joe luis medrano,,ML-1010,2014
+ML,2010,001,Leadership Develop I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,,ML-2010,2014
+ML,2010,001,Leadership Develop I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,rene romo,,ML-2010,2014
+ML,2010,002,Leadership Develop I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,rene romo,,ML-2010,2014
+ML,2010,002,Leadership Develop I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,,ML-2010,2014
+ML,3010,001,Adv Leadership I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jason danie bielski,,ML-3010,2014
+ML,3010,001,Adv Leadership I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,,ML-3010,2014
+ML,3010,002,Adv Leadership I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,,ML-3010,2014
+ML,3010,002,Adv Leadership I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jason danie bielski,,ML-3010,2014
+ML,4010,001,Org Leadership I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,,ML-4010,2014
+ML,4010,001,Org Leadership I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,phillip ale andrews,,ML-4010,2014
+ML,4010,003,Org Leadership I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,phillip ale andrews,,ML-4010,2014
+ML,4010,003,Org Leadership I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,,ML-4010,2014
+MSE,2100,001,Intro to Mat Science,0.4,0.33,0.16,0.05,0.03,0.0,0.0,0.03,eric skaar,,MSE-2100,2014
+MSE,2100,002,Intro to Mat Science,0.31,0.36,0.17,0.06,0.04,0.0,0.0,0.06,kyle brinkman,,MSE-2100,2014
+MSE,2100,003,Intro to Mat Science,0.25,0.38,0.19,0.07,0.02,0.0,0.0,0.09,eric skaar,,MSE-2100,2014
+MSE,2100,004,Intro to Mat Science,0.33,0.4,0.14,0.03,0.04,0.0,0.0,0.05,eric skaar,,MSE-2100,2014
+MSE,3190,001,Materials Proc I,0.14,0.36,0.36,0.09,0.05,0.0,0.0,0.0,henry rack,,MSE-3190,2014
+MSE,3190,002,Materials Proc I,0.45,0.43,0.11,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,,MSE-3190,2014
+MSE,3190,002,Materials Proc I,0.45,0.43,0.11,0.0,0.0,0.0,0.0,0.0,olin mefford,,MSE-3190,2014
+MSE,3260,001,Thermo of Materials,0.26,0.5,0.18,0.03,0.0,0.0,0.0,0.03,gary lickfield,,MSE-3260,2014
+MSE,3260,002,Thermo of Materials,0.09,0.41,0.38,0.06,0.0,0.0,0.0,0.06,gary lickfield,,MSE-3260,2014
+MSE,3270,001,Transport Phenomena,0.77,0.16,0.06,0.0,0.01,0.0,0.0,0.01,konstantin kornev,,MSE-3270,2014
+MSE,3270,002,Transport Phenomena,0.47,0.35,0.09,0.09,0.0,0.0,0.0,0.0,fei peng,,MSE-3270,2014
+MSE,4020,001,Solid State Material,0.28,0.44,0.28,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-4020,2014
+MSE,4130,001,Noncrystalline Mater,0.57,0.21,0.21,0.0,0.0,0.0,0.0,0.0,herbert david leigh,,MSE-4130,2014
+MSE,4150,001,Polymer Sc Engr,0.3,0.34,0.21,0.06,0.06,0.0,0.0,0.04,marek urban,,MSE-4150,2014
+MSE,4150,002,Polymer Sc Engr,0.35,0.35,0.15,0.11,0.01,0.0,0.0,0.02,olin mefford,,MSE-4150,2014
+MSE,4410,001,Mfg Laboratory,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,,MSE-4410,2014
+MSE,4550,001,Polymer Fiber Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,olin mefford,,MSE-4550,2014
+MSE,4550,002,Polymer Fiber Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,olin mefford,,MSE-4550,2014
+MSE,4580,001,Surf Phen in Ms&E,0.21,0.29,0.14,0.29,0.07,0.0,0.0,0.0,konstantin kornev,,MSE-4580,2014
+MSE,4610,001,Polymer & Fiber Mate,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,,MSE-4610,2014
+MSE,8010,001,Grad Sem in Material,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,,MSE-8010,2014
+MSE,8010,001,Grad Sem in Material,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,,MSE-8010,2014
+MSE,8200,001,Def Mech in Solids,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,marian kennedy,,MSE-8200,2014
+MSE,8270,001,Kin of Phase Tran,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,,MSE-8270,2014
+MSE,8520,001,Polymer Science II,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,igor luzinov,,MSE-8520,2014
+MUSC,1110,001,Beginning Class Guit,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,david stevenson,,MUSC-1110,2014
+MUSC,1420,001,Music Theory I,0.58,0.08,0.25,0.0,0.08,0.0,0.0,0.0,david conley,,MUSC-1420,2014
+MUSC,1420,002,Music Theory I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,david conley,,MUSC-1420,2014
+MUSC,2100,001,Music in West World,0.58,0.32,0.03,0.03,0.0,0.0,0.0,0.03,eric lapin,,MUSC-2100,2014
+MUSC,2100,002,Music in West World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,lisa sain odom,,MUSC-2100,2014
+MUSC,2100,003,Music in West World,0.84,0.1,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-2100,2014
+MUSC,2100,004,Music in West World,0.52,0.13,0.19,0.1,0.06,0.0,0.0,0.0,linda li-bleuel,,MUSC-2100,2014
+MUSC,2100,005,Music in West World,0.83,0.1,0.05,0.0,0.02,0.0,0.0,0.0,timothy ra hurlburt,,MUSC-2100,2014
+MUSC,2100,006,Music in West World,0.6,0.23,0.03,0.0,0.0,0.0,0.0,0.13,rhea beth jacobus,,MUSC-2100,2014
+MUSC,2100,007,Music in West World,0.76,0.17,0.0,0.0,0.03,0.0,0.0,0.03,rhea beth jacobus,,MUSC-2100,2014
+MUSC,2100,008,Music in West World,0.66,0.25,0.06,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,,MUSC-2100,2014
+MUSC,2100,009,Music in West World,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,evan michael jacobi,,MUSC-2100,2014
+MUSC,2100,010,Music in West World,0.84,0.0,0.16,0.0,0.0,0.0,0.0,0.0,linda dzuris,,MUSC-2100,2014
+MUSC,2100,012,Music in West World,0.52,0.35,0.1,0.0,0.0,0.0,0.0,0.03,lea kibler,,MUSC-2100,2014
+MUSC,3080,001,Surv of Broadway I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey christmas,,MUSC-3080,2014
+MUSC,3110,001,Hist of Amer Music,0.56,0.28,0.13,0.0,0.03,0.0,0.0,0.0,ned hosler,,MUSC-3110,2014
+MUSC,3120,001,History of Jazz,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-3120,2014
+MUSC,3130,001,Hist of Rock & Roll,0.46,0.39,0.07,0.04,0.0,0.0,0.0,0.04,hamilton altstatt,,MUSC-3130,2014
+MUSC,3170,001,Hist of Country Mus,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,ned hosler,,MUSC-3170,2014
+MUSC,3180,001,Hist of Audio Tech,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,,MUSC-3180,2014
+MUSC,3420,001,Women's Breakout Ens,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,david conley,,MUSC-3420,2014
+MUSC,3610,001,Marching Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.01,timothy ra hurlburt,,MUSC-3610,2014
+MUSC,3610,001,Marching Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,,MUSC-3610,2014
+MUSC,3630,001,Jazz Ensemble,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,timothy ra hurlburt,,MUSC-3630,2014
+MUSC,3700,001,Clemson University S,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,justin durham,,MUSC-3700,2014
+MUSC,3720,001,Men's Glee,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,david conley,,MUSC-3720,2014
+MUSC,4150,001,Music Hist to 1750,0.29,0.18,0.29,0.12,0.12,0.0,0.0,0.0,justin durham,,MUSC-4150,2014
+NPL,3000,001,Nonprofit Leadership,0.7,0.15,0.04,0.0,0.0,0.0,0.0,0.11,tracy diane lamb,,NPL-3000,2014
+NPL,3000,002,Nonprofit Leadership,0.72,0.12,0.04,0.0,0.08,0.0,0.0,0.04,tracy diane lamb,,NPL-3000,2014
+NURS,1020,001,Nrsg Success Skills,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,kristin goodenow,,NURS-1020,2014
+NURS,1400,001,Comp App Hlth Care,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,,NURS-1400,2014
+NURS,3030,001,Nursing of Adults,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,corinne croc harmon,,NURS-3030,2014
+NURS,3030,001,Nursing of Adults,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,,NURS-3030,2014
+NURS,3040,001,Pathophysiology,0.52,0.46,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,,NURS-3040,2014
+NURS,3040,400,Pathophysiology,0.43,0.38,0.1,0.0,0.05,0.0,0.0,0.05,catherine si murton,,NURS-3040,2014
+NURS,3040,401,Pathophysiology,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,NURS-3040,2014
+NURS,3050,001,Psychosocial Nursing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,,NURS-3050,2014
+NURS,3100,001,Health Assessment,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3100,2014
+NURS,3100,400,Health Assessment,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.05,jason thrift,,NURS-3100,2014
+NURS,3120,001,Foundations of Nurs,0.25,0.65,0.08,0.0,0.0,0.0,0.0,0.02,angela pye,,NURS-3120,2014
+NURS,3120,400,Foundations of Nurs,0.14,0.81,0.0,0.0,0.0,0.0,0.0,0.05,wanda leigh taylor,,NURS-3120,2014
+NURS,3190,400,Health Assessment fo,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,,NURS-3190,2014
+NURS,3200,400,Prof in Nurs,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,mary steck,,NURS-3200,2014
+NURS,3230,400,Gerontology Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,tawny jenn mcintosh,,NURS-3230,2014
+NURS,3300,002,Research in Nursing,0.91,0.05,0.05,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-3300,2014
+NURS,3330,400,Health Care Genetics,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,,NURS-3330,2014
+NURS,3400,001,Pharmther Nursing,0.43,0.43,0.06,0.06,0.02,0.0,0.0,0.02,catherine si murton,,NURS-3400,2014
+NURS,3400,400,Pharmther Nursing,0.29,0.52,0.05,0.05,0.05,0.0,0.0,0.05,catherine si murton,,NURS-3400,2014
+NURS,4010,001,Mental Health Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-4010,2014
+NURS,4030,200,Complex Nursing of A,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,,NURS-4030,2014
+NURS,4030,230,Complex Nursing of A,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,,NURS-4030,2014
+NURS,4100,001,Lead Mgt Practicum,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,,NURS-4100,2014
+NURS,4100,001,Lead Mgt Practicum,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,portia botchway,,NURS-4100,2014
+NURS,4100,400,Lead Mgt Practicum,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,,NURS-4100,2014
+NURS,4100,400,Lead Mgt Practicum,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,portia botchway,,NURS-4100,2014
+NURS,4110,001,Nursing of Children,0.66,0.29,0.05,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-4110,2014
+NURS,4120,001,Nurs Women and Fam,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2014
+NURS,4150,001,Comm Hlth Nursing,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,jackie gillespie,,NURS-4150,2014
+NURS,8050,400,Pharmaco Adv Nurs,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8050,2014
+NURS,8060,400,Advan Assessment for,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,,NURS-8060,2014
+NURS,8060,400,Advan Assessment for,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,,NURS-8060,2014
+NURS,8090,400,Pathophysiology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,,NURS-8090,2014
+NURS,8090,400,Pathophysiology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,julia eggert,,NURS-8090,2014
+NURS,8190,400,Developing Family,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-8190,2014
+NURS,8190,400,Developing Family,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,,NURS-8190,2014
+NURS,8200,400,Child & Adol Nursing,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-8200,2014
+NUTR,2030,001,Intro Princ of Human,0.42,0.34,0.15,0.02,0.02,0.0,0.0,0.04,deborah an hutcheon,,NUTR-2030,2014
+NUTR,2050,001,Nutr for Nurs Prof,0.66,0.31,0.02,0.01,0.0,0.0,0.0,0.0,deborah an hutcheon,,NUTR-2050,2014
+NUTR,2160,001,Evidence-Based Nutri,0.73,0.19,0.03,0.0,0.0,0.0,0.0,0.05,angela fraser,,NUTR-2160,2014
+NUTR,4190,001,Professional Dev in,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,,NUTR-4190,2014
+NUTR,4240,001,Medical Nutr Thera I,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,rita haliena,,NUTR-4240,2014
+NUTR,4510,001,Human Nutrition,0.39,0.44,0.11,0.05,0.02,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4510,2014
+PA,1010,001,Intro to Perf Arts,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,david hartmann,,PA-1010,2014
+PA,1030,001,Portfolio I,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,linda dzuris,,PA-1030,2014
+PA,2010,001,Career Planning and,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,ned hosler,,PA-2010,2014
+PA,2790,001,Perf Arts Pract I,0.86,0.0,0.09,0.0,0.05,0.0,0.0,0.0,kenneth moore,,PA-2790,2014
+PA,2800,001,Perf Arts Pract II,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,kenneth moore,,PA-2800,2014
+PA,3010,001,Prin of Arts Admin,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,paul buyer,,PA-3010,2014
+PADM,7020,400,Research Methods,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,,PADM-7020,2014
+PADM,8220,400,Public Policy Proces,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,mark daniel mellott,,PADM-8220,2014
+PADM,8290,400,Public Financial Man,0.4,0.47,0.0,0.0,0.0,0.0,0.0,0.13,robert frager,,PADM-8290,2014
+PADM,8510,400,Emergency Management,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,steven batson,,PADM-8510,2014
+PADM,8680,400,Local Government Adm,0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,alfred bundrick,,PADM-8680,2014
+PADM,8780,404,COMMUNICATIONS FOR P,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,scott schmidt,,PADM-8780,2014
+PAS,3010,001,Pan African Studies,0.48,0.3,0.15,0.04,0.0,0.0,0.0,0.02,abel bartley,,PAS-3010,2014
+PDBE,8010,001,Advanced Theory in E,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,,PDBE-8010,2014
+PDBE,8010,001,Advanced Theory in E,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,,PDBE-8010,2014
+PES,1040,001,Introduction to Plan,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,paula agudelo,,PES-1040,2014
+PES,2020,001,Soils,0.19,0.41,0.33,0.03,0.03,0.0,0.0,0.01,dara michelle park,,PES-2020,2014
+PES,4850,001,Environmental Soil C,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,,PES-4850,2014
+PHIL,1010,001,Intro to Phil Prob,0.76,0.15,0.06,0.0,0.03,0.0,0.0,0.0,david stegall,,PHIL-1010,2014
+PHIL,1010,002,Intro to Phil Prob,0.71,0.09,0.09,0.0,0.0,0.0,0.0,0.12,david stegall,,PHIL-1010,2014
+PHIL,1010,003,Intro to Phil Prob,0.37,0.34,0.26,0.0,0.0,0.0,0.0,0.03,christopher grau,,PHIL-1010,2014
+PHIL,1020,001,Intro to Logic,0.14,0.74,0.09,0.0,0.0,0.0,0.0,0.03,kelly smith,,PHIL-1020,2014
+PHIL,1020,002,Intro to Logic,0.09,0.76,0.15,0.0,0.0,0.0,0.0,0.0,kelly smith,,PHIL-1020,2014
+PHIL,1020,003,Intro to Logic,0.67,0.21,0.03,0.06,0.03,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2014
+PHIL,1020,004,Intro to Logic,0.83,0.13,0.0,0.03,0.0,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2014
+PHIL,1020,005,Intro to Logic,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,gregory scott moss,,PHIL-1020,2014
+PHIL,1020,006,Intro to Logic,0.74,0.09,0.06,0.0,0.0,0.0,0.0,0.12,gregory scott moss,,PHIL-1020,2014
+PHIL,1020,007,Intro to Logic,0.64,0.27,0.0,0.06,0.0,0.0,0.0,0.03,gregory scott moss,,PHIL-1020,2014
+PHIL,1030,001,Intro to Ethics (HON,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True,PHIL-1030,2014
+PHIL,1030,002,Intro to Ethics,0.29,0.29,0.17,0.14,0.09,0.0,0.0,0.03,jennifer ingle,,PHIL-1030,2014
+PHIL,1030,003,Intro to Ethics,0.47,0.44,0.03,0.0,0.0,0.0,0.0,0.06,michael hal hannen,,PHIL-1030,2014
+PHIL,1030,004,Intro to Ethics,0.14,0.51,0.29,0.06,0.0,0.0,0.0,0.0,jennifer ingle,,PHIL-1030,2014
+PHIL,1030,005,Intro to Ethics,0.24,0.52,0.09,0.0,0.06,0.0,0.0,0.09,charles starkey,,PHIL-1030,2014
+PHIL,1030,006,Intro to Ethics,0.51,0.34,0.03,0.03,0.03,0.0,0.0,0.06,ryan lake,,PHIL-1030,2014
+PHIL,1030,008,Intro to Ethics,0.33,0.43,0.19,0.0,0.05,0.0,0.0,0.0,ryan lake,,PHIL-1030,2014
+PHIL,1030,009,Intro to Ethics,0.51,0.37,0.09,0.0,0.0,0.0,0.0,0.03,ryan lake,,PHIL-1030,2014
+PHIL,3030,001,Phil of Religion,0.5,0.36,0.0,0.07,0.0,0.0,0.0,0.07,gregory scott moss,,PHIL-3030,2014
+PHIL,3040,001,Moral Philosophy,0.19,0.38,0.19,0.0,0.13,0.0,0.0,0.13,charles starkey,,PHIL-3040,2014
+PHIL,3050,001,Existentialism,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,david stegall,,PHIL-3050,2014
+PHIL,3150,001,Ancient Philosophy,0.18,0.43,0.25,0.07,0.07,0.0,0.0,0.0,stephen satris,,PHIL-3150,2014
+PHIL,3160,001,Mod Phil,0.61,0.3,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,,PHIL-3160,2014
+PHIL,3170,001,19th-Century Philoso,0.15,0.27,0.27,0.06,0.09,0.0,0.0,0.15,william maker,,PHIL-3170,2014
+PHIL,3200,001,Soc and Pol Phil,0.28,0.44,0.16,0.0,0.08,0.0,0.0,0.04,todd may,,PHIL-3200,2014
+PHIL,3260,001,Science and Values,0.36,0.48,0.06,0.0,0.03,0.0,0.0,0.06,andrew garnar,,PHIL-3260,2014
+PHIL,3260,002,Science and Values,0.41,0.38,0.15,0.0,0.03,0.0,0.0,0.03,andrew garnar,,PHIL-3260,2014
+PHIL,3260,003,Science and Values,0.49,0.49,0.0,0.0,0.03,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2014
+PHIL,3430,001,Phil of Law,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,david stegall,,PHIL-3430,2014
+PHIL,3440,001,Business Ethics,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,david stegall,,PHIL-3440,2014
+PHIL,3450,001,Environmental Ethics,0.42,0.21,0.06,0.12,0.12,0.0,0.0,0.06,jennifer ingle,,PHIL-3450,2014
+PHIL,3490,001,Gender and Sexuality,0.33,0.48,0.04,0.0,0.07,0.0,0.0,0.07,diane perpich,,PHIL-3490,2014
+PHIL,3550,001,Phil Mind & Cog Sci,0.4,0.4,0.1,0.0,0.0,0.0,0.0,0.1,andrew garnar,,PHIL-3550,2014
+PHIL,3990,001,Philosophy Portfolio,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,kelly smith,,PHIL-3990,2014
+PHIL,4020,001,Topics in Philosophy,0.41,0.41,0.12,0.0,0.06,0.0,0.0,0.0,todd may,,PHIL-4020,2014
+PHIL,4020,002,Topics in Philosophy,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,candice delmas,,PHIL-4020,2014
+PHIL,4750,001,Philosophy of Film,0.27,0.45,0.09,0.09,0.0,0.0,0.0,0.09,christopher grau,,PHIL-4750,2014
+PHSC,1180,001,Intro Phys & Astro,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1180,2014
+PHYS,1220,001,Physics With Cal I,0.31,0.3,0.23,0.06,0.05,0.0,0.0,0.04,lih-sin the,,PHYS-1220,2014
+PHYS,1220,002,Physics With Cal I,0.2,0.28,0.26,0.15,0.07,0.0,0.0,0.04,lih-sin the,,PHYS-1220,2014
+PHYS,1220,004,Phys W/Cal I (MAJ ON,0.28,0.39,0.11,0.11,0.0,0.0,0.0,0.11,murray daw,,PHYS-1220,2014
+PHYS,1240,001,Physics Lab I,0.06,0.83,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,002,Physics Lab I,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,003,Physics Lab I,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,004,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,005,Physics Lab I,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,006,Physics Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,007,Physics Lab I,0.27,0.67,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-1240,2014
+PHYS,1240,008,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,009,Physics Lab I,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,010,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,011,Physics Lab I,0.06,0.82,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,,PHYS-1240,2014
+PHYS,1240,012,Physics Lab I,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,013,Physics Lab I,0.19,0.63,0.13,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,014,Physics Lab I,0.06,0.63,0.19,0.0,0.06,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,016,Physics Lab I,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-1240,2014
+PHYS,1240,017,Physics Lab I,0.29,0.64,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-1240,2014
+PHYS,2070,001,General Physics I,0.42,0.35,0.16,0.04,0.01,0.0,0.0,0.02,amy liann pope,,PHYS-2070,2014
+PHYS,2070,002,General Physics I,0.52,0.33,0.09,0.02,0.01,0.0,0.0,0.02,amy liann pope,,PHYS-2070,2014
+PHYS,2070,003,General Physics I,0.34,0.28,0.22,0.07,0.06,0.0,0.0,0.03,pooja puneet,,PHYS-2070,2014
+PHYS,2080,001,General Physics II,0.42,0.37,0.12,0.04,0.04,0.0,0.0,0.03,pooja puneet,,PHYS-2080,2014
+PHYS,2090,001,Gen Phys Lab I,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2014
+PHYS,2090,002,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,003,Gen Phys Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,004,Gen Phys Lab I,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2014
+PHYS,2090,005,Gen Phys Lab I,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,006,Gen Phys Lab I,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,007,Gen Phys Lab I,0.68,0.23,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2014
+PHYS,2090,008,Gen Phys Lab I,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,009,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,010,Gen Phys Lab I,0.55,0.27,0.14,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2014
+PHYS,2090,011,Gen Phys Lab I,0.38,0.42,0.17,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2014
+PHYS,2090,012,Gen Phys Lab I,0.57,0.35,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,013,Gen Phys Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,014,Gen Phys Lab I,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,015,Gen Phys Lab I,0.26,0.57,0.09,0.0,0.0,0.0,0.0,0.09,jerry hester,,PHYS-2090,2014
+PHYS,2090,016,Gen Phys Lab I,0.5,0.27,0.18,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2014
+PHYS,2090,017,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2014
+PHYS,2090,018,Gen Phys Lab I,0.55,0.41,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,019,Gen Phys Lab I,0.14,0.64,0.23,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,020,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2014
+PHYS,2090,021,Gen Phys Lab I,0.18,0.59,0.09,0.0,0.0,0.0,0.0,0.14,jerry hester,,PHYS-2090,2014
+PHYS,2090,022,Gen Phys Lab I,0.43,0.43,0.09,0.04,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,023,Gen Phys Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,024,Gen Phys Lab I,0.55,0.23,0.14,0.0,0.0,0.0,0.0,0.09,jerry hester,,PHYS-2090,2014
+PHYS,2100,001,Gen Phys Lab II,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,002,Gen Phys Lab II,0.33,0.54,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,003,Gen Phys Lab II,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,004,Gen Phys Lab II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,006,Gen Phys Lab II,0.3,0.52,0.04,0.0,0.0,0.0,0.0,0.13,jerry hester,,PHYS-2100,2014
+PHYS,2100,007,Gen Phys Lab II,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,008,Gen Phys Lab II,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2210,001,Physics With Cal II,0.2,0.5,0.21,0.06,0.02,0.0,0.0,0.01,jason stratfo brown,,PHYS-2210,2014
+PHYS,2210,002,Physics With Cal II,0.27,0.52,0.16,0.03,0.02,0.0,0.0,0.0,jason stratfo brown,,PHYS-2210,2014
+PHYS,2210,003,Physics With Cal II,0.35,0.46,0.12,0.03,0.02,0.0,0.0,0.02,jason stratfo brown,,PHYS-2210,2014
+PHYS,2210,004,Physics With Cal II,0.24,0.47,0.2,0.05,0.02,0.0,0.0,0.02,lih-sin the,,PHYS-2210,2014
+PHYS,2210,007,Physics With Cal II,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,sean brittain,True,PHYS-2210,2014
+PHYS,2220,001,Phys With Cal III,0.28,0.5,0.11,0.06,0.06,0.0,0.0,0.0,jian he,,PHYS-2220,2014
+PHYS,2230,001,Physics Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,002,Physics Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,003,Physics Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,004,Physics Lab II,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,005,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,006,Physics Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,007,Physics Lab II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,009,Physics Lab II,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2014
+PHYS,2230,010,Physics Lab II,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,011,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,012,Physics Lab II,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2014
+PHYS,2230,013,Physics Lab II,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2014
+PHYS,2230,016,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,017,Physics Lab II,0.27,0.6,0.07,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-2230,2014
+PHYS,2450,001,Physics of Climate,0.23,0.41,0.11,0.03,0.01,0.0,0.0,0.21,john meriwether,,PHYS-2450,2014
+PHYS,3000,001,Intro to Research,0.82,0.05,0.05,0.05,0.05,0.0,0.0,0.0,terry tritt,,PHYS-3000,2014
+PHYS,3000,001,Intro to Research,0.82,0.05,0.05,0.05,0.05,0.0,0.0,0.0,jens oberheide,,PHYS-3000,2014
+PHYS,3110,001,Methods Theor Phys,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,feng ding,,PHYS-3110,2014
+PHYS,3210,001,Mechanics I,0.11,0.32,0.05,0.16,0.11,0.0,0.0,0.26,gerald lehmacher,,PHYS-3210,2014
+PHYS,3250,001,Exper Physics I,0.28,0.67,0.0,0.0,0.0,0.0,0.0,0.06,hye jung kang,,PHYS-3250,2014
+PHYS,3250,001,Exper Physics I,0.28,0.67,0.0,0.0,0.0,0.0,0.0,0.06,chad sosolik,,PHYS-3250,2014
+PHYS,4420,001,Electromagnetics II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,endre andras takacs,,PHYS-4420,2014
+PHYS,4550,001,Quantum Physics I,0.08,0.67,0.25,0.0,0.0,0.0,0.0,0.0,antony valentini,,PHYS-4550,2014
+PHYS,6520,001,Int to Nuclear Phys,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jeremy king,,PHYS-6520,2014
+PHYS,6550,001,Quantum Physics I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,antony valentini,,PHYS-6550,2014
+PHYS,8110,001,Meth of Theor Phys I,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley meyer,,PHYS-8110,2014
+PHYS,8210,001,Classical Mech I,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,dieter hartmann,,PHYS-8210,2014
+PHYS,8750,007,Intro to Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jens oberheide,,PHYS-8750,2014
+PHYS,8750,007,Intro to Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,terry tritt,,PHYS-8750,2014
+PHYS,9510,001,Quantum Mech I,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,,PHYS-9510,2014
+PKSC,1010,001,Pkgsc Orientation,0.81,0.08,0.06,0.05,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-1010,2014
+PKSC,1020,001,Intro to Pkg Sci,0.05,0.36,0.4,0.12,0.06,0.0,0.0,0.0,heather batt,,PKSC-1020,2014
+PKSC,2020,001,Packaging Mtl & Mfg,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2020,2014
+PKSC,2040,001,Container Systems,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2040,2014
+PKSC,2200,001,Product & Pkg Design,0.69,0.23,0.06,0.0,0.0,0.0,0.0,0.02,william aaro snyder,,PKSC-2200,2014
+PKSC,4010,001,Pkg Machinery,0.33,0.41,0.22,0.04,0.0,0.0,0.0,0.0,anthony lou pometto,,PKSC-4010,2014
+PKSC,4030,001,Pkg Career Prep,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2014
+PKSC,4040,001,Mech Prop & Prot Pkg,0.21,0.29,0.29,0.09,0.08,0.0,0.0,0.03,gregory batt,,PKSC-4040,2014
+PKSC,4160,001,Appl Polymers in Pkg,0.09,0.44,0.35,0.07,0.02,0.0,0.0,0.02,duncan darby,,PKSC-4160,2014
+PKSC,4200,001,Pkg Design & Dev,0.56,0.41,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2014
+PKSC,4540,001,Prod Pkg Evl Lab,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,gregory batt,,PKSC-4540,2014
+PKSC,4540,002,Prod Pkg Evl Lab,0.13,0.5,0.25,0.06,0.06,0.0,0.0,0.0,gregory batt,,PKSC-4540,2014
+PKSC,4540,003,Prod Pkg Evl Lab,0.13,0.31,0.38,0.0,0.06,0.0,0.0,0.13,gregory batt,,PKSC-4540,2014
+PKSC,4540,004,Prod Pkg Evl Lab,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2014
+PKSC,4540,005,Prod Pkg Evl Lab,0.25,0.33,0.17,0.0,0.25,0.0,0.0,0.0,gregory batt,,PKSC-4540,2014
+PKSC,4640,001,Fd & Hc Pkg Systems,0.3,0.63,0.03,0.03,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2014
+PLPA,3100,001,Principles of Plant,0.15,0.65,0.15,0.05,0.0,0.0,0.0,0.0,steven nye jeffers,,PLPA-3100,2014
+POSC,1010,001,Amer National Govt,0.16,0.3,0.24,0.18,0.02,0.0,0.0,0.1,joseph earl stewart,,POSC-1010,2014
+POSC,1010,002,Amer National Govt,0.27,0.29,0.27,0.07,0.05,0.0,0.0,0.05,jeffrey scott peake,,POSC-1010,2014
+POSC,1010,003,Amer National Govt,0.13,0.51,0.18,0.07,0.04,0.0,0.0,0.07,laura olson,,POSC-1010,2014
+POSC,1020,001,Intro Intl Relations,0.15,0.42,0.25,0.02,0.04,0.0,0.0,0.11,aron geo tannenbaum,,POSC-1020,2014
+POSC,1020,002,Intro Intl Relations,0.11,0.53,0.29,0.02,0.02,0.0,0.0,0.04,lydia loui lundgren,,POSC-1020,2014
+POSC,1020,003,Intro Intl Relations,0.14,0.49,0.22,0.04,0.01,0.0,0.0,0.09,colin pearce,,POSC-1020,2014
+POSC,1030,001,Intro to Political T,0.09,0.35,0.33,0.13,0.04,0.0,0.0,0.07,james woodard,,POSC-1030,2014
+POSC,1030,002,Intro to Political T,0.22,0.51,0.12,0.0,0.02,0.0,0.0,0.12,jeremy fortier,,POSC-1030,2014
+POSC,1040,001,Intro Compar Pol,0.21,0.38,0.35,0.03,0.0,0.0,0.0,0.03,xiaobo hu,,POSC-1040,2014
+POSC,1040,002,Intro Compar Pol,0.17,0.56,0.21,0.04,0.02,0.0,0.0,0.0,katherine am curtis,,POSC-1040,2014
+POSC,1990,001,Intro Pol Sci,0.44,0.27,0.14,0.04,0.09,0.0,0.0,0.02,meredith petersheim,,POSC-1990,2014
+POSC,3020,001,State and Loc Gov,0.13,0.6,0.17,0.0,0.07,0.0,0.0,0.03,bruce ransom,,POSC-3020,2014
+POSC,3110,001,Model United Nations,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,xiaobo hu,,POSC-3110,2014
+POSC,3120,001,State Student Leg,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michael cunningham,,POSC-3120,2014
+POSC,3410,001,Quant Meth in Pol Sc,0.31,0.31,0.08,0.15,0.15,0.0,0.0,0.0,steven vince miller,,POSC-3410,2014
+POSC,3610,001,Intl Pol in Crisis,0.21,0.46,0.1,0.02,0.19,0.0,0.0,0.02,steven vince miller,,POSC-3610,2014
+POSC,3620,001,Intl Organizations,0.27,0.38,0.15,0.08,0.04,0.0,0.0,0.08,lydia loui lundgren,,POSC-3620,2014
+POSC,3630,001,Us Foreign Policy,0.31,0.54,0.12,0.0,0.0,0.0,0.0,0.04,vladimir matic,,POSC-3630,2014
+POSC,3710,001,European Politics,0.34,0.56,0.09,0.0,0.0,0.0,0.0,0.0,vladimir matic,,POSC-3710,2014
+POSC,4030,001,United States Congre,0.22,0.36,0.2,0.13,0.07,0.0,0.0,0.02,jeffrey allen fine,,POSC-4030,2014
+POSC,4210,001,Public Policy,0.27,0.09,0.27,0.09,0.09,0.0,0.0,0.18,adam warber,,POSC-4210,2014
+POSC,4230,001,Urban Politics,0.1,0.7,0.1,0.0,0.0,0.0,0.0,0.1,bruce ransom,,POSC-4230,2014
+POSC,4360,001,Law Courts Politics,0.28,0.46,0.23,0.03,0.0,0.0,0.0,0.0,joseph earl stewart,,POSC-4360,2014
+POSC,4370,001,Constitut Law: Right,0.47,0.43,0.07,0.0,0.03,0.0,0.0,0.0,daniel frost,,POSC-4370,2014
+POSC,4380,001,Constitut Law: Struc,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,,POSC-4380,2014
+POSC,4420,001,Pol Parties & Elect,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,laura olson,,POSC-4420,2014
+POSC,4500,001,Classical & Modern L,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,brandon turner,,POSC-4500,2014
+POSC,4550,001,Pol Thght of America,0.24,0.55,0.19,0.02,0.0,0.0,0.0,0.0, bradley thompson,,POSC-4550,2014
+POSC,4560,001,Diplomacy,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,vladimir matic,,POSC-4560,2014
+POSC,4710,001,Russian Politics,0.5,0.32,0.05,0.05,0.05,0.0,0.0,0.05,aron geo tannenbaum,,POSC-4710,2014
+POSC,4760,001,Middle East Politics,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,vladimir matic,,POSC-4760,2014
+POSC,4890,002,WWII: Ideol. in Worl,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,james woodard,,POSC-4890,2014
+POSC,4890,003,International Law,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,katherine am curtis,,POSC-4890,2014
+PRTM,1950,002,Pro Golf Management,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-1950,2014
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,herbert chancellor,,PRTM-2260,2014
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,denise mar anderson,,PRTM-2260,2014
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,teresa walto tucker,,PRTM-2260,2014
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,francis mcguire,,PRTM-2260,2014
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,elizabeth baldwin,,PRTM-2260,2014
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,robert brookover,,PRTM-2260,2014
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,elizabeth baldwin,,PRTM-2270,2014
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,denise mar anderson,,PRTM-2270,2014
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,teresa walto tucker,,PRTM-2270,2014
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,robert brookover,,PRTM-2270,2014
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,francis mcguire,,PRTM-2270,2014
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,herbert chancellor,,PRTM-2270,2014
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,robert brookover,,PRTM-2290,2014
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,francis mcguire,,PRTM-2290,2014
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,denise mar anderson,,PRTM-2290,2014
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,elizabeth baldwin,,PRTM-2290,2014
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,teresa walto tucker,,PRTM-2290,2014
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,herbert chancellor,,PRTM-2290,2014
+PRTM,2950,001,Pro Golf Management,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-2950,2014
+PRTM,3070,002,Facility Operations,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,craig goodman,,PRTM-3070,2014
+PRTM,3200,001,Recreation Policy,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,bernard mwe kitheka,,PRTM-3200,2014
+PRTM,3220,001,Facilitation Techniq,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,,PRTM-3220,2014
+PRTM,3240,001,Assessment & Plannin,0.83,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3240,2014
+PRTM,3250,001,Global Persp in Rec,0.55,0.18,0.24,0.0,0.03,0.0,0.0,0.0,skye arthur-banning,,PRTM-3250,2014
+PRTM,3300,001,Visit Ser & Interp,0.36,0.43,0.14,0.07,0.0,0.0,0.0,0.0,robert bixler,,PRTM-3300,2014
+PRTM,3430,001,Spl Asp of Tourist B,0.35,0.6,0.05,0.0,0.0,0.0,0.0,0.0,william norman,,PRTM-3430,2014
+PRTM,3430,002,Spl Asp of Tourist B,0.4,0.45,0.08,0.05,0.03,0.0,0.0,0.0,william norman,,PRTM-3430,2014
+PRTM,3450,001,Tourism Management,0.43,0.32,0.17,0.05,0.03,0.0,0.0,0.0,lauren duffy,,PRTM-3450,2014
+PRTM,3530,002,Foundations of Camp,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,gwynn powell,,PRTM-3530,2014
+PRTM,3920,001,Special Event Manage,0.79,0.1,0.04,0.04,0.02,0.0,0.0,0.02,kenneth backman,,PRTM-3920,2014
+PRTM,3920,002,Special Event Manage,0.81,0.13,0.02,0.0,0.02,0.0,0.0,0.02,kenneth backman,,PRTM-3920,2014
+PRTM,3950,001,PGM Seminar III,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3950,2014
+PRTM,3950,001,PGM Seminar III,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-3950,2014
+PRTM,3980,003,Creative Inquiry in,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,kellie aman walters,,PRTM-3980,2014
+PRTM,3980,011,Creative Inquiry in,0.76,0.0,0.0,0.0,0.0,0.0,0.0,0.24,skye arthur-banning,,PRTM-3980,2014
+PRTM,4030,001,Elem of Rec/Pk Plan,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,robert baxte powell,,PRTM-4030,2014
+PRTM,4070,001,Pers Admin in PRTM,0.32,0.38,0.18,0.12,0.0,0.0,0.0,0.0,daniel mor anderson,,PRTM-4070,2014
+PRTM,4470,001,Perspect Intl Travel,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,lauren duffy,,PRTM-4470,2014
+PRTM,4550,001,Adv Program Planning,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-4550,2014
+PRTM,4830,001,Golf Club Mgt & Ops,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-4830,2014
+PRTM,4950,001,Pro Golf Management,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-4950,2014
+PRTM,4950,001,Pro Golf Management,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-4950,2014
+PRTM,4980,001,Creative Inquiry in,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,,PRTM-4980,2014
+PRTM,4980,007,Creative Inquiry in,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,denise mar anderson,,PRTM-4980,2014
+PRTM,4980,009,Creative Inquiry in,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,leslie conrad,,PRTM-4980,2014
+PRTM,4980,009,Creative Inquiry in,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-4980,2014
+PRTM,8010,002,Phil Found of PRTM,0.57,0.22,0.13,0.0,0.09,0.0,0.0,0.0,dorothy schmalz,,PRTM-8010,2014
+PRTM,8080,001,Behavioral Aspects,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-8080,2014
+PRTM,8220,002,Strateg Planning in,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,,PRTM-8220,2014
+PRTM,8560,001,Heritage Tourism,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,,PRTM-8560,2014
+PRTM,9000,004,The Politics of Scie,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,gary edward machlis,,PRTM-9000,2014
+PSYC,2010,001,Intro to Psychology,0.27,0.34,0.25,0.08,0.04,0.0,0.0,0.02,edwin brainerd,,PSYC-2010,2014
+PSYC,2010,002,Intro to Psychology,0.33,0.34,0.21,0.08,0.02,0.0,0.0,0.03,jo anne jorgensen,,PSYC-2010,2014
+PSYC,2010,003,Intro to Psychology,0.51,0.25,0.15,0.04,0.01,0.0,0.0,0.03,chong hyon pak,,PSYC-2010,2014
+PSYC,2010,004,Intro to Psychology,0.25,0.45,0.2,0.0,0.0,0.0,0.0,0.1,fred switzer,,PSYC-2010,2014
+PSYC,2010,005,Intro to Psychology,0.27,0.43,0.14,0.04,0.03,0.0,0.0,0.09,mary taylor,,PSYC-2010,2014
+PSYC,2010,006,Intro to Psychology,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,christopher pagano,True,PSYC-2010,2014
+PSYC,2010,104,Intro to Psychology,0.33,0.47,0.16,0.0,0.02,0.0,0.0,0.02,fred switzer,,PSYC-2010,2014
+PSYC,2020,001,Intro Psychology Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2014
+PSYC,2020,002,Intro Psychology Lab,0.76,0.06,0.0,0.06,0.12,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2014
+PSYC,2020,003,Intro Psychology Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2014
+PSYC,2020,004,Intro Psychology Lab,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,eric mckibben,,PSYC-2020,2014
+PSYC,2020,005,Intro Psychology Lab,0.79,0.13,0.04,0.04,0.0,0.0,0.0,0.0,lauren elizab ellis,,PSYC-2020,2014
+PSYC,2020,006,Intro Psychology Lab,0.81,0.1,0.05,0.05,0.0,0.0,0.0,0.0,hannah jeann murphy,,PSYC-2020,2014
+PSYC,3060,001,Human Sexual Beh,0.54,0.22,0.13,0.06,0.04,0.0,0.0,0.02,bruce michael king,,PSYC-3060,2014
+PSYC,3090,100,Intro Exp Psych,0.25,0.39,0.2,0.05,0.05,0.0,0.0,0.07,jennifer bai bisson,,PSYC-3090,2014
+PSYC,3090,200,Intro Exp Psych,0.33,0.42,0.09,0.08,0.03,0.0,0.0,0.05,patrick rosopa,,PSYC-3090,2014
+PSYC,3100,100,Advanced Experimenta,0.32,0.42,0.21,0.0,0.05,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3100,2014
+PSYC,3100,200,Advanced Experimenta,0.76,0.06,0.06,0.0,0.12,0.0,0.0,0.0,robert campbell,,PSYC-3100,2014
+PSYC,3100,300,Advanced Experimenta,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2014
+PSYC,3100,400,Advanced Experimenta,0.78,0.06,0.0,0.06,0.06,0.0,0.0,0.06,alice miche brawley,,PSYC-3100,2014
+PSYC,3100,500,Advanced Experimenta,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,allison lei wallace,,PSYC-3100,2014
+PSYC,3100,600,Advanced Experimenta,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2014
+PSYC,3240,001,Physiological Psych,0.33,0.34,0.14,0.07,0.07,0.0,0.0,0.04,claudio cantalupo,,PSYC-3240,2014
+PSYC,3240,002,Physiological Psych,0.25,0.41,0.16,0.1,0.07,0.0,0.0,0.0,june pilcher,,PSYC-3240,2014
+PSYC,3330,001,Cognitive Psych,0.64,0.2,0.09,0.06,0.0,0.0,0.0,0.01,paul steven merritt,,PSYC-3330,2014
+PSYC,3330,002,Cognitive Psych,0.72,0.13,0.12,0.01,0.0,0.0,0.0,0.01,paul steven merritt,,PSYC-3330,2014
+PSYC,3340,001,Cognitive Psych Lab,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,phillip weis jasper,,PSYC-3340,2014
+PSYC,3340,002,Cognitive Psych Lab,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,ashley ann sewall,,PSYC-3340,2014
+PSYC,3400,001,Lifespan Development,0.26,0.31,0.26,0.11,0.01,0.0,0.0,0.04,pamela alley,,PSYC-3400,2014
+PSYC,3520,001,Social Psychology,0.34,0.4,0.2,0.06,0.0,0.0,0.0,0.0,jo anne jorgensen,,PSYC-3520,2014
+PSYC,3520,002,Social Psychology,0.32,0.39,0.24,0.03,0.0,0.0,0.0,0.01,jo anne jorgensen,,PSYC-3520,2014
+PSYC,3520,003,Social Psychology (H,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True,PSYC-3520,2014
+PSYC,3640,001,Industrial Psych,0.56,0.31,0.09,0.01,0.03,0.0,0.0,0.0,eric mckibben,,PSYC-3640,2014
+PSYC,3680,001,Organizational Psych,0.38,0.38,0.14,0.07,0.03,0.0,0.0,0.0,thomas britt,,PSYC-3680,2014
+PSYC,3690,001,Leadership in Orgs,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.01,eric mckibben,,PSYC-3690,2014
+PSYC,3830,001,Abnormal Psychology,0.29,0.26,0.23,0.17,0.06,0.0,0.0,0.0,pamela alley,,PSYC-3830,2014
+PSYC,3830,002,Abnormal Psychology,0.42,0.39,0.14,0.06,0.0,0.0,0.0,0.0,pamela alley,,PSYC-3830,2014
+PSYC,3830,003,Abnormal Psychology,0.37,0.34,0.18,0.08,0.0,0.0,0.0,0.03,heidi marie zinzow,,PSYC-3830,2014
+PSYC,4080,001,Women and Psychology,0.5,0.25,0.17,0.04,0.0,0.0,0.0,0.04,robin mari kowalski,,PSYC-4080,2014
+PSYC,4150,001,Systems and Theories,0.38,0.22,0.09,0.19,0.06,0.0,0.0,0.06,edwin brainerd,,PSYC-4150,2014
+PSYC,4150,002,Systems and Theories,0.33,0.43,0.13,0.1,0.0,0.0,0.0,0.0,edwin brainerd,,PSYC-4150,2014
+PSYC,4220,001,Perception,0.19,0.15,0.22,0.33,0.07,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2014
+PSYC,4220,002,Perception,0.27,0.5,0.12,0.04,0.04,0.0,0.0,0.04,christopher pagano,,PSYC-4220,2014
+PSYC,4430,001,Infant & Child Dev,0.58,0.31,0.12,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-4430,2014
+PSYC,4430,002,Infant & Child Dev,0.44,0.33,0.15,0.0,0.0,0.0,0.0,0.07,sarah mae sanborn,,PSYC-4430,2014
+PSYC,4560,001,Psychophysiology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,eric muth,,PSYC-4560,2014
+PSYC,4710,001,Psych of Testing,0.85,0.08,0.0,0.0,0.04,0.0,0.0,0.04,larry alton pace,,PSYC-4710,2014
+PSYC,4800,001,Health Psychology,0.48,0.24,0.24,0.0,0.0,0.0,0.0,0.04,james mccubbin,,PSYC-4800,2014
+PSYC,4880,002,Psychotherapy,0.84,0.04,0.04,0.0,0.04,0.0,0.0,0.04,cynthia pury,,PSYC-4880,2014
+PSYC,4890,001,Psychology of Music,0.48,0.36,0.08,0.0,0.0,0.0,0.0,0.08,claudio cantalupo,,PSYC-4890,2014
+PSYC,4890,001,Psychology of Music,0.48,0.36,0.08,0.0,0.0,0.0,0.0,0.08,robert campbell,,PSYC-4890,2014
+PSYC,4890,002,Teamwork In 21st Cen,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,marissa leig porter,,PSYC-4890,2014
+PSYC,4920,001,Senior Laboratory,0.75,0.13,0.06,0.0,0.06,0.0,0.0,0.0,amelia jea kinsella,,PSYC-4920,2014
+PSYC,4920,002,Senior Laboratory,0.8,0.08,0.08,0.0,0.0,0.0,0.0,0.04,amelia jea kinsella,,PSYC-4920,2014
+PSYC,4920,003,Senior Laboratory,0.76,0.14,0.0,0.05,0.0,0.0,0.0,0.05,jessica anne stahl,,PSYC-4920,2014
+PSYC,4920,004,Senior Laboratory,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jessica anne stahl,,PSYC-4920,2014
+PSYC,4930,001,Pract Clinical Psych,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,,PSYC-4930,2014
+PSYC,8100,001,Research Design I,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0, dewayne moore,,PSYC-8100,2014
+PSYC,8220,001,Percept & Perform,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard tyrrell,,PSYC-8220,2014
+PSYC,8330,001,Adv Cog Psych,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,leo gugerty,,PSYC-8330,2014
+PSYC,8350,001,Adv Human Factors,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,leo gugerty,,PSYC-8350,2014
+PSYC,8680,001,Leadership in Orgs,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,patrick raymark,,PSYC-8680,2014
+PSYC,8730,001,SEM in App Psych,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0, dewayne moore,,PSYC-8730,2014
+PSYC,8990,003,Training & Dev,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,marissa leig porter,,PSYC-8990,2014
+RCID,8130,002,Special Topics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,,RCID-8130,2014
+RED,8000,001,Real Estate Dvlpment,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8000,2014
+RED,8160,001,Preservation Feasibi,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8160,2014
+REL,1010,001,Intro to Religion,0.18,0.35,0.12,0.06,0.12,0.0,0.0,0.18,peter cohen,,REL-1010,2014
+REL,1010,002,Intro to Religion,0.07,0.27,0.33,0.2,0.07,0.0,0.0,0.07,peter cohen,,REL-1010,2014
+REL,1010,004,Intro to Religion,0.09,0.33,0.24,0.18,0.09,0.0,0.0,0.06,peter cohen,,REL-1010,2014
+REL,1020,002,World Religions,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,robert stephens,,REL-1020,2014
+REL,1020,003,World Religions,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,robert stephens,,REL-1020,2014
+REL,1020,004,World Religions,0.5,0.29,0.18,0.04,0.0,0.0,0.0,0.0,robert stephens,,REL-1020,2014
+REL,1020,005,World Religions,0.58,0.27,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,,REL-1020,2014
+REL,3010,001,Old Testament,0.44,0.38,0.16,0.0,0.03,0.0,0.0,0.0,steven grosby,,REL-3010,2014
+REL,3020,001,New Testament Lit,0.39,0.52,0.06,0.03,0.0,0.0,0.0,0.0,benjamin white,,REL-3020,2014
+REL,3100,002,History of Religion,0.19,0.38,0.13,0.06,0.06,0.0,0.0,0.19,james brad jeffries,,REL-3100,2014
+REL,3120,001,Hinduism,0.71,0.14,0.04,0.0,0.0,0.0,0.0,0.11,robert stephens,,REL-3120,2014
+REL,3150,001,Islam,0.35,0.42,0.13,0.03,0.06,0.0,0.0,0.0,mashal saif,,REL-3150,2014
+REL,4010,001,Stud Biblical Litera,0.53,0.27,0.0,0.0,0.0,0.0,0.0,0.2,steven grosby,,REL-4010,2014
+RS,3010,001,Rural Sociology,0.26,0.44,0.26,0.0,0.0,0.0,0.0,0.04,kenneth robinson,,RS-3010,2014
+RUSS,1010,001,Elementary Russian,0.46,0.23,0.08,0.08,0.08,0.0,0.0,0.08,joan bridgwood,,RUSS-1010,2014
+SOC,2010,003,Introduction to Soci,0.37,0.29,0.24,0.05,0.03,0.0,0.0,0.01,stephani southworth,,SOC-2010,2014
+SOC,2010,004,Introduction to Soci,0.16,0.51,0.18,0.09,0.04,0.0,0.0,0.02,mary louise barr,,SOC-2010,2014
+SOC,2010,007,Introduction to Soci,0.37,0.41,0.13,0.04,0.02,0.0,0.0,0.02,stephani southworth,,SOC-2010,2014
+SOC,2010,009,Introduction to Soci,0.21,0.51,0.23,0.0,0.04,0.0,0.0,0.0,stephani southworth,,SOC-2010,2014
+SOC,2010,010,Introduction to Soci,0.47,0.43,0.08,0.02,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2014
+SOC,2010,011,Introduction to Soci,0.41,0.35,0.2,0.02,0.0,0.0,0.0,0.02,jennifer le holland,,SOC-2010,2014
+SOC,2010,012,Introduction to Soci,0.54,0.33,0.08,0.0,0.0,0.0,0.0,0.04,jennifer le holland,,SOC-2010,2014
+SOC,2010,013,Introduction to Soci,0.37,0.43,0.15,0.04,0.0,0.0,0.0,0.0,stephani southworth,,SOC-2010,2014
+SOC,2010,014,Introduction to Soci,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,,SOC-2010,2014
+SOC,2010,015,Introduction to Soci,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,,SOC-2010,2014
+SOC,2010,016,Introduction to Soci,0.52,0.45,0.02,0.0,0.0,0.0,0.0,0.01,jeffrey edwards,,SOC-2010,2014
+SOC,2010,018,Introduction to Soci,0.34,0.3,0.21,0.11,0.02,0.0,0.0,0.02,mary louise barr,,SOC-2010,2014
+SOC,2010,019,Introduction to Soci,0.39,0.5,0.08,0.03,0.0,0.0,0.0,0.0,mary louise barr,,SOC-2010,2014
+SOC,2010,020,Introduction to Soci,0.21,0.37,0.31,0.07,0.01,0.0,0.0,0.02,mary louise barr,,SOC-2010,2014
+SOC,2050,001,Sociology Lab,0.64,0.0,0.06,0.0,0.19,0.0,0.0,0.11,brenda vander mey,,SOC-2050,2014
+SOC,2050,002,Sociology Lab,0.71,0.0,0.0,0.06,0.18,0.0,0.0,0.06,brenda vander mey,,SOC-2050,2014
+SOC,3020,001,Research Methods I,0.17,0.42,0.25,0.14,0.0,0.0,0.0,0.03,andrew whitehead,,SOC-3020,2014
+SOC,3040,001,Research Methods II,0.3,0.33,0.13,0.2,0.03,0.0,0.0,0.0,ye luo,,SOC-3040,2014
+SOC,3600,001,Class & Poverty,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,william wentworth,,SOC-3600,2014
+SOC,3880,001,Criminal Justice,0.15,0.44,0.38,0.02,0.0,0.0,0.0,0.0,margaret tina britz,,SOC-3880,2014
+SOC,3890,001,Criminology,0.2,0.2,0.22,0.12,0.17,0.0,0.0,0.1,william white,,SOC-3890,2014
+SOC,3910,001,Soc of Deviance,0.15,0.39,0.26,0.09,0.04,0.0,0.0,0.07,william white,,SOC-3910,2014
+SOC,3920,001,Juvenile Delinquency,0.25,0.29,0.23,0.1,0.08,0.0,0.0,0.04,william white,,SOC-3920,2014
+SOC,3940,001,Soc Mental Illness,0.57,0.26,0.13,0.0,0.0,0.0,0.0,0.04,douglas sturkie,,SOC-3940,2014
+SOC,3970,001,Substance Abuse,0.63,0.24,0.08,0.0,0.0,0.0,0.0,0.04,jeffrey edwards,,SOC-3970,2014
+SOC,4030,001,"Technol, Environment",0.26,0.37,0.21,0.05,0.11,0.0,0.0,0.0, catherine mobley,,SOC-4030,2014
+SOC,4040,001,Soc Theory,0.35,0.32,0.18,0.06,0.06,0.0,0.0,0.03,william wentworth,,SOC-4040,2014
+SOC,4140,001,Policy&Social Change,0.34,0.59,0.07,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-4140,2014
+SOC,4320,001,Soc of Religion,0.43,0.24,0.16,0.12,0.04,0.0,0.0,0.0,andrew whitehead,,SOC-4320,2014
+SOC,4330,001,Global Social Change,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,william haller,,SOC-4330,2014
+SOC,4440,001,Sociology of Educ,0.18,0.43,0.14,0.11,0.0,0.0,0.0,0.14,stephani southworth,,SOC-4440,2014
+SOC,4600,001,Race & Ethnicity,0.52,0.24,0.24,0.0,0.0,0.0,0.0,0.0,brenda vander mey,,SOC-4600,2014
+SOC,4680,001,Criminal Evidence,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,margaret tina britz,,SOC-4680,2014
+SOC,4970,001,Senior Lab,0.44,0.12,0.36,0.0,0.08,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2014
+SOC,8030,001,Sur Dsgn App Res Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,,SOC-8030,2014
+SOC,8300,001,Human Systems Dev,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,ellen granberg,,SOC-8300,2014
+SPAN,1010,001,Elementary Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2014
+SPAN,1010,002,Elementary Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2014
+SPAN,1010,003,Elementary Spanish,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2014
+SPAN,1020,001,Elementary Spanish,0.17,0.44,0.17,0.0,0.0,0.0,0.0,0.22,roger simpson,,SPAN-1020,2014
+SPAN,1020,002,Elementary Spanish,0.22,0.44,0.11,0.11,0.06,0.0,0.0,0.06,roger simpson,,SPAN-1020,2014
+SPAN,1020,003,Elementary Spanish,0.44,0.39,0.11,0.06,0.0,0.0,0.0,0.0,roger simpson,,SPAN-1020,2014
+SPAN,1020,004,Elementary Spanish,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,roger simpson,,SPAN-1020,2014
+SPAN,1020,005,Elementary Spanish,0.21,0.37,0.21,0.05,0.05,0.0,0.0,0.11,roger simpson,,SPAN-1020,2014
+SPAN,1020,006,Elementary Spanish,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,cathy robison,,SPAN-1020,2014
+SPAN,1020,007,Elementary Spanish,0.4,0.33,0.2,0.0,0.0,0.0,0.0,0.07,cathy robison,,SPAN-1020,2014
+SPAN,1020,008,Elementary Spanish,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,ricardo tremolada,,SPAN-1020,2014
+SPAN,1020,009,Elementary Spanish,0.44,0.33,0.06,0.0,0.0,0.0,0.0,0.17,ricardo tremolada,,SPAN-1020,2014
+SPAN,1020,010,Elementary Spanish,0.35,0.41,0.24,0.0,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-1020,2014
+SPAN,1020,011,Elementary Spanish,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-1020,2014
+SPAN,1020,012,Elementary Spanish,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,allison ann hinds,,SPAN-1020,2014
+SPAN,1020,013,Elementary Spanish,0.61,0.0,0.28,0.06,0.06,0.0,0.0,0.0,allison ann hinds,,SPAN-1020,2014
+SPAN,1020,014,Elementary Spanish,0.41,0.29,0.06,0.06,0.0,0.0,0.0,0.18,allison ann hinds,,SPAN-1020,2014
+SPAN,1020,015,Elementary Spanish,0.44,0.19,0.06,0.19,0.0,0.0,0.0,0.13,ricardo tremolada,,SPAN-1020,2014
+SPAN,2010,001,Intermediate Spanish,0.26,0.26,0.32,0.11,0.0,0.0,0.0,0.05,cathy robison,,SPAN-2010,2014
+SPAN,2010,002,Intermediate Spanish,0.13,0.56,0.06,0.06,0.0,0.0,0.0,0.19,cathy robison,,SPAN-2010,2014
+SPAN,2010,003,Intermediate Spanish,0.33,0.28,0.33,0.0,0.0,0.0,0.0,0.06,maureen zamora,,SPAN-2010,2014
+SPAN,2010,004,Intermediate Spanish,0.37,0.26,0.16,0.0,0.05,0.0,0.0,0.16,ellory schmucker,,SPAN-2010,2014
+SPAN,2010,005,Intermediate Spanish,0.46,0.23,0.15,0.15,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2010,2014
+SPAN,2010,007,Intermediate Spanish,0.13,0.4,0.27,0.13,0.0,0.0,0.0,0.07,heidi montes,,SPAN-2010,2014
+SPAN,2010,008,Intermediate Spanish,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2010,2014
+SPAN,2010,009,Intermediate Spanish,0.35,0.41,0.18,0.0,0.06,0.0,0.0,0.0,ricardo tremolada,,SPAN-2010,2014
+SPAN,2010,010,Intermediate Spanish,0.39,0.28,0.11,0.22,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2014
+SPAN,2010,011,Intermediate Spanish,0.0,0.31,0.38,0.15,0.08,0.0,0.0,0.08,melva margu persico,,SPAN-2010,2014
+SPAN,2010,013,Intermediate Spanish,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,ze cruz valderramos,,SPAN-2010,2014
+SPAN,2010,014,Intermediate Spanish,0.33,0.5,0.06,0.0,0.06,0.0,0.0,0.06,maureen zamora,,SPAN-2010,2014
+SPAN,2010,015,Intermediate Spanish,0.37,0.42,0.05,0.0,0.05,0.0,0.0,0.11,ricardo tremolada,,SPAN-2010,2014
+SPAN,2010,016,Intermediate Spanish,0.28,0.56,0.17,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,,SPAN-2010,2014
+SPAN,2010,017,Intermediate Spanish,0.44,0.19,0.19,0.13,0.06,0.0,0.0,0.0,maureen zamora,,SPAN-2010,2014
+SPAN,2010,018,Intermediate Spanish,0.29,0.24,0.29,0.12,0.0,0.0,0.0,0.06,kari daus carson,,SPAN-2010,2014
+SPAN,2010,022,Intermediate Spanish,0.31,0.31,0.19,0.0,0.06,0.0,0.0,0.13,heidi montes,,SPAN-2010,2014
+SPAN,2010,023,Intermediate Spanish,0.07,0.5,0.21,0.07,0.0,0.0,0.0,0.14,maureen zamora,,SPAN-2010,2014
+SPAN,2010,024,Intermediate Spanish,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,allison ann hinds,,SPAN-2010,2014
+SPAN,2020,001,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2020,2014
+SPAN,2020,002,Intermediate Spanish,0.22,0.28,0.28,0.11,0.06,0.0,0.0,0.06,melva margu persico,,SPAN-2020,2014
+SPAN,2020,003,Intermediate Spanish,0.33,0.11,0.39,0.17,0.0,0.0,0.0,0.0,kari daus carson,,SPAN-2020,2014
+SPAN,2020,004,Intermediate Spanish,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2020,2014
+SPAN,2020,005,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2020,2014
+SPAN,2020,006,Intermediate Spanish,0.37,0.37,0.16,0.11,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2020,2014
+SPAN,2020,007,Intermediate Spanish,0.24,0.41,0.12,0.06,0.0,0.0,0.0,0.18,melva margu persico,,SPAN-2020,2014
+SPAN,2020,008,Intermediate Spanish,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-2020,2014
+SPAN,2020,009,Intermediate Spanish,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,ellory schmucker,,SPAN-2020,2014
+SPAN,2020,010,Intermediate Spanish,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2014
+SPAN,2020,011,Intermediate Spanish,0.32,0.42,0.11,0.11,0.0,0.0,0.0,0.05,kari daus carson,,SPAN-2020,2014
+SPAN,2020,012,Intermediate Spanish,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,juana martin-armas,,SPAN-2020,2014
+SPAN,2020,013,Intermediate Spanish,0.22,0.61,0.11,0.06,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2014
+SPAN,3020,001,Int Spn Gram & Comp,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,,SPAN-3020,2014
+SPAN,3050,002,Int Con Comp Span I,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,raquel anido,,SPAN-3050,2014
+SPAN,3050,003,Int Con Comp Span I,0.32,0.42,0.16,0.0,0.0,0.0,0.0,0.11,raquel anido,,SPAN-3050,2014
+SPAN,3080,001,Hispanic World: La,0.63,0.21,0.0,0.0,0.05,0.0,0.0,0.11,george palacios,,SPAN-3080,2014
+SPAN,3080,002,Hispanic World: La,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,tiffany dawn miller,,SPAN-3080,2014
+SPAN,3090,001,Intro to Span Phont,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,daniel smith,,SPAN-3090,2014
+SPAN,3110,001,Surv Span-Amer Lit,0.13,0.4,0.2,0.07,0.13,0.0,0.0,0.07,tiffany dawn miller,,SPAN-3110,2014
+SPAN,3130,001,Span Lit Survey I,0.2,0.4,0.13,0.0,0.0,0.0,0.0,0.27,mon rojas-de-massei,,SPAN-3130,2014
+SPAN,3130,002,Span Lit Survey I,0.27,0.4,0.2,0.07,0.0,0.0,0.0,0.07,mon rojas-de-massei,,SPAN-3130,2014
+SPAN,3140,001,Hispanic Linguistics,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,,SPAN-3140,2014
+SPAN,3180,001,Span Through Culture,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,george palacios,,SPAN-3180,2014
+SPAN,4030,001,Span Amer Wom Writer,0.3,0.4,0.1,0.0,0.2,0.0,0.0,0.0,tiffany dawn miller,,SPAN-4030,2014
+SPAN,4060,001,Narrative Fiction,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,mon rojas-de-massei,,SPAN-4060,2014
+SPAN,4060,002,Narrative Fiction,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,,SPAN-4060,2014
+SPAN,4070,001,Hispanic Film,0.5,0.31,0.06,0.06,0.0,0.0,0.0,0.06,raquel anido,,SPAN-4070,2014
+SPAN,4190,001,Health & Hisp Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-4190,2014
+STAT,2220,001,Statistics in Everyd,0.33,0.36,0.25,0.04,0.0,0.0,0.0,0.02,ros martinez-dawson,,STAT-2220,2014
+STAT,2220,002,Statistics in Everyd,0.36,0.28,0.23,0.08,0.02,0.0,0.0,0.04,james espey,,STAT-2220,2014
+STAT,2220,003,Statistics in Everyd,0.35,0.33,0.21,0.1,0.02,0.0,0.0,0.0,april thomas,,STAT-2220,2014
+STAT,2220,004,Statistics in Everyd,0.41,0.48,0.09,0.0,0.0,0.0,0.0,0.02,benjamin sharp,,STAT-2220,2014
+STAT,2220,005,Statistics in Everyd,0.37,0.29,0.31,0.02,0.02,0.0,0.0,0.0,james espey,,STAT-2220,2014
+STAT,2220,006,Statistics in Everyd,0.39,0.28,0.33,0.0,0.0,0.0,0.0,0.0,christopher wilson,,STAT-2220,2014
+STAT,2220,007,Statistics in Everyd,0.28,0.5,0.17,0.06,0.0,0.0,0.0,0.0,christopher wilson,,STAT-2220,2014
+STAT,2300,001,Statistical Methods,0.37,0.29,0.14,0.13,0.04,0.0,0.0,0.03,richard stev dubsky,,STAT-2300,2014
+STAT,2300,002,Statistical Methods,0.46,0.29,0.16,0.05,0.0,0.0,0.0,0.04,richard stev dubsky,,STAT-2300,2014
+STAT,2300,003,Statistical Methods,0.48,0.27,0.11,0.04,0.07,0.0,0.0,0.02,ros martinez-dawson,,STAT-2300,2014
+STAT,2300,004,Statistical Methods,0.38,0.32,0.13,0.08,0.09,0.0,0.0,0.01,christy jenki brown,,STAT-2300,2014
+STAT,2300,005,Statistical Methods,0.3,0.33,0.28,0.06,0.0,0.0,0.0,0.04,christy jenki brown,,STAT-2300,2014
+STAT,2300,006,Statistical Methods,0.35,0.29,0.24,0.05,0.03,0.0,0.0,0.03,jun luo,,STAT-2300,2014
+STAT,2300,008,Statistical Methods,0.46,0.35,0.12,0.03,0.02,0.0,0.0,0.02,richard stev dubsky,,STAT-2300,2014
+STAT,2300,009,Statistical Methods,0.42,0.31,0.14,0.07,0.01,0.0,0.0,0.04,christy jenki brown,,STAT-2300,2014
+STAT,3090,001,Introductory Busines,0.16,0.32,0.16,0.14,0.14,0.0,0.0,0.08,paul james cubre,,STAT-3090,2014
+STAT,3090,002,Introductory Busines,0.05,0.42,0.37,0.11,0.05,0.0,0.0,0.0,emily marie nystrom,,STAT-3090,2014
+STAT,3090,003,Introductory Busines,0.11,0.22,0.44,0.0,0.17,0.0,0.0,0.06,ziwen cheng,,STAT-3090,2014
+STAT,3090,004,Introductory Busines,0.48,0.32,0.14,0.05,0.02,0.0,0.0,0.0,lucas waddell,,STAT-3090,2014
+STAT,3090,005,Introductory Busines,0.33,0.26,0.33,0.0,0.05,0.0,0.0,0.05,gary fellers,,STAT-3090,2014
+STAT,3090,006,Introductory Busines,0.21,0.32,0.26,0.11,0.11,0.0,0.0,0.0,emily marie nystrom,,STAT-3090,2014
+STAT,3090,007,Introductory Busines,0.16,0.53,0.16,0.11,0.0,0.0,0.0,0.05,janie caro mcdonald,,STAT-3090,2014
+STAT,3090,008,Introductory Busines,0.3,0.32,0.25,0.05,0.07,0.0,0.0,0.02,gary fellers,,STAT-3090,2014
+STAT,3090,009,Introductory Busines,0.22,0.39,0.11,0.11,0.06,0.0,0.0,0.11,hewa priyadarshani,,STAT-3090,2014
+STAT,3090,010,Introductory Busines,0.32,0.43,0.11,0.05,0.07,0.0,0.0,0.02,gary fellers,,STAT-3090,2014
+STAT,3090,011,Introductory Busines,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,janie caro mcdonald,,STAT-3090,2014
+STAT,3090,012,Introductory Busines,0.2,0.6,0.14,0.03,0.03,0.0,0.0,0.0,margaret mar wiecek,,STAT-3090,2014
+STAT,3090,013,Introductory Busines,0.27,0.36,0.24,0.04,0.07,0.0,0.0,0.02,gary fellers,,STAT-3090,2014
+STAT,3090,014,Introductory Busines,0.15,0.46,0.23,0.0,0.15,0.0,0.0,0.0,ziwen cheng,,STAT-3090,2014
+STAT,3090,015,Introductory Busines,0.16,0.42,0.11,0.26,0.05,0.0,0.0,0.0,tao yang,,STAT-3090,2014
+STAT,3090,016,Introductory Busines,0.26,0.32,0.11,0.11,0.05,0.0,0.0,0.16,tao yang,,STAT-3090,2014
+STAT,3090,017,Introductory Busines,0.22,0.39,0.22,0.11,0.06,0.0,0.0,0.0,hewa priyadarshani,,STAT-3090,2014
+STAT,3090,018,Introductory Busines,0.29,0.56,0.08,0.04,0.02,0.0,0.0,0.0,jennifer van dyken,,STAT-3090,2014
+STAT,3090,019,Introductory Busines,0.3,0.36,0.16,0.11,0.0,0.0,0.0,0.07,laura jane shick,,STAT-3090,2014
+STAT,3090,020,Introductory Busines,0.11,0.41,0.25,0.09,0.09,0.0,0.0,0.05,laura jane shick,,STAT-3090,2014
+STAT,4020,001,Intro to Statistical,0.56,0.22,0.17,0.06,0.0,0.0,0.0,0.0,julia lynn sharp,,STAT-4020,2014
+STAT,4110,001,Stat Mthds for Proce,0.39,0.39,0.17,0.06,0.0,0.0,0.0,0.0,james rieck,,STAT-4110,2014
+STAT,4110,002,Stat Mthds for Proce,0.19,0.29,0.26,0.13,0.13,0.0,0.0,0.0,patrick gerard,,STAT-4110,2014
+STAT,8010,001,Statistical Methods,0.48,0.43,0.04,0.0,0.0,0.0,0.0,0.04,william bridges,,STAT-8010,2014
+STAT,8010,003,Statistical Methods,0.39,0.29,0.16,0.0,0.13,0.0,0.0,0.03,james rieck,,STAT-8010,2014
+STAT,8010,004,Statistical Methods,0.31,0.26,0.31,0.0,0.06,0.0,0.0,0.06,julia lynn sharp,,STAT-8010,2014
+STAT,8020,001,Statistical Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,,STAT-8020,2014
+STAT,8020,001,Statistical Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-8020,2014
+STAT,8050,001,Design & Anlys of Ex,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-8050,2014
+STS,1010,001,Survey of S T S,0.46,0.41,0.05,0.0,0.03,0.0,0.0,0.05,elizabeth stansell,,STS-1010,2014
+STS,1010,002,Survey of S T S,0.36,0.39,0.22,0.03,0.0,0.0,0.0,0.0,thomas oberdan,,STS-1010,2014
+STS,1010,003,Survey of S T S,0.89,0.08,0.0,0.0,0.03,0.0,0.0,0.0,scott brame,,STS-1010,2014
+STS,1010,005,Survey of S T S,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,thomas oberdan,,STS-1010,2014
+STS,1010,006,Survey of S T S,0.44,0.28,0.14,0.03,0.06,0.0,0.0,0.06,sarah mae cooper,,STS-1010,2014
+STS,1010,007,Survey of S T S,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,annah kamugiz amani,,STS-1010,2014
+STS,1010,008,Survey of S T S,0.27,0.45,0.15,0.03,0.0,0.0,0.0,0.09,david charles foltz,,STS-1010,2014
+STS,1010,009,Survey of S T S,0.4,0.46,0.11,0.0,0.03,0.0,0.0,0.0,allison ann hinds,,STS-1010,2014
+STS,1010,010,Survey of S T S,0.57,0.21,0.14,0.0,0.07,0.0,0.0,0.0,thomas oberdan,,STS-1010,2014
+STS,1010,020,Survey of S T S,0.19,0.47,0.25,0.03,0.0,0.0,0.0,0.06,thomas oberdan,,STS-1010,2014
+STS,2150,001,Crit Appr to Tech Re,0.32,0.32,0.27,0.05,0.0,0.0,0.0,0.05,thomas oberdan,,STS-2150,2014
+THEA,2100,001,Theatre Appreciation,0.53,0.34,0.06,0.0,0.0,0.0,0.0,0.06,richard st. peter,,THEA-2100,2014
+THEA,2100,003,Theatre Appreciation,0.65,0.16,0.1,0.03,0.06,0.0,0.0,0.0,kendra lyne johnson,,THEA-2100,2014
+THEA,2100,004,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,,THEA-2100,2014
+THEA,2100,005,Theatre Appreciation,0.44,0.38,0.13,0.03,0.0,0.0,0.0,0.03,carol collins,,THEA-2100,2014
+THEA,2100,006,Theatre Appreciation,0.52,0.26,0.1,0.03,0.03,0.0,0.0,0.06,jason adkins,,THEA-2100,2014
+THEA,2780,001,Acting I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,,THEA-2780,2014
+THEA,3170,001,African-Amer Thea I,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,kendra lyne johnson,,THEA-3170,2014
+THEA,4720,001,Improvisation,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-4720,2014
+THEA,6870,001,Stage Lighting I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,,THEA-6870,2014
+WFB,3000,001,Wildlife Biology,0.36,0.43,0.11,0.07,0.02,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3000,2014
+WFB,3000,002,Wildlife Biology,0.4,0.35,0.16,0.04,0.05,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3000,2014
+WFB,3010,001,Wildlife Biology Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,,WFB-3010,2014
+WFB,3010,002,Wildlife Biology Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2014
+WFB,4100,001,Wildlife Mgmt Tech,0.62,0.31,0.04,0.0,0.04,0.0,0.0,0.0,james davis,,WFB-4100,2014
+WFB,4100,002,Wildlife Mgmt Tech,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,james davis,,WFB-4100,2014
+WFB,4120,002,Wildlife Management,0.4,0.4,0.13,0.04,0.0,0.0,0.0,0.02,greg yarrow,,WFB-4120,2014
+WFB,4120,002,Wildlife Management,0.4,0.4,0.13,0.04,0.0,0.0,0.0,0.02,david sco jachowski,,WFB-4120,2014
+WFB,4180,001,Fishery Conservation,0.59,0.23,0.14,0.0,0.0,0.0,0.0,0.05,yoichiro kanno,,WFB-4180,2014
+WFB,4500,001,Aquaculture,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,,WFB-4500,2014
+WFB,4600,001,Warmwat Fish Disease,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,,WFB-4600,2014
+WFB,8610,200,Analysis of Ecologic,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,russell barrett,,WFB-8610,2014
+WS,1030,001,Women Global Perspec,0.75,0.14,0.06,0.06,0.0,0.0,0.0,0.0,saadiqa kumanyika,,WS-1030,2014
+WS,2300,001,Women and Leadership,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,saadiqa kumanyika,,WS-2300,2014
+WS,3010,001,Intro Women's Studie,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2014
+WS,3010,002,Intro Women's Studie,0.47,0.34,0.03,0.13,0.0,0.0,0.0,0.03,elizabeth ros adams,,WS-3010,2014
+YDP,3000,400,Youth Development in,0.43,0.36,0.14,0.0,0.07,0.0,0.0,0.0,barry garst,,YDP-3000,2014

--- a/bot/cogs/grades_cog/assets/2014_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2014_Fall.csv
@@ -1,3047 +1,3047 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1010,001,Survey of Art & Arch,0.44,0.42,0.11,0.0,0.0,0.0,0.0,0.02,beth ann lauritis,AAH-1010,2014
-AAH,2050,001,Art History and Theo,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.04,beth ann lauritis,AAH-2050,2014
-AAH,2100,400,Intro to Art and Arc,0.23,0.42,0.12,0.12,0.08,0.0,0.0,0.04,lydia jane dorsey,AAH-2100,2014
-AAH,2100,401,Intro to Art and Arc,0.45,0.34,0.14,0.07,0.0,0.0,0.0,0.0,lydia jane dorsey,AAH-2100,2014
-AAH,2100,402,Intro to Art and Arc,0.28,0.4,0.16,0.08,0.0,0.0,0.0,0.08,lydia jane dorsey,AAH-2100,2014
-AAH,2100,403,Intro to Art and Arc,0.39,0.43,0.0,0.04,0.07,0.0,0.0,0.07,lydia jane dorsey,AAH-2100,2014
-AAH,3050,001,Contemporary Art His,0.6,0.2,0.13,0.0,0.0,0.0,0.0,0.07,andrea feeser,AAH-3050,2014
-ACCT,2010,001,Financial Accounting,0.04,0.22,0.3,0.02,0.15,0.0,0.0,0.26,philip maiberger,ACCT-2010,2014
-ACCT,2010,002,Financial Accounting,0.13,0.3,0.28,0.09,0.04,0.0,0.0,0.17,philip maiberger,ACCT-2010,2014
-ACCT,2010,003,Financial Accounting,0.19,0.22,0.22,0.08,0.1,0.0,0.0,0.18,suzanne pearse,ACCT-2010,2014
-ACCT,2010,004,Financial Accounting,0.3,0.3,0.2,0.05,0.07,0.0,0.0,0.09,suzanne pearse,ACCT-2010,2014
-ACCT,2010,005,Fin Acct Concepts (H,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,ACCT-2010,2014
-ACCT,2010,006,Financial Accounting,0.24,0.33,0.24,0.07,0.05,0.0,0.0,0.07,annieka philo,ACCT-2010,2014
-ACCT,2010,007,Financial Accounting,0.24,0.27,0.11,0.08,0.16,0.0,0.0,0.14,lydia lan schleifer,ACCT-2010,2014
-ACCT,2010,008,Financial Accounting,0.24,0.33,0.14,0.04,0.1,0.0,0.0,0.14,lydia lan schleifer,ACCT-2010,2014
-ACCT,2010,009,Financial Accounting,0.12,0.34,0.24,0.07,0.1,0.0,0.0,0.12,annieka philo,ACCT-2010,2014
-ACCT,2010,010,Financial Accounting,0.26,0.13,0.26,0.08,0.05,0.0,0.0,0.23,lydia lan schleifer,ACCT-2010,2014
-ACCT,2010,011,Financial Accounting,0.2,0.18,0.25,0.15,0.05,0.0,0.0,0.18,james mil kohlmeyer,ACCT-2010,2014
-ACCT,2010,012,Financial Accounting,0.27,0.24,0.27,0.12,0.02,0.0,0.0,0.07,james mil kohlmeyer,ACCT-2010,2014
-ACCT,2010,013,Financial Accounting,0.19,0.43,0.16,0.1,0.03,0.0,0.0,0.09,the estate  guffey,ACCT-2010,2014
-ACCT,2010,014,Financial Accounting,0.09,0.31,0.2,0.13,0.09,0.0,0.0,0.19,jeffrey mcmillan,ACCT-2010,2014
-ACCT,2010,015,Financial Accounting,0.03,0.28,0.23,0.15,0.17,0.0,0.0,0.13,james mil kohlmeyer,ACCT-2010,2014
-ACCT,2020,001,Managerial Accountin,0.18,0.31,0.2,0.06,0.08,0.0,0.0,0.18,henry anderson,ACCT-2020,2014
-ACCT,2020,002,Managerial Accountin,0.23,0.28,0.19,0.04,0.09,0.0,0.0,0.17,henry anderson,ACCT-2020,2014
-ACCT,2020,003,Managerial Accountin,0.17,0.37,0.25,0.1,0.06,0.0,0.0,0.06,annieka philo,ACCT-2020,2014
-ACCT,2020,004,Managerial Accountin,0.24,0.27,0.25,0.12,0.08,0.0,0.0,0.04,annieka philo,ACCT-2020,2014
-ACCT,2020,006,Managerial Accountin,0.57,0.22,0.14,0.0,0.02,0.0,0.0,0.06,sarah martin,ACCT-2020,2014
-ACCT,2020,007,Managerial Accountin,0.14,0.21,0.31,0.03,0.12,0.0,0.0,0.21,henry anderson,ACCT-2020,2014
-ACCT,2020,008,Managerial Accountin,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,sarah martin,ACCT-2020,2014
-ACCT,2040,001,Accounting Procedure,0.53,0.25,0.08,0.02,0.02,0.0,0.0,0.11,jeffrey mcmillan,ACCT-2040,2014
-ACCT,2040,002,Accounting Procedure,0.37,0.25,0.14,0.02,0.03,0.0,0.0,0.19,jeffrey mcmillan,ACCT-2040,2014
-ACCT,3030,001,Cost Accounting,0.31,0.24,0.28,0.0,0.03,0.0,0.0,0.14,henry anderson,ACCT-3030,2014
-ACCT,3030,002,Cost Accounting,0.22,0.35,0.22,0.05,0.11,0.0,0.0,0.05,henry anderson,ACCT-3030,2014
-ACCT,3030,003,Cost Accounting,0.38,0.28,0.23,0.0,0.05,0.0,0.0,0.05,robin radtke,ACCT-3030,2014
-ACCT,3030,005,Cost Accounting,0.28,0.35,0.13,0.03,0.1,0.0,0.0,0.13,robin radtke,ACCT-3030,2014
-ACCT,3110,001,Intermed Financial A,0.5,0.31,0.13,0.06,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3110,2014
-ACCT,3110,002,Intermed Financial A,0.51,0.36,0.05,0.03,0.03,0.0,0.0,0.03,terry daniel knause,ACCT-3110,2014
-ACCT,3110,003,Intermed Financial A,0.38,0.23,0.28,0.05,0.0,0.0,0.0,0.05,terry daniel knause,ACCT-3110,2014
-ACCT,3110,005,Intermed Financial A,0.35,0.32,0.19,0.05,0.0,0.0,0.0,0.08,terry daniel knause,ACCT-3110,2014
-ACCT,3120,001,Intermed Financial A,0.03,0.18,0.41,0.21,0.09,0.0,0.0,0.09,brian todd carver,ACCT-3120,2014
-ACCT,3120,002,Intermed Financial A,0.17,0.3,0.26,0.09,0.07,0.0,0.0,0.11,suzanne pearse,ACCT-3120,2014
-ACCT,3120,003,Intermed Financial A,0.05,0.18,0.37,0.18,0.08,0.0,0.0,0.13,brian todd carver,ACCT-3120,2014
-ACCT,3120,004,Intermed Financial A,0.09,0.31,0.36,0.16,0.02,0.0,0.0,0.07,suzanne pearse,ACCT-3120,2014
-ACCT,3130,001,Intermed Financial A,0.17,0.42,0.42,0.0,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2014
-ACCT,3130,002,Intermed Financial A,0.19,0.47,0.22,0.06,0.0,0.0,0.0,0.06, russell madray,ACCT-3130,2014
-ACCT,3130,003,Intermed Financial A,0.21,0.47,0.24,0.0,0.05,0.0,0.0,0.03, russell madray,ACCT-3130,2014
-ACCT,3130,005,Intermed Financial A,0.18,0.24,0.42,0.05,0.05,0.0,0.0,0.05, russell madray,ACCT-3130,2014
-ACCT,3220,001,Accounting Informati,0.21,0.26,0.31,0.08,0.05,0.0,0.0,0.1,philip maiberger,ACCT-3220,2014
-ACCT,3220,002,Accounting Informati,0.15,0.41,0.08,0.13,0.08,0.0,0.0,0.15,philip maiberger,ACCT-3220,2014
-ACCT,3220,003,Accounting Informati,0.2,0.55,0.15,0.0,0.05,0.0,0.0,0.05,nancy lee harp,ACCT-3220,2014
-ACCT,4040,002,Individual Taxation,0.36,0.36,0.24,0.02,0.0,0.0,0.0,0.02,derek dalton,ACCT-4040,2014
-ACCT,4040,003,Individual Taxation,0.1,0.44,0.28,0.03,0.05,0.0,0.0,0.1,derek dalton,ACCT-4040,2014
-ACCT,4080,001,Retire & Estate Plan,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,john hine,ACCT-4080,2014
-ACCT,4100,001,Reporting and Mgmt C,0.34,0.42,0.18,0.03,0.0,0.0,0.0,0.03,sally kathr widener,ACCT-4100,2014
-ACCT,4100,002,Reporting and Mgmt C,0.57,0.3,0.04,0.04,0.04,0.0,0.0,0.0,sally kathr widener,ACCT-4100,2014
-ACCT,4150,001,Auditing,0.06,0.34,0.38,0.19,0.03,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2014
-ACCT,4150,002,Auditing,0.32,0.42,0.1,0.06,0.03,0.0,0.0,0.06,carl hollingsworth,ACCT-4150,2014
-ACCT,8510,001,Tax Research,0.25,0.59,0.16,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2014
-ACCT,8510,002,Tax Research,0.06,0.79,0.12,0.0,0.03,0.0,0.0,0.0,thomas dickens,ACCT-8510,2014
-ACCT,8530,001,Adv Acct Problems,0.52,0.36,0.09,0.0,0.0,0.0,0.0,0.03,ralph welton,ACCT-8530,2014
-ACCT,8530,002,Adv Acct Problems,0.48,0.42,0.03,0.0,0.06,0.0,0.0,0.0,ralph welton,ACCT-8530,2014
-ACCT,8550,001,Gov't and Nonprofit,0.59,0.35,0.03,0.0,0.03,0.0,0.0,0.0,james barnes,ACCT-8550,2014
-ACCT,8550,002,Gov't and Nonprofit,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2014
-ACCT,8630,001,Forensics Analysis,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,james irving,ACCT-8630,2014
-ACCT,8630,002,Forensics Analysis,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,james irving,ACCT-8630,2014
-ACCT,8630,003,Forensics Analysis,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,james irving,ACCT-8630,2014
-ACCT,8730,001,Intl/Spec Tax Topic,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,judson jahn,ACCT-8730,2014
-ACCT,8730,002,Intl/Spec Tax Topic,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,judson jahn,ACCT-8730,2014
-AGED,1020,001,Freshman Seminar,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,christina mel leard,AGED-1020,2014
-AGED,2010,001,Intro to Agric Educ,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2010,2014
-AGED,2040,001,App Ag Calculations,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2040,2014
-AGED,3030,001,Ag Ed Mech Tech,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-3030,2014
-AGED,3650,001,Multiculturalism in,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,alex byrd,AGED-3650,2014
-AGED,4010,001,Instr Methods Ag Ed,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,thomas dobbins,AGED-4010,2014
-AGED,4010,001,Instr Methods Ag Ed,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,AGED-4010,2014
-AGED,4030,001,Prin Adult/Ext Ed,0.55,0.1,0.2,0.0,0.05,0.0,0.0,0.1,freddie waltz,AGED-4030,2014
-AGED,4230,400,Curriculum,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,AGED-4230,2014
-AGED,6010,001,Instr Methods Ag Ed,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,kevin layfield,AGED-6010,2014
-AGED,6010,001,Instr Methods Ag Ed,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,thomas dobbins,AGED-6010,2014
-AGM,1010,001,Intro Ag Mech & Bus,0.64,0.25,0.07,0.02,0.02,0.0,0.0,0.0,hunter massey,AGM-1010,2014
-AGM,2050,001,Prin of Fabrication,0.15,0.52,0.28,0.01,0.01,0.0,0.0,0.01,hunter massey,AGM-2050,2014
-AGM,2060,001,Machinery Mgt,0.15,0.4,0.3,0.15,0.0,0.0,0.0,0.0,hunter massey,AGM-2060,2014
-AGM,2190,001,Agribuxiness and Foo,0.24,0.45,0.29,0.02,0.0,0.0,0.0,0.0,wilder ferreira,AGM-2190,2014
-AGM,2210,001,Land Measurements,0.44,0.4,0.12,0.01,0.03,0.0,0.0,0.0,charles privette,AGM-2210,2014
-AGM,3010,001,Soil Water Conserv,0.29,0.41,0.14,0.1,0.06,0.0,0.0,0.0,calvin sawyer,AGM-3010,2014
-AGM,3190,001,Agribusiness Decisio,0.38,0.28,0.22,0.13,0.0,0.0,0.0,0.0,wilder ferreira,AGM-3190,2014
-AGM,4050,001,Env Cont in Anim Str,0.38,0.56,0.05,0.0,0.0,0.0,0.0,0.0,john chastain,AGM-4050,2014
-AGM,4060,001,Mech & Hydraulic Sys,0.42,0.45,0.12,0.0,0.0,0.0,0.0,0.0,young han,AGM-4060,2014
-AGM,4600,001,Electrical Systems,0.42,0.52,0.06,0.0,0.0,0.0,0.0,0.0,young han,AGM-4600,2014
-AL,3490,400,Principles of Coachi,0.36,0.4,0.12,0.04,0.0,0.0,0.0,0.08,deborah cadorette,AL-3490,2014
-AL,3490,401,Principles of Coachi,0.52,0.33,0.15,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2014
-AL,3490,402,Principles of Coachi,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,AL-3490,2014
-AL,3490,403,Principles of Coachi,0.41,0.35,0.0,0.18,0.06,0.0,0.0,0.0,clyde keith connor,AL-3490,2014
-AL,3500,400,Sci Basis I/Ex Phy,0.22,0.44,0.26,0.04,0.04,0.0,0.0,0.0,michael godfrey,AL-3500,2014
-AL,3500,401,Sci Basis I/Ex Phy,0.28,0.12,0.16,0.32,0.08,0.0,0.0,0.04,michael godfrey,AL-3500,2014
-AL,3520,400,Kinesiology,0.29,0.21,0.21,0.14,0.14,0.0,0.0,0.0,michael godfrey,AL-3520,2014
-AL,3530,400,Athletic Injuries,0.16,0.47,0.21,0.11,0.05,0.0,0.0,0.0,isaac sean colbert,AL-3530,2014
-AL,3530,401,Athletic Injuries,0.15,0.25,0.15,0.35,0.1,0.0,0.0,0.0,isaac sean colbert,AL-3530,2014
-AL,3600,400,Hgh Sch Athl Ethical,0.43,0.25,0.18,0.07,0.04,0.0,0.0,0.04,clyde keith connor,AL-3600,2014
-AL,3610,400,Admin/Org of Athleti,0.73,0.19,0.04,0.0,0.04,0.0,0.0,0.0,henry oates,AL-3610,2014
-AL,3610,401,Admin/Org of Athleti,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2014
-AL,3610,402,Admin/Org of Athleti,0.8,0.12,0.0,0.0,0.04,0.0,0.0,0.04,henry oates,AL-3610,2014
-AL,3620,400,Psychology of Coachi,0.28,0.28,0.24,0.12,0.04,0.0,0.0,0.04,natalie anne carter,AL-3620,2014
-AL,3620,401,Psychology of Coachi,0.24,0.2,0.44,0.12,0.0,0.0,0.0,0.0,natalie anne carter,AL-3620,2014
-AL,3740,400,Coaching Football,0.67,0.07,0.0,0.19,0.0,0.0,0.0,0.07,edmond fry,AL-3740,2014
-AL,3760,400,Coaching Strength/Co,0.79,0.08,0.04,0.08,0.0,0.0,0.0,0.0,edmond fry,AL-3760,2014
-AL,3760,401,Coaching Strength/Co,0.42,0.21,0.05,0.16,0.05,0.0,0.0,0.11,edmond fry,AL-3760,2014
-AL,4380,400,Coach & Athlete in E,0.5,0.14,0.29,0.07,0.0,0.0,0.0,0.0,deborah cadorette,AL-4380,2014
-AL,8490,400,Athletic Leadership,0.52,0.35,0.04,0.0,0.04,0.0,0.0,0.04,michael godfrey,AL-8490,2014
-ANTH,2010,001,Intro Anthropology,0.07,0.17,0.32,0.19,0.08,0.0,0.0,0.18,john coggeshall,ANTH-2010,2014
-ANTH,2010,001,Introduction to Anth,0.07,0.17,0.32,0.19,0.08,0.0,0.0,0.18,john coggeshall,ANTH-2010,2014
-ANTH,2010,002,Intro Anthropology,0.15,0.21,0.29,0.21,0.08,0.0,0.0,0.06,john coggeshall,ANTH-2010,2014
-ANTH,2010,002,Introduction to Anth,0.15,0.21,0.29,0.21,0.08,0.0,0.0,0.06,john coggeshall,ANTH-2010,2014
-ANTH,2010,003,Introduction to Anth,0.24,0.59,0.08,0.04,0.02,0.0,0.0,0.02,katherine weisensee,ANTH-2010,2014
-ANTH,2010,003,Intro Anthropology,0.24,0.59,0.08,0.04,0.02,0.0,0.0,0.02,katherine weisensee,ANTH-2010,2014
-ANTH,2010,004,Introduction to Anth,0.17,0.44,0.18,0.07,0.0,0.0,0.0,0.15,melissa vogel,ANTH-2010,2014
-ANTH,2010,004,Intro Anthropology,0.17,0.44,0.18,0.07,0.0,0.0,0.0,0.15,melissa vogel,ANTH-2010,2014
-ANTH,2010,005,Introduction to Anth,0.29,0.4,0.18,0.0,0.04,0.0,0.0,0.09,lisa rapaport,ANTH-2010,2014
-ANTH,2010,005,Intro Anthropology,0.29,0.4,0.18,0.0,0.04,0.0,0.0,0.09,lisa rapaport,ANTH-2010,2014
-ANTH,3010,001,Cultural Anthropolog,0.18,0.35,0.24,0.06,0.06,0.0,0.0,0.12,john coggeshall,ANTH-3010,2014
-ANTH,3320,001,World Archaeology,0.21,0.32,0.21,0.16,0.05,0.0,0.0,0.05,melissa vogel,ANTH-3320,2014
-ANTH,3510,001,Biological Anthropol,0.2,0.53,0.13,0.0,0.0,0.0,0.0,0.13,lisa rapaport,ANTH-3510,2014
-ANTH,3530,001,Forensic Anthropolog,0.3,0.57,0.09,0.04,0.0,0.0,0.0,0.0,katherine weisensee,ANTH-3530,2014
-ANTH,4660,001,Evolution of Human B,0.4,0.3,0.1,0.0,0.0,0.0,0.0,0.2,lisa rapaport,ANTH-4660,2014
-ANTH,4960,003,Creative Inquiry,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,sharon nagy,ANTH-4960,2014
-APEC,2020,001,Agric Economics,0.28,0.3,0.33,0.03,0.04,0.0,0.0,0.01,webb smathers,APEC-2020,2014
-APEC,2020,002,Agric Economics,0.14,0.28,0.28,0.17,0.0,0.0,0.0,0.14,david brian willis,APEC-2020,2014
-APEC,2050,001,Agric and Society,0.3,0.47,0.23,0.0,0.0,0.0,0.0,0.0,michael vassalos,APEC-2050,2014
-APEC,2570,001,Nat Res Env Econ,0.15,0.27,0.3,0.12,0.05,0.0,0.0,0.12,david brian willis,APEC-2570,2014
-APEC,3020,001,Econ of Farm Mgt,0.31,0.37,0.31,0.0,0.0,0.0,0.0,0.0,michael vassalos,APEC-3020,2014
-APEC,3090,001,Econ Agric Marketing,0.73,0.09,0.16,0.0,0.0,0.0,0.0,0.02,yuliya val bolotova,APEC-3090,2014
-APEC,3510,001,Prin of Advertising,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,webb smathers,APEC-3510,2014
-APEC,3610,001,Int Health Care Econ,0.47,0.41,0.06,0.06,0.0,0.0,0.0,0.0,khoa dang truong,APEC-3610,2014
-APEC,4900,002,CAFLS Plus Prof. Dev,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,thomas scott,APEC-4900,2014
-ARAB,1010,001,Elementary Arabic I,0.59,0.18,0.0,0.0,0.0,0.0,0.0,0.24,sulafa abou-samra,ARAB-1010,2014
-ARCH,1010,001,Intro to Arch,0.56,0.36,0.03,0.0,0.01,0.0,0.0,0.05,sal hambright-belue,ARCH-1010,2014
-ARCH,2040,001,Hist of Modern Arch,0.38,0.25,0.35,0.03,0.0,0.0,0.0,0.0,robert bruhns,ARCH-2040,2014
-ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-2510,2014
-ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,marianne her glaser,ARCH-2510,2014
-ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-2510,2014
-ARCH,2510,002,Arch Foundations I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-2510,2014
-ARCH,2510,002,Arch Foundations I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,marianne her glaser,ARCH-2510,2014
-ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2510,2014
-ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2510,2014
-ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,marianne her glaser,ARCH-2510,2014
-ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,marianne her glaser,ARCH-2510,2014
-ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,annemarie jacques,ARCH-2510,2014
-ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,annemarie jacques,ARCH-2510,2014
-ARCH,2700,001,Structures I,0.42,0.33,0.08,0.08,0.08,0.0,0.0,0.0,dustin gra albright,ARCH-2700,2014
-ARCH,3510,001,Studio Clemson,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,robert john hogan,ARCH-3510,2014
-ARCH,3510,002,Studio Clemson,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-3510,2014
-ARCH,3510,002,Studio Clemson,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,robert john hogan,ARCH-3510,2014
-ARCH,3510,003,Studio Clemson,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,robert john hogan,ARCH-3510,2014
-ARCH,3510,003,Studio Clemson,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,criss mills,ARCH-3510,2014
-ARCH,3530,001,Studio Genoa,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-3530,2014
-ARCH,3540,001,Studio Barcelona,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-3540,2014
-ARCH,3540,001,Studio Barcelona,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-3540,2014
-ARCH,4010,001,Arch Portfolio,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,martha skinner,ARCH-4010,2014
-ARCH,4010,002,Arch Portfolio,0.33,0.29,0.29,0.05,0.0,0.0,0.0,0.05,arash soleimani,ARCH-4010,2014
-ARCH,4120,001,History Research,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-4120,2014
-ARCH,4120,002,History Research,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4120,2014
-ARCH,4120,002,History Research,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-4120,2014
-ARCH,4140,001,Design Seminar,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-4140,2014
-ARCH,4160,002,Field Studies,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4160,2014
-ARCH,4160,002,Field Studies,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-4160,2014
-ARCH,6290,002,Arch Graphics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lloyd bray,ARCH-6290,2014
-ARCH,6850,001,H/Th: Arch+Health,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-6850,2014
-ARCH,8210,001,Research Methods,0.63,0.35,0.0,0.0,0.0,0.0,0.0,0.03,dina battisto,ARCH-8210,2014
-ARCH,8410,001,Arch Studio I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,ARCH-8410,2014
-ARCH,8410,002,Arch Studio I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,junichi satoh,ARCH-8410,2014
-ARCH,8510,001,Design Studio III,0.09,0.82,0.0,0.0,0.0,0.0,0.0,0.09,ulrike ann-so heine,ARCH-8510,2014
-ARCH,8510,001,Design Studio III,0.09,0.82,0.0,0.0,0.0,0.0,0.0,0.09,dustin gra albright,ARCH-8510,2014
-ARCH,8510,002,Design Studio III,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,ARCH-8510,2014
-ARCH,8510,003,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,ARCH-8510,2014
-ARCH,8510,003,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8510,2014
-ARCH,8510,004,Design Studio III,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,dustin gra albright,ARCH-8510,2014
-ARCH,8510,004,Design Studio III,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-8510,2014
-ARCH,8600,001,History/Theory I,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,ufuk ersoy,ARCH-8600,2014
-ARCH,8720,001,Production & Assemb,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,daniel nevi harding,ARCH-8720,2014
-ARCH,8720,001,Production & Assemb,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02, franco santa cruz,ARCH-8720,2014
-ARCH,8790,002,Digtial Manufacturin,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,ARCH-8790,2014
-ARCH,8810,001,Pro Practice Survey,0.64,0.33,0.0,0.0,0.0,0.0,0.0,0.03,katherin schwennsen,ARCH-8810,2014
-ARCH,8890,001,Mentorship,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,ARCH-8890,2014
-ARCH,8950,001,A+H Studio: Projects,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-8950,2014
-ARCH,8950,001,A+H Studio: Projects,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8950,2014
-ART,1050,001,Foundation Drawing I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,ART-1050,2014
-ART,1510,001,Foundations Art I,0.8,0.07,0.07,0.07,0.0,0.0,0.0,0.0,alexandra giannell,ART-1510,2014
-ART,2070,001,Beginning Painting,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,hilary erin siber,ART-2070,2014
-ART,2110,001,Begin Printmaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,laken grace bridges,ART-2110,2014
-ART,2130,001,Begin Photography,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,anderson wrangle,ART-2130,2014
-ART,2170,001,Beginning Ceramics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,nina jeanette kawar,ART-2170,2014
-ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,ART-3550,2014
-ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,ART-3550,2014
-ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,david detrich,ART-3550,2014
-ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david detrich,ART-4550,2014
-ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,ART-4550,2014
-ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,ART-4550,2014
-ART,8210,001,Visual Narrative,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,ART-8210,2014
-AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,christopher mann,AS-1090,2014
-AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,stacey dean wiggins,AS-1090,2014
-AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,steven price jordan,AS-1090,2014
-AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,steven price jordan,AS-1090,2014
-AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher mann,AS-1090,2014
-AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,stacey dean wiggins,AS-1090,2014
-AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,stacey dean wiggins,AS-1090,2014
-AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,christopher mann,AS-1090,2014
-AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,steven price jordan,AS-1090,2014
-AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,AS-1090,2014
-AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,AS-1090,2014
-AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steven price jordan,AS-1090,2014
-AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,steven price jordan,AS-2090,2014
-AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,christopher mann,AS-2090,2014
-AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,AS-2090,2014
-AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,AS-2090,2014
-AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,steven price jordan,AS-2090,2014
-AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,AS-2090,2014
-ASL,1010,003,Am Sign Lang I,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,joseph paul may,ASL-1010,2014
-ASL,2010,001,Am Sign Lang II,0.28,0.44,0.28,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-2010,2014
-ASL,2010,002,Am Sign Lang II,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-2010,2014
-ASL,2020,001,Am Sign Lang II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-2020,2014
-ASL,3000,001,Fingerspelling & Num,0.23,0.46,0.23,0.08,0.0,0.0,0.0,0.0,joseph paul may,ASL-3000,2014
-ASTR,1010,001,SolarSystem Astr,0.42,0.36,0.17,0.0,0.01,0.0,0.0,0.04,phillip flower,ASTR-1010,2014
-ASTR,1010,002,Solar System Astr,0.5,0.28,0.17,0.01,0.01,0.0,0.0,0.04,phillip flower,ASTR-1010,2014
-ASTR,1010,003,Solar System Astr,0.45,0.34,0.17,0.0,0.02,0.0,0.0,0.02,phillip flower,ASTR-1010,2014
-ASTR,1030,001,Solar Systm Astr Lab,0.67,0.17,0.0,0.04,0.04,0.0,0.0,0.08,mark leising,ASTR-1030,2014
-ASTR,1030,002,Solar Systm Astr Lab,0.28,0.52,0.08,0.0,0.04,0.0,0.0,0.08,mark leising,ASTR-1030,2014
-ASTR,1030,003,Solar Systm Astr Lab,0.57,0.26,0.09,0.0,0.0,0.0,0.0,0.09,mark leising,ASTR-1030,2014
-ASTR,1030,004,Solar Systm Astr Lab,0.62,0.27,0.04,0.0,0.08,0.0,0.0,0.0,mark leising,ASTR-1030,2014
-ASTR,1030,005,Solar Systm Astr Lab,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,ASTR-1030,2014
-ASTR,1030,006,Solar Systm Astr Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,ASTR-1030,2014
-ASTR,1030,007,Solar Systm Astr Lab,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,mark leising,ASTR-1030,2014
-ASTR,1030,008,Solar Systm Astr Lab,0.48,0.28,0.04,0.0,0.16,0.0,0.0,0.04,mark leising,ASTR-1030,2014
-ASTR,1030,009,Solar Systm Astr Lab,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,mark leising,ASTR-1030,2014
-AUD,1850,001,Intro to Audio Tech,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-1850,2014
-AUD,2800,001,Sound Reinforcement,0.2,0.27,0.33,0.07,0.07,0.0,0.0,0.07,kenneth moore,AUD-2800,2014
-AUD,3800,001,Audio Engineering I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-3800,2014
-AUE,8270,005,Auto Cntrl Sys Des,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,beshah ayalew,AUE-8270,2014
-AUE,8330,003,Auto Manuf Proc Devl,0.42,0.39,0.15,0.0,0.03,0.0,0.0,0.01,fadi kama abu-farha,AUE-8330,2014
-AUE,8350,100,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,john david smith,AUE-8350,2014
-AUE,8350,100,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,simona onori,AUE-8350,2014
-AUE,8670,001,Veh Manuf Proc I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8670,2014
-AUE,8800,002,Vehicle Project Mngt,0.81,0.18,0.0,0.0,0.0,0.0,0.0,0.01,imtiaz ul haque,AUE-8800,2014
-AUE,8810,003,Automotive Systems O,0.18,0.79,0.01,0.0,0.0,0.0,0.0,0.01,paul venhovens,AUE-8810,2014
-AUE,8810,003,Automotive Systems O,0.18,0.79,0.01,0.0,0.0,0.0,0.0,0.01,johnell brooks,AUE-8810,2014
-AUE,8830,009,Applied Integration,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,johnell brooks,AUE-8830,2014
-AUE,8830,009,Applied Integration,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,AUE-8830,2014
-AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,douglas feldmaier,AUE-8870,2014
-AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,michael messman,AUE-8870,2014
-AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,imtiaz ul haque,AUE-8870,2014
-AUE,8930,013,Engine Analysis,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8930,2014
-AUE,8930,014,Automotive Composite,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,david wil schmueser,AUE-8930,2014
-AUE,8930,014,Automotive Composite,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,srikanth pilla,AUE-8930,2014
-AUE,8930,017,Hybrid,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,simona onori,AUE-8930,2014
-AUE,8930,018,Adv IC Engine Concep,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,zoran filipi,AUE-8930,2014
-AUE,8930,019,Innov & Sys Entrepre,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,AUE-8930,2014
-AVS,1000,001,Orientation to Avs,0.84,0.14,0.01,0.0,0.0,0.0,0.0,0.02,johanna joh lascano,AVS-1000,2014
-AVS,1500,001,Intro Animal Science,0.18,0.41,0.3,0.03,0.03,0.0,0.0,0.05,heather walker dunn,AVS-1500,2014
-AVS,1500,002,Intro Animal Science,0.2,0.49,0.25,0.05,0.0,0.0,0.0,0.01,brian bolt,AVS-1500,2014
-AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,brian bolt,AVS-1510,2014
-AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,richelle lor miller,AVS-1510,2014
-AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,anna rebecca baxley,AVS-1510,2014
-AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,heather walker dunn,AVS-1510,2014
-AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,heather walker dunn,AVS-1510,2014
-AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,brian bolt,AVS-1510,2014
-AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,anna rebecca baxley,AVS-1510,2014
-AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,richelle lor miller,AVS-1510,2014
-AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-1510,2014
-AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,heather walker dunn,AVS-1510,2014
-AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,brian bolt,AVS-1510,2014
-AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,AVS-1510,2014
-AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-1510,2014
-AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,AVS-1510,2014
-AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,brian bolt,AVS-1510,2014
-AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,heather walker dunn,AVS-1510,2014
-AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-1510,2014
-AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,heather walker dunn,AVS-1510,2014
-AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,brian bolt,AVS-1510,2014
-AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,AVS-1510,2014
-AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,heather walker dunn,AVS-1510,2014
-AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,brian bolt,AVS-1510,2014
-AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,anna rebecca baxley,AVS-1510,2014
-AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,richelle lor miller,AVS-1510,2014
-AVS,2010,001,Poultry Techniques,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-2010,2014
-AVS,2030,001,Dairy Sci Techniques,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.02,heather walker dunn,AVS-2030,2014
-AVS,2040,001,Horse Care Technique,0.52,0.3,0.13,0.04,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-2040,2014
-AVS,2050,001,Horsemanship Techniq,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,meredith donaldson,AVS-2050,2014
-AVS,2050,001,Horsemanship Techniq,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,AVS-2050,2014
-AVS,2060,001,Swine Techniques,0.59,0.33,0.08,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-2060,2014
-AVS,2110,001,Meat Processing Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,brian bolt,AVS-2110,2014
-AVS,2110,001,Meat Processing Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-2110,2014
-AVS,3010,001,Anat & Phys Dom Ani,0.34,0.32,0.2,0.08,0.05,0.0,0.0,0.01,glenn birrenkott,AVS-3010,2014
-AVS,3010,400,Anat & Phys Dom Ani,0.27,0.45,0.23,0.0,0.05,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2014
-AVS,3020,001,Livestk Sel Eval I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-3020,2014
-AVS,3090,001,Equine Evaluation,0.49,0.37,0.05,0.07,0.0,0.0,0.0,0.02,kristine lan vernon,AVS-3090,2014
-AVS,3100,001,Animal Health,0.47,0.26,0.11,0.03,0.0,0.0,0.0,0.14,richard bruner,AVS-3100,2014
-AVS,3700,001,Prin Animal Nutr,0.24,0.25,0.16,0.24,0.1,0.0,0.0,0.02,nathan long,AVS-3700,2014
-AVS,4000,001,AVS Professional Dev,0.69,0.2,0.03,0.03,0.06,0.0,0.0,0.0,james ro strickland,AVS-4000,2014
-AVS,4000,001,AVS Professional Dev,0.69,0.2,0.03,0.03,0.06,0.0,0.0,0.0,johanna joh lascano,AVS-4000,2014
-AVS,4060,001,Seminars & Relat Top,0.79,0.18,0.0,0.04,0.0,0.0,0.0,0.0,johanna joh lascano,AVS-4060,2014
-AVS,4060,001,Seminars & Relat Top,0.79,0.18,0.0,0.04,0.0,0.0,0.0,0.0,james ro strickland,AVS-4060,2014
-AVS,4060,002,Seminars & Relat Top,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,james ro strickland,AVS-4060,2014
-AVS,4060,002,Seminars & Relat Top,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,AVS-4060,2014
-AVS,4150,001,Contemp Issues Avs,0.1,0.38,0.38,0.06,0.03,0.0,0.0,0.05,peter skewes,AVS-4150,2014
-AVS,4160,001,Equine Exercise Phys,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,kristine lan vernon,AVS-4160,2014
-AVS,4700,001,Anim Genetics,0.71,0.2,0.06,0.04,0.0,0.0,0.0,0.0,brian bolt,AVS-4700,2014
-AVS,8080,400,Monogastric Nutritio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,AVS-8080,2014
-AVS,8200,001,Graduate Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,AVS-8200,2014
-BCHM,1030,001,Careers in Bioch/Gen,0.87,0.1,0.04,0.0,0.0,0.0,0.0,0.0,alison starr-moss,BCHM-1030,2014
-BCHM,3050,001,Essen Elements Bioch,0.2,0.32,0.2,0.12,0.03,0.0,0.0,0.12,srik chandrasekaran,BCHM-3050,2014
-BCHM,3050,002,Essen Elements Bioch,0.26,0.32,0.22,0.11,0.04,0.0,0.0,0.04,srik chandrasekaran,BCHM-3050,2014
-BCHM,4060,001,Physiological Chem,0.53,0.26,0.13,0.02,0.02,0.0,0.0,0.04,ashby burges bodine,BCHM-4060,2014
-BCHM,4310,001,Phys App to Bioch,0.22,0.27,0.27,0.14,0.03,0.0,0.0,0.08,weiguo cao,BCHM-4310,2014
-BCHM,4310,002,Phys App to Bioch (H,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4310,2014
-BCHM,4330,001,Gen Bioch Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4330,2014
-BCHM,4330,002,Gen Bioch Lab I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4330,2014
-BCHM,4400,001,Bioinformatics,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,BCHM-4400,2014
-BCHM,4430,001,Mol Basis Disease,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,kerry smith,BCHM-4430,2014
-BCHM,4430,001,Mol Basis Disease,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james morris,BCHM-4430,2014
-BE,2120,001,Fundamentals of Bios,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-2120,2014
-BE,3200,001,Principles & Prac of,0.45,0.32,0.18,0.05,0.0,0.0,0.0,0.0,tom owino,BE-3200,2014
-BE,4100,001,Biological Kinetics,0.4,0.3,0.25,0.05,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4100,2014
-BE,4150,001,Instr & Control Be,0.27,0.41,0.23,0.05,0.05,0.0,0.0,0.0,yi zheng,BE-4150,2014
-BE,4280,001,Biochem Engr,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4280,2014
-BE,4740,001,B E Design/Proj Mgt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,BE-4740,2014
-BE,4750,001,B E Capstone Design,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4750,2014
-BE,4750,001,B E Capstone Design,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4750,2014
-BIOE,2010,001,Intro Biomed Engr,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,charles webb,BIOE-2010,2014
-BIOE,2010,001,Intro Biomed Engr,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,frank alexis,BIOE-2010,2014
-BIOE,2010,002,Intro Biomed Engr,0.59,0.34,0.03,0.0,0.02,0.0,0.0,0.02,charles webb,BIOE-2010,2014
-BIOE,2010,002,Intro Biomed Engr,0.59,0.34,0.03,0.0,0.02,0.0,0.0,0.02,frank alexis,BIOE-2010,2014
-BIOE,3020,001,Biomaterials,0.49,0.3,0.15,0.0,0.02,0.0,0.0,0.04,vladimir vla reukov,BIOE-3020,2014
-BIOE,3200,001,Biomechanics,0.58,0.31,0.08,0.02,0.0,0.0,0.0,0.02,lisa benson,BIOE-3200,2014
-BIOE,3210,001,Biofluid Mechanics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,zhi gao,BIOE-3210,2014
-BIOE,3700,001,Bioinst & Imaging,0.67,0.3,0.02,0.0,0.0,0.0,0.0,0.02,delphine dean,BIOE-3700,2014
-BIOE,3700,002,Bioinst & Imaging,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,david kwartowitz,BIOE-3700,2014
-BIOE,4010,001,Bio E Design Theory,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,john desjardins,BIOE-4010,2014
-BIOE,4030,001,Applied Bio E Design,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,jorge iva rodriguez,BIOE-4030,2014
-BIOE,4030,001,Applied Bio E Design,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,jeremy mercuri,BIOE-4030,2014
-BIOE,4120,001,Orthopaedic Engr and,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,melinda harman,BIOE-4120,2014
-BIOE,4400,001,Biotech for Bio E,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,sarah harcum,BIOE-4400,2014
-BIOE,4510,007,CI Fr/Sr Design and,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,jorge iva rodriguez,BIOE-4510,2014
-BIOE,4510,007,CI Fr/Sr Design and,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john desjardins,BIOE-4510,2014
-BIOE,4510,022,CI- Mobile Health Ap,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,vladimir vla reukov,BIOE-4510,2014
-BIOE,4510,022,CI- Mobile Health Ap,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,ilya mark safro,BIOE-4510,2014
-BIOE,4510,029,CI- The DEN,0.74,0.0,0.0,0.0,0.0,0.0,0.0,0.26,john desjardins,BIOE-4510,2014
-BIOE,6120,001,Orthopaedic Engr & P,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,melinda harman,BIOE-6120,2014
-BIOE,6150,001,Research Principles,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.02,sarah harcum,BIOE-6150,2014
-BIOE,6400,001,Biotech for Bio E,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,sarah harcum,BIOE-6400,2014
-BIOE,8010,001,Bio Materials,0.33,0.64,0.02,0.0,0.0,0.0,0.0,0.0,robert latour,BIOE-8010,2014
-BIOE,8140,401,Medical Dev Commerci,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,BIOE-8140,2014
-BIOE,8140,401,Medical Dev Commerci,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew ray gevaert,BIOE-8140,2014
-BIOE,8200,001,Structl Biomechanics,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,hai yao,BIOE-8200,2014
-BIOL,1010,001,Frontiers in Biology,0.68,0.21,0.06,0.02,0.02,0.0,0.0,0.01,robert edwa ballard,BIOL-1010,2014
-BIOL,1010,001,Frontiers in Biology,0.68,0.21,0.06,0.02,0.02,0.0,0.0,0.01,michael childress,BIOL-1010,2014
-BIOL,1030,001,General Biology I,0.25,0.24,0.27,0.07,0.09,0.0,0.0,0.09,nora espinoza,BIOL-1030,2014
-BIOL,1030,002,General Biology I,0.49,0.29,0.14,0.02,0.02,0.0,0.0,0.03,renea chri hardwick,BIOL-1030,2014
-BIOL,1030,004,General Biology I,0.15,0.16,0.3,0.13,0.15,0.0,0.0,0.11,salvatore sparace,BIOL-1030,2014
-BIOL,1030,005,General Biology I,0.17,0.27,0.25,0.18,0.05,0.0,0.0,0.07,matthew turnbull,BIOL-1030,2014
-BIOL,1030,006,General Biology I,0.26,0.38,0.21,0.08,0.05,0.0,0.0,0.02,kristi ja whitehead,BIOL-1030,2014
-BIOL,1030,007,General Biology I (H,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,nora espinoza,BIOL-1030,2014
-BIOL,1030,008,General Biology I,0.29,0.25,0.25,0.11,0.03,0.0,0.0,0.07,william surver,BIOL-1030,2014
-BIOL,1050,001,General Biology Lab,0.41,0.36,0.09,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,002,General Biology Lab,0.45,0.32,0.05,0.0,0.14,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,003,General Biology Lab,0.45,0.23,0.18,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,004,General Biology Lab,0.36,0.32,0.14,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,005,General Biology Lab,0.59,0.23,0.05,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,006,General Biology Lab,0.23,0.5,0.14,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,007,General Biology Lab,0.36,0.27,0.05,0.09,0.09,0.0,0.0,0.14,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,008,General Biology Lab,0.55,0.23,0.14,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,009,General Biology Lab,0.3,0.3,0.1,0.05,0.1,0.0,0.0,0.15,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,010,General Biology Lab,0.26,0.39,0.22,0.0,0.09,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,011,General Biology Lab,0.38,0.21,0.25,0.08,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,012,General Biology Lab,0.33,0.38,0.13,0.0,0.08,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,013,General Biology Lab,0.68,0.14,0.05,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,014,General Biology Lab,0.32,0.41,0.18,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,015,General Biology Lab,0.29,0.48,0.1,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,016,General Biology Lab,0.42,0.42,0.04,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,017,General Biology Lab,0.5,0.36,0.0,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,018,General Biology Lab,0.32,0.41,0.23,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,019,General Biology Lab,0.43,0.35,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,020,General Biology Lab,0.39,0.3,0.17,0.0,0.04,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,021,General Biology Lab,0.43,0.17,0.13,0.09,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,022,General Biology Lab,0.5,0.36,0.09,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,023,General Biology Lab,0.5,0.2,0.1,0.05,0.05,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,024,General Biology Lab,0.37,0.37,0.05,0.16,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,025,General Biology Lab,0.36,0.36,0.23,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,026,General Biology Lab,0.52,0.22,0.22,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,027,General Biology Lab,0.27,0.55,0.09,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,028,General Biology Lab,0.64,0.23,0.14,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,029,General Biology Lab,0.36,0.5,0.05,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,030,General Biology Lab,0.5,0.32,0.0,0.0,0.0,0.0,0.0,0.18,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,031,General Biology Lab,0.32,0.23,0.27,0.05,0.0,0.0,0.0,0.14,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,032,General Biology Lab,0.38,0.24,0.1,0.0,0.14,0.0,0.0,0.14,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,033,General Biology Lab,0.42,0.16,0.0,0.05,0.16,0.0,0.0,0.21,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,034,General Biology Lab,0.52,0.3,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,036,General Biology Lab,0.42,0.25,0.13,0.04,0.13,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,037,General Biology Lab,0.62,0.29,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,038,General Biology Lab,0.33,0.48,0.14,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,039,General Biology Lab,0.48,0.24,0.1,0.05,0.05,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,040,General Biology Lab,0.64,0.18,0.05,0.09,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,041,General Biology Lab,0.48,0.29,0.1,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,042,General Biology Lab,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,043,General Biology Lab,0.33,0.38,0.14,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,044,General Biology Lab,0.45,0.36,0.0,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1050,046,General Biology Lab,0.38,0.42,0.13,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2014
-BIOL,1090,001,Intro to Life Sci,0.82,0.13,0.04,0.02,0.0,0.0,0.0,0.0,renea chri hardwick,BIOL-1090,2014
-BIOL,1100,001,Prin of Biology I,0.12,0.4,0.25,0.1,0.03,0.0,0.0,0.09,robert kosinski,BIOL-1100,2014
-BIOL,1100,003,Prin of Biology I,0.4,0.35,0.16,0.02,0.03,0.0,0.0,0.04,dylan dittrich-reed,BIOL-1100,2014
-BIOL,1100,004,Prin of Biology I (H,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,dylan dittrich-reed,BIOL-1100,2014
-BIOL,1200,001,Biological Inq Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,002,Biological Inq Lab,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,003,Biological Inq Lab,0.35,0.55,0.0,0.0,0.0,0.0,0.0,0.1, christine minor,BIOL-1200,2014
-BIOL,1200,004,Biological Inq Lab,0.4,0.35,0.15,0.05,0.0,0.0,0.0,0.05, christine minor,BIOL-1200,2014
-BIOL,1200,005,Biological Inq Lab,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,006,Biological Inq Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,007,Biological Inq Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,BIOL-1200,2014
-BIOL,1200,008,Biological Inq Lab,0.33,0.44,0.11,0.06,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2014
-BIOL,1200,010,Biological Inq Lab,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,BIOL-1200,2014
-BIOL,1200,011,Biological Inq Lab,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,012,Biological Inq Lab,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,013,Biological Inq Lab,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,014,Biological Inq Lab,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,015,Biological Inq Lab,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,016,Biological Inq Lab,0.5,0.38,0.06,0.0,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2014
-BIOL,1220,001,Keys to Biodiversity,0.24,0.4,0.24,0.07,0.02,0.0,0.0,0.02,kalan ickes,BIOL-1220,2014
-BIOL,1230,001,Keys to Human Biol,0.22,0.44,0.23,0.08,0.02,0.0,0.0,0.01, christine minor,BIOL-1230,2014
-BIOL,1230,002,Keys to Human Biol,0.33,0.43,0.17,0.07,0.01,0.0,0.0,0.0, christine minor,BIOL-1230,2014
-BIOL,2000,002,Biology in the News,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0, christine minor,BIOL-2000,2014
-BIOL,2000,009,Biology in the News,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,douglas bielenberg,BIOL-2000,2014
-BIOL,2000,010,Biology in the News,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,BIOL-2000,2014
-BIOL,2040,001,"Environ, Energy and",0.29,0.32,0.25,0.03,0.04,0.0,0.0,0.07,john jenkins hains,BIOL-2040,2014
-BIOL,2220,001,Human Anat and Physi,0.22,0.38,0.24,0.09,0.04,0.0,0.0,0.04,john cummings,BIOL-2220,2014
-BIOL,2220,002,Human Anat and Physi,0.19,0.37,0.24,0.11,0.02,0.0,0.0,0.05,john cummings,BIOL-2220,2014
-BIOL,3030,001,Vertebrate Biology,0.29,0.29,0.2,0.14,0.04,0.0,0.0,0.03,richard blob,BIOL-3030,2014
-BIOL,3030,002,Vertebrate Biology (,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3030,2014
-BIOL,3040,001,Biology of Plants,0.12,0.34,0.36,0.09,0.06,0.0,0.0,0.03,robert edwa ballard,BIOL-3040,2014
-BIOL,3070,001,Vertebrate Biology L,0.5,0.4,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3070,002,Vertebrate Biology L,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3070,003,Vertebrate Biology L,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3070,004,Vertebrate Biology L,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,richard blob,BIOL-3070,2014
-BIOL,3070,005,Vertebrate Biology L,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2014
-BIOL,3070,006,Vertebrate Biology L,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3070,007,Vertebrate Biology L,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3070,008,Vertebrate Biology L,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2014
-BIOL,3070,009,Vertebrate Biology L,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2014
-BIOL,3070,010,Vertebrate Biology L,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3070,011,Vertebrate Biology L,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3070,012,Vertebrate Biology L,0.55,0.4,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3070,013,Vertebrate Biology L,0.55,0.35,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2014
-BIOL,3080,001,Biology of Plants Pr,0.63,0.21,0.05,0.05,0.05,0.0,0.0,0.0,robert edwa ballard,BIOL-3080,2014
-BIOL,3080,002,Biology of Plants Pr,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,robert edwa ballard,BIOL-3080,2014
-BIOL,3080,003,Biology of Plants Pr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,robert edwa ballard,BIOL-3080,2014
-BIOL,3080,004,Biology of Plants Pr,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,robert edwa ballard,BIOL-3080,2014
-BIOL,3150,001,Functional Human Ana,0.25,0.46,0.19,0.04,0.01,0.0,0.0,0.05,tamara mcnutt-scott,BIOL-3150,2014
-BIOL,3200,001,Field Botany,0.19,0.37,0.24,0.09,0.07,0.0,0.0,0.04,timothy spira,BIOL-3200,2014
-BIOL,3350,001,Evolutionary Biology,0.27,0.46,0.11,0.06,0.04,0.0,0.0,0.04,margaret ptacek,BIOL-3350,2014
-BIOL,3510,001,Biological Anthropol,0.42,0.33,0.08,0.0,0.17,0.0,0.0,0.0,lisa rapaport,BIOL-3510,2014
-BIOL,3530,001,Forensic Anthrolpolo,0.31,0.38,0.15,0.08,0.08,0.0,0.0,0.0,katherine weisensee,BIOL-3530,2014
-BIOL,4340,001,Biological Chem Lab,0.15,0.23,0.38,0.08,0.0,0.0,0.0,0.15,salvatore sparace,BIOL-4340,2014
-BIOL,4340,003,Biological Chem Lab,0.17,0.5,0.08,0.25,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2014
-BIOL,4340,004,Biological Chem Lab,0.17,0.42,0.25,0.08,0.08,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2014
-BIOL,4410,001,Ecology,0.25,0.44,0.19,0.09,0.01,0.0,0.0,0.02,david tonkyn,BIOL-4410,2014
-BIOL,4430,001,Freshwater Ecology,0.56,0.29,0.13,0.0,0.0,0.0,0.0,0.02,john jenkins hains,BIOL-4430,2014
-BIOL,4450,001,Ecology Laboratory (,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,david tonkyn,BIOL-4450,2014
-BIOL,4450,002,Ecology Laboratory (,0.36,0.36,0.18,0.0,0.0,0.0,0.0,0.09,david tonkyn,BIOL-4450,2014
-BIOL,4450,003,Ecology Laboratory (,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,BIOL-4450,2014
-BIOL,4450,004,Ecology Laboratory (,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david tonkyn,BIOL-4450,2014
-BIOL,4610,001,Cell Biology,0.38,0.3,0.11,0.11,0.0,0.0,0.0,0.1,lesly temesvari,BIOL-4610,2014
-BIOL,4610,002,Cell Biology (HON),0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4610,2014
-BIOL,4610,003,Cell Biology,0.91,0.06,0.01,0.01,0.01,0.0,0.0,0.0,susan carol chapman,BIOL-4610,2014
-BIOL,4610,004,Cell Biology (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,susan carol chapman,BIOL-4610,2014
-BIOL,4620,001,Cell Biology Lab (Le,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4620,2014
-BIOL,4620,003,Cell Biology Lab (Le,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4620,2014
-BIOL,4620,004,Cell Biology Lab (Le,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4620,2014
-BIOL,4620,005,Cell Biology Lab (Le,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4620,2014
-BIOL,4620,006,Cell Biology Lab (Le,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4620,2014
-BIOL,4620,007,Cell Biology Lab (Le,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,david feliciano,BIOL-4620,2014
-BIOL,4620,008,Cell Biology Lab (Le,0.27,0.33,0.4,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4620,2014
-BIOL,4620,010,Cell Biology Lab (Le,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4620,2014
-BIOL,4620,011,Cell Biology Lab (Le,0.36,0.43,0.0,0.07,0.07,0.0,0.0,0.07,david feliciano,BIOL-4620,2014
-BIOL,4660,001,Evolution of Human B,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,lisa rapaport,BIOL-4660,2014
-BIOL,4670,001,Principles of Hemato,0.88,0.05,0.05,0.0,0.0,0.0,0.0,0.02,vincent gallicchio,BIOL-4670,2014
-BIOL,4750,001,Comparative Physiolo,0.3,0.43,0.14,0.0,0.08,0.0,0.0,0.05,michael sears,BIOL-4750,2014
-BIOL,4760,003,Comparative Physiolo,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael sears,BIOL-4760,2014
-BIOL,4930,002,Adv Cancer Research,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,wen chen,BIOL-4930,2014
-BIOL,4940,001,Aging Stress Induced,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,min cao,BIOL-4940,2014
-BIOL,4940,001,Aging Stress Induced,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,yuqing dong,BIOL-4940,2014
-BIOL,4940,007,Popular Science Jour,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,steven katz,BIOL-4940,2014
-BIOL,4940,007,Popular Science Jour,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4940,2014
-BIOL,4960,004,MARINE MICRO,0.27,0.33,0.27,0.13,0.0,0.0,0.0,0.0,john michael henson,BIOL-4960,2014
-BIOL,8200,001,Community Ecology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,saara dewalt,BIOL-8200,2014
-BIOL,8400,001,Understanding Biolog,0.83,0.1,0.01,0.0,0.02,0.0,0.0,0.03,michael childress,BIOL-8400,2014
-BIOL,8420,001,Understand Cellular,0.57,0.31,0.06,0.0,0.04,0.0,0.0,0.02,david feliciano,BIOL-8420,2014
-BIOL,8440,001,Understanding the Hu,0.65,0.29,0.03,0.0,0.02,0.0,0.0,0.0,heidi lynn jordan,BIOL-8440,2014
-BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,sandy edge,BUS-1010,2014
-BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2014
-BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,michael giebner,BUS-1010,2014
-BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2014
-BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,michael giebner,BUS-1010,2014
-BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,sandy edge,BUS-1010,2014
-BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,michael giebner,BUS-1010,2014
-BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2014
-BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,sandy edge,BUS-1010,2014
-BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,sandy edge,BUS-1010,2014
-BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,edward bar de iulio,BUS-1010,2014
-BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,michael giebner,BUS-1010,2014
-BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2014
-BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,sandy edge,BUS-1010,2014
-BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,michael giebner,BUS-1010,2014
-BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,sandy edge,BUS-1010,2014
-BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2014
-BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,michael giebner,BUS-1010,2014
-BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,william ern tumblin,BUS-1010,2014
-BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2014
-BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,sandy edge,BUS-1010,2014
-BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2014
-BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,michael giebner,BUS-1010,2014
-BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,william ern tumblin,BUS-1010,2014
-BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2014
-BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,michael giebner,BUS-1010,2014
-BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,sandy edge,BUS-1010,2014
-BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,BUS-1010,2014
-BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2014
-BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,michael giebner,BUS-1010,2014
-BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2014
-BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,sandy edge,BUS-1010,2014
-BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,william ern tumblin,BUS-1010,2014
-BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,william ern tumblin,BUS-1010,2014
-BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,william ern tumblin,BUS-1010,2014
-BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,william ern tumblin,BUS-1010,2014
-BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,william ern tumblin,BUS-1010,2014
-BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,sandy edge,BUS-1010,2014
-BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,michael giebner,BUS-1010,2014
-BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,edward bar de iulio,BUS-1010,2014
-BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,michael giebner,BUS-1010,2014
-BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,sandy edge,BUS-1010,2014
-BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,edward bar de iulio,BUS-1010,2014
-BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,renee hebert,BUS-1010,2014
-BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,michael giebner,BUS-1010,2014
-BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,edward bar de iulio,BUS-1010,2014
-BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,sandy edge,BUS-1010,2014
-BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,renee hebert,BUS-1010,2014
-BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,michael giebner,BUS-1010,2014
-BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,sandy edge,BUS-1010,2014
-BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,renee hebert,BUS-1010,2014
-BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,edward bar de iulio,BUS-1010,2014
-BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,BUS-1010,2014
-BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2014
-BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2014
-CE,2010,002,Statics,0.32,0.25,0.25,0.07,0.0,0.0,0.0,0.11,qiushi chen,CE-2010,2014
-CE,2010,003,Statics,0.24,0.24,0.29,0.05,0.13,0.0,0.0,0.05,scott schiff,CE-2010,2014
-CE,2010,004,Statics,0.2,0.29,0.22,0.02,0.07,0.0,0.0,0.2,melissa sternhagen,CE-2010,2014
-CE,2010,005,Statics,0.24,0.29,0.2,0.07,0.02,0.0,0.0,0.18,melissa sternhagen,CE-2010,2014
-CE,2010,006,Statics,0.4,0.23,0.14,0.05,0.07,0.0,0.0,0.12,nighat yasmin,CE-2010,2014
-CE,2010,007,Statics,0.38,0.3,0.19,0.03,0.03,0.0,0.0,0.08,weichiang pang,CE-2010,2014
-CE,2060,001,Structural Mechanics,0.14,0.16,0.51,0.08,0.06,0.0,0.0,0.04,bryant nielson,CE-2060,2014
-CE,2080,002,Dynamics,0.16,0.24,0.24,0.18,0.08,0.0,0.0,0.11,melissa sternhagen,CE-2080,2014
-CE,2080,004,Dynamics,0.05,0.3,0.35,0.15,0.1,0.0,0.0,0.05,melissa sternhagen,CE-2080,2014
-CE,2550,001,Geomatics,0.32,0.38,0.24,0.01,0.01,0.0,0.0,0.04,wayne sarasua,CE-2550,2014
-CE,3010,001,Structural Analysis,0.3,0.43,0.11,0.0,0.14,0.0,0.0,0.03,stephen csernak,CE-3010,2014
-CE,3010,002,Structural Analysis,0.21,0.31,0.34,0.06,0.06,0.0,0.0,0.02,bryant nielson,CE-3010,2014
-CE,3110,001,Transportation Engr,0.74,0.17,0.04,0.02,0.02,0.0,0.0,0.0,jennifer ogle,CE-3110,2014
-CE,3210,001,Geotechnical Enginee,0.31,0.46,0.15,0.0,0.06,0.0,0.0,0.02,qiushi chen,CE-3210,2014
-CE,3310,001,Constr Engr & Mgmnt,0.41,0.42,0.09,0.04,0.04,0.0,0.0,0.0,james burati,CE-3310,2014
-CE,3410,001,Intro to Fluid Mech,0.19,0.38,0.26,0.11,0.04,0.0,0.0,0.02,nigel gregory kaye,CE-3410,2014
-CE,3410,002,Intro to Fluid Mech,0.17,0.31,0.28,0.09,0.07,0.0,0.0,0.07,abdul khan,CE-3410,2014
-CE,3420,001,Hydraulics & Hydro,0.38,0.4,0.13,0.05,0.05,0.0,0.0,0.0,ashok mishra,CE-3420,2014
-CE,3510,001,Civil Engineering Ma,0.34,0.5,0.1,0.02,0.04,0.0,0.0,0.0,ami esmaeilpoursaee,CE-3510,2014
-CE,3510,002,Civil Engineering Ma,0.38,0.32,0.21,0.03,0.06,0.0,0.0,0.0,bradley putman,CE-3510,2014
-CE,3520,001,Econ Eval of Proj,0.37,0.33,0.12,0.08,0.08,0.0,0.0,0.01,yongxi huang,CE-3520,2014
-CE,3530,001,Professional Seminar,0.79,0.13,0.08,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-3530,2014
-CE,4060,001,Struct Steel Design,0.21,0.32,0.28,0.17,0.02,0.0,0.0,0.0,stephen csernak,CE-4060,2014
-CE,4080,001,Struct Loads & Sys,0.22,0.5,0.06,0.17,0.06,0.0,0.0,0.0,bryant nielson,CE-4080,2014
-CE,4100,001,Traffic Engr Oper,0.06,0.5,0.22,0.22,0.0,0.0,0.0,0.0,yongxi huang,CE-4100,2014
-CE,4240,001,Earth Slopes & Struc,0.24,0.42,0.24,0.05,0.03,0.0,0.0,0.03,nadara ravichandran,CE-4240,2014
-CE,4340,001,Const Est Proj Cont,0.61,0.32,0.05,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4340,2014
-CE,4360,001,Sustainable Constr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,CE-4360,2014
-CE,4390,001,Con Eqpmt Sel & Main,0.56,0.34,0.07,0.0,0.02,0.0,0.0,0.0,james burati,CE-4390,2014
-CE,4430,001,Water Resources Engr,0.45,0.09,0.36,0.0,0.0,0.0,0.0,0.09,abdul khan,CE-4430,2014
-CE,4560,001,Pave Design & Constr,0.37,0.42,0.17,0.03,0.0,0.0,0.0,0.02,bradley putman,CE-4560,2014
-CE,4590,001,Capstone Design Proj,0.25,0.57,0.1,0.08,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2014
-CE,4820,001,Groundwater & Contam,0.42,0.25,0.17,0.0,0.0,0.0,0.0,0.17,lawrence murdoch,CE-4820,2014
-CE,4990,052,C I in Civil Engr/CE,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,jennifer ogle,CE-4990,2014
-CE,6080,001,Struct Loads & Sys,0.42,0.46,0.13,0.0,0.0,0.0,0.0,0.0,bryant nielson,CE-6080,2014
-CE,6100,001,Traffic Engr Oper,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yongxi huang,CE-6100,2014
-CE,6240,001,Earth Slopes & Struc,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,CE-6240,2014
-CE,6360,001,Sustainable Constr,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,leidy klotz,CE-6360,2014
-CE,8020,001,Adv R/C Design,0.4,0.58,0.0,0.0,0.0,0.0,0.0,0.03,scott schiff,CE-8020,2014
-CE,8060,001,Dyn Analys of Struc,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,CE-8060,2014
-CE,8210,001,Advanced Soil Mech,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-8210,2014
-CE,8220,001,Foundation Engr,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,CE-8220,2014
-CE,8540,001,Travl Demnd Forecast,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,wayne sarasua,CE-8540,2014
-CE,8930,005,Connected Vehicle Te,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,mashrur chowdhury,CE-8930,2014
-CH,1010,001,General Chemistry,0.25,0.37,0.21,0.12,0.05,0.0,0.0,0.01,dennis taylor,CH-1010,2014
-CH,1010,002,General Chemistry,0.09,0.42,0.27,0.09,0.08,0.0,0.0,0.04,ava kreider-mueller,CH-1010,2014
-CH,1010,003,General Chemistry,0.23,0.39,0.2,0.08,0.06,0.0,0.0,0.05,dennis taylor,CH-1010,2014
-CH,1010,004,General Chemistry,0.24,0.31,0.2,0.14,0.04,0.0,0.0,0.07,dennis taylor,CH-1010,2014
-CH,1010,005,General Chemistry,0.11,0.29,0.32,0.15,0.11,0.0,0.0,0.02,ava kreider-mueller,CH-1010,2014
-CH,1010,006,General Chemistry,0.22,0.36,0.18,0.1,0.11,0.0,0.0,0.02,thomas hickman,CH-1010,2014
-CH,1010,007,General Chemistry,0.22,0.38,0.23,0.08,0.08,0.0,0.0,0.01,thomas hickman,CH-1010,2014
-CH,1010,008,General Chemistry,0.2,0.34,0.24,0.06,0.1,0.0,0.0,0.06,kenneth wi rillings,CH-1010,2014
-CH,1010,009,General Chemistry,0.13,0.32,0.26,0.12,0.1,0.0,0.0,0.06,ava kreider-mueller,CH-1010,2014
-CH,1010,010,General Chemistry,0.19,0.24,0.21,0.18,0.16,0.0,0.0,0.03,christopher wilson,CH-1010,2014
-CH,1010,011,General Chemistry,0.22,0.37,0.23,0.09,0.03,0.0,0.0,0.06,tania issa houjeiry,CH-1010,2014
-CH,1010,012,General Chemistry,0.11,0.27,0.28,0.2,0.09,0.0,0.0,0.05,christopher wilson,CH-1010,2014
-CH,1010,013,General Chemistry,0.18,0.29,0.3,0.08,0.11,0.0,0.0,0.04,olt geiculescu,CH-1010,2014
-CH,1010,014,General Chemistry,0.23,0.39,0.24,0.09,0.02,0.0,0.0,0.03,dennis taylor,CH-1010,2014
-CH,1010,015,General Chemistry: M,0.34,0.31,0.22,0.06,0.06,0.0,0.0,0.0,tania issa houjeiry,CH-1010,2014
-CH,1010,016,General Chemistry (R,0.2,0.45,0.26,0.03,0.03,0.0,0.0,0.03,tania issa houjeiry,CH-1010,2014
-CH,1010,017,General Chemistry (R,0.15,0.43,0.27,0.07,0.05,0.0,0.0,0.03,kenneth wi rillings,CH-1010,2014
-CH,1010,018,General Chemistry (R,0.17,0.44,0.25,0.07,0.04,0.0,0.0,0.03,kenneth wi rillings,CH-1010,2014
-CH,1010,019,General Chemistry: C,0.32,0.39,0.19,0.08,0.0,0.0,0.0,0.01,kenneth christensen,CH-1010,2014
-CH,1010,051,General Chemistry (H,0.68,0.29,0.02,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,CH-1010,2014
-CH,1010,052,General Chemistry (H,0.58,0.39,0.0,0.03,0.0,0.0,0.0,0.0,joseph stu thrasher,CH-1010,2014
-CH,1020,001,General Chemistry,0.32,0.26,0.27,0.09,0.02,0.0,0.0,0.03,stephe schvaneveldt,CH-1020,2014
-CH,1020,002,General Chemistry,0.28,0.32,0.19,0.09,0.05,0.0,0.0,0.07,stephe schvaneveldt,CH-1020,2014
-CH,1020,003,General Chemistry,0.24,0.24,0.25,0.17,0.03,0.0,0.0,0.07,stephe schvaneveldt,CH-1020,2014
-CH,1020,400,General Chemistry (O,0.11,0.24,0.27,0.16,0.11,0.0,0.0,0.11,stephe schvaneveldt,CH-1020,2014
-CH,1050,001,Chem in Context I,0.26,0.56,0.17,0.02,0.0,0.0,0.0,0.0,olt geiculescu,CH-1050,2014
-CH,1050,002,Chem in Context I,0.41,0.47,0.06,0.02,0.03,0.0,0.0,0.02,olt geiculescu,CH-1050,2014
-CH,1410,001,Chem Orientation,0.72,0.2,0.06,0.0,0.0,0.0,0.0,0.02,stephen creager,CH-1410,2014
-CH,2010,001,Survey of Organic Ch,0.44,0.32,0.08,0.03,0.04,0.0,0.0,0.08,thomas hickman,CH-2010,2014
-CH,2010,002,Survey of Organic Ch,0.45,0.37,0.12,0.03,0.0,0.0,0.0,0.04,thomas hickman,CH-2010,2014
-CH,2020,001,Surv of Organic Chem,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2020,2014
-CH,2020,009,Surv of Organic Chem,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,CH-2020,2014
-CH,2020,010,Surv of Organic Chem,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,CH-2020,2014
-CH,2020,011,Surv of Organic Chem,0.53,0.2,0.07,0.0,0.0,0.0,0.0,0.2,sean 'connor,CH-2020,2014
-CH,2020,012,Surv of Organic Chem,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2020,2014
-CH,2230,001,Organic Chemistry,0.09,0.2,0.31,0.12,0.11,0.0,0.0,0.17,dev priya arya,CH-2230,2014
-CH,2230,002,Organic Chemistry,0.35,0.29,0.18,0.08,0.03,0.0,0.0,0.07,rhett smith,CH-2230,2014
-CH,2230,003,Organic Chemistry,0.3,0.34,0.19,0.04,0.1,0.0,0.0,0.02,jacob schroeder,CH-2230,2014
-CH,2230,004,Organic Chemistry,0.2,0.28,0.24,0.17,0.03,0.0,0.0,0.07,modi wetzler,CH-2230,2014
-CH,2230,005,Organic Chemistry,0.26,0.3,0.25,0.09,0.03,0.0,0.0,0.07,modi wetzler,CH-2230,2014
-CH,2230,006,Organic Chemistry,0.38,0.34,0.21,0.02,0.01,0.0,0.0,0.04,tania issa houjeiry,CH-2230,2014
-CH,2230,007,Organic Chemistry,0.37,0.36,0.15,0.06,0.01,0.0,0.0,0.05,jacob schroeder,CH-2230,2014
-CH,2240,001,Organic Chemistry,0.31,0.3,0.22,0.09,0.02,0.0,0.0,0.06,jacob schroeder,CH-2240,2014
-CH,2240,002,Organic Chemistry,0.3,0.37,0.21,0.05,0.05,0.0,0.0,0.02,jacob schroeder,CH-2240,2014
-CH,2270,001,Organic Chem Lab,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,CH-2270,2014
-CH,2270,002,Organic Chem Lab,0.81,0.06,0.06,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,007,Organic Chem Lab,0.6,0.07,0.07,0.0,0.0,0.0,0.0,0.27,sean 'connor,CH-2270,2014
-CH,2270,011,Organic Chem Lab,0.69,0.13,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,CH-2270,2014
-CH,2270,014,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,015,Organic Chem Lab,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,016,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2014
-CH,2270,017,Organic Chem Lab,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2014
-CH,2270,019,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,020,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2014
-CH,2270,023,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,024,Organic Chem Lab,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,026,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,028,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,029,Organic Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,030,Organic Chem Lab,0.44,0.5,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,031,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,032,Organic Chem Lab,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2014
-CH,2270,033,Organic Chem Lab,0.55,0.09,0.09,0.18,0.0,0.0,0.0,0.09,sean 'connor,CH-2270,2014
-CH,2270,034,Organic Chem Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,sean 'connor,CH-2270,2014
-CH,2270,035,Organic Chem Lab,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2014
-CH,2270,036,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2014
-CH,2270,037,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,038,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,CH-2270,2014
-CH,2280,004,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,CH-2280,2014
-CH,2280,007,Organic Chem Lab,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,CH-2280,2014
-CH,3130,001,Quantitative Analys,0.4,0.33,0.1,0.07,0.02,0.0,0.0,0.07,stephen creager,CH-3130,2014
-CH,3150,002,Quant Analysis Lab,0.36,0.36,0.09,0.09,0.09,0.0,0.0,0.0,jeffrey natha anker,CH-3150,2014
-CH,3300,001,Intro to Phys Chem,0.41,0.37,0.18,0.0,0.0,0.0,0.0,0.04,brian dominy,CH-3300,2014
-CH,3310,001,Physical Chemistry,0.27,0.25,0.35,0.08,0.02,0.0,0.0,0.02,jason mcneill,CH-3310,2014
-CH,3320,001,Physical Chemistry,0.2,0.3,0.1,0.2,0.0,0.0,0.0,0.2,arkady kholodenko,CH-3320,2014
-CH,3390,001,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,CH-3390,2014
-CH,3390,005,Physical Chem Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,CH-3390,2014
-CH,4010,001,Organometallic Chemi,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,andrew gre tennyson,CH-4010,2014
-CH,4020,001,Inorganic Chemistry,0.2,0.73,0.07,0.0,0.0,0.0,0.0,0.0,joseph kolis,CH-4020,2014
-CH,8070,001,Chem Trans Elem,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,CH-8070,2014
-CH,8120,001,Spectrochemical Anal,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,george chumanov,CH-8120,2014
-CH,8150,001,Mass Spectrometry,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,richard marcus,CH-8150,2014
-CH,8210,001,Organic Chem I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, karl dieter,CH-8210,2014
-CH,8300,001,Fund Phys Chem,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,CH-8300,2014
-CH,8340,001,Stat Thermodynamics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,CH-8340,2014
-CH,8410,001,N M R Spectroscopy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,alek kitaygorodskiy,CH-8410,2014
-CH,8510,002,Grad Student Seminar,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey natha anker,CH-8510,2014
-CHE,2110,001,Intro to Chem Eng,0.23,0.24,0.18,0.03,0.26,0.0,0.0,0.06,rachel getman,CHE-2110,2014
-CHE,2110,002,Intro to Chem Eng,0.19,0.23,0.26,0.02,0.23,0.0,0.0,0.08,rachel getman,CHE-2110,2014
-CHE,3070,001,Unit Ops Lab I,0.14,0.6,0.21,0.02,0.0,0.0,0.0,0.02,christopher norfolk,CHE-3070,2014
-CHE,3070,001,Unit Ops Lab I,0.14,0.6,0.21,0.02,0.0,0.0,0.0,0.02,mark thies,CHE-3070,2014
-CHE,3190,001,Engr Materials,0.11,0.32,0.39,0.14,0.05,0.0,0.0,0.0,antho guiseppi-elie,CHE-3190,2014
-CHE,4070,001,Unit Op Lab II,0.16,0.84,0.0,0.0,0.0,0.0,0.0,0.0,scott husson,CHE-4070,2014
-CHE,4310,001,Process Design I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4310,2014
-CHE,4500,001,Chem Reaction Engr,0.17,0.34,0.34,0.09,0.06,0.0,0.0,0.0,mark alan blenner,CHE-4500,2014
-CHE,8030,001,Advanced Transport,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,douglas hirt,CHE-8030,2014
-CHE,8040,001,Ch E Thermodynamics,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,sapna sarupria,CHE-8040,2014
-CHE,8050,001,Ch E Kinetics,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,mark roberts,CHE-8050,2014
-CHE,8140,002,Numerical Methods,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,joseph scott,CHE-8140,2014
-CHIN,1010,001,Elementary Chinese,0.44,0.06,0.19,0.0,0.0,0.0,0.0,0.31,yanming an,CHIN-1010,2014
-CHIN,4010,001,Pre-Modern Chinese L,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,yanming an,CHIN-4010,2014
-COM,1500,001,Intro to Human Com,0.66,0.29,0.01,0.01,0.02,0.0,0.0,0.01,eddie smith,COM-1500,2014
-COM,1500,002,Introduction  to Hum,0.65,0.24,0.06,0.01,0.01,0.0,0.0,0.03,daniel lelan fecher,COM-1500,2014
-COM,1500,003,Intro to Human Com,0.69,0.26,0.02,0.01,0.01,0.0,0.0,0.01,eddie smith,COM-1500,2014
-COM,1500,004,Intro to Human Com,0.64,0.29,0.05,0.0,0.01,0.0,0.0,0.01,marianne her glaser,COM-1500,2014
-COM,1500,005,Intro to Human Com,0.71,0.22,0.05,0.0,0.01,0.0,0.0,0.01,marianne her glaser,COM-1500,2014
-COM,1500,006,Intro to Human Com,0.65,0.25,0.04,0.0,0.01,0.0,0.0,0.05,marianne her glaser,COM-1500,2014
-COM,1500,007,Intro to Human Com,0.4,0.47,0.06,0.02,0.01,0.0,0.0,0.03,daniel lelan fecher,COM-1500,2014
-COM,2010,001,Intr to Comm Studies,0.51,0.39,0.1,0.0,0.0,0.0,0.0,0.0,brenden kendall,COM-2010,2014
-COM,2500,001,Public Speaking,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,brandon boatwright,COM-2500,2014
-COM,2500,002,Public Speaking,0.11,0.58,0.16,0.0,0.11,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2014
-COM,2500,003,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2014
-COM,2500,004,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2014
-COM,2500,005,Public Speaking,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2014
-COM,2500,006,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,COM-2500,2014
-COM,2500,007,Public Speaking,0.37,0.42,0.16,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2014
-COM,2500,008,Public Speaking,0.68,0.11,0.0,0.05,0.05,0.0,0.0,0.11,jumah patrici taweh,COM-2500,2014
-COM,2500,009,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2014
-COM,2500,010,Public Speaking,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,COM-2500,2014
-COM,2500,011,Public Speaking,0.5,0.39,0.0,0.06,0.0,0.0,0.0,0.06,pauline matthey,COM-2500,2014
-COM,2500,012,Public Speaking,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,marilyn denise pugh,COM-2500,2014
-COM,2500,013,Public Speaking,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2014
-COM,2500,014,Public Speaking,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2014
-COM,2500,015,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2014
-COM,2500,016,Public Speaking,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,katharin schoonover,COM-2500,2014
-COM,2500,017,Public Speaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,the estate  geddes,COM-2500,2014
-COM,2500,018,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,COM-2500,2014
-COM,2500,019,Public Speaking,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2014
-COM,2500,020,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2014
-COM,2500,021,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2014
-COM,2500,022,Public Speaking,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2014
-COM,2500,023,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2014
-COM,2500,024,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2014
-COM,2500,025,Public Speaking (HON,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2014
-COM,2500,026,Public Speaking (HON,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-2500,2014
-COM,2500,400,Public Speaking,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2014
-COM,2500,401,Public Speaking,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alexis zachar davis,COM-2500,2014
-COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2014
-COM,2500,403,Public Speaking,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,COM-2500,2014
-COM,3010,001,Comm Theory,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,stephanie pangborn,COM-3010,2014
-COM,3020,001,Mass Comm Theory,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3020,2014
-COM,3070,001,Public Comm of Sts,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,david travers scott,COM-3070,2014
-COM,3080,001,Pub Comm & Pop Cult,0.28,0.4,0.18,0.04,0.02,0.0,0.0,0.08,chenjerai kumanyika,COM-3080,2014
-COM,3100,001,Quant Comm Methods,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-3100,2014
-COM,3110,001,Qual Comm Methods,0.37,0.47,0.0,0.0,0.05,0.0,0.0,0.11,chenjerai kumanyika,COM-3110,2014
-COM,3210,001,Comm Across Media Pl,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian mullen,COM-3210,2014
-COM,3220,001,Communication Design,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,lori marlise pindar,COM-3220,2014
-COM,3250,001,Survey of Sports Com,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-3250,2014
-COM,3250,002,Survey of Sports Com,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-3250,2014
-COM,3260,001,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2014
-COM,3260,002,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2014
-COM,3480,001,Interpersonal Comm,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,melinda ra weathers,COM-3480,2014
-COM,3550,001,Principles of Pr,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3550,2014
-COM,3550,002,Principles of Pr,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3550,2014
-COM,3660,001,EP: Advertising & Me,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,william reynolds,COM-3660,2014
-COM,3660,002,EP: Building the Bra,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,andrew mendelsohn,COM-3660,2014
-COM,3660,003,Live Broadcast Prod.,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,michael rodgers,COM-3660,2014
-COM,4300,001,Legal Communication,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,COM-4300,2014
-COM,4700,001,Comm & Health,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4700,2014
-COM,4800,001,Intercultural Comm,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,andrew stephen pyle,COM-4800,2014
-COM,8010,001,Communication Theory,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-8010,2014
-COM,8030,001,Comm Technology Stud,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,COM-8030,2014
-COM,8100,001,Comm Research Method,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-8100,2014
-CPSC,1010,001,Computer Science I,0.24,0.12,0.24,0.08,0.18,0.0,0.0,0.13,catherine hochrine,CPSC-1010,2014
-CPSC,1010,003,Computer Science I,0.75,0.11,0.02,0.0,0.02,0.0,0.0,0.09,lauren elizab dukes,CPSC-1010,2014
-CPSC,1010,004,Computer Science I,0.15,0.13,0.18,0.13,0.21,0.0,0.0,0.21,pradip srimani,CPSC-1010,2014
-CPSC,1020,001,Computer Science II,0.36,0.36,0.07,0.02,0.02,0.0,0.0,0.18,catherine hochrine,CPSC-1020,2014
-CPSC,1040,001,Intro Computer Prog,0.24,0.56,0.0,0.08,0.08,0.0,0.0,0.04,kenneth alle weaver,CPSC-1040,2014
-CPSC,1110,001,Intro to Programming,0.58,0.28,0.08,0.03,0.03,0.0,0.0,0.03,patrick sterling,CPSC-1110,2014
-CPSC,1110,002,Intro to Programming,0.52,0.31,0.07,0.0,0.1,0.0,0.0,0.0,patrick sterling,CPSC-1110,2014
-CPSC,1110,003,Intro to Programming,0.64,0.19,0.07,0.02,0.05,0.0,0.0,0.02,patrick sterling,CPSC-1110,2014
-CPSC,1110,004,Intro to Programming,0.87,0.07,0.02,0.0,0.04,0.0,0.0,0.0,toni bloodwor pence,CPSC-1110,2014
-CPSC,2070,001,Discrete Structures,0.13,0.29,0.28,0.1,0.04,0.0,0.0,0.15,roy pargas,CPSC-2070,2014
-CPSC,2100,001,Progrmng Methodology,0.54,0.13,0.1,0.06,0.1,0.0,0.0,0.08,rose lowe,CPSC-2100,2014
-CPSC,2120,001,Algs/Data Structures,0.28,0.28,0.23,0.02,0.06,0.0,0.0,0.12,brian christop dean,CPSC-2120,2014
-CPSC,2150,001,Software Dev Fndtns,0.35,0.28,0.23,0.05,0.05,0.0,0.0,0.05,blair madiso durkee,CPSC-2150,2014
-CPSC,2150,002,Software Dev Fndtns,0.21,0.31,0.33,0.05,0.05,0.0,0.0,0.05,catherine hochrine,CPSC-2150,2014
-CPSC,2200,001,Microcomputer Appl,0.32,0.42,0.16,0.0,0.11,0.0,0.0,0.0,renee lambert,CPSC-2200,2014
-CPSC,2200,002,Microcomputer Appl,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,patrick sterling,CPSC-2200,2014
-CPSC,2310,001,Intro Computer Org,0.22,0.35,0.24,0.05,0.14,0.0,0.0,0.0,rose lowe,CPSC-2310,2014
-CPSC,2310,002,Intro Computer Org,0.41,0.24,0.21,0.03,0.09,0.0,0.0,0.03,rose lowe,CPSC-2310,2014
-CPSC,2910,001,Prof Issues I,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,james jones,CPSC-2910,2014
-CPSC,2910,002,Prof Issues I,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,james jones,CPSC-2910,2014
-CPSC,2910,003,Prof Issues I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,james jones,CPSC-2910,2014
-CPSC,2910,004,Prof Issues I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james jones,CPSC-2910,2014
-CPSC,2910,006,Prof Issues I,0.6,0.0,0.2,0.0,0.1,0.0,0.0,0.1,renee lambert,CPSC-2910,2014
-CPSC,2910,008,Prof Issues I,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,renee lambert,CPSC-2910,2014
-CPSC,3220,001,Intro to Operating S,0.23,0.21,0.14,0.04,0.12,0.0,0.0,0.26,jacob sorber,CPSC-3220,2014
-CPSC,3300,001,Computer Systems Org,0.32,0.25,0.22,0.03,0.1,0.0,0.0,0.08,mark smotherman,CPSC-3300,2014
-CPSC,3500,001,Foundatns of Com Sci,0.22,0.27,0.22,0.08,0.1,0.0,0.0,0.12,ilya mark safro,CPSC-3500,2014
-CPSC,3520,001,Programming Systems,0.25,0.31,0.19,0.03,0.19,0.0,0.0,0.03,robert schalkoff,CPSC-3520,2014
-CPSC,3600,001,Network Programming,0.19,0.33,0.22,0.04,0.11,0.0,0.0,0.11,sekou lionel remy,CPSC-3600,2014
-CPSC,3620,001,Dist & Cluster Compu,0.36,0.3,0.18,0.09,0.06,0.0,0.0,0.0,amy apon,CPSC-3620,2014
-CPSC,3620,001,Dist & Cluster Compu,0.36,0.3,0.18,0.09,0.06,0.0,0.0,0.0,linh bao ngo,CPSC-3620,2014
-CPSC,3710,001,Systems Analysis,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,john mcgregor,CPSC-3710,2014
-CPSC,3720,001,Software Engineering,0.32,0.35,0.29,0.0,0.0,0.0,0.0,0.03,murali sitaraman,CPSC-3720,2014
-CPSC,3720,002,Software Engineering,0.15,0.35,0.35,0.09,0.03,0.0,0.0,0.03,stephen schaub,CPSC-3720,2014
-CPSC,3990,002,AdvCI Proc Gen Game,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,brian malloy,CPSC-3990,2014
-CPSC,4040,001,Cmptr Graphics Image,0.5,0.23,0.14,0.0,0.14,0.0,0.0,0.0,joshua levine,CPSC-4040,2014
-CPSC,4060,001,Gpu Computation,0.3,0.0,0.3,0.1,0.3,0.0,0.0,0.0,robert geist,CPSC-4060,2014
-CPSC,4110,001,Virtual Reality Syst,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,CPSC-4110,2014
-CPSC,4200,001,Computer Security Pr,0.32,0.36,0.18,0.05,0.05,0.0,0.0,0.05,pradip srimani,CPSC-4200,2014
-CPSC,4620,001,Database Management,0.29,0.5,0.18,0.0,0.0,0.0,0.0,0.04,feng luo,CPSC-4620,2014
-CPSC,4810,016,Programming Team,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian christop dean,CPSC-4810,2014
-CPSC,4910,001,Prof  Issues II,0.95,0.04,0.0,0.0,0.0,0.0,0.0,0.02,james jones,CPSC-4910,2014
-CPSC,6040,001,Cptr Graphics Image,0.65,0.2,0.05,0.0,0.05,0.0,0.0,0.05,joshua levine,CPSC-6040,2014
-CPSC,6060,001,Gpu Computation,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,robert geist,CPSC-6060,2014
-CPSC,6110,001,Virtual Reality Syst,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,CPSC-6110,2014
-CPSC,6620,001,Database Management,0.33,0.63,0.0,0.0,0.0,0.0,0.0,0.04,feng luo,CPSC-6620,2014
-CPSC,8070,001,3d Model Animation,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,CPSC-8070,2014
-CPSC,8200,001,Parallel Architechtu,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,pradip srimani,CPSC-8200,2014
-CPSC,8270,001,Translation of Progr,0.86,0.05,0.1,0.0,0.0,0.0,0.0,0.0,brian malloy,CPSC-8270,2014
-CPSC,8380,001,Adv Data Structures,0.23,0.09,0.09,0.0,0.45,0.0,0.0,0.14,sandra hedetniemi,CPSC-8380,2014
-CPSC,8450,001,Bioinfo Algorithms,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,CPSC-8450,2014
-CPSC,8510,001,Soft Sys Data Comm,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,james martin,CPSC-8510,2014
-CPSC,8700,001,O O Software Design,0.64,0.28,0.05,0.0,0.0,0.0,0.0,0.03,brian malloy,CPSC-8700,2014
-CPSC,8720,002,Software Spec & Desi,0.34,0.45,0.17,0.0,0.0,0.0,0.0,0.03,john mcgregor,CPSC-8720,2014
-CPSC,8770,001,Biometric Systems,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,damon woodard,CPSC-8770,2014
-CPSC,8810,001,Data Visualization,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,joshua levine,CPSC-8810,2014
-CRP,8000,001,Human Settlement,0.51,0.37,0.12,0.0,0.0,0.0,0.0,0.0,thomas will schurch,CRP-8000,2014
-CRP,8000,001,Human Settlement,0.51,0.37,0.12,0.0,0.0,0.0,0.0,0.0,john terrenc farris,CRP-8000,2014
-CRP,8010,001,Planning Process & L,0.26,0.7,0.0,0.0,0.0,0.0,0.0,0.04,caitlin dyckman,CRP-8010,2014
-CRP,8020,001,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,CRP-8020,2014
-CRP,8030,001,Quant Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,CRP-8030,2014
-CRP,8030,001,Quant Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,CRP-8030,2014
-CRP,8060,001,Urban Systems,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,timothy green,CRP-8060,2014
-CRP,8580,002,Research Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy green,CRP-8580,2014
-CSM,1000,001,Intro to Construct,0.2,0.63,0.13,0.04,0.02,0.0,0.0,0.0,joseph wintz,CSM-1000,2014
-CSM,2010,001,Structures I,0.27,0.41,0.14,0.14,0.0,0.0,0.0,0.05,shima clarke,CSM-2010,2014
-CSM,2010,002,Structures I,0.23,0.27,0.32,0.05,0.05,0.0,0.0,0.09,shima clarke,CSM-2010,2014
-CSM,2030,001,Mats & Meth of Const,0.19,0.67,0.15,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-2030,2014
-CSM,2030,002,Mats & Meth of Const,0.21,0.54,0.17,0.08,0.0,0.0,0.0,0.0,jason lucas,CSM-2030,2014
-CSM,3030,001,Soils & Foundations,0.27,0.47,0.13,0.13,0.0,0.0,0.0,0.0,joseph wintz,CSM-3030,2014
-CSM,3030,002,Soils & Foundations,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-3030,2014
-CSM,3040,001,Envir Systems I,0.33,0.43,0.24,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2014
-CSM,3040,002,Envir Systems I,0.32,0.47,0.05,0.11,0.05,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2014
-CSM,3510,001,Const Estimating,0.29,0.48,0.14,0.1,0.0,0.0,0.0,0.0,james packer smith,CSM-3510,2014
-CSM,3510,002,Const Estimating,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,james packer smith,CSM-3510,2014
-CSM,4110,001,Safety in Bldg Const,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,david devita,CSM-4110,2014
-CSM,4500,001,Construction Intern,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-4500,2014
-CSM,4530,001,Const Proj Mgmt,0.08,0.6,0.32,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-4530,2014
-CSM,4530,002,Const Proj Mgmt,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-4530,2014
-CSM,4610,001,Const Econ Seminar,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4610,2014
-CSM,4610,002,Const Econ Seminar,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4610,2014
-CSM,6550,001,Adverse Relations,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,joseph wintz,CSM-6550,2014
-CSM,8520,001,Const Mgmt Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,shima clarke,CSM-8520,2014
-CSM,8600,001,Constr Finan Plan &,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8600,2014
-CSM,8600,400,Constr Finan Plan &,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8600,2014
-CSM,8630,001,Adv Plan/Sched,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-8630,2014
-CSM,8630,400,Adv Plan/Sched,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-8630,2014
-CSM,8660,001,Role in Development,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8660,2014
-CU,1000,001,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.01,jeffrey appling,CU-1000,2014
-CU,1000,001,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.01,mary mcp von kaenel,CU-1000,2014
-CU,1000,002,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.01,jeffrey appling,CU-1000,2014
-CU,1000,002,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.01,mary mcp von kaenel,CU-1000,2014
-CU,1000,003,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,jeffrey appling,CU-1000,2014
-CU,1000,003,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,mary mcp von kaenel,CU-1000,2014
-CU,1000,004,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.84,0.15,0.02,jeffrey appling,CU-1000,2014
-CU,1000,004,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.84,0.15,0.02,mary mcp von kaenel,CU-1000,2014
-CU,1000,005,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.03,0.01,jeffrey appling,CU-1000,2014
-CU,1000,006,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.02,0.01,jeffrey appling,CU-1000,2014
-CU,1000,007,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,CU-1000,2014
-CU,1000,008,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,CU-1000,2014
-CU,1000,009,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey appling,CU-1000,2014
-CU,1000,010,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,jeffrey appling,CU-1000,2014
-CU,1000,011,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,CU-1000,2014
-CU,1000,012,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.05,0.01,jeffrey appling,CU-1000,2014
-CU,1000,013,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.01,jeffrey appling,CU-1000,2014
-CU,1000,014,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.89,0.1,0.01,jeffrey appling,CU-1000,2014
-CU,1010,001,Univ Success Skills,0.43,0.17,0.26,0.0,0.04,0.0,0.0,0.09,deborah ann vaughn,CU-1010,2014
-CU,1010,002,Univ Success Skills,0.35,0.39,0.09,0.09,0.04,0.0,0.0,0.04,rise jean sheriff,CU-1010,2014
-CU,1010,003,Univ Success Skills,0.44,0.36,0.08,0.04,0.08,0.0,0.0,0.0,cecelia hamby,CU-1010,2014
-CU,1010,005,Univ Success Skills,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,robert dav brackett,CU-1010,2014
-DANC,1600,001,Ballet Dance I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,cheryl hosler,DANC-1600,2014
-DPA,3070,001,Method 3d Production,0.43,0.3,0.04,0.04,0.13,0.0,0.0,0.04,virginia ba nearing,DPA-3070,2014
-DPA,4000,001,Tech Foundations I,0.08,0.17,0.33,0.0,0.08,0.0,0.0,0.33,christina sop joerg,DPA-4000,2014
-DPA,6000,001,Tech Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,christina sop joerg,DPA-6000,2014
-DPA,8600,001,Production Studio,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,DPA-8600,2014
-ECE,2010,001,Logic & Comp Device,0.16,0.3,0.28,0.13,0.09,0.0,0.0,0.05,william reid,ECE-2010,2014
-ECE,2010,002,Logic & Comp Device,0.62,0.24,0.1,0.0,0.05,0.0,0.0,0.0,william reid,ECE-2010,2014
-ECE,2020,001,Electric Circuits I,0.18,0.22,0.29,0.17,0.07,0.0,0.0,0.07,william harrell,ECE-2020,2014
-ECE,2020,002,Electric Circuits I,0.73,0.13,0.0,0.07,0.0,0.0,0.0,0.07,apoorva dee kapadia,ECE-2020,2014
-ECE,2070,001,Basic Electrical Eng,0.85,0.09,0.02,0.02,0.01,0.0,0.0,0.02,sung- kim,ECE-2070,2014
-ECE,2070,002,Basic Electrical Eng,0.4,0.23,0.13,0.1,0.08,0.0,0.0,0.06,surya sharma,ECE-2070,2014
-ECE,2070,003,Basic Electrical Eng,0.55,0.36,0.07,0.0,0.0,0.0,0.0,0.02,liang dong,ECE-2070,2014
-ECE,2080,001,Electrical Engineeri,0.85,0.05,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2080,2014
-ECE,2080,002,Electrical Engineeri,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,ECE-2080,2014
-ECE,2080,010,Electrical Engineeri,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2080,2014
-ECE,2080,011,Electrical Engineeri,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2080,2014
-ECE,2080,012,Electrical Engineeri,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,william harrell,ECE-2080,2014
-ECE,2080,013,Electrical Engineeri,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,ECE-2080,2014
-ECE,2090,001,Logic Lab,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,william harrell,ECE-2090,2014
-ECE,2090,003,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,william harrell,ECE-2090,2014
-ECE,2090,006,Logic Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2090,2014
-ECE,2090,014,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,william harrell,ECE-2090,2014
-ECE,2110,002,Elec Engr Lab I,0.65,0.15,0.0,0.0,0.05,0.0,0.0,0.15,william harrell,ECE-2110,2014
-ECE,2110,003,Elec Engr Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2110,2014
-ECE,2110,004,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,william harrell,ECE-2110,2014
-ECE,2110,005,Elec Engr Lab I,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,william harrell,ECE-2110,2014
-ECE,2110,006,Elec Engr Lab I,0.8,0.05,0.05,0.0,0.0,0.0,0.0,0.1,william harrell,ECE-2110,2014
-ECE,2110,008,Elec Engr Lab I,0.8,0.0,0.05,0.0,0.0,0.0,0.0,0.15,william harrell,ECE-2110,2014
-ECE,2110,009,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,ECE-2110,2014
-ECE,2110,010,Elec Engr Lab I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2110,2014
-ECE,2220,001,Syst Prog Concept,0.22,0.24,0.14,0.06,0.12,0.0,0.0,0.22,harlan russell,ECE-2220,2014
-ECE,2230,001,Comp Sys Eng,0.11,0.41,0.17,0.13,0.07,0.0,0.0,0.11,harlan russell,ECE-2230,2014
-ECE,2620,001,Elec Circuits II,0.47,0.25,0.25,0.02,0.02,0.0,0.0,0.0,michael bridgwood,ECE-2620,2014
-ECE,2720,001,Comp Organization,0.22,0.29,0.24,0.12,0.14,0.0,0.0,0.0,william reid,ECE-2720,2014
-ECE,2730,001,Computer Org Lab,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2730,2014
-ECE,2730,002,Computer Org Lab,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2730,2014
-ECE,2730,003,Computer Org Lab,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2730,2014
-ECE,3110,001,Electrical Engineeri,0.75,0.06,0.06,0.0,0.0,0.0,0.0,0.13,william harrell,ECE-3110,2014
-ECE,3110,002,Electrical Engineeri,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,william harrell,ECE-3110,2014
-ECE,3110,003,Electrical Engineeri,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,ECE-3110,2014
-ECE,3110,007,Electrical Engineeri,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-3110,2014
-ECE,3120,001,Electrical Engineeri,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-3120,2014
-ECE,3170,001,Rand Signal Analysis,0.25,0.51,0.18,0.02,0.04,0.0,0.0,0.02,stephen hubbard,ECE-3170,2014
-ECE,3200,001,Electronics I,0.34,0.36,0.15,0.07,0.05,0.0,0.0,0.03,stephen hubbard,ECE-3200,2014
-ECE,3210,001,Electronics II,0.2,0.2,0.41,0.11,0.05,0.0,0.0,0.02,stephen hubbard,ECE-3210,2014
-ECE,3220,001,Intro Operating Sys,0.3,0.1,0.05,0.15,0.3,0.0,0.0,0.1,jacob sorber,ECE-3220,2014
-ECE,3270,001,Dig Comp Design,0.11,0.21,0.18,0.14,0.25,0.0,0.0,0.11,melissa crawl smith,ECE-3270,2014
-ECE,3300,001,Signals & Systems,0.23,0.29,0.21,0.11,0.1,0.0,0.0,0.05,carl baum,ECE-3300,2014
-ECE,3300,002,Signals & Systems (H,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,daniel noneaker,ECE-3300,2014
-ECE,3520,001,Programming Systems,0.13,0.31,0.25,0.0,0.19,0.0,0.0,0.13,robert schalkoff,ECE-3520,2014
-ECE,3600,001,Elect Power Engr,0.18,0.26,0.26,0.08,0.19,0.0,0.0,0.03,andrew donal clarke,ECE-3600,2014
-ECE,3710,001,Microcontr Interface,0.38,0.25,0.29,0.03,0.01,0.0,0.0,0.03,william reid,ECE-3710,2014
-ECE,3800,001,Electromagnetics,0.41,0.17,0.11,0.1,0.14,0.0,0.0,0.07,anthony martin,ECE-3800,2014
-ECE,3810,001,Field Waves & Ckts,0.33,0.35,0.23,0.05,0.05,0.0,0.0,0.0,anthony martin,ECE-3810,2014
-ECE,4090,001,Cont & Discrete Sys,0.56,0.31,0.12,0.0,0.0,0.0,0.0,0.02,apoorva dee kapadia,ECE-4090,2014
-ECE,4180,001,Power Syst Analysis,0.48,0.22,0.3,0.0,0.0,0.0,0.0,0.0,elham makram,ECE-4180,2014
-ECE,4270,001,Communications Sys,0.23,0.35,0.28,0.08,0.03,0.0,0.0,0.04,madhabi manandhar,ECE-4270,2014
-ECE,4290,001,Organiz of Compu,0.29,0.36,0.29,0.07,0.0,0.0,0.0,0.0,hai ying shen,ECE-4290,2014
-ECE,4420,001,Knowledge Engr,0.38,0.31,0.08,0.08,0.0,0.0,0.0,0.15,robert schalkoff,ECE-4420,2014
-ECE,4490,001,Comp Ntwrk Security,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,richard brooks,ECE-4490,2014
-ECE,4610,001,Fundamentals of Sola,0.73,0.18,0.07,0.0,0.0,0.0,0.0,0.02,rajendra singh,ECE-4610,2014
-ECE,4730,001,Intro Parallel Sys,0.48,0.14,0.33,0.0,0.0,0.0,0.0,0.05,walter ligon,ECE-4730,2014
-ECE,4930,003,Power Electronics,0.36,0.27,0.36,0.0,0.0,0.0,0.0,0.0,keith corzine,ECE-4930,2014
-ECE,4950,001,Int Sys Design I,0.81,0.18,0.0,0.0,0.0,0.0,0.0,0.01,apoorva dee kapadia,ECE-4950,2014
-ECE,4960,001,Int Sys Design II,0.37,0.57,0.06,0.0,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2014
-ECE,6040,001,Semiconductor Device,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-6040,2014
-ECE,6420,001,Knowledge Engr,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,robert schalkoff,ECE-6420,2014
-ECE,6670,001,Intro to Dig Sig Pro,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,john gowdy,ECE-6670,2014
-ECE,6730,001,Intro Parallel Sys,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,walter ligon,ECE-6730,2014
-ECE,6930,001,Intro to Computer Vi,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,adam hoover,ECE-6930,2014
-ECE,6930,004,Optoelectronics and,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,lin zhu,ECE-6930,2014
-ECE,8010,001,Analysis of Lin Sys,0.47,0.37,0.17,0.0,0.0,0.0,0.0,0.0,richard groff,ECE-8010,2014
-ECE,8180,001,Rand Proc Appl Engr,0.38,0.38,0.19,0.0,0.0,0.0,0.0,0.06,carl baum,ECE-8180,2014
-ECE,8470,400,Digital Image Proc,0.43,0.37,0.1,0.0,0.0,0.0,0.0,0.1,stanley birchfield,ECE-8470,2014
-ECE,8540,001,Analysis of Tracking,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,adam hoover,ECE-8540,2014
-ECE,8930,005,CMOS RFIC,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,ECE-8930,2014
-ECE,8930,006,Computing Frontiers,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,ECE-8930,2014
-ECE,9910,032,Doctoral Dissertatio,0.0,0.0,0.0,0.0,0.0,0.44,0.56,0.0,hai ying shen,ECE-9910,2014
-ECON,2000,001,Economic Concepts,0.21,0.42,0.05,0.13,0.03,0.0,0.0,0.16,mallika garg,ECON-2000,2014
-ECON,2000,002,Economic Concepts,0.21,0.46,0.1,0.13,0.03,0.0,0.0,0.08,mallika garg,ECON-2000,2014
-ECON,2000,003,Economic Concepts,0.3,0.4,0.16,0.09,0.02,0.0,0.0,0.02,miren ivankovic,ECON-2000,2014
-ECON,2110,001,Principles of Microe,0.33,0.44,0.17,0.0,0.06,0.0,0.0,0.0,frederick hanssen,ECON-2110,2014
-ECON,2110,002,Principles of Microe,0.17,0.28,0.33,0.11,0.06,0.0,0.0,0.06,frederick hanssen,ECON-2110,2014
-ECON,2110,003,Principles of Microe,0.15,0.45,0.15,0.15,0.0,0.0,0.0,0.1,frederick hanssen,ECON-2110,2014
-ECON,2110,004,Principles of Microe,0.26,0.16,0.37,0.16,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2014
-ECON,2110,005,Principles of Microe,0.21,0.42,0.26,0.0,0.0,0.0,0.0,0.11,frederick hanssen,ECON-2110,2014
-ECON,2110,006,Principles of Microe,0.16,0.42,0.26,0.16,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2014
-ECON,2110,007,Principles of Microe,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,frederick hanssen,ECON-2110,2014
-ECON,2110,008,Principles of Microe,0.21,0.16,0.21,0.11,0.0,0.0,0.0,0.32,frederick hanssen,ECON-2110,2014
-ECON,2110,009,Principles of Microe,0.05,0.32,0.32,0.16,0.05,0.0,0.0,0.11,frederick hanssen,ECON-2110,2014
-ECON,2110,010,Principles of Microe,0.16,0.42,0.21,0.11,0.05,0.0,0.0,0.05,frederick hanssen,ECON-2110,2014
-ECON,2110,011,Principles of Microe,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2014
-ECON,2110,012,Principles of Microe,0.05,0.37,0.26,0.05,0.0,0.0,0.0,0.26,frederick hanssen,ECON-2110,2014
-ECON,2110,013,Principles of Microe,0.32,0.42,0.16,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2014
-ECON,2110,014,Principles of Microe,0.05,0.53,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2014
-ECON,2110,015,Principles of Microe,0.16,0.53,0.21,0.0,0.05,0.0,0.0,0.05,frederick hanssen,ECON-2110,2014
-ECON,2110,016,Principles of Microe,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2014
-ECON,2110,017,Principles of Microe,0.26,0.32,0.21,0.05,0.0,0.0,0.0,0.16,frederick hanssen,ECON-2110,2014
-ECON,2110,018,Principles of Microe,0.16,0.32,0.32,0.11,0.05,0.0,0.0,0.05,frederick hanssen,ECON-2110,2014
-ECON,2110,019,Principles of Microe,0.11,0.61,0.06,0.0,0.17,0.0,0.0,0.06,frederick hanssen,ECON-2110,2014
-ECON,2110,020,Principles of Microe,0.28,0.41,0.19,0.08,0.03,0.0,0.0,0.01,alexander fiore,ECON-2110,2014
-ECON,2110,021,Principles of Microe,0.26,0.33,0.3,0.08,0.01,0.0,0.0,0.01,timothy andr bersak,ECON-2110,2014
-ECON,2110,022,Principles of Microe,0.29,0.43,0.2,0.02,0.0,0.0,0.0,0.06,robert dew tollison,ECON-2110,2014
-ECON,2110,023,Principles of Microe,0.13,0.45,0.25,0.08,0.05,0.0,0.0,0.05,timothy jay bacon,ECON-2110,2014
-ECON,2110,024,Principles of Microe,0.26,0.36,0.25,0.1,0.02,0.0,0.0,0.02,adam millsap,ECON-2110,2014
-ECON,2110,025,Principles of Microe,0.28,0.33,0.23,0.13,0.0,0.0,0.0,0.03,timothy andr bersak,ECON-2110,2014
-ECON,2110,026,Principles of Microe,0.35,0.33,0.18,0.03,0.08,0.0,0.0,0.05,miren ivankovic,ECON-2110,2014
-ECON,2110,031,Principles of Microe,0.31,0.31,0.23,0.14,0.01,0.0,0.0,0.0,adam millsap,ECON-2110,2014
-ECON,2110,032,Principles of Microe,0.26,0.28,0.31,0.07,0.04,0.0,0.0,0.04,andew swanson,ECON-2110,2014
-ECON,2110,033,Principles of Microe,0.29,0.34,0.18,0.11,0.05,0.0,0.0,0.03,alexander fiore,ECON-2110,2014
-ECON,2110,034,Principles of Microe,0.31,0.36,0.29,0.02,0.0,0.0,0.0,0.02,amanda caitlin kerr,ECON-2110,2014
-ECON,2110,035,Principles of Microe,0.43,0.38,0.18,0.03,0.0,0.0,0.0,0.0,andew swanson,ECON-2110,2014
-ECON,2110,036,Principles of Microe,0.58,0.13,0.08,0.0,0.0,0.0,0.0,0.21,patrick warren,ECON-2110,2014
-ECON,2110,038,Principles of Microe,0.24,0.31,0.24,0.05,0.07,0.0,0.0,0.1,timothy jay bacon,ECON-2110,2014
-ECON,2120,001,Principles of Macro,0.12,0.17,0.38,0.14,0.05,0.0,0.0,0.14,ralph charles allen,ECON-2120,2014
-ECON,2120,002,Principles of Macro,0.24,0.33,0.26,0.02,0.07,0.0,0.0,0.09,peter david lorenz,ECON-2120,2014
-ECON,2120,003,Principles of Macro,0.2,0.3,0.2,0.05,0.08,0.0,0.0,0.18,ralph charles allen,ECON-2120,2014
-ECON,2120,004,Principles of Macro,0.16,0.42,0.24,0.07,0.02,0.0,0.0,0.09,peter david lorenz,ECON-2120,2014
-ECON,2120,005,Principles of Macro,0.29,0.38,0.18,0.12,0.0,0.0,0.0,0.03,yukun sun,ECON-2120,2014
-ECON,2120,006,Principles of Macro,0.2,0.43,0.23,0.07,0.07,0.0,0.0,0.0,yukun sun,ECON-2120,2014
-ECON,2120,007,Principles of Macro,0.23,0.48,0.18,0.03,0.05,0.0,0.0,0.05,danielle zanzalari,ECON-2120,2014
-ECON,2120,008,Principles of Macro,0.26,0.38,0.23,0.08,0.05,0.0,0.0,0.0,anne anders,ECON-2120,2014
-ECON,3020,001,Money and Banking,0.25,0.19,0.25,0.14,0.03,0.0,0.0,0.14,danielle zanzalari,ECON-3020,2014
-ECON,3060,001,Managerial Economics,0.38,0.46,0.04,0.04,0.04,0.0,0.0,0.04,jacob burgdorf,ECON-3060,2014
-ECON,3100,001,International Econ,0.2,0.37,0.16,0.12,0.02,0.0,0.0,0.14,ayse mujde erdogan,ECON-3100,2014
-ECON,3140,001,Intermediate Micro,0.16,0.3,0.27,0.14,0.0,0.0,0.0,0.14,robert kennet fleck,ECON-3140,2014
-ECON,3140,002,Intermediate Micro,0.27,0.29,0.17,0.08,0.06,0.0,0.0,0.13,molly espey,ECON-3140,2014
-ECON,3140,003,Intermediate Micro,0.24,0.27,0.22,0.08,0.08,0.0,0.0,0.1,robert kennet fleck,ECON-3140,2014
-ECON,3150,001,Intermediate Macro,0.33,0.22,0.31,0.0,0.06,0.0,0.0,0.08,sergey vla mityakov,ECON-3150,2014
-ECON,3150,002,Intermediate Macro,0.15,0.35,0.28,0.11,0.02,0.0,0.0,0.09,ayse mujde erdogan,ECON-3150,2014
-ECON,3190,001,Environmental Econ,0.22,0.43,0.22,0.08,0.0,0.0,0.0,0.05,molly espey,ECON-3190,2014
-ECON,3600,001,Public Choice,0.18,0.58,0.2,0.0,0.03,0.0,0.0,0.03,robert dew tollison,ECON-3600,2014
-ECON,3970,001,Creative Inq in Econ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,scott baier,ECON-3970,2014
-ECON,3970,001,Creative Inq in Econ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,raymond sauer,ECON-3970,2014
-ECON,3970,003,Creative Inq in Econ,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,scott baier,ECON-3970,2014
-ECON,3970,003,Creative Inq in Econ,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,raymond sauer,ECON-3970,2014
-ECON,4020,001,Law and Economics,0.26,0.43,0.12,0.05,0.05,0.0,0.0,0.1,howard ne bodenhorn,ECON-4020,2014
-ECON,4040,001,Comp Econ Systems,0.27,0.33,0.2,0.0,0.07,0.0,0.0,0.13,dar litsukova-bokar,ECON-4040,2014
-ECON,4050,001,Intro to Econometric,0.33,0.31,0.19,0.02,0.05,0.0,0.0,0.1,jaqueline oliveira,ECON-4050,2014
-ECON,4050,005,Intro to Econometric,0.42,0.08,0.08,0.08,0.17,0.0,0.0,0.17,scott barkowski,ECON-4050,2014
-ECON,4100,001,Economic Development,0.28,0.36,0.16,0.0,0.04,0.0,0.0,0.16,robert tamura,ECON-4100,2014
-ECON,4120,001,International Micro,0.5,0.38,0.06,0.0,0.03,0.0,0.0,0.03,scott baier,ECON-4120,2014
-ECON,4220,001,Monetary Economics,0.37,0.59,0.04,0.0,0.0,0.0,0.0,0.0,gerald dwyer,ECON-4220,2014
-ECON,4230,001,Economics of Health,0.17,0.39,0.22,0.11,0.06,0.0,0.0,0.06,daniel patri miller,ECON-4230,2014
-ECON,4240,001,Organization of Ind,0.41,0.35,0.18,0.0,0.06,0.0,0.0,0.0,daniel patri miller,ECON-4240,2014
-ECON,4350,001,Family Economics,0.44,0.16,0.2,0.0,0.16,0.0,0.0,0.04,jaqueline oliveira,ECON-4350,2014
-ECON,8010,001,Microeconomic Theory,0.33,0.38,0.29,0.0,0.0,0.0,0.0,0.0,william dougan,ECON-8010,2014
-ECON,8040,001,Applied Math Econ,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,curtis simon,ECON-8040,2014
-ECON,8060,001,Econometrics I,0.12,0.52,0.28,0.0,0.0,0.0,0.0,0.08,paul wayne wilson,ECON-8060,2014
-ECON,8230,001,Microecon Pub Pol,0.35,0.47,0.18,0.0,0.0,0.0,0.0,0.0,scott templeton,ECON-8230,2014
-ECON,8260,001,Econ Theory of Govt,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,ECON-8260,2014
-ECON,8550,001,Financial Economics,0.54,0.15,0.0,0.0,0.08,0.0,0.0,0.23,sergey vla mityakov,ECON-8550,2014
-ED,1050,003,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,patrick womac,ED-1050,2014
-ED,1050,008,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,rory phil tannebaum,ED-1050,2014
-ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen mich moysey,ED-3970,2014
-ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david matthew boyer,ED-3970,2014
-ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,penelope mar vargas,ED-3970,2014
-ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,ED-3970,2014
-ED,3970,012,Creative Inquiry in,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,joseph benedic ryan,ED-3970,2014
-ED,3970,012,Creative Inquiry in,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,deborah cadorette,ED-3970,2014
-ED,8380,402,Short Stories for Te,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,lienne federico,ED-8380,2014
-ED,8380,506,Literacy Lessons for,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,vicki steadman,ED-8380,2014
-ED,8380,510,Literacy Lessons for,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jennifer adams,ED-8380,2014
-ED,8380,511,Literacy Lessons for,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,jean ridley,ED-8380,2014
-EDC,3900,001,Skills for Stu Leads,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,mary price,EDC-3900,2014
-EDC,3900,001,Skills for Stu Leads,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,lloyd john  graham,EDC-3900,2014
-EDC,3900,002,Skills for Stu Leads,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mary price,EDC-3900,2014
-EDC,3900,002,Skills for Stu Leads,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2014
-EDC,8030,001,Stu Dev in Hi Ed,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,EDC-8030,2014
-EDC,8040,001,Theories Student Dev,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,EDC-8040,2014
-EDC,8040,002,Theories Student Dev,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,EDC-8040,2014
-EDC,8050,001,Clinical Mh Couns,0.91,0.05,0.0,0.0,0.05,0.0,0.0,0.0,david scott,EDC-8050,2014
-EDC,8440,001,Stu Affairs Intern,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,kristin walker,EDC-8440,2014
-EDC,8440,001,Stu Affairs Intern,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,tony cawthon,EDC-8440,2014
-EDEC,3000,001,Found Early Chld Ed,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,EDEC-3000,2014
-EDEC,4400,001,Early Childhood Engl,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-4400,2014
-EDEL,3100,002,Arts in Ele School,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,alison eliz leonard,EDEL-3100,2014
-EDEL,3210,001,Pe for the Elem Tchr,0.71,0.2,0.06,0.03,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2014
-EDEL,4010,002,Elem Field Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ann marie liebel,EDEL-4010,2014
-EDEL,4510,002,Elem Methods in Scie,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,EDEL-4510,2014
-EDEL,4870,002,Ele Meth Soc Studies,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,melinda spearman,EDEL-4870,2014
-EDF,3010,001,Principles of Americ,0.59,0.29,0.05,0.0,0.05,0.0,0.0,0.02,suzanne rosenblith,EDF-3010,2014
-EDF,3010,002,Principles of Americ,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,robert green,EDF-3010,2014
-EDF,3010,004,Principles of Americ,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,melinda spearman,EDF-3010,2014
-EDF,3020,001,Educ Psych,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,meihua qian,EDF-3020,2014
-EDF,3020,002,Educ Psych,0.23,0.57,0.06,0.11,0.0,0.0,0.0,0.03,penelope mar vargas,EDF-3020,2014
-EDF,3020,003,Educ Psych,0.16,0.58,0.16,0.06,0.03,0.0,0.0,0.0,penelope mar vargas,EDF-3020,2014
-EDF,3080,001,Classroom Assessment,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,EDF-3080,2014
-EDF,3080,002,Classroom Assessment,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,deborah switzer,EDF-3080,2014
-EDF,3200,001,History of US Educat,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,robert green,EDF-3200,2014
-EDF,3340,001,Child Growth and Dev,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,EDF-3340,2014
-EDF,3350,002,Adol Growth & Dev,0.52,0.39,0.0,0.04,0.0,0.0,0.0,0.04,david barrett,EDF-3350,2014
-EDF,4800,001,Digital Media & Lear,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,ryan visser,EDF-4800,2014
-EDF,4800,003,Digital Media & Lear,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2014
-EDF,4800,004,Digital Media & Lear,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2014
-EDF,6900,001,Classroom Management,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,alicia farr clinger,EDF-6900,2014
-EDF,8010,001,Human Growth and Dev,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jeromy blake snider,EDF-8010,2014
-EDF,8080,001,Ed Tests and Measure,0.5,0.33,0.04,0.0,0.08,0.0,0.0,0.04,william fisk,EDF-8080,2014
-EDF,8080,500,Ed Tests and Measure,0.7,0.1,0.05,0.0,0.1,0.0,0.0,0.05,deborah switzer,EDF-8080,2014
-EDF,8710,500,Cultural Diversity i,0.7,0.05,0.0,0.0,0.25,0.0,0.0,0.0,sus cridland-hughes,EDF-8710,2014
-EDF,9770,001,Multi Regress Ed Res,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david barrett,EDF-9770,2014
-EDF,9790,001,Qualitative Research,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,david matthew boyer,EDF-9790,2014
-EDL,7150,501,Sch & Comm Relations,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,frederick buskey,EDL-7150,2014
-EDL,8390,503,Research in Ed L,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,EDL-8390,2014
-EDL,8550,001,App Res & Eval in He,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michelle boettcher,EDL-8550,2014
-EDL,9000,400,Prin Edu Leadership,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,james satterfield,EDL-9000,2014
-EDL,9100,400,Intro Phd Seminar,0.59,0.18,0.0,0.0,0.0,0.0,0.0,0.24,jane lindle,EDL-9100,2014
-EDLT,4590,001,Teaching Reading Gra,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4590,2014
-EDLT,4600,001,Teaching Reading Gra,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,EDLT-4600,2014
-EDLT,4610,001,Content Area Rdg: 2-,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-4610,2014
-EDLT,4610,002,Content Area Rdg: 2-,0.63,0.19,0.13,0.06,0.0,0.0,0.0,0.0,pamela dunston,EDLT-4610,2014
-EDLT,4980,002,Secondary Content Ar,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,corrie leigh martin,EDLT-4980,2014
-EDLT,8100,500,Foundations: Reading,0.42,0.17,0.0,0.0,0.0,0.0,0.0,0.42,susan kin fullerton,EDLT-8100,2014
-EDLT,8640,400,Teaching Secondary S,0.71,0.07,0.07,0.0,0.14,0.0,0.0,0.0,corrie leigh martin,EDLT-8640,2014
-EDLT,8640,500,Teaching Secondary S,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8640,2014
-EDLT,8800,506,Reading Recovery Tea,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,EDLT-8800,2014
-EDLT,8800,511,Reading Recovery Tea,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,EDLT-8800,2014
-EDLT,8820,502,Read Recovery Practi,0.0,0.82,0.09,0.0,0.0,0.0,0.0,0.09,mia francesc riddle,EDLT-8820,2014
-EDLT,8820,506,Read Recovery Practi,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,EDLT-8820,2014
-EDLT,8820,511,Read Recovery Practi,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,EDLT-8820,2014
-EDML,8410,401,Adv Middle School Cu,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lienne federico,EDML-8410,2014
-EDSC,2260,001,Pr Apprch to Sec Alg,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,stacy megan che,EDSC-2260,2014
-EDSC,3240,001,Practicum Sec Engl,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,amy tali hallenbeck,EDSC-3240,2014
-EDSC,4260,001,Tchng Sec Math,0.56,0.25,0.13,0.0,0.06,0.0,0.0,0.0,dennis aminie kombe,EDSC-4260,2014
-EDSC,8610,001,Mthds & Strt Seconda,0.64,0.09,0.0,0.0,0.27,0.0,0.0,0.0,michelle patri cook,EDSC-8610,2014
-EDSP,3700,002,Intro to Special Ed,0.83,0.07,0.07,0.0,0.03,0.0,0.0,0.0,robin parks ennis,EDSP-3700,2014
-EDSP,3700,003,Intro to Special Ed,0.69,0.26,0.06,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,EDSP-3700,2014
-EDSP,3700,004,Intro to Special Ed,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,angelo vespe,EDSP-3700,2014
-EDSP,3720,001,Char & Instr Individ,0.9,0.0,0.05,0.0,0.05,0.0,0.0,0.0,catherine griffith,EDSP-3720,2014
-EDSP,3740,001,Char & Strat Emot/Be,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,robin parks ennis,EDSP-3740,2014
-EDSP,4920,001,Math Inst Ind W/Dis,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,pamela stecker,EDSP-4920,2014
-EDSP,4930,001,Clsrm/Beh Mgmt Sp Ed,0.75,0.13,0.08,0.0,0.0,0.0,0.0,0.04,joseph benedic ryan,EDSP-4930,2014
-EDSP,4940,001,Tchg Rdg Mild Dis,0.71,0.13,0.13,0.0,0.0,0.0,0.0,0.04,sara moo mackiewicz,EDSP-4940,2014
-EDSP,4970,001,Sec Meth Ind W/Dis,0.75,0.13,0.04,0.04,0.0,0.0,0.0,0.04,martha hodge,EDSP-4970,2014
-EDSP,8530,001,Legal/Pol Issu Sp Ed,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,antonis katsiyannis,EDSP-8530,2014
-EES,2010,001,Environ Engr Fundame,0.33,0.39,0.22,0.03,0.03,0.0,0.0,0.0,david freedman,EES-2010,2014
-EES,3030,001,Water Treatment Syst,0.3,0.57,0.14,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3030,2014
-EES,3040,001,Wastewater Treatment,0.35,0.54,0.11,0.0,0.0,0.0,0.0,0.0,david freedman,EES-3040,2014
-EES,3050,001,Water/Wastewater Tre,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2014
-EES,3050,001,Water/Wastewater Tre,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,david freedman,EES-3050,2014
-EES,3050,002,Water/Wastewater Tre,0.55,0.25,0.15,0.05,0.0,0.0,0.0,0.0,david freedman,EES-3050,2014
-EES,3050,002,Water/Wastewater Tre,0.55,0.25,0.15,0.05,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2014
-EES,4010,001,Environmental Engr,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,elizabeth carraway,EES-4010,2014
-EES,4010,002,Environmental Engr,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,mark schlautman,EES-4010,2014
-EES,4300,001,Air Pollution Engine,0.2,0.44,0.32,0.02,0.02,0.0,0.0,0.0,thomas overcamp,EES-4300,2014
-EES,4800,001,Environmental Risk A,0.24,0.28,0.28,0.1,0.07,0.0,0.0,0.03,timothy devol,EES-4800,2014
-EES,4860,001,Environmental Sustai,0.53,0.39,0.05,0.0,0.03,0.0,0.0,0.0,michael anthon dale,EES-4860,2014
-EES,6100,001,Environ Radiation Pr,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,EES-6100,2014
-EES,6800,001,Environmental Risk A,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,timothy devol,EES-6800,2014
-EES,8020,001,Environ Eng Prin,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,thomas overcamp,EES-8020,2014
-EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tanju karanfil,EES-8060,2014
-EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,thomas overcamp,EES-8060,2014
-EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,EES-8060,2014
-EES,8430,001,Environmental Chem,0.53,0.42,0.0,0.0,0.03,0.0,0.0,0.03,elizabeth carraway,EES-8430,2014
-EES,8510,001,Biol Prin Envir Engr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,EES-8510,2014
-ELE,3010,001,Intro to Entre,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,ELE-3010,2014
-ELE,3010,003,Intro to Entre,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,ELE-3010,2014
-ELE,4010,001,Exec Lead & Entr II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,ELE-4010,2014
-ENGL,1030,001,Accelerated Composit,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katrina torbert,ENGL-1030,2014
-ENGL,1030,002,Accelerated Comp,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,lauren taylo stukes,ENGL-1030,2014
-ENGL,1030,003,Accelerated Composit,0.21,0.37,0.21,0.11,0.0,0.0,0.0,0.11,chelsea mari clarey,ENGL-1030,2014
-ENGL,1030,004,Accelerated Composit,0.37,0.26,0.26,0.11,0.0,0.0,0.0,0.0,andrew mathas,ENGL-1030,2014
-ENGL,1030,005,Accelerated Composit,0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,andrew mathas,ENGL-1030,2014
-ENGL,1030,006,Accelerated Composit,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,chelsea mari clarey,ENGL-1030,2014
-ENGL,1030,007,Accelerated Composit,0.26,0.63,0.0,0.05,0.05,0.0,0.0,0.0,leslie ann salley,ENGL-1030,2014
-ENGL,1030,008,Accelerated Composit,0.42,0.21,0.21,0.05,0.0,0.0,0.0,0.11,joshua wood,ENGL-1030,2014
-ENGL,1030,009,Accelerated Composit,0.72,0.11,0.11,0.0,0.06,0.0,0.0,0.0,sarah ashto wickham,ENGL-1030,2014
-ENGL,1030,010,Accelerated Composit,0.16,0.58,0.16,0.0,0.11,0.0,0.0,0.0,leslie ann salley,ENGL-1030,2014
-ENGL,1030,011,Accelerated Composit,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,andrew mathas,ENGL-1030,2014
-ENGL,1030,012,Accelerated Composit,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,molly brian collins,ENGL-1030,2014
-ENGL,1030,013,Accelerated Composit,0.05,0.53,0.11,0.05,0.16,0.0,0.0,0.11,leslie ann salley,ENGL-1030,2014
-ENGL,1030,014,Accelerated Composit,0.44,0.28,0.22,0.06,0.0,0.0,0.0,0.0,justin all holliday,ENGL-1030,2014
-ENGL,1030,015,Accelerated Composit,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,molly brian collins,ENGL-1030,2014
-ENGL,1030,016,Accelerated Composit,0.61,0.06,0.11,0.0,0.17,0.0,0.0,0.06,joshua wood,ENGL-1030,2014
-ENGL,1030,017,Accelerated Composit,0.26,0.32,0.21,0.16,0.05,0.0,0.0,0.0,leslie ann salley,ENGL-1030,2014
-ENGL,1030,018,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,matthew mar russell,ENGL-1030,2014
-ENGL,1030,019,Accelerated Composit,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,joshua rya newberry,ENGL-1030,2014
-ENGL,1030,021,Accelerated Composit,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,ENGL-1030,2014
-ENGL,1030,022,Accelerated Composit,0.83,0.0,0.06,0.06,0.0,0.0,0.0,0.06,daniel frank,ENGL-1030,2014
-ENGL,1030,023,Accelerated Composit,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,matthew jose osborn,ENGL-1030,2014
-ENGL,1030,024,Accelerated Composit,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,matthew mar russell,ENGL-1030,2014
-ENGL,1030,025,Accelerated Composit,0.16,0.63,0.05,0.05,0.05,0.0,0.0,0.05,justin all holliday,ENGL-1030,2014
-ENGL,1030,026,Accelerated Composit,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-1030,2014
-ENGL,1030,027,Accelerated Composit,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,matthew jose osborn,ENGL-1030,2014
-ENGL,1030,028,Accelerated Composit,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,katherine hanzalik,ENGL-1030,2014
-ENGL,1030,029,Accelerated Composit,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,jarrod keit thacker,ENGL-1030,2014
-ENGL,1030,030,Accelerated Composit,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,kristen gay,ENGL-1030,2014
-ENGL,1030,031,Accelerated Composit,0.53,0.32,0.05,0.11,0.0,0.0,0.0,0.0,adrian carson,ENGL-1030,2014
-ENGL,1030,032,Accelerated Composit,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,hannah conl vaughan,ENGL-1030,2014
-ENGL,1030,033,Accelerated Composit,0.68,0.16,0.05,0.0,0.05,0.0,0.0,0.05,katherine elrick,ENGL-1030,2014
-ENGL,1030,034,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,ENGL-1030,2014
-ENGL,1030,035,Accelerated Composit,0.74,0.16,0.0,0.0,0.0,0.0,0.0,0.11,judith roxanne ball,ENGL-1030,2014
-ENGL,1030,036,Accelerated Composit,0.63,0.16,0.0,0.05,0.16,0.0,0.0,0.0,kristen gay,ENGL-1030,2014
-ENGL,1030,037,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,sarah ashto wickham,ENGL-1030,2014
-ENGL,1030,038,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,dustin cleag mosley,ENGL-1030,2014
-ENGL,1030,039,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,joshua rya newberry,ENGL-1030,2014
-ENGL,1030,040,Accelerated Composit,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,ENGL-1030,2014
-ENGL,1030,041,Accelerated Composit,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,katrina torbert,ENGL-1030,2014
-ENGL,1030,042,Accelerated Composit,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,katherine hanzalik,ENGL-1030,2014
-ENGL,1030,043,Accelerated Composit,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-1030,2014
-ENGL,1030,044,Accelerated Composit,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,daniel frank,ENGL-1030,2014
-ENGL,1030,045,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,adrian carson,ENGL-1030,2014
-ENGL,1030,046,Accelerated Composit,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,hannah conl vaughan,ENGL-1030,2014
-ENGL,1030,047,Accelerated Composit,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,katherine elrick,ENGL-1030,2014
-ENGL,1030,048,Accelerated Composit,0.26,0.42,0.21,0.0,0.11,0.0,0.0,0.0,lauren taylo stukes,ENGL-1030,2014
-ENGL,1030,049,Accelerated Composit,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,mari elena ramler,ENGL-1030,2014
-ENGL,1030,050,Accelerated Composit,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,dustin cleag mosley,ENGL-1030,2014
-ENGL,1030,051,Accelerated Composit,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,carlisle an sargent,ENGL-1030,2014
-ENGL,1030,052,Accelerated Composit,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,heathe christiansen,ENGL-1030,2014
-ENGL,1030,053,Accelerated Composit,0.63,0.32,0.0,0.05,0.0,0.0,0.0,0.0,stephanie mic heath,ENGL-1030,2014
-ENGL,1030,054,Accelerated Composit,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,allen swords,ENGL-1030,2014
-ENGL,1030,055,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,carlisle an sargent,ENGL-1030,2014
-ENGL,1030,056,Accelerated Composit,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,judith roxanne ball,ENGL-1030,2014
-ENGL,1030,057,Accelerated Composit,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,ENGL-1030,2014
-ENGL,1030,058,Accelerated Composit,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,hayley ren zertuche,ENGL-1030,2014
-ENGL,1030,059,Accelerated Composit,0.56,0.28,0.06,0.0,0.06,0.0,0.0,0.06,andrew mar barrocas,ENGL-1030,2014
-ENGL,1030,060,Accelerated Composit,0.29,0.41,0.12,0.06,0.12,0.0,0.0,0.0,hayley ren zertuche,ENGL-1030,2014
-ENGL,1030,061,Accelerated Composit,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sarah kath melchers,ENGL-1030,2014
-ENGL,1030,062,Accelerated Composit,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,mari elena ramler,ENGL-1030,2014
-ENGL,1030,063,Accelerated Composit,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,stephanie mic heath,ENGL-1030,2014
-ENGL,1030,064,Accelerated Composit,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,ENGL-1030,2014
-ENGL,1030,065,Accelerated Composit,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,sarah kath melchers,ENGL-1030,2014
-ENGL,1030,067,Accelerated Composit,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,ENGL-1030,2014
-ENGL,1030,068,Accelerated Composit,0.69,0.08,0.15,0.0,0.08,0.0,0.0,0.0,eda ozyesilpinar,ENGL-1030,2014
-ENGL,1030,069,Accelerated Composit,0.63,0.25,0.0,0.0,0.13,0.0,0.0,0.0,eda ozyesilpinar,ENGL-1030,2014
-ENGL,1030,500,Accelerated Composit,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-1030,2014
-ENGL,1030,501,Accelerated Composit,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,john conway,ENGL-1030,2014
-ENGL,2120,001,World Literature (MA,0.65,0.2,0.1,0.05,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-2120,2014
-ENGL,2120,002,World Literature (MA,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,andrew lemons,ENGL-2120,2014
-ENGL,2120,004,World Literature,0.66,0.21,0.07,0.0,0.0,0.0,0.0,0.07,lucian ghita,ENGL-2120,2014
-ENGL,2120,005,World Literature,0.71,0.11,0.04,0.0,0.04,0.0,0.0,0.11,david stubblefield,ENGL-2120,2014
-ENGL,2120,006,World Literature,0.22,0.48,0.11,0.0,0.0,0.0,0.0,0.19,karen kettnich,ENGL-2120,2014
-ENGL,2120,007,World Literature,0.36,0.32,0.14,0.11,0.0,0.0,0.0,0.07,karen kettnich,ENGL-2120,2014
-ENGL,2120,008,World Literature,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,lucian ghita,ENGL-2120,2014
-ENGL,2120,009,World Literature,0.35,0.46,0.12,0.0,0.04,0.0,0.0,0.04,andrew mathas,ENGL-2120,2014
-ENGL,2120,010,World Literature,0.15,0.5,0.12,0.08,0.04,0.0,0.0,0.12,david charles foltz,ENGL-2120,2014
-ENGL,2120,011,World Literature,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,allen swords,ENGL-2120,2014
-ENGL,2120,012,World Literature,0.62,0.34,0.03,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2120,2014
-ENGL,2120,013,World Literature,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-2120,2014
-ENGL,2120,014,World Literature,0.07,0.3,0.27,0.1,0.1,0.0,0.0,0.17,david charles foltz,ENGL-2120,2014
-ENGL,2120,015,World Literature,0.64,0.14,0.04,0.11,0.07,0.0,0.0,0.0,lauren woolbright,ENGL-2120,2014
-ENGL,2120,016,World Literature,0.61,0.18,0.07,0.04,0.07,0.0,0.0,0.04,lauren woolbright,ENGL-2120,2014
-ENGL,2120,018,World Literature,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2120,2014
-ENGL,2130,001,British Literature,0.82,0.11,0.04,0.04,0.0,0.0,0.0,0.0,sherri teres allred,ENGL-2130,2014
-ENGL,2130,002,British Literature,0.31,0.41,0.14,0.03,0.07,0.0,0.0,0.03,elizabeth stansell,ENGL-2130,2014
-ENGL,2130,003,British Literature,0.38,0.38,0.17,0.0,0.03,0.0,0.0,0.03,elizabeth stansell,ENGL-2130,2014
-ENGL,2130,004,British Literature,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,april susanne pelt,ENGL-2130,2014
-ENGL,2130,005,British Literature,0.82,0.11,0.0,0.0,0.0,0.0,0.0,0.07,april susanne pelt,ENGL-2130,2014
-ENGL,2130,007,British Literature,0.59,0.24,0.07,0.03,0.03,0.0,0.0,0.03,lucian ghita,ENGL-2130,2014
-ENGL,2130,009,British Literature,0.81,0.07,0.0,0.07,0.0,0.0,0.0,0.04,april susanne pelt,ENGL-2130,2014
-ENGL,2130,010,British Literature,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,april susanne pelt,ENGL-2130,2014
-ENGL,2130,011,British Literature,0.46,0.25,0.07,0.07,0.04,0.0,0.0,0.11,lucian ghita,ENGL-2130,2014
-ENGL,2130,012,British Literature,0.71,0.11,0.07,0.04,0.0,0.0,0.0,0.07,sherri teres allred,ENGL-2130,2014
-ENGL,2140,001,American Literature,0.48,0.45,0.0,0.0,0.07,0.0,0.0,0.0,melody fowl shirley,ENGL-2140,2014
-ENGL,2140,002,American Literature,0.39,0.25,0.29,0.04,0.04,0.0,0.0,0.0,melody fowl shirley,ENGL-2140,2014
-ENGL,2140,003,American Literature,0.14,0.36,0.36,0.0,0.09,0.0,0.0,0.05,barbara ramirez,ENGL-2140,2014
-ENGL,2140,005,American Literature,0.38,0.46,0.12,0.0,0.0,0.0,0.0,0.04,william stanton,ENGL-2140,2014
-ENGL,2140,006,American Literature,0.59,0.24,0.05,0.02,0.0,0.0,0.0,0.09, barton palmer,ENGL-2140,2014
-ENGL,2140,007,American Literature,0.34,0.52,0.03,0.07,0.0,0.0,0.0,0.03,john logan pursley,ENGL-2140,2014
-ENGL,2140,008,American Literature,0.44,0.3,0.19,0.0,0.04,0.0,0.0,0.04,william stanton,ENGL-2140,2014
-ENGL,2140,009,American Literature,0.14,0.41,0.17,0.07,0.17,0.0,0.0,0.03,john logan pursley,ENGL-2140,2014
-ENGL,2140,014,American Literature,0.18,0.39,0.25,0.07,0.07,0.0,0.0,0.04,meredith mccarroll,ENGL-2140,2014
-ENGL,2140,100,American Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,meredith mccarroll,ENGL-2140,2014
-ENGL,2150,001,Lit in 20th-21st Cen,0.07,0.67,0.19,0.0,0.0,0.0,0.0,0.07,amy monaghan,ENGL-2150,2014
-ENGL,2150,002,Lit in 20th-21st Cen,0.0,0.62,0.35,0.0,0.0,0.0,0.0,0.04,amy monaghan,ENGL-2150,2014
-ENGL,2150,003,Lit in 20th-21st Cen,0.17,0.55,0.14,0.03,0.03,0.0,0.0,0.07,sarah lauro,ENGL-2150,2014
-ENGL,2150,004,Lit in 20th-21st Cen,0.18,0.54,0.18,0.04,0.04,0.0,0.0,0.04,joshua nei waggoner,ENGL-2150,2014
-ENGL,2150,005,Lit in 20th-21st Cen,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,sarah lauro,ENGL-2150,2014
-ENGL,2150,006,Lit in 20th-21st Cen,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,william pulley,ENGL-2150,2014
-ENGL,2150,007,Lit in 20th-21st Cen,0.25,0.46,0.25,0.0,0.04,0.0,0.0,0.0,david charles foltz,ENGL-2150,2014
-ENGL,2150,008,Lit in 20th-21st Cen,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,alexander kudera,ENGL-2150,2014
-ENGL,2150,010,Lit in 20th-21st Cen,0.59,0.34,0.03,0.0,0.03,0.0,0.0,0.0,john morgenstern,ENGL-2150,2014
-ENGL,2150,011,Lit in 20th-21st Cen,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,john morgenstern,ENGL-2150,2014
-ENGL,2150,012,Lit in 20th-21st Cen,0.25,0.54,0.11,0.04,0.04,0.0,0.0,0.04,joshua nei waggoner,ENGL-2150,2014
-ENGL,2150,015,Lit in 20th-21st Cen,0.41,0.34,0.17,0.03,0.0,0.0,0.0,0.03,lindsay carr thomas,ENGL-2150,2014
-ENGL,2150,016,Lit in 20th-21st Cen,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,ENGL-2150,2014
-ENGL,2150,017,Lit in 20th-21st Cen,0.41,0.41,0.19,0.0,0.0,0.0,0.0,0.0,joshua nei waggoner,ENGL-2150,2014
-ENGL,2150,019,Lit in 20th-21st Cen,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,david charles foltz,ENGL-2150,2014
-ENGL,2150,020,Lit in 20th-21st Cen,0.56,0.4,0.0,0.0,0.0,0.0,0.0,0.04,garry bertholf,ENGL-2150,2014
-ENGL,2150,021,Lit in 20th-21st Cen,0.05,0.45,0.36,0.0,0.0,0.0,0.0,0.14,amy monaghan,ENGL-2150,2014
-ENGL,2150,100,20th - 21st Century,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sarah lauro,ENGL-2150,2014
-ENGL,3000,001,Professional Develop,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,cameron fa bushnell,ENGL-3000,2014
-ENGL,3040,002,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3040,2014
-ENGL,3040,003,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3040,2014
-ENGL,3040,004,Business Writing,0.33,0.44,0.17,0.0,0.0,0.0,0.0,0.06,megan no macalystre,ENGL-3040,2014
-ENGL,3040,005,Business Writing,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,ENGL-3040,2014
-ENGL,3040,011,Business Writing,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,sean williams,ENGL-3040,2014
-ENGL,3040,012,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexander kudera,ENGL-3040,2014
-ENGL,3040,013,Business Writing,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,sherri teres allred,ENGL-3040,2014
-ENGL,3040,015,Business Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,ENGL-3040,2014
-ENGL,3040,016,Business Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alexander kudera,ENGL-3040,2014
-ENGL,3100,001,Crit Writ Lit,0.44,0.22,0.17,0.0,0.0,0.0,0.0,0.17,david sweene coombs,ENGL-3100,2014
-ENGL,3100,002,Crit Writ Lit,0.26,0.37,0.21,0.0,0.05,0.0,0.0,0.11,erin marina goss,ENGL-3100,2014
-ENGL,3100,003,Crit Writ Lit,0.14,0.62,0.14,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,ENGL-3100,2014
-ENGL,3120,001,Advanced Composition,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2014
-ENGL,3120,002,Advanced Composition,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2014
-ENGL,3140,001,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2014
-ENGL,3140,002,Technical Writing,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,ENGL-3140,2014
-ENGL,3140,003,Technical Writing,0.29,0.29,0.12,0.06,0.06,0.0,0.0,0.18,katalin beck,ENGL-3140,2014
-ENGL,3140,004,Technical Writing,0.63,0.16,0.05,0.0,0.05,0.0,0.0,0.11,matthew schilleman,ENGL-3140,2014
-ENGL,3140,005,Technical Writing,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,meg woosley-goodman,ENGL-3140,2014
-ENGL,3140,006,Technical Writing,0.44,0.19,0.13,0.06,0.0,0.0,0.0,0.19,meg woosley-goodman,ENGL-3140,2014
-ENGL,3140,008,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,ENGL-3140,2014
-ENGL,3140,009,Technical Writing,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2014
-ENGL,3140,010,Technical Writing,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-3140,2014
-ENGL,3140,011,Technical Writing,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,david stubblefield,ENGL-3140,2014
-ENGL,3140,012,Technical Writing,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,katalin beck,ENGL-3140,2014
-ENGL,3140,013,Technical Writing,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2014
-ENGL,3140,014,Technical Writing,0.29,0.53,0.06,0.12,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2014
-ENGL,3140,015,Technical Writing,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,meg woosley-goodman,ENGL-3140,2014
-ENGL,3140,016,Technical Writing,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2014
-ENGL,3140,018,Technical Writing,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,megan eatman,ENGL-3140,2014
-ENGL,3140,019,Technical Writing,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,meg woosley-goodman,ENGL-3140,2014
-ENGL,3140,020,Technical Writing,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2014
-ENGL,3140,021,Technical Writing,0.39,0.28,0.11,0.0,0.06,0.0,0.0,0.17,matthew schilleman,ENGL-3140,2014
-ENGL,3140,400,Technical Writing (O,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-3140,2014
-ENGL,3140,401,Technical Writing (O,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-3140,2014
-ENGL,3150,003,Sci Writing & Comm,0.12,0.76,0.06,0.0,0.0,0.0,0.0,0.06,barbara ramirez,ENGL-3150,2014
-ENGL,3150,400,Sci Writing & Comm (,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2014
-ENGL,3150,401,Sci Writing & Comm (,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2014
-ENGL,3150,402,Sci Writing & Comm,0.53,0.13,0.07,0.2,0.07,0.0,0.0,0.0,carleton dew salley,ENGL-3150,2014
-ENGL,3320,001,Visual Communication,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,megan eatman,ENGL-3320,2014
-ENGL,3450,001,Structure of Fiction,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john logan pursley,ENGL-3450,2014
-ENGL,3450,002,Structure of Fiction,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-3450,2014
-ENGL,3460,002,Structure of Poetry,0.58,0.16,0.0,0.0,0.21,0.0,0.0,0.05,sharon kathl nalley,ENGL-3460,2014
-ENGL,3480,001,Structure Screenplay,0.72,0.17,0.06,0.0,0.06,0.0,0.0,0.0,joshua nei waggoner,ENGL-3480,2014
-ENGL,3490,001,Tech/Pop Imagination,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,matthew schilleman,ENGL-3490,2014
-ENGL,3530,001,Ethnic Am Lit,0.06,0.44,0.19,0.13,0.13,0.0,0.0,0.06,kimberly manganelli,ENGL-3530,2014
-ENGL,3560,001,Science Fiction,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,lindsay carr thomas,ENGL-3560,2014
-ENGL,3570,001,Film,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2014
-ENGL,3570,002,Film,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,agnieszka skrodzka,ENGL-3570,2014
-ENGL,3570,003,Film,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06, barton palmer,ENGL-3570,2014
-ENGL,3800,001,Women Writers,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-3800,2014
-ENGL,3850,001,Children's Lit,0.22,0.56,0.17,0.0,0.06,0.0,0.0,0.0,megan no macalystre,ENGL-3850,2014
-ENGL,3960,001,Brit Lit Survey I,0.3,0.35,0.3,0.0,0.0,0.0,0.0,0.05,brian mcgrath,ENGL-3960,2014
-ENGL,3960,002,Brit Lit Survey I,0.15,0.45,0.35,0.05,0.0,0.0,0.0,0.0,brian mcgrath,ENGL-3960,2014
-ENGL,3960,003,Brit Lit Survey I,0.15,0.4,0.35,0.05,0.0,0.0,0.0,0.05,brian mcgrath,ENGL-3960,2014
-ENGL,3970,001,Brit Lit Survey II,0.13,0.27,0.47,0.0,0.0,0.0,0.0,0.13,wayne chapman,ENGL-3970,2014
-ENGL,3980,001,Amer Lit Survey I,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,jonathan beec field,ENGL-3980,2014
-ENGL,3980,002,Amer Lit Survey I,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,rhondda robi thomas,ENGL-3980,2014
-ENGL,4030,001,Classics in Trans,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-4030,2014
-ENGL,4110,001,Shakespeare,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-4110,2014
-ENGL,4110,002,Shakespeare,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-4110,2014
-ENGL,4140,001,Milton,0.08,0.69,0.15,0.0,0.0,0.0,0.0,0.08,lee morrissey,ENGL-4140,2014
-ENGL,4180,001,English Novel,0.47,0.4,0.0,0.0,0.13,0.0,0.0,0.0,david sweene coombs,ENGL-4180,2014
-ENGL,4210,001,Amer Lit 1800-1899,0.27,0.45,0.09,0.0,0.09,0.0,0.0,0.09,dominic mastroianni,ENGL-4210,2014
-ENGL,4310,001,Modern Poetry,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,wayne chapman,ENGL-4310,2014
-ENGL,4340,001,Environmental Lit,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,sean morey,ENGL-4340,2014
-ENGL,4350,001,Literary Criticism,0.35,0.41,0.18,0.06,0.0,0.0,0.0,0.0,dominic mastroianni,ENGL-4350,2014
-ENGL,4420,001,Cultural Studies,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,garry bertholf,ENGL-4420,2014
-ENGL,4750,001,Writing for Media,0.39,0.39,0.11,0.06,0.0,0.0,0.0,0.06,gabriel and hankins,ENGL-4750,2014
-ENGL,4780,001,Digital Literacy,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,gabriel and hankins,ENGL-4780,2014
-ENGL,4820,001,Afr Am Lit to 1920,0.2,0.3,0.3,0.1,0.1,0.0,0.0,0.0,rhondda robi thomas,ENGL-4820,2014
-ENGL,4910,001,Classical Rhetoric,0.19,0.44,0.38,0.0,0.0,0.0,0.0,0.0,brian mcgrath,ENGL-4910,2014
-ENGL,4960,001,Senior Seminar,0.36,0.43,0.07,0.0,0.07,0.0,0.0,0.07,jonathan beec field,ENGL-4960,2014
-ENGL,4960,002,Senior Seminar,0.1,0.4,0.3,0.1,0.0,0.0,0.0,0.1,lee morrissey,ENGL-4960,2014
-ENGL,4960,003,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william stockton,ENGL-4960,2014
-ENGL,8000,001,Introduction to Rese,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,ENGL-8000,2014
-ENGL,8100,001,Literary Criticism &,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,angela naimou,ENGL-8100,2014
-ENGL,8310,002,Special Topics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,agnieszka skrodzka,ENGL-8310,2014
-ENGL,8520,001,Rhetoric & Prof Comm,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharon howard,ENGL-8520,2014
-ENGR,1050,005,Engr Discip & Skills,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,005,Engr Discip & Skills,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,john minor,ENGR-1050,2014
-ENGR,1050,007,Engr Discip & Skills,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1050,2014
-ENGR,1050,007,Engr Discip & Skills,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,009,Engr Discipline & Sk,0.27,0.33,0.2,0.07,0.05,0.0,0.0,0.08,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,009,Engr Discipline & Sk,0.27,0.33,0.2,0.07,0.05,0.0,0.0,0.08,john minor,ENGR-1050,2014
-ENGR,1050,011,Engr Discipline & Sk,0.27,0.3,0.18,0.06,0.05,0.0,0.0,0.14,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,011,Engr Discipline & Sk,0.27,0.3,0.18,0.06,0.05,0.0,0.0,0.14,ashley childers,ENGR-1050,2014
-ENGR,1050,013,Engr Discipl & Skill,0.3,0.46,0.15,0.04,0.0,0.0,0.0,0.04,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,013,Engr Discipl & Skill,0.3,0.46,0.15,0.04,0.0,0.0,0.0,0.04,john minor,ENGR-1050,2014
-ENGR,1050,015,Engr Discipl & Skill,0.28,0.23,0.43,0.02,0.02,0.0,0.0,0.02,christopher norfolk,ENGR-1050,2014
-ENGR,1050,015,Engr Discipl & Skill,0.28,0.23,0.43,0.02,0.02,0.0,0.0,0.02,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,017,Engr Discipline & Sk,0.23,0.31,0.25,0.08,0.08,0.0,0.0,0.05,william martin,ENGR-1050,2014
-ENGR,1050,017,Engr Discipline & Sk,0.23,0.31,0.25,0.08,0.08,0.0,0.0,0.05,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,019,Engr Discipline & Sk,0.21,0.27,0.24,0.05,0.1,0.0,0.0,0.14,steven brandon,ENGR-1050,2014
-ENGR,1050,019,Engr Discipline & Sk,0.21,0.27,0.24,0.05,0.1,0.0,0.0,0.14,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,021,Engr Discipline & Sk,0.24,0.41,0.24,0.03,0.02,0.0,0.0,0.06,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,021,Engr Discipline & Sk,0.24,0.41,0.24,0.03,0.02,0.0,0.0,0.06,ashley childers,ENGR-1050,2014
-ENGR,1050,025,Engr Discipline & Sk,0.17,0.38,0.24,0.05,0.05,0.0,0.0,0.12,sarah grigg,ENGR-1050,2014
-ENGR,1050,025,Engr Discipline & Sk,0.17,0.38,0.24,0.05,0.05,0.0,0.0,0.12,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,027,Engr Discipline & Sk,0.26,0.3,0.24,0.03,0.14,0.0,0.0,0.03,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,027,Engr Discipline & Sk,0.26,0.3,0.24,0.03,0.14,0.0,0.0,0.03,john minor,ENGR-1050,2014
-ENGR,1050,029,Engr Discipline & Sk,0.22,0.29,0.22,0.11,0.02,0.0,0.0,0.14,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,029,Engr Discipline & Sk,0.22,0.29,0.22,0.11,0.02,0.0,0.0,0.14,david ewing,ENGR-1050,2014
-ENGR,1050,031,Engr Discipline & Sk,0.23,0.41,0.21,0.02,0.05,0.0,0.0,0.09,william martin,ENGR-1050,2014
-ENGR,1050,031,Engr Discipline & Sk,0.23,0.41,0.21,0.02,0.05,0.0,0.0,0.09,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,033,Engr Discipline & Sk,0.22,0.32,0.21,0.11,0.03,0.0,0.0,0.11,matthew kent miller,ENGR-1050,2014
-ENGR,1050,033,Engr Discipline & Sk,0.22,0.32,0.21,0.11,0.03,0.0,0.0,0.11,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,034,Engr Discipl & Skill,0.38,0.36,0.09,0.09,0.04,0.0,0.0,0.04,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,034,Engr Discipl & Skill,0.38,0.36,0.09,0.09,0.04,0.0,0.0,0.04,steven brandon,ENGR-1050,2014
-ENGR,1050,050,Engr Discip & Skills,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1050,2014
-ENGR,1050,050,Engr Discip & Skills,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,056,Engr Discipl & Skill,0.2,0.38,0.16,0.02,0.02,0.0,0.0,0.22,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,056,Engr Discipl & Skill,0.2,0.38,0.16,0.02,0.02,0.0,0.0,0.22,john minor,ENGR-1050,2014
-ENGR,1050,058,Engr Discipl & Skill,0.37,0.33,0.16,0.05,0.0,0.0,0.0,0.09,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,058,Engr Discipl & Skill,0.37,0.33,0.16,0.05,0.0,0.0,0.0,0.09,john minor,ENGR-1050,2014
-ENGR,1050,060,Engr Discipl & Skill,0.27,0.31,0.27,0.04,0.02,0.0,0.0,0.09,william martin,ENGR-1050,2014
-ENGR,1050,060,Engr Discipl & Skill,0.27,0.31,0.27,0.04,0.02,0.0,0.0,0.09,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,062,Engr Discipl & Skill,0.23,0.45,0.16,0.05,0.02,0.0,0.0,0.09,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,062,Engr Discipl & Skill,0.23,0.45,0.16,0.05,0.02,0.0,0.0,0.09,christopher norfolk,ENGR-1050,2014
-ENGR,1050,064,Engr Discipl & Skill,0.17,0.57,0.09,0.09,0.02,0.0,0.0,0.06,steven brandon,ENGR-1050,2014
-ENGR,1050,064,Engr Discipl & Skill,0.17,0.57,0.09,0.09,0.02,0.0,0.0,0.06,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,111,Engr Discipline & Sk,0.08,0.33,0.35,0.08,0.15,0.0,0.0,0.02,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,111,Engr Discipline & Sk,0.08,0.33,0.35,0.08,0.15,0.0,0.0,0.02,john minor,ENGR-1050,2014
-ENGR,1050,112,Engr Discip & Skills,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,112,Engr Discip & Skills,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,ENGR-1050,2014
-ENGR,1050,113,Engr Discipline & Sk,0.15,0.24,0.26,0.13,0.19,0.0,0.0,0.03,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,113,Engr Discipline & Sk,0.15,0.24,0.26,0.13,0.19,0.0,0.0,0.03,richard watkins,ENGR-1050,2014
-ENGR,1050,117,Engr Discipline & Sk,0.15,0.26,0.29,0.08,0.1,0.0,0.0,0.13,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,119,Engr Discipline & Sk,0.27,0.32,0.17,0.02,0.03,0.0,0.0,0.19,matthew kent miller,ENGR-1050,2014
-ENGR,1050,119,Engr Discipline & Sk,0.27,0.32,0.17,0.02,0.03,0.0,0.0,0.19,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,400,Engr Discipline & Sk,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,elizabeth stephan,ENGR-1050,2014
-ENGR,1050,400,Engr Discipline & Sk,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,elizabeth stephan,ENGR-1050,2014
-ENGR,1060,005,Engr Discip & Skills,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,john minor,ENGR-1060,2014
-ENGR,1060,005,Engr Discip & Skills,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,007,Engr Discip & Skills,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,007,Engr Discip & Skills,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1060,2014
-ENGR,1060,009,Engr Discipline & Sk,0.02,0.17,0.29,0.14,0.06,0.0,0.0,0.31,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,011,Engr Discipline & Sk,0.17,0.28,0.34,0.06,0.02,0.0,0.0,0.13,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,011,Engr Discipline & Sk,0.17,0.28,0.34,0.06,0.02,0.0,0.0,0.13,ashley childers,ENGR-1060,2014
-ENGR,1060,012,Engr Discip & Skills,0.05,0.33,0.4,0.1,0.0,0.0,0.0,0.12,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,012,Engr Discip & Skills,0.05,0.33,0.4,0.1,0.0,0.0,0.0,0.12,john minor,ENGR-1060,2014
-ENGR,1060,013,Engr Discip & Skills,0.07,0.3,0.36,0.11,0.11,0.0,0.0,0.05,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,013,Engr Discip & Skills,0.07,0.3,0.36,0.11,0.11,0.0,0.0,0.05,christopher norfolk,ENGR-1060,2014
-ENGR,1060,014,Engr Discipline & Sk,0.15,0.35,0.2,0.2,0.05,0.0,0.0,0.05,william park,ENGR-1060,2014
-ENGR,1060,014,Engr Discipline & Sk,0.15,0.35,0.2,0.2,0.05,0.0,0.0,0.05,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,016,Engr Discipline & Sk,0.21,0.42,0.32,0.0,0.05,0.0,0.0,0.0,john minor,ENGR-1060,2014
-ENGR,1060,016,Engr Discipline & Sk,0.21,0.42,0.32,0.0,0.05,0.0,0.0,0.0,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,017,Engr Discipline & Sk,0.14,0.26,0.3,0.14,0.04,0.0,0.0,0.12,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,017,Engr Discipline & Sk,0.14,0.26,0.3,0.14,0.04,0.0,0.0,0.12,william martin,ENGR-1060,2014
-ENGR,1060,019,Engr Discipline & Sk,0.11,0.26,0.24,0.15,0.09,0.0,0.0,0.15,steven brandon,ENGR-1060,2014
-ENGR,1060,019,Engr Discipline & Sk,0.11,0.26,0.24,0.15,0.09,0.0,0.0,0.15,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,021,Engr Discipline & Sk,0.17,0.24,0.28,0.19,0.04,0.0,0.0,0.09,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,021,Engr Discipline & Sk,0.17,0.24,0.28,0.19,0.04,0.0,0.0,0.09,ashley childers,ENGR-1060,2014
-ENGR,1060,025,Engr Discipline & Sk,0.12,0.27,0.22,0.12,0.1,0.0,0.0,0.18,sarah grigg,ENGR-1060,2014
-ENGR,1060,025,Engr Discipline & Sk,0.12,0.27,0.22,0.12,0.1,0.0,0.0,0.18,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,027,Engr Discipline & Sk,0.1,0.31,0.31,0.19,0.06,0.0,0.0,0.04,john minor,ENGR-1060,2014
-ENGR,1060,027,Engr Discipline & Sk,0.1,0.31,0.31,0.19,0.06,0.0,0.0,0.04,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,029,Engr Discipline & Sk,0.16,0.23,0.35,0.14,0.07,0.0,0.0,0.05,david ewing,ENGR-1060,2014
-ENGR,1060,029,Engr Discipline & Sk,0.16,0.23,0.35,0.14,0.07,0.0,0.0,0.05,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,031,Engr Discipline & Sk,0.07,0.25,0.36,0.14,0.11,0.0,0.0,0.07,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,031,Engr Discipline & Sk,0.07,0.25,0.36,0.14,0.11,0.0,0.0,0.07,william martin,ENGR-1060,2014
-ENGR,1060,050,Engr Discip & Skills,0.59,0.28,0.03,0.03,0.0,0.0,0.0,0.07,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,050,Engr Discip & Skills,0.59,0.28,0.03,0.03,0.0,0.0,0.0,0.07,john minor,ENGR-1060,2014
-ENGR,1060,052,Engr Discip & Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1060,2014
-ENGR,1060,052,Engr Discip & Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,056,Engr Discip & Skills,0.06,0.48,0.21,0.12,0.0,0.0,0.0,0.12,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,056,Engr Discip & Skills,0.06,0.48,0.21,0.12,0.0,0.0,0.0,0.12,john minor,ENGR-1060,2014
-ENGR,1060,058,Engr Discip & Skills,0.16,0.43,0.3,0.03,0.0,0.0,0.0,0.08,john minor,ENGR-1060,2014
-ENGR,1060,058,Engr Discip & Skills,0.16,0.43,0.3,0.03,0.0,0.0,0.0,0.08,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,060,Engr Discip & Skills,0.03,0.38,0.24,0.19,0.05,0.0,0.0,0.11,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,060,Engr Discip & Skills,0.03,0.38,0.24,0.19,0.05,0.0,0.0,0.11,william martin,ENGR-1060,2014
-ENGR,1060,062,Engr Discip & Skills,0.05,0.32,0.41,0.08,0.08,0.0,0.0,0.05,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,062,Engr Discip & Skills,0.05,0.32,0.41,0.08,0.08,0.0,0.0,0.05,christopher norfolk,ENGR-1060,2014
-ENGR,1060,064,Engr Discip & Skills,0.08,0.53,0.18,0.13,0.03,0.0,0.0,0.05,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,064,Engr Discip & Skills,0.08,0.53,0.18,0.13,0.03,0.0,0.0,0.05,steven brandon,ENGR-1060,2014
-ENGR,1060,066,Engr Discipline & Sk,0.1,0.27,0.31,0.12,0.06,0.0,0.0,0.14,matthew kent miller,ENGR-1060,2014
-ENGR,1060,066,Engr Discipline & Sk,0.1,0.27,0.31,0.12,0.06,0.0,0.0,0.14,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,112,Engr Discip & Skills,0.53,0.4,0.03,0.0,0.0,0.0,0.0,0.03,steven brandon,ENGR-1060,2014
-ENGR,1060,112,Engr Discip & Skills,0.53,0.4,0.03,0.0,0.0,0.0,0.0,0.03,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,117,Engr Discipline & Sk,0.0,0.21,0.23,0.23,0.16,0.0,0.0,0.16,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,119,Engr Discipline & Sk,0.06,0.31,0.25,0.17,0.06,0.0,0.0,0.15,elizabeth stephan,ENGR-1060,2014
-ENGR,1060,119,Engr Discipline & Sk,0.06,0.31,0.25,0.17,0.06,0.0,0.0,0.15,matthew kent miller,ENGR-1060,2014
-ENGR,1060,170,Engr Discip & Skills,0.11,0.47,0.24,0.11,0.03,0.0,0.0,0.05,steven brandon,ENGR-1060,2014
-ENGR,1060,170,Engr Discip & Skills,0.11,0.47,0.24,0.11,0.03,0.0,0.0,0.05,elizabeth stephan,ENGR-1060,2014
-ENGR,1070,012,Programming & Prob S,0.08,0.19,0.29,0.16,0.08,0.0,0.0,0.19,david ewing,ENGR-1070,2014
-ENGR,1070,012,Programming & Prob S,0.08,0.19,0.29,0.16,0.08,0.0,0.0,0.19,john minor,ENGR-1070,2014
-ENGR,1070,018,Programming & Prob S,0.05,0.16,0.25,0.23,0.13,0.0,0.0,0.19,john minor,ENGR-1070,2014
-ENGR,1070,018,Programming & Prob S,0.05,0.16,0.25,0.23,0.13,0.0,0.0,0.19,david ewing,ENGR-1070,2014
-ENGR,1070,020,Programming & Prob S,0.02,0.14,0.34,0.16,0.2,0.0,0.0,0.14,william park,ENGR-1070,2014
-ENGR,1070,020,Programming & Prob S,0.02,0.14,0.34,0.16,0.2,0.0,0.0,0.14,david ewing,ENGR-1070,2014
-ENGR,1070,022,Program and Problem,0.02,0.2,0.24,0.11,0.22,0.0,0.0,0.22,william park,ENGR-1070,2014
-ENGR,1070,022,Program and Problem,0.02,0.2,0.24,0.11,0.22,0.0,0.0,0.22,david ewing,ENGR-1070,2014
-ENGR,1070,072,Program & Prob Solvi,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,david ewing,ENGR-1070,2014
-ENGR,1070,072,Program & Prob Solvi,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1070,2014
-ENGR,1080,018,Programming & Prob S,0.09,0.12,0.39,0.24,0.09,0.0,0.0,0.06,david ewing,ENGR-1080,2014
-ENGR,1080,018,Programming & Prob S,0.09,0.12,0.39,0.24,0.09,0.0,0.0,0.06,john minor,ENGR-1080,2014
-ENGR,1080,020,Programming & Prob S,0.24,0.18,0.33,0.15,0.09,0.0,0.0,0.0,john minor,ENGR-1080,2014
-ENGR,1080,020,Programming & Prob S,0.24,0.18,0.33,0.15,0.09,0.0,0.0,0.0,david ewing,ENGR-1080,2014
-ENGR,1080,022,Programming & Prob S,0.28,0.22,0.25,0.13,0.13,0.0,0.0,0.0,david ewing,ENGR-1080,2014
-ENGR,1080,022,Programming & Prob S,0.28,0.22,0.25,0.13,0.13,0.0,0.0,0.0,william park,ENGR-1080,2014
-ENGR,1080,056,Program/Prob Solving,0.04,0.43,0.13,0.13,0.26,0.0,0.0,0.0,william park,ENGR-1080,2014
-ENGR,1080,056,Program/Prob Solving,0.04,0.43,0.13,0.13,0.26,0.0,0.0,0.0,david ewing,ENGR-1080,2014
-ENGR,1080,072,Program/Prob Solving,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,david ewing,ENGR-1080,2014
-ENGR,1080,072,Program/Prob Solving,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1080,2014
-ENGR,1090,020,Prog/Problem Solving,0.28,0.48,0.2,0.03,0.0,0.0,0.0,0.03,david ewing,ENGR-1090,2014
-ENGR,1090,020,Prog/Problem Solving,0.28,0.48,0.2,0.03,0.0,0.0,0.0,0.03,john minor,ENGR-1090,2014
-ENGR,1090,024,Prog/Problem Solving,0.36,0.43,0.19,0.02,0.0,0.0,0.0,0.0,david ewing,ENGR-1090,2014
-ENGR,1090,024,Prog/Problem Solving,0.36,0.43,0.19,0.02,0.0,0.0,0.0,0.0,john minor,ENGR-1090,2014
-ENGR,1090,028,Prog/Problem Solving,0.43,0.33,0.17,0.07,0.0,0.0,0.0,0.0,david ewing,ENGR-1090,2014
-ENGR,1090,056,Prog/Problem Solv Ap,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1090,2014
-ENGR,1090,056,Prog/Problem Solv Ap,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,david ewing,ENGR-1090,2014
-ENGR,1900,013,CI in ENGR Architect,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christopher norfolk,ENGR-1900,2014
-ENGR,1900,013,CI in ENGR Architect,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1900,2014
-ENGR,1900,014,CI in ENGR Public Po,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,jonathan maier,ENGR-1900,2014
-ENGR,1900,014,CI in ENGR Public Po,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,christopher norfolk,ENGR-1900,2014
-ENGR,1900,017,CI  in ENGR What ENG,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,bradley putman,ENGR-1900,2014
-ENGR,1900,017,CI  in ENGR What ENG,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,jonathan maier,ENGR-1900,2014
-ENGR,1900,077,CI in ENGR Huan Powe,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,jonathan maier,ENGR-1900,2014
-ENGR,1900,077,CI in ENGR Huan Powe,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,gregory mocko,ENGR-1900,2014
-ENGR,2080,023,Engr Graphics & Mach,0.43,0.2,0.2,0.04,0.06,0.0,0.0,0.07,john minor,ENGR-2080,2014
-ENGR,2080,023,Engr Graphics & Mach,0.43,0.2,0.2,0.04,0.06,0.0,0.0,0.07,sarah grigg,ENGR-2080,2014
-ENGR,2080,028,Engr Graphics & Mach,0.3,0.39,0.11,0.01,0.09,0.0,0.0,0.09,sarah grigg,ENGR-2080,2014
-ENGR,2080,028,Engr Graphics & Mach,0.3,0.39,0.11,0.01,0.09,0.0,0.0,0.09,john minor,ENGR-2080,2014
-ENGR,2080,030,Engr Graphics & Mach,0.41,0.3,0.16,0.05,0.0,0.0,0.0,0.09,sarah grigg,ENGR-2080,2014
-ENGR,2080,030,Engr Graphics & Mach,0.41,0.3,0.16,0.05,0.0,0.0,0.0,0.09,john minor,ENGR-2080,2014
-ENGR,2080,053,Engr Graphics & Mach,0.28,0.32,0.19,0.02,0.11,0.0,0.0,0.09,sarah grigg,ENGR-2080,2014
-ENGR,2080,053,Engr Graphics & Mach,0.28,0.32,0.19,0.02,0.11,0.0,0.0,0.09,john minor,ENGR-2080,2014
-ENGR,2080,055,Engr Graphics & Mach,0.38,0.28,0.23,0.04,0.04,0.0,0.0,0.02,jonathan maier,ENGR-2080,2014
-ENGR,2080,055,Engr Graphics & Mach,0.38,0.28,0.23,0.04,0.04,0.0,0.0,0.02,sarah grigg,ENGR-2080,2014
-ENGR,2100,032,CAD & Engineering Ap,0.43,0.34,0.09,0.05,0.02,0.0,0.0,0.07,john minor,ENGR-2100,2014
-ENGR,2100,032,CAD & Engineering Ap,0.43,0.34,0.09,0.05,0.02,0.0,0.0,0.07,nighat yasmin,ENGR-2100,2014
-ENGR,2100,036,CAD & Engineering Ap,0.5,0.18,0.11,0.02,0.07,0.0,0.0,0.11,nighat yasmin,ENGR-2100,2014
-ENGR,2100,036,CAD & Engineering Ap,0.5,0.18,0.11,0.02,0.07,0.0,0.0,0.11,john minor,ENGR-2100,2014
-ENGR,2100,040,CAD & Engineering Ap,0.4,0.35,0.1,0.03,0.13,0.0,0.0,0.0,john minor,ENGR-2100,2014
-ENGR,2100,040,CAD & Engineering Ap,0.4,0.35,0.1,0.03,0.13,0.0,0.0,0.0,nighat yasmin,ENGR-2100,2014
-ENGR,2100,044,CAD & Engineering Ap,0.43,0.26,0.22,0.02,0.0,0.0,0.0,0.07,john minor,ENGR-2100,2014
-ENGR,2100,044,CAD & Engineering Ap,0.43,0.26,0.22,0.02,0.0,0.0,0.0,0.07,william martin,ENGR-2100,2014
-ENR,1010,001,Intro to Envir & Nat,0.7,0.17,0.06,0.02,0.04,0.0,0.0,0.02,alan johnson,ENR-1010,2014
-ENR,1010,001,Intro Env & Nat Rs I,0.7,0.17,0.06,0.02,0.04,0.0,0.0,0.02,alan johnson,ENR-1010,2014
-ENR,1010,002,Intro to Envir & Nat,0.65,0.12,0.1,0.06,0.04,0.0,0.0,0.02,alan johnson,ENR-1010,2014
-ENR,4290,001,Environ Law & Policy,0.47,0.38,0.09,0.03,0.03,0.0,0.0,0.0,alan johnson,ENR-4290,2014
-ENSP,2000,001,Intro Environ Sci,0.67,0.22,0.08,0.0,0.0,0.0,0.0,0.02,scott brame,ENSP-2000,2014
-ENSP,2000,002,Intro Environ Sci,0.66,0.28,0.04,0.0,0.02,0.0,0.0,0.0,minory nammouz,ENSP-2000,2014
-ENSP,2000,003,Intro Environ Sci,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2014
-ENSP,4000,001,Studies in En Sp,0.68,0.14,0.09,0.05,0.05,0.0,0.0,0.0,margaret thompson,ENSP-4000,2014
-ENT,2000,001,Six-Legged Science,0.71,0.13,0.08,0.0,0.0,0.0,0.0,0.08,suellen pometto,ENT-2000,2014
-ENT,2010,001,Selected Topics,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,joseph culin,ENT-2010,2014
-ENT,3010,001,Insect Biology & Div,0.33,0.33,0.17,0.0,0.17,0.0,0.0,0.0,eric benson,ENT-3010,2014
-ESED,8000,001,Seminar in Engr & Sc,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,julie patric martin,ESED-8000,2014
-ESED,8000,001,Seminar in Engr & Sc,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,karen ann high,ESED-8000,2014
-ESED,8200,001,Teaching Undergrad E,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,karen ann high,ESED-8200,2014
-ESED,8200,001,Teaching Undergrad E,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,ESED-8200,2014
-ESED,8750,001,Curr Issues in STEM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,ESED-8750,2014
-ESED,8750,001,Curr Issues in STEM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,karen ann high,ESED-8750,2014
-ETOX,4300,001,Toxicology,0.18,0.45,0.18,0.0,0.0,0.0,0.0,0.18,peter van den hurk,ETOX-4300,2014
-ETOX,6300,001,Toxicology,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,peter van den hurk,ETOX-6300,2014
-FCS,8130,003,Research Methods in,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,natallia ser sianko,FCS-8130,2014
-FCS,8130,003,Research Methods in,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,FCS-8130,2014
-FDSC,1010,001,Intro to Food Sci &,0.69,0.25,0.02,0.01,0.04,0.0,0.0,0.0,rita haliena,FDSC-1010,2014
-FDSC,1010,001,Intro to Food Sci &,0.69,0.25,0.02,0.01,0.04,0.0,0.0,0.0,aubrey dean coffee,FDSC-1010,2014
-FDSC,3010,001,Food Regulations,0.75,0.2,0.0,0.03,0.0,0.0,0.0,0.03,julie kat northcutt,FDSC-3010,2014
-FDSC,3060,001,Institutional Foodse,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,FDSC-3060,2014
-FDSC,3070,001,Restaurant Food Serv,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,margaret condrasky,FDSC-3070,2014
-FDSC,4010,001,Food Chem I,0.78,0.16,0.03,0.01,0.0,0.0,0.0,0.01,ronnie thomas,FDSC-4010,2014
-FDSC,4040,001,Food Prsv & Process,0.28,0.51,0.18,0.03,0.0,0.0,0.0,0.0,julie kat northcutt,FDSC-4040,2014
-FDSC,4070,001,Quantity Food Produc,0.43,0.49,0.06,0.01,0.0,0.0,0.0,0.01,heather batt,FDSC-4070,2014
-FDSC,4170,001,Seminar,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,aubrey dean coffee,FDSC-4170,2014
-FDSC,4300,001,Dairy Process & Sant,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,FDSC-4300,2014
-FDSC,8120,001,Microbial Food Syst,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,xiuping jiang,FDSC-8120,2014
-FIN,3040,001,Risk & Insurance,0.0,0.38,0.38,0.08,0.15,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2014
-FIN,3040,002,Risk & Insurance,0.21,0.32,0.34,0.11,0.0,0.0,0.0,0.03,kerri mcmillan,FIN-3040,2014
-FIN,3050,001,Investment Analysis,0.16,0.47,0.23,0.09,0.0,0.0,0.0,0.05,kerri mcmillan,FIN-3050,2014
-FIN,3050,002,Investment Analysis,0.22,0.41,0.27,0.07,0.02,0.0,0.0,0.02,kerri mcmillan,FIN-3050,2014
-FIN,3050,003,Investment Analysis,0.1,0.26,0.19,0.1,0.07,0.0,0.0,0.28,john alexander,FIN-3050,2014
-FIN,3060,002,Corporation Finance,0.11,0.19,0.53,0.08,0.03,0.0,0.0,0.06,john harris,FIN-3060,2014
-FIN,3060,003,Corporation Finance,0.08,0.57,0.28,0.06,0.0,0.0,0.0,0.02,neil waller,FIN-3060,2014
-FIN,3060,004,Corporation Finance,0.23,0.48,0.15,0.08,0.03,0.0,0.0,0.05,john harris,FIN-3060,2014
-FIN,3060,005,Corporation Finance,0.08,0.62,0.23,0.08,0.0,0.0,0.0,0.0,neil waller,FIN-3060,2014
-FIN,3060,006,Corporation Finance,0.07,0.2,0.49,0.07,0.05,0.0,0.0,0.12,john harris,FIN-3060,2014
-FIN,3060,007,Corporation Finance,0.16,0.51,0.24,0.08,0.0,0.0,0.0,0.02,neil waller,FIN-3060,2014
-FIN,3060,008,Corporation Finance,0.28,0.3,0.07,0.17,0.09,0.0,0.0,0.09,william hol johnson,FIN-3060,2014
-FIN,3060,009,Corporation Finance,0.22,0.38,0.25,0.0,0.03,0.0,0.0,0.13,john harris,FIN-3060,2014
-FIN,3060,010,Corporation Finance,0.28,0.2,0.28,0.13,0.03,0.0,0.0,0.1,william hol johnson,FIN-3060,2014
-FIN,3060,011,Corporation Finance,0.3,0.28,0.17,0.11,0.06,0.0,0.0,0.09,william hol johnson,FIN-3060,2014
-FIN,3070,001,Prin of Real Estate,0.15,0.4,0.32,0.09,0.02,0.0,0.0,0.02,thomas springer,FIN-3070,2014
-FIN,3070,002,Prin of Real Estate,0.15,0.44,0.33,0.04,0.04,0.0,0.0,0.0,thomas springer,FIN-3070,2014
-FIN,3080,001,Fin Inst & Mkts,0.23,0.37,0.2,0.13,0.03,0.0,0.0,0.03,daniel thoma greene,FIN-3080,2014
-FIN,3080,002,Fin Inst & Mkts,0.13,0.3,0.4,0.08,0.08,0.0,0.0,0.03,michael spivey,FIN-3080,2014
-FIN,3080,003,Fin Inst & Mkts,0.21,0.36,0.29,0.07,0.02,0.0,0.0,0.05,michael spivey,FIN-3080,2014
-FIN,3110,001,Financial Management,0.17,0.26,0.33,0.17,0.0,0.0,0.0,0.07,jared daniel smith,FIN-3110,2014
-FIN,3110,002,Financial Management,0.17,0.34,0.37,0.07,0.05,0.0,0.0,0.0,jared daniel smith,FIN-3110,2014
-FIN,3110,003,Financial Management,0.3,0.34,0.16,0.11,0.05,0.0,0.0,0.05,fei xie,FIN-3110,2014
-FIN,3110,004,Financial Management,0.3,0.43,0.18,0.02,0.02,0.0,0.0,0.05,fei xie,FIN-3110,2014
-FIN,3120,001,Financial Mgt II,0.09,0.31,0.38,0.16,0.0,0.0,0.0,0.06,lyudmila chernykh,FIN-3120,2014
-FIN,3120,002,Financial Mgt II,0.32,0.38,0.22,0.05,0.0,0.0,0.0,0.03,lyudmila chernykh,FIN-3120,2014
-FIN,3120,003,Financial Mgt II,0.53,0.19,0.16,0.02,0.02,0.0,0.0,0.07,melvin stith,FIN-3120,2014
-FIN,3120,004,Financial Mgt II,0.72,0.11,0.15,0.02,0.0,0.0,0.0,0.0,melvin stith,FIN-3120,2014
-FIN,4020,001,Corporate Valuation,0.35,0.28,0.25,0.13,0.0,0.0,0.0,0.0,angela morgan,FIN-4020,2014
-FIN,4020,003,Corporate Valuation,0.07,0.4,0.38,0.1,0.02,0.0,0.0,0.02,angela morgan,FIN-4020,2014
-FIN,4050,001,Port Mgt and Theory,0.14,0.18,0.39,0.14,0.0,0.0,0.0,0.14,john alexander,FIN-4050,2014
-FIN,4060,001,Derivatives Analysis,0.21,0.38,0.25,0.04,0.04,0.0,0.0,0.08,george bra lockhart,FIN-4060,2014
-FIN,4110,001,Int Fin Mgt,0.25,0.33,0.3,0.05,0.03,0.0,0.0,0.05,tilan tang,FIN-4110,2014
-FIN,4110,002,Int Fin Mgt,0.47,0.16,0.16,0.05,0.05,0.0,0.0,0.11,tilan tang,FIN-4110,2014
-FIN,4170,001,Real Estate Finance,0.36,0.36,0.27,0.0,0.0,0.0,0.0,0.0,neil waller,FIN-4170,2014
-FNR,2040,001,Soil Information Sys,0.72,0.22,0.03,0.02,0.0,0.0,0.0,0.02,elena mikhailova,FNR-2040,2014
-FOR,2050,001,Dendrology,0.25,0.31,0.19,0.16,0.09,0.0,0.0,0.0,donald hagan,FOR-2050,2014
-FOR,2050,002,Dendrology,0.18,0.24,0.35,0.24,0.0,0.0,0.0,0.0,donald hagan,FOR-2050,2014
-FOR,2050,003,Dendrology,0.31,0.23,0.2,0.11,0.09,0.0,0.0,0.06,donald hagan,FOR-2050,2014
-FOR,2210,001,Forest Biology,0.46,0.4,0.09,0.02,0.01,0.0,0.0,0.01,patrick mcmillan,FOR-2210,2014
-FOR,3020,001,Forest Biometrics,0.41,0.23,0.18,0.14,0.05,0.0,0.0,0.0,lawrence gering,FOR-3020,2014
-FOR,3040,001,Forest Res Econ,0.38,0.24,0.24,0.11,0.03,0.0,0.0,0.0,john edward hatcher,FOR-3040,2014
-FOR,4100,001,Harvesting Processes,0.36,0.27,0.27,0.09,0.0,0.0,0.0,0.0,greg yarrow,FOR-4100,2014
-FOR,4130,001,Int Forest Pest Mgmt,0.22,0.39,0.3,0.09,0.0,0.0,0.0,0.0,robert bellinger,FOR-4130,2014
-FOR,4130,001,Int Forest Pest Mgmt,0.22,0.39,0.3,0.09,0.0,0.0,0.0,0.0,julia loui kerrigan,FOR-4130,2014
-FOR,4160,001,For Pol and Adm,0.45,0.4,0.14,0.02,0.0,0.0,0.0,0.0,thomas straka,FOR-4160,2014
-FOR,4170,001,For Res Mgt and Reg,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,john edward hatcher,FOR-4170,2014
-FOR,4310,001,Mgt for Recreation,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert baxte powell,FOR-4310,2014
-FOR,4340,001,GIS for Landscape Pl,0.5,0.46,0.02,0.0,0.02,0.0,0.0,0.0,christopher post,FOR-4340,2014
-FOR,4930,200,Wildland and Prescri,0.45,0.34,0.0,0.0,0.07,0.0,0.0,0.14,donald hagan,FOR-4930,2014
-FR,1010,001,Elementary French,0.74,0.16,0.0,0.05,0.05,0.0,0.0,0.0,amy lyn grif sawyer,FR-1010,2014
-FR,1020,001,Elementary French,0.75,0.15,0.0,0.05,0.0,0.0,0.0,0.05,amy lyn grif sawyer,FR-1020,2014
-FR,1020,002,Elementary French,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2014
-FR,1020,003,Elementary French,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,julian hamil killey,FR-1020,2014
-FR,2010,001,Intermediate French,0.56,0.22,0.11,0.06,0.0,0.0,0.0,0.06,joseph mai,FR-2010,2014
-FR,2010,002,Intermediate French,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,kenneth dav widgren,FR-2010,2014
-FR,2010,003,Intermediate French,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-2010,2014
-FR,2010,004,Intermediate French,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,julian hamil killey,FR-2010,2014
-FR,2020,001,Intermediate French,0.85,0.0,0.1,0.0,0.0,0.0,0.0,0.05,amy lyn grif sawyer,FR-2020,2014
-FR,2020,002,Intermediate French,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,FR-2020,2014
-FR,2020,003,Intermediate French,0.35,0.29,0.24,0.0,0.0,0.0,0.0,0.12,kenneth dav widgren,FR-2020,2014
-FR,3040,001,French Short Story,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,eric touya,FR-3040,2014
-FR,3050,001,Int Fr Con & Comp I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-3050,2014
-FR,3070,001,French Civilization,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-3070,2014
-FR,4160,001,Fr for Intl Trade II,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,eric touya,FR-4160,2014
-GC,1010,001,Orientation to G C,0.78,0.14,0.08,0.0,0.0,0.0,0.0,0.0,rebecca suza edlein,GC-1010,2014
-GC,1010,002,Orientation to G C,0.8,0.1,0.04,0.02,0.02,0.0,0.0,0.02,kern cox,GC-1010,2014
-GC,1020,001,Comp Art & Cad Found,0.42,0.35,0.15,0.04,0.04,0.0,0.0,0.0,charles tabor weiss,GC-1020,2014
-GC,1020,002,Comp Art & Cad Found,0.52,0.45,0.0,0.0,0.0,0.0,0.0,0.03,nona woolbright,GC-1020,2014
-GC,1020,003,Comp Art & Cad Found,0.62,0.31,0.0,0.0,0.07,0.0,0.0,0.0,nona woolbright,GC-1020,2014
-GC,1020,004,Comp Art & Cad Found,0.42,0.38,0.12,0.0,0.08,0.0,0.0,0.0,carol jones,GC-1020,2014
-GC,1030,001,G C I for Pkgsc,0.29,0.38,0.24,0.05,0.0,0.0,0.0,0.05,john jacobs,GC-1030,2014
-GC,1040,001,Graphic Com I,0.56,0.29,0.09,0.0,0.03,0.0,0.0,0.03,rebecca suza edlein,GC-1040,2014
-GC,1040,001,Graphic Communicatio,0.56,0.29,0.09,0.0,0.03,0.0,0.0,0.03,rebecca suza edlein,GC-1040,2014
-GC,1990,003,Cr Inquiry in G C I-,0.86,0.05,0.0,0.0,0.05,0.0,0.0,0.05,janice ann lay,GC-1990,2014
-GC,2070,001,Graphic Communicatio,0.5,0.38,0.09,0.0,0.03,0.0,0.0,0.0,patrick gee rose,GC-2070,2014
-GC,3400,001,Digital Img & Emedia,0.6,0.29,0.07,0.02,0.02,0.0,0.0,0.0,erica black walker,GC-3400,2014
-GC,4060,001,Package and Specialt,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,kern cox,GC-4060,2014
-GC,4400,001,Commercial Printing,0.29,0.67,0.0,0.0,0.04,0.0,0.0,0.0,eric weisenmiller,GC-4400,2014
-GC,4400,002,Commercial Printing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,GC-4400,2014
-GC,4440,001,Current Dev in G C,0.38,0.47,0.09,0.03,0.03,0.0,0.0,0.0,liam henry 'hara,GC-4440,2014
-GC,4460,001,Ink & Substrates,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,liam henry 'hara,GC-4460,2014
-GC,4460,002,Ink & Substrates,0.08,0.31,0.23,0.23,0.15,0.0,0.0,0.0,liam henry 'hara,GC-4460,2014
-GC,4480,001,Plan and Cont Print,0.5,0.33,0.13,0.03,0.0,0.0,0.0,0.0,john leininger,GC-4480,2014
-GC,4900,230,G C Selected Topics-,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,john leininger,GC-4900,2014
-GC,6900,002,G C Selected Topics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,GC-6900,2014
-GEN,1030,001,Careers in Bioch/Gen,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,alison starr-moss,GEN-1030,2014
-GEN,3000,001,Fundamental Genetics,0.28,0.3,0.18,0.14,0.01,0.0,0.0,0.09,kate leanne wi tsai,GEN-3000,2014
-GEN,3000,002,Fundamental Genetics,0.34,0.37,0.19,0.05,0.01,0.0,0.0,0.04,kate leanne wi tsai,GEN-3000,2014
-GEN,3020,001,Molecular & General,0.23,0.37,0.25,0.06,0.04,0.0,0.0,0.06,liangjiang wang,GEN-3020,2014
-GEN,3020,001,Molecular & General,0.23,0.37,0.25,0.06,0.04,0.0,0.0,0.06,lukasz kozubowski,GEN-3020,2014
-GEN,3020,002,Molec & General Gene,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,GEN-3020,2014
-GEN,3020,002,Molec & General Gene,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,GEN-3020,2014
-GEN,3030,001,Molec & General Gene,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,liangjiang wang,GEN-3030,2014
-GEN,3030,001,Molec & General Gene,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,GEN-3030,2014
-GEN,3030,002,Molec & General Gene,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,lukasz kozubowski,GEN-3030,2014
-GEN,3030,002,Mol Gen Genet Lab,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,lukasz kozubowski,GEN-3030,2014
-GEN,3030,002,Molec & General Gene,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,liangjiang wang,GEN-3030,2014
-GEN,3030,002,Mol Gen Genet Lab,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,liangjiang wang,GEN-3030,2014
-GEN,3030,003,Molec & General Gene,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,GEN-3030,2014
-GEN,3030,003,Molec & General Gene,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,GEN-3030,2014
-GEN,3030,004,Molec & General Gene,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lukasz kozubowski,GEN-3030,2014
-GEN,3030,004,Mol Gen Genet Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lukasz kozubowski,GEN-3030,2014
-GEN,3030,004,Molec & General Gene,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,liangjiang wang,GEN-3030,2014
-GEN,3030,004,Mol Gen Genet Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,liangjiang wang,GEN-3030,2014
-GEN,4200,001,Molecular Genetics &,0.33,0.33,0.26,0.0,0.0,0.0,0.0,0.07,julia frugoli,GEN-4200,2014
-GEN,4200,002,Molecular Genetics &,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,GEN-4200,2014
-GEN,4210,002,Mol Gen Gene Reg Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,GEN-4210,2014
-GEN,4210,003,Mol Gen Gene Reg Lab,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,julia frugoli,GEN-4210,2014
-GEN,4210,004,Mol Gen Gene Reg Lab,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,julia frugoli,GEN-4210,2014
-GEN,4400,001,Bioinformatics,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,GEN-4400,2014
-GEN,4500,001,Comparative Genetics,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,leigh anne clark,GEN-4500,2014
-GEN,6400,001,Bioinformatics,0.63,0.25,0.0,0.0,0.13,0.0,0.0,0.0,frank alexan feltus,GEN-6400,2014
-GEN,8140,001,Advanced Genetics,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kate leanne wi tsai,GEN-8140,2014
-GEOG,1010,001,Intro to Geography,0.33,0.33,0.23,0.1,0.03,0.0,0.0,0.0,christa smith,GEOG-1010,2014
-GEOG,1030,001,World Regional Geog,0.76,0.14,0.03,0.02,0.02,0.0,0.0,0.02,lance forres howard,GEOG-1030,2014
-GEOG,1030,002,World Regional Geog,0.35,0.35,0.2,0.05,0.0,0.0,0.0,0.05,william churc terry,GEOG-1030,2014
-GEOG,1030,003,World Regional Geog,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,david doran,GEOG-1030,2014
-GEOG,1030,004,World Regional Geog,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david doran,GEOG-1030,2014
-GEOG,3400,001,Geog of Latin Amer,0.27,0.27,0.36,0.0,0.09,0.0,0.0,0.0,william churc terry,GEOG-3400,2014
-GEOL,1010,001,Physical Geology,0.18,0.29,0.21,0.15,0.07,0.0,0.0,0.09,alan coulson,GEOL-1010,2014
-GEOL,1010,002,Physical Geology,0.26,0.28,0.22,0.11,0.06,0.0,0.0,0.07,alan coulson,GEOL-1010,2014
-GEOL,1010,003,Physical Geology,0.37,0.35,0.24,0.04,0.0,0.0,0.0,0.0,stephen mich moysey,GEOL-1010,2014
-GEOL,1030,001,Physical Geol Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2014
-GEOL,1030,002,Physical Geol Lab,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,003,Physical Geol Lab,0.09,0.22,0.39,0.13,0.13,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,004,Physical Geol Lab,0.63,0.25,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2014
-GEOL,1030,005,Physical Geol Lab,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2014
-GEOL,1030,006,Physical Geol Lab,0.17,0.52,0.17,0.09,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,007,Physical Geol Lab,0.21,0.46,0.17,0.0,0.0,0.0,0.0,0.17,alan coulson,GEOL-1030,2014
-GEOL,1030,008,Physical Geol Lab,0.25,0.63,0.04,0.0,0.04,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,009,Physical Geol Lab,0.13,0.38,0.25,0.04,0.0,0.0,0.0,0.21,alan coulson,GEOL-1030,2014
-GEOL,1030,010,Physical Geol Lab,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2014
-GEOL,1030,012,Physical Geol Lab,0.13,0.43,0.22,0.13,0.0,0.0,0.0,0.09,alan coulson,GEOL-1030,2014
-GEOL,2050,001,Mineralogy & Intro P,0.4,0.27,0.2,0.0,0.13,0.0,0.0,0.0,lin shuller-nickles,GEOL-2050,2014
-GEOL,2070,001,Min & Intro Pet Lab,0.21,0.5,0.14,0.07,0.07,0.0,0.0,0.0,alan coulson,GEOL-2070,2014
-GEOL,2700,001,Sustainable Water,0.82,0.04,0.07,0.0,0.04,0.0,0.0,0.04,stephen mich moysey,GEOL-2700,2014
-GEOL,3000,001,Environmental Geol,0.41,0.38,0.15,0.06,0.0,0.0,0.0,0.0,scott brame,GEOL-3000,2014
-GEOL,4110,008,CI - Community Outre,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,john robert wagner,GEOL-4110,2014
-GEOL,6150,001,Analysis Geological,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,GEOL-6150,2014
-GEOL,8060,001,Aquifer Charact,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james castle,GEOL-8060,2014
-GEOL,8090,001,Subsurface Remed Mod,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ronald falta,GEOL-8090,2014
-GER,1010,001,Elementary German,0.32,0.37,0.16,0.0,0.05,0.0,0.0,0.11, lee ferrell,GER-1010,2014
-GER,1010,002,Elementary German,0.11,0.32,0.16,0.32,0.05,0.0,0.0,0.05, lee ferrell,GER-1010,2014
-GER,1010,003,Elementary German,0.24,0.18,0.24,0.06,0.06,0.0,0.0,0.24, lee ferrell,GER-1010,2014
-GER,1020,001,Elementary German,0.29,0.21,0.14,0.07,0.0,0.0,0.0,0.29, lee ferrell,GER-1020,2014
-GER,1020,003,Elementary German,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-1020,2014
-GER,2010,001,Intermediate German,0.33,0.4,0.07,0.0,0.07,0.0,0.0,0.13,gabriela stoicea,GER-2010,2014
-GER,2010,002,Intermediate German,0.22,0.33,0.17,0.17,0.0,0.0,0.0,0.11,johannes schmidt,GER-2010,2014
-GER,2020,001,Intermediate German,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-2020,2014
-GER,3050,001,Ger Conv & Comp,0.53,0.24,0.06,0.12,0.0,0.06,0.0,0.0,oswald harris king,GER-3050,2014
-GER,3690,001,German WWI Literatur,0.42,0.42,0.0,0.17,0.0,0.0,0.0,0.0,johannes schmidt,GER-3690,2014
-HCC,8310,001,Fundamentals of Hcc,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shaundra daily,HCC-8310,2014
-HCC,8810,001,Research Methods in,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,HCC-8810,2014
-HEHD,4100,001,Lead Beh & Civic En,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,katelyn mcc radford,HEHD-4100,2014
-HEHD,8000,400,Youth Dev Theories,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kellye rembert,HEHD-8000,2014
-HEHD,8050,001,Yth Dev in Families,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,HEHD-8050,2014
-HEHD,8050,001,Yth Dev in Families,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,william quinn,HEHD-8050,2014
-HEHD,8060,230,Diverse Society,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,william quinn,HEHD-8060,2014
-HEHD,8060,230,Diverse Society,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,keith george diem,HEHD-8060,2014
-HIST,1010,001,Hist of the U S,0.12,0.55,0.24,0.0,0.06,0.0,0.0,0.03,james brad jeffries,HIST-1010,2014
-HIST,1010,002,Hist of the U S,0.31,0.26,0.29,0.11,0.0,0.0,0.0,0.03,lee brady wilson,HIST-1010,2014
-HIST,1020,002,Hist of the U S,0.23,0.23,0.12,0.04,0.0,0.0,0.0,0.38,maribel morey,HIST-1020,2014
-HIST,1240,001,Environmental Hist,0.24,0.37,0.25,0.03,0.03,0.0,0.0,0.07,james brad jeffries,HIST-1240,2014
-HIST,1720,001,The West and the Wor,0.39,0.26,0.16,0.12,0.03,0.0,0.0,0.03,james burns,HIST-1720,2014
-HIST,1720,002,The West and the Wor,0.33,0.36,0.19,0.05,0.02,0.0,0.0,0.05,steven marks,HIST-1720,2014
-HIST,1730,001,The West and the Wor,0.3,0.33,0.17,0.05,0.06,0.0,0.0,0.09,richard saunders,HIST-1730,2014
-HIST,1730,002,The West and the Wor,0.32,0.38,0.13,0.03,0.08,0.0,0.0,0.05, alan grubb,HIST-1730,2014
-HIST,2990,001,Historian's Craft,0.47,0.2,0.13,0.0,0.07,0.0,0.0,0.13,michael silvestri,HIST-2990,2014
-HIST,2990,003,Historian's Craft,0.59,0.24,0.06,0.06,0.0,0.0,0.0,0.06,rachel anne moore,HIST-2990,2014
-HIST,3000,001,Hist Colonial Amer,0.3,0.49,0.14,0.03,0.05,0.0,0.0,0.0,lee brady wilson,HIST-3000,2014
-HIST,3030,001,Civil War & Recon,0.21,0.49,0.13,0.03,0.1,0.0,0.0,0.05,paul chris anderson,HIST-3030,2014
-HIST,3040,001,Indus & Progr Era,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0, roger grant,HIST-3040,2014
-HIST,3220,001,History of Technolog,0.37,0.33,0.13,0.03,0.1,0.0,0.0,0.03,pamela mack,HIST-3220,2014
-HIST,3280,001,US Legal History to,0.17,0.17,0.1,0.0,0.07,0.0,0.0,0.5,maribel morey,HIST-3280,2014
-HIST,3300,001,Hist of Mod China,0.31,0.23,0.38,0.0,0.08,0.0,0.0,0.0,edwin moise,HIST-3300,2014
-HIST,3400,001,Latin America I,0.48,0.38,0.1,0.0,0.02,0.0,0.0,0.02,rachel anne moore,HIST-3400,2014
-HIST,3550,001,Roman World,0.35,0.48,0.06,0.0,0.03,0.0,0.0,0.06,elizabeth carney,HIST-3550,2014
-HIST,3610,001,History of Britain t,0.42,0.36,0.12,0.03,0.06,0.0,0.0,0.0,caroline dunn clark,HIST-3610,2014
-HIST,3630,001,Britain Since 1688,0.37,0.26,0.21,0.05,0.05,0.0,0.0,0.05,stephani barczewski,HIST-3630,2014
-HIST,3700,001,Medieval History,0.41,0.31,0.09,0.06,0.06,0.0,0.0,0.06,caroline dunn clark,HIST-3700,2014
-HIST,3720,001,Renaissance,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,thomas kuehn,HIST-3720,2014
-HIST,3810,001,Germany Since 1918,0.2,0.47,0.13,0.0,0.2,0.0,0.0,0.0,michael meng,HIST-3810,2014
-HIST,3850,001,Imperial Russia,0.3,0.37,0.11,0.11,0.07,0.0,0.0,0.04,steven marks,HIST-3850,2014
-HIST,3900,001,Mod Mil Hist,0.09,0.41,0.41,0.0,0.05,0.0,0.0,0.05,edwin moise,HIST-3900,2014
-HIST,4090,001,Jfk Assassination,0.42,0.38,0.1,0.0,0.08,0.0,0.0,0.02,richard saunders,HIST-4090,2014
-HIST,4140,001,Study of Hist Museum,0.6,0.07,0.27,0.0,0.07,0.0,0.0,0.0,leslie white,HIST-4140,2014
-HIST,4710,001,Studies in Mod Europ,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,michael meng,HIST-4710,2014
-HIST,4870,001,World War II,0.2,0.57,0.07,0.09,0.04,0.0,0.0,0.04,john andrew,HIST-4870,2014
-HIST,4900,002,Film and Local Histo,0.45,0.45,0.0,0.09,0.0,0.0,0.0,0.0,james burns,HIST-4900,2014
-HIST,4900,003,HIST & GEOG Disney P,0.31,0.44,0.13,0.13,0.0,0.0,0.0,0.0,stephani barczewski,HIST-4900,2014
-HIST,4900,003,HIST & GEOG Disney P,0.31,0.44,0.13,0.13,0.0,0.0,0.0,0.0,christa smith,HIST-4900,2014
-HIST,4930,001,Slavery & Film,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,abel bartley,HIST-4930,2014
-HIST,4940,001,Europe's Dictators,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,amit bein,HIST-4940,2014
-HIST,8000,002,Major Probs SO Histo,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,john andrew,HIST-8000,2014
-HLTH,2020,001,Introduction to Publ,0.31,0.62,0.0,0.08,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2014
-HLTH,2020,002,Introduction to Publ,0.56,0.33,0.08,0.03,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2014
-HLTH,2020,003,Introduction to Publ,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2014
-HLTH,2020,004,Introduction to Publ,0.39,0.45,0.11,0.05,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2014
-HLTH,2020,005,Introduction to Publ,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2014
-HLTH,2020,006,Introduction to Publ,0.53,0.35,0.06,0.0,0.06,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2014
-HLTH,2030,001,Health Care Sys,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,lee alden crandall,HLTH-2030,2014
-HLTH,2030,002,Health Care Sys,0.68,0.28,0.0,0.0,0.03,0.0,0.0,0.03,ralph stewart welsh,HLTH-2030,2014
-HLTH,2030,400,Health Care Sys,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ralph stewart welsh,HLTH-2030,2014
-HLTH,2400,001,Deter of Hlth Behav,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.03,sarah griffin,HLTH-2400,2014
-HLTH,2400,002,Deter of Hlth Behav,0.36,0.49,0.09,0.0,0.0,0.0,0.0,0.06,sarah griffin,HLTH-2400,2014
-HLTH,2980,001,Human Hlth & Disease,0.6,0.33,0.05,0.0,0.0,0.0,0.0,0.02,deborah alma falta,HLTH-2980,2014
-HLTH,2980,002,Human Hlth & Disease,0.53,0.44,0.0,0.0,0.0,0.0,0.0,0.03,deborah alma falta,HLTH-2980,2014
-HLTH,3030,001,Public Health Comm,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,debra mitch charles,HLTH-3030,2014
-HLTH,3400,001,Hlth Prom Prog Plan,0.47,0.32,0.18,0.0,0.0,0.0,0.0,0.03,joel edwar williams,HLTH-3400,2014
-HLTH,3610,001,Int Health Care Econ,0.5,0.28,0.17,0.0,0.0,0.0,0.0,0.06,khoa dang truong,HLTH-3610,2014
-HLTH,3800,001,Epidemiology,0.19,0.6,0.15,0.04,0.0,0.0,0.0,0.02,hugh spitler,HLTH-3800,2014
-HLTH,3800,002,Epidemiology,0.16,0.64,0.2,0.0,0.0,0.0,0.0,0.0,hugh spitler,HLTH-3800,2014
-HLTH,3800,400,Epidemiology,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,deborah alma falta,HLTH-3800,2014
-HLTH,3980,001,Hlth Appraisal Sklls,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2014
-HLTH,4150,001,Obesity & Eating Dis,0.57,0.34,0.06,0.0,0.0,0.0,0.0,0.03,karen kemper,HLTH-4150,2014
-HLTH,4190,001,Health Sci Internshi,0.21,0.58,0.12,0.06,0.03,0.0,0.0,0.0,kathleen meyer,HLTH-4190,2014
-HLTH,4200,001,Hlth Science Intern,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2014
-HLTH,4400,001,Manag Hlth Serv Org,0.19,0.67,0.15,0.0,0.0,0.0,0.0,0.0,frederic fraizer,HLTH-4400,2014
-HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,ronald gimbel,HLTH-4700,2014
-HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,HLTH-4700,2014
-HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,rachel mayo,HLTH-4700,2014
-HLTH,4750,001,Hlthcr Oper Mgmt Res,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,HLTH-4750,2014
-HLTH,4900,001,Res Eval St Pub Hlth,0.57,0.19,0.14,0.05,0.0,0.0,0.0,0.05,khoa dang truong,HLTH-4900,2014
-HLTH,4900,002,Res Eval St Pub Hlth,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,lingling zhang,HLTH-4900,2014
-HON,1900,001,Holocaust Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,HON-1900,2014
-HON,1900,002,Amer Lit & Global Co,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,angela naimou,HON-1900,2014
-HON,1920,001,Positively Human,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,june pilcher,HON-1920,2014
-HON,1940,001,Scientific Skepticis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey appling,HON-1940,2014
-HON,2020,001,Stress in Health and,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,HON-2020,2014
-HON,2030,001,Music/Politics:Blues,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,HON-2030,2014
-HON,2200,001,Midterm Elections,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey allen fine,HON-2200,2014
-HON,2200,002,The Modern Israeli S,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,colin pearce,HON-2200,2014
-HON,2220,001,Science/Literaure in,0.64,0.27,0.0,0.09,0.0,0.0,0.0,0.0,gabriela stoicea,HON-2220,2014
-HORT,1010,001,Horticulture,0.63,0.31,0.07,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-1010,2014
-HORT,2100,001,Growing Fall Plants,0.33,0.17,0.17,0.17,0.0,0.0,0.0,0.17,samarakoon basnagala,HORT-2100,2014
-HORT,2120,001,Turfgrass Culture,0.55,0.43,0.0,0.0,0.03,0.0,0.0,0.0,haibo liu,HORT-2120,2014
-HORT,2130,001,Turf Culture Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,donald garrett,HORT-2130,2014
-HORT,2130,002,Turf Culture Lab,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,donald garrett,HORT-2130,2014
-HORT,3030,001,Landscape Plants,0.36,0.32,0.17,0.03,0.07,0.0,0.0,0.05,robert polomski,HORT-3030,2014
-HORT,3080,001,Sust Landscape Des,0.63,0.23,0.07,0.05,0.0,0.0,0.0,0.02,ellen anita vincent,HORT-3080,2014
-HORT,3090,001,Sust Landsc Des Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,harry harritos,HORT-3090,2014
-HORT,4090,001,Senior Capstone Cour,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,ellen anita vincent,HORT-4090,2014
-HORT,4120,001,Adv Turfgrass Mgt,0.3,0.3,0.2,0.0,0.0,0.0,0.0,0.2,lambert mccarty,HORT-4120,2014
-HORT,4330,001,Turf Weed Management,0.29,0.41,0.24,0.0,0.0,0.0,0.0,0.06,ted whitwell,HORT-4330,2014
-HP,8030,001,Building Tech and Pa,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amalia leifeste,HP-8030,2014
-HP,8070,400,American Architectur,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,carter lee hudgins,HP-8070,2014
-HP,8090,400,Historical Research,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,katherine pemberton,HP-8090,2014
-HP,8190,001,"Investig, Docum, Con",0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,amalia leifeste,HP-8190,2014
-HP,8190,001,"Investig, Docum, Con",0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,kristopher king,HP-8190,2014
-HRD,8200,400,Human Perform Improv,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,cynthia sims,HRD-8200,2014
-HRD,8200,401,Human Perform Improv,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,cynthia sims,HRD-8200,2014
-HRD,8200,402,Human Perform Improv,0.71,0.0,0.14,0.0,0.0,0.0,0.0,0.14,cynthia sims,HRD-8200,2014
-HRD,8200,403,Human Perform Improv,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,cynthia sims,HRD-8200,2014
-HRD,8200,405,Human Perform Improv,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,cynthia sims,HRD-8200,2014
-HRD,8200,406,Human Perform Improv,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,cynthia sims,HRD-8200,2014
-HRD,8300,400,Concepts of H R D,0.38,0.38,0.13,0.0,0.0,0.0,0.0,0.13,eileen newmark,HRD-8300,2014
-HRD,8300,401,Concepts of H R D,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,eileen newmark,HRD-8300,2014
-HRD,8300,402,Concepts of H R D,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,eileen newmark,HRD-8300,2014
-HRD,8300,403,Concepts of H R D,0.2,0.7,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,HRD-8300,2014
-HRD,8300,404,Concepts of H R D,0.5,0.25,0.13,0.0,0.13,0.0,0.0,0.0,eileen newmark,HRD-8300,2014
-HRD,8300,405,Concepts of H R D,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,HRD-8300,2014
-HRD,8300,406,Concepts of H R D,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,HRD-8300,2014
-HRD,8300,407,Concepts of H R D,0.63,0.13,0.0,0.0,0.0,0.0,0.0,0.25,eileen newmark,HRD-8300,2014
-HRD,8450,402,Needs Assess Ed/Ind,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,russell marion,HRD-8450,2014
-HRD,8600,404,Instruc Mat Devel,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,philip mcgee,HRD-8600,2014
-HRD,8600,405,Instruc Mat Devel,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,HRD-8600,2014
-HRD,8600,406,Instruc Mat Devel,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,HRD-8600,2014
-IE,2000,001,Soph Seminar in I E,0.53,0.26,0.12,0.06,0.02,0.0,0.0,0.01,brian melloy,IE-2000,2014
-IE,2010,001,Systems Design I,0.4,0.47,0.1,0.0,0.03,0.0,0.0,0.0,joel greenstein,IE-2010,2014
-IE,2010,002,Systems Design I,0.37,0.43,0.17,0.0,0.0,0.0,0.0,0.03,joel greenstein,IE-2010,2014
-IE,2010,003,Systems Design I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,IE-2010,2014
-IE,2800,001,Deterministic Operat,0.18,0.34,0.2,0.13,0.11,0.0,0.0,0.04,jonathan cole smith,IE-2800,2014
-IE,2800,002,Deterministic Operat,0.38,0.37,0.13,0.06,0.04,0.0,0.0,0.02,amin khademi,IE-2800,2014
-IE,3600,001,Industrial Apps of P,0.3,0.33,0.23,0.08,0.05,0.0,0.0,0.01,mary elizabeth kurz,IE-3600,2014
-IE,3680,001,Prof Practice in I E,0.87,0.08,0.02,0.01,0.01,0.0,0.0,0.01,brian melloy,IE-3680,2014
-IE,3860,001,Prod Plan & Cont,0.38,0.46,0.08,0.0,0.04,0.0,0.0,0.04,robert james riggs,IE-3860,2014
-IE,4020,003,Creative Inq Res,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,anand gramopadhye,IE-4020,2014
-IE,4400,001,Decision Support Sys,0.47,0.29,0.08,0.05,0.03,0.0,0.0,0.08,sandra dun eksioglu,IE-4400,2014
-IE,4400,002,Decision Support Sys,0.33,0.42,0.14,0.07,0.02,0.0,0.0,0.02,mary elizabeth kurz,IE-4400,2014
-IE,4560,001,Supply Chain Design,0.2,0.59,0.12,0.0,0.1,0.0,0.0,0.0,william ferrell,IE-4560,2014
-IE,4610,001,Quality Engineering,0.3,0.35,0.28,0.05,0.0,0.0,0.0,0.01,byung rae cho,IE-4610,2014
-IE,4650,001,Facilities Planning,0.26,0.53,0.18,0.02,0.0,0.0,0.0,0.01,brian melloy,IE-4650,2014
-IE,4820,001,Systems Modeling,0.32,0.47,0.19,0.01,0.0,0.0,0.0,0.01,kevin taaffe,IE-4820,2014
-IE,4910,001,Investigating Human,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,sara lu riggs,IE-4910,2014
-IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,sandra dun eksioglu,IE-4910,2014
-IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,sandra dun eksioglu,IE-4910,2014
-IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,kap chalil madathil,IE-4910,2014
-IE,6400,001,Decision Support Sys,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,IE-6400,2014
-IE,6560,001,Supply Chain Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,IE-6560,2014
-IE,6910,001,Selected Topics-I E,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,sara lu riggs,IE-6910,2014
-IE,8000,001,Human Factors Eng,0.11,0.75,0.13,0.0,0.01,0.0,0.0,0.0,david neyens,IE-8000,2014
-IE,8030,001,Engr Optimization an,0.23,0.39,0.26,0.0,0.06,0.0,0.0,0.06,scott jenning mason,IE-8030,2014
-IE,8090,001,Model Sys Under Risk,0.23,0.43,0.25,0.0,0.05,0.0,0.0,0.04,burak eksioglu,IE-8090,2014
-IE,8510,001,Data Coll Anl Interp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabeth kurz,IE-8510,2014
-IE,8530,001,Foundations of Qual,0.84,0.14,0.02,0.0,0.0,0.0,0.0,0.0,byung rae cho,IE-8530,2014
-IE,8550,001,Capital Projects Sc,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,kevin taaffe,IE-8550,2014
-IE,8870,001,Model Logist Behav S,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,IE-8870,2014
-INT,1010,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.91,0.06,0.03,troy nunamaker,INT-1010,2014
-INT,1020,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.88,0.11,0.01,troy nunamaker,INT-1020,2014
-INT,1030,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.85,0.11,0.04,troy nunamaker,INT-1030,2014
-IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,meredith fan wilson,IS-1010,2014
-IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,laura padfiel braun,IS-1010,2014
-IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,sharon nagy,IS-1010,2014
-IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,uttiyo raychaudhuri,IS-1010,2014
-ITAL,1010,001,Elementary Italian,0.47,0.11,0.11,0.0,0.11,0.0,0.0,0.21,luca barattoni,ITAL-1010,2014
-ITAL,1010,002,Elementary Italian,0.74,0.11,0.16,0.0,0.0,0.0,0.0,0.0,luca barattoni,ITAL-1010,2014
-ITAL,1010,003,Elementary Italian,0.32,0.42,0.11,0.05,0.11,0.0,0.0,0.0,valentina lombardi,ITAL-1010,2014
-ITAL,1010,004,Elementary Italian,0.5,0.25,0.0,0.0,0.13,0.0,0.0,0.13,valentina lombardi,ITAL-1010,2014
-ITAL,1020,001,Elementary Italian,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-1020,2014
-ITAL,2010,001,Intermediate Italian,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2010,2014
-ITAL,2010,002,Intermediate Italian,0.35,0.47,0.18,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2010,2014
-ITAL,2020,001,Intermediate Italian,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,barbara zaczek,ITAL-2020,2014
-JAPN,1010,001,Elementary Japanese,0.42,0.32,0.11,0.0,0.11,0.0,0.0,0.05,toshiko kishimoto,JAPN-1010,2014
-JAPN,1010,002,Elementary Japanese,0.42,0.21,0.11,0.05,0.05,0.0,0.0,0.16,toshiko kishimoto,JAPN-1010,2014
-JAPN,2010,001,Intermed Japanese,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,toshiko joerger,JAPN-2010,2014
-JAPN,3050,001,Japanese Conv & Comp,0.5,0.25,0.17,0.0,0.0,0.0,0.0,0.08,toshiko kishimoto,JAPN-3050,2014
-JAPN,4010,001,Japan Lit in Trans,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,kenneth jeff knight,JAPN-4010,2014
-LANG,2540,001,Introduction to Worl,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,joseph mai,LANG-2540,2014
-LANG,3710,001,Language and Culture,0.3,0.2,0.3,0.0,0.0,0.0,0.0,0.2,yanhua zhang,LANG-3710,2014
-LARC,1150,001,Intro Landscape Arch,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,LARC-1150,2014
-LARC,1280,001,Technical Graphics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,LARC-1280,2014
-LARC,1510,001,Basic Design I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,LARC-1510,2014
-LARC,3620,001,Design Impl II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,LARC-3620,2014
-LARC,4280,001,Comput Aided Design,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,shan jiang,LARC-4280,2014
-LARC,4530,001,Key Issues in Larch,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,LARC-4530,2014
-LARC,8500,001,Grad Colloquium,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,LARC-8500,2014
-LAW,3220,001,Legal Env of Bus,0.14,0.61,0.24,0.01,0.01,0.0,0.0,0.0,judson jahn,LAW-3220,2014
-LAW,3220,002,Legal Env of Bus,0.47,0.41,0.11,0.01,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2014
-LAW,3220,003,Legal Env of Bus (HO,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2014
-LAW,3220,004,Legal Env of Bus,0.06,0.42,0.21,0.12,0.03,0.0,0.0,0.15,virgini ward-vaughn,LAW-3220,2014
-LAW,3220,005,Legal Env of Bus,0.06,0.45,0.23,0.13,0.06,0.0,0.0,0.06,virgini ward-vaughn,LAW-3220,2014
-LAW,3220,006,Legal Env of Bus,0.23,0.26,0.32,0.13,0.0,0.0,0.0,0.06,virgini ward-vaughn,LAW-3220,2014
-LAW,3220,007,Legal Env of Bus,0.29,0.24,0.29,0.1,0.05,0.0,0.0,0.05,virgini ward-vaughn,LAW-3220,2014
-LAW,3220,009,Legal Env of Bus,0.51,0.39,0.1,0.0,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2014
-LAW,3220,010,Legal Env of Bus,0.42,0.38,0.16,0.05,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2014
-LAW,3220,011,Legal Env of Bus,0.18,0.46,0.19,0.1,0.0,0.0,0.0,0.06,kenneth toussaint,LAW-3220,2014
-LAW,3220,012,Legal Env of Bus,0.33,0.51,0.15,0.01,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2014
-LAW,3330,001,Real Estate Law,0.1,0.52,0.2,0.06,0.0,0.0,0.0,0.12,michael bra burrell,LAW-3330,2014
-LAW,4050,001,Construction Law,0.88,0.07,0.0,0.0,0.0,0.0,0.0,0.05,frances edwards,LAW-4050,2014
-LIT,1270,001,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,eric touya,LIT-1270,2014
-LS,1000,002,Therapeutic Yoga,0.63,0.11,0.0,0.05,0.0,0.0,0.0,0.21,ranjanbala dil amin,LS-1000,2014
-LS,1000,007,Photography,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,sarah elizab mudder,LS-1000,2014
-LS,1000,008,Intro to Volleyball,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,kelly lynn ator,LS-1000,2014
-LS,1000,013,Introduction to Sals,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,malik lewis baxter,LS-1000,2014
-LS,1130,001,Wood Carving,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,edwin eugene riggs,LS-1130,2014
-LS,1410,001,Top Rope Climbing,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,scott evan lipscomb,LS-1410,2014
-LS,1410,002,Top Rope Climbing,0.75,0.06,0.0,0.0,0.13,0.0,0.0,0.06,scott evan lipscomb,LS-1410,2014
-LS,1410,004,Top Rope Climbing,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott evan lipscomb,LS-1410,2014
-LS,1410,005,Top Rope Climbing,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,scott evan lipscomb,LS-1410,2014
-LS,1410,006,Top Rope Climbing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott evan lipscomb,LS-1410,2014
-LS,1560,001,Riflery,0.73,0.0,0.0,0.0,0.0,0.0,0.0,0.27,hubert cox,LS-1560,2014
-LS,1560,005,Riflery,0.73,0.09,0.0,0.0,0.0,0.0,0.0,0.18,hubert cox,LS-1560,2014
-LS,1560,007,Riflery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,herbert strickland,LS-1560,2014
-LS,1570,003,Shotgun Sports,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,charles flint,LS-1570,2014
-LS,1580,002,Archery,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,herbert strickland,LS-1580,2014
-LS,1580,003,Archery,0.71,0.07,0.07,0.0,0.0,0.0,0.0,0.14,herbert strickland,LS-1580,2014
-LS,1580,005,Archery,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,herbert strickland,LS-1580,2014
-LS,1640,001,Whitewater Kayaking,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,earl wade shealy,LS-1640,2014
-LS,1640,002,Whitewater Kayaking,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,robert taylor,LS-1640,2014
-LS,1750,002,Fly Fishing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael watts,LS-1750,2014
-LS,1850,003,Bowling,0.93,0.0,0.03,0.0,0.03,0.0,0.0,0.0,megan elizabet cato,LS-1850,2014
-LS,1870,002,Frisbee Sports,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,craig goodman,LS-1870,2014
-LS,1890,002,Tennis,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jennifer jo garrity,LS-1890,2014
-LS,1940,002,Racquetball,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,LS-1940,2014
-LS,1980,002,Golf,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jason jordan,LS-1980,2014
-LS,2100,001,Learn to Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,matthew lee krabbe,LS-2100,2014
-LS,2110,001,Introduction to Bell,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,stephanie pack,LS-2110,2014
-LS,2190,003,Country West Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,LS-2190,2014
-LS,2200,001,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,broadus fleming,LS-2200,2014
-LS,2200,004,Shag,0.78,0.0,0.0,0.0,0.04,0.0,0.0,0.17,broadus fleming,LS-2200,2014
-LS,2200,005,Shag,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,LS-2200,2014
-LS,2200,006,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,broadus fleming,LS-2200,2014
-LS,2200,009,Shag,0.74,0.0,0.0,0.0,0.0,0.0,0.0,0.26,matthew lee krabbe,LS-2200,2014
-LS,2210,002,Intermediate Shag,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,matthew lee krabbe,LS-2210,2014
-LS,2270,002,Intro to Swing Dance,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,LS-2270,2014
-LS,2320,001,Core Training,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,diane moreno,LS-2320,2014
-LS,2320,005,Core Training,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-2320,2014
-LS,2350,001,Basic Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,LS-2350,2014
-LS,2350,002,Basic Yoga,0.77,0.09,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,LS-2350,2014
-LS,2350,003,Basic Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,LS-2350,2014
-LS,2350,005,Basic Yoga,0.81,0.0,0.1,0.05,0.0,0.0,0.0,0.05,renee warren gahan,LS-2350,2014
-LS,2350,006,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2014
-LS,2350,007,Basic Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2014
-LS,2360,001,Power/Ashtanga Yoga,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,LS-2360,2014
-LS,2360,002,Power/Ashtanga Yoga,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,LS-2360,2014
-LS,2370,001,Kripalu Yoga,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,LS-2370,2014
-LS,2370,002,Kripalu Yoga,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,LS-2370,2014
-LS,2370,003,Kripalu Yoga,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,ashley austi lester,LS-2370,2014
-LS,2420,003,Meditation and Relax,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,jenefer nadenicek,LS-2420,2014
-LS,2420,006,Meditation and Relax,0.71,0.21,0.04,0.0,0.04,0.0,0.0,0.0,ani reina-nunnelley,LS-2420,2014
-LS,2420,007,Meditation and Relax,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,LS-2420,2014
-LS,2450,003,Pilates,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,melanie ivey job,LS-2450,2014
-LS,2500,001,Marathon Training,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,john walston dunn,LS-2500,2014
-LS,2510,002,Running & Jogging,0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,corey dou brookover,LS-2510,2014
-LS,2660,001,Hapkido,0.79,0.04,0.0,0.04,0.0,0.0,0.0,0.13,kelly smith,LS-2660,2014
-LS,2700,001,Sports Officiating,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher war cox,LS-2700,2014
-LS,2780,002,Wilderness First Aid,0.73,0.09,0.0,0.0,0.0,0.0,0.0,0.18,emily grace turke,LS-2780,2014
-MATH,1010,001,Essen Math for Infor,0.27,0.33,0.21,0.12,0.06,0.0,0.0,0.0,judith cottingham,MATH-1010,2014
-MATH,1010,002,Essen Math for Infor,0.25,0.33,0.25,0.0,0.08,0.0,0.0,0.08,qijun he,MATH-1010,2014
-MATH,1010,003,Essen Math for Infor,0.23,0.38,0.31,0.0,0.08,0.0,0.0,0.0,paran rebeka norton,MATH-1010,2014
-MATH,1010,004,Essen Math for Infor,0.39,0.33,0.17,0.06,0.06,0.0,0.0,0.0,merle glick,MATH-1010,2014
-MATH,1010,005,Essen Math for Infor,0.32,0.37,0.11,0.05,0.11,0.0,0.0,0.05,paran rebeka norton,MATH-1010,2014
-MATH,1010,006,Essen Math for Infor,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,vito capuano,MATH-1010,2014
-MATH,1010,007,Essen Math for Infor,0.29,0.47,0.12,0.06,0.0,0.0,0.0,0.06,qijun he,MATH-1010,2014
-MATH,1010,009,Essen Math for Infor,0.5,0.11,0.22,0.0,0.11,0.0,0.0,0.06,vito capuano,MATH-1010,2014
-MATH,1010,010,Essen Math for Infor,0.65,0.12,0.12,0.06,0.0,0.0,0.0,0.06,merle glick,MATH-1010,2014
-MATH,1010,011,Essen Math for Infor,0.39,0.33,0.14,0.11,0.03,0.0,0.0,0.0,judith cottingham,MATH-1010,2014
-MATH,1010,012,Essen Math for Infor,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,megan elizabet ryan,MATH-1010,2014
-MATH,1010,014,Essen Math for Infor,0.25,0.42,0.17,0.0,0.17,0.0,0.0,0.0,megan elizabet ryan,MATH-1010,2014
-MATH,1010,015,Essen Math for Infor,0.0,0.31,0.38,0.23,0.0,0.0,0.0,0.08,sergey charnyi,MATH-1010,2014
-MATH,1010,113,Essen Math for Infor,0.4,0.23,0.2,0.03,0.07,0.0,0.0,0.07,marilyn reba,MATH-1010,2014
-MATH,1010,113,Essen Math for Infor,0.4,0.23,0.2,0.03,0.07,0.0,0.0,0.07,meredith nicol burr,MATH-1010,2014
-MATH,1020,001,Intro to Mathematica,0.17,0.17,0.22,0.17,0.22,0.0,0.0,0.06,tony thanh nguyen,MATH-1020,2014
-MATH,1020,002,Intro to Mathematica,0.0,0.26,0.32,0.16,0.16,0.0,0.0,0.11, morales hernandez,MATH-1020,2014
-MATH,1020,003,Intro to Mathematica,0.06,0.18,0.29,0.29,0.18,0.0,0.0,0.0,"rodriguez esperanza,",MATH-1020,2014
-MATH,1020,004,Intro to Mathematica,0.24,0.41,0.24,0.0,0.06,0.0,0.0,0.06,margaret milliken,MATH-1020,2014
-MATH,1020,005,Intro to Mathematica,0.28,0.33,0.28,0.0,0.06,0.0,0.0,0.06,amy christine grady,MATH-1020,2014
-MATH,1020,006,Intro to Mathematica,0.37,0.17,0.26,0.11,0.06,0.0,0.0,0.03,warren adams,MATH-1020,2014
-MATH,1020,007,Intro to Mathematica,0.21,0.26,0.37,0.0,0.16,0.0,0.0,0.0,tony thanh nguyen,MATH-1020,2014
-MATH,1020,008,Intro to Mathematica,0.26,0.42,0.21,0.05,0.0,0.0,0.0,0.05,kevin wayne dettman,MATH-1020,2014
-MATH,1020,009,Intro to Mathematica,0.32,0.47,0.05,0.11,0.0,0.0,0.0,0.05,"rodriguez esperanza,",MATH-1020,2014
-MATH,1020,010,Intro to Mathematica,0.3,0.35,0.15,0.1,0.1,0.0,0.0,0.0,yisu jia,MATH-1020,2014
-MATH,1020,011,Intro to Mathematica,0.29,0.35,0.18,0.0,0.12,0.0,0.0,0.06,mengying xiao,MATH-1020,2014
-MATH,1020,012,Intro to Mathematica,0.22,0.19,0.22,0.14,0.19,0.0,0.0,0.03,abigail bowers,MATH-1020,2014
-MATH,1020,013,Intro to Mathematica,0.26,0.31,0.26,0.06,0.06,0.0,0.0,0.06,randy davidson,MATH-1020,2014
-MATH,1020,014,Intro to Mathematica,0.33,0.28,0.14,0.03,0.19,0.0,0.0,0.03,abigail bowers,MATH-1020,2014
-MATH,1020,015,Intro to Mathematica,0.32,0.21,0.21,0.05,0.16,0.0,0.0,0.05, morales hernandez,MATH-1020,2014
-MATH,1020,016,Intro to Mathematica,0.21,0.26,0.32,0.16,0.05,0.0,0.0,0.0,isaac justus,MATH-1020,2014
-MATH,1020,017,Intro to Mathematica,0.32,0.05,0.37,0.11,0.11,0.0,0.0,0.05,margaret milliken,MATH-1020,2014
-MATH,1020,018,Intro to Mathematica,0.33,0.28,0.17,0.11,0.06,0.0,0.0,0.06,thanh thien to,MATH-1020,2014
-MATH,1020,019,Intro to Mathematica,0.32,0.32,0.05,0.05,0.26,0.0,0.0,0.0,david james rea,MATH-1020,2014
-MATH,1020,020,Intro to Mathematica,0.35,0.18,0.18,0.18,0.06,0.0,0.0,0.06,liu zhu,MATH-1020,2014
-MATH,1020,021,Intro to Mathematica,0.22,0.44,0.06,0.06,0.22,0.0,0.0,0.0,isaac justus,MATH-1020,2014
-MATH,1020,022,Intro to Mathematica,0.32,0.11,0.21,0.05,0.21,0.0,0.0,0.11,amy christine grady,MATH-1020,2014
-MATH,1020,023,Intro to Mathematica,0.29,0.12,0.41,0.0,0.06,0.0,0.0,0.12,thanh thien to,MATH-1020,2014
-MATH,1020,024,Intro to Mathematica,0.35,0.35,0.06,0.06,0.12,0.0,0.0,0.06,liu zhu,MATH-1020,2014
-MATH,1020,025,Intro to Mathematica,0.0,0.41,0.12,0.24,0.06,0.0,0.0,0.18,mengying xiao,MATH-1020,2014
-MATH,1020,026,Intro to Mathematica,0.22,0.17,0.22,0.17,0.17,0.0,0.0,0.06,trevor scot vilardi,MATH-1020,2014
-MATH,1020,027,Intro to Mathematica,0.32,0.26,0.21,0.05,0.16,0.0,0.0,0.0,luke marti giberson,MATH-1020,2014
-MATH,1020,028,Intro to Mathematica,0.33,0.22,0.0,0.17,0.17,0.0,0.0,0.11,david james rea,MATH-1020,2014
-MATH,1020,029,Intro to Mathematica,0.21,0.24,0.26,0.21,0.09,0.0,0.0,0.0, erwin walker,MATH-1020,2014
-MATH,1020,030,Intro to Mathematica,0.42,0.31,0.08,0.08,0.11,0.0,0.0,0.0,randy davidson,MATH-1020,2014
-MATH,1020,031,Intro to Mathematica,0.06,0.53,0.24,0.06,0.06,0.0,0.0,0.06,samuel jose shesman,MATH-1020,2014
-MATH,1020,032,Intro to Mathematica,0.06,0.29,0.35,0.0,0.18,0.0,0.0,0.12,kevin wayne dettman,MATH-1020,2014
-MATH,1020,033,Intro to Mathematica,0.12,0.29,0.29,0.18,0.12,0.0,0.0,0.0,trevor scot vilardi,MATH-1020,2014
-MATH,1020,034,Intro to Mathematica,0.11,0.37,0.16,0.11,0.21,0.0,0.0,0.05,abigail bowers,MATH-1020,2014
-MATH,1020,035,Intro to Mathematica,0.22,0.38,0.25,0.13,0.0,0.0,0.0,0.03, erwin walker,MATH-1020,2014
-MATH,1020,036,Intro to Mathematica,0.27,0.36,0.09,0.06,0.15,0.0,0.0,0.06,abigail bowers,MATH-1020,2014
-MATH,1020,037,Intro to Mathematica,0.33,0.33,0.06,0.11,0.17,0.0,0.0,0.0,luke marti giberson,MATH-1020,2014
-MATH,1020,038,Intro to Mathematica,0.17,0.22,0.33,0.06,0.11,0.0,0.0,0.11,yisu jia,MATH-1020,2014
-MATH,1040,001,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.68,0.27,0.05,donna simms,MATH-1040,2014
-MATH,1040,002,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.56,0.27,0.18,jennifer mari hanna,MATH-1040,2014
-MATH,1040,003,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.44,0.42,0.14,abdullah al mamun,MATH-1040,2014
-MATH,1040,004,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.64,0.24,0.11,jennifer mari hanna,MATH-1040,2014
-MATH,1040,005,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.44,0.44,0.12,christa con johnson,MATH-1040,2014
-MATH,1040,006,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.51,0.36,0.13,jennifer mari hanna,MATH-1040,2014
-MATH,1040,007,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.38,0.53,0.09,fiona may knoll,MATH-1040,2014
-MATH,1040,008,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.56,0.33,0.11,jason to hedetniemi,MATH-1040,2014
-MATH,1040,009,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.33,0.65,0.02,jason lee joyner,MATH-1040,2014
-MATH,1040,010,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.45,0.47,0.08,christa con johnson,MATH-1040,2014
-MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.67,0.29,0.04,eliza dar gallagher,MATH-1050,2014
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.64,0.34,0.02,eliza dar gallagher,MATH-1050,2014
-MATH,1060,001,Calculus of One Vari,0.32,0.27,0.18,0.09,0.05,0.0,0.0,0.09,charity watson,MATH-1060,2014
-MATH,1060,002,Calculus of One Vari,0.02,0.3,0.3,0.09,0.17,0.0,0.0,0.13,javier ruiz ramirez,MATH-1060,2014
-MATH,1060,003,Calculus of One Vari,0.17,0.33,0.19,0.06,0.11,0.0,0.0,0.14,allen anderso guest,MATH-1060,2014
-MATH,1060,004,Calculus of One Vari,0.34,0.09,0.29,0.11,0.09,0.0,0.0,0.09,allen anderso guest,MATH-1060,2014
-MATH,1060,005,Calculus of One Vari,0.36,0.38,0.1,0.05,0.07,0.0,0.0,0.05,charity watson,MATH-1060,2014
-MATH,1060,006,Calculus of One Vari,0.15,0.42,0.23,0.06,0.06,0.0,0.0,0.08,meredith nicol burr,MATH-1060,2014
-MATH,1060,007,Calculus of One Vari,0.27,0.41,0.16,0.05,0.07,0.0,0.0,0.05,charity watson,MATH-1060,2014
-MATH,1060,008,Calculus of One Vari,0.2,0.32,0.2,0.1,0.14,0.0,0.0,0.04,sherry biggers,MATH-1060,2014
-MATH,1060,009,Calculus of One Vari,0.24,0.22,0.24,0.08,0.08,0.0,0.0,0.14,meredith nicol burr,MATH-1060,2014
-MATH,1060,010,Calculus of One Vari,0.27,0.41,0.14,0.05,0.11,0.0,0.0,0.02,honghai xu,MATH-1060,2014
-MATH,1060,011,Calculus of One Vari,0.17,0.27,0.25,0.1,0.13,0.0,0.0,0.08,charles johnson,MATH-1060,2014
-MATH,1060,012,Calculus of One Vari,0.19,0.27,0.21,0.15,0.08,0.0,0.0,0.1,sherry biggers,MATH-1060,2014
-MATH,1060,013,Calculus of One Vari,0.13,0.17,0.17,0.15,0.15,0.0,0.0,0.25,stefan adam bock,MATH-1060,2014
-MATH,1060,014,Calculus of One Vari,0.22,0.35,0.18,0.07,0.07,0.0,0.0,0.11,audrey nico devries,MATH-1060,2014
-MATH,1060,015,Calculus of One Vari,0.2,0.27,0.27,0.12,0.1,0.0,0.0,0.04,rachel eli grotheer,MATH-1060,2014
-MATH,1060,016,Calculus of One Vari,0.28,0.19,0.14,0.12,0.09,0.0,0.0,0.19,charles johnson,MATH-1060,2014
-MATH,1060,017,Calculus of One Vari,0.1,0.38,0.24,0.02,0.12,0.0,0.0,0.14,charles johnson,MATH-1060,2014
-MATH,1060,018,Calculus of One Vari,0.11,0.38,0.13,0.09,0.11,0.0,0.0,0.19,sherry biggers,MATH-1060,2014
-MATH,1060,019,Calculus of One Vari,0.31,0.28,0.19,0.03,0.17,0.0,0.0,0.03,marilyn reba,MATH-1060,2014
-MATH,1060,020,Calculus of One Vari,0.23,0.25,0.27,0.05,0.09,0.0,0.0,0.11,rebecca ramos,MATH-1060,2014
-MATH,1060,100,Calc of One Variable,0.42,0.33,0.0,0.08,0.0,0.0,0.0,0.17,james ba coykendall,MATH-1060,2014
-MATH,1060,201,Calculus of One Vari,0.43,0.21,0.14,0.0,0.21,0.0,0.0,0.0,james peterson,MATH-1060,2014
-MATH,1060,202,Calculus of One Vari,0.67,0.06,0.22,0.0,0.06,0.0,0.0,0.0,james peterson,MATH-1060,2014
-MATH,1070,001,Differen and Integra,0.08,0.23,0.38,0.18,0.13,0.0,0.0,0.03,donna simms,MATH-1070,2014
-MATH,1080,001,Calculus of One Vari,0.1,0.2,0.15,0.03,0.33,0.0,0.0,0.2,sarah eliz anderson,MATH-1080,2014
-MATH,1080,002,Calculus of One Vari,0.08,0.18,0.18,0.05,0.18,0.0,0.0,0.33,terri johnson,MATH-1080,2014
-MATH,1080,003,Calculus of One Vari,0.11,0.14,0.22,0.03,0.19,0.0,0.0,0.31,dania moham zantout,MATH-1080,2014
-MATH,1080,004,Calculus of One Vari,0.08,0.16,0.05,0.24,0.16,0.0,0.0,0.32,beth novick,MATH-1080,2014
-MATH,1080,005,Calculus of One Vari,0.05,0.13,0.1,0.08,0.43,0.0,0.0,0.23,terri johnson,MATH-1080,2014
-MATH,1080,006,Calculus of One Vari,0.22,0.17,0.22,0.12,0.1,0.0,0.0,0.17,dania moham zantout,MATH-1080,2014
-MATH,1080,007,Calculus of One Vari,0.07,0.07,0.1,0.12,0.37,0.0,0.0,0.27,karyn muir,MATH-1080,2014
-MATH,1080,008,Calculus of One Vari,0.14,0.17,0.24,0.12,0.19,0.0,0.0,0.14,anastasia br wilson,MATH-1080,2014
-MATH,1080,009,Calculus of One Vari,0.0,0.08,0.18,0.05,0.54,0.0,0.0,0.15,beth novick,MATH-1080,2014
-MATH,1080,010,Calculus of One Vari,0.11,0.27,0.14,0.05,0.3,0.0,0.0,0.14,shih-wei chao,MATH-1080,2014
-MATH,1080,011,Calculus of One Vari,0.27,0.21,0.18,0.12,0.03,0.0,0.0,0.18,dania moham zantout,MATH-1080,2014
-MATH,1080,100,Calc of One Variable,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,james brown,MATH-1080,2014
-MATH,1150,001,Contemp Math for Ele,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1150,2014
-MATH,1150,002,Contemp Math for Ele,0.59,0.31,0.09,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1150,2014
-MATH,1160,001,Contemp Math for Ele,0.8,0.1,0.07,0.03,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-1160,2014
-MATH,1990,400,Problem Solving in M,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,marion hanna,MATH-1990,2014
-MATH,2060,001,Calculus of Several,0.16,0.27,0.25,0.11,0.18,0.0,0.0,0.02,minerva rios-adams,MATH-2060,2014
-MATH,2060,002,Calculus of Several,0.26,0.21,0.21,0.07,0.14,0.0,0.0,0.12,gretchen matthews,MATH-2060,2014
-MATH,2060,003,Calculus of Several,0.32,0.42,0.13,0.05,0.03,0.0,0.0,0.05,xin liu,MATH-2060,2014
-MATH,2060,004,Calculus of Several,0.22,0.22,0.3,0.17,0.04,0.0,0.0,0.04,chanseok park,MATH-2060,2014
-MATH,2060,005,Calculus of Several,0.51,0.22,0.18,0.02,0.07,0.0,0.0,0.0,qingshan chen,MATH-2060,2014
-MATH,2060,006,Calculus of Several,0.09,0.03,0.36,0.03,0.21,0.0,0.0,0.27,eleanor jenkins,MATH-2060,2014
-MATH,2060,007,Calculus of Several,0.38,0.31,0.11,0.04,0.11,0.0,0.0,0.04,minerva rios-adams,MATH-2060,2014
-MATH,2060,008,Calculus of Several,0.14,0.28,0.14,0.08,0.22,0.0,0.0,0.14,gretchen matthews,MATH-2060,2014
-MATH,2060,009,Calculus of Several,0.16,0.32,0.25,0.09,0.14,0.0,0.0,0.05,minerva rios-adams,MATH-2060,2014
-MATH,2060,010,Calculus of Several,0.12,0.18,0.24,0.15,0.26,0.0,0.0,0.06,shari prevost,MATH-2060,2014
-MATH,2060,011,Calculus of Several,0.53,0.22,0.1,0.08,0.02,0.0,0.0,0.04,martin joha schmoll,MATH-2060,2014
-MATH,2060,012,Calculus of Several,0.2,0.28,0.28,0.11,0.11,0.0,0.0,0.02,timothy ch teitloff,MATH-2060,2014
-MATH,2060,013,Calculus of Several,0.13,0.44,0.33,0.0,0.09,0.0,0.0,0.0,brian fralix,MATH-2060,2014
-MATH,2060,014,Calculus of Several,0.29,0.29,0.16,0.08,0.11,0.0,0.0,0.08,gretchen matthews,MATH-2060,2014
-MATH,2060,015,Calculus of Several,0.49,0.27,0.14,0.0,0.08,0.0,0.0,0.03,sofya alekseeva,MATH-2060,2014
-MATH,2060,016,Calculus of Several,0.51,0.25,0.18,0.02,0.02,0.0,0.0,0.02,shitao liu,MATH-2060,2014
-MATH,2060,017,Calculus of Several,0.33,0.47,0.17,0.0,0.03,0.0,0.0,0.0,irina viktorova,MATH-2060,2014
-MATH,2060,018,Calculus of Several,0.28,0.21,0.19,0.09,0.23,0.0,0.0,0.0,timothy ch teitloff,MATH-2060,2014
-MATH,2060,019,Calculus of Several,0.42,0.37,0.18,0.0,0.0,0.0,0.0,0.03,irina viktorova,MATH-2060,2014
-MATH,2060,020,Calculus of Several,0.19,0.36,0.19,0.17,0.08,0.0,0.0,0.0,nathan jos adelgren,MATH-2060,2014
-MATH,2060,021,Calculus of Several,0.26,0.36,0.25,0.04,0.04,0.0,0.0,0.06,timothy ch teitloff,MATH-2060,2014
-MATH,2060,022,Calculus of Several,0.57,0.23,0.11,0.03,0.06,0.0,0.0,0.0,sofya alekseeva,MATH-2060,2014
-MATH,2060,100,Calc of Several Vars,0.4,0.4,0.0,0.05,0.0,0.0,0.0,0.15,shari prevost,MATH-2060,2014
-MATH,2070,001,Multivariable Calcul,0.16,0.21,0.32,0.05,0.21,0.0,0.0,0.05,alistair bentley,MATH-2070,2014
-MATH,2070,002,Multivariable Calcul,0.18,0.12,0.29,0.12,0.06,0.0,0.0,0.24,elaine ma sotherden,MATH-2070,2014
-MATH,2070,003,Multivariable Calcul,0.28,0.22,0.17,0.06,0.17,0.0,0.0,0.11,kara ail stasikelis,MATH-2070,2014
-MATH,2070,004,Multivariable Calcul,0.24,0.24,0.12,0.03,0.18,0.0,0.0,0.18,hui xue,MATH-2070,2014
-MATH,2070,005,Multivariable Calcul,0.27,0.18,0.18,0.0,0.09,0.0,0.0,0.27,elaine ma sotherden,MATH-2070,2014
-MATH,2070,006,Multivariable Calcul,0.21,0.21,0.32,0.11,0.11,0.0,0.0,0.05,alistair bentley,MATH-2070,2014
-MATH,2070,007,Multivariable Calcul,0.06,0.28,0.28,0.0,0.22,0.0,0.0,0.17,saba za alkaseasbeh,MATH-2070,2014
-MATH,2070,008,Multivariable Calcul,0.2,0.23,0.14,0.14,0.2,0.0,0.0,0.09,judith irene mcknew,MATH-2070,2014
-MATH,2070,009,Multivariable Calcul,0.32,0.11,0.11,0.21,0.21,0.0,0.0,0.05,kara ail stasikelis,MATH-2070,2014
-MATH,2070,010,Multivariable Calcul,0.22,0.22,0.11,0.11,0.28,0.0,0.0,0.06, ushijima-mwesigwa,MATH-2070,2014
-MATH,2070,011,Multivariable Calcul,0.12,0.36,0.15,0.15,0.06,0.0,0.0,0.15,judith irene mcknew,MATH-2070,2014
-MATH,2070,012,Multivariable Calcul,0.09,0.11,0.26,0.17,0.17,0.0,0.0,0.2,saba za alkaseasbeh,MATH-2070,2014
-MATH,2070,013,Multivariable Calcul,0.29,0.24,0.35,0.06,0.0,0.0,0.0,0.06,liem nguyen,MATH-2070,2014
-MATH,2070,014,Multivariable Calcul,0.06,0.61,0.17,0.0,0.11,0.0,0.0,0.06,garrett dranichak,MATH-2070,2014
-MATH,2070,015,Multivariable Calcul,0.22,0.33,0.22,0.0,0.11,0.0,0.0,0.11,liem nguyen,MATH-2070,2014
-MATH,2070,016,Multivariable Calcul,0.33,0.22,0.17,0.06,0.17,0.0,0.0,0.06, ushijima-mwesigwa,MATH-2070,2014
-MATH,2070,017,Multivariable Calcul,0.17,0.5,0.11,0.0,0.11,0.0,0.0,0.11,grady mcgowa thomas,MATH-2070,2014
-MATH,2070,018,Multivariable Calcul,0.2,0.13,0.13,0.2,0.27,0.0,0.0,0.07,garrett dranichak,MATH-2070,2014
-MATH,2070,019,Multivariable Calcul,0.12,0.18,0.35,0.0,0.35,0.0,0.0,0.0,grady mcgowa thomas,MATH-2070,2014
-MATH,2070,020,Multivariable Calcul,0.33,0.17,0.08,0.08,0.08,0.0,0.0,0.25,saba za alkaseasbeh,MATH-2070,2014
-MATH,2080,001,Intro to Ordin Diff,0.36,0.21,0.27,0.03,0.06,0.0,0.0,0.06,peter kiessler,MATH-2080,2014
-MATH,2080,002,Intro to Ordin Diff,0.33,0.31,0.14,0.03,0.11,0.0,0.0,0.08,timothy fra parrott,MATH-2080,2014
-MATH,2080,003,Intro to Ordin Diff,0.08,0.23,0.23,0.08,0.23,0.0,0.0,0.15,shari prevost,MATH-2080,2014
-MATH,2080,004,Intro to Ordin Diff,0.06,0.31,0.25,0.06,0.19,0.0,0.0,0.13,julie lassiter,MATH-2080,2014
-MATH,2080,005,Intro to Ordin Diff,0.47,0.11,0.22,0.03,0.11,0.0,0.0,0.06,timothy fra parrott,MATH-2080,2014
-MATH,2080,006,Intro to Ordin Diff,0.13,0.19,0.23,0.06,0.16,0.0,0.0,0.23,julie lassiter,MATH-2080,2014
-MATH,2080,007,Intro to Ordin Diff,0.28,0.22,0.22,0.11,0.08,0.0,0.0,0.08,timothy fra parrott,MATH-2080,2014
-MATH,2080,008,Intro to Ordin Diff,0.68,0.24,0.05,0.0,0.03,0.0,0.0,0.0,irina viktorova,MATH-2080,2014
-MATH,2080,009,Intro to Ordin Diff,0.29,0.29,0.29,0.0,0.11,0.0,0.0,0.03,brandon gra goodell,MATH-2080,2014
-MATH,2080,100,Intro to Ordin Diff,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,MATH-2080,2014
-MATH,2160,001,Geometry for Elem Sc,0.63,0.26,0.0,0.07,0.04,0.0,0.0,0.0,allison stoddard,MATH-2160,2014
-MATH,2160,002,Geometry for Elem Sc,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-2160,2014
-MATH,2500,001,Intro to Mathematica,0.8,0.11,0.06,0.0,0.0,0.0,0.0,0.03,daniel warner,MATH-2500,2014
-MATH,3020,001,Stat for Science & E,0.29,0.29,0.29,0.14,0.0,0.0,0.0,0.0,yanbo xia,MATH-3020,2014
-MATH,3020,002,Stat for Science & E,0.21,0.35,0.24,0.0,0.06,0.0,0.0,0.15,calvin williams,MATH-3020,2014
-MATH,3020,003,Stat for Science & E,0.09,0.41,0.29,0.0,0.0,0.0,0.0,0.21,calvin williams,MATH-3020,2014
-MATH,3020,004,Stat for Science & E,0.67,0.0,0.07,0.0,0.07,0.0,0.0,0.2,yanbo xia,MATH-3020,2014
-MATH,3020,005,Stat for Science & E,0.46,0.23,0.21,0.08,0.0,0.0,0.0,0.03,michael thom finney,MATH-3020,2014
-MATH,3020,006,Stat for Science & E,0.45,0.26,0.13,0.0,0.08,0.0,0.0,0.08,christopher mcmahan,MATH-3020,2014
-MATH,3020,007,Stat for Science & E,0.76,0.18,0.0,0.0,0.03,0.0,0.0,0.03,dominique morgan,MATH-3020,2014
-MATH,3110,001,Linear Algebra,0.13,0.21,0.21,0.13,0.21,0.0,0.0,0.13,mishko mitkovski,MATH-3110,2014
-MATH,3110,002,Linear Algebra,0.35,0.16,0.16,0.06,0.1,0.0,0.0,0.16,xuhong gao,MATH-3110,2014
-MATH,3110,003,Linear Algebra,0.21,0.21,0.21,0.14,0.1,0.0,0.0,0.14,felice manganiello,MATH-3110,2014
-MATH,3110,004,Linear Algebra,0.49,0.2,0.11,0.06,0.09,0.0,0.0,0.06,xiaoqian sun,MATH-3110,2014
-MATH,3110,005,Linear Algebra,0.3,0.33,0.18,0.09,0.06,0.0,0.0,0.03,svetlan poznanovikj,MATH-3110,2014
-MATH,3110,100,Linear Algebra (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,MATH-3110,2014
-MATH,3160,001,Prob Solving for Mat,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-3160,2014
-MATH,3190,001,Introduction to Proo,0.57,0.17,0.04,0.0,0.17,0.0,0.0,0.04,michael adam burr,MATH-3190,2014
-MATH,3190,002,Introduction to Proo,0.54,0.08,0.31,0.0,0.0,0.0,0.0,0.08,michael adam burr,MATH-3190,2014
-MATH,3600,001,Intermediate Math Co,0.4,0.27,0.07,0.03,0.13,0.0,0.0,0.1,neil calkin,MATH-3600,2014
-MATH,3650,001,Numerical Mthds for,0.14,0.24,0.24,0.21,0.1,0.0,0.0,0.07,christopher cox,MATH-3650,2014
-MATH,3650,002,Numerical Mthds for,0.12,0.24,0.21,0.12,0.06,0.0,0.0,0.24,christopher cox,MATH-3650,2014
-MATH,3650,003,Numerical Mthds for,0.32,0.44,0.12,0.03,0.03,0.0,0.0,0.06,timo johann heister,MATH-3650,2014
-MATH,3650,004,Numerical Mthds for,0.17,0.26,0.29,0.09,0.06,0.0,0.0,0.14,vincent ervin,MATH-3650,2014
-MATH,3990,001,CI in Mathematical S,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,MATH-3990,2014
-MATH,3990,001,CI in Mathematical S,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,laura jane shick,MATH-3990,2014
-MATH,4000,001,Theory of Probabilit,0.48,0.08,0.28,0.04,0.12,0.0,0.0,0.0,derek brown,MATH-4000,2014
-MATH,4000,002,Theory of Probabilit,0.44,0.15,0.24,0.06,0.03,0.0,0.0,0.09,yingbo li,MATH-4000,2014
-MATH,4070,001,Regress & Time-Serie,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-4070,2014
-MATH,4120,001,Intro to Modern Alge,0.08,0.17,0.5,0.08,0.08,0.0,0.0,0.08,xuhong gao,MATH-4120,2014
-MATH,4120,002,Intro to Modern Alge,0.3,0.3,0.13,0.17,0.1,0.0,0.0,0.0,kevin james,MATH-4120,2014
-MATH,4190,001,Discrete Math Struct,0.48,0.3,0.09,0.12,0.0,0.0,0.0,0.0,beth novick,MATH-4190,2014
-MATH,4310,001,Theory of Interest,0.53,0.24,0.06,0.06,0.06,0.0,0.0,0.06, erwin walker,MATH-4310,2014
-MATH,4340,001,Adv Engineering Math,0.17,0.2,0.23,0.07,0.07,0.0,0.0,0.27,eleanor jenkins,MATH-4340,2014
-MATH,4340,002,Adv Engineering Math,0.15,0.35,0.18,0.06,0.03,0.0,0.0,0.24,hyesuk lee,MATH-4340,2014
-MATH,4400,001,Linear Programming,0.41,0.23,0.18,0.05,0.09,0.0,0.0,0.05,akshay sunil gupte,MATH-4400,2014
-MATH,4530,001,Advanced Calculus I,0.18,0.53,0.18,0.03,0.03,0.0,0.0,0.06,taufiquar rahm khan,MATH-4530,2014
-MATH,4540,001,Advanced Calculus II,0.15,0.46,0.31,0.08,0.0,0.0,0.0,0.0,taufiquar rahm khan,MATH-4540,2014
-MATH,6120,001,Intro to Modern Alge,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,kevin james,MATH-6120,2014
-MATH,6340,001,Adv Engineering Math,0.34,0.41,0.15,0.0,0.05,0.0,0.0,0.05,vincent ervin,MATH-6340,2014
-MATH,6530,001,Advanced Calculus I,0.14,0.57,0.14,0.0,0.0,0.0,0.0,0.14,taufiquar rahm khan,MATH-6530,2014
-MATH,8000,001,Probability,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,MATH-8000,2014
-MATH,8010,001,General Linear Hypot,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,xiaoqian sun,MATH-8010,2014
-MATH,8040,001,Statistical Inferenc,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,MATH-8040,2014
-MATH,8050,001,Data Analysis,0.73,0.18,0.05,0.0,0.0,0.0,0.0,0.05,derek brown,MATH-8050,2014
-MATH,8100,001,Mathematical Program,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,matthew saltzman,MATH-8100,2014
-MATH,8120,001,Discrete Optimizatio,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,MATH-8120,2014
-MATH,8140,001,Network Flow Program,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,warren adams,MATH-8140,2014
-MATH,8170,001,Stochastic Mod in Op,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,peter kiessler,MATH-8170,2014
-MATH,8190,001,Multicriteria Optimi,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,MATH-8190,2014
-MATH,8210,001,Linear Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,MATH-8210,2014
-MATH,8230,001,Complex Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,MATH-8230,2014
-MATH,8510,001,Abstract Algebra I,0.57,0.14,0.14,0.0,0.0,0.0,0.0,0.14,felice manganiello,MATH-8510,2014
-MATH,8530,001,Matrix Analysis,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,james brown,MATH-8530,2014
-MATH,8550,001,Combinatorial Analys,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,MATH-8550,2014
-MATH,8600,001,Intro to Scientific,0.46,0.23,0.08,0.0,0.0,0.0,0.0,0.23,timo johann heister,MATH-8600,2014
-MATH,8610,001,Advanced Numerical A,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,hyesuk lee,MATH-8610,2014
-MATH,8650,001,Data Structures,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel warner,MATH-8650,2014
-MATH,8840,001,Statistics for Exper,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,MATH-8840,2014
-MATH,9810,001,Sel Top in Math Stat,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,yingbo li,MATH-9810,2014
-MATH,9830,001,Sel Top in Computati,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,qingshan chen,MATH-9830,2014
-MBA,8030,001,Stat Analy of Bus Op,0.46,0.43,0.09,0.0,0.03,0.0,0.0,0.0,yuhong he,MBA-8030,2014
-MBA,8060,001,Operations Mgt,0.31,0.51,0.07,0.0,0.02,0.0,0.0,0.09, sridharan,MBA-8060,2014
-MBA,8070,001,Financial Management,0.45,0.32,0.05,0.0,0.05,0.0,0.0,0.14,ramon tolb franklin,MBA-8070,2014
-MBA,8090,001,Org Beh & Hum Res Mg,0.55,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2014
-MBA,8090,002,Org Beh & Hum Res Mg,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2014
-MBA,8190,001,Intro to Acc and Fin,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,MBA-8190,2014
-MBA,8190,001,Intro to Acc and Fin,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,william hol johnson,MBA-8190,2014
-MBA,8290,001,Marketing Foundation,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,gary hunter,MBA-8290,2014
-MBA,8330,001,Real Estate Investmt,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,MBA-8330,2014
-MBA,8350,001,Investment Mgmt,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,uma sridharan,MBA-8350,2014
-MBA,8360,001,Real Estate Principl,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,MBA-8360,2014
-MBA,8370,001,Legal Environ of Bus,0.39,0.43,0.16,0.0,0.0,0.0,0.0,0.02,judson jahn,MBA-8370,2014
-MBA,8400,001,Entrepreneurship & V,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,MBA-8400,2014
-MBA,8420,001,R E Valuation,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,charles benja stone,MBA-8420,2014
-MBA,8430,001,Entrepreneurial Acco,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,sally kathr widener,MBA-8430,2014
-MBA,8440,001,Entrepreneurial Law,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,melinda davis lux,MBA-8440,2014
-MBA,8450,001,Tech & Innova Mgt,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8450,2014
-MBA,8480,001,Entrpr Mkting & Digi,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MBA-8480,2014
-MBA,8490,005,Entrepreneurial Strg,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8490,2014
-MBA,8510,001,Bus Operations & Log,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MBA-8510,2014
-MBA,8540,001,Mgrl Accounting,0.34,0.57,0.03,0.0,0.03,0.0,0.0,0.03,charles ellio davis,MBA-8540,2014
-MBA,8590,001,Mgr Decision Model,0.47,0.22,0.13,0.0,0.09,0.0,0.0,0.09,sara elizabet yoder,MBA-8590,2014
-MBA,8590,002,Mgr Decision Model,0.72,0.09,0.07,0.0,0.02,0.0,0.0,0.11,mark mcknew,MBA-8590,2014
-MBA,8600,001,Advanced Marketing S,0.34,0.55,0.11,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2014
-MBA,8600,002,Advanced Marketing S,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2014
-MBA,8610,001,Information Systems,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,MBA-8610,2014
-MBA,8620,001,Managerial Economics,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,scott templeton,MBA-8620,2014
-MBA,8620,002,Managerial Economics,0.72,0.23,0.04,0.0,0.0,0.0,0.0,0.0,stephen knec layton,MBA-8620,2014
-MBA,8700,001,Strategic Management,0.55,0.43,0.02,0.0,0.0,0.0,0.0,0.0,peter gianiodis,MBA-8700,2014
-MBA,8990,002,Creativity,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,MBA-8990,2014
-MBA,8990,003,International Busine,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8990,2014
-ME,2000,001,Sophomore Seminar,0.89,0.08,0.01,0.0,0.01,0.0,0.0,0.01,todd schweisinger,ME-2000,2014
-ME,2010,001,Statics & Dynamics,0.07,0.11,0.2,0.17,0.37,0.0,0.0,0.09,sherrill biggers,ME-2010,2014
-ME,2010,002,Statics & Dynamics,0.18,0.21,0.23,0.09,0.21,0.0,0.0,0.07,paul joseph,ME-2010,2014
-ME,2010,003,Statics & Dynamics,0.02,0.14,0.14,0.08,0.45,0.0,0.0,0.16,kalyan chakr katuri,ME-2010,2014
-ME,2030,001,Founda Th/Fl Syst,0.3,0.47,0.16,0.03,0.04,0.0,0.0,0.0,david zumbrunnen,ME-2030,2014
-ME,2040,001,Mechanics of Materia,0.15,0.38,0.34,0.08,0.05,0.0,0.0,0.0,michael porter,ME-2040,2014
-ME,2040,002,Mechanics of Materia,0.11,0.21,0.52,0.08,0.04,0.0,0.0,0.03,huijuan zhao,ME-2040,2014
-ME,2220,001,Mech Engr Lab I,0.19,0.44,0.38,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,002,Mech Engr Lab I,0.22,0.5,0.22,0.0,0.06,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,003,Mech Engr Lab I,0.15,0.75,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,005,Mech Engr Lab I,0.35,0.45,0.2,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,006,Mech Engr Lab I,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,007,Mech Engr Lab I,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,3000,001,Junior Honors Semina,0.0,0.0,0.0,0.0,0.0,0.91,0.0,0.09,paul joseph,ME-3000,2014
-ME,3030,002,Thermodynamics,0.31,0.4,0.2,0.07,0.0,0.0,0.0,0.02,richard miller,ME-3030,2014
-ME,3030,003,Thermodynamics,0.06,0.13,0.31,0.16,0.22,0.0,0.0,0.11,john saylor,ME-3030,2014
-ME,3040,001,Heat Transfer,0.19,0.26,0.32,0.14,0.03,0.0,0.0,0.06,jay ochterbeck,ME-3040,2014
-ME,3050,001,Model/an Dy Syst,0.21,0.32,0.3,0.02,0.06,0.0,0.0,0.09,mohammed fari daqaq,ME-3050,2014
-ME,3050,002,Model/an Dy Syst,0.12,0.67,0.18,0.03,0.0,0.0,0.0,0.0,yue wang,ME-3050,2014
-ME,3060,002,Fund Machine Design,0.26,0.43,0.2,0.07,0.0,0.0,0.0,0.04,todd schweisinger,ME-3060,2014
-ME,3060,003,Fund Machine Design,0.26,0.47,0.15,0.0,0.06,0.0,0.0,0.06,oliver myers,ME-3060,2014
-ME,3070,001,Found of Mechanical,0.32,0.42,0.12,0.04,0.04,0.0,0.0,0.06,lonny thompson,ME-3070,2014
-ME,3070,002,Found of Mechanical,0.09,0.56,0.29,0.06,0.0,0.0,0.0,0.0,gregory mocko,ME-3070,2014
-ME,3080,001,Fluid Mechanics,0.05,0.14,0.52,0.14,0.05,0.0,0.0,0.1,jean-marc delhaye,ME-3080,2014
-ME,3080,002,Fluid Mechanics,0.16,0.34,0.41,0.07,0.0,0.0,0.0,0.01,xiangchun xuan,ME-3080,2014
-ME,3080,003,Fluid Mechanics,0.38,0.28,0.26,0.03,0.05,0.0,0.0,0.0,marija vukicevic,ME-3080,2014
-ME,3120,001,Manuf Processes,0.5,0.38,0.05,0.02,0.0,0.0,0.0,0.05,hong seok choi,ME-3120,2014
-ME,3120,002,Manuf Processes,0.18,0.47,0.22,0.08,0.06,0.0,0.0,0.0,rod martinez-duarte,ME-3120,2014
-ME,3330,001,Mech Engr Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,3330,002,Mech Engr Lab II,0.31,0.5,0.0,0.06,0.0,0.0,0.0,0.13,todd schweisinger,ME-3330,2014
-ME,3330,003,Mech Engr Lab II,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,3330,004,Mech Engr Lab II,0.19,0.5,0.19,0.0,0.0,0.0,0.0,0.13,todd schweisinger,ME-3330,2014
-ME,3330,005,Mech Engr Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,3330,006,Mech Engr Lab II,0.08,0.85,0.0,0.0,0.0,0.0,0.0,0.08,todd schweisinger,ME-3330,2014
-ME,3330,007,Mech Engr Lab II,0.13,0.56,0.31,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,3330,008,Mech Engr Lab II,0.19,0.56,0.13,0.0,0.0,0.0,0.0,0.13,todd schweisinger,ME-3330,2014
-ME,4000,001,Senior Seminar,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03, ramasubramanian,ME-4000,2014
-ME,4010,001,Mech Engr Design,0.41,0.38,0.12,0.08,0.0,0.0,0.0,0.01,joshua summers,ME-4010,2014
-ME,4020,001,Intern in Engr Des,0.0,0.58,0.42,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2014
-ME,4020,002,Intern in Engr Des,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,ethan kung,ME-4020,2014
-ME,4020,002,Intern in Engr Des,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,kalyan chakr katuri,ME-4020,2014
-ME,4020,004,Intern in Engr Des,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-4020,2014
-ME,4020,005,Intern in Engr Des,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,ME-4020,2014
-ME,4030,001,Control Dynamic Syst,0.33,0.31,0.24,0.08,0.0,0.0,0.0,0.03,ardalan vahidi,ME-4030,2014
-ME,4180,001,F E A in M E Design,0.29,0.5,0.08,0.05,0.05,0.0,0.0,0.03,gang li,ME-4180,2014
-ME,4200,001,Ener Sources/Utiliz,0.26,0.54,0.2,0.0,0.0,0.0,0.0,0.0,david zumbrunnen,ME-4200,2014
-ME,4210,001,Intro to Comp Flow,0.38,0.19,0.27,0.12,0.0,0.0,0.0,0.04,chenning tong,ME-4210,2014
-ME,4400,001,Matls for Aggr Envir,0.58,0.33,0.04,0.04,0.0,0.0,0.0,0.0,mica grujicic,ME-4400,2014
-ME,4440,001,Mech Engr Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2014
-ME,4440,004,Mech Engr Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2014
-ME,4540,001,Design of Machine El,0.36,0.24,0.24,0.08,0.04,0.0,0.0,0.04,paul jeffrey meyer,ME-4540,2014
-ME,6210,001,Intro to Comp Flow,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,chenning tong,ME-6210,2014
-ME,6540,001,Des Machine Elements,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,ME-6540,2014
-ME,6930,001,Selected Topics Me:T,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-6930,2014
-ME,8010,001,Found of Fluid Mech,0.26,0.22,0.44,0.0,0.04,0.0,0.0,0.04,richard figliola,ME-8010,2014
-ME,8100,001,Macroscopic Thermo,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,jay ochterbeck,ME-8100,2014
-ME,8140,001,Turb Bound Layer,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,ME-8140,2014
-ME,8180,001,Intro to Fin Ele Ana,0.76,0.18,0.03,0.0,0.01,0.0,0.0,0.01,lonny thompson,ME-8180,2014
-ME,8230,001,Control Systems,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,john wagner,ME-8230,2014
-ME,8370,001,Theory of Elast I,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,ME-8370,2014
-ME,8430,001,Advanced Dynamics,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,phanin tallapragada,ME-8430,2014
-ME,8460,001,Inter Dynamics,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,mohammed fari daqaq,ME-8460,2014
-ME,8700,001,Adv Design Methods,0.47,0.26,0.21,0.0,0.03,0.0,0.0,0.03,georges fadel,ME-8700,2014
-ME,8710,001,Engr Optimization,0.57,0.34,0.04,0.0,0.02,0.0,0.0,0.04,georges fadel,ME-8710,2014
-ME,8930,027,ME SpecTopic - Optim,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,ardalan vahidi,ME-8930,2014
-MGT,2010,001,Principles of Mgt,0.31,0.37,0.21,0.05,0.06,0.0,0.0,0.01,katherine clark,MGT-2010,2014
-MGT,2010,002,Principles of Mgt,0.38,0.32,0.15,0.06,0.05,0.0,0.0,0.06,katherine clark,MGT-2010,2014
-MGT,2010,003,Principles of Mgt,0.36,0.36,0.19,0.03,0.04,0.0,0.0,0.01,katherine clark,MGT-2010,2014
-MGT,2010,004,Principles of Mgt,0.11,0.27,0.42,0.07,0.03,0.0,0.0,0.1,katherine clark,MGT-2010,2014
-MGT,2010,005,Principles of Mgt,0.31,0.41,0.14,0.06,0.0,0.0,0.0,0.08,tina robbins,MGT-2010,2014
-MGT,2010,006,Principles of Mgt,0.29,0.36,0.23,0.02,0.04,0.0,0.0,0.06,tina robbins,MGT-2010,2014
-MGT,2010,007,Principles of Mgt,0.25,0.37,0.22,0.06,0.07,0.0,0.0,0.02,tina robbins,MGT-2010,2014
-MGT,2010,008,Principles of Mgt,0.25,0.32,0.19,0.07,0.09,0.0,0.0,0.09,tina robbins,MGT-2010,2014
-MGT,2010,009,Principles of Mgt(HO,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,tina robbins,MGT-2010,2014
-MGT,2180,125,Management PC Applic,0.44,0.41,0.12,0.01,0.01,0.0,0.0,0.01, sridharan,MGT-2180,2014
-MGT,2180,125,Management PC Applic,0.44,0.41,0.12,0.01,0.01,0.0,0.0,0.01,ryan toole,MGT-2180,2014
-MGT,2180,200,Management PC Applic,0.43,0.34,0.14,0.02,0.0,0.0,0.0,0.07, sridharan,MGT-2180,2014
-MGT,2180,200,Management PC Applic,0.43,0.34,0.14,0.02,0.0,0.0,0.0,0.07,ryan toole,MGT-2180,2014
-MGT,2180,230,Management PC Applic,0.57,0.34,0.05,0.01,0.0,0.0,0.0,0.03, sridharan,MGT-2180,2014
-MGT,2180,230,Management PC Applic,0.57,0.34,0.05,0.01,0.0,0.0,0.0,0.03,ryan toole,MGT-2180,2014
-MGT,2180,905,Management PC Applic,0.47,0.34,0.11,0.02,0.02,0.0,0.0,0.04,ryan toole,MGT-2180,2014
-MGT,2180,905,Management PC Applic,0.47,0.34,0.11,0.02,0.02,0.0,0.0,0.04, sridharan,MGT-2180,2014
-MGT,3070,001,Human Resource Manag,0.19,0.68,0.06,0.0,0.03,0.0,0.0,0.03,kristin dam scott,MGT-3070,2014
-MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,MGT-3070,2014
-MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,MGT-3070,2014
-MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,katherine clark,MGT-3070,2014
-MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03, sridharan,MGT-3070,2014
-MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,katherine clark,MGT-3070,2014
-MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,marvin monroe ward,MGT-3070,2014
-MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,marvin monroe ward,MGT-3070,2014
-MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,marvin monroe ward,MGT-3070,2014
-MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,marvin monroe ward,MGT-3070,2014
-MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,katherine clark,MGT-3070,2014
-MGT,3070,006,Human Resource Manag,0.28,0.44,0.15,0.05,0.05,0.0,0.0,0.03,michael cole,MGT-3070,2014
-MGT,3070,007,Human Resource Manag,0.41,0.51,0.05,0.0,0.03,0.0,0.0,0.0,michael cole,MGT-3070,2014
-MGT,3100,001,Intermed Business St,0.15,0.3,0.13,0.08,0.23,0.0,0.0,0.13,sara elizabet yoder,MGT-3100,2014
-MGT,3100,002,Intermed Business St,0.23,0.23,0.3,0.08,0.08,0.0,0.0,0.1,sara elizabet yoder,MGT-3100,2014
-MGT,3100,003,Intermed Business St,0.39,0.14,0.25,0.14,0.06,0.0,0.0,0.03,sara elizabet yoder,MGT-3100,2014
-MGT,3100,005,Intermed Business St,0.28,0.28,0.25,0.13,0.0,0.0,0.0,0.08,zachary mo leffakis,MGT-3100,2014
-MGT,3100,006,Intermed Business St,0.55,0.3,0.13,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3100,2014
-MGT,3100,007,Intermed Business St,0.44,0.36,0.11,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3100,2014
-MGT,3100,008,Intermed Business St,0.33,0.23,0.26,0.03,0.03,0.0,0.0,0.13,zachary mo leffakis,MGT-3100,2014
-MGT,3100,009,Intermed Business St,0.07,0.27,0.17,0.07,0.05,0.0,0.0,0.37,niratc tungtisanont,MGT-3100,2014
-MGT,3100,011,Intermed Business St,0.27,0.4,0.17,0.0,0.07,0.0,0.0,0.1,yuhong he,MGT-3100,2014
-MGT,3100,B,Intermed Business St,0.29,0.44,0.15,0.07,0.05,0.0,0.0,0.0,james walsh,MGT-3100,2014
-MGT,3120,001,Decision Models for,0.29,0.15,0.44,0.07,0.05,0.0,0.0,0.0,mark mcknew,MGT-3120,2014
-MGT,3120,002,Decision Models for,0.09,0.49,0.29,0.0,0.11,0.0,0.0,0.02,mark mcknew,MGT-3120,2014
-MGT,3120,003,Decision Models for,0.18,0.42,0.33,0.02,0.04,0.0,0.0,0.0,mark mcknew,MGT-3120,2014
-MGT,3150,001,New Venture Creation,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,MGT-3150,2014
-MGT,3180,001,Mgt of Info Systems,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,heshan sun,MGT-3180,2014
-MGT,3180,002,Mgt of Info Systems,0.45,0.45,0.08,0.0,0.0,0.0,0.0,0.03,heshan sun,MGT-3180,2014
-MGT,3180,003,Mgt of Info Systems,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,dan jiang,MGT-3180,2014
-MGT,3180,004,Mgt of Info Systems,0.3,0.45,0.08,0.03,0.15,0.0,0.0,0.0,tina marie esposito,MGT-3180,2014
-MGT,3900,001,Ops Mgt,0.19,0.58,0.14,0.03,0.0,0.0,0.0,0.06,yunsik choi,MGT-3900,2014
-MGT,3900,002,Ops Mgt,0.44,0.36,0.15,0.0,0.05,0.0,0.0,0.0,qiong chen,MGT-3900,2014
-MGT,3900,003,Ops Mgt,0.33,0.51,0.13,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3900,2014
-MGT,3900,004,Ops Mgt,0.23,0.5,0.25,0.03,0.0,0.0,0.0,0.0,jerry kermi bilbrey,MGT-3900,2014
-MGT,3900,005,Ops Mgt,0.18,0.48,0.33,0.03,0.0,0.0,0.0,0.0,yann ferrand,MGT-3900,2014
-MGT,3900,006,Ops Mgt,0.16,0.29,0.23,0.0,0.1,0.0,0.0,0.23,qiong chen,MGT-3900,2014
-MGT,3900,007,Ops Mgt,0.3,0.41,0.24,0.03,0.03,0.0,0.0,0.0,remi charpin,MGT-3900,2014
-MGT,4000,001,Mgt of Org Beh,0.2,0.57,0.23,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2014
-MGT,4000,002,Mgt of Org Beh,0.25,0.5,0.2,0.0,0.0,0.0,0.0,0.05,michael cole,MGT-4000,2014
-MGT,4000,003,Mgt of Org Beh,0.15,0.48,0.33,0.03,0.03,0.0,0.0,0.0,philip roth,MGT-4000,2014
-MGT,4000,004,Mgt of Org Beh,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MGT-4000,2014
-MGT,4020,001,Ops Pln and Ctl,0.06,0.69,0.25,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4020,2014
-MGT,4020,002,Ops Pln and Ctl,0.15,0.69,0.08,0.08,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4020,2014
-MGT,4030,001,Bus Intelligence & A,0.23,0.46,0.23,0.0,0.08,0.0,0.0,0.0,siyuan li,MGT-4030,2014
-MGT,4080,001,Lean Operations,0.09,0.45,0.45,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MGT-4080,2014
-MGT,4110,001,Project Management,0.21,0.53,0.18,0.0,0.03,0.0,0.0,0.05,russell purvis,MGT-4110,2014
-MGT,4120,001,Supplier Management,0.04,0.64,0.28,0.04,0.0,0.0,0.0,0.0,shouqiang wang,MGT-4120,2014
-MGT,4150,001,Business Strategy,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2014
-MGT,4150,002,Business Strategy,0.19,0.52,0.29,0.0,0.0,0.0,0.0,0.0,peter gianiodis,MGT-4150,2014
-MGT,4150,003,Business Strategy,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2014
-MGT,4150,004,Business Strategy,0.37,0.45,0.08,0.0,0.11,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2014
-MGT,4150,006,Business Strategy,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2014
-MGT,4150,007,Business Strategy,0.17,0.46,0.32,0.02,0.0,0.0,0.0,0.02,jason wayne ridge,MGT-4150,2014
-MGT,4150,008,Business Strategy,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,MGT-4150,2014
-MGT,4150,009,Business Strategy,0.27,0.51,0.11,0.05,0.0,0.0,0.0,0.05,amy elizabet ingram,MGT-4150,2014
-MGT,4160,001,Special Topics Hr,0.44,0.44,0.08,0.03,0.0,0.0,0.0,0.0,kristin dam scott,MGT-4160,2014
-MGT,4230,001,Intern Bus Mgt,0.19,0.31,0.44,0.03,0.03,0.0,0.0,0.0,wayne stewart,MGT-4230,2014
-MGT,4230,002,Intern Bus Mgt,0.24,0.26,0.38,0.06,0.06,0.0,0.0,0.0,wayne stewart,MGT-4230,2014
-MGT,4230,003,Intern Bus Mgt,0.0,0.49,0.4,0.06,0.06,0.0,0.0,0.0,janis miller,MGT-4230,2014
-MGT,4230,004,Intern Bus Mgt,0.1,0.51,0.29,0.03,0.02,0.0,0.0,0.05,janis miller,MGT-4230,2014
-MGT,4240,001,Global Supply Chain,0.2,0.63,0.09,0.03,0.0,0.0,0.0,0.06,yann ferrand,MGT-4240,2014
-MGT,4270,001,Managing Improvement,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MGT-4270,2014
-MGT,4300,001,Statistical Modeling,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,jerry kermi bilbrey,MGT-4300,2014
-MGT,4310,001,Emp Rights & Resp,0.18,0.58,0.2,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,MGT-4310,2014
-MGT,4350,001,Pers Interviewing,0.33,0.38,0.2,0.1,0.0,0.0,0.0,0.0,philip roth,MGT-4350,2014
-MGT,4520,001,Business Analysis,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jackie patri london,MGT-4520,2014
-MGT,4550,001,Emerging I T Trends,0.39,0.53,0.06,0.0,0.0,0.0,0.0,0.03,jason thatcher,MGT-4550,2014
-MGT,4560,001,Business Info Mgt,0.33,0.25,0.33,0.08,0.0,0.0,0.0,0.0,siyuan li,MGT-4560,2014
-MGT,8690,001,Project Mgt,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,MGT-8690,2014
-MGT,9050,001,Research Methods,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,varun grover,MGT-9050,2014
-MHA,7210,001,Hlth Care Del Sys,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,MHA-7210,2014
-MICR,1010,001,Microbes & Hum Aff,0.58,0.21,0.12,0.02,0.06,0.0,0.0,0.01,michael childress,MICR-1010,2014
-MICR,1010,001,Microbes & Hum Aff,0.58,0.21,0.12,0.02,0.06,0.0,0.0,0.01,thomas hughes,MICR-1010,2014
-MICR,2050,001,Introductory Micro,0.42,0.42,0.15,0.0,0.0,0.0,0.0,0.01,john abercrombie,MICR-2050,2014
-MICR,3050,001,General Microbiology,0.53,0.25,0.16,0.06,0.0,0.0,0.0,0.01,krista barr rudolph,MICR-3050,2014
-MICR,3050,002,General Microbiology,0.32,0.46,0.17,0.04,0.0,0.0,0.0,0.02,krista barr rudolph,MICR-3050,2014
-MICR,4010,001,Microbial Diversity,0.17,0.32,0.2,0.15,0.05,0.0,0.0,0.12,barbara campbell,MICR-4010,2014
-MICR,4050,001,Adv Microbial Ecol o,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4050,2014
-MICR,4140,001,Basic Immunology,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,yanzhang wei,MICR-4140,2014
-MICR,4150,001,Microbial Genetics,0.25,0.31,0.25,0.17,0.02,0.0,0.0,0.0,min cao,MICR-4150,2014
-MICR,4250,001,Microbial Gen Lab,0.71,0.14,0.0,0.14,0.0,0.0,0.0,0.0,min cao,MICR-4250,2014
-MICR,4250,002,Microbial Gen Lab,0.68,0.18,0.14,0.0,0.0,0.0,0.0,0.0,min cao,MICR-4250,2014
-MKT,3010,001,Prin of Marketing,0.21,0.59,0.17,0.02,0.0,0.0,0.0,0.01,james gaubert,MKT-3010,2014
-MKT,3010,002,Prin of Marketing,0.15,0.44,0.3,0.07,0.04,0.0,0.0,0.0,carter wil mcelveen,MKT-3010,2014
-MKT,3010,003,Prin of Marketing,0.25,0.47,0.21,0.05,0.02,0.0,0.0,0.01,carter wil mcelveen,MKT-3010,2014
-MKT,3010,004,Prin of Marketing,0.28,0.42,0.28,0.02,0.0,0.0,0.0,0.0,carter wil mcelveen,MKT-3010,2014
-MKT,3010,005,Prin of Marketing,0.15,0.41,0.29,0.08,0.03,0.0,0.0,0.03,amanda cooper fine,MKT-3010,2014
-MKT,3010,006,Prin of Marketing,0.16,0.48,0.24,0.08,0.02,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2014
-MKT,3010,007,Prin of Marketing,0.21,0.39,0.33,0.05,0.01,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2014
-MKT,3010,008,Prin of Marketing,0.33,0.42,0.15,0.03,0.06,0.0,0.0,0.0,patricia knowles,MKT-3010,2014
-MKT,3020,001,Consumer Behavior,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2014
-MKT,3020,002,Consumer Behavior,0.43,0.45,0.11,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2014
-MKT,3020,003,Consumer Behavior,0.36,0.5,0.1,0.02,0.02,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2014
-MKT,3020,004,Consumer Behavior,0.4,0.34,0.24,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2014
-MKT,3210,001,Sports Marketing,0.43,0.43,0.11,0.0,0.0,0.0,0.0,0.04,delancy bennett,MKT-3210,2014
-MKT,4200,001,Professional Selling,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,gary hunter,MKT-4200,2014
-MKT,4200,002,Professional Selling,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2014
-MKT,4200,003,Professional Selling,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,jesse moore,MKT-4200,2014
-MKT,4200,004,Professional Selling,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,ryan mullins,MKT-4200,2014
-MKT,4230,001,Promotional Strategy,0.2,0.44,0.31,0.02,0.02,0.0,0.0,0.0,patricia knowles,MKT-4230,2014
-MKT,4240,001,Sales Management,0.32,0.58,0.03,0.0,0.0,0.0,0.0,0.06,ryan mullins,MKT-4240,2014
-MKT,4260,001,Business-to-Business,0.24,0.53,0.2,0.0,0.0,0.0,0.0,0.02,james gaubert,MKT-4260,2014
-MKT,4270,001,International Mktg,0.27,0.58,0.11,0.04,0.0,0.0,0.0,0.0,roger gomes,MKT-4270,2014
-MKT,4270,002,International Mktg,0.24,0.46,0.22,0.07,0.0,0.0,0.0,0.02,roger gomes,MKT-4270,2014
-MKT,4270,003,International Mktg,0.16,0.64,0.14,0.07,0.0,0.0,0.0,0.0,roger gomes,MKT-4270,2014
-MKT,4270,004,International Mktg,0.19,0.53,0.19,0.0,0.0,0.0,0.0,0.08,thomas poehlman,MKT-4270,2014
-MKT,4280,001,Services Marketing,0.23,0.44,0.33,0.0,0.0,0.0,0.0,0.0,stephen grove,MKT-4280,2014
-MKT,4280,002,Services Marketing,0.05,0.74,0.21,0.0,0.0,0.0,0.0,0.0,stephen grove,MKT-4280,2014
-MKT,4310,001,Marketing Research,0.18,0.5,0.27,0.05,0.0,0.0,0.0,0.0,peter weathers,MKT-4310,2014
-MKT,4310,002,Marketing Research,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2014
-MKT,4310,003,Marketing Research,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2014
-MKT,4310,004,Marketing Research,0.16,0.72,0.08,0.0,0.0,0.0,0.0,0.04,william kilbourne,MKT-4310,2014
-MKT,4430,001,Advertising Strategy,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,MKT-4430,2014
-MKT,4450,001,Macromarketing,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,MKT-4450,2014
-MKT,4500,001,Strategic Mktg Mgt,0.14,0.62,0.24,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2014
-MKT,4500,002,Strategic Mktg Mgt,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-4500,2014
-MKT,4500,003,Strategic Mktg Mgt,0.16,0.76,0.08,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4500,2014
-MKT,4950,001,Marketing Metrics,0.23,0.46,0.23,0.08,0.0,0.0,0.0,0.0,peter weathers,MKT-4950,2014
-MKT,8610,001,Marketing Research,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,christopher hopkins,MKT-8610,2014
-MKT,8630,001,Buyer Behavior,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,thomas poehlman,MKT-8630,2014
-ML,1010,001,Leadership Fund I,0.72,0.16,0.0,0.0,0.0,0.0,0.0,0.12,robert rozetar,ML-1010,2014
-ML,1010,001,Leadership Fund I,0.72,0.16,0.0,0.0,0.0,0.0,0.0,0.12,joe luis medrano,ML-1010,2014
-ML,1010,002,Leadership Fund I,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,robert rozetar,ML-1010,2014
-ML,1010,002,Leadership Fund I,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,joe luis medrano,ML-1010,2014
-ML,2010,001,Leadership Develop I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,ML-2010,2014
-ML,2010,001,Leadership Develop I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,rene romo,ML-2010,2014
-ML,2010,002,Leadership Develop I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,rene romo,ML-2010,2014
-ML,2010,002,Leadership Develop I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,ML-2010,2014
-ML,3010,001,Adv Leadership I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jason danie bielski,ML-3010,2014
-ML,3010,001,Adv Leadership I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,ML-3010,2014
-ML,3010,002,Adv Leadership I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,ML-3010,2014
-ML,3010,002,Adv Leadership I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jason danie bielski,ML-3010,2014
-ML,4010,001,Org Leadership I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,ML-4010,2014
-ML,4010,001,Org Leadership I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,phillip ale andrews,ML-4010,2014
-ML,4010,003,Org Leadership I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,phillip ale andrews,ML-4010,2014
-ML,4010,003,Org Leadership I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,ML-4010,2014
-MSE,2100,001,Intro to Mat Science,0.4,0.33,0.16,0.05,0.03,0.0,0.0,0.03,eric skaar,MSE-2100,2014
-MSE,2100,002,Intro to Mat Science,0.31,0.36,0.17,0.06,0.04,0.0,0.0,0.06,kyle brinkman,MSE-2100,2014
-MSE,2100,003,Intro to Mat Science,0.25,0.38,0.19,0.07,0.02,0.0,0.0,0.09,eric skaar,MSE-2100,2014
-MSE,2100,004,Intro to Mat Science,0.33,0.4,0.14,0.03,0.04,0.0,0.0,0.05,eric skaar,MSE-2100,2014
-MSE,3190,001,Materials Proc I,0.14,0.36,0.36,0.09,0.05,0.0,0.0,0.0,henry rack,MSE-3190,2014
-MSE,3190,002,Materials Proc I,0.45,0.43,0.11,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,MSE-3190,2014
-MSE,3190,002,Materials Proc I,0.45,0.43,0.11,0.0,0.0,0.0,0.0,0.0,olin mefford,MSE-3190,2014
-MSE,3260,001,Thermo of Materials,0.26,0.5,0.18,0.03,0.0,0.0,0.0,0.03,gary lickfield,MSE-3260,2014
-MSE,3260,002,Thermo of Materials,0.09,0.41,0.38,0.06,0.0,0.0,0.0,0.06,gary lickfield,MSE-3260,2014
-MSE,3270,001,Transport Phenomena,0.77,0.16,0.06,0.0,0.01,0.0,0.0,0.01,konstantin kornev,MSE-3270,2014
-MSE,3270,002,Transport Phenomena,0.47,0.35,0.09,0.09,0.0,0.0,0.0,0.0,fei peng,MSE-3270,2014
-MSE,4020,001,Solid State Material,0.28,0.44,0.28,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,MSE-4020,2014
-MSE,4130,001,Noncrystalline Mater,0.57,0.21,0.21,0.0,0.0,0.0,0.0,0.0,herbert david leigh,MSE-4130,2014
-MSE,4150,001,Polymer Sc Engr,0.3,0.34,0.21,0.06,0.06,0.0,0.0,0.04,marek urban,MSE-4150,2014
-MSE,4150,002,Polymer Sc Engr,0.35,0.35,0.15,0.11,0.01,0.0,0.0,0.02,olin mefford,MSE-4150,2014
-MSE,4410,001,Mfg Laboratory,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,MSE-4410,2014
-MSE,4550,001,Polymer Fiber Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,olin mefford,MSE-4550,2014
-MSE,4550,002,Polymer Fiber Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,olin mefford,MSE-4550,2014
-MSE,4580,001,Surf Phen in Ms&E,0.21,0.29,0.14,0.29,0.07,0.0,0.0,0.0,konstantin kornev,MSE-4580,2014
-MSE,4610,001,Polymer & Fiber Mate,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,MSE-4610,2014
-MSE,8010,001,Grad Sem in Material,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,MSE-8010,2014
-MSE,8010,001,Grad Sem in Material,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,MSE-8010,2014
-MSE,8200,001,Def Mech in Solids,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,marian kennedy,MSE-8200,2014
-MSE,8270,001,Kin of Phase Tran,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,MSE-8270,2014
-MSE,8520,001,Polymer Science II,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,igor luzinov,MSE-8520,2014
-MUSC,1110,001,Beginning Class Guit,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,david stevenson,MUSC-1110,2014
-MUSC,1420,001,Music Theory I,0.58,0.08,0.25,0.0,0.08,0.0,0.0,0.0,david conley,MUSC-1420,2014
-MUSC,1420,002,Music Theory I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,david conley,MUSC-1420,2014
-MUSC,2100,001,Music in West World,0.58,0.32,0.03,0.03,0.0,0.0,0.0,0.03,eric lapin,MUSC-2100,2014
-MUSC,2100,002,Music in West World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,lisa sain odom,MUSC-2100,2014
-MUSC,2100,003,Music in West World,0.84,0.1,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-2100,2014
-MUSC,2100,004,Music in West World,0.52,0.13,0.19,0.1,0.06,0.0,0.0,0.0,linda li-bleuel,MUSC-2100,2014
-MUSC,2100,005,Music in West World,0.83,0.1,0.05,0.0,0.02,0.0,0.0,0.0,timothy ra hurlburt,MUSC-2100,2014
-MUSC,2100,006,Music in West World,0.6,0.23,0.03,0.0,0.0,0.0,0.0,0.13,rhea beth jacobus,MUSC-2100,2014
-MUSC,2100,007,Music in West World,0.76,0.17,0.0,0.0,0.03,0.0,0.0,0.03,rhea beth jacobus,MUSC-2100,2014
-MUSC,2100,008,Music in West World,0.66,0.25,0.06,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,MUSC-2100,2014
-MUSC,2100,009,Music in West World,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,evan michael jacobi,MUSC-2100,2014
-MUSC,2100,010,Music in West World,0.84,0.0,0.16,0.0,0.0,0.0,0.0,0.0,linda dzuris,MUSC-2100,2014
-MUSC,2100,012,Music in West World,0.52,0.35,0.1,0.0,0.0,0.0,0.0,0.03,lea kibler,MUSC-2100,2014
-MUSC,3080,001,Surv of Broadway I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey christmas,MUSC-3080,2014
-MUSC,3110,001,Hist of Amer Music,0.56,0.28,0.13,0.0,0.03,0.0,0.0,0.0,ned hosler,MUSC-3110,2014
-MUSC,3120,001,History of Jazz,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-3120,2014
-MUSC,3130,001,Hist of Rock & Roll,0.46,0.39,0.07,0.04,0.0,0.0,0.0,0.04,hamilton altstatt,MUSC-3130,2014
-MUSC,3170,001,Hist of Country Mus,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,ned hosler,MUSC-3170,2014
-MUSC,3180,001,Hist of Audio Tech,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,MUSC-3180,2014
-MUSC,3420,001,Women's Breakout Ens,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,david conley,MUSC-3420,2014
-MUSC,3610,001,Marching Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.01,timothy ra hurlburt,MUSC-3610,2014
-MUSC,3610,001,Marching Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,MUSC-3610,2014
-MUSC,3630,001,Jazz Ensemble,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,timothy ra hurlburt,MUSC-3630,2014
-MUSC,3700,001,Clemson University S,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,justin durham,MUSC-3700,2014
-MUSC,3720,001,Men's Glee,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,david conley,MUSC-3720,2014
-MUSC,4150,001,Music Hist to 1750,0.29,0.18,0.29,0.12,0.12,0.0,0.0,0.0,justin durham,MUSC-4150,2014
-NPL,3000,001,Nonprofit Leadership,0.7,0.15,0.04,0.0,0.0,0.0,0.0,0.11,tracy diane lamb,NPL-3000,2014
-NPL,3000,002,Nonprofit Leadership,0.72,0.12,0.04,0.0,0.08,0.0,0.0,0.04,tracy diane lamb,NPL-3000,2014
-NURS,1020,001,Nrsg Success Skills,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,kristin goodenow,NURS-1020,2014
-NURS,1400,001,Comp App Hlth Care,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,NURS-1400,2014
-NURS,3030,001,Nursing of Adults,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,corinne croc harmon,NURS-3030,2014
-NURS,3030,001,Nursing of Adults,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,NURS-3030,2014
-NURS,3040,001,Pathophysiology,0.52,0.46,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,NURS-3040,2014
-NURS,3040,400,Pathophysiology,0.43,0.38,0.1,0.0,0.05,0.0,0.0,0.05,catherine si murton,NURS-3040,2014
-NURS,3040,401,Pathophysiology,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,NURS-3040,2014
-NURS,3050,001,Psychosocial Nursing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,NURS-3050,2014
-NURS,3100,001,Health Assessment,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3100,2014
-NURS,3100,400,Health Assessment,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.05,jason thrift,NURS-3100,2014
-NURS,3120,001,Foundations of Nurs,0.25,0.65,0.08,0.0,0.0,0.0,0.0,0.02,angela pye,NURS-3120,2014
-NURS,3120,400,Foundations of Nurs,0.14,0.81,0.0,0.0,0.0,0.0,0.0,0.05,wanda leigh taylor,NURS-3120,2014
-NURS,3190,400,Health Assessment fo,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,NURS-3190,2014
-NURS,3200,400,Prof in Nurs,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,mary steck,NURS-3200,2014
-NURS,3230,400,Gerontology Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,tawny jenn mcintosh,NURS-3230,2014
-NURS,3300,002,Research in Nursing,0.91,0.05,0.05,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-3300,2014
-NURS,3330,400,Health Care Genetics,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,NURS-3330,2014
-NURS,3400,001,Pharmther Nursing,0.43,0.43,0.06,0.06,0.02,0.0,0.0,0.02,catherine si murton,NURS-3400,2014
-NURS,3400,400,Pharmther Nursing,0.29,0.52,0.05,0.05,0.05,0.0,0.0,0.05,catherine si murton,NURS-3400,2014
-NURS,4010,001,Mental Health Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-4010,2014
-NURS,4030,200,Complex Nursing of A,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,NURS-4030,2014
-NURS,4030,230,Complex Nursing of A,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,NURS-4030,2014
-NURS,4100,001,Lead Mgt Practicum,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,NURS-4100,2014
-NURS,4100,001,Lead Mgt Practicum,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,portia botchway,NURS-4100,2014
-NURS,4100,400,Lead Mgt Practicum,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,NURS-4100,2014
-NURS,4100,400,Lead Mgt Practicum,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,portia botchway,NURS-4100,2014
-NURS,4110,001,Nursing of Children,0.66,0.29,0.05,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-4110,2014
-NURS,4120,001,Nurs Women and Fam,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2014
-NURS,4150,001,Comm Hlth Nursing,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,jackie gillespie,NURS-4150,2014
-NURS,8050,400,Pharmaco Adv Nurs,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8050,2014
-NURS,8060,400,Advan Assessment for,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,NURS-8060,2014
-NURS,8060,400,Advan Assessment for,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,NURS-8060,2014
-NURS,8090,400,Pathophysiology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,NURS-8090,2014
-NURS,8090,400,Pathophysiology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,julia eggert,NURS-8090,2014
-NURS,8190,400,Developing Family,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-8190,2014
-NURS,8190,400,Developing Family,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,NURS-8190,2014
-NURS,8200,400,Child & Adol Nursing,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-8200,2014
-NUTR,2030,001,Intro Princ of Human,0.42,0.34,0.15,0.02,0.02,0.0,0.0,0.04,deborah an hutcheon,NUTR-2030,2014
-NUTR,2050,001,Nutr for Nurs Prof,0.66,0.31,0.02,0.01,0.0,0.0,0.0,0.0,deborah an hutcheon,NUTR-2050,2014
-NUTR,2160,001,Evidence-Based Nutri,0.73,0.19,0.03,0.0,0.0,0.0,0.0,0.05,angela fraser,NUTR-2160,2014
-NUTR,4190,001,Professional Dev in,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,NUTR-4190,2014
-NUTR,4240,001,Medical Nutr Thera I,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,rita haliena,NUTR-4240,2014
-NUTR,4510,001,Human Nutrition,0.39,0.44,0.11,0.05,0.02,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4510,2014
-PA,1010,001,Intro to Perf Arts,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,david hartmann,PA-1010,2014
-PA,1030,001,Portfolio I,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,linda dzuris,PA-1030,2014
-PA,2010,001,Career Planning and,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,ned hosler,PA-2010,2014
-PA,2790,001,Perf Arts Pract I,0.86,0.0,0.09,0.0,0.05,0.0,0.0,0.0,kenneth moore,PA-2790,2014
-PA,2800,001,Perf Arts Pract II,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,kenneth moore,PA-2800,2014
-PA,3010,001,Prin of Arts Admin,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,paul buyer,PA-3010,2014
-PADM,7020,400,Research Methods,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,PADM-7020,2014
-PADM,8220,400,Public Policy Proces,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,mark daniel mellott,PADM-8220,2014
-PADM,8290,400,Public Financial Man,0.4,0.47,0.0,0.0,0.0,0.0,0.0,0.13,robert frager,PADM-8290,2014
-PADM,8510,400,Emergency Management,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,steven batson,PADM-8510,2014
-PADM,8680,400,Local Government Adm,0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,alfred bundrick,PADM-8680,2014
-PADM,8780,404,COMMUNICATIONS FOR P,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,scott schmidt,PADM-8780,2014
-PAS,3010,001,Pan African Studies,0.48,0.3,0.15,0.04,0.0,0.0,0.0,0.02,abel bartley,PAS-3010,2014
-PDBE,8010,001,Advanced Theory in E,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,PDBE-8010,2014
-PDBE,8010,001,Advanced Theory in E,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,PDBE-8010,2014
-PES,1040,001,Introduction to Plan,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,paula agudelo,PES-1040,2014
-PES,2020,001,Soils,0.19,0.41,0.33,0.03,0.03,0.0,0.0,0.01,dara michelle park,PES-2020,2014
-PES,4850,001,Environmental Soil C,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,PES-4850,2014
-PHIL,1010,001,Intro to Phil Prob,0.76,0.15,0.06,0.0,0.03,0.0,0.0,0.0,david stegall,PHIL-1010,2014
-PHIL,1010,002,Intro to Phil Prob,0.71,0.09,0.09,0.0,0.0,0.0,0.0,0.12,david stegall,PHIL-1010,2014
-PHIL,1010,003,Intro to Phil Prob,0.37,0.34,0.26,0.0,0.0,0.0,0.0,0.03,christopher grau,PHIL-1010,2014
-PHIL,1020,001,Intro to Logic,0.14,0.74,0.09,0.0,0.0,0.0,0.0,0.03,kelly smith,PHIL-1020,2014
-PHIL,1020,002,Intro to Logic,0.09,0.76,0.15,0.0,0.0,0.0,0.0,0.0,kelly smith,PHIL-1020,2014
-PHIL,1020,003,Intro to Logic,0.67,0.21,0.03,0.06,0.03,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2014
-PHIL,1020,004,Intro to Logic,0.83,0.13,0.0,0.03,0.0,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2014
-PHIL,1020,005,Intro to Logic,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,gregory scott moss,PHIL-1020,2014
-PHIL,1020,006,Intro to Logic,0.74,0.09,0.06,0.0,0.0,0.0,0.0,0.12,gregory scott moss,PHIL-1020,2014
-PHIL,1020,007,Intro to Logic,0.64,0.27,0.0,0.06,0.0,0.0,0.0,0.03,gregory scott moss,PHIL-1020,2014
-PHIL,1030,001,Intro to Ethics (HON,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,PHIL-1030,2014
-PHIL,1030,002,Intro to Ethics,0.29,0.29,0.17,0.14,0.09,0.0,0.0,0.03,jennifer ingle,PHIL-1030,2014
-PHIL,1030,003,Intro to Ethics,0.47,0.44,0.03,0.0,0.0,0.0,0.0,0.06,michael hal hannen,PHIL-1030,2014
-PHIL,1030,004,Intro to Ethics,0.14,0.51,0.29,0.06,0.0,0.0,0.0,0.0,jennifer ingle,PHIL-1030,2014
-PHIL,1030,005,Intro to Ethics,0.24,0.52,0.09,0.0,0.06,0.0,0.0,0.09,charles starkey,PHIL-1030,2014
-PHIL,1030,006,Intro to Ethics,0.51,0.34,0.03,0.03,0.03,0.0,0.0,0.06,ryan lake,PHIL-1030,2014
-PHIL,1030,008,Intro to Ethics,0.33,0.43,0.19,0.0,0.05,0.0,0.0,0.0,ryan lake,PHIL-1030,2014
-PHIL,1030,009,Intro to Ethics,0.51,0.37,0.09,0.0,0.0,0.0,0.0,0.03,ryan lake,PHIL-1030,2014
-PHIL,3030,001,Phil of Religion,0.5,0.36,0.0,0.07,0.0,0.0,0.0,0.07,gregory scott moss,PHIL-3030,2014
-PHIL,3040,001,Moral Philosophy,0.19,0.38,0.19,0.0,0.13,0.0,0.0,0.13,charles starkey,PHIL-3040,2014
-PHIL,3050,001,Existentialism,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,david stegall,PHIL-3050,2014
-PHIL,3150,001,Ancient Philosophy,0.18,0.43,0.25,0.07,0.07,0.0,0.0,0.0,stephen satris,PHIL-3150,2014
-PHIL,3160,001,Mod Phil,0.61,0.3,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,PHIL-3160,2014
-PHIL,3170,001,19th-Century Philoso,0.15,0.27,0.27,0.06,0.09,0.0,0.0,0.15,william maker,PHIL-3170,2014
-PHIL,3200,001,Soc and Pol Phil,0.28,0.44,0.16,0.0,0.08,0.0,0.0,0.04,todd may,PHIL-3200,2014
-PHIL,3260,001,Science and Values,0.36,0.48,0.06,0.0,0.03,0.0,0.0,0.06,andrew garnar,PHIL-3260,2014
-PHIL,3260,002,Science and Values,0.41,0.38,0.15,0.0,0.03,0.0,0.0,0.03,andrew garnar,PHIL-3260,2014
-PHIL,3260,003,Science and Values,0.49,0.49,0.0,0.0,0.03,0.0,0.0,0.0,andrew garnar,PHIL-3260,2014
-PHIL,3430,001,Phil of Law,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,david stegall,PHIL-3430,2014
-PHIL,3440,001,Business Ethics,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,david stegall,PHIL-3440,2014
-PHIL,3450,001,Environmental Ethics,0.42,0.21,0.06,0.12,0.12,0.0,0.0,0.06,jennifer ingle,PHIL-3450,2014
-PHIL,3490,001,Gender and Sexuality,0.33,0.48,0.04,0.0,0.07,0.0,0.0,0.07,diane perpich,PHIL-3490,2014
-PHIL,3550,001,Phil Mind & Cog Sci,0.4,0.4,0.1,0.0,0.0,0.0,0.0,0.1,andrew garnar,PHIL-3550,2014
-PHIL,3990,001,Philosophy Portfolio,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,kelly smith,PHIL-3990,2014
-PHIL,4020,001,Topics in Philosophy,0.41,0.41,0.12,0.0,0.06,0.0,0.0,0.0,todd may,PHIL-4020,2014
-PHIL,4020,002,Topics in Philosophy,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,candice delmas,PHIL-4020,2014
-PHIL,4750,001,Philosophy of Film,0.27,0.45,0.09,0.09,0.0,0.0,0.0,0.09,christopher grau,PHIL-4750,2014
-PHSC,1180,001,Intro Phys & Astro,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1180,2014
-PHYS,1220,001,Physics With Cal I,0.31,0.3,0.23,0.06,0.05,0.0,0.0,0.04,lih-sin the,PHYS-1220,2014
-PHYS,1220,002,Physics With Cal I,0.2,0.28,0.26,0.15,0.07,0.0,0.0,0.04,lih-sin the,PHYS-1220,2014
-PHYS,1220,004,Phys W/Cal I (MAJ ON,0.28,0.39,0.11,0.11,0.0,0.0,0.0,0.11,murray daw,PHYS-1220,2014
-PHYS,1240,001,Physics Lab I,0.06,0.83,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,002,Physics Lab I,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,003,Physics Lab I,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,004,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,005,Physics Lab I,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,006,Physics Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,007,Physics Lab I,0.27,0.67,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-1240,2014
-PHYS,1240,008,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,009,Physics Lab I,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,010,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,011,Physics Lab I,0.06,0.82,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,PHYS-1240,2014
-PHYS,1240,012,Physics Lab I,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,013,Physics Lab I,0.19,0.63,0.13,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,014,Physics Lab I,0.06,0.63,0.19,0.0,0.06,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,016,Physics Lab I,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-1240,2014
-PHYS,1240,017,Physics Lab I,0.29,0.64,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-1240,2014
-PHYS,2070,001,General Physics I,0.42,0.35,0.16,0.04,0.01,0.0,0.0,0.02,amy liann pope,PHYS-2070,2014
-PHYS,2070,002,General Physics I,0.52,0.33,0.09,0.02,0.01,0.0,0.0,0.02,amy liann pope,PHYS-2070,2014
-PHYS,2070,003,General Physics I,0.34,0.28,0.22,0.07,0.06,0.0,0.0,0.03,pooja puneet,PHYS-2070,2014
-PHYS,2080,001,General Physics II,0.42,0.37,0.12,0.04,0.04,0.0,0.0,0.03,pooja puneet,PHYS-2080,2014
-PHYS,2090,001,Gen Phys Lab I,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2014
-PHYS,2090,002,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,003,Gen Phys Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,004,Gen Phys Lab I,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2014
-PHYS,2090,005,Gen Phys Lab I,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,006,Gen Phys Lab I,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,007,Gen Phys Lab I,0.68,0.23,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2014
-PHYS,2090,008,Gen Phys Lab I,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,009,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,010,Gen Phys Lab I,0.55,0.27,0.14,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2014
-PHYS,2090,011,Gen Phys Lab I,0.38,0.42,0.17,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2014
-PHYS,2090,012,Gen Phys Lab I,0.57,0.35,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,013,Gen Phys Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,014,Gen Phys Lab I,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,015,Gen Phys Lab I,0.26,0.57,0.09,0.0,0.0,0.0,0.0,0.09,jerry hester,PHYS-2090,2014
-PHYS,2090,016,Gen Phys Lab I,0.5,0.27,0.18,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2014
-PHYS,2090,017,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2014
-PHYS,2090,018,Gen Phys Lab I,0.55,0.41,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,019,Gen Phys Lab I,0.14,0.64,0.23,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,020,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2014
-PHYS,2090,021,Gen Phys Lab I,0.18,0.59,0.09,0.0,0.0,0.0,0.0,0.14,jerry hester,PHYS-2090,2014
-PHYS,2090,022,Gen Phys Lab I,0.43,0.43,0.09,0.04,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,023,Gen Phys Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,024,Gen Phys Lab I,0.55,0.23,0.14,0.0,0.0,0.0,0.0,0.09,jerry hester,PHYS-2090,2014
-PHYS,2100,001,Gen Phys Lab II,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,002,Gen Phys Lab II,0.33,0.54,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,003,Gen Phys Lab II,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,004,Gen Phys Lab II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,006,Gen Phys Lab II,0.3,0.52,0.04,0.0,0.0,0.0,0.0,0.13,jerry hester,PHYS-2100,2014
-PHYS,2100,007,Gen Phys Lab II,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,008,Gen Phys Lab II,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2210,001,Physics With Cal II,0.2,0.5,0.21,0.06,0.02,0.0,0.0,0.01,jason stratfo brown,PHYS-2210,2014
-PHYS,2210,002,Physics With Cal II,0.27,0.52,0.16,0.03,0.02,0.0,0.0,0.0,jason stratfo brown,PHYS-2210,2014
-PHYS,2210,003,Physics With Cal II,0.35,0.46,0.12,0.03,0.02,0.0,0.0,0.02,jason stratfo brown,PHYS-2210,2014
-PHYS,2210,004,Physics With Cal II,0.24,0.47,0.2,0.05,0.02,0.0,0.0,0.02,lih-sin the,PHYS-2210,2014
-PHYS,2210,007,Physics With Cal II,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,sean brittain,PHYS-2210,2014
-PHYS,2220,001,Phys With Cal III,0.28,0.5,0.11,0.06,0.06,0.0,0.0,0.0,jian he,PHYS-2220,2014
-PHYS,2230,001,Physics Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,002,Physics Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,003,Physics Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,004,Physics Lab II,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,005,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,006,Physics Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,007,Physics Lab II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,009,Physics Lab II,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2014
-PHYS,2230,010,Physics Lab II,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,011,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,012,Physics Lab II,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2014
-PHYS,2230,013,Physics Lab II,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2014
-PHYS,2230,016,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,017,Physics Lab II,0.27,0.6,0.07,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-2230,2014
-PHYS,2450,001,Physics of Climate,0.23,0.41,0.11,0.03,0.01,0.0,0.0,0.21,john meriwether,PHYS-2450,2014
-PHYS,3000,001,Intro to Research,0.82,0.05,0.05,0.05,0.05,0.0,0.0,0.0,terry tritt,PHYS-3000,2014
-PHYS,3000,001,Intro to Research,0.82,0.05,0.05,0.05,0.05,0.0,0.0,0.0,jens oberheide,PHYS-3000,2014
-PHYS,3110,001,Methods Theor Phys,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,feng ding,PHYS-3110,2014
-PHYS,3210,001,Mechanics I,0.11,0.32,0.05,0.16,0.11,0.0,0.0,0.26,gerald lehmacher,PHYS-3210,2014
-PHYS,3250,001,Exper Physics I,0.28,0.67,0.0,0.0,0.0,0.0,0.0,0.06,hye jung kang,PHYS-3250,2014
-PHYS,3250,001,Exper Physics I,0.28,0.67,0.0,0.0,0.0,0.0,0.0,0.06,chad sosolik,PHYS-3250,2014
-PHYS,4420,001,Electromagnetics II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,endre andras takacs,PHYS-4420,2014
-PHYS,4550,001,Quantum Physics I,0.08,0.67,0.25,0.0,0.0,0.0,0.0,0.0,antony valentini,PHYS-4550,2014
-PHYS,6520,001,Int to Nuclear Phys,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jeremy king,PHYS-6520,2014
-PHYS,6550,001,Quantum Physics I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,antony valentini,PHYS-6550,2014
-PHYS,8110,001,Meth of Theor Phys I,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley meyer,PHYS-8110,2014
-PHYS,8210,001,Classical Mech I,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,dieter hartmann,PHYS-8210,2014
-PHYS,8750,007,Intro to Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jens oberheide,PHYS-8750,2014
-PHYS,8750,007,Intro to Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,terry tritt,PHYS-8750,2014
-PHYS,9510,001,Quantum Mech I,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,PHYS-9510,2014
-PKSC,1010,001,Pkgsc Orientation,0.81,0.08,0.06,0.05,0.0,0.0,0.0,0.0,robert truett moore,PKSC-1010,2014
-PKSC,1020,001,Intro to Pkg Sci,0.05,0.36,0.4,0.12,0.06,0.0,0.0,0.0,heather batt,PKSC-1020,2014
-PKSC,2020,001,Packaging Mtl & Mfg,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2020,2014
-PKSC,2040,001,Container Systems,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2040,2014
-PKSC,2200,001,Product & Pkg Design,0.69,0.23,0.06,0.0,0.0,0.0,0.0,0.02,william aaro snyder,PKSC-2200,2014
-PKSC,4010,001,Pkg Machinery,0.33,0.41,0.22,0.04,0.0,0.0,0.0,0.0,anthony lou pometto,PKSC-4010,2014
-PKSC,4030,001,Pkg Career Prep,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2014
-PKSC,4040,001,Mech Prop & Prot Pkg,0.21,0.29,0.29,0.09,0.08,0.0,0.0,0.03,gregory batt,PKSC-4040,2014
-PKSC,4160,001,Appl Polymers in Pkg,0.09,0.44,0.35,0.07,0.02,0.0,0.0,0.02,duncan darby,PKSC-4160,2014
-PKSC,4200,001,Pkg Design & Dev,0.56,0.41,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2014
-PKSC,4540,001,Prod Pkg Evl Lab,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,gregory batt,PKSC-4540,2014
-PKSC,4540,002,Prod Pkg Evl Lab,0.13,0.5,0.25,0.06,0.06,0.0,0.0,0.0,gregory batt,PKSC-4540,2014
-PKSC,4540,003,Prod Pkg Evl Lab,0.13,0.31,0.38,0.0,0.06,0.0,0.0,0.13,gregory batt,PKSC-4540,2014
-PKSC,4540,004,Prod Pkg Evl Lab,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2014
-PKSC,4540,005,Prod Pkg Evl Lab,0.25,0.33,0.17,0.0,0.25,0.0,0.0,0.0,gregory batt,PKSC-4540,2014
-PKSC,4640,001,Fd & Hc Pkg Systems,0.3,0.63,0.03,0.03,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2014
-PLPA,3100,001,Principles of Plant,0.15,0.65,0.15,0.05,0.0,0.0,0.0,0.0,steven nye jeffers,PLPA-3100,2014
-POSC,1010,001,Amer National Govt,0.16,0.3,0.24,0.18,0.02,0.0,0.0,0.1,joseph earl stewart,POSC-1010,2014
-POSC,1010,002,Amer National Govt,0.27,0.29,0.27,0.07,0.05,0.0,0.0,0.05,jeffrey scott peake,POSC-1010,2014
-POSC,1010,003,Amer National Govt,0.13,0.51,0.18,0.07,0.04,0.0,0.0,0.07,laura olson,POSC-1010,2014
-POSC,1020,001,Intro Intl Relations,0.15,0.42,0.25,0.02,0.04,0.0,0.0,0.11,aron geo tannenbaum,POSC-1020,2014
-POSC,1020,002,Intro Intl Relations,0.11,0.53,0.29,0.02,0.02,0.0,0.0,0.04,lydia loui lundgren,POSC-1020,2014
-POSC,1020,003,Intro Intl Relations,0.14,0.49,0.22,0.04,0.01,0.0,0.0,0.09,colin pearce,POSC-1020,2014
-POSC,1030,001,Intro to Political T,0.09,0.35,0.33,0.13,0.04,0.0,0.0,0.07,james woodard,POSC-1030,2014
-POSC,1030,002,Intro to Political T,0.22,0.51,0.12,0.0,0.02,0.0,0.0,0.12,jeremy fortier,POSC-1030,2014
-POSC,1040,001,Intro Compar Pol,0.21,0.38,0.35,0.03,0.0,0.0,0.0,0.03,xiaobo hu,POSC-1040,2014
-POSC,1040,002,Intro Compar Pol,0.17,0.56,0.21,0.04,0.02,0.0,0.0,0.0,katherine am curtis,POSC-1040,2014
-POSC,1990,001,Intro Pol Sci,0.44,0.27,0.14,0.04,0.09,0.0,0.0,0.02,meredith petersheim,POSC-1990,2014
-POSC,3020,001,State and Loc Gov,0.13,0.6,0.17,0.0,0.07,0.0,0.0,0.03,bruce ransom,POSC-3020,2014
-POSC,3110,001,Model United Nations,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,xiaobo hu,POSC-3110,2014
-POSC,3120,001,State Student Leg,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michael cunningham,POSC-3120,2014
-POSC,3410,001,Quant Meth in Pol Sc,0.31,0.31,0.08,0.15,0.15,0.0,0.0,0.0,steven vince miller,POSC-3410,2014
-POSC,3610,001,Intl Pol in Crisis,0.21,0.46,0.1,0.02,0.19,0.0,0.0,0.02,steven vince miller,POSC-3610,2014
-POSC,3620,001,Intl Organizations,0.27,0.38,0.15,0.08,0.04,0.0,0.0,0.08,lydia loui lundgren,POSC-3620,2014
-POSC,3630,001,Us Foreign Policy,0.31,0.54,0.12,0.0,0.0,0.0,0.0,0.04,vladimir matic,POSC-3630,2014
-POSC,3710,001,European Politics,0.34,0.56,0.09,0.0,0.0,0.0,0.0,0.0,vladimir matic,POSC-3710,2014
-POSC,4030,001,United States Congre,0.22,0.36,0.2,0.13,0.07,0.0,0.0,0.02,jeffrey allen fine,POSC-4030,2014
-POSC,4210,001,Public Policy,0.27,0.09,0.27,0.09,0.09,0.0,0.0,0.18,adam warber,POSC-4210,2014
-POSC,4230,001,Urban Politics,0.1,0.7,0.1,0.0,0.0,0.0,0.0,0.1,bruce ransom,POSC-4230,2014
-POSC,4360,001,Law Courts Politics,0.28,0.46,0.23,0.03,0.0,0.0,0.0,0.0,joseph earl stewart,POSC-4360,2014
-POSC,4370,001,Constitut Law: Right,0.47,0.43,0.07,0.0,0.03,0.0,0.0,0.0,daniel frost,POSC-4370,2014
-POSC,4380,001,Constitut Law: Struc,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,POSC-4380,2014
-POSC,4420,001,Pol Parties & Elect,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,laura olson,POSC-4420,2014
-POSC,4500,001,Classical & Modern L,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,brandon turner,POSC-4500,2014
-POSC,4550,001,Pol Thght of America,0.24,0.55,0.19,0.02,0.0,0.0,0.0,0.0, bradley thompson,POSC-4550,2014
-POSC,4560,001,Diplomacy,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,vladimir matic,POSC-4560,2014
-POSC,4710,001,Russian Politics,0.5,0.32,0.05,0.05,0.05,0.0,0.0,0.05,aron geo tannenbaum,POSC-4710,2014
-POSC,4760,001,Middle East Politics,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,vladimir matic,POSC-4760,2014
-POSC,4890,002,WWII: Ideol. in Worl,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,james woodard,POSC-4890,2014
-POSC,4890,003,International Law,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,katherine am curtis,POSC-4890,2014
-PRTM,1950,002,Pro Golf Management,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-1950,2014
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,herbert chancellor,PRTM-2260,2014
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,denise mar anderson,PRTM-2260,2014
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,teresa walto tucker,PRTM-2260,2014
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,francis mcguire,PRTM-2260,2014
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,elizabeth baldwin,PRTM-2260,2014
-PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,robert brookover,PRTM-2260,2014
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,elizabeth baldwin,PRTM-2270,2014
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,denise mar anderson,PRTM-2270,2014
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,teresa walto tucker,PRTM-2270,2014
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,robert brookover,PRTM-2270,2014
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,francis mcguire,PRTM-2270,2014
-PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,herbert chancellor,PRTM-2270,2014
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,robert brookover,PRTM-2290,2014
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,francis mcguire,PRTM-2290,2014
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,denise mar anderson,PRTM-2290,2014
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,elizabeth baldwin,PRTM-2290,2014
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,teresa walto tucker,PRTM-2290,2014
-PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,herbert chancellor,PRTM-2290,2014
-PRTM,2950,001,Pro Golf Management,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-2950,2014
-PRTM,3070,002,Facility Operations,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,craig goodman,PRTM-3070,2014
-PRTM,3200,001,Recreation Policy,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,bernard mwe kitheka,PRTM-3200,2014
-PRTM,3220,001,Facilitation Techniq,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,PRTM-3220,2014
-PRTM,3240,001,Assessment & Plannin,0.83,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3240,2014
-PRTM,3250,001,Global Persp in Rec,0.55,0.18,0.24,0.0,0.03,0.0,0.0,0.0,skye arthur-banning,PRTM-3250,2014
-PRTM,3300,001,Visit Ser & Interp,0.36,0.43,0.14,0.07,0.0,0.0,0.0,0.0,robert bixler,PRTM-3300,2014
-PRTM,3430,001,Spl Asp of Tourist B,0.35,0.6,0.05,0.0,0.0,0.0,0.0,0.0,william norman,PRTM-3430,2014
-PRTM,3430,002,Spl Asp of Tourist B,0.4,0.45,0.08,0.05,0.03,0.0,0.0,0.0,william norman,PRTM-3430,2014
-PRTM,3450,001,Tourism Management,0.43,0.32,0.17,0.05,0.03,0.0,0.0,0.0,lauren duffy,PRTM-3450,2014
-PRTM,3530,002,Foundations of Camp,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,gwynn powell,PRTM-3530,2014
-PRTM,3920,001,Special Event Manage,0.79,0.1,0.04,0.04,0.02,0.0,0.0,0.02,kenneth backman,PRTM-3920,2014
-PRTM,3920,002,Special Event Manage,0.81,0.13,0.02,0.0,0.02,0.0,0.0,0.02,kenneth backman,PRTM-3920,2014
-PRTM,3950,001,PGM Seminar III,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3950,2014
-PRTM,3950,001,PGM Seminar III,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-3950,2014
-PRTM,3980,003,Creative Inquiry in,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,kellie aman walters,PRTM-3980,2014
-PRTM,3980,011,Creative Inquiry in,0.76,0.0,0.0,0.0,0.0,0.0,0.0,0.24,skye arthur-banning,PRTM-3980,2014
-PRTM,4030,001,Elem of Rec/Pk Plan,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,robert baxte powell,PRTM-4030,2014
-PRTM,4070,001,Pers Admin in PRTM,0.32,0.38,0.18,0.12,0.0,0.0,0.0,0.0,daniel mor anderson,PRTM-4070,2014
-PRTM,4470,001,Perspect Intl Travel,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,lauren duffy,PRTM-4470,2014
-PRTM,4550,001,Adv Program Planning,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-4550,2014
-PRTM,4830,001,Golf Club Mgt & Ops,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-4830,2014
-PRTM,4950,001,Pro Golf Management,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-4950,2014
-PRTM,4950,001,Pro Golf Management,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-4950,2014
-PRTM,4980,001,Creative Inquiry in,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,PRTM-4980,2014
-PRTM,4980,007,Creative Inquiry in,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,denise mar anderson,PRTM-4980,2014
-PRTM,4980,009,Creative Inquiry in,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,leslie conrad,PRTM-4980,2014
-PRTM,4980,009,Creative Inquiry in,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-4980,2014
-PRTM,8010,002,Phil Found of PRTM,0.57,0.22,0.13,0.0,0.09,0.0,0.0,0.0,dorothy schmalz,PRTM-8010,2014
-PRTM,8080,001,Behavioral Aspects,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-8080,2014
-PRTM,8220,002,Strateg Planning in,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,PRTM-8220,2014
-PRTM,8560,001,Heritage Tourism,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,PRTM-8560,2014
-PRTM,9000,004,The Politics of Scie,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,gary edward machlis,PRTM-9000,2014
-PSYC,2010,001,Intro to Psychology,0.27,0.34,0.25,0.08,0.04,0.0,0.0,0.02,edwin brainerd,PSYC-2010,2014
-PSYC,2010,002,Intro to Psychology,0.33,0.34,0.21,0.08,0.02,0.0,0.0,0.03,jo anne jorgensen,PSYC-2010,2014
-PSYC,2010,003,Intro to Psychology,0.51,0.25,0.15,0.04,0.01,0.0,0.0,0.03,chong hyon pak,PSYC-2010,2014
-PSYC,2010,004,Intro to Psychology,0.25,0.45,0.2,0.0,0.0,0.0,0.0,0.1,fred switzer,PSYC-2010,2014
-PSYC,2010,005,Intro to Psychology,0.27,0.43,0.14,0.04,0.03,0.0,0.0,0.09,mary taylor,PSYC-2010,2014
-PSYC,2010,006,Intro to Psychology,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,christopher pagano,PSYC-2010,2014
-PSYC,2010,104,Intro to Psychology,0.33,0.47,0.16,0.0,0.02,0.0,0.0,0.02,fred switzer,PSYC-2010,2014
-PSYC,2020,001,Intro Psychology Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,eric mckibben,PSYC-2020,2014
-PSYC,2020,002,Intro Psychology Lab,0.76,0.06,0.0,0.06,0.12,0.0,0.0,0.0,eric mckibben,PSYC-2020,2014
-PSYC,2020,003,Intro Psychology Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,eric mckibben,PSYC-2020,2014
-PSYC,2020,004,Intro Psychology Lab,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,eric mckibben,PSYC-2020,2014
-PSYC,2020,005,Intro Psychology Lab,0.79,0.13,0.04,0.04,0.0,0.0,0.0,0.0,lauren elizab ellis,PSYC-2020,2014
-PSYC,2020,006,Intro Psychology Lab,0.81,0.1,0.05,0.05,0.0,0.0,0.0,0.0,hannah jeann murphy,PSYC-2020,2014
-PSYC,3060,001,Human Sexual Beh,0.54,0.22,0.13,0.06,0.04,0.0,0.0,0.02,bruce michael king,PSYC-3060,2014
-PSYC,3090,100,Intro Exp Psych,0.25,0.39,0.2,0.05,0.05,0.0,0.0,0.07,jennifer bai bisson,PSYC-3090,2014
-PSYC,3090,200,Intro Exp Psych,0.33,0.42,0.09,0.08,0.03,0.0,0.0,0.05,patrick rosopa,PSYC-3090,2014
-PSYC,3100,100,Advanced Experimenta,0.32,0.42,0.21,0.0,0.05,0.0,0.0,0.0,jennifer bai bisson,PSYC-3100,2014
-PSYC,3100,200,Advanced Experimenta,0.76,0.06,0.06,0.0,0.12,0.0,0.0,0.0,robert campbell,PSYC-3100,2014
-PSYC,3100,300,Advanced Experimenta,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2014
-PSYC,3100,400,Advanced Experimenta,0.78,0.06,0.0,0.06,0.06,0.0,0.0,0.06,alice miche brawley,PSYC-3100,2014
-PSYC,3100,500,Advanced Experimenta,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,allison lei wallace,PSYC-3100,2014
-PSYC,3100,600,Advanced Experimenta,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2014
-PSYC,3240,001,Physiological Psych,0.33,0.34,0.14,0.07,0.07,0.0,0.0,0.04,claudio cantalupo,PSYC-3240,2014
-PSYC,3240,002,Physiological Psych,0.25,0.41,0.16,0.1,0.07,0.0,0.0,0.0,june pilcher,PSYC-3240,2014
-PSYC,3330,001,Cognitive Psych,0.64,0.2,0.09,0.06,0.0,0.0,0.0,0.01,paul steven merritt,PSYC-3330,2014
-PSYC,3330,002,Cognitive Psych,0.72,0.13,0.12,0.01,0.0,0.0,0.0,0.01,paul steven merritt,PSYC-3330,2014
-PSYC,3340,001,Cognitive Psych Lab,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,phillip weis jasper,PSYC-3340,2014
-PSYC,3340,002,Cognitive Psych Lab,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,ashley ann sewall,PSYC-3340,2014
-PSYC,3400,001,Lifespan Development,0.26,0.31,0.26,0.11,0.01,0.0,0.0,0.04,pamela alley,PSYC-3400,2014
-PSYC,3520,001,Social Psychology,0.34,0.4,0.2,0.06,0.0,0.0,0.0,0.0,jo anne jorgensen,PSYC-3520,2014
-PSYC,3520,002,Social Psychology,0.32,0.39,0.24,0.03,0.0,0.0,0.0,0.01,jo anne jorgensen,PSYC-3520,2014
-PSYC,3520,003,Social Psychology (H,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-3520,2014
-PSYC,3640,001,Industrial Psych,0.56,0.31,0.09,0.01,0.03,0.0,0.0,0.0,eric mckibben,PSYC-3640,2014
-PSYC,3680,001,Organizational Psych,0.38,0.38,0.14,0.07,0.03,0.0,0.0,0.0,thomas britt,PSYC-3680,2014
-PSYC,3690,001,Leadership in Orgs,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.01,eric mckibben,PSYC-3690,2014
-PSYC,3830,001,Abnormal Psychology,0.29,0.26,0.23,0.17,0.06,0.0,0.0,0.0,pamela alley,PSYC-3830,2014
-PSYC,3830,002,Abnormal Psychology,0.42,0.39,0.14,0.06,0.0,0.0,0.0,0.0,pamela alley,PSYC-3830,2014
-PSYC,3830,003,Abnormal Psychology,0.37,0.34,0.18,0.08,0.0,0.0,0.0,0.03,heidi marie zinzow,PSYC-3830,2014
-PSYC,4080,001,Women and Psychology,0.5,0.25,0.17,0.04,0.0,0.0,0.0,0.04,robin mari kowalski,PSYC-4080,2014
-PSYC,4150,001,Systems and Theories,0.38,0.22,0.09,0.19,0.06,0.0,0.0,0.06,edwin brainerd,PSYC-4150,2014
-PSYC,4150,002,Systems and Theories,0.33,0.43,0.13,0.1,0.0,0.0,0.0,0.0,edwin brainerd,PSYC-4150,2014
-PSYC,4220,001,Perception,0.19,0.15,0.22,0.33,0.07,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2014
-PSYC,4220,002,Perception,0.27,0.5,0.12,0.04,0.04,0.0,0.0,0.04,christopher pagano,PSYC-4220,2014
-PSYC,4430,001,Infant & Child Dev,0.58,0.31,0.12,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-4430,2014
-PSYC,4430,002,Infant & Child Dev,0.44,0.33,0.15,0.0,0.0,0.0,0.0,0.07,sarah mae sanborn,PSYC-4430,2014
-PSYC,4560,001,Psychophysiology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,eric muth,PSYC-4560,2014
-PSYC,4710,001,Psych of Testing,0.85,0.08,0.0,0.0,0.04,0.0,0.0,0.04,larry alton pace,PSYC-4710,2014
-PSYC,4800,001,Health Psychology,0.48,0.24,0.24,0.0,0.0,0.0,0.0,0.04,james mccubbin,PSYC-4800,2014
-PSYC,4880,002,Psychotherapy,0.84,0.04,0.04,0.0,0.04,0.0,0.0,0.04,cynthia pury,PSYC-4880,2014
-PSYC,4890,001,Psychology of Music,0.48,0.36,0.08,0.0,0.0,0.0,0.0,0.08,claudio cantalupo,PSYC-4890,2014
-PSYC,4890,001,Psychology of Music,0.48,0.36,0.08,0.0,0.0,0.0,0.0,0.08,robert campbell,PSYC-4890,2014
-PSYC,4890,002,Teamwork In 21st Cen,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,marissa leig porter,PSYC-4890,2014
-PSYC,4920,001,Senior Laboratory,0.75,0.13,0.06,0.0,0.06,0.0,0.0,0.0,amelia jea kinsella,PSYC-4920,2014
-PSYC,4920,002,Senior Laboratory,0.8,0.08,0.08,0.0,0.0,0.0,0.0,0.04,amelia jea kinsella,PSYC-4920,2014
-PSYC,4920,003,Senior Laboratory,0.76,0.14,0.0,0.05,0.0,0.0,0.0,0.05,jessica anne stahl,PSYC-4920,2014
-PSYC,4920,004,Senior Laboratory,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jessica anne stahl,PSYC-4920,2014
-PSYC,4930,001,Pract Clinical Psych,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,PSYC-4930,2014
-PSYC,8100,001,Research Design I,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0, dewayne moore,PSYC-8100,2014
-PSYC,8220,001,Percept & Perform,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard tyrrell,PSYC-8220,2014
-PSYC,8330,001,Adv Cog Psych,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,leo gugerty,PSYC-8330,2014
-PSYC,8350,001,Adv Human Factors,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,leo gugerty,PSYC-8350,2014
-PSYC,8680,001,Leadership in Orgs,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,patrick raymark,PSYC-8680,2014
-PSYC,8730,001,SEM in App Psych,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0, dewayne moore,PSYC-8730,2014
-PSYC,8990,003,Training & Dev,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,marissa leig porter,PSYC-8990,2014
-RCID,8130,002,Special Topics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,RCID-8130,2014
-RED,8000,001,Real Estate Dvlpment,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8000,2014
-RED,8160,001,Preservation Feasibi,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8160,2014
-REL,1010,001,Intro to Religion,0.18,0.35,0.12,0.06,0.12,0.0,0.0,0.18,peter cohen,REL-1010,2014
-REL,1010,002,Intro to Religion,0.07,0.27,0.33,0.2,0.07,0.0,0.0,0.07,peter cohen,REL-1010,2014
-REL,1010,004,Intro to Religion,0.09,0.33,0.24,0.18,0.09,0.0,0.0,0.06,peter cohen,REL-1010,2014
-REL,1020,002,World Religions,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,robert stephens,REL-1020,2014
-REL,1020,003,World Religions,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,robert stephens,REL-1020,2014
-REL,1020,004,World Religions,0.5,0.29,0.18,0.04,0.0,0.0,0.0,0.0,robert stephens,REL-1020,2014
-REL,1020,005,World Religions,0.58,0.27,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,REL-1020,2014
-REL,3010,001,Old Testament,0.44,0.38,0.16,0.0,0.03,0.0,0.0,0.0,steven grosby,REL-3010,2014
-REL,3020,001,New Testament Lit,0.39,0.52,0.06,0.03,0.0,0.0,0.0,0.0,benjamin white,REL-3020,2014
-REL,3100,002,History of Religion,0.19,0.38,0.13,0.06,0.06,0.0,0.0,0.19,james brad jeffries,REL-3100,2014
-REL,3120,001,Hinduism,0.71,0.14,0.04,0.0,0.0,0.0,0.0,0.11,robert stephens,REL-3120,2014
-REL,3150,001,Islam,0.35,0.42,0.13,0.03,0.06,0.0,0.0,0.0,mashal saif,REL-3150,2014
-REL,4010,001,Stud Biblical Litera,0.53,0.27,0.0,0.0,0.0,0.0,0.0,0.2,steven grosby,REL-4010,2014
-RS,3010,001,Rural Sociology,0.26,0.44,0.26,0.0,0.0,0.0,0.0,0.04,kenneth robinson,RS-3010,2014
-RUSS,1010,001,Elementary Russian,0.46,0.23,0.08,0.08,0.08,0.0,0.0,0.08,joan bridgwood,RUSS-1010,2014
-SOC,2010,003,Introduction to Soci,0.37,0.29,0.24,0.05,0.03,0.0,0.0,0.01,stephani southworth,SOC-2010,2014
-SOC,2010,004,Introduction to Soci,0.16,0.51,0.18,0.09,0.04,0.0,0.0,0.02,mary louise barr,SOC-2010,2014
-SOC,2010,007,Introduction to Soci,0.37,0.41,0.13,0.04,0.02,0.0,0.0,0.02,stephani southworth,SOC-2010,2014
-SOC,2010,009,Introduction to Soci,0.21,0.51,0.23,0.0,0.04,0.0,0.0,0.0,stephani southworth,SOC-2010,2014
-SOC,2010,010,Introduction to Soci,0.47,0.43,0.08,0.02,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2014
-SOC,2010,011,Introduction to Soci,0.41,0.35,0.2,0.02,0.0,0.0,0.0,0.02,jennifer le holland,SOC-2010,2014
-SOC,2010,012,Introduction to Soci,0.54,0.33,0.08,0.0,0.0,0.0,0.0,0.04,jennifer le holland,SOC-2010,2014
-SOC,2010,013,Introduction to Soci,0.37,0.43,0.15,0.04,0.0,0.0,0.0,0.0,stephani southworth,SOC-2010,2014
-SOC,2010,014,Introduction to Soci,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,SOC-2010,2014
-SOC,2010,015,Introduction to Soci,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,SOC-2010,2014
-SOC,2010,016,Introduction to Soci,0.52,0.45,0.02,0.0,0.0,0.0,0.0,0.01,jeffrey edwards,SOC-2010,2014
-SOC,2010,018,Introduction to Soci,0.34,0.3,0.21,0.11,0.02,0.0,0.0,0.02,mary louise barr,SOC-2010,2014
-SOC,2010,019,Introduction to Soci,0.39,0.5,0.08,0.03,0.0,0.0,0.0,0.0,mary louise barr,SOC-2010,2014
-SOC,2010,020,Introduction to Soci,0.21,0.37,0.31,0.07,0.01,0.0,0.0,0.02,mary louise barr,SOC-2010,2014
-SOC,2050,001,Sociology Lab,0.64,0.0,0.06,0.0,0.19,0.0,0.0,0.11,brenda vander mey,SOC-2050,2014
-SOC,2050,002,Sociology Lab,0.71,0.0,0.0,0.06,0.18,0.0,0.0,0.06,brenda vander mey,SOC-2050,2014
-SOC,3020,001,Research Methods I,0.17,0.42,0.25,0.14,0.0,0.0,0.0,0.03,andrew whitehead,SOC-3020,2014
-SOC,3040,001,Research Methods II,0.3,0.33,0.13,0.2,0.03,0.0,0.0,0.0,ye luo,SOC-3040,2014
-SOC,3600,001,Class & Poverty,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,william wentworth,SOC-3600,2014
-SOC,3880,001,Criminal Justice,0.15,0.44,0.38,0.02,0.0,0.0,0.0,0.0,margaret tina britz,SOC-3880,2014
-SOC,3890,001,Criminology,0.2,0.2,0.22,0.12,0.17,0.0,0.0,0.1,william white,SOC-3890,2014
-SOC,3910,001,Soc of Deviance,0.15,0.39,0.26,0.09,0.04,0.0,0.0,0.07,william white,SOC-3910,2014
-SOC,3920,001,Juvenile Delinquency,0.25,0.29,0.23,0.1,0.08,0.0,0.0,0.04,william white,SOC-3920,2014
-SOC,3940,001,Soc Mental Illness,0.57,0.26,0.13,0.0,0.0,0.0,0.0,0.04,douglas sturkie,SOC-3940,2014
-SOC,3970,001,Substance Abuse,0.63,0.24,0.08,0.0,0.0,0.0,0.0,0.04,jeffrey edwards,SOC-3970,2014
-SOC,4030,001,"Technol, Environment",0.26,0.37,0.21,0.05,0.11,0.0,0.0,0.0, catherine mobley,SOC-4030,2014
-SOC,4040,001,Soc Theory,0.35,0.32,0.18,0.06,0.06,0.0,0.0,0.03,william wentworth,SOC-4040,2014
-SOC,4140,001,Policy&Social Change,0.34,0.59,0.07,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-4140,2014
-SOC,4320,001,Soc of Religion,0.43,0.24,0.16,0.12,0.04,0.0,0.0,0.0,andrew whitehead,SOC-4320,2014
-SOC,4330,001,Global Social Change,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,william haller,SOC-4330,2014
-SOC,4440,001,Sociology of Educ,0.18,0.43,0.14,0.11,0.0,0.0,0.0,0.14,stephani southworth,SOC-4440,2014
-SOC,4600,001,Race & Ethnicity,0.52,0.24,0.24,0.0,0.0,0.0,0.0,0.0,brenda vander mey,SOC-4600,2014
-SOC,4680,001,Criminal Evidence,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,margaret tina britz,SOC-4680,2014
-SOC,4970,001,Senior Lab,0.44,0.12,0.36,0.0,0.08,0.0,0.0,0.0,brenda vander mey,SOC-4970,2014
-SOC,8030,001,Sur Dsgn App Res Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,SOC-8030,2014
-SOC,8300,001,Human Systems Dev,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,ellen granberg,SOC-8300,2014
-SPAN,1010,001,Elementary Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2014
-SPAN,1010,002,Elementary Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2014
-SPAN,1010,003,Elementary Spanish,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2014
-SPAN,1020,001,Elementary Spanish,0.17,0.44,0.17,0.0,0.0,0.0,0.0,0.22,roger simpson,SPAN-1020,2014
-SPAN,1020,002,Elementary Spanish,0.22,0.44,0.11,0.11,0.06,0.0,0.0,0.06,roger simpson,SPAN-1020,2014
-SPAN,1020,003,Elementary Spanish,0.44,0.39,0.11,0.06,0.0,0.0,0.0,0.0,roger simpson,SPAN-1020,2014
-SPAN,1020,004,Elementary Spanish,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,roger simpson,SPAN-1020,2014
-SPAN,1020,005,Elementary Spanish,0.21,0.37,0.21,0.05,0.05,0.0,0.0,0.11,roger simpson,SPAN-1020,2014
-SPAN,1020,006,Elementary Spanish,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,cathy robison,SPAN-1020,2014
-SPAN,1020,007,Elementary Spanish,0.4,0.33,0.2,0.0,0.0,0.0,0.0,0.07,cathy robison,SPAN-1020,2014
-SPAN,1020,008,Elementary Spanish,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,ricardo tremolada,SPAN-1020,2014
-SPAN,1020,009,Elementary Spanish,0.44,0.33,0.06,0.0,0.0,0.0,0.0,0.17,ricardo tremolada,SPAN-1020,2014
-SPAN,1020,010,Elementary Spanish,0.35,0.41,0.24,0.0,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-1020,2014
-SPAN,1020,011,Elementary Spanish,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-1020,2014
-SPAN,1020,012,Elementary Spanish,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,allison ann hinds,SPAN-1020,2014
-SPAN,1020,013,Elementary Spanish,0.61,0.0,0.28,0.06,0.06,0.0,0.0,0.0,allison ann hinds,SPAN-1020,2014
-SPAN,1020,014,Elementary Spanish,0.41,0.29,0.06,0.06,0.0,0.0,0.0,0.18,allison ann hinds,SPAN-1020,2014
-SPAN,1020,015,Elementary Spanish,0.44,0.19,0.06,0.19,0.0,0.0,0.0,0.13,ricardo tremolada,SPAN-1020,2014
-SPAN,2010,001,Intermediate Spanish,0.26,0.26,0.32,0.11,0.0,0.0,0.0,0.05,cathy robison,SPAN-2010,2014
-SPAN,2010,002,Intermediate Spanish,0.13,0.56,0.06,0.06,0.0,0.0,0.0,0.19,cathy robison,SPAN-2010,2014
-SPAN,2010,003,Intermediate Spanish,0.33,0.28,0.33,0.0,0.0,0.0,0.0,0.06,maureen zamora,SPAN-2010,2014
-SPAN,2010,004,Intermediate Spanish,0.37,0.26,0.16,0.0,0.05,0.0,0.0,0.16,ellory schmucker,SPAN-2010,2014
-SPAN,2010,005,Intermediate Spanish,0.46,0.23,0.15,0.15,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2010,2014
-SPAN,2010,007,Intermediate Spanish,0.13,0.4,0.27,0.13,0.0,0.0,0.0,0.07,heidi montes,SPAN-2010,2014
-SPAN,2010,008,Intermediate Spanish,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2010,2014
-SPAN,2010,009,Intermediate Spanish,0.35,0.41,0.18,0.0,0.06,0.0,0.0,0.0,ricardo tremolada,SPAN-2010,2014
-SPAN,2010,010,Intermediate Spanish,0.39,0.28,0.11,0.22,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2014
-SPAN,2010,011,Intermediate Spanish,0.0,0.31,0.38,0.15,0.08,0.0,0.0,0.08,melva margu persico,SPAN-2010,2014
-SPAN,2010,013,Intermediate Spanish,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,ze cruz valderramos,SPAN-2010,2014
-SPAN,2010,014,Intermediate Spanish,0.33,0.5,0.06,0.0,0.06,0.0,0.0,0.06,maureen zamora,SPAN-2010,2014
-SPAN,2010,015,Intermediate Spanish,0.37,0.42,0.05,0.0,0.05,0.0,0.0,0.11,ricardo tremolada,SPAN-2010,2014
-SPAN,2010,016,Intermediate Spanish,0.28,0.56,0.17,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,SPAN-2010,2014
-SPAN,2010,017,Intermediate Spanish,0.44,0.19,0.19,0.13,0.06,0.0,0.0,0.0,maureen zamora,SPAN-2010,2014
-SPAN,2010,018,Intermediate Spanish,0.29,0.24,0.29,0.12,0.0,0.0,0.0,0.06,kari daus carson,SPAN-2010,2014
-SPAN,2010,022,Intermediate Spanish,0.31,0.31,0.19,0.0,0.06,0.0,0.0,0.13,heidi montes,SPAN-2010,2014
-SPAN,2010,023,Intermediate Spanish,0.07,0.5,0.21,0.07,0.0,0.0,0.0,0.14,maureen zamora,SPAN-2010,2014
-SPAN,2010,024,Intermediate Spanish,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,allison ann hinds,SPAN-2010,2014
-SPAN,2020,001,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-2020,2014
-SPAN,2020,002,Intermediate Spanish,0.22,0.28,0.28,0.11,0.06,0.0,0.0,0.06,melva margu persico,SPAN-2020,2014
-SPAN,2020,003,Intermediate Spanish,0.33,0.11,0.39,0.17,0.0,0.0,0.0,0.0,kari daus carson,SPAN-2020,2014
-SPAN,2020,004,Intermediate Spanish,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-2020,2014
-SPAN,2020,005,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2020,2014
-SPAN,2020,006,Intermediate Spanish,0.37,0.37,0.16,0.11,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2020,2014
-SPAN,2020,007,Intermediate Spanish,0.24,0.41,0.12,0.06,0.0,0.0,0.0,0.18,melva margu persico,SPAN-2020,2014
-SPAN,2020,008,Intermediate Spanish,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,melva margu persico,SPAN-2020,2014
-SPAN,2020,009,Intermediate Spanish,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,ellory schmucker,SPAN-2020,2014
-SPAN,2020,010,Intermediate Spanish,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2014
-SPAN,2020,011,Intermediate Spanish,0.32,0.42,0.11,0.11,0.0,0.0,0.0,0.05,kari daus carson,SPAN-2020,2014
-SPAN,2020,012,Intermediate Spanish,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,juana martin-armas,SPAN-2020,2014
-SPAN,2020,013,Intermediate Spanish,0.22,0.61,0.11,0.06,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2014
-SPAN,3020,001,Int Spn Gram & Comp,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,SPAN-3020,2014
-SPAN,3050,002,Int Con Comp Span I,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,raquel anido,SPAN-3050,2014
-SPAN,3050,003,Int Con Comp Span I,0.32,0.42,0.16,0.0,0.0,0.0,0.0,0.11,raquel anido,SPAN-3050,2014
-SPAN,3080,001,Hispanic World: La,0.63,0.21,0.0,0.0,0.05,0.0,0.0,0.11,george palacios,SPAN-3080,2014
-SPAN,3080,002,Hispanic World: La,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,tiffany dawn miller,SPAN-3080,2014
-SPAN,3090,001,Intro to Span Phont,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,daniel smith,SPAN-3090,2014
-SPAN,3110,001,Surv Span-Amer Lit,0.13,0.4,0.2,0.07,0.13,0.0,0.0,0.07,tiffany dawn miller,SPAN-3110,2014
-SPAN,3130,001,Span Lit Survey I,0.2,0.4,0.13,0.0,0.0,0.0,0.0,0.27,mon rojas-de-massei,SPAN-3130,2014
-SPAN,3130,002,Span Lit Survey I,0.27,0.4,0.2,0.07,0.0,0.0,0.0,0.07,mon rojas-de-massei,SPAN-3130,2014
-SPAN,3140,001,Hispanic Linguistics,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,SPAN-3140,2014
-SPAN,3180,001,Span Through Culture,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,george palacios,SPAN-3180,2014
-SPAN,4030,001,Span Amer Wom Writer,0.3,0.4,0.1,0.0,0.2,0.0,0.0,0.0,tiffany dawn miller,SPAN-4030,2014
-SPAN,4060,001,Narrative Fiction,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,mon rojas-de-massei,SPAN-4060,2014
-SPAN,4060,002,Narrative Fiction,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,SPAN-4060,2014
-SPAN,4070,001,Hispanic Film,0.5,0.31,0.06,0.06,0.0,0.0,0.0,0.06,raquel anido,SPAN-4070,2014
-SPAN,4190,001,Health & Hisp Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-4190,2014
-STAT,2220,001,Statistics in Everyd,0.33,0.36,0.25,0.04,0.0,0.0,0.0,0.02,ros martinez-dawson,STAT-2220,2014
-STAT,2220,002,Statistics in Everyd,0.36,0.28,0.23,0.08,0.02,0.0,0.0,0.04,james espey,STAT-2220,2014
-STAT,2220,003,Statistics in Everyd,0.35,0.33,0.21,0.1,0.02,0.0,0.0,0.0,april thomas,STAT-2220,2014
-STAT,2220,004,Statistics in Everyd,0.41,0.48,0.09,0.0,0.0,0.0,0.0,0.02,benjamin sharp,STAT-2220,2014
-STAT,2220,005,Statistics in Everyd,0.37,0.29,0.31,0.02,0.02,0.0,0.0,0.0,james espey,STAT-2220,2014
-STAT,2220,006,Statistics in Everyd,0.39,0.28,0.33,0.0,0.0,0.0,0.0,0.0,christopher wilson,STAT-2220,2014
-STAT,2220,007,Statistics in Everyd,0.28,0.5,0.17,0.06,0.0,0.0,0.0,0.0,christopher wilson,STAT-2220,2014
-STAT,2300,001,Statistical Methods,0.37,0.29,0.14,0.13,0.04,0.0,0.0,0.03,richard stev dubsky,STAT-2300,2014
-STAT,2300,002,Statistical Methods,0.46,0.29,0.16,0.05,0.0,0.0,0.0,0.04,richard stev dubsky,STAT-2300,2014
-STAT,2300,003,Statistical Methods,0.48,0.27,0.11,0.04,0.07,0.0,0.0,0.02,ros martinez-dawson,STAT-2300,2014
-STAT,2300,004,Statistical Methods,0.38,0.32,0.13,0.08,0.09,0.0,0.0,0.01,christy jenki brown,STAT-2300,2014
-STAT,2300,005,Statistical Methods,0.3,0.33,0.28,0.06,0.0,0.0,0.0,0.04,christy jenki brown,STAT-2300,2014
-STAT,2300,006,Statistical Methods,0.35,0.29,0.24,0.05,0.03,0.0,0.0,0.03,jun luo,STAT-2300,2014
-STAT,2300,008,Statistical Methods,0.46,0.35,0.12,0.03,0.02,0.0,0.0,0.02,richard stev dubsky,STAT-2300,2014
-STAT,2300,009,Statistical Methods,0.42,0.31,0.14,0.07,0.01,0.0,0.0,0.04,christy jenki brown,STAT-2300,2014
-STAT,3090,001,Introductory Busines,0.16,0.32,0.16,0.14,0.14,0.0,0.0,0.08,paul james cubre,STAT-3090,2014
-STAT,3090,002,Introductory Busines,0.05,0.42,0.37,0.11,0.05,0.0,0.0,0.0,emily marie nystrom,STAT-3090,2014
-STAT,3090,003,Introductory Busines,0.11,0.22,0.44,0.0,0.17,0.0,0.0,0.06,ziwen cheng,STAT-3090,2014
-STAT,3090,004,Introductory Busines,0.48,0.32,0.14,0.05,0.02,0.0,0.0,0.0,lucas waddell,STAT-3090,2014
-STAT,3090,005,Introductory Busines,0.33,0.26,0.33,0.0,0.05,0.0,0.0,0.05,gary fellers,STAT-3090,2014
-STAT,3090,006,Introductory Busines,0.21,0.32,0.26,0.11,0.11,0.0,0.0,0.0,emily marie nystrom,STAT-3090,2014
-STAT,3090,007,Introductory Busines,0.16,0.53,0.16,0.11,0.0,0.0,0.0,0.05,janie caro mcdonald,STAT-3090,2014
-STAT,3090,008,Introductory Busines,0.3,0.32,0.25,0.05,0.07,0.0,0.0,0.02,gary fellers,STAT-3090,2014
-STAT,3090,009,Introductory Busines,0.22,0.39,0.11,0.11,0.06,0.0,0.0,0.11,hewa priyadarshani,STAT-3090,2014
-STAT,3090,010,Introductory Busines,0.32,0.43,0.11,0.05,0.07,0.0,0.0,0.02,gary fellers,STAT-3090,2014
-STAT,3090,011,Introductory Busines,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,janie caro mcdonald,STAT-3090,2014
-STAT,3090,012,Introductory Busines,0.2,0.6,0.14,0.03,0.03,0.0,0.0,0.0,margaret mar wiecek,STAT-3090,2014
-STAT,3090,013,Introductory Busines,0.27,0.36,0.24,0.04,0.07,0.0,0.0,0.02,gary fellers,STAT-3090,2014
-STAT,3090,014,Introductory Busines,0.15,0.46,0.23,0.0,0.15,0.0,0.0,0.0,ziwen cheng,STAT-3090,2014
-STAT,3090,015,Introductory Busines,0.16,0.42,0.11,0.26,0.05,0.0,0.0,0.0,tao yang,STAT-3090,2014
-STAT,3090,016,Introductory Busines,0.26,0.32,0.11,0.11,0.05,0.0,0.0,0.16,tao yang,STAT-3090,2014
-STAT,3090,017,Introductory Busines,0.22,0.39,0.22,0.11,0.06,0.0,0.0,0.0,hewa priyadarshani,STAT-3090,2014
-STAT,3090,018,Introductory Busines,0.29,0.56,0.08,0.04,0.02,0.0,0.0,0.0,jennifer van dyken,STAT-3090,2014
-STAT,3090,019,Introductory Busines,0.3,0.36,0.16,0.11,0.0,0.0,0.0,0.07,laura jane shick,STAT-3090,2014
-STAT,3090,020,Introductory Busines,0.11,0.41,0.25,0.09,0.09,0.0,0.0,0.05,laura jane shick,STAT-3090,2014
-STAT,4020,001,Intro to Statistical,0.56,0.22,0.17,0.06,0.0,0.0,0.0,0.0,julia lynn sharp,STAT-4020,2014
-STAT,4110,001,Stat Mthds for Proce,0.39,0.39,0.17,0.06,0.0,0.0,0.0,0.0,james rieck,STAT-4110,2014
-STAT,4110,002,Stat Mthds for Proce,0.19,0.29,0.26,0.13,0.13,0.0,0.0,0.0,patrick gerard,STAT-4110,2014
-STAT,8010,001,Statistical Methods,0.48,0.43,0.04,0.0,0.0,0.0,0.0,0.04,william bridges,STAT-8010,2014
-STAT,8010,003,Statistical Methods,0.39,0.29,0.16,0.0,0.13,0.0,0.0,0.03,james rieck,STAT-8010,2014
-STAT,8010,004,Statistical Methods,0.31,0.26,0.31,0.0,0.06,0.0,0.0,0.06,julia lynn sharp,STAT-8010,2014
-STAT,8020,001,Statistical Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,STAT-8020,2014
-STAT,8020,001,Statistical Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-8020,2014
-STAT,8050,001,Design & Anlys of Ex,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-8050,2014
-STS,1010,001,Survey of S T S,0.46,0.41,0.05,0.0,0.03,0.0,0.0,0.05,elizabeth stansell,STS-1010,2014
-STS,1010,002,Survey of S T S,0.36,0.39,0.22,0.03,0.0,0.0,0.0,0.0,thomas oberdan,STS-1010,2014
-STS,1010,003,Survey of S T S,0.89,0.08,0.0,0.0,0.03,0.0,0.0,0.0,scott brame,STS-1010,2014
-STS,1010,005,Survey of S T S,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,thomas oberdan,STS-1010,2014
-STS,1010,006,Survey of S T S,0.44,0.28,0.14,0.03,0.06,0.0,0.0,0.06,sarah mae cooper,STS-1010,2014
-STS,1010,007,Survey of S T S,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,annah kamugiz amani,STS-1010,2014
-STS,1010,008,Survey of S T S,0.27,0.45,0.15,0.03,0.0,0.0,0.0,0.09,david charles foltz,STS-1010,2014
-STS,1010,009,Survey of S T S,0.4,0.46,0.11,0.0,0.03,0.0,0.0,0.0,allison ann hinds,STS-1010,2014
-STS,1010,010,Survey of S T S,0.57,0.21,0.14,0.0,0.07,0.0,0.0,0.0,thomas oberdan,STS-1010,2014
-STS,1010,020,Survey of S T S,0.19,0.47,0.25,0.03,0.0,0.0,0.0,0.06,thomas oberdan,STS-1010,2014
-STS,2150,001,Crit Appr to Tech Re,0.32,0.32,0.27,0.05,0.0,0.0,0.0,0.05,thomas oberdan,STS-2150,2014
-THEA,2100,001,Theatre Appreciation,0.53,0.34,0.06,0.0,0.0,0.0,0.0,0.06,richard st. peter,THEA-2100,2014
-THEA,2100,003,Theatre Appreciation,0.65,0.16,0.1,0.03,0.06,0.0,0.0,0.0,kendra lyne johnson,THEA-2100,2014
-THEA,2100,004,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,THEA-2100,2014
-THEA,2100,005,Theatre Appreciation,0.44,0.38,0.13,0.03,0.0,0.0,0.0,0.03,carol collins,THEA-2100,2014
-THEA,2100,006,Theatre Appreciation,0.52,0.26,0.1,0.03,0.03,0.0,0.0,0.06,jason adkins,THEA-2100,2014
-THEA,2780,001,Acting I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,THEA-2780,2014
-THEA,3170,001,African-Amer Thea I,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,kendra lyne johnson,THEA-3170,2014
-THEA,4720,001,Improvisation,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-4720,2014
-THEA,6870,001,Stage Lighting I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,THEA-6870,2014
-WFB,3000,001,Wildlife Biology,0.36,0.43,0.11,0.07,0.02,0.0,0.0,0.0,shari lyn rodriguez,WFB-3000,2014
-WFB,3000,002,Wildlife Biology,0.4,0.35,0.16,0.04,0.05,0.0,0.0,0.0,shari lyn rodriguez,WFB-3000,2014
-WFB,3010,001,Wildlife Biology Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,WFB-3010,2014
-WFB,3010,002,Wildlife Biology Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2014
-WFB,4100,001,Wildlife Mgmt Tech,0.62,0.31,0.04,0.0,0.04,0.0,0.0,0.0,james davis,WFB-4100,2014
-WFB,4100,002,Wildlife Mgmt Tech,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,james davis,WFB-4100,2014
-WFB,4120,002,Wildlife Management,0.4,0.4,0.13,0.04,0.0,0.0,0.0,0.02,greg yarrow,WFB-4120,2014
-WFB,4120,002,Wildlife Management,0.4,0.4,0.13,0.04,0.0,0.0,0.0,0.02,david sco jachowski,WFB-4120,2014
-WFB,4180,001,Fishery Conservation,0.59,0.23,0.14,0.0,0.0,0.0,0.0,0.05,yoichiro kanno,WFB-4180,2014
-WFB,4500,001,Aquaculture,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,WFB-4500,2014
-WFB,4600,001,Warmwat Fish Disease,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,WFB-4600,2014
-WFB,8610,200,Analysis of Ecologic,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,russell barrett,WFB-8610,2014
-WS,1030,001,Women Global Perspec,0.75,0.14,0.06,0.06,0.0,0.0,0.0,0.0,saadiqa kumanyika,WS-1030,2014
-WS,2300,001,Women and Leadership,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,saadiqa kumanyika,WS-2300,2014
-WS,3010,001,Intro Women's Studie,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2014
-WS,3010,002,Intro Women's Studie,0.47,0.34,0.03,0.13,0.0,0.0,0.0,0.03,elizabeth ros adams,WS-3010,2014
-YDP,3000,400,Youth Development in,0.43,0.36,0.14,0.0,0.07,0.0,0.0,0.0,barry garst,YDP-3000,2014
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1010,001,Survey of Art & Arch,0.44,0.42,0.11,0.0,0.0,0.0,0.0,0.02,beth ann lauritis,
+AAH,2050,001,Art History and Theo,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.04,beth ann lauritis,
+AAH,2100,400,Intro to Art and Arc,0.23,0.42,0.12,0.12,0.08,0.0,0.0,0.04,lydia jane dorsey,
+AAH,2100,401,Intro to Art and Arc,0.45,0.34,0.14,0.07,0.0,0.0,0.0,0.0,lydia jane dorsey,
+AAH,2100,402,Intro to Art and Arc,0.28,0.4,0.16,0.08,0.0,0.0,0.0,0.08,lydia jane dorsey,
+AAH,2100,403,Intro to Art and Arc,0.39,0.43,0.0,0.04,0.07,0.0,0.0,0.07,lydia jane dorsey,
+AAH,3050,001,Contemporary Art His,0.6,0.2,0.13,0.0,0.0,0.0,0.0,0.07,andrea feeser,
+ACCT,2010,001,Financial Accounting,0.04,0.22,0.3,0.02,0.15,0.0,0.0,0.26,philip maiberger,
+ACCT,2010,002,Financial Accounting,0.13,0.3,0.28,0.09,0.04,0.0,0.0,0.17,philip maiberger,
+ACCT,2010,003,Financial Accounting,0.19,0.22,0.22,0.08,0.1,0.0,0.0,0.18,suzanne pearse,
+ACCT,2010,004,Financial Accounting,0.3,0.3,0.2,0.05,0.07,0.0,0.0,0.09,suzanne pearse,
+ACCT,2010,005,Fin Acct Concepts (H,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True
+ACCT,2010,006,Financial Accounting,0.24,0.33,0.24,0.07,0.05,0.0,0.0,0.07,annieka philo,
+ACCT,2010,007,Financial Accounting,0.24,0.27,0.11,0.08,0.16,0.0,0.0,0.14,lydia lan schleifer,
+ACCT,2010,008,Financial Accounting,0.24,0.33,0.14,0.04,0.1,0.0,0.0,0.14,lydia lan schleifer,
+ACCT,2010,009,Financial Accounting,0.12,0.34,0.24,0.07,0.1,0.0,0.0,0.12,annieka philo,
+ACCT,2010,010,Financial Accounting,0.26,0.13,0.26,0.08,0.05,0.0,0.0,0.23,lydia lan schleifer,
+ACCT,2010,011,Financial Accounting,0.2,0.18,0.25,0.15,0.05,0.0,0.0,0.18,james mil kohlmeyer,
+ACCT,2010,012,Financial Accounting,0.27,0.24,0.27,0.12,0.02,0.0,0.0,0.07,james mil kohlmeyer,
+ACCT,2010,013,Financial Accounting,0.19,0.43,0.16,0.1,0.03,0.0,0.0,0.09,the estate  guffey,
+ACCT,2010,014,Financial Accounting,0.09,0.31,0.2,0.13,0.09,0.0,0.0,0.19,jeffrey mcmillan,
+ACCT,2010,015,Financial Accounting,0.03,0.28,0.23,0.15,0.17,0.0,0.0,0.13,james mil kohlmeyer,
+ACCT,2020,001,Managerial Accountin,0.18,0.31,0.2,0.06,0.08,0.0,0.0,0.18,henry anderson,
+ACCT,2020,002,Managerial Accountin,0.23,0.28,0.19,0.04,0.09,0.0,0.0,0.17,henry anderson,
+ACCT,2020,003,Managerial Accountin,0.17,0.37,0.25,0.1,0.06,0.0,0.0,0.06,annieka philo,
+ACCT,2020,004,Managerial Accountin,0.24,0.27,0.25,0.12,0.08,0.0,0.0,0.04,annieka philo,
+ACCT,2020,006,Managerial Accountin,0.57,0.22,0.14,0.0,0.02,0.0,0.0,0.06,sarah martin,
+ACCT,2020,007,Managerial Accountin,0.14,0.21,0.31,0.03,0.12,0.0,0.0,0.21,henry anderson,
+ACCT,2020,008,Managerial Accountin,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,sarah martin,
+ACCT,2040,001,Accounting Procedure,0.53,0.25,0.08,0.02,0.02,0.0,0.0,0.11,jeffrey mcmillan,
+ACCT,2040,002,Accounting Procedure,0.37,0.25,0.14,0.02,0.03,0.0,0.0,0.19,jeffrey mcmillan,
+ACCT,3030,001,Cost Accounting,0.31,0.24,0.28,0.0,0.03,0.0,0.0,0.14,henry anderson,
+ACCT,3030,002,Cost Accounting,0.22,0.35,0.22,0.05,0.11,0.0,0.0,0.05,henry anderson,
+ACCT,3030,003,Cost Accounting,0.38,0.28,0.23,0.0,0.05,0.0,0.0,0.05,robin radtke,
+ACCT,3030,005,Cost Accounting,0.28,0.35,0.13,0.03,0.1,0.0,0.0,0.13,robin radtke,
+ACCT,3110,001,Intermed Financial A,0.5,0.31,0.13,0.06,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3110,002,Intermed Financial A,0.51,0.36,0.05,0.03,0.03,0.0,0.0,0.03,terry daniel knause,
+ACCT,3110,003,Intermed Financial A,0.38,0.23,0.28,0.05,0.0,0.0,0.0,0.05,terry daniel knause,
+ACCT,3110,005,Intermed Financial A,0.35,0.32,0.19,0.05,0.0,0.0,0.0,0.08,terry daniel knause,
+ACCT,3120,001,Intermed Financial A,0.03,0.18,0.41,0.21,0.09,0.0,0.0,0.09,brian todd carver,
+ACCT,3120,002,Intermed Financial A,0.17,0.3,0.26,0.09,0.07,0.0,0.0,0.11,suzanne pearse,
+ACCT,3120,003,Intermed Financial A,0.05,0.18,0.37,0.18,0.08,0.0,0.0,0.13,brian todd carver,
+ACCT,3120,004,Intermed Financial A,0.09,0.31,0.36,0.16,0.02,0.0,0.0,0.07,suzanne pearse,
+ACCT,3130,001,Intermed Financial A,0.17,0.42,0.42,0.0,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3130,002,Intermed Financial A,0.19,0.47,0.22,0.06,0.0,0.0,0.0,0.06, russell madray,
+ACCT,3130,003,Intermed Financial A,0.21,0.47,0.24,0.0,0.05,0.0,0.0,0.03, russell madray,
+ACCT,3130,005,Intermed Financial A,0.18,0.24,0.42,0.05,0.05,0.0,0.0,0.05, russell madray,
+ACCT,3220,001,Accounting Informati,0.21,0.26,0.31,0.08,0.05,0.0,0.0,0.1,philip maiberger,
+ACCT,3220,002,Accounting Informati,0.15,0.41,0.08,0.13,0.08,0.0,0.0,0.15,philip maiberger,
+ACCT,3220,003,Accounting Informati,0.2,0.55,0.15,0.0,0.05,0.0,0.0,0.05,nancy lee harp,
+ACCT,4040,002,Individual Taxation,0.36,0.36,0.24,0.02,0.0,0.0,0.0,0.02,derek dalton,
+ACCT,4040,003,Individual Taxation,0.1,0.44,0.28,0.03,0.05,0.0,0.0,0.1,derek dalton,
+ACCT,4080,001,Retire & Estate Plan,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,john hine,
+ACCT,4100,001,Reporting and Mgmt C,0.34,0.42,0.18,0.03,0.0,0.0,0.0,0.03,sally kathr widener,
+ACCT,4100,002,Reporting and Mgmt C,0.57,0.3,0.04,0.04,0.04,0.0,0.0,0.0,sally kathr widener,
+ACCT,4150,001,Auditing,0.06,0.34,0.38,0.19,0.03,0.0,0.0,0.0,carl hollingsworth,
+ACCT,4150,002,Auditing,0.32,0.42,0.1,0.06,0.03,0.0,0.0,0.06,carl hollingsworth,
+ACCT,8510,001,Tax Research,0.25,0.59,0.16,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8510,002,Tax Research,0.06,0.79,0.12,0.0,0.03,0.0,0.0,0.0,thomas dickens,
+ACCT,8530,001,Adv Acct Problems,0.52,0.36,0.09,0.0,0.0,0.0,0.0,0.03,ralph welton,
+ACCT,8530,002,Adv Acct Problems,0.48,0.42,0.03,0.0,0.06,0.0,0.0,0.0,ralph welton,
+ACCT,8550,001,Gov't and Nonprofit,0.59,0.35,0.03,0.0,0.03,0.0,0.0,0.0,james barnes,
+ACCT,8550,002,Gov't and Nonprofit,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8630,001,Forensics Analysis,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,james irving,
+ACCT,8630,002,Forensics Analysis,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,james irving,
+ACCT,8630,003,Forensics Analysis,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,james irving,
+ACCT,8730,001,Intl/Spec Tax Topic,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,judson jahn,
+ACCT,8730,002,Intl/Spec Tax Topic,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,judson jahn,
+AGED,1020,001,Freshman Seminar,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,christina mel leard,
+AGED,2010,001,Intro to Agric Educ,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,2040,001,App Ag Calculations,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,3030,001,Ag Ed Mech Tech,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,3650,001,Multiculturalism in,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,alex byrd,
+AGED,4010,001,Instr Methods Ag Ed,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,thomas dobbins,
+AGED,4010,001,Instr Methods Ag Ed,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,
+AGED,4030,001,Prin Adult/Ext Ed,0.55,0.1,0.2,0.0,0.05,0.0,0.0,0.1,freddie waltz,
+AGED,4230,400,Curriculum,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,
+AGED,6010,001,Instr Methods Ag Ed,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,kevin layfield,
+AGED,6010,001,Instr Methods Ag Ed,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,thomas dobbins,
+AGM,1010,001,Intro Ag Mech & Bus,0.64,0.25,0.07,0.02,0.02,0.0,0.0,0.0,hunter massey,
+AGM,2050,001,Prin of Fabrication,0.15,0.52,0.28,0.01,0.01,0.0,0.0,0.01,hunter massey,
+AGM,2060,001,Machinery Mgt,0.15,0.4,0.3,0.15,0.0,0.0,0.0,0.0,hunter massey,
+AGM,2190,001,Agribuxiness and Foo,0.24,0.45,0.29,0.02,0.0,0.0,0.0,0.0,wilder ferreira,
+AGM,2210,001,Land Measurements,0.44,0.4,0.12,0.01,0.03,0.0,0.0,0.0,charles privette,
+AGM,3010,001,Soil Water Conserv,0.29,0.41,0.14,0.1,0.06,0.0,0.0,0.0,calvin sawyer,
+AGM,3190,001,Agribusiness Decisio,0.38,0.28,0.22,0.13,0.0,0.0,0.0,0.0,wilder ferreira,
+AGM,4050,001,Env Cont in Anim Str,0.38,0.56,0.05,0.0,0.0,0.0,0.0,0.0,john chastain,
+AGM,4060,001,Mech & Hydraulic Sys,0.42,0.45,0.12,0.0,0.0,0.0,0.0,0.0,young han,
+AGM,4600,001,Electrical Systems,0.42,0.52,0.06,0.0,0.0,0.0,0.0,0.0,young han,
+AL,3490,400,Principles of Coachi,0.36,0.4,0.12,0.04,0.0,0.0,0.0,0.08,deborah cadorette,
+AL,3490,401,Principles of Coachi,0.52,0.33,0.15,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,402,Principles of Coachi,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,
+AL,3490,403,Principles of Coachi,0.41,0.35,0.0,0.18,0.06,0.0,0.0,0.0,clyde keith connor,
+AL,3500,400,Sci Basis I/Ex Phy,0.22,0.44,0.26,0.04,0.04,0.0,0.0,0.0,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.28,0.12,0.16,0.32,0.08,0.0,0.0,0.04,michael godfrey,
+AL,3520,400,Kinesiology,0.29,0.21,0.21,0.14,0.14,0.0,0.0,0.0,michael godfrey,
+AL,3530,400,Athletic Injuries,0.16,0.47,0.21,0.11,0.05,0.0,0.0,0.0,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.15,0.25,0.15,0.35,0.1,0.0,0.0,0.0,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical,0.43,0.25,0.18,0.07,0.04,0.0,0.0,0.04,clyde keith connor,
+AL,3610,400,Admin/Org of Athleti,0.73,0.19,0.04,0.0,0.04,0.0,0.0,0.0,henry oates,
+AL,3610,401,Admin/Org of Athleti,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,Admin/Org of Athleti,0.8,0.12,0.0,0.0,0.04,0.0,0.0,0.04,henry oates,
+AL,3620,400,Psychology of Coachi,0.28,0.28,0.24,0.12,0.04,0.0,0.0,0.04,natalie anne carter,
+AL,3620,401,Psychology of Coachi,0.24,0.2,0.44,0.12,0.0,0.0,0.0,0.0,natalie anne carter,
+AL,3740,400,Coaching Football,0.67,0.07,0.0,0.19,0.0,0.0,0.0,0.07,edmond fry,
+AL,3760,400,Coaching Strength/Co,0.79,0.08,0.04,0.08,0.0,0.0,0.0,0.0,edmond fry,
+AL,3760,401,Coaching Strength/Co,0.42,0.21,0.05,0.16,0.05,0.0,0.0,0.11,edmond fry,
+AL,4380,400,Coach & Athlete in E,0.5,0.14,0.29,0.07,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,8490,400,Athletic Leadership,0.52,0.35,0.04,0.0,0.04,0.0,0.0,0.04,michael godfrey,
+ANTH,2010,001,Intro Anthropology,0.07,0.17,0.32,0.19,0.08,0.0,0.0,0.18,john coggeshall,
+ANTH,2010,001,Introduction to Anth,0.07,0.17,0.32,0.19,0.08,0.0,0.0,0.18,john coggeshall,
+ANTH,2010,002,Intro Anthropology,0.15,0.21,0.29,0.21,0.08,0.0,0.0,0.06,john coggeshall,
+ANTH,2010,002,Introduction to Anth,0.15,0.21,0.29,0.21,0.08,0.0,0.0,0.06,john coggeshall,
+ANTH,2010,003,Introduction to Anth,0.24,0.59,0.08,0.04,0.02,0.0,0.0,0.02,katherine weisensee,
+ANTH,2010,003,Intro Anthropology,0.24,0.59,0.08,0.04,0.02,0.0,0.0,0.02,katherine weisensee,
+ANTH,2010,004,Introduction to Anth,0.17,0.44,0.18,0.07,0.0,0.0,0.0,0.15,melissa vogel,
+ANTH,2010,004,Intro Anthropology,0.17,0.44,0.18,0.07,0.0,0.0,0.0,0.15,melissa vogel,
+ANTH,2010,005,Introduction to Anth,0.29,0.4,0.18,0.0,0.04,0.0,0.0,0.09,lisa rapaport,
+ANTH,2010,005,Intro Anthropology,0.29,0.4,0.18,0.0,0.04,0.0,0.0,0.09,lisa rapaport,
+ANTH,3010,001,Cultural Anthropolog,0.18,0.35,0.24,0.06,0.06,0.0,0.0,0.12,john coggeshall,
+ANTH,3320,001,World Archaeology,0.21,0.32,0.21,0.16,0.05,0.0,0.0,0.05,melissa vogel,
+ANTH,3510,001,Biological Anthropol,0.2,0.53,0.13,0.0,0.0,0.0,0.0,0.13,lisa rapaport,
+ANTH,3530,001,Forensic Anthropolog,0.3,0.57,0.09,0.04,0.0,0.0,0.0,0.0,katherine weisensee,
+ANTH,4660,001,Evolution of Human B,0.4,0.3,0.1,0.0,0.0,0.0,0.0,0.2,lisa rapaport,
+ANTH,4960,003,Creative Inquiry,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,sharon nagy,
+APEC,2020,001,Agric Economics,0.28,0.3,0.33,0.03,0.04,0.0,0.0,0.01,webb smathers,
+APEC,2020,002,Agric Economics,0.14,0.28,0.28,0.17,0.0,0.0,0.0,0.14,david brian willis,
+APEC,2050,001,Agric and Society,0.3,0.47,0.23,0.0,0.0,0.0,0.0,0.0,michael vassalos,
+APEC,2570,001,Nat Res Env Econ,0.15,0.27,0.3,0.12,0.05,0.0,0.0,0.12,david brian willis,
+APEC,3020,001,Econ of Farm Mgt,0.31,0.37,0.31,0.0,0.0,0.0,0.0,0.0,michael vassalos,
+APEC,3090,001,Econ Agric Marketing,0.73,0.09,0.16,0.0,0.0,0.0,0.0,0.02,yuliya val bolotova,
+APEC,3510,001,Prin of Advertising,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,webb smathers,
+APEC,3610,001,Int Health Care Econ,0.47,0.41,0.06,0.06,0.0,0.0,0.0,0.0,khoa dang truong,
+APEC,4900,002,CAFLS Plus Prof. Dev,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,thomas scott,
+ARAB,1010,001,Elementary Arabic I,0.59,0.18,0.0,0.0,0.0,0.0,0.0,0.24,sulafa abou-samra,
+ARCH,1010,001,Intro to Arch,0.56,0.36,0.03,0.0,0.01,0.0,0.0,0.05,sal hambright-belue,
+ARCH,2040,001,Hist of Modern Arch,0.38,0.25,0.35,0.03,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
+ARCH,2510,001,Arch Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,2510,002,Arch Foundations I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,2510,002,Arch Foundations I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
+ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2510,003,Arch Foundations I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
+ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
+ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,annemarie jacques,
+ARCH,2510,004,Arch Foundations I,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,annemarie jacques,
+ARCH,2700,001,Structures I,0.42,0.33,0.08,0.08,0.08,0.0,0.0,0.0,dustin gra albright,
+ARCH,3510,001,Studio Clemson,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,robert john hogan,
+ARCH,3510,002,Studio Clemson,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,3510,002,Studio Clemson,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,robert john hogan,
+ARCH,3510,003,Studio Clemson,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,robert john hogan,
+ARCH,3510,003,Studio Clemson,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,criss mills,
+ARCH,3530,001,Studio Genoa,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,3540,001,Studio Barcelona,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,3540,001,Studio Barcelona,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4010,001,Arch Portfolio,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,martha skinner,
+ARCH,4010,002,Arch Portfolio,0.33,0.29,0.29,0.05,0.0,0.0,0.0,0.05,arash soleimani,
+ARCH,4120,001,History Research,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,4120,002,History Research,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4120,002,History Research,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4140,001,Design Seminar,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,4160,002,Field Studies,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4160,002,Field Studies,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,6290,002,Arch Graphics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lloyd bray,
+ARCH,6850,001,H/Th: Arch+Health,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8210,001,Research Methods,0.63,0.35,0.0,0.0,0.0,0.0,0.0,0.03,dina battisto,
+ARCH,8410,001,Arch Studio I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,
+ARCH,8410,002,Arch Studio I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,junichi satoh,
+ARCH,8510,001,Design Studio III,0.09,0.82,0.0,0.0,0.0,0.0,0.0,0.09,ulrike ann-so heine,
+ARCH,8510,001,Design Studio III,0.09,0.82,0.0,0.0,0.0,0.0,0.0,0.09,dustin gra albright,
+ARCH,8510,002,Design Studio III,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
+ARCH,8510,003,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
+ARCH,8510,003,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8510,004,Design Studio III,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
+ARCH,8510,004,Design Studio III,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,8600,001,History/Theory I,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,ufuk ersoy,
+ARCH,8720,001,Production & Assemb,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,daniel nevi harding,
+ARCH,8720,001,Production & Assemb,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02, franco santa cruz,
+ARCH,8790,002,Digtial Manufacturin,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,
+ARCH,8810,001,Pro Practice Survey,0.64,0.33,0.0,0.0,0.0,0.0,0.0,0.03,katherin schwennsen,
+ARCH,8890,001,Mentorship,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,
+ARCH,8950,001,A+H Studio: Projects,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ARCH,8950,001,A+H Studio: Projects,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ART,1050,001,Foundation Drawing I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,
+ART,1510,001,Foundations Art I,0.8,0.07,0.07,0.07,0.0,0.0,0.0,0.0,alexandra giannell,
+ART,2070,001,Beginning Painting,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,hilary erin siber,
+ART,2110,001,Begin Printmaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,laken grace bridges,
+ART,2130,001,Begin Photography,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,anderson wrangle,
+ART,2170,001,Beginning Ceramics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,nina jeanette kawar,
+ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,
+ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
+ART,3550,001,Atelier InSite Creat,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,david detrich,
+ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david detrich,
+ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,
+ART,4550,001,Atelier InSite Creat,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
+ART,8210,001,Visual Narrative,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
+AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,christopher mann,
+AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,stacey dean wiggins,
+AS,1090,001,Air Force Today I,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,steven price jordan,
+AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,steven price jordan,
+AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher mann,
+AS,1090,002,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,stacey dean wiggins,
+AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,stacey dean wiggins,
+AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,christopher mann,
+AS,1090,003,Air Force Today I,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,steven price jordan,
+AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,
+AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,
+AS,1090,004,Air Force Today I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steven price jordan,
+AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,steven price jordan,
+AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,christopher mann,
+AS,2090,002,Dev of Air Power I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,
+AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,
+AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,steven price jordan,
+AS,2090,003,Dev of Air Power I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,
+ASL,1010,003,Am Sign Lang I,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,joseph paul may,
+ASL,2010,001,Am Sign Lang II,0.28,0.44,0.28,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,2010,002,Am Sign Lang II,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,2020,001,Am Sign Lang II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,3000,001,Fingerspelling & Num,0.23,0.46,0.23,0.08,0.0,0.0,0.0,0.0,joseph paul may,
+ASTR,1010,001,SolarSystem Astr,0.42,0.36,0.17,0.0,0.01,0.0,0.0,0.04,phillip flower,
+ASTR,1010,002,Solar System Astr,0.5,0.28,0.17,0.01,0.01,0.0,0.0,0.04,phillip flower,
+ASTR,1010,003,Solar System Astr,0.45,0.34,0.17,0.0,0.02,0.0,0.0,0.02,phillip flower,
+ASTR,1030,001,Solar Systm Astr Lab,0.67,0.17,0.0,0.04,0.04,0.0,0.0,0.08,mark leising,
+ASTR,1030,002,Solar Systm Astr Lab,0.28,0.52,0.08,0.0,0.04,0.0,0.0,0.08,mark leising,
+ASTR,1030,003,Solar Systm Astr Lab,0.57,0.26,0.09,0.0,0.0,0.0,0.0,0.09,mark leising,
+ASTR,1030,004,Solar Systm Astr Lab,0.62,0.27,0.04,0.0,0.08,0.0,0.0,0.0,mark leising,
+ASTR,1030,005,Solar Systm Astr Lab,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1030,006,Solar Systm Astr Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1030,007,Solar Systm Astr Lab,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1030,008,Solar Systm Astr Lab,0.48,0.28,0.04,0.0,0.16,0.0,0.0,0.04,mark leising,
+ASTR,1030,009,Solar Systm Astr Lab,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,mark leising,
+AUD,1850,001,Intro to Audio Tech,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUD,2800,001,Sound Reinforcement,0.2,0.27,0.33,0.07,0.07,0.0,0.0,0.07,kenneth moore,
+AUD,3800,001,Audio Engineering I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUE,8270,005,Auto Cntrl Sys Des,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,beshah ayalew,
+AUE,8330,003,Auto Manuf Proc Devl,0.42,0.39,0.15,0.0,0.03,0.0,0.0,0.01,fadi kama abu-farha,
+AUE,8350,100,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,john david smith,
+AUE,8350,100,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,simona onori,
+AUE,8670,001,Veh Manuf Proc I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8800,002,Vehicle Project Mngt,0.81,0.18,0.0,0.0,0.0,0.0,0.0,0.01,imtiaz ul haque,
+AUE,8810,003,Automotive Systems O,0.18,0.79,0.01,0.0,0.0,0.0,0.0,0.01,paul venhovens,
+AUE,8810,003,Automotive Systems O,0.18,0.79,0.01,0.0,0.0,0.0,0.0,0.01,johnell brooks,
+AUE,8830,009,Applied Integration,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,johnell brooks,
+AUE,8830,009,Applied Integration,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,
+AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,douglas feldmaier,
+AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,michael messman,
+AUE,8870,006,Meth Vehicle Testing,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,imtiaz ul haque,
+AUE,8930,013,Engine Analysis,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8930,014,Automotive Composite,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,david wil schmueser,
+AUE,8930,014,Automotive Composite,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,srikanth pilla,
+AUE,8930,017,Hybrid,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,simona onori,
+AUE,8930,018,Adv IC Engine Concep,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,zoran filipi,
+AUE,8930,019,Innov & Sys Entrepre,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,
+AVS,1000,001,Orientation to Avs,0.84,0.14,0.01,0.0,0.0,0.0,0.0,0.02,johanna joh lascano,
+AVS,1500,001,Intro Animal Science,0.18,0.41,0.3,0.03,0.03,0.0,0.0,0.05,heather walker dunn,
+AVS,1500,002,Intro Animal Science,0.2,0.49,0.25,0.05,0.0,0.0,0.0,0.01,brian bolt,
+AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,brian bolt,
+AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,richelle lor miller,
+AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,anna rebecca baxley,
+AVS,1510,001,Intro Ani Sci Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,heather walker dunn,
+AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,heather walker dunn,
+AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,brian bolt,
+AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,anna rebecca baxley,
+AVS,1510,002,Intro Ani Sci Lab,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,richelle lor miller,
+AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,brian bolt,
+AVS,1510,003,Intro Ani Sci Lab,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
+AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
+AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,brian bolt,
+AVS,1510,004,Intro Ani Sci Lab,0.24,0.69,0.07,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,brian bolt,
+AVS,1510,005,Intro Ani Sci Lab,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
+AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,heather walker dunn,
+AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,brian bolt,
+AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,anna rebecca baxley,
+AVS,1510,006,Intro Ani Sci Lab,0.33,0.47,0.17,0.0,0.0,0.0,0.0,0.03,richelle lor miller,
+AVS,2010,001,Poultry Techniques,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,2030,001,Dairy Sci Techniques,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.02,heather walker dunn,
+AVS,2040,001,Horse Care Technique,0.52,0.3,0.13,0.04,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,2050,001,Horsemanship Techniq,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,meredith donaldson,
+AVS,2050,001,Horsemanship Techniq,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
+AVS,2060,001,Swine Techniques,0.59,0.33,0.08,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,2110,001,Meat Processing Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,brian bolt,
+AVS,2110,001,Meat Processing Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3010,001,Anat & Phys Dom Ani,0.34,0.32,0.2,0.08,0.05,0.0,0.0,0.01,glenn birrenkott,
+AVS,3010,400,Anat & Phys Dom Ani,0.27,0.45,0.23,0.0,0.05,0.0,0.0,0.0,glenn birrenkott,
+AVS,3020,001,Livestk Sel Eval I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3090,001,Equine Evaluation,0.49,0.37,0.05,0.07,0.0,0.0,0.0,0.02,kristine lan vernon,
+AVS,3100,001,Animal Health,0.47,0.26,0.11,0.03,0.0,0.0,0.0,0.14,richard bruner,
+AVS,3700,001,Prin Animal Nutr,0.24,0.25,0.16,0.24,0.1,0.0,0.0,0.02,nathan long,
+AVS,4000,001,AVS Professional Dev,0.69,0.2,0.03,0.03,0.06,0.0,0.0,0.0,james ro strickland,
+AVS,4000,001,AVS Professional Dev,0.69,0.2,0.03,0.03,0.06,0.0,0.0,0.0,johanna joh lascano,
+AVS,4060,001,Seminars & Relat Top,0.79,0.18,0.0,0.04,0.0,0.0,0.0,0.0,johanna joh lascano,
+AVS,4060,001,Seminars & Relat Top,0.79,0.18,0.0,0.04,0.0,0.0,0.0,0.0,james ro strickland,
+AVS,4060,002,Seminars & Relat Top,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,james ro strickland,
+AVS,4060,002,Seminars & Relat Top,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
+AVS,4150,001,Contemp Issues Avs,0.1,0.38,0.38,0.06,0.03,0.0,0.0,0.05,peter skewes,
+AVS,4160,001,Equine Exercise Phys,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,kristine lan vernon,
+AVS,4700,001,Anim Genetics,0.71,0.2,0.06,0.04,0.0,0.0,0.0,0.0,brian bolt,
+AVS,8080,400,Monogastric Nutritio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,
+AVS,8200,001,Graduate Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,
+BCHM,1030,001,Careers in Bioch/Gen,0.87,0.1,0.04,0.0,0.0,0.0,0.0,0.0,alison starr-moss,
+BCHM,3050,001,Essen Elements Bioch,0.2,0.32,0.2,0.12,0.03,0.0,0.0,0.12,srik chandrasekaran,
+BCHM,3050,002,Essen Elements Bioch,0.26,0.32,0.22,0.11,0.04,0.0,0.0,0.04,srik chandrasekaran,
+BCHM,4060,001,Physiological Chem,0.53,0.26,0.13,0.02,0.02,0.0,0.0,0.04,ashby burges bodine,
+BCHM,4310,001,Phys App to Bioch,0.22,0.27,0.27,0.14,0.03,0.0,0.0,0.08,weiguo cao,
+BCHM,4310,002,Phys App to Bioch (H,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True
+BCHM,4330,001,Gen Bioch Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,
+BCHM,4330,002,Gen Bioch Lab I,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,weiguo cao,
+BCHM,4400,001,Bioinformatics,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
+BCHM,4430,001,Mol Basis Disease,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,kerry smith,
+BCHM,4430,001,Mol Basis Disease,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james morris,
+BE,2120,001,Fundamentals of Bios,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,3200,001,Principles & Prac of,0.45,0.32,0.18,0.05,0.0,0.0,0.0,0.0,tom owino,
+BE,4100,001,Biological Kinetics,0.4,0.3,0.25,0.05,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,4150,001,Instr & Control Be,0.27,0.41,0.23,0.05,0.05,0.0,0.0,0.0,yi zheng,
+BE,4280,001,Biochem Engr,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,terry walker,
+BE,4740,001,B E Design/Proj Mgt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4750,001,B E Capstone Design,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,
+BE,4750,001,B E Capstone Design,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BIOE,2010,001,Intro Biomed Engr,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,charles webb,
+BIOE,2010,001,Intro Biomed Engr,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,frank alexis,
+BIOE,2010,002,Intro Biomed Engr,0.59,0.34,0.03,0.0,0.02,0.0,0.0,0.02,charles webb,
+BIOE,2010,002,Intro Biomed Engr,0.59,0.34,0.03,0.0,0.02,0.0,0.0,0.02,frank alexis,
+BIOE,3020,001,Biomaterials,0.49,0.3,0.15,0.0,0.02,0.0,0.0,0.04,vladimir vla reukov,
+BIOE,3200,001,Biomechanics,0.58,0.31,0.08,0.02,0.0,0.0,0.0,0.02,lisa benson,
+BIOE,3210,001,Biofluid Mechanics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,zhi gao,
+BIOE,3700,001,Bioinst & Imaging,0.67,0.3,0.02,0.0,0.0,0.0,0.0,0.02,delphine dean,
+BIOE,3700,002,Bioinst & Imaging,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,david kwartowitz,
+BIOE,4010,001,Bio E Design Theory,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4030,001,Applied Bio E Design,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,jorge iva rodriguez,
+BIOE,4030,001,Applied Bio E Design,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,jeremy mercuri,
+BIOE,4120,001,Orthopaedic Engr and,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,melinda harman,
+BIOE,4400,001,Biotech for Bio E,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,sarah harcum,
+BIOE,4510,007,CI Fr/Sr Design and,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,jorge iva rodriguez,
+BIOE,4510,007,CI Fr/Sr Design and,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john desjardins,
+BIOE,4510,022,CI- Mobile Health Ap,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,vladimir vla reukov,
+BIOE,4510,022,CI- Mobile Health Ap,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,ilya mark safro,
+BIOE,4510,029,CI- The DEN,0.74,0.0,0.0,0.0,0.0,0.0,0.0,0.26,john desjardins,
+BIOE,6120,001,Orthopaedic Engr & P,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,melinda harman,
+BIOE,6150,001,Research Principles,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.02,sarah harcum,
+BIOE,6400,001,Biotech for Bio E,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,sarah harcum,
+BIOE,8010,001,Bio Materials,0.33,0.64,0.02,0.0,0.0,0.0,0.0,0.0,robert latour,
+BIOE,8140,401,Medical Dev Commerci,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
+BIOE,8140,401,Medical Dev Commerci,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew ray gevaert,
+BIOE,8200,001,Structl Biomechanics,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,hai yao,
+BIOL,1010,001,Frontiers in Biology,0.68,0.21,0.06,0.02,0.02,0.0,0.0,0.01,robert edwa ballard,
+BIOL,1010,001,Frontiers in Biology,0.68,0.21,0.06,0.02,0.02,0.0,0.0,0.01,michael childress,
+BIOL,1030,001,General Biology I,0.25,0.24,0.27,0.07,0.09,0.0,0.0,0.09,nora espinoza,
+BIOL,1030,002,General Biology I,0.49,0.29,0.14,0.02,0.02,0.0,0.0,0.03,renea chri hardwick,
+BIOL,1030,004,General Biology I,0.15,0.16,0.3,0.13,0.15,0.0,0.0,0.11,salvatore sparace,
+BIOL,1030,005,General Biology I,0.17,0.27,0.25,0.18,0.05,0.0,0.0,0.07,matthew turnbull,
+BIOL,1030,006,General Biology I,0.26,0.38,0.21,0.08,0.05,0.0,0.0,0.02,kristi ja whitehead,
+BIOL,1030,007,General Biology I (H,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
+BIOL,1030,008,General Biology I,0.29,0.25,0.25,0.11,0.03,0.0,0.0,0.07,william surver,
+BIOL,1050,001,General Biology Lab,0.41,0.36,0.09,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,002,General Biology Lab,0.45,0.32,0.05,0.0,0.14,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,003,General Biology Lab,0.45,0.23,0.18,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,004,General Biology Lab,0.36,0.32,0.14,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,005,General Biology Lab,0.59,0.23,0.05,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,006,General Biology Lab,0.23,0.5,0.14,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,007,General Biology Lab,0.36,0.27,0.05,0.09,0.09,0.0,0.0,0.14,tafadzwa kaisa,
+BIOL,1050,008,General Biology Lab,0.55,0.23,0.14,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,009,General Biology Lab,0.3,0.3,0.1,0.05,0.1,0.0,0.0,0.15,tafadzwa kaisa,
+BIOL,1050,010,General Biology Lab,0.26,0.39,0.22,0.0,0.09,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,011,General Biology Lab,0.38,0.21,0.25,0.08,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,012,General Biology Lab,0.33,0.38,0.13,0.0,0.08,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,013,General Biology Lab,0.68,0.14,0.05,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,014,General Biology Lab,0.32,0.41,0.18,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,015,General Biology Lab,0.29,0.48,0.1,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,016,General Biology Lab,0.42,0.42,0.04,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,017,General Biology Lab,0.5,0.36,0.0,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,018,General Biology Lab,0.32,0.41,0.23,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,019,General Biology Lab,0.43,0.35,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,020,General Biology Lab,0.39,0.3,0.17,0.0,0.04,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,021,General Biology Lab,0.43,0.17,0.13,0.09,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,022,General Biology Lab,0.5,0.36,0.09,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,023,General Biology Lab,0.5,0.2,0.1,0.05,0.05,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1050,024,General Biology Lab,0.37,0.37,0.05,0.16,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,025,General Biology Lab,0.36,0.36,0.23,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,026,General Biology Lab,0.52,0.22,0.22,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,027,General Biology Lab,0.27,0.55,0.09,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,028,General Biology Lab,0.64,0.23,0.14,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,029,General Biology Lab,0.36,0.5,0.05,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,030,General Biology Lab,0.5,0.32,0.0,0.0,0.0,0.0,0.0,0.18,tafadzwa kaisa,
+BIOL,1050,031,General Biology Lab,0.32,0.23,0.27,0.05,0.0,0.0,0.0,0.14,tafadzwa kaisa,
+BIOL,1050,032,General Biology Lab,0.38,0.24,0.1,0.0,0.14,0.0,0.0,0.14,tafadzwa kaisa,
+BIOL,1050,033,General Biology Lab,0.42,0.16,0.0,0.05,0.16,0.0,0.0,0.21,tafadzwa kaisa,
+BIOL,1050,034,General Biology Lab,0.52,0.3,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,036,General Biology Lab,0.42,0.25,0.13,0.04,0.13,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,037,General Biology Lab,0.62,0.29,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,038,General Biology Lab,0.33,0.48,0.14,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,039,General Biology Lab,0.48,0.24,0.1,0.05,0.05,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1050,040,General Biology Lab,0.64,0.18,0.05,0.09,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,041,General Biology Lab,0.48,0.29,0.1,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,042,General Biology Lab,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,043,General Biology Lab,0.33,0.38,0.14,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,044,General Biology Lab,0.45,0.36,0.0,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,046,General Biology Lab,0.38,0.42,0.13,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1090,001,Intro to Life Sci,0.82,0.13,0.04,0.02,0.0,0.0,0.0,0.0,renea chri hardwick,
+BIOL,1100,001,Prin of Biology I,0.12,0.4,0.25,0.1,0.03,0.0,0.0,0.09,robert kosinski,
+BIOL,1100,003,Prin of Biology I,0.4,0.35,0.16,0.02,0.03,0.0,0.0,0.04,dylan dittrich-reed,
+BIOL,1100,004,Prin of Biology I (H,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,dylan dittrich-reed,True
+BIOL,1200,001,Biological Inq Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,002,Biological Inq Lab,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,003,Biological Inq Lab,0.35,0.55,0.0,0.0,0.0,0.0,0.0,0.1, christine minor,
+BIOL,1200,004,Biological Inq Lab,0.4,0.35,0.15,0.05,0.0,0.0,0.0,0.05, christine minor,
+BIOL,1200,005,Biological Inq Lab,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,006,Biological Inq Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,007,Biological Inq Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,
+BIOL,1200,008,Biological Inq Lab,0.33,0.44,0.11,0.06,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1200,010,Biological Inq Lab,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,
+BIOL,1200,011,Biological Inq Lab,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,012,Biological Inq Lab,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,013,Biological Inq Lab,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,014,Biological Inq Lab,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,015,Biological Inq Lab,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,016,Biological Inq Lab,0.5,0.38,0.06,0.0,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1220,001,Keys to Biodiversity,0.24,0.4,0.24,0.07,0.02,0.0,0.0,0.02,kalan ickes,
+BIOL,1230,001,Keys to Human Biol,0.22,0.44,0.23,0.08,0.02,0.0,0.0,0.01, christine minor,
+BIOL,1230,002,Keys to Human Biol,0.33,0.43,0.17,0.07,0.01,0.0,0.0,0.0, christine minor,
+BIOL,2000,002,Biology in the News,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0, christine minor,
+BIOL,2000,009,Biology in the News,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,douglas bielenberg,
+BIOL,2000,010,Biology in the News,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,
+BIOL,2040,001,"Environ, Energy and",0.29,0.32,0.25,0.03,0.04,0.0,0.0,0.07,john jenkins hains,
+BIOL,2220,001,Human Anat and Physi,0.22,0.38,0.24,0.09,0.04,0.0,0.0,0.04,john cummings,
+BIOL,2220,002,Human Anat and Physi,0.19,0.37,0.24,0.11,0.02,0.0,0.0,0.05,john cummings,
+BIOL,3030,001,Vertebrate Biology,0.29,0.29,0.2,0.14,0.04,0.0,0.0,0.03,richard blob,
+BIOL,3030,002,Vertebrate Biology (,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True
+BIOL,3040,001,Biology of Plants,0.12,0.34,0.36,0.09,0.06,0.0,0.0,0.03,robert edwa ballard,
+BIOL,3070,001,Vertebrate Biology L,0.5,0.4,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,002,Vertebrate Biology L,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,003,Vertebrate Biology L,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,004,Vertebrate Biology L,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,richard blob,
+BIOL,3070,005,Vertebrate Biology L,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,006,Vertebrate Biology L,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,007,Vertebrate Biology L,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,008,Vertebrate Biology L,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,009,Vertebrate Biology L,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,010,Vertebrate Biology L,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,011,Vertebrate Biology L,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,012,Vertebrate Biology L,0.55,0.4,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,013,Vertebrate Biology L,0.55,0.35,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3080,001,Biology of Plants Pr,0.63,0.21,0.05,0.05,0.05,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3080,002,Biology of Plants Pr,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3080,003,Biology of Plants Pr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3080,004,Biology of Plants Pr,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,robert edwa ballard,
+BIOL,3150,001,Functional Human Ana,0.25,0.46,0.19,0.04,0.01,0.0,0.0,0.05,tamara mcnutt-scott,
+BIOL,3200,001,Field Botany,0.19,0.37,0.24,0.09,0.07,0.0,0.0,0.04,timothy spira,
+BIOL,3350,001,Evolutionary Biology,0.27,0.46,0.11,0.06,0.04,0.0,0.0,0.04,margaret ptacek,
+BIOL,3510,001,Biological Anthropol,0.42,0.33,0.08,0.0,0.17,0.0,0.0,0.0,lisa rapaport,
+BIOL,3530,001,Forensic Anthrolpolo,0.31,0.38,0.15,0.08,0.08,0.0,0.0,0.0,katherine weisensee,
+BIOL,4340,001,Biological Chem Lab,0.15,0.23,0.38,0.08,0.0,0.0,0.0,0.15,salvatore sparace,
+BIOL,4340,003,Biological Chem Lab,0.17,0.5,0.08,0.25,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,004,Biological Chem Lab,0.17,0.42,0.25,0.08,0.08,0.0,0.0,0.0,salvatore sparace,
+BIOL,4410,001,Ecology,0.25,0.44,0.19,0.09,0.01,0.0,0.0,0.02,david tonkyn,
+BIOL,4430,001,Freshwater Ecology,0.56,0.29,0.13,0.0,0.0,0.0,0.0,0.02,john jenkins hains,
+BIOL,4450,001,Ecology Laboratory (,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,david tonkyn,
+BIOL,4450,002,Ecology Laboratory (,0.36,0.36,0.18,0.0,0.0,0.0,0.0,0.09,david tonkyn,
+BIOL,4450,003,Ecology Laboratory (,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
+BIOL,4450,004,Ecology Laboratory (,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david tonkyn,
+BIOL,4610,001,Cell Biology,0.38,0.3,0.11,0.11,0.0,0.0,0.0,0.1,lesly temesvari,
+BIOL,4610,002,Cell Biology (HON),0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True
+BIOL,4610,003,Cell Biology,0.91,0.06,0.01,0.01,0.01,0.0,0.0,0.0,susan carol chapman,
+BIOL,4610,004,Cell Biology (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True
+BIOL,4620,001,Cell Biology Lab (Le,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4620,003,Cell Biology Lab (Le,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4620,004,Cell Biology Lab (Le,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4620,005,Cell Biology Lab (Le,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4620,006,Cell Biology Lab (Le,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4620,007,Cell Biology Lab (Le,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,david feliciano,
+BIOL,4620,008,Cell Biology Lab (Le,0.27,0.33,0.4,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4620,010,Cell Biology Lab (Le,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4620,011,Cell Biology Lab (Le,0.36,0.43,0.0,0.07,0.07,0.0,0.0,0.07,david feliciano,
+BIOL,4660,001,Evolution of Human B,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,lisa rapaport,
+BIOL,4670,001,Principles of Hemato,0.88,0.05,0.05,0.0,0.0,0.0,0.0,0.02,vincent gallicchio,
+BIOL,4750,001,Comparative Physiolo,0.3,0.43,0.14,0.0,0.08,0.0,0.0,0.05,michael sears,
+BIOL,4760,003,Comparative Physiolo,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael sears,
+BIOL,4930,002,Adv Cancer Research,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,wen chen,
+BIOL,4940,001,Aging Stress Induced,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,min cao,
+BIOL,4940,001,Aging Stress Induced,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,yuqing dong,
+BIOL,4940,007,Popular Science Jour,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,steven katz,
+BIOL,4940,007,Popular Science Jour,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
+BIOL,4960,004,MARINE MICRO,0.27,0.33,0.27,0.13,0.0,0.0,0.0,0.0,john michael henson,
+BIOL,8200,001,Community Ecology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,saara dewalt,
+BIOL,8400,001,Understanding Biolog,0.83,0.1,0.01,0.0,0.02,0.0,0.0,0.03,michael childress,
+BIOL,8420,001,Understand Cellular,0.57,0.31,0.06,0.0,0.04,0.0,0.0,0.02,david feliciano,
+BIOL,8440,001,Understanding the Hu,0.65,0.29,0.03,0.0,0.02,0.0,0.0,0.0,heidi lynn jordan,
+BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,001,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,002,Business Foundations,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,sandy edge,
+BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,003,Business Foundations,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,michael giebner,
+BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,004,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,005,Business Foundations,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,006,Business Foundations,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,michael giebner,
+BUS,1010,007,Business Foundations,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,sandy edge,
+BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,michael giebner,
+BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,008,Business Foundations,0.11,0.42,0.37,0.05,0.0,0.0,0.0,0.05,sandy edge,
+BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,sandy edge,
+BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,edward bar de iulio,
+BUS,1010,009,Business Foundations,0.35,0.29,0.24,0.0,0.06,0.0,0.0,0.06,michael giebner,
+BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,sandy edge,
+BUS,1010,010,Business Foundations,0.22,0.4,0.26,0.03,0.05,0.0,0.0,0.05,michael giebner,
+BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,sandy edge,
+BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,michael giebner,
+BUS,1010,011,Business Foundations,0.32,0.58,0.0,0.0,0.05,0.0,0.0,0.05,william ern tumblin,
+BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,012,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,sandy edge,
+BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,michael giebner,
+BUS,1010,013,Business Foundations,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
+BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,michael giebner,
+BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,sandy edge,
+BUS,1010,014,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
+BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,015,Business Foundations,0.26,0.68,0.0,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,michael giebner,
+BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,sandy edge,
+BUS,1010,016,Business Foundations,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
+BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,sandy edge,
+BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,michael giebner,
+BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,017,Business Foundations,0.37,0.26,0.32,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,sandy edge,
+BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,018,Business Foundations,0.11,0.53,0.26,0.05,0.05,0.0,0.0,0.0,michael giebner,
+BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,michael giebner,
+BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,019,Business Foundations,0.11,0.42,0.21,0.05,0.21,0.0,0.0,0.0,sandy edge,
+BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,sandy edge,
+BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,michael giebner,
+BUS,1010,020,Business Foundations,0.47,0.47,0.04,0.0,0.02,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,sandy edge,
+BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,michael giebner,
+BUS,1010,021,Business Foundations,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,edward bar de iulio,
+BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,022,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,023,Business Foundations,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,024,Business Foundations,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,michael giebner,
+BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,sandy edge,
+BUS,1010,025,Business Foundations,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,sandy edge,
+BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,michael giebner,
+BUS,1010,026,Business Foundations,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,027,Business Foundations,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,michael giebner,
+BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,sandy edge,
+BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,edward bar de iulio,
+BUS,1010,029,Business Foundations,0.12,0.35,0.35,0.12,0.0,0.0,0.0,0.06,renee hebert,
+BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,michael giebner,
+BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,edward bar de iulio,
+BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,sandy edge,
+BUS,1010,030,Business Foundations,0.22,0.44,0.17,0.06,0.0,0.0,0.0,0.11,renee hebert,
+BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,michael giebner,
+BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,sandy edge,
+BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,renee hebert,
+BUS,1010,031,Business Foundations,0.12,0.59,0.24,0.0,0.0,0.0,0.0,0.06,edward bar de iulio,
+BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,michael giebner,
+BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,
+BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,032,Business Foundations,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,sandy edge,
+CE,2010,002,Statics,0.32,0.25,0.25,0.07,0.0,0.0,0.0,0.11,qiushi chen,
+CE,2010,003,Statics,0.24,0.24,0.29,0.05,0.13,0.0,0.0,0.05,scott schiff,
+CE,2010,004,Statics,0.2,0.29,0.22,0.02,0.07,0.0,0.0,0.2,melissa sternhagen,
+CE,2010,005,Statics,0.24,0.29,0.2,0.07,0.02,0.0,0.0,0.18,melissa sternhagen,
+CE,2010,006,Statics,0.4,0.23,0.14,0.05,0.07,0.0,0.0,0.12,nighat yasmin,
+CE,2010,007,Statics,0.38,0.3,0.19,0.03,0.03,0.0,0.0,0.08,weichiang pang,
+CE,2060,001,Structural Mechanics,0.14,0.16,0.51,0.08,0.06,0.0,0.0,0.04,bryant nielson,
+CE,2080,002,Dynamics,0.16,0.24,0.24,0.18,0.08,0.0,0.0,0.11,melissa sternhagen,
+CE,2080,004,Dynamics,0.05,0.3,0.35,0.15,0.1,0.0,0.0,0.05,melissa sternhagen,
+CE,2550,001,Geomatics,0.32,0.38,0.24,0.01,0.01,0.0,0.0,0.04,wayne sarasua,
+CE,3010,001,Structural Analysis,0.3,0.43,0.11,0.0,0.14,0.0,0.0,0.03,stephen csernak,
+CE,3010,002,Structural Analysis,0.21,0.31,0.34,0.06,0.06,0.0,0.0,0.02,bryant nielson,
+CE,3110,001,Transportation Engr,0.74,0.17,0.04,0.02,0.02,0.0,0.0,0.0,jennifer ogle,
+CE,3210,001,Geotechnical Enginee,0.31,0.46,0.15,0.0,0.06,0.0,0.0,0.02,qiushi chen,
+CE,3310,001,Constr Engr & Mgmnt,0.41,0.42,0.09,0.04,0.04,0.0,0.0,0.0,james burati,
+CE,3410,001,Intro to Fluid Mech,0.19,0.38,0.26,0.11,0.04,0.0,0.0,0.02,nigel gregory kaye,
+CE,3410,002,Intro to Fluid Mech,0.17,0.31,0.28,0.09,0.07,0.0,0.0,0.07,abdul khan,
+CE,3420,001,Hydraulics & Hydro,0.38,0.4,0.13,0.05,0.05,0.0,0.0,0.0,ashok mishra,
+CE,3510,001,Civil Engineering Ma,0.34,0.5,0.1,0.02,0.04,0.0,0.0,0.0,ami esmaeilpoursaee,
+CE,3510,002,Civil Engineering Ma,0.38,0.32,0.21,0.03,0.06,0.0,0.0,0.0,bradley putman,
+CE,3520,001,Econ Eval of Proj,0.37,0.33,0.12,0.08,0.08,0.0,0.0,0.01,yongxi huang,
+CE,3530,001,Professional Seminar,0.79,0.13,0.08,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,4060,001,Struct Steel Design,0.21,0.32,0.28,0.17,0.02,0.0,0.0,0.0,stephen csernak,
+CE,4080,001,Struct Loads & Sys,0.22,0.5,0.06,0.17,0.06,0.0,0.0,0.0,bryant nielson,
+CE,4100,001,Traffic Engr Oper,0.06,0.5,0.22,0.22,0.0,0.0,0.0,0.0,yongxi huang,
+CE,4240,001,Earth Slopes & Struc,0.24,0.42,0.24,0.05,0.03,0.0,0.0,0.03,nadara ravichandran,
+CE,4340,001,Const Est Proj Cont,0.61,0.32,0.05,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,4360,001,Sustainable Constr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,
+CE,4390,001,Con Eqpmt Sel & Main,0.56,0.34,0.07,0.0,0.02,0.0,0.0,0.0,james burati,
+CE,4430,001,Water Resources Engr,0.45,0.09,0.36,0.0,0.0,0.0,0.0,0.09,abdul khan,
+CE,4560,001,Pave Design & Constr,0.37,0.42,0.17,0.03,0.0,0.0,0.0,0.02,bradley putman,
+CE,4590,001,Capstone Design Proj,0.25,0.57,0.1,0.08,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4820,001,Groundwater & Contam,0.42,0.25,0.17,0.0,0.0,0.0,0.0,0.17,lawrence murdoch,
+CE,4990,052,C I in Civil Engr/CE,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,jennifer ogle,
+CE,6080,001,Struct Loads & Sys,0.42,0.46,0.13,0.0,0.0,0.0,0.0,0.0,bryant nielson,
+CE,6100,001,Traffic Engr Oper,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yongxi huang,
+CE,6240,001,Earth Slopes & Struc,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,6360,001,Sustainable Constr,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,leidy klotz,
+CE,8020,001,Adv R/C Design,0.4,0.58,0.0,0.0,0.0,0.0,0.0,0.03,scott schiff,
+CE,8060,001,Dyn Analys of Struc,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
+CE,8210,001,Advanced Soil Mech,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,8220,001,Foundation Engr,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,8540,001,Travl Demnd Forecast,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
+CE,8930,005,Connected Vehicle Te,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,mashrur chowdhury,
+CH,1010,001,General Chemistry,0.25,0.37,0.21,0.12,0.05,0.0,0.0,0.01,dennis taylor,
+CH,1010,002,General Chemistry,0.09,0.42,0.27,0.09,0.08,0.0,0.0,0.04,ava kreider-mueller,
+CH,1010,003,General Chemistry,0.23,0.39,0.2,0.08,0.06,0.0,0.0,0.05,dennis taylor,
+CH,1010,004,General Chemistry,0.24,0.31,0.2,0.14,0.04,0.0,0.0,0.07,dennis taylor,
+CH,1010,005,General Chemistry,0.11,0.29,0.32,0.15,0.11,0.0,0.0,0.02,ava kreider-mueller,
+CH,1010,006,General Chemistry,0.22,0.36,0.18,0.1,0.11,0.0,0.0,0.02,thomas hickman,
+CH,1010,007,General Chemistry,0.22,0.38,0.23,0.08,0.08,0.0,0.0,0.01,thomas hickman,
+CH,1010,008,General Chemistry,0.2,0.34,0.24,0.06,0.1,0.0,0.0,0.06,kenneth wi rillings,
+CH,1010,009,General Chemistry,0.13,0.32,0.26,0.12,0.1,0.0,0.0,0.06,ava kreider-mueller,
+CH,1010,010,General Chemistry,0.19,0.24,0.21,0.18,0.16,0.0,0.0,0.03,christopher wilson,
+CH,1010,011,General Chemistry,0.22,0.37,0.23,0.09,0.03,0.0,0.0,0.06,tania issa houjeiry,
+CH,1010,012,General Chemistry,0.11,0.27,0.28,0.2,0.09,0.0,0.0,0.05,christopher wilson,
+CH,1010,013,General Chemistry,0.18,0.29,0.3,0.08,0.11,0.0,0.0,0.04,olt geiculescu,
+CH,1010,014,General Chemistry,0.23,0.39,0.24,0.09,0.02,0.0,0.0,0.03,dennis taylor,
+CH,1010,015,General Chemistry: M,0.34,0.31,0.22,0.06,0.06,0.0,0.0,0.0,tania issa houjeiry,
+CH,1010,016,General Chemistry (R,0.2,0.45,0.26,0.03,0.03,0.0,0.0,0.03,tania issa houjeiry,
+CH,1010,017,General Chemistry (R,0.15,0.43,0.27,0.07,0.05,0.0,0.0,0.03,kenneth wi rillings,
+CH,1010,018,General Chemistry (R,0.17,0.44,0.25,0.07,0.04,0.0,0.0,0.03,kenneth wi rillings,
+CH,1010,019,General Chemistry: C,0.32,0.39,0.19,0.08,0.0,0.0,0.0,0.01,kenneth christensen,
+CH,1010,051,General Chemistry (H,0.68,0.29,0.02,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True
+CH,1010,052,General Chemistry (H,0.58,0.39,0.0,0.03,0.0,0.0,0.0,0.0,joseph stu thrasher,True
+CH,1020,001,General Chemistry,0.32,0.26,0.27,0.09,0.02,0.0,0.0,0.03,stephe schvaneveldt,
+CH,1020,002,General Chemistry,0.28,0.32,0.19,0.09,0.05,0.0,0.0,0.07,stephe schvaneveldt,
+CH,1020,003,General Chemistry,0.24,0.24,0.25,0.17,0.03,0.0,0.0,0.07,stephe schvaneveldt,
+CH,1020,400,General Chemistry (O,0.11,0.24,0.27,0.16,0.11,0.0,0.0,0.11,stephe schvaneveldt,
+CH,1050,001,Chem in Context I,0.26,0.56,0.17,0.02,0.0,0.0,0.0,0.0,olt geiculescu,
+CH,1050,002,Chem in Context I,0.41,0.47,0.06,0.02,0.03,0.0,0.0,0.02,olt geiculescu,
+CH,1410,001,Chem Orientation,0.72,0.2,0.06,0.0,0.0,0.0,0.0,0.02,stephen creager,
+CH,2010,001,Survey of Organic Ch,0.44,0.32,0.08,0.03,0.04,0.0,0.0,0.08,thomas hickman,
+CH,2010,002,Survey of Organic Ch,0.45,0.37,0.12,0.03,0.0,0.0,0.0,0.04,thomas hickman,
+CH,2020,001,Surv of Organic Chem,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2020,009,Surv of Organic Chem,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
+CH,2020,010,Surv of Organic Chem,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,
+CH,2020,011,Surv of Organic Chem,0.53,0.2,0.07,0.0,0.0,0.0,0.0,0.2,sean 'connor,
+CH,2020,012,Surv of Organic Chem,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2230,001,Organic Chemistry,0.09,0.2,0.31,0.12,0.11,0.0,0.0,0.17,dev priya arya,
+CH,2230,002,Organic Chemistry,0.35,0.29,0.18,0.08,0.03,0.0,0.0,0.07,rhett smith,
+CH,2230,003,Organic Chemistry,0.3,0.34,0.19,0.04,0.1,0.0,0.0,0.02,jacob schroeder,
+CH,2230,004,Organic Chemistry,0.2,0.28,0.24,0.17,0.03,0.0,0.0,0.07,modi wetzler,
+CH,2230,005,Organic Chemistry,0.26,0.3,0.25,0.09,0.03,0.0,0.0,0.07,modi wetzler,
+CH,2230,006,Organic Chemistry,0.38,0.34,0.21,0.02,0.01,0.0,0.0,0.04,tania issa houjeiry,
+CH,2230,007,Organic Chemistry,0.37,0.36,0.15,0.06,0.01,0.0,0.0,0.05,jacob schroeder,
+CH,2240,001,Organic Chemistry,0.31,0.3,0.22,0.09,0.02,0.0,0.0,0.06,jacob schroeder,
+CH,2240,002,Organic Chemistry,0.3,0.37,0.21,0.05,0.05,0.0,0.0,0.02,jacob schroeder,
+CH,2270,001,Organic Chem Lab,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,
+CH,2270,002,Organic Chem Lab,0.81,0.06,0.06,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2270,007,Organic Chem Lab,0.6,0.07,0.07,0.0,0.0,0.0,0.0,0.27,sean 'connor,
+CH,2270,011,Organic Chem Lab,0.69,0.13,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,
+CH,2270,014,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,015,Organic Chem Lab,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,016,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,017,Organic Chem Lab,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,019,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,020,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,023,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,024,Organic Chem Lab,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,026,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,028,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,029,Organic Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,030,Organic Chem Lab,0.44,0.5,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2270,031,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,032,Organic Chem Lab,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,033,Organic Chem Lab,0.55,0.09,0.09,0.18,0.0,0.0,0.0,0.09,sean 'connor,
+CH,2270,034,Organic Chem Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,sean 'connor,
+CH,2270,035,Organic Chem Lab,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,036,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,037,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,038,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
+CH,2280,004,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
+CH,2280,007,Organic Chem Lab,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
+CH,3130,001,Quantitative Analys,0.4,0.33,0.1,0.07,0.02,0.0,0.0,0.07,stephen creager,
+CH,3150,002,Quant Analysis Lab,0.36,0.36,0.09,0.09,0.09,0.0,0.0,0.0,jeffrey natha anker,
+CH,3300,001,Intro to Phys Chem,0.41,0.37,0.18,0.0,0.0,0.0,0.0,0.04,brian dominy,
+CH,3310,001,Physical Chemistry,0.27,0.25,0.35,0.08,0.02,0.0,0.0,0.02,jason mcneill,
+CH,3320,001,Physical Chemistry,0.2,0.3,0.1,0.2,0.0,0.0,0.0,0.2,arkady kholodenko,
+CH,3390,001,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,
+CH,3390,005,Physical Chem Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,
+CH,4010,001,Organometallic Chemi,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,andrew gre tennyson,
+CH,4020,001,Inorganic Chemistry,0.2,0.73,0.07,0.0,0.0,0.0,0.0,0.0,joseph kolis,
+CH,8070,001,Chem Trans Elem,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
+CH,8120,001,Spectrochemical Anal,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,george chumanov,
+CH,8150,001,Mass Spectrometry,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,richard marcus,
+CH,8210,001,Organic Chem I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, karl dieter,
+CH,8300,001,Fund Phys Chem,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,
+CH,8340,001,Stat Thermodynamics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,
+CH,8410,001,N M R Spectroscopy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,alek kitaygorodskiy,
+CH,8510,002,Grad Student Seminar,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey natha anker,
+CHE,2110,001,Intro to Chem Eng,0.23,0.24,0.18,0.03,0.26,0.0,0.0,0.06,rachel getman,
+CHE,2110,002,Intro to Chem Eng,0.19,0.23,0.26,0.02,0.23,0.0,0.0,0.08,rachel getman,
+CHE,3070,001,Unit Ops Lab I,0.14,0.6,0.21,0.02,0.0,0.0,0.0,0.02,christopher norfolk,
+CHE,3070,001,Unit Ops Lab I,0.14,0.6,0.21,0.02,0.0,0.0,0.0,0.02,mark thies,
+CHE,3190,001,Engr Materials,0.11,0.32,0.39,0.14,0.05,0.0,0.0,0.0,antho guiseppi-elie,
+CHE,4070,001,Unit Op Lab II,0.16,0.84,0.0,0.0,0.0,0.0,0.0,0.0,scott husson,
+CHE,4310,001,Process Design I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,4500,001,Chem Reaction Engr,0.17,0.34,0.34,0.09,0.06,0.0,0.0,0.0,mark alan blenner,
+CHE,8030,001,Advanced Transport,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,douglas hirt,
+CHE,8040,001,Ch E Thermodynamics,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
+CHE,8050,001,Ch E Kinetics,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,mark roberts,
+CHE,8140,002,Numerical Methods,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,joseph scott,
+CHIN,1010,001,Elementary Chinese,0.44,0.06,0.19,0.0,0.0,0.0,0.0,0.31,yanming an,
+CHIN,4010,001,Pre-Modern Chinese L,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,yanming an,
+COM,1500,001,Intro to Human Com,0.66,0.29,0.01,0.01,0.02,0.0,0.0,0.01,eddie smith,
+COM,1500,002,Introduction  to Hum,0.65,0.24,0.06,0.01,0.01,0.0,0.0,0.03,daniel lelan fecher,
+COM,1500,003,Intro to Human Com,0.69,0.26,0.02,0.01,0.01,0.0,0.0,0.01,eddie smith,
+COM,1500,004,Intro to Human Com,0.64,0.29,0.05,0.0,0.01,0.0,0.0,0.01,marianne her glaser,
+COM,1500,005,Intro to Human Com,0.71,0.22,0.05,0.0,0.01,0.0,0.0,0.01,marianne her glaser,
+COM,1500,006,Intro to Human Com,0.65,0.25,0.04,0.0,0.01,0.0,0.0,0.05,marianne her glaser,
+COM,1500,007,Intro to Human Com,0.4,0.47,0.06,0.02,0.01,0.0,0.0,0.03,daniel lelan fecher,
+COM,2010,001,Intr to Comm Studies,0.51,0.39,0.1,0.0,0.0,0.0,0.0,0.0,brenden kendall,
+COM,2500,001,Public Speaking,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,brandon boatwright,
+COM,2500,002,Public Speaking,0.11,0.58,0.16,0.0,0.11,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,003,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,004,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,005,Public Speaking,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,006,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,
+COM,2500,007,Public Speaking,0.37,0.42,0.16,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,008,Public Speaking,0.68,0.11,0.0,0.05,0.05,0.0,0.0,0.11,jumah patrici taweh,
+COM,2500,009,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,010,Public Speaking,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,
+COM,2500,011,Public Speaking,0.5,0.39,0.0,0.06,0.0,0.0,0.0,0.06,pauline matthey,
+COM,2500,012,Public Speaking,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,marilyn denise pugh,
+COM,2500,013,Public Speaking,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,014,Public Speaking,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,015,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,016,Public Speaking,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,katharin schoonover,
+COM,2500,017,Public Speaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,the estate  geddes,
+COM,2500,018,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
+COM,2500,019,Public Speaking,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,pauline matthey,
+COM,2500,020,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,021,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,022,Public Speaking,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,023,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,024,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,025,Public Speaking (HON,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,True
+COM,2500,026,Public Speaking (HON,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True
+COM,2500,400,Public Speaking,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,401,Public Speaking,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alexis zachar davis,
+COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,403,Public Speaking,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
+COM,3010,001,Comm Theory,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,3020,001,Mass Comm Theory,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3070,001,Public Comm of Sts,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,david travers scott,
+COM,3080,001,Pub Comm & Pop Cult,0.28,0.4,0.18,0.04,0.02,0.0,0.0,0.08,chenjerai kumanyika,
+COM,3100,001,Quant Comm Methods,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,3110,001,Qual Comm Methods,0.37,0.47,0.0,0.0,0.05,0.0,0.0,0.11,chenjerai kumanyika,
+COM,3210,001,Comm Across Media Pl,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian mullen,
+COM,3220,001,Communication Design,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,lori marlise pindar,
+COM,3250,001,Survey of Sports Com,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,3250,002,Survey of Sports Com,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,3260,001,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3260,002,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3480,001,Interpersonal Comm,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,melinda ra weathers,
+COM,3550,001,Principles of Pr,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3550,002,Principles of Pr,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3660,001,EP: Advertising & Me,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,william reynolds,
+COM,3660,002,EP: Building the Bra,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,andrew mendelsohn,
+COM,3660,003,Live Broadcast Prod.,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,michael rodgers,
+COM,4300,001,Legal Communication,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
+COM,4700,001,Comm & Health,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,4800,001,Intercultural Comm,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,andrew stephen pyle,
+COM,8010,001,Communication Theory,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,8030,001,Comm Technology Stud,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
+COM,8100,001,Comm Research Method,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,darren linvill,
+CPSC,1010,001,Computer Science I,0.24,0.12,0.24,0.08,0.18,0.0,0.0,0.13,catherine hochrine,
+CPSC,1010,003,Computer Science I,0.75,0.11,0.02,0.0,0.02,0.0,0.0,0.09,lauren elizab dukes,
+CPSC,1010,004,Computer Science I,0.15,0.13,0.18,0.13,0.21,0.0,0.0,0.21,pradip srimani,
+CPSC,1020,001,Computer Science II,0.36,0.36,0.07,0.02,0.02,0.0,0.0,0.18,catherine hochrine,
+CPSC,1040,001,Intro Computer Prog,0.24,0.56,0.0,0.08,0.08,0.0,0.0,0.04,kenneth alle weaver,
+CPSC,1110,001,Intro to Programming,0.58,0.28,0.08,0.03,0.03,0.0,0.0,0.03,patrick sterling,
+CPSC,1110,002,Intro to Programming,0.52,0.31,0.07,0.0,0.1,0.0,0.0,0.0,patrick sterling,
+CPSC,1110,003,Intro to Programming,0.64,0.19,0.07,0.02,0.05,0.0,0.0,0.02,patrick sterling,
+CPSC,1110,004,Intro to Programming,0.87,0.07,0.02,0.0,0.04,0.0,0.0,0.0,toni bloodwor pence,
+CPSC,2070,001,Discrete Structures,0.13,0.29,0.28,0.1,0.04,0.0,0.0,0.15,roy pargas,
+CPSC,2100,001,Progrmng Methodology,0.54,0.13,0.1,0.06,0.1,0.0,0.0,0.08,rose lowe,
+CPSC,2120,001,Algs/Data Structures,0.28,0.28,0.23,0.02,0.06,0.0,0.0,0.12,brian christop dean,
+CPSC,2150,001,Software Dev Fndtns,0.35,0.28,0.23,0.05,0.05,0.0,0.0,0.05,blair madiso durkee,
+CPSC,2150,002,Software Dev Fndtns,0.21,0.31,0.33,0.05,0.05,0.0,0.0,0.05,catherine hochrine,
+CPSC,2200,001,Microcomputer Appl,0.32,0.42,0.16,0.0,0.11,0.0,0.0,0.0,renee lambert,
+CPSC,2200,002,Microcomputer Appl,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,patrick sterling,
+CPSC,2310,001,Intro Computer Org,0.22,0.35,0.24,0.05,0.14,0.0,0.0,0.0,rose lowe,
+CPSC,2310,002,Intro Computer Org,0.41,0.24,0.21,0.03,0.09,0.0,0.0,0.03,rose lowe,
+CPSC,2910,001,Prof Issues I,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,james jones,
+CPSC,2910,002,Prof Issues I,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,james jones,
+CPSC,2910,003,Prof Issues I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,james jones,
+CPSC,2910,004,Prof Issues I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
+CPSC,2910,006,Prof Issues I,0.6,0.0,0.2,0.0,0.1,0.0,0.0,0.1,renee lambert,
+CPSC,2910,008,Prof Issues I,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,renee lambert,
+CPSC,3220,001,Intro to Operating S,0.23,0.21,0.14,0.04,0.12,0.0,0.0,0.26,jacob sorber,
+CPSC,3300,001,Computer Systems Org,0.32,0.25,0.22,0.03,0.1,0.0,0.0,0.08,mark smotherman,
+CPSC,3500,001,Foundatns of Com Sci,0.22,0.27,0.22,0.08,0.1,0.0,0.0,0.12,ilya mark safro,
+CPSC,3520,001,Programming Systems,0.25,0.31,0.19,0.03,0.19,0.0,0.0,0.03,robert schalkoff,
+CPSC,3600,001,Network Programming,0.19,0.33,0.22,0.04,0.11,0.0,0.0,0.11,sekou lionel remy,
+CPSC,3620,001,Dist & Cluster Compu,0.36,0.3,0.18,0.09,0.06,0.0,0.0,0.0,amy apon,
+CPSC,3620,001,Dist & Cluster Compu,0.36,0.3,0.18,0.09,0.06,0.0,0.0,0.0,linh bao ngo,
+CPSC,3710,001,Systems Analysis,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+CPSC,3720,001,Software Engineering,0.32,0.35,0.29,0.0,0.0,0.0,0.0,0.03,murali sitaraman,
+CPSC,3720,002,Software Engineering,0.15,0.35,0.35,0.09,0.03,0.0,0.0,0.03,stephen schaub,
+CPSC,3990,002,AdvCI Proc Gen Game,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,brian malloy,
+CPSC,4040,001,Cmptr Graphics Image,0.5,0.23,0.14,0.0,0.14,0.0,0.0,0.0,joshua levine,
+CPSC,4060,001,Gpu Computation,0.3,0.0,0.3,0.1,0.3,0.0,0.0,0.0,robert geist,
+CPSC,4110,001,Virtual Reality Syst,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
+CPSC,4200,001,Computer Security Pr,0.32,0.36,0.18,0.05,0.05,0.0,0.0,0.05,pradip srimani,
+CPSC,4620,001,Database Management,0.29,0.5,0.18,0.0,0.0,0.0,0.0,0.04,feng luo,
+CPSC,4810,016,Programming Team,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian christop dean,
+CPSC,4910,001,Prof  Issues II,0.95,0.04,0.0,0.0,0.0,0.0,0.0,0.02,james jones,
+CPSC,6040,001,Cptr Graphics Image,0.65,0.2,0.05,0.0,0.05,0.0,0.0,0.05,joshua levine,
+CPSC,6060,001,Gpu Computation,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,robert geist,
+CPSC,6110,001,Virtual Reality Syst,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
+CPSC,6620,001,Database Management,0.33,0.63,0.0,0.0,0.0,0.0,0.0,0.04,feng luo,
+CPSC,8070,001,3d Model Animation,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+CPSC,8200,001,Parallel Architechtu,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,pradip srimani,
+CPSC,8270,001,Translation of Progr,0.86,0.05,0.1,0.0,0.0,0.0,0.0,0.0,brian malloy,
+CPSC,8380,001,Adv Data Structures,0.23,0.09,0.09,0.0,0.45,0.0,0.0,0.14,sandra hedetniemi,
+CPSC,8450,001,Bioinfo Algorithms,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,
+CPSC,8510,001,Soft Sys Data Comm,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,james martin,
+CPSC,8700,001,O O Software Design,0.64,0.28,0.05,0.0,0.0,0.0,0.0,0.03,brian malloy,
+CPSC,8720,002,Software Spec & Desi,0.34,0.45,0.17,0.0,0.0,0.0,0.0,0.03,john mcgregor,
+CPSC,8770,001,Biometric Systems,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,damon woodard,
+CPSC,8810,001,Data Visualization,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,joshua levine,
+CRP,8000,001,Human Settlement,0.51,0.37,0.12,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+CRP,8000,001,Human Settlement,0.51,0.37,0.12,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
+CRP,8010,001,Planning Process & L,0.26,0.7,0.0,0.0,0.0,0.0,0.0,0.04,caitlin dyckman,
+CRP,8020,001,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
+CRP,8030,001,Quant Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
+CRP,8030,001,Quant Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
+CRP,8060,001,Urban Systems,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,timothy green,
+CRP,8580,002,Research Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy green,
+CSM,1000,001,Intro to Construct,0.2,0.63,0.13,0.04,0.02,0.0,0.0,0.0,joseph wintz,
+CSM,2010,001,Structures I,0.27,0.41,0.14,0.14,0.0,0.0,0.0,0.05,shima clarke,
+CSM,2010,002,Structures I,0.23,0.27,0.32,0.05,0.05,0.0,0.0,0.09,shima clarke,
+CSM,2030,001,Mats & Meth of Const,0.19,0.67,0.15,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,2030,002,Mats & Meth of Const,0.21,0.54,0.17,0.08,0.0,0.0,0.0,0.0,jason lucas,
+CSM,3030,001,Soils & Foundations,0.27,0.47,0.13,0.13,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,3030,002,Soils & Foundations,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,3040,001,Envir Systems I,0.33,0.43,0.24,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3040,002,Envir Systems I,0.32,0.47,0.05,0.11,0.05,0.0,0.0,0.0,joseph mich burgett,
+CSM,3510,001,Const Estimating,0.29,0.48,0.14,0.1,0.0,0.0,0.0,0.0,james packer smith,
+CSM,3510,002,Const Estimating,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,james packer smith,
+CSM,4110,001,Safety in Bldg Const,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,david devita,
+CSM,4500,001,Construction Intern,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CSM,4530,001,Const Proj Mgmt,0.08,0.6,0.32,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,4530,002,Const Proj Mgmt,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,4610,001,Const Econ Seminar,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4610,002,Const Econ Seminar,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,6550,001,Adverse Relations,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,joseph wintz,
+CSM,8520,001,Const Mgmt Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,shima clarke,
+CSM,8600,001,Constr Finan Plan &,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8600,400,Constr Finan Plan &,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8630,001,Adv Plan/Sched,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8630,400,Adv Plan/Sched,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8660,001,Role in Development,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CU,1000,001,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.01,jeffrey appling,
+CU,1000,001,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.01,mary mcp von kaenel,
+CU,1000,002,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.01,jeffrey appling,
+CU,1000,002,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.01,mary mcp von kaenel,
+CU,1000,003,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,jeffrey appling,
+CU,1000,003,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,mary mcp von kaenel,
+CU,1000,004,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.84,0.15,0.02,jeffrey appling,
+CU,1000,004,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.84,0.15,0.02,mary mcp von kaenel,
+CU,1000,005,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.03,0.01,jeffrey appling,
+CU,1000,006,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.02,0.01,jeffrey appling,
+CU,1000,007,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,
+CU,1000,008,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,
+CU,1000,009,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey appling,
+CU,1000,010,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,jeffrey appling,
+CU,1000,011,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey appling,
+CU,1000,012,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.05,0.01,jeffrey appling,
+CU,1000,013,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.01,jeffrey appling,
+CU,1000,014,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.89,0.1,0.01,jeffrey appling,
+CU,1010,001,Univ Success Skills,0.43,0.17,0.26,0.0,0.04,0.0,0.0,0.09,deborah ann vaughn,
+CU,1010,002,Univ Success Skills,0.35,0.39,0.09,0.09,0.04,0.0,0.0,0.04,rise jean sheriff,
+CU,1010,003,Univ Success Skills,0.44,0.36,0.08,0.04,0.08,0.0,0.0,0.0,cecelia hamby,
+CU,1010,005,Univ Success Skills,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,robert dav brackett,
+DANC,1600,001,Ballet Dance I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,cheryl hosler,
+DPA,3070,001,Method 3d Production,0.43,0.3,0.04,0.04,0.13,0.0,0.0,0.04,virginia ba nearing,
+DPA,4000,001,Tech Foundations I,0.08,0.17,0.33,0.0,0.08,0.0,0.0,0.33,christina sop joerg,
+DPA,6000,001,Tech Foundations I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+DPA,8600,001,Production Studio,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,
+ECE,2010,001,Logic & Comp Device,0.16,0.3,0.28,0.13,0.09,0.0,0.0,0.05,william reid,
+ECE,2010,002,Logic & Comp Device,0.62,0.24,0.1,0.0,0.05,0.0,0.0,0.0,william reid,True
+ECE,2020,001,Electric Circuits I,0.18,0.22,0.29,0.17,0.07,0.0,0.0,0.07,william harrell,
+ECE,2020,002,Electric Circuits I,0.73,0.13,0.0,0.07,0.0,0.0,0.0,0.07,apoorva dee kapadia,True
+ECE,2070,001,Basic Electrical Eng,0.85,0.09,0.02,0.02,0.01,0.0,0.0,0.02,sung- kim,
+ECE,2070,002,Basic Electrical Eng,0.4,0.23,0.13,0.1,0.08,0.0,0.0,0.06,surya sharma,
+ECE,2070,003,Basic Electrical Eng,0.55,0.36,0.07,0.0,0.0,0.0,0.0,0.02,liang dong,
+ECE,2080,001,Electrical Engineeri,0.85,0.05,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2080,002,Electrical Engineeri,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,
+ECE,2080,010,Electrical Engineeri,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2080,011,Electrical Engineeri,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2080,012,Electrical Engineeri,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,william harrell,
+ECE,2080,013,Electrical Engineeri,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,
+ECE,2090,001,Logic Lab,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,william harrell,
+ECE,2090,003,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,william harrell,
+ECE,2090,006,Logic Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2090,014,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,william harrell,
+ECE,2110,002,Elec Engr Lab I,0.65,0.15,0.0,0.0,0.05,0.0,0.0,0.15,william harrell,
+ECE,2110,003,Elec Engr Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2110,004,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,william harrell,
+ECE,2110,005,Elec Engr Lab I,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,william harrell,
+ECE,2110,006,Elec Engr Lab I,0.8,0.05,0.05,0.0,0.0,0.0,0.0,0.1,william harrell,
+ECE,2110,008,Elec Engr Lab I,0.8,0.0,0.05,0.0,0.0,0.0,0.0,0.15,william harrell,
+ECE,2110,009,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,
+ECE,2110,010,Elec Engr Lab I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2220,001,Syst Prog Concept,0.22,0.24,0.14,0.06,0.12,0.0,0.0,0.22,harlan russell,
+ECE,2230,001,Comp Sys Eng,0.11,0.41,0.17,0.13,0.07,0.0,0.0,0.11,harlan russell,
+ECE,2620,001,Elec Circuits II,0.47,0.25,0.25,0.02,0.02,0.0,0.0,0.0,michael bridgwood,
+ECE,2720,001,Comp Organization,0.22,0.29,0.24,0.12,0.14,0.0,0.0,0.0,william reid,
+ECE,2730,001,Computer Org Lab,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2730,002,Computer Org Lab,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2730,003,Computer Org Lab,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,3110,001,Electrical Engineeri,0.75,0.06,0.06,0.0,0.0,0.0,0.0,0.13,william harrell,
+ECE,3110,002,Electrical Engineeri,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,william harrell,
+ECE,3110,003,Electrical Engineeri,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,
+ECE,3110,007,Electrical Engineeri,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,3120,001,Electrical Engineeri,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,3170,001,Rand Signal Analysis,0.25,0.51,0.18,0.02,0.04,0.0,0.0,0.02,stephen hubbard,
+ECE,3200,001,Electronics I,0.34,0.36,0.15,0.07,0.05,0.0,0.0,0.03,stephen hubbard,
+ECE,3210,001,Electronics II,0.2,0.2,0.41,0.11,0.05,0.0,0.0,0.02,stephen hubbard,
+ECE,3220,001,Intro Operating Sys,0.3,0.1,0.05,0.15,0.3,0.0,0.0,0.1,jacob sorber,
+ECE,3270,001,Dig Comp Design,0.11,0.21,0.18,0.14,0.25,0.0,0.0,0.11,melissa crawl smith,
+ECE,3300,001,Signals & Systems,0.23,0.29,0.21,0.11,0.1,0.0,0.0,0.05,carl baum,
+ECE,3300,002,Signals & Systems (H,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
+ECE,3520,001,Programming Systems,0.13,0.31,0.25,0.0,0.19,0.0,0.0,0.13,robert schalkoff,
+ECE,3600,001,Elect Power Engr,0.18,0.26,0.26,0.08,0.19,0.0,0.0,0.03,andrew donal clarke,
+ECE,3710,001,Microcontr Interface,0.38,0.25,0.29,0.03,0.01,0.0,0.0,0.03,william reid,
+ECE,3800,001,Electromagnetics,0.41,0.17,0.11,0.1,0.14,0.0,0.0,0.07,anthony martin,
+ECE,3810,001,Field Waves & Ckts,0.33,0.35,0.23,0.05,0.05,0.0,0.0,0.0,anthony martin,
+ECE,4090,001,Cont & Discrete Sys,0.56,0.31,0.12,0.0,0.0,0.0,0.0,0.02,apoorva dee kapadia,
+ECE,4180,001,Power Syst Analysis,0.48,0.22,0.3,0.0,0.0,0.0,0.0,0.0,elham makram,
+ECE,4270,001,Communications Sys,0.23,0.35,0.28,0.08,0.03,0.0,0.0,0.04,madhabi manandhar,
+ECE,4290,001,Organiz of Compu,0.29,0.36,0.29,0.07,0.0,0.0,0.0,0.0,hai ying shen,
+ECE,4420,001,Knowledge Engr,0.38,0.31,0.08,0.08,0.0,0.0,0.0,0.15,robert schalkoff,
+ECE,4490,001,Comp Ntwrk Security,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,richard brooks,
+ECE,4610,001,Fundamentals of Sola,0.73,0.18,0.07,0.0,0.0,0.0,0.0,0.02,rajendra singh,
+ECE,4730,001,Intro Parallel Sys,0.48,0.14,0.33,0.0,0.0,0.0,0.0,0.05,walter ligon,
+ECE,4930,003,Power Electronics,0.36,0.27,0.36,0.0,0.0,0.0,0.0,0.0,keith corzine,
+ECE,4950,001,Int Sys Design I,0.81,0.18,0.0,0.0,0.0,0.0,0.0,0.01,apoorva dee kapadia,
+ECE,4960,001,Int Sys Design II,0.37,0.57,0.06,0.0,0.0,0.0,0.0,0.0,richard groff,
+ECE,6040,001,Semiconductor Device,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,6420,001,Knowledge Engr,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,robert schalkoff,
+ECE,6670,001,Intro to Dig Sig Pro,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,john gowdy,
+ECE,6730,001,Intro Parallel Sys,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,walter ligon,
+ECE,6930,001,Intro to Computer Vi,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,adam hoover,
+ECE,6930,004,Optoelectronics and,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,lin zhu,
+ECE,8010,001,Analysis of Lin Sys,0.47,0.37,0.17,0.0,0.0,0.0,0.0,0.0,richard groff,
+ECE,8180,001,Rand Proc Appl Engr,0.38,0.38,0.19,0.0,0.0,0.0,0.0,0.06,carl baum,
+ECE,8470,400,Digital Image Proc,0.43,0.37,0.1,0.0,0.0,0.0,0.0,0.1,stanley birchfield,
+ECE,8540,001,Analysis of Tracking,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,adam hoover,
+ECE,8930,005,CMOS RFIC,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,
+ECE,8930,006,Computing Frontiers,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,
+ECE,9910,032,Doctoral Dissertatio,0.0,0.0,0.0,0.0,0.0,0.44,0.56,0.0,hai ying shen,
+ECON,2000,001,Economic Concepts,0.21,0.42,0.05,0.13,0.03,0.0,0.0,0.16,mallika garg,
+ECON,2000,002,Economic Concepts,0.21,0.46,0.1,0.13,0.03,0.0,0.0,0.08,mallika garg,
+ECON,2000,003,Economic Concepts,0.3,0.4,0.16,0.09,0.02,0.0,0.0,0.02,miren ivankovic,
+ECON,2110,001,Principles of Microe,0.33,0.44,0.17,0.0,0.06,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,002,Principles of Microe,0.17,0.28,0.33,0.11,0.06,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,003,Principles of Microe,0.15,0.45,0.15,0.15,0.0,0.0,0.0,0.1,frederick hanssen,
+ECON,2110,004,Principles of Microe,0.26,0.16,0.37,0.16,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,005,Principles of Microe,0.21,0.42,0.26,0.0,0.0,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,006,Principles of Microe,0.16,0.42,0.26,0.16,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,007,Principles of Microe,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,008,Principles of Microe,0.21,0.16,0.21,0.11,0.0,0.0,0.0,0.32,frederick hanssen,
+ECON,2110,009,Principles of Microe,0.05,0.32,0.32,0.16,0.05,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,010,Principles of Microe,0.16,0.42,0.21,0.11,0.05,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,011,Principles of Microe,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,012,Principles of Microe,0.05,0.37,0.26,0.05,0.0,0.0,0.0,0.26,frederick hanssen,
+ECON,2110,013,Principles of Microe,0.32,0.42,0.16,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,014,Principles of Microe,0.05,0.53,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,015,Principles of Microe,0.16,0.53,0.21,0.0,0.05,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,016,Principles of Microe,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,017,Principles of Microe,0.26,0.32,0.21,0.05,0.0,0.0,0.0,0.16,frederick hanssen,
+ECON,2110,018,Principles of Microe,0.16,0.32,0.32,0.11,0.05,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,019,Principles of Microe,0.11,0.61,0.06,0.0,0.17,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,020,Principles of Microe,0.28,0.41,0.19,0.08,0.03,0.0,0.0,0.01,alexander fiore,
+ECON,2110,021,Principles of Microe,0.26,0.33,0.3,0.08,0.01,0.0,0.0,0.01,timothy andr bersak,
+ECON,2110,022,Principles of Microe,0.29,0.43,0.2,0.02,0.0,0.0,0.0,0.06,robert dew tollison,
+ECON,2110,023,Principles of Microe,0.13,0.45,0.25,0.08,0.05,0.0,0.0,0.05,timothy jay bacon,
+ECON,2110,024,Principles of Microe,0.26,0.36,0.25,0.1,0.02,0.0,0.0,0.02,adam millsap,
+ECON,2110,025,Principles of Microe,0.28,0.33,0.23,0.13,0.0,0.0,0.0,0.03,timothy andr bersak,
+ECON,2110,026,Principles of Microe,0.35,0.33,0.18,0.03,0.08,0.0,0.0,0.05,miren ivankovic,
+ECON,2110,031,Principles of Microe,0.31,0.31,0.23,0.14,0.01,0.0,0.0,0.0,adam millsap,
+ECON,2110,032,Principles of Microe,0.26,0.28,0.31,0.07,0.04,0.0,0.0,0.04,andew swanson,
+ECON,2110,033,Principles of Microe,0.29,0.34,0.18,0.11,0.05,0.0,0.0,0.03,alexander fiore,
+ECON,2110,034,Principles of Microe,0.31,0.36,0.29,0.02,0.0,0.0,0.0,0.02,amanda caitlin kerr,
+ECON,2110,035,Principles of Microe,0.43,0.38,0.18,0.03,0.0,0.0,0.0,0.0,andew swanson,
+ECON,2110,036,Principles of Microe,0.58,0.13,0.08,0.0,0.0,0.0,0.0,0.21,patrick warren,True
+ECON,2110,038,Principles of Microe,0.24,0.31,0.24,0.05,0.07,0.0,0.0,0.1,timothy jay bacon,
+ECON,2120,001,Principles of Macro,0.12,0.17,0.38,0.14,0.05,0.0,0.0,0.14,ralph charles allen,
+ECON,2120,002,Principles of Macro,0.24,0.33,0.26,0.02,0.07,0.0,0.0,0.09,peter david lorenz,
+ECON,2120,003,Principles of Macro,0.2,0.3,0.2,0.05,0.08,0.0,0.0,0.18,ralph charles allen,
+ECON,2120,004,Principles of Macro,0.16,0.42,0.24,0.07,0.02,0.0,0.0,0.09,peter david lorenz,
+ECON,2120,005,Principles of Macro,0.29,0.38,0.18,0.12,0.0,0.0,0.0,0.03,yukun sun,
+ECON,2120,006,Principles of Macro,0.2,0.43,0.23,0.07,0.07,0.0,0.0,0.0,yukun sun,
+ECON,2120,007,Principles of Macro,0.23,0.48,0.18,0.03,0.05,0.0,0.0,0.05,danielle zanzalari,
+ECON,2120,008,Principles of Macro,0.26,0.38,0.23,0.08,0.05,0.0,0.0,0.0,anne anders,
+ECON,3020,001,Money and Banking,0.25,0.19,0.25,0.14,0.03,0.0,0.0,0.14,danielle zanzalari,
+ECON,3060,001,Managerial Economics,0.38,0.46,0.04,0.04,0.04,0.0,0.0,0.04,jacob burgdorf,
+ECON,3100,001,International Econ,0.2,0.37,0.16,0.12,0.02,0.0,0.0,0.14,ayse mujde erdogan,
+ECON,3140,001,Intermediate Micro,0.16,0.3,0.27,0.14,0.0,0.0,0.0,0.14,robert kennet fleck,
+ECON,3140,002,Intermediate Micro,0.27,0.29,0.17,0.08,0.06,0.0,0.0,0.13,molly espey,
+ECON,3140,003,Intermediate Micro,0.24,0.27,0.22,0.08,0.08,0.0,0.0,0.1,robert kennet fleck,
+ECON,3150,001,Intermediate Macro,0.33,0.22,0.31,0.0,0.06,0.0,0.0,0.08,sergey vla mityakov,
+ECON,3150,002,Intermediate Macro,0.15,0.35,0.28,0.11,0.02,0.0,0.0,0.09,ayse mujde erdogan,
+ECON,3190,001,Environmental Econ,0.22,0.43,0.22,0.08,0.0,0.0,0.0,0.05,molly espey,
+ECON,3600,001,Public Choice,0.18,0.58,0.2,0.0,0.03,0.0,0.0,0.03,robert dew tollison,
+ECON,3970,001,Creative Inq in Econ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,scott baier,
+ECON,3970,001,Creative Inq in Econ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,raymond sauer,
+ECON,3970,003,Creative Inq in Econ,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,scott baier,
+ECON,3970,003,Creative Inq in Econ,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,raymond sauer,
+ECON,4020,001,Law and Economics,0.26,0.43,0.12,0.05,0.05,0.0,0.0,0.1,howard ne bodenhorn,
+ECON,4040,001,Comp Econ Systems,0.27,0.33,0.2,0.0,0.07,0.0,0.0,0.13,dar litsukova-bokar,
+ECON,4050,001,Intro to Econometric,0.33,0.31,0.19,0.02,0.05,0.0,0.0,0.1,jaqueline oliveira,
+ECON,4050,005,Intro to Econometric,0.42,0.08,0.08,0.08,0.17,0.0,0.0,0.17,scott barkowski,
+ECON,4100,001,Economic Development,0.28,0.36,0.16,0.0,0.04,0.0,0.0,0.16,robert tamura,
+ECON,4120,001,International Micro,0.5,0.38,0.06,0.0,0.03,0.0,0.0,0.03,scott baier,
+ECON,4220,001,Monetary Economics,0.37,0.59,0.04,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
+ECON,4230,001,Economics of Health,0.17,0.39,0.22,0.11,0.06,0.0,0.0,0.06,daniel patri miller,
+ECON,4240,001,Organization of Ind,0.41,0.35,0.18,0.0,0.06,0.0,0.0,0.0,daniel patri miller,
+ECON,4350,001,Family Economics,0.44,0.16,0.2,0.0,0.16,0.0,0.0,0.04,jaqueline oliveira,
+ECON,8010,001,Microeconomic Theory,0.33,0.38,0.29,0.0,0.0,0.0,0.0,0.0,william dougan,
+ECON,8040,001,Applied Math Econ,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,curtis simon,
+ECON,8060,001,Econometrics I,0.12,0.52,0.28,0.0,0.0,0.0,0.0,0.08,paul wayne wilson,
+ECON,8230,001,Microecon Pub Pol,0.35,0.47,0.18,0.0,0.0,0.0,0.0,0.0,scott templeton,
+ECON,8260,001,Econ Theory of Govt,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,
+ECON,8550,001,Financial Economics,0.54,0.15,0.0,0.0,0.08,0.0,0.0,0.23,sergey vla mityakov,
+ED,1050,003,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,patrick womac,
+ED,1050,008,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,rory phil tannebaum,
+ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen mich moysey,
+ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david matthew boyer,
+ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,penelope mar vargas,
+ED,3970,005,Creative Inquiry in,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,
+ED,3970,012,Creative Inquiry in,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,joseph benedic ryan,
+ED,3970,012,Creative Inquiry in,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,deborah cadorette,
+ED,8380,402,Short Stories for Te,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,lienne federico,
+ED,8380,506,Literacy Lessons for,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,vicki steadman,
+ED,8380,510,Literacy Lessons for,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jennifer adams,
+ED,8380,511,Literacy Lessons for,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,jean ridley,
+EDC,3900,001,Skills for Stu Leads,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,mary price,
+EDC,3900,001,Skills for Stu Leads,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,lloyd john  graham,
+EDC,3900,002,Skills for Stu Leads,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
+EDC,3900,002,Skills for Stu Leads,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,8030,001,Stu Dev in Hi Ed,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
+EDC,8040,001,Theories Student Dev,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,
+EDC,8040,002,Theories Student Dev,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,
+EDC,8050,001,Clinical Mh Couns,0.91,0.05,0.0,0.0,0.05,0.0,0.0,0.0,david scott,
+EDC,8440,001,Stu Affairs Intern,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,kristin walker,
+EDC,8440,001,Stu Affairs Intern,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,tony cawthon,
+EDEC,3000,001,Found Early Chld Ed,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,
+EDEC,4400,001,Early Childhood Engl,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEL,3100,002,Arts in Ele School,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,alison eliz leonard,
+EDEL,3210,001,Pe for the Elem Tchr,0.71,0.2,0.06,0.03,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4010,002,Elem Field Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ann marie liebel,
+EDEL,4510,002,Elem Methods in Scie,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
+EDEL,4870,002,Ele Meth Soc Studies,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDF,3010,001,Principles of Americ,0.59,0.29,0.05,0.0,0.05,0.0,0.0,0.02,suzanne rosenblith,
+EDF,3010,002,Principles of Americ,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,robert green,
+EDF,3010,004,Principles of Americ,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDF,3020,001,Educ Psych,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,meihua qian,
+EDF,3020,002,Educ Psych,0.23,0.57,0.06,0.11,0.0,0.0,0.0,0.03,penelope mar vargas,
+EDF,3020,003,Educ Psych,0.16,0.58,0.16,0.06,0.03,0.0,0.0,0.0,penelope mar vargas,
+EDF,3080,001,Classroom Assessment,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,
+EDF,3080,002,Classroom Assessment,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,deborah switzer,
+EDF,3200,001,History of US Educat,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,robert green,
+EDF,3340,001,Child Growth and Dev,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
+EDF,3350,002,Adol Growth & Dev,0.52,0.39,0.0,0.04,0.0,0.0,0.0,0.04,david barrett,
+EDF,4800,001,Digital Media & Lear,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,ryan visser,
+EDF,4800,003,Digital Media & Lear,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,004,Digital Media & Lear,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,ryan visser,
+EDF,6900,001,Classroom Management,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,alicia farr clinger,
+EDF,8010,001,Human Growth and Dev,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jeromy blake snider,
+EDF,8080,001,Ed Tests and Measure,0.5,0.33,0.04,0.0,0.08,0.0,0.0,0.04,william fisk,
+EDF,8080,500,Ed Tests and Measure,0.7,0.1,0.05,0.0,0.1,0.0,0.0,0.05,deborah switzer,
+EDF,8710,500,Cultural Diversity i,0.7,0.05,0.0,0.0,0.25,0.0,0.0,0.0,sus cridland-hughes,
+EDF,9770,001,Multi Regress Ed Res,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david barrett,
+EDF,9790,001,Qualitative Research,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,david matthew boyer,
+EDL,7150,501,Sch & Comm Relations,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,frederick buskey,
+EDL,8390,503,Research in Ed L,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,
+EDL,8550,001,App Res & Eval in He,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michelle boettcher,
+EDL,9000,400,Prin Edu Leadership,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,james satterfield,
+EDL,9100,400,Intro Phd Seminar,0.59,0.18,0.0,0.0,0.0,0.0,0.0,0.24,jane lindle,
+EDLT,4590,001,Teaching Reading Gra,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4600,001,Teaching Reading Gra,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
+EDLT,4610,001,Content Area Rdg: 2-,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,4610,002,Content Area Rdg: 2-,0.63,0.19,0.13,0.06,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,4980,002,Secondary Content Ar,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,corrie leigh martin,
+EDLT,8100,500,Foundations: Reading,0.42,0.17,0.0,0.0,0.0,0.0,0.0,0.42,susan kin fullerton,
+EDLT,8640,400,Teaching Secondary S,0.71,0.07,0.07,0.0,0.14,0.0,0.0,0.0,corrie leigh martin,
+EDLT,8640,500,Teaching Secondary S,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8800,506,Reading Recovery Tea,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,
+EDLT,8800,511,Reading Recovery Tea,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,
+EDLT,8820,502,Read Recovery Practi,0.0,0.82,0.09,0.0,0.0,0.0,0.0,0.09,mia francesc riddle,
+EDLT,8820,506,Read Recovery Practi,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,
+EDLT,8820,511,Read Recovery Practi,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,
+EDML,8410,401,Adv Middle School Cu,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lienne federico,
+EDSC,2260,001,Pr Apprch to Sec Alg,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,stacy megan che,
+EDSC,3240,001,Practicum Sec Engl,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,amy tali hallenbeck,
+EDSC,4260,001,Tchng Sec Math,0.56,0.25,0.13,0.0,0.06,0.0,0.0,0.0,dennis aminie kombe,
+EDSC,8610,001,Mthds & Strt Seconda,0.64,0.09,0.0,0.0,0.27,0.0,0.0,0.0,michelle patri cook,
+EDSP,3700,002,Intro to Special Ed,0.83,0.07,0.07,0.0,0.03,0.0,0.0,0.0,robin parks ennis,
+EDSP,3700,003,Intro to Special Ed,0.69,0.26,0.06,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,
+EDSP,3700,004,Intro to Special Ed,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,angelo vespe,
+EDSP,3720,001,Char & Instr Individ,0.9,0.0,0.05,0.0,0.05,0.0,0.0,0.0,catherine griffith,
+EDSP,3740,001,Char & Strat Emot/Be,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,robin parks ennis,
+EDSP,4920,001,Math Inst Ind W/Dis,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,pamela stecker,
+EDSP,4930,001,Clsrm/Beh Mgmt Sp Ed,0.75,0.13,0.08,0.0,0.0,0.0,0.0,0.04,joseph benedic ryan,
+EDSP,4940,001,Tchg Rdg Mild Dis,0.71,0.13,0.13,0.0,0.0,0.0,0.0,0.04,sara moo mackiewicz,
+EDSP,4970,001,Sec Meth Ind W/Dis,0.75,0.13,0.04,0.04,0.0,0.0,0.0,0.04,martha hodge,
+EDSP,8530,001,Legal/Pol Issu Sp Ed,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,antonis katsiyannis,
+EES,2010,001,Environ Engr Fundame,0.33,0.39,0.22,0.03,0.03,0.0,0.0,0.0,david freedman,
+EES,3030,001,Water Treatment Syst,0.3,0.57,0.14,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3040,001,Wastewater Treatment,0.35,0.54,0.11,0.0,0.0,0.0,0.0,0.0,david freedman,
+EES,3050,001,Water/Wastewater Tre,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3050,001,Water/Wastewater Tre,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,david freedman,
+EES,3050,002,Water/Wastewater Tre,0.55,0.25,0.15,0.05,0.0,0.0,0.0,0.0,david freedman,
+EES,3050,002,Water/Wastewater Tre,0.55,0.25,0.15,0.05,0.0,0.0,0.0,0.0,david allen ladner,
+EES,4010,001,Environmental Engr,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,elizabeth carraway,
+EES,4010,002,Environmental Engr,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,mark schlautman,
+EES,4300,001,Air Pollution Engine,0.2,0.44,0.32,0.02,0.02,0.0,0.0,0.0,thomas overcamp,
+EES,4800,001,Environmental Risk A,0.24,0.28,0.28,0.1,0.07,0.0,0.0,0.03,timothy devol,
+EES,4860,001,Environmental Sustai,0.53,0.39,0.05,0.0,0.03,0.0,0.0,0.0,michael anthon dale,
+EES,6100,001,Environ Radiation Pr,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,
+EES,6800,001,Environmental Risk A,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,timothy devol,
+EES,8020,001,Environ Eng Prin,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,thomas overcamp,
+EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tanju karanfil,
+EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,thomas overcamp,
+EES,8060,001,Design Env Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,
+EES,8430,001,Environmental Chem,0.53,0.42,0.0,0.0,0.03,0.0,0.0,0.03,elizabeth carraway,
+EES,8510,001,Biol Prin Envir Engr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
+ELE,3010,001,Intro to Entre,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+ELE,3010,003,Intro to Entre,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
+ELE,4010,001,Exec Lead & Entr II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
+ENGL,1030,001,Accelerated Composit,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katrina torbert,
+ENGL,1030,002,Accelerated Comp,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,lauren taylo stukes,
+ENGL,1030,003,Accelerated Composit,0.21,0.37,0.21,0.11,0.0,0.0,0.0,0.11,chelsea mari clarey,
+ENGL,1030,004,Accelerated Composit,0.37,0.26,0.26,0.11,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,1030,005,Accelerated Composit,0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,1030,006,Accelerated Composit,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,chelsea mari clarey,
+ENGL,1030,007,Accelerated Composit,0.26,0.63,0.0,0.05,0.05,0.0,0.0,0.0,leslie ann salley,
+ENGL,1030,008,Accelerated Composit,0.42,0.21,0.21,0.05,0.0,0.0,0.0,0.11,joshua wood,
+ENGL,1030,009,Accelerated Composit,0.72,0.11,0.11,0.0,0.06,0.0,0.0,0.0,sarah ashto wickham,
+ENGL,1030,010,Accelerated Composit,0.16,0.58,0.16,0.0,0.11,0.0,0.0,0.0,leslie ann salley,
+ENGL,1030,011,Accelerated Composit,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,1030,012,Accelerated Composit,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,molly brian collins,
+ENGL,1030,013,Accelerated Composit,0.05,0.53,0.11,0.05,0.16,0.0,0.0,0.11,leslie ann salley,
+ENGL,1030,014,Accelerated Composit,0.44,0.28,0.22,0.06,0.0,0.0,0.0,0.0,justin all holliday,
+ENGL,1030,015,Accelerated Composit,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,molly brian collins,
+ENGL,1030,016,Accelerated Composit,0.61,0.06,0.11,0.0,0.17,0.0,0.0,0.06,joshua wood,
+ENGL,1030,017,Accelerated Composit,0.26,0.32,0.21,0.16,0.05,0.0,0.0,0.0,leslie ann salley,
+ENGL,1030,018,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,matthew mar russell,
+ENGL,1030,019,Accelerated Composit,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,joshua rya newberry,
+ENGL,1030,021,Accelerated Composit,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,
+ENGL,1030,022,Accelerated Composit,0.83,0.0,0.06,0.06,0.0,0.0,0.0,0.06,daniel frank,
+ENGL,1030,023,Accelerated Composit,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,matthew jose osborn,
+ENGL,1030,024,Accelerated Composit,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,matthew mar russell,
+ENGL,1030,025,Accelerated Composit,0.16,0.63,0.05,0.05,0.05,0.0,0.0,0.05,justin all holliday,
+ENGL,1030,026,Accelerated Composit,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,1030,027,Accelerated Composit,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,matthew jose osborn,
+ENGL,1030,028,Accelerated Composit,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,katherine hanzalik,
+ENGL,1030,029,Accelerated Composit,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,jarrod keit thacker,
+ENGL,1030,030,Accelerated Composit,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,kristen gay,
+ENGL,1030,031,Accelerated Composit,0.53,0.32,0.05,0.11,0.0,0.0,0.0,0.0,adrian carson,
+ENGL,1030,032,Accelerated Composit,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,hannah conl vaughan,
+ENGL,1030,033,Accelerated Composit,0.68,0.16,0.05,0.0,0.05,0.0,0.0,0.05,katherine elrick,
+ENGL,1030,034,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,
+ENGL,1030,035,Accelerated Composit,0.74,0.16,0.0,0.0,0.0,0.0,0.0,0.11,judith roxanne ball,
+ENGL,1030,036,Accelerated Composit,0.63,0.16,0.0,0.05,0.16,0.0,0.0,0.0,kristen gay,
+ENGL,1030,037,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,sarah ashto wickham,
+ENGL,1030,038,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,dustin cleag mosley,
+ENGL,1030,039,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,joshua rya newberry,
+ENGL,1030,040,Accelerated Composit,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,
+ENGL,1030,041,Accelerated Composit,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,katrina torbert,
+ENGL,1030,042,Accelerated Composit,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,katherine hanzalik,
+ENGL,1030,043,Accelerated Composit,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,1030,044,Accelerated Composit,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,daniel frank,
+ENGL,1030,045,Accelerated Composit,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,adrian carson,
+ENGL,1030,046,Accelerated Composit,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,hannah conl vaughan,
+ENGL,1030,047,Accelerated Composit,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,katherine elrick,
+ENGL,1030,048,Accelerated Composit,0.26,0.42,0.21,0.0,0.11,0.0,0.0,0.0,lauren taylo stukes,
+ENGL,1030,049,Accelerated Composit,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,mari elena ramler,
+ENGL,1030,050,Accelerated Composit,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,dustin cleag mosley,
+ENGL,1030,051,Accelerated Composit,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,carlisle an sargent,
+ENGL,1030,052,Accelerated Composit,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,heathe christiansen,
+ENGL,1030,053,Accelerated Composit,0.63,0.32,0.0,0.05,0.0,0.0,0.0,0.0,stephanie mic heath,
+ENGL,1030,054,Accelerated Composit,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,allen swords,
+ENGL,1030,055,Accelerated Composit,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,carlisle an sargent,
+ENGL,1030,056,Accelerated Composit,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,judith roxanne ball,
+ENGL,1030,057,Accelerated Composit,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,
+ENGL,1030,058,Accelerated Composit,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,hayley ren zertuche,
+ENGL,1030,059,Accelerated Composit,0.56,0.28,0.06,0.0,0.06,0.0,0.0,0.06,andrew mar barrocas,
+ENGL,1030,060,Accelerated Composit,0.29,0.41,0.12,0.06,0.12,0.0,0.0,0.0,hayley ren zertuche,
+ENGL,1030,061,Accelerated Composit,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sarah kath melchers,
+ENGL,1030,062,Accelerated Composit,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,mari elena ramler,
+ENGL,1030,063,Accelerated Composit,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,stephanie mic heath,
+ENGL,1030,064,Accelerated Composit,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,
+ENGL,1030,065,Accelerated Composit,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,sarah kath melchers,
+ENGL,1030,067,Accelerated Composit,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
+ENGL,1030,068,Accelerated Composit,0.69,0.08,0.15,0.0,0.08,0.0,0.0,0.0,eda ozyesilpinar,
+ENGL,1030,069,Accelerated Composit,0.63,0.25,0.0,0.0,0.13,0.0,0.0,0.0,eda ozyesilpinar,
+ENGL,1030,500,Accelerated Composit,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,1030,501,Accelerated Composit,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,john conway,
+ENGL,2120,001,World Literature (MA,0.65,0.2,0.1,0.05,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,2120,002,World Literature (MA,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,andrew lemons,
+ENGL,2120,004,World Literature,0.66,0.21,0.07,0.0,0.0,0.0,0.0,0.07,lucian ghita,
+ENGL,2120,005,World Literature,0.71,0.11,0.04,0.0,0.04,0.0,0.0,0.11,david stubblefield,
+ENGL,2120,006,World Literature,0.22,0.48,0.11,0.0,0.0,0.0,0.0,0.19,karen kettnich,
+ENGL,2120,007,World Literature,0.36,0.32,0.14,0.11,0.0,0.0,0.0,0.07,karen kettnich,
+ENGL,2120,008,World Literature,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,lucian ghita,
+ENGL,2120,009,World Literature,0.35,0.46,0.12,0.0,0.04,0.0,0.0,0.04,andrew mathas,
+ENGL,2120,010,World Literature,0.15,0.5,0.12,0.08,0.04,0.0,0.0,0.12,david charles foltz,
+ENGL,2120,011,World Literature,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,allen swords,
+ENGL,2120,012,World Literature,0.62,0.34,0.03,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2120,013,World Literature,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,2120,014,World Literature,0.07,0.3,0.27,0.1,0.1,0.0,0.0,0.17,david charles foltz,
+ENGL,2120,015,World Literature,0.64,0.14,0.04,0.11,0.07,0.0,0.0,0.0,lauren woolbright,
+ENGL,2120,016,World Literature,0.61,0.18,0.07,0.04,0.07,0.0,0.0,0.04,lauren woolbright,
+ENGL,2120,018,World Literature,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2130,001,British Literature,0.82,0.11,0.04,0.04,0.0,0.0,0.0,0.0,sherri teres allred,
+ENGL,2130,002,British Literature,0.31,0.41,0.14,0.03,0.07,0.0,0.0,0.03,elizabeth stansell,
+ENGL,2130,003,British Literature,0.38,0.38,0.17,0.0,0.03,0.0,0.0,0.03,elizabeth stansell,
+ENGL,2130,004,British Literature,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,april susanne pelt,
+ENGL,2130,005,British Literature,0.82,0.11,0.0,0.0,0.0,0.0,0.0,0.07,april susanne pelt,
+ENGL,2130,007,British Literature,0.59,0.24,0.07,0.03,0.03,0.0,0.0,0.03,lucian ghita,
+ENGL,2130,009,British Literature,0.81,0.07,0.0,0.07,0.0,0.0,0.0,0.04,april susanne pelt,
+ENGL,2130,010,British Literature,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,april susanne pelt,
+ENGL,2130,011,British Literature,0.46,0.25,0.07,0.07,0.04,0.0,0.0,0.11,lucian ghita,
+ENGL,2130,012,British Literature,0.71,0.11,0.07,0.04,0.0,0.0,0.0,0.07,sherri teres allred,
+ENGL,2140,001,American Literature,0.48,0.45,0.0,0.0,0.07,0.0,0.0,0.0,melody fowl shirley,
+ENGL,2140,002,American Literature,0.39,0.25,0.29,0.04,0.04,0.0,0.0,0.0,melody fowl shirley,
+ENGL,2140,003,American Literature,0.14,0.36,0.36,0.0,0.09,0.0,0.0,0.05,barbara ramirez,
+ENGL,2140,005,American Literature,0.38,0.46,0.12,0.0,0.0,0.0,0.0,0.04,william stanton,
+ENGL,2140,006,American Literature,0.59,0.24,0.05,0.02,0.0,0.0,0.0,0.09, barton palmer,
+ENGL,2140,007,American Literature,0.34,0.52,0.03,0.07,0.0,0.0,0.0,0.03,john logan pursley,
+ENGL,2140,008,American Literature,0.44,0.3,0.19,0.0,0.04,0.0,0.0,0.04,william stanton,
+ENGL,2140,009,American Literature,0.14,0.41,0.17,0.07,0.17,0.0,0.0,0.03,john logan pursley,
+ENGL,2140,014,American Literature,0.18,0.39,0.25,0.07,0.07,0.0,0.0,0.04,meredith mccarroll,
+ENGL,2140,100,American Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,meredith mccarroll,True
+ENGL,2150,001,Lit in 20th-21st Cen,0.07,0.67,0.19,0.0,0.0,0.0,0.0,0.07,amy monaghan,
+ENGL,2150,002,Lit in 20th-21st Cen,0.0,0.62,0.35,0.0,0.0,0.0,0.0,0.04,amy monaghan,
+ENGL,2150,003,Lit in 20th-21st Cen,0.17,0.55,0.14,0.03,0.03,0.0,0.0,0.07,sarah lauro,
+ENGL,2150,004,Lit in 20th-21st Cen,0.18,0.54,0.18,0.04,0.04,0.0,0.0,0.04,joshua nei waggoner,
+ENGL,2150,005,Lit in 20th-21st Cen,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,sarah lauro,
+ENGL,2150,006,Lit in 20th-21st Cen,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,william pulley,
+ENGL,2150,007,Lit in 20th-21st Cen,0.25,0.46,0.25,0.0,0.04,0.0,0.0,0.0,david charles foltz,
+ENGL,2150,008,Lit in 20th-21st Cen,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,alexander kudera,
+ENGL,2150,010,Lit in 20th-21st Cen,0.59,0.34,0.03,0.0,0.03,0.0,0.0,0.0,john morgenstern,
+ENGL,2150,011,Lit in 20th-21st Cen,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,john morgenstern,
+ENGL,2150,012,Lit in 20th-21st Cen,0.25,0.54,0.11,0.04,0.04,0.0,0.0,0.04,joshua nei waggoner,
+ENGL,2150,015,Lit in 20th-21st Cen,0.41,0.34,0.17,0.03,0.0,0.0,0.0,0.03,lindsay carr thomas,
+ENGL,2150,016,Lit in 20th-21st Cen,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
+ENGL,2150,017,Lit in 20th-21st Cen,0.41,0.41,0.19,0.0,0.0,0.0,0.0,0.0,joshua nei waggoner,
+ENGL,2150,019,Lit in 20th-21st Cen,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,david charles foltz,
+ENGL,2150,020,Lit in 20th-21st Cen,0.56,0.4,0.0,0.0,0.0,0.0,0.0,0.04,garry bertholf,
+ENGL,2150,021,Lit in 20th-21st Cen,0.05,0.45,0.36,0.0,0.0,0.0,0.0,0.14,amy monaghan,
+ENGL,2150,100,20th - 21st Century,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sarah lauro,True
+ENGL,3000,001,Professional Develop,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,cameron fa bushnell,
+ENGL,3040,002,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3040,003,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3040,004,Business Writing,0.33,0.44,0.17,0.0,0.0,0.0,0.0,0.06,megan no macalystre,
+ENGL,3040,005,Business Writing,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,
+ENGL,3040,011,Business Writing,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,sean williams,
+ENGL,3040,012,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexander kudera,
+ENGL,3040,013,Business Writing,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,sherri teres allred,
+ENGL,3040,015,Business Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
+ENGL,3040,016,Business Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alexander kudera,
+ENGL,3100,001,Crit Writ Lit,0.44,0.22,0.17,0.0,0.0,0.0,0.0,0.17,david sweene coombs,
+ENGL,3100,002,Crit Writ Lit,0.26,0.37,0.21,0.0,0.05,0.0,0.0,0.11,erin marina goss,
+ENGL,3100,003,Crit Writ Lit,0.14,0.62,0.14,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,
+ENGL,3120,001,Advanced Composition,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3120,002,Advanced Composition,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,001,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,002,Technical Writing,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,
+ENGL,3140,003,Technical Writing,0.29,0.29,0.12,0.06,0.06,0.0,0.0,0.18,katalin beck,
+ENGL,3140,004,Technical Writing,0.63,0.16,0.05,0.0,0.05,0.0,0.0,0.11,matthew schilleman,
+ENGL,3140,005,Technical Writing,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,meg woosley-goodman,
+ENGL,3140,006,Technical Writing,0.44,0.19,0.13,0.06,0.0,0.0,0.0,0.19,meg woosley-goodman,
+ENGL,3140,008,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,
+ENGL,3140,009,Technical Writing,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,010,Technical Writing,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,3140,011,Technical Writing,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,david stubblefield,
+ENGL,3140,012,Technical Writing,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,katalin beck,
+ENGL,3140,013,Technical Writing,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,014,Technical Writing,0.29,0.53,0.06,0.12,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,015,Technical Writing,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,meg woosley-goodman,
+ENGL,3140,016,Technical Writing,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,018,Technical Writing,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,megan eatman,
+ENGL,3140,019,Technical Writing,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,meg woosley-goodman,
+ENGL,3140,020,Technical Writing,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,021,Technical Writing,0.39,0.28,0.11,0.0,0.06,0.0,0.0,0.17,matthew schilleman,
+ENGL,3140,400,Technical Writing (O,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,3140,401,Technical Writing (O,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,3150,003,Sci Writing & Comm,0.12,0.76,0.06,0.0,0.0,0.0,0.0,0.06,barbara ramirez,
+ENGL,3150,400,Sci Writing & Comm (,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,401,Sci Writing & Comm (,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,402,Sci Writing & Comm,0.53,0.13,0.07,0.2,0.07,0.0,0.0,0.0,carleton dew salley,
+ENGL,3320,001,Visual Communication,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,megan eatman,
+ENGL,3450,001,Structure of Fiction,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,3450,002,Structure of Fiction,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,3460,002,Structure of Poetry,0.58,0.16,0.0,0.0,0.21,0.0,0.0,0.05,sharon kathl nalley,
+ENGL,3480,001,Structure Screenplay,0.72,0.17,0.06,0.0,0.06,0.0,0.0,0.0,joshua nei waggoner,
+ENGL,3490,001,Tech/Pop Imagination,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,matthew schilleman,
+ENGL,3530,001,Ethnic Am Lit,0.06,0.44,0.19,0.13,0.13,0.0,0.0,0.06,kimberly manganelli,
+ENGL,3560,001,Science Fiction,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,lindsay carr thomas,
+ENGL,3570,001,Film,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3570,002,Film,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,agnieszka skrodzka,
+ENGL,3570,003,Film,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06, barton palmer,
+ENGL,3800,001,Women Writers,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,3850,001,Children's Lit,0.22,0.56,0.17,0.0,0.06,0.0,0.0,0.0,megan no macalystre,
+ENGL,3960,001,Brit Lit Survey I,0.3,0.35,0.3,0.0,0.0,0.0,0.0,0.05,brian mcgrath,
+ENGL,3960,002,Brit Lit Survey I,0.15,0.45,0.35,0.05,0.0,0.0,0.0,0.0,brian mcgrath,
+ENGL,3960,003,Brit Lit Survey I,0.15,0.4,0.35,0.05,0.0,0.0,0.0,0.05,brian mcgrath,
+ENGL,3970,001,Brit Lit Survey II,0.13,0.27,0.47,0.0,0.0,0.0,0.0,0.13,wayne chapman,
+ENGL,3980,001,Amer Lit Survey I,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,jonathan beec field,
+ENGL,3980,002,Amer Lit Survey I,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,rhondda robi thomas,
+ENGL,4030,001,Classics in Trans,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,4110,001,Shakespeare,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4110,002,Shakespeare,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4140,001,Milton,0.08,0.69,0.15,0.0,0.0,0.0,0.0,0.08,lee morrissey,
+ENGL,4180,001,English Novel,0.47,0.4,0.0,0.0,0.13,0.0,0.0,0.0,david sweene coombs,
+ENGL,4210,001,Amer Lit 1800-1899,0.27,0.45,0.09,0.0,0.09,0.0,0.0,0.09,dominic mastroianni,
+ENGL,4310,001,Modern Poetry,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,wayne chapman,
+ENGL,4340,001,Environmental Lit,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,sean morey,
+ENGL,4350,001,Literary Criticism,0.35,0.41,0.18,0.06,0.0,0.0,0.0,0.0,dominic mastroianni,
+ENGL,4420,001,Cultural Studies,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,garry bertholf,
+ENGL,4750,001,Writing for Media,0.39,0.39,0.11,0.06,0.0,0.0,0.0,0.06,gabriel and hankins,
+ENGL,4780,001,Digital Literacy,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,gabriel and hankins,
+ENGL,4820,001,Afr Am Lit to 1920,0.2,0.3,0.3,0.1,0.1,0.0,0.0,0.0,rhondda robi thomas,
+ENGL,4910,001,Classical Rhetoric,0.19,0.44,0.38,0.0,0.0,0.0,0.0,0.0,brian mcgrath,
+ENGL,4960,001,Senior Seminar,0.36,0.43,0.07,0.0,0.07,0.0,0.0,0.07,jonathan beec field,
+ENGL,4960,002,Senior Seminar,0.1,0.4,0.3,0.1,0.0,0.0,0.0,0.1,lee morrissey,
+ENGL,4960,003,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william stockton,
+ENGL,8000,001,Introduction to Rese,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,
+ENGL,8100,001,Literary Criticism &,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,angela naimou,
+ENGL,8310,002,Special Topics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,agnieszka skrodzka,
+ENGL,8520,001,Rhetoric & Prof Comm,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharon howard,
+ENGR,1050,005,Engr Discip & Skills,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,elizabeth stephan,True
+ENGR,1050,005,Engr Discip & Skills,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,john minor,True
+ENGR,1050,007,Engr Discip & Skills,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1050,007,Engr Discip & Skills,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
+ENGR,1050,009,Engr Discipline & Sk,0.27,0.33,0.2,0.07,0.05,0.0,0.0,0.08,elizabeth stephan,
+ENGR,1050,009,Engr Discipline & Sk,0.27,0.33,0.2,0.07,0.05,0.0,0.0,0.08,john minor,
+ENGR,1050,011,Engr Discipline & Sk,0.27,0.3,0.18,0.06,0.05,0.0,0.0,0.14,elizabeth stephan,
+ENGR,1050,011,Engr Discipline & Sk,0.27,0.3,0.18,0.06,0.05,0.0,0.0,0.14,ashley childers,
+ENGR,1050,013,Engr Discipl & Skill,0.3,0.46,0.15,0.04,0.0,0.0,0.0,0.04,elizabeth stephan,
+ENGR,1050,013,Engr Discipl & Skill,0.3,0.46,0.15,0.04,0.0,0.0,0.0,0.04,john minor,
+ENGR,1050,015,Engr Discipl & Skill,0.28,0.23,0.43,0.02,0.02,0.0,0.0,0.02,christopher norfolk,
+ENGR,1050,015,Engr Discipl & Skill,0.28,0.23,0.43,0.02,0.02,0.0,0.0,0.02,elizabeth stephan,
+ENGR,1050,017,Engr Discipline & Sk,0.23,0.31,0.25,0.08,0.08,0.0,0.0,0.05,william martin,
+ENGR,1050,017,Engr Discipline & Sk,0.23,0.31,0.25,0.08,0.08,0.0,0.0,0.05,elizabeth stephan,
+ENGR,1050,019,Engr Discipline & Sk,0.21,0.27,0.24,0.05,0.1,0.0,0.0,0.14,steven brandon,
+ENGR,1050,019,Engr Discipline & Sk,0.21,0.27,0.24,0.05,0.1,0.0,0.0,0.14,elizabeth stephan,
+ENGR,1050,021,Engr Discipline & Sk,0.24,0.41,0.24,0.03,0.02,0.0,0.0,0.06,elizabeth stephan,
+ENGR,1050,021,Engr Discipline & Sk,0.24,0.41,0.24,0.03,0.02,0.0,0.0,0.06,ashley childers,
+ENGR,1050,025,Engr Discipline & Sk,0.17,0.38,0.24,0.05,0.05,0.0,0.0,0.12,sarah grigg,
+ENGR,1050,025,Engr Discipline & Sk,0.17,0.38,0.24,0.05,0.05,0.0,0.0,0.12,elizabeth stephan,
+ENGR,1050,027,Engr Discipline & Sk,0.26,0.3,0.24,0.03,0.14,0.0,0.0,0.03,elizabeth stephan,
+ENGR,1050,027,Engr Discipline & Sk,0.26,0.3,0.24,0.03,0.14,0.0,0.0,0.03,john minor,
+ENGR,1050,029,Engr Discipline & Sk,0.22,0.29,0.22,0.11,0.02,0.0,0.0,0.14,elizabeth stephan,
+ENGR,1050,029,Engr Discipline & Sk,0.22,0.29,0.22,0.11,0.02,0.0,0.0,0.14,david ewing,
+ENGR,1050,031,Engr Discipline & Sk,0.23,0.41,0.21,0.02,0.05,0.0,0.0,0.09,william martin,
+ENGR,1050,031,Engr Discipline & Sk,0.23,0.41,0.21,0.02,0.05,0.0,0.0,0.09,elizabeth stephan,
+ENGR,1050,033,Engr Discipline & Sk,0.22,0.32,0.21,0.11,0.03,0.0,0.0,0.11,matthew kent miller,
+ENGR,1050,033,Engr Discipline & Sk,0.22,0.32,0.21,0.11,0.03,0.0,0.0,0.11,elizabeth stephan,
+ENGR,1050,034,Engr Discipl & Skill,0.38,0.36,0.09,0.09,0.04,0.0,0.0,0.04,elizabeth stephan,
+ENGR,1050,034,Engr Discipl & Skill,0.38,0.36,0.09,0.09,0.04,0.0,0.0,0.04,steven brandon,
+ENGR,1050,050,Engr Discip & Skills,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1050,050,Engr Discip & Skills,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
+ENGR,1050,056,Engr Discipl & Skill,0.2,0.38,0.16,0.02,0.02,0.0,0.0,0.22,elizabeth stephan,
+ENGR,1050,056,Engr Discipl & Skill,0.2,0.38,0.16,0.02,0.02,0.0,0.0,0.22,john minor,
+ENGR,1050,058,Engr Discipl & Skill,0.37,0.33,0.16,0.05,0.0,0.0,0.0,0.09,elizabeth stephan,
+ENGR,1050,058,Engr Discipl & Skill,0.37,0.33,0.16,0.05,0.0,0.0,0.0,0.09,john minor,
+ENGR,1050,060,Engr Discipl & Skill,0.27,0.31,0.27,0.04,0.02,0.0,0.0,0.09,william martin,
+ENGR,1050,060,Engr Discipl & Skill,0.27,0.31,0.27,0.04,0.02,0.0,0.0,0.09,elizabeth stephan,
+ENGR,1050,062,Engr Discipl & Skill,0.23,0.45,0.16,0.05,0.02,0.0,0.0,0.09,elizabeth stephan,
+ENGR,1050,062,Engr Discipl & Skill,0.23,0.45,0.16,0.05,0.02,0.0,0.0,0.09,christopher norfolk,
+ENGR,1050,064,Engr Discipl & Skill,0.17,0.57,0.09,0.09,0.02,0.0,0.0,0.06,steven brandon,
+ENGR,1050,064,Engr Discipl & Skill,0.17,0.57,0.09,0.09,0.02,0.0,0.0,0.06,elizabeth stephan,
+ENGR,1050,111,Engr Discipline & Sk,0.08,0.33,0.35,0.08,0.15,0.0,0.0,0.02,elizabeth stephan,
+ENGR,1050,111,Engr Discipline & Sk,0.08,0.33,0.35,0.08,0.15,0.0,0.0,0.02,john minor,
+ENGR,1050,112,Engr Discip & Skills,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
+ENGR,1050,112,Engr Discip & Skills,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True
+ENGR,1050,113,Engr Discipline & Sk,0.15,0.24,0.26,0.13,0.19,0.0,0.0,0.03,elizabeth stephan,
+ENGR,1050,113,Engr Discipline & Sk,0.15,0.24,0.26,0.13,0.19,0.0,0.0,0.03,richard watkins,
+ENGR,1050,117,Engr Discipline & Sk,0.15,0.26,0.29,0.08,0.1,0.0,0.0,0.13,elizabeth stephan,
+ENGR,1050,119,Engr Discipline & Sk,0.27,0.32,0.17,0.02,0.03,0.0,0.0,0.19,matthew kent miller,
+ENGR,1050,119,Engr Discipline & Sk,0.27,0.32,0.17,0.02,0.03,0.0,0.0,0.19,elizabeth stephan,
+ENGR,1050,400,Engr Discipline & Sk,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,elizabeth stephan,
+ENGR,1050,400,Engr Discipline & Sk,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,elizabeth stephan,
+ENGR,1060,005,Engr Discip & Skills,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1060,005,Engr Discip & Skills,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,elizabeth stephan,True
+ENGR,1060,007,Engr Discip & Skills,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
+ENGR,1060,007,Engr Discip & Skills,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1060,009,Engr Discipline & Sk,0.02,0.17,0.29,0.14,0.06,0.0,0.0,0.31,elizabeth stephan,
+ENGR,1060,011,Engr Discipline & Sk,0.17,0.28,0.34,0.06,0.02,0.0,0.0,0.13,elizabeth stephan,
+ENGR,1060,011,Engr Discipline & Sk,0.17,0.28,0.34,0.06,0.02,0.0,0.0,0.13,ashley childers,
+ENGR,1060,012,Engr Discip & Skills,0.05,0.33,0.4,0.1,0.0,0.0,0.0,0.12,elizabeth stephan,
+ENGR,1060,012,Engr Discip & Skills,0.05,0.33,0.4,0.1,0.0,0.0,0.0,0.12,john minor,
+ENGR,1060,013,Engr Discip & Skills,0.07,0.3,0.36,0.11,0.11,0.0,0.0,0.05,elizabeth stephan,
+ENGR,1060,013,Engr Discip & Skills,0.07,0.3,0.36,0.11,0.11,0.0,0.0,0.05,christopher norfolk,
+ENGR,1060,014,Engr Discipline & Sk,0.15,0.35,0.2,0.2,0.05,0.0,0.0,0.05,william park,
+ENGR,1060,014,Engr Discipline & Sk,0.15,0.35,0.2,0.2,0.05,0.0,0.0,0.05,elizabeth stephan,
+ENGR,1060,016,Engr Discipline & Sk,0.21,0.42,0.32,0.0,0.05,0.0,0.0,0.0,john minor,
+ENGR,1060,016,Engr Discipline & Sk,0.21,0.42,0.32,0.0,0.05,0.0,0.0,0.0,elizabeth stephan,
+ENGR,1060,017,Engr Discipline & Sk,0.14,0.26,0.3,0.14,0.04,0.0,0.0,0.12,elizabeth stephan,
+ENGR,1060,017,Engr Discipline & Sk,0.14,0.26,0.3,0.14,0.04,0.0,0.0,0.12,william martin,
+ENGR,1060,019,Engr Discipline & Sk,0.11,0.26,0.24,0.15,0.09,0.0,0.0,0.15,steven brandon,
+ENGR,1060,019,Engr Discipline & Sk,0.11,0.26,0.24,0.15,0.09,0.0,0.0,0.15,elizabeth stephan,
+ENGR,1060,021,Engr Discipline & Sk,0.17,0.24,0.28,0.19,0.04,0.0,0.0,0.09,elizabeth stephan,
+ENGR,1060,021,Engr Discipline & Sk,0.17,0.24,0.28,0.19,0.04,0.0,0.0,0.09,ashley childers,
+ENGR,1060,025,Engr Discipline & Sk,0.12,0.27,0.22,0.12,0.1,0.0,0.0,0.18,sarah grigg,
+ENGR,1060,025,Engr Discipline & Sk,0.12,0.27,0.22,0.12,0.1,0.0,0.0,0.18,elizabeth stephan,
+ENGR,1060,027,Engr Discipline & Sk,0.1,0.31,0.31,0.19,0.06,0.0,0.0,0.04,john minor,
+ENGR,1060,027,Engr Discipline & Sk,0.1,0.31,0.31,0.19,0.06,0.0,0.0,0.04,elizabeth stephan,
+ENGR,1060,029,Engr Discipline & Sk,0.16,0.23,0.35,0.14,0.07,0.0,0.0,0.05,david ewing,
+ENGR,1060,029,Engr Discipline & Sk,0.16,0.23,0.35,0.14,0.07,0.0,0.0,0.05,elizabeth stephan,
+ENGR,1060,031,Engr Discipline & Sk,0.07,0.25,0.36,0.14,0.11,0.0,0.0,0.07,elizabeth stephan,
+ENGR,1060,031,Engr Discipline & Sk,0.07,0.25,0.36,0.14,0.11,0.0,0.0,0.07,william martin,
+ENGR,1060,050,Engr Discip & Skills,0.59,0.28,0.03,0.03,0.0,0.0,0.0,0.07,elizabeth stephan,True
+ENGR,1060,050,Engr Discip & Skills,0.59,0.28,0.03,0.03,0.0,0.0,0.0,0.07,john minor,True
+ENGR,1060,052,Engr Discip & Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1060,052,Engr Discip & Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,True
+ENGR,1060,056,Engr Discip & Skills,0.06,0.48,0.21,0.12,0.0,0.0,0.0,0.12,elizabeth stephan,
+ENGR,1060,056,Engr Discip & Skills,0.06,0.48,0.21,0.12,0.0,0.0,0.0,0.12,john minor,
+ENGR,1060,058,Engr Discip & Skills,0.16,0.43,0.3,0.03,0.0,0.0,0.0,0.08,john minor,
+ENGR,1060,058,Engr Discip & Skills,0.16,0.43,0.3,0.03,0.0,0.0,0.0,0.08,elizabeth stephan,
+ENGR,1060,060,Engr Discip & Skills,0.03,0.38,0.24,0.19,0.05,0.0,0.0,0.11,elizabeth stephan,
+ENGR,1060,060,Engr Discip & Skills,0.03,0.38,0.24,0.19,0.05,0.0,0.0,0.11,william martin,
+ENGR,1060,062,Engr Discip & Skills,0.05,0.32,0.41,0.08,0.08,0.0,0.0,0.05,elizabeth stephan,
+ENGR,1060,062,Engr Discip & Skills,0.05,0.32,0.41,0.08,0.08,0.0,0.0,0.05,christopher norfolk,
+ENGR,1060,064,Engr Discip & Skills,0.08,0.53,0.18,0.13,0.03,0.0,0.0,0.05,elizabeth stephan,
+ENGR,1060,064,Engr Discip & Skills,0.08,0.53,0.18,0.13,0.03,0.0,0.0,0.05,steven brandon,
+ENGR,1060,066,Engr Discipline & Sk,0.1,0.27,0.31,0.12,0.06,0.0,0.0,0.14,matthew kent miller,
+ENGR,1060,066,Engr Discipline & Sk,0.1,0.27,0.31,0.12,0.06,0.0,0.0,0.14,elizabeth stephan,
+ENGR,1060,112,Engr Discip & Skills,0.53,0.4,0.03,0.0,0.0,0.0,0.0,0.03,steven brandon,True
+ENGR,1060,112,Engr Discip & Skills,0.53,0.4,0.03,0.0,0.0,0.0,0.0,0.03,elizabeth stephan,True
+ENGR,1060,117,Engr Discipline & Sk,0.0,0.21,0.23,0.23,0.16,0.0,0.0,0.16,elizabeth stephan,
+ENGR,1060,119,Engr Discipline & Sk,0.06,0.31,0.25,0.17,0.06,0.0,0.0,0.15,elizabeth stephan,
+ENGR,1060,119,Engr Discipline & Sk,0.06,0.31,0.25,0.17,0.06,0.0,0.0,0.15,matthew kent miller,
+ENGR,1060,170,Engr Discip & Skills,0.11,0.47,0.24,0.11,0.03,0.0,0.0,0.05,steven brandon,
+ENGR,1060,170,Engr Discip & Skills,0.11,0.47,0.24,0.11,0.03,0.0,0.0,0.05,elizabeth stephan,
+ENGR,1070,012,Programming & Prob S,0.08,0.19,0.29,0.16,0.08,0.0,0.0,0.19,david ewing,
+ENGR,1070,012,Programming & Prob S,0.08,0.19,0.29,0.16,0.08,0.0,0.0,0.19,john minor,
+ENGR,1070,018,Programming & Prob S,0.05,0.16,0.25,0.23,0.13,0.0,0.0,0.19,john minor,
+ENGR,1070,018,Programming & Prob S,0.05,0.16,0.25,0.23,0.13,0.0,0.0,0.19,david ewing,
+ENGR,1070,020,Programming & Prob S,0.02,0.14,0.34,0.16,0.2,0.0,0.0,0.14,william park,
+ENGR,1070,020,Programming & Prob S,0.02,0.14,0.34,0.16,0.2,0.0,0.0,0.14,david ewing,
+ENGR,1070,022,Program and Problem,0.02,0.2,0.24,0.11,0.22,0.0,0.0,0.22,william park,
+ENGR,1070,022,Program and Problem,0.02,0.2,0.24,0.11,0.22,0.0,0.0,0.22,david ewing,
+ENGR,1070,072,Program & Prob Solvi,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,david ewing,True
+ENGR,1070,072,Program & Prob Solvi,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1080,018,Programming & Prob S,0.09,0.12,0.39,0.24,0.09,0.0,0.0,0.06,david ewing,
+ENGR,1080,018,Programming & Prob S,0.09,0.12,0.39,0.24,0.09,0.0,0.0,0.06,john minor,
+ENGR,1080,020,Programming & Prob S,0.24,0.18,0.33,0.15,0.09,0.0,0.0,0.0,john minor,
+ENGR,1080,020,Programming & Prob S,0.24,0.18,0.33,0.15,0.09,0.0,0.0,0.0,david ewing,
+ENGR,1080,022,Programming & Prob S,0.28,0.22,0.25,0.13,0.13,0.0,0.0,0.0,david ewing,
+ENGR,1080,022,Programming & Prob S,0.28,0.22,0.25,0.13,0.13,0.0,0.0,0.0,william park,
+ENGR,1080,056,Program/Prob Solving,0.04,0.43,0.13,0.13,0.26,0.0,0.0,0.0,william park,
+ENGR,1080,056,Program/Prob Solving,0.04,0.43,0.13,0.13,0.26,0.0,0.0,0.0,david ewing,
+ENGR,1080,072,Program/Prob Solving,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,david ewing,True
+ENGR,1080,072,Program/Prob Solving,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1090,020,Prog/Problem Solving,0.28,0.48,0.2,0.03,0.0,0.0,0.0,0.03,david ewing,
+ENGR,1090,020,Prog/Problem Solving,0.28,0.48,0.2,0.03,0.0,0.0,0.0,0.03,john minor,
+ENGR,1090,024,Prog/Problem Solving,0.36,0.43,0.19,0.02,0.0,0.0,0.0,0.0,david ewing,
+ENGR,1090,024,Prog/Problem Solving,0.36,0.43,0.19,0.02,0.0,0.0,0.0,0.0,john minor,
+ENGR,1090,028,Prog/Problem Solving,0.43,0.33,0.17,0.07,0.0,0.0,0.0,0.0,david ewing,
+ENGR,1090,056,Prog/Problem Solv Ap,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1090,056,Prog/Problem Solv Ap,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,david ewing,True
+ENGR,1900,013,CI in ENGR Architect,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
+ENGR,1900,013,CI in ENGR Architect,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,1900,014,CI in ENGR Public Po,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,jonathan maier,
+ENGR,1900,014,CI in ENGR Public Po,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,christopher norfolk,
+ENGR,1900,017,CI  in ENGR What ENG,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,bradley putman,
+ENGR,1900,017,CI  in ENGR What ENG,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,jonathan maier,
+ENGR,1900,077,CI in ENGR Huan Powe,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,jonathan maier,
+ENGR,1900,077,CI in ENGR Huan Powe,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,gregory mocko,
+ENGR,2080,023,Engr Graphics & Mach,0.43,0.2,0.2,0.04,0.06,0.0,0.0,0.07,john minor,
+ENGR,2080,023,Engr Graphics & Mach,0.43,0.2,0.2,0.04,0.06,0.0,0.0,0.07,sarah grigg,
+ENGR,2080,028,Engr Graphics & Mach,0.3,0.39,0.11,0.01,0.09,0.0,0.0,0.09,sarah grigg,
+ENGR,2080,028,Engr Graphics & Mach,0.3,0.39,0.11,0.01,0.09,0.0,0.0,0.09,john minor,
+ENGR,2080,030,Engr Graphics & Mach,0.41,0.3,0.16,0.05,0.0,0.0,0.0,0.09,sarah grigg,
+ENGR,2080,030,Engr Graphics & Mach,0.41,0.3,0.16,0.05,0.0,0.0,0.0,0.09,john minor,
+ENGR,2080,053,Engr Graphics & Mach,0.28,0.32,0.19,0.02,0.11,0.0,0.0,0.09,sarah grigg,
+ENGR,2080,053,Engr Graphics & Mach,0.28,0.32,0.19,0.02,0.11,0.0,0.0,0.09,john minor,
+ENGR,2080,055,Engr Graphics & Mach,0.38,0.28,0.23,0.04,0.04,0.0,0.0,0.02,jonathan maier,
+ENGR,2080,055,Engr Graphics & Mach,0.38,0.28,0.23,0.04,0.04,0.0,0.0,0.02,sarah grigg,
+ENGR,2100,032,CAD & Engineering Ap,0.43,0.34,0.09,0.05,0.02,0.0,0.0,0.07,john minor,
+ENGR,2100,032,CAD & Engineering Ap,0.43,0.34,0.09,0.05,0.02,0.0,0.0,0.07,nighat yasmin,
+ENGR,2100,036,CAD & Engineering Ap,0.5,0.18,0.11,0.02,0.07,0.0,0.0,0.11,nighat yasmin,
+ENGR,2100,036,CAD & Engineering Ap,0.5,0.18,0.11,0.02,0.07,0.0,0.0,0.11,john minor,
+ENGR,2100,040,CAD & Engineering Ap,0.4,0.35,0.1,0.03,0.13,0.0,0.0,0.0,john minor,
+ENGR,2100,040,CAD & Engineering Ap,0.4,0.35,0.1,0.03,0.13,0.0,0.0,0.0,nighat yasmin,
+ENGR,2100,044,CAD & Engineering Ap,0.43,0.26,0.22,0.02,0.0,0.0,0.0,0.07,john minor,
+ENGR,2100,044,CAD & Engineering Ap,0.43,0.26,0.22,0.02,0.0,0.0,0.0,0.07,william martin,
+ENR,1010,001,Intro to Envir & Nat,0.7,0.17,0.06,0.02,0.04,0.0,0.0,0.02,alan johnson,
+ENR,1010,001,Intro Env & Nat Rs I,0.7,0.17,0.06,0.02,0.04,0.0,0.0,0.02,alan johnson,
+ENR,1010,002,Intro to Envir & Nat,0.65,0.12,0.1,0.06,0.04,0.0,0.0,0.02,alan johnson,
+ENR,4290,001,Environ Law & Policy,0.47,0.38,0.09,0.03,0.03,0.0,0.0,0.0,alan johnson,
+ENSP,2000,001,Intro Environ Sci,0.67,0.22,0.08,0.0,0.0,0.0,0.0,0.02,scott brame,
+ENSP,2000,002,Intro Environ Sci,0.66,0.28,0.04,0.0,0.02,0.0,0.0,0.0,minory nammouz,
+ENSP,2000,003,Intro Environ Sci,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,4000,001,Studies in En Sp,0.68,0.14,0.09,0.05,0.05,0.0,0.0,0.0,margaret thompson,
+ENT,2000,001,Six-Legged Science,0.71,0.13,0.08,0.0,0.0,0.0,0.0,0.08,suellen pometto,
+ENT,2010,001,Selected Topics,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,joseph culin,
+ENT,3010,001,Insect Biology & Div,0.33,0.33,0.17,0.0,0.17,0.0,0.0,0.0,eric benson,
+ESED,8000,001,Seminar in Engr & Sc,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,julie patric martin,
+ESED,8000,001,Seminar in Engr & Sc,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,karen ann high,
+ESED,8200,001,Teaching Undergrad E,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,karen ann high,
+ESED,8200,001,Teaching Undergrad E,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,
+ESED,8750,001,Curr Issues in STEM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,
+ESED,8750,001,Curr Issues in STEM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,karen ann high,
+ETOX,4300,001,Toxicology,0.18,0.45,0.18,0.0,0.0,0.0,0.0,0.18,peter van den hurk,
+ETOX,6300,001,Toxicology,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,peter van den hurk,
+FCS,8130,003,Research Methods in,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,natallia ser sianko,
+FCS,8130,003,Research Methods in,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,
+FDSC,1010,001,Intro to Food Sci &,0.69,0.25,0.02,0.01,0.04,0.0,0.0,0.0,rita haliena,
+FDSC,1010,001,Intro to Food Sci &,0.69,0.25,0.02,0.01,0.04,0.0,0.0,0.0,aubrey dean coffee,
+FDSC,3010,001,Food Regulations,0.75,0.2,0.0,0.03,0.0,0.0,0.0,0.03,julie kat northcutt,
+FDSC,3060,001,Institutional Foodse,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,
+FDSC,3070,001,Restaurant Food Serv,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,margaret condrasky,
+FDSC,4010,001,Food Chem I,0.78,0.16,0.03,0.01,0.0,0.0,0.0,0.01,ronnie thomas,
+FDSC,4040,001,Food Prsv & Process,0.28,0.51,0.18,0.03,0.0,0.0,0.0,0.0,julie kat northcutt,
+FDSC,4070,001,Quantity Food Produc,0.43,0.49,0.06,0.01,0.0,0.0,0.0,0.01,heather batt,
+FDSC,4170,001,Seminar,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,aubrey dean coffee,
+FDSC,4300,001,Dairy Process & Sant,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+FDSC,8120,001,Microbial Food Syst,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,xiuping jiang,
+FIN,3040,001,Risk & Insurance,0.0,0.38,0.38,0.08,0.15,0.0,0.0,0.0,kerri mcmillan,
+FIN,3040,002,Risk & Insurance,0.21,0.32,0.34,0.11,0.0,0.0,0.0,0.03,kerri mcmillan,
+FIN,3050,001,Investment Analysis,0.16,0.47,0.23,0.09,0.0,0.0,0.0,0.05,kerri mcmillan,
+FIN,3050,002,Investment Analysis,0.22,0.41,0.27,0.07,0.02,0.0,0.0,0.02,kerri mcmillan,
+FIN,3050,003,Investment Analysis,0.1,0.26,0.19,0.1,0.07,0.0,0.0,0.28,john alexander,
+FIN,3060,002,Corporation Finance,0.11,0.19,0.53,0.08,0.03,0.0,0.0,0.06,john harris,
+FIN,3060,003,Corporation Finance,0.08,0.57,0.28,0.06,0.0,0.0,0.0,0.02,neil waller,
+FIN,3060,004,Corporation Finance,0.23,0.48,0.15,0.08,0.03,0.0,0.0,0.05,john harris,
+FIN,3060,005,Corporation Finance,0.08,0.62,0.23,0.08,0.0,0.0,0.0,0.0,neil waller,
+FIN,3060,006,Corporation Finance,0.07,0.2,0.49,0.07,0.05,0.0,0.0,0.12,john harris,
+FIN,3060,007,Corporation Finance,0.16,0.51,0.24,0.08,0.0,0.0,0.0,0.02,neil waller,
+FIN,3060,008,Corporation Finance,0.28,0.3,0.07,0.17,0.09,0.0,0.0,0.09,william hol johnson,
+FIN,3060,009,Corporation Finance,0.22,0.38,0.25,0.0,0.03,0.0,0.0,0.13,john harris,
+FIN,3060,010,Corporation Finance,0.28,0.2,0.28,0.13,0.03,0.0,0.0,0.1,william hol johnson,
+FIN,3060,011,Corporation Finance,0.3,0.28,0.17,0.11,0.06,0.0,0.0,0.09,william hol johnson,
+FIN,3070,001,Prin of Real Estate,0.15,0.4,0.32,0.09,0.02,0.0,0.0,0.02,thomas springer,
+FIN,3070,002,Prin of Real Estate,0.15,0.44,0.33,0.04,0.04,0.0,0.0,0.0,thomas springer,
+FIN,3080,001,Fin Inst & Mkts,0.23,0.37,0.2,0.13,0.03,0.0,0.0,0.03,daniel thoma greene,
+FIN,3080,002,Fin Inst & Mkts,0.13,0.3,0.4,0.08,0.08,0.0,0.0,0.03,michael spivey,
+FIN,3080,003,Fin Inst & Mkts,0.21,0.36,0.29,0.07,0.02,0.0,0.0,0.05,michael spivey,
+FIN,3110,001,Financial Management,0.17,0.26,0.33,0.17,0.0,0.0,0.0,0.07,jared daniel smith,
+FIN,3110,002,Financial Management,0.17,0.34,0.37,0.07,0.05,0.0,0.0,0.0,jared daniel smith,
+FIN,3110,003,Financial Management,0.3,0.34,0.16,0.11,0.05,0.0,0.0,0.05,fei xie,
+FIN,3110,004,Financial Management,0.3,0.43,0.18,0.02,0.02,0.0,0.0,0.05,fei xie,
+FIN,3120,001,Financial Mgt II,0.09,0.31,0.38,0.16,0.0,0.0,0.0,0.06,lyudmila chernykh,
+FIN,3120,002,Financial Mgt II,0.32,0.38,0.22,0.05,0.0,0.0,0.0,0.03,lyudmila chernykh,
+FIN,3120,003,Financial Mgt II,0.53,0.19,0.16,0.02,0.02,0.0,0.0,0.07,melvin stith,
+FIN,3120,004,Financial Mgt II,0.72,0.11,0.15,0.02,0.0,0.0,0.0,0.0,melvin stith,
+FIN,4020,001,Corporate Valuation,0.35,0.28,0.25,0.13,0.0,0.0,0.0,0.0,angela morgan,
+FIN,4020,003,Corporate Valuation,0.07,0.4,0.38,0.1,0.02,0.0,0.0,0.02,angela morgan,
+FIN,4050,001,Port Mgt and Theory,0.14,0.18,0.39,0.14,0.0,0.0,0.0,0.14,john alexander,
+FIN,4060,001,Derivatives Analysis,0.21,0.38,0.25,0.04,0.04,0.0,0.0,0.08,george bra lockhart,
+FIN,4110,001,Int Fin Mgt,0.25,0.33,0.3,0.05,0.03,0.0,0.0,0.05,tilan tang,
+FIN,4110,002,Int Fin Mgt,0.47,0.16,0.16,0.05,0.05,0.0,0.0,0.11,tilan tang,
+FIN,4170,001,Real Estate Finance,0.36,0.36,0.27,0.0,0.0,0.0,0.0,0.0,neil waller,
+FNR,2040,001,Soil Information Sys,0.72,0.22,0.03,0.02,0.0,0.0,0.0,0.02,elena mikhailova,
+FOR,2050,001,Dendrology,0.25,0.31,0.19,0.16,0.09,0.0,0.0,0.0,donald hagan,
+FOR,2050,002,Dendrology,0.18,0.24,0.35,0.24,0.0,0.0,0.0,0.0,donald hagan,
+FOR,2050,003,Dendrology,0.31,0.23,0.2,0.11,0.09,0.0,0.0,0.06,donald hagan,
+FOR,2210,001,Forest Biology,0.46,0.4,0.09,0.02,0.01,0.0,0.0,0.01,patrick mcmillan,
+FOR,3020,001,Forest Biometrics,0.41,0.23,0.18,0.14,0.05,0.0,0.0,0.0,lawrence gering,
+FOR,3040,001,Forest Res Econ,0.38,0.24,0.24,0.11,0.03,0.0,0.0,0.0,john edward hatcher,
+FOR,4100,001,Harvesting Processes,0.36,0.27,0.27,0.09,0.0,0.0,0.0,0.0,greg yarrow,
+FOR,4130,001,Int Forest Pest Mgmt,0.22,0.39,0.3,0.09,0.0,0.0,0.0,0.0,robert bellinger,
+FOR,4130,001,Int Forest Pest Mgmt,0.22,0.39,0.3,0.09,0.0,0.0,0.0,0.0,julia loui kerrigan,
+FOR,4160,001,For Pol and Adm,0.45,0.4,0.14,0.02,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4170,001,For Res Mgt and Reg,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,john edward hatcher,
+FOR,4310,001,Mgt for Recreation,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
+FOR,4340,001,GIS for Landscape Pl,0.5,0.46,0.02,0.0,0.02,0.0,0.0,0.0,christopher post,
+FOR,4930,200,Wildland and Prescri,0.45,0.34,0.0,0.0,0.07,0.0,0.0,0.14,donald hagan,
+FR,1010,001,Elementary French,0.74,0.16,0.0,0.05,0.05,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,1020,001,Elementary French,0.75,0.15,0.0,0.05,0.0,0.0,0.0,0.05,amy lyn grif sawyer,
+FR,1020,002,Elementary French,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,1020,003,Elementary French,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,julian hamil killey,
+FR,2010,001,Intermediate French,0.56,0.22,0.11,0.06,0.0,0.0,0.0,0.06,joseph mai,
+FR,2010,002,Intermediate French,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,kenneth dav widgren,
+FR,2010,003,Intermediate French,0.31,0.62,0.08,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,2010,004,Intermediate French,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,julian hamil killey,
+FR,2020,001,Intermediate French,0.85,0.0,0.1,0.0,0.0,0.0,0.0,0.05,amy lyn grif sawyer,
+FR,2020,002,Intermediate French,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
+FR,2020,003,Intermediate French,0.35,0.29,0.24,0.0,0.0,0.0,0.0,0.12,kenneth dav widgren,
+FR,3040,001,French Short Story,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,eric touya,
+FR,3050,001,Int Fr Con & Comp I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,3070,001,French Civilization,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,4160,001,Fr for Intl Trade II,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,eric touya,
+GC,1010,001,Orientation to G C,0.78,0.14,0.08,0.0,0.0,0.0,0.0,0.0,rebecca suza edlein,
+GC,1010,002,Orientation to G C,0.8,0.1,0.04,0.02,0.02,0.0,0.0,0.02,kern cox,
+GC,1020,001,Comp Art & Cad Found,0.42,0.35,0.15,0.04,0.04,0.0,0.0,0.0,charles tabor weiss,
+GC,1020,002,Comp Art & Cad Found,0.52,0.45,0.0,0.0,0.0,0.0,0.0,0.03,nona woolbright,
+GC,1020,003,Comp Art & Cad Found,0.62,0.31,0.0,0.0,0.07,0.0,0.0,0.0,nona woolbright,
+GC,1020,004,Comp Art & Cad Found,0.42,0.38,0.12,0.0,0.08,0.0,0.0,0.0,carol jones,
+GC,1030,001,G C I for Pkgsc,0.29,0.38,0.24,0.05,0.0,0.0,0.0,0.05,john jacobs,
+GC,1040,001,Graphic Com I,0.56,0.29,0.09,0.0,0.03,0.0,0.0,0.03,rebecca suza edlein,
+GC,1040,001,Graphic Communicatio,0.56,0.29,0.09,0.0,0.03,0.0,0.0,0.03,rebecca suza edlein,
+GC,1990,003,Cr Inquiry in G C I-,0.86,0.05,0.0,0.0,0.05,0.0,0.0,0.05,janice ann lay,
+GC,2070,001,Graphic Communicatio,0.5,0.38,0.09,0.0,0.03,0.0,0.0,0.0,patrick gee rose,
+GC,3400,001,Digital Img & Emedia,0.6,0.29,0.07,0.02,0.02,0.0,0.0,0.0,erica black walker,
+GC,4060,001,Package and Specialt,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,kern cox,
+GC,4400,001,Commercial Printing,0.29,0.67,0.0,0.0,0.04,0.0,0.0,0.0,eric weisenmiller,
+GC,4400,002,Commercial Printing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,
+GC,4440,001,Current Dev in G C,0.38,0.47,0.09,0.03,0.03,0.0,0.0,0.0,liam henry 'hara,
+GC,4460,001,Ink & Substrates,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,liam henry 'hara,
+GC,4460,002,Ink & Substrates,0.08,0.31,0.23,0.23,0.15,0.0,0.0,0.0,liam henry 'hara,
+GC,4480,001,Plan and Cont Print,0.5,0.33,0.13,0.03,0.0,0.0,0.0,0.0,john leininger,
+GC,4900,230,G C Selected Topics-,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,john leininger,
+GC,6900,002,G C Selected Topics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,
+GEN,1030,001,Careers in Bioch/Gen,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,alison starr-moss,
+GEN,3000,001,Fundamental Genetics,0.28,0.3,0.18,0.14,0.01,0.0,0.0,0.09,kate leanne wi tsai,
+GEN,3000,002,Fundamental Genetics,0.34,0.37,0.19,0.05,0.01,0.0,0.0,0.04,kate leanne wi tsai,
+GEN,3020,001,Molecular & General,0.23,0.37,0.25,0.06,0.04,0.0,0.0,0.06,liangjiang wang,
+GEN,3020,001,Molecular & General,0.23,0.37,0.25,0.06,0.04,0.0,0.0,0.06,lukasz kozubowski,
+GEN,3020,002,Molec & General Gene,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,True
+GEN,3020,002,Molec & General Gene,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,True
+GEN,3030,001,Molec & General Gene,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,liangjiang wang,
+GEN,3030,001,Molec & General Gene,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,
+GEN,3030,002,Molec & General Gene,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,lukasz kozubowski,
+GEN,3030,002,Mol Gen Genet Lab,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,lukasz kozubowski,
+GEN,3030,002,Molec & General Gene,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,liangjiang wang,
+GEN,3030,002,Mol Gen Genet Lab,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,liangjiang wang,
+GEN,3030,003,Molec & General Gene,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,
+GEN,3030,003,Molec & General Gene,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,
+GEN,3030,004,Molec & General Gene,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lukasz kozubowski,
+GEN,3030,004,Mol Gen Genet Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,lukasz kozubowski,
+GEN,3030,004,Molec & General Gene,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,liangjiang wang,
+GEN,3030,004,Mol Gen Genet Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,liangjiang wang,
+GEN,4200,001,Molecular Genetics &,0.33,0.33,0.26,0.0,0.0,0.0,0.0,0.07,julia frugoli,
+GEN,4200,002,Molecular Genetics &,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True
+GEN,4210,002,Mol Gen Gene Reg Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,
+GEN,4210,003,Mol Gen Gene Reg Lab,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,julia frugoli,
+GEN,4210,004,Mol Gen Gene Reg Lab,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,julia frugoli,
+GEN,4400,001,Bioinformatics,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
+GEN,4500,001,Comparative Genetics,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,leigh anne clark,
+GEN,6400,001,Bioinformatics,0.63,0.25,0.0,0.0,0.13,0.0,0.0,0.0,frank alexan feltus,
+GEN,8140,001,Advanced Genetics,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kate leanne wi tsai,
+GEOG,1010,001,Intro to Geography,0.33,0.33,0.23,0.1,0.03,0.0,0.0,0.0,christa smith,
+GEOG,1030,001,World Regional Geog,0.76,0.14,0.03,0.02,0.02,0.0,0.0,0.02,lance forres howard,
+GEOG,1030,002,World Regional Geog,0.35,0.35,0.2,0.05,0.0,0.0,0.0,0.05,william churc terry,
+GEOG,1030,003,World Regional Geog,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,david doran,
+GEOG,1030,004,World Regional Geog,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david doran,
+GEOG,3400,001,Geog of Latin Amer,0.27,0.27,0.36,0.0,0.09,0.0,0.0,0.0,william churc terry,
+GEOL,1010,001,Physical Geology,0.18,0.29,0.21,0.15,0.07,0.0,0.0,0.09,alan coulson,
+GEOL,1010,002,Physical Geology,0.26,0.28,0.22,0.11,0.06,0.0,0.0,0.07,alan coulson,
+GEOL,1010,003,Physical Geology,0.37,0.35,0.24,0.04,0.0,0.0,0.0,0.0,stephen mich moysey,
+GEOL,1030,001,Physical Geol Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,002,Physical Geol Lab,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,003,Physical Geol Lab,0.09,0.22,0.39,0.13,0.13,0.0,0.0,0.04,alan coulson,
+GEOL,1030,004,Physical Geol Lab,0.63,0.25,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,005,Physical Geol Lab,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,006,Physical Geol Lab,0.17,0.52,0.17,0.09,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,007,Physical Geol Lab,0.21,0.46,0.17,0.0,0.0,0.0,0.0,0.17,alan coulson,
+GEOL,1030,008,Physical Geol Lab,0.25,0.63,0.04,0.0,0.04,0.0,0.0,0.04,alan coulson,
+GEOL,1030,009,Physical Geol Lab,0.13,0.38,0.25,0.04,0.0,0.0,0.0,0.21,alan coulson,
+GEOL,1030,010,Physical Geol Lab,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,012,Physical Geol Lab,0.13,0.43,0.22,0.13,0.0,0.0,0.0,0.09,alan coulson,
+GEOL,2050,001,Mineralogy & Intro P,0.4,0.27,0.2,0.0,0.13,0.0,0.0,0.0,lin shuller-nickles,
+GEOL,2070,001,Min & Intro Pet Lab,0.21,0.5,0.14,0.07,0.07,0.0,0.0,0.0,alan coulson,
+GEOL,2700,001,Sustainable Water,0.82,0.04,0.07,0.0,0.04,0.0,0.0,0.04,stephen mich moysey,
+GEOL,3000,001,Environmental Geol,0.41,0.38,0.15,0.06,0.0,0.0,0.0,0.0,scott brame,
+GEOL,4110,008,CI - Community Outre,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,john robert wagner,
+GEOL,6150,001,Analysis Geological,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
+GEOL,8060,001,Aquifer Charact,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james castle,
+GEOL,8090,001,Subsurface Remed Mod,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ronald falta,
+GER,1010,001,Elementary German,0.32,0.37,0.16,0.0,0.05,0.0,0.0,0.11, lee ferrell,
+GER,1010,002,Elementary German,0.11,0.32,0.16,0.32,0.05,0.0,0.0,0.05, lee ferrell,
+GER,1010,003,Elementary German,0.24,0.18,0.24,0.06,0.06,0.0,0.0,0.24, lee ferrell,
+GER,1020,001,Elementary German,0.29,0.21,0.14,0.07,0.0,0.0,0.0,0.29, lee ferrell,
+GER,1020,003,Elementary German,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,2010,001,Intermediate German,0.33,0.4,0.07,0.0,0.07,0.0,0.0,0.13,gabriela stoicea,
+GER,2010,002,Intermediate German,0.22,0.33,0.17,0.17,0.0,0.0,0.0,0.11,johannes schmidt,
+GER,2020,001,Intermediate German,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,3050,001,Ger Conv & Comp,0.53,0.24,0.06,0.12,0.0,0.06,0.0,0.0,oswald harris king,
+GER,3690,001,German WWI Literatur,0.42,0.42,0.0,0.17,0.0,0.0,0.0,0.0,johannes schmidt,
+HCC,8310,001,Fundamentals of Hcc,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shaundra daily,
+HCC,8810,001,Research Methods in,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
+HEHD,4100,001,Lead Beh & Civic En,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,katelyn mcc radford,
+HEHD,8000,400,Youth Dev Theories,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kellye rembert,
+HEHD,8050,001,Yth Dev in Families,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
+HEHD,8050,001,Yth Dev in Families,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,william quinn,
+HEHD,8060,230,Diverse Society,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,william quinn,
+HEHD,8060,230,Diverse Society,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,keith george diem,
+HIST,1010,001,Hist of the U S,0.12,0.55,0.24,0.0,0.06,0.0,0.0,0.03,james brad jeffries,
+HIST,1010,002,Hist of the U S,0.31,0.26,0.29,0.11,0.0,0.0,0.0,0.03,lee brady wilson,
+HIST,1020,002,Hist of the U S,0.23,0.23,0.12,0.04,0.0,0.0,0.0,0.38,maribel morey,
+HIST,1240,001,Environmental Hist,0.24,0.37,0.25,0.03,0.03,0.0,0.0,0.07,james brad jeffries,
+HIST,1720,001,The West and the Wor,0.39,0.26,0.16,0.12,0.03,0.0,0.0,0.03,james burns,
+HIST,1720,002,The West and the Wor,0.33,0.36,0.19,0.05,0.02,0.0,0.0,0.05,steven marks,
+HIST,1730,001,The West and the Wor,0.3,0.33,0.17,0.05,0.06,0.0,0.0,0.09,richard saunders,
+HIST,1730,002,The West and the Wor,0.32,0.38,0.13,0.03,0.08,0.0,0.0,0.05, alan grubb,
+HIST,2990,001,Historian's Craft,0.47,0.2,0.13,0.0,0.07,0.0,0.0,0.13,michael silvestri,
+HIST,2990,003,Historian's Craft,0.59,0.24,0.06,0.06,0.0,0.0,0.0,0.06,rachel anne moore,
+HIST,3000,001,Hist Colonial Amer,0.3,0.49,0.14,0.03,0.05,0.0,0.0,0.0,lee brady wilson,
+HIST,3030,001,Civil War & Recon,0.21,0.49,0.13,0.03,0.1,0.0,0.0,0.05,paul chris anderson,
+HIST,3040,001,Indus & Progr Era,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0, roger grant,
+HIST,3220,001,History of Technolog,0.37,0.33,0.13,0.03,0.1,0.0,0.0,0.03,pamela mack,
+HIST,3280,001,US Legal History to,0.17,0.17,0.1,0.0,0.07,0.0,0.0,0.5,maribel morey,
+HIST,3300,001,Hist of Mod China,0.31,0.23,0.38,0.0,0.08,0.0,0.0,0.0,edwin moise,
+HIST,3400,001,Latin America I,0.48,0.38,0.1,0.0,0.02,0.0,0.0,0.02,rachel anne moore,
+HIST,3550,001,Roman World,0.35,0.48,0.06,0.0,0.03,0.0,0.0,0.06,elizabeth carney,
+HIST,3610,001,History of Britain t,0.42,0.36,0.12,0.03,0.06,0.0,0.0,0.0,caroline dunn clark,
+HIST,3630,001,Britain Since 1688,0.37,0.26,0.21,0.05,0.05,0.0,0.0,0.05,stephani barczewski,
+HIST,3700,001,Medieval History,0.41,0.31,0.09,0.06,0.06,0.0,0.0,0.06,caroline dunn clark,
+HIST,3720,001,Renaissance,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,thomas kuehn,
+HIST,3810,001,Germany Since 1918,0.2,0.47,0.13,0.0,0.2,0.0,0.0,0.0,michael meng,
+HIST,3850,001,Imperial Russia,0.3,0.37,0.11,0.11,0.07,0.0,0.0,0.04,steven marks,
+HIST,3900,001,Mod Mil Hist,0.09,0.41,0.41,0.0,0.05,0.0,0.0,0.05,edwin moise,
+HIST,4090,001,Jfk Assassination,0.42,0.38,0.1,0.0,0.08,0.0,0.0,0.02,richard saunders,
+HIST,4140,001,Study of Hist Museum,0.6,0.07,0.27,0.0,0.07,0.0,0.0,0.0,leslie white,
+HIST,4710,001,Studies in Mod Europ,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,michael meng,
+HIST,4870,001,World War II,0.2,0.57,0.07,0.09,0.04,0.0,0.0,0.04,john andrew,
+HIST,4900,002,Film and Local Histo,0.45,0.45,0.0,0.09,0.0,0.0,0.0,0.0,james burns,
+HIST,4900,003,HIST & GEOG Disney P,0.31,0.44,0.13,0.13,0.0,0.0,0.0,0.0,stephani barczewski,
+HIST,4900,003,HIST & GEOG Disney P,0.31,0.44,0.13,0.13,0.0,0.0,0.0,0.0,christa smith,
+HIST,4930,001,Slavery & Film,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,abel bartley,
+HIST,4940,001,Europe's Dictators,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,amit bein,
+HIST,8000,002,Major Probs SO Histo,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,john andrew,
+HLTH,2020,001,Introduction to Publ,0.31,0.62,0.0,0.08,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,002,Introduction to Publ,0.56,0.33,0.08,0.03,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,003,Introduction to Publ,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,004,Introduction to Publ,0.39,0.45,0.11,0.05,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,005,Introduction to Publ,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,006,Introduction to Publ,0.53,0.35,0.06,0.0,0.06,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2030,001,Health Care Sys,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,lee alden crandall,
+HLTH,2030,002,Health Care Sys,0.68,0.28,0.0,0.0,0.03,0.0,0.0,0.03,ralph stewart welsh,
+HLTH,2030,400,Health Care Sys,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ralph stewart welsh,
+HLTH,2400,001,Deter of Hlth Behav,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.03,sarah griffin,
+HLTH,2400,002,Deter of Hlth Behav,0.36,0.49,0.09,0.0,0.0,0.0,0.0,0.06,sarah griffin,
+HLTH,2980,001,Human Hlth & Disease,0.6,0.33,0.05,0.0,0.0,0.0,0.0,0.02,deborah alma falta,
+HLTH,2980,002,Human Hlth & Disease,0.53,0.44,0.0,0.0,0.0,0.0,0.0,0.03,deborah alma falta,
+HLTH,3030,001,Public Health Comm,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,debra mitch charles,
+HLTH,3400,001,Hlth Prom Prog Plan,0.47,0.32,0.18,0.0,0.0,0.0,0.0,0.03,joel edwar williams,
+HLTH,3610,001,Int Health Care Econ,0.5,0.28,0.17,0.0,0.0,0.0,0.0,0.06,khoa dang truong,
+HLTH,3800,001,Epidemiology,0.19,0.6,0.15,0.04,0.0,0.0,0.0,0.02,hugh spitler,
+HLTH,3800,002,Epidemiology,0.16,0.64,0.2,0.0,0.0,0.0,0.0,0.0,hugh spitler,
+HLTH,3800,400,Epidemiology,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,deborah alma falta,
+HLTH,3980,001,Hlth Appraisal Sklls,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4150,001,Obesity & Eating Dis,0.57,0.34,0.06,0.0,0.0,0.0,0.0,0.03,karen kemper,
+HLTH,4190,001,Health Sci Internshi,0.21,0.58,0.12,0.06,0.03,0.0,0.0,0.0,kathleen meyer,
+HLTH,4200,001,Hlth Science Intern,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4400,001,Manag Hlth Serv Org,0.19,0.67,0.15,0.0,0.0,0.0,0.0,0.0,frederic fraizer,
+HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,ronald gimbel,
+HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,4700,001,International Health,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,rachel mayo,
+HLTH,4750,001,Hlthcr Oper Mgmt Res,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,
+HLTH,4900,001,Res Eval St Pub Hlth,0.57,0.19,0.14,0.05,0.0,0.0,0.0,0.05,khoa dang truong,
+HLTH,4900,002,Res Eval St Pub Hlth,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,lingling zhang,
+HON,1900,001,Holocaust Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True
+HON,1900,002,Amer Lit & Global Co,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,angela naimou,True
+HON,1920,001,Positively Human,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,june pilcher,True
+HON,1940,001,Scientific Skepticis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey appling,True
+HON,2020,001,Stress in Health and,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,True
+HON,2030,001,Music/Politics:Blues,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,True
+HON,2200,001,Midterm Elections,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey allen fine,True
+HON,2200,002,The Modern Israeli S,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,colin pearce,True
+HON,2220,001,Science/Literaure in,0.64,0.27,0.0,0.09,0.0,0.0,0.0,0.0,gabriela stoicea,True
+HORT,1010,001,Horticulture,0.63,0.31,0.07,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HORT,2100,001,Growing Fall Plants,0.33,0.17,0.17,0.17,0.0,0.0,0.0,0.17,samarakoon basnagala,
+HORT,2120,001,Turfgrass Culture,0.55,0.43,0.0,0.0,0.03,0.0,0.0,0.0,haibo liu,
+HORT,2130,001,Turf Culture Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,donald garrett,
+HORT,2130,002,Turf Culture Lab,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,donald garrett,
+HORT,3030,001,Landscape Plants,0.36,0.32,0.17,0.03,0.07,0.0,0.0,0.05,robert polomski,
+HORT,3080,001,Sust Landscape Des,0.63,0.23,0.07,0.05,0.0,0.0,0.0,0.02,ellen anita vincent,
+HORT,3090,001,Sust Landsc Des Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,harry harritos,
+HORT,4090,001,Senior Capstone Cour,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,ellen anita vincent,
+HORT,4120,001,Adv Turfgrass Mgt,0.3,0.3,0.2,0.0,0.0,0.0,0.0,0.2,lambert mccarty,
+HORT,4330,001,Turf Weed Management,0.29,0.41,0.24,0.0,0.0,0.0,0.0,0.06,ted whitwell,
+HP,8030,001,Building Tech and Pa,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amalia leifeste,
+HP,8070,400,American Architectur,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,carter lee hudgins,
+HP,8090,400,Historical Research,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,katherine pemberton,
+HP,8190,001,"Investig, Docum, Con",0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,amalia leifeste,
+HP,8190,001,"Investig, Docum, Con",0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,kristopher king,
+HRD,8200,400,Human Perform Improv,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,cynthia sims,
+HRD,8200,401,Human Perform Improv,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,cynthia sims,
+HRD,8200,402,Human Perform Improv,0.71,0.0,0.14,0.0,0.0,0.0,0.0,0.14,cynthia sims,
+HRD,8200,403,Human Perform Improv,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,cynthia sims,
+HRD,8200,405,Human Perform Improv,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,cynthia sims,
+HRD,8200,406,Human Perform Improv,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,cynthia sims,
+HRD,8300,400,Concepts of H R D,0.38,0.38,0.13,0.0,0.0,0.0,0.0,0.13,eileen newmark,
+HRD,8300,401,Concepts of H R D,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,eileen newmark,
+HRD,8300,402,Concepts of H R D,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,eileen newmark,
+HRD,8300,403,Concepts of H R D,0.2,0.7,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,
+HRD,8300,404,Concepts of H R D,0.5,0.25,0.13,0.0,0.13,0.0,0.0,0.0,eileen newmark,
+HRD,8300,405,Concepts of H R D,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
+HRD,8300,406,Concepts of H R D,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
+HRD,8300,407,Concepts of H R D,0.63,0.13,0.0,0.0,0.0,0.0,0.0,0.25,eileen newmark,
+HRD,8450,402,Needs Assess Ed/Ind,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,russell marion,
+HRD,8600,404,Instruc Mat Devel,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,philip mcgee,
+HRD,8600,405,Instruc Mat Devel,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,
+HRD,8600,406,Instruc Mat Devel,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,
+IE,2000,001,Soph Seminar in I E,0.53,0.26,0.12,0.06,0.02,0.0,0.0,0.01,brian melloy,
+IE,2010,001,Systems Design I,0.4,0.47,0.1,0.0,0.03,0.0,0.0,0.0,joel greenstein,
+IE,2010,002,Systems Design I,0.37,0.43,0.17,0.0,0.0,0.0,0.0,0.03,joel greenstein,
+IE,2010,003,Systems Design I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
+IE,2800,001,Deterministic Operat,0.18,0.34,0.2,0.13,0.11,0.0,0.0,0.04,jonathan cole smith,
+IE,2800,002,Deterministic Operat,0.38,0.37,0.13,0.06,0.04,0.0,0.0,0.02,amin khademi,
+IE,3600,001,Industrial Apps of P,0.3,0.33,0.23,0.08,0.05,0.0,0.0,0.01,mary elizabeth kurz,
+IE,3680,001,Prof Practice in I E,0.87,0.08,0.02,0.01,0.01,0.0,0.0,0.01,brian melloy,
+IE,3860,001,Prod Plan & Cont,0.38,0.46,0.08,0.0,0.04,0.0,0.0,0.04,robert james riggs,
+IE,4020,003,Creative Inq Res,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,anand gramopadhye,
+IE,4400,001,Decision Support Sys,0.47,0.29,0.08,0.05,0.03,0.0,0.0,0.08,sandra dun eksioglu,
+IE,4400,002,Decision Support Sys,0.33,0.42,0.14,0.07,0.02,0.0,0.0,0.02,mary elizabeth kurz,
+IE,4560,001,Supply Chain Design,0.2,0.59,0.12,0.0,0.1,0.0,0.0,0.0,william ferrell,
+IE,4610,001,Quality Engineering,0.3,0.35,0.28,0.05,0.0,0.0,0.0,0.01,byung rae cho,
+IE,4650,001,Facilities Planning,0.26,0.53,0.18,0.02,0.0,0.0,0.0,0.01,brian melloy,
+IE,4820,001,Systems Modeling,0.32,0.47,0.19,0.01,0.0,0.0,0.0,0.01,kevin taaffe,
+IE,4910,001,Investigating Human,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,sara lu riggs,
+IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,sandra dun eksioglu,
+IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,sandra dun eksioglu,
+IE,4910,002,Capstone Preparation,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,kap chalil madathil,
+IE,6400,001,Decision Support Sys,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,
+IE,6560,001,Supply Chain Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,
+IE,6910,001,Selected Topics-I E,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,sara lu riggs,
+IE,8000,001,Human Factors Eng,0.11,0.75,0.13,0.0,0.01,0.0,0.0,0.0,david neyens,
+IE,8030,001,Engr Optimization an,0.23,0.39,0.26,0.0,0.06,0.0,0.0,0.06,scott jenning mason,
+IE,8090,001,Model Sys Under Risk,0.23,0.43,0.25,0.0,0.05,0.0,0.0,0.04,burak eksioglu,
+IE,8510,001,Data Coll Anl Interp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabeth kurz,
+IE,8530,001,Foundations of Qual,0.84,0.14,0.02,0.0,0.0,0.0,0.0,0.0,byung rae cho,
+IE,8550,001,Capital Projects Sc,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
+IE,8870,001,Model Logist Behav S,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
+INT,1010,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.91,0.06,0.03,troy nunamaker,
+INT,1020,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.88,0.11,0.01,troy nunamaker,
+INT,1030,005,Career Center Intern,0.0,0.0,0.0,0.0,0.0,0.85,0.11,0.04,troy nunamaker,
+IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,meredith fan wilson,
+IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,laura padfiel braun,
+IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,sharon nagy,
+IS,1010,100,CCA International Ex,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,uttiyo raychaudhuri,
+ITAL,1010,001,Elementary Italian,0.47,0.11,0.11,0.0,0.11,0.0,0.0,0.21,luca barattoni,
+ITAL,1010,002,Elementary Italian,0.74,0.11,0.16,0.0,0.0,0.0,0.0,0.0,luca barattoni,
+ITAL,1010,003,Elementary Italian,0.32,0.42,0.11,0.05,0.11,0.0,0.0,0.0,valentina lombardi,
+ITAL,1010,004,Elementary Italian,0.5,0.25,0.0,0.0,0.13,0.0,0.0,0.13,valentina lombardi,
+ITAL,1020,001,Elementary Italian,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+ITAL,2010,001,Intermediate Italian,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,2010,002,Intermediate Italian,0.35,0.47,0.18,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,2020,001,Intermediate Italian,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,barbara zaczek,
+JAPN,1010,001,Elementary Japanese,0.42,0.32,0.11,0.0,0.11,0.0,0.0,0.05,toshiko kishimoto,
+JAPN,1010,002,Elementary Japanese,0.42,0.21,0.11,0.05,0.05,0.0,0.0,0.16,toshiko kishimoto,
+JAPN,2010,001,Intermed Japanese,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,toshiko joerger,
+JAPN,3050,001,Japanese Conv & Comp,0.5,0.25,0.17,0.0,0.0,0.0,0.0,0.08,toshiko kishimoto,
+JAPN,4010,001,Japan Lit in Trans,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,kenneth jeff knight,
+LANG,2540,001,Introduction to Worl,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,joseph mai,
+LANG,3710,001,Language and Culture,0.3,0.2,0.3,0.0,0.0,0.0,0.0,0.2,yanhua zhang,
+LARC,1150,001,Intro Landscape Arch,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,
+LARC,1280,001,Technical Graphics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
+LARC,1510,001,Basic Design I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
+LARC,3620,001,Design Impl II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,
+LARC,4280,001,Comput Aided Design,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,shan jiang,
+LARC,4530,001,Key Issues in Larch,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
+LARC,8500,001,Grad Colloquium,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,
+LAW,3220,001,Legal Env of Bus,0.14,0.61,0.24,0.01,0.01,0.0,0.0,0.0,judson jahn,
+LAW,3220,002,Legal Env of Bus,0.47,0.41,0.11,0.01,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,003,Legal Env of Bus (HO,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,frances edwards,True
+LAW,3220,004,Legal Env of Bus,0.06,0.42,0.21,0.12,0.03,0.0,0.0,0.15,virgini ward-vaughn,
+LAW,3220,005,Legal Env of Bus,0.06,0.45,0.23,0.13,0.06,0.0,0.0,0.06,virgini ward-vaughn,
+LAW,3220,006,Legal Env of Bus,0.23,0.26,0.32,0.13,0.0,0.0,0.0,0.06,virgini ward-vaughn,
+LAW,3220,007,Legal Env of Bus,0.29,0.24,0.29,0.1,0.05,0.0,0.0,0.05,virgini ward-vaughn,
+LAW,3220,009,Legal Env of Bus,0.51,0.39,0.1,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,010,Legal Env of Bus,0.42,0.38,0.16,0.05,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,011,Legal Env of Bus,0.18,0.46,0.19,0.1,0.0,0.0,0.0,0.06,kenneth toussaint,
+LAW,3220,012,Legal Env of Bus,0.33,0.51,0.15,0.01,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3330,001,Real Estate Law,0.1,0.52,0.2,0.06,0.0,0.0,0.0,0.12,michael bra burrell,
+LAW,4050,001,Construction Law,0.88,0.07,0.0,0.0,0.0,0.0,0.0,0.05,frances edwards,
+LIT,1270,001,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,eric touya,
+LS,1000,002,Therapeutic Yoga,0.63,0.11,0.0,0.05,0.0,0.0,0.0,0.21,ranjanbala dil amin,
+LS,1000,007,Photography,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,sarah elizab mudder,
+LS,1000,008,Intro to Volleyball,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,kelly lynn ator,
+LS,1000,013,Introduction to Sals,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,malik lewis baxter,
+LS,1130,001,Wood Carving,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,edwin eugene riggs,
+LS,1410,001,Top Rope Climbing,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,scott evan lipscomb,
+LS,1410,002,Top Rope Climbing,0.75,0.06,0.0,0.0,0.13,0.0,0.0,0.06,scott evan lipscomb,
+LS,1410,004,Top Rope Climbing,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott evan lipscomb,
+LS,1410,005,Top Rope Climbing,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,scott evan lipscomb,
+LS,1410,006,Top Rope Climbing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott evan lipscomb,
+LS,1560,001,Riflery,0.73,0.0,0.0,0.0,0.0,0.0,0.0,0.27,hubert cox,
+LS,1560,005,Riflery,0.73,0.09,0.0,0.0,0.0,0.0,0.0,0.18,hubert cox,
+LS,1560,007,Riflery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,herbert strickland,
+LS,1570,003,Shotgun Sports,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,charles flint,
+LS,1580,002,Archery,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,herbert strickland,
+LS,1580,003,Archery,0.71,0.07,0.07,0.0,0.0,0.0,0.0,0.14,herbert strickland,
+LS,1580,005,Archery,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,herbert strickland,
+LS,1640,001,Whitewater Kayaking,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,earl wade shealy,
+LS,1640,002,Whitewater Kayaking,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,robert taylor,
+LS,1750,002,Fly Fishing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael watts,
+LS,1850,003,Bowling,0.93,0.0,0.03,0.0,0.03,0.0,0.0,0.0,megan elizabet cato,
+LS,1870,002,Frisbee Sports,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,craig goodman,
+LS,1890,002,Tennis,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jennifer jo garrity,
+LS,1940,002,Racquetball,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,
+LS,1980,002,Golf,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jason jordan,
+LS,2100,001,Learn to Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,matthew lee krabbe,
+LS,2110,001,Introduction to Bell,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,stephanie pack,
+LS,2190,003,Country West Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,
+LS,2200,001,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,broadus fleming,
+LS,2200,004,Shag,0.78,0.0,0.0,0.0,0.04,0.0,0.0,0.17,broadus fleming,
+LS,2200,005,Shag,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,
+LS,2200,006,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,broadus fleming,
+LS,2200,009,Shag,0.74,0.0,0.0,0.0,0.0,0.0,0.0,0.26,matthew lee krabbe,
+LS,2210,002,Intermediate Shag,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,matthew lee krabbe,
+LS,2270,002,Intro to Swing Dance,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,
+LS,2320,001,Core Training,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,diane moreno,
+LS,2320,005,Core Training,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,2350,001,Basic Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,
+LS,2350,002,Basic Yoga,0.77,0.09,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,
+LS,2350,003,Basic Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,
+LS,2350,005,Basic Yoga,0.81,0.0,0.1,0.05,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2350,006,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2350,007,Basic Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2360,001,Power/Ashtanga Yoga,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
+LS,2360,002,Power/Ashtanga Yoga,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
+LS,2370,001,Kripalu Yoga,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,
+LS,2370,002,Kripalu Yoga,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,
+LS,2370,003,Kripalu Yoga,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,ashley austi lester,
+LS,2420,003,Meditation and Relax,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,jenefer nadenicek,
+LS,2420,006,Meditation and Relax,0.71,0.21,0.04,0.0,0.04,0.0,0.0,0.0,ani reina-nunnelley,
+LS,2420,007,Meditation and Relax,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
+LS,2450,003,Pilates,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,melanie ivey job,
+LS,2500,001,Marathon Training,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,john walston dunn,
+LS,2510,002,Running & Jogging,0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,corey dou brookover,
+LS,2660,001,Hapkido,0.79,0.04,0.0,0.04,0.0,0.0,0.0,0.13,kelly smith,
+LS,2700,001,Sports Officiating,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher war cox,
+LS,2780,002,Wilderness First Aid,0.73,0.09,0.0,0.0,0.0,0.0,0.0,0.18,emily grace turke,
+MATH,1010,001,Essen Math for Infor,0.27,0.33,0.21,0.12,0.06,0.0,0.0,0.0,judith cottingham,
+MATH,1010,002,Essen Math for Infor,0.25,0.33,0.25,0.0,0.08,0.0,0.0,0.08,qijun he,
+MATH,1010,003,Essen Math for Infor,0.23,0.38,0.31,0.0,0.08,0.0,0.0,0.0,paran rebeka norton,
+MATH,1010,004,Essen Math for Infor,0.39,0.33,0.17,0.06,0.06,0.0,0.0,0.0,merle glick,
+MATH,1010,005,Essen Math for Infor,0.32,0.37,0.11,0.05,0.11,0.0,0.0,0.05,paran rebeka norton,
+MATH,1010,006,Essen Math for Infor,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,vito capuano,
+MATH,1010,007,Essen Math for Infor,0.29,0.47,0.12,0.06,0.0,0.0,0.0,0.06,qijun he,
+MATH,1010,009,Essen Math for Infor,0.5,0.11,0.22,0.0,0.11,0.0,0.0,0.06,vito capuano,
+MATH,1010,010,Essen Math for Infor,0.65,0.12,0.12,0.06,0.0,0.0,0.0,0.06,merle glick,
+MATH,1010,011,Essen Math for Infor,0.39,0.33,0.14,0.11,0.03,0.0,0.0,0.0,judith cottingham,
+MATH,1010,012,Essen Math for Infor,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,megan elizabet ryan,
+MATH,1010,014,Essen Math for Infor,0.25,0.42,0.17,0.0,0.17,0.0,0.0,0.0,megan elizabet ryan,
+MATH,1010,015,Essen Math for Infor,0.0,0.31,0.38,0.23,0.0,0.0,0.0,0.08,sergey charnyi,
+MATH,1010,113,Essen Math for Infor,0.4,0.23,0.2,0.03,0.07,0.0,0.0,0.07,marilyn reba,
+MATH,1010,113,Essen Math for Infor,0.4,0.23,0.2,0.03,0.07,0.0,0.0,0.07,meredith nicol burr,
+MATH,1020,001,Intro to Mathematica,0.17,0.17,0.22,0.17,0.22,0.0,0.0,0.06,tony thanh nguyen,
+MATH,1020,002,Intro to Mathematica,0.0,0.26,0.32,0.16,0.16,0.0,0.0,0.11, morales hernandez,
+MATH,1020,003,Intro to Mathematica,0.06,0.18,0.29,0.29,0.18,0.0,0.0,0.0,"rodriguez esperanza,",
+MATH,1020,004,Intro to Mathematica,0.24,0.41,0.24,0.0,0.06,0.0,0.0,0.06,margaret milliken,
+MATH,1020,005,Intro to Mathematica,0.28,0.33,0.28,0.0,0.06,0.0,0.0,0.06,amy christine grady,
+MATH,1020,006,Intro to Mathematica,0.37,0.17,0.26,0.11,0.06,0.0,0.0,0.03,warren adams,
+MATH,1020,007,Intro to Mathematica,0.21,0.26,0.37,0.0,0.16,0.0,0.0,0.0,tony thanh nguyen,
+MATH,1020,008,Intro to Mathematica,0.26,0.42,0.21,0.05,0.0,0.0,0.0,0.05,kevin wayne dettman,
+MATH,1020,009,Intro to Mathematica,0.32,0.47,0.05,0.11,0.0,0.0,0.0,0.05,"rodriguez esperanza,",
+MATH,1020,010,Intro to Mathematica,0.3,0.35,0.15,0.1,0.1,0.0,0.0,0.0,yisu jia,
+MATH,1020,011,Intro to Mathematica,0.29,0.35,0.18,0.0,0.12,0.0,0.0,0.06,mengying xiao,
+MATH,1020,012,Intro to Mathematica,0.22,0.19,0.22,0.14,0.19,0.0,0.0,0.03,abigail bowers,
+MATH,1020,013,Intro to Mathematica,0.26,0.31,0.26,0.06,0.06,0.0,0.0,0.06,randy davidson,
+MATH,1020,014,Intro to Mathematica,0.33,0.28,0.14,0.03,0.19,0.0,0.0,0.03,abigail bowers,
+MATH,1020,015,Intro to Mathematica,0.32,0.21,0.21,0.05,0.16,0.0,0.0,0.05, morales hernandez,
+MATH,1020,016,Intro to Mathematica,0.21,0.26,0.32,0.16,0.05,0.0,0.0,0.0,isaac justus,
+MATH,1020,017,Intro to Mathematica,0.32,0.05,0.37,0.11,0.11,0.0,0.0,0.05,margaret milliken,
+MATH,1020,018,Intro to Mathematica,0.33,0.28,0.17,0.11,0.06,0.0,0.0,0.06,thanh thien to,
+MATH,1020,019,Intro to Mathematica,0.32,0.32,0.05,0.05,0.26,0.0,0.0,0.0,david james rea,
+MATH,1020,020,Intro to Mathematica,0.35,0.18,0.18,0.18,0.06,0.0,0.0,0.06,liu zhu,
+MATH,1020,021,Intro to Mathematica,0.22,0.44,0.06,0.06,0.22,0.0,0.0,0.0,isaac justus,
+MATH,1020,022,Intro to Mathematica,0.32,0.11,0.21,0.05,0.21,0.0,0.0,0.11,amy christine grady,
+MATH,1020,023,Intro to Mathematica,0.29,0.12,0.41,0.0,0.06,0.0,0.0,0.12,thanh thien to,
+MATH,1020,024,Intro to Mathematica,0.35,0.35,0.06,0.06,0.12,0.0,0.0,0.06,liu zhu,
+MATH,1020,025,Intro to Mathematica,0.0,0.41,0.12,0.24,0.06,0.0,0.0,0.18,mengying xiao,
+MATH,1020,026,Intro to Mathematica,0.22,0.17,0.22,0.17,0.17,0.0,0.0,0.06,trevor scot vilardi,
+MATH,1020,027,Intro to Mathematica,0.32,0.26,0.21,0.05,0.16,0.0,0.0,0.0,luke marti giberson,
+MATH,1020,028,Intro to Mathematica,0.33,0.22,0.0,0.17,0.17,0.0,0.0,0.11,david james rea,
+MATH,1020,029,Intro to Mathematica,0.21,0.24,0.26,0.21,0.09,0.0,0.0,0.0, erwin walker,
+MATH,1020,030,Intro to Mathematica,0.42,0.31,0.08,0.08,0.11,0.0,0.0,0.0,randy davidson,
+MATH,1020,031,Intro to Mathematica,0.06,0.53,0.24,0.06,0.06,0.0,0.0,0.06,samuel jose shesman,
+MATH,1020,032,Intro to Mathematica,0.06,0.29,0.35,0.0,0.18,0.0,0.0,0.12,kevin wayne dettman,
+MATH,1020,033,Intro to Mathematica,0.12,0.29,0.29,0.18,0.12,0.0,0.0,0.0,trevor scot vilardi,
+MATH,1020,034,Intro to Mathematica,0.11,0.37,0.16,0.11,0.21,0.0,0.0,0.05,abigail bowers,
+MATH,1020,035,Intro to Mathematica,0.22,0.38,0.25,0.13,0.0,0.0,0.0,0.03, erwin walker,
+MATH,1020,036,Intro to Mathematica,0.27,0.36,0.09,0.06,0.15,0.0,0.0,0.06,abigail bowers,
+MATH,1020,037,Intro to Mathematica,0.33,0.33,0.06,0.11,0.17,0.0,0.0,0.0,luke marti giberson,
+MATH,1020,038,Intro to Mathematica,0.17,0.22,0.33,0.06,0.11,0.0,0.0,0.11,yisu jia,
+MATH,1040,001,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.68,0.27,0.05,donna simms,
+MATH,1040,002,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.56,0.27,0.18,jennifer mari hanna,
+MATH,1040,003,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.44,0.42,0.14,abdullah al mamun,
+MATH,1040,004,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.64,0.24,0.11,jennifer mari hanna,
+MATH,1040,005,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.44,0.44,0.12,christa con johnson,
+MATH,1040,006,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.51,0.36,0.13,jennifer mari hanna,
+MATH,1040,007,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.38,0.53,0.09,fiona may knoll,
+MATH,1040,008,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.56,0.33,0.11,jason to hedetniemi,
+MATH,1040,009,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.33,0.65,0.02,jason lee joyner,
+MATH,1040,010,Precalc & Intro Diff,0.0,0.0,0.0,0.0,0.0,0.45,0.47,0.08,christa con johnson,
+MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.67,0.29,0.04,eliza dar gallagher,
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.64,0.34,0.02,eliza dar gallagher,
+MATH,1060,001,Calculus of One Vari,0.32,0.27,0.18,0.09,0.05,0.0,0.0,0.09,charity watson,
+MATH,1060,002,Calculus of One Vari,0.02,0.3,0.3,0.09,0.17,0.0,0.0,0.13,javier ruiz ramirez,
+MATH,1060,003,Calculus of One Vari,0.17,0.33,0.19,0.06,0.11,0.0,0.0,0.14,allen anderso guest,
+MATH,1060,004,Calculus of One Vari,0.34,0.09,0.29,0.11,0.09,0.0,0.0,0.09,allen anderso guest,
+MATH,1060,005,Calculus of One Vari,0.36,0.38,0.1,0.05,0.07,0.0,0.0,0.05,charity watson,
+MATH,1060,006,Calculus of One Vari,0.15,0.42,0.23,0.06,0.06,0.0,0.0,0.08,meredith nicol burr,
+MATH,1060,007,Calculus of One Vari,0.27,0.41,0.16,0.05,0.07,0.0,0.0,0.05,charity watson,
+MATH,1060,008,Calculus of One Vari,0.2,0.32,0.2,0.1,0.14,0.0,0.0,0.04,sherry biggers,
+MATH,1060,009,Calculus of One Vari,0.24,0.22,0.24,0.08,0.08,0.0,0.0,0.14,meredith nicol burr,
+MATH,1060,010,Calculus of One Vari,0.27,0.41,0.14,0.05,0.11,0.0,0.0,0.02,honghai xu,
+MATH,1060,011,Calculus of One Vari,0.17,0.27,0.25,0.1,0.13,0.0,0.0,0.08,charles johnson,
+MATH,1060,012,Calculus of One Vari,0.19,0.27,0.21,0.15,0.08,0.0,0.0,0.1,sherry biggers,
+MATH,1060,013,Calculus of One Vari,0.13,0.17,0.17,0.15,0.15,0.0,0.0,0.25,stefan adam bock,
+MATH,1060,014,Calculus of One Vari,0.22,0.35,0.18,0.07,0.07,0.0,0.0,0.11,audrey nico devries,
+MATH,1060,015,Calculus of One Vari,0.2,0.27,0.27,0.12,0.1,0.0,0.0,0.04,rachel eli grotheer,
+MATH,1060,016,Calculus of One Vari,0.28,0.19,0.14,0.12,0.09,0.0,0.0,0.19,charles johnson,
+MATH,1060,017,Calculus of One Vari,0.1,0.38,0.24,0.02,0.12,0.0,0.0,0.14,charles johnson,
+MATH,1060,018,Calculus of One Vari,0.11,0.38,0.13,0.09,0.11,0.0,0.0,0.19,sherry biggers,
+MATH,1060,019,Calculus of One Vari,0.31,0.28,0.19,0.03,0.17,0.0,0.0,0.03,marilyn reba,
+MATH,1060,020,Calculus of One Vari,0.23,0.25,0.27,0.05,0.09,0.0,0.0,0.11,rebecca ramos,
+MATH,1060,100,Calc of One Variable,0.42,0.33,0.0,0.08,0.0,0.0,0.0,0.17,james ba coykendall,True
+MATH,1060,201,Calculus of One Vari,0.43,0.21,0.14,0.0,0.21,0.0,0.0,0.0,james peterson,
+MATH,1060,202,Calculus of One Vari,0.67,0.06,0.22,0.0,0.06,0.0,0.0,0.0,james peterson,
+MATH,1070,001,Differen and Integra,0.08,0.23,0.38,0.18,0.13,0.0,0.0,0.03,donna simms,
+MATH,1080,001,Calculus of One Vari,0.1,0.2,0.15,0.03,0.33,0.0,0.0,0.2,sarah eliz anderson,
+MATH,1080,002,Calculus of One Vari,0.08,0.18,0.18,0.05,0.18,0.0,0.0,0.33,terri johnson,
+MATH,1080,003,Calculus of One Vari,0.11,0.14,0.22,0.03,0.19,0.0,0.0,0.31,dania moham zantout,
+MATH,1080,004,Calculus of One Vari,0.08,0.16,0.05,0.24,0.16,0.0,0.0,0.32,beth novick,
+MATH,1080,005,Calculus of One Vari,0.05,0.13,0.1,0.08,0.43,0.0,0.0,0.23,terri johnson,
+MATH,1080,006,Calculus of One Vari,0.22,0.17,0.22,0.12,0.1,0.0,0.0,0.17,dania moham zantout,
+MATH,1080,007,Calculus of One Vari,0.07,0.07,0.1,0.12,0.37,0.0,0.0,0.27,karyn muir,
+MATH,1080,008,Calculus of One Vari,0.14,0.17,0.24,0.12,0.19,0.0,0.0,0.14,anastasia br wilson,
+MATH,1080,009,Calculus of One Vari,0.0,0.08,0.18,0.05,0.54,0.0,0.0,0.15,beth novick,
+MATH,1080,010,Calculus of One Vari,0.11,0.27,0.14,0.05,0.3,0.0,0.0,0.14,shih-wei chao,
+MATH,1080,011,Calculus of One Vari,0.27,0.21,0.18,0.12,0.03,0.0,0.0,0.18,dania moham zantout,
+MATH,1080,100,Calc of One Variable,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,james brown,True
+MATH,1150,001,Contemp Math for Ele,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1150,002,Contemp Math for Ele,0.59,0.31,0.09,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1160,001,Contemp Math for Ele,0.8,0.1,0.07,0.03,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,1990,400,Problem Solving in M,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,marion hanna,
+MATH,2060,001,Calculus of Several,0.16,0.27,0.25,0.11,0.18,0.0,0.0,0.02,minerva rios-adams,
+MATH,2060,002,Calculus of Several,0.26,0.21,0.21,0.07,0.14,0.0,0.0,0.12,gretchen matthews,
+MATH,2060,003,Calculus of Several,0.32,0.42,0.13,0.05,0.03,0.0,0.0,0.05,xin liu,
+MATH,2060,004,Calculus of Several,0.22,0.22,0.3,0.17,0.04,0.0,0.0,0.04,chanseok park,
+MATH,2060,005,Calculus of Several,0.51,0.22,0.18,0.02,0.07,0.0,0.0,0.0,qingshan chen,
+MATH,2060,006,Calculus of Several,0.09,0.03,0.36,0.03,0.21,0.0,0.0,0.27,eleanor jenkins,
+MATH,2060,007,Calculus of Several,0.38,0.31,0.11,0.04,0.11,0.0,0.0,0.04,minerva rios-adams,
+MATH,2060,008,Calculus of Several,0.14,0.28,0.14,0.08,0.22,0.0,0.0,0.14,gretchen matthews,
+MATH,2060,009,Calculus of Several,0.16,0.32,0.25,0.09,0.14,0.0,0.0,0.05,minerva rios-adams,
+MATH,2060,010,Calculus of Several,0.12,0.18,0.24,0.15,0.26,0.0,0.0,0.06,shari prevost,
+MATH,2060,011,Calculus of Several,0.53,0.22,0.1,0.08,0.02,0.0,0.0,0.04,martin joha schmoll,
+MATH,2060,012,Calculus of Several,0.2,0.28,0.28,0.11,0.11,0.0,0.0,0.02,timothy ch teitloff,
+MATH,2060,013,Calculus of Several,0.13,0.44,0.33,0.0,0.09,0.0,0.0,0.0,brian fralix,
+MATH,2060,014,Calculus of Several,0.29,0.29,0.16,0.08,0.11,0.0,0.0,0.08,gretchen matthews,
+MATH,2060,015,Calculus of Several,0.49,0.27,0.14,0.0,0.08,0.0,0.0,0.03,sofya alekseeva,
+MATH,2060,016,Calculus of Several,0.51,0.25,0.18,0.02,0.02,0.0,0.0,0.02,shitao liu,
+MATH,2060,017,Calculus of Several,0.33,0.47,0.17,0.0,0.03,0.0,0.0,0.0,irina viktorova,
+MATH,2060,018,Calculus of Several,0.28,0.21,0.19,0.09,0.23,0.0,0.0,0.0,timothy ch teitloff,
+MATH,2060,019,Calculus of Several,0.42,0.37,0.18,0.0,0.0,0.0,0.0,0.03,irina viktorova,
+MATH,2060,020,Calculus of Several,0.19,0.36,0.19,0.17,0.08,0.0,0.0,0.0,nathan jos adelgren,
+MATH,2060,021,Calculus of Several,0.26,0.36,0.25,0.04,0.04,0.0,0.0,0.06,timothy ch teitloff,
+MATH,2060,022,Calculus of Several,0.57,0.23,0.11,0.03,0.06,0.0,0.0,0.0,sofya alekseeva,
+MATH,2060,100,Calc of Several Vars,0.4,0.4,0.0,0.05,0.0,0.0,0.0,0.15,shari prevost,True
+MATH,2070,001,Multivariable Calcul,0.16,0.21,0.32,0.05,0.21,0.0,0.0,0.05,alistair bentley,
+MATH,2070,002,Multivariable Calcul,0.18,0.12,0.29,0.12,0.06,0.0,0.0,0.24,elaine ma sotherden,
+MATH,2070,003,Multivariable Calcul,0.28,0.22,0.17,0.06,0.17,0.0,0.0,0.11,kara ail stasikelis,
+MATH,2070,004,Multivariable Calcul,0.24,0.24,0.12,0.03,0.18,0.0,0.0,0.18,hui xue,
+MATH,2070,005,Multivariable Calcul,0.27,0.18,0.18,0.0,0.09,0.0,0.0,0.27,elaine ma sotherden,
+MATH,2070,006,Multivariable Calcul,0.21,0.21,0.32,0.11,0.11,0.0,0.0,0.05,alistair bentley,
+MATH,2070,007,Multivariable Calcul,0.06,0.28,0.28,0.0,0.22,0.0,0.0,0.17,saba za alkaseasbeh,
+MATH,2070,008,Multivariable Calcul,0.2,0.23,0.14,0.14,0.2,0.0,0.0,0.09,judith irene mcknew,
+MATH,2070,009,Multivariable Calcul,0.32,0.11,0.11,0.21,0.21,0.0,0.0,0.05,kara ail stasikelis,
+MATH,2070,010,Multivariable Calcul,0.22,0.22,0.11,0.11,0.28,0.0,0.0,0.06, ushijima-mwesigwa,
+MATH,2070,011,Multivariable Calcul,0.12,0.36,0.15,0.15,0.06,0.0,0.0,0.15,judith irene mcknew,
+MATH,2070,012,Multivariable Calcul,0.09,0.11,0.26,0.17,0.17,0.0,0.0,0.2,saba za alkaseasbeh,
+MATH,2070,013,Multivariable Calcul,0.29,0.24,0.35,0.06,0.0,0.0,0.0,0.06,liem nguyen,
+MATH,2070,014,Multivariable Calcul,0.06,0.61,0.17,0.0,0.11,0.0,0.0,0.06,garrett dranichak,
+MATH,2070,015,Multivariable Calcul,0.22,0.33,0.22,0.0,0.11,0.0,0.0,0.11,liem nguyen,
+MATH,2070,016,Multivariable Calcul,0.33,0.22,0.17,0.06,0.17,0.0,0.0,0.06, ushijima-mwesigwa,
+MATH,2070,017,Multivariable Calcul,0.17,0.5,0.11,0.0,0.11,0.0,0.0,0.11,grady mcgowa thomas,
+MATH,2070,018,Multivariable Calcul,0.2,0.13,0.13,0.2,0.27,0.0,0.0,0.07,garrett dranichak,
+MATH,2070,019,Multivariable Calcul,0.12,0.18,0.35,0.0,0.35,0.0,0.0,0.0,grady mcgowa thomas,
+MATH,2070,020,Multivariable Calcul,0.33,0.17,0.08,0.08,0.08,0.0,0.0,0.25,saba za alkaseasbeh,
+MATH,2080,001,Intro to Ordin Diff,0.36,0.21,0.27,0.03,0.06,0.0,0.0,0.06,peter kiessler,
+MATH,2080,002,Intro to Ordin Diff,0.33,0.31,0.14,0.03,0.11,0.0,0.0,0.08,timothy fra parrott,
+MATH,2080,003,Intro to Ordin Diff,0.08,0.23,0.23,0.08,0.23,0.0,0.0,0.15,shari prevost,
+MATH,2080,004,Intro to Ordin Diff,0.06,0.31,0.25,0.06,0.19,0.0,0.0,0.13,julie lassiter,
+MATH,2080,005,Intro to Ordin Diff,0.47,0.11,0.22,0.03,0.11,0.0,0.0,0.06,timothy fra parrott,
+MATH,2080,006,Intro to Ordin Diff,0.13,0.19,0.23,0.06,0.16,0.0,0.0,0.23,julie lassiter,
+MATH,2080,007,Intro to Ordin Diff,0.28,0.22,0.22,0.11,0.08,0.0,0.0,0.08,timothy fra parrott,
+MATH,2080,008,Intro to Ordin Diff,0.68,0.24,0.05,0.0,0.03,0.0,0.0,0.0,irina viktorova,
+MATH,2080,009,Intro to Ordin Diff,0.29,0.29,0.29,0.0,0.11,0.0,0.0,0.03,brandon gra goodell,
+MATH,2080,100,Intro to Ordin Diff,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True
+MATH,2160,001,Geometry for Elem Sc,0.63,0.26,0.0,0.07,0.04,0.0,0.0,0.0,allison stoddard,
+MATH,2160,002,Geometry for Elem Sc,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,2500,001,Intro to Mathematica,0.8,0.11,0.06,0.0,0.0,0.0,0.0,0.03,daniel warner,
+MATH,3020,001,Stat for Science & E,0.29,0.29,0.29,0.14,0.0,0.0,0.0,0.0,yanbo xia,
+MATH,3020,002,Stat for Science & E,0.21,0.35,0.24,0.0,0.06,0.0,0.0,0.15,calvin williams,
+MATH,3020,003,Stat for Science & E,0.09,0.41,0.29,0.0,0.0,0.0,0.0,0.21,calvin williams,
+MATH,3020,004,Stat for Science & E,0.67,0.0,0.07,0.0,0.07,0.0,0.0,0.2,yanbo xia,
+MATH,3020,005,Stat for Science & E,0.46,0.23,0.21,0.08,0.0,0.0,0.0,0.03,michael thom finney,
+MATH,3020,006,Stat for Science & E,0.45,0.26,0.13,0.0,0.08,0.0,0.0,0.08,christopher mcmahan,
+MATH,3020,007,Stat for Science & E,0.76,0.18,0.0,0.0,0.03,0.0,0.0,0.03,dominique morgan,
+MATH,3110,001,Linear Algebra,0.13,0.21,0.21,0.13,0.21,0.0,0.0,0.13,mishko mitkovski,
+MATH,3110,002,Linear Algebra,0.35,0.16,0.16,0.06,0.1,0.0,0.0,0.16,xuhong gao,
+MATH,3110,003,Linear Algebra,0.21,0.21,0.21,0.14,0.1,0.0,0.0,0.14,felice manganiello,
+MATH,3110,004,Linear Algebra,0.49,0.2,0.11,0.06,0.09,0.0,0.0,0.06,xiaoqian sun,
+MATH,3110,005,Linear Algebra,0.3,0.33,0.18,0.09,0.06,0.0,0.0,0.03,svetlan poznanovikj,
+MATH,3110,100,Linear Algebra (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,True
+MATH,3160,001,Prob Solving for Mat,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,3190,001,Introduction to Proo,0.57,0.17,0.04,0.0,0.17,0.0,0.0,0.04,michael adam burr,
+MATH,3190,002,Introduction to Proo,0.54,0.08,0.31,0.0,0.0,0.0,0.0,0.08,michael adam burr,
+MATH,3600,001,Intermediate Math Co,0.4,0.27,0.07,0.03,0.13,0.0,0.0,0.1,neil calkin,
+MATH,3650,001,Numerical Mthds for,0.14,0.24,0.24,0.21,0.1,0.0,0.0,0.07,christopher cox,
+MATH,3650,002,Numerical Mthds for,0.12,0.24,0.21,0.12,0.06,0.0,0.0,0.24,christopher cox,
+MATH,3650,003,Numerical Mthds for,0.32,0.44,0.12,0.03,0.03,0.0,0.0,0.06,timo johann heister,
+MATH,3650,004,Numerical Mthds for,0.17,0.26,0.29,0.09,0.06,0.0,0.0,0.14,vincent ervin,
+MATH,3990,001,CI in Mathematical S,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+MATH,3990,001,CI in Mathematical S,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,laura jane shick,
+MATH,4000,001,Theory of Probabilit,0.48,0.08,0.28,0.04,0.12,0.0,0.0,0.0,derek brown,
+MATH,4000,002,Theory of Probabilit,0.44,0.15,0.24,0.06,0.03,0.0,0.0,0.09,yingbo li,
+MATH,4070,001,Regress & Time-Serie,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,4120,001,Intro to Modern Alge,0.08,0.17,0.5,0.08,0.08,0.0,0.0,0.08,xuhong gao,
+MATH,4120,002,Intro to Modern Alge,0.3,0.3,0.13,0.17,0.1,0.0,0.0,0.0,kevin james,
+MATH,4190,001,Discrete Math Struct,0.48,0.3,0.09,0.12,0.0,0.0,0.0,0.0,beth novick,
+MATH,4310,001,Theory of Interest,0.53,0.24,0.06,0.06,0.06,0.0,0.0,0.06, erwin walker,
+MATH,4340,001,Adv Engineering Math,0.17,0.2,0.23,0.07,0.07,0.0,0.0,0.27,eleanor jenkins,
+MATH,4340,002,Adv Engineering Math,0.15,0.35,0.18,0.06,0.03,0.0,0.0,0.24,hyesuk lee,
+MATH,4400,001,Linear Programming,0.41,0.23,0.18,0.05,0.09,0.0,0.0,0.05,akshay sunil gupte,
+MATH,4530,001,Advanced Calculus I,0.18,0.53,0.18,0.03,0.03,0.0,0.0,0.06,taufiquar rahm khan,
+MATH,4540,001,Advanced Calculus II,0.15,0.46,0.31,0.08,0.0,0.0,0.0,0.0,taufiquar rahm khan,
+MATH,6120,001,Intro to Modern Alge,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,kevin james,
+MATH,6340,001,Adv Engineering Math,0.34,0.41,0.15,0.0,0.05,0.0,0.0,0.05,vincent ervin,
+MATH,6530,001,Advanced Calculus I,0.14,0.57,0.14,0.0,0.0,0.0,0.0,0.14,taufiquar rahm khan,
+MATH,8000,001,Probability,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
+MATH,8010,001,General Linear Hypot,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,xiaoqian sun,
+MATH,8040,001,Statistical Inferenc,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,
+MATH,8050,001,Data Analysis,0.73,0.18,0.05,0.0,0.0,0.0,0.0,0.05,derek brown,
+MATH,8100,001,Mathematical Program,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,matthew saltzman,
+MATH,8120,001,Discrete Optimizatio,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
+MATH,8140,001,Network Flow Program,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,warren adams,
+MATH,8170,001,Stochastic Mod in Op,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,peter kiessler,
+MATH,8190,001,Multicriteria Optimi,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,
+MATH,8210,001,Linear Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,
+MATH,8230,001,Complex Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,
+MATH,8510,001,Abstract Algebra I,0.57,0.14,0.14,0.0,0.0,0.0,0.0,0.14,felice manganiello,
+MATH,8530,001,Matrix Analysis,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,james brown,
+MATH,8550,001,Combinatorial Analys,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,
+MATH,8600,001,Intro to Scientific,0.46,0.23,0.08,0.0,0.0,0.0,0.0,0.23,timo johann heister,
+MATH,8610,001,Advanced Numerical A,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
+MATH,8650,001,Data Structures,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel warner,
+MATH,8840,001,Statistics for Exper,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+MATH,9810,001,Sel Top in Math Stat,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,yingbo li,
+MATH,9830,001,Sel Top in Computati,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,qingshan chen,
+MBA,8030,001,Stat Analy of Bus Op,0.46,0.43,0.09,0.0,0.03,0.0,0.0,0.0,yuhong he,
+MBA,8060,001,Operations Mgt,0.31,0.51,0.07,0.0,0.02,0.0,0.0,0.09, sridharan,
+MBA,8070,001,Financial Management,0.45,0.32,0.05,0.0,0.05,0.0,0.0,0.14,ramon tolb franklin,
+MBA,8090,001,Org Beh & Hum Res Mg,0.55,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8090,002,Org Beh & Hum Res Mg,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8190,001,Intro to Acc and Fin,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,
+MBA,8190,001,Intro to Acc and Fin,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,william hol johnson,
+MBA,8290,001,Marketing Foundation,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,gary hunter,
+MBA,8330,001,Real Estate Investmt,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,
+MBA,8350,001,Investment Mgmt,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,uma sridharan,
+MBA,8360,001,Real Estate Principl,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
+MBA,8370,001,Legal Environ of Bus,0.39,0.43,0.16,0.0,0.0,0.0,0.0,0.02,judson jahn,
+MBA,8400,001,Entrepreneurship & V,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
+MBA,8420,001,R E Valuation,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,charles benja stone,
+MBA,8430,001,Entrepreneurial Acco,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
+MBA,8440,001,Entrepreneurial Law,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,melinda davis lux,
+MBA,8450,001,Tech & Innova Mgt,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8480,001,Entrpr Mkting & Digi,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MBA,8490,005,Entrepreneurial Strg,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8510,001,Bus Operations & Log,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MBA,8540,001,Mgrl Accounting,0.34,0.57,0.03,0.0,0.03,0.0,0.0,0.03,charles ellio davis,
+MBA,8590,001,Mgr Decision Model,0.47,0.22,0.13,0.0,0.09,0.0,0.0,0.09,sara elizabet yoder,
+MBA,8590,002,Mgr Decision Model,0.72,0.09,0.07,0.0,0.02,0.0,0.0,0.11,mark mcknew,
+MBA,8600,001,Advanced Marketing S,0.34,0.55,0.11,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8600,002,Advanced Marketing S,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8610,001,Information Systems,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MBA,8620,001,Managerial Economics,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,scott templeton,
+MBA,8620,002,Managerial Economics,0.72,0.23,0.04,0.0,0.0,0.0,0.0,0.0,stephen knec layton,
+MBA,8700,001,Strategic Management,0.55,0.43,0.02,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
+MBA,8990,002,Creativity,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,
+MBA,8990,003,International Busine,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,judson jahn,
+ME,2000,001,Sophomore Seminar,0.89,0.08,0.01,0.0,0.01,0.0,0.0,0.01,todd schweisinger,
+ME,2010,001,Statics & Dynamics,0.07,0.11,0.2,0.17,0.37,0.0,0.0,0.09,sherrill biggers,
+ME,2010,002,Statics & Dynamics,0.18,0.21,0.23,0.09,0.21,0.0,0.0,0.07,paul joseph,
+ME,2010,003,Statics & Dynamics,0.02,0.14,0.14,0.08,0.45,0.0,0.0,0.16,kalyan chakr katuri,
+ME,2030,001,Founda Th/Fl Syst,0.3,0.47,0.16,0.03,0.04,0.0,0.0,0.0,david zumbrunnen,
+ME,2040,001,Mechanics of Materia,0.15,0.38,0.34,0.08,0.05,0.0,0.0,0.0,michael porter,
+ME,2040,002,Mechanics of Materia,0.11,0.21,0.52,0.08,0.04,0.0,0.0,0.03,huijuan zhao,
+ME,2220,001,Mech Engr Lab I,0.19,0.44,0.38,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,002,Mech Engr Lab I,0.22,0.5,0.22,0.0,0.06,0.0,0.0,0.0,todd schweisinger,
+ME,2220,003,Mech Engr Lab I,0.15,0.75,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,005,Mech Engr Lab I,0.35,0.45,0.2,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,006,Mech Engr Lab I,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,todd schweisinger,
+ME,2220,007,Mech Engr Lab I,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3000,001,Junior Honors Semina,0.0,0.0,0.0,0.0,0.0,0.91,0.0,0.09,paul joseph,True
+ME,3030,002,Thermodynamics,0.31,0.4,0.2,0.07,0.0,0.0,0.0,0.02,richard miller,
+ME,3030,003,Thermodynamics,0.06,0.13,0.31,0.16,0.22,0.0,0.0,0.11,john saylor,
+ME,3040,001,Heat Transfer,0.19,0.26,0.32,0.14,0.03,0.0,0.0,0.06,jay ochterbeck,
+ME,3050,001,Model/an Dy Syst,0.21,0.32,0.3,0.02,0.06,0.0,0.0,0.09,mohammed fari daqaq,
+ME,3050,002,Model/an Dy Syst,0.12,0.67,0.18,0.03,0.0,0.0,0.0,0.0,yue wang,
+ME,3060,002,Fund Machine Design,0.26,0.43,0.2,0.07,0.0,0.0,0.0,0.04,todd schweisinger,
+ME,3060,003,Fund Machine Design,0.26,0.47,0.15,0.0,0.06,0.0,0.0,0.06,oliver myers,
+ME,3070,001,Found of Mechanical,0.32,0.42,0.12,0.04,0.04,0.0,0.0,0.06,lonny thompson,
+ME,3070,002,Found of Mechanical,0.09,0.56,0.29,0.06,0.0,0.0,0.0,0.0,gregory mocko,
+ME,3080,001,Fluid Mechanics,0.05,0.14,0.52,0.14,0.05,0.0,0.0,0.1,jean-marc delhaye,
+ME,3080,002,Fluid Mechanics,0.16,0.34,0.41,0.07,0.0,0.0,0.0,0.01,xiangchun xuan,
+ME,3080,003,Fluid Mechanics,0.38,0.28,0.26,0.03,0.05,0.0,0.0,0.0,marija vukicevic,
+ME,3120,001,Manuf Processes,0.5,0.38,0.05,0.02,0.0,0.0,0.0,0.05,hong seok choi,
+ME,3120,002,Manuf Processes,0.18,0.47,0.22,0.08,0.06,0.0,0.0,0.0,rod martinez-duarte,
+ME,3330,001,Mech Engr Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,002,Mech Engr Lab II,0.31,0.5,0.0,0.06,0.0,0.0,0.0,0.13,todd schweisinger,
+ME,3330,003,Mech Engr Lab II,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,004,Mech Engr Lab II,0.19,0.5,0.19,0.0,0.0,0.0,0.0,0.13,todd schweisinger,
+ME,3330,005,Mech Engr Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,006,Mech Engr Lab II,0.08,0.85,0.0,0.0,0.0,0.0,0.0,0.08,todd schweisinger,
+ME,3330,007,Mech Engr Lab II,0.13,0.56,0.31,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,008,Mech Engr Lab II,0.19,0.56,0.13,0.0,0.0,0.0,0.0,0.13,todd schweisinger,
+ME,4000,001,Senior Seminar,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03, ramasubramanian,
+ME,4010,001,Mech Engr Design,0.41,0.38,0.12,0.08,0.0,0.0,0.0,0.01,joshua summers,
+ME,4020,001,Intern in Engr Des,0.0,0.58,0.42,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,002,Intern in Engr Des,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,ethan kung,
+ME,4020,002,Intern in Engr Des,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,kalyan chakr katuri,
+ME,4020,004,Intern in Engr Des,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,4020,005,Intern in Engr Des,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
+ME,4030,001,Control Dynamic Syst,0.33,0.31,0.24,0.08,0.0,0.0,0.0,0.03,ardalan vahidi,
+ME,4180,001,F E A in M E Design,0.29,0.5,0.08,0.05,0.05,0.0,0.0,0.03,gang li,
+ME,4200,001,Ener Sources/Utiliz,0.26,0.54,0.2,0.0,0.0,0.0,0.0,0.0,david zumbrunnen,
+ME,4210,001,Intro to Comp Flow,0.38,0.19,0.27,0.12,0.0,0.0,0.0,0.04,chenning tong,
+ME,4400,001,Matls for Aggr Envir,0.58,0.33,0.04,0.04,0.0,0.0,0.0,0.0,mica grujicic,
+ME,4440,001,Mech Engr Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,004,Mech Engr Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4540,001,Design of Machine El,0.36,0.24,0.24,0.08,0.04,0.0,0.0,0.04,paul jeffrey meyer,
+ME,6210,001,Intro to Comp Flow,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,chenning tong,
+ME,6540,001,Des Machine Elements,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,
+ME,6930,001,Selected Topics Me:T,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,8010,001,Found of Fluid Mech,0.26,0.22,0.44,0.0,0.04,0.0,0.0,0.04,richard figliola,
+ME,8100,001,Macroscopic Thermo,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,jay ochterbeck,
+ME,8140,001,Turb Bound Layer,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,
+ME,8180,001,Intro to Fin Ele Ana,0.76,0.18,0.03,0.0,0.01,0.0,0.0,0.01,lonny thompson,
+ME,8230,001,Control Systems,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,8370,001,Theory of Elast I,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
+ME,8430,001,Advanced Dynamics,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,phanin tallapragada,
+ME,8460,001,Inter Dynamics,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,mohammed fari daqaq,
+ME,8700,001,Adv Design Methods,0.47,0.26,0.21,0.0,0.03,0.0,0.0,0.03,georges fadel,
+ME,8710,001,Engr Optimization,0.57,0.34,0.04,0.0,0.02,0.0,0.0,0.04,georges fadel,
+ME,8930,027,ME SpecTopic - Optim,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,ardalan vahidi,
+MGT,2010,001,Principles of Mgt,0.31,0.37,0.21,0.05,0.06,0.0,0.0,0.01,katherine clark,
+MGT,2010,002,Principles of Mgt,0.38,0.32,0.15,0.06,0.05,0.0,0.0,0.06,katherine clark,
+MGT,2010,003,Principles of Mgt,0.36,0.36,0.19,0.03,0.04,0.0,0.0,0.01,katherine clark,
+MGT,2010,004,Principles of Mgt,0.11,0.27,0.42,0.07,0.03,0.0,0.0,0.1,katherine clark,
+MGT,2010,005,Principles of Mgt,0.31,0.41,0.14,0.06,0.0,0.0,0.0,0.08,tina robbins,
+MGT,2010,006,Principles of Mgt,0.29,0.36,0.23,0.02,0.04,0.0,0.0,0.06,tina robbins,
+MGT,2010,007,Principles of Mgt,0.25,0.37,0.22,0.06,0.07,0.0,0.0,0.02,tina robbins,
+MGT,2010,008,Principles of Mgt,0.25,0.32,0.19,0.07,0.09,0.0,0.0,0.09,tina robbins,
+MGT,2010,009,Principles of Mgt(HO,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,tina robbins,True
+MGT,2180,125,Management PC Applic,0.44,0.41,0.12,0.01,0.01,0.0,0.0,0.01, sridharan,
+MGT,2180,125,Management PC Applic,0.44,0.41,0.12,0.01,0.01,0.0,0.0,0.01,ryan toole,
+MGT,2180,200,Management PC Applic,0.43,0.34,0.14,0.02,0.0,0.0,0.0,0.07, sridharan,
+MGT,2180,200,Management PC Applic,0.43,0.34,0.14,0.02,0.0,0.0,0.0,0.07,ryan toole,
+MGT,2180,230,Management PC Applic,0.57,0.34,0.05,0.01,0.0,0.0,0.0,0.03, sridharan,
+MGT,2180,230,Management PC Applic,0.57,0.34,0.05,0.01,0.0,0.0,0.0,0.03,ryan toole,
+MGT,2180,905,Management PC Applic,0.47,0.34,0.11,0.02,0.02,0.0,0.0,0.04,ryan toole,
+MGT,2180,905,Management PC Applic,0.47,0.34,0.11,0.02,0.02,0.0,0.0,0.04, sridharan,
+MGT,3070,001,Human Resource Manag,0.19,0.68,0.06,0.0,0.03,0.0,0.0,0.03,kristin dam scott,
+MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,
+MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,
+MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03,katherine clark,
+MGT,3070,003,Human Resource Manag,0.23,0.48,0.25,0.03,0.0,0.0,0.0,0.03, sridharan,
+MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,katherine clark,
+MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,marvin monroe ward,
+MGT,3070,004,Human Resource Manag,0.23,0.33,0.35,0.08,0.0,0.0,0.0,0.03,marvin monroe ward,
+MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,marvin monroe ward,
+MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,marvin monroe ward,
+MGT,3070,005,Human Resource Manag,0.24,0.22,0.41,0.05,0.08,0.0,0.0,0.0,katherine clark,
+MGT,3070,006,Human Resource Manag,0.28,0.44,0.15,0.05,0.05,0.0,0.0,0.03,michael cole,
+MGT,3070,007,Human Resource Manag,0.41,0.51,0.05,0.0,0.03,0.0,0.0,0.0,michael cole,
+MGT,3100,001,Intermed Business St,0.15,0.3,0.13,0.08,0.23,0.0,0.0,0.13,sara elizabet yoder,
+MGT,3100,002,Intermed Business St,0.23,0.23,0.3,0.08,0.08,0.0,0.0,0.1,sara elizabet yoder,
+MGT,3100,003,Intermed Business St,0.39,0.14,0.25,0.14,0.06,0.0,0.0,0.03,sara elizabet yoder,
+MGT,3100,005,Intermed Business St,0.28,0.28,0.25,0.13,0.0,0.0,0.0,0.08,zachary mo leffakis,
+MGT,3100,006,Intermed Business St,0.55,0.3,0.13,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3100,007,Intermed Business St,0.44,0.36,0.11,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3100,008,Intermed Business St,0.33,0.23,0.26,0.03,0.03,0.0,0.0,0.13,zachary mo leffakis,
+MGT,3100,009,Intermed Business St,0.07,0.27,0.17,0.07,0.05,0.0,0.0,0.37,niratc tungtisanont,
+MGT,3100,011,Intermed Business St,0.27,0.4,0.17,0.0,0.07,0.0,0.0,0.1,yuhong he,
+MGT,3100,B,Intermed Business St,0.29,0.44,0.15,0.07,0.05,0.0,0.0,0.0,james walsh,
+MGT,3120,001,Decision Models for,0.29,0.15,0.44,0.07,0.05,0.0,0.0,0.0,mark mcknew,
+MGT,3120,002,Decision Models for,0.09,0.49,0.29,0.0,0.11,0.0,0.0,0.02,mark mcknew,
+MGT,3120,003,Decision Models for,0.18,0.42,0.33,0.02,0.04,0.0,0.0,0.0,mark mcknew,
+MGT,3150,001,New Venture Creation,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
+MGT,3180,001,Mgt of Info Systems,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,heshan sun,
+MGT,3180,002,Mgt of Info Systems,0.45,0.45,0.08,0.0,0.0,0.0,0.0,0.03,heshan sun,
+MGT,3180,003,Mgt of Info Systems,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,dan jiang,
+MGT,3180,004,Mgt of Info Systems,0.3,0.45,0.08,0.03,0.15,0.0,0.0,0.0,tina marie esposito,
+MGT,3900,001,Ops Mgt,0.19,0.58,0.14,0.03,0.0,0.0,0.0,0.06,yunsik choi,
+MGT,3900,002,Ops Mgt,0.44,0.36,0.15,0.0,0.05,0.0,0.0,0.0,qiong chen,
+MGT,3900,003,Ops Mgt,0.33,0.51,0.13,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3900,004,Ops Mgt,0.23,0.5,0.25,0.03,0.0,0.0,0.0,0.0,jerry kermi bilbrey,
+MGT,3900,005,Ops Mgt,0.18,0.48,0.33,0.03,0.0,0.0,0.0,0.0,yann ferrand,
+MGT,3900,006,Ops Mgt,0.16,0.29,0.23,0.0,0.1,0.0,0.0,0.23,qiong chen,
+MGT,3900,007,Ops Mgt,0.3,0.41,0.24,0.03,0.03,0.0,0.0,0.0,remi charpin,
+MGT,4000,001,Mgt of Org Beh,0.2,0.57,0.23,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,002,Mgt of Org Beh,0.25,0.5,0.2,0.0,0.0,0.0,0.0,0.05,michael cole,
+MGT,4000,003,Mgt of Org Beh,0.15,0.48,0.33,0.03,0.03,0.0,0.0,0.0,philip roth,
+MGT,4000,004,Mgt of Org Beh,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MGT,4020,001,Ops Pln and Ctl,0.06,0.69,0.25,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4020,002,Ops Pln and Ctl,0.15,0.69,0.08,0.08,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4030,001,Bus Intelligence & A,0.23,0.46,0.23,0.0,0.08,0.0,0.0,0.0,siyuan li,
+MGT,4080,001,Lean Operations,0.09,0.45,0.45,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MGT,4110,001,Project Management,0.21,0.53,0.18,0.0,0.03,0.0,0.0,0.05,russell purvis,
+MGT,4120,001,Supplier Management,0.04,0.64,0.28,0.04,0.0,0.0,0.0,0.0,shouqiang wang,
+MGT,4150,001,Business Strategy,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,002,Business Strategy,0.19,0.52,0.29,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
+MGT,4150,003,Business Strategy,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,004,Business Strategy,0.37,0.45,0.08,0.0,0.11,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,006,Business Strategy,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,007,Business Strategy,0.17,0.46,0.32,0.02,0.0,0.0,0.0,0.02,jason wayne ridge,
+MGT,4150,008,Business Strategy,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,
+MGT,4150,009,Business Strategy,0.27,0.51,0.11,0.05,0.0,0.0,0.0,0.05,amy elizabet ingram,
+MGT,4160,001,Special Topics Hr,0.44,0.44,0.08,0.03,0.0,0.0,0.0,0.0,kristin dam scott,
+MGT,4230,001,Intern Bus Mgt,0.19,0.31,0.44,0.03,0.03,0.0,0.0,0.0,wayne stewart,
+MGT,4230,002,Intern Bus Mgt,0.24,0.26,0.38,0.06,0.06,0.0,0.0,0.0,wayne stewart,
+MGT,4230,003,Intern Bus Mgt,0.0,0.49,0.4,0.06,0.06,0.0,0.0,0.0,janis miller,
+MGT,4230,004,Intern Bus Mgt,0.1,0.51,0.29,0.03,0.02,0.0,0.0,0.05,janis miller,
+MGT,4240,001,Global Supply Chain,0.2,0.63,0.09,0.03,0.0,0.0,0.0,0.06,yann ferrand,
+MGT,4270,001,Managing Improvement,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MGT,4300,001,Statistical Modeling,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,jerry kermi bilbrey,
+MGT,4310,001,Emp Rights & Resp,0.18,0.58,0.2,0.03,0.0,0.0,0.0,0.03,marvin monroe ward,
+MGT,4350,001,Pers Interviewing,0.33,0.38,0.2,0.1,0.0,0.0,0.0,0.0,philip roth,
+MGT,4520,001,Business Analysis,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jackie patri london,
+MGT,4550,001,Emerging I T Trends,0.39,0.53,0.06,0.0,0.0,0.0,0.0,0.03,jason thatcher,
+MGT,4560,001,Business Info Mgt,0.33,0.25,0.33,0.08,0.0,0.0,0.0,0.0,siyuan li,
+MGT,8690,001,Project Mgt,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+MGT,9050,001,Research Methods,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,varun grover,
+MHA,7210,001,Hlth Care Del Sys,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
+MICR,1010,001,Microbes & Hum Aff,0.58,0.21,0.12,0.02,0.06,0.0,0.0,0.01,michael childress,
+MICR,1010,001,Microbes & Hum Aff,0.58,0.21,0.12,0.02,0.06,0.0,0.0,0.01,thomas hughes,
+MICR,2050,001,Introductory Micro,0.42,0.42,0.15,0.0,0.0,0.0,0.0,0.01,john abercrombie,
+MICR,3050,001,General Microbiology,0.53,0.25,0.16,0.06,0.0,0.0,0.0,0.01,krista barr rudolph,
+MICR,3050,002,General Microbiology,0.32,0.46,0.17,0.04,0.0,0.0,0.0,0.02,krista barr rudolph,
+MICR,4010,001,Microbial Diversity,0.17,0.32,0.2,0.15,0.05,0.0,0.0,0.12,barbara campbell,
+MICR,4050,001,Adv Microbial Ecol o,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4140,001,Basic Immunology,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,yanzhang wei,
+MICR,4150,001,Microbial Genetics,0.25,0.31,0.25,0.17,0.02,0.0,0.0,0.0,min cao,
+MICR,4250,001,Microbial Gen Lab,0.71,0.14,0.0,0.14,0.0,0.0,0.0,0.0,min cao,
+MICR,4250,002,Microbial Gen Lab,0.68,0.18,0.14,0.0,0.0,0.0,0.0,0.0,min cao,
+MKT,3010,001,Prin of Marketing,0.21,0.59,0.17,0.02,0.0,0.0,0.0,0.01,james gaubert,
+MKT,3010,002,Prin of Marketing,0.15,0.44,0.3,0.07,0.04,0.0,0.0,0.0,carter wil mcelveen,
+MKT,3010,003,Prin of Marketing,0.25,0.47,0.21,0.05,0.02,0.0,0.0,0.01,carter wil mcelveen,
+MKT,3010,004,Prin of Marketing,0.28,0.42,0.28,0.02,0.0,0.0,0.0,0.0,carter wil mcelveen,
+MKT,3010,005,Prin of Marketing,0.15,0.41,0.29,0.08,0.03,0.0,0.0,0.03,amanda cooper fine,
+MKT,3010,006,Prin of Marketing,0.16,0.48,0.24,0.08,0.02,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,007,Prin of Marketing,0.21,0.39,0.33,0.05,0.01,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,008,Prin of Marketing,0.33,0.42,0.15,0.03,0.06,0.0,0.0,0.0,patricia knowles,
+MKT,3020,001,Consumer Behavior,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,002,Consumer Behavior,0.43,0.45,0.11,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,003,Consumer Behavior,0.36,0.5,0.1,0.02,0.02,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3020,004,Consumer Behavior,0.4,0.34,0.24,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3210,001,Sports Marketing,0.43,0.43,0.11,0.0,0.0,0.0,0.0,0.04,delancy bennett,
+MKT,4200,001,Professional Selling,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,gary hunter,
+MKT,4200,002,Professional Selling,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,003,Professional Selling,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,jesse moore,
+MKT,4200,004,Professional Selling,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,ryan mullins,
+MKT,4230,001,Promotional Strategy,0.2,0.44,0.31,0.02,0.02,0.0,0.0,0.0,patricia knowles,
+MKT,4240,001,Sales Management,0.32,0.58,0.03,0.0,0.0,0.0,0.0,0.06,ryan mullins,
+MKT,4260,001,Business-to-Business,0.24,0.53,0.2,0.0,0.0,0.0,0.0,0.02,james gaubert,
+MKT,4270,001,International Mktg,0.27,0.58,0.11,0.04,0.0,0.0,0.0,0.0,roger gomes,
+MKT,4270,002,International Mktg,0.24,0.46,0.22,0.07,0.0,0.0,0.0,0.02,roger gomes,
+MKT,4270,003,International Mktg,0.16,0.64,0.14,0.07,0.0,0.0,0.0,0.0,roger gomes,
+MKT,4270,004,International Mktg,0.19,0.53,0.19,0.0,0.0,0.0,0.0,0.08,thomas poehlman,
+MKT,4280,001,Services Marketing,0.23,0.44,0.33,0.0,0.0,0.0,0.0,0.0,stephen grove,
+MKT,4280,002,Services Marketing,0.05,0.74,0.21,0.0,0.0,0.0,0.0,0.0,stephen grove,
+MKT,4310,001,Marketing Research,0.18,0.5,0.27,0.05,0.0,0.0,0.0,0.0,peter weathers,
+MKT,4310,002,Marketing Research,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,003,Marketing Research,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,004,Marketing Research,0.16,0.72,0.08,0.0,0.0,0.0,0.0,0.04,william kilbourne,
+MKT,4430,001,Advertising Strategy,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,
+MKT,4450,001,Macromarketing,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
+MKT,4500,001,Strategic Mktg Mgt,0.14,0.62,0.24,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,002,Strategic Mktg Mgt,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,4500,003,Strategic Mktg Mgt,0.16,0.76,0.08,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4950,001,Marketing Metrics,0.23,0.46,0.23,0.08,0.0,0.0,0.0,0.0,peter weathers,
+MKT,8610,001,Marketing Research,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,christopher hopkins,
+MKT,8630,001,Buyer Behavior,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,thomas poehlman,
+ML,1010,001,Leadership Fund I,0.72,0.16,0.0,0.0,0.0,0.0,0.0,0.12,robert rozetar,
+ML,1010,001,Leadership Fund I,0.72,0.16,0.0,0.0,0.0,0.0,0.0,0.12,joe luis medrano,
+ML,1010,002,Leadership Fund I,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,robert rozetar,
+ML,1010,002,Leadership Fund I,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,joe luis medrano,
+ML,2010,001,Leadership Develop I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,
+ML,2010,001,Leadership Develop I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,rene romo,
+ML,2010,002,Leadership Develop I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,rene romo,
+ML,2010,002,Leadership Develop I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,
+ML,3010,001,Adv Leadership I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jason danie bielski,
+ML,3010,001,Adv Leadership I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,
+ML,3010,002,Adv Leadership I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,
+ML,3010,002,Adv Leadership I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jason danie bielski,
+ML,4010,001,Org Leadership I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
+ML,4010,001,Org Leadership I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,phillip ale andrews,
+ML,4010,003,Org Leadership I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,phillip ale andrews,
+ML,4010,003,Org Leadership I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
+MSE,2100,001,Intro to Mat Science,0.4,0.33,0.16,0.05,0.03,0.0,0.0,0.03,eric skaar,
+MSE,2100,002,Intro to Mat Science,0.31,0.36,0.17,0.06,0.04,0.0,0.0,0.06,kyle brinkman,
+MSE,2100,003,Intro to Mat Science,0.25,0.38,0.19,0.07,0.02,0.0,0.0,0.09,eric skaar,
+MSE,2100,004,Intro to Mat Science,0.33,0.4,0.14,0.03,0.04,0.0,0.0,0.05,eric skaar,
+MSE,3190,001,Materials Proc I,0.14,0.36,0.36,0.09,0.05,0.0,0.0,0.0,henry rack,
+MSE,3190,002,Materials Proc I,0.45,0.43,0.11,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,
+MSE,3190,002,Materials Proc I,0.45,0.43,0.11,0.0,0.0,0.0,0.0,0.0,olin mefford,
+MSE,3260,001,Thermo of Materials,0.26,0.5,0.18,0.03,0.0,0.0,0.0,0.03,gary lickfield,
+MSE,3260,002,Thermo of Materials,0.09,0.41,0.38,0.06,0.0,0.0,0.0,0.06,gary lickfield,
+MSE,3270,001,Transport Phenomena,0.77,0.16,0.06,0.0,0.01,0.0,0.0,0.01,konstantin kornev,
+MSE,3270,002,Transport Phenomena,0.47,0.35,0.09,0.09,0.0,0.0,0.0,0.0,fei peng,
+MSE,4020,001,Solid State Material,0.28,0.44,0.28,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,4130,001,Noncrystalline Mater,0.57,0.21,0.21,0.0,0.0,0.0,0.0,0.0,herbert david leigh,
+MSE,4150,001,Polymer Sc Engr,0.3,0.34,0.21,0.06,0.06,0.0,0.0,0.04,marek urban,
+MSE,4150,002,Polymer Sc Engr,0.35,0.35,0.15,0.11,0.01,0.0,0.0,0.02,olin mefford,
+MSE,4410,001,Mfg Laboratory,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,
+MSE,4550,001,Polymer Fiber Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,olin mefford,
+MSE,4550,002,Polymer Fiber Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,olin mefford,
+MSE,4580,001,Surf Phen in Ms&E,0.21,0.29,0.14,0.29,0.07,0.0,0.0,0.0,konstantin kornev,
+MSE,4610,001,Polymer & Fiber Mate,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,
+MSE,8010,001,Grad Sem in Material,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,
+MSE,8010,001,Grad Sem in Material,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
+MSE,8200,001,Def Mech in Solids,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,marian kennedy,
+MSE,8270,001,Kin of Phase Tran,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,
+MSE,8520,001,Polymer Science II,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,igor luzinov,
+MUSC,1110,001,Beginning Class Guit,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,david stevenson,
+MUSC,1420,001,Music Theory I,0.58,0.08,0.25,0.0,0.08,0.0,0.0,0.0,david conley,
+MUSC,1420,002,Music Theory I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,david conley,
+MUSC,2100,001,Music in West World,0.58,0.32,0.03,0.03,0.0,0.0,0.0,0.03,eric lapin,
+MUSC,2100,002,Music in West World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,lisa sain odom,
+MUSC,2100,003,Music in West World,0.84,0.1,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,2100,004,Music in West World,0.52,0.13,0.19,0.1,0.06,0.0,0.0,0.0,linda li-bleuel,
+MUSC,2100,005,Music in West World,0.83,0.1,0.05,0.0,0.02,0.0,0.0,0.0,timothy ra hurlburt,
+MUSC,2100,006,Music in West World,0.6,0.23,0.03,0.0,0.0,0.0,0.0,0.13,rhea beth jacobus,
+MUSC,2100,007,Music in West World,0.76,0.17,0.0,0.0,0.03,0.0,0.0,0.03,rhea beth jacobus,
+MUSC,2100,008,Music in West World,0.66,0.25,0.06,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
+MUSC,2100,009,Music in West World,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,evan michael jacobi,
+MUSC,2100,010,Music in West World,0.84,0.0,0.16,0.0,0.0,0.0,0.0,0.0,linda dzuris,
+MUSC,2100,012,Music in West World,0.52,0.35,0.1,0.0,0.0,0.0,0.0,0.03,lea kibler,
+MUSC,3080,001,Surv of Broadway I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey christmas,
+MUSC,3110,001,Hist of Amer Music,0.56,0.28,0.13,0.0,0.03,0.0,0.0,0.0,ned hosler,
+MUSC,3120,001,History of Jazz,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,3130,001,Hist of Rock & Roll,0.46,0.39,0.07,0.04,0.0,0.0,0.0,0.04,hamilton altstatt,
+MUSC,3170,001,Hist of Country Mus,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,ned hosler,
+MUSC,3180,001,Hist of Audio Tech,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,
+MUSC,3420,001,Women's Breakout Ens,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,david conley,
+MUSC,3610,001,Marching Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.01,timothy ra hurlburt,
+MUSC,3610,001,Marching Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
+MUSC,3630,001,Jazz Ensemble,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,timothy ra hurlburt,
+MUSC,3700,001,Clemson University S,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,justin durham,
+MUSC,3720,001,Men's Glee,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,david conley,
+MUSC,4150,001,Music Hist to 1750,0.29,0.18,0.29,0.12,0.12,0.0,0.0,0.0,justin durham,
+NPL,3000,001,Nonprofit Leadership,0.7,0.15,0.04,0.0,0.0,0.0,0.0,0.11,tracy diane lamb,
+NPL,3000,002,Nonprofit Leadership,0.72,0.12,0.04,0.0,0.08,0.0,0.0,0.04,tracy diane lamb,
+NURS,1020,001,Nrsg Success Skills,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,kristin goodenow,
+NURS,1400,001,Comp App Hlth Care,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
+NURS,3030,001,Nursing of Adults,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,corinne croc harmon,
+NURS,3030,001,Nursing of Adults,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,
+NURS,3040,001,Pathophysiology,0.52,0.46,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
+NURS,3040,400,Pathophysiology,0.43,0.38,0.1,0.0,0.05,0.0,0.0,0.05,catherine si murton,
+NURS,3040,401,Pathophysiology,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+NURS,3050,001,Psychosocial Nursing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
+NURS,3100,001,Health Assessment,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3100,400,Health Assessment,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.05,jason thrift,
+NURS,3120,001,Foundations of Nurs,0.25,0.65,0.08,0.0,0.0,0.0,0.0,0.02,angela pye,
+NURS,3120,400,Foundations of Nurs,0.14,0.81,0.0,0.0,0.0,0.0,0.0,0.05,wanda leigh taylor,
+NURS,3190,400,Health Assessment fo,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,
+NURS,3200,400,Prof in Nurs,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,mary steck,
+NURS,3230,400,Gerontology Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,tawny jenn mcintosh,
+NURS,3300,002,Research in Nursing,0.91,0.05,0.05,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,3330,400,Health Care Genetics,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,
+NURS,3400,001,Pharmther Nursing,0.43,0.43,0.06,0.06,0.02,0.0,0.0,0.02,catherine si murton,
+NURS,3400,400,Pharmther Nursing,0.29,0.52,0.05,0.05,0.05,0.0,0.0,0.05,catherine si murton,
+NURS,4010,001,Mental Health Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NURS,4030,200,Complex Nursing of A,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
+NURS,4030,230,Complex Nursing of A,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
+NURS,4100,001,Lead Mgt Practicum,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,
+NURS,4100,001,Lead Mgt Practicum,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,portia botchway,
+NURS,4100,400,Lead Mgt Practicum,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,
+NURS,4100,400,Lead Mgt Practicum,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,portia botchway,
+NURS,4110,001,Nursing of Children,0.66,0.29,0.05,0.0,0.0,0.0,0.0,0.0,heide temples,
+NURS,4120,001,Nurs Women and Fam,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4150,001,Comm Hlth Nursing,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,jackie gillespie,
+NURS,8050,400,Pharmaco Adv Nurs,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8060,400,Advan Assessment for,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,
+NURS,8060,400,Advan Assessment for,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,
+NURS,8090,400,Pathophysiology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
+NURS,8090,400,Pathophysiology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,julia eggert,
+NURS,8190,400,Developing Family,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8190,400,Developing Family,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,
+NURS,8200,400,Child & Adol Nursing,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,heide temples,
+NUTR,2030,001,Intro Princ of Human,0.42,0.34,0.15,0.02,0.02,0.0,0.0,0.04,deborah an hutcheon,
+NUTR,2050,001,Nutr for Nurs Prof,0.66,0.31,0.02,0.01,0.0,0.0,0.0,0.0,deborah an hutcheon,
+NUTR,2160,001,Evidence-Based Nutri,0.73,0.19,0.03,0.0,0.0,0.0,0.0,0.05,angela fraser,
+NUTR,4190,001,Professional Dev in,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,
+NUTR,4240,001,Medical Nutr Thera I,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,rita haliena,
+NUTR,4510,001,Human Nutrition,0.39,0.44,0.11,0.05,0.02,0.0,0.0,0.0,vivian haley-zitlin,
+PA,1010,001,Intro to Perf Arts,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,david hartmann,
+PA,1030,001,Portfolio I,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,linda dzuris,
+PA,2010,001,Career Planning and,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,ned hosler,
+PA,2790,001,Perf Arts Pract I,0.86,0.0,0.09,0.0,0.05,0.0,0.0,0.0,kenneth moore,
+PA,2800,001,Perf Arts Pract II,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,kenneth moore,
+PA,3010,001,Prin of Arts Admin,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,paul buyer,
+PADM,7020,400,Research Methods,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
+PADM,8220,400,Public Policy Proces,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,mark daniel mellott,
+PADM,8290,400,Public Financial Man,0.4,0.47,0.0,0.0,0.0,0.0,0.0,0.13,robert frager,
+PADM,8510,400,Emergency Management,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,steven batson,
+PADM,8680,400,Local Government Adm,0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,alfred bundrick,
+PADM,8780,404,COMMUNICATIONS FOR P,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,scott schmidt,
+PAS,3010,001,Pan African Studies,0.48,0.3,0.15,0.04,0.0,0.0,0.0,0.02,abel bartley,
+PDBE,8010,001,Advanced Theory in E,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
+PDBE,8010,001,Advanced Theory in E,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
+PES,1040,001,Introduction to Plan,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,paula agudelo,
+PES,2020,001,Soils,0.19,0.41,0.33,0.03,0.03,0.0,0.0,0.01,dara michelle park,
+PES,4850,001,Environmental Soil C,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
+PHIL,1010,001,Intro to Phil Prob,0.76,0.15,0.06,0.0,0.03,0.0,0.0,0.0,david stegall,
+PHIL,1010,002,Intro to Phil Prob,0.71,0.09,0.09,0.0,0.0,0.0,0.0,0.12,david stegall,
+PHIL,1010,003,Intro to Phil Prob,0.37,0.34,0.26,0.0,0.0,0.0,0.0,0.03,christopher grau,
+PHIL,1020,001,Intro to Logic,0.14,0.74,0.09,0.0,0.0,0.0,0.0,0.03,kelly smith,
+PHIL,1020,002,Intro to Logic,0.09,0.76,0.15,0.0,0.0,0.0,0.0,0.0,kelly smith,
+PHIL,1020,003,Intro to Logic,0.67,0.21,0.03,0.06,0.03,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,004,Intro to Logic,0.83,0.13,0.0,0.03,0.0,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,005,Intro to Logic,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,gregory scott moss,
+PHIL,1020,006,Intro to Logic,0.74,0.09,0.06,0.0,0.0,0.0,0.0,0.12,gregory scott moss,
+PHIL,1020,007,Intro to Logic,0.64,0.27,0.0,0.06,0.0,0.0,0.0,0.03,gregory scott moss,
+PHIL,1030,001,Intro to Ethics (HON,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True
+PHIL,1030,002,Intro to Ethics,0.29,0.29,0.17,0.14,0.09,0.0,0.0,0.03,jennifer ingle,
+PHIL,1030,003,Intro to Ethics,0.47,0.44,0.03,0.0,0.0,0.0,0.0,0.06,michael hal hannen,
+PHIL,1030,004,Intro to Ethics,0.14,0.51,0.29,0.06,0.0,0.0,0.0,0.0,jennifer ingle,
+PHIL,1030,005,Intro to Ethics,0.24,0.52,0.09,0.0,0.06,0.0,0.0,0.09,charles starkey,
+PHIL,1030,006,Intro to Ethics,0.51,0.34,0.03,0.03,0.03,0.0,0.0,0.06,ryan lake,
+PHIL,1030,008,Intro to Ethics,0.33,0.43,0.19,0.0,0.05,0.0,0.0,0.0,ryan lake,
+PHIL,1030,009,Intro to Ethics,0.51,0.37,0.09,0.0,0.0,0.0,0.0,0.03,ryan lake,
+PHIL,3030,001,Phil of Religion,0.5,0.36,0.0,0.07,0.0,0.0,0.0,0.07,gregory scott moss,
+PHIL,3040,001,Moral Philosophy,0.19,0.38,0.19,0.0,0.13,0.0,0.0,0.13,charles starkey,
+PHIL,3050,001,Existentialism,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,david stegall,
+PHIL,3150,001,Ancient Philosophy,0.18,0.43,0.25,0.07,0.07,0.0,0.0,0.0,stephen satris,
+PHIL,3160,001,Mod Phil,0.61,0.3,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
+PHIL,3170,001,19th-Century Philoso,0.15,0.27,0.27,0.06,0.09,0.0,0.0,0.15,william maker,
+PHIL,3200,001,Soc and Pol Phil,0.28,0.44,0.16,0.0,0.08,0.0,0.0,0.04,todd may,
+PHIL,3260,001,Science and Values,0.36,0.48,0.06,0.0,0.03,0.0,0.0,0.06,andrew garnar,
+PHIL,3260,002,Science and Values,0.41,0.38,0.15,0.0,0.03,0.0,0.0,0.03,andrew garnar,
+PHIL,3260,003,Science and Values,0.49,0.49,0.0,0.0,0.03,0.0,0.0,0.0,andrew garnar,
+PHIL,3430,001,Phil of Law,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,david stegall,
+PHIL,3440,001,Business Ethics,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,david stegall,
+PHIL,3450,001,Environmental Ethics,0.42,0.21,0.06,0.12,0.12,0.0,0.0,0.06,jennifer ingle,
+PHIL,3490,001,Gender and Sexuality,0.33,0.48,0.04,0.0,0.07,0.0,0.0,0.07,diane perpich,
+PHIL,3550,001,Phil Mind & Cog Sci,0.4,0.4,0.1,0.0,0.0,0.0,0.0,0.1,andrew garnar,
+PHIL,3990,001,Philosophy Portfolio,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,kelly smith,
+PHIL,4020,001,Topics in Philosophy,0.41,0.41,0.12,0.0,0.06,0.0,0.0,0.0,todd may,
+PHIL,4020,002,Topics in Philosophy,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,candice delmas,
+PHIL,4750,001,Philosophy of Film,0.27,0.45,0.09,0.09,0.0,0.0,0.0,0.09,christopher grau,
+PHSC,1180,001,Intro Phys & Astro,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,001,Physics With Cal I,0.31,0.3,0.23,0.06,0.05,0.0,0.0,0.04,lih-sin the,
+PHYS,1220,002,Physics With Cal I,0.2,0.28,0.26,0.15,0.07,0.0,0.0,0.04,lih-sin the,
+PHYS,1220,004,Phys W/Cal I (MAJ ON,0.28,0.39,0.11,0.11,0.0,0.0,0.0,0.11,murray daw,
+PHYS,1240,001,Physics Lab I,0.06,0.83,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,
+PHYS,1240,002,Physics Lab I,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,003,Physics Lab I,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,004,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,005,Physics Lab I,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,006,Physics Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,007,Physics Lab I,0.27,0.67,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,1240,008,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,009,Physics Lab I,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,010,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,011,Physics Lab I,0.06,0.82,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
+PHYS,1240,012,Physics Lab I,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,013,Physics Lab I,0.19,0.63,0.13,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,014,Physics Lab I,0.06,0.63,0.19,0.0,0.06,0.0,0.0,0.06,jerry hester,
+PHYS,1240,016,Physics Lab I,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,1240,017,Physics Lab I,0.29,0.64,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,2070,001,General Physics I,0.42,0.35,0.16,0.04,0.01,0.0,0.0,0.02,amy liann pope,
+PHYS,2070,002,General Physics I,0.52,0.33,0.09,0.02,0.01,0.0,0.0,0.02,amy liann pope,
+PHYS,2070,003,General Physics I,0.34,0.28,0.22,0.07,0.06,0.0,0.0,0.03,pooja puneet,
+PHYS,2080,001,General Physics II,0.42,0.37,0.12,0.04,0.04,0.0,0.0,0.03,pooja puneet,
+PHYS,2090,001,Gen Phys Lab I,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,002,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,003,Gen Phys Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,004,Gen Phys Lab I,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,005,Gen Phys Lab I,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,006,Gen Phys Lab I,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,007,Gen Phys Lab I,0.68,0.23,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,008,Gen Phys Lab I,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,009,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,010,Gen Phys Lab I,0.55,0.27,0.14,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,011,Gen Phys Lab I,0.38,0.42,0.17,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,012,Gen Phys Lab I,0.57,0.35,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,013,Gen Phys Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,014,Gen Phys Lab I,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,015,Gen Phys Lab I,0.26,0.57,0.09,0.0,0.0,0.0,0.0,0.09,jerry hester,
+PHYS,2090,016,Gen Phys Lab I,0.5,0.27,0.18,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,017,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,018,Gen Phys Lab I,0.55,0.41,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,019,Gen Phys Lab I,0.14,0.64,0.23,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,020,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,021,Gen Phys Lab I,0.18,0.59,0.09,0.0,0.0,0.0,0.0,0.14,jerry hester,
+PHYS,2090,022,Gen Phys Lab I,0.43,0.43,0.09,0.04,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,023,Gen Phys Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,024,Gen Phys Lab I,0.55,0.23,0.14,0.0,0.0,0.0,0.0,0.09,jerry hester,
+PHYS,2100,001,Gen Phys Lab II,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,002,Gen Phys Lab II,0.33,0.54,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,003,Gen Phys Lab II,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,004,Gen Phys Lab II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,006,Gen Phys Lab II,0.3,0.52,0.04,0.0,0.0,0.0,0.0,0.13,jerry hester,
+PHYS,2100,007,Gen Phys Lab II,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,008,Gen Phys Lab II,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2210,001,Physics With Cal II,0.2,0.5,0.21,0.06,0.02,0.0,0.0,0.01,jason stratfo brown,
+PHYS,2210,002,Physics With Cal II,0.27,0.52,0.16,0.03,0.02,0.0,0.0,0.0,jason stratfo brown,
+PHYS,2210,003,Physics With Cal II,0.35,0.46,0.12,0.03,0.02,0.0,0.0,0.02,jason stratfo brown,
+PHYS,2210,004,Physics With Cal II,0.24,0.47,0.2,0.05,0.02,0.0,0.0,0.02,lih-sin the,
+PHYS,2210,007,Physics With Cal II,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,sean brittain,True
+PHYS,2220,001,Phys With Cal III,0.28,0.5,0.11,0.06,0.06,0.0,0.0,0.0,jian he,
+PHYS,2230,001,Physics Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,002,Physics Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,003,Physics Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,004,Physics Lab II,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,005,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,006,Physics Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,007,Physics Lab II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,009,Physics Lab II,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,010,Physics Lab II,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,011,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,012,Physics Lab II,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,013,Physics Lab II,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,016,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,017,Physics Lab II,0.27,0.6,0.07,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,2450,001,Physics of Climate,0.23,0.41,0.11,0.03,0.01,0.0,0.0,0.21,john meriwether,
+PHYS,3000,001,Intro to Research,0.82,0.05,0.05,0.05,0.05,0.0,0.0,0.0,terry tritt,
+PHYS,3000,001,Intro to Research,0.82,0.05,0.05,0.05,0.05,0.0,0.0,0.0,jens oberheide,
+PHYS,3110,001,Methods Theor Phys,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,feng ding,
+PHYS,3210,001,Mechanics I,0.11,0.32,0.05,0.16,0.11,0.0,0.0,0.26,gerald lehmacher,
+PHYS,3250,001,Exper Physics I,0.28,0.67,0.0,0.0,0.0,0.0,0.0,0.06,hye jung kang,
+PHYS,3250,001,Exper Physics I,0.28,0.67,0.0,0.0,0.0,0.0,0.0,0.06,chad sosolik,
+PHYS,4420,001,Electromagnetics II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,endre andras takacs,
+PHYS,4550,001,Quantum Physics I,0.08,0.67,0.25,0.0,0.0,0.0,0.0,0.0,antony valentini,
+PHYS,6520,001,Int to Nuclear Phys,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jeremy king,
+PHYS,6550,001,Quantum Physics I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,antony valentini,
+PHYS,8110,001,Meth of Theor Phys I,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+PHYS,8210,001,Classical Mech I,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
+PHYS,8750,007,Intro to Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jens oberheide,
+PHYS,8750,007,Intro to Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,terry tritt,
+PHYS,9510,001,Quantum Mech I,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
+PKSC,1010,001,Pkgsc Orientation,0.81,0.08,0.06,0.05,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,1020,001,Intro to Pkg Sci,0.05,0.36,0.4,0.12,0.06,0.0,0.0,0.0,heather batt,
+PKSC,2020,001,Packaging Mtl & Mfg,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2040,001,Container Systems,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2200,001,Product & Pkg Design,0.69,0.23,0.06,0.0,0.0,0.0,0.0,0.02,william aaro snyder,
+PKSC,4010,001,Pkg Machinery,0.33,0.41,0.22,0.04,0.0,0.0,0.0,0.0,anthony lou pometto,
+PKSC,4030,001,Pkg Career Prep,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4040,001,Mech Prop & Prot Pkg,0.21,0.29,0.29,0.09,0.08,0.0,0.0,0.03,gregory batt,
+PKSC,4160,001,Appl Polymers in Pkg,0.09,0.44,0.35,0.07,0.02,0.0,0.0,0.02,duncan darby,
+PKSC,4200,001,Pkg Design & Dev,0.56,0.41,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4540,001,Prod Pkg Evl Lab,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,gregory batt,
+PKSC,4540,002,Prod Pkg Evl Lab,0.13,0.5,0.25,0.06,0.06,0.0,0.0,0.0,gregory batt,
+PKSC,4540,003,Prod Pkg Evl Lab,0.13,0.31,0.38,0.0,0.06,0.0,0.0,0.13,gregory batt,
+PKSC,4540,004,Prod Pkg Evl Lab,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4540,005,Prod Pkg Evl Lab,0.25,0.33,0.17,0.0,0.25,0.0,0.0,0.0,gregory batt,
+PKSC,4640,001,Fd & Hc Pkg Systems,0.3,0.63,0.03,0.03,0.0,0.0,0.0,0.0,kay cooksey,
+PLPA,3100,001,Principles of Plant,0.15,0.65,0.15,0.05,0.0,0.0,0.0,0.0,steven nye jeffers,
+POSC,1010,001,Amer National Govt,0.16,0.3,0.24,0.18,0.02,0.0,0.0,0.1,joseph earl stewart,
+POSC,1010,002,Amer National Govt,0.27,0.29,0.27,0.07,0.05,0.0,0.0,0.05,jeffrey scott peake,
+POSC,1010,003,Amer National Govt,0.13,0.51,0.18,0.07,0.04,0.0,0.0,0.07,laura olson,
+POSC,1020,001,Intro Intl Relations,0.15,0.42,0.25,0.02,0.04,0.0,0.0,0.11,aron geo tannenbaum,
+POSC,1020,002,Intro Intl Relations,0.11,0.53,0.29,0.02,0.02,0.0,0.0,0.04,lydia loui lundgren,
+POSC,1020,003,Intro Intl Relations,0.14,0.49,0.22,0.04,0.01,0.0,0.0,0.09,colin pearce,
+POSC,1030,001,Intro to Political T,0.09,0.35,0.33,0.13,0.04,0.0,0.0,0.07,james woodard,
+POSC,1030,002,Intro to Political T,0.22,0.51,0.12,0.0,0.02,0.0,0.0,0.12,jeremy fortier,
+POSC,1040,001,Intro Compar Pol,0.21,0.38,0.35,0.03,0.0,0.0,0.0,0.03,xiaobo hu,
+POSC,1040,002,Intro Compar Pol,0.17,0.56,0.21,0.04,0.02,0.0,0.0,0.0,katherine am curtis,
+POSC,1990,001,Intro Pol Sci,0.44,0.27,0.14,0.04,0.09,0.0,0.0,0.02,meredith petersheim,
+POSC,3020,001,State and Loc Gov,0.13,0.6,0.17,0.0,0.07,0.0,0.0,0.03,bruce ransom,
+POSC,3110,001,Model United Nations,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,xiaobo hu,
+POSC,3120,001,State Student Leg,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michael cunningham,
+POSC,3410,001,Quant Meth in Pol Sc,0.31,0.31,0.08,0.15,0.15,0.0,0.0,0.0,steven vince miller,
+POSC,3610,001,Intl Pol in Crisis,0.21,0.46,0.1,0.02,0.19,0.0,0.0,0.02,steven vince miller,
+POSC,3620,001,Intl Organizations,0.27,0.38,0.15,0.08,0.04,0.0,0.0,0.08,lydia loui lundgren,
+POSC,3630,001,Us Foreign Policy,0.31,0.54,0.12,0.0,0.0,0.0,0.0,0.04,vladimir matic,
+POSC,3710,001,European Politics,0.34,0.56,0.09,0.0,0.0,0.0,0.0,0.0,vladimir matic,
+POSC,4030,001,United States Congre,0.22,0.36,0.2,0.13,0.07,0.0,0.0,0.02,jeffrey allen fine,
+POSC,4210,001,Public Policy,0.27,0.09,0.27,0.09,0.09,0.0,0.0,0.18,adam warber,
+POSC,4230,001,Urban Politics,0.1,0.7,0.1,0.0,0.0,0.0,0.0,0.1,bruce ransom,
+POSC,4360,001,Law Courts Politics,0.28,0.46,0.23,0.03,0.0,0.0,0.0,0.0,joseph earl stewart,
+POSC,4370,001,Constitut Law: Right,0.47,0.43,0.07,0.0,0.03,0.0,0.0,0.0,daniel frost,
+POSC,4380,001,Constitut Law: Struc,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,
+POSC,4420,001,Pol Parties & Elect,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,laura olson,
+POSC,4500,001,Classical & Modern L,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,brandon turner,
+POSC,4550,001,Pol Thght of America,0.24,0.55,0.19,0.02,0.0,0.0,0.0,0.0, bradley thompson,
+POSC,4560,001,Diplomacy,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,vladimir matic,
+POSC,4710,001,Russian Politics,0.5,0.32,0.05,0.05,0.05,0.0,0.0,0.05,aron geo tannenbaum,
+POSC,4760,001,Middle East Politics,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,vladimir matic,
+POSC,4890,002,WWII: Ideol. in Worl,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,james woodard,
+POSC,4890,003,International Law,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,katherine am curtis,
+PRTM,1950,002,Pro Golf Management,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,herbert chancellor,
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,denise mar anderson,
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,teresa walto tucker,
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,francis mcguire,
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,elizabeth baldwin,
+PRTM,2260,001,Fnd of Mgt Adm PRTM,0.45,0.44,0.08,0.01,0.0,0.0,0.0,0.02,robert brookover,
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,elizabeth baldwin,
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,denise mar anderson,
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,teresa walto tucker,
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,robert brookover,
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,francis mcguire,
+PRTM,2270,001,Prov of Leisure Exp,0.38,0.5,0.1,0.0,0.0,0.0,0.0,0.02,herbert chancellor,
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,robert brookover,
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,francis mcguire,
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,denise mar anderson,
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,elizabeth baldwin,
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,teresa walto tucker,
+PRTM,2290,001,Comp Int in PRTM,0.46,0.41,0.1,0.01,0.01,0.0,0.0,0.02,herbert chancellor,
+PRTM,2950,001,Pro Golf Management,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3070,002,Facility Operations,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,craig goodman,
+PRTM,3200,001,Recreation Policy,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,bernard mwe kitheka,
+PRTM,3220,001,Facilitation Techniq,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,
+PRTM,3240,001,Assessment & Plannin,0.83,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3250,001,Global Persp in Rec,0.55,0.18,0.24,0.0,0.03,0.0,0.0,0.0,skye arthur-banning,
+PRTM,3300,001,Visit Ser & Interp,0.36,0.43,0.14,0.07,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,3430,001,Spl Asp of Tourist B,0.35,0.6,0.05,0.0,0.0,0.0,0.0,0.0,william norman,
+PRTM,3430,002,Spl Asp of Tourist B,0.4,0.45,0.08,0.05,0.03,0.0,0.0,0.0,william norman,
+PRTM,3450,001,Tourism Management,0.43,0.32,0.17,0.05,0.03,0.0,0.0,0.0,lauren duffy,
+PRTM,3530,002,Foundations of Camp,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,gwynn powell,
+PRTM,3920,001,Special Event Manage,0.79,0.1,0.04,0.04,0.02,0.0,0.0,0.02,kenneth backman,
+PRTM,3920,002,Special Event Manage,0.81,0.13,0.02,0.0,0.02,0.0,0.0,0.02,kenneth backman,
+PRTM,3950,001,PGM Seminar III,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3950,001,PGM Seminar III,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,3980,003,Creative Inquiry in,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,kellie aman walters,
+PRTM,3980,011,Creative Inquiry in,0.76,0.0,0.0,0.0,0.0,0.0,0.0,0.24,skye arthur-banning,
+PRTM,4030,001,Elem of Rec/Pk Plan,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
+PRTM,4070,001,Pers Admin in PRTM,0.32,0.38,0.18,0.12,0.0,0.0,0.0,0.0,daniel mor anderson,
+PRTM,4470,001,Perspect Intl Travel,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,lauren duffy,
+PRTM,4550,001,Adv Program Planning,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,4830,001,Golf Club Mgt & Ops,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,4950,001,Pro Golf Management,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,4950,001,Pro Golf Management,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,4980,001,Creative Inquiry in,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
+PRTM,4980,007,Creative Inquiry in,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,denise mar anderson,
+PRTM,4980,009,Creative Inquiry in,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,leslie conrad,
+PRTM,4980,009,Creative Inquiry in,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,8010,002,Phil Found of PRTM,0.57,0.22,0.13,0.0,0.09,0.0,0.0,0.0,dorothy schmalz,
+PRTM,8080,001,Behavioral Aspects,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,8220,002,Strateg Planning in,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,
+PRTM,8560,001,Heritage Tourism,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,
+PRTM,9000,004,The Politics of Scie,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,gary edward machlis,
+PSYC,2010,001,Intro to Psychology,0.27,0.34,0.25,0.08,0.04,0.0,0.0,0.02,edwin brainerd,
+PSYC,2010,002,Intro to Psychology,0.33,0.34,0.21,0.08,0.02,0.0,0.0,0.03,jo anne jorgensen,
+PSYC,2010,003,Intro to Psychology,0.51,0.25,0.15,0.04,0.01,0.0,0.0,0.03,chong hyon pak,
+PSYC,2010,004,Intro to Psychology,0.25,0.45,0.2,0.0,0.0,0.0,0.0,0.1,fred switzer,
+PSYC,2010,005,Intro to Psychology,0.27,0.43,0.14,0.04,0.03,0.0,0.0,0.09,mary taylor,
+PSYC,2010,006,Intro to Psychology,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,christopher pagano,True
+PSYC,2010,104,Intro to Psychology,0.33,0.47,0.16,0.0,0.02,0.0,0.0,0.02,fred switzer,
+PSYC,2020,001,Intro Psychology Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,2020,002,Intro Psychology Lab,0.76,0.06,0.0,0.06,0.12,0.0,0.0,0.0,eric mckibben,
+PSYC,2020,003,Intro Psychology Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,2020,004,Intro Psychology Lab,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,eric mckibben,
+PSYC,2020,005,Intro Psychology Lab,0.79,0.13,0.04,0.04,0.0,0.0,0.0,0.0,lauren elizab ellis,
+PSYC,2020,006,Intro Psychology Lab,0.81,0.1,0.05,0.05,0.0,0.0,0.0,0.0,hannah jeann murphy,
+PSYC,3060,001,Human Sexual Beh,0.54,0.22,0.13,0.06,0.04,0.0,0.0,0.02,bruce michael king,
+PSYC,3090,100,Intro Exp Psych,0.25,0.39,0.2,0.05,0.05,0.0,0.0,0.07,jennifer bai bisson,
+PSYC,3090,200,Intro Exp Psych,0.33,0.42,0.09,0.08,0.03,0.0,0.0,0.05,patrick rosopa,
+PSYC,3100,100,Advanced Experimenta,0.32,0.42,0.21,0.0,0.05,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimenta,0.76,0.06,0.06,0.0,0.12,0.0,0.0,0.0,robert campbell,
+PSYC,3100,300,Advanced Experimenta,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3100,400,Advanced Experimenta,0.78,0.06,0.0,0.06,0.06,0.0,0.0,0.06,alice miche brawley,
+PSYC,3100,500,Advanced Experimenta,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,allison lei wallace,
+PSYC,3100,600,Advanced Experimenta,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,3240,001,Physiological Psych,0.33,0.34,0.14,0.07,0.07,0.0,0.0,0.04,claudio cantalupo,
+PSYC,3240,002,Physiological Psych,0.25,0.41,0.16,0.1,0.07,0.0,0.0,0.0,june pilcher,
+PSYC,3330,001,Cognitive Psych,0.64,0.2,0.09,0.06,0.0,0.0,0.0,0.01,paul steven merritt,
+PSYC,3330,002,Cognitive Psych,0.72,0.13,0.12,0.01,0.0,0.0,0.0,0.01,paul steven merritt,
+PSYC,3340,001,Cognitive Psych Lab,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,phillip weis jasper,
+PSYC,3340,002,Cognitive Psych Lab,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,ashley ann sewall,
+PSYC,3400,001,Lifespan Development,0.26,0.31,0.26,0.11,0.01,0.0,0.0,0.04,pamela alley,
+PSYC,3520,001,Social Psychology,0.34,0.4,0.2,0.06,0.0,0.0,0.0,0.0,jo anne jorgensen,
+PSYC,3520,002,Social Psychology,0.32,0.39,0.24,0.03,0.0,0.0,0.0,0.01,jo anne jorgensen,
+PSYC,3520,003,Social Psychology (H,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
+PSYC,3640,001,Industrial Psych,0.56,0.31,0.09,0.01,0.03,0.0,0.0,0.0,eric mckibben,
+PSYC,3680,001,Organizational Psych,0.38,0.38,0.14,0.07,0.03,0.0,0.0,0.0,thomas britt,
+PSYC,3690,001,Leadership in Orgs,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.01,eric mckibben,
+PSYC,3830,001,Abnormal Psychology,0.29,0.26,0.23,0.17,0.06,0.0,0.0,0.0,pamela alley,
+PSYC,3830,002,Abnormal Psychology,0.42,0.39,0.14,0.06,0.0,0.0,0.0,0.0,pamela alley,
+PSYC,3830,003,Abnormal Psychology,0.37,0.34,0.18,0.08,0.0,0.0,0.0,0.03,heidi marie zinzow,
+PSYC,4080,001,Women and Psychology,0.5,0.25,0.17,0.04,0.0,0.0,0.0,0.04,robin mari kowalski,
+PSYC,4150,001,Systems and Theories,0.38,0.22,0.09,0.19,0.06,0.0,0.0,0.06,edwin brainerd,
+PSYC,4150,002,Systems and Theories,0.33,0.43,0.13,0.1,0.0,0.0,0.0,0.0,edwin brainerd,
+PSYC,4220,001,Perception,0.19,0.15,0.22,0.33,0.07,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4220,002,Perception,0.27,0.5,0.12,0.04,0.04,0.0,0.0,0.04,christopher pagano,
+PSYC,4430,001,Infant & Child Dev,0.58,0.31,0.12,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,4430,002,Infant & Child Dev,0.44,0.33,0.15,0.0,0.0,0.0,0.0,0.07,sarah mae sanborn,
+PSYC,4560,001,Psychophysiology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,eric muth,
+PSYC,4710,001,Psych of Testing,0.85,0.08,0.0,0.0,0.04,0.0,0.0,0.04,larry alton pace,
+PSYC,4800,001,Health Psychology,0.48,0.24,0.24,0.0,0.0,0.0,0.0,0.04,james mccubbin,
+PSYC,4880,002,Psychotherapy,0.84,0.04,0.04,0.0,0.04,0.0,0.0,0.04,cynthia pury,
+PSYC,4890,001,Psychology of Music,0.48,0.36,0.08,0.0,0.0,0.0,0.0,0.08,claudio cantalupo,
+PSYC,4890,001,Psychology of Music,0.48,0.36,0.08,0.0,0.0,0.0,0.0,0.08,robert campbell,
+PSYC,4890,002,Teamwork In 21st Cen,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,marissa leig porter,
+PSYC,4920,001,Senior Laboratory,0.75,0.13,0.06,0.0,0.06,0.0,0.0,0.0,amelia jea kinsella,
+PSYC,4920,002,Senior Laboratory,0.8,0.08,0.08,0.0,0.0,0.0,0.0,0.04,amelia jea kinsella,
+PSYC,4920,003,Senior Laboratory,0.76,0.14,0.0,0.05,0.0,0.0,0.0,0.05,jessica anne stahl,
+PSYC,4920,004,Senior Laboratory,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jessica anne stahl,
+PSYC,4930,001,Pract Clinical Psych,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,
+PSYC,8100,001,Research Design I,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0, dewayne moore,
+PSYC,8220,001,Percept & Perform,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard tyrrell,
+PSYC,8330,001,Adv Cog Psych,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,leo gugerty,
+PSYC,8350,001,Adv Human Factors,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,leo gugerty,
+PSYC,8680,001,Leadership in Orgs,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,patrick raymark,
+PSYC,8730,001,SEM in App Psych,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0, dewayne moore,
+PSYC,8990,003,Training & Dev,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,marissa leig porter,
+RCID,8130,002,Special Topics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
+RED,8000,001,Real Estate Dvlpment,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+RED,8160,001,Preservation Feasibi,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+REL,1010,001,Intro to Religion,0.18,0.35,0.12,0.06,0.12,0.0,0.0,0.18,peter cohen,
+REL,1010,002,Intro to Religion,0.07,0.27,0.33,0.2,0.07,0.0,0.0,0.07,peter cohen,
+REL,1010,004,Intro to Religion,0.09,0.33,0.24,0.18,0.09,0.0,0.0,0.06,peter cohen,
+REL,1020,002,World Religions,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,robert stephens,
+REL,1020,003,World Religions,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,robert stephens,
+REL,1020,004,World Religions,0.5,0.29,0.18,0.04,0.0,0.0,0.0,0.0,robert stephens,
+REL,1020,005,World Religions,0.58,0.27,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,
+REL,3010,001,Old Testament,0.44,0.38,0.16,0.0,0.03,0.0,0.0,0.0,steven grosby,
+REL,3020,001,New Testament Lit,0.39,0.52,0.06,0.03,0.0,0.0,0.0,0.0,benjamin white,
+REL,3100,002,History of Religion,0.19,0.38,0.13,0.06,0.06,0.0,0.0,0.19,james brad jeffries,
+REL,3120,001,Hinduism,0.71,0.14,0.04,0.0,0.0,0.0,0.0,0.11,robert stephens,
+REL,3150,001,Islam,0.35,0.42,0.13,0.03,0.06,0.0,0.0,0.0,mashal saif,
+REL,4010,001,Stud Biblical Litera,0.53,0.27,0.0,0.0,0.0,0.0,0.0,0.2,steven grosby,
+RS,3010,001,Rural Sociology,0.26,0.44,0.26,0.0,0.0,0.0,0.0,0.04,kenneth robinson,
+RUSS,1010,001,Elementary Russian,0.46,0.23,0.08,0.08,0.08,0.0,0.0,0.08,joan bridgwood,
+SOC,2010,003,Introduction to Soci,0.37,0.29,0.24,0.05,0.03,0.0,0.0,0.01,stephani southworth,
+SOC,2010,004,Introduction to Soci,0.16,0.51,0.18,0.09,0.04,0.0,0.0,0.02,mary louise barr,
+SOC,2010,007,Introduction to Soci,0.37,0.41,0.13,0.04,0.02,0.0,0.0,0.02,stephani southworth,
+SOC,2010,009,Introduction to Soci,0.21,0.51,0.23,0.0,0.04,0.0,0.0,0.0,stephani southworth,
+SOC,2010,010,Introduction to Soci,0.47,0.43,0.08,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,011,Introduction to Soci,0.41,0.35,0.2,0.02,0.0,0.0,0.0,0.02,jennifer le holland,
+SOC,2010,012,Introduction to Soci,0.54,0.33,0.08,0.0,0.0,0.0,0.0,0.04,jennifer le holland,
+SOC,2010,013,Introduction to Soci,0.37,0.43,0.15,0.04,0.0,0.0,0.0,0.0,stephani southworth,
+SOC,2010,014,Introduction to Soci,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
+SOC,2010,015,Introduction to Soci,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
+SOC,2010,016,Introduction to Soci,0.52,0.45,0.02,0.0,0.0,0.0,0.0,0.01,jeffrey edwards,
+SOC,2010,018,Introduction to Soci,0.34,0.3,0.21,0.11,0.02,0.0,0.0,0.02,mary louise barr,
+SOC,2010,019,Introduction to Soci,0.39,0.5,0.08,0.03,0.0,0.0,0.0,0.0,mary louise barr,
+SOC,2010,020,Introduction to Soci,0.21,0.37,0.31,0.07,0.01,0.0,0.0,0.02,mary louise barr,
+SOC,2050,001,Sociology Lab,0.64,0.0,0.06,0.0,0.19,0.0,0.0,0.11,brenda vander mey,
+SOC,2050,002,Sociology Lab,0.71,0.0,0.0,0.06,0.18,0.0,0.0,0.06,brenda vander mey,
+SOC,3020,001,Research Methods I,0.17,0.42,0.25,0.14,0.0,0.0,0.0,0.03,andrew whitehead,
+SOC,3040,001,Research Methods II,0.3,0.33,0.13,0.2,0.03,0.0,0.0,0.0,ye luo,
+SOC,3600,001,Class & Poverty,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,william wentworth,
+SOC,3880,001,Criminal Justice,0.15,0.44,0.38,0.02,0.0,0.0,0.0,0.0,margaret tina britz,
+SOC,3890,001,Criminology,0.2,0.2,0.22,0.12,0.17,0.0,0.0,0.1,william white,
+SOC,3910,001,Soc of Deviance,0.15,0.39,0.26,0.09,0.04,0.0,0.0,0.07,william white,
+SOC,3920,001,Juvenile Delinquency,0.25,0.29,0.23,0.1,0.08,0.0,0.0,0.04,william white,
+SOC,3940,001,Soc Mental Illness,0.57,0.26,0.13,0.0,0.0,0.0,0.0,0.04,douglas sturkie,
+SOC,3970,001,Substance Abuse,0.63,0.24,0.08,0.0,0.0,0.0,0.0,0.04,jeffrey edwards,
+SOC,4030,001,"Technol, Environment",0.26,0.37,0.21,0.05,0.11,0.0,0.0,0.0, catherine mobley,
+SOC,4040,001,Soc Theory,0.35,0.32,0.18,0.06,0.06,0.0,0.0,0.03,william wentworth,
+SOC,4140,001,Policy&Social Change,0.34,0.59,0.07,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,4320,001,Soc of Religion,0.43,0.24,0.16,0.12,0.04,0.0,0.0,0.0,andrew whitehead,
+SOC,4330,001,Global Social Change,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,william haller,
+SOC,4440,001,Sociology of Educ,0.18,0.43,0.14,0.11,0.0,0.0,0.0,0.14,stephani southworth,
+SOC,4600,001,Race & Ethnicity,0.52,0.24,0.24,0.0,0.0,0.0,0.0,0.0,brenda vander mey,
+SOC,4680,001,Criminal Evidence,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
+SOC,4970,001,Senior Lab,0.44,0.12,0.36,0.0,0.08,0.0,0.0,0.0,brenda vander mey,
+SOC,8030,001,Sur Dsgn App Res Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,
+SOC,8300,001,Human Systems Dev,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,ellen granberg,
+SPAN,1010,001,Elementary Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1010,002,Elementary Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1010,003,Elementary Spanish,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1020,001,Elementary Spanish,0.17,0.44,0.17,0.0,0.0,0.0,0.0,0.22,roger simpson,
+SPAN,1020,002,Elementary Spanish,0.22,0.44,0.11,0.11,0.06,0.0,0.0,0.06,roger simpson,
+SPAN,1020,003,Elementary Spanish,0.44,0.39,0.11,0.06,0.0,0.0,0.0,0.0,roger simpson,
+SPAN,1020,004,Elementary Spanish,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,roger simpson,
+SPAN,1020,005,Elementary Spanish,0.21,0.37,0.21,0.05,0.05,0.0,0.0,0.11,roger simpson,
+SPAN,1020,006,Elementary Spanish,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,cathy robison,
+SPAN,1020,007,Elementary Spanish,0.4,0.33,0.2,0.0,0.0,0.0,0.0,0.07,cathy robison,
+SPAN,1020,008,Elementary Spanish,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,ricardo tremolada,
+SPAN,1020,009,Elementary Spanish,0.44,0.33,0.06,0.0,0.0,0.0,0.0,0.17,ricardo tremolada,
+SPAN,1020,010,Elementary Spanish,0.35,0.41,0.24,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,1020,011,Elementary Spanish,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,1020,012,Elementary Spanish,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
+SPAN,1020,013,Elementary Spanish,0.61,0.0,0.28,0.06,0.06,0.0,0.0,0.0,allison ann hinds,
+SPAN,1020,014,Elementary Spanish,0.41,0.29,0.06,0.06,0.0,0.0,0.0,0.18,allison ann hinds,
+SPAN,1020,015,Elementary Spanish,0.44,0.19,0.06,0.19,0.0,0.0,0.0,0.13,ricardo tremolada,
+SPAN,2010,001,Intermediate Spanish,0.26,0.26,0.32,0.11,0.0,0.0,0.0,0.05,cathy robison,
+SPAN,2010,002,Intermediate Spanish,0.13,0.56,0.06,0.06,0.0,0.0,0.0,0.19,cathy robison,
+SPAN,2010,003,Intermediate Spanish,0.33,0.28,0.33,0.0,0.0,0.0,0.0,0.06,maureen zamora,
+SPAN,2010,004,Intermediate Spanish,0.37,0.26,0.16,0.0,0.05,0.0,0.0,0.16,ellory schmucker,
+SPAN,2010,005,Intermediate Spanish,0.46,0.23,0.15,0.15,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2010,007,Intermediate Spanish,0.13,0.4,0.27,0.13,0.0,0.0,0.0,0.07,heidi montes,
+SPAN,2010,008,Intermediate Spanish,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2010,009,Intermediate Spanish,0.35,0.41,0.18,0.0,0.06,0.0,0.0,0.0,ricardo tremolada,
+SPAN,2010,010,Intermediate Spanish,0.39,0.28,0.11,0.22,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,011,Intermediate Spanish,0.0,0.31,0.38,0.15,0.08,0.0,0.0,0.08,melva margu persico,
+SPAN,2010,013,Intermediate Spanish,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,ze cruz valderramos,
+SPAN,2010,014,Intermediate Spanish,0.33,0.5,0.06,0.0,0.06,0.0,0.0,0.06,maureen zamora,
+SPAN,2010,015,Intermediate Spanish,0.37,0.42,0.05,0.0,0.05,0.0,0.0,0.11,ricardo tremolada,
+SPAN,2010,016,Intermediate Spanish,0.28,0.56,0.17,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,
+SPAN,2010,017,Intermediate Spanish,0.44,0.19,0.19,0.13,0.06,0.0,0.0,0.0,maureen zamora,
+SPAN,2010,018,Intermediate Spanish,0.29,0.24,0.29,0.12,0.0,0.0,0.0,0.06,kari daus carson,
+SPAN,2010,022,Intermediate Spanish,0.31,0.31,0.19,0.0,0.06,0.0,0.0,0.13,heidi montes,
+SPAN,2010,023,Intermediate Spanish,0.07,0.5,0.21,0.07,0.0,0.0,0.0,0.14,maureen zamora,
+SPAN,2010,024,Intermediate Spanish,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,allison ann hinds,
+SPAN,2020,001,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,002,Intermediate Spanish,0.22,0.28,0.28,0.11,0.06,0.0,0.0,0.06,melva margu persico,
+SPAN,2020,003,Intermediate Spanish,0.33,0.11,0.39,0.17,0.0,0.0,0.0,0.0,kari daus carson,
+SPAN,2020,004,Intermediate Spanish,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,005,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2020,006,Intermediate Spanish,0.37,0.37,0.16,0.11,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2020,007,Intermediate Spanish,0.24,0.41,0.12,0.06,0.0,0.0,0.0,0.18,melva margu persico,
+SPAN,2020,008,Intermediate Spanish,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,2020,009,Intermediate Spanish,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,ellory schmucker,
+SPAN,2020,010,Intermediate Spanish,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,011,Intermediate Spanish,0.32,0.42,0.11,0.11,0.0,0.0,0.0,0.05,kari daus carson,
+SPAN,2020,012,Intermediate Spanish,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,juana martin-armas,
+SPAN,2020,013,Intermediate Spanish,0.22,0.61,0.11,0.06,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,3020,001,Int Spn Gram & Comp,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
+SPAN,3050,002,Int Con Comp Span I,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,raquel anido,
+SPAN,3050,003,Int Con Comp Span I,0.32,0.42,0.16,0.0,0.0,0.0,0.0,0.11,raquel anido,
+SPAN,3080,001,Hispanic World: La,0.63,0.21,0.0,0.0,0.05,0.0,0.0,0.11,george palacios,
+SPAN,3080,002,Hispanic World: La,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,tiffany dawn miller,
+SPAN,3090,001,Intro to Span Phont,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,daniel smith,
+SPAN,3110,001,Surv Span-Amer Lit,0.13,0.4,0.2,0.07,0.13,0.0,0.0,0.07,tiffany dawn miller,
+SPAN,3130,001,Span Lit Survey I,0.2,0.4,0.13,0.0,0.0,0.0,0.0,0.27,mon rojas-de-massei,
+SPAN,3130,002,Span Lit Survey I,0.27,0.4,0.2,0.07,0.0,0.0,0.0,0.07,mon rojas-de-massei,
+SPAN,3140,001,Hispanic Linguistics,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
+SPAN,3180,001,Span Through Culture,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,george palacios,
+SPAN,4030,001,Span Amer Wom Writer,0.3,0.4,0.1,0.0,0.2,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,4060,001,Narrative Fiction,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,mon rojas-de-massei,
+SPAN,4060,002,Narrative Fiction,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,
+SPAN,4070,001,Hispanic Film,0.5,0.31,0.06,0.06,0.0,0.0,0.0,0.06,raquel anido,
+SPAN,4190,001,Health & Hisp Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+STAT,2220,001,Statistics in Everyd,0.33,0.36,0.25,0.04,0.0,0.0,0.0,0.02,ros martinez-dawson,
+STAT,2220,002,Statistics in Everyd,0.36,0.28,0.23,0.08,0.02,0.0,0.0,0.04,james espey,
+STAT,2220,003,Statistics in Everyd,0.35,0.33,0.21,0.1,0.02,0.0,0.0,0.0,april thomas,
+STAT,2220,004,Statistics in Everyd,0.41,0.48,0.09,0.0,0.0,0.0,0.0,0.02,benjamin sharp,
+STAT,2220,005,Statistics in Everyd,0.37,0.29,0.31,0.02,0.02,0.0,0.0,0.0,james espey,
+STAT,2220,006,Statistics in Everyd,0.39,0.28,0.33,0.0,0.0,0.0,0.0,0.0,christopher wilson,
+STAT,2220,007,Statistics in Everyd,0.28,0.5,0.17,0.06,0.0,0.0,0.0,0.0,christopher wilson,
+STAT,2300,001,Statistical Methods,0.37,0.29,0.14,0.13,0.04,0.0,0.0,0.03,richard stev dubsky,
+STAT,2300,002,Statistical Methods,0.46,0.29,0.16,0.05,0.0,0.0,0.0,0.04,richard stev dubsky,
+STAT,2300,003,Statistical Methods,0.48,0.27,0.11,0.04,0.07,0.0,0.0,0.02,ros martinez-dawson,
+STAT,2300,004,Statistical Methods,0.38,0.32,0.13,0.08,0.09,0.0,0.0,0.01,christy jenki brown,
+STAT,2300,005,Statistical Methods,0.3,0.33,0.28,0.06,0.0,0.0,0.0,0.04,christy jenki brown,
+STAT,2300,006,Statistical Methods,0.35,0.29,0.24,0.05,0.03,0.0,0.0,0.03,jun luo,
+STAT,2300,008,Statistical Methods,0.46,0.35,0.12,0.03,0.02,0.0,0.0,0.02,richard stev dubsky,
+STAT,2300,009,Statistical Methods,0.42,0.31,0.14,0.07,0.01,0.0,0.0,0.04,christy jenki brown,
+STAT,3090,001,Introductory Busines,0.16,0.32,0.16,0.14,0.14,0.0,0.0,0.08,paul james cubre,
+STAT,3090,002,Introductory Busines,0.05,0.42,0.37,0.11,0.05,0.0,0.0,0.0,emily marie nystrom,
+STAT,3090,003,Introductory Busines,0.11,0.22,0.44,0.0,0.17,0.0,0.0,0.06,ziwen cheng,
+STAT,3090,004,Introductory Busines,0.48,0.32,0.14,0.05,0.02,0.0,0.0,0.0,lucas waddell,
+STAT,3090,005,Introductory Busines,0.33,0.26,0.33,0.0,0.05,0.0,0.0,0.05,gary fellers,
+STAT,3090,006,Introductory Busines,0.21,0.32,0.26,0.11,0.11,0.0,0.0,0.0,emily marie nystrom,
+STAT,3090,007,Introductory Busines,0.16,0.53,0.16,0.11,0.0,0.0,0.0,0.05,janie caro mcdonald,
+STAT,3090,008,Introductory Busines,0.3,0.32,0.25,0.05,0.07,0.0,0.0,0.02,gary fellers,
+STAT,3090,009,Introductory Busines,0.22,0.39,0.11,0.11,0.06,0.0,0.0,0.11,hewa priyadarshani,
+STAT,3090,010,Introductory Busines,0.32,0.43,0.11,0.05,0.07,0.0,0.0,0.02,gary fellers,
+STAT,3090,011,Introductory Busines,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,janie caro mcdonald,
+STAT,3090,012,Introductory Busines,0.2,0.6,0.14,0.03,0.03,0.0,0.0,0.0,margaret mar wiecek,
+STAT,3090,013,Introductory Busines,0.27,0.36,0.24,0.04,0.07,0.0,0.0,0.02,gary fellers,
+STAT,3090,014,Introductory Busines,0.15,0.46,0.23,0.0,0.15,0.0,0.0,0.0,ziwen cheng,
+STAT,3090,015,Introductory Busines,0.16,0.42,0.11,0.26,0.05,0.0,0.0,0.0,tao yang,
+STAT,3090,016,Introductory Busines,0.26,0.32,0.11,0.11,0.05,0.0,0.0,0.16,tao yang,
+STAT,3090,017,Introductory Busines,0.22,0.39,0.22,0.11,0.06,0.0,0.0,0.0,hewa priyadarshani,
+STAT,3090,018,Introductory Busines,0.29,0.56,0.08,0.04,0.02,0.0,0.0,0.0,jennifer van dyken,
+STAT,3090,019,Introductory Busines,0.3,0.36,0.16,0.11,0.0,0.0,0.0,0.07,laura jane shick,
+STAT,3090,020,Introductory Busines,0.11,0.41,0.25,0.09,0.09,0.0,0.0,0.05,laura jane shick,
+STAT,4020,001,Intro to Statistical,0.56,0.22,0.17,0.06,0.0,0.0,0.0,0.0,julia lynn sharp,
+STAT,4110,001,Stat Mthds for Proce,0.39,0.39,0.17,0.06,0.0,0.0,0.0,0.0,james rieck,
+STAT,4110,002,Stat Mthds for Proce,0.19,0.29,0.26,0.13,0.13,0.0,0.0,0.0,patrick gerard,
+STAT,8010,001,Statistical Methods,0.48,0.43,0.04,0.0,0.0,0.0,0.0,0.04,william bridges,
+STAT,8010,003,Statistical Methods,0.39,0.29,0.16,0.0,0.13,0.0,0.0,0.03,james rieck,
+STAT,8010,004,Statistical Methods,0.31,0.26,0.31,0.0,0.06,0.0,0.0,0.06,julia lynn sharp,
+STAT,8020,001,Statistical Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+STAT,8020,001,Statistical Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,8050,001,Design & Anlys of Ex,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STS,1010,001,Survey of S T S,0.46,0.41,0.05,0.0,0.03,0.0,0.0,0.05,elizabeth stansell,
+STS,1010,002,Survey of S T S,0.36,0.39,0.22,0.03,0.0,0.0,0.0,0.0,thomas oberdan,
+STS,1010,003,Survey of S T S,0.89,0.08,0.0,0.0,0.03,0.0,0.0,0.0,scott brame,
+STS,1010,005,Survey of S T S,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,thomas oberdan,
+STS,1010,006,Survey of S T S,0.44,0.28,0.14,0.03,0.06,0.0,0.0,0.06,sarah mae cooper,
+STS,1010,007,Survey of S T S,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,annah kamugiz amani,
+STS,1010,008,Survey of S T S,0.27,0.45,0.15,0.03,0.0,0.0,0.0,0.09,david charles foltz,
+STS,1010,009,Survey of S T S,0.4,0.46,0.11,0.0,0.03,0.0,0.0,0.0,allison ann hinds,
+STS,1010,010,Survey of S T S,0.57,0.21,0.14,0.0,0.07,0.0,0.0,0.0,thomas oberdan,
+STS,1010,020,Survey of S T S,0.19,0.47,0.25,0.03,0.0,0.0,0.0,0.06,thomas oberdan,
+STS,2150,001,Crit Appr to Tech Re,0.32,0.32,0.27,0.05,0.0,0.0,0.0,0.05,thomas oberdan,
+THEA,2100,001,Theatre Appreciation,0.53,0.34,0.06,0.0,0.0,0.0,0.0,0.06,richard st. peter,
+THEA,2100,003,Theatre Appreciation,0.65,0.16,0.1,0.03,0.06,0.0,0.0,0.0,kendra lyne johnson,
+THEA,2100,004,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,
+THEA,2100,005,Theatre Appreciation,0.44,0.38,0.13,0.03,0.0,0.0,0.0,0.03,carol collins,
+THEA,2100,006,Theatre Appreciation,0.52,0.26,0.1,0.03,0.03,0.0,0.0,0.06,jason adkins,
+THEA,2780,001,Acting I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,
+THEA,3170,001,African-Amer Thea I,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,kendra lyne johnson,
+THEA,4720,001,Improvisation,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,
+THEA,6870,001,Stage Lighting I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
+WFB,3000,001,Wildlife Biology,0.36,0.43,0.11,0.07,0.02,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3000,002,Wildlife Biology,0.4,0.35,0.16,0.04,0.05,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3010,001,Wildlife Biology Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,
+WFB,3010,002,Wildlife Biology Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,4100,001,Wildlife Mgmt Tech,0.62,0.31,0.04,0.0,0.04,0.0,0.0,0.0,james davis,
+WFB,4100,002,Wildlife Mgmt Tech,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,james davis,
+WFB,4120,002,Wildlife Management,0.4,0.4,0.13,0.04,0.0,0.0,0.0,0.02,greg yarrow,
+WFB,4120,002,Wildlife Management,0.4,0.4,0.13,0.04,0.0,0.0,0.0,0.02,david sco jachowski,
+WFB,4180,001,Fishery Conservation,0.59,0.23,0.14,0.0,0.0,0.0,0.0,0.05,yoichiro kanno,
+WFB,4500,001,Aquaculture,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,
+WFB,4600,001,Warmwat Fish Disease,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,
+WFB,8610,200,Analysis of Ecologic,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,russell barrett,
+WS,1030,001,Women Global Perspec,0.75,0.14,0.06,0.06,0.0,0.0,0.0,0.0,saadiqa kumanyika,
+WS,2300,001,Women and Leadership,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,saadiqa kumanyika,
+WS,3010,001,Intro Women's Studie,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth ros adams,
+WS,3010,002,Intro Women's Studie,0.47,0.34,0.03,0.13,0.0,0.0,0.0,0.03,elizabeth ros adams,
+YDP,3000,400,Youth Development in,0.43,0.36,0.14,0.0,0.07,0.0,0.0,0.0,barry garst,

--- a/bot/cogs/grades_cog/assets/2014_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2014_Spring.csv
@@ -1,2291 +1,2291 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1020,1,Survey of Art & Arch Hist II,0.49,0.38,0.11,0.0,0.01,0.0,0.0,0.01,beth ann lauritis,AAH-1020,2014
-AAH,2060,1,Art History and Theory II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,AAH-2060,2014
-AAH,2100,1,Intro to Art and Architecture,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,janet bever leblanc,AAH-2100,2014
-AAH,2100,2,Intro to Art and Architecture,0.39,0.32,0.21,0.07,0.0,0.0,0.0,0.0,janet bever leblanc,AAH-2100,2014
-AAH,2100,3,Intro to Art and Architecture,0.33,0.22,0.22,0.07,0.0,0.0,0.0,0.15,janet bever leblanc,AAH-2100,2014
-AAH,2100,4,Intro to Art and Architecture,0.24,0.38,0.21,0.03,0.0,0.0,0.0,0.14,janet bever leblanc,AAH-2100,2014
-ACCT,2010,1,Financial Accounting Concepts,0.14,0.32,0.26,0.08,0.08,0.0,0.0,0.12,suzanne pearse,ACCT-2010,2014
-ACCT,2010,2,Financial Accounting Concepts,0.08,0.25,0.35,0.15,0.1,0.0,0.0,0.08,henry anderson,ACCT-2010,2014
-ACCT,2010,3,Financial Accounting Concepts,0.15,0.24,0.33,0.11,0.02,0.0,0.0,0.15,suzanne pearse,ACCT-2010,2014
-ACCT,2010,4,Financial Accounting Concepts,0.2,0.34,0.18,0.09,0.05,0.0,0.0,0.14,the estate  guffey,ACCT-2010,2014
-ACCT,2010,5,Financial Accounting Concepts,0.09,0.26,0.33,0.02,0.16,0.0,0.0,0.14,henry anderson,ACCT-2010,2014
-ACCT,2010,6,Financial Accounting Concepts,0.17,0.26,0.28,0.09,0.11,0.0,0.0,0.11,suzanne pearse,ACCT-2010,2014
-ACCT,2010,7,Financial Accounting Concepts,0.23,0.23,0.32,0.11,0.04,0.0,0.0,0.06,suzanne pearse,ACCT-2010,2014
-ACCT,2010,8,Financial Accounting Concepts,0.11,0.24,0.2,0.04,0.2,0.0,0.0,0.2,henry anderson,ACCT-2010,2014
-ACCT,2010,9,Financial Accounting Concepts,0.07,0.34,0.23,0.14,0.07,0.0,0.0,0.16,the estate  guffey,ACCT-2010,2014
-ACCT,2010,10,Financial Accounting Concepts,0.13,0.38,0.18,0.11,0.04,0.0,0.0,0.16,the estate  guffey,ACCT-2010,2014
-ACCT,2010,11,Financial Accounting Concepts,0.12,0.27,0.29,0.11,0.09,0.0,0.0,0.12,jeffrey mcmillan,ACCT-2010,2014
-ACCT,2020,1,Managerial Accounting Concepts,0.25,0.4,0.17,0.1,0.06,0.0,0.0,0.02,annieka philo,ACCT-2020,2014
-ACCT,2020,2,Managerial Accounting Concepts,0.29,0.38,0.25,0.04,0.02,0.0,0.0,0.02,annieka philo,ACCT-2020,2014
-ACCT,2020,3,Managerial Accounting Concepts,0.23,0.29,0.31,0.06,0.08,0.0,0.0,0.02,annieka philo,ACCT-2020,2014
-ACCT,2020,4,Managerial Accounting Concepts,0.31,0.37,0.14,0.1,0.08,0.0,0.0,0.0,annieka philo,ACCT-2020,2014
-ACCT,2020,5,Managerial Accounting Concepts,0.27,0.29,0.16,0.02,0.03,0.0,0.0,0.23,henry anderson,ACCT-2020,2014
-ACCT,2020,6,Managerial Accounting Concepts,0.18,0.19,0.19,0.09,0.05,0.0,0.0,0.3,henry anderson,ACCT-2020,2014
-ACCT,2040,1,ACCT 2040: 001,0.53,0.29,0.08,0.03,0.06,0.0,0.0,0.01,jeffrey mcmillan,ACCT-2040,2014
-ACCT,2040,2,ACCT 2040: 002,0.37,0.36,0.11,0.04,0.06,0.0,0.0,0.07,jeffrey mcmillan,ACCT-2040,2014
-ACCT,3030,1,Cost Accounting,0.26,0.37,0.2,0.03,0.06,0.0,0.0,0.09,derek dalton,ACCT-3030,2014
-ACCT,3030,2,Cost Accounting,0.17,0.4,0.31,0.11,0.0,0.0,0.0,0.0,derek dalton,ACCT-3030,2014
-ACCT,3030,3,Cost Accounting,0.18,0.63,0.05,0.03,0.08,0.0,0.0,0.03,robin radtke,ACCT-3030,2014
-ACCT,3030,4,Cost Accounting,0.31,0.49,0.1,0.03,0.08,0.0,0.0,0.0,robin radtke,ACCT-3030,2014
-ACCT,3110,1,Intermed Financial Acct I,0.22,0.41,0.3,0.07,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3110,2014
-ACCT,3110,2,Intermed Financial Acct I,0.52,0.36,0.07,0.02,0.02,0.0,0.0,0.0,terry daniel knause,ACCT-3110,2014
-ACCT,3110,3,Intermed Financial Acct I,0.55,0.24,0.19,0.0,0.0,0.0,0.0,0.02,terry daniel knause,ACCT-3110,2014
-ACCT,3110,4,Intermed Financial Acct I,0.59,0.24,0.1,0.0,0.02,0.0,0.0,0.05,terry daniel knause,ACCT-3110,2014
-ACCT,3120,1,Intermed Financial Acct II,0.18,0.54,0.15,0.1,0.03,0.0,0.0,0.0, russell madray,ACCT-3120,2014
-ACCT,3120,2,Intermed Financial Acct II,0.3,0.46,0.19,0.03,0.0,0.0,0.0,0.03, russell madray,ACCT-3120,2014
-ACCT,3120,3,Intermed Financial Acct II,0.15,0.21,0.36,0.06,0.0,0.0,0.0,0.21,lydia lan schleifer,ACCT-3120,2014
-ACCT,3120,4,Intermed Financial Acct II,0.15,0.36,0.3,0.0,0.12,0.0,0.0,0.06,lydia lan schleifer,ACCT-3120,2014
-ACCT,3130,1,Intermed Financial Acct III,0.17,0.46,0.23,0.11,0.0,0.0,0.0,0.03, russell madray,ACCT-3130,2014
-ACCT,3130,2,Intermed Financial Acct III,0.51,0.22,0.22,0.03,0.03,0.0,0.0,0.0, russell madray,ACCT-3130,2014
-ACCT,3130,3,Intermed Financial Acct III,0.33,0.19,0.37,0.07,0.04,0.0,0.0,0.0,james irving,ACCT-3130,2014
-ACCT,3130,4,Intermed Financial Acct III,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,james irving,ACCT-3130,2014
-ACCT,3220,1,Accounting Information Systems,0.03,0.47,0.26,0.12,0.06,0.0,0.0,0.06,philip maiberger,ACCT-3220,2014
-ACCT,3220,2,Accounting Information Systems,0.16,0.26,0.35,0.13,0.06,0.0,0.0,0.03,philip maiberger,ACCT-3220,2014
-ACCT,3220,3,Accounting Information Systems,0.25,0.33,0.25,0.08,0.03,0.0,0.0,0.06,nancy lee harp,ACCT-3220,2014
-ACCT,4040,1,Individual Taxation,0.3,0.45,0.2,0.05,0.0,0.0,0.0,0.0,john hine,ACCT-4040,2014
-ACCT,4040,2,Individual Taxation,0.32,0.39,0.24,0.03,0.0,0.0,0.0,0.03,john hine,ACCT-4040,2014
-ACCT,4080,1,Retire & Estate Plan,0.29,0.38,0.33,0.0,0.0,0.0,0.0,0.0,john hine,ACCT-4080,2014
-ACCT,4100,1,Budget and Exec Cont,0.46,0.41,0.07,0.05,0.0,0.0,0.0,0.0,frances kennedy,ACCT-4100,2014
-ACCT,4100,2,Budget and Exec Cont,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,frances kennedy,ACCT-4100,2014
-ACCT,4150,1,Auditing,0.09,0.31,0.41,0.09,0.06,0.0,0.0,0.03,suzanne pearse,ACCT-4150,2014
-ACCT,4150,2,Auditing,0.15,0.15,0.35,0.25,0.1,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2014
-ACCT,8520,1,ACCT 8520: 001,0.36,0.61,0.03,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8520,2014
-ACCT,8520,2,ACCT 8520: 002,0.28,0.53,0.17,0.0,0.03,0.0,0.0,0.0,ralph welton,ACCT-8520,2014
-ACCT,8550,1,ACCT 8550: 001,0.66,0.29,0.03,0.0,0.03,0.0,0.0,0.0,james barnes,ACCT-8550,2014
-ACCT,8550,2,ACCT 8550: 002,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2014
-ACCT,8710,1,ACCT 8710: 001,0.23,0.71,0.03,0.0,0.03,0.0,0.0,0.0,derek dalton,ACCT-8710,2014
-ACCT,8710,2,ACCT 8710: 002,0.31,0.66,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2014
-AGED,3550,1,Team and Organiz Leadership,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thomas dobbins,AGED-3550,2014
-AGED,4150,1,AGED 4150: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,kevin layfield,AGED-4150,2014
-AGM,2050,1,AGM 2050: 001,0.15,0.42,0.32,0.04,0.0,0.0,0.0,0.08,hunter massey,AGM-2050,2014
-AGM,2060,1,AGM 2060: 001,0.23,0.55,0.18,0.05,0.0,0.0,0.0,0.0,hunter massey,AGM-2060,2014
-AGM,2210,1,AGM 2210: 001,0.29,0.46,0.2,0.0,0.06,0.0,0.0,0.0,charles privette,AGM-2210,2014
-AGM,3030,1,AGM 3030: 001,0.21,0.4,0.33,0.02,0.02,0.0,0.0,0.0,young han,AGM-3030,2014
-AGM,4020,1,AGM 4020: 001,0.06,0.66,0.26,0.0,0.03,0.0,0.0,0.0,charles privette,AGM-4020,2014
-AGM,4100,1,AGM 4100: 001,0.38,0.47,0.13,0.03,0.0,0.0,0.0,0.0,hunter massey,AGM-4100,2014
-AGM,4520,1,AGM 4520: 001,0.21,0.56,0.24,0.0,0.0,0.0,0.0,0.0,kendall kirk,AGM-4520,2014
-AGM,4720,1,AGM 4720: 001,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,john chastain,AGM-4720,2014
-AL,3490,400,AL 3490: 400,0.56,0.26,0.19,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2014
-AL,3490,401,AL 3490: 401,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2014
-AL,3490,402,AL 3490: 402,0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2014
-AL,3490,403,AL 3490: 403,0.68,0.25,0.0,0.0,0.07,0.0,0.0,0.0,clyde keith connor,AL-3490,2014
-AL,3490,404,AL 3490: 404,0.54,0.27,0.08,0.04,0.04,0.0,0.0,0.04,clyde keith connor,AL-3490,2014
-AL,3490,405,AL 3490: 405,0.8,0.12,0.0,0.04,0.04,0.0,0.0,0.0,edmond fry,AL-3490,2014
-AL,3500,400,AL 3500: 400,0.19,0.31,0.23,0.12,0.08,0.0,0.0,0.08,michael godfrey,AL-3500,2014
-AL,3500,401,AL 3500: 401,0.14,0.55,0.05,0.09,0.09,0.0,0.0,0.09,michael godfrey,AL-3500,2014
-AL,3520,400,AL 3520: 400,0.22,0.22,0.35,0.04,0.0,0.0,0.0,0.17,michael godfrey,AL-3520,2014
-AL,3530,400,AL 3530: 400,0.12,0.23,0.27,0.27,0.08,0.0,0.0,0.04,isaac sean colbert,AL-3530,2014
-AL,3530,401,AL 3530: 401,0.13,0.17,0.39,0.22,0.04,0.0,0.0,0.04,isaac sean colbert,AL-3530,2014
-AL,3600,400,AL 3600: 400,0.46,0.43,0.07,0.0,0.0,0.0,0.0,0.04,clyde keith connor,AL-3600,2014
-AL,3610,400,AL 3610: 400,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2014
-AL,3610,401,AL 3610: 401,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2014
-AL,3610,402,AL 3610: 402,0.88,0.04,0.04,0.04,0.0,0.0,0.0,0.0,henry oates,AL-3610,2014
-AL,3620,400,AL 3620: 400,0.08,0.44,0.2,0.16,0.04,0.0,0.0,0.08,natalie anne carter,AL-3620,2014
-AL,3620,401,AL 3620: 401,0.23,0.23,0.37,0.09,0.03,0.0,0.0,0.06,natalie anne carter,AL-3620,2014
-AL,3710,400,AL 3710: 400,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,justin hickey,AL-3710,2014
-AL,3720,400,AL 3720: 400,0.61,0.13,0.04,0.04,0.13,0.0,0.0,0.04,edmond fry,AL-3720,2014
-AL,3740,400,AL 3740: 400,0.46,0.21,0.29,0.0,0.0,0.0,0.0,0.04,deborah cadorette,AL-3740,2014
-AL,3750,400,AL 3750: 400,0.74,0.11,0.05,0.0,0.05,0.0,0.0,0.05,deborah cadorette,AL-3750,2014
-AL,3760,400,AL 3760: 400,0.38,0.14,0.19,0.1,0.19,0.0,0.0,0.0,edmond fry,AL-3760,2014
-AL,3760,401,AL 3760: 401,0.63,0.11,0.05,0.11,0.05,0.0,0.0,0.05,edmond fry,AL-3760,2014
-ANTH,2010,1,Intro Anthropology,0.06,0.21,0.41,0.11,0.12,0.0,0.0,0.09,john coggeshall,ANTH-2010,2014
-ANTH,2010,2,Intro Anthropology,0.24,0.32,0.24,0.11,0.05,0.0,0.0,0.05,melissa vogel,ANTH-2010,2014
-ANTH,2010,3,Intro Anthropology,0.36,0.32,0.19,0.07,0.03,0.0,0.0,0.03,lisa rapaport,ANTH-2010,2014
-ANTH,3200,1,North American Indian Cultures,0.18,0.35,0.24,0.0,0.0,0.0,0.0,0.24,john coggeshall,ANTH-3200,2014
-ANTH,3310,1,Archaeology,0.29,0.5,0.04,0.04,0.04,0.0,0.0,0.08,melissa vogel,ANTH-3310,2014
-ANTH,3510,1,Biological Anthropology,0.62,0.31,0.0,0.08,0.0,0.0,0.0,0.0,katherine weisensee,ANTH-3510,2014
-ANTH,4510,1,Biol Variation in Human Pop,0.33,0.33,0.25,0.0,0.0,0.0,0.0,0.08,katherine weisensee,ANTH-4510,2014
-APEC,2020,1,Agric Economics,0.38,0.28,0.23,0.0,0.07,0.0,0.0,0.05,webb smathers,APEC-2020,2014
-APEC,2050,1,Agric and Society,0.6,0.38,0.0,0.0,0.0,0.0,0.0,0.02,david wheele hughes,APEC-2050,2014
-APEC,3080,1,APEC 3080: 001,0.33,0.11,0.3,0.19,0.04,0.0,0.0,0.04,michael vassalos,APEC-3080,2014
-APEC,3570,1,Nat Resource Econ,0.1,0.36,0.51,0.0,0.0,0.0,0.0,0.03,molly espey,APEC-3570,2014
-APEC,4120,1,Reg Economic Devel,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david wheele hughes,APEC-4120,2014
-APEC,4520,1,Agric Policy,0.25,0.55,0.2,0.0,0.0,0.0,0.0,0.0,michael vassalos,APEC-4520,2014
-APEC,4750,1,Wildlife Economics,0.57,0.1,0.33,0.0,0.0,0.0,0.0,0.0,webb smathers,APEC-4750,2014
-ARAB,1010,1,ARAB 1010: 001,0.64,0.14,0.0,0.07,0.0,0.0,0.0,0.14,sulafa abou-samra,ARAB-1010,2014
-ARAB,1020,1,ARAB 1020: 001,0.55,0.09,0.09,0.09,0.0,0.0,0.0,0.18,sulafa abou-samra,ARAB-1020,2014
-ARCH,1510,3,ARCH 1510: 003,0.38,0.33,0.17,0.04,0.0,0.0,0.0,0.08,sal hambright-belue,ARCH-1510,2014
-ARCH,1510,4,ARCH 1510: 004,0.23,0.64,0.09,0.0,0.0,0.0,0.0,0.05,sal hambright-belue,ARCH-1510,2014
-ARCH,2520,1,ARCH 2520: 001,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-2520,2014
-ARCH,2520,3,ARCH 2520: 003,0.33,0.33,0.17,0.0,0.08,0.0,0.0,0.08,criss mills,ARCH-2520,2014
-ARCH,2520,4,ARCH 2520: 004,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2520,2014
-ARCH,2700,1,ARCH 2700: 001,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,robert john hogan,ARCH-2700,2014
-ARCH,2700,2,ARCH 2700: 002,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert john hogan,ARCH-2700,2014
-ARCH,2710,1,ARCH 2710: 001,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,ARCH-2710,2014
-ARCH,4050,1,ARCH 4050: 001,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,robert bruhns,ARCH-4050,2014
-ARCH,4520,2,ARCH 4520: 002,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,lynn craig,ARCH-4520,2014
-ARCH,4520,3,ARCH 4520: 003,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-4520,2014
-ARCH,4990,1,Freehand Drawing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,ARCH-4990,2014
-ARCH,6050,1,ARCH 6050: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-6050,2014
-ARCH,8110,1,ARCH 8110: 001,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,douglas hecker,ARCH-8110,2014
-ARCH,8120,1,ARCH 8120: 001,0.21,0.64,0.14,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-8120,2014
-ARCH,8200,1,Bldg Design & Constr,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,ARCH-8200,2014
-ARCH,8420,1,ARCH 8420: 001,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ar montilla navarro,ARCH-8420,2014
-ARCH,8420,2,ARCH 8420: 002,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,junichi satoh,ARCH-8420,2014
-ARCH,8520,2,ARCH 8520: 002,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,keith green,ARCH-8520,2014
-ARCH,8520,5,ARCH 8520: 005,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,nicholas ault,ARCH-8520,2014
-ARCH,8610,1,ARCH 8610: 001,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,ufuk ersoy,ARCH-8610,2014
-ARCH,8710,1,ARCH 8710: 001,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,dustin gra albright,ARCH-8710,2014
-ARCH,8730,1,ARCH 8730: 001,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,ARCH-8730,2014
-ARCH,8820,1,ARCH 8820: 001,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-8820,2014
-ARCH,8900,1,Directed Studies,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-8900,2014
-ARCH,8920,1,ARCH 8920: 001,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8920,2014
-ARCH,8920,2,ARCH 8920: 002,0.24,0.7,0.06,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-8920,2014
-ARCH,8960,1,A+H Studio: Tectonic,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8960,2014
-ART,1030,1,ART 1030: 001,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,lynette house,ART-1030,2014
-ART,1060,1,ART 1060: 001,0.68,0.18,0.05,0.0,0.09,0.0,0.0,0.0,carly drew,ART-1060,2014
-ART,1510,1,ART 1510: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,adrienne lichliter,ART-1510,2014
-ART,2050,1,ART 2050: 001,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,joel reese murray,ART-2050,2014
-ART,2070,1,ART 2070: 001,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,todd mcdonald,ART-2070,2014
-ART,2170,1,ART 2170: 001,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,nina jeanette kawar,ART-2170,2014
-AS,1100,1,AS 1100: 001,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,AS-1100,2014
-AS,4100,1,Nat Sec Policy II,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,steven price jordan,AS-4100,2014
-ASL,1010,1,ASL 1010: 001,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,joseph paul may,ASL-1010,2014
-ASL,1010,2,ASL 1010: 002,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,joseph paul may,ASL-1010,2014
-ASL,1020,1,ASL 1020: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-1020,2014
-ASL,1020,2,ASL 1020: 002,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-1020,2014
-ASL,2010,1,ASL 2010: 001,0.13,0.6,0.07,0.07,0.13,0.0,0.0,0.0,william alton brant,ASL-2010,2014
-ASL,2010,2,ASL 2010: 002,0.53,0.12,0.35,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-2010,2014
-ASL,2020,1,ASL 2020: 001,0.69,0.13,0.13,0.0,0.06,0.0,0.0,0.0,kim ma misener dunn,ASL-2020,2014
-ASL,2020,2,ASL 2020: 002,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-2020,2014
-ASL,3050,1,Deaf Studies,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-3050,2014
-ASL,4010,1,ASL 4010: 001,0.36,0.55,0.0,0.0,0.0,0.0,0.0,0.09,stephen fitzmaurice,ASL-4010,2014
-ASTR,1010,1,Solar System Astr,0.3,0.26,0.16,0.07,0.05,0.0,0.0,0.16,dina drozdov,ASTR-1010,2014
-ASTR,1020,1,Stellar Astronomy ONLINE,0.31,0.53,0.13,0.0,0.0,0.0,0.0,0.04,phillip flower,ASTR-1020,2014
-ASTR,1020,2,Stellar Astronomy ONLINE,0.27,0.35,0.27,0.0,0.03,0.0,0.0,0.06,phillip flower,ASTR-1020,2014
-ASTR,1020,3,Stellar Astronomy ONLINE,0.38,0.42,0.11,0.0,0.02,0.0,0.0,0.07,phillip flower,ASTR-1020,2014
-ASTR,1030,1,Solar Systm Astr Lab,0.46,0.19,0.19,0.04,0.12,0.0,0.0,0.0,mark leising,ASTR-1030,2014
-ASTR,1040,1,Stellar Astr Lab,0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,mark leising,ASTR-1040,2014
-ASTR,1040,3,Stellar Astr Lab,0.39,0.39,0.0,0.0,0.0,0.0,0.0,0.22,mark leising,ASTR-1040,2014
-ASTR,1040,5,Stellar Astr Lab,0.73,0.18,0.05,0.0,0.0,0.0,0.0,0.05,mark leising,ASTR-1040,2014
-ASTR,1040,6,Stellar Astr Lab,0.4,0.27,0.0,0.0,0.13,0.0,0.0,0.2,mark leising,ASTR-1040,2014
-AUD,2850,1,AUD 2850: 001,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-2850,2014
-AUE,8160,1,AUE 8160: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8160,2014
-AUE,8160,2,AUE 8160: 002,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-8160,2014
-AUE,8170,3,AUE 8170: 003,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8170,2014
-AUE,8290,4,AUE 8290: 004,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,timothy rhyne,AUE-8290,2014
-AUE,8500,6,AUE 8500: 006,0.43,0.46,0.04,0.0,0.0,0.0,0.0,0.07,beshah ayalew,AUE-8500,2014
-AUE,8550,16,AUE 8550: 016,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8550,2014
-AUE,8660,7,Adv Matl Auto Appl,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,AUE-8660,2014
-AUE,8690,8,AUE 8690: 008,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8690,2014
-AUE,8770,9,AUE 8770: 009,0.57,0.32,0.07,0.0,0.04,0.0,0.0,0.0,fadi kama abu-farha,AUE-8770,2014
-AUE,8820,10,AUE 8820: 010,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,AUE-8820,2014
-AUE,8860,11,AUE 8860: 011,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,AUE-8860,2014
-AUE,8900,400,AUE 8900: 400,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,AUE-8900,2014
-AUE,8930,15,Autovation I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,AUE-8930,2014
-AVS,2000,1,AVS 2000: 001,0.83,0.14,0.02,0.0,0.0,0.0,0.0,0.0,brian bolt,AVS-2000,2014
-AVS,2050,1,AVS 2050: 001,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,AVS-2050,2014
-AVS,2060,1,AVS 2060: 001,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-2060,2014
-AVS,2090,1,AVS 2090: 001,0.94,0.01,0.0,0.0,0.01,0.0,0.0,0.03,brian bolt,AVS-2090,2014
-AVS,2110,1,AVS 2110: 001,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,michelle hall,AVS-2110,2014
-AVS,3150,1,Animal Welfare,0.22,0.43,0.17,0.13,0.0,0.0,0.0,0.04,peter skewes,AVS-3150,2014
-AVS,3750,1,Appl Animal Nutr,0.1,0.37,0.29,0.15,0.01,0.0,0.0,0.09,nathan long,AVS-3750,2014
-AVS,4060,1,AVS 4060: 001,0.88,0.09,0.0,0.0,0.0,0.0,0.0,0.03,glenn birrenkott,AVS-4060,2014
-AVS,4100,1,AVS 4100: 001,0.15,0.41,0.32,0.09,0.02,0.0,0.0,0.01,peter skewes,AVS-4100,2014
-AVS,4120,1,Adv Equine Mgmt,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-4120,2014
-AVS,4130,1,AVS 4130: 001,0.35,0.45,0.13,0.01,0.0,0.0,0.0,0.05,michelle hall,AVS-4130,2014
-AVS,4170,1,AVS 4170: 001,0.38,0.5,0.0,0.04,0.04,0.0,0.0,0.04,kristine lan vernon,AVS-4170,2014
-AVS,4530,1,Animal Reproduction,0.31,0.52,0.11,0.03,0.01,0.0,0.0,0.01,glenn birrenkott,AVS-4530,2014
-AVS,4530,400,Animal Reproduction,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-4530,2014
-AVS,6110,1,AVS 6110: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,AVS-6110,2014
-AVS,8090,1,AVS 8090: 001,0.63,0.13,0.0,0.0,0.0,0.0,0.0,0.25,susan kay duckett,AVS-8090,2014
-BCHM,3010,1,Molecular Biochem,0.08,0.33,0.26,0.25,0.03,0.0,0.0,0.05,meredith tei morris,BCHM-3010,2014
-BCHM,3010,2,Molecular Biochem(HON),0.56,0.24,0.12,0.0,0.0,0.0,0.0,0.08,meredith tei morris,BCHM-3010,2014
-BCHM,3020,1,BCHM 3020: 001,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,meredith tei morris,BCHM-3020,2014
-BCHM,3020,2,BCHM 3020: 002,0.56,0.25,0.0,0.06,0.0,0.0,0.0,0.13,meredith tei morris,BCHM-3020,2014
-BCHM,3020,3,BCHM 3020: 003,0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,meredith tei morris,BCHM-3020,2014
-BCHM,3050,1,BCHM 3050: 001,0.24,0.22,0.27,0.18,0.04,0.0,0.0,0.04,james morris,BCHM-3050,2014
-BCHM,4060,1,BCHM 4060: 001,0.46,0.27,0.19,0.03,0.03,0.0,0.0,0.03,ashby burges bodine,BCHM-4060,2014
-BCHM,4320,1,Bioch of Metabolism,0.79,0.15,0.03,0.0,0.0,0.0,0.0,0.03,kimberly paul,BCHM-4320,2014
-BCHM,4360,1,Genes to Proteins,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,BCHM-4360,2014
-BE,2100,1,BE 2100: 001,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,yi zheng,BE-2100,2014
-BE,3220,1,BE 3220: 001,0.29,0.29,0.32,0.04,0.0,0.0,0.0,0.07,tom owino,BE-3220,2014
-BE,4120,1,BE 4120: 001,0.3,0.4,0.25,0.0,0.0,0.0,0.0,0.05,caye marie drapcho,BE-4120,2014
-BE,4210,1,BE 4210: 001,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,BE-4210,2014
-BE,4240,1,BE 4240: 001,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,BE-4240,2014
-BE,4380,1,BE 4380: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4380,2014
-BIOE,1010,1,BIOE 1010: 001,0.85,0.09,0.05,0.0,0.0,0.0,0.0,0.0,agneta simionescu,BIOE-1010,2014
-BIOE,2010,1,BIOE 2010: 001,0.28,0.4,0.16,0.04,0.04,0.0,0.0,0.08,charles webb,BIOE-2010,2014
-BIOE,3020,1,BIOE 3020: 001,0.48,0.42,0.06,0.02,0.02,0.0,0.0,0.0,alexey ale vertegel,BIOE-3020,2014
-BIOE,3200,1,BIOE 3200: 001,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,BIOE-3200,2014
-BIOE,3210,1,BIOE 3210: 001,0.42,0.42,0.06,0.03,0.0,0.0,0.0,0.06,sarah harcum,BIOE-3210,2014
-BIOE,3700,1,BIOE 3700: 001,0.62,0.31,0.02,0.0,0.02,0.0,0.0,0.03,delphine dean,BIOE-3700,2014
-BIOE,4030,1,BIOE 4030: 001,0.97,0.02,0.0,0.0,0.0,0.0,0.0,0.01,john desjardins,BIOE-4030,2014
-BIOE,4230,1,BIOE 4230: 001,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,dan simionescu,BIOE-4230,2014
-BIOE,4310,1,BIOE 4310: 001,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,david kwartowitz,BIOE-4310,2014
-BIOE,8020,410,BIOE 8020: 410,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,BIOE-8020,2014
-BIOE,8150,410,BIOE 8150: 410,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,BIOE-8150,2014
-BIOE,8470,1,BIOE 8470: 001,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,robert latour,BIOE-8470,2014
-BIOE,8490,1,BIOE 8490: 001,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,ying mei,BIOE-8490,2014
-BIOE,8500,3,Drug Delivery,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,jeoungsoo lee,BIOE-8500,2014
-BIOL,1040,1,General Biology II,0.3,0.33,0.24,0.06,0.02,0.0,0.0,0.05,nora espinoza,BIOL-1040,2014
-BIOL,1040,2,General Biology II,0.18,0.38,0.24,0.12,0.06,0.0,0.0,0.01,kalan ickes,BIOL-1040,2014
-BIOL,1040,3,General Biology II,0.18,0.22,0.3,0.16,0.08,0.0,0.0,0.08,salvatore sparace,BIOL-1040,2014
-BIOL,1040,4,General Biology II (HON),0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,nora espinoza,BIOL-1040,2014
-BIOL,1060,1,Gen Biology Lab II,0.26,0.26,0.37,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,2,Gen Biology Lab II,0.09,0.45,0.14,0.27,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,3,Gen Biology Lab II,0.16,0.47,0.16,0.16,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,4,Gen Biology Lab II,0.13,0.35,0.39,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,5,Gen Biology Lab II,0.22,0.35,0.09,0.04,0.26,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,6,Gen Biology Lab II,0.13,0.43,0.3,0.09,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,7,Gen Biology Lab II,0.14,0.57,0.1,0.1,0.0,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,8,Gen Biology Lab II,0.0,0.31,0.46,0.15,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,10,Gen Biology Lab II,0.15,0.3,0.4,0.15,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,11,Gen Biology Lab II,0.13,0.5,0.31,0.0,0.0,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,12,Gen Biology Lab II,0.71,0.21,0.0,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,13,Gen Biology Lab II,0.09,0.39,0.3,0.04,0.13,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,14,Gen Biology Lab II,0.17,0.26,0.35,0.09,0.13,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,15,Gen Biology Lab II,0.18,0.36,0.27,0.05,0.09,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,16,Gen Biology Lab II,0.23,0.41,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,17,Gen Biology Lab II,0.13,0.53,0.27,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,18,Gen Biology Lab II,0.24,0.35,0.18,0.18,0.0,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,19,Gen Biology Lab II,0.26,0.53,0.11,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,20,Gen Biology Lab II,0.06,0.56,0.22,0.11,0.06,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,21,Gen Biology Lab II,0.24,0.24,0.29,0.12,0.12,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,22,Gen Biology Lab II,0.13,0.44,0.38,0.0,0.06,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,23,Gen Biology Lab II,0.25,0.5,0.08,0.0,0.17,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,25,Gen Biology Lab II,0.29,0.33,0.19,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,26,Gen Biology Lab II,0.47,0.24,0.12,0.0,0.12,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,27,Gen Biology Lab II,0.25,0.5,0.06,0.13,0.06,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,28,Gen Biology Lab II,0.15,0.45,0.2,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,29,Gen Biology Lab II,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,30,Gen Biology Lab II,0.09,0.59,0.23,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,31,Gen Biology Lab II,0.19,0.52,0.19,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,34,Gen Biology Lab II,0.48,0.24,0.19,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,35,Gen Biology Lab II,0.25,0.58,0.0,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,36,Gen Biology Lab II,0.59,0.24,0.06,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,37,Gen Biology Lab II,0.3,0.35,0.17,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,38,Gen Biology Lab II,0.35,0.3,0.3,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,39,Gen Biology Lab II,0.43,0.3,0.22,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,40,Gen Biology Lab II,0.33,0.33,0.22,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,41,Gen Biology Lab II,0.25,0.31,0.31,0.06,0.06,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,42,Gen Biology Lab II,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,43,Gen Biology Lab II,0.36,0.29,0.14,0.07,0.07,0.0,0.0,0.07,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1060,44,Gen Biology Lab II,0.09,0.36,0.18,0.18,0.09,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2014
-BIOL,1090,1,Intro to Life Sci,0.9,0.07,0.0,0.0,0.02,0.0,0.0,0.0,renea chri hardwick,BIOL-1090,2014
-BIOL,1110,1,Prin of Biol II,0.32,0.35,0.24,0.03,0.06,0.0,0.0,0.0,dylan dittrich-reed,BIOL-1110,2014
-BIOL,1110,2,Prin of Biol II,0.3,0.44,0.17,0.07,0.01,0.0,0.0,0.02,robert kosinski,BIOL-1110,2014
-BIOL,1110,3,Prin of Biol II (HON),0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert kosinski,BIOL-1110,2014
-BIOL,1200,1,Biological Inq Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,2,Biological Inq Lab,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14, christine minor,BIOL-1200,2014
-BIOL,1200,5,Biological Inq Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1200,6,Biological Inq Lab,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2014
-BIOL,1200,12,Biological Inq Lab,0.33,0.56,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2014
-BIOL,1230,1,Keys to Human Biol,0.3,0.28,0.27,0.13,0.01,0.0,0.0,0.0, christine minor,BIOL-1230,2014
-BIOL,2000,2,Biology in the News,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-2000,2014
-BIOL,2000,3,Biology in the News,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,BIOL-2000,2014
-BIOL,2000,4,Biology in the News,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,barbara campbell,BIOL-2000,2014
-BIOL,2000,7,Biology in the News,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,michael sears,BIOL-2000,2014
-BIOL,2030,1,Human Disease & Soc,0.82,0.11,0.05,0.0,0.03,0.0,0.0,0.0, christine minor,BIOL-2030,2014
-BIOL,2040,1,"Environ, Energy and Society",0.33,0.39,0.18,0.06,0.03,0.0,0.0,0.03,john jenkins hains,BIOL-2040,2014
-BIOL,2110,1,Introduction to Toxicology,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,peter van den hurk,BIOL-2110,2014
-BIOL,2230,1,BIOL 2230: 001,0.37,0.41,0.13,0.04,0.03,0.0,0.0,0.02,john cummings,BIOL-2230,2014
-BIOL,2230,2,BIOL 2230: 002,0.37,0.39,0.15,0.07,0.01,0.0,0.0,0.02,john cummings,BIOL-2230,2014
-BIOL,3020,1,Invertebrate Biology,0.07,0.36,0.16,0.18,0.06,0.0,0.0,0.17,juan baeza migueles,BIOL-3020,2014
-BIOL,3040,1,Biology of Plants,0.11,0.38,0.32,0.12,0.08,0.0,0.0,0.0,robert edwa ballard,BIOL-3040,2014
-BIOL,3060,1,BIOL 3060: 001,0.24,0.41,0.06,0.24,0.0,0.0,0.0,0.06,juan baeza migueles,BIOL-3060,2014
-BIOL,3060,2,BIOL 3060: 002,0.15,0.25,0.35,0.05,0.2,0.0,0.0,0.0,juan baeza migueles,BIOL-3060,2014
-BIOL,3060,3,BIOL 3060: 003,0.22,0.39,0.11,0.0,0.0,0.0,0.0,0.28,juan baeza migueles,BIOL-3060,2014
-BIOL,3060,4,BIOL 3060: 004,0.16,0.32,0.21,0.11,0.05,0.0,0.0,0.16,juan baeza migueles,BIOL-3060,2014
-BIOL,3080,1,BIOL 3080: 001,0.11,0.26,0.21,0.16,0.11,0.0,0.0,0.16,robert edwa ballard,BIOL-3080,2014
-BIOL,3080,2,BIOL 3080: 002,0.22,0.39,0.22,0.11,0.06,0.0,0.0,0.0,robert edwa ballard,BIOL-3080,2014
-BIOL,3080,3,BIOL 3080: 003,0.28,0.33,0.33,0.06,0.0,0.0,0.0,0.0,robert edwa ballard,BIOL-3080,2014
-BIOL,3080,4,BIOL 3080: 004,0.19,0.25,0.13,0.06,0.06,0.0,0.0,0.31,robert edwa ballard,BIOL-3080,2014
-BIOL,3130,1,Conservation Biology,0.35,0.48,0.0,0.09,0.04,0.0,0.0,0.04,shari lyn rodriguez,BIOL-3130,2014
-BIOL,3130,2,Conservation Biology,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,shari lyn rodriguez,BIOL-3130,2014
-BIOL,3160,1,BIOL 3160: 001,0.25,0.49,0.18,0.04,0.02,0.0,0.0,0.01,tamara mcnutt-scott,BIOL-3160,2014
-BIOL,3200,1,BIOL 3200: 001,0.17,0.38,0.24,0.13,0.02,0.0,0.0,0.06,timothy spira,BIOL-3200,2014
-BIOL,3350,1,BIOL 3350: 001,0.36,0.38,0.13,0.04,0.07,0.0,0.0,0.03,margaret ptacek,BIOL-3350,2014
-BIOL,4010,1,Plant Physiology,0.13,0.13,0.19,0.35,0.13,0.0,0.0,0.08,douglas bielenberg,BIOL-4010,2014
-BIOL,4020,1,BIOL 4020: 001,0.31,0.31,0.08,0.0,0.23,0.0,0.0,0.08,douglas bielenberg,BIOL-4020,2014
-BIOL,4020,2,BIOL 4020: 002,0.43,0.29,0.14,0.07,0.0,0.0,0.0,0.07,douglas bielenberg,BIOL-4020,2014
-BIOL,4020,3,BIOL 4020: 003,0.31,0.38,0.08,0.15,0.0,0.0,0.0,0.08,douglas bielenberg,BIOL-4020,2014
-BIOL,4020,4,BIOL 4020: 004,0.33,0.4,0.13,0.07,0.0,0.0,0.0,0.07,douglas bielenberg,BIOL-4020,2014
-BIOL,4100,1,BIOL 4100: 001,0.37,0.39,0.2,0.02,0.0,0.0,0.0,0.02,john jenkins hains,BIOL-4100,2014
-BIOL,4140,1,Basic Immunology,0.72,0.22,0.0,0.0,0.02,0.0,0.0,0.04,charles rice,BIOL-4140,2014
-BIOL,4340,1,BIOL 4340: 001,0.25,0.33,0.42,0.0,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2014
-BIOL,4340,2,BIOL 4340: 002,0.09,0.27,0.27,0.27,0.0,0.0,0.0,0.09,salvatore sparace,BIOL-4340,2014
-BIOL,4340,3,BIOL 4340: 003,0.08,0.77,0.08,0.0,0.0,0.0,0.0,0.08,salvatore sparace,BIOL-4340,2014
-BIOL,4340,4,BIOL 4340: 004,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2014
-BIOL,4340,5,BIOL 4340: 005,0.18,0.45,0.27,0.09,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2014
-BIOL,4340,6,BIOL 4340: 006,0.0,0.33,0.5,0.17,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2014
-BIOL,4510,1,Biol Variation in Human Pop,0.25,0.5,0.13,0.0,0.06,0.0,0.0,0.06,katherine weisensee,BIOL-4510,2014
-BIOL,4610,1,Cell Biology,0.32,0.39,0.18,0.08,0.01,0.0,0.0,0.03,david feliciano,BIOL-4610,2014
-BIOL,4610,2,Cell Biology (HON),0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,david feliciano,BIOL-4610,2014
-BIOL,4620,2,BIOL 4620: 002,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4620,2014
-BIOL,4620,3,BIOL 4620: 003,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,lesly temesvari,BIOL-4620,2014
-BIOL,4620,4,BIOL 4620: 004,0.36,0.43,0.14,0.0,0.07,0.0,0.0,0.0,lesly temesvari,BIOL-4620,2014
-BIOL,4620,7,BIOL 4620: 007,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4620,2014
-BIOL,4620,8,BIOL 4620: 008,0.63,0.25,0.0,0.0,0.06,0.0,0.0,0.06,lesly temesvari,BIOL-4620,2014
-BIOL,4640,1,BIOL 4640: 001,0.29,0.41,0.24,0.0,0.0,0.0,0.0,0.06,john cummings,BIOL-4640,2014
-BIOL,4700,1,Behavioral Ecology,0.42,0.41,0.12,0.02,0.01,0.0,0.0,0.03,michael childress,BIOL-4700,2014
-BIOL,4710,1,BIOL 4710: 001,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,michael childress,BIOL-4710,2014
-BIOL,4710,2,BIOL 4710: 002,0.55,0.15,0.0,0.1,0.0,0.0,0.0,0.2,michael childress,BIOL-4710,2014
-BIOL,4710,3,BIOL 4710: 003,0.63,0.21,0.05,0.0,0.0,0.0,0.0,0.11,michael childress,BIOL-4710,2014
-BIOL,4710,4,BIOL 4710: 004,0.65,0.12,0.12,0.0,0.0,0.0,0.0,0.12,michael childress,BIOL-4710,2014
-BIOL,4780,1,BIOL 4780: 001,0.47,0.33,0.03,0.07,0.0,0.0,0.0,0.1,jason denton,BIOL-4780,2014
-BIOL,4930,5,BIOL 4930: 005,0.64,0.14,0.14,0.07,0.0,0.0,0.0,0.0,lisa bain,BIOL-4930,2014
-BIOL,6010,1,BIOL 6010: 001,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,BIOL-6010,2014
-BIOL,8450,1,Understanding Vertebrate Biol,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,tamara mcnutt-scott,BIOL-8450,2014
-BIOL,8470,1,Understanding Microbiology,0.59,0.38,0.0,0.0,0.0,0.0,0.0,0.03,harry kurtz,BIOL-8470,2014
-BIOL,8710,5,CS Ecological Risk Assess ETOX,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,stephen klaine,BIOL-8710,2014
-BIOL,8710,6,Proc Ecological Risk Assessmen,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,BIOL-8710,2014
-BT,2200,1,BT 2200: 001,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,shannon go lawrence,BT-2200,2014
-BUS,1010,1,BUS 1010: 001,0.16,0.51,0.2,0.09,0.0,0.0,0.0,0.04,lance scott young,BUS-1010,2014
-BUS,1010,2,BUS 1010: 002,0.1,0.59,0.24,0.03,0.03,0.0,0.0,0.0,michael giebner,BUS-1010,2014
-BUS,1010,3,BUS 1010: 003,0.12,0.55,0.28,0.02,0.02,0.0,0.0,0.02,lance scott young,BUS-1010,2014
-BUS,1010,4,BUS 1010: 004,0.0,0.57,0.27,0.03,0.07,0.0,0.0,0.07,michael giebner,BUS-1010,2014
-BUS,1010,6,BUS 1010: 006,0.15,0.5,0.22,0.03,0.06,0.0,0.0,0.04,michael giebner,BUS-1010,2014
-CE,2010,1,Statics,0.43,0.2,0.07,0.09,0.07,0.0,0.0,0.14,nighat yasmin,CE-2010,2014
-CE,2010,2,Statics,0.3,0.25,0.25,0.09,0.02,0.0,0.0,0.09,melissa sternhagen,CE-2010,2014
-CE,2010,3,Statics,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,CE-2010,2014
-CE,2010,4,Statics,0.36,0.3,0.2,0.02,0.0,0.0,0.0,0.11,melissa sternhagen,CE-2010,2014
-CE,2010,5,Statics,0.44,0.21,0.16,0.05,0.07,0.0,0.0,0.07,nighat yasmin,CE-2010,2014
-CE,2010,6,Statics,0.37,0.37,0.17,0.03,0.0,0.0,0.0,0.06,weichiang pang,CE-2010,2014
-CE,2010,7,Statics,0.27,0.52,0.09,0.03,0.03,0.0,0.0,0.06,ismail farajpour,CE-2010,2014
-CE,2060,1,CE 2060: 001,0.22,0.43,0.24,0.04,0.04,0.0,0.0,0.04,bryant nielson,CE-2060,2014
-CE,2060,2,CE 2060: 002,0.22,0.49,0.16,0.06,0.0,0.0,0.0,0.06,bryant nielson,CE-2060,2014
-CE,2080,1,CE 2080: 001,0.24,0.36,0.24,0.04,0.04,0.04,0.0,0.04,melissa sternhagen,CE-2080,2014
-CE,2080,2,CE 2080: 002,0.19,0.34,0.25,0.08,0.03,0.0,0.0,0.1,melissa sternhagen,CE-2080,2014
-CE,2080,3,CE 2080: 003,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,CE-2080,2014
-CE,2080,4,CE 2080: 004,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,CE-2080,2014
-CE,2550,1,CE 2550: 001,0.32,0.48,0.19,0.01,0.0,0.0,0.0,0.0,wayne sarasua,CE-2550,2014
-CE,3010,1,CE 3010: 001,0.17,0.17,0.29,0.1,0.17,0.0,0.0,0.12,scott schiff,CE-3010,2014
-CE,3110,1,CE 3110: 001,0.31,0.31,0.21,0.12,0.04,0.0,0.0,0.01,wayne sarasua,CE-3110,2014
-CE,3210,1,CE 3210: 001,0.59,0.3,0.09,0.0,0.0,0.0,0.0,0.02,charng-hsein juang,CE-3210,2014
-CE,3210,2,CE 3210: 002,0.4,0.4,0.08,0.04,0.08,0.0,0.0,0.0,qiushi chen,CE-3210,2014
-CE,3310,1,CE 3310: 001,0.45,0.29,0.17,0.05,0.02,0.0,0.0,0.02,james burati,CE-3310,2014
-CE,3410,1,CE 3410: 001,0.54,0.28,0.13,0.01,0.03,0.0,0.0,0.03,firat yener testik,CE-3410,2014
-CE,3420,1,CE 3420: 001,0.29,0.35,0.18,0.06,0.12,0.0,0.0,0.0,abdul khan,CE-3420,2014
-CE,3420,2,CE 3420: 002,0.39,0.49,0.1,0.02,0.0,0.0,0.0,0.0,ashok mishra,CE-3420,2014
-CE,3510,1,CE 3510: 001,0.5,0.33,0.1,0.03,0.0,0.0,0.0,0.05,ami esmaeilpoursaee,CE-3510,2014
-CE,3520,1,CE 3520: 001,0.31,0.31,0.19,0.1,0.03,0.0,0.0,0.06,yongxi huang,CE-3520,2014
-CE,3520,2,CE 3520: 002,0.41,0.37,0.13,0.04,0.04,0.0,0.0,0.02,bradley putman,CE-3520,2014
-CE,3530,1,CE 3530: 001,0.94,0.02,0.03,0.0,0.0,0.0,0.0,0.02,ronald andrus,CE-3530,2014
-CE,4010,1,CE 4010: 001,0.25,0.41,0.28,0.06,0.0,0.0,0.0,0.0,atamturktur russcher,CE-4010,2014
-CE,4020,1,CE 4020: 001,0.52,0.25,0.15,0.04,0.01,0.0,0.0,0.01,brandon ross,CE-4020,2014
-CE,4070,1,CE 4070: 001,0.19,0.35,0.32,0.13,0.0,0.0,0.0,0.0,weichiang pang,CE-4070,2014
-CE,4110,1,CE 4110: 001,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.07,jennifer ogle,CE-4110,2014
-CE,4120,1,Urban Transport Plan,0.21,0.45,0.24,0.03,0.03,0.0,0.0,0.03,mashrur chowdhury,CE-4120,2014
-CE,4210,1,CE 4210: 001,0.26,0.35,0.31,0.07,0.0,0.0,0.0,0.0,nadara ravichandran,CE-4210,2014
-CE,4340,1,CE 4340: 001,0.62,0.27,0.07,0.04,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4340,2014
-CE,4470,1,CE 4470: 001,0.59,0.22,0.19,0.0,0.0,0.0,0.0,0.0,nigel gregory kaye,CE-4470,2014
-CE,4590,1,CE 4590: 001,0.48,0.47,0.06,0.0,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2014
-CE,4620,1,CE 4620: 001,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,firat yener testik,CE-4620,2014
-CE,4910,1,Sustainable Proj Planning 3cr,0.73,0.2,0.05,0.0,0.02,0.0,0.0,0.0,leidy klotz,CE-4910,2014
-CE,6010,1,CE 6010: 001,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,CE-6010,2014
-CE,6070,1,CE 6070: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-6070,2014
-CE,8010,1,CE 8010: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,CE-8010,2014
-CE,8030,1,CE 8030: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,scott schiff,CE-8030,2014
-CE,8050,1,CE 8050: 001,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,bryant nielson,CE-8050,2014
-CE,8200,1,CE 8200: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-8200,2014
-CE,8280,1,CE 8280: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,CE-8280,2014
-CE,8530,1,CE 8530: 001,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-8530,2014
-CE,8930,1,Selec Topics in C E,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,CE-8930,2014
-CH,1010,1,General Chemistry,0.4,0.34,0.17,0.02,0.03,0.0,0.0,0.04,stephe schvaneveldt,CH-1010,2014
-CH,1010,2,General Chemistry,0.04,0.18,0.26,0.25,0.17,0.0,0.0,0.1,stephanie mccartney,CH-1010,2014
-CH,1010,3,General Chemistry,0.05,0.21,0.35,0.18,0.19,0.0,0.0,0.03,stephanie mccartney,CH-1010,2014
-CH,1010,4,General Chemistry,0.13,0.23,0.22,0.17,0.17,0.0,0.0,0.08,dennis taylor,CH-1010,2014
-CH,1010,400,General Chemistry,0.13,0.28,0.28,0.13,0.15,0.0,0.0,0.03,stephe schvaneveldt,CH-1010,2014
-CH,1020,1,General Chemistry,0.33,0.32,0.2,0.04,0.06,0.0,0.0,0.05,dennis taylor,CH-1020,2014
-CH,1020,2,General Chemistry,0.13,0.46,0.26,0.04,0.06,0.0,0.0,0.06,stephanie mccartney,CH-1020,2014
-CH,1020,3,General Chemistry,0.29,0.34,0.3,0.05,0.01,0.0,0.0,0.01,tania issa houjeiry,CH-1020,2014
-CH,1020,4,General Chemistry,0.34,0.43,0.13,0.06,0.01,0.0,0.0,0.04,karen an pressprich,CH-1020,2014
-CH,1020,5,General Chemistry,0.56,0.15,0.3,0.0,0.0,0.0,0.0,0.0,karen an pressprich,CH-1020,2014
-CH,1020,6,General Chemistry,0.29,0.36,0.25,0.05,0.03,0.0,0.0,0.03,dennis taylor,CH-1020,2014
-CH,1020,7,General Chemistry,0.2,0.45,0.27,0.04,0.02,0.0,0.0,0.02,kenneth wi rillings,CH-1020,2014
-CH,1020,8,General Chemistry,0.25,0.43,0.22,0.06,0.0,0.0,0.0,0.05,karen an pressprich,CH-1020,2014
-CH,1020,9,General Chemistry,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,kenneth wi rillings,CH-1020,2014
-CH,1020,10,General Chemistry,0.08,0.46,0.23,0.08,0.0,0.0,0.0,0.15,olt geiculescu,CH-1020,2014
-CH,1020,11,General Chemistry,0.2,0.48,0.2,0.07,0.01,0.0,0.0,0.05,kenneth wi rillings,CH-1020,2014
-CH,1020,12,General Chemistry,0.32,0.41,0.24,0.02,0.0,0.0,0.0,0.01,kenneth christensen,CH-1020,2014
-CH,1020,51,General Chemistry (HON),0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,CH-1020,2014
-CH,1020,52,General Chemistry (HON),0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,shiou-jyh hwu,CH-1020,2014
-CH,1050,1,Chem in Context I,0.23,0.49,0.24,0.04,0.0,0.0,0.0,0.0,thomas hickman,CH-1050,2014
-CH,1060,1,Chem in Context II,0.39,0.53,0.08,0.0,0.0,0.0,0.0,0.0,olt geiculescu,CH-1060,2014
-CH,1060,2,Chem in Context II,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,olt geiculescu,CH-1060,2014
-CH,1520,1,CH 1520: 001,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,richard marcus,CH-1520,2014
-CH,2010,1,CH 2010: 001,0.29,0.19,0.2,0.14,0.08,0.0,0.0,0.08,thomas hickman,CH-2010,2014
-CH,2011,2,CH 2011: 002,0.76,0.12,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2011,2014
-CH,2011,3,CH 2011: 003,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,sean 'connor,CH-2011,2014
-CH,2050,1,CH 2050: 001,0.48,0.3,0.18,0.0,0.0,0.0,0.0,0.05,william pennington,CH-2050,2014
-CH,2230,1,CH 2230: 001,0.34,0.35,0.21,0.02,0.06,0.0,0.0,0.02,jacob schroeder,CH-2230,2014
-CH,2230,2,CH 2230: 002,0.35,0.41,0.14,0.02,0.03,0.0,0.0,0.05,jacob schroeder,CH-2230,2014
-CH,2230,3,CH 2230: 003,0.26,0.29,0.24,0.08,0.05,0.0,0.0,0.08,thomas hickman,CH-2230,2014
-CH,2240,1,CH 2240: 001,0.32,0.47,0.1,0.08,0.02,0.0,0.0,0.01,tania issa houjeiry,CH-2240,2014
-CH,2240,2,CH 2240: 002,0.23,0.5,0.2,0.08,0.0,0.0,0.0,0.0,tania issa houjeiry,CH-2240,2014
-CH,2240,3,CH 2240: 003,0.2,0.36,0.27,0.07,0.04,0.0,0.0,0.05,jacob schroeder,CH-2240,2014
-CH,2240,4,CH 2240: 004,0.26,0.26,0.26,0.14,0.02,0.0,0.0,0.06,rhett smith,CH-2240,2014
-CH,2240,5,CH 2240: 005,0.32,0.39,0.19,0.06,0.01,0.0,0.0,0.03,modi wetzler,CH-2240,2014
-CH,2270,2,CH 2270: 002,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,3,CH 2270: 003,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,4,CH 2270: 004,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2014
-CH,2270,7,CH 2270: 007,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2014
-CH,2270,8,CH 2270: 008,0.69,0.25,0.0,0.06,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,9,CH 2270: 009,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2270,10,CH 2270: 010,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,sean 'connor,CH-2270,2014
-CH,2280,2,CH 2280: 002,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,sean 'connor,CH-2280,2014
-CH,2280,3,CH 2280: 003,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2014
-CH,2280,4,CH 2280: 004,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2280,2014
-CH,2280,5,CH 2280: 005,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2014
-CH,2280,8,CH 2280: 008,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2014
-CH,2280,13,CH 2280: 013,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2280,2014
-CH,2280,14,CH 2280: 014,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,CH-2280,2014
-CH,2280,18,CH 2280: 018,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2014
-CH,2280,23,CH 2280: 023,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2014
-CH,2280,29,CH 2280: 029,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2014
-CH,2290,1,CH 2290: 001,0.78,0.06,0.06,0.11,0.0,0.0,0.0,0.0,sean 'connor,CH-2290,2014
-CH,2290,2,CH 2290: 002,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2290,2014
-CH,3310,1,CH 3310: 001,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,arkady kholodenko,CH-3310,2014
-CH,3320,1,Physical Chemistry,0.33,0.44,0.18,0.03,0.03,0.0,0.0,0.0,steven stuart,CH-3320,2014
-CH,3320,2,Physical Chemistry,0.45,0.32,0.14,0.09,0.0,0.0,0.0,0.0,dvora perahia,CH-3320,2014
-CH,3400,1,CH 3400: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason mcneill,CH-3400,2014
-CH,3400,2,CH 3400: 002,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason mcneill,CH-3400,2014
-CH,3600,1,CH 3600: 001,0.34,0.39,0.2,0.07,0.0,0.0,0.0,0.0,brian dominy,CH-3600,2014
-CH,4110,1,CH 4110: 001,0.1,0.29,0.33,0.1,0.19,0.0,0.0,0.0,george chumanov,CH-4110,2014
-CH,4120,1,CH 4120: 001,0.27,0.64,0.0,0.0,0.09,0.0,0.0,0.0,jeffrey natha anker,CH-4120,2014
-CH,4130,1,Chem Aqueous Systems,0.29,0.29,0.36,0.07,0.0,0.0,0.0,0.0,cindy lee,CH-4130,2014
-CH,4500,1,CH 4500: 001,0.55,0.17,0.24,0.03,0.0,0.0,0.0,0.0,gauta bhattacharyya,CH-4500,2014
-CH,4520,1,CH 4520: 001,0.86,0.07,0.03,0.03,0.0,0.0,0.0,0.0,richard marcus,CH-4520,2014
-CH,8180,1,CH 8180: 001,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,stephen creager,CH-8180,2014
-CH,8220,1,CH 8220: 001,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,daniel whitehead,CH-8220,2014
-CH,8510,2,CH 8510: 002,0.94,0.0,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey natha anker,CH-8510,2014
-CH,8600,1,CH 8600: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,CH-8600,2014
-CHE,1300,1,CHE 1300: 001,0.26,0.42,0.25,0.04,0.0,0.0,0.0,0.04,antho guiseppi-elie,CHE-1300,2014
-CHE,1300,2,CHE 1300: 002,0.38,0.38,0.17,0.02,0.0,0.0,0.0,0.05,christopher norfolk,CHE-1300,2014
-CHE,2200,1,CHE 2200: 001,0.14,0.08,0.3,0.22,0.16,0.0,0.0,0.11,mark thies,CHE-2200,2014
-CHE,2200,2,CHE 2200: 002,0.11,0.23,0.31,0.11,0.14,0.0,0.0,0.09,mark thies,CHE-2200,2014
-CHE,2300,1,CHE 2300: 001,0.09,0.23,0.3,0.19,0.17,0.0,0.0,0.02,sapna sarupria,CHE-2300,2014
-CHE,2300,2,CHE 2300: 002,0.15,0.27,0.27,0.15,0.12,0.0,0.0,0.04,sapna sarupria,CHE-2300,2014
-CHE,3210,1,CHE 3210: 001,0.16,0.22,0.33,0.24,0.04,0.0,0.0,0.02,christophe kitchens,CHE-3210,2014
-CHE,3300,1,CHE 3300: 001,0.2,0.33,0.29,0.12,0.04,0.0,0.0,0.02,mark alan blenner,CHE-3300,2014
-CHE,3530,1,CHE 3530: 001,0.14,0.5,0.3,0.07,0.0,0.0,0.0,0.0,mark roberts,CHE-3530,2014
-CHE,4330,1,CHE 4330: 001,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4330,2014
-CHE,8450,2,E-Storage in Carbon Materials,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark roberts,CHE-8450,2014
-CHIN,1020,1,CHIN 1020: 001,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,yanhua zhang,CHIN-1020,2014
-CHIN,2020,1,CHIN 2020: 001,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,yanhua zhang,CHIN-2020,2014
-COM,1500,1,Intro to Human Com,0.63,0.31,0.02,0.01,0.01,0.0,0.0,0.03,eddie smith,COM-1500,2014
-COM,1500,2,Intro to Human Com,0.44,0.42,0.07,0.01,0.02,0.0,0.0,0.05,daniel lelan fecher,COM-1500,2014
-COM,1500,3,Intro to Human Com,0.7,0.21,0.05,0.0,0.01,0.0,0.0,0.03,eddie smith,COM-1500,2014
-COM,1500,4,Intro to Human Com,0.48,0.39,0.08,0.01,0.02,0.0,0.0,0.02,marianne her glaser,COM-1500,2014
-COM,1500,5,Intro to Human Com,0.45,0.44,0.05,0.02,0.02,0.0,0.0,0.02,marianne her glaser,COM-1500,2014
-COM,1500,6,Intro to Human Com,0.45,0.49,0.03,0.01,0.0,0.0,0.0,0.01,daniel lelan fecher,COM-1500,2014
-COM,2010,1,COMM 2010: 001,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,john steven spinda,COM-2010,2014
-COM,2010,2,COMM 2010: 002,0.46,0.33,0.17,0.04,0.0,0.0,0.0,0.0,brenden kendall,COM-2010,2014
-COM,2500,1,Public Speaking,0.44,0.33,0.11,0.0,0.06,0.0,0.0,0.06,brandon boatwright,COM-2500,2014
-COM,2500,2,Public Speaking,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2014
-COM,2500,3,Public Speaking,0.44,0.33,0.0,0.11,0.06,0.0,0.0,0.06,christop wasilewski,COM-2500,2014
-COM,2500,4,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2014
-COM,2500,5,Public Speaking,0.58,0.21,0.16,0.0,0.0,0.0,0.0,0.05,brandon boatwright,COM-2500,2014
-COM,2500,6,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2014
-COM,2500,7,Public Speaking,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2014
-COM,2500,8,Public Speaking,0.4,0.45,0.1,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2014
-COM,2500,9,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2014
-COM,2500,10,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2014
-COM,2500,11,Public Speaking,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2014
-COM,2500,12,Public Speaking,0.42,0.53,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,COM-2500,2014
-COM,2500,13,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2014
-COM,2500,14,Public Speaking,0.37,0.47,0.05,0.0,0.11,0.0,0.0,0.0,christop wasilewski,COM-2500,2014
-COM,2500,15,Public Speaking,0.45,0.35,0.15,0.0,0.0,0.0,0.0,0.05,caitlin baker,COM-2500,2014
-COM,2500,16,Public Speaking,0.75,0.15,0.05,0.05,0.0,0.0,0.0,0.0,the estate  geddes,COM-2500,2014
-COM,2500,17,Public Speaking,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2014
-COM,2500,18,Public Speaking,0.42,0.37,0.11,0.05,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2014
-COM,2500,19,Public Speaking,0.15,0.45,0.35,0.0,0.05,0.0,0.0,0.0,pauline matthey,COM-2500,2014
-COM,2500,20,Public Speaking,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2014
-COM,2500,21,Public Speaking,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,COM-2500,2014
-COM,2500,22,Public Speaking,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,COM-2500,2014
-COM,2500,23,Public Speaking,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,caitlin baker,COM-2500,2014
-COM,2500,24,Public Speaking,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,kayla steele payne,COM-2500,2014
-COM,2500,25,Public Speaking (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,COM-2500,2014
-COM,2500,400,Public Speaking,0.7,0.15,0.05,0.05,0.0,0.0,0.0,0.05,alexis zachar davis,COM-2500,2014
-COM,2500,401,Public Speaking,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,COM-2500,2014
-COM,2500,402,Public Speaking,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,COM-2500,2014
-COM,2500,403,Public Speaking,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,COM-2500,2014
-COM,2500,500,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2014
-COM,3020,1,COMM 3020: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3020,2014
-COM,3080,1,Pub Comm & Pop Cult,0.55,0.26,0.15,0.02,0.02,0.0,0.0,0.0,chenjerai kumanyika,COM-3080,2014
-COM,3100,1,COMM 3100: 001,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3100,2014
-COM,3110,1,COMM 3110: 001,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-3110,2014
-COM,3200,1,COMM 3200: 001,0.88,0.04,0.0,0.0,0.04,0.0,0.0,0.04,wanda johnson,COM-3200,2014
-COM,3260,1,COMM 3260: 001,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,COM-3260,2014
-COM,3480,1,COMM 3480: 001,0.31,0.44,0.17,0.06,0.0,0.0,0.0,0.02,melinda ra weathers,COM-3480,2014
-COM,3560,1,COMM 3560: 001,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristie leah byrum,COM-3560,2014
-COM,3610,1,COMM 3610: 001,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,lindsey dixon,COM-3610,2014
-COM,3660,1,EP: Advertising & Media,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,william reynolds,COM-3660,2014
-COM,3660,3,Live Broadcast Production,0.91,0.04,0.0,0.04,0.0,0.0,0.0,0.0,michael rodgers,COM-3660,2014
-COM,4250,1,COMM 4250: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4250,2014
-COM,4950,1,Senior Capstone Sem,0.67,0.1,0.24,0.0,0.0,0.0,0.0,0.0,chenjerai kumanyika,COM-4950,2014
-COM,8020,1,COMM 8020: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-8020,2014
-COM,8110,1,COMM 8110: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brenden kendall,COM-8110,2014
-CPSC,1010,1,Computer Science I,0.28,0.15,0.15,0.08,0.25,0.0,0.0,0.09,catherine hochrine,CPSC-1010,2014
-CPSC,1010,2,Computer Science I,0.29,0.2,0.16,0.07,0.16,0.0,0.0,0.13,kyla mcmullen,CPSC-1010,2014
-CPSC,1020,1,Computer Science II,0.38,0.38,0.07,0.04,0.02,0.0,0.0,0.11,catherine hochrine,CPSC-1020,2014
-CPSC,1020,2,Computer Science II,0.51,0.26,0.09,0.06,0.09,0.0,0.0,0.0,sabarish venka babu,CPSC-1020,2014
-CPSC,1110,1,CPSC 1110: 001,0.79,0.14,0.03,0.0,0.0,0.0,0.0,0.03,patrick sterling,CPSC-1110,2014
-CPSC,1110,2,CPSC 1110: 002,0.58,0.15,0.08,0.12,0.0,0.0,0.0,0.08,patrick sterling,CPSC-1110,2014
-CPSC,1110,3,CPSC 1110: 003,0.47,0.27,0.07,0.03,0.07,0.03,0.0,0.07,patrick sterling,CPSC-1110,2014
-CPSC,1110,4,CPSC 1110: 004,0.77,0.03,0.03,0.07,0.0,0.0,0.0,0.1,lauren elizab dukes,CPSC-1110,2014
-CPSC,2070,1,CPSC 2070: 001,0.36,0.32,0.14,0.07,0.09,0.0,0.0,0.02,larry hodges,CPSC-2070,2014
-CPSC,2070,2,CPSC 2070: 002,0.21,0.15,0.29,0.12,0.09,0.0,0.0,0.15,sandra hedetniemi,CPSC-2070,2014
-CPSC,2100,1,CPSC 2100: 001,0.26,0.26,0.15,0.15,0.07,0.0,0.0,0.11,rose lowe,CPSC-2100,2014
-CPSC,2120,1,Algs/Data Structures,0.36,0.29,0.18,0.07,0.07,0.0,0.0,0.04,feng luo,CPSC-2120,2014
-CPSC,2120,2,Algs/Data Structures,0.41,0.38,0.06,0.06,0.06,0.0,0.0,0.03,raghuveer mohan,CPSC-2120,2014
-CPSC,2150,1,CPSC 2150: 001,0.19,0.29,0.17,0.17,0.07,0.0,0.0,0.12,catherine hochrine,CPSC-2150,2014
-CPSC,2150,2,CPSC 2150: 002,0.48,0.3,0.09,0.09,0.03,0.0,0.0,0.0,john yates monteith,CPSC-2150,2014
-CPSC,2200,1,CPSC 2200: 001,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,patrick sterling,CPSC-2200,2014
-CPSC,2310,1,CPSC 2310: 001,0.47,0.26,0.1,0.06,0.06,0.0,0.0,0.04,rose lowe,CPSC-2310,2014
-CPSC,2910,1,CPSC 2910: 001,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,james jones,CPSC-2910,2014
-CPSC,2910,3,CPSC 2910: 003,0.73,0.0,0.0,0.0,0.09,0.0,0.0,0.18,james jones,CPSC-2910,2014
-CPSC,2910,4,CPSC 2910: 004,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,renee lambert,CPSC-2910,2014
-CPSC,2910,5,CPSC 2910: 005,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,renee lambert,CPSC-2910,2014
-CPSC,2910,6,CPSC 2910: 006,0.6,0.1,0.1,0.0,0.2,0.0,0.0,0.0,renee lambert,CPSC-2910,2014
-CPSC,2910,7,CPSC 2910: 007,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,renee lambert,CPSC-2910,2014
-CPSC,3220,1,Intro to Operating Systems,0.26,0.3,0.28,0.04,0.09,0.0,0.0,0.02,mark smotherman,CPSC-3220,2014
-CPSC,3300,1,CPSC 3300: 001,0.26,0.17,0.28,0.09,0.09,0.0,0.0,0.11,mark smotherman,CPSC-3300,2014
-CPSC,3500,1,CPSC 3500: 001,0.27,0.41,0.27,0.02,0.03,0.0,0.0,0.0,wayne goddard,CPSC-3500,2014
-CPSC,3520,1,Programming Systems,0.09,0.34,0.21,0.02,0.09,0.0,0.0,0.26,robert schalkoff,CPSC-3520,2014
-CPSC,3600,1,CPSC 3600: 001,0.23,0.3,0.09,0.09,0.11,0.0,0.0,0.18,jacob sorber,CPSC-3600,2014
-CPSC,3620,1,CPSC 3620: 001,0.28,0.28,0.3,0.02,0.0,0.0,0.0,0.12,amy apon,CPSC-3620,2014
-CPSC,3720,1,CPSC 3720: 001,0.33,0.47,0.14,0.02,0.0,0.0,0.0,0.04,stephen schaub,CPSC-3720,2014
-CPSC,4050,1,CPSC 4050: 001,0.26,0.3,0.13,0.04,0.13,0.0,0.0,0.13,donald henry house,CPSC-4050,2014
-CPSC,4140,1,CPSC 4140: 001,0.21,0.63,0.0,0.0,0.04,0.0,0.0,0.13,andrew duchowski,CPSC-4140,2014
-CPSC,4160,1,CPSC 4160: 001,0.36,0.36,0.28,0.0,0.0,0.0,0.0,0.0,brian malloy,CPSC-4160,2014
-CPSC,4240,1,CPSC 4240: 001,0.29,0.63,0.0,0.0,0.04,0.0,0.0,0.04,james martin,CPSC-4240,2014
-CPSC,4620,1,Database Management Systems,0.22,0.35,0.17,0.04,0.04,0.0,0.0,0.17,zijun wang,CPSC-4620,2014
-CPSC,4810,3,Topic:Software Dev for Mobile,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,roy pargas,CPSC-4810,2014
-CPSC,4810,13,Pro Gen of Video Game Media,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15,brian malloy,CPSC-4810,2014
-CPSC,4810,14,CI: Game & Python Programming,0.55,0.18,0.18,0.0,0.0,0.0,0.0,0.09,christina gardner,CPSC-4810,2014
-CPSC,4910,1,CPSC 4910: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james jones,CPSC-4910,2014
-CPSC,6050,1,CPSC 6050: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,donald henry house,CPSC-6050,2014
-CPSC,6140,1,CPSC 6140: 001,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,andrew duchowski,CPSC-6140,2014
-CPSC,6160,1,CPSC 6160: 001,0.52,0.38,0.0,0.0,0.0,0.05,0.0,0.05,brian malloy,CPSC-6160,2014
-CPSC,6240,1,CPSC 6240: 001,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,james martin,CPSC-6240,2014
-CPSC,6620,1,CPSC 6620: 001,0.29,0.53,0.12,0.0,0.03,0.0,0.0,0.03,zijun wang,CPSC-6620,2014
-CPSC,6810,1,Topic:Educational Technology,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christina gardner,CPSC-6810,2014
-CPSC,8080,1,CPSC 8080: 001,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,christina sop joerg,CPSC-8080,2014
-CPSC,8090,1,CPSC 8090: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,CPSC-8090,2014
-CPSC,8150,1,CPSC 8150: 001,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,timothy davis,CPSC-8150,2014
-CPSC,8190,1,CPSC 8190: 001,0.0,0.63,0.25,0.0,0.0,0.0,0.0,0.13,jerry tessendorf,CPSC-8190,2014
-CPSC,8220,1,CPSC 8220: 001,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,robert geist,CPSC-8220,2014
-CPSC,8400,1,CPSC 8400: 001,0.11,0.39,0.43,0.0,0.07,0.0,0.0,0.0,brian christop dean,CPSC-8400,2014
-CPSC,8520,1,CPSC 8520: 001,0.4,0.56,0.0,0.0,0.0,0.0,0.0,0.04,james martin,CPSC-8520,2014
-CPSC,8550,1,CPSC 8550: 001,0.45,0.27,0.18,0.0,0.0,0.0,0.0,0.09,jason hallstrom,CPSC-8550,2014
-CPSC,8620,1,CPSC 8620: 001,0.77,0.17,0.04,0.0,0.0,0.0,0.0,0.02,juan gilbert,CPSC-8620,2014
-CPSC,8630,1,CPSC 8630: 001,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,zijun wang,CPSC-8630,2014
-CPSC,8650,1,CPSC 8650: 001,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,zijun wang,CPSC-8650,2014
-CPSC,8750,1,CPSC 8750: 001,0.32,0.36,0.28,0.0,0.0,0.0,0.0,0.04,john mcgregor,CPSC-8750,2014
-CPSC,8810,1,Topic:Geometric Modeling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joshua levine,CPSC-8810,2014
-CRP,8010,1,Planning Process & Legal Found,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,CRP-8010,2014
-CRP,8050,1,Plning Theory & Hist,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,mickey lauria,CRP-8050,2014
-CRP,8090,1,CRP 8090: 001,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,barry nocks,CRP-8090,2014
-CRP,8140,1,Public Transit,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,CRP-8140,2014
-CRP,8220,1,Urban Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,CRP-8220,2014
-CRP,8890,3,S. Topic-Geodesign w/ CityEng.,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,CRP-8890,2014
-CSEN,2020,1,CSEN 2020: 001,0.4,0.23,0.13,0.15,0.04,0.0,0.0,0.04,dara michelle park,CSEN-2020,2014
-CSEN,4520,1,CSEN 4520: 001,0.52,0.39,0.0,0.0,0.0,0.0,0.0,0.09,haibo liu,CSEN-4520,2014
-CSM,1500,1,CSM 1500: 001,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-1500,2014
-CSM,1500,2,CSM 1500: 002,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-1500,2014
-CSM,2020,1,CSM 2020: 001,0.1,0.43,0.38,0.1,0.0,0.0,0.0,0.0,shima clarke,CSM-2020,2014
-CSM,2020,2,CSM 2020: 002,0.24,0.53,0.24,0.0,0.0,0.0,0.0,0.0,shima clarke,CSM-2020,2014
-CSM,2040,1,CSM 2040: 001,0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2040,2014
-CSM,2040,2,CSM 2040: 002,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2040,2014
-CSM,2050,1,CSM 2050: 001,0.42,0.21,0.21,0.16,0.0,0.0,0.0,0.0,jason lucas,CSM-2050,2014
-CSM,2050,2,CSM 2050: 002,0.3,0.25,0.35,0.1,0.0,0.0,0.0,0.0,jason lucas,CSM-2050,2014
-CSM,3050,1,CSM 3050: 001,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3050,2014
-CSM,3050,2,CSM 3050: 002,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3050,2014
-CSM,3520,1,CSM 3520: 001,0.24,0.67,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-3520,2014
-CSM,3520,2,CSM 3520: 002,0.06,0.47,0.35,0.12,0.0,0.0,0.0,0.0,christine piper,CSM-3520,2014
-CSM,3530,1,CSM 3530: 001,0.3,0.65,0.04,0.0,0.0,0.0,0.0,0.0,james packer smith,CSM-3530,2014
-CSM,3530,2,CSM 3530: 002,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,james packer smith,CSM-3530,2014
-CSM,4540,1,CSM 4540: 001,0.2,0.4,0.4,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4540,2014
-CSM,4540,2,CSM 4540: 002,0.2,0.47,0.33,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-4540,2014
-CSM,8620,1,Personnel Mgt & Neg,0.13,0.38,0.38,0.0,0.0,0.0,0.0,0.13,roger william liska,CSM-8620,2014
-CSM,8620,400,Personnel Mgt & Neg,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-8620,2014
-CU,1000,1,CU 1000: 001,0.0,0.0,0.0,0.0,0.0,0.87,0.11,0.02,jeffrey appling,CU-1000,2014
-CU,1010,1,CU 1010: 001,0.38,0.38,0.13,0.0,0.08,0.0,0.0,0.04,rise jean sheriff,CU-1010,2014
-CU,1010,2,CU 1010: 002,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,cecelia hamby,CU-1010,2014
-CU,1010,3,CU 1010: 003,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,donna mccubbin,CU-1010,2014
-CU,1010,5,CU 1010: 005,0.85,0.07,0.0,0.0,0.04,0.0,0.0,0.04,mary mcp von kaenel,CU-1010,2014
-CU,1010,6,CU 1010: 006,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,mary mcp von kaenel,CU-1010,2014
-CU,1010,10,CU 1010: 010,0.63,0.2,0.1,0.03,0.03,0.0,0.0,0.0, elaine richardson,CU-1010,2014
-CU,2010,1,CU 2010: 001,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,leidy klotz,CU-2010,2014
-DANC,1400,1,Jazz Dance I,0.91,0.0,0.05,0.0,0.05,0.0,0.0,0.0,cheryl hosler,DANC-1400,2014
-DANC,1500,1,Modern Dance I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,cheryl hosler,DANC-1500,2014
-DPA,3070,1,DPA 3070: 001,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,timothy curtis,DPA-3070,2014
-ECE,2010,1,Logic & Comp Device,0.21,0.27,0.19,0.31,0.0,0.0,0.0,0.02,lin zhu,ECE-2010,2014
-ECE,2020,1,Electric Circuits I,0.17,0.4,0.18,0.12,0.11,0.0,0.0,0.02,william harrell,ECE-2020,2014
-ECE,2090,2,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,timothy burg,ECE-2090,2014
-ECE,2090,3,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,ECE-2090,2014
-ECE,2090,4,Logic Lab,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,ECE-2090,2014
-ECE,2110,1,ECE 2110: 001,0.58,0.25,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,ECE-2110,2014
-ECE,2110,3,ECE 2110: 003,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,ECE-2110,2014
-ECE,2120,7,ECE 2120: 007,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,timothy burg,ECE-2120,2014
-ECE,2220,1,ECE 2220: 001,0.13,0.22,0.24,0.14,0.19,0.0,0.0,0.09,william reid,ECE-2220,2014
-ECE,2230,1,ECE 2230: 001,0.25,0.14,0.25,0.11,0.04,0.0,0.0,0.21,harlan russell,ECE-2230,2014
-ECE,2620,1,Elec Circuits II,0.24,0.29,0.29,0.11,0.05,0.0,0.0,0.01,richard groff,ECE-2620,2014
-ECE,2620,2,Elec Circuits II (HON),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2620,2014
-ECE,2720,1,Comp Organization,0.24,0.27,0.32,0.09,0.09,0.0,0.0,0.0,william reid,ECE-2720,2014
-ECE,2730,1,Computer Org Lab,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-2730,2014
-ECE,2730,2,Computer Org Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-2730,2014
-ECE,2730,3,Computer Org Lab,0.5,0.25,0.13,0.0,0.06,0.0,0.0,0.06,timothy burg,ECE-2730,2014
-ECE,2730,4,Computer Org Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-2730,2014
-ECE,2730,5,Computer Org Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-2730,2014
-ECE,3070,1,ECE 3070: 001,0.48,0.17,0.15,0.03,0.01,0.0,0.0,0.16,timothy burg,ECE-3070,2014
-ECE,3070,2,ECE 3070: 002,0.39,0.27,0.14,0.05,0.01,0.0,0.0,0.15,timothy burg,ECE-3070,2014
-ECE,3070,3,ECE 3070: 003,0.96,0.02,0.0,0.02,0.0,0.0,0.0,0.0,sung- kim,ECE-3070,2014
-ECE,3090,1,ECE 3090: 001,0.79,0.05,0.0,0.0,0.0,0.0,0.0,0.16,timothy burg,ECE-3090,2014
-ECE,3090,4,ECE 3090: 004,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,ECE-3090,2014
-ECE,3090,5,ECE 3090: 005,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,ECE-3090,2014
-ECE,3090,6,ECE 3090: 006,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,ECE-3090,2014
-ECE,3090,8,ECE 3090: 008,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,timothy burg,ECE-3090,2014
-ECE,3090,9,ECE 3090: 009,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-3090,2014
-ECE,3090,11,ECE 3090: 011,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,ECE-3090,2014
-ECE,3090,14,ECE 3090: 014,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,ECE-3090,2014
-ECE,3110,1,ECE 3110: 001,0.73,0.07,0.07,0.0,0.0,0.0,0.0,0.13,timothy burg,ECE-3110,2014
-ECE,3110,3,ECE 3110: 003,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-3110,2014
-ECE,3120,3,ECE 3120: 003,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,timothy burg,ECE-3120,2014
-ECE,3120,4,ECE 3120: 004,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,timothy burg,ECE-3120,2014
-ECE,3170,1,Rand Signal Analysis,0.39,0.47,0.14,0.0,0.0,0.0,0.0,0.0,stephen hubbard,ECE-3170,2014
-ECE,3170,2,Rand Signal Analysis (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,carl baum,ECE-3170,2014
-ECE,3200,1,Electronics I,0.44,0.37,0.1,0.07,0.0,0.0,0.0,0.01,stephen hubbard,ECE-3200,2014
-ECE,3210,1,ECE 3210: 001,0.15,0.39,0.3,0.13,0.01,0.0,0.0,0.01,stephen hubbard,ECE-3210,2014
-ECE,3220,1,Intro Operating Sys,0.39,0.43,0.11,0.0,0.04,0.0,0.0,0.04,mark smotherman,ECE-3220,2014
-ECE,3270,1,ECE 3270: 001,0.1,0.36,0.19,0.07,0.17,0.0,0.0,0.12,melissa crawl smith,ECE-3270,2014
-ECE,3300,1,Signals & Systems,0.23,0.16,0.26,0.2,0.08,0.0,0.0,0.07,carl baum,ECE-3300,2014
-ECE,3520,1,Programming Systems,0.5,0.35,0.12,0.0,0.0,0.0,0.0,0.04,robert schalkoff,ECE-3520,2014
-ECE,3600,1,ECE 3600: 001,0.35,0.21,0.26,0.09,0.09,0.0,0.0,0.0,ramtin hadidi,ECE-3600,2014
-ECE,3710,1,ECE 3710: 001,0.29,0.38,0.21,0.06,0.06,0.0,0.0,0.0,william reid,ECE-3710,2014
-ECE,3720,1,ECE 3720: 001,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-3720,2014
-ECE,3720,2,ECE 3720: 002,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-3720,2014
-ECE,3720,4,ECE 3720: 004,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,timothy burg,ECE-3720,2014
-ECE,3800,1,ECE 3800: 001,0.14,0.41,0.25,0.08,0.12,0.0,0.0,0.0,anthony martin,ECE-3800,2014
-ECE,3810,1,ECE 3810: 001,0.33,0.41,0.22,0.0,0.0,0.0,0.0,0.04,eric gordon johnson,ECE-3810,2014
-ECE,4090,1,ECE 4090: 001,0.47,0.3,0.21,0.0,0.0,0.0,0.0,0.02,darren dawson,ECE-4090,2014
-ECE,4170,1,ECE 4170: 001,0.29,0.41,0.0,0.06,0.0,0.0,0.0,0.24,darren dawson,ECE-4170,2014
-ECE,4190,1,ECE 4190: 001,0.6,0.28,0.04,0.04,0.04,0.0,0.0,0.0,keith corzine,ECE-4190,2014
-ECE,4200,1,ECE 4200: 001,0.29,0.18,0.38,0.06,0.03,0.0,0.0,0.06,elham makram,ECE-4200,2014
-ECE,4270,1,ECE 4270: 001,0.2,0.29,0.29,0.23,0.0,0.0,0.0,0.0,carl baum,ECE-4270,2014
-ECE,4380,1,ECE 4380: 001,0.31,0.31,0.31,0.0,0.0,0.0,0.0,0.06,harlan russell,ECE-4380,2014
-ECE,4400,1,ECE 4400: 001,0.38,0.41,0.18,0.0,0.0,0.0,0.0,0.03,kuang-ching wang,ECE-4400,2014
-ECE,4680,1,ECE 4680: 001,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,adam hoover,ECE-4680,2014
-ECE,4700,1,ECE 4700: 001,0.4,0.38,0.09,0.11,0.0,0.0,0.0,0.02,todd hubing,ECE-4700,2014
-ECE,4950,1,ECE 4950: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-4950,2014
-ECE,4960,1,ECE 4960: 001,0.48,0.41,0.11,0.0,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2014
-ECE,6170,1,ECE 6170: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,darren dawson,ECE-6170,2014
-ECE,6190,1,ECE 6190: 001,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,keith corzine,ECE-6190,2014
-ECE,6200,1,ECE 6200: 001,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,elham makram,ECE-6200,2014
-ECE,6380,1,ECE 6380: 001,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,ECE-6380,2014
-ECE,6400,1,ECE 6400: 001,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,ECE-6400,2014
-ECE,6680,1,ECE 6680: 001,0.69,0.06,0.25,0.0,0.0,0.0,0.0,0.0,adam hoover,ECE-6680,2014
-ECE,6930,2,CMOS Analog VLSI,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,ECE-6930,2014
-ECE,8240,1,ECE 8240: 001,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,ramtin hadidi,ECE-8240,2014
-ECE,8400,1,ECE 8400: 001,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,william harrell,ECE-8400,2014
-ECE,8440,1,ECE 8440: 001,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,john gowdy,ECE-8440,2014
-ECE,8480,1,ECE 8480: 001,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,ECE-8480,2014
-ECE,8720,1,ECE 8720: 001,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,robert schalkoff,ECE-8720,2014
-ECE,8740,1,ECE 8740: 001,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,ECE-8740,2014
-ECE,8930,1,Fiber Lasers,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,liang dong,ECE-8930,2014
-ECE,9910,32,ECE 9910: 032,0.0,0.0,0.0,0.0,0.0,0.6,0.4,0.0,hai ying shen,ECE-9910,2014
-ECON,2000,1,Economic Concepts,0.22,0.22,0.11,0.17,0.17,0.0,0.0,0.11,mallika garg,ECON-2000,2014
-ECON,2000,2,Economic Concepts,0.14,0.16,0.43,0.05,0.03,0.0,0.0,0.19,mallika garg,ECON-2000,2014
-ECON,2000,3,Economic Concepts,0.25,0.28,0.19,0.09,0.16,0.0,0.0,0.03,miren ivankovic,ECON-2000,2014
-ECON,2110,1,Principles of Microeconomics,0.18,0.33,0.43,0.05,0.03,0.0,0.0,0.0,eric peter makela,ECON-2110,2014
-ECON,2110,2,Principles of Microeconomics,0.13,0.55,0.18,0.0,0.13,0.0,0.0,0.0,ce castellon chicas,ECON-2110,2014
-ECON,2110,3,Principles of Microeconomics,0.12,0.44,0.33,0.07,0.05,0.0,0.0,0.0,adam millsap,ECON-2110,2014
-ECON,2110,4,Principles of Microeconomics,0.23,0.45,0.15,0.1,0.03,0.0,0.0,0.05,andew swanson,ECON-2110,2014
-ECON,2110,5,Principles of Microeconomics,0.35,0.3,0.23,0.08,0.03,0.0,0.0,0.03,jacob burgdorf,ECON-2110,2014
-ECON,2110,6,Principles of Microeconomics,0.26,0.26,0.23,0.21,0.02,0.0,0.0,0.02,timothy andr bersak,ECON-2110,2014
-ECON,2110,7,Principles of Microeconomics,0.17,0.41,0.3,0.08,0.01,0.0,0.0,0.03,adam millsap,ECON-2110,2014
-ECON,2110,8,Principles of Microeconomics,0.36,0.28,0.25,0.07,0.04,0.0,0.0,0.01,miren ivankovic,ECON-2110,2014
-ECON,2110,10,Principles of Microeconomics,0.22,0.3,0.26,0.04,0.02,0.0,0.0,0.15,robert dew tollison,ECON-2110,2014
-ECON,2110,11,Principles of Microeconomics,0.15,0.44,0.31,0.06,0.02,0.0,0.0,0.02,meng liu,ECON-2110,2014
-ECON,2110,12,Principles of Microeconomics,0.16,0.37,0.18,0.05,0.08,0.0,0.0,0.16,john devin shippey,ECON-2110,2014
-ECON,2110,13,Principles of Microecon(HON),0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,robert kennet fleck,ECON-2110,2014
-ECON,2120,1,Principles of Macro,0.16,0.37,0.37,0.0,0.11,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,2,Principles of Macro,0.06,0.44,0.5,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,3,Principles of Macro,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,4,Principles of Macro,0.21,0.47,0.26,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,5,Principles of Macro,0.18,0.35,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,6,Principles of Macro,0.16,0.37,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,7,Principles of Macro,0.11,0.22,0.56,0.06,0.0,0.0,0.0,0.06,scott baier,ECON-2120,2014
-ECON,2120,8,Principles of Macro,0.11,0.53,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,9,Principles of Macro,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,10,Principles of Macro,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,11,Principles of Macro,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,12,Principles of Macro,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,scott baier,ECON-2120,2014
-ECON,2120,13,Principles of Macro,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,14,Principles of Macro,0.26,0.37,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,15,Principles of Macro,0.21,0.37,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,16,Principles of Macro,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,17,Principles of Macro,0.21,0.53,0.21,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,18,Principles of Macro,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,19,Principles of Macro,0.17,0.39,0.33,0.11,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2014
-ECON,2120,20,Principles of Macro,0.3,0.45,0.23,0.0,0.0,0.0,0.0,0.03,anne anders,ECON-2120,2014
-ECON,2120,21,Principles of Macro,0.05,0.25,0.25,0.08,0.12,0.0,0.0,0.26,ralph charles allen,ECON-2120,2014
-ECON,2120,22,Principles of Macro,0.1,0.45,0.25,0.1,0.08,0.0,0.0,0.03,anne anders,ECON-2120,2014
-ECON,2120,23,Principles of Macro,0.35,0.4,0.18,0.0,0.05,0.0,0.0,0.03,yukun sun,ECON-2120,2014
-ECON,2120,24,Principles of Macro,0.09,0.18,0.24,0.09,0.16,0.0,0.0,0.24,ralph charles allen,ECON-2120,2014
-ECON,2120,25,Principles of Macro,0.25,0.55,0.1,0.1,0.0,0.0,0.0,0.0,lyudmyla ta sonchak,ECON-2120,2014
-ECON,2120,26,Principles of Macro,0.26,0.6,0.12,0.02,0.0,0.0,0.0,0.0,yukun sun,ECON-2120,2014
-ECON,3020,1,Money and Banking,0.2,0.4,0.15,0.1,0.13,0.0,0.0,0.03,danielle zanzalari,ECON-3020,2014
-ECON,3060,1,Managerial Economics,0.22,0.36,0.25,0.06,0.03,0.0,0.0,0.08,john devin shippey,ECON-3060,2014
-ECON,3100,1,International Econ,0.19,0.38,0.31,0.06,0.05,0.0,0.0,0.02,michal jerzmanowski,ECON-3100,2014
-ECON,3140,1,Intermediate Micro,0.21,0.26,0.16,0.0,0.11,0.0,0.0,0.26,patrick warren,ECON-3140,2014
-ECON,3140,2,Intermediate Micro,0.42,0.31,0.19,0.04,0.04,0.0,0.0,0.0,molly espey,ECON-3140,2014
-ECON,3140,3,Intermediate Micro,0.11,0.43,0.29,0.07,0.07,0.0,0.0,0.04,tomas cvrcek,ECON-3140,2014
-ECON,3150,1,Intermediate Macro,0.25,0.16,0.3,0.16,0.12,0.0,0.0,0.02,wesley harris,ECON-3150,2014
-ECON,3150,2,Intermediate Macro,0.37,0.4,0.2,0.0,0.03,0.0,0.0,0.0,sergey vla mityakov,ECON-3150,2014
-ECON,3440,1,Property Rights,0.17,0.43,0.22,0.09,0.04,0.0,0.0,0.04,dar litsukova-bokar,ECON-3440,2014
-ECON,4020,1,Law and Economics,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,thomas wins hazlett,ECON-4020,2014
-ECON,4050,1,Intro to Econometric,0.36,0.21,0.36,0.07,0.0,0.0,0.0,0.0,jaqueline oliveira,ECON-4050,2014
-ECON,4050,2,Intro to Econometric,0.31,0.15,0.31,0.0,0.23,0.0,0.0,0.0,jaqueline oliveira,ECON-4050,2014
-ECON,4050,3,Intro to Econometric,0.18,0.18,0.55,0.09,0.0,0.0,0.0,0.0,jaqueline oliveira,ECON-4050,2014
-ECON,4050,4,Intro to Econometric,0.17,0.25,0.17,0.33,0.08,0.0,0.0,0.0,jaqueline oliveira,ECON-4050,2014
-ECON,4110,1,Econ of Education,0.31,0.31,0.23,0.08,0.04,0.0,0.0,0.04,chungsang lam,ECON-4110,2014
-ECON,4130,1,International Macro,0.17,0.44,0.17,0.17,0.06,0.0,0.0,0.0,michal jerzmanowski,ECON-4130,2014
-ECON,4240,1,Organization of Ind,0.39,0.39,0.15,0.0,0.0,0.0,0.0,0.06,matthew lewis,ECON-4240,2014
-ECON,4250,1,Antitrust Economics,0.44,0.36,0.17,0.0,0.0,0.0,0.0,0.03,robert dew tollison,ECON-4250,2014
-ECON,4260,1,Sem Sport Economics,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,frederick hanssen,ECON-4260,2014
-ECON,4270,1,Dev American Economy,0.27,0.53,0.17,0.03,0.0,0.0,0.0,0.0,howard ne bodenhorn,ECON-4270,2014
-ECON,4350,1,Family Economics,0.06,0.45,0.27,0.09,0.06,0.0,0.0,0.06,tomas cvrcek,ECON-4350,2014
-ECON,4400,1,Game Theory,0.25,0.5,0.08,0.0,0.04,0.0,0.0,0.13,daniel wood,ECON-4400,2014
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.21,0.36,0.29,0.0,0.0,0.0,0.0,0.14,scott templeton,ECON-4570,2014
-ECON,6130,1,ECON 6130: 001,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,ECON-6130,2014
-ECON,8020,1,Adv Econ Concepts and Applic I,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,william dougan,ECON-8020,2014
-ECON,8050,1,ECON 8050: 001,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-8050,2014
-ECON,8070,1,ECON 8070: 001,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,thomas alvin mroz,ECON-8070,2014
-ECON,8200,1,Public Finance,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william dougan,ECON-8200,2014
-ECON,9010,1,Price Theory,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,daniel wood,ECON-9010,2014
-ECON,9090,1,ECON 9090: 001,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,gerald dwyer,ECON-9090,2014
-ECON,9170,1,Advanced Seminar Labor Econ,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,ECON-9170,2014
-ED,1050,1,ED 1050: 001,0.65,0.2,0.0,0.0,0.1,0.0,0.0,0.05,patrick womac,ED-1050,2014
-ED,1050,2,ED 1050: 002,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,patrick womac,ED-1050,2014
-ED,1050,3,ED 1050: 003,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,rory phil tannebaum,ED-1050,2014
-ED,1050,4,ED 1050: 004,0.8,0.08,0.0,0.0,0.08,0.0,0.0,0.04,rory phil tannebaum,ED-1050,2014
-ED,3220,1,ED 3220: 001,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,deborah smith,ED-3220,2014
-ED,8380,400,Physical Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard dallm white,ED-8380,2014
-ED,8380,537,Literacy Lessons Designed for,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,vicki steadman,ED-8380,2014
-ED,8390,505,ED 8390: 505,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0, paltrow zwerdling,ED-8390,2014
-ED,8600,400,ED 8600: 400,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,ED-8600,2014
-ED,9010,1,Research Design/ Infer. Stats,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,ED-9010,2014
-EDC,3900,10,EDC 3900: 010,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mary price,EDC-3900,2014
-EDC,3900,12,EDC 3900: 012,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mary price,EDC-3900,2014
-EDC,8060,1,EDC 8060: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,EDC-8060,2014
-EDC,8070,400,EDC 8070: 400,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,kristen leigh moran,EDC-8070,2014
-EDC,8190,1,EDC 8190: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,EDC-8190,2014
-EDEC,2200,1,EDEC 2200: 001,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,ysaaca axelrod,EDEC-2200,2014
-EDEL,3100,1,EDEL 3100: 001,0.91,0.04,0.0,0.0,0.04,0.0,0.0,0.0,alison eliz leonard,EDEL-3100,2014
-EDEL,3100,2,EDEL 3100: 002,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,jacqueline sh rosen,EDEL-3100,2014
-EDEL,3210,1,EDEL 3210: 001,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2014
-EDEL,4050,1,EDEL 4050: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,EDEL-4050,2014
-EDEL,4510,1,Elem Methods in Science Tchg,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,cynthia chri deaton,EDEL-4510,2014
-EDEL,4520,2,EDEL 4520: 002,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,james kwame dogbey,EDEL-4520,2014
-EDEL,4670,1,EDEL 4670: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDEL-4670,2014
-EDEL,4870,1,EDEL 4870: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,melinda spearman,EDEL-4870,2014
-EDF,3010,1,Principles of American Educat,0.2,0.36,0.32,0.0,0.0,0.0,0.0,0.12,robert green,EDF-3010,2014
-EDF,3010,2,Principles of American Educat,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,robert green,EDF-3010,2014
-EDF,3010,3,Principles of American Educat,0.54,0.35,0.08,0.03,0.0,0.0,0.0,0.0,suzanne rosenblith,EDF-3010,2014
-EDF,3020,1,Educ Psych,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,EDF-3020,2014
-EDF,3020,2,Educ Psych,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,deborah switzer,EDF-3020,2014
-EDF,3020,3,Educ Psych,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,EDF-3020,2014
-EDF,3020,5,Educ Psych,0.4,0.3,0.23,0.03,0.03,0.0,0.0,0.0,penelope mar vargas,EDF-3020,2014
-EDF,3150,1,Technology Skills for Learning,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,ryan visser,EDF-3150,2014
-EDF,3150,2,Technology Skills for Learning,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-3150,2014
-EDF,3340,1,Child Growth and Dev,0.69,0.21,0.07,0.0,0.0,0.0,0.0,0.03,winston holton,EDF-3340,2014
-EDF,3340,2,Child Growth and Dev,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,EDF-3340,2014
-EDF,3350,1,Adol Growth & Dev,0.31,0.52,0.17,0.0,0.0,0.0,0.0,0.0,david barrett,EDF-3350,2014
-EDF,3350,2,Adol Growth & Dev,0.67,0.23,0.1,0.0,0.0,0.0,0.0,0.0,david barrett,EDF-3350,2014
-EDF,4250,1,EDF 4250: 001,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4250,2014
-EDF,4800,2,Digital Media & Learning,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,david matthew boyer,EDF-4800,2014
-EDF,8800,400,EDF 8800: 400,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-8800,2014
-EDF,9050,1,EDF 9050: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,danielle chri herro,EDF-9050,2014
-EDL,7150,1,EDL 7150: 001,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,hans william klar,EDL-7150,2014
-EDL,7350,500,EDL 7350: 500,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,EDL-7350,2014
-EDL,7400,500,EDL 7400: 500,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,frederick buskey,EDL-7400,2014
-EDL,8850,400,Selected Topics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,leslie gonzales,EDL-8850,2014
-EDL,9100,400,Intro Phd Seminar,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,jane lindle,EDL-9100,2014
-EDLT,4580,1,EDLT 4580: 001,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4580,2014
-EDLT,4600,1,Teaching Reading Grades 2-6,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,EDLT-4600,2014
-EDLT,4620,1,EDLT 4620: 001,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4620,2014
-EDLT,4630,1,EDLT 4630: 001,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,ysaaca axelrod,EDLT-4630,2014
-EDLT,8670,400,EDLT 8670: 400,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8670,2014
-EDLT,8670,401,EDLT 8670: 401,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,phillip mich wilder,EDLT-8670,2014
-EDLT,8740,501,EDLT 8740: 501,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-8740,2014
-EDSC,4370,1,EDSC 4370: 001,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,robert horton,EDSC-4370,2014
-EDSC,8920,400,EDSC 8920: 400,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeff marshall,EDSC-8920,2014
-EDSP,3700,1,Intro to Special Ed,0.76,0.15,0.06,0.0,0.03,0.0,0.0,0.0,joseph benedic ryan,EDSP-3700,2014
-EDSP,3700,2,Intro to Special Ed,0.78,0.05,0.1,0.03,0.05,0.0,0.0,0.0,joseph benedic ryan,EDSP-3700,2014
-EDSP,3700,3,Intro to Special Ed,0.78,0.12,0.07,0.0,0.02,0.0,0.0,0.0,robin parks ennis,EDSP-3700,2014
-EDSP,3730,1,EDSP 3730: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,EDSP-3730,2014
-EDSP,3750,1,EDSP 3750: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,EDSP-3750,2014
-EDSP,4910,1,EDSP 4910: 001,0.67,0.29,0.0,0.0,0.04,0.0,0.0,0.0,antonis katsiyannis,EDSP-4910,2014
-EDSP,4950,1,EDSP 4950: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,martha hodge,EDSP-4950,2014
-EDSP,4980,1,EDSP 4980: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,beverly lu romansky,EDSP-4980,2014
-EES,2020,1,EES 2020: 001,0.49,0.44,0.02,0.0,0.02,0.0,0.0,0.02,kevin thom finneran,EES-2020,2014
-EES,4010,1,EES 4010: 001,0.41,0.49,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,EES-4010,2014
-EES,4010,2,EES 4010: 002,0.15,0.58,0.23,0.02,0.0,0.0,0.0,0.02,john coates,EES-4010,2014
-EES,4020,1,EES 4020: 001,0.41,0.41,0.09,0.0,0.05,0.0,0.0,0.05,david allen ladner,EES-4020,2014
-EES,4750,1,EES 4750: 001,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-4750,2014
-EES,4840,1,Solid Waste Mgt,0.29,0.55,0.1,0.03,0.03,0.0,0.0,0.0,thomas overcamp,EES-4840,2014
-EES,4850,1,EES 4850: 001,0.3,0.59,0.08,0.03,0.0,0.0,0.0,0.0,mark schlautman,EES-4850,2014
-EES,6110,1,EES 6110: 001,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,timothy devol,EES-6110,2014
-EES,6850,1,EES 6850: 001,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mark schlautman,EES-6850,2014
-EES,8030,1,EES 8030: 001,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,tanju karanfil,EES-8030,2014
-EES,8040,1,EES 8040: 001,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,EES-8040,2014
-EES,8050,1,EES 8050: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tanju karanfil,EES-8050,2014
-EES,8120,1,EES 8120: 001,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,lin shuller-nickles,EES-8120,2014
-EES,8200,1,EES 8200: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,annick anctil,EES-8200,2014
-EES,8450,1,EES 8450: 001,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,cindy lee,EES-8450,2014
-EES,8830,2,Advanced Topics in Health Phys,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,timothy devol,EES-8830,2014
-ELE,3010,1,Intro to Entre,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,ELE-3010,2014
-ELE,3010,2,Intro to Entre,0.56,0.38,0.05,0.0,0.0,0.0,0.0,0.0,anthony pa santella,ELE-3010,2014
-ELE,4010,1,Exec Lead & Entr II,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,anthony pa santella,ELE-4010,2014
-ENGL,1030,1,Accelerated Composition,0.47,0.37,0.05,0.11,0.0,0.0,0.0,0.0,leslie ann salley,ENGL-1030,2014
-ENGL,1030,3,Accelerated Composition,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,megan leigh roberts,ENGL-1030,2014
-ENGL,1030,4,Accelerated Composition,0.58,0.32,0.0,0.0,0.0,0.0,0.0,0.11,stephanie pai beard,ENGL-1030,2014
-ENGL,1030,5,Accelerated Composition,0.21,0.37,0.26,0.05,0.11,0.0,0.0,0.0,jacqueline fetzer,ENGL-1030,2014
-ENGL,1030,6,Accelerated Composition,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,kristen gay,ENGL-1030,2014
-ENGL,1030,7,Accelerated Composition,0.5,0.25,0.15,0.0,0.05,0.0,0.0,0.05,leslie ann salley,ENGL-1030,2014
-ENGL,1030,9,Accelerated Composition,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,jacqueline fetzer,ENGL-1030,2014
-ENGL,1030,10,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,stephanie pai beard,ENGL-1030,2014
-ENGL,1030,11,Accelerated Composition,0.5,0.4,0.05,0.0,0.05,0.0,0.0,0.0,leslie ann salley,ENGL-1030,2014
-ENGL,1030,12,Accelerated Composition,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,david stubblefield,ENGL-1030,2014
-ENGL,1030,14,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,dustin kyle pearson,ENGL-1030,2014
-ENGL,1030,15,Accelerated Composition,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,leslie ann salley,ENGL-1030,2014
-ENGL,1030,16,Accelerated Composition,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,david stubblefield,ENGL-1030,2014
-ENGL,1030,17,Accelerated Composition,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,dustin kyle pearson,ENGL-1030,2014
-ENGL,1030,18,Accelerated Composition,0.45,0.3,0.1,0.0,0.1,0.0,0.0,0.05,adrian carson,ENGL-1030,2014
-ENGL,1030,19,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathryn eliz harner,ENGL-1030,2014
-ENGL,1030,21,Accelerated Composition,0.58,0.26,0.05,0.0,0.0,0.0,0.0,0.11,caleb andr milligan,ENGL-1030,2014
-ENGL,1030,24,Accelerated Composition,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,laura ann smith,ENGL-1030,2014
-ENGL,1030,25,Accelerated Composition,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,hilary richards,ENGL-1030,2014
-ENGL,1030,26,Accelerated Composition,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,catherine mar blass,ENGL-1030,2014
-ENGL,1030,28,Accelerated Composition,0.74,0.16,0.0,0.05,0.0,0.0,0.0,0.05,kathryn eliz harner,ENGL-1030,2014
-ENGL,1030,29,Accelerated Composition,0.37,0.42,0.16,0.0,0.05,0.0,0.0,0.0,caleb andr milligan,ENGL-1030,2014
-ENGL,1030,32,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,laura ann smith,ENGL-1030,2014
-ENGL,1030,33,Accelerated Composition,0.84,0.05,0.05,0.05,0.0,0.0,0.0,0.0,hilary richards,ENGL-1030,2014
-ENGL,1030,35,Accelerated Composition,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,kiera angeli prince,ENGL-1030,2014
-ENGL,1030,36,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katherine elrick,ENGL-1030,2014
-ENGL,1030,37,Accelerated Composition,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,shawn andrew stowe,ENGL-1030,2014
-ENGL,1030,38,Accelerated Composition,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,katherine hanzalik,ENGL-1030,2014
-ENGL,1030,39,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,ENGL-1030,2014
-ENGL,1030,40,Accelerated Composition,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,joshua lee martin,ENGL-1030,2014
-ENGL,1030,41,Accelerated Composition,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,ENGL-1030,2014
-ENGL,1030,42,Accelerated Composition,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,katherine elrick,ENGL-1030,2014
-ENGL,1030,44,Accelerated Composition,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,katherine hanzalik,ENGL-1030,2014
-ENGL,1030,46,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,ENGL-1030,2014
-ENGL,1030,48,Accelerated Composition,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,joshua lee martin,ENGL-1030,2014
-ENGL,1030,51,Accelerated Composition,0.85,0.0,0.05,0.0,0.05,0.0,0.0,0.05,mari elena ramler,ENGL-1030,2014
-ENGL,1030,52,Accelerated Composition,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,kiera angeli prince,ENGL-1030,2014
-ENGL,1030,53,Accelerated Composition,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,justyna ann pekalak,ENGL-1030,2014
-ENGL,1030,54,Accelerated Composition,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,eric thomas hall,ENGL-1030,2014
-ENGL,1030,57,Accelerated Composition,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,kristen gay,ENGL-1030,2014
-ENGL,1030,58,Accelerated Composition,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,samuel jacks fuller,ENGL-1030,2014
-ENGL,1030,59,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,alyssa chris carver,ENGL-1030,2014
-ENGL,1030,60,Accelerated Composition,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,justyna ann pekalak,ENGL-1030,2014
-ENGL,2120,1,World Literature,0.52,0.3,0.15,0.04,0.0,0.0,0.0,0.0,andrew mathas,ENGL-2120,2014
-ENGL,2120,2,World Literature (MAJORS ONLY),0.71,0.12,0.12,0.0,0.0,0.0,0.0,0.06,lucian ghita,ENGL-2120,2014
-ENGL,2120,3,World Literature,0.36,0.43,0.11,0.04,0.07,0.0,0.0,0.0,andrew mathas,ENGL-2120,2014
-ENGL,2120,4,World Literature,0.71,0.18,0.0,0.04,0.04,0.0,0.0,0.04,april susanne pelt,ENGL-2120,2014
-ENGL,2120,5,World Literature,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-2120,2014
-ENGL,2120,7,World Literature (MAJORS ONLY),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-2120,2014
-ENGL,2120,8,World Literature,0.56,0.19,0.19,0.0,0.04,0.0,0.0,0.04,andrew mathas,ENGL-2120,2014
-ENGL,2120,9,World Literature,0.41,0.34,0.07,0.03,0.1,0.0,0.0,0.03,andrew mathas,ENGL-2120,2014
-ENGL,2120,12,World Literature,0.5,0.21,0.11,0.04,0.11,0.0,0.0,0.04,john conway,ENGL-2120,2014
-ENGL,2120,13,World Literature,0.23,0.46,0.19,0.08,0.0,0.0,0.0,0.04,david charles foltz,ENGL-2120,2014
-ENGL,2120,14,World Literature,0.08,0.5,0.31,0.0,0.04,0.0,0.0,0.08,david charles foltz,ENGL-2120,2014
-ENGL,2120,15,World Literature,0.44,0.15,0.26,0.04,0.11,0.0,0.0,0.0,john conway,ENGL-2120,2014
-ENGL,2120,16,World Literature,0.57,0.25,0.07,0.0,0.0,0.0,0.0,0.11,lucian ghita,ENGL-2120,2014
-ENGL,2130,1,British Literature,0.21,0.29,0.17,0.13,0.08,0.0,0.0,0.13,karen kettnich,ENGL-2130,2014
-ENGL,2130,2,British Literature,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,karen kettnich,ENGL-2130,2014
-ENGL,2130,3,British Literature,0.54,0.29,0.04,0.04,0.07,0.0,0.0,0.04,april susanne pelt,ENGL-2130,2014
-ENGL,2130,4,British Literature,0.67,0.15,0.04,0.04,0.0,0.0,0.0,0.11,april susanne pelt,ENGL-2130,2014
-ENGL,2130,5,British Literature,0.5,0.32,0.0,0.07,0.04,0.0,0.0,0.07,john conway,ENGL-2130,2014
-ENGL,2130,6,British Literature,0.48,0.3,0.15,0.0,0.0,0.0,0.0,0.07,lucian ghita,ENGL-2130,2014
-ENGL,2130,7,British Literature,0.5,0.36,0.07,0.04,0.0,0.0,0.0,0.04,lucian ghita,ENGL-2130,2014
-ENGL,2130,8,British Literature,0.5,0.25,0.11,0.04,0.04,0.0,0.0,0.07,april susanne pelt,ENGL-2130,2014
-ENGL,2130,9,British Literature,0.14,0.43,0.25,0.11,0.07,0.0,0.0,0.0,david charles foltz,ENGL-2130,2014
-ENGL,2130,10,British Literature,0.41,0.33,0.07,0.0,0.11,0.0,0.0,0.07,john conway,ENGL-2130,2014
-ENGL,2130,11,British Literature,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,sherri teres allred,ENGL-2130,2014
-ENGL,2130,12,British Literature,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,sherri teres allred,ENGL-2130,2014
-ENGL,2130,13,British Literature,0.19,0.33,0.26,0.07,0.04,0.0,0.0,0.11,david charles foltz,ENGL-2130,2014
-ENGL,2140,1,American Literature,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,joshua nei waggoner,ENGL-2140,2014
-ENGL,2140,2,American Literature,0.71,0.14,0.04,0.04,0.0,0.0,0.0,0.07,sharon kathl nalley,ENGL-2140,2014
-ENGL,2140,3,American Literature,0.29,0.39,0.11,0.11,0.0,0.0,0.0,0.11,sharon kathl nalley,ENGL-2140,2014
-ENGL,2140,4,American Literature,0.26,0.37,0.3,0.04,0.04,0.0,0.0,0.0,william stanton,ENGL-2140,2014
-ENGL,2140,5,American Literature,0.59,0.19,0.07,0.04,0.07,0.0,0.0,0.04,william stanton,ENGL-2140,2014
-ENGL,2140,6,American Literature,0.32,0.57,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2140,2014
-ENGL,2140,7,American Literature,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2140,2014
-ENGL,2140,8,American Literature,0.32,0.43,0.18,0.0,0.0,0.0,0.0,0.07,joshua nei waggoner,ENGL-2140,2014
-ENGL,2140,9,American Literature,0.41,0.56,0.0,0.0,0.0,0.0,0.0,0.04,joshua nei waggoner,ENGL-2140,2014
-ENGL,2140,11,American Literature,0.13,0.38,0.13,0.13,0.08,0.0,0.0,0.17,jonathan beec field,ENGL-2140,2014
-ENGL,2140,12,American Literature,0.2,0.28,0.16,0.04,0.12,0.0,0.0,0.2,jonathan beec field,ENGL-2140,2014
-ENGL,2140,13,American Literature,0.25,0.29,0.29,0.04,0.0,0.0,0.0,0.13,jonathan beec field,ENGL-2140,2014
-ENGL,2140,14,American Literature,0.63,0.21,0.04,0.0,0.0,0.0,0.0,0.13,jonathan beec field,ENGL-2140,2014
-ENGL,2140,15,American Literature,0.38,0.5,0.04,0.0,0.04,0.0,0.0,0.04,jonathan beec field,ENGL-2140,2014
-ENGL,2140,16,American Literature,0.09,0.48,0.3,0.0,0.09,0.0,0.0,0.04,jonathan beec field,ENGL-2140,2014
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.54,0.36,0.04,0.0,0.04,0.0,0.0,0.04,michael richa lucas,ENGL-2150,2014
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,michael richa lucas,ENGL-2150,2014
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.14,0.79,0.04,0.0,0.0,0.0,0.0,0.04,amy monaghan,ENGL-2150,2014
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.29,0.5,0.07,0.04,0.04,0.0,0.0,0.07,william pulley,ENGL-2150,2014
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.15,0.73,0.08,0.04,0.0,0.0,0.0,0.0,amy monaghan,ENGL-2150,2014
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.26,0.52,0.22,0.0,0.0,0.0,0.0,0.0,matthew schilleman,ENGL-2150,2014
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.0,lauren woolbright,ENGL-2150,2014
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,lauren woolbright,ENGL-2150,2014
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.55,0.28,0.1,0.07,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2014
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.39,0.46,0.07,0.04,0.0,0.0,0.0,0.04,john morgenstern,ENGL-2150,2014
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.36,0.43,0.14,0.04,0.0,0.0,0.0,0.04,sarah lauro,ENGL-2150,2014
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.46,0.39,0.14,0.0,0.0,0.0,0.0,0.0,sarah lauro,ENGL-2150,2014
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.59,0.24,0.14,0.0,0.0,0.0,0.0,0.03,john morgenstern,ENGL-2150,2014
-ENGL,3000,1,ENGL 3000: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,ENGL-3000,2014
-ENGL,3040,2,ENGL 3040: 002,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-3040,2014
-ENGL,3040,3,ENGL 3040: 003,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-3040,2014
-ENGL,3040,4,ENGL 3040: 004,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,sean williams,ENGL-3040,2014
-ENGL,3040,5,ENGL 3040: 005,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-3040,2014
-ENGL,3040,13,ENGL 3040: 013,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexander kudera,ENGL-3040,2014
-ENGL,3100,1,ENGL 3100: 001,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,walter edgar hunter,ENGL-3100,2014
-ENGL,3100,2,ENGL 3100: 002,0.11,0.37,0.26,0.16,0.0,0.0,0.0,0.11,william stockton,ENGL-3100,2014
-ENGL,3100,4,ENGL 3100: 004,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,cameron fa bushnell,ENGL-3100,2014
-ENGL,3120,1,ENGL 3120: 001,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2014
-ENGL,3120,2,ENGL 3120: 002,0.37,0.37,0.11,0.0,0.05,0.0,0.0,0.11,elizabeth stansell,ENGL-3120,2014
-ENGL,3140,1,Technical Writing,0.17,0.56,0.06,0.0,0.11,0.0,0.0,0.11,william pulley,ENGL-3140,2014
-ENGL,3140,2,Technical Writing,0.58,0.32,0.0,0.0,0.0,0.0,0.0,0.11,christopher benson,ENGL-3140,2014
-ENGL,3140,3,Technical Writing,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,william pulley,ENGL-3140,2014
-ENGL,3140,4,Technical Writing,0.42,0.37,0.11,0.0,0.05,0.0,0.0,0.05,william pulley,ENGL-3140,2014
-ENGL,3140,5,Technical Writing,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2014
-ENGL,3140,7,Technical Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2014
-ENGL,3140,8,Technical Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2014
-ENGL,3140,9,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,ENGL-3140,2014
-ENGL,3140,10,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nancy swanson,ENGL-3140,2014
-ENGL,3140,11,Technical Writing,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,nancy swanson,ENGL-3140,2014
-ENGL,3140,13,Technical Writing,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,nancy swanson,ENGL-3140,2014
-ENGL,3140,14,Technical Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,nancy swanson,ENGL-3140,2014
-ENGL,3140,16,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,ENGL-3140,2014
-ENGL,3140,17,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,ENGL-3140,2014
-ENGL,3140,18,Technical Writing,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,david stubblefield,ENGL-3140,2014
-ENGL,3140,19,Technical Writing,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3140,2014
-ENGL,3140,20,Technical Writing,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3140,2014
-ENGL,3140,140,Technical Writing,0.5,0.3,0.0,0.0,0.0,0.0,0.0,0.2,sarah mae cooper,ENGL-3140,2014
-ENGL,3150,1,ENGL 3150: 001,0.0,0.63,0.37,0.0,0.0,0.0,0.0,0.0,barbara ramirez,ENGL-3150,2014
-ENGL,3150,2,ENGL 3150: 002,0.06,0.61,0.28,0.0,0.0,0.0,0.0,0.06,barbara ramirez,ENGL-3150,2014
-ENGL,3150,6,ENGL 3150: 006,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sharon kay henry,ENGL-3150,2014
-ENGL,3150,7,ENGL 3150: 007,0.7,0.15,0.05,0.0,0.0,0.0,0.0,0.1,philip randall,ENGL-3150,2014
-ENGL,3150,18,ENGL 3150: 018,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,ENGL-3150,2014
-ENGL,3150,400,ENGL 3150: 400,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2014
-ENGL,3150,401,ENGL 3150: 401,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,philip randall,ENGL-3150,2014
-ENGL,3450,1,ENGL 3450: 001,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,john logan pursley,ENGL-3450,2014
-ENGL,3460,1,ENGL 3460: 001,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,angelina oberdan,ENGL-3460,2014
-ENGL,3480,1,ENGL 3480: 001,0.67,0.11,0.17,0.0,0.06,0.0,0.0,0.0,joshua nei waggoner,ENGL-3480,2014
-ENGL,3570,1,Film,0.36,0.5,0.05,0.05,0.0,0.0,0.0,0.05,sarah lauro,ENGL-3570,2014
-ENGL,3800,1,ENGL 3800: 001,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,angela naimou,ENGL-3800,2014
-ENGL,3850,1,ENGL 3850: 001,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-3850,2014
-ENGL,3860,1,ENGL 3860: 001,0.57,0.14,0.19,0.0,0.05,0.0,0.0,0.05,megan no macalystre,ENGL-3860,2014
-ENGL,3960,1,ENGL 3960: 001,0.32,0.23,0.23,0.05,0.14,0.0,0.0,0.05,william stockton,ENGL-3960,2014
-ENGL,3970,1,ENGL 3970: 001,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,david sweene coombs,ENGL-3970,2014
-ENGL,3980,1,ENGL 3980: 001,0.23,0.45,0.18,0.05,0.09,0.0,0.0,0.0,rhondda robi thomas,ENGL-3980,2014
-ENGL,3990,1,ENGL 3990: 001,0.36,0.27,0.27,0.0,0.05,0.0,0.0,0.05,matthew schilleman,ENGL-3990,2014
-ENGL,3990,2,ENGL 3990: 002,0.23,0.59,0.14,0.0,0.05,0.0,0.0,0.0,matthew schilleman,ENGL-3990,2014
-ENGL,4080,1,ENGL 4080: 001,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,susan hilligoss,ENGL-4080,2014
-ENGL,4100,1,ENGL 4100: 001,0.31,0.31,0.19,0.06,0.13,0.0,0.0,0.0,elizabeth rivlin,ENGL-4100,2014
-ENGL,4110,1,ENGL 4110: 001,0.62,0.24,0.05,0.0,0.05,0.0,0.0,0.05,susan hilligoss,ENGL-4110,2014
-ENGL,4110,2,ENGL 4110: 002,0.33,0.38,0.1,0.05,0.14,0.0,0.0,0.0,elizabeth rivlin,ENGL-4110,2014
-ENGL,4260,1,ENGL 4260: 001,0.5,0.28,0.17,0.0,0.06,0.0,0.0,0.0,jillian weise,ENGL-4260,2014
-ENGL,4300,1,Dramatic Literature II,0.68,0.16,0.11,0.0,0.05,0.0,0.0,0.0,richard st. peter,ENGL-4300,2014
-ENGL,4400,1,ENGL 4400: 001,0.29,0.48,0.19,0.0,0.05,0.0,0.0,0.0,brian mcgrath,ENGL-4400,2014
-ENGL,4400,2,ENGL 4400: 002,0.41,0.41,0.06,0.0,0.06,0.0,0.0,0.06,dominic mastroianni,ENGL-4400,2014
-ENGL,4410,1,Literary Editing,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,gabriel and hankins,ENGL-4410,2014
-ENGL,4430,1,ENGL 4430: 001,0.59,0.24,0.12,0.0,0.0,0.06,0.0,0.0,walter edgar hunter,ENGL-4430,2014
-ENGL,4450,1,ENGL 4450: 001,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,keith morris,ENGL-4450,2014
-ENGL,4600,1,ENGL 4600: 001,0.41,0.41,0.0,0.06,0.06,0.0,0.0,0.06,tharon howard,ENGL-4600,2014
-ENGL,4640,1,ENGL 4640: 001,0.4,0.27,0.13,0.07,0.13,0.0,0.0,0.0,dominic mastroianni,ENGL-4640,2014
-ENGL,4650,1,ENGL 4650: 001,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,angela naimou,ENGL-4650,2014
-ENGL,4830,1,ENGL 4830: 001,0.23,0.54,0.0,0.0,0.15,0.0,0.0,0.08,rhondda robi thomas,ENGL-4830,2014
-ENGL,4890,1,ENGL 4890: 001,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,sean williams,ENGL-4890,2014
-ENGL,4920,1,Modern Rhetoric,0.29,0.29,0.36,0.0,0.07,0.0,0.0,0.0,brian mcgrath,ENGL-4920,2014
-ENGL,4950,1,ENGL 4950: 001,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,sean morey,ENGL-4950,2014
-ENGL,4960,2,ENGL 4960: 002,0.36,0.36,0.07,0.07,0.07,0.0,0.0,0.07,agnieszka skrodzka,ENGL-4960,2014
-ENGL,4960,3,ENGL 4960: 003,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,ENGL-4960,2014
-ENGL,8310,1,Special Topics,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,ENGL-8310,2014
-ENGR,1020,14,Engineering Discipl & Skills,0.09,0.3,0.32,0.09,0.07,0.0,0.0,0.14,steven brandon,ENGR-1020,2014
-ENGR,1410,12,Programming & Problem Solving,0.11,0.39,0.28,0.16,0.02,0.0,0.0,0.05,steven brandon,ENGR-1410,2014
-ENGR,1410,13,Programming & Problem Solving,0.41,0.32,0.17,0.05,0.0,0.0,0.0,0.05,elizabeth stephan,ENGR-1410,2014
-ENGR,1410,17,Programming & Problem Solving,0.14,0.48,0.24,0.06,0.07,0.0,0.0,0.01,david ewing,ENGR-1410,2014
-ENGR,1410,18,Programming & Problem Solving,0.12,0.41,0.36,0.09,0.02,0.0,0.0,0.0,william martin,ENGR-1410,2014
-ENGR,1410,19,Programming & Problem Solving,0.12,0.29,0.39,0.1,0.03,0.0,0.0,0.07,david ewing,ENGR-1410,2014
-ENGR,1410,20,Programming & Problem Solving,0.18,0.42,0.3,0.06,0.03,0.0,0.0,0.01,christopher norfolk,ENGR-1410,2014
-ENGR,1410,22,Programming & Problem Solving,0.23,0.39,0.23,0.11,0.02,0.0,0.0,0.04,christopher norfolk,ENGR-1410,2014
-ENGR,1410,25,Programming & Problem Solving,0.15,0.42,0.2,0.13,0.07,0.0,0.0,0.04,william park,ENGR-1410,2014
-ENGR,1410,27,Programming & Problem Solving,0.05,0.21,0.43,0.12,0.09,0.0,0.0,0.1,william park,ENGR-1410,2014
-ENGR,1410,50,Programming & Problem Solving,0.33,0.45,0.19,0.0,0.02,0.0,0.0,0.0,john minor,ENGR-1410,2014
-ENGR,1410,52,Prog. & Problem Solving (HON),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ENGR-1410,2014
-ENGR,1410,56,Programming & Problem Solving,0.21,0.45,0.29,0.02,0.02,0.0,0.0,0.0,sabrina lau,ENGR-1410,2014
-ENGR,1410,58,Programming & Problem Solving,0.12,0.54,0.29,0.05,0.0,0.0,0.0,0.0,david ewing,ENGR-1410,2014
-ENGR,1410,60,Prog & Problem Solving (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ENGR-1410,2014
-ENGR,1410,64,Programming & Problem Solving,0.22,0.39,0.34,0.0,0.05,0.0,0.0,0.0,david ewing,ENGR-1410,2014
-ENGR,1410,66,Programming & Problem Solving,0.12,0.44,0.32,0.12,0.0,0.0,0.0,0.0,david ewing,ENGR-1410,2014
-ENGR,2080,11,Engr Graphics & Machine Design,0.57,0.15,0.21,0.01,0.01,0.0,0.0,0.04,sabrina lau,ENGR-2080,2014
-ENGR,2080,15,Engr Graphics & Machine Design,0.61,0.28,0.07,0.0,0.03,0.0,0.0,0.01,john minor,ENGR-2080,2014
-ENGR,2080,21,Engr Graphics & Machine Design,0.49,0.35,0.09,0.0,0.03,0.0,0.0,0.04,sarah grigg,ENGR-2080,2014
-ENGR,2080,23,Engr Graphics & Machine Design,0.46,0.29,0.11,0.04,0.03,0.0,0.0,0.07,sarah grigg,ENGR-2080,2014
-ENGR,2080,31,Engr Graphics & Machine Design,0.7,0.16,0.1,0.01,0.01,0.0,0.0,0.01,sabrina lau,ENGR-2080,2014
-ENGR,2080,39,Engr Graphics & Machine Design,0.61,0.3,0.04,0.01,0.0,0.0,0.0,0.03,sarah grigg,ENGR-2080,2014
-ENGR,2080,54,Engr Graphics & Machine Design,0.67,0.21,0.1,0.02,0.0,0.0,0.0,0.0,john minor,ENGR-2080,2014
-ENGR,2100,32,CAD & Engineering Apllications,0.63,0.15,0.05,0.05,0.05,0.0,0.0,0.07,william martin,ENGR-2100,2014
-ENGR,2100,38,CAD & Engineering Aplications,0.53,0.14,0.14,0.0,0.07,0.0,0.0,0.12,william martin,ENGR-2100,2014
-ENGR,2100,40,CAD & Engineering Apllications,0.76,0.09,0.09,0.0,0.0,0.0,0.0,0.07,nighat yasmin,ENGR-2100,2014
-ENR,3020,1,ENR 3020: 001,0.38,0.46,0.1,0.05,0.0,0.0,0.0,0.0,lawrence gering,ENR-3020,2014
-ENR,4500,1,ENR 4500: 001,0.79,0.05,0.11,0.0,0.03,0.0,0.0,0.03,alan johnson,ENR-4500,2014
-ENR,4500,2,ENR 4500: 002,0.71,0.21,0.04,0.04,0.0,0.0,0.0,0.0,alan johnson,ENR-4500,2014
-ENSP,2000,1,Intro Environ Sci,0.47,0.35,0.1,0.02,0.0,0.0,0.0,0.06,scott brame,ENSP-2000,2014
-ENSP,2000,2,Intro Environ Sci,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,ENSP-2000,2014
-ENSP,2000,3,Intro Environ Sci,0.24,0.64,0.1,0.0,0.0,0.0,0.0,0.02,john coates,ENSP-2000,2014
-ENT,2000,1,Six-Legged Science,0.39,0.42,0.06,0.06,0.0,0.0,0.0,0.06,patricia zungoli,ENT-2000,2014
-ENT,8100,1,Forensic Entomology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,peter adler,ENT-8100,2014
-ESED,8200,1,ESED 8200: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,ESED-8200,2014
-ETOX,8300,1,Mechanistic Toxicology,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,ETOX-8300,2014
-FCS,8920,1,Research Methods II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,FCS-8920,2014
-FCS,8920,13,Program Evaluation,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mark small,FCS-8920,2014
-FDSC,1020,1,FDSC 1020: 001,0.58,0.37,0.01,0.01,0.0,0.0,0.0,0.03,john mcgregor,FDSC-1020,2014
-FDSC,2140,1,Fd Resources & Soc,0.61,0.27,0.08,0.01,0.0,0.0,0.0,0.04,paul dawson,FDSC-2140,2014
-FDSC,4020,1,Food Chem II,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,feng chen,FDSC-4020,2014
-FDSC,4030,1,Food Ch & Analysis,0.82,0.15,0.0,0.0,0.0,0.0,0.0,0.03,paul dawson,FDSC-4030,2014
-FDSC,4080,1,FDSC 4080: 001,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,felix barron,FDSC-4080,2014
-FDSC,4090,1,TQM for Food & Pckg Industries,0.6,0.35,0.06,0.0,0.0,0.0,0.0,0.0,john mcgregor,FDSC-4090,2014
-FIN,3050,1,Investment Analysis,0.11,0.41,0.35,0.11,0.03,0.0,0.0,0.0,kerri mcmillan,FIN-3050,2014
-FIN,3050,2,Investment Analysis,0.26,0.36,0.28,0.08,0.03,0.0,0.0,0.0,kerri mcmillan,FIN-3050,2014
-FIN,3050,3,Investment Analysis,0.23,0.3,0.35,0.05,0.03,0.03,0.0,0.03,kerri mcmillan,FIN-3050,2014
-FIN,3060,1,Corporation Finance,0.17,0.17,0.23,0.17,0.15,0.0,0.0,0.1,william hol johnson,FIN-3060,2014
-FIN,3060,2,Corporation Finance,0.17,0.29,0.13,0.19,0.17,0.0,0.0,0.04,william hol johnson,FIN-3060,2014
-FIN,3060,3,Corporation Finance,0.24,0.4,0.24,0.1,0.0,0.0,0.0,0.02,neil waller,FIN-3060,2014
-FIN,3060,4,Corporation Finance,0.1,0.34,0.36,0.12,0.0,0.0,0.0,0.08,john harris,FIN-3060,2014
-FIN,3060,5,Corporation Finance,0.18,0.45,0.2,0.02,0.0,0.0,0.0,0.16,john harris,FIN-3060,2014
-FIN,3060,6,Corporation Finance,0.25,0.43,0.25,0.04,0.02,0.02,0.0,0.0,neil waller,FIN-3060,2014
-FIN,3060,7,Corporation Finance,0.12,0.5,0.27,0.08,0.04,0.0,0.0,0.0,neil waller,FIN-3060,2014
-FIN,3070,1,Prin of Real Estate,0.15,0.23,0.35,0.12,0.12,0.0,0.0,0.02,ramon tolb franklin,FIN-3070,2014
-FIN,3070,2,Prin of Real Estate,0.3,0.3,0.26,0.11,0.02,0.0,0.0,0.02,thomas springer,FIN-3070,2014
-FIN,3080,1,Fin Inst & Mkts,0.08,0.53,0.26,0.03,0.03,0.0,0.0,0.08,lyudmila chernykh,FIN-3080,2014
-FIN,3080,2,Fin Inst & Mkts,0.18,0.33,0.33,0.05,0.08,0.0,0.0,0.03,michael spivey,FIN-3080,2014
-FIN,3080,3,Fin Inst & Mkts,0.23,0.28,0.28,0.05,0.03,0.0,0.0,0.13,michael spivey,FIN-3080,2014
-FIN,3110,1,Financial Management I,0.09,0.2,0.45,0.14,0.05,0.0,0.0,0.07,ramon tolb franklin,FIN-3110,2014
-FIN,3110,2,Financial Management I,0.14,0.23,0.35,0.05,0.07,0.0,0.0,0.16,george bra lockhart,FIN-3110,2014
-FIN,3110,3,Financial Management I,0.27,0.27,0.31,0.02,0.0,0.0,0.0,0.13,george bra lockhart,FIN-3110,2014
-FIN,3110,4,Financial Management I,0.12,0.36,0.29,0.14,0.05,0.0,0.0,0.05,george bra lockhart,FIN-3110,2014
-FIN,3120,1,Financial Mgt II,0.16,0.65,0.13,0.03,0.03,0.0,0.0,0.0,lyudmila chernykh,FIN-3120,2014
-FIN,3120,2,Financial Mgt II,0.58,0.24,0.12,0.03,0.0,0.0,0.0,0.03,melvin stith,FIN-3120,2014
-FIN,3120,3,Financial Mgt II,0.53,0.31,0.03,0.06,0.08,0.0,0.0,0.0,melvin stith,FIN-3120,2014
-FIN,3120,4,Financial Mgt II,0.5,0.31,0.13,0.0,0.06,0.0,0.0,0.0,melvin stith,FIN-3120,2014
-FIN,4040,1,Financial Modeling,0.11,0.26,0.41,0.11,0.11,0.0,0.0,0.0,jack wolf,FIN-4040,2014
-FIN,4040,2,Financial Modeling,0.13,0.47,0.28,0.09,0.03,0.0,0.0,0.0,jack wolf,FIN-4040,2014
-FIN,4040,3,Financial Modeling,0.13,0.47,0.2,0.1,0.03,0.0,0.0,0.07,jack wolf,FIN-4040,2014
-FIN,4050,1,Port Mgt and Theory,0.24,0.24,0.24,0.24,0.0,0.0,0.0,0.04,john alexander,FIN-4050,2014
-FIN,4050,2,Port Mgt and Theory,0.14,0.14,0.29,0.14,0.1,0.0,0.0,0.19,john alexander,FIN-4050,2014
-FIN,4080,1,Mgt of Fin Inst,0.07,0.44,0.42,0.02,0.04,0.0,0.0,0.0,michael spivey,FIN-4080,2014
-FIN,4110,1,Int Fin Mgt,0.26,0.28,0.36,0.08,0.03,0.0,0.0,0.0,john harris,FIN-4110,2014
-FIN,4110,2,Int Fin Mgt,0.26,0.41,0.23,0.08,0.0,0.0,0.0,0.03,john harris,FIN-4110,2014
-FIN,4150,1,Real Estate Investmt,0.19,0.24,0.29,0.24,0.0,0.05,0.0,0.0,thomas springer,FIN-4150,2014
-FIN,4160,1,Real Estate Val,0.0,0.32,0.55,0.14,0.0,0.0,0.0,0.0,neil waller,FIN-4160,2014
-FNR,1020,1,FNR 1020: 001,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,elena mikhailova,FNR-1020,2014
-FNR,4990,1,FNR 4990: 001,0.72,0.11,0.06,0.06,0.06,0.0,0.0,0.0,donald hagan,FNR-4990,2014
-FNR,4990,3,FNR 4990: 003,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,donald hagan,FNR-4990,2014
-FOR,2060,1,FOR 2060: 001,0.38,0.34,0.19,0.07,0.0,0.0,0.0,0.02,donald hagan,FOR-2060,2014
-FOR,3080,1,FOR 3080: 001,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,lawrence gering,FOR-3080,2014
-FOR,4060,1,FOR 4060: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william roc english,FOR-4060,2014
-FOR,4080,1,FOR 4080: 001,0.54,0.36,0.11,0.0,0.0,0.0,0.0,0.0,patricia layton,FOR-4080,2014
-FOR,4150,1,FOR 4150: 001,0.23,0.59,0.18,0.0,0.0,0.0,0.0,0.0,james davis,FOR-4150,2014
-FOR,4180,1,FOR 4180: 001,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,thomas straka,FOR-4180,2014
-FOR,4340,1,GIS for Landscape Planning,0.19,0.64,0.14,0.0,0.0,0.0,0.0,0.03,robert frit baldwin,FOR-4340,2014
-FOR,4650,1,FOR 4650: 001,0.42,0.33,0.25,0.0,0.0,0.0,0.0,0.0,gaofeng wang,FOR-4650,2014
-FOR,6340,1,GIS for Landscape Planning,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robert frit baldwin,FOR-6340,2014
-FR,1010,1,FR 1010: 001,0.64,0.23,0.09,0.0,0.0,0.0,0.0,0.05,julian hamil killey,FR-1010,2014
-FR,1020,1,FR 1020: 001,0.38,0.38,0.0,0.19,0.0,0.0,0.0,0.06,julian hamil killey,FR-1020,2014
-FR,1020,2,FR 1020: 002,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,julian hamil killey,FR-1020,2014
-FR,1020,3,FR 1020: 003,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2014
-FR,2010,1,Intermediate French,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,amy lyn grif sawyer,FR-2010,2014
-FR,2010,2,Intermediate French,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2010,2014
-FR,2010,3,Intermediate French,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,julian hamil killey,FR-2010,2014
-FR,2020,1,Intermediate French,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2020,2014
-FR,2020,4,Intermediate French,0.14,0.5,0.21,0.0,0.07,0.0,0.0,0.07,kenneth dav widgren,FR-2020,2014
-FR,2020,5,Intermediate French,0.53,0.35,0.06,0.0,0.0,0.0,0.0,0.06,joseph mai,FR-2020,2014
-FR,3000,1,Survey of French Lit,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,karyna szmurlo,FR-3000,2014
-FR,3050,1,FR 3050: 001,0.41,0.24,0.12,0.0,0.06,0.0,0.0,0.18,kenneth dav widgren,FR-3050,2014
-FR,3170,1,FR 3170: 001,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,joseph mai,FR-3170,2014
-FR,4200,1,FR 4200: 001,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,karyna szmurlo,FR-4200,2014
-GC,1010,1,GC 1010: 001,0.57,0.34,0.02,0.0,0.0,0.0,0.0,0.07,kern cox,GC-1010,2014
-GC,1020,1,GC 1020: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,charles tabor weiss,GC-1020,2014
-GC,1020,2,GC 1020: 002,0.35,0.48,0.04,0.0,0.04,0.0,0.0,0.09,carol jones,GC-1020,2014
-GC,1030,1,GC 1030: 001,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,john jacobs,GC-1030,2014
-GC,1030,2,GC 1030: 002,0.67,0.13,0.07,0.07,0.07,0.0,0.0,0.0,john jacobs,GC-1030,2014
-GC,1040,1,Graphic Com I,0.49,0.41,0.06,0.0,0.01,0.0,0.0,0.02,rebecca suza edlein,GC-1040,2014
-GC,1990,4,CI in GC I-J Lay CS,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,janice ann lay,GC-1990,2014
-GC,2070,1,Graphic Com II,0.54,0.37,0.09,0.0,0.0,0.0,0.0,0.0,patrick gee rose,GC-2070,2014
-GC,3400,1,Digital Img & Emedia,0.33,0.46,0.17,0.0,0.04,0.0,0.0,0.0,erica black walker,GC-3400,2014
-GC,4060,1,Pkg & Spec Prtg,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kern cox,GC-4060,2014
-GC,4400,1,Commercial Printing,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,GC-4400,2014
-GC,4440,1,Current Dev in G C,0.29,0.57,0.07,0.07,0.0,0.0,0.0,0.0,liam henry 'hara,GC-4440,2014
-GC,4460,1,Ink & Substrates,0.27,0.59,0.14,0.0,0.0,0.0,0.0,0.0,liam henry 'hara,GC-4460,2014
-GC,4480,1,Plan and Cont Print,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john leininger,GC-4480,2014
-GC,4900,2,G C Selected Topics-Sales,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,GC-4900,2014
-GEN,3000,1,GEN 3000: 001,0.3,0.37,0.21,0.06,0.02,0.0,0.0,0.05,kate leanne wi tsai,GEN-3000,2014
-GEN,3000,2,GEN 3000: 002,0.36,0.3,0.17,0.11,0.01,0.0,0.0,0.06,kate leanne wi tsai,GEN-3000,2014
-GEN,4100,1,Population & Quant Genetics,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,GEN-4100,2014
-GEN,4110,2,GEN 4110: 002,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,GEN-4110,2014
-GEN,6100,1,Population & Quant Genetics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,GEN-6100,2014
-GEOG,1010,1,Intro to Geography,0.37,0.45,0.13,0.0,0.03,0.0,0.0,0.03,christa smith,GEOG-1010,2014
-GEOG,1030,1,World Regional Geog,0.82,0.11,0.04,0.02,0.0,0.0,0.0,0.01,lance forres howard,GEOG-1030,2014
-GEOG,1030,2,World Regional Geog,0.3,0.43,0.1,0.13,0.05,0.0,0.0,0.0,william churc terry,GEOG-1030,2014
-GEOG,3020,1,GEOG 3020: 001,0.67,0.25,0.0,0.0,0.08,0.0,0.0,0.0,william churc terry,GEOG-3020,2014
-GEOG,3050,1,GEOG 3050: 001,0.74,0.16,0.05,0.05,0.0,0.0,0.0,0.0,lance forres howard,GEOG-3050,2014
-GEOL,1010,1,Physical Geology,0.13,0.31,0.27,0.12,0.11,0.0,0.0,0.05,alan coulson,GEOL-1010,2014
-GEOL,1010,2,Physical Geology,0.28,0.37,0.2,0.06,0.05,0.0,0.0,0.04,alan coulson,GEOL-1010,2014
-GEOL,1020,1,Earth History,0.13,0.44,0.31,0.06,0.0,0.0,0.0,0.06,alan coulson,GEOL-1020,2014
-GEOL,1030,1,Physical Geol Lab,0.74,0.09,0.04,0.0,0.09,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,4,Physical Geol Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2014
-GEOL,1030,5,Physical Geol Lab,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,6,Physical Geol Lab,0.87,0.0,0.09,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,7,Physical Geol Lab,0.29,0.63,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,8,Physical Geol Lab,0.5,0.41,0.05,0.0,0.05,0.0,0.0,0.0,alan coulson,GEOL-1030,2014
-GEOL,1030,9,Physical Geol Lab,0.68,0.23,0.0,0.0,0.05,0.0,0.0,0.05,alan coulson,GEOL-1030,2014
-GEOL,1030,10,Physical Geol Lab,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2014
-GEOL,1030,11,Physical Geol Lab,0.46,0.5,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2014
-GEOL,1030,12,Physical Geol Lab,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,alan coulson,GEOL-1030,2014
-GEOL,3130,1,GEOL 3130: 001,0.14,0.57,0.24,0.05,0.0,0.0,0.0,0.0,james castle,GEOL-3130,2014
-GEOL,3180,1,GEOL 3180: 001,0.18,0.57,0.18,0.0,0.04,0.0,0.0,0.04,brian powell,GEOL-3180,2014
-GEOL,7900,500,Selected Topics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,GEOL-7900,2014
-GEOL,8080,1,Groundwater Modeling,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,GEOL-8080,2014
-GER,1010,3,GER 1010: 003,0.67,0.27,0.0,0.07,0.0,0.0,0.0,0.0,oswald harris king,GER-1010,2014
-GER,1010,4,GER 1010: 004,0.31,0.08,0.15,0.0,0.08,0.0,0.0,0.38,oswald harris king,GER-1010,2014
-GER,1010,5,GER 1010: 005,0.08,0.69,0.0,0.0,0.08,0.0,0.0,0.15,oswald harris king,GER-1010,2014
-GER,1020,3,GER 1020: 003,0.35,0.15,0.1,0.1,0.0,0.0,0.0,0.3, lee ferrell,GER-1020,2014
-GER,1020,4,GER 1020: 004,0.27,0.2,0.13,0.0,0.2,0.0,0.0,0.2, lee ferrell,GER-1020,2014
-GER,2010,2,Intermediate German,0.27,0.27,0.2,0.13,0.07,0.0,0.0,0.07,gabriela stoicea,GER-2010,2014
-GER,2020,3,Intermediate German,0.21,0.38,0.29,0.08,0.0,0.0,0.0,0.04,johannes schmidt,GER-2020,2014
-GER,3060,1,German Short Story,0.18,0.53,0.12,0.06,0.0,0.0,0.0,0.12,gabriela stoicea,GER-3060,2014
-GER,3160,1,GER 3160: 001,0.23,0.62,0.0,0.0,0.15,0.0,0.0,0.0, lee ferrell,GER-3160,2014
-GW,3010,1,Grt Books West World,0.47,0.24,0.18,0.0,0.12,0.0,0.0,0.0,henry clark,GW-3010,2014
-HCC,8810,2,Health Informatics,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,kelly caine,HCC-8810,2014
-HEHD,4000,1,HEHD 4000: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,HEHD-4000,2014
-HEHD,4100,1,HEHD 4100: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary price,HEHD-4100,2014
-HEHD,8000,230,HEHD 8000: 230,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,robert ja barcelona,HEHD-8000,2014
-HEHD,8010,230,HEHD 8010: 230,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,HEHD-8010,2014
-HIST,1010,1,Hist of the U S,0.22,0.24,0.19,0.14,0.16,0.0,0.0,0.05,james brad jeffries,HIST-1010,2014
-HIST,1220,1,"Hist, Tech & Society",0.53,0.21,0.15,0.06,0.0,0.01,0.0,0.03,henry clark,HIST-1220,2014
-HIST,1240,1,Environmental Hist,0.23,0.56,0.13,0.03,0.0,0.0,0.0,0.05,james brad jeffries,HIST-1240,2014
-HIST,1240,2,Environmental Hist,0.21,0.51,0.21,0.05,0.0,0.0,0.0,0.03,james brad jeffries,HIST-1240,2014
-HIST,1720,1,The West and the World I,0.36,0.29,0.26,0.05,0.02,0.0,0.0,0.02,henry clark,HIST-1720,2014
-HIST,1720,2,The West and the World I,0.27,0.71,0.02,0.0,0.0,0.0,0.0,0.0,emily wood,HIST-1720,2014
-HIST,1730,1,The West and the World II,0.27,0.27,0.25,0.02,0.11,0.0,0.0,0.07, alan grubb,HIST-1730,2014
-HIST,1730,2,The West and the World II,0.24,0.32,0.2,0.04,0.11,0.0,0.0,0.09,richard saunders,HIST-1730,2014
-HIST,1730,3,The West and the World II,0.21,0.47,0.18,0.06,0.05,0.0,0.0,0.04,steven marks,HIST-1730,2014
-HIST,2990,1,HIST 2990: 001,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,rachel anne moore,HIST-2990,2014
-HIST,2990,2,HIST 2990: 002,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,rachel anne moore,HIST-2990,2014
-HIST,3060,1,HIST 3060: 001,0.39,0.37,0.11,0.04,0.02,0.0,0.0,0.07,richard saunders,HIST-3060,2014
-HIST,3120,1,HIST 3120: 001,0.4,0.44,0.09,0.02,0.02,0.0,0.0,0.02,abel bartley,HIST-3120,2014
-HIST,3140,1,HIST 3140: 001,0.11,0.64,0.22,0.0,0.0,0.0,0.0,0.02,paul chris anderson,HIST-3140,2014
-HIST,3210,1,History of Science,0.28,0.23,0.21,0.15,0.05,0.0,0.0,0.08,pamela mack,HIST-3210,2014
-HIST,3260,1,HIST 3260: 001,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03, roger grant,HIST-3260,2014
-HIST,3290,1,HIST 3290: 001,0.17,0.42,0.21,0.08,0.0,0.0,0.0,0.13,maribel morey,HIST-3290,2014
-HIST,3390,1,HIST 3390: 001,0.46,0.21,0.15,0.08,0.08,0.0,0.0,0.03,james burns,HIST-3390,2014
-HIST,3420,1,HIST 3420: 001,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,rachel anne moore,HIST-3420,2014
-HIST,3670,1,HIST 3670: 001,0.37,0.34,0.13,0.0,0.11,0.0,0.0,0.05,michael silvestri,HIST-3670,2014
-HIST,3730,1,Age of Protestant Reformation,0.43,0.07,0.14,0.0,0.21,0.0,0.0,0.14,thomas kuehn,HIST-3730,2014
-HIST,3780,1,HIST 3780: 001,0.4,0.31,0.17,0.06,0.06,0.0,0.0,0.0,michael meng,HIST-3780,2014
-HIST,3900,1,HIST 3900: 001,0.15,0.41,0.3,0.07,0.07,0.0,0.0,0.0,edwin moise,HIST-3900,2014
-HIST,3970,1,HIST 3970: 001,0.44,0.44,0.07,0.0,0.02,0.0,0.0,0.02,amit bein,HIST-3970,2014
-HIST,4170,1,HIST 4170: 001,0.25,0.5,0.17,0.0,0.08,0.0,0.0,0.0,meg taylor-shockley,HIST-4170,2014
-HIST,4240,1,Top in Hist of Medicine & Hlth,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,pamela mack,HIST-4240,2014
-HIST,4360,1,HIST 4360: 001,0.23,0.27,0.41,0.0,0.09,0.0,0.0,0.0,edwin moise,HIST-4360,2014
-HIST,4600,1,Britain & WWII,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,james burns,HIST-4600,2014
-HIST,4710,1,The Great War 1914 & 1918,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0, alan grubb,HIST-4710,2014
-HIST,4900,2,The Empire World,0.4,0.27,0.2,0.0,0.07,0.0,0.0,0.07,michael silvestri,HIST-4900,2014
-HIST,4900,3,Heroic Failures,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,HIST-4900,2014
-HIST,4930,2,Urban History,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,abel bartley,HIST-4930,2014
-HLTH,2020,1,HLTH 2020: 001,0.23,0.64,0.13,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2014
-HLTH,2020,2,HLTH 2020: 002,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2014
-HLTH,2020,3,HLTH 2020: 003,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,sarah griffin,HLTH-2020,2014
-HLTH,2020,400,HLTH 2020: 400,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2014
-HLTH,2030,1,HLTH 2030: 001,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2030,2014
-HLTH,2030,2,HLTH 2030: 002,0.65,0.22,0.11,0.0,0.0,0.0,0.0,0.03,son albury-crandall,HLTH-2030,2014
-HLTH,2030,400,HLTH 2030: 400,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2030,2014
-HLTH,2030,401,HLTH 2030: 401,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2030,2014
-HLTH,2400,1,HLTH 2400: 001,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,joel edwar williams,HLTH-2400,2014
-HLTH,2400,2,HLTH 2400: 002,0.73,0.1,0.15,0.02,0.0,0.0,0.0,0.0,joel edwar williams,HLTH-2400,2014
-HLTH,2980,1,HLTH 2980: 001,0.52,0.45,0.02,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-2980,2014
-HLTH,2980,2,HLTH 2980: 002,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-2980,2014
-HLTH,3100,1,HLTH 3100: 001,0.19,0.62,0.15,0.0,0.0,0.0,0.0,0.04,rachel mayo,HLTH-3100,2014
-HLTH,3100,2,HLTH 3100: 002,0.48,0.36,0.12,0.04,0.0,0.0,0.0,0.0,rachel mayo,HLTH-3100,2014
-HLTH,3800,1,HLTH 3800: 001,0.41,0.44,0.13,0.0,0.03,0.0,0.0,0.0,liwei chen,HLTH-3800,2014
-HLTH,3800,2,HLTH 3800: 002,0.32,0.5,0.11,0.04,0.04,0.0,0.0,0.0,liwei chen,HLTH-3800,2014
-HLTH,3980,1,HLTH 3980: 001,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,kathleen meyer,HLTH-3980,2014
-HLTH,4000,1,Adolescent Health,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-4000,2014
-HLTH,4020,1,HLTH 4020: 001,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,karen kemper,HLTH-4020,2014
-HLTH,4190,1,HLTH 4190: 001,0.31,0.58,0.09,0.0,0.0,0.0,0.0,0.02,kathleen meyer,HLTH-4190,2014
-HLTH,4200,1,Hlth Science Intern,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2014
-HLTH,4300,1,HLTH 4300: 001,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,HLTH-4300,2014
-HLTH,4310,1,Public & Environ Hlt,0.63,0.29,0.04,0.0,0.02,0.0,0.0,0.02,deborah alma falta,HLTH-4310,2014
-HLTH,4400,1,HLTH 4400: 001,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,windsor we sherrill,HLTH-4400,2014
-HLTH,4600,1,HLTH 4600: 001,0.59,0.33,0.04,0.0,0.0,0.0,0.0,0.04,deidra jol morrison,HLTH-4600,2014
-HLTH,4780,1,HLTH 4780: 001,0.11,0.56,0.3,0.0,0.0,0.0,0.0,0.04,hugh spitler,HLTH-4780,2014
-HLTH,4790,1,HLTH 4790: 001,0.17,0.48,0.24,0.1,0.0,0.0,0.0,0.0,khoa dang truong,HLTH-4790,2014
-HLTH,4800,1,HLTH 4800: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,HLTH-4800,2014
-HLTH,4900,1,HLTH 4900: 001,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,lu shi,HLTH-4900,2014
-HLTH,4900,2,HLTH 4900: 002,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,lu shi,HLTH-4900,2014
-HON,2030,2,Music and Politics (HON),0.83,0.06,0.0,0.06,0.0,0.0,0.0,0.06,eric lapin,HON-2030,2014
-HON,2060,1,Intro to Nanotechnology,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,christophe kitchens,HON-2060,2014
-HON,2210,1,The Great War 1914-1918,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,HON-2210,2014
-HON,2210,3,20th Century Lit & Painting,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,john morgenstern,HON-2210,2014
-HON,2210,5,Spies and Spy Novels,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,william lasser,HON-2210,2014
-HORT,1010,1,HORT 1010: 001,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,HORT-1010,2014
-HORT,2110,1,HORT 2110: 001,0.33,0.33,0.19,0.11,0.04,0.0,0.0,0.0,james emerson faust,HORT-2110,2014
-HORT,4040,1,HORT 4040: 001,0.06,0.44,0.19,0.14,0.14,0.0,0.0,0.03,jeffrey adelberg,HORT-4040,2014
-HORT,4050,2,HORT 4050: 002,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,HORT-4050,2014
-HORT,4270,1,Urban Tree Care,0.18,0.36,0.18,0.05,0.18,0.0,0.0,0.05,robert polomski,HORT-4270,2014
-HORT,4330,1,Turf Weed Management,0.13,0.54,0.25,0.0,0.04,0.0,0.0,0.04,ted whitwell,HORT-4330,2014
-HORT,4720,1,HORT 4720: 001,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-4720,2014
-HP,8900,400,Directed Studies: Pres Eng,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,craig mille bennett,HP-8900,2014
-HP,8910,1,HP 8910: 001,0.0,0.0,0.0,0.0,0.0,0.85,0.15,0.0,carter lee hudgins,HP-8910,2014
-HRD,8470,400,HRD 8470: 400,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,HRD-8470,2014
-HRD,8470,401,HRD 8470: 401,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,HRD-8470,2014
-HRD,8470,402,HRD 8470: 402,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,HRD-8470,2014
-HRD,8470,403,HRD 8470: 403,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,HRD-8470,2014
-HRD,8470,405,HRD 8470: 405,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,HRD-8470,2014
-IE,2010,1,IE 2010: 001,0.37,0.27,0.23,0.13,0.0,0.0,0.0,0.0,joel greenstein,IE-2010,2014
-IE,2100,1,IE 2100: 001,0.46,0.4,0.08,0.02,0.02,0.0,0.0,0.01,antonia rodriguez,IE-2100,2014
-IE,3610,1,IE 3610: 001,0.42,0.32,0.1,0.09,0.05,0.0,0.0,0.03,david neyens,IE-3610,2014
-IE,3810,1,IE 3810: 001,0.34,0.42,0.14,0.07,0.02,0.0,0.0,0.01,mary elizabeth kurz,IE-3810,2014
-IE,3840,1,IE 3840: 001,0.36,0.2,0.16,0.05,0.08,0.0,0.0,0.14,brian melloy,IE-3840,2014
-IE,3860,1,IE 3860: 001,0.6,0.26,0.12,0.01,0.0,0.0,0.0,0.01,jonathan lowe,IE-3860,2014
-IE,4600,1,IE 4600: 001,0.33,0.39,0.22,0.06,0.0,0.0,0.0,0.0,joel greenstein,IE-4600,2014
-IE,4620,1,IE 4620: 001,0.35,0.6,0.03,0.0,0.0,0.02,0.0,0.0,byung rae cho,IE-4620,2014
-IE,4910,1,Appl Probability Models in IE,0.82,0.0,0.09,0.09,0.0,0.0,0.0,0.0,brian melloy,IE-4910,2014
-IE,6620,1,IE 6620: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,byung rae cho,IE-6620,2014
-IE,8010,1,Human-Machine Sys,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,IE-8010,2014
-IE,8040,1,IE 8040: 001,0.29,0.48,0.24,0.0,0.0,0.0,0.0,0.0,william ferrell,IE-8040,2014
-IE,8050,1,IE 8050: 001,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,byung rae cho,IE-8050,2014
-IE,8520,1,IE 8520: 001,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabeth kurz,IE-8520,2014
-IE,8540,1,IE 8540: 001,0.47,0.39,0.08,0.0,0.0,0.0,0.0,0.06,william ferrell,IE-8540,2014
-IE,8580,1,IE 8580: 001,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-8580,2014
-IE,8800,1,IE 8800: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,amin khademi,IE-8800,2014
-IS,2100,615,Sel Topics Int Study,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,sallie bro turnbull,IS-2100,2014
-ITAL,1010,1,ITAL 1010: 001,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,julia schmidt,ITAL-1010,2014
-ITAL,1020,1,ITAL 1020: 001,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,luca barattoni,ITAL-1020,2014
-ITAL,1020,2,ITAL 1020: 002,0.38,0.31,0.0,0.08,0.15,0.0,0.08,0.0,luca barattoni,ITAL-1020,2014
-ITAL,1020,3,ITAL 1020: 003,0.5,0.25,0.08,0.08,0.0,0.0,0.0,0.08,valentina lombardi,ITAL-1020,2014
-ITAL,2020,1,Intermediate Italian,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2020,2014
-ITAL,2020,2,Intermediate Italian,0.28,0.39,0.33,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2020,2014
-JAPN,1010,2,JAPN 1010: 002,0.21,0.36,0.07,0.07,0.21,0.0,0.0,0.07,kazuko shoji,JAPN-1010,2014
-JAPN,1020,1,JAPN 1020: 001,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0, leslie williams,JAPN-1020,2014
-JAPN,2020,1,JAPN 2020: 001,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,kazuko shoji,JAPN-2020,2014
-JAPN,3060,1,JAPN 3060: 001,0.4,0.3,0.1,0.0,0.0,0.1,0.0,0.1,toshiko kishimoto,JAPN-3060,2014
-JAPN,4170,1,Japan Cult & Soc,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0, leslie williams,JAPN-4170,2014
-LANG,4990,1,LANG 4990: 001,0.0,0.0,0.0,0.0,0.0,0.88,0.06,0.06,su- chen,LANG-4990,2014
-LARC,1160,1,History of Larch,0.31,0.36,0.2,0.05,0.05,0.0,0.0,0.04,hala fouad nassar,LARC-1160,2014
-LARC,1520,1,LARC 1520: 001,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,daniel ford,LARC-1520,2014
-LARC,2620,1,Design Impl I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,david pearson,LARC-2620,2014
-LARC,3520,1,LARC 3520: 001,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,robert hewitt,LARC-3520,2014
-LARC,6530,1,LARC 6530: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lycke,LARC-6530,2014
-LARC,8300,1,LARC 8300: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,LARC-8300,2014
-LAW,3220,1,Legal Env of Bus,0.35,0.4,0.16,0.03,0.0,0.0,0.0,0.06,edward ray claggett,LAW-3220,2014
-LAW,3220,2,Legal Env of Bus,0.53,0.31,0.08,0.05,0.02,0.0,0.0,0.02,edward ray claggett,LAW-3220,2014
-LAW,3220,3,Legal Env of Bus,0.43,0.41,0.13,0.02,0.0,0.0,0.0,0.02,frances edwards,LAW-3220,2014
-LAW,3220,4,Legal Env of Bus,0.3,0.49,0.17,0.03,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2014
-LAW,3220,5,Legal Env of Bus,0.41,0.44,0.13,0.02,0.0,0.0,0.0,0.02,frances edwards,LAW-3220,2014
-LAW,3220,6,Legal Env of Bus,0.0,0.17,0.29,0.2,0.07,0.0,0.0,0.27,virgini ward-vaughn,LAW-3220,2014
-LAW,3220,7,Legal Env of Bus,0.08,0.25,0.25,0.14,0.08,0.0,0.0,0.19,virgini ward-vaughn,LAW-3220,2014
-LAW,3220,8,Legal Env of Bus,0.02,0.14,0.36,0.12,0.12,0.0,0.0,0.24,virgini ward-vaughn,LAW-3220,2014
-LAW,3220,9,Legal Env of Bus,0.03,0.28,0.21,0.23,0.15,0.0,0.0,0.1,virgini ward-vaughn,LAW-3220,2014
-LAW,3330,1,Real Estate Law,0.15,0.31,0.46,0.02,0.04,0.0,0.0,0.02,judson jahn,LAW-3330,2014
-LAW,3330,2,Real Estate Law,0.13,0.38,0.38,0.06,0.02,0.0,0.0,0.02,judson jahn,LAW-3330,2014
-LAW,8480,1,LAW 8480: 001,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-8480,2014
-LAW,8500,1,LAW 8500: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,megan mowrey,LAW-8500,2014
-LAW,8500,2,LAW 8500: 002,0.89,0.08,0.0,0.0,0.03,0.0,0.0,0.0,megan mowrey,LAW-8500,2014
-LS,1000,2,Fitness Leadership,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,mary allison lynch,LS-1000,2014
-LS,1000,20,Intro to Volleyball,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,kelly lynn ator,LS-1000,2014
-LS,1000,22,Forestry Skills,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,tamara lee cushing,LS-1000,2014
-LS,1410,2,LS 1410: 002,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,glenn dav middleton,LS-1410,2014
-LS,1450,2,LS 1450: 002,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,george wal thompson,LS-1450,2014
-LS,1560,1,LS 1560: 001,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,david brad cottrell,LS-1560,2014
-LS,1560,3,LS 1560: 003,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,david brad cottrell,LS-1560,2014
-LS,1570,6,LS 1570: 006,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey la atkinson,LS-1570,2014
-LS,1570,10,LS 1570: 010,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,audrey caroli couch,LS-1570,2014
-LS,1580,1,LS 1580: 001,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,herbert strickland,LS-1580,2014
-LS,1580,5,LS 1580: 005,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,LS-1580,2014
-LS,1610,1,LS 1610: 001,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,richard willey,LS-1610,2014
-LS,1790,1,LS 1790: 001,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert bogan,LS-1790,2014
-LS,1830,1,LS 1830: 001,0.77,0.09,0.09,0.05,0.0,0.0,0.0,0.0,justin hickey,LS-1830,2014
-LS,1850,1,LS 1850: 001,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,matthew davi hughes,LS-1850,2014
-LS,1850,2,LS 1850: 002,0.93,0.0,0.0,0.04,0.0,0.0,0.0,0.04,matthew davi hughes,LS-1850,2014
-LS,1850,4,LS 1850: 004,0.96,0.0,0.0,0.0,0.04,0.0,0.0,0.0,megan elizabet cato,LS-1850,2014
-LS,1880,1,LS 1880: 001,0.73,0.0,0.0,0.0,0.07,0.0,0.0,0.2,jarrett bachman,LS-1880,2014
-LS,1890,1,LS 1890: 001,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,jennifer jo garrity,LS-1890,2014
-LS,1990,1,LS 1990: 001,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jason jordan,LS-1990,2014
-LS,2040,2,LS 2040: 002,0.83,0.0,0.0,0.09,0.0,0.0,0.0,0.09,denise ann adams,LS-2040,2014
-LS,2100,4,LS 2100: 004,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,paul hoke,LS-2100,2014
-LS,2110,2,LS 2110: 002,0.88,0.0,0.12,0.0,0.0,0.0,0.0,0.0,stephanie pack,LS-2110,2014
-LS,2190,1,LS 2190: 001,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,matthew lee krabbe,LS-2190,2014
-LS,2200,5,LS 2200: 005,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,broadus fleming,LS-2200,2014
-LS,2200,7,LS 2200: 007,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,matthew lee krabbe,LS-2200,2014
-LS,2200,8,LS 2200: 008,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,matthew lee krabbe,LS-2200,2014
-LS,2200,9,LS 2200: 009,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,matthew lee krabbe,LS-2200,2014
-LS,2210,1,LS 2210: 001,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,paul hoke,LS-2210,2014
-LS,2270,1,LS 2270: 001,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,LS-2270,2014
-LS,2270,2,LS 2270: 002,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,paul hoke,LS-2270,2014
-LS,2320,1,LS 2320: 001,0.87,0.0,0.0,0.0,0.04,0.0,0.0,0.09,diane moreno,LS-2320,2014
-LS,2320,2,LS 2320: 002,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,diane moreno,LS-2320,2014
-LS,2320,3,LS 2320: 003,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,diane moreno,LS-2320,2014
-LS,2320,5,LS 2320: 005,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-2320,2014
-LS,2350,1,LS 2350: 001,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,ranjanbala dil amin,LS-2350,2014
-LS,2350,2,LS 2350: 002,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,LS-2350,2014
-LS,2350,3,LS 2350: 003,0.7,0.09,0.13,0.0,0.0,0.0,0.0,0.09,renee warren gahan,LS-2350,2014
-LS,2350,4,LS 2350: 004,0.79,0.08,0.0,0.0,0.0,0.0,0.0,0.13,renee warren gahan,LS-2350,2014
-LS,2350,5,LS 2350: 005,0.65,0.17,0.0,0.0,0.0,0.0,0.0,0.17,renee warren gahan,LS-2350,2014
-LS,2350,6,LS 2350: 006,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-2350,2014
-LS,2350,8,LS 2350: 008,0.84,0.04,0.0,0.04,0.08,0.0,0.0,0.0,ranjanbala dil amin,LS-2350,2014
-LS,2360,1,LS 2360: 001,0.92,0.0,0.0,0.0,0.04,0.0,0.0,0.04,ani reina-nunnelley,LS-2360,2014
-LS,2360,2,LS 2360: 002,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,ani reina-nunnelley,LS-2360,2014
-LS,2360,3,LS 2360: 003,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,LS-2360,2014
-LS,2370,1,LS 2370: 001,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,ashley austi lester,LS-2370,2014
-LS,2370,2,LS 2370: 002,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,ashley austi lester,LS-2370,2014
-LS,2370,3,LS 2370: 003,0.72,0.17,0.0,0.0,0.0,0.0,0.0,0.11,ashley austi lester,LS-2370,2014
-LS,2370,4,LS 2370: 004,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,LS-2370,2014
-LS,2370,5,LS 2370: 005,0.77,0.09,0.0,0.0,0.05,0.0,0.0,0.09,ashley austi lester,LS-2370,2014
-LS,2380,2,LS 2380: 002,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,phaedra o'connell,LS-2380,2014
-LS,2380,3,LS 2380: 003,0.74,0.13,0.04,0.0,0.0,0.0,0.0,0.09,phaedra o'connell,LS-2380,2014
-LS,2380,5,LS 2380: 005,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,phaedra o'connell,LS-2380,2014
-LS,2420,1,LS 2420: 001,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,LS-2420,2014
-LS,2420,2,LS 2420: 002,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,phaedra o'connell,LS-2420,2014
-LS,2420,3,LS 2420: 003,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,ranjanbala dil amin,LS-2420,2014
-LS,2420,4,LS 2420: 004,0.87,0.0,0.09,0.0,0.0,0.0,0.0,0.04,phaedra o'connell,LS-2420,2014
-LS,2420,5,LS 2420: 005,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,LS-2420,2014
-LS,2770,1,LS 2770: 001,0.36,0.55,0.0,0.0,0.0,0.0,0.0,0.09,kelly lynn womack,LS-2770,2014
-MATH,1010,1,Essen Math for Informed Soc,0.18,0.35,0.29,0.06,0.12,0.0,0.0,0.0,chelsea rose snyder,MATH-1010,2014
-MATH,1010,2,Essen Math for Informed Soc,0.35,0.24,0.32,0.09,0.0,0.0,0.0,0.0,judith cottingham,MATH-1010,2014
-MATH,1010,3,Essen Math for Informed Soc,0.27,0.4,0.2,0.13,0.0,0.0,0.0,0.0,matthew keogh,MATH-1010,2014
-MATH,1010,4,Essen Math for Informed Soc,0.4,0.27,0.1,0.1,0.07,0.0,0.0,0.07,judith cottingham,MATH-1010,2014
-MATH,1010,5,Essen Math for Informed Soc,0.37,0.16,0.21,0.11,0.11,0.0,0.0,0.05,golubinski capaverde,MATH-1010,2014
-MATH,1010,6,Essen Math for Informed Soc,0.21,0.24,0.21,0.18,0.06,0.0,0.0,0.09,judith cottingham,MATH-1010,2014
-MATH,1010,7,Essen Math for Informed Soc,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,honghai xu,MATH-1010,2014
-MATH,1020,1,Intro to Mathematical Analysis,0.11,0.32,0.21,0.11,0.26,0.0,0.0,0.0,garrett dranichak,MATH-1020,2014
-MATH,1020,2,Intro to Mathematical Analysis,0.11,0.26,0.16,0.32,0.11,0.0,0.0,0.05,karyn muir,MATH-1020,2014
-MATH,1020,3,Intro to Mathematical Analysis,0.11,0.14,0.14,0.17,0.37,0.0,0.0,0.06,brian dandurand,MATH-1020,2014
-MATH,1020,4,Intro to Mathematical Analysis,0.3,0.05,0.3,0.2,0.15,0.0,0.0,0.0,caroline lee burch,MATH-1020,2014
-MATH,1020,5,Intro to Mathematical Analysis,0.1,0.29,0.26,0.05,0.24,0.0,0.0,0.07,randy davidson,MATH-1020,2014
-MATH,1020,6,Intro to Mathematical Analysis,0.29,0.29,0.14,0.0,0.19,0.0,0.0,0.1,kara ail stasikelis,MATH-1020,2014
-MATH,1020,7,Intro to Mathematical Analysis,0.18,0.23,0.3,0.18,0.08,0.0,0.0,0.05, erwin walker,MATH-1020,2014
-MATH,1020,8,Intro to Mathematical Analysis,0.17,0.24,0.31,0.1,0.17,0.0,0.0,0.02,allison stoddard,MATH-1020,2014
-MATH,1020,9,Intro to Mathematical Analysis,0.26,0.21,0.12,0.12,0.24,0.0,0.0,0.06,brian dandurand,MATH-1020,2014
-MATH,1020,10,Intro to Mathematical Analysis,0.25,0.14,0.28,0.08,0.17,0.0,0.0,0.08,randy davidson,MATH-1020,2014
-MATH,1020,11,Intro to Mathematical Analysis,0.17,0.29,0.26,0.09,0.14,0.0,0.0,0.06,randy davidson,MATH-1020,2014
-MATH,1020,12,Intro to Mathematical Analysis,0.06,0.19,0.31,0.13,0.13,0.0,0.0,0.19,drew jared lipman,MATH-1020,2014
-MATH,1020,13,Intro to Mathematical Analysis,0.39,0.17,0.11,0.06,0.17,0.0,0.0,0.11,paul james cubre,MATH-1020,2014
-MATH,1020,14,Intro to Mathematical Analysis,0.06,0.17,0.23,0.23,0.2,0.0,0.0,0.11,brian dandurand,MATH-1020,2014
-MATH,1040,1,MATH 1040: 001,0.0,0.0,0.0,0.0,0.0,0.62,0.31,0.08,lakmali weerasena,MATH-1040,2014
-MATH,1040,2,MATH 1040: 002,0.0,0.0,0.0,0.0,0.0,0.62,0.31,0.07,lakmali weerasena,MATH-1040,2014
-MATH,1050,400,MATH 1050: 400,0.0,0.0,0.0,0.0,0.0,0.63,0.35,0.02,eliza dar gallagher,MATH-1050,2014
-MATH,1060,1,Calculus of One Variable I,0.0,0.36,0.21,0.07,0.29,0.0,0.0,0.07,sarah eliz anderson,MATH-1060,2014
-MATH,1060,2,Calculus of One Variable I,0.05,0.2,0.25,0.3,0.2,0.0,0.0,0.0,charity watson,MATH-1060,2014
-MATH,1060,3,Calculus of One Variable I,0.04,0.25,0.25,0.04,0.21,0.0,0.0,0.21,allen anderso guest,MATH-1060,2014
-MATH,1060,4,Calculus of One Variable I,0.12,0.04,0.24,0.16,0.32,0.0,0.0,0.12,allen anderso guest,MATH-1060,2014
-MATH,1060,5,Calculus of One Variable I,0.09,0.22,0.25,0.09,0.25,0.0,0.0,0.09,marion hanna,MATH-1060,2014
-MATH,1060,6,Calculus of One Variable I,0.04,0.18,0.32,0.18,0.14,0.0,0.0,0.14,marilyn reba,MATH-1060,2014
-MATH,1060,7,Calculus of One Variable I,0.05,0.21,0.42,0.16,0.16,0.0,0.0,0.0,damitha bandara,MATH-1060,2014
-MATH,1060,8,Calculus of One Variable I,0.05,0.3,0.35,0.1,0.15,0.0,0.0,0.05,damitha bandara,MATH-1060,2014
-MATH,1060,202,Calculus of One Variable I,0.32,0.32,0.11,0.0,0.16,0.0,0.0,0.11,james peterson,MATH-1060,2014
-MATH,1070,1,Differen and Integral Calculus,0.16,0.43,0.18,0.09,0.11,0.0,0.0,0.02,donna simms,MATH-1070,2014
-MATH,1070,2,Differen and Integral Calculus,0.15,0.57,0.15,0.07,0.04,0.0,0.0,0.02,donna simms,MATH-1070,2014
-MATH,1070,3,Differen and Integral Calculus,0.23,0.3,0.38,0.06,0.02,0.0,0.0,0.0,christy jenki brown,MATH-1070,2014
-MATH,1070,4,Differen and Integral Calculus,0.33,0.29,0.22,0.07,0.02,0.0,0.0,0.07,jennifer mari hanna,MATH-1070,2014
-MATH,1070,5,Differen and Integral Calculus,0.36,0.21,0.28,0.09,0.06,0.0,0.0,0.0,jennifer mari hanna,MATH-1070,2014
-MATH,1070,6,Differen and Integral Calculus,0.26,0.36,0.26,0.09,0.04,0.0,0.0,0.0,jennifer mari hanna,MATH-1070,2014
-MATH,1080,1,Calculus of One Variable II,0.09,0.2,0.18,0.07,0.16,0.0,0.0,0.31,christa con johnson,MATH-1080,2014
-MATH,1080,2,Calculus of One Variable II,0.05,0.24,0.21,0.03,0.05,0.0,0.0,0.42,terri johnson,MATH-1080,2014
-MATH,1080,3,Calculus of One Variable II,0.18,0.25,0.11,0.05,0.18,0.0,0.0,0.23,anastasia br wilson,MATH-1080,2014
-MATH,1080,4,Calculus of One Variable II,0.04,0.24,0.2,0.07,0.13,0.0,0.0,0.33,beth novick,MATH-1080,2014
-MATH,1080,5,Calculus of One Variable II,0.09,0.26,0.24,0.04,0.0,0.0,0.0,0.37,terri johnson,MATH-1080,2014
-MATH,1080,6,Calculus of One Variable II,0.02,0.29,0.11,0.09,0.07,0.0,0.0,0.42,beth novick,MATH-1080,2014
-MATH,1080,7,Calculus of One Variable II,0.13,0.26,0.17,0.09,0.11,0.0,0.0,0.24,meredith nicol burr,MATH-1080,2014
-MATH,1080,8,Calculus of One Variable II,0.11,0.22,0.29,0.02,0.18,0.0,0.0,0.18,christa con johnson,MATH-1080,2014
-MATH,1080,9,Calculus of One Variable II,0.06,0.36,0.15,0.11,0.17,0.0,0.0,0.15,shih-wei chao,MATH-1080,2014
-MATH,1080,10,Calculus of One Variable II,0.02,0.16,0.27,0.11,0.16,0.0,0.0,0.29,akshay sunil gupte,MATH-1080,2014
-MATH,1080,11,Calculus of One Variable II,0.11,0.24,0.18,0.09,0.2,0.0,0.0,0.18,patrick buckingham,MATH-1080,2014
-MATH,1080,12,Calculus of One Variable II,0.42,0.27,0.18,0.02,0.02,0.0,0.0,0.09,dania moham zantout,MATH-1080,2014
-MATH,1080,13,Calculus of One Variable II,0.07,0.11,0.2,0.05,0.36,0.0,0.0,0.2,nathan chenette,MATH-1080,2014
-MATH,1080,14,Calculus of One Variable II,0.09,0.09,0.21,0.02,0.09,0.0,0.0,0.49,rachel eli grotheer,MATH-1080,2014
-MATH,1080,15,Calculus of One Variable II,0.11,0.19,0.26,0.06,0.17,0.0,0.0,0.22,nathanael dav black,MATH-1080,2014
-MATH,1150,1,Contemp Math for Elem Teach I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,james kwame dogbey,MATH-1150,2014
-MATH,1160,1,Contemp Math for Elem Teach II,0.56,0.31,0.03,0.09,0.0,0.0,0.0,0.0,allison stoddard,MATH-1160,2014
-MATH,1160,2,Contemp Math for Elem Teach II,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1160,2014
-MATH,1990,400,MATH 1990: 400,0.0,0.0,0.0,0.0,0.0,0.88,0.07,0.04,marion hanna,MATH-1990,2014
-MATH,2030,1,Elemen Statistical Inference,0.62,0.26,0.05,0.03,0.03,0.0,0.0,0.03,laura jane shick,MATH-2030,2014
-MATH,2030,2,Elemen Statistical Inference,0.44,0.23,0.15,0.13,0.0,0.0,0.0,0.05,laura jane shick,MATH-2030,2014
-MATH,2030,3,Elemen Statistical Inference,0.71,0.12,0.07,0.07,0.0,0.0,0.0,0.02,laura jane shick,MATH-2030,2014
-MATH,2030,4,Elemen Statistical Inference,0.49,0.29,0.06,0.06,0.09,0.0,0.0,0.03,christopher wilson,MATH-2030,2014
-MATH,2030,5,Elemen Statistical Inference,0.56,0.17,0.14,0.08,0.03,0.0,0.0,0.03,stephen wesl carden,MATH-2030,2014
-MATH,2030,6,Elemen Statistical Inference,0.6,0.18,0.13,0.05,0.03,0.0,0.0,0.03,dominique morgan,MATH-2030,2014
-MATH,2030,7,Elemen Statistical Inference,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,yan liu,MATH-2030,2014
-MATH,2060,1,Calculus of Several Variables,0.1,0.13,0.17,0.37,0.23,0.0,0.0,0.0,christopher cox,MATH-2060,2014
-MATH,2060,2,Calculus of Several Variables,0.26,0.59,0.06,0.03,0.0,0.0,0.0,0.06,peter kiessler,MATH-2060,2014
-MATH,2060,3,Calculus of Several Variables,0.41,0.16,0.27,0.05,0.08,0.0,0.0,0.03,charles johnson,MATH-2060,2014
-MATH,2060,4,Calculus of Several Variables,0.29,0.29,0.35,0.0,0.03,0.0,0.0,0.03,chanseok park,MATH-2060,2014
-MATH,2060,5,Calculus of Several Variables,0.43,0.14,0.29,0.09,0.06,0.0,0.0,0.0,timothy ch teitloff,MATH-2060,2014
-MATH,2060,6,Calculus of Several Variables,0.25,0.34,0.28,0.03,0.06,0.0,0.0,0.03,svetlan poznanovikj,MATH-2060,2014
-MATH,2060,7,Calculus of Several Variables,0.32,0.44,0.21,0.0,0.03,0.0,0.0,0.0,peter kiessler,MATH-2060,2014
-MATH,2060,8,Calculus of Several Variables,0.18,0.35,0.24,0.03,0.15,0.0,0.0,0.06,nathan jos adelgren,MATH-2060,2014
-MATH,2060,9,Calculus of Several Variables,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,martin joha schmoll,MATH-2060,2014
-MATH,2060,10,Calculus of Several Variables,0.27,0.3,0.21,0.06,0.03,0.0,0.0,0.12,qingshan chen,MATH-2060,2014
-MATH,2060,11,Calculus of Several Variables,0.26,0.32,0.18,0.12,0.03,0.0,0.0,0.09,xin liu,MATH-2060,2014
-MATH,2060,100,Calc of Several Variable (HON),0.58,0.25,0.08,0.0,0.08,0.0,0.0,0.0,james brown,MATH-2060,2014
-MATH,2070,1,Multivariable Calculus,0.22,0.06,0.33,0.11,0.11,0.0,0.0,0.17,elaine ma sotherden,MATH-2070,2014
-MATH,2070,3,Multivariable Calculus,0.35,0.35,0.29,0.0,0.0,0.0,0.0,0.0,rodney lewis keaton,MATH-2070,2014
-MATH,2070,4,Multivariable Calculus,0.08,0.31,0.31,0.06,0.17,0.0,0.0,0.08,sherry biggers,MATH-2070,2014
-MATH,2070,5,Multivariable Calculus,0.44,0.31,0.17,0.0,0.03,0.0,0.0,0.06,jennifer van dyken,MATH-2070,2014
-MATH,2070,6,Multivariable Calculus,0.17,0.49,0.23,0.11,0.0,0.0,0.0,0.0,judith irene mcknew,MATH-2070,2014
-MATH,2070,7,Multivariable Calculus,0.37,0.26,0.16,0.11,0.11,0.0,0.0,0.0,audrey nico devries,MATH-2070,2014
-MATH,2070,8,Multivariable Calculus,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,lawrence mccormick,MATH-2070,2014
-MATH,2070,9,Multivariable Calculus,0.26,0.53,0.11,0.11,0.0,0.0,0.0,0.0,alistair bentley,MATH-2070,2014
-MATH,2070,10,Multivariable Calculus,0.17,0.44,0.28,0.11,0.0,0.0,0.0,0.0,saba za alkaseasbeh,MATH-2070,2014
-MATH,2070,11,Multivariable Calculus,0.26,0.34,0.26,0.03,0.03,0.0,0.0,0.09,sherry biggers,MATH-2070,2014
-MATH,2070,12,Multivariable Calculus,0.33,0.36,0.14,0.08,0.06,0.0,0.0,0.03,judith irene mcknew,MATH-2070,2014
-MATH,2070,13,Multivariable Calculus,0.47,0.21,0.11,0.0,0.16,0.0,0.0,0.05,jason lee joyner,MATH-2070,2014
-MATH,2070,14,Multivariable Calculus,0.32,0.26,0.26,0.11,0.0,0.0,0.0,0.05,tony thanh nguyen,MATH-2070,2014
-MATH,2070,15,Multivariable Calculus,0.2,0.4,0.23,0.06,0.03,0.0,0.0,0.09,sherry biggers,MATH-2070,2014
-MATH,2070,16,Multivariable Calculus,0.53,0.16,0.05,0.11,0.11,0.0,0.0,0.05,rachel malinauskas,MATH-2070,2014
-MATH,2070,17,Multivariable Calculus,0.33,0.17,0.28,0.17,0.0,0.0,0.0,0.06,william bo lassiter,MATH-2070,2014
-MATH,2070,18,Multivariable Calculus,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0, ushijima-mwesigwa,MATH-2070,2014
-MATH,2070,19,Multivariable Calculus,0.37,0.37,0.11,0.05,0.11,0.0,0.0,0.0,zachary hollifield,MATH-2070,2014
-MATH,2070,20,Multivariable Calculus,0.35,0.35,0.1,0.1,0.05,0.0,0.0,0.05,luke marti giberson,MATH-2070,2014
-MATH,2070,21,Multivariable Calculus,0.15,0.48,0.24,0.03,0.03,0.0,0.0,0.06,mark thomas batell,MATH-2070,2014
-MATH,2070,22,Multivariable Calculus,0.32,0.47,0.05,0.0,0.11,0.0,0.0,0.05,jason to hedetniemi,MATH-2070,2014
-MATH,2070,23,Multivariable Calculus,0.16,0.47,0.32,0.0,0.05,0.0,0.0,0.0,janie caro mcdonald,MATH-2070,2014
-MATH,2070,24,Multivariable Calculus,0.28,0.28,0.28,0.0,0.06,0.0,0.0,0.11,grady mcgowa thomas,MATH-2070,2014
-MATH,2070,25,Multivariable Calculus,0.11,0.32,0.26,0.16,0.16,0.0,0.0,0.0,liem nguyen,MATH-2070,2014
-MATH,2070,26,Multivariable Calculus,0.15,0.5,0.15,0.1,0.1,0.0,0.0,0.0,fiona may knoll,MATH-2070,2014
-MATH,2080,1,Intro to Ordin Diff Equations,0.41,0.32,0.15,0.0,0.03,0.0,0.0,0.09,timothy fra parrott,MATH-2080,2014
-MATH,2080,2,Intro to Ordin Diff Equations,0.35,0.29,0.23,0.06,0.03,0.0,0.0,0.03,ebrahim nasrabadi,MATH-2080,2014
-MATH,2080,3,Intro to Ordin Diff Equations,0.24,0.24,0.18,0.06,0.12,0.0,0.0,0.18,shari prevost,MATH-2080,2014
-MATH,2080,4,Intro to Ordin Diff Equations,0.31,0.36,0.11,0.11,0.06,0.0,0.0,0.06,mishko mitkovski,MATH-2080,2014
-MATH,2080,5,Intro to Ordin Diff Equations,0.64,0.21,0.07,0.05,0.0,0.0,0.0,0.02,timothy fra parrott,MATH-2080,2014
-MATH,2080,6,Intro to Ordin Diff Equations,0.12,0.3,0.27,0.12,0.12,0.0,0.0,0.06,julie lassiter,MATH-2080,2014
-MATH,2080,7,Intro to Ordin Diff Equations,0.2,0.13,0.27,0.07,0.17,0.0,0.0,0.17,shari prevost,MATH-2080,2014
-MATH,2080,8,Intro to Ordin Diff Equations,0.17,0.27,0.23,0.13,0.1,0.0,0.0,0.1,julie lassiter,MATH-2080,2014
-MATH,2080,9,Intro to Ordin Diff Equations,0.47,0.19,0.22,0.06,0.06,0.0,0.0,0.0,timothy ch teitloff,MATH-2080,2014
-MATH,2080,10,Intro to Ordin Diff Equations,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,william moss,MATH-2080,2014
-MATH,2080,11,Intro to Ordin Diff Equations,0.17,0.38,0.13,0.13,0.17,0.0,0.0,0.04,brandon gra goodell,MATH-2080,2014
-MATH,2080,12,Intro to Ordin Diff Equations,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,irina viktorova,MATH-2080,2014
-MATH,2080,13,Intro to Ordin Diff Equations,0.41,0.41,0.05,0.02,0.07,0.0,0.0,0.02,timothy fra parrott,MATH-2080,2014
-MATH,2080,14,Intro to Ordin Diff Equations,0.66,0.11,0.11,0.06,0.06,0.0,0.0,0.0,timothy ch teitloff,MATH-2080,2014
-MATH,2080,15,Intro to Ordin Diff Equations,0.65,0.23,0.02,0.02,0.05,0.0,0.0,0.02,irina viktorova,MATH-2080,2014
-MATH,2080,16,Intro to Ordin Diff Equations,0.62,0.19,0.12,0.05,0.02,0.0,0.0,0.0,timothy ch teitloff,MATH-2080,2014
-MATH,2080,17,Intro to Ordin Diff Equations,0.32,0.37,0.13,0.05,0.08,0.0,0.0,0.05,timothy fra parrott,MATH-2080,2014
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,MATH-2080,2014
-MATH,2160,1,Geometry for Elem Sch Teachers,0.58,0.35,0.04,0.04,0.0,0.0,0.0,0.0,allison stoddard,MATH-2160,2014
-MATH,3010,1,Statistical Methods I,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hewa priyadarshani,MATH-3010,2014
-MATH,3010,2,Statistical Methods I,0.27,0.23,0.23,0.1,0.13,0.0,0.0,0.03,meredith nicol burr,MATH-3010,2014
-MATH,3010,3,Statistical Methods I,0.29,0.33,0.29,0.0,0.0,0.0,0.0,0.1,yanbo xia,MATH-3010,2014
-MATH,3010,4,Statistical Methods I,0.33,0.27,0.0,0.27,0.07,0.0,0.0,0.07,tao yang,MATH-3010,2014
-MATH,3010,5,Statistical Methods I,0.4,0.4,0.0,0.0,0.07,0.0,0.0,0.13,emily marie nystrom,MATH-3010,2014
-MATH,3020,1,MATH 3020: 001,0.26,0.35,0.24,0.09,0.0,0.0,0.0,0.06,derek brown,MATH-3020,2014
-MATH,3020,2,MATH 3020: 002,0.42,0.44,0.03,0.06,0.06,0.0,0.0,0.0,yingbo li,MATH-3020,2014
-MATH,3020,3,MATH 3020: 003,0.41,0.41,0.07,0.05,0.02,0.0,0.0,0.02,xiaoqian sun,MATH-3020,2014
-MATH,3020,4,MATH 3020: 004,0.28,0.33,0.18,0.05,0.08,0.0,0.0,0.08,calvin williams,MATH-3020,2014
-MATH,3020,5,MATH 3020: 005,0.34,0.26,0.2,0.09,0.06,0.0,0.0,0.06,michael thom finney,MATH-3020,2014
-MATH,3080,1,MATH 3080: 001,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,eliza dar gallagher,MATH-3080,2014
-MATH,3090,1,Intro to Business Statistics,0.19,0.26,0.33,0.04,0.15,0.0,0.0,0.04,gary fellers,MATH-3090,2014
-MATH,3090,2,Intro to Business Statistics,0.21,0.27,0.24,0.18,0.09,0.0,0.0,0.0,ellen hepfe breazel,MATH-3090,2014
-MATH,3090,3,Intro to Business Statistics,0.22,0.41,0.19,0.03,0.09,0.0,0.0,0.06,gary fellers,MATH-3090,2014
-MATH,3090,4,Intro to Business Statistics,0.05,0.16,0.26,0.32,0.21,0.0,0.0,0.0,bereket tesfaldet,MATH-3090,2014
-MATH,3090,5,Intro to Business Statistics,0.2,0.27,0.3,0.1,0.03,0.0,0.0,0.1,charity watson,MATH-3090,2014
-MATH,3090,6,Intro to Business Statistics,0.16,0.21,0.32,0.11,0.05,0.0,0.0,0.16,james ellis  wrenn,MATH-3090,2014
-MATH,3090,7,Intro to Business Statistics,0.1,0.26,0.32,0.19,0.1,0.0,0.0,0.03,margaret mar wiecek,MATH-3090,2014
-MATH,3090,8,Intro to Business Statistics,0.17,0.22,0.28,0.22,0.06,0.0,0.0,0.06,joshua crunkleton,MATH-3090,2014
-MATH,3090,9,Intro to Business Statistics,0.11,0.47,0.26,0.05,0.05,0.0,0.0,0.05,andrew jo schwarzer,MATH-3090,2014
-MATH,3090,10,Intro to Business Statistics,0.23,0.42,0.13,0.1,0.1,0.0,0.0,0.03,gary fellers,MATH-3090,2014
-MATH,3090,11,Intro to Business Statistics,0.1,0.35,0.32,0.13,0.06,0.0,0.0,0.03,gary fellers,MATH-3090,2014
-MATH,3090,12,Intro to Business Statistics,0.23,0.4,0.2,0.03,0.1,0.0,0.0,0.03,christy jenki brown,MATH-3090,2014
-MATH,3110,1,Linear Algebra,0.21,0.18,0.21,0.09,0.21,0.0,0.0,0.12,jeong rock yoon,MATH-3110,2014
-MATH,3110,2,Linear Algebra,0.29,0.21,0.26,0.06,0.18,0.0,0.0,0.0,neil calkin,MATH-3110,2014
-MATH,3110,3,Linear Algebra,0.19,0.19,0.13,0.16,0.22,0.0,0.0,0.13,nathan chenette,MATH-3110,2014
-MATH,3110,4,Linear Algebra,0.26,0.26,0.19,0.13,0.1,0.0,0.0,0.06,matthew macauley,MATH-3110,2014
-MATH,3110,5,Linear Algebra,0.1,0.05,0.24,0.24,0.05,0.0,0.0,0.33,felice manganiello,MATH-3110,2014
-MATH,3110,100,Linear Algebra (HON),0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,felice manganiello,MATH-3110,2014
-MATH,3150,1,MATH 3150: 001,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-3150,2014
-MATH,3190,2,MATH 3190: 002,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,michael adam burr,MATH-3190,2014
-MATH,3600,1,MATH 3600: 001,0.56,0.38,0.0,0.0,0.06,0.0,0.0,0.0,daniel warner,MATH-3600,2014
-MATH,3650,1,MATH 3650: 001,0.67,0.27,0.05,0.0,0.0,0.0,0.0,0.01,leo rebholz,MATH-3650,2014
-MATH,3650,2,MATH 3650: 002,0.37,0.23,0.07,0.07,0.13,0.0,0.0,0.13,timo johann heister,MATH-3650,2014
-MATH,4000,1,Theory of Probability,0.38,0.31,0.19,0.03,0.09,0.0,0.0,0.0,yingbo li,MATH-4000,2014
-MATH,4030,1,Intro to Statistical Theory,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,chanseok park,MATH-4030,2014
-MATH,4070,1,MATH 4070: 001,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-4070,2014
-MATH,4100,1,MATH 4100: 001,0.08,0.23,0.15,0.08,0.08,0.0,0.0,0.38,dania moham zantout,MATH-4100,2014
-MATH,4120,1,Intro to Modern Algebra,0.19,0.23,0.23,0.16,0.13,0.0,0.0,0.06,matthew macauley,MATH-4120,2014
-MATH,4190,1,Discrete Math Structures I,0.45,0.47,0.08,0.0,0.0,0.0,0.0,0.0,wayne goddard,MATH-4190,2014
-MATH,4300,1,MATH 4300: 001,0.2,0.2,0.1,0.2,0.2,0.0,0.0,0.1, erwin walker,MATH-4300,2014
-MATH,4340,1,MATH 4340: 001,0.14,0.24,0.17,0.17,0.03,0.0,0.0,0.24,eleanor jenkins,MATH-4340,2014
-MATH,4340,2,MATH 4340: 002,0.2,0.14,0.29,0.11,0.09,0.0,0.0,0.17,hyesuk lee,MATH-4340,2014
-MATH,4400,1,Linear Programming,0.12,0.35,0.15,0.08,0.04,0.0,0.0,0.27,akshay sunil gupte,MATH-4400,2014
-MATH,4410,1,Intro to Stochastic Models,0.38,0.29,0.17,0.04,0.08,0.0,0.0,0.04,brian fralix,MATH-4410,2014
-MATH,4500,1,MATH 4500: 001,0.18,0.18,0.09,0.36,0.09,0.0,0.0,0.09,vincent ervin,MATH-4500,2014
-MATH,4530,1,Advanced Calculus I,0.13,0.31,0.31,0.06,0.09,0.0,0.0,0.09,taufiquar rahm khan,MATH-4530,2014
-MATH,4540,1,Advanced Calculus II,0.24,0.44,0.16,0.04,0.04,0.0,0.0,0.08,taufiquar rahm khan,MATH-4540,2014
-MATH,6340,1,MATH 6340: 001,0.45,0.35,0.05,0.0,0.05,0.0,0.0,0.1,vincent ervin,MATH-6340,2014
-MATH,7060,400,MATH 7060: 400,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,stacy megan che,MATH-7060,2014
-MATH,8030,1,MATH 8030: 001,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,MATH-8030,2014
-MATH,8050,1,MATH 8050: 001,0.52,0.26,0.04,0.0,0.0,0.0,0.0,0.17,derek brown,MATH-8050,2014
-MATH,8060,1,MATH 8060: 001,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-8060,2014
-MATH,8100,1,MATH 8100: 001,0.47,0.41,0.0,0.0,0.06,0.0,0.0,0.06,matthew saltzman,MATH-8100,2014
-MATH,8110,1,MATH 8110: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,MATH-8110,2014
-MATH,8130,1,MATH 8130: 001,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,ebrahim nasrabadi,MATH-8130,2014
-MATH,8210,1,MATH 8210: 001,0.38,0.5,0.06,0.0,0.06,0.0,0.0,0.0,shitao liu,MATH-8210,2014
-MATH,8220,1,MATH 8220: 001,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,MATH-8220,2014
-MATH,8260,1,MATH 8260: 001,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,shitao liu,MATH-8260,2014
-MATH,8520,1,MATH 8520: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,MATH-8520,2014
-MATH,8530,1,MATH 8530: 001,0.47,0.12,0.29,0.0,0.06,0.0,0.0,0.06,svetlan poznanovikj,MATH-8530,2014
-MATH,8540,1,MATH 8540: 001,0.46,0.31,0.0,0.0,0.0,0.0,0.0,0.23,beth novick,MATH-8540,2014
-MATH,8600,1,MATH 8600: 001,0.3,0.57,0.09,0.0,0.0,0.0,0.0,0.04,qingshan chen,MATH-8600,2014
-MATH,8810,1,MATH 8810: 001,0.65,0.25,0.05,0.0,0.0,0.0,0.0,0.05,christopher mcmahan,MATH-8810,2014
-MATH,9830,1,Sel Top in Computational Math,0.57,0.14,0.29,0.0,0.0,0.0,0.0,0.0,timo johann heister,MATH-9830,2014
-MBA,8030,1,MBA 8030: 001,0.53,0.45,0.0,0.0,0.0,0.0,0.0,0.03,matthew charl klein,MBA-8030,2014
-MBA,8060,1,MBA 8060: 001,0.52,0.46,0.02,0.0,0.0,0.0,0.0,0.0,gulru fatma ozkan,MBA-8060,2014
-MBA,8070,1,MBA 8070: 001,0.41,0.41,0.12,0.0,0.0,0.0,0.0,0.06,fei xie,MBA-8070,2014
-MBA,8070,2,MBA 8070: 002,0.41,0.48,0.11,0.0,0.0,0.0,0.0,0.0,fei xie,MBA-8070,2014
-MBA,8090,1,Org Beh & Hum Res Mg,0.64,0.34,0.0,0.0,0.02,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2014
-MBA,8190,1,Intro to Acc and Fin,0.49,0.41,0.08,0.0,0.03,0.0,0.0,0.0,jeffrey mcmillan,MBA-8190,2014
-MBA,8190,2,Intro to Acc and Fin,0.31,0.58,0.12,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,MBA-8190,2014
-MBA,8290,1,Marketing Foundation,0.51,0.45,0.0,0.0,0.02,0.0,0.0,0.02,william kilbourne,MBA-8290,2014
-MBA,8370,1,Legal Environ of Bus,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.08,judson jahn,MBA-8370,2014
-MBA,8450,1,Tech & Innova Mgt,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david orr,MBA-8450,2014
-MBA,8470,1,MBA 8470: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,peter gianiodis,MBA-8470,2014
-MBA,8540,2,MBA 8540: 002,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,sarah martin,MBA-8540,2014
-MBA,8590,1,Mgr Decision Model,0.41,0.34,0.13,0.0,0.09,0.0,0.0,0.03,sara elizabet yoder,MBA-8590,2014
-MBA,8590,2,Mgr Decision Model,0.52,0.35,0.13,0.0,0.0,0.0,0.0,0.0,mark mcknew,MBA-8590,2014
-MBA,8600,1,MBA 8600: 001,0.15,0.5,0.23,0.0,0.04,0.0,0.0,0.08,michael dorsch,MBA-8600,2014
-MBA,8610,1,Information Systems,0.38,0.45,0.15,0.0,0.0,0.0,0.0,0.03,varun grover,MBA-8610,2014
-MBA,8610,2,Information Systems,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,MBA-8610,2014
-MBA,8620,1,Managerial Economics,0.34,0.37,0.14,0.0,0.0,0.0,0.0,0.14,scott templeton,MBA-8620,2014
-MBA,8700,1,MBA 8700: 001,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8700,2014
-MBA,8720,1,MBA 8720: 001,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,MBA-8720,2014
-MBA,8740,1,Managing Cont Impvmt,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,MBA-8740,2014
-MBA,8750,1,MBA 8750: 001,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8750,2014
-MBA,8990,1,Advanced Leadership,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.03,kathleen ann kegley,MBA-8990,2014
-ME,2000,1,ME 2000: 001,0.67,0.22,0.04,0.01,0.03,0.0,0.0,0.02,donald beasley,ME-2000,2014
-ME,2010,1,ME 2010: 001,0.03,0.27,0.23,0.11,0.34,0.0,0.0,0.03,sherrill biggers,ME-2010,2014
-ME,2010,2,ME 2010: 002,0.15,0.25,0.19,0.08,0.24,0.0,0.0,0.08,kalyan chakr katuri,ME-2010,2014
-ME,2020,1,ME 2020: 001,0.42,0.4,0.11,0.03,0.03,0.0,0.0,0.01,lonny thompson,ME-2020,2014
-ME,2020,2,ME 2020: 002,0.58,0.3,0.08,0.0,0.03,0.0,0.0,0.02,paul jeffrey meyer,ME-2020,2014
-ME,2030,1,ME 2030: 001,0.18,0.27,0.33,0.14,0.06,0.0,0.0,0.02,xiangchun xuan,ME-2030,2014
-ME,2030,2,ME 2030: 002,0.54,0.33,0.11,0.01,0.01,0.0,0.0,0.01,david zumbrunnen,ME-2030,2014
-ME,2030,3,ME 2030: 003,0.08,0.27,0.31,0.1,0.07,0.0,0.0,0.17,donald beasley,ME-2030,2014
-ME,2220,1,ME 2220: 001,0.35,0.41,0.06,0.0,0.06,0.0,0.0,0.12,todd schweisinger,ME-2220,2014
-ME,2220,2,ME 2220: 002,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,3,ME 2220: 003,0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,4,ME 2220: 004,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,5,ME 2220: 005,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,6,ME 2220: 006,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,7,ME 2220: 007,0.16,0.68,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,2220,8,ME 2220: 008,0.2,0.65,0.15,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2014
-ME,3020,1,Mech of Materials,0.2,0.31,0.22,0.11,0.13,0.0,0.0,0.02,paul joseph,ME-3020,2014
-ME,3020,2,Mech of Materials,0.18,0.3,0.33,0.1,0.08,0.0,0.0,0.02,huijuan zhao,ME-3020,2014
-ME,3020,3,Mech of Materials(HONORS),0.55,0.18,0.09,0.09,0.09,0.0,0.0,0.0,paul joseph,ME-3020,2014
-ME,3030,1,ME 3030: 001,0.12,0.24,0.3,0.14,0.12,0.0,0.0,0.08,john saylor,ME-3030,2014
-ME,3030,2,ME 3030: 002,0.05,0.41,0.43,0.09,0.0,0.0,0.0,0.02,richard miller,ME-3030,2014
-ME,3040,1,ME 3040: 001,0.09,0.23,0.26,0.09,0.09,0.0,0.0,0.23,jean-marc delhaye,ME-3040,2014
-ME,3040,2,ME 3040: 002,0.15,0.27,0.33,0.09,0.11,0.0,0.0,0.05,jay ochterbeck,ME-3040,2014
-ME,3050,1,ME 3050: 001,0.32,0.28,0.26,0.06,0.08,0.0,0.0,0.0,mohammed fari daqaq,ME-3050,2014
-ME,3050,2,ME 3050: 002,0.32,0.36,0.16,0.08,0.04,0.0,0.0,0.04,phanin tallapragada,ME-3050,2014
-ME,3060,1,ME 3060: 001,0.26,0.36,0.25,0.09,0.04,0.0,0.0,0.0,todd schweisinger,ME-3060,2014
-ME,3060,2,ME 3060: 002,0.19,0.47,0.26,0.05,0.02,0.0,0.0,0.02,paul jeffrey meyer,ME-3060,2014
-ME,3080,1,Fluid Mechanics,0.1,0.19,0.24,0.29,0.14,0.0,0.0,0.05,jean-marc delhaye,ME-3080,2014
-ME,3080,2,Fluid Mechanics,0.12,0.33,0.45,0.02,0.06,0.0,0.0,0.02,ilenia battiato,ME-3080,2014
-ME,3100,1,ME 3100: 001,0.22,0.17,0.33,0.13,0.13,0.0,0.0,0.02,jay ochterbeck,ME-3100,2014
-ME,3120,1,ME 3120: 001,0.36,0.56,0.08,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-3120,2014
-ME,3120,2,ME 3120: 002,0.17,0.66,0.14,0.03,0.0,0.0,0.0,0.0,rod martinez-duarte,ME-3120,2014
-ME,3330,1,ME 3330: 001,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,3330,2,ME 3330: 002,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,3330,3,ME 3330: 003,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,ME-3330,2014
-ME,3330,5,ME 3330: 005,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,3330,6,ME 3330: 006,0.36,0.57,0.0,0.0,0.07,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,3330,7,ME 3330: 007,0.07,0.8,0.07,0.07,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2014
-ME,4010,1,ME 4010: 001,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,joshua summers,ME-4010,2014
-ME,4020,1,ME 4020: 001,0.38,0.44,0.13,0.06,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2014
-ME,4020,2,ME 4020: 002,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,sherrill biggers,ME-4020,2014
-ME,4020,3,ME 4020: 003,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2014
-ME,4020,5,ME 4020: 005,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-4020,2014
-ME,4020,6,ME 4020: 006,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2014
-ME,4020,7,ME 4020: 007,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4020,2014
-ME,4030,1,ME 4030: 001,0.21,0.23,0.31,0.13,0.1,0.0,0.0,0.03, timothy freeman,ME-4030,2014
-ME,4030,2,ME 4030: 002,0.24,0.32,0.34,0.11,0.0,0.0,0.0,0.0,ardalan vahidi,ME-4030,2014
-ME,4170,1,ME 4170: 001,0.44,0.48,0.07,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4170,2014
-ME,4220,1,ME 4220: 001,0.34,0.31,0.24,0.07,0.03,0.0,0.0,0.0,abhijit som,ME-4220,2014
-ME,4230,1,ME 4230: 001,0.2,0.34,0.37,0.06,0.0,0.0,0.0,0.03,richard figliola,ME-4230,2014
-ME,4260,1,ME 4260: 001,0.22,0.53,0.25,0.0,0.0,0.0,0.0,0.0,david zumbrunnen,ME-4260,2014
-ME,4320,1,ME 4320: 001,0.32,0.58,0.03,0.0,0.0,0.0,0.0,0.06,gang li,ME-4320,2014
-ME,4440,1,ME 4440: 001,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2014
-ME,4440,3,ME 4440: 003,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2014
-ME,4710,1,ME 4710: 001,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4710,2014
-ME,4930,1,Selected Topics ME (HVAC),0.27,0.43,0.27,0.0,0.0,0.0,0.0,0.03,donald willoughby,ME-4930,2014
-ME,6220,1,ME 6220: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,ME-6220,2014
-ME,6710,1,ME 6710: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-6710,2014
-ME,8120,1,ME 8120: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,ME-8120,2014
-ME,8190,1,ME 8190: 001,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,ME-8190,2014
-ME,8200,1,ME 8200: 001,0.52,0.41,0.04,0.0,0.0,0.0,0.0,0.04,yue wang,ME-8200,2014
-ME,8310,1,ME 8310: 001,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rui qiao,ME-8310,2014
-ME,8520,1,ME 8520: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gang li,ME-8520,2014
-ME,8520,2,ME 8520: 002,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,gang li,ME-8520,2014
-ME,8610,1,ME 8610: 001,0.66,0.29,0.04,0.0,0.0,0.0,0.0,0.02,mica grujicic,ME-8610,2014
-ME,8730,1,ME 8730: 001,0.27,0.2,0.47,0.0,0.0,0.0,0.0,0.07,joshua summers,ME-8730,2014
-ME,8930,1,ME 8930: 001,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,nicole gise coutris,ME-8930,2014
-MGT,2010,1,Principles of Mgt,0.26,0.35,0.25,0.09,0.02,0.0,0.0,0.03,katherine clark,MGT-2010,2014
-MGT,2010,2,Principles of Mgt,0.26,0.32,0.24,0.12,0.04,0.0,0.0,0.02,katherine clark,MGT-2010,2014
-MGT,2010,3,Principles of Mgt,0.15,0.43,0.26,0.05,0.01,0.0,0.0,0.1,katherine clark,MGT-2010,2014
-MGT,2010,4,Principles of Mgt,0.23,0.32,0.28,0.08,0.03,0.0,0.0,0.06,katherine clark,MGT-2010,2014
-MGT,2010,5,Principles of Mgt,0.28,0.39,0.2,0.08,0.02,0.0,0.0,0.02,tina robbins,MGT-2010,2014
-MGT,2010,6,Principles of Mgt,0.14,0.46,0.25,0.12,0.01,0.0,0.0,0.03,tina robbins,MGT-2010,2014
-MGT,2010,7,Principles of Mgt,0.23,0.4,0.24,0.09,0.01,0.0,0.0,0.04,tina robbins,MGT-2010,2014
-MGT,2010,8,Principles of Mgt,0.14,0.44,0.25,0.1,0.02,0.0,0.0,0.05,tina robbins,MGT-2010,2014
-MGT,2010,9,Principles of Mgt(HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,MGT-2010,2014
-MGT,2180,125,MGT 2180: 125,0.31,0.44,0.15,0.04,0.01,0.01,0.0,0.04, sridharan,MGT-2180,2014
-MGT,2180,230,MGT 2180: 230,0.28,0.43,0.2,0.03,0.03,0.0,0.0,0.03, sridharan,MGT-2180,2014
-MGT,2180,335,MGT 2180: 335,0.22,0.43,0.23,0.06,0.01,0.0,0.0,0.05, sridharan,MGT-2180,2014
-MGT,2180,905,MGT 2180: 905,0.32,0.49,0.12,0.01,0.02,0.01,0.0,0.03, sridharan,MGT-2180,2014
-MGT,3070,1,Human Resource Management,0.13,0.41,0.38,0.08,0.0,0.0,0.0,0.0,marvin monroe ward,MGT-3070,2014
-MGT,3070,2,Human Resource Management,0.13,0.5,0.33,0.05,0.0,0.0,0.0,0.0,marvin monroe ward,MGT-3070,2014
-MGT,3070,3,Human Resource Management,0.21,0.32,0.39,0.03,0.05,0.0,0.0,0.0,marvin monroe ward,MGT-3070,2014
-MGT,3070,4,Human Resource Management,0.31,0.6,0.06,0.0,0.03,0.0,0.0,0.0,kristin dam scott,MGT-3070,2014
-MGT,3070,5,Human Resource Management,0.24,0.71,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2014
-MGT,3070,6,Human Resource Management,0.28,0.58,0.13,0.03,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2014
-MGT,3100,1,Intermed Business Statistics,0.07,0.28,0.26,0.16,0.12,0.0,0.0,0.12,zachary mo leffakis,MGT-3100,2014
-MGT,3100,2,Intermed Business Statistics,0.3,0.3,0.19,0.12,0.05,0.0,0.0,0.05,zachary mo leffakis,MGT-3100,2014
-MGT,3100,3,Intermed Business Statistics,0.19,0.33,0.21,0.05,0.02,0.0,0.0,0.19,niratc tungtisanont,MGT-3100,2014
-MGT,3100,4,Intermed Business Statistics,0.23,0.43,0.23,0.03,0.0,0.0,0.0,0.1,james walsh,MGT-3100,2014
-MGT,3100,5,Intermed Business Statistics,0.35,0.43,0.1,0.0,0.08,0.0,0.0,0.05,jerry kermi bilbrey,MGT-3100,2014
-MGT,3100,6,Intermed Business Statistics,0.3,0.48,0.2,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3100,2014
-MGT,3100,7,Intermed Business Statistics,0.14,0.26,0.07,0.11,0.11,0.0,0.0,0.3,sara elizabet yoder,MGT-3100,2014
-MGT,3100,8,Intermed Business Statistics,0.11,0.26,0.22,0.18,0.03,0.0,0.0,0.2,sara elizabet yoder,MGT-3100,2014
-MGT,3100,10,Intermed Business Statistics,0.21,0.31,0.28,0.14,0.03,0.0,0.0,0.03,lianlian jiang,MGT-3100,2014
-MGT,3100,11,Intermed Business Statistics,0.33,0.38,0.1,0.08,0.05,0.0,0.0,0.05,kevin mckenzie,MGT-3100,2014
-MGT,3120,1,Decision Models for Mgt,0.27,0.3,0.24,0.08,0.08,0.0,0.0,0.03,mark mcknew,MGT-3120,2014
-MGT,3120,2,Decision Models for Mgt,0.48,0.29,0.12,0.02,0.1,0.0,0.0,0.0,mark mcknew,MGT-3120,2014
-MGT,3120,3,Decision Models for Mgt,0.29,0.24,0.34,0.02,0.1,0.0,0.0,0.0,mark mcknew,MGT-3120,2014
-MGT,3150,1,New Venture Creation,0.21,0.33,0.42,0.0,0.03,0.0,0.0,0.0,peter gianiodis,MGT-3150,2014
-MGT,3170,1,Logistics Mgmt,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,shouqiang wang,MGT-3170,2014
-MGT,3180,1,Mgt of Info Systems,0.35,0.38,0.25,0.0,0.0,0.0,0.0,0.03,heshan sun,MGT-3180,2014
-MGT,3180,2,Mgt of Info Systems,0.43,0.5,0.05,0.0,0.0,0.0,0.0,0.03,dan jiang,MGT-3180,2014
-MGT,3180,3,Mgt of Info Systems,0.22,0.39,0.37,0.02,0.0,0.0,0.0,0.0,roopa raman,MGT-3180,2014
-MGT,3180,4,Mgt of Info Systems,0.43,0.48,0.08,0.0,0.03,0.0,0.0,0.0,tina marie esposito,MGT-3180,2014
-MGT,3900,1,Ops Mgt,0.08,0.33,0.28,0.22,0.06,0.0,0.0,0.03,yunsik choi,MGT-3900,2014
-MGT,3900,2,Ops Mgt,0.13,0.43,0.38,0.08,0.0,0.0,0.0,0.0,jerry kermi bilbrey,MGT-3900,2014
-MGT,3900,3,Ops Mgt,0.35,0.35,0.25,0.03,0.03,0.0,0.0,0.0,jerry kermi bilbrey,MGT-3900,2014
-MGT,3900,4,Ops Mgt,0.2,0.39,0.33,0.06,0.02,0.0,0.0,0.0,lawrence fredendall,MGT-3900,2014
-MGT,3900,5,Ops Mgt,0.24,0.49,0.17,0.05,0.05,0.0,0.0,0.0,yann ferrand,MGT-3900,2014
-MGT,4000,1,Mgt of Org Beh,0.25,0.35,0.38,0.03,0.0,0.0,0.0,0.0,philip roth,MGT-4000,2014
-MGT,4000,2,Mgt of Org Beh,0.16,0.62,0.22,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2014
-MGT,4000,3,Mgt of Org Beh,0.26,0.59,0.13,0.0,0.0,0.03,0.0,0.0,michael cole,MGT-4000,2014
-MGT,4000,4,Mgt of Org Beh,0.35,0.58,0.08,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MGT-4000,2014
-MGT,4020,1,Ops Pln and Ctl,0.1,0.48,0.14,0.14,0.14,0.0,0.0,0.0,zachary mo leffakis,MGT-4020,2014
-MGT,4030,1,Bus Intelligence & Analytics,0.26,0.35,0.19,0.03,0.16,0.0,0.0,0.0,siyuan li,MGT-4030,2014
-MGT,4110,1,Project Management,0.32,0.35,0.27,0.0,0.03,0.0,0.0,0.03,russell purvis,MGT-4110,2014
-MGT,4120,1,Supplier Management,0.26,0.54,0.17,0.03,0.0,0.0,0.0,0.0,shouqiang wang,MGT-4120,2014
-MGT,4150,1,Business Strategy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2014
-MGT,4150,2,Business Strategy,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2014
-MGT,4150,3,Business Strategy,0.78,0.2,0.0,0.0,0.02,0.0,0.0,0.0,john edward hopkins,MGT-4150,2014
-MGT,4150,4,Business Strategy,0.17,0.51,0.32,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,MGT-4150,2014
-MGT,4150,5,Business Strategy,0.09,0.5,0.35,0.04,0.0,0.0,0.0,0.02,jason wayne ridge,MGT-4150,2014
-MGT,4150,6,Business Strategy,0.32,0.49,0.14,0.0,0.05,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2014
-MGT,4150,7,Business Strategy,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2014
-MGT,4150,8,Business Strategy,0.32,0.48,0.16,0.03,0.0,0.0,0.0,0.0,peter gianiodis,MGT-4150,2014
-MGT,4160,1,Special Topics Hr,0.32,0.61,0.05,0.0,0.03,0.0,0.0,0.0,kristin dam scott,MGT-4160,2014
-MGT,4230,1,Intern Bus Mgt,0.1,0.54,0.28,0.08,0.0,0.0,0.0,0.0,janis miller,MGT-4230,2014
-MGT,4230,2,Intern Bus Mgt,0.08,0.58,0.25,0.03,0.05,0.0,0.0,0.03,janis miller,MGT-4230,2014
-MGT,4230,3,Intern Bus Mgt,0.13,0.26,0.51,0.05,0.05,0.0,0.0,0.0,wayne stewart,MGT-4230,2014
-MGT,4230,4,Intern Bus Mgt,0.1,0.25,0.6,0.05,0.0,0.0,0.0,0.0,wayne stewart,MGT-4230,2014
-MGT,4240,1,Global Supply Chain,0.17,0.6,0.23,0.0,0.0,0.0,0.0,0.0,yann ferrand,MGT-4240,2014
-MGT,4270,1,Managing Improvement,0.11,0.59,0.22,0.07,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4270,2014
-MGT,4310,1,Emp Rights & Resp,0.16,0.42,0.32,0.05,0.03,0.0,0.0,0.03,marvin monroe ward,MGT-4310,2014
-MGT,4350,1,Pers Interviewing,0.3,0.5,0.18,0.03,0.0,0.0,0.0,0.0,philip roth,MGT-4350,2014
-MGT,4520,1,Business Analysis,0.21,0.43,0.21,0.0,0.07,0.0,0.0,0.07,roopa raman,MGT-4520,2014
-MGT,4550,1,Emerging I T Trends,0.28,0.61,0.06,0.03,0.03,0.0,0.0,0.0,jason thatcher,MGT-4550,2014
-MGT,4560,1,Business Info Mgt,0.21,0.36,0.24,0.06,0.06,0.0,0.0,0.06,siyuan li,MGT-4560,2014
-MGT,8120,1,Supply Chain Mgt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,gulru fatma ozkan,MGT-8120,2014
-MGT,9040,1,MGT 9040: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,heshan sun,MGT-9040,2014
-MHA,7320,400,MHA 7320: 400,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,MHA-7320,2014
-MICR,3050,1,MICR 3050: 001,0.38,0.4,0.15,0.06,0.01,0.0,0.0,0.0,kristi ja whitehead,MICR-3050,2014
-MICR,3050,2,MICR 3050: 002,0.38,0.4,0.17,0.03,0.0,0.0,0.0,0.03,krista barr rudolph,MICR-3050,2014
-MICR,3050,3,MICR 3050: 003,0.62,0.24,0.09,0.03,0.0,0.0,0.0,0.03,krista barr rudolph,MICR-3050,2014
-MICR,4000,1,Public Health Micro,0.52,0.18,0.25,0.05,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4000,2014
-MICR,4070,1,Food and Dairy Micro,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,xiuping jiang,MICR-4070,2014
-MICR,4110,1,Pathogenic Bact,0.36,0.44,0.16,0.04,0.0,0.0,0.0,0.0,tamara lyn mcnealy,MICR-4110,2014
-MICR,4120,1,Bacterial Physiology,0.11,0.32,0.23,0.17,0.15,0.0,0.0,0.02,thomas hughes,MICR-4120,2014
-MICR,4130,1,Industrial Micro,0.41,0.5,0.05,0.03,0.0,0.0,0.0,0.02,tzuen-rong je tzeng,MICR-4130,2014
-MICR,4140,1,Basic Immunology,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,charles rice,MICR-4140,2014
-MICR,4170,1,Cancer and Aging,0.57,0.2,0.11,0.06,0.0,0.0,0.0,0.06,yuqing dong,MICR-4170,2014
-MICR,4210,2,MICR 4210: 002,0.57,0.21,0.07,0.14,0.0,0.0,0.0,0.0,tamara lyn mcnealy,MICR-4210,2014
-MICR,4220,1,MICR 4220: 001,0.75,0.15,0.05,0.05,0.0,0.0,0.0,0.0,thomas hughes,MICR-4220,2014
-MICR,4220,2,MICR 4220: 002,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,MICR-4220,2014
-MICR,4220,3,MICR 4220: 003,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,MICR-4220,2014
-MKT,3010,1,Prin of Marketing,0.27,0.55,0.14,0.04,0.0,0.0,0.0,0.0,carter wil mcelveen,MKT-3010,2014
-MKT,3010,2,Prin of Marketing,0.36,0.41,0.18,0.03,0.01,0.0,0.0,0.01,james gaubert,MKT-3010,2014
-MKT,3010,3,Prin of Marketing,0.29,0.4,0.2,0.07,0.03,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2014
-MKT,3010,4,Prin of Marketing,0.26,0.5,0.15,0.07,0.01,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2014
-MKT,3010,5,Prin of Marketing,0.24,0.41,0.23,0.07,0.02,0.0,0.0,0.03,patricia knowles,MKT-3010,2014
-MKT,3020,1,Consumer Behavior,0.65,0.28,0.04,0.02,0.02,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2014
-MKT,3020,2,Consumer Behavior,0.66,0.32,0.02,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2014
-MKT,3020,3,Consumer Behavior,0.36,0.44,0.12,0.02,0.04,0.0,0.0,0.02, thyroff fitzwater,MKT-3020,2014
-MKT,3020,4,Consumer Behavior,0.26,0.3,0.24,0.09,0.09,0.0,0.0,0.02, thyroff fitzwater,MKT-3020,2014
-MKT,3210,1,Sports Marketing,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2014
-MKT,3980,1,Creative Inquiry in Marketing,0.96,0.0,0.02,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,MKT-3980,2014
-MKT,4200,1,Professional Selling,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2014
-MKT,4200,2,Professional Selling,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jesse moore,MKT-4200,2014
-MKT,4200,3,Professional Selling,0.5,0.35,0.08,0.0,0.08,0.0,0.0,0.0,carter wil mcelveen,MKT-4200,2014
-MKT,4200,4,Professional Selling,0.75,0.21,0.0,0.04,0.0,0.0,0.0,0.0,carter wil mcelveen,MKT-4200,2014
-MKT,4230,1,Promotional Strategy,0.32,0.38,0.22,0.04,0.0,0.0,0.0,0.04,patricia knowles,MKT-4230,2014
-MKT,4240,1,Sales Management,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4240,2014
-MKT,4270,1,International Mktg,0.28,0.14,0.38,0.14,0.0,0.0,0.0,0.07,charles duke,MKT-4270,2014
-MKT,4270,2,International Mktg,0.2,0.27,0.5,0.0,0.0,0.0,0.0,0.03,charles duke,MKT-4270,2014
-MKT,4270,3,International Mktg,0.42,0.36,0.15,0.03,0.03,0.0,0.0,0.0,roger gomes,MKT-4270,2014
-MKT,4270,4,International Mktg,0.29,0.47,0.21,0.0,0.0,0.0,0.0,0.03,roger gomes,MKT-4270,2014
-MKT,4270,5,International Mktg,0.21,0.58,0.12,0.09,0.0,0.0,0.0,0.0,roger gomes,MKT-4270,2014
-MKT,4280,1,Services Marketing,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,james gaubert,MKT-4280,2014
-MKT,4310,1,Marketing Research,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2014
-MKT,4310,2,Marketing Research,0.35,0.57,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2014
-MKT,4310,3,Marketing Research,0.18,0.61,0.18,0.03,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4310,2014
-MKT,4330,1,Sport Mkt Strategy,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,MKT-4330,2014
-MKT,4430,1,Advertising Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,albert neil cameron,MKT-4430,2014
-MKT,4450,1,Macromarketing,0.56,0.34,0.03,0.0,0.0,0.06,0.0,0.0,william kilbourne,MKT-4450,2014
-MKT,4500,1,Strategic Mktg Mgt,0.19,0.63,0.19,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2014
-MKT,4500,2,Strategic Mktg Mgt,0.18,0.76,0.06,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4500,2014
-MKT,4500,3,Strategic Mktg Mgt,0.43,0.5,0.03,0.03,0.0,0.0,0.0,0.0,delancy bennett,MKT-4500,2014
-MKT,4500,4,Strategic Mktg Mgt,0.08,0.4,0.44,0.08,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2014
-MKT,4950,1,Selected Topics,0.28,0.39,0.17,0.06,0.0,0.0,0.0,0.11,peter weathers,MKT-4950,2014
-MKT,8620,1,MKT 8620: 001,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,MKT-8620,2014
-MKT,8650,1,MKT 8650: 001,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,MKT-8650,2014
-MKT,8660,1,Professional Selling,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,ryan mullins,MKT-8660,2014
-ML,1020,1,Leadership Fund II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,garry michae hansel,ML-1020,2014
-ML,1020,2,Leadership Fund II,0.57,0.24,0.1,0.0,0.05,0.0,0.0,0.05,garry michae hansel,ML-1020,2014
-ML,2020,1,ML 2020: 001,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thierry andre bras,ML-2020,2014
-ML,2020,2,ML 2020: 002,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,thierry andre bras,ML-2020,2014
-ML,3020,2,Adv Leadership II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,ML-3020,2014
-MSE,2100,1,MSE 2100: 001,0.3,0.38,0.24,0.04,0.02,0.0,0.0,0.01,marian kennedy,MSE-2100,2014
-MSE,2100,2,MSE 2100: 002,0.27,0.3,0.27,0.08,0.03,0.0,0.0,0.05,eric skaar,MSE-2100,2014
-MSE,2100,3,MSE 2100: 003,0.42,0.19,0.3,0.03,0.04,0.0,0.0,0.02,julie patric martin,MSE-2100,2014
-MSE,2500,1,MSE 2500: 001,0.68,0.25,0.04,0.0,0.04,0.0,0.0,0.0,deborah lickfield,MSE-2500,2014
-MSE,3260,1,MSE 3260: 001,0.24,0.26,0.36,0.09,0.04,0.0,0.0,0.01,gary lickfield,MSE-3260,2014
-MSE,3280,1,MSE 3280: 001,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,eric skaar,MSE-3280,2014
-MSE,3420,2,MSE 3420: 002,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,rajendra kum bordia,MSE-3420,2014
-MSE,3610,1,MSE 3610: 001,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,marian kennedy,MSE-3610,2014
-MSE,4160,1,MSE 4160: 001,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,eric skaar,MSE-4160,2014
-MSE,4220,1,MSE 4220: 001,0.26,0.52,0.19,0.0,0.0,0.0,0.0,0.04,vincent yves blouin,MSE-4220,2014
-MSE,4330,1,MSE 4330: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,MSE-4330,2014
-MSE,4560,1,MSE 4560: 001,0.25,0.5,0.19,0.0,0.06,0.0,0.0,0.0,gary lickfield,MSE-4560,2014
-MUSC,1120,2,Beg Class Guitar II,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,david stevenson,MUSC-1120,2014
-MUSC,1420,2,MUSC 1420: 002,0.6,0.1,0.0,0.0,0.1,0.0,0.0,0.2,dan rash,MUSC-1420,2014
-MUSC,1430,2,MUSC 1430: 002,0.7,0.0,0.0,0.0,0.1,0.0,0.0,0.2,dan rash,MUSC-1430,2014
-MUSC,1800,1,MUSC 1800: 001,0.25,0.67,0.0,0.0,0.08,0.0,0.0,0.0,hamilton altstatt,MUSC-1800,2014
-MUSC,2100,1,Music in West World,0.68,0.13,0.16,0.0,0.0,0.0,0.0,0.03,eric lapin,MUSC-2100,2014
-MUSC,2100,2,Music in West World,0.45,0.25,0.25,0.03,0.0,0.0,0.0,0.03,lisa sain odom,MUSC-2100,2014
-MUSC,2100,3,Music in West World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,eric lapin,MUSC-2100,2014
-MUSC,2100,4,Music in West World,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2014
-MUSC,2100,5,Music in West World,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2014
-MUSC,2100,6,Music in West World,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2014
-MUSC,2100,9,Music in West World,0.55,0.39,0.03,0.0,0.0,0.0,0.0,0.03,lea kibler,MUSC-2100,2014
-MUSC,3110,1,MUSC 3110: 001,0.57,0.33,0.07,0.03,0.0,0.0,0.0,0.0,ned hosler,MUSC-3110,2014
-MUSC,3120,1,History of Jazz,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,eric lapin,MUSC-3120,2014
-MUSC,3170,1,Hist of Country Mus,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3170,2014
-MUSC,3310,1,MUSC 3310: 001,0.86,0.06,0.04,0.0,0.0,0.0,0.0,0.04,timothy ra hurlburt,MUSC-3310,2014
-MUSC,3310,2,MUSC 3310: 002,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,MUSC-3310,2014
-MUSC,3620,1,Symphonic Band,0.91,0.02,0.04,0.0,0.0,0.0,0.0,0.02,mark spede,MUSC-3620,2014
-MUSC,3690,1,Symphony Orchestra,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,MUSC-3690,2014
-MUSC,3700,1,Clemson University Singers,0.91,0.04,0.02,0.0,0.02,0.0,0.0,0.02,justin durham,MUSC-3700,2014
-MUSC,3710,1,Women's Glee,0.92,0.02,0.03,0.0,0.03,0.0,0.0,0.0,justin durham,MUSC-3710,2014
-MUSC,3720,1,Men's Glee,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,david conley,MUSC-3720,2014
-MUSC,4160,1,MUSC 4160: 001,0.28,0.36,0.28,0.08,0.0,0.0,0.0,0.0,linda li-bleuel,MUSC-4160,2014
-NPL,3010,1,NPL 3010: 001,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,tracy diane lamb,NPL-3010,2014
-NPL,3030,1,NPL 3030: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,wendell price,NPL-3030,2014
-NURS,3030,1,NURS 3030: 001,0.36,0.51,0.1,0.0,0.0,0.0,0.0,0.03,leslie anne  ravan,NURS-3030,2014
-NURS,3030,400,NURS 3030: 400,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,NURS-3030,2014
-NURS,3100,1,NURS 3100: 001,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3100,2014
-NURS,3110,1,NURS 3110: 001,0.95,0.03,0.0,0.0,0.03,0.0,0.0,0.0,janice garri lanham,NURS-3110,2014
-NURS,3120,1,NURS 3120: 001,0.42,0.55,0.03,0.0,0.0,0.0,0.0,0.0,angela pye,NURS-3120,2014
-NURS,3190,400,NURS 3190: 400,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,kelly jordan smith,NURS-3190,2014
-NURS,3200,1,NURS 3200: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,NURS-3200,2014
-NURS,3330,1,Health Care Genetics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,NURS-3330,2014
-NURS,3330,400,Health Care Genetics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,NURS-3330,2014
-NURS,3400,1,NURS 3400: 001,0.21,0.66,0.08,0.03,0.03,0.0,0.0,0.0,catherine si murton,NURS-3400,2014
-NURS,4010,1,NURS 4010: 001,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-4010,2014
-NURS,4030,1,NURS 4030: 001,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,NURS-4030,2014
-NURS,4100,1,NURS 4100: 001,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,NURS-4100,2014
-NURS,4110,1,NURS 4110: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-4110,2014
-NURS,4120,1,NURS 4120: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2014
-NURS,4150,1,NURS 4150: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jackie gillespie,NURS-4150,2014
-NURS,4250,400,NURS 4250: 400,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,roxanne amerson,NURS-4250,2014
-NURS,4280,1,Senior Honors II (HON),0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,nancy meehan,NURS-4280,2014
-NURS,8010,400,NURS 8010: 400,0.56,0.36,0.03,0.0,0.0,0.0,0.0,0.05,shirley mae timmons,NURS-8010,2014
-NURS,8080,400,NURS 8080: 400,0.71,0.24,0.02,0.0,0.02,0.0,0.0,0.0,veronica parker,NURS-8080,2014
-NURS,8200,400,NURS 8200: 400,0.2,0.7,0.0,0.0,0.0,0.0,0.0,0.1,heide temples,NURS-8200,2014
-NURS,8210,400,NURS 8210: 400,0.68,0.27,0.0,0.0,0.0,0.0,0.0,0.05,tracy king fasolino,NURS-8210,2014
-NURS,8480,400,NURS 8480: 400,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,bonnie holaday,NURS-8480,2014
-NURS,8850,400,NURS 8850: 400,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-8850,2014
-NUTR,2030,1,Intro Princ of Human Nutrition,0.37,0.43,0.12,0.01,0.02,0.0,0.0,0.04,rita haliena,NUTR-2030,2014
-NUTR,4250,1,Medica Nutr Thera II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4250,2014
-NUTR,4260,1,NUTR 4260: 001,0.51,0.45,0.04,0.0,0.0,0.0,0.0,0.0,rita haliena,NUTR-4260,2014
-NUTR,4550,1,NUTR 4550: 001,0.48,0.39,0.1,0.0,0.03,0.0,0.0,0.0,elliot jesch,NUTR-4550,2014
-NUTR,8030,1,NUTR 8030: 001,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,vivian haley-zitlin,NUTR-8030,2014
-PA,2010,1,PA 2010: 001,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,ned hosler,PA-2010,2014
-PA,2800,1,PA 2800: 001,0.38,0.0,0.23,0.0,0.08,0.0,0.0,0.31,kenneth moore,PA-2800,2014
-PADM,8220,400,PADM 8220: 400,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,mark daniel mellott,PADM-8220,2014
-PADM,8340,400,PADM 8340: 400,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew moorman,PADM-8340,2014
-PADM,8680,400,PADM 8680: 400,0.36,0.57,0.0,0.0,0.07,0.0,0.0,0.0,alfred bundrick,PADM-8680,2014
-PHIL,1010,1,Intro to Phil Prob,0.47,0.35,0.06,0.03,0.03,0.0,0.0,0.06,david stegall,PHIL-1010,2014
-PHIL,1010,2,Intro to Phil Prob,0.68,0.18,0.09,0.0,0.0,0.0,0.0,0.06,david stegall,PHIL-1010,2014
-PHIL,1010,3,Intro to Phil Prob,0.45,0.36,0.15,0.0,0.03,0.0,0.0,0.0,christopher grau,PHIL-1010,2014
-PHIL,1020,1,Intro to Logic,0.73,0.09,0.03,0.03,0.09,0.0,0.0,0.03,michael hal hannen,PHIL-1020,2014
-PHIL,1020,2,Intro to Logic,0.68,0.15,0.06,0.0,0.03,0.0,0.0,0.09,michael hal hannen,PHIL-1020,2014
-PHIL,1020,3,Intro to Logic,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2014
-PHIL,1020,4,Intro to Logic,0.28,0.22,0.25,0.0,0.03,0.0,0.0,0.22,cecilea mun,PHIL-1020,2014
-PHIL,1020,5,Intro to Logic,0.07,0.43,0.11,0.0,0.04,0.0,0.0,0.36,cecilea mun,PHIL-1020,2014
-PHIL,1020,6,Intro to Logic,0.19,0.08,0.0,0.0,0.04,0.0,0.0,0.69,cecilea mun,PHIL-1020,2014
-PHIL,1030,1,Intro to Ethics HON,0.63,0.26,0.0,0.05,0.0,0.0,0.0,0.05,stephen satris,PHIL-1030,2014
-PHIL,1030,2,Intro to Ethics,0.57,0.3,0.08,0.0,0.0,0.0,0.0,0.05,david stegall,PHIL-1030,2014
-PHIL,1030,3,Intro to Ethics,0.36,0.53,0.03,0.0,0.0,0.0,0.0,0.08,stephen satris,PHIL-1030,2014
-PHIL,1030,4,Intro to Ethics,0.38,0.32,0.26,0.03,0.0,0.0,0.0,0.0,jennifer ingle,PHIL-1030,2014
-PHIL,1030,5,Intro to Ethics,0.36,0.45,0.06,0.06,0.03,0.0,0.0,0.03,jennifer ingle,PHIL-1030,2014
-PHIL,1030,6,Intro to Ethics,0.17,0.53,0.23,0.0,0.0,0.0,0.0,0.07,charles starkey,PHIL-1030,2014
-PHIL,3040,1,PHIL 3040: 001,0.54,0.39,0.04,0.0,0.0,0.0,0.0,0.04,michael hal hannen,PHIL-3040,2014
-PHIL,3050,1,PHIL 3050: 001,0.29,0.5,0.18,0.0,0.04,0.0,0.0,0.0,todd may,PHIL-3050,2014
-PHIL,3150,1,PHIL 3150: 001,0.32,0.32,0.14,0.07,0.07,0.0,0.0,0.07,jennifer ingle,PHIL-3150,2014
-PHIL,3160,1,Mod Phil,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,charles starkey,PHIL-3160,2014
-PHIL,3200,1,PHIL 3200: 001,0.38,0.5,0.0,0.0,0.08,0.0,0.0,0.04,candice delmas,PHIL-3200,2014
-PHIL,3250,1,Phil of Science,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,cecilea mun,PHIL-3250,2014
-PHIL,3260,1,Science and Values,0.56,0.32,0.09,0.0,0.0,0.0,0.0,0.03,andrew garnar,PHIL-3260,2014
-PHIL,3260,2,Science and Values,0.47,0.26,0.18,0.0,0.03,0.0,0.0,0.06,andrew garnar,PHIL-3260,2014
-PHIL,3260,3,Science and Values,0.47,0.44,0.06,0.0,0.03,0.0,0.0,0.0,andrew garnar,PHIL-3260,2014
-PHIL,3300,1,PHIL 3300: 001,0.5,0.35,0.08,0.04,0.0,0.0,0.0,0.04,todd may,PHIL-3300,2014
-PHIL,3430,1,PHIL 3430: 001,0.33,0.47,0.13,0.0,0.03,0.0,0.0,0.03,candice delmas,PHIL-3430,2014
-PHIL,3440,1,Business Ethics,0.83,0.15,0.0,0.0,0.0,0.0,0.0,0.03,david stegall,PHIL-3440,2014
-PHIL,3480,1,PHIL 3480: 001,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,christopher grau,PHIL-3480,2014
-PHIL,3490,1,Gender and Sexuality,0.45,0.31,0.14,0.03,0.03,0.0,0.0,0.03,jennifer ingle,PHIL-3490,2014
-PHIL,3990,1,PHIL 3990: 001,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,kelly smith,PHIL-3990,2014
-PHSC,1170,1,Intro Chem & Earth,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1170,2014
-PHYS,1220,1,Physics With Cal I,0.12,0.39,0.32,0.08,0.05,0.0,0.0,0.05,lih-sin the,PHYS-1220,2014
-PHYS,1220,2,Physics With Cal I,0.21,0.42,0.27,0.07,0.02,0.0,0.0,0.01,lih-sin the,PHYS-1220,2014
-PHYS,1220,3,Physics With Cal I,0.3,0.44,0.19,0.02,0.03,0.0,0.0,0.02,lih-sin the,PHYS-1220,2014
-PHYS,1220,4,Physics With Cal I,0.2,0.33,0.33,0.05,0.06,0.0,0.0,0.03,jason stratfo brown,PHYS-1220,2014
-PHYS,1220,5,Physics With Cal I,0.22,0.39,0.24,0.06,0.05,0.0,0.0,0.04,mark leising,PHYS-1220,2014
-PHYS,1220,8,Physics With Cal I HON,0.36,0.31,0.24,0.05,0.02,0.0,0.0,0.02,joan marler,PHYS-1220,2014
-PHYS,1240,1,Physics Lab I,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,2,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,3,Physics Lab I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,4,Physics Lab I,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,5,Physics Lab I,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,6,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,7,Physics Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,8,PHYSICS LAB I,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,9,Physics Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,10,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,11,Physics Lab I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,12,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,13,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,14,Physics Lab I,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-1240,2014
-PHYS,1240,15,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,16,Physics Lab I,0.17,0.61,0.06,0.0,0.0,0.0,0.0,0.17,jerry hester,PHYS-1240,2014
-PHYS,1240,17,Physics Lab I,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2014
-PHYS,1240,18,Physics Lab I,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,19,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,1240,20,Physics Lab I,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,21,Physics Lab I,0.32,0.42,0.0,0.0,0.0,0.0,0.0,0.26,jerry hester,PHYS-1240,2014
-PHYS,1240,22,Physics Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,PHYS-1240,2014
-PHYS,1240,23,Physics Lab I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,jerry hester,PHYS-1240,2014
-PHYS,1240,24,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,25,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,26,Physics Lab I,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,27,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2014
-PHYS,1240,29,Physics Lab I,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2014
-PHYS,2000,1,PHYS 2000: 001,0.34,0.38,0.26,0.0,0.0,0.0,0.0,0.02,amy liann pope,PHYS-2000,2014
-PHYS,2070,1,General Physics I,0.28,0.35,0.19,0.08,0.05,0.0,0.0,0.06,amy liann pope,PHYS-2070,2014
-PHYS,2080,1,General Physics II,0.33,0.46,0.13,0.07,0.01,0.0,0.0,0.0,pooja puneet,PHYS-2080,2014
-PHYS,2080,2,General Physics II,0.44,0.38,0.13,0.03,0.01,0.0,0.0,0.01,pooja puneet,PHYS-2080,2014
-PHYS,2090,1,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,2,Gen Phys Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,3,Gen Phys Lab I,0.33,0.54,0.04,0.08,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,4,Gen Phys Lab I,0.53,0.16,0.21,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-2090,2014
-PHYS,2090,5,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2014
-PHYS,2090,6,Gen Phys Lab I,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2014
-PHYS,2090,7,Gen Phys Lab I,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2014
-PHYS,2090,8,Gen Phys Lab I,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2014
-PHYS,2090,9,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2090,10,Gen Phys Lab I,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2014
-PHYS,2100,1,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,2,Gen Phys Lab II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,3,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,4,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,6,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,7,Gen Phys Lab II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,8,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,9,Gen Phys Lab II,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2014
-PHYS,2100,10,Gen Phys Lab II,0.54,0.29,0.08,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2100,2014
-PHYS,2100,11,Gen Phys Lab II,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,12,Gen Phys Lab II,0.63,0.21,0.04,0.0,0.04,0.0,0.0,0.08,jerry hester,PHYS-2100,2014
-PHYS,2100,13,Gen Phys Lab II,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,14,Gen Phys Lab II,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2100,2014
-PHYS,2100,15,Gen Phys Lab II,0.21,0.67,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2100,16,Gen Phys Lab II,0.23,0.5,0.18,0.05,0.05,0.0,0.0,0.0,jerry hester,PHYS-2100,2014
-PHYS,2210,1,Physics With Cal II,0.3,0.29,0.26,0.09,0.03,0.0,0.0,0.02,jason stratfo brown,PHYS-2210,2014
-PHYS,2210,2,Physics With Cal II,0.28,0.39,0.22,0.07,0.03,0.0,0.0,0.03,jason stratfo brown,PHYS-2210,2014
-PHYS,2210,3,Physics With Cal II,0.46,0.23,0.08,0.23,0.0,0.0,0.0,0.0,murray daw,PHYS-2210,2014
-PHYS,2220,1,Phys With Cal III,0.57,0.3,0.11,0.0,0.03,0.0,0.0,0.0,hye jung kang,PHYS-2220,2014
-PHYS,2230,2,Physics Lab II,0.35,0.29,0.29,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2014
-PHYS,2230,3,Physics Lab II,0.71,0.18,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,PHYS-2230,2014
-PHYS,2230,4,Physics Lab II,0.13,0.63,0.13,0.13,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,5,Physics Lab II,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,6,Physics Lab II,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2230,8,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2014
-PHYS,2240,1,Physics Lab III,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-2240,2014
-PHYS,2240,2,Physics Lab III,0.41,0.53,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2240,2014
-PHYS,2400,1,Phys of Weather ONLINE,0.31,0.29,0.18,0.1,0.04,0.0,0.0,0.08,miguel larsen,PHYS-2400,2014
-PHYS,3120,1,PHYS 3120: 001,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,feng ding,PHYS-3120,2014
-PHYS,3220,1,Mechanics II,0.27,0.33,0.2,0.13,0.0,0.0,0.0,0.07,john meriwether,PHYS-3220,2014
-PHYS,3260,1,Exper Physics II,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,chad sosolik,PHYS-3260,2014
-PHYS,3560,1,PHYS 3560: 001,0.58,0.25,0.0,0.08,0.0,0.0,0.0,0.08,chad sosolik,PHYS-3560,2014
-PHYS,4410,1,Electromagnetics I,0.27,0.45,0.18,0.0,0.0,0.0,0.0,0.09,endre andras takacs,PHYS-4410,2014
-PHYS,4560,1,Quantum Physics II,0.08,0.77,0.15,0.0,0.0,0.0,0.0,0.0,jian he,PHYS-4560,2014
-PHYS,4650,1,Thermo and Stat Mech,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,jeremy king,PHYS-4650,2014
-PHYS,8150,1,Statistical Therm I,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,jens oberheide,PHYS-8150,2014
-PHYS,8410,1,PHYS 8410: 001,0.11,0.72,0.11,0.0,0.0,0.0,0.0,0.06,gerald lehmacher,PHYS-8410,2014
-PHYS,9520,1,PHYS 9520: 001,0.06,0.33,0.61,0.0,0.0,0.0,0.0,0.0,domnita marinescu,PHYS-9520,2014
-PKSC,1020,1,PKSC 1020: 001,0.19,0.51,0.15,0.13,0.03,0.0,0.0,0.0,heather batt,PKSC-1020,2014
-PKSC,2010,1,PKSC 2010: 001,0.19,0.33,0.3,0.12,0.06,0.0,0.0,0.0,heather batt,PKSC-2010,2014
-PKSC,2020,1,PKSC 2020: 001,0.53,0.24,0.24,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2020,2014
-PKSC,2040,1,PKSC 2040: 001,0.66,0.16,0.13,0.02,0.02,0.0,0.0,0.02,robert truett moore,PKSC-2040,2014
-PKSC,2060,1,PKSC 2060: 001,0.93,0.04,0.0,0.04,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2060,2014
-PKSC,2200,1,PKSC 2200: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,william aaro snyder,PKSC-2200,2014
-PKSC,3200,1,PKSC 3200: 001,0.31,0.46,0.1,0.05,0.05,0.0,0.0,0.03,rupert hurley,PKSC-3200,2014
-PKSC,3680,1,Pkg and Society,0.13,0.41,0.18,0.1,0.15,0.0,0.0,0.03,heather batt,PKSC-3680,2014
-PKSC,4010,1,PKSC 4010: 001,0.45,0.49,0.02,0.0,0.04,0.0,0.0,0.0,anthony lou pometto,PKSC-4010,2014
-PKSC,4030,1,PKSC 4030: 001,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2014
-PKSC,4200,1,PKSC 4200: 001,0.7,0.17,0.13,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2014
-PKSC,4300,1,PKSC 4300: 001,0.16,0.67,0.14,0.0,0.02,0.0,0.0,0.02,duncan darby,PKSC-4300,2014
-PKSC,4400,1,PKSC 4400: 001,0.29,0.38,0.21,0.03,0.09,0.0,0.0,0.0,gregory batt,PKSC-4400,2014
-PKSC,4640,1,Fd & Hc Pkg Systems,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2014
-PKSC,8510,1,Pkg Sci Seminar,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,ronnie thomas,PKSC-8510,2014
-PLPA,2130,1,Fungi & Civilization,0.48,0.28,0.11,0.07,0.04,0.0,0.0,0.02,julia loui kerrigan,PLPA-2130,2014
-PLPA,6590,1,PLPA 6590: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,PLPA-6590,2014
-POSC,1010,1,Amer National Govt,0.13,0.63,0.23,0.0,0.0,0.0,0.0,0.01,joseph earl stewart,POSC-1010,2014
-POSC,1010,2,Amer National Govt,0.07,0.4,0.33,0.13,0.07,0.0,0.0,0.0,adam warber,POSC-1010,2014
-POSC,1020,1,Intro Intl Relations,0.13,0.44,0.28,0.08,0.04,0.0,0.0,0.04,aron geo tannenbaum,POSC-1020,2014
-POSC,1020,2,Intro Intl Relations,0.21,0.26,0.26,0.12,0.07,0.0,0.0,0.08,zeynep taydas,POSC-1020,2014
-POSC,1030,1,Intro to Political Theory,0.38,0.24,0.16,0.11,0.11,0.0,0.0,0.0,brandon turner,POSC-1030,2014
-POSC,1040,1,Intro Compar Pol,0.03,0.39,0.5,0.03,0.0,0.0,0.0,0.06,colin pearce,POSC-1040,2014
-POSC,1040,2,Intro Compar Pol,0.41,0.39,0.11,0.04,0.02,0.0,0.0,0.02,katherine am curtis,POSC-1040,2014
-POSC,1990,1,POSC 1990: 001,0.3,0.1,0.27,0.2,0.13,0.0,0.0,0.0,meredith petersheim,POSC-1990,2014
-POSC,3020,1,State and Loc Gov,0.17,0.63,0.1,0.0,0.07,0.0,0.0,0.03,bruce ransom,POSC-3020,2014
-POSC,3110,1,Model United Nations,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,xiaobo hu,POSC-3110,2014
-POSC,3210,1,Public Admin,0.05,0.38,0.31,0.15,0.1,0.0,0.0,0.0,james woodard,POSC-3210,2014
-POSC,3410,1,Quant Meth in Pol Sc,0.56,0.25,0.13,0.06,0.0,0.0,0.0,0.0,steven vince miller,POSC-3410,2014
-POSC,3610,1,Intl Pol in Crisis,0.21,0.39,0.26,0.05,0.05,0.0,0.0,0.03,vladimir matic,POSC-3610,2014
-POSC,3610,2,Intl Pol in Crisis,0.43,0.23,0.27,0.03,0.0,0.0,0.0,0.03,steven vince miller,POSC-3610,2014
-POSC,3630,1,Us Foreign Policy,0.17,0.45,0.28,0.03,0.03,0.0,0.0,0.03,jeffrey scott peake,POSC-3630,2014
-POSC,3710,1,European Politics,0.43,0.31,0.19,0.05,0.02,0.0,0.0,0.0,katherine am curtis,POSC-3710,2014
-POSC,3750,1,European Integration,0.15,0.54,0.08,0.23,0.0,0.0,0.0,0.0,zeynep taydas,POSC-3750,2014
-POSC,4050,1,American Presidency,0.15,0.46,0.23,0.0,0.08,0.0,0.0,0.08,adam warber,POSC-4050,2014
-POSC,4070,1,Religion and Politic,0.2,0.41,0.28,0.11,0.0,0.0,0.0,0.0,laura olson,POSC-4070,2014
-POSC,4240,1,Federalism and Igr,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,POSC-4240,2014
-POSC,4360,1,Law Courts Politics,0.52,0.31,0.1,0.0,0.02,0.0,0.0,0.05,joseph earl stewart,POSC-4360,2014
-POSC,4370,1,Constitut Law: Rights & Libert,0.34,0.54,0.09,0.03,0.0,0.0,0.0,0.0,daniel frost,POSC-4370,2014
-POSC,4380,1,Constitut Law: Struc of Gov,0.48,0.39,0.09,0.04,0.0,0.0,0.0,0.0,daniel frost,POSC-4380,2014
-POSC,4500,1,Plato to Postmodernism,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,andrew sc bernstein,POSC-4500,2014
-POSC,4530,1,American Political Thought,0.35,0.23,0.15,0.08,0.15,0.0,0.0,0.04,brandon turner,POSC-4530,2014
-POSC,4540,1,Southern Politics,0.04,0.48,0.33,0.07,0.04,0.0,0.0,0.04,james woodard,POSC-4540,2014
-POSC,4570,1,Political Terrorism,0.42,0.29,0.23,0.03,0.0,0.0,0.0,0.03,aron geo tannenbaum,POSC-4570,2014
-POSC,4610,1,Am Diplomacy & Pol,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,vladimir matic,POSC-4610,2014
-POSC,4760,1,Middle East Politics,0.48,0.33,0.05,0.0,0.0,0.0,0.0,0.14,vladimir matic,POSC-4760,2014
-POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.96,0.02,0.02,meredith petersheim,POSC-4990,2014
-POST,8430,1,POST 8430: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,POST-8430,2014
-PRTM,2000,1,PRTM 2000: 001,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.01,cindy hartman,PRTM-2000,2014
-PRTM,2200,1,PRTM 2200: 001,0.19,0.63,0.11,0.04,0.04,0.0,0.0,0.0,teresa walto tucker,PRTM-2200,2014
-PRTM,2200,2,PRTM 2200: 002,0.19,0.78,0.04,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2200,2014
-PRTM,2200,3,PRTM 2200: 003,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bernard mwe kitheka,PRTM-2200,2014
-PRTM,2200,4,PRTM 2200: 004,0.41,0.48,0.04,0.0,0.0,0.0,0.0,0.07,katherine eli evans,PRTM-2200,2014
-PRTM,2200,5,PRTM 2200: 005,0.65,0.23,0.08,0.04,0.0,0.0,0.0,0.0,kellie aman walters,PRTM-2200,2014
-PRTM,2200,6,PRTM 2200: 006,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,samuel ogletree,PRTM-2200,2014
-PRTM,2200,7,PRTM 2200: 007,0.22,0.48,0.26,0.04,0.0,0.0,0.0,0.0,denise mar anderson,PRTM-2200,2014
-PRTM,2410,1,PRTM 2410: 001,0.24,0.47,0.29,0.0,0.0,0.0,0.0,0.0,craig colistra,PRTM-2410,2014
-PRTM,2410,2,PRTM 2410: 002,0.42,0.35,0.23,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2410,2014
-PRTM,2600,1,PRTM 2600: 001,0.88,0.09,0.0,0.0,0.03,0.0,0.0,0.0,alison lynne cory,PRTM-2600,2014
-PRTM,2650,1,PRTM 2650: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,alison lynne cory,PRTM-2650,2014
-PRTM,2700,1,Intro Rec Res Mgt,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,stephen springs,PRTM-2700,2014
-PRTM,2810,1,Intro to Golf Mgt,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-2810,2014
-PRTM,2820,1,PRTM 2820: 001,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-2820,2014
-PRTM,2830,1,PRTM 2830: 001,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-2830,2014
-PRTM,2980,3,Creative Inquiry in PRTM II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,toni liechty,PRTM-2980,2014
-PRTM,2980,6,Creative Inquiry in PRTM II,0.73,0.07,0.2,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-2980,2014
-PRTM,3070,1,PRTM 3070: 001,0.85,0.13,0.03,0.0,0.0,0.0,0.0,0.0,craig goodman,PRTM-3070,2014
-PRTM,3260,1,PRTM 3260: 001,0.31,0.44,0.23,0.03,0.0,0.0,0.0,0.0,brandi crowe,PRTM-3260,2014
-PRTM,3270,1,PRTM 3270: 001,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3270,2014
-PRTM,3280,1,PRTM 3280: 001,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,alison lynne cory,PRTM-3280,2014
-PRTM,3420,1,Intro to Tourism,0.73,0.19,0.0,0.03,0.0,0.0,0.0,0.05,maloud shakona,PRTM-3420,2014
-PRTM,3420,2,Intro to Tourism,0.53,0.25,0.19,0.0,0.03,0.0,0.0,0.0,jarrett bachman,PRTM-3420,2014
-PRTM,3440,1,PRTM 3440: 001,0.39,0.36,0.21,0.0,0.04,0.0,0.0,0.0,sheila backman,PRTM-3440,2014
-PRTM,3440,2,PRTM 3440: 002,0.39,0.35,0.1,0.12,0.04,0.0,0.0,0.0,sheila backman,PRTM-3440,2014
-PRTM,3460,1,PRTM 3460: 001,0.13,0.65,0.17,0.04,0.0,0.0,0.0,0.0,gregory phi ramshaw,PRTM-3460,2014
-PRTM,3470,1,PRTM 3470: 001,0.34,0.34,0.21,0.1,0.0,0.0,0.0,0.0,gregory phi ramshaw,PRTM-3470,2014
-PRTM,3510,1,PRTM 3510: 001,0.2,0.2,0.5,0.1,0.0,0.0,0.0,0.0,daniel mor anderson,PRTM-3510,2014
-PRTM,3550,1,PRTM 3550: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-3550,2014
-PRTM,3830,1,PRTM 3830: 001,0.45,0.09,0.45,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-3830,2014
-PRTM,3980,1,Creative Inquiry in PRTM III,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,PRTM-3980,2014
-PRTM,3980,3,Creative Inquiry in PRTM III,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,PRTM-3980,2014
-PRTM,3980,4,Creative Inquiry in PRTM III,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi hughes,PRTM-3980,2014
-PRTM,3980,6,Creative Inquiry in PRTM III,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,PRTM-3980,2014
-PRTM,3980,9,Creative Inquiry in PRTM III,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-3980,2014
-PRTM,4070,1,PRTM 4070: 001,0.33,0.43,0.24,0.0,0.0,0.0,0.0,0.0,toni liechty,PRTM-4070,2014
-PRTM,4210,1,Rec Fin Resc Mgt,0.11,0.49,0.17,0.17,0.06,0.0,0.0,0.0,denise mar anderson,PRTM-4210,2014
-PRTM,4220,1,PRTM 4220: 001,0.32,0.54,0.11,0.0,0.0,0.0,0.0,0.04,anna-mar chancellor,PRTM-4220,2014
-PRTM,4260,1,PRTM 4260: 001,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-4260,2014
-PRTM,4300,1,World Geog Parks,0.58,0.35,0.06,0.0,0.0,0.0,0.0,0.0,robert baxte powell,PRTM-4300,2014
-PRTM,4310,1,Methods Envir Inter,0.43,0.21,0.29,0.07,0.0,0.0,0.0,0.0,robert bixler,PRTM-4310,2014
-PRTM,4410,1,PRTM 4410: 001,0.5,0.25,0.1,0.1,0.05,0.0,0.0,0.0,herbert chancellor,PRTM-4410,2014
-PRTM,4450,1,PRTM 4450: 001,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jeffery martin,PRTM-4450,2014
-PRTM,4470,1,PRTM 4470: 001,0.78,0.17,0.02,0.0,0.0,0.0,0.0,0.02,lauren duffy,PRTM-4470,2014
-PRTM,4510,1,PRTM 4510: 001,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-4510,2014
-PRTM,4540,1,Trends in Sport Mgt,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,PRTM-4540,2014
-PRTM,4550,1,PRTM 4550: 001,0.28,0.56,0.17,0.0,0.0,0.0,0.0,0.0,gwynn powell,PRTM-4550,2014
-PRTM,8030,1,PRTM 8030: 001,0.78,0.13,0.0,0.0,0.04,0.0,0.0,0.04,skye arthur-banning,PRTM-8030,2014
-PRTM,8110,1,PRTM 8110: 001,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,PRTM-8110,2014
-PRTM,8110,2,PRTM 8110: 002,0.65,0.2,0.1,0.0,0.0,0.0,0.0,0.05,jeffrey charl hallo,PRTM-8110,2014
-PRTM,8210,1,PRTM 8210: 001,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,denise mar anderson,PRTM-8210,2014
-PRTM,8250,1,PRTM 8250: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,toni liechty,PRTM-8250,2014
-PSYC,2010,1,Intro to Psychology,0.29,0.38,0.2,0.03,0.03,0.0,0.0,0.07,mary taylor,PSYC-2010,2014
-PSYC,2010,2,Intro to Psychology,0.09,0.44,0.36,0.04,0.03,0.0,0.0,0.04,mary taylor,PSYC-2010,2014
-PSYC,2010,3,Intro to Psychology (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,PSYC-2010,2014
-PSYC,2010,4,Intro to Psychology,0.3,0.25,0.31,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,PSYC-2010,2014
-PSYC,2010,5,Intro to Psychology,0.57,0.23,0.09,0.09,0.03,0.0,0.0,0.0,chong hyon pak,PSYC-2010,2014
-PSYC,2010,6,Intro to Psychology,0.37,0.31,0.19,0.06,0.04,0.0,0.0,0.03,fred switzer,PSYC-2010,2014
-PSYC,2010,7,Intro to Psychology,0.29,0.26,0.2,0.11,0.09,0.0,0.0,0.06,edwin brainerd,PSYC-2010,2014
-PSYC,2020,1,PSYC 2020: 001,0.84,0.0,0.11,0.0,0.0,0.0,0.0,0.05,eric mckibben,PSYC-2020,2014
-PSYC,2020,2,PSYC 2020: 002,0.79,0.08,0.0,0.04,0.0,0.0,0.0,0.08,eric mckibben,PSYC-2020,2014
-PSYC,2020,3,PSYC 2020: 003,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,eric mckibben,PSYC-2020,2014
-PSYC,2020,4,PSYC 2020: 004,0.78,0.04,0.09,0.0,0.04,0.0,0.0,0.04,eric mckibben,PSYC-2020,2014
-PSYC,2020,5,PSYC 2020: 005,0.78,0.09,0.09,0.0,0.04,0.0,0.0,0.0,lauren elizab ellis,PSYC-2020,2014
-PSYC,2020,6,PSYC 2020: 006,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,james nathan salley,PSYC-2020,2014
-PSYC,2020,7,PSYC 2020: 007,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,drew morgan link,PSYC-2020,2014
-PSYC,3060,1,Human Sexual Beh,0.67,0.18,0.09,0.03,0.02,0.0,0.0,0.01,bruce michael king,PSYC-3060,2014
-PSYC,3090,100,Intro Exp Psych,0.14,0.36,0.29,0.07,0.11,0.0,0.0,0.04,jennifer bai bisson,PSYC-3090,2014
-PSYC,3090,200,Intro Exp Psych,0.42,0.3,0.15,0.05,0.05,0.0,0.0,0.01,richard tyrrell,PSYC-3090,2014
-PSYC,3090,300,Intro Exp Psych,0.9,0.03,0.07,0.0,0.0,0.0,0.0,0.0,larry alton pace,PSYC-3090,2014
-PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,jennifer bai bisson,PSYC-3100,2014
-PSYC,3100,200,Advanced Experimental Psych,0.33,0.39,0.06,0.06,0.11,0.0,0.0,0.06,stephanie whetsel,PSYC-3100,2014
-PSYC,3100,300,Advanced Experimental Psych,0.35,0.47,0.06,0.0,0.12,0.0,0.0,0.0,robert campbell,PSYC-3100,2014
-PSYC,3100,400,Advanced Experimental Psych,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,larry alton pace,PSYC-3100,2014
-PSYC,3100,500,Advanced Experimental Psych,0.47,0.24,0.18,0.0,0.12,0.0,0.0,0.0,thomas britt,PSYC-3100,2014
-PSYC,3100,600,Advanced Experimental Psych,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,paul steven merritt,PSYC-3100,2014
-PSYC,3100,700,Advanced Experimental Psych,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2014
-PSYC,3240,1,Physiological Psych,0.37,0.27,0.17,0.08,0.06,0.0,0.0,0.06,claudio cantalupo,PSYC-3240,2014
-PSYC,3240,2,Physiological Psych,0.37,0.24,0.15,0.07,0.1,0.0,0.0,0.07,claudio cantalupo,PSYC-3240,2014
-PSYC,3330,1,Cognitive Psych,0.19,0.4,0.24,0.11,0.03,0.0,0.0,0.03,thomas alley,PSYC-3330,2014
-PSYC,3340,1,Cognitive Psych Lab,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,thomas alley,PSYC-3340,2014
-PSYC,3340,2,Cognitive Psych Lab,0.64,0.07,0.21,0.07,0.0,0.0,0.0,0.0,thomas alley,PSYC-3340,2014
-PSYC,3340,3,Cognitive Psych Lab,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,ashley ann sewall,PSYC-3340,2014
-PSYC,3400,1,Lifespan Developmental Psych,0.31,0.42,0.14,0.06,0.04,0.0,0.0,0.03,pamela alley,PSYC-3400,2014
-PSYC,3520,1,Social Psychology,0.45,0.34,0.14,0.07,0.0,0.0,0.0,0.0,jo anne jorgensen,PSYC-3520,2014
-PSYC,3520,2,Social Psychology,0.38,0.38,0.18,0.03,0.0,0.0,0.0,0.03,jo anne jorgensen,PSYC-3520,2014
-PSYC,3520,3,Social Psychology (HON),0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-3520,2014
-PSYC,3640,1,Industrial Psych,0.24,0.46,0.26,0.01,0.01,0.0,0.0,0.01,eric mckibben,PSYC-3640,2014
-PSYC,3680,1,Organizational Psych,0.56,0.24,0.17,0.01,0.0,0.0,0.0,0.01,skye gillispie,PSYC-3680,2014
-PSYC,3700,1,Personality,0.4,0.46,0.13,0.01,0.0,0.0,0.0,0.0,eric mckibben,PSYC-3700,2014
-PSYC,3830,1,Abnormal Psychology,0.34,0.31,0.26,0.0,0.06,0.0,0.0,0.03,pamela alley,PSYC-3830,2014
-PSYC,3830,2,Abnormal Psychology,0.26,0.26,0.26,0.15,0.0,0.0,0.0,0.06,pamela alley,PSYC-3830,2014
-PSYC,3830,3,Abnormal Psychology,0.17,0.46,0.28,0.04,0.03,0.0,0.0,0.01,heidi marie zinzow,PSYC-3830,2014
-PSYC,4080,1,Women and Psychology,0.44,0.32,0.16,0.04,0.04,0.0,0.0,0.0,robin mari kowalski,PSYC-4080,2014
-PSYC,4150,1,Systems and Theories,0.3,0.37,0.2,0.07,0.03,0.0,0.0,0.03,edwin brainerd,PSYC-4150,2014
-PSYC,4150,2,Systems and Theories,0.26,0.33,0.22,0.07,0.07,0.0,0.0,0.07,edwin brainerd,PSYC-4150,2014
-PSYC,4220,1,Perception,0.21,0.31,0.31,0.03,0.1,0.0,0.0,0.03,claudio cantalupo,PSYC-4220,2014
-PSYC,4220,2,Perception,0.29,0.26,0.29,0.13,0.03,0.0,0.0,0.0,christopher pagano,PSYC-4220,2014
-PSYC,4750,1,Brain and Behavior,0.5,0.28,0.11,0.0,0.0,0.0,0.0,0.11,june pilcher,PSYC-4750,2014
-PSYC,4800,1,Health Psychology,0.68,0.2,0.04,0.0,0.0,0.0,0.0,0.08,june pilcher,PSYC-4800,2014
-PSYC,4800,2,Health Psychology,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,james mccubbin,PSYC-4800,2014
-PSYC,4800,3,Health Psychology,0.64,0.28,0.04,0.0,0.04,0.0,0.0,0.0,james mccubbin,PSYC-4800,2014
-PSYC,4820,1,Positive Psychology,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,cynthia pury,PSYC-4820,2014
-PSYC,4890,1,Teamwork in the 21st Century,0.83,0.04,0.04,0.0,0.0,0.0,0.0,0.09,marissa leig porter,PSYC-4890,2014
-PSYC,4890,4,Teamwork in the 21st Century,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,marissa leig porter,PSYC-4890,2014
-PSYC,4920,1,Senior Laboratory,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,allison lei wallace,PSYC-4920,2014
-PSYC,4920,2,Senior Laboratory,0.82,0.11,0.07,0.0,0.0,0.0,0.0,0.0,allison lei wallace,PSYC-4920,2014
-PSYC,4920,3,Senior Laboratory,0.82,0.11,0.07,0.0,0.0,0.0,0.0,0.0,crystal burn fulmer,PSYC-4920,2014
-PSYC,4920,4,Senior Laboratory,0.71,0.17,0.0,0.08,0.04,0.0,0.0,0.0,crystal burn fulmer,PSYC-4920,2014
-PSYC,4930,100,Pract Clinical Psych,0.65,0.1,0.05,0.0,0.1,0.0,0.0,0.1,heidi marie zinzow,PSYC-4930,2014
-PSYC,8130,1,PSYC 8130: 001,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0, dewayne moore,PSYC-8130,2014
-PSYC,8620,1,PSYC 8620: 001,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,robert ray sinclair,PSYC-8620,2014
-RED,8010,1,Market Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,RED-8010,2014
-RED,8040,1,Resid Practicum,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,RED-8040,2014
-RED,8050,1,Commercial Practicum,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8050,2014
-RED,8120,1,Real Estate Technology,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,RED-8120,2014
-RED,8130,1,RED 8130: 001,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,RED-8130,2014
-REL,1010,1,Intro to Religion,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,robert stephens,REL-1010,2014
-REL,1010,2,Intro to Religion,0.79,0.09,0.03,0.0,0.0,0.0,0.0,0.09,robert stephens,REL-1010,2014
-REL,1020,1,World Religions,0.32,0.41,0.15,0.06,0.03,0.0,0.0,0.03,peter cohen,REL-1020,2014
-REL,1020,2,World Religions,0.47,0.34,0.06,0.06,0.0,0.0,0.0,0.06,peter cohen,REL-1020,2014
-REL,1020,4,World Religions,0.25,0.39,0.28,0.06,0.03,0.0,0.0,0.0,peter cohen,REL-1020,2014
-REL,1020,5,World Religions,0.77,0.17,0.0,0.0,0.0,0.0,0.0,0.07,robert stephens,REL-1020,2014
-REL,1020,6,World Religions,0.51,0.34,0.06,0.0,0.0,0.0,0.0,0.09,robert stephens,REL-1020,2014
-REL,3000,1,REL 3000: 001,0.58,0.24,0.03,0.03,0.03,0.0,0.0,0.09,steven grosby,REL-3000,2014
-REL,3010,1,Old Testament,0.59,0.21,0.12,0.0,0.0,0.06,0.0,0.03,steven grosby,REL-3010,2014
-REL,3010,2,Old Testament,0.42,0.56,0.0,0.0,0.0,0.0,0.0,0.03,steven grosby,REL-3010,2014
-REL,3730,1,Age of Protestant Reformation,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,thomas kuehn,REL-3730,2014
-RS,3010,1,Rural Sociology,0.37,0.37,0.14,0.09,0.0,0.0,0.0,0.03,kenneth robinson,RS-3010,2014
-RS,4590,1,The Community,0.64,0.07,0.21,0.0,0.0,0.0,0.0,0.07,kenneth robinson,RS-4590,2014
-RUSS,1020,1,RUSS 1020: 001,0.27,0.45,0.09,0.0,0.09,0.0,0.0,0.09,joan bridgwood,RUSS-1020,2014
-RUSS,2020,1,Intermediate Russ,0.5,0.2,0.1,0.0,0.0,0.0,0.0,0.2,joan bridgwood,RUSS-2020,2014
-SOC,2010,1,Intro to Sociology (HON),0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,sarah evely winslow,SOC-2010,2014
-SOC,2010,2,Introduction to Sociology,0.48,0.36,0.12,0.0,0.01,0.0,0.0,0.02,jennifer le holland,SOC-2010,2014
-SOC,2010,3,Introduction to Sociology,0.45,0.37,0.12,0.02,0.02,0.0,0.0,0.02,jennifer le holland,SOC-2010,2014
-SOC,2010,4,Introduction to Sociology,0.54,0.33,0.06,0.02,0.0,0.0,0.0,0.04,mary louise barr,SOC-2010,2014
-SOC,2010,5,Introduction to Sociology,0.71,0.22,0.04,0.02,0.0,0.0,0.0,0.0,mary louise barr,SOC-2010,2014
-SOC,2010,6,Introduction to Sociology,0.73,0.17,0.06,0.02,0.0,0.0,0.0,0.02,mary louise barr,SOC-2010,2014
-SOC,2010,7,Introduction to Sociology,0.55,0.31,0.14,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2014
-SOC,2010,8,Introduction to Sociology,0.38,0.42,0.16,0.01,0.0,0.0,0.0,0.02,mary louise barr,SOC-2010,2014
-SOC,2010,9,Introduction to Sociology,0.51,0.34,0.08,0.01,0.03,0.0,0.0,0.03,jennifer triplett,SOC-2010,2014
-SOC,2010,10,Introduction to Sociology,0.76,0.2,0.02,0.0,0.02,0.0,0.0,0.0,jennifer triplett,SOC-2010,2014
-SOC,2020,1,Social Problems,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,stephani southworth,SOC-2020,2014
-SOC,2020,2,Social Problems,0.48,0.35,0.09,0.04,0.04,0.0,0.0,0.0,stephani southworth,SOC-2020,2014
-SOC,2050,1,SOC 2050: 001,0.72,0.08,0.03,0.08,0.06,0.0,0.0,0.03,brenda vander mey,SOC-2050,2014
-SOC,3020,1,Research Methods I,0.15,0.38,0.42,0.04,0.0,0.0,0.0,0.02,ellen granberg,SOC-3020,2014
-SOC,3040,1,Research Methods II,0.22,0.48,0.22,0.04,0.0,0.0,0.0,0.04,ye luo,SOC-3040,2014
-SOC,3100,1,Marriage & Intimacy,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,SOC-3100,2014
-SOC,3100,2,Marriage & Intimacy,0.54,0.35,0.07,0.0,0.0,0.04,0.0,0.0,jeffrey edwards,SOC-3100,2014
-SOC,3110,1,The Family,0.52,0.38,0.06,0.04,0.0,0.0,0.0,0.0,jennifer triplett,SOC-3110,2014
-SOC,3310,1,Urban Sociology,0.27,0.38,0.15,0.04,0.1,0.0,0.0,0.06,stephani southworth,SOC-3310,2014
-SOC,3500,1,Self & Society,0.37,0.45,0.14,0.0,0.02,0.0,0.0,0.02,jennifer triplett,SOC-3500,2014
-SOC,3800,1,Intro Social Service,0.49,0.39,0.06,0.0,0.04,0.0,0.0,0.02,jennifer le holland,SOC-3800,2014
-SOC,3880,1,Criminal Justice,0.45,0.19,0.21,0.09,0.06,0.0,0.0,0.0,william white,SOC-3880,2014
-SOC,3890,1,Criminology,0.28,0.22,0.2,0.17,0.09,0.0,0.0,0.04,william white,SOC-3890,2014
-SOC,3910,1,Soc of Deviance,0.18,0.39,0.27,0.04,0.04,0.0,0.0,0.08,stephani southworth,SOC-3910,2014
-SOC,3920,1,Juvenile Delinquency,0.54,0.25,0.15,0.0,0.02,0.0,0.0,0.04,jeffrey edwards,SOC-3920,2014
-SOC,3970,1,Substance Abuse,0.51,0.36,0.04,0.0,0.04,0.0,0.0,0.04,jeffrey edwards,SOC-3970,2014
-SOC,4040,1,Soc Theory,0.54,0.34,0.07,0.0,0.02,0.0,0.0,0.02,william haller,SOC-4040,2014
-SOC,4330,1,Global Social Change,0.64,0.24,0.04,0.0,0.04,0.0,0.0,0.04,william haller,SOC-4330,2014
-SOC,4440,1,Sociology of Educ,0.25,0.21,0.08,0.08,0.25,0.0,0.0,0.13,stephani southworth,SOC-4440,2014
-SOC,4590,1,The Community,0.39,0.22,0.22,0.0,0.0,0.0,0.0,0.17,kenneth robinson,SOC-4590,2014
-SOC,4600,1,Race & Ethnicity,0.5,0.18,0.29,0.0,0.04,0.0,0.0,0.0,brenda vander mey,SOC-4600,2014
-SOC,4610,1,Sex & Gender,0.22,0.46,0.24,0.09,0.0,0.0,0.0,0.0,sarah evely winslow,SOC-4610,2014
-SOC,4840,1,Child Abuse,0.47,0.26,0.21,0.03,0.0,0.0,0.0,0.03,douglas sturkie,SOC-4840,2014
-SOC,4930,1,Soc of Corrections,0.4,0.33,0.13,0.13,0.0,0.0,0.0,0.0,william white,SOC-4930,2014
-SOC,4970,1,Senior Lab,0.65,0.19,0.0,0.15,0.0,0.0,0.0,0.0,brenda vander mey,SOC-4970,2014
-SOC,4970,2,Senior Lab,0.75,0.0,0.08,0.17,0.0,0.0,0.0,0.0,brenda vander mey,SOC-4970,2014
-SOC,4990,1,Sem- Issues in Cmmty Policity,0.1,0.4,0.5,0.0,0.0,0.0,0.0,0.0,william white,SOC-4990,2014
-SPAN,1010,1,SPAN 1010: 001,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2014
-SPAN,1010,2,SPAN 1010: 002,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2014
-SPAN,1010,3,SPAN 1010: 003,0.21,0.16,0.16,0.21,0.0,0.0,0.0,0.26,samuel palmer moody,SPAN-1010,2014
-SPAN,1020,1,SPAN 1020: 001,0.13,0.5,0.19,0.13,0.0,0.0,0.0,0.06,roger simpson,SPAN-1020,2014
-SPAN,1020,2,SPAN 1020: 002,0.06,0.12,0.18,0.24,0.18,0.0,0.0,0.24,roger simpson,SPAN-1020,2014
-SPAN,1020,3,SPAN 1020: 003,0.33,0.33,0.17,0.11,0.06,0.0,0.0,0.0,roger simpson,SPAN-1020,2014
-SPAN,1020,4,SPAN 1020: 004,0.22,0.17,0.28,0.06,0.11,0.0,0.0,0.17,roger simpson,SPAN-1020,2014
-SPAN,1020,5,SPAN 1020: 005,0.11,0.26,0.26,0.05,0.16,0.0,0.0,0.16,roger simpson,SPAN-1020,2014
-SPAN,1020,6,SPAN 1020: 006,0.0,0.29,0.53,0.12,0.0,0.0,0.0,0.06,cathy robison,SPAN-1020,2014
-SPAN,1020,7,SPAN 1020: 007,0.26,0.32,0.26,0.11,0.0,0.0,0.0,0.05,cathy robison,SPAN-1020,2014
-SPAN,1020,8,SPAN 1020: 008,0.17,0.28,0.39,0.0,0.06,0.0,0.0,0.11,ricardo tremolada,SPAN-1020,2014
-SPAN,1020,9,SPAN 1020: 009,0.24,0.29,0.18,0.06,0.06,0.0,0.0,0.18,ricardo tremolada,SPAN-1020,2014
-SPAN,1020,10,SPAN 1020: 010,0.21,0.42,0.26,0.0,0.05,0.0,0.0,0.05,allison ann hinds,SPAN-1020,2014
-SPAN,1020,11,SPAN 1020: 011,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,allison ann hinds,SPAN-1020,2014
-SPAN,1020,12,SPAN 1020: 012,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1020,2014
-SPAN,1020,14,SPAN 1020: 014,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,scott harris,SPAN-1020,2014
-SPAN,2010,1,Intermediate Spanish,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2014
-SPAN,2010,2,Intermediate Spanish,0.28,0.56,0.11,0.06,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2014
-SPAN,2010,3,Intermediate Spanish,0.21,0.53,0.11,0.0,0.0,0.0,0.0,0.16,maureen zamora,SPAN-2010,2014
-SPAN,2010,4,Intermediate Spanish,0.58,0.16,0.26,0.0,0.0,0.0,0.0,0.0,angeli leal,SPAN-2010,2014
-SPAN,2010,5,Intermediate Spanish,0.37,0.42,0.0,0.05,0.11,0.0,0.0,0.05,angeli leal,SPAN-2010,2014
-SPAN,2010,6,Intermediate Spanish,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,heidi montes,SPAN-2010,2014
-SPAN,2010,7,Intermediate Spanish,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,allison ann hinds,SPAN-2010,2014
-SPAN,2010,8,Intermediate Spanish,0.13,0.5,0.13,0.0,0.06,0.0,0.0,0.19,melva margu persico,SPAN-2010,2014
-SPAN,2010,9,Intermediate Spanish,0.08,0.58,0.25,0.0,0.08,0.0,0.0,0.0,melva margu persico,SPAN-2010,2014
-SPAN,2010,10,Intermediate Spanish,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2014
-SPAN,2010,11,Intermediate Spanish,0.25,0.31,0.31,0.13,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2014
-SPAN,2010,12,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,sarah stoll watt,SPAN-2010,2014
-SPAN,2010,13,Intermediate Spanish,0.37,0.42,0.11,0.11,0.0,0.0,0.0,0.0,sarah stoll watt,SPAN-2010,2014
-SPAN,2010,14,Intermediate Spanish,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,allison ann hinds,SPAN-2010,2014
-SPAN,2010,15,Intermediate Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-2010,2014
-SPAN,2020,1,Intermediate Spanish,0.55,0.2,0.25,0.0,0.0,0.0,0.0,0.0,michael greene,SPAN-2020,2014
-SPAN,2020,2,Intermediate Spanish,0.53,0.21,0.26,0.0,0.0,0.0,0.0,0.0,michael greene,SPAN-2020,2014
-SPAN,2020,3,Intermediate Spanish,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,michael greene,SPAN-2020,2014
-SPAN,2020,4,Intermediate Spanish,0.39,0.17,0.39,0.0,0.06,0.0,0.0,0.0,angeli leal,SPAN-2020,2014
-SPAN,2020,5,Intermediate Spanish,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,angeli leal,SPAN-2020,2014
-SPAN,2020,6,Intermediate Spanish,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,heidi montes,SPAN-2020,2014
-SPAN,2020,7,Intermediate Spanish,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-2020,2014
-SPAN,2020,8,Intermediate Spanish,0.29,0.35,0.18,0.06,0.06,0.0,0.0,0.06,melva margu persico,SPAN-2020,2014
-SPAN,2020,9,Intermediate Spanish,0.24,0.53,0.18,0.0,0.0,0.0,0.0,0.06,melva margu persico,SPAN-2020,2014
-SPAN,2020,10,Intermediate Spanish,0.58,0.16,0.16,0.11,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2020,2014
-SPAN,2020,11,Intermediate Spanish,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,ellory schmucker,SPAN-2020,2014
-SPAN,2020,12,Intermediate Spanish,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,sarah stoll watt,SPAN-2020,2014
-SPAN,2020,13,Intermediate Spanish,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,sarah stoll watt,SPAN-2020,2014
-SPAN,2020,15,Intermediate Spanish,0.53,0.18,0.12,0.12,0.0,0.0,0.0,0.06,ricardo tremolada,SPAN-2020,2014
-SPAN,2020,16,Intermediate Spanish,0.21,0.36,0.14,0.07,0.14,0.0,0.0,0.07,juana martin-armas,SPAN-2020,2014
-SPAN,2020,17,Intermediate Spanish,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,juana martin-armas,SPAN-2020,2014
-SPAN,2020,18,Intermediate Spanish (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,SPAN-2020,2014
-SPAN,3020,1,SPAN 3020: 001,0.39,0.44,0.0,0.0,0.06,0.0,0.0,0.11,juana martin-armas,SPAN-3020,2014
-SPAN,3020,2,SPAN 3020: 002,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,juana martin-armas,SPAN-3020,2014
-SPAN,3060,1,SPAN 3060: 001,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-3060,2014
-SPAN,3070,1,Hispanic World: Sp,0.71,0.07,0.0,0.0,0.0,0.0,0.0,0.21,raquel anido,SPAN-3070,2014
-SPAN,3080,1,Hispanic World: La,0.78,0.0,0.17,0.06,0.0,0.0,0.0,0.0,lisa kristi dewaard,SPAN-3080,2014
-SPAN,3080,2,Hispanic World: La,0.58,0.21,0.16,0.0,0.05,0.0,0.0,0.0,lisa kristi dewaard,SPAN-3080,2014
-SPAN,3090,1,SPAN 3090: 001,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,lisa kristi dewaard,SPAN-3090,2014
-SPAN,3140,1,SPAN 3140: 001,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,SPAN-3140,2014
-SPAN,4010,1,SPAN 4010: 001,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,raquel anido,SPAN-4010,2014
-SPAN,4050,1,SPAN 4050: 001,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,maureen zamora,SPAN-4050,2014
-SPAN,4060,1,SPAN 4060: 001,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,SPAN-4060,2014
-SPAN,4060,2,SPAN 4060: 002,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,mon rojas-de-massei,SPAN-4060,2014
-SPAN,4090,1,SPAN 4090: 001,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,SPAN-4090,2014
-SPAN,4150,1,SPAN 4150: 001,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,areli moore peralta,SPAN-4150,2014
-STAT,2220,1,Statistics in Everyday Life,0.45,0.25,0.19,0.08,0.02,0.0,0.0,0.02,ros martinez-dawson,STAT-2220,2014
-STAT,2220,2,Statistics in Everyday Life,0.5,0.3,0.09,0.09,0.02,0.0,0.0,0.0,ros martinez-dawson,STAT-2220,2014
-STAT,2220,3,Statistics in Everyday Life,0.22,0.34,0.2,0.1,0.1,0.0,0.0,0.05,ran xie,STAT-2220,2014
-STAT,2220,4,Statistics in Everyday Life,0.38,0.29,0.21,0.08,0.04,0.0,0.0,0.0,ran xie,STAT-2220,2014
-STAT,3010,1,Introductory Statistics,0.33,0.22,0.3,0.12,0.0,0.0,0.0,0.03,richard stev dubsky,STAT-3010,2014
-STAT,3010,2,Introductory Statistics,0.47,0.25,0.15,0.03,0.05,0.0,0.0,0.05,richard stev dubsky,STAT-3010,2014
-STAT,3010,3,Introductory Statistics,0.45,0.22,0.21,0.07,0.03,0.0,0.0,0.02,james espey,STAT-3010,2014
-STAT,3010,4,Introductory Statistics,0.53,0.19,0.17,0.08,0.03,0.0,0.0,0.0,ros martinez-dawson,STAT-3010,2014
-STAT,3010,5,Introductory Statistics,0.22,0.25,0.18,0.15,0.17,0.0,0.0,0.03, erwin walker,STAT-3010,2014
-STAT,3010,6,Introductory Statistics,0.35,0.17,0.28,0.1,0.08,0.0,0.0,0.02, erwin walker,STAT-3010,2014
-STAT,3010,7,Introductory Statistics,0.22,0.29,0.22,0.09,0.14,0.0,0.0,0.03,richard stev dubsky,STAT-3010,2014
-STAT,3010,8,Introductory Statistics,0.26,0.34,0.16,0.09,0.14,0.0,0.0,0.02,benjamin sharp,STAT-3010,2014
-STAT,3010,9,Introductory Statistics,0.32,0.3,0.14,0.1,0.11,0.0,0.0,0.03,ellen hepfe breazel,STAT-3010,2014
-STAT,3010,10,Introductory Statistics,0.29,0.25,0.16,0.07,0.16,0.0,0.0,0.07,jun luo,STAT-3010,2014
-STAT,4110,1,STAT 4110: 001,0.43,0.35,0.13,0.04,0.04,0.0,0.0,0.0,james rieck,STAT-4110,2014
-STAT,4110,2,STAT 4110: 002,0.19,0.44,0.19,0.0,0.13,0.0,0.0,0.06,patrick gerard,STAT-4110,2014
-STAT,8010,1,STAT 8010: 001,0.41,0.45,0.1,0.0,0.03,0.0,0.0,0.0,james rieck,STAT-8010,2014
-STAT,8010,2,STAT 8010: 002,0.59,0.35,0.0,0.0,0.03,0.0,0.0,0.03,william bridges,STAT-8010,2014
-STAT,8010,3,STAT 8010: 003,0.53,0.24,0.18,0.0,0.03,0.0,0.0,0.03,jun luo,STAT-8010,2014
-STAT,8020,1,STAT 8020: 001,0.7,0.22,0.0,0.0,0.0,0.0,0.0,0.07,william bridges,STAT-8020,2014
-STAT,8030,1,STAT 8030: 001,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,hoke hill,STAT-8030,2014
-STAT,8040,1,STAT 8040: 001,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,STAT-8040,2014
-STAT,8420,230,Intro to Statistical Methods,0.15,0.54,0.08,0.0,0.23,0.0,0.0,0.0,julia lynn sharp,STAT-8420,2014
-STS,1010,1,Survey of S T S,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,thomas oberdan,STS-1010,2014
-STS,1010,2,Survey of S T S,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,STS-1010,2014
-STS,1010,3,Survey of S T S,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,STS-1010,2014
-STS,1010,4,Survey of S T S,0.24,0.38,0.18,0.06,0.06,0.0,0.0,0.09,david charles foltz,STS-1010,2014
-STS,1010,5,Survey of S T S,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.03,michael greene,STS-1010,2014
-STS,1010,6,Survey of S T S,0.47,0.38,0.09,0.03,0.0,0.0,0.0,0.03,sarah mae cooper,STS-1010,2014
-STS,1010,7,Survey of S T S,0.48,0.42,0.03,0.03,0.03,0.0,0.0,0.0,thomas oberdan,STS-1010,2014
-STS,1010,20,Survey of S T S,0.29,0.45,0.21,0.0,0.0,0.0,0.0,0.05,thomas oberdan,STS-1010,2014
-STS,2150,1,Crit Appr to Tech Revolutions,0.21,0.16,0.58,0.0,0.05,0.0,0.0,0.0,thomas oberdan,STS-2150,2014
-THEA,2100,1,Theatre Appreciation,0.77,0.19,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,THEA-2100,2014
-THEA,2100,2,Theatre Appreciation,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-2100,2014
-THEA,2100,3,Theatre Appreciation,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,kerrie kath seymour,THEA-2100,2014
-THEA,2100,4,Theatre Appreciation,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-2100,2014
-THEA,2100,6,Theatre Appreciation,0.53,0.34,0.06,0.0,0.0,0.0,0.0,0.06,jason adkins,THEA-2100,2014
-THEA,2100,8,Theatre Appreciation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,THEA-2100,2014
-THEA,3150,1,Theatre History I,0.75,0.1,0.1,0.0,0.05,0.0,0.0,0.0,richard st. peter,THEA-3150,2014
-THEA,3180,1,THEA 3180: 001,0.4,0.35,0.15,0.1,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-3180,2014
-THEA,3680,1,THEA 3680: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,THEA-3680,2014
-THEA,4670,1,THEA 4670: 001,0.5,0.0,0.1,0.0,0.3,0.0,0.0,0.1,kendra lyne johnson,THEA-4670,2014
-WFB,3010,1,WFB 3010: 001,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2014
-WFB,3130,1,Conservation Biology,0.3,0.22,0.28,0.16,0.0,0.0,0.0,0.04,shari lyn rodriguez,WFB-3130,2014
-WFB,3130,2,Conservation Biology,0.29,0.16,0.42,0.1,0.03,0.0,0.0,0.0,shari lyn rodriguez,WFB-3130,2014
-WFB,3500,1,WFB 3500: 001,0.39,0.45,0.14,0.0,0.0,0.0,0.0,0.02,james davis,WFB-3500,2014
-WFB,3500,2,WFB 3500: 002,0.29,0.32,0.29,0.05,0.05,0.0,0.0,0.0,james davis,WFB-3500,2014
-WFB,4160,1,WFB 4160: 001,0.36,0.32,0.26,0.04,0.02,0.0,0.0,0.0,yoichiro kanno,WFB-4160,2014
-WFB,4300,1,WFB 4300: 001,0.56,0.3,0.05,0.0,0.06,0.0,0.0,0.03,joseph lanham,WFB-4300,2014
-WFB,4400,1,WFB 4400: 001,0.43,0.31,0.09,0.09,0.06,0.0,0.0,0.02,shari lyn rodriguez,WFB-4400,2014
-WFB,4440,1,WFB 4440: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,WFB-4440,2014
-WFB,4620,1,Wetland Wildl Biol,0.25,0.41,0.24,0.08,0.01,0.0,0.0,0.01,russell barrett,WFB-4620,2014
-WFB,4760,1,WFB 4760: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph lanham,WFB-4760,2014
-WFB,8610,1,Applied Population Dynamics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katherine mcfadden,WFB-8610,2014
-WS,1030,1,Women Global Perspec,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,WS-1030,2014
-WS,2300,1,WS 2300: 001,0.69,0.23,0.04,0.0,0.0,0.0,0.0,0.04,saadiqa kumanyika,WS-2300,2014
-WS,3010,1,Intro Womens Studies,0.7,0.24,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2014
-WS,3010,2,Intro Womens Studies,0.58,0.37,0.03,0.0,0.03,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2014
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1020,1,Survey of Art & Arch Hist II,0.49,0.38,0.11,0.0,0.01,0.0,0.0,0.01,beth ann lauritis,
+AAH,2060,1,Art History and Theory II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
+AAH,2100,1,Intro to Art and Architecture,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,janet bever leblanc,
+AAH,2100,2,Intro to Art and Architecture,0.39,0.32,0.21,0.07,0.0,0.0,0.0,0.0,janet bever leblanc,
+AAH,2100,3,Intro to Art and Architecture,0.33,0.22,0.22,0.07,0.0,0.0,0.0,0.15,janet bever leblanc,
+AAH,2100,4,Intro to Art and Architecture,0.24,0.38,0.21,0.03,0.0,0.0,0.0,0.14,janet bever leblanc,
+ACCT,2010,1,Financial Accounting Concepts,0.14,0.32,0.26,0.08,0.08,0.0,0.0,0.12,suzanne pearse,
+ACCT,2010,2,Financial Accounting Concepts,0.08,0.25,0.35,0.15,0.1,0.0,0.0,0.08,henry anderson,
+ACCT,2010,3,Financial Accounting Concepts,0.15,0.24,0.33,0.11,0.02,0.0,0.0,0.15,suzanne pearse,
+ACCT,2010,4,Financial Accounting Concepts,0.2,0.34,0.18,0.09,0.05,0.0,0.0,0.14,the estate  guffey,
+ACCT,2010,5,Financial Accounting Concepts,0.09,0.26,0.33,0.02,0.16,0.0,0.0,0.14,henry anderson,
+ACCT,2010,6,Financial Accounting Concepts,0.17,0.26,0.28,0.09,0.11,0.0,0.0,0.11,suzanne pearse,
+ACCT,2010,7,Financial Accounting Concepts,0.23,0.23,0.32,0.11,0.04,0.0,0.0,0.06,suzanne pearse,
+ACCT,2010,8,Financial Accounting Concepts,0.11,0.24,0.2,0.04,0.2,0.0,0.0,0.2,henry anderson,
+ACCT,2010,9,Financial Accounting Concepts,0.07,0.34,0.23,0.14,0.07,0.0,0.0,0.16,the estate  guffey,
+ACCT,2010,10,Financial Accounting Concepts,0.13,0.38,0.18,0.11,0.04,0.0,0.0,0.16,the estate  guffey,
+ACCT,2010,11,Financial Accounting Concepts,0.12,0.27,0.29,0.11,0.09,0.0,0.0,0.12,jeffrey mcmillan,
+ACCT,2020,1,Managerial Accounting Concepts,0.25,0.4,0.17,0.1,0.06,0.0,0.0,0.02,annieka philo,
+ACCT,2020,2,Managerial Accounting Concepts,0.29,0.38,0.25,0.04,0.02,0.0,0.0,0.02,annieka philo,
+ACCT,2020,3,Managerial Accounting Concepts,0.23,0.29,0.31,0.06,0.08,0.0,0.0,0.02,annieka philo,
+ACCT,2020,4,Managerial Accounting Concepts,0.31,0.37,0.14,0.1,0.08,0.0,0.0,0.0,annieka philo,
+ACCT,2020,5,Managerial Accounting Concepts,0.27,0.29,0.16,0.02,0.03,0.0,0.0,0.23,henry anderson,
+ACCT,2020,6,Managerial Accounting Concepts,0.18,0.19,0.19,0.09,0.05,0.0,0.0,0.3,henry anderson,
+ACCT,2040,1,ACCT 2040: 001,0.53,0.29,0.08,0.03,0.06,0.0,0.0,0.01,jeffrey mcmillan,
+ACCT,2040,2,ACCT 2040: 002,0.37,0.36,0.11,0.04,0.06,0.0,0.0,0.07,jeffrey mcmillan,
+ACCT,3030,1,Cost Accounting,0.26,0.37,0.2,0.03,0.06,0.0,0.0,0.09,derek dalton,
+ACCT,3030,2,Cost Accounting,0.17,0.4,0.31,0.11,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,3030,3,Cost Accounting,0.18,0.63,0.05,0.03,0.08,0.0,0.0,0.03,robin radtke,
+ACCT,3030,4,Cost Accounting,0.31,0.49,0.1,0.03,0.08,0.0,0.0,0.0,robin radtke,
+ACCT,3110,1,Intermed Financial Acct I,0.22,0.41,0.3,0.07,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3110,2,Intermed Financial Acct I,0.52,0.36,0.07,0.02,0.02,0.0,0.0,0.0,terry daniel knause,
+ACCT,3110,3,Intermed Financial Acct I,0.55,0.24,0.19,0.0,0.0,0.0,0.0,0.02,terry daniel knause,
+ACCT,3110,4,Intermed Financial Acct I,0.59,0.24,0.1,0.0,0.02,0.0,0.0,0.05,terry daniel knause,
+ACCT,3120,1,Intermed Financial Acct II,0.18,0.54,0.15,0.1,0.03,0.0,0.0,0.0, russell madray,
+ACCT,3120,2,Intermed Financial Acct II,0.3,0.46,0.19,0.03,0.0,0.0,0.0,0.03, russell madray,
+ACCT,3120,3,Intermed Financial Acct II,0.15,0.21,0.36,0.06,0.0,0.0,0.0,0.21,lydia lan schleifer,
+ACCT,3120,4,Intermed Financial Acct II,0.15,0.36,0.3,0.0,0.12,0.0,0.0,0.06,lydia lan schleifer,
+ACCT,3130,1,Intermed Financial Acct III,0.17,0.46,0.23,0.11,0.0,0.0,0.0,0.03, russell madray,
+ACCT,3130,2,Intermed Financial Acct III,0.51,0.22,0.22,0.03,0.03,0.0,0.0,0.0, russell madray,
+ACCT,3130,3,Intermed Financial Acct III,0.33,0.19,0.37,0.07,0.04,0.0,0.0,0.0,james irving,
+ACCT,3130,4,Intermed Financial Acct III,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,james irving,
+ACCT,3220,1,Accounting Information Systems,0.03,0.47,0.26,0.12,0.06,0.0,0.0,0.06,philip maiberger,
+ACCT,3220,2,Accounting Information Systems,0.16,0.26,0.35,0.13,0.06,0.0,0.0,0.03,philip maiberger,
+ACCT,3220,3,Accounting Information Systems,0.25,0.33,0.25,0.08,0.03,0.0,0.0,0.06,nancy lee harp,
+ACCT,4040,1,Individual Taxation,0.3,0.45,0.2,0.05,0.0,0.0,0.0,0.0,john hine,
+ACCT,4040,2,Individual Taxation,0.32,0.39,0.24,0.03,0.0,0.0,0.0,0.03,john hine,
+ACCT,4080,1,Retire & Estate Plan,0.29,0.38,0.33,0.0,0.0,0.0,0.0,0.0,john hine,
+ACCT,4100,1,Budget and Exec Cont,0.46,0.41,0.07,0.05,0.0,0.0,0.0,0.0,frances kennedy,
+ACCT,4100,2,Budget and Exec Cont,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,frances kennedy,
+ACCT,4150,1,Auditing,0.09,0.31,0.41,0.09,0.06,0.0,0.0,0.03,suzanne pearse,
+ACCT,4150,2,Auditing,0.15,0.15,0.35,0.25,0.1,0.0,0.0,0.0,carl hollingsworth,
+ACCT,8520,1,ACCT 8520: 001,0.36,0.61,0.03,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8520,2,ACCT 8520: 002,0.28,0.53,0.17,0.0,0.03,0.0,0.0,0.0,ralph welton,
+ACCT,8550,1,ACCT 8550: 001,0.66,0.29,0.03,0.0,0.03,0.0,0.0,0.0,james barnes,
+ACCT,8550,2,ACCT 8550: 002,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8710,1,ACCT 8710: 001,0.23,0.71,0.03,0.0,0.03,0.0,0.0,0.0,derek dalton,
+ACCT,8710,2,ACCT 8710: 002,0.31,0.66,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,
+AGED,3550,1,Team and Organiz Leadership,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thomas dobbins,
+AGED,4150,1,AGED 4150: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,kevin layfield,
+AGM,2050,1,AGM 2050: 001,0.15,0.42,0.32,0.04,0.0,0.0,0.0,0.08,hunter massey,
+AGM,2060,1,AGM 2060: 001,0.23,0.55,0.18,0.05,0.0,0.0,0.0,0.0,hunter massey,
+AGM,2210,1,AGM 2210: 001,0.29,0.46,0.2,0.0,0.06,0.0,0.0,0.0,charles privette,
+AGM,3030,1,AGM 3030: 001,0.21,0.4,0.33,0.02,0.02,0.0,0.0,0.0,young han,
+AGM,4020,1,AGM 4020: 001,0.06,0.66,0.26,0.0,0.03,0.0,0.0,0.0,charles privette,
+AGM,4100,1,AGM 4100: 001,0.38,0.47,0.13,0.03,0.0,0.0,0.0,0.0,hunter massey,
+AGM,4520,1,AGM 4520: 001,0.21,0.56,0.24,0.0,0.0,0.0,0.0,0.0,kendall kirk,
+AGM,4720,1,AGM 4720: 001,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,john chastain,
+AL,3490,400,AL 3490: 400,0.56,0.26,0.19,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,401,AL 3490: 401,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,402,AL 3490: 402,0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,403,AL 3490: 403,0.68,0.25,0.0,0.0,0.07,0.0,0.0,0.0,clyde keith connor,
+AL,3490,404,AL 3490: 404,0.54,0.27,0.08,0.04,0.04,0.0,0.0,0.04,clyde keith connor,
+AL,3490,405,AL 3490: 405,0.8,0.12,0.0,0.04,0.04,0.0,0.0,0.0,edmond fry,
+AL,3500,400,AL 3500: 400,0.19,0.31,0.23,0.12,0.08,0.0,0.0,0.08,michael godfrey,
+AL,3500,401,AL 3500: 401,0.14,0.55,0.05,0.09,0.09,0.0,0.0,0.09,michael godfrey,
+AL,3520,400,AL 3520: 400,0.22,0.22,0.35,0.04,0.0,0.0,0.0,0.17,michael godfrey,
+AL,3530,400,AL 3530: 400,0.12,0.23,0.27,0.27,0.08,0.0,0.0,0.04,isaac sean colbert,
+AL,3530,401,AL 3530: 401,0.13,0.17,0.39,0.22,0.04,0.0,0.0,0.04,isaac sean colbert,
+AL,3600,400,AL 3600: 400,0.46,0.43,0.07,0.0,0.0,0.0,0.0,0.04,clyde keith connor,
+AL,3610,400,AL 3610: 400,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,401,AL 3610: 401,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,AL 3610: 402,0.88,0.04,0.04,0.04,0.0,0.0,0.0,0.0,henry oates,
+AL,3620,400,AL 3620: 400,0.08,0.44,0.2,0.16,0.04,0.0,0.0,0.08,natalie anne carter,
+AL,3620,401,AL 3620: 401,0.23,0.23,0.37,0.09,0.03,0.0,0.0,0.06,natalie anne carter,
+AL,3710,400,AL 3710: 400,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,justin hickey,
+AL,3720,400,AL 3720: 400,0.61,0.13,0.04,0.04,0.13,0.0,0.0,0.04,edmond fry,
+AL,3740,400,AL 3740: 400,0.46,0.21,0.29,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
+AL,3750,400,AL 3750: 400,0.74,0.11,0.05,0.0,0.05,0.0,0.0,0.05,deborah cadorette,
+AL,3760,400,AL 3760: 400,0.38,0.14,0.19,0.1,0.19,0.0,0.0,0.0,edmond fry,
+AL,3760,401,AL 3760: 401,0.63,0.11,0.05,0.11,0.05,0.0,0.0,0.05,edmond fry,
+ANTH,2010,1,Intro Anthropology,0.06,0.21,0.41,0.11,0.12,0.0,0.0,0.09,john coggeshall,
+ANTH,2010,2,Intro Anthropology,0.24,0.32,0.24,0.11,0.05,0.0,0.0,0.05,melissa vogel,
+ANTH,2010,3,Intro Anthropology,0.36,0.32,0.19,0.07,0.03,0.0,0.0,0.03,lisa rapaport,
+ANTH,3200,1,North American Indian Cultures,0.18,0.35,0.24,0.0,0.0,0.0,0.0,0.24,john coggeshall,
+ANTH,3310,1,Archaeology,0.29,0.5,0.04,0.04,0.04,0.0,0.0,0.08,melissa vogel,
+ANTH,3510,1,Biological Anthropology,0.62,0.31,0.0,0.08,0.0,0.0,0.0,0.0,katherine weisensee,
+ANTH,4510,1,Biol Variation in Human Pop,0.33,0.33,0.25,0.0,0.0,0.0,0.0,0.08,katherine weisensee,
+APEC,2020,1,Agric Economics,0.38,0.28,0.23,0.0,0.07,0.0,0.0,0.05,webb smathers,
+APEC,2050,1,Agric and Society,0.6,0.38,0.0,0.0,0.0,0.0,0.0,0.02,david wheele hughes,
+APEC,3080,1,APEC 3080: 001,0.33,0.11,0.3,0.19,0.04,0.0,0.0,0.04,michael vassalos,
+APEC,3570,1,Nat Resource Econ,0.1,0.36,0.51,0.0,0.0,0.0,0.0,0.03,molly espey,
+APEC,4120,1,Reg Economic Devel,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david wheele hughes,
+APEC,4520,1,Agric Policy,0.25,0.55,0.2,0.0,0.0,0.0,0.0,0.0,michael vassalos,
+APEC,4750,1,Wildlife Economics,0.57,0.1,0.33,0.0,0.0,0.0,0.0,0.0,webb smathers,
+ARAB,1010,1,ARAB 1010: 001,0.64,0.14,0.0,0.07,0.0,0.0,0.0,0.14,sulafa abou-samra,
+ARAB,1020,1,ARAB 1020: 001,0.55,0.09,0.09,0.09,0.0,0.0,0.0,0.18,sulafa abou-samra,
+ARCH,1510,3,ARCH 1510: 003,0.38,0.33,0.17,0.04,0.0,0.0,0.0,0.08,sal hambright-belue,
+ARCH,1510,4,ARCH 1510: 004,0.23,0.64,0.09,0.0,0.0,0.0,0.0,0.05,sal hambright-belue,
+ARCH,2520,1,ARCH 2520: 001,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,2520,3,ARCH 2520: 003,0.33,0.33,0.17,0.0,0.08,0.0,0.0,0.08,criss mills,
+ARCH,2520,4,ARCH 2520: 004,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2700,1,ARCH 2700: 001,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,robert john hogan,
+ARCH,2700,2,ARCH 2700: 002,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert john hogan,
+ARCH,2710,1,ARCH 2710: 001,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,
+ARCH,4050,1,ARCH 4050: 001,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,robert bruhns,
+ARCH,4520,2,ARCH 4520: 002,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,lynn craig,
+ARCH,4520,3,ARCH 4520: 003,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,4990,1,Freehand Drawing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,
+ARCH,6050,1,ARCH 6050: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,8110,1,ARCH 8110: 001,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,douglas hecker,
+ARCH,8120,1,ARCH 8120: 001,0.21,0.64,0.14,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,8200,1,Bldg Design & Constr,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+ARCH,8420,1,ARCH 8420: 001,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ar montilla navarro,
+ARCH,8420,2,ARCH 8420: 002,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,junichi satoh,
+ARCH,8520,2,ARCH 8520: 002,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,keith green,
+ARCH,8520,5,ARCH 8520: 005,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,nicholas ault,
+ARCH,8610,1,ARCH 8610: 001,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,ufuk ersoy,
+ARCH,8710,1,ARCH 8710: 001,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,dustin gra albright,
+ARCH,8730,1,ARCH 8730: 001,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
+ARCH,8820,1,ARCH 8820: 001,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,8900,1,Directed Studies,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8920,1,ARCH 8920: 001,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,david allison,
+ARCH,8920,2,ARCH 8920: 002,0.24,0.7,0.06,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,8960,1,A+H Studio: Tectonic,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ART,1030,1,ART 1030: 001,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,lynette house,
+ART,1060,1,ART 1060: 001,0.68,0.18,0.05,0.0,0.09,0.0,0.0,0.0,carly drew,
+ART,1510,1,ART 1510: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,adrienne lichliter,
+ART,2050,1,ART 2050: 001,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,joel reese murray,
+ART,2070,1,ART 2070: 001,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,todd mcdonald,
+ART,2170,1,ART 2170: 001,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,nina jeanette kawar,
+AS,1100,1,AS 1100: 001,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,
+AS,4100,1,Nat Sec Policy II,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,steven price jordan,
+ASL,1010,1,ASL 1010: 001,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,joseph paul may,
+ASL,1010,2,ASL 1010: 002,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,joseph paul may,
+ASL,1020,1,ASL 1020: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,1020,2,ASL 1020: 002,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2010,1,ASL 2010: 001,0.13,0.6,0.07,0.07,0.13,0.0,0.0,0.0,william alton brant,
+ASL,2010,2,ASL 2010: 002,0.53,0.12,0.35,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,2020,1,ASL 2020: 001,0.69,0.13,0.13,0.0,0.06,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2020,2,ASL 2020: 002,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,3050,1,Deaf Studies,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,4010,1,ASL 4010: 001,0.36,0.55,0.0,0.0,0.0,0.0,0.0,0.09,stephen fitzmaurice,
+ASTR,1010,1,Solar System Astr,0.3,0.26,0.16,0.07,0.05,0.0,0.0,0.16,dina drozdov,
+ASTR,1020,1,Stellar Astronomy ONLINE,0.31,0.53,0.13,0.0,0.0,0.0,0.0,0.04,phillip flower,
+ASTR,1020,2,Stellar Astronomy ONLINE,0.27,0.35,0.27,0.0,0.03,0.0,0.0,0.06,phillip flower,
+ASTR,1020,3,Stellar Astronomy ONLINE,0.38,0.42,0.11,0.0,0.02,0.0,0.0,0.07,phillip flower,
+ASTR,1030,1,Solar Systm Astr Lab,0.46,0.19,0.19,0.04,0.12,0.0,0.0,0.0,mark leising,
+ASTR,1040,1,Stellar Astr Lab,0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,mark leising,
+ASTR,1040,3,Stellar Astr Lab,0.39,0.39,0.0,0.0,0.0,0.0,0.0,0.22,mark leising,
+ASTR,1040,5,Stellar Astr Lab,0.73,0.18,0.05,0.0,0.0,0.0,0.0,0.05,mark leising,
+ASTR,1040,6,Stellar Astr Lab,0.4,0.27,0.0,0.0,0.13,0.0,0.0,0.2,mark leising,
+AUD,2850,1,AUD 2850: 001,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUE,8160,1,AUE 8160: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8160,2,AUE 8160: 002,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,8170,3,AUE 8170: 003,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8290,4,AUE 8290: 004,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,timothy rhyne,
+AUE,8500,6,AUE 8500: 006,0.43,0.46,0.04,0.0,0.0,0.0,0.0,0.07,beshah ayalew,
+AUE,8550,16,AUE 8550: 016,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8660,7,Adv Matl Auto Appl,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
+AUE,8690,8,AUE 8690: 008,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8770,9,AUE 8770: 009,0.57,0.32,0.07,0.0,0.04,0.0,0.0,0.0,fadi kama abu-farha,
+AUE,8820,10,AUE 8820: 010,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,
+AUE,8860,11,AUE 8860: 011,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8900,400,AUE 8900: 400,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,
+AUE,8930,15,Autovation I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,
+AVS,2000,1,AVS 2000: 001,0.83,0.14,0.02,0.0,0.0,0.0,0.0,0.0,brian bolt,
+AVS,2050,1,AVS 2050: 001,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
+AVS,2060,1,AVS 2060: 001,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,2090,1,AVS 2090: 001,0.94,0.01,0.0,0.0,0.01,0.0,0.0,0.03,brian bolt,
+AVS,2110,1,AVS 2110: 001,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,michelle hall,
+AVS,3150,1,Animal Welfare,0.22,0.43,0.17,0.13,0.0,0.0,0.0,0.04,peter skewes,
+AVS,3750,1,Appl Animal Nutr,0.1,0.37,0.29,0.15,0.01,0.0,0.0,0.09,nathan long,
+AVS,4060,1,AVS 4060: 001,0.88,0.09,0.0,0.0,0.0,0.0,0.0,0.03,glenn birrenkott,
+AVS,4100,1,AVS 4100: 001,0.15,0.41,0.32,0.09,0.02,0.0,0.0,0.01,peter skewes,
+AVS,4120,1,Adv Equine Mgmt,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,4130,1,AVS 4130: 001,0.35,0.45,0.13,0.01,0.0,0.0,0.0,0.05,michelle hall,
+AVS,4170,1,AVS 4170: 001,0.38,0.5,0.0,0.04,0.04,0.0,0.0,0.04,kristine lan vernon,
+AVS,4530,1,Animal Reproduction,0.31,0.52,0.11,0.03,0.01,0.0,0.0,0.01,glenn birrenkott,
+AVS,4530,400,Animal Reproduction,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,6110,1,AVS 6110: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,
+AVS,8090,1,AVS 8090: 001,0.63,0.13,0.0,0.0,0.0,0.0,0.0,0.25,susan kay duckett,
+BCHM,3010,1,Molecular Biochem,0.08,0.33,0.26,0.25,0.03,0.0,0.0,0.05,meredith tei morris,
+BCHM,3010,2,Molecular Biochem(HON),0.56,0.24,0.12,0.0,0.0,0.0,0.0,0.08,meredith tei morris,True
+BCHM,3020,1,BCHM 3020: 001,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,meredith tei morris,
+BCHM,3020,2,BCHM 3020: 002,0.56,0.25,0.0,0.06,0.0,0.0,0.0,0.13,meredith tei morris,
+BCHM,3020,3,BCHM 3020: 003,0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,meredith tei morris,
+BCHM,3050,1,BCHM 3050: 001,0.24,0.22,0.27,0.18,0.04,0.0,0.0,0.04,james morris,
+BCHM,4060,1,BCHM 4060: 001,0.46,0.27,0.19,0.03,0.03,0.0,0.0,0.03,ashby burges bodine,
+BCHM,4320,1,Bioch of Metabolism,0.79,0.15,0.03,0.0,0.0,0.0,0.0,0.03,kimberly paul,
+BCHM,4360,1,Genes to Proteins,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
+BE,2100,1,BE 2100: 001,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,yi zheng,
+BE,3220,1,BE 3220: 001,0.29,0.29,0.32,0.04,0.0,0.0,0.0,0.07,tom owino,
+BE,4120,1,BE 4120: 001,0.3,0.4,0.25,0.0,0.0,0.0,0.0,0.05,caye marie drapcho,
+BE,4210,1,BE 4210: 001,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4240,1,BE 4240: 001,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,
+BE,4380,1,BE 4380: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,
+BIOE,1010,1,BIOE 1010: 001,0.85,0.09,0.05,0.0,0.0,0.0,0.0,0.0,agneta simionescu,
+BIOE,2010,1,BIOE 2010: 001,0.28,0.4,0.16,0.04,0.04,0.0,0.0,0.08,charles webb,
+BIOE,3020,1,BIOE 3020: 001,0.48,0.42,0.06,0.02,0.02,0.0,0.0,0.0,alexey ale vertegel,
+BIOE,3200,1,BIOE 3200: 001,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,
+BIOE,3210,1,BIOE 3210: 001,0.42,0.42,0.06,0.03,0.0,0.0,0.0,0.06,sarah harcum,
+BIOE,3700,1,BIOE 3700: 001,0.62,0.31,0.02,0.0,0.02,0.0,0.0,0.03,delphine dean,
+BIOE,4030,1,BIOE 4030: 001,0.97,0.02,0.0,0.0,0.0,0.0,0.0,0.01,john desjardins,
+BIOE,4230,1,BIOE 4230: 001,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,dan simionescu,
+BIOE,4310,1,BIOE 4310: 001,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,david kwartowitz,
+BIOE,8020,410,BIOE 8020: 410,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
+BIOE,8150,410,BIOE 8150: 410,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,
+BIOE,8470,1,BIOE 8470: 001,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,robert latour,
+BIOE,8490,1,BIOE 8490: 001,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,ying mei,
+BIOE,8500,3,Drug Delivery,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,jeoungsoo lee,
+BIOL,1040,1,General Biology II,0.3,0.33,0.24,0.06,0.02,0.0,0.0,0.05,nora espinoza,
+BIOL,1040,2,General Biology II,0.18,0.38,0.24,0.12,0.06,0.0,0.0,0.01,kalan ickes,
+BIOL,1040,3,General Biology II,0.18,0.22,0.3,0.16,0.08,0.0,0.0,0.08,salvatore sparace,
+BIOL,1040,4,General Biology II (HON),0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
+BIOL,1060,1,Gen Biology Lab II,0.26,0.26,0.37,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,2,Gen Biology Lab II,0.09,0.45,0.14,0.27,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,3,Gen Biology Lab II,0.16,0.47,0.16,0.16,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,4,Gen Biology Lab II,0.13,0.35,0.39,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,5,Gen Biology Lab II,0.22,0.35,0.09,0.04,0.26,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,6,Gen Biology Lab II,0.13,0.43,0.3,0.09,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,7,Gen Biology Lab II,0.14,0.57,0.1,0.1,0.0,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,8,Gen Biology Lab II,0.0,0.31,0.46,0.15,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1060,10,Gen Biology Lab II,0.15,0.3,0.4,0.15,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,11,Gen Biology Lab II,0.13,0.5,0.31,0.0,0.0,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1060,12,Gen Biology Lab II,0.71,0.21,0.0,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,13,Gen Biology Lab II,0.09,0.39,0.3,0.04,0.13,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,14,Gen Biology Lab II,0.17,0.26,0.35,0.09,0.13,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,15,Gen Biology Lab II,0.18,0.36,0.27,0.05,0.09,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,16,Gen Biology Lab II,0.23,0.41,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,17,Gen Biology Lab II,0.13,0.53,0.27,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,18,Gen Biology Lab II,0.24,0.35,0.18,0.18,0.0,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1060,19,Gen Biology Lab II,0.26,0.53,0.11,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,20,Gen Biology Lab II,0.06,0.56,0.22,0.11,0.06,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,21,Gen Biology Lab II,0.24,0.24,0.29,0.12,0.12,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,22,Gen Biology Lab II,0.13,0.44,0.38,0.0,0.06,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,23,Gen Biology Lab II,0.25,0.5,0.08,0.0,0.17,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,25,Gen Biology Lab II,0.29,0.33,0.19,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,26,Gen Biology Lab II,0.47,0.24,0.12,0.0,0.12,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1060,27,Gen Biology Lab II,0.25,0.5,0.06,0.13,0.06,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,28,Gen Biology Lab II,0.15,0.45,0.2,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,29,Gen Biology Lab II,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,30,Gen Biology Lab II,0.09,0.59,0.23,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,31,Gen Biology Lab II,0.19,0.52,0.19,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,34,Gen Biology Lab II,0.48,0.24,0.19,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,35,Gen Biology Lab II,0.25,0.58,0.0,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,36,Gen Biology Lab II,0.59,0.24,0.06,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1060,37,Gen Biology Lab II,0.3,0.35,0.17,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,38,Gen Biology Lab II,0.35,0.3,0.3,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,39,Gen Biology Lab II,0.43,0.3,0.22,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,40,Gen Biology Lab II,0.33,0.33,0.22,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1060,41,Gen Biology Lab II,0.25,0.31,0.31,0.06,0.06,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,42,Gen Biology Lab II,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,43,Gen Biology Lab II,0.36,0.29,0.14,0.07,0.07,0.0,0.0,0.07,tafadzwa kaisa,
+BIOL,1060,44,Gen Biology Lab II,0.09,0.36,0.18,0.18,0.09,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1090,1,Intro to Life Sci,0.9,0.07,0.0,0.0,0.02,0.0,0.0,0.0,renea chri hardwick,
+BIOL,1110,1,Prin of Biol II,0.32,0.35,0.24,0.03,0.06,0.0,0.0,0.0,dylan dittrich-reed,
+BIOL,1110,2,Prin of Biol II,0.3,0.44,0.17,0.07,0.01,0.0,0.0,0.02,robert kosinski,
+BIOL,1110,3,Prin of Biol II (HON),0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert kosinski,True
+BIOL,1200,1,Biological Inq Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,2,Biological Inq Lab,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14, christine minor,
+BIOL,1200,5,Biological Inq Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,6,Biological Inq Lab,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1200,12,Biological Inq Lab,0.33,0.56,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1230,1,Keys to Human Biol,0.3,0.28,0.27,0.13,0.01,0.0,0.0,0.0, christine minor,
+BIOL,2000,2,Biology in the News,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,2000,3,Biology in the News,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
+BIOL,2000,4,Biology in the News,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,barbara campbell,
+BIOL,2000,7,Biology in the News,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,michael sears,
+BIOL,2030,1,Human Disease & Soc,0.82,0.11,0.05,0.0,0.03,0.0,0.0,0.0, christine minor,
+BIOL,2040,1,"Environ, Energy and Society",0.33,0.39,0.18,0.06,0.03,0.0,0.0,0.03,john jenkins hains,
+BIOL,2110,1,Introduction to Toxicology,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,peter van den hurk,
+BIOL,2230,1,BIOL 2230: 001,0.37,0.41,0.13,0.04,0.03,0.0,0.0,0.02,john cummings,
+BIOL,2230,2,BIOL 2230: 002,0.37,0.39,0.15,0.07,0.01,0.0,0.0,0.02,john cummings,
+BIOL,3020,1,Invertebrate Biology,0.07,0.36,0.16,0.18,0.06,0.0,0.0,0.17,juan baeza migueles,
+BIOL,3040,1,Biology of Plants,0.11,0.38,0.32,0.12,0.08,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3060,1,BIOL 3060: 001,0.24,0.41,0.06,0.24,0.0,0.0,0.0,0.06,juan baeza migueles,
+BIOL,3060,2,BIOL 3060: 002,0.15,0.25,0.35,0.05,0.2,0.0,0.0,0.0,juan baeza migueles,
+BIOL,3060,3,BIOL 3060: 003,0.22,0.39,0.11,0.0,0.0,0.0,0.0,0.28,juan baeza migueles,
+BIOL,3060,4,BIOL 3060: 004,0.16,0.32,0.21,0.11,0.05,0.0,0.0,0.16,juan baeza migueles,
+BIOL,3080,1,BIOL 3080: 001,0.11,0.26,0.21,0.16,0.11,0.0,0.0,0.16,robert edwa ballard,
+BIOL,3080,2,BIOL 3080: 002,0.22,0.39,0.22,0.11,0.06,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3080,3,BIOL 3080: 003,0.28,0.33,0.33,0.06,0.0,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3080,4,BIOL 3080: 004,0.19,0.25,0.13,0.06,0.06,0.0,0.0,0.31,robert edwa ballard,
+BIOL,3130,1,Conservation Biology,0.35,0.48,0.0,0.09,0.04,0.0,0.0,0.04,shari lyn rodriguez,
+BIOL,3130,2,Conservation Biology,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+BIOL,3160,1,BIOL 3160: 001,0.25,0.49,0.18,0.04,0.02,0.0,0.0,0.01,tamara mcnutt-scott,
+BIOL,3200,1,BIOL 3200: 001,0.17,0.38,0.24,0.13,0.02,0.0,0.0,0.06,timothy spira,
+BIOL,3350,1,BIOL 3350: 001,0.36,0.38,0.13,0.04,0.07,0.0,0.0,0.03,margaret ptacek,
+BIOL,4010,1,Plant Physiology,0.13,0.13,0.19,0.35,0.13,0.0,0.0,0.08,douglas bielenberg,
+BIOL,4020,1,BIOL 4020: 001,0.31,0.31,0.08,0.0,0.23,0.0,0.0,0.08,douglas bielenberg,
+BIOL,4020,2,BIOL 4020: 002,0.43,0.29,0.14,0.07,0.0,0.0,0.0,0.07,douglas bielenberg,
+BIOL,4020,3,BIOL 4020: 003,0.31,0.38,0.08,0.15,0.0,0.0,0.0,0.08,douglas bielenberg,
+BIOL,4020,4,BIOL 4020: 004,0.33,0.4,0.13,0.07,0.0,0.0,0.0,0.07,douglas bielenberg,
+BIOL,4100,1,BIOL 4100: 001,0.37,0.39,0.2,0.02,0.0,0.0,0.0,0.02,john jenkins hains,
+BIOL,4140,1,Basic Immunology,0.72,0.22,0.0,0.0,0.02,0.0,0.0,0.04,charles rice,
+BIOL,4340,1,BIOL 4340: 001,0.25,0.33,0.42,0.0,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,2,BIOL 4340: 002,0.09,0.27,0.27,0.27,0.0,0.0,0.0,0.09,salvatore sparace,
+BIOL,4340,3,BIOL 4340: 003,0.08,0.77,0.08,0.0,0.0,0.0,0.0,0.08,salvatore sparace,
+BIOL,4340,4,BIOL 4340: 004,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,5,BIOL 4340: 005,0.18,0.45,0.27,0.09,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,6,BIOL 4340: 006,0.0,0.33,0.5,0.17,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4510,1,Biol Variation in Human Pop,0.25,0.5,0.13,0.0,0.06,0.0,0.0,0.06,katherine weisensee,
+BIOL,4610,1,Cell Biology,0.32,0.39,0.18,0.08,0.01,0.0,0.0,0.03,david feliciano,
+BIOL,4610,2,Cell Biology (HON),0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,david feliciano,True
+BIOL,4620,2,BIOL 4620: 002,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
+BIOL,4620,3,BIOL 4620: 003,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,lesly temesvari,
+BIOL,4620,4,BIOL 4620: 004,0.36,0.43,0.14,0.0,0.07,0.0,0.0,0.0,lesly temesvari,
+BIOL,4620,7,BIOL 4620: 007,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
+BIOL,4620,8,BIOL 4620: 008,0.63,0.25,0.0,0.0,0.06,0.0,0.0,0.06,lesly temesvari,
+BIOL,4640,1,BIOL 4640: 001,0.29,0.41,0.24,0.0,0.0,0.0,0.0,0.06,john cummings,
+BIOL,4700,1,Behavioral Ecology,0.42,0.41,0.12,0.02,0.01,0.0,0.0,0.03,michael childress,
+BIOL,4710,1,BIOL 4710: 001,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,michael childress,
+BIOL,4710,2,BIOL 4710: 002,0.55,0.15,0.0,0.1,0.0,0.0,0.0,0.2,michael childress,
+BIOL,4710,3,BIOL 4710: 003,0.63,0.21,0.05,0.0,0.0,0.0,0.0,0.11,michael childress,
+BIOL,4710,4,BIOL 4710: 004,0.65,0.12,0.12,0.0,0.0,0.0,0.0,0.12,michael childress,
+BIOL,4780,1,BIOL 4780: 001,0.47,0.33,0.03,0.07,0.0,0.0,0.0,0.1,jason denton,
+BIOL,4930,5,BIOL 4930: 005,0.64,0.14,0.14,0.07,0.0,0.0,0.0,0.0,lisa bain,
+BIOL,6010,1,BIOL 6010: 001,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
+BIOL,8450,1,Understanding Vertebrate Biol,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,tamara mcnutt-scott,
+BIOL,8470,1,Understanding Microbiology,0.59,0.38,0.0,0.0,0.0,0.0,0.0,0.03,harry kurtz,
+BIOL,8710,5,CS Ecological Risk Assess ETOX,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,stephen klaine,
+BIOL,8710,6,Proc Ecological Risk Assessmen,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
+BT,2200,1,BT 2200: 001,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,shannon go lawrence,
+BUS,1010,1,BUS 1010: 001,0.16,0.51,0.2,0.09,0.0,0.0,0.0,0.04,lance scott young,
+BUS,1010,2,BUS 1010: 002,0.1,0.59,0.24,0.03,0.03,0.0,0.0,0.0,michael giebner,
+BUS,1010,3,BUS 1010: 003,0.12,0.55,0.28,0.02,0.02,0.0,0.0,0.02,lance scott young,
+BUS,1010,4,BUS 1010: 004,0.0,0.57,0.27,0.03,0.07,0.0,0.0,0.07,michael giebner,
+BUS,1010,6,BUS 1010: 006,0.15,0.5,0.22,0.03,0.06,0.0,0.0,0.04,michael giebner,
+CE,2010,1,Statics,0.43,0.2,0.07,0.09,0.07,0.0,0.0,0.14,nighat yasmin,
+CE,2010,2,Statics,0.3,0.25,0.25,0.09,0.02,0.0,0.0,0.09,melissa sternhagen,
+CE,2010,3,Statics,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,
+CE,2010,4,Statics,0.36,0.3,0.2,0.02,0.0,0.0,0.0,0.11,melissa sternhagen,
+CE,2010,5,Statics,0.44,0.21,0.16,0.05,0.07,0.0,0.0,0.07,nighat yasmin,
+CE,2010,6,Statics,0.37,0.37,0.17,0.03,0.0,0.0,0.0,0.06,weichiang pang,
+CE,2010,7,Statics,0.27,0.52,0.09,0.03,0.03,0.0,0.0,0.06,ismail farajpour,
+CE,2060,1,CE 2060: 001,0.22,0.43,0.24,0.04,0.04,0.0,0.0,0.04,bryant nielson,
+CE,2060,2,CE 2060: 002,0.22,0.49,0.16,0.06,0.0,0.0,0.0,0.06,bryant nielson,
+CE,2080,1,CE 2080: 001,0.24,0.36,0.24,0.04,0.04,0.04,0.0,0.04,melissa sternhagen,
+CE,2080,2,CE 2080: 002,0.19,0.34,0.25,0.08,0.03,0.0,0.0,0.1,melissa sternhagen,
+CE,2080,3,CE 2080: 003,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,
+CE,2080,4,CE 2080: 004,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,
+CE,2550,1,CE 2550: 001,0.32,0.48,0.19,0.01,0.0,0.0,0.0,0.0,wayne sarasua,
+CE,3010,1,CE 3010: 001,0.17,0.17,0.29,0.1,0.17,0.0,0.0,0.12,scott schiff,
+CE,3110,1,CE 3110: 001,0.31,0.31,0.21,0.12,0.04,0.0,0.0,0.01,wayne sarasua,
+CE,3210,1,CE 3210: 001,0.59,0.3,0.09,0.0,0.0,0.0,0.0,0.02,charng-hsein juang,
+CE,3210,2,CE 3210: 002,0.4,0.4,0.08,0.04,0.08,0.0,0.0,0.0,qiushi chen,
+CE,3310,1,CE 3310: 001,0.45,0.29,0.17,0.05,0.02,0.0,0.0,0.02,james burati,
+CE,3410,1,CE 3410: 001,0.54,0.28,0.13,0.01,0.03,0.0,0.0,0.03,firat yener testik,
+CE,3420,1,CE 3420: 001,0.29,0.35,0.18,0.06,0.12,0.0,0.0,0.0,abdul khan,
+CE,3420,2,CE 3420: 002,0.39,0.49,0.1,0.02,0.0,0.0,0.0,0.0,ashok mishra,
+CE,3510,1,CE 3510: 001,0.5,0.33,0.1,0.03,0.0,0.0,0.0,0.05,ami esmaeilpoursaee,
+CE,3520,1,CE 3520: 001,0.31,0.31,0.19,0.1,0.03,0.0,0.0,0.06,yongxi huang,
+CE,3520,2,CE 3520: 002,0.41,0.37,0.13,0.04,0.04,0.0,0.0,0.02,bradley putman,
+CE,3530,1,CE 3530: 001,0.94,0.02,0.03,0.0,0.0,0.0,0.0,0.02,ronald andrus,
+CE,4010,1,CE 4010: 001,0.25,0.41,0.28,0.06,0.0,0.0,0.0,0.0,atamturktur russcher,
+CE,4020,1,CE 4020: 001,0.52,0.25,0.15,0.04,0.01,0.0,0.0,0.01,brandon ross,
+CE,4070,1,CE 4070: 001,0.19,0.35,0.32,0.13,0.0,0.0,0.0,0.0,weichiang pang,
+CE,4110,1,CE 4110: 001,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.07,jennifer ogle,
+CE,4120,1,Urban Transport Plan,0.21,0.45,0.24,0.03,0.03,0.0,0.0,0.03,mashrur chowdhury,
+CE,4210,1,CE 4210: 001,0.26,0.35,0.31,0.07,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,4340,1,CE 4340: 001,0.62,0.27,0.07,0.04,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,4470,1,CE 4470: 001,0.59,0.22,0.19,0.0,0.0,0.0,0.0,0.0,nigel gregory kaye,
+CE,4590,1,CE 4590: 001,0.48,0.47,0.06,0.0,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4620,1,CE 4620: 001,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,firat yener testik,
+CE,4910,1,Sustainable Proj Planning 3cr,0.73,0.2,0.05,0.0,0.02,0.0,0.0,0.0,leidy klotz,
+CE,6010,1,CE 6010: 001,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
+CE,6070,1,CE 6070: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CE,8010,1,CE 8010: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,8030,1,CE 8030: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,scott schiff,
+CE,8050,1,CE 8050: 001,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,bryant nielson,
+CE,8200,1,CE 8200: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,8280,1,CE 8280: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
+CE,8530,1,CE 8530: 001,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CE,8930,1,Selec Topics in C E,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
+CH,1010,1,General Chemistry,0.4,0.34,0.17,0.02,0.03,0.0,0.0,0.04,stephe schvaneveldt,
+CH,1010,2,General Chemistry,0.04,0.18,0.26,0.25,0.17,0.0,0.0,0.1,stephanie mccartney,
+CH,1010,3,General Chemistry,0.05,0.21,0.35,0.18,0.19,0.0,0.0,0.03,stephanie mccartney,
+CH,1010,4,General Chemistry,0.13,0.23,0.22,0.17,0.17,0.0,0.0,0.08,dennis taylor,
+CH,1010,400,General Chemistry,0.13,0.28,0.28,0.13,0.15,0.0,0.0,0.03,stephe schvaneveldt,
+CH,1020,1,General Chemistry,0.33,0.32,0.2,0.04,0.06,0.0,0.0,0.05,dennis taylor,
+CH,1020,2,General Chemistry,0.13,0.46,0.26,0.04,0.06,0.0,0.0,0.06,stephanie mccartney,
+CH,1020,3,General Chemistry,0.29,0.34,0.3,0.05,0.01,0.0,0.0,0.01,tania issa houjeiry,
+CH,1020,4,General Chemistry,0.34,0.43,0.13,0.06,0.01,0.0,0.0,0.04,karen an pressprich,
+CH,1020,5,General Chemistry,0.56,0.15,0.3,0.0,0.0,0.0,0.0,0.0,karen an pressprich,
+CH,1020,6,General Chemistry,0.29,0.36,0.25,0.05,0.03,0.0,0.0,0.03,dennis taylor,
+CH,1020,7,General Chemistry,0.2,0.45,0.27,0.04,0.02,0.0,0.0,0.02,kenneth wi rillings,
+CH,1020,8,General Chemistry,0.25,0.43,0.22,0.06,0.0,0.0,0.0,0.05,karen an pressprich,
+CH,1020,9,General Chemistry,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,kenneth wi rillings,
+CH,1020,10,General Chemistry,0.08,0.46,0.23,0.08,0.0,0.0,0.0,0.15,olt geiculescu,
+CH,1020,11,General Chemistry,0.2,0.48,0.2,0.07,0.01,0.0,0.0,0.05,kenneth wi rillings,
+CH,1020,12,General Chemistry,0.32,0.41,0.24,0.02,0.0,0.0,0.0,0.01,kenneth christensen,
+CH,1020,51,General Chemistry (HON),0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
+CH,1020,52,General Chemistry (HON),0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,shiou-jyh hwu,True
+CH,1050,1,Chem in Context I,0.23,0.49,0.24,0.04,0.0,0.0,0.0,0.0,thomas hickman,
+CH,1060,1,Chem in Context II,0.39,0.53,0.08,0.0,0.0,0.0,0.0,0.0,olt geiculescu,
+CH,1060,2,Chem in Context II,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,olt geiculescu,
+CH,1520,1,CH 1520: 001,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,richard marcus,
+CH,2010,1,CH 2010: 001,0.29,0.19,0.2,0.14,0.08,0.0,0.0,0.08,thomas hickman,
+CH,2011,2,CH 2011: 002,0.76,0.12,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2011,3,CH 2011: 003,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,sean 'connor,
+CH,2050,1,CH 2050: 001,0.48,0.3,0.18,0.0,0.0,0.0,0.0,0.05,william pennington,
+CH,2230,1,CH 2230: 001,0.34,0.35,0.21,0.02,0.06,0.0,0.0,0.02,jacob schroeder,
+CH,2230,2,CH 2230: 002,0.35,0.41,0.14,0.02,0.03,0.0,0.0,0.05,jacob schroeder,
+CH,2230,3,CH 2230: 003,0.26,0.29,0.24,0.08,0.05,0.0,0.0,0.08,thomas hickman,
+CH,2240,1,CH 2240: 001,0.32,0.47,0.1,0.08,0.02,0.0,0.0,0.01,tania issa houjeiry,
+CH,2240,2,CH 2240: 002,0.23,0.5,0.2,0.08,0.0,0.0,0.0,0.0,tania issa houjeiry,
+CH,2240,3,CH 2240: 003,0.2,0.36,0.27,0.07,0.04,0.0,0.0,0.05,jacob schroeder,
+CH,2240,4,CH 2240: 004,0.26,0.26,0.26,0.14,0.02,0.0,0.0,0.06,rhett smith,
+CH,2240,5,CH 2240: 005,0.32,0.39,0.19,0.06,0.01,0.0,0.0,0.03,modi wetzler,
+CH,2270,2,CH 2270: 002,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,3,CH 2270: 003,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2270,4,CH 2270: 004,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,7,CH 2270: 007,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,8,CH 2270: 008,0.69,0.25,0.0,0.06,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,9,CH 2270: 009,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,10,CH 2270: 010,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,sean 'connor,
+CH,2280,2,CH 2280: 002,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,sean 'connor,
+CH,2280,3,CH 2280: 003,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,4,CH 2280: 004,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,5,CH 2280: 005,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,8,CH 2280: 008,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,13,CH 2280: 013,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2280,14,CH 2280: 014,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,
+CH,2280,18,CH 2280: 018,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,23,CH 2280: 023,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,29,CH 2280: 029,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2290,1,CH 2290: 001,0.78,0.06,0.06,0.11,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2290,2,CH 2290: 002,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,3310,1,CH 3310: 001,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,arkady kholodenko,
+CH,3320,1,Physical Chemistry,0.33,0.44,0.18,0.03,0.03,0.0,0.0,0.0,steven stuart,
+CH,3320,2,Physical Chemistry,0.45,0.32,0.14,0.09,0.0,0.0,0.0,0.0,dvora perahia,
+CH,3400,1,CH 3400: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason mcneill,
+CH,3400,2,CH 3400: 002,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason mcneill,
+CH,3600,1,CH 3600: 001,0.34,0.39,0.2,0.07,0.0,0.0,0.0,0.0,brian dominy,
+CH,4110,1,CH 4110: 001,0.1,0.29,0.33,0.1,0.19,0.0,0.0,0.0,george chumanov,
+CH,4120,1,CH 4120: 001,0.27,0.64,0.0,0.0,0.09,0.0,0.0,0.0,jeffrey natha anker,
+CH,4130,1,Chem Aqueous Systems,0.29,0.29,0.36,0.07,0.0,0.0,0.0,0.0,cindy lee,
+CH,4500,1,CH 4500: 001,0.55,0.17,0.24,0.03,0.0,0.0,0.0,0.0,gauta bhattacharyya,
+CH,4520,1,CH 4520: 001,0.86,0.07,0.03,0.03,0.0,0.0,0.0,0.0,richard marcus,
+CH,8180,1,CH 8180: 001,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,stephen creager,
+CH,8220,1,CH 8220: 001,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,daniel whitehead,
+CH,8510,2,CH 8510: 002,0.94,0.0,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey natha anker,
+CH,8600,1,CH 8600: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
+CHE,1300,1,CHE 1300: 001,0.26,0.42,0.25,0.04,0.0,0.0,0.0,0.04,antho guiseppi-elie,
+CHE,1300,2,CHE 1300: 002,0.38,0.38,0.17,0.02,0.0,0.0,0.0,0.05,christopher norfolk,
+CHE,2200,1,CHE 2200: 001,0.14,0.08,0.3,0.22,0.16,0.0,0.0,0.11,mark thies,
+CHE,2200,2,CHE 2200: 002,0.11,0.23,0.31,0.11,0.14,0.0,0.0,0.09,mark thies,
+CHE,2300,1,CHE 2300: 001,0.09,0.23,0.3,0.19,0.17,0.0,0.0,0.02,sapna sarupria,
+CHE,2300,2,CHE 2300: 002,0.15,0.27,0.27,0.15,0.12,0.0,0.0,0.04,sapna sarupria,
+CHE,3210,1,CHE 3210: 001,0.16,0.22,0.33,0.24,0.04,0.0,0.0,0.02,christophe kitchens,
+CHE,3300,1,CHE 3300: 001,0.2,0.33,0.29,0.12,0.04,0.0,0.0,0.02,mark alan blenner,
+CHE,3530,1,CHE 3530: 001,0.14,0.5,0.3,0.07,0.0,0.0,0.0,0.0,mark roberts,
+CHE,4330,1,CHE 4330: 001,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,8450,2,E-Storage in Carbon Materials,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark roberts,
+CHIN,1020,1,CHIN 1020: 001,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
+CHIN,2020,1,CHIN 2020: 001,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,yanhua zhang,
+COM,1500,1,Intro to Human Com,0.63,0.31,0.02,0.01,0.01,0.0,0.0,0.03,eddie smith,
+COM,1500,2,Intro to Human Com,0.44,0.42,0.07,0.01,0.02,0.0,0.0,0.05,daniel lelan fecher,
+COM,1500,3,Intro to Human Com,0.7,0.21,0.05,0.0,0.01,0.0,0.0,0.03,eddie smith,
+COM,1500,4,Intro to Human Com,0.48,0.39,0.08,0.01,0.02,0.0,0.0,0.02,marianne her glaser,
+COM,1500,5,Intro to Human Com,0.45,0.44,0.05,0.02,0.02,0.0,0.0,0.02,marianne her glaser,
+COM,1500,6,Intro to Human Com,0.45,0.49,0.03,0.01,0.0,0.0,0.0,0.01,daniel lelan fecher,
+COM,2010,1,COMM 2010: 001,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,john steven spinda,
+COM,2010,2,COMM 2010: 002,0.46,0.33,0.17,0.04,0.0,0.0,0.0,0.0,brenden kendall,
+COM,2500,1,Public Speaking,0.44,0.33,0.11,0.0,0.06,0.0,0.0,0.06,brandon boatwright,
+COM,2500,2,Public Speaking,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,3,Public Speaking,0.44,0.33,0.0,0.11,0.06,0.0,0.0,0.06,christop wasilewski,
+COM,2500,4,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,5,Public Speaking,0.58,0.21,0.16,0.0,0.0,0.0,0.0,0.05,brandon boatwright,
+COM,2500,6,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,7,Public Speaking,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,8,Public Speaking,0.4,0.45,0.1,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,9,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,10,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,11,Public Speaking,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,12,Public Speaking,0.42,0.53,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
+COM,2500,13,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,14,Public Speaking,0.37,0.47,0.05,0.0,0.11,0.0,0.0,0.0,christop wasilewski,
+COM,2500,15,Public Speaking,0.45,0.35,0.15,0.0,0.0,0.0,0.0,0.05,caitlin baker,
+COM,2500,16,Public Speaking,0.75,0.15,0.05,0.05,0.0,0.0,0.0,0.0,the estate  geddes,
+COM,2500,17,Public Speaking,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,18,Public Speaking,0.42,0.37,0.11,0.05,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,19,Public Speaking,0.15,0.45,0.35,0.0,0.05,0.0,0.0,0.0,pauline matthey,
+COM,2500,20,Public Speaking,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,21,Public Speaking,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,
+COM,2500,22,Public Speaking,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,
+COM,2500,23,Public Speaking,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,caitlin baker,
+COM,2500,24,Public Speaking,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,kayla steele payne,
+COM,2500,25,Public Speaking (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,True
+COM,2500,400,Public Speaking,0.7,0.15,0.05,0.05,0.0,0.0,0.0,0.05,alexis zachar davis,
+COM,2500,401,Public Speaking,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
+COM,2500,402,Public Speaking,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
+COM,2500,403,Public Speaking,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
+COM,2500,500,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,3020,1,COMM 3020: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3080,1,Pub Comm & Pop Cult,0.55,0.26,0.15,0.02,0.02,0.0,0.0,0.0,chenjerai kumanyika,
+COM,3100,1,COMM 3100: 001,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3110,1,COMM 3110: 001,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,3200,1,COMM 3200: 001,0.88,0.04,0.0,0.0,0.04,0.0,0.0,0.04,wanda johnson,
+COM,3260,1,COMM 3260: 001,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
+COM,3480,1,COMM 3480: 001,0.31,0.44,0.17,0.06,0.0,0.0,0.0,0.02,melinda ra weathers,
+COM,3560,1,COMM 3560: 001,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristie leah byrum,
+COM,3610,1,COMM 3610: 001,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,lindsey dixon,
+COM,3660,1,EP: Advertising & Media,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,william reynolds,
+COM,3660,3,Live Broadcast Production,0.91,0.04,0.0,0.04,0.0,0.0,0.0,0.0,michael rodgers,
+COM,4250,1,COMM 4250: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4950,1,Senior Capstone Sem,0.67,0.1,0.24,0.0,0.0,0.0,0.0,0.0,chenjerai kumanyika,
+COM,8020,1,COMM 8020: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,8110,1,COMM 8110: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brenden kendall,
+CPSC,1010,1,Computer Science I,0.28,0.15,0.15,0.08,0.25,0.0,0.0,0.09,catherine hochrine,
+CPSC,1010,2,Computer Science I,0.29,0.2,0.16,0.07,0.16,0.0,0.0,0.13,kyla mcmullen,
+CPSC,1020,1,Computer Science II,0.38,0.38,0.07,0.04,0.02,0.0,0.0,0.11,catherine hochrine,
+CPSC,1020,2,Computer Science II,0.51,0.26,0.09,0.06,0.09,0.0,0.0,0.0,sabarish venka babu,
+CPSC,1110,1,CPSC 1110: 001,0.79,0.14,0.03,0.0,0.0,0.0,0.0,0.03,patrick sterling,
+CPSC,1110,2,CPSC 1110: 002,0.58,0.15,0.08,0.12,0.0,0.0,0.0,0.08,patrick sterling,
+CPSC,1110,3,CPSC 1110: 003,0.47,0.27,0.07,0.03,0.07,0.03,0.0,0.07,patrick sterling,
+CPSC,1110,4,CPSC 1110: 004,0.77,0.03,0.03,0.07,0.0,0.0,0.0,0.1,lauren elizab dukes,
+CPSC,2070,1,CPSC 2070: 001,0.36,0.32,0.14,0.07,0.09,0.0,0.0,0.02,larry hodges,
+CPSC,2070,2,CPSC 2070: 002,0.21,0.15,0.29,0.12,0.09,0.0,0.0,0.15,sandra hedetniemi,
+CPSC,2100,1,CPSC 2100: 001,0.26,0.26,0.15,0.15,0.07,0.0,0.0,0.11,rose lowe,
+CPSC,2120,1,Algs/Data Structures,0.36,0.29,0.18,0.07,0.07,0.0,0.0,0.04,feng luo,
+CPSC,2120,2,Algs/Data Structures,0.41,0.38,0.06,0.06,0.06,0.0,0.0,0.03,raghuveer mohan,
+CPSC,2150,1,CPSC 2150: 001,0.19,0.29,0.17,0.17,0.07,0.0,0.0,0.12,catherine hochrine,
+CPSC,2150,2,CPSC 2150: 002,0.48,0.3,0.09,0.09,0.03,0.0,0.0,0.0,john yates monteith,
+CPSC,2200,1,CPSC 2200: 001,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,patrick sterling,
+CPSC,2310,1,CPSC 2310: 001,0.47,0.26,0.1,0.06,0.06,0.0,0.0,0.04,rose lowe,
+CPSC,2910,1,CPSC 2910: 001,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,james jones,
+CPSC,2910,3,CPSC 2910: 003,0.73,0.0,0.0,0.0,0.09,0.0,0.0,0.18,james jones,
+CPSC,2910,4,CPSC 2910: 004,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,renee lambert,
+CPSC,2910,5,CPSC 2910: 005,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,renee lambert,
+CPSC,2910,6,CPSC 2910: 006,0.6,0.1,0.1,0.0,0.2,0.0,0.0,0.0,renee lambert,
+CPSC,2910,7,CPSC 2910: 007,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,renee lambert,
+CPSC,3220,1,Intro to Operating Systems,0.26,0.3,0.28,0.04,0.09,0.0,0.0,0.02,mark smotherman,
+CPSC,3300,1,CPSC 3300: 001,0.26,0.17,0.28,0.09,0.09,0.0,0.0,0.11,mark smotherman,
+CPSC,3500,1,CPSC 3500: 001,0.27,0.41,0.27,0.02,0.03,0.0,0.0,0.0,wayne goddard,
+CPSC,3520,1,Programming Systems,0.09,0.34,0.21,0.02,0.09,0.0,0.0,0.26,robert schalkoff,
+CPSC,3600,1,CPSC 3600: 001,0.23,0.3,0.09,0.09,0.11,0.0,0.0,0.18,jacob sorber,
+CPSC,3620,1,CPSC 3620: 001,0.28,0.28,0.3,0.02,0.0,0.0,0.0,0.12,amy apon,
+CPSC,3720,1,CPSC 3720: 001,0.33,0.47,0.14,0.02,0.0,0.0,0.0,0.04,stephen schaub,
+CPSC,4050,1,CPSC 4050: 001,0.26,0.3,0.13,0.04,0.13,0.0,0.0,0.13,donald henry house,
+CPSC,4140,1,CPSC 4140: 001,0.21,0.63,0.0,0.0,0.04,0.0,0.0,0.13,andrew duchowski,
+CPSC,4160,1,CPSC 4160: 001,0.36,0.36,0.28,0.0,0.0,0.0,0.0,0.0,brian malloy,
+CPSC,4240,1,CPSC 4240: 001,0.29,0.63,0.0,0.0,0.04,0.0,0.0,0.04,james martin,
+CPSC,4620,1,Database Management Systems,0.22,0.35,0.17,0.04,0.04,0.0,0.0,0.17,zijun wang,
+CPSC,4810,3,Topic:Software Dev for Mobile,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,roy pargas,
+CPSC,4810,13,Pro Gen of Video Game Media,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15,brian malloy,
+CPSC,4810,14,CI: Game & Python Programming,0.55,0.18,0.18,0.0,0.0,0.0,0.0,0.09,christina gardner,
+CPSC,4910,1,CPSC 4910: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
+CPSC,6050,1,CPSC 6050: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,donald henry house,
+CPSC,6140,1,CPSC 6140: 001,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,andrew duchowski,
+CPSC,6160,1,CPSC 6160: 001,0.52,0.38,0.0,0.0,0.0,0.05,0.0,0.05,brian malloy,
+CPSC,6240,1,CPSC 6240: 001,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,james martin,
+CPSC,6620,1,CPSC 6620: 001,0.29,0.53,0.12,0.0,0.03,0.0,0.0,0.03,zijun wang,
+CPSC,6810,1,Topic:Educational Technology,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christina gardner,
+CPSC,8080,1,CPSC 8080: 001,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+CPSC,8090,1,CPSC 8090: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,
+CPSC,8150,1,CPSC 8150: 001,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,timothy davis,
+CPSC,8190,1,CPSC 8190: 001,0.0,0.63,0.25,0.0,0.0,0.0,0.0,0.13,jerry tessendorf,
+CPSC,8220,1,CPSC 8220: 001,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,robert geist,
+CPSC,8400,1,CPSC 8400: 001,0.11,0.39,0.43,0.0,0.07,0.0,0.0,0.0,brian christop dean,
+CPSC,8520,1,CPSC 8520: 001,0.4,0.56,0.0,0.0,0.0,0.0,0.0,0.04,james martin,
+CPSC,8550,1,CPSC 8550: 001,0.45,0.27,0.18,0.0,0.0,0.0,0.0,0.09,jason hallstrom,
+CPSC,8620,1,CPSC 8620: 001,0.77,0.17,0.04,0.0,0.0,0.0,0.0,0.02,juan gilbert,
+CPSC,8630,1,CPSC 8630: 001,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,zijun wang,
+CPSC,8650,1,CPSC 8650: 001,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,zijun wang,
+CPSC,8750,1,CPSC 8750: 001,0.32,0.36,0.28,0.0,0.0,0.0,0.0,0.04,john mcgregor,
+CPSC,8810,1,Topic:Geometric Modeling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joshua levine,
+CRP,8010,1,Planning Process & Legal Found,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,
+CRP,8050,1,Plning Theory & Hist,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,mickey lauria,
+CRP,8090,1,CRP 8090: 001,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,barry nocks,
+CRP,8140,1,Public Transit,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
+CRP,8220,1,Urban Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+CRP,8890,3,S. Topic-Geodesign w/ CityEng.,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
+CSEN,2020,1,CSEN 2020: 001,0.4,0.23,0.13,0.15,0.04,0.0,0.0,0.04,dara michelle park,
+CSEN,4520,1,CSEN 4520: 001,0.52,0.39,0.0,0.0,0.0,0.0,0.0,0.09,haibo liu,
+CSM,1500,1,CSM 1500: 001,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,1500,2,CSM 1500: 002,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2020,1,CSM 2020: 001,0.1,0.43,0.38,0.1,0.0,0.0,0.0,0.0,shima clarke,
+CSM,2020,2,CSM 2020: 002,0.24,0.53,0.24,0.0,0.0,0.0,0.0,0.0,shima clarke,
+CSM,2040,1,CSM 2040: 001,0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2040,2,CSM 2040: 002,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2050,1,CSM 2050: 001,0.42,0.21,0.21,0.16,0.0,0.0,0.0,0.0,jason lucas,
+CSM,2050,2,CSM 2050: 002,0.3,0.25,0.35,0.1,0.0,0.0,0.0,0.0,jason lucas,
+CSM,3050,1,CSM 3050: 001,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3050,2,CSM 3050: 002,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3520,1,CSM 3520: 001,0.24,0.67,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,3520,2,CSM 3520: 002,0.06,0.47,0.35,0.12,0.0,0.0,0.0,0.0,christine piper,
+CSM,3530,1,CSM 3530: 001,0.3,0.65,0.04,0.0,0.0,0.0,0.0,0.0,james packer smith,
+CSM,3530,2,CSM 3530: 002,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,james packer smith,
+CSM,4540,1,CSM 4540: 001,0.2,0.4,0.4,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4540,2,CSM 4540: 002,0.2,0.47,0.33,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8620,1,Personnel Mgt & Neg,0.13,0.38,0.38,0.0,0.0,0.0,0.0,0.13,roger william liska,
+CSM,8620,400,Personnel Mgt & Neg,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CU,1000,1,CU 1000: 001,0.0,0.0,0.0,0.0,0.0,0.87,0.11,0.02,jeffrey appling,
+CU,1010,1,CU 1010: 001,0.38,0.38,0.13,0.0,0.08,0.0,0.0,0.04,rise jean sheriff,
+CU,1010,2,CU 1010: 002,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,cecelia hamby,
+CU,1010,3,CU 1010: 003,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+CU,1010,5,CU 1010: 005,0.85,0.07,0.0,0.0,0.04,0.0,0.0,0.04,mary mcp von kaenel,
+CU,1010,6,CU 1010: 006,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,mary mcp von kaenel,
+CU,1010,10,CU 1010: 010,0.63,0.2,0.1,0.03,0.03,0.0,0.0,0.0, elaine richardson,
+CU,2010,1,CU 2010: 001,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,leidy klotz,
+DANC,1400,1,Jazz Dance I,0.91,0.0,0.05,0.0,0.05,0.0,0.0,0.0,cheryl hosler,
+DANC,1500,1,Modern Dance I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,cheryl hosler,
+DPA,3070,1,DPA 3070: 001,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,timothy curtis,
+ECE,2010,1,Logic & Comp Device,0.21,0.27,0.19,0.31,0.0,0.0,0.0,0.02,lin zhu,
+ECE,2020,1,Electric Circuits I,0.17,0.4,0.18,0.12,0.11,0.0,0.0,0.02,william harrell,
+ECE,2090,2,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,timothy burg,
+ECE,2090,3,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,
+ECE,2090,4,Logic Lab,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,
+ECE,2110,1,ECE 2110: 001,0.58,0.25,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,
+ECE,2110,3,ECE 2110: 003,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
+ECE,2120,7,ECE 2120: 007,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,timothy burg,
+ECE,2220,1,ECE 2220: 001,0.13,0.22,0.24,0.14,0.19,0.0,0.0,0.09,william reid,
+ECE,2230,1,ECE 2230: 001,0.25,0.14,0.25,0.11,0.04,0.0,0.0,0.21,harlan russell,
+ECE,2620,1,Elec Circuits II,0.24,0.29,0.29,0.11,0.05,0.0,0.0,0.01,richard groff,
+ECE,2620,2,Elec Circuits II (HON),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
+ECE,2720,1,Comp Organization,0.24,0.27,0.32,0.09,0.09,0.0,0.0,0.0,william reid,
+ECE,2730,1,Computer Org Lab,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,2730,2,Computer Org Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,2730,3,Computer Org Lab,0.5,0.25,0.13,0.0,0.06,0.0,0.0,0.06,timothy burg,
+ECE,2730,4,Computer Org Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,2730,5,Computer Org Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,3070,1,ECE 3070: 001,0.48,0.17,0.15,0.03,0.01,0.0,0.0,0.16,timothy burg,
+ECE,3070,2,ECE 3070: 002,0.39,0.27,0.14,0.05,0.01,0.0,0.0,0.15,timothy burg,
+ECE,3070,3,ECE 3070: 003,0.96,0.02,0.0,0.02,0.0,0.0,0.0,0.0,sung- kim,
+ECE,3090,1,ECE 3090: 001,0.79,0.05,0.0,0.0,0.0,0.0,0.0,0.16,timothy burg,
+ECE,3090,4,ECE 3090: 004,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
+ECE,3090,5,ECE 3090: 005,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
+ECE,3090,6,ECE 3090: 006,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
+ECE,3090,8,ECE 3090: 008,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,timothy burg,
+ECE,3090,9,ECE 3090: 009,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,3090,11,ECE 3090: 011,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
+ECE,3090,14,ECE 3090: 014,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
+ECE,3110,1,ECE 3110: 001,0.73,0.07,0.07,0.0,0.0,0.0,0.0,0.13,timothy burg,
+ECE,3110,3,ECE 3110: 003,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,3120,3,ECE 3120: 003,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,timothy burg,
+ECE,3120,4,ECE 3120: 004,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,timothy burg,
+ECE,3170,1,Rand Signal Analysis,0.39,0.47,0.14,0.0,0.0,0.0,0.0,0.0,stephen hubbard,
+ECE,3170,2,Rand Signal Analysis (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,carl baum,True
+ECE,3200,1,Electronics I,0.44,0.37,0.1,0.07,0.0,0.0,0.0,0.01,stephen hubbard,
+ECE,3210,1,ECE 3210: 001,0.15,0.39,0.3,0.13,0.01,0.0,0.0,0.01,stephen hubbard,
+ECE,3220,1,Intro Operating Sys,0.39,0.43,0.11,0.0,0.04,0.0,0.0,0.04,mark smotherman,
+ECE,3270,1,ECE 3270: 001,0.1,0.36,0.19,0.07,0.17,0.0,0.0,0.12,melissa crawl smith,
+ECE,3300,1,Signals & Systems,0.23,0.16,0.26,0.2,0.08,0.0,0.0,0.07,carl baum,
+ECE,3520,1,Programming Systems,0.5,0.35,0.12,0.0,0.0,0.0,0.0,0.04,robert schalkoff,
+ECE,3600,1,ECE 3600: 001,0.35,0.21,0.26,0.09,0.09,0.0,0.0,0.0,ramtin hadidi,
+ECE,3710,1,ECE 3710: 001,0.29,0.38,0.21,0.06,0.06,0.0,0.0,0.0,william reid,
+ECE,3720,1,ECE 3720: 001,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,3720,2,ECE 3720: 002,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,3720,4,ECE 3720: 004,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,timothy burg,
+ECE,3800,1,ECE 3800: 001,0.14,0.41,0.25,0.08,0.12,0.0,0.0,0.0,anthony martin,
+ECE,3810,1,ECE 3810: 001,0.33,0.41,0.22,0.0,0.0,0.0,0.0,0.04,eric gordon johnson,
+ECE,4090,1,ECE 4090: 001,0.47,0.3,0.21,0.0,0.0,0.0,0.0,0.02,darren dawson,
+ECE,4170,1,ECE 4170: 001,0.29,0.41,0.0,0.06,0.0,0.0,0.0,0.24,darren dawson,
+ECE,4190,1,ECE 4190: 001,0.6,0.28,0.04,0.04,0.04,0.0,0.0,0.0,keith corzine,
+ECE,4200,1,ECE 4200: 001,0.29,0.18,0.38,0.06,0.03,0.0,0.0,0.06,elham makram,
+ECE,4270,1,ECE 4270: 001,0.2,0.29,0.29,0.23,0.0,0.0,0.0,0.0,carl baum,
+ECE,4380,1,ECE 4380: 001,0.31,0.31,0.31,0.0,0.0,0.0,0.0,0.06,harlan russell,
+ECE,4400,1,ECE 4400: 001,0.38,0.41,0.18,0.0,0.0,0.0,0.0,0.03,kuang-ching wang,
+ECE,4680,1,ECE 4680: 001,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,adam hoover,
+ECE,4700,1,ECE 4700: 001,0.4,0.38,0.09,0.11,0.0,0.0,0.0,0.02,todd hubing,
+ECE,4950,1,ECE 4950: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,4960,1,ECE 4960: 001,0.48,0.41,0.11,0.0,0.0,0.0,0.0,0.0,richard groff,
+ECE,6170,1,ECE 6170: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,darren dawson,
+ECE,6190,1,ECE 6190: 001,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,keith corzine,
+ECE,6200,1,ECE 6200: 001,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,elham makram,
+ECE,6380,1,ECE 6380: 001,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
+ECE,6400,1,ECE 6400: 001,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,
+ECE,6680,1,ECE 6680: 001,0.69,0.06,0.25,0.0,0.0,0.0,0.0,0.0,adam hoover,
+ECE,6930,2,CMOS Analog VLSI,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,
+ECE,8240,1,ECE 8240: 001,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,ramtin hadidi,
+ECE,8400,1,ECE 8400: 001,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,william harrell,
+ECE,8440,1,ECE 8440: 001,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,john gowdy,
+ECE,8480,1,ECE 8480: 001,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
+ECE,8720,1,ECE 8720: 001,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,robert schalkoff,
+ECE,8740,1,ECE 8740: 001,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
+ECE,8930,1,Fiber Lasers,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,liang dong,
+ECE,9910,32,ECE 9910: 032,0.0,0.0,0.0,0.0,0.0,0.6,0.4,0.0,hai ying shen,
+ECON,2000,1,Economic Concepts,0.22,0.22,0.11,0.17,0.17,0.0,0.0,0.11,mallika garg,
+ECON,2000,2,Economic Concepts,0.14,0.16,0.43,0.05,0.03,0.0,0.0,0.19,mallika garg,
+ECON,2000,3,Economic Concepts,0.25,0.28,0.19,0.09,0.16,0.0,0.0,0.03,miren ivankovic,
+ECON,2110,1,Principles of Microeconomics,0.18,0.33,0.43,0.05,0.03,0.0,0.0,0.0,eric peter makela,
+ECON,2110,2,Principles of Microeconomics,0.13,0.55,0.18,0.0,0.13,0.0,0.0,0.0,ce castellon chicas,
+ECON,2110,3,Principles of Microeconomics,0.12,0.44,0.33,0.07,0.05,0.0,0.0,0.0,adam millsap,
+ECON,2110,4,Principles of Microeconomics,0.23,0.45,0.15,0.1,0.03,0.0,0.0,0.05,andew swanson,
+ECON,2110,5,Principles of Microeconomics,0.35,0.3,0.23,0.08,0.03,0.0,0.0,0.03,jacob burgdorf,
+ECON,2110,6,Principles of Microeconomics,0.26,0.26,0.23,0.21,0.02,0.0,0.0,0.02,timothy andr bersak,
+ECON,2110,7,Principles of Microeconomics,0.17,0.41,0.3,0.08,0.01,0.0,0.0,0.03,adam millsap,
+ECON,2110,8,Principles of Microeconomics,0.36,0.28,0.25,0.07,0.04,0.0,0.0,0.01,miren ivankovic,
+ECON,2110,10,Principles of Microeconomics,0.22,0.3,0.26,0.04,0.02,0.0,0.0,0.15,robert dew tollison,
+ECON,2110,11,Principles of Microeconomics,0.15,0.44,0.31,0.06,0.02,0.0,0.0,0.02,meng liu,
+ECON,2110,12,Principles of Microeconomics,0.16,0.37,0.18,0.05,0.08,0.0,0.0,0.16,john devin shippey,
+ECON,2110,13,Principles of Microecon(HON),0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,robert kennet fleck,True
+ECON,2120,1,Principles of Macro,0.16,0.37,0.37,0.0,0.11,0.0,0.0,0.0,scott baier,
+ECON,2120,2,Principles of Macro,0.06,0.44,0.5,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,3,Principles of Macro,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0,scott baier,
+ECON,2120,4,Principles of Macro,0.21,0.47,0.26,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,5,Principles of Macro,0.18,0.35,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,6,Principles of Macro,0.16,0.37,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,7,Principles of Macro,0.11,0.22,0.56,0.06,0.0,0.0,0.0,0.06,scott baier,
+ECON,2120,8,Principles of Macro,0.11,0.53,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,9,Principles of Macro,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,10,Principles of Macro,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,11,Principles of Macro,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,12,Principles of Macro,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,scott baier,
+ECON,2120,13,Principles of Macro,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,14,Principles of Macro,0.26,0.37,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,15,Principles of Macro,0.21,0.37,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,16,Principles of Macro,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,17,Principles of Macro,0.21,0.53,0.21,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,18,Principles of Macro,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,19,Principles of Macro,0.17,0.39,0.33,0.11,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,20,Principles of Macro,0.3,0.45,0.23,0.0,0.0,0.0,0.0,0.03,anne anders,
+ECON,2120,21,Principles of Macro,0.05,0.25,0.25,0.08,0.12,0.0,0.0,0.26,ralph charles allen,
+ECON,2120,22,Principles of Macro,0.1,0.45,0.25,0.1,0.08,0.0,0.0,0.03,anne anders,
+ECON,2120,23,Principles of Macro,0.35,0.4,0.18,0.0,0.05,0.0,0.0,0.03,yukun sun,
+ECON,2120,24,Principles of Macro,0.09,0.18,0.24,0.09,0.16,0.0,0.0,0.24,ralph charles allen,
+ECON,2120,25,Principles of Macro,0.25,0.55,0.1,0.1,0.0,0.0,0.0,0.0,lyudmyla ta sonchak,
+ECON,2120,26,Principles of Macro,0.26,0.6,0.12,0.02,0.0,0.0,0.0,0.0,yukun sun,
+ECON,3020,1,Money and Banking,0.2,0.4,0.15,0.1,0.13,0.0,0.0,0.03,danielle zanzalari,
+ECON,3060,1,Managerial Economics,0.22,0.36,0.25,0.06,0.03,0.0,0.0,0.08,john devin shippey,
+ECON,3100,1,International Econ,0.19,0.38,0.31,0.06,0.05,0.0,0.0,0.02,michal jerzmanowski,
+ECON,3140,1,Intermediate Micro,0.21,0.26,0.16,0.0,0.11,0.0,0.0,0.26,patrick warren,
+ECON,3140,2,Intermediate Micro,0.42,0.31,0.19,0.04,0.04,0.0,0.0,0.0,molly espey,
+ECON,3140,3,Intermediate Micro,0.11,0.43,0.29,0.07,0.07,0.0,0.0,0.04,tomas cvrcek,
+ECON,3150,1,Intermediate Macro,0.25,0.16,0.3,0.16,0.12,0.0,0.0,0.02,wesley harris,
+ECON,3150,2,Intermediate Macro,0.37,0.4,0.2,0.0,0.03,0.0,0.0,0.0,sergey vla mityakov,
+ECON,3440,1,Property Rights,0.17,0.43,0.22,0.09,0.04,0.0,0.0,0.04,dar litsukova-bokar,
+ECON,4020,1,Law and Economics,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,thomas wins hazlett,
+ECON,4050,1,Intro to Econometric,0.36,0.21,0.36,0.07,0.0,0.0,0.0,0.0,jaqueline oliveira,
+ECON,4050,2,Intro to Econometric,0.31,0.15,0.31,0.0,0.23,0.0,0.0,0.0,jaqueline oliveira,
+ECON,4050,3,Intro to Econometric,0.18,0.18,0.55,0.09,0.0,0.0,0.0,0.0,jaqueline oliveira,
+ECON,4050,4,Intro to Econometric,0.17,0.25,0.17,0.33,0.08,0.0,0.0,0.0,jaqueline oliveira,
+ECON,4110,1,Econ of Education,0.31,0.31,0.23,0.08,0.04,0.0,0.0,0.04,chungsang lam,
+ECON,4130,1,International Macro,0.17,0.44,0.17,0.17,0.06,0.0,0.0,0.0,michal jerzmanowski,
+ECON,4240,1,Organization of Ind,0.39,0.39,0.15,0.0,0.0,0.0,0.0,0.06,matthew lewis,
+ECON,4250,1,Antitrust Economics,0.44,0.36,0.17,0.0,0.0,0.0,0.0,0.03,robert dew tollison,
+ECON,4260,1,Sem Sport Economics,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,4270,1,Dev American Economy,0.27,0.53,0.17,0.03,0.0,0.0,0.0,0.0,howard ne bodenhorn,
+ECON,4350,1,Family Economics,0.06,0.45,0.27,0.09,0.06,0.0,0.0,0.06,tomas cvrcek,
+ECON,4400,1,Game Theory,0.25,0.5,0.08,0.0,0.04,0.0,0.0,0.13,daniel wood,
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.21,0.36,0.29,0.0,0.0,0.0,0.0,0.14,scott templeton,
+ECON,6130,1,ECON 6130: 001,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,
+ECON,8020,1,Adv Econ Concepts and Applic I,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,william dougan,
+ECON,8050,1,ECON 8050: 001,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,8070,1,ECON 8070: 001,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,thomas alvin mroz,
+ECON,8200,1,Public Finance,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william dougan,
+ECON,9010,1,Price Theory,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,daniel wood,
+ECON,9090,1,ECON 9090: 001,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,gerald dwyer,
+ECON,9170,1,Advanced Seminar Labor Econ,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
+ED,1050,1,ED 1050: 001,0.65,0.2,0.0,0.0,0.1,0.0,0.0,0.05,patrick womac,
+ED,1050,2,ED 1050: 002,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,patrick womac,
+ED,1050,3,ED 1050: 003,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,rory phil tannebaum,
+ED,1050,4,ED 1050: 004,0.8,0.08,0.0,0.0,0.08,0.0,0.0,0.04,rory phil tannebaum,
+ED,3220,1,ED 3220: 001,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,deborah smith,
+ED,8380,400,Physical Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard dallm white,
+ED,8380,537,Literacy Lessons Designed for,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,vicki steadman,
+ED,8390,505,ED 8390: 505,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0, paltrow zwerdling,
+ED,8600,400,ED 8600: 400,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,
+ED,9010,1,Research Design/ Infer. Stats,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,
+EDC,3900,10,EDC 3900: 010,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
+EDC,3900,12,EDC 3900: 012,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
+EDC,8060,1,EDC 8060: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
+EDC,8070,400,EDC 8070: 400,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,kristen leigh moran,
+EDC,8190,1,EDC 8190: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
+EDEC,2200,1,EDEC 2200: 001,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,ysaaca axelrod,
+EDEL,3100,1,EDEL 3100: 001,0.91,0.04,0.0,0.0,0.04,0.0,0.0,0.0,alison eliz leonard,
+EDEL,3100,2,EDEL 3100: 002,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,jacqueline sh rosen,
+EDEL,3210,1,EDEL 3210: 001,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4050,1,EDEL 4050: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
+EDEL,4510,1,Elem Methods in Science Tchg,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,cynthia chri deaton,
+EDEL,4520,2,EDEL 4520: 002,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,james kwame dogbey,
+EDEL,4670,1,EDEL 4670: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDEL,4870,1,EDEL 4870: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDF,3010,1,Principles of American Educat,0.2,0.36,0.32,0.0,0.0,0.0,0.0,0.12,robert green,
+EDF,3010,2,Principles of American Educat,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,robert green,
+EDF,3010,3,Principles of American Educat,0.54,0.35,0.08,0.03,0.0,0.0,0.0,0.0,suzanne rosenblith,
+EDF,3020,1,Educ Psych,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,
+EDF,3020,2,Educ Psych,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,deborah switzer,
+EDF,3020,3,Educ Psych,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,
+EDF,3020,5,Educ Psych,0.4,0.3,0.23,0.03,0.03,0.0,0.0,0.0,penelope mar vargas,
+EDF,3150,1,Technology Skills for Learning,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,ryan visser,
+EDF,3150,2,Technology Skills for Learning,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,3340,1,Child Growth and Dev,0.69,0.21,0.07,0.0,0.0,0.0,0.0,0.03,winston holton,
+EDF,3340,2,Child Growth and Dev,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
+EDF,3350,1,Adol Growth & Dev,0.31,0.52,0.17,0.0,0.0,0.0,0.0,0.0,david barrett,
+EDF,3350,2,Adol Growth & Dev,0.67,0.23,0.1,0.0,0.0,0.0,0.0,0.0,david barrett,
+EDF,4250,1,EDF 4250: 001,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,2,Digital Media & Learning,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,david matthew boyer,
+EDF,8800,400,EDF 8800: 400,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,9050,1,EDF 9050: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,danielle chri herro,
+EDL,7150,1,EDL 7150: 001,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,hans william klar,
+EDL,7350,500,EDL 7350: 500,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,
+EDL,7400,500,EDL 7400: 500,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,frederick buskey,
+EDL,8850,400,Selected Topics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,leslie gonzales,
+EDL,9100,400,Intro Phd Seminar,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,jane lindle,
+EDLT,4580,1,EDLT 4580: 001,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4600,1,Teaching Reading Grades 2-6,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
+EDLT,4620,1,EDLT 4620: 001,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4630,1,EDLT 4630: 001,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,ysaaca axelrod,
+EDLT,8670,400,EDLT 8670: 400,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8670,401,EDLT 8670: 401,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,phillip mich wilder,
+EDLT,8740,501,EDLT 8740: 501,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDSC,4370,1,EDSC 4370: 001,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,robert horton,
+EDSC,8920,400,EDSC 8920: 400,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeff marshall,
+EDSP,3700,1,Intro to Special Ed,0.76,0.15,0.06,0.0,0.03,0.0,0.0,0.0,joseph benedic ryan,
+EDSP,3700,2,Intro to Special Ed,0.78,0.05,0.1,0.03,0.05,0.0,0.0,0.0,joseph benedic ryan,
+EDSP,3700,3,Intro to Special Ed,0.78,0.12,0.07,0.0,0.02,0.0,0.0,0.0,robin parks ennis,
+EDSP,3730,1,EDSP 3730: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
+EDSP,3750,1,EDSP 3750: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
+EDSP,4910,1,EDSP 4910: 001,0.67,0.29,0.0,0.0,0.04,0.0,0.0,0.0,antonis katsiyannis,
+EDSP,4950,1,EDSP 4950: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,martha hodge,
+EDSP,4980,1,EDSP 4980: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,beverly lu romansky,
+EES,2020,1,EES 2020: 001,0.49,0.44,0.02,0.0,0.02,0.0,0.0,0.02,kevin thom finneran,
+EES,4010,1,EES 4010: 001,0.41,0.49,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+EES,4010,2,EES 4010: 002,0.15,0.58,0.23,0.02,0.0,0.0,0.0,0.02,john coates,
+EES,4020,1,EES 4020: 001,0.41,0.41,0.09,0.0,0.05,0.0,0.0,0.05,david allen ladner,
+EES,4750,1,EES 4750: 001,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,4840,1,Solid Waste Mgt,0.29,0.55,0.1,0.03,0.03,0.0,0.0,0.0,thomas overcamp,
+EES,4850,1,EES 4850: 001,0.3,0.59,0.08,0.03,0.0,0.0,0.0,0.0,mark schlautman,
+EES,6110,1,EES 6110: 001,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,timothy devol,
+EES,6850,1,EES 6850: 001,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mark schlautman,
+EES,8030,1,EES 8030: 001,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,tanju karanfil,
+EES,8040,1,EES 8040: 001,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,
+EES,8050,1,EES 8050: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tanju karanfil,
+EES,8120,1,EES 8120: 001,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,lin shuller-nickles,
+EES,8200,1,EES 8200: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,annick anctil,
+EES,8450,1,EES 8450: 001,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,cindy lee,
+EES,8830,2,Advanced Topics in Health Phys,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,timothy devol,
+ELE,3010,1,Intro to Entre,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+ELE,3010,2,Intro to Entre,0.56,0.38,0.05,0.0,0.0,0.0,0.0,0.0,anthony pa santella,
+ELE,4010,1,Exec Lead & Entr II,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,anthony pa santella,
+ENGL,1030,1,Accelerated Composition,0.47,0.37,0.05,0.11,0.0,0.0,0.0,0.0,leslie ann salley,
+ENGL,1030,3,Accelerated Composition,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,megan leigh roberts,
+ENGL,1030,4,Accelerated Composition,0.58,0.32,0.0,0.0,0.0,0.0,0.0,0.11,stephanie pai beard,
+ENGL,1030,5,Accelerated Composition,0.21,0.37,0.26,0.05,0.11,0.0,0.0,0.0,jacqueline fetzer,
+ENGL,1030,6,Accelerated Composition,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,kristen gay,
+ENGL,1030,7,Accelerated Composition,0.5,0.25,0.15,0.0,0.05,0.0,0.0,0.05,leslie ann salley,
+ENGL,1030,9,Accelerated Composition,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,jacqueline fetzer,
+ENGL,1030,10,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,stephanie pai beard,
+ENGL,1030,11,Accelerated Composition,0.5,0.4,0.05,0.0,0.05,0.0,0.0,0.0,leslie ann salley,
+ENGL,1030,12,Accelerated Composition,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,david stubblefield,
+ENGL,1030,14,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,dustin kyle pearson,
+ENGL,1030,15,Accelerated Composition,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,leslie ann salley,
+ENGL,1030,16,Accelerated Composition,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,david stubblefield,
+ENGL,1030,17,Accelerated Composition,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,dustin kyle pearson,
+ENGL,1030,18,Accelerated Composition,0.45,0.3,0.1,0.0,0.1,0.0,0.0,0.05,adrian carson,
+ENGL,1030,19,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathryn eliz harner,
+ENGL,1030,21,Accelerated Composition,0.58,0.26,0.05,0.0,0.0,0.0,0.0,0.11,caleb andr milligan,
+ENGL,1030,24,Accelerated Composition,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,laura ann smith,
+ENGL,1030,25,Accelerated Composition,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,hilary richards,
+ENGL,1030,26,Accelerated Composition,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,catherine mar blass,
+ENGL,1030,28,Accelerated Composition,0.74,0.16,0.0,0.05,0.0,0.0,0.0,0.05,kathryn eliz harner,
+ENGL,1030,29,Accelerated Composition,0.37,0.42,0.16,0.0,0.05,0.0,0.0,0.0,caleb andr milligan,
+ENGL,1030,32,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,laura ann smith,
+ENGL,1030,33,Accelerated Composition,0.84,0.05,0.05,0.05,0.0,0.0,0.0,0.0,hilary richards,
+ENGL,1030,35,Accelerated Composition,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,kiera angeli prince,
+ENGL,1030,36,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katherine elrick,
+ENGL,1030,37,Accelerated Composition,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,shawn andrew stowe,
+ENGL,1030,38,Accelerated Composition,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,katherine hanzalik,
+ENGL,1030,39,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
+ENGL,1030,40,Accelerated Composition,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,joshua lee martin,
+ENGL,1030,41,Accelerated Composition,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,
+ENGL,1030,42,Accelerated Composition,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,katherine elrick,
+ENGL,1030,44,Accelerated Composition,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,katherine hanzalik,
+ENGL,1030,46,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
+ENGL,1030,48,Accelerated Composition,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,joshua lee martin,
+ENGL,1030,51,Accelerated Composition,0.85,0.0,0.05,0.0,0.05,0.0,0.0,0.05,mari elena ramler,
+ENGL,1030,52,Accelerated Composition,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,kiera angeli prince,
+ENGL,1030,53,Accelerated Composition,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,justyna ann pekalak,
+ENGL,1030,54,Accelerated Composition,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,eric thomas hall,
+ENGL,1030,57,Accelerated Composition,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,kristen gay,
+ENGL,1030,58,Accelerated Composition,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,samuel jacks fuller,
+ENGL,1030,59,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,alyssa chris carver,
+ENGL,1030,60,Accelerated Composition,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,justyna ann pekalak,
+ENGL,2120,1,World Literature,0.52,0.3,0.15,0.04,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,2120,2,World Literature (MAJORS ONLY),0.71,0.12,0.12,0.0,0.0,0.0,0.0,0.06,lucian ghita,
+ENGL,2120,3,World Literature,0.36,0.43,0.11,0.04,0.07,0.0,0.0,0.0,andrew mathas,
+ENGL,2120,4,World Literature,0.71,0.18,0.0,0.04,0.04,0.0,0.0,0.04,april susanne pelt,
+ENGL,2120,5,World Literature,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,2120,7,World Literature (MAJORS ONLY),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,2120,8,World Literature,0.56,0.19,0.19,0.0,0.04,0.0,0.0,0.04,andrew mathas,
+ENGL,2120,9,World Literature,0.41,0.34,0.07,0.03,0.1,0.0,0.0,0.03,andrew mathas,
+ENGL,2120,12,World Literature,0.5,0.21,0.11,0.04,0.11,0.0,0.0,0.04,john conway,
+ENGL,2120,13,World Literature,0.23,0.46,0.19,0.08,0.0,0.0,0.0,0.04,david charles foltz,
+ENGL,2120,14,World Literature,0.08,0.5,0.31,0.0,0.04,0.0,0.0,0.08,david charles foltz,
+ENGL,2120,15,World Literature,0.44,0.15,0.26,0.04,0.11,0.0,0.0,0.0,john conway,
+ENGL,2120,16,World Literature,0.57,0.25,0.07,0.0,0.0,0.0,0.0,0.11,lucian ghita,
+ENGL,2130,1,British Literature,0.21,0.29,0.17,0.13,0.08,0.0,0.0,0.13,karen kettnich,
+ENGL,2130,2,British Literature,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,karen kettnich,
+ENGL,2130,3,British Literature,0.54,0.29,0.04,0.04,0.07,0.0,0.0,0.04,april susanne pelt,
+ENGL,2130,4,British Literature,0.67,0.15,0.04,0.04,0.0,0.0,0.0,0.11,april susanne pelt,
+ENGL,2130,5,British Literature,0.5,0.32,0.0,0.07,0.04,0.0,0.0,0.07,john conway,
+ENGL,2130,6,British Literature,0.48,0.3,0.15,0.0,0.0,0.0,0.0,0.07,lucian ghita,
+ENGL,2130,7,British Literature,0.5,0.36,0.07,0.04,0.0,0.0,0.0,0.04,lucian ghita,
+ENGL,2130,8,British Literature,0.5,0.25,0.11,0.04,0.04,0.0,0.0,0.07,april susanne pelt,
+ENGL,2130,9,British Literature,0.14,0.43,0.25,0.11,0.07,0.0,0.0,0.0,david charles foltz,
+ENGL,2130,10,British Literature,0.41,0.33,0.07,0.0,0.11,0.0,0.0,0.07,john conway,
+ENGL,2130,11,British Literature,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
+ENGL,2130,12,British Literature,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,sherri teres allred,
+ENGL,2130,13,British Literature,0.19,0.33,0.26,0.07,0.04,0.0,0.0,0.11,david charles foltz,
+ENGL,2140,1,American Literature,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,joshua nei waggoner,
+ENGL,2140,2,American Literature,0.71,0.14,0.04,0.04,0.0,0.0,0.0,0.07,sharon kathl nalley,
+ENGL,2140,3,American Literature,0.29,0.39,0.11,0.11,0.0,0.0,0.0,0.11,sharon kathl nalley,
+ENGL,2140,4,American Literature,0.26,0.37,0.3,0.04,0.04,0.0,0.0,0.0,william stanton,
+ENGL,2140,5,American Literature,0.59,0.19,0.07,0.04,0.07,0.0,0.0,0.04,william stanton,
+ENGL,2140,6,American Literature,0.32,0.57,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2140,7,American Literature,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2140,8,American Literature,0.32,0.43,0.18,0.0,0.0,0.0,0.0,0.07,joshua nei waggoner,
+ENGL,2140,9,American Literature,0.41,0.56,0.0,0.0,0.0,0.0,0.0,0.04,joshua nei waggoner,
+ENGL,2140,11,American Literature,0.13,0.38,0.13,0.13,0.08,0.0,0.0,0.17,jonathan beec field,
+ENGL,2140,12,American Literature,0.2,0.28,0.16,0.04,0.12,0.0,0.0,0.2,jonathan beec field,
+ENGL,2140,13,American Literature,0.25,0.29,0.29,0.04,0.0,0.0,0.0,0.13,jonathan beec field,
+ENGL,2140,14,American Literature,0.63,0.21,0.04,0.0,0.0,0.0,0.0,0.13,jonathan beec field,
+ENGL,2140,15,American Literature,0.38,0.5,0.04,0.0,0.04,0.0,0.0,0.04,jonathan beec field,
+ENGL,2140,16,American Literature,0.09,0.48,0.3,0.0,0.09,0.0,0.0,0.04,jonathan beec field,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.54,0.36,0.04,0.0,0.04,0.0,0.0,0.04,michael richa lucas,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,michael richa lucas,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.14,0.79,0.04,0.0,0.0,0.0,0.0,0.04,amy monaghan,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.29,0.5,0.07,0.04,0.04,0.0,0.0,0.07,william pulley,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.15,0.73,0.08,0.04,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.26,0.52,0.22,0.0,0.0,0.0,0.0,0.0,matthew schilleman,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.0,lauren woolbright,
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,lauren woolbright,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.55,0.28,0.1,0.07,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.39,0.46,0.07,0.04,0.0,0.0,0.0,0.04,john morgenstern,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.36,0.43,0.14,0.04,0.0,0.0,0.0,0.04,sarah lauro,
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.46,0.39,0.14,0.0,0.0,0.0,0.0,0.0,sarah lauro,
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.59,0.24,0.14,0.0,0.0,0.0,0.0,0.03,john morgenstern,
+ENGL,3000,1,ENGL 3000: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
+ENGL,3040,2,ENGL 3040: 002,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,3040,3,ENGL 3040: 003,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,3040,4,ENGL 3040: 004,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,sean williams,
+ENGL,3040,5,ENGL 3040: 005,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,3040,13,ENGL 3040: 013,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexander kudera,
+ENGL,3100,1,ENGL 3100: 001,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,walter edgar hunter,
+ENGL,3100,2,ENGL 3100: 002,0.11,0.37,0.26,0.16,0.0,0.0,0.0,0.11,william stockton,
+ENGL,3100,4,ENGL 3100: 004,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,cameron fa bushnell,
+ENGL,3120,1,ENGL 3120: 001,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3120,2,ENGL 3120: 002,0.37,0.37,0.11,0.0,0.05,0.0,0.0,0.11,elizabeth stansell,
+ENGL,3140,1,Technical Writing,0.17,0.56,0.06,0.0,0.11,0.0,0.0,0.11,william pulley,
+ENGL,3140,2,Technical Writing,0.58,0.32,0.0,0.0,0.0,0.0,0.0,0.11,christopher benson,
+ENGL,3140,3,Technical Writing,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,william pulley,
+ENGL,3140,4,Technical Writing,0.42,0.37,0.11,0.0,0.05,0.0,0.0,0.05,william pulley,
+ENGL,3140,5,Technical Writing,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,7,Technical Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,8,Technical Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,9,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,
+ENGL,3140,10,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nancy swanson,
+ENGL,3140,11,Technical Writing,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,nancy swanson,
+ENGL,3140,13,Technical Writing,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,nancy swanson,
+ENGL,3140,14,Technical Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,nancy swanson,
+ENGL,3140,16,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,
+ENGL,3140,17,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,
+ENGL,3140,18,Technical Writing,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,david stubblefield,
+ENGL,3140,19,Technical Writing,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,20,Technical Writing,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,140,Technical Writing,0.5,0.3,0.0,0.0,0.0,0.0,0.0,0.2,sarah mae cooper,
+ENGL,3150,1,ENGL 3150: 001,0.0,0.63,0.37,0.0,0.0,0.0,0.0,0.0,barbara ramirez,
+ENGL,3150,2,ENGL 3150: 002,0.06,0.61,0.28,0.0,0.0,0.0,0.0,0.06,barbara ramirez,
+ENGL,3150,6,ENGL 3150: 006,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sharon kay henry,
+ENGL,3150,7,ENGL 3150: 007,0.7,0.15,0.05,0.0,0.0,0.0,0.0,0.1,philip randall,
+ENGL,3150,18,ENGL 3150: 018,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,
+ENGL,3150,400,ENGL 3150: 400,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,401,ENGL 3150: 401,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,philip randall,
+ENGL,3450,1,ENGL 3450: 001,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,john logan pursley,
+ENGL,3460,1,ENGL 3460: 001,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,angelina oberdan,
+ENGL,3480,1,ENGL 3480: 001,0.67,0.11,0.17,0.0,0.06,0.0,0.0,0.0,joshua nei waggoner,
+ENGL,3570,1,Film,0.36,0.5,0.05,0.05,0.0,0.0,0.0,0.05,sarah lauro,
+ENGL,3800,1,ENGL 3800: 001,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,angela naimou,
+ENGL,3850,1,ENGL 3850: 001,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,3860,1,ENGL 3860: 001,0.57,0.14,0.19,0.0,0.05,0.0,0.0,0.05,megan no macalystre,
+ENGL,3960,1,ENGL 3960: 001,0.32,0.23,0.23,0.05,0.14,0.0,0.0,0.05,william stockton,
+ENGL,3970,1,ENGL 3970: 001,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
+ENGL,3980,1,ENGL 3980: 001,0.23,0.45,0.18,0.05,0.09,0.0,0.0,0.0,rhondda robi thomas,
+ENGL,3990,1,ENGL 3990: 001,0.36,0.27,0.27,0.0,0.05,0.0,0.0,0.05,matthew schilleman,
+ENGL,3990,2,ENGL 3990: 002,0.23,0.59,0.14,0.0,0.05,0.0,0.0,0.0,matthew schilleman,
+ENGL,4080,1,ENGL 4080: 001,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,susan hilligoss,
+ENGL,4100,1,ENGL 4100: 001,0.31,0.31,0.19,0.06,0.13,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4110,1,ENGL 4110: 001,0.62,0.24,0.05,0.0,0.05,0.0,0.0,0.05,susan hilligoss,
+ENGL,4110,2,ENGL 4110: 002,0.33,0.38,0.1,0.05,0.14,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4260,1,ENGL 4260: 001,0.5,0.28,0.17,0.0,0.06,0.0,0.0,0.0,jillian weise,
+ENGL,4300,1,Dramatic Literature II,0.68,0.16,0.11,0.0,0.05,0.0,0.0,0.0,richard st. peter,
+ENGL,4400,1,ENGL 4400: 001,0.29,0.48,0.19,0.0,0.05,0.0,0.0,0.0,brian mcgrath,
+ENGL,4400,2,ENGL 4400: 002,0.41,0.41,0.06,0.0,0.06,0.0,0.0,0.06,dominic mastroianni,
+ENGL,4410,1,Literary Editing,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,gabriel and hankins,True
+ENGL,4430,1,ENGL 4430: 001,0.59,0.24,0.12,0.0,0.0,0.06,0.0,0.0,walter edgar hunter,
+ENGL,4450,1,ENGL 4450: 001,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,keith morris,
+ENGL,4600,1,ENGL 4600: 001,0.41,0.41,0.0,0.06,0.06,0.0,0.0,0.06,tharon howard,
+ENGL,4640,1,ENGL 4640: 001,0.4,0.27,0.13,0.07,0.13,0.0,0.0,0.0,dominic mastroianni,
+ENGL,4650,1,ENGL 4650: 001,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,angela naimou,
+ENGL,4830,1,ENGL 4830: 001,0.23,0.54,0.0,0.0,0.15,0.0,0.0,0.08,rhondda robi thomas,
+ENGL,4890,1,ENGL 4890: 001,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,sean williams,
+ENGL,4920,1,Modern Rhetoric,0.29,0.29,0.36,0.0,0.07,0.0,0.0,0.0,brian mcgrath,
+ENGL,4950,1,ENGL 4950: 001,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,sean morey,
+ENGL,4960,2,ENGL 4960: 002,0.36,0.36,0.07,0.07,0.07,0.0,0.0,0.07,agnieszka skrodzka,
+ENGL,4960,3,ENGL 4960: 003,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,
+ENGL,8310,1,Special Topics,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
+ENGR,1020,14,Engineering Discipl & Skills,0.09,0.3,0.32,0.09,0.07,0.0,0.0,0.14,steven brandon,
+ENGR,1410,12,Programming & Problem Solving,0.11,0.39,0.28,0.16,0.02,0.0,0.0,0.05,steven brandon,
+ENGR,1410,13,Programming & Problem Solving,0.41,0.32,0.17,0.05,0.0,0.0,0.0,0.05,elizabeth stephan,
+ENGR,1410,17,Programming & Problem Solving,0.14,0.48,0.24,0.06,0.07,0.0,0.0,0.01,david ewing,
+ENGR,1410,18,Programming & Problem Solving,0.12,0.41,0.36,0.09,0.02,0.0,0.0,0.0,william martin,
+ENGR,1410,19,Programming & Problem Solving,0.12,0.29,0.39,0.1,0.03,0.0,0.0,0.07,david ewing,
+ENGR,1410,20,Programming & Problem Solving,0.18,0.42,0.3,0.06,0.03,0.0,0.0,0.01,christopher norfolk,
+ENGR,1410,22,Programming & Problem Solving,0.23,0.39,0.23,0.11,0.02,0.0,0.0,0.04,christopher norfolk,
+ENGR,1410,25,Programming & Problem Solving,0.15,0.42,0.2,0.13,0.07,0.0,0.0,0.04,william park,
+ENGR,1410,27,Programming & Problem Solving,0.05,0.21,0.43,0.12,0.09,0.0,0.0,0.1,william park,
+ENGR,1410,50,Programming & Problem Solving,0.33,0.45,0.19,0.0,0.02,0.0,0.0,0.0,john minor,
+ENGR,1410,52,Prog. & Problem Solving (HON),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
+ENGR,1410,56,Programming & Problem Solving,0.21,0.45,0.29,0.02,0.02,0.0,0.0,0.0,sabrina lau,
+ENGR,1410,58,Programming & Problem Solving,0.12,0.54,0.29,0.05,0.0,0.0,0.0,0.0,david ewing,
+ENGR,1410,60,Prog & Problem Solving (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
+ENGR,1410,64,Programming & Problem Solving,0.22,0.39,0.34,0.0,0.05,0.0,0.0,0.0,david ewing,
+ENGR,1410,66,Programming & Problem Solving,0.12,0.44,0.32,0.12,0.0,0.0,0.0,0.0,david ewing,
+ENGR,2080,11,Engr Graphics & Machine Design,0.57,0.15,0.21,0.01,0.01,0.0,0.0,0.04,sabrina lau,
+ENGR,2080,15,Engr Graphics & Machine Design,0.61,0.28,0.07,0.0,0.03,0.0,0.0,0.01,john minor,
+ENGR,2080,21,Engr Graphics & Machine Design,0.49,0.35,0.09,0.0,0.03,0.0,0.0,0.04,sarah grigg,
+ENGR,2080,23,Engr Graphics & Machine Design,0.46,0.29,0.11,0.04,0.03,0.0,0.0,0.07,sarah grigg,
+ENGR,2080,31,Engr Graphics & Machine Design,0.7,0.16,0.1,0.01,0.01,0.0,0.0,0.01,sabrina lau,
+ENGR,2080,39,Engr Graphics & Machine Design,0.61,0.3,0.04,0.01,0.0,0.0,0.0,0.03,sarah grigg,
+ENGR,2080,54,Engr Graphics & Machine Design,0.67,0.21,0.1,0.02,0.0,0.0,0.0,0.0,john minor,
+ENGR,2100,32,CAD & Engineering Apllications,0.63,0.15,0.05,0.05,0.05,0.0,0.0,0.07,william martin,
+ENGR,2100,38,CAD & Engineering Aplications,0.53,0.14,0.14,0.0,0.07,0.0,0.0,0.12,william martin,
+ENGR,2100,40,CAD & Engineering Apllications,0.76,0.09,0.09,0.0,0.0,0.0,0.0,0.07,nighat yasmin,
+ENR,3020,1,ENR 3020: 001,0.38,0.46,0.1,0.05,0.0,0.0,0.0,0.0,lawrence gering,
+ENR,4500,1,ENR 4500: 001,0.79,0.05,0.11,0.0,0.03,0.0,0.0,0.03,alan johnson,
+ENR,4500,2,ENR 4500: 002,0.71,0.21,0.04,0.04,0.0,0.0,0.0,0.0,alan johnson,
+ENSP,2000,1,Intro Environ Sci,0.47,0.35,0.1,0.02,0.0,0.0,0.0,0.06,scott brame,
+ENSP,2000,2,Intro Environ Sci,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+ENSP,2000,3,Intro Environ Sci,0.24,0.64,0.1,0.0,0.0,0.0,0.0,0.02,john coates,
+ENT,2000,1,Six-Legged Science,0.39,0.42,0.06,0.06,0.0,0.0,0.0,0.06,patricia zungoli,
+ENT,8100,1,Forensic Entomology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,peter adler,
+ESED,8200,1,ESED 8200: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,
+ETOX,8300,1,Mechanistic Toxicology,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,
+FCS,8920,1,Research Methods II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,
+FCS,8920,13,Program Evaluation,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mark small,
+FDSC,1020,1,FDSC 1020: 001,0.58,0.37,0.01,0.01,0.0,0.0,0.0,0.03,john mcgregor,
+FDSC,2140,1,Fd Resources & Soc,0.61,0.27,0.08,0.01,0.0,0.0,0.0,0.04,paul dawson,
+FDSC,4020,1,Food Chem II,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4030,1,Food Ch & Analysis,0.82,0.15,0.0,0.0,0.0,0.0,0.0,0.03,paul dawson,
+FDSC,4080,1,FDSC 4080: 001,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,felix barron,
+FDSC,4090,1,TQM for Food & Pckg Industries,0.6,0.35,0.06,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+FIN,3050,1,Investment Analysis,0.11,0.41,0.35,0.11,0.03,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.26,0.36,0.28,0.08,0.03,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.23,0.3,0.35,0.05,0.03,0.03,0.0,0.03,kerri mcmillan,
+FIN,3060,1,Corporation Finance,0.17,0.17,0.23,0.17,0.15,0.0,0.0,0.1,william hol johnson,
+FIN,3060,2,Corporation Finance,0.17,0.29,0.13,0.19,0.17,0.0,0.0,0.04,william hol johnson,
+FIN,3060,3,Corporation Finance,0.24,0.4,0.24,0.1,0.0,0.0,0.0,0.02,neil waller,
+FIN,3060,4,Corporation Finance,0.1,0.34,0.36,0.12,0.0,0.0,0.0,0.08,john harris,
+FIN,3060,5,Corporation Finance,0.18,0.45,0.2,0.02,0.0,0.0,0.0,0.16,john harris,
+FIN,3060,6,Corporation Finance,0.25,0.43,0.25,0.04,0.02,0.02,0.0,0.0,neil waller,
+FIN,3060,7,Corporation Finance,0.12,0.5,0.27,0.08,0.04,0.0,0.0,0.0,neil waller,
+FIN,3070,1,Prin of Real Estate,0.15,0.23,0.35,0.12,0.12,0.0,0.0,0.02,ramon tolb franklin,
+FIN,3070,2,Prin of Real Estate,0.3,0.3,0.26,0.11,0.02,0.0,0.0,0.02,thomas springer,
+FIN,3080,1,Fin Inst & Mkts,0.08,0.53,0.26,0.03,0.03,0.0,0.0,0.08,lyudmila chernykh,
+FIN,3080,2,Fin Inst & Mkts,0.18,0.33,0.33,0.05,0.08,0.0,0.0,0.03,michael spivey,
+FIN,3080,3,Fin Inst & Mkts,0.23,0.28,0.28,0.05,0.03,0.0,0.0,0.13,michael spivey,
+FIN,3110,1,Financial Management I,0.09,0.2,0.45,0.14,0.05,0.0,0.0,0.07,ramon tolb franklin,
+FIN,3110,2,Financial Management I,0.14,0.23,0.35,0.05,0.07,0.0,0.0,0.16,george bra lockhart,
+FIN,3110,3,Financial Management I,0.27,0.27,0.31,0.02,0.0,0.0,0.0,0.13,george bra lockhart,
+FIN,3110,4,Financial Management I,0.12,0.36,0.29,0.14,0.05,0.0,0.0,0.05,george bra lockhart,
+FIN,3120,1,Financial Mgt II,0.16,0.65,0.13,0.03,0.03,0.0,0.0,0.0,lyudmila chernykh,
+FIN,3120,2,Financial Mgt II,0.58,0.24,0.12,0.03,0.0,0.0,0.0,0.03,melvin stith,
+FIN,3120,3,Financial Mgt II,0.53,0.31,0.03,0.06,0.08,0.0,0.0,0.0,melvin stith,
+FIN,3120,4,Financial Mgt II,0.5,0.31,0.13,0.0,0.06,0.0,0.0,0.0,melvin stith,
+FIN,4040,1,Financial Modeling,0.11,0.26,0.41,0.11,0.11,0.0,0.0,0.0,jack wolf,
+FIN,4040,2,Financial Modeling,0.13,0.47,0.28,0.09,0.03,0.0,0.0,0.0,jack wolf,
+FIN,4040,3,Financial Modeling,0.13,0.47,0.2,0.1,0.03,0.0,0.0,0.07,jack wolf,
+FIN,4050,1,Port Mgt and Theory,0.24,0.24,0.24,0.24,0.0,0.0,0.0,0.04,john alexander,
+FIN,4050,2,Port Mgt and Theory,0.14,0.14,0.29,0.14,0.1,0.0,0.0,0.19,john alexander,
+FIN,4080,1,Mgt of Fin Inst,0.07,0.44,0.42,0.02,0.04,0.0,0.0,0.0,michael spivey,
+FIN,4110,1,Int Fin Mgt,0.26,0.28,0.36,0.08,0.03,0.0,0.0,0.0,john harris,
+FIN,4110,2,Int Fin Mgt,0.26,0.41,0.23,0.08,0.0,0.0,0.0,0.03,john harris,
+FIN,4150,1,Real Estate Investmt,0.19,0.24,0.29,0.24,0.0,0.05,0.0,0.0,thomas springer,
+FIN,4160,1,Real Estate Val,0.0,0.32,0.55,0.14,0.0,0.0,0.0,0.0,neil waller,
+FNR,1020,1,FNR 1020: 001,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,elena mikhailova,
+FNR,4990,1,FNR 4990: 001,0.72,0.11,0.06,0.06,0.06,0.0,0.0,0.0,donald hagan,
+FNR,4990,3,FNR 4990: 003,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,donald hagan,
+FOR,2060,1,FOR 2060: 001,0.38,0.34,0.19,0.07,0.0,0.0,0.0,0.02,donald hagan,
+FOR,3080,1,FOR 3080: 001,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,lawrence gering,
+FOR,4060,1,FOR 4060: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william roc english,
+FOR,4080,1,FOR 4080: 001,0.54,0.36,0.11,0.0,0.0,0.0,0.0,0.0,patricia layton,
+FOR,4150,1,FOR 4150: 001,0.23,0.59,0.18,0.0,0.0,0.0,0.0,0.0,james davis,
+FOR,4180,1,FOR 4180: 001,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4340,1,GIS for Landscape Planning,0.19,0.64,0.14,0.0,0.0,0.0,0.0,0.03,robert frit baldwin,
+FOR,4650,1,FOR 4650: 001,0.42,0.33,0.25,0.0,0.0,0.0,0.0,0.0,gaofeng wang,
+FOR,6340,1,GIS for Landscape Planning,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robert frit baldwin,
+FR,1010,1,FR 1010: 001,0.64,0.23,0.09,0.0,0.0,0.0,0.0,0.05,julian hamil killey,
+FR,1020,1,FR 1020: 001,0.38,0.38,0.0,0.19,0.0,0.0,0.0,0.06,julian hamil killey,
+FR,1020,2,FR 1020: 002,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,julian hamil killey,
+FR,1020,3,FR 1020: 003,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,1,Intermediate French,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,amy lyn grif sawyer,
+FR,2010,2,Intermediate French,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,3,Intermediate French,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,julian hamil killey,
+FR,2020,1,Intermediate French,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2020,4,Intermediate French,0.14,0.5,0.21,0.0,0.07,0.0,0.0,0.07,kenneth dav widgren,
+FR,2020,5,Intermediate French,0.53,0.35,0.06,0.0,0.0,0.0,0.0,0.06,joseph mai,
+FR,3000,1,Survey of French Lit,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,karyna szmurlo,
+FR,3050,1,FR 3050: 001,0.41,0.24,0.12,0.0,0.06,0.0,0.0,0.18,kenneth dav widgren,
+FR,3170,1,FR 3170: 001,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,joseph mai,
+FR,4200,1,FR 4200: 001,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,karyna szmurlo,
+GC,1010,1,GC 1010: 001,0.57,0.34,0.02,0.0,0.0,0.0,0.0,0.07,kern cox,
+GC,1020,1,GC 1020: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,charles tabor weiss,
+GC,1020,2,GC 1020: 002,0.35,0.48,0.04,0.0,0.04,0.0,0.0,0.09,carol jones,
+GC,1030,1,GC 1030: 001,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,john jacobs,
+GC,1030,2,GC 1030: 002,0.67,0.13,0.07,0.07,0.07,0.0,0.0,0.0,john jacobs,
+GC,1040,1,Graphic Com I,0.49,0.41,0.06,0.0,0.01,0.0,0.0,0.02,rebecca suza edlein,
+GC,1990,4,CI in GC I-J Lay CS,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,janice ann lay,
+GC,2070,1,Graphic Com II,0.54,0.37,0.09,0.0,0.0,0.0,0.0,0.0,patrick gee rose,
+GC,3400,1,Digital Img & Emedia,0.33,0.46,0.17,0.0,0.04,0.0,0.0,0.0,erica black walker,
+GC,4060,1,Pkg & Spec Prtg,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kern cox,
+GC,4400,1,Commercial Printing,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,
+GC,4440,1,Current Dev in G C,0.29,0.57,0.07,0.07,0.0,0.0,0.0,0.0,liam henry 'hara,
+GC,4460,1,Ink & Substrates,0.27,0.59,0.14,0.0,0.0,0.0,0.0,0.0,liam henry 'hara,
+GC,4480,1,Plan and Cont Print,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john leininger,
+GC,4900,2,G C Selected Topics-Sales,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,
+GEN,3000,1,GEN 3000: 001,0.3,0.37,0.21,0.06,0.02,0.0,0.0,0.05,kate leanne wi tsai,
+GEN,3000,2,GEN 3000: 002,0.36,0.3,0.17,0.11,0.01,0.0,0.0,0.06,kate leanne wi tsai,
+GEN,4100,1,Population & Quant Genetics,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
+GEN,4110,2,GEN 4110: 002,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
+GEN,6100,1,Population & Quant Genetics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
+GEOG,1010,1,Intro to Geography,0.37,0.45,0.13,0.0,0.03,0.0,0.0,0.03,christa smith,
+GEOG,1030,1,World Regional Geog,0.82,0.11,0.04,0.02,0.0,0.0,0.0,0.01,lance forres howard,
+GEOG,1030,2,World Regional Geog,0.3,0.43,0.1,0.13,0.05,0.0,0.0,0.0,william churc terry,
+GEOG,3020,1,GEOG 3020: 001,0.67,0.25,0.0,0.0,0.08,0.0,0.0,0.0,william churc terry,
+GEOG,3050,1,GEOG 3050: 001,0.74,0.16,0.05,0.05,0.0,0.0,0.0,0.0,lance forres howard,
+GEOL,1010,1,Physical Geology,0.13,0.31,0.27,0.12,0.11,0.0,0.0,0.05,alan coulson,
+GEOL,1010,2,Physical Geology,0.28,0.37,0.2,0.06,0.05,0.0,0.0,0.04,alan coulson,
+GEOL,1020,1,Earth History,0.13,0.44,0.31,0.06,0.0,0.0,0.0,0.06,alan coulson,
+GEOL,1030,1,Physical Geol Lab,0.74,0.09,0.04,0.0,0.09,0.0,0.0,0.04,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.87,0.0,0.09,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.29,0.63,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.5,0.41,0.05,0.0,0.05,0.0,0.0,0.0,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.68,0.23,0.0,0.0,0.05,0.0,0.0,0.05,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.46,0.5,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,alan coulson,
+GEOL,3130,1,GEOL 3130: 001,0.14,0.57,0.24,0.05,0.0,0.0,0.0,0.0,james castle,
+GEOL,3180,1,GEOL 3180: 001,0.18,0.57,0.18,0.0,0.04,0.0,0.0,0.04,brian powell,
+GEOL,7900,500,Selected Topics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+GEOL,8080,1,Groundwater Modeling,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
+GER,1010,3,GER 1010: 003,0.67,0.27,0.0,0.07,0.0,0.0,0.0,0.0,oswald harris king,
+GER,1010,4,GER 1010: 004,0.31,0.08,0.15,0.0,0.08,0.0,0.0,0.38,oswald harris king,
+GER,1010,5,GER 1010: 005,0.08,0.69,0.0,0.0,0.08,0.0,0.0,0.15,oswald harris king,
+GER,1020,3,GER 1020: 003,0.35,0.15,0.1,0.1,0.0,0.0,0.0,0.3, lee ferrell,
+GER,1020,4,GER 1020: 004,0.27,0.2,0.13,0.0,0.2,0.0,0.0,0.2, lee ferrell,
+GER,2010,2,Intermediate German,0.27,0.27,0.2,0.13,0.07,0.0,0.0,0.07,gabriela stoicea,
+GER,2020,3,Intermediate German,0.21,0.38,0.29,0.08,0.0,0.0,0.0,0.04,johannes schmidt,
+GER,3060,1,German Short Story,0.18,0.53,0.12,0.06,0.0,0.0,0.0,0.12,gabriela stoicea,
+GER,3160,1,GER 3160: 001,0.23,0.62,0.0,0.0,0.15,0.0,0.0,0.0, lee ferrell,
+GW,3010,1,Grt Books West World,0.47,0.24,0.18,0.0,0.12,0.0,0.0,0.0,henry clark,
+HCC,8810,2,Health Informatics,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,kelly caine,
+HEHD,4000,1,HEHD 4000: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,
+HEHD,4100,1,HEHD 4100: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
+HEHD,8000,230,HEHD 8000: 230,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,robert ja barcelona,
+HEHD,8010,230,HEHD 8010: 230,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
+HIST,1010,1,Hist of the U S,0.22,0.24,0.19,0.14,0.16,0.0,0.0,0.05,james brad jeffries,
+HIST,1220,1,"Hist, Tech & Society",0.53,0.21,0.15,0.06,0.0,0.01,0.0,0.03,henry clark,
+HIST,1240,1,Environmental Hist,0.23,0.56,0.13,0.03,0.0,0.0,0.0,0.05,james brad jeffries,
+HIST,1240,2,Environmental Hist,0.21,0.51,0.21,0.05,0.0,0.0,0.0,0.03,james brad jeffries,
+HIST,1720,1,The West and the World I,0.36,0.29,0.26,0.05,0.02,0.0,0.0,0.02,henry clark,
+HIST,1720,2,The West and the World I,0.27,0.71,0.02,0.0,0.0,0.0,0.0,0.0,emily wood,
+HIST,1730,1,The West and the World II,0.27,0.27,0.25,0.02,0.11,0.0,0.0,0.07, alan grubb,
+HIST,1730,2,The West and the World II,0.24,0.32,0.2,0.04,0.11,0.0,0.0,0.09,richard saunders,
+HIST,1730,3,The West and the World II,0.21,0.47,0.18,0.06,0.05,0.0,0.0,0.04,steven marks,
+HIST,2990,1,HIST 2990: 001,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,rachel anne moore,
+HIST,2990,2,HIST 2990: 002,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,rachel anne moore,
+HIST,3060,1,HIST 3060: 001,0.39,0.37,0.11,0.04,0.02,0.0,0.0,0.07,richard saunders,
+HIST,3120,1,HIST 3120: 001,0.4,0.44,0.09,0.02,0.02,0.0,0.0,0.02,abel bartley,
+HIST,3140,1,HIST 3140: 001,0.11,0.64,0.22,0.0,0.0,0.0,0.0,0.02,paul chris anderson,
+HIST,3210,1,History of Science,0.28,0.23,0.21,0.15,0.05,0.0,0.0,0.08,pamela mack,
+HIST,3260,1,HIST 3260: 001,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03, roger grant,
+HIST,3290,1,HIST 3290: 001,0.17,0.42,0.21,0.08,0.0,0.0,0.0,0.13,maribel morey,
+HIST,3390,1,HIST 3390: 001,0.46,0.21,0.15,0.08,0.08,0.0,0.0,0.03,james burns,
+HIST,3420,1,HIST 3420: 001,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
+HIST,3670,1,HIST 3670: 001,0.37,0.34,0.13,0.0,0.11,0.0,0.0,0.05,michael silvestri,
+HIST,3730,1,Age of Protestant Reformation,0.43,0.07,0.14,0.0,0.21,0.0,0.0,0.14,thomas kuehn,
+HIST,3780,1,HIST 3780: 001,0.4,0.31,0.17,0.06,0.06,0.0,0.0,0.0,michael meng,
+HIST,3900,1,HIST 3900: 001,0.15,0.41,0.3,0.07,0.07,0.0,0.0,0.0,edwin moise,
+HIST,3970,1,HIST 3970: 001,0.44,0.44,0.07,0.0,0.02,0.0,0.0,0.02,amit bein,
+HIST,4170,1,HIST 4170: 001,0.25,0.5,0.17,0.0,0.08,0.0,0.0,0.0,meg taylor-shockley,
+HIST,4240,1,Top in Hist of Medicine & Hlth,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,pamela mack,
+HIST,4360,1,HIST 4360: 001,0.23,0.27,0.41,0.0,0.09,0.0,0.0,0.0,edwin moise,
+HIST,4600,1,Britain & WWII,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,james burns,
+HIST,4710,1,The Great War 1914 & 1918,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0, alan grubb,
+HIST,4900,2,The Empire World,0.4,0.27,0.2,0.0,0.07,0.0,0.0,0.07,michael silvestri,
+HIST,4900,3,Heroic Failures,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
+HIST,4930,2,Urban History,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,abel bartley,
+HLTH,2020,1,HLTH 2020: 001,0.23,0.64,0.13,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,2,HLTH 2020: 002,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,3,HLTH 2020: 003,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,sarah griffin,
+HLTH,2020,400,HLTH 2020: 400,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2030,1,HLTH 2030: 001,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2030,2,HLTH 2030: 002,0.65,0.22,0.11,0.0,0.0,0.0,0.0,0.03,son albury-crandall,
+HLTH,2030,400,HLTH 2030: 400,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2030,401,HLTH 2030: 401,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2400,1,HLTH 2400: 001,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,joel edwar williams,
+HLTH,2400,2,HLTH 2400: 002,0.73,0.1,0.15,0.02,0.0,0.0,0.0,0.0,joel edwar williams,
+HLTH,2980,1,HLTH 2980: 001,0.52,0.45,0.02,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,2980,2,HLTH 2980: 002,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,3100,1,HLTH 3100: 001,0.19,0.62,0.15,0.0,0.0,0.0,0.0,0.04,rachel mayo,
+HLTH,3100,2,HLTH 3100: 002,0.48,0.36,0.12,0.04,0.0,0.0,0.0,0.0,rachel mayo,
+HLTH,3800,1,HLTH 3800: 001,0.41,0.44,0.13,0.0,0.03,0.0,0.0,0.0,liwei chen,
+HLTH,3800,2,HLTH 3800: 002,0.32,0.5,0.11,0.04,0.04,0.0,0.0,0.0,liwei chen,
+HLTH,3980,1,HLTH 3980: 001,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,kathleen meyer,
+HLTH,4000,1,Adolescent Health,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,4020,1,HLTH 4020: 001,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,karen kemper,
+HLTH,4190,1,HLTH 4190: 001,0.31,0.58,0.09,0.0,0.0,0.0,0.0,0.02,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4300,1,HLTH 4300: 001,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,
+HLTH,4310,1,Public & Environ Hlt,0.63,0.29,0.04,0.0,0.02,0.0,0.0,0.02,deborah alma falta,
+HLTH,4400,1,HLTH 4400: 001,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,windsor we sherrill,
+HLTH,4600,1,HLTH 4600: 001,0.59,0.33,0.04,0.0,0.0,0.0,0.0,0.04,deidra jol morrison,
+HLTH,4780,1,HLTH 4780: 001,0.11,0.56,0.3,0.0,0.0,0.0,0.0,0.04,hugh spitler,
+HLTH,4790,1,HLTH 4790: 001,0.17,0.48,0.24,0.1,0.0,0.0,0.0,0.0,khoa dang truong,
+HLTH,4800,1,HLTH 4800: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,
+HLTH,4900,1,HLTH 4900: 001,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,lu shi,
+HLTH,4900,2,HLTH 4900: 002,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,lu shi,
+HON,2030,2,Music and Politics (HON),0.83,0.06,0.0,0.06,0.0,0.0,0.0,0.06,eric lapin,True
+HON,2060,1,Intro to Nanotechnology,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,christophe kitchens,True
+HON,2210,1,The Great War 1914-1918,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True
+HON,2210,3,20th Century Lit & Painting,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,john morgenstern,True
+HON,2210,5,Spies and Spy Novels,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,william lasser,True
+HORT,1010,1,HORT 1010: 001,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,
+HORT,2110,1,HORT 2110: 001,0.33,0.33,0.19,0.11,0.04,0.0,0.0,0.0,james emerson faust,
+HORT,4040,1,HORT 4040: 001,0.06,0.44,0.19,0.14,0.14,0.0,0.0,0.03,jeffrey adelberg,
+HORT,4050,2,HORT 4050: 002,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
+HORT,4270,1,Urban Tree Care,0.18,0.36,0.18,0.05,0.18,0.0,0.0,0.05,robert polomski,
+HORT,4330,1,Turf Weed Management,0.13,0.54,0.25,0.0,0.04,0.0,0.0,0.04,ted whitwell,
+HORT,4720,1,HORT 4720: 001,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HP,8900,400,Directed Studies: Pres Eng,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,craig mille bennett,
+HP,8910,1,HP 8910: 001,0.0,0.0,0.0,0.0,0.0,0.85,0.15,0.0,carter lee hudgins,
+HRD,8470,400,HRD 8470: 400,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
+HRD,8470,401,HRD 8470: 401,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,
+HRD,8470,402,HRD 8470: 402,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,
+HRD,8470,403,HRD 8470: 403,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
+HRD,8470,405,HRD 8470: 405,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
+IE,2010,1,IE 2010: 001,0.37,0.27,0.23,0.13,0.0,0.0,0.0,0.0,joel greenstein,
+IE,2100,1,IE 2100: 001,0.46,0.4,0.08,0.02,0.02,0.0,0.0,0.01,antonia rodriguez,
+IE,3610,1,IE 3610: 001,0.42,0.32,0.1,0.09,0.05,0.0,0.0,0.03,david neyens,
+IE,3810,1,IE 3810: 001,0.34,0.42,0.14,0.07,0.02,0.0,0.0,0.01,mary elizabeth kurz,
+IE,3840,1,IE 3840: 001,0.36,0.2,0.16,0.05,0.08,0.0,0.0,0.14,brian melloy,
+IE,3860,1,IE 3860: 001,0.6,0.26,0.12,0.01,0.0,0.0,0.0,0.01,jonathan lowe,
+IE,4600,1,IE 4600: 001,0.33,0.39,0.22,0.06,0.0,0.0,0.0,0.0,joel greenstein,
+IE,4620,1,IE 4620: 001,0.35,0.6,0.03,0.0,0.0,0.02,0.0,0.0,byung rae cho,
+IE,4910,1,Appl Probability Models in IE,0.82,0.0,0.09,0.09,0.0,0.0,0.0,0.0,brian melloy,
+IE,6620,1,IE 6620: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,byung rae cho,
+IE,8010,1,Human-Machine Sys,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,
+IE,8040,1,IE 8040: 001,0.29,0.48,0.24,0.0,0.0,0.0,0.0,0.0,william ferrell,
+IE,8050,1,IE 8050: 001,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,byung rae cho,
+IE,8520,1,IE 8520: 001,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabeth kurz,
+IE,8540,1,IE 8540: 001,0.47,0.39,0.08,0.0,0.0,0.0,0.0,0.06,william ferrell,
+IE,8580,1,IE 8580: 001,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+IE,8800,1,IE 8800: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,amin khademi,
+IS,2100,615,Sel Topics Int Study,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,sallie bro turnbull,
+ITAL,1010,1,ITAL 1010: 001,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,julia schmidt,
+ITAL,1020,1,ITAL 1020: 001,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,luca barattoni,
+ITAL,1020,2,ITAL 1020: 002,0.38,0.31,0.0,0.08,0.15,0.0,0.08,0.0,luca barattoni,
+ITAL,1020,3,ITAL 1020: 003,0.5,0.25,0.08,0.08,0.0,0.0,0.0,0.08,valentina lombardi,
+ITAL,2020,1,Intermediate Italian,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,2020,2,Intermediate Italian,0.28,0.39,0.33,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+JAPN,1010,2,JAPN 1010: 002,0.21,0.36,0.07,0.07,0.21,0.0,0.0,0.07,kazuko shoji,
+JAPN,1020,1,JAPN 1020: 001,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0, leslie williams,
+JAPN,2020,1,JAPN 2020: 001,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,kazuko shoji,
+JAPN,3060,1,JAPN 3060: 001,0.4,0.3,0.1,0.0,0.0,0.1,0.0,0.1,toshiko kishimoto,
+JAPN,4170,1,Japan Cult & Soc,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0, leslie williams,
+LANG,4990,1,LANG 4990: 001,0.0,0.0,0.0,0.0,0.0,0.88,0.06,0.06,su- chen,
+LARC,1160,1,History of Larch,0.31,0.36,0.2,0.05,0.05,0.0,0.0,0.04,hala fouad nassar,
+LARC,1520,1,LARC 1520: 001,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,daniel ford,
+LARC,2620,1,Design Impl I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,david pearson,
+LARC,3520,1,LARC 3520: 001,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,robert hewitt,
+LARC,6530,1,LARC 6530: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lycke,
+LARC,8300,1,LARC 8300: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+LAW,3220,1,Legal Env of Bus,0.35,0.4,0.16,0.03,0.0,0.0,0.0,0.06,edward ray claggett,
+LAW,3220,2,Legal Env of Bus,0.53,0.31,0.08,0.05,0.02,0.0,0.0,0.02,edward ray claggett,
+LAW,3220,3,Legal Env of Bus,0.43,0.41,0.13,0.02,0.0,0.0,0.0,0.02,frances edwards,
+LAW,3220,4,Legal Env of Bus,0.3,0.49,0.17,0.03,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,5,Legal Env of Bus,0.41,0.44,0.13,0.02,0.0,0.0,0.0,0.02,frances edwards,
+LAW,3220,6,Legal Env of Bus,0.0,0.17,0.29,0.2,0.07,0.0,0.0,0.27,virgini ward-vaughn,
+LAW,3220,7,Legal Env of Bus,0.08,0.25,0.25,0.14,0.08,0.0,0.0,0.19,virgini ward-vaughn,
+LAW,3220,8,Legal Env of Bus,0.02,0.14,0.36,0.12,0.12,0.0,0.0,0.24,virgini ward-vaughn,
+LAW,3220,9,Legal Env of Bus,0.03,0.28,0.21,0.23,0.15,0.0,0.0,0.1,virgini ward-vaughn,
+LAW,3330,1,Real Estate Law,0.15,0.31,0.46,0.02,0.04,0.0,0.0,0.02,judson jahn,
+LAW,3330,2,Real Estate Law,0.13,0.38,0.38,0.06,0.02,0.0,0.0,0.02,judson jahn,
+LAW,8480,1,LAW 8480: 001,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LAW,8500,1,LAW 8500: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,megan mowrey,
+LAW,8500,2,LAW 8500: 002,0.89,0.08,0.0,0.0,0.03,0.0,0.0,0.0,megan mowrey,
+LS,1000,2,Fitness Leadership,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,mary allison lynch,
+LS,1000,20,Intro to Volleyball,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,kelly lynn ator,
+LS,1000,22,Forestry Skills,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,tamara lee cushing,
+LS,1410,2,LS 1410: 002,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,glenn dav middleton,
+LS,1450,2,LS 1450: 002,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,george wal thompson,
+LS,1560,1,LS 1560: 001,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,david brad cottrell,
+LS,1560,3,LS 1560: 003,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,david brad cottrell,
+LS,1570,6,LS 1570: 006,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey la atkinson,
+LS,1570,10,LS 1570: 010,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,audrey caroli couch,
+LS,1580,1,LS 1580: 001,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,herbert strickland,
+LS,1580,5,LS 1580: 005,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1610,1,LS 1610: 001,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,richard willey,
+LS,1790,1,LS 1790: 001,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert bogan,
+LS,1830,1,LS 1830: 001,0.77,0.09,0.09,0.05,0.0,0.0,0.0,0.0,justin hickey,
+LS,1850,1,LS 1850: 001,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,matthew davi hughes,
+LS,1850,2,LS 1850: 002,0.93,0.0,0.0,0.04,0.0,0.0,0.0,0.04,matthew davi hughes,
+LS,1850,4,LS 1850: 004,0.96,0.0,0.0,0.0,0.04,0.0,0.0,0.0,megan elizabet cato,
+LS,1880,1,LS 1880: 001,0.73,0.0,0.0,0.0,0.07,0.0,0.0,0.2,jarrett bachman,
+LS,1890,1,LS 1890: 001,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,jennifer jo garrity,
+LS,1990,1,LS 1990: 001,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jason jordan,
+LS,2040,2,LS 2040: 002,0.83,0.0,0.0,0.09,0.0,0.0,0.0,0.09,denise ann adams,
+LS,2100,4,LS 2100: 004,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,paul hoke,
+LS,2110,2,LS 2110: 002,0.88,0.0,0.12,0.0,0.0,0.0,0.0,0.0,stephanie pack,
+LS,2190,1,LS 2190: 001,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,matthew lee krabbe,
+LS,2200,5,LS 2200: 005,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,broadus fleming,
+LS,2200,7,LS 2200: 007,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,matthew lee krabbe,
+LS,2200,8,LS 2200: 008,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,matthew lee krabbe,
+LS,2200,9,LS 2200: 009,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,matthew lee krabbe,
+LS,2210,1,LS 2210: 001,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,paul hoke,
+LS,2270,1,LS 2270: 001,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,
+LS,2270,2,LS 2270: 002,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,paul hoke,
+LS,2320,1,LS 2320: 001,0.87,0.0,0.0,0.0,0.04,0.0,0.0,0.09,diane moreno,
+LS,2320,2,LS 2320: 002,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,diane moreno,
+LS,2320,3,LS 2320: 003,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,diane moreno,
+LS,2320,5,LS 2320: 005,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,2350,1,LS 2350: 001,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,ranjanbala dil amin,
+LS,2350,2,LS 2350: 002,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
+LS,2350,3,LS 2350: 003,0.7,0.09,0.13,0.0,0.0,0.0,0.0,0.09,renee warren gahan,
+LS,2350,4,LS 2350: 004,0.79,0.08,0.0,0.0,0.0,0.0,0.0,0.13,renee warren gahan,
+LS,2350,5,LS 2350: 005,0.65,0.17,0.0,0.0,0.0,0.0,0.0,0.17,renee warren gahan,
+LS,2350,6,LS 2350: 006,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,2350,8,LS 2350: 008,0.84,0.04,0.0,0.04,0.08,0.0,0.0,0.0,ranjanbala dil amin,
+LS,2360,1,LS 2360: 001,0.92,0.0,0.0,0.0,0.04,0.0,0.0,0.04,ani reina-nunnelley,
+LS,2360,2,LS 2360: 002,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,ani reina-nunnelley,
+LS,2360,3,LS 2360: 003,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
+LS,2370,1,LS 2370: 001,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,ashley austi lester,
+LS,2370,2,LS 2370: 002,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,ashley austi lester,
+LS,2370,3,LS 2370: 003,0.72,0.17,0.0,0.0,0.0,0.0,0.0,0.11,ashley austi lester,
+LS,2370,4,LS 2370: 004,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,
+LS,2370,5,LS 2370: 005,0.77,0.09,0.0,0.0,0.05,0.0,0.0,0.09,ashley austi lester,
+LS,2380,2,LS 2380: 002,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,phaedra o'connell,
+LS,2380,3,LS 2380: 003,0.74,0.13,0.04,0.0,0.0,0.0,0.0,0.09,phaedra o'connell,
+LS,2380,5,LS 2380: 005,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,phaedra o'connell,
+LS,2420,1,LS 2420: 001,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
+LS,2420,2,LS 2420: 002,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,phaedra o'connell,
+LS,2420,3,LS 2420: 003,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,ranjanbala dil amin,
+LS,2420,4,LS 2420: 004,0.87,0.0,0.09,0.0,0.0,0.0,0.0,0.04,phaedra o'connell,
+LS,2420,5,LS 2420: 005,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,
+LS,2770,1,LS 2770: 001,0.36,0.55,0.0,0.0,0.0,0.0,0.0,0.09,kelly lynn womack,
+MATH,1010,1,Essen Math for Informed Soc,0.18,0.35,0.29,0.06,0.12,0.0,0.0,0.0,chelsea rose snyder,
+MATH,1010,2,Essen Math for Informed Soc,0.35,0.24,0.32,0.09,0.0,0.0,0.0,0.0,judith cottingham,
+MATH,1010,3,Essen Math for Informed Soc,0.27,0.4,0.2,0.13,0.0,0.0,0.0,0.0,matthew keogh,
+MATH,1010,4,Essen Math for Informed Soc,0.4,0.27,0.1,0.1,0.07,0.0,0.0,0.07,judith cottingham,
+MATH,1010,5,Essen Math for Informed Soc,0.37,0.16,0.21,0.11,0.11,0.0,0.0,0.05,golubinski capaverde,
+MATH,1010,6,Essen Math for Informed Soc,0.21,0.24,0.21,0.18,0.06,0.0,0.0,0.09,judith cottingham,
+MATH,1010,7,Essen Math for Informed Soc,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,honghai xu,
+MATH,1020,1,Intro to Mathematical Analysis,0.11,0.32,0.21,0.11,0.26,0.0,0.0,0.0,garrett dranichak,
+MATH,1020,2,Intro to Mathematical Analysis,0.11,0.26,0.16,0.32,0.11,0.0,0.0,0.05,karyn muir,
+MATH,1020,3,Intro to Mathematical Analysis,0.11,0.14,0.14,0.17,0.37,0.0,0.0,0.06,brian dandurand,
+MATH,1020,4,Intro to Mathematical Analysis,0.3,0.05,0.3,0.2,0.15,0.0,0.0,0.0,caroline lee burch,
+MATH,1020,5,Intro to Mathematical Analysis,0.1,0.29,0.26,0.05,0.24,0.0,0.0,0.07,randy davidson,
+MATH,1020,6,Intro to Mathematical Analysis,0.29,0.29,0.14,0.0,0.19,0.0,0.0,0.1,kara ail stasikelis,
+MATH,1020,7,Intro to Mathematical Analysis,0.18,0.23,0.3,0.18,0.08,0.0,0.0,0.05, erwin walker,
+MATH,1020,8,Intro to Mathematical Analysis,0.17,0.24,0.31,0.1,0.17,0.0,0.0,0.02,allison stoddard,
+MATH,1020,9,Intro to Mathematical Analysis,0.26,0.21,0.12,0.12,0.24,0.0,0.0,0.06,brian dandurand,
+MATH,1020,10,Intro to Mathematical Analysis,0.25,0.14,0.28,0.08,0.17,0.0,0.0,0.08,randy davidson,
+MATH,1020,11,Intro to Mathematical Analysis,0.17,0.29,0.26,0.09,0.14,0.0,0.0,0.06,randy davidson,
+MATH,1020,12,Intro to Mathematical Analysis,0.06,0.19,0.31,0.13,0.13,0.0,0.0,0.19,drew jared lipman,
+MATH,1020,13,Intro to Mathematical Analysis,0.39,0.17,0.11,0.06,0.17,0.0,0.0,0.11,paul james cubre,
+MATH,1020,14,Intro to Mathematical Analysis,0.06,0.17,0.23,0.23,0.2,0.0,0.0,0.11,brian dandurand,
+MATH,1040,1,MATH 1040: 001,0.0,0.0,0.0,0.0,0.0,0.62,0.31,0.08,lakmali weerasena,
+MATH,1040,2,MATH 1040: 002,0.0,0.0,0.0,0.0,0.0,0.62,0.31,0.07,lakmali weerasena,
+MATH,1050,400,MATH 1050: 400,0.0,0.0,0.0,0.0,0.0,0.63,0.35,0.02,eliza dar gallagher,
+MATH,1060,1,Calculus of One Variable I,0.0,0.36,0.21,0.07,0.29,0.0,0.0,0.07,sarah eliz anderson,
+MATH,1060,2,Calculus of One Variable I,0.05,0.2,0.25,0.3,0.2,0.0,0.0,0.0,charity watson,
+MATH,1060,3,Calculus of One Variable I,0.04,0.25,0.25,0.04,0.21,0.0,0.0,0.21,allen anderso guest,
+MATH,1060,4,Calculus of One Variable I,0.12,0.04,0.24,0.16,0.32,0.0,0.0,0.12,allen anderso guest,
+MATH,1060,5,Calculus of One Variable I,0.09,0.22,0.25,0.09,0.25,0.0,0.0,0.09,marion hanna,
+MATH,1060,6,Calculus of One Variable I,0.04,0.18,0.32,0.18,0.14,0.0,0.0,0.14,marilyn reba,
+MATH,1060,7,Calculus of One Variable I,0.05,0.21,0.42,0.16,0.16,0.0,0.0,0.0,damitha bandara,
+MATH,1060,8,Calculus of One Variable I,0.05,0.3,0.35,0.1,0.15,0.0,0.0,0.05,damitha bandara,
+MATH,1060,202,Calculus of One Variable I,0.32,0.32,0.11,0.0,0.16,0.0,0.0,0.11,james peterson,
+MATH,1070,1,Differen and Integral Calculus,0.16,0.43,0.18,0.09,0.11,0.0,0.0,0.02,donna simms,
+MATH,1070,2,Differen and Integral Calculus,0.15,0.57,0.15,0.07,0.04,0.0,0.0,0.02,donna simms,
+MATH,1070,3,Differen and Integral Calculus,0.23,0.3,0.38,0.06,0.02,0.0,0.0,0.0,christy jenki brown,
+MATH,1070,4,Differen and Integral Calculus,0.33,0.29,0.22,0.07,0.02,0.0,0.0,0.07,jennifer mari hanna,
+MATH,1070,5,Differen and Integral Calculus,0.36,0.21,0.28,0.09,0.06,0.0,0.0,0.0,jennifer mari hanna,
+MATH,1070,6,Differen and Integral Calculus,0.26,0.36,0.26,0.09,0.04,0.0,0.0,0.0,jennifer mari hanna,
+MATH,1080,1,Calculus of One Variable II,0.09,0.2,0.18,0.07,0.16,0.0,0.0,0.31,christa con johnson,
+MATH,1080,2,Calculus of One Variable II,0.05,0.24,0.21,0.03,0.05,0.0,0.0,0.42,terri johnson,
+MATH,1080,3,Calculus of One Variable II,0.18,0.25,0.11,0.05,0.18,0.0,0.0,0.23,anastasia br wilson,
+MATH,1080,4,Calculus of One Variable II,0.04,0.24,0.2,0.07,0.13,0.0,0.0,0.33,beth novick,
+MATH,1080,5,Calculus of One Variable II,0.09,0.26,0.24,0.04,0.0,0.0,0.0,0.37,terri johnson,
+MATH,1080,6,Calculus of One Variable II,0.02,0.29,0.11,0.09,0.07,0.0,0.0,0.42,beth novick,
+MATH,1080,7,Calculus of One Variable II,0.13,0.26,0.17,0.09,0.11,0.0,0.0,0.24,meredith nicol burr,
+MATH,1080,8,Calculus of One Variable II,0.11,0.22,0.29,0.02,0.18,0.0,0.0,0.18,christa con johnson,
+MATH,1080,9,Calculus of One Variable II,0.06,0.36,0.15,0.11,0.17,0.0,0.0,0.15,shih-wei chao,
+MATH,1080,10,Calculus of One Variable II,0.02,0.16,0.27,0.11,0.16,0.0,0.0,0.29,akshay sunil gupte,
+MATH,1080,11,Calculus of One Variable II,0.11,0.24,0.18,0.09,0.2,0.0,0.0,0.18,patrick buckingham,
+MATH,1080,12,Calculus of One Variable II,0.42,0.27,0.18,0.02,0.02,0.0,0.0,0.09,dania moham zantout,
+MATH,1080,13,Calculus of One Variable II,0.07,0.11,0.2,0.05,0.36,0.0,0.0,0.2,nathan chenette,
+MATH,1080,14,Calculus of One Variable II,0.09,0.09,0.21,0.02,0.09,0.0,0.0,0.49,rachel eli grotheer,
+MATH,1080,15,Calculus of One Variable II,0.11,0.19,0.26,0.06,0.17,0.0,0.0,0.22,nathanael dav black,
+MATH,1150,1,Contemp Math for Elem Teach I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,james kwame dogbey,
+MATH,1160,1,Contemp Math for Elem Teach II,0.56,0.31,0.03,0.09,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1160,2,Contemp Math for Elem Teach II,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1990,400,MATH 1990: 400,0.0,0.0,0.0,0.0,0.0,0.88,0.07,0.04,marion hanna,
+MATH,2030,1,Elemen Statistical Inference,0.62,0.26,0.05,0.03,0.03,0.0,0.0,0.03,laura jane shick,
+MATH,2030,2,Elemen Statistical Inference,0.44,0.23,0.15,0.13,0.0,0.0,0.0,0.05,laura jane shick,
+MATH,2030,3,Elemen Statistical Inference,0.71,0.12,0.07,0.07,0.0,0.0,0.0,0.02,laura jane shick,
+MATH,2030,4,Elemen Statistical Inference,0.49,0.29,0.06,0.06,0.09,0.0,0.0,0.03,christopher wilson,
+MATH,2030,5,Elemen Statistical Inference,0.56,0.17,0.14,0.08,0.03,0.0,0.0,0.03,stephen wesl carden,
+MATH,2030,6,Elemen Statistical Inference,0.6,0.18,0.13,0.05,0.03,0.0,0.0,0.03,dominique morgan,
+MATH,2030,7,Elemen Statistical Inference,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,yan liu,
+MATH,2060,1,Calculus of Several Variables,0.1,0.13,0.17,0.37,0.23,0.0,0.0,0.0,christopher cox,
+MATH,2060,2,Calculus of Several Variables,0.26,0.59,0.06,0.03,0.0,0.0,0.0,0.06,peter kiessler,
+MATH,2060,3,Calculus of Several Variables,0.41,0.16,0.27,0.05,0.08,0.0,0.0,0.03,charles johnson,
+MATH,2060,4,Calculus of Several Variables,0.29,0.29,0.35,0.0,0.03,0.0,0.0,0.03,chanseok park,
+MATH,2060,5,Calculus of Several Variables,0.43,0.14,0.29,0.09,0.06,0.0,0.0,0.0,timothy ch teitloff,
+MATH,2060,6,Calculus of Several Variables,0.25,0.34,0.28,0.03,0.06,0.0,0.0,0.03,svetlan poznanovikj,
+MATH,2060,7,Calculus of Several Variables,0.32,0.44,0.21,0.0,0.03,0.0,0.0,0.0,peter kiessler,
+MATH,2060,8,Calculus of Several Variables,0.18,0.35,0.24,0.03,0.15,0.0,0.0,0.06,nathan jos adelgren,
+MATH,2060,9,Calculus of Several Variables,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,martin joha schmoll,
+MATH,2060,10,Calculus of Several Variables,0.27,0.3,0.21,0.06,0.03,0.0,0.0,0.12,qingshan chen,
+MATH,2060,11,Calculus of Several Variables,0.26,0.32,0.18,0.12,0.03,0.0,0.0,0.09,xin liu,
+MATH,2060,100,Calc of Several Variable (HON),0.58,0.25,0.08,0.0,0.08,0.0,0.0,0.0,james brown,True
+MATH,2070,1,Multivariable Calculus,0.22,0.06,0.33,0.11,0.11,0.0,0.0,0.17,elaine ma sotherden,
+MATH,2070,3,Multivariable Calculus,0.35,0.35,0.29,0.0,0.0,0.0,0.0,0.0,rodney lewis keaton,
+MATH,2070,4,Multivariable Calculus,0.08,0.31,0.31,0.06,0.17,0.0,0.0,0.08,sherry biggers,
+MATH,2070,5,Multivariable Calculus,0.44,0.31,0.17,0.0,0.03,0.0,0.0,0.06,jennifer van dyken,
+MATH,2070,6,Multivariable Calculus,0.17,0.49,0.23,0.11,0.0,0.0,0.0,0.0,judith irene mcknew,
+MATH,2070,7,Multivariable Calculus,0.37,0.26,0.16,0.11,0.11,0.0,0.0,0.0,audrey nico devries,
+MATH,2070,8,Multivariable Calculus,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,lawrence mccormick,
+MATH,2070,9,Multivariable Calculus,0.26,0.53,0.11,0.11,0.0,0.0,0.0,0.0,alistair bentley,
+MATH,2070,10,Multivariable Calculus,0.17,0.44,0.28,0.11,0.0,0.0,0.0,0.0,saba za alkaseasbeh,
+MATH,2070,11,Multivariable Calculus,0.26,0.34,0.26,0.03,0.03,0.0,0.0,0.09,sherry biggers,
+MATH,2070,12,Multivariable Calculus,0.33,0.36,0.14,0.08,0.06,0.0,0.0,0.03,judith irene mcknew,
+MATH,2070,13,Multivariable Calculus,0.47,0.21,0.11,0.0,0.16,0.0,0.0,0.05,jason lee joyner,
+MATH,2070,14,Multivariable Calculus,0.32,0.26,0.26,0.11,0.0,0.0,0.0,0.05,tony thanh nguyen,
+MATH,2070,15,Multivariable Calculus,0.2,0.4,0.23,0.06,0.03,0.0,0.0,0.09,sherry biggers,
+MATH,2070,16,Multivariable Calculus,0.53,0.16,0.05,0.11,0.11,0.0,0.0,0.05,rachel malinauskas,
+MATH,2070,17,Multivariable Calculus,0.33,0.17,0.28,0.17,0.0,0.0,0.0,0.06,william bo lassiter,
+MATH,2070,18,Multivariable Calculus,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0, ushijima-mwesigwa,
+MATH,2070,19,Multivariable Calculus,0.37,0.37,0.11,0.05,0.11,0.0,0.0,0.0,zachary hollifield,
+MATH,2070,20,Multivariable Calculus,0.35,0.35,0.1,0.1,0.05,0.0,0.0,0.05,luke marti giberson,
+MATH,2070,21,Multivariable Calculus,0.15,0.48,0.24,0.03,0.03,0.0,0.0,0.06,mark thomas batell,
+MATH,2070,22,Multivariable Calculus,0.32,0.47,0.05,0.0,0.11,0.0,0.0,0.05,jason to hedetniemi,
+MATH,2070,23,Multivariable Calculus,0.16,0.47,0.32,0.0,0.05,0.0,0.0,0.0,janie caro mcdonald,
+MATH,2070,24,Multivariable Calculus,0.28,0.28,0.28,0.0,0.06,0.0,0.0,0.11,grady mcgowa thomas,
+MATH,2070,25,Multivariable Calculus,0.11,0.32,0.26,0.16,0.16,0.0,0.0,0.0,liem nguyen,
+MATH,2070,26,Multivariable Calculus,0.15,0.5,0.15,0.1,0.1,0.0,0.0,0.0,fiona may knoll,
+MATH,2080,1,Intro to Ordin Diff Equations,0.41,0.32,0.15,0.0,0.03,0.0,0.0,0.09,timothy fra parrott,
+MATH,2080,2,Intro to Ordin Diff Equations,0.35,0.29,0.23,0.06,0.03,0.0,0.0,0.03,ebrahim nasrabadi,
+MATH,2080,3,Intro to Ordin Diff Equations,0.24,0.24,0.18,0.06,0.12,0.0,0.0,0.18,shari prevost,
+MATH,2080,4,Intro to Ordin Diff Equations,0.31,0.36,0.11,0.11,0.06,0.0,0.0,0.06,mishko mitkovski,
+MATH,2080,5,Intro to Ordin Diff Equations,0.64,0.21,0.07,0.05,0.0,0.0,0.0,0.02,timothy fra parrott,
+MATH,2080,6,Intro to Ordin Diff Equations,0.12,0.3,0.27,0.12,0.12,0.0,0.0,0.06,julie lassiter,
+MATH,2080,7,Intro to Ordin Diff Equations,0.2,0.13,0.27,0.07,0.17,0.0,0.0,0.17,shari prevost,
+MATH,2080,8,Intro to Ordin Diff Equations,0.17,0.27,0.23,0.13,0.1,0.0,0.0,0.1,julie lassiter,
+MATH,2080,9,Intro to Ordin Diff Equations,0.47,0.19,0.22,0.06,0.06,0.0,0.0,0.0,timothy ch teitloff,
+MATH,2080,10,Intro to Ordin Diff Equations,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,william moss,
+MATH,2080,11,Intro to Ordin Diff Equations,0.17,0.38,0.13,0.13,0.17,0.0,0.0,0.04,brandon gra goodell,
+MATH,2080,12,Intro to Ordin Diff Equations,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,irina viktorova,
+MATH,2080,13,Intro to Ordin Diff Equations,0.41,0.41,0.05,0.02,0.07,0.0,0.0,0.02,timothy fra parrott,
+MATH,2080,14,Intro to Ordin Diff Equations,0.66,0.11,0.11,0.06,0.06,0.0,0.0,0.0,timothy ch teitloff,
+MATH,2080,15,Intro to Ordin Diff Equations,0.65,0.23,0.02,0.02,0.05,0.0,0.0,0.02,irina viktorova,
+MATH,2080,16,Intro to Ordin Diff Equations,0.62,0.19,0.12,0.05,0.02,0.0,0.0,0.0,timothy ch teitloff,
+MATH,2080,17,Intro to Ordin Diff Equations,0.32,0.37,0.13,0.05,0.08,0.0,0.0,0.05,timothy fra parrott,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.58,0.35,0.04,0.04,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,3010,1,Statistical Methods I,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hewa priyadarshani,
+MATH,3010,2,Statistical Methods I,0.27,0.23,0.23,0.1,0.13,0.0,0.0,0.03,meredith nicol burr,
+MATH,3010,3,Statistical Methods I,0.29,0.33,0.29,0.0,0.0,0.0,0.0,0.1,yanbo xia,
+MATH,3010,4,Statistical Methods I,0.33,0.27,0.0,0.27,0.07,0.0,0.0,0.07,tao yang,
+MATH,3010,5,Statistical Methods I,0.4,0.4,0.0,0.0,0.07,0.0,0.0,0.13,emily marie nystrom,
+MATH,3020,1,MATH 3020: 001,0.26,0.35,0.24,0.09,0.0,0.0,0.0,0.06,derek brown,
+MATH,3020,2,MATH 3020: 002,0.42,0.44,0.03,0.06,0.06,0.0,0.0,0.0,yingbo li,
+MATH,3020,3,MATH 3020: 003,0.41,0.41,0.07,0.05,0.02,0.0,0.0,0.02,xiaoqian sun,
+MATH,3020,4,MATH 3020: 004,0.28,0.33,0.18,0.05,0.08,0.0,0.0,0.08,calvin williams,
+MATH,3020,5,MATH 3020: 005,0.34,0.26,0.2,0.09,0.06,0.0,0.0,0.06,michael thom finney,
+MATH,3080,1,MATH 3080: 001,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,eliza dar gallagher,
+MATH,3090,1,Intro to Business Statistics,0.19,0.26,0.33,0.04,0.15,0.0,0.0,0.04,gary fellers,
+MATH,3090,2,Intro to Business Statistics,0.21,0.27,0.24,0.18,0.09,0.0,0.0,0.0,ellen hepfe breazel,
+MATH,3090,3,Intro to Business Statistics,0.22,0.41,0.19,0.03,0.09,0.0,0.0,0.06,gary fellers,
+MATH,3090,4,Intro to Business Statistics,0.05,0.16,0.26,0.32,0.21,0.0,0.0,0.0,bereket tesfaldet,
+MATH,3090,5,Intro to Business Statistics,0.2,0.27,0.3,0.1,0.03,0.0,0.0,0.1,charity watson,
+MATH,3090,6,Intro to Business Statistics,0.16,0.21,0.32,0.11,0.05,0.0,0.0,0.16,james ellis  wrenn,
+MATH,3090,7,Intro to Business Statistics,0.1,0.26,0.32,0.19,0.1,0.0,0.0,0.03,margaret mar wiecek,
+MATH,3090,8,Intro to Business Statistics,0.17,0.22,0.28,0.22,0.06,0.0,0.0,0.06,joshua crunkleton,
+MATH,3090,9,Intro to Business Statistics,0.11,0.47,0.26,0.05,0.05,0.0,0.0,0.05,andrew jo schwarzer,
+MATH,3090,10,Intro to Business Statistics,0.23,0.42,0.13,0.1,0.1,0.0,0.0,0.03,gary fellers,
+MATH,3090,11,Intro to Business Statistics,0.1,0.35,0.32,0.13,0.06,0.0,0.0,0.03,gary fellers,
+MATH,3090,12,Intro to Business Statistics,0.23,0.4,0.2,0.03,0.1,0.0,0.0,0.03,christy jenki brown,
+MATH,3110,1,Linear Algebra,0.21,0.18,0.21,0.09,0.21,0.0,0.0,0.12,jeong rock yoon,
+MATH,3110,2,Linear Algebra,0.29,0.21,0.26,0.06,0.18,0.0,0.0,0.0,neil calkin,
+MATH,3110,3,Linear Algebra,0.19,0.19,0.13,0.16,0.22,0.0,0.0,0.13,nathan chenette,
+MATH,3110,4,Linear Algebra,0.26,0.26,0.19,0.13,0.1,0.0,0.0,0.06,matthew macauley,
+MATH,3110,5,Linear Algebra,0.1,0.05,0.24,0.24,0.05,0.0,0.0,0.33,felice manganiello,
+MATH,3110,100,Linear Algebra (HON),0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,felice manganiello,True
+MATH,3150,1,MATH 3150: 001,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,3190,2,MATH 3190: 002,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,michael adam burr,
+MATH,3600,1,MATH 3600: 001,0.56,0.38,0.0,0.0,0.06,0.0,0.0,0.0,daniel warner,
+MATH,3650,1,MATH 3650: 001,0.67,0.27,0.05,0.0,0.0,0.0,0.0,0.01,leo rebholz,
+MATH,3650,2,MATH 3650: 002,0.37,0.23,0.07,0.07,0.13,0.0,0.0,0.13,timo johann heister,
+MATH,4000,1,Theory of Probability,0.38,0.31,0.19,0.03,0.09,0.0,0.0,0.0,yingbo li,
+MATH,4030,1,Intro to Statistical Theory,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,chanseok park,
+MATH,4070,1,MATH 4070: 001,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,4100,1,MATH 4100: 001,0.08,0.23,0.15,0.08,0.08,0.0,0.0,0.38,dania moham zantout,
+MATH,4120,1,Intro to Modern Algebra,0.19,0.23,0.23,0.16,0.13,0.0,0.0,0.06,matthew macauley,
+MATH,4190,1,Discrete Math Structures I,0.45,0.47,0.08,0.0,0.0,0.0,0.0,0.0,wayne goddard,
+MATH,4300,1,MATH 4300: 001,0.2,0.2,0.1,0.2,0.2,0.0,0.0,0.1, erwin walker,
+MATH,4340,1,MATH 4340: 001,0.14,0.24,0.17,0.17,0.03,0.0,0.0,0.24,eleanor jenkins,
+MATH,4340,2,MATH 4340: 002,0.2,0.14,0.29,0.11,0.09,0.0,0.0,0.17,hyesuk lee,
+MATH,4400,1,Linear Programming,0.12,0.35,0.15,0.08,0.04,0.0,0.0,0.27,akshay sunil gupte,
+MATH,4410,1,Intro to Stochastic Models,0.38,0.29,0.17,0.04,0.08,0.0,0.0,0.04,brian fralix,
+MATH,4500,1,MATH 4500: 001,0.18,0.18,0.09,0.36,0.09,0.0,0.0,0.09,vincent ervin,
+MATH,4530,1,Advanced Calculus I,0.13,0.31,0.31,0.06,0.09,0.0,0.0,0.09,taufiquar rahm khan,
+MATH,4540,1,Advanced Calculus II,0.24,0.44,0.16,0.04,0.04,0.0,0.0,0.08,taufiquar rahm khan,
+MATH,6340,1,MATH 6340: 001,0.45,0.35,0.05,0.0,0.05,0.0,0.0,0.1,vincent ervin,
+MATH,7060,400,MATH 7060: 400,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,stacy megan che,
+MATH,8030,1,MATH 8030: 001,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
+MATH,8050,1,MATH 8050: 001,0.52,0.26,0.04,0.0,0.0,0.0,0.0,0.17,derek brown,
+MATH,8060,1,MATH 8060: 001,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,8100,1,MATH 8100: 001,0.47,0.41,0.0,0.0,0.06,0.0,0.0,0.06,matthew saltzman,
+MATH,8110,1,MATH 8110: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,
+MATH,8130,1,MATH 8130: 001,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,ebrahim nasrabadi,
+MATH,8210,1,MATH 8210: 001,0.38,0.5,0.06,0.0,0.06,0.0,0.0,0.0,shitao liu,
+MATH,8220,1,MATH 8220: 001,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,
+MATH,8260,1,MATH 8260: 001,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,shitao liu,
+MATH,8520,1,MATH 8520: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,
+MATH,8530,1,MATH 8530: 001,0.47,0.12,0.29,0.0,0.06,0.0,0.0,0.06,svetlan poznanovikj,
+MATH,8540,1,MATH 8540: 001,0.46,0.31,0.0,0.0,0.0,0.0,0.0,0.23,beth novick,
+MATH,8600,1,MATH 8600: 001,0.3,0.57,0.09,0.0,0.0,0.0,0.0,0.04,qingshan chen,
+MATH,8810,1,MATH 8810: 001,0.65,0.25,0.05,0.0,0.0,0.0,0.0,0.05,christopher mcmahan,
+MATH,9830,1,Sel Top in Computational Math,0.57,0.14,0.29,0.0,0.0,0.0,0.0,0.0,timo johann heister,
+MBA,8030,1,MBA 8030: 001,0.53,0.45,0.0,0.0,0.0,0.0,0.0,0.03,matthew charl klein,
+MBA,8060,1,MBA 8060: 001,0.52,0.46,0.02,0.0,0.0,0.0,0.0,0.0,gulru fatma ozkan,
+MBA,8070,1,MBA 8070: 001,0.41,0.41,0.12,0.0,0.0,0.0,0.0,0.06,fei xie,
+MBA,8070,2,MBA 8070: 002,0.41,0.48,0.11,0.0,0.0,0.0,0.0,0.0,fei xie,
+MBA,8090,1,Org Beh & Hum Res Mg,0.64,0.34,0.0,0.0,0.02,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8190,1,Intro to Acc and Fin,0.49,0.41,0.08,0.0,0.03,0.0,0.0,0.0,jeffrey mcmillan,
+MBA,8190,2,Intro to Acc and Fin,0.31,0.58,0.12,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,
+MBA,8290,1,Marketing Foundation,0.51,0.45,0.0,0.0,0.02,0.0,0.0,0.02,william kilbourne,
+MBA,8370,1,Legal Environ of Bus,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.08,judson jahn,
+MBA,8450,1,Tech & Innova Mgt,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david orr,
+MBA,8470,1,MBA 8470: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
+MBA,8540,2,MBA 8540: 002,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,sarah martin,
+MBA,8590,1,Mgr Decision Model,0.41,0.34,0.13,0.0,0.09,0.0,0.0,0.03,sara elizabet yoder,
+MBA,8590,2,Mgr Decision Model,0.52,0.35,0.13,0.0,0.0,0.0,0.0,0.0,mark mcknew,
+MBA,8600,1,MBA 8600: 001,0.15,0.5,0.23,0.0,0.04,0.0,0.0,0.08,michael dorsch,
+MBA,8610,1,Information Systems,0.38,0.45,0.15,0.0,0.0,0.0,0.0,0.03,varun grover,
+MBA,8610,2,Information Systems,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MBA,8620,1,Managerial Economics,0.34,0.37,0.14,0.0,0.0,0.0,0.0,0.14,scott templeton,
+MBA,8700,1,MBA 8700: 001,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8720,1,MBA 8720: 001,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,
+MBA,8740,1,Managing Cont Impvmt,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,
+MBA,8750,1,MBA 8750: 001,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8990,1,Advanced Leadership,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.03,kathleen ann kegley,
+ME,2000,1,ME 2000: 001,0.67,0.22,0.04,0.01,0.03,0.0,0.0,0.02,donald beasley,
+ME,2010,1,ME 2010: 001,0.03,0.27,0.23,0.11,0.34,0.0,0.0,0.03,sherrill biggers,
+ME,2010,2,ME 2010: 002,0.15,0.25,0.19,0.08,0.24,0.0,0.0,0.08,kalyan chakr katuri,
+ME,2020,1,ME 2020: 001,0.42,0.4,0.11,0.03,0.03,0.0,0.0,0.01,lonny thompson,
+ME,2020,2,ME 2020: 002,0.58,0.3,0.08,0.0,0.03,0.0,0.0,0.02,paul jeffrey meyer,
+ME,2030,1,ME 2030: 001,0.18,0.27,0.33,0.14,0.06,0.0,0.0,0.02,xiangchun xuan,
+ME,2030,2,ME 2030: 002,0.54,0.33,0.11,0.01,0.01,0.0,0.0,0.01,david zumbrunnen,
+ME,2030,3,ME 2030: 003,0.08,0.27,0.31,0.1,0.07,0.0,0.0,0.17,donald beasley,
+ME,2220,1,ME 2220: 001,0.35,0.41,0.06,0.0,0.06,0.0,0.0,0.12,todd schweisinger,
+ME,2220,2,ME 2220: 002,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,3,ME 2220: 003,0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,4,ME 2220: 004,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,5,ME 2220: 005,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,6,ME 2220: 006,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,7,ME 2220: 007,0.16,0.68,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,8,ME 2220: 008,0.2,0.65,0.15,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3020,1,Mech of Materials,0.2,0.31,0.22,0.11,0.13,0.0,0.0,0.02,paul joseph,
+ME,3020,2,Mech of Materials,0.18,0.3,0.33,0.1,0.08,0.0,0.0,0.02,huijuan zhao,
+ME,3020,3,Mech of Materials(HONORS),0.55,0.18,0.09,0.09,0.09,0.0,0.0,0.0,paul joseph,True
+ME,3030,1,ME 3030: 001,0.12,0.24,0.3,0.14,0.12,0.0,0.0,0.08,john saylor,
+ME,3030,2,ME 3030: 002,0.05,0.41,0.43,0.09,0.0,0.0,0.0,0.02,richard miller,
+ME,3040,1,ME 3040: 001,0.09,0.23,0.26,0.09,0.09,0.0,0.0,0.23,jean-marc delhaye,
+ME,3040,2,ME 3040: 002,0.15,0.27,0.33,0.09,0.11,0.0,0.0,0.05,jay ochterbeck,
+ME,3050,1,ME 3050: 001,0.32,0.28,0.26,0.06,0.08,0.0,0.0,0.0,mohammed fari daqaq,
+ME,3050,2,ME 3050: 002,0.32,0.36,0.16,0.08,0.04,0.0,0.0,0.04,phanin tallapragada,
+ME,3060,1,ME 3060: 001,0.26,0.36,0.25,0.09,0.04,0.0,0.0,0.0,todd schweisinger,
+ME,3060,2,ME 3060: 002,0.19,0.47,0.26,0.05,0.02,0.0,0.0,0.02,paul jeffrey meyer,
+ME,3080,1,Fluid Mechanics,0.1,0.19,0.24,0.29,0.14,0.0,0.0,0.05,jean-marc delhaye,
+ME,3080,2,Fluid Mechanics,0.12,0.33,0.45,0.02,0.06,0.0,0.0,0.02,ilenia battiato,
+ME,3100,1,ME 3100: 001,0.22,0.17,0.33,0.13,0.13,0.0,0.0,0.02,jay ochterbeck,
+ME,3120,1,ME 3120: 001,0.36,0.56,0.08,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+ME,3120,2,ME 3120: 002,0.17,0.66,0.14,0.03,0.0,0.0,0.0,0.0,rod martinez-duarte,
+ME,3330,1,ME 3330: 001,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,todd schweisinger,
+ME,3330,2,ME 3330: 002,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,3,ME 3330: 003,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
+ME,3330,5,ME 3330: 005,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,6,ME 3330: 006,0.36,0.57,0.0,0.0,0.07,0.0,0.0,0.0,todd schweisinger,
+ME,3330,7,ME 3330: 007,0.07,0.8,0.07,0.07,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4010,1,ME 4010: 001,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,joshua summers,
+ME,4020,1,ME 4020: 001,0.38,0.44,0.13,0.06,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,2,ME 4020: 002,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,sherrill biggers,
+ME,4020,3,ME 4020: 003,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,5,ME 4020: 005,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,4020,6,ME 4020: 006,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,7,ME 4020: 007,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4030,1,ME 4030: 001,0.21,0.23,0.31,0.13,0.1,0.0,0.0,0.03, timothy freeman,
+ME,4030,2,ME 4030: 002,0.24,0.32,0.34,0.11,0.0,0.0,0.0,0.0,ardalan vahidi,
+ME,4170,1,ME 4170: 001,0.44,0.48,0.07,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4220,1,ME 4220: 001,0.34,0.31,0.24,0.07,0.03,0.0,0.0,0.0,abhijit som,
+ME,4230,1,ME 4230: 001,0.2,0.34,0.37,0.06,0.0,0.0,0.0,0.03,richard figliola,
+ME,4260,1,ME 4260: 001,0.22,0.53,0.25,0.0,0.0,0.0,0.0,0.0,david zumbrunnen,
+ME,4320,1,ME 4320: 001,0.32,0.58,0.03,0.0,0.0,0.0,0.0,0.06,gang li,
+ME,4440,1,ME 4440: 001,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,3,ME 4440: 003,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4710,1,ME 4710: 001,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4930,1,Selected Topics ME (HVAC),0.27,0.43,0.27,0.0,0.0,0.0,0.0,0.03,donald willoughby,
+ME,6220,1,ME 6220: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,
+ME,6710,1,ME 6710: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,8120,1,ME 8120: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
+ME,8190,1,ME 8190: 001,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,
+ME,8200,1,ME 8200: 001,0.52,0.41,0.04,0.0,0.0,0.0,0.0,0.04,yue wang,
+ME,8310,1,ME 8310: 001,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rui qiao,
+ME,8520,1,ME 8520: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gang li,
+ME,8520,2,ME 8520: 002,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,gang li,
+ME,8610,1,ME 8610: 001,0.66,0.29,0.04,0.0,0.0,0.0,0.0,0.02,mica grujicic,
+ME,8730,1,ME 8730: 001,0.27,0.2,0.47,0.0,0.0,0.0,0.0,0.07,joshua summers,
+ME,8930,1,ME 8930: 001,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,nicole gise coutris,
+MGT,2010,1,Principles of Mgt,0.26,0.35,0.25,0.09,0.02,0.0,0.0,0.03,katherine clark,
+MGT,2010,2,Principles of Mgt,0.26,0.32,0.24,0.12,0.04,0.0,0.0,0.02,katherine clark,
+MGT,2010,3,Principles of Mgt,0.15,0.43,0.26,0.05,0.01,0.0,0.0,0.1,katherine clark,
+MGT,2010,4,Principles of Mgt,0.23,0.32,0.28,0.08,0.03,0.0,0.0,0.06,katherine clark,
+MGT,2010,5,Principles of Mgt,0.28,0.39,0.2,0.08,0.02,0.0,0.0,0.02,tina robbins,
+MGT,2010,6,Principles of Mgt,0.14,0.46,0.25,0.12,0.01,0.0,0.0,0.03,tina robbins,
+MGT,2010,7,Principles of Mgt,0.23,0.4,0.24,0.09,0.01,0.0,0.0,0.04,tina robbins,
+MGT,2010,8,Principles of Mgt,0.14,0.44,0.25,0.1,0.02,0.0,0.0,0.05,tina robbins,
+MGT,2010,9,Principles of Mgt(HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
+MGT,2180,125,MGT 2180: 125,0.31,0.44,0.15,0.04,0.01,0.01,0.0,0.04, sridharan,
+MGT,2180,230,MGT 2180: 230,0.28,0.43,0.2,0.03,0.03,0.0,0.0,0.03, sridharan,
+MGT,2180,335,MGT 2180: 335,0.22,0.43,0.23,0.06,0.01,0.0,0.0,0.05, sridharan,
+MGT,2180,905,MGT 2180: 905,0.32,0.49,0.12,0.01,0.02,0.01,0.0,0.03, sridharan,
+MGT,3070,1,Human Resource Management,0.13,0.41,0.38,0.08,0.0,0.0,0.0,0.0,marvin monroe ward,
+MGT,3070,2,Human Resource Management,0.13,0.5,0.33,0.05,0.0,0.0,0.0,0.0,marvin monroe ward,
+MGT,3070,3,Human Resource Management,0.21,0.32,0.39,0.03,0.05,0.0,0.0,0.0,marvin monroe ward,
+MGT,3070,4,Human Resource Management,0.31,0.6,0.06,0.0,0.03,0.0,0.0,0.0,kristin dam scott,
+MGT,3070,5,Human Resource Management,0.24,0.71,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,6,Human Resource Management,0.28,0.58,0.13,0.03,0.0,0.0,0.0,0.0,michael cole,
+MGT,3100,1,Intermed Business Statistics,0.07,0.28,0.26,0.16,0.12,0.0,0.0,0.12,zachary mo leffakis,
+MGT,3100,2,Intermed Business Statistics,0.3,0.3,0.19,0.12,0.05,0.0,0.0,0.05,zachary mo leffakis,
+MGT,3100,3,Intermed Business Statistics,0.19,0.33,0.21,0.05,0.02,0.0,0.0,0.19,niratc tungtisanont,
+MGT,3100,4,Intermed Business Statistics,0.23,0.43,0.23,0.03,0.0,0.0,0.0,0.1,james walsh,
+MGT,3100,5,Intermed Business Statistics,0.35,0.43,0.1,0.0,0.08,0.0,0.0,0.05,jerry kermi bilbrey,
+MGT,3100,6,Intermed Business Statistics,0.3,0.48,0.2,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3100,7,Intermed Business Statistics,0.14,0.26,0.07,0.11,0.11,0.0,0.0,0.3,sara elizabet yoder,
+MGT,3100,8,Intermed Business Statistics,0.11,0.26,0.22,0.18,0.03,0.0,0.0,0.2,sara elizabet yoder,
+MGT,3100,10,Intermed Business Statistics,0.21,0.31,0.28,0.14,0.03,0.0,0.0,0.03,lianlian jiang,
+MGT,3100,11,Intermed Business Statistics,0.33,0.38,0.1,0.08,0.05,0.0,0.0,0.05,kevin mckenzie,
+MGT,3120,1,Decision Models for Mgt,0.27,0.3,0.24,0.08,0.08,0.0,0.0,0.03,mark mcknew,
+MGT,3120,2,Decision Models for Mgt,0.48,0.29,0.12,0.02,0.1,0.0,0.0,0.0,mark mcknew,
+MGT,3120,3,Decision Models for Mgt,0.29,0.24,0.34,0.02,0.1,0.0,0.0,0.0,mark mcknew,
+MGT,3150,1,New Venture Creation,0.21,0.33,0.42,0.0,0.03,0.0,0.0,0.0,peter gianiodis,
+MGT,3170,1,Logistics Mgmt,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,shouqiang wang,
+MGT,3180,1,Mgt of Info Systems,0.35,0.38,0.25,0.0,0.0,0.0,0.0,0.03,heshan sun,
+MGT,3180,2,Mgt of Info Systems,0.43,0.5,0.05,0.0,0.0,0.0,0.0,0.03,dan jiang,
+MGT,3180,3,Mgt of Info Systems,0.22,0.39,0.37,0.02,0.0,0.0,0.0,0.0,roopa raman,
+MGT,3180,4,Mgt of Info Systems,0.43,0.48,0.08,0.0,0.03,0.0,0.0,0.0,tina marie esposito,
+MGT,3900,1,Ops Mgt,0.08,0.33,0.28,0.22,0.06,0.0,0.0,0.03,yunsik choi,
+MGT,3900,2,Ops Mgt,0.13,0.43,0.38,0.08,0.0,0.0,0.0,0.0,jerry kermi bilbrey,
+MGT,3900,3,Ops Mgt,0.35,0.35,0.25,0.03,0.03,0.0,0.0,0.0,jerry kermi bilbrey,
+MGT,3900,4,Ops Mgt,0.2,0.39,0.33,0.06,0.02,0.0,0.0,0.0,lawrence fredendall,
+MGT,3900,5,Ops Mgt,0.24,0.49,0.17,0.05,0.05,0.0,0.0,0.0,yann ferrand,
+MGT,4000,1,Mgt of Org Beh,0.25,0.35,0.38,0.03,0.0,0.0,0.0,0.0,philip roth,
+MGT,4000,2,Mgt of Org Beh,0.16,0.62,0.22,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,3,Mgt of Org Beh,0.26,0.59,0.13,0.0,0.0,0.03,0.0,0.0,michael cole,
+MGT,4000,4,Mgt of Org Beh,0.35,0.58,0.08,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MGT,4020,1,Ops Pln and Ctl,0.1,0.48,0.14,0.14,0.14,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4030,1,Bus Intelligence & Analytics,0.26,0.35,0.19,0.03,0.16,0.0,0.0,0.0,siyuan li,
+MGT,4110,1,Project Management,0.32,0.35,0.27,0.0,0.03,0.0,0.0,0.03,russell purvis,
+MGT,4120,1,Supplier Management,0.26,0.54,0.17,0.03,0.0,0.0,0.0,0.0,shouqiang wang,
+MGT,4150,1,Business Strategy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,2,Business Strategy,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,3,Business Strategy,0.78,0.2,0.0,0.0,0.02,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,4,Business Strategy,0.17,0.51,0.32,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,
+MGT,4150,5,Business Strategy,0.09,0.5,0.35,0.04,0.0,0.0,0.0,0.02,jason wayne ridge,
+MGT,4150,6,Business Strategy,0.32,0.49,0.14,0.0,0.05,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,7,Business Strategy,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,8,Business Strategy,0.32,0.48,0.16,0.03,0.0,0.0,0.0,0.0,peter gianiodis,
+MGT,4160,1,Special Topics Hr,0.32,0.61,0.05,0.0,0.03,0.0,0.0,0.0,kristin dam scott,
+MGT,4230,1,Intern Bus Mgt,0.1,0.54,0.28,0.08,0.0,0.0,0.0,0.0,janis miller,
+MGT,4230,2,Intern Bus Mgt,0.08,0.58,0.25,0.03,0.05,0.0,0.0,0.03,janis miller,
+MGT,4230,3,Intern Bus Mgt,0.13,0.26,0.51,0.05,0.05,0.0,0.0,0.0,wayne stewart,
+MGT,4230,4,Intern Bus Mgt,0.1,0.25,0.6,0.05,0.0,0.0,0.0,0.0,wayne stewart,
+MGT,4240,1,Global Supply Chain,0.17,0.6,0.23,0.0,0.0,0.0,0.0,0.0,yann ferrand,
+MGT,4270,1,Managing Improvement,0.11,0.59,0.22,0.07,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4310,1,Emp Rights & Resp,0.16,0.42,0.32,0.05,0.03,0.0,0.0,0.03,marvin monroe ward,
+MGT,4350,1,Pers Interviewing,0.3,0.5,0.18,0.03,0.0,0.0,0.0,0.0,philip roth,
+MGT,4520,1,Business Analysis,0.21,0.43,0.21,0.0,0.07,0.0,0.0,0.07,roopa raman,
+MGT,4550,1,Emerging I T Trends,0.28,0.61,0.06,0.03,0.03,0.0,0.0,0.0,jason thatcher,
+MGT,4560,1,Business Info Mgt,0.21,0.36,0.24,0.06,0.06,0.0,0.0,0.06,siyuan li,
+MGT,8120,1,Supply Chain Mgt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,gulru fatma ozkan,
+MGT,9040,1,MGT 9040: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,heshan sun,
+MHA,7320,400,MHA 7320: 400,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+MICR,3050,1,MICR 3050: 001,0.38,0.4,0.15,0.06,0.01,0.0,0.0,0.0,kristi ja whitehead,
+MICR,3050,2,MICR 3050: 002,0.38,0.4,0.17,0.03,0.0,0.0,0.0,0.03,krista barr rudolph,
+MICR,3050,3,MICR 3050: 003,0.62,0.24,0.09,0.03,0.0,0.0,0.0,0.03,krista barr rudolph,
+MICR,4000,1,Public Health Micro,0.52,0.18,0.25,0.05,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4070,1,Food and Dairy Micro,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,xiuping jiang,
+MICR,4110,1,Pathogenic Bact,0.36,0.44,0.16,0.04,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
+MICR,4120,1,Bacterial Physiology,0.11,0.32,0.23,0.17,0.15,0.0,0.0,0.02,thomas hughes,
+MICR,4130,1,Industrial Micro,0.41,0.5,0.05,0.03,0.0,0.0,0.0,0.02,tzuen-rong je tzeng,
+MICR,4140,1,Basic Immunology,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,charles rice,
+MICR,4170,1,Cancer and Aging,0.57,0.2,0.11,0.06,0.0,0.0,0.0,0.06,yuqing dong,
+MICR,4210,2,MICR 4210: 002,0.57,0.21,0.07,0.14,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
+MICR,4220,1,MICR 4220: 001,0.75,0.15,0.05,0.05,0.0,0.0,0.0,0.0,thomas hughes,
+MICR,4220,2,MICR 4220: 002,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,
+MICR,4220,3,MICR 4220: 003,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,
+MKT,3010,1,Prin of Marketing,0.27,0.55,0.14,0.04,0.0,0.0,0.0,0.0,carter wil mcelveen,
+MKT,3010,2,Prin of Marketing,0.36,0.41,0.18,0.03,0.01,0.0,0.0,0.01,james gaubert,
+MKT,3010,3,Prin of Marketing,0.29,0.4,0.2,0.07,0.03,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,4,Prin of Marketing,0.26,0.5,0.15,0.07,0.01,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,5,Prin of Marketing,0.24,0.41,0.23,0.07,0.02,0.0,0.0,0.03,patricia knowles,
+MKT,3020,1,Consumer Behavior,0.65,0.28,0.04,0.02,0.02,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,2,Consumer Behavior,0.66,0.32,0.02,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,3,Consumer Behavior,0.36,0.44,0.12,0.02,0.04,0.0,0.0,0.02, thyroff fitzwater,
+MKT,3020,4,Consumer Behavior,0.26,0.3,0.24,0.09,0.09,0.0,0.0,0.02, thyroff fitzwater,
+MKT,3210,1,Sports Marketing,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3980,1,Creative Inquiry in Marketing,0.96,0.0,0.02,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,
+MKT,4200,1,Professional Selling,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,2,Professional Selling,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jesse moore,
+MKT,4200,3,Professional Selling,0.5,0.35,0.08,0.0,0.08,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4200,4,Professional Selling,0.75,0.21,0.0,0.04,0.0,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4230,1,Promotional Strategy,0.32,0.38,0.22,0.04,0.0,0.0,0.0,0.04,patricia knowles,
+MKT,4240,1,Sales Management,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4270,1,International Mktg,0.28,0.14,0.38,0.14,0.0,0.0,0.0,0.07,charles duke,
+MKT,4270,2,International Mktg,0.2,0.27,0.5,0.0,0.0,0.0,0.0,0.03,charles duke,
+MKT,4270,3,International Mktg,0.42,0.36,0.15,0.03,0.03,0.0,0.0,0.0,roger gomes,
+MKT,4270,4,International Mktg,0.29,0.47,0.21,0.0,0.0,0.0,0.0,0.03,roger gomes,
+MKT,4270,5,International Mktg,0.21,0.58,0.12,0.09,0.0,0.0,0.0,0.0,roger gomes,
+MKT,4280,1,Services Marketing,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,james gaubert,
+MKT,4310,1,Marketing Research,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,2,Marketing Research,0.35,0.57,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,3,Marketing Research,0.18,0.61,0.18,0.03,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4330,1,Sport Mkt Strategy,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,
+MKT,4430,1,Advertising Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,albert neil cameron,
+MKT,4450,1,Macromarketing,0.56,0.34,0.03,0.0,0.0,0.06,0.0,0.0,william kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.19,0.63,0.19,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,2,Strategic Mktg Mgt,0.18,0.76,0.06,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4500,3,Strategic Mktg Mgt,0.43,0.5,0.03,0.03,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,4500,4,Strategic Mktg Mgt,0.08,0.4,0.44,0.08,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4950,1,Selected Topics,0.28,0.39,0.17,0.06,0.0,0.0,0.0,0.11,peter weathers,
+MKT,8620,1,MKT 8620: 001,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
+MKT,8650,1,MKT 8650: 001,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MKT,8660,1,Professional Selling,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,ryan mullins,
+ML,1020,1,Leadership Fund II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,garry michae hansel,
+ML,1020,2,Leadership Fund II,0.57,0.24,0.1,0.0,0.05,0.0,0.0,0.05,garry michae hansel,
+ML,2020,1,ML 2020: 001,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thierry andre bras,
+ML,2020,2,ML 2020: 002,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,thierry andre bras,
+ML,3020,2,Adv Leadership II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,
+MSE,2100,1,MSE 2100: 001,0.3,0.38,0.24,0.04,0.02,0.0,0.0,0.01,marian kennedy,
+MSE,2100,2,MSE 2100: 002,0.27,0.3,0.27,0.08,0.03,0.0,0.0,0.05,eric skaar,
+MSE,2100,3,MSE 2100: 003,0.42,0.19,0.3,0.03,0.04,0.0,0.0,0.02,julie patric martin,
+MSE,2500,1,MSE 2500: 001,0.68,0.25,0.04,0.0,0.04,0.0,0.0,0.0,deborah lickfield,
+MSE,3260,1,MSE 3260: 001,0.24,0.26,0.36,0.09,0.04,0.0,0.0,0.01,gary lickfield,
+MSE,3280,1,MSE 3280: 001,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,eric skaar,
+MSE,3420,2,MSE 3420: 002,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,rajendra kum bordia,
+MSE,3610,1,MSE 3610: 001,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,marian kennedy,
+MSE,4160,1,MSE 4160: 001,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,eric skaar,
+MSE,4220,1,MSE 4220: 001,0.26,0.52,0.19,0.0,0.0,0.0,0.0,0.04,vincent yves blouin,
+MSE,4330,1,MSE 4330: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,
+MSE,4560,1,MSE 4560: 001,0.25,0.5,0.19,0.0,0.06,0.0,0.0,0.0,gary lickfield,
+MUSC,1120,2,Beg Class Guitar II,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,david stevenson,
+MUSC,1420,2,MUSC 1420: 002,0.6,0.1,0.0,0.0,0.1,0.0,0.0,0.2,dan rash,
+MUSC,1430,2,MUSC 1430: 002,0.7,0.0,0.0,0.0,0.1,0.0,0.0,0.2,dan rash,
+MUSC,1800,1,MUSC 1800: 001,0.25,0.67,0.0,0.0,0.08,0.0,0.0,0.0,hamilton altstatt,
+MUSC,2100,1,Music in West World,0.68,0.13,0.16,0.0,0.0,0.0,0.0,0.03,eric lapin,
+MUSC,2100,2,Music in West World,0.45,0.25,0.25,0.03,0.0,0.0,0.0,0.03,lisa sain odom,
+MUSC,2100,3,Music in West World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,2100,4,Music in West World,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,5,Music in West World,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,6,Music in West World,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,9,Music in West World,0.55,0.39,0.03,0.0,0.0,0.0,0.0,0.03,lea kibler,
+MUSC,3110,1,MUSC 3110: 001,0.57,0.33,0.07,0.03,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,eric lapin,
+MUSC,3170,1,Hist of Country Mus,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3310,1,MUSC 3310: 001,0.86,0.06,0.04,0.0,0.0,0.0,0.0,0.04,timothy ra hurlburt,
+MUSC,3310,2,MUSC 3310: 002,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,
+MUSC,3620,1,Symphonic Band,0.91,0.02,0.04,0.0,0.0,0.0,0.0,0.02,mark spede,
+MUSC,3690,1,Symphony Orchestra,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,
+MUSC,3700,1,Clemson University Singers,0.91,0.04,0.02,0.0,0.02,0.0,0.0,0.02,justin durham,
+MUSC,3710,1,Women's Glee,0.92,0.02,0.03,0.0,0.03,0.0,0.0,0.0,justin durham,
+MUSC,3720,1,Men's Glee,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,david conley,
+MUSC,4160,1,MUSC 4160: 001,0.28,0.36,0.28,0.08,0.0,0.0,0.0,0.0,linda li-bleuel,
+NPL,3010,1,NPL 3010: 001,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,tracy diane lamb,
+NPL,3030,1,NPL 3030: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,wendell price,
+NURS,3030,1,NURS 3030: 001,0.36,0.51,0.1,0.0,0.0,0.0,0.0,0.03,leslie anne  ravan,
+NURS,3030,400,NURS 3030: 400,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,
+NURS,3100,1,NURS 3100: 001,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3110,1,NURS 3110: 001,0.95,0.03,0.0,0.0,0.03,0.0,0.0,0.0,janice garri lanham,
+NURS,3120,1,NURS 3120: 001,0.42,0.55,0.03,0.0,0.0,0.0,0.0,0.0,angela pye,
+NURS,3190,400,NURS 3190: 400,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,kelly jordan smith,
+NURS,3200,1,NURS 3200: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+NURS,3330,1,Health Care Genetics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,
+NURS,3330,400,Health Care Genetics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+NURS,3400,1,NURS 3400: 001,0.21,0.66,0.08,0.03,0.03,0.0,0.0,0.0,catherine si murton,
+NURS,4010,1,NURS 4010: 001,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NURS,4030,1,NURS 4030: 001,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
+NURS,4100,1,NURS 4100: 001,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,
+NURS,4110,1,NURS 4110: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
+NURS,4120,1,NURS 4120: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4150,1,NURS 4150: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jackie gillespie,
+NURS,4250,400,NURS 4250: 400,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
+NURS,4280,1,Senior Honors II (HON),0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,nancy meehan,True
+NURS,8010,400,NURS 8010: 400,0.56,0.36,0.03,0.0,0.0,0.0,0.0,0.05,shirley mae timmons,
+NURS,8080,400,NURS 8080: 400,0.71,0.24,0.02,0.0,0.02,0.0,0.0,0.0,veronica parker,
+NURS,8200,400,NURS 8200: 400,0.2,0.7,0.0,0.0,0.0,0.0,0.0,0.1,heide temples,
+NURS,8210,400,NURS 8210: 400,0.68,0.27,0.0,0.0,0.0,0.0,0.0,0.05,tracy king fasolino,
+NURS,8480,400,NURS 8480: 400,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,bonnie holaday,
+NURS,8850,400,NURS 8850: 400,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.37,0.43,0.12,0.01,0.02,0.0,0.0,0.04,rita haliena,
+NUTR,4250,1,Medica Nutr Thera II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4260,1,NUTR 4260: 001,0.51,0.45,0.04,0.0,0.0,0.0,0.0,0.0,rita haliena,
+NUTR,4550,1,NUTR 4550: 001,0.48,0.39,0.1,0.0,0.03,0.0,0.0,0.0,elliot jesch,
+NUTR,8030,1,NUTR 8030: 001,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,vivian haley-zitlin,
+PA,2010,1,PA 2010: 001,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,ned hosler,
+PA,2800,1,PA 2800: 001,0.38,0.0,0.23,0.0,0.08,0.0,0.0,0.31,kenneth moore,
+PADM,8220,400,PADM 8220: 400,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,mark daniel mellott,
+PADM,8340,400,PADM 8340: 400,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew moorman,
+PADM,8680,400,PADM 8680: 400,0.36,0.57,0.0,0.0,0.07,0.0,0.0,0.0,alfred bundrick,
+PHIL,1010,1,Intro to Phil Prob,0.47,0.35,0.06,0.03,0.03,0.0,0.0,0.06,david stegall,
+PHIL,1010,2,Intro to Phil Prob,0.68,0.18,0.09,0.0,0.0,0.0,0.0,0.06,david stegall,
+PHIL,1010,3,Intro to Phil Prob,0.45,0.36,0.15,0.0,0.03,0.0,0.0,0.0,christopher grau,
+PHIL,1020,1,Intro to Logic,0.73,0.09,0.03,0.03,0.09,0.0,0.0,0.03,michael hal hannen,
+PHIL,1020,2,Intro to Logic,0.68,0.15,0.06,0.0,0.03,0.0,0.0,0.09,michael hal hannen,
+PHIL,1020,3,Intro to Logic,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,4,Intro to Logic,0.28,0.22,0.25,0.0,0.03,0.0,0.0,0.22,cecilea mun,
+PHIL,1020,5,Intro to Logic,0.07,0.43,0.11,0.0,0.04,0.0,0.0,0.36,cecilea mun,
+PHIL,1020,6,Intro to Logic,0.19,0.08,0.0,0.0,0.04,0.0,0.0,0.69,cecilea mun,
+PHIL,1030,1,Intro to Ethics HON,0.63,0.26,0.0,0.05,0.0,0.0,0.0,0.05,stephen satris,True
+PHIL,1030,2,Intro to Ethics,0.57,0.3,0.08,0.0,0.0,0.0,0.0,0.05,david stegall,
+PHIL,1030,3,Intro to Ethics,0.36,0.53,0.03,0.0,0.0,0.0,0.0,0.08,stephen satris,
+PHIL,1030,4,Intro to Ethics,0.38,0.32,0.26,0.03,0.0,0.0,0.0,0.0,jennifer ingle,
+PHIL,1030,5,Intro to Ethics,0.36,0.45,0.06,0.06,0.03,0.0,0.0,0.03,jennifer ingle,
+PHIL,1030,6,Intro to Ethics,0.17,0.53,0.23,0.0,0.0,0.0,0.0,0.07,charles starkey,
+PHIL,3040,1,PHIL 3040: 001,0.54,0.39,0.04,0.0,0.0,0.0,0.0,0.04,michael hal hannen,
+PHIL,3050,1,PHIL 3050: 001,0.29,0.5,0.18,0.0,0.04,0.0,0.0,0.0,todd may,
+PHIL,3150,1,PHIL 3150: 001,0.32,0.32,0.14,0.07,0.07,0.0,0.0,0.07,jennifer ingle,
+PHIL,3160,1,Mod Phil,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,charles starkey,
+PHIL,3200,1,PHIL 3200: 001,0.38,0.5,0.0,0.0,0.08,0.0,0.0,0.04,candice delmas,
+PHIL,3250,1,Phil of Science,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,cecilea mun,
+PHIL,3260,1,Science and Values,0.56,0.32,0.09,0.0,0.0,0.0,0.0,0.03,andrew garnar,
+PHIL,3260,2,Science and Values,0.47,0.26,0.18,0.0,0.03,0.0,0.0,0.06,andrew garnar,
+PHIL,3260,3,Science and Values,0.47,0.44,0.06,0.0,0.03,0.0,0.0,0.0,andrew garnar,
+PHIL,3300,1,PHIL 3300: 001,0.5,0.35,0.08,0.04,0.0,0.0,0.0,0.04,todd may,
+PHIL,3430,1,PHIL 3430: 001,0.33,0.47,0.13,0.0,0.03,0.0,0.0,0.03,candice delmas,
+PHIL,3440,1,Business Ethics,0.83,0.15,0.0,0.0,0.0,0.0,0.0,0.03,david stegall,
+PHIL,3480,1,PHIL 3480: 001,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,christopher grau,
+PHIL,3490,1,Gender and Sexuality,0.45,0.31,0.14,0.03,0.03,0.0,0.0,0.03,jennifer ingle,
+PHIL,3990,1,PHIL 3990: 001,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,kelly smith,
+PHSC,1170,1,Intro Chem & Earth,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics With Cal I,0.12,0.39,0.32,0.08,0.05,0.0,0.0,0.05,lih-sin the,
+PHYS,1220,2,Physics With Cal I,0.21,0.42,0.27,0.07,0.02,0.0,0.0,0.01,lih-sin the,
+PHYS,1220,3,Physics With Cal I,0.3,0.44,0.19,0.02,0.03,0.0,0.0,0.02,lih-sin the,
+PHYS,1220,4,Physics With Cal I,0.2,0.33,0.33,0.05,0.06,0.0,0.0,0.03,jason stratfo brown,
+PHYS,1220,5,Physics With Cal I,0.22,0.39,0.24,0.06,0.05,0.0,0.0,0.04,mark leising,
+PHYS,1220,8,Physics With Cal I HON,0.36,0.31,0.24,0.05,0.02,0.0,0.0,0.02,joan marler,True
+PHYS,1240,1,Physics Lab I,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,2,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,3,Physics Lab I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,4,Physics Lab I,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,5,Physics Lab I,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,6,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,7,Physics Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,8,PHYSICS LAB I,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,9,Physics Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,10,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,11,Physics Lab I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,12,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,13,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,14,Physics Lab I,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,1240,15,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,16,Physics Lab I,0.17,0.61,0.06,0.0,0.0,0.0,0.0,0.17,jerry hester,
+PHYS,1240,17,Physics Lab I,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,18,Physics Lab I,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,19,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,20,Physics Lab I,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,21,Physics Lab I,0.32,0.42,0.0,0.0,0.0,0.0,0.0,0.26,jerry hester,
+PHYS,1240,22,Physics Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,
+PHYS,1240,23,Physics Lab I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,jerry hester,
+PHYS,1240,24,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,25,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,26,Physics Lab I,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,27,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,29,Physics Lab I,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2000,1,PHYS 2000: 001,0.34,0.38,0.26,0.0,0.0,0.0,0.0,0.02,amy liann pope,
+PHYS,2070,1,General Physics I,0.28,0.35,0.19,0.08,0.05,0.0,0.0,0.06,amy liann pope,
+PHYS,2080,1,General Physics II,0.33,0.46,0.13,0.07,0.01,0.0,0.0,0.0,pooja puneet,
+PHYS,2080,2,General Physics II,0.44,0.38,0.13,0.03,0.01,0.0,0.0,0.01,pooja puneet,
+PHYS,2090,1,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,2,Gen Phys Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,3,Gen Phys Lab I,0.33,0.54,0.04,0.08,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,4,Gen Phys Lab I,0.53,0.16,0.21,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,2090,5,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,6,Gen Phys Lab I,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,7,Gen Phys Lab I,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,8,Gen Phys Lab I,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,9,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,10,Gen Phys Lab I,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,1,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,2,Gen Phys Lab II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,3,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,4,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,6,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,7,Gen Phys Lab II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,8,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,9,Gen Phys Lab II,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,10,Gen Phys Lab II,0.54,0.29,0.08,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2100,11,Gen Phys Lab II,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,12,Gen Phys Lab II,0.63,0.21,0.04,0.0,0.04,0.0,0.0,0.08,jerry hester,
+PHYS,2100,13,Gen Phys Lab II,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,14,Gen Phys Lab II,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2100,15,Gen Phys Lab II,0.21,0.67,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,16,Gen Phys Lab II,0.23,0.5,0.18,0.05,0.05,0.0,0.0,0.0,jerry hester,
+PHYS,2210,1,Physics With Cal II,0.3,0.29,0.26,0.09,0.03,0.0,0.0,0.02,jason stratfo brown,
+PHYS,2210,2,Physics With Cal II,0.28,0.39,0.22,0.07,0.03,0.0,0.0,0.03,jason stratfo brown,
+PHYS,2210,3,Physics With Cal II,0.46,0.23,0.08,0.23,0.0,0.0,0.0,0.0,murray daw,
+PHYS,2220,1,Phys With Cal III,0.57,0.3,0.11,0.0,0.03,0.0,0.0,0.0,hye jung kang,
+PHYS,2230,2,Physics Lab II,0.35,0.29,0.29,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,3,Physics Lab II,0.71,0.18,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,
+PHYS,2230,4,Physics Lab II,0.13,0.63,0.13,0.13,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,5,Physics Lab II,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,6,Physics Lab II,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,8,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2240,1,Physics Lab III,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,2240,2,Physics Lab III,0.41,0.53,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2400,1,Phys of Weather ONLINE,0.31,0.29,0.18,0.1,0.04,0.0,0.0,0.08,miguel larsen,
+PHYS,3120,1,PHYS 3120: 001,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,feng ding,
+PHYS,3220,1,Mechanics II,0.27,0.33,0.2,0.13,0.0,0.0,0.0,0.07,john meriwether,
+PHYS,3260,1,Exper Physics II,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,chad sosolik,
+PHYS,3560,1,PHYS 3560: 001,0.58,0.25,0.0,0.08,0.0,0.0,0.0,0.08,chad sosolik,
+PHYS,4410,1,Electromagnetics I,0.27,0.45,0.18,0.0,0.0,0.0,0.0,0.09,endre andras takacs,
+PHYS,4560,1,Quantum Physics II,0.08,0.77,0.15,0.0,0.0,0.0,0.0,0.0,jian he,
+PHYS,4650,1,Thermo and Stat Mech,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,jeremy king,
+PHYS,8150,1,Statistical Therm I,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,jens oberheide,
+PHYS,8410,1,PHYS 8410: 001,0.11,0.72,0.11,0.0,0.0,0.0,0.0,0.06,gerald lehmacher,
+PHYS,9520,1,PHYS 9520: 001,0.06,0.33,0.61,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
+PKSC,1020,1,PKSC 1020: 001,0.19,0.51,0.15,0.13,0.03,0.0,0.0,0.0,heather batt,
+PKSC,2010,1,PKSC 2010: 001,0.19,0.33,0.3,0.12,0.06,0.0,0.0,0.0,heather batt,
+PKSC,2020,1,PKSC 2020: 001,0.53,0.24,0.24,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2040,1,PKSC 2040: 001,0.66,0.16,0.13,0.02,0.02,0.0,0.0,0.02,robert truett moore,
+PKSC,2060,1,PKSC 2060: 001,0.93,0.04,0.0,0.04,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2200,1,PKSC 2200: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,william aaro snyder,
+PKSC,3200,1,PKSC 3200: 001,0.31,0.46,0.1,0.05,0.05,0.0,0.0,0.03,rupert hurley,
+PKSC,3680,1,Pkg and Society,0.13,0.41,0.18,0.1,0.15,0.0,0.0,0.03,heather batt,
+PKSC,4010,1,PKSC 4010: 001,0.45,0.49,0.02,0.0,0.04,0.0,0.0,0.0,anthony lou pometto,
+PKSC,4030,1,PKSC 4030: 001,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4200,1,PKSC 4200: 001,0.7,0.17,0.13,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4300,1,PKSC 4300: 001,0.16,0.67,0.14,0.0,0.02,0.0,0.0,0.02,duncan darby,
+PKSC,4400,1,PKSC 4400: 001,0.29,0.38,0.21,0.03,0.09,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1,Fd & Hc Pkg Systems,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,kay cooksey,
+PKSC,8510,1,Pkg Sci Seminar,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,ronnie thomas,
+PLPA,2130,1,Fungi & Civilization,0.48,0.28,0.11,0.07,0.04,0.0,0.0,0.02,julia loui kerrigan,
+PLPA,6590,1,PLPA 6590: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,
+POSC,1010,1,Amer National Govt,0.13,0.63,0.23,0.0,0.0,0.0,0.0,0.01,joseph earl stewart,
+POSC,1010,2,Amer National Govt,0.07,0.4,0.33,0.13,0.07,0.0,0.0,0.0,adam warber,
+POSC,1020,1,Intro Intl Relations,0.13,0.44,0.28,0.08,0.04,0.0,0.0,0.04,aron geo tannenbaum,
+POSC,1020,2,Intro Intl Relations,0.21,0.26,0.26,0.12,0.07,0.0,0.0,0.08,zeynep taydas,
+POSC,1030,1,Intro to Political Theory,0.38,0.24,0.16,0.11,0.11,0.0,0.0,0.0,brandon turner,
+POSC,1040,1,Intro Compar Pol,0.03,0.39,0.5,0.03,0.0,0.0,0.0,0.06,colin pearce,
+POSC,1040,2,Intro Compar Pol,0.41,0.39,0.11,0.04,0.02,0.0,0.0,0.02,katherine am curtis,
+POSC,1990,1,POSC 1990: 001,0.3,0.1,0.27,0.2,0.13,0.0,0.0,0.0,meredith petersheim,
+POSC,3020,1,State and Loc Gov,0.17,0.63,0.1,0.0,0.07,0.0,0.0,0.03,bruce ransom,
+POSC,3110,1,Model United Nations,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,xiaobo hu,
+POSC,3210,1,Public Admin,0.05,0.38,0.31,0.15,0.1,0.0,0.0,0.0,james woodard,
+POSC,3410,1,Quant Meth in Pol Sc,0.56,0.25,0.13,0.06,0.0,0.0,0.0,0.0,steven vince miller,
+POSC,3610,1,Intl Pol in Crisis,0.21,0.39,0.26,0.05,0.05,0.0,0.0,0.03,vladimir matic,
+POSC,3610,2,Intl Pol in Crisis,0.43,0.23,0.27,0.03,0.0,0.0,0.0,0.03,steven vince miller,
+POSC,3630,1,Us Foreign Policy,0.17,0.45,0.28,0.03,0.03,0.0,0.0,0.03,jeffrey scott peake,
+POSC,3710,1,European Politics,0.43,0.31,0.19,0.05,0.02,0.0,0.0,0.0,katherine am curtis,
+POSC,3750,1,European Integration,0.15,0.54,0.08,0.23,0.0,0.0,0.0,0.0,zeynep taydas,
+POSC,4050,1,American Presidency,0.15,0.46,0.23,0.0,0.08,0.0,0.0,0.08,adam warber,
+POSC,4070,1,Religion and Politic,0.2,0.41,0.28,0.11,0.0,0.0,0.0,0.0,laura olson,
+POSC,4240,1,Federalism and Igr,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,
+POSC,4360,1,Law Courts Politics,0.52,0.31,0.1,0.0,0.02,0.0,0.0,0.05,joseph earl stewart,
+POSC,4370,1,Constitut Law: Rights & Libert,0.34,0.54,0.09,0.03,0.0,0.0,0.0,0.0,daniel frost,
+POSC,4380,1,Constitut Law: Struc of Gov,0.48,0.39,0.09,0.04,0.0,0.0,0.0,0.0,daniel frost,
+POSC,4500,1,Plato to Postmodernism,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,andrew sc bernstein,
+POSC,4530,1,American Political Thought,0.35,0.23,0.15,0.08,0.15,0.0,0.0,0.04,brandon turner,
+POSC,4540,1,Southern Politics,0.04,0.48,0.33,0.07,0.04,0.0,0.0,0.04,james woodard,
+POSC,4570,1,Political Terrorism,0.42,0.29,0.23,0.03,0.0,0.0,0.0,0.03,aron geo tannenbaum,
+POSC,4610,1,Am Diplomacy & Pol,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,vladimir matic,
+POSC,4760,1,Middle East Politics,0.48,0.33,0.05,0.0,0.0,0.0,0.0,0.14,vladimir matic,
+POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.96,0.02,0.02,meredith petersheim,
+POST,8430,1,POST 8430: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,
+PRTM,2000,1,PRTM 2000: 001,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.01,cindy hartman,
+PRTM,2200,1,PRTM 2200: 001,0.19,0.63,0.11,0.04,0.04,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2200,2,PRTM 2200: 002,0.19,0.78,0.04,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2200,3,PRTM 2200: 003,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bernard mwe kitheka,
+PRTM,2200,4,PRTM 2200: 004,0.41,0.48,0.04,0.0,0.0,0.0,0.0,0.07,katherine eli evans,
+PRTM,2200,5,PRTM 2200: 005,0.65,0.23,0.08,0.04,0.0,0.0,0.0,0.0,kellie aman walters,
+PRTM,2200,6,PRTM 2200: 006,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,samuel ogletree,
+PRTM,2200,7,PRTM 2200: 007,0.22,0.48,0.26,0.04,0.0,0.0,0.0,0.0,denise mar anderson,
+PRTM,2410,1,PRTM 2410: 001,0.24,0.47,0.29,0.0,0.0,0.0,0.0,0.0,craig colistra,
+PRTM,2410,2,PRTM 2410: 002,0.42,0.35,0.23,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2600,1,PRTM 2600: 001,0.88,0.09,0.0,0.0,0.03,0.0,0.0,0.0,alison lynne cory,
+PRTM,2650,1,PRTM 2650: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,alison lynne cory,
+PRTM,2700,1,Intro Rec Res Mgt,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,stephen springs,
+PRTM,2810,1,Intro to Golf Mgt,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,2820,1,PRTM 2820: 001,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,2830,1,PRTM 2830: 001,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,2980,3,Creative Inquiry in PRTM II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,toni liechty,
+PRTM,2980,6,Creative Inquiry in PRTM II,0.73,0.07,0.2,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3070,1,PRTM 3070: 001,0.85,0.13,0.03,0.0,0.0,0.0,0.0,0.0,craig goodman,
+PRTM,3260,1,PRTM 3260: 001,0.31,0.44,0.23,0.03,0.0,0.0,0.0,0.0,brandi crowe,
+PRTM,3270,1,PRTM 3270: 001,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3280,1,PRTM 3280: 001,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,alison lynne cory,
+PRTM,3420,1,Intro to Tourism,0.73,0.19,0.0,0.03,0.0,0.0,0.0,0.05,maloud shakona,
+PRTM,3420,2,Intro to Tourism,0.53,0.25,0.19,0.0,0.03,0.0,0.0,0.0,jarrett bachman,
+PRTM,3440,1,PRTM 3440: 001,0.39,0.36,0.21,0.0,0.04,0.0,0.0,0.0,sheila backman,
+PRTM,3440,2,PRTM 3440: 002,0.39,0.35,0.1,0.12,0.04,0.0,0.0,0.0,sheila backman,
+PRTM,3460,1,PRTM 3460: 001,0.13,0.65,0.17,0.04,0.0,0.0,0.0,0.0,gregory phi ramshaw,
+PRTM,3470,1,PRTM 3470: 001,0.34,0.34,0.21,0.1,0.0,0.0,0.0,0.0,gregory phi ramshaw,
+PRTM,3510,1,PRTM 3510: 001,0.2,0.2,0.5,0.1,0.0,0.0,0.0,0.0,daniel mor anderson,
+PRTM,3550,1,PRTM 3550: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,3830,1,PRTM 3830: 001,0.45,0.09,0.45,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,3980,1,Creative Inquiry in PRTM III,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
+PRTM,3980,3,Creative Inquiry in PRTM III,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,
+PRTM,3980,4,Creative Inquiry in PRTM III,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi hughes,
+PRTM,3980,6,Creative Inquiry in PRTM III,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,
+PRTM,3980,9,Creative Inquiry in PRTM III,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,4070,1,PRTM 4070: 001,0.33,0.43,0.24,0.0,0.0,0.0,0.0,0.0,toni liechty,
+PRTM,4210,1,Rec Fin Resc Mgt,0.11,0.49,0.17,0.17,0.06,0.0,0.0,0.0,denise mar anderson,
+PRTM,4220,1,PRTM 4220: 001,0.32,0.54,0.11,0.0,0.0,0.0,0.0,0.04,anna-mar chancellor,
+PRTM,4260,1,PRTM 4260: 001,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,4300,1,World Geog Parks,0.58,0.35,0.06,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
+PRTM,4310,1,Methods Envir Inter,0.43,0.21,0.29,0.07,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,4410,1,PRTM 4410: 001,0.5,0.25,0.1,0.1,0.05,0.0,0.0,0.0,herbert chancellor,
+PRTM,4450,1,PRTM 4450: 001,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jeffery martin,
+PRTM,4470,1,PRTM 4470: 001,0.78,0.17,0.02,0.0,0.0,0.0,0.0,0.02,lauren duffy,
+PRTM,4510,1,PRTM 4510: 001,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,4540,1,Trends in Sport Mgt,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,
+PRTM,4550,1,PRTM 4550: 001,0.28,0.56,0.17,0.0,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,8030,1,PRTM 8030: 001,0.78,0.13,0.0,0.0,0.04,0.0,0.0,0.04,skye arthur-banning,
+PRTM,8110,1,PRTM 8110: 001,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,
+PRTM,8110,2,PRTM 8110: 002,0.65,0.2,0.1,0.0,0.0,0.0,0.0,0.05,jeffrey charl hallo,
+PRTM,8210,1,PRTM 8210: 001,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,denise mar anderson,
+PRTM,8250,1,PRTM 8250: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,toni liechty,
+PSYC,2010,1,Intro to Psychology,0.29,0.38,0.2,0.03,0.03,0.0,0.0,0.07,mary taylor,
+PSYC,2010,2,Intro to Psychology,0.09,0.44,0.36,0.04,0.03,0.0,0.0,0.04,mary taylor,
+PSYC,2010,3,Intro to Psychology (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True
+PSYC,2010,4,Intro to Psychology,0.3,0.25,0.31,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,
+PSYC,2010,5,Intro to Psychology,0.57,0.23,0.09,0.09,0.03,0.0,0.0,0.0,chong hyon pak,
+PSYC,2010,6,Intro to Psychology,0.37,0.31,0.19,0.06,0.04,0.0,0.0,0.03,fred switzer,
+PSYC,2010,7,Intro to Psychology,0.29,0.26,0.2,0.11,0.09,0.0,0.0,0.06,edwin brainerd,
+PSYC,2020,1,PSYC 2020: 001,0.84,0.0,0.11,0.0,0.0,0.0,0.0,0.05,eric mckibben,
+PSYC,2020,2,PSYC 2020: 002,0.79,0.08,0.0,0.04,0.0,0.0,0.0,0.08,eric mckibben,
+PSYC,2020,3,PSYC 2020: 003,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,2020,4,PSYC 2020: 004,0.78,0.04,0.09,0.0,0.04,0.0,0.0,0.04,eric mckibben,
+PSYC,2020,5,PSYC 2020: 005,0.78,0.09,0.09,0.0,0.04,0.0,0.0,0.0,lauren elizab ellis,
+PSYC,2020,6,PSYC 2020: 006,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,james nathan salley,
+PSYC,2020,7,PSYC 2020: 007,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,drew morgan link,
+PSYC,3060,1,Human Sexual Beh,0.67,0.18,0.09,0.03,0.02,0.0,0.0,0.01,bruce michael king,
+PSYC,3090,100,Intro Exp Psych,0.14,0.36,0.29,0.07,0.11,0.0,0.0,0.04,jennifer bai bisson,
+PSYC,3090,200,Intro Exp Psych,0.42,0.3,0.15,0.05,0.05,0.0,0.0,0.01,richard tyrrell,
+PSYC,3090,300,Intro Exp Psych,0.9,0.03,0.07,0.0,0.0,0.0,0.0,0.0,larry alton pace,
+PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimental Psych,0.33,0.39,0.06,0.06,0.11,0.0,0.0,0.06,stephanie whetsel,
+PSYC,3100,300,Advanced Experimental Psych,0.35,0.47,0.06,0.0,0.12,0.0,0.0,0.0,robert campbell,
+PSYC,3100,400,Advanced Experimental Psych,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,larry alton pace,
+PSYC,3100,500,Advanced Experimental Psych,0.47,0.24,0.18,0.0,0.12,0.0,0.0,0.0,thomas britt,
+PSYC,3100,600,Advanced Experimental Psych,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,paul steven merritt,
+PSYC,3100,700,Advanced Experimental Psych,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,3240,1,Physiological Psych,0.37,0.27,0.17,0.08,0.06,0.0,0.0,0.06,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.37,0.24,0.15,0.07,0.1,0.0,0.0,0.07,claudio cantalupo,
+PSYC,3330,1,Cognitive Psych,0.19,0.4,0.24,0.11,0.03,0.0,0.0,0.03,thomas alley,
+PSYC,3340,1,Cognitive Psych Lab,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,thomas alley,
+PSYC,3340,2,Cognitive Psych Lab,0.64,0.07,0.21,0.07,0.0,0.0,0.0,0.0,thomas alley,
+PSYC,3340,3,Cognitive Psych Lab,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,ashley ann sewall,
+PSYC,3400,1,Lifespan Developmental Psych,0.31,0.42,0.14,0.06,0.04,0.0,0.0,0.03,pamela alley,
+PSYC,3520,1,Social Psychology,0.45,0.34,0.14,0.07,0.0,0.0,0.0,0.0,jo anne jorgensen,
+PSYC,3520,2,Social Psychology,0.38,0.38,0.18,0.03,0.0,0.0,0.0,0.03,jo anne jorgensen,
+PSYC,3520,3,Social Psychology (HON),0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
+PSYC,3640,1,Industrial Psych,0.24,0.46,0.26,0.01,0.01,0.0,0.0,0.01,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.56,0.24,0.17,0.01,0.0,0.0,0.0,0.01,skye gillispie,
+PSYC,3700,1,Personality,0.4,0.46,0.13,0.01,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,3830,1,Abnormal Psychology,0.34,0.31,0.26,0.0,0.06,0.0,0.0,0.03,pamela alley,
+PSYC,3830,2,Abnormal Psychology,0.26,0.26,0.26,0.15,0.0,0.0,0.0,0.06,pamela alley,
+PSYC,3830,3,Abnormal Psychology,0.17,0.46,0.28,0.04,0.03,0.0,0.0,0.01,heidi marie zinzow,
+PSYC,4080,1,Women and Psychology,0.44,0.32,0.16,0.04,0.04,0.0,0.0,0.0,robin mari kowalski,
+PSYC,4150,1,Systems and Theories,0.3,0.37,0.2,0.07,0.03,0.0,0.0,0.03,edwin brainerd,
+PSYC,4150,2,Systems and Theories,0.26,0.33,0.22,0.07,0.07,0.0,0.0,0.07,edwin brainerd,
+PSYC,4220,1,Perception,0.21,0.31,0.31,0.03,0.1,0.0,0.0,0.03,claudio cantalupo,
+PSYC,4220,2,Perception,0.29,0.26,0.29,0.13,0.03,0.0,0.0,0.0,christopher pagano,
+PSYC,4750,1,Brain and Behavior,0.5,0.28,0.11,0.0,0.0,0.0,0.0,0.11,june pilcher,
+PSYC,4800,1,Health Psychology,0.68,0.2,0.04,0.0,0.0,0.0,0.0,0.08,june pilcher,
+PSYC,4800,2,Health Psychology,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,james mccubbin,
+PSYC,4800,3,Health Psychology,0.64,0.28,0.04,0.0,0.04,0.0,0.0,0.0,james mccubbin,
+PSYC,4820,1,Positive Psychology,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,cynthia pury,
+PSYC,4890,1,Teamwork in the 21st Century,0.83,0.04,0.04,0.0,0.0,0.0,0.0,0.09,marissa leig porter,
+PSYC,4890,4,Teamwork in the 21st Century,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,marissa leig porter,
+PSYC,4920,1,Senior Laboratory,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,allison lei wallace,
+PSYC,4920,2,Senior Laboratory,0.82,0.11,0.07,0.0,0.0,0.0,0.0,0.0,allison lei wallace,
+PSYC,4920,3,Senior Laboratory,0.82,0.11,0.07,0.0,0.0,0.0,0.0,0.0,crystal burn fulmer,
+PSYC,4920,4,Senior Laboratory,0.71,0.17,0.0,0.08,0.04,0.0,0.0,0.0,crystal burn fulmer,
+PSYC,4930,100,Pract Clinical Psych,0.65,0.1,0.05,0.0,0.1,0.0,0.0,0.1,heidi marie zinzow,
+PSYC,8130,1,PSYC 8130: 001,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0, dewayne moore,
+PSYC,8620,1,PSYC 8620: 001,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,robert ray sinclair,
+RED,8010,1,Market Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
+RED,8040,1,Resid Practicum,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
+RED,8050,1,Commercial Practicum,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+RED,8120,1,Real Estate Technology,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
+RED,8130,1,RED 8130: 001,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,
+REL,1010,1,Intro to Religion,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,robert stephens,
+REL,1010,2,Intro to Religion,0.79,0.09,0.03,0.0,0.0,0.0,0.0,0.09,robert stephens,
+REL,1020,1,World Religions,0.32,0.41,0.15,0.06,0.03,0.0,0.0,0.03,peter cohen,
+REL,1020,2,World Religions,0.47,0.34,0.06,0.06,0.0,0.0,0.0,0.06,peter cohen,
+REL,1020,4,World Religions,0.25,0.39,0.28,0.06,0.03,0.0,0.0,0.0,peter cohen,
+REL,1020,5,World Religions,0.77,0.17,0.0,0.0,0.0,0.0,0.0,0.07,robert stephens,
+REL,1020,6,World Religions,0.51,0.34,0.06,0.0,0.0,0.0,0.0,0.09,robert stephens,
+REL,3000,1,REL 3000: 001,0.58,0.24,0.03,0.03,0.03,0.0,0.0,0.09,steven grosby,
+REL,3010,1,Old Testament,0.59,0.21,0.12,0.0,0.0,0.06,0.0,0.03,steven grosby,
+REL,3010,2,Old Testament,0.42,0.56,0.0,0.0,0.0,0.0,0.0,0.03,steven grosby,
+REL,3730,1,Age of Protestant Reformation,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,thomas kuehn,
+RS,3010,1,Rural Sociology,0.37,0.37,0.14,0.09,0.0,0.0,0.0,0.03,kenneth robinson,
+RS,4590,1,The Community,0.64,0.07,0.21,0.0,0.0,0.0,0.0,0.07,kenneth robinson,
+RUSS,1020,1,RUSS 1020: 001,0.27,0.45,0.09,0.0,0.09,0.0,0.0,0.09,joan bridgwood,
+RUSS,2020,1,Intermediate Russ,0.5,0.2,0.1,0.0,0.0,0.0,0.0,0.2,joan bridgwood,
+SOC,2010,1,Intro to Sociology (HON),0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,sarah evely winslow,True
+SOC,2010,2,Introduction to Sociology,0.48,0.36,0.12,0.0,0.01,0.0,0.0,0.02,jennifer le holland,
+SOC,2010,3,Introduction to Sociology,0.45,0.37,0.12,0.02,0.02,0.0,0.0,0.02,jennifer le holland,
+SOC,2010,4,Introduction to Sociology,0.54,0.33,0.06,0.02,0.0,0.0,0.0,0.04,mary louise barr,
+SOC,2010,5,Introduction to Sociology,0.71,0.22,0.04,0.02,0.0,0.0,0.0,0.0,mary louise barr,
+SOC,2010,6,Introduction to Sociology,0.73,0.17,0.06,0.02,0.0,0.0,0.0,0.02,mary louise barr,
+SOC,2010,7,Introduction to Sociology,0.55,0.31,0.14,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,8,Introduction to Sociology,0.38,0.42,0.16,0.01,0.0,0.0,0.0,0.02,mary louise barr,
+SOC,2010,9,Introduction to Sociology,0.51,0.34,0.08,0.01,0.03,0.0,0.0,0.03,jennifer triplett,
+SOC,2010,10,Introduction to Sociology,0.76,0.2,0.02,0.0,0.02,0.0,0.0,0.0,jennifer triplett,
+SOC,2020,1,Social Problems,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,stephani southworth,
+SOC,2020,2,Social Problems,0.48,0.35,0.09,0.04,0.04,0.0,0.0,0.0,stephani southworth,
+SOC,2050,1,SOC 2050: 001,0.72,0.08,0.03,0.08,0.06,0.0,0.0,0.03,brenda vander mey,
+SOC,3020,1,Research Methods I,0.15,0.38,0.42,0.04,0.0,0.0,0.0,0.02,ellen granberg,
+SOC,3040,1,Research Methods II,0.22,0.48,0.22,0.04,0.0,0.0,0.0,0.04,ye luo,
+SOC,3100,1,Marriage & Intimacy,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
+SOC,3100,2,Marriage & Intimacy,0.54,0.35,0.07,0.0,0.0,0.04,0.0,0.0,jeffrey edwards,
+SOC,3110,1,The Family,0.52,0.38,0.06,0.04,0.0,0.0,0.0,0.0,jennifer triplett,
+SOC,3310,1,Urban Sociology,0.27,0.38,0.15,0.04,0.1,0.0,0.0,0.06,stephani southworth,
+SOC,3500,1,Self & Society,0.37,0.45,0.14,0.0,0.02,0.0,0.0,0.02,jennifer triplett,
+SOC,3800,1,Intro Social Service,0.49,0.39,0.06,0.0,0.04,0.0,0.0,0.02,jennifer le holland,
+SOC,3880,1,Criminal Justice,0.45,0.19,0.21,0.09,0.06,0.0,0.0,0.0,william white,
+SOC,3890,1,Criminology,0.28,0.22,0.2,0.17,0.09,0.0,0.0,0.04,william white,
+SOC,3910,1,Soc of Deviance,0.18,0.39,0.27,0.04,0.04,0.0,0.0,0.08,stephani southworth,
+SOC,3920,1,Juvenile Delinquency,0.54,0.25,0.15,0.0,0.02,0.0,0.0,0.04,jeffrey edwards,
+SOC,3970,1,Substance Abuse,0.51,0.36,0.04,0.0,0.04,0.0,0.0,0.04,jeffrey edwards,
+SOC,4040,1,Soc Theory,0.54,0.34,0.07,0.0,0.02,0.0,0.0,0.02,william haller,
+SOC,4330,1,Global Social Change,0.64,0.24,0.04,0.0,0.04,0.0,0.0,0.04,william haller,
+SOC,4440,1,Sociology of Educ,0.25,0.21,0.08,0.08,0.25,0.0,0.0,0.13,stephani southworth,
+SOC,4590,1,The Community,0.39,0.22,0.22,0.0,0.0,0.0,0.0,0.17,kenneth robinson,
+SOC,4600,1,Race & Ethnicity,0.5,0.18,0.29,0.0,0.04,0.0,0.0,0.0,brenda vander mey,
+SOC,4610,1,Sex & Gender,0.22,0.46,0.24,0.09,0.0,0.0,0.0,0.0,sarah evely winslow,
+SOC,4840,1,Child Abuse,0.47,0.26,0.21,0.03,0.0,0.0,0.0,0.03,douglas sturkie,
+SOC,4930,1,Soc of Corrections,0.4,0.33,0.13,0.13,0.0,0.0,0.0,0.0,william white,
+SOC,4970,1,Senior Lab,0.65,0.19,0.0,0.15,0.0,0.0,0.0,0.0,brenda vander mey,
+SOC,4970,2,Senior Lab,0.75,0.0,0.08,0.17,0.0,0.0,0.0,0.0,brenda vander mey,
+SOC,4990,1,Sem- Issues in Cmmty Policity,0.1,0.4,0.5,0.0,0.0,0.0,0.0,0.0,william white,
+SPAN,1010,1,SPAN 1010: 001,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1010,2,SPAN 1010: 002,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1010,3,SPAN 1010: 003,0.21,0.16,0.16,0.21,0.0,0.0,0.0,0.26,samuel palmer moody,
+SPAN,1020,1,SPAN 1020: 001,0.13,0.5,0.19,0.13,0.0,0.0,0.0,0.06,roger simpson,
+SPAN,1020,2,SPAN 1020: 002,0.06,0.12,0.18,0.24,0.18,0.0,0.0,0.24,roger simpson,
+SPAN,1020,3,SPAN 1020: 003,0.33,0.33,0.17,0.11,0.06,0.0,0.0,0.0,roger simpson,
+SPAN,1020,4,SPAN 1020: 004,0.22,0.17,0.28,0.06,0.11,0.0,0.0,0.17,roger simpson,
+SPAN,1020,5,SPAN 1020: 005,0.11,0.26,0.26,0.05,0.16,0.0,0.0,0.16,roger simpson,
+SPAN,1020,6,SPAN 1020: 006,0.0,0.29,0.53,0.12,0.0,0.0,0.0,0.06,cathy robison,
+SPAN,1020,7,SPAN 1020: 007,0.26,0.32,0.26,0.11,0.0,0.0,0.0,0.05,cathy robison,
+SPAN,1020,8,SPAN 1020: 008,0.17,0.28,0.39,0.0,0.06,0.0,0.0,0.11,ricardo tremolada,
+SPAN,1020,9,SPAN 1020: 009,0.24,0.29,0.18,0.06,0.06,0.0,0.0,0.18,ricardo tremolada,
+SPAN,1020,10,SPAN 1020: 010,0.21,0.42,0.26,0.0,0.05,0.0,0.0,0.05,allison ann hinds,
+SPAN,1020,11,SPAN 1020: 011,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,allison ann hinds,
+SPAN,1020,12,SPAN 1020: 012,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1020,14,SPAN 1020: 014,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,scott harris,
+SPAN,2010,1,Intermediate Spanish,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,2,Intermediate Spanish,0.28,0.56,0.11,0.06,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,3,Intermediate Spanish,0.21,0.53,0.11,0.0,0.0,0.0,0.0,0.16,maureen zamora,
+SPAN,2010,4,Intermediate Spanish,0.58,0.16,0.26,0.0,0.0,0.0,0.0,0.0,angeli leal,
+SPAN,2010,5,Intermediate Spanish,0.37,0.42,0.0,0.05,0.11,0.0,0.0,0.05,angeli leal,
+SPAN,2010,6,Intermediate Spanish,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,heidi montes,
+SPAN,2010,7,Intermediate Spanish,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,allison ann hinds,
+SPAN,2010,8,Intermediate Spanish,0.13,0.5,0.13,0.0,0.06,0.0,0.0,0.19,melva margu persico,
+SPAN,2010,9,Intermediate Spanish,0.08,0.58,0.25,0.0,0.08,0.0,0.0,0.0,melva margu persico,
+SPAN,2010,10,Intermediate Spanish,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,11,Intermediate Spanish,0.25,0.31,0.31,0.13,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,12,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,sarah stoll watt,
+SPAN,2010,13,Intermediate Spanish,0.37,0.42,0.11,0.11,0.0,0.0,0.0,0.0,sarah stoll watt,
+SPAN,2010,14,Intermediate Spanish,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,allison ann hinds,
+SPAN,2010,15,Intermediate Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,1,Intermediate Spanish,0.55,0.2,0.25,0.0,0.0,0.0,0.0,0.0,michael greene,
+SPAN,2020,2,Intermediate Spanish,0.53,0.21,0.26,0.0,0.0,0.0,0.0,0.0,michael greene,
+SPAN,2020,3,Intermediate Spanish,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,michael greene,
+SPAN,2020,4,Intermediate Spanish,0.39,0.17,0.39,0.0,0.06,0.0,0.0,0.0,angeli leal,
+SPAN,2020,5,Intermediate Spanish,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,angeli leal,
+SPAN,2020,6,Intermediate Spanish,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,heidi montes,
+SPAN,2020,7,Intermediate Spanish,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,8,Intermediate Spanish,0.29,0.35,0.18,0.06,0.06,0.0,0.0,0.06,melva margu persico,
+SPAN,2020,9,Intermediate Spanish,0.24,0.53,0.18,0.0,0.0,0.0,0.0,0.06,melva margu persico,
+SPAN,2020,10,Intermediate Spanish,0.58,0.16,0.16,0.11,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2020,11,Intermediate Spanish,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,ellory schmucker,
+SPAN,2020,12,Intermediate Spanish,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,sarah stoll watt,
+SPAN,2020,13,Intermediate Spanish,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,sarah stoll watt,
+SPAN,2020,15,Intermediate Spanish,0.53,0.18,0.12,0.12,0.0,0.0,0.0,0.06,ricardo tremolada,
+SPAN,2020,16,Intermediate Spanish,0.21,0.36,0.14,0.07,0.14,0.0,0.0,0.07,juana martin-armas,
+SPAN,2020,17,Intermediate Spanish,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,juana martin-armas,
+SPAN,2020,18,Intermediate Spanish (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,True
+SPAN,3020,1,SPAN 3020: 001,0.39,0.44,0.0,0.0,0.06,0.0,0.0,0.11,juana martin-armas,
+SPAN,3020,2,SPAN 3020: 002,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,juana martin-armas,
+SPAN,3060,1,SPAN 3060: 001,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,3070,1,Hispanic World: Sp,0.71,0.07,0.0,0.0,0.0,0.0,0.0,0.21,raquel anido,
+SPAN,3080,1,Hispanic World: La,0.78,0.0,0.17,0.06,0.0,0.0,0.0,0.0,lisa kristi dewaard,
+SPAN,3080,2,Hispanic World: La,0.58,0.21,0.16,0.0,0.05,0.0,0.0,0.0,lisa kristi dewaard,
+SPAN,3090,1,SPAN 3090: 001,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,lisa kristi dewaard,
+SPAN,3140,1,SPAN 3140: 001,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
+SPAN,4010,1,SPAN 4010: 001,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,raquel anido,
+SPAN,4050,1,SPAN 4050: 001,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,maureen zamora,
+SPAN,4060,1,SPAN 4060: 001,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,
+SPAN,4060,2,SPAN 4060: 002,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,mon rojas-de-massei,
+SPAN,4090,1,SPAN 4090: 001,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
+SPAN,4150,1,SPAN 4150: 001,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,areli moore peralta,
+STAT,2220,1,Statistics in Everyday Life,0.45,0.25,0.19,0.08,0.02,0.0,0.0,0.02,ros martinez-dawson,
+STAT,2220,2,Statistics in Everyday Life,0.5,0.3,0.09,0.09,0.02,0.0,0.0,0.0,ros martinez-dawson,
+STAT,2220,3,Statistics in Everyday Life,0.22,0.34,0.2,0.1,0.1,0.0,0.0,0.05,ran xie,
+STAT,2220,4,Statistics in Everyday Life,0.38,0.29,0.21,0.08,0.04,0.0,0.0,0.0,ran xie,
+STAT,3010,1,Introductory Statistics,0.33,0.22,0.3,0.12,0.0,0.0,0.0,0.03,richard stev dubsky,
+STAT,3010,2,Introductory Statistics,0.47,0.25,0.15,0.03,0.05,0.0,0.0,0.05,richard stev dubsky,
+STAT,3010,3,Introductory Statistics,0.45,0.22,0.21,0.07,0.03,0.0,0.0,0.02,james espey,
+STAT,3010,4,Introductory Statistics,0.53,0.19,0.17,0.08,0.03,0.0,0.0,0.0,ros martinez-dawson,
+STAT,3010,5,Introductory Statistics,0.22,0.25,0.18,0.15,0.17,0.0,0.0,0.03, erwin walker,
+STAT,3010,6,Introductory Statistics,0.35,0.17,0.28,0.1,0.08,0.0,0.0,0.02, erwin walker,
+STAT,3010,7,Introductory Statistics,0.22,0.29,0.22,0.09,0.14,0.0,0.0,0.03,richard stev dubsky,
+STAT,3010,8,Introductory Statistics,0.26,0.34,0.16,0.09,0.14,0.0,0.0,0.02,benjamin sharp,
+STAT,3010,9,Introductory Statistics,0.32,0.3,0.14,0.1,0.11,0.0,0.0,0.03,ellen hepfe breazel,
+STAT,3010,10,Introductory Statistics,0.29,0.25,0.16,0.07,0.16,0.0,0.0,0.07,jun luo,
+STAT,4110,1,STAT 4110: 001,0.43,0.35,0.13,0.04,0.04,0.0,0.0,0.0,james rieck,
+STAT,4110,2,STAT 4110: 002,0.19,0.44,0.19,0.0,0.13,0.0,0.0,0.06,patrick gerard,
+STAT,8010,1,STAT 8010: 001,0.41,0.45,0.1,0.0,0.03,0.0,0.0,0.0,james rieck,
+STAT,8010,2,STAT 8010: 002,0.59,0.35,0.0,0.0,0.03,0.0,0.0,0.03,william bridges,
+STAT,8010,3,STAT 8010: 003,0.53,0.24,0.18,0.0,0.03,0.0,0.0,0.03,jun luo,
+STAT,8020,1,STAT 8020: 001,0.7,0.22,0.0,0.0,0.0,0.0,0.0,0.07,william bridges,
+STAT,8030,1,STAT 8030: 001,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,hoke hill,
+STAT,8040,1,STAT 8040: 001,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+STAT,8420,230,Intro to Statistical Methods,0.15,0.54,0.08,0.0,0.23,0.0,0.0,0.0,julia lynn sharp,
+STS,1010,1,Survey of S T S,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,thomas oberdan,
+STS,1010,2,Survey of S T S,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,
+STS,1010,3,Survey of S T S,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,
+STS,1010,4,Survey of S T S,0.24,0.38,0.18,0.06,0.06,0.0,0.0,0.09,david charles foltz,
+STS,1010,5,Survey of S T S,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.03,michael greene,
+STS,1010,6,Survey of S T S,0.47,0.38,0.09,0.03,0.0,0.0,0.0,0.03,sarah mae cooper,
+STS,1010,7,Survey of S T S,0.48,0.42,0.03,0.03,0.03,0.0,0.0,0.0,thomas oberdan,
+STS,1010,20,Survey of S T S,0.29,0.45,0.21,0.0,0.0,0.0,0.0,0.05,thomas oberdan,
+STS,2150,1,Crit Appr to Tech Revolutions,0.21,0.16,0.58,0.0,0.05,0.0,0.0,0.0,thomas oberdan,
+THEA,2100,1,Theatre Appreciation,0.77,0.19,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,
+THEA,2100,2,Theatre Appreciation,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,2100,3,Theatre Appreciation,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,kerrie kath seymour,
+THEA,2100,4,Theatre Appreciation,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
+THEA,2100,6,Theatre Appreciation,0.53,0.34,0.06,0.0,0.0,0.0,0.0,0.06,jason adkins,
+THEA,2100,8,Theatre Appreciation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
+THEA,3150,1,Theatre History I,0.75,0.1,0.1,0.0,0.05,0.0,0.0,0.0,richard st. peter,
+THEA,3180,1,THEA 3180: 001,0.4,0.35,0.15,0.1,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,3680,1,THEA 3680: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,
+THEA,4670,1,THEA 4670: 001,0.5,0.0,0.1,0.0,0.3,0.0,0.0,0.1,kendra lyne johnson,
+WFB,3010,1,WFB 3010: 001,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3130,1,Conservation Biology,0.3,0.22,0.28,0.16,0.0,0.0,0.0,0.04,shari lyn rodriguez,
+WFB,3130,2,Conservation Biology,0.29,0.16,0.42,0.1,0.03,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3500,1,WFB 3500: 001,0.39,0.45,0.14,0.0,0.0,0.0,0.0,0.02,james davis,
+WFB,3500,2,WFB 3500: 002,0.29,0.32,0.29,0.05,0.05,0.0,0.0,0.0,james davis,
+WFB,4160,1,WFB 4160: 001,0.36,0.32,0.26,0.04,0.02,0.0,0.0,0.0,yoichiro kanno,
+WFB,4300,1,WFB 4300: 001,0.56,0.3,0.05,0.0,0.06,0.0,0.0,0.03,joseph lanham,
+WFB,4400,1,WFB 4400: 001,0.43,0.31,0.09,0.09,0.06,0.0,0.0,0.02,shari lyn rodriguez,
+WFB,4440,1,WFB 4440: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
+WFB,4620,1,Wetland Wildl Biol,0.25,0.41,0.24,0.08,0.01,0.0,0.0,0.01,russell barrett,
+WFB,4760,1,WFB 4760: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph lanham,
+WFB,8610,1,Applied Population Dynamics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katherine mcfadden,
+WS,1030,1,Women Global Perspec,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,
+WS,2300,1,WS 2300: 001,0.69,0.23,0.04,0.0,0.0,0.0,0.0,0.04,saadiqa kumanyika,
+WS,3010,1,Intro Womens Studies,0.7,0.24,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth ros adams,
+WS,3010,2,Intro Womens Studies,0.58,0.37,0.03,0.0,0.03,0.0,0.0,0.0,elizabeth ros adams,

--- a/bot/cogs/grades_cog/assets/2014_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2014_Spring.csv
@@ -1,2291 +1,2291 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1020,1,Survey of Art & Arch Hist II,0.49,0.38,0.11,0.0,0.01,0.0,0.0,0.01,beth ann lauritis,
-AAH,2060,1,Art History and Theory II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
-AAH,2100,1,Intro to Art and Architecture,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,janet bever leblanc,
-AAH,2100,2,Intro to Art and Architecture,0.39,0.32,0.21,0.07,0.0,0.0,0.0,0.0,janet bever leblanc,
-AAH,2100,3,Intro to Art and Architecture,0.33,0.22,0.22,0.07,0.0,0.0,0.0,0.15,janet bever leblanc,
-AAH,2100,4,Intro to Art and Architecture,0.24,0.38,0.21,0.03,0.0,0.0,0.0,0.14,janet bever leblanc,
-ACCT,2010,1,Financial Accounting Concepts,0.14,0.32,0.26,0.08,0.08,0.0,0.0,0.12,suzanne pearse,
-ACCT,2010,2,Financial Accounting Concepts,0.08,0.25,0.35,0.15,0.1,0.0,0.0,0.08,henry anderson,
-ACCT,2010,3,Financial Accounting Concepts,0.15,0.24,0.33,0.11,0.02,0.0,0.0,0.15,suzanne pearse,
-ACCT,2010,4,Financial Accounting Concepts,0.2,0.34,0.18,0.09,0.05,0.0,0.0,0.14,the estate  guffey,
-ACCT,2010,5,Financial Accounting Concepts,0.09,0.26,0.33,0.02,0.16,0.0,0.0,0.14,henry anderson,
-ACCT,2010,6,Financial Accounting Concepts,0.17,0.26,0.28,0.09,0.11,0.0,0.0,0.11,suzanne pearse,
-ACCT,2010,7,Financial Accounting Concepts,0.23,0.23,0.32,0.11,0.04,0.0,0.0,0.06,suzanne pearse,
-ACCT,2010,8,Financial Accounting Concepts,0.11,0.24,0.2,0.04,0.2,0.0,0.0,0.2,henry anderson,
-ACCT,2010,9,Financial Accounting Concepts,0.07,0.34,0.23,0.14,0.07,0.0,0.0,0.16,the estate  guffey,
-ACCT,2010,10,Financial Accounting Concepts,0.13,0.38,0.18,0.11,0.04,0.0,0.0,0.16,the estate  guffey,
-ACCT,2010,11,Financial Accounting Concepts,0.12,0.27,0.29,0.11,0.09,0.0,0.0,0.12,jeffrey mcmillan,
-ACCT,2020,1,Managerial Accounting Concepts,0.25,0.4,0.17,0.1,0.06,0.0,0.0,0.02,annieka philo,
-ACCT,2020,2,Managerial Accounting Concepts,0.29,0.38,0.25,0.04,0.02,0.0,0.0,0.02,annieka philo,
-ACCT,2020,3,Managerial Accounting Concepts,0.23,0.29,0.31,0.06,0.08,0.0,0.0,0.02,annieka philo,
-ACCT,2020,4,Managerial Accounting Concepts,0.31,0.37,0.14,0.1,0.08,0.0,0.0,0.0,annieka philo,
-ACCT,2020,5,Managerial Accounting Concepts,0.27,0.29,0.16,0.02,0.03,0.0,0.0,0.23,henry anderson,
-ACCT,2020,6,Managerial Accounting Concepts,0.18,0.19,0.19,0.09,0.05,0.0,0.0,0.3,henry anderson,
-ACCT,2040,1,ACCT 2040: 001,0.53,0.29,0.08,0.03,0.06,0.0,0.0,0.01,jeffrey mcmillan,
-ACCT,2040,2,ACCT 2040: 002,0.37,0.36,0.11,0.04,0.06,0.0,0.0,0.07,jeffrey mcmillan,
-ACCT,3030,1,Cost Accounting,0.26,0.37,0.2,0.03,0.06,0.0,0.0,0.09,derek dalton,
-ACCT,3030,2,Cost Accounting,0.17,0.4,0.31,0.11,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,3030,3,Cost Accounting,0.18,0.63,0.05,0.03,0.08,0.0,0.0,0.03,robin radtke,
-ACCT,3030,4,Cost Accounting,0.31,0.49,0.1,0.03,0.08,0.0,0.0,0.0,robin radtke,
-ACCT,3110,1,Intermed Financial Acct I,0.22,0.41,0.3,0.07,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3110,2,Intermed Financial Acct I,0.52,0.36,0.07,0.02,0.02,0.0,0.0,0.0,terry daniel knause,
-ACCT,3110,3,Intermed Financial Acct I,0.55,0.24,0.19,0.0,0.0,0.0,0.0,0.02,terry daniel knause,
-ACCT,3110,4,Intermed Financial Acct I,0.59,0.24,0.1,0.0,0.02,0.0,0.0,0.05,terry daniel knause,
-ACCT,3120,1,Intermed Financial Acct II,0.18,0.54,0.15,0.1,0.03,0.0,0.0,0.0, russell madray,
-ACCT,3120,2,Intermed Financial Acct II,0.3,0.46,0.19,0.03,0.0,0.0,0.0,0.03, russell madray,
-ACCT,3120,3,Intermed Financial Acct II,0.15,0.21,0.36,0.06,0.0,0.0,0.0,0.21,lydia lan schleifer,
-ACCT,3120,4,Intermed Financial Acct II,0.15,0.36,0.3,0.0,0.12,0.0,0.0,0.06,lydia lan schleifer,
-ACCT,3130,1,Intermed Financial Acct III,0.17,0.46,0.23,0.11,0.0,0.0,0.0,0.03, russell madray,
-ACCT,3130,2,Intermed Financial Acct III,0.51,0.22,0.22,0.03,0.03,0.0,0.0,0.0, russell madray,
-ACCT,3130,3,Intermed Financial Acct III,0.33,0.19,0.37,0.07,0.04,0.0,0.0,0.0,james irving,
-ACCT,3130,4,Intermed Financial Acct III,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,james irving,
-ACCT,3220,1,Accounting Information Systems,0.03,0.47,0.26,0.12,0.06,0.0,0.0,0.06,philip maiberger,
-ACCT,3220,2,Accounting Information Systems,0.16,0.26,0.35,0.13,0.06,0.0,0.0,0.03,philip maiberger,
-ACCT,3220,3,Accounting Information Systems,0.25,0.33,0.25,0.08,0.03,0.0,0.0,0.06,nancy lee harp,
-ACCT,4040,1,Individual Taxation,0.3,0.45,0.2,0.05,0.0,0.0,0.0,0.0,john hine,
-ACCT,4040,2,Individual Taxation,0.32,0.39,0.24,0.03,0.0,0.0,0.0,0.03,john hine,
-ACCT,4080,1,Retire & Estate Plan,0.29,0.38,0.33,0.0,0.0,0.0,0.0,0.0,john hine,
-ACCT,4100,1,Budget and Exec Cont,0.46,0.41,0.07,0.05,0.0,0.0,0.0,0.0,frances kennedy,
-ACCT,4100,2,Budget and Exec Cont,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,frances kennedy,
-ACCT,4150,1,Auditing,0.09,0.31,0.41,0.09,0.06,0.0,0.0,0.03,suzanne pearse,
-ACCT,4150,2,Auditing,0.15,0.15,0.35,0.25,0.1,0.0,0.0,0.0,carl hollingsworth,
-ACCT,8520,1,ACCT 8520: 001,0.36,0.61,0.03,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8520,2,ACCT 8520: 002,0.28,0.53,0.17,0.0,0.03,0.0,0.0,0.0,ralph welton,
-ACCT,8550,1,ACCT 8550: 001,0.66,0.29,0.03,0.0,0.03,0.0,0.0,0.0,james barnes,
-ACCT,8550,2,ACCT 8550: 002,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8710,1,ACCT 8710: 001,0.23,0.71,0.03,0.0,0.03,0.0,0.0,0.0,derek dalton,
-ACCT,8710,2,ACCT 8710: 002,0.31,0.66,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,
-AGED,3550,1,Team and Organiz Leadership,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thomas dobbins,
-AGED,4150,1,AGED 4150: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,kevin layfield,
-AGM,2050,1,AGM 2050: 001,0.15,0.42,0.32,0.04,0.0,0.0,0.0,0.08,hunter massey,
-AGM,2060,1,AGM 2060: 001,0.23,0.55,0.18,0.05,0.0,0.0,0.0,0.0,hunter massey,
-AGM,2210,1,AGM 2210: 001,0.29,0.46,0.2,0.0,0.06,0.0,0.0,0.0,charles privette,
-AGM,3030,1,AGM 3030: 001,0.21,0.4,0.33,0.02,0.02,0.0,0.0,0.0,young han,
-AGM,4020,1,AGM 4020: 001,0.06,0.66,0.26,0.0,0.03,0.0,0.0,0.0,charles privette,
-AGM,4100,1,AGM 4100: 001,0.38,0.47,0.13,0.03,0.0,0.0,0.0,0.0,hunter massey,
-AGM,4520,1,AGM 4520: 001,0.21,0.56,0.24,0.0,0.0,0.0,0.0,0.0,kendall kirk,
-AGM,4720,1,AGM 4720: 001,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,john chastain,
-AL,3490,400,AL 3490: 400,0.56,0.26,0.19,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,401,AL 3490: 401,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,402,AL 3490: 402,0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,403,AL 3490: 403,0.68,0.25,0.0,0.0,0.07,0.0,0.0,0.0,clyde keith connor,
-AL,3490,404,AL 3490: 404,0.54,0.27,0.08,0.04,0.04,0.0,0.0,0.04,clyde keith connor,
-AL,3490,405,AL 3490: 405,0.8,0.12,0.0,0.04,0.04,0.0,0.0,0.0,edmond fry,
-AL,3500,400,AL 3500: 400,0.19,0.31,0.23,0.12,0.08,0.0,0.0,0.08,michael godfrey,
-AL,3500,401,AL 3500: 401,0.14,0.55,0.05,0.09,0.09,0.0,0.0,0.09,michael godfrey,
-AL,3520,400,AL 3520: 400,0.22,0.22,0.35,0.04,0.0,0.0,0.0,0.17,michael godfrey,
-AL,3530,400,AL 3530: 400,0.12,0.23,0.27,0.27,0.08,0.0,0.0,0.04,isaac sean colbert,
-AL,3530,401,AL 3530: 401,0.13,0.17,0.39,0.22,0.04,0.0,0.0,0.04,isaac sean colbert,
-AL,3600,400,AL 3600: 400,0.46,0.43,0.07,0.0,0.0,0.0,0.0,0.04,clyde keith connor,
-AL,3610,400,AL 3610: 400,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,401,AL 3610: 401,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,AL 3610: 402,0.88,0.04,0.04,0.04,0.0,0.0,0.0,0.0,henry oates,
-AL,3620,400,AL 3620: 400,0.08,0.44,0.2,0.16,0.04,0.0,0.0,0.08,natalie anne carter,
-AL,3620,401,AL 3620: 401,0.23,0.23,0.37,0.09,0.03,0.0,0.0,0.06,natalie anne carter,
-AL,3710,400,AL 3710: 400,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,justin hickey,
-AL,3720,400,AL 3720: 400,0.61,0.13,0.04,0.04,0.13,0.0,0.0,0.04,edmond fry,
-AL,3740,400,AL 3740: 400,0.46,0.21,0.29,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
-AL,3750,400,AL 3750: 400,0.74,0.11,0.05,0.0,0.05,0.0,0.0,0.05,deborah cadorette,
-AL,3760,400,AL 3760: 400,0.38,0.14,0.19,0.1,0.19,0.0,0.0,0.0,edmond fry,
-AL,3760,401,AL 3760: 401,0.63,0.11,0.05,0.11,0.05,0.0,0.0,0.05,edmond fry,
-ANTH,2010,1,Intro Anthropology,0.06,0.21,0.41,0.11,0.12,0.0,0.0,0.09,john coggeshall,
-ANTH,2010,2,Intro Anthropology,0.24,0.32,0.24,0.11,0.05,0.0,0.0,0.05,melissa vogel,
-ANTH,2010,3,Intro Anthropology,0.36,0.32,0.19,0.07,0.03,0.0,0.0,0.03,lisa rapaport,
-ANTH,3200,1,North American Indian Cultures,0.18,0.35,0.24,0.0,0.0,0.0,0.0,0.24,john coggeshall,
-ANTH,3310,1,Archaeology,0.29,0.5,0.04,0.04,0.04,0.0,0.0,0.08,melissa vogel,
-ANTH,3510,1,Biological Anthropology,0.62,0.31,0.0,0.08,0.0,0.0,0.0,0.0,katherine weisensee,
-ANTH,4510,1,Biol Variation in Human Pop,0.33,0.33,0.25,0.0,0.0,0.0,0.0,0.08,katherine weisensee,
-APEC,2020,1,Agric Economics,0.38,0.28,0.23,0.0,0.07,0.0,0.0,0.05,webb smathers,
-APEC,2050,1,Agric and Society,0.6,0.38,0.0,0.0,0.0,0.0,0.0,0.02,david wheele hughes,
-APEC,3080,1,APEC 3080: 001,0.33,0.11,0.3,0.19,0.04,0.0,0.0,0.04,michael vassalos,
-APEC,3570,1,Nat Resource Econ,0.1,0.36,0.51,0.0,0.0,0.0,0.0,0.03,molly espey,
-APEC,4120,1,Reg Economic Devel,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david wheele hughes,
-APEC,4520,1,Agric Policy,0.25,0.55,0.2,0.0,0.0,0.0,0.0,0.0,michael vassalos,
-APEC,4750,1,Wildlife Economics,0.57,0.1,0.33,0.0,0.0,0.0,0.0,0.0,webb smathers,
-ARAB,1010,1,ARAB 1010: 001,0.64,0.14,0.0,0.07,0.0,0.0,0.0,0.14,sulafa abou-samra,
-ARAB,1020,1,ARAB 1020: 001,0.55,0.09,0.09,0.09,0.0,0.0,0.0,0.18,sulafa abou-samra,
-ARCH,1510,3,ARCH 1510: 003,0.38,0.33,0.17,0.04,0.0,0.0,0.0,0.08,sal hambright-belue,
-ARCH,1510,4,ARCH 1510: 004,0.23,0.64,0.09,0.0,0.0,0.0,0.0,0.05,sal hambright-belue,
-ARCH,2520,1,ARCH 2520: 001,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,2520,3,ARCH 2520: 003,0.33,0.33,0.17,0.0,0.08,0.0,0.0,0.08,criss mills,
-ARCH,2520,4,ARCH 2520: 004,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2700,1,ARCH 2700: 001,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,robert john hogan,
-ARCH,2700,2,ARCH 2700: 002,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert john hogan,
-ARCH,2710,1,ARCH 2710: 001,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,
-ARCH,4050,1,ARCH 4050: 001,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,robert bruhns,
-ARCH,4520,2,ARCH 4520: 002,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,lynn craig,
-ARCH,4520,3,ARCH 4520: 003,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,4990,1,Freehand Drawing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,
-ARCH,6050,1,ARCH 6050: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,8110,1,ARCH 8110: 001,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,douglas hecker,
-ARCH,8120,1,ARCH 8120: 001,0.21,0.64,0.14,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,8200,1,Bldg Design & Constr,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-ARCH,8420,1,ARCH 8420: 001,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ar montilla navarro,
-ARCH,8420,2,ARCH 8420: 002,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,junichi satoh,
-ARCH,8520,2,ARCH 8520: 002,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,keith green,
-ARCH,8520,5,ARCH 8520: 005,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,nicholas ault,
-ARCH,8610,1,ARCH 8610: 001,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,ufuk ersoy,
-ARCH,8710,1,ARCH 8710: 001,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,dustin gra albright,
-ARCH,8730,1,ARCH 8730: 001,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
-ARCH,8820,1,ARCH 8820: 001,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,8900,1,Directed Studies,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8920,1,ARCH 8920: 001,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,david allison,
-ARCH,8920,2,ARCH 8920: 002,0.24,0.7,0.06,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,8960,1,A+H Studio: Tectonic,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ART,1030,1,ART 1030: 001,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,lynette house,
-ART,1060,1,ART 1060: 001,0.68,0.18,0.05,0.0,0.09,0.0,0.0,0.0,carly drew,
-ART,1510,1,ART 1510: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,adrienne lichliter,
-ART,2050,1,ART 2050: 001,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,joel reese murray,
-ART,2070,1,ART 2070: 001,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,todd mcdonald,
-ART,2170,1,ART 2170: 001,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,nina jeanette kawar,
-AS,1100,1,AS 1100: 001,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,
-AS,4100,1,Nat Sec Policy II,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,steven price jordan,
-ASL,1010,1,ASL 1010: 001,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,joseph paul may,
-ASL,1010,2,ASL 1010: 002,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,joseph paul may,
-ASL,1020,1,ASL 1020: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,1020,2,ASL 1020: 002,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2010,1,ASL 2010: 001,0.13,0.6,0.07,0.07,0.13,0.0,0.0,0.0,william alton brant,
-ASL,2010,2,ASL 2010: 002,0.53,0.12,0.35,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,2020,1,ASL 2020: 001,0.69,0.13,0.13,0.0,0.06,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2020,2,ASL 2020: 002,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,3050,1,Deaf Studies,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,4010,1,ASL 4010: 001,0.36,0.55,0.0,0.0,0.0,0.0,0.0,0.09,stephen fitzmaurice,
-ASTR,1010,1,Solar System Astr,0.3,0.26,0.16,0.07,0.05,0.0,0.0,0.16,dina drozdov,
-ASTR,1020,1,Stellar Astronomy ONLINE,0.31,0.53,0.13,0.0,0.0,0.0,0.0,0.04,phillip flower,
-ASTR,1020,2,Stellar Astronomy ONLINE,0.27,0.35,0.27,0.0,0.03,0.0,0.0,0.06,phillip flower,
-ASTR,1020,3,Stellar Astronomy ONLINE,0.38,0.42,0.11,0.0,0.02,0.0,0.0,0.07,phillip flower,
-ASTR,1030,1,Solar Systm Astr Lab,0.46,0.19,0.19,0.04,0.12,0.0,0.0,0.0,mark leising,
-ASTR,1040,1,Stellar Astr Lab,0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,mark leising,
-ASTR,1040,3,Stellar Astr Lab,0.39,0.39,0.0,0.0,0.0,0.0,0.0,0.22,mark leising,
-ASTR,1040,5,Stellar Astr Lab,0.73,0.18,0.05,0.0,0.0,0.0,0.0,0.05,mark leising,
-ASTR,1040,6,Stellar Astr Lab,0.4,0.27,0.0,0.0,0.13,0.0,0.0,0.2,mark leising,
-AUD,2850,1,AUD 2850: 001,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUE,8160,1,AUE 8160: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8160,2,AUE 8160: 002,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,8170,3,AUE 8170: 003,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8290,4,AUE 8290: 004,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,timothy rhyne,
-AUE,8500,6,AUE 8500: 006,0.43,0.46,0.04,0.0,0.0,0.0,0.0,0.07,beshah ayalew,
-AUE,8550,16,AUE 8550: 016,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8660,7,Adv Matl Auto Appl,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
-AUE,8690,8,AUE 8690: 008,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8770,9,AUE 8770: 009,0.57,0.32,0.07,0.0,0.04,0.0,0.0,0.0,fadi kama abu-farha,
-AUE,8820,10,AUE 8820: 010,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,
-AUE,8860,11,AUE 8860: 011,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8900,400,AUE 8900: 400,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,
-AUE,8930,15,Autovation I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,
-AVS,2000,1,AVS 2000: 001,0.83,0.14,0.02,0.0,0.0,0.0,0.0,0.0,brian bolt,
-AVS,2050,1,AVS 2050: 001,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
-AVS,2060,1,AVS 2060: 001,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,2090,1,AVS 2090: 001,0.94,0.01,0.0,0.0,0.01,0.0,0.0,0.03,brian bolt,
-AVS,2110,1,AVS 2110: 001,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,michelle hall,
-AVS,3150,1,Animal Welfare,0.22,0.43,0.17,0.13,0.0,0.0,0.0,0.04,peter skewes,
-AVS,3750,1,Appl Animal Nutr,0.1,0.37,0.29,0.15,0.01,0.0,0.0,0.09,nathan long,
-AVS,4060,1,AVS 4060: 001,0.88,0.09,0.0,0.0,0.0,0.0,0.0,0.03,glenn birrenkott,
-AVS,4100,1,AVS 4100: 001,0.15,0.41,0.32,0.09,0.02,0.0,0.0,0.01,peter skewes,
-AVS,4120,1,Adv Equine Mgmt,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,4130,1,AVS 4130: 001,0.35,0.45,0.13,0.01,0.0,0.0,0.0,0.05,michelle hall,
-AVS,4170,1,AVS 4170: 001,0.38,0.5,0.0,0.04,0.04,0.0,0.0,0.04,kristine lan vernon,
-AVS,4530,1,Animal Reproduction,0.31,0.52,0.11,0.03,0.01,0.0,0.0,0.01,glenn birrenkott,
-AVS,4530,400,Animal Reproduction,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,6110,1,AVS 6110: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,
-AVS,8090,1,AVS 8090: 001,0.63,0.13,0.0,0.0,0.0,0.0,0.0,0.25,susan kay duckett,
-BCHM,3010,1,Molecular Biochem,0.08,0.33,0.26,0.25,0.03,0.0,0.0,0.05,meredith tei morris,
-BCHM,3010,2,Molecular Biochem(HON),0.56,0.24,0.12,0.0,0.0,0.0,0.0,0.08,meredith tei morris,True
-BCHM,3020,1,BCHM 3020: 001,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,meredith tei morris,
-BCHM,3020,2,BCHM 3020: 002,0.56,0.25,0.0,0.06,0.0,0.0,0.0,0.13,meredith tei morris,
-BCHM,3020,3,BCHM 3020: 003,0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,meredith tei morris,
-BCHM,3050,1,BCHM 3050: 001,0.24,0.22,0.27,0.18,0.04,0.0,0.0,0.04,james morris,
-BCHM,4060,1,BCHM 4060: 001,0.46,0.27,0.19,0.03,0.03,0.0,0.0,0.03,ashby burges bodine,
-BCHM,4320,1,Bioch of Metabolism,0.79,0.15,0.03,0.0,0.0,0.0,0.0,0.03,kimberly paul,
-BCHM,4360,1,Genes to Proteins,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
-BE,2100,1,BE 2100: 001,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,yi zheng,
-BE,3220,1,BE 3220: 001,0.29,0.29,0.32,0.04,0.0,0.0,0.0,0.07,tom owino,
-BE,4120,1,BE 4120: 001,0.3,0.4,0.25,0.0,0.0,0.0,0.0,0.05,caye marie drapcho,
-BE,4210,1,BE 4210: 001,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4240,1,BE 4240: 001,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,
-BE,4380,1,BE 4380: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,
-BIOE,1010,1,BIOE 1010: 001,0.85,0.09,0.05,0.0,0.0,0.0,0.0,0.0,agneta simionescu,
-BIOE,2010,1,BIOE 2010: 001,0.28,0.4,0.16,0.04,0.04,0.0,0.0,0.08,charles webb,
-BIOE,3020,1,BIOE 3020: 001,0.48,0.42,0.06,0.02,0.02,0.0,0.0,0.0,alexey ale vertegel,
-BIOE,3200,1,BIOE 3200: 001,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,
-BIOE,3210,1,BIOE 3210: 001,0.42,0.42,0.06,0.03,0.0,0.0,0.0,0.06,sarah harcum,
-BIOE,3700,1,BIOE 3700: 001,0.62,0.31,0.02,0.0,0.02,0.0,0.0,0.03,delphine dean,
-BIOE,4030,1,BIOE 4030: 001,0.97,0.02,0.0,0.0,0.0,0.0,0.0,0.01,john desjardins,
-BIOE,4230,1,BIOE 4230: 001,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,dan simionescu,
-BIOE,4310,1,BIOE 4310: 001,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,david kwartowitz,
-BIOE,8020,410,BIOE 8020: 410,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
-BIOE,8150,410,BIOE 8150: 410,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,
-BIOE,8470,1,BIOE 8470: 001,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,robert latour,
-BIOE,8490,1,BIOE 8490: 001,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,ying mei,
-BIOE,8500,3,Drug Delivery,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,jeoungsoo lee,
-BIOL,1040,1,General Biology II,0.3,0.33,0.24,0.06,0.02,0.0,0.0,0.05,nora espinoza,
-BIOL,1040,2,General Biology II,0.18,0.38,0.24,0.12,0.06,0.0,0.0,0.01,kalan ickes,
-BIOL,1040,3,General Biology II,0.18,0.22,0.3,0.16,0.08,0.0,0.0,0.08,salvatore sparace,
-BIOL,1040,4,General Biology II (HON),0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
-BIOL,1060,1,Gen Biology Lab II,0.26,0.26,0.37,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,2,Gen Biology Lab II,0.09,0.45,0.14,0.27,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,3,Gen Biology Lab II,0.16,0.47,0.16,0.16,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,4,Gen Biology Lab II,0.13,0.35,0.39,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,5,Gen Biology Lab II,0.22,0.35,0.09,0.04,0.26,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,6,Gen Biology Lab II,0.13,0.43,0.3,0.09,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,7,Gen Biology Lab II,0.14,0.57,0.1,0.1,0.0,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,8,Gen Biology Lab II,0.0,0.31,0.46,0.15,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1060,10,Gen Biology Lab II,0.15,0.3,0.4,0.15,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,11,Gen Biology Lab II,0.13,0.5,0.31,0.0,0.0,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1060,12,Gen Biology Lab II,0.71,0.21,0.0,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,13,Gen Biology Lab II,0.09,0.39,0.3,0.04,0.13,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,14,Gen Biology Lab II,0.17,0.26,0.35,0.09,0.13,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,15,Gen Biology Lab II,0.18,0.36,0.27,0.05,0.09,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,16,Gen Biology Lab II,0.23,0.41,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,17,Gen Biology Lab II,0.13,0.53,0.27,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,18,Gen Biology Lab II,0.24,0.35,0.18,0.18,0.0,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1060,19,Gen Biology Lab II,0.26,0.53,0.11,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,20,Gen Biology Lab II,0.06,0.56,0.22,0.11,0.06,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,21,Gen Biology Lab II,0.24,0.24,0.29,0.12,0.12,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,22,Gen Biology Lab II,0.13,0.44,0.38,0.0,0.06,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,23,Gen Biology Lab II,0.25,0.5,0.08,0.0,0.17,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,25,Gen Biology Lab II,0.29,0.33,0.19,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,26,Gen Biology Lab II,0.47,0.24,0.12,0.0,0.12,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1060,27,Gen Biology Lab II,0.25,0.5,0.06,0.13,0.06,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,28,Gen Biology Lab II,0.15,0.45,0.2,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,29,Gen Biology Lab II,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,30,Gen Biology Lab II,0.09,0.59,0.23,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,31,Gen Biology Lab II,0.19,0.52,0.19,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,34,Gen Biology Lab II,0.48,0.24,0.19,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,35,Gen Biology Lab II,0.25,0.58,0.0,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,36,Gen Biology Lab II,0.59,0.24,0.06,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1060,37,Gen Biology Lab II,0.3,0.35,0.17,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,38,Gen Biology Lab II,0.35,0.3,0.3,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,39,Gen Biology Lab II,0.43,0.3,0.22,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,40,Gen Biology Lab II,0.33,0.33,0.22,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1060,41,Gen Biology Lab II,0.25,0.31,0.31,0.06,0.06,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,42,Gen Biology Lab II,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,43,Gen Biology Lab II,0.36,0.29,0.14,0.07,0.07,0.0,0.0,0.07,tafadzwa kaisa,
-BIOL,1060,44,Gen Biology Lab II,0.09,0.36,0.18,0.18,0.09,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1090,1,Intro to Life Sci,0.9,0.07,0.0,0.0,0.02,0.0,0.0,0.0,renea chri hardwick,
-BIOL,1110,1,Prin of Biol II,0.32,0.35,0.24,0.03,0.06,0.0,0.0,0.0,dylan dittrich-reed,
-BIOL,1110,2,Prin of Biol II,0.3,0.44,0.17,0.07,0.01,0.0,0.0,0.02,robert kosinski,
-BIOL,1110,3,Prin of Biol II (HON),0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert kosinski,True
-BIOL,1200,1,Biological Inq Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,2,Biological Inq Lab,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14, christine minor,
-BIOL,1200,5,Biological Inq Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,6,Biological Inq Lab,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1200,12,Biological Inq Lab,0.33,0.56,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1230,1,Keys to Human Biol,0.3,0.28,0.27,0.13,0.01,0.0,0.0,0.0, christine minor,
-BIOL,2000,2,Biology in the News,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,2000,3,Biology in the News,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
-BIOL,2000,4,Biology in the News,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,barbara campbell,
-BIOL,2000,7,Biology in the News,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,michael sears,
-BIOL,2030,1,Human Disease & Soc,0.82,0.11,0.05,0.0,0.03,0.0,0.0,0.0, christine minor,
-BIOL,2040,1,"Environ, Energy and Society",0.33,0.39,0.18,0.06,0.03,0.0,0.0,0.03,john jenkins hains,
-BIOL,2110,1,Introduction to Toxicology,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,peter van den hurk,
-BIOL,2230,1,BIOL 2230: 001,0.37,0.41,0.13,0.04,0.03,0.0,0.0,0.02,john cummings,
-BIOL,2230,2,BIOL 2230: 002,0.37,0.39,0.15,0.07,0.01,0.0,0.0,0.02,john cummings,
-BIOL,3020,1,Invertebrate Biology,0.07,0.36,0.16,0.18,0.06,0.0,0.0,0.17,juan baeza migueles,
-BIOL,3040,1,Biology of Plants,0.11,0.38,0.32,0.12,0.08,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3060,1,BIOL 3060: 001,0.24,0.41,0.06,0.24,0.0,0.0,0.0,0.06,juan baeza migueles,
-BIOL,3060,2,BIOL 3060: 002,0.15,0.25,0.35,0.05,0.2,0.0,0.0,0.0,juan baeza migueles,
-BIOL,3060,3,BIOL 3060: 003,0.22,0.39,0.11,0.0,0.0,0.0,0.0,0.28,juan baeza migueles,
-BIOL,3060,4,BIOL 3060: 004,0.16,0.32,0.21,0.11,0.05,0.0,0.0,0.16,juan baeza migueles,
-BIOL,3080,1,BIOL 3080: 001,0.11,0.26,0.21,0.16,0.11,0.0,0.0,0.16,robert edwa ballard,
-BIOL,3080,2,BIOL 3080: 002,0.22,0.39,0.22,0.11,0.06,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3080,3,BIOL 3080: 003,0.28,0.33,0.33,0.06,0.0,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3080,4,BIOL 3080: 004,0.19,0.25,0.13,0.06,0.06,0.0,0.0,0.31,robert edwa ballard,
-BIOL,3130,1,Conservation Biology,0.35,0.48,0.0,0.09,0.04,0.0,0.0,0.04,shari lyn rodriguez,
-BIOL,3130,2,Conservation Biology,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-BIOL,3160,1,BIOL 3160: 001,0.25,0.49,0.18,0.04,0.02,0.0,0.0,0.01,tamara mcnutt-scott,
-BIOL,3200,1,BIOL 3200: 001,0.17,0.38,0.24,0.13,0.02,0.0,0.0,0.06,timothy spira,
-BIOL,3350,1,BIOL 3350: 001,0.36,0.38,0.13,0.04,0.07,0.0,0.0,0.03,margaret ptacek,
-BIOL,4010,1,Plant Physiology,0.13,0.13,0.19,0.35,0.13,0.0,0.0,0.08,douglas bielenberg,
-BIOL,4020,1,BIOL 4020: 001,0.31,0.31,0.08,0.0,0.23,0.0,0.0,0.08,douglas bielenberg,
-BIOL,4020,2,BIOL 4020: 002,0.43,0.29,0.14,0.07,0.0,0.0,0.0,0.07,douglas bielenberg,
-BIOL,4020,3,BIOL 4020: 003,0.31,0.38,0.08,0.15,0.0,0.0,0.0,0.08,douglas bielenberg,
-BIOL,4020,4,BIOL 4020: 004,0.33,0.4,0.13,0.07,0.0,0.0,0.0,0.07,douglas bielenberg,
-BIOL,4100,1,BIOL 4100: 001,0.37,0.39,0.2,0.02,0.0,0.0,0.0,0.02,john jenkins hains,
-BIOL,4140,1,Basic Immunology,0.72,0.22,0.0,0.0,0.02,0.0,0.0,0.04,charles rice,
-BIOL,4340,1,BIOL 4340: 001,0.25,0.33,0.42,0.0,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,2,BIOL 4340: 002,0.09,0.27,0.27,0.27,0.0,0.0,0.0,0.09,salvatore sparace,
-BIOL,4340,3,BIOL 4340: 003,0.08,0.77,0.08,0.0,0.0,0.0,0.0,0.08,salvatore sparace,
-BIOL,4340,4,BIOL 4340: 004,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,5,BIOL 4340: 005,0.18,0.45,0.27,0.09,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,6,BIOL 4340: 006,0.0,0.33,0.5,0.17,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4510,1,Biol Variation in Human Pop,0.25,0.5,0.13,0.0,0.06,0.0,0.0,0.06,katherine weisensee,
-BIOL,4610,1,Cell Biology,0.32,0.39,0.18,0.08,0.01,0.0,0.0,0.03,david feliciano,
-BIOL,4610,2,Cell Biology (HON),0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,david feliciano,True
-BIOL,4620,2,BIOL 4620: 002,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
-BIOL,4620,3,BIOL 4620: 003,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,lesly temesvari,
-BIOL,4620,4,BIOL 4620: 004,0.36,0.43,0.14,0.0,0.07,0.0,0.0,0.0,lesly temesvari,
-BIOL,4620,7,BIOL 4620: 007,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
-BIOL,4620,8,BIOL 4620: 008,0.63,0.25,0.0,0.0,0.06,0.0,0.0,0.06,lesly temesvari,
-BIOL,4640,1,BIOL 4640: 001,0.29,0.41,0.24,0.0,0.0,0.0,0.0,0.06,john cummings,
-BIOL,4700,1,Behavioral Ecology,0.42,0.41,0.12,0.02,0.01,0.0,0.0,0.03,michael childress,
-BIOL,4710,1,BIOL 4710: 001,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,michael childress,
-BIOL,4710,2,BIOL 4710: 002,0.55,0.15,0.0,0.1,0.0,0.0,0.0,0.2,michael childress,
-BIOL,4710,3,BIOL 4710: 003,0.63,0.21,0.05,0.0,0.0,0.0,0.0,0.11,michael childress,
-BIOL,4710,4,BIOL 4710: 004,0.65,0.12,0.12,0.0,0.0,0.0,0.0,0.12,michael childress,
-BIOL,4780,1,BIOL 4780: 001,0.47,0.33,0.03,0.07,0.0,0.0,0.0,0.1,jason denton,
-BIOL,4930,5,BIOL 4930: 005,0.64,0.14,0.14,0.07,0.0,0.0,0.0,0.0,lisa bain,
-BIOL,6010,1,BIOL 6010: 001,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
-BIOL,8450,1,Understanding Vertebrate Biol,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,tamara mcnutt-scott,
-BIOL,8470,1,Understanding Microbiology,0.59,0.38,0.0,0.0,0.0,0.0,0.0,0.03,harry kurtz,
-BIOL,8710,5,CS Ecological Risk Assess ETOX,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,stephen klaine,
-BIOL,8710,6,Proc Ecological Risk Assessmen,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
-BT,2200,1,BT 2200: 001,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,shannon go lawrence,
-BUS,1010,1,BUS 1010: 001,0.16,0.51,0.2,0.09,0.0,0.0,0.0,0.04,lance scott young,
-BUS,1010,2,BUS 1010: 002,0.1,0.59,0.24,0.03,0.03,0.0,0.0,0.0,michael giebner,
-BUS,1010,3,BUS 1010: 003,0.12,0.55,0.28,0.02,0.02,0.0,0.0,0.02,lance scott young,
-BUS,1010,4,BUS 1010: 004,0.0,0.57,0.27,0.03,0.07,0.0,0.0,0.07,michael giebner,
-BUS,1010,6,BUS 1010: 006,0.15,0.5,0.22,0.03,0.06,0.0,0.0,0.04,michael giebner,
-CE,2010,1,Statics,0.43,0.2,0.07,0.09,0.07,0.0,0.0,0.14,nighat yasmin,
-CE,2010,2,Statics,0.3,0.25,0.25,0.09,0.02,0.0,0.0,0.09,melissa sternhagen,
-CE,2010,3,Statics,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,
-CE,2010,4,Statics,0.36,0.3,0.2,0.02,0.0,0.0,0.0,0.11,melissa sternhagen,
-CE,2010,5,Statics,0.44,0.21,0.16,0.05,0.07,0.0,0.0,0.07,nighat yasmin,
-CE,2010,6,Statics,0.37,0.37,0.17,0.03,0.0,0.0,0.0,0.06,weichiang pang,
-CE,2010,7,Statics,0.27,0.52,0.09,0.03,0.03,0.0,0.0,0.06,ismail farajpour,
-CE,2060,1,CE 2060: 001,0.22,0.43,0.24,0.04,0.04,0.0,0.0,0.04,bryant nielson,
-CE,2060,2,CE 2060: 002,0.22,0.49,0.16,0.06,0.0,0.0,0.0,0.06,bryant nielson,
-CE,2080,1,CE 2080: 001,0.24,0.36,0.24,0.04,0.04,0.04,0.0,0.04,melissa sternhagen,
-CE,2080,2,CE 2080: 002,0.19,0.34,0.25,0.08,0.03,0.0,0.0,0.1,melissa sternhagen,
-CE,2080,3,CE 2080: 003,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,
-CE,2080,4,CE 2080: 004,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,
-CE,2550,1,CE 2550: 001,0.32,0.48,0.19,0.01,0.0,0.0,0.0,0.0,wayne sarasua,
-CE,3010,1,CE 3010: 001,0.17,0.17,0.29,0.1,0.17,0.0,0.0,0.12,scott schiff,
-CE,3110,1,CE 3110: 001,0.31,0.31,0.21,0.12,0.04,0.0,0.0,0.01,wayne sarasua,
-CE,3210,1,CE 3210: 001,0.59,0.3,0.09,0.0,0.0,0.0,0.0,0.02,charng-hsein juang,
-CE,3210,2,CE 3210: 002,0.4,0.4,0.08,0.04,0.08,0.0,0.0,0.0,qiushi chen,
-CE,3310,1,CE 3310: 001,0.45,0.29,0.17,0.05,0.02,0.0,0.0,0.02,james burati,
-CE,3410,1,CE 3410: 001,0.54,0.28,0.13,0.01,0.03,0.0,0.0,0.03,firat yener testik,
-CE,3420,1,CE 3420: 001,0.29,0.35,0.18,0.06,0.12,0.0,0.0,0.0,abdul khan,
-CE,3420,2,CE 3420: 002,0.39,0.49,0.1,0.02,0.0,0.0,0.0,0.0,ashok mishra,
-CE,3510,1,CE 3510: 001,0.5,0.33,0.1,0.03,0.0,0.0,0.0,0.05,ami esmaeilpoursaee,
-CE,3520,1,CE 3520: 001,0.31,0.31,0.19,0.1,0.03,0.0,0.0,0.06,yongxi huang,
-CE,3520,2,CE 3520: 002,0.41,0.37,0.13,0.04,0.04,0.0,0.0,0.02,bradley putman,
-CE,3530,1,CE 3530: 001,0.94,0.02,0.03,0.0,0.0,0.0,0.0,0.02,ronald andrus,
-CE,4010,1,CE 4010: 001,0.25,0.41,0.28,0.06,0.0,0.0,0.0,0.0,atamturktur russcher,
-CE,4020,1,CE 4020: 001,0.52,0.25,0.15,0.04,0.01,0.0,0.0,0.01,brandon ross,
-CE,4070,1,CE 4070: 001,0.19,0.35,0.32,0.13,0.0,0.0,0.0,0.0,weichiang pang,
-CE,4110,1,CE 4110: 001,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.07,jennifer ogle,
-CE,4120,1,Urban Transport Plan,0.21,0.45,0.24,0.03,0.03,0.0,0.0,0.03,mashrur chowdhury,
-CE,4210,1,CE 4210: 001,0.26,0.35,0.31,0.07,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,4340,1,CE 4340: 001,0.62,0.27,0.07,0.04,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,4470,1,CE 4470: 001,0.59,0.22,0.19,0.0,0.0,0.0,0.0,0.0,nigel gregory kaye,
-CE,4590,1,CE 4590: 001,0.48,0.47,0.06,0.0,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4620,1,CE 4620: 001,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,firat yener testik,
-CE,4910,1,Sustainable Proj Planning 3cr,0.73,0.2,0.05,0.0,0.02,0.0,0.0,0.0,leidy klotz,
-CE,6010,1,CE 6010: 001,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
-CE,6070,1,CE 6070: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CE,8010,1,CE 8010: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,8030,1,CE 8030: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,scott schiff,
-CE,8050,1,CE 8050: 001,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,bryant nielson,
-CE,8200,1,CE 8200: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,8280,1,CE 8280: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
-CE,8530,1,CE 8530: 001,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CE,8930,1,Selec Topics in C E,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
-CH,1010,1,General Chemistry,0.4,0.34,0.17,0.02,0.03,0.0,0.0,0.04,stephe schvaneveldt,
-CH,1010,2,General Chemistry,0.04,0.18,0.26,0.25,0.17,0.0,0.0,0.1,stephanie mccartney,
-CH,1010,3,General Chemistry,0.05,0.21,0.35,0.18,0.19,0.0,0.0,0.03,stephanie mccartney,
-CH,1010,4,General Chemistry,0.13,0.23,0.22,0.17,0.17,0.0,0.0,0.08,dennis taylor,
-CH,1010,400,General Chemistry,0.13,0.28,0.28,0.13,0.15,0.0,0.0,0.03,stephe schvaneveldt,
-CH,1020,1,General Chemistry,0.33,0.32,0.2,0.04,0.06,0.0,0.0,0.05,dennis taylor,
-CH,1020,2,General Chemistry,0.13,0.46,0.26,0.04,0.06,0.0,0.0,0.06,stephanie mccartney,
-CH,1020,3,General Chemistry,0.29,0.34,0.3,0.05,0.01,0.0,0.0,0.01,tania issa houjeiry,
-CH,1020,4,General Chemistry,0.34,0.43,0.13,0.06,0.01,0.0,0.0,0.04,karen an pressprich,
-CH,1020,5,General Chemistry,0.56,0.15,0.3,0.0,0.0,0.0,0.0,0.0,karen an pressprich,
-CH,1020,6,General Chemistry,0.29,0.36,0.25,0.05,0.03,0.0,0.0,0.03,dennis taylor,
-CH,1020,7,General Chemistry,0.2,0.45,0.27,0.04,0.02,0.0,0.0,0.02,kenneth wi rillings,
-CH,1020,8,General Chemistry,0.25,0.43,0.22,0.06,0.0,0.0,0.0,0.05,karen an pressprich,
-CH,1020,9,General Chemistry,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,kenneth wi rillings,
-CH,1020,10,General Chemistry,0.08,0.46,0.23,0.08,0.0,0.0,0.0,0.15,olt geiculescu,
-CH,1020,11,General Chemistry,0.2,0.48,0.2,0.07,0.01,0.0,0.0,0.05,kenneth wi rillings,
-CH,1020,12,General Chemistry,0.32,0.41,0.24,0.02,0.0,0.0,0.0,0.01,kenneth christensen,
-CH,1020,51,General Chemistry (HON),0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
-CH,1020,52,General Chemistry (HON),0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,shiou-jyh hwu,True
-CH,1050,1,Chem in Context I,0.23,0.49,0.24,0.04,0.0,0.0,0.0,0.0,thomas hickman,
-CH,1060,1,Chem in Context II,0.39,0.53,0.08,0.0,0.0,0.0,0.0,0.0,olt geiculescu,
-CH,1060,2,Chem in Context II,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,olt geiculescu,
-CH,1520,1,CH 1520: 001,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,richard marcus,
-CH,2010,1,CH 2010: 001,0.29,0.19,0.2,0.14,0.08,0.0,0.0,0.08,thomas hickman,
-CH,2011,2,CH 2011: 002,0.76,0.12,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2011,3,CH 2011: 003,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,sean 'connor,
-CH,2050,1,CH 2050: 001,0.48,0.3,0.18,0.0,0.0,0.0,0.0,0.05,william pennington,
-CH,2230,1,CH 2230: 001,0.34,0.35,0.21,0.02,0.06,0.0,0.0,0.02,jacob schroeder,
-CH,2230,2,CH 2230: 002,0.35,0.41,0.14,0.02,0.03,0.0,0.0,0.05,jacob schroeder,
-CH,2230,3,CH 2230: 003,0.26,0.29,0.24,0.08,0.05,0.0,0.0,0.08,thomas hickman,
-CH,2240,1,CH 2240: 001,0.32,0.47,0.1,0.08,0.02,0.0,0.0,0.01,tania issa houjeiry,
-CH,2240,2,CH 2240: 002,0.23,0.5,0.2,0.08,0.0,0.0,0.0,0.0,tania issa houjeiry,
-CH,2240,3,CH 2240: 003,0.2,0.36,0.27,0.07,0.04,0.0,0.0,0.05,jacob schroeder,
-CH,2240,4,CH 2240: 004,0.26,0.26,0.26,0.14,0.02,0.0,0.0,0.06,rhett smith,
-CH,2240,5,CH 2240: 005,0.32,0.39,0.19,0.06,0.01,0.0,0.0,0.03,modi wetzler,
-CH,2270,2,CH 2270: 002,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,3,CH 2270: 003,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2270,4,CH 2270: 004,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,7,CH 2270: 007,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,8,CH 2270: 008,0.69,0.25,0.0,0.06,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,9,CH 2270: 009,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,10,CH 2270: 010,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,sean 'connor,
-CH,2280,2,CH 2280: 002,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,sean 'connor,
-CH,2280,3,CH 2280: 003,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,4,CH 2280: 004,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,5,CH 2280: 005,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,8,CH 2280: 008,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,13,CH 2280: 013,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2280,14,CH 2280: 014,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,
-CH,2280,18,CH 2280: 018,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,23,CH 2280: 023,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,29,CH 2280: 029,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2290,1,CH 2290: 001,0.78,0.06,0.06,0.11,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2290,2,CH 2290: 002,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,3310,1,CH 3310: 001,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,arkady kholodenko,
-CH,3320,1,Physical Chemistry,0.33,0.44,0.18,0.03,0.03,0.0,0.0,0.0,steven stuart,
-CH,3320,2,Physical Chemistry,0.45,0.32,0.14,0.09,0.0,0.0,0.0,0.0,dvora perahia,
-CH,3400,1,CH 3400: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason mcneill,
-CH,3400,2,CH 3400: 002,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason mcneill,
-CH,3600,1,CH 3600: 001,0.34,0.39,0.2,0.07,0.0,0.0,0.0,0.0,brian dominy,
-CH,4110,1,CH 4110: 001,0.1,0.29,0.33,0.1,0.19,0.0,0.0,0.0,george chumanov,
-CH,4120,1,CH 4120: 001,0.27,0.64,0.0,0.0,0.09,0.0,0.0,0.0,jeffrey natha anker,
-CH,4130,1,Chem Aqueous Systems,0.29,0.29,0.36,0.07,0.0,0.0,0.0,0.0,cindy lee,
-CH,4500,1,CH 4500: 001,0.55,0.17,0.24,0.03,0.0,0.0,0.0,0.0,gauta bhattacharyya,
-CH,4520,1,CH 4520: 001,0.86,0.07,0.03,0.03,0.0,0.0,0.0,0.0,richard marcus,
-CH,8180,1,CH 8180: 001,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,stephen creager,
-CH,8220,1,CH 8220: 001,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,daniel whitehead,
-CH,8510,2,CH 8510: 002,0.94,0.0,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey natha anker,
-CH,8600,1,CH 8600: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
-CHE,1300,1,CHE 1300: 001,0.26,0.42,0.25,0.04,0.0,0.0,0.0,0.04,antho guiseppi-elie,
-CHE,1300,2,CHE 1300: 002,0.38,0.38,0.17,0.02,0.0,0.0,0.0,0.05,christopher norfolk,
-CHE,2200,1,CHE 2200: 001,0.14,0.08,0.3,0.22,0.16,0.0,0.0,0.11,mark thies,
-CHE,2200,2,CHE 2200: 002,0.11,0.23,0.31,0.11,0.14,0.0,0.0,0.09,mark thies,
-CHE,2300,1,CHE 2300: 001,0.09,0.23,0.3,0.19,0.17,0.0,0.0,0.02,sapna sarupria,
-CHE,2300,2,CHE 2300: 002,0.15,0.27,0.27,0.15,0.12,0.0,0.0,0.04,sapna sarupria,
-CHE,3210,1,CHE 3210: 001,0.16,0.22,0.33,0.24,0.04,0.0,0.0,0.02,christophe kitchens,
-CHE,3300,1,CHE 3300: 001,0.2,0.33,0.29,0.12,0.04,0.0,0.0,0.02,mark alan blenner,
-CHE,3530,1,CHE 3530: 001,0.14,0.5,0.3,0.07,0.0,0.0,0.0,0.0,mark roberts,
-CHE,4330,1,CHE 4330: 001,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,8450,2,E-Storage in Carbon Materials,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark roberts,
-CHIN,1020,1,CHIN 1020: 001,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
-CHIN,2020,1,CHIN 2020: 001,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,yanhua zhang,
-COM,1500,1,Intro to Human Com,0.63,0.31,0.02,0.01,0.01,0.0,0.0,0.03,eddie smith,
-COM,1500,2,Intro to Human Com,0.44,0.42,0.07,0.01,0.02,0.0,0.0,0.05,daniel lelan fecher,
-COM,1500,3,Intro to Human Com,0.7,0.21,0.05,0.0,0.01,0.0,0.0,0.03,eddie smith,
-COM,1500,4,Intro to Human Com,0.48,0.39,0.08,0.01,0.02,0.0,0.0,0.02,marianne her glaser,
-COM,1500,5,Intro to Human Com,0.45,0.44,0.05,0.02,0.02,0.0,0.0,0.02,marianne her glaser,
-COM,1500,6,Intro to Human Com,0.45,0.49,0.03,0.01,0.0,0.0,0.0,0.01,daniel lelan fecher,
-COM,2010,1,COMM 2010: 001,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,john steven spinda,
-COM,2010,2,COMM 2010: 002,0.46,0.33,0.17,0.04,0.0,0.0,0.0,0.0,brenden kendall,
-COM,2500,1,Public Speaking,0.44,0.33,0.11,0.0,0.06,0.0,0.0,0.06,brandon boatwright,
-COM,2500,2,Public Speaking,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,3,Public Speaking,0.44,0.33,0.0,0.11,0.06,0.0,0.0,0.06,christop wasilewski,
-COM,2500,4,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,5,Public Speaking,0.58,0.21,0.16,0.0,0.0,0.0,0.0,0.05,brandon boatwright,
-COM,2500,6,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,7,Public Speaking,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,8,Public Speaking,0.4,0.45,0.1,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,9,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,10,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,11,Public Speaking,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,12,Public Speaking,0.42,0.53,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
-COM,2500,13,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,14,Public Speaking,0.37,0.47,0.05,0.0,0.11,0.0,0.0,0.0,christop wasilewski,
-COM,2500,15,Public Speaking,0.45,0.35,0.15,0.0,0.0,0.0,0.0,0.05,caitlin baker,
-COM,2500,16,Public Speaking,0.75,0.15,0.05,0.05,0.0,0.0,0.0,0.0,the estate  geddes,
-COM,2500,17,Public Speaking,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,18,Public Speaking,0.42,0.37,0.11,0.05,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,19,Public Speaking,0.15,0.45,0.35,0.0,0.05,0.0,0.0,0.0,pauline matthey,
-COM,2500,20,Public Speaking,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,21,Public Speaking,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,
-COM,2500,22,Public Speaking,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,
-COM,2500,23,Public Speaking,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,caitlin baker,
-COM,2500,24,Public Speaking,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,kayla steele payne,
-COM,2500,25,Public Speaking (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,True
-COM,2500,400,Public Speaking,0.7,0.15,0.05,0.05,0.0,0.0,0.0,0.05,alexis zachar davis,
-COM,2500,401,Public Speaking,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
-COM,2500,402,Public Speaking,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
-COM,2500,403,Public Speaking,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
-COM,2500,500,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,3020,1,COMM 3020: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3080,1,Pub Comm & Pop Cult,0.55,0.26,0.15,0.02,0.02,0.0,0.0,0.0,chenjerai kumanyika,
-COM,3100,1,COMM 3100: 001,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3110,1,COMM 3110: 001,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,3200,1,COMM 3200: 001,0.88,0.04,0.0,0.0,0.04,0.0,0.0,0.04,wanda johnson,
-COM,3260,1,COMM 3260: 001,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
-COM,3480,1,COMM 3480: 001,0.31,0.44,0.17,0.06,0.0,0.0,0.0,0.02,melinda ra weathers,
-COM,3560,1,COMM 3560: 001,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristie leah byrum,
-COM,3610,1,COMM 3610: 001,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,lindsey dixon,
-COM,3660,1,EP: Advertising & Media,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,william reynolds,
-COM,3660,3,Live Broadcast Production,0.91,0.04,0.0,0.04,0.0,0.0,0.0,0.0,michael rodgers,
-COM,4250,1,COMM 4250: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4950,1,Senior Capstone Sem,0.67,0.1,0.24,0.0,0.0,0.0,0.0,0.0,chenjerai kumanyika,
-COM,8020,1,COMM 8020: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,8110,1,COMM 8110: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brenden kendall,
-CPSC,1010,1,Computer Science I,0.28,0.15,0.15,0.08,0.25,0.0,0.0,0.09,catherine hochrine,
-CPSC,1010,2,Computer Science I,0.29,0.2,0.16,0.07,0.16,0.0,0.0,0.13,kyla mcmullen,
-CPSC,1020,1,Computer Science II,0.38,0.38,0.07,0.04,0.02,0.0,0.0,0.11,catherine hochrine,
-CPSC,1020,2,Computer Science II,0.51,0.26,0.09,0.06,0.09,0.0,0.0,0.0,sabarish venka babu,
-CPSC,1110,1,CPSC 1110: 001,0.79,0.14,0.03,0.0,0.0,0.0,0.0,0.03,patrick sterling,
-CPSC,1110,2,CPSC 1110: 002,0.58,0.15,0.08,0.12,0.0,0.0,0.0,0.08,patrick sterling,
-CPSC,1110,3,CPSC 1110: 003,0.47,0.27,0.07,0.03,0.07,0.03,0.0,0.07,patrick sterling,
-CPSC,1110,4,CPSC 1110: 004,0.77,0.03,0.03,0.07,0.0,0.0,0.0,0.1,lauren elizab dukes,
-CPSC,2070,1,CPSC 2070: 001,0.36,0.32,0.14,0.07,0.09,0.0,0.0,0.02,larry hodges,
-CPSC,2070,2,CPSC 2070: 002,0.21,0.15,0.29,0.12,0.09,0.0,0.0,0.15,sandra hedetniemi,
-CPSC,2100,1,CPSC 2100: 001,0.26,0.26,0.15,0.15,0.07,0.0,0.0,0.11,rose lowe,
-CPSC,2120,1,Algs/Data Structures,0.36,0.29,0.18,0.07,0.07,0.0,0.0,0.04,feng luo,
-CPSC,2120,2,Algs/Data Structures,0.41,0.38,0.06,0.06,0.06,0.0,0.0,0.03,raghuveer mohan,
-CPSC,2150,1,CPSC 2150: 001,0.19,0.29,0.17,0.17,0.07,0.0,0.0,0.12,catherine hochrine,
-CPSC,2150,2,CPSC 2150: 002,0.48,0.3,0.09,0.09,0.03,0.0,0.0,0.0,john yates monteith,
-CPSC,2200,1,CPSC 2200: 001,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,patrick sterling,
-CPSC,2310,1,CPSC 2310: 001,0.47,0.26,0.1,0.06,0.06,0.0,0.0,0.04,rose lowe,
-CPSC,2910,1,CPSC 2910: 001,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,james jones,
-CPSC,2910,3,CPSC 2910: 003,0.73,0.0,0.0,0.0,0.09,0.0,0.0,0.18,james jones,
-CPSC,2910,4,CPSC 2910: 004,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,renee lambert,
-CPSC,2910,5,CPSC 2910: 005,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,renee lambert,
-CPSC,2910,6,CPSC 2910: 006,0.6,0.1,0.1,0.0,0.2,0.0,0.0,0.0,renee lambert,
-CPSC,2910,7,CPSC 2910: 007,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,renee lambert,
-CPSC,3220,1,Intro to Operating Systems,0.26,0.3,0.28,0.04,0.09,0.0,0.0,0.02,mark smotherman,
-CPSC,3300,1,CPSC 3300: 001,0.26,0.17,0.28,0.09,0.09,0.0,0.0,0.11,mark smotherman,
-CPSC,3500,1,CPSC 3500: 001,0.27,0.41,0.27,0.02,0.03,0.0,0.0,0.0,wayne goddard,
-CPSC,3520,1,Programming Systems,0.09,0.34,0.21,0.02,0.09,0.0,0.0,0.26,robert schalkoff,
-CPSC,3600,1,CPSC 3600: 001,0.23,0.3,0.09,0.09,0.11,0.0,0.0,0.18,jacob sorber,
-CPSC,3620,1,CPSC 3620: 001,0.28,0.28,0.3,0.02,0.0,0.0,0.0,0.12,amy apon,
-CPSC,3720,1,CPSC 3720: 001,0.33,0.47,0.14,0.02,0.0,0.0,0.0,0.04,stephen schaub,
-CPSC,4050,1,CPSC 4050: 001,0.26,0.3,0.13,0.04,0.13,0.0,0.0,0.13,donald henry house,
-CPSC,4140,1,CPSC 4140: 001,0.21,0.63,0.0,0.0,0.04,0.0,0.0,0.13,andrew duchowski,
-CPSC,4160,1,CPSC 4160: 001,0.36,0.36,0.28,0.0,0.0,0.0,0.0,0.0,brian malloy,
-CPSC,4240,1,CPSC 4240: 001,0.29,0.63,0.0,0.0,0.04,0.0,0.0,0.04,james martin,
-CPSC,4620,1,Database Management Systems,0.22,0.35,0.17,0.04,0.04,0.0,0.0,0.17,zijun wang,
-CPSC,4810,3,Topic:Software Dev for Mobile,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,roy pargas,
-CPSC,4810,13,Pro Gen of Video Game Media,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15,brian malloy,
-CPSC,4810,14,CI: Game & Python Programming,0.55,0.18,0.18,0.0,0.0,0.0,0.0,0.09,christina gardner,
-CPSC,4910,1,CPSC 4910: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
-CPSC,6050,1,CPSC 6050: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,donald henry house,
-CPSC,6140,1,CPSC 6140: 001,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,andrew duchowski,
-CPSC,6160,1,CPSC 6160: 001,0.52,0.38,0.0,0.0,0.0,0.05,0.0,0.05,brian malloy,
-CPSC,6240,1,CPSC 6240: 001,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,james martin,
-CPSC,6620,1,CPSC 6620: 001,0.29,0.53,0.12,0.0,0.03,0.0,0.0,0.03,zijun wang,
-CPSC,6810,1,Topic:Educational Technology,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christina gardner,
-CPSC,8080,1,CPSC 8080: 001,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-CPSC,8090,1,CPSC 8090: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,
-CPSC,8150,1,CPSC 8150: 001,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,timothy davis,
-CPSC,8190,1,CPSC 8190: 001,0.0,0.63,0.25,0.0,0.0,0.0,0.0,0.13,jerry tessendorf,
-CPSC,8220,1,CPSC 8220: 001,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,robert geist,
-CPSC,8400,1,CPSC 8400: 001,0.11,0.39,0.43,0.0,0.07,0.0,0.0,0.0,brian christop dean,
-CPSC,8520,1,CPSC 8520: 001,0.4,0.56,0.0,0.0,0.0,0.0,0.0,0.04,james martin,
-CPSC,8550,1,CPSC 8550: 001,0.45,0.27,0.18,0.0,0.0,0.0,0.0,0.09,jason hallstrom,
-CPSC,8620,1,CPSC 8620: 001,0.77,0.17,0.04,0.0,0.0,0.0,0.0,0.02,juan gilbert,
-CPSC,8630,1,CPSC 8630: 001,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,zijun wang,
-CPSC,8650,1,CPSC 8650: 001,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,zijun wang,
-CPSC,8750,1,CPSC 8750: 001,0.32,0.36,0.28,0.0,0.0,0.0,0.0,0.04,john mcgregor,
-CPSC,8810,1,Topic:Geometric Modeling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joshua levine,
-CRP,8010,1,Planning Process & Legal Found,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,
-CRP,8050,1,Plning Theory & Hist,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,mickey lauria,
-CRP,8090,1,CRP 8090: 001,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,barry nocks,
-CRP,8140,1,Public Transit,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
-CRP,8220,1,Urban Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-CRP,8890,3,S. Topic-Geodesign w/ CityEng.,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
-CSEN,2020,1,CSEN 2020: 001,0.4,0.23,0.13,0.15,0.04,0.0,0.0,0.04,dara michelle park,
-CSEN,4520,1,CSEN 4520: 001,0.52,0.39,0.0,0.0,0.0,0.0,0.0,0.09,haibo liu,
-CSM,1500,1,CSM 1500: 001,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,1500,2,CSM 1500: 002,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2020,1,CSM 2020: 001,0.1,0.43,0.38,0.1,0.0,0.0,0.0,0.0,shima clarke,
-CSM,2020,2,CSM 2020: 002,0.24,0.53,0.24,0.0,0.0,0.0,0.0,0.0,shima clarke,
-CSM,2040,1,CSM 2040: 001,0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2040,2,CSM 2040: 002,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2050,1,CSM 2050: 001,0.42,0.21,0.21,0.16,0.0,0.0,0.0,0.0,jason lucas,
-CSM,2050,2,CSM 2050: 002,0.3,0.25,0.35,0.1,0.0,0.0,0.0,0.0,jason lucas,
-CSM,3050,1,CSM 3050: 001,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3050,2,CSM 3050: 002,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3520,1,CSM 3520: 001,0.24,0.67,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,3520,2,CSM 3520: 002,0.06,0.47,0.35,0.12,0.0,0.0,0.0,0.0,christine piper,
-CSM,3530,1,CSM 3530: 001,0.3,0.65,0.04,0.0,0.0,0.0,0.0,0.0,james packer smith,
-CSM,3530,2,CSM 3530: 002,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,james packer smith,
-CSM,4540,1,CSM 4540: 001,0.2,0.4,0.4,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4540,2,CSM 4540: 002,0.2,0.47,0.33,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8620,1,Personnel Mgt & Neg,0.13,0.38,0.38,0.0,0.0,0.0,0.0,0.13,roger william liska,
-CSM,8620,400,Personnel Mgt & Neg,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CU,1000,1,CU 1000: 001,0.0,0.0,0.0,0.0,0.0,0.87,0.11,0.02,jeffrey appling,
-CU,1010,1,CU 1010: 001,0.38,0.38,0.13,0.0,0.08,0.0,0.0,0.04,rise jean sheriff,
-CU,1010,2,CU 1010: 002,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,cecelia hamby,
-CU,1010,3,CU 1010: 003,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-CU,1010,5,CU 1010: 005,0.85,0.07,0.0,0.0,0.04,0.0,0.0,0.04,mary mcp von kaenel,
-CU,1010,6,CU 1010: 006,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,mary mcp von kaenel,
-CU,1010,10,CU 1010: 010,0.63,0.2,0.1,0.03,0.03,0.0,0.0,0.0, elaine richardson,
-CU,2010,1,CU 2010: 001,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,leidy klotz,
-DANC,1400,1,Jazz Dance I,0.91,0.0,0.05,0.0,0.05,0.0,0.0,0.0,cheryl hosler,
-DANC,1500,1,Modern Dance I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,cheryl hosler,
-DPA,3070,1,DPA 3070: 001,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,timothy curtis,
-ECE,2010,1,Logic & Comp Device,0.21,0.27,0.19,0.31,0.0,0.0,0.0,0.02,lin zhu,
-ECE,2020,1,Electric Circuits I,0.17,0.4,0.18,0.12,0.11,0.0,0.0,0.02,william harrell,
-ECE,2090,2,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,timothy burg,
-ECE,2090,3,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,
-ECE,2090,4,Logic Lab,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,
-ECE,2110,1,ECE 2110: 001,0.58,0.25,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,
-ECE,2110,3,ECE 2110: 003,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
-ECE,2120,7,ECE 2120: 007,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,timothy burg,
-ECE,2220,1,ECE 2220: 001,0.13,0.22,0.24,0.14,0.19,0.0,0.0,0.09,william reid,
-ECE,2230,1,ECE 2230: 001,0.25,0.14,0.25,0.11,0.04,0.0,0.0,0.21,harlan russell,
-ECE,2620,1,Elec Circuits II,0.24,0.29,0.29,0.11,0.05,0.0,0.0,0.01,richard groff,
-ECE,2620,2,Elec Circuits II (HON),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
-ECE,2720,1,Comp Organization,0.24,0.27,0.32,0.09,0.09,0.0,0.0,0.0,william reid,
-ECE,2730,1,Computer Org Lab,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,2730,2,Computer Org Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,2730,3,Computer Org Lab,0.5,0.25,0.13,0.0,0.06,0.0,0.0,0.06,timothy burg,
-ECE,2730,4,Computer Org Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,2730,5,Computer Org Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,3070,1,ECE 3070: 001,0.48,0.17,0.15,0.03,0.01,0.0,0.0,0.16,timothy burg,
-ECE,3070,2,ECE 3070: 002,0.39,0.27,0.14,0.05,0.01,0.0,0.0,0.15,timothy burg,
-ECE,3070,3,ECE 3070: 003,0.96,0.02,0.0,0.02,0.0,0.0,0.0,0.0,sung- kim,
-ECE,3090,1,ECE 3090: 001,0.79,0.05,0.0,0.0,0.0,0.0,0.0,0.16,timothy burg,
-ECE,3090,4,ECE 3090: 004,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
-ECE,3090,5,ECE 3090: 005,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
-ECE,3090,6,ECE 3090: 006,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
-ECE,3090,8,ECE 3090: 008,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,timothy burg,
-ECE,3090,9,ECE 3090: 009,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,3090,11,ECE 3090: 011,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
-ECE,3090,14,ECE 3090: 014,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,
-ECE,3110,1,ECE 3110: 001,0.73,0.07,0.07,0.0,0.0,0.0,0.0,0.13,timothy burg,
-ECE,3110,3,ECE 3110: 003,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,3120,3,ECE 3120: 003,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,timothy burg,
-ECE,3120,4,ECE 3120: 004,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,timothy burg,
-ECE,3170,1,Rand Signal Analysis,0.39,0.47,0.14,0.0,0.0,0.0,0.0,0.0,stephen hubbard,
-ECE,3170,2,Rand Signal Analysis (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,carl baum,True
-ECE,3200,1,Electronics I,0.44,0.37,0.1,0.07,0.0,0.0,0.0,0.01,stephen hubbard,
-ECE,3210,1,ECE 3210: 001,0.15,0.39,0.3,0.13,0.01,0.0,0.0,0.01,stephen hubbard,
-ECE,3220,1,Intro Operating Sys,0.39,0.43,0.11,0.0,0.04,0.0,0.0,0.04,mark smotherman,
-ECE,3270,1,ECE 3270: 001,0.1,0.36,0.19,0.07,0.17,0.0,0.0,0.12,melissa crawl smith,
-ECE,3300,1,Signals & Systems,0.23,0.16,0.26,0.2,0.08,0.0,0.0,0.07,carl baum,
-ECE,3520,1,Programming Systems,0.5,0.35,0.12,0.0,0.0,0.0,0.0,0.04,robert schalkoff,
-ECE,3600,1,ECE 3600: 001,0.35,0.21,0.26,0.09,0.09,0.0,0.0,0.0,ramtin hadidi,
-ECE,3710,1,ECE 3710: 001,0.29,0.38,0.21,0.06,0.06,0.0,0.0,0.0,william reid,
-ECE,3720,1,ECE 3720: 001,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,3720,2,ECE 3720: 002,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,3720,4,ECE 3720: 004,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,timothy burg,
-ECE,3800,1,ECE 3800: 001,0.14,0.41,0.25,0.08,0.12,0.0,0.0,0.0,anthony martin,
-ECE,3810,1,ECE 3810: 001,0.33,0.41,0.22,0.0,0.0,0.0,0.0,0.04,eric gordon johnson,
-ECE,4090,1,ECE 4090: 001,0.47,0.3,0.21,0.0,0.0,0.0,0.0,0.02,darren dawson,
-ECE,4170,1,ECE 4170: 001,0.29,0.41,0.0,0.06,0.0,0.0,0.0,0.24,darren dawson,
-ECE,4190,1,ECE 4190: 001,0.6,0.28,0.04,0.04,0.04,0.0,0.0,0.0,keith corzine,
-ECE,4200,1,ECE 4200: 001,0.29,0.18,0.38,0.06,0.03,0.0,0.0,0.06,elham makram,
-ECE,4270,1,ECE 4270: 001,0.2,0.29,0.29,0.23,0.0,0.0,0.0,0.0,carl baum,
-ECE,4380,1,ECE 4380: 001,0.31,0.31,0.31,0.0,0.0,0.0,0.0,0.06,harlan russell,
-ECE,4400,1,ECE 4400: 001,0.38,0.41,0.18,0.0,0.0,0.0,0.0,0.03,kuang-ching wang,
-ECE,4680,1,ECE 4680: 001,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,adam hoover,
-ECE,4700,1,ECE 4700: 001,0.4,0.38,0.09,0.11,0.0,0.0,0.0,0.02,todd hubing,
-ECE,4950,1,ECE 4950: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,4960,1,ECE 4960: 001,0.48,0.41,0.11,0.0,0.0,0.0,0.0,0.0,richard groff,
-ECE,6170,1,ECE 6170: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,darren dawson,
-ECE,6190,1,ECE 6190: 001,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,keith corzine,
-ECE,6200,1,ECE 6200: 001,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,elham makram,
-ECE,6380,1,ECE 6380: 001,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
-ECE,6400,1,ECE 6400: 001,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,
-ECE,6680,1,ECE 6680: 001,0.69,0.06,0.25,0.0,0.0,0.0,0.0,0.0,adam hoover,
-ECE,6930,2,CMOS Analog VLSI,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,
-ECE,8240,1,ECE 8240: 001,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,ramtin hadidi,
-ECE,8400,1,ECE 8400: 001,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,william harrell,
-ECE,8440,1,ECE 8440: 001,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,john gowdy,
-ECE,8480,1,ECE 8480: 001,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
-ECE,8720,1,ECE 8720: 001,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,robert schalkoff,
-ECE,8740,1,ECE 8740: 001,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,
-ECE,8930,1,Fiber Lasers,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,liang dong,
-ECE,9910,32,ECE 9910: 032,0.0,0.0,0.0,0.0,0.0,0.6,0.4,0.0,hai ying shen,
-ECON,2000,1,Economic Concepts,0.22,0.22,0.11,0.17,0.17,0.0,0.0,0.11,mallika garg,
-ECON,2000,2,Economic Concepts,0.14,0.16,0.43,0.05,0.03,0.0,0.0,0.19,mallika garg,
-ECON,2000,3,Economic Concepts,0.25,0.28,0.19,0.09,0.16,0.0,0.0,0.03,miren ivankovic,
-ECON,2110,1,Principles of Microeconomics,0.18,0.33,0.43,0.05,0.03,0.0,0.0,0.0,eric peter makela,
-ECON,2110,2,Principles of Microeconomics,0.13,0.55,0.18,0.0,0.13,0.0,0.0,0.0,ce castellon chicas,
-ECON,2110,3,Principles of Microeconomics,0.12,0.44,0.33,0.07,0.05,0.0,0.0,0.0,adam millsap,
-ECON,2110,4,Principles of Microeconomics,0.23,0.45,0.15,0.1,0.03,0.0,0.0,0.05,andew swanson,
-ECON,2110,5,Principles of Microeconomics,0.35,0.3,0.23,0.08,0.03,0.0,0.0,0.03,jacob burgdorf,
-ECON,2110,6,Principles of Microeconomics,0.26,0.26,0.23,0.21,0.02,0.0,0.0,0.02,timothy andr bersak,
-ECON,2110,7,Principles of Microeconomics,0.17,0.41,0.3,0.08,0.01,0.0,0.0,0.03,adam millsap,
-ECON,2110,8,Principles of Microeconomics,0.36,0.28,0.25,0.07,0.04,0.0,0.0,0.01,miren ivankovic,
-ECON,2110,10,Principles of Microeconomics,0.22,0.3,0.26,0.04,0.02,0.0,0.0,0.15,robert dew tollison,
-ECON,2110,11,Principles of Microeconomics,0.15,0.44,0.31,0.06,0.02,0.0,0.0,0.02,meng liu,
-ECON,2110,12,Principles of Microeconomics,0.16,0.37,0.18,0.05,0.08,0.0,0.0,0.16,john devin shippey,
-ECON,2110,13,Principles of Microecon(HON),0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,robert kennet fleck,True
-ECON,2120,1,Principles of Macro,0.16,0.37,0.37,0.0,0.11,0.0,0.0,0.0,scott baier,
-ECON,2120,2,Principles of Macro,0.06,0.44,0.5,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,3,Principles of Macro,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0,scott baier,
-ECON,2120,4,Principles of Macro,0.21,0.47,0.26,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,5,Principles of Macro,0.18,0.35,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,6,Principles of Macro,0.16,0.37,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,7,Principles of Macro,0.11,0.22,0.56,0.06,0.0,0.0,0.0,0.06,scott baier,
-ECON,2120,8,Principles of Macro,0.11,0.53,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,9,Principles of Macro,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,10,Principles of Macro,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,11,Principles of Macro,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,12,Principles of Macro,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,scott baier,
-ECON,2120,13,Principles of Macro,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,14,Principles of Macro,0.26,0.37,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,15,Principles of Macro,0.21,0.37,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,16,Principles of Macro,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,17,Principles of Macro,0.21,0.53,0.21,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,18,Principles of Macro,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,19,Principles of Macro,0.17,0.39,0.33,0.11,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,20,Principles of Macro,0.3,0.45,0.23,0.0,0.0,0.0,0.0,0.03,anne anders,
-ECON,2120,21,Principles of Macro,0.05,0.25,0.25,0.08,0.12,0.0,0.0,0.26,ralph charles allen,
-ECON,2120,22,Principles of Macro,0.1,0.45,0.25,0.1,0.08,0.0,0.0,0.03,anne anders,
-ECON,2120,23,Principles of Macro,0.35,0.4,0.18,0.0,0.05,0.0,0.0,0.03,yukun sun,
-ECON,2120,24,Principles of Macro,0.09,0.18,0.24,0.09,0.16,0.0,0.0,0.24,ralph charles allen,
-ECON,2120,25,Principles of Macro,0.25,0.55,0.1,0.1,0.0,0.0,0.0,0.0,lyudmyla ta sonchak,
-ECON,2120,26,Principles of Macro,0.26,0.6,0.12,0.02,0.0,0.0,0.0,0.0,yukun sun,
-ECON,3020,1,Money and Banking,0.2,0.4,0.15,0.1,0.13,0.0,0.0,0.03,danielle zanzalari,
-ECON,3060,1,Managerial Economics,0.22,0.36,0.25,0.06,0.03,0.0,0.0,0.08,john devin shippey,
-ECON,3100,1,International Econ,0.19,0.38,0.31,0.06,0.05,0.0,0.0,0.02,michal jerzmanowski,
-ECON,3140,1,Intermediate Micro,0.21,0.26,0.16,0.0,0.11,0.0,0.0,0.26,patrick warren,
-ECON,3140,2,Intermediate Micro,0.42,0.31,0.19,0.04,0.04,0.0,0.0,0.0,molly espey,
-ECON,3140,3,Intermediate Micro,0.11,0.43,0.29,0.07,0.07,0.0,0.0,0.04,tomas cvrcek,
-ECON,3150,1,Intermediate Macro,0.25,0.16,0.3,0.16,0.12,0.0,0.0,0.02,wesley harris,
-ECON,3150,2,Intermediate Macro,0.37,0.4,0.2,0.0,0.03,0.0,0.0,0.0,sergey vla mityakov,
-ECON,3440,1,Property Rights,0.17,0.43,0.22,0.09,0.04,0.0,0.0,0.04,dar litsukova-bokar,
-ECON,4020,1,Law and Economics,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,thomas wins hazlett,
-ECON,4050,1,Intro to Econometric,0.36,0.21,0.36,0.07,0.0,0.0,0.0,0.0,jaqueline oliveira,
-ECON,4050,2,Intro to Econometric,0.31,0.15,0.31,0.0,0.23,0.0,0.0,0.0,jaqueline oliveira,
-ECON,4050,3,Intro to Econometric,0.18,0.18,0.55,0.09,0.0,0.0,0.0,0.0,jaqueline oliveira,
-ECON,4050,4,Intro to Econometric,0.17,0.25,0.17,0.33,0.08,0.0,0.0,0.0,jaqueline oliveira,
-ECON,4110,1,Econ of Education,0.31,0.31,0.23,0.08,0.04,0.0,0.0,0.04,chungsang lam,
-ECON,4130,1,International Macro,0.17,0.44,0.17,0.17,0.06,0.0,0.0,0.0,michal jerzmanowski,
-ECON,4240,1,Organization of Ind,0.39,0.39,0.15,0.0,0.0,0.0,0.0,0.06,matthew lewis,
-ECON,4250,1,Antitrust Economics,0.44,0.36,0.17,0.0,0.0,0.0,0.0,0.03,robert dew tollison,
-ECON,4260,1,Sem Sport Economics,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,4270,1,Dev American Economy,0.27,0.53,0.17,0.03,0.0,0.0,0.0,0.0,howard ne bodenhorn,
-ECON,4350,1,Family Economics,0.06,0.45,0.27,0.09,0.06,0.0,0.0,0.06,tomas cvrcek,
-ECON,4400,1,Game Theory,0.25,0.5,0.08,0.0,0.04,0.0,0.0,0.13,daniel wood,
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.21,0.36,0.29,0.0,0.0,0.0,0.0,0.14,scott templeton,
-ECON,6130,1,ECON 6130: 001,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,
-ECON,8020,1,Adv Econ Concepts and Applic I,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,william dougan,
-ECON,8050,1,ECON 8050: 001,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,8070,1,ECON 8070: 001,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,thomas alvin mroz,
-ECON,8200,1,Public Finance,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william dougan,
-ECON,9010,1,Price Theory,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,daniel wood,
-ECON,9090,1,ECON 9090: 001,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,gerald dwyer,
-ECON,9170,1,Advanced Seminar Labor Econ,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
-ED,1050,1,ED 1050: 001,0.65,0.2,0.0,0.0,0.1,0.0,0.0,0.05,patrick womac,
-ED,1050,2,ED 1050: 002,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,patrick womac,
-ED,1050,3,ED 1050: 003,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,rory phil tannebaum,
-ED,1050,4,ED 1050: 004,0.8,0.08,0.0,0.0,0.08,0.0,0.0,0.04,rory phil tannebaum,
-ED,3220,1,ED 3220: 001,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,deborah smith,
-ED,8380,400,Physical Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard dallm white,
-ED,8380,537,Literacy Lessons Designed for,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,vicki steadman,
-ED,8390,505,ED 8390: 505,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0, paltrow zwerdling,
-ED,8600,400,ED 8600: 400,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,
-ED,9010,1,Research Design/ Infer. Stats,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,
-EDC,3900,10,EDC 3900: 010,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
-EDC,3900,12,EDC 3900: 012,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
-EDC,8060,1,EDC 8060: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
-EDC,8070,400,EDC 8070: 400,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,kristen leigh moran,
-EDC,8190,1,EDC 8190: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
-EDEC,2200,1,EDEC 2200: 001,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,ysaaca axelrod,
-EDEL,3100,1,EDEL 3100: 001,0.91,0.04,0.0,0.0,0.04,0.0,0.0,0.0,alison eliz leonard,
-EDEL,3100,2,EDEL 3100: 002,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,jacqueline sh rosen,
-EDEL,3210,1,EDEL 3210: 001,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4050,1,EDEL 4050: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
-EDEL,4510,1,Elem Methods in Science Tchg,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,cynthia chri deaton,
-EDEL,4520,2,EDEL 4520: 002,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,james kwame dogbey,
-EDEL,4670,1,EDEL 4670: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDEL,4870,1,EDEL 4870: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDF,3010,1,Principles of American Educat,0.2,0.36,0.32,0.0,0.0,0.0,0.0,0.12,robert green,
-EDF,3010,2,Principles of American Educat,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,robert green,
-EDF,3010,3,Principles of American Educat,0.54,0.35,0.08,0.03,0.0,0.0,0.0,0.0,suzanne rosenblith,
-EDF,3020,1,Educ Psych,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,
-EDF,3020,2,Educ Psych,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,deborah switzer,
-EDF,3020,3,Educ Psych,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,
-EDF,3020,5,Educ Psych,0.4,0.3,0.23,0.03,0.03,0.0,0.0,0.0,penelope mar vargas,
-EDF,3150,1,Technology Skills for Learning,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,ryan visser,
-EDF,3150,2,Technology Skills for Learning,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,3340,1,Child Growth and Dev,0.69,0.21,0.07,0.0,0.0,0.0,0.0,0.03,winston holton,
-EDF,3340,2,Child Growth and Dev,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
-EDF,3350,1,Adol Growth & Dev,0.31,0.52,0.17,0.0,0.0,0.0,0.0,0.0,david barrett,
-EDF,3350,2,Adol Growth & Dev,0.67,0.23,0.1,0.0,0.0,0.0,0.0,0.0,david barrett,
-EDF,4250,1,EDF 4250: 001,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,2,Digital Media & Learning,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,david matthew boyer,
-EDF,8800,400,EDF 8800: 400,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,9050,1,EDF 9050: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,danielle chri herro,
-EDL,7150,1,EDL 7150: 001,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,hans william klar,
-EDL,7350,500,EDL 7350: 500,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,
-EDL,7400,500,EDL 7400: 500,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,frederick buskey,
-EDL,8850,400,Selected Topics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,leslie gonzales,
-EDL,9100,400,Intro Phd Seminar,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,jane lindle,
-EDLT,4580,1,EDLT 4580: 001,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4600,1,Teaching Reading Grades 2-6,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
-EDLT,4620,1,EDLT 4620: 001,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4630,1,EDLT 4630: 001,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,ysaaca axelrod,
-EDLT,8670,400,EDLT 8670: 400,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8670,401,EDLT 8670: 401,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,phillip mich wilder,
-EDLT,8740,501,EDLT 8740: 501,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDSC,4370,1,EDSC 4370: 001,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,robert horton,
-EDSC,8920,400,EDSC 8920: 400,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeff marshall,
-EDSP,3700,1,Intro to Special Ed,0.76,0.15,0.06,0.0,0.03,0.0,0.0,0.0,joseph benedic ryan,
-EDSP,3700,2,Intro to Special Ed,0.78,0.05,0.1,0.03,0.05,0.0,0.0,0.0,joseph benedic ryan,
-EDSP,3700,3,Intro to Special Ed,0.78,0.12,0.07,0.0,0.02,0.0,0.0,0.0,robin parks ennis,
-EDSP,3730,1,EDSP 3730: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
-EDSP,3750,1,EDSP 3750: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
-EDSP,4910,1,EDSP 4910: 001,0.67,0.29,0.0,0.0,0.04,0.0,0.0,0.0,antonis katsiyannis,
-EDSP,4950,1,EDSP 4950: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,martha hodge,
-EDSP,4980,1,EDSP 4980: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,beverly lu romansky,
-EES,2020,1,EES 2020: 001,0.49,0.44,0.02,0.0,0.02,0.0,0.0,0.02,kevin thom finneran,
-EES,4010,1,EES 4010: 001,0.41,0.49,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-EES,4010,2,EES 4010: 002,0.15,0.58,0.23,0.02,0.0,0.0,0.0,0.02,john coates,
-EES,4020,1,EES 4020: 001,0.41,0.41,0.09,0.0,0.05,0.0,0.0,0.05,david allen ladner,
-EES,4750,1,EES 4750: 001,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,4840,1,Solid Waste Mgt,0.29,0.55,0.1,0.03,0.03,0.0,0.0,0.0,thomas overcamp,
-EES,4850,1,EES 4850: 001,0.3,0.59,0.08,0.03,0.0,0.0,0.0,0.0,mark schlautman,
-EES,6110,1,EES 6110: 001,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,timothy devol,
-EES,6850,1,EES 6850: 001,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mark schlautman,
-EES,8030,1,EES 8030: 001,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,tanju karanfil,
-EES,8040,1,EES 8040: 001,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,
-EES,8050,1,EES 8050: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tanju karanfil,
-EES,8120,1,EES 8120: 001,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,lin shuller-nickles,
-EES,8200,1,EES 8200: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,annick anctil,
-EES,8450,1,EES 8450: 001,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,cindy lee,
-EES,8830,2,Advanced Topics in Health Phys,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,timothy devol,
-ELE,3010,1,Intro to Entre,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-ELE,3010,2,Intro to Entre,0.56,0.38,0.05,0.0,0.0,0.0,0.0,0.0,anthony pa santella,
-ELE,4010,1,Exec Lead & Entr II,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,anthony pa santella,
-ENGL,1030,1,Accelerated Composition,0.47,0.37,0.05,0.11,0.0,0.0,0.0,0.0,leslie ann salley,
-ENGL,1030,3,Accelerated Composition,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,megan leigh roberts,
-ENGL,1030,4,Accelerated Composition,0.58,0.32,0.0,0.0,0.0,0.0,0.0,0.11,stephanie pai beard,
-ENGL,1030,5,Accelerated Composition,0.21,0.37,0.26,0.05,0.11,0.0,0.0,0.0,jacqueline fetzer,
-ENGL,1030,6,Accelerated Composition,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,kristen gay,
-ENGL,1030,7,Accelerated Composition,0.5,0.25,0.15,0.0,0.05,0.0,0.0,0.05,leslie ann salley,
-ENGL,1030,9,Accelerated Composition,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,jacqueline fetzer,
-ENGL,1030,10,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,stephanie pai beard,
-ENGL,1030,11,Accelerated Composition,0.5,0.4,0.05,0.0,0.05,0.0,0.0,0.0,leslie ann salley,
-ENGL,1030,12,Accelerated Composition,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,david stubblefield,
-ENGL,1030,14,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,dustin kyle pearson,
-ENGL,1030,15,Accelerated Composition,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,leslie ann salley,
-ENGL,1030,16,Accelerated Composition,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,david stubblefield,
-ENGL,1030,17,Accelerated Composition,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,dustin kyle pearson,
-ENGL,1030,18,Accelerated Composition,0.45,0.3,0.1,0.0,0.1,0.0,0.0,0.05,adrian carson,
-ENGL,1030,19,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathryn eliz harner,
-ENGL,1030,21,Accelerated Composition,0.58,0.26,0.05,0.0,0.0,0.0,0.0,0.11,caleb andr milligan,
-ENGL,1030,24,Accelerated Composition,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,laura ann smith,
-ENGL,1030,25,Accelerated Composition,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,hilary richards,
-ENGL,1030,26,Accelerated Composition,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,catherine mar blass,
-ENGL,1030,28,Accelerated Composition,0.74,0.16,0.0,0.05,0.0,0.0,0.0,0.05,kathryn eliz harner,
-ENGL,1030,29,Accelerated Composition,0.37,0.42,0.16,0.0,0.05,0.0,0.0,0.0,caleb andr milligan,
-ENGL,1030,32,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,laura ann smith,
-ENGL,1030,33,Accelerated Composition,0.84,0.05,0.05,0.05,0.0,0.0,0.0,0.0,hilary richards,
-ENGL,1030,35,Accelerated Composition,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,kiera angeli prince,
-ENGL,1030,36,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katherine elrick,
-ENGL,1030,37,Accelerated Composition,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,shawn andrew stowe,
-ENGL,1030,38,Accelerated Composition,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,katherine hanzalik,
-ENGL,1030,39,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
-ENGL,1030,40,Accelerated Composition,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,joshua lee martin,
-ENGL,1030,41,Accelerated Composition,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,
-ENGL,1030,42,Accelerated Composition,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,katherine elrick,
-ENGL,1030,44,Accelerated Composition,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,katherine hanzalik,
-ENGL,1030,46,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
-ENGL,1030,48,Accelerated Composition,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,joshua lee martin,
-ENGL,1030,51,Accelerated Composition,0.85,0.0,0.05,0.0,0.05,0.0,0.0,0.05,mari elena ramler,
-ENGL,1030,52,Accelerated Composition,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,kiera angeli prince,
-ENGL,1030,53,Accelerated Composition,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,justyna ann pekalak,
-ENGL,1030,54,Accelerated Composition,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,eric thomas hall,
-ENGL,1030,57,Accelerated Composition,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,kristen gay,
-ENGL,1030,58,Accelerated Composition,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,samuel jacks fuller,
-ENGL,1030,59,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,alyssa chris carver,
-ENGL,1030,60,Accelerated Composition,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,justyna ann pekalak,
-ENGL,2120,1,World Literature,0.52,0.3,0.15,0.04,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,2120,2,World Literature (MAJORS ONLY),0.71,0.12,0.12,0.0,0.0,0.0,0.0,0.06,lucian ghita,
-ENGL,2120,3,World Literature,0.36,0.43,0.11,0.04,0.07,0.0,0.0,0.0,andrew mathas,
-ENGL,2120,4,World Literature,0.71,0.18,0.0,0.04,0.04,0.0,0.0,0.04,april susanne pelt,
-ENGL,2120,5,World Literature,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,2120,7,World Literature (MAJORS ONLY),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,2120,8,World Literature,0.56,0.19,0.19,0.0,0.04,0.0,0.0,0.04,andrew mathas,
-ENGL,2120,9,World Literature,0.41,0.34,0.07,0.03,0.1,0.0,0.0,0.03,andrew mathas,
-ENGL,2120,12,World Literature,0.5,0.21,0.11,0.04,0.11,0.0,0.0,0.04,john conway,
-ENGL,2120,13,World Literature,0.23,0.46,0.19,0.08,0.0,0.0,0.0,0.04,david charles foltz,
-ENGL,2120,14,World Literature,0.08,0.5,0.31,0.0,0.04,0.0,0.0,0.08,david charles foltz,
-ENGL,2120,15,World Literature,0.44,0.15,0.26,0.04,0.11,0.0,0.0,0.0,john conway,
-ENGL,2120,16,World Literature,0.57,0.25,0.07,0.0,0.0,0.0,0.0,0.11,lucian ghita,
-ENGL,2130,1,British Literature,0.21,0.29,0.17,0.13,0.08,0.0,0.0,0.13,karen kettnich,
-ENGL,2130,2,British Literature,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,karen kettnich,
-ENGL,2130,3,British Literature,0.54,0.29,0.04,0.04,0.07,0.0,0.0,0.04,april susanne pelt,
-ENGL,2130,4,British Literature,0.67,0.15,0.04,0.04,0.0,0.0,0.0,0.11,april susanne pelt,
-ENGL,2130,5,British Literature,0.5,0.32,0.0,0.07,0.04,0.0,0.0,0.07,john conway,
-ENGL,2130,6,British Literature,0.48,0.3,0.15,0.0,0.0,0.0,0.0,0.07,lucian ghita,
-ENGL,2130,7,British Literature,0.5,0.36,0.07,0.04,0.0,0.0,0.0,0.04,lucian ghita,
-ENGL,2130,8,British Literature,0.5,0.25,0.11,0.04,0.04,0.0,0.0,0.07,april susanne pelt,
-ENGL,2130,9,British Literature,0.14,0.43,0.25,0.11,0.07,0.0,0.0,0.0,david charles foltz,
-ENGL,2130,10,British Literature,0.41,0.33,0.07,0.0,0.11,0.0,0.0,0.07,john conway,
-ENGL,2130,11,British Literature,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
-ENGL,2130,12,British Literature,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,sherri teres allred,
-ENGL,2130,13,British Literature,0.19,0.33,0.26,0.07,0.04,0.0,0.0,0.11,david charles foltz,
-ENGL,2140,1,American Literature,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,joshua nei waggoner,
-ENGL,2140,2,American Literature,0.71,0.14,0.04,0.04,0.0,0.0,0.0,0.07,sharon kathl nalley,
-ENGL,2140,3,American Literature,0.29,0.39,0.11,0.11,0.0,0.0,0.0,0.11,sharon kathl nalley,
-ENGL,2140,4,American Literature,0.26,0.37,0.3,0.04,0.04,0.0,0.0,0.0,william stanton,
-ENGL,2140,5,American Literature,0.59,0.19,0.07,0.04,0.07,0.0,0.0,0.04,william stanton,
-ENGL,2140,6,American Literature,0.32,0.57,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2140,7,American Literature,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2140,8,American Literature,0.32,0.43,0.18,0.0,0.0,0.0,0.0,0.07,joshua nei waggoner,
-ENGL,2140,9,American Literature,0.41,0.56,0.0,0.0,0.0,0.0,0.0,0.04,joshua nei waggoner,
-ENGL,2140,11,American Literature,0.13,0.38,0.13,0.13,0.08,0.0,0.0,0.17,jonathan beec field,
-ENGL,2140,12,American Literature,0.2,0.28,0.16,0.04,0.12,0.0,0.0,0.2,jonathan beec field,
-ENGL,2140,13,American Literature,0.25,0.29,0.29,0.04,0.0,0.0,0.0,0.13,jonathan beec field,
-ENGL,2140,14,American Literature,0.63,0.21,0.04,0.0,0.0,0.0,0.0,0.13,jonathan beec field,
-ENGL,2140,15,American Literature,0.38,0.5,0.04,0.0,0.04,0.0,0.0,0.04,jonathan beec field,
-ENGL,2140,16,American Literature,0.09,0.48,0.3,0.0,0.09,0.0,0.0,0.04,jonathan beec field,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.54,0.36,0.04,0.0,0.04,0.0,0.0,0.04,michael richa lucas,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,michael richa lucas,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.14,0.79,0.04,0.0,0.0,0.0,0.0,0.04,amy monaghan,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.29,0.5,0.07,0.04,0.04,0.0,0.0,0.07,william pulley,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.15,0.73,0.08,0.04,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.26,0.52,0.22,0.0,0.0,0.0,0.0,0.0,matthew schilleman,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.0,lauren woolbright,
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,lauren woolbright,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.55,0.28,0.1,0.07,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.39,0.46,0.07,0.04,0.0,0.0,0.0,0.04,john morgenstern,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.36,0.43,0.14,0.04,0.0,0.0,0.0,0.04,sarah lauro,
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.46,0.39,0.14,0.0,0.0,0.0,0.0,0.0,sarah lauro,
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.59,0.24,0.14,0.0,0.0,0.0,0.0,0.03,john morgenstern,
-ENGL,3000,1,ENGL 3000: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
-ENGL,3040,2,ENGL 3040: 002,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,3040,3,ENGL 3040: 003,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,3040,4,ENGL 3040: 004,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,sean williams,
-ENGL,3040,5,ENGL 3040: 005,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,3040,13,ENGL 3040: 013,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexander kudera,
-ENGL,3100,1,ENGL 3100: 001,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,walter edgar hunter,
-ENGL,3100,2,ENGL 3100: 002,0.11,0.37,0.26,0.16,0.0,0.0,0.0,0.11,william stockton,
-ENGL,3100,4,ENGL 3100: 004,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,cameron fa bushnell,
-ENGL,3120,1,ENGL 3120: 001,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3120,2,ENGL 3120: 002,0.37,0.37,0.11,0.0,0.05,0.0,0.0,0.11,elizabeth stansell,
-ENGL,3140,1,Technical Writing,0.17,0.56,0.06,0.0,0.11,0.0,0.0,0.11,william pulley,
-ENGL,3140,2,Technical Writing,0.58,0.32,0.0,0.0,0.0,0.0,0.0,0.11,christopher benson,
-ENGL,3140,3,Technical Writing,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,william pulley,
-ENGL,3140,4,Technical Writing,0.42,0.37,0.11,0.0,0.05,0.0,0.0,0.05,william pulley,
-ENGL,3140,5,Technical Writing,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,7,Technical Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,8,Technical Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,9,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,
-ENGL,3140,10,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nancy swanson,
-ENGL,3140,11,Technical Writing,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,nancy swanson,
-ENGL,3140,13,Technical Writing,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,nancy swanson,
-ENGL,3140,14,Technical Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,nancy swanson,
-ENGL,3140,16,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,
-ENGL,3140,17,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,
-ENGL,3140,18,Technical Writing,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,david stubblefield,
-ENGL,3140,19,Technical Writing,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,20,Technical Writing,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,140,Technical Writing,0.5,0.3,0.0,0.0,0.0,0.0,0.0,0.2,sarah mae cooper,
-ENGL,3150,1,ENGL 3150: 001,0.0,0.63,0.37,0.0,0.0,0.0,0.0,0.0,barbara ramirez,
-ENGL,3150,2,ENGL 3150: 002,0.06,0.61,0.28,0.0,0.0,0.0,0.0,0.06,barbara ramirez,
-ENGL,3150,6,ENGL 3150: 006,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sharon kay henry,
-ENGL,3150,7,ENGL 3150: 007,0.7,0.15,0.05,0.0,0.0,0.0,0.0,0.1,philip randall,
-ENGL,3150,18,ENGL 3150: 018,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,
-ENGL,3150,400,ENGL 3150: 400,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,401,ENGL 3150: 401,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,philip randall,
-ENGL,3450,1,ENGL 3450: 001,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,john logan pursley,
-ENGL,3460,1,ENGL 3460: 001,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,angelina oberdan,
-ENGL,3480,1,ENGL 3480: 001,0.67,0.11,0.17,0.0,0.06,0.0,0.0,0.0,joshua nei waggoner,
-ENGL,3570,1,Film,0.36,0.5,0.05,0.05,0.0,0.0,0.0,0.05,sarah lauro,
-ENGL,3800,1,ENGL 3800: 001,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,angela naimou,
-ENGL,3850,1,ENGL 3850: 001,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,3860,1,ENGL 3860: 001,0.57,0.14,0.19,0.0,0.05,0.0,0.0,0.05,megan no macalystre,
-ENGL,3960,1,ENGL 3960: 001,0.32,0.23,0.23,0.05,0.14,0.0,0.0,0.05,william stockton,
-ENGL,3970,1,ENGL 3970: 001,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
-ENGL,3980,1,ENGL 3980: 001,0.23,0.45,0.18,0.05,0.09,0.0,0.0,0.0,rhondda robi thomas,
-ENGL,3990,1,ENGL 3990: 001,0.36,0.27,0.27,0.0,0.05,0.0,0.0,0.05,matthew schilleman,
-ENGL,3990,2,ENGL 3990: 002,0.23,0.59,0.14,0.0,0.05,0.0,0.0,0.0,matthew schilleman,
-ENGL,4080,1,ENGL 4080: 001,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,susan hilligoss,
-ENGL,4100,1,ENGL 4100: 001,0.31,0.31,0.19,0.06,0.13,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4110,1,ENGL 4110: 001,0.62,0.24,0.05,0.0,0.05,0.0,0.0,0.05,susan hilligoss,
-ENGL,4110,2,ENGL 4110: 002,0.33,0.38,0.1,0.05,0.14,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4260,1,ENGL 4260: 001,0.5,0.28,0.17,0.0,0.06,0.0,0.0,0.0,jillian weise,
-ENGL,4300,1,Dramatic Literature II,0.68,0.16,0.11,0.0,0.05,0.0,0.0,0.0,richard st. peter,
-ENGL,4400,1,ENGL 4400: 001,0.29,0.48,0.19,0.0,0.05,0.0,0.0,0.0,brian mcgrath,
-ENGL,4400,2,ENGL 4400: 002,0.41,0.41,0.06,0.0,0.06,0.0,0.0,0.06,dominic mastroianni,
-ENGL,4410,1,Literary Editing,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,gabriel and hankins,True
-ENGL,4430,1,ENGL 4430: 001,0.59,0.24,0.12,0.0,0.0,0.06,0.0,0.0,walter edgar hunter,
-ENGL,4450,1,ENGL 4450: 001,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,keith morris,
-ENGL,4600,1,ENGL 4600: 001,0.41,0.41,0.0,0.06,0.06,0.0,0.0,0.06,tharon howard,
-ENGL,4640,1,ENGL 4640: 001,0.4,0.27,0.13,0.07,0.13,0.0,0.0,0.0,dominic mastroianni,
-ENGL,4650,1,ENGL 4650: 001,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,angela naimou,
-ENGL,4830,1,ENGL 4830: 001,0.23,0.54,0.0,0.0,0.15,0.0,0.0,0.08,rhondda robi thomas,
-ENGL,4890,1,ENGL 4890: 001,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,sean williams,
-ENGL,4920,1,Modern Rhetoric,0.29,0.29,0.36,0.0,0.07,0.0,0.0,0.0,brian mcgrath,
-ENGL,4950,1,ENGL 4950: 001,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,sean morey,
-ENGL,4960,2,ENGL 4960: 002,0.36,0.36,0.07,0.07,0.07,0.0,0.0,0.07,agnieszka skrodzka,
-ENGL,4960,3,ENGL 4960: 003,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,
-ENGL,8310,1,Special Topics,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
-ENGR,1020,14,Engineering Discipl & Skills,0.09,0.3,0.32,0.09,0.07,0.0,0.0,0.14,steven brandon,
-ENGR,1410,12,Programming & Problem Solving,0.11,0.39,0.28,0.16,0.02,0.0,0.0,0.05,steven brandon,
-ENGR,1410,13,Programming & Problem Solving,0.41,0.32,0.17,0.05,0.0,0.0,0.0,0.05,elizabeth stephan,
-ENGR,1410,17,Programming & Problem Solving,0.14,0.48,0.24,0.06,0.07,0.0,0.0,0.01,david ewing,
-ENGR,1410,18,Programming & Problem Solving,0.12,0.41,0.36,0.09,0.02,0.0,0.0,0.0,william martin,
-ENGR,1410,19,Programming & Problem Solving,0.12,0.29,0.39,0.1,0.03,0.0,0.0,0.07,david ewing,
-ENGR,1410,20,Programming & Problem Solving,0.18,0.42,0.3,0.06,0.03,0.0,0.0,0.01,christopher norfolk,
-ENGR,1410,22,Programming & Problem Solving,0.23,0.39,0.23,0.11,0.02,0.0,0.0,0.04,christopher norfolk,
-ENGR,1410,25,Programming & Problem Solving,0.15,0.42,0.2,0.13,0.07,0.0,0.0,0.04,william park,
-ENGR,1410,27,Programming & Problem Solving,0.05,0.21,0.43,0.12,0.09,0.0,0.0,0.1,william park,
-ENGR,1410,50,Programming & Problem Solving,0.33,0.45,0.19,0.0,0.02,0.0,0.0,0.0,john minor,
-ENGR,1410,52,Prog. & Problem Solving (HON),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
-ENGR,1410,56,Programming & Problem Solving,0.21,0.45,0.29,0.02,0.02,0.0,0.0,0.0,sabrina lau,
-ENGR,1410,58,Programming & Problem Solving,0.12,0.54,0.29,0.05,0.0,0.0,0.0,0.0,david ewing,
-ENGR,1410,60,Prog & Problem Solving (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
-ENGR,1410,64,Programming & Problem Solving,0.22,0.39,0.34,0.0,0.05,0.0,0.0,0.0,david ewing,
-ENGR,1410,66,Programming & Problem Solving,0.12,0.44,0.32,0.12,0.0,0.0,0.0,0.0,david ewing,
-ENGR,2080,11,Engr Graphics & Machine Design,0.57,0.15,0.21,0.01,0.01,0.0,0.0,0.04,sabrina lau,
-ENGR,2080,15,Engr Graphics & Machine Design,0.61,0.28,0.07,0.0,0.03,0.0,0.0,0.01,john minor,
-ENGR,2080,21,Engr Graphics & Machine Design,0.49,0.35,0.09,0.0,0.03,0.0,0.0,0.04,sarah grigg,
-ENGR,2080,23,Engr Graphics & Machine Design,0.46,0.29,0.11,0.04,0.03,0.0,0.0,0.07,sarah grigg,
-ENGR,2080,31,Engr Graphics & Machine Design,0.7,0.16,0.1,0.01,0.01,0.0,0.0,0.01,sabrina lau,
-ENGR,2080,39,Engr Graphics & Machine Design,0.61,0.3,0.04,0.01,0.0,0.0,0.0,0.03,sarah grigg,
-ENGR,2080,54,Engr Graphics & Machine Design,0.67,0.21,0.1,0.02,0.0,0.0,0.0,0.0,john minor,
-ENGR,2100,32,CAD & Engineering Apllications,0.63,0.15,0.05,0.05,0.05,0.0,0.0,0.07,william martin,
-ENGR,2100,38,CAD & Engineering Aplications,0.53,0.14,0.14,0.0,0.07,0.0,0.0,0.12,william martin,
-ENGR,2100,40,CAD & Engineering Apllications,0.76,0.09,0.09,0.0,0.0,0.0,0.0,0.07,nighat yasmin,
-ENR,3020,1,ENR 3020: 001,0.38,0.46,0.1,0.05,0.0,0.0,0.0,0.0,lawrence gering,
-ENR,4500,1,ENR 4500: 001,0.79,0.05,0.11,0.0,0.03,0.0,0.0,0.03,alan johnson,
-ENR,4500,2,ENR 4500: 002,0.71,0.21,0.04,0.04,0.0,0.0,0.0,0.0,alan johnson,
-ENSP,2000,1,Intro Environ Sci,0.47,0.35,0.1,0.02,0.0,0.0,0.0,0.06,scott brame,
-ENSP,2000,2,Intro Environ Sci,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-ENSP,2000,3,Intro Environ Sci,0.24,0.64,0.1,0.0,0.0,0.0,0.0,0.02,john coates,
-ENT,2000,1,Six-Legged Science,0.39,0.42,0.06,0.06,0.0,0.0,0.0,0.06,patricia zungoli,
-ENT,8100,1,Forensic Entomology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,peter adler,
-ESED,8200,1,ESED 8200: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,
-ETOX,8300,1,Mechanistic Toxicology,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,
-FCS,8920,1,Research Methods II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,
-FCS,8920,13,Program Evaluation,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mark small,
-FDSC,1020,1,FDSC 1020: 001,0.58,0.37,0.01,0.01,0.0,0.0,0.0,0.03,john mcgregor,
-FDSC,2140,1,Fd Resources & Soc,0.61,0.27,0.08,0.01,0.0,0.0,0.0,0.04,paul dawson,
-FDSC,4020,1,Food Chem II,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4030,1,Food Ch & Analysis,0.82,0.15,0.0,0.0,0.0,0.0,0.0,0.03,paul dawson,
-FDSC,4080,1,FDSC 4080: 001,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,felix barron,
-FDSC,4090,1,TQM for Food & Pckg Industries,0.6,0.35,0.06,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-FIN,3050,1,Investment Analysis,0.11,0.41,0.35,0.11,0.03,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.26,0.36,0.28,0.08,0.03,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.23,0.3,0.35,0.05,0.03,0.03,0.0,0.03,kerri mcmillan,
-FIN,3060,1,Corporation Finance,0.17,0.17,0.23,0.17,0.15,0.0,0.0,0.1,william hol johnson,
-FIN,3060,2,Corporation Finance,0.17,0.29,0.13,0.19,0.17,0.0,0.0,0.04,william hol johnson,
-FIN,3060,3,Corporation Finance,0.24,0.4,0.24,0.1,0.0,0.0,0.0,0.02,neil waller,
-FIN,3060,4,Corporation Finance,0.1,0.34,0.36,0.12,0.0,0.0,0.0,0.08,john harris,
-FIN,3060,5,Corporation Finance,0.18,0.45,0.2,0.02,0.0,0.0,0.0,0.16,john harris,
-FIN,3060,6,Corporation Finance,0.25,0.43,0.25,0.04,0.02,0.02,0.0,0.0,neil waller,
-FIN,3060,7,Corporation Finance,0.12,0.5,0.27,0.08,0.04,0.0,0.0,0.0,neil waller,
-FIN,3070,1,Prin of Real Estate,0.15,0.23,0.35,0.12,0.12,0.0,0.0,0.02,ramon tolb franklin,
-FIN,3070,2,Prin of Real Estate,0.3,0.3,0.26,0.11,0.02,0.0,0.0,0.02,thomas springer,
-FIN,3080,1,Fin Inst & Mkts,0.08,0.53,0.26,0.03,0.03,0.0,0.0,0.08,lyudmila chernykh,
-FIN,3080,2,Fin Inst & Mkts,0.18,0.33,0.33,0.05,0.08,0.0,0.0,0.03,michael spivey,
-FIN,3080,3,Fin Inst & Mkts,0.23,0.28,0.28,0.05,0.03,0.0,0.0,0.13,michael spivey,
-FIN,3110,1,Financial Management I,0.09,0.2,0.45,0.14,0.05,0.0,0.0,0.07,ramon tolb franklin,
-FIN,3110,2,Financial Management I,0.14,0.23,0.35,0.05,0.07,0.0,0.0,0.16,george bra lockhart,
-FIN,3110,3,Financial Management I,0.27,0.27,0.31,0.02,0.0,0.0,0.0,0.13,george bra lockhart,
-FIN,3110,4,Financial Management I,0.12,0.36,0.29,0.14,0.05,0.0,0.0,0.05,george bra lockhart,
-FIN,3120,1,Financial Mgt II,0.16,0.65,0.13,0.03,0.03,0.0,0.0,0.0,lyudmila chernykh,
-FIN,3120,2,Financial Mgt II,0.58,0.24,0.12,0.03,0.0,0.0,0.0,0.03,melvin stith,
-FIN,3120,3,Financial Mgt II,0.53,0.31,0.03,0.06,0.08,0.0,0.0,0.0,melvin stith,
-FIN,3120,4,Financial Mgt II,0.5,0.31,0.13,0.0,0.06,0.0,0.0,0.0,melvin stith,
-FIN,4040,1,Financial Modeling,0.11,0.26,0.41,0.11,0.11,0.0,0.0,0.0,jack wolf,
-FIN,4040,2,Financial Modeling,0.13,0.47,0.28,0.09,0.03,0.0,0.0,0.0,jack wolf,
-FIN,4040,3,Financial Modeling,0.13,0.47,0.2,0.1,0.03,0.0,0.0,0.07,jack wolf,
-FIN,4050,1,Port Mgt and Theory,0.24,0.24,0.24,0.24,0.0,0.0,0.0,0.04,john alexander,
-FIN,4050,2,Port Mgt and Theory,0.14,0.14,0.29,0.14,0.1,0.0,0.0,0.19,john alexander,
-FIN,4080,1,Mgt of Fin Inst,0.07,0.44,0.42,0.02,0.04,0.0,0.0,0.0,michael spivey,
-FIN,4110,1,Int Fin Mgt,0.26,0.28,0.36,0.08,0.03,0.0,0.0,0.0,john harris,
-FIN,4110,2,Int Fin Mgt,0.26,0.41,0.23,0.08,0.0,0.0,0.0,0.03,john harris,
-FIN,4150,1,Real Estate Investmt,0.19,0.24,0.29,0.24,0.0,0.05,0.0,0.0,thomas springer,
-FIN,4160,1,Real Estate Val,0.0,0.32,0.55,0.14,0.0,0.0,0.0,0.0,neil waller,
-FNR,1020,1,FNR 1020: 001,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,elena mikhailova,
-FNR,4990,1,FNR 4990: 001,0.72,0.11,0.06,0.06,0.06,0.0,0.0,0.0,donald hagan,
-FNR,4990,3,FNR 4990: 003,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,donald hagan,
-FOR,2060,1,FOR 2060: 001,0.38,0.34,0.19,0.07,0.0,0.0,0.0,0.02,donald hagan,
-FOR,3080,1,FOR 3080: 001,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,lawrence gering,
-FOR,4060,1,FOR 4060: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william roc english,
-FOR,4080,1,FOR 4080: 001,0.54,0.36,0.11,0.0,0.0,0.0,0.0,0.0,patricia layton,
-FOR,4150,1,FOR 4150: 001,0.23,0.59,0.18,0.0,0.0,0.0,0.0,0.0,james davis,
-FOR,4180,1,FOR 4180: 001,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4340,1,GIS for Landscape Planning,0.19,0.64,0.14,0.0,0.0,0.0,0.0,0.03,robert frit baldwin,
-FOR,4650,1,FOR 4650: 001,0.42,0.33,0.25,0.0,0.0,0.0,0.0,0.0,gaofeng wang,
-FOR,6340,1,GIS for Landscape Planning,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robert frit baldwin,
-FR,1010,1,FR 1010: 001,0.64,0.23,0.09,0.0,0.0,0.0,0.0,0.05,julian hamil killey,
-FR,1020,1,FR 1020: 001,0.38,0.38,0.0,0.19,0.0,0.0,0.0,0.06,julian hamil killey,
-FR,1020,2,FR 1020: 002,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,julian hamil killey,
-FR,1020,3,FR 1020: 003,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,1,Intermediate French,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,amy lyn grif sawyer,
-FR,2010,2,Intermediate French,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,3,Intermediate French,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,julian hamil killey,
-FR,2020,1,Intermediate French,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2020,4,Intermediate French,0.14,0.5,0.21,0.0,0.07,0.0,0.0,0.07,kenneth dav widgren,
-FR,2020,5,Intermediate French,0.53,0.35,0.06,0.0,0.0,0.0,0.0,0.06,joseph mai,
-FR,3000,1,Survey of French Lit,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,karyna szmurlo,
-FR,3050,1,FR 3050: 001,0.41,0.24,0.12,0.0,0.06,0.0,0.0,0.18,kenneth dav widgren,
-FR,3170,1,FR 3170: 001,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,joseph mai,
-FR,4200,1,FR 4200: 001,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,karyna szmurlo,
-GC,1010,1,GC 1010: 001,0.57,0.34,0.02,0.0,0.0,0.0,0.0,0.07,kern cox,
-GC,1020,1,GC 1020: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,charles tabor weiss,
-GC,1020,2,GC 1020: 002,0.35,0.48,0.04,0.0,0.04,0.0,0.0,0.09,carol jones,
-GC,1030,1,GC 1030: 001,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,john jacobs,
-GC,1030,2,GC 1030: 002,0.67,0.13,0.07,0.07,0.07,0.0,0.0,0.0,john jacobs,
-GC,1040,1,Graphic Com I,0.49,0.41,0.06,0.0,0.01,0.0,0.0,0.02,rebecca suza edlein,
-GC,1990,4,CI in GC I-J Lay CS,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,janice ann lay,
-GC,2070,1,Graphic Com II,0.54,0.37,0.09,0.0,0.0,0.0,0.0,0.0,patrick gee rose,
-GC,3400,1,Digital Img & Emedia,0.33,0.46,0.17,0.0,0.04,0.0,0.0,0.0,erica black walker,
-GC,4060,1,Pkg & Spec Prtg,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kern cox,
-GC,4400,1,Commercial Printing,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,
-GC,4440,1,Current Dev in G C,0.29,0.57,0.07,0.07,0.0,0.0,0.0,0.0,liam henry 'hara,
-GC,4460,1,Ink & Substrates,0.27,0.59,0.14,0.0,0.0,0.0,0.0,0.0,liam henry 'hara,
-GC,4480,1,Plan and Cont Print,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john leininger,
-GC,4900,2,G C Selected Topics-Sales,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,
-GEN,3000,1,GEN 3000: 001,0.3,0.37,0.21,0.06,0.02,0.0,0.0,0.05,kate leanne wi tsai,
-GEN,3000,2,GEN 3000: 002,0.36,0.3,0.17,0.11,0.01,0.0,0.0,0.06,kate leanne wi tsai,
-GEN,4100,1,Population & Quant Genetics,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
-GEN,4110,2,GEN 4110: 002,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
-GEN,6100,1,Population & Quant Genetics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
-GEOG,1010,1,Intro to Geography,0.37,0.45,0.13,0.0,0.03,0.0,0.0,0.03,christa smith,
-GEOG,1030,1,World Regional Geog,0.82,0.11,0.04,0.02,0.0,0.0,0.0,0.01,lance forres howard,
-GEOG,1030,2,World Regional Geog,0.3,0.43,0.1,0.13,0.05,0.0,0.0,0.0,william churc terry,
-GEOG,3020,1,GEOG 3020: 001,0.67,0.25,0.0,0.0,0.08,0.0,0.0,0.0,william churc terry,
-GEOG,3050,1,GEOG 3050: 001,0.74,0.16,0.05,0.05,0.0,0.0,0.0,0.0,lance forres howard,
-GEOL,1010,1,Physical Geology,0.13,0.31,0.27,0.12,0.11,0.0,0.0,0.05,alan coulson,
-GEOL,1010,2,Physical Geology,0.28,0.37,0.2,0.06,0.05,0.0,0.0,0.04,alan coulson,
-GEOL,1020,1,Earth History,0.13,0.44,0.31,0.06,0.0,0.0,0.0,0.06,alan coulson,
-GEOL,1030,1,Physical Geol Lab,0.74,0.09,0.04,0.0,0.09,0.0,0.0,0.04,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.87,0.0,0.09,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.29,0.63,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.5,0.41,0.05,0.0,0.05,0.0,0.0,0.0,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.68,0.23,0.0,0.0,0.05,0.0,0.0,0.05,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.46,0.5,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,alan coulson,
-GEOL,3130,1,GEOL 3130: 001,0.14,0.57,0.24,0.05,0.0,0.0,0.0,0.0,james castle,
-GEOL,3180,1,GEOL 3180: 001,0.18,0.57,0.18,0.0,0.04,0.0,0.0,0.04,brian powell,
-GEOL,7900,500,Selected Topics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-GEOL,8080,1,Groundwater Modeling,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
-GER,1010,3,GER 1010: 003,0.67,0.27,0.0,0.07,0.0,0.0,0.0,0.0,oswald harris king,
-GER,1010,4,GER 1010: 004,0.31,0.08,0.15,0.0,0.08,0.0,0.0,0.38,oswald harris king,
-GER,1010,5,GER 1010: 005,0.08,0.69,0.0,0.0,0.08,0.0,0.0,0.15,oswald harris king,
-GER,1020,3,GER 1020: 003,0.35,0.15,0.1,0.1,0.0,0.0,0.0,0.3, lee ferrell,
-GER,1020,4,GER 1020: 004,0.27,0.2,0.13,0.0,0.2,0.0,0.0,0.2, lee ferrell,
-GER,2010,2,Intermediate German,0.27,0.27,0.2,0.13,0.07,0.0,0.0,0.07,gabriela stoicea,
-GER,2020,3,Intermediate German,0.21,0.38,0.29,0.08,0.0,0.0,0.0,0.04,johannes schmidt,
-GER,3060,1,German Short Story,0.18,0.53,0.12,0.06,0.0,0.0,0.0,0.12,gabriela stoicea,
-GER,3160,1,GER 3160: 001,0.23,0.62,0.0,0.0,0.15,0.0,0.0,0.0, lee ferrell,
-GW,3010,1,Grt Books West World,0.47,0.24,0.18,0.0,0.12,0.0,0.0,0.0,henry clark,
-HCC,8810,2,Health Informatics,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,kelly caine,
-HEHD,4000,1,HEHD 4000: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,
-HEHD,4100,1,HEHD 4100: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
-HEHD,8000,230,HEHD 8000: 230,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,robert ja barcelona,
-HEHD,8010,230,HEHD 8010: 230,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
-HIST,1010,1,Hist of the U S,0.22,0.24,0.19,0.14,0.16,0.0,0.0,0.05,james brad jeffries,
-HIST,1220,1,"Hist, Tech & Society",0.53,0.21,0.15,0.06,0.0,0.01,0.0,0.03,henry clark,
-HIST,1240,1,Environmental Hist,0.23,0.56,0.13,0.03,0.0,0.0,0.0,0.05,james brad jeffries,
-HIST,1240,2,Environmental Hist,0.21,0.51,0.21,0.05,0.0,0.0,0.0,0.03,james brad jeffries,
-HIST,1720,1,The West and the World I,0.36,0.29,0.26,0.05,0.02,0.0,0.0,0.02,henry clark,
-HIST,1720,2,The West and the World I,0.27,0.71,0.02,0.0,0.0,0.0,0.0,0.0,emily wood,
-HIST,1730,1,The West and the World II,0.27,0.27,0.25,0.02,0.11,0.0,0.0,0.07, alan grubb,
-HIST,1730,2,The West and the World II,0.24,0.32,0.2,0.04,0.11,0.0,0.0,0.09,richard saunders,
-HIST,1730,3,The West and the World II,0.21,0.47,0.18,0.06,0.05,0.0,0.0,0.04,steven marks,
-HIST,2990,1,HIST 2990: 001,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,rachel anne moore,
-HIST,2990,2,HIST 2990: 002,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,rachel anne moore,
-HIST,3060,1,HIST 3060: 001,0.39,0.37,0.11,0.04,0.02,0.0,0.0,0.07,richard saunders,
-HIST,3120,1,HIST 3120: 001,0.4,0.44,0.09,0.02,0.02,0.0,0.0,0.02,abel bartley,
-HIST,3140,1,HIST 3140: 001,0.11,0.64,0.22,0.0,0.0,0.0,0.0,0.02,paul chris anderson,
-HIST,3210,1,History of Science,0.28,0.23,0.21,0.15,0.05,0.0,0.0,0.08,pamela mack,
-HIST,3260,1,HIST 3260: 001,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03, roger grant,
-HIST,3290,1,HIST 3290: 001,0.17,0.42,0.21,0.08,0.0,0.0,0.0,0.13,maribel morey,
-HIST,3390,1,HIST 3390: 001,0.46,0.21,0.15,0.08,0.08,0.0,0.0,0.03,james burns,
-HIST,3420,1,HIST 3420: 001,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
-HIST,3670,1,HIST 3670: 001,0.37,0.34,0.13,0.0,0.11,0.0,0.0,0.05,michael silvestri,
-HIST,3730,1,Age of Protestant Reformation,0.43,0.07,0.14,0.0,0.21,0.0,0.0,0.14,thomas kuehn,
-HIST,3780,1,HIST 3780: 001,0.4,0.31,0.17,0.06,0.06,0.0,0.0,0.0,michael meng,
-HIST,3900,1,HIST 3900: 001,0.15,0.41,0.3,0.07,0.07,0.0,0.0,0.0,edwin moise,
-HIST,3970,1,HIST 3970: 001,0.44,0.44,0.07,0.0,0.02,0.0,0.0,0.02,amit bein,
-HIST,4170,1,HIST 4170: 001,0.25,0.5,0.17,0.0,0.08,0.0,0.0,0.0,meg taylor-shockley,
-HIST,4240,1,Top in Hist of Medicine & Hlth,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,pamela mack,
-HIST,4360,1,HIST 4360: 001,0.23,0.27,0.41,0.0,0.09,0.0,0.0,0.0,edwin moise,
-HIST,4600,1,Britain & WWII,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,james burns,
-HIST,4710,1,The Great War 1914 & 1918,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0, alan grubb,
-HIST,4900,2,The Empire World,0.4,0.27,0.2,0.0,0.07,0.0,0.0,0.07,michael silvestri,
-HIST,4900,3,Heroic Failures,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
-HIST,4930,2,Urban History,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,abel bartley,
-HLTH,2020,1,HLTH 2020: 001,0.23,0.64,0.13,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,2,HLTH 2020: 002,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,3,HLTH 2020: 003,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,sarah griffin,
-HLTH,2020,400,HLTH 2020: 400,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2030,1,HLTH 2030: 001,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2030,2,HLTH 2030: 002,0.65,0.22,0.11,0.0,0.0,0.0,0.0,0.03,son albury-crandall,
-HLTH,2030,400,HLTH 2030: 400,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2030,401,HLTH 2030: 401,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2400,1,HLTH 2400: 001,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,joel edwar williams,
-HLTH,2400,2,HLTH 2400: 002,0.73,0.1,0.15,0.02,0.0,0.0,0.0,0.0,joel edwar williams,
-HLTH,2980,1,HLTH 2980: 001,0.52,0.45,0.02,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,2980,2,HLTH 2980: 002,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,3100,1,HLTH 3100: 001,0.19,0.62,0.15,0.0,0.0,0.0,0.0,0.04,rachel mayo,
-HLTH,3100,2,HLTH 3100: 002,0.48,0.36,0.12,0.04,0.0,0.0,0.0,0.0,rachel mayo,
-HLTH,3800,1,HLTH 3800: 001,0.41,0.44,0.13,0.0,0.03,0.0,0.0,0.0,liwei chen,
-HLTH,3800,2,HLTH 3800: 002,0.32,0.5,0.11,0.04,0.04,0.0,0.0,0.0,liwei chen,
-HLTH,3980,1,HLTH 3980: 001,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,kathleen meyer,
-HLTH,4000,1,Adolescent Health,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,4020,1,HLTH 4020: 001,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,karen kemper,
-HLTH,4190,1,HLTH 4190: 001,0.31,0.58,0.09,0.0,0.0,0.0,0.0,0.02,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4300,1,HLTH 4300: 001,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,
-HLTH,4310,1,Public & Environ Hlt,0.63,0.29,0.04,0.0,0.02,0.0,0.0,0.02,deborah alma falta,
-HLTH,4400,1,HLTH 4400: 001,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,windsor we sherrill,
-HLTH,4600,1,HLTH 4600: 001,0.59,0.33,0.04,0.0,0.0,0.0,0.0,0.04,deidra jol morrison,
-HLTH,4780,1,HLTH 4780: 001,0.11,0.56,0.3,0.0,0.0,0.0,0.0,0.04,hugh spitler,
-HLTH,4790,1,HLTH 4790: 001,0.17,0.48,0.24,0.1,0.0,0.0,0.0,0.0,khoa dang truong,
-HLTH,4800,1,HLTH 4800: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,
-HLTH,4900,1,HLTH 4900: 001,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,lu shi,
-HLTH,4900,2,HLTH 4900: 002,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,lu shi,
-HON,2030,2,Music and Politics (HON),0.83,0.06,0.0,0.06,0.0,0.0,0.0,0.06,eric lapin,True
-HON,2060,1,Intro to Nanotechnology,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,christophe kitchens,True
-HON,2210,1,The Great War 1914-1918,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True
-HON,2210,3,20th Century Lit & Painting,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,john morgenstern,True
-HON,2210,5,Spies and Spy Novels,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,william lasser,True
-HORT,1010,1,HORT 1010: 001,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,
-HORT,2110,1,HORT 2110: 001,0.33,0.33,0.19,0.11,0.04,0.0,0.0,0.0,james emerson faust,
-HORT,4040,1,HORT 4040: 001,0.06,0.44,0.19,0.14,0.14,0.0,0.0,0.03,jeffrey adelberg,
-HORT,4050,2,HORT 4050: 002,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
-HORT,4270,1,Urban Tree Care,0.18,0.36,0.18,0.05,0.18,0.0,0.0,0.05,robert polomski,
-HORT,4330,1,Turf Weed Management,0.13,0.54,0.25,0.0,0.04,0.0,0.0,0.04,ted whitwell,
-HORT,4720,1,HORT 4720: 001,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HP,8900,400,Directed Studies: Pres Eng,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,craig mille bennett,
-HP,8910,1,HP 8910: 001,0.0,0.0,0.0,0.0,0.0,0.85,0.15,0.0,carter lee hudgins,
-HRD,8470,400,HRD 8470: 400,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
-HRD,8470,401,HRD 8470: 401,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,
-HRD,8470,402,HRD 8470: 402,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,
-HRD,8470,403,HRD 8470: 403,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
-HRD,8470,405,HRD 8470: 405,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,
-IE,2010,1,IE 2010: 001,0.37,0.27,0.23,0.13,0.0,0.0,0.0,0.0,joel greenstein,
-IE,2100,1,IE 2100: 001,0.46,0.4,0.08,0.02,0.02,0.0,0.0,0.01,antonia rodriguez,
-IE,3610,1,IE 3610: 001,0.42,0.32,0.1,0.09,0.05,0.0,0.0,0.03,david neyens,
-IE,3810,1,IE 3810: 001,0.34,0.42,0.14,0.07,0.02,0.0,0.0,0.01,mary elizabeth kurz,
-IE,3840,1,IE 3840: 001,0.36,0.2,0.16,0.05,0.08,0.0,0.0,0.14,brian melloy,
-IE,3860,1,IE 3860: 001,0.6,0.26,0.12,0.01,0.0,0.0,0.0,0.01,jonathan lowe,
-IE,4600,1,IE 4600: 001,0.33,0.39,0.22,0.06,0.0,0.0,0.0,0.0,joel greenstein,
-IE,4620,1,IE 4620: 001,0.35,0.6,0.03,0.0,0.0,0.02,0.0,0.0,byung rae cho,
-IE,4910,1,Appl Probability Models in IE,0.82,0.0,0.09,0.09,0.0,0.0,0.0,0.0,brian melloy,
-IE,6620,1,IE 6620: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,byung rae cho,
-IE,8010,1,Human-Machine Sys,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,
-IE,8040,1,IE 8040: 001,0.29,0.48,0.24,0.0,0.0,0.0,0.0,0.0,william ferrell,
-IE,8050,1,IE 8050: 001,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,byung rae cho,
-IE,8520,1,IE 8520: 001,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabeth kurz,
-IE,8540,1,IE 8540: 001,0.47,0.39,0.08,0.0,0.0,0.0,0.0,0.06,william ferrell,
-IE,8580,1,IE 8580: 001,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-IE,8800,1,IE 8800: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,amin khademi,
-IS,2100,615,Sel Topics Int Study,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,sallie bro turnbull,
-ITAL,1010,1,ITAL 1010: 001,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,julia schmidt,
-ITAL,1020,1,ITAL 1020: 001,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,luca barattoni,
-ITAL,1020,2,ITAL 1020: 002,0.38,0.31,0.0,0.08,0.15,0.0,0.08,0.0,luca barattoni,
-ITAL,1020,3,ITAL 1020: 003,0.5,0.25,0.08,0.08,0.0,0.0,0.0,0.08,valentina lombardi,
-ITAL,2020,1,Intermediate Italian,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,2020,2,Intermediate Italian,0.28,0.39,0.33,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-JAPN,1010,2,JAPN 1010: 002,0.21,0.36,0.07,0.07,0.21,0.0,0.0,0.07,kazuko shoji,
-JAPN,1020,1,JAPN 1020: 001,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0, leslie williams,
-JAPN,2020,1,JAPN 2020: 001,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,kazuko shoji,
-JAPN,3060,1,JAPN 3060: 001,0.4,0.3,0.1,0.0,0.0,0.1,0.0,0.1,toshiko kishimoto,
-JAPN,4170,1,Japan Cult & Soc,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0, leslie williams,
-LANG,4990,1,LANG 4990: 001,0.0,0.0,0.0,0.0,0.0,0.88,0.06,0.06,su- chen,
-LARC,1160,1,History of Larch,0.31,0.36,0.2,0.05,0.05,0.0,0.0,0.04,hala fouad nassar,
-LARC,1520,1,LARC 1520: 001,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,daniel ford,
-LARC,2620,1,Design Impl I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,david pearson,
-LARC,3520,1,LARC 3520: 001,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,robert hewitt,
-LARC,6530,1,LARC 6530: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lycke,
-LARC,8300,1,LARC 8300: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-LAW,3220,1,Legal Env of Bus,0.35,0.4,0.16,0.03,0.0,0.0,0.0,0.06,edward ray claggett,
-LAW,3220,2,Legal Env of Bus,0.53,0.31,0.08,0.05,0.02,0.0,0.0,0.02,edward ray claggett,
-LAW,3220,3,Legal Env of Bus,0.43,0.41,0.13,0.02,0.0,0.0,0.0,0.02,frances edwards,
-LAW,3220,4,Legal Env of Bus,0.3,0.49,0.17,0.03,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,5,Legal Env of Bus,0.41,0.44,0.13,0.02,0.0,0.0,0.0,0.02,frances edwards,
-LAW,3220,6,Legal Env of Bus,0.0,0.17,0.29,0.2,0.07,0.0,0.0,0.27,virgini ward-vaughn,
-LAW,3220,7,Legal Env of Bus,0.08,0.25,0.25,0.14,0.08,0.0,0.0,0.19,virgini ward-vaughn,
-LAW,3220,8,Legal Env of Bus,0.02,0.14,0.36,0.12,0.12,0.0,0.0,0.24,virgini ward-vaughn,
-LAW,3220,9,Legal Env of Bus,0.03,0.28,0.21,0.23,0.15,0.0,0.0,0.1,virgini ward-vaughn,
-LAW,3330,1,Real Estate Law,0.15,0.31,0.46,0.02,0.04,0.0,0.0,0.02,judson jahn,
-LAW,3330,2,Real Estate Law,0.13,0.38,0.38,0.06,0.02,0.0,0.0,0.02,judson jahn,
-LAW,8480,1,LAW 8480: 001,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LAW,8500,1,LAW 8500: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,megan mowrey,
-LAW,8500,2,LAW 8500: 002,0.89,0.08,0.0,0.0,0.03,0.0,0.0,0.0,megan mowrey,
-LS,1000,2,Fitness Leadership,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,mary allison lynch,
-LS,1000,20,Intro to Volleyball,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,kelly lynn ator,
-LS,1000,22,Forestry Skills,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,tamara lee cushing,
-LS,1410,2,LS 1410: 002,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,glenn dav middleton,
-LS,1450,2,LS 1450: 002,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,george wal thompson,
-LS,1560,1,LS 1560: 001,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,david brad cottrell,
-LS,1560,3,LS 1560: 003,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,david brad cottrell,
-LS,1570,6,LS 1570: 006,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey la atkinson,
-LS,1570,10,LS 1570: 010,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,audrey caroli couch,
-LS,1580,1,LS 1580: 001,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,herbert strickland,
-LS,1580,5,LS 1580: 005,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1610,1,LS 1610: 001,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,richard willey,
-LS,1790,1,LS 1790: 001,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert bogan,
-LS,1830,1,LS 1830: 001,0.77,0.09,0.09,0.05,0.0,0.0,0.0,0.0,justin hickey,
-LS,1850,1,LS 1850: 001,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,matthew davi hughes,
-LS,1850,2,LS 1850: 002,0.93,0.0,0.0,0.04,0.0,0.0,0.0,0.04,matthew davi hughes,
-LS,1850,4,LS 1850: 004,0.96,0.0,0.0,0.0,0.04,0.0,0.0,0.0,megan elizabet cato,
-LS,1880,1,LS 1880: 001,0.73,0.0,0.0,0.0,0.07,0.0,0.0,0.2,jarrett bachman,
-LS,1890,1,LS 1890: 001,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,jennifer jo garrity,
-LS,1990,1,LS 1990: 001,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jason jordan,
-LS,2040,2,LS 2040: 002,0.83,0.0,0.0,0.09,0.0,0.0,0.0,0.09,denise ann adams,
-LS,2100,4,LS 2100: 004,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,paul hoke,
-LS,2110,2,LS 2110: 002,0.88,0.0,0.12,0.0,0.0,0.0,0.0,0.0,stephanie pack,
-LS,2190,1,LS 2190: 001,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,matthew lee krabbe,
-LS,2200,5,LS 2200: 005,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,broadus fleming,
-LS,2200,7,LS 2200: 007,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,matthew lee krabbe,
-LS,2200,8,LS 2200: 008,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,matthew lee krabbe,
-LS,2200,9,LS 2200: 009,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,matthew lee krabbe,
-LS,2210,1,LS 2210: 001,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,paul hoke,
-LS,2270,1,LS 2270: 001,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,
-LS,2270,2,LS 2270: 002,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,paul hoke,
-LS,2320,1,LS 2320: 001,0.87,0.0,0.0,0.0,0.04,0.0,0.0,0.09,diane moreno,
-LS,2320,2,LS 2320: 002,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,diane moreno,
-LS,2320,3,LS 2320: 003,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,diane moreno,
-LS,2320,5,LS 2320: 005,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,2350,1,LS 2350: 001,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,ranjanbala dil amin,
-LS,2350,2,LS 2350: 002,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
-LS,2350,3,LS 2350: 003,0.7,0.09,0.13,0.0,0.0,0.0,0.0,0.09,renee warren gahan,
-LS,2350,4,LS 2350: 004,0.79,0.08,0.0,0.0,0.0,0.0,0.0,0.13,renee warren gahan,
-LS,2350,5,LS 2350: 005,0.65,0.17,0.0,0.0,0.0,0.0,0.0,0.17,renee warren gahan,
-LS,2350,6,LS 2350: 006,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,2350,8,LS 2350: 008,0.84,0.04,0.0,0.04,0.08,0.0,0.0,0.0,ranjanbala dil amin,
-LS,2360,1,LS 2360: 001,0.92,0.0,0.0,0.0,0.04,0.0,0.0,0.04,ani reina-nunnelley,
-LS,2360,2,LS 2360: 002,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,ani reina-nunnelley,
-LS,2360,3,LS 2360: 003,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
-LS,2370,1,LS 2370: 001,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,ashley austi lester,
-LS,2370,2,LS 2370: 002,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,ashley austi lester,
-LS,2370,3,LS 2370: 003,0.72,0.17,0.0,0.0,0.0,0.0,0.0,0.11,ashley austi lester,
-LS,2370,4,LS 2370: 004,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,
-LS,2370,5,LS 2370: 005,0.77,0.09,0.0,0.0,0.05,0.0,0.0,0.09,ashley austi lester,
-LS,2380,2,LS 2380: 002,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,phaedra o'connell,
-LS,2380,3,LS 2380: 003,0.74,0.13,0.04,0.0,0.0,0.0,0.0,0.09,phaedra o'connell,
-LS,2380,5,LS 2380: 005,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,phaedra o'connell,
-LS,2420,1,LS 2420: 001,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
-LS,2420,2,LS 2420: 002,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,phaedra o'connell,
-LS,2420,3,LS 2420: 003,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,ranjanbala dil amin,
-LS,2420,4,LS 2420: 004,0.87,0.0,0.09,0.0,0.0,0.0,0.0,0.04,phaedra o'connell,
-LS,2420,5,LS 2420: 005,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,
-LS,2770,1,LS 2770: 001,0.36,0.55,0.0,0.0,0.0,0.0,0.0,0.09,kelly lynn womack,
-MATH,1010,1,Essen Math for Informed Soc,0.18,0.35,0.29,0.06,0.12,0.0,0.0,0.0,chelsea rose snyder,
-MATH,1010,2,Essen Math for Informed Soc,0.35,0.24,0.32,0.09,0.0,0.0,0.0,0.0,judith cottingham,
-MATH,1010,3,Essen Math for Informed Soc,0.27,0.4,0.2,0.13,0.0,0.0,0.0,0.0,matthew keogh,
-MATH,1010,4,Essen Math for Informed Soc,0.4,0.27,0.1,0.1,0.07,0.0,0.0,0.07,judith cottingham,
-MATH,1010,5,Essen Math for Informed Soc,0.37,0.16,0.21,0.11,0.11,0.0,0.0,0.05,golubinski capaverde,
-MATH,1010,6,Essen Math for Informed Soc,0.21,0.24,0.21,0.18,0.06,0.0,0.0,0.09,judith cottingham,
-MATH,1010,7,Essen Math for Informed Soc,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,honghai xu,
-MATH,1020,1,Intro to Mathematical Analysis,0.11,0.32,0.21,0.11,0.26,0.0,0.0,0.0,garrett dranichak,
-MATH,1020,2,Intro to Mathematical Analysis,0.11,0.26,0.16,0.32,0.11,0.0,0.0,0.05,karyn muir,
-MATH,1020,3,Intro to Mathematical Analysis,0.11,0.14,0.14,0.17,0.37,0.0,0.0,0.06,brian dandurand,
-MATH,1020,4,Intro to Mathematical Analysis,0.3,0.05,0.3,0.2,0.15,0.0,0.0,0.0,caroline lee burch,
-MATH,1020,5,Intro to Mathematical Analysis,0.1,0.29,0.26,0.05,0.24,0.0,0.0,0.07,randy davidson,
-MATH,1020,6,Intro to Mathematical Analysis,0.29,0.29,0.14,0.0,0.19,0.0,0.0,0.1,kara ail stasikelis,
-MATH,1020,7,Intro to Mathematical Analysis,0.18,0.23,0.3,0.18,0.08,0.0,0.0,0.05, erwin walker,
-MATH,1020,8,Intro to Mathematical Analysis,0.17,0.24,0.31,0.1,0.17,0.0,0.0,0.02,allison stoddard,
-MATH,1020,9,Intro to Mathematical Analysis,0.26,0.21,0.12,0.12,0.24,0.0,0.0,0.06,brian dandurand,
-MATH,1020,10,Intro to Mathematical Analysis,0.25,0.14,0.28,0.08,0.17,0.0,0.0,0.08,randy davidson,
-MATH,1020,11,Intro to Mathematical Analysis,0.17,0.29,0.26,0.09,0.14,0.0,0.0,0.06,randy davidson,
-MATH,1020,12,Intro to Mathematical Analysis,0.06,0.19,0.31,0.13,0.13,0.0,0.0,0.19,drew jared lipman,
-MATH,1020,13,Intro to Mathematical Analysis,0.39,0.17,0.11,0.06,0.17,0.0,0.0,0.11,paul james cubre,
-MATH,1020,14,Intro to Mathematical Analysis,0.06,0.17,0.23,0.23,0.2,0.0,0.0,0.11,brian dandurand,
-MATH,1040,1,MATH 1040: 001,0.0,0.0,0.0,0.0,0.0,0.62,0.31,0.08,lakmali weerasena,
-MATH,1040,2,MATH 1040: 002,0.0,0.0,0.0,0.0,0.0,0.62,0.31,0.07,lakmali weerasena,
-MATH,1050,400,MATH 1050: 400,0.0,0.0,0.0,0.0,0.0,0.63,0.35,0.02,eliza dar gallagher,
-MATH,1060,1,Calculus of One Variable I,0.0,0.36,0.21,0.07,0.29,0.0,0.0,0.07,sarah eliz anderson,
-MATH,1060,2,Calculus of One Variable I,0.05,0.2,0.25,0.3,0.2,0.0,0.0,0.0,charity watson,
-MATH,1060,3,Calculus of One Variable I,0.04,0.25,0.25,0.04,0.21,0.0,0.0,0.21,allen anderso guest,
-MATH,1060,4,Calculus of One Variable I,0.12,0.04,0.24,0.16,0.32,0.0,0.0,0.12,allen anderso guest,
-MATH,1060,5,Calculus of One Variable I,0.09,0.22,0.25,0.09,0.25,0.0,0.0,0.09,marion hanna,
-MATH,1060,6,Calculus of One Variable I,0.04,0.18,0.32,0.18,0.14,0.0,0.0,0.14,marilyn reba,
-MATH,1060,7,Calculus of One Variable I,0.05,0.21,0.42,0.16,0.16,0.0,0.0,0.0,damitha bandara,
-MATH,1060,8,Calculus of One Variable I,0.05,0.3,0.35,0.1,0.15,0.0,0.0,0.05,damitha bandara,
-MATH,1060,202,Calculus of One Variable I,0.32,0.32,0.11,0.0,0.16,0.0,0.0,0.11,james peterson,
-MATH,1070,1,Differen and Integral Calculus,0.16,0.43,0.18,0.09,0.11,0.0,0.0,0.02,donna simms,
-MATH,1070,2,Differen and Integral Calculus,0.15,0.57,0.15,0.07,0.04,0.0,0.0,0.02,donna simms,
-MATH,1070,3,Differen and Integral Calculus,0.23,0.3,0.38,0.06,0.02,0.0,0.0,0.0,christy jenki brown,
-MATH,1070,4,Differen and Integral Calculus,0.33,0.29,0.22,0.07,0.02,0.0,0.0,0.07,jennifer mari hanna,
-MATH,1070,5,Differen and Integral Calculus,0.36,0.21,0.28,0.09,0.06,0.0,0.0,0.0,jennifer mari hanna,
-MATH,1070,6,Differen and Integral Calculus,0.26,0.36,0.26,0.09,0.04,0.0,0.0,0.0,jennifer mari hanna,
-MATH,1080,1,Calculus of One Variable II,0.09,0.2,0.18,0.07,0.16,0.0,0.0,0.31,christa con johnson,
-MATH,1080,2,Calculus of One Variable II,0.05,0.24,0.21,0.03,0.05,0.0,0.0,0.42,terri johnson,
-MATH,1080,3,Calculus of One Variable II,0.18,0.25,0.11,0.05,0.18,0.0,0.0,0.23,anastasia br wilson,
-MATH,1080,4,Calculus of One Variable II,0.04,0.24,0.2,0.07,0.13,0.0,0.0,0.33,beth novick,
-MATH,1080,5,Calculus of One Variable II,0.09,0.26,0.24,0.04,0.0,0.0,0.0,0.37,terri johnson,
-MATH,1080,6,Calculus of One Variable II,0.02,0.29,0.11,0.09,0.07,0.0,0.0,0.42,beth novick,
-MATH,1080,7,Calculus of One Variable II,0.13,0.26,0.17,0.09,0.11,0.0,0.0,0.24,meredith nicol burr,
-MATH,1080,8,Calculus of One Variable II,0.11,0.22,0.29,0.02,0.18,0.0,0.0,0.18,christa con johnson,
-MATH,1080,9,Calculus of One Variable II,0.06,0.36,0.15,0.11,0.17,0.0,0.0,0.15,shih-wei chao,
-MATH,1080,10,Calculus of One Variable II,0.02,0.16,0.27,0.11,0.16,0.0,0.0,0.29,akshay sunil gupte,
-MATH,1080,11,Calculus of One Variable II,0.11,0.24,0.18,0.09,0.2,0.0,0.0,0.18,patrick buckingham,
-MATH,1080,12,Calculus of One Variable II,0.42,0.27,0.18,0.02,0.02,0.0,0.0,0.09,dania moham zantout,
-MATH,1080,13,Calculus of One Variable II,0.07,0.11,0.2,0.05,0.36,0.0,0.0,0.2,nathan chenette,
-MATH,1080,14,Calculus of One Variable II,0.09,0.09,0.21,0.02,0.09,0.0,0.0,0.49,rachel eli grotheer,
-MATH,1080,15,Calculus of One Variable II,0.11,0.19,0.26,0.06,0.17,0.0,0.0,0.22,nathanael dav black,
-MATH,1150,1,Contemp Math for Elem Teach I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,james kwame dogbey,
-MATH,1160,1,Contemp Math for Elem Teach II,0.56,0.31,0.03,0.09,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1160,2,Contemp Math for Elem Teach II,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1990,400,MATH 1990: 400,0.0,0.0,0.0,0.0,0.0,0.88,0.07,0.04,marion hanna,
-MATH,2030,1,Elemen Statistical Inference,0.62,0.26,0.05,0.03,0.03,0.0,0.0,0.03,laura jane shick,
-MATH,2030,2,Elemen Statistical Inference,0.44,0.23,0.15,0.13,0.0,0.0,0.0,0.05,laura jane shick,
-MATH,2030,3,Elemen Statistical Inference,0.71,0.12,0.07,0.07,0.0,0.0,0.0,0.02,laura jane shick,
-MATH,2030,4,Elemen Statistical Inference,0.49,0.29,0.06,0.06,0.09,0.0,0.0,0.03,christopher wilson,
-MATH,2030,5,Elemen Statistical Inference,0.56,0.17,0.14,0.08,0.03,0.0,0.0,0.03,stephen wesl carden,
-MATH,2030,6,Elemen Statistical Inference,0.6,0.18,0.13,0.05,0.03,0.0,0.0,0.03,dominique morgan,
-MATH,2030,7,Elemen Statistical Inference,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,yan liu,
-MATH,2060,1,Calculus of Several Variables,0.1,0.13,0.17,0.37,0.23,0.0,0.0,0.0,christopher cox,
-MATH,2060,2,Calculus of Several Variables,0.26,0.59,0.06,0.03,0.0,0.0,0.0,0.06,peter kiessler,
-MATH,2060,3,Calculus of Several Variables,0.41,0.16,0.27,0.05,0.08,0.0,0.0,0.03,charles johnson,
-MATH,2060,4,Calculus of Several Variables,0.29,0.29,0.35,0.0,0.03,0.0,0.0,0.03,chanseok park,
-MATH,2060,5,Calculus of Several Variables,0.43,0.14,0.29,0.09,0.06,0.0,0.0,0.0,timothy ch teitloff,
-MATH,2060,6,Calculus of Several Variables,0.25,0.34,0.28,0.03,0.06,0.0,0.0,0.03,svetlan poznanovikj,
-MATH,2060,7,Calculus of Several Variables,0.32,0.44,0.21,0.0,0.03,0.0,0.0,0.0,peter kiessler,
-MATH,2060,8,Calculus of Several Variables,0.18,0.35,0.24,0.03,0.15,0.0,0.0,0.06,nathan jos adelgren,
-MATH,2060,9,Calculus of Several Variables,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,martin joha schmoll,
-MATH,2060,10,Calculus of Several Variables,0.27,0.3,0.21,0.06,0.03,0.0,0.0,0.12,qingshan chen,
-MATH,2060,11,Calculus of Several Variables,0.26,0.32,0.18,0.12,0.03,0.0,0.0,0.09,xin liu,
-MATH,2060,100,Calc of Several Variable (HON),0.58,0.25,0.08,0.0,0.08,0.0,0.0,0.0,james brown,True
-MATH,2070,1,Multivariable Calculus,0.22,0.06,0.33,0.11,0.11,0.0,0.0,0.17,elaine ma sotherden,
-MATH,2070,3,Multivariable Calculus,0.35,0.35,0.29,0.0,0.0,0.0,0.0,0.0,rodney lewis keaton,
-MATH,2070,4,Multivariable Calculus,0.08,0.31,0.31,0.06,0.17,0.0,0.0,0.08,sherry biggers,
-MATH,2070,5,Multivariable Calculus,0.44,0.31,0.17,0.0,0.03,0.0,0.0,0.06,jennifer van dyken,
-MATH,2070,6,Multivariable Calculus,0.17,0.49,0.23,0.11,0.0,0.0,0.0,0.0,judith irene mcknew,
-MATH,2070,7,Multivariable Calculus,0.37,0.26,0.16,0.11,0.11,0.0,0.0,0.0,audrey nico devries,
-MATH,2070,8,Multivariable Calculus,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,lawrence mccormick,
-MATH,2070,9,Multivariable Calculus,0.26,0.53,0.11,0.11,0.0,0.0,0.0,0.0,alistair bentley,
-MATH,2070,10,Multivariable Calculus,0.17,0.44,0.28,0.11,0.0,0.0,0.0,0.0,saba za alkaseasbeh,
-MATH,2070,11,Multivariable Calculus,0.26,0.34,0.26,0.03,0.03,0.0,0.0,0.09,sherry biggers,
-MATH,2070,12,Multivariable Calculus,0.33,0.36,0.14,0.08,0.06,0.0,0.0,0.03,judith irene mcknew,
-MATH,2070,13,Multivariable Calculus,0.47,0.21,0.11,0.0,0.16,0.0,0.0,0.05,jason lee joyner,
-MATH,2070,14,Multivariable Calculus,0.32,0.26,0.26,0.11,0.0,0.0,0.0,0.05,tony thanh nguyen,
-MATH,2070,15,Multivariable Calculus,0.2,0.4,0.23,0.06,0.03,0.0,0.0,0.09,sherry biggers,
-MATH,2070,16,Multivariable Calculus,0.53,0.16,0.05,0.11,0.11,0.0,0.0,0.05,rachel malinauskas,
-MATH,2070,17,Multivariable Calculus,0.33,0.17,0.28,0.17,0.0,0.0,0.0,0.06,william bo lassiter,
-MATH,2070,18,Multivariable Calculus,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0, ushijima-mwesigwa,
-MATH,2070,19,Multivariable Calculus,0.37,0.37,0.11,0.05,0.11,0.0,0.0,0.0,zachary hollifield,
-MATH,2070,20,Multivariable Calculus,0.35,0.35,0.1,0.1,0.05,0.0,0.0,0.05,luke marti giberson,
-MATH,2070,21,Multivariable Calculus,0.15,0.48,0.24,0.03,0.03,0.0,0.0,0.06,mark thomas batell,
-MATH,2070,22,Multivariable Calculus,0.32,0.47,0.05,0.0,0.11,0.0,0.0,0.05,jason to hedetniemi,
-MATH,2070,23,Multivariable Calculus,0.16,0.47,0.32,0.0,0.05,0.0,0.0,0.0,janie caro mcdonald,
-MATH,2070,24,Multivariable Calculus,0.28,0.28,0.28,0.0,0.06,0.0,0.0,0.11,grady mcgowa thomas,
-MATH,2070,25,Multivariable Calculus,0.11,0.32,0.26,0.16,0.16,0.0,0.0,0.0,liem nguyen,
-MATH,2070,26,Multivariable Calculus,0.15,0.5,0.15,0.1,0.1,0.0,0.0,0.0,fiona may knoll,
-MATH,2080,1,Intro to Ordin Diff Equations,0.41,0.32,0.15,0.0,0.03,0.0,0.0,0.09,timothy fra parrott,
-MATH,2080,2,Intro to Ordin Diff Equations,0.35,0.29,0.23,0.06,0.03,0.0,0.0,0.03,ebrahim nasrabadi,
-MATH,2080,3,Intro to Ordin Diff Equations,0.24,0.24,0.18,0.06,0.12,0.0,0.0,0.18,shari prevost,
-MATH,2080,4,Intro to Ordin Diff Equations,0.31,0.36,0.11,0.11,0.06,0.0,0.0,0.06,mishko mitkovski,
-MATH,2080,5,Intro to Ordin Diff Equations,0.64,0.21,0.07,0.05,0.0,0.0,0.0,0.02,timothy fra parrott,
-MATH,2080,6,Intro to Ordin Diff Equations,0.12,0.3,0.27,0.12,0.12,0.0,0.0,0.06,julie lassiter,
-MATH,2080,7,Intro to Ordin Diff Equations,0.2,0.13,0.27,0.07,0.17,0.0,0.0,0.17,shari prevost,
-MATH,2080,8,Intro to Ordin Diff Equations,0.17,0.27,0.23,0.13,0.1,0.0,0.0,0.1,julie lassiter,
-MATH,2080,9,Intro to Ordin Diff Equations,0.47,0.19,0.22,0.06,0.06,0.0,0.0,0.0,timothy ch teitloff,
-MATH,2080,10,Intro to Ordin Diff Equations,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,william moss,
-MATH,2080,11,Intro to Ordin Diff Equations,0.17,0.38,0.13,0.13,0.17,0.0,0.0,0.04,brandon gra goodell,
-MATH,2080,12,Intro to Ordin Diff Equations,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,irina viktorova,
-MATH,2080,13,Intro to Ordin Diff Equations,0.41,0.41,0.05,0.02,0.07,0.0,0.0,0.02,timothy fra parrott,
-MATH,2080,14,Intro to Ordin Diff Equations,0.66,0.11,0.11,0.06,0.06,0.0,0.0,0.0,timothy ch teitloff,
-MATH,2080,15,Intro to Ordin Diff Equations,0.65,0.23,0.02,0.02,0.05,0.0,0.0,0.02,irina viktorova,
-MATH,2080,16,Intro to Ordin Diff Equations,0.62,0.19,0.12,0.05,0.02,0.0,0.0,0.0,timothy ch teitloff,
-MATH,2080,17,Intro to Ordin Diff Equations,0.32,0.37,0.13,0.05,0.08,0.0,0.0,0.05,timothy fra parrott,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.58,0.35,0.04,0.04,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,3010,1,Statistical Methods I,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hewa priyadarshani,
-MATH,3010,2,Statistical Methods I,0.27,0.23,0.23,0.1,0.13,0.0,0.0,0.03,meredith nicol burr,
-MATH,3010,3,Statistical Methods I,0.29,0.33,0.29,0.0,0.0,0.0,0.0,0.1,yanbo xia,
-MATH,3010,4,Statistical Methods I,0.33,0.27,0.0,0.27,0.07,0.0,0.0,0.07,tao yang,
-MATH,3010,5,Statistical Methods I,0.4,0.4,0.0,0.0,0.07,0.0,0.0,0.13,emily marie nystrom,
-MATH,3020,1,MATH 3020: 001,0.26,0.35,0.24,0.09,0.0,0.0,0.0,0.06,derek brown,
-MATH,3020,2,MATH 3020: 002,0.42,0.44,0.03,0.06,0.06,0.0,0.0,0.0,yingbo li,
-MATH,3020,3,MATH 3020: 003,0.41,0.41,0.07,0.05,0.02,0.0,0.0,0.02,xiaoqian sun,
-MATH,3020,4,MATH 3020: 004,0.28,0.33,0.18,0.05,0.08,0.0,0.0,0.08,calvin williams,
-MATH,3020,5,MATH 3020: 005,0.34,0.26,0.2,0.09,0.06,0.0,0.0,0.06,michael thom finney,
-MATH,3080,1,MATH 3080: 001,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,eliza dar gallagher,
-MATH,3090,1,Intro to Business Statistics,0.19,0.26,0.33,0.04,0.15,0.0,0.0,0.04,gary fellers,
-MATH,3090,2,Intro to Business Statistics,0.21,0.27,0.24,0.18,0.09,0.0,0.0,0.0,ellen hepfe breazel,
-MATH,3090,3,Intro to Business Statistics,0.22,0.41,0.19,0.03,0.09,0.0,0.0,0.06,gary fellers,
-MATH,3090,4,Intro to Business Statistics,0.05,0.16,0.26,0.32,0.21,0.0,0.0,0.0,bereket tesfaldet,
-MATH,3090,5,Intro to Business Statistics,0.2,0.27,0.3,0.1,0.03,0.0,0.0,0.1,charity watson,
-MATH,3090,6,Intro to Business Statistics,0.16,0.21,0.32,0.11,0.05,0.0,0.0,0.16,james ellis  wrenn,
-MATH,3090,7,Intro to Business Statistics,0.1,0.26,0.32,0.19,0.1,0.0,0.0,0.03,margaret mar wiecek,
-MATH,3090,8,Intro to Business Statistics,0.17,0.22,0.28,0.22,0.06,0.0,0.0,0.06,joshua crunkleton,
-MATH,3090,9,Intro to Business Statistics,0.11,0.47,0.26,0.05,0.05,0.0,0.0,0.05,andrew jo schwarzer,
-MATH,3090,10,Intro to Business Statistics,0.23,0.42,0.13,0.1,0.1,0.0,0.0,0.03,gary fellers,
-MATH,3090,11,Intro to Business Statistics,0.1,0.35,0.32,0.13,0.06,0.0,0.0,0.03,gary fellers,
-MATH,3090,12,Intro to Business Statistics,0.23,0.4,0.2,0.03,0.1,0.0,0.0,0.03,christy jenki brown,
-MATH,3110,1,Linear Algebra,0.21,0.18,0.21,0.09,0.21,0.0,0.0,0.12,jeong rock yoon,
-MATH,3110,2,Linear Algebra,0.29,0.21,0.26,0.06,0.18,0.0,0.0,0.0,neil calkin,
-MATH,3110,3,Linear Algebra,0.19,0.19,0.13,0.16,0.22,0.0,0.0,0.13,nathan chenette,
-MATH,3110,4,Linear Algebra,0.26,0.26,0.19,0.13,0.1,0.0,0.0,0.06,matthew macauley,
-MATH,3110,5,Linear Algebra,0.1,0.05,0.24,0.24,0.05,0.0,0.0,0.33,felice manganiello,
-MATH,3110,100,Linear Algebra (HON),0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,felice manganiello,True
-MATH,3150,1,MATH 3150: 001,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,3190,2,MATH 3190: 002,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,michael adam burr,
-MATH,3600,1,MATH 3600: 001,0.56,0.38,0.0,0.0,0.06,0.0,0.0,0.0,daniel warner,
-MATH,3650,1,MATH 3650: 001,0.67,0.27,0.05,0.0,0.0,0.0,0.0,0.01,leo rebholz,
-MATH,3650,2,MATH 3650: 002,0.37,0.23,0.07,0.07,0.13,0.0,0.0,0.13,timo johann heister,
-MATH,4000,1,Theory of Probability,0.38,0.31,0.19,0.03,0.09,0.0,0.0,0.0,yingbo li,
-MATH,4030,1,Intro to Statistical Theory,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,chanseok park,
-MATH,4070,1,MATH 4070: 001,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,4100,1,MATH 4100: 001,0.08,0.23,0.15,0.08,0.08,0.0,0.0,0.38,dania moham zantout,
-MATH,4120,1,Intro to Modern Algebra,0.19,0.23,0.23,0.16,0.13,0.0,0.0,0.06,matthew macauley,
-MATH,4190,1,Discrete Math Structures I,0.45,0.47,0.08,0.0,0.0,0.0,0.0,0.0,wayne goddard,
-MATH,4300,1,MATH 4300: 001,0.2,0.2,0.1,0.2,0.2,0.0,0.0,0.1, erwin walker,
-MATH,4340,1,MATH 4340: 001,0.14,0.24,0.17,0.17,0.03,0.0,0.0,0.24,eleanor jenkins,
-MATH,4340,2,MATH 4340: 002,0.2,0.14,0.29,0.11,0.09,0.0,0.0,0.17,hyesuk lee,
-MATH,4400,1,Linear Programming,0.12,0.35,0.15,0.08,0.04,0.0,0.0,0.27,akshay sunil gupte,
-MATH,4410,1,Intro to Stochastic Models,0.38,0.29,0.17,0.04,0.08,0.0,0.0,0.04,brian fralix,
-MATH,4500,1,MATH 4500: 001,0.18,0.18,0.09,0.36,0.09,0.0,0.0,0.09,vincent ervin,
-MATH,4530,1,Advanced Calculus I,0.13,0.31,0.31,0.06,0.09,0.0,0.0,0.09,taufiquar rahm khan,
-MATH,4540,1,Advanced Calculus II,0.24,0.44,0.16,0.04,0.04,0.0,0.0,0.08,taufiquar rahm khan,
-MATH,6340,1,MATH 6340: 001,0.45,0.35,0.05,0.0,0.05,0.0,0.0,0.1,vincent ervin,
-MATH,7060,400,MATH 7060: 400,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,stacy megan che,
-MATH,8030,1,MATH 8030: 001,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
-MATH,8050,1,MATH 8050: 001,0.52,0.26,0.04,0.0,0.0,0.0,0.0,0.17,derek brown,
-MATH,8060,1,MATH 8060: 001,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,8100,1,MATH 8100: 001,0.47,0.41,0.0,0.0,0.06,0.0,0.0,0.06,matthew saltzman,
-MATH,8110,1,MATH 8110: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,
-MATH,8130,1,MATH 8130: 001,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,ebrahim nasrabadi,
-MATH,8210,1,MATH 8210: 001,0.38,0.5,0.06,0.0,0.06,0.0,0.0,0.0,shitao liu,
-MATH,8220,1,MATH 8220: 001,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,
-MATH,8260,1,MATH 8260: 001,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,shitao liu,
-MATH,8520,1,MATH 8520: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,
-MATH,8530,1,MATH 8530: 001,0.47,0.12,0.29,0.0,0.06,0.0,0.0,0.06,svetlan poznanovikj,
-MATH,8540,1,MATH 8540: 001,0.46,0.31,0.0,0.0,0.0,0.0,0.0,0.23,beth novick,
-MATH,8600,1,MATH 8600: 001,0.3,0.57,0.09,0.0,0.0,0.0,0.0,0.04,qingshan chen,
-MATH,8810,1,MATH 8810: 001,0.65,0.25,0.05,0.0,0.0,0.0,0.0,0.05,christopher mcmahan,
-MATH,9830,1,Sel Top in Computational Math,0.57,0.14,0.29,0.0,0.0,0.0,0.0,0.0,timo johann heister,
-MBA,8030,1,MBA 8030: 001,0.53,0.45,0.0,0.0,0.0,0.0,0.0,0.03,matthew charl klein,
-MBA,8060,1,MBA 8060: 001,0.52,0.46,0.02,0.0,0.0,0.0,0.0,0.0,gulru fatma ozkan,
-MBA,8070,1,MBA 8070: 001,0.41,0.41,0.12,0.0,0.0,0.0,0.0,0.06,fei xie,
-MBA,8070,2,MBA 8070: 002,0.41,0.48,0.11,0.0,0.0,0.0,0.0,0.0,fei xie,
-MBA,8090,1,Org Beh & Hum Res Mg,0.64,0.34,0.0,0.0,0.02,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8190,1,Intro to Acc and Fin,0.49,0.41,0.08,0.0,0.03,0.0,0.0,0.0,jeffrey mcmillan,
-MBA,8190,2,Intro to Acc and Fin,0.31,0.58,0.12,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,
-MBA,8290,1,Marketing Foundation,0.51,0.45,0.0,0.0,0.02,0.0,0.0,0.02,william kilbourne,
-MBA,8370,1,Legal Environ of Bus,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.08,judson jahn,
-MBA,8450,1,Tech & Innova Mgt,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david orr,
-MBA,8470,1,MBA 8470: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
-MBA,8540,2,MBA 8540: 002,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,sarah martin,
-MBA,8590,1,Mgr Decision Model,0.41,0.34,0.13,0.0,0.09,0.0,0.0,0.03,sara elizabet yoder,
-MBA,8590,2,Mgr Decision Model,0.52,0.35,0.13,0.0,0.0,0.0,0.0,0.0,mark mcknew,
-MBA,8600,1,MBA 8600: 001,0.15,0.5,0.23,0.0,0.04,0.0,0.0,0.08,michael dorsch,
-MBA,8610,1,Information Systems,0.38,0.45,0.15,0.0,0.0,0.0,0.0,0.03,varun grover,
-MBA,8610,2,Information Systems,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MBA,8620,1,Managerial Economics,0.34,0.37,0.14,0.0,0.0,0.0,0.0,0.14,scott templeton,
-MBA,8700,1,MBA 8700: 001,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8720,1,MBA 8720: 001,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,
-MBA,8740,1,Managing Cont Impvmt,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,
-MBA,8750,1,MBA 8750: 001,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8990,1,Advanced Leadership,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.03,kathleen ann kegley,
-ME,2000,1,ME 2000: 001,0.67,0.22,0.04,0.01,0.03,0.0,0.0,0.02,donald beasley,
-ME,2010,1,ME 2010: 001,0.03,0.27,0.23,0.11,0.34,0.0,0.0,0.03,sherrill biggers,
-ME,2010,2,ME 2010: 002,0.15,0.25,0.19,0.08,0.24,0.0,0.0,0.08,kalyan chakr katuri,
-ME,2020,1,ME 2020: 001,0.42,0.4,0.11,0.03,0.03,0.0,0.0,0.01,lonny thompson,
-ME,2020,2,ME 2020: 002,0.58,0.3,0.08,0.0,0.03,0.0,0.0,0.02,paul jeffrey meyer,
-ME,2030,1,ME 2030: 001,0.18,0.27,0.33,0.14,0.06,0.0,0.0,0.02,xiangchun xuan,
-ME,2030,2,ME 2030: 002,0.54,0.33,0.11,0.01,0.01,0.0,0.0,0.01,david zumbrunnen,
-ME,2030,3,ME 2030: 003,0.08,0.27,0.31,0.1,0.07,0.0,0.0,0.17,donald beasley,
-ME,2220,1,ME 2220: 001,0.35,0.41,0.06,0.0,0.06,0.0,0.0,0.12,todd schweisinger,
-ME,2220,2,ME 2220: 002,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,3,ME 2220: 003,0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,4,ME 2220: 004,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,5,ME 2220: 005,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,6,ME 2220: 006,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,7,ME 2220: 007,0.16,0.68,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,8,ME 2220: 008,0.2,0.65,0.15,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3020,1,Mech of Materials,0.2,0.31,0.22,0.11,0.13,0.0,0.0,0.02,paul joseph,
-ME,3020,2,Mech of Materials,0.18,0.3,0.33,0.1,0.08,0.0,0.0,0.02,huijuan zhao,
-ME,3020,3,Mech of Materials(HONORS),0.55,0.18,0.09,0.09,0.09,0.0,0.0,0.0,paul joseph,True
-ME,3030,1,ME 3030: 001,0.12,0.24,0.3,0.14,0.12,0.0,0.0,0.08,john saylor,
-ME,3030,2,ME 3030: 002,0.05,0.41,0.43,0.09,0.0,0.0,0.0,0.02,richard miller,
-ME,3040,1,ME 3040: 001,0.09,0.23,0.26,0.09,0.09,0.0,0.0,0.23,jean-marc delhaye,
-ME,3040,2,ME 3040: 002,0.15,0.27,0.33,0.09,0.11,0.0,0.0,0.05,jay ochterbeck,
-ME,3050,1,ME 3050: 001,0.32,0.28,0.26,0.06,0.08,0.0,0.0,0.0,mohammed fari daqaq,
-ME,3050,2,ME 3050: 002,0.32,0.36,0.16,0.08,0.04,0.0,0.0,0.04,phanin tallapragada,
-ME,3060,1,ME 3060: 001,0.26,0.36,0.25,0.09,0.04,0.0,0.0,0.0,todd schweisinger,
-ME,3060,2,ME 3060: 002,0.19,0.47,0.26,0.05,0.02,0.0,0.0,0.02,paul jeffrey meyer,
-ME,3080,1,Fluid Mechanics,0.1,0.19,0.24,0.29,0.14,0.0,0.0,0.05,jean-marc delhaye,
-ME,3080,2,Fluid Mechanics,0.12,0.33,0.45,0.02,0.06,0.0,0.0,0.02,ilenia battiato,
-ME,3100,1,ME 3100: 001,0.22,0.17,0.33,0.13,0.13,0.0,0.0,0.02,jay ochterbeck,
-ME,3120,1,ME 3120: 001,0.36,0.56,0.08,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-ME,3120,2,ME 3120: 002,0.17,0.66,0.14,0.03,0.0,0.0,0.0,0.0,rod martinez-duarte,
-ME,3330,1,ME 3330: 001,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,todd schweisinger,
-ME,3330,2,ME 3330: 002,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,3,ME 3330: 003,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
-ME,3330,5,ME 3330: 005,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,6,ME 3330: 006,0.36,0.57,0.0,0.0,0.07,0.0,0.0,0.0,todd schweisinger,
-ME,3330,7,ME 3330: 007,0.07,0.8,0.07,0.07,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4010,1,ME 4010: 001,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,joshua summers,
-ME,4020,1,ME 4020: 001,0.38,0.44,0.13,0.06,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,2,ME 4020: 002,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,sherrill biggers,
-ME,4020,3,ME 4020: 003,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,5,ME 4020: 005,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,4020,6,ME 4020: 006,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,7,ME 4020: 007,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4030,1,ME 4030: 001,0.21,0.23,0.31,0.13,0.1,0.0,0.0,0.03, timothy freeman,
-ME,4030,2,ME 4030: 002,0.24,0.32,0.34,0.11,0.0,0.0,0.0,0.0,ardalan vahidi,
-ME,4170,1,ME 4170: 001,0.44,0.48,0.07,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4220,1,ME 4220: 001,0.34,0.31,0.24,0.07,0.03,0.0,0.0,0.0,abhijit som,
-ME,4230,1,ME 4230: 001,0.2,0.34,0.37,0.06,0.0,0.0,0.0,0.03,richard figliola,
-ME,4260,1,ME 4260: 001,0.22,0.53,0.25,0.0,0.0,0.0,0.0,0.0,david zumbrunnen,
-ME,4320,1,ME 4320: 001,0.32,0.58,0.03,0.0,0.0,0.0,0.0,0.06,gang li,
-ME,4440,1,ME 4440: 001,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,3,ME 4440: 003,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4710,1,ME 4710: 001,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4930,1,Selected Topics ME (HVAC),0.27,0.43,0.27,0.0,0.0,0.0,0.0,0.03,donald willoughby,
-ME,6220,1,ME 6220: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,
-ME,6710,1,ME 6710: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,8120,1,ME 8120: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
-ME,8190,1,ME 8190: 001,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,
-ME,8200,1,ME 8200: 001,0.52,0.41,0.04,0.0,0.0,0.0,0.0,0.04,yue wang,
-ME,8310,1,ME 8310: 001,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rui qiao,
-ME,8520,1,ME 8520: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gang li,
-ME,8520,2,ME 8520: 002,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,gang li,
-ME,8610,1,ME 8610: 001,0.66,0.29,0.04,0.0,0.0,0.0,0.0,0.02,mica grujicic,
-ME,8730,1,ME 8730: 001,0.27,0.2,0.47,0.0,0.0,0.0,0.0,0.07,joshua summers,
-ME,8930,1,ME 8930: 001,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,nicole gise coutris,
-MGT,2010,1,Principles of Mgt,0.26,0.35,0.25,0.09,0.02,0.0,0.0,0.03,katherine clark,
-MGT,2010,2,Principles of Mgt,0.26,0.32,0.24,0.12,0.04,0.0,0.0,0.02,katherine clark,
-MGT,2010,3,Principles of Mgt,0.15,0.43,0.26,0.05,0.01,0.0,0.0,0.1,katherine clark,
-MGT,2010,4,Principles of Mgt,0.23,0.32,0.28,0.08,0.03,0.0,0.0,0.06,katherine clark,
-MGT,2010,5,Principles of Mgt,0.28,0.39,0.2,0.08,0.02,0.0,0.0,0.02,tina robbins,
-MGT,2010,6,Principles of Mgt,0.14,0.46,0.25,0.12,0.01,0.0,0.0,0.03,tina robbins,
-MGT,2010,7,Principles of Mgt,0.23,0.4,0.24,0.09,0.01,0.0,0.0,0.04,tina robbins,
-MGT,2010,8,Principles of Mgt,0.14,0.44,0.25,0.1,0.02,0.0,0.0,0.05,tina robbins,
-MGT,2010,9,Principles of Mgt(HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
-MGT,2180,125,MGT 2180: 125,0.31,0.44,0.15,0.04,0.01,0.01,0.0,0.04, sridharan,
-MGT,2180,230,MGT 2180: 230,0.28,0.43,0.2,0.03,0.03,0.0,0.0,0.03, sridharan,
-MGT,2180,335,MGT 2180: 335,0.22,0.43,0.23,0.06,0.01,0.0,0.0,0.05, sridharan,
-MGT,2180,905,MGT 2180: 905,0.32,0.49,0.12,0.01,0.02,0.01,0.0,0.03, sridharan,
-MGT,3070,1,Human Resource Management,0.13,0.41,0.38,0.08,0.0,0.0,0.0,0.0,marvin monroe ward,
-MGT,3070,2,Human Resource Management,0.13,0.5,0.33,0.05,0.0,0.0,0.0,0.0,marvin monroe ward,
-MGT,3070,3,Human Resource Management,0.21,0.32,0.39,0.03,0.05,0.0,0.0,0.0,marvin monroe ward,
-MGT,3070,4,Human Resource Management,0.31,0.6,0.06,0.0,0.03,0.0,0.0,0.0,kristin dam scott,
-MGT,3070,5,Human Resource Management,0.24,0.71,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,6,Human Resource Management,0.28,0.58,0.13,0.03,0.0,0.0,0.0,0.0,michael cole,
-MGT,3100,1,Intermed Business Statistics,0.07,0.28,0.26,0.16,0.12,0.0,0.0,0.12,zachary mo leffakis,
-MGT,3100,2,Intermed Business Statistics,0.3,0.3,0.19,0.12,0.05,0.0,0.0,0.05,zachary mo leffakis,
-MGT,3100,3,Intermed Business Statistics,0.19,0.33,0.21,0.05,0.02,0.0,0.0,0.19,niratc tungtisanont,
-MGT,3100,4,Intermed Business Statistics,0.23,0.43,0.23,0.03,0.0,0.0,0.0,0.1,james walsh,
-MGT,3100,5,Intermed Business Statistics,0.35,0.43,0.1,0.0,0.08,0.0,0.0,0.05,jerry kermi bilbrey,
-MGT,3100,6,Intermed Business Statistics,0.3,0.48,0.2,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3100,7,Intermed Business Statistics,0.14,0.26,0.07,0.11,0.11,0.0,0.0,0.3,sara elizabet yoder,
-MGT,3100,8,Intermed Business Statistics,0.11,0.26,0.22,0.18,0.03,0.0,0.0,0.2,sara elizabet yoder,
-MGT,3100,10,Intermed Business Statistics,0.21,0.31,0.28,0.14,0.03,0.0,0.0,0.03,lianlian jiang,
-MGT,3100,11,Intermed Business Statistics,0.33,0.38,0.1,0.08,0.05,0.0,0.0,0.05,kevin mckenzie,
-MGT,3120,1,Decision Models for Mgt,0.27,0.3,0.24,0.08,0.08,0.0,0.0,0.03,mark mcknew,
-MGT,3120,2,Decision Models for Mgt,0.48,0.29,0.12,0.02,0.1,0.0,0.0,0.0,mark mcknew,
-MGT,3120,3,Decision Models for Mgt,0.29,0.24,0.34,0.02,0.1,0.0,0.0,0.0,mark mcknew,
-MGT,3150,1,New Venture Creation,0.21,0.33,0.42,0.0,0.03,0.0,0.0,0.0,peter gianiodis,
-MGT,3170,1,Logistics Mgmt,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,shouqiang wang,
-MGT,3180,1,Mgt of Info Systems,0.35,0.38,0.25,0.0,0.0,0.0,0.0,0.03,heshan sun,
-MGT,3180,2,Mgt of Info Systems,0.43,0.5,0.05,0.0,0.0,0.0,0.0,0.03,dan jiang,
-MGT,3180,3,Mgt of Info Systems,0.22,0.39,0.37,0.02,0.0,0.0,0.0,0.0,roopa raman,
-MGT,3180,4,Mgt of Info Systems,0.43,0.48,0.08,0.0,0.03,0.0,0.0,0.0,tina marie esposito,
-MGT,3900,1,Ops Mgt,0.08,0.33,0.28,0.22,0.06,0.0,0.0,0.03,yunsik choi,
-MGT,3900,2,Ops Mgt,0.13,0.43,0.38,0.08,0.0,0.0,0.0,0.0,jerry kermi bilbrey,
-MGT,3900,3,Ops Mgt,0.35,0.35,0.25,0.03,0.03,0.0,0.0,0.0,jerry kermi bilbrey,
-MGT,3900,4,Ops Mgt,0.2,0.39,0.33,0.06,0.02,0.0,0.0,0.0,lawrence fredendall,
-MGT,3900,5,Ops Mgt,0.24,0.49,0.17,0.05,0.05,0.0,0.0,0.0,yann ferrand,
-MGT,4000,1,Mgt of Org Beh,0.25,0.35,0.38,0.03,0.0,0.0,0.0,0.0,philip roth,
-MGT,4000,2,Mgt of Org Beh,0.16,0.62,0.22,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,3,Mgt of Org Beh,0.26,0.59,0.13,0.0,0.0,0.03,0.0,0.0,michael cole,
-MGT,4000,4,Mgt of Org Beh,0.35,0.58,0.08,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MGT,4020,1,Ops Pln and Ctl,0.1,0.48,0.14,0.14,0.14,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4030,1,Bus Intelligence & Analytics,0.26,0.35,0.19,0.03,0.16,0.0,0.0,0.0,siyuan li,
-MGT,4110,1,Project Management,0.32,0.35,0.27,0.0,0.03,0.0,0.0,0.03,russell purvis,
-MGT,4120,1,Supplier Management,0.26,0.54,0.17,0.03,0.0,0.0,0.0,0.0,shouqiang wang,
-MGT,4150,1,Business Strategy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,2,Business Strategy,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,3,Business Strategy,0.78,0.2,0.0,0.0,0.02,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,4,Business Strategy,0.17,0.51,0.32,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,
-MGT,4150,5,Business Strategy,0.09,0.5,0.35,0.04,0.0,0.0,0.0,0.02,jason wayne ridge,
-MGT,4150,6,Business Strategy,0.32,0.49,0.14,0.0,0.05,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,7,Business Strategy,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,8,Business Strategy,0.32,0.48,0.16,0.03,0.0,0.0,0.0,0.0,peter gianiodis,
-MGT,4160,1,Special Topics Hr,0.32,0.61,0.05,0.0,0.03,0.0,0.0,0.0,kristin dam scott,
-MGT,4230,1,Intern Bus Mgt,0.1,0.54,0.28,0.08,0.0,0.0,0.0,0.0,janis miller,
-MGT,4230,2,Intern Bus Mgt,0.08,0.58,0.25,0.03,0.05,0.0,0.0,0.03,janis miller,
-MGT,4230,3,Intern Bus Mgt,0.13,0.26,0.51,0.05,0.05,0.0,0.0,0.0,wayne stewart,
-MGT,4230,4,Intern Bus Mgt,0.1,0.25,0.6,0.05,0.0,0.0,0.0,0.0,wayne stewart,
-MGT,4240,1,Global Supply Chain,0.17,0.6,0.23,0.0,0.0,0.0,0.0,0.0,yann ferrand,
-MGT,4270,1,Managing Improvement,0.11,0.59,0.22,0.07,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4310,1,Emp Rights & Resp,0.16,0.42,0.32,0.05,0.03,0.0,0.0,0.03,marvin monroe ward,
-MGT,4350,1,Pers Interviewing,0.3,0.5,0.18,0.03,0.0,0.0,0.0,0.0,philip roth,
-MGT,4520,1,Business Analysis,0.21,0.43,0.21,0.0,0.07,0.0,0.0,0.07,roopa raman,
-MGT,4550,1,Emerging I T Trends,0.28,0.61,0.06,0.03,0.03,0.0,0.0,0.0,jason thatcher,
-MGT,4560,1,Business Info Mgt,0.21,0.36,0.24,0.06,0.06,0.0,0.0,0.06,siyuan li,
-MGT,8120,1,Supply Chain Mgt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,gulru fatma ozkan,
-MGT,9040,1,MGT 9040: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,heshan sun,
-MHA,7320,400,MHA 7320: 400,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-MICR,3050,1,MICR 3050: 001,0.38,0.4,0.15,0.06,0.01,0.0,0.0,0.0,kristi ja whitehead,
-MICR,3050,2,MICR 3050: 002,0.38,0.4,0.17,0.03,0.0,0.0,0.0,0.03,krista barr rudolph,
-MICR,3050,3,MICR 3050: 003,0.62,0.24,0.09,0.03,0.0,0.0,0.0,0.03,krista barr rudolph,
-MICR,4000,1,Public Health Micro,0.52,0.18,0.25,0.05,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4070,1,Food and Dairy Micro,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,xiuping jiang,
-MICR,4110,1,Pathogenic Bact,0.36,0.44,0.16,0.04,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
-MICR,4120,1,Bacterial Physiology,0.11,0.32,0.23,0.17,0.15,0.0,0.0,0.02,thomas hughes,
-MICR,4130,1,Industrial Micro,0.41,0.5,0.05,0.03,0.0,0.0,0.0,0.02,tzuen-rong je tzeng,
-MICR,4140,1,Basic Immunology,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,charles rice,
-MICR,4170,1,Cancer and Aging,0.57,0.2,0.11,0.06,0.0,0.0,0.0,0.06,yuqing dong,
-MICR,4210,2,MICR 4210: 002,0.57,0.21,0.07,0.14,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
-MICR,4220,1,MICR 4220: 001,0.75,0.15,0.05,0.05,0.0,0.0,0.0,0.0,thomas hughes,
-MICR,4220,2,MICR 4220: 002,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,
-MICR,4220,3,MICR 4220: 003,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,
-MKT,3010,1,Prin of Marketing,0.27,0.55,0.14,0.04,0.0,0.0,0.0,0.0,carter wil mcelveen,
-MKT,3010,2,Prin of Marketing,0.36,0.41,0.18,0.03,0.01,0.0,0.0,0.01,james gaubert,
-MKT,3010,3,Prin of Marketing,0.29,0.4,0.2,0.07,0.03,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,4,Prin of Marketing,0.26,0.5,0.15,0.07,0.01,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,5,Prin of Marketing,0.24,0.41,0.23,0.07,0.02,0.0,0.0,0.03,patricia knowles,
-MKT,3020,1,Consumer Behavior,0.65,0.28,0.04,0.02,0.02,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,2,Consumer Behavior,0.66,0.32,0.02,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,3,Consumer Behavior,0.36,0.44,0.12,0.02,0.04,0.0,0.0,0.02, thyroff fitzwater,
-MKT,3020,4,Consumer Behavior,0.26,0.3,0.24,0.09,0.09,0.0,0.0,0.02, thyroff fitzwater,
-MKT,3210,1,Sports Marketing,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3980,1,Creative Inquiry in Marketing,0.96,0.0,0.02,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,
-MKT,4200,1,Professional Selling,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,2,Professional Selling,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jesse moore,
-MKT,4200,3,Professional Selling,0.5,0.35,0.08,0.0,0.08,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4200,4,Professional Selling,0.75,0.21,0.0,0.04,0.0,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4230,1,Promotional Strategy,0.32,0.38,0.22,0.04,0.0,0.0,0.0,0.04,patricia knowles,
-MKT,4240,1,Sales Management,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4270,1,International Mktg,0.28,0.14,0.38,0.14,0.0,0.0,0.0,0.07,charles duke,
-MKT,4270,2,International Mktg,0.2,0.27,0.5,0.0,0.0,0.0,0.0,0.03,charles duke,
-MKT,4270,3,International Mktg,0.42,0.36,0.15,0.03,0.03,0.0,0.0,0.0,roger gomes,
-MKT,4270,4,International Mktg,0.29,0.47,0.21,0.0,0.0,0.0,0.0,0.03,roger gomes,
-MKT,4270,5,International Mktg,0.21,0.58,0.12,0.09,0.0,0.0,0.0,0.0,roger gomes,
-MKT,4280,1,Services Marketing,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,james gaubert,
-MKT,4310,1,Marketing Research,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,2,Marketing Research,0.35,0.57,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,3,Marketing Research,0.18,0.61,0.18,0.03,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4330,1,Sport Mkt Strategy,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,
-MKT,4430,1,Advertising Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,albert neil cameron,
-MKT,4450,1,Macromarketing,0.56,0.34,0.03,0.0,0.0,0.06,0.0,0.0,william kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.19,0.63,0.19,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,2,Strategic Mktg Mgt,0.18,0.76,0.06,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4500,3,Strategic Mktg Mgt,0.43,0.5,0.03,0.03,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,4500,4,Strategic Mktg Mgt,0.08,0.4,0.44,0.08,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4950,1,Selected Topics,0.28,0.39,0.17,0.06,0.0,0.0,0.0,0.11,peter weathers,
-MKT,8620,1,MKT 8620: 001,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
-MKT,8650,1,MKT 8650: 001,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MKT,8660,1,Professional Selling,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,ryan mullins,
-ML,1020,1,Leadership Fund II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,garry michae hansel,
-ML,1020,2,Leadership Fund II,0.57,0.24,0.1,0.0,0.05,0.0,0.0,0.05,garry michae hansel,
-ML,2020,1,ML 2020: 001,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thierry andre bras,
-ML,2020,2,ML 2020: 002,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,thierry andre bras,
-ML,3020,2,Adv Leadership II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,
-MSE,2100,1,MSE 2100: 001,0.3,0.38,0.24,0.04,0.02,0.0,0.0,0.01,marian kennedy,
-MSE,2100,2,MSE 2100: 002,0.27,0.3,0.27,0.08,0.03,0.0,0.0,0.05,eric skaar,
-MSE,2100,3,MSE 2100: 003,0.42,0.19,0.3,0.03,0.04,0.0,0.0,0.02,julie patric martin,
-MSE,2500,1,MSE 2500: 001,0.68,0.25,0.04,0.0,0.04,0.0,0.0,0.0,deborah lickfield,
-MSE,3260,1,MSE 3260: 001,0.24,0.26,0.36,0.09,0.04,0.0,0.0,0.01,gary lickfield,
-MSE,3280,1,MSE 3280: 001,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,eric skaar,
-MSE,3420,2,MSE 3420: 002,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,rajendra kum bordia,
-MSE,3610,1,MSE 3610: 001,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,marian kennedy,
-MSE,4160,1,MSE 4160: 001,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,eric skaar,
-MSE,4220,1,MSE 4220: 001,0.26,0.52,0.19,0.0,0.0,0.0,0.0,0.04,vincent yves blouin,
-MSE,4330,1,MSE 4330: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,
-MSE,4560,1,MSE 4560: 001,0.25,0.5,0.19,0.0,0.06,0.0,0.0,0.0,gary lickfield,
-MUSC,1120,2,Beg Class Guitar II,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,david stevenson,
-MUSC,1420,2,MUSC 1420: 002,0.6,0.1,0.0,0.0,0.1,0.0,0.0,0.2,dan rash,
-MUSC,1430,2,MUSC 1430: 002,0.7,0.0,0.0,0.0,0.1,0.0,0.0,0.2,dan rash,
-MUSC,1800,1,MUSC 1800: 001,0.25,0.67,0.0,0.0,0.08,0.0,0.0,0.0,hamilton altstatt,
-MUSC,2100,1,Music in West World,0.68,0.13,0.16,0.0,0.0,0.0,0.0,0.03,eric lapin,
-MUSC,2100,2,Music in West World,0.45,0.25,0.25,0.03,0.0,0.0,0.0,0.03,lisa sain odom,
-MUSC,2100,3,Music in West World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,2100,4,Music in West World,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,5,Music in West World,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,6,Music in West World,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,9,Music in West World,0.55,0.39,0.03,0.0,0.0,0.0,0.0,0.03,lea kibler,
-MUSC,3110,1,MUSC 3110: 001,0.57,0.33,0.07,0.03,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,eric lapin,
-MUSC,3170,1,Hist of Country Mus,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3310,1,MUSC 3310: 001,0.86,0.06,0.04,0.0,0.0,0.0,0.0,0.04,timothy ra hurlburt,
-MUSC,3310,2,MUSC 3310: 002,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,
-MUSC,3620,1,Symphonic Band,0.91,0.02,0.04,0.0,0.0,0.0,0.0,0.02,mark spede,
-MUSC,3690,1,Symphony Orchestra,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,
-MUSC,3700,1,Clemson University Singers,0.91,0.04,0.02,0.0,0.02,0.0,0.0,0.02,justin durham,
-MUSC,3710,1,Women's Glee,0.92,0.02,0.03,0.0,0.03,0.0,0.0,0.0,justin durham,
-MUSC,3720,1,Men's Glee,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,david conley,
-MUSC,4160,1,MUSC 4160: 001,0.28,0.36,0.28,0.08,0.0,0.0,0.0,0.0,linda li-bleuel,
-NPL,3010,1,NPL 3010: 001,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,tracy diane lamb,
-NPL,3030,1,NPL 3030: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,wendell price,
-NURS,3030,1,NURS 3030: 001,0.36,0.51,0.1,0.0,0.0,0.0,0.0,0.03,leslie anne  ravan,
-NURS,3030,400,NURS 3030: 400,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,
-NURS,3100,1,NURS 3100: 001,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3110,1,NURS 3110: 001,0.95,0.03,0.0,0.0,0.03,0.0,0.0,0.0,janice garri lanham,
-NURS,3120,1,NURS 3120: 001,0.42,0.55,0.03,0.0,0.0,0.0,0.0,0.0,angela pye,
-NURS,3190,400,NURS 3190: 400,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,kelly jordan smith,
-NURS,3200,1,NURS 3200: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-NURS,3330,1,Health Care Genetics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,
-NURS,3330,400,Health Care Genetics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-NURS,3400,1,NURS 3400: 001,0.21,0.66,0.08,0.03,0.03,0.0,0.0,0.0,catherine si murton,
-NURS,4010,1,NURS 4010: 001,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NURS,4030,1,NURS 4030: 001,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
-NURS,4100,1,NURS 4100: 001,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,
-NURS,4110,1,NURS 4110: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
-NURS,4120,1,NURS 4120: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4150,1,NURS 4150: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jackie gillespie,
-NURS,4250,400,NURS 4250: 400,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
-NURS,4280,1,Senior Honors II (HON),0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,nancy meehan,True
-NURS,8010,400,NURS 8010: 400,0.56,0.36,0.03,0.0,0.0,0.0,0.0,0.05,shirley mae timmons,
-NURS,8080,400,NURS 8080: 400,0.71,0.24,0.02,0.0,0.02,0.0,0.0,0.0,veronica parker,
-NURS,8200,400,NURS 8200: 400,0.2,0.7,0.0,0.0,0.0,0.0,0.0,0.1,heide temples,
-NURS,8210,400,NURS 8210: 400,0.68,0.27,0.0,0.0,0.0,0.0,0.0,0.05,tracy king fasolino,
-NURS,8480,400,NURS 8480: 400,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,bonnie holaday,
-NURS,8850,400,NURS 8850: 400,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.37,0.43,0.12,0.01,0.02,0.0,0.0,0.04,rita haliena,
-NUTR,4250,1,Medica Nutr Thera II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4260,1,NUTR 4260: 001,0.51,0.45,0.04,0.0,0.0,0.0,0.0,0.0,rita haliena,
-NUTR,4550,1,NUTR 4550: 001,0.48,0.39,0.1,0.0,0.03,0.0,0.0,0.0,elliot jesch,
-NUTR,8030,1,NUTR 8030: 001,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,vivian haley-zitlin,
-PA,2010,1,PA 2010: 001,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,ned hosler,
-PA,2800,1,PA 2800: 001,0.38,0.0,0.23,0.0,0.08,0.0,0.0,0.31,kenneth moore,
-PADM,8220,400,PADM 8220: 400,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,mark daniel mellott,
-PADM,8340,400,PADM 8340: 400,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew moorman,
-PADM,8680,400,PADM 8680: 400,0.36,0.57,0.0,0.0,0.07,0.0,0.0,0.0,alfred bundrick,
-PHIL,1010,1,Intro to Phil Prob,0.47,0.35,0.06,0.03,0.03,0.0,0.0,0.06,david stegall,
-PHIL,1010,2,Intro to Phil Prob,0.68,0.18,0.09,0.0,0.0,0.0,0.0,0.06,david stegall,
-PHIL,1010,3,Intro to Phil Prob,0.45,0.36,0.15,0.0,0.03,0.0,0.0,0.0,christopher grau,
-PHIL,1020,1,Intro to Logic,0.73,0.09,0.03,0.03,0.09,0.0,0.0,0.03,michael hal hannen,
-PHIL,1020,2,Intro to Logic,0.68,0.15,0.06,0.0,0.03,0.0,0.0,0.09,michael hal hannen,
-PHIL,1020,3,Intro to Logic,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,4,Intro to Logic,0.28,0.22,0.25,0.0,0.03,0.0,0.0,0.22,cecilea mun,
-PHIL,1020,5,Intro to Logic,0.07,0.43,0.11,0.0,0.04,0.0,0.0,0.36,cecilea mun,
-PHIL,1020,6,Intro to Logic,0.19,0.08,0.0,0.0,0.04,0.0,0.0,0.69,cecilea mun,
-PHIL,1030,1,Intro to Ethics HON,0.63,0.26,0.0,0.05,0.0,0.0,0.0,0.05,stephen satris,True
-PHIL,1030,2,Intro to Ethics,0.57,0.3,0.08,0.0,0.0,0.0,0.0,0.05,david stegall,
-PHIL,1030,3,Intro to Ethics,0.36,0.53,0.03,0.0,0.0,0.0,0.0,0.08,stephen satris,
-PHIL,1030,4,Intro to Ethics,0.38,0.32,0.26,0.03,0.0,0.0,0.0,0.0,jennifer ingle,
-PHIL,1030,5,Intro to Ethics,0.36,0.45,0.06,0.06,0.03,0.0,0.0,0.03,jennifer ingle,
-PHIL,1030,6,Intro to Ethics,0.17,0.53,0.23,0.0,0.0,0.0,0.0,0.07,charles starkey,
-PHIL,3040,1,PHIL 3040: 001,0.54,0.39,0.04,0.0,0.0,0.0,0.0,0.04,michael hal hannen,
-PHIL,3050,1,PHIL 3050: 001,0.29,0.5,0.18,0.0,0.04,0.0,0.0,0.0,todd may,
-PHIL,3150,1,PHIL 3150: 001,0.32,0.32,0.14,0.07,0.07,0.0,0.0,0.07,jennifer ingle,
-PHIL,3160,1,Mod Phil,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,charles starkey,
-PHIL,3200,1,PHIL 3200: 001,0.38,0.5,0.0,0.0,0.08,0.0,0.0,0.04,candice delmas,
-PHIL,3250,1,Phil of Science,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,cecilea mun,
-PHIL,3260,1,Science and Values,0.56,0.32,0.09,0.0,0.0,0.0,0.0,0.03,andrew garnar,
-PHIL,3260,2,Science and Values,0.47,0.26,0.18,0.0,0.03,0.0,0.0,0.06,andrew garnar,
-PHIL,3260,3,Science and Values,0.47,0.44,0.06,0.0,0.03,0.0,0.0,0.0,andrew garnar,
-PHIL,3300,1,PHIL 3300: 001,0.5,0.35,0.08,0.04,0.0,0.0,0.0,0.04,todd may,
-PHIL,3430,1,PHIL 3430: 001,0.33,0.47,0.13,0.0,0.03,0.0,0.0,0.03,candice delmas,
-PHIL,3440,1,Business Ethics,0.83,0.15,0.0,0.0,0.0,0.0,0.0,0.03,david stegall,
-PHIL,3480,1,PHIL 3480: 001,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,christopher grau,
-PHIL,3490,1,Gender and Sexuality,0.45,0.31,0.14,0.03,0.03,0.0,0.0,0.03,jennifer ingle,
-PHIL,3990,1,PHIL 3990: 001,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,kelly smith,
-PHSC,1170,1,Intro Chem & Earth,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics With Cal I,0.12,0.39,0.32,0.08,0.05,0.0,0.0,0.05,lih-sin the,
-PHYS,1220,2,Physics With Cal I,0.21,0.42,0.27,0.07,0.02,0.0,0.0,0.01,lih-sin the,
-PHYS,1220,3,Physics With Cal I,0.3,0.44,0.19,0.02,0.03,0.0,0.0,0.02,lih-sin the,
-PHYS,1220,4,Physics With Cal I,0.2,0.33,0.33,0.05,0.06,0.0,0.0,0.03,jason stratfo brown,
-PHYS,1220,5,Physics With Cal I,0.22,0.39,0.24,0.06,0.05,0.0,0.0,0.04,mark leising,
-PHYS,1220,8,Physics With Cal I HON,0.36,0.31,0.24,0.05,0.02,0.0,0.0,0.02,joan marler,True
-PHYS,1240,1,Physics Lab I,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,2,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,3,Physics Lab I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,4,Physics Lab I,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,5,Physics Lab I,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,6,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,7,Physics Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,8,PHYSICS LAB I,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,9,Physics Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,10,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,11,Physics Lab I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,12,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,13,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,14,Physics Lab I,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,1240,15,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,16,Physics Lab I,0.17,0.61,0.06,0.0,0.0,0.0,0.0,0.17,jerry hester,
-PHYS,1240,17,Physics Lab I,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,18,Physics Lab I,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,19,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,20,Physics Lab I,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,21,Physics Lab I,0.32,0.42,0.0,0.0,0.0,0.0,0.0,0.26,jerry hester,
-PHYS,1240,22,Physics Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,
-PHYS,1240,23,Physics Lab I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,jerry hester,
-PHYS,1240,24,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,25,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,26,Physics Lab I,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,27,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,29,Physics Lab I,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2000,1,PHYS 2000: 001,0.34,0.38,0.26,0.0,0.0,0.0,0.0,0.02,amy liann pope,
-PHYS,2070,1,General Physics I,0.28,0.35,0.19,0.08,0.05,0.0,0.0,0.06,amy liann pope,
-PHYS,2080,1,General Physics II,0.33,0.46,0.13,0.07,0.01,0.0,0.0,0.0,pooja puneet,
-PHYS,2080,2,General Physics II,0.44,0.38,0.13,0.03,0.01,0.0,0.0,0.01,pooja puneet,
-PHYS,2090,1,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,2,Gen Phys Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,3,Gen Phys Lab I,0.33,0.54,0.04,0.08,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,4,Gen Phys Lab I,0.53,0.16,0.21,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,2090,5,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,6,Gen Phys Lab I,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,7,Gen Phys Lab I,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,8,Gen Phys Lab I,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,9,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,10,Gen Phys Lab I,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,1,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,2,Gen Phys Lab II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,3,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,4,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,6,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,7,Gen Phys Lab II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,8,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,9,Gen Phys Lab II,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,10,Gen Phys Lab II,0.54,0.29,0.08,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2100,11,Gen Phys Lab II,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,12,Gen Phys Lab II,0.63,0.21,0.04,0.0,0.04,0.0,0.0,0.08,jerry hester,
-PHYS,2100,13,Gen Phys Lab II,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,14,Gen Phys Lab II,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2100,15,Gen Phys Lab II,0.21,0.67,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,16,Gen Phys Lab II,0.23,0.5,0.18,0.05,0.05,0.0,0.0,0.0,jerry hester,
-PHYS,2210,1,Physics With Cal II,0.3,0.29,0.26,0.09,0.03,0.0,0.0,0.02,jason stratfo brown,
-PHYS,2210,2,Physics With Cal II,0.28,0.39,0.22,0.07,0.03,0.0,0.0,0.03,jason stratfo brown,
-PHYS,2210,3,Physics With Cal II,0.46,0.23,0.08,0.23,0.0,0.0,0.0,0.0,murray daw,
-PHYS,2220,1,Phys With Cal III,0.57,0.3,0.11,0.0,0.03,0.0,0.0,0.0,hye jung kang,
-PHYS,2230,2,Physics Lab II,0.35,0.29,0.29,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,3,Physics Lab II,0.71,0.18,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,
-PHYS,2230,4,Physics Lab II,0.13,0.63,0.13,0.13,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,5,Physics Lab II,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,6,Physics Lab II,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,8,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2240,1,Physics Lab III,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,2240,2,Physics Lab III,0.41,0.53,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2400,1,Phys of Weather ONLINE,0.31,0.29,0.18,0.1,0.04,0.0,0.0,0.08,miguel larsen,
-PHYS,3120,1,PHYS 3120: 001,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,feng ding,
-PHYS,3220,1,Mechanics II,0.27,0.33,0.2,0.13,0.0,0.0,0.0,0.07,john meriwether,
-PHYS,3260,1,Exper Physics II,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,chad sosolik,
-PHYS,3560,1,PHYS 3560: 001,0.58,0.25,0.0,0.08,0.0,0.0,0.0,0.08,chad sosolik,
-PHYS,4410,1,Electromagnetics I,0.27,0.45,0.18,0.0,0.0,0.0,0.0,0.09,endre andras takacs,
-PHYS,4560,1,Quantum Physics II,0.08,0.77,0.15,0.0,0.0,0.0,0.0,0.0,jian he,
-PHYS,4650,1,Thermo and Stat Mech,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,jeremy king,
-PHYS,8150,1,Statistical Therm I,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,jens oberheide,
-PHYS,8410,1,PHYS 8410: 001,0.11,0.72,0.11,0.0,0.0,0.0,0.0,0.06,gerald lehmacher,
-PHYS,9520,1,PHYS 9520: 001,0.06,0.33,0.61,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
-PKSC,1020,1,PKSC 1020: 001,0.19,0.51,0.15,0.13,0.03,0.0,0.0,0.0,heather batt,
-PKSC,2010,1,PKSC 2010: 001,0.19,0.33,0.3,0.12,0.06,0.0,0.0,0.0,heather batt,
-PKSC,2020,1,PKSC 2020: 001,0.53,0.24,0.24,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2040,1,PKSC 2040: 001,0.66,0.16,0.13,0.02,0.02,0.0,0.0,0.02,robert truett moore,
-PKSC,2060,1,PKSC 2060: 001,0.93,0.04,0.0,0.04,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2200,1,PKSC 2200: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,william aaro snyder,
-PKSC,3200,1,PKSC 3200: 001,0.31,0.46,0.1,0.05,0.05,0.0,0.0,0.03,rupert hurley,
-PKSC,3680,1,Pkg and Society,0.13,0.41,0.18,0.1,0.15,0.0,0.0,0.03,heather batt,
-PKSC,4010,1,PKSC 4010: 001,0.45,0.49,0.02,0.0,0.04,0.0,0.0,0.0,anthony lou pometto,
-PKSC,4030,1,PKSC 4030: 001,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4200,1,PKSC 4200: 001,0.7,0.17,0.13,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4300,1,PKSC 4300: 001,0.16,0.67,0.14,0.0,0.02,0.0,0.0,0.02,duncan darby,
-PKSC,4400,1,PKSC 4400: 001,0.29,0.38,0.21,0.03,0.09,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1,Fd & Hc Pkg Systems,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,kay cooksey,
-PKSC,8510,1,Pkg Sci Seminar,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,ronnie thomas,
-PLPA,2130,1,Fungi & Civilization,0.48,0.28,0.11,0.07,0.04,0.0,0.0,0.02,julia loui kerrigan,
-PLPA,6590,1,PLPA 6590: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,
-POSC,1010,1,Amer National Govt,0.13,0.63,0.23,0.0,0.0,0.0,0.0,0.01,joseph earl stewart,
-POSC,1010,2,Amer National Govt,0.07,0.4,0.33,0.13,0.07,0.0,0.0,0.0,adam warber,
-POSC,1020,1,Intro Intl Relations,0.13,0.44,0.28,0.08,0.04,0.0,0.0,0.04,aron geo tannenbaum,
-POSC,1020,2,Intro Intl Relations,0.21,0.26,0.26,0.12,0.07,0.0,0.0,0.08,zeynep taydas,
-POSC,1030,1,Intro to Political Theory,0.38,0.24,0.16,0.11,0.11,0.0,0.0,0.0,brandon turner,
-POSC,1040,1,Intro Compar Pol,0.03,0.39,0.5,0.03,0.0,0.0,0.0,0.06,colin pearce,
-POSC,1040,2,Intro Compar Pol,0.41,0.39,0.11,0.04,0.02,0.0,0.0,0.02,katherine am curtis,
-POSC,1990,1,POSC 1990: 001,0.3,0.1,0.27,0.2,0.13,0.0,0.0,0.0,meredith petersheim,
-POSC,3020,1,State and Loc Gov,0.17,0.63,0.1,0.0,0.07,0.0,0.0,0.03,bruce ransom,
-POSC,3110,1,Model United Nations,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,xiaobo hu,
-POSC,3210,1,Public Admin,0.05,0.38,0.31,0.15,0.1,0.0,0.0,0.0,james woodard,
-POSC,3410,1,Quant Meth in Pol Sc,0.56,0.25,0.13,0.06,0.0,0.0,0.0,0.0,steven vince miller,
-POSC,3610,1,Intl Pol in Crisis,0.21,0.39,0.26,0.05,0.05,0.0,0.0,0.03,vladimir matic,
-POSC,3610,2,Intl Pol in Crisis,0.43,0.23,0.27,0.03,0.0,0.0,0.0,0.03,steven vince miller,
-POSC,3630,1,Us Foreign Policy,0.17,0.45,0.28,0.03,0.03,0.0,0.0,0.03,jeffrey scott peake,
-POSC,3710,1,European Politics,0.43,0.31,0.19,0.05,0.02,0.0,0.0,0.0,katherine am curtis,
-POSC,3750,1,European Integration,0.15,0.54,0.08,0.23,0.0,0.0,0.0,0.0,zeynep taydas,
-POSC,4050,1,American Presidency,0.15,0.46,0.23,0.0,0.08,0.0,0.0,0.08,adam warber,
-POSC,4070,1,Religion and Politic,0.2,0.41,0.28,0.11,0.0,0.0,0.0,0.0,laura olson,
-POSC,4240,1,Federalism and Igr,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,
-POSC,4360,1,Law Courts Politics,0.52,0.31,0.1,0.0,0.02,0.0,0.0,0.05,joseph earl stewart,
-POSC,4370,1,Constitut Law: Rights & Libert,0.34,0.54,0.09,0.03,0.0,0.0,0.0,0.0,daniel frost,
-POSC,4380,1,Constitut Law: Struc of Gov,0.48,0.39,0.09,0.04,0.0,0.0,0.0,0.0,daniel frost,
-POSC,4500,1,Plato to Postmodernism,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,andrew sc bernstein,
-POSC,4530,1,American Political Thought,0.35,0.23,0.15,0.08,0.15,0.0,0.0,0.04,brandon turner,
-POSC,4540,1,Southern Politics,0.04,0.48,0.33,0.07,0.04,0.0,0.0,0.04,james woodard,
-POSC,4570,1,Political Terrorism,0.42,0.29,0.23,0.03,0.0,0.0,0.0,0.03,aron geo tannenbaum,
-POSC,4610,1,Am Diplomacy & Pol,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,vladimir matic,
-POSC,4760,1,Middle East Politics,0.48,0.33,0.05,0.0,0.0,0.0,0.0,0.14,vladimir matic,
-POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.96,0.02,0.02,meredith petersheim,
-POST,8430,1,POST 8430: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,
-PRTM,2000,1,PRTM 2000: 001,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.01,cindy hartman,
-PRTM,2200,1,PRTM 2200: 001,0.19,0.63,0.11,0.04,0.04,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2200,2,PRTM 2200: 002,0.19,0.78,0.04,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2200,3,PRTM 2200: 003,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bernard mwe kitheka,
-PRTM,2200,4,PRTM 2200: 004,0.41,0.48,0.04,0.0,0.0,0.0,0.0,0.07,katherine eli evans,
-PRTM,2200,5,PRTM 2200: 005,0.65,0.23,0.08,0.04,0.0,0.0,0.0,0.0,kellie aman walters,
-PRTM,2200,6,PRTM 2200: 006,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,samuel ogletree,
-PRTM,2200,7,PRTM 2200: 007,0.22,0.48,0.26,0.04,0.0,0.0,0.0,0.0,denise mar anderson,
-PRTM,2410,1,PRTM 2410: 001,0.24,0.47,0.29,0.0,0.0,0.0,0.0,0.0,craig colistra,
-PRTM,2410,2,PRTM 2410: 002,0.42,0.35,0.23,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2600,1,PRTM 2600: 001,0.88,0.09,0.0,0.0,0.03,0.0,0.0,0.0,alison lynne cory,
-PRTM,2650,1,PRTM 2650: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,alison lynne cory,
-PRTM,2700,1,Intro Rec Res Mgt,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,stephen springs,
-PRTM,2810,1,Intro to Golf Mgt,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,2820,1,PRTM 2820: 001,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,2830,1,PRTM 2830: 001,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,2980,3,Creative Inquiry in PRTM II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,toni liechty,
-PRTM,2980,6,Creative Inquiry in PRTM II,0.73,0.07,0.2,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3070,1,PRTM 3070: 001,0.85,0.13,0.03,0.0,0.0,0.0,0.0,0.0,craig goodman,
-PRTM,3260,1,PRTM 3260: 001,0.31,0.44,0.23,0.03,0.0,0.0,0.0,0.0,brandi crowe,
-PRTM,3270,1,PRTM 3270: 001,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3280,1,PRTM 3280: 001,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,alison lynne cory,
-PRTM,3420,1,Intro to Tourism,0.73,0.19,0.0,0.03,0.0,0.0,0.0,0.05,maloud shakona,
-PRTM,3420,2,Intro to Tourism,0.53,0.25,0.19,0.0,0.03,0.0,0.0,0.0,jarrett bachman,
-PRTM,3440,1,PRTM 3440: 001,0.39,0.36,0.21,0.0,0.04,0.0,0.0,0.0,sheila backman,
-PRTM,3440,2,PRTM 3440: 002,0.39,0.35,0.1,0.12,0.04,0.0,0.0,0.0,sheila backman,
-PRTM,3460,1,PRTM 3460: 001,0.13,0.65,0.17,0.04,0.0,0.0,0.0,0.0,gregory phi ramshaw,
-PRTM,3470,1,PRTM 3470: 001,0.34,0.34,0.21,0.1,0.0,0.0,0.0,0.0,gregory phi ramshaw,
-PRTM,3510,1,PRTM 3510: 001,0.2,0.2,0.5,0.1,0.0,0.0,0.0,0.0,daniel mor anderson,
-PRTM,3550,1,PRTM 3550: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,3830,1,PRTM 3830: 001,0.45,0.09,0.45,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,3980,1,Creative Inquiry in PRTM III,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
-PRTM,3980,3,Creative Inquiry in PRTM III,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,
-PRTM,3980,4,Creative Inquiry in PRTM III,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi hughes,
-PRTM,3980,6,Creative Inquiry in PRTM III,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,
-PRTM,3980,9,Creative Inquiry in PRTM III,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,4070,1,PRTM 4070: 001,0.33,0.43,0.24,0.0,0.0,0.0,0.0,0.0,toni liechty,
-PRTM,4210,1,Rec Fin Resc Mgt,0.11,0.49,0.17,0.17,0.06,0.0,0.0,0.0,denise mar anderson,
-PRTM,4220,1,PRTM 4220: 001,0.32,0.54,0.11,0.0,0.0,0.0,0.0,0.04,anna-mar chancellor,
-PRTM,4260,1,PRTM 4260: 001,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,4300,1,World Geog Parks,0.58,0.35,0.06,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
-PRTM,4310,1,Methods Envir Inter,0.43,0.21,0.29,0.07,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,4410,1,PRTM 4410: 001,0.5,0.25,0.1,0.1,0.05,0.0,0.0,0.0,herbert chancellor,
-PRTM,4450,1,PRTM 4450: 001,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jeffery martin,
-PRTM,4470,1,PRTM 4470: 001,0.78,0.17,0.02,0.0,0.0,0.0,0.0,0.02,lauren duffy,
-PRTM,4510,1,PRTM 4510: 001,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,4540,1,Trends in Sport Mgt,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,
-PRTM,4550,1,PRTM 4550: 001,0.28,0.56,0.17,0.0,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,8030,1,PRTM 8030: 001,0.78,0.13,0.0,0.0,0.04,0.0,0.0,0.04,skye arthur-banning,
-PRTM,8110,1,PRTM 8110: 001,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,
-PRTM,8110,2,PRTM 8110: 002,0.65,0.2,0.1,0.0,0.0,0.0,0.0,0.05,jeffrey charl hallo,
-PRTM,8210,1,PRTM 8210: 001,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,denise mar anderson,
-PRTM,8250,1,PRTM 8250: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,toni liechty,
-PSYC,2010,1,Intro to Psychology,0.29,0.38,0.2,0.03,0.03,0.0,0.0,0.07,mary taylor,
-PSYC,2010,2,Intro to Psychology,0.09,0.44,0.36,0.04,0.03,0.0,0.0,0.04,mary taylor,
-PSYC,2010,3,Intro to Psychology (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True
-PSYC,2010,4,Intro to Psychology,0.3,0.25,0.31,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,
-PSYC,2010,5,Intro to Psychology,0.57,0.23,0.09,0.09,0.03,0.0,0.0,0.0,chong hyon pak,
-PSYC,2010,6,Intro to Psychology,0.37,0.31,0.19,0.06,0.04,0.0,0.0,0.03,fred switzer,
-PSYC,2010,7,Intro to Psychology,0.29,0.26,0.2,0.11,0.09,0.0,0.0,0.06,edwin brainerd,
-PSYC,2020,1,PSYC 2020: 001,0.84,0.0,0.11,0.0,0.0,0.0,0.0,0.05,eric mckibben,
-PSYC,2020,2,PSYC 2020: 002,0.79,0.08,0.0,0.04,0.0,0.0,0.0,0.08,eric mckibben,
-PSYC,2020,3,PSYC 2020: 003,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,2020,4,PSYC 2020: 004,0.78,0.04,0.09,0.0,0.04,0.0,0.0,0.04,eric mckibben,
-PSYC,2020,5,PSYC 2020: 005,0.78,0.09,0.09,0.0,0.04,0.0,0.0,0.0,lauren elizab ellis,
-PSYC,2020,6,PSYC 2020: 006,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,james nathan salley,
-PSYC,2020,7,PSYC 2020: 007,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,drew morgan link,
-PSYC,3060,1,Human Sexual Beh,0.67,0.18,0.09,0.03,0.02,0.0,0.0,0.01,bruce michael king,
-PSYC,3090,100,Intro Exp Psych,0.14,0.36,0.29,0.07,0.11,0.0,0.0,0.04,jennifer bai bisson,
-PSYC,3090,200,Intro Exp Psych,0.42,0.3,0.15,0.05,0.05,0.0,0.0,0.01,richard tyrrell,
-PSYC,3090,300,Intro Exp Psych,0.9,0.03,0.07,0.0,0.0,0.0,0.0,0.0,larry alton pace,
-PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimental Psych,0.33,0.39,0.06,0.06,0.11,0.0,0.0,0.06,stephanie whetsel,
-PSYC,3100,300,Advanced Experimental Psych,0.35,0.47,0.06,0.0,0.12,0.0,0.0,0.0,robert campbell,
-PSYC,3100,400,Advanced Experimental Psych,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,larry alton pace,
-PSYC,3100,500,Advanced Experimental Psych,0.47,0.24,0.18,0.0,0.12,0.0,0.0,0.0,thomas britt,
-PSYC,3100,600,Advanced Experimental Psych,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,paul steven merritt,
-PSYC,3100,700,Advanced Experimental Psych,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,3240,1,Physiological Psych,0.37,0.27,0.17,0.08,0.06,0.0,0.0,0.06,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.37,0.24,0.15,0.07,0.1,0.0,0.0,0.07,claudio cantalupo,
-PSYC,3330,1,Cognitive Psych,0.19,0.4,0.24,0.11,0.03,0.0,0.0,0.03,thomas alley,
-PSYC,3340,1,Cognitive Psych Lab,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,thomas alley,
-PSYC,3340,2,Cognitive Psych Lab,0.64,0.07,0.21,0.07,0.0,0.0,0.0,0.0,thomas alley,
-PSYC,3340,3,Cognitive Psych Lab,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,ashley ann sewall,
-PSYC,3400,1,Lifespan Developmental Psych,0.31,0.42,0.14,0.06,0.04,0.0,0.0,0.03,pamela alley,
-PSYC,3520,1,Social Psychology,0.45,0.34,0.14,0.07,0.0,0.0,0.0,0.0,jo anne jorgensen,
-PSYC,3520,2,Social Psychology,0.38,0.38,0.18,0.03,0.0,0.0,0.0,0.03,jo anne jorgensen,
-PSYC,3520,3,Social Psychology (HON),0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
-PSYC,3640,1,Industrial Psych,0.24,0.46,0.26,0.01,0.01,0.0,0.0,0.01,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.56,0.24,0.17,0.01,0.0,0.0,0.0,0.01,skye gillispie,
-PSYC,3700,1,Personality,0.4,0.46,0.13,0.01,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,3830,1,Abnormal Psychology,0.34,0.31,0.26,0.0,0.06,0.0,0.0,0.03,pamela alley,
-PSYC,3830,2,Abnormal Psychology,0.26,0.26,0.26,0.15,0.0,0.0,0.0,0.06,pamela alley,
-PSYC,3830,3,Abnormal Psychology,0.17,0.46,0.28,0.04,0.03,0.0,0.0,0.01,heidi marie zinzow,
-PSYC,4080,1,Women and Psychology,0.44,0.32,0.16,0.04,0.04,0.0,0.0,0.0,robin mari kowalski,
-PSYC,4150,1,Systems and Theories,0.3,0.37,0.2,0.07,0.03,0.0,0.0,0.03,edwin brainerd,
-PSYC,4150,2,Systems and Theories,0.26,0.33,0.22,0.07,0.07,0.0,0.0,0.07,edwin brainerd,
-PSYC,4220,1,Perception,0.21,0.31,0.31,0.03,0.1,0.0,0.0,0.03,claudio cantalupo,
-PSYC,4220,2,Perception,0.29,0.26,0.29,0.13,0.03,0.0,0.0,0.0,christopher pagano,
-PSYC,4750,1,Brain and Behavior,0.5,0.28,0.11,0.0,0.0,0.0,0.0,0.11,june pilcher,
-PSYC,4800,1,Health Psychology,0.68,0.2,0.04,0.0,0.0,0.0,0.0,0.08,june pilcher,
-PSYC,4800,2,Health Psychology,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,james mccubbin,
-PSYC,4800,3,Health Psychology,0.64,0.28,0.04,0.0,0.04,0.0,0.0,0.0,james mccubbin,
-PSYC,4820,1,Positive Psychology,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,cynthia pury,
-PSYC,4890,1,Teamwork in the 21st Century,0.83,0.04,0.04,0.0,0.0,0.0,0.0,0.09,marissa leig porter,
-PSYC,4890,4,Teamwork in the 21st Century,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,marissa leig porter,
-PSYC,4920,1,Senior Laboratory,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,allison lei wallace,
-PSYC,4920,2,Senior Laboratory,0.82,0.11,0.07,0.0,0.0,0.0,0.0,0.0,allison lei wallace,
-PSYC,4920,3,Senior Laboratory,0.82,0.11,0.07,0.0,0.0,0.0,0.0,0.0,crystal burn fulmer,
-PSYC,4920,4,Senior Laboratory,0.71,0.17,0.0,0.08,0.04,0.0,0.0,0.0,crystal burn fulmer,
-PSYC,4930,100,Pract Clinical Psych,0.65,0.1,0.05,0.0,0.1,0.0,0.0,0.1,heidi marie zinzow,
-PSYC,8130,1,PSYC 8130: 001,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0, dewayne moore,
-PSYC,8620,1,PSYC 8620: 001,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,robert ray sinclair,
-RED,8010,1,Market Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
-RED,8040,1,Resid Practicum,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
-RED,8050,1,Commercial Practicum,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-RED,8120,1,Real Estate Technology,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
-RED,8130,1,RED 8130: 001,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,
-REL,1010,1,Intro to Religion,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,robert stephens,
-REL,1010,2,Intro to Religion,0.79,0.09,0.03,0.0,0.0,0.0,0.0,0.09,robert stephens,
-REL,1020,1,World Religions,0.32,0.41,0.15,0.06,0.03,0.0,0.0,0.03,peter cohen,
-REL,1020,2,World Religions,0.47,0.34,0.06,0.06,0.0,0.0,0.0,0.06,peter cohen,
-REL,1020,4,World Religions,0.25,0.39,0.28,0.06,0.03,0.0,0.0,0.0,peter cohen,
-REL,1020,5,World Religions,0.77,0.17,0.0,0.0,0.0,0.0,0.0,0.07,robert stephens,
-REL,1020,6,World Religions,0.51,0.34,0.06,0.0,0.0,0.0,0.0,0.09,robert stephens,
-REL,3000,1,REL 3000: 001,0.58,0.24,0.03,0.03,0.03,0.0,0.0,0.09,steven grosby,
-REL,3010,1,Old Testament,0.59,0.21,0.12,0.0,0.0,0.06,0.0,0.03,steven grosby,
-REL,3010,2,Old Testament,0.42,0.56,0.0,0.0,0.0,0.0,0.0,0.03,steven grosby,
-REL,3730,1,Age of Protestant Reformation,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,thomas kuehn,
-RS,3010,1,Rural Sociology,0.37,0.37,0.14,0.09,0.0,0.0,0.0,0.03,kenneth robinson,
-RS,4590,1,The Community,0.64,0.07,0.21,0.0,0.0,0.0,0.0,0.07,kenneth robinson,
-RUSS,1020,1,RUSS 1020: 001,0.27,0.45,0.09,0.0,0.09,0.0,0.0,0.09,joan bridgwood,
-RUSS,2020,1,Intermediate Russ,0.5,0.2,0.1,0.0,0.0,0.0,0.0,0.2,joan bridgwood,
-SOC,2010,1,Intro to Sociology (HON),0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,sarah evely winslow,True
-SOC,2010,2,Introduction to Sociology,0.48,0.36,0.12,0.0,0.01,0.0,0.0,0.02,jennifer le holland,
-SOC,2010,3,Introduction to Sociology,0.45,0.37,0.12,0.02,0.02,0.0,0.0,0.02,jennifer le holland,
-SOC,2010,4,Introduction to Sociology,0.54,0.33,0.06,0.02,0.0,0.0,0.0,0.04,mary louise barr,
-SOC,2010,5,Introduction to Sociology,0.71,0.22,0.04,0.02,0.0,0.0,0.0,0.0,mary louise barr,
-SOC,2010,6,Introduction to Sociology,0.73,0.17,0.06,0.02,0.0,0.0,0.0,0.02,mary louise barr,
-SOC,2010,7,Introduction to Sociology,0.55,0.31,0.14,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,8,Introduction to Sociology,0.38,0.42,0.16,0.01,0.0,0.0,0.0,0.02,mary louise barr,
-SOC,2010,9,Introduction to Sociology,0.51,0.34,0.08,0.01,0.03,0.0,0.0,0.03,jennifer triplett,
-SOC,2010,10,Introduction to Sociology,0.76,0.2,0.02,0.0,0.02,0.0,0.0,0.0,jennifer triplett,
-SOC,2020,1,Social Problems,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,stephani southworth,
-SOC,2020,2,Social Problems,0.48,0.35,0.09,0.04,0.04,0.0,0.0,0.0,stephani southworth,
-SOC,2050,1,SOC 2050: 001,0.72,0.08,0.03,0.08,0.06,0.0,0.0,0.03,brenda vander mey,
-SOC,3020,1,Research Methods I,0.15,0.38,0.42,0.04,0.0,0.0,0.0,0.02,ellen granberg,
-SOC,3040,1,Research Methods II,0.22,0.48,0.22,0.04,0.0,0.0,0.0,0.04,ye luo,
-SOC,3100,1,Marriage & Intimacy,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
-SOC,3100,2,Marriage & Intimacy,0.54,0.35,0.07,0.0,0.0,0.04,0.0,0.0,jeffrey edwards,
-SOC,3110,1,The Family,0.52,0.38,0.06,0.04,0.0,0.0,0.0,0.0,jennifer triplett,
-SOC,3310,1,Urban Sociology,0.27,0.38,0.15,0.04,0.1,0.0,0.0,0.06,stephani southworth,
-SOC,3500,1,Self & Society,0.37,0.45,0.14,0.0,0.02,0.0,0.0,0.02,jennifer triplett,
-SOC,3800,1,Intro Social Service,0.49,0.39,0.06,0.0,0.04,0.0,0.0,0.02,jennifer le holland,
-SOC,3880,1,Criminal Justice,0.45,0.19,0.21,0.09,0.06,0.0,0.0,0.0,william white,
-SOC,3890,1,Criminology,0.28,0.22,0.2,0.17,0.09,0.0,0.0,0.04,william white,
-SOC,3910,1,Soc of Deviance,0.18,0.39,0.27,0.04,0.04,0.0,0.0,0.08,stephani southworth,
-SOC,3920,1,Juvenile Delinquency,0.54,0.25,0.15,0.0,0.02,0.0,0.0,0.04,jeffrey edwards,
-SOC,3970,1,Substance Abuse,0.51,0.36,0.04,0.0,0.04,0.0,0.0,0.04,jeffrey edwards,
-SOC,4040,1,Soc Theory,0.54,0.34,0.07,0.0,0.02,0.0,0.0,0.02,william haller,
-SOC,4330,1,Global Social Change,0.64,0.24,0.04,0.0,0.04,0.0,0.0,0.04,william haller,
-SOC,4440,1,Sociology of Educ,0.25,0.21,0.08,0.08,0.25,0.0,0.0,0.13,stephani southworth,
-SOC,4590,1,The Community,0.39,0.22,0.22,0.0,0.0,0.0,0.0,0.17,kenneth robinson,
-SOC,4600,1,Race & Ethnicity,0.5,0.18,0.29,0.0,0.04,0.0,0.0,0.0,brenda vander mey,
-SOC,4610,1,Sex & Gender,0.22,0.46,0.24,0.09,0.0,0.0,0.0,0.0,sarah evely winslow,
-SOC,4840,1,Child Abuse,0.47,0.26,0.21,0.03,0.0,0.0,0.0,0.03,douglas sturkie,
-SOC,4930,1,Soc of Corrections,0.4,0.33,0.13,0.13,0.0,0.0,0.0,0.0,william white,
-SOC,4970,1,Senior Lab,0.65,0.19,0.0,0.15,0.0,0.0,0.0,0.0,brenda vander mey,
-SOC,4970,2,Senior Lab,0.75,0.0,0.08,0.17,0.0,0.0,0.0,0.0,brenda vander mey,
-SOC,4990,1,Sem- Issues in Cmmty Policity,0.1,0.4,0.5,0.0,0.0,0.0,0.0,0.0,william white,
-SPAN,1010,1,SPAN 1010: 001,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1010,2,SPAN 1010: 002,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1010,3,SPAN 1010: 003,0.21,0.16,0.16,0.21,0.0,0.0,0.0,0.26,samuel palmer moody,
-SPAN,1020,1,SPAN 1020: 001,0.13,0.5,0.19,0.13,0.0,0.0,0.0,0.06,roger simpson,
-SPAN,1020,2,SPAN 1020: 002,0.06,0.12,0.18,0.24,0.18,0.0,0.0,0.24,roger simpson,
-SPAN,1020,3,SPAN 1020: 003,0.33,0.33,0.17,0.11,0.06,0.0,0.0,0.0,roger simpson,
-SPAN,1020,4,SPAN 1020: 004,0.22,0.17,0.28,0.06,0.11,0.0,0.0,0.17,roger simpson,
-SPAN,1020,5,SPAN 1020: 005,0.11,0.26,0.26,0.05,0.16,0.0,0.0,0.16,roger simpson,
-SPAN,1020,6,SPAN 1020: 006,0.0,0.29,0.53,0.12,0.0,0.0,0.0,0.06,cathy robison,
-SPAN,1020,7,SPAN 1020: 007,0.26,0.32,0.26,0.11,0.0,0.0,0.0,0.05,cathy robison,
-SPAN,1020,8,SPAN 1020: 008,0.17,0.28,0.39,0.0,0.06,0.0,0.0,0.11,ricardo tremolada,
-SPAN,1020,9,SPAN 1020: 009,0.24,0.29,0.18,0.06,0.06,0.0,0.0,0.18,ricardo tremolada,
-SPAN,1020,10,SPAN 1020: 010,0.21,0.42,0.26,0.0,0.05,0.0,0.0,0.05,allison ann hinds,
-SPAN,1020,11,SPAN 1020: 011,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,allison ann hinds,
-SPAN,1020,12,SPAN 1020: 012,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1020,14,SPAN 1020: 014,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,scott harris,
-SPAN,2010,1,Intermediate Spanish,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,2,Intermediate Spanish,0.28,0.56,0.11,0.06,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,3,Intermediate Spanish,0.21,0.53,0.11,0.0,0.0,0.0,0.0,0.16,maureen zamora,
-SPAN,2010,4,Intermediate Spanish,0.58,0.16,0.26,0.0,0.0,0.0,0.0,0.0,angeli leal,
-SPAN,2010,5,Intermediate Spanish,0.37,0.42,0.0,0.05,0.11,0.0,0.0,0.05,angeli leal,
-SPAN,2010,6,Intermediate Spanish,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,heidi montes,
-SPAN,2010,7,Intermediate Spanish,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,allison ann hinds,
-SPAN,2010,8,Intermediate Spanish,0.13,0.5,0.13,0.0,0.06,0.0,0.0,0.19,melva margu persico,
-SPAN,2010,9,Intermediate Spanish,0.08,0.58,0.25,0.0,0.08,0.0,0.0,0.0,melva margu persico,
-SPAN,2010,10,Intermediate Spanish,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,11,Intermediate Spanish,0.25,0.31,0.31,0.13,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,12,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,sarah stoll watt,
-SPAN,2010,13,Intermediate Spanish,0.37,0.42,0.11,0.11,0.0,0.0,0.0,0.0,sarah stoll watt,
-SPAN,2010,14,Intermediate Spanish,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,allison ann hinds,
-SPAN,2010,15,Intermediate Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,1,Intermediate Spanish,0.55,0.2,0.25,0.0,0.0,0.0,0.0,0.0,michael greene,
-SPAN,2020,2,Intermediate Spanish,0.53,0.21,0.26,0.0,0.0,0.0,0.0,0.0,michael greene,
-SPAN,2020,3,Intermediate Spanish,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,michael greene,
-SPAN,2020,4,Intermediate Spanish,0.39,0.17,0.39,0.0,0.06,0.0,0.0,0.0,angeli leal,
-SPAN,2020,5,Intermediate Spanish,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,angeli leal,
-SPAN,2020,6,Intermediate Spanish,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,heidi montes,
-SPAN,2020,7,Intermediate Spanish,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,8,Intermediate Spanish,0.29,0.35,0.18,0.06,0.06,0.0,0.0,0.06,melva margu persico,
-SPAN,2020,9,Intermediate Spanish,0.24,0.53,0.18,0.0,0.0,0.0,0.0,0.06,melva margu persico,
-SPAN,2020,10,Intermediate Spanish,0.58,0.16,0.16,0.11,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2020,11,Intermediate Spanish,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,ellory schmucker,
-SPAN,2020,12,Intermediate Spanish,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,sarah stoll watt,
-SPAN,2020,13,Intermediate Spanish,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,sarah stoll watt,
-SPAN,2020,15,Intermediate Spanish,0.53,0.18,0.12,0.12,0.0,0.0,0.0,0.06,ricardo tremolada,
-SPAN,2020,16,Intermediate Spanish,0.21,0.36,0.14,0.07,0.14,0.0,0.0,0.07,juana martin-armas,
-SPAN,2020,17,Intermediate Spanish,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,juana martin-armas,
-SPAN,2020,18,Intermediate Spanish (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,True
-SPAN,3020,1,SPAN 3020: 001,0.39,0.44,0.0,0.0,0.06,0.0,0.0,0.11,juana martin-armas,
-SPAN,3020,2,SPAN 3020: 002,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,juana martin-armas,
-SPAN,3060,1,SPAN 3060: 001,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,3070,1,Hispanic World: Sp,0.71,0.07,0.0,0.0,0.0,0.0,0.0,0.21,raquel anido,
-SPAN,3080,1,Hispanic World: La,0.78,0.0,0.17,0.06,0.0,0.0,0.0,0.0,lisa kristi dewaard,
-SPAN,3080,2,Hispanic World: La,0.58,0.21,0.16,0.0,0.05,0.0,0.0,0.0,lisa kristi dewaard,
-SPAN,3090,1,SPAN 3090: 001,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,lisa kristi dewaard,
-SPAN,3140,1,SPAN 3140: 001,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
-SPAN,4010,1,SPAN 4010: 001,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,raquel anido,
-SPAN,4050,1,SPAN 4050: 001,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,maureen zamora,
-SPAN,4060,1,SPAN 4060: 001,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,
-SPAN,4060,2,SPAN 4060: 002,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,mon rojas-de-massei,
-SPAN,4090,1,SPAN 4090: 001,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
-SPAN,4150,1,SPAN 4150: 001,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,areli moore peralta,
-STAT,2220,1,Statistics in Everyday Life,0.45,0.25,0.19,0.08,0.02,0.0,0.0,0.02,ros martinez-dawson,
-STAT,2220,2,Statistics in Everyday Life,0.5,0.3,0.09,0.09,0.02,0.0,0.0,0.0,ros martinez-dawson,
-STAT,2220,3,Statistics in Everyday Life,0.22,0.34,0.2,0.1,0.1,0.0,0.0,0.05,ran xie,
-STAT,2220,4,Statistics in Everyday Life,0.38,0.29,0.21,0.08,0.04,0.0,0.0,0.0,ran xie,
-STAT,3010,1,Introductory Statistics,0.33,0.22,0.3,0.12,0.0,0.0,0.0,0.03,richard stev dubsky,
-STAT,3010,2,Introductory Statistics,0.47,0.25,0.15,0.03,0.05,0.0,0.0,0.05,richard stev dubsky,
-STAT,3010,3,Introductory Statistics,0.45,0.22,0.21,0.07,0.03,0.0,0.0,0.02,james espey,
-STAT,3010,4,Introductory Statistics,0.53,0.19,0.17,0.08,0.03,0.0,0.0,0.0,ros martinez-dawson,
-STAT,3010,5,Introductory Statistics,0.22,0.25,0.18,0.15,0.17,0.0,0.0,0.03, erwin walker,
-STAT,3010,6,Introductory Statistics,0.35,0.17,0.28,0.1,0.08,0.0,0.0,0.02, erwin walker,
-STAT,3010,7,Introductory Statistics,0.22,0.29,0.22,0.09,0.14,0.0,0.0,0.03,richard stev dubsky,
-STAT,3010,8,Introductory Statistics,0.26,0.34,0.16,0.09,0.14,0.0,0.0,0.02,benjamin sharp,
-STAT,3010,9,Introductory Statistics,0.32,0.3,0.14,0.1,0.11,0.0,0.0,0.03,ellen hepfe breazel,
-STAT,3010,10,Introductory Statistics,0.29,0.25,0.16,0.07,0.16,0.0,0.0,0.07,jun luo,
-STAT,4110,1,STAT 4110: 001,0.43,0.35,0.13,0.04,0.04,0.0,0.0,0.0,james rieck,
-STAT,4110,2,STAT 4110: 002,0.19,0.44,0.19,0.0,0.13,0.0,0.0,0.06,patrick gerard,
-STAT,8010,1,STAT 8010: 001,0.41,0.45,0.1,0.0,0.03,0.0,0.0,0.0,james rieck,
-STAT,8010,2,STAT 8010: 002,0.59,0.35,0.0,0.0,0.03,0.0,0.0,0.03,william bridges,
-STAT,8010,3,STAT 8010: 003,0.53,0.24,0.18,0.0,0.03,0.0,0.0,0.03,jun luo,
-STAT,8020,1,STAT 8020: 001,0.7,0.22,0.0,0.0,0.0,0.0,0.0,0.07,william bridges,
-STAT,8030,1,STAT 8030: 001,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,hoke hill,
-STAT,8040,1,STAT 8040: 001,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-STAT,8420,230,Intro to Statistical Methods,0.15,0.54,0.08,0.0,0.23,0.0,0.0,0.0,julia lynn sharp,
-STS,1010,1,Survey of S T S,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,thomas oberdan,
-STS,1010,2,Survey of S T S,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,
-STS,1010,3,Survey of S T S,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,
-STS,1010,4,Survey of S T S,0.24,0.38,0.18,0.06,0.06,0.0,0.0,0.09,david charles foltz,
-STS,1010,5,Survey of S T S,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.03,michael greene,
-STS,1010,6,Survey of S T S,0.47,0.38,0.09,0.03,0.0,0.0,0.0,0.03,sarah mae cooper,
-STS,1010,7,Survey of S T S,0.48,0.42,0.03,0.03,0.03,0.0,0.0,0.0,thomas oberdan,
-STS,1010,20,Survey of S T S,0.29,0.45,0.21,0.0,0.0,0.0,0.0,0.05,thomas oberdan,
-STS,2150,1,Crit Appr to Tech Revolutions,0.21,0.16,0.58,0.0,0.05,0.0,0.0,0.0,thomas oberdan,
-THEA,2100,1,Theatre Appreciation,0.77,0.19,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,
-THEA,2100,2,Theatre Appreciation,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,2100,3,Theatre Appreciation,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,kerrie kath seymour,
-THEA,2100,4,Theatre Appreciation,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
-THEA,2100,6,Theatre Appreciation,0.53,0.34,0.06,0.0,0.0,0.0,0.0,0.06,jason adkins,
-THEA,2100,8,Theatre Appreciation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
-THEA,3150,1,Theatre History I,0.75,0.1,0.1,0.0,0.05,0.0,0.0,0.0,richard st. peter,
-THEA,3180,1,THEA 3180: 001,0.4,0.35,0.15,0.1,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,3680,1,THEA 3680: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,
-THEA,4670,1,THEA 4670: 001,0.5,0.0,0.1,0.0,0.3,0.0,0.0,0.1,kendra lyne johnson,
-WFB,3010,1,WFB 3010: 001,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3130,1,Conservation Biology,0.3,0.22,0.28,0.16,0.0,0.0,0.0,0.04,shari lyn rodriguez,
-WFB,3130,2,Conservation Biology,0.29,0.16,0.42,0.1,0.03,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3500,1,WFB 3500: 001,0.39,0.45,0.14,0.0,0.0,0.0,0.0,0.02,james davis,
-WFB,3500,2,WFB 3500: 002,0.29,0.32,0.29,0.05,0.05,0.0,0.0,0.0,james davis,
-WFB,4160,1,WFB 4160: 001,0.36,0.32,0.26,0.04,0.02,0.0,0.0,0.0,yoichiro kanno,
-WFB,4300,1,WFB 4300: 001,0.56,0.3,0.05,0.0,0.06,0.0,0.0,0.03,joseph lanham,
-WFB,4400,1,WFB 4400: 001,0.43,0.31,0.09,0.09,0.06,0.0,0.0,0.02,shari lyn rodriguez,
-WFB,4440,1,WFB 4440: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
-WFB,4620,1,Wetland Wildl Biol,0.25,0.41,0.24,0.08,0.01,0.0,0.0,0.01,russell barrett,
-WFB,4760,1,WFB 4760: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph lanham,
-WFB,8610,1,Applied Population Dynamics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katherine mcfadden,
-WS,1030,1,Women Global Perspec,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,
-WS,2300,1,WS 2300: 001,0.69,0.23,0.04,0.0,0.0,0.0,0.0,0.04,saadiqa kumanyika,
-WS,3010,1,Intro Womens Studies,0.7,0.24,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth ros adams,
-WS,3010,2,Intro Womens Studies,0.58,0.37,0.03,0.0,0.03,0.0,0.0,0.0,elizabeth ros adams,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1020,1,Survey of Art & Arch Hist II,0.49,0.38,0.11,0.0,0.01,0.0,0.0,0.01,beth ann lauritis,,AAH-1020,2014
+AAH,2060,1,Art History and Theory II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,,AAH-2060,2014
+AAH,2100,1,Intro to Art and Architecture,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,janet bever leblanc,,AAH-2100,2014
+AAH,2100,2,Intro to Art and Architecture,0.39,0.32,0.21,0.07,0.0,0.0,0.0,0.0,janet bever leblanc,,AAH-2100,2014
+AAH,2100,3,Intro to Art and Architecture,0.33,0.22,0.22,0.07,0.0,0.0,0.0,0.15,janet bever leblanc,,AAH-2100,2014
+AAH,2100,4,Intro to Art and Architecture,0.24,0.38,0.21,0.03,0.0,0.0,0.0,0.14,janet bever leblanc,,AAH-2100,2014
+ACCT,2010,1,Financial Accounting Concepts,0.14,0.32,0.26,0.08,0.08,0.0,0.0,0.12,suzanne pearse,,ACCT-2010,2014
+ACCT,2010,2,Financial Accounting Concepts,0.08,0.25,0.35,0.15,0.1,0.0,0.0,0.08,henry anderson,,ACCT-2010,2014
+ACCT,2010,3,Financial Accounting Concepts,0.15,0.24,0.33,0.11,0.02,0.0,0.0,0.15,suzanne pearse,,ACCT-2010,2014
+ACCT,2010,4,Financial Accounting Concepts,0.2,0.34,0.18,0.09,0.05,0.0,0.0,0.14,the estate  guffey,,ACCT-2010,2014
+ACCT,2010,5,Financial Accounting Concepts,0.09,0.26,0.33,0.02,0.16,0.0,0.0,0.14,henry anderson,,ACCT-2010,2014
+ACCT,2010,6,Financial Accounting Concepts,0.17,0.26,0.28,0.09,0.11,0.0,0.0,0.11,suzanne pearse,,ACCT-2010,2014
+ACCT,2010,7,Financial Accounting Concepts,0.23,0.23,0.32,0.11,0.04,0.0,0.0,0.06,suzanne pearse,,ACCT-2010,2014
+ACCT,2010,8,Financial Accounting Concepts,0.11,0.24,0.2,0.04,0.2,0.0,0.0,0.2,henry anderson,,ACCT-2010,2014
+ACCT,2010,9,Financial Accounting Concepts,0.07,0.34,0.23,0.14,0.07,0.0,0.0,0.16,the estate  guffey,,ACCT-2010,2014
+ACCT,2010,10,Financial Accounting Concepts,0.13,0.38,0.18,0.11,0.04,0.0,0.0,0.16,the estate  guffey,,ACCT-2010,2014
+ACCT,2010,11,Financial Accounting Concepts,0.12,0.27,0.29,0.11,0.09,0.0,0.0,0.12,jeffrey mcmillan,,ACCT-2010,2014
+ACCT,2020,1,Managerial Accounting Concepts,0.25,0.4,0.17,0.1,0.06,0.0,0.0,0.02,annieka philo,,ACCT-2020,2014
+ACCT,2020,2,Managerial Accounting Concepts,0.29,0.38,0.25,0.04,0.02,0.0,0.0,0.02,annieka philo,,ACCT-2020,2014
+ACCT,2020,3,Managerial Accounting Concepts,0.23,0.29,0.31,0.06,0.08,0.0,0.0,0.02,annieka philo,,ACCT-2020,2014
+ACCT,2020,4,Managerial Accounting Concepts,0.31,0.37,0.14,0.1,0.08,0.0,0.0,0.0,annieka philo,,ACCT-2020,2014
+ACCT,2020,5,Managerial Accounting Concepts,0.27,0.29,0.16,0.02,0.03,0.0,0.0,0.23,henry anderson,,ACCT-2020,2014
+ACCT,2020,6,Managerial Accounting Concepts,0.18,0.19,0.19,0.09,0.05,0.0,0.0,0.3,henry anderson,,ACCT-2020,2014
+ACCT,2040,1,ACCT 2040: 001,0.53,0.29,0.08,0.03,0.06,0.0,0.0,0.01,jeffrey mcmillan,,ACCT-2040,2014
+ACCT,2040,2,ACCT 2040: 002,0.37,0.36,0.11,0.04,0.06,0.0,0.0,0.07,jeffrey mcmillan,,ACCT-2040,2014
+ACCT,3030,1,Cost Accounting,0.26,0.37,0.2,0.03,0.06,0.0,0.0,0.09,derek dalton,,ACCT-3030,2014
+ACCT,3030,2,Cost Accounting,0.17,0.4,0.31,0.11,0.0,0.0,0.0,0.0,derek dalton,,ACCT-3030,2014
+ACCT,3030,3,Cost Accounting,0.18,0.63,0.05,0.03,0.08,0.0,0.0,0.03,robin radtke,,ACCT-3030,2014
+ACCT,3030,4,Cost Accounting,0.31,0.49,0.1,0.03,0.08,0.0,0.0,0.0,robin radtke,,ACCT-3030,2014
+ACCT,3110,1,Intermed Financial Acct I,0.22,0.41,0.3,0.07,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3110,2014
+ACCT,3110,2,Intermed Financial Acct I,0.52,0.36,0.07,0.02,0.02,0.0,0.0,0.0,terry daniel knause,,ACCT-3110,2014
+ACCT,3110,3,Intermed Financial Acct I,0.55,0.24,0.19,0.0,0.0,0.0,0.0,0.02,terry daniel knause,,ACCT-3110,2014
+ACCT,3110,4,Intermed Financial Acct I,0.59,0.24,0.1,0.0,0.02,0.0,0.0,0.05,terry daniel knause,,ACCT-3110,2014
+ACCT,3120,1,Intermed Financial Acct II,0.18,0.54,0.15,0.1,0.03,0.0,0.0,0.0, russell madray,,ACCT-3120,2014
+ACCT,3120,2,Intermed Financial Acct II,0.3,0.46,0.19,0.03,0.0,0.0,0.0,0.03, russell madray,,ACCT-3120,2014
+ACCT,3120,3,Intermed Financial Acct II,0.15,0.21,0.36,0.06,0.0,0.0,0.0,0.21,lydia lan schleifer,,ACCT-3120,2014
+ACCT,3120,4,Intermed Financial Acct II,0.15,0.36,0.3,0.0,0.12,0.0,0.0,0.06,lydia lan schleifer,,ACCT-3120,2014
+ACCT,3130,1,Intermed Financial Acct III,0.17,0.46,0.23,0.11,0.0,0.0,0.0,0.03, russell madray,,ACCT-3130,2014
+ACCT,3130,2,Intermed Financial Acct III,0.51,0.22,0.22,0.03,0.03,0.0,0.0,0.0, russell madray,,ACCT-3130,2014
+ACCT,3130,3,Intermed Financial Acct III,0.33,0.19,0.37,0.07,0.04,0.0,0.0,0.0,james irving,,ACCT-3130,2014
+ACCT,3130,4,Intermed Financial Acct III,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,james irving,,ACCT-3130,2014
+ACCT,3220,1,Accounting Information Systems,0.03,0.47,0.26,0.12,0.06,0.0,0.0,0.06,philip maiberger,,ACCT-3220,2014
+ACCT,3220,2,Accounting Information Systems,0.16,0.26,0.35,0.13,0.06,0.0,0.0,0.03,philip maiberger,,ACCT-3220,2014
+ACCT,3220,3,Accounting Information Systems,0.25,0.33,0.25,0.08,0.03,0.0,0.0,0.06,nancy lee harp,,ACCT-3220,2014
+ACCT,4040,1,Individual Taxation,0.3,0.45,0.2,0.05,0.0,0.0,0.0,0.0,john hine,,ACCT-4040,2014
+ACCT,4040,2,Individual Taxation,0.32,0.39,0.24,0.03,0.0,0.0,0.0,0.03,john hine,,ACCT-4040,2014
+ACCT,4080,1,Retire & Estate Plan,0.29,0.38,0.33,0.0,0.0,0.0,0.0,0.0,john hine,,ACCT-4080,2014
+ACCT,4100,1,Budget and Exec Cont,0.46,0.41,0.07,0.05,0.0,0.0,0.0,0.0,frances kennedy,,ACCT-4100,2014
+ACCT,4100,2,Budget and Exec Cont,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,frances kennedy,,ACCT-4100,2014
+ACCT,4150,1,Auditing,0.09,0.31,0.41,0.09,0.06,0.0,0.0,0.03,suzanne pearse,,ACCT-4150,2014
+ACCT,4150,2,Auditing,0.15,0.15,0.35,0.25,0.1,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2014
+ACCT,8520,1,ACCT 8520: 001,0.36,0.61,0.03,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8520,2014
+ACCT,8520,2,ACCT 8520: 002,0.28,0.53,0.17,0.0,0.03,0.0,0.0,0.0,ralph welton,,ACCT-8520,2014
+ACCT,8550,1,ACCT 8550: 001,0.66,0.29,0.03,0.0,0.03,0.0,0.0,0.0,james barnes,,ACCT-8550,2014
+ACCT,8550,2,ACCT 8550: 002,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2014
+ACCT,8710,1,ACCT 8710: 001,0.23,0.71,0.03,0.0,0.03,0.0,0.0,0.0,derek dalton,,ACCT-8710,2014
+ACCT,8710,2,ACCT 8710: 002,0.31,0.66,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2014
+AGED,3550,1,Team and Organiz Leadership,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thomas dobbins,,AGED-3550,2014
+AGED,4150,1,AGED 4150: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,kevin layfield,,AGED-4150,2014
+AGM,2050,1,AGM 2050: 001,0.15,0.42,0.32,0.04,0.0,0.0,0.0,0.08,hunter massey,,AGM-2050,2014
+AGM,2060,1,AGM 2060: 001,0.23,0.55,0.18,0.05,0.0,0.0,0.0,0.0,hunter massey,,AGM-2060,2014
+AGM,2210,1,AGM 2210: 001,0.29,0.46,0.2,0.0,0.06,0.0,0.0,0.0,charles privette,,AGM-2210,2014
+AGM,3030,1,AGM 3030: 001,0.21,0.4,0.33,0.02,0.02,0.0,0.0,0.0,young han,,AGM-3030,2014
+AGM,4020,1,AGM 4020: 001,0.06,0.66,0.26,0.0,0.03,0.0,0.0,0.0,charles privette,,AGM-4020,2014
+AGM,4100,1,AGM 4100: 001,0.38,0.47,0.13,0.03,0.0,0.0,0.0,0.0,hunter massey,,AGM-4100,2014
+AGM,4520,1,AGM 4520: 001,0.21,0.56,0.24,0.0,0.0,0.0,0.0,0.0,kendall kirk,,AGM-4520,2014
+AGM,4720,1,AGM 4720: 001,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,john chastain,,AGM-4720,2014
+AL,3490,400,AL 3490: 400,0.56,0.26,0.19,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2014
+AL,3490,401,AL 3490: 401,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2014
+AL,3490,402,AL 3490: 402,0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2014
+AL,3490,403,AL 3490: 403,0.68,0.25,0.0,0.0,0.07,0.0,0.0,0.0,clyde keith connor,,AL-3490,2014
+AL,3490,404,AL 3490: 404,0.54,0.27,0.08,0.04,0.04,0.0,0.0,0.04,clyde keith connor,,AL-3490,2014
+AL,3490,405,AL 3490: 405,0.8,0.12,0.0,0.04,0.04,0.0,0.0,0.0,edmond fry,,AL-3490,2014
+AL,3500,400,AL 3500: 400,0.19,0.31,0.23,0.12,0.08,0.0,0.0,0.08,michael godfrey,,AL-3500,2014
+AL,3500,401,AL 3500: 401,0.14,0.55,0.05,0.09,0.09,0.0,0.0,0.09,michael godfrey,,AL-3500,2014
+AL,3520,400,AL 3520: 400,0.22,0.22,0.35,0.04,0.0,0.0,0.0,0.17,michael godfrey,,AL-3520,2014
+AL,3530,400,AL 3530: 400,0.12,0.23,0.27,0.27,0.08,0.0,0.0,0.04,isaac sean colbert,,AL-3530,2014
+AL,3530,401,AL 3530: 401,0.13,0.17,0.39,0.22,0.04,0.0,0.0,0.04,isaac sean colbert,,AL-3530,2014
+AL,3600,400,AL 3600: 400,0.46,0.43,0.07,0.0,0.0,0.0,0.0,0.04,clyde keith connor,,AL-3600,2014
+AL,3610,400,AL 3610: 400,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2014
+AL,3610,401,AL 3610: 401,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2014
+AL,3610,402,AL 3610: 402,0.88,0.04,0.04,0.04,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2014
+AL,3620,400,AL 3620: 400,0.08,0.44,0.2,0.16,0.04,0.0,0.0,0.08,natalie anne carter,,AL-3620,2014
+AL,3620,401,AL 3620: 401,0.23,0.23,0.37,0.09,0.03,0.0,0.0,0.06,natalie anne carter,,AL-3620,2014
+AL,3710,400,AL 3710: 400,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,justin hickey,,AL-3710,2014
+AL,3720,400,AL 3720: 400,0.61,0.13,0.04,0.04,0.13,0.0,0.0,0.04,edmond fry,,AL-3720,2014
+AL,3740,400,AL 3740: 400,0.46,0.21,0.29,0.0,0.0,0.0,0.0,0.04,deborah cadorette,,AL-3740,2014
+AL,3750,400,AL 3750: 400,0.74,0.11,0.05,0.0,0.05,0.0,0.0,0.05,deborah cadorette,,AL-3750,2014
+AL,3760,400,AL 3760: 400,0.38,0.14,0.19,0.1,0.19,0.0,0.0,0.0,edmond fry,,AL-3760,2014
+AL,3760,401,AL 3760: 401,0.63,0.11,0.05,0.11,0.05,0.0,0.0,0.05,edmond fry,,AL-3760,2014
+ANTH,2010,1,Intro Anthropology,0.06,0.21,0.41,0.11,0.12,0.0,0.0,0.09,john coggeshall,,ANTH-2010,2014
+ANTH,2010,2,Intro Anthropology,0.24,0.32,0.24,0.11,0.05,0.0,0.0,0.05,melissa vogel,,ANTH-2010,2014
+ANTH,2010,3,Intro Anthropology,0.36,0.32,0.19,0.07,0.03,0.0,0.0,0.03,lisa rapaport,,ANTH-2010,2014
+ANTH,3200,1,North American Indian Cultures,0.18,0.35,0.24,0.0,0.0,0.0,0.0,0.24,john coggeshall,,ANTH-3200,2014
+ANTH,3310,1,Archaeology,0.29,0.5,0.04,0.04,0.04,0.0,0.0,0.08,melissa vogel,,ANTH-3310,2014
+ANTH,3510,1,Biological Anthropology,0.62,0.31,0.0,0.08,0.0,0.0,0.0,0.0,katherine weisensee,,ANTH-3510,2014
+ANTH,4510,1,Biol Variation in Human Pop,0.33,0.33,0.25,0.0,0.0,0.0,0.0,0.08,katherine weisensee,,ANTH-4510,2014
+APEC,2020,1,Agric Economics,0.38,0.28,0.23,0.0,0.07,0.0,0.0,0.05,webb smathers,,APEC-2020,2014
+APEC,2050,1,Agric and Society,0.6,0.38,0.0,0.0,0.0,0.0,0.0,0.02,david wheele hughes,,APEC-2050,2014
+APEC,3080,1,APEC 3080: 001,0.33,0.11,0.3,0.19,0.04,0.0,0.0,0.04,michael vassalos,,APEC-3080,2014
+APEC,3570,1,Nat Resource Econ,0.1,0.36,0.51,0.0,0.0,0.0,0.0,0.03,molly espey,,APEC-3570,2014
+APEC,4120,1,Reg Economic Devel,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david wheele hughes,,APEC-4120,2014
+APEC,4520,1,Agric Policy,0.25,0.55,0.2,0.0,0.0,0.0,0.0,0.0,michael vassalos,,APEC-4520,2014
+APEC,4750,1,Wildlife Economics,0.57,0.1,0.33,0.0,0.0,0.0,0.0,0.0,webb smathers,,APEC-4750,2014
+ARAB,1010,1,ARAB 1010: 001,0.64,0.14,0.0,0.07,0.0,0.0,0.0,0.14,sulafa abou-samra,,ARAB-1010,2014
+ARAB,1020,1,ARAB 1020: 001,0.55,0.09,0.09,0.09,0.0,0.0,0.0,0.18,sulafa abou-samra,,ARAB-1020,2014
+ARCH,1510,3,ARCH 1510: 003,0.38,0.33,0.17,0.04,0.0,0.0,0.0,0.08,sal hambright-belue,,ARCH-1510,2014
+ARCH,1510,4,ARCH 1510: 004,0.23,0.64,0.09,0.0,0.0,0.0,0.0,0.05,sal hambright-belue,,ARCH-1510,2014
+ARCH,2520,1,ARCH 2520: 001,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-2520,2014
+ARCH,2520,3,ARCH 2520: 003,0.33,0.33,0.17,0.0,0.08,0.0,0.0,0.08,criss mills,,ARCH-2520,2014
+ARCH,2520,4,ARCH 2520: 004,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2520,2014
+ARCH,2700,1,ARCH 2700: 001,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,robert john hogan,,ARCH-2700,2014
+ARCH,2700,2,ARCH 2700: 002,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert john hogan,,ARCH-2700,2014
+ARCH,2710,1,ARCH 2710: 001,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,,ARCH-2710,2014
+ARCH,4050,1,ARCH 4050: 001,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,robert bruhns,,ARCH-4050,2014
+ARCH,4520,2,ARCH 4520: 002,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,lynn craig,,ARCH-4520,2014
+ARCH,4520,3,ARCH 4520: 003,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-4520,2014
+ARCH,4990,1,Freehand Drawing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,,ARCH-4990,2014
+ARCH,6050,1,ARCH 6050: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-6050,2014
+ARCH,8110,1,ARCH 8110: 001,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,douglas hecker,,ARCH-8110,2014
+ARCH,8120,1,ARCH 8120: 001,0.21,0.64,0.14,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-8120,2014
+ARCH,8200,1,Bldg Design & Constr,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,ARCH-8200,2014
+ARCH,8420,1,ARCH 8420: 001,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ar montilla navarro,,ARCH-8420,2014
+ARCH,8420,2,ARCH 8420: 002,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,junichi satoh,,ARCH-8420,2014
+ARCH,8520,2,ARCH 8520: 002,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,keith green,,ARCH-8520,2014
+ARCH,8520,5,ARCH 8520: 005,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,nicholas ault,,ARCH-8520,2014
+ARCH,8610,1,ARCH 8610: 001,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,ufuk ersoy,,ARCH-8610,2014
+ARCH,8710,1,ARCH 8710: 001,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,dustin gra albright,,ARCH-8710,2014
+ARCH,8730,1,ARCH 8730: 001,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,,ARCH-8730,2014
+ARCH,8820,1,ARCH 8820: 001,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-8820,2014
+ARCH,8900,1,Directed Studies,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-8900,2014
+ARCH,8920,1,ARCH 8920: 001,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8920,2014
+ARCH,8920,2,ARCH 8920: 002,0.24,0.7,0.06,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-8920,2014
+ARCH,8960,1,A+H Studio: Tectonic,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8960,2014
+ART,1030,1,ART 1030: 001,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,lynette house,,ART-1030,2014
+ART,1060,1,ART 1060: 001,0.68,0.18,0.05,0.0,0.09,0.0,0.0,0.0,carly drew,,ART-1060,2014
+ART,1510,1,ART 1510: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,adrienne lichliter,,ART-1510,2014
+ART,2050,1,ART 2050: 001,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,joel reese murray,,ART-2050,2014
+ART,2070,1,ART 2070: 001,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,todd mcdonald,,ART-2070,2014
+ART,2170,1,ART 2170: 001,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,nina jeanette kawar,,ART-2170,2014
+AS,1100,1,AS 1100: 001,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,stacey dean wiggins,,AS-1100,2014
+AS,4100,1,Nat Sec Policy II,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,steven price jordan,,AS-4100,2014
+ASL,1010,1,ASL 1010: 001,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,joseph paul may,,ASL-1010,2014
+ASL,1010,2,ASL 1010: 002,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,joseph paul may,,ASL-1010,2014
+ASL,1020,1,ASL 1020: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-1020,2014
+ASL,1020,2,ASL 1020: 002,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-1020,2014
+ASL,2010,1,ASL 2010: 001,0.13,0.6,0.07,0.07,0.13,0.0,0.0,0.0,william alton brant,,ASL-2010,2014
+ASL,2010,2,ASL 2010: 002,0.53,0.12,0.35,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-2010,2014
+ASL,2020,1,ASL 2020: 001,0.69,0.13,0.13,0.0,0.06,0.0,0.0,0.0,kim ma misener dunn,,ASL-2020,2014
+ASL,2020,2,ASL 2020: 002,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-2020,2014
+ASL,3050,1,Deaf Studies,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-3050,2014
+ASL,4010,1,ASL 4010: 001,0.36,0.55,0.0,0.0,0.0,0.0,0.0,0.09,stephen fitzmaurice,,ASL-4010,2014
+ASTR,1010,1,Solar System Astr,0.3,0.26,0.16,0.07,0.05,0.0,0.0,0.16,dina drozdov,,ASTR-1010,2014
+ASTR,1020,1,Stellar Astronomy ONLINE,0.31,0.53,0.13,0.0,0.0,0.0,0.0,0.04,phillip flower,,ASTR-1020,2014
+ASTR,1020,2,Stellar Astronomy ONLINE,0.27,0.35,0.27,0.0,0.03,0.0,0.0,0.06,phillip flower,,ASTR-1020,2014
+ASTR,1020,3,Stellar Astronomy ONLINE,0.38,0.42,0.11,0.0,0.02,0.0,0.0,0.07,phillip flower,,ASTR-1020,2014
+ASTR,1030,1,Solar Systm Astr Lab,0.46,0.19,0.19,0.04,0.12,0.0,0.0,0.0,mark leising,,ASTR-1030,2014
+ASTR,1040,1,Stellar Astr Lab,0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,mark leising,,ASTR-1040,2014
+ASTR,1040,3,Stellar Astr Lab,0.39,0.39,0.0,0.0,0.0,0.0,0.0,0.22,mark leising,,ASTR-1040,2014
+ASTR,1040,5,Stellar Astr Lab,0.73,0.18,0.05,0.0,0.0,0.0,0.0,0.05,mark leising,,ASTR-1040,2014
+ASTR,1040,6,Stellar Astr Lab,0.4,0.27,0.0,0.0,0.13,0.0,0.0,0.2,mark leising,,ASTR-1040,2014
+AUD,2850,1,AUD 2850: 001,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-2850,2014
+AUE,8160,1,AUE 8160: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8160,2014
+AUE,8160,2,AUE 8160: 002,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-8160,2014
+AUE,8170,3,AUE 8170: 003,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8170,2014
+AUE,8290,4,AUE 8290: 004,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,timothy rhyne,,AUE-8290,2014
+AUE,8500,6,AUE 8500: 006,0.43,0.46,0.04,0.0,0.0,0.0,0.0,0.07,beshah ayalew,,AUE-8500,2014
+AUE,8550,16,AUE 8550: 016,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8550,2014
+AUE,8660,7,Adv Matl Auto Appl,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,,AUE-8660,2014
+AUE,8690,8,AUE 8690: 008,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8690,2014
+AUE,8770,9,AUE 8770: 009,0.57,0.32,0.07,0.0,0.04,0.0,0.0,0.0,fadi kama abu-farha,,AUE-8770,2014
+AUE,8820,10,AUE 8820: 010,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,,AUE-8820,2014
+AUE,8860,11,AUE 8860: 011,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,,AUE-8860,2014
+AUE,8900,400,AUE 8900: 400,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,,AUE-8900,2014
+AUE,8930,15,Autovation I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,,AUE-8930,2014
+AVS,2000,1,AVS 2000: 001,0.83,0.14,0.02,0.0,0.0,0.0,0.0,0.0,brian bolt,,AVS-2000,2014
+AVS,2050,1,AVS 2050: 001,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,,AVS-2050,2014
+AVS,2060,1,AVS 2060: 001,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-2060,2014
+AVS,2090,1,AVS 2090: 001,0.94,0.01,0.0,0.0,0.01,0.0,0.0,0.03,brian bolt,,AVS-2090,2014
+AVS,2110,1,AVS 2110: 001,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,michelle hall,,AVS-2110,2014
+AVS,3150,1,Animal Welfare,0.22,0.43,0.17,0.13,0.0,0.0,0.0,0.04,peter skewes,,AVS-3150,2014
+AVS,3750,1,Appl Animal Nutr,0.1,0.37,0.29,0.15,0.01,0.0,0.0,0.09,nathan long,,AVS-3750,2014
+AVS,4060,1,AVS 4060: 001,0.88,0.09,0.0,0.0,0.0,0.0,0.0,0.03,glenn birrenkott,,AVS-4060,2014
+AVS,4100,1,AVS 4100: 001,0.15,0.41,0.32,0.09,0.02,0.0,0.0,0.01,peter skewes,,AVS-4100,2014
+AVS,4120,1,Adv Equine Mgmt,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-4120,2014
+AVS,4130,1,AVS 4130: 001,0.35,0.45,0.13,0.01,0.0,0.0,0.0,0.05,michelle hall,,AVS-4130,2014
+AVS,4170,1,AVS 4170: 001,0.38,0.5,0.0,0.04,0.04,0.0,0.0,0.04,kristine lan vernon,,AVS-4170,2014
+AVS,4530,1,Animal Reproduction,0.31,0.52,0.11,0.03,0.01,0.0,0.0,0.01,glenn birrenkott,,AVS-4530,2014
+AVS,4530,400,Animal Reproduction,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-4530,2014
+AVS,6110,1,AVS 6110: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,,AVS-6110,2014
+AVS,8090,1,AVS 8090: 001,0.63,0.13,0.0,0.0,0.0,0.0,0.0,0.25,susan kay duckett,,AVS-8090,2014
+BCHM,3010,1,Molecular Biochem,0.08,0.33,0.26,0.25,0.03,0.0,0.0,0.05,meredith tei morris,,BCHM-3010,2014
+BCHM,3010,2,Molecular Biochem(HON),0.56,0.24,0.12,0.0,0.0,0.0,0.0,0.08,meredith tei morris,True,BCHM-3010,2014
+BCHM,3020,1,BCHM 3020: 001,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,meredith tei morris,,BCHM-3020,2014
+BCHM,3020,2,BCHM 3020: 002,0.56,0.25,0.0,0.06,0.0,0.0,0.0,0.13,meredith tei morris,,BCHM-3020,2014
+BCHM,3020,3,BCHM 3020: 003,0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,meredith tei morris,,BCHM-3020,2014
+BCHM,3050,1,BCHM 3050: 001,0.24,0.22,0.27,0.18,0.04,0.0,0.0,0.04,james morris,,BCHM-3050,2014
+BCHM,4060,1,BCHM 4060: 001,0.46,0.27,0.19,0.03,0.03,0.0,0.0,0.03,ashby burges bodine,,BCHM-4060,2014
+BCHM,4320,1,Bioch of Metabolism,0.79,0.15,0.03,0.0,0.0,0.0,0.0,0.03,kimberly paul,,BCHM-4320,2014
+BCHM,4360,1,Genes to Proteins,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,,BCHM-4360,2014
+BE,2100,1,BE 2100: 001,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,yi zheng,,BE-2100,2014
+BE,3220,1,BE 3220: 001,0.29,0.29,0.32,0.04,0.0,0.0,0.0,0.07,tom owino,,BE-3220,2014
+BE,4120,1,BE 4120: 001,0.3,0.4,0.25,0.0,0.0,0.0,0.0,0.05,caye marie drapcho,,BE-4120,2014
+BE,4210,1,BE 4210: 001,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-4210,2014
+BE,4240,1,BE 4240: 001,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,,BE-4240,2014
+BE,4380,1,BE 4380: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4380,2014
+BIOE,1010,1,BIOE 1010: 001,0.85,0.09,0.05,0.0,0.0,0.0,0.0,0.0,agneta simionescu,,BIOE-1010,2014
+BIOE,2010,1,BIOE 2010: 001,0.28,0.4,0.16,0.04,0.04,0.0,0.0,0.08,charles webb,,BIOE-2010,2014
+BIOE,3020,1,BIOE 3020: 001,0.48,0.42,0.06,0.02,0.02,0.0,0.0,0.0,alexey ale vertegel,,BIOE-3020,2014
+BIOE,3200,1,BIOE 3200: 001,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,,BIOE-3200,2014
+BIOE,3210,1,BIOE 3210: 001,0.42,0.42,0.06,0.03,0.0,0.0,0.0,0.06,sarah harcum,,BIOE-3210,2014
+BIOE,3700,1,BIOE 3700: 001,0.62,0.31,0.02,0.0,0.02,0.0,0.0,0.03,delphine dean,,BIOE-3700,2014
+BIOE,4030,1,BIOE 4030: 001,0.97,0.02,0.0,0.0,0.0,0.0,0.0,0.01,john desjardins,,BIOE-4030,2014
+BIOE,4230,1,BIOE 4230: 001,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,dan simionescu,,BIOE-4230,2014
+BIOE,4310,1,BIOE 4310: 001,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,david kwartowitz,,BIOE-4310,2014
+BIOE,8020,410,BIOE 8020: 410,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,,BIOE-8020,2014
+BIOE,8150,410,BIOE 8150: 410,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,,BIOE-8150,2014
+BIOE,8470,1,BIOE 8470: 001,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,robert latour,,BIOE-8470,2014
+BIOE,8490,1,BIOE 8490: 001,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,ying mei,,BIOE-8490,2014
+BIOE,8500,3,Drug Delivery,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,jeoungsoo lee,,BIOE-8500,2014
+BIOL,1040,1,General Biology II,0.3,0.33,0.24,0.06,0.02,0.0,0.0,0.05,nora espinoza,,BIOL-1040,2014
+BIOL,1040,2,General Biology II,0.18,0.38,0.24,0.12,0.06,0.0,0.0,0.01,kalan ickes,,BIOL-1040,2014
+BIOL,1040,3,General Biology II,0.18,0.22,0.3,0.16,0.08,0.0,0.0,0.08,salvatore sparace,,BIOL-1040,2014
+BIOL,1040,4,General Biology II (HON),0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,nora espinoza,True,BIOL-1040,2014
+BIOL,1060,1,Gen Biology Lab II,0.26,0.26,0.37,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,2,Gen Biology Lab II,0.09,0.45,0.14,0.27,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,3,Gen Biology Lab II,0.16,0.47,0.16,0.16,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,4,Gen Biology Lab II,0.13,0.35,0.39,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,5,Gen Biology Lab II,0.22,0.35,0.09,0.04,0.26,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,6,Gen Biology Lab II,0.13,0.43,0.3,0.09,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,7,Gen Biology Lab II,0.14,0.57,0.1,0.1,0.0,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,8,Gen Biology Lab II,0.0,0.31,0.46,0.15,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,10,Gen Biology Lab II,0.15,0.3,0.4,0.15,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,11,Gen Biology Lab II,0.13,0.5,0.31,0.0,0.0,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,12,Gen Biology Lab II,0.71,0.21,0.0,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,13,Gen Biology Lab II,0.09,0.39,0.3,0.04,0.13,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,14,Gen Biology Lab II,0.17,0.26,0.35,0.09,0.13,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,15,Gen Biology Lab II,0.18,0.36,0.27,0.05,0.09,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,16,Gen Biology Lab II,0.23,0.41,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,17,Gen Biology Lab II,0.13,0.53,0.27,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,18,Gen Biology Lab II,0.24,0.35,0.18,0.18,0.0,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,19,Gen Biology Lab II,0.26,0.53,0.11,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,20,Gen Biology Lab II,0.06,0.56,0.22,0.11,0.06,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,21,Gen Biology Lab II,0.24,0.24,0.29,0.12,0.12,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,22,Gen Biology Lab II,0.13,0.44,0.38,0.0,0.06,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,23,Gen Biology Lab II,0.25,0.5,0.08,0.0,0.17,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,25,Gen Biology Lab II,0.29,0.33,0.19,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,26,Gen Biology Lab II,0.47,0.24,0.12,0.0,0.12,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,27,Gen Biology Lab II,0.25,0.5,0.06,0.13,0.06,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,28,Gen Biology Lab II,0.15,0.45,0.2,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,29,Gen Biology Lab II,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,30,Gen Biology Lab II,0.09,0.59,0.23,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,31,Gen Biology Lab II,0.19,0.52,0.19,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,34,Gen Biology Lab II,0.48,0.24,0.19,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,35,Gen Biology Lab II,0.25,0.58,0.0,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,36,Gen Biology Lab II,0.59,0.24,0.06,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,37,Gen Biology Lab II,0.3,0.35,0.17,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,38,Gen Biology Lab II,0.35,0.3,0.3,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,39,Gen Biology Lab II,0.43,0.3,0.22,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,40,Gen Biology Lab II,0.33,0.33,0.22,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,41,Gen Biology Lab II,0.25,0.31,0.31,0.06,0.06,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,42,Gen Biology Lab II,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,43,Gen Biology Lab II,0.36,0.29,0.14,0.07,0.07,0.0,0.0,0.07,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1060,44,Gen Biology Lab II,0.09,0.36,0.18,0.18,0.09,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2014
+BIOL,1090,1,Intro to Life Sci,0.9,0.07,0.0,0.0,0.02,0.0,0.0,0.0,renea chri hardwick,,BIOL-1090,2014
+BIOL,1110,1,Prin of Biol II,0.32,0.35,0.24,0.03,0.06,0.0,0.0,0.0,dylan dittrich-reed,,BIOL-1110,2014
+BIOL,1110,2,Prin of Biol II,0.3,0.44,0.17,0.07,0.01,0.0,0.0,0.02,robert kosinski,,BIOL-1110,2014
+BIOL,1110,3,Prin of Biol II (HON),0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert kosinski,True,BIOL-1110,2014
+BIOL,1200,1,Biological Inq Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,2,Biological Inq Lab,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14, christine minor,,BIOL-1200,2014
+BIOL,1200,5,Biological Inq Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1200,6,Biological Inq Lab,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2014
+BIOL,1200,12,Biological Inq Lab,0.33,0.56,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2014
+BIOL,1230,1,Keys to Human Biol,0.3,0.28,0.27,0.13,0.01,0.0,0.0,0.0, christine minor,,BIOL-1230,2014
+BIOL,2000,2,Biology in the News,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-2000,2014
+BIOL,2000,3,Biology in the News,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,,BIOL-2000,2014
+BIOL,2000,4,Biology in the News,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,barbara campbell,,BIOL-2000,2014
+BIOL,2000,7,Biology in the News,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,michael sears,,BIOL-2000,2014
+BIOL,2030,1,Human Disease & Soc,0.82,0.11,0.05,0.0,0.03,0.0,0.0,0.0, christine minor,,BIOL-2030,2014
+BIOL,2040,1,"Environ, Energy and Society",0.33,0.39,0.18,0.06,0.03,0.0,0.0,0.03,john jenkins hains,,BIOL-2040,2014
+BIOL,2110,1,Introduction to Toxicology,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,peter van den hurk,,BIOL-2110,2014
+BIOL,2230,1,BIOL 2230: 001,0.37,0.41,0.13,0.04,0.03,0.0,0.0,0.02,john cummings,,BIOL-2230,2014
+BIOL,2230,2,BIOL 2230: 002,0.37,0.39,0.15,0.07,0.01,0.0,0.0,0.02,john cummings,,BIOL-2230,2014
+BIOL,3020,1,Invertebrate Biology,0.07,0.36,0.16,0.18,0.06,0.0,0.0,0.17,juan baeza migueles,,BIOL-3020,2014
+BIOL,3040,1,Biology of Plants,0.11,0.38,0.32,0.12,0.08,0.0,0.0,0.0,robert edwa ballard,,BIOL-3040,2014
+BIOL,3060,1,BIOL 3060: 001,0.24,0.41,0.06,0.24,0.0,0.0,0.0,0.06,juan baeza migueles,,BIOL-3060,2014
+BIOL,3060,2,BIOL 3060: 002,0.15,0.25,0.35,0.05,0.2,0.0,0.0,0.0,juan baeza migueles,,BIOL-3060,2014
+BIOL,3060,3,BIOL 3060: 003,0.22,0.39,0.11,0.0,0.0,0.0,0.0,0.28,juan baeza migueles,,BIOL-3060,2014
+BIOL,3060,4,BIOL 3060: 004,0.16,0.32,0.21,0.11,0.05,0.0,0.0,0.16,juan baeza migueles,,BIOL-3060,2014
+BIOL,3080,1,BIOL 3080: 001,0.11,0.26,0.21,0.16,0.11,0.0,0.0,0.16,robert edwa ballard,,BIOL-3080,2014
+BIOL,3080,2,BIOL 3080: 002,0.22,0.39,0.22,0.11,0.06,0.0,0.0,0.0,robert edwa ballard,,BIOL-3080,2014
+BIOL,3080,3,BIOL 3080: 003,0.28,0.33,0.33,0.06,0.0,0.0,0.0,0.0,robert edwa ballard,,BIOL-3080,2014
+BIOL,3080,4,BIOL 3080: 004,0.19,0.25,0.13,0.06,0.06,0.0,0.0,0.31,robert edwa ballard,,BIOL-3080,2014
+BIOL,3130,1,Conservation Biology,0.35,0.48,0.0,0.09,0.04,0.0,0.0,0.04,shari lyn rodriguez,,BIOL-3130,2014
+BIOL,3130,2,Conservation Biology,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,shari lyn rodriguez,,BIOL-3130,2014
+BIOL,3160,1,BIOL 3160: 001,0.25,0.49,0.18,0.04,0.02,0.0,0.0,0.01,tamara mcnutt-scott,,BIOL-3160,2014
+BIOL,3200,1,BIOL 3200: 001,0.17,0.38,0.24,0.13,0.02,0.0,0.0,0.06,timothy spira,,BIOL-3200,2014
+BIOL,3350,1,BIOL 3350: 001,0.36,0.38,0.13,0.04,0.07,0.0,0.0,0.03,margaret ptacek,,BIOL-3350,2014
+BIOL,4010,1,Plant Physiology,0.13,0.13,0.19,0.35,0.13,0.0,0.0,0.08,douglas bielenberg,,BIOL-4010,2014
+BIOL,4020,1,BIOL 4020: 001,0.31,0.31,0.08,0.0,0.23,0.0,0.0,0.08,douglas bielenberg,,BIOL-4020,2014
+BIOL,4020,2,BIOL 4020: 002,0.43,0.29,0.14,0.07,0.0,0.0,0.0,0.07,douglas bielenberg,,BIOL-4020,2014
+BIOL,4020,3,BIOL 4020: 003,0.31,0.38,0.08,0.15,0.0,0.0,0.0,0.08,douglas bielenberg,,BIOL-4020,2014
+BIOL,4020,4,BIOL 4020: 004,0.33,0.4,0.13,0.07,0.0,0.0,0.0,0.07,douglas bielenberg,,BIOL-4020,2014
+BIOL,4100,1,BIOL 4100: 001,0.37,0.39,0.2,0.02,0.0,0.0,0.0,0.02,john jenkins hains,,BIOL-4100,2014
+BIOL,4140,1,Basic Immunology,0.72,0.22,0.0,0.0,0.02,0.0,0.0,0.04,charles rice,,BIOL-4140,2014
+BIOL,4340,1,BIOL 4340: 001,0.25,0.33,0.42,0.0,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2014
+BIOL,4340,2,BIOL 4340: 002,0.09,0.27,0.27,0.27,0.0,0.0,0.0,0.09,salvatore sparace,,BIOL-4340,2014
+BIOL,4340,3,BIOL 4340: 003,0.08,0.77,0.08,0.0,0.0,0.0,0.0,0.08,salvatore sparace,,BIOL-4340,2014
+BIOL,4340,4,BIOL 4340: 004,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2014
+BIOL,4340,5,BIOL 4340: 005,0.18,0.45,0.27,0.09,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2014
+BIOL,4340,6,BIOL 4340: 006,0.0,0.33,0.5,0.17,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2014
+BIOL,4510,1,Biol Variation in Human Pop,0.25,0.5,0.13,0.0,0.06,0.0,0.0,0.06,katherine weisensee,,BIOL-4510,2014
+BIOL,4610,1,Cell Biology,0.32,0.39,0.18,0.08,0.01,0.0,0.0,0.03,david feliciano,,BIOL-4610,2014
+BIOL,4610,2,Cell Biology (HON),0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,david feliciano,True,BIOL-4610,2014
+BIOL,4620,2,BIOL 4620: 002,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,,BIOL-4620,2014
+BIOL,4620,3,BIOL 4620: 003,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,lesly temesvari,,BIOL-4620,2014
+BIOL,4620,4,BIOL 4620: 004,0.36,0.43,0.14,0.0,0.07,0.0,0.0,0.0,lesly temesvari,,BIOL-4620,2014
+BIOL,4620,7,BIOL 4620: 007,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,lesly temesvari,,BIOL-4620,2014
+BIOL,4620,8,BIOL 4620: 008,0.63,0.25,0.0,0.0,0.06,0.0,0.0,0.06,lesly temesvari,,BIOL-4620,2014
+BIOL,4640,1,BIOL 4640: 001,0.29,0.41,0.24,0.0,0.0,0.0,0.0,0.06,john cummings,,BIOL-4640,2014
+BIOL,4700,1,Behavioral Ecology,0.42,0.41,0.12,0.02,0.01,0.0,0.0,0.03,michael childress,,BIOL-4700,2014
+BIOL,4710,1,BIOL 4710: 001,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,michael childress,,BIOL-4710,2014
+BIOL,4710,2,BIOL 4710: 002,0.55,0.15,0.0,0.1,0.0,0.0,0.0,0.2,michael childress,,BIOL-4710,2014
+BIOL,4710,3,BIOL 4710: 003,0.63,0.21,0.05,0.0,0.0,0.0,0.0,0.11,michael childress,,BIOL-4710,2014
+BIOL,4710,4,BIOL 4710: 004,0.65,0.12,0.12,0.0,0.0,0.0,0.0,0.12,michael childress,,BIOL-4710,2014
+BIOL,4780,1,BIOL 4780: 001,0.47,0.33,0.03,0.07,0.0,0.0,0.0,0.1,jason denton,,BIOL-4780,2014
+BIOL,4930,5,BIOL 4930: 005,0.64,0.14,0.14,0.07,0.0,0.0,0.0,0.0,lisa bain,,BIOL-4930,2014
+BIOL,6010,1,BIOL 6010: 001,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,,BIOL-6010,2014
+BIOL,8450,1,Understanding Vertebrate Biol,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,tamara mcnutt-scott,,BIOL-8450,2014
+BIOL,8470,1,Understanding Microbiology,0.59,0.38,0.0,0.0,0.0,0.0,0.0,0.03,harry kurtz,,BIOL-8470,2014
+BIOL,8710,5,CS Ecological Risk Assess ETOX,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,stephen klaine,,BIOL-8710,2014
+BIOL,8710,6,Proc Ecological Risk Assessmen,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,,BIOL-8710,2014
+BT,2200,1,BT 2200: 001,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,shannon go lawrence,,BT-2200,2014
+BUS,1010,1,BUS 1010: 001,0.16,0.51,0.2,0.09,0.0,0.0,0.0,0.04,lance scott young,,BUS-1010,2014
+BUS,1010,2,BUS 1010: 002,0.1,0.59,0.24,0.03,0.03,0.0,0.0,0.0,michael giebner,,BUS-1010,2014
+BUS,1010,3,BUS 1010: 003,0.12,0.55,0.28,0.02,0.02,0.0,0.0,0.02,lance scott young,,BUS-1010,2014
+BUS,1010,4,BUS 1010: 004,0.0,0.57,0.27,0.03,0.07,0.0,0.0,0.07,michael giebner,,BUS-1010,2014
+BUS,1010,6,BUS 1010: 006,0.15,0.5,0.22,0.03,0.06,0.0,0.0,0.04,michael giebner,,BUS-1010,2014
+CE,2010,1,Statics,0.43,0.2,0.07,0.09,0.07,0.0,0.0,0.14,nighat yasmin,,CE-2010,2014
+CE,2010,2,Statics,0.3,0.25,0.25,0.09,0.02,0.0,0.0,0.09,melissa sternhagen,,CE-2010,2014
+CE,2010,3,Statics,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,,CE-2010,2014
+CE,2010,4,Statics,0.36,0.3,0.2,0.02,0.0,0.0,0.0,0.11,melissa sternhagen,,CE-2010,2014
+CE,2010,5,Statics,0.44,0.21,0.16,0.05,0.07,0.0,0.0,0.07,nighat yasmin,,CE-2010,2014
+CE,2010,6,Statics,0.37,0.37,0.17,0.03,0.0,0.0,0.0,0.06,weichiang pang,,CE-2010,2014
+CE,2010,7,Statics,0.27,0.52,0.09,0.03,0.03,0.0,0.0,0.06,ismail farajpour,,CE-2010,2014
+CE,2060,1,CE 2060: 001,0.22,0.43,0.24,0.04,0.04,0.0,0.0,0.04,bryant nielson,,CE-2060,2014
+CE,2060,2,CE 2060: 002,0.22,0.49,0.16,0.06,0.0,0.0,0.0,0.06,bryant nielson,,CE-2060,2014
+CE,2080,1,CE 2080: 001,0.24,0.36,0.24,0.04,0.04,0.04,0.0,0.04,melissa sternhagen,,CE-2080,2014
+CE,2080,2,CE 2080: 002,0.19,0.34,0.25,0.08,0.03,0.0,0.0,0.1,melissa sternhagen,,CE-2080,2014
+CE,2080,3,CE 2080: 003,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,,CE-2080,2014
+CE,2080,4,CE 2080: 004,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,enamur rahi latifee,,CE-2080,2014
+CE,2550,1,CE 2550: 001,0.32,0.48,0.19,0.01,0.0,0.0,0.0,0.0,wayne sarasua,,CE-2550,2014
+CE,3010,1,CE 3010: 001,0.17,0.17,0.29,0.1,0.17,0.0,0.0,0.12,scott schiff,,CE-3010,2014
+CE,3110,1,CE 3110: 001,0.31,0.31,0.21,0.12,0.04,0.0,0.0,0.01,wayne sarasua,,CE-3110,2014
+CE,3210,1,CE 3210: 001,0.59,0.3,0.09,0.0,0.0,0.0,0.0,0.02,charng-hsein juang,,CE-3210,2014
+CE,3210,2,CE 3210: 002,0.4,0.4,0.08,0.04,0.08,0.0,0.0,0.0,qiushi chen,,CE-3210,2014
+CE,3310,1,CE 3310: 001,0.45,0.29,0.17,0.05,0.02,0.0,0.0,0.02,james burati,,CE-3310,2014
+CE,3410,1,CE 3410: 001,0.54,0.28,0.13,0.01,0.03,0.0,0.0,0.03,firat yener testik,,CE-3410,2014
+CE,3420,1,CE 3420: 001,0.29,0.35,0.18,0.06,0.12,0.0,0.0,0.0,abdul khan,,CE-3420,2014
+CE,3420,2,CE 3420: 002,0.39,0.49,0.1,0.02,0.0,0.0,0.0,0.0,ashok mishra,,CE-3420,2014
+CE,3510,1,CE 3510: 001,0.5,0.33,0.1,0.03,0.0,0.0,0.0,0.05,ami esmaeilpoursaee,,CE-3510,2014
+CE,3520,1,CE 3520: 001,0.31,0.31,0.19,0.1,0.03,0.0,0.0,0.06,yongxi huang,,CE-3520,2014
+CE,3520,2,CE 3520: 002,0.41,0.37,0.13,0.04,0.04,0.0,0.0,0.02,bradley putman,,CE-3520,2014
+CE,3530,1,CE 3530: 001,0.94,0.02,0.03,0.0,0.0,0.0,0.0,0.02,ronald andrus,,CE-3530,2014
+CE,4010,1,CE 4010: 001,0.25,0.41,0.28,0.06,0.0,0.0,0.0,0.0,atamturktur russcher,,CE-4010,2014
+CE,4020,1,CE 4020: 001,0.52,0.25,0.15,0.04,0.01,0.0,0.0,0.01,brandon ross,,CE-4020,2014
+CE,4070,1,CE 4070: 001,0.19,0.35,0.32,0.13,0.0,0.0,0.0,0.0,weichiang pang,,CE-4070,2014
+CE,4110,1,CE 4110: 001,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.07,jennifer ogle,,CE-4110,2014
+CE,4120,1,Urban Transport Plan,0.21,0.45,0.24,0.03,0.03,0.0,0.0,0.03,mashrur chowdhury,,CE-4120,2014
+CE,4210,1,CE 4210: 001,0.26,0.35,0.31,0.07,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-4210,2014
+CE,4340,1,CE 4340: 001,0.62,0.27,0.07,0.04,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4340,2014
+CE,4470,1,CE 4470: 001,0.59,0.22,0.19,0.0,0.0,0.0,0.0,0.0,nigel gregory kaye,,CE-4470,2014
+CE,4590,1,CE 4590: 001,0.48,0.47,0.06,0.0,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2014
+CE,4620,1,CE 4620: 001,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,firat yener testik,,CE-4620,2014
+CE,4910,1,Sustainable Proj Planning 3cr,0.73,0.2,0.05,0.0,0.02,0.0,0.0,0.0,leidy klotz,,CE-4910,2014
+CE,6010,1,CE 6010: 001,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,,CE-6010,2014
+CE,6070,1,CE 6070: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-6070,2014
+CE,8010,1,CE 8010: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-8010,2014
+CE,8030,1,CE 8030: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,scott schiff,,CE-8030,2014
+CE,8050,1,CE 8050: 001,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,bryant nielson,,CE-8050,2014
+CE,8200,1,CE 8200: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-8200,2014
+CE,8280,1,CE 8280: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,,CE-8280,2014
+CE,8530,1,CE 8530: 001,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-8530,2014
+CE,8930,1,Selec Topics in C E,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,,CE-8930,2014
+CH,1010,1,General Chemistry,0.4,0.34,0.17,0.02,0.03,0.0,0.0,0.04,stephe schvaneveldt,,CH-1010,2014
+CH,1010,2,General Chemistry,0.04,0.18,0.26,0.25,0.17,0.0,0.0,0.1,stephanie mccartney,,CH-1010,2014
+CH,1010,3,General Chemistry,0.05,0.21,0.35,0.18,0.19,0.0,0.0,0.03,stephanie mccartney,,CH-1010,2014
+CH,1010,4,General Chemistry,0.13,0.23,0.22,0.17,0.17,0.0,0.0,0.08,dennis taylor,,CH-1010,2014
+CH,1010,400,General Chemistry,0.13,0.28,0.28,0.13,0.15,0.0,0.0,0.03,stephe schvaneveldt,,CH-1010,2014
+CH,1020,1,General Chemistry,0.33,0.32,0.2,0.04,0.06,0.0,0.0,0.05,dennis taylor,,CH-1020,2014
+CH,1020,2,General Chemistry,0.13,0.46,0.26,0.04,0.06,0.0,0.0,0.06,stephanie mccartney,,CH-1020,2014
+CH,1020,3,General Chemistry,0.29,0.34,0.3,0.05,0.01,0.0,0.0,0.01,tania issa houjeiry,,CH-1020,2014
+CH,1020,4,General Chemistry,0.34,0.43,0.13,0.06,0.01,0.0,0.0,0.04,karen an pressprich,,CH-1020,2014
+CH,1020,5,General Chemistry,0.56,0.15,0.3,0.0,0.0,0.0,0.0,0.0,karen an pressprich,,CH-1020,2014
+CH,1020,6,General Chemistry,0.29,0.36,0.25,0.05,0.03,0.0,0.0,0.03,dennis taylor,,CH-1020,2014
+CH,1020,7,General Chemistry,0.2,0.45,0.27,0.04,0.02,0.0,0.0,0.02,kenneth wi rillings,,CH-1020,2014
+CH,1020,8,General Chemistry,0.25,0.43,0.22,0.06,0.0,0.0,0.0,0.05,karen an pressprich,,CH-1020,2014
+CH,1020,9,General Chemistry,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,kenneth wi rillings,,CH-1020,2014
+CH,1020,10,General Chemistry,0.08,0.46,0.23,0.08,0.0,0.0,0.0,0.15,olt geiculescu,,CH-1020,2014
+CH,1020,11,General Chemistry,0.2,0.48,0.2,0.07,0.01,0.0,0.0,0.05,kenneth wi rillings,,CH-1020,2014
+CH,1020,12,General Chemistry,0.32,0.41,0.24,0.02,0.0,0.0,0.0,0.01,kenneth christensen,,CH-1020,2014
+CH,1020,51,General Chemistry (HON),0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True,CH-1020,2014
+CH,1020,52,General Chemistry (HON),0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,shiou-jyh hwu,True,CH-1020,2014
+CH,1050,1,Chem in Context I,0.23,0.49,0.24,0.04,0.0,0.0,0.0,0.0,thomas hickman,,CH-1050,2014
+CH,1060,1,Chem in Context II,0.39,0.53,0.08,0.0,0.0,0.0,0.0,0.0,olt geiculescu,,CH-1060,2014
+CH,1060,2,Chem in Context II,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,olt geiculescu,,CH-1060,2014
+CH,1520,1,CH 1520: 001,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,richard marcus,,CH-1520,2014
+CH,2010,1,CH 2010: 001,0.29,0.19,0.2,0.14,0.08,0.0,0.0,0.08,thomas hickman,,CH-2010,2014
+CH,2011,2,CH 2011: 002,0.76,0.12,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2011,2014
+CH,2011,3,CH 2011: 003,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,sean 'connor,,CH-2011,2014
+CH,2050,1,CH 2050: 001,0.48,0.3,0.18,0.0,0.0,0.0,0.0,0.05,william pennington,,CH-2050,2014
+CH,2230,1,CH 2230: 001,0.34,0.35,0.21,0.02,0.06,0.0,0.0,0.02,jacob schroeder,,CH-2230,2014
+CH,2230,2,CH 2230: 002,0.35,0.41,0.14,0.02,0.03,0.0,0.0,0.05,jacob schroeder,,CH-2230,2014
+CH,2230,3,CH 2230: 003,0.26,0.29,0.24,0.08,0.05,0.0,0.0,0.08,thomas hickman,,CH-2230,2014
+CH,2240,1,CH 2240: 001,0.32,0.47,0.1,0.08,0.02,0.0,0.0,0.01,tania issa houjeiry,,CH-2240,2014
+CH,2240,2,CH 2240: 002,0.23,0.5,0.2,0.08,0.0,0.0,0.0,0.0,tania issa houjeiry,,CH-2240,2014
+CH,2240,3,CH 2240: 003,0.2,0.36,0.27,0.07,0.04,0.0,0.0,0.05,jacob schroeder,,CH-2240,2014
+CH,2240,4,CH 2240: 004,0.26,0.26,0.26,0.14,0.02,0.0,0.0,0.06,rhett smith,,CH-2240,2014
+CH,2240,5,CH 2240: 005,0.32,0.39,0.19,0.06,0.01,0.0,0.0,0.03,modi wetzler,,CH-2240,2014
+CH,2270,2,CH 2270: 002,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,3,CH 2270: 003,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,4,CH 2270: 004,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2014
+CH,2270,7,CH 2270: 007,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2014
+CH,2270,8,CH 2270: 008,0.69,0.25,0.0,0.06,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,9,CH 2270: 009,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2270,10,CH 2270: 010,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,sean 'connor,,CH-2270,2014
+CH,2280,2,CH 2280: 002,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,sean 'connor,,CH-2280,2014
+CH,2280,3,CH 2280: 003,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2014
+CH,2280,4,CH 2280: 004,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2280,2014
+CH,2280,5,CH 2280: 005,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2014
+CH,2280,8,CH 2280: 008,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2014
+CH,2280,13,CH 2280: 013,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2280,2014
+CH,2280,14,CH 2280: 014,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,,CH-2280,2014
+CH,2280,18,CH 2280: 018,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2014
+CH,2280,23,CH 2280: 023,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2014
+CH,2280,29,CH 2280: 029,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2014
+CH,2290,1,CH 2290: 001,0.78,0.06,0.06,0.11,0.0,0.0,0.0,0.0,sean 'connor,,CH-2290,2014
+CH,2290,2,CH 2290: 002,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2290,2014
+CH,3310,1,CH 3310: 001,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,arkady kholodenko,,CH-3310,2014
+CH,3320,1,Physical Chemistry,0.33,0.44,0.18,0.03,0.03,0.0,0.0,0.0,steven stuart,,CH-3320,2014
+CH,3320,2,Physical Chemistry,0.45,0.32,0.14,0.09,0.0,0.0,0.0,0.0,dvora perahia,,CH-3320,2014
+CH,3400,1,CH 3400: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason mcneill,,CH-3400,2014
+CH,3400,2,CH 3400: 002,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason mcneill,,CH-3400,2014
+CH,3600,1,CH 3600: 001,0.34,0.39,0.2,0.07,0.0,0.0,0.0,0.0,brian dominy,,CH-3600,2014
+CH,4110,1,CH 4110: 001,0.1,0.29,0.33,0.1,0.19,0.0,0.0,0.0,george chumanov,,CH-4110,2014
+CH,4120,1,CH 4120: 001,0.27,0.64,0.0,0.0,0.09,0.0,0.0,0.0,jeffrey natha anker,,CH-4120,2014
+CH,4130,1,Chem Aqueous Systems,0.29,0.29,0.36,0.07,0.0,0.0,0.0,0.0,cindy lee,,CH-4130,2014
+CH,4500,1,CH 4500: 001,0.55,0.17,0.24,0.03,0.0,0.0,0.0,0.0,gauta bhattacharyya,,CH-4500,2014
+CH,4520,1,CH 4520: 001,0.86,0.07,0.03,0.03,0.0,0.0,0.0,0.0,richard marcus,,CH-4520,2014
+CH,8180,1,CH 8180: 001,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,stephen creager,,CH-8180,2014
+CH,8220,1,CH 8220: 001,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,daniel whitehead,,CH-8220,2014
+CH,8510,2,CH 8510: 002,0.94,0.0,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey natha anker,,CH-8510,2014
+CH,8600,1,CH 8600: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,,CH-8600,2014
+CHE,1300,1,CHE 1300: 001,0.26,0.42,0.25,0.04,0.0,0.0,0.0,0.04,antho guiseppi-elie,,CHE-1300,2014
+CHE,1300,2,CHE 1300: 002,0.38,0.38,0.17,0.02,0.0,0.0,0.0,0.05,christopher norfolk,,CHE-1300,2014
+CHE,2200,1,CHE 2200: 001,0.14,0.08,0.3,0.22,0.16,0.0,0.0,0.11,mark thies,,CHE-2200,2014
+CHE,2200,2,CHE 2200: 002,0.11,0.23,0.31,0.11,0.14,0.0,0.0,0.09,mark thies,,CHE-2200,2014
+CHE,2300,1,CHE 2300: 001,0.09,0.23,0.3,0.19,0.17,0.0,0.0,0.02,sapna sarupria,,CHE-2300,2014
+CHE,2300,2,CHE 2300: 002,0.15,0.27,0.27,0.15,0.12,0.0,0.0,0.04,sapna sarupria,,CHE-2300,2014
+CHE,3210,1,CHE 3210: 001,0.16,0.22,0.33,0.24,0.04,0.0,0.0,0.02,christophe kitchens,,CHE-3210,2014
+CHE,3300,1,CHE 3300: 001,0.2,0.33,0.29,0.12,0.04,0.0,0.0,0.02,mark alan blenner,,CHE-3300,2014
+CHE,3530,1,CHE 3530: 001,0.14,0.5,0.3,0.07,0.0,0.0,0.0,0.0,mark roberts,,CHE-3530,2014
+CHE,4330,1,CHE 4330: 001,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4330,2014
+CHE,8450,2,E-Storage in Carbon Materials,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark roberts,,CHE-8450,2014
+CHIN,1020,1,CHIN 1020: 001,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,yanhua zhang,,CHIN-1020,2014
+CHIN,2020,1,CHIN 2020: 001,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,yanhua zhang,,CHIN-2020,2014
+COM,1500,1,Intro to Human Com,0.63,0.31,0.02,0.01,0.01,0.0,0.0,0.03,eddie smith,,COM-1500,2014
+COM,1500,2,Intro to Human Com,0.44,0.42,0.07,0.01,0.02,0.0,0.0,0.05,daniel lelan fecher,,COM-1500,2014
+COM,1500,3,Intro to Human Com,0.7,0.21,0.05,0.0,0.01,0.0,0.0,0.03,eddie smith,,COM-1500,2014
+COM,1500,4,Intro to Human Com,0.48,0.39,0.08,0.01,0.02,0.0,0.0,0.02,marianne her glaser,,COM-1500,2014
+COM,1500,5,Intro to Human Com,0.45,0.44,0.05,0.02,0.02,0.0,0.0,0.02,marianne her glaser,,COM-1500,2014
+COM,1500,6,Intro to Human Com,0.45,0.49,0.03,0.01,0.0,0.0,0.0,0.01,daniel lelan fecher,,COM-1500,2014
+COM,2010,1,COMM 2010: 001,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,john steven spinda,,COM-2010,2014
+COM,2010,2,COMM 2010: 002,0.46,0.33,0.17,0.04,0.0,0.0,0.0,0.0,brenden kendall,,COM-2010,2014
+COM,2500,1,Public Speaking,0.44,0.33,0.11,0.0,0.06,0.0,0.0,0.06,brandon boatwright,,COM-2500,2014
+COM,2500,2,Public Speaking,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2014
+COM,2500,3,Public Speaking,0.44,0.33,0.0,0.11,0.06,0.0,0.0,0.06,christop wasilewski,,COM-2500,2014
+COM,2500,4,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2014
+COM,2500,5,Public Speaking,0.58,0.21,0.16,0.0,0.0,0.0,0.0,0.05,brandon boatwright,,COM-2500,2014
+COM,2500,6,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2014
+COM,2500,7,Public Speaking,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2014
+COM,2500,8,Public Speaking,0.4,0.45,0.1,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2014
+COM,2500,9,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2014
+COM,2500,10,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2014
+COM,2500,11,Public Speaking,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2014
+COM,2500,12,Public Speaking,0.42,0.53,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,,COM-2500,2014
+COM,2500,13,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2014
+COM,2500,14,Public Speaking,0.37,0.47,0.05,0.0,0.11,0.0,0.0,0.0,christop wasilewski,,COM-2500,2014
+COM,2500,15,Public Speaking,0.45,0.35,0.15,0.0,0.0,0.0,0.0,0.05,caitlin baker,,COM-2500,2014
+COM,2500,16,Public Speaking,0.75,0.15,0.05,0.05,0.0,0.0,0.0,0.0,the estate  geddes,,COM-2500,2014
+COM,2500,17,Public Speaking,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2014
+COM,2500,18,Public Speaking,0.42,0.37,0.11,0.05,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2014
+COM,2500,19,Public Speaking,0.15,0.45,0.35,0.0,0.05,0.0,0.0,0.0,pauline matthey,,COM-2500,2014
+COM,2500,20,Public Speaking,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2014
+COM,2500,21,Public Speaking,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,,COM-2500,2014
+COM,2500,22,Public Speaking,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,,COM-2500,2014
+COM,2500,23,Public Speaking,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,caitlin baker,,COM-2500,2014
+COM,2500,24,Public Speaking,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,kayla steele payne,,COM-2500,2014
+COM,2500,25,Public Speaking (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kayla steele payne,True,COM-2500,2014
+COM,2500,400,Public Speaking,0.7,0.15,0.05,0.05,0.0,0.0,0.0,0.05,alexis zachar davis,,COM-2500,2014
+COM,2500,401,Public Speaking,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,,COM-2500,2014
+COM,2500,402,Public Speaking,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,,COM-2500,2014
+COM,2500,403,Public Speaking,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,,COM-2500,2014
+COM,2500,500,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2014
+COM,3020,1,COMM 3020: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3020,2014
+COM,3080,1,Pub Comm & Pop Cult,0.55,0.26,0.15,0.02,0.02,0.0,0.0,0.0,chenjerai kumanyika,,COM-3080,2014
+COM,3100,1,COMM 3100: 001,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3100,2014
+COM,3110,1,COMM 3110: 001,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-3110,2014
+COM,3200,1,COMM 3200: 001,0.88,0.04,0.0,0.0,0.04,0.0,0.0,0.04,wanda johnson,,COM-3200,2014
+COM,3260,1,COMM 3260: 001,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,,COM-3260,2014
+COM,3480,1,COMM 3480: 001,0.31,0.44,0.17,0.06,0.0,0.0,0.0,0.02,melinda ra weathers,,COM-3480,2014
+COM,3560,1,COMM 3560: 001,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristie leah byrum,,COM-3560,2014
+COM,3610,1,COMM 3610: 001,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,lindsey dixon,,COM-3610,2014
+COM,3660,1,EP: Advertising & Media,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,william reynolds,,COM-3660,2014
+COM,3660,3,Live Broadcast Production,0.91,0.04,0.0,0.04,0.0,0.0,0.0,0.0,michael rodgers,,COM-3660,2014
+COM,4250,1,COMM 4250: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4250,2014
+COM,4950,1,Senior Capstone Sem,0.67,0.1,0.24,0.0,0.0,0.0,0.0,0.0,chenjerai kumanyika,,COM-4950,2014
+COM,8020,1,COMM 8020: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-8020,2014
+COM,8110,1,COMM 8110: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brenden kendall,,COM-8110,2014
+CPSC,1010,1,Computer Science I,0.28,0.15,0.15,0.08,0.25,0.0,0.0,0.09,catherine hochrine,,CPSC-1010,2014
+CPSC,1010,2,Computer Science I,0.29,0.2,0.16,0.07,0.16,0.0,0.0,0.13,kyla mcmullen,,CPSC-1010,2014
+CPSC,1020,1,Computer Science II,0.38,0.38,0.07,0.04,0.02,0.0,0.0,0.11,catherine hochrine,,CPSC-1020,2014
+CPSC,1020,2,Computer Science II,0.51,0.26,0.09,0.06,0.09,0.0,0.0,0.0,sabarish venka babu,,CPSC-1020,2014
+CPSC,1110,1,CPSC 1110: 001,0.79,0.14,0.03,0.0,0.0,0.0,0.0,0.03,patrick sterling,,CPSC-1110,2014
+CPSC,1110,2,CPSC 1110: 002,0.58,0.15,0.08,0.12,0.0,0.0,0.0,0.08,patrick sterling,,CPSC-1110,2014
+CPSC,1110,3,CPSC 1110: 003,0.47,0.27,0.07,0.03,0.07,0.03,0.0,0.07,patrick sterling,,CPSC-1110,2014
+CPSC,1110,4,CPSC 1110: 004,0.77,0.03,0.03,0.07,0.0,0.0,0.0,0.1,lauren elizab dukes,,CPSC-1110,2014
+CPSC,2070,1,CPSC 2070: 001,0.36,0.32,0.14,0.07,0.09,0.0,0.0,0.02,larry hodges,,CPSC-2070,2014
+CPSC,2070,2,CPSC 2070: 002,0.21,0.15,0.29,0.12,0.09,0.0,0.0,0.15,sandra hedetniemi,,CPSC-2070,2014
+CPSC,2100,1,CPSC 2100: 001,0.26,0.26,0.15,0.15,0.07,0.0,0.0,0.11,rose lowe,,CPSC-2100,2014
+CPSC,2120,1,Algs/Data Structures,0.36,0.29,0.18,0.07,0.07,0.0,0.0,0.04,feng luo,,CPSC-2120,2014
+CPSC,2120,2,Algs/Data Structures,0.41,0.38,0.06,0.06,0.06,0.0,0.0,0.03,raghuveer mohan,,CPSC-2120,2014
+CPSC,2150,1,CPSC 2150: 001,0.19,0.29,0.17,0.17,0.07,0.0,0.0,0.12,catherine hochrine,,CPSC-2150,2014
+CPSC,2150,2,CPSC 2150: 002,0.48,0.3,0.09,0.09,0.03,0.0,0.0,0.0,john yates monteith,,CPSC-2150,2014
+CPSC,2200,1,CPSC 2200: 001,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,patrick sterling,,CPSC-2200,2014
+CPSC,2310,1,CPSC 2310: 001,0.47,0.26,0.1,0.06,0.06,0.0,0.0,0.04,rose lowe,,CPSC-2310,2014
+CPSC,2910,1,CPSC 2910: 001,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,james jones,,CPSC-2910,2014
+CPSC,2910,3,CPSC 2910: 003,0.73,0.0,0.0,0.0,0.09,0.0,0.0,0.18,james jones,,CPSC-2910,2014
+CPSC,2910,4,CPSC 2910: 004,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,renee lambert,,CPSC-2910,2014
+CPSC,2910,5,CPSC 2910: 005,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,renee lambert,,CPSC-2910,2014
+CPSC,2910,6,CPSC 2910: 006,0.6,0.1,0.1,0.0,0.2,0.0,0.0,0.0,renee lambert,,CPSC-2910,2014
+CPSC,2910,7,CPSC 2910: 007,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,renee lambert,,CPSC-2910,2014
+CPSC,3220,1,Intro to Operating Systems,0.26,0.3,0.28,0.04,0.09,0.0,0.0,0.02,mark smotherman,,CPSC-3220,2014
+CPSC,3300,1,CPSC 3300: 001,0.26,0.17,0.28,0.09,0.09,0.0,0.0,0.11,mark smotherman,,CPSC-3300,2014
+CPSC,3500,1,CPSC 3500: 001,0.27,0.41,0.27,0.02,0.03,0.0,0.0,0.0,wayne goddard,,CPSC-3500,2014
+CPSC,3520,1,Programming Systems,0.09,0.34,0.21,0.02,0.09,0.0,0.0,0.26,robert schalkoff,,CPSC-3520,2014
+CPSC,3600,1,CPSC 3600: 001,0.23,0.3,0.09,0.09,0.11,0.0,0.0,0.18,jacob sorber,,CPSC-3600,2014
+CPSC,3620,1,CPSC 3620: 001,0.28,0.28,0.3,0.02,0.0,0.0,0.0,0.12,amy apon,,CPSC-3620,2014
+CPSC,3720,1,CPSC 3720: 001,0.33,0.47,0.14,0.02,0.0,0.0,0.0,0.04,stephen schaub,,CPSC-3720,2014
+CPSC,4050,1,CPSC 4050: 001,0.26,0.3,0.13,0.04,0.13,0.0,0.0,0.13,donald henry house,,CPSC-4050,2014
+CPSC,4140,1,CPSC 4140: 001,0.21,0.63,0.0,0.0,0.04,0.0,0.0,0.13,andrew duchowski,,CPSC-4140,2014
+CPSC,4160,1,CPSC 4160: 001,0.36,0.36,0.28,0.0,0.0,0.0,0.0,0.0,brian malloy,,CPSC-4160,2014
+CPSC,4240,1,CPSC 4240: 001,0.29,0.63,0.0,0.0,0.04,0.0,0.0,0.04,james martin,,CPSC-4240,2014
+CPSC,4620,1,Database Management Systems,0.22,0.35,0.17,0.04,0.04,0.0,0.0,0.17,zijun wang,,CPSC-4620,2014
+CPSC,4810,3,Topic:Software Dev for Mobile,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,roy pargas,,CPSC-4810,2014
+CPSC,4810,13,Pro Gen of Video Game Media,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15,brian malloy,,CPSC-4810,2014
+CPSC,4810,14,CI: Game & Python Programming,0.55,0.18,0.18,0.0,0.0,0.0,0.0,0.09,christina gardner,,CPSC-4810,2014
+CPSC,4910,1,CPSC 4910: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james jones,,CPSC-4910,2014
+CPSC,6050,1,CPSC 6050: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,donald henry house,,CPSC-6050,2014
+CPSC,6140,1,CPSC 6140: 001,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,andrew duchowski,,CPSC-6140,2014
+CPSC,6160,1,CPSC 6160: 001,0.52,0.38,0.0,0.0,0.0,0.05,0.0,0.05,brian malloy,,CPSC-6160,2014
+CPSC,6240,1,CPSC 6240: 001,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,james martin,,CPSC-6240,2014
+CPSC,6620,1,CPSC 6620: 001,0.29,0.53,0.12,0.0,0.03,0.0,0.0,0.03,zijun wang,,CPSC-6620,2014
+CPSC,6810,1,Topic:Educational Technology,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christina gardner,,CPSC-6810,2014
+CPSC,8080,1,CPSC 8080: 001,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,CPSC-8080,2014
+CPSC,8090,1,CPSC 8090: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,,CPSC-8090,2014
+CPSC,8150,1,CPSC 8150: 001,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,timothy davis,,CPSC-8150,2014
+CPSC,8190,1,CPSC 8190: 001,0.0,0.63,0.25,0.0,0.0,0.0,0.0,0.13,jerry tessendorf,,CPSC-8190,2014
+CPSC,8220,1,CPSC 8220: 001,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,robert geist,,CPSC-8220,2014
+CPSC,8400,1,CPSC 8400: 001,0.11,0.39,0.43,0.0,0.07,0.0,0.0,0.0,brian christop dean,,CPSC-8400,2014
+CPSC,8520,1,CPSC 8520: 001,0.4,0.56,0.0,0.0,0.0,0.0,0.0,0.04,james martin,,CPSC-8520,2014
+CPSC,8550,1,CPSC 8550: 001,0.45,0.27,0.18,0.0,0.0,0.0,0.0,0.09,jason hallstrom,,CPSC-8550,2014
+CPSC,8620,1,CPSC 8620: 001,0.77,0.17,0.04,0.0,0.0,0.0,0.0,0.02,juan gilbert,,CPSC-8620,2014
+CPSC,8630,1,CPSC 8630: 001,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,zijun wang,,CPSC-8630,2014
+CPSC,8650,1,CPSC 8650: 001,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,zijun wang,,CPSC-8650,2014
+CPSC,8750,1,CPSC 8750: 001,0.32,0.36,0.28,0.0,0.0,0.0,0.0,0.04,john mcgregor,,CPSC-8750,2014
+CPSC,8810,1,Topic:Geometric Modeling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joshua levine,,CPSC-8810,2014
+CRP,8010,1,Planning Process & Legal Found,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,,CRP-8010,2014
+CRP,8050,1,Plning Theory & Hist,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,mickey lauria,,CRP-8050,2014
+CRP,8090,1,CRP 8090: 001,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,barry nocks,,CRP-8090,2014
+CRP,8140,1,Public Transit,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,,CRP-8140,2014
+CRP,8220,1,Urban Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,CRP-8220,2014
+CRP,8890,3,S. Topic-Geodesign w/ CityEng.,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,,CRP-8890,2014
+CSEN,2020,1,CSEN 2020: 001,0.4,0.23,0.13,0.15,0.04,0.0,0.0,0.04,dara michelle park,,CSEN-2020,2014
+CSEN,4520,1,CSEN 4520: 001,0.52,0.39,0.0,0.0,0.0,0.0,0.0,0.09,haibo liu,,CSEN-4520,2014
+CSM,1500,1,CSM 1500: 001,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-1500,2014
+CSM,1500,2,CSM 1500: 002,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-1500,2014
+CSM,2020,1,CSM 2020: 001,0.1,0.43,0.38,0.1,0.0,0.0,0.0,0.0,shima clarke,,CSM-2020,2014
+CSM,2020,2,CSM 2020: 002,0.24,0.53,0.24,0.0,0.0,0.0,0.0,0.0,shima clarke,,CSM-2020,2014
+CSM,2040,1,CSM 2040: 001,0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2040,2014
+CSM,2040,2,CSM 2040: 002,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2040,2014
+CSM,2050,1,CSM 2050: 001,0.42,0.21,0.21,0.16,0.0,0.0,0.0,0.0,jason lucas,,CSM-2050,2014
+CSM,2050,2,CSM 2050: 002,0.3,0.25,0.35,0.1,0.0,0.0,0.0,0.0,jason lucas,,CSM-2050,2014
+CSM,3050,1,CSM 3050: 001,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3050,2014
+CSM,3050,2,CSM 3050: 002,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3050,2014
+CSM,3520,1,CSM 3520: 001,0.24,0.67,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-3520,2014
+CSM,3520,2,CSM 3520: 002,0.06,0.47,0.35,0.12,0.0,0.0,0.0,0.0,christine piper,,CSM-3520,2014
+CSM,3530,1,CSM 3530: 001,0.3,0.65,0.04,0.0,0.0,0.0,0.0,0.0,james packer smith,,CSM-3530,2014
+CSM,3530,2,CSM 3530: 002,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,james packer smith,,CSM-3530,2014
+CSM,4540,1,CSM 4540: 001,0.2,0.4,0.4,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4540,2014
+CSM,4540,2,CSM 4540: 002,0.2,0.47,0.33,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-4540,2014
+CSM,8620,1,Personnel Mgt & Neg,0.13,0.38,0.38,0.0,0.0,0.0,0.0,0.13,roger william liska,,CSM-8620,2014
+CSM,8620,400,Personnel Mgt & Neg,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-8620,2014
+CU,1000,1,CU 1000: 001,0.0,0.0,0.0,0.0,0.0,0.87,0.11,0.02,jeffrey appling,,CU-1000,2014
+CU,1010,1,CU 1010: 001,0.38,0.38,0.13,0.0,0.08,0.0,0.0,0.04,rise jean sheriff,,CU-1010,2014
+CU,1010,2,CU 1010: 002,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,cecelia hamby,,CU-1010,2014
+CU,1010,3,CU 1010: 003,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,CU-1010,2014
+CU,1010,5,CU 1010: 005,0.85,0.07,0.0,0.0,0.04,0.0,0.0,0.04,mary mcp von kaenel,,CU-1010,2014
+CU,1010,6,CU 1010: 006,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,mary mcp von kaenel,,CU-1010,2014
+CU,1010,10,CU 1010: 010,0.63,0.2,0.1,0.03,0.03,0.0,0.0,0.0, elaine richardson,,CU-1010,2014
+CU,2010,1,CU 2010: 001,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,leidy klotz,,CU-2010,2014
+DANC,1400,1,Jazz Dance I,0.91,0.0,0.05,0.0,0.05,0.0,0.0,0.0,cheryl hosler,,DANC-1400,2014
+DANC,1500,1,Modern Dance I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,cheryl hosler,,DANC-1500,2014
+DPA,3070,1,DPA 3070: 001,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,timothy curtis,,DPA-3070,2014
+ECE,2010,1,Logic & Comp Device,0.21,0.27,0.19,0.31,0.0,0.0,0.0,0.02,lin zhu,,ECE-2010,2014
+ECE,2020,1,Electric Circuits I,0.17,0.4,0.18,0.12,0.11,0.0,0.0,0.02,william harrell,,ECE-2020,2014
+ECE,2090,2,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,timothy burg,,ECE-2090,2014
+ECE,2090,3,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,,ECE-2090,2014
+ECE,2090,4,Logic Lab,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,,ECE-2090,2014
+ECE,2110,1,ECE 2110: 001,0.58,0.25,0.0,0.0,0.0,0.0,0.0,0.17,timothy burg,,ECE-2110,2014
+ECE,2110,3,ECE 2110: 003,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,,ECE-2110,2014
+ECE,2120,7,ECE 2120: 007,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,timothy burg,,ECE-2120,2014
+ECE,2220,1,ECE 2220: 001,0.13,0.22,0.24,0.14,0.19,0.0,0.0,0.09,william reid,,ECE-2220,2014
+ECE,2230,1,ECE 2230: 001,0.25,0.14,0.25,0.11,0.04,0.0,0.0,0.21,harlan russell,,ECE-2230,2014
+ECE,2620,1,Elec Circuits II,0.24,0.29,0.29,0.11,0.05,0.0,0.0,0.01,richard groff,,ECE-2620,2014
+ECE,2620,2,Elec Circuits II (HON),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True,ECE-2620,2014
+ECE,2720,1,Comp Organization,0.24,0.27,0.32,0.09,0.09,0.0,0.0,0.0,william reid,,ECE-2720,2014
+ECE,2730,1,Computer Org Lab,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-2730,2014
+ECE,2730,2,Computer Org Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-2730,2014
+ECE,2730,3,Computer Org Lab,0.5,0.25,0.13,0.0,0.06,0.0,0.0,0.06,timothy burg,,ECE-2730,2014
+ECE,2730,4,Computer Org Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-2730,2014
+ECE,2730,5,Computer Org Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-2730,2014
+ECE,3070,1,ECE 3070: 001,0.48,0.17,0.15,0.03,0.01,0.0,0.0,0.16,timothy burg,,ECE-3070,2014
+ECE,3070,2,ECE 3070: 002,0.39,0.27,0.14,0.05,0.01,0.0,0.0,0.15,timothy burg,,ECE-3070,2014
+ECE,3070,3,ECE 3070: 003,0.96,0.02,0.0,0.02,0.0,0.0,0.0,0.0,sung- kim,,ECE-3070,2014
+ECE,3090,1,ECE 3090: 001,0.79,0.05,0.0,0.0,0.0,0.0,0.0,0.16,timothy burg,,ECE-3090,2014
+ECE,3090,4,ECE 3090: 004,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,,ECE-3090,2014
+ECE,3090,5,ECE 3090: 005,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,,ECE-3090,2014
+ECE,3090,6,ECE 3090: 006,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,,ECE-3090,2014
+ECE,3090,8,ECE 3090: 008,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,timothy burg,,ECE-3090,2014
+ECE,3090,9,ECE 3090: 009,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-3090,2014
+ECE,3090,11,ECE 3090: 011,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,,ECE-3090,2014
+ECE,3090,14,ECE 3090: 014,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,timothy burg,,ECE-3090,2014
+ECE,3110,1,ECE 3110: 001,0.73,0.07,0.07,0.0,0.0,0.0,0.0,0.13,timothy burg,,ECE-3110,2014
+ECE,3110,3,ECE 3110: 003,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-3110,2014
+ECE,3120,3,ECE 3120: 003,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,timothy burg,,ECE-3120,2014
+ECE,3120,4,ECE 3120: 004,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,timothy burg,,ECE-3120,2014
+ECE,3170,1,Rand Signal Analysis,0.39,0.47,0.14,0.0,0.0,0.0,0.0,0.0,stephen hubbard,,ECE-3170,2014
+ECE,3170,2,Rand Signal Analysis (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,carl baum,True,ECE-3170,2014
+ECE,3200,1,Electronics I,0.44,0.37,0.1,0.07,0.0,0.0,0.0,0.01,stephen hubbard,,ECE-3200,2014
+ECE,3210,1,ECE 3210: 001,0.15,0.39,0.3,0.13,0.01,0.0,0.0,0.01,stephen hubbard,,ECE-3210,2014
+ECE,3220,1,Intro Operating Sys,0.39,0.43,0.11,0.0,0.04,0.0,0.0,0.04,mark smotherman,,ECE-3220,2014
+ECE,3270,1,ECE 3270: 001,0.1,0.36,0.19,0.07,0.17,0.0,0.0,0.12,melissa crawl smith,,ECE-3270,2014
+ECE,3300,1,Signals & Systems,0.23,0.16,0.26,0.2,0.08,0.0,0.0,0.07,carl baum,,ECE-3300,2014
+ECE,3520,1,Programming Systems,0.5,0.35,0.12,0.0,0.0,0.0,0.0,0.04,robert schalkoff,,ECE-3520,2014
+ECE,3600,1,ECE 3600: 001,0.35,0.21,0.26,0.09,0.09,0.0,0.0,0.0,ramtin hadidi,,ECE-3600,2014
+ECE,3710,1,ECE 3710: 001,0.29,0.38,0.21,0.06,0.06,0.0,0.0,0.0,william reid,,ECE-3710,2014
+ECE,3720,1,ECE 3720: 001,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-3720,2014
+ECE,3720,2,ECE 3720: 002,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-3720,2014
+ECE,3720,4,ECE 3720: 004,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,timothy burg,,ECE-3720,2014
+ECE,3800,1,ECE 3800: 001,0.14,0.41,0.25,0.08,0.12,0.0,0.0,0.0,anthony martin,,ECE-3800,2014
+ECE,3810,1,ECE 3810: 001,0.33,0.41,0.22,0.0,0.0,0.0,0.0,0.04,eric gordon johnson,,ECE-3810,2014
+ECE,4090,1,ECE 4090: 001,0.47,0.3,0.21,0.0,0.0,0.0,0.0,0.02,darren dawson,,ECE-4090,2014
+ECE,4170,1,ECE 4170: 001,0.29,0.41,0.0,0.06,0.0,0.0,0.0,0.24,darren dawson,,ECE-4170,2014
+ECE,4190,1,ECE 4190: 001,0.6,0.28,0.04,0.04,0.04,0.0,0.0,0.0,keith corzine,,ECE-4190,2014
+ECE,4200,1,ECE 4200: 001,0.29,0.18,0.38,0.06,0.03,0.0,0.0,0.06,elham makram,,ECE-4200,2014
+ECE,4270,1,ECE 4270: 001,0.2,0.29,0.29,0.23,0.0,0.0,0.0,0.0,carl baum,,ECE-4270,2014
+ECE,4380,1,ECE 4380: 001,0.31,0.31,0.31,0.0,0.0,0.0,0.0,0.06,harlan russell,,ECE-4380,2014
+ECE,4400,1,ECE 4400: 001,0.38,0.41,0.18,0.0,0.0,0.0,0.0,0.03,kuang-ching wang,,ECE-4400,2014
+ECE,4680,1,ECE 4680: 001,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,adam hoover,,ECE-4680,2014
+ECE,4700,1,ECE 4700: 001,0.4,0.38,0.09,0.11,0.0,0.0,0.0,0.02,todd hubing,,ECE-4700,2014
+ECE,4950,1,ECE 4950: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-4950,2014
+ECE,4960,1,ECE 4960: 001,0.48,0.41,0.11,0.0,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2014
+ECE,6170,1,ECE 6170: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,darren dawson,,ECE-6170,2014
+ECE,6190,1,ECE 6190: 001,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,keith corzine,,ECE-6190,2014
+ECE,6200,1,ECE 6200: 001,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,elham makram,,ECE-6200,2014
+ECE,6380,1,ECE 6380: 001,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,,ECE-6380,2014
+ECE,6400,1,ECE 6400: 001,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,,ECE-6400,2014
+ECE,6680,1,ECE 6680: 001,0.69,0.06,0.25,0.0,0.0,0.0,0.0,0.0,adam hoover,,ECE-6680,2014
+ECE,6930,2,CMOS Analog VLSI,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,,ECE-6930,2014
+ECE,8240,1,ECE 8240: 001,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,ramtin hadidi,,ECE-8240,2014
+ECE,8400,1,ECE 8400: 001,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,william harrell,,ECE-8400,2014
+ECE,8440,1,ECE 8440: 001,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,john gowdy,,ECE-8440,2014
+ECE,8480,1,ECE 8480: 001,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,,ECE-8480,2014
+ECE,8720,1,ECE 8720: 001,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,robert schalkoff,,ECE-8720,2014
+ECE,8740,1,ECE 8740: 001,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,timothy burg,,ECE-8740,2014
+ECE,8930,1,Fiber Lasers,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,liang dong,,ECE-8930,2014
+ECE,9910,32,ECE 9910: 032,0.0,0.0,0.0,0.0,0.0,0.6,0.4,0.0,hai ying shen,,ECE-9910,2014
+ECON,2000,1,Economic Concepts,0.22,0.22,0.11,0.17,0.17,0.0,0.0,0.11,mallika garg,,ECON-2000,2014
+ECON,2000,2,Economic Concepts,0.14,0.16,0.43,0.05,0.03,0.0,0.0,0.19,mallika garg,,ECON-2000,2014
+ECON,2000,3,Economic Concepts,0.25,0.28,0.19,0.09,0.16,0.0,0.0,0.03,miren ivankovic,,ECON-2000,2014
+ECON,2110,1,Principles of Microeconomics,0.18,0.33,0.43,0.05,0.03,0.0,0.0,0.0,eric peter makela,,ECON-2110,2014
+ECON,2110,2,Principles of Microeconomics,0.13,0.55,0.18,0.0,0.13,0.0,0.0,0.0,ce castellon chicas,,ECON-2110,2014
+ECON,2110,3,Principles of Microeconomics,0.12,0.44,0.33,0.07,0.05,0.0,0.0,0.0,adam millsap,,ECON-2110,2014
+ECON,2110,4,Principles of Microeconomics,0.23,0.45,0.15,0.1,0.03,0.0,0.0,0.05,andew swanson,,ECON-2110,2014
+ECON,2110,5,Principles of Microeconomics,0.35,0.3,0.23,0.08,0.03,0.0,0.0,0.03,jacob burgdorf,,ECON-2110,2014
+ECON,2110,6,Principles of Microeconomics,0.26,0.26,0.23,0.21,0.02,0.0,0.0,0.02,timothy andr bersak,,ECON-2110,2014
+ECON,2110,7,Principles of Microeconomics,0.17,0.41,0.3,0.08,0.01,0.0,0.0,0.03,adam millsap,,ECON-2110,2014
+ECON,2110,8,Principles of Microeconomics,0.36,0.28,0.25,0.07,0.04,0.0,0.0,0.01,miren ivankovic,,ECON-2110,2014
+ECON,2110,10,Principles of Microeconomics,0.22,0.3,0.26,0.04,0.02,0.0,0.0,0.15,robert dew tollison,,ECON-2110,2014
+ECON,2110,11,Principles of Microeconomics,0.15,0.44,0.31,0.06,0.02,0.0,0.0,0.02,meng liu,,ECON-2110,2014
+ECON,2110,12,Principles of Microeconomics,0.16,0.37,0.18,0.05,0.08,0.0,0.0,0.16,john devin shippey,,ECON-2110,2014
+ECON,2110,13,Principles of Microecon(HON),0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,robert kennet fleck,True,ECON-2110,2014
+ECON,2120,1,Principles of Macro,0.16,0.37,0.37,0.0,0.11,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,2,Principles of Macro,0.06,0.44,0.5,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,3,Principles of Macro,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,4,Principles of Macro,0.21,0.47,0.26,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,5,Principles of Macro,0.18,0.35,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,6,Principles of Macro,0.16,0.37,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,7,Principles of Macro,0.11,0.22,0.56,0.06,0.0,0.0,0.0,0.06,scott baier,,ECON-2120,2014
+ECON,2120,8,Principles of Macro,0.11,0.53,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,9,Principles of Macro,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,10,Principles of Macro,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,11,Principles of Macro,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,12,Principles of Macro,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,scott baier,,ECON-2120,2014
+ECON,2120,13,Principles of Macro,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,14,Principles of Macro,0.26,0.37,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,15,Principles of Macro,0.21,0.37,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,16,Principles of Macro,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,17,Principles of Macro,0.21,0.53,0.21,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,18,Principles of Macro,0.16,0.53,0.26,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,19,Principles of Macro,0.17,0.39,0.33,0.11,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2014
+ECON,2120,20,Principles of Macro,0.3,0.45,0.23,0.0,0.0,0.0,0.0,0.03,anne anders,,ECON-2120,2014
+ECON,2120,21,Principles of Macro,0.05,0.25,0.25,0.08,0.12,0.0,0.0,0.26,ralph charles allen,,ECON-2120,2014
+ECON,2120,22,Principles of Macro,0.1,0.45,0.25,0.1,0.08,0.0,0.0,0.03,anne anders,,ECON-2120,2014
+ECON,2120,23,Principles of Macro,0.35,0.4,0.18,0.0,0.05,0.0,0.0,0.03,yukun sun,,ECON-2120,2014
+ECON,2120,24,Principles of Macro,0.09,0.18,0.24,0.09,0.16,0.0,0.0,0.24,ralph charles allen,,ECON-2120,2014
+ECON,2120,25,Principles of Macro,0.25,0.55,0.1,0.1,0.0,0.0,0.0,0.0,lyudmyla ta sonchak,,ECON-2120,2014
+ECON,2120,26,Principles of Macro,0.26,0.6,0.12,0.02,0.0,0.0,0.0,0.0,yukun sun,,ECON-2120,2014
+ECON,3020,1,Money and Banking,0.2,0.4,0.15,0.1,0.13,0.0,0.0,0.03,danielle zanzalari,,ECON-3020,2014
+ECON,3060,1,Managerial Economics,0.22,0.36,0.25,0.06,0.03,0.0,0.0,0.08,john devin shippey,,ECON-3060,2014
+ECON,3100,1,International Econ,0.19,0.38,0.31,0.06,0.05,0.0,0.0,0.02,michal jerzmanowski,,ECON-3100,2014
+ECON,3140,1,Intermediate Micro,0.21,0.26,0.16,0.0,0.11,0.0,0.0,0.26,patrick warren,,ECON-3140,2014
+ECON,3140,2,Intermediate Micro,0.42,0.31,0.19,0.04,0.04,0.0,0.0,0.0,molly espey,,ECON-3140,2014
+ECON,3140,3,Intermediate Micro,0.11,0.43,0.29,0.07,0.07,0.0,0.0,0.04,tomas cvrcek,,ECON-3140,2014
+ECON,3150,1,Intermediate Macro,0.25,0.16,0.3,0.16,0.12,0.0,0.0,0.02,wesley harris,,ECON-3150,2014
+ECON,3150,2,Intermediate Macro,0.37,0.4,0.2,0.0,0.03,0.0,0.0,0.0,sergey vla mityakov,,ECON-3150,2014
+ECON,3440,1,Property Rights,0.17,0.43,0.22,0.09,0.04,0.0,0.0,0.04,dar litsukova-bokar,,ECON-3440,2014
+ECON,4020,1,Law and Economics,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,thomas wins hazlett,,ECON-4020,2014
+ECON,4050,1,Intro to Econometric,0.36,0.21,0.36,0.07,0.0,0.0,0.0,0.0,jaqueline oliveira,,ECON-4050,2014
+ECON,4050,2,Intro to Econometric,0.31,0.15,0.31,0.0,0.23,0.0,0.0,0.0,jaqueline oliveira,,ECON-4050,2014
+ECON,4050,3,Intro to Econometric,0.18,0.18,0.55,0.09,0.0,0.0,0.0,0.0,jaqueline oliveira,,ECON-4050,2014
+ECON,4050,4,Intro to Econometric,0.17,0.25,0.17,0.33,0.08,0.0,0.0,0.0,jaqueline oliveira,,ECON-4050,2014
+ECON,4110,1,Econ of Education,0.31,0.31,0.23,0.08,0.04,0.0,0.0,0.04,chungsang lam,,ECON-4110,2014
+ECON,4130,1,International Macro,0.17,0.44,0.17,0.17,0.06,0.0,0.0,0.0,michal jerzmanowski,,ECON-4130,2014
+ECON,4240,1,Organization of Ind,0.39,0.39,0.15,0.0,0.0,0.0,0.0,0.06,matthew lewis,,ECON-4240,2014
+ECON,4250,1,Antitrust Economics,0.44,0.36,0.17,0.0,0.0,0.0,0.0,0.03,robert dew tollison,,ECON-4250,2014
+ECON,4260,1,Sem Sport Economics,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-4260,2014
+ECON,4270,1,Dev American Economy,0.27,0.53,0.17,0.03,0.0,0.0,0.0,0.0,howard ne bodenhorn,,ECON-4270,2014
+ECON,4350,1,Family Economics,0.06,0.45,0.27,0.09,0.06,0.0,0.0,0.06,tomas cvrcek,,ECON-4350,2014
+ECON,4400,1,Game Theory,0.25,0.5,0.08,0.0,0.04,0.0,0.0,0.13,daniel wood,,ECON-4400,2014
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.21,0.36,0.29,0.0,0.0,0.0,0.0,0.14,scott templeton,,ECON-4570,2014
+ECON,6130,1,ECON 6130: 001,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,,ECON-6130,2014
+ECON,8020,1,Adv Econ Concepts and Applic I,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,william dougan,,ECON-8020,2014
+ECON,8050,1,ECON 8050: 001,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-8050,2014
+ECON,8070,1,ECON 8070: 001,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,thomas alvin mroz,,ECON-8070,2014
+ECON,8200,1,Public Finance,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william dougan,,ECON-8200,2014
+ECON,9010,1,Price Theory,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,daniel wood,,ECON-9010,2014
+ECON,9090,1,ECON 9090: 001,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,gerald dwyer,,ECON-9090,2014
+ECON,9170,1,Advanced Seminar Labor Econ,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,,ECON-9170,2014
+ED,1050,1,ED 1050: 001,0.65,0.2,0.0,0.0,0.1,0.0,0.0,0.05,patrick womac,,ED-1050,2014
+ED,1050,2,ED 1050: 002,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,patrick womac,,ED-1050,2014
+ED,1050,3,ED 1050: 003,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,rory phil tannebaum,,ED-1050,2014
+ED,1050,4,ED 1050: 004,0.8,0.08,0.0,0.0,0.08,0.0,0.0,0.04,rory phil tannebaum,,ED-1050,2014
+ED,3220,1,ED 3220: 001,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,deborah smith,,ED-3220,2014
+ED,8380,400,Physical Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard dallm white,,ED-8380,2014
+ED,8380,537,Literacy Lessons Designed for,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,vicki steadman,,ED-8380,2014
+ED,8390,505,ED 8390: 505,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0, paltrow zwerdling,,ED-8390,2014
+ED,8600,400,ED 8600: 400,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,,ED-8600,2014
+ED,9010,1,Research Design/ Infer. Stats,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,,ED-9010,2014
+EDC,3900,10,EDC 3900: 010,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mary price,,EDC-3900,2014
+EDC,3900,12,EDC 3900: 012,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mary price,,EDC-3900,2014
+EDC,8060,1,EDC 8060: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,,EDC-8060,2014
+EDC,8070,400,EDC 8070: 400,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,kristen leigh moran,,EDC-8070,2014
+EDC,8190,1,EDC 8190: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,,EDC-8190,2014
+EDEC,2200,1,EDEC 2200: 001,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,ysaaca axelrod,,EDEC-2200,2014
+EDEL,3100,1,EDEL 3100: 001,0.91,0.04,0.0,0.0,0.04,0.0,0.0,0.0,alison eliz leonard,,EDEL-3100,2014
+EDEL,3100,2,EDEL 3100: 002,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,jacqueline sh rosen,,EDEL-3100,2014
+EDEL,3210,1,EDEL 3210: 001,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2014
+EDEL,4050,1,EDEL 4050: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,,EDEL-4050,2014
+EDEL,4510,1,Elem Methods in Science Tchg,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,cynthia chri deaton,,EDEL-4510,2014
+EDEL,4520,2,EDEL 4520: 002,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,james kwame dogbey,,EDEL-4520,2014
+EDEL,4670,1,EDEL 4670: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDEL-4670,2014
+EDEL,4870,1,EDEL 4870: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,melinda spearman,,EDEL-4870,2014
+EDF,3010,1,Principles of American Educat,0.2,0.36,0.32,0.0,0.0,0.0,0.0,0.12,robert green,,EDF-3010,2014
+EDF,3010,2,Principles of American Educat,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,robert green,,EDF-3010,2014
+EDF,3010,3,Principles of American Educat,0.54,0.35,0.08,0.03,0.0,0.0,0.0,0.0,suzanne rosenblith,,EDF-3010,2014
+EDF,3020,1,Educ Psych,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,,EDF-3020,2014
+EDF,3020,2,Educ Psych,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,deborah switzer,,EDF-3020,2014
+EDF,3020,3,Educ Psych,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,,EDF-3020,2014
+EDF,3020,5,Educ Psych,0.4,0.3,0.23,0.03,0.03,0.0,0.0,0.0,penelope mar vargas,,EDF-3020,2014
+EDF,3150,1,Technology Skills for Learning,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,ryan visser,,EDF-3150,2014
+EDF,3150,2,Technology Skills for Learning,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-3150,2014
+EDF,3340,1,Child Growth and Dev,0.69,0.21,0.07,0.0,0.0,0.0,0.0,0.03,winston holton,,EDF-3340,2014
+EDF,3340,2,Child Growth and Dev,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,,EDF-3340,2014
+EDF,3350,1,Adol Growth & Dev,0.31,0.52,0.17,0.0,0.0,0.0,0.0,0.0,david barrett,,EDF-3350,2014
+EDF,3350,2,Adol Growth & Dev,0.67,0.23,0.1,0.0,0.0,0.0,0.0,0.0,david barrett,,EDF-3350,2014
+EDF,4250,1,EDF 4250: 001,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4250,2014
+EDF,4800,2,Digital Media & Learning,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,david matthew boyer,,EDF-4800,2014
+EDF,8800,400,EDF 8800: 400,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-8800,2014
+EDF,9050,1,EDF 9050: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,danielle chri herro,,EDF-9050,2014
+EDL,7150,1,EDL 7150: 001,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,hans william klar,,EDL-7150,2014
+EDL,7350,500,EDL 7350: 500,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,,EDL-7350,2014
+EDL,7400,500,EDL 7400: 500,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,frederick buskey,,EDL-7400,2014
+EDL,8850,400,Selected Topics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,leslie gonzales,,EDL-8850,2014
+EDL,9100,400,Intro Phd Seminar,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,jane lindle,,EDL-9100,2014
+EDLT,4580,1,EDLT 4580: 001,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4580,2014
+EDLT,4600,1,Teaching Reading Grades 2-6,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,,EDLT-4600,2014
+EDLT,4620,1,EDLT 4620: 001,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4620,2014
+EDLT,4630,1,EDLT 4630: 001,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,ysaaca axelrod,,EDLT-4630,2014
+EDLT,8670,400,EDLT 8670: 400,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8670,2014
+EDLT,8670,401,EDLT 8670: 401,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,phillip mich wilder,,EDLT-8670,2014
+EDLT,8740,501,EDLT 8740: 501,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-8740,2014
+EDSC,4370,1,EDSC 4370: 001,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,robert horton,,EDSC-4370,2014
+EDSC,8920,400,EDSC 8920: 400,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeff marshall,,EDSC-8920,2014
+EDSP,3700,1,Intro to Special Ed,0.76,0.15,0.06,0.0,0.03,0.0,0.0,0.0,joseph benedic ryan,,EDSP-3700,2014
+EDSP,3700,2,Intro to Special Ed,0.78,0.05,0.1,0.03,0.05,0.0,0.0,0.0,joseph benedic ryan,,EDSP-3700,2014
+EDSP,3700,3,Intro to Special Ed,0.78,0.12,0.07,0.0,0.02,0.0,0.0,0.0,robin parks ennis,,EDSP-3700,2014
+EDSP,3730,1,EDSP 3730: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,,EDSP-3730,2014
+EDSP,3750,1,EDSP 3750: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,,EDSP-3750,2014
+EDSP,4910,1,EDSP 4910: 001,0.67,0.29,0.0,0.0,0.04,0.0,0.0,0.0,antonis katsiyannis,,EDSP-4910,2014
+EDSP,4950,1,EDSP 4950: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,martha hodge,,EDSP-4950,2014
+EDSP,4980,1,EDSP 4980: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,beverly lu romansky,,EDSP-4980,2014
+EES,2020,1,EES 2020: 001,0.49,0.44,0.02,0.0,0.02,0.0,0.0,0.02,kevin thom finneran,,EES-2020,2014
+EES,4010,1,EES 4010: 001,0.41,0.49,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,EES-4010,2014
+EES,4010,2,EES 4010: 002,0.15,0.58,0.23,0.02,0.0,0.0,0.0,0.02,john coates,,EES-4010,2014
+EES,4020,1,EES 4020: 001,0.41,0.41,0.09,0.0,0.05,0.0,0.0,0.05,david allen ladner,,EES-4020,2014
+EES,4750,1,EES 4750: 001,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-4750,2014
+EES,4840,1,Solid Waste Mgt,0.29,0.55,0.1,0.03,0.03,0.0,0.0,0.0,thomas overcamp,,EES-4840,2014
+EES,4850,1,EES 4850: 001,0.3,0.59,0.08,0.03,0.0,0.0,0.0,0.0,mark schlautman,,EES-4850,2014
+EES,6110,1,EES 6110: 001,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,timothy devol,,EES-6110,2014
+EES,6850,1,EES 6850: 001,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mark schlautman,,EES-6850,2014
+EES,8030,1,EES 8030: 001,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,tanju karanfil,,EES-8030,2014
+EES,8040,1,EES 8040: 001,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,,EES-8040,2014
+EES,8050,1,EES 8050: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tanju karanfil,,EES-8050,2014
+EES,8120,1,EES 8120: 001,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,lin shuller-nickles,,EES-8120,2014
+EES,8200,1,EES 8200: 001,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,annick anctil,,EES-8200,2014
+EES,8450,1,EES 8450: 001,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,cindy lee,,EES-8450,2014
+EES,8830,2,Advanced Topics in Health Phys,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,timothy devol,,EES-8830,2014
+ELE,3010,1,Intro to Entre,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,ELE-3010,2014
+ELE,3010,2,Intro to Entre,0.56,0.38,0.05,0.0,0.0,0.0,0.0,0.0,anthony pa santella,,ELE-3010,2014
+ELE,4010,1,Exec Lead & Entr II,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,anthony pa santella,,ELE-4010,2014
+ENGL,1030,1,Accelerated Composition,0.47,0.37,0.05,0.11,0.0,0.0,0.0,0.0,leslie ann salley,,ENGL-1030,2014
+ENGL,1030,3,Accelerated Composition,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,megan leigh roberts,,ENGL-1030,2014
+ENGL,1030,4,Accelerated Composition,0.58,0.32,0.0,0.0,0.0,0.0,0.0,0.11,stephanie pai beard,,ENGL-1030,2014
+ENGL,1030,5,Accelerated Composition,0.21,0.37,0.26,0.05,0.11,0.0,0.0,0.0,jacqueline fetzer,,ENGL-1030,2014
+ENGL,1030,6,Accelerated Composition,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,kristen gay,,ENGL-1030,2014
+ENGL,1030,7,Accelerated Composition,0.5,0.25,0.15,0.0,0.05,0.0,0.0,0.05,leslie ann salley,,ENGL-1030,2014
+ENGL,1030,9,Accelerated Composition,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,jacqueline fetzer,,ENGL-1030,2014
+ENGL,1030,10,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,stephanie pai beard,,ENGL-1030,2014
+ENGL,1030,11,Accelerated Composition,0.5,0.4,0.05,0.0,0.05,0.0,0.0,0.0,leslie ann salley,,ENGL-1030,2014
+ENGL,1030,12,Accelerated Composition,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,david stubblefield,,ENGL-1030,2014
+ENGL,1030,14,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,dustin kyle pearson,,ENGL-1030,2014
+ENGL,1030,15,Accelerated Composition,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,leslie ann salley,,ENGL-1030,2014
+ENGL,1030,16,Accelerated Composition,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,david stubblefield,,ENGL-1030,2014
+ENGL,1030,17,Accelerated Composition,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,dustin kyle pearson,,ENGL-1030,2014
+ENGL,1030,18,Accelerated Composition,0.45,0.3,0.1,0.0,0.1,0.0,0.0,0.05,adrian carson,,ENGL-1030,2014
+ENGL,1030,19,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathryn eliz harner,,ENGL-1030,2014
+ENGL,1030,21,Accelerated Composition,0.58,0.26,0.05,0.0,0.0,0.0,0.0,0.11,caleb andr milligan,,ENGL-1030,2014
+ENGL,1030,24,Accelerated Composition,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,laura ann smith,,ENGL-1030,2014
+ENGL,1030,25,Accelerated Composition,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,hilary richards,,ENGL-1030,2014
+ENGL,1030,26,Accelerated Composition,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,catherine mar blass,,ENGL-1030,2014
+ENGL,1030,28,Accelerated Composition,0.74,0.16,0.0,0.05,0.0,0.0,0.0,0.05,kathryn eliz harner,,ENGL-1030,2014
+ENGL,1030,29,Accelerated Composition,0.37,0.42,0.16,0.0,0.05,0.0,0.0,0.0,caleb andr milligan,,ENGL-1030,2014
+ENGL,1030,32,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,laura ann smith,,ENGL-1030,2014
+ENGL,1030,33,Accelerated Composition,0.84,0.05,0.05,0.05,0.0,0.0,0.0,0.0,hilary richards,,ENGL-1030,2014
+ENGL,1030,35,Accelerated Composition,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,kiera angeli prince,,ENGL-1030,2014
+ENGL,1030,36,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katherine elrick,,ENGL-1030,2014
+ENGL,1030,37,Accelerated Composition,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,shawn andrew stowe,,ENGL-1030,2014
+ENGL,1030,38,Accelerated Composition,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,katherine hanzalik,,ENGL-1030,2014
+ENGL,1030,39,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,,ENGL-1030,2014
+ENGL,1030,40,Accelerated Composition,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,joshua lee martin,,ENGL-1030,2014
+ENGL,1030,41,Accelerated Composition,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,,ENGL-1030,2014
+ENGL,1030,42,Accelerated Composition,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,katherine elrick,,ENGL-1030,2014
+ENGL,1030,44,Accelerated Composition,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,katherine hanzalik,,ENGL-1030,2014
+ENGL,1030,46,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,,ENGL-1030,2014
+ENGL,1030,48,Accelerated Composition,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,joshua lee martin,,ENGL-1030,2014
+ENGL,1030,51,Accelerated Composition,0.85,0.0,0.05,0.0,0.05,0.0,0.0,0.05,mari elena ramler,,ENGL-1030,2014
+ENGL,1030,52,Accelerated Composition,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,kiera angeli prince,,ENGL-1030,2014
+ENGL,1030,53,Accelerated Composition,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,justyna ann pekalak,,ENGL-1030,2014
+ENGL,1030,54,Accelerated Composition,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,eric thomas hall,,ENGL-1030,2014
+ENGL,1030,57,Accelerated Composition,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,kristen gay,,ENGL-1030,2014
+ENGL,1030,58,Accelerated Composition,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,samuel jacks fuller,,ENGL-1030,2014
+ENGL,1030,59,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,alyssa chris carver,,ENGL-1030,2014
+ENGL,1030,60,Accelerated Composition,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,justyna ann pekalak,,ENGL-1030,2014
+ENGL,2120,1,World Literature,0.52,0.3,0.15,0.04,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-2120,2014
+ENGL,2120,2,World Literature (MAJORS ONLY),0.71,0.12,0.12,0.0,0.0,0.0,0.0,0.06,lucian ghita,,ENGL-2120,2014
+ENGL,2120,3,World Literature,0.36,0.43,0.11,0.04,0.07,0.0,0.0,0.0,andrew mathas,,ENGL-2120,2014
+ENGL,2120,4,World Literature,0.71,0.18,0.0,0.04,0.04,0.0,0.0,0.04,april susanne pelt,,ENGL-2120,2014
+ENGL,2120,5,World Literature,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-2120,2014
+ENGL,2120,7,World Literature (MAJORS ONLY),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-2120,2014
+ENGL,2120,8,World Literature,0.56,0.19,0.19,0.0,0.04,0.0,0.0,0.04,andrew mathas,,ENGL-2120,2014
+ENGL,2120,9,World Literature,0.41,0.34,0.07,0.03,0.1,0.0,0.0,0.03,andrew mathas,,ENGL-2120,2014
+ENGL,2120,12,World Literature,0.5,0.21,0.11,0.04,0.11,0.0,0.0,0.04,john conway,,ENGL-2120,2014
+ENGL,2120,13,World Literature,0.23,0.46,0.19,0.08,0.0,0.0,0.0,0.04,david charles foltz,,ENGL-2120,2014
+ENGL,2120,14,World Literature,0.08,0.5,0.31,0.0,0.04,0.0,0.0,0.08,david charles foltz,,ENGL-2120,2014
+ENGL,2120,15,World Literature,0.44,0.15,0.26,0.04,0.11,0.0,0.0,0.0,john conway,,ENGL-2120,2014
+ENGL,2120,16,World Literature,0.57,0.25,0.07,0.0,0.0,0.0,0.0,0.11,lucian ghita,,ENGL-2120,2014
+ENGL,2130,1,British Literature,0.21,0.29,0.17,0.13,0.08,0.0,0.0,0.13,karen kettnich,,ENGL-2130,2014
+ENGL,2130,2,British Literature,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,karen kettnich,,ENGL-2130,2014
+ENGL,2130,3,British Literature,0.54,0.29,0.04,0.04,0.07,0.0,0.0,0.04,april susanne pelt,,ENGL-2130,2014
+ENGL,2130,4,British Literature,0.67,0.15,0.04,0.04,0.0,0.0,0.0,0.11,april susanne pelt,,ENGL-2130,2014
+ENGL,2130,5,British Literature,0.5,0.32,0.0,0.07,0.04,0.0,0.0,0.07,john conway,,ENGL-2130,2014
+ENGL,2130,6,British Literature,0.48,0.3,0.15,0.0,0.0,0.0,0.0,0.07,lucian ghita,,ENGL-2130,2014
+ENGL,2130,7,British Literature,0.5,0.36,0.07,0.04,0.0,0.0,0.0,0.04,lucian ghita,,ENGL-2130,2014
+ENGL,2130,8,British Literature,0.5,0.25,0.11,0.04,0.04,0.0,0.0,0.07,april susanne pelt,,ENGL-2130,2014
+ENGL,2130,9,British Literature,0.14,0.43,0.25,0.11,0.07,0.0,0.0,0.0,david charles foltz,,ENGL-2130,2014
+ENGL,2130,10,British Literature,0.41,0.33,0.07,0.0,0.11,0.0,0.0,0.07,john conway,,ENGL-2130,2014
+ENGL,2130,11,British Literature,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,sherri teres allred,,ENGL-2130,2014
+ENGL,2130,12,British Literature,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,sherri teres allred,,ENGL-2130,2014
+ENGL,2130,13,British Literature,0.19,0.33,0.26,0.07,0.04,0.0,0.0,0.11,david charles foltz,,ENGL-2130,2014
+ENGL,2140,1,American Literature,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,joshua nei waggoner,,ENGL-2140,2014
+ENGL,2140,2,American Literature,0.71,0.14,0.04,0.04,0.0,0.0,0.0,0.07,sharon kathl nalley,,ENGL-2140,2014
+ENGL,2140,3,American Literature,0.29,0.39,0.11,0.11,0.0,0.0,0.0,0.11,sharon kathl nalley,,ENGL-2140,2014
+ENGL,2140,4,American Literature,0.26,0.37,0.3,0.04,0.04,0.0,0.0,0.0,william stanton,,ENGL-2140,2014
+ENGL,2140,5,American Literature,0.59,0.19,0.07,0.04,0.07,0.0,0.0,0.04,william stanton,,ENGL-2140,2014
+ENGL,2140,6,American Literature,0.32,0.57,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2140,2014
+ENGL,2140,7,American Literature,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2140,2014
+ENGL,2140,8,American Literature,0.32,0.43,0.18,0.0,0.0,0.0,0.0,0.07,joshua nei waggoner,,ENGL-2140,2014
+ENGL,2140,9,American Literature,0.41,0.56,0.0,0.0,0.0,0.0,0.0,0.04,joshua nei waggoner,,ENGL-2140,2014
+ENGL,2140,11,American Literature,0.13,0.38,0.13,0.13,0.08,0.0,0.0,0.17,jonathan beec field,,ENGL-2140,2014
+ENGL,2140,12,American Literature,0.2,0.28,0.16,0.04,0.12,0.0,0.0,0.2,jonathan beec field,,ENGL-2140,2014
+ENGL,2140,13,American Literature,0.25,0.29,0.29,0.04,0.0,0.0,0.0,0.13,jonathan beec field,,ENGL-2140,2014
+ENGL,2140,14,American Literature,0.63,0.21,0.04,0.0,0.0,0.0,0.0,0.13,jonathan beec field,,ENGL-2140,2014
+ENGL,2140,15,American Literature,0.38,0.5,0.04,0.0,0.04,0.0,0.0,0.04,jonathan beec field,,ENGL-2140,2014
+ENGL,2140,16,American Literature,0.09,0.48,0.3,0.0,0.09,0.0,0.0,0.04,jonathan beec field,,ENGL-2140,2014
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.54,0.36,0.04,0.0,0.04,0.0,0.0,0.04,michael richa lucas,,ENGL-2150,2014
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,michael richa lucas,,ENGL-2150,2014
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.14,0.79,0.04,0.0,0.0,0.0,0.0,0.04,amy monaghan,,ENGL-2150,2014
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.29,0.5,0.07,0.04,0.04,0.0,0.0,0.07,william pulley,,ENGL-2150,2014
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.15,0.73,0.08,0.04,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-2150,2014
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.26,0.52,0.22,0.0,0.0,0.0,0.0,0.0,matthew schilleman,,ENGL-2150,2014
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.0,lauren woolbright,,ENGL-2150,2014
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,lauren woolbright,,ENGL-2150,2014
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.55,0.28,0.1,0.07,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2014
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.39,0.46,0.07,0.04,0.0,0.0,0.0,0.04,john morgenstern,,ENGL-2150,2014
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.36,0.43,0.14,0.04,0.0,0.0,0.0,0.04,sarah lauro,,ENGL-2150,2014
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.46,0.39,0.14,0.0,0.0,0.0,0.0,0.0,sarah lauro,,ENGL-2150,2014
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.59,0.24,0.14,0.0,0.0,0.0,0.0,0.03,john morgenstern,,ENGL-2150,2014
+ENGL,3000,1,ENGL 3000: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,,ENGL-3000,2014
+ENGL,3040,2,ENGL 3040: 002,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-3040,2014
+ENGL,3040,3,ENGL 3040: 003,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-3040,2014
+ENGL,3040,4,ENGL 3040: 004,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,sean williams,,ENGL-3040,2014
+ENGL,3040,5,ENGL 3040: 005,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-3040,2014
+ENGL,3040,13,ENGL 3040: 013,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexander kudera,,ENGL-3040,2014
+ENGL,3100,1,ENGL 3100: 001,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,walter edgar hunter,,ENGL-3100,2014
+ENGL,3100,2,ENGL 3100: 002,0.11,0.37,0.26,0.16,0.0,0.0,0.0,0.11,william stockton,,ENGL-3100,2014
+ENGL,3100,4,ENGL 3100: 004,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,cameron fa bushnell,,ENGL-3100,2014
+ENGL,3120,1,ENGL 3120: 001,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2014
+ENGL,3120,2,ENGL 3120: 002,0.37,0.37,0.11,0.0,0.05,0.0,0.0,0.11,elizabeth stansell,,ENGL-3120,2014
+ENGL,3140,1,Technical Writing,0.17,0.56,0.06,0.0,0.11,0.0,0.0,0.11,william pulley,,ENGL-3140,2014
+ENGL,3140,2,Technical Writing,0.58,0.32,0.0,0.0,0.0,0.0,0.0,0.11,christopher benson,,ENGL-3140,2014
+ENGL,3140,3,Technical Writing,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,william pulley,,ENGL-3140,2014
+ENGL,3140,4,Technical Writing,0.42,0.37,0.11,0.0,0.05,0.0,0.0,0.05,william pulley,,ENGL-3140,2014
+ENGL,3140,5,Technical Writing,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2014
+ENGL,3140,7,Technical Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2014
+ENGL,3140,8,Technical Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2014
+ENGL,3140,9,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,,ENGL-3140,2014
+ENGL,3140,10,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nancy swanson,,ENGL-3140,2014
+ENGL,3140,11,Technical Writing,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,nancy swanson,,ENGL-3140,2014
+ENGL,3140,13,Technical Writing,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,nancy swanson,,ENGL-3140,2014
+ENGL,3140,14,Technical Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,nancy swanson,,ENGL-3140,2014
+ENGL,3140,16,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,,ENGL-3140,2014
+ENGL,3140,17,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,,ENGL-3140,2014
+ENGL,3140,18,Technical Writing,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,david stubblefield,,ENGL-3140,2014
+ENGL,3140,19,Technical Writing,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3140,2014
+ENGL,3140,20,Technical Writing,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3140,2014
+ENGL,3140,140,Technical Writing,0.5,0.3,0.0,0.0,0.0,0.0,0.0,0.2,sarah mae cooper,,ENGL-3140,2014
+ENGL,3150,1,ENGL 3150: 001,0.0,0.63,0.37,0.0,0.0,0.0,0.0,0.0,barbara ramirez,,ENGL-3150,2014
+ENGL,3150,2,ENGL 3150: 002,0.06,0.61,0.28,0.0,0.0,0.0,0.0,0.06,barbara ramirez,,ENGL-3150,2014
+ENGL,3150,6,ENGL 3150: 006,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sharon kay henry,,ENGL-3150,2014
+ENGL,3150,7,ENGL 3150: 007,0.7,0.15,0.05,0.0,0.0,0.0,0.0,0.1,philip randall,,ENGL-3150,2014
+ENGL,3150,18,ENGL 3150: 018,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,,ENGL-3150,2014
+ENGL,3150,400,ENGL 3150: 400,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2014
+ENGL,3150,401,ENGL 3150: 401,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,philip randall,,ENGL-3150,2014
+ENGL,3450,1,ENGL 3450: 001,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,john logan pursley,,ENGL-3450,2014
+ENGL,3460,1,ENGL 3460: 001,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,angelina oberdan,,ENGL-3460,2014
+ENGL,3480,1,ENGL 3480: 001,0.67,0.11,0.17,0.0,0.06,0.0,0.0,0.0,joshua nei waggoner,,ENGL-3480,2014
+ENGL,3570,1,Film,0.36,0.5,0.05,0.05,0.0,0.0,0.0,0.05,sarah lauro,,ENGL-3570,2014
+ENGL,3800,1,ENGL 3800: 001,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,angela naimou,,ENGL-3800,2014
+ENGL,3850,1,ENGL 3850: 001,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-3850,2014
+ENGL,3860,1,ENGL 3860: 001,0.57,0.14,0.19,0.0,0.05,0.0,0.0,0.05,megan no macalystre,,ENGL-3860,2014
+ENGL,3960,1,ENGL 3960: 001,0.32,0.23,0.23,0.05,0.14,0.0,0.0,0.05,william stockton,,ENGL-3960,2014
+ENGL,3970,1,ENGL 3970: 001,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,david sweene coombs,,ENGL-3970,2014
+ENGL,3980,1,ENGL 3980: 001,0.23,0.45,0.18,0.05,0.09,0.0,0.0,0.0,rhondda robi thomas,,ENGL-3980,2014
+ENGL,3990,1,ENGL 3990: 001,0.36,0.27,0.27,0.0,0.05,0.0,0.0,0.05,matthew schilleman,,ENGL-3990,2014
+ENGL,3990,2,ENGL 3990: 002,0.23,0.59,0.14,0.0,0.05,0.0,0.0,0.0,matthew schilleman,,ENGL-3990,2014
+ENGL,4080,1,ENGL 4080: 001,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,susan hilligoss,,ENGL-4080,2014
+ENGL,4100,1,ENGL 4100: 001,0.31,0.31,0.19,0.06,0.13,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4100,2014
+ENGL,4110,1,ENGL 4110: 001,0.62,0.24,0.05,0.0,0.05,0.0,0.0,0.05,susan hilligoss,,ENGL-4110,2014
+ENGL,4110,2,ENGL 4110: 002,0.33,0.38,0.1,0.05,0.14,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4110,2014
+ENGL,4260,1,ENGL 4260: 001,0.5,0.28,0.17,0.0,0.06,0.0,0.0,0.0,jillian weise,,ENGL-4260,2014
+ENGL,4300,1,Dramatic Literature II,0.68,0.16,0.11,0.0,0.05,0.0,0.0,0.0,richard st. peter,,ENGL-4300,2014
+ENGL,4400,1,ENGL 4400: 001,0.29,0.48,0.19,0.0,0.05,0.0,0.0,0.0,brian mcgrath,,ENGL-4400,2014
+ENGL,4400,2,ENGL 4400: 002,0.41,0.41,0.06,0.0,0.06,0.0,0.0,0.06,dominic mastroianni,,ENGL-4400,2014
+ENGL,4410,1,Literary Editing,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,gabriel and hankins,True,ENGL-4410,2014
+ENGL,4430,1,ENGL 4430: 001,0.59,0.24,0.12,0.0,0.0,0.06,0.0,0.0,walter edgar hunter,,ENGL-4430,2014
+ENGL,4450,1,ENGL 4450: 001,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,keith morris,,ENGL-4450,2014
+ENGL,4600,1,ENGL 4600: 001,0.41,0.41,0.0,0.06,0.06,0.0,0.0,0.06,tharon howard,,ENGL-4600,2014
+ENGL,4640,1,ENGL 4640: 001,0.4,0.27,0.13,0.07,0.13,0.0,0.0,0.0,dominic mastroianni,,ENGL-4640,2014
+ENGL,4650,1,ENGL 4650: 001,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,angela naimou,,ENGL-4650,2014
+ENGL,4830,1,ENGL 4830: 001,0.23,0.54,0.0,0.0,0.15,0.0,0.0,0.08,rhondda robi thomas,,ENGL-4830,2014
+ENGL,4890,1,ENGL 4890: 001,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,sean williams,,ENGL-4890,2014
+ENGL,4920,1,Modern Rhetoric,0.29,0.29,0.36,0.0,0.07,0.0,0.0,0.0,brian mcgrath,,ENGL-4920,2014
+ENGL,4950,1,ENGL 4950: 001,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,sean morey,,ENGL-4950,2014
+ENGL,4960,2,ENGL 4960: 002,0.36,0.36,0.07,0.07,0.07,0.0,0.0,0.07,agnieszka skrodzka,,ENGL-4960,2014
+ENGL,4960,3,ENGL 4960: 003,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,,ENGL-4960,2014
+ENGL,8310,1,Special Topics,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,,ENGL-8310,2014
+ENGR,1020,14,Engineering Discipl & Skills,0.09,0.3,0.32,0.09,0.07,0.0,0.0,0.14,steven brandon,,ENGR-1020,2014
+ENGR,1410,12,Programming & Problem Solving,0.11,0.39,0.28,0.16,0.02,0.0,0.0,0.05,steven brandon,,ENGR-1410,2014
+ENGR,1410,13,Programming & Problem Solving,0.41,0.32,0.17,0.05,0.0,0.0,0.0,0.05,elizabeth stephan,,ENGR-1410,2014
+ENGR,1410,17,Programming & Problem Solving,0.14,0.48,0.24,0.06,0.07,0.0,0.0,0.01,david ewing,,ENGR-1410,2014
+ENGR,1410,18,Programming & Problem Solving,0.12,0.41,0.36,0.09,0.02,0.0,0.0,0.0,william martin,,ENGR-1410,2014
+ENGR,1410,19,Programming & Problem Solving,0.12,0.29,0.39,0.1,0.03,0.0,0.0,0.07,david ewing,,ENGR-1410,2014
+ENGR,1410,20,Programming & Problem Solving,0.18,0.42,0.3,0.06,0.03,0.0,0.0,0.01,christopher norfolk,,ENGR-1410,2014
+ENGR,1410,22,Programming & Problem Solving,0.23,0.39,0.23,0.11,0.02,0.0,0.0,0.04,christopher norfolk,,ENGR-1410,2014
+ENGR,1410,25,Programming & Problem Solving,0.15,0.42,0.2,0.13,0.07,0.0,0.0,0.04,william park,,ENGR-1410,2014
+ENGR,1410,27,Programming & Problem Solving,0.05,0.21,0.43,0.12,0.09,0.0,0.0,0.1,william park,,ENGR-1410,2014
+ENGR,1410,50,Programming & Problem Solving,0.33,0.45,0.19,0.0,0.02,0.0,0.0,0.0,john minor,,ENGR-1410,2014
+ENGR,1410,52,Prog. & Problem Solving (HON),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True,ENGR-1410,2014
+ENGR,1410,56,Programming & Problem Solving,0.21,0.45,0.29,0.02,0.02,0.0,0.0,0.0,sabrina lau,,ENGR-1410,2014
+ENGR,1410,58,Programming & Problem Solving,0.12,0.54,0.29,0.05,0.0,0.0,0.0,0.0,david ewing,,ENGR-1410,2014
+ENGR,1410,60,Prog & Problem Solving (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True,ENGR-1410,2014
+ENGR,1410,64,Programming & Problem Solving,0.22,0.39,0.34,0.0,0.05,0.0,0.0,0.0,david ewing,,ENGR-1410,2014
+ENGR,1410,66,Programming & Problem Solving,0.12,0.44,0.32,0.12,0.0,0.0,0.0,0.0,david ewing,,ENGR-1410,2014
+ENGR,2080,11,Engr Graphics & Machine Design,0.57,0.15,0.21,0.01,0.01,0.0,0.0,0.04,sabrina lau,,ENGR-2080,2014
+ENGR,2080,15,Engr Graphics & Machine Design,0.61,0.28,0.07,0.0,0.03,0.0,0.0,0.01,john minor,,ENGR-2080,2014
+ENGR,2080,21,Engr Graphics & Machine Design,0.49,0.35,0.09,0.0,0.03,0.0,0.0,0.04,sarah grigg,,ENGR-2080,2014
+ENGR,2080,23,Engr Graphics & Machine Design,0.46,0.29,0.11,0.04,0.03,0.0,0.0,0.07,sarah grigg,,ENGR-2080,2014
+ENGR,2080,31,Engr Graphics & Machine Design,0.7,0.16,0.1,0.01,0.01,0.0,0.0,0.01,sabrina lau,,ENGR-2080,2014
+ENGR,2080,39,Engr Graphics & Machine Design,0.61,0.3,0.04,0.01,0.0,0.0,0.0,0.03,sarah grigg,,ENGR-2080,2014
+ENGR,2080,54,Engr Graphics & Machine Design,0.67,0.21,0.1,0.02,0.0,0.0,0.0,0.0,john minor,,ENGR-2080,2014
+ENGR,2100,32,CAD & Engineering Apllications,0.63,0.15,0.05,0.05,0.05,0.0,0.0,0.07,william martin,,ENGR-2100,2014
+ENGR,2100,38,CAD & Engineering Aplications,0.53,0.14,0.14,0.0,0.07,0.0,0.0,0.12,william martin,,ENGR-2100,2014
+ENGR,2100,40,CAD & Engineering Apllications,0.76,0.09,0.09,0.0,0.0,0.0,0.0,0.07,nighat yasmin,,ENGR-2100,2014
+ENR,3020,1,ENR 3020: 001,0.38,0.46,0.1,0.05,0.0,0.0,0.0,0.0,lawrence gering,,ENR-3020,2014
+ENR,4500,1,ENR 4500: 001,0.79,0.05,0.11,0.0,0.03,0.0,0.0,0.03,alan johnson,,ENR-4500,2014
+ENR,4500,2,ENR 4500: 002,0.71,0.21,0.04,0.04,0.0,0.0,0.0,0.0,alan johnson,,ENR-4500,2014
+ENSP,2000,1,Intro Environ Sci,0.47,0.35,0.1,0.02,0.0,0.0,0.0,0.06,scott brame,,ENSP-2000,2014
+ENSP,2000,2,Intro Environ Sci,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,ENSP-2000,2014
+ENSP,2000,3,Intro Environ Sci,0.24,0.64,0.1,0.0,0.0,0.0,0.0,0.02,john coates,,ENSP-2000,2014
+ENT,2000,1,Six-Legged Science,0.39,0.42,0.06,0.06,0.0,0.0,0.0,0.06,patricia zungoli,,ENT-2000,2014
+ENT,8100,1,Forensic Entomology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,peter adler,,ENT-8100,2014
+ESED,8200,1,ESED 8200: 001,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lisa benson,,ESED-8200,2014
+ETOX,8300,1,Mechanistic Toxicology,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,,ETOX-8300,2014
+FCS,8920,1,Research Methods II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,,FCS-8920,2014
+FCS,8920,13,Program Evaluation,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mark small,,FCS-8920,2014
+FDSC,1020,1,FDSC 1020: 001,0.58,0.37,0.01,0.01,0.0,0.0,0.0,0.03,john mcgregor,,FDSC-1020,2014
+FDSC,2140,1,Fd Resources & Soc,0.61,0.27,0.08,0.01,0.0,0.0,0.0,0.04,paul dawson,,FDSC-2140,2014
+FDSC,4020,1,Food Chem II,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,feng chen,,FDSC-4020,2014
+FDSC,4030,1,Food Ch & Analysis,0.82,0.15,0.0,0.0,0.0,0.0,0.0,0.03,paul dawson,,FDSC-4030,2014
+FDSC,4080,1,FDSC 4080: 001,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,felix barron,,FDSC-4080,2014
+FDSC,4090,1,TQM for Food & Pckg Industries,0.6,0.35,0.06,0.0,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-4090,2014
+FIN,3050,1,Investment Analysis,0.11,0.41,0.35,0.11,0.03,0.0,0.0,0.0,kerri mcmillan,,FIN-3050,2014
+FIN,3050,2,Investment Analysis,0.26,0.36,0.28,0.08,0.03,0.0,0.0,0.0,kerri mcmillan,,FIN-3050,2014
+FIN,3050,3,Investment Analysis,0.23,0.3,0.35,0.05,0.03,0.03,0.0,0.03,kerri mcmillan,,FIN-3050,2014
+FIN,3060,1,Corporation Finance,0.17,0.17,0.23,0.17,0.15,0.0,0.0,0.1,william hol johnson,,FIN-3060,2014
+FIN,3060,2,Corporation Finance,0.17,0.29,0.13,0.19,0.17,0.0,0.0,0.04,william hol johnson,,FIN-3060,2014
+FIN,3060,3,Corporation Finance,0.24,0.4,0.24,0.1,0.0,0.0,0.0,0.02,neil waller,,FIN-3060,2014
+FIN,3060,4,Corporation Finance,0.1,0.34,0.36,0.12,0.0,0.0,0.0,0.08,john harris,,FIN-3060,2014
+FIN,3060,5,Corporation Finance,0.18,0.45,0.2,0.02,0.0,0.0,0.0,0.16,john harris,,FIN-3060,2014
+FIN,3060,6,Corporation Finance,0.25,0.43,0.25,0.04,0.02,0.02,0.0,0.0,neil waller,,FIN-3060,2014
+FIN,3060,7,Corporation Finance,0.12,0.5,0.27,0.08,0.04,0.0,0.0,0.0,neil waller,,FIN-3060,2014
+FIN,3070,1,Prin of Real Estate,0.15,0.23,0.35,0.12,0.12,0.0,0.0,0.02,ramon tolb franklin,,FIN-3070,2014
+FIN,3070,2,Prin of Real Estate,0.3,0.3,0.26,0.11,0.02,0.0,0.0,0.02,thomas springer,,FIN-3070,2014
+FIN,3080,1,Fin Inst & Mkts,0.08,0.53,0.26,0.03,0.03,0.0,0.0,0.08,lyudmila chernykh,,FIN-3080,2014
+FIN,3080,2,Fin Inst & Mkts,0.18,0.33,0.33,0.05,0.08,0.0,0.0,0.03,michael spivey,,FIN-3080,2014
+FIN,3080,3,Fin Inst & Mkts,0.23,0.28,0.28,0.05,0.03,0.0,0.0,0.13,michael spivey,,FIN-3080,2014
+FIN,3110,1,Financial Management I,0.09,0.2,0.45,0.14,0.05,0.0,0.0,0.07,ramon tolb franklin,,FIN-3110,2014
+FIN,3110,2,Financial Management I,0.14,0.23,0.35,0.05,0.07,0.0,0.0,0.16,george bra lockhart,,FIN-3110,2014
+FIN,3110,3,Financial Management I,0.27,0.27,0.31,0.02,0.0,0.0,0.0,0.13,george bra lockhart,,FIN-3110,2014
+FIN,3110,4,Financial Management I,0.12,0.36,0.29,0.14,0.05,0.0,0.0,0.05,george bra lockhart,,FIN-3110,2014
+FIN,3120,1,Financial Mgt II,0.16,0.65,0.13,0.03,0.03,0.0,0.0,0.0,lyudmila chernykh,,FIN-3120,2014
+FIN,3120,2,Financial Mgt II,0.58,0.24,0.12,0.03,0.0,0.0,0.0,0.03,melvin stith,,FIN-3120,2014
+FIN,3120,3,Financial Mgt II,0.53,0.31,0.03,0.06,0.08,0.0,0.0,0.0,melvin stith,,FIN-3120,2014
+FIN,3120,4,Financial Mgt II,0.5,0.31,0.13,0.0,0.06,0.0,0.0,0.0,melvin stith,,FIN-3120,2014
+FIN,4040,1,Financial Modeling,0.11,0.26,0.41,0.11,0.11,0.0,0.0,0.0,jack wolf,,FIN-4040,2014
+FIN,4040,2,Financial Modeling,0.13,0.47,0.28,0.09,0.03,0.0,0.0,0.0,jack wolf,,FIN-4040,2014
+FIN,4040,3,Financial Modeling,0.13,0.47,0.2,0.1,0.03,0.0,0.0,0.07,jack wolf,,FIN-4040,2014
+FIN,4050,1,Port Mgt and Theory,0.24,0.24,0.24,0.24,0.0,0.0,0.0,0.04,john alexander,,FIN-4050,2014
+FIN,4050,2,Port Mgt and Theory,0.14,0.14,0.29,0.14,0.1,0.0,0.0,0.19,john alexander,,FIN-4050,2014
+FIN,4080,1,Mgt of Fin Inst,0.07,0.44,0.42,0.02,0.04,0.0,0.0,0.0,michael spivey,,FIN-4080,2014
+FIN,4110,1,Int Fin Mgt,0.26,0.28,0.36,0.08,0.03,0.0,0.0,0.0,john harris,,FIN-4110,2014
+FIN,4110,2,Int Fin Mgt,0.26,0.41,0.23,0.08,0.0,0.0,0.0,0.03,john harris,,FIN-4110,2014
+FIN,4150,1,Real Estate Investmt,0.19,0.24,0.29,0.24,0.0,0.05,0.0,0.0,thomas springer,,FIN-4150,2014
+FIN,4160,1,Real Estate Val,0.0,0.32,0.55,0.14,0.0,0.0,0.0,0.0,neil waller,,FIN-4160,2014
+FNR,1020,1,FNR 1020: 001,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,elena mikhailova,,FNR-1020,2014
+FNR,4990,1,FNR 4990: 001,0.72,0.11,0.06,0.06,0.06,0.0,0.0,0.0,donald hagan,,FNR-4990,2014
+FNR,4990,3,FNR 4990: 003,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,donald hagan,,FNR-4990,2014
+FOR,2060,1,FOR 2060: 001,0.38,0.34,0.19,0.07,0.0,0.0,0.0,0.02,donald hagan,,FOR-2060,2014
+FOR,3080,1,FOR 3080: 001,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,lawrence gering,,FOR-3080,2014
+FOR,4060,1,FOR 4060: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william roc english,,FOR-4060,2014
+FOR,4080,1,FOR 4080: 001,0.54,0.36,0.11,0.0,0.0,0.0,0.0,0.0,patricia layton,,FOR-4080,2014
+FOR,4150,1,FOR 4150: 001,0.23,0.59,0.18,0.0,0.0,0.0,0.0,0.0,james davis,,FOR-4150,2014
+FOR,4180,1,FOR 4180: 001,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,thomas straka,,FOR-4180,2014
+FOR,4340,1,GIS for Landscape Planning,0.19,0.64,0.14,0.0,0.0,0.0,0.0,0.03,robert frit baldwin,,FOR-4340,2014
+FOR,4650,1,FOR 4650: 001,0.42,0.33,0.25,0.0,0.0,0.0,0.0,0.0,gaofeng wang,,FOR-4650,2014
+FOR,6340,1,GIS for Landscape Planning,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robert frit baldwin,,FOR-6340,2014
+FR,1010,1,FR 1010: 001,0.64,0.23,0.09,0.0,0.0,0.0,0.0,0.05,julian hamil killey,,FR-1010,2014
+FR,1020,1,FR 1020: 001,0.38,0.38,0.0,0.19,0.0,0.0,0.0,0.06,julian hamil killey,,FR-1020,2014
+FR,1020,2,FR 1020: 002,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,julian hamil killey,,FR-1020,2014
+FR,1020,3,FR 1020: 003,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2014
+FR,2010,1,Intermediate French,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,amy lyn grif sawyer,,FR-2010,2014
+FR,2010,2,Intermediate French,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2010,2014
+FR,2010,3,Intermediate French,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,julian hamil killey,,FR-2010,2014
+FR,2020,1,Intermediate French,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2020,2014
+FR,2020,4,Intermediate French,0.14,0.5,0.21,0.0,0.07,0.0,0.0,0.07,kenneth dav widgren,,FR-2020,2014
+FR,2020,5,Intermediate French,0.53,0.35,0.06,0.0,0.0,0.0,0.0,0.06,joseph mai,,FR-2020,2014
+FR,3000,1,Survey of French Lit,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,karyna szmurlo,,FR-3000,2014
+FR,3050,1,FR 3050: 001,0.41,0.24,0.12,0.0,0.06,0.0,0.0,0.18,kenneth dav widgren,,FR-3050,2014
+FR,3170,1,FR 3170: 001,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,joseph mai,,FR-3170,2014
+FR,4200,1,FR 4200: 001,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,karyna szmurlo,,FR-4200,2014
+GC,1010,1,GC 1010: 001,0.57,0.34,0.02,0.0,0.0,0.0,0.0,0.07,kern cox,,GC-1010,2014
+GC,1020,1,GC 1020: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,charles tabor weiss,,GC-1020,2014
+GC,1020,2,GC 1020: 002,0.35,0.48,0.04,0.0,0.04,0.0,0.0,0.09,carol jones,,GC-1020,2014
+GC,1030,1,GC 1030: 001,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,john jacobs,,GC-1030,2014
+GC,1030,2,GC 1030: 002,0.67,0.13,0.07,0.07,0.07,0.0,0.0,0.0,john jacobs,,GC-1030,2014
+GC,1040,1,Graphic Com I,0.49,0.41,0.06,0.0,0.01,0.0,0.0,0.02,rebecca suza edlein,,GC-1040,2014
+GC,1990,4,CI in GC I-J Lay CS,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,janice ann lay,,GC-1990,2014
+GC,2070,1,Graphic Com II,0.54,0.37,0.09,0.0,0.0,0.0,0.0,0.0,patrick gee rose,,GC-2070,2014
+GC,3400,1,Digital Img & Emedia,0.33,0.46,0.17,0.0,0.04,0.0,0.0,0.0,erica black walker,,GC-3400,2014
+GC,4060,1,Pkg & Spec Prtg,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kern cox,,GC-4060,2014
+GC,4400,1,Commercial Printing,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,,GC-4400,2014
+GC,4440,1,Current Dev in G C,0.29,0.57,0.07,0.07,0.0,0.0,0.0,0.0,liam henry 'hara,,GC-4440,2014
+GC,4460,1,Ink & Substrates,0.27,0.59,0.14,0.0,0.0,0.0,0.0,0.0,liam henry 'hara,,GC-4460,2014
+GC,4480,1,Plan and Cont Print,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john leininger,,GC-4480,2014
+GC,4900,2,G C Selected Topics-Sales,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,,GC-4900,2014
+GEN,3000,1,GEN 3000: 001,0.3,0.37,0.21,0.06,0.02,0.0,0.0,0.05,kate leanne wi tsai,,GEN-3000,2014
+GEN,3000,2,GEN 3000: 002,0.36,0.3,0.17,0.11,0.01,0.0,0.0,0.06,kate leanne wi tsai,,GEN-3000,2014
+GEN,4100,1,Population & Quant Genetics,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,,GEN-4100,2014
+GEN,4110,2,GEN 4110: 002,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,,GEN-4110,2014
+GEN,6100,1,Population & Quant Genetics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,,GEN-6100,2014
+GEOG,1010,1,Intro to Geography,0.37,0.45,0.13,0.0,0.03,0.0,0.0,0.03,christa smith,,GEOG-1010,2014
+GEOG,1030,1,World Regional Geog,0.82,0.11,0.04,0.02,0.0,0.0,0.0,0.01,lance forres howard,,GEOG-1030,2014
+GEOG,1030,2,World Regional Geog,0.3,0.43,0.1,0.13,0.05,0.0,0.0,0.0,william churc terry,,GEOG-1030,2014
+GEOG,3020,1,GEOG 3020: 001,0.67,0.25,0.0,0.0,0.08,0.0,0.0,0.0,william churc terry,,GEOG-3020,2014
+GEOG,3050,1,GEOG 3050: 001,0.74,0.16,0.05,0.05,0.0,0.0,0.0,0.0,lance forres howard,,GEOG-3050,2014
+GEOL,1010,1,Physical Geology,0.13,0.31,0.27,0.12,0.11,0.0,0.0,0.05,alan coulson,,GEOL-1010,2014
+GEOL,1010,2,Physical Geology,0.28,0.37,0.2,0.06,0.05,0.0,0.0,0.04,alan coulson,,GEOL-1010,2014
+GEOL,1020,1,Earth History,0.13,0.44,0.31,0.06,0.0,0.0,0.0,0.06,alan coulson,,GEOL-1020,2014
+GEOL,1030,1,Physical Geol Lab,0.74,0.09,0.04,0.0,0.09,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,4,Physical Geol Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2014
+GEOL,1030,5,Physical Geol Lab,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,6,Physical Geol Lab,0.87,0.0,0.09,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,7,Physical Geol Lab,0.29,0.63,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,8,Physical Geol Lab,0.5,0.41,0.05,0.0,0.05,0.0,0.0,0.0,alan coulson,,GEOL-1030,2014
+GEOL,1030,9,Physical Geol Lab,0.68,0.23,0.0,0.0,0.05,0.0,0.0,0.05,alan coulson,,GEOL-1030,2014
+GEOL,1030,10,Physical Geol Lab,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2014
+GEOL,1030,11,Physical Geol Lab,0.46,0.5,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2014
+GEOL,1030,12,Physical Geol Lab,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,alan coulson,,GEOL-1030,2014
+GEOL,3130,1,GEOL 3130: 001,0.14,0.57,0.24,0.05,0.0,0.0,0.0,0.0,james castle,,GEOL-3130,2014
+GEOL,3180,1,GEOL 3180: 001,0.18,0.57,0.18,0.0,0.04,0.0,0.0,0.04,brian powell,,GEOL-3180,2014
+GEOL,7900,500,Selected Topics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,GEOL-7900,2014
+GEOL,8080,1,Groundwater Modeling,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,,GEOL-8080,2014
+GER,1010,3,GER 1010: 003,0.67,0.27,0.0,0.07,0.0,0.0,0.0,0.0,oswald harris king,,GER-1010,2014
+GER,1010,4,GER 1010: 004,0.31,0.08,0.15,0.0,0.08,0.0,0.0,0.38,oswald harris king,,GER-1010,2014
+GER,1010,5,GER 1010: 005,0.08,0.69,0.0,0.0,0.08,0.0,0.0,0.15,oswald harris king,,GER-1010,2014
+GER,1020,3,GER 1020: 003,0.35,0.15,0.1,0.1,0.0,0.0,0.0,0.3, lee ferrell,,GER-1020,2014
+GER,1020,4,GER 1020: 004,0.27,0.2,0.13,0.0,0.2,0.0,0.0,0.2, lee ferrell,,GER-1020,2014
+GER,2010,2,Intermediate German,0.27,0.27,0.2,0.13,0.07,0.0,0.0,0.07,gabriela stoicea,,GER-2010,2014
+GER,2020,3,Intermediate German,0.21,0.38,0.29,0.08,0.0,0.0,0.0,0.04,johannes schmidt,,GER-2020,2014
+GER,3060,1,German Short Story,0.18,0.53,0.12,0.06,0.0,0.0,0.0,0.12,gabriela stoicea,,GER-3060,2014
+GER,3160,1,GER 3160: 001,0.23,0.62,0.0,0.0,0.15,0.0,0.0,0.0, lee ferrell,,GER-3160,2014
+GW,3010,1,Grt Books West World,0.47,0.24,0.18,0.0,0.12,0.0,0.0,0.0,henry clark,,GW-3010,2014
+HCC,8810,2,Health Informatics,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,kelly caine,,HCC-8810,2014
+HEHD,4000,1,HEHD 4000: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,,HEHD-4000,2014
+HEHD,4100,1,HEHD 4100: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary price,,HEHD-4100,2014
+HEHD,8000,230,HEHD 8000: 230,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,robert ja barcelona,,HEHD-8000,2014
+HEHD,8010,230,HEHD 8010: 230,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,,HEHD-8010,2014
+HIST,1010,1,Hist of the U S,0.22,0.24,0.19,0.14,0.16,0.0,0.0,0.05,james brad jeffries,,HIST-1010,2014
+HIST,1220,1,"Hist, Tech & Society",0.53,0.21,0.15,0.06,0.0,0.01,0.0,0.03,henry clark,,HIST-1220,2014
+HIST,1240,1,Environmental Hist,0.23,0.56,0.13,0.03,0.0,0.0,0.0,0.05,james brad jeffries,,HIST-1240,2014
+HIST,1240,2,Environmental Hist,0.21,0.51,0.21,0.05,0.0,0.0,0.0,0.03,james brad jeffries,,HIST-1240,2014
+HIST,1720,1,The West and the World I,0.36,0.29,0.26,0.05,0.02,0.0,0.0,0.02,henry clark,,HIST-1720,2014
+HIST,1720,2,The West and the World I,0.27,0.71,0.02,0.0,0.0,0.0,0.0,0.0,emily wood,,HIST-1720,2014
+HIST,1730,1,The West and the World II,0.27,0.27,0.25,0.02,0.11,0.0,0.0,0.07, alan grubb,,HIST-1730,2014
+HIST,1730,2,The West and the World II,0.24,0.32,0.2,0.04,0.11,0.0,0.0,0.09,richard saunders,,HIST-1730,2014
+HIST,1730,3,The West and the World II,0.21,0.47,0.18,0.06,0.05,0.0,0.0,0.04,steven marks,,HIST-1730,2014
+HIST,2990,1,HIST 2990: 001,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,rachel anne moore,,HIST-2990,2014
+HIST,2990,2,HIST 2990: 002,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,rachel anne moore,,HIST-2990,2014
+HIST,3060,1,HIST 3060: 001,0.39,0.37,0.11,0.04,0.02,0.0,0.0,0.07,richard saunders,,HIST-3060,2014
+HIST,3120,1,HIST 3120: 001,0.4,0.44,0.09,0.02,0.02,0.0,0.0,0.02,abel bartley,,HIST-3120,2014
+HIST,3140,1,HIST 3140: 001,0.11,0.64,0.22,0.0,0.0,0.0,0.0,0.02,paul chris anderson,,HIST-3140,2014
+HIST,3210,1,History of Science,0.28,0.23,0.21,0.15,0.05,0.0,0.0,0.08,pamela mack,,HIST-3210,2014
+HIST,3260,1,HIST 3260: 001,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03, roger grant,,HIST-3260,2014
+HIST,3290,1,HIST 3290: 001,0.17,0.42,0.21,0.08,0.0,0.0,0.0,0.13,maribel morey,,HIST-3290,2014
+HIST,3390,1,HIST 3390: 001,0.46,0.21,0.15,0.08,0.08,0.0,0.0,0.03,james burns,,HIST-3390,2014
+HIST,3420,1,HIST 3420: 001,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,rachel anne moore,,HIST-3420,2014
+HIST,3670,1,HIST 3670: 001,0.37,0.34,0.13,0.0,0.11,0.0,0.0,0.05,michael silvestri,,HIST-3670,2014
+HIST,3730,1,Age of Protestant Reformation,0.43,0.07,0.14,0.0,0.21,0.0,0.0,0.14,thomas kuehn,,HIST-3730,2014
+HIST,3780,1,HIST 3780: 001,0.4,0.31,0.17,0.06,0.06,0.0,0.0,0.0,michael meng,,HIST-3780,2014
+HIST,3900,1,HIST 3900: 001,0.15,0.41,0.3,0.07,0.07,0.0,0.0,0.0,edwin moise,,HIST-3900,2014
+HIST,3970,1,HIST 3970: 001,0.44,0.44,0.07,0.0,0.02,0.0,0.0,0.02,amit bein,,HIST-3970,2014
+HIST,4170,1,HIST 4170: 001,0.25,0.5,0.17,0.0,0.08,0.0,0.0,0.0,meg taylor-shockley,,HIST-4170,2014
+HIST,4240,1,Top in Hist of Medicine & Hlth,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,pamela mack,,HIST-4240,2014
+HIST,4360,1,HIST 4360: 001,0.23,0.27,0.41,0.0,0.09,0.0,0.0,0.0,edwin moise,,HIST-4360,2014
+HIST,4600,1,Britain & WWII,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,james burns,,HIST-4600,2014
+HIST,4710,1,The Great War 1914 & 1918,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0, alan grubb,,HIST-4710,2014
+HIST,4900,2,The Empire World,0.4,0.27,0.2,0.0,0.07,0.0,0.0,0.07,michael silvestri,,HIST-4900,2014
+HIST,4900,3,Heroic Failures,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,,HIST-4900,2014
+HIST,4930,2,Urban History,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,abel bartley,,HIST-4930,2014
+HLTH,2020,1,HLTH 2020: 001,0.23,0.64,0.13,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2014
+HLTH,2020,2,HLTH 2020: 002,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2014
+HLTH,2020,3,HLTH 2020: 003,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,sarah griffin,,HLTH-2020,2014
+HLTH,2020,400,HLTH 2020: 400,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2014
+HLTH,2030,1,HLTH 2030: 001,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2030,2014
+HLTH,2030,2,HLTH 2030: 002,0.65,0.22,0.11,0.0,0.0,0.0,0.0,0.03,son albury-crandall,,HLTH-2030,2014
+HLTH,2030,400,HLTH 2030: 400,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2030,2014
+HLTH,2030,401,HLTH 2030: 401,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2030,2014
+HLTH,2400,1,HLTH 2400: 001,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,joel edwar williams,,HLTH-2400,2014
+HLTH,2400,2,HLTH 2400: 002,0.73,0.1,0.15,0.02,0.0,0.0,0.0,0.0,joel edwar williams,,HLTH-2400,2014
+HLTH,2980,1,HLTH 2980: 001,0.52,0.45,0.02,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-2980,2014
+HLTH,2980,2,HLTH 2980: 002,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-2980,2014
+HLTH,3100,1,HLTH 3100: 001,0.19,0.62,0.15,0.0,0.0,0.0,0.0,0.04,rachel mayo,,HLTH-3100,2014
+HLTH,3100,2,HLTH 3100: 002,0.48,0.36,0.12,0.04,0.0,0.0,0.0,0.0,rachel mayo,,HLTH-3100,2014
+HLTH,3800,1,HLTH 3800: 001,0.41,0.44,0.13,0.0,0.03,0.0,0.0,0.0,liwei chen,,HLTH-3800,2014
+HLTH,3800,2,HLTH 3800: 002,0.32,0.5,0.11,0.04,0.04,0.0,0.0,0.0,liwei chen,,HLTH-3800,2014
+HLTH,3980,1,HLTH 3980: 001,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,kathleen meyer,,HLTH-3980,2014
+HLTH,4000,1,Adolescent Health,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-4000,2014
+HLTH,4020,1,HLTH 4020: 001,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,karen kemper,,HLTH-4020,2014
+HLTH,4190,1,HLTH 4190: 001,0.31,0.58,0.09,0.0,0.0,0.0,0.0,0.02,kathleen meyer,,HLTH-4190,2014
+HLTH,4200,1,Hlth Science Intern,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2014
+HLTH,4300,1,HLTH 4300: 001,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,,HLTH-4300,2014
+HLTH,4310,1,Public & Environ Hlt,0.63,0.29,0.04,0.0,0.02,0.0,0.0,0.02,deborah alma falta,,HLTH-4310,2014
+HLTH,4400,1,HLTH 4400: 001,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,windsor we sherrill,,HLTH-4400,2014
+HLTH,4600,1,HLTH 4600: 001,0.59,0.33,0.04,0.0,0.0,0.0,0.0,0.04,deidra jol morrison,,HLTH-4600,2014
+HLTH,4780,1,HLTH 4780: 001,0.11,0.56,0.3,0.0,0.0,0.0,0.0,0.04,hugh spitler,,HLTH-4780,2014
+HLTH,4790,1,HLTH 4790: 001,0.17,0.48,0.24,0.1,0.0,0.0,0.0,0.0,khoa dang truong,,HLTH-4790,2014
+HLTH,4800,1,HLTH 4800: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,,HLTH-4800,2014
+HLTH,4900,1,HLTH 4900: 001,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,lu shi,,HLTH-4900,2014
+HLTH,4900,2,HLTH 4900: 002,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,lu shi,,HLTH-4900,2014
+HON,2030,2,Music and Politics (HON),0.83,0.06,0.0,0.06,0.0,0.0,0.0,0.06,eric lapin,True,HON-2030,2014
+HON,2060,1,Intro to Nanotechnology,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,christophe kitchens,True,HON-2060,2014
+HON,2210,1,The Great War 1914-1918,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True,HON-2210,2014
+HON,2210,3,20th Century Lit & Painting,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,john morgenstern,True,HON-2210,2014
+HON,2210,5,Spies and Spy Novels,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,william lasser,True,HON-2210,2014
+HORT,1010,1,HORT 1010: 001,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,,HORT-1010,2014
+HORT,2110,1,HORT 2110: 001,0.33,0.33,0.19,0.11,0.04,0.0,0.0,0.0,james emerson faust,,HORT-2110,2014
+HORT,4040,1,HORT 4040: 001,0.06,0.44,0.19,0.14,0.14,0.0,0.0,0.03,jeffrey adelberg,,HORT-4040,2014
+HORT,4050,2,HORT 4050: 002,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,,HORT-4050,2014
+HORT,4270,1,Urban Tree Care,0.18,0.36,0.18,0.05,0.18,0.0,0.0,0.05,robert polomski,,HORT-4270,2014
+HORT,4330,1,Turf Weed Management,0.13,0.54,0.25,0.0,0.04,0.0,0.0,0.04,ted whitwell,,HORT-4330,2014
+HORT,4720,1,HORT 4720: 001,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-4720,2014
+HP,8900,400,Directed Studies: Pres Eng,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,craig mille bennett,,HP-8900,2014
+HP,8910,1,HP 8910: 001,0.0,0.0,0.0,0.0,0.0,0.85,0.15,0.0,carter lee hudgins,,HP-8910,2014
+HRD,8470,400,HRD 8470: 400,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,,HRD-8470,2014
+HRD,8470,401,HRD 8470: 401,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,,HRD-8470,2014
+HRD,8470,402,HRD 8470: 402,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,eileen newmark,,HRD-8470,2014
+HRD,8470,403,HRD 8470: 403,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,,HRD-8470,2014
+HRD,8470,405,HRD 8470: 405,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eileen newmark,,HRD-8470,2014
+IE,2010,1,IE 2010: 001,0.37,0.27,0.23,0.13,0.0,0.0,0.0,0.0,joel greenstein,,IE-2010,2014
+IE,2100,1,IE 2100: 001,0.46,0.4,0.08,0.02,0.02,0.0,0.0,0.01,antonia rodriguez,,IE-2100,2014
+IE,3610,1,IE 3610: 001,0.42,0.32,0.1,0.09,0.05,0.0,0.0,0.03,david neyens,,IE-3610,2014
+IE,3810,1,IE 3810: 001,0.34,0.42,0.14,0.07,0.02,0.0,0.0,0.01,mary elizabeth kurz,,IE-3810,2014
+IE,3840,1,IE 3840: 001,0.36,0.2,0.16,0.05,0.08,0.0,0.0,0.14,brian melloy,,IE-3840,2014
+IE,3860,1,IE 3860: 001,0.6,0.26,0.12,0.01,0.0,0.0,0.0,0.01,jonathan lowe,,IE-3860,2014
+IE,4600,1,IE 4600: 001,0.33,0.39,0.22,0.06,0.0,0.0,0.0,0.0,joel greenstein,,IE-4600,2014
+IE,4620,1,IE 4620: 001,0.35,0.6,0.03,0.0,0.0,0.02,0.0,0.0,byung rae cho,,IE-4620,2014
+IE,4910,1,Appl Probability Models in IE,0.82,0.0,0.09,0.09,0.0,0.0,0.0,0.0,brian melloy,,IE-4910,2014
+IE,6620,1,IE 6620: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,byung rae cho,,IE-6620,2014
+IE,8010,1,Human-Machine Sys,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,,IE-8010,2014
+IE,8040,1,IE 8040: 001,0.29,0.48,0.24,0.0,0.0,0.0,0.0,0.0,william ferrell,,IE-8040,2014
+IE,8050,1,IE 8050: 001,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,byung rae cho,,IE-8050,2014
+IE,8520,1,IE 8520: 001,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabeth kurz,,IE-8520,2014
+IE,8540,1,IE 8540: 001,0.47,0.39,0.08,0.0,0.0,0.0,0.0,0.06,william ferrell,,IE-8540,2014
+IE,8580,1,IE 8580: 001,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-8580,2014
+IE,8800,1,IE 8800: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,amin khademi,,IE-8800,2014
+IS,2100,615,Sel Topics Int Study,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,sallie bro turnbull,,IS-2100,2014
+ITAL,1010,1,ITAL 1010: 001,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,julia schmidt,,ITAL-1010,2014
+ITAL,1020,1,ITAL 1020: 001,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,luca barattoni,,ITAL-1020,2014
+ITAL,1020,2,ITAL 1020: 002,0.38,0.31,0.0,0.08,0.15,0.0,0.08,0.0,luca barattoni,,ITAL-1020,2014
+ITAL,1020,3,ITAL 1020: 003,0.5,0.25,0.08,0.08,0.0,0.0,0.0,0.08,valentina lombardi,,ITAL-1020,2014
+ITAL,2020,1,Intermediate Italian,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2020,2014
+ITAL,2020,2,Intermediate Italian,0.28,0.39,0.33,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2020,2014
+JAPN,1010,2,JAPN 1010: 002,0.21,0.36,0.07,0.07,0.21,0.0,0.0,0.07,kazuko shoji,,JAPN-1010,2014
+JAPN,1020,1,JAPN 1020: 001,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0, leslie williams,,JAPN-1020,2014
+JAPN,2020,1,JAPN 2020: 001,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,kazuko shoji,,JAPN-2020,2014
+JAPN,3060,1,JAPN 3060: 001,0.4,0.3,0.1,0.0,0.0,0.1,0.0,0.1,toshiko kishimoto,,JAPN-3060,2014
+JAPN,4170,1,Japan Cult & Soc,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0, leslie williams,,JAPN-4170,2014
+LANG,4990,1,LANG 4990: 001,0.0,0.0,0.0,0.0,0.0,0.88,0.06,0.06,su- chen,,LANG-4990,2014
+LARC,1160,1,History of Larch,0.31,0.36,0.2,0.05,0.05,0.0,0.0,0.04,hala fouad nassar,,LARC-1160,2014
+LARC,1520,1,LARC 1520: 001,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,daniel ford,,LARC-1520,2014
+LARC,2620,1,Design Impl I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,david pearson,,LARC-2620,2014
+LARC,3520,1,LARC 3520: 001,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,robert hewitt,,LARC-3520,2014
+LARC,6530,1,LARC 6530: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lycke,,LARC-6530,2014
+LARC,8300,1,LARC 8300: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,LARC-8300,2014
+LAW,3220,1,Legal Env of Bus,0.35,0.4,0.16,0.03,0.0,0.0,0.0,0.06,edward ray claggett,,LAW-3220,2014
+LAW,3220,2,Legal Env of Bus,0.53,0.31,0.08,0.05,0.02,0.0,0.0,0.02,edward ray claggett,,LAW-3220,2014
+LAW,3220,3,Legal Env of Bus,0.43,0.41,0.13,0.02,0.0,0.0,0.0,0.02,frances edwards,,LAW-3220,2014
+LAW,3220,4,Legal Env of Bus,0.3,0.49,0.17,0.03,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2014
+LAW,3220,5,Legal Env of Bus,0.41,0.44,0.13,0.02,0.0,0.0,0.0,0.02,frances edwards,,LAW-3220,2014
+LAW,3220,6,Legal Env of Bus,0.0,0.17,0.29,0.2,0.07,0.0,0.0,0.27,virgini ward-vaughn,,LAW-3220,2014
+LAW,3220,7,Legal Env of Bus,0.08,0.25,0.25,0.14,0.08,0.0,0.0,0.19,virgini ward-vaughn,,LAW-3220,2014
+LAW,3220,8,Legal Env of Bus,0.02,0.14,0.36,0.12,0.12,0.0,0.0,0.24,virgini ward-vaughn,,LAW-3220,2014
+LAW,3220,9,Legal Env of Bus,0.03,0.28,0.21,0.23,0.15,0.0,0.0,0.1,virgini ward-vaughn,,LAW-3220,2014
+LAW,3330,1,Real Estate Law,0.15,0.31,0.46,0.02,0.04,0.0,0.0,0.02,judson jahn,,LAW-3330,2014
+LAW,3330,2,Real Estate Law,0.13,0.38,0.38,0.06,0.02,0.0,0.0,0.02,judson jahn,,LAW-3330,2014
+LAW,8480,1,LAW 8480: 001,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-8480,2014
+LAW,8500,1,LAW 8500: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,megan mowrey,,LAW-8500,2014
+LAW,8500,2,LAW 8500: 002,0.89,0.08,0.0,0.0,0.03,0.0,0.0,0.0,megan mowrey,,LAW-8500,2014
+LS,1000,2,Fitness Leadership,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,mary allison lynch,,LS-1000,2014
+LS,1000,20,Intro to Volleyball,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,kelly lynn ator,,LS-1000,2014
+LS,1000,22,Forestry Skills,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,tamara lee cushing,,LS-1000,2014
+LS,1410,2,LS 1410: 002,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,glenn dav middleton,,LS-1410,2014
+LS,1450,2,LS 1450: 002,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,george wal thompson,,LS-1450,2014
+LS,1560,1,LS 1560: 001,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,david brad cottrell,,LS-1560,2014
+LS,1560,3,LS 1560: 003,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,david brad cottrell,,LS-1560,2014
+LS,1570,6,LS 1570: 006,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey la atkinson,,LS-1570,2014
+LS,1570,10,LS 1570: 010,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,audrey caroli couch,,LS-1570,2014
+LS,1580,1,LS 1580: 001,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,herbert strickland,,LS-1580,2014
+LS,1580,5,LS 1580: 005,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,,LS-1580,2014
+LS,1610,1,LS 1610: 001,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,richard willey,,LS-1610,2014
+LS,1790,1,LS 1790: 001,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert bogan,,LS-1790,2014
+LS,1830,1,LS 1830: 001,0.77,0.09,0.09,0.05,0.0,0.0,0.0,0.0,justin hickey,,LS-1830,2014
+LS,1850,1,LS 1850: 001,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,matthew davi hughes,,LS-1850,2014
+LS,1850,2,LS 1850: 002,0.93,0.0,0.0,0.04,0.0,0.0,0.0,0.04,matthew davi hughes,,LS-1850,2014
+LS,1850,4,LS 1850: 004,0.96,0.0,0.0,0.0,0.04,0.0,0.0,0.0,megan elizabet cato,,LS-1850,2014
+LS,1880,1,LS 1880: 001,0.73,0.0,0.0,0.0,0.07,0.0,0.0,0.2,jarrett bachman,,LS-1880,2014
+LS,1890,1,LS 1890: 001,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,jennifer jo garrity,,LS-1890,2014
+LS,1990,1,LS 1990: 001,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jason jordan,,LS-1990,2014
+LS,2040,2,LS 2040: 002,0.83,0.0,0.0,0.09,0.0,0.0,0.0,0.09,denise ann adams,,LS-2040,2014
+LS,2100,4,LS 2100: 004,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,paul hoke,,LS-2100,2014
+LS,2110,2,LS 2110: 002,0.88,0.0,0.12,0.0,0.0,0.0,0.0,0.0,stephanie pack,,LS-2110,2014
+LS,2190,1,LS 2190: 001,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,matthew lee krabbe,,LS-2190,2014
+LS,2200,5,LS 2200: 005,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,broadus fleming,,LS-2200,2014
+LS,2200,7,LS 2200: 007,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,matthew lee krabbe,,LS-2200,2014
+LS,2200,8,LS 2200: 008,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,matthew lee krabbe,,LS-2200,2014
+LS,2200,9,LS 2200: 009,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,matthew lee krabbe,,LS-2200,2014
+LS,2210,1,LS 2210: 001,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,paul hoke,,LS-2210,2014
+LS,2270,1,LS 2270: 001,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,,LS-2270,2014
+LS,2270,2,LS 2270: 002,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,paul hoke,,LS-2270,2014
+LS,2320,1,LS 2320: 001,0.87,0.0,0.0,0.0,0.04,0.0,0.0,0.09,diane moreno,,LS-2320,2014
+LS,2320,2,LS 2320: 002,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,diane moreno,,LS-2320,2014
+LS,2320,3,LS 2320: 003,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,diane moreno,,LS-2320,2014
+LS,2320,5,LS 2320: 005,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-2320,2014
+LS,2350,1,LS 2350: 001,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,ranjanbala dil amin,,LS-2350,2014
+LS,2350,2,LS 2350: 002,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,,LS-2350,2014
+LS,2350,3,LS 2350: 003,0.7,0.09,0.13,0.0,0.0,0.0,0.0,0.09,renee warren gahan,,LS-2350,2014
+LS,2350,4,LS 2350: 004,0.79,0.08,0.0,0.0,0.0,0.0,0.0,0.13,renee warren gahan,,LS-2350,2014
+LS,2350,5,LS 2350: 005,0.65,0.17,0.0,0.0,0.0,0.0,0.0,0.17,renee warren gahan,,LS-2350,2014
+LS,2350,6,LS 2350: 006,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-2350,2014
+LS,2350,8,LS 2350: 008,0.84,0.04,0.0,0.04,0.08,0.0,0.0,0.0,ranjanbala dil amin,,LS-2350,2014
+LS,2360,1,LS 2360: 001,0.92,0.0,0.0,0.0,0.04,0.0,0.0,0.04,ani reina-nunnelley,,LS-2360,2014
+LS,2360,2,LS 2360: 002,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,ani reina-nunnelley,,LS-2360,2014
+LS,2360,3,LS 2360: 003,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,,LS-2360,2014
+LS,2370,1,LS 2370: 001,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,ashley austi lester,,LS-2370,2014
+LS,2370,2,LS 2370: 002,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,ashley austi lester,,LS-2370,2014
+LS,2370,3,LS 2370: 003,0.72,0.17,0.0,0.0,0.0,0.0,0.0,0.11,ashley austi lester,,LS-2370,2014
+LS,2370,4,LS 2370: 004,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,,LS-2370,2014
+LS,2370,5,LS 2370: 005,0.77,0.09,0.0,0.0,0.05,0.0,0.0,0.09,ashley austi lester,,LS-2370,2014
+LS,2380,2,LS 2380: 002,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,phaedra o'connell,,LS-2380,2014
+LS,2380,3,LS 2380: 003,0.74,0.13,0.04,0.0,0.0,0.0,0.0,0.09,phaedra o'connell,,LS-2380,2014
+LS,2380,5,LS 2380: 005,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,phaedra o'connell,,LS-2380,2014
+LS,2420,1,LS 2420: 001,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,,LS-2420,2014
+LS,2420,2,LS 2420: 002,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,phaedra o'connell,,LS-2420,2014
+LS,2420,3,LS 2420: 003,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,ranjanbala dil amin,,LS-2420,2014
+LS,2420,4,LS 2420: 004,0.87,0.0,0.09,0.0,0.0,0.0,0.0,0.04,phaedra o'connell,,LS-2420,2014
+LS,2420,5,LS 2420: 005,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,,LS-2420,2014
+LS,2770,1,LS 2770: 001,0.36,0.55,0.0,0.0,0.0,0.0,0.0,0.09,kelly lynn womack,,LS-2770,2014
+MATH,1010,1,Essen Math for Informed Soc,0.18,0.35,0.29,0.06,0.12,0.0,0.0,0.0,chelsea rose snyder,,MATH-1010,2014
+MATH,1010,2,Essen Math for Informed Soc,0.35,0.24,0.32,0.09,0.0,0.0,0.0,0.0,judith cottingham,,MATH-1010,2014
+MATH,1010,3,Essen Math for Informed Soc,0.27,0.4,0.2,0.13,0.0,0.0,0.0,0.0,matthew keogh,,MATH-1010,2014
+MATH,1010,4,Essen Math for Informed Soc,0.4,0.27,0.1,0.1,0.07,0.0,0.0,0.07,judith cottingham,,MATH-1010,2014
+MATH,1010,5,Essen Math for Informed Soc,0.37,0.16,0.21,0.11,0.11,0.0,0.0,0.05,golubinski capaverde,,MATH-1010,2014
+MATH,1010,6,Essen Math for Informed Soc,0.21,0.24,0.21,0.18,0.06,0.0,0.0,0.09,judith cottingham,,MATH-1010,2014
+MATH,1010,7,Essen Math for Informed Soc,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,honghai xu,,MATH-1010,2014
+MATH,1020,1,Intro to Mathematical Analysis,0.11,0.32,0.21,0.11,0.26,0.0,0.0,0.0,garrett dranichak,,MATH-1020,2014
+MATH,1020,2,Intro to Mathematical Analysis,0.11,0.26,0.16,0.32,0.11,0.0,0.0,0.05,karyn muir,,MATH-1020,2014
+MATH,1020,3,Intro to Mathematical Analysis,0.11,0.14,0.14,0.17,0.37,0.0,0.0,0.06,brian dandurand,,MATH-1020,2014
+MATH,1020,4,Intro to Mathematical Analysis,0.3,0.05,0.3,0.2,0.15,0.0,0.0,0.0,caroline lee burch,,MATH-1020,2014
+MATH,1020,5,Intro to Mathematical Analysis,0.1,0.29,0.26,0.05,0.24,0.0,0.0,0.07,randy davidson,,MATH-1020,2014
+MATH,1020,6,Intro to Mathematical Analysis,0.29,0.29,0.14,0.0,0.19,0.0,0.0,0.1,kara ail stasikelis,,MATH-1020,2014
+MATH,1020,7,Intro to Mathematical Analysis,0.18,0.23,0.3,0.18,0.08,0.0,0.0,0.05, erwin walker,,MATH-1020,2014
+MATH,1020,8,Intro to Mathematical Analysis,0.17,0.24,0.31,0.1,0.17,0.0,0.0,0.02,allison stoddard,,MATH-1020,2014
+MATH,1020,9,Intro to Mathematical Analysis,0.26,0.21,0.12,0.12,0.24,0.0,0.0,0.06,brian dandurand,,MATH-1020,2014
+MATH,1020,10,Intro to Mathematical Analysis,0.25,0.14,0.28,0.08,0.17,0.0,0.0,0.08,randy davidson,,MATH-1020,2014
+MATH,1020,11,Intro to Mathematical Analysis,0.17,0.29,0.26,0.09,0.14,0.0,0.0,0.06,randy davidson,,MATH-1020,2014
+MATH,1020,12,Intro to Mathematical Analysis,0.06,0.19,0.31,0.13,0.13,0.0,0.0,0.19,drew jared lipman,,MATH-1020,2014
+MATH,1020,13,Intro to Mathematical Analysis,0.39,0.17,0.11,0.06,0.17,0.0,0.0,0.11,paul james cubre,,MATH-1020,2014
+MATH,1020,14,Intro to Mathematical Analysis,0.06,0.17,0.23,0.23,0.2,0.0,0.0,0.11,brian dandurand,,MATH-1020,2014
+MATH,1040,1,MATH 1040: 001,0.0,0.0,0.0,0.0,0.0,0.62,0.31,0.08,lakmali weerasena,,MATH-1040,2014
+MATH,1040,2,MATH 1040: 002,0.0,0.0,0.0,0.0,0.0,0.62,0.31,0.07,lakmali weerasena,,MATH-1040,2014
+MATH,1050,400,MATH 1050: 400,0.0,0.0,0.0,0.0,0.0,0.63,0.35,0.02,eliza dar gallagher,,MATH-1050,2014
+MATH,1060,1,Calculus of One Variable I,0.0,0.36,0.21,0.07,0.29,0.0,0.0,0.07,sarah eliz anderson,,MATH-1060,2014
+MATH,1060,2,Calculus of One Variable I,0.05,0.2,0.25,0.3,0.2,0.0,0.0,0.0,charity watson,,MATH-1060,2014
+MATH,1060,3,Calculus of One Variable I,0.04,0.25,0.25,0.04,0.21,0.0,0.0,0.21,allen anderso guest,,MATH-1060,2014
+MATH,1060,4,Calculus of One Variable I,0.12,0.04,0.24,0.16,0.32,0.0,0.0,0.12,allen anderso guest,,MATH-1060,2014
+MATH,1060,5,Calculus of One Variable I,0.09,0.22,0.25,0.09,0.25,0.0,0.0,0.09,marion hanna,,MATH-1060,2014
+MATH,1060,6,Calculus of One Variable I,0.04,0.18,0.32,0.18,0.14,0.0,0.0,0.14,marilyn reba,,MATH-1060,2014
+MATH,1060,7,Calculus of One Variable I,0.05,0.21,0.42,0.16,0.16,0.0,0.0,0.0,damitha bandara,,MATH-1060,2014
+MATH,1060,8,Calculus of One Variable I,0.05,0.3,0.35,0.1,0.15,0.0,0.0,0.05,damitha bandara,,MATH-1060,2014
+MATH,1060,202,Calculus of One Variable I,0.32,0.32,0.11,0.0,0.16,0.0,0.0,0.11,james peterson,,MATH-1060,2014
+MATH,1070,1,Differen and Integral Calculus,0.16,0.43,0.18,0.09,0.11,0.0,0.0,0.02,donna simms,,MATH-1070,2014
+MATH,1070,2,Differen and Integral Calculus,0.15,0.57,0.15,0.07,0.04,0.0,0.0,0.02,donna simms,,MATH-1070,2014
+MATH,1070,3,Differen and Integral Calculus,0.23,0.3,0.38,0.06,0.02,0.0,0.0,0.0,christy jenki brown,,MATH-1070,2014
+MATH,1070,4,Differen and Integral Calculus,0.33,0.29,0.22,0.07,0.02,0.0,0.0,0.07,jennifer mari hanna,,MATH-1070,2014
+MATH,1070,5,Differen and Integral Calculus,0.36,0.21,0.28,0.09,0.06,0.0,0.0,0.0,jennifer mari hanna,,MATH-1070,2014
+MATH,1070,6,Differen and Integral Calculus,0.26,0.36,0.26,0.09,0.04,0.0,0.0,0.0,jennifer mari hanna,,MATH-1070,2014
+MATH,1080,1,Calculus of One Variable II,0.09,0.2,0.18,0.07,0.16,0.0,0.0,0.31,christa con johnson,,MATH-1080,2014
+MATH,1080,2,Calculus of One Variable II,0.05,0.24,0.21,0.03,0.05,0.0,0.0,0.42,terri johnson,,MATH-1080,2014
+MATH,1080,3,Calculus of One Variable II,0.18,0.25,0.11,0.05,0.18,0.0,0.0,0.23,anastasia br wilson,,MATH-1080,2014
+MATH,1080,4,Calculus of One Variable II,0.04,0.24,0.2,0.07,0.13,0.0,0.0,0.33,beth novick,,MATH-1080,2014
+MATH,1080,5,Calculus of One Variable II,0.09,0.26,0.24,0.04,0.0,0.0,0.0,0.37,terri johnson,,MATH-1080,2014
+MATH,1080,6,Calculus of One Variable II,0.02,0.29,0.11,0.09,0.07,0.0,0.0,0.42,beth novick,,MATH-1080,2014
+MATH,1080,7,Calculus of One Variable II,0.13,0.26,0.17,0.09,0.11,0.0,0.0,0.24,meredith nicol burr,,MATH-1080,2014
+MATH,1080,8,Calculus of One Variable II,0.11,0.22,0.29,0.02,0.18,0.0,0.0,0.18,christa con johnson,,MATH-1080,2014
+MATH,1080,9,Calculus of One Variable II,0.06,0.36,0.15,0.11,0.17,0.0,0.0,0.15,shih-wei chao,,MATH-1080,2014
+MATH,1080,10,Calculus of One Variable II,0.02,0.16,0.27,0.11,0.16,0.0,0.0,0.29,akshay sunil gupte,,MATH-1080,2014
+MATH,1080,11,Calculus of One Variable II,0.11,0.24,0.18,0.09,0.2,0.0,0.0,0.18,patrick buckingham,,MATH-1080,2014
+MATH,1080,12,Calculus of One Variable II,0.42,0.27,0.18,0.02,0.02,0.0,0.0,0.09,dania moham zantout,,MATH-1080,2014
+MATH,1080,13,Calculus of One Variable II,0.07,0.11,0.2,0.05,0.36,0.0,0.0,0.2,nathan chenette,,MATH-1080,2014
+MATH,1080,14,Calculus of One Variable II,0.09,0.09,0.21,0.02,0.09,0.0,0.0,0.49,rachel eli grotheer,,MATH-1080,2014
+MATH,1080,15,Calculus of One Variable II,0.11,0.19,0.26,0.06,0.17,0.0,0.0,0.22,nathanael dav black,,MATH-1080,2014
+MATH,1150,1,Contemp Math for Elem Teach I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,james kwame dogbey,,MATH-1150,2014
+MATH,1160,1,Contemp Math for Elem Teach II,0.56,0.31,0.03,0.09,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1160,2014
+MATH,1160,2,Contemp Math for Elem Teach II,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1160,2014
+MATH,1990,400,MATH 1990: 400,0.0,0.0,0.0,0.0,0.0,0.88,0.07,0.04,marion hanna,,MATH-1990,2014
+MATH,2030,1,Elemen Statistical Inference,0.62,0.26,0.05,0.03,0.03,0.0,0.0,0.03,laura jane shick,,MATH-2030,2014
+MATH,2030,2,Elemen Statistical Inference,0.44,0.23,0.15,0.13,0.0,0.0,0.0,0.05,laura jane shick,,MATH-2030,2014
+MATH,2030,3,Elemen Statistical Inference,0.71,0.12,0.07,0.07,0.0,0.0,0.0,0.02,laura jane shick,,MATH-2030,2014
+MATH,2030,4,Elemen Statistical Inference,0.49,0.29,0.06,0.06,0.09,0.0,0.0,0.03,christopher wilson,,MATH-2030,2014
+MATH,2030,5,Elemen Statistical Inference,0.56,0.17,0.14,0.08,0.03,0.0,0.0,0.03,stephen wesl carden,,MATH-2030,2014
+MATH,2030,6,Elemen Statistical Inference,0.6,0.18,0.13,0.05,0.03,0.0,0.0,0.03,dominique morgan,,MATH-2030,2014
+MATH,2030,7,Elemen Statistical Inference,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,yan liu,,MATH-2030,2014
+MATH,2060,1,Calculus of Several Variables,0.1,0.13,0.17,0.37,0.23,0.0,0.0,0.0,christopher cox,,MATH-2060,2014
+MATH,2060,2,Calculus of Several Variables,0.26,0.59,0.06,0.03,0.0,0.0,0.0,0.06,peter kiessler,,MATH-2060,2014
+MATH,2060,3,Calculus of Several Variables,0.41,0.16,0.27,0.05,0.08,0.0,0.0,0.03,charles johnson,,MATH-2060,2014
+MATH,2060,4,Calculus of Several Variables,0.29,0.29,0.35,0.0,0.03,0.0,0.0,0.03,chanseok park,,MATH-2060,2014
+MATH,2060,5,Calculus of Several Variables,0.43,0.14,0.29,0.09,0.06,0.0,0.0,0.0,timothy ch teitloff,,MATH-2060,2014
+MATH,2060,6,Calculus of Several Variables,0.25,0.34,0.28,0.03,0.06,0.0,0.0,0.03,svetlan poznanovikj,,MATH-2060,2014
+MATH,2060,7,Calculus of Several Variables,0.32,0.44,0.21,0.0,0.03,0.0,0.0,0.0,peter kiessler,,MATH-2060,2014
+MATH,2060,8,Calculus of Several Variables,0.18,0.35,0.24,0.03,0.15,0.0,0.0,0.06,nathan jos adelgren,,MATH-2060,2014
+MATH,2060,9,Calculus of Several Variables,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,martin joha schmoll,,MATH-2060,2014
+MATH,2060,10,Calculus of Several Variables,0.27,0.3,0.21,0.06,0.03,0.0,0.0,0.12,qingshan chen,,MATH-2060,2014
+MATH,2060,11,Calculus of Several Variables,0.26,0.32,0.18,0.12,0.03,0.0,0.0,0.09,xin liu,,MATH-2060,2014
+MATH,2060,100,Calc of Several Variable (HON),0.58,0.25,0.08,0.0,0.08,0.0,0.0,0.0,james brown,True,MATH-2060,2014
+MATH,2070,1,Multivariable Calculus,0.22,0.06,0.33,0.11,0.11,0.0,0.0,0.17,elaine ma sotherden,,MATH-2070,2014
+MATH,2070,3,Multivariable Calculus,0.35,0.35,0.29,0.0,0.0,0.0,0.0,0.0,rodney lewis keaton,,MATH-2070,2014
+MATH,2070,4,Multivariable Calculus,0.08,0.31,0.31,0.06,0.17,0.0,0.0,0.08,sherry biggers,,MATH-2070,2014
+MATH,2070,5,Multivariable Calculus,0.44,0.31,0.17,0.0,0.03,0.0,0.0,0.06,jennifer van dyken,,MATH-2070,2014
+MATH,2070,6,Multivariable Calculus,0.17,0.49,0.23,0.11,0.0,0.0,0.0,0.0,judith irene mcknew,,MATH-2070,2014
+MATH,2070,7,Multivariable Calculus,0.37,0.26,0.16,0.11,0.11,0.0,0.0,0.0,audrey nico devries,,MATH-2070,2014
+MATH,2070,8,Multivariable Calculus,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,lawrence mccormick,,MATH-2070,2014
+MATH,2070,9,Multivariable Calculus,0.26,0.53,0.11,0.11,0.0,0.0,0.0,0.0,alistair bentley,,MATH-2070,2014
+MATH,2070,10,Multivariable Calculus,0.17,0.44,0.28,0.11,0.0,0.0,0.0,0.0,saba za alkaseasbeh,,MATH-2070,2014
+MATH,2070,11,Multivariable Calculus,0.26,0.34,0.26,0.03,0.03,0.0,0.0,0.09,sherry biggers,,MATH-2070,2014
+MATH,2070,12,Multivariable Calculus,0.33,0.36,0.14,0.08,0.06,0.0,0.0,0.03,judith irene mcknew,,MATH-2070,2014
+MATH,2070,13,Multivariable Calculus,0.47,0.21,0.11,0.0,0.16,0.0,0.0,0.05,jason lee joyner,,MATH-2070,2014
+MATH,2070,14,Multivariable Calculus,0.32,0.26,0.26,0.11,0.0,0.0,0.0,0.05,tony thanh nguyen,,MATH-2070,2014
+MATH,2070,15,Multivariable Calculus,0.2,0.4,0.23,0.06,0.03,0.0,0.0,0.09,sherry biggers,,MATH-2070,2014
+MATH,2070,16,Multivariable Calculus,0.53,0.16,0.05,0.11,0.11,0.0,0.0,0.05,rachel malinauskas,,MATH-2070,2014
+MATH,2070,17,Multivariable Calculus,0.33,0.17,0.28,0.17,0.0,0.0,0.0,0.06,william bo lassiter,,MATH-2070,2014
+MATH,2070,18,Multivariable Calculus,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0, ushijima-mwesigwa,,MATH-2070,2014
+MATH,2070,19,Multivariable Calculus,0.37,0.37,0.11,0.05,0.11,0.0,0.0,0.0,zachary hollifield,,MATH-2070,2014
+MATH,2070,20,Multivariable Calculus,0.35,0.35,0.1,0.1,0.05,0.0,0.0,0.05,luke marti giberson,,MATH-2070,2014
+MATH,2070,21,Multivariable Calculus,0.15,0.48,0.24,0.03,0.03,0.0,0.0,0.06,mark thomas batell,,MATH-2070,2014
+MATH,2070,22,Multivariable Calculus,0.32,0.47,0.05,0.0,0.11,0.0,0.0,0.05,jason to hedetniemi,,MATH-2070,2014
+MATH,2070,23,Multivariable Calculus,0.16,0.47,0.32,0.0,0.05,0.0,0.0,0.0,janie caro mcdonald,,MATH-2070,2014
+MATH,2070,24,Multivariable Calculus,0.28,0.28,0.28,0.0,0.06,0.0,0.0,0.11,grady mcgowa thomas,,MATH-2070,2014
+MATH,2070,25,Multivariable Calculus,0.11,0.32,0.26,0.16,0.16,0.0,0.0,0.0,liem nguyen,,MATH-2070,2014
+MATH,2070,26,Multivariable Calculus,0.15,0.5,0.15,0.1,0.1,0.0,0.0,0.0,fiona may knoll,,MATH-2070,2014
+MATH,2080,1,Intro to Ordin Diff Equations,0.41,0.32,0.15,0.0,0.03,0.0,0.0,0.09,timothy fra parrott,,MATH-2080,2014
+MATH,2080,2,Intro to Ordin Diff Equations,0.35,0.29,0.23,0.06,0.03,0.0,0.0,0.03,ebrahim nasrabadi,,MATH-2080,2014
+MATH,2080,3,Intro to Ordin Diff Equations,0.24,0.24,0.18,0.06,0.12,0.0,0.0,0.18,shari prevost,,MATH-2080,2014
+MATH,2080,4,Intro to Ordin Diff Equations,0.31,0.36,0.11,0.11,0.06,0.0,0.0,0.06,mishko mitkovski,,MATH-2080,2014
+MATH,2080,5,Intro to Ordin Diff Equations,0.64,0.21,0.07,0.05,0.0,0.0,0.0,0.02,timothy fra parrott,,MATH-2080,2014
+MATH,2080,6,Intro to Ordin Diff Equations,0.12,0.3,0.27,0.12,0.12,0.0,0.0,0.06,julie lassiter,,MATH-2080,2014
+MATH,2080,7,Intro to Ordin Diff Equations,0.2,0.13,0.27,0.07,0.17,0.0,0.0,0.17,shari prevost,,MATH-2080,2014
+MATH,2080,8,Intro to Ordin Diff Equations,0.17,0.27,0.23,0.13,0.1,0.0,0.0,0.1,julie lassiter,,MATH-2080,2014
+MATH,2080,9,Intro to Ordin Diff Equations,0.47,0.19,0.22,0.06,0.06,0.0,0.0,0.0,timothy ch teitloff,,MATH-2080,2014
+MATH,2080,10,Intro to Ordin Diff Equations,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,william moss,,MATH-2080,2014
+MATH,2080,11,Intro to Ordin Diff Equations,0.17,0.38,0.13,0.13,0.17,0.0,0.0,0.04,brandon gra goodell,,MATH-2080,2014
+MATH,2080,12,Intro to Ordin Diff Equations,0.52,0.33,0.05,0.0,0.05,0.0,0.0,0.05,irina viktorova,,MATH-2080,2014
+MATH,2080,13,Intro to Ordin Diff Equations,0.41,0.41,0.05,0.02,0.07,0.0,0.0,0.02,timothy fra parrott,,MATH-2080,2014
+MATH,2080,14,Intro to Ordin Diff Equations,0.66,0.11,0.11,0.06,0.06,0.0,0.0,0.0,timothy ch teitloff,,MATH-2080,2014
+MATH,2080,15,Intro to Ordin Diff Equations,0.65,0.23,0.02,0.02,0.05,0.0,0.0,0.02,irina viktorova,,MATH-2080,2014
+MATH,2080,16,Intro to Ordin Diff Equations,0.62,0.19,0.12,0.05,0.02,0.0,0.0,0.0,timothy ch teitloff,,MATH-2080,2014
+MATH,2080,17,Intro to Ordin Diff Equations,0.32,0.37,0.13,0.05,0.08,0.0,0.0,0.05,timothy fra parrott,,MATH-2080,2014
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True,MATH-2080,2014
+MATH,2160,1,Geometry for Elem Sch Teachers,0.58,0.35,0.04,0.04,0.0,0.0,0.0,0.0,allison stoddard,,MATH-2160,2014
+MATH,3010,1,Statistical Methods I,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hewa priyadarshani,,MATH-3010,2014
+MATH,3010,2,Statistical Methods I,0.27,0.23,0.23,0.1,0.13,0.0,0.0,0.03,meredith nicol burr,,MATH-3010,2014
+MATH,3010,3,Statistical Methods I,0.29,0.33,0.29,0.0,0.0,0.0,0.0,0.1,yanbo xia,,MATH-3010,2014
+MATH,3010,4,Statistical Methods I,0.33,0.27,0.0,0.27,0.07,0.0,0.0,0.07,tao yang,,MATH-3010,2014
+MATH,3010,5,Statistical Methods I,0.4,0.4,0.0,0.0,0.07,0.0,0.0,0.13,emily marie nystrom,,MATH-3010,2014
+MATH,3020,1,MATH 3020: 001,0.26,0.35,0.24,0.09,0.0,0.0,0.0,0.06,derek brown,,MATH-3020,2014
+MATH,3020,2,MATH 3020: 002,0.42,0.44,0.03,0.06,0.06,0.0,0.0,0.0,yingbo li,,MATH-3020,2014
+MATH,3020,3,MATH 3020: 003,0.41,0.41,0.07,0.05,0.02,0.0,0.0,0.02,xiaoqian sun,,MATH-3020,2014
+MATH,3020,4,MATH 3020: 004,0.28,0.33,0.18,0.05,0.08,0.0,0.0,0.08,calvin williams,,MATH-3020,2014
+MATH,3020,5,MATH 3020: 005,0.34,0.26,0.2,0.09,0.06,0.0,0.0,0.06,michael thom finney,,MATH-3020,2014
+MATH,3080,1,MATH 3080: 001,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,eliza dar gallagher,,MATH-3080,2014
+MATH,3090,1,Intro to Business Statistics,0.19,0.26,0.33,0.04,0.15,0.0,0.0,0.04,gary fellers,,MATH-3090,2014
+MATH,3090,2,Intro to Business Statistics,0.21,0.27,0.24,0.18,0.09,0.0,0.0,0.0,ellen hepfe breazel,,MATH-3090,2014
+MATH,3090,3,Intro to Business Statistics,0.22,0.41,0.19,0.03,0.09,0.0,0.0,0.06,gary fellers,,MATH-3090,2014
+MATH,3090,4,Intro to Business Statistics,0.05,0.16,0.26,0.32,0.21,0.0,0.0,0.0,bereket tesfaldet,,MATH-3090,2014
+MATH,3090,5,Intro to Business Statistics,0.2,0.27,0.3,0.1,0.03,0.0,0.0,0.1,charity watson,,MATH-3090,2014
+MATH,3090,6,Intro to Business Statistics,0.16,0.21,0.32,0.11,0.05,0.0,0.0,0.16,james ellis  wrenn,,MATH-3090,2014
+MATH,3090,7,Intro to Business Statistics,0.1,0.26,0.32,0.19,0.1,0.0,0.0,0.03,margaret mar wiecek,,MATH-3090,2014
+MATH,3090,8,Intro to Business Statistics,0.17,0.22,0.28,0.22,0.06,0.0,0.0,0.06,joshua crunkleton,,MATH-3090,2014
+MATH,3090,9,Intro to Business Statistics,0.11,0.47,0.26,0.05,0.05,0.0,0.0,0.05,andrew jo schwarzer,,MATH-3090,2014
+MATH,3090,10,Intro to Business Statistics,0.23,0.42,0.13,0.1,0.1,0.0,0.0,0.03,gary fellers,,MATH-3090,2014
+MATH,3090,11,Intro to Business Statistics,0.1,0.35,0.32,0.13,0.06,0.0,0.0,0.03,gary fellers,,MATH-3090,2014
+MATH,3090,12,Intro to Business Statistics,0.23,0.4,0.2,0.03,0.1,0.0,0.0,0.03,christy jenki brown,,MATH-3090,2014
+MATH,3110,1,Linear Algebra,0.21,0.18,0.21,0.09,0.21,0.0,0.0,0.12,jeong rock yoon,,MATH-3110,2014
+MATH,3110,2,Linear Algebra,0.29,0.21,0.26,0.06,0.18,0.0,0.0,0.0,neil calkin,,MATH-3110,2014
+MATH,3110,3,Linear Algebra,0.19,0.19,0.13,0.16,0.22,0.0,0.0,0.13,nathan chenette,,MATH-3110,2014
+MATH,3110,4,Linear Algebra,0.26,0.26,0.19,0.13,0.1,0.0,0.0,0.06,matthew macauley,,MATH-3110,2014
+MATH,3110,5,Linear Algebra,0.1,0.05,0.24,0.24,0.05,0.0,0.0,0.33,felice manganiello,,MATH-3110,2014
+MATH,3110,100,Linear Algebra (HON),0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,felice manganiello,True,MATH-3110,2014
+MATH,3150,1,MATH 3150: 001,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-3150,2014
+MATH,3190,2,MATH 3190: 002,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,michael adam burr,,MATH-3190,2014
+MATH,3600,1,MATH 3600: 001,0.56,0.38,0.0,0.0,0.06,0.0,0.0,0.0,daniel warner,,MATH-3600,2014
+MATH,3650,1,MATH 3650: 001,0.67,0.27,0.05,0.0,0.0,0.0,0.0,0.01,leo rebholz,,MATH-3650,2014
+MATH,3650,2,MATH 3650: 002,0.37,0.23,0.07,0.07,0.13,0.0,0.0,0.13,timo johann heister,,MATH-3650,2014
+MATH,4000,1,Theory of Probability,0.38,0.31,0.19,0.03,0.09,0.0,0.0,0.0,yingbo li,,MATH-4000,2014
+MATH,4030,1,Intro to Statistical Theory,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,chanseok park,,MATH-4030,2014
+MATH,4070,1,MATH 4070: 001,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-4070,2014
+MATH,4100,1,MATH 4100: 001,0.08,0.23,0.15,0.08,0.08,0.0,0.0,0.38,dania moham zantout,,MATH-4100,2014
+MATH,4120,1,Intro to Modern Algebra,0.19,0.23,0.23,0.16,0.13,0.0,0.0,0.06,matthew macauley,,MATH-4120,2014
+MATH,4190,1,Discrete Math Structures I,0.45,0.47,0.08,0.0,0.0,0.0,0.0,0.0,wayne goddard,,MATH-4190,2014
+MATH,4300,1,MATH 4300: 001,0.2,0.2,0.1,0.2,0.2,0.0,0.0,0.1, erwin walker,,MATH-4300,2014
+MATH,4340,1,MATH 4340: 001,0.14,0.24,0.17,0.17,0.03,0.0,0.0,0.24,eleanor jenkins,,MATH-4340,2014
+MATH,4340,2,MATH 4340: 002,0.2,0.14,0.29,0.11,0.09,0.0,0.0,0.17,hyesuk lee,,MATH-4340,2014
+MATH,4400,1,Linear Programming,0.12,0.35,0.15,0.08,0.04,0.0,0.0,0.27,akshay sunil gupte,,MATH-4400,2014
+MATH,4410,1,Intro to Stochastic Models,0.38,0.29,0.17,0.04,0.08,0.0,0.0,0.04,brian fralix,,MATH-4410,2014
+MATH,4500,1,MATH 4500: 001,0.18,0.18,0.09,0.36,0.09,0.0,0.0,0.09,vincent ervin,,MATH-4500,2014
+MATH,4530,1,Advanced Calculus I,0.13,0.31,0.31,0.06,0.09,0.0,0.0,0.09,taufiquar rahm khan,,MATH-4530,2014
+MATH,4540,1,Advanced Calculus II,0.24,0.44,0.16,0.04,0.04,0.0,0.0,0.08,taufiquar rahm khan,,MATH-4540,2014
+MATH,6340,1,MATH 6340: 001,0.45,0.35,0.05,0.0,0.05,0.0,0.0,0.1,vincent ervin,,MATH-6340,2014
+MATH,7060,400,MATH 7060: 400,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,stacy megan che,,MATH-7060,2014
+MATH,8030,1,MATH 8030: 001,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,,MATH-8030,2014
+MATH,8050,1,MATH 8050: 001,0.52,0.26,0.04,0.0,0.0,0.0,0.0,0.17,derek brown,,MATH-8050,2014
+MATH,8060,1,MATH 8060: 001,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-8060,2014
+MATH,8100,1,MATH 8100: 001,0.47,0.41,0.0,0.0,0.06,0.0,0.0,0.06,matthew saltzman,,MATH-8100,2014
+MATH,8110,1,MATH 8110: 001,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,,MATH-8110,2014
+MATH,8130,1,MATH 8130: 001,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,ebrahim nasrabadi,,MATH-8130,2014
+MATH,8210,1,MATH 8210: 001,0.38,0.5,0.06,0.0,0.06,0.0,0.0,0.0,shitao liu,,MATH-8210,2014
+MATH,8220,1,MATH 8220: 001,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,,MATH-8220,2014
+MATH,8260,1,MATH 8260: 001,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,shitao liu,,MATH-8260,2014
+MATH,8520,1,MATH 8520: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,,MATH-8520,2014
+MATH,8530,1,MATH 8530: 001,0.47,0.12,0.29,0.0,0.06,0.0,0.0,0.06,svetlan poznanovikj,,MATH-8530,2014
+MATH,8540,1,MATH 8540: 001,0.46,0.31,0.0,0.0,0.0,0.0,0.0,0.23,beth novick,,MATH-8540,2014
+MATH,8600,1,MATH 8600: 001,0.3,0.57,0.09,0.0,0.0,0.0,0.0,0.04,qingshan chen,,MATH-8600,2014
+MATH,8810,1,MATH 8810: 001,0.65,0.25,0.05,0.0,0.0,0.0,0.0,0.05,christopher mcmahan,,MATH-8810,2014
+MATH,9830,1,Sel Top in Computational Math,0.57,0.14,0.29,0.0,0.0,0.0,0.0,0.0,timo johann heister,,MATH-9830,2014
+MBA,8030,1,MBA 8030: 001,0.53,0.45,0.0,0.0,0.0,0.0,0.0,0.03,matthew charl klein,,MBA-8030,2014
+MBA,8060,1,MBA 8060: 001,0.52,0.46,0.02,0.0,0.0,0.0,0.0,0.0,gulru fatma ozkan,,MBA-8060,2014
+MBA,8070,1,MBA 8070: 001,0.41,0.41,0.12,0.0,0.0,0.0,0.0,0.06,fei xie,,MBA-8070,2014
+MBA,8070,2,MBA 8070: 002,0.41,0.48,0.11,0.0,0.0,0.0,0.0,0.0,fei xie,,MBA-8070,2014
+MBA,8090,1,Org Beh & Hum Res Mg,0.64,0.34,0.0,0.0,0.02,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2014
+MBA,8190,1,Intro to Acc and Fin,0.49,0.41,0.08,0.0,0.03,0.0,0.0,0.0,jeffrey mcmillan,,MBA-8190,2014
+MBA,8190,2,Intro to Acc and Fin,0.31,0.58,0.12,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,,MBA-8190,2014
+MBA,8290,1,Marketing Foundation,0.51,0.45,0.0,0.0,0.02,0.0,0.0,0.02,william kilbourne,,MBA-8290,2014
+MBA,8370,1,Legal Environ of Bus,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.08,judson jahn,,MBA-8370,2014
+MBA,8450,1,Tech & Innova Mgt,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david orr,,MBA-8450,2014
+MBA,8470,1,MBA 8470: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,peter gianiodis,,MBA-8470,2014
+MBA,8540,2,MBA 8540: 002,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,sarah martin,,MBA-8540,2014
+MBA,8590,1,Mgr Decision Model,0.41,0.34,0.13,0.0,0.09,0.0,0.0,0.03,sara elizabet yoder,,MBA-8590,2014
+MBA,8590,2,Mgr Decision Model,0.52,0.35,0.13,0.0,0.0,0.0,0.0,0.0,mark mcknew,,MBA-8590,2014
+MBA,8600,1,MBA 8600: 001,0.15,0.5,0.23,0.0,0.04,0.0,0.0,0.08,michael dorsch,,MBA-8600,2014
+MBA,8610,1,Information Systems,0.38,0.45,0.15,0.0,0.0,0.0,0.0,0.03,varun grover,,MBA-8610,2014
+MBA,8610,2,Information Systems,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MBA-8610,2014
+MBA,8620,1,Managerial Economics,0.34,0.37,0.14,0.0,0.0,0.0,0.0,0.14,scott templeton,,MBA-8620,2014
+MBA,8700,1,MBA 8700: 001,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8700,2014
+MBA,8720,1,MBA 8720: 001,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,,MBA-8720,2014
+MBA,8740,1,Managing Cont Impvmt,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,,MBA-8740,2014
+MBA,8750,1,MBA 8750: 001,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8750,2014
+MBA,8990,1,Advanced Leadership,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.03,kathleen ann kegley,,MBA-8990,2014
+ME,2000,1,ME 2000: 001,0.67,0.22,0.04,0.01,0.03,0.0,0.0,0.02,donald beasley,,ME-2000,2014
+ME,2010,1,ME 2010: 001,0.03,0.27,0.23,0.11,0.34,0.0,0.0,0.03,sherrill biggers,,ME-2010,2014
+ME,2010,2,ME 2010: 002,0.15,0.25,0.19,0.08,0.24,0.0,0.0,0.08,kalyan chakr katuri,,ME-2010,2014
+ME,2020,1,ME 2020: 001,0.42,0.4,0.11,0.03,0.03,0.0,0.0,0.01,lonny thompson,,ME-2020,2014
+ME,2020,2,ME 2020: 002,0.58,0.3,0.08,0.0,0.03,0.0,0.0,0.02,paul jeffrey meyer,,ME-2020,2014
+ME,2030,1,ME 2030: 001,0.18,0.27,0.33,0.14,0.06,0.0,0.0,0.02,xiangchun xuan,,ME-2030,2014
+ME,2030,2,ME 2030: 002,0.54,0.33,0.11,0.01,0.01,0.0,0.0,0.01,david zumbrunnen,,ME-2030,2014
+ME,2030,3,ME 2030: 003,0.08,0.27,0.31,0.1,0.07,0.0,0.0,0.17,donald beasley,,ME-2030,2014
+ME,2220,1,ME 2220: 001,0.35,0.41,0.06,0.0,0.06,0.0,0.0,0.12,todd schweisinger,,ME-2220,2014
+ME,2220,2,ME 2220: 002,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,3,ME 2220: 003,0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,4,ME 2220: 004,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,5,ME 2220: 005,0.25,0.7,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,6,ME 2220: 006,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,7,ME 2220: 007,0.16,0.68,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,2220,8,ME 2220: 008,0.2,0.65,0.15,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2014
+ME,3020,1,Mech of Materials,0.2,0.31,0.22,0.11,0.13,0.0,0.0,0.02,paul joseph,,ME-3020,2014
+ME,3020,2,Mech of Materials,0.18,0.3,0.33,0.1,0.08,0.0,0.0,0.02,huijuan zhao,,ME-3020,2014
+ME,3020,3,Mech of Materials(HONORS),0.55,0.18,0.09,0.09,0.09,0.0,0.0,0.0,paul joseph,True,ME-3020,2014
+ME,3030,1,ME 3030: 001,0.12,0.24,0.3,0.14,0.12,0.0,0.0,0.08,john saylor,,ME-3030,2014
+ME,3030,2,ME 3030: 002,0.05,0.41,0.43,0.09,0.0,0.0,0.0,0.02,richard miller,,ME-3030,2014
+ME,3040,1,ME 3040: 001,0.09,0.23,0.26,0.09,0.09,0.0,0.0,0.23,jean-marc delhaye,,ME-3040,2014
+ME,3040,2,ME 3040: 002,0.15,0.27,0.33,0.09,0.11,0.0,0.0,0.05,jay ochterbeck,,ME-3040,2014
+ME,3050,1,ME 3050: 001,0.32,0.28,0.26,0.06,0.08,0.0,0.0,0.0,mohammed fari daqaq,,ME-3050,2014
+ME,3050,2,ME 3050: 002,0.32,0.36,0.16,0.08,0.04,0.0,0.0,0.04,phanin tallapragada,,ME-3050,2014
+ME,3060,1,ME 3060: 001,0.26,0.36,0.25,0.09,0.04,0.0,0.0,0.0,todd schweisinger,,ME-3060,2014
+ME,3060,2,ME 3060: 002,0.19,0.47,0.26,0.05,0.02,0.0,0.0,0.02,paul jeffrey meyer,,ME-3060,2014
+ME,3080,1,Fluid Mechanics,0.1,0.19,0.24,0.29,0.14,0.0,0.0,0.05,jean-marc delhaye,,ME-3080,2014
+ME,3080,2,Fluid Mechanics,0.12,0.33,0.45,0.02,0.06,0.0,0.0,0.02,ilenia battiato,,ME-3080,2014
+ME,3100,1,ME 3100: 001,0.22,0.17,0.33,0.13,0.13,0.0,0.0,0.02,jay ochterbeck,,ME-3100,2014
+ME,3120,1,ME 3120: 001,0.36,0.56,0.08,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-3120,2014
+ME,3120,2,ME 3120: 002,0.17,0.66,0.14,0.03,0.0,0.0,0.0,0.0,rod martinez-duarte,,ME-3120,2014
+ME,3330,1,ME 3330: 001,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,3330,2,ME 3330: 002,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,3330,3,ME 3330: 003,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,,ME-3330,2014
+ME,3330,5,ME 3330: 005,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,3330,6,ME 3330: 006,0.36,0.57,0.0,0.0,0.07,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,3330,7,ME 3330: 007,0.07,0.8,0.07,0.07,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2014
+ME,4010,1,ME 4010: 001,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,joshua summers,,ME-4010,2014
+ME,4020,1,ME 4020: 001,0.38,0.44,0.13,0.06,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2014
+ME,4020,2,ME 4020: 002,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,sherrill biggers,,ME-4020,2014
+ME,4020,3,ME 4020: 003,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2014
+ME,4020,5,ME 4020: 005,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-4020,2014
+ME,4020,6,ME 4020: 006,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2014
+ME,4020,7,ME 4020: 007,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4020,2014
+ME,4030,1,ME 4030: 001,0.21,0.23,0.31,0.13,0.1,0.0,0.0,0.03, timothy freeman,,ME-4030,2014
+ME,4030,2,ME 4030: 002,0.24,0.32,0.34,0.11,0.0,0.0,0.0,0.0,ardalan vahidi,,ME-4030,2014
+ME,4170,1,ME 4170: 001,0.44,0.48,0.07,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4170,2014
+ME,4220,1,ME 4220: 001,0.34,0.31,0.24,0.07,0.03,0.0,0.0,0.0,abhijit som,,ME-4220,2014
+ME,4230,1,ME 4230: 001,0.2,0.34,0.37,0.06,0.0,0.0,0.0,0.03,richard figliola,,ME-4230,2014
+ME,4260,1,ME 4260: 001,0.22,0.53,0.25,0.0,0.0,0.0,0.0,0.0,david zumbrunnen,,ME-4260,2014
+ME,4320,1,ME 4320: 001,0.32,0.58,0.03,0.0,0.0,0.0,0.0,0.06,gang li,,ME-4320,2014
+ME,4440,1,ME 4440: 001,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2014
+ME,4440,3,ME 4440: 003,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2014
+ME,4710,1,ME 4710: 001,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4710,2014
+ME,4930,1,Selected Topics ME (HVAC),0.27,0.43,0.27,0.0,0.0,0.0,0.0,0.03,donald willoughby,,ME-4930,2014
+ME,6220,1,ME 6220: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,,ME-6220,2014
+ME,6710,1,ME 6710: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-6710,2014
+ME,8120,1,ME 8120: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,,ME-8120,2014
+ME,8190,1,ME 8190: 001,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,,ME-8190,2014
+ME,8200,1,ME 8200: 001,0.52,0.41,0.04,0.0,0.0,0.0,0.0,0.04,yue wang,,ME-8200,2014
+ME,8310,1,ME 8310: 001,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rui qiao,,ME-8310,2014
+ME,8520,1,ME 8520: 001,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gang li,,ME-8520,2014
+ME,8520,2,ME 8520: 002,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,gang li,,ME-8520,2014
+ME,8610,1,ME 8610: 001,0.66,0.29,0.04,0.0,0.0,0.0,0.0,0.02,mica grujicic,,ME-8610,2014
+ME,8730,1,ME 8730: 001,0.27,0.2,0.47,0.0,0.0,0.0,0.0,0.07,joshua summers,,ME-8730,2014
+ME,8930,1,ME 8930: 001,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,nicole gise coutris,,ME-8930,2014
+MGT,2010,1,Principles of Mgt,0.26,0.35,0.25,0.09,0.02,0.0,0.0,0.03,katherine clark,,MGT-2010,2014
+MGT,2010,2,Principles of Mgt,0.26,0.32,0.24,0.12,0.04,0.0,0.0,0.02,katherine clark,,MGT-2010,2014
+MGT,2010,3,Principles of Mgt,0.15,0.43,0.26,0.05,0.01,0.0,0.0,0.1,katherine clark,,MGT-2010,2014
+MGT,2010,4,Principles of Mgt,0.23,0.32,0.28,0.08,0.03,0.0,0.0,0.06,katherine clark,,MGT-2010,2014
+MGT,2010,5,Principles of Mgt,0.28,0.39,0.2,0.08,0.02,0.0,0.0,0.02,tina robbins,,MGT-2010,2014
+MGT,2010,6,Principles of Mgt,0.14,0.46,0.25,0.12,0.01,0.0,0.0,0.03,tina robbins,,MGT-2010,2014
+MGT,2010,7,Principles of Mgt,0.23,0.4,0.24,0.09,0.01,0.0,0.0,0.04,tina robbins,,MGT-2010,2014
+MGT,2010,8,Principles of Mgt,0.14,0.44,0.25,0.1,0.02,0.0,0.0,0.05,tina robbins,,MGT-2010,2014
+MGT,2010,9,Principles of Mgt(HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True,MGT-2010,2014
+MGT,2180,125,MGT 2180: 125,0.31,0.44,0.15,0.04,0.01,0.01,0.0,0.04, sridharan,,MGT-2180,2014
+MGT,2180,230,MGT 2180: 230,0.28,0.43,0.2,0.03,0.03,0.0,0.0,0.03, sridharan,,MGT-2180,2014
+MGT,2180,335,MGT 2180: 335,0.22,0.43,0.23,0.06,0.01,0.0,0.0,0.05, sridharan,,MGT-2180,2014
+MGT,2180,905,MGT 2180: 905,0.32,0.49,0.12,0.01,0.02,0.01,0.0,0.03, sridharan,,MGT-2180,2014
+MGT,3070,1,Human Resource Management,0.13,0.41,0.38,0.08,0.0,0.0,0.0,0.0,marvin monroe ward,,MGT-3070,2014
+MGT,3070,2,Human Resource Management,0.13,0.5,0.33,0.05,0.0,0.0,0.0,0.0,marvin monroe ward,,MGT-3070,2014
+MGT,3070,3,Human Resource Management,0.21,0.32,0.39,0.03,0.05,0.0,0.0,0.0,marvin monroe ward,,MGT-3070,2014
+MGT,3070,4,Human Resource Management,0.31,0.6,0.06,0.0,0.03,0.0,0.0,0.0,kristin dam scott,,MGT-3070,2014
+MGT,3070,5,Human Resource Management,0.24,0.71,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2014
+MGT,3070,6,Human Resource Management,0.28,0.58,0.13,0.03,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2014
+MGT,3100,1,Intermed Business Statistics,0.07,0.28,0.26,0.16,0.12,0.0,0.0,0.12,zachary mo leffakis,,MGT-3100,2014
+MGT,3100,2,Intermed Business Statistics,0.3,0.3,0.19,0.12,0.05,0.0,0.0,0.05,zachary mo leffakis,,MGT-3100,2014
+MGT,3100,3,Intermed Business Statistics,0.19,0.33,0.21,0.05,0.02,0.0,0.0,0.19,niratc tungtisanont,,MGT-3100,2014
+MGT,3100,4,Intermed Business Statistics,0.23,0.43,0.23,0.03,0.0,0.0,0.0,0.1,james walsh,,MGT-3100,2014
+MGT,3100,5,Intermed Business Statistics,0.35,0.43,0.1,0.0,0.08,0.0,0.0,0.05,jerry kermi bilbrey,,MGT-3100,2014
+MGT,3100,6,Intermed Business Statistics,0.3,0.48,0.2,0.0,0.0,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3100,2014
+MGT,3100,7,Intermed Business Statistics,0.14,0.26,0.07,0.11,0.11,0.0,0.0,0.3,sara elizabet yoder,,MGT-3100,2014
+MGT,3100,8,Intermed Business Statistics,0.11,0.26,0.22,0.18,0.03,0.0,0.0,0.2,sara elizabet yoder,,MGT-3100,2014
+MGT,3100,10,Intermed Business Statistics,0.21,0.31,0.28,0.14,0.03,0.0,0.0,0.03,lianlian jiang,,MGT-3100,2014
+MGT,3100,11,Intermed Business Statistics,0.33,0.38,0.1,0.08,0.05,0.0,0.0,0.05,kevin mckenzie,,MGT-3100,2014
+MGT,3120,1,Decision Models for Mgt,0.27,0.3,0.24,0.08,0.08,0.0,0.0,0.03,mark mcknew,,MGT-3120,2014
+MGT,3120,2,Decision Models for Mgt,0.48,0.29,0.12,0.02,0.1,0.0,0.0,0.0,mark mcknew,,MGT-3120,2014
+MGT,3120,3,Decision Models for Mgt,0.29,0.24,0.34,0.02,0.1,0.0,0.0,0.0,mark mcknew,,MGT-3120,2014
+MGT,3150,1,New Venture Creation,0.21,0.33,0.42,0.0,0.03,0.0,0.0,0.0,peter gianiodis,,MGT-3150,2014
+MGT,3170,1,Logistics Mgmt,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,shouqiang wang,,MGT-3170,2014
+MGT,3180,1,Mgt of Info Systems,0.35,0.38,0.25,0.0,0.0,0.0,0.0,0.03,heshan sun,,MGT-3180,2014
+MGT,3180,2,Mgt of Info Systems,0.43,0.5,0.05,0.0,0.0,0.0,0.0,0.03,dan jiang,,MGT-3180,2014
+MGT,3180,3,Mgt of Info Systems,0.22,0.39,0.37,0.02,0.0,0.0,0.0,0.0,roopa raman,,MGT-3180,2014
+MGT,3180,4,Mgt of Info Systems,0.43,0.48,0.08,0.0,0.03,0.0,0.0,0.0,tina marie esposito,,MGT-3180,2014
+MGT,3900,1,Ops Mgt,0.08,0.33,0.28,0.22,0.06,0.0,0.0,0.03,yunsik choi,,MGT-3900,2014
+MGT,3900,2,Ops Mgt,0.13,0.43,0.38,0.08,0.0,0.0,0.0,0.0,jerry kermi bilbrey,,MGT-3900,2014
+MGT,3900,3,Ops Mgt,0.35,0.35,0.25,0.03,0.03,0.0,0.0,0.0,jerry kermi bilbrey,,MGT-3900,2014
+MGT,3900,4,Ops Mgt,0.2,0.39,0.33,0.06,0.02,0.0,0.0,0.0,lawrence fredendall,,MGT-3900,2014
+MGT,3900,5,Ops Mgt,0.24,0.49,0.17,0.05,0.05,0.0,0.0,0.0,yann ferrand,,MGT-3900,2014
+MGT,4000,1,Mgt of Org Beh,0.25,0.35,0.38,0.03,0.0,0.0,0.0,0.0,philip roth,,MGT-4000,2014
+MGT,4000,2,Mgt of Org Beh,0.16,0.62,0.22,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2014
+MGT,4000,3,Mgt of Org Beh,0.26,0.59,0.13,0.0,0.0,0.03,0.0,0.0,michael cole,,MGT-4000,2014
+MGT,4000,4,Mgt of Org Beh,0.35,0.58,0.08,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MGT-4000,2014
+MGT,4020,1,Ops Pln and Ctl,0.1,0.48,0.14,0.14,0.14,0.0,0.0,0.0,zachary mo leffakis,,MGT-4020,2014
+MGT,4030,1,Bus Intelligence & Analytics,0.26,0.35,0.19,0.03,0.16,0.0,0.0,0.0,siyuan li,,MGT-4030,2014
+MGT,4110,1,Project Management,0.32,0.35,0.27,0.0,0.03,0.0,0.0,0.03,russell purvis,,MGT-4110,2014
+MGT,4120,1,Supplier Management,0.26,0.54,0.17,0.03,0.0,0.0,0.0,0.0,shouqiang wang,,MGT-4120,2014
+MGT,4150,1,Business Strategy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2014
+MGT,4150,2,Business Strategy,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2014
+MGT,4150,3,Business Strategy,0.78,0.2,0.0,0.0,0.02,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2014
+MGT,4150,4,Business Strategy,0.17,0.51,0.32,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,,MGT-4150,2014
+MGT,4150,5,Business Strategy,0.09,0.5,0.35,0.04,0.0,0.0,0.0,0.02,jason wayne ridge,,MGT-4150,2014
+MGT,4150,6,Business Strategy,0.32,0.49,0.14,0.0,0.05,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2014
+MGT,4150,7,Business Strategy,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2014
+MGT,4150,8,Business Strategy,0.32,0.48,0.16,0.03,0.0,0.0,0.0,0.0,peter gianiodis,,MGT-4150,2014
+MGT,4160,1,Special Topics Hr,0.32,0.61,0.05,0.0,0.03,0.0,0.0,0.0,kristin dam scott,,MGT-4160,2014
+MGT,4230,1,Intern Bus Mgt,0.1,0.54,0.28,0.08,0.0,0.0,0.0,0.0,janis miller,,MGT-4230,2014
+MGT,4230,2,Intern Bus Mgt,0.08,0.58,0.25,0.03,0.05,0.0,0.0,0.03,janis miller,,MGT-4230,2014
+MGT,4230,3,Intern Bus Mgt,0.13,0.26,0.51,0.05,0.05,0.0,0.0,0.0,wayne stewart,,MGT-4230,2014
+MGT,4230,4,Intern Bus Mgt,0.1,0.25,0.6,0.05,0.0,0.0,0.0,0.0,wayne stewart,,MGT-4230,2014
+MGT,4240,1,Global Supply Chain,0.17,0.6,0.23,0.0,0.0,0.0,0.0,0.0,yann ferrand,,MGT-4240,2014
+MGT,4270,1,Managing Improvement,0.11,0.59,0.22,0.07,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4270,2014
+MGT,4310,1,Emp Rights & Resp,0.16,0.42,0.32,0.05,0.03,0.0,0.0,0.03,marvin monroe ward,,MGT-4310,2014
+MGT,4350,1,Pers Interviewing,0.3,0.5,0.18,0.03,0.0,0.0,0.0,0.0,philip roth,,MGT-4350,2014
+MGT,4520,1,Business Analysis,0.21,0.43,0.21,0.0,0.07,0.0,0.0,0.07,roopa raman,,MGT-4520,2014
+MGT,4550,1,Emerging I T Trends,0.28,0.61,0.06,0.03,0.03,0.0,0.0,0.0,jason thatcher,,MGT-4550,2014
+MGT,4560,1,Business Info Mgt,0.21,0.36,0.24,0.06,0.06,0.0,0.0,0.06,siyuan li,,MGT-4560,2014
+MGT,8120,1,Supply Chain Mgt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,gulru fatma ozkan,,MGT-8120,2014
+MGT,9040,1,MGT 9040: 001,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,heshan sun,,MGT-9040,2014
+MHA,7320,400,MHA 7320: 400,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,MHA-7320,2014
+MICR,3050,1,MICR 3050: 001,0.38,0.4,0.15,0.06,0.01,0.0,0.0,0.0,kristi ja whitehead,,MICR-3050,2014
+MICR,3050,2,MICR 3050: 002,0.38,0.4,0.17,0.03,0.0,0.0,0.0,0.03,krista barr rudolph,,MICR-3050,2014
+MICR,3050,3,MICR 3050: 003,0.62,0.24,0.09,0.03,0.0,0.0,0.0,0.03,krista barr rudolph,,MICR-3050,2014
+MICR,4000,1,Public Health Micro,0.52,0.18,0.25,0.05,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4000,2014
+MICR,4070,1,Food and Dairy Micro,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,xiuping jiang,,MICR-4070,2014
+MICR,4110,1,Pathogenic Bact,0.36,0.44,0.16,0.04,0.0,0.0,0.0,0.0,tamara lyn mcnealy,,MICR-4110,2014
+MICR,4120,1,Bacterial Physiology,0.11,0.32,0.23,0.17,0.15,0.0,0.0,0.02,thomas hughes,,MICR-4120,2014
+MICR,4130,1,Industrial Micro,0.41,0.5,0.05,0.03,0.0,0.0,0.0,0.02,tzuen-rong je tzeng,,MICR-4130,2014
+MICR,4140,1,Basic Immunology,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,charles rice,,MICR-4140,2014
+MICR,4170,1,Cancer and Aging,0.57,0.2,0.11,0.06,0.0,0.0,0.0,0.06,yuqing dong,,MICR-4170,2014
+MICR,4210,2,MICR 4210: 002,0.57,0.21,0.07,0.14,0.0,0.0,0.0,0.0,tamara lyn mcnealy,,MICR-4210,2014
+MICR,4220,1,MICR 4220: 001,0.75,0.15,0.05,0.05,0.0,0.0,0.0,0.0,thomas hughes,,MICR-4220,2014
+MICR,4220,2,MICR 4220: 002,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,,MICR-4220,2014
+MICR,4220,3,MICR 4220: 003,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,thomas hughes,,MICR-4220,2014
+MKT,3010,1,Prin of Marketing,0.27,0.55,0.14,0.04,0.0,0.0,0.0,0.0,carter wil mcelveen,,MKT-3010,2014
+MKT,3010,2,Prin of Marketing,0.36,0.41,0.18,0.03,0.01,0.0,0.0,0.01,james gaubert,,MKT-3010,2014
+MKT,3010,3,Prin of Marketing,0.29,0.4,0.2,0.07,0.03,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2014
+MKT,3010,4,Prin of Marketing,0.26,0.5,0.15,0.07,0.01,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2014
+MKT,3010,5,Prin of Marketing,0.24,0.41,0.23,0.07,0.02,0.0,0.0,0.03,patricia knowles,,MKT-3010,2014
+MKT,3020,1,Consumer Behavior,0.65,0.28,0.04,0.02,0.02,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2014
+MKT,3020,2,Consumer Behavior,0.66,0.32,0.02,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2014
+MKT,3020,3,Consumer Behavior,0.36,0.44,0.12,0.02,0.04,0.0,0.0,0.02, thyroff fitzwater,,MKT-3020,2014
+MKT,3020,4,Consumer Behavior,0.26,0.3,0.24,0.09,0.09,0.0,0.0,0.02, thyroff fitzwater,,MKT-3020,2014
+MKT,3210,1,Sports Marketing,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2014
+MKT,3980,1,Creative Inquiry in Marketing,0.96,0.0,0.02,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,,MKT-3980,2014
+MKT,4200,1,Professional Selling,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2014
+MKT,4200,2,Professional Selling,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jesse moore,,MKT-4200,2014
+MKT,4200,3,Professional Selling,0.5,0.35,0.08,0.0,0.08,0.0,0.0,0.0,carter wil mcelveen,,MKT-4200,2014
+MKT,4200,4,Professional Selling,0.75,0.21,0.0,0.04,0.0,0.0,0.0,0.0,carter wil mcelveen,,MKT-4200,2014
+MKT,4230,1,Promotional Strategy,0.32,0.38,0.22,0.04,0.0,0.0,0.0,0.04,patricia knowles,,MKT-4230,2014
+MKT,4240,1,Sales Management,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4240,2014
+MKT,4270,1,International Mktg,0.28,0.14,0.38,0.14,0.0,0.0,0.0,0.07,charles duke,,MKT-4270,2014
+MKT,4270,2,International Mktg,0.2,0.27,0.5,0.0,0.0,0.0,0.0,0.03,charles duke,,MKT-4270,2014
+MKT,4270,3,International Mktg,0.42,0.36,0.15,0.03,0.03,0.0,0.0,0.0,roger gomes,,MKT-4270,2014
+MKT,4270,4,International Mktg,0.29,0.47,0.21,0.0,0.0,0.0,0.0,0.03,roger gomes,,MKT-4270,2014
+MKT,4270,5,International Mktg,0.21,0.58,0.12,0.09,0.0,0.0,0.0,0.0,roger gomes,,MKT-4270,2014
+MKT,4280,1,Services Marketing,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,james gaubert,,MKT-4280,2014
+MKT,4310,1,Marketing Research,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2014
+MKT,4310,2,Marketing Research,0.35,0.57,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2014
+MKT,4310,3,Marketing Research,0.18,0.61,0.18,0.03,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4310,2014
+MKT,4330,1,Sport Mkt Strategy,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,,MKT-4330,2014
+MKT,4430,1,Advertising Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,albert neil cameron,,MKT-4430,2014
+MKT,4450,1,Macromarketing,0.56,0.34,0.03,0.0,0.0,0.06,0.0,0.0,william kilbourne,,MKT-4450,2014
+MKT,4500,1,Strategic Mktg Mgt,0.19,0.63,0.19,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2014
+MKT,4500,2,Strategic Mktg Mgt,0.18,0.76,0.06,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2014
+MKT,4500,3,Strategic Mktg Mgt,0.43,0.5,0.03,0.03,0.0,0.0,0.0,0.0,delancy bennett,,MKT-4500,2014
+MKT,4500,4,Strategic Mktg Mgt,0.08,0.4,0.44,0.08,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2014
+MKT,4950,1,Selected Topics,0.28,0.39,0.17,0.06,0.0,0.0,0.0,0.11,peter weathers,,MKT-4950,2014
+MKT,8620,1,MKT 8620: 001,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,,MKT-8620,2014
+MKT,8650,1,MKT 8650: 001,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MKT-8650,2014
+MKT,8660,1,Professional Selling,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,ryan mullins,,MKT-8660,2014
+ML,1020,1,Leadership Fund II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,garry michae hansel,,ML-1020,2014
+ML,1020,2,Leadership Fund II,0.57,0.24,0.1,0.0,0.05,0.0,0.0,0.05,garry michae hansel,,ML-1020,2014
+ML,2020,1,ML 2020: 001,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,thierry andre bras,,ML-2020,2014
+ML,2020,2,ML 2020: 002,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,thierry andre bras,,ML-2020,2014
+ML,3020,2,Adv Leadership II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,,ML-3020,2014
+MSE,2100,1,MSE 2100: 001,0.3,0.38,0.24,0.04,0.02,0.0,0.0,0.01,marian kennedy,,MSE-2100,2014
+MSE,2100,2,MSE 2100: 002,0.27,0.3,0.27,0.08,0.03,0.0,0.0,0.05,eric skaar,,MSE-2100,2014
+MSE,2100,3,MSE 2100: 003,0.42,0.19,0.3,0.03,0.04,0.0,0.0,0.02,julie patric martin,,MSE-2100,2014
+MSE,2500,1,MSE 2500: 001,0.68,0.25,0.04,0.0,0.04,0.0,0.0,0.0,deborah lickfield,,MSE-2500,2014
+MSE,3260,1,MSE 3260: 001,0.24,0.26,0.36,0.09,0.04,0.0,0.0,0.01,gary lickfield,,MSE-3260,2014
+MSE,3280,1,MSE 3280: 001,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,eric skaar,,MSE-3280,2014
+MSE,3420,2,MSE 3420: 002,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,rajendra kum bordia,,MSE-3420,2014
+MSE,3610,1,MSE 3610: 001,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,marian kennedy,,MSE-3610,2014
+MSE,4160,1,MSE 4160: 001,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,eric skaar,,MSE-4160,2014
+MSE,4220,1,MSE 4220: 001,0.26,0.52,0.19,0.0,0.0,0.0,0.0,0.04,vincent yves blouin,,MSE-4220,2014
+MSE,4330,1,MSE 4330: 001,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,,MSE-4330,2014
+MSE,4560,1,MSE 4560: 001,0.25,0.5,0.19,0.0,0.06,0.0,0.0,0.0,gary lickfield,,MSE-4560,2014
+MUSC,1120,2,Beg Class Guitar II,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,david stevenson,,MUSC-1120,2014
+MUSC,1420,2,MUSC 1420: 002,0.6,0.1,0.0,0.0,0.1,0.0,0.0,0.2,dan rash,,MUSC-1420,2014
+MUSC,1430,2,MUSC 1430: 002,0.7,0.0,0.0,0.0,0.1,0.0,0.0,0.2,dan rash,,MUSC-1430,2014
+MUSC,1800,1,MUSC 1800: 001,0.25,0.67,0.0,0.0,0.08,0.0,0.0,0.0,hamilton altstatt,,MUSC-1800,2014
+MUSC,2100,1,Music in West World,0.68,0.13,0.16,0.0,0.0,0.0,0.0,0.03,eric lapin,,MUSC-2100,2014
+MUSC,2100,2,Music in West World,0.45,0.25,0.25,0.03,0.0,0.0,0.0,0.03,lisa sain odom,,MUSC-2100,2014
+MUSC,2100,3,Music in West World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,eric lapin,,MUSC-2100,2014
+MUSC,2100,4,Music in West World,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2014
+MUSC,2100,5,Music in West World,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2014
+MUSC,2100,6,Music in West World,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2014
+MUSC,2100,9,Music in West World,0.55,0.39,0.03,0.0,0.0,0.0,0.0,0.03,lea kibler,,MUSC-2100,2014
+MUSC,3110,1,MUSC 3110: 001,0.57,0.33,0.07,0.03,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3110,2014
+MUSC,3120,1,History of Jazz,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,eric lapin,,MUSC-3120,2014
+MUSC,3170,1,Hist of Country Mus,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3170,2014
+MUSC,3310,1,MUSC 3310: 001,0.86,0.06,0.04,0.0,0.0,0.0,0.0,0.04,timothy ra hurlburt,,MUSC-3310,2014
+MUSC,3310,2,MUSC 3310: 002,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,,MUSC-3310,2014
+MUSC,3620,1,Symphonic Band,0.91,0.02,0.04,0.0,0.0,0.0,0.0,0.02,mark spede,,MUSC-3620,2014
+MUSC,3690,1,Symphony Orchestra,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,,MUSC-3690,2014
+MUSC,3700,1,Clemson University Singers,0.91,0.04,0.02,0.0,0.02,0.0,0.0,0.02,justin durham,,MUSC-3700,2014
+MUSC,3710,1,Women's Glee,0.92,0.02,0.03,0.0,0.03,0.0,0.0,0.0,justin durham,,MUSC-3710,2014
+MUSC,3720,1,Men's Glee,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,david conley,,MUSC-3720,2014
+MUSC,4160,1,MUSC 4160: 001,0.28,0.36,0.28,0.08,0.0,0.0,0.0,0.0,linda li-bleuel,,MUSC-4160,2014
+NPL,3010,1,NPL 3010: 001,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,tracy diane lamb,,NPL-3010,2014
+NPL,3030,1,NPL 3030: 001,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,wendell price,,NPL-3030,2014
+NURS,3030,1,NURS 3030: 001,0.36,0.51,0.1,0.0,0.0,0.0,0.0,0.03,leslie anne  ravan,,NURS-3030,2014
+NURS,3030,400,NURS 3030: 400,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,,NURS-3030,2014
+NURS,3100,1,NURS 3100: 001,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3100,2014
+NURS,3110,1,NURS 3110: 001,0.95,0.03,0.0,0.0,0.03,0.0,0.0,0.0,janice garri lanham,,NURS-3110,2014
+NURS,3120,1,NURS 3120: 001,0.42,0.55,0.03,0.0,0.0,0.0,0.0,0.0,angela pye,,NURS-3120,2014
+NURS,3190,400,NURS 3190: 400,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,kelly jordan smith,,NURS-3190,2014
+NURS,3200,1,NURS 3200: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,NURS-3200,2014
+NURS,3330,1,Health Care Genetics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,,NURS-3330,2014
+NURS,3330,400,Health Care Genetics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,NURS-3330,2014
+NURS,3400,1,NURS 3400: 001,0.21,0.66,0.08,0.03,0.03,0.0,0.0,0.0,catherine si murton,,NURS-3400,2014
+NURS,4010,1,NURS 4010: 001,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-4010,2014
+NURS,4030,1,NURS 4030: 001,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,,NURS-4030,2014
+NURS,4100,1,NURS 4100: 001,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,,NURS-4100,2014
+NURS,4110,1,NURS 4110: 001,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-4110,2014
+NURS,4120,1,NURS 4120: 001,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2014
+NURS,4150,1,NURS 4150: 001,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jackie gillespie,,NURS-4150,2014
+NURS,4250,400,NURS 4250: 400,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,roxanne amerson,,NURS-4250,2014
+NURS,4280,1,Senior Honors II (HON),0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,nancy meehan,True,NURS-4280,2014
+NURS,8010,400,NURS 8010: 400,0.56,0.36,0.03,0.0,0.0,0.0,0.0,0.05,shirley mae timmons,,NURS-8010,2014
+NURS,8080,400,NURS 8080: 400,0.71,0.24,0.02,0.0,0.02,0.0,0.0,0.0,veronica parker,,NURS-8080,2014
+NURS,8200,400,NURS 8200: 400,0.2,0.7,0.0,0.0,0.0,0.0,0.0,0.1,heide temples,,NURS-8200,2014
+NURS,8210,400,NURS 8210: 400,0.68,0.27,0.0,0.0,0.0,0.0,0.0,0.05,tracy king fasolino,,NURS-8210,2014
+NURS,8480,400,NURS 8480: 400,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,bonnie holaday,,NURS-8480,2014
+NURS,8850,400,NURS 8850: 400,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-8850,2014
+NUTR,2030,1,Intro Princ of Human Nutrition,0.37,0.43,0.12,0.01,0.02,0.0,0.0,0.04,rita haliena,,NUTR-2030,2014
+NUTR,4250,1,Medica Nutr Thera II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4250,2014
+NUTR,4260,1,NUTR 4260: 001,0.51,0.45,0.04,0.0,0.0,0.0,0.0,0.0,rita haliena,,NUTR-4260,2014
+NUTR,4550,1,NUTR 4550: 001,0.48,0.39,0.1,0.0,0.03,0.0,0.0,0.0,elliot jesch,,NUTR-4550,2014
+NUTR,8030,1,NUTR 8030: 001,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,vivian haley-zitlin,,NUTR-8030,2014
+PA,2010,1,PA 2010: 001,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,ned hosler,,PA-2010,2014
+PA,2800,1,PA 2800: 001,0.38,0.0,0.23,0.0,0.08,0.0,0.0,0.31,kenneth moore,,PA-2800,2014
+PADM,8220,400,PADM 8220: 400,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,mark daniel mellott,,PADM-8220,2014
+PADM,8340,400,PADM 8340: 400,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew moorman,,PADM-8340,2014
+PADM,8680,400,PADM 8680: 400,0.36,0.57,0.0,0.0,0.07,0.0,0.0,0.0,alfred bundrick,,PADM-8680,2014
+PHIL,1010,1,Intro to Phil Prob,0.47,0.35,0.06,0.03,0.03,0.0,0.0,0.06,david stegall,,PHIL-1010,2014
+PHIL,1010,2,Intro to Phil Prob,0.68,0.18,0.09,0.0,0.0,0.0,0.0,0.06,david stegall,,PHIL-1010,2014
+PHIL,1010,3,Intro to Phil Prob,0.45,0.36,0.15,0.0,0.03,0.0,0.0,0.0,christopher grau,,PHIL-1010,2014
+PHIL,1020,1,Intro to Logic,0.73,0.09,0.03,0.03,0.09,0.0,0.0,0.03,michael hal hannen,,PHIL-1020,2014
+PHIL,1020,2,Intro to Logic,0.68,0.15,0.06,0.0,0.03,0.0,0.0,0.09,michael hal hannen,,PHIL-1020,2014
+PHIL,1020,3,Intro to Logic,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2014
+PHIL,1020,4,Intro to Logic,0.28,0.22,0.25,0.0,0.03,0.0,0.0,0.22,cecilea mun,,PHIL-1020,2014
+PHIL,1020,5,Intro to Logic,0.07,0.43,0.11,0.0,0.04,0.0,0.0,0.36,cecilea mun,,PHIL-1020,2014
+PHIL,1020,6,Intro to Logic,0.19,0.08,0.0,0.0,0.04,0.0,0.0,0.69,cecilea mun,,PHIL-1020,2014
+PHIL,1030,1,Intro to Ethics HON,0.63,0.26,0.0,0.05,0.0,0.0,0.0,0.05,stephen satris,True,PHIL-1030,2014
+PHIL,1030,2,Intro to Ethics,0.57,0.3,0.08,0.0,0.0,0.0,0.0,0.05,david stegall,,PHIL-1030,2014
+PHIL,1030,3,Intro to Ethics,0.36,0.53,0.03,0.0,0.0,0.0,0.0,0.08,stephen satris,,PHIL-1030,2014
+PHIL,1030,4,Intro to Ethics,0.38,0.32,0.26,0.03,0.0,0.0,0.0,0.0,jennifer ingle,,PHIL-1030,2014
+PHIL,1030,5,Intro to Ethics,0.36,0.45,0.06,0.06,0.03,0.0,0.0,0.03,jennifer ingle,,PHIL-1030,2014
+PHIL,1030,6,Intro to Ethics,0.17,0.53,0.23,0.0,0.0,0.0,0.0,0.07,charles starkey,,PHIL-1030,2014
+PHIL,3040,1,PHIL 3040: 001,0.54,0.39,0.04,0.0,0.0,0.0,0.0,0.04,michael hal hannen,,PHIL-3040,2014
+PHIL,3050,1,PHIL 3050: 001,0.29,0.5,0.18,0.0,0.04,0.0,0.0,0.0,todd may,,PHIL-3050,2014
+PHIL,3150,1,PHIL 3150: 001,0.32,0.32,0.14,0.07,0.07,0.0,0.0,0.07,jennifer ingle,,PHIL-3150,2014
+PHIL,3160,1,Mod Phil,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,charles starkey,,PHIL-3160,2014
+PHIL,3200,1,PHIL 3200: 001,0.38,0.5,0.0,0.0,0.08,0.0,0.0,0.04,candice delmas,,PHIL-3200,2014
+PHIL,3250,1,Phil of Science,0.45,0.27,0.09,0.0,0.0,0.0,0.0,0.18,cecilea mun,,PHIL-3250,2014
+PHIL,3260,1,Science and Values,0.56,0.32,0.09,0.0,0.0,0.0,0.0,0.03,andrew garnar,,PHIL-3260,2014
+PHIL,3260,2,Science and Values,0.47,0.26,0.18,0.0,0.03,0.0,0.0,0.06,andrew garnar,,PHIL-3260,2014
+PHIL,3260,3,Science and Values,0.47,0.44,0.06,0.0,0.03,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2014
+PHIL,3300,1,PHIL 3300: 001,0.5,0.35,0.08,0.04,0.0,0.0,0.0,0.04,todd may,,PHIL-3300,2014
+PHIL,3430,1,PHIL 3430: 001,0.33,0.47,0.13,0.0,0.03,0.0,0.0,0.03,candice delmas,,PHIL-3430,2014
+PHIL,3440,1,Business Ethics,0.83,0.15,0.0,0.0,0.0,0.0,0.0,0.03,david stegall,,PHIL-3440,2014
+PHIL,3480,1,PHIL 3480: 001,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,christopher grau,,PHIL-3480,2014
+PHIL,3490,1,Gender and Sexuality,0.45,0.31,0.14,0.03,0.03,0.0,0.0,0.03,jennifer ingle,,PHIL-3490,2014
+PHIL,3990,1,PHIL 3990: 001,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,kelly smith,,PHIL-3990,2014
+PHSC,1170,1,Intro Chem & Earth,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1170,2014
+PHYS,1220,1,Physics With Cal I,0.12,0.39,0.32,0.08,0.05,0.0,0.0,0.05,lih-sin the,,PHYS-1220,2014
+PHYS,1220,2,Physics With Cal I,0.21,0.42,0.27,0.07,0.02,0.0,0.0,0.01,lih-sin the,,PHYS-1220,2014
+PHYS,1220,3,Physics With Cal I,0.3,0.44,0.19,0.02,0.03,0.0,0.0,0.02,lih-sin the,,PHYS-1220,2014
+PHYS,1220,4,Physics With Cal I,0.2,0.33,0.33,0.05,0.06,0.0,0.0,0.03,jason stratfo brown,,PHYS-1220,2014
+PHYS,1220,5,Physics With Cal I,0.22,0.39,0.24,0.06,0.05,0.0,0.0,0.04,mark leising,,PHYS-1220,2014
+PHYS,1220,8,Physics With Cal I HON,0.36,0.31,0.24,0.05,0.02,0.0,0.0,0.02,joan marler,True,PHYS-1220,2014
+PHYS,1240,1,Physics Lab I,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,2,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,3,Physics Lab I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,4,Physics Lab I,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,5,Physics Lab I,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,6,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,7,Physics Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,8,PHYSICS LAB I,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,9,Physics Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,10,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,11,Physics Lab I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,12,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,13,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,14,Physics Lab I,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-1240,2014
+PHYS,1240,15,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,16,Physics Lab I,0.17,0.61,0.06,0.0,0.0,0.0,0.0,0.17,jerry hester,,PHYS-1240,2014
+PHYS,1240,17,Physics Lab I,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2014
+PHYS,1240,18,Physics Lab I,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,19,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,1240,20,Physics Lab I,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,21,Physics Lab I,0.32,0.42,0.0,0.0,0.0,0.0,0.0,0.26,jerry hester,,PHYS-1240,2014
+PHYS,1240,22,Physics Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,,PHYS-1240,2014
+PHYS,1240,23,Physics Lab I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,jerry hester,,PHYS-1240,2014
+PHYS,1240,24,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,25,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,26,Physics Lab I,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,27,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2014
+PHYS,1240,29,Physics Lab I,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2014
+PHYS,2000,1,PHYS 2000: 001,0.34,0.38,0.26,0.0,0.0,0.0,0.0,0.02,amy liann pope,,PHYS-2000,2014
+PHYS,2070,1,General Physics I,0.28,0.35,0.19,0.08,0.05,0.0,0.0,0.06,amy liann pope,,PHYS-2070,2014
+PHYS,2080,1,General Physics II,0.33,0.46,0.13,0.07,0.01,0.0,0.0,0.0,pooja puneet,,PHYS-2080,2014
+PHYS,2080,2,General Physics II,0.44,0.38,0.13,0.03,0.01,0.0,0.0,0.01,pooja puneet,,PHYS-2080,2014
+PHYS,2090,1,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,2,Gen Phys Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,3,Gen Phys Lab I,0.33,0.54,0.04,0.08,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,4,Gen Phys Lab I,0.53,0.16,0.21,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-2090,2014
+PHYS,2090,5,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2014
+PHYS,2090,6,Gen Phys Lab I,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2014
+PHYS,2090,7,Gen Phys Lab I,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2014
+PHYS,2090,8,Gen Phys Lab I,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2014
+PHYS,2090,9,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2090,10,Gen Phys Lab I,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2014
+PHYS,2100,1,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,2,Gen Phys Lab II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,3,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,4,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,6,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,7,Gen Phys Lab II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,8,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,9,Gen Phys Lab II,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2014
+PHYS,2100,10,Gen Phys Lab II,0.54,0.29,0.08,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2100,2014
+PHYS,2100,11,Gen Phys Lab II,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,12,Gen Phys Lab II,0.63,0.21,0.04,0.0,0.04,0.0,0.0,0.08,jerry hester,,PHYS-2100,2014
+PHYS,2100,13,Gen Phys Lab II,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,14,Gen Phys Lab II,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2100,2014
+PHYS,2100,15,Gen Phys Lab II,0.21,0.67,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2100,16,Gen Phys Lab II,0.23,0.5,0.18,0.05,0.05,0.0,0.0,0.0,jerry hester,,PHYS-2100,2014
+PHYS,2210,1,Physics With Cal II,0.3,0.29,0.26,0.09,0.03,0.0,0.0,0.02,jason stratfo brown,,PHYS-2210,2014
+PHYS,2210,2,Physics With Cal II,0.28,0.39,0.22,0.07,0.03,0.0,0.0,0.03,jason stratfo brown,,PHYS-2210,2014
+PHYS,2210,3,Physics With Cal II,0.46,0.23,0.08,0.23,0.0,0.0,0.0,0.0,murray daw,,PHYS-2210,2014
+PHYS,2220,1,Phys With Cal III,0.57,0.3,0.11,0.0,0.03,0.0,0.0,0.0,hye jung kang,,PHYS-2220,2014
+PHYS,2230,2,Physics Lab II,0.35,0.29,0.29,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2014
+PHYS,2230,3,Physics Lab II,0.71,0.18,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,,PHYS-2230,2014
+PHYS,2230,4,Physics Lab II,0.13,0.63,0.13,0.13,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,5,Physics Lab II,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,6,Physics Lab II,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2230,8,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2014
+PHYS,2240,1,Physics Lab III,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-2240,2014
+PHYS,2240,2,Physics Lab III,0.41,0.53,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2240,2014
+PHYS,2400,1,Phys of Weather ONLINE,0.31,0.29,0.18,0.1,0.04,0.0,0.0,0.08,miguel larsen,,PHYS-2400,2014
+PHYS,3120,1,PHYS 3120: 001,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,feng ding,,PHYS-3120,2014
+PHYS,3220,1,Mechanics II,0.27,0.33,0.2,0.13,0.0,0.0,0.0,0.07,john meriwether,,PHYS-3220,2014
+PHYS,3260,1,Exper Physics II,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,chad sosolik,,PHYS-3260,2014
+PHYS,3560,1,PHYS 3560: 001,0.58,0.25,0.0,0.08,0.0,0.0,0.0,0.08,chad sosolik,,PHYS-3560,2014
+PHYS,4410,1,Electromagnetics I,0.27,0.45,0.18,0.0,0.0,0.0,0.0,0.09,endre andras takacs,,PHYS-4410,2014
+PHYS,4560,1,Quantum Physics II,0.08,0.77,0.15,0.0,0.0,0.0,0.0,0.0,jian he,,PHYS-4560,2014
+PHYS,4650,1,Thermo and Stat Mech,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,jeremy king,,PHYS-4650,2014
+PHYS,8150,1,Statistical Therm I,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,jens oberheide,,PHYS-8150,2014
+PHYS,8410,1,PHYS 8410: 001,0.11,0.72,0.11,0.0,0.0,0.0,0.0,0.06,gerald lehmacher,,PHYS-8410,2014
+PHYS,9520,1,PHYS 9520: 001,0.06,0.33,0.61,0.0,0.0,0.0,0.0,0.0,domnita marinescu,,PHYS-9520,2014
+PKSC,1020,1,PKSC 1020: 001,0.19,0.51,0.15,0.13,0.03,0.0,0.0,0.0,heather batt,,PKSC-1020,2014
+PKSC,2010,1,PKSC 2010: 001,0.19,0.33,0.3,0.12,0.06,0.0,0.0,0.0,heather batt,,PKSC-2010,2014
+PKSC,2020,1,PKSC 2020: 001,0.53,0.24,0.24,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2020,2014
+PKSC,2040,1,PKSC 2040: 001,0.66,0.16,0.13,0.02,0.02,0.0,0.0,0.02,robert truett moore,,PKSC-2040,2014
+PKSC,2060,1,PKSC 2060: 001,0.93,0.04,0.0,0.04,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2060,2014
+PKSC,2200,1,PKSC 2200: 001,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,william aaro snyder,,PKSC-2200,2014
+PKSC,3200,1,PKSC 3200: 001,0.31,0.46,0.1,0.05,0.05,0.0,0.0,0.03,rupert hurley,,PKSC-3200,2014
+PKSC,3680,1,Pkg and Society,0.13,0.41,0.18,0.1,0.15,0.0,0.0,0.03,heather batt,,PKSC-3680,2014
+PKSC,4010,1,PKSC 4010: 001,0.45,0.49,0.02,0.0,0.04,0.0,0.0,0.0,anthony lou pometto,,PKSC-4010,2014
+PKSC,4030,1,PKSC 4030: 001,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2014
+PKSC,4200,1,PKSC 4200: 001,0.7,0.17,0.13,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2014
+PKSC,4300,1,PKSC 4300: 001,0.16,0.67,0.14,0.0,0.02,0.0,0.0,0.02,duncan darby,,PKSC-4300,2014
+PKSC,4400,1,PKSC 4400: 001,0.29,0.38,0.21,0.03,0.09,0.0,0.0,0.0,gregory batt,,PKSC-4400,2014
+PKSC,4640,1,Fd & Hc Pkg Systems,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2014
+PKSC,8510,1,Pkg Sci Seminar,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,ronnie thomas,,PKSC-8510,2014
+PLPA,2130,1,Fungi & Civilization,0.48,0.28,0.11,0.07,0.04,0.0,0.0,0.02,julia loui kerrigan,,PLPA-2130,2014
+PLPA,6590,1,PLPA 6590: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,,PLPA-6590,2014
+POSC,1010,1,Amer National Govt,0.13,0.63,0.23,0.0,0.0,0.0,0.0,0.01,joseph earl stewart,,POSC-1010,2014
+POSC,1010,2,Amer National Govt,0.07,0.4,0.33,0.13,0.07,0.0,0.0,0.0,adam warber,,POSC-1010,2014
+POSC,1020,1,Intro Intl Relations,0.13,0.44,0.28,0.08,0.04,0.0,0.0,0.04,aron geo tannenbaum,,POSC-1020,2014
+POSC,1020,2,Intro Intl Relations,0.21,0.26,0.26,0.12,0.07,0.0,0.0,0.08,zeynep taydas,,POSC-1020,2014
+POSC,1030,1,Intro to Political Theory,0.38,0.24,0.16,0.11,0.11,0.0,0.0,0.0,brandon turner,,POSC-1030,2014
+POSC,1040,1,Intro Compar Pol,0.03,0.39,0.5,0.03,0.0,0.0,0.0,0.06,colin pearce,,POSC-1040,2014
+POSC,1040,2,Intro Compar Pol,0.41,0.39,0.11,0.04,0.02,0.0,0.0,0.02,katherine am curtis,,POSC-1040,2014
+POSC,1990,1,POSC 1990: 001,0.3,0.1,0.27,0.2,0.13,0.0,0.0,0.0,meredith petersheim,,POSC-1990,2014
+POSC,3020,1,State and Loc Gov,0.17,0.63,0.1,0.0,0.07,0.0,0.0,0.03,bruce ransom,,POSC-3020,2014
+POSC,3110,1,Model United Nations,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,xiaobo hu,,POSC-3110,2014
+POSC,3210,1,Public Admin,0.05,0.38,0.31,0.15,0.1,0.0,0.0,0.0,james woodard,,POSC-3210,2014
+POSC,3410,1,Quant Meth in Pol Sc,0.56,0.25,0.13,0.06,0.0,0.0,0.0,0.0,steven vince miller,,POSC-3410,2014
+POSC,3610,1,Intl Pol in Crisis,0.21,0.39,0.26,0.05,0.05,0.0,0.0,0.03,vladimir matic,,POSC-3610,2014
+POSC,3610,2,Intl Pol in Crisis,0.43,0.23,0.27,0.03,0.0,0.0,0.0,0.03,steven vince miller,,POSC-3610,2014
+POSC,3630,1,Us Foreign Policy,0.17,0.45,0.28,0.03,0.03,0.0,0.0,0.03,jeffrey scott peake,,POSC-3630,2014
+POSC,3710,1,European Politics,0.43,0.31,0.19,0.05,0.02,0.0,0.0,0.0,katherine am curtis,,POSC-3710,2014
+POSC,3750,1,European Integration,0.15,0.54,0.08,0.23,0.0,0.0,0.0,0.0,zeynep taydas,,POSC-3750,2014
+POSC,4050,1,American Presidency,0.15,0.46,0.23,0.0,0.08,0.0,0.0,0.08,adam warber,,POSC-4050,2014
+POSC,4070,1,Religion and Politic,0.2,0.41,0.28,0.11,0.0,0.0,0.0,0.0,laura olson,,POSC-4070,2014
+POSC,4240,1,Federalism and Igr,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,,POSC-4240,2014
+POSC,4360,1,Law Courts Politics,0.52,0.31,0.1,0.0,0.02,0.0,0.0,0.05,joseph earl stewart,,POSC-4360,2014
+POSC,4370,1,Constitut Law: Rights & Libert,0.34,0.54,0.09,0.03,0.0,0.0,0.0,0.0,daniel frost,,POSC-4370,2014
+POSC,4380,1,Constitut Law: Struc of Gov,0.48,0.39,0.09,0.04,0.0,0.0,0.0,0.0,daniel frost,,POSC-4380,2014
+POSC,4500,1,Plato to Postmodernism,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,andrew sc bernstein,,POSC-4500,2014
+POSC,4530,1,American Political Thought,0.35,0.23,0.15,0.08,0.15,0.0,0.0,0.04,brandon turner,,POSC-4530,2014
+POSC,4540,1,Southern Politics,0.04,0.48,0.33,0.07,0.04,0.0,0.0,0.04,james woodard,,POSC-4540,2014
+POSC,4570,1,Political Terrorism,0.42,0.29,0.23,0.03,0.0,0.0,0.0,0.03,aron geo tannenbaum,,POSC-4570,2014
+POSC,4610,1,Am Diplomacy & Pol,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,vladimir matic,,POSC-4610,2014
+POSC,4760,1,Middle East Politics,0.48,0.33,0.05,0.0,0.0,0.0,0.0,0.14,vladimir matic,,POSC-4760,2014
+POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.96,0.02,0.02,meredith petersheim,,POSC-4990,2014
+POST,8430,1,POST 8430: 001,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,,POST-8430,2014
+PRTM,2000,1,PRTM 2000: 001,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.01,cindy hartman,,PRTM-2000,2014
+PRTM,2200,1,PRTM 2200: 001,0.19,0.63,0.11,0.04,0.04,0.0,0.0,0.0,teresa walto tucker,,PRTM-2200,2014
+PRTM,2200,2,PRTM 2200: 002,0.19,0.78,0.04,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2200,2014
+PRTM,2200,3,PRTM 2200: 003,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bernard mwe kitheka,,PRTM-2200,2014
+PRTM,2200,4,PRTM 2200: 004,0.41,0.48,0.04,0.0,0.0,0.0,0.0,0.07,katherine eli evans,,PRTM-2200,2014
+PRTM,2200,5,PRTM 2200: 005,0.65,0.23,0.08,0.04,0.0,0.0,0.0,0.0,kellie aman walters,,PRTM-2200,2014
+PRTM,2200,6,PRTM 2200: 006,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,samuel ogletree,,PRTM-2200,2014
+PRTM,2200,7,PRTM 2200: 007,0.22,0.48,0.26,0.04,0.0,0.0,0.0,0.0,denise mar anderson,,PRTM-2200,2014
+PRTM,2410,1,PRTM 2410: 001,0.24,0.47,0.29,0.0,0.0,0.0,0.0,0.0,craig colistra,,PRTM-2410,2014
+PRTM,2410,2,PRTM 2410: 002,0.42,0.35,0.23,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2410,2014
+PRTM,2600,1,PRTM 2600: 001,0.88,0.09,0.0,0.0,0.03,0.0,0.0,0.0,alison lynne cory,,PRTM-2600,2014
+PRTM,2650,1,PRTM 2650: 001,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,alison lynne cory,,PRTM-2650,2014
+PRTM,2700,1,Intro Rec Res Mgt,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,stephen springs,,PRTM-2700,2014
+PRTM,2810,1,Intro to Golf Mgt,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-2810,2014
+PRTM,2820,1,PRTM 2820: 001,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-2820,2014
+PRTM,2830,1,PRTM 2830: 001,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-2830,2014
+PRTM,2980,3,Creative Inquiry in PRTM II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,toni liechty,,PRTM-2980,2014
+PRTM,2980,6,Creative Inquiry in PRTM II,0.73,0.07,0.2,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-2980,2014
+PRTM,3070,1,PRTM 3070: 001,0.85,0.13,0.03,0.0,0.0,0.0,0.0,0.0,craig goodman,,PRTM-3070,2014
+PRTM,3260,1,PRTM 3260: 001,0.31,0.44,0.23,0.03,0.0,0.0,0.0,0.0,brandi crowe,,PRTM-3260,2014
+PRTM,3270,1,PRTM 3270: 001,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3270,2014
+PRTM,3280,1,PRTM 3280: 001,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,alison lynne cory,,PRTM-3280,2014
+PRTM,3420,1,Intro to Tourism,0.73,0.19,0.0,0.03,0.0,0.0,0.0,0.05,maloud shakona,,PRTM-3420,2014
+PRTM,3420,2,Intro to Tourism,0.53,0.25,0.19,0.0,0.03,0.0,0.0,0.0,jarrett bachman,,PRTM-3420,2014
+PRTM,3440,1,PRTM 3440: 001,0.39,0.36,0.21,0.0,0.04,0.0,0.0,0.0,sheila backman,,PRTM-3440,2014
+PRTM,3440,2,PRTM 3440: 002,0.39,0.35,0.1,0.12,0.04,0.0,0.0,0.0,sheila backman,,PRTM-3440,2014
+PRTM,3460,1,PRTM 3460: 001,0.13,0.65,0.17,0.04,0.0,0.0,0.0,0.0,gregory phi ramshaw,,PRTM-3460,2014
+PRTM,3470,1,PRTM 3470: 001,0.34,0.34,0.21,0.1,0.0,0.0,0.0,0.0,gregory phi ramshaw,,PRTM-3470,2014
+PRTM,3510,1,PRTM 3510: 001,0.2,0.2,0.5,0.1,0.0,0.0,0.0,0.0,daniel mor anderson,,PRTM-3510,2014
+PRTM,3550,1,PRTM 3550: 001,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-3550,2014
+PRTM,3830,1,PRTM 3830: 001,0.45,0.09,0.45,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-3830,2014
+PRTM,3980,1,Creative Inquiry in PRTM III,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,,PRTM-3980,2014
+PRTM,3980,3,Creative Inquiry in PRTM III,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,,PRTM-3980,2014
+PRTM,3980,4,Creative Inquiry in PRTM III,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi hughes,,PRTM-3980,2014
+PRTM,3980,6,Creative Inquiry in PRTM III,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,,PRTM-3980,2014
+PRTM,3980,9,Creative Inquiry in PRTM III,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-3980,2014
+PRTM,4070,1,PRTM 4070: 001,0.33,0.43,0.24,0.0,0.0,0.0,0.0,0.0,toni liechty,,PRTM-4070,2014
+PRTM,4210,1,Rec Fin Resc Mgt,0.11,0.49,0.17,0.17,0.06,0.0,0.0,0.0,denise mar anderson,,PRTM-4210,2014
+PRTM,4220,1,PRTM 4220: 001,0.32,0.54,0.11,0.0,0.0,0.0,0.0,0.04,anna-mar chancellor,,PRTM-4220,2014
+PRTM,4260,1,PRTM 4260: 001,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-4260,2014
+PRTM,4300,1,World Geog Parks,0.58,0.35,0.06,0.0,0.0,0.0,0.0,0.0,robert baxte powell,,PRTM-4300,2014
+PRTM,4310,1,Methods Envir Inter,0.43,0.21,0.29,0.07,0.0,0.0,0.0,0.0,robert bixler,,PRTM-4310,2014
+PRTM,4410,1,PRTM 4410: 001,0.5,0.25,0.1,0.1,0.05,0.0,0.0,0.0,herbert chancellor,,PRTM-4410,2014
+PRTM,4450,1,PRTM 4450: 001,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jeffery martin,,PRTM-4450,2014
+PRTM,4470,1,PRTM 4470: 001,0.78,0.17,0.02,0.0,0.0,0.0,0.0,0.02,lauren duffy,,PRTM-4470,2014
+PRTM,4510,1,PRTM 4510: 001,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-4510,2014
+PRTM,4540,1,Trends in Sport Mgt,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,,PRTM-4540,2014
+PRTM,4550,1,PRTM 4550: 001,0.28,0.56,0.17,0.0,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-4550,2014
+PRTM,8030,1,PRTM 8030: 001,0.78,0.13,0.0,0.0,0.04,0.0,0.0,0.04,skye arthur-banning,,PRTM-8030,2014
+PRTM,8110,1,PRTM 8110: 001,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,,PRTM-8110,2014
+PRTM,8110,2,PRTM 8110: 002,0.65,0.2,0.1,0.0,0.0,0.0,0.0,0.05,jeffrey charl hallo,,PRTM-8110,2014
+PRTM,8210,1,PRTM 8210: 001,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,denise mar anderson,,PRTM-8210,2014
+PRTM,8250,1,PRTM 8250: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,toni liechty,,PRTM-8250,2014
+PSYC,2010,1,Intro to Psychology,0.29,0.38,0.2,0.03,0.03,0.0,0.0,0.07,mary taylor,,PSYC-2010,2014
+PSYC,2010,2,Intro to Psychology,0.09,0.44,0.36,0.04,0.03,0.0,0.0,0.04,mary taylor,,PSYC-2010,2014
+PSYC,2010,3,Intro to Psychology (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True,PSYC-2010,2014
+PSYC,2010,4,Intro to Psychology,0.3,0.25,0.31,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,,PSYC-2010,2014
+PSYC,2010,5,Intro to Psychology,0.57,0.23,0.09,0.09,0.03,0.0,0.0,0.0,chong hyon pak,,PSYC-2010,2014
+PSYC,2010,6,Intro to Psychology,0.37,0.31,0.19,0.06,0.04,0.0,0.0,0.03,fred switzer,,PSYC-2010,2014
+PSYC,2010,7,Intro to Psychology,0.29,0.26,0.2,0.11,0.09,0.0,0.0,0.06,edwin brainerd,,PSYC-2010,2014
+PSYC,2020,1,PSYC 2020: 001,0.84,0.0,0.11,0.0,0.0,0.0,0.0,0.05,eric mckibben,,PSYC-2020,2014
+PSYC,2020,2,PSYC 2020: 002,0.79,0.08,0.0,0.04,0.0,0.0,0.0,0.08,eric mckibben,,PSYC-2020,2014
+PSYC,2020,3,PSYC 2020: 003,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2014
+PSYC,2020,4,PSYC 2020: 004,0.78,0.04,0.09,0.0,0.04,0.0,0.0,0.04,eric mckibben,,PSYC-2020,2014
+PSYC,2020,5,PSYC 2020: 005,0.78,0.09,0.09,0.0,0.04,0.0,0.0,0.0,lauren elizab ellis,,PSYC-2020,2014
+PSYC,2020,6,PSYC 2020: 006,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,james nathan salley,,PSYC-2020,2014
+PSYC,2020,7,PSYC 2020: 007,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,drew morgan link,,PSYC-2020,2014
+PSYC,3060,1,Human Sexual Beh,0.67,0.18,0.09,0.03,0.02,0.0,0.0,0.01,bruce michael king,,PSYC-3060,2014
+PSYC,3090,100,Intro Exp Psych,0.14,0.36,0.29,0.07,0.11,0.0,0.0,0.04,jennifer bai bisson,,PSYC-3090,2014
+PSYC,3090,200,Intro Exp Psych,0.42,0.3,0.15,0.05,0.05,0.0,0.0,0.01,richard tyrrell,,PSYC-3090,2014
+PSYC,3090,300,Intro Exp Psych,0.9,0.03,0.07,0.0,0.0,0.0,0.0,0.0,larry alton pace,,PSYC-3090,2014
+PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3100,2014
+PSYC,3100,200,Advanced Experimental Psych,0.33,0.39,0.06,0.06,0.11,0.0,0.0,0.06,stephanie whetsel,,PSYC-3100,2014
+PSYC,3100,300,Advanced Experimental Psych,0.35,0.47,0.06,0.0,0.12,0.0,0.0,0.0,robert campbell,,PSYC-3100,2014
+PSYC,3100,400,Advanced Experimental Psych,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,larry alton pace,,PSYC-3100,2014
+PSYC,3100,500,Advanced Experimental Psych,0.47,0.24,0.18,0.0,0.12,0.0,0.0,0.0,thomas britt,,PSYC-3100,2014
+PSYC,3100,600,Advanced Experimental Psych,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,paul steven merritt,,PSYC-3100,2014
+PSYC,3100,700,Advanced Experimental Psych,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2014
+PSYC,3240,1,Physiological Psych,0.37,0.27,0.17,0.08,0.06,0.0,0.0,0.06,claudio cantalupo,,PSYC-3240,2014
+PSYC,3240,2,Physiological Psych,0.37,0.24,0.15,0.07,0.1,0.0,0.0,0.07,claudio cantalupo,,PSYC-3240,2014
+PSYC,3330,1,Cognitive Psych,0.19,0.4,0.24,0.11,0.03,0.0,0.0,0.03,thomas alley,,PSYC-3330,2014
+PSYC,3340,1,Cognitive Psych Lab,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,thomas alley,,PSYC-3340,2014
+PSYC,3340,2,Cognitive Psych Lab,0.64,0.07,0.21,0.07,0.0,0.0,0.0,0.0,thomas alley,,PSYC-3340,2014
+PSYC,3340,3,Cognitive Psych Lab,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,ashley ann sewall,,PSYC-3340,2014
+PSYC,3400,1,Lifespan Developmental Psych,0.31,0.42,0.14,0.06,0.04,0.0,0.0,0.03,pamela alley,,PSYC-3400,2014
+PSYC,3520,1,Social Psychology,0.45,0.34,0.14,0.07,0.0,0.0,0.0,0.0,jo anne jorgensen,,PSYC-3520,2014
+PSYC,3520,2,Social Psychology,0.38,0.38,0.18,0.03,0.0,0.0,0.0,0.03,jo anne jorgensen,,PSYC-3520,2014
+PSYC,3520,3,Social Psychology (HON),0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True,PSYC-3520,2014
+PSYC,3640,1,Industrial Psych,0.24,0.46,0.26,0.01,0.01,0.0,0.0,0.01,eric mckibben,,PSYC-3640,2014
+PSYC,3680,1,Organizational Psych,0.56,0.24,0.17,0.01,0.0,0.0,0.0,0.01,skye gillispie,,PSYC-3680,2014
+PSYC,3700,1,Personality,0.4,0.46,0.13,0.01,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-3700,2014
+PSYC,3830,1,Abnormal Psychology,0.34,0.31,0.26,0.0,0.06,0.0,0.0,0.03,pamela alley,,PSYC-3830,2014
+PSYC,3830,2,Abnormal Psychology,0.26,0.26,0.26,0.15,0.0,0.0,0.0,0.06,pamela alley,,PSYC-3830,2014
+PSYC,3830,3,Abnormal Psychology,0.17,0.46,0.28,0.04,0.03,0.0,0.0,0.01,heidi marie zinzow,,PSYC-3830,2014
+PSYC,4080,1,Women and Psychology,0.44,0.32,0.16,0.04,0.04,0.0,0.0,0.0,robin mari kowalski,,PSYC-4080,2014
+PSYC,4150,1,Systems and Theories,0.3,0.37,0.2,0.07,0.03,0.0,0.0,0.03,edwin brainerd,,PSYC-4150,2014
+PSYC,4150,2,Systems and Theories,0.26,0.33,0.22,0.07,0.07,0.0,0.0,0.07,edwin brainerd,,PSYC-4150,2014
+PSYC,4220,1,Perception,0.21,0.31,0.31,0.03,0.1,0.0,0.0,0.03,claudio cantalupo,,PSYC-4220,2014
+PSYC,4220,2,Perception,0.29,0.26,0.29,0.13,0.03,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2014
+PSYC,4750,1,Brain and Behavior,0.5,0.28,0.11,0.0,0.0,0.0,0.0,0.11,june pilcher,,PSYC-4750,2014
+PSYC,4800,1,Health Psychology,0.68,0.2,0.04,0.0,0.0,0.0,0.0,0.08,june pilcher,,PSYC-4800,2014
+PSYC,4800,2,Health Psychology,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2014
+PSYC,4800,3,Health Psychology,0.64,0.28,0.04,0.0,0.04,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2014
+PSYC,4820,1,Positive Psychology,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,cynthia pury,,PSYC-4820,2014
+PSYC,4890,1,Teamwork in the 21st Century,0.83,0.04,0.04,0.0,0.0,0.0,0.0,0.09,marissa leig porter,,PSYC-4890,2014
+PSYC,4890,4,Teamwork in the 21st Century,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,marissa leig porter,,PSYC-4890,2014
+PSYC,4920,1,Senior Laboratory,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,allison lei wallace,,PSYC-4920,2014
+PSYC,4920,2,Senior Laboratory,0.82,0.11,0.07,0.0,0.0,0.0,0.0,0.0,allison lei wallace,,PSYC-4920,2014
+PSYC,4920,3,Senior Laboratory,0.82,0.11,0.07,0.0,0.0,0.0,0.0,0.0,crystal burn fulmer,,PSYC-4920,2014
+PSYC,4920,4,Senior Laboratory,0.71,0.17,0.0,0.08,0.04,0.0,0.0,0.0,crystal burn fulmer,,PSYC-4920,2014
+PSYC,4930,100,Pract Clinical Psych,0.65,0.1,0.05,0.0,0.1,0.0,0.0,0.1,heidi marie zinzow,,PSYC-4930,2014
+PSYC,8130,1,PSYC 8130: 001,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0, dewayne moore,,PSYC-8130,2014
+PSYC,8620,1,PSYC 8620: 001,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,robert ray sinclair,,PSYC-8620,2014
+RED,8010,1,Market Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,,RED-8010,2014
+RED,8040,1,Resid Practicum,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,,RED-8040,2014
+RED,8050,1,Commercial Practicum,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8050,2014
+RED,8120,1,Real Estate Technology,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,,RED-8120,2014
+RED,8130,1,RED 8130: 001,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,,RED-8130,2014
+REL,1010,1,Intro to Religion,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,robert stephens,,REL-1010,2014
+REL,1010,2,Intro to Religion,0.79,0.09,0.03,0.0,0.0,0.0,0.0,0.09,robert stephens,,REL-1010,2014
+REL,1020,1,World Religions,0.32,0.41,0.15,0.06,0.03,0.0,0.0,0.03,peter cohen,,REL-1020,2014
+REL,1020,2,World Religions,0.47,0.34,0.06,0.06,0.0,0.0,0.0,0.06,peter cohen,,REL-1020,2014
+REL,1020,4,World Religions,0.25,0.39,0.28,0.06,0.03,0.0,0.0,0.0,peter cohen,,REL-1020,2014
+REL,1020,5,World Religions,0.77,0.17,0.0,0.0,0.0,0.0,0.0,0.07,robert stephens,,REL-1020,2014
+REL,1020,6,World Religions,0.51,0.34,0.06,0.0,0.0,0.0,0.0,0.09,robert stephens,,REL-1020,2014
+REL,3000,1,REL 3000: 001,0.58,0.24,0.03,0.03,0.03,0.0,0.0,0.09,steven grosby,,REL-3000,2014
+REL,3010,1,Old Testament,0.59,0.21,0.12,0.0,0.0,0.06,0.0,0.03,steven grosby,,REL-3010,2014
+REL,3010,2,Old Testament,0.42,0.56,0.0,0.0,0.0,0.0,0.0,0.03,steven grosby,,REL-3010,2014
+REL,3730,1,Age of Protestant Reformation,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,thomas kuehn,,REL-3730,2014
+RS,3010,1,Rural Sociology,0.37,0.37,0.14,0.09,0.0,0.0,0.0,0.03,kenneth robinson,,RS-3010,2014
+RS,4590,1,The Community,0.64,0.07,0.21,0.0,0.0,0.0,0.0,0.07,kenneth robinson,,RS-4590,2014
+RUSS,1020,1,RUSS 1020: 001,0.27,0.45,0.09,0.0,0.09,0.0,0.0,0.09,joan bridgwood,,RUSS-1020,2014
+RUSS,2020,1,Intermediate Russ,0.5,0.2,0.1,0.0,0.0,0.0,0.0,0.2,joan bridgwood,,RUSS-2020,2014
+SOC,2010,1,Intro to Sociology (HON),0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,sarah evely winslow,True,SOC-2010,2014
+SOC,2010,2,Introduction to Sociology,0.48,0.36,0.12,0.0,0.01,0.0,0.0,0.02,jennifer le holland,,SOC-2010,2014
+SOC,2010,3,Introduction to Sociology,0.45,0.37,0.12,0.02,0.02,0.0,0.0,0.02,jennifer le holland,,SOC-2010,2014
+SOC,2010,4,Introduction to Sociology,0.54,0.33,0.06,0.02,0.0,0.0,0.0,0.04,mary louise barr,,SOC-2010,2014
+SOC,2010,5,Introduction to Sociology,0.71,0.22,0.04,0.02,0.0,0.0,0.0,0.0,mary louise barr,,SOC-2010,2014
+SOC,2010,6,Introduction to Sociology,0.73,0.17,0.06,0.02,0.0,0.0,0.0,0.02,mary louise barr,,SOC-2010,2014
+SOC,2010,7,Introduction to Sociology,0.55,0.31,0.14,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2014
+SOC,2010,8,Introduction to Sociology,0.38,0.42,0.16,0.01,0.0,0.0,0.0,0.02,mary louise barr,,SOC-2010,2014
+SOC,2010,9,Introduction to Sociology,0.51,0.34,0.08,0.01,0.03,0.0,0.0,0.03,jennifer triplett,,SOC-2010,2014
+SOC,2010,10,Introduction to Sociology,0.76,0.2,0.02,0.0,0.02,0.0,0.0,0.0,jennifer triplett,,SOC-2010,2014
+SOC,2020,1,Social Problems,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,stephani southworth,,SOC-2020,2014
+SOC,2020,2,Social Problems,0.48,0.35,0.09,0.04,0.04,0.0,0.0,0.0,stephani southworth,,SOC-2020,2014
+SOC,2050,1,SOC 2050: 001,0.72,0.08,0.03,0.08,0.06,0.0,0.0,0.03,brenda vander mey,,SOC-2050,2014
+SOC,3020,1,Research Methods I,0.15,0.38,0.42,0.04,0.0,0.0,0.0,0.02,ellen granberg,,SOC-3020,2014
+SOC,3040,1,Research Methods II,0.22,0.48,0.22,0.04,0.0,0.0,0.0,0.04,ye luo,,SOC-3040,2014
+SOC,3100,1,Marriage & Intimacy,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,,SOC-3100,2014
+SOC,3100,2,Marriage & Intimacy,0.54,0.35,0.07,0.0,0.0,0.04,0.0,0.0,jeffrey edwards,,SOC-3100,2014
+SOC,3110,1,The Family,0.52,0.38,0.06,0.04,0.0,0.0,0.0,0.0,jennifer triplett,,SOC-3110,2014
+SOC,3310,1,Urban Sociology,0.27,0.38,0.15,0.04,0.1,0.0,0.0,0.06,stephani southworth,,SOC-3310,2014
+SOC,3500,1,Self & Society,0.37,0.45,0.14,0.0,0.02,0.0,0.0,0.02,jennifer triplett,,SOC-3500,2014
+SOC,3800,1,Intro Social Service,0.49,0.39,0.06,0.0,0.04,0.0,0.0,0.02,jennifer le holland,,SOC-3800,2014
+SOC,3880,1,Criminal Justice,0.45,0.19,0.21,0.09,0.06,0.0,0.0,0.0,william white,,SOC-3880,2014
+SOC,3890,1,Criminology,0.28,0.22,0.2,0.17,0.09,0.0,0.0,0.04,william white,,SOC-3890,2014
+SOC,3910,1,Soc of Deviance,0.18,0.39,0.27,0.04,0.04,0.0,0.0,0.08,stephani southworth,,SOC-3910,2014
+SOC,3920,1,Juvenile Delinquency,0.54,0.25,0.15,0.0,0.02,0.0,0.0,0.04,jeffrey edwards,,SOC-3920,2014
+SOC,3970,1,Substance Abuse,0.51,0.36,0.04,0.0,0.04,0.0,0.0,0.04,jeffrey edwards,,SOC-3970,2014
+SOC,4040,1,Soc Theory,0.54,0.34,0.07,0.0,0.02,0.0,0.0,0.02,william haller,,SOC-4040,2014
+SOC,4330,1,Global Social Change,0.64,0.24,0.04,0.0,0.04,0.0,0.0,0.04,william haller,,SOC-4330,2014
+SOC,4440,1,Sociology of Educ,0.25,0.21,0.08,0.08,0.25,0.0,0.0,0.13,stephani southworth,,SOC-4440,2014
+SOC,4590,1,The Community,0.39,0.22,0.22,0.0,0.0,0.0,0.0,0.17,kenneth robinson,,SOC-4590,2014
+SOC,4600,1,Race & Ethnicity,0.5,0.18,0.29,0.0,0.04,0.0,0.0,0.0,brenda vander mey,,SOC-4600,2014
+SOC,4610,1,Sex & Gender,0.22,0.46,0.24,0.09,0.0,0.0,0.0,0.0,sarah evely winslow,,SOC-4610,2014
+SOC,4840,1,Child Abuse,0.47,0.26,0.21,0.03,0.0,0.0,0.0,0.03,douglas sturkie,,SOC-4840,2014
+SOC,4930,1,Soc of Corrections,0.4,0.33,0.13,0.13,0.0,0.0,0.0,0.0,william white,,SOC-4930,2014
+SOC,4970,1,Senior Lab,0.65,0.19,0.0,0.15,0.0,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2014
+SOC,4970,2,Senior Lab,0.75,0.0,0.08,0.17,0.0,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2014
+SOC,4990,1,Sem- Issues in Cmmty Policity,0.1,0.4,0.5,0.0,0.0,0.0,0.0,0.0,william white,,SOC-4990,2014
+SPAN,1010,1,SPAN 1010: 001,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2014
+SPAN,1010,2,SPAN 1010: 002,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2014
+SPAN,1010,3,SPAN 1010: 003,0.21,0.16,0.16,0.21,0.0,0.0,0.0,0.26,samuel palmer moody,,SPAN-1010,2014
+SPAN,1020,1,SPAN 1020: 001,0.13,0.5,0.19,0.13,0.0,0.0,0.0,0.06,roger simpson,,SPAN-1020,2014
+SPAN,1020,2,SPAN 1020: 002,0.06,0.12,0.18,0.24,0.18,0.0,0.0,0.24,roger simpson,,SPAN-1020,2014
+SPAN,1020,3,SPAN 1020: 003,0.33,0.33,0.17,0.11,0.06,0.0,0.0,0.0,roger simpson,,SPAN-1020,2014
+SPAN,1020,4,SPAN 1020: 004,0.22,0.17,0.28,0.06,0.11,0.0,0.0,0.17,roger simpson,,SPAN-1020,2014
+SPAN,1020,5,SPAN 1020: 005,0.11,0.26,0.26,0.05,0.16,0.0,0.0,0.16,roger simpson,,SPAN-1020,2014
+SPAN,1020,6,SPAN 1020: 006,0.0,0.29,0.53,0.12,0.0,0.0,0.0,0.06,cathy robison,,SPAN-1020,2014
+SPAN,1020,7,SPAN 1020: 007,0.26,0.32,0.26,0.11,0.0,0.0,0.0,0.05,cathy robison,,SPAN-1020,2014
+SPAN,1020,8,SPAN 1020: 008,0.17,0.28,0.39,0.0,0.06,0.0,0.0,0.11,ricardo tremolada,,SPAN-1020,2014
+SPAN,1020,9,SPAN 1020: 009,0.24,0.29,0.18,0.06,0.06,0.0,0.0,0.18,ricardo tremolada,,SPAN-1020,2014
+SPAN,1020,10,SPAN 1020: 010,0.21,0.42,0.26,0.0,0.05,0.0,0.0,0.05,allison ann hinds,,SPAN-1020,2014
+SPAN,1020,11,SPAN 1020: 011,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,allison ann hinds,,SPAN-1020,2014
+SPAN,1020,12,SPAN 1020: 012,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1020,2014
+SPAN,1020,14,SPAN 1020: 014,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,scott harris,,SPAN-1020,2014
+SPAN,2010,1,Intermediate Spanish,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2014
+SPAN,2010,2,Intermediate Spanish,0.28,0.56,0.11,0.06,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2014
+SPAN,2010,3,Intermediate Spanish,0.21,0.53,0.11,0.0,0.0,0.0,0.0,0.16,maureen zamora,,SPAN-2010,2014
+SPAN,2010,4,Intermediate Spanish,0.58,0.16,0.26,0.0,0.0,0.0,0.0,0.0,angeli leal,,SPAN-2010,2014
+SPAN,2010,5,Intermediate Spanish,0.37,0.42,0.0,0.05,0.11,0.0,0.0,0.05,angeli leal,,SPAN-2010,2014
+SPAN,2010,6,Intermediate Spanish,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,heidi montes,,SPAN-2010,2014
+SPAN,2010,7,Intermediate Spanish,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,allison ann hinds,,SPAN-2010,2014
+SPAN,2010,8,Intermediate Spanish,0.13,0.5,0.13,0.0,0.06,0.0,0.0,0.19,melva margu persico,,SPAN-2010,2014
+SPAN,2010,9,Intermediate Spanish,0.08,0.58,0.25,0.0,0.08,0.0,0.0,0.0,melva margu persico,,SPAN-2010,2014
+SPAN,2010,10,Intermediate Spanish,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2014
+SPAN,2010,11,Intermediate Spanish,0.25,0.31,0.31,0.13,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2014
+SPAN,2010,12,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,sarah stoll watt,,SPAN-2010,2014
+SPAN,2010,13,Intermediate Spanish,0.37,0.42,0.11,0.11,0.0,0.0,0.0,0.0,sarah stoll watt,,SPAN-2010,2014
+SPAN,2010,14,Intermediate Spanish,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,allison ann hinds,,SPAN-2010,2014
+SPAN,2010,15,Intermediate Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2010,2014
+SPAN,2020,1,Intermediate Spanish,0.55,0.2,0.25,0.0,0.0,0.0,0.0,0.0,michael greene,,SPAN-2020,2014
+SPAN,2020,2,Intermediate Spanish,0.53,0.21,0.26,0.0,0.0,0.0,0.0,0.0,michael greene,,SPAN-2020,2014
+SPAN,2020,3,Intermediate Spanish,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,michael greene,,SPAN-2020,2014
+SPAN,2020,4,Intermediate Spanish,0.39,0.17,0.39,0.0,0.06,0.0,0.0,0.0,angeli leal,,SPAN-2020,2014
+SPAN,2020,5,Intermediate Spanish,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,angeli leal,,SPAN-2020,2014
+SPAN,2020,6,Intermediate Spanish,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,heidi montes,,SPAN-2020,2014
+SPAN,2020,7,Intermediate Spanish,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2020,2014
+SPAN,2020,8,Intermediate Spanish,0.29,0.35,0.18,0.06,0.06,0.0,0.0,0.06,melva margu persico,,SPAN-2020,2014
+SPAN,2020,9,Intermediate Spanish,0.24,0.53,0.18,0.0,0.0,0.0,0.0,0.06,melva margu persico,,SPAN-2020,2014
+SPAN,2020,10,Intermediate Spanish,0.58,0.16,0.16,0.11,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2020,2014
+SPAN,2020,11,Intermediate Spanish,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,ellory schmucker,,SPAN-2020,2014
+SPAN,2020,12,Intermediate Spanish,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,sarah stoll watt,,SPAN-2020,2014
+SPAN,2020,13,Intermediate Spanish,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,sarah stoll watt,,SPAN-2020,2014
+SPAN,2020,15,Intermediate Spanish,0.53,0.18,0.12,0.12,0.0,0.0,0.0,0.06,ricardo tremolada,,SPAN-2020,2014
+SPAN,2020,16,Intermediate Spanish,0.21,0.36,0.14,0.07,0.14,0.0,0.0,0.07,juana martin-armas,,SPAN-2020,2014
+SPAN,2020,17,Intermediate Spanish,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,juana martin-armas,,SPAN-2020,2014
+SPAN,2020,18,Intermediate Spanish (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,True,SPAN-2020,2014
+SPAN,3020,1,SPAN 3020: 001,0.39,0.44,0.0,0.0,0.06,0.0,0.0,0.11,juana martin-armas,,SPAN-3020,2014
+SPAN,3020,2,SPAN 3020: 002,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,juana martin-armas,,SPAN-3020,2014
+SPAN,3060,1,SPAN 3060: 001,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-3060,2014
+SPAN,3070,1,Hispanic World: Sp,0.71,0.07,0.0,0.0,0.0,0.0,0.0,0.21,raquel anido,,SPAN-3070,2014
+SPAN,3080,1,Hispanic World: La,0.78,0.0,0.17,0.06,0.0,0.0,0.0,0.0,lisa kristi dewaard,,SPAN-3080,2014
+SPAN,3080,2,Hispanic World: La,0.58,0.21,0.16,0.0,0.05,0.0,0.0,0.0,lisa kristi dewaard,,SPAN-3080,2014
+SPAN,3090,1,SPAN 3090: 001,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,lisa kristi dewaard,,SPAN-3090,2014
+SPAN,3140,1,SPAN 3140: 001,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,,SPAN-3140,2014
+SPAN,4010,1,SPAN 4010: 001,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,raquel anido,,SPAN-4010,2014
+SPAN,4050,1,SPAN 4050: 001,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,maureen zamora,,SPAN-4050,2014
+SPAN,4060,1,SPAN 4060: 001,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,,SPAN-4060,2014
+SPAN,4060,2,SPAN 4060: 002,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,mon rojas-de-massei,,SPAN-4060,2014
+SPAN,4090,1,SPAN 4090: 001,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,,SPAN-4090,2014
+SPAN,4150,1,SPAN 4150: 001,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,areli moore peralta,,SPAN-4150,2014
+STAT,2220,1,Statistics in Everyday Life,0.45,0.25,0.19,0.08,0.02,0.0,0.0,0.02,ros martinez-dawson,,STAT-2220,2014
+STAT,2220,2,Statistics in Everyday Life,0.5,0.3,0.09,0.09,0.02,0.0,0.0,0.0,ros martinez-dawson,,STAT-2220,2014
+STAT,2220,3,Statistics in Everyday Life,0.22,0.34,0.2,0.1,0.1,0.0,0.0,0.05,ran xie,,STAT-2220,2014
+STAT,2220,4,Statistics in Everyday Life,0.38,0.29,0.21,0.08,0.04,0.0,0.0,0.0,ran xie,,STAT-2220,2014
+STAT,3010,1,Introductory Statistics,0.33,0.22,0.3,0.12,0.0,0.0,0.0,0.03,richard stev dubsky,,STAT-3010,2014
+STAT,3010,2,Introductory Statistics,0.47,0.25,0.15,0.03,0.05,0.0,0.0,0.05,richard stev dubsky,,STAT-3010,2014
+STAT,3010,3,Introductory Statistics,0.45,0.22,0.21,0.07,0.03,0.0,0.0,0.02,james espey,,STAT-3010,2014
+STAT,3010,4,Introductory Statistics,0.53,0.19,0.17,0.08,0.03,0.0,0.0,0.0,ros martinez-dawson,,STAT-3010,2014
+STAT,3010,5,Introductory Statistics,0.22,0.25,0.18,0.15,0.17,0.0,0.0,0.03, erwin walker,,STAT-3010,2014
+STAT,3010,6,Introductory Statistics,0.35,0.17,0.28,0.1,0.08,0.0,0.0,0.02, erwin walker,,STAT-3010,2014
+STAT,3010,7,Introductory Statistics,0.22,0.29,0.22,0.09,0.14,0.0,0.0,0.03,richard stev dubsky,,STAT-3010,2014
+STAT,3010,8,Introductory Statistics,0.26,0.34,0.16,0.09,0.14,0.0,0.0,0.02,benjamin sharp,,STAT-3010,2014
+STAT,3010,9,Introductory Statistics,0.32,0.3,0.14,0.1,0.11,0.0,0.0,0.03,ellen hepfe breazel,,STAT-3010,2014
+STAT,3010,10,Introductory Statistics,0.29,0.25,0.16,0.07,0.16,0.0,0.0,0.07,jun luo,,STAT-3010,2014
+STAT,4110,1,STAT 4110: 001,0.43,0.35,0.13,0.04,0.04,0.0,0.0,0.0,james rieck,,STAT-4110,2014
+STAT,4110,2,STAT 4110: 002,0.19,0.44,0.19,0.0,0.13,0.0,0.0,0.06,patrick gerard,,STAT-4110,2014
+STAT,8010,1,STAT 8010: 001,0.41,0.45,0.1,0.0,0.03,0.0,0.0,0.0,james rieck,,STAT-8010,2014
+STAT,8010,2,STAT 8010: 002,0.59,0.35,0.0,0.0,0.03,0.0,0.0,0.03,william bridges,,STAT-8010,2014
+STAT,8010,3,STAT 8010: 003,0.53,0.24,0.18,0.0,0.03,0.0,0.0,0.03,jun luo,,STAT-8010,2014
+STAT,8020,1,STAT 8020: 001,0.7,0.22,0.0,0.0,0.0,0.0,0.0,0.07,william bridges,,STAT-8020,2014
+STAT,8030,1,STAT 8030: 001,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,hoke hill,,STAT-8030,2014
+STAT,8040,1,STAT 8040: 001,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,,STAT-8040,2014
+STAT,8420,230,Intro to Statistical Methods,0.15,0.54,0.08,0.0,0.23,0.0,0.0,0.0,julia lynn sharp,,STAT-8420,2014
+STS,1010,1,Survey of S T S,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,thomas oberdan,,STS-1010,2014
+STS,1010,2,Survey of S T S,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,,STS-1010,2014
+STS,1010,3,Survey of S T S,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angelina oberdan,,STS-1010,2014
+STS,1010,4,Survey of S T S,0.24,0.38,0.18,0.06,0.06,0.0,0.0,0.09,david charles foltz,,STS-1010,2014
+STS,1010,5,Survey of S T S,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.03,michael greene,,STS-1010,2014
+STS,1010,6,Survey of S T S,0.47,0.38,0.09,0.03,0.0,0.0,0.0,0.03,sarah mae cooper,,STS-1010,2014
+STS,1010,7,Survey of S T S,0.48,0.42,0.03,0.03,0.03,0.0,0.0,0.0,thomas oberdan,,STS-1010,2014
+STS,1010,20,Survey of S T S,0.29,0.45,0.21,0.0,0.0,0.0,0.0,0.05,thomas oberdan,,STS-1010,2014
+STS,2150,1,Crit Appr to Tech Revolutions,0.21,0.16,0.58,0.0,0.05,0.0,0.0,0.0,thomas oberdan,,STS-2150,2014
+THEA,2100,1,Theatre Appreciation,0.77,0.19,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,,THEA-2100,2014
+THEA,2100,2,Theatre Appreciation,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-2100,2014
+THEA,2100,3,Theatre Appreciation,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,kerrie kath seymour,,THEA-2100,2014
+THEA,2100,4,Theatre Appreciation,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-2100,2014
+THEA,2100,6,Theatre Appreciation,0.53,0.34,0.06,0.0,0.0,0.0,0.0,0.06,jason adkins,,THEA-2100,2014
+THEA,2100,8,Theatre Appreciation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,,THEA-2100,2014
+THEA,3150,1,Theatre History I,0.75,0.1,0.1,0.0,0.05,0.0,0.0,0.0,richard st. peter,,THEA-3150,2014
+THEA,3180,1,THEA 3180: 001,0.4,0.35,0.15,0.1,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-3180,2014
+THEA,3680,1,THEA 3680: 001,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,,THEA-3680,2014
+THEA,4670,1,THEA 4670: 001,0.5,0.0,0.1,0.0,0.3,0.0,0.0,0.1,kendra lyne johnson,,THEA-4670,2014
+WFB,3010,1,WFB 3010: 001,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2014
+WFB,3130,1,Conservation Biology,0.3,0.22,0.28,0.16,0.0,0.0,0.0,0.04,shari lyn rodriguez,,WFB-3130,2014
+WFB,3130,2,Conservation Biology,0.29,0.16,0.42,0.1,0.03,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3130,2014
+WFB,3500,1,WFB 3500: 001,0.39,0.45,0.14,0.0,0.0,0.0,0.0,0.02,james davis,,WFB-3500,2014
+WFB,3500,2,WFB 3500: 002,0.29,0.32,0.29,0.05,0.05,0.0,0.0,0.0,james davis,,WFB-3500,2014
+WFB,4160,1,WFB 4160: 001,0.36,0.32,0.26,0.04,0.02,0.0,0.0,0.0,yoichiro kanno,,WFB-4160,2014
+WFB,4300,1,WFB 4300: 001,0.56,0.3,0.05,0.0,0.06,0.0,0.0,0.03,joseph lanham,,WFB-4300,2014
+WFB,4400,1,WFB 4400: 001,0.43,0.31,0.09,0.09,0.06,0.0,0.0,0.02,shari lyn rodriguez,,WFB-4400,2014
+WFB,4440,1,WFB 4440: 001,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,,WFB-4440,2014
+WFB,4620,1,Wetland Wildl Biol,0.25,0.41,0.24,0.08,0.01,0.0,0.0,0.01,russell barrett,,WFB-4620,2014
+WFB,4760,1,WFB 4760: 001,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph lanham,,WFB-4760,2014
+WFB,8610,1,Applied Population Dynamics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katherine mcfadden,,WFB-8610,2014
+WS,1030,1,Women Global Perspec,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,,WS-1030,2014
+WS,2300,1,WS 2300: 001,0.69,0.23,0.04,0.0,0.0,0.0,0.0,0.04,saadiqa kumanyika,,WS-2300,2014
+WS,3010,1,Intro Womens Studies,0.7,0.24,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2014
+WS,3010,2,Intro Womens Studies,0.58,0.37,0.03,0.0,0.03,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2014

--- a/bot/cogs/grades_cog/assets/2015_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2015_Fall.csv
@@ -1,2702 +1,2702 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1010,1,Survey of Art & Arch History I,0.5,0.35,0.11,0.0,0.01,0.0,0.0,0.04,beth ann lauritis,
-AAH,2050,1,Art History and Theory I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,beth ann lauritis,
-AAH,3050,1,Contemporary Art History,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,andrea feeser,
-ACCT,2010,1,Financial Accounting Concepts,0.11,0.23,0.26,0.11,0.13,0.0,0.0,0.17,philip maiberger,
-ACCT,2010,2,Financial Accounting Concepts,0.13,0.4,0.3,0.06,0.0,0.0,0.0,0.11,philip maiberger,
-ACCT,2010,3,Financial Accounting Concepts,0.41,0.23,0.13,0.05,0.03,0.0,0.0,0.15,lydia lan schleifer,
-ACCT,2010,4,Financial Accounting Concepts,0.32,0.43,0.14,0.03,0.08,0.0,0.0,0.0,annieka philo,
-ACCT,2010,5,Financial Accounting Concepts,0.26,0.24,0.13,0.08,0.11,0.0,0.0,0.18,lydia lan schleifer,
-ACCT,2010,6,Financial Accounting Concepts,0.2,0.27,0.17,0.03,0.07,0.0,0.0,0.27,the estate  guffey,
-ACCT,2010,7,Financial Accounting Concepts,0.33,0.43,0.1,0.12,0.0,0.0,0.0,0.02,annieka philo,
-ACCT,2010,8,Financial Accounting Concepts,0.1,0.36,0.36,0.03,0.1,0.0,0.0,0.05,philip maiberger,
-ACCT,2010,9,Financial Accounting Concepts,0.2,0.28,0.25,0.05,0.15,0.0,0.0,0.08,lydia lan schleifer,
-ACCT,2010,10,Financial Accounting Concepts,0.41,0.32,0.14,0.05,0.09,0.0,0.0,0.0,annieka philo,
-ACCT,2010,11,Financial Accounting Concepts,0.05,0.45,0.21,0.1,0.1,0.0,0.0,0.1,the estate  guffey,
-ACCT,2010,12,Financial Accounting Concepts,0.21,0.37,0.15,0.03,0.09,0.0,0.0,0.16,james mil kohlmeyer,
-ACCT,2010,13,Financial Accounting Concepts,0.13,0.53,0.16,0.0,0.08,0.0,0.0,0.11,mary ann  prater,
-ACCT,2010,14,Financial Accounting Concepts,0.13,0.56,0.17,0.06,0.06,0.0,0.0,0.04,james mil kohlmeyer,
-ACCT,2010,100,Fin Accounting Concepts (HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True
-ACCT,2010,400,Financial Accounting Concepts,0.15,0.27,0.25,0.14,0.13,0.0,0.0,0.07,jeffrey mcmillan,
-ACCT,2020,1,Managerial Accounting Concepts,0.14,0.14,0.24,0.12,0.07,0.0,0.0,0.29,henry anderson,
-ACCT,2020,2,Managerial Accounting Concepts,0.23,0.34,0.21,0.02,0.09,0.0,0.0,0.11,henry anderson,
-ACCT,2020,3,Managerial Accounting Concepts,0.26,0.32,0.19,0.08,0.09,0.0,0.0,0.06,holly rhiannio hawk,
-ACCT,2020,4,Managerial Accounting Concepts,0.14,0.41,0.24,0.14,0.08,0.0,0.0,0.0,holly rhiannio hawk,
-ACCT,2020,5,Managerial Accounting Concepts,0.37,0.28,0.28,0.02,0.06,0.0,0.0,0.0,tonya dionne smalls,
-ACCT,2020,6,Managerial Accounting Concepts,0.37,0.24,0.18,0.02,0.12,0.0,0.0,0.08,tonya dionne smalls,
-ACCT,2020,400,Managerial Accounting Concepts,0.18,0.15,0.18,0.09,0.08,0.0,0.0,0.31,henry anderson,
-ACCT,3030,1,Cost Accounting,0.18,0.52,0.18,0.0,0.02,0.0,0.0,0.11,holly rhiannio hawk,
-ACCT,3030,2,Cost Accounting,0.33,0.42,0.07,0.0,0.09,0.0,0.0,0.09,holly rhiannio hawk,
-ACCT,3030,3,Cost Accounting,0.22,0.43,0.22,0.07,0.04,0.0,0.0,0.02,jace garrett,
-ACCT,3030,4,Cost Accounting,0.16,0.6,0.16,0.0,0.0,0.0,0.0,0.09,jace garrett,
-ACCT,3110,1,Intermediate Financial Acct I,0.18,0.42,0.24,0.03,0.11,0.0,0.0,0.03,terry daniel knause,
-ACCT,3110,2,Intermediate Financial Acct I,0.35,0.26,0.21,0.06,0.06,0.0,0.0,0.06,terry daniel knause,
-ACCT,3110,3,Intermediate Financial Acct I,0.23,0.38,0.15,0.1,0.1,0.0,0.0,0.03,terry daniel knause,
-ACCT,3110,4,Intermediate Financial Acct I,0.33,0.4,0.18,0.05,0.03,0.0,0.0,0.03,terry daniel knause,
-ACCT,3110,5,Intermediate Financial Acct I,0.23,0.46,0.21,0.05,0.03,0.0,0.0,0.03, russell madray,
-ACCT,3110,400,Intermediate Financial Acct I,0.08,0.21,0.38,0.13,0.08,0.0,0.0,0.13, russell madray,
-ACCT,3120,1,Intermediate Financial Acct II,0.07,0.21,0.32,0.21,0.14,0.0,0.0,0.04,brian todd carver,
-ACCT,3120,2,Intermediate Financial Acct II,0.08,0.28,0.38,0.13,0.08,0.0,0.0,0.05,brian todd carver,
-ACCT,3120,3,Intermediate Financial Acct II,0.15,0.28,0.38,0.1,0.05,0.0,0.0,0.03,jeremy micha vinson,
-ACCT,3120,4,Intermediate Financial Acct II,0.13,0.45,0.34,0.05,0.03,0.0,0.0,0.0,jeremy micha vinson,
-ACCT,3120,5,Intermediate Financial Acct II,0.13,0.38,0.38,0.05,0.05,0.0,0.0,0.0,jeremy micha vinson,
-ACCT,3130,1,Intermediate Fin Acct III,0.18,0.33,0.39,0.03,0.03,0.0,0.0,0.03, russell madray,
-ACCT,3130,2,Intermediate Fin Acct III,0.37,0.43,0.17,0.0,0.0,0.0,0.0,0.03, russell madray,
-ACCT,3130,3,Intermediate Fin Acct III,0.2,0.35,0.28,0.13,0.0,0.0,0.0,0.05,james irving,
-ACCT,3130,4,Intermediate Fin Acct III,0.26,0.36,0.28,0.08,0.03,0.0,0.0,0.0, russell madray,
-ACCT,3220,1,Accounting Information Systems,0.09,0.26,0.23,0.11,0.06,0.0,0.0,0.26,philip maiberger,
-ACCT,3220,2,Accounting Information Systems,0.27,0.32,0.3,0.11,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,3220,3,Accounting Information Systems,0.11,0.35,0.3,0.11,0.05,0.0,0.0,0.08,nancy lee harp,
-ACCT,4040,1,Individual Taxation,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,2,Individual Taxation,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4080,1,Retire & Estate Plan,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,john hine,
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.31,0.46,0.13,0.08,0.0,0.0,0.0,0.03,sally kathr widener,
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
-ACCT,4150,1,Auditing,0.17,0.4,0.31,0.11,0.0,0.0,0.0,0.0,carl hollingsworth,
-ACCT,4150,2,Auditing,0.21,0.29,0.29,0.12,0.03,0.0,0.0,0.06,carl hollingsworth,
-ACCT,8510,1,Tax Research,0.27,0.7,0.03,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8510,2,Tax Research,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8510,3,Tax Research,0.26,0.71,0.03,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8530,1,Adv Acct Problems,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8530,2,Adv Acct Problems,0.39,0.42,0.13,0.0,0.0,0.0,0.0,0.06,ralph welton,
-ACCT,8530,3,Adv Acct Problems,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8550,1,Gov't and Nonprofit Accounting,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8550,2,Gov't and Nonprofit Accounting,0.58,0.35,0.08,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8630,1,Forensics Analysis,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,james irving,
-ACCT,8630,2,Forensics Analysis,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james irving,
-ACCT,8630,601,Forensics Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,james irving,
-ACCT,8650,1,Tax & Bus Decisions,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,judson jahn,
-ACCT,8730,1,Intl/Spec Tax Topic,0.31,0.58,0.08,0.0,0.0,0.0,0.0,0.03,judson jahn,
-AGED,1020,1,Freshman Seminar,0.65,0.12,0.06,0.06,0.0,0.0,0.0,0.12,catheri dibenedetto,
-AGED,2010,1,Intro to Agric Educ,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,2040,1,App Ag Calculations,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,3030,1,Ag Ed Mech Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGED,3650,1,Multiculturalism in Agric Educ,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGED,4000,1,Supervised Field Experience II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,4010,1,Instr Methods Ag Ed,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,
-AGED,4030,1,Prin Adult/Ext Ed,0.76,0.19,0.0,0.05,0.0,0.0,0.0,0.0,kevin layfield,
-AGED,4230,400,Curriculum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,
-AGM,1010,1,Intro Ag Mech & Bus,0.73,0.16,0.1,0.02,0.0,0.0,0.0,0.0,hunter massey,
-AGM,2050,1,Prin of Fabrication,0.16,0.37,0.37,0.04,0.03,0.0,0.0,0.03,hunter massey,
-AGM,2060,1,Machinery Mgt,0.19,0.43,0.29,0.05,0.05,0.0,0.0,0.0,hunter massey,
-AGM,2210,1,Land Measurements,0.36,0.4,0.2,0.01,0.01,0.0,0.0,0.02,charles privette,
-AGM,3010,1,Soil Water Conserv,0.29,0.39,0.27,0.02,0.0,0.0,0.0,0.03,calvin sawyer,
-AGM,3190,1,Agribusiness Decision Analysis,0.26,0.43,0.23,0.06,0.0,0.0,0.0,0.02,lisha zhang,
-AGM,4050,1,Env Cont in Anim Str,0.08,0.35,0.38,0.15,0.0,0.0,0.0,0.03,john chastain,
-AGM,4060,1,Mech & Hydraulic Sys,0.33,0.5,0.12,0.02,0.0,0.0,0.0,0.02,ali bulent koc,
-AGM,4600,1,Electrical Systems,0.33,0.48,0.17,0.0,0.0,0.0,0.0,0.02,young han,
-AGRB,2020,1,Agricultural Economics,0.66,0.24,0.04,0.0,0.04,0.0,0.0,0.02,yuliya val bolotova,
-AGRB,2020,2,Agricultural Economics,0.15,0.48,0.33,0.04,0.0,0.0,0.0,0.0,matthew jam fischer,
-AGRB,2050,1,Agriculture and Society,0.36,0.44,0.14,0.06,0.0,0.0,0.0,0.0,michael vassalos,
-AGRB,2570,1,"Nat Resources, Environ & Econ",0.23,0.3,0.23,0.11,0.05,0.0,0.0,0.09,david brian willis,
-AGRB,3020,1,Economics of Farm Management,0.13,0.38,0.3,0.14,0.02,0.0,0.0,0.03,michael vassalos,
-AGRB,3090,1,Econ of Agricultural Marketing,0.89,0.04,0.04,0.02,0.0,0.0,0.0,0.0,yuliya val bolotova,
-AGRB,4120,1,Reg Econ Devel Theory & Policy,0.26,0.26,0.37,0.05,0.0,0.0,0.0,0.05,robert carey,
-AGRB,4600,1,Agricultural Finance,0.38,0.46,0.0,0.0,0.08,0.0,0.0,0.08,scott mickey,
-AL,3490,400,Principles of Coaching,0.4,0.48,0.08,0.04,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,401,Principles of Coaching,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,402,Principles of Coaching,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,
-AL,3490,403,Principles of Coaching,0.72,0.12,0.08,0.04,0.0,0.0,0.0,0.04,clyde keith connor,
-AL,3490,405,Principles of Coaching,0.67,0.21,0.04,0.0,0.0,0.0,0.0,0.08,clyde keith connor,
-AL,3490,406,Principles of Coaching,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,edmond fry,
-AL,3500,400,Sci Basis I/Ex Phy,0.32,0.12,0.36,0.08,0.04,0.0,0.0,0.08,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.2,0.28,0.28,0.12,0.12,0.0,0.0,0.0,michael godfrey,
-AL,3520,400,Kinesiology,0.47,0.33,0.13,0.07,0.0,0.0,0.0,0.0,isaac sean colbert,
-AL,3530,400,Athletic Injuries,0.14,0.33,0.29,0.14,0.05,0.0,0.0,0.05,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.19,0.38,0.13,0.19,0.0,0.0,0.0,0.13,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.32,0.52,0.08,0.0,0.0,0.0,0.0,0.08,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.6,0.32,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,401,Admin/Org of Athletic Programs,0.5,0.38,0.04,0.0,0.0,0.0,0.0,0.08,henry oates,
-AL,3610,402,Admin/Org of Athletic Programs,0.75,0.13,0.04,0.04,0.0,0.0,0.0,0.04,henry oates,
-AL,3620,400,Psychology of Coaching,0.31,0.31,0.19,0.08,0.08,0.0,0.0,0.04,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.4,0.24,0.16,0.2,0.0,0.0,0.0,0.0,natalie anne carter,
-AL,3620,402,Psychology of Coaching,0.44,0.22,0.28,0.0,0.06,0.0,0.0,0.0,natalie anne carter,
-AL,3740,400,Coaching Football,0.63,0.17,0.04,0.04,0.04,0.0,0.0,0.08,edmond fry,
-AL,3760,400,Coaching Strength/Conditioning,0.48,0.2,0.12,0.04,0.04,0.0,0.0,0.12,edmond fry,
-AL,3760,401,Coaching Strength/Conditioning,0.58,0.17,0.08,0.04,0.04,0.0,0.0,0.08,edmond fry,
-AL,4380,402,Coaching Women,0.43,0.22,0.3,0.04,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,8490,400,Athletic Leadership Dev,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8500,400,Principles Strength and Condit,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-ANTH,2010,1,Introduction to Anthropology,0.07,0.24,0.3,0.18,0.09,0.0,0.0,0.12,john coggeshall,
-ANTH,2010,2,Introduction to Anthropology,0.07,0.41,0.39,0.02,0.0,0.0,0.0,0.1,john coggeshall,
-ANTH,2010,3,Introduction to Anthropology,0.41,0.37,0.06,0.08,0.04,0.0,0.0,0.04,katherine weisensee,
-ANTH,2010,4,Introduction to Anthropology,0.33,0.36,0.13,0.04,0.07,0.0,0.0,0.07,yi wu,
-ANTH,2010,5,Introduction to Anthropology,0.48,0.28,0.07,0.04,0.07,0.0,0.0,0.07,lisa rapaport,
-ANTH,3010,1,Cultural Anthropology,0.1,0.41,0.31,0.1,0.0,0.0,0.0,0.07,john coggeshall,
-ANTH,3320,1,World Archaeology,0.09,0.32,0.29,0.06,0.03,0.0,0.0,0.21,melissa vogel,
-ANTH,3510,1,Biological Anthropology,0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,katherine weisensee,
-ANTH,3710,1,Language and Culture,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
-ANTH,4230,1,Women in the Developing World,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,melissa vogel,
-ANTH,4990,1,Special Topics,0.53,0.2,0.27,0.0,0.0,0.0,0.0,0.0,yi wu,
-ARCH,1010,1,Intro to Arch,0.46,0.36,0.02,0.0,0.03,0.0,0.0,0.13,sal hambright-belue,
-ARCH,2040,1,Hist of Modern Arch,0.25,0.61,0.08,0.0,0.03,0.0,0.0,0.02,robert bruhns,
-ARCH,2510,1,Arch Foundations I,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,robert silance,
-ARCH,2510,3,Arch Foundations I,0.62,0.31,0.0,0.0,0.08,0.0,0.0,0.0,clarissa mendez,
-ARCH,2510,4,Arch Foundations I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,james barker,
-ARCH,2510,5,Arch Foundations I,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,2700,1,Structures I,0.54,0.33,0.08,0.0,0.0,0.0,0.0,0.04,robert john hogan,
-ARCH,3510,1,Studio Clemson,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ARCH,3510,2,Studio Clemson,0.31,0.38,0.23,0.08,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,3510,3,Studio Clemson,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,3510,10,Studio Clemson,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,criss mills,
-ARCH,4010,1,Architectural Portfolio,0.42,0.42,0.06,0.0,0.06,0.0,0.0,0.06,clarissa mendez,
-ARCH,4010,2,Architectural Portfolio,0.61,0.29,0.04,0.0,0.0,0.0,0.0,0.07,clarissa mendez,
-ARCH,6300,1,Technology and Arch,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,barbara lamprecht,
-ARCH,6850,1,H/Th: Arch+Health,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8100,1,Visualization I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,8210,1,Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8510,1,Design Studio III,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,8510,3,Design Studio III,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8510,4,Design Studio III,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,8570,4,Design Studio V,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,raymond huff,
-ARCH,8600,1,History/Theory I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8720,1,Production & Assemb,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,8790,2,Digtial Manufacturing Process,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,
-ARCH,8810,1,Pro Practice Survey,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,
-ARCH,8860,1,Health Facilities,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ARCH,8890,1,Mentorship,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,
-ARCH,8970,1,A+H Studio: Hospital,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ART,1050,1,Foundation Drawing I,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,kathleen ann thum,
-ART,1510,1,Foundations Art I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,gregory wi shelnutt,
-ART,2070,1,Beginning Painting,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,mary jane king,
-ART,2090,1,Beginning Sculpture,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabet cooke,
-ART,2100,400,Art Appreciation,0.48,0.19,0.22,0.0,0.04,0.0,0.0,0.07,lydia jane dorsey,
-ART,2100,401,Art Appreciation,0.59,0.22,0.0,0.04,0.04,0.0,0.0,0.11,lydia jane dorsey,
-ART,2100,402,Art Appreciation,0.5,0.21,0.18,0.0,0.07,0.0,0.0,0.04,lydia jane dorsey,
-ART,2100,403,Art Appreciation,0.46,0.31,0.04,0.0,0.12,0.0,0.0,0.08,lydia jane dorsey,
-ART,2130,1,Begin Photography,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,haley brooke floyd,
-ART,2170,1,Beginning Ceramics,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,en iwamura,
-ART,8050,1,Visual Arts Sem I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,todd mcdonald,
-AS,1090,2,Air Force Today I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,christopher mann,
-AS,2090,2,Dev of Air Power I,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,christopher mann,
-AS,2090,3,Dev of Air Power I,0.6,0.35,0.0,0.0,0.05,0.0,0.0,0.0,christopher mann,
-ASL,1010,1,Am Sign Lang I,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,1010,2,Am Sign Lang I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,2010,1,Am Sign Lang II,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,2010,2,Am Sign Lang II,0.26,0.42,0.32,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,2020,1,Am Sign Lang II,0.31,0.38,0.31,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,3150,1,Survey Interpreting,0.47,0.2,0.13,0.07,0.0,0.0,0.0,0.13,stephen fitzmaurice,
-ASTR,1010,1,Solar System Astronomy,0.41,0.36,0.1,0.03,0.03,0.0,0.0,0.08,phillip flower,
-ASTR,1010,2,Solar System Astronomy,0.43,0.33,0.14,0.03,0.03,0.0,0.0,0.03,phillip flower,
-ASTR,1010,3,Solar System Astronomy,0.32,0.45,0.1,0.04,0.05,0.0,0.0,0.04,phillip flower,
-ASTR,1030,1,Solar Systm Astr Lab,0.6,0.2,0.04,0.0,0.12,0.0,0.0,0.04,mark leising,
-ASTR,1030,2,Solar Systm Astr Lab,0.5,0.15,0.08,0.04,0.12,0.0,0.0,0.12,mark leising,
-ASTR,1030,3,Solar Systm Astr Lab,0.52,0.2,0.08,0.0,0.12,0.0,0.0,0.08,mark leising,
-ASTR,1030,4,Solar Systm Astr Lab,0.42,0.25,0.13,0.13,0.0,0.0,0.0,0.08,mark leising,
-ASTR,1030,5,Solar Systm Astr Lab,0.5,0.23,0.08,0.04,0.08,0.0,0.0,0.08,mark leising,
-ASTR,1030,6,Solar Systm Astr Lab,0.25,0.5,0.21,0.04,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1030,7,Solar Systm Astr Lab,0.19,0.42,0.15,0.12,0.04,0.0,0.0,0.08,mark leising,
-ASTR,1030,8,Solar Systm Astr Lab,0.38,0.33,0.17,0.08,0.0,0.0,0.0,0.04,mark leising,
-ASTR,1030,9,Solar Systm Astr Lab,0.24,0.48,0.12,0.0,0.04,0.0,0.0,0.12,mark leising,
-ASTR,8100,1,Astroph I: Radiation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,marco ajello,
-AUD,2800,1,Sound Reinforcement,0.0,0.33,0.42,0.17,0.08,0.0,0.0,0.0,kenneth moore,
-AUE,8260,5,Vehicle Diagnostics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8270,5,Auto Cntrl Sys Des,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8280,79,Driveline/Powertrain,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,zoran filipi,
-AUE,8330,30,Auto Manuf Proc Devl,0.35,0.62,0.03,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,8670,1,Veh Manuf Proc I,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,michael mears,
-AUE,8800,2,Vehicle Project Mngt,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8810,3,Automotive Systems Overview,0.22,0.7,0.09,0.0,0.0,0.0,0.0,0.0,paul venhovens,
-AUE,8870,8,Meth Vehicle Testing,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8930,13,Engine Analysis,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8930,14,Automotive Composites,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
-AUE,8930,17,Hybrids,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8930,18,Adv IC Engine Concept,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,8930,78,Applied Dynamics,0.5,0.0,0.33,0.0,0.17,0.0,0.0,0.0,imtiaz ul haque,
-AVS,1000,1,Orientation to AVS,0.83,0.09,0.01,0.01,0.03,0.0,0.0,0.03,johanna joh lascano,
-AVS,1500,1,Intro Animal Science,0.59,0.27,0.05,0.02,0.03,0.0,0.0,0.04,heather walker dunn,
-AVS,1510,1,Intro Ani Sci Lab,0.7,0.26,0.0,0.0,0.0,0.0,0.0,0.04,anna rebecca baxley,
-AVS,1510,2,Intro Ani Sci Lab,0.52,0.4,0.04,0.04,0.0,0.0,0.0,0.0,anna rebecca baxley,
-AVS,1510,3,Intro Ani Sci Lab,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,richelle lor miller,
-AVS,1510,4,Intro Ani Sci Lab,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,1510,5,Intro Ani Sci Lab,0.36,0.56,0.0,0.0,0.0,0.0,0.0,0.08,anna rebecca baxley,
-AVS,1510,6,Intro Ani Sci Lab,0.52,0.36,0.04,0.0,0.0,0.0,0.0,0.08,heather walker dunn,
-AVS,1510,7,Intro Ani Sci Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,richelle lor miller,
-AVS,2010,1,Poultry Techniques,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,2020,1,CAFLS Plus,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,thomas scott,
-AVS,2030,1,Dairy Sci Techniques,0.93,0.02,0.0,0.0,0.02,0.0,0.0,0.02,heather walker dunn,
-AVS,2040,1,Horse Care Techniques,0.57,0.36,0.03,0.0,0.03,0.0,0.0,0.0,kristine lan vernon,
-AVS,2110,1,Meat Processing Techniques,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3010,1,Anat & Phys Dom Ani,0.45,0.2,0.18,0.13,0.04,0.0,0.0,0.0,glenn birrenkott,
-AVS,3010,400,Anat & Phys Dom Ani,0.36,0.36,0.14,0.14,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,3020,1,Livestk Sel Eval I,0.61,0.34,0.02,0.0,0.0,0.0,0.0,0.02,richelle lor miller,
-AVS,3090,1,Equine Evaluation,0.5,0.32,0.11,0.04,0.0,0.0,0.0,0.04,kristine lan vernon,
-AVS,3100,2,Animal Health,0.65,0.19,0.07,0.02,0.02,0.0,0.0,0.06,thomas scott,
-AVS,3700,1,Principles of Animal Nutrition,0.17,0.22,0.25,0.23,0.07,0.0,0.0,0.07,nathan long,
-AVS,3750,1,Applied Animal Nutrition,0.18,0.53,0.28,0.03,0.0,0.0,0.0,0.0,gustavo jos lascano,
-AVS,4000,1,AVS Professional Development,0.66,0.2,0.1,0.0,0.05,0.0,0.0,0.0,johanna joh lascano,
-AVS,4060,1,Seminars & Related Topics,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4060,2,Seminars & Related Topics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4150,1,Contemporary Issues in AVS,0.12,0.42,0.36,0.03,0.03,0.0,0.0,0.05,peter skewes,
-AVS,4160,1,Equine Exercise Phys,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,kristine lan vernon,
-AVS,4530,1,Animal Reproduction,0.27,0.38,0.27,0.04,0.04,0.0,0.0,0.0,tiffany wilmoth,
-AVS,4700,1,Animal Genetics,0.47,0.21,0.22,0.05,0.05,0.0,0.0,0.0,meenakshi mukherjee,
-BCHM,1030,1,Careers in Bioch/Gen,0.88,0.03,0.01,0.04,0.01,0.0,0.0,0.02,alison starr-moss,
-BCHM,3010,1,Molecular Biochem,0.26,0.21,0.21,0.16,0.16,0.0,0.0,0.0,cheryl ingram-smith,
-BCHM,3050,1,Essen Elements Bioch,0.25,0.34,0.22,0.06,0.05,0.0,0.0,0.08,srik chandrasekaran,
-BCHM,3050,2,Essen Elements Bioch,0.26,0.34,0.25,0.12,0.02,0.0,0.0,0.01,srik chandrasekaran,
-BCHM,3050,3,Essen Elements Bioch,0.28,0.37,0.11,0.06,0.07,0.0,0.0,0.11,srik chandrasekaran,
-BCHM,4060,1,Physiological Chem,0.68,0.19,0.03,0.03,0.03,0.0,0.0,0.03,james ro strickland,
-BCHM,4310,1,Physical Approach to Biochem,0.25,0.34,0.32,0.02,0.0,0.0,0.0,0.07,weiguo cao,
-BCHM,4310,2,Phys App to Bioch (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True
-BCHM,4330,1,General Biochemistry Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,
-BCHM,4330,2,General Biochemistry Lab I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,weiguo cao,
-BCHM,4330,3,General Biochemistry Lab I,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,
-BCHM,4330,4,General Biochemistry Lab I,0.6,0.1,0.1,0.0,0.0,0.0,0.0,0.2,weiguo cao,
-BCHM,4400,1,Bioinformatics,0.74,0.08,0.03,0.08,0.0,0.0,0.0,0.08,frank alexan feltus,
-BCHM,4900,7,C-MED,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,michael glen sehorn,
-BCHM,8140,1,Advanced Biochemistry,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,kerry smith,
-BE,2120,1,Fundamentals of Biosys Engr,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,caye marie drapcho,
-BE,3200,1,Principles & Prac of Geomatics,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4100,1,Biological Kinetics,0.44,0.32,0.24,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,4150,1,Instr & Control for Biosys Eng,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,yi zheng,
-BE,4280,1,Biochem Engr,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,terry walker,
-BE,4740,1,B E Design/Proj Mgt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4750,1,B E Capstone Design,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BIOE,1010,1,Biol for Bioengr,0.65,0.24,0.0,0.06,0.0,0.0,0.0,0.06,vladimir vla reukov,
-BIOE,2010,1,Intro Biomed Engr,0.52,0.39,0.08,0.0,0.0,0.0,0.0,0.02,charles webb,
-BIOE,2010,2,Intro Biomed Engr,0.38,0.58,0.01,0.0,0.0,0.0,0.0,0.03,vladimir vla reukov,
-BIOE,3020,1,Biomaterials,0.44,0.34,0.1,0.06,0.02,0.0,0.0,0.04,alexey ale vertegel,
-BIOE,3200,1,Biomechanics,0.65,0.31,0.02,0.02,0.0,0.0,0.0,0.02,lisa benson,
-BIOE,3210,1,Biofluid Mechanics,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,zhi gao,
-BIOE,3700,1,Bioinst & Imaging,0.74,0.21,0.03,0.02,0.0,0.0,0.0,0.0,david kwartowitz,
-BIOE,4010,1,Bioengineering Design Theory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4030,1,Applied Bio E Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
-BIOE,4120,1,Orthopaedic Engr and Pathology,0.56,0.33,0.04,0.0,0.0,0.0,0.0,0.07,melinda harman,
-BIOE,4400,1,Biopharmaceutical Engineering,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,sarah harcum,
-BIOE,6120,1,Orthopaedic Engr & Pathology,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,melinda harman,
-BIOE,8010,1,Bio Materials,0.36,0.54,0.07,0.04,0.0,0.0,0.0,0.0,robert latour,
-BIOE,8160,1,BioE Professional Development,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,martine laberge,
-BIOE,8200,1,Structl Biomechanics,0.78,0.19,0.0,0.0,0.0,0.0,0.0,0.04,hai yao,
-BIOE,8500,4,Cardiovascular Biomechanics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,
-BIOL,1010,1,Frontiers in Biology I,0.71,0.19,0.06,0.02,0.01,0.0,0.0,0.01,robert edwa ballard,
-BIOL,1010,2,Frontiers in Biology I,0.67,0.21,0.05,0.05,0.02,0.0,0.0,0.01,thomas hughes,
-BIOL,1010,3,Frontiers in Biology I,0.67,0.25,0.02,0.01,0.04,0.0,0.0,0.01,joseph paul thames,
-BIOL,1030,1,General Biology I,0.21,0.23,0.24,0.14,0.09,0.0,0.0,0.09,nora espinoza,
-BIOL,1030,3,General Biology I,0.26,0.32,0.26,0.07,0.04,0.0,0.0,0.05,kristi ja whitehead,
-BIOL,1030,4,General Biology I,0.29,0.3,0.21,0.06,0.04,0.0,0.0,0.1,william surver,
-BIOL,1030,5,General Biology I,0.19,0.23,0.35,0.12,0.05,0.0,0.0,0.06,salvatore sparace,
-BIOL,1030,6,General Biology I (HON),0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True
-BIOL,1050,1,General Biology Lab I,0.46,0.33,0.13,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,2,General Biology Lab I,0.17,0.3,0.35,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,3,General Biology Lab I,0.17,0.35,0.17,0.09,0.04,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,4,General Biology Lab I,0.33,0.17,0.21,0.13,0.08,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,5,General Biology Lab I,0.13,0.42,0.33,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,6,General Biology Lab I,0.25,0.42,0.21,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,7,General Biology Lab I,0.25,0.29,0.21,0.21,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,8,General Biology Lab I,0.25,0.21,0.29,0.04,0.08,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,9,General Biology Lab I,0.22,0.48,0.13,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,10,General Biology Lab I,0.29,0.5,0.08,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,11,General Biology Lab I,0.08,0.46,0.29,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,12,General Biology Lab I,0.5,0.25,0.17,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,13,General Biology Lab I,0.24,0.28,0.28,0.12,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,14,General Biology Lab I,0.17,0.42,0.25,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,15,General Biology Lab I,0.29,0.5,0.08,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,16,General Biology Lab I,0.29,0.42,0.17,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,17,General Biology Lab I,0.38,0.42,0.04,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,18,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,19,General Biology Lab I,0.17,0.42,0.38,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,20,General Biology Lab I,0.22,0.57,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,21,General Biology Lab I,0.13,0.38,0.21,0.08,0.08,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,25,General Biology Lab I,0.54,0.42,0.0,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,26,General Biology Lab I,0.38,0.29,0.17,0.0,0.08,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,28,General Biology Lab I,0.63,0.21,0.04,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,29,General Biology Lab I,0.29,0.42,0.25,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,30,General Biology Lab I,0.29,0.5,0.08,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,31,General Biology Lab I,0.17,0.33,0.29,0.04,0.08,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,32,General Biology Lab I,0.26,0.43,0.09,0.04,0.0,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,33,General Biology Lab I,0.29,0.54,0.0,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,34,General Biology Lab I,0.46,0.17,0.21,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,35,General Biology Lab I,0.38,0.42,0.17,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,36,General Biology Lab I,0.08,0.29,0.42,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,37,General Biology Lab I,0.17,0.54,0.17,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,38,General Biology Lab I,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,39,General Biology Lab I,0.25,0.33,0.25,0.04,0.0,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,40,General Biology Lab I,0.17,0.5,0.25,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,41,General Biology Lab I,0.13,0.54,0.17,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,42,General Biology Lab I,0.26,0.48,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,43,General Biology Lab I,0.04,0.26,0.35,0.13,0.17,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,44,General Biology Lab I,0.22,0.26,0.22,0.13,0.09,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,47,General Biology Lab I,0.17,0.38,0.21,0.08,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,48,General Biology Lab I,0.06,0.35,0.29,0.06,0.18,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1090,1,Intro to Life Sci,0.77,0.21,0.02,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
-BIOL,1100,1,Principles of Biology I,0.21,0.33,0.29,0.07,0.03,0.0,0.0,0.07,robert kosinski,
-BIOL,1100,2,Principles of Biology I,0.19,0.46,0.19,0.06,0.02,0.0,0.0,0.08,dylan dittrich-reed,
-BIOL,1100,4,Prin of Biology I (HON),0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True
-BIOL,1200,1,Biological Inq Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,2,Biological Inq Lab,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,3,Biological Inq Lab,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0, christine minor,
-BIOL,1200,4,Biological Inq Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0, christine minor,
-BIOL,1200,6,Biological Inq Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,7,Biological Inq Lab,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,11,Biological Inq Lab,0.7,0.2,0.0,0.05,0.0,0.0,0.0,0.05, christine minor,
-BIOL,1200,12,Biological Inq Lab,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,14,Biological Inq Lab,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0, christine minor,
-BIOL,1230,1,Keys to Human Biol,0.21,0.4,0.26,0.09,0.03,0.0,0.0,0.01, christine minor,
-BIOL,1230,2,Keys to Human Biol,0.23,0.47,0.24,0.03,0.02,0.0,0.0,0.02, christine minor,
-BIOL,2000,3,Biology in the News,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,2000,7,Biology in the News,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
-BIOL,2040,1,"Environ, Energy and Society",0.53,0.19,0.09,0.09,0.03,0.0,0.0,0.08,john jenkins hains,
-BIOL,2220,1,Human Anat and Physiology I,0.19,0.35,0.24,0.09,0.07,0.0,0.0,0.07,john cummings,
-BIOL,2220,2,Human Anat and Physiology I,0.24,0.3,0.21,0.11,0.1,0.0,0.0,0.05,john cummings,
-BIOL,3030,1,Vertebrate Biology,0.27,0.31,0.17,0.15,0.04,0.0,0.0,0.05,richard blob,
-BIOL,3030,2,Vertebrate Biology (HON),0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,richard blob,True
-BIOL,3040,1,Biology of Plants,0.29,0.36,0.19,0.09,0.06,0.0,0.0,0.03,saara dewalt,
-BIOL,3070,1,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,2,Vertebrate Biology Lab,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,3,Vertebrate Biology Lab,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,4,Vertebrate Biology Lab,0.38,0.52,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,5,Vertebrate Biology Lab,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,7,Vertebrate Biology Lab,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,8,Vertebrate Biology Lab,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,9,Vertebrate Biology Lab,0.38,0.38,0.14,0.05,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,10,Vertebrate Biology Lab,0.71,0.24,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,11,Vertebrate Biology Lab,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,12,Vertebrate Biology Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,13,Vertebrate Biology Lab,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3080,1,Biology of Plants Practicum,0.24,0.29,0.35,0.06,0.06,0.0,0.0,0.0,saara dewalt,
-BIOL,3080,2,Biology of Plants Practicum,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,saara dewalt,
-BIOL,3080,3,Biology of Plants Practicum,0.4,0.3,0.25,0.0,0.0,0.0,0.0,0.05,saara dewalt,
-BIOL,3080,4,Biology of Plants Practicum,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,saara dewalt,
-BIOL,3150,1,Functional Human Anatomy,0.25,0.49,0.18,0.04,0.02,0.0,0.0,0.03,tamara mcnutt-scott,
-BIOL,3200,1,Field Botany,0.2,0.18,0.3,0.2,0.02,0.0,0.0,0.1,robert edwa ballard,
-BIOL,3350,1,Evolutionary Biology,0.24,0.26,0.18,0.13,0.09,0.0,0.0,0.11,lisa rapaport,
-BIOL,3510,1,Biological Anthropology,0.46,0.38,0.08,0.08,0.0,0.0,0.0,0.0,katherine weisensee,
-BIOL,4140,1,Basic Immunology,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,yanzhang wei,
-BIOL,4200,1,Neurobiology,0.29,0.28,0.16,0.03,0.01,0.0,0.0,0.22,david feliciano,
-BIOL,4200,2,Neurobiology (HON),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,True
-BIOL,4250,1,Introductory Mycology,0.6,0.1,0.0,0.2,0.1,0.0,0.0,0.0,julia loui kerrigan,
-BIOL,4340,1,Biological Chem Lab Techniques,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,2,Biological Chem Lab Techniques,0.45,0.27,0.0,0.27,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,3,Biological Chem Lab Techniques,0.23,0.31,0.15,0.31,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4410,1,Ecology,0.18,0.38,0.28,0.08,0.01,0.0,0.0,0.07,david tonkyn,
-BIOL,4410,2,Ecology (HON),0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,david tonkyn,True
-BIOL,4430,1,Freshwater Ecology,0.63,0.22,0.1,0.0,0.0,0.0,0.0,0.05,john jenkins hains,
-BIOL,4450,1,Ecology Laboratory (Lec),0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,david tonkyn,
-BIOL,4450,3,Ecology Laboratory (Lec),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
-BIOL,4450,4,Ecology Laboratory (Lec),0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david tonkyn,
-BIOL,4610,1,Cell Biology,0.29,0.3,0.29,0.07,0.02,0.0,0.0,0.03,lesly temesvari,
-BIOL,4610,2,Cell Biology (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True
-BIOL,4610,3,Cell Biology,0.33,0.29,0.28,0.04,0.02,0.0,0.0,0.04,susan carol chapman,
-BIOL,4610,4,Cell Biology (HON),0.24,0.57,0.19,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True
-BIOL,4620,1,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,2,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,3,Cell Biology Lab (Lec),0.53,0.2,0.27,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,4,Cell Biology Lab (Lec),0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.71,0.18,0.06,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
-BIOL,4620,7,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,8,Cell Biology Lab (Lec),0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,9,Cell Biology Lab (Lec),0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,10,Cell Biology Lab (Lec),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
-BIOL,4620,11,Cell Biology Lab (Lec),0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,xianzhong yu,
-BIOL,4670,1,Principles of Hematology,0.91,0.0,0.05,0.0,0.0,0.0,0.0,0.05,vincent gallicchio,
-BIOL,4750,1,Comparative Physiology,0.49,0.32,0.05,0.02,0.0,0.0,0.0,0.12,michael sears,
-BIOL,4930,2,Senior Seminar,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,wen chen,
-BIOL,4930,4,Senior Seminar,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,juan baeza migueles,
-BIOL,6030,1,Intro to Applied Genomics,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vincent pa richards,
-BIOL,8400,1,Understanding Biological Inq,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,dylan dittrich-reed,
-BIOL,8420,1,Understand Cellular Processes,0.73,0.21,0.0,0.0,0.02,0.0,0.0,0.04,david feliciano,
-BIOL,8440,1,Understanding the Human Body,0.47,0.34,0.1,0.01,0.04,0.0,0.0,0.03,william baldwin,
-BUS,1010,1,Business Foundations,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,2,Business Foundations,0.27,0.46,0.24,0.03,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,3,Business Foundations,0.43,0.27,0.14,0.03,0.05,0.0,0.0,0.08,william ern tumblin,
-BUS,1010,4,Business Foundations,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,5,Business Foundations,0.39,0.32,0.16,0.03,0.05,0.0,0.0,0.05,donna mccubbin,
-BUS,1010,6,Business Foundations,0.47,0.34,0.16,0.03,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,7,Business Foundations,0.02,0.45,0.38,0.02,0.07,0.0,0.0,0.05,donna mccubbin,
-BUS,1010,8,Business Foundations,0.3,0.35,0.21,0.02,0.0,0.0,0.0,0.12,donna mccubbin,
-BUS,1010,9,Business Foundations,0.16,0.44,0.21,0.05,0.07,0.0,0.0,0.07,donna mccubbin,
-BUS,1010,10,Business Foundations,0.19,0.49,0.19,0.02,0.09,0.0,0.0,0.02,william ern tumblin,
-BUS,1010,11,Business Foundations,0.21,0.74,0.0,0.05,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,12,Business Foundations,0.42,0.32,0.11,0.05,0.05,0.0,0.0,0.05,sandy edge,
-BUS,1010,13,Business Foundations,0.21,0.68,0.05,0.0,0.0,0.0,0.0,0.05,sandy edge,
-BUS,1010,14,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,15,Business Foundations,0.32,0.42,0.21,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,16,Business Foundations,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,17,Business Foundations,0.16,0.42,0.26,0.0,0.05,0.0,0.0,0.11,william ern tumblin,
-BUS,1010,18,Business Foundations,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,19,Business Foundations,0.11,0.28,0.39,0.11,0.06,0.0,0.0,0.06,william ern tumblin,
-BUS,1010,20,Business Foundations,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,william ern tumblin,
-BUS,1010,27,Business Foundations,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,28,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-CE,2010,2,Statics,0.41,0.19,0.14,0.14,0.1,0.0,0.0,0.02,qiushi chen,
-CE,2010,3,Statics,0.48,0.11,0.27,0.07,0.0,0.0,0.0,0.07,brandon ross,
-CE,2010,4,Statics,0.11,0.32,0.09,0.05,0.11,0.0,0.0,0.32,melissa sternhagen,
-CE,2010,5,Statics,0.36,0.21,0.17,0.05,0.07,0.0,0.0,0.14,melissa sternhagen,
-CE,2010,6,Statics,0.46,0.17,0.19,0.02,0.07,0.0,0.0,0.09,mahmoodreza soltani,
-CE,2010,7,Statics,0.23,0.45,0.13,0.06,0.0,0.0,0.0,0.13,weichiang pang,
-CE,2060,1,Structural Mechanics,0.07,0.39,0.34,0.1,0.02,0.0,0.0,0.07,bryant nielson,
-CE,2080,2,Dynamics,0.04,0.3,0.26,0.11,0.04,0.0,0.0,0.26,melissa sternhagen,
-CE,2080,4,Dynamics,0.04,0.19,0.38,0.15,0.08,0.0,0.0,0.15,melissa sternhagen,
-CE,2550,1,Geomatics,0.32,0.47,0.19,0.0,0.0,0.0,0.0,0.02,wayne sarasua,
-CE,2550,2,Geomatics,0.44,0.31,0.18,0.03,0.05,0.0,0.0,0.0,wayne sarasua,
-CE,3010,1,Structural Analysis,0.21,0.59,0.12,0.06,0.03,0.0,0.0,0.0,stephen csernak,
-CE,3010,2,Structural Analysis,0.28,0.23,0.38,0.08,0.03,0.0,0.0,0.0,bryant nielson,
-CE,3110,1,Transportation Engr,0.71,0.18,0.07,0.02,0.02,0.0,0.0,0.0,jennifer ogle,
-CE,3210,1,Geotechnical Engineering,0.38,0.38,0.18,0.0,0.05,0.0,0.0,0.0,qiushi chen,
-CE,3310,1,Constr Engr & Mgmnt,0.41,0.37,0.12,0.06,0.04,0.0,0.0,0.0,james burati,
-CE,3410,1,Intro to Fluid Mech,0.13,0.6,0.24,0.04,0.0,0.0,0.0,0.0,nigel gregory kaye,
-CE,3410,2,Intro to Fluid Mech,0.14,0.33,0.39,0.07,0.02,0.0,0.0,0.05,abdul khan,
-CE,3420,1,Hydraulics & Hydro,0.29,0.47,0.12,0.08,0.02,0.0,0.0,0.02,ashok mishra,
-CE,3510,1,Civil Engineering Materials,0.68,0.28,0.03,0.03,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,
-CE,3510,2,Civil Engineering Materials,0.54,0.29,0.13,0.02,0.02,0.0,0.0,0.0,ami esmaeilpoursaee,
-CE,3520,1,Econ Eval of Proj,0.36,0.22,0.09,0.13,0.11,0.0,0.0,0.09,yongxi huang,
-CE,3530,1,Professional Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,4010,1,Matrix Str Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
-CE,4020,1,Reinfor Con Design,0.44,0.38,0.16,0.03,0.0,0.0,0.0,0.0,brandon ross,
-CE,4060,1,Struct Steel Design,0.35,0.28,0.28,0.05,0.05,0.0,0.0,0.0,stephen csernak,
-CE,4070,1,Wood Design,0.13,0.4,0.13,0.0,0.07,0.0,0.0,0.27,weichiang pang,
-CE,4100,1,Traffic Engr Oper,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,yongxi huang,
-CE,4210,1,Geotechnical Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
-CE,4240,1,Earth Slopes & Struc,0.29,0.29,0.24,0.05,0.05,0.0,0.0,0.1,nadara ravichandran,
-CE,4370,1,Sustainable Energy Proj Design,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,leidy klotz,
-CE,4390,1,Con Eqpmt Sel & Main,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,james burati,
-CE,4560,1,Pave Design & Constr,0.29,0.48,0.17,0.05,0.02,0.0,0.0,0.0,bradley putman,
-CE,4590,1,Capstone Design Proj,0.69,0.26,0.03,0.0,0.0,0.0,0.0,0.03,stephen csernak,
-CE,4910,1,BIM in Construction Management,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,6010,1,Matrix Str Analysis,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
-CE,6070,1,Wood Design,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CE,6100,1,Traffic Engr Oper,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,yongxi huang,
-CE,6240,1,Earth Slopes & Struc,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,6560,1,Pavement Des & Const,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,bradley putman,
-CE,6910,1,BIM in Construction Management,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,8020,1,Adv R/C Design,0.23,0.58,0.19,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,
-CE,8050,1,Adv Struc Mech,0.38,0.48,0.14,0.0,0.0,0.0,0.0,0.0,bryant nielson,
-CE,8060,1,Dyn Analys of Struc,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
-CE,8140,1,Intel Trans Systems,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,kakan dey,
-CE,8200,1,Geotech Site Charac,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,8260,1,Prop of Concrete,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
-CH,1010,1,General Chemistry,0.19,0.32,0.21,0.12,0.09,0.0,0.0,0.06,thomas hickman,
-CH,1010,2,General Chemistry,0.19,0.27,0.28,0.08,0.1,0.0,0.0,0.08,christopher wilson,
-CH,1010,3,General Chemistry,0.28,0.21,0.25,0.09,0.09,0.0,0.0,0.07,christopher wilson,
-CH,1010,4,General Chemistry,0.16,0.44,0.21,0.1,0.03,0.0,0.0,0.06,dennis taylor,
-CH,1010,5,General Chemistry,0.23,0.32,0.23,0.07,0.06,0.0,0.0,0.09,dennis taylor,
-CH,1010,6,General Chemistry,0.08,0.32,0.2,0.11,0.13,0.0,0.0,0.16,william joh wallace,
-CH,1010,7,General Chemistry,0.16,0.31,0.26,0.13,0.03,0.0,0.0,0.12,dennis taylor,
-CH,1010,8,General Chemistry,0.21,0.32,0.28,0.04,0.1,0.0,0.0,0.05,olt geiculescu,
-CH,1010,9,General Chemistry,0.08,0.26,0.26,0.17,0.14,0.0,0.0,0.1,william joh wallace,
-CH,1010,10,General Chemistry,0.3,0.27,0.25,0.08,0.06,0.0,0.0,0.04,ava kreider-mueller,
-CH,1010,11,General Chemistry,0.22,0.41,0.19,0.11,0.03,0.0,0.0,0.03,tania issa houjeiry,
-CH,1010,12,General Chemistry,0.25,0.35,0.16,0.08,0.08,0.0,0.0,0.07,ava kreider-mueller,
-CH,1010,13,General Chemistry,0.14,0.36,0.29,0.07,0.09,0.0,0.0,0.05,elliot ennis,
-CH,1010,14,General Chemistry,0.09,0.27,0.35,0.11,0.11,0.0,0.0,0.07,william joh wallace,
-CH,1010,16,General Chemistry,0.22,0.37,0.31,0.06,0.03,0.0,0.0,0.01,tania issa houjeiry,
-CH,1010,17,General Chemistry,0.14,0.31,0.31,0.11,0.08,0.0,0.0,0.05,elliot ennis,
-CH,1010,18,General Chemistry,0.23,0.31,0.28,0.08,0.03,0.0,0.0,0.06,ava kreider-mueller,
-CH,1010,50,General Chemistry,0.35,0.38,0.19,0.08,0.0,0.0,0.0,0.0,william pennington,
-CH,1010,51,General Chemistry (HON),0.67,0.22,0.07,0.0,0.0,0.0,0.0,0.04,joseph stu thrasher,True
-CH,1010,52,General Chemistry (HON),0.56,0.31,0.1,0.0,0.0,0.0,0.0,0.03,shiou-jyh hwu,True
-CH,1010,53,General Chemistry,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,edward collins,
-CH,1020,1,General Chemistry,0.27,0.25,0.25,0.11,0.06,0.0,0.0,0.06,stephe schvaneveldt,
-CH,1020,2,General Chemistry,0.3,0.31,0.23,0.08,0.04,0.0,0.0,0.05,stephe schvaneveldt,
-CH,1020,3,General Chemistry,0.27,0.27,0.26,0.1,0.02,0.0,0.0,0.08,stephe schvaneveldt,
-CH,1020,400,General Chemistry,0.05,0.34,0.34,0.07,0.1,0.0,0.0,0.1,stephe schvaneveldt,
-CH,1050,1,Chemistry in Context I,0.39,0.53,0.08,0.0,0.0,0.0,0.0,0.0,olt geiculescu,
-CH,1050,2,Chemistry in Context I,0.48,0.35,0.11,0.03,0.0,0.0,0.0,0.04,olt geiculescu,
-CH,1410,1,Chem Orientation,0.89,0.06,0.0,0.0,0.02,0.0,0.0,0.02, karl dieter,
-CH,2010,1,Survey of Organic Chemistry,0.29,0.35,0.29,0.0,0.02,0.0,0.0,0.05,thomas hickman,
-CH,2010,2,Survey of Organic Chemistry,0.36,0.41,0.21,0.0,0.01,0.0,0.0,0.01,thomas hickman,
-CH,2020,1,Surv of Organic Chemistry Lab,0.56,0.25,0.0,0.13,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2020,2,Surv of Organic Chemistry Lab,0.72,0.17,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
-CH,2020,6,Surv of Organic Chemistry Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2020,8,Surv of Organic Chemistry Lab,0.67,0.06,0.17,0.0,0.0,0.0,0.0,0.11,sean 'connor,
-CH,2230,1,Organic Chemistry,0.21,0.37,0.27,0.04,0.06,0.0,0.0,0.04,modi wetzler,
-CH,2230,2,Organic Chemistry,0.33,0.34,0.14,0.1,0.06,0.0,0.0,0.04,modi wetzler,
-CH,2230,3,Organic Chemistry,0.3,0.4,0.21,0.04,0.06,0.0,0.0,0.0,daniel whitehead,
-CH,2230,4,Organic Chemistry,0.3,0.42,0.17,0.04,0.05,0.0,0.0,0.04,jacob schroeder,
-CH,2230,5,Organic Chemistry,0.25,0.27,0.3,0.07,0.07,0.0,0.0,0.05,elliot ennis,
-CH,2230,6,Organic Chemistry,0.25,0.31,0.13,0.03,0.07,0.0,0.0,0.21,rhett smith,
-CH,2230,7,Organic Chemistry,0.33,0.32,0.16,0.08,0.05,0.0,0.0,0.06,tania issa houjeiry,
-CH,2240,1,Organic Chemistry,0.24,0.38,0.19,0.06,0.03,0.0,0.0,0.09,jacob schroeder,
-CH,2240,2,Organic Chemistry,0.29,0.38,0.15,0.05,0.01,0.0,0.0,0.11,jacob schroeder,
-CH,2270,1,Organic Chem Lab,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,2,Organic Chem Lab,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,7,Organic Chem Lab,0.56,0.25,0.0,0.0,0.06,0.0,0.0,0.13,sean 'connor,
-CH,2270,10,Organic Chem Lab,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,12,Organic Chem Lab,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,13,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,14,Organic Chem Lab,0.56,0.25,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,
-CH,2270,15,Organic Chem Lab,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
-CH,2270,16,Organic Chem Lab,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,17,Organic Chem Lab,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,
-CH,2270,18,Organic Chem Lab,0.69,0.06,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,
-CH,2270,20,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,23,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,25,Organic Chem Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,28,Organic Chem Lab,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,
-CH,2270,31,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,sean 'connor,
-CH,2270,33,Organic Chem Lab,0.56,0.19,0.0,0.0,0.06,0.0,0.0,0.19,sean 'connor,
-CH,2270,35,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,36,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,37,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,sean 'connor,
-CH,2270,38,Organic Chem Lab,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,
-CH,2280,3,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
-CH,2280,6,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,sean 'connor,
-CH,2280,7,Organic Chem Lab,0.59,0.18,0.12,0.0,0.0,0.0,0.0,0.12,sean 'connor,
-CH,2280,8,Organic Chem Lab,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
-CH,3130,1,Quantitative Analys,0.44,0.31,0.09,0.09,0.0,0.0,0.0,0.06,stephen creager,
-CH,3300,1,Intro to Phys Chem,0.37,0.27,0.21,0.07,0.01,0.0,0.0,0.06,brian dominy,
-CH,3310,1,Physical Chemistry,0.58,0.19,0.13,0.06,0.03,0.0,0.0,0.0,leah bec casabianca,
-CH,3310,2,Physical Chemistry,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,arkady kholodenko,
-CH,3320,1,Physical Chemistry,0.26,0.32,0.32,0.05,0.0,0.0,0.0,0.05,arkady kholodenko,
-CH,3390,1,Physical Chem Lab,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,christopher wilson,
-CH,3390,4,Physical Chem Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,
-CH,4010,1,Organometallic Chemistry,0.53,0.35,0.12,0.0,0.0,0.0,0.0,0.0,andrew gre tennyson,
-CH,4020,1,Inorganic Chemistry,0.38,0.57,0.0,0.0,0.0,0.0,0.0,0.05,joseph kolis,
-CH,8070,1,Chem Trans Elem,0.36,0.36,0.09,0.0,0.0,0.0,0.0,0.18,julia brumaghim,
-CH,8140,1,Analytical Imaging,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,george chumanov,
-CH,8160,1,Separation Science,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,richard marcus,
-CH,8210,1,Organic Chem I,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07, karl dieter,
-CH,8300,1,Fund Phys Chem,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,
-CH,8380,1,Computational Chem,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,
-CH,8510,1,Grad Student Seminar,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,joseph stu thrasher,
-CH,8510,2,Grad Student Seminar,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,steven stuart,
-CHE,2110,1,Intro to Chem Eng,0.19,0.27,0.27,0.03,0.16,0.0,0.0,0.07,rachel getman,
-CHE,2110,2,Intro to Chem Eng,0.27,0.37,0.19,0.01,0.1,0.0,0.0,0.04,rachel getman,
-CHE,3070,1,Unit Ops Lab I,0.11,0.74,0.13,0.02,0.0,0.0,0.0,0.0,christopher norfolk,
-CHE,3190,1,Engr Materials,0.16,0.38,0.25,0.12,0.08,0.0,0.0,0.0,amod ogale,
-CHE,4070,1,Unit Op Lab II,0.22,0.64,0.15,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
-CHE,4310,1,Process Design I,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,4450,1,Green Engineering,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,christophe kitchens,
-CHE,4500,1,Chem Reaction Engr,0.25,0.32,0.32,0.1,0.0,0.0,0.0,0.0,mark alan blenner,
-CHE,4990,14,CI-  Membrane Separations,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott husson,
-CHE,8030,1,Advanced Transport,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,douglas hirt,
-CHE,8040,1,Ch E Thermodynamics,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
-CHE,8050,1,Ch E Kinetics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mark roberts,
-CHIN,1010,1,Elementary Chinese,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,yanlin wang,
-CHIN,1010,2,Elementary Chinese,0.57,0.14,0.14,0.0,0.07,0.0,0.0,0.07,yanlin wang,
-CHIN,1020,1,Elementary Chinese,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,su- chen,
-CHIN,4010,1,Pre-Modern Chinese Literature,0.58,0.21,0.16,0.0,0.05,0.0,0.0,0.0,yanming an,
-COM,1500,1,Intro to Human Communication,0.63,0.27,0.05,0.01,0.02,0.0,0.0,0.01,eddie smith,
-COM,1500,2,Intro to Human Communication,0.58,0.34,0.04,0.01,0.02,0.0,0.0,0.01,daniel lelan fecher,
-COM,1500,3,Intro to Human Communication,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,eddie smith,
-COM,1500,4,Intro to Human Communication,0.63,0.27,0.05,0.01,0.04,0.0,0.0,0.01,marianne her glaser,
-COM,1500,5,Intro to Human Communication,0.61,0.35,0.03,0.0,0.01,0.0,0.0,0.0,marianne her glaser,
-COM,1500,6,Intro to Human Communication,0.65,0.29,0.03,0.02,0.01,0.0,0.0,0.0,marianne her glaser,
-COM,1500,7,Intro to Human Communication,0.55,0.35,0.05,0.0,0.01,0.0,0.0,0.04,daniel lelan fecher,
-COM,2010,1,Intr to Comm Studies,0.56,0.36,0.04,0.0,0.04,0.0,0.0,0.0,karyn jones,
-COM,2010,2,Intr to Comm Studies,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,2500,1,Public Speaking,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,2,Public Speaking,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,3,Public Speaking,0.28,0.5,0.11,0.0,0.11,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,4,Public Speaking,0.74,0.05,0.05,0.0,0.16,0.0,0.0,0.0,brandon boatwright,
-COM,2500,5,Public Speaking,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,brandon boatwright,
-COM,2500,6,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,7,Public Speaking,0.21,0.53,0.21,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,8,Public Speaking,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,9,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,10,Public Speaking,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,11,Public Speaking,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
-COM,2500,12,Public Speaking,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,pauline matthey,
-COM,2500,13,Public Speaking,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,pauline matthey,
-COM,2500,14,Public Speaking,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07,pauline matthey,
-COM,2500,15,Public Speaking,0.83,0.06,0.11,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,16,Public Speaking,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,17,Public Speaking,0.71,0.18,0.06,0.0,0.0,0.0,0.0,0.06,the estate  geddes,
-COM,2500,18,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,19,Public Speaking,0.47,0.37,0.0,0.0,0.05,0.0,0.0,0.11,jumah patrici taweh,
-COM,2500,20,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,21,Public Speaking,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
-COM,2500,22,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,23,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
-COM,2500,24,Public Speaking,0.61,0.22,0.0,0.0,0.0,0.0,0.0,0.17,jumah patrici taweh,
-COM,2500,28,Public Speaking,0.35,0.35,0.12,0.0,0.12,0.0,0.0,0.06,sara grumbl crocker,
-COM,2500,29,Public Speaking,0.47,0.32,0.16,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,30,Public Speaking,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,31,Public Speaking,0.42,0.26,0.26,0.05,0.0,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,32,Public Speaking,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,33,Public Speaking,0.68,0.11,0.11,0.0,0.11,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,34,Public Speaking,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,35,Public Speaking,0.54,0.23,0.0,0.0,0.15,0.0,0.0,0.08,vanessa anne condon,
-COM,2500,400,Public Speaking,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,
-COM,2500,403,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,
-COM,3010,1,Comm Theory,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,3020,1,Mass Comm Theory,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3050,1,Persuasion,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
-COM,3050,2,Persuasion,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
-COM,3100,1,Quant Comm Methods,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3110,1,Qual Comm Methods,0.53,0.21,0.21,0.0,0.0,0.0,0.0,0.05,chenjerai kumanyika,
-COM,3240,1,"Communication, Sport & Society",0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,john steven spinda,
-COM,3260,1,Pr in Sports,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3480,1,Interpersonal Comm,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,melinda ra weathers,
-COM,3550,1,Principles of Public Relations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3550,2,Principles of Public Relations,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,andrew stephen pyle,
-COM,3660,1,Special Topics in Comm,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,william reynolds,
-COM,3660,6,Special Topics in Comm,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,angela pratt,
-COM,4040,1,Media Comm & Social Identities,0.3,0.47,0.13,0.03,0.0,0.0,0.0,0.07,chenjerai kumanyika,
-COM,4250,1,Adv Sports Comm,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,4300,1,Legal Communication,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
-COM,4700,1,Comm & Health,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,4800,1,Intercultural Comm,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,melinda ra weathers,
-COM,4950,1,Senior Capstone Seminar,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,4950,2,Senior Capstone Seminar,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,john steven spinda,
-COM,8100,1,Comm Research Methods I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
-CPSC,1010,1,Computer Science I,0.48,0.22,0.11,0.11,0.07,0.0,0.0,0.02,yvon feaster,
-CPSC,1010,2,Computer Science I,0.35,0.33,0.07,0.14,0.07,0.0,0.0,0.05,yvon feaster,
-CPSC,1010,3,Computer Science I,0.27,0.23,0.16,0.09,0.11,0.0,0.0,0.14,christopher plaue,
-CPSC,1010,4,Computer Science I,0.15,0.2,0.24,0.07,0.12,0.0,0.0,0.22,pradip srimani,
-CPSC,1020,1,Computer Science II,0.3,0.32,0.07,0.03,0.15,0.0,0.0,0.13,catherine hochrine,
-CPSC,1040,1,Intro Computer Prog,0.15,0.19,0.46,0.12,0.0,0.04,0.0,0.04,roy pargas,
-CPSC,1110,1,Intro to Programming in C,0.59,0.1,0.07,0.05,0.12,0.0,0.0,0.07,catherine hochrine,
-CPSC,1110,2,Intro to Programming in C,0.6,0.15,0.08,0.04,0.04,0.0,0.0,0.08,catherine hochrine,
-CPSC,1110,3,Intro to Programming in C,0.65,0.23,0.08,0.0,0.04,0.0,0.0,0.0,wanda moses,
-CPSC,1110,4,Intro to Programming in C,0.7,0.13,0.05,0.0,0.05,0.0,0.0,0.08,wanda moses,
-CPSC,2070,1,Discrete Structures,0.2,0.37,0.16,0.12,0.09,0.0,0.0,0.05,larry hodges,
-CPSC,2100,1,Progrmng Methodology,0.32,0.21,0.08,0.03,0.29,0.0,0.0,0.08,timothy davis,
-CPSC,2100,2,Progrmng Methodology,0.47,0.28,0.09,0.13,0.03,0.0,0.0,0.0,rose lowe,
-CPSC,2120,1,Algs/Data Structures,0.31,0.24,0.23,0.02,0.12,0.0,0.0,0.08,brian christop dean,
-CPSC,2150,1,Software Dev Fndtns,0.24,0.27,0.22,0.12,0.12,0.0,0.0,0.04,blair madiso durkee,
-CPSC,2150,2,Software Dev Fndtns,0.5,0.23,0.17,0.0,0.1,0.0,0.0,0.0,yvon feaster,
-CPSC,2200,1,Microcomputer Appl,0.41,0.24,0.12,0.06,0.12,0.0,0.0,0.06,renee lambert,
-CPSC,2200,2,Microcomputer Appl,0.4,0.3,0.15,0.0,0.05,0.0,0.0,0.1,renee lambert,
-CPSC,2310,1,Intro Computer Org,0.49,0.31,0.13,0.08,0.0,0.0,0.0,0.0,rose lowe,
-CPSC,2310,2,Intro Computer Org,0.36,0.21,0.21,0.07,0.07,0.0,0.0,0.07,rose lowe,
-CPSC,2910,2,Prof Issues I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
-CPSC,2910,5,Prof Issues I,0.25,0.33,0.08,0.08,0.0,0.0,0.0,0.25,renee lambert,
-CPSC,2910,6,Prof Issues I,0.6,0.1,0.0,0.1,0.0,0.0,0.0,0.2,renee lambert,
-CPSC,2910,7,Prof Issues I,0.53,0.07,0.07,0.13,0.07,0.0,0.0,0.13,renee lambert,
-CPSC,3220,1,Intro to Operating Systems,0.13,0.31,0.23,0.08,0.12,0.0,0.0,0.13,jacob sorber,
-CPSC,3300,1,Computer Systems Org,0.14,0.22,0.38,0.12,0.12,0.0,0.0,0.01,mark smotherman,
-CPSC,3500,1,Foundations of Computer Sci,0.25,0.13,0.38,0.0,0.15,0.0,0.0,0.1,ilya mark safro,
-CPSC,3520,1,Programming Systems,0.36,0.26,0.17,0.0,0.14,0.0,0.0,0.07,robert schalkoff,
-CPSC,3600,1,Network Programming,0.16,0.3,0.39,0.09,0.05,0.0,0.0,0.02,sekou lionel remy,
-CPSC,3600,2,Network Programming,0.4,0.43,0.1,0.0,0.08,0.0,0.0,0.0,kevin mckenzie,
-CPSC,3620,1,Distributed/Cluster Computing,0.28,0.5,0.15,0.03,0.0,0.0,0.0,0.05,linh bao ngo,
-CPSC,3720,1,Software Engineering,0.34,0.41,0.22,0.0,0.03,0.0,0.0,0.0,murali sitaraman,
-CPSC,3720,2,Software Engineering,0.28,0.33,0.28,0.03,0.03,0.0,0.0,0.06,stephen schaub,
-CPSC,3990,4,Adv Creative Inquiry Computing,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,james martin,
-CPSC,3990,10,Adv CI:Google Glass,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,roy pargas,
-CPSC,4040,1,Cmptr Graphics Image,0.47,0.32,0.16,0.05,0.0,0.0,0.0,0.0,joshua levine,
-CPSC,4110,1,Virtual Reality Systems,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,sabarish venka babu,
-CPSC,4200,1,Computer Security Principles,0.59,0.28,0.14,0.0,0.0,0.0,0.0,0.0,hongxin hu,
-CPSC,4620,1,Database Management Systems,0.12,0.27,0.18,0.15,0.12,0.0,0.0,0.15,pradip srimani,
-CPSC,4780,1,Gen Purpose Computation on GPU,0.27,0.36,0.18,0.09,0.09,0.0,0.0,0.0,robert geist,
-CPSC,4810,16,Sel Top:Programming Team,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,brian christop dean,
-CPSC,4820,1,Spec Top:Embedded Systems,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,jacob sorber,
-CPSC,4820,3,Spec Top:Mobile Device Sftware,0.61,0.17,0.11,0.0,0.06,0.0,0.0,0.06,roy pargas,
-CPSC,4910,1,Professional Issues II,0.96,0.0,0.01,0.0,0.01,0.0,0.0,0.01,james jones,
-CPSC,6040,1,Cptr Graphics Image,0.5,0.11,0.04,0.0,0.18,0.0,0.0,0.18,joshua levine,
-CPSC,6110,1,Virtual Reality Systems,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
-CPSC,6620,1,Database Management Systems,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,pradip srimani,
-CPSC,6780,1,Gen Purpose Computation on GPU,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,
-CPSC,8040,1,Data Visualization,0.5,0.3,0.1,0.0,0.05,0.0,0.0,0.05,joshua levine,
-CPSC,8070,1,3d Model Animation,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,christina sop joerg,
-CPSC,8100,1,Intro Artif Intell,0.18,0.71,0.11,0.0,0.0,0.0,0.0,0.0,feng luo,
-CPSC,8150,1,Fx Compositing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,
-CPSC,8170,1,Physically Based Animation,0.62,0.27,0.08,0.0,0.0,0.0,0.0,0.04,donald henry house,
-CPSC,8390,1,Theoretical Cp Sci Foundations,0.31,0.61,0.06,0.0,0.0,0.0,0.0,0.02,wayne goddard,
-CPSC,8480,1,Network Science,0.44,0.11,0.44,0.0,0.0,0.0,0.0,0.0,ilya mark safro,
-CPSC,8520,1,Internetworking,0.4,0.33,0.27,0.0,0.0,0.0,0.0,0.0,james martin,
-CPSC,8700,1,O O Software Design,0.46,0.33,0.14,0.0,0.03,0.0,0.0,0.03,brian malloy,
-CPSC,8710,1,Found. of Software Engineering,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-CPSC,8730,1,"Software Verif, Valid & Measur",0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-CPSC,8810,3,Selected Topics: Visual Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
-CRP,8000,1,Human Settlement,0.56,0.34,0.05,0.0,0.0,0.0,0.0,0.05,john terrenc farris,
-CRP,8010,1,Planning Process & Legal Found,0.38,0.38,0.1,0.1,0.0,0.0,0.0,0.05,caitlin dyckman,
-CRP,8020,1,Site Planning,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
-CRP,8030,1,Quant Analysis,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
-CRP,8060,1,Urban & Reg Econ for Planners,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,timothy green,
-CRP,8340,1,Spatial Modeling/Gis,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,stephen sperry,
-CRP,8580,2,Research Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,timothy green,
-CSM,1000,1,Intro to Construct,0.41,0.47,0.11,0.02,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2010,1,Structures I,0.3,0.33,0.26,0.11,0.0,0.0,0.0,0.0,shima clarke,
-CSM,2010,2,Structures I,0.5,0.19,0.19,0.12,0.0,0.0,0.0,0.0,shima clarke,
-CSM,2030,1,Mats & Meth of Const,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,2030,2,Mats & Meth of Const,0.22,0.63,0.15,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,3030,1,Soils & Foundations,0.08,0.63,0.29,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,3030,2,Soils & Foundations,0.12,0.69,0.19,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,3040,1,Envir Systems I,0.42,0.42,0.12,0.0,0.04,0.0,0.0,0.0,joseph mich burgett,
-CSM,3040,2,Envir Systems I,0.13,0.67,0.21,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3510,1,Const Estimating,0.19,0.69,0.08,0.04,0.0,0.0,0.0,0.0,james packer smith,
-CSM,3510,2,Const Estimating,0.11,0.48,0.26,0.15,0.0,0.0,0.0,0.0,james packer smith,
-CSM,4110,1,Safety in Bldg Const,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,david devita,
-CSM,4500,1,Construction Intern,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CSM,4530,1,Const Proj Mgmt,0.19,0.67,0.14,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,4530,2,Const Proj Mgmt,0.11,0.72,0.17,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,4610,1,Const Econ Seminar,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4610,2,Const Econ Seminar,0.05,0.76,0.19,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8640,1,Construction Bus Strat & Mktg,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,christine piper,
-CSM,8650,1,Project Management,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8650,400,Project Management,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8660,1,Role in Development,0.31,0.63,0.0,0.0,0.0,0.0,0.0,0.06,dennis bausman,
-CSM,8900,401,Directed Studies,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,8900,402,Directed Studies,0.57,0.14,0.14,0.0,0.14,0.0,0.0,0.0,jason lucas,
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,susan whorton,
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.88,0.12,0.01,susan whorton,
-CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.02,susan whorton,
-CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.73,0.26,0.01,susan whorton,
-CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
-CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
-CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
-CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.05,0.01,susan whorton,
-CU,1000,9,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.01,susan whorton,
-CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.08,0.01,susan whorton,
-CU,1000,11,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,susan whorton,
-CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,susan whorton,
-CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.88,0.11,0.02,susan whorton,
-CU,1010,1,Univ Success Skills,0.5,0.19,0.06,0.0,0.13,0.0,0.0,0.13,emma reynol reabold,
-CU,1010,2,Univ Success Skills,0.45,0.14,0.32,0.05,0.05,0.0,0.0,0.0,cari allyn brooks,
-CU,1010,3,Univ Success Skills,0.32,0.32,0.16,0.04,0.08,0.0,0.0,0.08,matthew james kirk,
-CU,1010,5,Univ Success Skills,0.55,0.18,0.0,0.09,0.18,0.0,0.0,0.0,ashley crisp,
-CU,1010,6,Univ Success Skills,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,amber allen mulkey,
-CU,1010,7,Univ Success Skills,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,amber allen mulkey,
-CU,1110,3,Intro Supplemental Instruction,0.0,0.0,0.0,0.0,0.0,0.88,0.06,0.06,laurel ann whisler,
-CU,1400,1,The Entrepreneurial Mindset,0.76,0.17,0.05,0.01,0.0,0.0,0.0,0.02,john michael hannon,
-CU,2010,1,Sustainability Leadership,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,leidy klotz,
-CVT,2260,1,Intro Cardiovas Sono,0.2,0.6,0.13,0.0,0.0,0.0,0.0,0.07,eric walker,
-DANC,3300,1,University Dance Company,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,cheryl hosler,
-DPA,4000,1,Tech Foundations I,0.65,0.06,0.06,0.0,0.0,0.0,0.0,0.24,brian malloy,
-DPA,8600,1,Production Studio,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
-ECE,2010,1,Logic and Computing Devices,0.2,0.35,0.24,0.05,0.13,0.0,0.0,0.03,william reid,
-ECE,2010,2,Logic & Comp Device (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william reid,True
-ECE,2020,1,Electric Circuits I,0.29,0.27,0.24,0.04,0.1,0.0,0.0,0.06,william harrell,
-ECE,2020,2,Electric Circuits I (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
-ECE,2020,3,Electric Circuits I,0.21,0.17,0.3,0.12,0.16,0.0,0.0,0.03,daniel bla cutshall,
-ECE,2070,1,Basic Electrical Engineering,0.14,0.31,0.33,0.12,0.03,0.0,0.0,0.07,william th kolodzey,
-ECE,2070,2,Basic Electrical Engineering,0.45,0.25,0.13,0.05,0.05,0.0,0.0,0.08,oleg viktorov sivov,
-ECE,2070,3,Basic Electrical Engineering,0.33,0.35,0.16,0.1,0.04,0.0,0.0,0.02,amir ahmed asif,
-ECE,2080,7,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
-ECE,2080,9,Electrical Engineering Lab I,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,
-ECE,2080,10,Electrical Engineering Lab I,0.65,0.05,0.0,0.0,0.1,0.0,0.0,0.2,apoorva dee kapadia,
-ECE,2080,13,Electrical Engineering Lab I,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,apoorva dee kapadia,
-ECE,2090,1,Logic Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,9,Logic Lab,0.82,0.0,0.0,0.0,0.18,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,10,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva dee kapadia,
-ECE,2090,11,Logic Lab,0.83,0.0,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,13,Logic Lab,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,apoorva dee kapadia,
-ECE,2110,6,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
-ECE,2110,8,Elec Engr Lab I,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2110,9,Elec Engr Lab I,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,apoorva dee kapadia,
-ECE,2220,1,Syst Prog Concept,0.12,0.27,0.22,0.1,0.1,0.0,0.0,0.2,harlan russell,
-ECE,2230,1,Comp Sys Eng,0.18,0.25,0.2,0.11,0.14,0.0,0.0,0.11,harlan russell,
-ECE,2620,1,Electric Circuits II,0.59,0.15,0.1,0.03,0.03,0.0,0.0,0.1,liang dong,
-ECE,2720,1,Comp Organization,0.19,0.29,0.33,0.05,0.1,0.0,0.0,0.05,william reid,
-ECE,2730,2,Computer Org Lab,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2730,3,Computer Org Lab,0.57,0.14,0.21,0.0,0.07,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,2,Electrical Engineering Lab III,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
-ECE,3110,4,Electrical Engineering Lab III,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,6,Electrical Engineering Lab III,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,apoorva dee kapadia,
-ECE,3110,7,Electrical Engineering Lab III,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
-ECE,3120,2,Electrical Engineering Lab IV,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3170,1,Rand Signal Analysis,0.23,0.23,0.25,0.14,0.11,0.0,0.0,0.05,stephen hubbard,
-ECE,3200,1,Electronics I,0.25,0.18,0.18,0.18,0.22,0.0,0.0,0.0,stephen hubbard,
-ECE,3210,1,Electronics II,0.37,0.32,0.2,0.1,0.02,0.0,0.0,0.0,stephen hubbard,
-ECE,3220,1,Intro Operating Sys,0.25,0.35,0.15,0.15,0.1,0.0,0.0,0.0,jacob sorber,
-ECE,3270,1,Dig Comp Design,0.15,0.15,0.2,0.15,0.13,0.0,0.0,0.23,melissa crawl smith,
-ECE,3300,1,Signals & Systems,0.14,0.23,0.26,0.17,0.06,0.0,0.0,0.15,carl baum,
-ECE,3300,2,Signals & Systems (HON),0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
-ECE,3520,1,Programming Systems,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.31,0.3,0.28,0.02,0.02,0.0,0.0,0.08,edward collins,
-ECE,3710,1,Microcontr Interface,0.38,0.34,0.21,0.06,0.0,0.0,0.0,0.01,william reid,
-ECE,3720,1,Micro Int Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,3,Micro Int Lab,0.75,0.17,0.0,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,6,Micro Int Lab,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3800,1,Electromagnetics,0.3,0.2,0.18,0.13,0.15,0.0,0.0,0.05,anthony martin,
-ECE,3810,1,Field Waves & Ckts,0.45,0.21,0.24,0.07,0.02,0.0,0.0,0.0,anthony martin,
-ECE,4040,1,Semiconductor Devices,0.25,0.44,0.25,0.0,0.06,0.0,0.0,0.0,william harrell,
-ECE,4090,1,Cont & Discrete Sys,0.4,0.37,0.15,0.03,0.03,0.0,0.0,0.01,apoorva dee kapadia,
-ECE,4120,1,Elect Mach Lab,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,elham makram,
-ECE,4180,1,Power Syst Analysis,0.31,0.12,0.27,0.15,0.08,0.0,0.0,0.08,elham makram,
-ECE,4270,1,Communications Sys,0.31,0.22,0.22,0.17,0.08,0.0,0.0,0.0,madhabi manandhar,
-ECE,4290,1,Organiz of Compu,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,hai ying shen,
-ECE,4350,1,Grounding/Shielding,0.43,0.29,0.07,0.14,0.0,0.0,0.0,0.07,todd hubing,
-ECE,4420,1,Knowledge Engr,0.37,0.32,0.11,0.05,0.05,0.0,0.0,0.11,robert schalkoff,
-ECE,4490,1,Comp Ntwrk Security,0.35,0.3,0.05,0.0,0.0,0.0,0.0,0.3,richard brooks,
-ECE,4610,1,Fundamentals of Solar Energy,0.63,0.25,0.07,0.05,0.0,0.0,0.0,0.0,rajendra singh,
-ECE,4730,1,Intro Parallel Sys,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,walter ligon,
-ECE,4950,1,Int Sys Design I,0.74,0.23,0.04,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4960,1,Int Sys Design II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,richard groff,
-ECE,6040,1,Semiconductor Devices,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,6350,1,Grounding/Shielding,0.6,0.2,0.1,0.0,0.1,0.0,0.0,0.0,todd hubing,
-ECE,6420,1,Knowledge Engr,0.26,0.63,0.05,0.0,0.05,0.0,0.0,0.0,robert schalkoff,
-ECE,6490,1,Comp Ntwrk Security,0.88,0.0,0.12,0.0,0.0,0.0,0.0,0.0,richard brooks,
-ECE,6610,1,Fundamentals of Solar Energy,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,rajendra singh,
-ECE,6930,1,Intro to Computer Vision,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,
-ECE,6930,3,Power Electronics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,keith corzine,
-ECE,8010,1,Analysis of Lin Sys,0.32,0.5,0.11,0.02,0.02,0.0,0.0,0.02,richard groff,
-ECE,8190,1,Detection & Estimation Theory,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,carl baum,
-ECE,8470,400,Digital Image Proc,0.87,0.11,0.03,0.0,0.0,0.0,0.0,0.0,stanley birchfield,
-ECE,8540,1,Analysis of Tracking Systems,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,adam hoover,
-ECE,8750,1,Peer to Peer Wireless & Cloud,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,hai ying shen,
-ECE,9910,32,Doctoral Dissertation Research,0.0,0.0,0.0,0.0,0.0,0.86,0.14,0.0,hai ying shen,
-ECON,2000,1,Economic Concepts,0.31,0.38,0.27,0.04,0.0,0.0,0.0,0.0,mallika garg,
-ECON,2000,2,Economic Concepts,0.32,0.29,0.24,0.03,0.0,0.0,0.0,0.12,mallika garg,
-ECON,2000,3,Economic Concepts,0.31,0.34,0.1,0.17,0.0,0.0,0.0,0.07,miren ivankovic,
-ECON,2110,1,Principles of Microeconomics,0.16,0.32,0.37,0.0,0.11,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,2,Principles of Microeconomics,0.16,0.21,0.47,0.05,0.05,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,3,Principles of Microeconomics,0.05,0.37,0.42,0.05,0.11,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,4,Principles of Microeconomics,0.1,0.5,0.2,0.05,0.15,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,5,Principles of Microeconomics,0.16,0.37,0.26,0.0,0.16,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,6,Principles of Microeconomics,0.18,0.47,0.24,0.06,0.0,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,7,Principles of Microeconomics,0.05,0.42,0.21,0.21,0.0,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,8,Principles of Microeconomics,0.11,0.47,0.26,0.11,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,9,Principles of Microeconomics,0.16,0.26,0.47,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,10,Principles of Microeconomics,0.0,0.37,0.42,0.0,0.11,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,11,Principles of Microeconomics,0.33,0.39,0.22,0.06,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,12,Principles of Microeconomics,0.05,0.53,0.21,0.11,0.0,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,13,Principles of Microeconomics,0.06,0.28,0.56,0.0,0.06,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,14,Principles of Microeconomics,0.37,0.32,0.21,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,15,Principles of Microeconomics,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,16,Principles of Microeconomics,0.22,0.28,0.28,0.06,0.0,0.0,0.0,0.17,frederick hanssen,
-ECON,2110,17,Principles of Microeconomics,0.21,0.53,0.16,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,18,Principles of Microeconomics,0.17,0.39,0.22,0.11,0.11,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,19,Principles of Microeconomics,0.11,0.53,0.32,0.05,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,20,Principles of Microeconomics,0.24,0.27,0.25,0.13,0.08,0.0,0.0,0.03,timothy jay bacon,
-ECON,2110,21,Principles of Microeconomics,0.21,0.48,0.29,0.02,0.0,0.0,0.0,0.0,michael makowsky,
-ECON,2110,22,Principles of Microeconomics,0.23,0.43,0.23,0.07,0.0,0.0,0.0,0.05,richard alan sessa,
-ECON,2110,23,Principles of Microeconomics,0.18,0.45,0.3,0.04,0.0,0.0,0.0,0.03,alexander fiore,
-ECON,2110,24,Principles of Microeconomics,0.32,0.33,0.21,0.07,0.02,0.0,0.0,0.03,leah jacq kitashima,
-ECON,2110,25,Principles of Microeconomics,0.28,0.33,0.23,0.08,0.03,0.0,0.0,0.08,charles thomas,
-ECON,2110,26,Principles of Microeconomics,0.29,0.39,0.18,0.05,0.08,0.0,0.0,0.0,jonathan orr ernest,
-ECON,2110,31,Principles of Microeconomics,0.2,0.59,0.21,0.01,0.0,0.0,0.0,0.0,alexander fiore,
-ECON,2110,32,Principles of Microeconomics,0.38,0.24,0.14,0.1,0.0,0.0,0.0,0.14,maria droganova,
-ECON,2110,33,Principles of Microeconomics,0.21,0.29,0.32,0.13,0.03,0.0,0.0,0.03,charles thomas,
-ECON,2110,34,Principles of Microeconomics,0.26,0.28,0.28,0.1,0.03,0.0,0.0,0.05,benjamin jo schwall,
-ECON,2110,35,Principles of Microeconomics,0.34,0.34,0.23,0.03,0.03,0.0,0.0,0.03,maria droganova,
-ECON,2110,38,Principles of Microeconomics,0.36,0.48,0.1,0.0,0.05,0.0,0.0,0.02,amanda caitlin kerr,
-ECON,2110,40,Principles of Micro (HON),0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert kennet fleck,True
-ECON,2110,41,Principles of Microeconomics,0.15,0.45,0.2,0.15,0.05,0.0,0.0,0.0,ce castellon chicas,
-ECON,2120,1,Principles of Macroeconomics,0.17,0.16,0.22,0.12,0.2,0.0,0.0,0.13,ralph charles allen,
-ECON,2120,2,Principles of Macroeconomics,0.33,0.27,0.31,0.07,0.02,0.0,0.0,0.0,peter david lorenz,
-ECON,2120,3,Principles of Macroeconomics,0.27,0.13,0.24,0.16,0.07,0.0,0.0,0.13,ralph charles allen,
-ECON,2120,4,Principles of Macroeconomics,0.26,0.3,0.24,0.09,0.04,0.0,0.0,0.07,andew swanson,
-ECON,2120,5,Principles of Macroeconomics,0.29,0.29,0.23,0.17,0.0,0.0,0.0,0.03,andew swanson,
-ECON,2120,6,Principles of Macroeconomics,0.38,0.19,0.28,0.0,0.13,0.0,0.0,0.03,peter david lorenz,
-ECON,2120,7,Principles of Macroeconomics,0.18,0.46,0.21,0.1,0.0,0.0,0.0,0.05,chen wang,
-ECON,2120,8,Principles of Macroeconomics,0.25,0.33,0.23,0.07,0.07,0.0,0.0,0.05,kelsey vict roberts,
-ECON,2120,9,Principles of Macroeconomics,0.26,0.31,0.18,0.15,0.03,0.0,0.0,0.08,shan jiang,
-ECON,2120,10,Principles of Macroeconomics,0.41,0.15,0.19,0.15,0.04,0.0,0.0,0.07,shan jiang,
-ECON,3020,1,Money and Banking,0.16,0.2,0.32,0.16,0.04,0.0,0.0,0.12,randall scot cragun,
-ECON,3060,1,Managerial Economics,0.33,0.28,0.13,0.08,0.1,0.0,0.0,0.08,jacob burgdorf,
-ECON,3100,1,International Econ,0.22,0.33,0.22,0.2,0.02,0.0,0.0,0.02,michal jerzmanowski,
-ECON,3140,1,Intermediate Micro,0.12,0.31,0.26,0.1,0.05,0.0,0.0,0.17,robert kennet fleck,
-ECON,3140,2,Intermediate Micro,0.28,0.26,0.21,0.06,0.06,0.0,0.0,0.13,molly espey,
-ECON,3140,3,Intermediate Micro,0.17,0.26,0.23,0.04,0.13,0.0,0.0,0.17,frederick hanssen,
-ECON,3150,1,Intermediate Macro,0.19,0.25,0.27,0.1,0.06,0.0,0.0,0.13,randall scot cragun,
-ECON,3150,2,Intermediate Macro,0.29,0.29,0.25,0.02,0.08,0.0,0.0,0.06,michal jerzmanowski,
-ECON,3190,1,Environmental Econ,0.16,0.46,0.35,0.0,0.0,0.0,0.0,0.03,molly espey,
-ECON,3600,1,Public Choice,0.38,0.38,0.2,0.0,0.0,0.0,0.0,0.05,robert dew tollison,
-ECON,3600,2,Public Choice,0.19,0.44,0.19,0.0,0.06,0.0,0.0,0.13,robert dew tollison,
-ECON,4010,1,Labor Mkt Analysis,0.31,0.31,0.23,0.0,0.08,0.0,0.0,0.08,chungsang lam,
-ECON,4020,1,Law and Economics,0.41,0.36,0.14,0.02,0.07,0.0,0.0,0.0,howard ne bodenhorn,
-ECON,4040,1,Comp Econ Systems,0.12,0.29,0.24,0.18,0.0,0.0,0.0,0.18,dar litsukova-bokar,
-ECON,4050,1,Intro to Econometric,0.18,0.38,0.24,0.06,0.12,0.0,0.0,0.03,jaqueline oliveira,
-ECON,4050,5,Intro to Econometric,0.23,0.27,0.35,0.08,0.04,0.0,0.0,0.04,scott barkowski,
-ECON,4100,1,Economic Development,0.11,0.63,0.0,0.0,0.11,0.0,0.0,0.16,robert tamura,
-ECON,4120,1,International Micro,0.37,0.32,0.27,0.02,0.0,0.0,0.0,0.02,scott baier,
-ECON,4220,1,Monetary Economics,0.29,0.48,0.19,0.0,0.0,0.0,0.0,0.05,gerald dwyer,
-ECON,4230,1,Economics of Health,0.43,0.17,0.26,0.09,0.0,0.0,0.0,0.04,daniel patri miller,
-ECON,4240,1,Organization of Ind,0.3,0.2,0.4,0.0,0.05,0.0,0.0,0.05,daniel patri miller,
-ECON,4350,1,Family Economics,0.55,0.25,0.15,0.03,0.0,0.0,0.0,0.03,jaqueline oliveira,
-ECON,6050,1,Intro to Econometric,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jaqueline oliveira,
-ECON,6060,1,Advanced Econometric,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,
-ECON,6120,1,Internatiional Micro,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,8010,1,Microeconomic Theory,0.43,0.21,0.21,0.0,0.07,0.0,0.0,0.07,william dougan,
-ECON,8040,1,Applied Math Econ,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,curtis simon,
-ECON,8060,1,Econometrics I,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,
-ECON,8080,1,Econometrics III,0.38,0.25,0.19,0.0,0.06,0.0,0.0,0.13,paul wayne wilson,
-ECON,8160,1,Labor Economics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
-ECON,8210,1,Public Choice,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,patrick warren,
-ECON,8230,1,Microecon Pub Pol,0.4,0.45,0.15,0.0,0.0,0.0,0.0,0.0,scott templeton,
-ECON,8240,1,Org of Industry,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,matthew lewis,
-ECON,8260,1,Econ Theory of Govt Regulation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,thomas wins hazlett,
-ECON,8400,1,International Trade,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,scott baier,
-ECON,9500,2,Monetary Economics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
-ED,1050,2,Educ Orientation,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,william da mccorkle,
-ED,1050,5,Educ Orientation,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,william da mccorkle,
-ED,1050,6,Educ Orientation,0.68,0.16,0.05,0.05,0.0,0.0,0.0,0.05,william da mccorkle,
-ED,1050,7,Educ Orientation,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,william da mccorkle,
-ED,3970,5,Creative Inquiry in Education,0.8,0.08,0.0,0.0,0.0,0.0,0.0,0.12,david matthew boyer,
-ED,3970,12,Creative Inquiry in Education,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,joseph benedic ryan,
-ED,8380,404,Adolescent Development,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,heather rog brooker,
-ED,8380,505,Literacy Lessons for Indiv I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
-ED,8380,510,Literacy Lessons for Indiv I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jamie felder white,
-ED,8380,511,Literacy Lessons for Indiv I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ellen adkin sanford,
-ED,8380,512,Literacy Lessons for Indiv I,0.4,0.2,0.0,0.0,0.0,0.0,0.0,0.4,kimberly fair floyd,
-ED,8380,530,Improving Literacy Outcomes fo,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,renee gatlin anders,
-ED,8670,500,Practicum in ESOL Instruction,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,margaret mar warner,
-EDC,3900,1,Skills for Stu Leads,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,mary price,
-EDC,3900,2,Skills for Stu Leads,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,leasa ann  evinger,
-EDC,8110,1,Multicultural Couns,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,robin phelps-ward,
-EDC,8110,2,Multicultural Couns,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,
-EDC,8130,1,Appraisal Procedures,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,amy sue milsom,
-EDEC,3000,1,Found Early Chld Ed,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,
-EDEC,4300,1,Early Childhd Math,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,sandra mamma linder,
-EDEC,4400,1,Early Childhood Engl Lang Art,0.78,0.13,0.09,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEC,4600,1,Critical Iss/Diversity in ECE,0.91,0.04,0.0,0.04,0.0,0.0,0.0,0.0,dolores an stegelin,
-EDEC,8100,1,Adv Ece Found & Meth,0.56,0.11,0.22,0.11,0.0,0.0,0.0,0.0,dolores an stegelin,
-EDEL,3210,1,Pe for the Elem Tchr,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,3210,2,Pe for the Elem Tchr,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4010,1,Elem Field Exp,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,ann marie liebel,
-EDEL,4010,2,Elem Field Exp,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ann marie liebel,
-EDEL,4510,1,Elem Methods in Science Tchg,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,cynthia chri deaton,
-EDEL,4510,2,Elem Methods in Science Tchg,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
-EDEL,4870,1,Ele Meth Soc Studies,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,melinda spearman,
-EDEL,4870,2,Ele Meth Soc Studies,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDEL,4880,1,Elem Meth La Tchng,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,jacquelynn malloy,
-EDEL,4880,2,Elem Meth La Tchng,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
-EDF,3010,1,Principles of American Educat,0.58,0.35,0.06,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,
-EDF,3010,2,Principles of American Educat,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
-EDF,3020,3,Educational Psychology,0.34,0.28,0.21,0.14,0.0,0.0,0.0,0.03,penelope mar vargas,
-EDF,3020,4,Educational Psychology,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,penelope mar vargas,
-EDF,3080,1,Classroom Assessment,0.7,0.22,0.09,0.0,0.0,0.0,0.0,0.0,deborah switzer,
-EDF,3080,2,Classroom Assessment,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,deborah switzer,
-EDF,3200,1,History of US Education,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
-EDF,3340,1,Child Growth and Development,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,andrea emerson,
-EDF,3340,2,Child Growth and Development,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
-EDF,3350,1,Adolescent Growth & Develop,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
-EDF,4800,1,Digital Media & Learning,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,2,Digital Media & Learning,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,3,Digital Media & Learning,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,6900,400,Classroom Management,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,heather rog brooker,
-EDF,8010,1,Human Growth and Development,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeromy blake snider,
-EDF,8710,501,Cultural Diversity in Educatio,0.6,0.3,0.05,0.0,0.05,0.0,0.0,0.0,sus cridland-hughes,
-EDF,9010,1,Learning Sciences Seminar I,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,david matthew boyer,
-EDF,9270,1,Quant Rsrch & Stats for Ed,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,jennie lynn farmer,
-EDF,9270,2,Quant Rsrch & Stats for Ed,0.67,0.17,0.0,0.08,0.0,0.0,0.0,0.08,jennie lynn farmer,
-EDL,7000,502,Public School Adm,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,frederick buskey,
-EDL,7300,500,Techniq of Supervision-Pub Sch,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,
-EDL,7400,500,Curr Plan: Sch Adm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,
-EDL,9110,400,Systematic Inq Ed L,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,
-EDL,9250,501,Instructional Leadership,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,elizabeth reynolds,
-EDLT,4590,1,Teaching Reading Grades K-3,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,linda gambrell,
-EDLT,4600,3,Teaching Reading Grades 2-6,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
-EDLT,4600,5,Teaching Reading Grades 2-6,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
-EDLT,4610,1,Content Area Rdg: Grades 2-6,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,pamela dunston,
-EDLT,4610,2,Content Area Rdg: Grades 2-6,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,4980,4,Secondary Content Area Reading,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.04,barbara everson,
-EDLT,8120,500,Reading-Writing Assess Strat,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8140,500,Instr & Asmnt Diverse Students,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDLT,8270,400,Disciplinary Literacies 6-12,0.74,0.11,0.05,0.05,0.05,0.0,0.0,0.0,corrie leigh martin,
-EDLT,8800,502,Reading Recovery Teacher I,0.54,0.23,0.15,0.0,0.0,0.0,0.0,0.08,mary petters,
-EDLT,8820,502,Read Recovery Practicum I,0.38,0.38,0.15,0.0,0.0,0.0,0.0,0.08,mary petters,
-EDLT,9140,1,"Lang Dev, Diversity, Discourse",0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,mikel walker cole,
-EDSC,2260,1,Pr Apprch to Sec Alg,0.57,0.21,0.14,0.0,0.0,0.0,0.0,0.07,stacy megan che,
-EDSC,3240,1,Practicum Sec Engl,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,amy tali hallenbeck,
-EDSC,4240,1,Tchng Sec English,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,
-EDSC,4260,1,Tchng Sec Math,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,dennis aminie kombe,
-EDSC,8620,400,Methods & Strat Secondary Math,0.67,0.0,0.17,0.17,0.0,0.0,0.0,0.0,nicole alai sinwell,
-EDSP,3700,2,Intro to Special Education,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,
-EDSP,3700,3,Intro to Special Education,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,
-EDSP,3700,4,Intro to Special Education,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,bridget carv briley,
-EDSP,3720,1,Char & Instr Individ with LD,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,
-EDSP,4920,1,Math Inst Ind W/Dis,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,
-EDSP,4940,1,Tchg Rdg Mild Dis,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
-EDSP,8530,1,Legal/Pol Issu Sp Ed,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
-EDSP,8530,2,Legal/Pol Issu Sp Ed,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
-EES,2010,1,Environ Engr Fundamentals I,0.31,0.5,0.13,0.0,0.03,0.0,0.0,0.03,david freedman,
-EES,3030,1,Water Treatment Systems,0.5,0.38,0.12,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3040,1,Wastewater Treatment Systems,0.38,0.44,0.15,0.03,0.0,0.0,0.0,0.0,david freedman,
-EES,3050,1,Water/Wastewater Treatment Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3050,2,Water/Wastewater Treatment Lab,0.64,0.29,0.0,0.07,0.0,0.0,0.0,0.0,david allen ladner,
-EES,4010,1,Environmental Engr,0.46,0.46,0.0,0.0,0.05,0.0,0.0,0.03,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.04,0.63,0.3,0.0,0.0,0.0,0.0,0.04,mark schlautman,
-EES,4300,1,Air Pollution Engineering,0.15,0.37,0.39,0.02,0.07,0.0,0.0,0.0,thomas overcamp,
-EES,4500,1,Professional Seminar,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,thomas overcamp,
-EES,4800,1,Environmental Risk Assessment,0.22,0.24,0.27,0.19,0.05,0.0,0.0,0.03,timothy devol,
-EES,4860,1,Environmental Sustainability,0.53,0.33,0.1,0.0,0.04,0.0,0.0,0.0,michael anthon dale,
-EES,4900,11,CI-EvalWaterQual & Kidney Corr,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,david allen ladner,
-EES,6100,1,Environ Radiation Protection I,0.33,0.58,0.0,0.08,0.0,0.0,0.0,0.0,nicole eli martinez,
-EES,6800,1,Environmental Risk Assessment,0.36,0.29,0.21,0.07,0.0,0.0,0.0,0.07,timothy devol,
-EES,6860,1,Environmental Sustainability,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
-EES,8020,1,Environ Eng Prin,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,david allen ladner,
-EES,8430,1,Environmental Chem,0.47,0.41,0.03,0.0,0.0,0.0,0.0,0.09,brian powell,
-EES,8510,1,Biol Prin Envir Engr,0.42,0.32,0.11,0.0,0.0,0.0,0.0,0.16,kevin thom finneran,
-EES,9610,1,Ee&S Phd Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,brian powell,
-ELE,3010,1,Intro to Entre,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-ELE,3010,2,Intro to Entre,0.51,0.34,0.0,0.0,0.0,0.03,0.0,0.11,chad navis,
-ELE,3010,3,Intro to Entre,0.31,0.56,0.14,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
-ELE,4010,1,Exec Lead & Entr II,0.28,0.5,0.15,0.05,0.03,0.0,0.0,0.0,ashley will parnell,
-ENGL,1030,2,Accelerated Composition,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,trevor lanc seigler,
-ENGL,1030,3,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,madison ali johnson,
-ENGL,1030,4,Accelerated Composition,0.26,0.32,0.11,0.11,0.21,0.0,0.0,0.0,todd rossi smith,
-ENGL,1030,5,Accelerated Composition,0.74,0.11,0.0,0.0,0.05,0.0,0.0,0.11,emily anne boyter,
-ENGL,1030,6,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,
-ENGL,1030,7,Accelerated Composition,0.42,0.37,0.05,0.05,0.05,0.0,0.0,0.05,melissa dugan,
-ENGL,1030,8,Accelerated Composition,0.61,0.28,0.0,0.06,0.0,0.0,0.0,0.06,madison ali johnson,
-ENGL,1030,9,Accelerated Composition,0.37,0.42,0.11,0.05,0.0,0.0,0.0,0.05,kristen joy hixon,
-ENGL,1030,10,Accelerated Composition,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,1030,11,Accelerated Composition,0.58,0.26,0.11,0.05,0.0,0.0,0.0,0.0,rebecca nico shaver,
-ENGL,1030,13,Accelerated Composition,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,crystal pa stephens,
-ENGL,1030,14,Accelerated Composition,0.21,0.53,0.05,0.11,0.11,0.0,0.0,0.0,todd rossi smith,
-ENGL,1030,15,Accelerated Composition,0.53,0.26,0.05,0.05,0.0,0.0,0.0,0.11,candace wiley,
-ENGL,1030,16,Accelerated Composition,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kristen joy hixon,
-ENGL,1030,17,Accelerated Composition,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,mary dickens,
-ENGL,1030,18,Accelerated Composition,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,melissa dugan,
-ENGL,1030,19,Accelerated Composition,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,katie jo vann,
-ENGL,1030,21,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,candace wiley,
-ENGL,1030,22,Accelerated Composition,0.35,0.59,0.0,0.0,0.0,0.0,0.0,0.06,mary dickens,
-ENGL,1030,23,Accelerated Composition,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,rebecca nico shaver,
-ENGL,1030,26,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,chloe mich whitaker,
-ENGL,1030,27,Accelerated Composition,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,katie jo vann,
-ENGL,1030,28,Accelerated Composition,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,caroline ca swanson,
-ENGL,1030,29,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,karen mary stewart,
-ENGL,1030,30,Accelerated Composition,0.84,0.0,0.05,0.0,0.11,0.0,0.0,0.0,teneshia head,
-ENGL,1030,31,Accelerated Composition,0.53,0.42,0.0,0.0,0.05,0.0,0.0,0.0,nathan riggs,
-ENGL,1030,32,Accelerated Composition,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,chloe mich whitaker,
-ENGL,1030,33,Accelerated Composition,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,daniel frank,
-ENGL,1030,34,Accelerated Composition,0.79,0.05,0.0,0.0,0.11,0.0,0.0,0.05,eda ozyesilpinar,
-ENGL,1030,35,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
-ENGL,1030,36,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,nathan riggs,
-ENGL,1030,37,Accelerated Composition,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel frank,
-ENGL,1030,38,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,stephen quigley,
-ENGL,1030,39,Accelerated Composition,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,charlotte powell,
-ENGL,1030,40,Accelerated Composition,0.37,0.32,0.21,0.0,0.11,0.0,0.0,0.0,caroline ca swanson,
-ENGL,1030,41,Accelerated Composition,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,eda ozyesilpinar,
-ENGL,1030,42,Accelerated Composition,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,austin gorman,
-ENGL,1030,43,Accelerated Composition,0.47,0.32,0.05,0.05,0.11,0.0,0.0,0.0,adrian carson,
-ENGL,1030,44,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jack butts,
-ENGL,1030,45,Accelerated Composition,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,jason crider,
-ENGL,1030,46,Accelerated Composition,0.58,0.26,0.0,0.0,0.05,0.0,0.0,0.11,joshua wood,
-ENGL,1030,47,Accelerated Composition,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,kellie eliz osborne,
-ENGL,1030,48,Accelerated Composition,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,jason crider,
-ENGL,1030,49,Accelerated Composition,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,eric stephens,
-ENGL,1030,50,Accelerated Composition,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,jennifer moeder,
-ENGL,1030,51,Accelerated Composition,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,april obrien,
-ENGL,1030,52,Accelerated Composition,0.47,0.42,0.0,0.0,0.11,0.0,0.0,0.0,adrian carson,
-ENGL,1030,53,Accelerated Composition,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,april obrien,
-ENGL,1030,54,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,danielle shuff,
-ENGL,1030,55,Accelerated Composition,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,brian lee gaines,
-ENGL,1030,56,Accelerated Composition,0.26,0.47,0.11,0.0,0.05,0.0,0.0,0.11,charlotte powell,
-ENGL,1030,57,Accelerated Composition,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
-ENGL,1030,58,Accelerated Composition,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,brian lee gaines,
-ENGL,1030,59,Accelerated Composition,0.53,0.32,0.05,0.05,0.05,0.0,0.0,0.0,stephen quigley,
-ENGL,1030,60,Accelerated Composition,0.63,0.21,0.05,0.0,0.0,0.0,0.0,0.11,danielle shuff,
-ENGL,1030,64,Accelerated Composition,0.58,0.37,0.0,0.05,0.0,0.0,0.0,0.0,jack butts,
-ENGL,1030,65,Accelerated Composition,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joshua wood,
-ENGL,1030,66,Accelerated Composition,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,eric stephens,
-ENGL,1030,67,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,kellie eliz osborne,
-ENGL,1030,68,Accelerated Composition,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jennifer moeder,
-ENGL,1030,500,Accelerated Composition,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,1030,501,Accelerated Composition,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,2120,1,World Literature,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,john morgenstern,
-ENGL,2120,3,World Literature,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,garry bertholf,
-ENGL,2120,5,World Literature,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,christopher benson,
-ENGL,2120,6,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,2120,7,World Literature,0.32,0.25,0.29,0.07,0.04,0.0,0.0,0.04,andrew mathas,
-ENGL,2120,8,World Literature,0.37,0.3,0.15,0.07,0.04,0.0,0.0,0.07,andrew mathas,
-ENGL,2120,9,World Literature,0.52,0.37,0.07,0.0,0.0,0.0,0.0,0.04,jeffrey fallis,
-ENGL,2120,10,World Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey fallis,
-ENGL,2120,11,World Literature,0.61,0.29,0.04,0.0,0.04,0.0,0.0,0.04,lucian ghita,
-ENGL,2120,12,World Literature,0.56,0.28,0.04,0.0,0.04,0.0,0.0,0.08,lucian ghita,
-ENGL,2120,13,World Literature,0.12,0.48,0.16,0.04,0.16,0.0,0.0,0.04,meg woosley-goodman,
-ENGL,2120,14,World Literature,0.29,0.43,0.11,0.07,0.07,0.0,0.0,0.04,meg woosley-goodman,
-ENGL,2120,15,World Literature,0.19,0.62,0.12,0.0,0.08,0.0,0.0,0.0,meg woosley-goodman,
-ENGL,2120,16,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
-ENGL,2120,17,World Literature,0.58,0.15,0.12,0.04,0.08,0.0,0.0,0.04,geveryl le robinson,
-ENGL,2120,18,World Literature,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
-ENGL,2120,19,World Literature,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,geveryl le robinson,
-ENGL,2130,1,British Literature,0.46,0.42,0.12,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,2130,2,British Literature,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,2130,3,British Literature,0.71,0.18,0.04,0.0,0.04,0.0,0.0,0.04,stephanie stripling,
-ENGL,2130,5,British Literature,0.64,0.21,0.04,0.0,0.04,0.0,0.0,0.07,lucian ghita,
-ENGL,2130,7,British Literature,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,
-ENGL,2130,9,British Literature,0.85,0.08,0.0,0.0,0.04,0.0,0.0,0.04,krist aldebol-hazle,
-ENGL,2130,10,British Literature,0.61,0.14,0.0,0.11,0.14,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,2130,11,British Literature,0.6,0.2,0.0,0.04,0.04,0.0,0.0,0.12,krist aldebol-hazle,
-ENGL,2130,12,British Literature,0.56,0.3,0.04,0.0,0.07,0.0,0.0,0.04,sherri teres allred,
-ENGL,2130,13,British Literature,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
-ENGL,2140,1,American Literature,0.68,0.18,0.08,0.02,0.01,0.0,0.0,0.02, barton palmer,
-ENGL,2140,5,American Literature,0.32,0.32,0.29,0.04,0.0,0.0,0.0,0.04,william stanton,
-ENGL,2140,6,American Literature,0.14,0.68,0.11,0.0,0.07,0.0,0.0,0.0,william stanton,
-ENGL,2140,7,American Literature,0.52,0.3,0.15,0.0,0.04,0.0,0.0,0.0,john morgenstern,
-ENGL,2140,8,American Literature,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,2140,9,American Literature,0.57,0.29,0.11,0.0,0.0,0.0,0.0,0.04,sharon kathl nalley,
-ENGL,2140,10,American Literature,0.48,0.33,0.0,0.0,0.05,0.0,0.0,0.14,candace wiley,
-ENGL,2140,11,American Literature,0.44,0.37,0.04,0.0,0.04,0.0,0.0,0.11,candace wiley,
-ENGL,2140,12,American Literature,0.59,0.3,0.07,0.04,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,2140,13,American Literature,0.68,0.21,0.04,0.04,0.0,0.0,0.0,0.04,crystal pa stephens,
-ENGL,2140,14,American Literature,0.3,0.41,0.11,0.0,0.07,0.0,0.0,0.11,sharon kathl nalley,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.36,0.39,0.21,0.0,0.04,0.0,0.0,0.0,andrew mathas,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.36,0.43,0.07,0.04,0.04,0.0,0.0,0.07,andrew mathas,
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.54,0.21,0.21,0.04,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.43,0.25,0.18,0.04,0.0,0.0,0.0,0.11,john logan pursley,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.64,0.18,0.11,0.04,0.0,0.0,0.0,0.04,john logan pursley,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.38,0.38,0.19,0.0,0.0,0.0,0.0,0.04,agnieszka skrodzka,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.68,0.18,0.07,0.0,0.0,0.0,0.0,0.07,april susanne pelt,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,alexander kudera,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.64,0.32,0.0,0.0,0.04,0.0,0.0,0.0,alexander kudera,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.15,0.5,0.15,0.0,0.04,0.0,0.0,0.15,david charles foltz,
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.13,0.38,0.17,0.04,0.08,0.0,0.0,0.21,david charles foltz,
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.14,0.43,0.18,0.07,0.04,0.0,0.0,0.14,david charles foltz,
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.11,0.37,0.15,0.04,0.15,0.0,0.0,0.19,david charles foltz,
-ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.64,0.25,0.04,0.07,0.0,0.0,0.0,0.0,stephanie stripling,
-ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
-ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey fallis,
-ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,austin gorman,
-ENGL,2150,100,20th - 21st Century Lit (HON),0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,True
-ENGL,2150,101,20th-21st Century Lit (HON),0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
-ENGL,3010,1,Grt Books West World,0.15,0.77,0.0,0.08,0.0,0.0,0.0,0.0,colin pearce,
-ENGL,3040,3,Business Writing,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,
-ENGL,3040,4,Business Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3040,11,Business Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexander kudera,
-ENGL,3040,12,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,3040,15,Business Writing,0.16,0.26,0.37,0.11,0.05,0.0,0.0,0.05,megan no macalystre,
-ENGL,3040,16,Business Writing,0.44,0.44,0.06,0.0,0.06,0.0,0.0,0.0,megan no macalystre,
-ENGL,3040,19,Business Writing,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,3040,20,Business Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,
-ENGL,3100,1,Crit Writ Lit,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
-ENGL,3100,2,Crit Writ Lit,0.68,0.16,0.05,0.0,0.05,0.0,0.0,0.05,walter edgar hunter,
-ENGL,3100,3,Crit Writ Lit,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
-ENGL,3100,4,Crit Writ Lit,0.31,0.56,0.0,0.0,0.06,0.0,0.0,0.06,agnieszka skrodzka,
-ENGL,3120,1,Advanced Composition,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3120,2,Advanced Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,1,Technical Writing,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,william pulley,
-ENGL,3140,2,Technical Writing,0.39,0.33,0.28,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,3,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
-ENGL,3140,4,Technical Writing,0.63,0.11,0.16,0.0,0.0,0.0,0.0,0.11,melissa dugan,
-ENGL,3140,5,Technical Writing,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,melissa dugan,
-ENGL,3140,6,Technical Writing,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,7,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,8,Technical Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
-ENGL,3140,10,Technical Writing,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,11,Technical Writing,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,12,Technical Writing,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,katalin beck,
-ENGL,3140,14,Technical Writing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,brian adam smith,
-ENGL,3140,19,Technical Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
-ENGL,3140,20,Technical Writing,0.32,0.21,0.11,0.05,0.11,0.0,0.0,0.21,matthew jose osborn,
-ENGL,3140,21,Technical Writing,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,heathe christiansen,
-ENGL,3140,22,Technical Writing,0.74,0.05,0.05,0.0,0.11,0.0,0.0,0.05,kristen gay,
-ENGL,3140,23,Technical Writing,0.72,0.11,0.06,0.0,0.0,0.0,0.0,0.11,kristen gay,
-ENGL,3140,100,Technical Writing (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,True
-ENGL,3140,400,Technical Writing,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,john conway,
-ENGL,3140,401,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,3150,1,Scientific Writing & Comm,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,barbara ramirez,
-ENGL,3150,2,Scientific Writing & Comm,0.11,0.68,0.05,0.0,0.0,0.0,0.0,0.16,barbara ramirez,
-ENGL,3150,3,Scientific Writing & Comm,0.58,0.16,0.11,0.05,0.05,0.0,0.0,0.05,william pulley,
-ENGL,3150,4,Scientific Writing & Comm,0.58,0.21,0.11,0.0,0.0,0.0,0.0,0.11,william pulley,
-ENGL,3150,401,Sci Writing & Communication,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,
-ENGL,3150,402,Sci Writing & Communication,0.21,0.53,0.11,0.0,0.0,0.0,0.0,0.16,carleton dew salley,
-ENGL,3320,1,Visual Communication,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,tharon howard,
-ENGL,3450,1,Structure of Fiction,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,3460,2,Structure of Poetry,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,3470,1,Structure of Drama,0.54,0.31,0.08,0.08,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,3560,1,Science Fiction,0.33,0.33,0.2,0.0,0.0,0.0,0.0,0.13,lindsay carr thomas,
-ENGL,3570,1,Film,0.21,0.53,0.16,0.0,0.0,0.0,0.0,0.11,amy monaghan,
-ENGL,3570,2,Film,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3570,3,Film,0.12,0.76,0.12,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3800,1,Women Writers,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,meg woosley-goodman,
-ENGL,3850,1,Children's Lit,0.33,0.2,0.33,0.0,0.13,0.0,0.0,0.0,megan no macalystre,
-ENGL,3960,1,Brit Lit Survey I,0.2,0.3,0.3,0.05,0.0,0.0,0.0,0.15,erin marina goss,
-ENGL,3960,2,Brit Lit Survey I,0.2,0.25,0.35,0.0,0.15,0.0,0.0,0.05,erin marina goss,
-ENGL,3960,3,Brit Lit Survey I,0.19,0.06,0.38,0.0,0.06,0.0,0.0,0.31,erin marina goss,
-ENGL,3970,1,Brit Lit Survey II,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
-ENGL,3980,2,Amer Lit Survey I,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,jonathan beec field,
-ENGL,3990,1,Amer Lit Survey II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,4010,1,Grammar Survey,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,william stockton,
-ENGL,4070,1,Medieval Period,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,andrew lemons,
-ENGL,4110,1,Shakespeare,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,
-ENGL,4110,2,Shakespeare,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4140,1,Milton,0.2,0.4,0.2,0.0,0.1,0.0,0.0,0.1,lee morrissey,
-ENGL,4160,1,Romantic Period,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,erin marina goss,
-ENGL,4170,1,Victorian Period,0.0,0.58,0.25,0.08,0.0,0.0,0.0,0.08,kimberly manganelli,
-ENGL,4210,1,Amer Lit 1800-1899,0.38,0.38,0.08,0.08,0.0,0.0,0.0,0.08,dominic mastroianni,
-ENGL,4280,1,Contemporary Literature,0.33,0.2,0.33,0.0,0.0,0.0,0.0,0.13,michael lemahieu,
-ENGL,4340,1,Environmental Lit,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,sean morey,
-ENGL,4350,1,Literary Criticism,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,dominic mastroianni,
-ENGL,4430,1,Theories of World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,4510,1,Film Theo/Criticism,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0, barton palmer,
-ENGL,4600,1,Writing Technologies,0.53,0.27,0.07,0.0,0.0,0.0,0.0,0.13,lindsay carr thomas,
-ENGL,4750,1,Writing for Media,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,megan eatman,
-ENGL,4780,1,Digital Literacy,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
-ENGL,4820,1,Afr Am Lit to 1920,0.3,0.2,0.3,0.0,0.2,0.0,0.0,0.0,rhondda robi thomas,
-ENGL,4960,1,Senior Seminar,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.0,wayne chapman,
-ENGL,4960,2,Senior Seminar,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,
-ENGL,4960,3,Senior Seminar,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,
-ENGL,4990,2,Practicum in Writing,0.0,0.0,0.0,0.0,0.0,0.82,0.0,0.18,elizabeth rivlin,
-ENGL,8050,1,Topics in Medieval Literature,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,andrew lemons,
-ENGL,8140,1,Topics Vict & Mod British Lit,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,wayne chapman,
-ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,steven brandon,
-ENGR,1050,111,Engr Discipline & Skills I,0.49,0.37,0.07,0.02,0.0,0.0,0.0,0.05,christopher norfolk,
-ENGR,1050,112,Engr Discipline & Skills I,0.4,0.38,0.12,0.02,0.0,0.0,0.0,0.07,mariah magagnotti,
-ENGR,1050,113,Engr Discipline & Skills I,0.33,0.33,0.19,0.07,0.05,0.0,0.0,0.05,mariah magagnotti,
-ENGR,1050,114,Engr Discipline & Skills I,0.45,0.36,0.1,0.0,0.02,0.0,0.0,0.07,matthew kent miller,
-ENGR,1050,115,Engr Discipline & Skills I,0.43,0.4,0.12,0.02,0.0,0.0,0.0,0.02,matthew kent miller,
-ENGR,1050,117,Engr Discipline & Skills I,0.57,0.29,0.02,0.07,0.0,0.0,0.0,0.05,matthew kent miller,
-ENGR,1050,118,Engr Discipline & Skills I,0.29,0.5,0.07,0.07,0.05,0.0,0.0,0.02,matthew kent miller,
-ENGR,1050,211,Engr Discipline & Skills I,0.53,0.27,0.07,0.0,0.04,0.0,0.0,0.09,ashley childers,
-ENGR,1050,212,Engr Discipline & Skills I,0.47,0.4,0.05,0.02,0.0,0.0,0.0,0.05,ashley childers,
-ENGR,1050,213,Engr Discipline & Skills I,0.38,0.36,0.14,0.05,0.0,0.0,0.0,0.07,andrew isaa neptune,
-ENGR,1050,214,Engr Discipline & Skills I,0.22,0.39,0.32,0.05,0.02,0.0,0.0,0.0,andrew isaa neptune,
-ENGR,1050,215,Engr Discipline & Skills I,0.17,0.25,0.27,0.15,0.02,0.0,0.0,0.13,mariah magagnotti,
-ENGR,1050,216,Engr Discipline & Skills I,0.14,0.26,0.29,0.12,0.1,0.0,0.0,0.1,mariah magagnotti,
-ENGR,1050,217,Engr Discipline & Skills I,0.37,0.39,0.2,0.0,0.02,0.0,0.0,0.02,andrew isaa neptune,
-ENGR,1050,218,Engr Discipline & Skills I,0.33,0.45,0.13,0.0,0.03,0.0,0.0,0.08,andrew isaa neptune,
-ENGR,1050,311,Engr Discipline & Skills I,0.1,0.41,0.21,0.1,0.03,0.0,0.0,0.14,elizabeth stephan,
-ENGR,1050,312,Engr Discipline & Skills I,0.36,0.36,0.12,0.05,0.0,0.0,0.0,0.12,elizabeth stephan,
-ENGR,1050,313,Engr Discipline & Skills I,0.26,0.25,0.2,0.11,0.02,0.0,0.0,0.16,michael giebner,
-ENGR,1050,314,Engr Discipline & Skills I,0.31,0.37,0.19,0.05,0.0,0.0,0.0,0.08,michael giebner,
-ENGR,1050,315,Engr Discipline & Skills I,0.4,0.22,0.22,0.1,0.02,0.0,0.0,0.03,william park,
-ENGR,1050,316,Engr Discipline & Skills I,0.34,0.31,0.17,0.07,0.02,0.0,0.0,0.1,william park,
-ENGR,1050,317,Engr Discipline & Skills I,0.37,0.25,0.22,0.05,0.03,0.0,0.0,0.07,william park,
-ENGR,1050,318,Engr Discipline & Skills I,0.22,0.31,0.21,0.05,0.07,0.0,0.0,0.14,michael giebner,
-ENGR,1050,349,Engr Discipline & Skills I,0.14,0.11,0.26,0.17,0.2,0.0,0.0,0.11,michael giebner,
-ENGR,1050,400,Engr Discipline & Skills I,0.08,0.28,0.3,0.1,0.2,0.0,0.0,0.05,sarah grigg,
-ENGR,1050,611,Engr Discip & Skills I (HON),0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,steven brandon,True
-ENGR,1050,613,Engr Discip & Skills I (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True
-ENGR,1050,614,Engr Discipl & Skills I (HON),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,steven brandon,True
-ENGR,1050,615,Engr Discipl & Skills I (HON),0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,richard watkins,True
-ENGR,1060,111,Engr Discipline & Skills II,0.11,0.39,0.24,0.11,0.03,0.0,0.0,0.13,christopher norfolk,
-ENGR,1060,112,Engr Discipline & Skills II,0.15,0.41,0.36,0.0,0.03,0.0,0.0,0.05,mariah magagnotti,
-ENGR,1060,113,Engr Discipline & Skills II,0.03,0.26,0.53,0.06,0.03,0.0,0.0,0.09,mariah magagnotti,
-ENGR,1060,114,Engr Discipline & Skills II,0.27,0.43,0.22,0.05,0.03,0.0,0.0,0.0,matthew kent miller,
-ENGR,1060,115,Engr Discipline & Skills II,0.23,0.25,0.43,0.0,0.0,0.0,0.0,0.1,matthew kent miller,
-ENGR,1060,117,Engr Discipline & Skills II,0.22,0.5,0.22,0.0,0.03,0.0,0.0,0.03,matthew kent miller,
-ENGR,1060,118,Engr Discipline & Skills II,0.06,0.34,0.31,0.17,0.03,0.0,0.0,0.09,matthew kent miller,
-ENGR,1060,211,Engr Discipline & Skills II,0.24,0.43,0.26,0.04,0.0,0.0,0.0,0.02,ashley childers,
-ENGR,1060,212,Engr Discipline & Skills II,0.29,0.44,0.21,0.0,0.02,0.0,0.0,0.04,ashley childers,
-ENGR,1060,213,Engr Discipline & Skills II,0.11,0.41,0.24,0.11,0.05,0.0,0.0,0.08,andrew isaa neptune,
-ENGR,1060,214,Engr Discipline & Skills II,0.16,0.29,0.21,0.21,0.0,0.0,0.0,0.13,andrew isaa neptune,
-ENGR,1060,215,Engr Discipline & Skills II,0.15,0.21,0.31,0.18,0.05,0.0,0.0,0.1,mariah magagnotti,
-ENGR,1060,216,Engr Discipline & Skills II,0.07,0.22,0.48,0.04,0.07,0.0,0.0,0.11,mariah magagnotti,
-ENGR,1060,217,Engr Discipline & Skills II,0.15,0.38,0.31,0.05,0.0,0.0,0.0,0.1,andrew isaa neptune,
-ENGR,1060,218,Engr Discipline & Skills II,0.03,0.53,0.22,0.06,0.06,0.0,0.0,0.11,andrew isaa neptune,
-ENGR,1060,243,Engr Discipline & Skills II,0.17,0.31,0.31,0.06,0.06,0.0,0.0,0.11,michael giebner,
-ENGR,1060,312,Engr Discipline & Skills II,0.16,0.35,0.24,0.16,0.02,0.0,0.0,0.06,elizabeth stephan,
-ENGR,1060,313,Engr Discipline & Skills II,0.13,0.47,0.22,0.09,0.04,0.0,0.0,0.04,michael giebner,
-ENGR,1060,314,Engr Discipline & Skills II,0.12,0.29,0.43,0.04,0.04,0.0,0.0,0.08,michael giebner,
-ENGR,1060,315,Engr Discipline & Skills II,0.09,0.33,0.28,0.09,0.09,0.0,0.0,0.13,william park,
-ENGR,1060,316,Engr Discipline & Skills II,0.08,0.35,0.31,0.08,0.1,0.0,0.0,0.08,william park,
-ENGR,1060,317,Engr Discipline & Skills II,0.1,0.33,0.42,0.06,0.04,0.0,0.0,0.04,william park,
-ENGR,1060,318,Engr Discipline & Skills II,0.24,0.36,0.17,0.1,0.02,0.0,0.0,0.12,michael giebner,
-ENGR,1060,400,Engr Discipline & Skills II,0.11,0.22,0.33,0.11,0.06,0.0,0.0,0.17,sarah grigg,
-ENGR,1060,611,Engr Discip & Skills II (HON),0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,steven brandon,True
-ENGR,1060,613,Engr Discip & Skills II (HON),0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,steven brandon,True
-ENGR,1060,614,Engr Discip & Skills II (HON),0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.03,steven brandon,True
-ENGR,1060,615,Engr Discip & Skills II (HON),0.6,0.25,0.1,0.0,0.0,0.0,0.0,0.05,richard watkins,True
-ENGR,1070,322,Programming & Prob Solving I,0.07,0.07,0.29,0.24,0.24,0.0,0.0,0.07,jordon anth gilmore,
-ENGR,1070,325,Programming & Prob Solving I,0.03,0.18,0.28,0.21,0.1,0.0,0.0,0.21,william martin,
-ENGR,1070,326,Programming & Prob Solving I,0.1,0.26,0.21,0.23,0.13,0.0,0.0,0.08,william martin,
-ENGR,1070,327,Programming & Prob Solving I,0.15,0.21,0.18,0.21,0.03,0.0,0.0,0.24,william martin,
-ENGR,1080,220,Programming & Prob Solving II,0.03,0.19,0.42,0.0,0.11,0.0,0.0,0.25,srinivasarangan rang,
-ENGR,1080,221,Programming & Prob Solving II,0.0,0.15,0.56,0.12,0.06,0.0,0.0,0.12,srinivasarangan rang,
-ENGR,1080,322,Programming & Prob Solving II,0.09,0.18,0.21,0.24,0.18,0.0,0.0,0.12,jordon anth gilmore,
-ENGR,1080,325,Programming & Prob Solving II,0.0,0.25,0.42,0.08,0.21,0.0,0.0,0.04,william martin,
-ENGR,1080,326,Programming & Prob Solving II,0.06,0.13,0.33,0.17,0.17,0.0,0.0,0.13,william martin,
-ENGR,1080,327,Programming & Prob Solving II,0.11,0.29,0.37,0.16,0.05,0.0,0.0,0.03,william martin,
-ENGR,1090,331,Prog/Problem Solving Apps,0.09,0.22,0.28,0.16,0.13,0.0,0.0,0.13,jordon anth gilmore,
-ENGR,1090,332,Prog/Problem Solving Apps,0.3,0.42,0.19,0.0,0.05,0.0,0.0,0.05,christopher norfolk,
-ENGR,1090,333,Prog/Problem Solving Apps,0.19,0.16,0.3,0.19,0.05,0.0,0.0,0.12,william park,
-ENGR,1090,334,Prog/Problem Solving Apps,0.06,0.26,0.29,0.12,0.0,0.0,0.0,0.26,william park,
-ENGR,1150,500,Engineering Design & Modeling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john minor,
-ENGR,1520,500,Engineering Computer Skills,0.1,0.2,0.6,0.1,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,1520,501,Engineering Computer Skills,0.15,0.46,0.15,0.23,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,2080,181,Engr Graphics & Machine Design,0.34,0.36,0.13,0.02,0.04,0.0,0.0,0.11,nighat yasmin,
-ENGR,2080,182,Engr Graphics & Machine Design,0.4,0.33,0.1,0.13,0.04,0.0,0.0,0.0,nighat yasmin,
-ENGR,2080,285,Engr Graphics & Machine Design,0.32,0.3,0.18,0.0,0.06,0.0,0.0,0.14,anthony pau garland,
-ENGR,2080,286,Engr Graphics & Machine Design,0.29,0.31,0.1,0.08,0.08,0.0,0.0,0.14,anthony pau garland,
-ENGR,2080,384,Engr Graphics & Machine Design,0.52,0.14,0.14,0.1,0.04,0.0,0.0,0.06,john minor,
-ENGR,2100,103,CAD & Engineering Apllications,0.59,0.24,0.04,0.02,0.02,0.0,0.0,0.09,mary kayla kilgo,
-ENGR,2100,104,CAD & Engineering Apllications,0.38,0.23,0.1,0.08,0.08,0.0,0.0,0.13,nighat yasmin,
-ENGR,2100,105,CAD & Engineering Apllications,0.45,0.34,0.07,0.0,0.07,0.0,0.0,0.07,nighat yasmin,
-ENGR,2200,107,Evaluating Innovations,0.29,0.55,0.13,0.0,0.0,0.0,0.0,0.03,sarah grigg,
-ENGR,2200,204,Evaluating Innovations,0.37,0.34,0.24,0.0,0.0,0.0,0.0,0.05,sarah grigg,
-ENGR,2200,206,Evaluating Innovations,0.48,0.4,0.08,0.03,0.0,0.0,0.0,0.03,sarah grigg,
-ENR,1010,1,Intro to Envir & Natur Res I,0.54,0.27,0.1,0.03,0.04,0.0,0.0,0.01,alan johnson,
-ENR,1010,2,Intro to Envir & Natur Res I,0.74,0.12,0.05,0.05,0.02,0.0,0.0,0.02,alan johnson,
-ENR,4290,1,Environ Law & Policy,0.54,0.34,0.08,0.0,0.0,0.0,0.0,0.04,alan johnson,
-ENSP,2000,1,Intro Environ Sci,0.55,0.24,0.1,0.05,0.02,0.0,0.0,0.05,scott brame,
-ENSP,2000,2,Intro Environ Sci,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2000,3,Intro Environ Sci,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2000,4,Intro Environ Sci,0.42,0.39,0.17,0.0,0.03,0.0,0.0,0.0,elizabeth carraway,
-ENSP,4000,1,Studies in Environmental Sci,0.69,0.15,0.0,0.04,0.04,0.0,0.0,0.08,margaret thompson,
-ENT,2000,1,Six-Legged Science,0.64,0.13,0.13,0.0,0.0,0.0,0.0,0.1,suellen pometto,
-ENT,2010,1,Insects and Death,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,joseph culin,
-ENT,3010,1,Insect Biology & Diversity,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,eric benson,
-ENT,8700,1,Insect Phys Mol Bio,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
-FCS,8300,1,Community Dev: Princ & Pract,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,areli moore peralta,
-FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.65,0.21,0.05,0.01,0.03,0.0,0.0,0.06,aubrey dean coffee,
-FDSC,2160,1,Baking Science,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,
-FDSC,3010,1,Food Regulations,0.78,0.15,0.07,0.0,0.0,0.0,0.0,0.0,julie kat northcutt,
-FDSC,3060,1,Institutional Food Service Mgt,0.54,0.35,0.07,0.0,0.03,0.0,0.0,0.0,angela fraser,
-FDSC,4010,1,Food Chemistry I,0.48,0.4,0.08,0.03,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4040,1,Food Prsv & Process,0.51,0.4,0.09,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,
-FDSC,4070,1,Quantity Food Production,0.58,0.34,0.05,0.03,0.0,0.0,0.0,0.0,heather batt,
-FDSC,4170,1,Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,
-FDSC,4200,5,Selected Topics,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katherine cason,
-FDSC,4300,1,Dairy Process & Sant,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-FDSC,8510,1,Food Science Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,
-FIN,3040,1,Risk & Insurance,0.13,0.35,0.35,0.09,0.09,0.0,0.0,0.0,kerri mcmillan,
-FIN,3040,2,Risk & Insurance,0.23,0.33,0.37,0.07,0.0,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.27,0.3,0.27,0.11,0.0,0.0,0.0,0.05,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.14,0.36,0.34,0.11,0.0,0.02,0.0,0.02,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.29,0.36,0.31,0.0,0.02,0.0,0.0,0.02,thomas albe wessels,
-FIN,3050,4,Investment Analysis,0.28,0.41,0.28,0.0,0.03,0.0,0.0,0.0,thomas albe wessels,
-FIN,3060,1,Corporation Finance,0.1,0.35,0.13,0.29,0.06,0.0,0.0,0.06,ramon tolb franklin,
-FIN,3060,2,Corporation Finance,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,neil waller,
-FIN,3060,3,Corporation Finance,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,neil waller,
-FIN,3060,4,Corporation Finance,0.17,0.36,0.19,0.11,0.08,0.0,0.0,0.08,ramon tolb franklin,
-FIN,3060,5,Corporation Finance,0.26,0.43,0.21,0.1,0.0,0.0,0.0,0.0,neil waller,
-FIN,3060,6,Corporation Finance,0.14,0.14,0.26,0.21,0.17,0.0,0.0,0.07,william hol johnson,
-FIN,3060,7,Corporation Finance,0.24,0.2,0.39,0.02,0.05,0.0,0.0,0.1,william hol johnson,
-FIN,3060,8,Corporation Finance,0.24,0.12,0.12,0.12,0.14,0.0,0.0,0.26,william hol johnson,
-FIN,3060,9,Corporation Finance,0.03,0.13,0.16,0.1,0.32,0.0,0.0,0.26,william hol johnson,
-FIN,3060,10,Corporation Finance,0.18,0.24,0.18,0.29,0.0,0.0,0.0,0.12,ramon tolb franklin,
-FIN,3070,1,Prin of Real Estate,0.18,0.24,0.37,0.13,0.02,0.02,0.0,0.05,thomas springer,
-FIN,3070,2,Prin of Real Estate,0.08,0.4,0.28,0.12,0.03,0.0,0.0,0.08,thomas springer,
-FIN,3080,1,Fin Inst & Mkts,0.24,0.57,0.09,0.04,0.02,0.0,0.0,0.04,lyudmila chernykh,
-FIN,3080,2,Fin Inst & Mkts,0.16,0.51,0.26,0.02,0.02,0.0,0.0,0.02,lyudmila chernykh,
-FIN,3080,3,Fin Inst & Mkts,0.18,0.41,0.26,0.03,0.1,0.0,0.0,0.03,daniel thoma greene,
-FIN,3110,1,Financial Management I,0.1,0.43,0.25,0.08,0.08,0.0,0.0,0.08,george bra lockhart,
-FIN,3110,2,Financial Management I,0.08,0.37,0.29,0.16,0.06,0.0,0.0,0.04,angela morgan,
-FIN,3110,3,Financial Management I,0.11,0.22,0.43,0.15,0.09,0.0,0.0,0.0,jared daniel smith,
-FIN,3110,4,Financial Management I,0.2,0.3,0.28,0.13,0.0,0.0,0.0,0.09,jared daniel smith,
-FIN,3120,1,Financial Management II,0.13,0.44,0.21,0.15,0.03,0.0,0.0,0.05,vincent intintoli,
-FIN,3120,2,Financial Management II,0.13,0.29,0.4,0.16,0.0,0.0,0.0,0.02,vincent intintoli,
-FIN,3120,3,Financial Management II,0.43,0.23,0.17,0.15,0.0,0.0,0.0,0.02,melvin stith,
-FIN,3120,4,Financial Management II,0.61,0.26,0.07,0.04,0.02,0.0,0.0,0.0,melvin stith,
-FIN,4020,1,Corporate Valuation,0.05,0.3,0.34,0.27,0.02,0.0,0.0,0.02,jack wolf,
-FIN,4020,2,Corporate Valuation,0.06,0.27,0.29,0.25,0.04,0.0,0.0,0.08,jack wolf,
-FIN,4050,1,Portfolio Management & Theory,0.03,0.3,0.33,0.1,0.0,0.0,0.0,0.23,john alexander,
-FIN,4060,1,Derivatives Analysis,0.24,0.36,0.24,0.09,0.03,0.03,0.0,0.0,george bra lockhart,
-FIN,4110,1,Int Fin Mgt,0.13,0.34,0.38,0.03,0.03,0.0,0.0,0.09,tilan tang,
-FIN,4110,2,Int Fin Mgt,0.19,0.49,0.24,0.08,0.0,0.0,0.0,0.0,tilan tang,
-FIN,4170,1,Real Estate Finance,0.43,0.29,0.21,0.07,0.0,0.0,0.0,0.0,neil waller,
-FIN,4980,2,Creative Inquiry in Finance,0.5,0.2,0.0,0.0,0.0,0.0,0.0,0.3,jack wolf,
-FNR,2040,1,Soil Information Systems,0.86,0.11,0.0,0.0,0.02,0.0,0.0,0.02,elena mikhailova,
-FNR,4900,1,Field Training in Natural Res,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,patricia layton,
-FNR,4990,1,Natural Resources Seminar,0.83,0.11,0.0,0.0,0.06,0.0,0.0,0.0,russell barrett,
-FOR,2050,1,Dendrology,0.23,0.31,0.27,0.04,0.08,0.0,0.0,0.08,donald hagan,
-FOR,2050,2,Dendrology,0.39,0.18,0.14,0.04,0.18,0.0,0.0,0.07,donald hagan,
-FOR,2050,3,Dendrology,0.37,0.26,0.13,0.13,0.03,0.0,0.0,0.08,donald hagan,
-FOR,2210,1,Forest Biology,0.13,0.34,0.3,0.16,0.05,0.0,0.0,0.02,victor ba shelburne,
-FOR,3020,1,Forest Biometrics,0.13,0.35,0.26,0.23,0.03,0.0,0.0,0.0,lawrence gering,
-FOR,3040,1,Forest Resource Economics,0.28,0.49,0.15,0.05,0.0,0.0,0.0,0.03,thomas straka,
-FOR,3410,1,Wood Procure Pract,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,patrick hiesl,
-FOR,4100,1,Harvesting Processes,0.24,0.56,0.12,0.08,0.0,0.0,0.0,0.0,patrick hiesl,
-FOR,4130,1,Integrated Forest Pest Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,roy leslie hedden,
-FOR,4160,1,Forest Policy and Admin,0.68,0.25,0.03,0.01,0.0,0.0,0.0,0.03,joseph lanham,
-FOR,4170,1,Forest Resource Mgt & Regulatn,0.42,0.42,0.12,0.04,0.0,0.0,0.0,0.0,greg yarrow,
-FOR,4310,1,Recreation Res Plan in For Mgt,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
-FOR,4340,1,GIS for Natural Resources,0.82,0.16,0.0,0.0,0.02,0.0,0.0,0.0,christopher post,
-FR,1010,1,Elementary French,0.11,0.47,0.32,0.05,0.0,0.0,0.0,0.05,anne salces  nedeo,
-FR,1020,1,Elementary French,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,1020,2,Elementary French,0.67,0.17,0.11,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,
-FR,1020,3,Elementary French,0.14,0.29,0.43,0.07,0.07,0.0,0.0,0.0,anne salces  nedeo,
-FR,2010,1,Intermediate French,0.43,0.43,0.0,0.0,0.07,0.0,0.0,0.07,paulin de tholozany,
-FR,2010,2,Intermediate French,0.25,0.44,0.19,0.13,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,2010,3,Intermediate French,0.2,0.5,0.1,0.0,0.1,0.0,0.0,0.1,kenneth dav widgren,
-FR,2010,4,Intermediate French,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,paulin de tholozany,
-FR,2020,1,Intermediate French,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2020,3,Intermediate French,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
-FR,2020,4,Intermediate French,0.36,0.43,0.07,0.0,0.07,0.0,0.0,0.07,kenneth dav widgren,
-FR,2020,5,Intermediate French,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,3000,1,Survey of French Lit,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,paulin de tholozany,
-FR,3050,1,Int Fr Con & Comp I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
-FR,3070,1,French Civilization,0.63,0.26,0.0,0.0,0.11,0.0,0.0,0.0,kelly digby peebles,
-FR,4000,1,Modern French Lit,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,eric touya,
-GC,1010,1,Orientation to G C,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,nona woolbright,
-GC,1020,1,Computer Art & CAD Foundations,0.44,0.4,0.02,0.05,0.09,0.0,0.0,0.0,carol jones,
-GC,1020,2,Computer Art & CAD Foundations,0.49,0.41,0.02,0.04,0.04,0.0,0.0,0.0,nona woolbright,
-GC,1030,1,G C I for Pkgsc,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,john jacobs,
-GC,1040,1,Graphic Communications I,0.36,0.55,0.05,0.0,0.05,0.0,0.0,0.0,rebecca suza edlein,
-GC,2070,1,Graphic Communications II,0.68,0.28,0.0,0.02,0.0,0.0,0.0,0.02,patrick gee rose,
-GC,2400,1,Intro to Web Design and Dev,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,erica black walker,
-GC,3400,1,Digital Imaging and eMedia,0.29,0.6,0.04,0.02,0.02,0.0,0.0,0.02,erica black walker,
-GC,3460,1,Ink and Substrates,0.28,0.45,0.2,0.02,0.02,0.0,0.0,0.03,liam henry 'hara,
-GC,4060,1,Package and Specialty Printing,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,kern cox,
-GC,4400,1,Commercial Printing,0.17,0.67,0.04,0.0,0.08,0.0,0.0,0.04,eric weisenmiller,
-GC,4400,2,Commercial Printing,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,
-GC,4440,1,Current Dev/Trends in Gr Comm,0.39,0.3,0.18,0.06,0.03,0.0,0.0,0.03,liam henry 'hara,
-GC,4480,1,Plan and Cont Print,0.42,0.47,0.05,0.03,0.03,0.0,0.0,0.0,john leininger,
-GC,4800,1,Senior Seminar in GC,0.7,0.27,0.0,0.0,0.03,0.0,0.0,0.0,charles edwa tonkin,
-GC,4900,230,G C Selected Topics-GC Sales,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,john leininger,
-GEN,1030,1,Careers in Bioch/Gen,0.85,0.07,0.01,0.03,0.0,0.0,0.0,0.04,alison starr-moss,
-GEN,3000,1,Fundamental Genetics,0.39,0.34,0.23,0.03,0.0,0.0,0.0,0.01,kate leanne wi tsai,
-GEN,3000,2,Fundamental Genetics,0.33,0.47,0.14,0.02,0.02,0.0,0.0,0.02,kate leanne wi tsai,
-GEN,3000,3,Fundamental Genetics,0.35,0.41,0.13,0.04,0.0,0.0,0.0,0.07,kate leanne wi tsai,
-GEN,3020,1,Molecular & General Genetics,0.28,0.47,0.16,0.0,0.06,0.0,0.0,0.03,rajandeep si sekhon,
-GEN,3020,2,Molec & General Genetics (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True
-GEN,3020,3,Molecular & General Genetics,0.21,0.35,0.19,0.08,0.04,0.0,0.0,0.13,lukasz kozubowski,
-GEN,4200,1,Molecular Genetics & Gene Reg,0.47,0.38,0.13,0.03,0.0,0.0,0.0,0.0,julia frugoli,
-GEN,4200,2,Molecular Genetics & Gen (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True
-GEN,4210,2,Mol Gen Gene Reg Lab,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,julia frugoli,
-GEN,4210,3,Mol Gen Gene Reg Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,
-GEN,4400,1,Bioinformatics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
-GEN,4500,1,Comparative Genetics,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,leigh anne clark,
-GEN,6400,1,Bioinformatics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
-GEOG,1010,1,Intro to Geography,0.23,0.4,0.33,0.05,0.0,0.0,0.0,0.0,christa smith,
-GEOG,1030,1,World Regional Geog,0.69,0.2,0.06,0.02,0.02,0.0,0.0,0.0,lance forres howard,
-GEOG,1030,2,World Regional Geog,0.47,0.21,0.11,0.05,0.05,0.0,0.0,0.11,william churc terry,
-GEOG,1030,3,World Regional Geog,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,lance forres howard,
-GEOL,1010,1,Physical Geology,0.17,0.26,0.34,0.12,0.06,0.0,0.0,0.05,alan coulson,
-GEOL,1010,2,Physical Geology,0.14,0.3,0.33,0.07,0.09,0.0,0.0,0.07,alan coulson,
-GEOL,1010,3,Physical Geology,0.33,0.33,0.12,0.04,0.08,0.0,0.0,0.12,mine dogan,
-GEOL,1030,1,Physical Geol Lab,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.57,0.24,0.05,0.0,0.14,0.0,0.0,0.0,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.27,0.59,0.05,0.05,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.17,0.65,0.04,0.0,0.04,0.0,0.0,0.09,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.21,0.5,0.04,0.0,0.0,0.0,0.0,0.25,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,alan coulson,
-GEOL,2050,1,Mineralogy & Intro Petrology,0.35,0.41,0.18,0.0,0.0,0.0,0.0,0.06,lin shuller-nickles,
-GEOL,2070,1,Min & Intro Pet Lab,0.13,0.56,0.31,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,2700,1,Sustainable Water,0.55,0.3,0.07,0.0,0.02,0.0,0.0,0.07,stephen mich moysey,
-GEOL,2750,1,Field Methods,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,3000,1,Environmental Geology,0.39,0.43,0.07,0.04,0.04,0.0,0.0,0.04,scott brame,
-GEOL,3020,1,Structural Geology,0.2,0.13,0.4,0.2,0.0,0.0,0.0,0.07,james castle,
-GEOL,4820,1,Groundwater & Contam Transport,0.42,0.33,0.17,0.0,0.0,0.0,0.0,0.08,lawrence murdoch,
-GER,1010,1,Elementary German,0.37,0.21,0.26,0.0,0.0,0.0,0.0,0.16, lee ferrell,
-GER,1010,2,Elementary German,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0, lee ferrell,
-GER,1020,1,Elementary German,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,1020,2,Elementary German,0.33,0.47,0.07,0.07,0.07,0.0,0.0,0.0,oswald harris king,
-GER,2010,1,Intermediate German,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,oswald harris king,
-GER,2010,2,Intermediate German,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,oswald harris king,
-GER,2020,1,Intermediate German,0.25,0.25,0.31,0.13,0.06,0.0,0.0,0.0, lee ferrell,
-GER,3050,1,Ger Conv & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-HCC,8310,1,Fundamentals of Hcc,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,kelly caine,
-HCG,9050,1,Genom & Hlth Policy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-HEHD,3990,1,Building Healthy Communities,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,areli moore peralta,
-HEHD,4000,1,Intro Leadership Theor & Conc,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,
-HEHD,8000,400,Youth Dev Theories,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
-HEHD,8030,400,Ethical Leadership,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,barry garst,
-HEHD,8060,230,Diverse Society,0.59,0.32,0.05,0.05,0.0,0.0,0.0,0.0,keith george diem,
-HIST,1010,1,Hist of the U S,0.24,0.44,0.26,0.03,0.03,0.0,0.0,0.0,james brad jeffries,
-HIST,1010,2,Hist of the U S,0.42,0.47,0.09,0.0,0.0,0.0,0.0,0.02,lee brady wilson,
-HIST,1020,1,Hist of the U S,0.11,0.11,0.21,0.11,0.11,0.0,0.0,0.37,maribel morey,
-HIST,1020,2,Hist of the U S,0.43,0.25,0.13,0.1,0.05,0.0,0.0,0.05,john andrew,
-HIST,1220,1,"Hist, Tech & Society",0.21,0.49,0.17,0.04,0.07,0.0,0.0,0.02,pamela mack,
-HIST,1240,1,Environmental History Survey,0.13,0.61,0.11,0.03,0.05,0.0,0.0,0.08,james brad jeffries,
-HIST,1240,2,Environmental History Survey,0.23,0.38,0.35,0.0,0.03,0.0,0.0,0.03,james brad jeffries,
-HIST,1720,1,The West and the World I,0.27,0.44,0.16,0.06,0.03,0.0,0.0,0.05,steven marks,
-HIST,1720,2,The West and the World I,0.3,0.42,0.18,0.03,0.02,0.0,0.0,0.05,steven marks,
-HIST,1720,3,The West and the World I,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,emily wood,
-HIST,1720,4,The West and the World I,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,emily wood,
-HIST,1730,2,The West and the World II,0.24,0.44,0.12,0.05,0.06,0.0,0.0,0.09, alan grubb,
-HIST,2990,1,Historian's Craft,0.75,0.17,0.0,0.08,0.0,0.0,0.0,0.0,michael silvestri,
-HIST,2990,2,Historian's Craft,0.3,0.4,0.0,0.0,0.3,0.0,0.0,0.0,elizabeth carney,
-HIST,2990,3,Historian's Craft,0.32,0.63,0.0,0.0,0.05,0.0,0.0,0.0,rachel anne moore,
-HIST,3000,1,Hist Colonial Amer,0.61,0.32,0.03,0.0,0.03,0.0,0.0,0.03,lee brady wilson,
-HIST,3040,1,Indus & Progr Era,0.54,0.21,0.17,0.04,0.04,0.0,0.0,0.0, roger grant,
-HIST,3100,1,History of Religion in the US,0.42,0.17,0.17,0.0,0.25,0.0,0.0,0.0,elizabeth jemison,
-HIST,3280,1,US Legal History to 1890,0.1,0.29,0.24,0.05,0.1,0.0,0.0,0.24,maribel morey,
-HIST,3300,1,Hist of Mod China,0.16,0.32,0.26,0.05,0.0,0.0,0.0,0.21,edwin moise,
-HIST,3390,1,Africa 1875-Present,0.51,0.15,0.18,0.0,0.13,0.0,0.0,0.03,james burns,
-HIST,3420,1,South Am Since 1800,0.46,0.49,0.05,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
-HIST,3520,1,Pharaonic Egypt,0.34,0.43,0.09,0.09,0.03,0.0,0.0,0.03,elizabeth carney,
-HIST,3610,2,History of Britain to 1688,0.45,0.38,0.03,0.1,0.03,0.0,0.0,0.0,caroline dunn clark,
-HIST,3630,1,Britain Since 1688,0.29,0.42,0.18,0.0,0.05,0.0,0.0,0.05,stephani barczewski,
-HIST,3670,1,Modern Ireland,0.46,0.31,0.13,0.05,0.05,0.0,0.0,0.0,michael silvestri,
-HIST,3890,8,Creative Inquiry in History,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,abel bartley,
-HIST,3900,1,Modern Military History,0.18,0.33,0.39,0.03,0.03,0.0,0.0,0.03,edwin moise,
-HIST,4000,1,Honor & Mastery InTheOld South,0.33,0.42,0.17,0.0,0.08,0.0,0.0,0.0,paul chris anderson,True
-HIST,4140,1,Study of Hist Museum,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,meg taylor-shockley,
-HIST,4720,2,Medieval Conquests & Crusades,0.21,0.42,0.11,0.11,0.05,0.0,0.0,0.11,caroline dunn clark,
-HIST,4900,3,Spanish Civil War,0.24,0.29,0.24,0.06,0.12,0.0,0.0,0.06,steven marks,
-HIST,4900,5,Oral History,0.5,0.22,0.17,0.0,0.06,0.0,0.0,0.06,meg taylor-shockley,
-HIST,4930,1,Urban History,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,abel bartley,
-HIST,4940,1,War & Peace in Middle East,0.57,0.29,0.0,0.0,0.07,0.0,0.0,0.07,amit bein,
-HIST,8000,2,SO. Biog,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john andrew,
-HIST,8810,1,Historiography,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, alan grubb,
-HLTH,2020,1,Introduction to Public Health,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,2,Introduction to Public Health,0.61,0.35,0.03,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,3,Introduction to Public Health,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,4,Introduction to Public Health,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,5,Introduction to Public Health,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,400,Introduction to Public Health,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.6,0.29,0.06,0.06,0.0,0.0,0.0,0.0,frederic fraizer,
-HLTH,2030,2,Health Care Sys,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-HLTH,2400,1,Deter of Hlth Behav,0.36,0.32,0.27,0.0,0.05,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2400,2,Deter of Hlth Behav,0.41,0.32,0.21,0.0,0.03,0.0,0.0,0.03,amelia clinkscales,
-HLTH,2500,1,Health and Fitness,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,kari jea strothmann,
-HLTH,2980,1,Human Hlth & Disease,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,2980,2,Human Hlth & Disease,0.85,0.09,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,3030,1,Public Health Comm,0.63,0.31,0.03,0.0,0.0,0.0,0.0,0.03,debra mitch charles,
-HLTH,3050,1,Body Resp Hlth Beh,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,brian patric graves,
-HLTH,3400,1,Hlth Prom Prog Plan,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,brian patric graves,
-HLTH,3610,1,Int Health Care Econ,0.49,0.29,0.13,0.02,0.0,0.0,0.0,0.07,khoa dang truong,
-HLTH,3800,1,Epidemiology,0.37,0.42,0.13,0.08,0.0,0.0,0.0,0.0,hugh spitler,
-HLTH,3800,2,Epidemiology,0.22,0.52,0.22,0.0,0.0,0.0,0.0,0.04,hugh spitler,
-HLTH,3800,400,Epidemiology,0.36,0.18,0.27,0.0,0.0,0.0,0.0,0.18,deborah alma falta,
-HLTH,3980,1,Hlth Appraisal Sklls,0.62,0.23,0.15,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,3980,2,Hlth Appraisal Sklls,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.33,0.36,0.16,0.13,0.0,0.0,0.0,0.02,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.77,0.15,0.05,0.0,0.0,0.0,0.0,0.03,kathleen meyer,
-HLTH,4400,1,Manag Hlth Serv Org,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,frederic fraizer,
-HLTH,4700,1,Global Health,0.83,0.14,0.0,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,4750,1,Hlthcr Oper Mgmt Res,0.77,0.19,0.0,0.0,0.0,0.0,0.0,0.03,lu shi,
-HLTH,4900,1,Res Eval St Pub Hlth,0.33,0.51,0.13,0.0,0.0,0.0,0.0,0.03,lingling zhang,
-HLTH,4900,2,Res Eval St Pub Hlth,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,lingling zhang,
-HLTH,4970,3,Creative Inq in Public Health,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,crystal burn fulmer,
-HLTH,8120,500,Clinical and Translational Sci,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ronald gimbel,
-HON,1910,1,Wicked Opera,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,johannes schmidt,
-HON,1920,2,Who Gets What and Why?,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,sarah evely winslow,
-HON,2060,2,PANDEMIC: Extinction Pending?,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,james morris,
-HON,2200,4,The Economic Crisis,0.64,0.18,0.09,0.0,0.09,0.0,0.0,0.0,patrick warren,
-HON,2220,1,Pact with the Devil,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,
-HORT,1010,1,Horticulture,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HORT,2100,1,Growing Fall Plants,0.32,0.42,0.11,0.05,0.0,0.0,0.0,0.11,james emerson faust,
-HORT,2120,1,Turfgrass Culture,0.52,0.39,0.07,0.02,0.0,0.0,0.0,0.0,haibo liu,
-HORT,2130,1,Turf Culture Lab,0.71,0.14,0.05,0.0,0.0,0.0,0.0,0.1,donald garrett,
-HORT,2130,2,Turf Culture Lab,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,donald garrett,
-HORT,3030,1,Landscape Plants,0.31,0.27,0.17,0.09,0.09,0.0,0.0,0.06,robert polomski,
-HORT,3080,1,Sust Landsc Des Install Maint,0.59,0.19,0.13,0.0,0.06,0.0,0.0,0.03,ellen anita vincent,
-HORT,4090,1,Senior Capstone Course,0.79,0.13,0.04,0.0,0.04,0.0,0.0,0.0,ellen anita vincent,
-HORT,4120,1,Adv Turfgrass Mgt,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,lambert mccarty,
-HORT,4330,1,Turf Weed Management,0.15,0.6,0.2,0.05,0.0,0.0,0.0,0.0,ted whitwell,
-HP,8010,1,Preservation Law and Econ,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,barry louis stiefel,
-HRD,8200,400,Human Perform Improv,0.93,0.0,0.0,0.0,0.02,0.0,0.0,0.05,russell marion,
-HRD,8300,400,Concepts of H R D,0.74,0.09,0.02,0.0,0.09,0.0,0.0,0.05,cynthia sims,
-HRD,8450,400,Needs Assess Ed/Ind,0.93,0.04,0.0,0.0,0.02,0.0,0.0,0.0,philip mcgee,
-HRD,8600,400,Instruc Mat Devel,0.89,0.04,0.04,0.0,0.02,0.0,0.0,0.02,philip mcgee,
-HUM,3090,1,Studies in Humanities,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,
-IE,2000,1,Soph Seminar in I E,0.56,0.17,0.11,0.08,0.08,0.0,0.0,0.0,brian melloy,
-IE,2100,1,Des Analysis Wrk Sys,0.07,0.68,0.21,0.02,0.01,0.0,0.0,0.0,david neyens,
-IE,2800,1,Deterministic Operations Rsrch,0.19,0.32,0.24,0.13,0.05,0.0,0.0,0.06,amin khademi,
-IE,2800,2,Deterministic Operations Rsrch,0.47,0.24,0.15,0.05,0.07,0.0,0.0,0.02,jonathan lowe,
-IE,3010,1,Systems Design I,0.28,0.59,0.08,0.03,0.0,0.0,0.0,0.03,joel greenstein,
-IE,3600,1,Industrial Apps of Prob/Stat I,0.29,0.32,0.25,0.05,0.07,0.0,0.0,0.02,mary elizabeth kurz,
-IE,3680,1,Prof Practice in I E,0.93,0.03,0.02,0.02,0.0,0.0,0.0,0.0,robert james riggs,
-IE,3840,1,Engr Econ Analysis,0.08,0.22,0.11,0.08,0.11,0.0,0.0,0.41,brian melloy,
-IE,3860,1,Prod Plan & Cont,0.21,0.41,0.21,0.18,0.0,0.0,0.0,0.0,robert james riggs,
-IE,4400,1,Decision Support Sys,0.35,0.29,0.15,0.08,0.11,0.0,0.0,0.02,scott jenning mason,
-IE,4400,2,Decision Support Sys,0.29,0.25,0.1,0.13,0.17,0.0,0.0,0.06,site wang,
-IE,4560,1,Supply Chain Design & Control,0.31,0.42,0.18,0.04,0.0,0.0,0.0,0.04,william ferrell,
-IE,4610,1,Quality Engineering,0.25,0.33,0.31,0.06,0.02,0.0,0.0,0.02,byung rae cho,
-IE,4650,1,Facilities Planning & Design,0.79,0.18,0.01,0.02,0.0,0.0,0.0,0.0,jonathan lowe,
-IE,4650,2,Facilities Planning & Design,0.25,0.38,0.19,0.16,0.0,0.0,0.0,0.02,william ferrell,
-IE,4820,1,Systems Modeling,0.48,0.38,0.11,0.02,0.0,0.0,0.0,0.0,kevin taaffe,
-IE,4820,2,Systems Modeling,0.21,0.3,0.3,0.1,0.04,0.0,0.0,0.04,tugce isik,
-IE,4910,1,Network Flows for IE App,0.25,0.13,0.25,0.06,0.06,0.0,0.0,0.25,burak eksioglu,
-IE,4910,2,Modeling & Analysis of MFG,0.61,0.26,0.0,0.03,0.06,0.0,0.0,0.03,mary elizabeth kurz,
-IE,6560,1,Supply Chain Design & Control,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,william ferrell,
-IE,6910,3,Simulation Modeling & Analysis,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
-IE,8000,1,Human Factors Eng,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,david neyens,
-IE,8030,1,Engr Optimization and Apps,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,
-IE,8090,1,Model Sys Under Risk,0.25,0.54,0.21,0.0,0.0,0.0,0.0,0.0,burak eksioglu,
-IE,8510,1,Descriptive Analytics,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,mary elizabeth kurz,
-IE,8530,1,Foundations of Quality,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,byung rae cho,
-IE,8550,1,SC & Logistics Modeling II,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
-IE,8930,1,Multilevel Math Optimization,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
-INT,1010,5,Career Center Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,troy nunamaker,
-INT,1020,5,Career Center Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,troy nunamaker,
-INT,1030,5,Career Center Internship PT 3+,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,troy nunamaker,
-IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.03,sharon nagy,
-ITAL,1010,1,Elementary Italian,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,luca barattoni,
-ITAL,1010,2,Elementary Italian,0.61,0.11,0.0,0.11,0.06,0.0,0.0,0.11,luca barattoni,
-ITAL,1010,3,Elementary Italian,0.42,0.37,0.05,0.0,0.0,0.0,0.0,0.16,valentina lombardi,
-ITAL,1010,4,Elementary Italian,0.43,0.36,0.07,0.0,0.07,0.0,0.0,0.07,valentina lombardi,
-ITAL,1020,1,Elementary Italian,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-ITAL,2010,1,Intermediate Italian,0.44,0.31,0.25,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,2010,2,Intermediate Italian,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-JAPN,1010,1,Elementary Japanese,0.76,0.0,0.18,0.06,0.0,0.0,0.0,0.0,jae allegr takeuchi,
-JAPN,1010,2,Elementary Japanese,0.59,0.12,0.12,0.0,0.06,0.0,0.0,0.12,jae allegr takeuchi,
-JAPN,1020,1,Elementary Japanese,0.38,0.31,0.08,0.08,0.0,0.0,0.0,0.15,kazuko shoji,
-JAPN,2010,1,Intermed Japanese,0.47,0.33,0.13,0.0,0.07,0.0,0.0,0.0,kazuko shoji,
-JAPN,3050,1,Japanese Conversation & Comp,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,toshiko kishimoto,
-LANG,2540,1,Introduction to World Cinemas,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,raquel anido,
-LANG,3710,1,Language and Culture,0.36,0.45,0.09,0.09,0.0,0.0,0.0,0.0,yanhua zhang,
-LARC,1150,1,Intro Landscape Architecture,0.48,0.18,0.24,0.0,0.06,0.0,0.0,0.03,martin john holland,
-LARC,1280,1,Technical Graphics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
-LARC,1510,1,Basic Design I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
-LARC,2510,1,Larch Design Fund,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,robert hewitt,
-LARC,2620,1,Design Impl I,0.36,0.14,0.29,0.0,0.14,0.0,0.0,0.07,paul russell,
-LARC,3510,1,Regional Design,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,yang song,
-LARC,4530,2,Key Issues in Larch,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
-LARC,8210,1,Research Methods,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,
-LARC,8500,1,Grad Colloquium,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,
-LAW,3220,1,Legal Env of Bus,0.5,0.27,0.16,0.05,0.02,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,2,Legal Env of Bus,0.57,0.28,0.09,0.02,0.02,0.0,0.0,0.02,edward ray claggett,
-LAW,3220,3,Legal Env of Bus,0.31,0.36,0.17,0.07,0.05,0.0,0.0,0.05,kenneth toussaint,
-LAW,3220,4,Legal Env of Bus,0.21,0.4,0.24,0.05,0.07,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,5,Legal Env of Bus,0.2,0.36,0.36,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,6,Legal Env of Bus,0.12,0.49,0.3,0.02,0.05,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,7,Legal Env of Bus,0.45,0.32,0.2,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,
-LAW,3220,8,Legal Env of Bus,0.39,0.36,0.23,0.0,0.0,0.0,0.0,0.02,kath kisska-schulze,
-LAW,3220,9,Legal Env of Bus,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,john hine,
-LAW,3220,10,Legal Env of Bus,0.27,0.41,0.25,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,11,Legal Env of Bus,0.51,0.47,0.02,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,100,Legal Env of Bus (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,True
-LAW,3220,400,Legal Env of Bus,0.15,0.38,0.15,0.06,0.12,0.0,0.0,0.15,virgini ward-vaughn,
-LAW,3220,401,Legal Env of Bus,0.1,0.35,0.23,0.03,0.06,0.0,0.0,0.23,virgini ward-vaughn,
-LAW,3220,402,Legal Env of Bus,0.13,0.27,0.37,0.07,0.1,0.0,0.0,0.07,virgini ward-vaughn,
-LAW,3220,403,Legal Env of Bus,0.19,0.3,0.11,0.07,0.15,0.0,0.0,0.19,virgini ward-vaughn,
-LAW,3330,1,Real Estate Law,0.22,0.49,0.2,0.05,0.02,0.02,0.0,0.0,judson jahn,
-LAW,4050,1,Construction Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LIB,3010,1,Patent Searching,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,janice comfort,
-LIH,1270,1,Introduction to L&Ih,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,graciela tissera,
-LS,1000,1,Therapeutic Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,
-LS,1000,2,Therapeutic Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,1000,3,Therapeutic Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ranjanbala dil amin,
-LS,1000,6,Beg. Non-competitive Karate,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,june pilcher,
-LS,1000,19,Introduction to Hip-Hop Dance,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,andrew ellio boland,
-LS,1000,31,Stand-up Paddleboarding,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,elizabeth venable,
-LS,1410,1,Top Rope Climbing,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,glenn dav middleton,
-LS,1410,5,Top Rope Climbing,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,glenn dav middleton,
-LS,1450,5,Camping/Backpacking,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,samuel james keith,
-LS,1570,7,Shotgun Sports,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,susan ruth sullivan,
-LS,1580,5,Archery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,herbert strickland,
-LS,1640,1,Whitewater Kayaking,0.73,0.0,0.09,0.0,0.0,0.0,0.0,0.18,samuel dylan mcgee,
-LS,1640,3,Whitewater Kayaking,0.64,0.09,0.0,0.0,0.0,0.0,0.0,0.27,emily grace turke,
-LS,1650,3,Inland Kayak Touring,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,sarah wilcer,
-LS,1750,2,Fly Fishing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael watts,
-LS,1850,3,Bowling,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,megan elizabet cato,
-LS,1850,10,Bowling,0.83,0.07,0.07,0.03,0.0,0.0,0.0,0.0,katie dudley,
-LS,1940,2,Racquetball,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,
-LS,2040,1,Soccer,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,jessica ca doughtie,
-LS,2100,1,Learn to Dance,0.89,0.03,0.0,0.0,0.03,0.0,0.0,0.06,matthew lee krabbe,
-LS,2110,1,Introduction to Belly Dance,0.8,0.05,0.0,0.0,0.0,0.0,0.0,0.15,stephanie pack,
-LS,2110,3,Introduction to Belly Dance,0.86,0.09,0.0,0.0,0.05,0.0,0.0,0.0,stephanie pack,
-LS,2200,4,Shag,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,broadus fleming,
-LS,2200,7,Shag,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,
-LS,2200,10,Shag,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,matthew lee krabbe,
-LS,2270,2,Intro to Swing Dance,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,paul hoke,
-LS,2270,3,Intro to Swing Dance,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,
-LS,2270,4,Intro to Swing Dance,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,
-LS,2280,1,Intermediate Swing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,paul hoke,
-LS,2320,2,Core Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,diane moreno,
-LS,2320,3,Core Training,0.88,0.0,0.04,0.0,0.0,0.0,0.0,0.08,diane moreno,
-LS,2320,4,Core Training,0.91,0.0,0.04,0.0,0.0,0.0,0.0,0.04,diane moreno,
-LS,2350,4,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
-LS,2350,5,Basic Yoga,0.65,0.22,0.0,0.0,0.0,0.0,0.0,0.13,renee warren gahan,
-LS,2350,6,Basic Yoga,0.71,0.14,0.1,0.05,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2350,7,Basic Yoga,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2360,1,Power/Ashtanga Yoga,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,ani reina-nunnelley,
-LS,2360,2,Power/Ashtanga Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
-LS,2360,3,Power/Ashtanga Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
-LS,2360,6,Power/Ashtanga Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,silica eliza larkin,
-LS,2380,3,Vinyasa Flow Yoga,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,jenefer nadenicek,
-LS,2380,4,Vinyasa Flow Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,jenefer nadenicek,
-LS,2380,5,Vinyasa Flow Yoga,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jenefer nadenicek,
-LS,2420,2,Meditation and Relax,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,renee warren gahan,
-LS,2420,3,Meditation and Relax,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,
-LS,2420,5,Meditation and Relax,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
-LS,2420,7,Meditation and Relax,0.79,0.13,0.0,0.0,0.04,0.0,0.0,0.04,renee warren gahan,
-LS,2450,2,Pilates,0.89,0.0,0.06,0.0,0.0,0.0,0.0,0.06,melanie ivey job,
-LS,2450,3,Pilates,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
-LS,2450,6,Pilates,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
-LS,2460,1,Intermediate Pilates,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,melanie ivey job,
-LS,2510,3,Running & Jogging,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,robert edwar lawson,
-LS,2700,1,Sports Officiating,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,christopher war cox,
-LS,2770,1,Lifeguarding,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,kelly lynn womack,
-LS,3580,1,Advanced Shotgun Skeet,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,charles flint,
-MATH,1010,2,Essen Math for Informed Soc,0.26,0.26,0.21,0.05,0.16,0.0,0.0,0.05,paran rebeka norton,
-MATH,1010,3,Essen Math for Informed Soc,0.18,0.45,0.27,0.09,0.0,0.0,0.0,0.0,minghua cui,
-MATH,1010,4,Essen Math for Informed Soc,0.44,0.36,0.08,0.08,0.03,0.0,0.0,0.0,judith cottingham,
-MATH,1010,6,Essen Math for Informed Soc,0.39,0.36,0.17,0.06,0.0,0.0,0.0,0.03,judith cottingham,
-MATH,1010,8,Essen Math for Informed Soc,0.42,0.21,0.26,0.05,0.05,0.0,0.0,0.0,paran rebeka norton,
-MATH,1010,9,Essen Math for Informed Soc,0.35,0.24,0.12,0.06,0.24,0.0,0.0,0.0,yijun chen,
-MATH,1010,10,Essen Math for Informed Soc,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,xiyan tan,
-MATH,1010,12,Essen Math for Informed Soc,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,yijun chen,
-MATH,1010,14,Essen Math for Informed Soc,0.39,0.33,0.22,0.0,0.06,0.0,0.0,0.0,xiyan tan,
-MATH,1010,101,Essen Math for Informed Soc,0.35,0.27,0.12,0.12,0.0,0.0,0.0,0.15,meredith nicol burr,
-MATH,1020,1,Intro to Mathematical Analysis,0.25,0.28,0.19,0.08,0.14,0.0,0.0,0.06,warren adams,
-MATH,1020,2,Intro to Mathematical Analysis,0.0,0.32,0.37,0.16,0.11,0.0,0.0,0.05,michael we lamoreux,
-MATH,1020,3,Intro to Mathematical Analysis,0.16,0.42,0.11,0.0,0.26,0.0,0.0,0.05,jerry lero phillips,
-MATH,1020,4,Intro to Mathematical Analysis,0.06,0.22,0.39,0.11,0.06,0.0,0.0,0.17,huixi li,
-MATH,1020,5,Intro to Mathematical Analysis,0.11,0.37,0.26,0.11,0.16,0.0,0.0,0.0,aaro ramirez flores,
-MATH,1020,6,Intro to Mathematical Analysis,0.26,0.37,0.16,0.05,0.11,0.0,0.0,0.05,stefani ca mokalled,
-MATH,1020,7,Intro to Mathematical Analysis,0.21,0.05,0.21,0.26,0.21,0.0,0.0,0.05,huixi li,
-MATH,1020,8,Intro to Mathematical Analysis,0.21,0.11,0.21,0.32,0.05,0.0,0.0,0.11,aaro ramirez flores,
-MATH,1020,9,Intro to Mathematical Analysis,0.11,0.22,0.33,0.11,0.17,0.0,0.0,0.06,jerry lero phillips,
-MATH,1020,10,Intro to Mathematical Analysis,0.26,0.16,0.21,0.21,0.0,0.0,0.0,0.16,xiaoyuan liu,
-MATH,1020,11,Intro to Mathematical Analysis,0.21,0.21,0.26,0.11,0.16,0.0,0.0,0.05,travis baumbaugh,
-MATH,1020,12,Intro to Mathematical Analysis,0.17,0.39,0.11,0.17,0.0,0.0,0.0,0.17,tianhui wei,
-MATH,1020,13,Intro to Mathematical Analysis,0.2,0.43,0.18,0.05,0.08,0.0,0.0,0.08,randy davidson,
-MATH,1020,14,Intro to Mathematical Analysis,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,jennifer van dyken,
-MATH,1020,15,Intro to Mathematical Analysis,0.06,0.22,0.33,0.22,0.06,0.0,0.0,0.11,yibo xu,
-MATH,1020,16,Intro to Mathematical Analysis,0.39,0.28,0.11,0.06,0.06,0.0,0.0,0.11,stefani ca mokalled,
-MATH,1020,17,Intro to Mathematical Analysis,0.17,0.28,0.22,0.17,0.17,0.0,0.0,0.0,tiantian yang,
-MATH,1020,18,Intro to Mathematical Analysis,0.16,0.42,0.32,0.11,0.0,0.0,0.0,0.0,xiaoyuan liu,
-MATH,1020,19,Intro to Mathematical Analysis,0.16,0.42,0.21,0.11,0.0,0.0,0.0,0.11,chase norman joyner,
-MATH,1020,20,Intro to Mathematical Analysis,0.26,0.16,0.21,0.05,0.11,0.0,0.0,0.21,tianhui wei,
-MATH,1020,21,Intro to Mathematical Analysis,0.21,0.32,0.21,0.11,0.16,0.0,0.0,0.0,prab withana gamage,
-MATH,1020,22,Intro to Mathematical Analysis,0.16,0.26,0.21,0.05,0.21,0.0,0.0,0.11,michael we lamoreux,
-MATH,1020,23,Intro to Mathematical Analysis,0.22,0.11,0.17,0.0,0.33,0.0,0.0,0.17,hao zuo,
-MATH,1020,24,Intro to Mathematical Analysis,0.06,0.33,0.33,0.06,0.17,0.0,0.0,0.06,yibo xu,
-MATH,1020,25,Intro to Mathematical Analysis,0.05,0.37,0.26,0.11,0.11,0.0,0.0,0.11,junyang zhuang,
-MATH,1020,26,Intro to Mathematical Analysis,0.42,0.21,0.16,0.11,0.0,0.0,0.0,0.11,xintao liu,
-MATH,1020,27,Intro to Mathematical Analysis,0.26,0.37,0.16,0.11,0.05,0.0,0.0,0.05,haodong li,
-MATH,1020,28,Intro to Mathematical Analysis,0.32,0.11,0.26,0.05,0.21,0.0,0.0,0.05,chase norman joyner,
-MATH,1020,29,Intro to Mathematical Analysis,0.21,0.37,0.26,0.11,0.05,0.0,0.0,0.0,randy davidson,
-MATH,1020,30,Intro to Mathematical Analysis,0.21,0.26,0.26,0.0,0.16,0.0,0.0,0.11,prab withana gamage,
-MATH,1020,31,Intro to Mathematical Analysis,0.17,0.33,0.33,0.0,0.0,0.0,0.0,0.17,xintao liu,
-MATH,1020,32,Intro to Mathematical Analysis,0.0,0.21,0.42,0.21,0.16,0.0,0.0,0.0,junyang zhuang,
-MATH,1020,33,Intro to Mathematical Analysis,0.26,0.37,0.21,0.05,0.05,0.0,0.0,0.05,janie caro mcdonald,
-MATH,1020,34,Intro to Mathematical Analysis,0.26,0.21,0.21,0.11,0.16,0.0,0.0,0.05,randy davidson,
-MATH,1020,35,Intro to Mathematical Analysis,0.22,0.44,0.22,0.0,0.0,0.0,0.0,0.11,yinggu bao,
-MATH,1020,36,Intro to Mathematical Analysis,0.21,0.21,0.16,0.21,0.16,0.0,0.0,0.05,haodong li,
-MATH,1020,37,Intro to Mathematical Analysis,0.11,0.28,0.22,0.17,0.06,0.0,0.0,0.17,tiantian yang,
-MATH,1020,38,Intro to Mathematical Analysis,0.17,0.28,0.17,0.06,0.11,0.0,0.0,0.22,hao zuo,
-MATH,1020,39,Intro to Mathematical Analysis,0.0,0.32,0.26,0.05,0.32,0.0,0.0,0.05, erwin walker,
-MATH,1020,40,Intro to Mathematical Analysis,0.16,0.21,0.16,0.05,0.26,0.0,0.0,0.16,travis baumbaugh,
-MATH,1020,41,Intro to Mathematical Analysis,0.17,0.28,0.22,0.06,0.22,0.0,0.0,0.06,travis baumbaugh,
-MATH,1020,42,Intro to Mathematical Analysis,0.0,0.29,0.35,0.06,0.12,0.0,0.0,0.18,michael we lamoreux,
-MATH,1020,43,Intro to Mathematical Analysis,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,jennifer van dyken,
-MATH,1020,44,Intro to Mathematical Analysis,0.37,0.26,0.05,0.11,0.16,0.0,0.0,0.05,randy davidson,
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.6,0.33,0.07,donna simms,
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.62,0.03,tony thanh nguyen,
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.57,0.07,stella watson,
-MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.34,0.59,0.07,patrick buckingham,
-MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.42,0.53,0.04,rebecca lynn knoll,
-MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.36,0.18,liang zhao,
-MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.5,0.41,0.09,patrick buckingham,
-MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.52,0.33,0.14,jason to hedetniemi,
-MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.41,0.12,muhamm mohebujjaman,
-MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.41,0.57,0.02,hugh geller,
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.42,0.48,0.11,eliza dar gallagher,
-MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.6,0.37,0.03,charity watson,
-MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.39,0.02,charity watson,
-MATH,1060,1,Calculus of One Variable I,0.07,0.32,0.15,0.07,0.27,0.0,0.0,0.12,stefan adam bock,
-MATH,1060,2,Calculus of One Variable I,0.2,0.29,0.2,0.09,0.04,0.0,0.0,0.18,jonathon leverenz,
-MATH,1060,3,Calculus of One Variable I,0.1,0.25,0.21,0.13,0.1,0.0,0.0,0.21,abigail bowers,
-MATH,1060,4,Calculus of One Variable I,0.29,0.14,0.26,0.11,0.11,0.0,0.0,0.09,marilyn reba,
-MATH,1060,5,Calculus of One Variable I,0.1,0.29,0.24,0.07,0.19,0.0,0.0,0.12,abigail bowers,
-MATH,1060,6,Calculus of One Variable I,0.26,0.26,0.13,0.07,0.09,0.0,0.0,0.2,meredith nicol burr,
-MATH,1060,7,Calculus of One Variable I,0.14,0.31,0.2,0.09,0.09,0.0,0.0,0.17,marilyn reba,
-MATH,1060,8,Calculus of One Variable I,0.04,0.38,0.3,0.06,0.17,0.0,0.0,0.04,abigail bowers,
-MATH,1060,9,Calculus of One Variable I,0.29,0.33,0.21,0.02,0.02,0.0,0.0,0.12,abdullah al mamun,
-MATH,1060,10,Calculus of One Variable I,0.2,0.3,0.18,0.07,0.09,0.0,0.0,0.16,meredith nicol burr,
-MATH,1060,11,Calculus of One Variable I,0.12,0.31,0.31,0.14,0.0,0.0,0.0,0.12,beth novick,
-MATH,1060,12,Calculus of One Variable I,0.09,0.28,0.19,0.06,0.26,0.0,0.0,0.13,michael gl eldredge,
-MATH,1060,13,Calculus of One Variable I,0.04,0.41,0.3,0.09,0.07,0.0,0.0,0.09,sea sather-wagstaff,
-MATH,1060,14,Calculus of One Variable I,0.15,0.36,0.24,0.09,0.09,0.0,0.0,0.06,allen anderso guest,
-MATH,1060,15,Calculus of One Variable I,0.16,0.52,0.13,0.06,0.1,0.0,0.0,0.03,allen anderso guest,
-MATH,1060,16,Calculus of One Variable I,0.11,0.28,0.23,0.09,0.15,0.0,0.0,0.15,sea sather-wagstaff,
-MATH,1060,17,Calculus of One Variable I,0.34,0.25,0.23,0.09,0.05,0.0,0.0,0.05,ryan grove,
-MATH,1060,18,Calculus of One Variable I,0.05,0.3,0.28,0.08,0.23,0.0,0.0,0.08,amy christine grady,
-MATH,1060,19,Calculus of One Variable I,0.15,0.32,0.11,0.17,0.17,0.0,0.0,0.08,jonathon leverenz,
-MATH,1060,20,Calculus of One Variable I,0.07,0.26,0.17,0.05,0.12,0.0,0.0,0.33,sergey charnyi,
-MATH,1060,21,Calculus of One Variable I,0.14,0.17,0.08,0.17,0.14,0.0,0.0,0.31,rui gong,
-MATH,1060,22,Calculus of One Variable I,0.11,0.2,0.29,0.0,0.09,0.0,0.0,0.31,lee andrew jenkins,
-MATH,1060,23,Calculus of One Variable I,0.16,0.27,0.24,0.09,0.07,0.0,0.0,0.18,stefan adam bock,
-MATH,1060,24,Calculus of One Variable I,0.05,0.21,0.32,0.05,0.26,0.0,0.0,0.11,jennifer van dyken,
-MATH,1060,25,Calculus of One Variable I,0.32,0.29,0.21,0.03,0.11,0.0,0.0,0.05,shiyi tu,
-MATH,1060,100,Calc of One Variable I (HON),0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,beth novick,True
-MATH,1070,1,Differen and Integral Calculus,0.0,0.47,0.29,0.18,0.06,0.0,0.0,0.0,donna simms,
-MATH,1080,1,Calculus of One Variable II,0.1,0.16,0.19,0.0,0.26,0.0,0.0,0.29,alistair bentley,
-MATH,1080,2,Calculus of One Variable II,0.09,0.22,0.13,0.09,0.13,0.0,0.0,0.35,terri johnson,
-MATH,1080,3,Calculus of One Variable II,0.05,0.19,0.27,0.03,0.3,0.0,0.0,0.16,fiona may knoll,
-MATH,1080,4,Calculus of One Variable II,0.03,0.15,0.21,0.09,0.21,0.0,0.0,0.3,sanwar ahmad,
-MATH,1080,5,Calculus of One Variable II,0.05,0.23,0.18,0.08,0.21,0.0,0.0,0.26,garrett dranichak,
-MATH,1080,6,Calculus of One Variable II,0.03,0.17,0.17,0.06,0.43,0.0,0.0,0.14,javier ruiz ramirez,
-MATH,1080,7,Calculus of One Variable II,0.09,0.12,0.18,0.12,0.27,0.0,0.0,0.21,rebecca ramos,
-MATH,1080,8,Calculus of One Variable II,0.07,0.22,0.33,0.19,0.11,0.0,0.0,0.07,qijun he,
-MATH,1080,10,Calculus of One Variable II,0.03,0.11,0.18,0.26,0.24,0.0,0.0,0.18,honghai xu,
-MATH,1080,11,Calculus of One Variable II,0.03,0.22,0.08,0.08,0.46,0.0,0.0,0.14,audrey nico devries,
-MATH,1080,12,Calculus of One Variable II,0.06,0.2,0.2,0.09,0.26,0.0,0.0,0.2,shuhan xu,
-MATH,1080,100,Calc of One Variable II (HON),0.18,0.24,0.12,0.06,0.0,0.0,0.0,0.41,terri johnson,True
-MATH,1150,1,Contemp Math for Elem Teach I,0.63,0.23,0.13,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1150,2,Contemp Math for Elem Teach I,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,allison stoddard,
-MATH,1160,1,Contemp Math for Elem Teach II,0.64,0.28,0.06,0.03,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.02,marion hanna,
-MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,marion hanna,
-MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.04,marion hanna,
-MATH,2060,1,Calculus of Several Variables,0.36,0.23,0.05,0.13,0.1,0.0,0.0,0.13,mishko mitkovski,
-MATH,2060,2,Calculus of Several Variables,0.19,0.25,0.22,0.14,0.14,0.0,0.0,0.06,christopher cox,
-MATH,2060,3,Calculus of Several Variables,0.26,0.16,0.16,0.1,0.19,0.0,0.0,0.13,akshay sunil gupte,
-MATH,2060,4,Calculus of Several Variables,0.36,0.38,0.18,0.0,0.03,0.0,0.0,0.05,xin liu,
-MATH,2060,5,Calculus of Several Variables,0.18,0.26,0.08,0.05,0.26,0.0,0.0,0.16,gretchen matthews,
-MATH,2060,6,Calculus of Several Variables,0.11,0.39,0.08,0.17,0.14,0.0,0.0,0.11,shari prevost,
-MATH,2060,7,Calculus of Several Variables,0.37,0.24,0.24,0.0,0.11,0.0,0.0,0.05,martin joha schmoll,
-MATH,2060,8,Calculus of Several Variables,0.44,0.33,0.08,0.03,0.03,0.0,0.0,0.1,xin liu,
-MATH,2060,9,Calculus of Several Variables,0.16,0.27,0.14,0.08,0.19,0.0,0.0,0.16,gretchen matthews,
-MATH,2060,10,Calculus of Several Variables,0.37,0.23,0.26,0.06,0.03,0.0,0.0,0.06,minerva rios-adams,
-MATH,2060,11,Calculus of Several Variables,0.26,0.11,0.26,0.11,0.14,0.0,0.0,0.11,shari prevost,
-MATH,2060,12,Calculus of Several Variables,0.26,0.24,0.16,0.03,0.21,0.0,0.0,0.11,gretchen matthews,
-MATH,2060,13,Calculus of Several Variables,0.15,0.46,0.2,0.17,0.02,0.0,0.0,0.0,minerva rios-adams,
-MATH,2060,14,Calculus of Several Variables,0.28,0.39,0.17,0.06,0.06,0.0,0.0,0.06,timothy fra parrott,
-MATH,2060,15,Calculus of Several Variables,0.17,0.27,0.37,0.12,0.07,0.0,0.0,0.0,timothy ch teitloff,
-MATH,2060,17,Calculus of Several Variables,0.13,0.31,0.18,0.05,0.26,0.0,0.0,0.08,timothy ch teitloff,
-MATH,2060,18,Calculus of Several Variables,0.28,0.19,0.25,0.06,0.08,0.0,0.0,0.14,timothy fra parrott,
-MATH,2060,19,Calculus of Several Variables,0.41,0.24,0.14,0.08,0.03,0.0,0.0,0.11,peter kiessler,
-MATH,2060,20,Calculus of Several Variables,0.72,0.26,0.0,0.0,0.0,0.0,0.0,0.03,sofya alekseeva,
-MATH,2060,21,Calculus of Several Variables,0.16,0.16,0.38,0.11,0.14,0.0,0.0,0.05,timothy ch teitloff,
-MATH,2060,22,Calculus of Several Variables,0.28,0.28,0.33,0.03,0.0,0.0,0.0,0.08,nathan jos adelgren,
-MATH,2060,23,Calculus of Several Variables,0.09,0.21,0.38,0.15,0.18,0.0,0.0,0.0,julie lassiter,
-MATH,2060,24,Calculus of Several Variables,0.54,0.44,0.03,0.0,0.0,0.0,0.0,0.0,sofya alekseeva,
-MATH,2060,25,Calculus of Several Variables,0.43,0.34,0.09,0.03,0.03,0.0,0.0,0.09,sofya alekseeva,
-MATH,2060,100,Calc of Several Vars (HON),0.63,0.17,0.08,0.0,0.04,0.0,0.0,0.08,shari prevost,True
-MATH,2070,1,Multivariable Calculus,0.11,0.26,0.21,0.16,0.21,0.0,0.0,0.05,trevor scot vilardi,
-MATH,2070,2,Multivariable Calculus,0.06,0.24,0.24,0.12,0.18,0.0,0.0,0.18,mengying xiao,
-MATH,2070,3,Multivariable Calculus,0.18,0.24,0.18,0.06,0.18,0.0,0.0,0.18,thanh thien to,
-MATH,2070,4,Multivariable Calculus,0.16,0.37,0.42,0.0,0.0,0.0,0.0,0.05,jennifer mari hanna,
-MATH,2070,5,Multivariable Calculus,0.15,0.08,0.38,0.15,0.08,0.0,0.0,0.15,liu zhu,
-MATH,2070,6,Multivariable Calculus,0.32,0.11,0.21,0.21,0.11,0.0,0.0,0.05,judith irene mcknew,
-MATH,2070,7,Multivariable Calculus,0.26,0.32,0.37,0.05,0.0,0.0,0.0,0.0,luke marti giberson,
-MATH,2070,8,Multivariable Calculus,0.29,0.29,0.2,0.2,0.03,0.0,0.0,0.0,jennifer mari hanna,
-MATH,2070,9,Multivariable Calculus,0.26,0.32,0.16,0.16,0.05,0.0,0.0,0.05,kevin wayne dettman,
-MATH,2070,10,Multivariable Calculus,0.37,0.21,0.21,0.11,0.05,0.0,0.0,0.05,luke marti giberson,
-MATH,2070,11,Multivariable Calculus,0.22,0.39,0.33,0.0,0.0,0.0,0.0,0.06,judith irene mcknew,
-MATH,2070,12,Multivariable Calculus,0.26,0.32,0.11,0.05,0.16,0.0,0.0,0.11,yisu jia,
-MATH,2070,13,Multivariable Calculus,0.25,0.13,0.31,0.13,0.13,0.0,0.0,0.06,liu zhu,
-MATH,2070,14,Multivariable Calculus,0.39,0.22,0.17,0.11,0.11,0.0,0.0,0.0,trevor scot vilardi,
-MATH,2070,15,Multivariable Calculus,0.21,0.27,0.27,0.03,0.12,0.0,0.0,0.09,jennifer mari hanna,
-MATH,2070,16,Multivariable Calculus,0.17,0.17,0.2,0.2,0.06,0.0,0.0,0.2,hui xue,
-MATH,2070,18,Multivariable Calculus,0.06,0.18,0.29,0.12,0.29,0.0,0.0,0.06,kevin wayne dettman,
-MATH,2070,19,Multivariable Calculus,0.22,0.33,0.28,0.11,0.0,0.0,0.0,0.06,jennifer mari hanna,
-MATH,2070,20,Multivariable Calculus,0.17,0.22,0.33,0.22,0.06,0.0,0.0,0.0,yisu jia,
-MATH,2070,21,Multivariable Calculus,0.26,0.32,0.26,0.0,0.0,0.0,0.0,0.16,allison stoddard,
-MATH,2070,22,Multivariable Calculus,0.11,0.22,0.33,0.06,0.06,0.0,0.0,0.22,thanh thien to,
-MATH,2070,23,Multivariable Calculus,0.18,0.29,0.29,0.18,0.06,0.0,0.0,0.0,marion hanna,
-MATH,2080,1,Intro to Ordin Diff Equations,0.13,0.16,0.47,0.16,0.03,0.0,0.0,0.06,matthew macauley,
-MATH,2080,2,Intro to Ordin Diff Equations,0.76,0.0,0.0,0.0,0.18,0.0,0.0,0.06,brandon gra goodell,
-MATH,2080,3,Intro to Ordin Diff Equations,0.36,0.28,0.17,0.03,0.11,0.0,0.0,0.06,matthew macauley,
-MATH,2080,4,Intro to Ordin Diff Equations,0.57,0.26,0.11,0.0,0.0,0.0,0.0,0.06,irina viktorova,
-MATH,2080,5,Intro to Ordin Diff Equations,0.03,0.21,0.29,0.15,0.15,0.0,0.0,0.18,julie lassiter,
-MATH,2080,6,Intro to Ordin Diff Equations,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,irina viktorova,
-MATH,2080,8,Intro to Ordin Diff Equations,0.09,0.11,0.16,0.23,0.18,0.0,0.0,0.23,julie lassiter,
-MATH,2080,9,Intro to Ordin Diff Equations,0.15,0.41,0.09,0.06,0.15,0.0,0.0,0.15,timothy fra parrott,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,2160,2,Geometry for Elem Sch Teachers,0.78,0.17,0.05,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,2500,1,Intro to Mathematical Sciences,0.78,0.11,0.0,0.0,0.07,0.0,0.0,0.04,matthew saltzman,
-MATH,3020,1,Stat for Science & Engineering,0.37,0.53,0.05,0.0,0.05,0.0,0.0,0.0,hewa priyadarshani,
-MATH,3020,2,Stat for Science & Engineering,0.53,0.28,0.08,0.06,0.03,0.0,0.0,0.03,derek brown,
-MATH,3020,3,Stat for Science & Engineering,0.26,0.4,0.17,0.06,0.03,0.0,0.0,0.09,derek brown,
-MATH,3020,4,Stat for Science & Engineering,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,hewa priyadarshani,
-MATH,3020,5,Stat for Science & Engineering,0.25,0.28,0.38,0.03,0.0,0.0,0.0,0.06,calvin williams,
-MATH,3020,6,Stat for Science & Engineering,0.42,0.24,0.21,0.06,0.0,0.0,0.0,0.06,calvin williams,
-MATH,3020,7,Stat for Science & Engineering,0.5,0.28,0.19,0.03,0.0,0.0,0.0,0.0,xiaoqian sun,
-MATH,3020,8,Stat for Science & Engineering,0.34,0.29,0.17,0.06,0.06,0.0,0.0,0.09,yanbo xia,
-MATH,3020,9,Stat for Science & Engineering,0.22,0.33,0.3,0.0,0.04,0.0,0.0,0.11,rachel eli grotheer,
-MATH,3110,1,Linear Algebra,0.16,0.32,0.36,0.08,0.04,0.0,0.0,0.04,michael adam burr,
-MATH,3110,2,Linear Algebra,0.32,0.21,0.13,0.11,0.18,0.0,0.0,0.05,xuhong gao,
-MATH,3110,3,Linear Algebra,0.41,0.19,0.05,0.16,0.14,0.0,0.0,0.05,xuhong gao,
-MATH,3110,4,Linear Algebra,0.24,0.37,0.16,0.16,0.08,0.0,0.0,0.0,kevin james,
-MATH,3110,5,Linear Algebra,0.17,0.37,0.23,0.09,0.06,0.0,0.0,0.09,felice manganiello,
-MATH,3160,1,Prob Solving for Math Teachers,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,3190,1,Introduction to Proof,0.19,0.38,0.15,0.04,0.19,0.0,0.0,0.04,elena sta dimitrova,
-MATH,3190,2,Introduction to Proof,0.54,0.23,0.15,0.04,0.0,0.0,0.0,0.04,elena sta dimitrova,
-MATH,3600,1,Intermediate Math Computing,0.61,0.16,0.0,0.0,0.06,0.0,0.0,0.16,neil calkin,
-MATH,3650,1,Numerical Mthds for Engineers,0.19,0.32,0.16,0.14,0.05,0.0,0.0,0.14,vincent ervin,
-MATH,3650,2,Numerical Mthds for Engineers,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,leo rebholz,
-MATH,3650,3,Numerical Mthds for Engineers,0.29,0.58,0.08,0.0,0.0,0.0,0.0,0.05,leo rebholz,
-MATH,3650,4,Numerical Mthds for Engineers,0.33,0.46,0.1,0.03,0.03,0.0,0.0,0.05,timo johann heister,
-MATH,4000,1,Theory of Probability,0.44,0.19,0.19,0.0,0.19,0.0,0.0,0.0,yingbo li,
-MATH,4000,2,Theory of Probability,0.33,0.28,0.11,0.06,0.11,0.0,0.0,0.11,yingbo li,
-MATH,4070,1,Regress & Time-Series Analysis,0.2,0.4,0.1,0.1,0.1,0.0,0.0,0.1,christopher mcmahan,
-MATH,4120,1,Algebra I,0.17,0.25,0.21,0.13,0.13,0.0,0.0,0.13,elena sta dimitrova,
-MATH,4190,1,Discrete Math Structures I,0.44,0.44,0.05,0.0,0.08,0.0,0.0,0.0,wayne goddard,
-MATH,4310,1,Theory of Interest,0.63,0.0,0.0,0.06,0.19,0.0,0.0,0.13,mark cawood,
-MATH,4340,1,Adv Engineering Mathematics,0.23,0.47,0.1,0.03,0.0,0.0,0.0,0.17,qingshan chen,
-MATH,4340,2,Adv Engineering Mathematics,0.29,0.25,0.14,0.14,0.0,0.0,0.0,0.18,eleanor jenkins,
-MATH,4400,1,Linear Programming,0.61,0.11,0.11,0.11,0.04,0.0,0.0,0.04,yuyuan ouyang,
-MATH,4410,1,Intro to Stochastic Models,0.65,0.12,0.12,0.0,0.0,0.0,0.0,0.12,peter kiessler,
-MATH,4530,1,Advanced Calculus I,0.27,0.41,0.14,0.14,0.05,0.0,0.0,0.0,taufiquar rahm khan,
-MATH,4530,2,Advanced Calculus I,0.3,0.26,0.17,0.13,0.13,0.0,0.0,0.0,shitao liu,
-MATH,6340,1,Adv Engineering Mathematics,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,vincent ervin,
-MATH,8000,1,Probability,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,robert lund,
-MATH,8010,1,General Linear Hypothesis I,0.3,0.5,0.15,0.0,0.0,0.0,0.0,0.05,xiaoqian sun,
-MATH,8050,1,Data Analysis,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,derek brown,
-MATH,8070,1,Applied Multivariate Analysis,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,8100,1,Mathematical Programming,0.68,0.09,0.05,0.0,0.0,0.0,0.0,0.18,margaret mar wiecek,
-MATH,8120,1,Discrete Optimization,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,akshay sunil gupte,
-MATH,8140,1,Network Flow Programming,0.14,0.71,0.14,0.0,0.0,0.0,0.0,0.0,warren adams,
-MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
-MATH,8210,1,Linear Analysis,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,
-MATH,8510,1,Abstract Algebra I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,james ba coykendall,
-MATH,8530,1,Matrix Analysis,0.22,0.39,0.28,0.0,0.0,0.0,0.0,0.11,felice manganiello,
-MATH,8600,1,Intro to Scientific Computing,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,qingshan chen,
-MATH,8650,1,Data Structures,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,timo johann heister,
-MATH,8840,1,Statistics for Experimenters,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-MBA,8030,1,Stat Analy of Bus Op,0.53,0.33,0.09,0.0,0.0,0.0,0.0,0.04,janis miller,
-MBA,8060,1,Operations Mgt,0.13,0.74,0.05,0.03,0.03,0.0,0.0,0.03, sridharan,
-MBA,8070,1,Financial Management,0.44,0.28,0.21,0.0,0.0,0.0,0.0,0.08,ramon tolb franklin,
-MBA,8090,1,Org Beh & Hum Res Mg,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8090,2,Org Beh & Hum Res Mg,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8190,1,Intro to Acc and Fin,0.53,0.39,0.05,0.0,0.0,0.0,0.0,0.03,annieka philo,
-MBA,8190,2,Intro to Acc and Fin,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,
-MBA,8290,1,Marketing Foundation,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MBA,8330,1,Real Estate Investmt,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,franklin bog wallin,
-MBA,8350,1,Investment Mgmt,0.39,0.46,0.07,0.04,0.0,0.0,0.0,0.04,john alexander,
-MBA,8360,1,Real Estate Principles,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,jeffrey randolph,
-MBA,8370,1,Legal Environ of Bus,0.43,0.55,0.02,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,prashant prabhu,
-MBA,8430,1,Entrepreneurial Accounting,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,sally kathr widener,
-MBA,8450,1,Technology & Innovation Mgt,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8490,5,Entrepreneurial Strategy,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8510,1,Bus Operations & Logistics,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09, sridharan,
-MBA,8590,1,Mgr Decision Model,0.39,0.36,0.17,0.03,0.03,0.0,0.0,0.03,sara elizabet yoder,
-MBA,8590,2,Mgr Decision Model,0.53,0.14,0.23,0.0,0.02,0.0,0.0,0.07,mark mcknew,
-MBA,8600,1,Advanced Marketing Strategy,0.48,0.42,0.09,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8600,2,Advanced Marketing Strategy,0.17,0.66,0.1,0.03,0.0,0.0,0.0,0.03,michael dorsch,
-MBA,8610,1,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MBA,8620,1,Managerial Economics,0.34,0.54,0.06,0.0,0.0,0.0,0.0,0.06,scott templeton,
-MBA,8620,2,Managerial Economics,0.6,0.33,0.03,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,
-MBA,8650,1,Taxation of Business Decisions,0.27,0.64,0.0,0.0,0.0,0.0,0.0,0.09,judson jahn,
-MBA,8700,1,Strategic Management,0.62,0.35,0.04,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
-MBA,8810,1,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,evguenia pas layton,
-MBA,8990,2,Creativity,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,
-MBA,8990,10,Selected Topics in Entrepreneu,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
-ME,2000,1,Sophomore Seminar,0.93,0.03,0.0,0.01,0.0,0.0,0.0,0.03,donald beasley,
-ME,2010,1,Statics & Dynamics,0.1,0.08,0.14,0.07,0.38,0.0,0.0,0.23,sherrill biggers,
-ME,2010,2,Statics & Dynamics,0.14,0.18,0.23,0.09,0.19,0.0,0.0,0.17,paul joseph,
-ME,2010,3,Statics & Dynamics,0.15,0.18,0.24,0.0,0.28,0.0,0.0,0.15,kalyan chakr katuri,
-ME,2030,1,Founda Th/Fl Syst,0.07,0.21,0.34,0.2,0.07,0.0,0.0,0.1,jay ochterbeck,
-ME,2040,1,Mechanics of Materials,0.16,0.42,0.3,0.06,0.03,0.0,0.0,0.03,garrett pataky,
-ME,2040,2,Mechanics of Materials,0.08,0.44,0.3,0.06,0.1,0.0,0.0,0.02,huijuan zhao,
-ME,2220,1,Mechanical Engineering Lab I,0.21,0.71,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,2,Mechanical Engineering Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,2220,3,Mechanical Engineering Lab I,0.35,0.5,0.05,0.0,0.0,0.0,0.0,0.1,todd schweisinger,
-ME,2220,4,Mechanical Engineering Lab I,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
-ME,2220,5,Mechanical Engineering Lab I,0.55,0.35,0.0,0.0,0.0,0.0,0.0,0.1,todd schweisinger,
-ME,2220,6,Mechanical Engineering Lab I,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,7,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,8,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,9,Mechanical Engineering Lab I,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3030,1,Thermodynamics,0.22,0.35,0.33,0.03,0.0,0.0,0.0,0.06,daniel fant,
-ME,3030,2,Thermodynamics,0.37,0.43,0.11,0.02,0.06,0.0,0.0,0.02,daniel fant,
-ME,3040,1,Heat Transfer,0.15,0.35,0.26,0.06,0.12,0.0,0.0,0.06,jean-marc delhaye,
-ME,3040,2,Heat Transfer,0.32,0.3,0.3,0.04,0.02,0.0,0.0,0.02,xin zhao,
-ME,3050,1,Model/an Dy Syst,0.16,0.34,0.34,0.09,0.07,0.0,0.0,0.0,todd schweisinger,
-ME,3050,2,Model/an Dy Syst,0.19,0.43,0.29,0.05,0.0,0.0,0.0,0.05,yue wang,
-ME,3060,1,Fund Machine Design,0.07,0.52,0.31,0.0,0.03,0.0,0.0,0.07,oliver myers,
-ME,3060,2,Fund Machine Design,0.2,0.4,0.22,0.13,0.02,0.0,0.0,0.02,paul jeffrey meyer,
-ME,3070,1,Found of Mechanical Systems,0.44,0.4,0.15,0.0,0.0,0.0,0.0,0.01,lonny thompson,
-ME,3070,2,Found of Mechanical Systems,0.17,0.41,0.21,0.12,0.03,0.0,0.0,0.05,georges fadel,
-ME,3080,1,Fluid Mechanics,0.07,0.22,0.29,0.12,0.17,0.0,0.0,0.12,jean-marc delhaye,
-ME,3080,2,Fluid Mechanics,0.23,0.4,0.26,0.07,0.02,0.0,0.0,0.02,xiangchun xuan,
-ME,3080,3,Fluid Mechanics,0.15,0.22,0.44,0.04,0.07,0.0,0.0,0.09,ethan kung,
-ME,3120,2,Manuf Processes,0.44,0.38,0.12,0.04,0.02,0.0,0.0,0.0,rod martinez-duarte,
-ME,3330,1,Mechanical Engineering Lab II,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,2,Mechanical Engineering Lab II,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,3,Mechanical Engineering Lab II,0.37,0.42,0.16,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
-ME,3330,4,Mechanical Engineering Lab II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,5,Mechanical Engineering Lab II,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,todd schweisinger,
-ME,3330,6,Mechanical Engineering Lab II,0.07,0.79,0.14,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,7,Mechanical Engineering Lab II,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,todd schweisinger,
-ME,3330,8,Mechanical Engineering Lab II,0.27,0.36,0.09,0.0,0.0,0.0,0.0,0.27,todd schweisinger,
-ME,4000,1,Senior Seminar,0.96,0.03,0.0,0.01,0.0,0.0,0.0,0.0, ramasubramanian,
-ME,4010,1,Mech Engr Design,0.08,0.66,0.16,0.09,0.01,0.0,0.0,0.0,joshua summers,
-ME,4020,2,Intern in Engr Des,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,4020,3,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,4020,4,Intern in Engr Des,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
-ME,4030,1,Control Dynamic Systems,0.3,0.28,0.3,0.11,0.0,0.0,0.0,0.01,ardalan vahidi,
-ME,4030,2,Control Dynamic Systems,0.27,0.51,0.2,0.02,0.0,0.0,0.0,0.0,seye parvini oskoui,
-ME,4180,1,F E A in M E Design,0.63,0.3,0.03,0.0,0.0,0.0,0.0,0.03,gang li,
-ME,4200,1,Ener Sources/Utiliz,0.54,0.43,0.03,0.0,0.0,0.0,0.0,0.0,donald beasley,
-ME,4210,1,Intro to Comp Flow,0.27,0.27,0.33,0.07,0.0,0.0,0.0,0.07,chenning tong,
-ME,4400,1,Matls for Aggr Envir,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mica grujicic,
-ME,4440,1,Mechanical Engineering Lab III,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,2,Mechanical Engineering Lab III,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,3,Mechanical Engineering Lab III,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,4,Mechanical Engineering Lab III,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,7,Mechanical Engineering Lab III,0.0,0.83,0.0,0.0,0.08,0.0,0.0,0.08,john wagner,
-ME,4540,1,Design of Machine Elements,0.52,0.3,0.06,0.03,0.03,0.0,0.0,0.06,paul jeffrey meyer,
-ME,4930,36,Selected Topics ME - BioDesign,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,michael porter,
-ME,6210,1,Intro to Comp Flow,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
-ME,6540,1,Des Machine Elements,0.57,0.36,0.0,0.0,0.07,0.0,0.0,0.0,paul jeffrey meyer,
-ME,8010,1,Found of Fluid Mech,0.29,0.5,0.17,0.0,0.0,0.0,0.0,0.04,richard figliola,
-ME,8100,1,Macroscopic Thermo,0.32,0.6,0.08,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,
-ME,8140,1,Turb Bound Layer,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,richard miller,
-ME,8180,1,Intro to Fin Ele Ana,0.75,0.23,0.02,0.0,0.0,0.0,0.0,0.0,lonny thompson,
-ME,8230,1,Control Systems,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,8370,1,Theory of Elast I,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
-ME,8460,1,Inter Dynamics,0.19,0.57,0.19,0.05,0.0,0.0,0.0,0.0,phanin tallapragada,
-ME,8700,1,Adv Design Methods,0.34,0.66,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,8710,1,Engr Optimization,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,8930,27,Sel Topics in Mechanical Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-MGT,2010,1,Principles of Management,0.33,0.41,0.17,0.03,0.04,0.0,0.0,0.03,katherine clark,
-MGT,2010,2,Principles of Management,0.32,0.41,0.16,0.05,0.03,0.0,0.0,0.03,katherine clark,
-MGT,2010,3,Principles of Management,0.36,0.36,0.22,0.03,0.01,0.0,0.0,0.03,katherine clark,
-MGT,2010,4,Principles of Management,0.13,0.44,0.28,0.07,0.03,0.0,0.0,0.04,katherine clark,
-MGT,2010,5,Principles of Management,0.22,0.36,0.34,0.02,0.02,0.0,0.0,0.05,tina robbins,
-MGT,2010,6,Principles of Management,0.4,0.41,0.15,0.01,0.01,0.0,0.0,0.01,tina robbins,
-MGT,2010,7,Principles of Management,0.33,0.46,0.11,0.07,0.03,0.0,0.0,0.0,tina robbins,
-MGT,2010,8,Principles of Management,0.42,0.42,0.14,0.0,0.01,0.0,0.0,0.0,tina robbins,
-MGT,2010,9,Principles of Mgt(HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
-MGT,2180,1,Management PC Applications,0.5,0.29,0.12,0.02,0.0,0.0,0.0,0.07,ryan toole,
-MGT,2180,2,Management PC Applications,0.5,0.33,0.04,0.02,0.06,0.0,0.0,0.05,ryan toole,
-MGT,2180,3,Management PC Applications,0.42,0.33,0.16,0.02,0.02,0.0,0.0,0.05,ryan toole,
-MGT,2180,4,Management PC Applications,0.47,0.28,0.14,0.02,0.05,0.0,0.0,0.04,ryan toole,
-MGT,2970,1,CI - How to Start a Startup,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,matthew charl klein,
-MGT,2970,2,CI - How to Start a Startup,0.5,0.14,0.0,0.0,0.0,0.0,0.0,0.36,gregory pickett,
-MGT,3070,1,Human Resource Management,0.38,0.51,0.08,0.0,0.0,0.0,0.0,0.03,michael cole,
-MGT,3070,3,Human Resource Management,0.16,0.34,0.39,0.02,0.02,0.0,0.0,0.07,kristin dam scott,
-MGT,3070,4,Human Resource Management,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,priscilla harrison,
-MGT,3070,5,Human Resource Management,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,6,Human Resource Management,0.53,0.35,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,7,Human Resource Management,0.33,0.54,0.05,0.05,0.03,0.0,0.0,0.0,michael cole,
-MGT,3100,1,Intermed Business Statistics,0.23,0.19,0.29,0.06,0.13,0.0,0.0,0.1,sara elizabet yoder,
-MGT,3100,2,Intermed Business Statistics,0.28,0.13,0.3,0.08,0.13,0.0,0.0,0.1,sara elizabet yoder,
-MGT,3100,3,Intermed Business Statistics,0.15,0.18,0.3,0.1,0.13,0.0,0.0,0.15,sara elizabet yoder,
-MGT,3100,5,Intermed Business Statistics,0.32,0.15,0.18,0.09,0.09,0.0,0.0,0.18,jerry kermi bilbrey,
-MGT,3100,6,Intermed Business Statistics,0.53,0.25,0.06,0.03,0.03,0.0,0.0,0.11,jerry kermi bilbrey,
-MGT,3100,7,Intermed Business Statistics,0.35,0.3,0.24,0.03,0.0,0.0,0.0,0.08,jerry kermi bilbrey,
-MGT,3100,8,Intermed Business Statistics,0.33,0.25,0.15,0.05,0.1,0.0,0.0,0.13,remi charpin,
-MGT,3100,9,Intermed Business Statistics,0.33,0.2,0.23,0.13,0.05,0.0,0.0,0.08,min kyung lee,
-MGT,3100,10,Intermed Business Statistics,0.58,0.28,0.06,0.0,0.08,0.0,0.0,0.0,shih lun tseng,
-MGT,3100,11,Intermed Business Statistics,0.47,0.25,0.11,0.03,0.0,0.0,0.0,0.14,iaroslava dutchak,
-MGT,3100,12,Intermed Business Statistics,0.25,0.28,0.19,0.03,0.11,0.0,0.0,0.14,yunsik choi,
-MGT,3100,13,Intermed Business Statistics,0.16,0.32,0.21,0.05,0.11,0.0,0.0,0.16,jerry kermi bilbrey,
-MGT,3120,1,Decision Models for Management,0.15,0.46,0.17,0.02,0.15,0.0,0.0,0.05,mark mcknew,
-MGT,3120,2,Decision Models for Management,0.4,0.24,0.24,0.02,0.07,0.0,0.0,0.02,mark mcknew,
-MGT,3120,3,Decision Models for Management,0.3,0.17,0.37,0.04,0.09,0.0,0.0,0.02,mark mcknew,
-MGT,3150,1,New Venture Creation,0.4,0.33,0.18,0.03,0.03,0.0,0.0,0.05,elizabeth er powell,
-MGT,3170,1,Logistics Mgmt,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,shouqiang wang,
-MGT,3180,1,Mgt of Info Systems,0.26,0.6,0.14,0.0,0.0,0.0,0.0,0.0,heshan sun,
-MGT,3180,2,Mgt of Info Systems,0.2,0.6,0.15,0.05,0.0,0.0,0.0,0.0,roopa raman,
-MGT,3180,3,Mgt of Info Systems,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,
-MGT,3180,4,Mgt of Info Systems,0.63,0.28,0.04,0.02,0.02,0.0,0.0,0.0,jackie patri london,
-MGT,3900,1,Ops Mgt,0.24,0.37,0.24,0.11,0.03,0.0,0.0,0.03,yann ferrand,
-MGT,3900,2,Ops Mgt,0.68,0.2,0.08,0.0,0.0,0.0,0.0,0.05,berna quiroga gomez,
-MGT,3900,3,Ops Mgt,0.0,0.58,0.29,0.06,0.03,0.0,0.0,0.03,zachary mo leffakis,
-MGT,3900,4,Ops Mgt,0.56,0.28,0.08,0.03,0.0,0.0,0.0,0.05,brandon woohyeo lee,
-MGT,3900,5,Ops Mgt,0.49,0.27,0.11,0.0,0.03,0.0,0.0,0.11,berna quiroga gomez,
-MGT,4000,1,Mgt of Organizational Behavior,0.27,0.5,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MGT,4000,2,Mgt of Organizational Behavior,0.39,0.39,0.14,0.03,0.0,0.0,0.0,0.06,michael cole,
-MGT,4000,3,Mgt of Organizational Behavior,0.33,0.23,0.3,0.02,0.07,0.0,0.0,0.05,philip roth,
-MGT,4020,1,Ops Pln and Ctl,0.25,0.25,0.44,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,
-MGT,4030,1,Special Problems,0.09,0.55,0.18,0.0,0.0,0.0,0.0,0.18,siyuan li,
-MGT,4080,1,Lean Operations,0.25,0.33,0.33,0.0,0.0,0.0,0.0,0.08,zachary mo leffakis,
-MGT,4110,1,Project Management,0.29,0.56,0.1,0.0,0.0,0.0,0.0,0.05,russell purvis,
-MGT,4120,1,Supplier Management,0.19,0.58,0.13,0.03,0.03,0.0,0.0,0.03,shouqiang wang,
-MGT,4150,1,Business Strategy,0.6,0.38,0.0,0.02,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,3,Business Strategy,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,4,Business Strategy,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,7,Business Strategy,0.25,0.66,0.05,0.02,0.02,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,8,Business Strategy,0.09,0.66,0.11,0.0,0.06,0.0,0.0,0.09,amy elizabet ingram,
-MGT,4150,9,Business Strategy,0.18,0.49,0.28,0.0,0.0,0.0,0.0,0.05,peter gianiodis,
-MGT,4160,1,Special Topics Hr,0.22,0.64,0.11,0.03,0.0,0.0,0.0,0.0,kristin dam scott,
-MGT,4230,1,Intern Bus Mgt,0.25,0.23,0.35,0.03,0.08,0.0,0.0,0.08,wayne stewart,
-MGT,4230,2,Intern Bus Mgt,0.11,0.26,0.47,0.0,0.05,0.0,0.0,0.11,wayne stewart,
-MGT,4230,3,Intern Bus Mgt,0.06,0.32,0.32,0.06,0.19,0.0,0.0,0.03,janis miller,
-MGT,4230,4,Intern Bus Mgt,0.14,0.51,0.32,0.03,0.0,0.0,0.0,0.0,janis miller,
-MGT,4240,1,Global Supply Chain,0.17,0.66,0.14,0.0,0.0,0.0,0.0,0.03,yann ferrand,
-MGT,4270,1,Managing Improvement,0.07,0.5,0.29,0.07,0.0,0.0,0.0,0.07,lawrence fredendall,
-MGT,4300,2,Senior Seminar in Management,0.83,0.0,0.0,0.0,0.17,0.0,0.0,0.0,david leo bodde,
-MGT,4310,1,Emp Rights & Resp,0.48,0.28,0.2,0.0,0.0,0.0,0.0,0.05,leonard jos spooner,
-MGT,4310,2,Emp Rights & Resp,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,4350,1,Pers Interviewing,0.44,0.38,0.13,0.04,0.0,0.0,0.0,0.0,philip roth,
-MGT,4520,1,Business Analysis,0.2,0.4,0.2,0.07,0.07,0.0,0.0,0.07,roopa raman,
-MGT,4550,1,Emerging I T Trends,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MGT,8690,1,Project Mgt,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
-MICR,2050,1,Introductory Micro,0.46,0.42,0.09,0.0,0.01,0.0,0.0,0.03,john abercrombie,
-MICR,3000,1,Essential Skills in Microbiol,0.59,0.37,0.0,0.0,0.02,0.0,0.0,0.02,tamara lyn mcnealy,
-MICR,3050,1,General Microbiology,0.37,0.4,0.15,0.05,0.01,0.0,0.0,0.02,krista barr rudolph,
-MICR,3050,2,General Microbiology,0.43,0.33,0.22,0.01,0.0,0.0,0.0,0.01,krista barr rudolph,
-MICR,4010,1,Microbial Diversity & Ecology,0.2,0.5,0.24,0.02,0.02,0.0,0.0,0.02,barbara campbell,
-MICR,4030,1,Marine Microbiology,0.2,0.4,0.0,0.1,0.1,0.0,0.0,0.2,john michael henson,
-MICR,4050,1,Adv Microbial Ecol of Humans,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4140,1,Basic Immunology,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,yanzhang wei,
-MICR,4150,1,Microbial Genetics,0.4,0.33,0.07,0.17,0.0,0.0,0.0,0.03,min cao,
-MICR,4160,1,Intro Virology,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,simon scott,
-MICR,4510,1,Advanced Microbiology II,0.62,0.23,0.15,0.0,0.0,0.0,0.0,0.0,min cao,
-MICR,4510,2,Advanced Microbiology II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,min cao,
-MKT,3010,2,Prin of Marketing,0.3,0.41,0.23,0.01,0.04,0.0,0.0,0.01,carter wil mcelveen,
-MKT,3010,3,Prin of Marketing,0.41,0.39,0.17,0.02,0.01,0.0,0.0,0.0,carter wil mcelveen,
-MKT,3010,4,Prin of Marketing,0.23,0.4,0.22,0.11,0.03,0.0,0.0,0.01,carter wil mcelveen,
-MKT,3010,5,Prin of Marketing,0.27,0.39,0.25,0.08,0.0,0.0,0.0,0.01,amanda cooper fine,
-MKT,3010,6,Prin of Marketing,0.36,0.42,0.14,0.06,0.02,0.0,0.0,0.0,amanda cooper fine,
-MKT,3010,7,Prin of Marketing,0.24,0.41,0.21,0.07,0.03,0.0,0.0,0.04,amanda cooper fine,
-MKT,3010,8,Prin of Marketing,0.49,0.3,0.12,0.02,0.04,0.0,0.0,0.02,patricia knowles,
-MKT,3010,9,Prin of Marketing(HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james gaubert,True
-MKT,3020,1,Consumer Behavior,0.4,0.46,0.15,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,2,Consumer Behavior,0.66,0.3,0.02,0.0,0.02,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,3,Consumer Behavior,0.36,0.49,0.09,0.06,0.0,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3020,4,Consumer Behavior,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3210,1,Sports Marketing,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3210,2,Sports Marketing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3310,1,Marketing Metrics & Analytics,0.24,0.41,0.12,0.24,0.0,0.0,0.0,0.0,peter weathers,
-MKT,4200,1,Professional Selling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4200,2,Professional Selling,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,3,Professional Selling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,4,Professional Selling,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4230,1,Promotional Strategy,0.27,0.48,0.23,0.0,0.02,0.0,0.0,0.0,patricia knowles,
-MKT,4240,1,Sales Management,0.38,0.55,0.03,0.0,0.0,0.0,0.0,0.03,ryan mullins,
-MKT,4260,1,Business-to-Business,0.54,0.41,0.03,0.0,0.0,0.0,0.0,0.03,james gaubert,
-MKT,4260,2,Business-to-Business,0.31,0.55,0.1,0.0,0.02,0.0,0.0,0.02,james gaubert,
-MKT,4270,1,International Mktg,0.32,0.48,0.09,0.07,0.0,0.0,0.0,0.05,roger gomes,
-MKT,4270,2,International Mktg,0.18,0.34,0.25,0.11,0.05,0.0,0.0,0.07,roger gomes,
-MKT,4270,3,International Mktg,0.27,0.31,0.31,0.04,0.02,0.0,0.0,0.04,roger gomes,
-MKT,4270,4,International Mktg,0.33,0.49,0.18,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
-MKT,4280,1,Services Marketing,0.39,0.55,0.05,0.0,0.0,0.0,0.0,0.02,stephen grove,
-MKT,4280,2,Services Marketing,0.44,0.28,0.22,0.0,0.06,0.0,0.0,0.0,stephen grove,
-MKT,4310,1,Marketing Research,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,peter weathers,
-MKT,4310,2,Marketing Research,0.3,0.67,0.0,0.0,0.0,0.0,0.0,0.04,scott darren swain,
-MKT,4310,3,Marketing Research,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,4,Marketing Research,0.29,0.36,0.29,0.0,0.0,0.0,0.0,0.07,william kilbourne,
-MKT,4430,1,Advertising Strategy,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,
-MKT,4450,1,Macromarketing,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.31,0.59,0.1,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,2,Strategic Mktg Mgt,0.19,0.61,0.19,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,8610,1,Marketing Research,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,christopher hopkins,
-MKT,8630,1,Buyer Behavior,0.48,0.44,0.07,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
-ML,1010,1,Leadership Fund I,0.85,0.0,0.0,0.0,0.07,0.0,0.0,0.07,amanda carol kane,
-ML,2010,1,Leadership Development I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,thierry andre bras,
-ML,2010,2,Leadership Development I,0.71,0.19,0.05,0.05,0.0,0.0,0.0,0.0,thierry andre bras,
-ML,4010,1,Organizational Leadership I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
-MSE,2100,2,Intro to Mat Science,0.35,0.32,0.17,0.05,0.04,0.0,0.0,0.06,eric skaar,
-MSE,2100,3,Intro to Mat Science,0.37,0.4,0.11,0.02,0.06,0.0,0.0,0.04,eric skaar,
-MSE,2100,4,Intro to Mat Science,0.35,0.34,0.17,0.06,0.06,0.0,0.0,0.02,marian kennedy,
-MSE,2410,1,Metrics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
-MSE,3190,2,Materials Proc I,0.46,0.44,0.07,0.02,0.0,0.0,0.0,0.01,olin mefford,
-MSE,3260,1,Thermo of Materials,0.31,0.47,0.08,0.08,0.0,0.0,0.0,0.06,gary lickfield,
-MSE,3260,2,Thermo of Materials,0.03,0.45,0.29,0.16,0.0,0.0,0.0,0.06,gary lickfield,
-MSE,3270,1,Transport Phenomena,0.78,0.11,0.07,0.04,0.0,0.0,0.0,0.01,konstantin kornev,
-MSE,4020,1,Solid State Material,0.24,0.42,0.27,0.03,0.03,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,4130,1,Noncrystalline Materials,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,fei peng,
-MSE,4150,1,Polymer Sc Engr,0.42,0.36,0.19,0.04,0.0,0.0,0.0,0.0,igor luzinov,
-MSE,4150,2,Polymer Sc Engr,0.51,0.37,0.11,0.0,0.01,0.0,0.0,0.0,olin mefford,
-MSE,4320,1,Manuf Proc & Systems,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,denis brosnan,
-MSE,4410,1,Mfg Laboratory,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,denis brosnan,
-MSE,4550,3,Polymer Fiber Lab,0.64,0.18,0.09,0.09,0.0,0.0,0.0,0.0,olin mefford,
-MSE,4580,1,Surf Phen in Ms&E,0.24,0.44,0.2,0.12,0.0,0.0,0.0,0.0,konstantin kornev,
-MSE,4610,1,Polymer & Fiber Materials III,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,
-MSE,4910,1,Undergraduate Research,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,marian kennedy,
-MSE,8100,1,Fundamentals of Materials Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,
-MSE,8270,1,Kin of Phase Tran,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,
-MSE,8510,1,Polymer Science I,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,gary lickfield,
-MUSC,1110,9,Beginning Class Guitar,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,david stevenson,
-MUSC,1420,1,Music Theory I,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,anthony bernarducci,
-MUSC,1420,2,Music Theory I,0.72,0.06,0.17,0.0,0.0,0.0,0.0,0.06,anthony bernarducci,
-MUSC,1430,1,Aural Skills I,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,anthony bernarducci,
-MUSC,1430,2,Aural Skills I,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,anthony bernarducci,
-MUSC,2100,1,Music in the Western World,0.77,0.1,0.1,0.0,0.03,0.0,0.0,0.0,eric lapin,
-MUSC,2100,2,Music in the Western World,0.71,0.13,0.1,0.06,0.0,0.0,0.0,0.0,lisa sain odom,
-MUSC,2100,3,Music in the Western World,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,eric lapin,
-MUSC,2100,4,Music in the Western World,0.58,0.23,0.1,0.03,0.06,0.0,0.0,0.0,linda li-bleuel,
-MUSC,2100,5,Music in the Western World,0.83,0.13,0.03,0.0,0.0,0.0,0.0,0.03,timothy ra hurlburt,
-MUSC,2100,6,Music in the Western World,0.5,0.38,0.09,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
-MUSC,2100,7,Music in the Western World,0.56,0.34,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
-MUSC,2100,8,Music in the Western World,0.58,0.32,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
-MUSC,2100,9,Music in the Western World,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,evan michael jacobi,
-MUSC,2100,10,Music in the Western World,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,linda dzuris,
-MUSC,2100,12,Music in the Western World,0.65,0.32,0.03,0.0,0.0,0.0,0.0,0.0,lea kibler,
-MUSC,2100,15,Music in West World (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,True
-MUSC,3110,1,History of American Music,0.5,0.34,0.06,0.09,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,eric lapin,
-MUSC,3130,1,Hist of Rock & Roll,0.61,0.29,0.04,0.0,0.04,0.0,0.0,0.04,hamilton altstatt,
-MUSC,3170,1,Hist of Country Mus,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,ned hosler,
-MUSC,3180,1,Hist of Audio Tech,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,
-MUSC,3610,1,Marching Band,0.97,0.02,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
-MUSC,3690,1,Symphony Orchestra,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,andrew levin,True
-MUSC,3710,1,Women's Chorus,0.95,0.0,0.0,0.0,0.03,0.0,0.0,0.02,justin durham,
-MUSC,3720,1,Men's Chorus,0.89,0.04,0.0,0.0,0.04,0.0,0.0,0.04,anthony bernarducci,
-MUSC,4150,1,Music Hist to 1750,0.15,0.23,0.31,0.23,0.08,0.0,0.0,0.0,justin durham,
-NPL,3000,1,Nonprofit Leadership,0.84,0.06,0.03,0.0,0.0,0.0,0.0,0.06,tracy diane lamb,
-NPL,3000,3,Nonprofit Leadership,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,james dougl bennett,
-NPL,3020,1,NPL Fundraising,0.69,0.15,0.08,0.0,0.08,0.0,0.0,0.0,robert frager,
-NPL,3040,1,NPL Risk Management,0.46,0.46,0.0,0.08,0.0,0.0,0.0,0.0,anthony shau catone,
-NURS,1020,1,Nrsg Success Skills,0.77,0.22,0.0,0.01,0.0,0.0,0.0,0.0,kristin goodenow,
-NURS,1400,1,Comp App Hlth Care,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
-NURS,3030,1,Nursing of Adults,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,
-NURS,3040,1,Pathophysiology,0.27,0.58,0.08,0.06,0.02,0.0,0.0,0.0,catherine si murton,
-NURS,3040,400,Pathophysiology,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,catherine si murton,
-NURS,3040,401,Pathophysiology,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
-NURS,3100,1,Health Assessment,0.47,0.51,0.02,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
-NURS,3100,400,Health Assessment,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,
-NURS,3120,1,Foundations of Nursing,0.45,0.51,0.04,0.0,0.0,0.0,0.0,0.0,angela pye,
-NURS,3120,400,Foundations of Nursing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3300,2,Research in Nursing,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,3400,1,Pharmther Nursing,0.27,0.61,0.08,0.02,0.02,0.0,0.0,0.0,catherine si murton,
-NURS,3400,400,Pharmther Nursing,0.27,0.58,0.15,0.0,0.0,0.0,0.0,0.0,catherine si murton,
-NURS,3600,400,Social Determinants in Health,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,roxanne amerson,
-NURS,4030,200,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
-NURS,4110,1,Nursing of Children,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
-NURS,4120,1,Nurs Women and Fam,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4250,200,Community Nursing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
-NURS,8050,400,Pharmaco Adv Nurs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8060,400,Advan Assessment for Nursing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,
-NURS,8090,400,Pathophysiology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
-NURS,8200,400,Child & Adol Nursing,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.44,0.36,0.09,0.04,0.01,0.0,0.0,0.05,deborah an hutcheon,
-NUTR,2050,1,Nutr for Nurs Prof,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
-NUTR,2160,1,Evidence-Based Nutrition,0.44,0.38,0.1,0.02,0.03,0.0,0.0,0.03,angela fraser,
-NUTR,4180,1,Prof Development in Dietetics,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
-NUTR,4190,1,Professional Dev in Nutrition,0.92,0.0,0.0,0.04,0.04,0.0,0.0,0.0,angela fraser,
-NUTR,4240,1,Medical Nutr Thera I,0.63,0.35,0.02,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4510,1,Human Nutrition,0.43,0.22,0.14,0.07,0.09,0.0,0.0,0.05,michell bohan brown,
-NUTR,6510,1,Human Nutrition,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michell bohan brown,
-PA,1010,1,Intro to Perf Arts,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,david hartmann,
-PA,1030,1,Portfolio I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,linda dzuris,
-PA,2790,1,Perf Arts Pract I,0.69,0.19,0.0,0.0,0.13,0.0,0.0,0.0,kenneth moore,
-PA,3010,1,Prin of Arts Admin,0.81,0.13,0.0,0.06,0.0,0.0,0.0,0.0,paul buyer,
-PA,4010,1,Capstone Project,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
-PADM,7020,400,Research Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
-PADM,7020,401,Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
-PADM,8210,400,Perspectives on Public Admin,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,mark daniel mellott,
-PADM,8270,400,Public Personnel Admin,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,lawrence nichols,
-PADM,8290,400,Public Financial Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,
-PADM,8670,400,State Government Admin,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,alfred bundrick,
-PADM,8710,400,Sustainability Practices Appli,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
-PADM,8780,400,Legal Aspects of Nonprofits,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,anthony shau catone,
-PADM,8780,401,Local Govt Budgeting & Finance,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,kevin yokim,
-PAS,3010,1,Pan African Studies,0.17,0.56,0.25,0.02,0.01,0.0,0.0,0.0,abel bartley,
-PDBE,8100,1,Contemporary Issues in EDP,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
-PES,1040,1,Introduction to Plant Sciences,0.67,0.17,0.0,0.0,0.03,0.0,0.0,0.13,paula agudelo,
-PES,2020,1,Soils,0.12,0.45,0.3,0.12,0.0,0.0,0.0,0.01,dara michelle park,
-PES,4090,1,Biology of Invasive Plants,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,
-PES,4210,1,Princ of Field Crop Production,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,sruthi naraya kutty,
-PHIL,1010,2,Intro to Philosophic Problems,0.53,0.17,0.13,0.03,0.1,0.0,0.0,0.03,adam gies,
-PHIL,1010,3,Intro to Philosophic Problems,0.4,0.4,0.11,0.06,0.0,0.0,0.0,0.03,christopher grau,
-PHIL,1010,4,Intro to Philosophic Problems,0.47,0.3,0.03,0.1,0.07,0.0,0.0,0.03,john randall wolfe,
-PHIL,1020,1,Introduction to Logic,0.62,0.21,0.03,0.0,0.09,0.0,0.0,0.06,david stegall,
-PHIL,1020,2,Introduction to Logic,0.43,0.37,0.06,0.03,0.06,0.0,0.0,0.06,david stegall,
-PHIL,1020,3,Introduction to Logic,0.76,0.18,0.03,0.03,0.0,0.0,0.0,0.0,gregory scott moss,
-PHIL,1020,4,Introduction to Logic,0.74,0.15,0.03,0.03,0.0,0.0,0.0,0.06,gregory scott moss,
-PHIL,1020,5,Introduction to Logic,0.71,0.18,0.09,0.0,0.03,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,6,Introduction to Logic,0.68,0.21,0.06,0.03,0.0,0.0,0.0,0.03,michael hal hannen,
-PHIL,1030,1,Intro to Ethics (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True
-PHIL,1030,2,Introduction to Ethics,0.54,0.31,0.06,0.0,0.0,0.0,0.0,0.09,michael hal hannen,
-PHIL,1030,3,Introduction to Ethics,0.31,0.49,0.17,0.0,0.0,0.0,0.0,0.03,ryan lake,
-PHIL,1030,4,Introduction to Ethics,0.26,0.68,0.06,0.0,0.0,0.0,0.0,0.0,ryan lake,
-PHIL,1030,5,Introduction to Ethics,0.29,0.29,0.15,0.15,0.0,0.0,0.0,0.12,malcolm edwa munson,
-PHIL,1030,6,Introduction to Ethics,0.21,0.32,0.12,0.12,0.09,0.0,0.0,0.15,malcolm edwa munson,
-PHIL,1030,9,Introduction to Ethics,0.29,0.24,0.18,0.18,0.12,0.0,0.0,0.0,adam gies,
-PHIL,1030,10,Introduction to Ethics,0.72,0.16,0.09,0.03,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1030,11,Introduction to Ethics,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,adam gies,
-PHIL,3040,1,Moral Philosophy,0.36,0.33,0.15,0.03,0.12,0.0,0.0,0.0,charles starkey,
-PHIL,3120,1,Philosophy in Ancient China,0.29,0.38,0.03,0.06,0.09,0.0,0.0,0.15,yanming an,
-PHIL,3150,1,Ancient Philosophy,0.26,0.37,0.22,0.07,0.07,0.0,0.0,0.0,stephen satris,
-PHIL,3160,1,Modern Philosophy,0.63,0.28,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
-PHIL,3170,1,19th-Century Philosophy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,gregory scott moss,
-PHIL,3180,1,20th-Century Philosophy,0.63,0.3,0.0,0.04,0.04,0.0,0.0,0.0,john randall wolfe,
-PHIL,3240,1,Philosophy of Tech,0.38,0.44,0.03,0.03,0.03,0.0,0.0,0.09,andrew garnar,
-PHIL,3260,1,Science and Values,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,andrew garnar,
-PHIL,3260,2,Science and Values,0.47,0.38,0.06,0.0,0.03,0.0,0.0,0.06,andrew garnar,
-PHIL,3260,3,Science and Values,0.42,0.52,0.03,0.0,0.0,0.0,0.0,0.03,andrew garnar,
-PHIL,3330,1,Metaphysics,0.81,0.0,0.05,0.0,0.0,0.0,0.0,0.14,david stegall,
-PHIL,3430,1,Philosophy of Law,0.29,0.38,0.15,0.06,0.06,0.0,0.0,0.06,jennifer ingle,
-PHIL,3440,1,Business Ethics,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,david stegall,
-PHIL,3450,1,Environmental Ethics,0.74,0.19,0.03,0.0,0.03,0.0,0.0,0.0,john randall wolfe,
-PHIL,3450,2,Environmental Ethics,0.74,0.19,0.03,0.03,0.0,0.0,0.0,0.0,john randall wolfe,
-PHIL,3480,1,Philosophies of Art,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,christopher grau,
-PHIL,3490,1,Gender and Sexuality,0.75,0.04,0.08,0.04,0.0,0.0,0.0,0.08,jennifer ingle,
-PHIL,3550,1,Philosophy of Mind & Cog Scien,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,ryan lake,
-PHIL,4020,1,Topics in Philosophy,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,ryan lake,
-PHIL,4220,1,Anarchism,0.44,0.28,0.17,0.0,0.06,0.0,0.0,0.06,todd may,
-PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics with Calculus I,0.25,0.3,0.29,0.07,0.05,0.0,0.0,0.04,lih-sin the,
-PHYS,1220,2,Physics with Calculus I,0.23,0.26,0.29,0.09,0.06,0.0,0.0,0.08,lih-sin the,
-PHYS,1220,4,Physics with Calculus I,0.4,0.15,0.15,0.05,0.15,0.0,0.0,0.1,murray daw,
-PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,2,Physics Lab I,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,3,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,4,Physics Lab I,0.18,0.71,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
-PHYS,1240,5,Physics Lab I,0.0,0.72,0.06,0.0,0.0,0.0,0.0,0.22,jerry hester,
-PHYS,1240,6,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,7,Physics Lab I,0.56,0.25,0.13,0.0,0.06,0.0,0.0,0.0,jerry hester,
-PHYS,1240,8,Physics Lab I,0.28,0.61,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,
-PHYS,1240,9,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,10,Physics Lab I,0.33,0.44,0.11,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,11,Physics Lab I,0.29,0.41,0.18,0.06,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,12,Physics Lab I,0.17,0.56,0.17,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,13,Physics Lab I,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,15,Physics Lab I,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,16,Physics Lab I,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,1240,17,Physics Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2070,1,General Physics I,0.39,0.36,0.14,0.04,0.03,0.0,0.0,0.03,amy liann pope,
-PHYS,2070,2,General Physics I,0.42,0.33,0.19,0.03,0.01,0.0,0.0,0.02,amy liann pope,
-PHYS,2070,3,General Physics I,0.27,0.39,0.2,0.06,0.07,0.0,0.0,0.03,pooja puneet,
-PHYS,2080,1,General Physics II,0.31,0.42,0.16,0.05,0.04,0.0,0.0,0.02,pooja puneet,
-PHYS,2090,1,Gen Phys Lab I,0.54,0.29,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,2,Gen Phys Lab I,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,3,Gen Phys Lab I,0.29,0.54,0.08,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,4,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,5,Gen Phys Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,6,Gen Phys Lab I,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,7,Gen Phys Lab I,0.83,0.09,0.0,0.0,0.04,0.0,0.0,0.04,jerry hester,
-PHYS,2090,8,Gen Phys Lab I,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,9,Gen Phys Lab I,0.58,0.33,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,10,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,11,Gen Phys Lab I,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,
-PHYS,2090,12,Gen Phys Lab I,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,13,Gen Phys Lab I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,14,Gen Phys Lab I,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,
-PHYS,2090,15,Gen Phys Lab I,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,16,Gen Phys Lab I,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,17,Gen Phys Lab I,0.44,0.48,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,18,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,19,Gen Phys Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,20,Gen Phys Lab I,0.73,0.23,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,21,Gen Phys Lab I,0.43,0.35,0.13,0.0,0.04,0.0,0.0,0.04,jerry hester,
-PHYS,2090,22,Gen Phys Lab I,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,23,Gen Phys Lab I,0.36,0.55,0.05,0.0,0.05,0.0,0.0,0.0,jerry hester,
-PHYS,2090,24,Gen Phys Lab I,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,2,Gen Phys Lab II,0.7,0.17,0.04,0.0,0.0,0.0,0.0,0.09,jerry hester,
-PHYS,2100,3,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,4,Gen Phys Lab II,0.82,0.09,0.0,0.05,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2100,7,Gen Phys Lab II,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,
-PHYS,2100,8,Gen Phys Lab II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2210,1,Physics with Calculus II,0.26,0.43,0.19,0.08,0.02,0.0,0.0,0.02,jason stratfo brown,
-PHYS,2210,2,Physics with Calculus II,0.31,0.48,0.13,0.02,0.03,0.0,0.0,0.03,jason stratfo brown,
-PHYS,2210,3,Physics with Calculus II,0.35,0.51,0.1,0.02,0.01,0.0,0.0,0.0,jason stratfo brown,
-PHYS,2210,4,Physics with Calculus II,0.24,0.51,0.18,0.05,0.01,0.0,0.0,0.0,ramakrishna podila,
-PHYS,2210,7,Physics With Cal II (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True
-PHYS,2220,1,Physics with Calculus III,0.22,0.59,0.11,0.0,0.04,0.0,0.0,0.04,jeremy king,
-PHYS,2230,1,Physics Lab II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,2,Physics Lab II,0.28,0.33,0.39,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,3,Physics Lab II,0.18,0.76,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,4,Physics Lab II,0.38,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,5,Physics Lab II,0.0,0.82,0.18,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,6,Physics Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,9,Physics Lab II,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,10,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,12,Physics Lab II,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,13,Physics Lab II,0.24,0.65,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
-PHYS,2230,16,Physics Lab II,0.08,0.75,0.0,0.0,0.0,0.0,0.0,0.17,jerry hester,
-PHYS,2230,17,Physics Lab II,0.08,0.83,0.0,0.0,0.08,0.0,0.0,0.0,jerry hester,
-PHYS,2450,1,Physics of Climate,0.38,0.2,0.12,0.01,0.06,0.0,0.0,0.23,jens oberheide,
-PHYS,3120,1,Meth Theor Phys II,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,hye jung kang,
-PHYS,3150,1,Intro to Computational Physics,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,emil georgie alexov,
-PHYS,3210,1,Mechanics I,0.31,0.19,0.13,0.19,0.13,0.0,0.0,0.06,gerald lehmacher,
-PHYS,3250,1,Exper Physics I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,chad sosolik,
-PHYS,4410,1,Electromagnetics I,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,joan marler,
-PHYS,8110,1,Meth of Theor Phys I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-PHYS,8210,1,Classical Mech I,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
-PHYS,8750,7,Intro to Research,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,terry tritt,
-PHYS,9510,1,Quantum Mech I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,sumanta tewari,
-PKSC,1010,1,Pkgsc Orientation,0.76,0.11,0.06,0.05,0.02,0.0,0.0,0.01,robert truett moore,
-PKSC,1020,1,Intro to Pkg Sci,0.14,0.28,0.3,0.18,0.05,0.0,0.0,0.04,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.68,0.17,0.14,0.0,0.01,0.0,0.0,0.0,robert truett moore,
-PKSC,2200,1,Product & Pkg Design,0.69,0.1,0.06,0.08,0.06,0.0,0.0,0.0,william aaro snyder,
-PKSC,3200,1,Pkg Design Theory,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,rupert hurley,
-PKSC,4010,1,Packaging Machinery,0.53,0.37,0.09,0.0,0.01,0.0,0.0,0.0,anthony lou pometto,
-PKSC,4030,1,Pkg Career Prep,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4040,1,Protective Packaging Prop/Prin,0.19,0.34,0.26,0.06,0.1,0.0,0.0,0.04,gregory batt,
-PKSC,4160,1,Appl Polymers in Pkg,0.24,0.51,0.19,0.03,0.03,0.0,0.0,0.0,duncan darby,
-PKSC,4200,1,Pkg Design & Dev,0.56,0.41,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4540,1,Prod Pkg Evl Lab,0.5,0.25,0.06,0.13,0.06,0.0,0.0,0.0,gregory batt,
-PKSC,4540,2,Prod Pkg Evl Lab,0.33,0.4,0.07,0.0,0.07,0.0,0.0,0.13,gregory batt,
-PKSC,4540,3,Prod Pkg Evl Lab,0.24,0.53,0.06,0.0,0.12,0.0,0.0,0.06,gregory batt,
-PKSC,4540,4,Prod Pkg Evl Lab,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,gregory batt,
-PKSC,4540,6,Prod Pkg Evl Lab,0.0,0.54,0.23,0.23,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1,Food & Health Care Pkg Systems,0.63,0.31,0.03,0.03,0.0,0.0,0.0,0.0,kay cooksey,
-PKSC,8170,1,Pckg Materials: Sci & Technol,0.73,0.09,0.0,0.0,0.18,0.0,0.0,0.0,duncan darby,
-PKSC,8220,400,3D Parametric Design,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,rupert hurley,
-PKSC,8220,401,Structural Pkging Design,0.6,0.0,0.0,0.0,0.4,0.0,0.0,0.0,rupert hurley,
-PLPA,3100,1,Principles of Plant Pathology,0.33,0.33,0.26,0.04,0.0,0.0,0.0,0.04,steven nye jeffers,
-POSC,1010,1,Amer National Govt,0.05,0.58,0.16,0.05,0.16,0.0,0.0,0.0,joseph earl stewart,
-POSC,1010,2,Amer National Govt,0.24,0.48,0.15,0.06,0.02,0.0,0.0,0.05,jeffrey allen fine,
-POSC,1010,3,Amer National Govt,0.08,0.2,0.3,0.2,0.0,0.0,0.0,0.23,james woodard,
-POSC,1020,1,Intro Intl Relations,0.17,0.43,0.31,0.03,0.03,0.0,0.0,0.03,aron geo tannenbaum,
-POSC,1020,2,Intro Intl Relations,0.17,0.5,0.2,0.02,0.09,0.0,0.0,0.02,lydia loui lundgren,
-POSC,1020,3,Intro Intl Relations,0.19,0.29,0.25,0.1,0.08,0.0,0.0,0.08,steven vince miller,
-POSC,1020,4,Intro Intl Relations,0.09,0.49,0.26,0.06,0.04,0.0,0.0,0.06,colin pearce,
-POSC,1030,1,Intro to Political Theory,0.28,0.36,0.19,0.07,0.11,0.0,0.0,0.0,brandon turner,
-POSC,1040,1,Intro Compar Pol,0.08,0.49,0.33,0.08,0.0,0.0,0.0,0.03,xiaobo hu,
-POSC,1040,2,Intro Compar Pol,0.36,0.55,0.06,0.02,0.0,0.0,0.0,0.0,katherine am curtis,
-POSC,1990,1,Intro Pol Sci,0.43,0.29,0.15,0.03,0.04,0.0,0.0,0.06,meredith petersheim,
-POSC,3020,1,State and Loc Gov,0.1,0.57,0.27,0.0,0.02,0.0,0.0,0.04,bruce ransom,
-POSC,3110,1,Model United Nations,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,xiaobo hu,
-POSC,3410,1,Quant Meth in Pol Sc,0.12,0.47,0.06,0.24,0.12,0.0,0.0,0.0,steven vince miller,
-POSC,3430,1,Mass Media in Americ Politics,0.31,0.35,0.16,0.04,0.1,0.0,0.0,0.04,jeffrey scott peake,
-POSC,3610,1,Intl Pol in Crisis,0.21,0.63,0.06,0.02,0.04,0.0,0.0,0.04,vladimir matic,
-POSC,3710,1,European Politics,0.15,0.61,0.07,0.0,0.07,0.0,0.0,0.1,vladimir matic,
-POSC,3750,1,European Integration,0.3,0.33,0.15,0.07,0.11,0.0,0.0,0.04,lydia loui lundgren,
-POSC,3890,1,Indiv. Autonomy & the Const.,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,
-POSC,4210,1,Public Policy,0.18,0.12,0.35,0.18,0.06,0.0,0.0,0.12,adam warber,
-POSC,4360,1,Law Courts Politics,0.69,0.2,0.04,0.0,0.06,0.0,0.0,0.02,joseph earl stewart,
-POSC,4380,1,Constitut Law: Struc of Gov,0.45,0.41,0.11,0.02,0.0,0.0,0.0,0.0,daniel frost,
-POSC,4420,1,Pol Parties & Elect,0.02,0.23,0.53,0.09,0.07,0.0,0.0,0.05,james woodard,
-POSC,4470,1,International Law,0.27,0.48,0.12,0.06,0.03,0.0,0.0,0.03,katherine am curtis,
-POSC,4500,1,Modern Ideologies,0.33,0.43,0.14,0.0,0.05,0.0,0.0,0.05,james woodard,
-POSC,4530,1,American Political Thought,0.27,0.62,0.08,0.0,0.0,0.0,0.0,0.04,kimberly hurd hale,
-POSC,4560,1,Diplomacy,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
-POSC,4710,1,Russian Politics,0.3,0.52,0.03,0.03,0.06,0.0,0.0,0.06,aron geo tannenbaum,
-POSC,4760,1,Middle East Politics,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,vladimir matic,
-POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,meredith petersheim,
-POST,8220,1,Pol Analy/Pol Choice,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.01,teresa walto tucker,
-PRTM,2270,1,Prov of Leisure Exp,0.53,0.43,0.02,0.01,0.0,0.0,0.0,0.01,teresa walto tucker,
-PRTM,2290,1,Competency Integration in PRTM,0.54,0.41,0.04,0.01,0.0,0.0,0.0,0.01,teresa walto tucker,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.47,0.17,0.15,0.13,0.06,0.0,0.0,0.02,daniel mor anderson,
-PRTM,3070,2,Facility Operations,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,craig goodman,
-PRTM,3200,1,Recreation Policy,0.16,0.74,0.0,0.11,0.0,0.0,0.0,0.0,lincoln larson,
-PRTM,3210,1,Recreation Admin,0.35,0.46,0.13,0.0,0.02,0.0,0.0,0.04,mariela fernandez,
-PRTM,3220,1,Facilitation Techniques in RT,0.89,0.09,0.0,0.02,0.0,0.0,0.0,0.0,stephen thoma lewis,
-PRTM,3240,1,Assessment & Planning in RT,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3250,1,Global Persp in Rec,0.6,0.28,0.04,0.08,0.0,0.0,0.0,0.0,skye arthur-banning,
-PRTM,3420,2,Intro to Tourism,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,maloud shakona,
-PRTM,3430,1,Spl Asp of Tourist B,0.23,0.5,0.18,0.09,0.0,0.0,0.0,0.0,william norman,
-PRTM,3430,2,Spl Asp of Tourist B,0.46,0.37,0.11,0.03,0.03,0.0,0.0,0.0,william norman,
-PRTM,3520,1,Camp Org and Admin,0.08,0.31,0.31,0.15,0.0,0.0,0.0,0.15,gwynn powell,
-PRTM,3540,1,Youth Development in Camp,0.71,0.1,0.1,0.05,0.0,0.0,0.0,0.05,gwynn powell,
-PRTM,3900,8,Independent Study in PRTM,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3920,1,Special Event Management,0.73,0.15,0.06,0.02,0.04,0.0,0.0,0.0,kenneth backman,
-PRTM,3920,2,Special Event Management,0.82,0.1,0.04,0.02,0.0,0.0,0.0,0.02,kenneth backman,
-PRTM,4030,1,Elem of Rec/Pk Plan,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,robert baxte powell,
-PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,
-PRTM,4220,1,Management of RT Services,0.59,0.23,0.14,0.0,0.05,0.0,0.0,0.0,anna-mar chancellor,
-PRTM,4410,1,Commercial Rec,0.39,0.22,0.28,0.06,0.0,0.06,0.0,0.0,herbert chancellor,
-PRTM,4470,1,Perspect Intl Travel,0.65,0.19,0.1,0.0,0.03,0.0,0.0,0.03,lauren duffy,
-PRTM,4550,1,Adv Program Planning,0.46,0.37,0.11,0.03,0.0,0.0,0.0,0.03,jamie lynn cathey,
-PRTM,8010,2,Phil Found of PRTM,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
-PRTM,8020,1,Group Proc in Leisure Services,0.53,0.33,0.0,0.0,0.07,0.0,0.0,0.07,skye arthur-banning,
-PRTM,8080,1,Behavioral Aspects,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,8220,2,Strateg Planning in PRTM Orgs,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,
-PRTM,9000,6,Comm Conserv Sustain Develop,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lawrence allen,
-PRTM,9080,2,PRTM Stats,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
-PSYC,2010,1,Intro to Psychology,0.52,0.25,0.13,0.06,0.02,0.0,0.0,0.03,chong hyon pak,
-PSYC,2010,2,Intro to Psychology,0.35,0.34,0.2,0.07,0.02,0.0,0.0,0.02,jo anne jorgensen,
-PSYC,2010,3,Intro to Psychology,0.28,0.33,0.19,0.08,0.07,0.0,0.0,0.04,edwin brainerd,
-PSYC,2010,4,Intro to Psychology,0.15,0.43,0.29,0.03,0.01,0.0,0.0,0.09,christopher pagano,
-PSYC,2010,5,Intro to Psychology,0.26,0.41,0.21,0.01,0.01,0.0,0.0,0.09,mary taylor,
-PSYC,2010,6,Intro to Psychology (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
-PSYC,2020,1,Intro Psychology Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,2020,2,Intro Psychology Lab,0.8,0.04,0.12,0.0,0.04,0.0,0.0,0.0,eric mckibben,
-PSYC,2020,4,Intro Psychology Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,
-PSYC,2020,5,Intro Psychology Lab,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,eric mckibben,
-PSYC,2020,6,Intro Psychology Lab,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,3060,1,Human Sexual Beh,0.52,0.21,0.16,0.05,0.04,0.0,0.0,0.03,bruce michael king,
-PSYC,3090,100,Intro Exp Psych,0.51,0.2,0.13,0.11,0.04,0.0,0.0,0.01,patrick rosopa,
-PSYC,3090,200,Intro Exp Psych,0.41,0.31,0.17,0.03,0.07,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3090,300,Intro Exp Psych,0.3,0.47,0.1,0.07,0.03,0.0,0.0,0.03,richard tyrrell,
-PSYC,3100,100,Advanced Experimental Psych,0.24,0.53,0.12,0.0,0.0,0.0,0.0,0.12,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,robert campbell,
-PSYC,3100,300,Advanced Experimental Psych,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,robert campbell,
-PSYC,3100,400,Advanced Experimental Psych,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,3100,500,Advanced Experimental Psych,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,sarah mae sanborn,
-PSYC,3100,600,Advanced Experimental Psych,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3240,1,Physiological Psych,0.26,0.37,0.17,0.17,0.03,0.0,0.0,0.0,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.26,0.31,0.19,0.1,0.12,0.0,0.0,0.01,june pilcher,
-PSYC,3330,1,Cognitive Psych,0.7,0.16,0.09,0.03,0.01,0.0,0.0,0.01,allison lei wallace,
-PSYC,3330,2,Cognitive Psych,0.21,0.37,0.19,0.13,0.03,0.0,0.0,0.07,thomas alley,
-PSYC,3340,4,Cognitive Psych Lab,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,leah hartman,
-PSYC,3400,1,Lifespan Developmental Psych,0.29,0.32,0.22,0.01,0.07,0.0,0.0,0.07,pamela alley,
-PSYC,3400,2,Lifespan Developmental Psych,0.65,0.24,0.09,0.01,0.0,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3520,1,Social Psychology,0.35,0.41,0.09,0.09,0.03,0.0,0.0,0.03,jo anne jorgensen,
-PSYC,3520,2,Social Psychology,0.62,0.29,0.04,0.0,0.04,0.0,0.0,0.0,alice miche brawley,
-PSYC,3640,1,Industrial Psych,0.34,0.5,0.13,0.01,0.0,0.0,0.0,0.01,eric mckibben,
-PSYC,3640,2,Industrial Psych,0.48,0.3,0.18,0.01,0.01,0.0,0.0,0.01,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.43,0.33,0.17,0.01,0.0,0.0,0.0,0.04,kristen su jennings,
-PSYC,3690,1,Leadership in Orgs,0.56,0.26,0.15,0.03,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,3700,1,Personality,0.32,0.27,0.31,0.08,0.01,0.0,0.0,0.0,edwin brainerd,
-PSYC,3830,1,Abnormal Psychology,0.45,0.34,0.11,0.06,0.03,0.0,0.0,0.01,jo anne jorgensen,
-PSYC,3830,2,Abnormal Psychology,0.17,0.43,0.29,0.0,0.06,0.0,0.0,0.06,pamela alley,
-PSYC,3830,3,Abnormal Psychology,0.34,0.37,0.14,0.03,0.03,0.0,0.0,0.09,pamela alley,
-PSYC,4080,1,Women and Psychology,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,
-PSYC,4150,1,Systems and Theories,0.48,0.35,0.06,0.03,0.03,0.0,0.0,0.03,brian day,
-PSYC,4150,2,Systems and Theories,0.38,0.22,0.28,0.03,0.06,0.0,0.0,0.03,edwin brainerd,
-PSYC,4220,1,Perception,0.41,0.22,0.22,0.11,0.0,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4220,2,Perception,0.16,0.36,0.4,0.08,0.0,0.0,0.0,0.0,christopher pagano,
-PSYC,4220,3,Perception,0.26,0.26,0.26,0.07,0.04,0.0,0.0,0.11,claudio cantalupo,
-PSYC,4350,1,Human Factors,0.48,0.24,0.05,0.1,0.05,0.0,0.0,0.1,laura whitlock,
-PSYC,4430,1,Infant & Child Dev,0.44,0.36,0.12,0.04,0.04,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,4560,1,Psychophysiology,0.48,0.35,0.09,0.09,0.0,0.0,0.0,0.0,drew michael morris,
-PSYC,4710,1,Psych of Testing,0.38,0.33,0.1,0.1,0.05,0.0,0.0,0.05,fred switzer,
-PSYC,4800,1,Health Psychology,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,june pilcher,
-PSYC,4880,1,Psychotherapy,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,lucinda sorci quick,
-PSYC,4890,1,Judgment and Decision Making,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,fred switzer,
-PSYC,4890,2,Psyc of Food and Eating,0.3,0.52,0.13,0.0,0.0,0.0,0.0,0.04,thomas alley,
-PSYC,4920,1,Senior Laboratory,0.85,0.04,0.08,0.04,0.0,0.0,0.0,0.0,hiu ngae jan cheung,
-PSYC,4920,2,Senior Laboratory,0.85,0.0,0.07,0.0,0.0,0.0,0.0,0.07,stephen robertson,
-PSYC,4920,4,Senior Laboratory,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,brooke bake allison,
-PSYC,8100,1,Research Design I,0.71,0.14,0.05,0.0,0.05,0.0,0.0,0.05, dewayne moore,
-PSYC,8350,1,Adv Human Factors,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,8620,1,Org Psychology,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,
-PSYC,8850,1,Org Stress,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas britt,
-RED,8000,1,Real Estate Dvlpment,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-RED,8030,1,Pub-Priv Partnership,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,john terrenc farris,
-RED,8130,1,Strat in Real Estate,0.5,0.31,0.13,0.0,0.0,0.0,0.0,0.06,phillip rive hughes,
-RED,8160,1,Preservation Feasibility,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-REL,1010,1,Intro to Religion,0.05,0.53,0.11,0.16,0.05,0.0,0.0,0.11,peter cohen,
-REL,1010,2,Intro to Religion,0.21,0.32,0.16,0.21,0.0,0.0,0.0,0.11,peter cohen,
-REL,1010,4,Intro to Religion,0.21,0.42,0.11,0.0,0.0,0.0,0.0,0.26,peter cohen,
-REL,1010,5,Intro to Religion,0.8,0.09,0.0,0.0,0.06,0.0,0.0,0.06,jennifer singletary,
-REL,1010,6,Intro to Religion,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jennifer singletary,
-REL,1020,2,World Religions,0.56,0.35,0.03,0.0,0.06,0.0,0.0,0.0,robert stephens,
-REL,1020,3,World Religions,0.72,0.14,0.06,0.0,0.08,0.0,0.0,0.0,robert stephens,
-REL,1020,4,World Religions,0.8,0.06,0.0,0.03,0.03,0.0,0.0,0.09,robert stephens,
-REL,3010,1,Old Testament,0.59,0.32,0.06,0.0,0.03,0.0,0.0,0.0,steven grosby,
-REL,3020,1,New Testament Lit,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,benjamin white,
-REL,3080,1,Rel of Ancient World,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3100,1,History of Religion in the US,0.47,0.21,0.21,0.05,0.0,0.0,0.0,0.05,elizabeth jemison,
-REL,3150,1,Islam,0.44,0.29,0.18,0.09,0.0,0.0,0.0,0.0,mashal saif,
-RS,3010,1,Rural Sociology,0.56,0.2,0.2,0.0,0.0,0.0,0.0,0.04,kenneth robinson,
-RUSS,1010,1,Elementary Russian,0.33,0.17,0.17,0.0,0.08,0.0,0.0,0.25,joan bridgwood,
-SOC,2010,1,Intro to Sociology (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,rachael chatterson,True
-SOC,2010,2,Introduction to Sociology,0.48,0.32,0.16,0.03,0.0,0.0,0.0,0.01,stephani southworth,
-SOC,2010,3,Introduction to Sociology,0.46,0.31,0.1,0.1,0.0,0.0,0.0,0.02,stephani southworth,
-SOC,2010,4,Introduction to Sociology,0.49,0.34,0.15,0.02,0.0,0.0,0.0,0.0,stephani southworth,
-SOC,2010,5,Introduction to Sociology,0.32,0.42,0.16,0.08,0.02,0.0,0.0,0.0,mary louise barr,
-SOC,2010,6,Introduction to Sociology,0.32,0.29,0.32,0.03,0.03,0.0,0.0,0.03,mary louise barr,
-SOC,2010,7,Introduction to Sociology,0.43,0.39,0.13,0.02,0.02,0.0,0.0,0.0,mary louise barr,
-SOC,2010,8,Introduction to Sociology,0.32,0.36,0.23,0.03,0.03,0.0,0.0,0.03,mary louise barr,
-SOC,2010,9,Introduction to Sociology,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,10,Introduction to Sociology,0.52,0.35,0.11,0.0,0.0,0.0,0.0,0.02,jennifer le holland,
-SOC,2010,11,Introduction to Sociology,0.55,0.26,0.16,0.0,0.03,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,12,Introduction to Sociology,0.53,0.34,0.13,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,13,Introduction to Sociology,0.59,0.27,0.05,0.03,0.0,0.0,0.0,0.05,shannon mcdonough,
-SOC,2010,14,Introduction to Sociology,0.2,0.38,0.22,0.09,0.07,0.0,0.0,0.04,margaret tina britz,
-SOC,2010,15,Introduction to Sociology,0.56,0.24,0.11,0.04,0.02,0.0,0.0,0.02,rachael chatterson,
-SOC,2010,16,Introduction to Sociology,0.41,0.36,0.14,0.01,0.04,0.0,0.0,0.03,rachael chatterson,
-SOC,2010,17,Introduction to Sociology,0.38,0.48,0.13,0.0,0.0,0.0,0.0,0.03,rachael chatterson,
-SOC,2020,1,Social Problems,0.3,0.33,0.26,0.07,0.0,0.0,0.0,0.04,stephani southworth,
-SOC,2050,1,Sociology Lab,0.74,0.03,0.09,0.0,0.14,0.0,0.0,0.0,brenda vander mey,
-SOC,2050,2,Sociology Lab,0.65,0.06,0.06,0.18,0.0,0.0,0.0,0.06,brenda vander mey,
-SOC,3020,1,Research Methods I,0.33,0.3,0.18,0.08,0.08,0.0,0.0,0.05,andrew whitehead,
-SOC,3040,1,Social Research Methods II,0.22,0.3,0.39,0.09,0.0,0.0,0.0,0.0,ye luo,
-SOC,3110,1,The Family,0.22,0.56,0.2,0.02,0.0,0.0,0.0,0.0,andrew whitehead,
-SOC,3600,1,Class & Poverty,0.77,0.17,0.02,0.0,0.04,0.0,0.0,0.0,william haller,
-SOC,3880,1,Criminal Justice,0.13,0.27,0.36,0.13,0.11,0.0,0.0,0.0,margaret tina britz,
-SOC,3890,1,Criminology,0.37,0.26,0.06,0.06,0.17,0.0,0.0,0.09,william white,
-SOC,3910,1,Soc of Deviance,0.47,0.28,0.09,0.07,0.0,0.0,0.0,0.09,william white,
-SOC,3920,1,Juvenile Delinquency,0.23,0.08,0.23,0.23,0.15,0.0,0.0,0.08,william white,
-SOC,3940,1,Sociology of Mental Illness,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,douglas sturkie,
-SOC,3970,1,Substance Abuse,0.41,0.46,0.11,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,
-SOC,4040,1,Soc Theory,0.54,0.29,0.15,0.0,0.0,0.0,0.0,0.02,william wentworth,
-SOC,4140,1,Policy&Social Change,0.33,0.48,0.15,0.04,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,4330,1,Global Social Change,0.67,0.17,0.11,0.0,0.06,0.0,0.0,0.0,william haller,
-SOC,4440,1,Sociology of Educ,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,stephani southworth,
-SOC,4600,1,Race & Ethnicity,0.29,0.29,0.33,0.08,0.0,0.0,0.0,0.0,brenda vander mey,
-SOC,4600,2,Race & Ethnicity,0.5,0.17,0.08,0.17,0.08,0.0,0.0,0.0,brenda vander mey,
-SOC,4610,1,Sex & Gender,0.39,0.43,0.11,0.0,0.02,0.0,0.0,0.04,traci ann hefner,
-SOC,4680,1,Criminal Evidence,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
-SOC,4860,1,Creative Inquiry in Sociology,0.64,0.14,0.07,0.0,0.07,0.0,0.0,0.07,margaret tina britz,
-SOC,4970,1,Senior Lab,0.56,0.16,0.16,0.09,0.0,0.0,0.0,0.03,brenda vander mey,
-SOC,8030,1,Sur Dsgn App Res Lab,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,
-SPAN,1010,1,Elementary Spanish,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,scott harris,
-SPAN,1010,2,Elementary Spanish,0.63,0.16,0.05,0.11,0.05,0.0,0.0,0.0,scott harris,
-SPAN,1010,3,Elementary Spanish,0.47,0.42,0.0,0.0,0.05,0.0,0.0,0.05,scott harris,
-SPAN,1020,1,Elementary Spanish,0.16,0.37,0.16,0.16,0.0,0.0,0.0,0.16,roger simpson,
-SPAN,1020,2,Elementary Spanish,0.18,0.29,0.24,0.18,0.0,0.0,0.0,0.12,roger simpson,
-SPAN,1020,3,Elementary Spanish,0.11,0.37,0.16,0.16,0.05,0.0,0.0,0.16,roger simpson,
-SPAN,1020,4,Elementary Spanish,0.42,0.26,0.05,0.11,0.05,0.0,0.0,0.11,roger simpson,
-SPAN,1020,5,Elementary Spanish,0.17,0.28,0.28,0.11,0.0,0.0,0.0,0.17,roger simpson,
-SPAN,1020,6,Elementary Spanish,0.39,0.39,0.11,0.06,0.0,0.0,0.0,0.06,cathy robison,
-SPAN,1020,7,Elementary Spanish,0.11,0.39,0.22,0.06,0.11,0.0,0.0,0.11,cathy robison,
-SPAN,1020,8,Elementary Spanish,0.39,0.28,0.06,0.06,0.17,0.0,0.0,0.06,ana paula  miller,
-SPAN,1020,9,Elementary Spanish,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,ana paula  miller,
-SPAN,1020,10,Elementary Spanish,0.58,0.26,0.0,0.05,0.05,0.0,0.0,0.05,debra oa williamson,
-SPAN,1020,11,Elementary Spanish,0.39,0.33,0.0,0.06,0.0,0.0,0.0,0.22,debra oa williamson,
-SPAN,1020,12,Elementary Spanish,0.53,0.21,0.11,0.0,0.11,0.0,0.0,0.05,adrienne eliza fama,
-SPAN,1020,13,Elementary Spanish,0.32,0.37,0.26,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,1020,14,Elementary Spanish,0.32,0.21,0.21,0.11,0.05,0.0,0.0,0.11,ana paula  miller,
-SPAN,2010,1,Intermediate Spanish,0.24,0.41,0.18,0.12,0.0,0.0,0.0,0.06,cathy robison,
-SPAN,2010,2,Intermediate Spanish,0.11,0.72,0.17,0.0,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,3,Intermediate Spanish,0.38,0.31,0.25,0.0,0.0,0.0,0.0,0.06,allison ann hinds,
-SPAN,2010,4,Intermediate Spanish,0.21,0.5,0.29,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
-SPAN,2010,5,Intermediate Spanish,0.53,0.18,0.18,0.06,0.0,0.0,0.0,0.06,allison ann hinds,
-SPAN,2010,6,Intermediate Spanish,0.5,0.19,0.25,0.0,0.0,0.0,0.0,0.06,heidi montes,
-SPAN,2010,7,Intermediate Spanish,0.25,0.25,0.25,0.13,0.0,0.0,0.0,0.13,heidi montes,
-SPAN,2010,8,Intermediate Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,2010,9,Intermediate Spanish,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,2010,10,Intermediate Spanish,0.38,0.31,0.08,0.0,0.15,0.0,0.0,0.08,ricardo tremolada,
-SPAN,2010,11,Intermediate Spanish,0.27,0.45,0.09,0.0,0.0,0.0,0.0,0.18,melva margu persico,
-SPAN,2010,12,Intermediate Spanish,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2010,13,Intermediate Spanish,0.26,0.37,0.26,0.0,0.0,0.0,0.0,0.11,maureen zamora,
-SPAN,2010,14,Intermediate Spanish,0.13,0.19,0.44,0.0,0.0,0.0,0.0,0.25,maureen zamora,
-SPAN,2010,15,Intermediate Spanish,0.53,0.2,0.0,0.0,0.07,0.0,0.0,0.2,ricardo tremolada,
-SPAN,2010,16,Intermediate Spanish,0.59,0.24,0.0,0.0,0.06,0.0,0.0,0.12,ricardo tremolada,
-SPAN,2010,17,Intermediate Spanish,0.68,0.11,0.16,0.0,0.05,0.0,0.0,0.0,ricardo tremolada,
-SPAN,2010,18,Intermediate Spanish,0.29,0.36,0.21,0.07,0.0,0.0,0.0,0.07,ana paula  miller,
-SPAN,2010,19,Intermediate Spanish,0.24,0.41,0.24,0.0,0.0,0.0,0.0,0.12,debra oa williamson,
-SPAN,2020,1,Intermediate Spanish,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,2,Intermediate Spanish,0.06,0.56,0.31,0.06,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,2020,3,Intermediate Spanish,0.31,0.31,0.25,0.13,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,4,Intermediate Spanish,0.28,0.5,0.11,0.0,0.0,0.0,0.0,0.11,heidi montes,
-SPAN,2020,5,Intermediate Spanish,0.64,0.07,0.14,0.0,0.0,0.0,0.0,0.14,ze cruz valderramos,
-SPAN,2020,6,Intermediate Spanish,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,ze cruz valderramos,
-SPAN,2020,7,Intermediate Spanish,0.39,0.28,0.28,0.0,0.0,0.0,0.0,0.06,melva margu persico,
-SPAN,2020,8,Intermediate Spanish,0.41,0.47,0.06,0.06,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,2020,9,Intermediate Spanish,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,10,Intermediate Spanish,0.47,0.35,0.12,0.0,0.06,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,11,Intermediate Spanish,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,kari daus carson,
-SPAN,2020,12,Intermediate Spanish,0.37,0.53,0.0,0.0,0.0,0.0,0.0,0.11,kari daus carson,
-SPAN,2020,13,Intermediate Spanish,0.37,0.21,0.32,0.05,0.05,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,14,Intermediate Spanish,0.56,0.28,0.06,0.0,0.0,0.0,0.0,0.11,ze cruz valderramos,
-SPAN,2020,15,Intermediate Spanish,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,3050,2,Int Con Comp Span I,0.5,0.28,0.17,0.0,0.0,0.0,0.0,0.06,juana martin-armas,
-SPAN,3050,3,Int Con Comp Span I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,3060,1,Span Comp for Bus,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,maureen zamora,
-SPAN,3070,1,Hispanic World: Sp,0.72,0.11,0.0,0.06,0.0,0.0,0.0,0.11,salvador oropesa,
-SPAN,3070,2,Hispanic World: Sp,0.26,0.58,0.0,0.0,0.0,0.0,0.0,0.16,raquel anido,
-SPAN,3080,1,Hispanic World: La,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,george palacios,
-SPAN,3110,1,Surv Span-Amer Lit,0.21,0.29,0.21,0.14,0.0,0.0,0.0,0.14,tiffany dawn miller,
-SPAN,3130,1,Span Lit Survey I,0.27,0.27,0.18,0.09,0.0,0.0,0.0,0.18,mon rojas-de-massei,
-SPAN,3130,2,Span Lit Survey I,0.27,0.4,0.2,0.0,0.0,0.0,0.0,0.13,mon rojas-de-massei,
-SPAN,3140,1,Hispanic Linguistics,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,daniel smith,
-SPAN,4060,1,Narrative Fiction,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,
-SPAN,4160,1,Span Intl Trade II,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,maureen zamora,
-SPAN,4190,1,Health & Hisp Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-SPAN,4220,1,Contem Span Am Novel,0.83,0.11,0.0,0.0,0.06,0.0,0.0,0.0,ricardo tremolada,
-SPAN,4350,1,Contemp Hisp Cult,0.45,0.27,0.09,0.0,0.09,0.0,0.0,0.09,tiffany dawn miller,
-STAT,2220,1,Statistics in Everyday Life,0.51,0.21,0.14,0.05,0.05,0.0,0.0,0.05,ros martinez-dawson,
-STAT,2220,2,Statistics in Everyday Life,0.39,0.19,0.17,0.17,0.09,0.0,0.0,0.0,ros martinez-dawson,
-STAT,2220,3,Statistics in Everyday Life,0.35,0.39,0.2,0.02,0.04,0.0,0.0,0.0,james espey,
-STAT,2220,4,Statistics in Everyday Life,0.54,0.22,0.17,0.06,0.02,0.0,0.0,0.0,james espey,
-STAT,2220,5,Statistics in Everyday Life,0.5,0.35,0.13,0.0,0.0,0.0,0.0,0.02,james espey,
-STAT,2220,7,Statistics in Everyday Life,0.42,0.34,0.12,0.07,0.02,0.0,0.0,0.02,james espey,
-STAT,2300,1,Statistical Methods I,0.43,0.31,0.08,0.11,0.06,0.0,0.0,0.01,christy jenki brown,
-STAT,2300,2,Statistical Methods I,0.38,0.3,0.1,0.11,0.08,0.0,0.0,0.04,christy jenki brown,
-STAT,2300,3,Statistical Methods I,0.45,0.35,0.08,0.07,0.03,0.0,0.0,0.01,christy jenki brown,
-STAT,2300,4,Statistical Methods I,0.34,0.33,0.15,0.09,0.09,0.0,0.0,0.01, erwin walker,
-STAT,2300,5,Statistical Methods I,0.31,0.36,0.21,0.06,0.06,0.0,0.0,0.0, erwin walker,
-STAT,2300,6,Statistical Methods I,0.31,0.35,0.16,0.12,0.05,0.0,0.0,0.01,benjamin sharp,
-STAT,2300,7,Statistical Methods I,0.28,0.34,0.22,0.06,0.06,0.0,0.0,0.04,brook thaye russell,
-STAT,2300,8,Statistical Methods I,0.19,0.31,0.31,0.12,0.07,0.0,0.0,0.0, erwin walker,
-STAT,3090,1,Introductory Business Stats,0.06,0.41,0.26,0.03,0.21,0.0,0.0,0.03,janie caro mcdonald,
-STAT,3090,2,Introductory Business Stats,0.33,0.28,0.22,0.11,0.06,0.0,0.0,0.0,kara ail stasikelis,
-STAT,3090,3,Introductory Business Stats,0.14,0.17,0.43,0.09,0.06,0.0,0.0,0.11,laura jane shick,
-STAT,3090,4,Introductory Business Stats,0.15,0.38,0.21,0.15,0.1,0.0,0.0,0.0,gary fellers,
-STAT,3090,5,Introductory Business Stats,0.13,0.42,0.24,0.08,0.11,0.0,0.0,0.03,laura jane shick,
-STAT,3090,6,Introductory Business Stats,0.28,0.5,0.19,0.03,0.0,0.0,0.0,0.0,ellen hepfe breazel,
-STAT,3090,7,Introductory Business Stats,0.37,0.21,0.26,0.05,0.11,0.0,0.0,0.0,kara ail stasikelis,
-STAT,3090,8,Introductory Business Stats,0.16,0.42,0.21,0.11,0.05,0.0,0.0,0.05,christopher wilson,
-STAT,3090,9,Introductory Business Stats,0.33,0.26,0.23,0.03,0.15,0.0,0.0,0.0,gary fellers,
-STAT,3090,10,Introductory Business Stats,0.26,0.4,0.26,0.0,0.06,0.0,0.0,0.03,janie caro mcdonald,
-STAT,3090,11,Introductory Business Stats,0.22,0.36,0.22,0.19,0.0,0.0,0.0,0.0,ellen hepfe breazel,
-STAT,3090,12,Introductory Business Stats,0.26,0.36,0.13,0.08,0.1,0.0,0.0,0.08,laura jane shick,
-STAT,3090,13,Introductory Business Stats,0.16,0.26,0.42,0.16,0.0,0.0,0.0,0.0,janie caro mcdonald,
-STAT,3090,14,Introductory Business Stats,0.26,0.47,0.13,0.08,0.03,0.0,0.0,0.03,margaret mar wiecek,
-STAT,3090,15,Introductory Business Stats,0.11,0.47,0.32,0.0,0.05,0.0,0.0,0.05,emily marie nystrom,
-STAT,3090,16,Introductory Business Stats,0.11,0.37,0.32,0.11,0.11,0.0,0.0,0.0,laura jane shick,
-STAT,3090,17,Introductory Business Stats,0.0,0.47,0.26,0.0,0.11,0.0,0.0,0.16,tao yang,
-STAT,3090,18,Introductory Business Stats,0.36,0.31,0.23,0.03,0.05,0.0,0.0,0.03,gary fellers,
-STAT,3090,19,Introductory Business Stats,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,emily marie nystrom,
-STAT,3090,20,Introductory Business Stats,0.0,0.4,0.13,0.13,0.2,0.0,0.0,0.13,paul james cubre,
-STAT,3090,21,Introductory Business Stats,0.26,0.33,0.26,0.05,0.08,0.0,0.0,0.03,gary fellers,
-STAT,3090,22,Introductory Business Stats,0.14,0.29,0.29,0.09,0.14,0.0,0.0,0.06,janie caro mcdonald,
-STAT,3090,23,Introductory Business Stats,0.11,0.37,0.22,0.15,0.07,0.0,0.0,0.07,tao yang,
-STAT,3090,24,Introductory Business Stats,0.32,0.26,0.21,0.0,0.11,0.0,0.0,0.11,paul james cubre,
-STAT,3090,25,Introductory Business Stats,0.16,0.63,0.05,0.0,0.11,0.0,0.0,0.05,drew jared lipman,
-STAT,3090,26,Introductory Business Stats,0.11,0.16,0.32,0.21,0.11,0.0,0.0,0.11,christopher wilson,
-STAT,3300,1,Statistical Methods II,0.21,0.38,0.21,0.0,0.0,0.0,0.0,0.21,ros martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.44,0.31,0.06,0.06,0.06,0.0,0.0,0.06,julia lynn sharp,
-STAT,4110,1,Stat Mthds for Process Control,0.3,0.4,0.23,0.0,0.08,0.0,0.0,0.0,william bridges,
-STAT,4110,2,Stat Mthds for Process Control,0.44,0.25,0.16,0.09,0.06,0.0,0.0,0.0,patrick gerard,
-STAT,6020,1,Intro to Statistical Computing,0.57,0.14,0.14,0.0,0.0,0.0,0.0,0.14,julia lynn sharp,
-STAT,8010,1,Statistical Methods I,0.47,0.23,0.13,0.0,0.1,0.0,0.0,0.07,james rieck,
-STAT,8010,2,Statistical Methods I,0.26,0.42,0.06,0.0,0.16,0.0,0.0,0.1,james rieck,
-STAT,8010,3,Statistical Methods I,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,jun luo,
-STAT,8010,4,Statistical Methods I,0.29,0.57,0.04,0.0,0.07,0.0,0.0,0.04,julia lynn sharp,
-STAT,8020,1,Statistical Methods II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,8030,1,Regress & Least Squares Anlys,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,jun luo,
-STS,1010,1,Survey of S T S,0.49,0.49,0.0,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,
-STS,1010,2,Survey of S T S,0.56,0.42,0.03,0.0,0.0,0.0,0.0,0.0,philip randall,
-STS,1010,3,Survey of S T S,0.27,0.61,0.06,0.03,0.0,0.0,0.0,0.03,scott brame,
-STS,1010,5,Survey of S T S,0.58,0.36,0.03,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,
-STS,1010,6,Survey of S T S,0.32,0.5,0.09,0.03,0.03,0.0,0.0,0.03,sarah mae cooper,
-STS,1010,7,Survey of S T S,0.86,0.08,0.03,0.0,0.0,0.0,0.0,0.03,annah kamugiz amani,
-STS,1010,8,Survey of S T S,0.19,0.35,0.29,0.06,0.06,0.0,0.0,0.03,david charles foltz,
-STS,1010,9,Survey of S T S,0.47,0.25,0.17,0.03,0.0,0.0,0.0,0.08,allison ann hinds,
-STS,1010,10,Survey of S T S,0.49,0.26,0.11,0.06,0.03,0.0,0.0,0.06,megan no macalystre,
-THEA,2100,2,Theatre Appreciation,0.91,0.03,0.03,0.0,0.03,0.0,0.0,0.0,kerrie kath seymour,
-THEA,2100,3,Theatre Appreciation,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,2100,4,Theatre Appreciation,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
-THEA,2100,5,Theatre Appreciation,0.43,0.53,0.0,0.0,0.0,0.0,0.0,0.03,carol collins,
-THEA,2100,6,Theatre Appreciation,0.67,0.2,0.07,0.0,0.03,0.0,0.0,0.03,anthony penna,
-THEA,2100,7,Theatre Appreciation,0.52,0.39,0.1,0.0,0.0,0.0,0.0,0.0,jason adkins,
-THEA,2780,1,Acting I,0.69,0.08,0.0,0.08,0.15,0.0,0.0,0.0,kerrie kath seymour,
-THEA,2790,1,Theatre Practicum,0.5,0.13,0.13,0.0,0.0,0.0,0.0,0.25,matthew leckenbusch,
-THEA,3170,1,African-Amer Thea I,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,3760,1,Stage Directing I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richard st. peter,
-THEA,3980,2,Special Topics in Theatre,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
-THEA,4720,1,Improvisation,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,
-WFB,3000,1,Wildlife Biology,0.46,0.3,0.16,0.02,0.06,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3000,2,Wildlife Biology,0.46,0.32,0.19,0.04,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3010,1,Wildlife Biology Lab,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3010,2,Wildlife Biology Lab,0.53,0.24,0.18,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,
-WFB,4100,2,Wildlife Management Techniques,0.15,0.55,0.23,0.05,0.03,0.0,0.0,0.0,james davis,
-WFB,4440,1,Wildlife Damage Management,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,james davis,
-WFB,4500,1,Aquaculture,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,
-WFB,4930,1,Waterfowl Ecology & Mgt,0.33,0.58,0.04,0.0,0.0,0.0,0.0,0.04,richard ma kaminski,
-WFB,8180,1,Waterfowl Ecology & Mgt,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
-WS,1030,1,Women Global Perspec,0.68,0.24,0.06,0.0,0.0,0.0,0.0,0.03,saadiqa kumanyika,
-WS,1030,2,Women Global Perspec,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,
-WS,2300,1,Women and Leadership,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,diane perpich,
-WS,3010,1,Intro Women's Studies,0.54,0.31,0.09,0.06,0.0,0.0,0.0,0.0,elizabeth ros adams,
-WS,3010,2,Intro Women's Studies,0.46,0.4,0.09,0.03,0.0,0.0,0.0,0.03,elizabeth ros adams,
-YDP,3000,400,Youth Development in Society,0.58,0.05,0.21,0.0,0.16,0.0,0.0,0.0,barry garst,
-YDP,3050,400,Theory/Phil of Youth Dev Work,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1010,1,Survey of Art & Arch History I,0.5,0.35,0.11,0.0,0.01,0.0,0.0,0.04,beth ann lauritis,,AAH-1010,2015
+AAH,2050,1,Art History and Theory I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,beth ann lauritis,,AAH-2050,2015
+AAH,3050,1,Contemporary Art History,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,andrea feeser,,AAH-3050,2015
+ACCT,2010,1,Financial Accounting Concepts,0.11,0.23,0.26,0.11,0.13,0.0,0.0,0.17,philip maiberger,,ACCT-2010,2015
+ACCT,2010,2,Financial Accounting Concepts,0.13,0.4,0.3,0.06,0.0,0.0,0.0,0.11,philip maiberger,,ACCT-2010,2015
+ACCT,2010,3,Financial Accounting Concepts,0.41,0.23,0.13,0.05,0.03,0.0,0.0,0.15,lydia lan schleifer,,ACCT-2010,2015
+ACCT,2010,4,Financial Accounting Concepts,0.32,0.43,0.14,0.03,0.08,0.0,0.0,0.0,annieka philo,,ACCT-2010,2015
+ACCT,2010,5,Financial Accounting Concepts,0.26,0.24,0.13,0.08,0.11,0.0,0.0,0.18,lydia lan schleifer,,ACCT-2010,2015
+ACCT,2010,6,Financial Accounting Concepts,0.2,0.27,0.17,0.03,0.07,0.0,0.0,0.27,the estate  guffey,,ACCT-2010,2015
+ACCT,2010,7,Financial Accounting Concepts,0.33,0.43,0.1,0.12,0.0,0.0,0.0,0.02,annieka philo,,ACCT-2010,2015
+ACCT,2010,8,Financial Accounting Concepts,0.1,0.36,0.36,0.03,0.1,0.0,0.0,0.05,philip maiberger,,ACCT-2010,2015
+ACCT,2010,9,Financial Accounting Concepts,0.2,0.28,0.25,0.05,0.15,0.0,0.0,0.08,lydia lan schleifer,,ACCT-2010,2015
+ACCT,2010,10,Financial Accounting Concepts,0.41,0.32,0.14,0.05,0.09,0.0,0.0,0.0,annieka philo,,ACCT-2010,2015
+ACCT,2010,11,Financial Accounting Concepts,0.05,0.45,0.21,0.1,0.1,0.0,0.0,0.1,the estate  guffey,,ACCT-2010,2015
+ACCT,2010,12,Financial Accounting Concepts,0.21,0.37,0.15,0.03,0.09,0.0,0.0,0.16,james mil kohlmeyer,,ACCT-2010,2015
+ACCT,2010,13,Financial Accounting Concepts,0.13,0.53,0.16,0.0,0.08,0.0,0.0,0.11,mary ann  prater,,ACCT-2010,2015
+ACCT,2010,14,Financial Accounting Concepts,0.13,0.56,0.17,0.06,0.06,0.0,0.0,0.04,james mil kohlmeyer,,ACCT-2010,2015
+ACCT,2010,100,Fin Accounting Concepts (HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True,ACCT-2010,2015
+ACCT,2010,400,Financial Accounting Concepts,0.15,0.27,0.25,0.14,0.13,0.0,0.0,0.07,jeffrey mcmillan,,ACCT-2010,2015
+ACCT,2020,1,Managerial Accounting Concepts,0.14,0.14,0.24,0.12,0.07,0.0,0.0,0.29,henry anderson,,ACCT-2020,2015
+ACCT,2020,2,Managerial Accounting Concepts,0.23,0.34,0.21,0.02,0.09,0.0,0.0,0.11,henry anderson,,ACCT-2020,2015
+ACCT,2020,3,Managerial Accounting Concepts,0.26,0.32,0.19,0.08,0.09,0.0,0.0,0.06,holly rhiannio hawk,,ACCT-2020,2015
+ACCT,2020,4,Managerial Accounting Concepts,0.14,0.41,0.24,0.14,0.08,0.0,0.0,0.0,holly rhiannio hawk,,ACCT-2020,2015
+ACCT,2020,5,Managerial Accounting Concepts,0.37,0.28,0.28,0.02,0.06,0.0,0.0,0.0,tonya dionne smalls,,ACCT-2020,2015
+ACCT,2020,6,Managerial Accounting Concepts,0.37,0.24,0.18,0.02,0.12,0.0,0.0,0.08,tonya dionne smalls,,ACCT-2020,2015
+ACCT,2020,400,Managerial Accounting Concepts,0.18,0.15,0.18,0.09,0.08,0.0,0.0,0.31,henry anderson,,ACCT-2020,2015
+ACCT,3030,1,Cost Accounting,0.18,0.52,0.18,0.0,0.02,0.0,0.0,0.11,holly rhiannio hawk,,ACCT-3030,2015
+ACCT,3030,2,Cost Accounting,0.33,0.42,0.07,0.0,0.09,0.0,0.0,0.09,holly rhiannio hawk,,ACCT-3030,2015
+ACCT,3030,3,Cost Accounting,0.22,0.43,0.22,0.07,0.04,0.0,0.0,0.02,jace garrett,,ACCT-3030,2015
+ACCT,3030,4,Cost Accounting,0.16,0.6,0.16,0.0,0.0,0.0,0.0,0.09,jace garrett,,ACCT-3030,2015
+ACCT,3110,1,Intermediate Financial Acct I,0.18,0.42,0.24,0.03,0.11,0.0,0.0,0.03,terry daniel knause,,ACCT-3110,2015
+ACCT,3110,2,Intermediate Financial Acct I,0.35,0.26,0.21,0.06,0.06,0.0,0.0,0.06,terry daniel knause,,ACCT-3110,2015
+ACCT,3110,3,Intermediate Financial Acct I,0.23,0.38,0.15,0.1,0.1,0.0,0.0,0.03,terry daniel knause,,ACCT-3110,2015
+ACCT,3110,4,Intermediate Financial Acct I,0.33,0.4,0.18,0.05,0.03,0.0,0.0,0.03,terry daniel knause,,ACCT-3110,2015
+ACCT,3110,5,Intermediate Financial Acct I,0.23,0.46,0.21,0.05,0.03,0.0,0.0,0.03, russell madray,,ACCT-3110,2015
+ACCT,3110,400,Intermediate Financial Acct I,0.08,0.21,0.38,0.13,0.08,0.0,0.0,0.13, russell madray,,ACCT-3110,2015
+ACCT,3120,1,Intermediate Financial Acct II,0.07,0.21,0.32,0.21,0.14,0.0,0.0,0.04,brian todd carver,,ACCT-3120,2015
+ACCT,3120,2,Intermediate Financial Acct II,0.08,0.28,0.38,0.13,0.08,0.0,0.0,0.05,brian todd carver,,ACCT-3120,2015
+ACCT,3120,3,Intermediate Financial Acct II,0.15,0.28,0.38,0.1,0.05,0.0,0.0,0.03,jeremy micha vinson,,ACCT-3120,2015
+ACCT,3120,4,Intermediate Financial Acct II,0.13,0.45,0.34,0.05,0.03,0.0,0.0,0.0,jeremy micha vinson,,ACCT-3120,2015
+ACCT,3120,5,Intermediate Financial Acct II,0.13,0.38,0.38,0.05,0.05,0.0,0.0,0.0,jeremy micha vinson,,ACCT-3120,2015
+ACCT,3130,1,Intermediate Fin Acct III,0.18,0.33,0.39,0.03,0.03,0.0,0.0,0.03, russell madray,,ACCT-3130,2015
+ACCT,3130,2,Intermediate Fin Acct III,0.37,0.43,0.17,0.0,0.0,0.0,0.0,0.03, russell madray,,ACCT-3130,2015
+ACCT,3130,3,Intermediate Fin Acct III,0.2,0.35,0.28,0.13,0.0,0.0,0.0,0.05,james irving,,ACCT-3130,2015
+ACCT,3130,4,Intermediate Fin Acct III,0.26,0.36,0.28,0.08,0.03,0.0,0.0,0.0, russell madray,,ACCT-3130,2015
+ACCT,3220,1,Accounting Information Systems,0.09,0.26,0.23,0.11,0.06,0.0,0.0,0.26,philip maiberger,,ACCT-3220,2015
+ACCT,3220,2,Accounting Information Systems,0.27,0.32,0.3,0.11,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-3220,2015
+ACCT,3220,3,Accounting Information Systems,0.11,0.35,0.3,0.11,0.05,0.0,0.0,0.08,nancy lee harp,,ACCT-3220,2015
+ACCT,4040,1,Individual Taxation,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2015
+ACCT,4040,2,Individual Taxation,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2015
+ACCT,4080,1,Retire & Estate Plan,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,john hine,,ACCT-4080,2015
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.31,0.46,0.13,0.08,0.0,0.0,0.0,0.03,sally kathr widener,,ACCT-4100,2015
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,sally kathr widener,,ACCT-4100,2015
+ACCT,4150,1,Auditing,0.17,0.4,0.31,0.11,0.0,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2015
+ACCT,4150,2,Auditing,0.21,0.29,0.29,0.12,0.03,0.0,0.0,0.06,carl hollingsworth,,ACCT-4150,2015
+ACCT,8510,1,Tax Research,0.27,0.7,0.03,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2015
+ACCT,8510,2,Tax Research,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2015
+ACCT,8510,3,Tax Research,0.26,0.71,0.03,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2015
+ACCT,8530,1,Adv Acct Problems,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8530,2015
+ACCT,8530,2,Adv Acct Problems,0.39,0.42,0.13,0.0,0.0,0.0,0.0,0.06,ralph welton,,ACCT-8530,2015
+ACCT,8530,3,Adv Acct Problems,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8530,2015
+ACCT,8550,1,Gov't and Nonprofit Accounting,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2015
+ACCT,8550,2,Gov't and Nonprofit Accounting,0.58,0.35,0.08,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2015
+ACCT,8630,1,Forensics Analysis,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,james irving,,ACCT-8630,2015
+ACCT,8630,2,Forensics Analysis,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james irving,,ACCT-8630,2015
+ACCT,8630,601,Forensics Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,james irving,,ACCT-8630,2015
+ACCT,8650,1,Tax & Bus Decisions,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,judson jahn,,ACCT-8650,2015
+ACCT,8730,1,Intl/Spec Tax Topic,0.31,0.58,0.08,0.0,0.0,0.0,0.0,0.03,judson jahn,,ACCT-8730,2015
+AGED,1020,1,Freshman Seminar,0.65,0.12,0.06,0.06,0.0,0.0,0.0,0.12,catheri dibenedetto,,AGED-1020,2015
+AGED,2010,1,Intro to Agric Educ,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2010,2015
+AGED,2040,1,App Ag Calculations,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2040,2015
+AGED,3030,1,Ag Ed Mech Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-3030,2015
+AGED,3650,1,Multiculturalism in Agric Educ,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-3650,2015
+AGED,4000,1,Supervised Field Experience II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-4000,2015
+AGED,4010,1,Instr Methods Ag Ed,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,,AGED-4010,2015
+AGED,4030,1,Prin Adult/Ext Ed,0.76,0.19,0.0,0.05,0.0,0.0,0.0,0.0,kevin layfield,,AGED-4030,2015
+AGED,4230,400,Curriculum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,,AGED-4230,2015
+AGM,1010,1,Intro Ag Mech & Bus,0.73,0.16,0.1,0.02,0.0,0.0,0.0,0.0,hunter massey,,AGM-1010,2015
+AGM,2050,1,Prin of Fabrication,0.16,0.37,0.37,0.04,0.03,0.0,0.0,0.03,hunter massey,,AGM-2050,2015
+AGM,2060,1,Machinery Mgt,0.19,0.43,0.29,0.05,0.05,0.0,0.0,0.0,hunter massey,,AGM-2060,2015
+AGM,2210,1,Land Measurements,0.36,0.4,0.2,0.01,0.01,0.0,0.0,0.02,charles privette,,AGM-2210,2015
+AGM,3010,1,Soil Water Conserv,0.29,0.39,0.27,0.02,0.0,0.0,0.0,0.03,calvin sawyer,,AGM-3010,2015
+AGM,3190,1,Agribusiness Decision Analysis,0.26,0.43,0.23,0.06,0.0,0.0,0.0,0.02,lisha zhang,,AGM-3190,2015
+AGM,4050,1,Env Cont in Anim Str,0.08,0.35,0.38,0.15,0.0,0.0,0.0,0.03,john chastain,,AGM-4050,2015
+AGM,4060,1,Mech & Hydraulic Sys,0.33,0.5,0.12,0.02,0.0,0.0,0.0,0.02,ali bulent koc,,AGM-4060,2015
+AGM,4600,1,Electrical Systems,0.33,0.48,0.17,0.0,0.0,0.0,0.0,0.02,young han,,AGM-4600,2015
+AGRB,2020,1,Agricultural Economics,0.66,0.24,0.04,0.0,0.04,0.0,0.0,0.02,yuliya val bolotova,,AGRB-2020,2015
+AGRB,2020,2,Agricultural Economics,0.15,0.48,0.33,0.04,0.0,0.0,0.0,0.0,matthew jam fischer,,AGRB-2020,2015
+AGRB,2050,1,Agriculture and Society,0.36,0.44,0.14,0.06,0.0,0.0,0.0,0.0,michael vassalos,,AGRB-2050,2015
+AGRB,2570,1,"Nat Resources, Environ & Econ",0.23,0.3,0.23,0.11,0.05,0.0,0.0,0.09,david brian willis,,AGRB-2570,2015
+AGRB,3020,1,Economics of Farm Management,0.13,0.38,0.3,0.14,0.02,0.0,0.0,0.03,michael vassalos,,AGRB-3020,2015
+AGRB,3090,1,Econ of Agricultural Marketing,0.89,0.04,0.04,0.02,0.0,0.0,0.0,0.0,yuliya val bolotova,,AGRB-3090,2015
+AGRB,4120,1,Reg Econ Devel Theory & Policy,0.26,0.26,0.37,0.05,0.0,0.0,0.0,0.05,robert carey,,AGRB-4120,2015
+AGRB,4600,1,Agricultural Finance,0.38,0.46,0.0,0.0,0.08,0.0,0.0,0.08,scott mickey,,AGRB-4600,2015
+AL,3490,400,Principles of Coaching,0.4,0.48,0.08,0.04,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2015
+AL,3490,401,Principles of Coaching,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2015
+AL,3490,402,Principles of Coaching,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,,AL-3490,2015
+AL,3490,403,Principles of Coaching,0.72,0.12,0.08,0.04,0.0,0.0,0.0,0.04,clyde keith connor,,AL-3490,2015
+AL,3490,405,Principles of Coaching,0.67,0.21,0.04,0.0,0.0,0.0,0.0,0.08,clyde keith connor,,AL-3490,2015
+AL,3490,406,Principles of Coaching,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,edmond fry,,AL-3490,2015
+AL,3500,400,Sci Basis I/Ex Phy,0.32,0.12,0.36,0.08,0.04,0.0,0.0,0.08,michael godfrey,,AL-3500,2015
+AL,3500,401,Sci Basis I/Ex Phy,0.2,0.28,0.28,0.12,0.12,0.0,0.0,0.0,michael godfrey,,AL-3500,2015
+AL,3520,400,Kinesiology,0.47,0.33,0.13,0.07,0.0,0.0,0.0,0.0,isaac sean colbert,,AL-3520,2015
+AL,3530,400,Athletic Injuries,0.14,0.33,0.29,0.14,0.05,0.0,0.0,0.05,isaac sean colbert,,AL-3530,2015
+AL,3530,401,Athletic Injuries,0.19,0.38,0.13,0.19,0.0,0.0,0.0,0.13,isaac sean colbert,,AL-3530,2015
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.32,0.52,0.08,0.0,0.0,0.0,0.0,0.08,clyde keith connor,,AL-3600,2015
+AL,3610,400,Admin/Org of Athletic Programs,0.6,0.32,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2015
+AL,3610,401,Admin/Org of Athletic Programs,0.5,0.38,0.04,0.0,0.0,0.0,0.0,0.08,henry oates,,AL-3610,2015
+AL,3610,402,Admin/Org of Athletic Programs,0.75,0.13,0.04,0.04,0.0,0.0,0.0,0.04,henry oates,,AL-3610,2015
+AL,3620,400,Psychology of Coaching,0.31,0.31,0.19,0.08,0.08,0.0,0.0,0.04,natalie anne carter,,AL-3620,2015
+AL,3620,401,Psychology of Coaching,0.4,0.24,0.16,0.2,0.0,0.0,0.0,0.0,natalie anne carter,,AL-3620,2015
+AL,3620,402,Psychology of Coaching,0.44,0.22,0.28,0.0,0.06,0.0,0.0,0.0,natalie anne carter,,AL-3620,2015
+AL,3740,400,Coaching Football,0.63,0.17,0.04,0.04,0.04,0.0,0.0,0.08,edmond fry,,AL-3740,2015
+AL,3760,400,Coaching Strength/Conditioning,0.48,0.2,0.12,0.04,0.04,0.0,0.0,0.12,edmond fry,,AL-3760,2015
+AL,3760,401,Coaching Strength/Conditioning,0.58,0.17,0.08,0.04,0.04,0.0,0.0,0.08,edmond fry,,AL-3760,2015
+AL,4380,402,Coaching Women,0.43,0.22,0.3,0.04,0.0,0.0,0.0,0.0,deborah cadorette,,AL-4380,2015
+AL,8490,400,Athletic Leadership Dev,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8490,2015
+AL,8500,400,Principles Strength and Condit,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8500,2015
+ANTH,2010,1,Introduction to Anthropology,0.07,0.24,0.3,0.18,0.09,0.0,0.0,0.12,john coggeshall,,ANTH-2010,2015
+ANTH,2010,2,Introduction to Anthropology,0.07,0.41,0.39,0.02,0.0,0.0,0.0,0.1,john coggeshall,,ANTH-2010,2015
+ANTH,2010,3,Introduction to Anthropology,0.41,0.37,0.06,0.08,0.04,0.0,0.0,0.04,katherine weisensee,,ANTH-2010,2015
+ANTH,2010,4,Introduction to Anthropology,0.33,0.36,0.13,0.04,0.07,0.0,0.0,0.07,yi wu,,ANTH-2010,2015
+ANTH,2010,5,Introduction to Anthropology,0.48,0.28,0.07,0.04,0.07,0.0,0.0,0.07,lisa rapaport,,ANTH-2010,2015
+ANTH,3010,1,Cultural Anthropology,0.1,0.41,0.31,0.1,0.0,0.0,0.0,0.07,john coggeshall,,ANTH-3010,2015
+ANTH,3320,1,World Archaeology,0.09,0.32,0.29,0.06,0.03,0.0,0.0,0.21,melissa vogel,,ANTH-3320,2015
+ANTH,3510,1,Biological Anthropology,0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,katherine weisensee,,ANTH-3510,2015
+ANTH,3710,1,Language and Culture,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,yanhua zhang,,ANTH-3710,2015
+ANTH,4230,1,Women in the Developing World,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,melissa vogel,,ANTH-4230,2015
+ANTH,4990,1,Special Topics,0.53,0.2,0.27,0.0,0.0,0.0,0.0,0.0,yi wu,,ANTH-4990,2015
+ARCH,1010,1,Intro to Arch,0.46,0.36,0.02,0.0,0.03,0.0,0.0,0.13,sal hambright-belue,,ARCH-1010,2015
+ARCH,2040,1,Hist of Modern Arch,0.25,0.61,0.08,0.0,0.03,0.0,0.0,0.02,robert bruhns,,ARCH-2040,2015
+ARCH,2510,1,Arch Foundations I,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,robert silance,,ARCH-2510,2015
+ARCH,2510,3,Arch Foundations I,0.62,0.31,0.0,0.0,0.08,0.0,0.0,0.0,clarissa mendez,,ARCH-2510,2015
+ARCH,2510,4,Arch Foundations I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,james barker,,ARCH-2510,2015
+ARCH,2510,5,Arch Foundations I,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-2510,2015
+ARCH,2700,1,Structures I,0.54,0.33,0.08,0.0,0.0,0.0,0.0,0.04,robert john hogan,,ARCH-2700,2015
+ARCH,3510,1,Studio Clemson,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-3510,2015
+ARCH,3510,2,Studio Clemson,0.31,0.38,0.23,0.08,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-3510,2015
+ARCH,3510,3,Studio Clemson,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-3510,2015
+ARCH,3510,10,Studio Clemson,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,criss mills,,ARCH-3510,2015
+ARCH,4010,1,Architectural Portfolio,0.42,0.42,0.06,0.0,0.06,0.0,0.0,0.06,clarissa mendez,,ARCH-4010,2015
+ARCH,4010,2,Architectural Portfolio,0.61,0.29,0.04,0.0,0.0,0.0,0.0,0.07,clarissa mendez,,ARCH-4010,2015
+ARCH,6300,1,Technology and Arch,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,barbara lamprecht,,ARCH-6300,2015
+ARCH,6850,1,H/Th: Arch+Health,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-6850,2015
+ARCH,8100,1,Visualization I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-8100,2015
+ARCH,8210,1,Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-8210,2015
+ARCH,8510,1,Design Studio III,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-8510,2015
+ARCH,8510,3,Design Studio III,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8510,2015
+ARCH,8510,4,Design Studio III,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-8510,2015
+ARCH,8570,4,Design Studio V,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,raymond huff,,ARCH-8570,2015
+ARCH,8600,1,History/Theory I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8600,2015
+ARCH,8720,1,Production & Assemb,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-8720,2015
+ARCH,8790,2,Digtial Manufacturing Process,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,,ARCH-8790,2015
+ARCH,8810,1,Pro Practice Survey,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,,ARCH-8810,2015
+ARCH,8860,1,Health Facilities,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8860,2015
+ARCH,8890,1,Mentorship,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,,ARCH-8890,2015
+ARCH,8970,1,A+H Studio: Hospital,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8970,2015
+ART,1050,1,Foundation Drawing I,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,kathleen ann thum,,ART-1050,2015
+ART,1510,1,Foundations Art I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,gregory wi shelnutt,,ART-1510,2015
+ART,2070,1,Beginning Painting,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,mary jane king,,ART-2070,2015
+ART,2090,1,Beginning Sculpture,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabet cooke,,ART-2090,2015
+ART,2100,400,Art Appreciation,0.48,0.19,0.22,0.0,0.04,0.0,0.0,0.07,lydia jane dorsey,,ART-2100,2015
+ART,2100,401,Art Appreciation,0.59,0.22,0.0,0.04,0.04,0.0,0.0,0.11,lydia jane dorsey,,ART-2100,2015
+ART,2100,402,Art Appreciation,0.5,0.21,0.18,0.0,0.07,0.0,0.0,0.04,lydia jane dorsey,,ART-2100,2015
+ART,2100,403,Art Appreciation,0.46,0.31,0.04,0.0,0.12,0.0,0.0,0.08,lydia jane dorsey,,ART-2100,2015
+ART,2130,1,Begin Photography,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,haley brooke floyd,,ART-2130,2015
+ART,2170,1,Beginning Ceramics,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,en iwamura,,ART-2170,2015
+ART,8050,1,Visual Arts Sem I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,todd mcdonald,,ART-8050,2015
+AS,1090,2,Air Force Today I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,christopher mann,,AS-1090,2015
+AS,2090,2,Dev of Air Power I,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,christopher mann,,AS-2090,2015
+AS,2090,3,Dev of Air Power I,0.6,0.35,0.0,0.0,0.05,0.0,0.0,0.0,christopher mann,,AS-2090,2015
+ASL,1010,1,Am Sign Lang I,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-1010,2015
+ASL,1010,2,Am Sign Lang I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-1010,2015
+ASL,2010,1,Am Sign Lang II,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-2010,2015
+ASL,2010,2,Am Sign Lang II,0.26,0.42,0.32,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-2010,2015
+ASL,2020,1,Am Sign Lang II,0.31,0.38,0.31,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-2020,2015
+ASL,3150,1,Survey Interpreting,0.47,0.2,0.13,0.07,0.0,0.0,0.0,0.13,stephen fitzmaurice,,ASL-3150,2015
+ASTR,1010,1,Solar System Astronomy,0.41,0.36,0.1,0.03,0.03,0.0,0.0,0.08,phillip flower,,ASTR-1010,2015
+ASTR,1010,2,Solar System Astronomy,0.43,0.33,0.14,0.03,0.03,0.0,0.0,0.03,phillip flower,,ASTR-1010,2015
+ASTR,1010,3,Solar System Astronomy,0.32,0.45,0.1,0.04,0.05,0.0,0.0,0.04,phillip flower,,ASTR-1010,2015
+ASTR,1030,1,Solar Systm Astr Lab,0.6,0.2,0.04,0.0,0.12,0.0,0.0,0.04,mark leising,,ASTR-1030,2015
+ASTR,1030,2,Solar Systm Astr Lab,0.5,0.15,0.08,0.04,0.12,0.0,0.0,0.12,mark leising,,ASTR-1030,2015
+ASTR,1030,3,Solar Systm Astr Lab,0.52,0.2,0.08,0.0,0.12,0.0,0.0,0.08,mark leising,,ASTR-1030,2015
+ASTR,1030,4,Solar Systm Astr Lab,0.42,0.25,0.13,0.13,0.0,0.0,0.0,0.08,mark leising,,ASTR-1030,2015
+ASTR,1030,5,Solar Systm Astr Lab,0.5,0.23,0.08,0.04,0.08,0.0,0.0,0.08,mark leising,,ASTR-1030,2015
+ASTR,1030,6,Solar Systm Astr Lab,0.25,0.5,0.21,0.04,0.0,0.0,0.0,0.0,mark leising,,ASTR-1030,2015
+ASTR,1030,7,Solar Systm Astr Lab,0.19,0.42,0.15,0.12,0.04,0.0,0.0,0.08,mark leising,,ASTR-1030,2015
+ASTR,1030,8,Solar Systm Astr Lab,0.38,0.33,0.17,0.08,0.0,0.0,0.0,0.04,mark leising,,ASTR-1030,2015
+ASTR,1030,9,Solar Systm Astr Lab,0.24,0.48,0.12,0.0,0.04,0.0,0.0,0.12,mark leising,,ASTR-1030,2015
+ASTR,8100,1,Astroph I: Radiation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,marco ajello,,ASTR-8100,2015
+AUD,2800,1,Sound Reinforcement,0.0,0.33,0.42,0.17,0.08,0.0,0.0,0.0,kenneth moore,,AUD-2800,2015
+AUE,8260,5,Vehicle Diagnostics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8260,2015
+AUE,8270,5,Auto Cntrl Sys Des,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8270,2015
+AUE,8280,79,Driveline/Powertrain,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,zoran filipi,,AUE-8280,2015
+AUE,8330,30,Auto Manuf Proc Devl,0.35,0.62,0.03,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-8330,2015
+AUE,8670,1,Veh Manuf Proc I,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,michael mears,,AUE-8670,2015
+AUE,8800,2,Vehicle Project Mngt,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,,AUE-8800,2015
+AUE,8810,3,Automotive Systems Overview,0.22,0.7,0.09,0.0,0.0,0.0,0.0,0.0,paul venhovens,,AUE-8810,2015
+AUE,8870,8,Meth Vehicle Testing,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,,AUE-8870,2015
+AUE,8930,13,Engine Analysis,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8930,2015
+AUE,8930,14,Automotive Composites,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,,AUE-8930,2015
+AUE,8930,17,Hybrids,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8930,2015
+AUE,8930,18,Adv IC Engine Concept,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-8930,2015
+AUE,8930,78,Applied Dynamics,0.5,0.0,0.33,0.0,0.17,0.0,0.0,0.0,imtiaz ul haque,,AUE-8930,2015
+AVS,1000,1,Orientation to AVS,0.83,0.09,0.01,0.01,0.03,0.0,0.0,0.03,johanna joh lascano,,AVS-1000,2015
+AVS,1500,1,Intro Animal Science,0.59,0.27,0.05,0.02,0.03,0.0,0.0,0.04,heather walker dunn,,AVS-1500,2015
+AVS,1510,1,Intro Ani Sci Lab,0.7,0.26,0.0,0.0,0.0,0.0,0.0,0.04,anna rebecca baxley,,AVS-1510,2015
+AVS,1510,2,Intro Ani Sci Lab,0.52,0.4,0.04,0.04,0.0,0.0,0.0,0.0,anna rebecca baxley,,AVS-1510,2015
+AVS,1510,3,Intro Ani Sci Lab,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,richelle lor miller,,AVS-1510,2015
+AVS,1510,4,Intro Ani Sci Lab,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-1510,2015
+AVS,1510,5,Intro Ani Sci Lab,0.36,0.56,0.0,0.0,0.0,0.0,0.0,0.08,anna rebecca baxley,,AVS-1510,2015
+AVS,1510,6,Intro Ani Sci Lab,0.52,0.36,0.04,0.0,0.0,0.0,0.0,0.08,heather walker dunn,,AVS-1510,2015
+AVS,1510,7,Intro Ani Sci Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,richelle lor miller,,AVS-1510,2015
+AVS,2010,1,Poultry Techniques,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-2010,2015
+AVS,2020,1,CAFLS Plus,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,thomas scott,,AVS-2020,2015
+AVS,2030,1,Dairy Sci Techniques,0.93,0.02,0.0,0.0,0.02,0.0,0.0,0.02,heather walker dunn,,AVS-2030,2015
+AVS,2040,1,Horse Care Techniques,0.57,0.36,0.03,0.0,0.03,0.0,0.0,0.0,kristine lan vernon,,AVS-2040,2015
+AVS,2110,1,Meat Processing Techniques,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-2110,2015
+AVS,3010,1,Anat & Phys Dom Ani,0.45,0.2,0.18,0.13,0.04,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2015
+AVS,3010,400,Anat & Phys Dom Ani,0.36,0.36,0.14,0.14,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2015
+AVS,3020,1,Livestk Sel Eval I,0.61,0.34,0.02,0.0,0.0,0.0,0.0,0.02,richelle lor miller,,AVS-3020,2015
+AVS,3090,1,Equine Evaluation,0.5,0.32,0.11,0.04,0.0,0.0,0.0,0.04,kristine lan vernon,,AVS-3090,2015
+AVS,3100,2,Animal Health,0.65,0.19,0.07,0.02,0.02,0.0,0.0,0.06,thomas scott,,AVS-3100,2015
+AVS,3700,1,Principles of Animal Nutrition,0.17,0.22,0.25,0.23,0.07,0.0,0.0,0.07,nathan long,,AVS-3700,2015
+AVS,3750,1,Applied Animal Nutrition,0.18,0.53,0.28,0.03,0.0,0.0,0.0,0.0,gustavo jos lascano,,AVS-3750,2015
+AVS,4000,1,AVS Professional Development,0.66,0.2,0.1,0.0,0.05,0.0,0.0,0.0,johanna joh lascano,,AVS-4000,2015
+AVS,4060,1,Seminars & Related Topics,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2015
+AVS,4060,2,Seminars & Related Topics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2015
+AVS,4150,1,Contemporary Issues in AVS,0.12,0.42,0.36,0.03,0.03,0.0,0.0,0.05,peter skewes,,AVS-4150,2015
+AVS,4160,1,Equine Exercise Phys,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,kristine lan vernon,,AVS-4160,2015
+AVS,4530,1,Animal Reproduction,0.27,0.38,0.27,0.04,0.04,0.0,0.0,0.0,tiffany wilmoth,,AVS-4530,2015
+AVS,4700,1,Animal Genetics,0.47,0.21,0.22,0.05,0.05,0.0,0.0,0.0,meenakshi mukherjee,,AVS-4700,2015
+BCHM,1030,1,Careers in Bioch/Gen,0.88,0.03,0.01,0.04,0.01,0.0,0.0,0.02,alison starr-moss,,BCHM-1030,2015
+BCHM,3010,1,Molecular Biochem,0.26,0.21,0.21,0.16,0.16,0.0,0.0,0.0,cheryl ingram-smith,,BCHM-3010,2015
+BCHM,3050,1,Essen Elements Bioch,0.25,0.34,0.22,0.06,0.05,0.0,0.0,0.08,srik chandrasekaran,,BCHM-3050,2015
+BCHM,3050,2,Essen Elements Bioch,0.26,0.34,0.25,0.12,0.02,0.0,0.0,0.01,srik chandrasekaran,,BCHM-3050,2015
+BCHM,3050,3,Essen Elements Bioch,0.28,0.37,0.11,0.06,0.07,0.0,0.0,0.11,srik chandrasekaran,,BCHM-3050,2015
+BCHM,4060,1,Physiological Chem,0.68,0.19,0.03,0.03,0.03,0.0,0.0,0.03,james ro strickland,,BCHM-4060,2015
+BCHM,4310,1,Physical Approach to Biochem,0.25,0.34,0.32,0.02,0.0,0.0,0.0,0.07,weiguo cao,,BCHM-4310,2015
+BCHM,4310,2,Phys App to Bioch (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True,BCHM-4310,2015
+BCHM,4330,1,General Biochemistry Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,,BCHM-4330,2015
+BCHM,4330,2,General Biochemistry Lab I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,weiguo cao,,BCHM-4330,2015
+BCHM,4330,3,General Biochemistry Lab I,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,,BCHM-4330,2015
+BCHM,4330,4,General Biochemistry Lab I,0.6,0.1,0.1,0.0,0.0,0.0,0.0,0.2,weiguo cao,,BCHM-4330,2015
+BCHM,4400,1,Bioinformatics,0.74,0.08,0.03,0.08,0.0,0.0,0.0,0.08,frank alexan feltus,,BCHM-4400,2015
+BCHM,4900,7,C-MED,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,michael glen sehorn,,BCHM-4900,2015
+BCHM,8140,1,Advanced Biochemistry,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,kerry smith,,BCHM-8140,2015
+BE,2120,1,Fundamentals of Biosys Engr,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,caye marie drapcho,,BE-2120,2015
+BE,3200,1,Principles & Prac of Geomatics,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-3200,2015
+BE,4100,1,Biological Kinetics,0.44,0.32,0.24,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4100,2015
+BE,4150,1,Instr & Control for Biosys Eng,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,yi zheng,,BE-4150,2015
+BE,4280,1,Biochem Engr,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4280,2015
+BE,4740,1,B E Design/Proj Mgt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-4740,2015
+BE,4750,1,B E Capstone Design,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4750,2015
+BIOE,1010,1,Biol for Bioengr,0.65,0.24,0.0,0.06,0.0,0.0,0.0,0.06,vladimir vla reukov,,BIOE-1010,2015
+BIOE,2010,1,Intro Biomed Engr,0.52,0.39,0.08,0.0,0.0,0.0,0.0,0.02,charles webb,,BIOE-2010,2015
+BIOE,2010,2,Intro Biomed Engr,0.38,0.58,0.01,0.0,0.0,0.0,0.0,0.03,vladimir vla reukov,,BIOE-2010,2015
+BIOE,3020,1,Biomaterials,0.44,0.34,0.1,0.06,0.02,0.0,0.0,0.04,alexey ale vertegel,,BIOE-3020,2015
+BIOE,3200,1,Biomechanics,0.65,0.31,0.02,0.02,0.0,0.0,0.0,0.02,lisa benson,,BIOE-3200,2015
+BIOE,3210,1,Biofluid Mechanics,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,zhi gao,,BIOE-3210,2015
+BIOE,3700,1,Bioinst & Imaging,0.74,0.21,0.03,0.02,0.0,0.0,0.0,0.0,david kwartowitz,,BIOE-3700,2015
+BIOE,4010,1,Bioengineering Design Theory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4010,2015
+BIOE,4030,1,Applied Bio E Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,,BIOE-4030,2015
+BIOE,4120,1,Orthopaedic Engr and Pathology,0.56,0.33,0.04,0.0,0.0,0.0,0.0,0.07,melinda harman,,BIOE-4120,2015
+BIOE,4400,1,Biopharmaceutical Engineering,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,sarah harcum,,BIOE-4400,2015
+BIOE,6120,1,Orthopaedic Engr & Pathology,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,melinda harman,,BIOE-6120,2015
+BIOE,8010,1,Bio Materials,0.36,0.54,0.07,0.04,0.0,0.0,0.0,0.0,robert latour,,BIOE-8010,2015
+BIOE,8160,1,BioE Professional Development,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,martine laberge,,BIOE-8160,2015
+BIOE,8200,1,Structl Biomechanics,0.78,0.19,0.0,0.0,0.0,0.0,0.0,0.04,hai yao,,BIOE-8200,2015
+BIOE,8500,4,Cardiovascular Biomechanics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,,BIOE-8500,2015
+BIOL,1010,1,Frontiers in Biology I,0.71,0.19,0.06,0.02,0.01,0.0,0.0,0.01,robert edwa ballard,,BIOL-1010,2015
+BIOL,1010,2,Frontiers in Biology I,0.67,0.21,0.05,0.05,0.02,0.0,0.0,0.01,thomas hughes,,BIOL-1010,2015
+BIOL,1010,3,Frontiers in Biology I,0.67,0.25,0.02,0.01,0.04,0.0,0.0,0.01,joseph paul thames,,BIOL-1010,2015
+BIOL,1030,1,General Biology I,0.21,0.23,0.24,0.14,0.09,0.0,0.0,0.09,nora espinoza,,BIOL-1030,2015
+BIOL,1030,3,General Biology I,0.26,0.32,0.26,0.07,0.04,0.0,0.0,0.05,kristi ja whitehead,,BIOL-1030,2015
+BIOL,1030,4,General Biology I,0.29,0.3,0.21,0.06,0.04,0.0,0.0,0.1,william surver,,BIOL-1030,2015
+BIOL,1030,5,General Biology I,0.19,0.23,0.35,0.12,0.05,0.0,0.0,0.06,salvatore sparace,,BIOL-1030,2015
+BIOL,1030,6,General Biology I (HON),0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True,BIOL-1030,2015
+BIOL,1050,1,General Biology Lab I,0.46,0.33,0.13,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,2,General Biology Lab I,0.17,0.3,0.35,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,3,General Biology Lab I,0.17,0.35,0.17,0.09,0.04,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,4,General Biology Lab I,0.33,0.17,0.21,0.13,0.08,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,5,General Biology Lab I,0.13,0.42,0.33,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,6,General Biology Lab I,0.25,0.42,0.21,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,7,General Biology Lab I,0.25,0.29,0.21,0.21,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,8,General Biology Lab I,0.25,0.21,0.29,0.04,0.08,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,9,General Biology Lab I,0.22,0.48,0.13,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,10,General Biology Lab I,0.29,0.5,0.08,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,11,General Biology Lab I,0.08,0.46,0.29,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,12,General Biology Lab I,0.5,0.25,0.17,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,13,General Biology Lab I,0.24,0.28,0.28,0.12,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,14,General Biology Lab I,0.17,0.42,0.25,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,15,General Biology Lab I,0.29,0.5,0.08,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,16,General Biology Lab I,0.29,0.42,0.17,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,17,General Biology Lab I,0.38,0.42,0.04,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,18,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,19,General Biology Lab I,0.17,0.42,0.38,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,20,General Biology Lab I,0.22,0.57,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,21,General Biology Lab I,0.13,0.38,0.21,0.08,0.08,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,25,General Biology Lab I,0.54,0.42,0.0,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,26,General Biology Lab I,0.38,0.29,0.17,0.0,0.08,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,28,General Biology Lab I,0.63,0.21,0.04,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,29,General Biology Lab I,0.29,0.42,0.25,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,30,General Biology Lab I,0.29,0.5,0.08,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,31,General Biology Lab I,0.17,0.33,0.29,0.04,0.08,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,32,General Biology Lab I,0.26,0.43,0.09,0.04,0.0,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,33,General Biology Lab I,0.29,0.54,0.0,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,34,General Biology Lab I,0.46,0.17,0.21,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,35,General Biology Lab I,0.38,0.42,0.17,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,36,General Biology Lab I,0.08,0.29,0.42,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,37,General Biology Lab I,0.17,0.54,0.17,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,38,General Biology Lab I,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,39,General Biology Lab I,0.25,0.33,0.25,0.04,0.0,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,40,General Biology Lab I,0.17,0.5,0.25,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,41,General Biology Lab I,0.13,0.54,0.17,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,42,General Biology Lab I,0.26,0.48,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,43,General Biology Lab I,0.04,0.26,0.35,0.13,0.17,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,44,General Biology Lab I,0.22,0.26,0.22,0.13,0.09,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,47,General Biology Lab I,0.17,0.38,0.21,0.08,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1050,48,General Biology Lab I,0.06,0.35,0.29,0.06,0.18,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1050,2015
+BIOL,1090,1,Intro to Life Sci,0.77,0.21,0.02,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,,BIOL-1090,2015
+BIOL,1100,1,Principles of Biology I,0.21,0.33,0.29,0.07,0.03,0.0,0.0,0.07,robert kosinski,,BIOL-1100,2015
+BIOL,1100,2,Principles of Biology I,0.19,0.46,0.19,0.06,0.02,0.0,0.0,0.08,dylan dittrich-reed,,BIOL-1100,2015
+BIOL,1100,4,Prin of Biology I (HON),0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True,BIOL-1100,2015
+BIOL,1200,1,Biological Inq Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,2,Biological Inq Lab,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,3,Biological Inq Lab,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,4,Biological Inq Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,6,Biological Inq Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,7,Biological Inq Lab,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,11,Biological Inq Lab,0.7,0.2,0.0,0.05,0.0,0.0,0.0,0.05, christine minor,,BIOL-1200,2015
+BIOL,1200,12,Biological Inq Lab,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,14,Biological Inq Lab,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1230,1,Keys to Human Biol,0.21,0.4,0.26,0.09,0.03,0.0,0.0,0.01, christine minor,,BIOL-1230,2015
+BIOL,1230,2,Keys to Human Biol,0.23,0.47,0.24,0.03,0.02,0.0,0.0,0.02, christine minor,,BIOL-1230,2015
+BIOL,2000,3,Biology in the News,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-2000,2015
+BIOL,2000,7,Biology in the News,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,,BIOL-2000,2015
+BIOL,2040,1,"Environ, Energy and Society",0.53,0.19,0.09,0.09,0.03,0.0,0.0,0.08,john jenkins hains,,BIOL-2040,2015
+BIOL,2220,1,Human Anat and Physiology I,0.19,0.35,0.24,0.09,0.07,0.0,0.0,0.07,john cummings,,BIOL-2220,2015
+BIOL,2220,2,Human Anat and Physiology I,0.24,0.3,0.21,0.11,0.1,0.0,0.0,0.05,john cummings,,BIOL-2220,2015
+BIOL,3030,1,Vertebrate Biology,0.27,0.31,0.17,0.15,0.04,0.0,0.0,0.05,richard blob,,BIOL-3030,2015
+BIOL,3030,2,Vertebrate Biology (HON),0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,richard blob,True,BIOL-3030,2015
+BIOL,3040,1,Biology of Plants,0.29,0.36,0.19,0.09,0.06,0.0,0.0,0.03,saara dewalt,,BIOL-3040,2015
+BIOL,3070,1,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2015
+BIOL,3070,2,Vertebrate Biology Lab,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2015
+BIOL,3070,3,Vertebrate Biology Lab,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2015
+BIOL,3070,4,Vertebrate Biology Lab,0.38,0.52,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2015
+BIOL,3070,5,Vertebrate Biology Lab,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2015
+BIOL,3070,7,Vertebrate Biology Lab,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2015
+BIOL,3070,8,Vertebrate Biology Lab,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2015
+BIOL,3070,9,Vertebrate Biology Lab,0.38,0.38,0.14,0.05,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2015
+BIOL,3070,10,Vertebrate Biology Lab,0.71,0.24,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2015
+BIOL,3070,11,Vertebrate Biology Lab,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2015
+BIOL,3070,12,Vertebrate Biology Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2015
+BIOL,3070,13,Vertebrate Biology Lab,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2015
+BIOL,3080,1,Biology of Plants Practicum,0.24,0.29,0.35,0.06,0.06,0.0,0.0,0.0,saara dewalt,,BIOL-3080,2015
+BIOL,3080,2,Biology of Plants Practicum,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,saara dewalt,,BIOL-3080,2015
+BIOL,3080,3,Biology of Plants Practicum,0.4,0.3,0.25,0.0,0.0,0.0,0.0,0.05,saara dewalt,,BIOL-3080,2015
+BIOL,3080,4,Biology of Plants Practicum,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,saara dewalt,,BIOL-3080,2015
+BIOL,3150,1,Functional Human Anatomy,0.25,0.49,0.18,0.04,0.02,0.0,0.0,0.03,tamara mcnutt-scott,,BIOL-3150,2015
+BIOL,3200,1,Field Botany,0.2,0.18,0.3,0.2,0.02,0.0,0.0,0.1,robert edwa ballard,,BIOL-3200,2015
+BIOL,3350,1,Evolutionary Biology,0.24,0.26,0.18,0.13,0.09,0.0,0.0,0.11,lisa rapaport,,BIOL-3350,2015
+BIOL,3510,1,Biological Anthropology,0.46,0.38,0.08,0.08,0.0,0.0,0.0,0.0,katherine weisensee,,BIOL-3510,2015
+BIOL,4140,1,Basic Immunology,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,yanzhang wei,,BIOL-4140,2015
+BIOL,4200,1,Neurobiology,0.29,0.28,0.16,0.03,0.01,0.0,0.0,0.22,david feliciano,,BIOL-4200,2015
+BIOL,4200,2,Neurobiology (HON),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,True,BIOL-4200,2015
+BIOL,4250,1,Introductory Mycology,0.6,0.1,0.0,0.2,0.1,0.0,0.0,0.0,julia loui kerrigan,,BIOL-4250,2015
+BIOL,4340,1,Biological Chem Lab Techniques,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2015
+BIOL,4340,2,Biological Chem Lab Techniques,0.45,0.27,0.0,0.27,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2015
+BIOL,4340,3,Biological Chem Lab Techniques,0.23,0.31,0.15,0.31,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2015
+BIOL,4410,1,Ecology,0.18,0.38,0.28,0.08,0.01,0.0,0.0,0.07,david tonkyn,,BIOL-4410,2015
+BIOL,4410,2,Ecology (HON),0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,david tonkyn,True,BIOL-4410,2015
+BIOL,4430,1,Freshwater Ecology,0.63,0.22,0.1,0.0,0.0,0.0,0.0,0.05,john jenkins hains,,BIOL-4430,2015
+BIOL,4450,1,Ecology Laboratory (Lec),0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,david tonkyn,,BIOL-4450,2015
+BIOL,4450,3,Ecology Laboratory (Lec),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,,BIOL-4450,2015
+BIOL,4450,4,Ecology Laboratory (Lec),0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david tonkyn,,BIOL-4450,2015
+BIOL,4610,1,Cell Biology,0.29,0.3,0.29,0.07,0.02,0.0,0.0,0.03,lesly temesvari,,BIOL-4610,2015
+BIOL,4610,2,Cell Biology (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True,BIOL-4610,2015
+BIOL,4610,3,Cell Biology,0.33,0.29,0.28,0.04,0.02,0.0,0.0,0.04,susan carol chapman,,BIOL-4610,2015
+BIOL,4610,4,Cell Biology (HON),0.24,0.57,0.19,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True,BIOL-4610,2015
+BIOL,4620,1,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,2,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,3,Cell Biology Lab (Lec),0.53,0.2,0.27,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,4,Cell Biology Lab (Lec),0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,5,Cell Biology Lab (Lec),0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,6,Cell Biology Lab (Lec),0.71,0.18,0.06,0.0,0.0,0.0,0.0,0.06,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,7,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,8,Cell Biology Lab (Lec),0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,9,Cell Biology Lab (Lec),0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,10,Cell Biology Lab (Lec),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,11,Cell Biology Lab (Lec),0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,xianzhong yu,,BIOL-4620,2015
+BIOL,4670,1,Principles of Hematology,0.91,0.0,0.05,0.0,0.0,0.0,0.0,0.05,vincent gallicchio,,BIOL-4670,2015
+BIOL,4750,1,Comparative Physiology,0.49,0.32,0.05,0.02,0.0,0.0,0.0,0.12,michael sears,,BIOL-4750,2015
+BIOL,4930,2,Senior Seminar,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,wen chen,,BIOL-4930,2015
+BIOL,4930,4,Senior Seminar,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,juan baeza migueles,,BIOL-4930,2015
+BIOL,6030,1,Intro to Applied Genomics,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vincent pa richards,,BIOL-6030,2015
+BIOL,8400,1,Understanding Biological Inq,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,dylan dittrich-reed,,BIOL-8400,2015
+BIOL,8420,1,Understand Cellular Processes,0.73,0.21,0.0,0.0,0.02,0.0,0.0,0.04,david feliciano,,BIOL-8420,2015
+BIOL,8440,1,Understanding the Human Body,0.47,0.34,0.1,0.01,0.04,0.0,0.0,0.03,william baldwin,,BIOL-8440,2015
+BUS,1010,1,Business Foundations,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2015
+BUS,1010,2,Business Foundations,0.27,0.46,0.24,0.03,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2015
+BUS,1010,3,Business Foundations,0.43,0.27,0.14,0.03,0.05,0.0,0.0,0.08,william ern tumblin,,BUS-1010,2015
+BUS,1010,4,Business Foundations,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2015
+BUS,1010,5,Business Foundations,0.39,0.32,0.16,0.03,0.05,0.0,0.0,0.05,donna mccubbin,,BUS-1010,2015
+BUS,1010,6,Business Foundations,0.47,0.34,0.16,0.03,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2015
+BUS,1010,7,Business Foundations,0.02,0.45,0.38,0.02,0.07,0.0,0.0,0.05,donna mccubbin,,BUS-1010,2015
+BUS,1010,8,Business Foundations,0.3,0.35,0.21,0.02,0.0,0.0,0.0,0.12,donna mccubbin,,BUS-1010,2015
+BUS,1010,9,Business Foundations,0.16,0.44,0.21,0.05,0.07,0.0,0.0,0.07,donna mccubbin,,BUS-1010,2015
+BUS,1010,10,Business Foundations,0.19,0.49,0.19,0.02,0.09,0.0,0.0,0.02,william ern tumblin,,BUS-1010,2015
+BUS,1010,11,Business Foundations,0.21,0.74,0.0,0.05,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2015
+BUS,1010,12,Business Foundations,0.42,0.32,0.11,0.05,0.05,0.0,0.0,0.05,sandy edge,,BUS-1010,2015
+BUS,1010,13,Business Foundations,0.21,0.68,0.05,0.0,0.0,0.0,0.0,0.05,sandy edge,,BUS-1010,2015
+BUS,1010,14,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2015
+BUS,1010,15,Business Foundations,0.32,0.42,0.21,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2015
+BUS,1010,16,Business Foundations,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2015
+BUS,1010,17,Business Foundations,0.16,0.42,0.26,0.0,0.05,0.0,0.0,0.11,william ern tumblin,,BUS-1010,2015
+BUS,1010,18,Business Foundations,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2015
+BUS,1010,19,Business Foundations,0.11,0.28,0.39,0.11,0.06,0.0,0.0,0.06,william ern tumblin,,BUS-1010,2015
+BUS,1010,20,Business Foundations,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,william ern tumblin,,BUS-1010,2015
+BUS,1010,27,Business Foundations,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2015
+BUS,1010,28,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2015
+CE,2010,2,Statics,0.41,0.19,0.14,0.14,0.1,0.0,0.0,0.02,qiushi chen,,CE-2010,2015
+CE,2010,3,Statics,0.48,0.11,0.27,0.07,0.0,0.0,0.0,0.07,brandon ross,,CE-2010,2015
+CE,2010,4,Statics,0.11,0.32,0.09,0.05,0.11,0.0,0.0,0.32,melissa sternhagen,,CE-2010,2015
+CE,2010,5,Statics,0.36,0.21,0.17,0.05,0.07,0.0,0.0,0.14,melissa sternhagen,,CE-2010,2015
+CE,2010,6,Statics,0.46,0.17,0.19,0.02,0.07,0.0,0.0,0.09,mahmoodreza soltani,,CE-2010,2015
+CE,2010,7,Statics,0.23,0.45,0.13,0.06,0.0,0.0,0.0,0.13,weichiang pang,,CE-2010,2015
+CE,2060,1,Structural Mechanics,0.07,0.39,0.34,0.1,0.02,0.0,0.0,0.07,bryant nielson,,CE-2060,2015
+CE,2080,2,Dynamics,0.04,0.3,0.26,0.11,0.04,0.0,0.0,0.26,melissa sternhagen,,CE-2080,2015
+CE,2080,4,Dynamics,0.04,0.19,0.38,0.15,0.08,0.0,0.0,0.15,melissa sternhagen,,CE-2080,2015
+CE,2550,1,Geomatics,0.32,0.47,0.19,0.0,0.0,0.0,0.0,0.02,wayne sarasua,,CE-2550,2015
+CE,2550,2,Geomatics,0.44,0.31,0.18,0.03,0.05,0.0,0.0,0.0,wayne sarasua,,CE-2550,2015
+CE,3010,1,Structural Analysis,0.21,0.59,0.12,0.06,0.03,0.0,0.0,0.0,stephen csernak,,CE-3010,2015
+CE,3010,2,Structural Analysis,0.28,0.23,0.38,0.08,0.03,0.0,0.0,0.0,bryant nielson,,CE-3010,2015
+CE,3110,1,Transportation Engr,0.71,0.18,0.07,0.02,0.02,0.0,0.0,0.0,jennifer ogle,,CE-3110,2015
+CE,3210,1,Geotechnical Engineering,0.38,0.38,0.18,0.0,0.05,0.0,0.0,0.0,qiushi chen,,CE-3210,2015
+CE,3310,1,Constr Engr & Mgmnt,0.41,0.37,0.12,0.06,0.04,0.0,0.0,0.0,james burati,,CE-3310,2015
+CE,3410,1,Intro to Fluid Mech,0.13,0.6,0.24,0.04,0.0,0.0,0.0,0.0,nigel gregory kaye,,CE-3410,2015
+CE,3410,2,Intro to Fluid Mech,0.14,0.33,0.39,0.07,0.02,0.0,0.0,0.05,abdul khan,,CE-3410,2015
+CE,3420,1,Hydraulics & Hydro,0.29,0.47,0.12,0.08,0.02,0.0,0.0,0.02,ashok mishra,,CE-3420,2015
+CE,3510,1,Civil Engineering Materials,0.68,0.28,0.03,0.03,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,,CE-3510,2015
+CE,3510,2,Civil Engineering Materials,0.54,0.29,0.13,0.02,0.02,0.0,0.0,0.0,ami esmaeilpoursaee,,CE-3510,2015
+CE,3520,1,Econ Eval of Proj,0.36,0.22,0.09,0.13,0.11,0.0,0.0,0.09,yongxi huang,,CE-3520,2015
+CE,3530,1,Professional Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-3530,2015
+CE,4010,1,Matrix Str Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,,CE-4010,2015
+CE,4020,1,Reinfor Con Design,0.44,0.38,0.16,0.03,0.0,0.0,0.0,0.0,brandon ross,,CE-4020,2015
+CE,4060,1,Struct Steel Design,0.35,0.28,0.28,0.05,0.05,0.0,0.0,0.0,stephen csernak,,CE-4060,2015
+CE,4070,1,Wood Design,0.13,0.4,0.13,0.0,0.07,0.0,0.0,0.27,weichiang pang,,CE-4070,2015
+CE,4100,1,Traffic Engr Oper,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,yongxi huang,,CE-4100,2015
+CE,4210,1,Geotechnical Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,,CE-4210,2015
+CE,4240,1,Earth Slopes & Struc,0.29,0.29,0.24,0.05,0.05,0.0,0.0,0.1,nadara ravichandran,,CE-4240,2015
+CE,4370,1,Sustainable Energy Proj Design,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,leidy klotz,,CE-4370,2015
+CE,4390,1,Con Eqpmt Sel & Main,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,james burati,,CE-4390,2015
+CE,4560,1,Pave Design & Constr,0.29,0.48,0.17,0.05,0.02,0.0,0.0,0.0,bradley putman,,CE-4560,2015
+CE,4590,1,Capstone Design Proj,0.69,0.26,0.03,0.0,0.0,0.0,0.0,0.03,stephen csernak,,CE-4590,2015
+CE,4910,1,BIM in Construction Management,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4910,2015
+CE,6010,1,Matrix Str Analysis,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,,CE-6010,2015
+CE,6070,1,Wood Design,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-6070,2015
+CE,6100,1,Traffic Engr Oper,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,yongxi huang,,CE-6100,2015
+CE,6240,1,Earth Slopes & Struc,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-6240,2015
+CE,6560,1,Pavement Des & Const,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,bradley putman,,CE-6560,2015
+CE,6910,1,BIM in Construction Management,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-6910,2015
+CE,8020,1,Adv R/C Design,0.23,0.58,0.19,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,,CE-8020,2015
+CE,8050,1,Adv Struc Mech,0.38,0.48,0.14,0.0,0.0,0.0,0.0,0.0,bryant nielson,,CE-8050,2015
+CE,8060,1,Dyn Analys of Struc,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,,CE-8060,2015
+CE,8140,1,Intel Trans Systems,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,kakan dey,,CE-8140,2015
+CE,8200,1,Geotech Site Charac,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-8200,2015
+CE,8260,1,Prop of Concrete,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,,CE-8260,2015
+CH,1010,1,General Chemistry,0.19,0.32,0.21,0.12,0.09,0.0,0.0,0.06,thomas hickman,,CH-1010,2015
+CH,1010,2,General Chemistry,0.19,0.27,0.28,0.08,0.1,0.0,0.0,0.08,christopher wilson,,CH-1010,2015
+CH,1010,3,General Chemistry,0.28,0.21,0.25,0.09,0.09,0.0,0.0,0.07,christopher wilson,,CH-1010,2015
+CH,1010,4,General Chemistry,0.16,0.44,0.21,0.1,0.03,0.0,0.0,0.06,dennis taylor,,CH-1010,2015
+CH,1010,5,General Chemistry,0.23,0.32,0.23,0.07,0.06,0.0,0.0,0.09,dennis taylor,,CH-1010,2015
+CH,1010,6,General Chemistry,0.08,0.32,0.2,0.11,0.13,0.0,0.0,0.16,william joh wallace,,CH-1010,2015
+CH,1010,7,General Chemistry,0.16,0.31,0.26,0.13,0.03,0.0,0.0,0.12,dennis taylor,,CH-1010,2015
+CH,1010,8,General Chemistry,0.21,0.32,0.28,0.04,0.1,0.0,0.0,0.05,olt geiculescu,,CH-1010,2015
+CH,1010,9,General Chemistry,0.08,0.26,0.26,0.17,0.14,0.0,0.0,0.1,william joh wallace,,CH-1010,2015
+CH,1010,10,General Chemistry,0.3,0.27,0.25,0.08,0.06,0.0,0.0,0.04,ava kreider-mueller,,CH-1010,2015
+CH,1010,11,General Chemistry,0.22,0.41,0.19,0.11,0.03,0.0,0.0,0.03,tania issa houjeiry,,CH-1010,2015
+CH,1010,12,General Chemistry,0.25,0.35,0.16,0.08,0.08,0.0,0.0,0.07,ava kreider-mueller,,CH-1010,2015
+CH,1010,13,General Chemistry,0.14,0.36,0.29,0.07,0.09,0.0,0.0,0.05,elliot ennis,,CH-1010,2015
+CH,1010,14,General Chemistry,0.09,0.27,0.35,0.11,0.11,0.0,0.0,0.07,william joh wallace,,CH-1010,2015
+CH,1010,16,General Chemistry,0.22,0.37,0.31,0.06,0.03,0.0,0.0,0.01,tania issa houjeiry,,CH-1010,2015
+CH,1010,17,General Chemistry,0.14,0.31,0.31,0.11,0.08,0.0,0.0,0.05,elliot ennis,,CH-1010,2015
+CH,1010,18,General Chemistry,0.23,0.31,0.28,0.08,0.03,0.0,0.0,0.06,ava kreider-mueller,,CH-1010,2015
+CH,1010,50,General Chemistry,0.35,0.38,0.19,0.08,0.0,0.0,0.0,0.0,william pennington,,CH-1010,2015
+CH,1010,51,General Chemistry (HON),0.67,0.22,0.07,0.0,0.0,0.0,0.0,0.04,joseph stu thrasher,True,CH-1010,2015
+CH,1010,52,General Chemistry (HON),0.56,0.31,0.1,0.0,0.0,0.0,0.0,0.03,shiou-jyh hwu,True,CH-1010,2015
+CH,1010,53,General Chemistry,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,edward collins,,CH-1010,2015
+CH,1020,1,General Chemistry,0.27,0.25,0.25,0.11,0.06,0.0,0.0,0.06,stephe schvaneveldt,,CH-1020,2015
+CH,1020,2,General Chemistry,0.3,0.31,0.23,0.08,0.04,0.0,0.0,0.05,stephe schvaneveldt,,CH-1020,2015
+CH,1020,3,General Chemistry,0.27,0.27,0.26,0.1,0.02,0.0,0.0,0.08,stephe schvaneveldt,,CH-1020,2015
+CH,1020,400,General Chemistry,0.05,0.34,0.34,0.07,0.1,0.0,0.0,0.1,stephe schvaneveldt,,CH-1020,2015
+CH,1050,1,Chemistry in Context I,0.39,0.53,0.08,0.0,0.0,0.0,0.0,0.0,olt geiculescu,,CH-1050,2015
+CH,1050,2,Chemistry in Context I,0.48,0.35,0.11,0.03,0.0,0.0,0.0,0.04,olt geiculescu,,CH-1050,2015
+CH,1410,1,Chem Orientation,0.89,0.06,0.0,0.0,0.02,0.0,0.0,0.02, karl dieter,,CH-1410,2015
+CH,2010,1,Survey of Organic Chemistry,0.29,0.35,0.29,0.0,0.02,0.0,0.0,0.05,thomas hickman,,CH-2010,2015
+CH,2010,2,Survey of Organic Chemistry,0.36,0.41,0.21,0.0,0.01,0.0,0.0,0.01,thomas hickman,,CH-2010,2015
+CH,2020,1,Surv of Organic Chemistry Lab,0.56,0.25,0.0,0.13,0.0,0.0,0.0,0.06,sean 'connor,,CH-2020,2015
+CH,2020,2,Surv of Organic Chemistry Lab,0.72,0.17,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,,CH-2020,2015
+CH,2020,6,Surv of Organic Chemistry Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2020,2015
+CH,2020,8,Surv of Organic Chemistry Lab,0.67,0.06,0.17,0.0,0.0,0.0,0.0,0.11,sean 'connor,,CH-2020,2015
+CH,2230,1,Organic Chemistry,0.21,0.37,0.27,0.04,0.06,0.0,0.0,0.04,modi wetzler,,CH-2230,2015
+CH,2230,2,Organic Chemistry,0.33,0.34,0.14,0.1,0.06,0.0,0.0,0.04,modi wetzler,,CH-2230,2015
+CH,2230,3,Organic Chemistry,0.3,0.4,0.21,0.04,0.06,0.0,0.0,0.0,daniel whitehead,,CH-2230,2015
+CH,2230,4,Organic Chemistry,0.3,0.42,0.17,0.04,0.05,0.0,0.0,0.04,jacob schroeder,,CH-2230,2015
+CH,2230,5,Organic Chemistry,0.25,0.27,0.3,0.07,0.07,0.0,0.0,0.05,elliot ennis,,CH-2230,2015
+CH,2230,6,Organic Chemistry,0.25,0.31,0.13,0.03,0.07,0.0,0.0,0.21,rhett smith,,CH-2230,2015
+CH,2230,7,Organic Chemistry,0.33,0.32,0.16,0.08,0.05,0.0,0.0,0.06,tania issa houjeiry,,CH-2230,2015
+CH,2240,1,Organic Chemistry,0.24,0.38,0.19,0.06,0.03,0.0,0.0,0.09,jacob schroeder,,CH-2240,2015
+CH,2240,2,Organic Chemistry,0.29,0.38,0.15,0.05,0.01,0.0,0.0,0.11,jacob schroeder,,CH-2240,2015
+CH,2270,1,Organic Chem Lab,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2015
+CH,2270,2,Organic Chem Lab,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2015
+CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2015
+CH,2270,7,Organic Chem Lab,0.56,0.25,0.0,0.0,0.06,0.0,0.0,0.13,sean 'connor,,CH-2270,2015
+CH,2270,10,Organic Chem Lab,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2015
+CH,2270,12,Organic Chem Lab,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2015
+CH,2270,13,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2015
+CH,2270,14,Organic Chem Lab,0.56,0.25,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,,CH-2270,2015
+CH,2270,15,Organic Chem Lab,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,,CH-2270,2015
+CH,2270,16,Organic Chem Lab,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2015
+CH,2270,17,Organic Chem Lab,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,,CH-2270,2015
+CH,2270,18,Organic Chem Lab,0.69,0.06,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,,CH-2270,2015
+CH,2270,20,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2015
+CH,2270,23,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2015
+CH,2270,25,Organic Chem Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2015
+CH,2270,28,Organic Chem Lab,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,,CH-2270,2015
+CH,2270,31,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,sean 'connor,,CH-2270,2015
+CH,2270,33,Organic Chem Lab,0.56,0.19,0.0,0.0,0.06,0.0,0.0,0.19,sean 'connor,,CH-2270,2015
+CH,2270,35,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2015
+CH,2270,36,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2015
+CH,2270,37,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,sean 'connor,,CH-2270,2015
+CH,2270,38,Organic Chem Lab,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,,CH-2270,2015
+CH,2280,3,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,,CH-2280,2015
+CH,2280,6,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,sean 'connor,,CH-2280,2015
+CH,2280,7,Organic Chem Lab,0.59,0.18,0.12,0.0,0.0,0.0,0.0,0.12,sean 'connor,,CH-2280,2015
+CH,2280,8,Organic Chem Lab,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,,CH-2280,2015
+CH,3130,1,Quantitative Analys,0.44,0.31,0.09,0.09,0.0,0.0,0.0,0.06,stephen creager,,CH-3130,2015
+CH,3300,1,Intro to Phys Chem,0.37,0.27,0.21,0.07,0.01,0.0,0.0,0.06,brian dominy,,CH-3300,2015
+CH,3310,1,Physical Chemistry,0.58,0.19,0.13,0.06,0.03,0.0,0.0,0.0,leah bec casabianca,,CH-3310,2015
+CH,3310,2,Physical Chemistry,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,arkady kholodenko,,CH-3310,2015
+CH,3320,1,Physical Chemistry,0.26,0.32,0.32,0.05,0.0,0.0,0.0,0.05,arkady kholodenko,,CH-3320,2015
+CH,3390,1,Physical Chem Lab,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,christopher wilson,,CH-3390,2015
+CH,3390,4,Physical Chem Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,,CH-3390,2015
+CH,4010,1,Organometallic Chemistry,0.53,0.35,0.12,0.0,0.0,0.0,0.0,0.0,andrew gre tennyson,,CH-4010,2015
+CH,4020,1,Inorganic Chemistry,0.38,0.57,0.0,0.0,0.0,0.0,0.0,0.05,joseph kolis,,CH-4020,2015
+CH,8070,1,Chem Trans Elem,0.36,0.36,0.09,0.0,0.0,0.0,0.0,0.18,julia brumaghim,,CH-8070,2015
+CH,8140,1,Analytical Imaging,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,george chumanov,,CH-8140,2015
+CH,8160,1,Separation Science,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,richard marcus,,CH-8160,2015
+CH,8210,1,Organic Chem I,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07, karl dieter,,CH-8210,2015
+CH,8300,1,Fund Phys Chem,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,,CH-8300,2015
+CH,8380,1,Computational Chem,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,,CH-8380,2015
+CH,8510,1,Grad Student Seminar,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,joseph stu thrasher,,CH-8510,2015
+CH,8510,2,Grad Student Seminar,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,steven stuart,,CH-8510,2015
+CHE,2110,1,Intro to Chem Eng,0.19,0.27,0.27,0.03,0.16,0.0,0.0,0.07,rachel getman,,CHE-2110,2015
+CHE,2110,2,Intro to Chem Eng,0.27,0.37,0.19,0.01,0.1,0.0,0.0,0.04,rachel getman,,CHE-2110,2015
+CHE,3070,1,Unit Ops Lab I,0.11,0.74,0.13,0.02,0.0,0.0,0.0,0.0,christopher norfolk,,CHE-3070,2015
+CHE,3190,1,Engr Materials,0.16,0.38,0.25,0.12,0.08,0.0,0.0,0.0,amod ogale,,CHE-3190,2015
+CHE,4070,1,Unit Op Lab II,0.22,0.64,0.15,0.0,0.0,0.0,0.0,0.0,christopher norfolk,,CHE-4070,2015
+CHE,4310,1,Process Design I,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4310,2015
+CHE,4450,1,Green Engineering,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,christophe kitchens,,CHE-4450,2015
+CHE,4500,1,Chem Reaction Engr,0.25,0.32,0.32,0.1,0.0,0.0,0.0,0.0,mark alan blenner,,CHE-4500,2015
+CHE,4990,14,CI-  Membrane Separations,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott husson,,CHE-4990,2015
+CHE,8030,1,Advanced Transport,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,douglas hirt,,CHE-8030,2015
+CHE,8040,1,Ch E Thermodynamics,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,sapna sarupria,,CHE-8040,2015
+CHE,8050,1,Ch E Kinetics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mark roberts,,CHE-8050,2015
+CHIN,1010,1,Elementary Chinese,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,yanlin wang,,CHIN-1010,2015
+CHIN,1010,2,Elementary Chinese,0.57,0.14,0.14,0.0,0.07,0.0,0.0,0.07,yanlin wang,,CHIN-1010,2015
+CHIN,1020,1,Elementary Chinese,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,su- chen,,CHIN-1020,2015
+CHIN,4010,1,Pre-Modern Chinese Literature,0.58,0.21,0.16,0.0,0.05,0.0,0.0,0.0,yanming an,,CHIN-4010,2015
+COM,1500,1,Intro to Human Communication,0.63,0.27,0.05,0.01,0.02,0.0,0.0,0.01,eddie smith,,COM-1500,2015
+COM,1500,2,Intro to Human Communication,0.58,0.34,0.04,0.01,0.02,0.0,0.0,0.01,daniel lelan fecher,,COM-1500,2015
+COM,1500,3,Intro to Human Communication,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,eddie smith,,COM-1500,2015
+COM,1500,4,Intro to Human Communication,0.63,0.27,0.05,0.01,0.04,0.0,0.0,0.01,marianne her glaser,,COM-1500,2015
+COM,1500,5,Intro to Human Communication,0.61,0.35,0.03,0.0,0.01,0.0,0.0,0.0,marianne her glaser,,COM-1500,2015
+COM,1500,6,Intro to Human Communication,0.65,0.29,0.03,0.02,0.01,0.0,0.0,0.0,marianne her glaser,,COM-1500,2015
+COM,1500,7,Intro to Human Communication,0.55,0.35,0.05,0.0,0.01,0.0,0.0,0.04,daniel lelan fecher,,COM-1500,2015
+COM,2010,1,Intr to Comm Studies,0.56,0.36,0.04,0.0,0.04,0.0,0.0,0.0,karyn jones,,COM-2010,2015
+COM,2010,2,Intr to Comm Studies,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-2010,2015
+COM,2500,1,Public Speaking,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2015
+COM,2500,2,Public Speaking,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2015
+COM,2500,3,Public Speaking,0.28,0.5,0.11,0.0,0.11,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2015
+COM,2500,4,Public Speaking,0.74,0.05,0.05,0.0,0.16,0.0,0.0,0.0,brandon boatwright,,COM-2500,2015
+COM,2500,5,Public Speaking,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,brandon boatwright,,COM-2500,2015
+COM,2500,6,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2015
+COM,2500,7,Public Speaking,0.21,0.53,0.21,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2015
+COM,2500,8,Public Speaking,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2015
+COM,2500,9,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2015
+COM,2500,10,Public Speaking,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2015
+COM,2500,11,Public Speaking,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,,COM-2500,2015
+COM,2500,12,Public Speaking,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,pauline matthey,,COM-2500,2015
+COM,2500,13,Public Speaking,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,pauline matthey,,COM-2500,2015
+COM,2500,14,Public Speaking,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07,pauline matthey,,COM-2500,2015
+COM,2500,15,Public Speaking,0.83,0.06,0.11,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2015
+COM,2500,16,Public Speaking,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2015
+COM,2500,17,Public Speaking,0.71,0.18,0.06,0.0,0.0,0.0,0.0,0.06,the estate  geddes,,COM-2500,2015
+COM,2500,18,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2015
+COM,2500,19,Public Speaking,0.47,0.37,0.0,0.0,0.05,0.0,0.0,0.11,jumah patrici taweh,,COM-2500,2015
+COM,2500,20,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2015
+COM,2500,21,Public Speaking,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,lindsey dixon,,COM-2500,2015
+COM,2500,22,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2015
+COM,2500,23,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,,COM-2500,2015
+COM,2500,24,Public Speaking,0.61,0.22,0.0,0.0,0.0,0.0,0.0,0.17,jumah patrici taweh,,COM-2500,2015
+COM,2500,28,Public Speaking,0.35,0.35,0.12,0.0,0.12,0.0,0.0,0.06,sara grumbl crocker,,COM-2500,2015
+COM,2500,29,Public Speaking,0.47,0.32,0.16,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2015
+COM,2500,30,Public Speaking,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2015
+COM,2500,31,Public Speaking,0.42,0.26,0.26,0.05,0.0,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2015
+COM,2500,32,Public Speaking,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2015
+COM,2500,33,Public Speaking,0.68,0.11,0.11,0.0,0.11,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2015
+COM,2500,34,Public Speaking,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2015
+COM,2500,35,Public Speaking,0.54,0.23,0.0,0.0,0.15,0.0,0.0,0.08,vanessa anne condon,,COM-2500,2015
+COM,2500,400,Public Speaking,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,,COM-2500,2015
+COM,2500,403,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,,COM-2500,2015
+COM,3010,1,Comm Theory,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-3010,2015
+COM,3020,1,Mass Comm Theory,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3020,2015
+COM,3050,1,Persuasion,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,,COM-3050,2015
+COM,3050,2,Persuasion,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,,COM-3050,2015
+COM,3100,1,Quant Comm Methods,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3100,2015
+COM,3110,1,Qual Comm Methods,0.53,0.21,0.21,0.0,0.0,0.0,0.0,0.05,chenjerai kumanyika,,COM-3110,2015
+COM,3240,1,"Communication, Sport & Society",0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,john steven spinda,,COM-3240,2015
+COM,3260,1,Pr in Sports,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2015
+COM,3480,1,Interpersonal Comm,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,melinda ra weathers,,COM-3480,2015
+COM,3550,1,Principles of Public Relations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3550,2015
+COM,3550,2,Principles of Public Relations,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,andrew stephen pyle,,COM-3550,2015
+COM,3660,1,Special Topics in Comm,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,william reynolds,,COM-3660,2015
+COM,3660,6,Special Topics in Comm,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,angela pratt,,COM-3660,2015
+COM,4040,1,Media Comm & Social Identities,0.3,0.47,0.13,0.03,0.0,0.0,0.0,0.07,chenjerai kumanyika,,COM-4040,2015
+COM,4250,1,Adv Sports Comm,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-4250,2015
+COM,4300,1,Legal Communication,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,james isaac roberts,,COM-4300,2015
+COM,4700,1,Comm & Health,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4700,2015
+COM,4800,1,Intercultural Comm,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,melinda ra weathers,,COM-4800,2015
+COM,4950,1,Senior Capstone Seminar,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4950,2015
+COM,4950,2,Senior Capstone Seminar,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,john steven spinda,,COM-4950,2015
+COM,8100,1,Comm Research Methods I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,,COM-8100,2015
+CPSC,1010,1,Computer Science I,0.48,0.22,0.11,0.11,0.07,0.0,0.0,0.02,yvon feaster,,CPSC-1010,2015
+CPSC,1010,2,Computer Science I,0.35,0.33,0.07,0.14,0.07,0.0,0.0,0.05,yvon feaster,,CPSC-1010,2015
+CPSC,1010,3,Computer Science I,0.27,0.23,0.16,0.09,0.11,0.0,0.0,0.14,christopher plaue,,CPSC-1010,2015
+CPSC,1010,4,Computer Science I,0.15,0.2,0.24,0.07,0.12,0.0,0.0,0.22,pradip srimani,,CPSC-1010,2015
+CPSC,1020,1,Computer Science II,0.3,0.32,0.07,0.03,0.15,0.0,0.0,0.13,catherine hochrine,,CPSC-1020,2015
+CPSC,1040,1,Intro Computer Prog,0.15,0.19,0.46,0.12,0.0,0.04,0.0,0.04,roy pargas,,CPSC-1040,2015
+CPSC,1110,1,Intro to Programming in C,0.59,0.1,0.07,0.05,0.12,0.0,0.0,0.07,catherine hochrine,,CPSC-1110,2015
+CPSC,1110,2,Intro to Programming in C,0.6,0.15,0.08,0.04,0.04,0.0,0.0,0.08,catherine hochrine,,CPSC-1110,2015
+CPSC,1110,3,Intro to Programming in C,0.65,0.23,0.08,0.0,0.04,0.0,0.0,0.0,wanda moses,,CPSC-1110,2015
+CPSC,1110,4,Intro to Programming in C,0.7,0.13,0.05,0.0,0.05,0.0,0.0,0.08,wanda moses,,CPSC-1110,2015
+CPSC,2070,1,Discrete Structures,0.2,0.37,0.16,0.12,0.09,0.0,0.0,0.05,larry hodges,,CPSC-2070,2015
+CPSC,2100,1,Progrmng Methodology,0.32,0.21,0.08,0.03,0.29,0.0,0.0,0.08,timothy davis,,CPSC-2100,2015
+CPSC,2100,2,Progrmng Methodology,0.47,0.28,0.09,0.13,0.03,0.0,0.0,0.0,rose lowe,,CPSC-2100,2015
+CPSC,2120,1,Algs/Data Structures,0.31,0.24,0.23,0.02,0.12,0.0,0.0,0.08,brian christop dean,,CPSC-2120,2015
+CPSC,2150,1,Software Dev Fndtns,0.24,0.27,0.22,0.12,0.12,0.0,0.0,0.04,blair madiso durkee,,CPSC-2150,2015
+CPSC,2150,2,Software Dev Fndtns,0.5,0.23,0.17,0.0,0.1,0.0,0.0,0.0,yvon feaster,,CPSC-2150,2015
+CPSC,2200,1,Microcomputer Appl,0.41,0.24,0.12,0.06,0.12,0.0,0.0,0.06,renee lambert,,CPSC-2200,2015
+CPSC,2200,2,Microcomputer Appl,0.4,0.3,0.15,0.0,0.05,0.0,0.0,0.1,renee lambert,,CPSC-2200,2015
+CPSC,2310,1,Intro Computer Org,0.49,0.31,0.13,0.08,0.0,0.0,0.0,0.0,rose lowe,,CPSC-2310,2015
+CPSC,2310,2,Intro Computer Org,0.36,0.21,0.21,0.07,0.07,0.0,0.0,0.07,rose lowe,,CPSC-2310,2015
+CPSC,2910,2,Prof Issues I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james jones,,CPSC-2910,2015
+CPSC,2910,5,Prof Issues I,0.25,0.33,0.08,0.08,0.0,0.0,0.0,0.25,renee lambert,,CPSC-2910,2015
+CPSC,2910,6,Prof Issues I,0.6,0.1,0.0,0.1,0.0,0.0,0.0,0.2,renee lambert,,CPSC-2910,2015
+CPSC,2910,7,Prof Issues I,0.53,0.07,0.07,0.13,0.07,0.0,0.0,0.13,renee lambert,,CPSC-2910,2015
+CPSC,3220,1,Intro to Operating Systems,0.13,0.31,0.23,0.08,0.12,0.0,0.0,0.13,jacob sorber,,CPSC-3220,2015
+CPSC,3300,1,Computer Systems Org,0.14,0.22,0.38,0.12,0.12,0.0,0.0,0.01,mark smotherman,,CPSC-3300,2015
+CPSC,3500,1,Foundations of Computer Sci,0.25,0.13,0.38,0.0,0.15,0.0,0.0,0.1,ilya mark safro,,CPSC-3500,2015
+CPSC,3520,1,Programming Systems,0.36,0.26,0.17,0.0,0.14,0.0,0.0,0.07,robert schalkoff,,CPSC-3520,2015
+CPSC,3600,1,Network Programming,0.16,0.3,0.39,0.09,0.05,0.0,0.0,0.02,sekou lionel remy,,CPSC-3600,2015
+CPSC,3600,2,Network Programming,0.4,0.43,0.1,0.0,0.08,0.0,0.0,0.0,kevin mckenzie,,CPSC-3600,2015
+CPSC,3620,1,Distributed/Cluster Computing,0.28,0.5,0.15,0.03,0.0,0.0,0.0,0.05,linh bao ngo,,CPSC-3620,2015
+CPSC,3720,1,Software Engineering,0.34,0.41,0.22,0.0,0.03,0.0,0.0,0.0,murali sitaraman,,CPSC-3720,2015
+CPSC,3720,2,Software Engineering,0.28,0.33,0.28,0.03,0.03,0.0,0.0,0.06,stephen schaub,,CPSC-3720,2015
+CPSC,3990,4,Adv Creative Inquiry Computing,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,james martin,,CPSC-3990,2015
+CPSC,3990,10,Adv CI:Google Glass,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,roy pargas,,CPSC-3990,2015
+CPSC,4040,1,Cmptr Graphics Image,0.47,0.32,0.16,0.05,0.0,0.0,0.0,0.0,joshua levine,,CPSC-4040,2015
+CPSC,4110,1,Virtual Reality Systems,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,sabarish venka babu,,CPSC-4110,2015
+CPSC,4200,1,Computer Security Principles,0.59,0.28,0.14,0.0,0.0,0.0,0.0,0.0,hongxin hu,,CPSC-4200,2015
+CPSC,4620,1,Database Management Systems,0.12,0.27,0.18,0.15,0.12,0.0,0.0,0.15,pradip srimani,,CPSC-4620,2015
+CPSC,4780,1,Gen Purpose Computation on GPU,0.27,0.36,0.18,0.09,0.09,0.0,0.0,0.0,robert geist,,CPSC-4780,2015
+CPSC,4810,16,Sel Top:Programming Team,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,brian christop dean,,CPSC-4810,2015
+CPSC,4820,1,Spec Top:Embedded Systems,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,jacob sorber,,CPSC-4820,2015
+CPSC,4820,3,Spec Top:Mobile Device Sftware,0.61,0.17,0.11,0.0,0.06,0.0,0.0,0.06,roy pargas,,CPSC-4820,2015
+CPSC,4910,1,Professional Issues II,0.96,0.0,0.01,0.0,0.01,0.0,0.0,0.01,james jones,,CPSC-4910,2015
+CPSC,6040,1,Cptr Graphics Image,0.5,0.11,0.04,0.0,0.18,0.0,0.0,0.18,joshua levine,,CPSC-6040,2015
+CPSC,6110,1,Virtual Reality Systems,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,,CPSC-6110,2015
+CPSC,6620,1,Database Management Systems,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,pradip srimani,,CPSC-6620,2015
+CPSC,6780,1,Gen Purpose Computation on GPU,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,,CPSC-6780,2015
+CPSC,8040,1,Data Visualization,0.5,0.3,0.1,0.0,0.05,0.0,0.0,0.05,joshua levine,,CPSC-8040,2015
+CPSC,8070,1,3d Model Animation,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,christina sop joerg,,CPSC-8070,2015
+CPSC,8100,1,Intro Artif Intell,0.18,0.71,0.11,0.0,0.0,0.0,0.0,0.0,feng luo,,CPSC-8100,2015
+CPSC,8150,1,Fx Compositing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,,CPSC-8150,2015
+CPSC,8170,1,Physically Based Animation,0.62,0.27,0.08,0.0,0.0,0.0,0.0,0.04,donald henry house,,CPSC-8170,2015
+CPSC,8390,1,Theoretical Cp Sci Foundations,0.31,0.61,0.06,0.0,0.0,0.0,0.0,0.02,wayne goddard,,CPSC-8390,2015
+CPSC,8480,1,Network Science,0.44,0.11,0.44,0.0,0.0,0.0,0.0,0.0,ilya mark safro,,CPSC-8480,2015
+CPSC,8520,1,Internetworking,0.4,0.33,0.27,0.0,0.0,0.0,0.0,0.0,james martin,,CPSC-8520,2015
+CPSC,8700,1,O O Software Design,0.46,0.33,0.14,0.0,0.03,0.0,0.0,0.03,brian malloy,,CPSC-8700,2015
+CPSC,8710,1,Found. of Software Engineering,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,,CPSC-8710,2015
+CPSC,8730,1,"Software Verif, Valid & Measur",0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,,CPSC-8730,2015
+CPSC,8810,3,Selected Topics: Visual Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,,CPSC-8810,2015
+CRP,8000,1,Human Settlement,0.56,0.34,0.05,0.0,0.0,0.0,0.0,0.05,john terrenc farris,,CRP-8000,2015
+CRP,8010,1,Planning Process & Legal Found,0.38,0.38,0.1,0.1,0.0,0.0,0.0,0.05,caitlin dyckman,,CRP-8010,2015
+CRP,8020,1,Site Planning,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,,CRP-8020,2015
+CRP,8030,1,Quant Analysis,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,,CRP-8030,2015
+CRP,8060,1,Urban & Reg Econ for Planners,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,timothy green,,CRP-8060,2015
+CRP,8340,1,Spatial Modeling/Gis,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,stephen sperry,,CRP-8340,2015
+CRP,8580,2,Research Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,timothy green,,CRP-8580,2015
+CSM,1000,1,Intro to Construct,0.41,0.47,0.11,0.02,0.0,0.0,0.0,0.0,joseph wintz,,CSM-1000,2015
+CSM,2010,1,Structures I,0.3,0.33,0.26,0.11,0.0,0.0,0.0,0.0,shima clarke,,CSM-2010,2015
+CSM,2010,2,Structures I,0.5,0.19,0.19,0.12,0.0,0.0,0.0,0.0,shima clarke,,CSM-2010,2015
+CSM,2030,1,Mats & Meth of Const,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-2030,2015
+CSM,2030,2,Mats & Meth of Const,0.22,0.63,0.15,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-2030,2015
+CSM,3030,1,Soils & Foundations,0.08,0.63,0.29,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-3030,2015
+CSM,3030,2,Soils & Foundations,0.12,0.69,0.19,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-3030,2015
+CSM,3040,1,Envir Systems I,0.42,0.42,0.12,0.0,0.04,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2015
+CSM,3040,2,Envir Systems I,0.13,0.67,0.21,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2015
+CSM,3510,1,Const Estimating,0.19,0.69,0.08,0.04,0.0,0.0,0.0,0.0,james packer smith,,CSM-3510,2015
+CSM,3510,2,Const Estimating,0.11,0.48,0.26,0.15,0.0,0.0,0.0,0.0,james packer smith,,CSM-3510,2015
+CSM,4110,1,Safety in Bldg Const,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,david devita,,CSM-4110,2015
+CSM,4500,1,Construction Intern,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-4500,2015
+CSM,4530,1,Const Proj Mgmt,0.19,0.67,0.14,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-4530,2015
+CSM,4530,2,Const Proj Mgmt,0.11,0.72,0.17,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-4530,2015
+CSM,4610,1,Const Econ Seminar,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4610,2015
+CSM,4610,2,Const Econ Seminar,0.05,0.76,0.19,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4610,2015
+CSM,8640,1,Construction Bus Strat & Mktg,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,christine piper,,CSM-8640,2015
+CSM,8650,1,Project Management,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8650,2015
+CSM,8650,400,Project Management,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8650,2015
+CSM,8660,1,Role in Development,0.31,0.63,0.0,0.0,0.0,0.0,0.0,0.06,dennis bausman,,CSM-8660,2015
+CSM,8900,401,Directed Studies,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-8900,2015
+CSM,8900,402,Directed Studies,0.57,0.14,0.14,0.0,0.14,0.0,0.0,0.0,jason lucas,,CSM-8900,2015
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,susan whorton,,CU-1000,2015
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.88,0.12,0.01,susan whorton,,CU-1000,2015
+CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.02,susan whorton,,CU-1000,2015
+CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.73,0.26,0.01,susan whorton,,CU-1000,2015
+CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,,CU-1000,2015
+CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,,CU-1000,2015
+CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,,CU-1000,2015
+CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.05,0.01,susan whorton,,CU-1000,2015
+CU,1000,9,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.01,susan whorton,,CU-1000,2015
+CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.08,0.01,susan whorton,,CU-1000,2015
+CU,1000,11,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,susan whorton,,CU-1000,2015
+CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,susan whorton,,CU-1000,2015
+CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.88,0.11,0.02,susan whorton,,CU-1000,2015
+CU,1010,1,Univ Success Skills,0.5,0.19,0.06,0.0,0.13,0.0,0.0,0.13,emma reynol reabold,,CU-1010,2015
+CU,1010,2,Univ Success Skills,0.45,0.14,0.32,0.05,0.05,0.0,0.0,0.0,cari allyn brooks,,CU-1010,2015
+CU,1010,3,Univ Success Skills,0.32,0.32,0.16,0.04,0.08,0.0,0.0,0.08,matthew james kirk,,CU-1010,2015
+CU,1010,5,Univ Success Skills,0.55,0.18,0.0,0.09,0.18,0.0,0.0,0.0,ashley crisp,,CU-1010,2015
+CU,1010,6,Univ Success Skills,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,amber allen mulkey,,CU-1010,2015
+CU,1010,7,Univ Success Skills,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,amber allen mulkey,,CU-1010,2015
+CU,1110,3,Intro Supplemental Instruction,0.0,0.0,0.0,0.0,0.0,0.88,0.06,0.06,laurel ann whisler,,CU-1110,2015
+CU,1400,1,The Entrepreneurial Mindset,0.76,0.17,0.05,0.01,0.0,0.0,0.0,0.02,john michael hannon,,CU-1400,2015
+CU,2010,1,Sustainability Leadership,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,leidy klotz,,CU-2010,2015
+CVT,2260,1,Intro Cardiovas Sono,0.2,0.6,0.13,0.0,0.0,0.0,0.0,0.07,eric walker,,CVT-2260,2015
+DANC,3300,1,University Dance Company,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,cheryl hosler,,DANC-3300,2015
+DPA,4000,1,Tech Foundations I,0.65,0.06,0.06,0.0,0.0,0.0,0.0,0.24,brian malloy,,DPA-4000,2015
+DPA,8600,1,Production Studio,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,,DPA-8600,2015
+ECE,2010,1,Logic and Computing Devices,0.2,0.35,0.24,0.05,0.13,0.0,0.0,0.03,william reid,,ECE-2010,2015
+ECE,2010,2,Logic & Comp Device (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william reid,True,ECE-2010,2015
+ECE,2020,1,Electric Circuits I,0.29,0.27,0.24,0.04,0.1,0.0,0.0,0.06,william harrell,,ECE-2020,2015
+ECE,2020,2,Electric Circuits I (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True,ECE-2020,2015
+ECE,2020,3,Electric Circuits I,0.21,0.17,0.3,0.12,0.16,0.0,0.0,0.03,daniel bla cutshall,,ECE-2020,2015
+ECE,2070,1,Basic Electrical Engineering,0.14,0.31,0.33,0.12,0.03,0.0,0.0,0.07,william th kolodzey,,ECE-2070,2015
+ECE,2070,2,Basic Electrical Engineering,0.45,0.25,0.13,0.05,0.05,0.0,0.0,0.08,oleg viktorov sivov,,ECE-2070,2015
+ECE,2070,3,Basic Electrical Engineering,0.33,0.35,0.16,0.1,0.04,0.0,0.0,0.02,amir ahmed asif,,ECE-2070,2015
+ECE,2080,7,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,,ECE-2080,2015
+ECE,2080,9,Electrical Engineering Lab I,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,,ECE-2080,2015
+ECE,2080,10,Electrical Engineering Lab I,0.65,0.05,0.0,0.0,0.1,0.0,0.0,0.2,apoorva dee kapadia,,ECE-2080,2015
+ECE,2080,13,Electrical Engineering Lab I,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,apoorva dee kapadia,,ECE-2080,2015
+ECE,2090,1,Logic Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2015
+ECE,2090,9,Logic Lab,0.82,0.0,0.0,0.0,0.18,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2015
+ECE,2090,10,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva dee kapadia,,ECE-2090,2015
+ECE,2090,11,Logic Lab,0.83,0.0,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2015
+ECE,2090,13,Logic Lab,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,apoorva dee kapadia,,ECE-2090,2015
+ECE,2110,6,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,,ECE-2110,2015
+ECE,2110,8,Elec Engr Lab I,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2110,2015
+ECE,2110,9,Elec Engr Lab I,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,apoorva dee kapadia,,ECE-2110,2015
+ECE,2220,1,Syst Prog Concept,0.12,0.27,0.22,0.1,0.1,0.0,0.0,0.2,harlan russell,,ECE-2220,2015
+ECE,2230,1,Comp Sys Eng,0.18,0.25,0.2,0.11,0.14,0.0,0.0,0.11,harlan russell,,ECE-2230,2015
+ECE,2620,1,Electric Circuits II,0.59,0.15,0.1,0.03,0.03,0.0,0.0,0.1,liang dong,,ECE-2620,2015
+ECE,2720,1,Comp Organization,0.19,0.29,0.33,0.05,0.1,0.0,0.0,0.05,william reid,,ECE-2720,2015
+ECE,2730,2,Computer Org Lab,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2730,2015
+ECE,2730,3,Computer Org Lab,0.57,0.14,0.21,0.0,0.07,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2015
+ECE,3110,2,Electrical Engineering Lab III,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,,ECE-3110,2015
+ECE,3110,4,Electrical Engineering Lab III,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2015
+ECE,3110,6,Electrical Engineering Lab III,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,apoorva dee kapadia,,ECE-3110,2015
+ECE,3110,7,Electrical Engineering Lab III,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,,ECE-3110,2015
+ECE,3120,2,Electrical Engineering Lab IV,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3120,2015
+ECE,3170,1,Rand Signal Analysis,0.23,0.23,0.25,0.14,0.11,0.0,0.0,0.05,stephen hubbard,,ECE-3170,2015
+ECE,3200,1,Electronics I,0.25,0.18,0.18,0.18,0.22,0.0,0.0,0.0,stephen hubbard,,ECE-3200,2015
+ECE,3210,1,Electronics II,0.37,0.32,0.2,0.1,0.02,0.0,0.0,0.0,stephen hubbard,,ECE-3210,2015
+ECE,3220,1,Intro Operating Sys,0.25,0.35,0.15,0.15,0.1,0.0,0.0,0.0,jacob sorber,,ECE-3220,2015
+ECE,3270,1,Dig Comp Design,0.15,0.15,0.2,0.15,0.13,0.0,0.0,0.23,melissa crawl smith,,ECE-3270,2015
+ECE,3300,1,Signals & Systems,0.14,0.23,0.26,0.17,0.06,0.0,0.0,0.15,carl baum,,ECE-3300,2015
+ECE,3300,2,Signals & Systems (HON),0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True,ECE-3300,2015
+ECE,3520,1,Programming Systems,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,robert schalkoff,,ECE-3520,2015
+ECE,3600,1,Elect Power Engr,0.31,0.3,0.28,0.02,0.02,0.0,0.0,0.08,edward collins,,ECE-3600,2015
+ECE,3710,1,Microcontr Interface,0.38,0.34,0.21,0.06,0.0,0.0,0.0,0.01,william reid,,ECE-3710,2015
+ECE,3720,1,Micro Int Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2015
+ECE,3720,3,Micro Int Lab,0.75,0.17,0.0,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2015
+ECE,3720,6,Micro Int Lab,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2015
+ECE,3800,1,Electromagnetics,0.3,0.2,0.18,0.13,0.15,0.0,0.0,0.05,anthony martin,,ECE-3800,2015
+ECE,3810,1,Field Waves & Ckts,0.45,0.21,0.24,0.07,0.02,0.0,0.0,0.0,anthony martin,,ECE-3810,2015
+ECE,4040,1,Semiconductor Devices,0.25,0.44,0.25,0.0,0.06,0.0,0.0,0.0,william harrell,,ECE-4040,2015
+ECE,4090,1,Cont & Discrete Sys,0.4,0.37,0.15,0.03,0.03,0.0,0.0,0.01,apoorva dee kapadia,,ECE-4090,2015
+ECE,4120,1,Elect Mach Lab,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,elham makram,,ECE-4120,2015
+ECE,4180,1,Power Syst Analysis,0.31,0.12,0.27,0.15,0.08,0.0,0.0,0.08,elham makram,,ECE-4180,2015
+ECE,4270,1,Communications Sys,0.31,0.22,0.22,0.17,0.08,0.0,0.0,0.0,madhabi manandhar,,ECE-4270,2015
+ECE,4290,1,Organiz of Compu,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,hai ying shen,,ECE-4290,2015
+ECE,4350,1,Grounding/Shielding,0.43,0.29,0.07,0.14,0.0,0.0,0.0,0.07,todd hubing,,ECE-4350,2015
+ECE,4420,1,Knowledge Engr,0.37,0.32,0.11,0.05,0.05,0.0,0.0,0.11,robert schalkoff,,ECE-4420,2015
+ECE,4490,1,Comp Ntwrk Security,0.35,0.3,0.05,0.0,0.0,0.0,0.0,0.3,richard brooks,,ECE-4490,2015
+ECE,4610,1,Fundamentals of Solar Energy,0.63,0.25,0.07,0.05,0.0,0.0,0.0,0.0,rajendra singh,,ECE-4610,2015
+ECE,4730,1,Intro Parallel Sys,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,walter ligon,,ECE-4730,2015
+ECE,4950,1,Int Sys Design I,0.74,0.23,0.04,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4950,2015
+ECE,4960,1,Int Sys Design II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2015
+ECE,6040,1,Semiconductor Devices,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-6040,2015
+ECE,6350,1,Grounding/Shielding,0.6,0.2,0.1,0.0,0.1,0.0,0.0,0.0,todd hubing,,ECE-6350,2015
+ECE,6420,1,Knowledge Engr,0.26,0.63,0.05,0.0,0.05,0.0,0.0,0.0,robert schalkoff,,ECE-6420,2015
+ECE,6490,1,Comp Ntwrk Security,0.88,0.0,0.12,0.0,0.0,0.0,0.0,0.0,richard brooks,,ECE-6490,2015
+ECE,6610,1,Fundamentals of Solar Energy,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,rajendra singh,,ECE-6610,2015
+ECE,6930,1,Intro to Computer Vision,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,,ECE-6930,2015
+ECE,6930,3,Power Electronics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,keith corzine,,ECE-6930,2015
+ECE,8010,1,Analysis of Lin Sys,0.32,0.5,0.11,0.02,0.02,0.0,0.0,0.02,richard groff,,ECE-8010,2015
+ECE,8190,1,Detection & Estimation Theory,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,carl baum,,ECE-8190,2015
+ECE,8470,400,Digital Image Proc,0.87,0.11,0.03,0.0,0.0,0.0,0.0,0.0,stanley birchfield,,ECE-8470,2015
+ECE,8540,1,Analysis of Tracking Systems,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,adam hoover,,ECE-8540,2015
+ECE,8750,1,Peer to Peer Wireless & Cloud,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,hai ying shen,,ECE-8750,2015
+ECE,9910,32,Doctoral Dissertation Research,0.0,0.0,0.0,0.0,0.0,0.86,0.14,0.0,hai ying shen,,ECE-9910,2015
+ECON,2000,1,Economic Concepts,0.31,0.38,0.27,0.04,0.0,0.0,0.0,0.0,mallika garg,,ECON-2000,2015
+ECON,2000,2,Economic Concepts,0.32,0.29,0.24,0.03,0.0,0.0,0.0,0.12,mallika garg,,ECON-2000,2015
+ECON,2000,3,Economic Concepts,0.31,0.34,0.1,0.17,0.0,0.0,0.0,0.07,miren ivankovic,,ECON-2000,2015
+ECON,2110,1,Principles of Microeconomics,0.16,0.32,0.37,0.0,0.11,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2015
+ECON,2110,2,Principles of Microeconomics,0.16,0.21,0.47,0.05,0.05,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2015
+ECON,2110,3,Principles of Microeconomics,0.05,0.37,0.42,0.05,0.11,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,4,Principles of Microeconomics,0.1,0.5,0.2,0.05,0.15,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,5,Principles of Microeconomics,0.16,0.37,0.26,0.0,0.16,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2015
+ECON,2110,6,Principles of Microeconomics,0.18,0.47,0.24,0.06,0.0,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2015
+ECON,2110,7,Principles of Microeconomics,0.05,0.42,0.21,0.21,0.0,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2015
+ECON,2110,8,Principles of Microeconomics,0.11,0.47,0.26,0.11,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,9,Principles of Microeconomics,0.16,0.26,0.47,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,10,Principles of Microeconomics,0.0,0.37,0.42,0.0,0.11,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2015
+ECON,2110,11,Principles of Microeconomics,0.33,0.39,0.22,0.06,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,12,Principles of Microeconomics,0.05,0.53,0.21,0.11,0.0,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2015
+ECON,2110,13,Principles of Microeconomics,0.06,0.28,0.56,0.0,0.06,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2015
+ECON,2110,14,Principles of Microeconomics,0.37,0.32,0.21,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,15,Principles of Microeconomics,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,16,Principles of Microeconomics,0.22,0.28,0.28,0.06,0.0,0.0,0.0,0.17,frederick hanssen,,ECON-2110,2015
+ECON,2110,17,Principles of Microeconomics,0.21,0.53,0.16,0.05,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,18,Principles of Microeconomics,0.17,0.39,0.22,0.11,0.11,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,19,Principles of Microeconomics,0.11,0.53,0.32,0.05,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2015
+ECON,2110,20,Principles of Microeconomics,0.24,0.27,0.25,0.13,0.08,0.0,0.0,0.03,timothy jay bacon,,ECON-2110,2015
+ECON,2110,21,Principles of Microeconomics,0.21,0.48,0.29,0.02,0.0,0.0,0.0,0.0,michael makowsky,,ECON-2110,2015
+ECON,2110,22,Principles of Microeconomics,0.23,0.43,0.23,0.07,0.0,0.0,0.0,0.05,richard alan sessa,,ECON-2110,2015
+ECON,2110,23,Principles of Microeconomics,0.18,0.45,0.3,0.04,0.0,0.0,0.0,0.03,alexander fiore,,ECON-2110,2015
+ECON,2110,24,Principles of Microeconomics,0.32,0.33,0.21,0.07,0.02,0.0,0.0,0.03,leah jacq kitashima,,ECON-2110,2015
+ECON,2110,25,Principles of Microeconomics,0.28,0.33,0.23,0.08,0.03,0.0,0.0,0.08,charles thomas,,ECON-2110,2015
+ECON,2110,26,Principles of Microeconomics,0.29,0.39,0.18,0.05,0.08,0.0,0.0,0.0,jonathan orr ernest,,ECON-2110,2015
+ECON,2110,31,Principles of Microeconomics,0.2,0.59,0.21,0.01,0.0,0.0,0.0,0.0,alexander fiore,,ECON-2110,2015
+ECON,2110,32,Principles of Microeconomics,0.38,0.24,0.14,0.1,0.0,0.0,0.0,0.14,maria droganova,,ECON-2110,2015
+ECON,2110,33,Principles of Microeconomics,0.21,0.29,0.32,0.13,0.03,0.0,0.0,0.03,charles thomas,,ECON-2110,2015
+ECON,2110,34,Principles of Microeconomics,0.26,0.28,0.28,0.1,0.03,0.0,0.0,0.05,benjamin jo schwall,,ECON-2110,2015
+ECON,2110,35,Principles of Microeconomics,0.34,0.34,0.23,0.03,0.03,0.0,0.0,0.03,maria droganova,,ECON-2110,2015
+ECON,2110,38,Principles of Microeconomics,0.36,0.48,0.1,0.0,0.05,0.0,0.0,0.02,amanda caitlin kerr,,ECON-2110,2015
+ECON,2110,40,Principles of Micro (HON),0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert kennet fleck,True,ECON-2110,2015
+ECON,2110,41,Principles of Microeconomics,0.15,0.45,0.2,0.15,0.05,0.0,0.0,0.0,ce castellon chicas,,ECON-2110,2015
+ECON,2120,1,Principles of Macroeconomics,0.17,0.16,0.22,0.12,0.2,0.0,0.0,0.13,ralph charles allen,,ECON-2120,2015
+ECON,2120,2,Principles of Macroeconomics,0.33,0.27,0.31,0.07,0.02,0.0,0.0,0.0,peter david lorenz,,ECON-2120,2015
+ECON,2120,3,Principles of Macroeconomics,0.27,0.13,0.24,0.16,0.07,0.0,0.0,0.13,ralph charles allen,,ECON-2120,2015
+ECON,2120,4,Principles of Macroeconomics,0.26,0.3,0.24,0.09,0.04,0.0,0.0,0.07,andew swanson,,ECON-2120,2015
+ECON,2120,5,Principles of Macroeconomics,0.29,0.29,0.23,0.17,0.0,0.0,0.0,0.03,andew swanson,,ECON-2120,2015
+ECON,2120,6,Principles of Macroeconomics,0.38,0.19,0.28,0.0,0.13,0.0,0.0,0.03,peter david lorenz,,ECON-2120,2015
+ECON,2120,7,Principles of Macroeconomics,0.18,0.46,0.21,0.1,0.0,0.0,0.0,0.05,chen wang,,ECON-2120,2015
+ECON,2120,8,Principles of Macroeconomics,0.25,0.33,0.23,0.07,0.07,0.0,0.0,0.05,kelsey vict roberts,,ECON-2120,2015
+ECON,2120,9,Principles of Macroeconomics,0.26,0.31,0.18,0.15,0.03,0.0,0.0,0.08,shan jiang,,ECON-2120,2015
+ECON,2120,10,Principles of Macroeconomics,0.41,0.15,0.19,0.15,0.04,0.0,0.0,0.07,shan jiang,,ECON-2120,2015
+ECON,3020,1,Money and Banking,0.16,0.2,0.32,0.16,0.04,0.0,0.0,0.12,randall scot cragun,,ECON-3020,2015
+ECON,3060,1,Managerial Economics,0.33,0.28,0.13,0.08,0.1,0.0,0.0,0.08,jacob burgdorf,,ECON-3060,2015
+ECON,3100,1,International Econ,0.22,0.33,0.22,0.2,0.02,0.0,0.0,0.02,michal jerzmanowski,,ECON-3100,2015
+ECON,3140,1,Intermediate Micro,0.12,0.31,0.26,0.1,0.05,0.0,0.0,0.17,robert kennet fleck,,ECON-3140,2015
+ECON,3140,2,Intermediate Micro,0.28,0.26,0.21,0.06,0.06,0.0,0.0,0.13,molly espey,,ECON-3140,2015
+ECON,3140,3,Intermediate Micro,0.17,0.26,0.23,0.04,0.13,0.0,0.0,0.17,frederick hanssen,,ECON-3140,2015
+ECON,3150,1,Intermediate Macro,0.19,0.25,0.27,0.1,0.06,0.0,0.0,0.13,randall scot cragun,,ECON-3150,2015
+ECON,3150,2,Intermediate Macro,0.29,0.29,0.25,0.02,0.08,0.0,0.0,0.06,michal jerzmanowski,,ECON-3150,2015
+ECON,3190,1,Environmental Econ,0.16,0.46,0.35,0.0,0.0,0.0,0.0,0.03,molly espey,,ECON-3190,2015
+ECON,3600,1,Public Choice,0.38,0.38,0.2,0.0,0.0,0.0,0.0,0.05,robert dew tollison,,ECON-3600,2015
+ECON,3600,2,Public Choice,0.19,0.44,0.19,0.0,0.06,0.0,0.0,0.13,robert dew tollison,,ECON-3600,2015
+ECON,4010,1,Labor Mkt Analysis,0.31,0.31,0.23,0.0,0.08,0.0,0.0,0.08,chungsang lam,,ECON-4010,2015
+ECON,4020,1,Law and Economics,0.41,0.36,0.14,0.02,0.07,0.0,0.0,0.0,howard ne bodenhorn,,ECON-4020,2015
+ECON,4040,1,Comp Econ Systems,0.12,0.29,0.24,0.18,0.0,0.0,0.0,0.18,dar litsukova-bokar,,ECON-4040,2015
+ECON,4050,1,Intro to Econometric,0.18,0.38,0.24,0.06,0.12,0.0,0.0,0.03,jaqueline oliveira,,ECON-4050,2015
+ECON,4050,5,Intro to Econometric,0.23,0.27,0.35,0.08,0.04,0.0,0.0,0.04,scott barkowski,,ECON-4050,2015
+ECON,4100,1,Economic Development,0.11,0.63,0.0,0.0,0.11,0.0,0.0,0.16,robert tamura,,ECON-4100,2015
+ECON,4120,1,International Micro,0.37,0.32,0.27,0.02,0.0,0.0,0.0,0.02,scott baier,,ECON-4120,2015
+ECON,4220,1,Monetary Economics,0.29,0.48,0.19,0.0,0.0,0.0,0.0,0.05,gerald dwyer,,ECON-4220,2015
+ECON,4230,1,Economics of Health,0.43,0.17,0.26,0.09,0.0,0.0,0.0,0.04,daniel patri miller,,ECON-4230,2015
+ECON,4240,1,Organization of Ind,0.3,0.2,0.4,0.0,0.05,0.0,0.0,0.05,daniel patri miller,,ECON-4240,2015
+ECON,4350,1,Family Economics,0.55,0.25,0.15,0.03,0.0,0.0,0.0,0.03,jaqueline oliveira,,ECON-4350,2015
+ECON,6050,1,Intro to Econometric,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jaqueline oliveira,,ECON-6050,2015
+ECON,6060,1,Advanced Econometric,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,,ECON-6060,2015
+ECON,6120,1,Internatiional Micro,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-6120,2015
+ECON,8010,1,Microeconomic Theory,0.43,0.21,0.21,0.0,0.07,0.0,0.0,0.07,william dougan,,ECON-8010,2015
+ECON,8040,1,Applied Math Econ,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,curtis simon,,ECON-8040,2015
+ECON,8060,1,Econometrics I,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,,ECON-8060,2015
+ECON,8080,1,Econometrics III,0.38,0.25,0.19,0.0,0.06,0.0,0.0,0.13,paul wayne wilson,,ECON-8080,2015
+ECON,8160,1,Labor Economics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,,ECON-8160,2015
+ECON,8210,1,Public Choice,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,patrick warren,,ECON-8210,2015
+ECON,8230,1,Microecon Pub Pol,0.4,0.45,0.15,0.0,0.0,0.0,0.0,0.0,scott templeton,,ECON-8230,2015
+ECON,8240,1,Org of Industry,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,matthew lewis,,ECON-8240,2015
+ECON,8260,1,Econ Theory of Govt Regulation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,thomas wins hazlett,,ECON-8260,2015
+ECON,8400,1,International Trade,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,scott baier,,ECON-8400,2015
+ECON,9500,2,Monetary Economics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,,ECON-9500,2015
+ED,1050,2,Educ Orientation,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,william da mccorkle,,ED-1050,2015
+ED,1050,5,Educ Orientation,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,william da mccorkle,,ED-1050,2015
+ED,1050,6,Educ Orientation,0.68,0.16,0.05,0.05,0.0,0.0,0.0,0.05,william da mccorkle,,ED-1050,2015
+ED,1050,7,Educ Orientation,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,william da mccorkle,,ED-1050,2015
+ED,3970,5,Creative Inquiry in Education,0.8,0.08,0.0,0.0,0.0,0.0,0.0,0.12,david matthew boyer,,ED-3970,2015
+ED,3970,12,Creative Inquiry in Education,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,joseph benedic ryan,,ED-3970,2015
+ED,8380,404,Adolescent Development,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,heather rog brooker,,ED-8380,2015
+ED,8380,505,Literacy Lessons for Indiv I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,,ED-8380,2015
+ED,8380,510,Literacy Lessons for Indiv I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jamie felder white,,ED-8380,2015
+ED,8380,511,Literacy Lessons for Indiv I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ellen adkin sanford,,ED-8380,2015
+ED,8380,512,Literacy Lessons for Indiv I,0.4,0.2,0.0,0.0,0.0,0.0,0.0,0.4,kimberly fair floyd,,ED-8380,2015
+ED,8380,530,Improving Literacy Outcomes fo,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,renee gatlin anders,,ED-8380,2015
+ED,8670,500,Practicum in ESOL Instruction,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,margaret mar warner,,ED-8670,2015
+EDC,3900,1,Skills for Stu Leads,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,mary price,,EDC-3900,2015
+EDC,3900,2,Skills for Stu Leads,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,leasa ann  evinger,,EDC-3900,2015
+EDC,8110,1,Multicultural Couns,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,robin phelps-ward,,EDC-8110,2015
+EDC,8110,2,Multicultural Couns,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,,EDC-8110,2015
+EDC,8130,1,Appraisal Procedures,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,amy sue milsom,,EDC-8130,2015
+EDEC,3000,1,Found Early Chld Ed,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,,EDEC-3000,2015
+EDEC,4300,1,Early Childhd Math,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,sandra mamma linder,,EDEC-4300,2015
+EDEC,4400,1,Early Childhood Engl Lang Art,0.78,0.13,0.09,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-4400,2015
+EDEC,4600,1,Critical Iss/Diversity in ECE,0.91,0.04,0.0,0.04,0.0,0.0,0.0,0.0,dolores an stegelin,,EDEC-4600,2015
+EDEC,8100,1,Adv Ece Found & Meth,0.56,0.11,0.22,0.11,0.0,0.0,0.0,0.0,dolores an stegelin,,EDEC-8100,2015
+EDEL,3210,1,Pe for the Elem Tchr,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2015
+EDEL,3210,2,Pe for the Elem Tchr,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2015
+EDEL,4010,1,Elem Field Exp,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,ann marie liebel,,EDEL-4010,2015
+EDEL,4010,2,Elem Field Exp,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ann marie liebel,,EDEL-4010,2015
+EDEL,4510,1,Elem Methods in Science Tchg,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,cynthia chri deaton,,EDEL-4510,2015
+EDEL,4510,2,Elem Methods in Science Tchg,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,,EDEL-4510,2015
+EDEL,4870,1,Ele Meth Soc Studies,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,melinda spearman,,EDEL-4870,2015
+EDEL,4870,2,Ele Meth Soc Studies,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,,EDEL-4870,2015
+EDEL,4880,1,Elem Meth La Tchng,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,jacquelynn malloy,,EDEL-4880,2015
+EDEL,4880,2,Elem Meth La Tchng,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,,EDEL-4880,2015
+EDF,3010,1,Principles of American Educat,0.58,0.35,0.06,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,,EDF-3010,2015
+EDF,3010,2,Principles of American Educat,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,,EDF-3010,2015
+EDF,3020,3,Educational Psychology,0.34,0.28,0.21,0.14,0.0,0.0,0.0,0.03,penelope mar vargas,,EDF-3020,2015
+EDF,3020,4,Educational Psychology,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,penelope mar vargas,,EDF-3020,2015
+EDF,3080,1,Classroom Assessment,0.7,0.22,0.09,0.0,0.0,0.0,0.0,0.0,deborah switzer,,EDF-3080,2015
+EDF,3080,2,Classroom Assessment,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,deborah switzer,,EDF-3080,2015
+EDF,3200,1,History of US Education,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,,EDF-3200,2015
+EDF,3340,1,Child Growth and Development,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,andrea emerson,,EDF-3340,2015
+EDF,3340,2,Child Growth and Development,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,,EDF-3340,2015
+EDF,3350,1,Adolescent Growth & Develop,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,,EDF-3350,2015
+EDF,4800,1,Digital Media & Learning,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2015
+EDF,4800,2,Digital Media & Learning,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2015
+EDF,4800,3,Digital Media & Learning,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2015
+EDF,6900,400,Classroom Management,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,heather rog brooker,,EDF-6900,2015
+EDF,8010,1,Human Growth and Development,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeromy blake snider,,EDF-8010,2015
+EDF,8710,501,Cultural Diversity in Educatio,0.6,0.3,0.05,0.0,0.05,0.0,0.0,0.0,sus cridland-hughes,,EDF-8710,2015
+EDF,9010,1,Learning Sciences Seminar I,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,david matthew boyer,,EDF-9010,2015
+EDF,9270,1,Quant Rsrch & Stats for Ed,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,jennie lynn farmer,,EDF-9270,2015
+EDF,9270,2,Quant Rsrch & Stats for Ed,0.67,0.17,0.0,0.08,0.0,0.0,0.0,0.08,jennie lynn farmer,,EDF-9270,2015
+EDL,7000,502,Public School Adm,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,frederick buskey,,EDL-7000,2015
+EDL,7300,500,Techniq of Supervision-Pub Sch,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,,EDL-7300,2015
+EDL,7400,500,Curr Plan: Sch Adm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,,EDL-7400,2015
+EDL,9110,400,Systematic Inq Ed L,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,,EDL-9110,2015
+EDL,9250,501,Instructional Leadership,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,elizabeth reynolds,,EDL-9250,2015
+EDLT,4590,1,Teaching Reading Grades K-3,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,linda gambrell,,EDLT-4590,2015
+EDLT,4600,3,Teaching Reading Grades 2-6,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,,EDLT-4600,2015
+EDLT,4600,5,Teaching Reading Grades 2-6,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,,EDLT-4600,2015
+EDLT,4610,1,Content Area Rdg: Grades 2-6,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,pamela dunston,,EDLT-4610,2015
+EDLT,4610,2,Content Area Rdg: Grades 2-6,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-4610,2015
+EDLT,4980,4,Secondary Content Area Reading,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.04,barbara everson,,EDLT-4980,2015
+EDLT,8120,500,Reading-Writing Assess Strat,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8120,2015
+EDLT,8140,500,Instr & Asmnt Diverse Students,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-8140,2015
+EDLT,8270,400,Disciplinary Literacies 6-12,0.74,0.11,0.05,0.05,0.05,0.0,0.0,0.0,corrie leigh martin,,EDLT-8270,2015
+EDLT,8800,502,Reading Recovery Teacher I,0.54,0.23,0.15,0.0,0.0,0.0,0.0,0.08,mary petters,,EDLT-8800,2015
+EDLT,8820,502,Read Recovery Practicum I,0.38,0.38,0.15,0.0,0.0,0.0,0.0,0.08,mary petters,,EDLT-8820,2015
+EDLT,9140,1,"Lang Dev, Diversity, Discourse",0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,mikel walker cole,,EDLT-9140,2015
+EDSC,2260,1,Pr Apprch to Sec Alg,0.57,0.21,0.14,0.0,0.0,0.0,0.0,0.07,stacy megan che,,EDSC-2260,2015
+EDSC,3240,1,Practicum Sec Engl,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,amy tali hallenbeck,,EDSC-3240,2015
+EDSC,4240,1,Tchng Sec English,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,,EDSC-4240,2015
+EDSC,4260,1,Tchng Sec Math,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,dennis aminie kombe,,EDSC-4260,2015
+EDSC,8620,400,Methods & Strat Secondary Math,0.67,0.0,0.17,0.17,0.0,0.0,0.0,0.0,nicole alai sinwell,,EDSC-8620,2015
+EDSP,3700,2,Intro to Special Education,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,,EDSP-3700,2015
+EDSP,3700,3,Intro to Special Education,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,,EDSP-3700,2015
+EDSP,3700,4,Intro to Special Education,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,bridget carv briley,,EDSP-3700,2015
+EDSP,3720,1,Char & Instr Individ with LD,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,,EDSP-3720,2015
+EDSP,4920,1,Math Inst Ind W/Dis,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,,EDSP-4920,2015
+EDSP,4940,1,Tchg Rdg Mild Dis,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,,EDSP-4940,2015
+EDSP,8530,1,Legal/Pol Issu Sp Ed,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,,EDSP-8530,2015
+EDSP,8530,2,Legal/Pol Issu Sp Ed,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,,EDSP-8530,2015
+EES,2010,1,Environ Engr Fundamentals I,0.31,0.5,0.13,0.0,0.03,0.0,0.0,0.03,david freedman,,EES-2010,2015
+EES,3030,1,Water Treatment Systems,0.5,0.38,0.12,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3030,2015
+EES,3040,1,Wastewater Treatment Systems,0.38,0.44,0.15,0.03,0.0,0.0,0.0,0.0,david freedman,,EES-3040,2015
+EES,3050,1,Water/Wastewater Treatment Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2015
+EES,3050,2,Water/Wastewater Treatment Lab,0.64,0.29,0.0,0.07,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2015
+EES,4010,1,Environmental Engr,0.46,0.46,0.0,0.0,0.05,0.0,0.0,0.03,elizabeth carraway,,EES-4010,2015
+EES,4010,2,Environmental Engr,0.04,0.63,0.3,0.0,0.0,0.0,0.0,0.04,mark schlautman,,EES-4010,2015
+EES,4300,1,Air Pollution Engineering,0.15,0.37,0.39,0.02,0.07,0.0,0.0,0.0,thomas overcamp,,EES-4300,2015
+EES,4500,1,Professional Seminar,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,thomas overcamp,,EES-4500,2015
+EES,4800,1,Environmental Risk Assessment,0.22,0.24,0.27,0.19,0.05,0.0,0.0,0.03,timothy devol,,EES-4800,2015
+EES,4860,1,Environmental Sustainability,0.53,0.33,0.1,0.0,0.04,0.0,0.0,0.0,michael anthon dale,,EES-4860,2015
+EES,4900,11,CI-EvalWaterQual & Kidney Corr,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,david allen ladner,,EES-4900,2015
+EES,6100,1,Environ Radiation Protection I,0.33,0.58,0.0,0.08,0.0,0.0,0.0,0.0,nicole eli martinez,,EES-6100,2015
+EES,6800,1,Environmental Risk Assessment,0.36,0.29,0.21,0.07,0.0,0.0,0.0,0.07,timothy devol,,EES-6800,2015
+EES,6860,1,Environmental Sustainability,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,,EES-6860,2015
+EES,8020,1,Environ Eng Prin,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,david allen ladner,,EES-8020,2015
+EES,8430,1,Environmental Chem,0.47,0.41,0.03,0.0,0.0,0.0,0.0,0.09,brian powell,,EES-8430,2015
+EES,8510,1,Biol Prin Envir Engr,0.42,0.32,0.11,0.0,0.0,0.0,0.0,0.16,kevin thom finneran,,EES-8510,2015
+EES,9610,1,Ee&S Phd Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,brian powell,,EES-9610,2015
+ELE,3010,1,Intro to Entre,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,ELE-3010,2015
+ELE,3010,2,Intro to Entre,0.51,0.34,0.0,0.0,0.0,0.03,0.0,0.11,chad navis,,ELE-3010,2015
+ELE,3010,3,Intro to Entre,0.31,0.56,0.14,0.0,0.0,0.0,0.0,0.0,ashley will parnell,,ELE-3010,2015
+ELE,4010,1,Exec Lead & Entr II,0.28,0.5,0.15,0.05,0.03,0.0,0.0,0.0,ashley will parnell,,ELE-4010,2015
+ENGL,1030,2,Accelerated Composition,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,trevor lanc seigler,,ENGL-1030,2015
+ENGL,1030,3,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,madison ali johnson,,ENGL-1030,2015
+ENGL,1030,4,Accelerated Composition,0.26,0.32,0.11,0.11,0.21,0.0,0.0,0.0,todd rossi smith,,ENGL-1030,2015
+ENGL,1030,5,Accelerated Composition,0.74,0.11,0.0,0.0,0.05,0.0,0.0,0.11,emily anne boyter,,ENGL-1030,2015
+ENGL,1030,6,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,,ENGL-1030,2015
+ENGL,1030,7,Accelerated Composition,0.42,0.37,0.05,0.05,0.05,0.0,0.0,0.05,melissa dugan,,ENGL-1030,2015
+ENGL,1030,8,Accelerated Composition,0.61,0.28,0.0,0.06,0.0,0.0,0.0,0.06,madison ali johnson,,ENGL-1030,2015
+ENGL,1030,9,Accelerated Composition,0.37,0.42,0.11,0.05,0.0,0.0,0.0,0.05,kristen joy hixon,,ENGL-1030,2015
+ENGL,1030,10,Accelerated Composition,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-1030,2015
+ENGL,1030,11,Accelerated Composition,0.58,0.26,0.11,0.05,0.0,0.0,0.0,0.0,rebecca nico shaver,,ENGL-1030,2015
+ENGL,1030,13,Accelerated Composition,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,crystal pa stephens,,ENGL-1030,2015
+ENGL,1030,14,Accelerated Composition,0.21,0.53,0.05,0.11,0.11,0.0,0.0,0.0,todd rossi smith,,ENGL-1030,2015
+ENGL,1030,15,Accelerated Composition,0.53,0.26,0.05,0.05,0.0,0.0,0.0,0.11,candace wiley,,ENGL-1030,2015
+ENGL,1030,16,Accelerated Composition,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kristen joy hixon,,ENGL-1030,2015
+ENGL,1030,17,Accelerated Composition,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,mary dickens,,ENGL-1030,2015
+ENGL,1030,18,Accelerated Composition,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,melissa dugan,,ENGL-1030,2015
+ENGL,1030,19,Accelerated Composition,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,katie jo vann,,ENGL-1030,2015
+ENGL,1030,21,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,candace wiley,,ENGL-1030,2015
+ENGL,1030,22,Accelerated Composition,0.35,0.59,0.0,0.0,0.0,0.0,0.0,0.06,mary dickens,,ENGL-1030,2015
+ENGL,1030,23,Accelerated Composition,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,rebecca nico shaver,,ENGL-1030,2015
+ENGL,1030,26,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,chloe mich whitaker,,ENGL-1030,2015
+ENGL,1030,27,Accelerated Composition,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,katie jo vann,,ENGL-1030,2015
+ENGL,1030,28,Accelerated Composition,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,caroline ca swanson,,ENGL-1030,2015
+ENGL,1030,29,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,karen mary stewart,,ENGL-1030,2015
+ENGL,1030,30,Accelerated Composition,0.84,0.0,0.05,0.0,0.11,0.0,0.0,0.0,teneshia head,,ENGL-1030,2015
+ENGL,1030,31,Accelerated Composition,0.53,0.42,0.0,0.0,0.05,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2015
+ENGL,1030,32,Accelerated Composition,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,chloe mich whitaker,,ENGL-1030,2015
+ENGL,1030,33,Accelerated Composition,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,daniel frank,,ENGL-1030,2015
+ENGL,1030,34,Accelerated Composition,0.79,0.05,0.0,0.0,0.11,0.0,0.0,0.05,eda ozyesilpinar,,ENGL-1030,2015
+ENGL,1030,35,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,,ENGL-1030,2015
+ENGL,1030,36,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2015
+ENGL,1030,37,Accelerated Composition,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel frank,,ENGL-1030,2015
+ENGL,1030,38,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,stephen quigley,,ENGL-1030,2015
+ENGL,1030,39,Accelerated Composition,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,charlotte powell,,ENGL-1030,2015
+ENGL,1030,40,Accelerated Composition,0.37,0.32,0.21,0.0,0.11,0.0,0.0,0.0,caroline ca swanson,,ENGL-1030,2015
+ENGL,1030,41,Accelerated Composition,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,eda ozyesilpinar,,ENGL-1030,2015
+ENGL,1030,42,Accelerated Composition,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,austin gorman,,ENGL-1030,2015
+ENGL,1030,43,Accelerated Composition,0.47,0.32,0.05,0.05,0.11,0.0,0.0,0.0,adrian carson,,ENGL-1030,2015
+ENGL,1030,44,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jack butts,,ENGL-1030,2015
+ENGL,1030,45,Accelerated Composition,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,jason crider,,ENGL-1030,2015
+ENGL,1030,46,Accelerated Composition,0.58,0.26,0.0,0.0,0.05,0.0,0.0,0.11,joshua wood,,ENGL-1030,2015
+ENGL,1030,47,Accelerated Composition,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,kellie eliz osborne,,ENGL-1030,2015
+ENGL,1030,48,Accelerated Composition,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,jason crider,,ENGL-1030,2015
+ENGL,1030,49,Accelerated Composition,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,eric stephens,,ENGL-1030,2015
+ENGL,1030,50,Accelerated Composition,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,jennifer moeder,,ENGL-1030,2015
+ENGL,1030,51,Accelerated Composition,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,april obrien,,ENGL-1030,2015
+ENGL,1030,52,Accelerated Composition,0.47,0.42,0.0,0.0,0.11,0.0,0.0,0.0,adrian carson,,ENGL-1030,2015
+ENGL,1030,53,Accelerated Composition,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,april obrien,,ENGL-1030,2015
+ENGL,1030,54,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,danielle shuff,,ENGL-1030,2015
+ENGL,1030,55,Accelerated Composition,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,brian lee gaines,,ENGL-1030,2015
+ENGL,1030,56,Accelerated Composition,0.26,0.47,0.11,0.0,0.05,0.0,0.0,0.11,charlotte powell,,ENGL-1030,2015
+ENGL,1030,57,Accelerated Composition,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,,ENGL-1030,2015
+ENGL,1030,58,Accelerated Composition,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,brian lee gaines,,ENGL-1030,2015
+ENGL,1030,59,Accelerated Composition,0.53,0.32,0.05,0.05,0.05,0.0,0.0,0.0,stephen quigley,,ENGL-1030,2015
+ENGL,1030,60,Accelerated Composition,0.63,0.21,0.05,0.0,0.0,0.0,0.0,0.11,danielle shuff,,ENGL-1030,2015
+ENGL,1030,64,Accelerated Composition,0.58,0.37,0.0,0.05,0.0,0.0,0.0,0.0,jack butts,,ENGL-1030,2015
+ENGL,1030,65,Accelerated Composition,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joshua wood,,ENGL-1030,2015
+ENGL,1030,66,Accelerated Composition,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,eric stephens,,ENGL-1030,2015
+ENGL,1030,67,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,kellie eliz osborne,,ENGL-1030,2015
+ENGL,1030,68,Accelerated Composition,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jennifer moeder,,ENGL-1030,2015
+ENGL,1030,500,Accelerated Composition,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-1030,2015
+ENGL,1030,501,Accelerated Composition,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-1030,2015
+ENGL,2120,1,World Literature,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,john morgenstern,,ENGL-2120,2015
+ENGL,2120,3,World Literature,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,garry bertholf,,ENGL-2120,2015
+ENGL,2120,5,World Literature,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,christopher benson,,ENGL-2120,2015
+ENGL,2120,6,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-2120,2015
+ENGL,2120,7,World Literature,0.32,0.25,0.29,0.07,0.04,0.0,0.0,0.04,andrew mathas,,ENGL-2120,2015
+ENGL,2120,8,World Literature,0.37,0.3,0.15,0.07,0.04,0.0,0.0,0.07,andrew mathas,,ENGL-2120,2015
+ENGL,2120,9,World Literature,0.52,0.37,0.07,0.0,0.0,0.0,0.0,0.04,jeffrey fallis,,ENGL-2120,2015
+ENGL,2120,10,World Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey fallis,,ENGL-2120,2015
+ENGL,2120,11,World Literature,0.61,0.29,0.04,0.0,0.04,0.0,0.0,0.04,lucian ghita,,ENGL-2120,2015
+ENGL,2120,12,World Literature,0.56,0.28,0.04,0.0,0.04,0.0,0.0,0.08,lucian ghita,,ENGL-2120,2015
+ENGL,2120,13,World Literature,0.12,0.48,0.16,0.04,0.16,0.0,0.0,0.04,meg woosley-goodman,,ENGL-2120,2015
+ENGL,2120,14,World Literature,0.29,0.43,0.11,0.07,0.07,0.0,0.0,0.04,meg woosley-goodman,,ENGL-2120,2015
+ENGL,2120,15,World Literature,0.19,0.62,0.12,0.0,0.08,0.0,0.0,0.0,meg woosley-goodman,,ENGL-2120,2015
+ENGL,2120,16,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,,ENGL-2120,2015
+ENGL,2120,17,World Literature,0.58,0.15,0.12,0.04,0.08,0.0,0.0,0.04,geveryl le robinson,,ENGL-2120,2015
+ENGL,2120,18,World Literature,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,,ENGL-2120,2015
+ENGL,2120,19,World Literature,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,geveryl le robinson,,ENGL-2120,2015
+ENGL,2130,1,British Literature,0.46,0.42,0.12,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-2130,2015
+ENGL,2130,2,British Literature,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-2130,2015
+ENGL,2130,3,British Literature,0.71,0.18,0.04,0.0,0.04,0.0,0.0,0.04,stephanie stripling,,ENGL-2130,2015
+ENGL,2130,5,British Literature,0.64,0.21,0.04,0.0,0.04,0.0,0.0,0.07,lucian ghita,,ENGL-2130,2015
+ENGL,2130,7,British Literature,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,,ENGL-2130,2015
+ENGL,2130,9,British Literature,0.85,0.08,0.0,0.0,0.04,0.0,0.0,0.04,krist aldebol-hazle,,ENGL-2130,2015
+ENGL,2130,10,British Literature,0.61,0.14,0.0,0.11,0.14,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-2130,2015
+ENGL,2130,11,British Literature,0.6,0.2,0.0,0.04,0.04,0.0,0.0,0.12,krist aldebol-hazle,,ENGL-2130,2015
+ENGL,2130,12,British Literature,0.56,0.3,0.04,0.0,0.07,0.0,0.0,0.04,sherri teres allred,,ENGL-2130,2015
+ENGL,2130,13,British Literature,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,sherri teres allred,,ENGL-2130,2015
+ENGL,2140,1,American Literature,0.68,0.18,0.08,0.02,0.01,0.0,0.0,0.02, barton palmer,,ENGL-2140,2015
+ENGL,2140,5,American Literature,0.32,0.32,0.29,0.04,0.0,0.0,0.0,0.04,william stanton,,ENGL-2140,2015
+ENGL,2140,6,American Literature,0.14,0.68,0.11,0.0,0.07,0.0,0.0,0.0,william stanton,,ENGL-2140,2015
+ENGL,2140,7,American Literature,0.52,0.3,0.15,0.0,0.04,0.0,0.0,0.0,john morgenstern,,ENGL-2140,2015
+ENGL,2140,8,American Literature,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-2140,2015
+ENGL,2140,9,American Literature,0.57,0.29,0.11,0.0,0.0,0.0,0.0,0.04,sharon kathl nalley,,ENGL-2140,2015
+ENGL,2140,10,American Literature,0.48,0.33,0.0,0.0,0.05,0.0,0.0,0.14,candace wiley,,ENGL-2140,2015
+ENGL,2140,11,American Literature,0.44,0.37,0.04,0.0,0.04,0.0,0.0,0.11,candace wiley,,ENGL-2140,2015
+ENGL,2140,12,American Literature,0.59,0.3,0.07,0.04,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-2140,2015
+ENGL,2140,13,American Literature,0.68,0.21,0.04,0.04,0.0,0.0,0.0,0.04,crystal pa stephens,,ENGL-2140,2015
+ENGL,2140,14,American Literature,0.3,0.41,0.11,0.0,0.07,0.0,0.0,0.11,sharon kathl nalley,,ENGL-2140,2015
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.36,0.39,0.21,0.0,0.04,0.0,0.0,0.0,andrew mathas,,ENGL-2150,2015
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.36,0.43,0.07,0.04,0.04,0.0,0.0,0.07,andrew mathas,,ENGL-2150,2015
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.54,0.21,0.21,0.04,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2015
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.43,0.25,0.18,0.04,0.0,0.0,0.0,0.11,john logan pursley,,ENGL-2150,2015
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.64,0.18,0.11,0.04,0.0,0.0,0.0,0.04,john logan pursley,,ENGL-2150,2015
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.38,0.38,0.19,0.0,0.0,0.0,0.0,0.04,agnieszka skrodzka,,ENGL-2150,2015
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.68,0.18,0.07,0.0,0.0,0.0,0.0,0.07,april susanne pelt,,ENGL-2150,2015
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,alexander kudera,,ENGL-2150,2015
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.64,0.32,0.0,0.0,0.04,0.0,0.0,0.0,alexander kudera,,ENGL-2150,2015
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2150,2015
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.15,0.5,0.15,0.0,0.04,0.0,0.0,0.15,david charles foltz,,ENGL-2150,2015
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.13,0.38,0.17,0.04,0.08,0.0,0.0,0.21,david charles foltz,,ENGL-2150,2015
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.14,0.43,0.18,0.07,0.04,0.0,0.0,0.14,david charles foltz,,ENGL-2150,2015
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.11,0.37,0.15,0.04,0.15,0.0,0.0,0.19,david charles foltz,,ENGL-2150,2015
+ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.64,0.25,0.04,0.07,0.0,0.0,0.0,0.0,stephanie stripling,,ENGL-2150,2015
+ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,stephanie stripling,,ENGL-2150,2015
+ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey fallis,,ENGL-2150,2015
+ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,austin gorman,,ENGL-2150,2015
+ENGL,2150,100,20th - 21st Century Lit (HON),0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,True,ENGL-2150,2015
+ENGL,2150,101,20th-21st Century Lit (HON),0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True,ENGL-2150,2015
+ENGL,3010,1,Grt Books West World,0.15,0.77,0.0,0.08,0.0,0.0,0.0,0.0,colin pearce,,ENGL-3010,2015
+ENGL,3040,3,Business Writing,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,,ENGL-3040,2015
+ENGL,3040,4,Business Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3040,2015
+ENGL,3040,11,Business Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexander kudera,,ENGL-3040,2015
+ENGL,3040,12,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-3040,2015
+ENGL,3040,15,Business Writing,0.16,0.26,0.37,0.11,0.05,0.0,0.0,0.05,megan no macalystre,,ENGL-3040,2015
+ENGL,3040,16,Business Writing,0.44,0.44,0.06,0.0,0.06,0.0,0.0,0.0,megan no macalystre,,ENGL-3040,2015
+ENGL,3040,19,Business Writing,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-3040,2015
+ENGL,3040,20,Business Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,,ENGL-3040,2015
+ENGL,3100,1,Crit Writ Lit,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,,ENGL-3100,2015
+ENGL,3100,2,Crit Writ Lit,0.68,0.16,0.05,0.0,0.05,0.0,0.0,0.05,walter edgar hunter,,ENGL-3100,2015
+ENGL,3100,3,Crit Writ Lit,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,david sweene coombs,,ENGL-3100,2015
+ENGL,3100,4,Crit Writ Lit,0.31,0.56,0.0,0.0,0.06,0.0,0.0,0.06,agnieszka skrodzka,,ENGL-3100,2015
+ENGL,3120,1,Advanced Composition,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2015
+ENGL,3120,2,Advanced Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2015
+ENGL,3140,1,Technical Writing,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,william pulley,,ENGL-3140,2015
+ENGL,3140,2,Technical Writing,0.39,0.33,0.28,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2015
+ENGL,3140,3,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,,ENGL-3140,2015
+ENGL,3140,4,Technical Writing,0.63,0.11,0.16,0.0,0.0,0.0,0.0,0.11,melissa dugan,,ENGL-3140,2015
+ENGL,3140,5,Technical Writing,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,melissa dugan,,ENGL-3140,2015
+ENGL,3140,6,Technical Writing,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2015
+ENGL,3140,7,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2015
+ENGL,3140,8,Technical Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,,ENGL-3140,2015
+ENGL,3140,10,Technical Writing,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2015
+ENGL,3140,11,Technical Writing,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2015
+ENGL,3140,12,Technical Writing,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,katalin beck,,ENGL-3140,2015
+ENGL,3140,14,Technical Writing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,brian adam smith,,ENGL-3140,2015
+ENGL,3140,19,Technical Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,,ENGL-3140,2015
+ENGL,3140,20,Technical Writing,0.32,0.21,0.11,0.05,0.11,0.0,0.0,0.21,matthew jose osborn,,ENGL-3140,2015
+ENGL,3140,21,Technical Writing,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,heathe christiansen,,ENGL-3140,2015
+ENGL,3140,22,Technical Writing,0.74,0.05,0.05,0.0,0.11,0.0,0.0,0.05,kristen gay,,ENGL-3140,2015
+ENGL,3140,23,Technical Writing,0.72,0.11,0.06,0.0,0.0,0.0,0.0,0.11,kristen gay,,ENGL-3140,2015
+ENGL,3140,100,Technical Writing (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,True,ENGL-3140,2015
+ENGL,3140,400,Technical Writing,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,john conway,,ENGL-3140,2015
+ENGL,3140,401,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-3140,2015
+ENGL,3150,1,Scientific Writing & Comm,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,barbara ramirez,,ENGL-3150,2015
+ENGL,3150,2,Scientific Writing & Comm,0.11,0.68,0.05,0.0,0.0,0.0,0.0,0.16,barbara ramirez,,ENGL-3150,2015
+ENGL,3150,3,Scientific Writing & Comm,0.58,0.16,0.11,0.05,0.05,0.0,0.0,0.05,william pulley,,ENGL-3150,2015
+ENGL,3150,4,Scientific Writing & Comm,0.58,0.21,0.11,0.0,0.0,0.0,0.0,0.11,william pulley,,ENGL-3150,2015
+ENGL,3150,401,Sci Writing & Communication,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,,ENGL-3150,2015
+ENGL,3150,402,Sci Writing & Communication,0.21,0.53,0.11,0.0,0.0,0.0,0.0,0.16,carleton dew salley,,ENGL-3150,2015
+ENGL,3320,1,Visual Communication,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,tharon howard,,ENGL-3320,2015
+ENGL,3450,1,Structure of Fiction,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-3450,2015
+ENGL,3460,2,Structure of Poetry,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-3460,2015
+ENGL,3470,1,Structure of Drama,0.54,0.31,0.08,0.08,0.0,0.0,0.0,0.0,jillian weise,,ENGL-3470,2015
+ENGL,3560,1,Science Fiction,0.33,0.33,0.2,0.0,0.0,0.0,0.0,0.13,lindsay carr thomas,,ENGL-3560,2015
+ENGL,3570,1,Film,0.21,0.53,0.16,0.0,0.0,0.0,0.0,0.11,amy monaghan,,ENGL-3570,2015
+ENGL,3570,2,Film,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2015
+ENGL,3570,3,Film,0.12,0.76,0.12,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2015
+ENGL,3800,1,Women Writers,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,meg woosley-goodman,,ENGL-3800,2015
+ENGL,3850,1,Children's Lit,0.33,0.2,0.33,0.0,0.13,0.0,0.0,0.0,megan no macalystre,,ENGL-3850,2015
+ENGL,3960,1,Brit Lit Survey I,0.2,0.3,0.3,0.05,0.0,0.0,0.0,0.15,erin marina goss,,ENGL-3960,2015
+ENGL,3960,2,Brit Lit Survey I,0.2,0.25,0.35,0.0,0.15,0.0,0.0,0.05,erin marina goss,,ENGL-3960,2015
+ENGL,3960,3,Brit Lit Survey I,0.19,0.06,0.38,0.0,0.06,0.0,0.0,0.31,erin marina goss,,ENGL-3960,2015
+ENGL,3970,1,Brit Lit Survey II,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,david sweene coombs,,ENGL-3970,2015
+ENGL,3980,2,Amer Lit Survey I,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,jonathan beec field,,ENGL-3980,2015
+ENGL,3990,1,Amer Lit Survey II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-3990,2015
+ENGL,4010,1,Grammar Survey,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,william stockton,,ENGL-4010,2015
+ENGL,4070,1,Medieval Period,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,andrew lemons,,ENGL-4070,2015
+ENGL,4110,1,Shakespeare,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,,ENGL-4110,2015
+ENGL,4110,2,Shakespeare,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4110,2015
+ENGL,4140,1,Milton,0.2,0.4,0.2,0.0,0.1,0.0,0.0,0.1,lee morrissey,,ENGL-4140,2015
+ENGL,4160,1,Romantic Period,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,erin marina goss,,ENGL-4160,2015
+ENGL,4170,1,Victorian Period,0.0,0.58,0.25,0.08,0.0,0.0,0.0,0.08,kimberly manganelli,,ENGL-4170,2015
+ENGL,4210,1,Amer Lit 1800-1899,0.38,0.38,0.08,0.08,0.0,0.0,0.0,0.08,dominic mastroianni,,ENGL-4210,2015
+ENGL,4280,1,Contemporary Literature,0.33,0.2,0.33,0.0,0.0,0.0,0.0,0.13,michael lemahieu,,ENGL-4280,2015
+ENGL,4340,1,Environmental Lit,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,sean morey,,ENGL-4340,2015
+ENGL,4350,1,Literary Criticism,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,dominic mastroianni,,ENGL-4350,2015
+ENGL,4430,1,Theories of World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-4430,2015
+ENGL,4510,1,Film Theo/Criticism,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0, barton palmer,,ENGL-4510,2015
+ENGL,4600,1,Writing Technologies,0.53,0.27,0.07,0.0,0.0,0.0,0.0,0.13,lindsay carr thomas,,ENGL-4600,2015
+ENGL,4750,1,Writing for Media,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,megan eatman,,ENGL-4750,2015
+ENGL,4780,1,Digital Literacy,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,,ENGL-4780,2015
+ENGL,4820,1,Afr Am Lit to 1920,0.3,0.2,0.3,0.0,0.2,0.0,0.0,0.0,rhondda robi thomas,,ENGL-4820,2015
+ENGL,4960,1,Senior Seminar,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.0,wayne chapman,,ENGL-4960,2015
+ENGL,4960,2,Senior Seminar,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,,ENGL-4960,2015
+ENGL,4960,3,Senior Seminar,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,,ENGL-4960,2015
+ENGL,4990,2,Practicum in Writing,0.0,0.0,0.0,0.0,0.0,0.82,0.0,0.18,elizabeth rivlin,,ENGL-4990,2015
+ENGL,8050,1,Topics in Medieval Literature,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,andrew lemons,,ENGL-8050,2015
+ENGL,8140,1,Topics Vict & Mod British Lit,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,wayne chapman,,ENGL-8140,2015
+ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,steven brandon,,ENGR-1000,2015
+ENGR,1050,111,Engr Discipline & Skills I,0.49,0.37,0.07,0.02,0.0,0.0,0.0,0.05,christopher norfolk,,ENGR-1050,2015
+ENGR,1050,112,Engr Discipline & Skills I,0.4,0.38,0.12,0.02,0.0,0.0,0.0,0.07,mariah magagnotti,,ENGR-1050,2015
+ENGR,1050,113,Engr Discipline & Skills I,0.33,0.33,0.19,0.07,0.05,0.0,0.0,0.05,mariah magagnotti,,ENGR-1050,2015
+ENGR,1050,114,Engr Discipline & Skills I,0.45,0.36,0.1,0.0,0.02,0.0,0.0,0.07,matthew kent miller,,ENGR-1050,2015
+ENGR,1050,115,Engr Discipline & Skills I,0.43,0.4,0.12,0.02,0.0,0.0,0.0,0.02,matthew kent miller,,ENGR-1050,2015
+ENGR,1050,117,Engr Discipline & Skills I,0.57,0.29,0.02,0.07,0.0,0.0,0.0,0.05,matthew kent miller,,ENGR-1050,2015
+ENGR,1050,118,Engr Discipline & Skills I,0.29,0.5,0.07,0.07,0.05,0.0,0.0,0.02,matthew kent miller,,ENGR-1050,2015
+ENGR,1050,211,Engr Discipline & Skills I,0.53,0.27,0.07,0.0,0.04,0.0,0.0,0.09,ashley childers,,ENGR-1050,2015
+ENGR,1050,212,Engr Discipline & Skills I,0.47,0.4,0.05,0.02,0.0,0.0,0.0,0.05,ashley childers,,ENGR-1050,2015
+ENGR,1050,213,Engr Discipline & Skills I,0.38,0.36,0.14,0.05,0.0,0.0,0.0,0.07,andrew isaa neptune,,ENGR-1050,2015
+ENGR,1050,214,Engr Discipline & Skills I,0.22,0.39,0.32,0.05,0.02,0.0,0.0,0.0,andrew isaa neptune,,ENGR-1050,2015
+ENGR,1050,215,Engr Discipline & Skills I,0.17,0.25,0.27,0.15,0.02,0.0,0.0,0.13,mariah magagnotti,,ENGR-1050,2015
+ENGR,1050,216,Engr Discipline & Skills I,0.14,0.26,0.29,0.12,0.1,0.0,0.0,0.1,mariah magagnotti,,ENGR-1050,2015
+ENGR,1050,217,Engr Discipline & Skills I,0.37,0.39,0.2,0.0,0.02,0.0,0.0,0.02,andrew isaa neptune,,ENGR-1050,2015
+ENGR,1050,218,Engr Discipline & Skills I,0.33,0.45,0.13,0.0,0.03,0.0,0.0,0.08,andrew isaa neptune,,ENGR-1050,2015
+ENGR,1050,311,Engr Discipline & Skills I,0.1,0.41,0.21,0.1,0.03,0.0,0.0,0.14,elizabeth stephan,,ENGR-1050,2015
+ENGR,1050,312,Engr Discipline & Skills I,0.36,0.36,0.12,0.05,0.0,0.0,0.0,0.12,elizabeth stephan,,ENGR-1050,2015
+ENGR,1050,313,Engr Discipline & Skills I,0.26,0.25,0.2,0.11,0.02,0.0,0.0,0.16,michael giebner,,ENGR-1050,2015
+ENGR,1050,314,Engr Discipline & Skills I,0.31,0.37,0.19,0.05,0.0,0.0,0.0,0.08,michael giebner,,ENGR-1050,2015
+ENGR,1050,315,Engr Discipline & Skills I,0.4,0.22,0.22,0.1,0.02,0.0,0.0,0.03,william park,,ENGR-1050,2015
+ENGR,1050,316,Engr Discipline & Skills I,0.34,0.31,0.17,0.07,0.02,0.0,0.0,0.1,william park,,ENGR-1050,2015
+ENGR,1050,317,Engr Discipline & Skills I,0.37,0.25,0.22,0.05,0.03,0.0,0.0,0.07,william park,,ENGR-1050,2015
+ENGR,1050,318,Engr Discipline & Skills I,0.22,0.31,0.21,0.05,0.07,0.0,0.0,0.14,michael giebner,,ENGR-1050,2015
+ENGR,1050,349,Engr Discipline & Skills I,0.14,0.11,0.26,0.17,0.2,0.0,0.0,0.11,michael giebner,,ENGR-1050,2015
+ENGR,1050,400,Engr Discipline & Skills I,0.08,0.28,0.3,0.1,0.2,0.0,0.0,0.05,sarah grigg,,ENGR-1050,2015
+ENGR,1050,611,Engr Discip & Skills I (HON),0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,steven brandon,True,ENGR-1050,2015
+ENGR,1050,613,Engr Discip & Skills I (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True,ENGR-1050,2015
+ENGR,1050,614,Engr Discipl & Skills I (HON),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,steven brandon,True,ENGR-1050,2015
+ENGR,1050,615,Engr Discipl & Skills I (HON),0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,richard watkins,True,ENGR-1050,2015
+ENGR,1060,111,Engr Discipline & Skills II,0.11,0.39,0.24,0.11,0.03,0.0,0.0,0.13,christopher norfolk,,ENGR-1060,2015
+ENGR,1060,112,Engr Discipline & Skills II,0.15,0.41,0.36,0.0,0.03,0.0,0.0,0.05,mariah magagnotti,,ENGR-1060,2015
+ENGR,1060,113,Engr Discipline & Skills II,0.03,0.26,0.53,0.06,0.03,0.0,0.0,0.09,mariah magagnotti,,ENGR-1060,2015
+ENGR,1060,114,Engr Discipline & Skills II,0.27,0.43,0.22,0.05,0.03,0.0,0.0,0.0,matthew kent miller,,ENGR-1060,2015
+ENGR,1060,115,Engr Discipline & Skills II,0.23,0.25,0.43,0.0,0.0,0.0,0.0,0.1,matthew kent miller,,ENGR-1060,2015
+ENGR,1060,117,Engr Discipline & Skills II,0.22,0.5,0.22,0.0,0.03,0.0,0.0,0.03,matthew kent miller,,ENGR-1060,2015
+ENGR,1060,118,Engr Discipline & Skills II,0.06,0.34,0.31,0.17,0.03,0.0,0.0,0.09,matthew kent miller,,ENGR-1060,2015
+ENGR,1060,211,Engr Discipline & Skills II,0.24,0.43,0.26,0.04,0.0,0.0,0.0,0.02,ashley childers,,ENGR-1060,2015
+ENGR,1060,212,Engr Discipline & Skills II,0.29,0.44,0.21,0.0,0.02,0.0,0.0,0.04,ashley childers,,ENGR-1060,2015
+ENGR,1060,213,Engr Discipline & Skills II,0.11,0.41,0.24,0.11,0.05,0.0,0.0,0.08,andrew isaa neptune,,ENGR-1060,2015
+ENGR,1060,214,Engr Discipline & Skills II,0.16,0.29,0.21,0.21,0.0,0.0,0.0,0.13,andrew isaa neptune,,ENGR-1060,2015
+ENGR,1060,215,Engr Discipline & Skills II,0.15,0.21,0.31,0.18,0.05,0.0,0.0,0.1,mariah magagnotti,,ENGR-1060,2015
+ENGR,1060,216,Engr Discipline & Skills II,0.07,0.22,0.48,0.04,0.07,0.0,0.0,0.11,mariah magagnotti,,ENGR-1060,2015
+ENGR,1060,217,Engr Discipline & Skills II,0.15,0.38,0.31,0.05,0.0,0.0,0.0,0.1,andrew isaa neptune,,ENGR-1060,2015
+ENGR,1060,218,Engr Discipline & Skills II,0.03,0.53,0.22,0.06,0.06,0.0,0.0,0.11,andrew isaa neptune,,ENGR-1060,2015
+ENGR,1060,243,Engr Discipline & Skills II,0.17,0.31,0.31,0.06,0.06,0.0,0.0,0.11,michael giebner,,ENGR-1060,2015
+ENGR,1060,312,Engr Discipline & Skills II,0.16,0.35,0.24,0.16,0.02,0.0,0.0,0.06,elizabeth stephan,,ENGR-1060,2015
+ENGR,1060,313,Engr Discipline & Skills II,0.13,0.47,0.22,0.09,0.04,0.0,0.0,0.04,michael giebner,,ENGR-1060,2015
+ENGR,1060,314,Engr Discipline & Skills II,0.12,0.29,0.43,0.04,0.04,0.0,0.0,0.08,michael giebner,,ENGR-1060,2015
+ENGR,1060,315,Engr Discipline & Skills II,0.09,0.33,0.28,0.09,0.09,0.0,0.0,0.13,william park,,ENGR-1060,2015
+ENGR,1060,316,Engr Discipline & Skills II,0.08,0.35,0.31,0.08,0.1,0.0,0.0,0.08,william park,,ENGR-1060,2015
+ENGR,1060,317,Engr Discipline & Skills II,0.1,0.33,0.42,0.06,0.04,0.0,0.0,0.04,william park,,ENGR-1060,2015
+ENGR,1060,318,Engr Discipline & Skills II,0.24,0.36,0.17,0.1,0.02,0.0,0.0,0.12,michael giebner,,ENGR-1060,2015
+ENGR,1060,400,Engr Discipline & Skills II,0.11,0.22,0.33,0.11,0.06,0.0,0.0,0.17,sarah grigg,,ENGR-1060,2015
+ENGR,1060,611,Engr Discip & Skills II (HON),0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,steven brandon,True,ENGR-1060,2015
+ENGR,1060,613,Engr Discip & Skills II (HON),0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,steven brandon,True,ENGR-1060,2015
+ENGR,1060,614,Engr Discip & Skills II (HON),0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.03,steven brandon,True,ENGR-1060,2015
+ENGR,1060,615,Engr Discip & Skills II (HON),0.6,0.25,0.1,0.0,0.0,0.0,0.0,0.05,richard watkins,True,ENGR-1060,2015
+ENGR,1070,322,Programming & Prob Solving I,0.07,0.07,0.29,0.24,0.24,0.0,0.0,0.07,jordon anth gilmore,,ENGR-1070,2015
+ENGR,1070,325,Programming & Prob Solving I,0.03,0.18,0.28,0.21,0.1,0.0,0.0,0.21,william martin,,ENGR-1070,2015
+ENGR,1070,326,Programming & Prob Solving I,0.1,0.26,0.21,0.23,0.13,0.0,0.0,0.08,william martin,,ENGR-1070,2015
+ENGR,1070,327,Programming & Prob Solving I,0.15,0.21,0.18,0.21,0.03,0.0,0.0,0.24,william martin,,ENGR-1070,2015
+ENGR,1080,220,Programming & Prob Solving II,0.03,0.19,0.42,0.0,0.11,0.0,0.0,0.25,srinivasarangan rang,,ENGR-1080,2015
+ENGR,1080,221,Programming & Prob Solving II,0.0,0.15,0.56,0.12,0.06,0.0,0.0,0.12,srinivasarangan rang,,ENGR-1080,2015
+ENGR,1080,322,Programming & Prob Solving II,0.09,0.18,0.21,0.24,0.18,0.0,0.0,0.12,jordon anth gilmore,,ENGR-1080,2015
+ENGR,1080,325,Programming & Prob Solving II,0.0,0.25,0.42,0.08,0.21,0.0,0.0,0.04,william martin,,ENGR-1080,2015
+ENGR,1080,326,Programming & Prob Solving II,0.06,0.13,0.33,0.17,0.17,0.0,0.0,0.13,william martin,,ENGR-1080,2015
+ENGR,1080,327,Programming & Prob Solving II,0.11,0.29,0.37,0.16,0.05,0.0,0.0,0.03,william martin,,ENGR-1080,2015
+ENGR,1090,331,Prog/Problem Solving Apps,0.09,0.22,0.28,0.16,0.13,0.0,0.0,0.13,jordon anth gilmore,,ENGR-1090,2015
+ENGR,1090,332,Prog/Problem Solving Apps,0.3,0.42,0.19,0.0,0.05,0.0,0.0,0.05,christopher norfolk,,ENGR-1090,2015
+ENGR,1090,333,Prog/Problem Solving Apps,0.19,0.16,0.3,0.19,0.05,0.0,0.0,0.12,william park,,ENGR-1090,2015
+ENGR,1090,334,Prog/Problem Solving Apps,0.06,0.26,0.29,0.12,0.0,0.0,0.0,0.26,william park,,ENGR-1090,2015
+ENGR,1150,500,Engineering Design & Modeling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john minor,,ENGR-1150,2015
+ENGR,1520,500,Engineering Computer Skills,0.1,0.2,0.6,0.1,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1520,2015
+ENGR,1520,501,Engineering Computer Skills,0.15,0.46,0.15,0.23,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1520,2015
+ENGR,2080,181,Engr Graphics & Machine Design,0.34,0.36,0.13,0.02,0.04,0.0,0.0,0.11,nighat yasmin,,ENGR-2080,2015
+ENGR,2080,182,Engr Graphics & Machine Design,0.4,0.33,0.1,0.13,0.04,0.0,0.0,0.0,nighat yasmin,,ENGR-2080,2015
+ENGR,2080,285,Engr Graphics & Machine Design,0.32,0.3,0.18,0.0,0.06,0.0,0.0,0.14,anthony pau garland,,ENGR-2080,2015
+ENGR,2080,286,Engr Graphics & Machine Design,0.29,0.31,0.1,0.08,0.08,0.0,0.0,0.14,anthony pau garland,,ENGR-2080,2015
+ENGR,2080,384,Engr Graphics & Machine Design,0.52,0.14,0.14,0.1,0.04,0.0,0.0,0.06,john minor,,ENGR-2080,2015
+ENGR,2100,103,CAD & Engineering Apllications,0.59,0.24,0.04,0.02,0.02,0.0,0.0,0.09,mary kayla kilgo,,ENGR-2100,2015
+ENGR,2100,104,CAD & Engineering Apllications,0.38,0.23,0.1,0.08,0.08,0.0,0.0,0.13,nighat yasmin,,ENGR-2100,2015
+ENGR,2100,105,CAD & Engineering Apllications,0.45,0.34,0.07,0.0,0.07,0.0,0.0,0.07,nighat yasmin,,ENGR-2100,2015
+ENGR,2200,107,Evaluating Innovations,0.29,0.55,0.13,0.0,0.0,0.0,0.0,0.03,sarah grigg,,ENGR-2200,2015
+ENGR,2200,204,Evaluating Innovations,0.37,0.34,0.24,0.0,0.0,0.0,0.0,0.05,sarah grigg,,ENGR-2200,2015
+ENGR,2200,206,Evaluating Innovations,0.48,0.4,0.08,0.03,0.0,0.0,0.0,0.03,sarah grigg,,ENGR-2200,2015
+ENR,1010,1,Intro to Envir & Natur Res I,0.54,0.27,0.1,0.03,0.04,0.0,0.0,0.01,alan johnson,,ENR-1010,2015
+ENR,1010,2,Intro to Envir & Natur Res I,0.74,0.12,0.05,0.05,0.02,0.0,0.0,0.02,alan johnson,,ENR-1010,2015
+ENR,4290,1,Environ Law & Policy,0.54,0.34,0.08,0.0,0.0,0.0,0.0,0.04,alan johnson,,ENR-4290,2015
+ENSP,2000,1,Intro Environ Sci,0.55,0.24,0.1,0.05,0.02,0.0,0.0,0.05,scott brame,,ENSP-2000,2015
+ENSP,2000,2,Intro Environ Sci,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2015
+ENSP,2000,3,Intro Environ Sci,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2015
+ENSP,2000,4,Intro Environ Sci,0.42,0.39,0.17,0.0,0.03,0.0,0.0,0.0,elizabeth carraway,,ENSP-2000,2015
+ENSP,4000,1,Studies in Environmental Sci,0.69,0.15,0.0,0.04,0.04,0.0,0.0,0.08,margaret thompson,,ENSP-4000,2015
+ENT,2000,1,Six-Legged Science,0.64,0.13,0.13,0.0,0.0,0.0,0.0,0.1,suellen pometto,,ENT-2000,2015
+ENT,2010,1,Insects and Death,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,joseph culin,,ENT-2010,2015
+ENT,3010,1,Insect Biology & Diversity,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,eric benson,,ENT-3010,2015
+ENT,8700,1,Insect Phys Mol Bio,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,,ENT-8700,2015
+FCS,8300,1,Community Dev: Princ & Pract,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,areli moore peralta,,FCS-8300,2015
+FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.65,0.21,0.05,0.01,0.03,0.0,0.0,0.06,aubrey dean coffee,,FDSC-1010,2015
+FDSC,2160,1,Baking Science,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,,FDSC-2160,2015
+FDSC,3010,1,Food Regulations,0.78,0.15,0.07,0.0,0.0,0.0,0.0,0.0,julie kat northcutt,,FDSC-3010,2015
+FDSC,3060,1,Institutional Food Service Mgt,0.54,0.35,0.07,0.0,0.03,0.0,0.0,0.0,angela fraser,,FDSC-3060,2015
+FDSC,4010,1,Food Chemistry I,0.48,0.4,0.08,0.03,0.0,0.0,0.0,0.0,feng chen,,FDSC-4010,2015
+FDSC,4040,1,Food Prsv & Process,0.51,0.4,0.09,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,,FDSC-4040,2015
+FDSC,4070,1,Quantity Food Production,0.58,0.34,0.05,0.03,0.0,0.0,0.0,0.0,heather batt,,FDSC-4070,2015
+FDSC,4170,1,Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,,FDSC-4170,2015
+FDSC,4200,5,Selected Topics,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katherine cason,,FDSC-4200,2015
+FDSC,4300,1,Dairy Process & Sant,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-4300,2015
+FDSC,8510,1,Food Science Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,,FDSC-8510,2015
+FIN,3040,1,Risk & Insurance,0.13,0.35,0.35,0.09,0.09,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2015
+FIN,3040,2,Risk & Insurance,0.23,0.33,0.37,0.07,0.0,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2015
+FIN,3050,1,Investment Analysis,0.27,0.3,0.27,0.11,0.0,0.0,0.0,0.05,kerri mcmillan,,FIN-3050,2015
+FIN,3050,2,Investment Analysis,0.14,0.36,0.34,0.11,0.0,0.02,0.0,0.02,kerri mcmillan,,FIN-3050,2015
+FIN,3050,3,Investment Analysis,0.29,0.36,0.31,0.0,0.02,0.0,0.0,0.02,thomas albe wessels,,FIN-3050,2015
+FIN,3050,4,Investment Analysis,0.28,0.41,0.28,0.0,0.03,0.0,0.0,0.0,thomas albe wessels,,FIN-3050,2015
+FIN,3060,1,Corporation Finance,0.1,0.35,0.13,0.29,0.06,0.0,0.0,0.06,ramon tolb franklin,,FIN-3060,2015
+FIN,3060,2,Corporation Finance,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,neil waller,,FIN-3060,2015
+FIN,3060,3,Corporation Finance,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,neil waller,,FIN-3060,2015
+FIN,3060,4,Corporation Finance,0.17,0.36,0.19,0.11,0.08,0.0,0.0,0.08,ramon tolb franklin,,FIN-3060,2015
+FIN,3060,5,Corporation Finance,0.26,0.43,0.21,0.1,0.0,0.0,0.0,0.0,neil waller,,FIN-3060,2015
+FIN,3060,6,Corporation Finance,0.14,0.14,0.26,0.21,0.17,0.0,0.0,0.07,william hol johnson,,FIN-3060,2015
+FIN,3060,7,Corporation Finance,0.24,0.2,0.39,0.02,0.05,0.0,0.0,0.1,william hol johnson,,FIN-3060,2015
+FIN,3060,8,Corporation Finance,0.24,0.12,0.12,0.12,0.14,0.0,0.0,0.26,william hol johnson,,FIN-3060,2015
+FIN,3060,9,Corporation Finance,0.03,0.13,0.16,0.1,0.32,0.0,0.0,0.26,william hol johnson,,FIN-3060,2015
+FIN,3060,10,Corporation Finance,0.18,0.24,0.18,0.29,0.0,0.0,0.0,0.12,ramon tolb franklin,,FIN-3060,2015
+FIN,3070,1,Prin of Real Estate,0.18,0.24,0.37,0.13,0.02,0.02,0.0,0.05,thomas springer,,FIN-3070,2015
+FIN,3070,2,Prin of Real Estate,0.08,0.4,0.28,0.12,0.03,0.0,0.0,0.08,thomas springer,,FIN-3070,2015
+FIN,3080,1,Fin Inst & Mkts,0.24,0.57,0.09,0.04,0.02,0.0,0.0,0.04,lyudmila chernykh,,FIN-3080,2015
+FIN,3080,2,Fin Inst & Mkts,0.16,0.51,0.26,0.02,0.02,0.0,0.0,0.02,lyudmila chernykh,,FIN-3080,2015
+FIN,3080,3,Fin Inst & Mkts,0.18,0.41,0.26,0.03,0.1,0.0,0.0,0.03,daniel thoma greene,,FIN-3080,2015
+FIN,3110,1,Financial Management I,0.1,0.43,0.25,0.08,0.08,0.0,0.0,0.08,george bra lockhart,,FIN-3110,2015
+FIN,3110,2,Financial Management I,0.08,0.37,0.29,0.16,0.06,0.0,0.0,0.04,angela morgan,,FIN-3110,2015
+FIN,3110,3,Financial Management I,0.11,0.22,0.43,0.15,0.09,0.0,0.0,0.0,jared daniel smith,,FIN-3110,2015
+FIN,3110,4,Financial Management I,0.2,0.3,0.28,0.13,0.0,0.0,0.0,0.09,jared daniel smith,,FIN-3110,2015
+FIN,3120,1,Financial Management II,0.13,0.44,0.21,0.15,0.03,0.0,0.0,0.05,vincent intintoli,,FIN-3120,2015
+FIN,3120,2,Financial Management II,0.13,0.29,0.4,0.16,0.0,0.0,0.0,0.02,vincent intintoli,,FIN-3120,2015
+FIN,3120,3,Financial Management II,0.43,0.23,0.17,0.15,0.0,0.0,0.0,0.02,melvin stith,,FIN-3120,2015
+FIN,3120,4,Financial Management II,0.61,0.26,0.07,0.04,0.02,0.0,0.0,0.0,melvin stith,,FIN-3120,2015
+FIN,4020,1,Corporate Valuation,0.05,0.3,0.34,0.27,0.02,0.0,0.0,0.02,jack wolf,,FIN-4020,2015
+FIN,4020,2,Corporate Valuation,0.06,0.27,0.29,0.25,0.04,0.0,0.0,0.08,jack wolf,,FIN-4020,2015
+FIN,4050,1,Portfolio Management & Theory,0.03,0.3,0.33,0.1,0.0,0.0,0.0,0.23,john alexander,,FIN-4050,2015
+FIN,4060,1,Derivatives Analysis,0.24,0.36,0.24,0.09,0.03,0.03,0.0,0.0,george bra lockhart,,FIN-4060,2015
+FIN,4110,1,Int Fin Mgt,0.13,0.34,0.38,0.03,0.03,0.0,0.0,0.09,tilan tang,,FIN-4110,2015
+FIN,4110,2,Int Fin Mgt,0.19,0.49,0.24,0.08,0.0,0.0,0.0,0.0,tilan tang,,FIN-4110,2015
+FIN,4170,1,Real Estate Finance,0.43,0.29,0.21,0.07,0.0,0.0,0.0,0.0,neil waller,,FIN-4170,2015
+FIN,4980,2,Creative Inquiry in Finance,0.5,0.2,0.0,0.0,0.0,0.0,0.0,0.3,jack wolf,,FIN-4980,2015
+FNR,2040,1,Soil Information Systems,0.86,0.11,0.0,0.0,0.02,0.0,0.0,0.02,elena mikhailova,,FNR-2040,2015
+FNR,4900,1,Field Training in Natural Res,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,patricia layton,,FNR-4900,2015
+FNR,4990,1,Natural Resources Seminar,0.83,0.11,0.0,0.0,0.06,0.0,0.0,0.0,russell barrett,,FNR-4990,2015
+FOR,2050,1,Dendrology,0.23,0.31,0.27,0.04,0.08,0.0,0.0,0.08,donald hagan,,FOR-2050,2015
+FOR,2050,2,Dendrology,0.39,0.18,0.14,0.04,0.18,0.0,0.0,0.07,donald hagan,,FOR-2050,2015
+FOR,2050,3,Dendrology,0.37,0.26,0.13,0.13,0.03,0.0,0.0,0.08,donald hagan,,FOR-2050,2015
+FOR,2210,1,Forest Biology,0.13,0.34,0.3,0.16,0.05,0.0,0.0,0.02,victor ba shelburne,,FOR-2210,2015
+FOR,3020,1,Forest Biometrics,0.13,0.35,0.26,0.23,0.03,0.0,0.0,0.0,lawrence gering,,FOR-3020,2015
+FOR,3040,1,Forest Resource Economics,0.28,0.49,0.15,0.05,0.0,0.0,0.0,0.03,thomas straka,,FOR-3040,2015
+FOR,3410,1,Wood Procure Pract,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,patrick hiesl,,FOR-3410,2015
+FOR,4100,1,Harvesting Processes,0.24,0.56,0.12,0.08,0.0,0.0,0.0,0.0,patrick hiesl,,FOR-4100,2015
+FOR,4130,1,Integrated Forest Pest Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,roy leslie hedden,,FOR-4130,2015
+FOR,4160,1,Forest Policy and Admin,0.68,0.25,0.03,0.01,0.0,0.0,0.0,0.03,joseph lanham,,FOR-4160,2015
+FOR,4170,1,Forest Resource Mgt & Regulatn,0.42,0.42,0.12,0.04,0.0,0.0,0.0,0.0,greg yarrow,,FOR-4170,2015
+FOR,4310,1,Recreation Res Plan in For Mgt,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,robert baxte powell,,FOR-4310,2015
+FOR,4340,1,GIS for Natural Resources,0.82,0.16,0.0,0.0,0.02,0.0,0.0,0.0,christopher post,,FOR-4340,2015
+FR,1010,1,Elementary French,0.11,0.47,0.32,0.05,0.0,0.0,0.0,0.05,anne salces  nedeo,,FR-1010,2015
+FR,1020,1,Elementary French,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2015
+FR,1020,2,Elementary French,0.67,0.17,0.11,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,,FR-1020,2015
+FR,1020,3,Elementary French,0.14,0.29,0.43,0.07,0.07,0.0,0.0,0.0,anne salces  nedeo,,FR-1020,2015
+FR,2010,1,Intermediate French,0.43,0.43,0.0,0.0,0.07,0.0,0.0,0.07,paulin de tholozany,,FR-2010,2015
+FR,2010,2,Intermediate French,0.25,0.44,0.19,0.13,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-2010,2015
+FR,2010,3,Intermediate French,0.2,0.5,0.1,0.0,0.1,0.0,0.0,0.1,kenneth dav widgren,,FR-2010,2015
+FR,2010,4,Intermediate French,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,paulin de tholozany,,FR-2010,2015
+FR,2020,1,Intermediate French,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2020,2015
+FR,2020,3,Intermediate French,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,,FR-2020,2015
+FR,2020,4,Intermediate French,0.36,0.43,0.07,0.0,0.07,0.0,0.0,0.07,kenneth dav widgren,,FR-2020,2015
+FR,2020,5,Intermediate French,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2020,2015
+FR,3000,1,Survey of French Lit,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,paulin de tholozany,,FR-3000,2015
+FR,3050,1,Int Fr Con & Comp I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,,FR-3050,2015
+FR,3070,1,French Civilization,0.63,0.26,0.0,0.0,0.11,0.0,0.0,0.0,kelly digby peebles,,FR-3070,2015
+FR,4000,1,Modern French Lit,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-4000,2015
+GC,1010,1,Orientation to G C,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,nona woolbright,,GC-1010,2015
+GC,1020,1,Computer Art & CAD Foundations,0.44,0.4,0.02,0.05,0.09,0.0,0.0,0.0,carol jones,,GC-1020,2015
+GC,1020,2,Computer Art & CAD Foundations,0.49,0.41,0.02,0.04,0.04,0.0,0.0,0.0,nona woolbright,,GC-1020,2015
+GC,1030,1,G C I for Pkgsc,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,john jacobs,,GC-1030,2015
+GC,1040,1,Graphic Communications I,0.36,0.55,0.05,0.0,0.05,0.0,0.0,0.0,rebecca suza edlein,,GC-1040,2015
+GC,2070,1,Graphic Communications II,0.68,0.28,0.0,0.02,0.0,0.0,0.0,0.02,patrick gee rose,,GC-2070,2015
+GC,2400,1,Intro to Web Design and Dev,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,erica black walker,,GC-2400,2015
+GC,3400,1,Digital Imaging and eMedia,0.29,0.6,0.04,0.02,0.02,0.0,0.0,0.02,erica black walker,,GC-3400,2015
+GC,3460,1,Ink and Substrates,0.28,0.45,0.2,0.02,0.02,0.0,0.0,0.03,liam henry 'hara,,GC-3460,2015
+GC,4060,1,Package and Specialty Printing,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,kern cox,,GC-4060,2015
+GC,4400,1,Commercial Printing,0.17,0.67,0.04,0.0,0.08,0.0,0.0,0.04,eric weisenmiller,,GC-4400,2015
+GC,4400,2,Commercial Printing,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,,GC-4400,2015
+GC,4440,1,Current Dev/Trends in Gr Comm,0.39,0.3,0.18,0.06,0.03,0.0,0.0,0.03,liam henry 'hara,,GC-4440,2015
+GC,4480,1,Plan and Cont Print,0.42,0.47,0.05,0.03,0.03,0.0,0.0,0.0,john leininger,,GC-4480,2015
+GC,4800,1,Senior Seminar in GC,0.7,0.27,0.0,0.0,0.03,0.0,0.0,0.0,charles edwa tonkin,,GC-4800,2015
+GC,4900,230,G C Selected Topics-GC Sales,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,john leininger,,GC-4900,2015
+GEN,1030,1,Careers in Bioch/Gen,0.85,0.07,0.01,0.03,0.0,0.0,0.0,0.04,alison starr-moss,,GEN-1030,2015
+GEN,3000,1,Fundamental Genetics,0.39,0.34,0.23,0.03,0.0,0.0,0.0,0.01,kate leanne wi tsai,,GEN-3000,2015
+GEN,3000,2,Fundamental Genetics,0.33,0.47,0.14,0.02,0.02,0.0,0.0,0.02,kate leanne wi tsai,,GEN-3000,2015
+GEN,3000,3,Fundamental Genetics,0.35,0.41,0.13,0.04,0.0,0.0,0.0,0.07,kate leanne wi tsai,,GEN-3000,2015
+GEN,3020,1,Molecular & General Genetics,0.28,0.47,0.16,0.0,0.06,0.0,0.0,0.03,rajandeep si sekhon,,GEN-3020,2015
+GEN,3020,2,Molec & General Genetics (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True,GEN-3020,2015
+GEN,3020,3,Molecular & General Genetics,0.21,0.35,0.19,0.08,0.04,0.0,0.0,0.13,lukasz kozubowski,,GEN-3020,2015
+GEN,4200,1,Molecular Genetics & Gene Reg,0.47,0.38,0.13,0.03,0.0,0.0,0.0,0.0,julia frugoli,,GEN-4200,2015
+GEN,4200,2,Molecular Genetics & Gen (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True,GEN-4200,2015
+GEN,4210,2,Mol Gen Gene Reg Lab,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,julia frugoli,,GEN-4210,2015
+GEN,4210,3,Mol Gen Gene Reg Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,,GEN-4210,2015
+GEN,4400,1,Bioinformatics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,,GEN-4400,2015
+GEN,4500,1,Comparative Genetics,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,leigh anne clark,,GEN-4500,2015
+GEN,6400,1,Bioinformatics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,,GEN-6400,2015
+GEOG,1010,1,Intro to Geography,0.23,0.4,0.33,0.05,0.0,0.0,0.0,0.0,christa smith,,GEOG-1010,2015
+GEOG,1030,1,World Regional Geog,0.69,0.2,0.06,0.02,0.02,0.0,0.0,0.0,lance forres howard,,GEOG-1030,2015
+GEOG,1030,2,World Regional Geog,0.47,0.21,0.11,0.05,0.05,0.0,0.0,0.11,william churc terry,,GEOG-1030,2015
+GEOG,1030,3,World Regional Geog,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,lance forres howard,,GEOG-1030,2015
+GEOL,1010,1,Physical Geology,0.17,0.26,0.34,0.12,0.06,0.0,0.0,0.05,alan coulson,,GEOL-1010,2015
+GEOL,1010,2,Physical Geology,0.14,0.3,0.33,0.07,0.09,0.0,0.0,0.07,alan coulson,,GEOL-1010,2015
+GEOL,1010,3,Physical Geology,0.33,0.33,0.12,0.04,0.08,0.0,0.0,0.12,mine dogan,,GEOL-1010,2015
+GEOL,1030,1,Physical Geol Lab,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,alan coulson,,GEOL-1030,2015
+GEOL,1030,2,Physical Geol Lab,0.57,0.24,0.05,0.0,0.14,0.0,0.0,0.0,alan coulson,,GEOL-1030,2015
+GEOL,1030,3,Physical Geol Lab,0.27,0.59,0.05,0.05,0.0,0.0,0.0,0.05,alan coulson,,GEOL-1030,2015
+GEOL,1030,4,Physical Geol Lab,0.17,0.65,0.04,0.0,0.04,0.0,0.0,0.09,alan coulson,,GEOL-1030,2015
+GEOL,1030,5,Physical Geol Lab,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2015
+GEOL,1030,6,Physical Geol Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2015
+GEOL,1030,7,Physical Geol Lab,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2015
+GEOL,1030,8,Physical Geol Lab,0.21,0.5,0.04,0.0,0.0,0.0,0.0,0.25,alan coulson,,GEOL-1030,2015
+GEOL,1030,9,Physical Geol Lab,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,alan coulson,,GEOL-1030,2015
+GEOL,1030,10,Physical Geol Lab,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2015
+GEOL,1030,11,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2015
+GEOL,1030,12,Physical Geol Lab,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,alan coulson,,GEOL-1030,2015
+GEOL,2050,1,Mineralogy & Intro Petrology,0.35,0.41,0.18,0.0,0.0,0.0,0.0,0.06,lin shuller-nickles,,GEOL-2050,2015
+GEOL,2070,1,Min & Intro Pet Lab,0.13,0.56,0.31,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-2070,2015
+GEOL,2700,1,Sustainable Water,0.55,0.3,0.07,0.0,0.02,0.0,0.0,0.07,stephen mich moysey,,GEOL-2700,2015
+GEOL,2750,1,Field Methods,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-2750,2015
+GEOL,3000,1,Environmental Geology,0.39,0.43,0.07,0.04,0.04,0.0,0.0,0.04,scott brame,,GEOL-3000,2015
+GEOL,3020,1,Structural Geology,0.2,0.13,0.4,0.2,0.0,0.0,0.0,0.07,james castle,,GEOL-3020,2015
+GEOL,4820,1,Groundwater & Contam Transport,0.42,0.33,0.17,0.0,0.0,0.0,0.0,0.08,lawrence murdoch,,GEOL-4820,2015
+GER,1010,1,Elementary German,0.37,0.21,0.26,0.0,0.0,0.0,0.0,0.16, lee ferrell,,GER-1010,2015
+GER,1010,2,Elementary German,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0, lee ferrell,,GER-1010,2015
+GER,1020,1,Elementary German,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-1020,2015
+GER,1020,2,Elementary German,0.33,0.47,0.07,0.07,0.07,0.0,0.0,0.0,oswald harris king,,GER-1020,2015
+GER,2010,1,Intermediate German,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,oswald harris king,,GER-2010,2015
+GER,2010,2,Intermediate German,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,oswald harris king,,GER-2010,2015
+GER,2020,1,Intermediate German,0.25,0.25,0.31,0.13,0.06,0.0,0.0,0.0, lee ferrell,,GER-2020,2015
+GER,3050,1,Ger Conv & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-3050,2015
+HCC,8310,1,Fundamentals of Hcc,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,kelly caine,,HCC-8310,2015
+HCG,9050,1,Genom & Hlth Policy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,HCG-9050,2015
+HEHD,3990,1,Building Healthy Communities,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,areli moore peralta,,HEHD-3990,2015
+HEHD,4000,1,Intro Leadership Theor & Conc,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,,HEHD-4000,2015
+HEHD,8000,400,Youth Dev Theories,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,,HEHD-8000,2015
+HEHD,8030,400,Ethical Leadership,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,barry garst,,HEHD-8030,2015
+HEHD,8060,230,Diverse Society,0.59,0.32,0.05,0.05,0.0,0.0,0.0,0.0,keith george diem,,HEHD-8060,2015
+HIST,1010,1,Hist of the U S,0.24,0.44,0.26,0.03,0.03,0.0,0.0,0.0,james brad jeffries,,HIST-1010,2015
+HIST,1010,2,Hist of the U S,0.42,0.47,0.09,0.0,0.0,0.0,0.0,0.02,lee brady wilson,,HIST-1010,2015
+HIST,1020,1,Hist of the U S,0.11,0.11,0.21,0.11,0.11,0.0,0.0,0.37,maribel morey,,HIST-1020,2015
+HIST,1020,2,Hist of the U S,0.43,0.25,0.13,0.1,0.05,0.0,0.0,0.05,john andrew,,HIST-1020,2015
+HIST,1220,1,"Hist, Tech & Society",0.21,0.49,0.17,0.04,0.07,0.0,0.0,0.02,pamela mack,,HIST-1220,2015
+HIST,1240,1,Environmental History Survey,0.13,0.61,0.11,0.03,0.05,0.0,0.0,0.08,james brad jeffries,,HIST-1240,2015
+HIST,1240,2,Environmental History Survey,0.23,0.38,0.35,0.0,0.03,0.0,0.0,0.03,james brad jeffries,,HIST-1240,2015
+HIST,1720,1,The West and the World I,0.27,0.44,0.16,0.06,0.03,0.0,0.0,0.05,steven marks,,HIST-1720,2015
+HIST,1720,2,The West and the World I,0.3,0.42,0.18,0.03,0.02,0.0,0.0,0.05,steven marks,,HIST-1720,2015
+HIST,1720,3,The West and the World I,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,emily wood,,HIST-1720,2015
+HIST,1720,4,The West and the World I,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,emily wood,,HIST-1720,2015
+HIST,1730,2,The West and the World II,0.24,0.44,0.12,0.05,0.06,0.0,0.0,0.09, alan grubb,,HIST-1730,2015
+HIST,2990,1,Historian's Craft,0.75,0.17,0.0,0.08,0.0,0.0,0.0,0.0,michael silvestri,,HIST-2990,2015
+HIST,2990,2,Historian's Craft,0.3,0.4,0.0,0.0,0.3,0.0,0.0,0.0,elizabeth carney,,HIST-2990,2015
+HIST,2990,3,Historian's Craft,0.32,0.63,0.0,0.0,0.05,0.0,0.0,0.0,rachel anne moore,,HIST-2990,2015
+HIST,3000,1,Hist Colonial Amer,0.61,0.32,0.03,0.0,0.03,0.0,0.0,0.03,lee brady wilson,,HIST-3000,2015
+HIST,3040,1,Indus & Progr Era,0.54,0.21,0.17,0.04,0.04,0.0,0.0,0.0, roger grant,,HIST-3040,2015
+HIST,3100,1,History of Religion in the US,0.42,0.17,0.17,0.0,0.25,0.0,0.0,0.0,elizabeth jemison,,HIST-3100,2015
+HIST,3280,1,US Legal History to 1890,0.1,0.29,0.24,0.05,0.1,0.0,0.0,0.24,maribel morey,,HIST-3280,2015
+HIST,3300,1,Hist of Mod China,0.16,0.32,0.26,0.05,0.0,0.0,0.0,0.21,edwin moise,,HIST-3300,2015
+HIST,3390,1,Africa 1875-Present,0.51,0.15,0.18,0.0,0.13,0.0,0.0,0.03,james burns,,HIST-3390,2015
+HIST,3420,1,South Am Since 1800,0.46,0.49,0.05,0.0,0.0,0.0,0.0,0.0,rachel anne moore,,HIST-3420,2015
+HIST,3520,1,Pharaonic Egypt,0.34,0.43,0.09,0.09,0.03,0.0,0.0,0.03,elizabeth carney,,HIST-3520,2015
+HIST,3610,2,History of Britain to 1688,0.45,0.38,0.03,0.1,0.03,0.0,0.0,0.0,caroline dunn clark,,HIST-3610,2015
+HIST,3630,1,Britain Since 1688,0.29,0.42,0.18,0.0,0.05,0.0,0.0,0.05,stephani barczewski,,HIST-3630,2015
+HIST,3670,1,Modern Ireland,0.46,0.31,0.13,0.05,0.05,0.0,0.0,0.0,michael silvestri,,HIST-3670,2015
+HIST,3890,8,Creative Inquiry in History,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,abel bartley,,HIST-3890,2015
+HIST,3900,1,Modern Military History,0.18,0.33,0.39,0.03,0.03,0.0,0.0,0.03,edwin moise,,HIST-3900,2015
+HIST,4000,1,Honor & Mastery InTheOld South,0.33,0.42,0.17,0.0,0.08,0.0,0.0,0.0,paul chris anderson,True,HIST-4000,2015
+HIST,4140,1,Study of Hist Museum,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,meg taylor-shockley,,HIST-4140,2015
+HIST,4720,2,Medieval Conquests & Crusades,0.21,0.42,0.11,0.11,0.05,0.0,0.0,0.11,caroline dunn clark,,HIST-4720,2015
+HIST,4900,3,Spanish Civil War,0.24,0.29,0.24,0.06,0.12,0.0,0.0,0.06,steven marks,,HIST-4900,2015
+HIST,4900,5,Oral History,0.5,0.22,0.17,0.0,0.06,0.0,0.0,0.06,meg taylor-shockley,,HIST-4900,2015
+HIST,4930,1,Urban History,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,abel bartley,,HIST-4930,2015
+HIST,4940,1,War & Peace in Middle East,0.57,0.29,0.0,0.0,0.07,0.0,0.0,0.07,amit bein,,HIST-4940,2015
+HIST,8000,2,SO. Biog,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john andrew,,HIST-8000,2015
+HIST,8810,1,Historiography,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, alan grubb,,HIST-8810,2015
+HLTH,2020,1,Introduction to Public Health,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2015
+HLTH,2020,2,Introduction to Public Health,0.61,0.35,0.03,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2015
+HLTH,2020,3,Introduction to Public Health,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2015
+HLTH,2020,4,Introduction to Public Health,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2015
+HLTH,2020,5,Introduction to Public Health,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2015
+HLTH,2020,400,Introduction to Public Health,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,ralph stewart welsh,,HLTH-2020,2015
+HLTH,2030,1,Health Care Sys,0.6,0.29,0.06,0.06,0.0,0.0,0.0,0.0,frederic fraizer,,HLTH-2030,2015
+HLTH,2030,2,Health Care Sys,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,HLTH-2030,2015
+HLTH,2400,1,Deter of Hlth Behav,0.36,0.32,0.27,0.0,0.05,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2015
+HLTH,2400,2,Deter of Hlth Behav,0.41,0.32,0.21,0.0,0.03,0.0,0.0,0.03,amelia clinkscales,,HLTH-2400,2015
+HLTH,2500,1,Health and Fitness,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,kari jea strothmann,,HLTH-2500,2015
+HLTH,2980,1,Human Hlth & Disease,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,,HLTH-2980,2015
+HLTH,2980,2,Human Hlth & Disease,0.85,0.09,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,,HLTH-2980,2015
+HLTH,3030,1,Public Health Comm,0.63,0.31,0.03,0.0,0.0,0.0,0.0,0.03,debra mitch charles,,HLTH-3030,2015
+HLTH,3050,1,Body Resp Hlth Beh,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,brian patric graves,,HLTH-3050,2015
+HLTH,3400,1,Hlth Prom Prog Plan,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,brian patric graves,,HLTH-3400,2015
+HLTH,3610,1,Int Health Care Econ,0.49,0.29,0.13,0.02,0.0,0.0,0.0,0.07,khoa dang truong,,HLTH-3610,2015
+HLTH,3800,1,Epidemiology,0.37,0.42,0.13,0.08,0.0,0.0,0.0,0.0,hugh spitler,,HLTH-3800,2015
+HLTH,3800,2,Epidemiology,0.22,0.52,0.22,0.0,0.0,0.0,0.0,0.04,hugh spitler,,HLTH-3800,2015
+HLTH,3800,400,Epidemiology,0.36,0.18,0.27,0.0,0.0,0.0,0.0,0.18,deborah alma falta,,HLTH-3800,2015
+HLTH,3980,1,Hlth Appraisal Sklls,0.62,0.23,0.15,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2015
+HLTH,3980,2,Hlth Appraisal Sklls,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2015
+HLTH,4190,1,Health Sci Internship Prep Sem,0.33,0.36,0.16,0.13,0.0,0.0,0.0,0.02,kathleen meyer,,HLTH-4190,2015
+HLTH,4200,1,Hlth Science Intern,0.77,0.15,0.05,0.0,0.0,0.0,0.0,0.03,kathleen meyer,,HLTH-4200,2015
+HLTH,4400,1,Manag Hlth Serv Org,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,frederic fraizer,,HLTH-4400,2015
+HLTH,4700,1,Global Health,0.83,0.14,0.0,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,,HLTH-4700,2015
+HLTH,4750,1,Hlthcr Oper Mgmt Res,0.77,0.19,0.0,0.0,0.0,0.0,0.0,0.03,lu shi,,HLTH-4750,2015
+HLTH,4900,1,Res Eval St Pub Hlth,0.33,0.51,0.13,0.0,0.0,0.0,0.0,0.03,lingling zhang,,HLTH-4900,2015
+HLTH,4900,2,Res Eval St Pub Hlth,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,lingling zhang,,HLTH-4900,2015
+HLTH,4970,3,Creative Inq in Public Health,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,crystal burn fulmer,,HLTH-4970,2015
+HLTH,8120,500,Clinical and Translational Sci,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ronald gimbel,,HLTH-8120,2015
+HON,1910,1,Wicked Opera,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,johannes schmidt,,HON-1910,2015
+HON,1920,2,Who Gets What and Why?,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,sarah evely winslow,,HON-1920,2015
+HON,2060,2,PANDEMIC: Extinction Pending?,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,james morris,,HON-2060,2015
+HON,2200,4,The Economic Crisis,0.64,0.18,0.09,0.0,0.09,0.0,0.0,0.0,patrick warren,,HON-2200,2015
+HON,2220,1,Pact with the Devil,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,,HON-2220,2015
+HORT,1010,1,Horticulture,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-1010,2015
+HORT,2100,1,Growing Fall Plants,0.32,0.42,0.11,0.05,0.0,0.0,0.0,0.11,james emerson faust,,HORT-2100,2015
+HORT,2120,1,Turfgrass Culture,0.52,0.39,0.07,0.02,0.0,0.0,0.0,0.0,haibo liu,,HORT-2120,2015
+HORT,2130,1,Turf Culture Lab,0.71,0.14,0.05,0.0,0.0,0.0,0.0,0.1,donald garrett,,HORT-2130,2015
+HORT,2130,2,Turf Culture Lab,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,donald garrett,,HORT-2130,2015
+HORT,3030,1,Landscape Plants,0.31,0.27,0.17,0.09,0.09,0.0,0.0,0.06,robert polomski,,HORT-3030,2015
+HORT,3080,1,Sust Landsc Des Install Maint,0.59,0.19,0.13,0.0,0.06,0.0,0.0,0.03,ellen anita vincent,,HORT-3080,2015
+HORT,4090,1,Senior Capstone Course,0.79,0.13,0.04,0.0,0.04,0.0,0.0,0.0,ellen anita vincent,,HORT-4090,2015
+HORT,4120,1,Adv Turfgrass Mgt,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,lambert mccarty,,HORT-4120,2015
+HORT,4330,1,Turf Weed Management,0.15,0.6,0.2,0.05,0.0,0.0,0.0,0.0,ted whitwell,,HORT-4330,2015
+HP,8010,1,Preservation Law and Econ,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,barry louis stiefel,,HP-8010,2015
+HRD,8200,400,Human Perform Improv,0.93,0.0,0.0,0.0,0.02,0.0,0.0,0.05,russell marion,,HRD-8200,2015
+HRD,8300,400,Concepts of H R D,0.74,0.09,0.02,0.0,0.09,0.0,0.0,0.05,cynthia sims,,HRD-8300,2015
+HRD,8450,400,Needs Assess Ed/Ind,0.93,0.04,0.0,0.0,0.02,0.0,0.0,0.0,philip mcgee,,HRD-8450,2015
+HRD,8600,400,Instruc Mat Devel,0.89,0.04,0.04,0.0,0.02,0.0,0.0,0.02,philip mcgee,,HRD-8600,2015
+HUM,3090,1,Studies in Humanities,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,,HUM-3090,2015
+IE,2000,1,Soph Seminar in I E,0.56,0.17,0.11,0.08,0.08,0.0,0.0,0.0,brian melloy,,IE-2000,2015
+IE,2100,1,Des Analysis Wrk Sys,0.07,0.68,0.21,0.02,0.01,0.0,0.0,0.0,david neyens,,IE-2100,2015
+IE,2800,1,Deterministic Operations Rsrch,0.19,0.32,0.24,0.13,0.05,0.0,0.0,0.06,amin khademi,,IE-2800,2015
+IE,2800,2,Deterministic Operations Rsrch,0.47,0.24,0.15,0.05,0.07,0.0,0.0,0.02,jonathan lowe,,IE-2800,2015
+IE,3010,1,Systems Design I,0.28,0.59,0.08,0.03,0.0,0.0,0.0,0.03,joel greenstein,,IE-3010,2015
+IE,3600,1,Industrial Apps of Prob/Stat I,0.29,0.32,0.25,0.05,0.07,0.0,0.0,0.02,mary elizabeth kurz,,IE-3600,2015
+IE,3680,1,Prof Practice in I E,0.93,0.03,0.02,0.02,0.0,0.0,0.0,0.0,robert james riggs,,IE-3680,2015
+IE,3840,1,Engr Econ Analysis,0.08,0.22,0.11,0.08,0.11,0.0,0.0,0.41,brian melloy,,IE-3840,2015
+IE,3860,1,Prod Plan & Cont,0.21,0.41,0.21,0.18,0.0,0.0,0.0,0.0,robert james riggs,,IE-3860,2015
+IE,4400,1,Decision Support Sys,0.35,0.29,0.15,0.08,0.11,0.0,0.0,0.02,scott jenning mason,,IE-4400,2015
+IE,4400,2,Decision Support Sys,0.29,0.25,0.1,0.13,0.17,0.0,0.0,0.06,site wang,,IE-4400,2015
+IE,4560,1,Supply Chain Design & Control,0.31,0.42,0.18,0.04,0.0,0.0,0.0,0.04,william ferrell,,IE-4560,2015
+IE,4610,1,Quality Engineering,0.25,0.33,0.31,0.06,0.02,0.0,0.0,0.02,byung rae cho,,IE-4610,2015
+IE,4650,1,Facilities Planning & Design,0.79,0.18,0.01,0.02,0.0,0.0,0.0,0.0,jonathan lowe,,IE-4650,2015
+IE,4650,2,Facilities Planning & Design,0.25,0.38,0.19,0.16,0.0,0.0,0.0,0.02,william ferrell,,IE-4650,2015
+IE,4820,1,Systems Modeling,0.48,0.38,0.11,0.02,0.0,0.0,0.0,0.0,kevin taaffe,,IE-4820,2015
+IE,4820,2,Systems Modeling,0.21,0.3,0.3,0.1,0.04,0.0,0.0,0.04,tugce isik,,IE-4820,2015
+IE,4910,1,Network Flows for IE App,0.25,0.13,0.25,0.06,0.06,0.0,0.0,0.25,burak eksioglu,,IE-4910,2015
+IE,4910,2,Modeling & Analysis of MFG,0.61,0.26,0.0,0.03,0.06,0.0,0.0,0.03,mary elizabeth kurz,,IE-4910,2015
+IE,6560,1,Supply Chain Design & Control,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,william ferrell,,IE-6560,2015
+IE,6910,3,Simulation Modeling & Analysis,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,,IE-6910,2015
+IE,8000,1,Human Factors Eng,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,david neyens,,IE-8000,2015
+IE,8030,1,Engr Optimization and Apps,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,,IE-8030,2015
+IE,8090,1,Model Sys Under Risk,0.25,0.54,0.21,0.0,0.0,0.0,0.0,0.0,burak eksioglu,,IE-8090,2015
+IE,8510,1,Descriptive Analytics,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,mary elizabeth kurz,,IE-8510,2015
+IE,8530,1,Foundations of Quality,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,byung rae cho,,IE-8530,2015
+IE,8550,1,SC & Logistics Modeling II,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kevin taaffe,,IE-8550,2015
+IE,8930,1,Multilevel Math Optimization,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,,IE-8930,2015
+INT,1010,5,Career Center Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,troy nunamaker,,INT-1010,2015
+INT,1020,5,Career Center Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,troy nunamaker,,INT-1020,2015
+INT,1030,5,Career Center Internship PT 3+,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,troy nunamaker,,INT-1030,2015
+IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.03,sharon nagy,,IS-1010,2015
+ITAL,1010,1,Elementary Italian,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,luca barattoni,,ITAL-1010,2015
+ITAL,1010,2,Elementary Italian,0.61,0.11,0.0,0.11,0.06,0.0,0.0,0.11,luca barattoni,,ITAL-1010,2015
+ITAL,1010,3,Elementary Italian,0.42,0.37,0.05,0.0,0.0,0.0,0.0,0.16,valentina lombardi,,ITAL-1010,2015
+ITAL,1010,4,Elementary Italian,0.43,0.36,0.07,0.0,0.07,0.0,0.0,0.07,valentina lombardi,,ITAL-1010,2015
+ITAL,1020,1,Elementary Italian,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-1020,2015
+ITAL,2010,1,Intermediate Italian,0.44,0.31,0.25,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2010,2015
+ITAL,2010,2,Intermediate Italian,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2010,2015
+JAPN,1010,1,Elementary Japanese,0.76,0.0,0.18,0.06,0.0,0.0,0.0,0.0,jae allegr takeuchi,,JAPN-1010,2015
+JAPN,1010,2,Elementary Japanese,0.59,0.12,0.12,0.0,0.06,0.0,0.0,0.12,jae allegr takeuchi,,JAPN-1010,2015
+JAPN,1020,1,Elementary Japanese,0.38,0.31,0.08,0.08,0.0,0.0,0.0,0.15,kazuko shoji,,JAPN-1020,2015
+JAPN,2010,1,Intermed Japanese,0.47,0.33,0.13,0.0,0.07,0.0,0.0,0.0,kazuko shoji,,JAPN-2010,2015
+JAPN,3050,1,Japanese Conversation & Comp,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,toshiko kishimoto,,JAPN-3050,2015
+LANG,2540,1,Introduction to World Cinemas,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,raquel anido,,LANG-2540,2015
+LANG,3710,1,Language and Culture,0.36,0.45,0.09,0.09,0.0,0.0,0.0,0.0,yanhua zhang,,LANG-3710,2015
+LARC,1150,1,Intro Landscape Architecture,0.48,0.18,0.24,0.0,0.06,0.0,0.0,0.03,martin john holland,,LARC-1150,2015
+LARC,1280,1,Technical Graphics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,,LARC-1280,2015
+LARC,1510,1,Basic Design I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,,LARC-1510,2015
+LARC,2510,1,Larch Design Fund,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,robert hewitt,,LARC-2510,2015
+LARC,2620,1,Design Impl I,0.36,0.14,0.29,0.0,0.14,0.0,0.0,0.07,paul russell,,LARC-2620,2015
+LARC,3510,1,Regional Design,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,yang song,,LARC-3510,2015
+LARC,4530,2,Key Issues in Larch,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,,LARC-4530,2015
+LARC,8210,1,Research Methods,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,,LARC-8210,2015
+LARC,8500,1,Grad Colloquium,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,,LARC-8500,2015
+LAW,3220,1,Legal Env of Bus,0.5,0.27,0.16,0.05,0.02,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2015
+LAW,3220,2,Legal Env of Bus,0.57,0.28,0.09,0.02,0.02,0.0,0.0,0.02,edward ray claggett,,LAW-3220,2015
+LAW,3220,3,Legal Env of Bus,0.31,0.36,0.17,0.07,0.05,0.0,0.0,0.05,kenneth toussaint,,LAW-3220,2015
+LAW,3220,4,Legal Env of Bus,0.21,0.4,0.24,0.05,0.07,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2015
+LAW,3220,5,Legal Env of Bus,0.2,0.36,0.36,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2015
+LAW,3220,6,Legal Env of Bus,0.12,0.49,0.3,0.02,0.05,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2015
+LAW,3220,7,Legal Env of Bus,0.45,0.32,0.2,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,,LAW-3220,2015
+LAW,3220,8,Legal Env of Bus,0.39,0.36,0.23,0.0,0.0,0.0,0.0,0.02,kath kisska-schulze,,LAW-3220,2015
+LAW,3220,9,Legal Env of Bus,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,john hine,,LAW-3220,2015
+LAW,3220,10,Legal Env of Bus,0.27,0.41,0.25,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2015
+LAW,3220,11,Legal Env of Bus,0.51,0.47,0.02,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2015
+LAW,3220,100,Legal Env of Bus (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,True,LAW-3220,2015
+LAW,3220,400,Legal Env of Bus,0.15,0.38,0.15,0.06,0.12,0.0,0.0,0.15,virgini ward-vaughn,,LAW-3220,2015
+LAW,3220,401,Legal Env of Bus,0.1,0.35,0.23,0.03,0.06,0.0,0.0,0.23,virgini ward-vaughn,,LAW-3220,2015
+LAW,3220,402,Legal Env of Bus,0.13,0.27,0.37,0.07,0.1,0.0,0.0,0.07,virgini ward-vaughn,,LAW-3220,2015
+LAW,3220,403,Legal Env of Bus,0.19,0.3,0.11,0.07,0.15,0.0,0.0,0.19,virgini ward-vaughn,,LAW-3220,2015
+LAW,3330,1,Real Estate Law,0.22,0.49,0.2,0.05,0.02,0.02,0.0,0.0,judson jahn,,LAW-3330,2015
+LAW,4050,1,Construction Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-4050,2015
+LIB,3010,1,Patent Searching,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,janice comfort,,LIB-3010,2015
+LIH,1270,1,Introduction to L&Ih,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,graciela tissera,,LIH-1270,2015
+LS,1000,1,Therapeutic Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,,LS-1000,2015
+LS,1000,2,Therapeutic Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-1000,2015
+LS,1000,3,Therapeutic Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ranjanbala dil amin,,LS-1000,2015
+LS,1000,6,Beg. Non-competitive Karate,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,june pilcher,,LS-1000,2015
+LS,1000,19,Introduction to Hip-Hop Dance,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,andrew ellio boland,,LS-1000,2015
+LS,1000,31,Stand-up Paddleboarding,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,elizabeth venable,,LS-1000,2015
+LS,1410,1,Top Rope Climbing,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,glenn dav middleton,,LS-1410,2015
+LS,1410,5,Top Rope Climbing,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,glenn dav middleton,,LS-1410,2015
+LS,1450,5,Camping/Backpacking,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,samuel james keith,,LS-1450,2015
+LS,1570,7,Shotgun Sports,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,susan ruth sullivan,,LS-1570,2015
+LS,1580,5,Archery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,herbert strickland,,LS-1580,2015
+LS,1640,1,Whitewater Kayaking,0.73,0.0,0.09,0.0,0.0,0.0,0.0,0.18,samuel dylan mcgee,,LS-1640,2015
+LS,1640,3,Whitewater Kayaking,0.64,0.09,0.0,0.0,0.0,0.0,0.0,0.27,emily grace turke,,LS-1640,2015
+LS,1650,3,Inland Kayak Touring,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,sarah wilcer,,LS-1650,2015
+LS,1750,2,Fly Fishing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael watts,,LS-1750,2015
+LS,1850,3,Bowling,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,megan elizabet cato,,LS-1850,2015
+LS,1850,10,Bowling,0.83,0.07,0.07,0.03,0.0,0.0,0.0,0.0,katie dudley,,LS-1850,2015
+LS,1940,2,Racquetball,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,,LS-1940,2015
+LS,2040,1,Soccer,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,jessica ca doughtie,,LS-2040,2015
+LS,2100,1,Learn to Dance,0.89,0.03,0.0,0.0,0.03,0.0,0.0,0.06,matthew lee krabbe,,LS-2100,2015
+LS,2110,1,Introduction to Belly Dance,0.8,0.05,0.0,0.0,0.0,0.0,0.0,0.15,stephanie pack,,LS-2110,2015
+LS,2110,3,Introduction to Belly Dance,0.86,0.09,0.0,0.0,0.05,0.0,0.0,0.0,stephanie pack,,LS-2110,2015
+LS,2200,4,Shag,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,broadus fleming,,LS-2200,2015
+LS,2200,7,Shag,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,,LS-2200,2015
+LS,2200,10,Shag,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,matthew lee krabbe,,LS-2200,2015
+LS,2270,2,Intro to Swing Dance,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,paul hoke,,LS-2270,2015
+LS,2270,3,Intro to Swing Dance,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,,LS-2270,2015
+LS,2270,4,Intro to Swing Dance,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,,LS-2270,2015
+LS,2280,1,Intermediate Swing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,paul hoke,,LS-2280,2015
+LS,2320,2,Core Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,diane moreno,,LS-2320,2015
+LS,2320,3,Core Training,0.88,0.0,0.04,0.0,0.0,0.0,0.0,0.08,diane moreno,,LS-2320,2015
+LS,2320,4,Core Training,0.91,0.0,0.04,0.0,0.0,0.0,0.0,0.04,diane moreno,,LS-2320,2015
+LS,2350,4,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,,LS-2350,2015
+LS,2350,5,Basic Yoga,0.65,0.22,0.0,0.0,0.0,0.0,0.0,0.13,renee warren gahan,,LS-2350,2015
+LS,2350,6,Basic Yoga,0.71,0.14,0.1,0.05,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2015
+LS,2350,7,Basic Yoga,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2015
+LS,2360,1,Power/Ashtanga Yoga,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,ani reina-nunnelley,,LS-2360,2015
+LS,2360,2,Power/Ashtanga Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,,LS-2360,2015
+LS,2360,3,Power/Ashtanga Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,,LS-2360,2015
+LS,2360,6,Power/Ashtanga Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,silica eliza larkin,,LS-2360,2015
+LS,2380,3,Vinyasa Flow Yoga,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,jenefer nadenicek,,LS-2380,2015
+LS,2380,4,Vinyasa Flow Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,jenefer nadenicek,,LS-2380,2015
+LS,2380,5,Vinyasa Flow Yoga,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jenefer nadenicek,,LS-2380,2015
+LS,2420,2,Meditation and Relax,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,renee warren gahan,,LS-2420,2015
+LS,2420,3,Meditation and Relax,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,,LS-2420,2015
+LS,2420,5,Meditation and Relax,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,,LS-2420,2015
+LS,2420,7,Meditation and Relax,0.79,0.13,0.0,0.0,0.04,0.0,0.0,0.04,renee warren gahan,,LS-2420,2015
+LS,2450,2,Pilates,0.89,0.0,0.06,0.0,0.0,0.0,0.0,0.06,melanie ivey job,,LS-2450,2015
+LS,2450,3,Pilates,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,,LS-2450,2015
+LS,2450,6,Pilates,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,,LS-2450,2015
+LS,2460,1,Intermediate Pilates,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,melanie ivey job,,LS-2460,2015
+LS,2510,3,Running & Jogging,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,robert edwar lawson,,LS-2510,2015
+LS,2700,1,Sports Officiating,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,christopher war cox,,LS-2700,2015
+LS,2770,1,Lifeguarding,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,kelly lynn womack,,LS-2770,2015
+LS,3580,1,Advanced Shotgun Skeet,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,charles flint,,LS-3580,2015
+MATH,1010,2,Essen Math for Informed Soc,0.26,0.26,0.21,0.05,0.16,0.0,0.0,0.05,paran rebeka norton,,MATH-1010,2015
+MATH,1010,3,Essen Math for Informed Soc,0.18,0.45,0.27,0.09,0.0,0.0,0.0,0.0,minghua cui,,MATH-1010,2015
+MATH,1010,4,Essen Math for Informed Soc,0.44,0.36,0.08,0.08,0.03,0.0,0.0,0.0,judith cottingham,,MATH-1010,2015
+MATH,1010,6,Essen Math for Informed Soc,0.39,0.36,0.17,0.06,0.0,0.0,0.0,0.03,judith cottingham,,MATH-1010,2015
+MATH,1010,8,Essen Math for Informed Soc,0.42,0.21,0.26,0.05,0.05,0.0,0.0,0.0,paran rebeka norton,,MATH-1010,2015
+MATH,1010,9,Essen Math for Informed Soc,0.35,0.24,0.12,0.06,0.24,0.0,0.0,0.0,yijun chen,,MATH-1010,2015
+MATH,1010,10,Essen Math for Informed Soc,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,xiyan tan,,MATH-1010,2015
+MATH,1010,12,Essen Math for Informed Soc,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,yijun chen,,MATH-1010,2015
+MATH,1010,14,Essen Math for Informed Soc,0.39,0.33,0.22,0.0,0.06,0.0,0.0,0.0,xiyan tan,,MATH-1010,2015
+MATH,1010,101,Essen Math for Informed Soc,0.35,0.27,0.12,0.12,0.0,0.0,0.0,0.15,meredith nicol burr,,MATH-1010,2015
+MATH,1020,1,Intro to Mathematical Analysis,0.25,0.28,0.19,0.08,0.14,0.0,0.0,0.06,warren adams,,MATH-1020,2015
+MATH,1020,2,Intro to Mathematical Analysis,0.0,0.32,0.37,0.16,0.11,0.0,0.0,0.05,michael we lamoreux,,MATH-1020,2015
+MATH,1020,3,Intro to Mathematical Analysis,0.16,0.42,0.11,0.0,0.26,0.0,0.0,0.05,jerry lero phillips,,MATH-1020,2015
+MATH,1020,4,Intro to Mathematical Analysis,0.06,0.22,0.39,0.11,0.06,0.0,0.0,0.17,huixi li,,MATH-1020,2015
+MATH,1020,5,Intro to Mathematical Analysis,0.11,0.37,0.26,0.11,0.16,0.0,0.0,0.0,aaro ramirez flores,,MATH-1020,2015
+MATH,1020,6,Intro to Mathematical Analysis,0.26,0.37,0.16,0.05,0.11,0.0,0.0,0.05,stefani ca mokalled,,MATH-1020,2015
+MATH,1020,7,Intro to Mathematical Analysis,0.21,0.05,0.21,0.26,0.21,0.0,0.0,0.05,huixi li,,MATH-1020,2015
+MATH,1020,8,Intro to Mathematical Analysis,0.21,0.11,0.21,0.32,0.05,0.0,0.0,0.11,aaro ramirez flores,,MATH-1020,2015
+MATH,1020,9,Intro to Mathematical Analysis,0.11,0.22,0.33,0.11,0.17,0.0,0.0,0.06,jerry lero phillips,,MATH-1020,2015
+MATH,1020,10,Intro to Mathematical Analysis,0.26,0.16,0.21,0.21,0.0,0.0,0.0,0.16,xiaoyuan liu,,MATH-1020,2015
+MATH,1020,11,Intro to Mathematical Analysis,0.21,0.21,0.26,0.11,0.16,0.0,0.0,0.05,travis baumbaugh,,MATH-1020,2015
+MATH,1020,12,Intro to Mathematical Analysis,0.17,0.39,0.11,0.17,0.0,0.0,0.0,0.17,tianhui wei,,MATH-1020,2015
+MATH,1020,13,Intro to Mathematical Analysis,0.2,0.43,0.18,0.05,0.08,0.0,0.0,0.08,randy davidson,,MATH-1020,2015
+MATH,1020,14,Intro to Mathematical Analysis,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,jennifer van dyken,,MATH-1020,2015
+MATH,1020,15,Intro to Mathematical Analysis,0.06,0.22,0.33,0.22,0.06,0.0,0.0,0.11,yibo xu,,MATH-1020,2015
+MATH,1020,16,Intro to Mathematical Analysis,0.39,0.28,0.11,0.06,0.06,0.0,0.0,0.11,stefani ca mokalled,,MATH-1020,2015
+MATH,1020,17,Intro to Mathematical Analysis,0.17,0.28,0.22,0.17,0.17,0.0,0.0,0.0,tiantian yang,,MATH-1020,2015
+MATH,1020,18,Intro to Mathematical Analysis,0.16,0.42,0.32,0.11,0.0,0.0,0.0,0.0,xiaoyuan liu,,MATH-1020,2015
+MATH,1020,19,Intro to Mathematical Analysis,0.16,0.42,0.21,0.11,0.0,0.0,0.0,0.11,chase norman joyner,,MATH-1020,2015
+MATH,1020,20,Intro to Mathematical Analysis,0.26,0.16,0.21,0.05,0.11,0.0,0.0,0.21,tianhui wei,,MATH-1020,2015
+MATH,1020,21,Intro to Mathematical Analysis,0.21,0.32,0.21,0.11,0.16,0.0,0.0,0.0,prab withana gamage,,MATH-1020,2015
+MATH,1020,22,Intro to Mathematical Analysis,0.16,0.26,0.21,0.05,0.21,0.0,0.0,0.11,michael we lamoreux,,MATH-1020,2015
+MATH,1020,23,Intro to Mathematical Analysis,0.22,0.11,0.17,0.0,0.33,0.0,0.0,0.17,hao zuo,,MATH-1020,2015
+MATH,1020,24,Intro to Mathematical Analysis,0.06,0.33,0.33,0.06,0.17,0.0,0.0,0.06,yibo xu,,MATH-1020,2015
+MATH,1020,25,Intro to Mathematical Analysis,0.05,0.37,0.26,0.11,0.11,0.0,0.0,0.11,junyang zhuang,,MATH-1020,2015
+MATH,1020,26,Intro to Mathematical Analysis,0.42,0.21,0.16,0.11,0.0,0.0,0.0,0.11,xintao liu,,MATH-1020,2015
+MATH,1020,27,Intro to Mathematical Analysis,0.26,0.37,0.16,0.11,0.05,0.0,0.0,0.05,haodong li,,MATH-1020,2015
+MATH,1020,28,Intro to Mathematical Analysis,0.32,0.11,0.26,0.05,0.21,0.0,0.0,0.05,chase norman joyner,,MATH-1020,2015
+MATH,1020,29,Intro to Mathematical Analysis,0.21,0.37,0.26,0.11,0.05,0.0,0.0,0.0,randy davidson,,MATH-1020,2015
+MATH,1020,30,Intro to Mathematical Analysis,0.21,0.26,0.26,0.0,0.16,0.0,0.0,0.11,prab withana gamage,,MATH-1020,2015
+MATH,1020,31,Intro to Mathematical Analysis,0.17,0.33,0.33,0.0,0.0,0.0,0.0,0.17,xintao liu,,MATH-1020,2015
+MATH,1020,32,Intro to Mathematical Analysis,0.0,0.21,0.42,0.21,0.16,0.0,0.0,0.0,junyang zhuang,,MATH-1020,2015
+MATH,1020,33,Intro to Mathematical Analysis,0.26,0.37,0.21,0.05,0.05,0.0,0.0,0.05,janie caro mcdonald,,MATH-1020,2015
+MATH,1020,34,Intro to Mathematical Analysis,0.26,0.21,0.21,0.11,0.16,0.0,0.0,0.05,randy davidson,,MATH-1020,2015
+MATH,1020,35,Intro to Mathematical Analysis,0.22,0.44,0.22,0.0,0.0,0.0,0.0,0.11,yinggu bao,,MATH-1020,2015
+MATH,1020,36,Intro to Mathematical Analysis,0.21,0.21,0.16,0.21,0.16,0.0,0.0,0.05,haodong li,,MATH-1020,2015
+MATH,1020,37,Intro to Mathematical Analysis,0.11,0.28,0.22,0.17,0.06,0.0,0.0,0.17,tiantian yang,,MATH-1020,2015
+MATH,1020,38,Intro to Mathematical Analysis,0.17,0.28,0.17,0.06,0.11,0.0,0.0,0.22,hao zuo,,MATH-1020,2015
+MATH,1020,39,Intro to Mathematical Analysis,0.0,0.32,0.26,0.05,0.32,0.0,0.0,0.05, erwin walker,,MATH-1020,2015
+MATH,1020,40,Intro to Mathematical Analysis,0.16,0.21,0.16,0.05,0.26,0.0,0.0,0.16,travis baumbaugh,,MATH-1020,2015
+MATH,1020,41,Intro to Mathematical Analysis,0.17,0.28,0.22,0.06,0.22,0.0,0.0,0.06,travis baumbaugh,,MATH-1020,2015
+MATH,1020,42,Intro to Mathematical Analysis,0.0,0.29,0.35,0.06,0.12,0.0,0.0,0.18,michael we lamoreux,,MATH-1020,2015
+MATH,1020,43,Intro to Mathematical Analysis,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,jennifer van dyken,,MATH-1020,2015
+MATH,1020,44,Intro to Mathematical Analysis,0.37,0.26,0.05,0.11,0.16,0.0,0.0,0.05,randy davidson,,MATH-1020,2015
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.6,0.33,0.07,donna simms,,MATH-1040,2015
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.62,0.03,tony thanh nguyen,,MATH-1040,2015
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.57,0.07,stella watson,,MATH-1040,2015
+MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.34,0.59,0.07,patrick buckingham,,MATH-1040,2015
+MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.42,0.53,0.04,rebecca lynn knoll,,MATH-1040,2015
+MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.36,0.18,liang zhao,,MATH-1040,2015
+MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.5,0.41,0.09,patrick buckingham,,MATH-1040,2015
+MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.52,0.33,0.14,jason to hedetniemi,,MATH-1040,2015
+MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.41,0.12,muhamm mohebujjaman,,MATH-1040,2015
+MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.41,0.57,0.02,hugh geller,,MATH-1040,2015
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.42,0.48,0.11,eliza dar gallagher,,MATH-1050,2015
+MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.6,0.37,0.03,charity watson,,MATH-1050,2015
+MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.39,0.02,charity watson,,MATH-1050,2015
+MATH,1060,1,Calculus of One Variable I,0.07,0.32,0.15,0.07,0.27,0.0,0.0,0.12,stefan adam bock,,MATH-1060,2015
+MATH,1060,2,Calculus of One Variable I,0.2,0.29,0.2,0.09,0.04,0.0,0.0,0.18,jonathon leverenz,,MATH-1060,2015
+MATH,1060,3,Calculus of One Variable I,0.1,0.25,0.21,0.13,0.1,0.0,0.0,0.21,abigail bowers,,MATH-1060,2015
+MATH,1060,4,Calculus of One Variable I,0.29,0.14,0.26,0.11,0.11,0.0,0.0,0.09,marilyn reba,,MATH-1060,2015
+MATH,1060,5,Calculus of One Variable I,0.1,0.29,0.24,0.07,0.19,0.0,0.0,0.12,abigail bowers,,MATH-1060,2015
+MATH,1060,6,Calculus of One Variable I,0.26,0.26,0.13,0.07,0.09,0.0,0.0,0.2,meredith nicol burr,,MATH-1060,2015
+MATH,1060,7,Calculus of One Variable I,0.14,0.31,0.2,0.09,0.09,0.0,0.0,0.17,marilyn reba,,MATH-1060,2015
+MATH,1060,8,Calculus of One Variable I,0.04,0.38,0.3,0.06,0.17,0.0,0.0,0.04,abigail bowers,,MATH-1060,2015
+MATH,1060,9,Calculus of One Variable I,0.29,0.33,0.21,0.02,0.02,0.0,0.0,0.12,abdullah al mamun,,MATH-1060,2015
+MATH,1060,10,Calculus of One Variable I,0.2,0.3,0.18,0.07,0.09,0.0,0.0,0.16,meredith nicol burr,,MATH-1060,2015
+MATH,1060,11,Calculus of One Variable I,0.12,0.31,0.31,0.14,0.0,0.0,0.0,0.12,beth novick,,MATH-1060,2015
+MATH,1060,12,Calculus of One Variable I,0.09,0.28,0.19,0.06,0.26,0.0,0.0,0.13,michael gl eldredge,,MATH-1060,2015
+MATH,1060,13,Calculus of One Variable I,0.04,0.41,0.3,0.09,0.07,0.0,0.0,0.09,sea sather-wagstaff,,MATH-1060,2015
+MATH,1060,14,Calculus of One Variable I,0.15,0.36,0.24,0.09,0.09,0.0,0.0,0.06,allen anderso guest,,MATH-1060,2015
+MATH,1060,15,Calculus of One Variable I,0.16,0.52,0.13,0.06,0.1,0.0,0.0,0.03,allen anderso guest,,MATH-1060,2015
+MATH,1060,16,Calculus of One Variable I,0.11,0.28,0.23,0.09,0.15,0.0,0.0,0.15,sea sather-wagstaff,,MATH-1060,2015
+MATH,1060,17,Calculus of One Variable I,0.34,0.25,0.23,0.09,0.05,0.0,0.0,0.05,ryan grove,,MATH-1060,2015
+MATH,1060,18,Calculus of One Variable I,0.05,0.3,0.28,0.08,0.23,0.0,0.0,0.08,amy christine grady,,MATH-1060,2015
+MATH,1060,19,Calculus of One Variable I,0.15,0.32,0.11,0.17,0.17,0.0,0.0,0.08,jonathon leverenz,,MATH-1060,2015
+MATH,1060,20,Calculus of One Variable I,0.07,0.26,0.17,0.05,0.12,0.0,0.0,0.33,sergey charnyi,,MATH-1060,2015
+MATH,1060,21,Calculus of One Variable I,0.14,0.17,0.08,0.17,0.14,0.0,0.0,0.31,rui gong,,MATH-1060,2015
+MATH,1060,22,Calculus of One Variable I,0.11,0.2,0.29,0.0,0.09,0.0,0.0,0.31,lee andrew jenkins,,MATH-1060,2015
+MATH,1060,23,Calculus of One Variable I,0.16,0.27,0.24,0.09,0.07,0.0,0.0,0.18,stefan adam bock,,MATH-1060,2015
+MATH,1060,24,Calculus of One Variable I,0.05,0.21,0.32,0.05,0.26,0.0,0.0,0.11,jennifer van dyken,,MATH-1060,2015
+MATH,1060,25,Calculus of One Variable I,0.32,0.29,0.21,0.03,0.11,0.0,0.0,0.05,shiyi tu,,MATH-1060,2015
+MATH,1060,100,Calc of One Variable I (HON),0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,beth novick,True,MATH-1060,2015
+MATH,1070,1,Differen and Integral Calculus,0.0,0.47,0.29,0.18,0.06,0.0,0.0,0.0,donna simms,,MATH-1070,2015
+MATH,1080,1,Calculus of One Variable II,0.1,0.16,0.19,0.0,0.26,0.0,0.0,0.29,alistair bentley,,MATH-1080,2015
+MATH,1080,2,Calculus of One Variable II,0.09,0.22,0.13,0.09,0.13,0.0,0.0,0.35,terri johnson,,MATH-1080,2015
+MATH,1080,3,Calculus of One Variable II,0.05,0.19,0.27,0.03,0.3,0.0,0.0,0.16,fiona may knoll,,MATH-1080,2015
+MATH,1080,4,Calculus of One Variable II,0.03,0.15,0.21,0.09,0.21,0.0,0.0,0.3,sanwar ahmad,,MATH-1080,2015
+MATH,1080,5,Calculus of One Variable II,0.05,0.23,0.18,0.08,0.21,0.0,0.0,0.26,garrett dranichak,,MATH-1080,2015
+MATH,1080,6,Calculus of One Variable II,0.03,0.17,0.17,0.06,0.43,0.0,0.0,0.14,javier ruiz ramirez,,MATH-1080,2015
+MATH,1080,7,Calculus of One Variable II,0.09,0.12,0.18,0.12,0.27,0.0,0.0,0.21,rebecca ramos,,MATH-1080,2015
+MATH,1080,8,Calculus of One Variable II,0.07,0.22,0.33,0.19,0.11,0.0,0.0,0.07,qijun he,,MATH-1080,2015
+MATH,1080,10,Calculus of One Variable II,0.03,0.11,0.18,0.26,0.24,0.0,0.0,0.18,honghai xu,,MATH-1080,2015
+MATH,1080,11,Calculus of One Variable II,0.03,0.22,0.08,0.08,0.46,0.0,0.0,0.14,audrey nico devries,,MATH-1080,2015
+MATH,1080,12,Calculus of One Variable II,0.06,0.2,0.2,0.09,0.26,0.0,0.0,0.2,shuhan xu,,MATH-1080,2015
+MATH,1080,100,Calc of One Variable II (HON),0.18,0.24,0.12,0.06,0.0,0.0,0.0,0.41,terri johnson,True,MATH-1080,2015
+MATH,1150,1,Contemp Math for Elem Teach I,0.63,0.23,0.13,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1150,2015
+MATH,1150,2,Contemp Math for Elem Teach I,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,allison stoddard,,MATH-1150,2015
+MATH,1160,1,Contemp Math for Elem Teach II,0.64,0.28,0.06,0.03,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-1160,2015
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.02,marion hanna,,MATH-1990,2015
+MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,marion hanna,,MATH-1990,2015
+MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.04,marion hanna,,MATH-1990,2015
+MATH,2060,1,Calculus of Several Variables,0.36,0.23,0.05,0.13,0.1,0.0,0.0,0.13,mishko mitkovski,,MATH-2060,2015
+MATH,2060,2,Calculus of Several Variables,0.19,0.25,0.22,0.14,0.14,0.0,0.0,0.06,christopher cox,,MATH-2060,2015
+MATH,2060,3,Calculus of Several Variables,0.26,0.16,0.16,0.1,0.19,0.0,0.0,0.13,akshay sunil gupte,,MATH-2060,2015
+MATH,2060,4,Calculus of Several Variables,0.36,0.38,0.18,0.0,0.03,0.0,0.0,0.05,xin liu,,MATH-2060,2015
+MATH,2060,5,Calculus of Several Variables,0.18,0.26,0.08,0.05,0.26,0.0,0.0,0.16,gretchen matthews,,MATH-2060,2015
+MATH,2060,6,Calculus of Several Variables,0.11,0.39,0.08,0.17,0.14,0.0,0.0,0.11,shari prevost,,MATH-2060,2015
+MATH,2060,7,Calculus of Several Variables,0.37,0.24,0.24,0.0,0.11,0.0,0.0,0.05,martin joha schmoll,,MATH-2060,2015
+MATH,2060,8,Calculus of Several Variables,0.44,0.33,0.08,0.03,0.03,0.0,0.0,0.1,xin liu,,MATH-2060,2015
+MATH,2060,9,Calculus of Several Variables,0.16,0.27,0.14,0.08,0.19,0.0,0.0,0.16,gretchen matthews,,MATH-2060,2015
+MATH,2060,10,Calculus of Several Variables,0.37,0.23,0.26,0.06,0.03,0.0,0.0,0.06,minerva rios-adams,,MATH-2060,2015
+MATH,2060,11,Calculus of Several Variables,0.26,0.11,0.26,0.11,0.14,0.0,0.0,0.11,shari prevost,,MATH-2060,2015
+MATH,2060,12,Calculus of Several Variables,0.26,0.24,0.16,0.03,0.21,0.0,0.0,0.11,gretchen matthews,,MATH-2060,2015
+MATH,2060,13,Calculus of Several Variables,0.15,0.46,0.2,0.17,0.02,0.0,0.0,0.0,minerva rios-adams,,MATH-2060,2015
+MATH,2060,14,Calculus of Several Variables,0.28,0.39,0.17,0.06,0.06,0.0,0.0,0.06,timothy fra parrott,,MATH-2060,2015
+MATH,2060,15,Calculus of Several Variables,0.17,0.27,0.37,0.12,0.07,0.0,0.0,0.0,timothy ch teitloff,,MATH-2060,2015
+MATH,2060,17,Calculus of Several Variables,0.13,0.31,0.18,0.05,0.26,0.0,0.0,0.08,timothy ch teitloff,,MATH-2060,2015
+MATH,2060,18,Calculus of Several Variables,0.28,0.19,0.25,0.06,0.08,0.0,0.0,0.14,timothy fra parrott,,MATH-2060,2015
+MATH,2060,19,Calculus of Several Variables,0.41,0.24,0.14,0.08,0.03,0.0,0.0,0.11,peter kiessler,,MATH-2060,2015
+MATH,2060,20,Calculus of Several Variables,0.72,0.26,0.0,0.0,0.0,0.0,0.0,0.03,sofya alekseeva,,MATH-2060,2015
+MATH,2060,21,Calculus of Several Variables,0.16,0.16,0.38,0.11,0.14,0.0,0.0,0.05,timothy ch teitloff,,MATH-2060,2015
+MATH,2060,22,Calculus of Several Variables,0.28,0.28,0.33,0.03,0.0,0.0,0.0,0.08,nathan jos adelgren,,MATH-2060,2015
+MATH,2060,23,Calculus of Several Variables,0.09,0.21,0.38,0.15,0.18,0.0,0.0,0.0,julie lassiter,,MATH-2060,2015
+MATH,2060,24,Calculus of Several Variables,0.54,0.44,0.03,0.0,0.0,0.0,0.0,0.0,sofya alekseeva,,MATH-2060,2015
+MATH,2060,25,Calculus of Several Variables,0.43,0.34,0.09,0.03,0.03,0.0,0.0,0.09,sofya alekseeva,,MATH-2060,2015
+MATH,2060,100,Calc of Several Vars (HON),0.63,0.17,0.08,0.0,0.04,0.0,0.0,0.08,shari prevost,True,MATH-2060,2015
+MATH,2070,1,Multivariable Calculus,0.11,0.26,0.21,0.16,0.21,0.0,0.0,0.05,trevor scot vilardi,,MATH-2070,2015
+MATH,2070,2,Multivariable Calculus,0.06,0.24,0.24,0.12,0.18,0.0,0.0,0.18,mengying xiao,,MATH-2070,2015
+MATH,2070,3,Multivariable Calculus,0.18,0.24,0.18,0.06,0.18,0.0,0.0,0.18,thanh thien to,,MATH-2070,2015
+MATH,2070,4,Multivariable Calculus,0.16,0.37,0.42,0.0,0.0,0.0,0.0,0.05,jennifer mari hanna,,MATH-2070,2015
+MATH,2070,5,Multivariable Calculus,0.15,0.08,0.38,0.15,0.08,0.0,0.0,0.15,liu zhu,,MATH-2070,2015
+MATH,2070,6,Multivariable Calculus,0.32,0.11,0.21,0.21,0.11,0.0,0.0,0.05,judith irene mcknew,,MATH-2070,2015
+MATH,2070,7,Multivariable Calculus,0.26,0.32,0.37,0.05,0.0,0.0,0.0,0.0,luke marti giberson,,MATH-2070,2015
+MATH,2070,8,Multivariable Calculus,0.29,0.29,0.2,0.2,0.03,0.0,0.0,0.0,jennifer mari hanna,,MATH-2070,2015
+MATH,2070,9,Multivariable Calculus,0.26,0.32,0.16,0.16,0.05,0.0,0.0,0.05,kevin wayne dettman,,MATH-2070,2015
+MATH,2070,10,Multivariable Calculus,0.37,0.21,0.21,0.11,0.05,0.0,0.0,0.05,luke marti giberson,,MATH-2070,2015
+MATH,2070,11,Multivariable Calculus,0.22,0.39,0.33,0.0,0.0,0.0,0.0,0.06,judith irene mcknew,,MATH-2070,2015
+MATH,2070,12,Multivariable Calculus,0.26,0.32,0.11,0.05,0.16,0.0,0.0,0.11,yisu jia,,MATH-2070,2015
+MATH,2070,13,Multivariable Calculus,0.25,0.13,0.31,0.13,0.13,0.0,0.0,0.06,liu zhu,,MATH-2070,2015
+MATH,2070,14,Multivariable Calculus,0.39,0.22,0.17,0.11,0.11,0.0,0.0,0.0,trevor scot vilardi,,MATH-2070,2015
+MATH,2070,15,Multivariable Calculus,0.21,0.27,0.27,0.03,0.12,0.0,0.0,0.09,jennifer mari hanna,,MATH-2070,2015
+MATH,2070,16,Multivariable Calculus,0.17,0.17,0.2,0.2,0.06,0.0,0.0,0.2,hui xue,,MATH-2070,2015
+MATH,2070,18,Multivariable Calculus,0.06,0.18,0.29,0.12,0.29,0.0,0.0,0.06,kevin wayne dettman,,MATH-2070,2015
+MATH,2070,19,Multivariable Calculus,0.22,0.33,0.28,0.11,0.0,0.0,0.0,0.06,jennifer mari hanna,,MATH-2070,2015
+MATH,2070,20,Multivariable Calculus,0.17,0.22,0.33,0.22,0.06,0.0,0.0,0.0,yisu jia,,MATH-2070,2015
+MATH,2070,21,Multivariable Calculus,0.26,0.32,0.26,0.0,0.0,0.0,0.0,0.16,allison stoddard,,MATH-2070,2015
+MATH,2070,22,Multivariable Calculus,0.11,0.22,0.33,0.06,0.06,0.0,0.0,0.22,thanh thien to,,MATH-2070,2015
+MATH,2070,23,Multivariable Calculus,0.18,0.29,0.29,0.18,0.06,0.0,0.0,0.0,marion hanna,,MATH-2070,2015
+MATH,2080,1,Intro to Ordin Diff Equations,0.13,0.16,0.47,0.16,0.03,0.0,0.0,0.06,matthew macauley,,MATH-2080,2015
+MATH,2080,2,Intro to Ordin Diff Equations,0.76,0.0,0.0,0.0,0.18,0.0,0.0,0.06,brandon gra goodell,,MATH-2080,2015
+MATH,2080,3,Intro to Ordin Diff Equations,0.36,0.28,0.17,0.03,0.11,0.0,0.0,0.06,matthew macauley,,MATH-2080,2015
+MATH,2080,4,Intro to Ordin Diff Equations,0.57,0.26,0.11,0.0,0.0,0.0,0.0,0.06,irina viktorova,,MATH-2080,2015
+MATH,2080,5,Intro to Ordin Diff Equations,0.03,0.21,0.29,0.15,0.15,0.0,0.0,0.18,julie lassiter,,MATH-2080,2015
+MATH,2080,6,Intro to Ordin Diff Equations,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,irina viktorova,,MATH-2080,2015
+MATH,2080,8,Intro to Ordin Diff Equations,0.09,0.11,0.16,0.23,0.18,0.0,0.0,0.23,julie lassiter,,MATH-2080,2015
+MATH,2080,9,Intro to Ordin Diff Equations,0.15,0.41,0.09,0.06,0.15,0.0,0.0,0.15,timothy fra parrott,,MATH-2080,2015
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True,MATH-2080,2015
+MATH,2160,1,Geometry for Elem Sch Teachers,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-2160,2015
+MATH,2160,2,Geometry for Elem Sch Teachers,0.78,0.17,0.05,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-2160,2015
+MATH,2500,1,Intro to Mathematical Sciences,0.78,0.11,0.0,0.0,0.07,0.0,0.0,0.04,matthew saltzman,,MATH-2500,2015
+MATH,3020,1,Stat for Science & Engineering,0.37,0.53,0.05,0.0,0.05,0.0,0.0,0.0,hewa priyadarshani,,MATH-3020,2015
+MATH,3020,2,Stat for Science & Engineering,0.53,0.28,0.08,0.06,0.03,0.0,0.0,0.03,derek brown,,MATH-3020,2015
+MATH,3020,3,Stat for Science & Engineering,0.26,0.4,0.17,0.06,0.03,0.0,0.0,0.09,derek brown,,MATH-3020,2015
+MATH,3020,4,Stat for Science & Engineering,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,hewa priyadarshani,,MATH-3020,2015
+MATH,3020,5,Stat for Science & Engineering,0.25,0.28,0.38,0.03,0.0,0.0,0.0,0.06,calvin williams,,MATH-3020,2015
+MATH,3020,6,Stat for Science & Engineering,0.42,0.24,0.21,0.06,0.0,0.0,0.0,0.06,calvin williams,,MATH-3020,2015
+MATH,3020,7,Stat for Science & Engineering,0.5,0.28,0.19,0.03,0.0,0.0,0.0,0.0,xiaoqian sun,,MATH-3020,2015
+MATH,3020,8,Stat for Science & Engineering,0.34,0.29,0.17,0.06,0.06,0.0,0.0,0.09,yanbo xia,,MATH-3020,2015
+MATH,3020,9,Stat for Science & Engineering,0.22,0.33,0.3,0.0,0.04,0.0,0.0,0.11,rachel eli grotheer,,MATH-3020,2015
+MATH,3110,1,Linear Algebra,0.16,0.32,0.36,0.08,0.04,0.0,0.0,0.04,michael adam burr,,MATH-3110,2015
+MATH,3110,2,Linear Algebra,0.32,0.21,0.13,0.11,0.18,0.0,0.0,0.05,xuhong gao,,MATH-3110,2015
+MATH,3110,3,Linear Algebra,0.41,0.19,0.05,0.16,0.14,0.0,0.0,0.05,xuhong gao,,MATH-3110,2015
+MATH,3110,4,Linear Algebra,0.24,0.37,0.16,0.16,0.08,0.0,0.0,0.0,kevin james,,MATH-3110,2015
+MATH,3110,5,Linear Algebra,0.17,0.37,0.23,0.09,0.06,0.0,0.0,0.09,felice manganiello,,MATH-3110,2015
+MATH,3160,1,Prob Solving for Math Teachers,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-3160,2015
+MATH,3190,1,Introduction to Proof,0.19,0.38,0.15,0.04,0.19,0.0,0.0,0.04,elena sta dimitrova,,MATH-3190,2015
+MATH,3190,2,Introduction to Proof,0.54,0.23,0.15,0.04,0.0,0.0,0.0,0.04,elena sta dimitrova,,MATH-3190,2015
+MATH,3600,1,Intermediate Math Computing,0.61,0.16,0.0,0.0,0.06,0.0,0.0,0.16,neil calkin,,MATH-3600,2015
+MATH,3650,1,Numerical Mthds for Engineers,0.19,0.32,0.16,0.14,0.05,0.0,0.0,0.14,vincent ervin,,MATH-3650,2015
+MATH,3650,2,Numerical Mthds for Engineers,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,leo rebholz,,MATH-3650,2015
+MATH,3650,3,Numerical Mthds for Engineers,0.29,0.58,0.08,0.0,0.0,0.0,0.0,0.05,leo rebholz,,MATH-3650,2015
+MATH,3650,4,Numerical Mthds for Engineers,0.33,0.46,0.1,0.03,0.03,0.0,0.0,0.05,timo johann heister,,MATH-3650,2015
+MATH,4000,1,Theory of Probability,0.44,0.19,0.19,0.0,0.19,0.0,0.0,0.0,yingbo li,,MATH-4000,2015
+MATH,4000,2,Theory of Probability,0.33,0.28,0.11,0.06,0.11,0.0,0.0,0.11,yingbo li,,MATH-4000,2015
+MATH,4070,1,Regress & Time-Series Analysis,0.2,0.4,0.1,0.1,0.1,0.0,0.0,0.1,christopher mcmahan,,MATH-4070,2015
+MATH,4120,1,Algebra I,0.17,0.25,0.21,0.13,0.13,0.0,0.0,0.13,elena sta dimitrova,,MATH-4120,2015
+MATH,4190,1,Discrete Math Structures I,0.44,0.44,0.05,0.0,0.08,0.0,0.0,0.0,wayne goddard,,MATH-4190,2015
+MATH,4310,1,Theory of Interest,0.63,0.0,0.0,0.06,0.19,0.0,0.0,0.13,mark cawood,,MATH-4310,2015
+MATH,4340,1,Adv Engineering Mathematics,0.23,0.47,0.1,0.03,0.0,0.0,0.0,0.17,qingshan chen,,MATH-4340,2015
+MATH,4340,2,Adv Engineering Mathematics,0.29,0.25,0.14,0.14,0.0,0.0,0.0,0.18,eleanor jenkins,,MATH-4340,2015
+MATH,4400,1,Linear Programming,0.61,0.11,0.11,0.11,0.04,0.0,0.0,0.04,yuyuan ouyang,,MATH-4400,2015
+MATH,4410,1,Intro to Stochastic Models,0.65,0.12,0.12,0.0,0.0,0.0,0.0,0.12,peter kiessler,,MATH-4410,2015
+MATH,4530,1,Advanced Calculus I,0.27,0.41,0.14,0.14,0.05,0.0,0.0,0.0,taufiquar rahm khan,,MATH-4530,2015
+MATH,4530,2,Advanced Calculus I,0.3,0.26,0.17,0.13,0.13,0.0,0.0,0.0,shitao liu,,MATH-4530,2015
+MATH,6340,1,Adv Engineering Mathematics,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,vincent ervin,,MATH-6340,2015
+MATH,8000,1,Probability,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,robert lund,,MATH-8000,2015
+MATH,8010,1,General Linear Hypothesis I,0.3,0.5,0.15,0.0,0.0,0.0,0.0,0.05,xiaoqian sun,,MATH-8010,2015
+MATH,8050,1,Data Analysis,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,derek brown,,MATH-8050,2015
+MATH,8070,1,Applied Multivariate Analysis,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-8070,2015
+MATH,8100,1,Mathematical Programming,0.68,0.09,0.05,0.0,0.0,0.0,0.0,0.18,margaret mar wiecek,,MATH-8100,2015
+MATH,8120,1,Discrete Optimization,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,akshay sunil gupte,,MATH-8120,2015
+MATH,8140,1,Network Flow Programming,0.14,0.71,0.14,0.0,0.0,0.0,0.0,0.0,warren adams,,MATH-8140,2015
+MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,,MATH-8170,2015
+MATH,8210,1,Linear Analysis,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,,MATH-8210,2015
+MATH,8510,1,Abstract Algebra I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,james ba coykendall,,MATH-8510,2015
+MATH,8530,1,Matrix Analysis,0.22,0.39,0.28,0.0,0.0,0.0,0.0,0.11,felice manganiello,,MATH-8530,2015
+MATH,8600,1,Intro to Scientific Computing,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,qingshan chen,,MATH-8600,2015
+MATH,8650,1,Data Structures,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,timo johann heister,,MATH-8650,2015
+MATH,8840,1,Statistics for Experimenters,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,,MATH-8840,2015
+MBA,8030,1,Stat Analy of Bus Op,0.53,0.33,0.09,0.0,0.0,0.0,0.0,0.04,janis miller,,MBA-8030,2015
+MBA,8060,1,Operations Mgt,0.13,0.74,0.05,0.03,0.03,0.0,0.0,0.03, sridharan,,MBA-8060,2015
+MBA,8070,1,Financial Management,0.44,0.28,0.21,0.0,0.0,0.0,0.0,0.08,ramon tolb franklin,,MBA-8070,2015
+MBA,8090,1,Org Beh & Hum Res Mg,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2015
+MBA,8090,2,Org Beh & Hum Res Mg,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2015
+MBA,8190,1,Intro to Acc and Fin,0.53,0.39,0.05,0.0,0.0,0.0,0.0,0.03,annieka philo,,MBA-8190,2015
+MBA,8190,2,Intro to Acc and Fin,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,,MBA-8190,2015
+MBA,8290,1,Marketing Foundation,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MBA-8290,2015
+MBA,8330,1,Real Estate Investmt,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,franklin bog wallin,,MBA-8330,2015
+MBA,8350,1,Investment Mgmt,0.39,0.46,0.07,0.04,0.0,0.0,0.0,0.04,john alexander,,MBA-8350,2015
+MBA,8360,1,Real Estate Principles,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,jeffrey randolph,,MBA-8360,2015
+MBA,8370,1,Legal Environ of Bus,0.43,0.55,0.02,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2015
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,prashant prabhu,,MBA-8400,2015
+MBA,8430,1,Entrepreneurial Accounting,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,sally kathr widener,,MBA-8430,2015
+MBA,8450,1,Technology & Innovation Mgt,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8450,2015
+MBA,8490,5,Entrepreneurial Strategy,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8490,2015
+MBA,8510,1,Bus Operations & Logistics,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09, sridharan,,MBA-8510,2015
+MBA,8590,1,Mgr Decision Model,0.39,0.36,0.17,0.03,0.03,0.0,0.0,0.03,sara elizabet yoder,,MBA-8590,2015
+MBA,8590,2,Mgr Decision Model,0.53,0.14,0.23,0.0,0.02,0.0,0.0,0.07,mark mcknew,,MBA-8590,2015
+MBA,8600,1,Advanced Marketing Strategy,0.48,0.42,0.09,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2015
+MBA,8600,2,Advanced Marketing Strategy,0.17,0.66,0.1,0.03,0.0,0.0,0.0,0.03,michael dorsch,,MBA-8600,2015
+MBA,8610,1,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MBA-8610,2015
+MBA,8620,1,Managerial Economics,0.34,0.54,0.06,0.0,0.0,0.0,0.0,0.06,scott templeton,,MBA-8620,2015
+MBA,8620,2,Managerial Economics,0.6,0.33,0.03,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,,MBA-8620,2015
+MBA,8650,1,Taxation of Business Decisions,0.27,0.64,0.0,0.0,0.0,0.0,0.0,0.09,judson jahn,,MBA-8650,2015
+MBA,8700,1,Strategic Management,0.62,0.35,0.04,0.0,0.0,0.0,0.0,0.0,peter gianiodis,,MBA-8700,2015
+MBA,8810,1,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,evguenia pas layton,,MBA-8810,2015
+MBA,8990,2,Creativity,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,,MBA-8990,2015
+MBA,8990,10,Selected Topics in Entrepreneu,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,aleda marie roth,,MBA-8990,2015
+ME,2000,1,Sophomore Seminar,0.93,0.03,0.0,0.01,0.0,0.0,0.0,0.03,donald beasley,,ME-2000,2015
+ME,2010,1,Statics & Dynamics,0.1,0.08,0.14,0.07,0.38,0.0,0.0,0.23,sherrill biggers,,ME-2010,2015
+ME,2010,2,Statics & Dynamics,0.14,0.18,0.23,0.09,0.19,0.0,0.0,0.17,paul joseph,,ME-2010,2015
+ME,2010,3,Statics & Dynamics,0.15,0.18,0.24,0.0,0.28,0.0,0.0,0.15,kalyan chakr katuri,,ME-2010,2015
+ME,2030,1,Founda Th/Fl Syst,0.07,0.21,0.34,0.2,0.07,0.0,0.0,0.1,jay ochterbeck,,ME-2030,2015
+ME,2040,1,Mechanics of Materials,0.16,0.42,0.3,0.06,0.03,0.0,0.0,0.03,garrett pataky,,ME-2040,2015
+ME,2040,2,Mechanics of Materials,0.08,0.44,0.3,0.06,0.1,0.0,0.0,0.02,huijuan zhao,,ME-2040,2015
+ME,2220,1,Mechanical Engineering Lab I,0.21,0.71,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,2,Mechanical Engineering Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-2220,2015
+ME,2220,3,Mechanical Engineering Lab I,0.35,0.5,0.05,0.0,0.0,0.0,0.0,0.1,todd schweisinger,,ME-2220,2015
+ME,2220,4,Mechanical Engineering Lab I,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,,ME-2220,2015
+ME,2220,5,Mechanical Engineering Lab I,0.55,0.35,0.0,0.0,0.0,0.0,0.0,0.1,todd schweisinger,,ME-2220,2015
+ME,2220,6,Mechanical Engineering Lab I,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,7,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,8,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,9,Mechanical Engineering Lab I,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,3030,1,Thermodynamics,0.22,0.35,0.33,0.03,0.0,0.0,0.0,0.06,daniel fant,,ME-3030,2015
+ME,3030,2,Thermodynamics,0.37,0.43,0.11,0.02,0.06,0.0,0.0,0.02,daniel fant,,ME-3030,2015
+ME,3040,1,Heat Transfer,0.15,0.35,0.26,0.06,0.12,0.0,0.0,0.06,jean-marc delhaye,,ME-3040,2015
+ME,3040,2,Heat Transfer,0.32,0.3,0.3,0.04,0.02,0.0,0.0,0.02,xin zhao,,ME-3040,2015
+ME,3050,1,Model/an Dy Syst,0.16,0.34,0.34,0.09,0.07,0.0,0.0,0.0,todd schweisinger,,ME-3050,2015
+ME,3050,2,Model/an Dy Syst,0.19,0.43,0.29,0.05,0.0,0.0,0.0,0.05,yue wang,,ME-3050,2015
+ME,3060,1,Fund Machine Design,0.07,0.52,0.31,0.0,0.03,0.0,0.0,0.07,oliver myers,,ME-3060,2015
+ME,3060,2,Fund Machine Design,0.2,0.4,0.22,0.13,0.02,0.0,0.0,0.02,paul jeffrey meyer,,ME-3060,2015
+ME,3070,1,Found of Mechanical Systems,0.44,0.4,0.15,0.0,0.0,0.0,0.0,0.01,lonny thompson,,ME-3070,2015
+ME,3070,2,Found of Mechanical Systems,0.17,0.41,0.21,0.12,0.03,0.0,0.0,0.05,georges fadel,,ME-3070,2015
+ME,3080,1,Fluid Mechanics,0.07,0.22,0.29,0.12,0.17,0.0,0.0,0.12,jean-marc delhaye,,ME-3080,2015
+ME,3080,2,Fluid Mechanics,0.23,0.4,0.26,0.07,0.02,0.0,0.0,0.02,xiangchun xuan,,ME-3080,2015
+ME,3080,3,Fluid Mechanics,0.15,0.22,0.44,0.04,0.07,0.0,0.0,0.09,ethan kung,,ME-3080,2015
+ME,3120,2,Manuf Processes,0.44,0.38,0.12,0.04,0.02,0.0,0.0,0.0,rod martinez-duarte,,ME-3120,2015
+ME,3330,1,Mechanical Engineering Lab II,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,3330,2,Mechanical Engineering Lab II,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,3330,3,Mechanical Engineering Lab II,0.37,0.42,0.16,0.0,0.0,0.0,0.0,0.05,todd schweisinger,,ME-3330,2015
+ME,3330,4,Mechanical Engineering Lab II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,3330,5,Mechanical Engineering Lab II,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,todd schweisinger,,ME-3330,2015
+ME,3330,6,Mechanical Engineering Lab II,0.07,0.79,0.14,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,3330,7,Mechanical Engineering Lab II,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,todd schweisinger,,ME-3330,2015
+ME,3330,8,Mechanical Engineering Lab II,0.27,0.36,0.09,0.0,0.0,0.0,0.0,0.27,todd schweisinger,,ME-3330,2015
+ME,4000,1,Senior Seminar,0.96,0.03,0.0,0.01,0.0,0.0,0.0,0.0, ramasubramanian,,ME-4000,2015
+ME,4010,1,Mech Engr Design,0.08,0.66,0.16,0.09,0.01,0.0,0.0,0.0,joshua summers,,ME-4010,2015
+ME,4020,2,Intern in Engr Des,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-4020,2015
+ME,4020,3,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-4020,2015
+ME,4020,4,Intern in Engr Des,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,,ME-4020,2015
+ME,4030,1,Control Dynamic Systems,0.3,0.28,0.3,0.11,0.0,0.0,0.0,0.01,ardalan vahidi,,ME-4030,2015
+ME,4030,2,Control Dynamic Systems,0.27,0.51,0.2,0.02,0.0,0.0,0.0,0.0,seye parvini oskoui,,ME-4030,2015
+ME,4180,1,F E A in M E Design,0.63,0.3,0.03,0.0,0.0,0.0,0.0,0.03,gang li,,ME-4180,2015
+ME,4200,1,Ener Sources/Utiliz,0.54,0.43,0.03,0.0,0.0,0.0,0.0,0.0,donald beasley,,ME-4200,2015
+ME,4210,1,Intro to Comp Flow,0.27,0.27,0.33,0.07,0.0,0.0,0.0,0.07,chenning tong,,ME-4210,2015
+ME,4400,1,Matls for Aggr Envir,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mica grujicic,,ME-4400,2015
+ME,4440,1,Mechanical Engineering Lab III,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2015
+ME,4440,2,Mechanical Engineering Lab III,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2015
+ME,4440,3,Mechanical Engineering Lab III,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2015
+ME,4440,4,Mechanical Engineering Lab III,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2015
+ME,4440,7,Mechanical Engineering Lab III,0.0,0.83,0.0,0.0,0.08,0.0,0.0,0.08,john wagner,,ME-4440,2015
+ME,4540,1,Design of Machine Elements,0.52,0.3,0.06,0.03,0.03,0.0,0.0,0.06,paul jeffrey meyer,,ME-4540,2015
+ME,4930,36,Selected Topics ME - BioDesign,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,michael porter,,ME-4930,2015
+ME,6210,1,Intro to Comp Flow,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,,ME-6210,2015
+ME,6540,1,Des Machine Elements,0.57,0.36,0.0,0.0,0.07,0.0,0.0,0.0,paul jeffrey meyer,,ME-6540,2015
+ME,8010,1,Found of Fluid Mech,0.29,0.5,0.17,0.0,0.0,0.0,0.0,0.04,richard figliola,,ME-8010,2015
+ME,8100,1,Macroscopic Thermo,0.32,0.6,0.08,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,,ME-8100,2015
+ME,8140,1,Turb Bound Layer,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,richard miller,,ME-8140,2015
+ME,8180,1,Intro to Fin Ele Ana,0.75,0.23,0.02,0.0,0.0,0.0,0.0,0.0,lonny thompson,,ME-8180,2015
+ME,8230,1,Control Systems,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-8230,2015
+ME,8370,1,Theory of Elast I,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,,ME-8370,2015
+ME,8460,1,Inter Dynamics,0.19,0.57,0.19,0.05,0.0,0.0,0.0,0.0,phanin tallapragada,,ME-8460,2015
+ME,8700,1,Adv Design Methods,0.34,0.66,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-8700,2015
+ME,8710,1,Engr Optimization,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-8710,2015
+ME,8930,27,Sel Topics in Mechanical Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-8930,2015
+MGT,2010,1,Principles of Management,0.33,0.41,0.17,0.03,0.04,0.0,0.0,0.03,katherine clark,,MGT-2010,2015
+MGT,2010,2,Principles of Management,0.32,0.41,0.16,0.05,0.03,0.0,0.0,0.03,katherine clark,,MGT-2010,2015
+MGT,2010,3,Principles of Management,0.36,0.36,0.22,0.03,0.01,0.0,0.0,0.03,katherine clark,,MGT-2010,2015
+MGT,2010,4,Principles of Management,0.13,0.44,0.28,0.07,0.03,0.0,0.0,0.04,katherine clark,,MGT-2010,2015
+MGT,2010,5,Principles of Management,0.22,0.36,0.34,0.02,0.02,0.0,0.0,0.05,tina robbins,,MGT-2010,2015
+MGT,2010,6,Principles of Management,0.4,0.41,0.15,0.01,0.01,0.0,0.0,0.01,tina robbins,,MGT-2010,2015
+MGT,2010,7,Principles of Management,0.33,0.46,0.11,0.07,0.03,0.0,0.0,0.0,tina robbins,,MGT-2010,2015
+MGT,2010,8,Principles of Management,0.42,0.42,0.14,0.0,0.01,0.0,0.0,0.0,tina robbins,,MGT-2010,2015
+MGT,2010,9,Principles of Mgt(HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True,MGT-2010,2015
+MGT,2180,1,Management PC Applications,0.5,0.29,0.12,0.02,0.0,0.0,0.0,0.07,ryan toole,,MGT-2180,2015
+MGT,2180,2,Management PC Applications,0.5,0.33,0.04,0.02,0.06,0.0,0.0,0.05,ryan toole,,MGT-2180,2015
+MGT,2180,3,Management PC Applications,0.42,0.33,0.16,0.02,0.02,0.0,0.0,0.05,ryan toole,,MGT-2180,2015
+MGT,2180,4,Management PC Applications,0.47,0.28,0.14,0.02,0.05,0.0,0.0,0.04,ryan toole,,MGT-2180,2015
+MGT,2970,1,CI - How to Start a Startup,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,matthew charl klein,,MGT-2970,2015
+MGT,2970,2,CI - How to Start a Startup,0.5,0.14,0.0,0.0,0.0,0.0,0.0,0.36,gregory pickett,,MGT-2970,2015
+MGT,3070,1,Human Resource Management,0.38,0.51,0.08,0.0,0.0,0.0,0.0,0.03,michael cole,,MGT-3070,2015
+MGT,3070,3,Human Resource Management,0.16,0.34,0.39,0.02,0.02,0.0,0.0,0.07,kristin dam scott,,MGT-3070,2015
+MGT,3070,4,Human Resource Management,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,priscilla harrison,,MGT-3070,2015
+MGT,3070,5,Human Resource Management,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2015
+MGT,3070,6,Human Resource Management,0.53,0.35,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2015
+MGT,3070,7,Human Resource Management,0.33,0.54,0.05,0.05,0.03,0.0,0.0,0.0,michael cole,,MGT-3070,2015
+MGT,3100,1,Intermed Business Statistics,0.23,0.19,0.29,0.06,0.13,0.0,0.0,0.1,sara elizabet yoder,,MGT-3100,2015
+MGT,3100,2,Intermed Business Statistics,0.28,0.13,0.3,0.08,0.13,0.0,0.0,0.1,sara elizabet yoder,,MGT-3100,2015
+MGT,3100,3,Intermed Business Statistics,0.15,0.18,0.3,0.1,0.13,0.0,0.0,0.15,sara elizabet yoder,,MGT-3100,2015
+MGT,3100,5,Intermed Business Statistics,0.32,0.15,0.18,0.09,0.09,0.0,0.0,0.18,jerry kermi bilbrey,,MGT-3100,2015
+MGT,3100,6,Intermed Business Statistics,0.53,0.25,0.06,0.03,0.03,0.0,0.0,0.11,jerry kermi bilbrey,,MGT-3100,2015
+MGT,3100,7,Intermed Business Statistics,0.35,0.3,0.24,0.03,0.0,0.0,0.0,0.08,jerry kermi bilbrey,,MGT-3100,2015
+MGT,3100,8,Intermed Business Statistics,0.33,0.25,0.15,0.05,0.1,0.0,0.0,0.13,remi charpin,,MGT-3100,2015
+MGT,3100,9,Intermed Business Statistics,0.33,0.2,0.23,0.13,0.05,0.0,0.0,0.08,min kyung lee,,MGT-3100,2015
+MGT,3100,10,Intermed Business Statistics,0.58,0.28,0.06,0.0,0.08,0.0,0.0,0.0,shih lun tseng,,MGT-3100,2015
+MGT,3100,11,Intermed Business Statistics,0.47,0.25,0.11,0.03,0.0,0.0,0.0,0.14,iaroslava dutchak,,MGT-3100,2015
+MGT,3100,12,Intermed Business Statistics,0.25,0.28,0.19,0.03,0.11,0.0,0.0,0.14,yunsik choi,,MGT-3100,2015
+MGT,3100,13,Intermed Business Statistics,0.16,0.32,0.21,0.05,0.11,0.0,0.0,0.16,jerry kermi bilbrey,,MGT-3100,2015
+MGT,3120,1,Decision Models for Management,0.15,0.46,0.17,0.02,0.15,0.0,0.0,0.05,mark mcknew,,MGT-3120,2015
+MGT,3120,2,Decision Models for Management,0.4,0.24,0.24,0.02,0.07,0.0,0.0,0.02,mark mcknew,,MGT-3120,2015
+MGT,3120,3,Decision Models for Management,0.3,0.17,0.37,0.04,0.09,0.0,0.0,0.02,mark mcknew,,MGT-3120,2015
+MGT,3150,1,New Venture Creation,0.4,0.33,0.18,0.03,0.03,0.0,0.0,0.05,elizabeth er powell,,MGT-3150,2015
+MGT,3170,1,Logistics Mgmt,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,shouqiang wang,,MGT-3170,2015
+MGT,3180,1,Mgt of Info Systems,0.26,0.6,0.14,0.0,0.0,0.0,0.0,0.0,heshan sun,,MGT-3180,2015
+MGT,3180,2,Mgt of Info Systems,0.2,0.6,0.15,0.05,0.0,0.0,0.0,0.0,roopa raman,,MGT-3180,2015
+MGT,3180,3,Mgt of Info Systems,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,,MGT-3180,2015
+MGT,3180,4,Mgt of Info Systems,0.63,0.28,0.04,0.02,0.02,0.0,0.0,0.0,jackie patri london,,MGT-3180,2015
+MGT,3900,1,Ops Mgt,0.24,0.37,0.24,0.11,0.03,0.0,0.0,0.03,yann ferrand,,MGT-3900,2015
+MGT,3900,2,Ops Mgt,0.68,0.2,0.08,0.0,0.0,0.0,0.0,0.05,berna quiroga gomez,,MGT-3900,2015
+MGT,3900,3,Ops Mgt,0.0,0.58,0.29,0.06,0.03,0.0,0.0,0.03,zachary mo leffakis,,MGT-3900,2015
+MGT,3900,4,Ops Mgt,0.56,0.28,0.08,0.03,0.0,0.0,0.0,0.05,brandon woohyeo lee,,MGT-3900,2015
+MGT,3900,5,Ops Mgt,0.49,0.27,0.11,0.0,0.03,0.0,0.0,0.11,berna quiroga gomez,,MGT-3900,2015
+MGT,4000,1,Mgt of Organizational Behavior,0.27,0.5,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MGT-4000,2015
+MGT,4000,2,Mgt of Organizational Behavior,0.39,0.39,0.14,0.03,0.0,0.0,0.0,0.06,michael cole,,MGT-4000,2015
+MGT,4000,3,Mgt of Organizational Behavior,0.33,0.23,0.3,0.02,0.07,0.0,0.0,0.05,philip roth,,MGT-4000,2015
+MGT,4020,1,Ops Pln and Ctl,0.25,0.25,0.44,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,,MGT-4020,2015
+MGT,4030,1,Special Problems,0.09,0.55,0.18,0.0,0.0,0.0,0.0,0.18,siyuan li,,MGT-4030,2015
+MGT,4080,1,Lean Operations,0.25,0.33,0.33,0.0,0.0,0.0,0.0,0.08,zachary mo leffakis,,MGT-4080,2015
+MGT,4110,1,Project Management,0.29,0.56,0.1,0.0,0.0,0.0,0.0,0.05,russell purvis,,MGT-4110,2015
+MGT,4120,1,Supplier Management,0.19,0.58,0.13,0.03,0.03,0.0,0.0,0.03,shouqiang wang,,MGT-4120,2015
+MGT,4150,1,Business Strategy,0.6,0.38,0.0,0.02,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2015
+MGT,4150,3,Business Strategy,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2015
+MGT,4150,4,Business Strategy,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2015
+MGT,4150,7,Business Strategy,0.25,0.66,0.05,0.02,0.02,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2015
+MGT,4150,8,Business Strategy,0.09,0.66,0.11,0.0,0.06,0.0,0.0,0.09,amy elizabet ingram,,MGT-4150,2015
+MGT,4150,9,Business Strategy,0.18,0.49,0.28,0.0,0.0,0.0,0.0,0.05,peter gianiodis,,MGT-4150,2015
+MGT,4160,1,Special Topics Hr,0.22,0.64,0.11,0.03,0.0,0.0,0.0,0.0,kristin dam scott,,MGT-4160,2015
+MGT,4230,1,Intern Bus Mgt,0.25,0.23,0.35,0.03,0.08,0.0,0.0,0.08,wayne stewart,,MGT-4230,2015
+MGT,4230,2,Intern Bus Mgt,0.11,0.26,0.47,0.0,0.05,0.0,0.0,0.11,wayne stewart,,MGT-4230,2015
+MGT,4230,3,Intern Bus Mgt,0.06,0.32,0.32,0.06,0.19,0.0,0.0,0.03,janis miller,,MGT-4230,2015
+MGT,4230,4,Intern Bus Mgt,0.14,0.51,0.32,0.03,0.0,0.0,0.0,0.0,janis miller,,MGT-4230,2015
+MGT,4240,1,Global Supply Chain,0.17,0.66,0.14,0.0,0.0,0.0,0.0,0.03,yann ferrand,,MGT-4240,2015
+MGT,4270,1,Managing Improvement,0.07,0.5,0.29,0.07,0.0,0.0,0.0,0.07,lawrence fredendall,,MGT-4270,2015
+MGT,4300,2,Senior Seminar in Management,0.83,0.0,0.0,0.0,0.17,0.0,0.0,0.0,david leo bodde,,MGT-4300,2015
+MGT,4310,1,Emp Rights & Resp,0.48,0.28,0.2,0.0,0.0,0.0,0.0,0.05,leonard jos spooner,,MGT-4310,2015
+MGT,4310,2,Emp Rights & Resp,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-4310,2015
+MGT,4350,1,Pers Interviewing,0.44,0.38,0.13,0.04,0.0,0.0,0.0,0.0,philip roth,,MGT-4350,2015
+MGT,4520,1,Business Analysis,0.2,0.4,0.2,0.07,0.07,0.0,0.0,0.07,roopa raman,,MGT-4520,2015
+MGT,4550,1,Emerging I T Trends,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MGT-4550,2015
+MGT,8690,1,Project Mgt,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,,MGT-8690,2015
+MICR,2050,1,Introductory Micro,0.46,0.42,0.09,0.0,0.01,0.0,0.0,0.03,john abercrombie,,MICR-2050,2015
+MICR,3000,1,Essential Skills in Microbiol,0.59,0.37,0.0,0.0,0.02,0.0,0.0,0.02,tamara lyn mcnealy,,MICR-3000,2015
+MICR,3050,1,General Microbiology,0.37,0.4,0.15,0.05,0.01,0.0,0.0,0.02,krista barr rudolph,,MICR-3050,2015
+MICR,3050,2,General Microbiology,0.43,0.33,0.22,0.01,0.0,0.0,0.0,0.01,krista barr rudolph,,MICR-3050,2015
+MICR,4010,1,Microbial Diversity & Ecology,0.2,0.5,0.24,0.02,0.02,0.0,0.0,0.02,barbara campbell,,MICR-4010,2015
+MICR,4030,1,Marine Microbiology,0.2,0.4,0.0,0.1,0.1,0.0,0.0,0.2,john michael henson,,MICR-4030,2015
+MICR,4050,1,Adv Microbial Ecol of Humans,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4050,2015
+MICR,4140,1,Basic Immunology,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,yanzhang wei,,MICR-4140,2015
+MICR,4150,1,Microbial Genetics,0.4,0.33,0.07,0.17,0.0,0.0,0.0,0.03,min cao,,MICR-4150,2015
+MICR,4160,1,Intro Virology,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,simon scott,,MICR-4160,2015
+MICR,4510,1,Advanced Microbiology II,0.62,0.23,0.15,0.0,0.0,0.0,0.0,0.0,min cao,,MICR-4510,2015
+MICR,4510,2,Advanced Microbiology II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,min cao,,MICR-4510,2015
+MKT,3010,2,Prin of Marketing,0.3,0.41,0.23,0.01,0.04,0.0,0.0,0.01,carter wil mcelveen,,MKT-3010,2015
+MKT,3010,3,Prin of Marketing,0.41,0.39,0.17,0.02,0.01,0.0,0.0,0.0,carter wil mcelveen,,MKT-3010,2015
+MKT,3010,4,Prin of Marketing,0.23,0.4,0.22,0.11,0.03,0.0,0.0,0.01,carter wil mcelveen,,MKT-3010,2015
+MKT,3010,5,Prin of Marketing,0.27,0.39,0.25,0.08,0.0,0.0,0.0,0.01,amanda cooper fine,,MKT-3010,2015
+MKT,3010,6,Prin of Marketing,0.36,0.42,0.14,0.06,0.02,0.0,0.0,0.0,amanda cooper fine,,MKT-3010,2015
+MKT,3010,7,Prin of Marketing,0.24,0.41,0.21,0.07,0.03,0.0,0.0,0.04,amanda cooper fine,,MKT-3010,2015
+MKT,3010,8,Prin of Marketing,0.49,0.3,0.12,0.02,0.04,0.0,0.0,0.02,patricia knowles,,MKT-3010,2015
+MKT,3010,9,Prin of Marketing(HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james gaubert,True,MKT-3010,2015
+MKT,3020,1,Consumer Behavior,0.4,0.46,0.15,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2015
+MKT,3020,2,Consumer Behavior,0.66,0.3,0.02,0.0,0.02,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2015
+MKT,3020,3,Consumer Behavior,0.36,0.49,0.09,0.06,0.0,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2015
+MKT,3020,4,Consumer Behavior,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2015
+MKT,3210,1,Sports Marketing,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2015
+MKT,3210,2,Sports Marketing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2015
+MKT,3310,1,Marketing Metrics & Analytics,0.24,0.41,0.12,0.24,0.0,0.0,0.0,0.0,peter weathers,,MKT-3310,2015
+MKT,4200,1,Professional Selling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,,MKT-4200,2015
+MKT,4200,2,Professional Selling,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2015
+MKT,4200,3,Professional Selling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2015
+MKT,4200,4,Professional Selling,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2015
+MKT,4230,1,Promotional Strategy,0.27,0.48,0.23,0.0,0.02,0.0,0.0,0.0,patricia knowles,,MKT-4230,2015
+MKT,4240,1,Sales Management,0.38,0.55,0.03,0.0,0.0,0.0,0.0,0.03,ryan mullins,,MKT-4240,2015
+MKT,4260,1,Business-to-Business,0.54,0.41,0.03,0.0,0.0,0.0,0.0,0.03,james gaubert,,MKT-4260,2015
+MKT,4260,2,Business-to-Business,0.31,0.55,0.1,0.0,0.02,0.0,0.0,0.02,james gaubert,,MKT-4260,2015
+MKT,4270,1,International Mktg,0.32,0.48,0.09,0.07,0.0,0.0,0.0,0.05,roger gomes,,MKT-4270,2015
+MKT,4270,2,International Mktg,0.18,0.34,0.25,0.11,0.05,0.0,0.0,0.07,roger gomes,,MKT-4270,2015
+MKT,4270,3,International Mktg,0.27,0.31,0.31,0.04,0.02,0.0,0.0,0.04,roger gomes,,MKT-4270,2015
+MKT,4270,4,International Mktg,0.33,0.49,0.18,0.0,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-4270,2015
+MKT,4280,1,Services Marketing,0.39,0.55,0.05,0.0,0.0,0.0,0.0,0.02,stephen grove,,MKT-4280,2015
+MKT,4280,2,Services Marketing,0.44,0.28,0.22,0.0,0.06,0.0,0.0,0.0,stephen grove,,MKT-4280,2015
+MKT,4310,1,Marketing Research,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,peter weathers,,MKT-4310,2015
+MKT,4310,2,Marketing Research,0.3,0.67,0.0,0.0,0.0,0.0,0.0,0.04,scott darren swain,,MKT-4310,2015
+MKT,4310,3,Marketing Research,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2015
+MKT,4310,4,Marketing Research,0.29,0.36,0.29,0.0,0.0,0.0,0.0,0.07,william kilbourne,,MKT-4310,2015
+MKT,4430,1,Advertising Strategy,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,,MKT-4430,2015
+MKT,4450,1,Macromarketing,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,,MKT-4450,2015
+MKT,4500,1,Strategic Mktg Mgt,0.31,0.59,0.1,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2015
+MKT,4500,2,Strategic Mktg Mgt,0.19,0.61,0.19,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2015
+MKT,8610,1,Marketing Research,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,christopher hopkins,,MKT-8610,2015
+MKT,8630,1,Buyer Behavior,0.48,0.44,0.07,0.0,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-8630,2015
+ML,1010,1,Leadership Fund I,0.85,0.0,0.0,0.0,0.07,0.0,0.0,0.07,amanda carol kane,,ML-1010,2015
+ML,2010,1,Leadership Development I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,thierry andre bras,,ML-2010,2015
+ML,2010,2,Leadership Development I,0.71,0.19,0.05,0.05,0.0,0.0,0.0,0.0,thierry andre bras,,ML-2010,2015
+ML,4010,1,Organizational Leadership I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,,ML-4010,2015
+MSE,2100,2,Intro to Mat Science,0.35,0.32,0.17,0.05,0.04,0.0,0.0,0.06,eric skaar,,MSE-2100,2015
+MSE,2100,3,Intro to Mat Science,0.37,0.4,0.11,0.02,0.06,0.0,0.0,0.04,eric skaar,,MSE-2100,2015
+MSE,2100,4,Intro to Mat Science,0.35,0.34,0.17,0.06,0.06,0.0,0.0,0.02,marian kennedy,,MSE-2100,2015
+MSE,2410,1,Metrics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,,MSE-2410,2015
+MSE,3190,2,Materials Proc I,0.46,0.44,0.07,0.02,0.0,0.0,0.0,0.01,olin mefford,,MSE-3190,2015
+MSE,3260,1,Thermo of Materials,0.31,0.47,0.08,0.08,0.0,0.0,0.0,0.06,gary lickfield,,MSE-3260,2015
+MSE,3260,2,Thermo of Materials,0.03,0.45,0.29,0.16,0.0,0.0,0.0,0.06,gary lickfield,,MSE-3260,2015
+MSE,3270,1,Transport Phenomena,0.78,0.11,0.07,0.04,0.0,0.0,0.0,0.01,konstantin kornev,,MSE-3270,2015
+MSE,4020,1,Solid State Material,0.24,0.42,0.27,0.03,0.03,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-4020,2015
+MSE,4130,1,Noncrystalline Materials,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,fei peng,,MSE-4130,2015
+MSE,4150,1,Polymer Sc Engr,0.42,0.36,0.19,0.04,0.0,0.0,0.0,0.0,igor luzinov,,MSE-4150,2015
+MSE,4150,2,Polymer Sc Engr,0.51,0.37,0.11,0.0,0.01,0.0,0.0,0.0,olin mefford,,MSE-4150,2015
+MSE,4320,1,Manuf Proc & Systems,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,denis brosnan,,MSE-4320,2015
+MSE,4410,1,Mfg Laboratory,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,denis brosnan,,MSE-4410,2015
+MSE,4550,3,Polymer Fiber Lab,0.64,0.18,0.09,0.09,0.0,0.0,0.0,0.0,olin mefford,,MSE-4550,2015
+MSE,4580,1,Surf Phen in Ms&E,0.24,0.44,0.2,0.12,0.0,0.0,0.0,0.0,konstantin kornev,,MSE-4580,2015
+MSE,4610,1,Polymer & Fiber Materials III,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,,MSE-4610,2015
+MSE,4910,1,Undergraduate Research,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,marian kennedy,,MSE-4910,2015
+MSE,8100,1,Fundamentals of Materials Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,,MSE-8100,2015
+MSE,8270,1,Kin of Phase Tran,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,,MSE-8270,2015
+MSE,8510,1,Polymer Science I,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,gary lickfield,,MSE-8510,2015
+MUSC,1110,9,Beginning Class Guitar,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,david stevenson,,MUSC-1110,2015
+MUSC,1420,1,Music Theory I,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,anthony bernarducci,,MUSC-1420,2015
+MUSC,1420,2,Music Theory I,0.72,0.06,0.17,0.0,0.0,0.0,0.0,0.06,anthony bernarducci,,MUSC-1420,2015
+MUSC,1430,1,Aural Skills I,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,anthony bernarducci,,MUSC-1430,2015
+MUSC,1430,2,Aural Skills I,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,anthony bernarducci,,MUSC-1430,2015
+MUSC,2100,1,Music in the Western World,0.77,0.1,0.1,0.0,0.03,0.0,0.0,0.0,eric lapin,,MUSC-2100,2015
+MUSC,2100,2,Music in the Western World,0.71,0.13,0.1,0.06,0.0,0.0,0.0,0.0,lisa sain odom,,MUSC-2100,2015
+MUSC,2100,3,Music in the Western World,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,eric lapin,,MUSC-2100,2015
+MUSC,2100,4,Music in the Western World,0.58,0.23,0.1,0.03,0.06,0.0,0.0,0.0,linda li-bleuel,,MUSC-2100,2015
+MUSC,2100,5,Music in the Western World,0.83,0.13,0.03,0.0,0.0,0.0,0.0,0.03,timothy ra hurlburt,,MUSC-2100,2015
+MUSC,2100,6,Music in the Western World,0.5,0.38,0.09,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,,MUSC-2100,2015
+MUSC,2100,7,Music in the Western World,0.56,0.34,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,,MUSC-2100,2015
+MUSC,2100,8,Music in the Western World,0.58,0.32,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,,MUSC-2100,2015
+MUSC,2100,9,Music in the Western World,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,evan michael jacobi,,MUSC-2100,2015
+MUSC,2100,10,Music in the Western World,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,linda dzuris,,MUSC-2100,2015
+MUSC,2100,12,Music in the Western World,0.65,0.32,0.03,0.0,0.0,0.0,0.0,0.0,lea kibler,,MUSC-2100,2015
+MUSC,2100,15,Music in West World (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,True,MUSC-2100,2015
+MUSC,3110,1,History of American Music,0.5,0.34,0.06,0.09,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3110,2015
+MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,eric lapin,,MUSC-3120,2015
+MUSC,3130,1,Hist of Rock & Roll,0.61,0.29,0.04,0.0,0.04,0.0,0.0,0.04,hamilton altstatt,,MUSC-3130,2015
+MUSC,3170,1,Hist of Country Mus,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,ned hosler,,MUSC-3170,2015
+MUSC,3180,1,Hist of Audio Tech,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,,MUSC-3180,2015
+MUSC,3610,1,Marching Band,0.97,0.02,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,,MUSC-3610,2015
+MUSC,3690,1,Symphony Orchestra,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,andrew levin,True,MUSC-3690,2015
+MUSC,3710,1,Women's Chorus,0.95,0.0,0.0,0.0,0.03,0.0,0.0,0.02,justin durham,,MUSC-3710,2015
+MUSC,3720,1,Men's Chorus,0.89,0.04,0.0,0.0,0.04,0.0,0.0,0.04,anthony bernarducci,,MUSC-3720,2015
+MUSC,4150,1,Music Hist to 1750,0.15,0.23,0.31,0.23,0.08,0.0,0.0,0.0,justin durham,,MUSC-4150,2015
+NPL,3000,1,Nonprofit Leadership,0.84,0.06,0.03,0.0,0.0,0.0,0.0,0.06,tracy diane lamb,,NPL-3000,2015
+NPL,3000,3,Nonprofit Leadership,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,james dougl bennett,,NPL-3000,2015
+NPL,3020,1,NPL Fundraising,0.69,0.15,0.08,0.0,0.08,0.0,0.0,0.0,robert frager,,NPL-3020,2015
+NPL,3040,1,NPL Risk Management,0.46,0.46,0.0,0.08,0.0,0.0,0.0,0.0,anthony shau catone,,NPL-3040,2015
+NURS,1020,1,Nrsg Success Skills,0.77,0.22,0.0,0.01,0.0,0.0,0.0,0.0,kristin goodenow,,NURS-1020,2015
+NURS,1400,1,Comp App Hlth Care,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,,NURS-1400,2015
+NURS,3030,1,Nursing of Adults,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,,NURS-3030,2015
+NURS,3040,1,Pathophysiology,0.27,0.58,0.08,0.06,0.02,0.0,0.0,0.0,catherine si murton,,NURS-3040,2015
+NURS,3040,400,Pathophysiology,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,catherine si murton,,NURS-3040,2015
+NURS,3040,401,Pathophysiology,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,,NURS-3040,2015
+NURS,3100,1,Health Assessment,0.47,0.51,0.02,0.0,0.0,0.0,0.0,0.0,terry kaye busby,,NURS-3100,2015
+NURS,3100,400,Health Assessment,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,,NURS-3100,2015
+NURS,3120,1,Foundations of Nursing,0.45,0.51,0.04,0.0,0.0,0.0,0.0,0.0,angela pye,,NURS-3120,2015
+NURS,3120,400,Foundations of Nursing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3120,2015
+NURS,3300,2,Research in Nursing,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-3300,2015
+NURS,3400,1,Pharmther Nursing,0.27,0.61,0.08,0.02,0.02,0.0,0.0,0.0,catherine si murton,,NURS-3400,2015
+NURS,3400,400,Pharmther Nursing,0.27,0.58,0.15,0.0,0.0,0.0,0.0,0.0,catherine si murton,,NURS-3400,2015
+NURS,3600,400,Social Determinants in Health,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,roxanne amerson,,NURS-3600,2015
+NURS,4030,200,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,,NURS-4030,2015
+NURS,4110,1,Nursing of Children,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-4110,2015
+NURS,4120,1,Nurs Women and Fam,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2015
+NURS,4250,200,Community Nursing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,,NURS-4250,2015
+NURS,8050,400,Pharmaco Adv Nurs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8050,2015
+NURS,8060,400,Advan Assessment for Nursing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,,NURS-8060,2015
+NURS,8090,400,Pathophysiology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,,NURS-8090,2015
+NURS,8200,400,Child & Adol Nursing,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-8200,2015
+NUTR,2030,1,Intro Princ of Human Nutrition,0.44,0.36,0.09,0.04,0.01,0.0,0.0,0.05,deborah an hutcheon,,NUTR-2030,2015
+NUTR,2050,1,Nutr for Nurs Prof,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,,NUTR-2050,2015
+NUTR,2160,1,Evidence-Based Nutrition,0.44,0.38,0.1,0.02,0.03,0.0,0.0,0.03,angela fraser,,NUTR-2160,2015
+NUTR,4180,1,Prof Development in Dietetics,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,,NUTR-4180,2015
+NUTR,4190,1,Professional Dev in Nutrition,0.92,0.0,0.0,0.04,0.04,0.0,0.0,0.0,angela fraser,,NUTR-4190,2015
+NUTR,4240,1,Medical Nutr Thera I,0.63,0.35,0.02,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4240,2015
+NUTR,4510,1,Human Nutrition,0.43,0.22,0.14,0.07,0.09,0.0,0.0,0.05,michell bohan brown,,NUTR-4510,2015
+NUTR,6510,1,Human Nutrition,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michell bohan brown,,NUTR-6510,2015
+PA,1010,1,Intro to Perf Arts,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,david hartmann,,PA-1010,2015
+PA,1030,1,Portfolio I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,linda dzuris,,PA-1030,2015
+PA,2790,1,Perf Arts Pract I,0.69,0.19,0.0,0.0,0.13,0.0,0.0,0.0,kenneth moore,,PA-2790,2015
+PA,3010,1,Prin of Arts Admin,0.81,0.13,0.0,0.06,0.0,0.0,0.0,0.0,paul buyer,,PA-3010,2015
+PA,4010,1,Capstone Project,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,,PA-4010,2015
+PADM,7020,400,Research Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,,PADM-7020,2015
+PADM,7020,401,Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,,PADM-7020,2015
+PADM,8210,400,Perspectives on Public Admin,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,mark daniel mellott,,PADM-8210,2015
+PADM,8270,400,Public Personnel Admin,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,lawrence nichols,,PADM-8270,2015
+PADM,8290,400,Public Financial Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,,PADM-8290,2015
+PADM,8670,400,State Government Admin,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,alfred bundrick,,PADM-8670,2015
+PADM,8710,400,Sustainability Practices Appli,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,,PADM-8710,2015
+PADM,8780,400,Legal Aspects of Nonprofits,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,anthony shau catone,,PADM-8780,2015
+PADM,8780,401,Local Govt Budgeting & Finance,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,kevin yokim,,PADM-8780,2015
+PAS,3010,1,Pan African Studies,0.17,0.56,0.25,0.02,0.01,0.0,0.0,0.0,abel bartley,,PAS-3010,2015
+PDBE,8100,1,Contemporary Issues in EDP,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,,PDBE-8100,2015
+PES,1040,1,Introduction to Plant Sciences,0.67,0.17,0.0,0.0,0.03,0.0,0.0,0.13,paula agudelo,,PES-1040,2015
+PES,2020,1,Soils,0.12,0.45,0.3,0.12,0.0,0.0,0.0,0.01,dara michelle park,,PES-2020,2015
+PES,4090,1,Biology of Invasive Plants,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,,PES-4090,2015
+PES,4210,1,Princ of Field Crop Production,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,sruthi naraya kutty,,PES-4210,2015
+PHIL,1010,2,Intro to Philosophic Problems,0.53,0.17,0.13,0.03,0.1,0.0,0.0,0.03,adam gies,,PHIL-1010,2015
+PHIL,1010,3,Intro to Philosophic Problems,0.4,0.4,0.11,0.06,0.0,0.0,0.0,0.03,christopher grau,,PHIL-1010,2015
+PHIL,1010,4,Intro to Philosophic Problems,0.47,0.3,0.03,0.1,0.07,0.0,0.0,0.03,john randall wolfe,,PHIL-1010,2015
+PHIL,1020,1,Introduction to Logic,0.62,0.21,0.03,0.0,0.09,0.0,0.0,0.06,david stegall,,PHIL-1020,2015
+PHIL,1020,2,Introduction to Logic,0.43,0.37,0.06,0.03,0.06,0.0,0.0,0.06,david stegall,,PHIL-1020,2015
+PHIL,1020,3,Introduction to Logic,0.76,0.18,0.03,0.03,0.0,0.0,0.0,0.0,gregory scott moss,,PHIL-1020,2015
+PHIL,1020,4,Introduction to Logic,0.74,0.15,0.03,0.03,0.0,0.0,0.0,0.06,gregory scott moss,,PHIL-1020,2015
+PHIL,1020,5,Introduction to Logic,0.71,0.18,0.09,0.0,0.03,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2015
+PHIL,1020,6,Introduction to Logic,0.68,0.21,0.06,0.03,0.0,0.0,0.0,0.03,michael hal hannen,,PHIL-1020,2015
+PHIL,1030,1,Intro to Ethics (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True,PHIL-1030,2015
+PHIL,1030,2,Introduction to Ethics,0.54,0.31,0.06,0.0,0.0,0.0,0.0,0.09,michael hal hannen,,PHIL-1030,2015
+PHIL,1030,3,Introduction to Ethics,0.31,0.49,0.17,0.0,0.0,0.0,0.0,0.03,ryan lake,,PHIL-1030,2015
+PHIL,1030,4,Introduction to Ethics,0.26,0.68,0.06,0.0,0.0,0.0,0.0,0.0,ryan lake,,PHIL-1030,2015
+PHIL,1030,5,Introduction to Ethics,0.29,0.29,0.15,0.15,0.0,0.0,0.0,0.12,malcolm edwa munson,,PHIL-1030,2015
+PHIL,1030,6,Introduction to Ethics,0.21,0.32,0.12,0.12,0.09,0.0,0.0,0.15,malcolm edwa munson,,PHIL-1030,2015
+PHIL,1030,9,Introduction to Ethics,0.29,0.24,0.18,0.18,0.12,0.0,0.0,0.0,adam gies,,PHIL-1030,2015
+PHIL,1030,10,Introduction to Ethics,0.72,0.16,0.09,0.03,0.0,0.0,0.0,0.0,adam gies,,PHIL-1030,2015
+PHIL,1030,11,Introduction to Ethics,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,adam gies,,PHIL-1030,2015
+PHIL,3040,1,Moral Philosophy,0.36,0.33,0.15,0.03,0.12,0.0,0.0,0.0,charles starkey,,PHIL-3040,2015
+PHIL,3120,1,Philosophy in Ancient China,0.29,0.38,0.03,0.06,0.09,0.0,0.0,0.15,yanming an,,PHIL-3120,2015
+PHIL,3150,1,Ancient Philosophy,0.26,0.37,0.22,0.07,0.07,0.0,0.0,0.0,stephen satris,,PHIL-3150,2015
+PHIL,3160,1,Modern Philosophy,0.63,0.28,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,,PHIL-3160,2015
+PHIL,3170,1,19th-Century Philosophy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,gregory scott moss,,PHIL-3170,2015
+PHIL,3180,1,20th-Century Philosophy,0.63,0.3,0.0,0.04,0.04,0.0,0.0,0.0,john randall wolfe,,PHIL-3180,2015
+PHIL,3240,1,Philosophy of Tech,0.38,0.44,0.03,0.03,0.03,0.0,0.0,0.09,andrew garnar,,PHIL-3240,2015
+PHIL,3260,1,Science and Values,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2015
+PHIL,3260,2,Science and Values,0.47,0.38,0.06,0.0,0.03,0.0,0.0,0.06,andrew garnar,,PHIL-3260,2015
+PHIL,3260,3,Science and Values,0.42,0.52,0.03,0.0,0.0,0.0,0.0,0.03,andrew garnar,,PHIL-3260,2015
+PHIL,3330,1,Metaphysics,0.81,0.0,0.05,0.0,0.0,0.0,0.0,0.14,david stegall,,PHIL-3330,2015
+PHIL,3430,1,Philosophy of Law,0.29,0.38,0.15,0.06,0.06,0.0,0.0,0.06,jennifer ingle,,PHIL-3430,2015
+PHIL,3440,1,Business Ethics,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,david stegall,,PHIL-3440,2015
+PHIL,3450,1,Environmental Ethics,0.74,0.19,0.03,0.0,0.03,0.0,0.0,0.0,john randall wolfe,,PHIL-3450,2015
+PHIL,3450,2,Environmental Ethics,0.74,0.19,0.03,0.03,0.0,0.0,0.0,0.0,john randall wolfe,,PHIL-3450,2015
+PHIL,3480,1,Philosophies of Art,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,christopher grau,,PHIL-3480,2015
+PHIL,3490,1,Gender and Sexuality,0.75,0.04,0.08,0.04,0.0,0.0,0.0,0.08,jennifer ingle,,PHIL-3490,2015
+PHIL,3550,1,Philosophy of Mind & Cog Scien,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,ryan lake,,PHIL-3550,2015
+PHIL,4020,1,Topics in Philosophy,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,ryan lake,,PHIL-4020,2015
+PHIL,4220,1,Anarchism,0.44,0.28,0.17,0.0,0.06,0.0,0.0,0.06,todd may,,PHIL-4220,2015
+PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1180,2015
+PHYS,1220,1,Physics with Calculus I,0.25,0.3,0.29,0.07,0.05,0.0,0.0,0.04,lih-sin the,,PHYS-1220,2015
+PHYS,1220,2,Physics with Calculus I,0.23,0.26,0.29,0.09,0.06,0.0,0.0,0.08,lih-sin the,,PHYS-1220,2015
+PHYS,1220,4,Physics with Calculus I,0.4,0.15,0.15,0.05,0.15,0.0,0.0,0.1,murray daw,,PHYS-1220,2015
+PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,2,Physics Lab I,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,3,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,4,Physics Lab I,0.18,0.71,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,,PHYS-1240,2015
+PHYS,1240,5,Physics Lab I,0.0,0.72,0.06,0.0,0.0,0.0,0.0,0.22,jerry hester,,PHYS-1240,2015
+PHYS,1240,6,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,7,Physics Lab I,0.56,0.25,0.13,0.0,0.06,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,8,Physics Lab I,0.28,0.61,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,9,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,10,Physics Lab I,0.33,0.44,0.11,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2015
+PHYS,1240,11,Physics Lab I,0.29,0.41,0.18,0.06,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,12,Physics Lab I,0.17,0.56,0.17,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2015
+PHYS,1240,13,Physics Lab I,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,15,Physics Lab I,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,16,Physics Lab I,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-1240,2015
+PHYS,1240,17,Physics Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,2070,1,General Physics I,0.39,0.36,0.14,0.04,0.03,0.0,0.0,0.03,amy liann pope,,PHYS-2070,2015
+PHYS,2070,2,General Physics I,0.42,0.33,0.19,0.03,0.01,0.0,0.0,0.02,amy liann pope,,PHYS-2070,2015
+PHYS,2070,3,General Physics I,0.27,0.39,0.2,0.06,0.07,0.0,0.0,0.03,pooja puneet,,PHYS-2070,2015
+PHYS,2080,1,General Physics II,0.31,0.42,0.16,0.05,0.04,0.0,0.0,0.02,pooja puneet,,PHYS-2080,2015
+PHYS,2090,1,Gen Phys Lab I,0.54,0.29,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2015
+PHYS,2090,2,Gen Phys Lab I,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2015
+PHYS,2090,3,Gen Phys Lab I,0.29,0.54,0.08,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2015
+PHYS,2090,4,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,5,Gen Phys Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,6,Gen Phys Lab I,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2015
+PHYS,2090,7,Gen Phys Lab I,0.83,0.09,0.0,0.0,0.04,0.0,0.0,0.04,jerry hester,,PHYS-2090,2015
+PHYS,2090,8,Gen Phys Lab I,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2015
+PHYS,2090,9,Gen Phys Lab I,0.58,0.33,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2015
+PHYS,2090,10,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2015
+PHYS,2090,11,Gen Phys Lab I,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,12,Gen Phys Lab I,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,13,Gen Phys Lab I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,14,Gen Phys Lab I,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,15,Gen Phys Lab I,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2015
+PHYS,2090,16,Gen Phys Lab I,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,17,Gen Phys Lab I,0.44,0.48,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,18,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,19,Gen Phys Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,20,Gen Phys Lab I,0.73,0.23,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2015
+PHYS,2090,21,Gen Phys Lab I,0.43,0.35,0.13,0.0,0.04,0.0,0.0,0.04,jerry hester,,PHYS-2090,2015
+PHYS,2090,22,Gen Phys Lab I,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,23,Gen Phys Lab I,0.36,0.55,0.05,0.0,0.05,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,24,Gen Phys Lab I,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2100,2,Gen Phys Lab II,0.7,0.17,0.04,0.0,0.0,0.0,0.0,0.09,jerry hester,,PHYS-2100,2015
+PHYS,2100,3,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,4,Gen Phys Lab II,0.82,0.09,0.0,0.05,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2100,2015
+PHYS,2100,7,Gen Phys Lab II,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,8,Gen Phys Lab II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2210,1,Physics with Calculus II,0.26,0.43,0.19,0.08,0.02,0.0,0.0,0.02,jason stratfo brown,,PHYS-2210,2015
+PHYS,2210,2,Physics with Calculus II,0.31,0.48,0.13,0.02,0.03,0.0,0.0,0.03,jason stratfo brown,,PHYS-2210,2015
+PHYS,2210,3,Physics with Calculus II,0.35,0.51,0.1,0.02,0.01,0.0,0.0,0.0,jason stratfo brown,,PHYS-2210,2015
+PHYS,2210,4,Physics with Calculus II,0.24,0.51,0.18,0.05,0.01,0.0,0.0,0.0,ramakrishna podila,,PHYS-2210,2015
+PHYS,2210,7,Physics With Cal II (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True,PHYS-2210,2015
+PHYS,2220,1,Physics with Calculus III,0.22,0.59,0.11,0.0,0.04,0.0,0.0,0.04,jeremy king,,PHYS-2220,2015
+PHYS,2230,1,Physics Lab II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,2,Physics Lab II,0.28,0.33,0.39,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,3,Physics Lab II,0.18,0.76,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,4,Physics Lab II,0.38,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2015
+PHYS,2230,5,Physics Lab II,0.0,0.82,0.18,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,6,Physics Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,9,Physics Lab II,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,10,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,12,Physics Lab II,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,13,Physics Lab II,0.24,0.65,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,,PHYS-2230,2015
+PHYS,2230,16,Physics Lab II,0.08,0.75,0.0,0.0,0.0,0.0,0.0,0.17,jerry hester,,PHYS-2230,2015
+PHYS,2230,17,Physics Lab II,0.08,0.83,0.0,0.0,0.08,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2450,1,Physics of Climate,0.38,0.2,0.12,0.01,0.06,0.0,0.0,0.23,jens oberheide,,PHYS-2450,2015
+PHYS,3120,1,Meth Theor Phys II,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,hye jung kang,,PHYS-3120,2015
+PHYS,3150,1,Intro to Computational Physics,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,emil georgie alexov,,PHYS-3150,2015
+PHYS,3210,1,Mechanics I,0.31,0.19,0.13,0.19,0.13,0.0,0.0,0.06,gerald lehmacher,,PHYS-3210,2015
+PHYS,3250,1,Exper Physics I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,chad sosolik,,PHYS-3250,2015
+PHYS,4410,1,Electromagnetics I,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,joan marler,,PHYS-4410,2015
+PHYS,8110,1,Meth of Theor Phys I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,bradley meyer,,PHYS-8110,2015
+PHYS,8210,1,Classical Mech I,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,dieter hartmann,,PHYS-8210,2015
+PHYS,8750,7,Intro to Research,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,terry tritt,,PHYS-8750,2015
+PHYS,9510,1,Quantum Mech I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,sumanta tewari,,PHYS-9510,2015
+PKSC,1010,1,Pkgsc Orientation,0.76,0.11,0.06,0.05,0.02,0.0,0.0,0.01,robert truett moore,,PKSC-1010,2015
+PKSC,1020,1,Intro to Pkg Sci,0.14,0.28,0.3,0.18,0.05,0.0,0.0,0.04,heather batt,,PKSC-1020,2015
+PKSC,2020,1,Packaging Mtl & Mfg,0.68,0.17,0.14,0.0,0.01,0.0,0.0,0.0,robert truett moore,,PKSC-2020,2015
+PKSC,2200,1,Product & Pkg Design,0.69,0.1,0.06,0.08,0.06,0.0,0.0,0.0,william aaro snyder,,PKSC-2200,2015
+PKSC,3200,1,Pkg Design Theory,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,rupert hurley,,PKSC-3200,2015
+PKSC,4010,1,Packaging Machinery,0.53,0.37,0.09,0.0,0.01,0.0,0.0,0.0,anthony lou pometto,,PKSC-4010,2015
+PKSC,4030,1,Pkg Career Prep,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2015
+PKSC,4040,1,Protective Packaging Prop/Prin,0.19,0.34,0.26,0.06,0.1,0.0,0.0,0.04,gregory batt,,PKSC-4040,2015
+PKSC,4160,1,Appl Polymers in Pkg,0.24,0.51,0.19,0.03,0.03,0.0,0.0,0.0,duncan darby,,PKSC-4160,2015
+PKSC,4200,1,Pkg Design & Dev,0.56,0.41,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2015
+PKSC,4540,1,Prod Pkg Evl Lab,0.5,0.25,0.06,0.13,0.06,0.0,0.0,0.0,gregory batt,,PKSC-4540,2015
+PKSC,4540,2,Prod Pkg Evl Lab,0.33,0.4,0.07,0.0,0.07,0.0,0.0,0.13,gregory batt,,PKSC-4540,2015
+PKSC,4540,3,Prod Pkg Evl Lab,0.24,0.53,0.06,0.0,0.12,0.0,0.0,0.06,gregory batt,,PKSC-4540,2015
+PKSC,4540,4,Prod Pkg Evl Lab,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,gregory batt,,PKSC-4540,2015
+PKSC,4540,6,Prod Pkg Evl Lab,0.0,0.54,0.23,0.23,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2015
+PKSC,4640,1,Food & Health Care Pkg Systems,0.63,0.31,0.03,0.03,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2015
+PKSC,8170,1,Pckg Materials: Sci & Technol,0.73,0.09,0.0,0.0,0.18,0.0,0.0,0.0,duncan darby,,PKSC-8170,2015
+PKSC,8220,400,3D Parametric Design,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,rupert hurley,,PKSC-8220,2015
+PKSC,8220,401,Structural Pkging Design,0.6,0.0,0.0,0.0,0.4,0.0,0.0,0.0,rupert hurley,,PKSC-8220,2015
+PLPA,3100,1,Principles of Plant Pathology,0.33,0.33,0.26,0.04,0.0,0.0,0.0,0.04,steven nye jeffers,,PLPA-3100,2015
+POSC,1010,1,Amer National Govt,0.05,0.58,0.16,0.05,0.16,0.0,0.0,0.0,joseph earl stewart,,POSC-1010,2015
+POSC,1010,2,Amer National Govt,0.24,0.48,0.15,0.06,0.02,0.0,0.0,0.05,jeffrey allen fine,,POSC-1010,2015
+POSC,1010,3,Amer National Govt,0.08,0.2,0.3,0.2,0.0,0.0,0.0,0.23,james woodard,,POSC-1010,2015
+POSC,1020,1,Intro Intl Relations,0.17,0.43,0.31,0.03,0.03,0.0,0.0,0.03,aron geo tannenbaum,,POSC-1020,2015
+POSC,1020,2,Intro Intl Relations,0.17,0.5,0.2,0.02,0.09,0.0,0.0,0.02,lydia loui lundgren,,POSC-1020,2015
+POSC,1020,3,Intro Intl Relations,0.19,0.29,0.25,0.1,0.08,0.0,0.0,0.08,steven vince miller,,POSC-1020,2015
+POSC,1020,4,Intro Intl Relations,0.09,0.49,0.26,0.06,0.04,0.0,0.0,0.06,colin pearce,,POSC-1020,2015
+POSC,1030,1,Intro to Political Theory,0.28,0.36,0.19,0.07,0.11,0.0,0.0,0.0,brandon turner,,POSC-1030,2015
+POSC,1040,1,Intro Compar Pol,0.08,0.49,0.33,0.08,0.0,0.0,0.0,0.03,xiaobo hu,,POSC-1040,2015
+POSC,1040,2,Intro Compar Pol,0.36,0.55,0.06,0.02,0.0,0.0,0.0,0.0,katherine am curtis,,POSC-1040,2015
+POSC,1990,1,Intro Pol Sci,0.43,0.29,0.15,0.03,0.04,0.0,0.0,0.06,meredith petersheim,,POSC-1990,2015
+POSC,3020,1,State and Loc Gov,0.1,0.57,0.27,0.0,0.02,0.0,0.0,0.04,bruce ransom,,POSC-3020,2015
+POSC,3110,1,Model United Nations,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,xiaobo hu,,POSC-3110,2015
+POSC,3410,1,Quant Meth in Pol Sc,0.12,0.47,0.06,0.24,0.12,0.0,0.0,0.0,steven vince miller,,POSC-3410,2015
+POSC,3430,1,Mass Media in Americ Politics,0.31,0.35,0.16,0.04,0.1,0.0,0.0,0.04,jeffrey scott peake,,POSC-3430,2015
+POSC,3610,1,Intl Pol in Crisis,0.21,0.63,0.06,0.02,0.04,0.0,0.0,0.04,vladimir matic,,POSC-3610,2015
+POSC,3710,1,European Politics,0.15,0.61,0.07,0.0,0.07,0.0,0.0,0.1,vladimir matic,,POSC-3710,2015
+POSC,3750,1,European Integration,0.3,0.33,0.15,0.07,0.11,0.0,0.0,0.04,lydia loui lundgren,,POSC-3750,2015
+POSC,3890,1,Indiv. Autonomy & the Const.,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,,POSC-3890,2015
+POSC,4210,1,Public Policy,0.18,0.12,0.35,0.18,0.06,0.0,0.0,0.12,adam warber,,POSC-4210,2015
+POSC,4360,1,Law Courts Politics,0.69,0.2,0.04,0.0,0.06,0.0,0.0,0.02,joseph earl stewart,,POSC-4360,2015
+POSC,4380,1,Constitut Law: Struc of Gov,0.45,0.41,0.11,0.02,0.0,0.0,0.0,0.0,daniel frost,,POSC-4380,2015
+POSC,4420,1,Pol Parties & Elect,0.02,0.23,0.53,0.09,0.07,0.0,0.0,0.05,james woodard,,POSC-4420,2015
+POSC,4470,1,International Law,0.27,0.48,0.12,0.06,0.03,0.0,0.0,0.03,katherine am curtis,,POSC-4470,2015
+POSC,4500,1,Modern Ideologies,0.33,0.43,0.14,0.0,0.05,0.0,0.0,0.05,james woodard,,POSC-4500,2015
+POSC,4530,1,American Political Thought,0.27,0.62,0.08,0.0,0.0,0.0,0.0,0.04,kimberly hurd hale,,POSC-4530,2015
+POSC,4560,1,Diplomacy,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,,POSC-4560,2015
+POSC,4710,1,Russian Politics,0.3,0.52,0.03,0.03,0.06,0.0,0.0,0.06,aron geo tannenbaum,,POSC-4710,2015
+POSC,4760,1,Middle East Politics,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,vladimir matic,,POSC-4760,2015
+POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,meredith petersheim,,POSC-4990,2015
+POST,8220,1,Pol Analy/Pol Choice,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,,POST-8220,2015
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.01,teresa walto tucker,,PRTM-2260,2015
+PRTM,2270,1,Prov of Leisure Exp,0.53,0.43,0.02,0.01,0.0,0.0,0.0,0.01,teresa walto tucker,,PRTM-2270,2015
+PRTM,2290,1,Competency Integration in PRTM,0.54,0.41,0.04,0.01,0.0,0.0,0.0,0.01,teresa walto tucker,,PRTM-2290,2015
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.47,0.17,0.15,0.13,0.06,0.0,0.0,0.02,daniel mor anderson,,PRTM-3050,2015
+PRTM,3070,2,Facility Operations,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,craig goodman,,PRTM-3070,2015
+PRTM,3200,1,Recreation Policy,0.16,0.74,0.0,0.11,0.0,0.0,0.0,0.0,lincoln larson,,PRTM-3200,2015
+PRTM,3210,1,Recreation Admin,0.35,0.46,0.13,0.0,0.02,0.0,0.0,0.04,mariela fernandez,,PRTM-3210,2015
+PRTM,3220,1,Facilitation Techniques in RT,0.89,0.09,0.0,0.02,0.0,0.0,0.0,0.0,stephen thoma lewis,,PRTM-3220,2015
+PRTM,3240,1,Assessment & Planning in RT,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3240,2015
+PRTM,3250,1,Global Persp in Rec,0.6,0.28,0.04,0.08,0.0,0.0,0.0,0.0,skye arthur-banning,,PRTM-3250,2015
+PRTM,3420,2,Intro to Tourism,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,maloud shakona,,PRTM-3420,2015
+PRTM,3430,1,Spl Asp of Tourist B,0.23,0.5,0.18,0.09,0.0,0.0,0.0,0.0,william norman,,PRTM-3430,2015
+PRTM,3430,2,Spl Asp of Tourist B,0.46,0.37,0.11,0.03,0.03,0.0,0.0,0.0,william norman,,PRTM-3430,2015
+PRTM,3520,1,Camp Org and Admin,0.08,0.31,0.31,0.15,0.0,0.0,0.0,0.15,gwynn powell,,PRTM-3520,2015
+PRTM,3540,1,Youth Development in Camp,0.71,0.1,0.1,0.05,0.0,0.0,0.0,0.05,gwynn powell,,PRTM-3540,2015
+PRTM,3900,8,Independent Study in PRTM,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3900,2015
+PRTM,3920,1,Special Event Management,0.73,0.15,0.06,0.02,0.04,0.0,0.0,0.0,kenneth backman,,PRTM-3920,2015
+PRTM,3920,2,Special Event Management,0.82,0.1,0.04,0.02,0.0,0.0,0.0,0.02,kenneth backman,,PRTM-3920,2015
+PRTM,4030,1,Elem of Rec/Pk Plan,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,robert baxte powell,,PRTM-4030,2015
+PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,,PRTM-4040,2015
+PRTM,4220,1,Management of RT Services,0.59,0.23,0.14,0.0,0.05,0.0,0.0,0.0,anna-mar chancellor,,PRTM-4220,2015
+PRTM,4410,1,Commercial Rec,0.39,0.22,0.28,0.06,0.0,0.06,0.0,0.0,herbert chancellor,,PRTM-4410,2015
+PRTM,4470,1,Perspect Intl Travel,0.65,0.19,0.1,0.0,0.03,0.0,0.0,0.03,lauren duffy,,PRTM-4470,2015
+PRTM,4550,1,Adv Program Planning,0.46,0.37,0.11,0.03,0.0,0.0,0.0,0.03,jamie lynn cathey,,PRTM-4550,2015
+PRTM,8010,2,Phil Found of PRTM,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,,PRTM-8010,2015
+PRTM,8020,1,Group Proc in Leisure Services,0.53,0.33,0.0,0.0,0.07,0.0,0.0,0.07,skye arthur-banning,,PRTM-8020,2015
+PRTM,8080,1,Behavioral Aspects,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-8080,2015
+PRTM,8220,2,Strateg Planning in PRTM Orgs,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,,PRTM-8220,2015
+PRTM,9000,6,Comm Conserv Sustain Develop,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lawrence allen,,PRTM-9000,2015
+PRTM,9080,2,PRTM Stats,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,,PRTM-9080,2015
+PSYC,2010,1,Intro to Psychology,0.52,0.25,0.13,0.06,0.02,0.0,0.0,0.03,chong hyon pak,,PSYC-2010,2015
+PSYC,2010,2,Intro to Psychology,0.35,0.34,0.2,0.07,0.02,0.0,0.0,0.02,jo anne jorgensen,,PSYC-2010,2015
+PSYC,2010,3,Intro to Psychology,0.28,0.33,0.19,0.08,0.07,0.0,0.0,0.04,edwin brainerd,,PSYC-2010,2015
+PSYC,2010,4,Intro to Psychology,0.15,0.43,0.29,0.03,0.01,0.0,0.0,0.09,christopher pagano,,PSYC-2010,2015
+PSYC,2010,5,Intro to Psychology,0.26,0.41,0.21,0.01,0.01,0.0,0.0,0.09,mary taylor,,PSYC-2010,2015
+PSYC,2010,6,Intro to Psychology (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True,PSYC-2010,2015
+PSYC,2020,1,Intro Psychology Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2015
+PSYC,2020,2,Intro Psychology Lab,0.8,0.04,0.12,0.0,0.04,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2015
+PSYC,2020,4,Intro Psychology Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,,PSYC-2020,2015
+PSYC,2020,5,Intro Psychology Lab,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,eric mckibben,,PSYC-2020,2015
+PSYC,2020,6,Intro Psychology Lab,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2015
+PSYC,3060,1,Human Sexual Beh,0.52,0.21,0.16,0.05,0.04,0.0,0.0,0.03,bruce michael king,,PSYC-3060,2015
+PSYC,3090,100,Intro Exp Psych,0.51,0.2,0.13,0.11,0.04,0.0,0.0,0.01,patrick rosopa,,PSYC-3090,2015
+PSYC,3090,200,Intro Exp Psych,0.41,0.31,0.17,0.03,0.07,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3090,2015
+PSYC,3090,300,Intro Exp Psych,0.3,0.47,0.1,0.07,0.03,0.0,0.0,0.03,richard tyrrell,,PSYC-3090,2015
+PSYC,3100,100,Advanced Experimental Psych,0.24,0.53,0.12,0.0,0.0,0.0,0.0,0.12,jennifer bai bisson,,PSYC-3100,2015
+PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,robert campbell,,PSYC-3100,2015
+PSYC,3100,300,Advanced Experimental Psych,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,robert campbell,,PSYC-3100,2015
+PSYC,3100,400,Advanced Experimental Psych,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2015
+PSYC,3100,500,Advanced Experimental Psych,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,sarah mae sanborn,,PSYC-3100,2015
+PSYC,3100,600,Advanced Experimental Psych,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2015
+PSYC,3240,1,Physiological Psych,0.26,0.37,0.17,0.17,0.03,0.0,0.0,0.0,claudio cantalupo,,PSYC-3240,2015
+PSYC,3240,2,Physiological Psych,0.26,0.31,0.19,0.1,0.12,0.0,0.0,0.01,june pilcher,,PSYC-3240,2015
+PSYC,3330,1,Cognitive Psych,0.7,0.16,0.09,0.03,0.01,0.0,0.0,0.01,allison lei wallace,,PSYC-3330,2015
+PSYC,3330,2,Cognitive Psych,0.21,0.37,0.19,0.13,0.03,0.0,0.0,0.07,thomas alley,,PSYC-3330,2015
+PSYC,3340,4,Cognitive Psych Lab,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,leah hartman,,PSYC-3340,2015
+PSYC,3400,1,Lifespan Developmental Psych,0.29,0.32,0.22,0.01,0.07,0.0,0.0,0.07,pamela alley,,PSYC-3400,2015
+PSYC,3400,2,Lifespan Developmental Psych,0.65,0.24,0.09,0.01,0.0,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3400,2015
+PSYC,3520,1,Social Psychology,0.35,0.41,0.09,0.09,0.03,0.0,0.0,0.03,jo anne jorgensen,,PSYC-3520,2015
+PSYC,3520,2,Social Psychology,0.62,0.29,0.04,0.0,0.04,0.0,0.0,0.0,alice miche brawley,,PSYC-3520,2015
+PSYC,3640,1,Industrial Psych,0.34,0.5,0.13,0.01,0.0,0.0,0.0,0.01,eric mckibben,,PSYC-3640,2015
+PSYC,3640,2,Industrial Psych,0.48,0.3,0.18,0.01,0.01,0.0,0.0,0.01,eric mckibben,,PSYC-3640,2015
+PSYC,3680,1,Organizational Psych,0.43,0.33,0.17,0.01,0.0,0.0,0.0,0.04,kristen su jennings,,PSYC-3680,2015
+PSYC,3690,1,Leadership in Orgs,0.56,0.26,0.15,0.03,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-3690,2015
+PSYC,3700,1,Personality,0.32,0.27,0.31,0.08,0.01,0.0,0.0,0.0,edwin brainerd,,PSYC-3700,2015
+PSYC,3830,1,Abnormal Psychology,0.45,0.34,0.11,0.06,0.03,0.0,0.0,0.01,jo anne jorgensen,,PSYC-3830,2015
+PSYC,3830,2,Abnormal Psychology,0.17,0.43,0.29,0.0,0.06,0.0,0.0,0.06,pamela alley,,PSYC-3830,2015
+PSYC,3830,3,Abnormal Psychology,0.34,0.37,0.14,0.03,0.03,0.0,0.0,0.09,pamela alley,,PSYC-3830,2015
+PSYC,4080,1,Women and Psychology,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,,PSYC-4080,2015
+PSYC,4150,1,Systems and Theories,0.48,0.35,0.06,0.03,0.03,0.0,0.0,0.03,brian day,,PSYC-4150,2015
+PSYC,4150,2,Systems and Theories,0.38,0.22,0.28,0.03,0.06,0.0,0.0,0.03,edwin brainerd,,PSYC-4150,2015
+PSYC,4220,1,Perception,0.41,0.22,0.22,0.11,0.0,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2015
+PSYC,4220,2,Perception,0.16,0.36,0.4,0.08,0.0,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2015
+PSYC,4220,3,Perception,0.26,0.26,0.26,0.07,0.04,0.0,0.0,0.11,claudio cantalupo,,PSYC-4220,2015
+PSYC,4350,1,Human Factors,0.48,0.24,0.05,0.1,0.05,0.0,0.0,0.1,laura whitlock,,PSYC-4350,2015
+PSYC,4430,1,Infant & Child Dev,0.44,0.36,0.12,0.04,0.04,0.0,0.0,0.0,sarah mae sanborn,,PSYC-4430,2015
+PSYC,4560,1,Psychophysiology,0.48,0.35,0.09,0.09,0.0,0.0,0.0,0.0,drew michael morris,,PSYC-4560,2015
+PSYC,4710,1,Psych of Testing,0.38,0.33,0.1,0.1,0.05,0.0,0.0,0.05,fred switzer,,PSYC-4710,2015
+PSYC,4800,1,Health Psychology,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,june pilcher,,PSYC-4800,2015
+PSYC,4880,1,Psychotherapy,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,lucinda sorci quick,,PSYC-4880,2015
+PSYC,4890,1,Judgment and Decision Making,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,fred switzer,,PSYC-4890,2015
+PSYC,4890,2,Psyc of Food and Eating,0.3,0.52,0.13,0.0,0.0,0.0,0.0,0.04,thomas alley,,PSYC-4890,2015
+PSYC,4920,1,Senior Laboratory,0.85,0.04,0.08,0.04,0.0,0.0,0.0,0.0,hiu ngae jan cheung,,PSYC-4920,2015
+PSYC,4920,2,Senior Laboratory,0.85,0.0,0.07,0.0,0.0,0.0,0.0,0.07,stephen robertson,,PSYC-4920,2015
+PSYC,4920,4,Senior Laboratory,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,brooke bake allison,,PSYC-4920,2015
+PSYC,8100,1,Research Design I,0.71,0.14,0.05,0.0,0.05,0.0,0.0,0.05, dewayne moore,,PSYC-8100,2015
+PSYC,8350,1,Adv Human Factors,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-8350,2015
+PSYC,8620,1,Org Psychology,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,,PSYC-8620,2015
+PSYC,8850,1,Org Stress,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas britt,,PSYC-8850,2015
+RED,8000,1,Real Estate Dvlpment,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8000,2015
+RED,8030,1,Pub-Priv Partnership,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,john terrenc farris,,RED-8030,2015
+RED,8130,1,Strat in Real Estate,0.5,0.31,0.13,0.0,0.0,0.0,0.0,0.06,phillip rive hughes,,RED-8130,2015
+RED,8160,1,Preservation Feasibility,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8160,2015
+REL,1010,1,Intro to Religion,0.05,0.53,0.11,0.16,0.05,0.0,0.0,0.11,peter cohen,,REL-1010,2015
+REL,1010,2,Intro to Religion,0.21,0.32,0.16,0.21,0.0,0.0,0.0,0.11,peter cohen,,REL-1010,2015
+REL,1010,4,Intro to Religion,0.21,0.42,0.11,0.0,0.0,0.0,0.0,0.26,peter cohen,,REL-1010,2015
+REL,1010,5,Intro to Religion,0.8,0.09,0.0,0.0,0.06,0.0,0.0,0.06,jennifer singletary,,REL-1010,2015
+REL,1010,6,Intro to Religion,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jennifer singletary,,REL-1010,2015
+REL,1020,2,World Religions,0.56,0.35,0.03,0.0,0.06,0.0,0.0,0.0,robert stephens,,REL-1020,2015
+REL,1020,3,World Religions,0.72,0.14,0.06,0.0,0.08,0.0,0.0,0.0,robert stephens,,REL-1020,2015
+REL,1020,4,World Religions,0.8,0.06,0.0,0.03,0.03,0.0,0.0,0.09,robert stephens,,REL-1020,2015
+REL,3010,1,Old Testament,0.59,0.32,0.06,0.0,0.03,0.0,0.0,0.0,steven grosby,,REL-3010,2015
+REL,3020,1,New Testament Lit,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,benjamin white,,REL-3020,2015
+REL,3080,1,Rel of Ancient World,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3080,2015
+REL,3100,1,History of Religion in the US,0.47,0.21,0.21,0.05,0.0,0.0,0.0,0.05,elizabeth jemison,,REL-3100,2015
+REL,3150,1,Islam,0.44,0.29,0.18,0.09,0.0,0.0,0.0,0.0,mashal saif,,REL-3150,2015
+RS,3010,1,Rural Sociology,0.56,0.2,0.2,0.0,0.0,0.0,0.0,0.04,kenneth robinson,,RS-3010,2015
+RUSS,1010,1,Elementary Russian,0.33,0.17,0.17,0.0,0.08,0.0,0.0,0.25,joan bridgwood,,RUSS-1010,2015
+SOC,2010,1,Intro to Sociology (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,rachael chatterson,True,SOC-2010,2015
+SOC,2010,2,Introduction to Sociology,0.48,0.32,0.16,0.03,0.0,0.0,0.0,0.01,stephani southworth,,SOC-2010,2015
+SOC,2010,3,Introduction to Sociology,0.46,0.31,0.1,0.1,0.0,0.0,0.0,0.02,stephani southworth,,SOC-2010,2015
+SOC,2010,4,Introduction to Sociology,0.49,0.34,0.15,0.02,0.0,0.0,0.0,0.0,stephani southworth,,SOC-2010,2015
+SOC,2010,5,Introduction to Sociology,0.32,0.42,0.16,0.08,0.02,0.0,0.0,0.0,mary louise barr,,SOC-2010,2015
+SOC,2010,6,Introduction to Sociology,0.32,0.29,0.32,0.03,0.03,0.0,0.0,0.03,mary louise barr,,SOC-2010,2015
+SOC,2010,7,Introduction to Sociology,0.43,0.39,0.13,0.02,0.02,0.0,0.0,0.0,mary louise barr,,SOC-2010,2015
+SOC,2010,8,Introduction to Sociology,0.32,0.36,0.23,0.03,0.03,0.0,0.0,0.03,mary louise barr,,SOC-2010,2015
+SOC,2010,9,Introduction to Sociology,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2015
+SOC,2010,10,Introduction to Sociology,0.52,0.35,0.11,0.0,0.0,0.0,0.0,0.02,jennifer le holland,,SOC-2010,2015
+SOC,2010,11,Introduction to Sociology,0.55,0.26,0.16,0.0,0.03,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2015
+SOC,2010,12,Introduction to Sociology,0.53,0.34,0.13,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2015
+SOC,2010,13,Introduction to Sociology,0.59,0.27,0.05,0.03,0.0,0.0,0.0,0.05,shannon mcdonough,,SOC-2010,2015
+SOC,2010,14,Introduction to Sociology,0.2,0.38,0.22,0.09,0.07,0.0,0.0,0.04,margaret tina britz,,SOC-2010,2015
+SOC,2010,15,Introduction to Sociology,0.56,0.24,0.11,0.04,0.02,0.0,0.0,0.02,rachael chatterson,,SOC-2010,2015
+SOC,2010,16,Introduction to Sociology,0.41,0.36,0.14,0.01,0.04,0.0,0.0,0.03,rachael chatterson,,SOC-2010,2015
+SOC,2010,17,Introduction to Sociology,0.38,0.48,0.13,0.0,0.0,0.0,0.0,0.03,rachael chatterson,,SOC-2010,2015
+SOC,2020,1,Social Problems,0.3,0.33,0.26,0.07,0.0,0.0,0.0,0.04,stephani southworth,,SOC-2020,2015
+SOC,2050,1,Sociology Lab,0.74,0.03,0.09,0.0,0.14,0.0,0.0,0.0,brenda vander mey,,SOC-2050,2015
+SOC,2050,2,Sociology Lab,0.65,0.06,0.06,0.18,0.0,0.0,0.0,0.06,brenda vander mey,,SOC-2050,2015
+SOC,3020,1,Research Methods I,0.33,0.3,0.18,0.08,0.08,0.0,0.0,0.05,andrew whitehead,,SOC-3020,2015
+SOC,3040,1,Social Research Methods II,0.22,0.3,0.39,0.09,0.0,0.0,0.0,0.0,ye luo,,SOC-3040,2015
+SOC,3110,1,The Family,0.22,0.56,0.2,0.02,0.0,0.0,0.0,0.0,andrew whitehead,,SOC-3110,2015
+SOC,3600,1,Class & Poverty,0.77,0.17,0.02,0.0,0.04,0.0,0.0,0.0,william haller,,SOC-3600,2015
+SOC,3880,1,Criminal Justice,0.13,0.27,0.36,0.13,0.11,0.0,0.0,0.0,margaret tina britz,,SOC-3880,2015
+SOC,3890,1,Criminology,0.37,0.26,0.06,0.06,0.17,0.0,0.0,0.09,william white,,SOC-3890,2015
+SOC,3910,1,Soc of Deviance,0.47,0.28,0.09,0.07,0.0,0.0,0.0,0.09,william white,,SOC-3910,2015
+SOC,3920,1,Juvenile Delinquency,0.23,0.08,0.23,0.23,0.15,0.0,0.0,0.08,william white,,SOC-3920,2015
+SOC,3940,1,Sociology of Mental Illness,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,douglas sturkie,,SOC-3940,2015
+SOC,3970,1,Substance Abuse,0.41,0.46,0.11,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,,SOC-3970,2015
+SOC,4040,1,Soc Theory,0.54,0.29,0.15,0.0,0.0,0.0,0.0,0.02,william wentworth,,SOC-4040,2015
+SOC,4140,1,Policy&Social Change,0.33,0.48,0.15,0.04,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-4140,2015
+SOC,4330,1,Global Social Change,0.67,0.17,0.11,0.0,0.06,0.0,0.0,0.0,william haller,,SOC-4330,2015
+SOC,4440,1,Sociology of Educ,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,stephani southworth,,SOC-4440,2015
+SOC,4600,1,Race & Ethnicity,0.29,0.29,0.33,0.08,0.0,0.0,0.0,0.0,brenda vander mey,,SOC-4600,2015
+SOC,4600,2,Race & Ethnicity,0.5,0.17,0.08,0.17,0.08,0.0,0.0,0.0,brenda vander mey,,SOC-4600,2015
+SOC,4610,1,Sex & Gender,0.39,0.43,0.11,0.0,0.02,0.0,0.0,0.04,traci ann hefner,,SOC-4610,2015
+SOC,4680,1,Criminal Evidence,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,margaret tina britz,,SOC-4680,2015
+SOC,4860,1,Creative Inquiry in Sociology,0.64,0.14,0.07,0.0,0.07,0.0,0.0,0.07,margaret tina britz,,SOC-4860,2015
+SOC,4970,1,Senior Lab,0.56,0.16,0.16,0.09,0.0,0.0,0.0,0.03,brenda vander mey,,SOC-4970,2015
+SOC,8030,1,Sur Dsgn App Res Lab,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,,SOC-8030,2015
+SPAN,1010,1,Elementary Spanish,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,scott harris,,SPAN-1010,2015
+SPAN,1010,2,Elementary Spanish,0.63,0.16,0.05,0.11,0.05,0.0,0.0,0.0,scott harris,,SPAN-1010,2015
+SPAN,1010,3,Elementary Spanish,0.47,0.42,0.0,0.0,0.05,0.0,0.0,0.05,scott harris,,SPAN-1010,2015
+SPAN,1020,1,Elementary Spanish,0.16,0.37,0.16,0.16,0.0,0.0,0.0,0.16,roger simpson,,SPAN-1020,2015
+SPAN,1020,2,Elementary Spanish,0.18,0.29,0.24,0.18,0.0,0.0,0.0,0.12,roger simpson,,SPAN-1020,2015
+SPAN,1020,3,Elementary Spanish,0.11,0.37,0.16,0.16,0.05,0.0,0.0,0.16,roger simpson,,SPAN-1020,2015
+SPAN,1020,4,Elementary Spanish,0.42,0.26,0.05,0.11,0.05,0.0,0.0,0.11,roger simpson,,SPAN-1020,2015
+SPAN,1020,5,Elementary Spanish,0.17,0.28,0.28,0.11,0.0,0.0,0.0,0.17,roger simpson,,SPAN-1020,2015
+SPAN,1020,6,Elementary Spanish,0.39,0.39,0.11,0.06,0.0,0.0,0.0,0.06,cathy robison,,SPAN-1020,2015
+SPAN,1020,7,Elementary Spanish,0.11,0.39,0.22,0.06,0.11,0.0,0.0,0.11,cathy robison,,SPAN-1020,2015
+SPAN,1020,8,Elementary Spanish,0.39,0.28,0.06,0.06,0.17,0.0,0.0,0.06,ana paula  miller,,SPAN-1020,2015
+SPAN,1020,9,Elementary Spanish,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,ana paula  miller,,SPAN-1020,2015
+SPAN,1020,10,Elementary Spanish,0.58,0.26,0.0,0.05,0.05,0.0,0.0,0.05,debra oa williamson,,SPAN-1020,2015
+SPAN,1020,11,Elementary Spanish,0.39,0.33,0.0,0.06,0.0,0.0,0.0,0.22,debra oa williamson,,SPAN-1020,2015
+SPAN,1020,12,Elementary Spanish,0.53,0.21,0.11,0.0,0.11,0.0,0.0,0.05,adrienne eliza fama,,SPAN-1020,2015
+SPAN,1020,13,Elementary Spanish,0.32,0.37,0.26,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-1020,2015
+SPAN,1020,14,Elementary Spanish,0.32,0.21,0.21,0.11,0.05,0.0,0.0,0.11,ana paula  miller,,SPAN-1020,2015
+SPAN,2010,1,Intermediate Spanish,0.24,0.41,0.18,0.12,0.0,0.0,0.0,0.06,cathy robison,,SPAN-2010,2015
+SPAN,2010,2,Intermediate Spanish,0.11,0.72,0.17,0.0,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2015
+SPAN,2010,3,Intermediate Spanish,0.38,0.31,0.25,0.0,0.0,0.0,0.0,0.06,allison ann hinds,,SPAN-2010,2015
+SPAN,2010,4,Intermediate Spanish,0.21,0.5,0.29,0.0,0.0,0.0,0.0,0.0,allison ann hinds,,SPAN-2010,2015
+SPAN,2010,5,Intermediate Spanish,0.53,0.18,0.18,0.06,0.0,0.0,0.0,0.06,allison ann hinds,,SPAN-2010,2015
+SPAN,2010,6,Intermediate Spanish,0.5,0.19,0.25,0.0,0.0,0.0,0.0,0.06,heidi montes,,SPAN-2010,2015
+SPAN,2010,7,Intermediate Spanish,0.25,0.25,0.25,0.13,0.0,0.0,0.0,0.13,heidi montes,,SPAN-2010,2015
+SPAN,2010,8,Intermediate Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-2010,2015
+SPAN,2010,9,Intermediate Spanish,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-2010,2015
+SPAN,2010,10,Intermediate Spanish,0.38,0.31,0.08,0.0,0.15,0.0,0.0,0.08,ricardo tremolada,,SPAN-2010,2015
+SPAN,2010,11,Intermediate Spanish,0.27,0.45,0.09,0.0,0.0,0.0,0.0,0.18,melva margu persico,,SPAN-2010,2015
+SPAN,2010,12,Intermediate Spanish,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2010,2015
+SPAN,2010,13,Intermediate Spanish,0.26,0.37,0.26,0.0,0.0,0.0,0.0,0.11,maureen zamora,,SPAN-2010,2015
+SPAN,2010,14,Intermediate Spanish,0.13,0.19,0.44,0.0,0.0,0.0,0.0,0.25,maureen zamora,,SPAN-2010,2015
+SPAN,2010,15,Intermediate Spanish,0.53,0.2,0.0,0.0,0.07,0.0,0.0,0.2,ricardo tremolada,,SPAN-2010,2015
+SPAN,2010,16,Intermediate Spanish,0.59,0.24,0.0,0.0,0.06,0.0,0.0,0.12,ricardo tremolada,,SPAN-2010,2015
+SPAN,2010,17,Intermediate Spanish,0.68,0.11,0.16,0.0,0.05,0.0,0.0,0.0,ricardo tremolada,,SPAN-2010,2015
+SPAN,2010,18,Intermediate Spanish,0.29,0.36,0.21,0.07,0.0,0.0,0.0,0.07,ana paula  miller,,SPAN-2010,2015
+SPAN,2010,19,Intermediate Spanish,0.24,0.41,0.24,0.0,0.0,0.0,0.0,0.12,debra oa williamson,,SPAN-2010,2015
+SPAN,2020,1,Intermediate Spanish,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2020,2015
+SPAN,2020,2,Intermediate Spanish,0.06,0.56,0.31,0.06,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-2020,2015
+SPAN,2020,3,Intermediate Spanish,0.31,0.31,0.25,0.13,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2015
+SPAN,2020,4,Intermediate Spanish,0.28,0.5,0.11,0.0,0.0,0.0,0.0,0.11,heidi montes,,SPAN-2020,2015
+SPAN,2020,5,Intermediate Spanish,0.64,0.07,0.14,0.0,0.0,0.0,0.0,0.14,ze cruz valderramos,,SPAN-2020,2015
+SPAN,2020,6,Intermediate Spanish,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,ze cruz valderramos,,SPAN-2020,2015
+SPAN,2020,7,Intermediate Spanish,0.39,0.28,0.28,0.0,0.0,0.0,0.0,0.06,melva margu persico,,SPAN-2020,2015
+SPAN,2020,8,Intermediate Spanish,0.41,0.47,0.06,0.06,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-2020,2015
+SPAN,2020,9,Intermediate Spanish,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2015
+SPAN,2020,10,Intermediate Spanish,0.47,0.35,0.12,0.0,0.06,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2015
+SPAN,2020,11,Intermediate Spanish,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,kari daus carson,,SPAN-2020,2015
+SPAN,2020,12,Intermediate Spanish,0.37,0.53,0.0,0.0,0.0,0.0,0.0,0.11,kari daus carson,,SPAN-2020,2015
+SPAN,2020,13,Intermediate Spanish,0.37,0.21,0.32,0.05,0.05,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2015
+SPAN,2020,14,Intermediate Spanish,0.56,0.28,0.06,0.0,0.0,0.0,0.0,0.11,ze cruz valderramos,,SPAN-2020,2015
+SPAN,2020,15,Intermediate Spanish,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2015
+SPAN,3050,2,Int Con Comp Span I,0.5,0.28,0.17,0.0,0.0,0.0,0.0,0.06,juana martin-armas,,SPAN-3050,2015
+SPAN,3050,3,Int Con Comp Span I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-3050,2015
+SPAN,3060,1,Span Comp for Bus,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,maureen zamora,,SPAN-3060,2015
+SPAN,3070,1,Hispanic World: Sp,0.72,0.11,0.0,0.06,0.0,0.0,0.0,0.11,salvador oropesa,,SPAN-3070,2015
+SPAN,3070,2,Hispanic World: Sp,0.26,0.58,0.0,0.0,0.0,0.0,0.0,0.16,raquel anido,,SPAN-3070,2015
+SPAN,3080,1,Hispanic World: La,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,george palacios,,SPAN-3080,2015
+SPAN,3110,1,Surv Span-Amer Lit,0.21,0.29,0.21,0.14,0.0,0.0,0.0,0.14,tiffany dawn miller,,SPAN-3110,2015
+SPAN,3130,1,Span Lit Survey I,0.27,0.27,0.18,0.09,0.0,0.0,0.0,0.18,mon rojas-de-massei,,SPAN-3130,2015
+SPAN,3130,2,Span Lit Survey I,0.27,0.4,0.2,0.0,0.0,0.0,0.0,0.13,mon rojas-de-massei,,SPAN-3130,2015
+SPAN,3140,1,Hispanic Linguistics,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,daniel smith,,SPAN-3140,2015
+SPAN,4060,1,Narrative Fiction,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,,SPAN-4060,2015
+SPAN,4160,1,Span Intl Trade II,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,maureen zamora,,SPAN-4160,2015
+SPAN,4190,1,Health & Hisp Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-4190,2015
+SPAN,4220,1,Contem Span Am Novel,0.83,0.11,0.0,0.0,0.06,0.0,0.0,0.0,ricardo tremolada,,SPAN-4220,2015
+SPAN,4350,1,Contemp Hisp Cult,0.45,0.27,0.09,0.0,0.09,0.0,0.0,0.09,tiffany dawn miller,,SPAN-4350,2015
+STAT,2220,1,Statistics in Everyday Life,0.51,0.21,0.14,0.05,0.05,0.0,0.0,0.05,ros martinez-dawson,,STAT-2220,2015
+STAT,2220,2,Statistics in Everyday Life,0.39,0.19,0.17,0.17,0.09,0.0,0.0,0.0,ros martinez-dawson,,STAT-2220,2015
+STAT,2220,3,Statistics in Everyday Life,0.35,0.39,0.2,0.02,0.04,0.0,0.0,0.0,james espey,,STAT-2220,2015
+STAT,2220,4,Statistics in Everyday Life,0.54,0.22,0.17,0.06,0.02,0.0,0.0,0.0,james espey,,STAT-2220,2015
+STAT,2220,5,Statistics in Everyday Life,0.5,0.35,0.13,0.0,0.0,0.0,0.0,0.02,james espey,,STAT-2220,2015
+STAT,2220,7,Statistics in Everyday Life,0.42,0.34,0.12,0.07,0.02,0.0,0.0,0.02,james espey,,STAT-2220,2015
+STAT,2300,1,Statistical Methods I,0.43,0.31,0.08,0.11,0.06,0.0,0.0,0.01,christy jenki brown,,STAT-2300,2015
+STAT,2300,2,Statistical Methods I,0.38,0.3,0.1,0.11,0.08,0.0,0.0,0.04,christy jenki brown,,STAT-2300,2015
+STAT,2300,3,Statistical Methods I,0.45,0.35,0.08,0.07,0.03,0.0,0.0,0.01,christy jenki brown,,STAT-2300,2015
+STAT,2300,4,Statistical Methods I,0.34,0.33,0.15,0.09,0.09,0.0,0.0,0.01, erwin walker,,STAT-2300,2015
+STAT,2300,5,Statistical Methods I,0.31,0.36,0.21,0.06,0.06,0.0,0.0,0.0, erwin walker,,STAT-2300,2015
+STAT,2300,6,Statistical Methods I,0.31,0.35,0.16,0.12,0.05,0.0,0.0,0.01,benjamin sharp,,STAT-2300,2015
+STAT,2300,7,Statistical Methods I,0.28,0.34,0.22,0.06,0.06,0.0,0.0,0.04,brook thaye russell,,STAT-2300,2015
+STAT,2300,8,Statistical Methods I,0.19,0.31,0.31,0.12,0.07,0.0,0.0,0.0, erwin walker,,STAT-2300,2015
+STAT,3090,1,Introductory Business Stats,0.06,0.41,0.26,0.03,0.21,0.0,0.0,0.03,janie caro mcdonald,,STAT-3090,2015
+STAT,3090,2,Introductory Business Stats,0.33,0.28,0.22,0.11,0.06,0.0,0.0,0.0,kara ail stasikelis,,STAT-3090,2015
+STAT,3090,3,Introductory Business Stats,0.14,0.17,0.43,0.09,0.06,0.0,0.0,0.11,laura jane shick,,STAT-3090,2015
+STAT,3090,4,Introductory Business Stats,0.15,0.38,0.21,0.15,0.1,0.0,0.0,0.0,gary fellers,,STAT-3090,2015
+STAT,3090,5,Introductory Business Stats,0.13,0.42,0.24,0.08,0.11,0.0,0.0,0.03,laura jane shick,,STAT-3090,2015
+STAT,3090,6,Introductory Business Stats,0.28,0.5,0.19,0.03,0.0,0.0,0.0,0.0,ellen hepfe breazel,,STAT-3090,2015
+STAT,3090,7,Introductory Business Stats,0.37,0.21,0.26,0.05,0.11,0.0,0.0,0.0,kara ail stasikelis,,STAT-3090,2015
+STAT,3090,8,Introductory Business Stats,0.16,0.42,0.21,0.11,0.05,0.0,0.0,0.05,christopher wilson,,STAT-3090,2015
+STAT,3090,9,Introductory Business Stats,0.33,0.26,0.23,0.03,0.15,0.0,0.0,0.0,gary fellers,,STAT-3090,2015
+STAT,3090,10,Introductory Business Stats,0.26,0.4,0.26,0.0,0.06,0.0,0.0,0.03,janie caro mcdonald,,STAT-3090,2015
+STAT,3090,11,Introductory Business Stats,0.22,0.36,0.22,0.19,0.0,0.0,0.0,0.0,ellen hepfe breazel,,STAT-3090,2015
+STAT,3090,12,Introductory Business Stats,0.26,0.36,0.13,0.08,0.1,0.0,0.0,0.08,laura jane shick,,STAT-3090,2015
+STAT,3090,13,Introductory Business Stats,0.16,0.26,0.42,0.16,0.0,0.0,0.0,0.0,janie caro mcdonald,,STAT-3090,2015
+STAT,3090,14,Introductory Business Stats,0.26,0.47,0.13,0.08,0.03,0.0,0.0,0.03,margaret mar wiecek,,STAT-3090,2015
+STAT,3090,15,Introductory Business Stats,0.11,0.47,0.32,0.0,0.05,0.0,0.0,0.05,emily marie nystrom,,STAT-3090,2015
+STAT,3090,16,Introductory Business Stats,0.11,0.37,0.32,0.11,0.11,0.0,0.0,0.0,laura jane shick,,STAT-3090,2015
+STAT,3090,17,Introductory Business Stats,0.0,0.47,0.26,0.0,0.11,0.0,0.0,0.16,tao yang,,STAT-3090,2015
+STAT,3090,18,Introductory Business Stats,0.36,0.31,0.23,0.03,0.05,0.0,0.0,0.03,gary fellers,,STAT-3090,2015
+STAT,3090,19,Introductory Business Stats,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,emily marie nystrom,,STAT-3090,2015
+STAT,3090,20,Introductory Business Stats,0.0,0.4,0.13,0.13,0.2,0.0,0.0,0.13,paul james cubre,,STAT-3090,2015
+STAT,3090,21,Introductory Business Stats,0.26,0.33,0.26,0.05,0.08,0.0,0.0,0.03,gary fellers,,STAT-3090,2015
+STAT,3090,22,Introductory Business Stats,0.14,0.29,0.29,0.09,0.14,0.0,0.0,0.06,janie caro mcdonald,,STAT-3090,2015
+STAT,3090,23,Introductory Business Stats,0.11,0.37,0.22,0.15,0.07,0.0,0.0,0.07,tao yang,,STAT-3090,2015
+STAT,3090,24,Introductory Business Stats,0.32,0.26,0.21,0.0,0.11,0.0,0.0,0.11,paul james cubre,,STAT-3090,2015
+STAT,3090,25,Introductory Business Stats,0.16,0.63,0.05,0.0,0.11,0.0,0.0,0.05,drew jared lipman,,STAT-3090,2015
+STAT,3090,26,Introductory Business Stats,0.11,0.16,0.32,0.21,0.11,0.0,0.0,0.11,christopher wilson,,STAT-3090,2015
+STAT,3300,1,Statistical Methods II,0.21,0.38,0.21,0.0,0.0,0.0,0.0,0.21,ros martinez-dawson,,STAT-3300,2015
+STAT,4020,1,Intro to Statistical Computing,0.44,0.31,0.06,0.06,0.06,0.0,0.0,0.06,julia lynn sharp,,STAT-4020,2015
+STAT,4110,1,Stat Mthds for Process Control,0.3,0.4,0.23,0.0,0.08,0.0,0.0,0.0,william bridges,,STAT-4110,2015
+STAT,4110,2,Stat Mthds for Process Control,0.44,0.25,0.16,0.09,0.06,0.0,0.0,0.0,patrick gerard,,STAT-4110,2015
+STAT,6020,1,Intro to Statistical Computing,0.57,0.14,0.14,0.0,0.0,0.0,0.0,0.14,julia lynn sharp,,STAT-6020,2015
+STAT,8010,1,Statistical Methods I,0.47,0.23,0.13,0.0,0.1,0.0,0.0,0.07,james rieck,,STAT-8010,2015
+STAT,8010,2,Statistical Methods I,0.26,0.42,0.06,0.0,0.16,0.0,0.0,0.1,james rieck,,STAT-8010,2015
+STAT,8010,3,Statistical Methods I,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,jun luo,,STAT-8010,2015
+STAT,8010,4,Statistical Methods I,0.29,0.57,0.04,0.0,0.07,0.0,0.0,0.04,julia lynn sharp,,STAT-8010,2015
+STAT,8020,1,Statistical Methods II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-8020,2015
+STAT,8030,1,Regress & Least Squares Anlys,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,jun luo,,STAT-8030,2015
+STS,1010,1,Survey of S T S,0.49,0.49,0.0,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,,STS-1010,2015
+STS,1010,2,Survey of S T S,0.56,0.42,0.03,0.0,0.0,0.0,0.0,0.0,philip randall,,STS-1010,2015
+STS,1010,3,Survey of S T S,0.27,0.61,0.06,0.03,0.0,0.0,0.0,0.03,scott brame,,STS-1010,2015
+STS,1010,5,Survey of S T S,0.58,0.36,0.03,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,,STS-1010,2015
+STS,1010,6,Survey of S T S,0.32,0.5,0.09,0.03,0.03,0.0,0.0,0.03,sarah mae cooper,,STS-1010,2015
+STS,1010,7,Survey of S T S,0.86,0.08,0.03,0.0,0.0,0.0,0.0,0.03,annah kamugiz amani,,STS-1010,2015
+STS,1010,8,Survey of S T S,0.19,0.35,0.29,0.06,0.06,0.0,0.0,0.03,david charles foltz,,STS-1010,2015
+STS,1010,9,Survey of S T S,0.47,0.25,0.17,0.03,0.0,0.0,0.0,0.08,allison ann hinds,,STS-1010,2015
+STS,1010,10,Survey of S T S,0.49,0.26,0.11,0.06,0.03,0.0,0.0,0.06,megan no macalystre,,STS-1010,2015
+THEA,2100,2,Theatre Appreciation,0.91,0.03,0.03,0.0,0.03,0.0,0.0,0.0,kerrie kath seymour,,THEA-2100,2015
+THEA,2100,3,Theatre Appreciation,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-2100,2015
+THEA,2100,4,Theatre Appreciation,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,,THEA-2100,2015
+THEA,2100,5,Theatre Appreciation,0.43,0.53,0.0,0.0,0.0,0.0,0.0,0.03,carol collins,,THEA-2100,2015
+THEA,2100,6,Theatre Appreciation,0.67,0.2,0.07,0.0,0.03,0.0,0.0,0.03,anthony penna,,THEA-2100,2015
+THEA,2100,7,Theatre Appreciation,0.52,0.39,0.1,0.0,0.0,0.0,0.0,0.0,jason adkins,,THEA-2100,2015
+THEA,2780,1,Acting I,0.69,0.08,0.0,0.08,0.15,0.0,0.0,0.0,kerrie kath seymour,,THEA-2780,2015
+THEA,2790,1,Theatre Practicum,0.5,0.13,0.13,0.0,0.0,0.0,0.0,0.25,matthew leckenbusch,,THEA-2790,2015
+THEA,3170,1,African-Amer Thea I,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-3170,2015
+THEA,3760,1,Stage Directing I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richard st. peter,,THEA-3760,2015
+THEA,3980,2,Special Topics in Theatre,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,,THEA-3980,2015
+THEA,4720,1,Improvisation,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-4720,2015
+WFB,3000,1,Wildlife Biology,0.46,0.3,0.16,0.02,0.06,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3000,2015
+WFB,3000,2,Wildlife Biology,0.46,0.32,0.19,0.04,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3000,2015
+WFB,3010,1,Wildlife Biology Lab,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2015
+WFB,3010,2,Wildlife Biology Lab,0.53,0.24,0.18,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,,WFB-3010,2015
+WFB,4100,2,Wildlife Management Techniques,0.15,0.55,0.23,0.05,0.03,0.0,0.0,0.0,james davis,,WFB-4100,2015
+WFB,4440,1,Wildlife Damage Management,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,james davis,,WFB-4440,2015
+WFB,4500,1,Aquaculture,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,,WFB-4500,2015
+WFB,4930,1,Waterfowl Ecology & Mgt,0.33,0.58,0.04,0.0,0.0,0.0,0.0,0.04,richard ma kaminski,,WFB-4930,2015
+WFB,8180,1,Waterfowl Ecology & Mgt,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,,WFB-8180,2015
+WS,1030,1,Women Global Perspec,0.68,0.24,0.06,0.0,0.0,0.0,0.0,0.03,saadiqa kumanyika,,WS-1030,2015
+WS,1030,2,Women Global Perspec,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,,WS-1030,2015
+WS,2300,1,Women and Leadership,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,diane perpich,,WS-2300,2015
+WS,3010,1,Intro Women's Studies,0.54,0.31,0.09,0.06,0.0,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2015
+WS,3010,2,Intro Women's Studies,0.46,0.4,0.09,0.03,0.0,0.0,0.0,0.03,elizabeth ros adams,,WS-3010,2015
+YDP,3000,400,Youth Development in Society,0.58,0.05,0.21,0.0,0.16,0.0,0.0,0.0,barry garst,,YDP-3000,2015
+YDP,3050,400,Theory/Phil of Youth Dev Work,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,,YDP-3050,2015

--- a/bot/cogs/grades_cog/assets/2015_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2015_Fall.csv
@@ -1,2701 +1,2702 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1010,1,Survey of Art & Arch History I,0.5,0.35,0.11,0.0,0.01,0.0,0.0,0.04,beth ann lauritis,AAH-1010,2015
-AAH,2050,1,Art History and Theory I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,beth ann lauritis,AAH-2050,2015
-AAH,3050,1,Contemporary Art History,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,andrea feeser,AAH-3050,2015
-ACCT,2010,1,Financial Accounting Concepts,0.11,0.23,0.26,0.11,0.13,0.0,0.0,0.17,philip maiberger,ACCT-2010,2015
-ACCT,2010,2,Financial Accounting Concepts,0.13,0.4,0.3,0.06,0.0,0.0,0.0,0.11,philip maiberger,ACCT-2010,2015
-ACCT,2010,3,Financial Accounting Concepts,0.41,0.23,0.13,0.05,0.03,0.0,0.0,0.15,lydia lan schleifer,ACCT-2010,2015
-ACCT,2010,4,Financial Accounting Concepts,0.32,0.43,0.14,0.03,0.08,0.0,0.0,0.0,annieka philo,ACCT-2010,2015
-ACCT,2010,5,Financial Accounting Concepts,0.26,0.24,0.13,0.08,0.11,0.0,0.0,0.18,lydia lan schleifer,ACCT-2010,2015
-ACCT,2010,6,Financial Accounting Concepts,0.2,0.27,0.17,0.03,0.07,0.0,0.0,0.27,the estate  guffey,ACCT-2010,2015
-ACCT,2010,7,Financial Accounting Concepts,0.33,0.43,0.1,0.12,0.0,0.0,0.0,0.02,annieka philo,ACCT-2010,2015
-ACCT,2010,8,Financial Accounting Concepts,0.1,0.36,0.36,0.03,0.1,0.0,0.0,0.05,philip maiberger,ACCT-2010,2015
-ACCT,2010,9,Financial Accounting Concepts,0.2,0.28,0.25,0.05,0.15,0.0,0.0,0.08,lydia lan schleifer,ACCT-2010,2015
-ACCT,2010,10,Financial Accounting Concepts,0.41,0.32,0.14,0.05,0.09,0.0,0.0,0.0,annieka philo,ACCT-2010,2015
-ACCT,2010,11,Financial Accounting Concepts,0.05,0.45,0.21,0.1,0.1,0.0,0.0,0.1,the estate  guffey,ACCT-2010,2015
-ACCT,2010,12,Financial Accounting Concepts,0.21,0.37,0.15,0.03,0.09,0.0,0.0,0.16,james mil kohlmeyer,ACCT-2010,2015
-ACCT,2010,13,Financial Accounting Concepts,0.13,0.53,0.16,0.0,0.08,0.0,0.0,0.11,mary ann  prater,ACCT-2010,2015
-ACCT,2010,14,Financial Accounting Concepts,0.13,0.56,0.17,0.06,0.06,0.0,0.0,0.04,james mil kohlmeyer,ACCT-2010,2015
-ACCT,2010,100,Fin Accounting Concepts (HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,ACCT-2010,2015
-ACCT,2010,400,Financial Accounting Concepts,0.15,0.27,0.25,0.14,0.13,0.0,0.0,0.07,jeffrey mcmillan,ACCT-2010,2015
-ACCT,2020,1,Managerial Accounting Concepts,0.14,0.14,0.24,0.12,0.07,0.0,0.0,0.29,henry anderson,ACCT-2020,2015
-ACCT,2020,2,Managerial Accounting Concepts,0.23,0.34,0.21,0.02,0.09,0.0,0.0,0.11,henry anderson,ACCT-2020,2015
-ACCT,2020,3,Managerial Accounting Concepts,0.26,0.32,0.19,0.08,0.09,0.0,0.0,0.06,holly rhiannio hawk,ACCT-2020,2015
-ACCT,2020,4,Managerial Accounting Concepts,0.14,0.41,0.24,0.14,0.08,0.0,0.0,0.0,holly rhiannio hawk,ACCT-2020,2015
-ACCT,2020,5,Managerial Accounting Concepts,0.37,0.28,0.28,0.02,0.06,0.0,0.0,0.0,tonya dionne smalls,ACCT-2020,2015
-ACCT,2020,6,Managerial Accounting Concepts,0.37,0.24,0.18,0.02,0.12,0.0,0.0,0.08,tonya dionne smalls,ACCT-2020,2015
-ACCT,2020,400,Managerial Accounting Concepts,0.18,0.15,0.18,0.09,0.08,0.0,0.0,0.31,henry anderson,ACCT-2020,2015
-ACCT,3030,1,Cost Accounting,0.18,0.52,0.18,0.0,0.02,0.0,0.0,0.11,holly rhiannio hawk,ACCT-3030,2015
-ACCT,3030,2,Cost Accounting,0.33,0.42,0.07,0.0,0.09,0.0,0.0,0.09,holly rhiannio hawk,ACCT-3030,2015
-ACCT,3030,3,Cost Accounting,0.22,0.43,0.22,0.07,0.04,0.0,0.0,0.02,jace garrett,ACCT-3030,2015
-ACCT,3030,4,Cost Accounting,0.16,0.6,0.16,0.0,0.0,0.0,0.0,0.09,jace garrett,ACCT-3030,2015
-ACCT,3110,1,Intermediate Financial Acct I,0.18,0.42,0.24,0.03,0.11,0.0,0.0,0.03,terry daniel knause,ACCT-3110,2015
-ACCT,3110,2,Intermediate Financial Acct I,0.35,0.26,0.21,0.06,0.06,0.0,0.0,0.06,terry daniel knause,ACCT-3110,2015
-ACCT,3110,3,Intermediate Financial Acct I,0.23,0.38,0.15,0.1,0.1,0.0,0.0,0.03,terry daniel knause,ACCT-3110,2015
-ACCT,3110,4,Intermediate Financial Acct I,0.33,0.4,0.18,0.05,0.03,0.0,0.0,0.03,terry daniel knause,ACCT-3110,2015
-ACCT,3110,5,Intermediate Financial Acct I,0.23,0.46,0.21,0.05,0.03,0.0,0.0,0.03, russell madray,ACCT-3110,2015
-ACCT,3110,400,Intermediate Financial Acct I,0.08,0.21,0.38,0.13,0.08,0.0,0.0,0.13, russell madray,ACCT-3110,2015
-ACCT,3120,1,Intermediate Financial Acct II,0.07,0.21,0.32,0.21,0.14,0.0,0.0,0.04,brian todd carver,ACCT-3120,2015
-ACCT,3120,2,Intermediate Financial Acct II,0.08,0.28,0.38,0.13,0.08,0.0,0.0,0.05,brian todd carver,ACCT-3120,2015
-ACCT,3120,3,Intermediate Financial Acct II,0.15,0.28,0.38,0.1,0.05,0.0,0.0,0.03,jeremy micha vinson,ACCT-3120,2015
-ACCT,3120,4,Intermediate Financial Acct II,0.13,0.45,0.34,0.05,0.03,0.0,0.0,0.0,jeremy micha vinson,ACCT-3120,2015
-ACCT,3120,5,Intermediate Financial Acct II,0.13,0.38,0.38,0.05,0.05,0.0,0.0,0.0,jeremy micha vinson,ACCT-3120,2015
-ACCT,3130,1,Intermediate Fin Acct III,0.18,0.33,0.39,0.03,0.03,0.0,0.0,0.03, russell madray,ACCT-3130,2015
-ACCT,3130,2,Intermediate Fin Acct III,0.37,0.43,0.17,0.0,0.0,0.0,0.0,0.03, russell madray,ACCT-3130,2015
-ACCT,3130,3,Intermediate Fin Acct III,0.2,0.35,0.28,0.13,0.0,0.0,0.0,0.05,james irving,ACCT-3130,2015
-ACCT,3130,4,Intermediate Fin Acct III,0.26,0.36,0.28,0.08,0.03,0.0,0.0,0.0, russell madray,ACCT-3130,2015
-ACCT,3220,1,Accounting Information Systems,0.09,0.26,0.23,0.11,0.06,0.0,0.0,0.26,philip maiberger,ACCT-3220,2015
-ACCT,3220,2,Accounting Information Systems,0.27,0.32,0.3,0.11,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-3220,2015
-ACCT,3220,3,Accounting Information Systems,0.11,0.35,0.3,0.11,0.05,0.0,0.0,0.08,nancy lee harp,ACCT-3220,2015
-ACCT,4040,1,Individual Taxation,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2015
-ACCT,4040,2,Individual Taxation,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2015
-ACCT,4080,1,Retire & Estate Plan,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,john hine,ACCT-4080,2015
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.31,0.46,0.13,0.08,0.0,0.0,0.0,0.03,sally kathr widener,ACCT-4100,2015
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,sally kathr widener,ACCT-4100,2015
-ACCT,4150,1,Auditing,0.17,0.4,0.31,0.11,0.0,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2015
-ACCT,4150,2,Auditing,0.21,0.29,0.29,0.12,0.03,0.0,0.0,0.06,carl hollingsworth,ACCT-4150,2015
-ACCT,8510,1,Tax Research,0.27,0.7,0.03,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2015
-ACCT,8510,2,Tax Research,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2015
-ACCT,8510,3,Tax Research,0.26,0.71,0.03,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2015
-ACCT,8530,1,Adv Acct Problems,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8530,2015
-ACCT,8530,2,Adv Acct Problems,0.39,0.42,0.13,0.0,0.0,0.0,0.0,0.06,ralph welton,ACCT-8530,2015
-ACCT,8530,3,Adv Acct Problems,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8530,2015
-ACCT,8550,1,Gov't and Nonprofit Accounting,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2015
-ACCT,8550,2,Gov't and Nonprofit Accounting,0.58,0.35,0.08,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2015
-ACCT,8630,1,Forensics Analysis,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,james irving,ACCT-8630,2015
-ACCT,8630,2,Forensics Analysis,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james irving,ACCT-8630,2015
-ACCT,8630,601,Forensics Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,james irving,ACCT-8630,2015
-ACCT,8650,1,Tax & Bus Decisions,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,judson jahn,ACCT-8650,2015
-ACCT,8730,1,Intl/Spec Tax Topic,0.31,0.58,0.08,0.0,0.0,0.0,0.0,0.03,judson jahn,ACCT-8730,2015
-AGED,1020,1,Freshman Seminar,0.65,0.12,0.06,0.06,0.0,0.0,0.0,0.12,catheri dibenedetto,AGED-1020,2015
-AGED,2010,1,Intro to Agric Educ,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2010,2015
-AGED,2040,1,App Ag Calculations,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2040,2015
-AGED,3030,1,Ag Ed Mech Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-3030,2015
-AGED,3650,1,Multiculturalism in Agric Educ,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-3650,2015
-AGED,4000,1,Supervised Field Experience II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-4000,2015
-AGED,4010,1,Instr Methods Ag Ed,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,AGED-4010,2015
-AGED,4030,1,Prin Adult/Ext Ed,0.76,0.19,0.0,0.05,0.0,0.0,0.0,0.0,kevin layfield,AGED-4030,2015
-AGED,4230,400,Curriculum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,AGED-4230,2015
-AGM,1010,1,Intro Ag Mech & Bus,0.73,0.16,0.1,0.02,0.0,0.0,0.0,0.0,hunter massey,AGM-1010,2015
-AGM,2050,1,Prin of Fabrication,0.16,0.37,0.37,0.04,0.03,0.0,0.0,0.03,hunter massey,AGM-2050,2015
-AGM,2060,1,Machinery Mgt,0.19,0.43,0.29,0.05,0.05,0.0,0.0,0.0,hunter massey,AGM-2060,2015
-AGM,2210,1,Land Measurements,0.36,0.4,0.2,0.01,0.01,0.0,0.0,0.02,charles privette,AGM-2210,2015
-AGM,3010,1,Soil Water Conserv,0.29,0.39,0.27,0.02,0.0,0.0,0.0,0.03,calvin sawyer,AGM-3010,2015
-AGM,3190,1,Agribusiness Decision Analysis,0.26,0.43,0.23,0.06,0.0,0.0,0.0,0.02,lisha zhang,AGM-3190,2015
-AGM,4050,1,Env Cont in Anim Str,0.08,0.35,0.38,0.15,0.0,0.0,0.0,0.03,john chastain,AGM-4050,2015
-AGM,4060,1,Mech & Hydraulic Sys,0.33,0.5,0.12,0.02,0.0,0.0,0.0,0.02,ali bulent koc,AGM-4060,2015
-AGM,4600,1,Electrical Systems,0.33,0.48,0.17,0.0,0.0,0.0,0.0,0.02,young han,AGM-4600,2015
-AGRB,2020,1,Agricultural Economics,0.66,0.24,0.04,0.0,0.04,0.0,0.0,0.02,yuliya val bolotova,AGRB-2020,2015
-AGRB,2020,2,Agricultural Economics,0.15,0.48,0.33,0.04,0.0,0.0,0.0,0.0,matthew jam fischer,AGRB-2020,2015
-AGRB,2050,1,Agriculture and Society,0.36,0.44,0.14,0.06,0.0,0.0,0.0,0.0,michael vassalos,AGRB-2050,2015
-AGRB,2570,1,"Nat Resources, Environ & Econ",0.23,0.3,0.23,0.11,0.05,0.0,0.0,0.09,david brian willis,AGRB-2570,2015
-AGRB,3020,1,Economics of Farm Management,0.13,0.38,0.3,0.14,0.02,0.0,0.0,0.03,michael vassalos,AGRB-3020,2015
-AGRB,3090,1,Econ of Agricultural Marketing,0.89,0.04,0.04,0.02,0.0,0.0,0.0,0.0,yuliya val bolotova,AGRB-3090,2015
-AGRB,4120,1,Reg Econ Devel Theory & Policy,0.26,0.26,0.37,0.05,0.0,0.0,0.0,0.05,robert carey,AGRB-4120,2015
-AGRB,4600,1,Agricultural Finance,0.38,0.46,0.0,0.0,0.08,0.0,0.0,0.08,scott mickey,AGRB-4600,2015
-AL,3490,400,Principles of Coaching,0.4,0.48,0.08,0.04,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2015
-AL,3490,401,Principles of Coaching,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2015
-AL,3490,402,Principles of Coaching,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,AL-3490,2015
-AL,3490,403,Principles of Coaching,0.72,0.12,0.08,0.04,0.0,0.0,0.0,0.04,clyde keith connor,AL-3490,2015
-AL,3490,405,Principles of Coaching,0.67,0.21,0.04,0.0,0.0,0.0,0.0,0.08,clyde keith connor,AL-3490,2015
-AL,3490,406,Principles of Coaching,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,edmond fry,AL-3490,2015
-AL,3500,400,Sci Basis I/Ex Phy,0.32,0.12,0.36,0.08,0.04,0.0,0.0,0.08,michael godfrey,AL-3500,2015
-AL,3500,401,Sci Basis I/Ex Phy,0.2,0.28,0.28,0.12,0.12,0.0,0.0,0.0,michael godfrey,AL-3500,2015
-AL,3520,400,Kinesiology,0.47,0.33,0.13,0.07,0.0,0.0,0.0,0.0,isaac sean colbert,AL-3520,2015
-AL,3530,400,Athletic Injuries,0.14,0.33,0.29,0.14,0.05,0.0,0.0,0.05,isaac sean colbert,AL-3530,2015
-AL,3530,401,Athletic Injuries,0.19,0.38,0.13,0.19,0.0,0.0,0.0,0.13,isaac sean colbert,AL-3530,2015
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.32,0.52,0.08,0.0,0.0,0.0,0.0,0.08,clyde keith connor,AL-3600,2015
-AL,3610,400,Admin/Org of Athletic Programs,0.6,0.32,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2015
-AL,3610,401,Admin/Org of Athletic Programs,0.5,0.38,0.04,0.0,0.0,0.0,0.0,0.08,henry oates,AL-3610,2015
-AL,3610,402,Admin/Org of Athletic Programs,0.75,0.13,0.04,0.04,0.0,0.0,0.0,0.04,henry oates,AL-3610,2015
-AL,3620,400,Psychology of Coaching,0.31,0.31,0.19,0.08,0.08,0.0,0.0,0.04,natalie anne carter,AL-3620,2015
-AL,3620,401,Psychology of Coaching,0.4,0.24,0.16,0.2,0.0,0.0,0.0,0.0,natalie anne carter,AL-3620,2015
-AL,3620,402,Psychology of Coaching,0.44,0.22,0.28,0.0,0.06,0.0,0.0,0.0,natalie anne carter,AL-3620,2015
-AL,3740,400,Coaching Football,0.63,0.17,0.04,0.04,0.04,0.0,0.0,0.08,edmond fry,AL-3740,2015
-AL,3760,400,Coaching Strength/Conditioning,0.48,0.2,0.12,0.04,0.04,0.0,0.0,0.12,edmond fry,AL-3760,2015
-AL,3760,401,Coaching Strength/Conditioning,0.58,0.17,0.08,0.04,0.04,0.0,0.0,0.08,edmond fry,AL-3760,2015
-AL,4380,402,Coaching Women,0.43,0.22,0.3,0.04,0.0,0.0,0.0,0.0,deborah cadorette,AL-4380,2015
-AL,8490,400,Athletic Leadership Dev,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8490,2015
-AL,8500,400,Principles Strength and Condit,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8500,2015
-ANTH,2010,1,Introduction to Anthropology,0.07,0.24,0.3,0.18,0.09,0.0,0.0,0.12,john coggeshall,ANTH-2010,2015
-ANTH,2010,2,Introduction to Anthropology,0.07,0.41,0.39,0.02,0.0,0.0,0.0,0.1,john coggeshall,ANTH-2010,2015
-ANTH,2010,3,Introduction to Anthropology,0.41,0.37,0.06,0.08,0.04,0.0,0.0,0.04,katherine weisensee,ANTH-2010,2015
-ANTH,2010,4,Introduction to Anthropology,0.33,0.36,0.13,0.04,0.07,0.0,0.0,0.07,yi wu,ANTH-2010,2015
-ANTH,2010,5,Introduction to Anthropology,0.48,0.28,0.07,0.04,0.07,0.0,0.0,0.07,lisa rapaport,ANTH-2010,2015
-ANTH,3010,1,Cultural Anthropology,0.1,0.41,0.31,0.1,0.0,0.0,0.0,0.07,john coggeshall,ANTH-3010,2015
-ANTH,3320,1,World Archaeology,0.09,0.32,0.29,0.06,0.03,0.0,0.0,0.21,melissa vogel,ANTH-3320,2015
-ANTH,3510,1,Biological Anthropology,0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,katherine weisensee,ANTH-3510,2015
-ANTH,3710,1,Language and Culture,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,yanhua zhang,ANTH-3710,2015
-ANTH,4230,1,Women in the Developing World,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,melissa vogel,ANTH-4230,2015
-ANTH,4990,1,Special Topics,0.53,0.2,0.27,0.0,0.0,0.0,0.0,0.0,yi wu,ANTH-4990,2015
-ARCH,1010,1,Intro to Arch,0.46,0.36,0.02,0.0,0.03,0.0,0.0,0.13,sal hambright-belue,ARCH-1010,2015
-ARCH,2040,1,Hist of Modern Arch,0.25,0.61,0.08,0.0,0.03,0.0,0.0,0.02,robert bruhns,ARCH-2040,2015
-ARCH,2510,1,Arch Foundations I,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,robert silance,ARCH-2510,2015
-ARCH,2510,3,Arch Foundations I,0.62,0.31,0.0,0.0,0.08,0.0,0.0,0.0,clarissa mendez,ARCH-2510,2015
-ARCH,2510,4,Arch Foundations I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,james barker,ARCH-2510,2015
-ARCH,2510,5,Arch Foundations I,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-2510,2015
-ARCH,2700,1,Structures I,0.54,0.33,0.08,0.0,0.0,0.0,0.0,0.04,robert john hogan,ARCH-2700,2015
-ARCH,3510,1,Studio Clemson,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-3510,2015
-ARCH,3510,2,Studio Clemson,0.31,0.38,0.23,0.08,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-3510,2015
-ARCH,3510,3,Studio Clemson,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-3510,2015
-ARCH,3510,10,Studio Clemson,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,criss mills,ARCH-3510,2015
-ARCH,4010,1,Architectural Portfolio,0.42,0.42,0.06,0.0,0.06,0.0,0.0,0.06,clarissa mendez,ARCH-4010,2015
-ARCH,4010,2,Architectural Portfolio,0.61,0.29,0.04,0.0,0.0,0.0,0.0,0.07,clarissa mendez,ARCH-4010,2015
-ARCH,6300,1,Technology and Arch,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,barbara lamprecht,ARCH-6300,2015
-ARCH,6850,1,H/Th: Arch+Health,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-6850,2015
-ARCH,8100,1,Visualization I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-8100,2015
-ARCH,8210,1,Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-8210,2015
-ARCH,8510,1,Design Studio III,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-8510,2015
-ARCH,8510,3,Design Studio III,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8510,2015
-ARCH,8510,4,Design Studio III,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-8510,2015
-ARCH,8570,4,Design Studio V,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,raymond huff,ARCH-8570,2015
-ARCH,8600,1,History/Theory I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8600,2015
-ARCH,8720,1,Production & Assemb,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-8720,2015
-ARCH,8790,2,Digtial Manufacturing Process,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,ARCH-8790,2015
-ARCH,8810,1,Pro Practice Survey,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,ARCH-8810,2015
-ARCH,8860,1,Health Facilities,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8860,2015
-ARCH,8890,1,Mentorship,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,ARCH-8890,2015
-ARCH,8970,1,A+H Studio: Hospital,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8970,2015
-ART,1050,1,Foundation Drawing I,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,kathleen ann thum,ART-1050,2015
-ART,1510,1,Foundations Art I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,gregory wi shelnutt,ART-1510,2015
-ART,2070,1,Beginning Painting,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,mary jane king,ART-2070,2015
-ART,2090,1,Beginning Sculpture,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabet cooke,ART-2090,2015
-ART,2100,400,Art Appreciation,0.48,0.19,0.22,0.0,0.04,0.0,0.0,0.07,lydia jane dorsey,ART-2100,2015
-ART,2100,401,Art Appreciation,0.59,0.22,0.0,0.04,0.04,0.0,0.0,0.11,lydia jane dorsey,ART-2100,2015
-ART,2100,402,Art Appreciation,0.5,0.21,0.18,0.0,0.07,0.0,0.0,0.04,lydia jane dorsey,ART-2100,2015
-ART,2100,403,Art Appreciation,0.46,0.31,0.04,0.0,0.12,0.0,0.0,0.08,lydia jane dorsey,ART-2100,2015
-ART,2130,1,Begin Photography,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,haley brooke floyd,ART-2130,2015
-ART,2170,1,Beginning Ceramics,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,en iwamura,ART-2170,2015
-ART,8050,1,Visual Arts Sem I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,todd mcdonald,ART-8050,2015
-AS,1090,2,Air Force Today I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,christopher mann,AS-1090,2015
-AS,2090,2,Dev of Air Power I,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,christopher mann,AS-2090,2015
-AS,2090,3,Dev of Air Power I,0.6,0.35,0.0,0.0,0.05,0.0,0.0,0.0,christopher mann,AS-2090,2015
-ASL,1010,1,Am Sign Lang I,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-1010,2015
-ASL,1010,2,Am Sign Lang I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-1010,2015
-ASL,2010,1,Am Sign Lang II,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-2010,2015
-ASL,2010,2,Am Sign Lang II,0.26,0.42,0.32,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-2010,2015
-ASL,2020,1,Am Sign Lang II,0.31,0.38,0.31,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-2020,2015
-ASL,3150,1,Survey Interpreting,0.47,0.2,0.13,0.07,0.0,0.0,0.0,0.13,stephen fitzmaurice,ASL-3150,2015
-ASTR,1010,1,Solar System Astronomy,0.41,0.36,0.1,0.03,0.03,0.0,0.0,0.08,phillip flower,ASTR-1010,2015
-ASTR,1010,2,Solar System Astronomy,0.43,0.33,0.14,0.03,0.03,0.0,0.0,0.03,phillip flower,ASTR-1010,2015
-ASTR,1010,3,Solar System Astronomy,0.32,0.45,0.1,0.04,0.05,0.0,0.0,0.04,phillip flower,ASTR-1010,2015
-ASTR,1030,1,Solar Systm Astr Lab,0.6,0.2,0.04,0.0,0.12,0.0,0.0,0.04,mark leising,ASTR-1030,2015
-ASTR,1030,2,Solar Systm Astr Lab,0.5,0.15,0.08,0.04,0.12,0.0,0.0,0.12,mark leising,ASTR-1030,2015
-ASTR,1030,3,Solar Systm Astr Lab,0.52,0.2,0.08,0.0,0.12,0.0,0.0,0.08,mark leising,ASTR-1030,2015
-ASTR,1030,4,Solar Systm Astr Lab,0.42,0.25,0.13,0.13,0.0,0.0,0.0,0.08,mark leising,ASTR-1030,2015
-ASTR,1030,5,Solar Systm Astr Lab,0.5,0.23,0.08,0.04,0.08,0.0,0.0,0.08,mark leising,ASTR-1030,2015
-ASTR,1030,6,Solar Systm Astr Lab,0.25,0.5,0.21,0.04,0.0,0.0,0.0,0.0,mark leising,ASTR-1030,2015
-ASTR,1030,7,Solar Systm Astr Lab,0.19,0.42,0.15,0.12,0.04,0.0,0.0,0.08,mark leising,ASTR-1030,2015
-ASTR,1030,8,Solar Systm Astr Lab,0.38,0.33,0.17,0.08,0.0,0.0,0.0,0.04,mark leising,ASTR-1030,2015
-ASTR,1030,9,Solar Systm Astr Lab,0.24,0.48,0.12,0.0,0.04,0.0,0.0,0.12,mark leising,ASTR-1030,2015
-ASTR,8100,1,Astroph I: Radiation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,marco ajello,ASTR-8100,2015
-AUD,2800,1,Sound Reinforcement,0.0,0.33,0.42,0.17,0.08,0.0,0.0,0.0,kenneth moore,AUD-2800,2015
-AUE,8260,5,Vehicle Diagnostics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8260,2015
-AUE,8270,5,Auto Cntrl Sys Des,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8270,2015
-AUE,8280,79,Driveline/Powertrain,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,zoran filipi,AUE-8280,2015
-AUE,8330,30,Auto Manuf Proc Devl,0.35,0.62,0.03,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-8330,2015
-AUE,8670,1,Veh Manuf Proc I,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,michael mears,AUE-8670,2015
-AUE,8800,2,Vehicle Project Mngt,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,AUE-8800,2015
-AUE,8810,3,Automotive Systems Overview,0.22,0.7,0.09,0.0,0.0,0.0,0.0,0.0,paul venhovens,AUE-8810,2015
-AUE,8870,8,Meth Vehicle Testing,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,AUE-8870,2015
-AUE,8930,13,Engine Analysis,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8930,2015
-AUE,8930,14,Automotive Composites,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,AUE-8930,2015
-AUE,8930,17,Hybrids,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8930,2015
-AUE,8930,18,Adv IC Engine Concept,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-8930,2015
-AUE,8930,78,Applied Dynamics,0.5,0.0,0.33,0.0,0.17,0.0,0.0,0.0,imtiaz ul haque,AUE-8930,2015
-AVS,1000,1,Orientation to AVS,0.83,0.09,0.01,0.01,0.03,0.0,0.0,0.03,johanna joh lascano,AVS-1000,2015
-AVS,1500,1,Intro Animal Science,0.59,0.27,0.05,0.02,0.03,0.0,0.0,0.04,heather walker dunn,AVS-1500,2015
-AVS,1510,1,Intro Ani Sci Lab,0.7,0.26,0.0,0.0,0.0,0.0,0.0,0.04,anna rebecca baxley,AVS-1510,2015
-AVS,1510,2,Intro Ani Sci Lab,0.52,0.4,0.04,0.04,0.0,0.0,0.0,0.0,anna rebecca baxley,AVS-1510,2015
-AVS,1510,3,Intro Ani Sci Lab,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,richelle lor miller,AVS-1510,2015
-AVS,1510,4,Intro Ani Sci Lab,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-1510,2015
-AVS,1510,5,Intro Ani Sci Lab,0.36,0.56,0.0,0.0,0.0,0.0,0.0,0.08,anna rebecca baxley,AVS-1510,2015
-AVS,1510,6,Intro Ani Sci Lab,0.52,0.36,0.04,0.0,0.0,0.0,0.0,0.08,heather walker dunn,AVS-1510,2015
-AVS,1510,7,Intro Ani Sci Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,richelle lor miller,AVS-1510,2015
-AVS,2010,1,Poultry Techniques,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-2010,2015
-AVS,2020,1,CAFLS Plus,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,thomas scott,AVS-2020,2015
-AVS,2030,1,Dairy Sci Techniques,0.93,0.02,0.0,0.0,0.02,0.0,0.0,0.02,heather walker dunn,AVS-2030,2015
-AVS,2040,1,Horse Care Techniques,0.57,0.36,0.03,0.0,0.03,0.0,0.0,0.0,kristine lan vernon,AVS-2040,2015
-AVS,2110,1,Meat Processing Techniques,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-2110,2015
-AVS,3010,1,Anat & Phys Dom Ani,0.45,0.2,0.18,0.13,0.04,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2015
-AVS,3010,400,Anat & Phys Dom Ani,0.36,0.36,0.14,0.14,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2015
-AVS,3020,1,Livestk Sel Eval I,0.61,0.34,0.02,0.0,0.0,0.0,0.0,0.02,richelle lor miller,AVS-3020,2015
-AVS,3090,1,Equine Evaluation,0.5,0.32,0.11,0.04,0.0,0.0,0.0,0.04,kristine lan vernon,AVS-3090,2015
-AVS,3100,2,Animal Health,0.65,0.19,0.07,0.02,0.02,0.0,0.0,0.06,thomas scott,AVS-3100,2015
-AVS,3700,1,Principles of Animal Nutrition,0.17,0.22,0.25,0.23,0.07,0.0,0.0,0.07,nathan long,AVS-3700,2015
-AVS,3750,1,Applied Animal Nutrition,0.18,0.53,0.28,0.03,0.0,0.0,0.0,0.0,gustavo jos lascano,AVS-3750,2015
-AVS,4000,1,AVS Professional Development,0.66,0.2,0.1,0.0,0.05,0.0,0.0,0.0,johanna joh lascano,AVS-4000,2015
-AVS,4060,1,Seminars & Related Topics,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2015
-AVS,4060,2,Seminars & Related Topics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2015
-AVS,4150,1,Contemporary Issues in AVS,0.12,0.42,0.36,0.03,0.03,0.0,0.0,0.05,peter skewes,AVS-4150,2015
-AVS,4160,1,Equine Exercise Phys,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,kristine lan vernon,AVS-4160,2015
-AVS,4530,1,Animal Reproduction,0.27,0.38,0.27,0.04,0.04,0.0,0.0,0.0,tiffany wilmoth,AVS-4530,2015
-AVS,4700,1,Animal Genetics,0.47,0.21,0.22,0.05,0.05,0.0,0.0,0.0,meenakshi mukherjee,AVS-4700,2015
-BCHM,1030,1,Careers in Bioch/Gen,0.88,0.03,0.01,0.04,0.01,0.0,0.0,0.02,alison starr-moss,BCHM-1030,2015
-BCHM,3010,1,Molecular Biochem,0.26,0.21,0.21,0.16,0.16,0.0,0.0,0.0,cheryl ingram-smith,BCHM-3010,2015
-BCHM,3050,1,Essen Elements Bioch,0.25,0.34,0.22,0.06,0.05,0.0,0.0,0.08,srik chandrasekaran,BCHM-3050,2015
-BCHM,3050,2,Essen Elements Bioch,0.26,0.34,0.25,0.12,0.02,0.0,0.0,0.01,srik chandrasekaran,BCHM-3050,2015
-BCHM,3050,3,Essen Elements Bioch,0.28,0.37,0.11,0.06,0.07,0.0,0.0,0.11,srik chandrasekaran,BCHM-3050,2015
-BCHM,4060,1,Physiological Chem,0.68,0.19,0.03,0.03,0.03,0.0,0.0,0.03,james ro strickland,BCHM-4060,2015
-BCHM,4310,1,Physical Approach to Biochem,0.25,0.34,0.32,0.02,0.0,0.0,0.0,0.07,weiguo cao,BCHM-4310,2015
-BCHM,4310,2,Phys App to Bioch (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4310,2015
-BCHM,4330,1,General Biochemistry Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4330,2015
-BCHM,4330,2,General Biochemistry Lab I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,weiguo cao,BCHM-4330,2015
-BCHM,4330,3,General Biochemistry Lab I,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4330,2015
-BCHM,4330,4,General Biochemistry Lab I,0.6,0.1,0.1,0.0,0.0,0.0,0.0,0.2,weiguo cao,BCHM-4330,2015
-BCHM,4400,1,Bioinformatics,0.74,0.08,0.03,0.08,0.0,0.0,0.0,0.08,frank alexan feltus,BCHM-4400,2015
-BCHM,4900,7,C-MED,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,michael glen sehorn,BCHM-4900,2015
-BCHM,8140,1,Advanced Biochemistry,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,kerry smith,BCHM-8140,2015
-BE,2120,1,Fundamentals of Biosys Engr,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,caye marie drapcho,BE-2120,2015
-BE,3200,1,Principles & Prac of Geomatics,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,BE-3200,2015
-BE,4100,1,Biological Kinetics,0.44,0.32,0.24,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4100,2015
-BE,4150,1,Instr & Control for Biosys Eng,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,yi zheng,BE-4150,2015
-BE,4280,1,Biochem Engr,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4280,2015
-BE,4740,1,B E Design/Proj Mgt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,BE-4740,2015
-BE,4750,1,B E Capstone Design,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4750,2015
-BIOE,1010,1,Biol for Bioengr,0.65,0.24,0.0,0.06,0.0,0.0,0.0,0.06,vladimir vla reukov,BIOE-1010,2015
-BIOE,2010,1,Intro Biomed Engr,0.52,0.39,0.08,0.0,0.0,0.0,0.0,0.02,charles webb,BIOE-2010,2015
-BIOE,2010,2,Intro Biomed Engr,0.38,0.58,0.01,0.0,0.0,0.0,0.0,0.03,vladimir vla reukov,BIOE-2010,2015
-BIOE,3020,1,Biomaterials,0.44,0.34,0.1,0.06,0.02,0.0,0.0,0.04,alexey ale vertegel,BIOE-3020,2015
-BIOE,3200,1,Biomechanics,0.65,0.31,0.02,0.02,0.0,0.0,0.0,0.02,lisa benson,BIOE-3200,2015
-BIOE,3210,1,Biofluid Mechanics,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,zhi gao,BIOE-3210,2015
-BIOE,3700,1,Bioinst & Imaging,0.74,0.21,0.03,0.02,0.0,0.0,0.0,0.0,david kwartowitz,BIOE-3700,2015
-BIOE,4010,1,Bioengineering Design Theory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,BIOE-4010,2015
-BIOE,4030,1,Applied Bio E Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,BIOE-4030,2015
-BIOE,4120,1,Orthopaedic Engr and Pathology,0.56,0.33,0.04,0.0,0.0,0.0,0.0,0.07,melinda harman,BIOE-4120,2015
-BIOE,4400,1,Biopharmaceutical Engineering,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,sarah harcum,BIOE-4400,2015
-BIOE,6120,1,Orthopaedic Engr & Pathology,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,melinda harman,BIOE-6120,2015
-BIOE,8010,1,Bio Materials,0.36,0.54,0.07,0.04,0.0,0.0,0.0,0.0,robert latour,BIOE-8010,2015
-BIOE,8160,1,BioE Professional Development,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,martine laberge,BIOE-8160,2015
-BIOE,8200,1,Structl Biomechanics,0.78,0.19,0.0,0.0,0.0,0.0,0.0,0.04,hai yao,BIOE-8200,2015
-BIOE,8500,4,Cardiovascular Biomechanics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,BIOE-8500,2015
-BIOL,1010,1,Frontiers in Biology I,0.71,0.19,0.06,0.02,0.01,0.0,0.0,0.01,robert edwa ballard,BIOL-1010,2015
-BIOL,1010,2,Frontiers in Biology I,0.67,0.21,0.05,0.05,0.02,0.0,0.0,0.01,thomas hughes,BIOL-1010,2015
-BIOL,1010,3,Frontiers in Biology I,0.67,0.25,0.02,0.01,0.04,0.0,0.0,0.01,joseph paul thames,BIOL-1010,2015
-BIOL,1030,1,General Biology I,0.21,0.23,0.24,0.14,0.09,0.0,0.0,0.09,nora espinoza,BIOL-1030,2015
-BIOL,1030,3,General Biology I,0.26,0.32,0.26,0.07,0.04,0.0,0.0,0.05,kristi ja whitehead,BIOL-1030,2015
-BIOL,1030,4,General Biology I,0.29,0.3,0.21,0.06,0.04,0.0,0.0,0.1,william surver,BIOL-1030,2015
-BIOL,1030,5,General Biology I,0.19,0.23,0.35,0.12,0.05,0.0,0.0,0.06,salvatore sparace,BIOL-1030,2015
-BIOL,1030,6,General Biology I (HON),0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,BIOL-1030,2015
-BIOL,1050,1,General Biology Lab I,0.46,0.33,0.13,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,2,General Biology Lab I,0.17,0.3,0.35,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,3,General Biology Lab I,0.17,0.35,0.17,0.09,0.04,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,4,General Biology Lab I,0.33,0.17,0.21,0.13,0.08,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,5,General Biology Lab I,0.13,0.42,0.33,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,6,General Biology Lab I,0.25,0.42,0.21,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,7,General Biology Lab I,0.25,0.29,0.21,0.21,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,8,General Biology Lab I,0.25,0.21,0.29,0.04,0.08,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,9,General Biology Lab I,0.22,0.48,0.13,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,10,General Biology Lab I,0.29,0.5,0.08,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,11,General Biology Lab I,0.08,0.46,0.29,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,12,General Biology Lab I,0.5,0.25,0.17,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,13,General Biology Lab I,0.24,0.28,0.28,0.12,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,14,General Biology Lab I,0.17,0.42,0.25,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,15,General Biology Lab I,0.29,0.5,0.08,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,16,General Biology Lab I,0.29,0.42,0.17,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,17,General Biology Lab I,0.38,0.42,0.04,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,18,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,19,General Biology Lab I,0.17,0.42,0.38,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,20,General Biology Lab I,0.22,0.57,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,21,General Biology Lab I,0.13,0.38,0.21,0.08,0.08,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,25,General Biology Lab I,0.54,0.42,0.0,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,26,General Biology Lab I,0.38,0.29,0.17,0.0,0.08,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,28,General Biology Lab I,0.63,0.21,0.04,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,29,General Biology Lab I,0.29,0.42,0.25,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,30,General Biology Lab I,0.29,0.5,0.08,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,31,General Biology Lab I,0.17,0.33,0.29,0.04,0.08,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,32,General Biology Lab I,0.26,0.43,0.09,0.04,0.0,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,33,General Biology Lab I,0.29,0.54,0.0,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,34,General Biology Lab I,0.46,0.17,0.21,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,35,General Biology Lab I,0.38,0.42,0.17,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,36,General Biology Lab I,0.08,0.29,0.42,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,37,General Biology Lab I,0.17,0.54,0.17,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,38,General Biology Lab I,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,39,General Biology Lab I,0.25,0.33,0.25,0.04,0.0,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,40,General Biology Lab I,0.17,0.5,0.25,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,41,General Biology Lab I,0.13,0.54,0.17,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,42,General Biology Lab I,0.26,0.48,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,43,General Biology Lab I,0.04,0.26,0.35,0.13,0.17,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,44,General Biology Lab I,0.22,0.26,0.22,0.13,0.09,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,47,General Biology Lab I,0.17,0.38,0.21,0.08,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1050,48,General Biology Lab I,0.06,0.35,0.29,0.06,0.18,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1050,2015
-BIOL,1090,1,Intro to Life Sci,0.77,0.21,0.02,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,BIOL-1090,2015
-BIOL,1100,1,Principles of Biology I,0.21,0.33,0.29,0.07,0.03,0.0,0.0,0.07,robert kosinski,BIOL-1100,2015
-BIOL,1100,2,Principles of Biology I,0.19,0.46,0.19,0.06,0.02,0.0,0.0,0.08,dylan dittrich-reed,BIOL-1100,2015
-BIOL,1100,4,Prin of Biology I (HON),0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,BIOL-1100,2015
-BIOL,1200,1,Biological Inq Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,2,Biological Inq Lab,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,3,Biological Inq Lab,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,4,Biological Inq Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,6,Biological Inq Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,7,Biological Inq Lab,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,11,Biological Inq Lab,0.7,0.2,0.0,0.05,0.0,0.0,0.0,0.05, christine minor,BIOL-1200,2015
-BIOL,1200,12,Biological Inq Lab,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,14,Biological Inq Lab,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1230,1,Keys to Human Biol,0.21,0.4,0.26,0.09,0.03,0.0,0.0,0.01, christine minor,BIOL-1230,2015
-BIOL,1230,2,Keys to Human Biol,0.23,0.47,0.24,0.03,0.02,0.0,0.0,0.02, christine minor,BIOL-1230,2015
-BIOL,2000,3,Biology in the News,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-2000,2015
-BIOL,2000,7,Biology in the News,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,BIOL-2000,2015
-BIOL,2040,1,"Environ, Energy and Society",0.53,0.19,0.09,0.09,0.03,0.0,0.0,0.08,john jenkins hains,BIOL-2040,2015
-BIOL,2220,1,Human Anat and Physiology I,0.19,0.35,0.24,0.09,0.07,0.0,0.0,0.07,john cummings,BIOL-2220,2015
-BIOL,2220,2,Human Anat and Physiology I,0.24,0.3,0.21,0.11,0.1,0.0,0.0,0.05,john cummings,BIOL-2220,2015
-BIOL,3030,1,Vertebrate Biology,0.27,0.31,0.17,0.15,0.04,0.0,0.0,0.05,richard blob,BIOL-3030,2015
-BIOL,3030,2,Vertebrate Biology (HON),0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3030,2015
-BIOL,3040,1,Biology of Plants,0.29,0.36,0.19,0.09,0.06,0.0,0.0,0.03,saara dewalt,BIOL-3040,2015
-BIOL,3070,1,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2015
-BIOL,3070,2,Vertebrate Biology Lab,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2015
-BIOL,3070,3,Vertebrate Biology Lab,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2015
-BIOL,3070,4,Vertebrate Biology Lab,0.38,0.52,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2015
-BIOL,3070,5,Vertebrate Biology Lab,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2015
-BIOL,3070,7,Vertebrate Biology Lab,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2015
-BIOL,3070,8,Vertebrate Biology Lab,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2015
-BIOL,3070,9,Vertebrate Biology Lab,0.38,0.38,0.14,0.05,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2015
-BIOL,3070,10,Vertebrate Biology Lab,0.71,0.24,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2015
-BIOL,3070,11,Vertebrate Biology Lab,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2015
-BIOL,3070,12,Vertebrate Biology Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2015
-BIOL,3070,13,Vertebrate Biology Lab,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2015
-BIOL,3080,1,Biology of Plants Practicum,0.24,0.29,0.35,0.06,0.06,0.0,0.0,0.0,saara dewalt,BIOL-3080,2015
-BIOL,3080,2,Biology of Plants Practicum,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,saara dewalt,BIOL-3080,2015
-BIOL,3080,3,Biology of Plants Practicum,0.4,0.3,0.25,0.0,0.0,0.0,0.0,0.05,saara dewalt,BIOL-3080,2015
-BIOL,3080,4,Biology of Plants Practicum,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,saara dewalt,BIOL-3080,2015
-BIOL,3150,1,Functional Human Anatomy,0.25,0.49,0.18,0.04,0.02,0.0,0.0,0.03,tamara mcnutt-scott,BIOL-3150,2015
-BIOL,3200,1,Field Botany,0.2,0.18,0.3,0.2,0.02,0.0,0.0,0.1,robert edwa ballard,BIOL-3200,2015
-BIOL,3350,1,Evolutionary Biology,0.24,0.26,0.18,0.13,0.09,0.0,0.0,0.11,lisa rapaport,BIOL-3350,2015
-BIOL,3510,1,Biological Anthropology,0.46,0.38,0.08,0.08,0.0,0.0,0.0,0.0,katherine weisensee,BIOL-3510,2015
-BIOL,4140,1,Basic Immunology,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,yanzhang wei,BIOL-4140,2015
-BIOL,4200,1,Neurobiology,0.29,0.28,0.16,0.03,0.01,0.0,0.0,0.22,david feliciano,BIOL-4200,2015
-BIOL,4200,2,Neurobiology (HON),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4200,2015
-BIOL,4250,1,Introductory Mycology,0.6,0.1,0.0,0.2,0.1,0.0,0.0,0.0,julia loui kerrigan,BIOL-4250,2015
-BIOL,4340,1,Biological Chem Lab Techniques,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2015
-BIOL,4340,2,Biological Chem Lab Techniques,0.45,0.27,0.0,0.27,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2015
-BIOL,4340,3,Biological Chem Lab Techniques,0.23,0.31,0.15,0.31,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2015
-BIOL,4410,1,Ecology,0.18,0.38,0.28,0.08,0.01,0.0,0.0,0.07,david tonkyn,BIOL-4410,2015
-BIOL,4410,2,Ecology (HON),0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,david tonkyn,BIOL-4410,2015
-BIOL,4430,1,Freshwater Ecology,0.63,0.22,0.1,0.0,0.0,0.0,0.0,0.05,john jenkins hains,BIOL-4430,2015
-BIOL,4450,1,Ecology Laboratory (Lec),0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,david tonkyn,BIOL-4450,2015
-BIOL,4450,3,Ecology Laboratory (Lec),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,BIOL-4450,2015
-BIOL,4450,4,Ecology Laboratory (Lec),0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david tonkyn,BIOL-4450,2015
-BIOL,4610,1,Cell Biology,0.29,0.3,0.29,0.07,0.02,0.0,0.0,0.03,lesly temesvari,BIOL-4610,2015
-BIOL,4610,2,Cell Biology (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4610,2015
-BIOL,4610,3,Cell Biology,0.33,0.29,0.28,0.04,0.02,0.0,0.0,0.04,susan carol chapman,BIOL-4610,2015
-BIOL,4610,4,Cell Biology (HON),0.24,0.57,0.19,0.0,0.0,0.0,0.0,0.0,susan carol chapman,BIOL-4610,2015
-BIOL,4620,1,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,2,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,3,Cell Biology Lab (Lec),0.53,0.2,0.27,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,4,Cell Biology Lab (Lec),0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,xianzhong yu,BIOL-4620,2015
-BIOL,4620,5,Cell Biology Lab (Lec),0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,BIOL-4620,2015
-BIOL,4620,6,Cell Biology Lab (Lec),0.71,0.18,0.06,0.0,0.0,0.0,0.0,0.06,xianzhong yu,BIOL-4620,2015
-BIOL,4620,7,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,8,Cell Biology Lab (Lec),0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,9,Cell Biology Lab (Lec),0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,10,Cell Biology Lab (Lec),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,BIOL-4620,2015
-BIOL,4620,11,Cell Biology Lab (Lec),0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,xianzhong yu,BIOL-4620,2015
-BIOL,4670,1,Principles of Hematology,0.91,0.0,0.05,0.0,0.0,0.0,0.0,0.05,vincent gallicchio,BIOL-4670,2015
-BIOL,4750,1,Comparative Physiology,0.49,0.32,0.05,0.02,0.0,0.0,0.0,0.12,michael sears,BIOL-4750,2015
-BIOL,4930,2,Senior Seminar,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,wen chen,BIOL-4930,2015
-BIOL,4930,4,Senior Seminar,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,juan baeza migueles,BIOL-4930,2015
-BIOL,6030,1,Intro to Applied Genomics,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vincent pa richards,BIOL-6030,2015
-BIOL,8400,1,Understanding Biological Inq,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,dylan dittrich-reed,BIOL-8400,2015
-BIOL,8420,1,Understand Cellular Processes,0.73,0.21,0.0,0.0,0.02,0.0,0.0,0.04,david feliciano,BIOL-8420,2015
-BIOL,8440,1,Understanding the Human Body,0.47,0.34,0.1,0.01,0.04,0.0,0.0,0.03,william baldwin,BIOL-8440,2015
-BUS,1010,1,Business Foundations,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2015
-BUS,1010,2,Business Foundations,0.27,0.46,0.24,0.03,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2015
-BUS,1010,3,Business Foundations,0.43,0.27,0.14,0.03,0.05,0.0,0.0,0.08,william ern tumblin,BUS-1010,2015
-BUS,1010,4,Business Foundations,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2015
-BUS,1010,5,Business Foundations,0.39,0.32,0.16,0.03,0.05,0.0,0.0,0.05,donna mccubbin,BUS-1010,2015
-BUS,1010,6,Business Foundations,0.47,0.34,0.16,0.03,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2015
-BUS,1010,7,Business Foundations,0.02,0.45,0.38,0.02,0.07,0.0,0.0,0.05,donna mccubbin,BUS-1010,2015
-BUS,1010,8,Business Foundations,0.3,0.35,0.21,0.02,0.0,0.0,0.0,0.12,donna mccubbin,BUS-1010,2015
-BUS,1010,9,Business Foundations,0.16,0.44,0.21,0.05,0.07,0.0,0.0,0.07,donna mccubbin,BUS-1010,2015
-BUS,1010,10,Business Foundations,0.19,0.49,0.19,0.02,0.09,0.0,0.0,0.02,william ern tumblin,BUS-1010,2015
-BUS,1010,11,Business Foundations,0.21,0.74,0.0,0.05,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2015
-BUS,1010,12,Business Foundations,0.42,0.32,0.11,0.05,0.05,0.0,0.0,0.05,sandy edge,BUS-1010,2015
-BUS,1010,13,Business Foundations,0.21,0.68,0.05,0.0,0.0,0.0,0.0,0.05,sandy edge,BUS-1010,2015
-BUS,1010,14,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2015
-BUS,1010,15,Business Foundations,0.32,0.42,0.21,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2015
-BUS,1010,16,Business Foundations,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2015
-BUS,1010,17,Business Foundations,0.16,0.42,0.26,0.0,0.05,0.0,0.0,0.11,william ern tumblin,BUS-1010,2015
-BUS,1010,18,Business Foundations,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,william ern tumblin,BUS-1010,2015
-BUS,1010,19,Business Foundations,0.11,0.28,0.39,0.11,0.06,0.0,0.0,0.06,william ern tumblin,BUS-1010,2015
-BUS,1010,20,Business Foundations,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,william ern tumblin,BUS-1010,2015
-BUS,1010,27,Business Foundations,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2015
-BUS,1010,28,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2015
-CE,2010,2,Statics,0.41,0.19,0.14,0.14,0.1,0.0,0.0,0.02,qiushi chen,CE-2010,2015
-CE,2010,3,Statics,0.48,0.11,0.27,0.07,0.0,0.0,0.0,0.07,brandon ross,CE-2010,2015
-CE,2010,4,Statics,0.11,0.32,0.09,0.05,0.11,0.0,0.0,0.32,melissa sternhagen,CE-2010,2015
-CE,2010,5,Statics,0.36,0.21,0.17,0.05,0.07,0.0,0.0,0.14,melissa sternhagen,CE-2010,2015
-CE,2010,6,Statics,0.46,0.17,0.19,0.02,0.07,0.0,0.0,0.09,mahmoodreza soltani,CE-2010,2015
-CE,2010,7,Statics,0.23,0.45,0.13,0.06,0.0,0.0,0.0,0.13,weichiang pang,CE-2010,2015
-CE,2060,1,Structural Mechanics,0.07,0.39,0.34,0.1,0.02,0.0,0.0,0.07,bryant nielson,CE-2060,2015
-CE,2080,2,Dynamics,0.04,0.3,0.26,0.11,0.04,0.0,0.0,0.26,melissa sternhagen,CE-2080,2015
-CE,2080,4,Dynamics,0.04,0.19,0.38,0.15,0.08,0.0,0.0,0.15,melissa sternhagen,CE-2080,2015
-CE,2550,1,Geomatics,0.32,0.47,0.19,0.0,0.0,0.0,0.0,0.02,wayne sarasua,CE-2550,2015
-CE,2550,2,Geomatics,0.44,0.31,0.18,0.03,0.05,0.0,0.0,0.0,wayne sarasua,CE-2550,2015
-CE,3010,1,Structural Analysis,0.21,0.59,0.12,0.06,0.03,0.0,0.0,0.0,stephen csernak,CE-3010,2015
-CE,3010,2,Structural Analysis,0.28,0.23,0.38,0.08,0.03,0.0,0.0,0.0,bryant nielson,CE-3010,2015
-CE,3110,1,Transportation Engr,0.71,0.18,0.07,0.02,0.02,0.0,0.0,0.0,jennifer ogle,CE-3110,2015
-CE,3210,1,Geotechnical Engineering,0.38,0.38,0.18,0.0,0.05,0.0,0.0,0.0,qiushi chen,CE-3210,2015
-CE,3310,1,Constr Engr & Mgmnt,0.41,0.37,0.12,0.06,0.04,0.0,0.0,0.0,james burati,CE-3310,2015
-CE,3410,1,Intro to Fluid Mech,0.13,0.6,0.24,0.04,0.0,0.0,0.0,0.0,nigel gregory kaye,CE-3410,2015
-CE,3410,2,Intro to Fluid Mech,0.14,0.33,0.39,0.07,0.02,0.0,0.0,0.05,abdul khan,CE-3410,2015
-CE,3420,1,Hydraulics & Hydro,0.29,0.47,0.12,0.08,0.02,0.0,0.0,0.02,ashok mishra,CE-3420,2015
-CE,3510,1,Civil Engineering Materials,0.68,0.28,0.03,0.03,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,CE-3510,2015
-CE,3510,2,Civil Engineering Materials,0.54,0.29,0.13,0.02,0.02,0.0,0.0,0.0,ami esmaeilpoursaee,CE-3510,2015
-CE,3520,1,Econ Eval of Proj,0.36,0.22,0.09,0.13,0.11,0.0,0.0,0.09,yongxi huang,CE-3520,2015
-CE,3530,1,Professional Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-3530,2015
-CE,4010,1,Matrix Str Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,CE-4010,2015
-CE,4020,1,Reinfor Con Design,0.44,0.38,0.16,0.03,0.0,0.0,0.0,0.0,brandon ross,CE-4020,2015
-CE,4060,1,Struct Steel Design,0.35,0.28,0.28,0.05,0.05,0.0,0.0,0.0,stephen csernak,CE-4060,2015
-CE,4070,1,Wood Design,0.13,0.4,0.13,0.0,0.07,0.0,0.0,0.27,weichiang pang,CE-4070,2015
-CE,4100,1,Traffic Engr Oper,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,yongxi huang,CE-4100,2015
-CE,4210,1,Geotechnical Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,CE-4210,2015
-CE,4240,1,Earth Slopes & Struc,0.29,0.29,0.24,0.05,0.05,0.0,0.0,0.1,nadara ravichandran,CE-4240,2015
-CE,4370,1,Sustainable Energy Proj Design,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,leidy klotz,CE-4370,2015
-CE,4390,1,Con Eqpmt Sel & Main,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,james burati,CE-4390,2015
-CE,4560,1,Pave Design & Constr,0.29,0.48,0.17,0.05,0.02,0.0,0.0,0.0,bradley putman,CE-4560,2015
-CE,4590,1,Capstone Design Proj,0.69,0.26,0.03,0.0,0.0,0.0,0.0,0.03,stephen csernak,CE-4590,2015
-CE,4910,1,BIM in Construction Management,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4910,2015
-CE,6010,1,Matrix Str Analysis,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,CE-6010,2015
-CE,6070,1,Wood Design,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-6070,2015
-CE,6100,1,Traffic Engr Oper,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,yongxi huang,CE-6100,2015
-CE,6240,1,Earth Slopes & Struc,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,CE-6240,2015
-CE,6560,1,Pavement Des & Const,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,bradley putman,CE-6560,2015
-CE,6910,1,BIM in Construction Management,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-6910,2015
-CE,8020,1,Adv R/C Design,0.23,0.58,0.19,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,CE-8020,2015
-CE,8050,1,Adv Struc Mech,0.38,0.48,0.14,0.0,0.0,0.0,0.0,0.0,bryant nielson,CE-8050,2015
-CE,8060,1,Dyn Analys of Struc,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,CE-8060,2015
-CE,8140,1,Intel Trans Systems,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,kakan dey,CE-8140,2015
-CE,8200,1,Geotech Site Charac,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-8200,2015
-CE,8260,1,Prop of Concrete,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,CE-8260,2015
-CH,1010,1,General Chemistry,0.19,0.32,0.21,0.12,0.09,0.0,0.0,0.06,thomas hickman,CH-1010,2015
-CH,1010,2,General Chemistry,0.19,0.27,0.28,0.08,0.1,0.0,0.0,0.08,christopher wilson,CH-1010,2015
-CH,1010,3,General Chemistry,0.28,0.21,0.25,0.09,0.09,0.0,0.0,0.07,christopher wilson,CH-1010,2015
-CH,1010,4,General Chemistry,0.16,0.44,0.21,0.1,0.03,0.0,0.0,0.06,dennis taylor,CH-1010,2015
-CH,1010,5,General Chemistry,0.23,0.32,0.23,0.07,0.06,0.0,0.0,0.09,dennis taylor,CH-1010,2015
-CH,1010,6,General Chemistry,0.08,0.32,0.2,0.11,0.13,0.0,0.0,0.16,william joh wallace,CH-1010,2015
-CH,1010,7,General Chemistry,0.16,0.31,0.26,0.13,0.03,0.0,0.0,0.12,dennis taylor,CH-1010,2015
-CH,1010,8,General Chemistry,0.21,0.32,0.28,0.04,0.1,0.0,0.0,0.05,olt geiculescu,CH-1010,2015
-CH,1010,9,General Chemistry,0.08,0.26,0.26,0.17,0.14,0.0,0.0,0.1,william joh wallace,CH-1010,2015
-CH,1010,10,General Chemistry,0.3,0.27,0.25,0.08,0.06,0.0,0.0,0.04,ava kreider-mueller,CH-1010,2015
-CH,1010,11,General Chemistry,0.22,0.41,0.19,0.11,0.03,0.0,0.0,0.03,tania issa houjeiry,CH-1010,2015
-CH,1010,12,General Chemistry,0.25,0.35,0.16,0.08,0.08,0.0,0.0,0.07,ava kreider-mueller,CH-1010,2015
-CH,1010,13,General Chemistry,0.14,0.36,0.29,0.07,0.09,0.0,0.0,0.05,elliot ennis,CH-1010,2015
-CH,1010,14,General Chemistry,0.09,0.27,0.35,0.11,0.11,0.0,0.0,0.07,william joh wallace,CH-1010,2015
-CH,1010,16,General Chemistry,0.22,0.37,0.31,0.06,0.03,0.0,0.0,0.01,tania issa houjeiry,CH-1010,2015
-CH,1010,17,General Chemistry,0.14,0.31,0.31,0.11,0.08,0.0,0.0,0.05,elliot ennis,CH-1010,2015
-CH,1010,18,General Chemistry,0.23,0.31,0.28,0.08,0.03,0.0,0.0,0.06,ava kreider-mueller,CH-1010,2015
-CH,1010,50,General Chemistry,0.35,0.38,0.19,0.08,0.0,0.0,0.0,0.0,william pennington,CH-1010,2015
-CH,1010,51,General Chemistry (HON),0.67,0.22,0.07,0.0,0.0,0.0,0.0,0.04,joseph stu thrasher,CH-1010,2015
-CH,1010,52,General Chemistry (HON),0.56,0.31,0.1,0.0,0.0,0.0,0.0,0.03,shiou-jyh hwu,CH-1010,2015
-CH,1010,53,General Chemistry,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,edward collins,CH-1010,2015
-CH,1020,1,General Chemistry,0.27,0.25,0.25,0.11,0.06,0.0,0.0,0.06,stephe schvaneveldt,CH-1020,2015
-CH,1020,2,General Chemistry,0.3,0.31,0.23,0.08,0.04,0.0,0.0,0.05,stephe schvaneveldt,CH-1020,2015
-CH,1020,3,General Chemistry,0.27,0.27,0.26,0.1,0.02,0.0,0.0,0.08,stephe schvaneveldt,CH-1020,2015
-CH,1020,400,General Chemistry,0.05,0.34,0.34,0.07,0.1,0.0,0.0,0.1,stephe schvaneveldt,CH-1020,2015
-CH,1050,1,Chemistry in Context I,0.39,0.53,0.08,0.0,0.0,0.0,0.0,0.0,olt geiculescu,CH-1050,2015
-CH,1050,2,Chemistry in Context I,0.48,0.35,0.11,0.03,0.0,0.0,0.0,0.04,olt geiculescu,CH-1050,2015
-CH,1410,1,Chem Orientation,0.89,0.06,0.0,0.0,0.02,0.0,0.0,0.02, karl dieter,CH-1410,2015
-CH,2010,1,Survey of Organic Chemistry,0.29,0.35,0.29,0.0,0.02,0.0,0.0,0.05,thomas hickman,CH-2010,2015
-CH,2010,2,Survey of Organic Chemistry,0.36,0.41,0.21,0.0,0.01,0.0,0.0,0.01,thomas hickman,CH-2010,2015
-CH,2020,1,Surv of Organic Chemistry Lab,0.56,0.25,0.0,0.13,0.0,0.0,0.0,0.06,sean 'connor,CH-2020,2015
-CH,2020,2,Surv of Organic Chemistry Lab,0.72,0.17,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,CH-2020,2015
-CH,2020,6,Surv of Organic Chemistry Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2020,2015
-CH,2020,8,Surv of Organic Chemistry Lab,0.67,0.06,0.17,0.0,0.0,0.0,0.0,0.11,sean 'connor,CH-2020,2015
-CH,2230,1,Organic Chemistry,0.21,0.37,0.27,0.04,0.06,0.0,0.0,0.04,modi wetzler,CH-2230,2015
-CH,2230,2,Organic Chemistry,0.33,0.34,0.14,0.1,0.06,0.0,0.0,0.04,modi wetzler,CH-2230,2015
-CH,2230,3,Organic Chemistry,0.3,0.4,0.21,0.04,0.06,0.0,0.0,0.0,daniel whitehead,CH-2230,2015
-CH,2230,4,Organic Chemistry,0.3,0.42,0.17,0.04,0.05,0.0,0.0,0.04,jacob schroeder,CH-2230,2015
-CH,2230,5,Organic Chemistry,0.25,0.27,0.3,0.07,0.07,0.0,0.0,0.05,elliot ennis,CH-2230,2015
-CH,2230,6,Organic Chemistry,0.25,0.31,0.13,0.03,0.07,0.0,0.0,0.21,rhett smith,CH-2230,2015
-CH,2230,7,Organic Chemistry,0.33,0.32,0.16,0.08,0.05,0.0,0.0,0.06,tania issa houjeiry,CH-2230,2015
-CH,2240,1,Organic Chemistry,0.24,0.38,0.19,0.06,0.03,0.0,0.0,0.09,jacob schroeder,CH-2240,2015
-CH,2240,2,Organic Chemistry,0.29,0.38,0.15,0.05,0.01,0.0,0.0,0.11,jacob schroeder,CH-2240,2015
-CH,2270,1,Organic Chem Lab,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2015
-CH,2270,2,Organic Chem Lab,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2015
-CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2015
-CH,2270,7,Organic Chem Lab,0.56,0.25,0.0,0.0,0.06,0.0,0.0,0.13,sean 'connor,CH-2270,2015
-CH,2270,10,Organic Chem Lab,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2015
-CH,2270,12,Organic Chem Lab,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2015
-CH,2270,13,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2015
-CH,2270,14,Organic Chem Lab,0.56,0.25,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,CH-2270,2015
-CH,2270,15,Organic Chem Lab,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,CH-2270,2015
-CH,2270,16,Organic Chem Lab,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2015
-CH,2270,17,Organic Chem Lab,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,CH-2270,2015
-CH,2270,18,Organic Chem Lab,0.69,0.06,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,CH-2270,2015
-CH,2270,20,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2015
-CH,2270,23,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2015
-CH,2270,25,Organic Chem Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2015
-CH,2270,28,Organic Chem Lab,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,CH-2270,2015
-CH,2270,31,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,sean 'connor,CH-2270,2015
-CH,2270,33,Organic Chem Lab,0.56,0.19,0.0,0.0,0.06,0.0,0.0,0.19,sean 'connor,CH-2270,2015
-CH,2270,35,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2015
-CH,2270,36,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2015
-CH,2270,37,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,sean 'connor,CH-2270,2015
-CH,2270,38,Organic Chem Lab,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,CH-2270,2015
-CH,2280,3,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,CH-2280,2015
-CH,2280,6,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,sean 'connor,CH-2280,2015
-CH,2280,7,Organic Chem Lab,0.59,0.18,0.12,0.0,0.0,0.0,0.0,0.12,sean 'connor,CH-2280,2015
-CH,2280,8,Organic Chem Lab,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,CH-2280,2015
-CH,3130,1,Quantitative Analys,0.44,0.31,0.09,0.09,0.0,0.0,0.0,0.06,stephen creager,CH-3130,2015
-CH,3300,1,Intro to Phys Chem,0.37,0.27,0.21,0.07,0.01,0.0,0.0,0.06,brian dominy,CH-3300,2015
-CH,3310,1,Physical Chemistry,0.58,0.19,0.13,0.06,0.03,0.0,0.0,0.0,leah bec casabianca,CH-3310,2015
-CH,3310,2,Physical Chemistry,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,arkady kholodenko,CH-3310,2015
-CH,3320,1,Physical Chemistry,0.26,0.32,0.32,0.05,0.0,0.0,0.0,0.05,arkady kholodenko,CH-3320,2015
-CH,3390,1,Physical Chem Lab,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,christopher wilson,CH-3390,2015
-CH,3390,4,Physical Chem Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,CH-3390,2015
-CH,4010,1,Organometallic Chemistry,0.53,0.35,0.12,0.0,0.0,0.0,0.0,0.0,andrew gre tennyson,CH-4010,2015
-CH,4020,1,Inorganic Chemistry,0.38,0.57,0.0,0.0,0.0,0.0,0.0,0.05,joseph kolis,CH-4020,2015
-CH,8070,1,Chem Trans Elem,0.36,0.36,0.09,0.0,0.0,0.0,0.0,0.18,julia brumaghim,CH-8070,2015
-CH,8140,1,Analytical Imaging,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,george chumanov,CH-8140,2015
-CH,8160,1,Separation Science,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,richard marcus,CH-8160,2015
-CH,8210,1,Organic Chem I,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07, karl dieter,CH-8210,2015
-CH,8300,1,Fund Phys Chem,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,CH-8300,2015
-CH,8380,1,Computational Chem,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,CH-8380,2015
-CH,8510,1,Grad Student Seminar,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,joseph stu thrasher,CH-8510,2015
-CH,8510,2,Grad Student Seminar,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,steven stuart,CH-8510,2015
-CHE,2110,1,Intro to Chem Eng,0.19,0.27,0.27,0.03,0.16,0.0,0.0,0.07,rachel getman,CHE-2110,2015
-CHE,2110,2,Intro to Chem Eng,0.27,0.37,0.19,0.01,0.1,0.0,0.0,0.04,rachel getman,CHE-2110,2015
-CHE,3070,1,Unit Ops Lab I,0.11,0.74,0.13,0.02,0.0,0.0,0.0,0.0,christopher norfolk,CHE-3070,2015
-CHE,3190,1,Engr Materials,0.16,0.38,0.25,0.12,0.08,0.0,0.0,0.0,amod ogale,CHE-3190,2015
-CHE,4070,1,Unit Op Lab II,0.22,0.64,0.15,0.0,0.0,0.0,0.0,0.0,christopher norfolk,CHE-4070,2015
-CHE,4310,1,Process Design I,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4310,2015
-CHE,4450,1,Green Engineering,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,christophe kitchens,CHE-4450,2015
-CHE,4500,1,Chem Reaction Engr,0.25,0.32,0.32,0.1,0.0,0.0,0.0,0.0,mark alan blenner,CHE-4500,2015
-CHE,4990,14,CI-  Membrane Separations,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott husson,CHE-4990,2015
-CHE,8030,1,Advanced Transport,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,douglas hirt,CHE-8030,2015
-CHE,8040,1,Ch E Thermodynamics,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,sapna sarupria,CHE-8040,2015
-CHE,8050,1,Ch E Kinetics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mark roberts,CHE-8050,2015
-CHIN,1010,1,Elementary Chinese,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,yanlin wang,CHIN-1010,2015
-CHIN,1010,2,Elementary Chinese,0.57,0.14,0.14,0.0,0.07,0.0,0.0,0.07,yanlin wang,CHIN-1010,2015
-CHIN,1020,1,Elementary Chinese,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,su- chen,CHIN-1020,2015
-CHIN,4010,1,Pre-Modern Chinese Literature,0.58,0.21,0.16,0.0,0.05,0.0,0.0,0.0,yanming an,CHIN-4010,2015
-COM,1500,1,Intro to Human Communication,0.63,0.27,0.05,0.01,0.02,0.0,0.0,0.01,eddie smith,COM-1500,2015
-COM,1500,2,Intro to Human Communication,0.58,0.34,0.04,0.01,0.02,0.0,0.0,0.01,daniel lelan fecher,COM-1500,2015
-COM,1500,3,Intro to Human Communication,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,eddie smith,COM-1500,2015
-COM,1500,4,Intro to Human Communication,0.63,0.27,0.05,0.01,0.04,0.0,0.0,0.01,marianne her glaser,COM-1500,2015
-COM,1500,5,Intro to Human Communication,0.61,0.35,0.03,0.0,0.01,0.0,0.0,0.0,marianne her glaser,COM-1500,2015
-COM,1500,6,Intro to Human Communication,0.65,0.29,0.03,0.02,0.01,0.0,0.0,0.0,marianne her glaser,COM-1500,2015
-COM,1500,7,Intro to Human Communication,0.55,0.35,0.05,0.0,0.01,0.0,0.0,0.04,daniel lelan fecher,COM-1500,2015
-COM,2010,1,Intr to Comm Studies,0.56,0.36,0.04,0.0,0.04,0.0,0.0,0.0,karyn jones,COM-2010,2015
-COM,2010,2,Intr to Comm Studies,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-2010,2015
-COM,2500,1,Public Speaking,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2015
-COM,2500,2,Public Speaking,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2015
-COM,2500,3,Public Speaking,0.28,0.5,0.11,0.0,0.11,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2015
-COM,2500,4,Public Speaking,0.74,0.05,0.05,0.0,0.16,0.0,0.0,0.0,brandon boatwright,COM-2500,2015
-COM,2500,5,Public Speaking,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,brandon boatwright,COM-2500,2015
-COM,2500,6,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2015
-COM,2500,7,Public Speaking,0.21,0.53,0.21,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2015
-COM,2500,8,Public Speaking,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2015
-COM,2500,9,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,COM-2500,2015
-COM,2500,10,Public Speaking,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2015
-COM,2500,11,Public Speaking,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,COM-2500,2015
-COM,2500,12,Public Speaking,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2015
-COM,2500,13,Public Speaking,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,pauline matthey,COM-2500,2015
-COM,2500,14,Public Speaking,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07,pauline matthey,COM-2500,2015
-COM,2500,15,Public Speaking,0.83,0.06,0.11,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2015
-COM,2500,16,Public Speaking,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2015
-COM,2500,17,Public Speaking,0.71,0.18,0.06,0.0,0.0,0.0,0.0,0.06,the estate  geddes,COM-2500,2015
-COM,2500,18,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2015
-COM,2500,19,Public Speaking,0.47,0.37,0.0,0.0,0.05,0.0,0.0,0.11,jumah patrici taweh,COM-2500,2015
-COM,2500,20,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2015
-COM,2500,21,Public Speaking,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-2500,2015
-COM,2500,22,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2015
-COM,2500,23,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,COM-2500,2015
-COM,2500,24,Public Speaking,0.61,0.22,0.0,0.0,0.0,0.0,0.0,0.17,jumah patrici taweh,COM-2500,2015
-COM,2500,28,Public Speaking,0.35,0.35,0.12,0.0,0.12,0.0,0.0,0.06,sara grumbl crocker,COM-2500,2015
-COM,2500,29,Public Speaking,0.47,0.32,0.16,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2015
-COM,2500,30,Public Speaking,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2015
-COM,2500,31,Public Speaking,0.42,0.26,0.26,0.05,0.0,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2015
-COM,2500,32,Public Speaking,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,vanessa anne condon,COM-2500,2015
-COM,2500,33,Public Speaking,0.68,0.11,0.11,0.0,0.11,0.0,0.0,0.0,vanessa anne condon,COM-2500,2015
-COM,2500,34,Public Speaking,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,vanessa anne condon,COM-2500,2015
-COM,2500,35,Public Speaking,0.54,0.23,0.0,0.0,0.15,0.0,0.0,0.08,vanessa anne condon,COM-2500,2015
-COM,2500,400,Public Speaking,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,COM-2500,2015
-COM,2500,403,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,COM-2500,2015
-COM,3010,1,Comm Theory,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-3010,2015
-COM,3020,1,Mass Comm Theory,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3020,2015
-COM,3050,1,Persuasion,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-3050,2015
-COM,3050,2,Persuasion,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,COM-3050,2015
-COM,3100,1,Quant Comm Methods,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3100,2015
-COM,3110,1,Qual Comm Methods,0.53,0.21,0.21,0.0,0.0,0.0,0.0,0.05,chenjerai kumanyika,COM-3110,2015
-COM,3240,1,"Communication, Sport & Society",0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,john steven spinda,COM-3240,2015
-COM,3260,1,Pr in Sports,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2015
-COM,3480,1,Interpersonal Comm,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,melinda ra weathers,COM-3480,2015
-COM,3550,1,Principles of Public Relations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3550,2015
-COM,3550,2,Principles of Public Relations,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,andrew stephen pyle,COM-3550,2015
-COM,3660,1,Special Topics in Comm,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,william reynolds,COM-3660,2015
-COM,3660,6,Special Topics in Comm,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,angela pratt,COM-3660,2015
-COM,4040,1,Media Comm & Social Identities,0.3,0.47,0.13,0.03,0.0,0.0,0.0,0.07,chenjerai kumanyika,COM-4040,2015
-COM,4250,1,Adv Sports Comm,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-4250,2015
-COM,4300,1,Legal Communication,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,james isaac roberts,COM-4300,2015
-COM,4700,1,Comm & Health,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4700,2015
-COM,4800,1,Intercultural Comm,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,melinda ra weathers,COM-4800,2015
-COM,4950,1,Senior Capstone Seminar,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4950,2015
-COM,4950,2,Senior Capstone Seminar,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,john steven spinda,COM-4950,2015
-COM,8100,1,Comm Research Methods I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,COM-8100,2015
-CPSC,1010,1,Computer Science I,0.48,0.22,0.11,0.11,0.07,0.0,0.0,0.02,yvon feaster,CPSC-1010,2015
-CPSC,1010,2,Computer Science I,0.35,0.33,0.07,0.14,0.07,0.0,0.0,0.05,yvon feaster,CPSC-1010,2015
-CPSC,1010,3,Computer Science I,0.27,0.23,0.16,0.09,0.11,0.0,0.0,0.14,christopher plaue,CPSC-1010,2015
-CPSC,1010,4,Computer Science I,0.15,0.2,0.24,0.07,0.12,0.0,0.0,0.22,pradip srimani,CPSC-1010,2015
-CPSC,1020,1,Computer Science II,0.3,0.32,0.07,0.03,0.15,0.0,0.0,0.13,catherine hochrine,CPSC-1020,2015
-CPSC,1040,1,Intro Computer Prog,0.15,0.19,0.46,0.12,0.0,0.04,0.0,0.04,roy pargas,CPSC-1040,2015
-CPSC,1110,1,Intro to Programming in C,0.59,0.1,0.07,0.05,0.12,0.0,0.0,0.07,catherine hochrine,CPSC-1110,2015
-CPSC,1110,2,Intro to Programming in C,0.6,0.15,0.08,0.04,0.04,0.0,0.0,0.08,catherine hochrine,CPSC-1110,2015
-CPSC,1110,3,Intro to Programming in C,0.65,0.23,0.08,0.0,0.04,0.0,0.0,0.0,wanda moses,CPSC-1110,2015
-CPSC,1110,4,Intro to Programming in C,0.7,0.13,0.05,0.0,0.05,0.0,0.0,0.08,wanda moses,CPSC-1110,2015
-CPSC,2070,1,Discrete Structures,0.2,0.37,0.16,0.12,0.09,0.0,0.0,0.05,larry hodges,CPSC-2070,2015
-CPSC,2100,1,Progrmng Methodology,0.32,0.21,0.08,0.03,0.29,0.0,0.0,0.08,timothy davis,CPSC-2100,2015
-CPSC,2100,2,Progrmng Methodology,0.47,0.28,0.09,0.13,0.03,0.0,0.0,0.0,rose lowe,CPSC-2100,2015
-CPSC,2120,1,Algs/Data Structures,0.31,0.24,0.23,0.02,0.12,0.0,0.0,0.08,brian christop dean,CPSC-2120,2015
-CPSC,2150,1,Software Dev Fndtns,0.24,0.27,0.22,0.12,0.12,0.0,0.0,0.04,blair madiso durkee,CPSC-2150,2015
-CPSC,2150,2,Software Dev Fndtns,0.5,0.23,0.17,0.0,0.1,0.0,0.0,0.0,yvon feaster,CPSC-2150,2015
-CPSC,2200,1,Microcomputer Appl,0.41,0.24,0.12,0.06,0.12,0.0,0.0,0.06,renee lambert,CPSC-2200,2015
-CPSC,2200,2,Microcomputer Appl,0.4,0.3,0.15,0.0,0.05,0.0,0.0,0.1,renee lambert,CPSC-2200,2015
-CPSC,2310,1,Intro Computer Org,0.49,0.31,0.13,0.08,0.0,0.0,0.0,0.0,rose lowe,CPSC-2310,2015
-CPSC,2310,2,Intro Computer Org,0.36,0.21,0.21,0.07,0.07,0.0,0.0,0.07,rose lowe,CPSC-2310,2015
-CPSC,2910,2,Prof Issues I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james jones,CPSC-2910,2015
-CPSC,2910,5,Prof Issues I,0.25,0.33,0.08,0.08,0.0,0.0,0.0,0.25,renee lambert,CPSC-2910,2015
-CPSC,2910,6,Prof Issues I,0.6,0.1,0.0,0.1,0.0,0.0,0.0,0.2,renee lambert,CPSC-2910,2015
-CPSC,2910,7,Prof Issues I,0.53,0.07,0.07,0.13,0.07,0.0,0.0,0.13,renee lambert,CPSC-2910,2015
-CPSC,3220,1,Intro to Operating Systems,0.13,0.31,0.23,0.08,0.12,0.0,0.0,0.13,jacob sorber,CPSC-3220,2015
-CPSC,3300,1,Computer Systems Org,0.14,0.22,0.38,0.12,0.12,0.0,0.0,0.01,mark smotherman,CPSC-3300,2015
-CPSC,3500,1,Foundations of Computer Sci,0.25,0.13,0.38,0.0,0.15,0.0,0.0,0.1,ilya mark safro,CPSC-3500,2015
-CPSC,3520,1,Programming Systems,0.36,0.26,0.17,0.0,0.14,0.0,0.0,0.07,robert schalkoff,CPSC-3520,2015
-CPSC,3600,1,Network Programming,0.16,0.3,0.39,0.09,0.05,0.0,0.0,0.02,sekou lionel remy,CPSC-3600,2015
-CPSC,3600,2,Network Programming,0.4,0.43,0.1,0.0,0.08,0.0,0.0,0.0,kevin mckenzie,CPSC-3600,2015
-CPSC,3620,1,Distributed/Cluster Computing,0.28,0.5,0.15,0.03,0.0,0.0,0.0,0.05,linh bao ngo,CPSC-3620,2015
-CPSC,3720,1,Software Engineering,0.34,0.41,0.22,0.0,0.03,0.0,0.0,0.0,murali sitaraman,CPSC-3720,2015
-CPSC,3720,2,Software Engineering,0.28,0.33,0.28,0.03,0.03,0.0,0.0,0.06,stephen schaub,CPSC-3720,2015
-CPSC,3990,4,Adv Creative Inquiry Computing,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,james martin,CPSC-3990,2015
-CPSC,3990,10,Adv CI:Google Glass,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,roy pargas,CPSC-3990,2015
-CPSC,4040,1,Cmptr Graphics Image,0.47,0.32,0.16,0.05,0.0,0.0,0.0,0.0,joshua levine,CPSC-4040,2015
-CPSC,4110,1,Virtual Reality Systems,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,sabarish venka babu,CPSC-4110,2015
-CPSC,4200,1,Computer Security Principles,0.59,0.28,0.14,0.0,0.0,0.0,0.0,0.0,hongxin hu,CPSC-4200,2015
-CPSC,4620,1,Database Management Systems,0.12,0.27,0.18,0.15,0.12,0.0,0.0,0.15,pradip srimani,CPSC-4620,2015
-CPSC,4780,1,Gen Purpose Computation on GPU,0.27,0.36,0.18,0.09,0.09,0.0,0.0,0.0,robert geist,CPSC-4780,2015
-CPSC,4810,16,Sel Top:Programming Team,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,brian christop dean,CPSC-4810,2015
-CPSC,4820,1,Spec Top:Embedded Systems,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,jacob sorber,CPSC-4820,2015
-CPSC,4820,3,Spec Top:Mobile Device Sftware,0.61,0.17,0.11,0.0,0.06,0.0,0.0,0.06,roy pargas,CPSC-4820,2015
-CPSC,4910,1,Professional Issues II,0.96,0.0,0.01,0.0,0.01,0.0,0.0,0.01,james jones,CPSC-4910,2015
-CPSC,6040,1,Cptr Graphics Image,0.5,0.11,0.04,0.0,0.18,0.0,0.0,0.18,joshua levine,CPSC-6040,2015
-CPSC,6110,1,Virtual Reality Systems,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,CPSC-6110,2015
-CPSC,6620,1,Database Management Systems,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,pradip srimani,CPSC-6620,2015
-CPSC,6780,1,Gen Purpose Computation on GPU,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,CPSC-6780,2015
-CPSC,8040,1,Data Visualization,0.5,0.3,0.1,0.0,0.05,0.0,0.0,0.05,joshua levine,CPSC-8040,2015
-CPSC,8070,1,3d Model Animation,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,christina sop joerg,CPSC-8070,2015
-CPSC,8100,1,Intro Artif Intell,0.18,0.71,0.11,0.0,0.0,0.0,0.0,0.0,feng luo,CPSC-8100,2015
-CPSC,8150,1,Fx Compositing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,CPSC-8150,2015
-CPSC,8170,1,Physically Based Animation,0.62,0.27,0.08,0.0,0.0,0.0,0.0,0.04,donald henry house,CPSC-8170,2015
-CPSC,8390,1,Theoretical Cp Sci Foundations,0.31,0.61,0.06,0.0,0.0,0.0,0.0,0.02,wayne goddard,CPSC-8390,2015
-CPSC,8480,1,Network Science,0.44,0.11,0.44,0.0,0.0,0.0,0.0,0.0,ilya mark safro,CPSC-8480,2015
-CPSC,8520,1,Internetworking,0.4,0.33,0.27,0.0,0.0,0.0,0.0,0.0,james martin,CPSC-8520,2015
-CPSC,8700,1,O O Software Design,0.46,0.33,0.14,0.0,0.03,0.0,0.0,0.03,brian malloy,CPSC-8700,2015
-CPSC,8710,1,Found. of Software Engineering,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,CPSC-8710,2015
-CPSC,8730,1,"Software Verif, Valid & Measur",0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,CPSC-8730,2015
-CPSC,8810,3,Selected Topics: Visual Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,CPSC-8810,2015
-CRP,8000,1,Human Settlement,0.56,0.34,0.05,0.0,0.0,0.0,0.0,0.05,john terrenc farris,CRP-8000,2015
-CRP,8010,1,Planning Process & Legal Found,0.38,0.38,0.1,0.1,0.0,0.0,0.0,0.05,caitlin dyckman,CRP-8010,2015
-CRP,8020,1,Site Planning,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,CRP-8020,2015
-CRP,8030,1,Quant Analysis,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,CRP-8030,2015
-CRP,8060,1,Urban & Reg Econ for Planners,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,timothy green,CRP-8060,2015
-CRP,8340,1,Spatial Modeling/Gis,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,stephen sperry,CRP-8340,2015
-CRP,8580,2,Research Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,timothy green,CRP-8580,2015
-CSM,1000,1,Intro to Construct,0.41,0.47,0.11,0.02,0.0,0.0,0.0,0.0,joseph wintz,CSM-1000,2015
-CSM,2010,1,Structures I,0.3,0.33,0.26,0.11,0.0,0.0,0.0,0.0,shima clarke,CSM-2010,2015
-CSM,2010,2,Structures I,0.5,0.19,0.19,0.12,0.0,0.0,0.0,0.0,shima clarke,CSM-2010,2015
-CSM,2030,1,Mats & Meth of Const,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-2030,2015
-CSM,2030,2,Mats & Meth of Const,0.22,0.63,0.15,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-2030,2015
-CSM,3030,1,Soils & Foundations,0.08,0.63,0.29,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-3030,2015
-CSM,3030,2,Soils & Foundations,0.12,0.69,0.19,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-3030,2015
-CSM,3040,1,Envir Systems I,0.42,0.42,0.12,0.0,0.04,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2015
-CSM,3040,2,Envir Systems I,0.13,0.67,0.21,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2015
-CSM,3510,1,Const Estimating,0.19,0.69,0.08,0.04,0.0,0.0,0.0,0.0,james packer smith,CSM-3510,2015
-CSM,3510,2,Const Estimating,0.11,0.48,0.26,0.15,0.0,0.0,0.0,0.0,james packer smith,CSM-3510,2015
-CSM,4110,1,Safety in Bldg Const,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,david devita,CSM-4110,2015
-CSM,4500,1,Construction Intern,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-4500,2015
-CSM,4530,1,Const Proj Mgmt,0.19,0.67,0.14,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-4530,2015
-CSM,4530,2,Const Proj Mgmt,0.11,0.72,0.17,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-4530,2015
-CSM,4610,1,Const Econ Seminar,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4610,2015
-CSM,4610,2,Const Econ Seminar,0.05,0.76,0.19,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4610,2015
-CSM,8640,1,Construction Bus Strat & Mktg,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,christine piper,CSM-8640,2015
-CSM,8650,1,Project Management,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8650,2015
-CSM,8650,400,Project Management,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8650,2015
-CSM,8660,1,Role in Development,0.31,0.63,0.0,0.0,0.0,0.0,0.0,0.06,dennis bausman,CSM-8660,2015
-CSM,8900,401,Directed Studies,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-8900,2015
-CSM,8900,402,Directed Studies,0.57,0.14,0.14,0.0,0.14,0.0,0.0,0.0,jason lucas,CSM-8900,2015
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,susan whorton,CU-1000,2015
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.88,0.12,0.01,susan whorton,CU-1000,2015
-CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.02,susan whorton,CU-1000,2015
-CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.73,0.26,0.01,susan whorton,CU-1000,2015
-CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,CU-1000,2015
-CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,CU-1000,2015
-CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,CU-1000,2015
-CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.05,0.01,susan whorton,CU-1000,2015
-CU,1000,9,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.01,susan whorton,CU-1000,2015
-CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.08,0.01,susan whorton,CU-1000,2015
-CU,1000,11,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,susan whorton,CU-1000,2015
-CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,susan whorton,CU-1000,2015
-CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.88,0.11,0.02,susan whorton,CU-1000,2015
-CU,1010,1,Univ Success Skills,0.5,0.19,0.06,0.0,0.13,0.0,0.0,0.13,emma reynol reabold,CU-1010,2015
-CU,1010,2,Univ Success Skills,0.45,0.14,0.32,0.05,0.05,0.0,0.0,0.0,cari allyn brooks,CU-1010,2015
-CU,1010,3,Univ Success Skills,0.32,0.32,0.16,0.04,0.08,0.0,0.0,0.08,matthew james kirk,CU-1010,2015
-CU,1010,5,Univ Success Skills,0.55,0.18,0.0,0.09,0.18,0.0,0.0,0.0,ashley crisp,CU-1010,2015
-CU,1010,6,Univ Success Skills,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,amber allen mulkey,CU-1010,2015
-CU,1010,7,Univ Success Skills,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,amber allen mulkey,CU-1010,2015
-CU,1110,3,Intro Supplemental Instruction,0.0,0.0,0.0,0.0,0.0,0.88,0.06,0.06,laurel ann whisler,CU-1110,2015
-CU,1400,1,The Entrepreneurial Mindset,0.76,0.17,0.05,0.01,0.0,0.0,0.0,0.02,john michael hannon,CU-1400,2015
-CU,2010,1,Sustainability Leadership,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,leidy klotz,CU-2010,2015
-CVT,2260,1,Intro Cardiovas Sono,0.2,0.6,0.13,0.0,0.0,0.0,0.0,0.07,eric walker,CVT-2260,2015
-DANC,3300,1,University Dance Company,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,cheryl hosler,DANC-3300,2015
-DPA,4000,1,Tech Foundations I,0.65,0.06,0.06,0.0,0.0,0.0,0.0,0.24,brian malloy,DPA-4000,2015
-DPA,8600,1,Production Studio,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,DPA-8600,2015
-ECE,2010,1,Logic and Computing Devices,0.2,0.35,0.24,0.05,0.13,0.0,0.0,0.03,william reid,ECE-2010,2015
-ECE,2010,2,Logic & Comp Device (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william reid,ECE-2010,2015
-ECE,2020,1,Electric Circuits I,0.29,0.27,0.24,0.04,0.1,0.0,0.0,0.06,william harrell,ECE-2020,2015
-ECE,2020,2,Electric Circuits I (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2020,2015
-ECE,2020,3,Electric Circuits I,0.21,0.17,0.3,0.12,0.16,0.0,0.0,0.03,daniel bla cutshall,ECE-2020,2015
-ECE,2070,1,Basic Electrical Engineering,0.14,0.31,0.33,0.12,0.03,0.0,0.0,0.07,william th kolodzey,ECE-2070,2015
-ECE,2070,2,Basic Electrical Engineering,0.45,0.25,0.13,0.05,0.05,0.0,0.0,0.08,oleg viktorov sivov,ECE-2070,2015
-ECE,2070,3,Basic Electrical Engineering,0.33,0.35,0.16,0.1,0.04,0.0,0.0,0.02,amir ahmed asif,ECE-2070,2015
-ECE,2080,7,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,ECE-2080,2015
-ECE,2080,9,Electrical Engineering Lab I,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,ECE-2080,2015
-ECE,2080,10,Electrical Engineering Lab I,0.65,0.05,0.0,0.0,0.1,0.0,0.0,0.2,apoorva dee kapadia,ECE-2080,2015
-ECE,2080,13,Electrical Engineering Lab I,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,apoorva dee kapadia,ECE-2080,2015
-ECE,2090,1,Logic Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2015
-ECE,2090,9,Logic Lab,0.82,0.0,0.0,0.0,0.18,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2015
-ECE,2090,10,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva dee kapadia,ECE-2090,2015
-ECE,2090,11,Logic Lab,0.83,0.0,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2015
-ECE,2090,13,Logic Lab,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,apoorva dee kapadia,ECE-2090,2015
-ECE,2110,6,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,ECE-2110,2015
-ECE,2110,8,Elec Engr Lab I,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2110,2015
-ECE,2110,9,Elec Engr Lab I,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,apoorva dee kapadia,ECE-2110,2015
-ECE,2220,1,Syst Prog Concept,0.12,0.27,0.22,0.1,0.1,0.0,0.0,0.2,harlan russell,ECE-2220,2015
-ECE,2230,1,Comp Sys Eng,0.18,0.25,0.2,0.11,0.14,0.0,0.0,0.11,harlan russell,ECE-2230,2015
-ECE,2620,1,Electric Circuits II,0.59,0.15,0.1,0.03,0.03,0.0,0.0,0.1,liang dong,ECE-2620,2015
-ECE,2720,1,Comp Organization,0.19,0.29,0.33,0.05,0.1,0.0,0.0,0.05,william reid,ECE-2720,2015
-ECE,2730,2,Computer Org Lab,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-2730,2015
-ECE,2730,3,Computer Org Lab,0.57,0.14,0.21,0.0,0.07,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2015
-ECE,3110,2,Electrical Engineering Lab III,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,ECE-3110,2015
-ECE,3110,4,Electrical Engineering Lab III,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2015
-ECE,3110,6,Electrical Engineering Lab III,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,apoorva dee kapadia,ECE-3110,2015
-ECE,3110,7,Electrical Engineering Lab III,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,ECE-3110,2015
-ECE,3120,2,Electrical Engineering Lab IV,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3120,2015
-ECE,3170,1,Rand Signal Analysis,0.23,0.23,0.25,0.14,0.11,0.0,0.0,0.05,stephen hubbard,ECE-3170,2015
-ECE,3200,1,Electronics I,0.25,0.18,0.18,0.18,0.22,0.0,0.0,0.0,stephen hubbard,ECE-3200,2015
-ECE,3210,1,Electronics II,0.37,0.32,0.2,0.1,0.02,0.0,0.0,0.0,stephen hubbard,ECE-3210,2015
-ECE,3220,1,Intro Operating Sys,0.25,0.35,0.15,0.15,0.1,0.0,0.0,0.0,jacob sorber,ECE-3220,2015
-ECE,3270,1,Dig Comp Design,0.15,0.15,0.2,0.15,0.13,0.0,0.0,0.23,melissa crawl smith,ECE-3270,2015
-ECE,3300,1,Signals & Systems,0.14,0.23,0.26,0.17,0.06,0.0,0.0,0.15,carl baum,ECE-3300,2015
-ECE,3300,2,Signals & Systems (HON),0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,daniel noneaker,ECE-3300,2015
-ECE,3520,1,Programming Systems,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,robert schalkoff,ECE-3520,2015
-ECE,3600,1,Elect Power Engr,0.31,0.3,0.28,0.02,0.02,0.0,0.0,0.08,edward collins,ECE-3600,2015
-ECE,3710,1,Microcontr Interface,0.38,0.34,0.21,0.06,0.0,0.0,0.0,0.01,william reid,ECE-3710,2015
-ECE,3720,1,Micro Int Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2015
-ECE,3720,3,Micro Int Lab,0.75,0.17,0.0,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2015
-ECE,3720,6,Micro Int Lab,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2015
-ECE,3800,1,Electromagnetics,0.3,0.2,0.18,0.13,0.15,0.0,0.0,0.05,anthony martin,ECE-3800,2015
-ECE,3810,1,Field Waves & Ckts,0.45,0.21,0.24,0.07,0.02,0.0,0.0,0.0,anthony martin,ECE-3810,2015
-ECE,4040,1,Semiconductor Devices,0.25,0.44,0.25,0.0,0.06,0.0,0.0,0.0,william harrell,ECE-4040,2015
-ECE,4090,1,Cont & Discrete Sys,0.4,0.37,0.15,0.03,0.03,0.0,0.0,0.01,apoorva dee kapadia,ECE-4090,2015
-ECE,4120,1,Elect Mach Lab,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,elham makram,ECE-4120,2015
-ECE,4180,1,Power Syst Analysis,0.31,0.12,0.27,0.15,0.08,0.0,0.0,0.08,elham makram,ECE-4180,2015
-ECE,4270,1,Communications Sys,0.31,0.22,0.22,0.17,0.08,0.0,0.0,0.0,madhabi manandhar,ECE-4270,2015
-ECE,4290,1,Organiz of Compu,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,hai ying shen,ECE-4290,2015
-ECE,4350,1,Grounding/Shielding,0.43,0.29,0.07,0.14,0.0,0.0,0.0,0.07,todd hubing,ECE-4350,2015
-ECE,4420,1,Knowledge Engr,0.37,0.32,0.11,0.05,0.05,0.0,0.0,0.11,robert schalkoff,ECE-4420,2015
-ECE,4490,1,Comp Ntwrk Security,0.35,0.3,0.05,0.0,0.0,0.0,0.0,0.3,richard brooks,ECE-4490,2015
-ECE,4610,1,Fundamentals of Solar Energy,0.63,0.25,0.07,0.05,0.0,0.0,0.0,0.0,rajendra singh,ECE-4610,2015
-ECE,4730,1,Intro Parallel Sys,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,walter ligon,ECE-4730,2015
-ECE,4950,1,Int Sys Design I,0.74,0.23,0.04,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-4950,2015
-ECE,4960,1,Int Sys Design II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2015
-ECE,6040,1,Semiconductor Devices,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-6040,2015
-ECE,6350,1,Grounding/Shielding,0.6,0.2,0.1,0.0,0.1,0.0,0.0,0.0,todd hubing,ECE-6350,2015
-ECE,6420,1,Knowledge Engr,0.26,0.63,0.05,0.0,0.05,0.0,0.0,0.0,robert schalkoff,ECE-6420,2015
-ECE,6490,1,Comp Ntwrk Security,0.88,0.0,0.12,0.0,0.0,0.0,0.0,0.0,richard brooks,ECE-6490,2015
-ECE,6610,1,Fundamentals of Solar Energy,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,rajendra singh,ECE-6610,2015
-ECE,6930,1,Intro to Computer Vision,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,ECE-6930,2015
-ECE,6930,3,Power Electronics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,keith corzine,ECE-6930,2015
-ECE,8010,1,Analysis of Lin Sys,0.32,0.5,0.11,0.02,0.02,0.0,0.0,0.02,richard groff,ECE-8010,2015
-ECE,8190,1,Detection & Estimation Theory,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,carl baum,ECE-8190,2015
-ECE,8470,400,Digital Image Proc,0.87,0.11,0.03,0.0,0.0,0.0,0.0,0.0,stanley birchfield,ECE-8470,2015
-ECE,8540,1,Analysis of Tracking Systems,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,adam hoover,ECE-8540,2015
-ECE,8750,1,Peer to Peer Wireless & Cloud,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,hai ying shen,ECE-8750,2015
-ECE,9910,32,Doctoral Dissertation Research,0.0,0.0,0.0,0.0,0.0,0.86,0.14,0.0,hai ying shen,ECE-9910,2015
-ECON,2000,1,Economic Concepts,0.31,0.38,0.27,0.04,0.0,0.0,0.0,0.0,mallika garg,ECON-2000,2015
-ECON,2000,2,Economic Concepts,0.32,0.29,0.24,0.03,0.0,0.0,0.0,0.12,mallika garg,ECON-2000,2015
-ECON,2000,3,Economic Concepts,0.31,0.34,0.1,0.17,0.0,0.0,0.0,0.07,miren ivankovic,ECON-2000,2015
-ECON,2110,1,Principles of Microeconomics,0.16,0.32,0.37,0.0,0.11,0.0,0.0,0.05,frederick hanssen,ECON-2110,2015
-ECON,2110,2,Principles of Microeconomics,0.16,0.21,0.47,0.05,0.05,0.0,0.0,0.05,frederick hanssen,ECON-2110,2015
-ECON,2110,3,Principles of Microeconomics,0.05,0.37,0.42,0.05,0.11,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,4,Principles of Microeconomics,0.1,0.5,0.2,0.05,0.15,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,5,Principles of Microeconomics,0.16,0.37,0.26,0.0,0.16,0.0,0.0,0.05,frederick hanssen,ECON-2110,2015
-ECON,2110,6,Principles of Microeconomics,0.18,0.47,0.24,0.06,0.0,0.0,0.0,0.06,frederick hanssen,ECON-2110,2015
-ECON,2110,7,Principles of Microeconomics,0.05,0.42,0.21,0.21,0.0,0.0,0.0,0.11,frederick hanssen,ECON-2110,2015
-ECON,2110,8,Principles of Microeconomics,0.11,0.47,0.26,0.11,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,9,Principles of Microeconomics,0.16,0.26,0.47,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,10,Principles of Microeconomics,0.0,0.37,0.42,0.0,0.11,0.0,0.0,0.11,frederick hanssen,ECON-2110,2015
-ECON,2110,11,Principles of Microeconomics,0.33,0.39,0.22,0.06,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,12,Principles of Microeconomics,0.05,0.53,0.21,0.11,0.0,0.0,0.0,0.11,frederick hanssen,ECON-2110,2015
-ECON,2110,13,Principles of Microeconomics,0.06,0.28,0.56,0.0,0.06,0.0,0.0,0.06,frederick hanssen,ECON-2110,2015
-ECON,2110,14,Principles of Microeconomics,0.37,0.32,0.21,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,15,Principles of Microeconomics,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,16,Principles of Microeconomics,0.22,0.28,0.28,0.06,0.0,0.0,0.0,0.17,frederick hanssen,ECON-2110,2015
-ECON,2110,17,Principles of Microeconomics,0.21,0.53,0.16,0.05,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,18,Principles of Microeconomics,0.17,0.39,0.22,0.11,0.11,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,19,Principles of Microeconomics,0.11,0.53,0.32,0.05,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2015
-ECON,2110,20,Principles of Microeconomics,0.24,0.27,0.25,0.13,0.08,0.0,0.0,0.03,timothy jay bacon,ECON-2110,2015
-ECON,2110,21,Principles of Microeconomics,0.21,0.48,0.29,0.02,0.0,0.0,0.0,0.0,michael makowsky,ECON-2110,2015
-ECON,2110,22,Principles of Microeconomics,0.23,0.43,0.23,0.07,0.0,0.0,0.0,0.05,richard alan sessa,ECON-2110,2015
-ECON,2110,23,Principles of Microeconomics,0.18,0.45,0.3,0.04,0.0,0.0,0.0,0.03,alexander fiore,ECON-2110,2015
-ECON,2110,24,Principles of Microeconomics,0.32,0.33,0.21,0.07,0.02,0.0,0.0,0.03,leah jacq kitashima,ECON-2110,2015
-ECON,2110,25,Principles of Microeconomics,0.28,0.33,0.23,0.08,0.03,0.0,0.0,0.08,charles thomas,ECON-2110,2015
-ECON,2110,26,Principles of Microeconomics,0.29,0.39,0.18,0.05,0.08,0.0,0.0,0.0,jonathan orr ernest,ECON-2110,2015
-ECON,2110,31,Principles of Microeconomics,0.2,0.59,0.21,0.01,0.0,0.0,0.0,0.0,alexander fiore,ECON-2110,2015
-ECON,2110,32,Principles of Microeconomics,0.38,0.24,0.14,0.1,0.0,0.0,0.0,0.14,maria droganova,ECON-2110,2015
-ECON,2110,33,Principles of Microeconomics,0.21,0.29,0.32,0.13,0.03,0.0,0.0,0.03,charles thomas,ECON-2110,2015
-ECON,2110,34,Principles of Microeconomics,0.26,0.28,0.28,0.1,0.03,0.0,0.0,0.05,benjamin jo schwall,ECON-2110,2015
-ECON,2110,35,Principles of Microeconomics,0.34,0.34,0.23,0.03,0.03,0.0,0.0,0.03,maria droganova,ECON-2110,2015
-ECON,2110,38,Principles of Microeconomics,0.36,0.48,0.1,0.0,0.05,0.0,0.0,0.02,amanda caitlin kerr,ECON-2110,2015
-ECON,2110,40,Principles of Micro (HON),0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert kennet fleck,ECON-2110,2015
-ECON,2110,41,Principles of Microeconomics,0.15,0.45,0.2,0.15,0.05,0.0,0.0,0.0,ce castellon chicas,ECON-2110,2015
-ECON,2120,1,Principles of Macroeconomics,0.17,0.16,0.22,0.12,0.2,0.0,0.0,0.13,ralph charles allen,ECON-2120,2015
-ECON,2120,2,Principles of Macroeconomics,0.33,0.27,0.31,0.07,0.02,0.0,0.0,0.0,peter david lorenz,ECON-2120,2015
-ECON,2120,3,Principles of Macroeconomics,0.27,0.13,0.24,0.16,0.07,0.0,0.0,0.13,ralph charles allen,ECON-2120,2015
-ECON,2120,4,Principles of Macroeconomics,0.26,0.3,0.24,0.09,0.04,0.0,0.0,0.07,andew swanson,ECON-2120,2015
-ECON,2120,5,Principles of Macroeconomics,0.29,0.29,0.23,0.17,0.0,0.0,0.0,0.03,andew swanson,ECON-2120,2015
-ECON,2120,6,Principles of Macroeconomics,0.38,0.19,0.28,0.0,0.13,0.0,0.0,0.03,peter david lorenz,ECON-2120,2015
-ECON,2120,7,Principles of Macroeconomics,0.18,0.46,0.21,0.1,0.0,0.0,0.0,0.05,chen wang,ECON-2120,2015
-ECON,2120,8,Principles of Macroeconomics,0.25,0.33,0.23,0.07,0.07,0.0,0.0,0.05,kelsey vict roberts,ECON-2120,2015
-ECON,2120,9,Principles of Macroeconomics,0.26,0.31,0.18,0.15,0.03,0.0,0.0,0.08,shan jiang,ECON-2120,2015
-ECON,2120,10,Principles of Macroeconomics,0.41,0.15,0.19,0.15,0.04,0.0,0.0,0.07,shan jiang,ECON-2120,2015
-ECON,3020,1,Money and Banking,0.16,0.2,0.32,0.16,0.04,0.0,0.0,0.12,randall scot cragun,ECON-3020,2015
-ECON,3060,1,Managerial Economics,0.33,0.28,0.13,0.08,0.1,0.0,0.0,0.08,jacob burgdorf,ECON-3060,2015
-ECON,3100,1,International Econ,0.22,0.33,0.22,0.2,0.02,0.0,0.0,0.02,michal jerzmanowski,ECON-3100,2015
-ECON,3140,1,Intermediate Micro,0.12,0.31,0.26,0.1,0.05,0.0,0.0,0.17,robert kennet fleck,ECON-3140,2015
-ECON,3140,2,Intermediate Micro,0.28,0.26,0.21,0.06,0.06,0.0,0.0,0.13,molly espey,ECON-3140,2015
-ECON,3140,3,Intermediate Micro,0.17,0.26,0.23,0.04,0.13,0.0,0.0,0.17,frederick hanssen,ECON-3140,2015
-ECON,3150,1,Intermediate Macro,0.19,0.25,0.27,0.1,0.06,0.0,0.0,0.13,randall scot cragun,ECON-3150,2015
-ECON,3150,2,Intermediate Macro,0.29,0.29,0.25,0.02,0.08,0.0,0.0,0.06,michal jerzmanowski,ECON-3150,2015
-ECON,3190,1,Environmental Econ,0.16,0.46,0.35,0.0,0.0,0.0,0.0,0.03,molly espey,ECON-3190,2015
-ECON,3600,1,Public Choice,0.38,0.38,0.2,0.0,0.0,0.0,0.0,0.05,robert dew tollison,ECON-3600,2015
-ECON,3600,2,Public Choice,0.19,0.44,0.19,0.0,0.06,0.0,0.0,0.13,robert dew tollison,ECON-3600,2015
-ECON,4010,1,Labor Mkt Analysis,0.31,0.31,0.23,0.0,0.08,0.0,0.0,0.08,chungsang lam,ECON-4010,2015
-ECON,4020,1,Law and Economics,0.41,0.36,0.14,0.02,0.07,0.0,0.0,0.0,howard ne bodenhorn,ECON-4020,2015
-ECON,4040,1,Comp Econ Systems,0.12,0.29,0.24,0.18,0.0,0.0,0.0,0.18,dar litsukova-bokar,ECON-4040,2015
-ECON,4050,1,Intro to Econometric,0.18,0.38,0.24,0.06,0.12,0.0,0.0,0.03,jaqueline oliveira,ECON-4050,2015
-ECON,4050,5,Intro to Econometric,0.23,0.27,0.35,0.08,0.04,0.0,0.0,0.04,scott barkowski,ECON-4050,2015
-ECON,4100,1,Economic Development,0.11,0.63,0.0,0.0,0.11,0.0,0.0,0.16,robert tamura,ECON-4100,2015
-ECON,4120,1,International Micro,0.37,0.32,0.27,0.02,0.0,0.0,0.0,0.02,scott baier,ECON-4120,2015
-ECON,4220,1,Monetary Economics,0.29,0.48,0.19,0.0,0.0,0.0,0.0,0.05,gerald dwyer,ECON-4220,2015
-ECON,4230,1,Economics of Health,0.43,0.17,0.26,0.09,0.0,0.0,0.0,0.04,daniel patri miller,ECON-4230,2015
-ECON,4240,1,Organization of Ind,0.3,0.2,0.4,0.0,0.05,0.0,0.0,0.05,daniel patri miller,ECON-4240,2015
-ECON,4350,1,Family Economics,0.55,0.25,0.15,0.03,0.0,0.0,0.0,0.03,jaqueline oliveira,ECON-4350,2015
-ECON,6050,1,Intro to Econometric,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jaqueline oliveira,ECON-6050,2015
-ECON,6060,1,Advanced Econometric,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,ECON-6060,2015
-ECON,6120,1,Internatiional Micro,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-6120,2015
-ECON,8010,1,Microeconomic Theory,0.43,0.21,0.21,0.0,0.07,0.0,0.0,0.07,william dougan,ECON-8010,2015
-ECON,8040,1,Applied Math Econ,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,curtis simon,ECON-8040,2015
-ECON,8060,1,Econometrics I,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,ECON-8060,2015
-ECON,8080,1,Econometrics III,0.38,0.25,0.19,0.0,0.06,0.0,0.0,0.13,paul wayne wilson,ECON-8080,2015
-ECON,8160,1,Labor Economics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,ECON-8160,2015
-ECON,8210,1,Public Choice,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,patrick warren,ECON-8210,2015
-ECON,8230,1,Microecon Pub Pol,0.4,0.45,0.15,0.0,0.0,0.0,0.0,0.0,scott templeton,ECON-8230,2015
-ECON,8240,1,Org of Industry,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,matthew lewis,ECON-8240,2015
-ECON,8260,1,Econ Theory of Govt Regulation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,thomas wins hazlett,ECON-8260,2015
-ECON,8400,1,International Trade,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,scott baier,ECON-8400,2015
-ECON,9500,2,Monetary Economics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,ECON-9500,2015
-ED,1050,2,Educ Orientation,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,william da mccorkle,ED-1050,2015
-ED,1050,5,Educ Orientation,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,william da mccorkle,ED-1050,2015
-ED,1050,6,Educ Orientation,0.68,0.16,0.05,0.05,0.0,0.0,0.0,0.05,william da mccorkle,ED-1050,2015
-ED,1050,7,Educ Orientation,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,william da mccorkle,ED-1050,2015
-ED,3970,5,Creative Inquiry in Education,0.8,0.08,0.0,0.0,0.0,0.0,0.0,0.12,david matthew boyer,ED-3970,2015
-ED,3970,12,Creative Inquiry in Education,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,joseph benedic ryan,ED-3970,2015
-ED,8380,404,Adolescent Development,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,heather rog brooker,ED-8380,2015
-ED,8380,505,Literacy Lessons for Indiv I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,ED-8380,2015
-ED,8380,510,Literacy Lessons for Indiv I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jamie felder white,ED-8380,2015
-ED,8380,511,Literacy Lessons for Indiv I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ellen adkin sanford,ED-8380,2015
-ED,8380,512,Literacy Lessons for Indiv I,0.4,0.2,0.0,0.0,0.0,0.0,0.0,0.4,kimberly fair floyd,ED-8380,2015
-ED,8380,530,Improving Literacy Outcomes fo,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,renee gatlin anders,ED-8380,2015
-ED,8670,500,Practicum in ESOL Instruction,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,margaret mar warner,ED-8670,2015
-EDC,3900,1,Skills for Stu Leads,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,mary price,EDC-3900,2015
-EDC,3900,2,Skills for Stu Leads,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,leasa ann  evinger,EDC-3900,2015
-EDC,8110,1,Multicultural Couns,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,robin phelps-ward,EDC-8110,2015
-EDC,8110,2,Multicultural Couns,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,EDC-8110,2015
-EDC,8130,1,Appraisal Procedures,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,amy sue milsom,EDC-8130,2015
-EDEC,3000,1,Found Early Chld Ed,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,EDEC-3000,2015
-EDEC,4300,1,Early Childhd Math,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,sandra mamma linder,EDEC-4300,2015
-EDEC,4400,1,Early Childhood Engl Lang Art,0.78,0.13,0.09,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-4400,2015
-EDEC,4600,1,Critical Iss/Diversity in ECE,0.91,0.04,0.0,0.04,0.0,0.0,0.0,0.0,dolores an stegelin,EDEC-4600,2015
-EDEC,8100,1,Adv Ece Found & Meth,0.56,0.11,0.22,0.11,0.0,0.0,0.0,0.0,dolores an stegelin,EDEC-8100,2015
-EDEL,3210,1,Pe for the Elem Tchr,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2015
-EDEL,3210,2,Pe for the Elem Tchr,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2015
-EDEL,4010,1,Elem Field Exp,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,ann marie liebel,EDEL-4010,2015
-EDEL,4010,2,Elem Field Exp,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ann marie liebel,EDEL-4010,2015
-EDEL,4510,1,Elem Methods in Science Tchg,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,cynthia chri deaton,EDEL-4510,2015
-EDEL,4510,2,Elem Methods in Science Tchg,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,EDEL-4510,2015
-EDEL,4870,1,Ele Meth Soc Studies,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,melinda spearman,EDEL-4870,2015
-EDEL,4870,2,Ele Meth Soc Studies,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,EDEL-4870,2015
-EDEL,4880,1,Elem Meth La Tchng,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,jacquelynn malloy,EDEL-4880,2015
-EDEL,4880,2,Elem Meth La Tchng,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,EDEL-4880,2015
-EDF,3010,1,Principles of American Educat,0.58,0.35,0.06,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,EDF-3010,2015
-EDF,3010,2,Principles of American Educat,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,EDF-3010,2015
-EDF,3020,3,Educational Psychology,0.34,0.28,0.21,0.14,0.0,0.0,0.0,0.03,penelope mar vargas,EDF-3020,2015
-EDF,3020,4,Educational Psychology,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,penelope mar vargas,EDF-3020,2015
-EDF,3080,1,Classroom Assessment,0.7,0.22,0.09,0.0,0.0,0.0,0.0,0.0,deborah switzer,EDF-3080,2015
-EDF,3080,2,Classroom Assessment,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,deborah switzer,EDF-3080,2015
-EDF,3200,1,History of US Education,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,EDF-3200,2015
-EDF,3340,1,Child Growth and Development,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,andrea emerson,EDF-3340,2015
-EDF,3340,2,Child Growth and Development,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,EDF-3340,2015
-EDF,3350,1,Adolescent Growth & Develop,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,EDF-3350,2015
-EDF,4800,1,Digital Media & Learning,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2015
-EDF,4800,2,Digital Media & Learning,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2015
-EDF,4800,3,Digital Media & Learning,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2015
-EDF,6900,400,Classroom Management,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,heather rog brooker,EDF-6900,2015
-EDF,8010,1,Human Growth and Development,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeromy blake snider,EDF-8010,2015
-EDF,8710,501,Cultural Diversity in Educatio,0.6,0.3,0.05,0.0,0.05,0.0,0.0,0.0,sus cridland-hughes,EDF-8710,2015
-EDF,9010,1,Learning Sciences Seminar I,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,david matthew boyer,EDF-9010,2015
-EDF,9270,1,Quant Rsrch & Stats for Ed,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,jennie lynn farmer,EDF-9270,2015
-EDF,9270,2,Quant Rsrch & Stats for Ed,0.67,0.17,0.0,0.08,0.0,0.0,0.0,0.08,jennie lynn farmer,EDF-9270,2015
-EDL,7000,502,Public School Adm,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,frederick buskey,EDL-7000,2015
-EDL,7300,500,Techniq of Supervision-Pub Sch,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,EDL-7300,2015
-EDL,7400,500,Curr Plan: Sch Adm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,EDL-7400,2015
-EDL,9110,400,Systematic Inq Ed L,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,EDL-9110,2015
-EDL,9250,501,Instructional Leadership,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,elizabeth reynolds,EDL-9250,2015
-EDLT,4590,1,Teaching Reading Grades K-3,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,linda gambrell,EDLT-4590,2015
-EDLT,4600,3,Teaching Reading Grades 2-6,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,EDLT-4600,2015
-EDLT,4600,5,Teaching Reading Grades 2-6,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,EDLT-4600,2015
-EDLT,4610,1,Content Area Rdg: Grades 2-6,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,pamela dunston,EDLT-4610,2015
-EDLT,4610,2,Content Area Rdg: Grades 2-6,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-4610,2015
-EDLT,4980,4,Secondary Content Area Reading,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.04,barbara everson,EDLT-4980,2015
-EDLT,8120,500,Reading-Writing Assess Strat,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8120,2015
-EDLT,8140,500,Instr & Asmnt Diverse Students,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-8140,2015
-EDLT,8270,400,Disciplinary Literacies 6-12,0.74,0.11,0.05,0.05,0.05,0.0,0.0,0.0,corrie leigh martin,EDLT-8270,2015
-EDLT,8800,502,Reading Recovery Teacher I,0.54,0.23,0.15,0.0,0.0,0.0,0.0,0.08,mary petters,EDLT-8800,2015
-EDLT,8820,502,Read Recovery Practicum I,0.38,0.38,0.15,0.0,0.0,0.0,0.0,0.08,mary petters,EDLT-8820,2015
-EDLT,9140,1,"Lang Dev, Diversity, Discourse",0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,mikel walker cole,EDLT-9140,2015
-EDSC,2260,1,Pr Apprch to Sec Alg,0.57,0.21,0.14,0.0,0.0,0.0,0.0,0.07,stacy megan che,EDSC-2260,2015
-EDSC,3240,1,Practicum Sec Engl,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,amy tali hallenbeck,EDSC-3240,2015
-EDSC,4240,1,Tchng Sec English,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,EDSC-4240,2015
-EDSC,4260,1,Tchng Sec Math,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,dennis aminie kombe,EDSC-4260,2015
-EDSC,8620,400,Methods & Strat Secondary Math,0.67,0.0,0.17,0.17,0.0,0.0,0.0,0.0,nicole alai sinwell,EDSC-8620,2015
-EDSP,3700,2,Intro to Special Education,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,EDSP-3700,2015
-EDSP,3700,3,Intro to Special Education,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,EDSP-3700,2015
-EDSP,3700,4,Intro to Special Education,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,bridget carv briley,EDSP-3700,2015
-EDSP,3720,1,Char & Instr Individ with LD,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,EDSP-3720,2015
-EDSP,4920,1,Math Inst Ind W/Dis,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,EDSP-4920,2015
-EDSP,4940,1,Tchg Rdg Mild Dis,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,EDSP-4940,2015
-EDSP,8530,1,Legal/Pol Issu Sp Ed,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,EDSP-8530,2015
-EDSP,8530,2,Legal/Pol Issu Sp Ed,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,EDSP-8530,2015
-EES,2010,1,Environ Engr Fundamentals I,0.31,0.5,0.13,0.0,0.03,0.0,0.0,0.03,david freedman,EES-2010,2015
-EES,3030,1,Water Treatment Systems,0.5,0.38,0.12,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3030,2015
-EES,3040,1,Wastewater Treatment Systems,0.38,0.44,0.15,0.03,0.0,0.0,0.0,0.0,david freedman,EES-3040,2015
-EES,3050,1,Water/Wastewater Treatment Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2015
-EES,3050,2,Water/Wastewater Treatment Lab,0.64,0.29,0.0,0.07,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2015
-EES,4010,1,Environmental Engr,0.46,0.46,0.0,0.0,0.05,0.0,0.0,0.03,elizabeth carraway,EES-4010,2015
-EES,4010,2,Environmental Engr,0.04,0.63,0.3,0.0,0.0,0.0,0.0,0.04,mark schlautman,EES-4010,2015
-EES,4300,1,Air Pollution Engineering,0.15,0.37,0.39,0.02,0.07,0.0,0.0,0.0,thomas overcamp,EES-4300,2015
-EES,4500,1,Professional Seminar,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,thomas overcamp,EES-4500,2015
-EES,4800,1,Environmental Risk Assessment,0.22,0.24,0.27,0.19,0.05,0.0,0.0,0.03,timothy devol,EES-4800,2015
-EES,4860,1,Environmental Sustainability,0.53,0.33,0.1,0.0,0.04,0.0,0.0,0.0,michael anthon dale,EES-4860,2015
-EES,4900,11,CI-EvalWaterQual & Kidney Corr,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,david allen ladner,EES-4900,2015
-EES,6100,1,Environ Radiation Protection I,0.33,0.58,0.0,0.08,0.0,0.0,0.0,0.0,nicole eli martinez,EES-6100,2015
-EES,6800,1,Environmental Risk Assessment,0.36,0.29,0.21,0.07,0.0,0.0,0.0,0.07,timothy devol,EES-6800,2015
-EES,6860,1,Environmental Sustainability,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,EES-6860,2015
-EES,8020,1,Environ Eng Prin,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,david allen ladner,EES-8020,2015
-EES,8430,1,Environmental Chem,0.47,0.41,0.03,0.0,0.0,0.0,0.0,0.09,brian powell,EES-8430,2015
-EES,8510,1,Biol Prin Envir Engr,0.42,0.32,0.11,0.0,0.0,0.0,0.0,0.16,kevin thom finneran,EES-8510,2015
-EES,9610,1,Ee&S Phd Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,brian powell,EES-9610,2015
-ELE,3010,1,Intro to Entre,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,ELE-3010,2015
-ELE,3010,2,Intro to Entre,0.51,0.34,0.0,0.0,0.0,0.03,0.0,0.11,chad navis,ELE-3010,2015
-ELE,3010,3,Intro to Entre,0.31,0.56,0.14,0.0,0.0,0.0,0.0,0.0,ashley will parnell,ELE-3010,2015
-ELE,4010,1,Exec Lead & Entr II,0.28,0.5,0.15,0.05,0.03,0.0,0.0,0.0,ashley will parnell,ELE-4010,2015
-ENGL,1030,2,Accelerated Composition,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,trevor lanc seigler,ENGL-1030,2015
-ENGL,1030,3,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,madison ali johnson,ENGL-1030,2015
-ENGL,1030,4,Accelerated Composition,0.26,0.32,0.11,0.11,0.21,0.0,0.0,0.0,todd rossi smith,ENGL-1030,2015
-ENGL,1030,5,Accelerated Composition,0.74,0.11,0.0,0.0,0.05,0.0,0.0,0.11,emily anne boyter,ENGL-1030,2015
-ENGL,1030,6,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,ENGL-1030,2015
-ENGL,1030,7,Accelerated Composition,0.42,0.37,0.05,0.05,0.05,0.0,0.0,0.05,melissa dugan,ENGL-1030,2015
-ENGL,1030,8,Accelerated Composition,0.61,0.28,0.0,0.06,0.0,0.0,0.0,0.06,madison ali johnson,ENGL-1030,2015
-ENGL,1030,9,Accelerated Composition,0.37,0.42,0.11,0.05,0.0,0.0,0.0,0.05,kristen joy hixon,ENGL-1030,2015
-ENGL,1030,10,Accelerated Composition,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,ENGL-1030,2015
-ENGL,1030,11,Accelerated Composition,0.58,0.26,0.11,0.05,0.0,0.0,0.0,0.0,rebecca nico shaver,ENGL-1030,2015
-ENGL,1030,13,Accelerated Composition,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,crystal pa stephens,ENGL-1030,2015
-ENGL,1030,14,Accelerated Composition,0.21,0.53,0.05,0.11,0.11,0.0,0.0,0.0,todd rossi smith,ENGL-1030,2015
-ENGL,1030,15,Accelerated Composition,0.53,0.26,0.05,0.05,0.0,0.0,0.0,0.11,candace wiley,ENGL-1030,2015
-ENGL,1030,16,Accelerated Composition,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kristen joy hixon,ENGL-1030,2015
-ENGL,1030,17,Accelerated Composition,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,mary dickens,ENGL-1030,2015
-ENGL,1030,18,Accelerated Composition,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,melissa dugan,ENGL-1030,2015
-ENGL,1030,19,Accelerated Composition,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,katie jo vann,ENGL-1030,2015
-ENGL,1030,21,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,candace wiley,ENGL-1030,2015
-ENGL,1030,22,Accelerated Composition,0.35,0.59,0.0,0.0,0.0,0.0,0.0,0.06,mary dickens,ENGL-1030,2015
-ENGL,1030,23,Accelerated Composition,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,rebecca nico shaver,ENGL-1030,2015
-ENGL,1030,26,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,chloe mich whitaker,ENGL-1030,2015
-ENGL,1030,27,Accelerated Composition,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,katie jo vann,ENGL-1030,2015
-ENGL,1030,28,Accelerated Composition,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,caroline ca swanson,ENGL-1030,2015
-ENGL,1030,29,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,karen mary stewart,ENGL-1030,2015
-ENGL,1030,30,Accelerated Composition,0.84,0.0,0.05,0.0,0.11,0.0,0.0,0.0,teneshia head,ENGL-1030,2015
-ENGL,1030,31,Accelerated Composition,0.53,0.42,0.0,0.0,0.05,0.0,0.0,0.0,nathan riggs,ENGL-1030,2015
-ENGL,1030,32,Accelerated Composition,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,chloe mich whitaker,ENGL-1030,2015
-ENGL,1030,33,Accelerated Composition,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,daniel frank,ENGL-1030,2015
-ENGL,1030,34,Accelerated Composition,0.79,0.05,0.0,0.0,0.11,0.0,0.0,0.05,eda ozyesilpinar,ENGL-1030,2015
-ENGL,1030,35,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,ENGL-1030,2015
-ENGL,1030,36,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,nathan riggs,ENGL-1030,2015
-ENGL,1030,37,Accelerated Composition,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel frank,ENGL-1030,2015
-ENGL,1030,38,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,stephen quigley,ENGL-1030,2015
-ENGL,1030,39,Accelerated Composition,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,charlotte powell,ENGL-1030,2015
-ENGL,1030,40,Accelerated Composition,0.37,0.32,0.21,0.0,0.11,0.0,0.0,0.0,caroline ca swanson,ENGL-1030,2015
-ENGL,1030,41,Accelerated Composition,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,eda ozyesilpinar,ENGL-1030,2015
-ENGL,1030,42,Accelerated Composition,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,austin gorman,ENGL-1030,2015
-ENGL,1030,43,Accelerated Composition,0.47,0.32,0.05,0.05,0.11,0.0,0.0,0.0,adrian carson,ENGL-1030,2015
-ENGL,1030,44,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jack butts,ENGL-1030,2015
-ENGL,1030,45,Accelerated Composition,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,jason crider,ENGL-1030,2015
-ENGL,1030,46,Accelerated Composition,0.58,0.26,0.0,0.0,0.05,0.0,0.0,0.11,joshua wood,ENGL-1030,2015
-ENGL,1030,47,Accelerated Composition,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,kellie eliz osborne,ENGL-1030,2015
-ENGL,1030,48,Accelerated Composition,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,jason crider,ENGL-1030,2015
-ENGL,1030,49,Accelerated Composition,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,eric stephens,ENGL-1030,2015
-ENGL,1030,50,Accelerated Composition,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,jennifer moeder,ENGL-1030,2015
-ENGL,1030,51,Accelerated Composition,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,april obrien,ENGL-1030,2015
-ENGL,1030,52,Accelerated Composition,0.47,0.42,0.0,0.0,0.11,0.0,0.0,0.0,adrian carson,ENGL-1030,2015
-ENGL,1030,53,Accelerated Composition,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,april obrien,ENGL-1030,2015
-ENGL,1030,54,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,danielle shuff,ENGL-1030,2015
-ENGL,1030,55,Accelerated Composition,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,brian lee gaines,ENGL-1030,2015
-ENGL,1030,56,Accelerated Composition,0.26,0.47,0.11,0.0,0.05,0.0,0.0,0.11,charlotte powell,ENGL-1030,2015
-ENGL,1030,57,Accelerated Composition,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,ENGL-1030,2015
-ENGL,1030,58,Accelerated Composition,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,brian lee gaines,ENGL-1030,2015
-ENGL,1030,59,Accelerated Composition,0.53,0.32,0.05,0.05,0.05,0.0,0.0,0.0,stephen quigley,ENGL-1030,2015
-ENGL,1030,60,Accelerated Composition,0.63,0.21,0.05,0.0,0.0,0.0,0.0,0.11,danielle shuff,ENGL-1030,2015
-ENGL,1030,64,Accelerated Composition,0.58,0.37,0.0,0.05,0.0,0.0,0.0,0.0,jack butts,ENGL-1030,2015
-ENGL,1030,65,Accelerated Composition,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joshua wood,ENGL-1030,2015
-ENGL,1030,66,Accelerated Composition,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,eric stephens,ENGL-1030,2015
-ENGL,1030,67,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,kellie eliz osborne,ENGL-1030,2015
-ENGL,1030,68,Accelerated Composition,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jennifer moeder,ENGL-1030,2015
-ENGL,1030,500,Accelerated Composition,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-1030,2015
-ENGL,1030,501,Accelerated Composition,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-1030,2015
-ENGL,2120,1,World Literature,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,john morgenstern,ENGL-2120,2015
-ENGL,2120,3,World Literature,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,garry bertholf,ENGL-2120,2015
-ENGL,2120,5,World Literature,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,christopher benson,ENGL-2120,2015
-ENGL,2120,6,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-2120,2015
-ENGL,2120,7,World Literature,0.32,0.25,0.29,0.07,0.04,0.0,0.0,0.04,andrew mathas,ENGL-2120,2015
-ENGL,2120,8,World Literature,0.37,0.3,0.15,0.07,0.04,0.0,0.0,0.07,andrew mathas,ENGL-2120,2015
-ENGL,2120,9,World Literature,0.52,0.37,0.07,0.0,0.0,0.0,0.0,0.04,jeffrey fallis,ENGL-2120,2015
-ENGL,2120,10,World Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey fallis,ENGL-2120,2015
-ENGL,2120,11,World Literature,0.61,0.29,0.04,0.0,0.04,0.0,0.0,0.04,lucian ghita,ENGL-2120,2015
-ENGL,2120,12,World Literature,0.56,0.28,0.04,0.0,0.04,0.0,0.0,0.08,lucian ghita,ENGL-2120,2015
-ENGL,2120,13,World Literature,0.12,0.48,0.16,0.04,0.16,0.0,0.0,0.04,meg woosley-goodman,ENGL-2120,2015
-ENGL,2120,14,World Literature,0.29,0.43,0.11,0.07,0.07,0.0,0.0,0.04,meg woosley-goodman,ENGL-2120,2015
-ENGL,2120,15,World Literature,0.19,0.62,0.12,0.0,0.08,0.0,0.0,0.0,meg woosley-goodman,ENGL-2120,2015
-ENGL,2120,16,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,ENGL-2120,2015
-ENGL,2120,17,World Literature,0.58,0.15,0.12,0.04,0.08,0.0,0.0,0.04,geveryl le robinson,ENGL-2120,2015
-ENGL,2120,18,World Literature,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,ENGL-2120,2015
-ENGL,2120,19,World Literature,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,geveryl le robinson,ENGL-2120,2015
-ENGL,2130,1,British Literature,0.46,0.42,0.12,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-2130,2015
-ENGL,2130,2,British Literature,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-2130,2015
-ENGL,2130,3,British Literature,0.71,0.18,0.04,0.0,0.04,0.0,0.0,0.04,stephanie stripling,ENGL-2130,2015
-ENGL,2130,5,British Literature,0.64,0.21,0.04,0.0,0.04,0.0,0.0,0.07,lucian ghita,ENGL-2130,2015
-ENGL,2130,7,British Literature,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,ENGL-2130,2015
-ENGL,2130,9,British Literature,0.85,0.08,0.0,0.0,0.04,0.0,0.0,0.04,krist aldebol-hazle,ENGL-2130,2015
-ENGL,2130,10,British Literature,0.61,0.14,0.0,0.11,0.14,0.0,0.0,0.0,krist aldebol-hazle,ENGL-2130,2015
-ENGL,2130,11,British Literature,0.6,0.2,0.0,0.04,0.04,0.0,0.0,0.12,krist aldebol-hazle,ENGL-2130,2015
-ENGL,2130,12,British Literature,0.56,0.3,0.04,0.0,0.07,0.0,0.0,0.04,sherri teres allred,ENGL-2130,2015
-ENGL,2130,13,British Literature,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,sherri teres allred,ENGL-2130,2015
-ENGL,2140,1,American Literature,0.68,0.18,0.08,0.02,0.01,0.0,0.0,0.02, barton palmer,ENGL-2140,2015
-ENGL,2140,5,American Literature,0.32,0.32,0.29,0.04,0.0,0.0,0.0,0.04,william stanton,ENGL-2140,2015
-ENGL,2140,6,American Literature,0.14,0.68,0.11,0.0,0.07,0.0,0.0,0.0,william stanton,ENGL-2140,2015
-ENGL,2140,7,American Literature,0.52,0.3,0.15,0.0,0.04,0.0,0.0,0.0,john morgenstern,ENGL-2140,2015
-ENGL,2140,8,American Literature,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-2140,2015
-ENGL,2140,9,American Literature,0.57,0.29,0.11,0.0,0.0,0.0,0.0,0.04,sharon kathl nalley,ENGL-2140,2015
-ENGL,2140,10,American Literature,0.48,0.33,0.0,0.0,0.05,0.0,0.0,0.14,candace wiley,ENGL-2140,2015
-ENGL,2140,11,American Literature,0.44,0.37,0.04,0.0,0.04,0.0,0.0,0.11,candace wiley,ENGL-2140,2015
-ENGL,2140,12,American Literature,0.59,0.3,0.07,0.04,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-2140,2015
-ENGL,2140,13,American Literature,0.68,0.21,0.04,0.04,0.0,0.0,0.0,0.04,crystal pa stephens,ENGL-2140,2015
-ENGL,2140,14,American Literature,0.3,0.41,0.11,0.0,0.07,0.0,0.0,0.11,sharon kathl nalley,ENGL-2140,2015
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.36,0.39,0.21,0.0,0.04,0.0,0.0,0.0,andrew mathas,ENGL-2150,2015
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.36,0.43,0.07,0.04,0.04,0.0,0.0,0.07,andrew mathas,ENGL-2150,2015
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.54,0.21,0.21,0.04,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2015
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.43,0.25,0.18,0.04,0.0,0.0,0.0,0.11,john logan pursley,ENGL-2150,2015
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.64,0.18,0.11,0.04,0.0,0.0,0.0,0.04,john logan pursley,ENGL-2150,2015
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.38,0.38,0.19,0.0,0.0,0.0,0.0,0.04,agnieszka skrodzka,ENGL-2150,2015
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.68,0.18,0.07,0.0,0.0,0.0,0.0,0.07,april susanne pelt,ENGL-2150,2015
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,alexander kudera,ENGL-2150,2015
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.64,0.32,0.0,0.0,0.04,0.0,0.0,0.0,alexander kudera,ENGL-2150,2015
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2150,2015
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.15,0.5,0.15,0.0,0.04,0.0,0.0,0.15,david charles foltz,ENGL-2150,2015
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.13,0.38,0.17,0.04,0.08,0.0,0.0,0.21,david charles foltz,ENGL-2150,2015
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.14,0.43,0.18,0.07,0.04,0.0,0.0,0.14,david charles foltz,ENGL-2150,2015
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.11,0.37,0.15,0.04,0.15,0.0,0.0,0.19,david charles foltz,ENGL-2150,2015
-ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.64,0.25,0.04,0.07,0.0,0.0,0.0,0.0,stephanie stripling,ENGL-2150,2015
-ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,stephanie stripling,ENGL-2150,2015
-ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey fallis,ENGL-2150,2015
-ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,austin gorman,ENGL-2150,2015
-ENGL,2150,100,20th - 21st Century Lit (HON),0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2150,2015
-ENGL,2150,101,20th-21st Century Lit (HON),0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-2150,2015
-ENGL,3010,1,Grt Books West World,0.15,0.77,0.0,0.08,0.0,0.0,0.0,0.0,colin pearce,ENGL-3010,2015
-ENGL,3040,3,Business Writing,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,ENGL-3040,2015
-ENGL,3040,4,Business Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3040,2015
-ENGL,3040,11,Business Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexander kudera,ENGL-3040,2015
-ENGL,3040,12,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-3040,2015
-ENGL,3040,15,Business Writing,0.16,0.26,0.37,0.11,0.05,0.0,0.0,0.05,megan no macalystre,ENGL-3040,2015
-ENGL,3040,16,Business Writing,0.44,0.44,0.06,0.0,0.06,0.0,0.0,0.0,megan no macalystre,ENGL-3040,2015
-ENGL,3040,19,Business Writing,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-3040,2015
-ENGL,3040,20,Business Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,ENGL-3040,2015
-ENGL,3100,1,Crit Writ Lit,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,ENGL-3100,2015
-ENGL,3100,2,Crit Writ Lit,0.68,0.16,0.05,0.0,0.05,0.0,0.0,0.05,walter edgar hunter,ENGL-3100,2015
-ENGL,3100,3,Crit Writ Lit,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,david sweene coombs,ENGL-3100,2015
-ENGL,3100,4,Crit Writ Lit,0.31,0.56,0.0,0.0,0.06,0.0,0.0,0.06,agnieszka skrodzka,ENGL-3100,2015
-ENGL,3120,1,Advanced Composition,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2015
-ENGL,3120,2,Advanced Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2015
-ENGL,3140,1,Technical Writing,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,william pulley,ENGL-3140,2015
-ENGL,3140,2,Technical Writing,0.39,0.33,0.28,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2015
-ENGL,3140,3,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,ENGL-3140,2015
-ENGL,3140,4,Technical Writing,0.63,0.11,0.16,0.0,0.0,0.0,0.0,0.11,melissa dugan,ENGL-3140,2015
-ENGL,3140,5,Technical Writing,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,melissa dugan,ENGL-3140,2015
-ENGL,3140,6,Technical Writing,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2015
-ENGL,3140,7,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2015
-ENGL,3140,8,Technical Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,ENGL-3140,2015
-ENGL,3140,10,Technical Writing,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2015
-ENGL,3140,11,Technical Writing,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2015
-ENGL,3140,12,Technical Writing,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,katalin beck,ENGL-3140,2015
-ENGL,3140,14,Technical Writing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,brian adam smith,ENGL-3140,2015
-ENGL,3140,19,Technical Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,ENGL-3140,2015
-ENGL,3140,20,Technical Writing,0.32,0.21,0.11,0.05,0.11,0.0,0.0,0.21,matthew jose osborn,ENGL-3140,2015
-ENGL,3140,21,Technical Writing,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,heathe christiansen,ENGL-3140,2015
-ENGL,3140,22,Technical Writing,0.74,0.05,0.05,0.0,0.11,0.0,0.0,0.05,kristen gay,ENGL-3140,2015
-ENGL,3140,23,Technical Writing,0.72,0.11,0.06,0.0,0.0,0.0,0.0,0.11,kristen gay,ENGL-3140,2015
-ENGL,3140,100,Technical Writing (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2015
-ENGL,3140,400,Technical Writing,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,john conway,ENGL-3140,2015
-ENGL,3140,401,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-3140,2015
-ENGL,3150,1,Scientific Writing & Comm,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,barbara ramirez,ENGL-3150,2015
-ENGL,3150,2,Scientific Writing & Comm,0.11,0.68,0.05,0.0,0.0,0.0,0.0,0.16,barbara ramirez,ENGL-3150,2015
-ENGL,3150,3,Scientific Writing & Comm,0.58,0.16,0.11,0.05,0.05,0.0,0.0,0.05,william pulley,ENGL-3150,2015
-ENGL,3150,4,Scientific Writing & Comm,0.58,0.21,0.11,0.0,0.0,0.0,0.0,0.11,william pulley,ENGL-3150,2015
-ENGL,3150,401,Sci Writing & Communication,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,ENGL-3150,2015
-ENGL,3150,402,Sci Writing & Communication,0.21,0.53,0.11,0.0,0.0,0.0,0.0,0.16,carleton dew salley,ENGL-3150,2015
-ENGL,3320,1,Visual Communication,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,tharon howard,ENGL-3320,2015
-ENGL,3450,1,Structure of Fiction,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-3450,2015
-ENGL,3460,2,Structure of Poetry,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-3460,2015
-ENGL,3470,1,Structure of Drama,0.54,0.31,0.08,0.08,0.0,0.0,0.0,0.0,jillian weise,ENGL-3470,2015
-ENGL,3560,1,Science Fiction,0.33,0.33,0.2,0.0,0.0,0.0,0.0,0.13,lindsay carr thomas,ENGL-3560,2015
-ENGL,3570,1,Film,0.21,0.53,0.16,0.0,0.0,0.0,0.0,0.11,amy monaghan,ENGL-3570,2015
-ENGL,3570,2,Film,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2015
-ENGL,3570,3,Film,0.12,0.76,0.12,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2015
-ENGL,3800,1,Women Writers,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,meg woosley-goodman,ENGL-3800,2015
-ENGL,3850,1,Children's Lit,0.33,0.2,0.33,0.0,0.13,0.0,0.0,0.0,megan no macalystre,ENGL-3850,2015
-ENGL,3960,1,Brit Lit Survey I,0.2,0.3,0.3,0.05,0.0,0.0,0.0,0.15,erin marina goss,ENGL-3960,2015
-ENGL,3960,2,Brit Lit Survey I,0.2,0.25,0.35,0.0,0.15,0.0,0.0,0.05,erin marina goss,ENGL-3960,2015
-ENGL,3960,3,Brit Lit Survey I,0.19,0.06,0.38,0.0,0.06,0.0,0.0,0.31,erin marina goss,ENGL-3960,2015
-ENGL,3970,1,Brit Lit Survey II,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,david sweene coombs,ENGL-3970,2015
-ENGL,3980,2,Amer Lit Survey I,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,jonathan beec field,ENGL-3980,2015
-ENGL,3990,1,Amer Lit Survey II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-3990,2015
-ENGL,4010,1,Grammar Survey,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,william stockton,ENGL-4010,2015
-ENGL,4070,1,Medieval Period,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,andrew lemons,ENGL-4070,2015
-ENGL,4110,1,Shakespeare,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,ENGL-4110,2015
-ENGL,4110,2,Shakespeare,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-4110,2015
-ENGL,4140,1,Milton,0.2,0.4,0.2,0.0,0.1,0.0,0.0,0.1,lee morrissey,ENGL-4140,2015
-ENGL,4160,1,Romantic Period,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,erin marina goss,ENGL-4160,2015
-ENGL,4170,1,Victorian Period,0.0,0.58,0.25,0.08,0.0,0.0,0.0,0.08,kimberly manganelli,ENGL-4170,2015
-ENGL,4210,1,Amer Lit 1800-1899,0.38,0.38,0.08,0.08,0.0,0.0,0.0,0.08,dominic mastroianni,ENGL-4210,2015
-ENGL,4280,1,Contemporary Literature,0.33,0.2,0.33,0.0,0.0,0.0,0.0,0.13,michael lemahieu,ENGL-4280,2015
-ENGL,4340,1,Environmental Lit,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,sean morey,ENGL-4340,2015
-ENGL,4350,1,Literary Criticism,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,dominic mastroianni,ENGL-4350,2015
-ENGL,4430,1,Theories of World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-4430,2015
-ENGL,4510,1,Film Theo/Criticism,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0, barton palmer,ENGL-4510,2015
-ENGL,4600,1,Writing Technologies,0.53,0.27,0.07,0.0,0.0,0.0,0.0,0.13,lindsay carr thomas,ENGL-4600,2015
-ENGL,4750,1,Writing for Media,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,megan eatman,ENGL-4750,2015
-ENGL,4780,1,Digital Literacy,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,ENGL-4780,2015
-ENGL,4820,1,Afr Am Lit to 1920,0.3,0.2,0.3,0.0,0.2,0.0,0.0,0.0,rhondda robi thomas,ENGL-4820,2015
-ENGL,4960,1,Senior Seminar,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.0,wayne chapman,ENGL-4960,2015
-ENGL,4960,2,Senior Seminar,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,ENGL-4960,2015
-ENGL,4960,3,Senior Seminar,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,ENGL-4960,2015
-ENGL,4990,2,Practicum in Writing,0.0,0.0,0.0,0.0,0.0,0.82,0.0,0.18,elizabeth rivlin,ENGL-4990,2015
-ENGL,8050,1,Topics in Medieval Literature,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,andrew lemons,ENGL-8050,2015
-ENGL,8140,1,Topics Vict & Mod British Lit,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,wayne chapman,ENGL-8140,2015
-ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,steven brandon,ENGR-1000,2015
-ENGR,1050,111,Engr Discipline & Skills I,0.49,0.37,0.07,0.02,0.0,0.0,0.0,0.05,christopher norfolk,ENGR-1050,2015
-ENGR,1050,112,Engr Discipline & Skills I,0.4,0.38,0.12,0.02,0.0,0.0,0.0,0.07,mariah magagnotti,ENGR-1050,2015
-ENGR,1050,113,Engr Discipline & Skills I,0.33,0.33,0.19,0.07,0.05,0.0,0.0,0.05,mariah magagnotti,ENGR-1050,2015
-ENGR,1050,114,Engr Discipline & Skills I,0.45,0.36,0.1,0.0,0.02,0.0,0.0,0.07,matthew kent miller,ENGR-1050,2015
-ENGR,1050,115,Engr Discipline & Skills I,0.43,0.4,0.12,0.02,0.0,0.0,0.0,0.02,matthew kent miller,ENGR-1050,2015
-ENGR,1050,117,Engr Discipline & Skills I,0.57,0.29,0.02,0.07,0.0,0.0,0.0,0.05,matthew kent miller,ENGR-1050,2015
-ENGR,1050,118,Engr Discipline & Skills I,0.29,0.5,0.07,0.07,0.05,0.0,0.0,0.02,matthew kent miller,ENGR-1050,2015
-ENGR,1050,211,Engr Discipline & Skills I,0.53,0.27,0.07,0.0,0.04,0.0,0.0,0.09,ashley childers,ENGR-1050,2015
-ENGR,1050,212,Engr Discipline & Skills I,0.47,0.4,0.05,0.02,0.0,0.0,0.0,0.05,ashley childers,ENGR-1050,2015
-ENGR,1050,213,Engr Discipline & Skills I,0.38,0.36,0.14,0.05,0.0,0.0,0.0,0.07,andrew isaa neptune,ENGR-1050,2015
-ENGR,1050,214,Engr Discipline & Skills I,0.22,0.39,0.32,0.05,0.02,0.0,0.0,0.0,andrew isaa neptune,ENGR-1050,2015
-ENGR,1050,215,Engr Discipline & Skills I,0.17,0.25,0.27,0.15,0.02,0.0,0.0,0.13,mariah magagnotti,ENGR-1050,2015
-ENGR,1050,216,Engr Discipline & Skills I,0.14,0.26,0.29,0.12,0.1,0.0,0.0,0.1,mariah magagnotti,ENGR-1050,2015
-ENGR,1050,217,Engr Discipline & Skills I,0.37,0.39,0.2,0.0,0.02,0.0,0.0,0.02,andrew isaa neptune,ENGR-1050,2015
-ENGR,1050,218,Engr Discipline & Skills I,0.33,0.45,0.13,0.0,0.03,0.0,0.0,0.08,andrew isaa neptune,ENGR-1050,2015
-ENGR,1050,311,Engr Discipline & Skills I,0.1,0.41,0.21,0.1,0.03,0.0,0.0,0.14,elizabeth stephan,ENGR-1050,2015
-ENGR,1050,312,Engr Discipline & Skills I,0.36,0.36,0.12,0.05,0.0,0.0,0.0,0.12,elizabeth stephan,ENGR-1050,2015
-ENGR,1050,313,Engr Discipline & Skills I,0.26,0.25,0.2,0.11,0.02,0.0,0.0,0.16,michael giebner,ENGR-1050,2015
-ENGR,1050,314,Engr Discipline & Skills I,0.31,0.37,0.19,0.05,0.0,0.0,0.0,0.08,michael giebner,ENGR-1050,2015
-ENGR,1050,315,Engr Discipline & Skills I,0.4,0.22,0.22,0.1,0.02,0.0,0.0,0.03,william park,ENGR-1050,2015
-ENGR,1050,316,Engr Discipline & Skills I,0.34,0.31,0.17,0.07,0.02,0.0,0.0,0.1,william park,ENGR-1050,2015
-ENGR,1050,317,Engr Discipline & Skills I,0.37,0.25,0.22,0.05,0.03,0.0,0.0,0.07,william park,ENGR-1050,2015
-ENGR,1050,318,Engr Discipline & Skills I,0.22,0.31,0.21,0.05,0.07,0.0,0.0,0.14,michael giebner,ENGR-1050,2015
-ENGR,1050,349,Engr Discipline & Skills I,0.14,0.11,0.26,0.17,0.2,0.0,0.0,0.11,michael giebner,ENGR-1050,2015
-ENGR,1050,400,Engr Discipline & Skills I,0.08,0.28,0.3,0.1,0.2,0.0,0.0,0.05,sarah grigg,ENGR-1050,2015
-ENGR,1050,611,Engr Discip & Skills I (HON),0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,steven brandon,ENGR-1050,2015
-ENGR,1050,613,Engr Discip & Skills I (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,ENGR-1050,2015
-ENGR,1050,614,Engr Discipl & Skills I (HON),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,steven brandon,ENGR-1050,2015
-ENGR,1050,615,Engr Discipl & Skills I (HON),0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,richard watkins,ENGR-1050,2015
-ENGR,1060,111,Engr Discipline & Skills II,0.11,0.39,0.24,0.11,0.03,0.0,0.0,0.13,christopher norfolk,ENGR-1060,2015
-ENGR,1060,112,Engr Discipline & Skills II,0.15,0.41,0.36,0.0,0.03,0.0,0.0,0.05,mariah magagnotti,ENGR-1060,2015
-ENGR,1060,113,Engr Discipline & Skills II,0.03,0.26,0.53,0.06,0.03,0.0,0.0,0.09,mariah magagnotti,ENGR-1060,2015
-ENGR,1060,114,Engr Discipline & Skills II,0.27,0.43,0.22,0.05,0.03,0.0,0.0,0.0,matthew kent miller,ENGR-1060,2015
-ENGR,1060,115,Engr Discipline & Skills II,0.23,0.25,0.43,0.0,0.0,0.0,0.0,0.1,matthew kent miller,ENGR-1060,2015
-ENGR,1060,117,Engr Discipline & Skills II,0.22,0.5,0.22,0.0,0.03,0.0,0.0,0.03,matthew kent miller,ENGR-1060,2015
-ENGR,1060,118,Engr Discipline & Skills II,0.06,0.34,0.31,0.17,0.03,0.0,0.0,0.09,matthew kent miller,ENGR-1060,2015
-ENGR,1060,211,Engr Discipline & Skills II,0.24,0.43,0.26,0.04,0.0,0.0,0.0,0.02,ashley childers,ENGR-1060,2015
-ENGR,1060,212,Engr Discipline & Skills II,0.29,0.44,0.21,0.0,0.02,0.0,0.0,0.04,ashley childers,ENGR-1060,2015
-ENGR,1060,213,Engr Discipline & Skills II,0.11,0.41,0.24,0.11,0.05,0.0,0.0,0.08,andrew isaa neptune,ENGR-1060,2015
-ENGR,1060,214,Engr Discipline & Skills II,0.16,0.29,0.21,0.21,0.0,0.0,0.0,0.13,andrew isaa neptune,ENGR-1060,2015
-ENGR,1060,215,Engr Discipline & Skills II,0.15,0.21,0.31,0.18,0.05,0.0,0.0,0.1,mariah magagnotti,ENGR-1060,2015
-ENGR,1060,216,Engr Discipline & Skills II,0.07,0.22,0.48,0.04,0.07,0.0,0.0,0.11,mariah magagnotti,ENGR-1060,2015
-ENGR,1060,217,Engr Discipline & Skills II,0.15,0.38,0.31,0.05,0.0,0.0,0.0,0.1,andrew isaa neptune,ENGR-1060,2015
-ENGR,1060,218,Engr Discipline & Skills II,0.03,0.53,0.22,0.06,0.06,0.0,0.0,0.11,andrew isaa neptune,ENGR-1060,2015
-ENGR,1060,243,Engr Discipline & Skills II,0.17,0.31,0.31,0.06,0.06,0.0,0.0,0.11,michael giebner,ENGR-1060,2015
-ENGR,1060,312,Engr Discipline & Skills II,0.16,0.35,0.24,0.16,0.02,0.0,0.0,0.06,elizabeth stephan,ENGR-1060,2015
-ENGR,1060,313,Engr Discipline & Skills II,0.13,0.47,0.22,0.09,0.04,0.0,0.0,0.04,michael giebner,ENGR-1060,2015
-ENGR,1060,314,Engr Discipline & Skills II,0.12,0.29,0.43,0.04,0.04,0.0,0.0,0.08,michael giebner,ENGR-1060,2015
-ENGR,1060,315,Engr Discipline & Skills II,0.09,0.33,0.28,0.09,0.09,0.0,0.0,0.13,william park,ENGR-1060,2015
-ENGR,1060,316,Engr Discipline & Skills II,0.08,0.35,0.31,0.08,0.1,0.0,0.0,0.08,william park,ENGR-1060,2015
-ENGR,1060,317,Engr Discipline & Skills II,0.1,0.33,0.42,0.06,0.04,0.0,0.0,0.04,william park,ENGR-1060,2015
-ENGR,1060,318,Engr Discipline & Skills II,0.24,0.36,0.17,0.1,0.02,0.0,0.0,0.12,michael giebner,ENGR-1060,2015
-ENGR,1060,400,Engr Discipline & Skills II,0.11,0.22,0.33,0.11,0.06,0.0,0.0,0.17,sarah grigg,ENGR-1060,2015
-ENGR,1060,611,Engr Discip & Skills II (HON),0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,steven brandon,ENGR-1060,2015
-ENGR,1060,613,Engr Discip & Skills II (HON),0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,steven brandon,ENGR-1060,2015
-ENGR,1060,614,Engr Discip & Skills II (HON),0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.03,steven brandon,ENGR-1060,2015
-ENGR,1060,615,Engr Discip & Skills II (HON),0.6,0.25,0.1,0.0,0.0,0.0,0.0,0.05,richard watkins,ENGR-1060,2015
-ENGR,1070,322,Programming & Prob Solving I,0.07,0.07,0.29,0.24,0.24,0.0,0.0,0.07,jordon anth gilmore,ENGR-1070,2015
-ENGR,1070,325,Programming & Prob Solving I,0.03,0.18,0.28,0.21,0.1,0.0,0.0,0.21,william martin,ENGR-1070,2015
-ENGR,1070,326,Programming & Prob Solving I,0.1,0.26,0.21,0.23,0.13,0.0,0.0,0.08,william martin,ENGR-1070,2015
-ENGR,1070,327,Programming & Prob Solving I,0.15,0.21,0.18,0.21,0.03,0.0,0.0,0.24,william martin,ENGR-1070,2015
-ENGR,1080,220,Programming & Prob Solving II,0.03,0.19,0.42,0.0,0.11,0.0,0.0,0.25,srinivasarangan rang,ENGR-1080,2015
-ENGR,1080,221,Programming & Prob Solving II,0.0,0.15,0.56,0.12,0.06,0.0,0.0,0.12,srinivasarangan rang,ENGR-1080,2015
-ENGR,1080,322,Programming & Prob Solving II,0.09,0.18,0.21,0.24,0.18,0.0,0.0,0.12,jordon anth gilmore,ENGR-1080,2015
-ENGR,1080,325,Programming & Prob Solving II,0.0,0.25,0.42,0.08,0.21,0.0,0.0,0.04,william martin,ENGR-1080,2015
-ENGR,1080,326,Programming & Prob Solving II,0.06,0.13,0.33,0.17,0.17,0.0,0.0,0.13,william martin,ENGR-1080,2015
-ENGR,1080,327,Programming & Prob Solving II,0.11,0.29,0.37,0.16,0.05,0.0,0.0,0.03,william martin,ENGR-1080,2015
-ENGR,1090,331,Prog/Problem Solving Apps,0.09,0.22,0.28,0.16,0.13,0.0,0.0,0.13,jordon anth gilmore,ENGR-1090,2015
-ENGR,1090,332,Prog/Problem Solving Apps,0.3,0.42,0.19,0.0,0.05,0.0,0.0,0.05,christopher norfolk,ENGR-1090,2015
-ENGR,1090,333,Prog/Problem Solving Apps,0.19,0.16,0.3,0.19,0.05,0.0,0.0,0.12,william park,ENGR-1090,2015
-ENGR,1090,334,Prog/Problem Solving Apps,0.06,0.26,0.29,0.12,0.0,0.0,0.0,0.26,william park,ENGR-1090,2015
-ENGR,1150,500,Engineering Design & Modeling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1150,2015
-ENGR,1520,500,Engineering Computer Skills,0.1,0.2,0.6,0.1,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1520,2015
-ENGR,1520,501,Engineering Computer Skills,0.15,0.46,0.15,0.23,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1520,2015
-ENGR,2080,181,Engr Graphics & Machine Design,0.34,0.36,0.13,0.02,0.04,0.0,0.0,0.11,nighat yasmin,ENGR-2080,2015
-ENGR,2080,182,Engr Graphics & Machine Design,0.4,0.33,0.1,0.13,0.04,0.0,0.0,0.0,nighat yasmin,ENGR-2080,2015
-ENGR,2080,285,Engr Graphics & Machine Design,0.32,0.3,0.18,0.0,0.06,0.0,0.0,0.14,anthony pau garland,ENGR-2080,2015
-ENGR,2080,286,Engr Graphics & Machine Design,0.29,0.31,0.1,0.08,0.08,0.0,0.0,0.14,anthony pau garland,ENGR-2080,2015
-ENGR,2080,384,Engr Graphics & Machine Design,0.52,0.14,0.14,0.1,0.04,0.0,0.0,0.06,john minor,ENGR-2080,2015
-ENGR,2100,103,CAD & Engineering Apllications,0.59,0.24,0.04,0.02,0.02,0.0,0.0,0.09,mary kayla kilgo,ENGR-2100,2015
-ENGR,2100,104,CAD & Engineering Apllications,0.38,0.23,0.1,0.08,0.08,0.0,0.0,0.13,nighat yasmin,ENGR-2100,2015
-ENGR,2100,105,CAD & Engineering Apllications,0.45,0.34,0.07,0.0,0.07,0.0,0.0,0.07,nighat yasmin,ENGR-2100,2015
-ENGR,2200,107,Evaluating Innovations,0.29,0.55,0.13,0.0,0.0,0.0,0.0,0.03,sarah grigg,ENGR-2200,2015
-ENGR,2200,204,Evaluating Innovations,0.37,0.34,0.24,0.0,0.0,0.0,0.0,0.05,sarah grigg,ENGR-2200,2015
-ENGR,2200,206,Evaluating Innovations,0.48,0.4,0.08,0.03,0.0,0.0,0.0,0.03,sarah grigg,ENGR-2200,2015
-ENR,1010,1,Intro to Envir & Natur Res I,0.54,0.27,0.1,0.03,0.04,0.0,0.0,0.01,alan johnson,ENR-1010,2015
-ENR,1010,2,Intro to Envir & Natur Res I,0.74,0.12,0.05,0.05,0.02,0.0,0.0,0.02,alan johnson,ENR-1010,2015
-ENR,4290,1,Environ Law & Policy,0.54,0.34,0.08,0.0,0.0,0.0,0.0,0.04,alan johnson,ENR-4290,2015
-ENSP,2000,1,Intro Environ Sci,0.55,0.24,0.1,0.05,0.02,0.0,0.0,0.05,scott brame,ENSP-2000,2015
-ENSP,2000,2,Intro Environ Sci,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2015
-ENSP,2000,3,Intro Environ Sci,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2015
-ENSP,2000,4,Intro Environ Sci,0.42,0.39,0.17,0.0,0.03,0.0,0.0,0.0,elizabeth carraway,ENSP-2000,2015
-ENSP,4000,1,Studies in Environmental Sci,0.69,0.15,0.0,0.04,0.04,0.0,0.0,0.08,margaret thompson,ENSP-4000,2015
-ENT,2000,1,Six-Legged Science,0.64,0.13,0.13,0.0,0.0,0.0,0.0,0.1,suellen pometto,ENT-2000,2015
-ENT,2010,1,Insects and Death,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,joseph culin,ENT-2010,2015
-ENT,3010,1,Insect Biology & Diversity,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,eric benson,ENT-3010,2015
-ENT,8700,1,Insect Phys Mol Bio,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,ENT-8700,2015
-FCS,8300,1,Community Dev: Princ & Pract,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,areli moore peralta,FCS-8300,2015
-FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.65,0.21,0.05,0.01,0.03,0.0,0.0,0.06,aubrey dean coffee,FDSC-1010,2015
-FDSC,2160,1,Baking Science,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,FDSC-2160,2015
-FDSC,3010,1,Food Regulations,0.78,0.15,0.07,0.0,0.0,0.0,0.0,0.0,julie kat northcutt,FDSC-3010,2015
-FDSC,3060,1,Institutional Food Service Mgt,0.54,0.35,0.07,0.0,0.03,0.0,0.0,0.0,angela fraser,FDSC-3060,2015
-FDSC,4010,1,Food Chemistry I,0.48,0.4,0.08,0.03,0.0,0.0,0.0,0.0,feng chen,FDSC-4010,2015
-FDSC,4040,1,Food Prsv & Process,0.51,0.4,0.09,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,FDSC-4040,2015
-FDSC,4070,1,Quantity Food Production,0.58,0.34,0.05,0.03,0.0,0.0,0.0,0.0,heather batt,FDSC-4070,2015
-FDSC,4170,1,Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,FDSC-4170,2015
-FDSC,4200,5,Selected Topics,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katherine cason,FDSC-4200,2015
-FDSC,4300,1,Dairy Process & Sant,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,FDSC-4300,2015
-FDSC,8510,1,Food Science Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,FDSC-8510,2015
-FIN,3040,1,Risk & Insurance,0.13,0.35,0.35,0.09,0.09,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2015
-FIN,3040,2,Risk & Insurance,0.23,0.33,0.37,0.07,0.0,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2015
-FIN,3050,1,Investment Analysis,0.27,0.3,0.27,0.11,0.0,0.0,0.0,0.05,kerri mcmillan,FIN-3050,2015
-FIN,3050,2,Investment Analysis,0.14,0.36,0.34,0.11,0.0,0.02,0.0,0.02,kerri mcmillan,FIN-3050,2015
-FIN,3050,3,Investment Analysis,0.29,0.36,0.31,0.0,0.02,0.0,0.0,0.02,thomas albe wessels,FIN-3050,2015
-FIN,3050,4,Investment Analysis,0.28,0.41,0.28,0.0,0.03,0.0,0.0,0.0,thomas albe wessels,FIN-3050,2015
-FIN,3060,1,Corporation Finance,0.1,0.35,0.13,0.29,0.06,0.0,0.0,0.06,ramon tolb franklin,FIN-3060,2015
-FIN,3060,2,Corporation Finance,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,neil waller,FIN-3060,2015
-FIN,3060,3,Corporation Finance,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,neil waller,FIN-3060,2015
-FIN,3060,4,Corporation Finance,0.17,0.36,0.19,0.11,0.08,0.0,0.0,0.08,ramon tolb franklin,FIN-3060,2015
-FIN,3060,5,Corporation Finance,0.26,0.43,0.21,0.1,0.0,0.0,0.0,0.0,neil waller,FIN-3060,2015
-FIN,3060,6,Corporation Finance,0.14,0.14,0.26,0.21,0.17,0.0,0.0,0.07,william hol johnson,FIN-3060,2015
-FIN,3060,7,Corporation Finance,0.24,0.2,0.39,0.02,0.05,0.0,0.0,0.1,william hol johnson,FIN-3060,2015
-FIN,3060,8,Corporation Finance,0.24,0.12,0.12,0.12,0.14,0.0,0.0,0.26,william hol johnson,FIN-3060,2015
-FIN,3060,9,Corporation Finance,0.03,0.13,0.16,0.1,0.32,0.0,0.0,0.26,william hol johnson,FIN-3060,2015
-FIN,3060,10,Corporation Finance,0.18,0.24,0.18,0.29,0.0,0.0,0.0,0.12,ramon tolb franklin,FIN-3060,2015
-FIN,3070,1,Prin of Real Estate,0.18,0.24,0.37,0.13,0.02,0.02,0.0,0.05,thomas springer,FIN-3070,2015
-FIN,3070,2,Prin of Real Estate,0.08,0.4,0.28,0.12,0.03,0.0,0.0,0.08,thomas springer,FIN-3070,2015
-FIN,3080,1,Fin Inst & Mkts,0.24,0.57,0.09,0.04,0.02,0.0,0.0,0.04,lyudmila chernykh,FIN-3080,2015
-FIN,3080,2,Fin Inst & Mkts,0.16,0.51,0.26,0.02,0.02,0.0,0.0,0.02,lyudmila chernykh,FIN-3080,2015
-FIN,3080,3,Fin Inst & Mkts,0.18,0.41,0.26,0.03,0.1,0.0,0.0,0.03,daniel thoma greene,FIN-3080,2015
-FIN,3110,1,Financial Management I,0.1,0.43,0.25,0.08,0.08,0.0,0.0,0.08,george bra lockhart,FIN-3110,2015
-FIN,3110,2,Financial Management I,0.08,0.37,0.29,0.16,0.06,0.0,0.0,0.04,angela morgan,FIN-3110,2015
-FIN,3110,3,Financial Management I,0.11,0.22,0.43,0.15,0.09,0.0,0.0,0.0,jared daniel smith,FIN-3110,2015
-FIN,3110,4,Financial Management I,0.2,0.3,0.28,0.13,0.0,0.0,0.0,0.09,jared daniel smith,FIN-3110,2015
-FIN,3120,1,Financial Management II,0.13,0.44,0.21,0.15,0.03,0.0,0.0,0.05,vincent intintoli,FIN-3120,2015
-FIN,3120,2,Financial Management II,0.13,0.29,0.4,0.16,0.0,0.0,0.0,0.02,vincent intintoli,FIN-3120,2015
-FIN,3120,3,Financial Management II,0.43,0.23,0.17,0.15,0.0,0.0,0.0,0.02,melvin stith,FIN-3120,2015
-FIN,3120,4,Financial Management II,0.61,0.26,0.07,0.04,0.02,0.0,0.0,0.0,melvin stith,FIN-3120,2015
-FIN,4020,1,Corporate Valuation,0.05,0.3,0.34,0.27,0.02,0.0,0.0,0.02,jack wolf,FIN-4020,2015
-FIN,4020,2,Corporate Valuation,0.06,0.27,0.29,0.25,0.04,0.0,0.0,0.08,jack wolf,FIN-4020,2015
-FIN,4050,1,Portfolio Management & Theory,0.03,0.3,0.33,0.1,0.0,0.0,0.0,0.23,john alexander,FIN-4050,2015
-FIN,4060,1,Derivatives Analysis,0.24,0.36,0.24,0.09,0.03,0.03,0.0,0.0,george bra lockhart,FIN-4060,2015
-FIN,4110,1,Int Fin Mgt,0.13,0.34,0.38,0.03,0.03,0.0,0.0,0.09,tilan tang,FIN-4110,2015
-FIN,4110,2,Int Fin Mgt,0.19,0.49,0.24,0.08,0.0,0.0,0.0,0.0,tilan tang,FIN-4110,2015
-FIN,4170,1,Real Estate Finance,0.43,0.29,0.21,0.07,0.0,0.0,0.0,0.0,neil waller,FIN-4170,2015
-FIN,4980,2,Creative Inquiry in Finance,0.5,0.2,0.0,0.0,0.0,0.0,0.0,0.3,jack wolf,FIN-4980,2015
-FNR,2040,1,Soil Information Systems,0.86,0.11,0.0,0.0,0.02,0.0,0.0,0.02,elena mikhailova,FNR-2040,2015
-FNR,4900,1,Field Training in Natural Res,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,patricia layton,FNR-4900,2015
-FNR,4990,1,Natural Resources Seminar,0.83,0.11,0.0,0.0,0.06,0.0,0.0,0.0,russell barrett,FNR-4990,2015
-FOR,2050,1,Dendrology,0.23,0.31,0.27,0.04,0.08,0.0,0.0,0.08,donald hagan,FOR-2050,2015
-FOR,2050,2,Dendrology,0.39,0.18,0.14,0.04,0.18,0.0,0.0,0.07,donald hagan,FOR-2050,2015
-FOR,2050,3,Dendrology,0.37,0.26,0.13,0.13,0.03,0.0,0.0,0.08,donald hagan,FOR-2050,2015
-FOR,2210,1,Forest Biology,0.13,0.34,0.3,0.16,0.05,0.0,0.0,0.02,victor ba shelburne,FOR-2210,2015
-FOR,3020,1,Forest Biometrics,0.13,0.35,0.26,0.23,0.03,0.0,0.0,0.0,lawrence gering,FOR-3020,2015
-FOR,3040,1,Forest Resource Economics,0.28,0.49,0.15,0.05,0.0,0.0,0.0,0.03,thomas straka,FOR-3040,2015
-FOR,3410,1,Wood Procure Pract,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,patrick hiesl,FOR-3410,2015
-FOR,4100,1,Harvesting Processes,0.24,0.56,0.12,0.08,0.0,0.0,0.0,0.0,patrick hiesl,FOR-4100,2015
-FOR,4130,1,Integrated Forest Pest Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,roy leslie hedden,FOR-4130,2015
-FOR,4160,1,Forest Policy and Admin,0.68,0.25,0.03,0.01,0.0,0.0,0.0,0.03,joseph lanham,FOR-4160,2015
-FOR,4170,1,Forest Resource Mgt & Regulatn,0.42,0.42,0.12,0.04,0.0,0.0,0.0,0.0,greg yarrow,FOR-4170,2015
-FOR,4310,1,Recreation Res Plan in For Mgt,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,robert baxte powell,FOR-4310,2015
-FOR,4340,1,GIS for Natural Resources,0.82,0.16,0.0,0.0,0.02,0.0,0.0,0.0,christopher post,FOR-4340,2015
-FR,1010,1,Elementary French,0.11,0.47,0.32,0.05,0.0,0.0,0.0,0.05,anne salces  nedeo,FR-1010,2015
-FR,1020,1,Elementary French,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2015
-FR,1020,2,Elementary French,0.67,0.17,0.11,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,FR-1020,2015
-FR,1020,3,Elementary French,0.14,0.29,0.43,0.07,0.07,0.0,0.0,0.0,anne salces  nedeo,FR-1020,2015
-FR,2010,1,Intermediate French,0.43,0.43,0.0,0.0,0.07,0.0,0.0,0.07,paulin de tholozany,FR-2010,2015
-FR,2010,2,Intermediate French,0.25,0.44,0.19,0.13,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-2010,2015
-FR,2010,3,Intermediate French,0.2,0.5,0.1,0.0,0.1,0.0,0.0,0.1,kenneth dav widgren,FR-2010,2015
-FR,2010,4,Intermediate French,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,paulin de tholozany,FR-2010,2015
-FR,2020,1,Intermediate French,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2020,2015
-FR,2020,3,Intermediate French,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,FR-2020,2015
-FR,2020,4,Intermediate French,0.36,0.43,0.07,0.0,0.07,0.0,0.0,0.07,kenneth dav widgren,FR-2020,2015
-FR,2020,5,Intermediate French,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2020,2015
-FR,3000,1,Survey of French Lit,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,paulin de tholozany,FR-3000,2015
-FR,3050,1,Int Fr Con & Comp I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,FR-3050,2015
-FR,3070,1,French Civilization,0.63,0.26,0.0,0.0,0.11,0.0,0.0,0.0,kelly digby peebles,FR-3070,2015
-FR,4000,1,Modern French Lit,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,eric touya,FR-4000,2015
-GC,1010,1,Orientation to G C,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,nona woolbright,GC-1010,2015
-GC,1020,1,Computer Art & CAD Foundations,0.44,0.4,0.02,0.05,0.09,0.0,0.0,0.0,carol jones,GC-1020,2015
-GC,1020,2,Computer Art & CAD Foundations,0.49,0.41,0.02,0.04,0.04,0.0,0.0,0.0,nona woolbright,GC-1020,2015
-GC,1030,1,G C I for Pkgsc,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,john jacobs,GC-1030,2015
-GC,1040,1,Graphic Communications I,0.36,0.55,0.05,0.0,0.05,0.0,0.0,0.0,rebecca suza edlein,GC-1040,2015
-GC,2070,1,Graphic Communications II,0.68,0.28,0.0,0.02,0.0,0.0,0.0,0.02,patrick gee rose,GC-2070,2015
-GC,2400,1,Intro to Web Design and Dev,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,erica black walker,GC-2400,2015
-GC,3400,1,Digital Imaging and eMedia,0.29,0.6,0.04,0.02,0.02,0.0,0.0,0.02,erica black walker,GC-3400,2015
-GC,3460,1,Ink and Substrates,0.28,0.45,0.2,0.02,0.02,0.0,0.0,0.03,liam henry 'hara,GC-3460,2015
-GC,4060,1,Package and Specialty Printing,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,kern cox,GC-4060,2015
-GC,4400,1,Commercial Printing,0.17,0.67,0.04,0.0,0.08,0.0,0.0,0.04,eric weisenmiller,GC-4400,2015
-GC,4400,2,Commercial Printing,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,GC-4400,2015
-GC,4440,1,Current Dev/Trends in Gr Comm,0.39,0.3,0.18,0.06,0.03,0.0,0.0,0.03,liam henry 'hara,GC-4440,2015
-GC,4480,1,Plan and Cont Print,0.42,0.47,0.05,0.03,0.03,0.0,0.0,0.0,john leininger,GC-4480,2015
-GC,4800,1,Senior Seminar in GC,0.7,0.27,0.0,0.0,0.03,0.0,0.0,0.0,charles edwa tonkin,GC-4800,2015
-GC,4900,230,G C Selected Topics-GC Sales,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,john leininger,GC-4900,2015
-GEN,1030,1,Careers in Bioch/Gen,0.85,0.07,0.01,0.03,0.0,0.0,0.0,0.04,alison starr-moss,GEN-1030,2015
-GEN,3000,1,Fundamental Genetics,0.39,0.34,0.23,0.03,0.0,0.0,0.0,0.01,kate leanne wi tsai,GEN-3000,2015
-GEN,3000,2,Fundamental Genetics,0.33,0.47,0.14,0.02,0.02,0.0,0.0,0.02,kate leanne wi tsai,GEN-3000,2015
-GEN,3000,3,Fundamental Genetics,0.35,0.41,0.13,0.04,0.0,0.0,0.0,0.07,kate leanne wi tsai,GEN-3000,2015
-GEN,3020,1,Molecular & General Genetics,0.28,0.47,0.16,0.0,0.06,0.0,0.0,0.03,rajandeep si sekhon,GEN-3020,2015
-GEN,3020,2,Molec & General Genetics (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,GEN-3020,2015
-GEN,3020,3,Molecular & General Genetics,0.21,0.35,0.19,0.08,0.04,0.0,0.0,0.13,lukasz kozubowski,GEN-3020,2015
-GEN,4200,1,Molecular Genetics & Gene Reg,0.47,0.38,0.13,0.03,0.0,0.0,0.0,0.0,julia frugoli,GEN-4200,2015
-GEN,4200,2,Molecular Genetics & Gen (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,GEN-4200,2015
-GEN,4210,2,Mol Gen Gene Reg Lab,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,julia frugoli,GEN-4210,2015
-GEN,4210,3,Mol Gen Gene Reg Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,GEN-4210,2015
-GEN,4400,1,Bioinformatics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,GEN-4400,2015
-GEN,4500,1,Comparative Genetics,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,leigh anne clark,GEN-4500,2015
-GEN,6400,1,Bioinformatics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,GEN-6400,2015
-GEOG,1010,1,Intro to Geography,0.23,0.4,0.33,0.05,0.0,0.0,0.0,0.0,christa smith,GEOG-1010,2015
-GEOG,1030,1,World Regional Geog,0.69,0.2,0.06,0.02,0.02,0.0,0.0,0.0,lance forres howard,GEOG-1030,2015
-GEOG,1030,2,World Regional Geog,0.47,0.21,0.11,0.05,0.05,0.0,0.0,0.11,william churc terry,GEOG-1030,2015
-GEOG,1030,3,World Regional Geog,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,lance forres howard,GEOG-1030,2015
-GEOL,1010,1,Physical Geology,0.17,0.26,0.34,0.12,0.06,0.0,0.0,0.05,alan coulson,GEOL-1010,2015
-GEOL,1010,2,Physical Geology,0.14,0.3,0.33,0.07,0.09,0.0,0.0,0.07,alan coulson,GEOL-1010,2015
-GEOL,1010,3,Physical Geology,0.33,0.33,0.12,0.04,0.08,0.0,0.0,0.12,mine dogan,GEOL-1010,2015
-GEOL,1030,1,Physical Geol Lab,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,alan coulson,GEOL-1030,2015
-GEOL,1030,2,Physical Geol Lab,0.57,0.24,0.05,0.0,0.14,0.0,0.0,0.0,alan coulson,GEOL-1030,2015
-GEOL,1030,3,Physical Geol Lab,0.27,0.59,0.05,0.05,0.0,0.0,0.0,0.05,alan coulson,GEOL-1030,2015
-GEOL,1030,4,Physical Geol Lab,0.17,0.65,0.04,0.0,0.04,0.0,0.0,0.09,alan coulson,GEOL-1030,2015
-GEOL,1030,5,Physical Geol Lab,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2015
-GEOL,1030,6,Physical Geol Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2015
-GEOL,1030,7,Physical Geol Lab,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2015
-GEOL,1030,8,Physical Geol Lab,0.21,0.5,0.04,0.0,0.0,0.0,0.0,0.25,alan coulson,GEOL-1030,2015
-GEOL,1030,9,Physical Geol Lab,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,alan coulson,GEOL-1030,2015
-GEOL,1030,10,Physical Geol Lab,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2015
-GEOL,1030,11,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2015
-GEOL,1030,12,Physical Geol Lab,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,alan coulson,GEOL-1030,2015
-GEOL,2050,1,Mineralogy & Intro Petrology,0.35,0.41,0.18,0.0,0.0,0.0,0.0,0.06,lin shuller-nickles,GEOL-2050,2015
-GEOL,2070,1,Min & Intro Pet Lab,0.13,0.56,0.31,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-2070,2015
-GEOL,2700,1,Sustainable Water,0.55,0.3,0.07,0.0,0.02,0.0,0.0,0.07,stephen mich moysey,GEOL-2700,2015
-GEOL,2750,1,Field Methods,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-2750,2015
-GEOL,3000,1,Environmental Geology,0.39,0.43,0.07,0.04,0.04,0.0,0.0,0.04,scott brame,GEOL-3000,2015
-GEOL,3020,1,Structural Geology,0.2,0.13,0.4,0.2,0.0,0.0,0.0,0.07,james castle,GEOL-3020,2015
-GEOL,4820,1,Groundwater & Contam Transport,0.42,0.33,0.17,0.0,0.0,0.0,0.0,0.08,lawrence murdoch,GEOL-4820,2015
-GER,1010,1,Elementary German,0.37,0.21,0.26,0.0,0.0,0.0,0.0,0.16, lee ferrell,GER-1010,2015
-GER,1010,2,Elementary German,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0, lee ferrell,GER-1010,2015
-GER,1020,1,Elementary German,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-1020,2015
-GER,1020,2,Elementary German,0.33,0.47,0.07,0.07,0.07,0.0,0.0,0.0,oswald harris king,GER-1020,2015
-GER,2010,1,Intermediate German,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,oswald harris king,GER-2010,2015
-GER,2010,2,Intermediate German,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,oswald harris king,GER-2010,2015
-GER,2020,1,Intermediate German,0.25,0.25,0.31,0.13,0.06,0.0,0.0,0.0, lee ferrell,GER-2020,2015
-GER,3050,1,Ger Conv & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-3050,2015
-HCC,8310,1,Fundamentals of Hcc,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,kelly caine,HCC-8310,2015
-HCG,9050,1,Genom & Hlth Policy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,HCG-9050,2015
-HEHD,3990,1,Building Healthy Communities,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,areli moore peralta,HEHD-3990,2015
-HEHD,4000,1,Intro Leadership Theor & Conc,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,HEHD-4000,2015
-HEHD,8000,400,Youth Dev Theories,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,HEHD-8000,2015
-HEHD,8030,400,Ethical Leadership,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,barry garst,HEHD-8030,2015
-HEHD,8060,230,Diverse Society,0.59,0.32,0.05,0.05,0.0,0.0,0.0,0.0,keith george diem,HEHD-8060,2015
-HIST,1010,1,Hist of the U S,0.24,0.44,0.26,0.03,0.03,0.0,0.0,0.0,james brad jeffries,HIST-1010,2015
-HIST,1010,2,Hist of the U S,0.42,0.47,0.09,0.0,0.0,0.0,0.0,0.02,lee brady wilson,HIST-1010,2015
-HIST,1020,1,Hist of the U S,0.11,0.11,0.21,0.11,0.11,0.0,0.0,0.37,maribel morey,HIST-1020,2015
-HIST,1020,2,Hist of the U S,0.43,0.25,0.13,0.1,0.05,0.0,0.0,0.05,john andrew,HIST-1020,2015
-HIST,1220,1,"Hist, Tech & Society",0.21,0.49,0.17,0.04,0.07,0.0,0.0,0.02,pamela mack,HIST-1220,2015
-HIST,1240,1,Environmental History Survey,0.13,0.61,0.11,0.03,0.05,0.0,0.0,0.08,james brad jeffries,HIST-1240,2015
-HIST,1240,2,Environmental History Survey,0.23,0.38,0.35,0.0,0.03,0.0,0.0,0.03,james brad jeffries,HIST-1240,2015
-HIST,1720,1,The West and the World I,0.27,0.44,0.16,0.06,0.03,0.0,0.0,0.05,steven marks,HIST-1720,2015
-HIST,1720,2,The West and the World I,0.3,0.42,0.18,0.03,0.02,0.0,0.0,0.05,steven marks,HIST-1720,2015
-HIST,1720,3,The West and the World I,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,emily wood,HIST-1720,2015
-HIST,1720,4,The West and the World I,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,emily wood,HIST-1720,2015
-HIST,1730,2,The West and the World II,0.24,0.44,0.12,0.05,0.06,0.0,0.0,0.09, alan grubb,HIST-1730,2015
-HIST,2990,1,Historian's Craft,0.75,0.17,0.0,0.08,0.0,0.0,0.0,0.0,michael silvestri,HIST-2990,2015
-HIST,2990,2,Historian's Craft,0.3,0.4,0.0,0.0,0.3,0.0,0.0,0.0,elizabeth carney,HIST-2990,2015
-HIST,2990,3,Historian's Craft,0.32,0.63,0.0,0.0,0.05,0.0,0.0,0.0,rachel anne moore,HIST-2990,2015
-HIST,3000,1,Hist Colonial Amer,0.61,0.32,0.03,0.0,0.03,0.0,0.0,0.03,lee brady wilson,HIST-3000,2015
-HIST,3040,1,Indus & Progr Era,0.54,0.21,0.17,0.04,0.04,0.0,0.0,0.0, roger grant,HIST-3040,2015
-HIST,3100,1,History of Religion in the US,0.42,0.17,0.17,0.0,0.25,0.0,0.0,0.0,elizabeth jemison,HIST-3100,2015
-HIST,3280,1,US Legal History to 1890,0.1,0.29,0.24,0.05,0.1,0.0,0.0,0.24,maribel morey,HIST-3280,2015
-HIST,3300,1,Hist of Mod China,0.16,0.32,0.26,0.05,0.0,0.0,0.0,0.21,edwin moise,HIST-3300,2015
-HIST,3390,1,Africa 1875-Present,0.51,0.15,0.18,0.0,0.13,0.0,0.0,0.03,james burns,HIST-3390,2015
-HIST,3420,1,South Am Since 1800,0.46,0.49,0.05,0.0,0.0,0.0,0.0,0.0,rachel anne moore,HIST-3420,2015
-HIST,3520,1,Pharaonic Egypt,0.34,0.43,0.09,0.09,0.03,0.0,0.0,0.03,elizabeth carney,HIST-3520,2015
-HIST,3610,2,History of Britain to 1688,0.45,0.38,0.03,0.1,0.03,0.0,0.0,0.0,caroline dunn clark,HIST-3610,2015
-HIST,3630,1,Britain Since 1688,0.29,0.42,0.18,0.0,0.05,0.0,0.0,0.05,stephani barczewski,HIST-3630,2015
-HIST,3670,1,Modern Ireland,0.46,0.31,0.13,0.05,0.05,0.0,0.0,0.0,michael silvestri,HIST-3670,2015
-HIST,3890,8,Creative Inquiry in History,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,abel bartley,HIST-3890,2015
-HIST,3900,1,Modern Military History,0.18,0.33,0.39,0.03,0.03,0.0,0.0,0.03,edwin moise,HIST-3900,2015
-HIST,4000,1,Honor & Mastery InTheOld South,0.33,0.42,0.17,0.0,0.08,0.0,0.0,0.0,paul chris anderson,HIST-4000,2015
-HIST,4140,1,Study of Hist Museum,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,meg taylor-shockley,HIST-4140,2015
-HIST,4720,2,Medieval Conquests & Crusades,0.21,0.42,0.11,0.11,0.05,0.0,0.0,0.11,caroline dunn clark,HIST-4720,2015
-HIST,4900,3,Spanish Civil War,0.24,0.29,0.24,0.06,0.12,0.0,0.0,0.06,steven marks,HIST-4900,2015
-HIST,4900,5,Oral History,0.5,0.22,0.17,0.0,0.06,0.0,0.0,0.06,meg taylor-shockley,HIST-4900,2015
-HIST,4930,1,Urban History,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,abel bartley,HIST-4930,2015
-HIST,4940,1,War & Peace in Middle East,0.57,0.29,0.0,0.0,0.07,0.0,0.0,0.07,amit bein,HIST-4940,2015
-HIST,8000,2,SO. Biog,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john andrew,HIST-8000,2015
-HIST,8810,1,Historiography,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, alan grubb,HIST-8810,2015
-HLTH,2020,1,Introduction to Public Health,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2015
-HLTH,2020,2,Introduction to Public Health,0.61,0.35,0.03,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2015
-HLTH,2020,3,Introduction to Public Health,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2015
-HLTH,2020,4,Introduction to Public Health,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2015
-HLTH,2020,5,Introduction to Public Health,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2015
-HLTH,2020,400,Introduction to Public Health,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,ralph stewart welsh,HLTH-2020,2015
-HLTH,2030,1,Health Care Sys,0.6,0.29,0.06,0.06,0.0,0.0,0.0,0.0,frederic fraizer,HLTH-2030,2015
-HLTH,2030,2,Health Care Sys,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,lee alden crandall,HLTH-2030,2015
-HLTH,2400,1,Deter of Hlth Behav,0.36,0.32,0.27,0.0,0.05,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2015
-HLTH,2400,2,Deter of Hlth Behav,0.41,0.32,0.21,0.0,0.03,0.0,0.0,0.03,amelia clinkscales,HLTH-2400,2015
-HLTH,2500,1,Health and Fitness,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,kari jea strothmann,HLTH-2500,2015
-HLTH,2980,1,Human Hlth & Disease,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,HLTH-2980,2015
-HLTH,2980,2,Human Hlth & Disease,0.85,0.09,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,HLTH-2980,2015
-HLTH,3030,1,Public Health Comm,0.63,0.31,0.03,0.0,0.0,0.0,0.0,0.03,debra mitch charles,HLTH-3030,2015
-HLTH,3050,1,Body Resp Hlth Beh,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,brian patric graves,HLTH-3050,2015
-HLTH,3400,1,Hlth Prom Prog Plan,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,brian patric graves,HLTH-3400,2015
-HLTH,3610,1,Int Health Care Econ,0.49,0.29,0.13,0.02,0.0,0.0,0.0,0.07,khoa dang truong,HLTH-3610,2015
-HLTH,3800,1,Epidemiology,0.37,0.42,0.13,0.08,0.0,0.0,0.0,0.0,hugh spitler,HLTH-3800,2015
-HLTH,3800,2,Epidemiology,0.22,0.52,0.22,0.0,0.0,0.0,0.0,0.04,hugh spitler,HLTH-3800,2015
-HLTH,3800,400,Epidemiology,0.36,0.18,0.27,0.0,0.0,0.0,0.0,0.18,deborah alma falta,HLTH-3800,2015
-HLTH,3980,1,Hlth Appraisal Sklls,0.62,0.23,0.15,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2015
-HLTH,3980,2,Hlth Appraisal Sklls,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2015
-HLTH,4190,1,Health Sci Internship Prep Sem,0.33,0.36,0.16,0.13,0.0,0.0,0.0,0.02,kathleen meyer,HLTH-4190,2015
-HLTH,4200,1,Hlth Science Intern,0.77,0.15,0.05,0.0,0.0,0.0,0.0,0.03,kathleen meyer,HLTH-4200,2015
-HLTH,4400,1,Manag Hlth Serv Org,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,frederic fraizer,HLTH-4400,2015
-HLTH,4700,1,Global Health,0.83,0.14,0.0,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,HLTH-4700,2015
-HLTH,4750,1,Hlthcr Oper Mgmt Res,0.77,0.19,0.0,0.0,0.0,0.0,0.0,0.03,lu shi,HLTH-4750,2015
-HLTH,4900,1,Res Eval St Pub Hlth,0.33,0.51,0.13,0.0,0.0,0.0,0.0,0.03,lingling zhang,HLTH-4900,2015
-HLTH,4900,2,Res Eval St Pub Hlth,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,lingling zhang,HLTH-4900,2015
-HLTH,4970,3,Creative Inq in Public Health,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,crystal burn fulmer,HLTH-4970,2015
-HLTH,8120,500,Clinical and Translational Sci,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ronald gimbel,HLTH-8120,2015
-HON,1910,1,Wicked Opera,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,johannes schmidt,HON-1910,2015
-HON,1920,2,Who Gets What and Why?,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,sarah evely winslow,HON-1920,2015
-HON,2060,2,PANDEMIC: Extinction Pending?,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,james morris,HON-2060,2015
-HON,2200,4,The Economic Crisis,0.64,0.18,0.09,0.0,0.09,0.0,0.0,0.0,patrick warren,HON-2200,2015
-HON,2220,1,Pact with the Devil,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,HON-2220,2015
-HORT,1010,1,Horticulture,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-1010,2015
-HORT,2100,1,Growing Fall Plants,0.32,0.42,0.11,0.05,0.0,0.0,0.0,0.11,james emerson faust,HORT-2100,2015
-HORT,2120,1,Turfgrass Culture,0.52,0.39,0.07,0.02,0.0,0.0,0.0,0.0,haibo liu,HORT-2120,2015
-HORT,2130,1,Turf Culture Lab,0.71,0.14,0.05,0.0,0.0,0.0,0.0,0.1,donald garrett,HORT-2130,2015
-HORT,2130,2,Turf Culture Lab,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,donald garrett,HORT-2130,2015
-HORT,3030,1,Landscape Plants,0.31,0.27,0.17,0.09,0.09,0.0,0.0,0.06,robert polomski,HORT-3030,2015
-HORT,3080,1,Sust Landsc Des Install Maint,0.59,0.19,0.13,0.0,0.06,0.0,0.0,0.03,ellen anita vincent,HORT-3080,2015
-HORT,4090,1,Senior Capstone Course,0.79,0.13,0.04,0.0,0.04,0.0,0.0,0.0,ellen anita vincent,HORT-4090,2015
-HORT,4120,1,Adv Turfgrass Mgt,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,lambert mccarty,HORT-4120,2015
-HORT,4330,1,Turf Weed Management,0.15,0.6,0.2,0.05,0.0,0.0,0.0,0.0,ted whitwell,HORT-4330,2015
-HP,8010,1,Preservation Law and Econ,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,barry louis stiefel,HP-8010,2015
-HRD,8200,400,Human Perform Improv,0.93,0.0,0.0,0.0,0.02,0.0,0.0,0.05,russell marion,HRD-8200,2015
-HRD,8300,400,Concepts of H R D,0.74,0.09,0.02,0.0,0.09,0.0,0.0,0.05,cynthia sims,HRD-8300,2015
-HRD,8450,400,Needs Assess Ed/Ind,0.93,0.04,0.0,0.0,0.02,0.0,0.0,0.0,philip mcgee,HRD-8450,2015
-HRD,8600,400,Instruc Mat Devel,0.89,0.04,0.04,0.0,0.02,0.0,0.0,0.02,philip mcgee,HRD-8600,2015
-HUM,3090,1,Studies in Humanities,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,HUM-3090,2015
-IE,2000,1,Soph Seminar in I E,0.56,0.17,0.11,0.08,0.08,0.0,0.0,0.0,brian melloy,IE-2000,2015
-IE,2100,1,Des Analysis Wrk Sys,0.07,0.68,0.21,0.02,0.01,0.0,0.0,0.0,david neyens,IE-2100,2015
-IE,2800,1,Deterministic Operations Rsrch,0.19,0.32,0.24,0.13,0.05,0.0,0.0,0.06,amin khademi,IE-2800,2015
-IE,2800,2,Deterministic Operations Rsrch,0.47,0.24,0.15,0.05,0.07,0.0,0.0,0.02,jonathan lowe,IE-2800,2015
-IE,3010,1,Systems Design I,0.28,0.59,0.08,0.03,0.0,0.0,0.0,0.03,joel greenstein,IE-3010,2015
-IE,3600,1,Industrial Apps of Prob/Stat I,0.29,0.32,0.25,0.05,0.07,0.0,0.0,0.02,mary elizabeth kurz,IE-3600,2015
-IE,3680,1,Prof Practice in I E,0.93,0.03,0.02,0.02,0.0,0.0,0.0,0.0,robert james riggs,IE-3680,2015
-IE,3840,1,Engr Econ Analysis,0.08,0.22,0.11,0.08,0.11,0.0,0.0,0.41,brian melloy,IE-3840,2015
-IE,3860,1,Prod Plan & Cont,0.21,0.41,0.21,0.18,0.0,0.0,0.0,0.0,robert james riggs,IE-3860,2015
-IE,4400,1,Decision Support Sys,0.35,0.29,0.15,0.08,0.11,0.0,0.0,0.02,scott jenning mason,IE-4400,2015
-IE,4400,2,Decision Support Sys,0.29,0.25,0.1,0.13,0.17,0.0,0.0,0.06,site wang,IE-4400,2015
-IE,4560,1,Supply Chain Design & Control,0.31,0.42,0.18,0.04,0.0,0.0,0.0,0.04,william ferrell,IE-4560,2015
-IE,4610,1,Quality Engineering,0.25,0.33,0.31,0.06,0.02,0.0,0.0,0.02,byung rae cho,IE-4610,2015
-IE,4650,1,Facilities Planning & Design,0.79,0.18,0.01,0.02,0.0,0.0,0.0,0.0,jonathan lowe,IE-4650,2015
-IE,4650,2,Facilities Planning & Design,0.25,0.38,0.19,0.16,0.0,0.0,0.0,0.02,william ferrell,IE-4650,2015
-IE,4820,1,Systems Modeling,0.48,0.38,0.11,0.02,0.0,0.0,0.0,0.0,kevin taaffe,IE-4820,2015
-IE,4820,2,Systems Modeling,0.21,0.3,0.3,0.1,0.04,0.0,0.0,0.04,tugce isik,IE-4820,2015
-IE,4910,1,Network Flows for IE App,0.25,0.13,0.25,0.06,0.06,0.0,0.0,0.25,burak eksioglu,IE-4910,2015
-IE,4910,2,Modeling & Analysis of MFG,0.61,0.26,0.0,0.03,0.06,0.0,0.0,0.03,mary elizabeth kurz,IE-4910,2015
-IE,6560,1,Supply Chain Design & Control,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,william ferrell,IE-6560,2015
-IE,6910,3,Simulation Modeling & Analysis,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,IE-6910,2015
-IE,8000,1,Human Factors Eng,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,david neyens,IE-8000,2015
-IE,8030,1,Engr Optimization and Apps,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,IE-8030,2015
-IE,8090,1,Model Sys Under Risk,0.25,0.54,0.21,0.0,0.0,0.0,0.0,0.0,burak eksioglu,IE-8090,2015
-IE,8510,1,Descriptive Analytics,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,mary elizabeth kurz,IE-8510,2015
-IE,8530,1,Foundations of Quality,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,byung rae cho,IE-8530,2015
-IE,8550,1,SC & Logistics Modeling II,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kevin taaffe,IE-8550,2015
-IE,8930,1,Multilevel Math Optimization,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,IE-8930,2015
-INT,1010,5,Career Center Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,troy nunamaker,INT-1010,2015
-INT,1020,5,Career Center Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,troy nunamaker,INT-1020,2015
-INT,1030,5,Career Center Internship PT 3+,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,troy nunamaker,INT-1030,2015
-IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.03,sharon nagy,IS-1010,2015
-ITAL,1010,1,Elementary Italian,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,luca barattoni,ITAL-1010,2015
-ITAL,1010,2,Elementary Italian,0.61,0.11,0.0,0.11,0.06,0.0,0.0,0.11,luca barattoni,ITAL-1010,2015
-ITAL,1010,3,Elementary Italian,0.42,0.37,0.05,0.0,0.0,0.0,0.0,0.16,valentina lombardi,ITAL-1010,2015
-ITAL,1010,4,Elementary Italian,0.43,0.36,0.07,0.0,0.07,0.0,0.0,0.07,valentina lombardi,ITAL-1010,2015
-ITAL,1020,1,Elementary Italian,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-1020,2015
-ITAL,2010,1,Intermediate Italian,0.44,0.31,0.25,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2010,2015
-ITAL,2010,2,Intermediate Italian,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2010,2015
-JAPN,1010,1,Elementary Japanese,0.76,0.0,0.18,0.06,0.0,0.0,0.0,0.0,jae allegr takeuchi,JAPN-1010,2015
-JAPN,1010,2,Elementary Japanese,0.59,0.12,0.12,0.0,0.06,0.0,0.0,0.12,jae allegr takeuchi,JAPN-1010,2015
-JAPN,1020,1,Elementary Japanese,0.38,0.31,0.08,0.08,0.0,0.0,0.0,0.15,kazuko shoji,JAPN-1020,2015
-JAPN,2010,1,Intermed Japanese,0.47,0.33,0.13,0.0,0.07,0.0,0.0,0.0,kazuko shoji,JAPN-2010,2015
-JAPN,3050,1,Japanese Conversation & Comp,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,toshiko kishimoto,JAPN-3050,2015
-LANG,2540,1,Introduction to World Cinemas,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,raquel anido,LANG-2540,2015
-LANG,3710,1,Language and Culture,0.36,0.45,0.09,0.09,0.0,0.0,0.0,0.0,yanhua zhang,LANG-3710,2015
-LARC,1150,1,Intro Landscape Architecture,0.48,0.18,0.24,0.0,0.06,0.0,0.0,0.03,martin john holland,LARC-1150,2015
-LARC,1280,1,Technical Graphics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,LARC-1280,2015
-LARC,1510,1,Basic Design I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,LARC-1510,2015
-LARC,2510,1,Larch Design Fund,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,robert hewitt,LARC-2510,2015
-LARC,2620,1,Design Impl I,0.36,0.14,0.29,0.0,0.14,0.0,0.0,0.07,paul russell,LARC-2620,2015
-LARC,3510,1,Regional Design,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,yang song,LARC-3510,2015
-LARC,4530,2,Key Issues in Larch,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,LARC-4530,2015
-LARC,8210,1,Research Methods,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,LARC-8210,2015
-LARC,8500,1,Grad Colloquium,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,LARC-8500,2015
-LAW,3220,1,Legal Env of Bus,0.5,0.27,0.16,0.05,0.02,0.0,0.0,0.0,edward ray claggett,LAW-3220,2015
-LAW,3220,2,Legal Env of Bus,0.57,0.28,0.09,0.02,0.02,0.0,0.0,0.02,edward ray claggett,LAW-3220,2015
-LAW,3220,3,Legal Env of Bus,0.31,0.36,0.17,0.07,0.05,0.0,0.0,0.05,kenneth toussaint,LAW-3220,2015
-LAW,3220,4,Legal Env of Bus,0.21,0.4,0.24,0.05,0.07,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2015
-LAW,3220,5,Legal Env of Bus,0.2,0.36,0.36,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2015
-LAW,3220,6,Legal Env of Bus,0.12,0.49,0.3,0.02,0.05,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2015
-LAW,3220,7,Legal Env of Bus,0.45,0.32,0.2,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,LAW-3220,2015
-LAW,3220,8,Legal Env of Bus,0.39,0.36,0.23,0.0,0.0,0.0,0.0,0.02,kath kisska-schulze,LAW-3220,2015
-LAW,3220,9,Legal Env of Bus,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,john hine,LAW-3220,2015
-LAW,3220,10,Legal Env of Bus,0.27,0.41,0.25,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2015
-LAW,3220,11,Legal Env of Bus,0.51,0.47,0.02,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2015
-LAW,3220,100,Legal Env of Bus (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2015
-LAW,3220,400,Legal Env of Bus,0.15,0.38,0.15,0.06,0.12,0.0,0.0,0.15,virgini ward-vaughn,LAW-3220,2015
-LAW,3220,401,Legal Env of Bus,0.1,0.35,0.23,0.03,0.06,0.0,0.0,0.23,virgini ward-vaughn,LAW-3220,2015
-LAW,3220,402,Legal Env of Bus,0.13,0.27,0.37,0.07,0.1,0.0,0.0,0.07,virgini ward-vaughn,LAW-3220,2015
-LAW,3220,403,Legal Env of Bus,0.19,0.3,0.11,0.07,0.15,0.0,0.0,0.19,virgini ward-vaughn,LAW-3220,2015
-LAW,3330,1,Real Estate Law,0.22,0.49,0.2,0.05,0.02,0.02,0.0,0.0,judson jahn,LAW-3330,2015
-LAW,4050,1,Construction Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-4050,2015
-LIB,3010,1,Patent Searching,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,janice comfort,LIB-3010,2015
-LIH,1270,1,Introduction to L&Ih,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,graciela tissera,LIH-1270,2015
-LS,1000,1,Therapeutic Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,LS-1000,2015
-LS,1000,2,Therapeutic Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-1000,2015
-LS,1000,3,Therapeutic Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ranjanbala dil amin,LS-1000,2015
-LS,1000,6,Beg. Non-competitive Karate,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,june pilcher,LS-1000,2015
-LS,1000,19,Introduction to Hip-Hop Dance,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,andrew ellio boland,LS-1000,2015
-LS,1000,31,Stand-up Paddleboarding,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,elizabeth venable,LS-1000,2015
-LS,1410,1,Top Rope Climbing,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,glenn dav middleton,LS-1410,2015
-LS,1410,5,Top Rope Climbing,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,glenn dav middleton,LS-1410,2015
-LS,1450,5,Camping/Backpacking,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,samuel james keith,LS-1450,2015
-LS,1570,7,Shotgun Sports,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,susan ruth sullivan,LS-1570,2015
-LS,1580,5,Archery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,herbert strickland,LS-1580,2015
-LS,1640,1,Whitewater Kayaking,0.73,0.0,0.09,0.0,0.0,0.0,0.0,0.18,samuel dylan mcgee,LS-1640,2015
-LS,1640,3,Whitewater Kayaking,0.64,0.09,0.0,0.0,0.0,0.0,0.0,0.27,emily grace turke,LS-1640,2015
-LS,1650,3,Inland Kayak Touring,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,sarah wilcer,LS-1650,2015
-LS,1750,2,Fly Fishing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael watts,LS-1750,2015
-LS,1850,3,Bowling,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,megan elizabet cato,LS-1850,2015
-LS,1850,10,Bowling,0.83,0.07,0.07,0.03,0.0,0.0,0.0,0.0,katie dudley,LS-1850,2015
-LS,1940,2,Racquetball,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,LS-1940,2015
-LS,2040,1,Soccer,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,jessica ca doughtie,LS-2040,2015
-LS,2100,1,Learn to Dance,0.89,0.03,0.0,0.0,0.03,0.0,0.0,0.06,matthew lee krabbe,LS-2100,2015
-LS,2110,1,Introduction to Belly Dance,0.8,0.05,0.0,0.0,0.0,0.0,0.0,0.15,stephanie pack,LS-2110,2015
-LS,2110,3,Introduction to Belly Dance,0.86,0.09,0.0,0.0,0.05,0.0,0.0,0.0,stephanie pack,LS-2110,2015
-LS,2200,4,Shag,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,broadus fleming,LS-2200,2015
-LS,2200,7,Shag,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,LS-2200,2015
-LS,2200,10,Shag,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,matthew lee krabbe,LS-2200,2015
-LS,2270,2,Intro to Swing Dance,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,paul hoke,LS-2270,2015
-LS,2270,3,Intro to Swing Dance,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,LS-2270,2015
-LS,2270,4,Intro to Swing Dance,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,LS-2270,2015
-LS,2280,1,Intermediate Swing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,paul hoke,LS-2280,2015
-LS,2320,2,Core Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,diane moreno,LS-2320,2015
-LS,2320,3,Core Training,0.88,0.0,0.04,0.0,0.0,0.0,0.0,0.08,diane moreno,LS-2320,2015
-LS,2320,4,Core Training,0.91,0.0,0.04,0.0,0.0,0.0,0.0,0.04,diane moreno,LS-2320,2015
-LS,2350,4,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,LS-2350,2015
-LS,2350,5,Basic Yoga,0.65,0.22,0.0,0.0,0.0,0.0,0.0,0.13,renee warren gahan,LS-2350,2015
-LS,2350,6,Basic Yoga,0.71,0.14,0.1,0.05,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2015
-LS,2350,7,Basic Yoga,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2015
-LS,2360,1,Power/Ashtanga Yoga,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,ani reina-nunnelley,LS-2360,2015
-LS,2360,2,Power/Ashtanga Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,LS-2360,2015
-LS,2360,3,Power/Ashtanga Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,LS-2360,2015
-LS,2360,6,Power/Ashtanga Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,silica eliza larkin,LS-2360,2015
-LS,2380,3,Vinyasa Flow Yoga,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,jenefer nadenicek,LS-2380,2015
-LS,2380,4,Vinyasa Flow Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,jenefer nadenicek,LS-2380,2015
-LS,2380,5,Vinyasa Flow Yoga,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jenefer nadenicek,LS-2380,2015
-LS,2420,2,Meditation and Relax,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,renee warren gahan,LS-2420,2015
-LS,2420,3,Meditation and Relax,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,LS-2420,2015
-LS,2420,5,Meditation and Relax,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,LS-2420,2015
-LS,2420,7,Meditation and Relax,0.79,0.13,0.0,0.0,0.04,0.0,0.0,0.04,renee warren gahan,LS-2420,2015
-LS,2450,2,Pilates,0.89,0.0,0.06,0.0,0.0,0.0,0.0,0.06,melanie ivey job,LS-2450,2015
-LS,2450,3,Pilates,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,LS-2450,2015
-LS,2450,6,Pilates,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,LS-2450,2015
-LS,2460,1,Intermediate Pilates,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,melanie ivey job,LS-2460,2015
-LS,2510,3,Running & Jogging,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,robert edwar lawson,LS-2510,2015
-LS,2700,1,Sports Officiating,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,christopher war cox,LS-2700,2015
-LS,2770,1,Lifeguarding,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,kelly lynn womack,LS-2770,2015
-LS,3580,1,Advanced Shotgun Skeet,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,charles flint,LS-3580,2015
-MATH,1010,2,Essen Math for Informed Soc,0.26,0.26,0.21,0.05,0.16,0.0,0.0,0.05,paran rebeka norton,MATH-1010,2015
-MATH,1010,3,Essen Math for Informed Soc,0.18,0.45,0.27,0.09,0.0,0.0,0.0,0.0,minghua cui,MATH-1010,2015
-MATH,1010,4,Essen Math for Informed Soc,0.44,0.36,0.08,0.08,0.03,0.0,0.0,0.0,judith cottingham,MATH-1010,2015
-MATH,1010,6,Essen Math for Informed Soc,0.39,0.36,0.17,0.06,0.0,0.0,0.0,0.03,judith cottingham,MATH-1010,2015
-MATH,1010,8,Essen Math for Informed Soc,0.42,0.21,0.26,0.05,0.05,0.0,0.0,0.0,paran rebeka norton,MATH-1010,2015
-MATH,1010,9,Essen Math for Informed Soc,0.35,0.24,0.12,0.06,0.24,0.0,0.0,0.0,yijun chen,MATH-1010,2015
-MATH,1010,10,Essen Math for Informed Soc,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,xiyan tan,MATH-1010,2015
-MATH,1010,12,Essen Math for Informed Soc,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,yijun chen,MATH-1010,2015
-MATH,1010,14,Essen Math for Informed Soc,0.39,0.33,0.22,0.0,0.06,0.0,0.0,0.0,xiyan tan,MATH-1010,2015
-MATH,1010,101,Essen Math for Informed Soc,0.35,0.27,0.12,0.12,0.0,0.0,0.0,0.15,meredith nicol burr,MATH-1010,2015
-MATH,1020,1,Intro to Mathematical Analysis,0.25,0.28,0.19,0.08,0.14,0.0,0.0,0.06,warren adams,MATH-1020,2015
-MATH,1020,2,Intro to Mathematical Analysis,0.0,0.32,0.37,0.16,0.11,0.0,0.0,0.05,michael we lamoreux,MATH-1020,2015
-MATH,1020,3,Intro to Mathematical Analysis,0.16,0.42,0.11,0.0,0.26,0.0,0.0,0.05,jerry lero phillips,MATH-1020,2015
-MATH,1020,4,Intro to Mathematical Analysis,0.06,0.22,0.39,0.11,0.06,0.0,0.0,0.17,huixi li,MATH-1020,2015
-MATH,1020,5,Intro to Mathematical Analysis,0.11,0.37,0.26,0.11,0.16,0.0,0.0,0.0,aaro ramirez flores,MATH-1020,2015
-MATH,1020,6,Intro to Mathematical Analysis,0.26,0.37,0.16,0.05,0.11,0.0,0.0,0.05,stefani ca mokalled,MATH-1020,2015
-MATH,1020,7,Intro to Mathematical Analysis,0.21,0.05,0.21,0.26,0.21,0.0,0.0,0.05,huixi li,MATH-1020,2015
-MATH,1020,8,Intro to Mathematical Analysis,0.21,0.11,0.21,0.32,0.05,0.0,0.0,0.11,aaro ramirez flores,MATH-1020,2015
-MATH,1020,9,Intro to Mathematical Analysis,0.11,0.22,0.33,0.11,0.17,0.0,0.0,0.06,jerry lero phillips,MATH-1020,2015
-MATH,1020,10,Intro to Mathematical Analysis,0.26,0.16,0.21,0.21,0.0,0.0,0.0,0.16,xiaoyuan liu,MATH-1020,2015
-MATH,1020,11,Intro to Mathematical Analysis,0.21,0.21,0.26,0.11,0.16,0.0,0.0,0.05,travis baumbaugh,MATH-1020,2015
-MATH,1020,12,Intro to Mathematical Analysis,0.17,0.39,0.11,0.17,0.0,0.0,0.0,0.17,tianhui wei,MATH-1020,2015
-MATH,1020,13,Intro to Mathematical Analysis,0.2,0.43,0.18,0.05,0.08,0.0,0.0,0.08,randy davidson,MATH-1020,2015
-MATH,1020,14,Intro to Mathematical Analysis,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,jennifer van dyken,MATH-1020,2015
-MATH,1020,15,Intro to Mathematical Analysis,0.06,0.22,0.33,0.22,0.06,0.0,0.0,0.11,yibo xu,MATH-1020,2015
-MATH,1020,16,Intro to Mathematical Analysis,0.39,0.28,0.11,0.06,0.06,0.0,0.0,0.11,stefani ca mokalled,MATH-1020,2015
-MATH,1020,17,Intro to Mathematical Analysis,0.17,0.28,0.22,0.17,0.17,0.0,0.0,0.0,tiantian yang,MATH-1020,2015
-MATH,1020,18,Intro to Mathematical Analysis,0.16,0.42,0.32,0.11,0.0,0.0,0.0,0.0,xiaoyuan liu,MATH-1020,2015
-MATH,1020,19,Intro to Mathematical Analysis,0.16,0.42,0.21,0.11,0.0,0.0,0.0,0.11,chase norman joyner,MATH-1020,2015
-MATH,1020,20,Intro to Mathematical Analysis,0.26,0.16,0.21,0.05,0.11,0.0,0.0,0.21,tianhui wei,MATH-1020,2015
-MATH,1020,21,Intro to Mathematical Analysis,0.21,0.32,0.21,0.11,0.16,0.0,0.0,0.0,prab withana gamage,MATH-1020,2015
-MATH,1020,22,Intro to Mathematical Analysis,0.16,0.26,0.21,0.05,0.21,0.0,0.0,0.11,michael we lamoreux,MATH-1020,2015
-MATH,1020,23,Intro to Mathematical Analysis,0.22,0.11,0.17,0.0,0.33,0.0,0.0,0.17,hao zuo,MATH-1020,2015
-MATH,1020,24,Intro to Mathematical Analysis,0.06,0.33,0.33,0.06,0.17,0.0,0.0,0.06,yibo xu,MATH-1020,2015
-MATH,1020,25,Intro to Mathematical Analysis,0.05,0.37,0.26,0.11,0.11,0.0,0.0,0.11,junyang zhuang,MATH-1020,2015
-MATH,1020,26,Intro to Mathematical Analysis,0.42,0.21,0.16,0.11,0.0,0.0,0.0,0.11,xintao liu,MATH-1020,2015
-MATH,1020,27,Intro to Mathematical Analysis,0.26,0.37,0.16,0.11,0.05,0.0,0.0,0.05,haodong li,MATH-1020,2015
-MATH,1020,28,Intro to Mathematical Analysis,0.32,0.11,0.26,0.05,0.21,0.0,0.0,0.05,chase norman joyner,MATH-1020,2015
-MATH,1020,29,Intro to Mathematical Analysis,0.21,0.37,0.26,0.11,0.05,0.0,0.0,0.0,randy davidson,MATH-1020,2015
-MATH,1020,30,Intro to Mathematical Analysis,0.21,0.26,0.26,0.0,0.16,0.0,0.0,0.11,prab withana gamage,MATH-1020,2015
-MATH,1020,31,Intro to Mathematical Analysis,0.17,0.33,0.33,0.0,0.0,0.0,0.0,0.17,xintao liu,MATH-1020,2015
-MATH,1020,32,Intro to Mathematical Analysis,0.0,0.21,0.42,0.21,0.16,0.0,0.0,0.0,junyang zhuang,MATH-1020,2015
-MATH,1020,33,Intro to Mathematical Analysis,0.26,0.37,0.21,0.05,0.05,0.0,0.0,0.05,janie caro mcdonald,MATH-1020,2015
-MATH,1020,34,Intro to Mathematical Analysis,0.26,0.21,0.21,0.11,0.16,0.0,0.0,0.05,randy davidson,MATH-1020,2015
-MATH,1020,35,Intro to Mathematical Analysis,0.22,0.44,0.22,0.0,0.0,0.0,0.0,0.11,yinggu bao,MATH-1020,2015
-MATH,1020,36,Intro to Mathematical Analysis,0.21,0.21,0.16,0.21,0.16,0.0,0.0,0.05,haodong li,MATH-1020,2015
-MATH,1020,37,Intro to Mathematical Analysis,0.11,0.28,0.22,0.17,0.06,0.0,0.0,0.17,tiantian yang,MATH-1020,2015
-MATH,1020,38,Intro to Mathematical Analysis,0.17,0.28,0.17,0.06,0.11,0.0,0.0,0.22,hao zuo,MATH-1020,2015
-MATH,1020,39,Intro to Mathematical Analysis,0.0,0.32,0.26,0.05,0.32,0.0,0.0,0.05, erwin walker,MATH-1020,2015
-MATH,1020,40,Intro to Mathematical Analysis,0.16,0.21,0.16,0.05,0.26,0.0,0.0,0.16,travis baumbaugh,MATH-1020,2015
-MATH,1020,41,Intro to Mathematical Analysis,0.17,0.28,0.22,0.06,0.22,0.0,0.0,0.06,travis baumbaugh,MATH-1020,2015
-MATH,1020,42,Intro to Mathematical Analysis,0.0,0.29,0.35,0.06,0.12,0.0,0.0,0.18,michael we lamoreux,MATH-1020,2015
-MATH,1020,43,Intro to Mathematical Analysis,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,jennifer van dyken,MATH-1020,2015
-MATH,1020,44,Intro to Mathematical Analysis,0.37,0.26,0.05,0.11,0.16,0.0,0.0,0.05,randy davidson,MATH-1020,2015
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.6,0.33,0.07,donna simms,MATH-1040,2015
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.62,0.03,tony thanh nguyen,MATH-1040,2015
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.57,0.07,stella watson,MATH-1040,2015
-MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.34,0.59,0.07,patrick buckingham,MATH-1040,2015
-MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.42,0.53,0.04,rebecca lynn knoll,MATH-1040,2015
-MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.36,0.18,liang zhao,MATH-1040,2015
-MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.5,0.41,0.09,patrick buckingham,MATH-1040,2015
-MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.52,0.33,0.14,jason to hedetniemi,MATH-1040,2015
-MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.41,0.12,muhamm mohebujjaman,MATH-1040,2015
-MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.41,0.57,0.02,hugh geller,MATH-1040,2015
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.42,0.48,0.11,eliza dar gallagher,MATH-1050,2015
-MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.6,0.37,0.03,charity watson,MATH-1050,2015
-MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.39,0.02,charity watson,MATH-1050,2015
-MATH,1060,1,Calculus of One Variable I,0.07,0.32,0.15,0.07,0.27,0.0,0.0,0.12,stefan adam bock,MATH-1060,2015
-MATH,1060,2,Calculus of One Variable I,0.2,0.29,0.2,0.09,0.04,0.0,0.0,0.18,jonathon leverenz,MATH-1060,2015
-MATH,1060,3,Calculus of One Variable I,0.1,0.25,0.21,0.13,0.1,0.0,0.0,0.21,abigail bowers,MATH-1060,2015
-MATH,1060,4,Calculus of One Variable I,0.29,0.14,0.26,0.11,0.11,0.0,0.0,0.09,marilyn reba,MATH-1060,2015
-MATH,1060,5,Calculus of One Variable I,0.1,0.29,0.24,0.07,0.19,0.0,0.0,0.12,abigail bowers,MATH-1060,2015
-MATH,1060,6,Calculus of One Variable I,0.26,0.26,0.13,0.07,0.09,0.0,0.0,0.2,meredith nicol burr,MATH-1060,2015
-MATH,1060,7,Calculus of One Variable I,0.14,0.31,0.2,0.09,0.09,0.0,0.0,0.17,marilyn reba,MATH-1060,2015
-MATH,1060,8,Calculus of One Variable I,0.04,0.38,0.3,0.06,0.17,0.0,0.0,0.04,abigail bowers,MATH-1060,2015
-MATH,1060,9,Calculus of One Variable I,0.29,0.33,0.21,0.02,0.02,0.0,0.0,0.12,abdullah al mamun,MATH-1060,2015
-MATH,1060,10,Calculus of One Variable I,0.2,0.3,0.18,0.07,0.09,0.0,0.0,0.16,meredith nicol burr,MATH-1060,2015
-MATH,1060,11,Calculus of One Variable I,0.12,0.31,0.31,0.14,0.0,0.0,0.0,0.12,beth novick,MATH-1060,2015
-MATH,1060,12,Calculus of One Variable I,0.09,0.28,0.19,0.06,0.26,0.0,0.0,0.13,michael gl eldredge,MATH-1060,2015
-MATH,1060,13,Calculus of One Variable I,0.04,0.41,0.3,0.09,0.07,0.0,0.0,0.09,sea sather-wagstaff,MATH-1060,2015
-MATH,1060,14,Calculus of One Variable I,0.15,0.36,0.24,0.09,0.09,0.0,0.0,0.06,allen anderso guest,MATH-1060,2015
-MATH,1060,15,Calculus of One Variable I,0.16,0.52,0.13,0.06,0.1,0.0,0.0,0.03,allen anderso guest,MATH-1060,2015
-MATH,1060,16,Calculus of One Variable I,0.11,0.28,0.23,0.09,0.15,0.0,0.0,0.15,sea sather-wagstaff,MATH-1060,2015
-MATH,1060,17,Calculus of One Variable I,0.34,0.25,0.23,0.09,0.05,0.0,0.0,0.05,ryan grove,MATH-1060,2015
-MATH,1060,18,Calculus of One Variable I,0.05,0.3,0.28,0.08,0.23,0.0,0.0,0.08,amy christine grady,MATH-1060,2015
-MATH,1060,19,Calculus of One Variable I,0.15,0.32,0.11,0.17,0.17,0.0,0.0,0.08,jonathon leverenz,MATH-1060,2015
-MATH,1060,20,Calculus of One Variable I,0.07,0.26,0.17,0.05,0.12,0.0,0.0,0.33,sergey charnyi,MATH-1060,2015
-MATH,1060,21,Calculus of One Variable I,0.14,0.17,0.08,0.17,0.14,0.0,0.0,0.31,rui gong,MATH-1060,2015
-MATH,1060,22,Calculus of One Variable I,0.11,0.2,0.29,0.0,0.09,0.0,0.0,0.31,lee andrew jenkins,MATH-1060,2015
-MATH,1060,23,Calculus of One Variable I,0.16,0.27,0.24,0.09,0.07,0.0,0.0,0.18,stefan adam bock,MATH-1060,2015
-MATH,1060,24,Calculus of One Variable I,0.05,0.21,0.32,0.05,0.26,0.0,0.0,0.11,jennifer van dyken,MATH-1060,2015
-MATH,1060,25,Calculus of One Variable I,0.32,0.29,0.21,0.03,0.11,0.0,0.0,0.05,shiyi tu,MATH-1060,2015
-MATH,1060,100,Calc of One Variable I (HON),0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,beth novick,MATH-1060,2015
-MATH,1070,1,Differen and Integral Calculus,0.0,0.47,0.29,0.18,0.06,0.0,0.0,0.0,donna simms,MATH-1070,2015
-MATH,1080,1,Calculus of One Variable II,0.1,0.16,0.19,0.0,0.26,0.0,0.0,0.29,alistair bentley,MATH-1080,2015
-MATH,1080,2,Calculus of One Variable II,0.09,0.22,0.13,0.09,0.13,0.0,0.0,0.35,terri johnson,MATH-1080,2015
-MATH,1080,3,Calculus of One Variable II,0.05,0.19,0.27,0.03,0.3,0.0,0.0,0.16,fiona may knoll,MATH-1080,2015
-MATH,1080,4,Calculus of One Variable II,0.03,0.15,0.21,0.09,0.21,0.0,0.0,0.3,sanwar ahmad,MATH-1080,2015
-MATH,1080,5,Calculus of One Variable II,0.05,0.23,0.18,0.08,0.21,0.0,0.0,0.26,garrett dranichak,MATH-1080,2015
-MATH,1080,6,Calculus of One Variable II,0.03,0.17,0.17,0.06,0.43,0.0,0.0,0.14,javier ruiz ramirez,MATH-1080,2015
-MATH,1080,7,Calculus of One Variable II,0.09,0.12,0.18,0.12,0.27,0.0,0.0,0.21,rebecca ramos,MATH-1080,2015
-MATH,1080,8,Calculus of One Variable II,0.07,0.22,0.33,0.19,0.11,0.0,0.0,0.07,qijun he,MATH-1080,2015
-MATH,1080,10,Calculus of One Variable II,0.03,0.11,0.18,0.26,0.24,0.0,0.0,0.18,honghai xu,MATH-1080,2015
-MATH,1080,11,Calculus of One Variable II,0.03,0.22,0.08,0.08,0.46,0.0,0.0,0.14,audrey nico devries,MATH-1080,2015
-MATH,1080,12,Calculus of One Variable II,0.06,0.2,0.2,0.09,0.26,0.0,0.0,0.2,shuhan xu,MATH-1080,2015
-MATH,1080,100,Calc of One Variable II (HON),0.18,0.24,0.12,0.06,0.0,0.0,0.0,0.41,terri johnson,MATH-1080,2015
-MATH,1150,1,Contemp Math for Elem Teach I,0.63,0.23,0.13,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1150,2015
-MATH,1150,2,Contemp Math for Elem Teach I,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,allison stoddard,MATH-1150,2015
-MATH,1160,1,Contemp Math for Elem Teach II,0.64,0.28,0.06,0.03,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-1160,2015
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.02,marion hanna,MATH-1990,2015
-MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,marion hanna,MATH-1990,2015
-MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.04,marion hanna,MATH-1990,2015
-MATH,2060,1,Calculus of Several Variables,0.36,0.23,0.05,0.13,0.1,0.0,0.0,0.13,mishko mitkovski,MATH-2060,2015
-MATH,2060,2,Calculus of Several Variables,0.19,0.25,0.22,0.14,0.14,0.0,0.0,0.06,christopher cox,MATH-2060,2015
-MATH,2060,3,Calculus of Several Variables,0.26,0.16,0.16,0.1,0.19,0.0,0.0,0.13,akshay sunil gupte,MATH-2060,2015
-MATH,2060,4,Calculus of Several Variables,0.36,0.38,0.18,0.0,0.03,0.0,0.0,0.05,xin liu,MATH-2060,2015
-MATH,2060,5,Calculus of Several Variables,0.18,0.26,0.08,0.05,0.26,0.0,0.0,0.16,gretchen matthews,MATH-2060,2015
-MATH,2060,6,Calculus of Several Variables,0.11,0.39,0.08,0.17,0.14,0.0,0.0,0.11,shari prevost,MATH-2060,2015
-MATH,2060,7,Calculus of Several Variables,0.37,0.24,0.24,0.0,0.11,0.0,0.0,0.05,martin joha schmoll,MATH-2060,2015
-MATH,2060,8,Calculus of Several Variables,0.44,0.33,0.08,0.03,0.03,0.0,0.0,0.1,xin liu,MATH-2060,2015
-MATH,2060,9,Calculus of Several Variables,0.16,0.27,0.14,0.08,0.19,0.0,0.0,0.16,gretchen matthews,MATH-2060,2015
-MATH,2060,10,Calculus of Several Variables,0.37,0.23,0.26,0.06,0.03,0.0,0.0,0.06,minerva rios-adams,MATH-2060,2015
-MATH,2060,11,Calculus of Several Variables,0.26,0.11,0.26,0.11,0.14,0.0,0.0,0.11,shari prevost,MATH-2060,2015
-MATH,2060,12,Calculus of Several Variables,0.26,0.24,0.16,0.03,0.21,0.0,0.0,0.11,gretchen matthews,MATH-2060,2015
-MATH,2060,13,Calculus of Several Variables,0.15,0.46,0.2,0.17,0.02,0.0,0.0,0.0,minerva rios-adams,MATH-2060,2015
-MATH,2060,14,Calculus of Several Variables,0.28,0.39,0.17,0.06,0.06,0.0,0.0,0.06,timothy fra parrott,MATH-2060,2015
-MATH,2060,15,Calculus of Several Variables,0.17,0.27,0.37,0.12,0.07,0.0,0.0,0.0,timothy ch teitloff,MATH-2060,2015
-MATH,2060,17,Calculus of Several Variables,0.13,0.31,0.18,0.05,0.26,0.0,0.0,0.08,timothy ch teitloff,MATH-2060,2015
-MATH,2060,18,Calculus of Several Variables,0.28,0.19,0.25,0.06,0.08,0.0,0.0,0.14,timothy fra parrott,MATH-2060,2015
-MATH,2060,19,Calculus of Several Variables,0.41,0.24,0.14,0.08,0.03,0.0,0.0,0.11,peter kiessler,MATH-2060,2015
-MATH,2060,20,Calculus of Several Variables,0.72,0.26,0.0,0.0,0.0,0.0,0.0,0.03,sofya alekseeva,MATH-2060,2015
-MATH,2060,21,Calculus of Several Variables,0.16,0.16,0.38,0.11,0.14,0.0,0.0,0.05,timothy ch teitloff,MATH-2060,2015
-MATH,2060,22,Calculus of Several Variables,0.28,0.28,0.33,0.03,0.0,0.0,0.0,0.08,nathan jos adelgren,MATH-2060,2015
-MATH,2060,23,Calculus of Several Variables,0.09,0.21,0.38,0.15,0.18,0.0,0.0,0.0,julie lassiter,MATH-2060,2015
-MATH,2060,24,Calculus of Several Variables,0.54,0.44,0.03,0.0,0.0,0.0,0.0,0.0,sofya alekseeva,MATH-2060,2015
-MATH,2060,25,Calculus of Several Variables,0.43,0.34,0.09,0.03,0.03,0.0,0.0,0.09,sofya alekseeva,MATH-2060,2015
-MATH,2060,100,Calc of Several Vars (HON),0.63,0.17,0.08,0.0,0.04,0.0,0.0,0.08,shari prevost,MATH-2060,2015
-MATH,2070,1,Multivariable Calculus,0.11,0.26,0.21,0.16,0.21,0.0,0.0,0.05,trevor scot vilardi,MATH-2070,2015
-MATH,2070,2,Multivariable Calculus,0.06,0.24,0.24,0.12,0.18,0.0,0.0,0.18,mengying xiao,MATH-2070,2015
-MATH,2070,3,Multivariable Calculus,0.18,0.24,0.18,0.06,0.18,0.0,0.0,0.18,thanh thien to,MATH-2070,2015
-MATH,2070,4,Multivariable Calculus,0.16,0.37,0.42,0.0,0.0,0.0,0.0,0.05,jennifer mari hanna,MATH-2070,2015
-MATH,2070,5,Multivariable Calculus,0.15,0.08,0.38,0.15,0.08,0.0,0.0,0.15,liu zhu,MATH-2070,2015
-MATH,2070,6,Multivariable Calculus,0.32,0.11,0.21,0.21,0.11,0.0,0.0,0.05,judith irene mcknew,MATH-2070,2015
-MATH,2070,7,Multivariable Calculus,0.26,0.32,0.37,0.05,0.0,0.0,0.0,0.0,luke marti giberson,MATH-2070,2015
-MATH,2070,8,Multivariable Calculus,0.29,0.29,0.2,0.2,0.03,0.0,0.0,0.0,jennifer mari hanna,MATH-2070,2015
-MATH,2070,9,Multivariable Calculus,0.26,0.32,0.16,0.16,0.05,0.0,0.0,0.05,kevin wayne dettman,MATH-2070,2015
-MATH,2070,10,Multivariable Calculus,0.37,0.21,0.21,0.11,0.05,0.0,0.0,0.05,luke marti giberson,MATH-2070,2015
-MATH,2070,11,Multivariable Calculus,0.22,0.39,0.33,0.0,0.0,0.0,0.0,0.06,judith irene mcknew,MATH-2070,2015
-MATH,2070,12,Multivariable Calculus,0.26,0.32,0.11,0.05,0.16,0.0,0.0,0.11,yisu jia,MATH-2070,2015
-MATH,2070,13,Multivariable Calculus,0.25,0.13,0.31,0.13,0.13,0.0,0.0,0.06,liu zhu,MATH-2070,2015
-MATH,2070,14,Multivariable Calculus,0.39,0.22,0.17,0.11,0.11,0.0,0.0,0.0,trevor scot vilardi,MATH-2070,2015
-MATH,2070,15,Multivariable Calculus,0.21,0.27,0.27,0.03,0.12,0.0,0.0,0.09,jennifer mari hanna,MATH-2070,2015
-MATH,2070,16,Multivariable Calculus,0.17,0.17,0.2,0.2,0.06,0.0,0.0,0.2,hui xue,MATH-2070,2015
-MATH,2070,18,Multivariable Calculus,0.06,0.18,0.29,0.12,0.29,0.0,0.0,0.06,kevin wayne dettman,MATH-2070,2015
-MATH,2070,19,Multivariable Calculus,0.22,0.33,0.28,0.11,0.0,0.0,0.0,0.06,jennifer mari hanna,MATH-2070,2015
-MATH,2070,20,Multivariable Calculus,0.17,0.22,0.33,0.22,0.06,0.0,0.0,0.0,yisu jia,MATH-2070,2015
-MATH,2070,21,Multivariable Calculus,0.26,0.32,0.26,0.0,0.0,0.0,0.0,0.16,allison stoddard,MATH-2070,2015
-MATH,2070,22,Multivariable Calculus,0.11,0.22,0.33,0.06,0.06,0.0,0.0,0.22,thanh thien to,MATH-2070,2015
-MATH,2070,23,Multivariable Calculus,0.18,0.29,0.29,0.18,0.06,0.0,0.0,0.0,marion hanna,MATH-2070,2015
-MATH,2080,1,Intro to Ordin Diff Equations,0.13,0.16,0.47,0.16,0.03,0.0,0.0,0.06,matthew macauley,MATH-2080,2015
-MATH,2080,2,Intro to Ordin Diff Equations,0.76,0.0,0.0,0.0,0.18,0.0,0.0,0.06,brandon gra goodell,MATH-2080,2015
-MATH,2080,3,Intro to Ordin Diff Equations,0.36,0.28,0.17,0.03,0.11,0.0,0.0,0.06,matthew macauley,MATH-2080,2015
-MATH,2080,4,Intro to Ordin Diff Equations,0.57,0.26,0.11,0.0,0.0,0.0,0.0,0.06,irina viktorova,MATH-2080,2015
-MATH,2080,5,Intro to Ordin Diff Equations,0.03,0.21,0.29,0.15,0.15,0.0,0.0,0.18,julie lassiter,MATH-2080,2015
-MATH,2080,6,Intro to Ordin Diff Equations,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,irina viktorova,MATH-2080,2015
-MATH,2080,8,Intro to Ordin Diff Equations,0.09,0.11,0.16,0.23,0.18,0.0,0.0,0.23,julie lassiter,MATH-2080,2015
-MATH,2080,9,Intro to Ordin Diff Equations,0.15,0.41,0.09,0.06,0.15,0.0,0.0,0.15,timothy fra parrott,MATH-2080,2015
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,MATH-2080,2015
-MATH,2160,1,Geometry for Elem Sch Teachers,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-2160,2015
-MATH,2160,2,Geometry for Elem Sch Teachers,0.78,0.17,0.05,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-2160,2015
-MATH,2500,1,Intro to Mathematical Sciences,0.78,0.11,0.0,0.0,0.07,0.0,0.0,0.04,matthew saltzman,MATH-2500,2015
-MATH,3020,1,Stat for Science & Engineering,0.37,0.53,0.05,0.0,0.05,0.0,0.0,0.0,hewa priyadarshani,MATH-3020,2015
-MATH,3020,2,Stat for Science & Engineering,0.53,0.28,0.08,0.06,0.03,0.0,0.0,0.03,derek brown,MATH-3020,2015
-MATH,3020,3,Stat for Science & Engineering,0.26,0.4,0.17,0.06,0.03,0.0,0.0,0.09,derek brown,MATH-3020,2015
-MATH,3020,4,Stat for Science & Engineering,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,hewa priyadarshani,MATH-3020,2015
-MATH,3020,5,Stat for Science & Engineering,0.25,0.28,0.38,0.03,0.0,0.0,0.0,0.06,calvin williams,MATH-3020,2015
-MATH,3020,6,Stat for Science & Engineering,0.42,0.24,0.21,0.06,0.0,0.0,0.0,0.06,calvin williams,MATH-3020,2015
-MATH,3020,7,Stat for Science & Engineering,0.5,0.28,0.19,0.03,0.0,0.0,0.0,0.0,xiaoqian sun,MATH-3020,2015
-MATH,3020,8,Stat for Science & Engineering,0.34,0.29,0.17,0.06,0.06,0.0,0.0,0.09,yanbo xia,MATH-3020,2015
-MATH,3020,9,Stat for Science & Engineering,0.22,0.33,0.3,0.0,0.04,0.0,0.0,0.11,rachel eli grotheer,MATH-3020,2015
-MATH,3110,1,Linear Algebra,0.16,0.32,0.36,0.08,0.04,0.0,0.0,0.04,michael adam burr,MATH-3110,2015
-MATH,3110,2,Linear Algebra,0.32,0.21,0.13,0.11,0.18,0.0,0.0,0.05,xuhong gao,MATH-3110,2015
-MATH,3110,3,Linear Algebra,0.41,0.19,0.05,0.16,0.14,0.0,0.0,0.05,xuhong gao,MATH-3110,2015
-MATH,3110,4,Linear Algebra,0.24,0.37,0.16,0.16,0.08,0.0,0.0,0.0,kevin james,MATH-3110,2015
-MATH,3110,5,Linear Algebra,0.17,0.37,0.23,0.09,0.06,0.0,0.0,0.09,felice manganiello,MATH-3110,2015
-MATH,3160,1,Prob Solving for Math Teachers,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-3160,2015
-MATH,3190,1,Introduction to Proof,0.19,0.38,0.15,0.04,0.19,0.0,0.0,0.04,elena sta dimitrova,MATH-3190,2015
-MATH,3190,2,Introduction to Proof,0.54,0.23,0.15,0.04,0.0,0.0,0.0,0.04,elena sta dimitrova,MATH-3190,2015
-MATH,3600,1,Intermediate Math Computing,0.61,0.16,0.0,0.0,0.06,0.0,0.0,0.16,neil calkin,MATH-3600,2015
-MATH,3650,1,Numerical Mthds for Engineers,0.19,0.32,0.16,0.14,0.05,0.0,0.0,0.14,vincent ervin,MATH-3650,2015
-MATH,3650,2,Numerical Mthds for Engineers,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,leo rebholz,MATH-3650,2015
-MATH,3650,3,Numerical Mthds for Engineers,0.29,0.58,0.08,0.0,0.0,0.0,0.0,0.05,leo rebholz,MATH-3650,2015
-MATH,3650,4,Numerical Mthds for Engineers,0.33,0.46,0.1,0.03,0.03,0.0,0.0,0.05,timo johann heister,MATH-3650,2015
-MATH,4000,1,Theory of Probability,0.44,0.19,0.19,0.0,0.19,0.0,0.0,0.0,yingbo li,MATH-4000,2015
-MATH,4000,2,Theory of Probability,0.33,0.28,0.11,0.06,0.11,0.0,0.0,0.11,yingbo li,MATH-4000,2015
-MATH,4070,1,Regress & Time-Series Analysis,0.2,0.4,0.1,0.1,0.1,0.0,0.0,0.1,christopher mcmahan,MATH-4070,2015
-MATH,4120,1,Algebra I,0.17,0.25,0.21,0.13,0.13,0.0,0.0,0.13,elena sta dimitrova,MATH-4120,2015
-MATH,4190,1,Discrete Math Structures I,0.44,0.44,0.05,0.0,0.08,0.0,0.0,0.0,wayne goddard,MATH-4190,2015
-MATH,4310,1,Theory of Interest,0.63,0.0,0.0,0.06,0.19,0.0,0.0,0.13,mark cawood,MATH-4310,2015
-MATH,4340,1,Adv Engineering Mathematics,0.23,0.47,0.1,0.03,0.0,0.0,0.0,0.17,qingshan chen,MATH-4340,2015
-MATH,4340,2,Adv Engineering Mathematics,0.29,0.25,0.14,0.14,0.0,0.0,0.0,0.18,eleanor jenkins,MATH-4340,2015
-MATH,4400,1,Linear Programming,0.61,0.11,0.11,0.11,0.04,0.0,0.0,0.04,yuyuan ouyang,MATH-4400,2015
-MATH,4410,1,Intro to Stochastic Models,0.65,0.12,0.12,0.0,0.0,0.0,0.0,0.12,peter kiessler,MATH-4410,2015
-MATH,4530,1,Advanced Calculus I,0.27,0.41,0.14,0.14,0.05,0.0,0.0,0.0,taufiquar rahm khan,MATH-4530,2015
-MATH,4530,2,Advanced Calculus I,0.3,0.26,0.17,0.13,0.13,0.0,0.0,0.0,shitao liu,MATH-4530,2015
-MATH,6340,1,Adv Engineering Mathematics,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,vincent ervin,MATH-6340,2015
-MATH,8000,1,Probability,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,robert lund,MATH-8000,2015
-MATH,8010,1,General Linear Hypothesis I,0.3,0.5,0.15,0.0,0.0,0.0,0.0,0.05,xiaoqian sun,MATH-8010,2015
-MATH,8050,1,Data Analysis,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,derek brown,MATH-8050,2015
-MATH,8070,1,Applied Multivariate Analysis,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-8070,2015
-MATH,8100,1,Mathematical Programming,0.68,0.09,0.05,0.0,0.0,0.0,0.0,0.18,margaret mar wiecek,MATH-8100,2015
-MATH,8120,1,Discrete Optimization,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,akshay sunil gupte,MATH-8120,2015
-MATH,8140,1,Network Flow Programming,0.14,0.71,0.14,0.0,0.0,0.0,0.0,0.0,warren adams,MATH-8140,2015
-MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,MATH-8170,2015
-MATH,8210,1,Linear Analysis,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,MATH-8210,2015
-MATH,8510,1,Abstract Algebra I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,james ba coykendall,MATH-8510,2015
-MATH,8530,1,Matrix Analysis,0.22,0.39,0.28,0.0,0.0,0.0,0.0,0.11,felice manganiello,MATH-8530,2015
-MATH,8600,1,Intro to Scientific Computing,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,qingshan chen,MATH-8600,2015
-MATH,8650,1,Data Structures,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,timo johann heister,MATH-8650,2015
-MATH,8840,1,Statistics for Experimenters,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,MATH-8840,2015
-MBA,8030,1,Stat Analy of Bus Op,0.53,0.33,0.09,0.0,0.0,0.0,0.0,0.04,janis miller,MBA-8030,2015
-MBA,8060,1,Operations Mgt,0.13,0.74,0.05,0.03,0.03,0.0,0.0,0.03, sridharan,MBA-8060,2015
-MBA,8070,1,Financial Management,0.44,0.28,0.21,0.0,0.0,0.0,0.0,0.08,ramon tolb franklin,MBA-8070,2015
-MBA,8090,1,Org Beh & Hum Res Mg,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2015
-MBA,8090,2,Org Beh & Hum Res Mg,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2015
-MBA,8190,1,Intro to Acc and Fin,0.53,0.39,0.05,0.0,0.0,0.0,0.0,0.03,annieka philo,MBA-8190,2015
-MBA,8190,2,Intro to Acc and Fin,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,MBA-8190,2015
-MBA,8290,1,Marketing Foundation,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MBA-8290,2015
-MBA,8330,1,Real Estate Investmt,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,franklin bog wallin,MBA-8330,2015
-MBA,8350,1,Investment Mgmt,0.39,0.46,0.07,0.04,0.0,0.0,0.0,0.04,john alexander,MBA-8350,2015
-MBA,8360,1,Real Estate Principles,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,jeffrey randolph,MBA-8360,2015
-MBA,8370,1,Legal Environ of Bus,0.43,0.55,0.02,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2015
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,prashant prabhu,MBA-8400,2015
-MBA,8430,1,Entrepreneurial Accounting,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,sally kathr widener,MBA-8430,2015
-MBA,8450,1,Technology & Innovation Mgt,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8450,2015
-MBA,8490,5,Entrepreneurial Strategy,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8490,2015
-MBA,8510,1,Bus Operations & Logistics,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09, sridharan,MBA-8510,2015
-MBA,8590,1,Mgr Decision Model,0.39,0.36,0.17,0.03,0.03,0.0,0.0,0.03,sara elizabet yoder,MBA-8590,2015
-MBA,8590,2,Mgr Decision Model,0.53,0.14,0.23,0.0,0.02,0.0,0.0,0.07,mark mcknew,MBA-8590,2015
-MBA,8600,1,Advanced Marketing Strategy,0.48,0.42,0.09,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2015
-MBA,8600,2,Advanced Marketing Strategy,0.17,0.66,0.1,0.03,0.0,0.0,0.0,0.03,michael dorsch,MBA-8600,2015
-MBA,8610,1,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,MBA-8610,2015
-MBA,8620,1,Managerial Economics,0.34,0.54,0.06,0.0,0.0,0.0,0.0,0.06,scott templeton,MBA-8620,2015
-MBA,8620,2,Managerial Economics,0.6,0.33,0.03,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,MBA-8620,2015
-MBA,8650,1,Taxation of Business Decisions,0.27,0.64,0.0,0.0,0.0,0.0,0.0,0.09,judson jahn,MBA-8650,2015
-MBA,8700,1,Strategic Management,0.62,0.35,0.04,0.0,0.0,0.0,0.0,0.0,peter gianiodis,MBA-8700,2015
-MBA,8810,1,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,evguenia pas layton,MBA-8810,2015
-MBA,8990,2,Creativity,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,MBA-8990,2015
-MBA,8990,10,Selected Topics in Entrepreneu,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,aleda marie roth,MBA-8990,2015
-ME,2000,1,Sophomore Seminar,0.93,0.03,0.0,0.01,0.0,0.0,0.0,0.03,donald beasley,ME-2000,2015
-ME,2010,1,Statics & Dynamics,0.1,0.08,0.14,0.07,0.38,0.0,0.0,0.23,sherrill biggers,ME-2010,2015
-ME,2010,2,Statics & Dynamics,0.14,0.18,0.23,0.09,0.19,0.0,0.0,0.17,paul joseph,ME-2010,2015
-ME,2010,3,Statics & Dynamics,0.15,0.18,0.24,0.0,0.28,0.0,0.0,0.15,kalyan chakr katuri,ME-2010,2015
-ME,2030,1,Founda Th/Fl Syst,0.07,0.21,0.34,0.2,0.07,0.0,0.0,0.1,jay ochterbeck,ME-2030,2015
-ME,2040,1,Mechanics of Materials,0.16,0.42,0.3,0.06,0.03,0.0,0.0,0.03,garrett pataky,ME-2040,2015
-ME,2040,2,Mechanics of Materials,0.08,0.44,0.3,0.06,0.1,0.0,0.0,0.02,huijuan zhao,ME-2040,2015
-ME,2220,1,Mechanical Engineering Lab I,0.21,0.71,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,2,Mechanical Engineering Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-2220,2015
-ME,2220,3,Mechanical Engineering Lab I,0.35,0.5,0.05,0.0,0.0,0.0,0.0,0.1,todd schweisinger,ME-2220,2015
-ME,2220,4,Mechanical Engineering Lab I,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,ME-2220,2015
-ME,2220,5,Mechanical Engineering Lab I,0.55,0.35,0.0,0.0,0.0,0.0,0.0,0.1,todd schweisinger,ME-2220,2015
-ME,2220,6,Mechanical Engineering Lab I,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,7,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,8,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,9,Mechanical Engineering Lab I,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,3030,1,Thermodynamics,0.22,0.35,0.33,0.03,0.0,0.0,0.0,0.06,daniel fant,ME-3030,2015
-ME,3030,2,Thermodynamics,0.37,0.43,0.11,0.02,0.06,0.0,0.0,0.02,daniel fant,ME-3030,2015
-ME,3040,1,Heat Transfer,0.15,0.35,0.26,0.06,0.12,0.0,0.0,0.06,jean-marc delhaye,ME-3040,2015
-ME,3040,2,Heat Transfer,0.32,0.3,0.3,0.04,0.02,0.0,0.0,0.02,xin zhao,ME-3040,2015
-ME,3050,1,Model/an Dy Syst,0.16,0.34,0.34,0.09,0.07,0.0,0.0,0.0,todd schweisinger,ME-3050,2015
-ME,3050,2,Model/an Dy Syst,0.19,0.43,0.29,0.05,0.0,0.0,0.0,0.05,yue wang,ME-3050,2015
-ME,3060,1,Fund Machine Design,0.07,0.52,0.31,0.0,0.03,0.0,0.0,0.07,oliver myers,ME-3060,2015
-ME,3060,2,Fund Machine Design,0.2,0.4,0.22,0.13,0.02,0.0,0.0,0.02,paul jeffrey meyer,ME-3060,2015
-ME,3070,1,Found of Mechanical Systems,0.44,0.4,0.15,0.0,0.0,0.0,0.0,0.01,lonny thompson,ME-3070,2015
-ME,3070,2,Found of Mechanical Systems,0.17,0.41,0.21,0.12,0.03,0.0,0.0,0.05,georges fadel,ME-3070,2015
-ME,3080,1,Fluid Mechanics,0.07,0.22,0.29,0.12,0.17,0.0,0.0,0.12,jean-marc delhaye,ME-3080,2015
-ME,3080,2,Fluid Mechanics,0.23,0.4,0.26,0.07,0.02,0.0,0.0,0.02,xiangchun xuan,ME-3080,2015
-ME,3080,3,Fluid Mechanics,0.15,0.22,0.44,0.04,0.07,0.0,0.0,0.09,ethan kung,ME-3080,2015
-ME,3120,2,Manuf Processes,0.44,0.38,0.12,0.04,0.02,0.0,0.0,0.0,rod martinez-duarte,ME-3120,2015
-ME,3330,1,Mechanical Engineering Lab II,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,3330,2,Mechanical Engineering Lab II,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,3330,3,Mechanical Engineering Lab II,0.37,0.42,0.16,0.0,0.0,0.0,0.0,0.05,todd schweisinger,ME-3330,2015
-ME,3330,4,Mechanical Engineering Lab II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,3330,5,Mechanical Engineering Lab II,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,todd schweisinger,ME-3330,2015
-ME,3330,6,Mechanical Engineering Lab II,0.07,0.79,0.14,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,3330,7,Mechanical Engineering Lab II,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,todd schweisinger,ME-3330,2015
-ME,3330,8,Mechanical Engineering Lab II,0.27,0.36,0.09,0.0,0.0,0.0,0.0,0.27,todd schweisinger,ME-3330,2015
-ME,4000,1,Senior Seminar,0.96,0.03,0.0,0.01,0.0,0.0,0.0,0.0, ramasubramanian,ME-4000,2015
-ME,4010,1,Mech Engr Design,0.08,0.66,0.16,0.09,0.01,0.0,0.0,0.0,joshua summers,ME-4010,2015
-ME,4020,2,Intern in Engr Des,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-4020,2015
-ME,4020,3,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-4020,2015
-ME,4020,4,Intern in Engr Des,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,ME-4020,2015
-ME,4030,1,Control Dynamic Systems,0.3,0.28,0.3,0.11,0.0,0.0,0.0,0.01,ardalan vahidi,ME-4030,2015
-ME,4030,2,Control Dynamic Systems,0.27,0.51,0.2,0.02,0.0,0.0,0.0,0.0,seye parvini oskoui,ME-4030,2015
-ME,4180,1,F E A in M E Design,0.63,0.3,0.03,0.0,0.0,0.0,0.0,0.03,gang li,ME-4180,2015
-ME,4200,1,Ener Sources/Utiliz,0.54,0.43,0.03,0.0,0.0,0.0,0.0,0.0,donald beasley,ME-4200,2015
-ME,4210,1,Intro to Comp Flow,0.27,0.27,0.33,0.07,0.0,0.0,0.0,0.07,chenning tong,ME-4210,2015
-ME,4400,1,Matls for Aggr Envir,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mica grujicic,ME-4400,2015
-ME,4440,1,Mechanical Engineering Lab III,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2015
-ME,4440,2,Mechanical Engineering Lab III,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2015
-ME,4440,3,Mechanical Engineering Lab III,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2015
-ME,4440,4,Mechanical Engineering Lab III,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2015
-ME,4440,7,Mechanical Engineering Lab III,0.0,0.83,0.0,0.0,0.08,0.0,0.0,0.08,john wagner,ME-4440,2015
-ME,4540,1,Design of Machine Elements,0.52,0.3,0.06,0.03,0.03,0.0,0.0,0.06,paul jeffrey meyer,ME-4540,2015
-ME,4930,36,Selected Topics ME - BioDesign,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,michael porter,ME-4930,2015
-ME,6210,1,Intro to Comp Flow,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,ME-6210,2015
-ME,6540,1,Des Machine Elements,0.57,0.36,0.0,0.0,0.07,0.0,0.0,0.0,paul jeffrey meyer,ME-6540,2015
-ME,8010,1,Found of Fluid Mech,0.29,0.5,0.17,0.0,0.0,0.0,0.0,0.04,richard figliola,ME-8010,2015
-ME,8100,1,Macroscopic Thermo,0.32,0.6,0.08,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,ME-8100,2015
-ME,8140,1,Turb Bound Layer,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,richard miller,ME-8140,2015
-ME,8180,1,Intro to Fin Ele Ana,0.75,0.23,0.02,0.0,0.0,0.0,0.0,0.0,lonny thompson,ME-8180,2015
-ME,8230,1,Control Systems,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,john wagner,ME-8230,2015
-ME,8370,1,Theory of Elast I,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,ME-8370,2015
-ME,8460,1,Inter Dynamics,0.19,0.57,0.19,0.05,0.0,0.0,0.0,0.0,phanin tallapragada,ME-8460,2015
-ME,8700,1,Adv Design Methods,0.34,0.66,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-8700,2015
-ME,8710,1,Engr Optimization,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-8710,2015
-ME,8930,27,Sel Topics in Mechanical Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-8930,2015
-MGT,2010,1,Principles of Management,0.33,0.41,0.17,0.03,0.04,0.0,0.0,0.03,katherine clark,MGT-2010,2015
-MGT,2010,2,Principles of Management,0.32,0.41,0.16,0.05,0.03,0.0,0.0,0.03,katherine clark,MGT-2010,2015
-MGT,2010,3,Principles of Management,0.36,0.36,0.22,0.03,0.01,0.0,0.0,0.03,katherine clark,MGT-2010,2015
-MGT,2010,4,Principles of Management,0.13,0.44,0.28,0.07,0.03,0.0,0.0,0.04,katherine clark,MGT-2010,2015
-MGT,2010,5,Principles of Management,0.22,0.36,0.34,0.02,0.02,0.0,0.0,0.05,tina robbins,MGT-2010,2015
-MGT,2010,6,Principles of Management,0.4,0.41,0.15,0.01,0.01,0.0,0.0,0.01,tina robbins,MGT-2010,2015
-MGT,2010,7,Principles of Management,0.33,0.46,0.11,0.07,0.03,0.0,0.0,0.0,tina robbins,MGT-2010,2015
-MGT,2010,8,Principles of Management,0.42,0.42,0.14,0.0,0.01,0.0,0.0,0.0,tina robbins,MGT-2010,2015
-MGT,2010,9,Principles of Mgt(HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,MGT-2010,2015
-MGT,2180,1,Management PC Applications,0.5,0.29,0.12,0.02,0.0,0.0,0.0,0.07,ryan toole,MGT-2180,2015
-MGT,2180,2,Management PC Applications,0.5,0.33,0.04,0.02,0.06,0.0,0.0,0.05,ryan toole,MGT-2180,2015
-MGT,2180,3,Management PC Applications,0.42,0.33,0.16,0.02,0.02,0.0,0.0,0.05,ryan toole,MGT-2180,2015
-MGT,2180,4,Management PC Applications,0.47,0.28,0.14,0.02,0.05,0.0,0.0,0.04,ryan toole,MGT-2180,2015
-MGT,2970,1,CI - How to Start a Startup,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,matthew charl klein,MGT-2970,2015
-MGT,2970,2,CI - How to Start a Startup,0.5,0.14,0.0,0.0,0.0,0.0,0.0,0.36,gregory pickett,MGT-2970,2015
-MGT,3070,1,Human Resource Management,0.38,0.51,0.08,0.0,0.0,0.0,0.0,0.03,michael cole,MGT-3070,2015
-MGT,3070,3,Human Resource Management,0.16,0.34,0.39,0.02,0.02,0.0,0.0,0.07,kristin dam scott,MGT-3070,2015
-MGT,3070,4,Human Resource Management,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,priscilla harrison,MGT-3070,2015
-MGT,3070,5,Human Resource Management,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2015
-MGT,3070,6,Human Resource Management,0.53,0.35,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2015
-MGT,3070,7,Human Resource Management,0.33,0.54,0.05,0.05,0.03,0.0,0.0,0.0,michael cole,MGT-3070,2015
-MGT,3100,1,Intermed Business Statistics,0.23,0.19,0.29,0.06,0.13,0.0,0.0,0.1,sara elizabet yoder,MGT-3100,2015
-MGT,3100,2,Intermed Business Statistics,0.28,0.13,0.3,0.08,0.13,0.0,0.0,0.1,sara elizabet yoder,MGT-3100,2015
-MGT,3100,3,Intermed Business Statistics,0.15,0.18,0.3,0.1,0.13,0.0,0.0,0.15,sara elizabet yoder,MGT-3100,2015
-MGT,3100,5,Intermed Business Statistics,0.32,0.15,0.18,0.09,0.09,0.0,0.0,0.18,jerry kermi bilbrey,MGT-3100,2015
-MGT,3100,6,Intermed Business Statistics,0.53,0.25,0.06,0.03,0.03,0.0,0.0,0.11,jerry kermi bilbrey,MGT-3100,2015
-MGT,3100,7,Intermed Business Statistics,0.35,0.3,0.24,0.03,0.0,0.0,0.0,0.08,jerry kermi bilbrey,MGT-3100,2015
-MGT,3100,8,Intermed Business Statistics,0.33,0.25,0.15,0.05,0.1,0.0,0.0,0.13,remi charpin,MGT-3100,2015
-MGT,3100,9,Intermed Business Statistics,0.33,0.2,0.23,0.13,0.05,0.0,0.0,0.08,min kyung lee,MGT-3100,2015
-MGT,3100,10,Intermed Business Statistics,0.58,0.28,0.06,0.0,0.08,0.0,0.0,0.0,shih lun tseng,MGT-3100,2015
-MGT,3100,11,Intermed Business Statistics,0.47,0.25,0.11,0.03,0.0,0.0,0.0,0.14,iaroslava dutchak,MGT-3100,2015
-MGT,3100,12,Intermed Business Statistics,0.25,0.28,0.19,0.03,0.11,0.0,0.0,0.14,yunsik choi,MGT-3100,2015
-MGT,3100,13,Intermed Business Statistics,0.16,0.32,0.21,0.05,0.11,0.0,0.0,0.16,jerry kermi bilbrey,MGT-3100,2015
-MGT,3120,1,Decision Models for Management,0.15,0.46,0.17,0.02,0.15,0.0,0.0,0.05,mark mcknew,MGT-3120,2015
-MGT,3120,2,Decision Models for Management,0.4,0.24,0.24,0.02,0.07,0.0,0.0,0.02,mark mcknew,MGT-3120,2015
-MGT,3120,3,Decision Models for Management,0.3,0.17,0.37,0.04,0.09,0.0,0.0,0.02,mark mcknew,MGT-3120,2015
-MGT,3150,1,New Venture Creation,0.4,0.33,0.18,0.03,0.03,0.0,0.0,0.05,elizabeth er powell,MGT-3150,2015
-MGT,3170,1,Logistics Mgmt,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,shouqiang wang,MGT-3170,2015
-MGT,3180,1,Mgt of Info Systems,0.26,0.6,0.14,0.0,0.0,0.0,0.0,0.0,heshan sun,MGT-3180,2015
-MGT,3180,2,Mgt of Info Systems,0.2,0.6,0.15,0.05,0.0,0.0,0.0,0.0,roopa raman,MGT-3180,2015
-MGT,3180,3,Mgt of Info Systems,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,MGT-3180,2015
-MGT,3180,4,Mgt of Info Systems,0.63,0.28,0.04,0.02,0.02,0.0,0.0,0.0,jackie patri london,MGT-3180,2015
-MGT,3900,1,Ops Mgt,0.24,0.37,0.24,0.11,0.03,0.0,0.0,0.03,yann ferrand,MGT-3900,2015
-MGT,3900,2,Ops Mgt,0.68,0.2,0.08,0.0,0.0,0.0,0.0,0.05,berna quiroga gomez,MGT-3900,2015
-MGT,3900,3,Ops Mgt,0.0,0.58,0.29,0.06,0.03,0.0,0.0,0.03,zachary mo leffakis,MGT-3900,2015
-MGT,3900,4,Ops Mgt,0.56,0.28,0.08,0.03,0.0,0.0,0.0,0.05,brandon woohyeo lee,MGT-3900,2015
-MGT,3900,5,Ops Mgt,0.49,0.27,0.11,0.0,0.03,0.0,0.0,0.11,berna quiroga gomez,MGT-3900,2015
-MGT,4000,1,Mgt of Organizational Behavior,0.27,0.5,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MGT-4000,2015
-MGT,4000,2,Mgt of Organizational Behavior,0.39,0.39,0.14,0.03,0.0,0.0,0.0,0.06,michael cole,MGT-4000,2015
-MGT,4000,3,Mgt of Organizational Behavior,0.33,0.23,0.3,0.02,0.07,0.0,0.0,0.05,philip roth,MGT-4000,2015
-MGT,4020,1,Ops Pln and Ctl,0.25,0.25,0.44,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,MGT-4020,2015
-MGT,4030,1,Special Problems,0.09,0.55,0.18,0.0,0.0,0.0,0.0,0.18,siyuan li,MGT-4030,2015
-MGT,4080,1,Lean Operations,0.25,0.33,0.33,0.0,0.0,0.0,0.0,0.08,zachary mo leffakis,MGT-4080,2015
-MGT,4110,1,Project Management,0.29,0.56,0.1,0.0,0.0,0.0,0.0,0.05,russell purvis,MGT-4110,2015
-MGT,4120,1,Supplier Management,0.19,0.58,0.13,0.03,0.03,0.0,0.0,0.03,shouqiang wang,MGT-4120,2015
-MGT,4150,1,Business Strategy,0.6,0.38,0.0,0.02,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2015
-MGT,4150,3,Business Strategy,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2015
-MGT,4150,4,Business Strategy,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2015
-MGT,4150,7,Business Strategy,0.25,0.66,0.05,0.02,0.02,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2015
-MGT,4150,8,Business Strategy,0.09,0.66,0.11,0.0,0.06,0.0,0.0,0.09,amy elizabet ingram,MGT-4150,2015
-MGT,4150,9,Business Strategy,0.18,0.49,0.28,0.0,0.0,0.0,0.0,0.05,peter gianiodis,MGT-4150,2015
-MGT,4160,1,Special Topics Hr,0.22,0.64,0.11,0.03,0.0,0.0,0.0,0.0,kristin dam scott,MGT-4160,2015
-MGT,4230,1,Intern Bus Mgt,0.25,0.23,0.35,0.03,0.08,0.0,0.0,0.08,wayne stewart,MGT-4230,2015
-MGT,4230,2,Intern Bus Mgt,0.11,0.26,0.47,0.0,0.05,0.0,0.0,0.11,wayne stewart,MGT-4230,2015
-MGT,4230,3,Intern Bus Mgt,0.06,0.32,0.32,0.06,0.19,0.0,0.0,0.03,janis miller,MGT-4230,2015
-MGT,4230,4,Intern Bus Mgt,0.14,0.51,0.32,0.03,0.0,0.0,0.0,0.0,janis miller,MGT-4230,2015
-MGT,4240,1,Global Supply Chain,0.17,0.66,0.14,0.0,0.0,0.0,0.0,0.03,yann ferrand,MGT-4240,2015
-MGT,4270,1,Managing Improvement,0.07,0.5,0.29,0.07,0.0,0.0,0.0,0.07,lawrence fredendall,MGT-4270,2015
-MGT,4300,2,Senior Seminar in Management,0.83,0.0,0.0,0.0,0.17,0.0,0.0,0.0,david leo bodde,MGT-4300,2015
-MGT,4310,1,Emp Rights & Resp,0.48,0.28,0.2,0.0,0.0,0.0,0.0,0.05,leonard jos spooner,MGT-4310,2015
-MGT,4310,2,Emp Rights & Resp,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-4310,2015
-MGT,4350,1,Pers Interviewing,0.44,0.38,0.13,0.04,0.0,0.0,0.0,0.0,philip roth,MGT-4350,2015
-MGT,4520,1,Business Analysis,0.2,0.4,0.2,0.07,0.07,0.0,0.0,0.07,roopa raman,MGT-4520,2015
-MGT,4550,1,Emerging I T Trends,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,jason thatcher,MGT-4550,2015
-MGT,8690,1,Project Mgt,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,MGT-8690,2015
-MICR,2050,1,Introductory Micro,0.46,0.42,0.09,0.0,0.01,0.0,0.0,0.03,john abercrombie,MICR-2050,2015
-MICR,3000,1,Essential Skills in Microbiol,0.59,0.37,0.0,0.0,0.02,0.0,0.0,0.02,tamara lyn mcnealy,MICR-3000,2015
-MICR,3050,1,General Microbiology,0.37,0.4,0.15,0.05,0.01,0.0,0.0,0.02,krista barr rudolph,MICR-3050,2015
-MICR,3050,2,General Microbiology,0.43,0.33,0.22,0.01,0.0,0.0,0.0,0.01,krista barr rudolph,MICR-3050,2015
-MICR,4010,1,Microbial Diversity & Ecology,0.2,0.5,0.24,0.02,0.02,0.0,0.0,0.02,barbara campbell,MICR-4010,2015
-MICR,4030,1,Marine Microbiology,0.2,0.4,0.0,0.1,0.1,0.0,0.0,0.2,john michael henson,MICR-4030,2015
-MICR,4050,1,Adv Microbial Ecol of Humans,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4050,2015
-MICR,4140,1,Basic Immunology,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,yanzhang wei,MICR-4140,2015
-MICR,4150,1,Microbial Genetics,0.4,0.33,0.07,0.17,0.0,0.0,0.0,0.03,min cao,MICR-4150,2015
-MICR,4160,1,Intro Virology,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,simon scott,MICR-4160,2015
-MICR,4510,1,Advanced Microbiology II,0.62,0.23,0.15,0.0,0.0,0.0,0.0,0.0,min cao,MICR-4510,2015
-MICR,4510,2,Advanced Microbiology II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,min cao,MICR-4510,2015
-MKT,3010,2,Prin of Marketing,0.3,0.41,0.23,0.01,0.04,0.0,0.0,0.01,carter wil mcelveen,MKT-3010,2015
-MKT,3010,3,Prin of Marketing,0.41,0.39,0.17,0.02,0.01,0.0,0.0,0.0,carter wil mcelveen,MKT-3010,2015
-MKT,3010,4,Prin of Marketing,0.23,0.4,0.22,0.11,0.03,0.0,0.0,0.01,carter wil mcelveen,MKT-3010,2015
-MKT,3010,5,Prin of Marketing,0.27,0.39,0.25,0.08,0.0,0.0,0.0,0.01,amanda cooper fine,MKT-3010,2015
-MKT,3010,6,Prin of Marketing,0.36,0.42,0.14,0.06,0.02,0.0,0.0,0.0,amanda cooper fine,MKT-3010,2015
-MKT,3010,7,Prin of Marketing,0.24,0.41,0.21,0.07,0.03,0.0,0.0,0.04,amanda cooper fine,MKT-3010,2015
-MKT,3010,8,Prin of Marketing,0.49,0.3,0.12,0.02,0.04,0.0,0.0,0.02,patricia knowles,MKT-3010,2015
-MKT,3010,9,Prin of Marketing(HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-3010,2015
-MKT,3020,1,Consumer Behavior,0.4,0.46,0.15,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2015
-MKT,3020,2,Consumer Behavior,0.66,0.3,0.02,0.0,0.02,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2015
-MKT,3020,3,Consumer Behavior,0.36,0.49,0.09,0.06,0.0,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2015
-MKT,3020,4,Consumer Behavior,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2015
-MKT,3210,1,Sports Marketing,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2015
-MKT,3210,2,Sports Marketing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2015
-MKT,3310,1,Marketing Metrics & Analytics,0.24,0.41,0.12,0.24,0.0,0.0,0.0,0.0,peter weathers,MKT-3310,2015
-MKT,4200,1,Professional Selling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,MKT-4200,2015
-MKT,4200,2,Professional Selling,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2015
-MKT,4200,3,Professional Selling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2015
-MKT,4200,4,Professional Selling,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2015
-MKT,4230,1,Promotional Strategy,0.27,0.48,0.23,0.0,0.02,0.0,0.0,0.0,patricia knowles,MKT-4230,2015
-MKT,4240,1,Sales Management,0.38,0.55,0.03,0.0,0.0,0.0,0.0,0.03,ryan mullins,MKT-4240,2015
-MKT,4260,1,Business-to-Business,0.54,0.41,0.03,0.0,0.0,0.0,0.0,0.03,james gaubert,MKT-4260,2015
-MKT,4260,2,Business-to-Business,0.31,0.55,0.1,0.0,0.02,0.0,0.0,0.02,james gaubert,MKT-4260,2015
-MKT,4270,1,International Mktg,0.32,0.48,0.09,0.07,0.0,0.0,0.0,0.05,roger gomes,MKT-4270,2015
-MKT,4270,2,International Mktg,0.18,0.34,0.25,0.11,0.05,0.0,0.0,0.07,roger gomes,MKT-4270,2015
-MKT,4270,3,International Mktg,0.27,0.31,0.31,0.04,0.02,0.0,0.0,0.04,roger gomes,MKT-4270,2015
-MKT,4270,4,International Mktg,0.33,0.49,0.18,0.0,0.0,0.0,0.0,0.0,thomas poehlman,MKT-4270,2015
-MKT,4280,1,Services Marketing,0.39,0.55,0.05,0.0,0.0,0.0,0.0,0.02,stephen grove,MKT-4280,2015
-MKT,4280,2,Services Marketing,0.44,0.28,0.22,0.0,0.06,0.0,0.0,0.0,stephen grove,MKT-4280,2015
-MKT,4310,1,Marketing Research,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,peter weathers,MKT-4310,2015
-MKT,4310,2,Marketing Research,0.3,0.67,0.0,0.0,0.0,0.0,0.0,0.04,scott darren swain,MKT-4310,2015
-MKT,4310,3,Marketing Research,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2015
-MKT,4310,4,Marketing Research,0.29,0.36,0.29,0.0,0.0,0.0,0.0,0.07,william kilbourne,MKT-4310,2015
-MKT,4430,1,Advertising Strategy,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,MKT-4430,2015
-MKT,4450,1,Macromarketing,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,MKT-4450,2015
-MKT,4500,1,Strategic Mktg Mgt,0.31,0.59,0.1,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2015
-MKT,4500,2,Strategic Mktg Mgt,0.19,0.61,0.19,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4500,2015
-MKT,8610,1,Marketing Research,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,christopher hopkins,MKT-8610,2015
-MKT,8630,1,Buyer Behavior,0.48,0.44,0.07,0.0,0.0,0.0,0.0,0.0,thomas poehlman,MKT-8630,2015
-ML,1010,1,Leadership Fund I,0.85,0.0,0.0,0.0,0.07,0.0,0.0,0.07,amanda carol kane,ML-1010,2015
-ML,2010,1,Leadership Development I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,thierry andre bras,ML-2010,2015
-ML,2010,2,Leadership Development I,0.71,0.19,0.05,0.05,0.0,0.0,0.0,0.0,thierry andre bras,ML-2010,2015
-ML,4010,1,Organizational Leadership I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,ML-4010,2015
-MSE,2100,2,Intro to Mat Science,0.35,0.32,0.17,0.05,0.04,0.0,0.0,0.06,eric skaar,MSE-2100,2015
-MSE,2100,3,Intro to Mat Science,0.37,0.4,0.11,0.02,0.06,0.0,0.0,0.04,eric skaar,MSE-2100,2015
-MSE,2100,4,Intro to Mat Science,0.35,0.34,0.17,0.06,0.06,0.0,0.0,0.02,marian kennedy,MSE-2100,2015
-MSE,2410,1,Metrics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,MSE-2410,2015
-MSE,3190,2,Materials Proc I,0.46,0.44,0.07,0.02,0.0,0.0,0.0,0.01,olin mefford,MSE-3190,2015
-MSE,3260,1,Thermo of Materials,0.31,0.47,0.08,0.08,0.0,0.0,0.0,0.06,gary lickfield,MSE-3260,2015
-MSE,3260,2,Thermo of Materials,0.03,0.45,0.29,0.16,0.0,0.0,0.0,0.06,gary lickfield,MSE-3260,2015
-MSE,3270,1,Transport Phenomena,0.78,0.11,0.07,0.04,0.0,0.0,0.0,0.01,konstantin kornev,MSE-3270,2015
-MSE,4020,1,Solid State Material,0.24,0.42,0.27,0.03,0.03,0.0,0.0,0.0,luiz gust jacobsohn,MSE-4020,2015
-MSE,4130,1,Noncrystalline Materials,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,fei peng,MSE-4130,2015
-MSE,4150,1,Polymer Sc Engr,0.42,0.36,0.19,0.04,0.0,0.0,0.0,0.0,igor luzinov,MSE-4150,2015
-MSE,4150,2,Polymer Sc Engr,0.51,0.37,0.11,0.0,0.01,0.0,0.0,0.0,olin mefford,MSE-4150,2015
-MSE,4320,1,Manuf Proc & Systems,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,denis brosnan,MSE-4320,2015
-MSE,4410,1,Mfg Laboratory,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,denis brosnan,MSE-4410,2015
-MSE,4550,3,Polymer Fiber Lab,0.64,0.18,0.09,0.09,0.0,0.0,0.0,0.0,olin mefford,MSE-4550,2015
-MSE,4580,1,Surf Phen in Ms&E,0.24,0.44,0.2,0.12,0.0,0.0,0.0,0.0,konstantin kornev,MSE-4580,2015
-MSE,4610,1,Polymer & Fiber Materials III,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,MSE-4610,2015
-MSE,4910,1,Undergraduate Research,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,marian kennedy,MSE-4910,2015
-MSE,8100,1,Fundamentals of Materials Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,MSE-8100,2015
-MSE,8270,1,Kin of Phase Tran,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,MSE-8270,2015
-MSE,8510,1,Polymer Science I,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,gary lickfield,MSE-8510,2015
-MUSC,1110,9,Beginning Class Guitar,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,david stevenson,MUSC-1110,2015
-MUSC,1420,1,Music Theory I,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,anthony bernarducci,MUSC-1420,2015
-MUSC,1420,2,Music Theory I,0.72,0.06,0.17,0.0,0.0,0.0,0.0,0.06,anthony bernarducci,MUSC-1420,2015
-MUSC,1430,1,Aural Skills I,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,anthony bernarducci,MUSC-1430,2015
-MUSC,1430,2,Aural Skills I,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,anthony bernarducci,MUSC-1430,2015
-MUSC,2100,1,Music in the Western World,0.77,0.1,0.1,0.0,0.03,0.0,0.0,0.0,eric lapin,MUSC-2100,2015
-MUSC,2100,2,Music in the Western World,0.71,0.13,0.1,0.06,0.0,0.0,0.0,0.0,lisa sain odom,MUSC-2100,2015
-MUSC,2100,3,Music in the Western World,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,eric lapin,MUSC-2100,2015
-MUSC,2100,4,Music in the Western World,0.58,0.23,0.1,0.03,0.06,0.0,0.0,0.0,linda li-bleuel,MUSC-2100,2015
-MUSC,2100,5,Music in the Western World,0.83,0.13,0.03,0.0,0.0,0.0,0.0,0.03,timothy ra hurlburt,MUSC-2100,2015
-MUSC,2100,6,Music in the Western World,0.5,0.38,0.09,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,MUSC-2100,2015
-MUSC,2100,7,Music in the Western World,0.56,0.34,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,MUSC-2100,2015
-MUSC,2100,8,Music in the Western World,0.58,0.32,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,MUSC-2100,2015
-MUSC,2100,9,Music in the Western World,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,evan michael jacobi,MUSC-2100,2015
-MUSC,2100,10,Music in the Western World,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,linda dzuris,MUSC-2100,2015
-MUSC,2100,12,Music in the Western World,0.65,0.32,0.03,0.0,0.0,0.0,0.0,0.0,lea kibler,MUSC-2100,2015
-MUSC,2100,15,Music in West World (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,MUSC-2100,2015
-MUSC,3110,1,History of American Music,0.5,0.34,0.06,0.09,0.0,0.0,0.0,0.0,ned hosler,MUSC-3110,2015
-MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,eric lapin,MUSC-3120,2015
-MUSC,3130,1,Hist of Rock & Roll,0.61,0.29,0.04,0.0,0.04,0.0,0.0,0.04,hamilton altstatt,MUSC-3130,2015
-MUSC,3170,1,Hist of Country Mus,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,ned hosler,MUSC-3170,2015
-MUSC,3180,1,Hist of Audio Tech,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,MUSC-3180,2015
-MUSC,3610,1,Marching Band,0.97,0.02,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,MUSC-3610,2015
-MUSC,3690,1,Symphony Orchestra,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,andrew levin,MUSC-3690,2015
-MUSC,3710,1,Women's Chorus,0.95,0.0,0.0,0.0,0.03,0.0,0.0,0.02,justin durham,MUSC-3710,2015
-MUSC,3720,1,Men's Chorus,0.89,0.04,0.0,0.0,0.04,0.0,0.0,0.04,anthony bernarducci,MUSC-3720,2015
-MUSC,4150,1,Music Hist to 1750,0.15,0.23,0.31,0.23,0.08,0.0,0.0,0.0,justin durham,MUSC-4150,2015
-NPL,3000,1,Nonprofit Leadership,0.84,0.06,0.03,0.0,0.0,0.0,0.0,0.06,tracy diane lamb,NPL-3000,2015
-NPL,3000,3,Nonprofit Leadership,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,james dougl bennett,NPL-3000,2015
-NPL,3020,1,NPL Fundraising,0.69,0.15,0.08,0.0,0.08,0.0,0.0,0.0,robert frager,NPL-3020,2015
-NPL,3040,1,NPL Risk Management,0.46,0.46,0.0,0.08,0.0,0.0,0.0,0.0,anthony shau catone,NPL-3040,2015
-NURS,1020,1,Nrsg Success Skills,0.77,0.22,0.0,0.01,0.0,0.0,0.0,0.0,kristin goodenow,NURS-1020,2015
-NURS,1400,1,Comp App Hlth Care,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,NURS-1400,2015
-NURS,3030,1,Nursing of Adults,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,NURS-3030,2015
-NURS,3040,1,Pathophysiology,0.27,0.58,0.08,0.06,0.02,0.0,0.0,0.0,catherine si murton,NURS-3040,2015
-NURS,3040,400,Pathophysiology,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,catherine si murton,NURS-3040,2015
-NURS,3040,401,Pathophysiology,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,NURS-3040,2015
-NURS,3100,1,Health Assessment,0.47,0.51,0.02,0.0,0.0,0.0,0.0,0.0,terry kaye busby,NURS-3100,2015
-NURS,3100,400,Health Assessment,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,NURS-3100,2015
-NURS,3120,1,Foundations of Nursing,0.45,0.51,0.04,0.0,0.0,0.0,0.0,0.0,angela pye,NURS-3120,2015
-NURS,3120,400,Foundations of Nursing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3120,2015
-NURS,3300,2,Research in Nursing,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-3300,2015
-NURS,3400,1,Pharmther Nursing,0.27,0.61,0.08,0.02,0.02,0.0,0.0,0.0,catherine si murton,NURS-3400,2015
-NURS,3400,400,Pharmther Nursing,0.27,0.58,0.15,0.0,0.0,0.0,0.0,0.0,catherine si murton,NURS-3400,2015
-NURS,3600,400,Social Determinants in Health,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,roxanne amerson,NURS-3600,2015
-NURS,4030,200,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,NURS-4030,2015
-NURS,4110,1,Nursing of Children,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-4110,2015
-NURS,4120,1,Nurs Women and Fam,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2015
-NURS,4250,200,Community Nursing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,NURS-4250,2015
-NURS,8050,400,Pharmaco Adv Nurs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8050,2015
-NURS,8060,400,Advan Assessment for Nursing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,NURS-8060,2015
-NURS,8090,400,Pathophysiology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,NURS-8090,2015
-NURS,8200,400,Child & Adol Nursing,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-8200,2015
-NUTR,2030,1,Intro Princ of Human Nutrition,0.44,0.36,0.09,0.04,0.01,0.0,0.0,0.05,deborah an hutcheon,NUTR-2030,2015
-NUTR,2050,1,Nutr for Nurs Prof,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,NUTR-2050,2015
-NUTR,2160,1,Evidence-Based Nutrition,0.44,0.38,0.1,0.02,0.03,0.0,0.0,0.03,angela fraser,NUTR-2160,2015
-NUTR,4180,1,Prof Development in Dietetics,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,NUTR-4180,2015
-NUTR,4190,1,Professional Dev in Nutrition,0.92,0.0,0.0,0.04,0.04,0.0,0.0,0.0,angela fraser,NUTR-4190,2015
-NUTR,4240,1,Medical Nutr Thera I,0.63,0.35,0.02,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4240,2015
-NUTR,4510,1,Human Nutrition,0.43,0.22,0.14,0.07,0.09,0.0,0.0,0.05,michell bohan brown,NUTR-4510,2015
-NUTR,6510,1,Human Nutrition,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michell bohan brown,NUTR-6510,2015
-PA,1010,1,Intro to Perf Arts,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,david hartmann,PA-1010,2015
-PA,1030,1,Portfolio I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,linda dzuris,PA-1030,2015
-PA,2790,1,Perf Arts Pract I,0.69,0.19,0.0,0.0,0.13,0.0,0.0,0.0,kenneth moore,PA-2790,2015
-PA,3010,1,Prin of Arts Admin,0.81,0.13,0.0,0.06,0.0,0.0,0.0,0.0,paul buyer,PA-3010,2015
-PA,4010,1,Capstone Project,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,PA-4010,2015
-PADM,7020,400,Research Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,PADM-7020,2015
-PADM,7020,401,Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,PADM-7020,2015
-PADM,8210,400,Perspectives on Public Admin,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,mark daniel mellott,PADM-8210,2015
-PADM,8270,400,Public Personnel Admin,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,lawrence nichols,PADM-8270,2015
-PADM,8290,400,Public Financial Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,PADM-8290,2015
-PADM,8670,400,State Government Admin,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,alfred bundrick,PADM-8670,2015
-PADM,8710,400,Sustainability Practices Appli,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,PADM-8710,2015
-PADM,8780,400,Legal Aspects of Nonprofits,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,anthony shau catone,PADM-8780,2015
-PADM,8780,401,Local Govt Budgeting & Finance,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,kevin yokim,PADM-8780,2015
-PAS,3010,1,Pan African Studies,0.17,0.56,0.25,0.02,0.01,0.0,0.0,0.0,abel bartley,PAS-3010,2015
-PDBE,8100,1,Contemporary Issues in EDP,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,PDBE-8100,2015
-PES,1040,1,Introduction to Plant Sciences,0.67,0.17,0.0,0.0,0.03,0.0,0.0,0.13,paula agudelo,PES-1040,2015
-PES,2020,1,Soils,0.12,0.45,0.3,0.12,0.0,0.0,0.0,0.01,dara michelle park,PES-2020,2015
-PES,4090,1,Biology of Invasive Plants,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,PES-4090,2015
-PES,4210,1,Princ of Field Crop Production,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,sruthi naraya kutty,PES-4210,2015
-PHIL,1010,2,Intro to Philosophic Problems,0.53,0.17,0.13,0.03,0.1,0.0,0.0,0.03,adam gies,PHIL-1010,2015
-PHIL,1010,3,Intro to Philosophic Problems,0.4,0.4,0.11,0.06,0.0,0.0,0.0,0.03,christopher grau,PHIL-1010,2015
-PHIL,1010,4,Intro to Philosophic Problems,0.47,0.3,0.03,0.1,0.07,0.0,0.0,0.03,john randall wolfe,PHIL-1010,2015
-PHIL,1020,1,Introduction to Logic,0.62,0.21,0.03,0.0,0.09,0.0,0.0,0.06,david stegall,PHIL-1020,2015
-PHIL,1020,2,Introduction to Logic,0.43,0.37,0.06,0.03,0.06,0.0,0.0,0.06,david stegall,PHIL-1020,2015
-PHIL,1020,3,Introduction to Logic,0.76,0.18,0.03,0.03,0.0,0.0,0.0,0.0,gregory scott moss,PHIL-1020,2015
-PHIL,1020,4,Introduction to Logic,0.74,0.15,0.03,0.03,0.0,0.0,0.0,0.06,gregory scott moss,PHIL-1020,2015
-PHIL,1020,5,Introduction to Logic,0.71,0.18,0.09,0.0,0.03,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2015
-PHIL,1020,6,Introduction to Logic,0.68,0.21,0.06,0.03,0.0,0.0,0.0,0.03,michael hal hannen,PHIL-1020,2015
-PHIL,1030,1,Intro to Ethics (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,PHIL-1030,2015
-PHIL,1030,2,Introduction to Ethics,0.54,0.31,0.06,0.0,0.0,0.0,0.0,0.09,michael hal hannen,PHIL-1030,2015
-PHIL,1030,3,Introduction to Ethics,0.31,0.49,0.17,0.0,0.0,0.0,0.0,0.03,ryan lake,PHIL-1030,2015
-PHIL,1030,4,Introduction to Ethics,0.26,0.68,0.06,0.0,0.0,0.0,0.0,0.0,ryan lake,PHIL-1030,2015
-PHIL,1030,5,Introduction to Ethics,0.29,0.29,0.15,0.15,0.0,0.0,0.0,0.12,malcolm edwa munson,PHIL-1030,2015
-PHIL,1030,6,Introduction to Ethics,0.21,0.32,0.12,0.12,0.09,0.0,0.0,0.15,malcolm edwa munson,PHIL-1030,2015
-PHIL,1030,9,Introduction to Ethics,0.29,0.24,0.18,0.18,0.12,0.0,0.0,0.0,adam gies,PHIL-1030,2015
-PHIL,1030,10,Introduction to Ethics,0.72,0.16,0.09,0.03,0.0,0.0,0.0,0.0,adam gies,PHIL-1030,2015
-PHIL,1030,11,Introduction to Ethics,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,adam gies,PHIL-1030,2015
-PHIL,3040,1,Moral Philosophy,0.36,0.33,0.15,0.03,0.12,0.0,0.0,0.0,charles starkey,PHIL-3040,2015
-PHIL,3120,1,Philosophy in Ancient China,0.29,0.38,0.03,0.06,0.09,0.0,0.0,0.15,yanming an,PHIL-3120,2015
-PHIL,3150,1,Ancient Philosophy,0.26,0.37,0.22,0.07,0.07,0.0,0.0,0.0,stephen satris,PHIL-3150,2015
-PHIL,3160,1,Modern Philosophy,0.63,0.28,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,PHIL-3160,2015
-PHIL,3170,1,19th-Century Philosophy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,gregory scott moss,PHIL-3170,2015
-PHIL,3180,1,20th-Century Philosophy,0.63,0.3,0.0,0.04,0.04,0.0,0.0,0.0,john randall wolfe,PHIL-3180,2015
-PHIL,3240,1,Philosophy of Tech,0.38,0.44,0.03,0.03,0.03,0.0,0.0,0.09,andrew garnar,PHIL-3240,2015
-PHIL,3260,1,Science and Values,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,andrew garnar,PHIL-3260,2015
-PHIL,3260,2,Science and Values,0.47,0.38,0.06,0.0,0.03,0.0,0.0,0.06,andrew garnar,PHIL-3260,2015
-PHIL,3260,3,Science and Values,0.42,0.52,0.03,0.0,0.0,0.0,0.0,0.03,andrew garnar,PHIL-3260,2015
-PHIL,3330,1,Metaphysics,0.81,0.0,0.05,0.0,0.0,0.0,0.0,0.14,david stegall,PHIL-3330,2015
-PHIL,3430,1,Philosophy of Law,0.29,0.38,0.15,0.06,0.06,0.0,0.0,0.06,jennifer ingle,PHIL-3430,2015
-PHIL,3440,1,Business Ethics,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,david stegall,PHIL-3440,2015
-PHIL,3450,1,Environmental Ethics,0.74,0.19,0.03,0.0,0.03,0.0,0.0,0.0,john randall wolfe,PHIL-3450,2015
-PHIL,3450,2,Environmental Ethics,0.74,0.19,0.03,0.03,0.0,0.0,0.0,0.0,john randall wolfe,PHIL-3450,2015
-PHIL,3480,1,Philosophies of Art,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,christopher grau,PHIL-3480,2015
-PHIL,3490,1,Gender and Sexuality,0.75,0.04,0.08,0.04,0.0,0.0,0.0,0.08,jennifer ingle,PHIL-3490,2015
-PHIL,3550,1,Philosophy of Mind & Cog Scien,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,ryan lake,PHIL-3550,2015
-PHIL,4020,1,Topics in Philosophy,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,ryan lake,PHIL-4020,2015
-PHIL,4220,1,Anarchism,0.44,0.28,0.17,0.0,0.06,0.0,0.0,0.06,todd may,PHIL-4220,2015
-PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1180,2015
-PHYS,1220,1,Physics with Calculus I,0.25,0.3,0.29,0.07,0.05,0.0,0.0,0.04,lih-sin the,PHYS-1220,2015
-PHYS,1220,2,Physics with Calculus I,0.23,0.26,0.29,0.09,0.06,0.0,0.0,0.08,lih-sin the,PHYS-1220,2015
-PHYS,1220,4,Physics with Calculus I,0.4,0.15,0.15,0.05,0.15,0.0,0.0,0.1,murray daw,PHYS-1220,2015
-PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,2,Physics Lab I,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,3,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,4,Physics Lab I,0.18,0.71,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,PHYS-1240,2015
-PHYS,1240,5,Physics Lab I,0.0,0.72,0.06,0.0,0.0,0.0,0.0,0.22,jerry hester,PHYS-1240,2015
-PHYS,1240,6,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,7,Physics Lab I,0.56,0.25,0.13,0.0,0.06,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,8,Physics Lab I,0.28,0.61,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,9,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,10,Physics Lab I,0.33,0.44,0.11,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2015
-PHYS,1240,11,Physics Lab I,0.29,0.41,0.18,0.06,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,12,Physics Lab I,0.17,0.56,0.17,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2015
-PHYS,1240,13,Physics Lab I,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,15,Physics Lab I,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,16,Physics Lab I,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-1240,2015
-PHYS,1240,17,Physics Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,2070,1,General Physics I,0.39,0.36,0.14,0.04,0.03,0.0,0.0,0.03,amy liann pope,PHYS-2070,2015
-PHYS,2070,2,General Physics I,0.42,0.33,0.19,0.03,0.01,0.0,0.0,0.02,amy liann pope,PHYS-2070,2015
-PHYS,2070,3,General Physics I,0.27,0.39,0.2,0.06,0.07,0.0,0.0,0.03,pooja puneet,PHYS-2070,2015
-PHYS,2080,1,General Physics II,0.31,0.42,0.16,0.05,0.04,0.0,0.0,0.02,pooja puneet,PHYS-2080,2015
-PHYS,2090,1,Gen Phys Lab I,0.54,0.29,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2015
-PHYS,2090,2,Gen Phys Lab I,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2015
-PHYS,2090,3,Gen Phys Lab I,0.29,0.54,0.08,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2015
-PHYS,2090,4,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,5,Gen Phys Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,6,Gen Phys Lab I,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2015
-PHYS,2090,7,Gen Phys Lab I,0.83,0.09,0.0,0.0,0.04,0.0,0.0,0.04,jerry hester,PHYS-2090,2015
-PHYS,2090,8,Gen Phys Lab I,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2015
-PHYS,2090,9,Gen Phys Lab I,0.58,0.33,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2015
-PHYS,2090,10,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2015
-PHYS,2090,11,Gen Phys Lab I,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,12,Gen Phys Lab I,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,13,Gen Phys Lab I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,14,Gen Phys Lab I,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,15,Gen Phys Lab I,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2015
-PHYS,2090,16,Gen Phys Lab I,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,17,Gen Phys Lab I,0.44,0.48,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,18,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,19,Gen Phys Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,20,Gen Phys Lab I,0.73,0.23,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2015
-PHYS,2090,21,Gen Phys Lab I,0.43,0.35,0.13,0.0,0.04,0.0,0.0,0.04,jerry hester,PHYS-2090,2015
-PHYS,2090,22,Gen Phys Lab I,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,23,Gen Phys Lab I,0.36,0.55,0.05,0.0,0.05,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,24,Gen Phys Lab I,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2100,2,Gen Phys Lab II,0.7,0.17,0.04,0.0,0.0,0.0,0.0,0.09,jerry hester,PHYS-2100,2015
-PHYS,2100,3,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,4,Gen Phys Lab II,0.82,0.09,0.0,0.05,0.0,0.0,0.0,0.05,jerry hester,PHYS-2100,2015
-PHYS,2100,7,Gen Phys Lab II,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,8,Gen Phys Lab II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2210,1,Physics with Calculus II,0.26,0.43,0.19,0.08,0.02,0.0,0.0,0.02,jason stratfo brown,PHYS-2210,2015
-PHYS,2210,2,Physics with Calculus II,0.31,0.48,0.13,0.02,0.03,0.0,0.0,0.03,jason stratfo brown,PHYS-2210,2015
-PHYS,2210,3,Physics with Calculus II,0.35,0.51,0.1,0.02,0.01,0.0,0.0,0.0,jason stratfo brown,PHYS-2210,2015
-PHYS,2210,4,Physics with Calculus II,0.24,0.51,0.18,0.05,0.01,0.0,0.0,0.0,ramakrishna podila,PHYS-2210,2015
-PHYS,2210,7,Physics With Cal II (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,PHYS-2210,2015
-PHYS,2220,1,Physics with Calculus III,0.22,0.59,0.11,0.0,0.04,0.0,0.0,0.04,jeremy king,PHYS-2220,2015
-PHYS,2230,1,Physics Lab II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,2,Physics Lab II,0.28,0.33,0.39,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,3,Physics Lab II,0.18,0.76,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,4,Physics Lab II,0.38,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2015
-PHYS,2230,5,Physics Lab II,0.0,0.82,0.18,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,6,Physics Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,9,Physics Lab II,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,10,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,12,Physics Lab II,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,13,Physics Lab II,0.24,0.65,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,PHYS-2230,2015
-PHYS,2230,16,Physics Lab II,0.08,0.75,0.0,0.0,0.0,0.0,0.0,0.17,jerry hester,PHYS-2230,2015
-PHYS,2230,17,Physics Lab II,0.08,0.83,0.0,0.0,0.08,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2450,1,Physics of Climate,0.38,0.2,0.12,0.01,0.06,0.0,0.0,0.23,jens oberheide,PHYS-2450,2015
-PHYS,3120,1,Meth Theor Phys II,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,hye jung kang,PHYS-3120,2015
-PHYS,3150,1,Intro to Computational Physics,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,emil georgie alexov,PHYS-3150,2015
-PHYS,3210,1,Mechanics I,0.31,0.19,0.13,0.19,0.13,0.0,0.0,0.06,gerald lehmacher,PHYS-3210,2015
-PHYS,3250,1,Exper Physics I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,chad sosolik,PHYS-3250,2015
-PHYS,4410,1,Electromagnetics I,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,joan marler,PHYS-4410,2015
-PHYS,8110,1,Meth of Theor Phys I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,bradley meyer,PHYS-8110,2015
-PHYS,8210,1,Classical Mech I,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,dieter hartmann,PHYS-8210,2015
-PHYS,8750,7,Intro to Research,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,terry tritt,PHYS-8750,2015
-PHYS,9510,1,Quantum Mech I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,sumanta tewari,PHYS-9510,2015
-PKSC,1010,1,Pkgsc Orientation,0.76,0.11,0.06,0.05,0.02,0.0,0.0,0.01,robert truett moore,PKSC-1010,2015
-PKSC,1020,1,Intro to Pkg Sci,0.14,0.28,0.3,0.18,0.05,0.0,0.0,0.04,heather batt,PKSC-1020,2015
-PKSC,2020,1,Packaging Mtl & Mfg,0.68,0.17,0.14,0.0,0.01,0.0,0.0,0.0,robert truett moore,PKSC-2020,2015
-PKSC,2200,1,Product & Pkg Design,0.69,0.1,0.06,0.08,0.06,0.0,0.0,0.0,william aaro snyder,PKSC-2200,2015
-PKSC,3200,1,Pkg Design Theory,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,rupert hurley,PKSC-3200,2015
-PKSC,4010,1,Packaging Machinery,0.53,0.37,0.09,0.0,0.01,0.0,0.0,0.0,anthony lou pometto,PKSC-4010,2015
-PKSC,4030,1,Pkg Career Prep,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2015
-PKSC,4040,1,Protective Packaging Prop/Prin,0.19,0.34,0.26,0.06,0.1,0.0,0.0,0.04,gregory batt,PKSC-4040,2015
-PKSC,4160,1,Appl Polymers in Pkg,0.24,0.51,0.19,0.03,0.03,0.0,0.0,0.0,duncan darby,PKSC-4160,2015
-PKSC,4200,1,Pkg Design & Dev,0.56,0.41,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2015
-PKSC,4540,1,Prod Pkg Evl Lab,0.5,0.25,0.06,0.13,0.06,0.0,0.0,0.0,gregory batt,PKSC-4540,2015
-PKSC,4540,2,Prod Pkg Evl Lab,0.33,0.4,0.07,0.0,0.07,0.0,0.0,0.13,gregory batt,PKSC-4540,2015
-PKSC,4540,3,Prod Pkg Evl Lab,0.24,0.53,0.06,0.0,0.12,0.0,0.0,0.06,gregory batt,PKSC-4540,2015
-PKSC,4540,4,Prod Pkg Evl Lab,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,gregory batt,PKSC-4540,2015
-PKSC,4540,6,Prod Pkg Evl Lab,0.0,0.54,0.23,0.23,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2015
-PKSC,4640,1,Food & Health Care Pkg Systems,0.63,0.31,0.03,0.03,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2015
-PKSC,8170,1,Pckg Materials: Sci & Technol,0.73,0.09,0.0,0.0,0.18,0.0,0.0,0.0,duncan darby,PKSC-8170,2015
-PKSC,8220,400,3D Parametric Design,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,rupert hurley,PKSC-8220,2015
-PKSC,8220,401,Structural Pkging Design,0.6,0.0,0.0,0.0,0.4,0.0,0.0,0.0,rupert hurley,PKSC-8220,2015
-PLPA,3100,1,Principles of Plant Pathology,0.33,0.33,0.26,0.04,0.0,0.0,0.0,0.04,steven nye jeffers,PLPA-3100,2015
-POSC,1010,1,Amer National Govt,0.05,0.58,0.16,0.05,0.16,0.0,0.0,0.0,joseph earl stewart,POSC-1010,2015
-POSC,1010,2,Amer National Govt,0.24,0.48,0.15,0.06,0.02,0.0,0.0,0.05,jeffrey allen fine,POSC-1010,2015
-POSC,1010,3,Amer National Govt,0.08,0.2,0.3,0.2,0.0,0.0,0.0,0.23,james woodard,POSC-1010,2015
-POSC,1020,1,Intro Intl Relations,0.17,0.43,0.31,0.03,0.03,0.0,0.0,0.03,aron geo tannenbaum,POSC-1020,2015
-POSC,1020,2,Intro Intl Relations,0.17,0.5,0.2,0.02,0.09,0.0,0.0,0.02,lydia loui lundgren,POSC-1020,2015
-POSC,1020,3,Intro Intl Relations,0.19,0.29,0.25,0.1,0.08,0.0,0.0,0.08,steven vince miller,POSC-1020,2015
-POSC,1020,4,Intro Intl Relations,0.09,0.49,0.26,0.06,0.04,0.0,0.0,0.06,colin pearce,POSC-1020,2015
-POSC,1030,1,Intro to Political Theory,0.28,0.36,0.19,0.07,0.11,0.0,0.0,0.0,brandon turner,POSC-1030,2015
-POSC,1040,1,Intro Compar Pol,0.08,0.49,0.33,0.08,0.0,0.0,0.0,0.03,xiaobo hu,POSC-1040,2015
-POSC,1040,2,Intro Compar Pol,0.36,0.55,0.06,0.02,0.0,0.0,0.0,0.0,katherine am curtis,POSC-1040,2015
-POSC,1990,1,Intro Pol Sci,0.43,0.29,0.15,0.03,0.04,0.0,0.0,0.06,meredith petersheim,POSC-1990,2015
-POSC,3020,1,State and Loc Gov,0.1,0.57,0.27,0.0,0.02,0.0,0.0,0.04,bruce ransom,POSC-3020,2015
-POSC,3110,1,Model United Nations,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,xiaobo hu,POSC-3110,2015
-POSC,3410,1,Quant Meth in Pol Sc,0.12,0.47,0.06,0.24,0.12,0.0,0.0,0.0,steven vince miller,POSC-3410,2015
-POSC,3430,1,Mass Media in Americ Politics,0.31,0.35,0.16,0.04,0.1,0.0,0.0,0.04,jeffrey scott peake,POSC-3430,2015
-POSC,3610,1,Intl Pol in Crisis,0.21,0.63,0.06,0.02,0.04,0.0,0.0,0.04,vladimir matic,POSC-3610,2015
-POSC,3710,1,European Politics,0.15,0.61,0.07,0.0,0.07,0.0,0.0,0.1,vladimir matic,POSC-3710,2015
-POSC,3750,1,European Integration,0.3,0.33,0.15,0.07,0.11,0.0,0.0,0.04,lydia loui lundgren,POSC-3750,2015
-POSC,3890,1,Indiv. Autonomy & the Const.,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,POSC-3890,2015
-POSC,4210,1,Public Policy,0.18,0.12,0.35,0.18,0.06,0.0,0.0,0.12,adam warber,POSC-4210,2015
-POSC,4360,1,Law Courts Politics,0.69,0.2,0.04,0.0,0.06,0.0,0.0,0.02,joseph earl stewart,POSC-4360,2015
-POSC,4380,1,Constitut Law: Struc of Gov,0.45,0.41,0.11,0.02,0.0,0.0,0.0,0.0,daniel frost,POSC-4380,2015
-POSC,4420,1,Pol Parties & Elect,0.02,0.23,0.53,0.09,0.07,0.0,0.0,0.05,james woodard,POSC-4420,2015
-POSC,4470,1,International Law,0.27,0.48,0.12,0.06,0.03,0.0,0.0,0.03,katherine am curtis,POSC-4470,2015
-POSC,4500,1,Modern Ideologies,0.33,0.43,0.14,0.0,0.05,0.0,0.0,0.05,james woodard,POSC-4500,2015
-POSC,4530,1,American Political Thought,0.27,0.62,0.08,0.0,0.0,0.0,0.0,0.04,kimberly hurd hale,POSC-4530,2015
-POSC,4560,1,Diplomacy,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,POSC-4560,2015
-POSC,4710,1,Russian Politics,0.3,0.52,0.03,0.03,0.06,0.0,0.0,0.06,aron geo tannenbaum,POSC-4710,2015
-POSC,4760,1,Middle East Politics,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,vladimir matic,POSC-4760,2015
-POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,meredith petersheim,POSC-4990,2015
-POST,8220,1,Pol Analy/Pol Choice,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,POST-8220,2015
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.01,teresa walto tucker,PRTM-2260,2015
-PRTM,2270,1,Prov of Leisure Exp,0.53,0.43,0.02,0.01,0.0,0.0,0.0,0.01,teresa walto tucker,PRTM-2270,2015
-PRTM,2290,1,Competency Integration in PRTM,0.54,0.41,0.04,0.01,0.0,0.0,0.0,0.01,teresa walto tucker,PRTM-2290,2015
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.47,0.17,0.15,0.13,0.06,0.0,0.0,0.02,daniel mor anderson,PRTM-3050,2015
-PRTM,3070,2,Facility Operations,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,craig goodman,PRTM-3070,2015
-PRTM,3200,1,Recreation Policy,0.16,0.74,0.0,0.11,0.0,0.0,0.0,0.0,lincoln larson,PRTM-3200,2015
-PRTM,3210,1,Recreation Admin,0.35,0.46,0.13,0.0,0.02,0.0,0.0,0.04,mariela fernandez,PRTM-3210,2015
-PRTM,3220,1,Facilitation Techniques in RT,0.89,0.09,0.0,0.02,0.0,0.0,0.0,0.0,stephen thoma lewis,PRTM-3220,2015
-PRTM,3240,1,Assessment & Planning in RT,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3240,2015
-PRTM,3250,1,Global Persp in Rec,0.6,0.28,0.04,0.08,0.0,0.0,0.0,0.0,skye arthur-banning,PRTM-3250,2015
-PRTM,3420,2,Intro to Tourism,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,maloud shakona,PRTM-3420,2015
-PRTM,3430,1,Spl Asp of Tourist B,0.23,0.5,0.18,0.09,0.0,0.0,0.0,0.0,william norman,PRTM-3430,2015
-PRTM,3430,2,Spl Asp of Tourist B,0.46,0.37,0.11,0.03,0.03,0.0,0.0,0.0,william norman,PRTM-3430,2015
-PRTM,3520,1,Camp Org and Admin,0.08,0.31,0.31,0.15,0.0,0.0,0.0,0.15,gwynn powell,PRTM-3520,2015
-PRTM,3540,1,Youth Development in Camp,0.71,0.1,0.1,0.05,0.0,0.0,0.0,0.05,gwynn powell,PRTM-3540,2015
-PRTM,3900,8,Independent Study in PRTM,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3900,2015
-PRTM,3920,1,Special Event Management,0.73,0.15,0.06,0.02,0.04,0.0,0.0,0.0,kenneth backman,PRTM-3920,2015
-PRTM,3920,2,Special Event Management,0.82,0.1,0.04,0.02,0.0,0.0,0.0,0.02,kenneth backman,PRTM-3920,2015
-PRTM,4030,1,Elem of Rec/Pk Plan,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,robert baxte powell,PRTM-4030,2015
-PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,PRTM-4040,2015
-PRTM,4220,1,Management of RT Services,0.59,0.23,0.14,0.0,0.05,0.0,0.0,0.0,anna-mar chancellor,PRTM-4220,2015
-PRTM,4410,1,Commercial Rec,0.39,0.22,0.28,0.06,0.0,0.06,0.0,0.0,herbert chancellor,PRTM-4410,2015
-PRTM,4470,1,Perspect Intl Travel,0.65,0.19,0.1,0.0,0.03,0.0,0.0,0.03,lauren duffy,PRTM-4470,2015
-PRTM,4550,1,Adv Program Planning,0.46,0.37,0.11,0.03,0.0,0.0,0.0,0.03,jamie lynn cathey,PRTM-4550,2015
-PRTM,8010,2,Phil Found of PRTM,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,PRTM-8010,2015
-PRTM,8020,1,Group Proc in Leisure Services,0.53,0.33,0.0,0.0,0.07,0.0,0.0,0.07,skye arthur-banning,PRTM-8020,2015
-PRTM,8080,1,Behavioral Aspects,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-8080,2015
-PRTM,8220,2,Strateg Planning in PRTM Orgs,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,PRTM-8220,2015
-PRTM,9000,6,Comm Conserv Sustain Develop,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lawrence allen,PRTM-9000,2015
-PRTM,9080,2,PRTM Stats,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,PRTM-9080,2015
-PSYC,2010,1,Intro to Psychology,0.52,0.25,0.13,0.06,0.02,0.0,0.0,0.03,chong hyon pak,PSYC-2010,2015
-PSYC,2010,2,Intro to Psychology,0.35,0.34,0.2,0.07,0.02,0.0,0.0,0.02,jo anne jorgensen,PSYC-2010,2015
-PSYC,2010,3,Intro to Psychology,0.28,0.33,0.19,0.08,0.07,0.0,0.0,0.04,edwin brainerd,PSYC-2010,2015
-PSYC,2010,4,Intro to Psychology,0.15,0.43,0.29,0.03,0.01,0.0,0.0,0.09,christopher pagano,PSYC-2010,2015
-PSYC,2010,5,Intro to Psychology,0.26,0.41,0.21,0.01,0.01,0.0,0.0,0.09,mary taylor,PSYC-2010,2015
-PSYC,2010,6,Intro to Psychology (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-2010,2015
-PSYC,2020,1,Intro Psychology Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,eric mckibben,PSYC-2020,2015
-PSYC,2020,2,Intro Psychology Lab,0.8,0.04,0.12,0.0,0.04,0.0,0.0,0.0,eric mckibben,PSYC-2020,2015
-PSYC,2020,4,Intro Psychology Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,PSYC-2020,2015
-PSYC,2020,5,Intro Psychology Lab,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,eric mckibben,PSYC-2020,2015
-PSYC,2020,6,Intro Psychology Lab,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,eric mckibben,PSYC-2020,2015
-PSYC,3060,1,Human Sexual Beh,0.52,0.21,0.16,0.05,0.04,0.0,0.0,0.03,bruce michael king,PSYC-3060,2015
-PSYC,3090,100,Intro Exp Psych,0.51,0.2,0.13,0.11,0.04,0.0,0.0,0.01,patrick rosopa,PSYC-3090,2015
-PSYC,3090,200,Intro Exp Psych,0.41,0.31,0.17,0.03,0.07,0.0,0.0,0.0,jennifer bai bisson,PSYC-3090,2015
-PSYC,3090,300,Intro Exp Psych,0.3,0.47,0.1,0.07,0.03,0.0,0.0,0.03,richard tyrrell,PSYC-3090,2015
-PSYC,3100,100,Advanced Experimental Psych,0.24,0.53,0.12,0.0,0.0,0.0,0.0,0.12,jennifer bai bisson,PSYC-3100,2015
-PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,robert campbell,PSYC-3100,2015
-PSYC,3100,300,Advanced Experimental Psych,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,robert campbell,PSYC-3100,2015
-PSYC,3100,400,Advanced Experimental Psych,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2015
-PSYC,3100,500,Advanced Experimental Psych,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,sarah mae sanborn,PSYC-3100,2015
-PSYC,3100,600,Advanced Experimental Psych,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2015
-PSYC,3240,1,Physiological Psych,0.26,0.37,0.17,0.17,0.03,0.0,0.0,0.0,claudio cantalupo,PSYC-3240,2015
-PSYC,3240,2,Physiological Psych,0.26,0.31,0.19,0.1,0.12,0.0,0.0,0.01,june pilcher,PSYC-3240,2015
-PSYC,3330,1,Cognitive Psych,0.7,0.16,0.09,0.03,0.01,0.0,0.0,0.01,allison lei wallace,PSYC-3330,2015
-PSYC,3330,2,Cognitive Psych,0.21,0.37,0.19,0.13,0.03,0.0,0.0,0.07,thomas alley,PSYC-3330,2015
-PSYC,3340,4,Cognitive Psych Lab,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,leah hartman,PSYC-3340,2015
-PSYC,3400,1,Lifespan Developmental Psych,0.29,0.32,0.22,0.01,0.07,0.0,0.0,0.07,pamela alley,PSYC-3400,2015
-PSYC,3400,2,Lifespan Developmental Psych,0.65,0.24,0.09,0.01,0.0,0.0,0.0,0.0,jennifer bai bisson,PSYC-3400,2015
-PSYC,3520,1,Social Psychology,0.35,0.41,0.09,0.09,0.03,0.0,0.0,0.03,jo anne jorgensen,PSYC-3520,2015
-PSYC,3520,2,Social Psychology,0.62,0.29,0.04,0.0,0.04,0.0,0.0,0.0,alice miche brawley,PSYC-3520,2015
-PSYC,3640,1,Industrial Psych,0.34,0.5,0.13,0.01,0.0,0.0,0.0,0.01,eric mckibben,PSYC-3640,2015
-PSYC,3640,2,Industrial Psych,0.48,0.3,0.18,0.01,0.01,0.0,0.0,0.01,eric mckibben,PSYC-3640,2015
-PSYC,3680,1,Organizational Psych,0.43,0.33,0.17,0.01,0.0,0.0,0.0,0.04,kristen su jennings,PSYC-3680,2015
-PSYC,3690,1,Leadership in Orgs,0.56,0.26,0.15,0.03,0.0,0.0,0.0,0.0,eric mckibben,PSYC-3690,2015
-PSYC,3700,1,Personality,0.32,0.27,0.31,0.08,0.01,0.0,0.0,0.0,edwin brainerd,PSYC-3700,2015
-PSYC,3830,1,Abnormal Psychology,0.45,0.34,0.11,0.06,0.03,0.0,0.0,0.01,jo anne jorgensen,PSYC-3830,2015
-PSYC,3830,2,Abnormal Psychology,0.17,0.43,0.29,0.0,0.06,0.0,0.0,0.06,pamela alley,PSYC-3830,2015
-PSYC,3830,3,Abnormal Psychology,0.34,0.37,0.14,0.03,0.03,0.0,0.0,0.09,pamela alley,PSYC-3830,2015
-PSYC,4080,1,Women and Psychology,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-4080,2015
-PSYC,4150,1,Systems and Theories,0.48,0.35,0.06,0.03,0.03,0.0,0.0,0.03,brian day,PSYC-4150,2015
-PSYC,4150,2,Systems and Theories,0.38,0.22,0.28,0.03,0.06,0.0,0.0,0.03,edwin brainerd,PSYC-4150,2015
-PSYC,4220,1,Perception,0.41,0.22,0.22,0.11,0.0,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2015
-PSYC,4220,2,Perception,0.16,0.36,0.4,0.08,0.0,0.0,0.0,0.0,christopher pagano,PSYC-4220,2015
-PSYC,4220,3,Perception,0.26,0.26,0.26,0.07,0.04,0.0,0.0,0.11,claudio cantalupo,PSYC-4220,2015
-PSYC,4350,1,Human Factors,0.48,0.24,0.05,0.1,0.05,0.0,0.0,0.1,laura whitlock,PSYC-4350,2015
-PSYC,4430,1,Infant & Child Dev,0.44,0.36,0.12,0.04,0.04,0.0,0.0,0.0,sarah mae sanborn,PSYC-4430,2015
-PSYC,4560,1,Psychophysiology,0.48,0.35,0.09,0.09,0.0,0.0,0.0,0.0,drew michael morris,PSYC-4560,2015
-PSYC,4710,1,Psych of Testing,0.38,0.33,0.1,0.1,0.05,0.0,0.0,0.05,fred switzer,PSYC-4710,2015
-PSYC,4800,1,Health Psychology,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,june pilcher,PSYC-4800,2015
-PSYC,4880,1,Psychotherapy,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,lucinda sorci quick,PSYC-4880,2015
-PSYC,4890,1,Judgment and Decision Making,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,fred switzer,PSYC-4890,2015
-PSYC,4890,2,Psyc of Food and Eating,0.3,0.52,0.13,0.0,0.0,0.0,0.0,0.04,thomas alley,PSYC-4890,2015
-PSYC,4920,1,Senior Laboratory,0.85,0.04,0.08,0.04,0.0,0.0,0.0,0.0,hiu ngae jan cheung,PSYC-4920,2015
-PSYC,4920,2,Senior Laboratory,0.85,0.0,0.07,0.0,0.0,0.0,0.0,0.07,stephen robertson,PSYC-4920,2015
-PSYC,4920,4,Senior Laboratory,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,brooke bake allison,PSYC-4920,2015
-PSYC,8100,1,Research Design I,0.71,0.14,0.05,0.0,0.05,0.0,0.0,0.05, dewayne moore,PSYC-8100,2015
-PSYC,8350,1,Adv Human Factors,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-8350,2015
-PSYC,8620,1,Org Psychology,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,PSYC-8620,2015
-PSYC,8850,1,Org Stress,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas britt,PSYC-8850,2015
-RED,8000,1,Real Estate Dvlpment,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8000,2015
-RED,8030,1,Pub-Priv Partnership,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,john terrenc farris,RED-8030,2015
-RED,8130,1,Strat in Real Estate,0.5,0.31,0.13,0.0,0.0,0.0,0.0,0.06,phillip rive hughes,RED-8130,2015
-RED,8160,1,Preservation Feasibility,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8160,2015
-REL,1010,1,Intro to Religion,0.05,0.53,0.11,0.16,0.05,0.0,0.0,0.11,peter cohen,REL-1010,2015
-REL,1010,2,Intro to Religion,0.21,0.32,0.16,0.21,0.0,0.0,0.0,0.11,peter cohen,REL-1010,2015
-REL,1010,4,Intro to Religion,0.21,0.42,0.11,0.0,0.0,0.0,0.0,0.26,peter cohen,REL-1010,2015
-REL,1010,5,Intro to Religion,0.8,0.09,0.0,0.0,0.06,0.0,0.0,0.06,jennifer singletary,REL-1010,2015
-REL,1010,6,Intro to Religion,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jennifer singletary,REL-1010,2015
-REL,1020,2,World Religions,0.56,0.35,0.03,0.0,0.06,0.0,0.0,0.0,robert stephens,REL-1020,2015
-REL,1020,3,World Religions,0.72,0.14,0.06,0.0,0.08,0.0,0.0,0.0,robert stephens,REL-1020,2015
-REL,1020,4,World Religions,0.8,0.06,0.0,0.03,0.03,0.0,0.0,0.09,robert stephens,REL-1020,2015
-REL,3010,1,Old Testament,0.59,0.32,0.06,0.0,0.03,0.0,0.0,0.0,steven grosby,REL-3010,2015
-REL,3020,1,New Testament Lit,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,benjamin white,REL-3020,2015
-REL,3080,1,Rel of Ancient World,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3080,2015
-REL,3100,1,History of Religion in the US,0.47,0.21,0.21,0.05,0.0,0.0,0.0,0.05,elizabeth jemison,REL-3100,2015
-REL,3150,1,Islam,0.44,0.29,0.18,0.09,0.0,0.0,0.0,0.0,mashal saif,REL-3150,2015
-RS,3010,1,Rural Sociology,0.56,0.2,0.2,0.0,0.0,0.0,0.0,0.04,kenneth robinson,RS-3010,2015
-RUSS,1010,1,Elementary Russian,0.33,0.17,0.17,0.0,0.08,0.0,0.0,0.25,joan bridgwood,RUSS-1010,2015
-SOC,2010,1,Intro to Sociology (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,rachael chatterson,SOC-2010,2015
-SOC,2010,2,Introduction to Sociology,0.48,0.32,0.16,0.03,0.0,0.0,0.0,0.01,stephani southworth,SOC-2010,2015
-SOC,2010,3,Introduction to Sociology,0.46,0.31,0.1,0.1,0.0,0.0,0.0,0.02,stephani southworth,SOC-2010,2015
-SOC,2010,4,Introduction to Sociology,0.49,0.34,0.15,0.02,0.0,0.0,0.0,0.0,stephani southworth,SOC-2010,2015
-SOC,2010,5,Introduction to Sociology,0.32,0.42,0.16,0.08,0.02,0.0,0.0,0.0,mary louise barr,SOC-2010,2015
-SOC,2010,6,Introduction to Sociology,0.32,0.29,0.32,0.03,0.03,0.0,0.0,0.03,mary louise barr,SOC-2010,2015
-SOC,2010,7,Introduction to Sociology,0.43,0.39,0.13,0.02,0.02,0.0,0.0,0.0,mary louise barr,SOC-2010,2015
-SOC,2010,8,Introduction to Sociology,0.32,0.36,0.23,0.03,0.03,0.0,0.0,0.03,mary louise barr,SOC-2010,2015
-SOC,2010,9,Introduction to Sociology,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2015
-SOC,2010,10,Introduction to Sociology,0.52,0.35,0.11,0.0,0.0,0.0,0.0,0.02,jennifer le holland,SOC-2010,2015
-SOC,2010,11,Introduction to Sociology,0.55,0.26,0.16,0.0,0.03,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2015
-SOC,2010,12,Introduction to Sociology,0.53,0.34,0.13,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2015
-SOC,2010,13,Introduction to Sociology,0.59,0.27,0.05,0.03,0.0,0.0,0.0,0.05,shannon mcdonough,SOC-2010,2015
-SOC,2010,14,Introduction to Sociology,0.2,0.38,0.22,0.09,0.07,0.0,0.0,0.04,margaret tina britz,SOC-2010,2015
-SOC,2010,15,Introduction to Sociology,0.56,0.24,0.11,0.04,0.02,0.0,0.0,0.02,rachael chatterson,SOC-2010,2015
-SOC,2010,16,Introduction to Sociology,0.41,0.36,0.14,0.01,0.04,0.0,0.0,0.03,rachael chatterson,SOC-2010,2015
-SOC,2010,17,Introduction to Sociology,0.38,0.48,0.13,0.0,0.0,0.0,0.0,0.03,rachael chatterson,SOC-2010,2015
-SOC,2020,1,Social Problems,0.3,0.33,0.26,0.07,0.0,0.0,0.0,0.04,stephani southworth,SOC-2020,2015
-SOC,2050,1,Sociology Lab,0.74,0.03,0.09,0.0,0.14,0.0,0.0,0.0,brenda vander mey,SOC-2050,2015
-SOC,2050,2,Sociology Lab,0.65,0.06,0.06,0.18,0.0,0.0,0.0,0.06,brenda vander mey,SOC-2050,2015
-SOC,3020,1,Research Methods I,0.33,0.3,0.18,0.08,0.08,0.0,0.0,0.05,andrew whitehead,SOC-3020,2015
-SOC,3040,1,Social Research Methods II,0.22,0.3,0.39,0.09,0.0,0.0,0.0,0.0,ye luo,SOC-3040,2015
-SOC,3110,1,The Family,0.22,0.56,0.2,0.02,0.0,0.0,0.0,0.0,andrew whitehead,SOC-3110,2015
-SOC,3600,1,Class & Poverty,0.77,0.17,0.02,0.0,0.04,0.0,0.0,0.0,william haller,SOC-3600,2015
-SOC,3880,1,Criminal Justice,0.13,0.27,0.36,0.13,0.11,0.0,0.0,0.0,margaret tina britz,SOC-3880,2015
-SOC,3890,1,Criminology,0.37,0.26,0.06,0.06,0.17,0.0,0.0,0.09,william white,SOC-3890,2015
-SOC,3910,1,Soc of Deviance,0.47,0.28,0.09,0.07,0.0,0.0,0.0,0.09,william white,SOC-3910,2015
-SOC,3920,1,Juvenile Delinquency,0.23,0.08,0.23,0.23,0.15,0.0,0.0,0.08,william white,SOC-3920,2015
-SOC,3940,1,Sociology of Mental Illness,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,douglas sturkie,SOC-3940,2015
-SOC,3970,1,Substance Abuse,0.41,0.46,0.11,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,SOC-3970,2015
-SOC,4040,1,Soc Theory,0.54,0.29,0.15,0.0,0.0,0.0,0.0,0.02,william wentworth,SOC-4040,2015
-SOC,4140,1,Policy&Social Change,0.33,0.48,0.15,0.04,0.0,0.0,0.0,0.0,jennifer le holland,SOC-4140,2015
-SOC,4330,1,Global Social Change,0.67,0.17,0.11,0.0,0.06,0.0,0.0,0.0,william haller,SOC-4330,2015
-SOC,4440,1,Sociology of Educ,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,stephani southworth,SOC-4440,2015
-SOC,4600,1,Race & Ethnicity,0.29,0.29,0.33,0.08,0.0,0.0,0.0,0.0,brenda vander mey,SOC-4600,2015
-SOC,4600,2,Race & Ethnicity,0.5,0.17,0.08,0.17,0.08,0.0,0.0,0.0,brenda vander mey,SOC-4600,2015
-SOC,4610,1,Sex & Gender,0.39,0.43,0.11,0.0,0.02,0.0,0.0,0.04,traci ann hefner,SOC-4610,2015
-SOC,4680,1,Criminal Evidence,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,margaret tina britz,SOC-4680,2015
-SOC,4860,1,Creative Inquiry in Sociology,0.64,0.14,0.07,0.0,0.07,0.0,0.0,0.07,margaret tina britz,SOC-4860,2015
-SOC,4970,1,Senior Lab,0.56,0.16,0.16,0.09,0.0,0.0,0.0,0.03,brenda vander mey,SOC-4970,2015
-SOC,8030,1,Sur Dsgn App Res Lab,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,SOC-8030,2015
-SPAN,1010,1,Elementary Spanish,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,scott harris,SPAN-1010,2015
-SPAN,1010,2,Elementary Spanish,0.63,0.16,0.05,0.11,0.05,0.0,0.0,0.0,scott harris,SPAN-1010,2015
-SPAN,1010,3,Elementary Spanish,0.47,0.42,0.0,0.0,0.05,0.0,0.0,0.05,scott harris,SPAN-1010,2015
-SPAN,1020,1,Elementary Spanish,0.16,0.37,0.16,0.16,0.0,0.0,0.0,0.16,roger simpson,SPAN-1020,2015
-SPAN,1020,2,Elementary Spanish,0.18,0.29,0.24,0.18,0.0,0.0,0.0,0.12,roger simpson,SPAN-1020,2015
-SPAN,1020,3,Elementary Spanish,0.11,0.37,0.16,0.16,0.05,0.0,0.0,0.16,roger simpson,SPAN-1020,2015
-SPAN,1020,4,Elementary Spanish,0.42,0.26,0.05,0.11,0.05,0.0,0.0,0.11,roger simpson,SPAN-1020,2015
-SPAN,1020,5,Elementary Spanish,0.17,0.28,0.28,0.11,0.0,0.0,0.0,0.17,roger simpson,SPAN-1020,2015
-SPAN,1020,6,Elementary Spanish,0.39,0.39,0.11,0.06,0.0,0.0,0.0,0.06,cathy robison,SPAN-1020,2015
-SPAN,1020,7,Elementary Spanish,0.11,0.39,0.22,0.06,0.11,0.0,0.0,0.11,cathy robison,SPAN-1020,2015
-SPAN,1020,8,Elementary Spanish,0.39,0.28,0.06,0.06,0.17,0.0,0.0,0.06,ana paula  miller,SPAN-1020,2015
-SPAN,1020,9,Elementary Spanish,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,ana paula  miller,SPAN-1020,2015
-SPAN,1020,10,Elementary Spanish,0.58,0.26,0.0,0.05,0.05,0.0,0.0,0.05,debra oa williamson,SPAN-1020,2015
-SPAN,1020,11,Elementary Spanish,0.39,0.33,0.0,0.06,0.0,0.0,0.0,0.22,debra oa williamson,SPAN-1020,2015
-SPAN,1020,12,Elementary Spanish,0.53,0.21,0.11,0.0,0.11,0.0,0.0,0.05,adrienne eliza fama,SPAN-1020,2015
-SPAN,1020,13,Elementary Spanish,0.32,0.37,0.26,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-1020,2015
-SPAN,1020,14,Elementary Spanish,0.32,0.21,0.21,0.11,0.05,0.0,0.0,0.11,ana paula  miller,SPAN-1020,2015
-SPAN,2010,1,Intermediate Spanish,0.24,0.41,0.18,0.12,0.0,0.0,0.0,0.06,cathy robison,SPAN-2010,2015
-SPAN,2010,2,Intermediate Spanish,0.11,0.72,0.17,0.0,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2015
-SPAN,2010,3,Intermediate Spanish,0.38,0.31,0.25,0.0,0.0,0.0,0.0,0.06,allison ann hinds,SPAN-2010,2015
-SPAN,2010,4,Intermediate Spanish,0.21,0.5,0.29,0.0,0.0,0.0,0.0,0.0,allison ann hinds,SPAN-2010,2015
-SPAN,2010,5,Intermediate Spanish,0.53,0.18,0.18,0.06,0.0,0.0,0.0,0.06,allison ann hinds,SPAN-2010,2015
-SPAN,2010,6,Intermediate Spanish,0.5,0.19,0.25,0.0,0.0,0.0,0.0,0.06,heidi montes,SPAN-2010,2015
-SPAN,2010,7,Intermediate Spanish,0.25,0.25,0.25,0.13,0.0,0.0,0.0,0.13,heidi montes,SPAN-2010,2015
-SPAN,2010,8,Intermediate Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-2010,2015
-SPAN,2010,9,Intermediate Spanish,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-2010,2015
-SPAN,2010,10,Intermediate Spanish,0.38,0.31,0.08,0.0,0.15,0.0,0.0,0.08,ricardo tremolada,SPAN-2010,2015
-SPAN,2010,11,Intermediate Spanish,0.27,0.45,0.09,0.0,0.0,0.0,0.0,0.18,melva margu persico,SPAN-2010,2015
-SPAN,2010,12,Intermediate Spanish,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2010,2015
-SPAN,2010,13,Intermediate Spanish,0.26,0.37,0.26,0.0,0.0,0.0,0.0,0.11,maureen zamora,SPAN-2010,2015
-SPAN,2010,14,Intermediate Spanish,0.13,0.19,0.44,0.0,0.0,0.0,0.0,0.25,maureen zamora,SPAN-2010,2015
-SPAN,2010,15,Intermediate Spanish,0.53,0.2,0.0,0.0,0.07,0.0,0.0,0.2,ricardo tremolada,SPAN-2010,2015
-SPAN,2010,16,Intermediate Spanish,0.59,0.24,0.0,0.0,0.06,0.0,0.0,0.12,ricardo tremolada,SPAN-2010,2015
-SPAN,2010,17,Intermediate Spanish,0.68,0.11,0.16,0.0,0.05,0.0,0.0,0.0,ricardo tremolada,SPAN-2010,2015
-SPAN,2010,18,Intermediate Spanish,0.29,0.36,0.21,0.07,0.0,0.0,0.0,0.07,ana paula  miller,SPAN-2010,2015
-SPAN,2010,19,Intermediate Spanish,0.24,0.41,0.24,0.0,0.0,0.0,0.0,0.12,debra oa williamson,SPAN-2010,2015
-SPAN,2020,1,Intermediate Spanish,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-2020,2015
-SPAN,2020,2,Intermediate Spanish,0.06,0.56,0.31,0.06,0.0,0.0,0.0,0.0,melva margu persico,SPAN-2020,2015
-SPAN,2020,3,Intermediate Spanish,0.31,0.31,0.25,0.13,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2015
-SPAN,2020,4,Intermediate Spanish,0.28,0.5,0.11,0.0,0.0,0.0,0.0,0.11,heidi montes,SPAN-2020,2015
-SPAN,2020,5,Intermediate Spanish,0.64,0.07,0.14,0.0,0.0,0.0,0.0,0.14,ze cruz valderramos,SPAN-2020,2015
-SPAN,2020,6,Intermediate Spanish,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,ze cruz valderramos,SPAN-2020,2015
-SPAN,2020,7,Intermediate Spanish,0.39,0.28,0.28,0.0,0.0,0.0,0.0,0.06,melva margu persico,SPAN-2020,2015
-SPAN,2020,8,Intermediate Spanish,0.41,0.47,0.06,0.06,0.0,0.0,0.0,0.0,melva margu persico,SPAN-2020,2015
-SPAN,2020,9,Intermediate Spanish,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2015
-SPAN,2020,10,Intermediate Spanish,0.47,0.35,0.12,0.0,0.06,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2015
-SPAN,2020,11,Intermediate Spanish,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,kari daus carson,SPAN-2020,2015
-SPAN,2020,12,Intermediate Spanish,0.37,0.53,0.0,0.0,0.0,0.0,0.0,0.11,kari daus carson,SPAN-2020,2015
-SPAN,2020,13,Intermediate Spanish,0.37,0.21,0.32,0.05,0.05,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2015
-SPAN,2020,14,Intermediate Spanish,0.56,0.28,0.06,0.0,0.0,0.0,0.0,0.11,ze cruz valderramos,SPAN-2020,2015
-SPAN,2020,15,Intermediate Spanish,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2015
-SPAN,3050,2,Int Con Comp Span I,0.5,0.28,0.17,0.0,0.0,0.0,0.0,0.06,juana martin-armas,SPAN-3050,2015
-SPAN,3050,3,Int Con Comp Span I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-3050,2015
-SPAN,3060,1,Span Comp for Bus,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,maureen zamora,SPAN-3060,2015
-SPAN,3070,1,Hispanic World: Sp,0.72,0.11,0.0,0.06,0.0,0.0,0.0,0.11,salvador oropesa,SPAN-3070,2015
-SPAN,3070,2,Hispanic World: Sp,0.26,0.58,0.0,0.0,0.0,0.0,0.0,0.16,raquel anido,SPAN-3070,2015
-SPAN,3080,1,Hispanic World: La,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,george palacios,SPAN-3080,2015
-SPAN,3110,1,Surv Span-Amer Lit,0.21,0.29,0.21,0.14,0.0,0.0,0.0,0.14,tiffany dawn miller,SPAN-3110,2015
-SPAN,3130,1,Span Lit Survey I,0.27,0.27,0.18,0.09,0.0,0.0,0.0,0.18,mon rojas-de-massei,SPAN-3130,2015
-SPAN,3130,2,Span Lit Survey I,0.27,0.4,0.2,0.0,0.0,0.0,0.0,0.13,mon rojas-de-massei,SPAN-3130,2015
-SPAN,3140,1,Hispanic Linguistics,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,daniel smith,SPAN-3140,2015
-SPAN,4060,1,Narrative Fiction,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,SPAN-4060,2015
-SPAN,4160,1,Span Intl Trade II,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,maureen zamora,SPAN-4160,2015
-SPAN,4190,1,Health & Hisp Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-4190,2015
-SPAN,4220,1,Contem Span Am Novel,0.83,0.11,0.0,0.0,0.06,0.0,0.0,0.0,ricardo tremolada,SPAN-4220,2015
-SPAN,4350,1,Contemp Hisp Cult,0.45,0.27,0.09,0.0,0.09,0.0,0.0,0.09,tiffany dawn miller,SPAN-4350,2015
-STAT,2220,1,Statistics in Everyday Life,0.51,0.21,0.14,0.05,0.05,0.0,0.0,0.05,ros martinez-dawson,STAT-2220,2015
-STAT,2220,2,Statistics in Everyday Life,0.39,0.19,0.17,0.17,0.09,0.0,0.0,0.0,ros martinez-dawson,STAT-2220,2015
-STAT,2220,3,Statistics in Everyday Life,0.35,0.39,0.2,0.02,0.04,0.0,0.0,0.0,james espey,STAT-2220,2015
-STAT,2220,4,Statistics in Everyday Life,0.54,0.22,0.17,0.06,0.02,0.0,0.0,0.0,james espey,STAT-2220,2015
-STAT,2220,5,Statistics in Everyday Life,0.5,0.35,0.13,0.0,0.0,0.0,0.0,0.02,james espey,STAT-2220,2015
-STAT,2220,7,Statistics in Everyday Life,0.42,0.34,0.12,0.07,0.02,0.0,0.0,0.02,james espey,STAT-2220,2015
-STAT,2300,1,Statistical Methods I,0.43,0.31,0.08,0.11,0.06,0.0,0.0,0.01,christy jenki brown,STAT-2300,2015
-STAT,2300,2,Statistical Methods I,0.38,0.3,0.1,0.11,0.08,0.0,0.0,0.04,christy jenki brown,STAT-2300,2015
-STAT,2300,3,Statistical Methods I,0.45,0.35,0.08,0.07,0.03,0.0,0.0,0.01,christy jenki brown,STAT-2300,2015
-STAT,2300,4,Statistical Methods I,0.34,0.33,0.15,0.09,0.09,0.0,0.0,0.01, erwin walker,STAT-2300,2015
-STAT,2300,5,Statistical Methods I,0.31,0.36,0.21,0.06,0.06,0.0,0.0,0.0, erwin walker,STAT-2300,2015
-STAT,2300,6,Statistical Methods I,0.31,0.35,0.16,0.12,0.05,0.0,0.0,0.01,benjamin sharp,STAT-2300,2015
-STAT,2300,7,Statistical Methods I,0.28,0.34,0.22,0.06,0.06,0.0,0.0,0.04,brook thaye russell,STAT-2300,2015
-STAT,2300,8,Statistical Methods I,0.19,0.31,0.31,0.12,0.07,0.0,0.0,0.0, erwin walker,STAT-2300,2015
-STAT,3090,1,Introductory Business Stats,0.06,0.41,0.26,0.03,0.21,0.0,0.0,0.03,janie caro mcdonald,STAT-3090,2015
-STAT,3090,2,Introductory Business Stats,0.33,0.28,0.22,0.11,0.06,0.0,0.0,0.0,kara ail stasikelis,STAT-3090,2015
-STAT,3090,3,Introductory Business Stats,0.14,0.17,0.43,0.09,0.06,0.0,0.0,0.11,laura jane shick,STAT-3090,2015
-STAT,3090,4,Introductory Business Stats,0.15,0.38,0.21,0.15,0.1,0.0,0.0,0.0,gary fellers,STAT-3090,2015
-STAT,3090,5,Introductory Business Stats,0.13,0.42,0.24,0.08,0.11,0.0,0.0,0.03,laura jane shick,STAT-3090,2015
-STAT,3090,6,Introductory Business Stats,0.28,0.5,0.19,0.03,0.0,0.0,0.0,0.0,ellen hepfe breazel,STAT-3090,2015
-STAT,3090,7,Introductory Business Stats,0.37,0.21,0.26,0.05,0.11,0.0,0.0,0.0,kara ail stasikelis,STAT-3090,2015
-STAT,3090,8,Introductory Business Stats,0.16,0.42,0.21,0.11,0.05,0.0,0.0,0.05,christopher wilson,STAT-3090,2015
-STAT,3090,9,Introductory Business Stats,0.33,0.26,0.23,0.03,0.15,0.0,0.0,0.0,gary fellers,STAT-3090,2015
-STAT,3090,10,Introductory Business Stats,0.26,0.4,0.26,0.0,0.06,0.0,0.0,0.03,janie caro mcdonald,STAT-3090,2015
-STAT,3090,11,Introductory Business Stats,0.22,0.36,0.22,0.19,0.0,0.0,0.0,0.0,ellen hepfe breazel,STAT-3090,2015
-STAT,3090,12,Introductory Business Stats,0.26,0.36,0.13,0.08,0.1,0.0,0.0,0.08,laura jane shick,STAT-3090,2015
-STAT,3090,13,Introductory Business Stats,0.16,0.26,0.42,0.16,0.0,0.0,0.0,0.0,janie caro mcdonald,STAT-3090,2015
-STAT,3090,14,Introductory Business Stats,0.26,0.47,0.13,0.08,0.03,0.0,0.0,0.03,margaret mar wiecek,STAT-3090,2015
-STAT,3090,15,Introductory Business Stats,0.11,0.47,0.32,0.0,0.05,0.0,0.0,0.05,emily marie nystrom,STAT-3090,2015
-STAT,3090,16,Introductory Business Stats,0.11,0.37,0.32,0.11,0.11,0.0,0.0,0.0,laura jane shick,STAT-3090,2015
-STAT,3090,17,Introductory Business Stats,0.0,0.47,0.26,0.0,0.11,0.0,0.0,0.16,tao yang,STAT-3090,2015
-STAT,3090,18,Introductory Business Stats,0.36,0.31,0.23,0.03,0.05,0.0,0.0,0.03,gary fellers,STAT-3090,2015
-STAT,3090,19,Introductory Business Stats,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,emily marie nystrom,STAT-3090,2015
-STAT,3090,20,Introductory Business Stats,0.0,0.4,0.13,0.13,0.2,0.0,0.0,0.13,paul james cubre,STAT-3090,2015
-STAT,3090,21,Introductory Business Stats,0.26,0.33,0.26,0.05,0.08,0.0,0.0,0.03,gary fellers,STAT-3090,2015
-STAT,3090,22,Introductory Business Stats,0.14,0.29,0.29,0.09,0.14,0.0,0.0,0.06,janie caro mcdonald,STAT-3090,2015
-STAT,3090,23,Introductory Business Stats,0.11,0.37,0.22,0.15,0.07,0.0,0.0,0.07,tao yang,STAT-3090,2015
-STAT,3090,24,Introductory Business Stats,0.32,0.26,0.21,0.0,0.11,0.0,0.0,0.11,paul james cubre,STAT-3090,2015
-STAT,3090,25,Introductory Business Stats,0.16,0.63,0.05,0.0,0.11,0.0,0.0,0.05,drew jared lipman,STAT-3090,2015
-STAT,3090,26,Introductory Business Stats,0.11,0.16,0.32,0.21,0.11,0.0,0.0,0.11,christopher wilson,STAT-3090,2015
-STAT,3300,1,Statistical Methods II,0.21,0.38,0.21,0.0,0.0,0.0,0.0,0.21,ros martinez-dawson,STAT-3300,2015
-STAT,4020,1,Intro to Statistical Computing,0.44,0.31,0.06,0.06,0.06,0.0,0.0,0.06,julia lynn sharp,STAT-4020,2015
-STAT,4110,1,Stat Mthds for Process Control,0.3,0.4,0.23,0.0,0.08,0.0,0.0,0.0,william bridges,STAT-4110,2015
-STAT,4110,2,Stat Mthds for Process Control,0.44,0.25,0.16,0.09,0.06,0.0,0.0,0.0,patrick gerard,STAT-4110,2015
-STAT,6020,1,Intro to Statistical Computing,0.57,0.14,0.14,0.0,0.0,0.0,0.0,0.14,julia lynn sharp,STAT-6020,2015
-STAT,8010,1,Statistical Methods I,0.47,0.23,0.13,0.0,0.1,0.0,0.0,0.07,james rieck,STAT-8010,2015
-STAT,8010,2,Statistical Methods I,0.26,0.42,0.06,0.0,0.16,0.0,0.0,0.1,james rieck,STAT-8010,2015
-STAT,8010,3,Statistical Methods I,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,jun luo,STAT-8010,2015
-STAT,8010,4,Statistical Methods I,0.29,0.57,0.04,0.0,0.07,0.0,0.0,0.04,julia lynn sharp,STAT-8010,2015
-STAT,8020,1,Statistical Methods II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-8020,2015
-STAT,8030,1,Regress & Least Squares Anlys,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,jun luo,STAT-8030,2015
-STS,1010,1,Survey of S T S,0.49,0.49,0.0,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,STS-1010,2015
-STS,1010,2,Survey of S T S,0.56,0.42,0.03,0.0,0.0,0.0,0.0,0.0,philip randall,STS-1010,2015
-STS,1010,3,Survey of S T S,0.27,0.61,0.06,0.03,0.0,0.0,0.0,0.03,scott brame,STS-1010,2015
-STS,1010,5,Survey of S T S,0.58,0.36,0.03,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,STS-1010,2015
-STS,1010,6,Survey of S T S,0.32,0.5,0.09,0.03,0.03,0.0,0.0,0.03,sarah mae cooper,STS-1010,2015
-STS,1010,7,Survey of S T S,0.86,0.08,0.03,0.0,0.0,0.0,0.0,0.03,annah kamugiz amani,STS-1010,2015
-STS,1010,8,Survey of S T S,0.19,0.35,0.29,0.06,0.06,0.0,0.0,0.03,david charles foltz,STS-1010,2015
-STS,1010,9,Survey of S T S,0.47,0.25,0.17,0.03,0.0,0.0,0.0,0.08,allison ann hinds,STS-1010,2015
-STS,1010,10,Survey of S T S,0.49,0.26,0.11,0.06,0.03,0.0,0.0,0.06,megan no macalystre,STS-1010,2015
-THEA,2100,2,Theatre Appreciation,0.91,0.03,0.03,0.0,0.03,0.0,0.0,0.0,kerrie kath seymour,THEA-2100,2015
-THEA,2100,3,Theatre Appreciation,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-2100,2015
-THEA,2100,4,Theatre Appreciation,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,THEA-2100,2015
-THEA,2100,5,Theatre Appreciation,0.43,0.53,0.0,0.0,0.0,0.0,0.0,0.03,carol collins,THEA-2100,2015
-THEA,2100,6,Theatre Appreciation,0.67,0.2,0.07,0.0,0.03,0.0,0.0,0.03,anthony penna,THEA-2100,2015
-THEA,2100,7,Theatre Appreciation,0.52,0.39,0.1,0.0,0.0,0.0,0.0,0.0,jason adkins,THEA-2100,2015
-THEA,2780,1,Acting I,0.69,0.08,0.0,0.08,0.15,0.0,0.0,0.0,kerrie kath seymour,THEA-2780,2015
-THEA,2790,1,Theatre Practicum,0.5,0.13,0.13,0.0,0.0,0.0,0.0,0.25,matthew leckenbusch,THEA-2790,2015
-THEA,3170,1,African-Amer Thea I,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-3170,2015
-THEA,3760,1,Stage Directing I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richard st. peter,THEA-3760,2015
-THEA,3980,2,Special Topics in Theatre,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,THEA-3980,2015
-THEA,4720,1,Improvisation,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-4720,2015
-WFB,3000,1,Wildlife Biology,0.46,0.3,0.16,0.02,0.06,0.0,0.0,0.0,shari lyn rodriguez,WFB-3000,2015
-WFB,3000,2,Wildlife Biology,0.46,0.32,0.19,0.04,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3000,2015
-WFB,3010,1,Wildlife Biology Lab,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2015
-WFB,3010,2,Wildlife Biology Lab,0.53,0.24,0.18,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,WFB-3010,2015
-WFB,4100,2,Wildlife Management Techniques,0.15,0.55,0.23,0.05,0.03,0.0,0.0,0.0,james davis,WFB-4100,2015
-WFB,4440,1,Wildlife Damage Management,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,james davis,WFB-4440,2015
-WFB,4500,1,Aquaculture,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,WFB-4500,2015
-WFB,4930,1,Waterfowl Ecology & Mgt,0.33,0.58,0.04,0.0,0.0,0.0,0.0,0.04,richard ma kaminski,WFB-4930,2015
-WFB,8180,1,Waterfowl Ecology & Mgt,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,WFB-8180,2015
-WS,1030,1,Women Global Perspec,0.68,0.24,0.06,0.0,0.0,0.0,0.0,0.03,saadiqa kumanyika,WS-1030,2015
-WS,1030,2,Women Global Perspec,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,WS-1030,2015
-WS,2300,1,Women and Leadership,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,diane perpich,WS-2300,2015
-WS,3010,1,Intro Women's Studies,0.54,0.31,0.09,0.06,0.0,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2015
-WS,3010,2,Intro Women's Studies,0.46,0.4,0.09,0.03,0.0,0.0,0.0,0.03,elizabeth ros adams,WS-3010,2015
-YDP,3000,400,Youth Development in Society,0.58,0.05,0.21,0.0,0.16,0.0,0.0,0.0,barry garst,YDP-3000,2015
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1010,1,Survey of Art & Arch History I,0.5,0.35,0.11,0.0,0.01,0.0,0.0,0.04,beth ann lauritis,
+AAH,2050,1,Art History and Theory I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,beth ann lauritis,
+AAH,3050,1,Contemporary Art History,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,andrea feeser,
+ACCT,2010,1,Financial Accounting Concepts,0.11,0.23,0.26,0.11,0.13,0.0,0.0,0.17,philip maiberger,
+ACCT,2010,2,Financial Accounting Concepts,0.13,0.4,0.3,0.06,0.0,0.0,0.0,0.11,philip maiberger,
+ACCT,2010,3,Financial Accounting Concepts,0.41,0.23,0.13,0.05,0.03,0.0,0.0,0.15,lydia lan schleifer,
+ACCT,2010,4,Financial Accounting Concepts,0.32,0.43,0.14,0.03,0.08,0.0,0.0,0.0,annieka philo,
+ACCT,2010,5,Financial Accounting Concepts,0.26,0.24,0.13,0.08,0.11,0.0,0.0,0.18,lydia lan schleifer,
+ACCT,2010,6,Financial Accounting Concepts,0.2,0.27,0.17,0.03,0.07,0.0,0.0,0.27,the estate  guffey,
+ACCT,2010,7,Financial Accounting Concepts,0.33,0.43,0.1,0.12,0.0,0.0,0.0,0.02,annieka philo,
+ACCT,2010,8,Financial Accounting Concepts,0.1,0.36,0.36,0.03,0.1,0.0,0.0,0.05,philip maiberger,
+ACCT,2010,9,Financial Accounting Concepts,0.2,0.28,0.25,0.05,0.15,0.0,0.0,0.08,lydia lan schleifer,
+ACCT,2010,10,Financial Accounting Concepts,0.41,0.32,0.14,0.05,0.09,0.0,0.0,0.0,annieka philo,
+ACCT,2010,11,Financial Accounting Concepts,0.05,0.45,0.21,0.1,0.1,0.0,0.0,0.1,the estate  guffey,
+ACCT,2010,12,Financial Accounting Concepts,0.21,0.37,0.15,0.03,0.09,0.0,0.0,0.16,james mil kohlmeyer,
+ACCT,2010,13,Financial Accounting Concepts,0.13,0.53,0.16,0.0,0.08,0.0,0.0,0.11,mary ann  prater,
+ACCT,2010,14,Financial Accounting Concepts,0.13,0.56,0.17,0.06,0.06,0.0,0.0,0.04,james mil kohlmeyer,
+ACCT,2010,100,Fin Accounting Concepts (HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True
+ACCT,2010,400,Financial Accounting Concepts,0.15,0.27,0.25,0.14,0.13,0.0,0.0,0.07,jeffrey mcmillan,
+ACCT,2020,1,Managerial Accounting Concepts,0.14,0.14,0.24,0.12,0.07,0.0,0.0,0.29,henry anderson,
+ACCT,2020,2,Managerial Accounting Concepts,0.23,0.34,0.21,0.02,0.09,0.0,0.0,0.11,henry anderson,
+ACCT,2020,3,Managerial Accounting Concepts,0.26,0.32,0.19,0.08,0.09,0.0,0.0,0.06,holly rhiannio hawk,
+ACCT,2020,4,Managerial Accounting Concepts,0.14,0.41,0.24,0.14,0.08,0.0,0.0,0.0,holly rhiannio hawk,
+ACCT,2020,5,Managerial Accounting Concepts,0.37,0.28,0.28,0.02,0.06,0.0,0.0,0.0,tonya dionne smalls,
+ACCT,2020,6,Managerial Accounting Concepts,0.37,0.24,0.18,0.02,0.12,0.0,0.0,0.08,tonya dionne smalls,
+ACCT,2020,400,Managerial Accounting Concepts,0.18,0.15,0.18,0.09,0.08,0.0,0.0,0.31,henry anderson,
+ACCT,3030,1,Cost Accounting,0.18,0.52,0.18,0.0,0.02,0.0,0.0,0.11,holly rhiannio hawk,
+ACCT,3030,2,Cost Accounting,0.33,0.42,0.07,0.0,0.09,0.0,0.0,0.09,holly rhiannio hawk,
+ACCT,3030,3,Cost Accounting,0.22,0.43,0.22,0.07,0.04,0.0,0.0,0.02,jace garrett,
+ACCT,3030,4,Cost Accounting,0.16,0.6,0.16,0.0,0.0,0.0,0.0,0.09,jace garrett,
+ACCT,3110,1,Intermediate Financial Acct I,0.18,0.42,0.24,0.03,0.11,0.0,0.0,0.03,terry daniel knause,
+ACCT,3110,2,Intermediate Financial Acct I,0.35,0.26,0.21,0.06,0.06,0.0,0.0,0.06,terry daniel knause,
+ACCT,3110,3,Intermediate Financial Acct I,0.23,0.38,0.15,0.1,0.1,0.0,0.0,0.03,terry daniel knause,
+ACCT,3110,4,Intermediate Financial Acct I,0.33,0.4,0.18,0.05,0.03,0.0,0.0,0.03,terry daniel knause,
+ACCT,3110,5,Intermediate Financial Acct I,0.23,0.46,0.21,0.05,0.03,0.0,0.0,0.03, russell madray,
+ACCT,3110,400,Intermediate Financial Acct I,0.08,0.21,0.38,0.13,0.08,0.0,0.0,0.13, russell madray,
+ACCT,3120,1,Intermediate Financial Acct II,0.07,0.21,0.32,0.21,0.14,0.0,0.0,0.04,brian todd carver,
+ACCT,3120,2,Intermediate Financial Acct II,0.08,0.28,0.38,0.13,0.08,0.0,0.0,0.05,brian todd carver,
+ACCT,3120,3,Intermediate Financial Acct II,0.15,0.28,0.38,0.1,0.05,0.0,0.0,0.03,jeremy micha vinson,
+ACCT,3120,4,Intermediate Financial Acct II,0.13,0.45,0.34,0.05,0.03,0.0,0.0,0.0,jeremy micha vinson,
+ACCT,3120,5,Intermediate Financial Acct II,0.13,0.38,0.38,0.05,0.05,0.0,0.0,0.0,jeremy micha vinson,
+ACCT,3130,1,Intermediate Fin Acct III,0.18,0.33,0.39,0.03,0.03,0.0,0.0,0.03, russell madray,
+ACCT,3130,2,Intermediate Fin Acct III,0.37,0.43,0.17,0.0,0.0,0.0,0.0,0.03, russell madray,
+ACCT,3130,3,Intermediate Fin Acct III,0.2,0.35,0.28,0.13,0.0,0.0,0.0,0.05,james irving,
+ACCT,3130,4,Intermediate Fin Acct III,0.26,0.36,0.28,0.08,0.03,0.0,0.0,0.0, russell madray,
+ACCT,3220,1,Accounting Information Systems,0.09,0.26,0.23,0.11,0.06,0.0,0.0,0.26,philip maiberger,
+ACCT,3220,2,Accounting Information Systems,0.27,0.32,0.3,0.11,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,3220,3,Accounting Information Systems,0.11,0.35,0.3,0.11,0.05,0.0,0.0,0.08,nancy lee harp,
+ACCT,4040,1,Individual Taxation,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,2,Individual Taxation,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4080,1,Retire & Estate Plan,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,john hine,
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.31,0.46,0.13,0.08,0.0,0.0,0.0,0.03,sally kathr widener,
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
+ACCT,4150,1,Auditing,0.17,0.4,0.31,0.11,0.0,0.0,0.0,0.0,carl hollingsworth,
+ACCT,4150,2,Auditing,0.21,0.29,0.29,0.12,0.03,0.0,0.0,0.06,carl hollingsworth,
+ACCT,8510,1,Tax Research,0.27,0.7,0.03,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8510,2,Tax Research,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8510,3,Tax Research,0.26,0.71,0.03,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8530,1,Adv Acct Problems,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8530,2,Adv Acct Problems,0.39,0.42,0.13,0.0,0.0,0.0,0.0,0.06,ralph welton,
+ACCT,8530,3,Adv Acct Problems,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8550,1,Gov't and Nonprofit Accounting,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8550,2,Gov't and Nonprofit Accounting,0.58,0.35,0.08,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8630,1,Forensics Analysis,0.44,0.52,0.04,0.0,0.0,0.0,0.0,0.0,james irving,
+ACCT,8630,2,Forensics Analysis,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james irving,
+ACCT,8630,601,Forensics Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,james irving,
+ACCT,8650,1,Tax & Bus Decisions,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,judson jahn,
+ACCT,8730,1,Intl/Spec Tax Topic,0.31,0.58,0.08,0.0,0.0,0.0,0.0,0.03,judson jahn,
+AGED,1020,1,Freshman Seminar,0.65,0.12,0.06,0.06,0.0,0.0,0.0,0.12,catheri dibenedetto,
+AGED,2010,1,Intro to Agric Educ,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,2040,1,App Ag Calculations,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,3030,1,Ag Ed Mech Tech,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGED,3650,1,Multiculturalism in Agric Educ,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGED,4000,1,Supervised Field Experience II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,4010,1,Instr Methods Ag Ed,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,
+AGED,4030,1,Prin Adult/Ext Ed,0.76,0.19,0.0,0.05,0.0,0.0,0.0,0.0,kevin layfield,
+AGED,4230,400,Curriculum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,
+AGM,1010,1,Intro Ag Mech & Bus,0.73,0.16,0.1,0.02,0.0,0.0,0.0,0.0,hunter massey,
+AGM,2050,1,Prin of Fabrication,0.16,0.37,0.37,0.04,0.03,0.0,0.0,0.03,hunter massey,
+AGM,2060,1,Machinery Mgt,0.19,0.43,0.29,0.05,0.05,0.0,0.0,0.0,hunter massey,
+AGM,2210,1,Land Measurements,0.36,0.4,0.2,0.01,0.01,0.0,0.0,0.02,charles privette,
+AGM,3010,1,Soil Water Conserv,0.29,0.39,0.27,0.02,0.0,0.0,0.0,0.03,calvin sawyer,
+AGM,3190,1,Agribusiness Decision Analysis,0.26,0.43,0.23,0.06,0.0,0.0,0.0,0.02,lisha zhang,
+AGM,4050,1,Env Cont in Anim Str,0.08,0.35,0.38,0.15,0.0,0.0,0.0,0.03,john chastain,
+AGM,4060,1,Mech & Hydraulic Sys,0.33,0.5,0.12,0.02,0.0,0.0,0.0,0.02,ali bulent koc,
+AGM,4600,1,Electrical Systems,0.33,0.48,0.17,0.0,0.0,0.0,0.0,0.02,young han,
+AGRB,2020,1,Agricultural Economics,0.66,0.24,0.04,0.0,0.04,0.0,0.0,0.02,yuliya val bolotova,
+AGRB,2020,2,Agricultural Economics,0.15,0.48,0.33,0.04,0.0,0.0,0.0,0.0,matthew jam fischer,
+AGRB,2050,1,Agriculture and Society,0.36,0.44,0.14,0.06,0.0,0.0,0.0,0.0,michael vassalos,
+AGRB,2570,1,"Nat Resources, Environ & Econ",0.23,0.3,0.23,0.11,0.05,0.0,0.0,0.09,david brian willis,
+AGRB,3020,1,Economics of Farm Management,0.13,0.38,0.3,0.14,0.02,0.0,0.0,0.03,michael vassalos,
+AGRB,3090,1,Econ of Agricultural Marketing,0.89,0.04,0.04,0.02,0.0,0.0,0.0,0.0,yuliya val bolotova,
+AGRB,4120,1,Reg Econ Devel Theory & Policy,0.26,0.26,0.37,0.05,0.0,0.0,0.0,0.05,robert carey,
+AGRB,4600,1,Agricultural Finance,0.38,0.46,0.0,0.0,0.08,0.0,0.0,0.08,scott mickey,
+AL,3490,400,Principles of Coaching,0.4,0.48,0.08,0.04,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,401,Principles of Coaching,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,402,Principles of Coaching,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,
+AL,3490,403,Principles of Coaching,0.72,0.12,0.08,0.04,0.0,0.0,0.0,0.04,clyde keith connor,
+AL,3490,405,Principles of Coaching,0.67,0.21,0.04,0.0,0.0,0.0,0.0,0.08,clyde keith connor,
+AL,3490,406,Principles of Coaching,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,edmond fry,
+AL,3500,400,Sci Basis I/Ex Phy,0.32,0.12,0.36,0.08,0.04,0.0,0.0,0.08,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.2,0.28,0.28,0.12,0.12,0.0,0.0,0.0,michael godfrey,
+AL,3520,400,Kinesiology,0.47,0.33,0.13,0.07,0.0,0.0,0.0,0.0,isaac sean colbert,
+AL,3530,400,Athletic Injuries,0.14,0.33,0.29,0.14,0.05,0.0,0.0,0.05,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.19,0.38,0.13,0.19,0.0,0.0,0.0,0.13,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.32,0.52,0.08,0.0,0.0,0.0,0.0,0.08,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.6,0.32,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,401,Admin/Org of Athletic Programs,0.5,0.38,0.04,0.0,0.0,0.0,0.0,0.08,henry oates,
+AL,3610,402,Admin/Org of Athletic Programs,0.75,0.13,0.04,0.04,0.0,0.0,0.0,0.04,henry oates,
+AL,3620,400,Psychology of Coaching,0.31,0.31,0.19,0.08,0.08,0.0,0.0,0.04,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.4,0.24,0.16,0.2,0.0,0.0,0.0,0.0,natalie anne carter,
+AL,3620,402,Psychology of Coaching,0.44,0.22,0.28,0.0,0.06,0.0,0.0,0.0,natalie anne carter,
+AL,3740,400,Coaching Football,0.63,0.17,0.04,0.04,0.04,0.0,0.0,0.08,edmond fry,
+AL,3760,400,Coaching Strength/Conditioning,0.48,0.2,0.12,0.04,0.04,0.0,0.0,0.12,edmond fry,
+AL,3760,401,Coaching Strength/Conditioning,0.58,0.17,0.08,0.04,0.04,0.0,0.0,0.08,edmond fry,
+AL,4380,402,Coaching Women,0.43,0.22,0.3,0.04,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,8490,400,Athletic Leadership Dev,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8500,400,Principles Strength and Condit,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+ANTH,2010,1,Introduction to Anthropology,0.07,0.24,0.3,0.18,0.09,0.0,0.0,0.12,john coggeshall,
+ANTH,2010,2,Introduction to Anthropology,0.07,0.41,0.39,0.02,0.0,0.0,0.0,0.1,john coggeshall,
+ANTH,2010,3,Introduction to Anthropology,0.41,0.37,0.06,0.08,0.04,0.0,0.0,0.04,katherine weisensee,
+ANTH,2010,4,Introduction to Anthropology,0.33,0.36,0.13,0.04,0.07,0.0,0.0,0.07,yi wu,
+ANTH,2010,5,Introduction to Anthropology,0.48,0.28,0.07,0.04,0.07,0.0,0.0,0.07,lisa rapaport,
+ANTH,3010,1,Cultural Anthropology,0.1,0.41,0.31,0.1,0.0,0.0,0.0,0.07,john coggeshall,
+ANTH,3320,1,World Archaeology,0.09,0.32,0.29,0.06,0.03,0.0,0.0,0.21,melissa vogel,
+ANTH,3510,1,Biological Anthropology,0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,katherine weisensee,
+ANTH,3710,1,Language and Culture,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
+ANTH,4230,1,Women in the Developing World,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,melissa vogel,
+ANTH,4990,1,Special Topics,0.53,0.2,0.27,0.0,0.0,0.0,0.0,0.0,yi wu,
+ARCH,1010,1,Intro to Arch,0.46,0.36,0.02,0.0,0.03,0.0,0.0,0.13,sal hambright-belue,
+ARCH,2040,1,Hist of Modern Arch,0.25,0.61,0.08,0.0,0.03,0.0,0.0,0.02,robert bruhns,
+ARCH,2510,1,Arch Foundations I,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,robert silance,
+ARCH,2510,3,Arch Foundations I,0.62,0.31,0.0,0.0,0.08,0.0,0.0,0.0,clarissa mendez,
+ARCH,2510,4,Arch Foundations I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,james barker,
+ARCH,2510,5,Arch Foundations I,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,2700,1,Structures I,0.54,0.33,0.08,0.0,0.0,0.0,0.0,0.04,robert john hogan,
+ARCH,3510,1,Studio Clemson,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ARCH,3510,2,Studio Clemson,0.31,0.38,0.23,0.08,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,3510,3,Studio Clemson,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,3510,10,Studio Clemson,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,criss mills,
+ARCH,4010,1,Architectural Portfolio,0.42,0.42,0.06,0.0,0.06,0.0,0.0,0.06,clarissa mendez,
+ARCH,4010,2,Architectural Portfolio,0.61,0.29,0.04,0.0,0.0,0.0,0.0,0.07,clarissa mendez,
+ARCH,6300,1,Technology and Arch,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,barbara lamprecht,
+ARCH,6850,1,H/Th: Arch+Health,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8100,1,Visualization I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,8210,1,Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8510,1,Design Studio III,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,8510,3,Design Studio III,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8510,4,Design Studio III,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,8570,4,Design Studio V,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,raymond huff,
+ARCH,8600,1,History/Theory I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8720,1,Production & Assemb,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,8790,2,Digtial Manufacturing Process,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,
+ARCH,8810,1,Pro Practice Survey,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,
+ARCH,8860,1,Health Facilities,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ARCH,8890,1,Mentorship,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,
+ARCH,8970,1,A+H Studio: Hospital,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ART,1050,1,Foundation Drawing I,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,kathleen ann thum,
+ART,1510,1,Foundations Art I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,gregory wi shelnutt,
+ART,2070,1,Beginning Painting,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,mary jane king,
+ART,2090,1,Beginning Sculpture,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabet cooke,
+ART,2100,400,Art Appreciation,0.48,0.19,0.22,0.0,0.04,0.0,0.0,0.07,lydia jane dorsey,
+ART,2100,401,Art Appreciation,0.59,0.22,0.0,0.04,0.04,0.0,0.0,0.11,lydia jane dorsey,
+ART,2100,402,Art Appreciation,0.5,0.21,0.18,0.0,0.07,0.0,0.0,0.04,lydia jane dorsey,
+ART,2100,403,Art Appreciation,0.46,0.31,0.04,0.0,0.12,0.0,0.0,0.08,lydia jane dorsey,
+ART,2130,1,Begin Photography,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,haley brooke floyd,
+ART,2170,1,Beginning Ceramics,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,en iwamura,
+ART,8050,1,Visual Arts Sem I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,todd mcdonald,
+AS,1090,2,Air Force Today I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,christopher mann,
+AS,2090,2,Dev of Air Power I,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,christopher mann,
+AS,2090,3,Dev of Air Power I,0.6,0.35,0.0,0.0,0.05,0.0,0.0,0.0,christopher mann,
+ASL,1010,1,Am Sign Lang I,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,1010,2,Am Sign Lang I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,2010,1,Am Sign Lang II,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,2010,2,Am Sign Lang II,0.26,0.42,0.32,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,2020,1,Am Sign Lang II,0.31,0.38,0.31,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,3150,1,Survey Interpreting,0.47,0.2,0.13,0.07,0.0,0.0,0.0,0.13,stephen fitzmaurice,
+ASTR,1010,1,Solar System Astronomy,0.41,0.36,0.1,0.03,0.03,0.0,0.0,0.08,phillip flower,
+ASTR,1010,2,Solar System Astronomy,0.43,0.33,0.14,0.03,0.03,0.0,0.0,0.03,phillip flower,
+ASTR,1010,3,Solar System Astronomy,0.32,0.45,0.1,0.04,0.05,0.0,0.0,0.04,phillip flower,
+ASTR,1030,1,Solar Systm Astr Lab,0.6,0.2,0.04,0.0,0.12,0.0,0.0,0.04,mark leising,
+ASTR,1030,2,Solar Systm Astr Lab,0.5,0.15,0.08,0.04,0.12,0.0,0.0,0.12,mark leising,
+ASTR,1030,3,Solar Systm Astr Lab,0.52,0.2,0.08,0.0,0.12,0.0,0.0,0.08,mark leising,
+ASTR,1030,4,Solar Systm Astr Lab,0.42,0.25,0.13,0.13,0.0,0.0,0.0,0.08,mark leising,
+ASTR,1030,5,Solar Systm Astr Lab,0.5,0.23,0.08,0.04,0.08,0.0,0.0,0.08,mark leising,
+ASTR,1030,6,Solar Systm Astr Lab,0.25,0.5,0.21,0.04,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1030,7,Solar Systm Astr Lab,0.19,0.42,0.15,0.12,0.04,0.0,0.0,0.08,mark leising,
+ASTR,1030,8,Solar Systm Astr Lab,0.38,0.33,0.17,0.08,0.0,0.0,0.0,0.04,mark leising,
+ASTR,1030,9,Solar Systm Astr Lab,0.24,0.48,0.12,0.0,0.04,0.0,0.0,0.12,mark leising,
+ASTR,8100,1,Astroph I: Radiation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,marco ajello,
+AUD,2800,1,Sound Reinforcement,0.0,0.33,0.42,0.17,0.08,0.0,0.0,0.0,kenneth moore,
+AUE,8260,5,Vehicle Diagnostics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8270,5,Auto Cntrl Sys Des,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8280,79,Driveline/Powertrain,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,zoran filipi,
+AUE,8330,30,Auto Manuf Proc Devl,0.35,0.62,0.03,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,8670,1,Veh Manuf Proc I,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,michael mears,
+AUE,8800,2,Vehicle Project Mngt,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8810,3,Automotive Systems Overview,0.22,0.7,0.09,0.0,0.0,0.0,0.0,0.0,paul venhovens,
+AUE,8870,8,Meth Vehicle Testing,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8930,13,Engine Analysis,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8930,14,Automotive Composites,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
+AUE,8930,17,Hybrids,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8930,18,Adv IC Engine Concept,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,8930,78,Applied Dynamics,0.5,0.0,0.33,0.0,0.17,0.0,0.0,0.0,imtiaz ul haque,
+AVS,1000,1,Orientation to AVS,0.83,0.09,0.01,0.01,0.03,0.0,0.0,0.03,johanna joh lascano,
+AVS,1500,1,Intro Animal Science,0.59,0.27,0.05,0.02,0.03,0.0,0.0,0.04,heather walker dunn,
+AVS,1510,1,Intro Ani Sci Lab,0.7,0.26,0.0,0.0,0.0,0.0,0.0,0.04,anna rebecca baxley,
+AVS,1510,2,Intro Ani Sci Lab,0.52,0.4,0.04,0.04,0.0,0.0,0.0,0.0,anna rebecca baxley,
+AVS,1510,3,Intro Ani Sci Lab,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,richelle lor miller,
+AVS,1510,4,Intro Ani Sci Lab,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,1510,5,Intro Ani Sci Lab,0.36,0.56,0.0,0.0,0.0,0.0,0.0,0.08,anna rebecca baxley,
+AVS,1510,6,Intro Ani Sci Lab,0.52,0.36,0.04,0.0,0.0,0.0,0.0,0.08,heather walker dunn,
+AVS,1510,7,Intro Ani Sci Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,richelle lor miller,
+AVS,2010,1,Poultry Techniques,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,2020,1,CAFLS Plus,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,thomas scott,
+AVS,2030,1,Dairy Sci Techniques,0.93,0.02,0.0,0.0,0.02,0.0,0.0,0.02,heather walker dunn,
+AVS,2040,1,Horse Care Techniques,0.57,0.36,0.03,0.0,0.03,0.0,0.0,0.0,kristine lan vernon,
+AVS,2110,1,Meat Processing Techniques,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3010,1,Anat & Phys Dom Ani,0.45,0.2,0.18,0.13,0.04,0.0,0.0,0.0,glenn birrenkott,
+AVS,3010,400,Anat & Phys Dom Ani,0.36,0.36,0.14,0.14,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,3020,1,Livestk Sel Eval I,0.61,0.34,0.02,0.0,0.0,0.0,0.0,0.02,richelle lor miller,
+AVS,3090,1,Equine Evaluation,0.5,0.32,0.11,0.04,0.0,0.0,0.0,0.04,kristine lan vernon,
+AVS,3100,2,Animal Health,0.65,0.19,0.07,0.02,0.02,0.0,0.0,0.06,thomas scott,
+AVS,3700,1,Principles of Animal Nutrition,0.17,0.22,0.25,0.23,0.07,0.0,0.0,0.07,nathan long,
+AVS,3750,1,Applied Animal Nutrition,0.18,0.53,0.28,0.03,0.0,0.0,0.0,0.0,gustavo jos lascano,
+AVS,4000,1,AVS Professional Development,0.66,0.2,0.1,0.0,0.05,0.0,0.0,0.0,johanna joh lascano,
+AVS,4060,1,Seminars & Related Topics,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4060,2,Seminars & Related Topics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4150,1,Contemporary Issues in AVS,0.12,0.42,0.36,0.03,0.03,0.0,0.0,0.05,peter skewes,
+AVS,4160,1,Equine Exercise Phys,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,kristine lan vernon,
+AVS,4530,1,Animal Reproduction,0.27,0.38,0.27,0.04,0.04,0.0,0.0,0.0,tiffany wilmoth,
+AVS,4700,1,Animal Genetics,0.47,0.21,0.22,0.05,0.05,0.0,0.0,0.0,meenakshi mukherjee,
+BCHM,1030,1,Careers in Bioch/Gen,0.88,0.03,0.01,0.04,0.01,0.0,0.0,0.02,alison starr-moss,
+BCHM,3010,1,Molecular Biochem,0.26,0.21,0.21,0.16,0.16,0.0,0.0,0.0,cheryl ingram-smith,
+BCHM,3050,1,Essen Elements Bioch,0.25,0.34,0.22,0.06,0.05,0.0,0.0,0.08,srik chandrasekaran,
+BCHM,3050,2,Essen Elements Bioch,0.26,0.34,0.25,0.12,0.02,0.0,0.0,0.01,srik chandrasekaran,
+BCHM,3050,3,Essen Elements Bioch,0.28,0.37,0.11,0.06,0.07,0.0,0.0,0.11,srik chandrasekaran,
+BCHM,4060,1,Physiological Chem,0.68,0.19,0.03,0.03,0.03,0.0,0.0,0.03,james ro strickland,
+BCHM,4310,1,Physical Approach to Biochem,0.25,0.34,0.32,0.02,0.0,0.0,0.0,0.07,weiguo cao,
+BCHM,4310,2,Phys App to Bioch (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True
+BCHM,4330,1,General Biochemistry Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,
+BCHM,4330,2,General Biochemistry Lab I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,weiguo cao,
+BCHM,4330,3,General Biochemistry Lab I,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,
+BCHM,4330,4,General Biochemistry Lab I,0.6,0.1,0.1,0.0,0.0,0.0,0.0,0.2,weiguo cao,
+BCHM,4400,1,Bioinformatics,0.74,0.08,0.03,0.08,0.0,0.0,0.0,0.08,frank alexan feltus,
+BCHM,4900,7,C-MED,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,michael glen sehorn,
+BCHM,8140,1,Advanced Biochemistry,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,kerry smith,
+BE,2120,1,Fundamentals of Biosys Engr,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,caye marie drapcho,
+BE,3200,1,Principles & Prac of Geomatics,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4100,1,Biological Kinetics,0.44,0.32,0.24,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,4150,1,Instr & Control for Biosys Eng,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,yi zheng,
+BE,4280,1,Biochem Engr,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,terry walker,
+BE,4740,1,B E Design/Proj Mgt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4750,1,B E Capstone Design,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BIOE,1010,1,Biol for Bioengr,0.65,0.24,0.0,0.06,0.0,0.0,0.0,0.06,vladimir vla reukov,
+BIOE,2010,1,Intro Biomed Engr,0.52,0.39,0.08,0.0,0.0,0.0,0.0,0.02,charles webb,
+BIOE,2010,2,Intro Biomed Engr,0.38,0.58,0.01,0.0,0.0,0.0,0.0,0.03,vladimir vla reukov,
+BIOE,3020,1,Biomaterials,0.44,0.34,0.1,0.06,0.02,0.0,0.0,0.04,alexey ale vertegel,
+BIOE,3200,1,Biomechanics,0.65,0.31,0.02,0.02,0.0,0.0,0.0,0.02,lisa benson,
+BIOE,3210,1,Biofluid Mechanics,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,zhi gao,
+BIOE,3700,1,Bioinst & Imaging,0.74,0.21,0.03,0.02,0.0,0.0,0.0,0.0,david kwartowitz,
+BIOE,4010,1,Bioengineering Design Theory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4030,1,Applied Bio E Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
+BIOE,4120,1,Orthopaedic Engr and Pathology,0.56,0.33,0.04,0.0,0.0,0.0,0.0,0.07,melinda harman,
+BIOE,4400,1,Biopharmaceutical Engineering,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,sarah harcum,
+BIOE,6120,1,Orthopaedic Engr & Pathology,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,melinda harman,
+BIOE,8010,1,Bio Materials,0.36,0.54,0.07,0.04,0.0,0.0,0.0,0.0,robert latour,
+BIOE,8160,1,BioE Professional Development,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,martine laberge,
+BIOE,8200,1,Structl Biomechanics,0.78,0.19,0.0,0.0,0.0,0.0,0.0,0.04,hai yao,
+BIOE,8500,4,Cardiovascular Biomechanics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,
+BIOL,1010,1,Frontiers in Biology I,0.71,0.19,0.06,0.02,0.01,0.0,0.0,0.01,robert edwa ballard,
+BIOL,1010,2,Frontiers in Biology I,0.67,0.21,0.05,0.05,0.02,0.0,0.0,0.01,thomas hughes,
+BIOL,1010,3,Frontiers in Biology I,0.67,0.25,0.02,0.01,0.04,0.0,0.0,0.01,joseph paul thames,
+BIOL,1030,1,General Biology I,0.21,0.23,0.24,0.14,0.09,0.0,0.0,0.09,nora espinoza,
+BIOL,1030,3,General Biology I,0.26,0.32,0.26,0.07,0.04,0.0,0.0,0.05,kristi ja whitehead,
+BIOL,1030,4,General Biology I,0.29,0.3,0.21,0.06,0.04,0.0,0.0,0.1,william surver,
+BIOL,1030,5,General Biology I,0.19,0.23,0.35,0.12,0.05,0.0,0.0,0.06,salvatore sparace,
+BIOL,1030,6,General Biology I (HON),0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True
+BIOL,1050,1,General Biology Lab I,0.46,0.33,0.13,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,2,General Biology Lab I,0.17,0.3,0.35,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,3,General Biology Lab I,0.17,0.35,0.17,0.09,0.04,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,4,General Biology Lab I,0.33,0.17,0.21,0.13,0.08,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,5,General Biology Lab I,0.13,0.42,0.33,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,6,General Biology Lab I,0.25,0.42,0.21,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,7,General Biology Lab I,0.25,0.29,0.21,0.21,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,8,General Biology Lab I,0.25,0.21,0.29,0.04,0.08,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,9,General Biology Lab I,0.22,0.48,0.13,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,10,General Biology Lab I,0.29,0.5,0.08,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,11,General Biology Lab I,0.08,0.46,0.29,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,12,General Biology Lab I,0.5,0.25,0.17,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,13,General Biology Lab I,0.24,0.28,0.28,0.12,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,14,General Biology Lab I,0.17,0.42,0.25,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,15,General Biology Lab I,0.29,0.5,0.08,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,16,General Biology Lab I,0.29,0.42,0.17,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,17,General Biology Lab I,0.38,0.42,0.04,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,18,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,19,General Biology Lab I,0.17,0.42,0.38,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,20,General Biology Lab I,0.22,0.57,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,21,General Biology Lab I,0.13,0.38,0.21,0.08,0.08,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,25,General Biology Lab I,0.54,0.42,0.0,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,26,General Biology Lab I,0.38,0.29,0.17,0.0,0.08,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,28,General Biology Lab I,0.63,0.21,0.04,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,29,General Biology Lab I,0.29,0.42,0.25,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,30,General Biology Lab I,0.29,0.5,0.08,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,31,General Biology Lab I,0.17,0.33,0.29,0.04,0.08,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,32,General Biology Lab I,0.26,0.43,0.09,0.04,0.0,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,33,General Biology Lab I,0.29,0.54,0.0,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,34,General Biology Lab I,0.46,0.17,0.21,0.08,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,35,General Biology Lab I,0.38,0.42,0.17,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,36,General Biology Lab I,0.08,0.29,0.42,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,37,General Biology Lab I,0.17,0.54,0.17,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,38,General Biology Lab I,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,39,General Biology Lab I,0.25,0.33,0.25,0.04,0.0,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,40,General Biology Lab I,0.17,0.5,0.25,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,41,General Biology Lab I,0.13,0.54,0.17,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,42,General Biology Lab I,0.26,0.48,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,43,General Biology Lab I,0.04,0.26,0.35,0.13,0.17,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,44,General Biology Lab I,0.22,0.26,0.22,0.13,0.09,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,47,General Biology Lab I,0.17,0.38,0.21,0.08,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,48,General Biology Lab I,0.06,0.35,0.29,0.06,0.18,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1090,1,Intro to Life Sci,0.77,0.21,0.02,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
+BIOL,1100,1,Principles of Biology I,0.21,0.33,0.29,0.07,0.03,0.0,0.0,0.07,robert kosinski,
+BIOL,1100,2,Principles of Biology I,0.19,0.46,0.19,0.06,0.02,0.0,0.0,0.08,dylan dittrich-reed,
+BIOL,1100,4,Prin of Biology I (HON),0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True
+BIOL,1200,1,Biological Inq Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,2,Biological Inq Lab,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,3,Biological Inq Lab,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0, christine minor,
+BIOL,1200,4,Biological Inq Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0, christine minor,
+BIOL,1200,6,Biological Inq Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,7,Biological Inq Lab,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,11,Biological Inq Lab,0.7,0.2,0.0,0.05,0.0,0.0,0.0,0.05, christine minor,
+BIOL,1200,12,Biological Inq Lab,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,14,Biological Inq Lab,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0, christine minor,
+BIOL,1230,1,Keys to Human Biol,0.21,0.4,0.26,0.09,0.03,0.0,0.0,0.01, christine minor,
+BIOL,1230,2,Keys to Human Biol,0.23,0.47,0.24,0.03,0.02,0.0,0.0,0.02, christine minor,
+BIOL,2000,3,Biology in the News,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,2000,7,Biology in the News,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
+BIOL,2040,1,"Environ, Energy and Society",0.53,0.19,0.09,0.09,0.03,0.0,0.0,0.08,john jenkins hains,
+BIOL,2220,1,Human Anat and Physiology I,0.19,0.35,0.24,0.09,0.07,0.0,0.0,0.07,john cummings,
+BIOL,2220,2,Human Anat and Physiology I,0.24,0.3,0.21,0.11,0.1,0.0,0.0,0.05,john cummings,
+BIOL,3030,1,Vertebrate Biology,0.27,0.31,0.17,0.15,0.04,0.0,0.0,0.05,richard blob,
+BIOL,3030,2,Vertebrate Biology (HON),0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,richard blob,True
+BIOL,3040,1,Biology of Plants,0.29,0.36,0.19,0.09,0.06,0.0,0.0,0.03,saara dewalt,
+BIOL,3070,1,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,2,Vertebrate Biology Lab,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,3,Vertebrate Biology Lab,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,4,Vertebrate Biology Lab,0.38,0.52,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,5,Vertebrate Biology Lab,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,7,Vertebrate Biology Lab,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,8,Vertebrate Biology Lab,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,9,Vertebrate Biology Lab,0.38,0.38,0.14,0.05,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,10,Vertebrate Biology Lab,0.71,0.24,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,11,Vertebrate Biology Lab,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,12,Vertebrate Biology Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,13,Vertebrate Biology Lab,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3080,1,Biology of Plants Practicum,0.24,0.29,0.35,0.06,0.06,0.0,0.0,0.0,saara dewalt,
+BIOL,3080,2,Biology of Plants Practicum,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,saara dewalt,
+BIOL,3080,3,Biology of Plants Practicum,0.4,0.3,0.25,0.0,0.0,0.0,0.0,0.05,saara dewalt,
+BIOL,3080,4,Biology of Plants Practicum,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,saara dewalt,
+BIOL,3150,1,Functional Human Anatomy,0.25,0.49,0.18,0.04,0.02,0.0,0.0,0.03,tamara mcnutt-scott,
+BIOL,3200,1,Field Botany,0.2,0.18,0.3,0.2,0.02,0.0,0.0,0.1,robert edwa ballard,
+BIOL,3350,1,Evolutionary Biology,0.24,0.26,0.18,0.13,0.09,0.0,0.0,0.11,lisa rapaport,
+BIOL,3510,1,Biological Anthropology,0.46,0.38,0.08,0.08,0.0,0.0,0.0,0.0,katherine weisensee,
+BIOL,4140,1,Basic Immunology,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,yanzhang wei,
+BIOL,4200,1,Neurobiology,0.29,0.28,0.16,0.03,0.01,0.0,0.0,0.22,david feliciano,
+BIOL,4200,2,Neurobiology (HON),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,True
+BIOL,4250,1,Introductory Mycology,0.6,0.1,0.0,0.2,0.1,0.0,0.0,0.0,julia loui kerrigan,
+BIOL,4340,1,Biological Chem Lab Techniques,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,2,Biological Chem Lab Techniques,0.45,0.27,0.0,0.27,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,3,Biological Chem Lab Techniques,0.23,0.31,0.15,0.31,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4410,1,Ecology,0.18,0.38,0.28,0.08,0.01,0.0,0.0,0.07,david tonkyn,
+BIOL,4410,2,Ecology (HON),0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,david tonkyn,True
+BIOL,4430,1,Freshwater Ecology,0.63,0.22,0.1,0.0,0.0,0.0,0.0,0.05,john jenkins hains,
+BIOL,4450,1,Ecology Laboratory (Lec),0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,david tonkyn,
+BIOL,4450,3,Ecology Laboratory (Lec),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
+BIOL,4450,4,Ecology Laboratory (Lec),0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,david tonkyn,
+BIOL,4610,1,Cell Biology,0.29,0.3,0.29,0.07,0.02,0.0,0.0,0.03,lesly temesvari,
+BIOL,4610,2,Cell Biology (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True
+BIOL,4610,3,Cell Biology,0.33,0.29,0.28,0.04,0.02,0.0,0.0,0.04,susan carol chapman,
+BIOL,4610,4,Cell Biology (HON),0.24,0.57,0.19,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True
+BIOL,4620,1,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,2,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,3,Cell Biology Lab (Lec),0.53,0.2,0.27,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,4,Cell Biology Lab (Lec),0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.71,0.18,0.06,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
+BIOL,4620,7,Cell Biology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,8,Cell Biology Lab (Lec),0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,9,Cell Biology Lab (Lec),0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,10,Cell Biology Lab (Lec),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
+BIOL,4620,11,Cell Biology Lab (Lec),0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,xianzhong yu,
+BIOL,4670,1,Principles of Hematology,0.91,0.0,0.05,0.0,0.0,0.0,0.0,0.05,vincent gallicchio,
+BIOL,4750,1,Comparative Physiology,0.49,0.32,0.05,0.02,0.0,0.0,0.0,0.12,michael sears,
+BIOL,4930,2,Senior Seminar,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,wen chen,
+BIOL,4930,4,Senior Seminar,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,juan baeza migueles,
+BIOL,6030,1,Intro to Applied Genomics,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vincent pa richards,
+BIOL,8400,1,Understanding Biological Inq,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,dylan dittrich-reed,
+BIOL,8420,1,Understand Cellular Processes,0.73,0.21,0.0,0.0,0.02,0.0,0.0,0.04,david feliciano,
+BIOL,8440,1,Understanding the Human Body,0.47,0.34,0.1,0.01,0.04,0.0,0.0,0.03,william baldwin,
+BUS,1010,1,Business Foundations,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,2,Business Foundations,0.27,0.46,0.24,0.03,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,3,Business Foundations,0.43,0.27,0.14,0.03,0.05,0.0,0.0,0.08,william ern tumblin,
+BUS,1010,4,Business Foundations,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,5,Business Foundations,0.39,0.32,0.16,0.03,0.05,0.0,0.0,0.05,donna mccubbin,
+BUS,1010,6,Business Foundations,0.47,0.34,0.16,0.03,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,7,Business Foundations,0.02,0.45,0.38,0.02,0.07,0.0,0.0,0.05,donna mccubbin,
+BUS,1010,8,Business Foundations,0.3,0.35,0.21,0.02,0.0,0.0,0.0,0.12,donna mccubbin,
+BUS,1010,9,Business Foundations,0.16,0.44,0.21,0.05,0.07,0.0,0.0,0.07,donna mccubbin,
+BUS,1010,10,Business Foundations,0.19,0.49,0.19,0.02,0.09,0.0,0.0,0.02,william ern tumblin,
+BUS,1010,11,Business Foundations,0.21,0.74,0.0,0.05,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,12,Business Foundations,0.42,0.32,0.11,0.05,0.05,0.0,0.0,0.05,sandy edge,
+BUS,1010,13,Business Foundations,0.21,0.68,0.05,0.0,0.0,0.0,0.0,0.05,sandy edge,
+BUS,1010,14,Business Foundations,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,15,Business Foundations,0.32,0.42,0.21,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,16,Business Foundations,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,17,Business Foundations,0.16,0.42,0.26,0.0,0.05,0.0,0.0,0.11,william ern tumblin,
+BUS,1010,18,Business Foundations,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,19,Business Foundations,0.11,0.28,0.39,0.11,0.06,0.0,0.0,0.06,william ern tumblin,
+BUS,1010,20,Business Foundations,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,william ern tumblin,
+BUS,1010,27,Business Foundations,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,28,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+CE,2010,2,Statics,0.41,0.19,0.14,0.14,0.1,0.0,0.0,0.02,qiushi chen,
+CE,2010,3,Statics,0.48,0.11,0.27,0.07,0.0,0.0,0.0,0.07,brandon ross,
+CE,2010,4,Statics,0.11,0.32,0.09,0.05,0.11,0.0,0.0,0.32,melissa sternhagen,
+CE,2010,5,Statics,0.36,0.21,0.17,0.05,0.07,0.0,0.0,0.14,melissa sternhagen,
+CE,2010,6,Statics,0.46,0.17,0.19,0.02,0.07,0.0,0.0,0.09,mahmoodreza soltani,
+CE,2010,7,Statics,0.23,0.45,0.13,0.06,0.0,0.0,0.0,0.13,weichiang pang,
+CE,2060,1,Structural Mechanics,0.07,0.39,0.34,0.1,0.02,0.0,0.0,0.07,bryant nielson,
+CE,2080,2,Dynamics,0.04,0.3,0.26,0.11,0.04,0.0,0.0,0.26,melissa sternhagen,
+CE,2080,4,Dynamics,0.04,0.19,0.38,0.15,0.08,0.0,0.0,0.15,melissa sternhagen,
+CE,2550,1,Geomatics,0.32,0.47,0.19,0.0,0.0,0.0,0.0,0.02,wayne sarasua,
+CE,2550,2,Geomatics,0.44,0.31,0.18,0.03,0.05,0.0,0.0,0.0,wayne sarasua,
+CE,3010,1,Structural Analysis,0.21,0.59,0.12,0.06,0.03,0.0,0.0,0.0,stephen csernak,
+CE,3010,2,Structural Analysis,0.28,0.23,0.38,0.08,0.03,0.0,0.0,0.0,bryant nielson,
+CE,3110,1,Transportation Engr,0.71,0.18,0.07,0.02,0.02,0.0,0.0,0.0,jennifer ogle,
+CE,3210,1,Geotechnical Engineering,0.38,0.38,0.18,0.0,0.05,0.0,0.0,0.0,qiushi chen,
+CE,3310,1,Constr Engr & Mgmnt,0.41,0.37,0.12,0.06,0.04,0.0,0.0,0.0,james burati,
+CE,3410,1,Intro to Fluid Mech,0.13,0.6,0.24,0.04,0.0,0.0,0.0,0.0,nigel gregory kaye,
+CE,3410,2,Intro to Fluid Mech,0.14,0.33,0.39,0.07,0.02,0.0,0.0,0.05,abdul khan,
+CE,3420,1,Hydraulics & Hydro,0.29,0.47,0.12,0.08,0.02,0.0,0.0,0.02,ashok mishra,
+CE,3510,1,Civil Engineering Materials,0.68,0.28,0.03,0.03,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,
+CE,3510,2,Civil Engineering Materials,0.54,0.29,0.13,0.02,0.02,0.0,0.0,0.0,ami esmaeilpoursaee,
+CE,3520,1,Econ Eval of Proj,0.36,0.22,0.09,0.13,0.11,0.0,0.0,0.09,yongxi huang,
+CE,3530,1,Professional Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,4010,1,Matrix Str Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
+CE,4020,1,Reinfor Con Design,0.44,0.38,0.16,0.03,0.0,0.0,0.0,0.0,brandon ross,
+CE,4060,1,Struct Steel Design,0.35,0.28,0.28,0.05,0.05,0.0,0.0,0.0,stephen csernak,
+CE,4070,1,Wood Design,0.13,0.4,0.13,0.0,0.07,0.0,0.0,0.27,weichiang pang,
+CE,4100,1,Traffic Engr Oper,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,yongxi huang,
+CE,4210,1,Geotechnical Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
+CE,4240,1,Earth Slopes & Struc,0.29,0.29,0.24,0.05,0.05,0.0,0.0,0.1,nadara ravichandran,
+CE,4370,1,Sustainable Energy Proj Design,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,leidy klotz,
+CE,4390,1,Con Eqpmt Sel & Main,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,james burati,
+CE,4560,1,Pave Design & Constr,0.29,0.48,0.17,0.05,0.02,0.0,0.0,0.0,bradley putman,
+CE,4590,1,Capstone Design Proj,0.69,0.26,0.03,0.0,0.0,0.0,0.0,0.03,stephen csernak,
+CE,4910,1,BIM in Construction Management,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,6010,1,Matrix Str Analysis,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
+CE,6070,1,Wood Design,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CE,6100,1,Traffic Engr Oper,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,yongxi huang,
+CE,6240,1,Earth Slopes & Struc,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,6560,1,Pavement Des & Const,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,bradley putman,
+CE,6910,1,BIM in Construction Management,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,8020,1,Adv R/C Design,0.23,0.58,0.19,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,
+CE,8050,1,Adv Struc Mech,0.38,0.48,0.14,0.0,0.0,0.0,0.0,0.0,bryant nielson,
+CE,8060,1,Dyn Analys of Struc,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
+CE,8140,1,Intel Trans Systems,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,kakan dey,
+CE,8200,1,Geotech Site Charac,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,8260,1,Prop of Concrete,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
+CH,1010,1,General Chemistry,0.19,0.32,0.21,0.12,0.09,0.0,0.0,0.06,thomas hickman,
+CH,1010,2,General Chemistry,0.19,0.27,0.28,0.08,0.1,0.0,0.0,0.08,christopher wilson,
+CH,1010,3,General Chemistry,0.28,0.21,0.25,0.09,0.09,0.0,0.0,0.07,christopher wilson,
+CH,1010,4,General Chemistry,0.16,0.44,0.21,0.1,0.03,0.0,0.0,0.06,dennis taylor,
+CH,1010,5,General Chemistry,0.23,0.32,0.23,0.07,0.06,0.0,0.0,0.09,dennis taylor,
+CH,1010,6,General Chemistry,0.08,0.32,0.2,0.11,0.13,0.0,0.0,0.16,william joh wallace,
+CH,1010,7,General Chemistry,0.16,0.31,0.26,0.13,0.03,0.0,0.0,0.12,dennis taylor,
+CH,1010,8,General Chemistry,0.21,0.32,0.28,0.04,0.1,0.0,0.0,0.05,olt geiculescu,
+CH,1010,9,General Chemistry,0.08,0.26,0.26,0.17,0.14,0.0,0.0,0.1,william joh wallace,
+CH,1010,10,General Chemistry,0.3,0.27,0.25,0.08,0.06,0.0,0.0,0.04,ava kreider-mueller,
+CH,1010,11,General Chemistry,0.22,0.41,0.19,0.11,0.03,0.0,0.0,0.03,tania issa houjeiry,
+CH,1010,12,General Chemistry,0.25,0.35,0.16,0.08,0.08,0.0,0.0,0.07,ava kreider-mueller,
+CH,1010,13,General Chemistry,0.14,0.36,0.29,0.07,0.09,0.0,0.0,0.05,elliot ennis,
+CH,1010,14,General Chemistry,0.09,0.27,0.35,0.11,0.11,0.0,0.0,0.07,william joh wallace,
+CH,1010,16,General Chemistry,0.22,0.37,0.31,0.06,0.03,0.0,0.0,0.01,tania issa houjeiry,
+CH,1010,17,General Chemistry,0.14,0.31,0.31,0.11,0.08,0.0,0.0,0.05,elliot ennis,
+CH,1010,18,General Chemistry,0.23,0.31,0.28,0.08,0.03,0.0,0.0,0.06,ava kreider-mueller,
+CH,1010,50,General Chemistry,0.35,0.38,0.19,0.08,0.0,0.0,0.0,0.0,william pennington,
+CH,1010,51,General Chemistry (HON),0.67,0.22,0.07,0.0,0.0,0.0,0.0,0.04,joseph stu thrasher,True
+CH,1010,52,General Chemistry (HON),0.56,0.31,0.1,0.0,0.0,0.0,0.0,0.03,shiou-jyh hwu,True
+CH,1010,53,General Chemistry,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,edward collins,
+CH,1020,1,General Chemistry,0.27,0.25,0.25,0.11,0.06,0.0,0.0,0.06,stephe schvaneveldt,
+CH,1020,2,General Chemistry,0.3,0.31,0.23,0.08,0.04,0.0,0.0,0.05,stephe schvaneveldt,
+CH,1020,3,General Chemistry,0.27,0.27,0.26,0.1,0.02,0.0,0.0,0.08,stephe schvaneveldt,
+CH,1020,400,General Chemistry,0.05,0.34,0.34,0.07,0.1,0.0,0.0,0.1,stephe schvaneveldt,
+CH,1050,1,Chemistry in Context I,0.39,0.53,0.08,0.0,0.0,0.0,0.0,0.0,olt geiculescu,
+CH,1050,2,Chemistry in Context I,0.48,0.35,0.11,0.03,0.0,0.0,0.0,0.04,olt geiculescu,
+CH,1410,1,Chem Orientation,0.89,0.06,0.0,0.0,0.02,0.0,0.0,0.02, karl dieter,
+CH,2010,1,Survey of Organic Chemistry,0.29,0.35,0.29,0.0,0.02,0.0,0.0,0.05,thomas hickman,
+CH,2010,2,Survey of Organic Chemistry,0.36,0.41,0.21,0.0,0.01,0.0,0.0,0.01,thomas hickman,
+CH,2020,1,Surv of Organic Chemistry Lab,0.56,0.25,0.0,0.13,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2020,2,Surv of Organic Chemistry Lab,0.72,0.17,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
+CH,2020,6,Surv of Organic Chemistry Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2020,8,Surv of Organic Chemistry Lab,0.67,0.06,0.17,0.0,0.0,0.0,0.0,0.11,sean 'connor,
+CH,2230,1,Organic Chemistry,0.21,0.37,0.27,0.04,0.06,0.0,0.0,0.04,modi wetzler,
+CH,2230,2,Organic Chemistry,0.33,0.34,0.14,0.1,0.06,0.0,0.0,0.04,modi wetzler,
+CH,2230,3,Organic Chemistry,0.3,0.4,0.21,0.04,0.06,0.0,0.0,0.0,daniel whitehead,
+CH,2230,4,Organic Chemistry,0.3,0.42,0.17,0.04,0.05,0.0,0.0,0.04,jacob schroeder,
+CH,2230,5,Organic Chemistry,0.25,0.27,0.3,0.07,0.07,0.0,0.0,0.05,elliot ennis,
+CH,2230,6,Organic Chemistry,0.25,0.31,0.13,0.03,0.07,0.0,0.0,0.21,rhett smith,
+CH,2230,7,Organic Chemistry,0.33,0.32,0.16,0.08,0.05,0.0,0.0,0.06,tania issa houjeiry,
+CH,2240,1,Organic Chemistry,0.24,0.38,0.19,0.06,0.03,0.0,0.0,0.09,jacob schroeder,
+CH,2240,2,Organic Chemistry,0.29,0.38,0.15,0.05,0.01,0.0,0.0,0.11,jacob schroeder,
+CH,2270,1,Organic Chem Lab,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,2,Organic Chem Lab,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,7,Organic Chem Lab,0.56,0.25,0.0,0.0,0.06,0.0,0.0,0.13,sean 'connor,
+CH,2270,10,Organic Chem Lab,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,12,Organic Chem Lab,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,13,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,14,Organic Chem Lab,0.56,0.25,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,
+CH,2270,15,Organic Chem Lab,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
+CH,2270,16,Organic Chem Lab,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,17,Organic Chem Lab,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,
+CH,2270,18,Organic Chem Lab,0.69,0.06,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,
+CH,2270,20,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,23,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,25,Organic Chem Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,28,Organic Chem Lab,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,sean 'connor,
+CH,2270,31,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,sean 'connor,
+CH,2270,33,Organic Chem Lab,0.56,0.19,0.0,0.0,0.06,0.0,0.0,0.19,sean 'connor,
+CH,2270,35,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,36,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,37,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,sean 'connor,
+CH,2270,38,Organic Chem Lab,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,
+CH,2280,3,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
+CH,2280,6,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,sean 'connor,
+CH,2280,7,Organic Chem Lab,0.59,0.18,0.12,0.0,0.0,0.0,0.0,0.12,sean 'connor,
+CH,2280,8,Organic Chem Lab,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
+CH,3130,1,Quantitative Analys,0.44,0.31,0.09,0.09,0.0,0.0,0.0,0.06,stephen creager,
+CH,3300,1,Intro to Phys Chem,0.37,0.27,0.21,0.07,0.01,0.0,0.0,0.06,brian dominy,
+CH,3310,1,Physical Chemistry,0.58,0.19,0.13,0.06,0.03,0.0,0.0,0.0,leah bec casabianca,
+CH,3310,2,Physical Chemistry,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,arkady kholodenko,
+CH,3320,1,Physical Chemistry,0.26,0.32,0.32,0.05,0.0,0.0,0.0,0.05,arkady kholodenko,
+CH,3390,1,Physical Chem Lab,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,christopher wilson,
+CH,3390,4,Physical Chem Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,
+CH,4010,1,Organometallic Chemistry,0.53,0.35,0.12,0.0,0.0,0.0,0.0,0.0,andrew gre tennyson,
+CH,4020,1,Inorganic Chemistry,0.38,0.57,0.0,0.0,0.0,0.0,0.0,0.05,joseph kolis,
+CH,8070,1,Chem Trans Elem,0.36,0.36,0.09,0.0,0.0,0.0,0.0,0.18,julia brumaghim,
+CH,8140,1,Analytical Imaging,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,george chumanov,
+CH,8160,1,Separation Science,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,richard marcus,
+CH,8210,1,Organic Chem I,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07, karl dieter,
+CH,8300,1,Fund Phys Chem,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,
+CH,8380,1,Computational Chem,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,
+CH,8510,1,Grad Student Seminar,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,joseph stu thrasher,
+CH,8510,2,Grad Student Seminar,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,steven stuart,
+CHE,2110,1,Intro to Chem Eng,0.19,0.27,0.27,0.03,0.16,0.0,0.0,0.07,rachel getman,
+CHE,2110,2,Intro to Chem Eng,0.27,0.37,0.19,0.01,0.1,0.0,0.0,0.04,rachel getman,
+CHE,3070,1,Unit Ops Lab I,0.11,0.74,0.13,0.02,0.0,0.0,0.0,0.0,christopher norfolk,
+CHE,3190,1,Engr Materials,0.16,0.38,0.25,0.12,0.08,0.0,0.0,0.0,amod ogale,
+CHE,4070,1,Unit Op Lab II,0.22,0.64,0.15,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
+CHE,4310,1,Process Design I,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,4450,1,Green Engineering,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,christophe kitchens,
+CHE,4500,1,Chem Reaction Engr,0.25,0.32,0.32,0.1,0.0,0.0,0.0,0.0,mark alan blenner,
+CHE,4990,14,CI-  Membrane Separations,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott husson,
+CHE,8030,1,Advanced Transport,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,douglas hirt,
+CHE,8040,1,Ch E Thermodynamics,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
+CHE,8050,1,Ch E Kinetics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mark roberts,
+CHIN,1010,1,Elementary Chinese,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,yanlin wang,
+CHIN,1010,2,Elementary Chinese,0.57,0.14,0.14,0.0,0.07,0.0,0.0,0.07,yanlin wang,
+CHIN,1020,1,Elementary Chinese,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,su- chen,
+CHIN,4010,1,Pre-Modern Chinese Literature,0.58,0.21,0.16,0.0,0.05,0.0,0.0,0.0,yanming an,
+COM,1500,1,Intro to Human Communication,0.63,0.27,0.05,0.01,0.02,0.0,0.0,0.01,eddie smith,
+COM,1500,2,Intro to Human Communication,0.58,0.34,0.04,0.01,0.02,0.0,0.0,0.01,daniel lelan fecher,
+COM,1500,3,Intro to Human Communication,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,eddie smith,
+COM,1500,4,Intro to Human Communication,0.63,0.27,0.05,0.01,0.04,0.0,0.0,0.01,marianne her glaser,
+COM,1500,5,Intro to Human Communication,0.61,0.35,0.03,0.0,0.01,0.0,0.0,0.0,marianne her glaser,
+COM,1500,6,Intro to Human Communication,0.65,0.29,0.03,0.02,0.01,0.0,0.0,0.0,marianne her glaser,
+COM,1500,7,Intro to Human Communication,0.55,0.35,0.05,0.0,0.01,0.0,0.0,0.04,daniel lelan fecher,
+COM,2010,1,Intr to Comm Studies,0.56,0.36,0.04,0.0,0.04,0.0,0.0,0.0,karyn jones,
+COM,2010,2,Intr to Comm Studies,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,2500,1,Public Speaking,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,2,Public Speaking,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,3,Public Speaking,0.28,0.5,0.11,0.0,0.11,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,4,Public Speaking,0.74,0.05,0.05,0.0,0.16,0.0,0.0,0.0,brandon boatwright,
+COM,2500,5,Public Speaking,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,brandon boatwright,
+COM,2500,6,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,7,Public Speaking,0.21,0.53,0.21,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,8,Public Speaking,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,9,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,10,Public Speaking,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,11,Public Speaking,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
+COM,2500,12,Public Speaking,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,pauline matthey,
+COM,2500,13,Public Speaking,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,pauline matthey,
+COM,2500,14,Public Speaking,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07,pauline matthey,
+COM,2500,15,Public Speaking,0.83,0.06,0.11,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,16,Public Speaking,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,17,Public Speaking,0.71,0.18,0.06,0.0,0.0,0.0,0.0,0.06,the estate  geddes,
+COM,2500,18,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,19,Public Speaking,0.47,0.37,0.0,0.0,0.05,0.0,0.0,0.11,jumah patrici taweh,
+COM,2500,20,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,21,Public Speaking,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
+COM,2500,22,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,23,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
+COM,2500,24,Public Speaking,0.61,0.22,0.0,0.0,0.0,0.0,0.0,0.17,jumah patrici taweh,
+COM,2500,28,Public Speaking,0.35,0.35,0.12,0.0,0.12,0.0,0.0,0.06,sara grumbl crocker,
+COM,2500,29,Public Speaking,0.47,0.32,0.16,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,30,Public Speaking,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,31,Public Speaking,0.42,0.26,0.26,0.05,0.0,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,32,Public Speaking,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,33,Public Speaking,0.68,0.11,0.11,0.0,0.11,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,34,Public Speaking,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,35,Public Speaking,0.54,0.23,0.0,0.0,0.15,0.0,0.0,0.08,vanessa anne condon,
+COM,2500,400,Public Speaking,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,
+COM,2500,403,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,
+COM,3010,1,Comm Theory,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,3020,1,Mass Comm Theory,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3050,1,Persuasion,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
+COM,3050,2,Persuasion,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
+COM,3100,1,Quant Comm Methods,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3110,1,Qual Comm Methods,0.53,0.21,0.21,0.0,0.0,0.0,0.0,0.05,chenjerai kumanyika,
+COM,3240,1,"Communication, Sport & Society",0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,john steven spinda,
+COM,3260,1,Pr in Sports,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3480,1,Interpersonal Comm,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,melinda ra weathers,
+COM,3550,1,Principles of Public Relations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3550,2,Principles of Public Relations,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,andrew stephen pyle,
+COM,3660,1,Special Topics in Comm,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,william reynolds,
+COM,3660,6,Special Topics in Comm,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,angela pratt,
+COM,4040,1,Media Comm & Social Identities,0.3,0.47,0.13,0.03,0.0,0.0,0.0,0.07,chenjerai kumanyika,
+COM,4250,1,Adv Sports Comm,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,4300,1,Legal Communication,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
+COM,4700,1,Comm & Health,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,4800,1,Intercultural Comm,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,melinda ra weathers,
+COM,4950,1,Senior Capstone Seminar,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,4950,2,Senior Capstone Seminar,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,john steven spinda,
+COM,8100,1,Comm Research Methods I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
+CPSC,1010,1,Computer Science I,0.48,0.22,0.11,0.11,0.07,0.0,0.0,0.02,yvon feaster,
+CPSC,1010,2,Computer Science I,0.35,0.33,0.07,0.14,0.07,0.0,0.0,0.05,yvon feaster,
+CPSC,1010,3,Computer Science I,0.27,0.23,0.16,0.09,0.11,0.0,0.0,0.14,christopher plaue,
+CPSC,1010,4,Computer Science I,0.15,0.2,0.24,0.07,0.12,0.0,0.0,0.22,pradip srimani,
+CPSC,1020,1,Computer Science II,0.3,0.32,0.07,0.03,0.15,0.0,0.0,0.13,catherine hochrine,
+CPSC,1040,1,Intro Computer Prog,0.15,0.19,0.46,0.12,0.0,0.04,0.0,0.04,roy pargas,
+CPSC,1110,1,Intro to Programming in C,0.59,0.1,0.07,0.05,0.12,0.0,0.0,0.07,catherine hochrine,
+CPSC,1110,2,Intro to Programming in C,0.6,0.15,0.08,0.04,0.04,0.0,0.0,0.08,catherine hochrine,
+CPSC,1110,3,Intro to Programming in C,0.65,0.23,0.08,0.0,0.04,0.0,0.0,0.0,wanda moses,
+CPSC,1110,4,Intro to Programming in C,0.7,0.13,0.05,0.0,0.05,0.0,0.0,0.08,wanda moses,
+CPSC,2070,1,Discrete Structures,0.2,0.37,0.16,0.12,0.09,0.0,0.0,0.05,larry hodges,
+CPSC,2100,1,Progrmng Methodology,0.32,0.21,0.08,0.03,0.29,0.0,0.0,0.08,timothy davis,
+CPSC,2100,2,Progrmng Methodology,0.47,0.28,0.09,0.13,0.03,0.0,0.0,0.0,rose lowe,
+CPSC,2120,1,Algs/Data Structures,0.31,0.24,0.23,0.02,0.12,0.0,0.0,0.08,brian christop dean,
+CPSC,2150,1,Software Dev Fndtns,0.24,0.27,0.22,0.12,0.12,0.0,0.0,0.04,blair madiso durkee,
+CPSC,2150,2,Software Dev Fndtns,0.5,0.23,0.17,0.0,0.1,0.0,0.0,0.0,yvon feaster,
+CPSC,2200,1,Microcomputer Appl,0.41,0.24,0.12,0.06,0.12,0.0,0.0,0.06,renee lambert,
+CPSC,2200,2,Microcomputer Appl,0.4,0.3,0.15,0.0,0.05,0.0,0.0,0.1,renee lambert,
+CPSC,2310,1,Intro Computer Org,0.49,0.31,0.13,0.08,0.0,0.0,0.0,0.0,rose lowe,
+CPSC,2310,2,Intro Computer Org,0.36,0.21,0.21,0.07,0.07,0.0,0.0,0.07,rose lowe,
+CPSC,2910,2,Prof Issues I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
+CPSC,2910,5,Prof Issues I,0.25,0.33,0.08,0.08,0.0,0.0,0.0,0.25,renee lambert,
+CPSC,2910,6,Prof Issues I,0.6,0.1,0.0,0.1,0.0,0.0,0.0,0.2,renee lambert,
+CPSC,2910,7,Prof Issues I,0.53,0.07,0.07,0.13,0.07,0.0,0.0,0.13,renee lambert,
+CPSC,3220,1,Intro to Operating Systems,0.13,0.31,0.23,0.08,0.12,0.0,0.0,0.13,jacob sorber,
+CPSC,3300,1,Computer Systems Org,0.14,0.22,0.38,0.12,0.12,0.0,0.0,0.01,mark smotherman,
+CPSC,3500,1,Foundations of Computer Sci,0.25,0.13,0.38,0.0,0.15,0.0,0.0,0.1,ilya mark safro,
+CPSC,3520,1,Programming Systems,0.36,0.26,0.17,0.0,0.14,0.0,0.0,0.07,robert schalkoff,
+CPSC,3600,1,Network Programming,0.16,0.3,0.39,0.09,0.05,0.0,0.0,0.02,sekou lionel remy,
+CPSC,3600,2,Network Programming,0.4,0.43,0.1,0.0,0.08,0.0,0.0,0.0,kevin mckenzie,
+CPSC,3620,1,Distributed/Cluster Computing,0.28,0.5,0.15,0.03,0.0,0.0,0.0,0.05,linh bao ngo,
+CPSC,3720,1,Software Engineering,0.34,0.41,0.22,0.0,0.03,0.0,0.0,0.0,murali sitaraman,
+CPSC,3720,2,Software Engineering,0.28,0.33,0.28,0.03,0.03,0.0,0.0,0.06,stephen schaub,
+CPSC,3990,4,Adv Creative Inquiry Computing,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,james martin,
+CPSC,3990,10,Adv CI:Google Glass,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,roy pargas,
+CPSC,4040,1,Cmptr Graphics Image,0.47,0.32,0.16,0.05,0.0,0.0,0.0,0.0,joshua levine,
+CPSC,4110,1,Virtual Reality Systems,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,sabarish venka babu,
+CPSC,4200,1,Computer Security Principles,0.59,0.28,0.14,0.0,0.0,0.0,0.0,0.0,hongxin hu,
+CPSC,4620,1,Database Management Systems,0.12,0.27,0.18,0.15,0.12,0.0,0.0,0.15,pradip srimani,
+CPSC,4780,1,Gen Purpose Computation on GPU,0.27,0.36,0.18,0.09,0.09,0.0,0.0,0.0,robert geist,
+CPSC,4810,16,Sel Top:Programming Team,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,brian christop dean,
+CPSC,4820,1,Spec Top:Embedded Systems,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,jacob sorber,
+CPSC,4820,3,Spec Top:Mobile Device Sftware,0.61,0.17,0.11,0.0,0.06,0.0,0.0,0.06,roy pargas,
+CPSC,4910,1,Professional Issues II,0.96,0.0,0.01,0.0,0.01,0.0,0.0,0.01,james jones,
+CPSC,6040,1,Cptr Graphics Image,0.5,0.11,0.04,0.0,0.18,0.0,0.0,0.18,joshua levine,
+CPSC,6110,1,Virtual Reality Systems,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
+CPSC,6620,1,Database Management Systems,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,pradip srimani,
+CPSC,6780,1,Gen Purpose Computation on GPU,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,
+CPSC,8040,1,Data Visualization,0.5,0.3,0.1,0.0,0.05,0.0,0.0,0.05,joshua levine,
+CPSC,8070,1,3d Model Animation,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,christina sop joerg,
+CPSC,8100,1,Intro Artif Intell,0.18,0.71,0.11,0.0,0.0,0.0,0.0,0.0,feng luo,
+CPSC,8150,1,Fx Compositing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,
+CPSC,8170,1,Physically Based Animation,0.62,0.27,0.08,0.0,0.0,0.0,0.0,0.04,donald henry house,
+CPSC,8390,1,Theoretical Cp Sci Foundations,0.31,0.61,0.06,0.0,0.0,0.0,0.0,0.02,wayne goddard,
+CPSC,8480,1,Network Science,0.44,0.11,0.44,0.0,0.0,0.0,0.0,0.0,ilya mark safro,
+CPSC,8520,1,Internetworking,0.4,0.33,0.27,0.0,0.0,0.0,0.0,0.0,james martin,
+CPSC,8700,1,O O Software Design,0.46,0.33,0.14,0.0,0.03,0.0,0.0,0.03,brian malloy,
+CPSC,8710,1,Found. of Software Engineering,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+CPSC,8730,1,"Software Verif, Valid & Measur",0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+CPSC,8810,3,Selected Topics: Visual Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
+CRP,8000,1,Human Settlement,0.56,0.34,0.05,0.0,0.0,0.0,0.0,0.05,john terrenc farris,
+CRP,8010,1,Planning Process & Legal Found,0.38,0.38,0.1,0.1,0.0,0.0,0.0,0.05,caitlin dyckman,
+CRP,8020,1,Site Planning,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
+CRP,8030,1,Quant Analysis,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
+CRP,8060,1,Urban & Reg Econ for Planners,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,timothy green,
+CRP,8340,1,Spatial Modeling/Gis,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,stephen sperry,
+CRP,8580,2,Research Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,timothy green,
+CSM,1000,1,Intro to Construct,0.41,0.47,0.11,0.02,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2010,1,Structures I,0.3,0.33,0.26,0.11,0.0,0.0,0.0,0.0,shima clarke,
+CSM,2010,2,Structures I,0.5,0.19,0.19,0.12,0.0,0.0,0.0,0.0,shima clarke,
+CSM,2030,1,Mats & Meth of Const,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,2030,2,Mats & Meth of Const,0.22,0.63,0.15,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,3030,1,Soils & Foundations,0.08,0.63,0.29,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,3030,2,Soils & Foundations,0.12,0.69,0.19,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,3040,1,Envir Systems I,0.42,0.42,0.12,0.0,0.04,0.0,0.0,0.0,joseph mich burgett,
+CSM,3040,2,Envir Systems I,0.13,0.67,0.21,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3510,1,Const Estimating,0.19,0.69,0.08,0.04,0.0,0.0,0.0,0.0,james packer smith,
+CSM,3510,2,Const Estimating,0.11,0.48,0.26,0.15,0.0,0.0,0.0,0.0,james packer smith,
+CSM,4110,1,Safety in Bldg Const,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,david devita,
+CSM,4500,1,Construction Intern,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CSM,4530,1,Const Proj Mgmt,0.19,0.67,0.14,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,4530,2,Const Proj Mgmt,0.11,0.72,0.17,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,4610,1,Const Econ Seminar,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4610,2,Const Econ Seminar,0.05,0.76,0.19,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8640,1,Construction Bus Strat & Mktg,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,christine piper,
+CSM,8650,1,Project Management,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8650,400,Project Management,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8660,1,Role in Development,0.31,0.63,0.0,0.0,0.0,0.0,0.0,0.06,dennis bausman,
+CSM,8900,401,Directed Studies,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,8900,402,Directed Studies,0.57,0.14,0.14,0.0,0.14,0.0,0.0,0.0,jason lucas,
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.01,susan whorton,
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.88,0.12,0.01,susan whorton,
+CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.02,susan whorton,
+CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.73,0.26,0.01,susan whorton,
+CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
+CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
+CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
+CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.05,0.01,susan whorton,
+CU,1000,9,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.01,susan whorton,
+CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.08,0.01,susan whorton,
+CU,1000,11,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,susan whorton,
+CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,susan whorton,
+CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.88,0.11,0.02,susan whorton,
+CU,1010,1,Univ Success Skills,0.5,0.19,0.06,0.0,0.13,0.0,0.0,0.13,emma reynol reabold,
+CU,1010,2,Univ Success Skills,0.45,0.14,0.32,0.05,0.05,0.0,0.0,0.0,cari allyn brooks,
+CU,1010,3,Univ Success Skills,0.32,0.32,0.16,0.04,0.08,0.0,0.0,0.08,matthew james kirk,
+CU,1010,5,Univ Success Skills,0.55,0.18,0.0,0.09,0.18,0.0,0.0,0.0,ashley crisp,
+CU,1010,6,Univ Success Skills,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,amber allen mulkey,
+CU,1010,7,Univ Success Skills,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,amber allen mulkey,
+CU,1110,3,Intro Supplemental Instruction,0.0,0.0,0.0,0.0,0.0,0.88,0.06,0.06,laurel ann whisler,
+CU,1400,1,The Entrepreneurial Mindset,0.76,0.17,0.05,0.01,0.0,0.0,0.0,0.02,john michael hannon,
+CU,2010,1,Sustainability Leadership,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,leidy klotz,
+CVT,2260,1,Intro Cardiovas Sono,0.2,0.6,0.13,0.0,0.0,0.0,0.0,0.07,eric walker,
+DANC,3300,1,University Dance Company,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,cheryl hosler,
+DPA,4000,1,Tech Foundations I,0.65,0.06,0.06,0.0,0.0,0.0,0.0,0.24,brian malloy,
+DPA,8600,1,Production Studio,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
+ECE,2010,1,Logic and Computing Devices,0.2,0.35,0.24,0.05,0.13,0.0,0.0,0.03,william reid,
+ECE,2010,2,Logic & Comp Device (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william reid,True
+ECE,2020,1,Electric Circuits I,0.29,0.27,0.24,0.04,0.1,0.0,0.0,0.06,william harrell,
+ECE,2020,2,Electric Circuits I (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
+ECE,2020,3,Electric Circuits I,0.21,0.17,0.3,0.12,0.16,0.0,0.0,0.03,daniel bla cutshall,
+ECE,2070,1,Basic Electrical Engineering,0.14,0.31,0.33,0.12,0.03,0.0,0.0,0.07,william th kolodzey,
+ECE,2070,2,Basic Electrical Engineering,0.45,0.25,0.13,0.05,0.05,0.0,0.0,0.08,oleg viktorov sivov,
+ECE,2070,3,Basic Electrical Engineering,0.33,0.35,0.16,0.1,0.04,0.0,0.0,0.02,amir ahmed asif,
+ECE,2080,7,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
+ECE,2080,9,Electrical Engineering Lab I,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,
+ECE,2080,10,Electrical Engineering Lab I,0.65,0.05,0.0,0.0,0.1,0.0,0.0,0.2,apoorva dee kapadia,
+ECE,2080,13,Electrical Engineering Lab I,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,apoorva dee kapadia,
+ECE,2090,1,Logic Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,9,Logic Lab,0.82,0.0,0.0,0.0,0.18,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,10,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva dee kapadia,
+ECE,2090,11,Logic Lab,0.83,0.0,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,13,Logic Lab,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,apoorva dee kapadia,
+ECE,2110,6,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
+ECE,2110,8,Elec Engr Lab I,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2110,9,Elec Engr Lab I,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,apoorva dee kapadia,
+ECE,2220,1,Syst Prog Concept,0.12,0.27,0.22,0.1,0.1,0.0,0.0,0.2,harlan russell,
+ECE,2230,1,Comp Sys Eng,0.18,0.25,0.2,0.11,0.14,0.0,0.0,0.11,harlan russell,
+ECE,2620,1,Electric Circuits II,0.59,0.15,0.1,0.03,0.03,0.0,0.0,0.1,liang dong,
+ECE,2720,1,Comp Organization,0.19,0.29,0.33,0.05,0.1,0.0,0.0,0.05,william reid,
+ECE,2730,2,Computer Org Lab,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2730,3,Computer Org Lab,0.57,0.14,0.21,0.0,0.07,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,2,Electrical Engineering Lab III,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
+ECE,3110,4,Electrical Engineering Lab III,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,6,Electrical Engineering Lab III,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,apoorva dee kapadia,
+ECE,3110,7,Electrical Engineering Lab III,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
+ECE,3120,2,Electrical Engineering Lab IV,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3170,1,Rand Signal Analysis,0.23,0.23,0.25,0.14,0.11,0.0,0.0,0.05,stephen hubbard,
+ECE,3200,1,Electronics I,0.25,0.18,0.18,0.18,0.22,0.0,0.0,0.0,stephen hubbard,
+ECE,3210,1,Electronics II,0.37,0.32,0.2,0.1,0.02,0.0,0.0,0.0,stephen hubbard,
+ECE,3220,1,Intro Operating Sys,0.25,0.35,0.15,0.15,0.1,0.0,0.0,0.0,jacob sorber,
+ECE,3270,1,Dig Comp Design,0.15,0.15,0.2,0.15,0.13,0.0,0.0,0.23,melissa crawl smith,
+ECE,3300,1,Signals & Systems,0.14,0.23,0.26,0.17,0.06,0.0,0.0,0.15,carl baum,
+ECE,3300,2,Signals & Systems (HON),0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
+ECE,3520,1,Programming Systems,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.31,0.3,0.28,0.02,0.02,0.0,0.0,0.08,edward collins,
+ECE,3710,1,Microcontr Interface,0.38,0.34,0.21,0.06,0.0,0.0,0.0,0.01,william reid,
+ECE,3720,1,Micro Int Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,3,Micro Int Lab,0.75,0.17,0.0,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,6,Micro Int Lab,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3800,1,Electromagnetics,0.3,0.2,0.18,0.13,0.15,0.0,0.0,0.05,anthony martin,
+ECE,3810,1,Field Waves & Ckts,0.45,0.21,0.24,0.07,0.02,0.0,0.0,0.0,anthony martin,
+ECE,4040,1,Semiconductor Devices,0.25,0.44,0.25,0.0,0.06,0.0,0.0,0.0,william harrell,
+ECE,4090,1,Cont & Discrete Sys,0.4,0.37,0.15,0.03,0.03,0.0,0.0,0.01,apoorva dee kapadia,
+ECE,4120,1,Elect Mach Lab,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,elham makram,
+ECE,4180,1,Power Syst Analysis,0.31,0.12,0.27,0.15,0.08,0.0,0.0,0.08,elham makram,
+ECE,4270,1,Communications Sys,0.31,0.22,0.22,0.17,0.08,0.0,0.0,0.0,madhabi manandhar,
+ECE,4290,1,Organiz of Compu,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,hai ying shen,
+ECE,4350,1,Grounding/Shielding,0.43,0.29,0.07,0.14,0.0,0.0,0.0,0.07,todd hubing,
+ECE,4420,1,Knowledge Engr,0.37,0.32,0.11,0.05,0.05,0.0,0.0,0.11,robert schalkoff,
+ECE,4490,1,Comp Ntwrk Security,0.35,0.3,0.05,0.0,0.0,0.0,0.0,0.3,richard brooks,
+ECE,4610,1,Fundamentals of Solar Energy,0.63,0.25,0.07,0.05,0.0,0.0,0.0,0.0,rajendra singh,
+ECE,4730,1,Intro Parallel Sys,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,walter ligon,
+ECE,4950,1,Int Sys Design I,0.74,0.23,0.04,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4960,1,Int Sys Design II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,richard groff,
+ECE,6040,1,Semiconductor Devices,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,6350,1,Grounding/Shielding,0.6,0.2,0.1,0.0,0.1,0.0,0.0,0.0,todd hubing,
+ECE,6420,1,Knowledge Engr,0.26,0.63,0.05,0.0,0.05,0.0,0.0,0.0,robert schalkoff,
+ECE,6490,1,Comp Ntwrk Security,0.88,0.0,0.12,0.0,0.0,0.0,0.0,0.0,richard brooks,
+ECE,6610,1,Fundamentals of Solar Energy,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,rajendra singh,
+ECE,6930,1,Intro to Computer Vision,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,
+ECE,6930,3,Power Electronics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,keith corzine,
+ECE,8010,1,Analysis of Lin Sys,0.32,0.5,0.11,0.02,0.02,0.0,0.0,0.02,richard groff,
+ECE,8190,1,Detection & Estimation Theory,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,carl baum,
+ECE,8470,400,Digital Image Proc,0.87,0.11,0.03,0.0,0.0,0.0,0.0,0.0,stanley birchfield,
+ECE,8540,1,Analysis of Tracking Systems,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,adam hoover,
+ECE,8750,1,Peer to Peer Wireless & Cloud,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,hai ying shen,
+ECE,9910,32,Doctoral Dissertation Research,0.0,0.0,0.0,0.0,0.0,0.86,0.14,0.0,hai ying shen,
+ECON,2000,1,Economic Concepts,0.31,0.38,0.27,0.04,0.0,0.0,0.0,0.0,mallika garg,
+ECON,2000,2,Economic Concepts,0.32,0.29,0.24,0.03,0.0,0.0,0.0,0.12,mallika garg,
+ECON,2000,3,Economic Concepts,0.31,0.34,0.1,0.17,0.0,0.0,0.0,0.07,miren ivankovic,
+ECON,2110,1,Principles of Microeconomics,0.16,0.32,0.37,0.0,0.11,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,2,Principles of Microeconomics,0.16,0.21,0.47,0.05,0.05,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,3,Principles of Microeconomics,0.05,0.37,0.42,0.05,0.11,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,4,Principles of Microeconomics,0.1,0.5,0.2,0.05,0.15,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,5,Principles of Microeconomics,0.16,0.37,0.26,0.0,0.16,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,6,Principles of Microeconomics,0.18,0.47,0.24,0.06,0.0,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,7,Principles of Microeconomics,0.05,0.42,0.21,0.21,0.0,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,8,Principles of Microeconomics,0.11,0.47,0.26,0.11,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,9,Principles of Microeconomics,0.16,0.26,0.47,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,10,Principles of Microeconomics,0.0,0.37,0.42,0.0,0.11,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,11,Principles of Microeconomics,0.33,0.39,0.22,0.06,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,12,Principles of Microeconomics,0.05,0.53,0.21,0.11,0.0,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,13,Principles of Microeconomics,0.06,0.28,0.56,0.0,0.06,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,14,Principles of Microeconomics,0.37,0.32,0.21,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,15,Principles of Microeconomics,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,16,Principles of Microeconomics,0.22,0.28,0.28,0.06,0.0,0.0,0.0,0.17,frederick hanssen,
+ECON,2110,17,Principles of Microeconomics,0.21,0.53,0.16,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,18,Principles of Microeconomics,0.17,0.39,0.22,0.11,0.11,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,19,Principles of Microeconomics,0.11,0.53,0.32,0.05,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,20,Principles of Microeconomics,0.24,0.27,0.25,0.13,0.08,0.0,0.0,0.03,timothy jay bacon,
+ECON,2110,21,Principles of Microeconomics,0.21,0.48,0.29,0.02,0.0,0.0,0.0,0.0,michael makowsky,
+ECON,2110,22,Principles of Microeconomics,0.23,0.43,0.23,0.07,0.0,0.0,0.0,0.05,richard alan sessa,
+ECON,2110,23,Principles of Microeconomics,0.18,0.45,0.3,0.04,0.0,0.0,0.0,0.03,alexander fiore,
+ECON,2110,24,Principles of Microeconomics,0.32,0.33,0.21,0.07,0.02,0.0,0.0,0.03,leah jacq kitashima,
+ECON,2110,25,Principles of Microeconomics,0.28,0.33,0.23,0.08,0.03,0.0,0.0,0.08,charles thomas,
+ECON,2110,26,Principles of Microeconomics,0.29,0.39,0.18,0.05,0.08,0.0,0.0,0.0,jonathan orr ernest,
+ECON,2110,31,Principles of Microeconomics,0.2,0.59,0.21,0.01,0.0,0.0,0.0,0.0,alexander fiore,
+ECON,2110,32,Principles of Microeconomics,0.38,0.24,0.14,0.1,0.0,0.0,0.0,0.14,maria droganova,
+ECON,2110,33,Principles of Microeconomics,0.21,0.29,0.32,0.13,0.03,0.0,0.0,0.03,charles thomas,
+ECON,2110,34,Principles of Microeconomics,0.26,0.28,0.28,0.1,0.03,0.0,0.0,0.05,benjamin jo schwall,
+ECON,2110,35,Principles of Microeconomics,0.34,0.34,0.23,0.03,0.03,0.0,0.0,0.03,maria droganova,
+ECON,2110,38,Principles of Microeconomics,0.36,0.48,0.1,0.0,0.05,0.0,0.0,0.02,amanda caitlin kerr,
+ECON,2110,40,Principles of Micro (HON),0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert kennet fleck,True
+ECON,2110,41,Principles of Microeconomics,0.15,0.45,0.2,0.15,0.05,0.0,0.0,0.0,ce castellon chicas,
+ECON,2120,1,Principles of Macroeconomics,0.17,0.16,0.22,0.12,0.2,0.0,0.0,0.13,ralph charles allen,
+ECON,2120,2,Principles of Macroeconomics,0.33,0.27,0.31,0.07,0.02,0.0,0.0,0.0,peter david lorenz,
+ECON,2120,3,Principles of Macroeconomics,0.27,0.13,0.24,0.16,0.07,0.0,0.0,0.13,ralph charles allen,
+ECON,2120,4,Principles of Macroeconomics,0.26,0.3,0.24,0.09,0.04,0.0,0.0,0.07,andew swanson,
+ECON,2120,5,Principles of Macroeconomics,0.29,0.29,0.23,0.17,0.0,0.0,0.0,0.03,andew swanson,
+ECON,2120,6,Principles of Macroeconomics,0.38,0.19,0.28,0.0,0.13,0.0,0.0,0.03,peter david lorenz,
+ECON,2120,7,Principles of Macroeconomics,0.18,0.46,0.21,0.1,0.0,0.0,0.0,0.05,chen wang,
+ECON,2120,8,Principles of Macroeconomics,0.25,0.33,0.23,0.07,0.07,0.0,0.0,0.05,kelsey vict roberts,
+ECON,2120,9,Principles of Macroeconomics,0.26,0.31,0.18,0.15,0.03,0.0,0.0,0.08,shan jiang,
+ECON,2120,10,Principles of Macroeconomics,0.41,0.15,0.19,0.15,0.04,0.0,0.0,0.07,shan jiang,
+ECON,3020,1,Money and Banking,0.16,0.2,0.32,0.16,0.04,0.0,0.0,0.12,randall scot cragun,
+ECON,3060,1,Managerial Economics,0.33,0.28,0.13,0.08,0.1,0.0,0.0,0.08,jacob burgdorf,
+ECON,3100,1,International Econ,0.22,0.33,0.22,0.2,0.02,0.0,0.0,0.02,michal jerzmanowski,
+ECON,3140,1,Intermediate Micro,0.12,0.31,0.26,0.1,0.05,0.0,0.0,0.17,robert kennet fleck,
+ECON,3140,2,Intermediate Micro,0.28,0.26,0.21,0.06,0.06,0.0,0.0,0.13,molly espey,
+ECON,3140,3,Intermediate Micro,0.17,0.26,0.23,0.04,0.13,0.0,0.0,0.17,frederick hanssen,
+ECON,3150,1,Intermediate Macro,0.19,0.25,0.27,0.1,0.06,0.0,0.0,0.13,randall scot cragun,
+ECON,3150,2,Intermediate Macro,0.29,0.29,0.25,0.02,0.08,0.0,0.0,0.06,michal jerzmanowski,
+ECON,3190,1,Environmental Econ,0.16,0.46,0.35,0.0,0.0,0.0,0.0,0.03,molly espey,
+ECON,3600,1,Public Choice,0.38,0.38,0.2,0.0,0.0,0.0,0.0,0.05,robert dew tollison,
+ECON,3600,2,Public Choice,0.19,0.44,0.19,0.0,0.06,0.0,0.0,0.13,robert dew tollison,
+ECON,4010,1,Labor Mkt Analysis,0.31,0.31,0.23,0.0,0.08,0.0,0.0,0.08,chungsang lam,
+ECON,4020,1,Law and Economics,0.41,0.36,0.14,0.02,0.07,0.0,0.0,0.0,howard ne bodenhorn,
+ECON,4040,1,Comp Econ Systems,0.12,0.29,0.24,0.18,0.0,0.0,0.0,0.18,dar litsukova-bokar,
+ECON,4050,1,Intro to Econometric,0.18,0.38,0.24,0.06,0.12,0.0,0.0,0.03,jaqueline oliveira,
+ECON,4050,5,Intro to Econometric,0.23,0.27,0.35,0.08,0.04,0.0,0.0,0.04,scott barkowski,
+ECON,4100,1,Economic Development,0.11,0.63,0.0,0.0,0.11,0.0,0.0,0.16,robert tamura,
+ECON,4120,1,International Micro,0.37,0.32,0.27,0.02,0.0,0.0,0.0,0.02,scott baier,
+ECON,4220,1,Monetary Economics,0.29,0.48,0.19,0.0,0.0,0.0,0.0,0.05,gerald dwyer,
+ECON,4230,1,Economics of Health,0.43,0.17,0.26,0.09,0.0,0.0,0.0,0.04,daniel patri miller,
+ECON,4240,1,Organization of Ind,0.3,0.2,0.4,0.0,0.05,0.0,0.0,0.05,daniel patri miller,
+ECON,4350,1,Family Economics,0.55,0.25,0.15,0.03,0.0,0.0,0.0,0.03,jaqueline oliveira,
+ECON,6050,1,Intro to Econometric,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jaqueline oliveira,
+ECON,6060,1,Advanced Econometric,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,
+ECON,6120,1,Internatiional Micro,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,8010,1,Microeconomic Theory,0.43,0.21,0.21,0.0,0.07,0.0,0.0,0.07,william dougan,
+ECON,8040,1,Applied Math Econ,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,curtis simon,
+ECON,8060,1,Econometrics I,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,
+ECON,8080,1,Econometrics III,0.38,0.25,0.19,0.0,0.06,0.0,0.0,0.13,paul wayne wilson,
+ECON,8160,1,Labor Economics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
+ECON,8210,1,Public Choice,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,patrick warren,
+ECON,8230,1,Microecon Pub Pol,0.4,0.45,0.15,0.0,0.0,0.0,0.0,0.0,scott templeton,
+ECON,8240,1,Org of Industry,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,matthew lewis,
+ECON,8260,1,Econ Theory of Govt Regulation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,thomas wins hazlett,
+ECON,8400,1,International Trade,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,scott baier,
+ECON,9500,2,Monetary Economics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
+ED,1050,2,Educ Orientation,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,william da mccorkle,
+ED,1050,5,Educ Orientation,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,william da mccorkle,
+ED,1050,6,Educ Orientation,0.68,0.16,0.05,0.05,0.0,0.0,0.0,0.05,william da mccorkle,
+ED,1050,7,Educ Orientation,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,william da mccorkle,
+ED,3970,5,Creative Inquiry in Education,0.8,0.08,0.0,0.0,0.0,0.0,0.0,0.12,david matthew boyer,
+ED,3970,12,Creative Inquiry in Education,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,joseph benedic ryan,
+ED,8380,404,Adolescent Development,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,heather rog brooker,
+ED,8380,505,Literacy Lessons for Indiv I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
+ED,8380,510,Literacy Lessons for Indiv I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jamie felder white,
+ED,8380,511,Literacy Lessons for Indiv I,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ellen adkin sanford,
+ED,8380,512,Literacy Lessons for Indiv I,0.4,0.2,0.0,0.0,0.0,0.0,0.0,0.4,kimberly fair floyd,
+ED,8380,530,Improving Literacy Outcomes fo,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,renee gatlin anders,
+ED,8670,500,Practicum in ESOL Instruction,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,margaret mar warner,
+EDC,3900,1,Skills for Stu Leads,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,mary price,
+EDC,3900,2,Skills for Stu Leads,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,leasa ann  evinger,
+EDC,8110,1,Multicultural Couns,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,robin phelps-ward,
+EDC,8110,2,Multicultural Couns,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,
+EDC,8130,1,Appraisal Procedures,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,amy sue milsom,
+EDEC,3000,1,Found Early Chld Ed,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,
+EDEC,4300,1,Early Childhd Math,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,sandra mamma linder,
+EDEC,4400,1,Early Childhood Engl Lang Art,0.78,0.13,0.09,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEC,4600,1,Critical Iss/Diversity in ECE,0.91,0.04,0.0,0.04,0.0,0.0,0.0,0.0,dolores an stegelin,
+EDEC,8100,1,Adv Ece Found & Meth,0.56,0.11,0.22,0.11,0.0,0.0,0.0,0.0,dolores an stegelin,
+EDEL,3210,1,Pe for the Elem Tchr,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,3210,2,Pe for the Elem Tchr,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4010,1,Elem Field Exp,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,ann marie liebel,
+EDEL,4010,2,Elem Field Exp,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ann marie liebel,
+EDEL,4510,1,Elem Methods in Science Tchg,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,cynthia chri deaton,
+EDEL,4510,2,Elem Methods in Science Tchg,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
+EDEL,4870,1,Ele Meth Soc Studies,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,melinda spearman,
+EDEL,4870,2,Ele Meth Soc Studies,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDEL,4880,1,Elem Meth La Tchng,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,jacquelynn malloy,
+EDEL,4880,2,Elem Meth La Tchng,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
+EDF,3010,1,Principles of American Educat,0.58,0.35,0.06,0.0,0.0,0.0,0.0,0.0,suzanne rosenblith,
+EDF,3010,2,Principles of American Educat,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
+EDF,3020,3,Educational Psychology,0.34,0.28,0.21,0.14,0.0,0.0,0.0,0.03,penelope mar vargas,
+EDF,3020,4,Educational Psychology,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,penelope mar vargas,
+EDF,3080,1,Classroom Assessment,0.7,0.22,0.09,0.0,0.0,0.0,0.0,0.0,deborah switzer,
+EDF,3080,2,Classroom Assessment,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,deborah switzer,
+EDF,3200,1,History of US Education,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
+EDF,3340,1,Child Growth and Development,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,andrea emerson,
+EDF,3340,2,Child Growth and Development,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
+EDF,3350,1,Adolescent Growth & Develop,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
+EDF,4800,1,Digital Media & Learning,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,2,Digital Media & Learning,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,3,Digital Media & Learning,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,6900,400,Classroom Management,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,heather rog brooker,
+EDF,8010,1,Human Growth and Development,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeromy blake snider,
+EDF,8710,501,Cultural Diversity in Educatio,0.6,0.3,0.05,0.0,0.05,0.0,0.0,0.0,sus cridland-hughes,
+EDF,9010,1,Learning Sciences Seminar I,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,david matthew boyer,
+EDF,9270,1,Quant Rsrch & Stats for Ed,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,jennie lynn farmer,
+EDF,9270,2,Quant Rsrch & Stats for Ed,0.67,0.17,0.0,0.08,0.0,0.0,0.0,0.08,jennie lynn farmer,
+EDL,7000,502,Public School Adm,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,frederick buskey,
+EDL,7300,500,Techniq of Supervision-Pub Sch,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,
+EDL,7400,500,Curr Plan: Sch Adm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,
+EDL,9110,400,Systematic Inq Ed L,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,
+EDL,9250,501,Instructional Leadership,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,elizabeth reynolds,
+EDLT,4590,1,Teaching Reading Grades K-3,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,linda gambrell,
+EDLT,4600,3,Teaching Reading Grades 2-6,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
+EDLT,4600,5,Teaching Reading Grades 2-6,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
+EDLT,4610,1,Content Area Rdg: Grades 2-6,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,pamela dunston,
+EDLT,4610,2,Content Area Rdg: Grades 2-6,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,4980,4,Secondary Content Area Reading,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.04,barbara everson,
+EDLT,8120,500,Reading-Writing Assess Strat,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8140,500,Instr & Asmnt Diverse Students,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDLT,8270,400,Disciplinary Literacies 6-12,0.74,0.11,0.05,0.05,0.05,0.0,0.0,0.0,corrie leigh martin,
+EDLT,8800,502,Reading Recovery Teacher I,0.54,0.23,0.15,0.0,0.0,0.0,0.0,0.08,mary petters,
+EDLT,8820,502,Read Recovery Practicum I,0.38,0.38,0.15,0.0,0.0,0.0,0.0,0.08,mary petters,
+EDLT,9140,1,"Lang Dev, Diversity, Discourse",0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,mikel walker cole,
+EDSC,2260,1,Pr Apprch to Sec Alg,0.57,0.21,0.14,0.0,0.0,0.0,0.0,0.07,stacy megan che,
+EDSC,3240,1,Practicum Sec Engl,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,amy tali hallenbeck,
+EDSC,4240,1,Tchng Sec English,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,
+EDSC,4260,1,Tchng Sec Math,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,dennis aminie kombe,
+EDSC,8620,400,Methods & Strat Secondary Math,0.67,0.0,0.17,0.17,0.0,0.0,0.0,0.0,nicole alai sinwell,
+EDSP,3700,2,Intro to Special Education,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,
+EDSP,3700,3,Intro to Special Education,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,rhonda dilmo miller,
+EDSP,3700,4,Intro to Special Education,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,bridget carv briley,
+EDSP,3720,1,Char & Instr Individ with LD,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,
+EDSP,4920,1,Math Inst Ind W/Dis,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,
+EDSP,4940,1,Tchg Rdg Mild Dis,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
+EDSP,8530,1,Legal/Pol Issu Sp Ed,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
+EDSP,8530,2,Legal/Pol Issu Sp Ed,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
+EES,2010,1,Environ Engr Fundamentals I,0.31,0.5,0.13,0.0,0.03,0.0,0.0,0.03,david freedman,
+EES,3030,1,Water Treatment Systems,0.5,0.38,0.12,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3040,1,Wastewater Treatment Systems,0.38,0.44,0.15,0.03,0.0,0.0,0.0,0.0,david freedman,
+EES,3050,1,Water/Wastewater Treatment Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3050,2,Water/Wastewater Treatment Lab,0.64,0.29,0.0,0.07,0.0,0.0,0.0,0.0,david allen ladner,
+EES,4010,1,Environmental Engr,0.46,0.46,0.0,0.0,0.05,0.0,0.0,0.03,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.04,0.63,0.3,0.0,0.0,0.0,0.0,0.04,mark schlautman,
+EES,4300,1,Air Pollution Engineering,0.15,0.37,0.39,0.02,0.07,0.0,0.0,0.0,thomas overcamp,
+EES,4500,1,Professional Seminar,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,thomas overcamp,
+EES,4800,1,Environmental Risk Assessment,0.22,0.24,0.27,0.19,0.05,0.0,0.0,0.03,timothy devol,
+EES,4860,1,Environmental Sustainability,0.53,0.33,0.1,0.0,0.04,0.0,0.0,0.0,michael anthon dale,
+EES,4900,11,CI-EvalWaterQual & Kidney Corr,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,david allen ladner,
+EES,6100,1,Environ Radiation Protection I,0.33,0.58,0.0,0.08,0.0,0.0,0.0,0.0,nicole eli martinez,
+EES,6800,1,Environmental Risk Assessment,0.36,0.29,0.21,0.07,0.0,0.0,0.0,0.07,timothy devol,
+EES,6860,1,Environmental Sustainability,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
+EES,8020,1,Environ Eng Prin,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,david allen ladner,
+EES,8430,1,Environmental Chem,0.47,0.41,0.03,0.0,0.0,0.0,0.0,0.09,brian powell,
+EES,8510,1,Biol Prin Envir Engr,0.42,0.32,0.11,0.0,0.0,0.0,0.0,0.16,kevin thom finneran,
+EES,9610,1,Ee&S Phd Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,brian powell,
+ELE,3010,1,Intro to Entre,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+ELE,3010,2,Intro to Entre,0.51,0.34,0.0,0.0,0.0,0.03,0.0,0.11,chad navis,
+ELE,3010,3,Intro to Entre,0.31,0.56,0.14,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
+ELE,4010,1,Exec Lead & Entr II,0.28,0.5,0.15,0.05,0.03,0.0,0.0,0.0,ashley will parnell,
+ENGL,1030,2,Accelerated Composition,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,trevor lanc seigler,
+ENGL,1030,3,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,madison ali johnson,
+ENGL,1030,4,Accelerated Composition,0.26,0.32,0.11,0.11,0.21,0.0,0.0,0.0,todd rossi smith,
+ENGL,1030,5,Accelerated Composition,0.74,0.11,0.0,0.0,0.05,0.0,0.0,0.11,emily anne boyter,
+ENGL,1030,6,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,
+ENGL,1030,7,Accelerated Composition,0.42,0.37,0.05,0.05,0.05,0.0,0.0,0.05,melissa dugan,
+ENGL,1030,8,Accelerated Composition,0.61,0.28,0.0,0.06,0.0,0.0,0.0,0.06,madison ali johnson,
+ENGL,1030,9,Accelerated Composition,0.37,0.42,0.11,0.05,0.0,0.0,0.0,0.05,kristen joy hixon,
+ENGL,1030,10,Accelerated Composition,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,1030,11,Accelerated Composition,0.58,0.26,0.11,0.05,0.0,0.0,0.0,0.0,rebecca nico shaver,
+ENGL,1030,13,Accelerated Composition,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,crystal pa stephens,
+ENGL,1030,14,Accelerated Composition,0.21,0.53,0.05,0.11,0.11,0.0,0.0,0.0,todd rossi smith,
+ENGL,1030,15,Accelerated Composition,0.53,0.26,0.05,0.05,0.0,0.0,0.0,0.11,candace wiley,
+ENGL,1030,16,Accelerated Composition,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kristen joy hixon,
+ENGL,1030,17,Accelerated Composition,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,mary dickens,
+ENGL,1030,18,Accelerated Composition,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,melissa dugan,
+ENGL,1030,19,Accelerated Composition,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,katie jo vann,
+ENGL,1030,21,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,candace wiley,
+ENGL,1030,22,Accelerated Composition,0.35,0.59,0.0,0.0,0.0,0.0,0.0,0.06,mary dickens,
+ENGL,1030,23,Accelerated Composition,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,rebecca nico shaver,
+ENGL,1030,26,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,chloe mich whitaker,
+ENGL,1030,27,Accelerated Composition,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,katie jo vann,
+ENGL,1030,28,Accelerated Composition,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,caroline ca swanson,
+ENGL,1030,29,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,karen mary stewart,
+ENGL,1030,30,Accelerated Composition,0.84,0.0,0.05,0.0,0.11,0.0,0.0,0.0,teneshia head,
+ENGL,1030,31,Accelerated Composition,0.53,0.42,0.0,0.0,0.05,0.0,0.0,0.0,nathan riggs,
+ENGL,1030,32,Accelerated Composition,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,chloe mich whitaker,
+ENGL,1030,33,Accelerated Composition,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,daniel frank,
+ENGL,1030,34,Accelerated Composition,0.79,0.05,0.0,0.0,0.11,0.0,0.0,0.05,eda ozyesilpinar,
+ENGL,1030,35,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
+ENGL,1030,36,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,nathan riggs,
+ENGL,1030,37,Accelerated Composition,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel frank,
+ENGL,1030,38,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,stephen quigley,
+ENGL,1030,39,Accelerated Composition,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,charlotte powell,
+ENGL,1030,40,Accelerated Composition,0.37,0.32,0.21,0.0,0.11,0.0,0.0,0.0,caroline ca swanson,
+ENGL,1030,41,Accelerated Composition,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,eda ozyesilpinar,
+ENGL,1030,42,Accelerated Composition,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,austin gorman,
+ENGL,1030,43,Accelerated Composition,0.47,0.32,0.05,0.05,0.11,0.0,0.0,0.0,adrian carson,
+ENGL,1030,44,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jack butts,
+ENGL,1030,45,Accelerated Composition,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,jason crider,
+ENGL,1030,46,Accelerated Composition,0.58,0.26,0.0,0.0,0.05,0.0,0.0,0.11,joshua wood,
+ENGL,1030,47,Accelerated Composition,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,kellie eliz osborne,
+ENGL,1030,48,Accelerated Composition,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,jason crider,
+ENGL,1030,49,Accelerated Composition,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,eric stephens,
+ENGL,1030,50,Accelerated Composition,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,jennifer moeder,
+ENGL,1030,51,Accelerated Composition,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,april obrien,
+ENGL,1030,52,Accelerated Composition,0.47,0.42,0.0,0.0,0.11,0.0,0.0,0.0,adrian carson,
+ENGL,1030,53,Accelerated Composition,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,april obrien,
+ENGL,1030,54,Accelerated Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,danielle shuff,
+ENGL,1030,55,Accelerated Composition,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,brian lee gaines,
+ENGL,1030,56,Accelerated Composition,0.26,0.47,0.11,0.0,0.05,0.0,0.0,0.11,charlotte powell,
+ENGL,1030,57,Accelerated Composition,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
+ENGL,1030,58,Accelerated Composition,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,brian lee gaines,
+ENGL,1030,59,Accelerated Composition,0.53,0.32,0.05,0.05,0.05,0.0,0.0,0.0,stephen quigley,
+ENGL,1030,60,Accelerated Composition,0.63,0.21,0.05,0.0,0.0,0.0,0.0,0.11,danielle shuff,
+ENGL,1030,64,Accelerated Composition,0.58,0.37,0.0,0.05,0.0,0.0,0.0,0.0,jack butts,
+ENGL,1030,65,Accelerated Composition,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joshua wood,
+ENGL,1030,66,Accelerated Composition,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,eric stephens,
+ENGL,1030,67,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,kellie eliz osborne,
+ENGL,1030,68,Accelerated Composition,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jennifer moeder,
+ENGL,1030,500,Accelerated Composition,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,1030,501,Accelerated Composition,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,2120,1,World Literature,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,john morgenstern,
+ENGL,2120,3,World Literature,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,garry bertholf,
+ENGL,2120,5,World Literature,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,christopher benson,
+ENGL,2120,6,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,2120,7,World Literature,0.32,0.25,0.29,0.07,0.04,0.0,0.0,0.04,andrew mathas,
+ENGL,2120,8,World Literature,0.37,0.3,0.15,0.07,0.04,0.0,0.0,0.07,andrew mathas,
+ENGL,2120,9,World Literature,0.52,0.37,0.07,0.0,0.0,0.0,0.0,0.04,jeffrey fallis,
+ENGL,2120,10,World Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey fallis,
+ENGL,2120,11,World Literature,0.61,0.29,0.04,0.0,0.04,0.0,0.0,0.04,lucian ghita,
+ENGL,2120,12,World Literature,0.56,0.28,0.04,0.0,0.04,0.0,0.0,0.08,lucian ghita,
+ENGL,2120,13,World Literature,0.12,0.48,0.16,0.04,0.16,0.0,0.0,0.04,meg woosley-goodman,
+ENGL,2120,14,World Literature,0.29,0.43,0.11,0.07,0.07,0.0,0.0,0.04,meg woosley-goodman,
+ENGL,2120,15,World Literature,0.19,0.62,0.12,0.0,0.08,0.0,0.0,0.0,meg woosley-goodman,
+ENGL,2120,16,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
+ENGL,2120,17,World Literature,0.58,0.15,0.12,0.04,0.08,0.0,0.0,0.04,geveryl le robinson,
+ENGL,2120,18,World Literature,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
+ENGL,2120,19,World Literature,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,geveryl le robinson,
+ENGL,2130,1,British Literature,0.46,0.42,0.12,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,2130,2,British Literature,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,2130,3,British Literature,0.71,0.18,0.04,0.0,0.04,0.0,0.0,0.04,stephanie stripling,
+ENGL,2130,5,British Literature,0.64,0.21,0.04,0.0,0.04,0.0,0.0,0.07,lucian ghita,
+ENGL,2130,7,British Literature,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,
+ENGL,2130,9,British Literature,0.85,0.08,0.0,0.0,0.04,0.0,0.0,0.04,krist aldebol-hazle,
+ENGL,2130,10,British Literature,0.61,0.14,0.0,0.11,0.14,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,2130,11,British Literature,0.6,0.2,0.0,0.04,0.04,0.0,0.0,0.12,krist aldebol-hazle,
+ENGL,2130,12,British Literature,0.56,0.3,0.04,0.0,0.07,0.0,0.0,0.04,sherri teres allred,
+ENGL,2130,13,British Literature,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
+ENGL,2140,1,American Literature,0.68,0.18,0.08,0.02,0.01,0.0,0.0,0.02, barton palmer,
+ENGL,2140,5,American Literature,0.32,0.32,0.29,0.04,0.0,0.0,0.0,0.04,william stanton,
+ENGL,2140,6,American Literature,0.14,0.68,0.11,0.0,0.07,0.0,0.0,0.0,william stanton,
+ENGL,2140,7,American Literature,0.52,0.3,0.15,0.0,0.04,0.0,0.0,0.0,john morgenstern,
+ENGL,2140,8,American Literature,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,2140,9,American Literature,0.57,0.29,0.11,0.0,0.0,0.0,0.0,0.04,sharon kathl nalley,
+ENGL,2140,10,American Literature,0.48,0.33,0.0,0.0,0.05,0.0,0.0,0.14,candace wiley,
+ENGL,2140,11,American Literature,0.44,0.37,0.04,0.0,0.04,0.0,0.0,0.11,candace wiley,
+ENGL,2140,12,American Literature,0.59,0.3,0.07,0.04,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,2140,13,American Literature,0.68,0.21,0.04,0.04,0.0,0.0,0.0,0.04,crystal pa stephens,
+ENGL,2140,14,American Literature,0.3,0.41,0.11,0.0,0.07,0.0,0.0,0.11,sharon kathl nalley,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.36,0.39,0.21,0.0,0.04,0.0,0.0,0.0,andrew mathas,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.36,0.43,0.07,0.04,0.04,0.0,0.0,0.07,andrew mathas,
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.54,0.21,0.21,0.04,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.43,0.25,0.18,0.04,0.0,0.0,0.0,0.11,john logan pursley,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.64,0.18,0.11,0.04,0.0,0.0,0.0,0.04,john logan pursley,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.38,0.38,0.19,0.0,0.0,0.0,0.0,0.04,agnieszka skrodzka,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.68,0.18,0.07,0.0,0.0,0.0,0.0,0.07,april susanne pelt,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,alexander kudera,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.64,0.32,0.0,0.0,0.04,0.0,0.0,0.0,alexander kudera,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.15,0.5,0.15,0.0,0.04,0.0,0.0,0.15,david charles foltz,
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.13,0.38,0.17,0.04,0.08,0.0,0.0,0.21,david charles foltz,
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.14,0.43,0.18,0.07,0.04,0.0,0.0,0.14,david charles foltz,
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.11,0.37,0.15,0.04,0.15,0.0,0.0,0.19,david charles foltz,
+ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.64,0.25,0.04,0.07,0.0,0.0,0.0,0.0,stephanie stripling,
+ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
+ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey fallis,
+ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,austin gorman,
+ENGL,2150,100,20th - 21st Century Lit (HON),0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,True
+ENGL,2150,101,20th-21st Century Lit (HON),0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
+ENGL,3010,1,Grt Books West World,0.15,0.77,0.0,0.08,0.0,0.0,0.0,0.0,colin pearce,
+ENGL,3040,3,Business Writing,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,
+ENGL,3040,4,Business Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3040,11,Business Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexander kudera,
+ENGL,3040,12,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,3040,15,Business Writing,0.16,0.26,0.37,0.11,0.05,0.0,0.0,0.05,megan no macalystre,
+ENGL,3040,16,Business Writing,0.44,0.44,0.06,0.0,0.06,0.0,0.0,0.0,megan no macalystre,
+ENGL,3040,19,Business Writing,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,3040,20,Business Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,
+ENGL,3100,1,Crit Writ Lit,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
+ENGL,3100,2,Crit Writ Lit,0.68,0.16,0.05,0.0,0.05,0.0,0.0,0.05,walter edgar hunter,
+ENGL,3100,3,Crit Writ Lit,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
+ENGL,3100,4,Crit Writ Lit,0.31,0.56,0.0,0.0,0.06,0.0,0.0,0.06,agnieszka skrodzka,
+ENGL,3120,1,Advanced Composition,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3120,2,Advanced Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,1,Technical Writing,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,william pulley,
+ENGL,3140,2,Technical Writing,0.39,0.33,0.28,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,3,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
+ENGL,3140,4,Technical Writing,0.63,0.11,0.16,0.0,0.0,0.0,0.0,0.11,melissa dugan,
+ENGL,3140,5,Technical Writing,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,melissa dugan,
+ENGL,3140,6,Technical Writing,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,7,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,8,Technical Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
+ENGL,3140,10,Technical Writing,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,11,Technical Writing,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,12,Technical Writing,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,katalin beck,
+ENGL,3140,14,Technical Writing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,brian adam smith,
+ENGL,3140,19,Technical Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
+ENGL,3140,20,Technical Writing,0.32,0.21,0.11,0.05,0.11,0.0,0.0,0.21,matthew jose osborn,
+ENGL,3140,21,Technical Writing,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,heathe christiansen,
+ENGL,3140,22,Technical Writing,0.74,0.05,0.05,0.0,0.11,0.0,0.0,0.05,kristen gay,
+ENGL,3140,23,Technical Writing,0.72,0.11,0.06,0.0,0.0,0.0,0.0,0.11,kristen gay,
+ENGL,3140,100,Technical Writing (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,True
+ENGL,3140,400,Technical Writing,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,john conway,
+ENGL,3140,401,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,3150,1,Scientific Writing & Comm,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,barbara ramirez,
+ENGL,3150,2,Scientific Writing & Comm,0.11,0.68,0.05,0.0,0.0,0.0,0.0,0.16,barbara ramirez,
+ENGL,3150,3,Scientific Writing & Comm,0.58,0.16,0.11,0.05,0.05,0.0,0.0,0.05,william pulley,
+ENGL,3150,4,Scientific Writing & Comm,0.58,0.21,0.11,0.0,0.0,0.0,0.0,0.11,william pulley,
+ENGL,3150,401,Sci Writing & Communication,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,
+ENGL,3150,402,Sci Writing & Communication,0.21,0.53,0.11,0.0,0.0,0.0,0.0,0.16,carleton dew salley,
+ENGL,3320,1,Visual Communication,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,tharon howard,
+ENGL,3450,1,Structure of Fiction,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,3460,2,Structure of Poetry,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,3470,1,Structure of Drama,0.54,0.31,0.08,0.08,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,3560,1,Science Fiction,0.33,0.33,0.2,0.0,0.0,0.0,0.0,0.13,lindsay carr thomas,
+ENGL,3570,1,Film,0.21,0.53,0.16,0.0,0.0,0.0,0.0,0.11,amy monaghan,
+ENGL,3570,2,Film,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3570,3,Film,0.12,0.76,0.12,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3800,1,Women Writers,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,meg woosley-goodman,
+ENGL,3850,1,Children's Lit,0.33,0.2,0.33,0.0,0.13,0.0,0.0,0.0,megan no macalystre,
+ENGL,3960,1,Brit Lit Survey I,0.2,0.3,0.3,0.05,0.0,0.0,0.0,0.15,erin marina goss,
+ENGL,3960,2,Brit Lit Survey I,0.2,0.25,0.35,0.0,0.15,0.0,0.0,0.05,erin marina goss,
+ENGL,3960,3,Brit Lit Survey I,0.19,0.06,0.38,0.0,0.06,0.0,0.0,0.31,erin marina goss,
+ENGL,3970,1,Brit Lit Survey II,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
+ENGL,3980,2,Amer Lit Survey I,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,jonathan beec field,
+ENGL,3990,1,Amer Lit Survey II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,4010,1,Grammar Survey,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,william stockton,
+ENGL,4070,1,Medieval Period,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,andrew lemons,
+ENGL,4110,1,Shakespeare,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,
+ENGL,4110,2,Shakespeare,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4140,1,Milton,0.2,0.4,0.2,0.0,0.1,0.0,0.0,0.1,lee morrissey,
+ENGL,4160,1,Romantic Period,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,erin marina goss,
+ENGL,4170,1,Victorian Period,0.0,0.58,0.25,0.08,0.0,0.0,0.0,0.08,kimberly manganelli,
+ENGL,4210,1,Amer Lit 1800-1899,0.38,0.38,0.08,0.08,0.0,0.0,0.0,0.08,dominic mastroianni,
+ENGL,4280,1,Contemporary Literature,0.33,0.2,0.33,0.0,0.0,0.0,0.0,0.13,michael lemahieu,
+ENGL,4340,1,Environmental Lit,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,sean morey,
+ENGL,4350,1,Literary Criticism,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,dominic mastroianni,
+ENGL,4430,1,Theories of World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,4510,1,Film Theo/Criticism,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0, barton palmer,
+ENGL,4600,1,Writing Technologies,0.53,0.27,0.07,0.0,0.0,0.0,0.0,0.13,lindsay carr thomas,
+ENGL,4750,1,Writing for Media,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,megan eatman,
+ENGL,4780,1,Digital Literacy,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
+ENGL,4820,1,Afr Am Lit to 1920,0.3,0.2,0.3,0.0,0.2,0.0,0.0,0.0,rhondda robi thomas,
+ENGL,4960,1,Senior Seminar,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.0,wayne chapman,
+ENGL,4960,2,Senior Seminar,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,
+ENGL,4960,3,Senior Seminar,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,
+ENGL,4990,2,Practicum in Writing,0.0,0.0,0.0,0.0,0.0,0.82,0.0,0.18,elizabeth rivlin,
+ENGL,8050,1,Topics in Medieval Literature,0.5,0.4,0.0,0.1,0.0,0.0,0.0,0.0,andrew lemons,
+ENGL,8140,1,Topics Vict & Mod British Lit,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,wayne chapman,
+ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,steven brandon,
+ENGR,1050,111,Engr Discipline & Skills I,0.49,0.37,0.07,0.02,0.0,0.0,0.0,0.05,christopher norfolk,
+ENGR,1050,112,Engr Discipline & Skills I,0.4,0.38,0.12,0.02,0.0,0.0,0.0,0.07,mariah magagnotti,
+ENGR,1050,113,Engr Discipline & Skills I,0.33,0.33,0.19,0.07,0.05,0.0,0.0,0.05,mariah magagnotti,
+ENGR,1050,114,Engr Discipline & Skills I,0.45,0.36,0.1,0.0,0.02,0.0,0.0,0.07,matthew kent miller,
+ENGR,1050,115,Engr Discipline & Skills I,0.43,0.4,0.12,0.02,0.0,0.0,0.0,0.02,matthew kent miller,
+ENGR,1050,117,Engr Discipline & Skills I,0.57,0.29,0.02,0.07,0.0,0.0,0.0,0.05,matthew kent miller,
+ENGR,1050,118,Engr Discipline & Skills I,0.29,0.5,0.07,0.07,0.05,0.0,0.0,0.02,matthew kent miller,
+ENGR,1050,211,Engr Discipline & Skills I,0.53,0.27,0.07,0.0,0.04,0.0,0.0,0.09,ashley childers,
+ENGR,1050,212,Engr Discipline & Skills I,0.47,0.4,0.05,0.02,0.0,0.0,0.0,0.05,ashley childers,
+ENGR,1050,213,Engr Discipline & Skills I,0.38,0.36,0.14,0.05,0.0,0.0,0.0,0.07,andrew isaa neptune,
+ENGR,1050,214,Engr Discipline & Skills I,0.22,0.39,0.32,0.05,0.02,0.0,0.0,0.0,andrew isaa neptune,
+ENGR,1050,215,Engr Discipline & Skills I,0.17,0.25,0.27,0.15,0.02,0.0,0.0,0.13,mariah magagnotti,
+ENGR,1050,216,Engr Discipline & Skills I,0.14,0.26,0.29,0.12,0.1,0.0,0.0,0.1,mariah magagnotti,
+ENGR,1050,217,Engr Discipline & Skills I,0.37,0.39,0.2,0.0,0.02,0.0,0.0,0.02,andrew isaa neptune,
+ENGR,1050,218,Engr Discipline & Skills I,0.33,0.45,0.13,0.0,0.03,0.0,0.0,0.08,andrew isaa neptune,
+ENGR,1050,311,Engr Discipline & Skills I,0.1,0.41,0.21,0.1,0.03,0.0,0.0,0.14,elizabeth stephan,
+ENGR,1050,312,Engr Discipline & Skills I,0.36,0.36,0.12,0.05,0.0,0.0,0.0,0.12,elizabeth stephan,
+ENGR,1050,313,Engr Discipline & Skills I,0.26,0.25,0.2,0.11,0.02,0.0,0.0,0.16,michael giebner,
+ENGR,1050,314,Engr Discipline & Skills I,0.31,0.37,0.19,0.05,0.0,0.0,0.0,0.08,michael giebner,
+ENGR,1050,315,Engr Discipline & Skills I,0.4,0.22,0.22,0.1,0.02,0.0,0.0,0.03,william park,
+ENGR,1050,316,Engr Discipline & Skills I,0.34,0.31,0.17,0.07,0.02,0.0,0.0,0.1,william park,
+ENGR,1050,317,Engr Discipline & Skills I,0.37,0.25,0.22,0.05,0.03,0.0,0.0,0.07,william park,
+ENGR,1050,318,Engr Discipline & Skills I,0.22,0.31,0.21,0.05,0.07,0.0,0.0,0.14,michael giebner,
+ENGR,1050,349,Engr Discipline & Skills I,0.14,0.11,0.26,0.17,0.2,0.0,0.0,0.11,michael giebner,
+ENGR,1050,400,Engr Discipline & Skills I,0.08,0.28,0.3,0.1,0.2,0.0,0.0,0.05,sarah grigg,
+ENGR,1050,611,Engr Discip & Skills I (HON),0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,steven brandon,True
+ENGR,1050,613,Engr Discip & Skills I (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True
+ENGR,1050,614,Engr Discipl & Skills I (HON),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,steven brandon,True
+ENGR,1050,615,Engr Discipl & Skills I (HON),0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,richard watkins,True
+ENGR,1060,111,Engr Discipline & Skills II,0.11,0.39,0.24,0.11,0.03,0.0,0.0,0.13,christopher norfolk,
+ENGR,1060,112,Engr Discipline & Skills II,0.15,0.41,0.36,0.0,0.03,0.0,0.0,0.05,mariah magagnotti,
+ENGR,1060,113,Engr Discipline & Skills II,0.03,0.26,0.53,0.06,0.03,0.0,0.0,0.09,mariah magagnotti,
+ENGR,1060,114,Engr Discipline & Skills II,0.27,0.43,0.22,0.05,0.03,0.0,0.0,0.0,matthew kent miller,
+ENGR,1060,115,Engr Discipline & Skills II,0.23,0.25,0.43,0.0,0.0,0.0,0.0,0.1,matthew kent miller,
+ENGR,1060,117,Engr Discipline & Skills II,0.22,0.5,0.22,0.0,0.03,0.0,0.0,0.03,matthew kent miller,
+ENGR,1060,118,Engr Discipline & Skills II,0.06,0.34,0.31,0.17,0.03,0.0,0.0,0.09,matthew kent miller,
+ENGR,1060,211,Engr Discipline & Skills II,0.24,0.43,0.26,0.04,0.0,0.0,0.0,0.02,ashley childers,
+ENGR,1060,212,Engr Discipline & Skills II,0.29,0.44,0.21,0.0,0.02,0.0,0.0,0.04,ashley childers,
+ENGR,1060,213,Engr Discipline & Skills II,0.11,0.41,0.24,0.11,0.05,0.0,0.0,0.08,andrew isaa neptune,
+ENGR,1060,214,Engr Discipline & Skills II,0.16,0.29,0.21,0.21,0.0,0.0,0.0,0.13,andrew isaa neptune,
+ENGR,1060,215,Engr Discipline & Skills II,0.15,0.21,0.31,0.18,0.05,0.0,0.0,0.1,mariah magagnotti,
+ENGR,1060,216,Engr Discipline & Skills II,0.07,0.22,0.48,0.04,0.07,0.0,0.0,0.11,mariah magagnotti,
+ENGR,1060,217,Engr Discipline & Skills II,0.15,0.38,0.31,0.05,0.0,0.0,0.0,0.1,andrew isaa neptune,
+ENGR,1060,218,Engr Discipline & Skills II,0.03,0.53,0.22,0.06,0.06,0.0,0.0,0.11,andrew isaa neptune,
+ENGR,1060,243,Engr Discipline & Skills II,0.17,0.31,0.31,0.06,0.06,0.0,0.0,0.11,michael giebner,
+ENGR,1060,312,Engr Discipline & Skills II,0.16,0.35,0.24,0.16,0.02,0.0,0.0,0.06,elizabeth stephan,
+ENGR,1060,313,Engr Discipline & Skills II,0.13,0.47,0.22,0.09,0.04,0.0,0.0,0.04,michael giebner,
+ENGR,1060,314,Engr Discipline & Skills II,0.12,0.29,0.43,0.04,0.04,0.0,0.0,0.08,michael giebner,
+ENGR,1060,315,Engr Discipline & Skills II,0.09,0.33,0.28,0.09,0.09,0.0,0.0,0.13,william park,
+ENGR,1060,316,Engr Discipline & Skills II,0.08,0.35,0.31,0.08,0.1,0.0,0.0,0.08,william park,
+ENGR,1060,317,Engr Discipline & Skills II,0.1,0.33,0.42,0.06,0.04,0.0,0.0,0.04,william park,
+ENGR,1060,318,Engr Discipline & Skills II,0.24,0.36,0.17,0.1,0.02,0.0,0.0,0.12,michael giebner,
+ENGR,1060,400,Engr Discipline & Skills II,0.11,0.22,0.33,0.11,0.06,0.0,0.0,0.17,sarah grigg,
+ENGR,1060,611,Engr Discip & Skills II (HON),0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,steven brandon,True
+ENGR,1060,613,Engr Discip & Skills II (HON),0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,steven brandon,True
+ENGR,1060,614,Engr Discip & Skills II (HON),0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.03,steven brandon,True
+ENGR,1060,615,Engr Discip & Skills II (HON),0.6,0.25,0.1,0.0,0.0,0.0,0.0,0.05,richard watkins,True
+ENGR,1070,322,Programming & Prob Solving I,0.07,0.07,0.29,0.24,0.24,0.0,0.0,0.07,jordon anth gilmore,
+ENGR,1070,325,Programming & Prob Solving I,0.03,0.18,0.28,0.21,0.1,0.0,0.0,0.21,william martin,
+ENGR,1070,326,Programming & Prob Solving I,0.1,0.26,0.21,0.23,0.13,0.0,0.0,0.08,william martin,
+ENGR,1070,327,Programming & Prob Solving I,0.15,0.21,0.18,0.21,0.03,0.0,0.0,0.24,william martin,
+ENGR,1080,220,Programming & Prob Solving II,0.03,0.19,0.42,0.0,0.11,0.0,0.0,0.25,srinivasarangan rang,
+ENGR,1080,221,Programming & Prob Solving II,0.0,0.15,0.56,0.12,0.06,0.0,0.0,0.12,srinivasarangan rang,
+ENGR,1080,322,Programming & Prob Solving II,0.09,0.18,0.21,0.24,0.18,0.0,0.0,0.12,jordon anth gilmore,
+ENGR,1080,325,Programming & Prob Solving II,0.0,0.25,0.42,0.08,0.21,0.0,0.0,0.04,william martin,
+ENGR,1080,326,Programming & Prob Solving II,0.06,0.13,0.33,0.17,0.17,0.0,0.0,0.13,william martin,
+ENGR,1080,327,Programming & Prob Solving II,0.11,0.29,0.37,0.16,0.05,0.0,0.0,0.03,william martin,
+ENGR,1090,331,Prog/Problem Solving Apps,0.09,0.22,0.28,0.16,0.13,0.0,0.0,0.13,jordon anth gilmore,
+ENGR,1090,332,Prog/Problem Solving Apps,0.3,0.42,0.19,0.0,0.05,0.0,0.0,0.05,christopher norfolk,
+ENGR,1090,333,Prog/Problem Solving Apps,0.19,0.16,0.3,0.19,0.05,0.0,0.0,0.12,william park,
+ENGR,1090,334,Prog/Problem Solving Apps,0.06,0.26,0.29,0.12,0.0,0.0,0.0,0.26,william park,
+ENGR,1150,500,Engineering Design & Modeling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john minor,
+ENGR,1520,500,Engineering Computer Skills,0.1,0.2,0.6,0.1,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,1520,501,Engineering Computer Skills,0.15,0.46,0.15,0.23,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,2080,181,Engr Graphics & Machine Design,0.34,0.36,0.13,0.02,0.04,0.0,0.0,0.11,nighat yasmin,
+ENGR,2080,182,Engr Graphics & Machine Design,0.4,0.33,0.1,0.13,0.04,0.0,0.0,0.0,nighat yasmin,
+ENGR,2080,285,Engr Graphics & Machine Design,0.32,0.3,0.18,0.0,0.06,0.0,0.0,0.14,anthony pau garland,
+ENGR,2080,286,Engr Graphics & Machine Design,0.29,0.31,0.1,0.08,0.08,0.0,0.0,0.14,anthony pau garland,
+ENGR,2080,384,Engr Graphics & Machine Design,0.52,0.14,0.14,0.1,0.04,0.0,0.0,0.06,john minor,
+ENGR,2100,103,CAD & Engineering Apllications,0.59,0.24,0.04,0.02,0.02,0.0,0.0,0.09,mary kayla kilgo,
+ENGR,2100,104,CAD & Engineering Apllications,0.38,0.23,0.1,0.08,0.08,0.0,0.0,0.13,nighat yasmin,
+ENGR,2100,105,CAD & Engineering Apllications,0.45,0.34,0.07,0.0,0.07,0.0,0.0,0.07,nighat yasmin,
+ENGR,2200,107,Evaluating Innovations,0.29,0.55,0.13,0.0,0.0,0.0,0.0,0.03,sarah grigg,
+ENGR,2200,204,Evaluating Innovations,0.37,0.34,0.24,0.0,0.0,0.0,0.0,0.05,sarah grigg,
+ENGR,2200,206,Evaluating Innovations,0.48,0.4,0.08,0.03,0.0,0.0,0.0,0.03,sarah grigg,
+ENR,1010,1,Intro to Envir & Natur Res I,0.54,0.27,0.1,0.03,0.04,0.0,0.0,0.01,alan johnson,
+ENR,1010,2,Intro to Envir & Natur Res I,0.74,0.12,0.05,0.05,0.02,0.0,0.0,0.02,alan johnson,
+ENR,4290,1,Environ Law & Policy,0.54,0.34,0.08,0.0,0.0,0.0,0.0,0.04,alan johnson,
+ENSP,2000,1,Intro Environ Sci,0.55,0.24,0.1,0.05,0.02,0.0,0.0,0.05,scott brame,
+ENSP,2000,2,Intro Environ Sci,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2000,3,Intro Environ Sci,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2000,4,Intro Environ Sci,0.42,0.39,0.17,0.0,0.03,0.0,0.0,0.0,elizabeth carraway,
+ENSP,4000,1,Studies in Environmental Sci,0.69,0.15,0.0,0.04,0.04,0.0,0.0,0.08,margaret thompson,
+ENT,2000,1,Six-Legged Science,0.64,0.13,0.13,0.0,0.0,0.0,0.0,0.1,suellen pometto,
+ENT,2010,1,Insects and Death,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,joseph culin,
+ENT,3010,1,Insect Biology & Diversity,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,eric benson,
+ENT,8700,1,Insect Phys Mol Bio,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
+FCS,8300,1,Community Dev: Princ & Pract,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,areli moore peralta,
+FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.65,0.21,0.05,0.01,0.03,0.0,0.0,0.06,aubrey dean coffee,
+FDSC,2160,1,Baking Science,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,
+FDSC,3010,1,Food Regulations,0.78,0.15,0.07,0.0,0.0,0.0,0.0,0.0,julie kat northcutt,
+FDSC,3060,1,Institutional Food Service Mgt,0.54,0.35,0.07,0.0,0.03,0.0,0.0,0.0,angela fraser,
+FDSC,4010,1,Food Chemistry I,0.48,0.4,0.08,0.03,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4040,1,Food Prsv & Process,0.51,0.4,0.09,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,
+FDSC,4070,1,Quantity Food Production,0.58,0.34,0.05,0.03,0.0,0.0,0.0,0.0,heather batt,
+FDSC,4170,1,Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,
+FDSC,4200,5,Selected Topics,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katherine cason,
+FDSC,4300,1,Dairy Process & Sant,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+FDSC,8510,1,Food Science Seminar,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,
+FIN,3040,1,Risk & Insurance,0.13,0.35,0.35,0.09,0.09,0.0,0.0,0.0,kerri mcmillan,
+FIN,3040,2,Risk & Insurance,0.23,0.33,0.37,0.07,0.0,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.27,0.3,0.27,0.11,0.0,0.0,0.0,0.05,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.14,0.36,0.34,0.11,0.0,0.02,0.0,0.02,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.29,0.36,0.31,0.0,0.02,0.0,0.0,0.02,thomas albe wessels,
+FIN,3050,4,Investment Analysis,0.28,0.41,0.28,0.0,0.03,0.0,0.0,0.0,thomas albe wessels,
+FIN,3060,1,Corporation Finance,0.1,0.35,0.13,0.29,0.06,0.0,0.0,0.06,ramon tolb franklin,
+FIN,3060,2,Corporation Finance,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,neil waller,
+FIN,3060,3,Corporation Finance,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,neil waller,
+FIN,3060,4,Corporation Finance,0.17,0.36,0.19,0.11,0.08,0.0,0.0,0.08,ramon tolb franklin,
+FIN,3060,5,Corporation Finance,0.26,0.43,0.21,0.1,0.0,0.0,0.0,0.0,neil waller,
+FIN,3060,6,Corporation Finance,0.14,0.14,0.26,0.21,0.17,0.0,0.0,0.07,william hol johnson,
+FIN,3060,7,Corporation Finance,0.24,0.2,0.39,0.02,0.05,0.0,0.0,0.1,william hol johnson,
+FIN,3060,8,Corporation Finance,0.24,0.12,0.12,0.12,0.14,0.0,0.0,0.26,william hol johnson,
+FIN,3060,9,Corporation Finance,0.03,0.13,0.16,0.1,0.32,0.0,0.0,0.26,william hol johnson,
+FIN,3060,10,Corporation Finance,0.18,0.24,0.18,0.29,0.0,0.0,0.0,0.12,ramon tolb franklin,
+FIN,3070,1,Prin of Real Estate,0.18,0.24,0.37,0.13,0.02,0.02,0.0,0.05,thomas springer,
+FIN,3070,2,Prin of Real Estate,0.08,0.4,0.28,0.12,0.03,0.0,0.0,0.08,thomas springer,
+FIN,3080,1,Fin Inst & Mkts,0.24,0.57,0.09,0.04,0.02,0.0,0.0,0.04,lyudmila chernykh,
+FIN,3080,2,Fin Inst & Mkts,0.16,0.51,0.26,0.02,0.02,0.0,0.0,0.02,lyudmila chernykh,
+FIN,3080,3,Fin Inst & Mkts,0.18,0.41,0.26,0.03,0.1,0.0,0.0,0.03,daniel thoma greene,
+FIN,3110,1,Financial Management I,0.1,0.43,0.25,0.08,0.08,0.0,0.0,0.08,george bra lockhart,
+FIN,3110,2,Financial Management I,0.08,0.37,0.29,0.16,0.06,0.0,0.0,0.04,angela morgan,
+FIN,3110,3,Financial Management I,0.11,0.22,0.43,0.15,0.09,0.0,0.0,0.0,jared daniel smith,
+FIN,3110,4,Financial Management I,0.2,0.3,0.28,0.13,0.0,0.0,0.0,0.09,jared daniel smith,
+FIN,3120,1,Financial Management II,0.13,0.44,0.21,0.15,0.03,0.0,0.0,0.05,vincent intintoli,
+FIN,3120,2,Financial Management II,0.13,0.29,0.4,0.16,0.0,0.0,0.0,0.02,vincent intintoli,
+FIN,3120,3,Financial Management II,0.43,0.23,0.17,0.15,0.0,0.0,0.0,0.02,melvin stith,
+FIN,3120,4,Financial Management II,0.61,0.26,0.07,0.04,0.02,0.0,0.0,0.0,melvin stith,
+FIN,4020,1,Corporate Valuation,0.05,0.3,0.34,0.27,0.02,0.0,0.0,0.02,jack wolf,
+FIN,4020,2,Corporate Valuation,0.06,0.27,0.29,0.25,0.04,0.0,0.0,0.08,jack wolf,
+FIN,4050,1,Portfolio Management & Theory,0.03,0.3,0.33,0.1,0.0,0.0,0.0,0.23,john alexander,
+FIN,4060,1,Derivatives Analysis,0.24,0.36,0.24,0.09,0.03,0.03,0.0,0.0,george bra lockhart,
+FIN,4110,1,Int Fin Mgt,0.13,0.34,0.38,0.03,0.03,0.0,0.0,0.09,tilan tang,
+FIN,4110,2,Int Fin Mgt,0.19,0.49,0.24,0.08,0.0,0.0,0.0,0.0,tilan tang,
+FIN,4170,1,Real Estate Finance,0.43,0.29,0.21,0.07,0.0,0.0,0.0,0.0,neil waller,
+FIN,4980,2,Creative Inquiry in Finance,0.5,0.2,0.0,0.0,0.0,0.0,0.0,0.3,jack wolf,
+FNR,2040,1,Soil Information Systems,0.86,0.11,0.0,0.0,0.02,0.0,0.0,0.02,elena mikhailova,
+FNR,4900,1,Field Training in Natural Res,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,patricia layton,
+FNR,4990,1,Natural Resources Seminar,0.83,0.11,0.0,0.0,0.06,0.0,0.0,0.0,russell barrett,
+FOR,2050,1,Dendrology,0.23,0.31,0.27,0.04,0.08,0.0,0.0,0.08,donald hagan,
+FOR,2050,2,Dendrology,0.39,0.18,0.14,0.04,0.18,0.0,0.0,0.07,donald hagan,
+FOR,2050,3,Dendrology,0.37,0.26,0.13,0.13,0.03,0.0,0.0,0.08,donald hagan,
+FOR,2210,1,Forest Biology,0.13,0.34,0.3,0.16,0.05,0.0,0.0,0.02,victor ba shelburne,
+FOR,3020,1,Forest Biometrics,0.13,0.35,0.26,0.23,0.03,0.0,0.0,0.0,lawrence gering,
+FOR,3040,1,Forest Resource Economics,0.28,0.49,0.15,0.05,0.0,0.0,0.0,0.03,thomas straka,
+FOR,3410,1,Wood Procure Pract,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,patrick hiesl,
+FOR,4100,1,Harvesting Processes,0.24,0.56,0.12,0.08,0.0,0.0,0.0,0.0,patrick hiesl,
+FOR,4130,1,Integrated Forest Pest Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,roy leslie hedden,
+FOR,4160,1,Forest Policy and Admin,0.68,0.25,0.03,0.01,0.0,0.0,0.0,0.03,joseph lanham,
+FOR,4170,1,Forest Resource Mgt & Regulatn,0.42,0.42,0.12,0.04,0.0,0.0,0.0,0.0,greg yarrow,
+FOR,4310,1,Recreation Res Plan in For Mgt,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
+FOR,4340,1,GIS for Natural Resources,0.82,0.16,0.0,0.0,0.02,0.0,0.0,0.0,christopher post,
+FR,1010,1,Elementary French,0.11,0.47,0.32,0.05,0.0,0.0,0.0,0.05,anne salces  nedeo,
+FR,1020,1,Elementary French,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,1020,2,Elementary French,0.67,0.17,0.11,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,
+FR,1020,3,Elementary French,0.14,0.29,0.43,0.07,0.07,0.0,0.0,0.0,anne salces  nedeo,
+FR,2010,1,Intermediate French,0.43,0.43,0.0,0.0,0.07,0.0,0.0,0.07,paulin de tholozany,
+FR,2010,2,Intermediate French,0.25,0.44,0.19,0.13,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,2010,3,Intermediate French,0.2,0.5,0.1,0.0,0.1,0.0,0.0,0.1,kenneth dav widgren,
+FR,2010,4,Intermediate French,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,paulin de tholozany,
+FR,2020,1,Intermediate French,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2020,3,Intermediate French,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
+FR,2020,4,Intermediate French,0.36,0.43,0.07,0.0,0.07,0.0,0.0,0.07,kenneth dav widgren,
+FR,2020,5,Intermediate French,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,3000,1,Survey of French Lit,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,paulin de tholozany,
+FR,3050,1,Int Fr Con & Comp I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
+FR,3070,1,French Civilization,0.63,0.26,0.0,0.0,0.11,0.0,0.0,0.0,kelly digby peebles,
+FR,4000,1,Modern French Lit,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,eric touya,
+GC,1010,1,Orientation to G C,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,nona woolbright,
+GC,1020,1,Computer Art & CAD Foundations,0.44,0.4,0.02,0.05,0.09,0.0,0.0,0.0,carol jones,
+GC,1020,2,Computer Art & CAD Foundations,0.49,0.41,0.02,0.04,0.04,0.0,0.0,0.0,nona woolbright,
+GC,1030,1,G C I for Pkgsc,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,john jacobs,
+GC,1040,1,Graphic Communications I,0.36,0.55,0.05,0.0,0.05,0.0,0.0,0.0,rebecca suza edlein,
+GC,2070,1,Graphic Communications II,0.68,0.28,0.0,0.02,0.0,0.0,0.0,0.02,patrick gee rose,
+GC,2400,1,Intro to Web Design and Dev,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,erica black walker,
+GC,3400,1,Digital Imaging and eMedia,0.29,0.6,0.04,0.02,0.02,0.0,0.0,0.02,erica black walker,
+GC,3460,1,Ink and Substrates,0.28,0.45,0.2,0.02,0.02,0.0,0.0,0.03,liam henry 'hara,
+GC,4060,1,Package and Specialty Printing,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,kern cox,
+GC,4400,1,Commercial Printing,0.17,0.67,0.04,0.0,0.08,0.0,0.0,0.04,eric weisenmiller,
+GC,4400,2,Commercial Printing,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,
+GC,4440,1,Current Dev/Trends in Gr Comm,0.39,0.3,0.18,0.06,0.03,0.0,0.0,0.03,liam henry 'hara,
+GC,4480,1,Plan and Cont Print,0.42,0.47,0.05,0.03,0.03,0.0,0.0,0.0,john leininger,
+GC,4800,1,Senior Seminar in GC,0.7,0.27,0.0,0.0,0.03,0.0,0.0,0.0,charles edwa tonkin,
+GC,4900,230,G C Selected Topics-GC Sales,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,john leininger,
+GEN,1030,1,Careers in Bioch/Gen,0.85,0.07,0.01,0.03,0.0,0.0,0.0,0.04,alison starr-moss,
+GEN,3000,1,Fundamental Genetics,0.39,0.34,0.23,0.03,0.0,0.0,0.0,0.01,kate leanne wi tsai,
+GEN,3000,2,Fundamental Genetics,0.33,0.47,0.14,0.02,0.02,0.0,0.0,0.02,kate leanne wi tsai,
+GEN,3000,3,Fundamental Genetics,0.35,0.41,0.13,0.04,0.0,0.0,0.0,0.07,kate leanne wi tsai,
+GEN,3020,1,Molecular & General Genetics,0.28,0.47,0.16,0.0,0.06,0.0,0.0,0.03,rajandeep si sekhon,
+GEN,3020,2,Molec & General Genetics (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True
+GEN,3020,3,Molecular & General Genetics,0.21,0.35,0.19,0.08,0.04,0.0,0.0,0.13,lukasz kozubowski,
+GEN,4200,1,Molecular Genetics & Gene Reg,0.47,0.38,0.13,0.03,0.0,0.0,0.0,0.0,julia frugoli,
+GEN,4200,2,Molecular Genetics & Gen (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True
+GEN,4210,2,Mol Gen Gene Reg Lab,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,julia frugoli,
+GEN,4210,3,Mol Gen Gene Reg Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,
+GEN,4400,1,Bioinformatics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
+GEN,4500,1,Comparative Genetics,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,leigh anne clark,
+GEN,6400,1,Bioinformatics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
+GEOG,1010,1,Intro to Geography,0.23,0.4,0.33,0.05,0.0,0.0,0.0,0.0,christa smith,
+GEOG,1030,1,World Regional Geog,0.69,0.2,0.06,0.02,0.02,0.0,0.0,0.0,lance forres howard,
+GEOG,1030,2,World Regional Geog,0.47,0.21,0.11,0.05,0.05,0.0,0.0,0.11,william churc terry,
+GEOG,1030,3,World Regional Geog,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,lance forres howard,
+GEOL,1010,1,Physical Geology,0.17,0.26,0.34,0.12,0.06,0.0,0.0,0.05,alan coulson,
+GEOL,1010,2,Physical Geology,0.14,0.3,0.33,0.07,0.09,0.0,0.0,0.07,alan coulson,
+GEOL,1010,3,Physical Geology,0.33,0.33,0.12,0.04,0.08,0.0,0.0,0.12,mine dogan,
+GEOL,1030,1,Physical Geol Lab,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.57,0.24,0.05,0.0,0.14,0.0,0.0,0.0,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.27,0.59,0.05,0.05,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.17,0.65,0.04,0.0,0.04,0.0,0.0,0.09,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.21,0.5,0.04,0.0,0.0,0.0,0.0,0.25,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,alan coulson,
+GEOL,2050,1,Mineralogy & Intro Petrology,0.35,0.41,0.18,0.0,0.0,0.0,0.0,0.06,lin shuller-nickles,
+GEOL,2070,1,Min & Intro Pet Lab,0.13,0.56,0.31,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,2700,1,Sustainable Water,0.55,0.3,0.07,0.0,0.02,0.0,0.0,0.07,stephen mich moysey,
+GEOL,2750,1,Field Methods,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,3000,1,Environmental Geology,0.39,0.43,0.07,0.04,0.04,0.0,0.0,0.04,scott brame,
+GEOL,3020,1,Structural Geology,0.2,0.13,0.4,0.2,0.0,0.0,0.0,0.07,james castle,
+GEOL,4820,1,Groundwater & Contam Transport,0.42,0.33,0.17,0.0,0.0,0.0,0.0,0.08,lawrence murdoch,
+GER,1010,1,Elementary German,0.37,0.21,0.26,0.0,0.0,0.0,0.0,0.16, lee ferrell,
+GER,1010,2,Elementary German,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0, lee ferrell,
+GER,1020,1,Elementary German,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,1020,2,Elementary German,0.33,0.47,0.07,0.07,0.07,0.0,0.0,0.0,oswald harris king,
+GER,2010,1,Intermediate German,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,oswald harris king,
+GER,2010,2,Intermediate German,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,oswald harris king,
+GER,2020,1,Intermediate German,0.25,0.25,0.31,0.13,0.06,0.0,0.0,0.0, lee ferrell,
+GER,3050,1,Ger Conv & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+HCC,8310,1,Fundamentals of Hcc,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,kelly caine,
+HCG,9050,1,Genom & Hlth Policy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+HEHD,3990,1,Building Healthy Communities,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,areli moore peralta,
+HEHD,4000,1,Intro Leadership Theor & Conc,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,
+HEHD,8000,400,Youth Dev Theories,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
+HEHD,8030,400,Ethical Leadership,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,barry garst,
+HEHD,8060,230,Diverse Society,0.59,0.32,0.05,0.05,0.0,0.0,0.0,0.0,keith george diem,
+HIST,1010,1,Hist of the U S,0.24,0.44,0.26,0.03,0.03,0.0,0.0,0.0,james brad jeffries,
+HIST,1010,2,Hist of the U S,0.42,0.47,0.09,0.0,0.0,0.0,0.0,0.02,lee brady wilson,
+HIST,1020,1,Hist of the U S,0.11,0.11,0.21,0.11,0.11,0.0,0.0,0.37,maribel morey,
+HIST,1020,2,Hist of the U S,0.43,0.25,0.13,0.1,0.05,0.0,0.0,0.05,john andrew,
+HIST,1220,1,"Hist, Tech & Society",0.21,0.49,0.17,0.04,0.07,0.0,0.0,0.02,pamela mack,
+HIST,1240,1,Environmental History Survey,0.13,0.61,0.11,0.03,0.05,0.0,0.0,0.08,james brad jeffries,
+HIST,1240,2,Environmental History Survey,0.23,0.38,0.35,0.0,0.03,0.0,0.0,0.03,james brad jeffries,
+HIST,1720,1,The West and the World I,0.27,0.44,0.16,0.06,0.03,0.0,0.0,0.05,steven marks,
+HIST,1720,2,The West and the World I,0.3,0.42,0.18,0.03,0.02,0.0,0.0,0.05,steven marks,
+HIST,1720,3,The West and the World I,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,emily wood,
+HIST,1720,4,The West and the World I,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,emily wood,
+HIST,1730,2,The West and the World II,0.24,0.44,0.12,0.05,0.06,0.0,0.0,0.09, alan grubb,
+HIST,2990,1,Historian's Craft,0.75,0.17,0.0,0.08,0.0,0.0,0.0,0.0,michael silvestri,
+HIST,2990,2,Historian's Craft,0.3,0.4,0.0,0.0,0.3,0.0,0.0,0.0,elizabeth carney,
+HIST,2990,3,Historian's Craft,0.32,0.63,0.0,0.0,0.05,0.0,0.0,0.0,rachel anne moore,
+HIST,3000,1,Hist Colonial Amer,0.61,0.32,0.03,0.0,0.03,0.0,0.0,0.03,lee brady wilson,
+HIST,3040,1,Indus & Progr Era,0.54,0.21,0.17,0.04,0.04,0.0,0.0,0.0, roger grant,
+HIST,3100,1,History of Religion in the US,0.42,0.17,0.17,0.0,0.25,0.0,0.0,0.0,elizabeth jemison,
+HIST,3280,1,US Legal History to 1890,0.1,0.29,0.24,0.05,0.1,0.0,0.0,0.24,maribel morey,
+HIST,3300,1,Hist of Mod China,0.16,0.32,0.26,0.05,0.0,0.0,0.0,0.21,edwin moise,
+HIST,3390,1,Africa 1875-Present,0.51,0.15,0.18,0.0,0.13,0.0,0.0,0.03,james burns,
+HIST,3420,1,South Am Since 1800,0.46,0.49,0.05,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
+HIST,3520,1,Pharaonic Egypt,0.34,0.43,0.09,0.09,0.03,0.0,0.0,0.03,elizabeth carney,
+HIST,3610,2,History of Britain to 1688,0.45,0.38,0.03,0.1,0.03,0.0,0.0,0.0,caroline dunn clark,
+HIST,3630,1,Britain Since 1688,0.29,0.42,0.18,0.0,0.05,0.0,0.0,0.05,stephani barczewski,
+HIST,3670,1,Modern Ireland,0.46,0.31,0.13,0.05,0.05,0.0,0.0,0.0,michael silvestri,
+HIST,3890,8,Creative Inquiry in History,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,abel bartley,
+HIST,3900,1,Modern Military History,0.18,0.33,0.39,0.03,0.03,0.0,0.0,0.03,edwin moise,
+HIST,4000,1,Honor & Mastery InTheOld South,0.33,0.42,0.17,0.0,0.08,0.0,0.0,0.0,paul chris anderson,True
+HIST,4140,1,Study of Hist Museum,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,meg taylor-shockley,
+HIST,4720,2,Medieval Conquests & Crusades,0.21,0.42,0.11,0.11,0.05,0.0,0.0,0.11,caroline dunn clark,
+HIST,4900,3,Spanish Civil War,0.24,0.29,0.24,0.06,0.12,0.0,0.0,0.06,steven marks,
+HIST,4900,5,Oral History,0.5,0.22,0.17,0.0,0.06,0.0,0.0,0.06,meg taylor-shockley,
+HIST,4930,1,Urban History,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,abel bartley,
+HIST,4940,1,War & Peace in Middle East,0.57,0.29,0.0,0.0,0.07,0.0,0.0,0.07,amit bein,
+HIST,8000,2,SO. Biog,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john andrew,
+HIST,8810,1,Historiography,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, alan grubb,
+HLTH,2020,1,Introduction to Public Health,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,2,Introduction to Public Health,0.61,0.35,0.03,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,3,Introduction to Public Health,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,4,Introduction to Public Health,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,5,Introduction to Public Health,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,400,Introduction to Public Health,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.6,0.29,0.06,0.06,0.0,0.0,0.0,0.0,frederic fraizer,
+HLTH,2030,2,Health Care Sys,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+HLTH,2400,1,Deter of Hlth Behav,0.36,0.32,0.27,0.0,0.05,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2400,2,Deter of Hlth Behav,0.41,0.32,0.21,0.0,0.03,0.0,0.0,0.03,amelia clinkscales,
+HLTH,2500,1,Health and Fitness,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,kari jea strothmann,
+HLTH,2980,1,Human Hlth & Disease,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,2980,2,Human Hlth & Disease,0.85,0.09,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,3030,1,Public Health Comm,0.63,0.31,0.03,0.0,0.0,0.0,0.0,0.03,debra mitch charles,
+HLTH,3050,1,Body Resp Hlth Beh,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,brian patric graves,
+HLTH,3400,1,Hlth Prom Prog Plan,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,brian patric graves,
+HLTH,3610,1,Int Health Care Econ,0.49,0.29,0.13,0.02,0.0,0.0,0.0,0.07,khoa dang truong,
+HLTH,3800,1,Epidemiology,0.37,0.42,0.13,0.08,0.0,0.0,0.0,0.0,hugh spitler,
+HLTH,3800,2,Epidemiology,0.22,0.52,0.22,0.0,0.0,0.0,0.0,0.04,hugh spitler,
+HLTH,3800,400,Epidemiology,0.36,0.18,0.27,0.0,0.0,0.0,0.0,0.18,deborah alma falta,
+HLTH,3980,1,Hlth Appraisal Sklls,0.62,0.23,0.15,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,3980,2,Hlth Appraisal Sklls,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.33,0.36,0.16,0.13,0.0,0.0,0.0,0.02,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.77,0.15,0.05,0.0,0.0,0.0,0.0,0.03,kathleen meyer,
+HLTH,4400,1,Manag Hlth Serv Org,0.29,0.54,0.13,0.0,0.0,0.0,0.0,0.04,frederic fraizer,
+HLTH,4700,1,Global Health,0.83,0.14,0.0,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,4750,1,Hlthcr Oper Mgmt Res,0.77,0.19,0.0,0.0,0.0,0.0,0.0,0.03,lu shi,
+HLTH,4900,1,Res Eval St Pub Hlth,0.33,0.51,0.13,0.0,0.0,0.0,0.0,0.03,lingling zhang,
+HLTH,4900,2,Res Eval St Pub Hlth,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,lingling zhang,
+HLTH,4970,3,Creative Inq in Public Health,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,crystal burn fulmer,
+HLTH,8120,500,Clinical and Translational Sci,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ronald gimbel,
+HON,1910,1,Wicked Opera,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,johannes schmidt,
+HON,1920,2,Who Gets What and Why?,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,sarah evely winslow,
+HON,2060,2,PANDEMIC: Extinction Pending?,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,james morris,
+HON,2200,4,The Economic Crisis,0.64,0.18,0.09,0.0,0.09,0.0,0.0,0.0,patrick warren,
+HON,2220,1,Pact with the Devil,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,
+HORT,1010,1,Horticulture,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HORT,2100,1,Growing Fall Plants,0.32,0.42,0.11,0.05,0.0,0.0,0.0,0.11,james emerson faust,
+HORT,2120,1,Turfgrass Culture,0.52,0.39,0.07,0.02,0.0,0.0,0.0,0.0,haibo liu,
+HORT,2130,1,Turf Culture Lab,0.71,0.14,0.05,0.0,0.0,0.0,0.0,0.1,donald garrett,
+HORT,2130,2,Turf Culture Lab,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,donald garrett,
+HORT,3030,1,Landscape Plants,0.31,0.27,0.17,0.09,0.09,0.0,0.0,0.06,robert polomski,
+HORT,3080,1,Sust Landsc Des Install Maint,0.59,0.19,0.13,0.0,0.06,0.0,0.0,0.03,ellen anita vincent,
+HORT,4090,1,Senior Capstone Course,0.79,0.13,0.04,0.0,0.04,0.0,0.0,0.0,ellen anita vincent,
+HORT,4120,1,Adv Turfgrass Mgt,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,lambert mccarty,
+HORT,4330,1,Turf Weed Management,0.15,0.6,0.2,0.05,0.0,0.0,0.0,0.0,ted whitwell,
+HP,8010,1,Preservation Law and Econ,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,barry louis stiefel,
+HRD,8200,400,Human Perform Improv,0.93,0.0,0.0,0.0,0.02,0.0,0.0,0.05,russell marion,
+HRD,8300,400,Concepts of H R D,0.74,0.09,0.02,0.0,0.09,0.0,0.0,0.05,cynthia sims,
+HRD,8450,400,Needs Assess Ed/Ind,0.93,0.04,0.0,0.0,0.02,0.0,0.0,0.0,philip mcgee,
+HRD,8600,400,Instruc Mat Devel,0.89,0.04,0.04,0.0,0.02,0.0,0.0,0.02,philip mcgee,
+HUM,3090,1,Studies in Humanities,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,
+IE,2000,1,Soph Seminar in I E,0.56,0.17,0.11,0.08,0.08,0.0,0.0,0.0,brian melloy,
+IE,2100,1,Des Analysis Wrk Sys,0.07,0.68,0.21,0.02,0.01,0.0,0.0,0.0,david neyens,
+IE,2800,1,Deterministic Operations Rsrch,0.19,0.32,0.24,0.13,0.05,0.0,0.0,0.06,amin khademi,
+IE,2800,2,Deterministic Operations Rsrch,0.47,0.24,0.15,0.05,0.07,0.0,0.0,0.02,jonathan lowe,
+IE,3010,1,Systems Design I,0.28,0.59,0.08,0.03,0.0,0.0,0.0,0.03,joel greenstein,
+IE,3600,1,Industrial Apps of Prob/Stat I,0.29,0.32,0.25,0.05,0.07,0.0,0.0,0.02,mary elizabeth kurz,
+IE,3680,1,Prof Practice in I E,0.93,0.03,0.02,0.02,0.0,0.0,0.0,0.0,robert james riggs,
+IE,3840,1,Engr Econ Analysis,0.08,0.22,0.11,0.08,0.11,0.0,0.0,0.41,brian melloy,
+IE,3860,1,Prod Plan & Cont,0.21,0.41,0.21,0.18,0.0,0.0,0.0,0.0,robert james riggs,
+IE,4400,1,Decision Support Sys,0.35,0.29,0.15,0.08,0.11,0.0,0.0,0.02,scott jenning mason,
+IE,4400,2,Decision Support Sys,0.29,0.25,0.1,0.13,0.17,0.0,0.0,0.06,site wang,
+IE,4560,1,Supply Chain Design & Control,0.31,0.42,0.18,0.04,0.0,0.0,0.0,0.04,william ferrell,
+IE,4610,1,Quality Engineering,0.25,0.33,0.31,0.06,0.02,0.0,0.0,0.02,byung rae cho,
+IE,4650,1,Facilities Planning & Design,0.79,0.18,0.01,0.02,0.0,0.0,0.0,0.0,jonathan lowe,
+IE,4650,2,Facilities Planning & Design,0.25,0.38,0.19,0.16,0.0,0.0,0.0,0.02,william ferrell,
+IE,4820,1,Systems Modeling,0.48,0.38,0.11,0.02,0.0,0.0,0.0,0.0,kevin taaffe,
+IE,4820,2,Systems Modeling,0.21,0.3,0.3,0.1,0.04,0.0,0.0,0.04,tugce isik,
+IE,4910,1,Network Flows for IE App,0.25,0.13,0.25,0.06,0.06,0.0,0.0,0.25,burak eksioglu,
+IE,4910,2,Modeling & Analysis of MFG,0.61,0.26,0.0,0.03,0.06,0.0,0.0,0.03,mary elizabeth kurz,
+IE,6560,1,Supply Chain Design & Control,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,william ferrell,
+IE,6910,3,Simulation Modeling & Analysis,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
+IE,8000,1,Human Factors Eng,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,david neyens,
+IE,8030,1,Engr Optimization and Apps,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,
+IE,8090,1,Model Sys Under Risk,0.25,0.54,0.21,0.0,0.0,0.0,0.0,0.0,burak eksioglu,
+IE,8510,1,Descriptive Analytics,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,mary elizabeth kurz,
+IE,8530,1,Foundations of Quality,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,byung rae cho,
+IE,8550,1,SC & Logistics Modeling II,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
+IE,8930,1,Multilevel Math Optimization,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
+INT,1010,5,Career Center Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,troy nunamaker,
+INT,1020,5,Career Center Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,troy nunamaker,
+INT,1030,5,Career Center Internship PT 3+,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,troy nunamaker,
+IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.03,sharon nagy,
+ITAL,1010,1,Elementary Italian,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,luca barattoni,
+ITAL,1010,2,Elementary Italian,0.61,0.11,0.0,0.11,0.06,0.0,0.0,0.11,luca barattoni,
+ITAL,1010,3,Elementary Italian,0.42,0.37,0.05,0.0,0.0,0.0,0.0,0.16,valentina lombardi,
+ITAL,1010,4,Elementary Italian,0.43,0.36,0.07,0.0,0.07,0.0,0.0,0.07,valentina lombardi,
+ITAL,1020,1,Elementary Italian,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+ITAL,2010,1,Intermediate Italian,0.44,0.31,0.25,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,2010,2,Intermediate Italian,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+JAPN,1010,1,Elementary Japanese,0.76,0.0,0.18,0.06,0.0,0.0,0.0,0.0,jae allegr takeuchi,
+JAPN,1010,2,Elementary Japanese,0.59,0.12,0.12,0.0,0.06,0.0,0.0,0.12,jae allegr takeuchi,
+JAPN,1020,1,Elementary Japanese,0.38,0.31,0.08,0.08,0.0,0.0,0.0,0.15,kazuko shoji,
+JAPN,2010,1,Intermed Japanese,0.47,0.33,0.13,0.0,0.07,0.0,0.0,0.0,kazuko shoji,
+JAPN,3050,1,Japanese Conversation & Comp,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,toshiko kishimoto,
+LANG,2540,1,Introduction to World Cinemas,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,raquel anido,
+LANG,3710,1,Language and Culture,0.36,0.45,0.09,0.09,0.0,0.0,0.0,0.0,yanhua zhang,
+LARC,1150,1,Intro Landscape Architecture,0.48,0.18,0.24,0.0,0.06,0.0,0.0,0.03,martin john holland,
+LARC,1280,1,Technical Graphics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
+LARC,1510,1,Basic Design I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
+LARC,2510,1,Larch Design Fund,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,robert hewitt,
+LARC,2620,1,Design Impl I,0.36,0.14,0.29,0.0,0.14,0.0,0.0,0.07,paul russell,
+LARC,3510,1,Regional Design,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,yang song,
+LARC,4530,2,Key Issues in Larch,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
+LARC,8210,1,Research Methods,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,
+LARC,8500,1,Grad Colloquium,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,
+LAW,3220,1,Legal Env of Bus,0.5,0.27,0.16,0.05,0.02,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,2,Legal Env of Bus,0.57,0.28,0.09,0.02,0.02,0.0,0.0,0.02,edward ray claggett,
+LAW,3220,3,Legal Env of Bus,0.31,0.36,0.17,0.07,0.05,0.0,0.0,0.05,kenneth toussaint,
+LAW,3220,4,Legal Env of Bus,0.21,0.4,0.24,0.05,0.07,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,5,Legal Env of Bus,0.2,0.36,0.36,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,6,Legal Env of Bus,0.12,0.49,0.3,0.02,0.05,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,7,Legal Env of Bus,0.45,0.32,0.2,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,
+LAW,3220,8,Legal Env of Bus,0.39,0.36,0.23,0.0,0.0,0.0,0.0,0.02,kath kisska-schulze,
+LAW,3220,9,Legal Env of Bus,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,john hine,
+LAW,3220,10,Legal Env of Bus,0.27,0.41,0.25,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,11,Legal Env of Bus,0.51,0.47,0.02,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,100,Legal Env of Bus (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,True
+LAW,3220,400,Legal Env of Bus,0.15,0.38,0.15,0.06,0.12,0.0,0.0,0.15,virgini ward-vaughn,
+LAW,3220,401,Legal Env of Bus,0.1,0.35,0.23,0.03,0.06,0.0,0.0,0.23,virgini ward-vaughn,
+LAW,3220,402,Legal Env of Bus,0.13,0.27,0.37,0.07,0.1,0.0,0.0,0.07,virgini ward-vaughn,
+LAW,3220,403,Legal Env of Bus,0.19,0.3,0.11,0.07,0.15,0.0,0.0,0.19,virgini ward-vaughn,
+LAW,3330,1,Real Estate Law,0.22,0.49,0.2,0.05,0.02,0.02,0.0,0.0,judson jahn,
+LAW,4050,1,Construction Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LIB,3010,1,Patent Searching,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,janice comfort,
+LIH,1270,1,Introduction to L&Ih,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,graciela tissera,
+LS,1000,1,Therapeutic Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,
+LS,1000,2,Therapeutic Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,1000,3,Therapeutic Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ranjanbala dil amin,
+LS,1000,6,Beg. Non-competitive Karate,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,june pilcher,
+LS,1000,19,Introduction to Hip-Hop Dance,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,andrew ellio boland,
+LS,1000,31,Stand-up Paddleboarding,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,elizabeth venable,
+LS,1410,1,Top Rope Climbing,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,glenn dav middleton,
+LS,1410,5,Top Rope Climbing,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,glenn dav middleton,
+LS,1450,5,Camping/Backpacking,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,samuel james keith,
+LS,1570,7,Shotgun Sports,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,susan ruth sullivan,
+LS,1580,5,Archery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,herbert strickland,
+LS,1640,1,Whitewater Kayaking,0.73,0.0,0.09,0.0,0.0,0.0,0.0,0.18,samuel dylan mcgee,
+LS,1640,3,Whitewater Kayaking,0.64,0.09,0.0,0.0,0.0,0.0,0.0,0.27,emily grace turke,
+LS,1650,3,Inland Kayak Touring,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,sarah wilcer,
+LS,1750,2,Fly Fishing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael watts,
+LS,1850,3,Bowling,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,megan elizabet cato,
+LS,1850,10,Bowling,0.83,0.07,0.07,0.03,0.0,0.0,0.0,0.0,katie dudley,
+LS,1940,2,Racquetball,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,
+LS,2040,1,Soccer,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,jessica ca doughtie,
+LS,2100,1,Learn to Dance,0.89,0.03,0.0,0.0,0.03,0.0,0.0,0.06,matthew lee krabbe,
+LS,2110,1,Introduction to Belly Dance,0.8,0.05,0.0,0.0,0.0,0.0,0.0,0.15,stephanie pack,
+LS,2110,3,Introduction to Belly Dance,0.86,0.09,0.0,0.0,0.05,0.0,0.0,0.0,stephanie pack,
+LS,2200,4,Shag,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,broadus fleming,
+LS,2200,7,Shag,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,
+LS,2200,10,Shag,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,matthew lee krabbe,
+LS,2270,2,Intro to Swing Dance,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,paul hoke,
+LS,2270,3,Intro to Swing Dance,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,
+LS,2270,4,Intro to Swing Dance,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,
+LS,2280,1,Intermediate Swing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,paul hoke,
+LS,2320,2,Core Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,diane moreno,
+LS,2320,3,Core Training,0.88,0.0,0.04,0.0,0.0,0.0,0.0,0.08,diane moreno,
+LS,2320,4,Core Training,0.91,0.0,0.04,0.0,0.0,0.0,0.0,0.04,diane moreno,
+LS,2350,4,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
+LS,2350,5,Basic Yoga,0.65,0.22,0.0,0.0,0.0,0.0,0.0,0.13,renee warren gahan,
+LS,2350,6,Basic Yoga,0.71,0.14,0.1,0.05,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2350,7,Basic Yoga,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2360,1,Power/Ashtanga Yoga,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,ani reina-nunnelley,
+LS,2360,2,Power/Ashtanga Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
+LS,2360,3,Power/Ashtanga Yoga,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
+LS,2360,6,Power/Ashtanga Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,silica eliza larkin,
+LS,2380,3,Vinyasa Flow Yoga,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,jenefer nadenicek,
+LS,2380,4,Vinyasa Flow Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,jenefer nadenicek,
+LS,2380,5,Vinyasa Flow Yoga,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jenefer nadenicek,
+LS,2420,2,Meditation and Relax,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,renee warren gahan,
+LS,2420,3,Meditation and Relax,0.83,0.04,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,
+LS,2420,5,Meditation and Relax,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
+LS,2420,7,Meditation and Relax,0.79,0.13,0.0,0.0,0.04,0.0,0.0,0.04,renee warren gahan,
+LS,2450,2,Pilates,0.89,0.0,0.06,0.0,0.0,0.0,0.0,0.06,melanie ivey job,
+LS,2450,3,Pilates,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
+LS,2450,6,Pilates,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
+LS,2460,1,Intermediate Pilates,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,melanie ivey job,
+LS,2510,3,Running & Jogging,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,robert edwar lawson,
+LS,2700,1,Sports Officiating,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,christopher war cox,
+LS,2770,1,Lifeguarding,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,kelly lynn womack,
+LS,3580,1,Advanced Shotgun Skeet,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,charles flint,
+MATH,1010,2,Essen Math for Informed Soc,0.26,0.26,0.21,0.05,0.16,0.0,0.0,0.05,paran rebeka norton,
+MATH,1010,3,Essen Math for Informed Soc,0.18,0.45,0.27,0.09,0.0,0.0,0.0,0.0,minghua cui,
+MATH,1010,4,Essen Math for Informed Soc,0.44,0.36,0.08,0.08,0.03,0.0,0.0,0.0,judith cottingham,
+MATH,1010,6,Essen Math for Informed Soc,0.39,0.36,0.17,0.06,0.0,0.0,0.0,0.03,judith cottingham,
+MATH,1010,8,Essen Math for Informed Soc,0.42,0.21,0.26,0.05,0.05,0.0,0.0,0.0,paran rebeka norton,
+MATH,1010,9,Essen Math for Informed Soc,0.35,0.24,0.12,0.06,0.24,0.0,0.0,0.0,yijun chen,
+MATH,1010,10,Essen Math for Informed Soc,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,xiyan tan,
+MATH,1010,12,Essen Math for Informed Soc,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,yijun chen,
+MATH,1010,14,Essen Math for Informed Soc,0.39,0.33,0.22,0.0,0.06,0.0,0.0,0.0,xiyan tan,
+MATH,1010,101,Essen Math for Informed Soc,0.35,0.27,0.12,0.12,0.0,0.0,0.0,0.15,meredith nicol burr,
+MATH,1020,1,Intro to Mathematical Analysis,0.25,0.28,0.19,0.08,0.14,0.0,0.0,0.06,warren adams,
+MATH,1020,2,Intro to Mathematical Analysis,0.0,0.32,0.37,0.16,0.11,0.0,0.0,0.05,michael we lamoreux,
+MATH,1020,3,Intro to Mathematical Analysis,0.16,0.42,0.11,0.0,0.26,0.0,0.0,0.05,jerry lero phillips,
+MATH,1020,4,Intro to Mathematical Analysis,0.06,0.22,0.39,0.11,0.06,0.0,0.0,0.17,huixi li,
+MATH,1020,5,Intro to Mathematical Analysis,0.11,0.37,0.26,0.11,0.16,0.0,0.0,0.0,aaro ramirez flores,
+MATH,1020,6,Intro to Mathematical Analysis,0.26,0.37,0.16,0.05,0.11,0.0,0.0,0.05,stefani ca mokalled,
+MATH,1020,7,Intro to Mathematical Analysis,0.21,0.05,0.21,0.26,0.21,0.0,0.0,0.05,huixi li,
+MATH,1020,8,Intro to Mathematical Analysis,0.21,0.11,0.21,0.32,0.05,0.0,0.0,0.11,aaro ramirez flores,
+MATH,1020,9,Intro to Mathematical Analysis,0.11,0.22,0.33,0.11,0.17,0.0,0.0,0.06,jerry lero phillips,
+MATH,1020,10,Intro to Mathematical Analysis,0.26,0.16,0.21,0.21,0.0,0.0,0.0,0.16,xiaoyuan liu,
+MATH,1020,11,Intro to Mathematical Analysis,0.21,0.21,0.26,0.11,0.16,0.0,0.0,0.05,travis baumbaugh,
+MATH,1020,12,Intro to Mathematical Analysis,0.17,0.39,0.11,0.17,0.0,0.0,0.0,0.17,tianhui wei,
+MATH,1020,13,Intro to Mathematical Analysis,0.2,0.43,0.18,0.05,0.08,0.0,0.0,0.08,randy davidson,
+MATH,1020,14,Intro to Mathematical Analysis,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,jennifer van dyken,
+MATH,1020,15,Intro to Mathematical Analysis,0.06,0.22,0.33,0.22,0.06,0.0,0.0,0.11,yibo xu,
+MATH,1020,16,Intro to Mathematical Analysis,0.39,0.28,0.11,0.06,0.06,0.0,0.0,0.11,stefani ca mokalled,
+MATH,1020,17,Intro to Mathematical Analysis,0.17,0.28,0.22,0.17,0.17,0.0,0.0,0.0,tiantian yang,
+MATH,1020,18,Intro to Mathematical Analysis,0.16,0.42,0.32,0.11,0.0,0.0,0.0,0.0,xiaoyuan liu,
+MATH,1020,19,Intro to Mathematical Analysis,0.16,0.42,0.21,0.11,0.0,0.0,0.0,0.11,chase norman joyner,
+MATH,1020,20,Intro to Mathematical Analysis,0.26,0.16,0.21,0.05,0.11,0.0,0.0,0.21,tianhui wei,
+MATH,1020,21,Intro to Mathematical Analysis,0.21,0.32,0.21,0.11,0.16,0.0,0.0,0.0,prab withana gamage,
+MATH,1020,22,Intro to Mathematical Analysis,0.16,0.26,0.21,0.05,0.21,0.0,0.0,0.11,michael we lamoreux,
+MATH,1020,23,Intro to Mathematical Analysis,0.22,0.11,0.17,0.0,0.33,0.0,0.0,0.17,hao zuo,
+MATH,1020,24,Intro to Mathematical Analysis,0.06,0.33,0.33,0.06,0.17,0.0,0.0,0.06,yibo xu,
+MATH,1020,25,Intro to Mathematical Analysis,0.05,0.37,0.26,0.11,0.11,0.0,0.0,0.11,junyang zhuang,
+MATH,1020,26,Intro to Mathematical Analysis,0.42,0.21,0.16,0.11,0.0,0.0,0.0,0.11,xintao liu,
+MATH,1020,27,Intro to Mathematical Analysis,0.26,0.37,0.16,0.11,0.05,0.0,0.0,0.05,haodong li,
+MATH,1020,28,Intro to Mathematical Analysis,0.32,0.11,0.26,0.05,0.21,0.0,0.0,0.05,chase norman joyner,
+MATH,1020,29,Intro to Mathematical Analysis,0.21,0.37,0.26,0.11,0.05,0.0,0.0,0.0,randy davidson,
+MATH,1020,30,Intro to Mathematical Analysis,0.21,0.26,0.26,0.0,0.16,0.0,0.0,0.11,prab withana gamage,
+MATH,1020,31,Intro to Mathematical Analysis,0.17,0.33,0.33,0.0,0.0,0.0,0.0,0.17,xintao liu,
+MATH,1020,32,Intro to Mathematical Analysis,0.0,0.21,0.42,0.21,0.16,0.0,0.0,0.0,junyang zhuang,
+MATH,1020,33,Intro to Mathematical Analysis,0.26,0.37,0.21,0.05,0.05,0.0,0.0,0.05,janie caro mcdonald,
+MATH,1020,34,Intro to Mathematical Analysis,0.26,0.21,0.21,0.11,0.16,0.0,0.0,0.05,randy davidson,
+MATH,1020,35,Intro to Mathematical Analysis,0.22,0.44,0.22,0.0,0.0,0.0,0.0,0.11,yinggu bao,
+MATH,1020,36,Intro to Mathematical Analysis,0.21,0.21,0.16,0.21,0.16,0.0,0.0,0.05,haodong li,
+MATH,1020,37,Intro to Mathematical Analysis,0.11,0.28,0.22,0.17,0.06,0.0,0.0,0.17,tiantian yang,
+MATH,1020,38,Intro to Mathematical Analysis,0.17,0.28,0.17,0.06,0.11,0.0,0.0,0.22,hao zuo,
+MATH,1020,39,Intro to Mathematical Analysis,0.0,0.32,0.26,0.05,0.32,0.0,0.0,0.05, erwin walker,
+MATH,1020,40,Intro to Mathematical Analysis,0.16,0.21,0.16,0.05,0.26,0.0,0.0,0.16,travis baumbaugh,
+MATH,1020,41,Intro to Mathematical Analysis,0.17,0.28,0.22,0.06,0.22,0.0,0.0,0.06,travis baumbaugh,
+MATH,1020,42,Intro to Mathematical Analysis,0.0,0.29,0.35,0.06,0.12,0.0,0.0,0.18,michael we lamoreux,
+MATH,1020,43,Intro to Mathematical Analysis,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,jennifer van dyken,
+MATH,1020,44,Intro to Mathematical Analysis,0.37,0.26,0.05,0.11,0.16,0.0,0.0,0.05,randy davidson,
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.6,0.33,0.07,donna simms,
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.62,0.03,tony thanh nguyen,
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.57,0.07,stella watson,
+MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.34,0.59,0.07,patrick buckingham,
+MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.42,0.53,0.04,rebecca lynn knoll,
+MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.36,0.18,liang zhao,
+MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.5,0.41,0.09,patrick buckingham,
+MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.52,0.33,0.14,jason to hedetniemi,
+MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.41,0.12,muhamm mohebujjaman,
+MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.41,0.57,0.02,hugh geller,
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.42,0.48,0.11,eliza dar gallagher,
+MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.6,0.37,0.03,charity watson,
+MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.39,0.02,charity watson,
+MATH,1060,1,Calculus of One Variable I,0.07,0.32,0.15,0.07,0.27,0.0,0.0,0.12,stefan adam bock,
+MATH,1060,2,Calculus of One Variable I,0.2,0.29,0.2,0.09,0.04,0.0,0.0,0.18,jonathon leverenz,
+MATH,1060,3,Calculus of One Variable I,0.1,0.25,0.21,0.13,0.1,0.0,0.0,0.21,abigail bowers,
+MATH,1060,4,Calculus of One Variable I,0.29,0.14,0.26,0.11,0.11,0.0,0.0,0.09,marilyn reba,
+MATH,1060,5,Calculus of One Variable I,0.1,0.29,0.24,0.07,0.19,0.0,0.0,0.12,abigail bowers,
+MATH,1060,6,Calculus of One Variable I,0.26,0.26,0.13,0.07,0.09,0.0,0.0,0.2,meredith nicol burr,
+MATH,1060,7,Calculus of One Variable I,0.14,0.31,0.2,0.09,0.09,0.0,0.0,0.17,marilyn reba,
+MATH,1060,8,Calculus of One Variable I,0.04,0.38,0.3,0.06,0.17,0.0,0.0,0.04,abigail bowers,
+MATH,1060,9,Calculus of One Variable I,0.29,0.33,0.21,0.02,0.02,0.0,0.0,0.12,abdullah al mamun,
+MATH,1060,10,Calculus of One Variable I,0.2,0.3,0.18,0.07,0.09,0.0,0.0,0.16,meredith nicol burr,
+MATH,1060,11,Calculus of One Variable I,0.12,0.31,0.31,0.14,0.0,0.0,0.0,0.12,beth novick,
+MATH,1060,12,Calculus of One Variable I,0.09,0.28,0.19,0.06,0.26,0.0,0.0,0.13,michael gl eldredge,
+MATH,1060,13,Calculus of One Variable I,0.04,0.41,0.3,0.09,0.07,0.0,0.0,0.09,sea sather-wagstaff,
+MATH,1060,14,Calculus of One Variable I,0.15,0.36,0.24,0.09,0.09,0.0,0.0,0.06,allen anderso guest,
+MATH,1060,15,Calculus of One Variable I,0.16,0.52,0.13,0.06,0.1,0.0,0.0,0.03,allen anderso guest,
+MATH,1060,16,Calculus of One Variable I,0.11,0.28,0.23,0.09,0.15,0.0,0.0,0.15,sea sather-wagstaff,
+MATH,1060,17,Calculus of One Variable I,0.34,0.25,0.23,0.09,0.05,0.0,0.0,0.05,ryan grove,
+MATH,1060,18,Calculus of One Variable I,0.05,0.3,0.28,0.08,0.23,0.0,0.0,0.08,amy christine grady,
+MATH,1060,19,Calculus of One Variable I,0.15,0.32,0.11,0.17,0.17,0.0,0.0,0.08,jonathon leverenz,
+MATH,1060,20,Calculus of One Variable I,0.07,0.26,0.17,0.05,0.12,0.0,0.0,0.33,sergey charnyi,
+MATH,1060,21,Calculus of One Variable I,0.14,0.17,0.08,0.17,0.14,0.0,0.0,0.31,rui gong,
+MATH,1060,22,Calculus of One Variable I,0.11,0.2,0.29,0.0,0.09,0.0,0.0,0.31,lee andrew jenkins,
+MATH,1060,23,Calculus of One Variable I,0.16,0.27,0.24,0.09,0.07,0.0,0.0,0.18,stefan adam bock,
+MATH,1060,24,Calculus of One Variable I,0.05,0.21,0.32,0.05,0.26,0.0,0.0,0.11,jennifer van dyken,
+MATH,1060,25,Calculus of One Variable I,0.32,0.29,0.21,0.03,0.11,0.0,0.0,0.05,shiyi tu,
+MATH,1060,100,Calc of One Variable I (HON),0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,beth novick,True
+MATH,1070,1,Differen and Integral Calculus,0.0,0.47,0.29,0.18,0.06,0.0,0.0,0.0,donna simms,
+MATH,1080,1,Calculus of One Variable II,0.1,0.16,0.19,0.0,0.26,0.0,0.0,0.29,alistair bentley,
+MATH,1080,2,Calculus of One Variable II,0.09,0.22,0.13,0.09,0.13,0.0,0.0,0.35,terri johnson,
+MATH,1080,3,Calculus of One Variable II,0.05,0.19,0.27,0.03,0.3,0.0,0.0,0.16,fiona may knoll,
+MATH,1080,4,Calculus of One Variable II,0.03,0.15,0.21,0.09,0.21,0.0,0.0,0.3,sanwar ahmad,
+MATH,1080,5,Calculus of One Variable II,0.05,0.23,0.18,0.08,0.21,0.0,0.0,0.26,garrett dranichak,
+MATH,1080,6,Calculus of One Variable II,0.03,0.17,0.17,0.06,0.43,0.0,0.0,0.14,javier ruiz ramirez,
+MATH,1080,7,Calculus of One Variable II,0.09,0.12,0.18,0.12,0.27,0.0,0.0,0.21,rebecca ramos,
+MATH,1080,8,Calculus of One Variable II,0.07,0.22,0.33,0.19,0.11,0.0,0.0,0.07,qijun he,
+MATH,1080,10,Calculus of One Variable II,0.03,0.11,0.18,0.26,0.24,0.0,0.0,0.18,honghai xu,
+MATH,1080,11,Calculus of One Variable II,0.03,0.22,0.08,0.08,0.46,0.0,0.0,0.14,audrey nico devries,
+MATH,1080,12,Calculus of One Variable II,0.06,0.2,0.2,0.09,0.26,0.0,0.0,0.2,shuhan xu,
+MATH,1080,100,Calc of One Variable II (HON),0.18,0.24,0.12,0.06,0.0,0.0,0.0,0.41,terri johnson,True
+MATH,1150,1,Contemp Math for Elem Teach I,0.63,0.23,0.13,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1150,2,Contemp Math for Elem Teach I,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,allison stoddard,
+MATH,1160,1,Contemp Math for Elem Teach II,0.64,0.28,0.06,0.03,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.02,marion hanna,
+MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,marion hanna,
+MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.04,marion hanna,
+MATH,2060,1,Calculus of Several Variables,0.36,0.23,0.05,0.13,0.1,0.0,0.0,0.13,mishko mitkovski,
+MATH,2060,2,Calculus of Several Variables,0.19,0.25,0.22,0.14,0.14,0.0,0.0,0.06,christopher cox,
+MATH,2060,3,Calculus of Several Variables,0.26,0.16,0.16,0.1,0.19,0.0,0.0,0.13,akshay sunil gupte,
+MATH,2060,4,Calculus of Several Variables,0.36,0.38,0.18,0.0,0.03,0.0,0.0,0.05,xin liu,
+MATH,2060,5,Calculus of Several Variables,0.18,0.26,0.08,0.05,0.26,0.0,0.0,0.16,gretchen matthews,
+MATH,2060,6,Calculus of Several Variables,0.11,0.39,0.08,0.17,0.14,0.0,0.0,0.11,shari prevost,
+MATH,2060,7,Calculus of Several Variables,0.37,0.24,0.24,0.0,0.11,0.0,0.0,0.05,martin joha schmoll,
+MATH,2060,8,Calculus of Several Variables,0.44,0.33,0.08,0.03,0.03,0.0,0.0,0.1,xin liu,
+MATH,2060,9,Calculus of Several Variables,0.16,0.27,0.14,0.08,0.19,0.0,0.0,0.16,gretchen matthews,
+MATH,2060,10,Calculus of Several Variables,0.37,0.23,0.26,0.06,0.03,0.0,0.0,0.06,minerva rios-adams,
+MATH,2060,11,Calculus of Several Variables,0.26,0.11,0.26,0.11,0.14,0.0,0.0,0.11,shari prevost,
+MATH,2060,12,Calculus of Several Variables,0.26,0.24,0.16,0.03,0.21,0.0,0.0,0.11,gretchen matthews,
+MATH,2060,13,Calculus of Several Variables,0.15,0.46,0.2,0.17,0.02,0.0,0.0,0.0,minerva rios-adams,
+MATH,2060,14,Calculus of Several Variables,0.28,0.39,0.17,0.06,0.06,0.0,0.0,0.06,timothy fra parrott,
+MATH,2060,15,Calculus of Several Variables,0.17,0.27,0.37,0.12,0.07,0.0,0.0,0.0,timothy ch teitloff,
+MATH,2060,17,Calculus of Several Variables,0.13,0.31,0.18,0.05,0.26,0.0,0.0,0.08,timothy ch teitloff,
+MATH,2060,18,Calculus of Several Variables,0.28,0.19,0.25,0.06,0.08,0.0,0.0,0.14,timothy fra parrott,
+MATH,2060,19,Calculus of Several Variables,0.41,0.24,0.14,0.08,0.03,0.0,0.0,0.11,peter kiessler,
+MATH,2060,20,Calculus of Several Variables,0.72,0.26,0.0,0.0,0.0,0.0,0.0,0.03,sofya alekseeva,
+MATH,2060,21,Calculus of Several Variables,0.16,0.16,0.38,0.11,0.14,0.0,0.0,0.05,timothy ch teitloff,
+MATH,2060,22,Calculus of Several Variables,0.28,0.28,0.33,0.03,0.0,0.0,0.0,0.08,nathan jos adelgren,
+MATH,2060,23,Calculus of Several Variables,0.09,0.21,0.38,0.15,0.18,0.0,0.0,0.0,julie lassiter,
+MATH,2060,24,Calculus of Several Variables,0.54,0.44,0.03,0.0,0.0,0.0,0.0,0.0,sofya alekseeva,
+MATH,2060,25,Calculus of Several Variables,0.43,0.34,0.09,0.03,0.03,0.0,0.0,0.09,sofya alekseeva,
+MATH,2060,100,Calc of Several Vars (HON),0.63,0.17,0.08,0.0,0.04,0.0,0.0,0.08,shari prevost,True
+MATH,2070,1,Multivariable Calculus,0.11,0.26,0.21,0.16,0.21,0.0,0.0,0.05,trevor scot vilardi,
+MATH,2070,2,Multivariable Calculus,0.06,0.24,0.24,0.12,0.18,0.0,0.0,0.18,mengying xiao,
+MATH,2070,3,Multivariable Calculus,0.18,0.24,0.18,0.06,0.18,0.0,0.0,0.18,thanh thien to,
+MATH,2070,4,Multivariable Calculus,0.16,0.37,0.42,0.0,0.0,0.0,0.0,0.05,jennifer mari hanna,
+MATH,2070,5,Multivariable Calculus,0.15,0.08,0.38,0.15,0.08,0.0,0.0,0.15,liu zhu,
+MATH,2070,6,Multivariable Calculus,0.32,0.11,0.21,0.21,0.11,0.0,0.0,0.05,judith irene mcknew,
+MATH,2070,7,Multivariable Calculus,0.26,0.32,0.37,0.05,0.0,0.0,0.0,0.0,luke marti giberson,
+MATH,2070,8,Multivariable Calculus,0.29,0.29,0.2,0.2,0.03,0.0,0.0,0.0,jennifer mari hanna,
+MATH,2070,9,Multivariable Calculus,0.26,0.32,0.16,0.16,0.05,0.0,0.0,0.05,kevin wayne dettman,
+MATH,2070,10,Multivariable Calculus,0.37,0.21,0.21,0.11,0.05,0.0,0.0,0.05,luke marti giberson,
+MATH,2070,11,Multivariable Calculus,0.22,0.39,0.33,0.0,0.0,0.0,0.0,0.06,judith irene mcknew,
+MATH,2070,12,Multivariable Calculus,0.26,0.32,0.11,0.05,0.16,0.0,0.0,0.11,yisu jia,
+MATH,2070,13,Multivariable Calculus,0.25,0.13,0.31,0.13,0.13,0.0,0.0,0.06,liu zhu,
+MATH,2070,14,Multivariable Calculus,0.39,0.22,0.17,0.11,0.11,0.0,0.0,0.0,trevor scot vilardi,
+MATH,2070,15,Multivariable Calculus,0.21,0.27,0.27,0.03,0.12,0.0,0.0,0.09,jennifer mari hanna,
+MATH,2070,16,Multivariable Calculus,0.17,0.17,0.2,0.2,0.06,0.0,0.0,0.2,hui xue,
+MATH,2070,18,Multivariable Calculus,0.06,0.18,0.29,0.12,0.29,0.0,0.0,0.06,kevin wayne dettman,
+MATH,2070,19,Multivariable Calculus,0.22,0.33,0.28,0.11,0.0,0.0,0.0,0.06,jennifer mari hanna,
+MATH,2070,20,Multivariable Calculus,0.17,0.22,0.33,0.22,0.06,0.0,0.0,0.0,yisu jia,
+MATH,2070,21,Multivariable Calculus,0.26,0.32,0.26,0.0,0.0,0.0,0.0,0.16,allison stoddard,
+MATH,2070,22,Multivariable Calculus,0.11,0.22,0.33,0.06,0.06,0.0,0.0,0.22,thanh thien to,
+MATH,2070,23,Multivariable Calculus,0.18,0.29,0.29,0.18,0.06,0.0,0.0,0.0,marion hanna,
+MATH,2080,1,Intro to Ordin Diff Equations,0.13,0.16,0.47,0.16,0.03,0.0,0.0,0.06,matthew macauley,
+MATH,2080,2,Intro to Ordin Diff Equations,0.76,0.0,0.0,0.0,0.18,0.0,0.0,0.06,brandon gra goodell,
+MATH,2080,3,Intro to Ordin Diff Equations,0.36,0.28,0.17,0.03,0.11,0.0,0.0,0.06,matthew macauley,
+MATH,2080,4,Intro to Ordin Diff Equations,0.57,0.26,0.11,0.0,0.0,0.0,0.0,0.06,irina viktorova,
+MATH,2080,5,Intro to Ordin Diff Equations,0.03,0.21,0.29,0.15,0.15,0.0,0.0,0.18,julie lassiter,
+MATH,2080,6,Intro to Ordin Diff Equations,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,irina viktorova,
+MATH,2080,8,Intro to Ordin Diff Equations,0.09,0.11,0.16,0.23,0.18,0.0,0.0,0.23,julie lassiter,
+MATH,2080,9,Intro to Ordin Diff Equations,0.15,0.41,0.09,0.06,0.15,0.0,0.0,0.15,timothy fra parrott,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,2160,2,Geometry for Elem Sch Teachers,0.78,0.17,0.05,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,2500,1,Intro to Mathematical Sciences,0.78,0.11,0.0,0.0,0.07,0.0,0.0,0.04,matthew saltzman,
+MATH,3020,1,Stat for Science & Engineering,0.37,0.53,0.05,0.0,0.05,0.0,0.0,0.0,hewa priyadarshani,
+MATH,3020,2,Stat for Science & Engineering,0.53,0.28,0.08,0.06,0.03,0.0,0.0,0.03,derek brown,
+MATH,3020,3,Stat for Science & Engineering,0.26,0.4,0.17,0.06,0.03,0.0,0.0,0.09,derek brown,
+MATH,3020,4,Stat for Science & Engineering,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,hewa priyadarshani,
+MATH,3020,5,Stat for Science & Engineering,0.25,0.28,0.38,0.03,0.0,0.0,0.0,0.06,calvin williams,
+MATH,3020,6,Stat for Science & Engineering,0.42,0.24,0.21,0.06,0.0,0.0,0.0,0.06,calvin williams,
+MATH,3020,7,Stat for Science & Engineering,0.5,0.28,0.19,0.03,0.0,0.0,0.0,0.0,xiaoqian sun,
+MATH,3020,8,Stat for Science & Engineering,0.34,0.29,0.17,0.06,0.06,0.0,0.0,0.09,yanbo xia,
+MATH,3020,9,Stat for Science & Engineering,0.22,0.33,0.3,0.0,0.04,0.0,0.0,0.11,rachel eli grotheer,
+MATH,3110,1,Linear Algebra,0.16,0.32,0.36,0.08,0.04,0.0,0.0,0.04,michael adam burr,
+MATH,3110,2,Linear Algebra,0.32,0.21,0.13,0.11,0.18,0.0,0.0,0.05,xuhong gao,
+MATH,3110,3,Linear Algebra,0.41,0.19,0.05,0.16,0.14,0.0,0.0,0.05,xuhong gao,
+MATH,3110,4,Linear Algebra,0.24,0.37,0.16,0.16,0.08,0.0,0.0,0.0,kevin james,
+MATH,3110,5,Linear Algebra,0.17,0.37,0.23,0.09,0.06,0.0,0.0,0.09,felice manganiello,
+MATH,3160,1,Prob Solving for Math Teachers,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,3190,1,Introduction to Proof,0.19,0.38,0.15,0.04,0.19,0.0,0.0,0.04,elena sta dimitrova,
+MATH,3190,2,Introduction to Proof,0.54,0.23,0.15,0.04,0.0,0.0,0.0,0.04,elena sta dimitrova,
+MATH,3600,1,Intermediate Math Computing,0.61,0.16,0.0,0.0,0.06,0.0,0.0,0.16,neil calkin,
+MATH,3650,1,Numerical Mthds for Engineers,0.19,0.32,0.16,0.14,0.05,0.0,0.0,0.14,vincent ervin,
+MATH,3650,2,Numerical Mthds for Engineers,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,leo rebholz,
+MATH,3650,3,Numerical Mthds for Engineers,0.29,0.58,0.08,0.0,0.0,0.0,0.0,0.05,leo rebholz,
+MATH,3650,4,Numerical Mthds for Engineers,0.33,0.46,0.1,0.03,0.03,0.0,0.0,0.05,timo johann heister,
+MATH,4000,1,Theory of Probability,0.44,0.19,0.19,0.0,0.19,0.0,0.0,0.0,yingbo li,
+MATH,4000,2,Theory of Probability,0.33,0.28,0.11,0.06,0.11,0.0,0.0,0.11,yingbo li,
+MATH,4070,1,Regress & Time-Series Analysis,0.2,0.4,0.1,0.1,0.1,0.0,0.0,0.1,christopher mcmahan,
+MATH,4120,1,Algebra I,0.17,0.25,0.21,0.13,0.13,0.0,0.0,0.13,elena sta dimitrova,
+MATH,4190,1,Discrete Math Structures I,0.44,0.44,0.05,0.0,0.08,0.0,0.0,0.0,wayne goddard,
+MATH,4310,1,Theory of Interest,0.63,0.0,0.0,0.06,0.19,0.0,0.0,0.13,mark cawood,
+MATH,4340,1,Adv Engineering Mathematics,0.23,0.47,0.1,0.03,0.0,0.0,0.0,0.17,qingshan chen,
+MATH,4340,2,Adv Engineering Mathematics,0.29,0.25,0.14,0.14,0.0,0.0,0.0,0.18,eleanor jenkins,
+MATH,4400,1,Linear Programming,0.61,0.11,0.11,0.11,0.04,0.0,0.0,0.04,yuyuan ouyang,
+MATH,4410,1,Intro to Stochastic Models,0.65,0.12,0.12,0.0,0.0,0.0,0.0,0.12,peter kiessler,
+MATH,4530,1,Advanced Calculus I,0.27,0.41,0.14,0.14,0.05,0.0,0.0,0.0,taufiquar rahm khan,
+MATH,4530,2,Advanced Calculus I,0.3,0.26,0.17,0.13,0.13,0.0,0.0,0.0,shitao liu,
+MATH,6340,1,Adv Engineering Mathematics,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,vincent ervin,
+MATH,8000,1,Probability,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,robert lund,
+MATH,8010,1,General Linear Hypothesis I,0.3,0.5,0.15,0.0,0.0,0.0,0.0,0.05,xiaoqian sun,
+MATH,8050,1,Data Analysis,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,derek brown,
+MATH,8070,1,Applied Multivariate Analysis,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,8100,1,Mathematical Programming,0.68,0.09,0.05,0.0,0.0,0.0,0.0,0.18,margaret mar wiecek,
+MATH,8120,1,Discrete Optimization,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,akshay sunil gupte,
+MATH,8140,1,Network Flow Programming,0.14,0.71,0.14,0.0,0.0,0.0,0.0,0.0,warren adams,
+MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
+MATH,8210,1,Linear Analysis,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,
+MATH,8510,1,Abstract Algebra I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,james ba coykendall,
+MATH,8530,1,Matrix Analysis,0.22,0.39,0.28,0.0,0.0,0.0,0.0,0.11,felice manganiello,
+MATH,8600,1,Intro to Scientific Computing,0.44,0.22,0.33,0.0,0.0,0.0,0.0,0.0,qingshan chen,
+MATH,8650,1,Data Structures,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,timo johann heister,
+MATH,8840,1,Statistics for Experimenters,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+MBA,8030,1,Stat Analy of Bus Op,0.53,0.33,0.09,0.0,0.0,0.0,0.0,0.04,janis miller,
+MBA,8060,1,Operations Mgt,0.13,0.74,0.05,0.03,0.03,0.0,0.0,0.03, sridharan,
+MBA,8070,1,Financial Management,0.44,0.28,0.21,0.0,0.0,0.0,0.0,0.08,ramon tolb franklin,
+MBA,8090,1,Org Beh & Hum Res Mg,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8090,2,Org Beh & Hum Res Mg,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8190,1,Intro to Acc and Fin,0.53,0.39,0.05,0.0,0.0,0.0,0.0,0.03,annieka philo,
+MBA,8190,2,Intro to Acc and Fin,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,
+MBA,8290,1,Marketing Foundation,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MBA,8330,1,Real Estate Investmt,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,franklin bog wallin,
+MBA,8350,1,Investment Mgmt,0.39,0.46,0.07,0.04,0.0,0.0,0.0,0.04,john alexander,
+MBA,8360,1,Real Estate Principles,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,jeffrey randolph,
+MBA,8370,1,Legal Environ of Bus,0.43,0.55,0.02,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,prashant prabhu,
+MBA,8430,1,Entrepreneurial Accounting,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,sally kathr widener,
+MBA,8450,1,Technology & Innovation Mgt,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8490,5,Entrepreneurial Strategy,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8510,1,Bus Operations & Logistics,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09, sridharan,
+MBA,8590,1,Mgr Decision Model,0.39,0.36,0.17,0.03,0.03,0.0,0.0,0.03,sara elizabet yoder,
+MBA,8590,2,Mgr Decision Model,0.53,0.14,0.23,0.0,0.02,0.0,0.0,0.07,mark mcknew,
+MBA,8600,1,Advanced Marketing Strategy,0.48,0.42,0.09,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8600,2,Advanced Marketing Strategy,0.17,0.66,0.1,0.03,0.0,0.0,0.0,0.03,michael dorsch,
+MBA,8610,1,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MBA,8620,1,Managerial Economics,0.34,0.54,0.06,0.0,0.0,0.0,0.0,0.06,scott templeton,
+MBA,8620,2,Managerial Economics,0.6,0.33,0.03,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,
+MBA,8650,1,Taxation of Business Decisions,0.27,0.64,0.0,0.0,0.0,0.0,0.0,0.09,judson jahn,
+MBA,8700,1,Strategic Management,0.62,0.35,0.04,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
+MBA,8810,1,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,evguenia pas layton,
+MBA,8990,2,Creativity,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,
+MBA,8990,10,Selected Topics in Entrepreneu,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
+ME,2000,1,Sophomore Seminar,0.93,0.03,0.0,0.01,0.0,0.0,0.0,0.03,donald beasley,
+ME,2010,1,Statics & Dynamics,0.1,0.08,0.14,0.07,0.38,0.0,0.0,0.23,sherrill biggers,
+ME,2010,2,Statics & Dynamics,0.14,0.18,0.23,0.09,0.19,0.0,0.0,0.17,paul joseph,
+ME,2010,3,Statics & Dynamics,0.15,0.18,0.24,0.0,0.28,0.0,0.0,0.15,kalyan chakr katuri,
+ME,2030,1,Founda Th/Fl Syst,0.07,0.21,0.34,0.2,0.07,0.0,0.0,0.1,jay ochterbeck,
+ME,2040,1,Mechanics of Materials,0.16,0.42,0.3,0.06,0.03,0.0,0.0,0.03,garrett pataky,
+ME,2040,2,Mechanics of Materials,0.08,0.44,0.3,0.06,0.1,0.0,0.0,0.02,huijuan zhao,
+ME,2220,1,Mechanical Engineering Lab I,0.21,0.71,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,2,Mechanical Engineering Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,2220,3,Mechanical Engineering Lab I,0.35,0.5,0.05,0.0,0.0,0.0,0.0,0.1,todd schweisinger,
+ME,2220,4,Mechanical Engineering Lab I,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
+ME,2220,5,Mechanical Engineering Lab I,0.55,0.35,0.0,0.0,0.0,0.0,0.0,0.1,todd schweisinger,
+ME,2220,6,Mechanical Engineering Lab I,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,7,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,8,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,9,Mechanical Engineering Lab I,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3030,1,Thermodynamics,0.22,0.35,0.33,0.03,0.0,0.0,0.0,0.06,daniel fant,
+ME,3030,2,Thermodynamics,0.37,0.43,0.11,0.02,0.06,0.0,0.0,0.02,daniel fant,
+ME,3040,1,Heat Transfer,0.15,0.35,0.26,0.06,0.12,0.0,0.0,0.06,jean-marc delhaye,
+ME,3040,2,Heat Transfer,0.32,0.3,0.3,0.04,0.02,0.0,0.0,0.02,xin zhao,
+ME,3050,1,Model/an Dy Syst,0.16,0.34,0.34,0.09,0.07,0.0,0.0,0.0,todd schweisinger,
+ME,3050,2,Model/an Dy Syst,0.19,0.43,0.29,0.05,0.0,0.0,0.0,0.05,yue wang,
+ME,3060,1,Fund Machine Design,0.07,0.52,0.31,0.0,0.03,0.0,0.0,0.07,oliver myers,
+ME,3060,2,Fund Machine Design,0.2,0.4,0.22,0.13,0.02,0.0,0.0,0.02,paul jeffrey meyer,
+ME,3070,1,Found of Mechanical Systems,0.44,0.4,0.15,0.0,0.0,0.0,0.0,0.01,lonny thompson,
+ME,3070,2,Found of Mechanical Systems,0.17,0.41,0.21,0.12,0.03,0.0,0.0,0.05,georges fadel,
+ME,3080,1,Fluid Mechanics,0.07,0.22,0.29,0.12,0.17,0.0,0.0,0.12,jean-marc delhaye,
+ME,3080,2,Fluid Mechanics,0.23,0.4,0.26,0.07,0.02,0.0,0.0,0.02,xiangchun xuan,
+ME,3080,3,Fluid Mechanics,0.15,0.22,0.44,0.04,0.07,0.0,0.0,0.09,ethan kung,
+ME,3120,2,Manuf Processes,0.44,0.38,0.12,0.04,0.02,0.0,0.0,0.0,rod martinez-duarte,
+ME,3330,1,Mechanical Engineering Lab II,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,2,Mechanical Engineering Lab II,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,3,Mechanical Engineering Lab II,0.37,0.42,0.16,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
+ME,3330,4,Mechanical Engineering Lab II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,5,Mechanical Engineering Lab II,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,todd schweisinger,
+ME,3330,6,Mechanical Engineering Lab II,0.07,0.79,0.14,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,7,Mechanical Engineering Lab II,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,todd schweisinger,
+ME,3330,8,Mechanical Engineering Lab II,0.27,0.36,0.09,0.0,0.0,0.0,0.0,0.27,todd schweisinger,
+ME,4000,1,Senior Seminar,0.96,0.03,0.0,0.01,0.0,0.0,0.0,0.0, ramasubramanian,
+ME,4010,1,Mech Engr Design,0.08,0.66,0.16,0.09,0.01,0.0,0.0,0.0,joshua summers,
+ME,4020,2,Intern in Engr Des,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,4020,3,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,4020,4,Intern in Engr Des,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
+ME,4030,1,Control Dynamic Systems,0.3,0.28,0.3,0.11,0.0,0.0,0.0,0.01,ardalan vahidi,
+ME,4030,2,Control Dynamic Systems,0.27,0.51,0.2,0.02,0.0,0.0,0.0,0.0,seye parvini oskoui,
+ME,4180,1,F E A in M E Design,0.63,0.3,0.03,0.0,0.0,0.0,0.0,0.03,gang li,
+ME,4200,1,Ener Sources/Utiliz,0.54,0.43,0.03,0.0,0.0,0.0,0.0,0.0,donald beasley,
+ME,4210,1,Intro to Comp Flow,0.27,0.27,0.33,0.07,0.0,0.0,0.0,0.07,chenning tong,
+ME,4400,1,Matls for Aggr Envir,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mica grujicic,
+ME,4440,1,Mechanical Engineering Lab III,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,2,Mechanical Engineering Lab III,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,3,Mechanical Engineering Lab III,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,4,Mechanical Engineering Lab III,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,7,Mechanical Engineering Lab III,0.0,0.83,0.0,0.0,0.08,0.0,0.0,0.08,john wagner,
+ME,4540,1,Design of Machine Elements,0.52,0.3,0.06,0.03,0.03,0.0,0.0,0.06,paul jeffrey meyer,
+ME,4930,36,Selected Topics ME - BioDesign,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,michael porter,
+ME,6210,1,Intro to Comp Flow,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
+ME,6540,1,Des Machine Elements,0.57,0.36,0.0,0.0,0.07,0.0,0.0,0.0,paul jeffrey meyer,
+ME,8010,1,Found of Fluid Mech,0.29,0.5,0.17,0.0,0.0,0.0,0.0,0.04,richard figliola,
+ME,8100,1,Macroscopic Thermo,0.32,0.6,0.08,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,
+ME,8140,1,Turb Bound Layer,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,richard miller,
+ME,8180,1,Intro to Fin Ele Ana,0.75,0.23,0.02,0.0,0.0,0.0,0.0,0.0,lonny thompson,
+ME,8230,1,Control Systems,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,8370,1,Theory of Elast I,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
+ME,8460,1,Inter Dynamics,0.19,0.57,0.19,0.05,0.0,0.0,0.0,0.0,phanin tallapragada,
+ME,8700,1,Adv Design Methods,0.34,0.66,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,8710,1,Engr Optimization,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,8930,27,Sel Topics in Mechanical Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+MGT,2010,1,Principles of Management,0.33,0.41,0.17,0.03,0.04,0.0,0.0,0.03,katherine clark,
+MGT,2010,2,Principles of Management,0.32,0.41,0.16,0.05,0.03,0.0,0.0,0.03,katherine clark,
+MGT,2010,3,Principles of Management,0.36,0.36,0.22,0.03,0.01,0.0,0.0,0.03,katherine clark,
+MGT,2010,4,Principles of Management,0.13,0.44,0.28,0.07,0.03,0.0,0.0,0.04,katherine clark,
+MGT,2010,5,Principles of Management,0.22,0.36,0.34,0.02,0.02,0.0,0.0,0.05,tina robbins,
+MGT,2010,6,Principles of Management,0.4,0.41,0.15,0.01,0.01,0.0,0.0,0.01,tina robbins,
+MGT,2010,7,Principles of Management,0.33,0.46,0.11,0.07,0.03,0.0,0.0,0.0,tina robbins,
+MGT,2010,8,Principles of Management,0.42,0.42,0.14,0.0,0.01,0.0,0.0,0.0,tina robbins,
+MGT,2010,9,Principles of Mgt(HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
+MGT,2180,1,Management PC Applications,0.5,0.29,0.12,0.02,0.0,0.0,0.0,0.07,ryan toole,
+MGT,2180,2,Management PC Applications,0.5,0.33,0.04,0.02,0.06,0.0,0.0,0.05,ryan toole,
+MGT,2180,3,Management PC Applications,0.42,0.33,0.16,0.02,0.02,0.0,0.0,0.05,ryan toole,
+MGT,2180,4,Management PC Applications,0.47,0.28,0.14,0.02,0.05,0.0,0.0,0.04,ryan toole,
+MGT,2970,1,CI - How to Start a Startup,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,matthew charl klein,
+MGT,2970,2,CI - How to Start a Startup,0.5,0.14,0.0,0.0,0.0,0.0,0.0,0.36,gregory pickett,
+MGT,3070,1,Human Resource Management,0.38,0.51,0.08,0.0,0.0,0.0,0.0,0.03,michael cole,
+MGT,3070,3,Human Resource Management,0.16,0.34,0.39,0.02,0.02,0.0,0.0,0.07,kristin dam scott,
+MGT,3070,4,Human Resource Management,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,priscilla harrison,
+MGT,3070,5,Human Resource Management,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,6,Human Resource Management,0.53,0.35,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,7,Human Resource Management,0.33,0.54,0.05,0.05,0.03,0.0,0.0,0.0,michael cole,
+MGT,3100,1,Intermed Business Statistics,0.23,0.19,0.29,0.06,0.13,0.0,0.0,0.1,sara elizabet yoder,
+MGT,3100,2,Intermed Business Statistics,0.28,0.13,0.3,0.08,0.13,0.0,0.0,0.1,sara elizabet yoder,
+MGT,3100,3,Intermed Business Statistics,0.15,0.18,0.3,0.1,0.13,0.0,0.0,0.15,sara elizabet yoder,
+MGT,3100,5,Intermed Business Statistics,0.32,0.15,0.18,0.09,0.09,0.0,0.0,0.18,jerry kermi bilbrey,
+MGT,3100,6,Intermed Business Statistics,0.53,0.25,0.06,0.03,0.03,0.0,0.0,0.11,jerry kermi bilbrey,
+MGT,3100,7,Intermed Business Statistics,0.35,0.3,0.24,0.03,0.0,0.0,0.0,0.08,jerry kermi bilbrey,
+MGT,3100,8,Intermed Business Statistics,0.33,0.25,0.15,0.05,0.1,0.0,0.0,0.13,remi charpin,
+MGT,3100,9,Intermed Business Statistics,0.33,0.2,0.23,0.13,0.05,0.0,0.0,0.08,min kyung lee,
+MGT,3100,10,Intermed Business Statistics,0.58,0.28,0.06,0.0,0.08,0.0,0.0,0.0,shih lun tseng,
+MGT,3100,11,Intermed Business Statistics,0.47,0.25,0.11,0.03,0.0,0.0,0.0,0.14,iaroslava dutchak,
+MGT,3100,12,Intermed Business Statistics,0.25,0.28,0.19,0.03,0.11,0.0,0.0,0.14,yunsik choi,
+MGT,3100,13,Intermed Business Statistics,0.16,0.32,0.21,0.05,0.11,0.0,0.0,0.16,jerry kermi bilbrey,
+MGT,3120,1,Decision Models for Management,0.15,0.46,0.17,0.02,0.15,0.0,0.0,0.05,mark mcknew,
+MGT,3120,2,Decision Models for Management,0.4,0.24,0.24,0.02,0.07,0.0,0.0,0.02,mark mcknew,
+MGT,3120,3,Decision Models for Management,0.3,0.17,0.37,0.04,0.09,0.0,0.0,0.02,mark mcknew,
+MGT,3150,1,New Venture Creation,0.4,0.33,0.18,0.03,0.03,0.0,0.0,0.05,elizabeth er powell,
+MGT,3170,1,Logistics Mgmt,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,shouqiang wang,
+MGT,3180,1,Mgt of Info Systems,0.26,0.6,0.14,0.0,0.0,0.0,0.0,0.0,heshan sun,
+MGT,3180,2,Mgt of Info Systems,0.2,0.6,0.15,0.05,0.0,0.0,0.0,0.0,roopa raman,
+MGT,3180,3,Mgt of Info Systems,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,
+MGT,3180,4,Mgt of Info Systems,0.63,0.28,0.04,0.02,0.02,0.0,0.0,0.0,jackie patri london,
+MGT,3900,1,Ops Mgt,0.24,0.37,0.24,0.11,0.03,0.0,0.0,0.03,yann ferrand,
+MGT,3900,2,Ops Mgt,0.68,0.2,0.08,0.0,0.0,0.0,0.0,0.05,berna quiroga gomez,
+MGT,3900,3,Ops Mgt,0.0,0.58,0.29,0.06,0.03,0.0,0.0,0.03,zachary mo leffakis,
+MGT,3900,4,Ops Mgt,0.56,0.28,0.08,0.03,0.0,0.0,0.0,0.05,brandon woohyeo lee,
+MGT,3900,5,Ops Mgt,0.49,0.27,0.11,0.0,0.03,0.0,0.0,0.11,berna quiroga gomez,
+MGT,4000,1,Mgt of Organizational Behavior,0.27,0.5,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MGT,4000,2,Mgt of Organizational Behavior,0.39,0.39,0.14,0.03,0.0,0.0,0.0,0.06,michael cole,
+MGT,4000,3,Mgt of Organizational Behavior,0.33,0.23,0.3,0.02,0.07,0.0,0.0,0.05,philip roth,
+MGT,4020,1,Ops Pln and Ctl,0.25,0.25,0.44,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,
+MGT,4030,1,Special Problems,0.09,0.55,0.18,0.0,0.0,0.0,0.0,0.18,siyuan li,
+MGT,4080,1,Lean Operations,0.25,0.33,0.33,0.0,0.0,0.0,0.0,0.08,zachary mo leffakis,
+MGT,4110,1,Project Management,0.29,0.56,0.1,0.0,0.0,0.0,0.0,0.05,russell purvis,
+MGT,4120,1,Supplier Management,0.19,0.58,0.13,0.03,0.03,0.0,0.0,0.03,shouqiang wang,
+MGT,4150,1,Business Strategy,0.6,0.38,0.0,0.02,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,3,Business Strategy,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,4,Business Strategy,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,7,Business Strategy,0.25,0.66,0.05,0.02,0.02,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,8,Business Strategy,0.09,0.66,0.11,0.0,0.06,0.0,0.0,0.09,amy elizabet ingram,
+MGT,4150,9,Business Strategy,0.18,0.49,0.28,0.0,0.0,0.0,0.0,0.05,peter gianiodis,
+MGT,4160,1,Special Topics Hr,0.22,0.64,0.11,0.03,0.0,0.0,0.0,0.0,kristin dam scott,
+MGT,4230,1,Intern Bus Mgt,0.25,0.23,0.35,0.03,0.08,0.0,0.0,0.08,wayne stewart,
+MGT,4230,2,Intern Bus Mgt,0.11,0.26,0.47,0.0,0.05,0.0,0.0,0.11,wayne stewart,
+MGT,4230,3,Intern Bus Mgt,0.06,0.32,0.32,0.06,0.19,0.0,0.0,0.03,janis miller,
+MGT,4230,4,Intern Bus Mgt,0.14,0.51,0.32,0.03,0.0,0.0,0.0,0.0,janis miller,
+MGT,4240,1,Global Supply Chain,0.17,0.66,0.14,0.0,0.0,0.0,0.0,0.03,yann ferrand,
+MGT,4270,1,Managing Improvement,0.07,0.5,0.29,0.07,0.0,0.0,0.0,0.07,lawrence fredendall,
+MGT,4300,2,Senior Seminar in Management,0.83,0.0,0.0,0.0,0.17,0.0,0.0,0.0,david leo bodde,
+MGT,4310,1,Emp Rights & Resp,0.48,0.28,0.2,0.0,0.0,0.0,0.0,0.05,leonard jos spooner,
+MGT,4310,2,Emp Rights & Resp,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,4350,1,Pers Interviewing,0.44,0.38,0.13,0.04,0.0,0.0,0.0,0.0,philip roth,
+MGT,4520,1,Business Analysis,0.2,0.4,0.2,0.07,0.07,0.0,0.0,0.07,roopa raman,
+MGT,4550,1,Emerging I T Trends,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MGT,8690,1,Project Mgt,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
+MICR,2050,1,Introductory Micro,0.46,0.42,0.09,0.0,0.01,0.0,0.0,0.03,john abercrombie,
+MICR,3000,1,Essential Skills in Microbiol,0.59,0.37,0.0,0.0,0.02,0.0,0.0,0.02,tamara lyn mcnealy,
+MICR,3050,1,General Microbiology,0.37,0.4,0.15,0.05,0.01,0.0,0.0,0.02,krista barr rudolph,
+MICR,3050,2,General Microbiology,0.43,0.33,0.22,0.01,0.0,0.0,0.0,0.01,krista barr rudolph,
+MICR,4010,1,Microbial Diversity & Ecology,0.2,0.5,0.24,0.02,0.02,0.0,0.0,0.02,barbara campbell,
+MICR,4030,1,Marine Microbiology,0.2,0.4,0.0,0.1,0.1,0.0,0.0,0.2,john michael henson,
+MICR,4050,1,Adv Microbial Ecol of Humans,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4140,1,Basic Immunology,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,yanzhang wei,
+MICR,4150,1,Microbial Genetics,0.4,0.33,0.07,0.17,0.0,0.0,0.0,0.03,min cao,
+MICR,4160,1,Intro Virology,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,simon scott,
+MICR,4510,1,Advanced Microbiology II,0.62,0.23,0.15,0.0,0.0,0.0,0.0,0.0,min cao,
+MICR,4510,2,Advanced Microbiology II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,min cao,
+MKT,3010,2,Prin of Marketing,0.3,0.41,0.23,0.01,0.04,0.0,0.0,0.01,carter wil mcelveen,
+MKT,3010,3,Prin of Marketing,0.41,0.39,0.17,0.02,0.01,0.0,0.0,0.0,carter wil mcelveen,
+MKT,3010,4,Prin of Marketing,0.23,0.4,0.22,0.11,0.03,0.0,0.0,0.01,carter wil mcelveen,
+MKT,3010,5,Prin of Marketing,0.27,0.39,0.25,0.08,0.0,0.0,0.0,0.01,amanda cooper fine,
+MKT,3010,6,Prin of Marketing,0.36,0.42,0.14,0.06,0.02,0.0,0.0,0.0,amanda cooper fine,
+MKT,3010,7,Prin of Marketing,0.24,0.41,0.21,0.07,0.03,0.0,0.0,0.04,amanda cooper fine,
+MKT,3010,8,Prin of Marketing,0.49,0.3,0.12,0.02,0.04,0.0,0.0,0.02,patricia knowles,
+MKT,3010,9,Prin of Marketing(HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james gaubert,True
+MKT,3020,1,Consumer Behavior,0.4,0.46,0.15,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,2,Consumer Behavior,0.66,0.3,0.02,0.0,0.02,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,3,Consumer Behavior,0.36,0.49,0.09,0.06,0.0,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3020,4,Consumer Behavior,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3210,1,Sports Marketing,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3210,2,Sports Marketing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3310,1,Marketing Metrics & Analytics,0.24,0.41,0.12,0.24,0.0,0.0,0.0,0.0,peter weathers,
+MKT,4200,1,Professional Selling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4200,2,Professional Selling,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,3,Professional Selling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,4,Professional Selling,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4230,1,Promotional Strategy,0.27,0.48,0.23,0.0,0.02,0.0,0.0,0.0,patricia knowles,
+MKT,4240,1,Sales Management,0.38,0.55,0.03,0.0,0.0,0.0,0.0,0.03,ryan mullins,
+MKT,4260,1,Business-to-Business,0.54,0.41,0.03,0.0,0.0,0.0,0.0,0.03,james gaubert,
+MKT,4260,2,Business-to-Business,0.31,0.55,0.1,0.0,0.02,0.0,0.0,0.02,james gaubert,
+MKT,4270,1,International Mktg,0.32,0.48,0.09,0.07,0.0,0.0,0.0,0.05,roger gomes,
+MKT,4270,2,International Mktg,0.18,0.34,0.25,0.11,0.05,0.0,0.0,0.07,roger gomes,
+MKT,4270,3,International Mktg,0.27,0.31,0.31,0.04,0.02,0.0,0.0,0.04,roger gomes,
+MKT,4270,4,International Mktg,0.33,0.49,0.18,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
+MKT,4280,1,Services Marketing,0.39,0.55,0.05,0.0,0.0,0.0,0.0,0.02,stephen grove,
+MKT,4280,2,Services Marketing,0.44,0.28,0.22,0.0,0.06,0.0,0.0,0.0,stephen grove,
+MKT,4310,1,Marketing Research,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,peter weathers,
+MKT,4310,2,Marketing Research,0.3,0.67,0.0,0.0,0.0,0.0,0.0,0.04,scott darren swain,
+MKT,4310,3,Marketing Research,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,4,Marketing Research,0.29,0.36,0.29,0.0,0.0,0.0,0.0,0.07,william kilbourne,
+MKT,4430,1,Advertising Strategy,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,
+MKT,4450,1,Macromarketing,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.31,0.59,0.1,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,2,Strategic Mktg Mgt,0.19,0.61,0.19,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,8610,1,Marketing Research,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,christopher hopkins,
+MKT,8630,1,Buyer Behavior,0.48,0.44,0.07,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
+ML,1010,1,Leadership Fund I,0.85,0.0,0.0,0.0,0.07,0.0,0.0,0.07,amanda carol kane,
+ML,2010,1,Leadership Development I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,thierry andre bras,
+ML,2010,2,Leadership Development I,0.71,0.19,0.05,0.05,0.0,0.0,0.0,0.0,thierry andre bras,
+ML,4010,1,Organizational Leadership I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
+MSE,2100,2,Intro to Mat Science,0.35,0.32,0.17,0.05,0.04,0.0,0.0,0.06,eric skaar,
+MSE,2100,3,Intro to Mat Science,0.37,0.4,0.11,0.02,0.06,0.0,0.0,0.04,eric skaar,
+MSE,2100,4,Intro to Mat Science,0.35,0.34,0.17,0.06,0.06,0.0,0.0,0.02,marian kennedy,
+MSE,2410,1,Metrics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
+MSE,3190,2,Materials Proc I,0.46,0.44,0.07,0.02,0.0,0.0,0.0,0.01,olin mefford,
+MSE,3260,1,Thermo of Materials,0.31,0.47,0.08,0.08,0.0,0.0,0.0,0.06,gary lickfield,
+MSE,3260,2,Thermo of Materials,0.03,0.45,0.29,0.16,0.0,0.0,0.0,0.06,gary lickfield,
+MSE,3270,1,Transport Phenomena,0.78,0.11,0.07,0.04,0.0,0.0,0.0,0.01,konstantin kornev,
+MSE,4020,1,Solid State Material,0.24,0.42,0.27,0.03,0.03,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,4130,1,Noncrystalline Materials,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,fei peng,
+MSE,4150,1,Polymer Sc Engr,0.42,0.36,0.19,0.04,0.0,0.0,0.0,0.0,igor luzinov,
+MSE,4150,2,Polymer Sc Engr,0.51,0.37,0.11,0.0,0.01,0.0,0.0,0.0,olin mefford,
+MSE,4320,1,Manuf Proc & Systems,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,denis brosnan,
+MSE,4410,1,Mfg Laboratory,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,denis brosnan,
+MSE,4550,3,Polymer Fiber Lab,0.64,0.18,0.09,0.09,0.0,0.0,0.0,0.0,olin mefford,
+MSE,4580,1,Surf Phen in Ms&E,0.24,0.44,0.2,0.12,0.0,0.0,0.0,0.0,konstantin kornev,
+MSE,4610,1,Polymer & Fiber Materials III,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,
+MSE,4910,1,Undergraduate Research,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,marian kennedy,
+MSE,8100,1,Fundamentals of Materials Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,
+MSE,8270,1,Kin of Phase Tran,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,
+MSE,8510,1,Polymer Science I,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,gary lickfield,
+MUSC,1110,9,Beginning Class Guitar,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,david stevenson,
+MUSC,1420,1,Music Theory I,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,anthony bernarducci,
+MUSC,1420,2,Music Theory I,0.72,0.06,0.17,0.0,0.0,0.0,0.0,0.06,anthony bernarducci,
+MUSC,1430,1,Aural Skills I,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,anthony bernarducci,
+MUSC,1430,2,Aural Skills I,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,anthony bernarducci,
+MUSC,2100,1,Music in the Western World,0.77,0.1,0.1,0.0,0.03,0.0,0.0,0.0,eric lapin,
+MUSC,2100,2,Music in the Western World,0.71,0.13,0.1,0.06,0.0,0.0,0.0,0.0,lisa sain odom,
+MUSC,2100,3,Music in the Western World,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,eric lapin,
+MUSC,2100,4,Music in the Western World,0.58,0.23,0.1,0.03,0.06,0.0,0.0,0.0,linda li-bleuel,
+MUSC,2100,5,Music in the Western World,0.83,0.13,0.03,0.0,0.0,0.0,0.0,0.03,timothy ra hurlburt,
+MUSC,2100,6,Music in the Western World,0.5,0.38,0.09,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
+MUSC,2100,7,Music in the Western World,0.56,0.34,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
+MUSC,2100,8,Music in the Western World,0.58,0.32,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
+MUSC,2100,9,Music in the Western World,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,evan michael jacobi,
+MUSC,2100,10,Music in the Western World,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,linda dzuris,
+MUSC,2100,12,Music in the Western World,0.65,0.32,0.03,0.0,0.0,0.0,0.0,0.0,lea kibler,
+MUSC,2100,15,Music in West World (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,True
+MUSC,3110,1,History of American Music,0.5,0.34,0.06,0.09,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,eric lapin,
+MUSC,3130,1,Hist of Rock & Roll,0.61,0.29,0.04,0.0,0.04,0.0,0.0,0.04,hamilton altstatt,
+MUSC,3170,1,Hist of Country Mus,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,ned hosler,
+MUSC,3180,1,Hist of Audio Tech,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,
+MUSC,3610,1,Marching Band,0.97,0.02,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
+MUSC,3690,1,Symphony Orchestra,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,andrew levin,True
+MUSC,3710,1,Women's Chorus,0.95,0.0,0.0,0.0,0.03,0.0,0.0,0.02,justin durham,
+MUSC,3720,1,Men's Chorus,0.89,0.04,0.0,0.0,0.04,0.0,0.0,0.04,anthony bernarducci,
+MUSC,4150,1,Music Hist to 1750,0.15,0.23,0.31,0.23,0.08,0.0,0.0,0.0,justin durham,
+NPL,3000,1,Nonprofit Leadership,0.84,0.06,0.03,0.0,0.0,0.0,0.0,0.06,tracy diane lamb,
+NPL,3000,3,Nonprofit Leadership,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,james dougl bennett,
+NPL,3020,1,NPL Fundraising,0.69,0.15,0.08,0.0,0.08,0.0,0.0,0.0,robert frager,
+NPL,3040,1,NPL Risk Management,0.46,0.46,0.0,0.08,0.0,0.0,0.0,0.0,anthony shau catone,
+NURS,1020,1,Nrsg Success Skills,0.77,0.22,0.0,0.01,0.0,0.0,0.0,0.0,kristin goodenow,
+NURS,1400,1,Comp App Hlth Care,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
+NURS,3030,1,Nursing of Adults,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,
+NURS,3040,1,Pathophysiology,0.27,0.58,0.08,0.06,0.02,0.0,0.0,0.0,catherine si murton,
+NURS,3040,400,Pathophysiology,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,catherine si murton,
+NURS,3040,401,Pathophysiology,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
+NURS,3100,1,Health Assessment,0.47,0.51,0.02,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
+NURS,3100,400,Health Assessment,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,
+NURS,3120,1,Foundations of Nursing,0.45,0.51,0.04,0.0,0.0,0.0,0.0,0.0,angela pye,
+NURS,3120,400,Foundations of Nursing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3300,2,Research in Nursing,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,3400,1,Pharmther Nursing,0.27,0.61,0.08,0.02,0.02,0.0,0.0,0.0,catherine si murton,
+NURS,3400,400,Pharmther Nursing,0.27,0.58,0.15,0.0,0.0,0.0,0.0,0.0,catherine si murton,
+NURS,3600,400,Social Determinants in Health,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,roxanne amerson,
+NURS,4030,200,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
+NURS,4110,1,Nursing of Children,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
+NURS,4120,1,Nurs Women and Fam,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4250,200,Community Nursing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
+NURS,8050,400,Pharmaco Adv Nurs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8060,400,Advan Assessment for Nursing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,
+NURS,8090,400,Pathophysiology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
+NURS,8200,400,Child & Adol Nursing,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.44,0.36,0.09,0.04,0.01,0.0,0.0,0.05,deborah an hutcheon,
+NUTR,2050,1,Nutr for Nurs Prof,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
+NUTR,2160,1,Evidence-Based Nutrition,0.44,0.38,0.1,0.02,0.03,0.0,0.0,0.03,angela fraser,
+NUTR,4180,1,Prof Development in Dietetics,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
+NUTR,4190,1,Professional Dev in Nutrition,0.92,0.0,0.0,0.04,0.04,0.0,0.0,0.0,angela fraser,
+NUTR,4240,1,Medical Nutr Thera I,0.63,0.35,0.02,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4510,1,Human Nutrition,0.43,0.22,0.14,0.07,0.09,0.0,0.0,0.05,michell bohan brown,
+NUTR,6510,1,Human Nutrition,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michell bohan brown,
+PA,1010,1,Intro to Perf Arts,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,david hartmann,
+PA,1030,1,Portfolio I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,linda dzuris,
+PA,2790,1,Perf Arts Pract I,0.69,0.19,0.0,0.0,0.13,0.0,0.0,0.0,kenneth moore,
+PA,3010,1,Prin of Arts Admin,0.81,0.13,0.0,0.06,0.0,0.0,0.0,0.0,paul buyer,
+PA,4010,1,Capstone Project,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
+PADM,7020,400,Research Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
+PADM,7020,401,Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
+PADM,8210,400,Perspectives on Public Admin,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,mark daniel mellott,
+PADM,8270,400,Public Personnel Admin,0.56,0.22,0.0,0.0,0.0,0.0,0.0,0.22,lawrence nichols,
+PADM,8290,400,Public Financial Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,
+PADM,8670,400,State Government Admin,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,alfred bundrick,
+PADM,8710,400,Sustainability Practices Appli,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
+PADM,8780,400,Legal Aspects of Nonprofits,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,anthony shau catone,
+PADM,8780,401,Local Govt Budgeting & Finance,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,kevin yokim,
+PAS,3010,1,Pan African Studies,0.17,0.56,0.25,0.02,0.01,0.0,0.0,0.0,abel bartley,
+PDBE,8100,1,Contemporary Issues in EDP,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
+PES,1040,1,Introduction to Plant Sciences,0.67,0.17,0.0,0.0,0.03,0.0,0.0,0.13,paula agudelo,
+PES,2020,1,Soils,0.12,0.45,0.3,0.12,0.0,0.0,0.0,0.01,dara michelle park,
+PES,4090,1,Biology of Invasive Plants,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,
+PES,4210,1,Princ of Field Crop Production,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,sruthi naraya kutty,
+PHIL,1010,2,Intro to Philosophic Problems,0.53,0.17,0.13,0.03,0.1,0.0,0.0,0.03,adam gies,
+PHIL,1010,3,Intro to Philosophic Problems,0.4,0.4,0.11,0.06,0.0,0.0,0.0,0.03,christopher grau,
+PHIL,1010,4,Intro to Philosophic Problems,0.47,0.3,0.03,0.1,0.07,0.0,0.0,0.03,john randall wolfe,
+PHIL,1020,1,Introduction to Logic,0.62,0.21,0.03,0.0,0.09,0.0,0.0,0.06,david stegall,
+PHIL,1020,2,Introduction to Logic,0.43,0.37,0.06,0.03,0.06,0.0,0.0,0.06,david stegall,
+PHIL,1020,3,Introduction to Logic,0.76,0.18,0.03,0.03,0.0,0.0,0.0,0.0,gregory scott moss,
+PHIL,1020,4,Introduction to Logic,0.74,0.15,0.03,0.03,0.0,0.0,0.0,0.06,gregory scott moss,
+PHIL,1020,5,Introduction to Logic,0.71,0.18,0.09,0.0,0.03,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,6,Introduction to Logic,0.68,0.21,0.06,0.03,0.0,0.0,0.0,0.03,michael hal hannen,
+PHIL,1030,1,Intro to Ethics (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True
+PHIL,1030,2,Introduction to Ethics,0.54,0.31,0.06,0.0,0.0,0.0,0.0,0.09,michael hal hannen,
+PHIL,1030,3,Introduction to Ethics,0.31,0.49,0.17,0.0,0.0,0.0,0.0,0.03,ryan lake,
+PHIL,1030,4,Introduction to Ethics,0.26,0.68,0.06,0.0,0.0,0.0,0.0,0.0,ryan lake,
+PHIL,1030,5,Introduction to Ethics,0.29,0.29,0.15,0.15,0.0,0.0,0.0,0.12,malcolm edwa munson,
+PHIL,1030,6,Introduction to Ethics,0.21,0.32,0.12,0.12,0.09,0.0,0.0,0.15,malcolm edwa munson,
+PHIL,1030,9,Introduction to Ethics,0.29,0.24,0.18,0.18,0.12,0.0,0.0,0.0,adam gies,
+PHIL,1030,10,Introduction to Ethics,0.72,0.16,0.09,0.03,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1030,11,Introduction to Ethics,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,adam gies,
+PHIL,3040,1,Moral Philosophy,0.36,0.33,0.15,0.03,0.12,0.0,0.0,0.0,charles starkey,
+PHIL,3120,1,Philosophy in Ancient China,0.29,0.38,0.03,0.06,0.09,0.0,0.0,0.15,yanming an,
+PHIL,3150,1,Ancient Philosophy,0.26,0.37,0.22,0.07,0.07,0.0,0.0,0.0,stephen satris,
+PHIL,3160,1,Modern Philosophy,0.63,0.28,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
+PHIL,3170,1,19th-Century Philosophy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,gregory scott moss,
+PHIL,3180,1,20th-Century Philosophy,0.63,0.3,0.0,0.04,0.04,0.0,0.0,0.0,john randall wolfe,
+PHIL,3240,1,Philosophy of Tech,0.38,0.44,0.03,0.03,0.03,0.0,0.0,0.09,andrew garnar,
+PHIL,3260,1,Science and Values,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,andrew garnar,
+PHIL,3260,2,Science and Values,0.47,0.38,0.06,0.0,0.03,0.0,0.0,0.06,andrew garnar,
+PHIL,3260,3,Science and Values,0.42,0.52,0.03,0.0,0.0,0.0,0.0,0.03,andrew garnar,
+PHIL,3330,1,Metaphysics,0.81,0.0,0.05,0.0,0.0,0.0,0.0,0.14,david stegall,
+PHIL,3430,1,Philosophy of Law,0.29,0.38,0.15,0.06,0.06,0.0,0.0,0.06,jennifer ingle,
+PHIL,3440,1,Business Ethics,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,david stegall,
+PHIL,3450,1,Environmental Ethics,0.74,0.19,0.03,0.0,0.03,0.0,0.0,0.0,john randall wolfe,
+PHIL,3450,2,Environmental Ethics,0.74,0.19,0.03,0.03,0.0,0.0,0.0,0.0,john randall wolfe,
+PHIL,3480,1,Philosophies of Art,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,christopher grau,
+PHIL,3490,1,Gender and Sexuality,0.75,0.04,0.08,0.04,0.0,0.0,0.0,0.08,jennifer ingle,
+PHIL,3550,1,Philosophy of Mind & Cog Scien,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,ryan lake,
+PHIL,4020,1,Topics in Philosophy,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,ryan lake,
+PHIL,4220,1,Anarchism,0.44,0.28,0.17,0.0,0.06,0.0,0.0,0.06,todd may,
+PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics with Calculus I,0.25,0.3,0.29,0.07,0.05,0.0,0.0,0.04,lih-sin the,
+PHYS,1220,2,Physics with Calculus I,0.23,0.26,0.29,0.09,0.06,0.0,0.0,0.08,lih-sin the,
+PHYS,1220,4,Physics with Calculus I,0.4,0.15,0.15,0.05,0.15,0.0,0.0,0.1,murray daw,
+PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,2,Physics Lab I,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,3,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,4,Physics Lab I,0.18,0.71,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
+PHYS,1240,5,Physics Lab I,0.0,0.72,0.06,0.0,0.0,0.0,0.0,0.22,jerry hester,
+PHYS,1240,6,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,7,Physics Lab I,0.56,0.25,0.13,0.0,0.06,0.0,0.0,0.0,jerry hester,
+PHYS,1240,8,Physics Lab I,0.28,0.61,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,
+PHYS,1240,9,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,10,Physics Lab I,0.33,0.44,0.11,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,11,Physics Lab I,0.29,0.41,0.18,0.06,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,12,Physics Lab I,0.17,0.56,0.17,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,13,Physics Lab I,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,15,Physics Lab I,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,16,Physics Lab I,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,1240,17,Physics Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2070,1,General Physics I,0.39,0.36,0.14,0.04,0.03,0.0,0.0,0.03,amy liann pope,
+PHYS,2070,2,General Physics I,0.42,0.33,0.19,0.03,0.01,0.0,0.0,0.02,amy liann pope,
+PHYS,2070,3,General Physics I,0.27,0.39,0.2,0.06,0.07,0.0,0.0,0.03,pooja puneet,
+PHYS,2080,1,General Physics II,0.31,0.42,0.16,0.05,0.04,0.0,0.0,0.02,pooja puneet,
+PHYS,2090,1,Gen Phys Lab I,0.54,0.29,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,2,Gen Phys Lab I,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,3,Gen Phys Lab I,0.29,0.54,0.08,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,4,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,5,Gen Phys Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,6,Gen Phys Lab I,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,7,Gen Phys Lab I,0.83,0.09,0.0,0.0,0.04,0.0,0.0,0.04,jerry hester,
+PHYS,2090,8,Gen Phys Lab I,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,9,Gen Phys Lab I,0.58,0.33,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,10,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,11,Gen Phys Lab I,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,
+PHYS,2090,12,Gen Phys Lab I,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,13,Gen Phys Lab I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,14,Gen Phys Lab I,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,
+PHYS,2090,15,Gen Phys Lab I,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,16,Gen Phys Lab I,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,17,Gen Phys Lab I,0.44,0.48,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,18,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,19,Gen Phys Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,20,Gen Phys Lab I,0.73,0.23,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,21,Gen Phys Lab I,0.43,0.35,0.13,0.0,0.04,0.0,0.0,0.04,jerry hester,
+PHYS,2090,22,Gen Phys Lab I,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,23,Gen Phys Lab I,0.36,0.55,0.05,0.0,0.05,0.0,0.0,0.0,jerry hester,
+PHYS,2090,24,Gen Phys Lab I,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,2,Gen Phys Lab II,0.7,0.17,0.04,0.0,0.0,0.0,0.0,0.09,jerry hester,
+PHYS,2100,3,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,4,Gen Phys Lab II,0.82,0.09,0.0,0.05,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2100,7,Gen Phys Lab II,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,
+PHYS,2100,8,Gen Phys Lab II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2210,1,Physics with Calculus II,0.26,0.43,0.19,0.08,0.02,0.0,0.0,0.02,jason stratfo brown,
+PHYS,2210,2,Physics with Calculus II,0.31,0.48,0.13,0.02,0.03,0.0,0.0,0.03,jason stratfo brown,
+PHYS,2210,3,Physics with Calculus II,0.35,0.51,0.1,0.02,0.01,0.0,0.0,0.0,jason stratfo brown,
+PHYS,2210,4,Physics with Calculus II,0.24,0.51,0.18,0.05,0.01,0.0,0.0,0.0,ramakrishna podila,
+PHYS,2210,7,Physics With Cal II (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True
+PHYS,2220,1,Physics with Calculus III,0.22,0.59,0.11,0.0,0.04,0.0,0.0,0.04,jeremy king,
+PHYS,2230,1,Physics Lab II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,2,Physics Lab II,0.28,0.33,0.39,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,3,Physics Lab II,0.18,0.76,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,4,Physics Lab II,0.38,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,5,Physics Lab II,0.0,0.82,0.18,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,6,Physics Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,9,Physics Lab II,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,10,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,12,Physics Lab II,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,13,Physics Lab II,0.24,0.65,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
+PHYS,2230,16,Physics Lab II,0.08,0.75,0.0,0.0,0.0,0.0,0.0,0.17,jerry hester,
+PHYS,2230,17,Physics Lab II,0.08,0.83,0.0,0.0,0.08,0.0,0.0,0.0,jerry hester,
+PHYS,2450,1,Physics of Climate,0.38,0.2,0.12,0.01,0.06,0.0,0.0,0.23,jens oberheide,
+PHYS,3120,1,Meth Theor Phys II,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,hye jung kang,
+PHYS,3150,1,Intro to Computational Physics,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,emil georgie alexov,
+PHYS,3210,1,Mechanics I,0.31,0.19,0.13,0.19,0.13,0.0,0.0,0.06,gerald lehmacher,
+PHYS,3250,1,Exper Physics I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,chad sosolik,
+PHYS,4410,1,Electromagnetics I,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,joan marler,
+PHYS,8110,1,Meth of Theor Phys I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+PHYS,8210,1,Classical Mech I,0.19,0.56,0.25,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
+PHYS,8750,7,Intro to Research,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,terry tritt,
+PHYS,9510,1,Quantum Mech I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,sumanta tewari,
+PKSC,1010,1,Pkgsc Orientation,0.76,0.11,0.06,0.05,0.02,0.0,0.0,0.01,robert truett moore,
+PKSC,1020,1,Intro to Pkg Sci,0.14,0.28,0.3,0.18,0.05,0.0,0.0,0.04,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.68,0.17,0.14,0.0,0.01,0.0,0.0,0.0,robert truett moore,
+PKSC,2200,1,Product & Pkg Design,0.69,0.1,0.06,0.08,0.06,0.0,0.0,0.0,william aaro snyder,
+PKSC,3200,1,Pkg Design Theory,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,rupert hurley,
+PKSC,4010,1,Packaging Machinery,0.53,0.37,0.09,0.0,0.01,0.0,0.0,0.0,anthony lou pometto,
+PKSC,4030,1,Pkg Career Prep,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4040,1,Protective Packaging Prop/Prin,0.19,0.34,0.26,0.06,0.1,0.0,0.0,0.04,gregory batt,
+PKSC,4160,1,Appl Polymers in Pkg,0.24,0.51,0.19,0.03,0.03,0.0,0.0,0.0,duncan darby,
+PKSC,4200,1,Pkg Design & Dev,0.56,0.41,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4540,1,Prod Pkg Evl Lab,0.5,0.25,0.06,0.13,0.06,0.0,0.0,0.0,gregory batt,
+PKSC,4540,2,Prod Pkg Evl Lab,0.33,0.4,0.07,0.0,0.07,0.0,0.0,0.13,gregory batt,
+PKSC,4540,3,Prod Pkg Evl Lab,0.24,0.53,0.06,0.0,0.12,0.0,0.0,0.06,gregory batt,
+PKSC,4540,4,Prod Pkg Evl Lab,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,gregory batt,
+PKSC,4540,6,Prod Pkg Evl Lab,0.0,0.54,0.23,0.23,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1,Food & Health Care Pkg Systems,0.63,0.31,0.03,0.03,0.0,0.0,0.0,0.0,kay cooksey,
+PKSC,8170,1,Pckg Materials: Sci & Technol,0.73,0.09,0.0,0.0,0.18,0.0,0.0,0.0,duncan darby,
+PKSC,8220,400,3D Parametric Design,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,rupert hurley,
+PKSC,8220,401,Structural Pkging Design,0.6,0.0,0.0,0.0,0.4,0.0,0.0,0.0,rupert hurley,
+PLPA,3100,1,Principles of Plant Pathology,0.33,0.33,0.26,0.04,0.0,0.0,0.0,0.04,steven nye jeffers,
+POSC,1010,1,Amer National Govt,0.05,0.58,0.16,0.05,0.16,0.0,0.0,0.0,joseph earl stewart,
+POSC,1010,2,Amer National Govt,0.24,0.48,0.15,0.06,0.02,0.0,0.0,0.05,jeffrey allen fine,
+POSC,1010,3,Amer National Govt,0.08,0.2,0.3,0.2,0.0,0.0,0.0,0.23,james woodard,
+POSC,1020,1,Intro Intl Relations,0.17,0.43,0.31,0.03,0.03,0.0,0.0,0.03,aron geo tannenbaum,
+POSC,1020,2,Intro Intl Relations,0.17,0.5,0.2,0.02,0.09,0.0,0.0,0.02,lydia loui lundgren,
+POSC,1020,3,Intro Intl Relations,0.19,0.29,0.25,0.1,0.08,0.0,0.0,0.08,steven vince miller,
+POSC,1020,4,Intro Intl Relations,0.09,0.49,0.26,0.06,0.04,0.0,0.0,0.06,colin pearce,
+POSC,1030,1,Intro to Political Theory,0.28,0.36,0.19,0.07,0.11,0.0,0.0,0.0,brandon turner,
+POSC,1040,1,Intro Compar Pol,0.08,0.49,0.33,0.08,0.0,0.0,0.0,0.03,xiaobo hu,
+POSC,1040,2,Intro Compar Pol,0.36,0.55,0.06,0.02,0.0,0.0,0.0,0.0,katherine am curtis,
+POSC,1990,1,Intro Pol Sci,0.43,0.29,0.15,0.03,0.04,0.0,0.0,0.06,meredith petersheim,
+POSC,3020,1,State and Loc Gov,0.1,0.57,0.27,0.0,0.02,0.0,0.0,0.04,bruce ransom,
+POSC,3110,1,Model United Nations,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,xiaobo hu,
+POSC,3410,1,Quant Meth in Pol Sc,0.12,0.47,0.06,0.24,0.12,0.0,0.0,0.0,steven vince miller,
+POSC,3430,1,Mass Media in Americ Politics,0.31,0.35,0.16,0.04,0.1,0.0,0.0,0.04,jeffrey scott peake,
+POSC,3610,1,Intl Pol in Crisis,0.21,0.63,0.06,0.02,0.04,0.0,0.0,0.04,vladimir matic,
+POSC,3710,1,European Politics,0.15,0.61,0.07,0.0,0.07,0.0,0.0,0.1,vladimir matic,
+POSC,3750,1,European Integration,0.3,0.33,0.15,0.07,0.11,0.0,0.0,0.04,lydia loui lundgren,
+POSC,3890,1,Indiv. Autonomy & the Const.,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,
+POSC,4210,1,Public Policy,0.18,0.12,0.35,0.18,0.06,0.0,0.0,0.12,adam warber,
+POSC,4360,1,Law Courts Politics,0.69,0.2,0.04,0.0,0.06,0.0,0.0,0.02,joseph earl stewart,
+POSC,4380,1,Constitut Law: Struc of Gov,0.45,0.41,0.11,0.02,0.0,0.0,0.0,0.0,daniel frost,
+POSC,4420,1,Pol Parties & Elect,0.02,0.23,0.53,0.09,0.07,0.0,0.0,0.05,james woodard,
+POSC,4470,1,International Law,0.27,0.48,0.12,0.06,0.03,0.0,0.0,0.03,katherine am curtis,
+POSC,4500,1,Modern Ideologies,0.33,0.43,0.14,0.0,0.05,0.0,0.0,0.05,james woodard,
+POSC,4530,1,American Political Thought,0.27,0.62,0.08,0.0,0.0,0.0,0.0,0.04,kimberly hurd hale,
+POSC,4560,1,Diplomacy,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
+POSC,4710,1,Russian Politics,0.3,0.52,0.03,0.03,0.06,0.0,0.0,0.06,aron geo tannenbaum,
+POSC,4760,1,Middle East Politics,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,vladimir matic,
+POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,meredith petersheim,
+POST,8220,1,Pol Analy/Pol Choice,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.01,teresa walto tucker,
+PRTM,2270,1,Prov of Leisure Exp,0.53,0.43,0.02,0.01,0.0,0.0,0.0,0.01,teresa walto tucker,
+PRTM,2290,1,Competency Integration in PRTM,0.54,0.41,0.04,0.01,0.0,0.0,0.0,0.01,teresa walto tucker,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.47,0.17,0.15,0.13,0.06,0.0,0.0,0.02,daniel mor anderson,
+PRTM,3070,2,Facility Operations,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,craig goodman,
+PRTM,3200,1,Recreation Policy,0.16,0.74,0.0,0.11,0.0,0.0,0.0,0.0,lincoln larson,
+PRTM,3210,1,Recreation Admin,0.35,0.46,0.13,0.0,0.02,0.0,0.0,0.04,mariela fernandez,
+PRTM,3220,1,Facilitation Techniques in RT,0.89,0.09,0.0,0.02,0.0,0.0,0.0,0.0,stephen thoma lewis,
+PRTM,3240,1,Assessment & Planning in RT,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3250,1,Global Persp in Rec,0.6,0.28,0.04,0.08,0.0,0.0,0.0,0.0,skye arthur-banning,
+PRTM,3420,2,Intro to Tourism,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,maloud shakona,
+PRTM,3430,1,Spl Asp of Tourist B,0.23,0.5,0.18,0.09,0.0,0.0,0.0,0.0,william norman,
+PRTM,3430,2,Spl Asp of Tourist B,0.46,0.37,0.11,0.03,0.03,0.0,0.0,0.0,william norman,
+PRTM,3520,1,Camp Org and Admin,0.08,0.31,0.31,0.15,0.0,0.0,0.0,0.15,gwynn powell,
+PRTM,3540,1,Youth Development in Camp,0.71,0.1,0.1,0.05,0.0,0.0,0.0,0.05,gwynn powell,
+PRTM,3900,8,Independent Study in PRTM,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3920,1,Special Event Management,0.73,0.15,0.06,0.02,0.04,0.0,0.0,0.0,kenneth backman,
+PRTM,3920,2,Special Event Management,0.82,0.1,0.04,0.02,0.0,0.0,0.0,0.02,kenneth backman,
+PRTM,4030,1,Elem of Rec/Pk Plan,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,robert baxte powell,
+PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,
+PRTM,4220,1,Management of RT Services,0.59,0.23,0.14,0.0,0.05,0.0,0.0,0.0,anna-mar chancellor,
+PRTM,4410,1,Commercial Rec,0.39,0.22,0.28,0.06,0.0,0.06,0.0,0.0,herbert chancellor,
+PRTM,4470,1,Perspect Intl Travel,0.65,0.19,0.1,0.0,0.03,0.0,0.0,0.03,lauren duffy,
+PRTM,4550,1,Adv Program Planning,0.46,0.37,0.11,0.03,0.0,0.0,0.0,0.03,jamie lynn cathey,
+PRTM,8010,2,Phil Found of PRTM,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
+PRTM,8020,1,Group Proc in Leisure Services,0.53,0.33,0.0,0.0,0.07,0.0,0.0,0.07,skye arthur-banning,
+PRTM,8080,1,Behavioral Aspects,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,8220,2,Strateg Planning in PRTM Orgs,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,
+PRTM,9000,6,Comm Conserv Sustain Develop,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lawrence allen,
+PRTM,9080,2,PRTM Stats,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
+PSYC,2010,1,Intro to Psychology,0.52,0.25,0.13,0.06,0.02,0.0,0.0,0.03,chong hyon pak,
+PSYC,2010,2,Intro to Psychology,0.35,0.34,0.2,0.07,0.02,0.0,0.0,0.02,jo anne jorgensen,
+PSYC,2010,3,Intro to Psychology,0.28,0.33,0.19,0.08,0.07,0.0,0.0,0.04,edwin brainerd,
+PSYC,2010,4,Intro to Psychology,0.15,0.43,0.29,0.03,0.01,0.0,0.0,0.09,christopher pagano,
+PSYC,2010,5,Intro to Psychology,0.26,0.41,0.21,0.01,0.01,0.0,0.0,0.09,mary taylor,
+PSYC,2010,6,Intro to Psychology (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
+PSYC,2020,1,Intro Psychology Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,2020,2,Intro Psychology Lab,0.8,0.04,0.12,0.0,0.04,0.0,0.0,0.0,eric mckibben,
+PSYC,2020,4,Intro Psychology Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,
+PSYC,2020,5,Intro Psychology Lab,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,eric mckibben,
+PSYC,2020,6,Intro Psychology Lab,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,3060,1,Human Sexual Beh,0.52,0.21,0.16,0.05,0.04,0.0,0.0,0.03,bruce michael king,
+PSYC,3090,100,Intro Exp Psych,0.51,0.2,0.13,0.11,0.04,0.0,0.0,0.01,patrick rosopa,
+PSYC,3090,200,Intro Exp Psych,0.41,0.31,0.17,0.03,0.07,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3090,300,Intro Exp Psych,0.3,0.47,0.1,0.07,0.03,0.0,0.0,0.03,richard tyrrell,
+PSYC,3100,100,Advanced Experimental Psych,0.24,0.53,0.12,0.0,0.0,0.0,0.0,0.12,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,robert campbell,
+PSYC,3100,300,Advanced Experimental Psych,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,robert campbell,
+PSYC,3100,400,Advanced Experimental Psych,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,3100,500,Advanced Experimental Psych,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,sarah mae sanborn,
+PSYC,3100,600,Advanced Experimental Psych,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3240,1,Physiological Psych,0.26,0.37,0.17,0.17,0.03,0.0,0.0,0.0,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.26,0.31,0.19,0.1,0.12,0.0,0.0,0.01,june pilcher,
+PSYC,3330,1,Cognitive Psych,0.7,0.16,0.09,0.03,0.01,0.0,0.0,0.01,allison lei wallace,
+PSYC,3330,2,Cognitive Psych,0.21,0.37,0.19,0.13,0.03,0.0,0.0,0.07,thomas alley,
+PSYC,3340,4,Cognitive Psych Lab,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,leah hartman,
+PSYC,3400,1,Lifespan Developmental Psych,0.29,0.32,0.22,0.01,0.07,0.0,0.0,0.07,pamela alley,
+PSYC,3400,2,Lifespan Developmental Psych,0.65,0.24,0.09,0.01,0.0,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3520,1,Social Psychology,0.35,0.41,0.09,0.09,0.03,0.0,0.0,0.03,jo anne jorgensen,
+PSYC,3520,2,Social Psychology,0.62,0.29,0.04,0.0,0.04,0.0,0.0,0.0,alice miche brawley,
+PSYC,3640,1,Industrial Psych,0.34,0.5,0.13,0.01,0.0,0.0,0.0,0.01,eric mckibben,
+PSYC,3640,2,Industrial Psych,0.48,0.3,0.18,0.01,0.01,0.0,0.0,0.01,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.43,0.33,0.17,0.01,0.0,0.0,0.0,0.04,kristen su jennings,
+PSYC,3690,1,Leadership in Orgs,0.56,0.26,0.15,0.03,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,3700,1,Personality,0.32,0.27,0.31,0.08,0.01,0.0,0.0,0.0,edwin brainerd,
+PSYC,3830,1,Abnormal Psychology,0.45,0.34,0.11,0.06,0.03,0.0,0.0,0.01,jo anne jorgensen,
+PSYC,3830,2,Abnormal Psychology,0.17,0.43,0.29,0.0,0.06,0.0,0.0,0.06,pamela alley,
+PSYC,3830,3,Abnormal Psychology,0.34,0.37,0.14,0.03,0.03,0.0,0.0,0.09,pamela alley,
+PSYC,4080,1,Women and Psychology,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,
+PSYC,4150,1,Systems and Theories,0.48,0.35,0.06,0.03,0.03,0.0,0.0,0.03,brian day,
+PSYC,4150,2,Systems and Theories,0.38,0.22,0.28,0.03,0.06,0.0,0.0,0.03,edwin brainerd,
+PSYC,4220,1,Perception,0.41,0.22,0.22,0.11,0.0,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4220,2,Perception,0.16,0.36,0.4,0.08,0.0,0.0,0.0,0.0,christopher pagano,
+PSYC,4220,3,Perception,0.26,0.26,0.26,0.07,0.04,0.0,0.0,0.11,claudio cantalupo,
+PSYC,4350,1,Human Factors,0.48,0.24,0.05,0.1,0.05,0.0,0.0,0.1,laura whitlock,
+PSYC,4430,1,Infant & Child Dev,0.44,0.36,0.12,0.04,0.04,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,4560,1,Psychophysiology,0.48,0.35,0.09,0.09,0.0,0.0,0.0,0.0,drew michael morris,
+PSYC,4710,1,Psych of Testing,0.38,0.33,0.1,0.1,0.05,0.0,0.0,0.05,fred switzer,
+PSYC,4800,1,Health Psychology,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,june pilcher,
+PSYC,4880,1,Psychotherapy,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,lucinda sorci quick,
+PSYC,4890,1,Judgment and Decision Making,0.68,0.16,0.16,0.0,0.0,0.0,0.0,0.0,fred switzer,
+PSYC,4890,2,Psyc of Food and Eating,0.3,0.52,0.13,0.0,0.0,0.0,0.0,0.04,thomas alley,
+PSYC,4920,1,Senior Laboratory,0.85,0.04,0.08,0.04,0.0,0.0,0.0,0.0,hiu ngae jan cheung,
+PSYC,4920,2,Senior Laboratory,0.85,0.0,0.07,0.0,0.0,0.0,0.0,0.07,stephen robertson,
+PSYC,4920,4,Senior Laboratory,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,brooke bake allison,
+PSYC,8100,1,Research Design I,0.71,0.14,0.05,0.0,0.05,0.0,0.0,0.05, dewayne moore,
+PSYC,8350,1,Adv Human Factors,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,8620,1,Org Psychology,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,
+PSYC,8850,1,Org Stress,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas britt,
+RED,8000,1,Real Estate Dvlpment,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+RED,8030,1,Pub-Priv Partnership,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,john terrenc farris,
+RED,8130,1,Strat in Real Estate,0.5,0.31,0.13,0.0,0.0,0.0,0.0,0.06,phillip rive hughes,
+RED,8160,1,Preservation Feasibility,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+REL,1010,1,Intro to Religion,0.05,0.53,0.11,0.16,0.05,0.0,0.0,0.11,peter cohen,
+REL,1010,2,Intro to Religion,0.21,0.32,0.16,0.21,0.0,0.0,0.0,0.11,peter cohen,
+REL,1010,4,Intro to Religion,0.21,0.42,0.11,0.0,0.0,0.0,0.0,0.26,peter cohen,
+REL,1010,5,Intro to Religion,0.8,0.09,0.0,0.0,0.06,0.0,0.0,0.06,jennifer singletary,
+REL,1010,6,Intro to Religion,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jennifer singletary,
+REL,1020,2,World Religions,0.56,0.35,0.03,0.0,0.06,0.0,0.0,0.0,robert stephens,
+REL,1020,3,World Religions,0.72,0.14,0.06,0.0,0.08,0.0,0.0,0.0,robert stephens,
+REL,1020,4,World Religions,0.8,0.06,0.0,0.03,0.03,0.0,0.0,0.09,robert stephens,
+REL,3010,1,Old Testament,0.59,0.32,0.06,0.0,0.03,0.0,0.0,0.0,steven grosby,
+REL,3020,1,New Testament Lit,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,benjamin white,
+REL,3080,1,Rel of Ancient World,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3100,1,History of Religion in the US,0.47,0.21,0.21,0.05,0.0,0.0,0.0,0.05,elizabeth jemison,
+REL,3150,1,Islam,0.44,0.29,0.18,0.09,0.0,0.0,0.0,0.0,mashal saif,
+RS,3010,1,Rural Sociology,0.56,0.2,0.2,0.0,0.0,0.0,0.0,0.04,kenneth robinson,
+RUSS,1010,1,Elementary Russian,0.33,0.17,0.17,0.0,0.08,0.0,0.0,0.25,joan bridgwood,
+SOC,2010,1,Intro to Sociology (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,rachael chatterson,True
+SOC,2010,2,Introduction to Sociology,0.48,0.32,0.16,0.03,0.0,0.0,0.0,0.01,stephani southworth,
+SOC,2010,3,Introduction to Sociology,0.46,0.31,0.1,0.1,0.0,0.0,0.0,0.02,stephani southworth,
+SOC,2010,4,Introduction to Sociology,0.49,0.34,0.15,0.02,0.0,0.0,0.0,0.0,stephani southworth,
+SOC,2010,5,Introduction to Sociology,0.32,0.42,0.16,0.08,0.02,0.0,0.0,0.0,mary louise barr,
+SOC,2010,6,Introduction to Sociology,0.32,0.29,0.32,0.03,0.03,0.0,0.0,0.03,mary louise barr,
+SOC,2010,7,Introduction to Sociology,0.43,0.39,0.13,0.02,0.02,0.0,0.0,0.0,mary louise barr,
+SOC,2010,8,Introduction to Sociology,0.32,0.36,0.23,0.03,0.03,0.0,0.0,0.03,mary louise barr,
+SOC,2010,9,Introduction to Sociology,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,10,Introduction to Sociology,0.52,0.35,0.11,0.0,0.0,0.0,0.0,0.02,jennifer le holland,
+SOC,2010,11,Introduction to Sociology,0.55,0.26,0.16,0.0,0.03,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,12,Introduction to Sociology,0.53,0.34,0.13,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,13,Introduction to Sociology,0.59,0.27,0.05,0.03,0.0,0.0,0.0,0.05,shannon mcdonough,
+SOC,2010,14,Introduction to Sociology,0.2,0.38,0.22,0.09,0.07,0.0,0.0,0.04,margaret tina britz,
+SOC,2010,15,Introduction to Sociology,0.56,0.24,0.11,0.04,0.02,0.0,0.0,0.02,rachael chatterson,
+SOC,2010,16,Introduction to Sociology,0.41,0.36,0.14,0.01,0.04,0.0,0.0,0.03,rachael chatterson,
+SOC,2010,17,Introduction to Sociology,0.38,0.48,0.13,0.0,0.0,0.0,0.0,0.03,rachael chatterson,
+SOC,2020,1,Social Problems,0.3,0.33,0.26,0.07,0.0,0.0,0.0,0.04,stephani southworth,
+SOC,2050,1,Sociology Lab,0.74,0.03,0.09,0.0,0.14,0.0,0.0,0.0,brenda vander mey,
+SOC,2050,2,Sociology Lab,0.65,0.06,0.06,0.18,0.0,0.0,0.0,0.06,brenda vander mey,
+SOC,3020,1,Research Methods I,0.33,0.3,0.18,0.08,0.08,0.0,0.0,0.05,andrew whitehead,
+SOC,3040,1,Social Research Methods II,0.22,0.3,0.39,0.09,0.0,0.0,0.0,0.0,ye luo,
+SOC,3110,1,The Family,0.22,0.56,0.2,0.02,0.0,0.0,0.0,0.0,andrew whitehead,
+SOC,3600,1,Class & Poverty,0.77,0.17,0.02,0.0,0.04,0.0,0.0,0.0,william haller,
+SOC,3880,1,Criminal Justice,0.13,0.27,0.36,0.13,0.11,0.0,0.0,0.0,margaret tina britz,
+SOC,3890,1,Criminology,0.37,0.26,0.06,0.06,0.17,0.0,0.0,0.09,william white,
+SOC,3910,1,Soc of Deviance,0.47,0.28,0.09,0.07,0.0,0.0,0.0,0.09,william white,
+SOC,3920,1,Juvenile Delinquency,0.23,0.08,0.23,0.23,0.15,0.0,0.0,0.08,william white,
+SOC,3940,1,Sociology of Mental Illness,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,douglas sturkie,
+SOC,3970,1,Substance Abuse,0.41,0.46,0.11,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,
+SOC,4040,1,Soc Theory,0.54,0.29,0.15,0.0,0.0,0.0,0.0,0.02,william wentworth,
+SOC,4140,1,Policy&Social Change,0.33,0.48,0.15,0.04,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,4330,1,Global Social Change,0.67,0.17,0.11,0.0,0.06,0.0,0.0,0.0,william haller,
+SOC,4440,1,Sociology of Educ,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,stephani southworth,
+SOC,4600,1,Race & Ethnicity,0.29,0.29,0.33,0.08,0.0,0.0,0.0,0.0,brenda vander mey,
+SOC,4600,2,Race & Ethnicity,0.5,0.17,0.08,0.17,0.08,0.0,0.0,0.0,brenda vander mey,
+SOC,4610,1,Sex & Gender,0.39,0.43,0.11,0.0,0.02,0.0,0.0,0.04,traci ann hefner,
+SOC,4680,1,Criminal Evidence,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
+SOC,4860,1,Creative Inquiry in Sociology,0.64,0.14,0.07,0.0,0.07,0.0,0.0,0.07,margaret tina britz,
+SOC,4970,1,Senior Lab,0.56,0.16,0.16,0.09,0.0,0.0,0.0,0.03,brenda vander mey,
+SOC,8030,1,Sur Dsgn App Res Lab,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,
+SPAN,1010,1,Elementary Spanish,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,scott harris,
+SPAN,1010,2,Elementary Spanish,0.63,0.16,0.05,0.11,0.05,0.0,0.0,0.0,scott harris,
+SPAN,1010,3,Elementary Spanish,0.47,0.42,0.0,0.0,0.05,0.0,0.0,0.05,scott harris,
+SPAN,1020,1,Elementary Spanish,0.16,0.37,0.16,0.16,0.0,0.0,0.0,0.16,roger simpson,
+SPAN,1020,2,Elementary Spanish,0.18,0.29,0.24,0.18,0.0,0.0,0.0,0.12,roger simpson,
+SPAN,1020,3,Elementary Spanish,0.11,0.37,0.16,0.16,0.05,0.0,0.0,0.16,roger simpson,
+SPAN,1020,4,Elementary Spanish,0.42,0.26,0.05,0.11,0.05,0.0,0.0,0.11,roger simpson,
+SPAN,1020,5,Elementary Spanish,0.17,0.28,0.28,0.11,0.0,0.0,0.0,0.17,roger simpson,
+SPAN,1020,6,Elementary Spanish,0.39,0.39,0.11,0.06,0.0,0.0,0.0,0.06,cathy robison,
+SPAN,1020,7,Elementary Spanish,0.11,0.39,0.22,0.06,0.11,0.0,0.0,0.11,cathy robison,
+SPAN,1020,8,Elementary Spanish,0.39,0.28,0.06,0.06,0.17,0.0,0.0,0.06,ana paula  miller,
+SPAN,1020,9,Elementary Spanish,0.26,0.37,0.26,0.05,0.0,0.0,0.0,0.05,ana paula  miller,
+SPAN,1020,10,Elementary Spanish,0.58,0.26,0.0,0.05,0.05,0.0,0.0,0.05,debra oa williamson,
+SPAN,1020,11,Elementary Spanish,0.39,0.33,0.0,0.06,0.0,0.0,0.0,0.22,debra oa williamson,
+SPAN,1020,12,Elementary Spanish,0.53,0.21,0.11,0.0,0.11,0.0,0.0,0.05,adrienne eliza fama,
+SPAN,1020,13,Elementary Spanish,0.32,0.37,0.26,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,1020,14,Elementary Spanish,0.32,0.21,0.21,0.11,0.05,0.0,0.0,0.11,ana paula  miller,
+SPAN,2010,1,Intermediate Spanish,0.24,0.41,0.18,0.12,0.0,0.0,0.0,0.06,cathy robison,
+SPAN,2010,2,Intermediate Spanish,0.11,0.72,0.17,0.0,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,3,Intermediate Spanish,0.38,0.31,0.25,0.0,0.0,0.0,0.0,0.06,allison ann hinds,
+SPAN,2010,4,Intermediate Spanish,0.21,0.5,0.29,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
+SPAN,2010,5,Intermediate Spanish,0.53,0.18,0.18,0.06,0.0,0.0,0.0,0.06,allison ann hinds,
+SPAN,2010,6,Intermediate Spanish,0.5,0.19,0.25,0.0,0.0,0.0,0.0,0.06,heidi montes,
+SPAN,2010,7,Intermediate Spanish,0.25,0.25,0.25,0.13,0.0,0.0,0.0,0.13,heidi montes,
+SPAN,2010,8,Intermediate Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,2010,9,Intermediate Spanish,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,2010,10,Intermediate Spanish,0.38,0.31,0.08,0.0,0.15,0.0,0.0,0.08,ricardo tremolada,
+SPAN,2010,11,Intermediate Spanish,0.27,0.45,0.09,0.0,0.0,0.0,0.0,0.18,melva margu persico,
+SPAN,2010,12,Intermediate Spanish,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2010,13,Intermediate Spanish,0.26,0.37,0.26,0.0,0.0,0.0,0.0,0.11,maureen zamora,
+SPAN,2010,14,Intermediate Spanish,0.13,0.19,0.44,0.0,0.0,0.0,0.0,0.25,maureen zamora,
+SPAN,2010,15,Intermediate Spanish,0.53,0.2,0.0,0.0,0.07,0.0,0.0,0.2,ricardo tremolada,
+SPAN,2010,16,Intermediate Spanish,0.59,0.24,0.0,0.0,0.06,0.0,0.0,0.12,ricardo tremolada,
+SPAN,2010,17,Intermediate Spanish,0.68,0.11,0.16,0.0,0.05,0.0,0.0,0.0,ricardo tremolada,
+SPAN,2010,18,Intermediate Spanish,0.29,0.36,0.21,0.07,0.0,0.0,0.0,0.07,ana paula  miller,
+SPAN,2010,19,Intermediate Spanish,0.24,0.41,0.24,0.0,0.0,0.0,0.0,0.12,debra oa williamson,
+SPAN,2020,1,Intermediate Spanish,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,2,Intermediate Spanish,0.06,0.56,0.31,0.06,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,2020,3,Intermediate Spanish,0.31,0.31,0.25,0.13,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,4,Intermediate Spanish,0.28,0.5,0.11,0.0,0.0,0.0,0.0,0.11,heidi montes,
+SPAN,2020,5,Intermediate Spanish,0.64,0.07,0.14,0.0,0.0,0.0,0.0,0.14,ze cruz valderramos,
+SPAN,2020,6,Intermediate Spanish,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,ze cruz valderramos,
+SPAN,2020,7,Intermediate Spanish,0.39,0.28,0.28,0.0,0.0,0.0,0.0,0.06,melva margu persico,
+SPAN,2020,8,Intermediate Spanish,0.41,0.47,0.06,0.06,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,2020,9,Intermediate Spanish,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,10,Intermediate Spanish,0.47,0.35,0.12,0.0,0.06,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,11,Intermediate Spanish,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,kari daus carson,
+SPAN,2020,12,Intermediate Spanish,0.37,0.53,0.0,0.0,0.0,0.0,0.0,0.11,kari daus carson,
+SPAN,2020,13,Intermediate Spanish,0.37,0.21,0.32,0.05,0.05,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,14,Intermediate Spanish,0.56,0.28,0.06,0.0,0.0,0.0,0.0,0.11,ze cruz valderramos,
+SPAN,2020,15,Intermediate Spanish,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,3050,2,Int Con Comp Span I,0.5,0.28,0.17,0.0,0.0,0.0,0.0,0.06,juana martin-armas,
+SPAN,3050,3,Int Con Comp Span I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,3060,1,Span Comp for Bus,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,maureen zamora,
+SPAN,3070,1,Hispanic World: Sp,0.72,0.11,0.0,0.06,0.0,0.0,0.0,0.11,salvador oropesa,
+SPAN,3070,2,Hispanic World: Sp,0.26,0.58,0.0,0.0,0.0,0.0,0.0,0.16,raquel anido,
+SPAN,3080,1,Hispanic World: La,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,george palacios,
+SPAN,3110,1,Surv Span-Amer Lit,0.21,0.29,0.21,0.14,0.0,0.0,0.0,0.14,tiffany dawn miller,
+SPAN,3130,1,Span Lit Survey I,0.27,0.27,0.18,0.09,0.0,0.0,0.0,0.18,mon rojas-de-massei,
+SPAN,3130,2,Span Lit Survey I,0.27,0.4,0.2,0.0,0.0,0.0,0.0,0.13,mon rojas-de-massei,
+SPAN,3140,1,Hispanic Linguistics,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,daniel smith,
+SPAN,4060,1,Narrative Fiction,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,
+SPAN,4160,1,Span Intl Trade II,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,maureen zamora,
+SPAN,4190,1,Health & Hisp Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+SPAN,4220,1,Contem Span Am Novel,0.83,0.11,0.0,0.0,0.06,0.0,0.0,0.0,ricardo tremolada,
+SPAN,4350,1,Contemp Hisp Cult,0.45,0.27,0.09,0.0,0.09,0.0,0.0,0.09,tiffany dawn miller,
+STAT,2220,1,Statistics in Everyday Life,0.51,0.21,0.14,0.05,0.05,0.0,0.0,0.05,ros martinez-dawson,
+STAT,2220,2,Statistics in Everyday Life,0.39,0.19,0.17,0.17,0.09,0.0,0.0,0.0,ros martinez-dawson,
+STAT,2220,3,Statistics in Everyday Life,0.35,0.39,0.2,0.02,0.04,0.0,0.0,0.0,james espey,
+STAT,2220,4,Statistics in Everyday Life,0.54,0.22,0.17,0.06,0.02,0.0,0.0,0.0,james espey,
+STAT,2220,5,Statistics in Everyday Life,0.5,0.35,0.13,0.0,0.0,0.0,0.0,0.02,james espey,
+STAT,2220,7,Statistics in Everyday Life,0.42,0.34,0.12,0.07,0.02,0.0,0.0,0.02,james espey,
+STAT,2300,1,Statistical Methods I,0.43,0.31,0.08,0.11,0.06,0.0,0.0,0.01,christy jenki brown,
+STAT,2300,2,Statistical Methods I,0.38,0.3,0.1,0.11,0.08,0.0,0.0,0.04,christy jenki brown,
+STAT,2300,3,Statistical Methods I,0.45,0.35,0.08,0.07,0.03,0.0,0.0,0.01,christy jenki brown,
+STAT,2300,4,Statistical Methods I,0.34,0.33,0.15,0.09,0.09,0.0,0.0,0.01, erwin walker,
+STAT,2300,5,Statistical Methods I,0.31,0.36,0.21,0.06,0.06,0.0,0.0,0.0, erwin walker,
+STAT,2300,6,Statistical Methods I,0.31,0.35,0.16,0.12,0.05,0.0,0.0,0.01,benjamin sharp,
+STAT,2300,7,Statistical Methods I,0.28,0.34,0.22,0.06,0.06,0.0,0.0,0.04,brook thaye russell,
+STAT,2300,8,Statistical Methods I,0.19,0.31,0.31,0.12,0.07,0.0,0.0,0.0, erwin walker,
+STAT,3090,1,Introductory Business Stats,0.06,0.41,0.26,0.03,0.21,0.0,0.0,0.03,janie caro mcdonald,
+STAT,3090,2,Introductory Business Stats,0.33,0.28,0.22,0.11,0.06,0.0,0.0,0.0,kara ail stasikelis,
+STAT,3090,3,Introductory Business Stats,0.14,0.17,0.43,0.09,0.06,0.0,0.0,0.11,laura jane shick,
+STAT,3090,4,Introductory Business Stats,0.15,0.38,0.21,0.15,0.1,0.0,0.0,0.0,gary fellers,
+STAT,3090,5,Introductory Business Stats,0.13,0.42,0.24,0.08,0.11,0.0,0.0,0.03,laura jane shick,
+STAT,3090,6,Introductory Business Stats,0.28,0.5,0.19,0.03,0.0,0.0,0.0,0.0,ellen hepfe breazel,
+STAT,3090,7,Introductory Business Stats,0.37,0.21,0.26,0.05,0.11,0.0,0.0,0.0,kara ail stasikelis,
+STAT,3090,8,Introductory Business Stats,0.16,0.42,0.21,0.11,0.05,0.0,0.0,0.05,christopher wilson,
+STAT,3090,9,Introductory Business Stats,0.33,0.26,0.23,0.03,0.15,0.0,0.0,0.0,gary fellers,
+STAT,3090,10,Introductory Business Stats,0.26,0.4,0.26,0.0,0.06,0.0,0.0,0.03,janie caro mcdonald,
+STAT,3090,11,Introductory Business Stats,0.22,0.36,0.22,0.19,0.0,0.0,0.0,0.0,ellen hepfe breazel,
+STAT,3090,12,Introductory Business Stats,0.26,0.36,0.13,0.08,0.1,0.0,0.0,0.08,laura jane shick,
+STAT,3090,13,Introductory Business Stats,0.16,0.26,0.42,0.16,0.0,0.0,0.0,0.0,janie caro mcdonald,
+STAT,3090,14,Introductory Business Stats,0.26,0.47,0.13,0.08,0.03,0.0,0.0,0.03,margaret mar wiecek,
+STAT,3090,15,Introductory Business Stats,0.11,0.47,0.32,0.0,0.05,0.0,0.0,0.05,emily marie nystrom,
+STAT,3090,16,Introductory Business Stats,0.11,0.37,0.32,0.11,0.11,0.0,0.0,0.0,laura jane shick,
+STAT,3090,17,Introductory Business Stats,0.0,0.47,0.26,0.0,0.11,0.0,0.0,0.16,tao yang,
+STAT,3090,18,Introductory Business Stats,0.36,0.31,0.23,0.03,0.05,0.0,0.0,0.03,gary fellers,
+STAT,3090,19,Introductory Business Stats,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,emily marie nystrom,
+STAT,3090,20,Introductory Business Stats,0.0,0.4,0.13,0.13,0.2,0.0,0.0,0.13,paul james cubre,
+STAT,3090,21,Introductory Business Stats,0.26,0.33,0.26,0.05,0.08,0.0,0.0,0.03,gary fellers,
+STAT,3090,22,Introductory Business Stats,0.14,0.29,0.29,0.09,0.14,0.0,0.0,0.06,janie caro mcdonald,
+STAT,3090,23,Introductory Business Stats,0.11,0.37,0.22,0.15,0.07,0.0,0.0,0.07,tao yang,
+STAT,3090,24,Introductory Business Stats,0.32,0.26,0.21,0.0,0.11,0.0,0.0,0.11,paul james cubre,
+STAT,3090,25,Introductory Business Stats,0.16,0.63,0.05,0.0,0.11,0.0,0.0,0.05,drew jared lipman,
+STAT,3090,26,Introductory Business Stats,0.11,0.16,0.32,0.21,0.11,0.0,0.0,0.11,christopher wilson,
+STAT,3300,1,Statistical Methods II,0.21,0.38,0.21,0.0,0.0,0.0,0.0,0.21,ros martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.44,0.31,0.06,0.06,0.06,0.0,0.0,0.06,julia lynn sharp,
+STAT,4110,1,Stat Mthds for Process Control,0.3,0.4,0.23,0.0,0.08,0.0,0.0,0.0,william bridges,
+STAT,4110,2,Stat Mthds for Process Control,0.44,0.25,0.16,0.09,0.06,0.0,0.0,0.0,patrick gerard,
+STAT,6020,1,Intro to Statistical Computing,0.57,0.14,0.14,0.0,0.0,0.0,0.0,0.14,julia lynn sharp,
+STAT,8010,1,Statistical Methods I,0.47,0.23,0.13,0.0,0.1,0.0,0.0,0.07,james rieck,
+STAT,8010,2,Statistical Methods I,0.26,0.42,0.06,0.0,0.16,0.0,0.0,0.1,james rieck,
+STAT,8010,3,Statistical Methods I,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,jun luo,
+STAT,8010,4,Statistical Methods I,0.29,0.57,0.04,0.0,0.07,0.0,0.0,0.04,julia lynn sharp,
+STAT,8020,1,Statistical Methods II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,8030,1,Regress & Least Squares Anlys,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,jun luo,
+STS,1010,1,Survey of S T S,0.49,0.49,0.0,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,
+STS,1010,2,Survey of S T S,0.56,0.42,0.03,0.0,0.0,0.0,0.0,0.0,philip randall,
+STS,1010,3,Survey of S T S,0.27,0.61,0.06,0.03,0.0,0.0,0.0,0.03,scott brame,
+STS,1010,5,Survey of S T S,0.58,0.36,0.03,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,
+STS,1010,6,Survey of S T S,0.32,0.5,0.09,0.03,0.03,0.0,0.0,0.03,sarah mae cooper,
+STS,1010,7,Survey of S T S,0.86,0.08,0.03,0.0,0.0,0.0,0.0,0.03,annah kamugiz amani,
+STS,1010,8,Survey of S T S,0.19,0.35,0.29,0.06,0.06,0.0,0.0,0.03,david charles foltz,
+STS,1010,9,Survey of S T S,0.47,0.25,0.17,0.03,0.0,0.0,0.0,0.08,allison ann hinds,
+STS,1010,10,Survey of S T S,0.49,0.26,0.11,0.06,0.03,0.0,0.0,0.06,megan no macalystre,
+THEA,2100,2,Theatre Appreciation,0.91,0.03,0.03,0.0,0.03,0.0,0.0,0.0,kerrie kath seymour,
+THEA,2100,3,Theatre Appreciation,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,2100,4,Theatre Appreciation,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
+THEA,2100,5,Theatre Appreciation,0.43,0.53,0.0,0.0,0.0,0.0,0.0,0.03,carol collins,
+THEA,2100,6,Theatre Appreciation,0.67,0.2,0.07,0.0,0.03,0.0,0.0,0.03,anthony penna,
+THEA,2100,7,Theatre Appreciation,0.52,0.39,0.1,0.0,0.0,0.0,0.0,0.0,jason adkins,
+THEA,2780,1,Acting I,0.69,0.08,0.0,0.08,0.15,0.0,0.0,0.0,kerrie kath seymour,
+THEA,2790,1,Theatre Practicum,0.5,0.13,0.13,0.0,0.0,0.0,0.0,0.25,matthew leckenbusch,
+THEA,3170,1,African-Amer Thea I,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,3760,1,Stage Directing I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richard st. peter,
+THEA,3980,2,Special Topics in Theatre,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
+THEA,4720,1,Improvisation,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,
+WFB,3000,1,Wildlife Biology,0.46,0.3,0.16,0.02,0.06,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3000,2,Wildlife Biology,0.46,0.32,0.19,0.04,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3010,1,Wildlife Biology Lab,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3010,2,Wildlife Biology Lab,0.53,0.24,0.18,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,
+WFB,4100,2,Wildlife Management Techniques,0.15,0.55,0.23,0.05,0.03,0.0,0.0,0.0,james davis,
+WFB,4440,1,Wildlife Damage Management,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,james davis,
+WFB,4500,1,Aquaculture,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,
+WFB,4930,1,Waterfowl Ecology & Mgt,0.33,0.58,0.04,0.0,0.0,0.0,0.0,0.04,richard ma kaminski,
+WFB,8180,1,Waterfowl Ecology & Mgt,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
+WS,1030,1,Women Global Perspec,0.68,0.24,0.06,0.0,0.0,0.0,0.0,0.03,saadiqa kumanyika,
+WS,1030,2,Women Global Perspec,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,
+WS,2300,1,Women and Leadership,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,diane perpich,
+WS,3010,1,Intro Women's Studies,0.54,0.31,0.09,0.06,0.0,0.0,0.0,0.0,elizabeth ros adams,
+WS,3010,2,Intro Women's Studies,0.46,0.4,0.09,0.03,0.0,0.0,0.0,0.03,elizabeth ros adams,
+YDP,3000,400,Youth Development in Society,0.58,0.05,0.21,0.0,0.16,0.0,0.0,0.0,barry garst,
+YDP,3050,400,Theory/Phil of Youth Dev Work,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,

--- a/bot/cogs/grades_cog/assets/2015_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2015_Spring.csv
@@ -1,2316 +1,2316 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1020,1,Survey of Art & Arch Hist II,0.4,0.49,0.09,0.0,0.0,0.0,0.0,0.01,beth ann lauritis,
-AAH,2060,1,Art History and Theory II,0.48,0.29,0.24,0.0,0.0,0.0,0.0,0.0,andrea feeser,
-AAH,2100,1,Intro to Art and Architecture,0.39,0.32,0.14,0.04,0.07,0.0,0.0,0.04,lydia jane dorsey,
-AAH,2100,2,Intro to Art and Architecture,0.29,0.36,0.29,0.0,0.04,0.0,0.0,0.04,lydia jane dorsey,
-AAH,2100,3,Intro to Art and Architecture,0.21,0.54,0.11,0.07,0.0,0.0,0.0,0.07,lydia jane dorsey,
-AAH,2100,4,Intro to Art and Architecture,0.22,0.22,0.26,0.11,0.0,0.0,0.0,0.19,lydia jane dorsey,
-ACCT,2010,1,Financial Accounting Concepts,0.19,0.3,0.21,0.12,0.09,0.0,0.0,0.09,suzanne pearse,
-ACCT,2010,2,Financial Accounting Concepts,0.32,0.17,0.13,0.09,0.09,0.0,0.0,0.21,lydia lan schleifer,
-ACCT,2010,3,Financial Accounting Concepts,0.18,0.32,0.25,0.02,0.09,0.0,0.0,0.14,suzanne pearse,
-ACCT,2010,4,Financial Accounting Concepts,0.12,0.2,0.3,0.16,0.1,0.0,0.0,0.12,philip maiberger,
-ACCT,2010,5,Financial Accounting Concepts,0.12,0.37,0.24,0.04,0.06,0.0,0.0,0.16,philip maiberger,
-ACCT,2010,6,Financial Accounting Concepts,0.29,0.38,0.1,0.05,0.05,0.0,0.0,0.14,suzanne pearse,
-ACCT,2010,7,Financial Accounting Concepts,0.3,0.13,0.22,0.15,0.04,0.0,0.0,0.15,lydia lan schleifer,
-ACCT,2010,8,Financial Accounting Concepts,0.31,0.2,0.2,0.11,0.11,0.0,0.0,0.07,lydia lan schleifer,
-ACCT,2010,9,Financial Accounting Concepts,0.09,0.23,0.36,0.16,0.0,0.0,0.0,0.16,the estate  guffey,
-ACCT,2010,10,Financial Accounting Concepts,0.17,0.27,0.23,0.03,0.1,0.0,0.0,0.2,the estate  guffey,
-ACCT,2010,11,Financial Accounting Concepts,0.13,0.3,0.16,0.13,0.14,0.0,0.0,0.14,jeffrey mcmillan,
-ACCT,2010,12,Financial Accounting Concepts,0.16,0.14,0.2,0.26,0.08,0.0,0.0,0.16,philip maiberger,
-ACCT,2010,13,Fin Acct Concepts (HON),0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True
-ACCT,2020,1,Managerial Accounting Concepts,0.22,0.33,0.2,0.12,0.02,0.0,0.0,0.1,annieka philo,
-ACCT,2020,2,Managerial Accounting Concepts,0.33,0.3,0.24,0.06,0.06,0.0,0.0,0.02,annieka philo,
-ACCT,2020,3,Managerial Accounting Concepts,0.35,0.24,0.28,0.04,0.04,0.0,0.0,0.06,annieka philo,
-ACCT,2020,4,Managerial Accounting Concepts,0.33,0.35,0.15,0.09,0.04,0.0,0.0,0.04,annieka philo,
-ACCT,2020,5,Managerial Accounting Concepts,0.14,0.18,0.39,0.05,0.0,0.0,0.0,0.25,henry anderson,
-ACCT,2020,6,Managerial Accounting Concepts,0.26,0.3,0.2,0.07,0.02,0.0,0.0,0.15,henry anderson,
-ACCT,2020,8,Managerial Accounting Concepts,0.14,0.11,0.2,0.17,0.09,0.0,0.0,0.29,henry anderson,
-ACCT,3030,1,Cost Accounting,0.28,0.35,0.23,0.05,0.02,0.0,0.0,0.06,frances kennedy,
-ACCT,3030,3,Cost Accounting,0.35,0.43,0.14,0.05,0.0,0.0,0.0,0.03,holly rhiannio hawk,
-ACCT,3030,4,Cost Accounting,0.24,0.5,0.13,0.0,0.03,0.0,0.0,0.11,holly rhiannio hawk,
-ACCT,3110,1,Intermed Financial Acct I,0.2,0.5,0.2,0.03,0.0,0.0,0.0,0.08,terry daniel knause,
-ACCT,3110,2,Intermed Financial Acct I,0.41,0.44,0.15,0.0,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3110,3,Intermed Financial Acct I,0.22,0.45,0.29,0.02,0.0,0.0,0.0,0.02,terry daniel knause,
-ACCT,3110,4,Intermed Financial Acct I,0.31,0.57,0.09,0.02,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3120,1,Intermed Financial Acct II,0.33,0.45,0.18,0.03,0.0,0.0,0.0,0.03, russell madray,
-ACCT,3120,2,Intermed Financial Acct II,0.32,0.38,0.15,0.04,0.04,0.0,0.0,0.06, russell madray,
-ACCT,3120,3,Intermed Financial Acct II,0.05,0.28,0.21,0.26,0.18,0.0,0.0,0.03,brian todd carver,
-ACCT,3120,4,Intermed Financial Acct II,0.03,0.18,0.38,0.24,0.18,0.0,0.0,0.0,brian todd carver,
-ACCT,3130,1,Intermed Financial Acct III,0.28,0.38,0.31,0.03,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3130,2,Intermed Financial Acct III,0.27,0.41,0.24,0.03,0.05,0.0,0.0,0.0, russell madray,
-ACCT,3130,3,Intermed Financial Acct III,0.11,0.48,0.26,0.11,0.04,0.0,0.0,0.0,james irving,
-ACCT,3130,4,Intermed Financial Acct III,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,james irving,
-ACCT,3220,1,Accounting Information Systems,0.28,0.28,0.4,0.03,0.0,0.0,0.0,0.03,nancy lee harp,
-ACCT,3220,2,Accounting Information Systems,0.26,0.18,0.38,0.08,0.08,0.0,0.0,0.03,nancy lee harp,
-ACCT,3220,3,Accounting Information Systems,0.19,0.49,0.19,0.11,0.0,0.0,0.0,0.03,nancy lee harp,
-ACCT,4040,1,Individual Taxation,0.76,0.18,0.03,0.0,0.03,0.0,0.0,0.0,sarah martin,
-ACCT,4040,2,Individual Taxation,0.88,0.05,0.07,0.0,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.36,0.46,0.13,0.0,0.0,0.0,0.0,0.05,james mil kohlmeyer,
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.19,0.73,0.08,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,
-ACCT,4150,1,Auditing,0.16,0.46,0.27,0.08,0.0,0.0,0.0,0.03,suzanne pearse,
-ACCT,4150,2,Auditing,0.29,0.48,0.19,0.03,0.0,0.0,0.0,0.0,carl hollingsworth,
-ACCT,8520,1,Fin Acct Theory/Res,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8520,2,Fin Acct Theory/Res,0.32,0.58,0.1,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8540,1,Prof Responsibility,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,
-ACCT,8710,1,Corporate Taxation,0.46,0.51,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,2,Corporate Taxation,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,derek dalton,
-AGED,1000,1,Orientation & Field Experience,0.85,0.07,0.04,0.0,0.0,0.0,0.0,0.04,philip fravel,
-AGED,2030,1,Teaching Agriscience,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGED,4160,1,Ethics and Issues,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,
-AGM,2050,1,Prin of Fabrication,0.13,0.45,0.3,0.05,0.0,0.0,0.0,0.07,hunter massey,
-AGM,2060,1,Machinery Mgt,0.15,0.36,0.3,0.09,0.03,0.0,0.0,0.06,hunter massey,
-AGM,2210,1,Land Measurements,0.31,0.42,0.19,0.08,0.0,0.0,0.0,0.0,charles privette,
-AGM,3030,1,Cal for Mech Ag,0.48,0.4,0.1,0.0,0.0,0.0,0.0,0.02,young han,
-AGM,4020,1,Land Drain and Irrig,0.1,0.55,0.3,0.05,0.0,0.0,0.0,0.0,charles privette,
-AGM,4100,1,Precision Ag Tech,0.24,0.44,0.22,0.1,0.0,0.0,0.0,0.0,hunter massey,
-AGM,4520,1,Mobile Power,0.24,0.44,0.24,0.05,0.0,0.0,0.0,0.02,hunter massey,
-AGM,4720,1,Capstone,0.07,0.36,0.57,0.0,0.0,0.0,0.0,0.0,john chastain,
-AL,3490,400,Principles of Coaching,0.41,0.22,0.33,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
-AL,3490,401,Principles of Coaching,0.31,0.52,0.1,0.03,0.03,0.0,0.0,0.0,deborah cadorette,
-AL,3490,402,Principles of Coaching,0.52,0.28,0.04,0.08,0.04,0.0,0.0,0.04,julia wright,
-AL,3490,403,Principles of Coaching,0.67,0.26,0.04,0.0,0.04,0.0,0.0,0.0,clyde keith connor,
-AL,3490,404,Principles of Coaching,0.5,0.31,0.12,0.04,0.04,0.0,0.0,0.0,clyde keith connor,
-AL,3490,405,Principles of Coaching,0.74,0.11,0.0,0.07,0.04,0.0,0.0,0.04,edmond fry,
-AL,3500,400,Sci Basis I/Ex Phy,0.22,0.19,0.26,0.22,0.07,0.0,0.0,0.04,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.36,0.16,0.32,0.08,0.04,0.0,0.0,0.04,michael godfrey,
-AL,3520,400,Kinesiology,0.42,0.05,0.16,0.16,0.11,0.0,0.0,0.11,michael godfrey,
-AL,3530,400,Athletic Injuries,0.42,0.15,0.27,0.15,0.0,0.0,0.0,0.0,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.22,0.22,0.22,0.17,0.13,0.0,0.0,0.04,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.38,0.19,0.05,0.05,0.0,0.0,0.0,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.81,0.12,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,401,Admin/Org of Athletic Programs,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,Admin/Org of Athletic Programs,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,henry oates,
-AL,3620,400,Psychology of Coaching,0.44,0.24,0.12,0.16,0.04,0.0,0.0,0.0,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.18,0.3,0.27,0.15,0.06,0.0,0.0,0.03,natalie anne carter,
-AL,3710,400,Coaching Baseball,0.65,0.1,0.1,0.1,0.05,0.0,0.0,0.0,justin hickey,
-AL,3720,400,Coaching Basketball,0.5,0.08,0.17,0.04,0.13,0.0,0.0,0.08,edmond fry,
-AL,3740,400,Coaching Football,0.54,0.21,0.08,0.0,0.17,0.0,0.0,0.0,edmond fry,
-AL,3760,400,Coaching Strength/Conditioning,0.58,0.17,0.04,0.08,0.04,0.0,0.0,0.08,edmond fry,
-AL,4380,400,Creative Inquire C&A,0.47,0.27,0.13,0.07,0.07,0.0,0.0,0.0,deborah cadorette,
-AL,4380,410,Coaching Rugby,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,deborah cadorette,
-AL,8640,400,Ethical Iss in Collegiate Athl,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,james satterfield,
-ANTH,2010,1,Introduction to Anthropology,0.05,0.25,0.37,0.15,0.08,0.0,0.0,0.1,john coggeshall,
-ANTH,2010,2,Introduction to Anthropology,0.37,0.44,0.14,0.03,0.01,0.0,0.0,0.01,katherine weisensee,
-ANTH,2010,3,Introduction to Anthropology,0.55,0.21,0.07,0.04,0.02,0.0,0.0,0.11,lisa rapaport,
-ANTH,3200,1,North American Indian Cultures,0.3,0.4,0.2,0.0,0.0,0.0,0.0,0.1,john coggeshall,
-ANTH,3310,1,Archaeology,0.24,0.35,0.35,0.06,0.0,0.0,0.0,0.0,melissa vogel,
-ANTH,3510,1,Biological Anthropology,0.35,0.4,0.2,0.05,0.0,0.0,0.0,0.0,katherine weisensee,
-ANTH,4230,1,Women in the Developing World,0.61,0.33,0.0,0.06,0.0,0.0,0.0,0.0,melissa vogel,
-APEC,2020,1,Agric Economics,0.87,0.11,0.02,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
-APEC,2050,1,Agric and Society,0.39,0.38,0.18,0.04,0.0,0.0,0.0,0.02,michael vassalos,
-APEC,3190,1,Agribusiness Mgt,0.34,0.3,0.26,0.04,0.02,0.0,0.0,0.04,michael vassalos,
-APEC,3570,1,Nat Resource Econ,0.29,0.19,0.27,0.19,0.02,0.0,0.0,0.04,david brian willis,
-APEC,4560,1,Prices,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
-ARAB,1010,1,Elementary Arabic I,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sulafa abou-samra,
-ARAB,1020,1,Elementary Arabic II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sulafa abou-samra,
-ARCH,1510,1,Arch Communication,0.53,0.41,0.0,0.0,0.06,0.0,0.0,0.0,sal hambright-belue,
-ARCH,1510,2,Arch Communication,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,robert silance,
-ARCH,1510,3,Arch Communication,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,junichi satoh,
-ARCH,1510,4,Arch Communication,0.58,0.21,0.05,0.05,0.0,0.0,0.0,0.11,clarissa mendez,
-ARCH,2520,1,Arch Foundations II,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,david lee,
-ARCH,2520,2,Arch Foundations II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,2520,4,Arch Foundations II,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2700,1,Structures I,0.43,0.36,0.14,0.07,0.0,0.0,0.0,0.0,robert john hogan,
-ARCH,2700,2,Structures I,0.47,0.47,0.0,0.0,0.06,0.0,0.0,0.0,robert john hogan,
-ARCH,2710,1,Structures II,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,michael carl kleiss,
-ARCH,3530,1,Studio Genoa,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
-ARCH,4010,1,Arch Portfolio,0.5,0.14,0.18,0.0,0.05,0.0,0.0,0.14,arash soleimani,
-ARCH,4520,1,Synthesis Studio,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,4520,2,Synthesis Studio,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,4520,3,Synthesis Studio,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,criss mills,
-ARCH,6880,1,Arch Programming,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ARCH,6990,2,Glass as a Modern Material,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8110,1,Visualization II,0.38,0.5,0.0,0.0,0.06,0.0,0.0,0.06,douglas hecker,
-ARCH,8200,1,Bldg Design & Constr,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,dennis bausman,
-ARCH,8420,1,Arch Studio II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,
-ARCH,8420,2,Arch Studio II,0.22,0.44,0.11,0.0,0.11,0.0,0.0,0.11,junichi satoh,
-ARCH,8610,1,History/Theory II,0.4,0.47,0.0,0.0,0.07,0.0,0.0,0.07,robert bruhns,
-ARCH,8710,1,Structures II,0.45,0.41,0.09,0.0,0.0,0.0,0.0,0.05,dustin gra albright,
-ARCH,8730,1,Environmental Sys,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,vincent yves blouin,
-ARCH,8740,1,Building Process:TR,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john jacques,
-ARCH,8740,2,Building Process:TR,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,john jacques,
-ARCH,8820,1,Building Economics,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,8900,1,Directed Studies,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,anjali joseph,
-ARCH,8920,2,Comprehensive Studio,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,8920,3,Comprehensive Studio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
-ARCH,8920,4,Comprehensive Studio,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,8920,5,Comprehensive Studio,0.0,0.7,0.3,0.0,0.0,0.0,0.0,0.0,keith green,
-ARCH,8960,1,A+H Studio: Tectonic,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ART,1060,1,Foundation Drawing II,0.52,0.24,0.14,0.0,0.05,0.0,0.0,0.05,kathleen ann thum,
-ART,1520,1,Foundations Art II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
-ART,2050,1,Beginning Life Drawing,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,alexandra giannell,
-ART,2070,1,Beginning Painting,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,hilary erin siber,
-ART,2090,1,Beginning Sculpture,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,tanna burchinal,
-ART,2130,1,Begin Photography,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,
-ART,2170,1,Beginning Ceramics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lindsey ann elsey,
-AS,1100,2,Air Force Today II,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,steven price jordan,
-AS,2100,3,Dev of Air Power II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,christopher mann,
-ASL,1010,2,Am Sign Lang I,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,william alton brant,
-ASL,1020,2,Am Sign Lang I,0.71,0.07,0.21,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2020,1,Am Sign Lang II,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASTR,1010,1,Solar System Astr,0.47,0.22,0.15,0.07,0.03,0.0,0.0,0.05,sean brittain,
-ASTR,1020,1,Stellar Astronomy,0.22,0.49,0.18,0.02,0.02,0.0,0.0,0.06,phillip flower,
-ASTR,1020,2,Stellar Astronomy,0.17,0.52,0.2,0.01,0.01,0.0,0.0,0.09,phillip flower,
-ASTR,1020,3,Stellar Astronomy,0.18,0.38,0.34,0.04,0.04,0.0,0.0,0.01,phillip flower,
-ASTR,1030,1,Solar Systm Astr Lab,0.58,0.19,0.04,0.0,0.08,0.0,0.0,0.12,mark leising,
-ASTR,1030,2,Solar Systm Astr Lab,0.5,0.15,0.05,0.05,0.15,0.0,0.0,0.1,mark leising,
-ASTR,1040,1,Stellar Astr Lab,0.44,0.32,0.2,0.0,0.04,0.0,0.0,0.0,mark leising,
-ASTR,1040,2,Stellar Astr Lab,0.35,0.45,0.15,0.0,0.05,0.0,0.0,0.0,mark leising,
-ASTR,1040,3,Stellar Astr Lab,0.64,0.28,0.0,0.0,0.0,0.0,0.0,0.08,mark leising,
-ASTR,1040,5,Stellar Astr Lab,0.33,0.33,0.17,0.0,0.11,0.0,0.0,0.06,mark leising,
-ASTR,1040,6,Stellar Astr Lab,0.14,0.52,0.24,0.0,0.1,0.0,0.0,0.0,mark leising,
-AUD,2850,1,Acoustics of Music,0.2,0.47,0.27,0.0,0.0,0.0,0.0,0.07,hamilton altstatt,
-AUE,8160,1,Eng Combustion Emiss,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8170,3,Alt Energy Sources,0.37,0.59,0.05,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8500,6,Stability/Safety Sys,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8550,16,Auto Struct Analysis,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8770,9,Light-Weight Design,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,
-AUE,8820,10,Systems Integration Method,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,
-AUE,8860,11,Noise Vibration,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8930,15,Innov & Entrepreneurship,0.56,0.42,0.0,0.0,0.0,0.0,0.0,0.02,david leo bodde,
-AUE,8930,16,Fundamentals of Injection Mold,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
-AVS,2010,1,Poultry Techniques,0.93,0.04,0.0,0.04,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,2050,1,Horsemanship Techniques,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
-AVS,2060,1,Swine Techniques,0.83,0.11,0.02,0.0,0.02,0.0,0.0,0.02,richelle lor miller,
-AVS,2090,1,Livestock Exhibition Technique,0.93,0.06,0.0,0.0,0.0,0.0,0.0,0.01,richelle lor miller,
-AVS,2110,1,Meat Processing Techniques,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brian bolt,
-AVS,2120,1,Small Ruminant Techniques,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,heather walker dunn,
-AVS,3010,1,Anat & Phys Dom Ani,0.4,0.29,0.22,0.04,0.04,0.0,0.0,0.02,tiffany wilmoth,
-AVS,3100,1,Animal Health,0.71,0.16,0.06,0.02,0.03,0.0,0.0,0.02,thomas scott,
-AVS,3150,1,Animal Welfare,0.27,0.36,0.27,0.05,0.05,0.0,0.0,0.0,peter skewes,
-AVS,3700,1,Prin Animal Nutr,0.1,0.18,0.4,0.11,0.18,0.0,0.0,0.03,nathan long,
-AVS,3750,1,Appl Animal Nutr,0.4,0.34,0.18,0.06,0.0,0.0,0.0,0.02,gustavo jos lascano,
-AVS,4000,1,AVS Professional Development,0.62,0.24,0.0,0.12,0.0,0.0,0.0,0.03,johanna joh lascano,
-AVS,4060,1,Seminars & Relat Top,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4090,2,Selected Topics/CAFLS Plus,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,thomas scott,
-AVS,4090,7,Sel Topics- Scientific Writing,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4100,1,Domestic Ani Behav,0.37,0.39,0.18,0.03,0.02,0.0,0.0,0.01,peter skewes,
-AVS,4110,400,Ani Growth & Develop,0.62,0.15,0.15,0.0,0.08,0.0,0.0,0.0,susan kay duckett,
-AVS,4120,1,Adv Equine Mgmt,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,4130,1,Animal Products,0.78,0.21,0.01,0.0,0.0,0.0,0.0,0.0,brian bolt,
-AVS,4170,1,Animal Agribusiness Develpmnt,0.23,0.68,0.09,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,4220,2,Special Problems/CAFLS Plus,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,thomas scott,
-AVS,4530,1,Animal Reproduction,0.5,0.31,0.17,0.0,0.0,0.0,0.0,0.02,glenn birrenkott,
-AVS,4530,400,Animal Reproduction,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,6110,1,Ani Growth & Develop,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,
-BCHM,3010,1,Molecular Biochem,0.25,0.21,0.25,0.13,0.06,0.0,0.0,0.1,meredith tei morris,
-BCHM,3010,2,Molecular Biochem(HON),0.68,0.15,0.15,0.0,0.0,0.0,0.0,0.03,meredith tei morris,True
-BCHM,3020,1,Molecular Biochemistry Lab,0.77,0.08,0.08,0.0,0.0,0.0,0.0,0.08,meredith tei morris,
-BCHM,3020,2,Molecular Biochemistry Lab,0.56,0.25,0.06,0.13,0.0,0.0,0.0,0.0,meredith tei morris,
-BCHM,3020,3,Molecular Biochemistry Lab,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,meredith tei morris,
-BCHM,3050,1,Essen Elements Bioch,0.32,0.36,0.18,0.05,0.05,0.0,0.0,0.04,srik chandrasekaran,
-BCHM,3050,2,Essen Elements Bioch,0.4,0.37,0.13,0.07,0.01,0.0,0.0,0.03,liangjiang wang,
-BCHM,4060,1,Physiological Chem,0.41,0.25,0.25,0.02,0.04,0.0,0.0,0.02,ashby burges bodine,
-BCHM,4320,1,Bioch of Metabolism,0.61,0.35,0.0,0.03,0.0,0.0,0.0,0.0,kimberly paul,
-BCHM,4340,1,General Biochemistry Lab II,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,kimberly paul,
-BCHM,4340,2,General Biochemistry Lab II,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,kimberly paul,
-BCHM,4360,1,Genes to Proteins,0.23,0.41,0.27,0.0,0.05,0.0,0.0,0.05,michael glen sehorn,
-BCHM,4360,2,Genes to Proteins(HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True
-BCHM,4900,1,Strategic Markting Relay 4 Lif,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,michael glen sehorn,
-BE,2100,1,Intro to Biosystems Engr,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,yi zheng,
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.29,0.33,0.29,0.04,0.04,0.0,0.0,0.0,tom owino,
-BE,4120,1,Be Heat Mass Trans,0.48,0.29,0.1,0.1,0.05,0.0,0.0,0.0,caye marie drapcho,
-BE,4240,1,Ecological Engr,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,
-BE,4380,1,Bioprocess Engineering Design,0.52,0.29,0.0,0.14,0.05,0.0,0.0,0.0,terry walker,
-BIOE,2010,1,Intro Biomed Engr,0.47,0.31,0.16,0.0,0.0,0.0,0.0,0.06,charles webb,
-BIOE,3020,1,Biomaterials,0.53,0.33,0.08,0.01,0.01,0.0,0.0,0.03,vladimir vla reukov,
-BIOE,3200,1,Biomechanics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,
-BIOE,3210,1,Biofluid Mechanics,0.34,0.43,0.12,0.05,0.0,0.0,0.0,0.06,sarah harcum,
-BIOE,3700,1,Bioinst & Imaging,0.29,0.53,0.11,0.0,0.02,0.0,0.0,0.05,david kwartowitz,
-BIOE,4030,1,Applied Bio E Design,0.97,0.01,0.0,0.01,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4200,1,Sports Engineering,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
-BIOE,4510,33,CI-Og Design,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,john desjardins,
-BIOE,6350,1,Modeling of Multiphysics Prob,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,guigen zhang,
-BIOE,8020,410,Biocompatibility,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
-BIOE,8150,410,Design Manuf Medical Devices,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,
-BIOE,8500,401,"Cells, Stem Cells & Dev't",0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ann catherine foley,
-BIOL,1040,1,General Biology II,0.24,0.31,0.25,0.12,0.05,0.0,0.0,0.05,nora espinoza,
-BIOL,1040,2,General Biology II,0.15,0.32,0.28,0.12,0.09,0.0,0.0,0.04,kalan ickes,
-BIOL,1040,3,General Biology II,0.46,0.33,0.14,0.05,0.01,0.0,0.0,0.0,william surver,
-BIOL,1040,4,General Biology II (HON),0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True
-BIOL,1060,1,Gen Biology Lab II,0.25,0.25,0.15,0.25,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,2,Gen Biology Lab II,0.11,0.26,0.21,0.32,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,3,Gen Biology Lab II,0.15,0.5,0.15,0.1,0.1,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,4,Gen Biology Lab II,0.2,0.2,0.25,0.25,0.0,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,5,Gen Biology Lab II,0.2,0.2,0.35,0.15,0.1,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,6,Gen Biology Lab II,0.2,0.25,0.15,0.2,0.2,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,7,Gen Biology Lab II,0.25,0.3,0.15,0.25,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,10,Gen Biology Lab II,0.0,0.3,0.3,0.25,0.05,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,11,Gen Biology Lab II,0.1,0.2,0.3,0.2,0.1,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,12,Gen Biology Lab II,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,13,Gen Biology Lab II,0.35,0.3,0.2,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,14,Gen Biology Lab II,0.1,0.25,0.35,0.2,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,15,Gen Biology Lab II,0.4,0.2,0.35,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,16,Gen Biology Lab II,0.25,0.35,0.15,0.15,0.1,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,17,Gen Biology Lab II,0.1,0.65,0.2,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,18,Gen Biology Lab II,0.3,0.3,0.2,0.1,0.1,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,19,Gen Biology Lab II,0.3,0.25,0.3,0.0,0.0,0.0,0.0,0.15,tafadzwa kaisa,
-BIOL,1060,21,Gen Biology Lab II,0.15,0.55,0.2,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,22,Gen Biology Lab II,0.35,0.35,0.25,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,25,Gen Biology Lab II,0.3,0.45,0.15,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,26,Gen Biology Lab II,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,27,Gen Biology Lab II,0.3,0.25,0.25,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,28,Gen Biology Lab II,0.35,0.25,0.25,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,29,Gen Biology Lab II,0.35,0.15,0.3,0.15,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,30,Gen Biology Lab II,0.2,0.2,0.3,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,31,Gen Biology Lab II,0.3,0.45,0.15,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,34,Gen Biology Lab II,0.26,0.53,0.16,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,36,Gen Biology Lab II,0.25,0.35,0.15,0.05,0.2,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,37,Gen Biology Lab II,0.32,0.32,0.21,0.05,0.11,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,38,Gen Biology Lab II,0.21,0.37,0.21,0.0,0.05,0.0,0.0,0.16,tafadzwa kaisa,
-BIOL,1060,39,Gen Biology Lab II,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,40,Gen Biology Lab II,0.3,0.25,0.2,0.05,0.1,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,41,Gen Biology Lab II,0.37,0.05,0.21,0.05,0.32,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,42,Gen Biology Lab II,0.3,0.25,0.15,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1090,1,Intro to Life Sci,0.67,0.19,0.14,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
-BIOL,1110,1,Prin of Biol II,0.26,0.51,0.12,0.08,0.01,0.0,0.0,0.02,robert kosinski,
-BIOL,1110,2,Prin of Biol II,0.43,0.35,0.18,0.0,0.03,0.0,0.0,0.01,dylan dittrich-reed,
-BIOL,1110,4,Prin of Biol II  (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True
-BIOL,1200,4,Biological Inq Lab,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,5,Biological Inq Lab,0.67,0.17,0.0,0.11,0.06,0.0,0.0,0.0, christine minor,
-BIOL,1200,6,Biological Inq Lab,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,9,Biological Inq Lab,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,
-BIOL,1200,12,Biological Inq Lab,0.5,0.33,0.06,0.0,0.11,0.0,0.0,0.0, christine minor,
-BIOL,1220,1,Keys to Biodiversity,0.36,0.2,0.16,0.12,0.12,0.0,0.0,0.04,kalan ickes,
-BIOL,1230,1,Keys to Human Biol,0.26,0.33,0.28,0.09,0.04,0.0,0.0,0.01, christine minor,
-BIOL,2000,2,Biology in the News,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,2000,4,Biology in the News,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,david tonkyn,
-BIOL,2000,5,Biology in the News,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
-BIOL,2000,8,Biology in the News,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,min cao,
-BIOL,2000,9,Biology in the News,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,michael sears,
-BIOL,2030,1,Human Disease & Soc,0.79,0.14,0.02,0.0,0.0,0.0,0.0,0.05, christine minor,
-BIOL,2040,1,"Environ, Energy and Society",0.47,0.26,0.13,0.11,0.01,0.0,0.0,0.02,john jenkins hains,
-BIOL,2110,1,Introduction to Toxicology,0.26,0.56,0.12,0.0,0.03,0.0,0.0,0.03,peter van den hurk,
-BIOL,2230,1,Human Anat and Physiology II,0.37,0.3,0.18,0.1,0.04,0.0,0.0,0.02,john cummings,
-BIOL,2230,2,Human Anat and Physiology II,0.51,0.31,0.15,0.01,0.0,0.0,0.0,0.02,john cummings,
-BIOL,3020,1,Invertebrate Biology,0.16,0.42,0.24,0.05,0.05,0.0,0.0,0.08,juan baeza migueles,
-BIOL,3040,1,Biology of Plants,0.6,0.29,0.1,0.0,0.02,0.0,0.0,0.0,christina wells,
-BIOL,3060,2,Invertebrate Biology Lab,0.05,0.5,0.3,0.1,0.05,0.0,0.0,0.0,juan baeza migueles,
-BIOL,3060,4,Invertebrate Biology Lab,0.18,0.35,0.29,0.06,0.0,0.0,0.0,0.12,juan baeza migueles,
-BIOL,3080,2,Biology of Plants Practicum,0.63,0.21,0.11,0.0,0.05,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3080,3,Biology of Plants Practicum,0.71,0.18,0.06,0.0,0.06,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3080,4,Biology of Plants Practicum,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert edwa ballard,
-BIOL,3130,1,Conservation Biology,0.28,0.44,0.16,0.12,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-BIOL,3130,2,Conservation Biology,0.21,0.37,0.26,0.11,0.0,0.0,0.0,0.05,shari lyn rodriguez,
-BIOL,3160,1,Human Physiology,0.29,0.45,0.23,0.02,0.01,0.0,0.0,0.01,tamara mcnutt-scott,
-BIOL,3200,1,Field Botany,0.13,0.31,0.28,0.11,0.11,0.0,0.0,0.06,timothy spira,
-BIOL,3350,1,Evolutionary Biology,0.19,0.44,0.19,0.06,0.03,0.0,0.0,0.09,lisa rapaport,
-BIOL,3510,1,Biological Anthropology,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
-BIOL,4010,1,Plant Physiology,0.16,0.19,0.41,0.22,0.03,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4020,2,Plant Physiology Lab,0.38,0.5,0.0,0.06,0.06,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4020,4,Plant Physiology Lab,0.53,0.24,0.18,0.06,0.0,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4030,3,Intro to Applied Genomics,0.18,0.18,0.27,0.0,0.09,0.0,0.0,0.27,vincent pa richards,
-BIOL,4100,1,Limnology,0.4,0.25,0.18,0.05,0.0,0.0,0.0,0.13,john jenkins hains,
-BIOL,4140,1,Basic Immunology,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,charles rice,
-BIOL,4340,1,Biological Chem Lab Techniques,0.17,0.25,0.5,0.08,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,2,Biological Chem Lab Techniques,0.0,0.58,0.33,0.08,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,3,Biological Chem Lab Techniques,0.09,0.36,0.27,0.09,0.18,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,4,Biological Chem Lab Techniques,0.2,0.2,0.3,0.2,0.0,0.0,0.0,0.1,salvatore sparace,
-BIOL,4340,5,Biological Chem Lab Techniques,0.0,0.55,0.36,0.09,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,6,Biological Chem Lab Techniques,0.1,0.4,0.3,0.0,0.1,0.0,0.0,0.1,salvatore sparace,
-BIOL,4400,1,Developmental Animal Biology,0.67,0.07,0.07,0.0,0.0,0.0,0.0,0.2,susan carol chapman,
-BIOL,4610,1,Cell Biology,0.23,0.3,0.26,0.14,0.05,0.0,0.0,0.03,lisa bain,
-BIOL,4610,2,Cell Biology (HON),0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,lisa bain,True
-BIOL,4620,1,Cell Biology Lab (Lec),0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,2,Cell Biology Lab (Lec),0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
-BIOL,4620,3,Cell Biology Lab (Lec),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,4,Cell Biology Lab (Lec),0.44,0.5,0.0,0.06,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,7,Cell Biology Lab (Lec),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,8,Cell Biology Lab (Lec),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
-BIOL,4620,9,Cell Biology Lab (Lec),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4640,1,Mammalogy,0.06,0.39,0.22,0.11,0.11,0.0,0.0,0.11,john cummings,
-BIOL,4670,1,Principles of Hematology,0.83,0.07,0.09,0.0,0.02,0.0,0.0,0.0,vincent gallicchio,
-BIOL,4700,1,Behavioral Ecology,0.37,0.42,0.11,0.02,0.06,0.0,0.0,0.01,michael childress,
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,michael childress,
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.53,0.2,0.0,0.07,0.0,0.0,0.0,0.2,michael childress,
-BIOL,4710,3,Behavioral Ecology Lab (Lec),0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,michael childress,
-BIOL,4710,4,Behavioral Ecology Lab (Lec),0.69,0.15,0.08,0.0,0.0,0.0,0.0,0.08,michael childress,
-BIOL,4930,2,Oceans End & Climate Sr Sem,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,andrew mount,
-BIOL,4930,4,Adv Cancer Research Sr Sem,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
-BIOL,6800,1,Vertebrate Endocrinology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,
-BIOL,8430,1,Underst Genetics & Evol Biol,0.91,0.05,0.01,0.0,0.02,0.0,0.0,0.01,renea chri hardwick,
-BIOL,8450,1,Understanding Vertebrate Biol,0.9,0.08,0.0,0.0,0.02,0.0,0.0,0.0,tamara mcnutt-scott,
-BIOL,8470,1,Understanding Microbiology,0.53,0.43,0.03,0.0,0.01,0.0,0.0,0.0,harry kurtz,
-BMOL,4250,1,Biomolecular Engineering,0.3,0.4,0.1,0.0,0.0,0.0,0.0,0.2,mark alan blenner,
-BUS,1010,1,Business Foundations,0.13,0.4,0.18,0.08,0.05,0.0,0.0,0.15,michael giebner,
-BUS,1010,2,Business Foundations,0.19,0.51,0.19,0.05,0.02,0.0,0.0,0.05,michael giebner,
-BUS,1010,3,Business Foundations,0.14,0.52,0.1,0.1,0.1,0.0,0.0,0.03,william ern tumblin,
-BUS,1010,4,Business Foundations,0.2,0.5,0.17,0.03,0.03,0.0,0.0,0.07,william ern tumblin,
-BUS,1010,6,Business Foundations,0.13,0.45,0.32,0.03,0.03,0.0,0.0,0.03,william ern tumblin,
-CE,2010,1,Statics,0.45,0.2,0.16,0.09,0.02,0.0,0.0,0.07,nighat yasmin,
-CE,2010,2,Statics,0.27,0.25,0.23,0.07,0.09,0.0,0.0,0.09,michael pa esposito,
-CE,2010,3,Statics,0.34,0.27,0.2,0.02,0.09,0.0,0.0,0.07,md akhter hossain,
-CE,2010,4,Statics,0.15,0.22,0.27,0.12,0.15,0.0,0.0,0.1,melissa sternhagen,
-CE,2010,5,Statics,0.7,0.16,0.09,0.0,0.02,0.0,0.0,0.02,nighat yasmin,
-CE,2010,6,Statics,0.44,0.23,0.03,0.1,0.08,0.0,0.0,0.13,michael pa esposito,
-CE,2010,7,Statics,0.18,0.12,0.18,0.12,0.24,0.0,0.0,0.18,thomas edfo cousins,
-CE,2060,1,Structural Mechanics,0.19,0.47,0.19,0.13,0.03,0.0,0.0,0.0,bryant nielson,
-CE,2060,2,Structural Mechanics,0.22,0.44,0.27,0.03,0.02,0.0,0.0,0.02,bryant nielson,
-CE,2080,1,Dynamics,0.32,0.43,0.23,0.0,0.0,0.0,0.0,0.02,melissa sternhagen,
-CE,2080,2,Dynamics,0.2,0.59,0.14,0.04,0.0,0.0,0.0,0.02,melissa sternhagen,
-CE,2080,3,Dynamics,0.15,0.63,0.15,0.03,0.0,0.0,0.0,0.05,melissa sternhagen,
-CE,2550,1,Geomatics,0.25,0.42,0.22,0.06,0.01,0.0,0.0,0.04,wayne sarasua,
-CE,3010,1,Structural Analysis,0.22,0.3,0.22,0.16,0.1,0.0,0.0,0.0,stephen csernak,
-CE,3110,1,Transportation Engr,0.22,0.51,0.21,0.01,0.0,0.0,0.0,0.04,wayne sarasua,
-CE,3210,1,Geotechnical Engineering,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
-CE,3210,2,Geotechnical Engineering,0.3,0.3,0.28,0.1,0.03,0.0,0.0,0.0,charng-hsein juang,
-CE,3310,1,Constr Engr & Mgmnt,0.28,0.36,0.26,0.08,0.0,0.0,0.0,0.02,james burati,
-CE,3410,1,Intro to Fluid Mech,0.15,0.41,0.29,0.07,0.05,0.0,0.0,0.02,nigel gregory kaye,
-CE,3420,1,Hydraulics & Hydro,0.12,0.39,0.27,0.09,0.03,0.0,0.0,0.09,abdul khan,
-CE,3420,2,Hydraulics & Hydro,0.5,0.38,0.1,0.0,0.0,0.0,0.0,0.03,ashok mishra,
-CE,3510,1,Civil Engineering Materials,0.33,0.56,0.05,0.05,0.02,0.0,0.0,0.0,prasada rangaraju,
-CE,3520,1,Econ Eval of Proj,0.35,0.23,0.2,0.15,0.05,0.0,0.0,0.02,yongxi huang,
-CE,3520,2,Econ Eval of Proj,0.53,0.31,0.14,0.02,0.0,0.0,0.0,0.0,bradley putman,
-CE,3530,1,Professional Seminar,0.92,0.06,0.01,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,4010,1,Matrix Str Analysis,0.08,0.5,0.0,0.08,0.17,0.0,0.0,0.17,bryant nielson,
-CE,4020,1,Reinfor Con Design,0.42,0.36,0.16,0.04,0.02,0.0,0.0,0.0,brandon ross,
-CE,4040,1,Masonry Struct Des,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,atamturktur russcher,
-CE,4110,1,Roadway Geo Design,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
-CE,4120,1,Urban Transport Plan,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,mashrur chowdhury,
-CE,4210,1,Geotechnical Design,0.26,0.57,0.11,0.06,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,4330,1,Const Plan & Sched,0.39,0.42,0.15,0.01,0.01,0.0,0.0,0.01, kent nilsson,
-CE,4340,1,Const Est Proj Cont,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,4470,1,Stormwater Managemnt,0.36,0.52,0.08,0.0,0.0,0.0,0.0,0.04,nigel gregory kaye,
-CE,4590,1,Capstone Design Proj,0.52,0.44,0.05,0.0,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4590,100,Capstone Design Proj,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,
-CE,6010,1,Matrix Str Analysis,0.29,0.52,0.14,0.0,0.05,0.0,0.0,0.0,bryant nielson,
-CE,6040,1,Masonry Struct Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
-CE,6210,1,Geotechnical Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,6330,1,Const Plan & Sched,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0, kent nilsson,
-CE,8040,1,Prestressed Concrete,0.49,0.41,0.1,0.0,0.0,0.0,0.0,0.0,brandon ross,
-CE,8080,1,Earthquake Engr,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CE,8250,1,Geotech Equake Engr,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,8270,1,Spec Cements & Concr,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,prasada rangaraju,
-CE,8530,1,Apps in Traffic En,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CE,8930,2,Selec Topics in C E - Construc,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,james burati,
-CE,9910,19,Doctoral Dissertation Research,0.0,0.0,0.0,0.0,0.0,0.8,0.2,0.0,leidy klotz,
-CH,1010,1,General Chemistry,0.09,0.23,0.3,0.2,0.12,0.0,0.0,0.06,ava kreider-mueller,
-CH,1010,2,General Chemistry,0.07,0.21,0.3,0.2,0.14,0.0,0.0,0.08,ava kreider-mueller,
-CH,1010,3,General Chemistry,0.17,0.29,0.28,0.11,0.1,0.0,0.0,0.05,dennis taylor,
-CH,1010,4,General Chemistry,0.1,0.19,0.25,0.25,0.13,0.0,0.0,0.08,joseph stu thrasher,
-CH,1010,400,General Chemistry (ONLINE),0.21,0.19,0.36,0.08,0.13,0.0,0.0,0.03,stephe schvaneveldt,
-CH,1020,1,General Chemistry,0.2,0.25,0.2,0.18,0.08,0.0,0.0,0.1,christopher wilson,
-CH,1020,2,General Chemistry,0.19,0.26,0.26,0.12,0.04,0.0,0.0,0.14,christopher wilson,
-CH,1020,3,General Chemistry,0.29,0.38,0.25,0.03,0.01,0.0,0.0,0.03,dennis taylor,
-CH,1020,4,General Chemistry,0.25,0.42,0.22,0.06,0.03,0.0,0.0,0.03,dennis taylor,
-CH,1020,5,General Chemistry,0.15,0.39,0.31,0.07,0.04,0.0,0.0,0.04,olt geiculescu,
-CH,1020,7,General Chemistry,0.21,0.53,0.16,0.06,0.02,0.0,0.0,0.03,kenneth wi rillings,
-CH,1020,8,General Chemistry,0.23,0.4,0.26,0.06,0.02,0.0,0.0,0.03,kenneth wi rillings,
-CH,1020,9,General Chemistry,0.24,0.41,0.23,0.05,0.05,0.0,0.0,0.02,ava kreider-mueller,
-CH,1020,10,General Chemistry,0.21,0.42,0.32,0.04,0.02,0.0,0.0,0.0,kenneth wi rillings,
-CH,1020,11,General Chemistry (CH majors),0.55,0.18,0.24,0.0,0.0,0.0,0.0,0.03,stephe schvaneveldt,
-CH,1020,12,General Chemistry (CLUE),0.36,0.5,0.07,0.02,0.0,0.0,0.0,0.05,kenneth christensen,
-CH,1020,51,General Chemistry (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
-CH,1020,52,General Chemistry (HON),0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,shiou-jyh hwu,True
-CH,1050,1,Chem in Context I,0.27,0.45,0.24,0.03,0.0,0.0,0.0,0.01,thomas hickman,
-CH,1060,1,Chem in Context II,0.36,0.61,0.0,0.0,0.04,0.0,0.0,0.0,olt geiculescu,
-CH,1060,2,Chem in Context II,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,olt geiculescu,
-CH,1520,1,Chem Commun I,0.83,0.02,0.02,0.0,0.0,0.0,0.0,0.13,richard marcus,
-CH,2010,1,Survey of Organic Chemistry,0.37,0.26,0.19,0.1,0.04,0.0,0.0,0.03,tania issa houjeiry,
-CH,2020,1,Surv of Organic Chemistry Lab,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,
-CH,2020,2,Surv of Organic Chemistry Lab,0.53,0.29,0.12,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2020,3,Surv of Organic Chemistry Lab,0.71,0.18,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2050,1,Intro Inorg Chem,0.54,0.29,0.17,0.0,0.0,0.0,0.0,0.0,william pennington,
-CH,2230,1,Organic Chemistry,0.23,0.3,0.12,0.12,0.17,0.0,0.0,0.07,jacob schroeder,
-CH,2230,2,Organic Chemistry,0.44,0.27,0.14,0.06,0.03,0.0,0.0,0.06,jacob schroeder,
-CH,2230,3,Organic Chemistry,0.35,0.33,0.08,0.07,0.11,0.0,0.0,0.07,jacob schroeder,
-CH,2240,1,Organic Chemistry,0.39,0.43,0.12,0.05,0.0,0.0,0.0,0.01,tania issa houjeiry,
-CH,2240,2,Organic Chemistry,0.29,0.57,0.09,0.03,0.02,0.0,0.0,0.0,thomas hickman,
-CH,2240,3,Organic Chemistry,0.22,0.39,0.24,0.1,0.02,0.0,0.0,0.04,thomas hickman,
-CH,2240,4,Organic Chemistry,0.37,0.26,0.09,0.12,0.07,0.0,0.0,0.09,rhett smith,
-CH,2240,5,Organic Chemistry,0.33,0.4,0.18,0.02,0.04,0.0,0.0,0.04,jacob schroeder,
-CH,2270,1,Organic Chem Lab,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,5,Organic Chem Lab,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,8,Organic Chem Lab,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,9,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,1,Organic Chem Lab,0.62,0.08,0.0,0.0,0.0,0.0,0.0,0.31,sean 'connor,
-CH,2280,2,Organic Chem Lab,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,
-CH,2280,3,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2280,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,7,Organic Chem Lab,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2280,8,Organic Chem Lab,0.73,0.13,0.0,0.07,0.0,0.0,0.0,0.07,sean 'connor,
-CH,2280,12,Organic Chem Lab,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,21,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,sean 'connor,
-CH,2280,24,Organic Chem Lab,0.63,0.19,0.13,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2290,3,Organic Chem Lab,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,3310,1,Physical Chemistry,0.42,0.32,0.11,0.05,0.0,0.0,0.0,0.11,arkady kholodenko,
-CH,3320,1,Physical Chemistry (ENGR only),0.49,0.33,0.13,0.03,0.01,0.0,0.0,0.0,steven stuart,
-CH,3320,2,Physical Chemistry (CH majors),0.42,0.29,0.21,0.04,0.04,0.0,0.0,0.0,jason mcneill,
-CH,3400,2,Physical Chem Lab,0.78,0.17,0.0,0.06,0.0,0.0,0.0,0.0,christopher wilson,
-CH,3400,3,Physical Chem Lab,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,christopher wilson,
-CH,3400,4,Physical Chem Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,
-CH,3600,1,Chemical Biology,0.38,0.27,0.17,0.1,0.0,0.0,0.0,0.08,modi wetzler,
-CH,4110,1,Instrumental Analy,0.23,0.32,0.09,0.18,0.18,0.0,0.0,0.0,george chumanov,
-CH,4120,1,Instr Analysis Lab,0.33,0.25,0.25,0.08,0.08,0.0,0.0,0.0,jeffrey natha anker,
-CH,4120,2,Instr Analysis Lab,0.55,0.27,0.09,0.09,0.0,0.0,0.0,0.0,jeffrey natha anker,
-CH,4130,1,Chem Aqueous Systems,0.42,0.32,0.11,0.0,0.0,0.0,0.0,0.16,cindy lee,
-CH,4500,1,Chemistry Capstone,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
-CH,8090,1,Chem App/X-Ray Cryst,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,
-CH,8130,1,Electrochem Sci,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,stephen creager,
-CH,8510,1,Grad Student Seminar,0.82,0.07,0.07,0.0,0.04,0.0,0.0,0.0,joseph stu thrasher,
-CHE,1300,1,Chemical Eng Tools,0.27,0.41,0.14,0.02,0.08,0.0,0.0,0.08,christopher norfolk,
-CHE,1300,2,Chemical Eng Tools,0.35,0.33,0.15,0.09,0.03,0.0,0.0,0.05,christopher norfolk,
-CHE,2200,1,Ch E Thermo I,0.22,0.2,0.27,0.1,0.16,0.0,0.0,0.06,mark thies,
-CHE,2200,2,Ch E Thermo I,0.25,0.19,0.25,0.17,0.14,0.0,0.0,0.0,mark thies,
-CHE,2300,1,Fluids/Heat Transfer,0.12,0.22,0.41,0.14,0.06,0.0,0.0,0.04,douglas hirt,
-CHE,2300,2,Fluids/Heat Transfer,0.19,0.33,0.19,0.19,0.08,0.0,0.0,0.0,douglas hirt,
-CHE,3210,1,Ch E Thermo II,0.23,0.23,0.39,0.09,0.07,0.0,0.0,0.0,christophe kitchens,
-CHE,3300,1,Mass Trans & Seprtn,0.23,0.32,0.25,0.08,0.12,0.0,0.0,0.0,mark alan blenner,
-CHE,3530,1,Proc Dyn & Control,0.22,0.49,0.24,0.04,0.02,0.0,0.0,0.0,mark roberts,
-CHE,4330,1,Process Design II,0.57,0.37,0.06,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,4990,14,CI- Membrane Separations,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,scott husson,
-CHIN,1010,1,Elementary Chinese,0.47,0.26,0.16,0.11,0.0,0.0,0.0,0.0,yanhua zhang,
-CHIN,1020,1,Elementary Chinese,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,yanming an,
-COM,1500,1,Intro to Human Com,0.89,0.07,0.01,0.0,0.01,0.0,0.0,0.03,eddie smith,
-COM,1500,2,Intro to Human Com,0.49,0.44,0.03,0.01,0.01,0.0,0.0,0.01,daniel lelan fecher,
-COM,1500,3,Intro to Human Com,0.85,0.13,0.0,0.0,0.01,0.0,0.0,0.01,eddie smith,
-COM,1500,4,Intro to Human Com,0.78,0.16,0.02,0.01,0.01,0.0,0.0,0.02,marianne her glaser,
-COM,1500,5,Intro to Human Com,0.66,0.28,0.03,0.01,0.0,0.0,0.0,0.02,marianne her glaser,
-COM,1500,6,Intro to Human Com,0.54,0.41,0.04,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,
-COM,1500,6,Intro to Human Communication,0.54,0.41,0.04,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,
-COM,2010,1,Intr to Comm Studies,0.44,0.36,0.2,0.0,0.0,0.0,0.0,0.0,brenden kendall,
-COM,2010,2,Intr to Comm Studies,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,2500,1,Public Speaking,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,2,Public Speaking,0.47,0.32,0.05,0.05,0.0,0.0,0.0,0.11,marilyn denise pugh,
-COM,2500,3,Public Speaking,0.5,0.45,0.0,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,4,Public Speaking,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,5,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,6,Public Speaking,0.45,0.4,0.1,0.0,0.05,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,7,Public Speaking,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,8,Public Speaking,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,10,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,11,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,
-COM,2500,13,Public Speaking,0.26,0.53,0.16,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
-COM,2500,14,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,
-COM,2500,15,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,
-COM,2500,16,Public Speaking,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,the estate  geddes,
-COM,2500,17,Public Speaking,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,pauline matthey,
-COM,2500,18,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,19,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,20,Public Speaking,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,pauline matthey,
-COM,2500,21,Public Speaking,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,22,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,23,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,24,Public Speaking,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,pauline matthey,
-COM,2500,28,Public Speaking,0.26,0.53,0.05,0.05,0.0,0.0,0.0,0.11,marilyn denise pugh,
-COM,2500,400,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,401,Public Speaking,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,402,Public Speaking,0.72,0.11,0.0,0.06,0.0,0.0,0.0,0.11,alexis zachar davis,
-COM,2500,403,Public Speaking,0.63,0.26,0.0,0.05,0.05,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,500,Public Speaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,501,Public Speaking,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,3010,1,Comm Theory,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,3020,1,Mass Comm Theory,0.62,0.3,0.04,0.04,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3080,1,Pub Comm & Pop Cult,0.29,0.42,0.19,0.03,0.0,0.0,0.0,0.06,chenjerai kumanyika,
-COM,3100,1,Quant Comm Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3110,1,Qual Comm Methods,0.58,0.25,0.13,0.0,0.04,0.0,0.0,0.0,stephanie pangborn,
-COM,3200,1,Bdcst Production,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,wanda johnson,
-COM,3260,1,Pr in Sports,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3480,1,Interpersonal Comm,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,melinda ra weathers,
-COM,3500,1,Sm Group & Team Comm,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,joseph mazer,
-COM,3560,1,Stakeholder Comm,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3660,1,EP: Advertising & Media,0.56,0.32,0.04,0.04,0.0,0.0,0.0,0.04,william reynolds,
-COM,3660,2,EP: Building the Brand,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,andrew mendelsohn,
-COM,3660,3,Live Broadcast Production,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,michael rodgers,
-COM,3680,1,Applied Digital Communication,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,
-COM,3990,6,CI: Tigers Talk Ethics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,
-COM,4260,1,Social Media and Sports Comm,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4260,2,Social Media and Sports Comm,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4700,1,Comm & Health,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,stephanie pangborn,
-COM,4950,1,Sr. Capstone: Agenda Building,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,bryan denham,
-COM,4950,2,Sr. Capstone: Advert. & Sport,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,8110,1,Comm Research Methods II,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,chenjerai kumanyika,
-CPSC,1010,1,Computer Science I,0.19,0.18,0.19,0.12,0.14,0.0,0.0,0.18,catherine hochrine,
-CPSC,1010,2,Computer Science I,0.61,0.24,0.1,0.0,0.0,0.0,0.0,0.05,lauren elizab dukes,
-CPSC,1020,1,Computer Science II,0.48,0.24,0.08,0.0,0.08,0.0,0.0,0.12,catherine hochrine,
-CPSC,1020,2,Computer Science II,0.62,0.12,0.04,0.0,0.04,0.0,0.0,0.19,yvon feaster,
-CPSC,1020,3,Computer Science II,0.68,0.04,0.08,0.0,0.08,0.0,0.0,0.12,yvon feaster,
-CPSC,1020,4,Computer Science II,0.33,0.24,0.14,0.05,0.05,0.0,0.0,0.19,joshua levine,
-CPSC,1110,1,Intro to Programming in C,0.68,0.25,0.0,0.0,0.04,0.0,0.0,0.04,patrick sterling,
-CPSC,1110,2,Intro to Programming in C,0.77,0.1,0.07,0.03,0.0,0.0,0.0,0.03,patrick sterling,
-CPSC,1110,3,Intro to Programming in C,0.57,0.2,0.07,0.07,0.03,0.0,0.0,0.07,patrick sterling,
-CPSC,1110,4,Intro to Programming in C,0.63,0.04,0.04,0.04,0.15,0.0,0.0,0.11,toni bloodwor pence,
-CPSC,1200,1,Intro Info Tech,0.82,0.06,0.0,0.0,0.06,0.0,0.0,0.06,renee lambert,
-CPSC,2070,1,Discrete Structures,0.34,0.25,0.18,0.02,0.09,0.0,0.0,0.11,sandra hedetniemi,
-CPSC,2070,401,Discrete Structures,0.2,0.34,0.25,0.13,0.05,0.0,0.0,0.04,larry hodges,
-CPSC,2100,1,Progrmng Methodology,0.23,0.23,0.23,0.06,0.2,0.0,0.0,0.06,rose lowe,
-CPSC,2120,1,Algs/Data Structures,0.36,0.31,0.16,0.05,0.12,0.0,0.0,0.01,wayne goddard,
-CPSC,2150,1,Software Dev Fndtns,0.35,0.39,0.15,0.07,0.02,0.0,0.0,0.02,yu-shan sun,
-CPSC,2150,2,Software Dev Fndtns,0.23,0.21,0.32,0.06,0.11,0.0,0.0,0.06,blair madiso durkee,
-CPSC,2200,1,Microcomputer Appl,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,patrick sterling,
-CPSC,2310,1,Intro Computer Org,0.21,0.31,0.36,0.05,0.05,0.0,0.0,0.03,rose lowe,
-CPSC,2310,2,Intro Computer Org,0.32,0.32,0.24,0.0,0.09,0.0,0.0,0.03,rose lowe,
-CPSC,2910,2,Prof Issues I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,renee lambert,
-CPSC,2910,3,Prof Issues I,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,renee lambert,
-CPSC,2910,4,Prof Issues I,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,renee lambert,
-CPSC,2910,5,Prof Issues I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
-CPSC,2910,6,Prof Issues I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
-CPSC,2910,7,Prof Issues I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,james jones,
-CPSC,3220,1,Intro to Operating Systems,0.26,0.21,0.23,0.05,0.18,0.0,0.0,0.08,jacob sorber,
-CPSC,3220,2,Intro to Operating Systems,0.17,0.14,0.2,0.09,0.17,0.0,0.0,0.23,jacob sorber,
-CPSC,3300,1,Computer Systems Org,0.27,0.24,0.26,0.06,0.1,0.0,0.0,0.06,mark smotherman,
-CPSC,3500,1,Foundations of Computer Sci,0.15,0.23,0.37,0.1,0.06,0.0,0.0,0.1,ilya mark safro,
-CPSC,3520,1,Programming Systems,0.41,0.3,0.05,0.0,0.09,0.0,0.0,0.16,robert schalkoff,
-CPSC,3600,1,Network Programming,0.16,0.27,0.25,0.16,0.1,0.0,0.0,0.06,sekou lionel remy,
-CPSC,3620,1,Distributed Computng,0.29,0.38,0.15,0.08,0.04,0.0,0.0,0.06,linh bao ngo,
-CPSC,3720,1,Software Engineering,0.17,0.39,0.3,0.04,0.04,0.0,0.0,0.04,stephen schaub,
-CPSC,3720,2,Software Engineering,0.26,0.29,0.29,0.1,0.03,0.0,0.0,0.03,stephen schaub,
-CPSC,4050,1,Computer Graphics,0.26,0.52,0.13,0.04,0.0,0.0,0.0,0.04,robert geist,
-CPSC,4140,1,Human and Computer Interaction,0.35,0.48,0.04,0.04,0.09,0.0,0.0,0.0,sabarish venka babu,
-CPSC,4140,2,Human and Computer Interaction,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,kelly caine,
-CPSC,4160,1,2-D Game Engine Construction,0.5,0.33,0.1,0.0,0.07,0.0,0.0,0.0,brian malloy,
-CPSC,4240,1,System Admin and Security,0.15,0.58,0.19,0.04,0.04,0.0,0.0,0.0,james martin,
-CPSC,4620,1,Database Management Systems,0.22,0.44,0.22,0.07,0.04,0.0,0.0,0.0,zijun wang,
-CPSC,4820,1,Design & Implementation,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,christina sop joerg,
-CPSC,4820,2,Mobile Device,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,roy pargas,
-CPSC,4910,1,Prof Issues II,0.93,0.04,0.0,0.0,0.02,0.0,0.0,0.0,james jones,
-CPSC,6050,1,Computer Graphics,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,robert geist,
-CPSC,6140,1,Human and Computer Interaction,0.57,0.29,0.07,0.0,0.0,0.0,0.0,0.07,sabarish venka babu,
-CPSC,6140,2,Human and Computer Interaction,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,kelly caine,
-CPSC,6160,1,2-D Game Engine Construction,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,brian malloy,
-CPSC,6240,1,System Admin and Security,0.57,0.29,0.07,0.0,0.0,0.0,0.0,0.07,james martin,
-CPSC,6620,1,Database Management Systems,0.46,0.27,0.19,0.0,0.08,0.0,0.0,0.0,zijun wang,
-CPSC,6820,1,Special Topics:Design & Imple,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-CPSC,8080,1,Advanced Animation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
-CPSC,8090,1,Render and Shade,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,
-CPSC,8220,1,Case Study in Operating Sys,0.27,0.67,0.0,0.0,0.0,0.0,0.0,0.07,robert geist,
-CPSC,8280,1,Theory of Program. Languages,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,murali sitaraman,
-CPSC,8550,1,Embedded Network Sys,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,yvon feaster,
-CPSC,8620,1,Database Mngmt System Design,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,zijun wang,
-CPSC,8630,1,Multimedia Sys/Apps,0.27,0.5,0.14,0.0,0.05,0.0,0.0,0.05,zijun wang,
-CPSC,8750,1,Software Architectur,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-CPSC,8810,1,Topic:Info Retrieval,0.23,0.65,0.1,0.0,0.0,0.0,0.0,0.03,feng luo,
-CPSC,8810,2,Advanced Networking & Security,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,hongxin hu,
-CRP,8020,1,Site Planning,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,clifford dona ellis,
-CRP,8040,1,Land Use Analysis,0.82,0.0,0.12,0.0,0.0,0.0,0.0,0.06,stephen sperry,
-CRP,8050,1,Plning Theory & Hist,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,mickey lauria,
-CRP,8090,1,Current Issues,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
-CRP,8130,1,Transportation Plan,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
-CRP,8200,1,Negotiation,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
-CRP,8220,1,Urban Design,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-CSM,1500,1,Constr Prob Solving,0.39,0.56,0.0,0.0,0.06,0.0,0.0,0.0,jason lucas,
-CSM,1500,2,Constr Prob Solving,0.57,0.24,0.19,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,1500,3,Constr Prob Solving,0.3,0.6,0.05,0.05,0.0,0.0,0.0,0.0,jason lucas,
-CSM,2020,1,Structures II,0.24,0.38,0.24,0.14,0.0,0.0,0.0,0.0,shima clarke,
-CSM,2020,2,Structures II,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,shima clarke,
-CSM,2040,1,Cont Documents,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2040,2,Cont Documents,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2050,1,Mats & Methods II,0.37,0.33,0.22,0.07,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2050,2,Mats & Methods II,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,3050,1,Envir Systems II,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3050,2,Envir Systems II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3520,1,Const Scheduling,0.2,0.5,0.25,0.0,0.0,0.0,0.0,0.05,christine piper,
-CSM,3520,2,Const Scheduling,0.16,0.32,0.53,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,3530,1,Const Estimating II,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,james packer smith,
-CSM,3530,2,Const Estimating II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,james packer smith,
-CSM,4540,1,Const Capstone,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4540,2,Const Capstone,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8610,1,Construction Control Systems,0.07,0.67,0.27,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8610,400,Construction Control Systems,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,christine piper,
-CSM,8810,1,Professional Seminar,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CSM,8810,400,Professional Seminar,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.06,0.03,jeffrey appling,
-CU,1010,1,Univ Success Skills,0.83,0.04,0.04,0.04,0.0,0.0,0.0,0.04,rise jean sheriff,
-CU,1010,2,Univ Success Skills,0.68,0.05,0.14,0.05,0.0,0.0,0.0,0.09,cecelia hamby,
-CU,1010,3,Univ Success Skills,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,matthew james kirk,
-CU,1010,4,Univ Success Skills,0.41,0.55,0.0,0.0,0.03,0.0,0.0,0.0,matthew james kirk,
-CU,1010,5,Univ Success Skills,0.54,0.33,0.04,0.0,0.0,0.0,0.0,0.08,mary mcp von kaenel,
-CU,1010,6,Univ Success Skills,0.65,0.17,0.13,0.0,0.04,0.0,0.0,0.0,robert dav brackett,
-CU,1010,7,Univ Success Skills,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,deborah ann vaughn,
-CU,2010,1,Sustainability Leadership,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,
-DPA,3070,1,Method 3d Production,0.52,0.19,0.05,0.1,0.0,0.0,0.0,0.14,virginia ba nearing,
-DPA,8600,1,Production Studio,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,
-DPA,8600,2,Production Studio,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,
-ECE,2010,1,Logic & Comp Device,0.19,0.32,0.18,0.19,0.09,0.0,0.0,0.04,lin zhu,
-ECE,2020,1,Electric Circuits I,0.14,0.22,0.29,0.18,0.12,0.0,0.0,0.04,william harrell,
-ECE,2070,1,Basic Electrical Engineering,0.44,0.24,0.14,0.05,0.04,0.0,0.0,0.09,surya sharma,
-ECE,2070,2,Basic Electrical Engineering,0.56,0.33,0.1,0.01,0.0,0.0,0.0,0.0,hai xiao,
-ECE,2070,3,Basic Electrical Engineering,0.89,0.04,0.05,0.0,0.0,0.0,0.0,0.01,sung- kim,
-ECE,2080,5,Electrical Engineering Lab I,0.8,0.1,0.0,0.05,0.0,0.0,0.0,0.05,william harrell,
-ECE,2080,8,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,william harrell,
-ECE,2080,13,Electrical Engineering Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,
-ECE,2080,17,Electrical Engineering Lab I,0.78,0.06,0.06,0.0,0.06,0.0,0.0,0.06,william harrell,
-ECE,2080,18,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,william harrell,
-ECE,2080,20,Electrical Engineering Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2090,4,Logic Lab,0.67,0.08,0.08,0.08,0.0,0.0,0.0,0.08,william harrell,
-ECE,2220,1,Syst Prog Concept,0.23,0.21,0.23,0.12,0.1,0.0,0.0,0.12,william reid,
-ECE,2230,1,Comp Sys Eng,0.2,0.12,0.32,0.05,0.15,0.0,0.0,0.17,harlan russell,
-ECE,2620,1,Elec Circuits II,0.33,0.27,0.23,0.09,0.07,0.0,0.0,0.01,richard groff,
-ECE,2620,2,Elec Circuits II (HON),0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
-ECE,2720,1,Comp Organization,0.28,0.31,0.25,0.11,0.05,0.0,0.0,0.0,william reid,
-ECE,2720,1,,0.28,0.31,0.25,0.11,0.05,0.0,0.0,0.0,william reid,
-ECE,2730,1,Computer Org Lab,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2730,3,Computer Org Lab,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,william harrell,
-ECE,2730,4,Computer Org Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2730,5,Computer Org Lab,0.71,0.14,0.07,0.0,0.07,0.0,0.0,0.0,william harrell,
-ECE,2730,6,Computer Org Lab,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,2730,7,Computer Org Lab,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,3110,1,Electrical Engineering Lab III,0.56,0.13,0.0,0.13,0.13,0.0,0.0,0.06,william harrell,
-ECE,3110,4,Electrical Engineering Lab III,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,william harrell,
-ECE,3110,5,Electrical Engineering Lab III,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,
-ECE,3170,1,Rand Signal Analysis,0.16,0.34,0.2,0.09,0.13,0.0,0.0,0.08,stephen hubbard,
-ECE,3170,2,Rand Signal Analysis (HON),0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,carl baum,True
-ECE,3200,1,Electronics I,0.28,0.22,0.15,0.13,0.2,0.0,0.0,0.03,stephen hubbard,
-ECE,3210,1,Electronics II,0.55,0.27,0.09,0.02,0.08,0.0,0.0,0.0,stephen hubbard,
-ECE,3220,1,Intro Operating Sys,0.06,0.41,0.35,0.06,0.0,0.0,0.0,0.12,jacob sorber,
-ECE,3220,2,Intro Operating Sys,0.05,0.35,0.4,0.05,0.05,0.0,0.0,0.1,jacob sorber,
-ECE,3270,1,Dig Comp Design,0.1,0.26,0.26,0.08,0.08,0.0,0.0,0.23,melissa crawl smith,
-ECE,3300,1,Signals & Systems,0.21,0.19,0.23,0.14,0.14,0.0,0.0,0.08,carl baum,
-ECE,3520,1,Programming Systems,0.28,0.48,0.14,0.03,0.0,0.0,0.0,0.07,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.25,0.29,0.25,0.06,0.06,0.0,0.0,0.08,edward collins,
-ECE,3710,1,Microcontr Interface,0.4,0.38,0.2,0.01,0.01,0.0,0.0,0.0,william reid,
-ECE,3720,6,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,3800,1,Electromagnetics,0.23,0.18,0.36,0.13,0.1,0.0,0.0,0.0,anthony martin,
-ECE,3810,1,Field Waves & Ckts,0.45,0.33,0.16,0.04,0.02,0.0,0.0,0.0,eric gordon johnson,
-ECE,4090,1,Cont & Discrete Sys,0.37,0.4,0.17,0.06,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4190,1,Elec Mach and Drives,0.28,0.38,0.21,0.0,0.03,0.0,0.0,0.1,keith corzine,
-ECE,4270,1,Communications Sys,0.24,0.29,0.3,0.09,0.05,0.0,0.0,0.03,madhabi manandhar,
-ECE,4380,1,Computer Commun,0.28,0.18,0.23,0.13,0.05,0.0,0.0,0.15,harlan russell,
-ECE,4680,1,Embedded Computing,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,adam hoover,
-ECE,4700,1,Vehicle Electronics,0.54,0.35,0.06,0.04,0.0,0.0,0.0,0.0,todd hubing,
-ECE,4950,1,Int Sys Design I,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4960,1,Int Sys Design II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,richard groff,
-ECE,6190,1,Elec Mach and Drives,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,keith corzine,
-ECE,6380,1,Computer Commun,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
-ECE,6460,1,Antennas,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,anthony martin,
-ECE,6680,1,Embedded Computing,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,adam hoover,
-ECE,6930,1,MEMS,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,
-ECE,8070,1,Comp Meth Pwr Anal,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,gan venayagamoorthy,
-ECE,8160,1,Elec Power Distr Sys Engr,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,elham makram,
-ECE,8300,1,Electromagnetics I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,anthony martin,
-ECE,8400,1,Semicond Devices,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,8440,1,Digital Signal Proc,0.43,0.52,0.05,0.0,0.0,0.0,0.0,0.0,john gowdy,
-ECE,8560,1,Pattern Recognition,0.37,0.46,0.11,0.0,0.0,0.0,0.0,0.06,robert schalkoff,
-ECE,8930,3,HPC with GPUs,0.32,0.52,0.08,0.0,0.0,0.0,0.0,0.08,melissa crawl smith,
-ECE,8930,4,Distributed Dynamical Systems,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,yongqiang wang,
-ECON,2000,1,Economic Concepts,0.05,0.35,0.23,0.1,0.18,0.0,0.0,0.1,mallika garg,
-ECON,2000,2,Economic Concepts,0.31,0.39,0.17,0.08,0.03,0.0,0.0,0.03,mallika garg,
-ECON,2000,3,Economic Concepts,0.3,0.28,0.15,0.08,0.15,0.0,0.0,0.05,miren ivankovic,
-ECON,2110,1,Principles of Microeconomics,0.36,0.21,0.33,0.03,0.03,0.0,0.0,0.05,robert dew tollison,
-ECON,2110,2,Principles of Microeconomics,0.15,0.48,0.3,0.03,0.03,0.0,0.0,0.03,alexander fiore,
-ECON,2110,3,Principles of Microeconomics,0.14,0.49,0.25,0.07,0.03,0.0,0.0,0.03,adam millsap,
-ECON,2110,4,Principles of Microeconomics,0.32,0.37,0.15,0.05,0.02,0.0,0.0,0.1,amanda caitlin kerr,
-ECON,2110,5,Principles of Microeconomics,0.18,0.38,0.4,0.0,0.03,0.0,0.0,0.03,molly espey,
-ECON,2110,6,Principles of Microeconomics,0.29,0.26,0.14,0.1,0.14,0.0,0.0,0.07,andew swanson,
-ECON,2110,7,Principles of Microeconomics,0.28,0.41,0.24,0.03,0.03,0.0,0.0,0.02,alexander fiore,
-ECON,2110,8,Principles of Microeconomics,0.29,0.26,0.26,0.08,0.05,0.0,0.0,0.06,timothy andr bersak,
-ECON,2110,10,Principles of Microeconomics,0.23,0.34,0.26,0.06,0.0,0.0,0.0,0.11,anne anders,
-ECON,2110,11,Principles of Microeconomics,0.39,0.32,0.23,0.07,0.0,0.0,0.0,0.0,amanda caitlin kerr,
-ECON,2110,12,Principles of Microeconomics,0.1,0.58,0.25,0.05,0.0,0.0,0.0,0.03,molly espey,
-ECON,2120,1,Principles of Macro,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,2,Principles of Macro,0.17,0.22,0.56,0.06,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,3,Principles of Macro,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,4,Principles of Macro,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,5,Principles of Macro,0.41,0.24,0.29,0.0,0.0,0.0,0.0,0.06,scott baier,
-ECON,2120,6,Principles of Macro,0.11,0.56,0.22,0.0,0.06,0.0,0.0,0.06,scott baier,
-ECON,2120,7,Principles of Macro,0.21,0.16,0.53,0.05,0.0,0.0,0.0,0.05,scott baier,
-ECON,2120,8,Principles of Macro,0.37,0.16,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,9,Principles of Macro,0.2,0.25,0.35,0.05,0.05,0.0,0.0,0.1,scott baier,
-ECON,2120,10,Principles of Macro,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,11,Principles of Macro,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,12,Principles of Macro,0.26,0.37,0.32,0.0,0.0,0.0,0.0,0.05,scott baier,
-ECON,2120,13,Principles of Macro,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,14,Principles of Macro,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,15,Principles of Macro,0.29,0.43,0.24,0.0,0.0,0.0,0.0,0.05,scott baier,
-ECON,2120,16,Principles of Macro,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,17,Principles of Macro,0.32,0.37,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,18,Principles of Macro,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,scott baier,
-ECON,2120,19,Principles of Macro,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,20,Principles of Macro,0.26,0.36,0.3,0.04,0.02,0.0,0.0,0.02,peter david lorenz,
-ECON,2120,21,Principles of Macro,0.25,0.51,0.2,0.03,0.0,0.0,0.0,0.02,peter david lorenz,
-ECON,2120,22,Principles of Macro,0.35,0.25,0.33,0.03,0.0,0.0,0.0,0.05,yukun sun,
-ECON,2120,23,Principles of Macro,0.45,0.38,0.18,0.0,0.0,0.0,0.0,0.0,yukun sun,
-ECON,2120,24,Principles of Macro,0.21,0.52,0.17,0.05,0.04,0.0,0.0,0.01,scott barkowski,
-ECON,2120,25,Principles of Macro,0.17,0.64,0.17,0.0,0.03,0.0,0.0,0.0,scott barkowski,
-ECON,2120,26,Principles of Macro,0.22,0.08,0.27,0.05,0.22,0.0,0.0,0.16,ralph charles allen,
-ECON,3020,1,Money and Banking,0.23,0.23,0.3,0.13,0.05,0.0,0.0,0.08,danielle zanzalari,
-ECON,3060,1,Managerial Economics,0.28,0.31,0.25,0.03,0.06,0.0,0.0,0.06,jacob burgdorf,
-ECON,3100,1,International Econ,0.26,0.33,0.17,0.17,0.02,0.0,0.0,0.05,ayse mujde erdogan,
-ECON,3140,1,Intermediate Micro,0.23,0.28,0.21,0.08,0.05,0.0,0.0,0.15,patrick warren,
-ECON,3140,2,Intermediate Micro,0.13,0.19,0.29,0.13,0.03,0.0,0.0,0.23,robert kennet fleck,
-ECON,3140,3,Intermediate Micro,0.17,0.19,0.33,0.08,0.17,0.0,0.0,0.06,frederick hanssen,
-ECON,3150,1,Intermediate Macro,0.36,0.26,0.22,0.07,0.03,0.0,0.0,0.06,ayse mujde erdogan,
-ECON,3150,2,Intermediate Macro,0.31,0.26,0.26,0.0,0.03,0.0,0.0,0.14,sergey vla mityakov,
-ECON,3440,1,Property Rights,0.11,0.3,0.26,0.07,0.07,0.0,0.0,0.19,dar litsukova-bokar,
-ECON,3600,1,Public Choice,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,robert dew tollison,
-ECON,4010,1,Labor Mkt Analysis,0.38,0.38,0.15,0.0,0.04,0.0,0.0,0.04,curtis simon,
-ECON,4020,1,Law and Economics,0.42,0.25,0.21,0.08,0.0,0.0,0.0,0.04,thomas wins hazlett,
-ECON,4050,1,Intro to Econometric,0.22,0.3,0.28,0.08,0.08,0.0,0.0,0.04,jaqueline oliveira,
-ECON,4100,1,Economic Development,0.4,0.32,0.12,0.04,0.0,0.0,0.0,0.12,robert tamura,
-ECON,4200,1,Pub Sector Econ,0.29,0.29,0.24,0.0,0.0,0.0,0.0,0.19,william dougan,
-ECON,4240,1,Organization of Ind,0.36,0.39,0.14,0.04,0.04,0.0,0.0,0.04,matthew lewis,
-ECON,4260,1,Sem Sport Economics,0.71,0.19,0.0,0.0,0.0,0.0,0.0,0.1,raymond sauer,
-ECON,4270,1,Dev American Economy,0.34,0.28,0.19,0.13,0.0,0.0,0.0,0.06,howard ne bodenhorn,
-ECON,4290,1,Economics of Energy Markets,0.48,0.38,0.0,0.0,0.0,0.0,0.0,0.14,matthew lewis,
-ECON,4400,1,Game Theory,0.47,0.37,0.0,0.0,0.0,0.0,0.0,0.16,daniel wood,
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.38,0.25,0.13,0.19,0.0,0.0,0.0,0.06,scott templeton,
-ECON,8020,1,Adv Econ Concepts and Applic I,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
-ECON,8050,1,Macroeconomic Theory,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,8070,1,Econometrics II,0.1,0.65,0.25,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,
-ECON,8200,1,Public Finance,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william dougan,
-ECON,8990,1,Sel Topics-Appl Welfare Econ,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,arnold harberger,
-ECON,9010,1,Price Theory,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,daniel wood,
-ECON,9090,1,Time-Series Econ,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
-ED,1050,1,Educ Orientation,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,rory phil tannebaum,
-ED,1050,3,Educ Orientation,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,rory phil tannebaum,
-ED,8380,400,Astronomy - Middle School Tch,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard dallm white,
-ED,8380,534,Literacy Lessons for Indiv II,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,jennifer adams,
-ED,8380,537,Literacy Lessons for Indiv II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,
-ED,8380,539,Literacy Lessons for Indiv II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jean ridley,
-ED,8600,400,Action Research,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,
-EDC,8060,1,Student Aff Issues,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
-EDC,8190,1,Cont College Student,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
-EDEC,4200,1,Early Childhood Science,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,
-EDEC,4500,1,EC Curric & Soc Stud Methods,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEL,3100,2,Arts in Ele School,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alison eliz leonard,
-EDEL,3210,1,Pe for the Elem Tchr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4510,1,Elem Methods in Science Tchg,0.5,0.44,0.0,0.06,0.0,0.0,0.0,0.0,cynthia chri deaton,
-EDEL,4520,1,Elem Methods Math Teaching,0.71,0.19,0.0,0.1,0.0,0.0,0.0,0.0,andrew mic tyminski,
-EDEL,4670,1,Tchng Esol: Elem Sch,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDF,3010,1,Principles of American Educat,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,suzanne rosenblith,
-EDF,3010,2,Principles of American Educat,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,patrick womac,
-EDF,3020,1,Educ Psych,0.35,0.42,0.13,0.1,0.0,0.0,0.0,0.0,penelope mar vargas,
-EDF,3340,1,Child Growth and Dev,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
-EDF,3350,1,Adol Growth & Dev,0.77,0.16,0.03,0.03,0.0,0.0,0.0,0.0,david barrett,
-EDF,4800,3,Digital Media & Learning,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,8770,500,Research Meth in Education I,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,david fleming,
-EDF,8800,400,Dig Media for Mid Sch Teachers,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,ryan visser,
-EDF,9270,1,Quant Rsrch & Stats for Ed,0.71,0.17,0.13,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,
-EDF,9710,1,Cse Stdy Ethnog Mthd,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,cynthia chri deaton,
-EDL,7150,500,Sch & Comm Relations,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth reynolds,
-EDL,7300,501,Techniq of Supervision-Pub Sch,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,
-EDL,7500,503,El Prin & Spv Ex I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,frederick buskey,
-EDL,9050,400,Thry/Prac Ed Ldrshp,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,james satterfield,
-EDL,9100,400,Intro Phd Seminar,0.62,0.23,0.0,0.0,0.0,0.0,0.0,0.15,leslie gonzales,
-EDL,9110,400,Systematic Inq Ed L,0.76,0.06,0.06,0.0,0.0,0.0,0.0,0.12,jane lindle,
-EDL,9760,1,External Effect He,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,leslie gonzales,
-EDLT,4580,1,Early Literacy: Birth-Kindergn,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,barbara everson,
-EDLT,4620,1,Reading Children's Lit in Elem,0.68,0.23,0.05,0.05,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4620,2,Reading Children's Lit in Elem,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4630,1,Teaching Rdg/Writing for ELLs,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDLT,8100,501,Foundations of Literacy,0.63,0.0,0.0,0.0,0.0,0.0,0.0,0.38,linda gambrell,
-EDLT,8670,400,Middle School Reading,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,phillip mich wilder,
-EDLT,8810,506,Reading Recovery Teacher II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vicki steadman,
-EDLT,8810,509,Reading Recovery Teacher II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jean floyd,
-EDLT,8830,506,Read Recovery Practicum II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vicki steadman,
-EDLT,8830,509,Read Recovery Practicum II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jean floyd,
-EDSC,4370,1,Technology in Math,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,corrie leigh martin,
-EDSP,3700,2,Intro to Special Ed,0.74,0.2,0.06,0.0,0.0,0.0,0.0,0.0,pamela stecker,
-EDSP,3700,3,Intro to Special Ed,0.77,0.14,0.06,0.0,0.03,0.0,0.0,0.0,joseph benedic ryan,
-EDSP,3730,1,Char & Instr of ID & Autism,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
-EDSP,4910,1,Ed Assess Ind W/Dis,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
-EDSP,8230,400,Tch Integrated Set,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,
-EES,2020,1,Environ Engr Fundamentals II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
-EES,4010,1,Environmental Engr,0.51,0.44,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.24,0.59,0.15,0.0,0.02,0.0,0.0,0.0,mark schlautman,
-EES,4020,1,Water & Waste Water Treatment,0.44,0.25,0.13,0.0,0.06,0.0,0.0,0.13,david allen ladner,
-EES,4750,1,Capstone Design Project,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,4840,1,Solid Waste Mgt,0.35,0.35,0.23,0.07,0.0,0.0,0.0,0.0,thomas overcamp,
-EES,4850,1,Hazard Waste Management,0.19,0.5,0.25,0.06,0.0,0.0,0.0,0.0,mark schlautman,
-EES,8030,1,Phy/Chem Ops W/WW T,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,ezra lucas ho cates,
-EES,8040,1,Biochem Ops WW Trt,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,
-EES,8160,1,Technical Nuclear Forensics,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,lin shuller-nickles,
-EES,8420,1,Actinide Chemistry,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,brian powell,
-EES,8450,1,Environ Organic Chem,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,cindy lee,
-ELE,3010,1,Intro to Entre,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-ELE,3010,2,Intro to Entre,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,ashley will parnell,
-ELE,3010,3,Intro to Entre,0.77,0.2,0.03,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-ELE,4010,1,Exec Lead & Entr II,0.78,0.23,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
-ENGL,1030,1,Accelerated Composition,0.52,0.38,0.05,0.0,0.05,0.0,0.0,0.0,andrew mathas,
-ENGL,1030,2,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,
-ENGL,1030,3,Accelerated Composition,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,chelsea mari clarey,
-ENGL,1030,4,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,dustin cleag mosley,
-ENGL,1030,5,Accelerated Composition,0.44,0.33,0.06,0.0,0.11,0.0,0.0,0.06,sarah ashto wickham,
-ENGL,1030,6,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,matthew mar russell,
-ENGL,1030,7,Accelerated Composition,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,
-ENGL,1030,8,Accelerated Composition,0.6,0.25,0.05,0.05,0.0,0.0,0.0,0.05,chelsea mari clarey,
-ENGL,1030,10,Accelerated Composition,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,sarah ashto wickham,
-ENGL,1030,13,Accelerated Composition,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,molly brian collins,
-ENGL,1030,16,Accelerated Composition,0.65,0.2,0.05,0.0,0.0,0.0,0.0,0.1,molly brian collins,
-ENGL,1030,17,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,
-ENGL,1030,18,Accelerated Composition,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,justin all holliday,
-ENGL,1030,19,Accelerated Composition,0.85,0.05,0.0,0.0,0.1,0.0,0.0,0.0,daniel frank,
-ENGL,1030,21,Accelerated Composition,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,katherine elrick,
-ENGL,1030,23,Accelerated Composition,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,adrian carson,
-ENGL,1030,24,Accelerated Composition,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,eda ozyesilpinar,
-ENGL,1030,25,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
-ENGL,1030,26,Accelerated Composition,0.68,0.05,0.0,0.11,0.16,0.0,0.0,0.0,adrian carson,
-ENGL,1030,27,Accelerated Composition,0.68,0.05,0.21,0.0,0.0,0.0,0.0,0.05,daniel frank,
-ENGL,1030,28,Accelerated Composition,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,katherine elrick,
-ENGL,1030,29,Accelerated Composition,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,lauren taylo stukes,
-ENGL,1030,30,Accelerated Composition,0.89,0.0,0.05,0.05,0.0,0.0,0.0,0.0,joshua wood,
-ENGL,1030,32,Accelerated Composition,0.67,0.22,0.0,0.06,0.06,0.0,0.0,0.0,sarah michel naciuk,
-ENGL,1030,37,Accelerated Composition,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,
-ENGL,1030,39,Accelerated Composition,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,stephanie mic heath,
-ENGL,1030,42,Accelerated Composition,0.85,0.05,0.05,0.0,0.05,0.0,0.0,0.0,stephanie mic heath,
-ENGL,1030,44,Accelerated Composition,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,carlisle an sargent,
-ENGL,1030,47,Accelerated Composition,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,sarah kath melchers,
-ENGL,1030,49,Accelerated Composition,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,hayley ren zertuche,
-ENGL,1030,53,Accelerated Composition,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,hannah conl vaughan,
-ENGL,1030,54,Accelerated Composition,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,
-ENGL,1030,56,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,nathan riggs,
-ENGL,1030,57,Accelerated Composition,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katherine hanzalik,
-ENGL,1030,58,Accelerated Composition,0.18,0.18,0.29,0.06,0.24,0.0,0.0,0.06,justin all holliday,
-ENGL,1030,60,Accelerated Composition,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kristen gay,
-ENGL,1030,61,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,2120,1,World Literature,0.52,0.38,0.0,0.07,0.0,0.0,0.0,0.03,christopher benson,
-ENGL,2120,2,World Literature,0.76,0.1,0.05,0.0,0.1,0.0,0.0,0.0,andrew lemons,
-ENGL,2120,3,World Literature,0.17,0.38,0.21,0.0,0.17,0.0,0.0,0.08,david charles foltz,
-ENGL,2120,4,World Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,2120,5,World Literature,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,2120,7,World Literature,0.12,0.54,0.15,0.04,0.0,0.0,0.0,0.15,david charles foltz,
-ENGL,2120,9,World Literature,0.38,0.45,0.07,0.1,0.0,0.0,0.0,0.0,joshua nei waggoner,
-ENGL,2120,10,World Literature,0.14,0.61,0.21,0.0,0.0,0.0,0.0,0.04,joshua nei waggoner,
-ENGL,2120,11,World Literature,0.32,0.4,0.04,0.04,0.12,0.0,0.0,0.08,karen kettnich,
-ENGL,2120,12,World Literature,0.16,0.64,0.04,0.16,0.0,0.0,0.0,0.0,karen kettnich,
-ENGL,2120,13,World Literature,0.3,0.37,0.26,0.04,0.04,0.0,0.0,0.0,meg woosley-goodman,
-ENGL,2120,14,World Literature,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,meg woosley-goodman,
-ENGL,2120,15,World Literature,0.27,0.5,0.23,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2120,16,World Literature,0.48,0.33,0.15,0.04,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2120,17,World Literature,0.37,0.41,0.04,0.0,0.15,0.0,0.0,0.04,joshua nei waggoner,
-ENGL,2120,18,World Literature,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
-ENGL,2130,1,British Literature,0.36,0.54,0.04,0.0,0.0,0.0,0.0,0.07,adrian paterson,
-ENGL,2130,2,British Literature,0.69,0.12,0.15,0.04,0.0,0.0,0.0,0.0,april susanne pelt,
-ENGL,2130,3,British Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,april susanne pelt,
-ENGL,2130,4,British Literature,0.54,0.32,0.04,0.07,0.0,0.0,0.0,0.04,april susanne pelt,
-ENGL,2130,5,British Literature,0.62,0.19,0.12,0.04,0.0,0.0,0.0,0.04,april susanne pelt,
-ENGL,2130,6,British Literature,0.2,0.44,0.2,0.0,0.08,0.0,0.0,0.08,meg woosley-goodman,
-ENGL,2130,7,British Literature,0.46,0.32,0.07,0.0,0.07,0.0,0.0,0.07,meg woosley-goodman,
-ENGL,2130,10,British Literature,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,
-ENGL,2130,11,British Literature,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,12,British Literature,0.68,0.25,0.0,0.0,0.04,0.0,0.0,0.04,lucian ghita,
-ENGL,2130,13,British Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2140,1,American Literature,0.04,0.71,0.25,0.0,0.0,0.0,0.0,0.0,rhondda robi thomas,
-ENGL,2140,2,American Literature,0.11,0.32,0.29,0.11,0.14,0.0,0.0,0.04,barbara ramirez,
-ENGL,2140,3,American Literature,0.12,0.46,0.35,0.04,0.04,0.0,0.0,0.0,barbara ramirez,
-ENGL,2140,4,American Literature,0.66,0.24,0.03,0.03,0.03,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,2140,5,American Literature,0.76,0.17,0.0,0.03,0.03,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,2140,6,American Literature,0.39,0.39,0.11,0.04,0.04,0.0,0.0,0.04,william stanton,
-ENGL,2140,7,American Literature,0.54,0.36,0.07,0.0,0.04,0.0,0.0,0.0,william stanton,
-ENGL,2140,8,American Literature,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,david stubblefield,
-ENGL,2140,9,American Literature,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,david stubblefield,
-ENGL,2140,11,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,
-ENGL,2140,12,American Literature,0.75,0.11,0.11,0.04,0.0,0.0,0.0,0.0,david stubblefield,
-ENGL,2140,13,American Literature,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,2140,14,American Literature,0.1,0.41,0.48,0.0,0.0,0.0,0.0,0.0,barbara ramirez,
-ENGL,2140,15,American Literature,0.44,0.19,0.19,0.11,0.0,0.0,0.0,0.07,meredith mccarroll,
-ENGL,2140,16,American Literature,0.29,0.43,0.21,0.0,0.04,0.0,0.0,0.04,susanna ashton,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.72,0.24,0.0,0.0,0.03,0.0,0.0,0.0,nicholas chri brown,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.0,0.48,0.44,0.04,0.0,0.0,0.0,0.04,amy monaghan,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.04,0.52,0.41,0.0,0.04,0.0,0.0,0.0,amy monaghan,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.52,0.33,0.11,0.0,0.04,0.0,0.0,0.0,sarah lauro,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,sarah lauro,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.14,0.48,0.28,0.0,0.0,0.0,0.0,0.1,david charles foltz,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.61,0.25,0.07,0.07,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.57,0.32,0.07,0.04,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.83,0.07,0.03,0.0,0.07,0.0,0.0,0.0,alexander kudera,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.2,0.68,0.04,0.0,0.0,0.0,0.0,0.08,david charles foltz,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.45,0.31,0.1,0.1,0.03,0.0,0.0,0.0,andrew mathas,
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.55,0.28,0.07,0.03,0.07,0.0,0.0,0.0,andrew mathas,
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.31,0.5,0.12,0.04,0.04,0.0,0.0,0.0,matthew schilleman,
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.36,0.21,0.25,0.04,0.07,0.0,0.0,0.07,andrew mathas,
-ENGL,3000,1,Professional Develop,0.7,0.13,0.13,0.0,0.03,0.0,0.0,0.0,cameron fa bushnell,
-ENGL,3040,2,Business Writing,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,
-ENGL,3040,3,Business Writing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,
-ENGL,3040,4,Business Writing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3040,5,Business Writing,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3040,14,Business Writing,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,3040,15,Business Writing,0.7,0.15,0.1,0.0,0.0,0.0,0.0,0.05,philip randall,
-ENGL,3040,17,Business Writing,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,3040,18,Business Writing,0.4,0.5,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,
-ENGL,3100,1,Crit Writ Lit,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
-ENGL,3100,2,Crit Writ Lit,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,dominic mastroianni,
-ENGL,3100,4,Crit Writ Lit,0.38,0.29,0.19,0.0,0.05,0.0,0.0,0.1,erin marina goss,
-ENGL,3120,1,Advanced Composition,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3120,2,Advanced Composition,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,2,Technical Writing,0.25,0.6,0.1,0.0,0.0,0.0,0.0,0.05,william pulley,
-ENGL,3140,3,Technical Writing,0.15,0.5,0.1,0.05,0.15,0.0,0.0,0.05,william pulley,
-ENGL,3140,4,Technical Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew schilleman,
-ENGL,3140,5,Technical Writing,0.32,0.58,0.0,0.0,0.0,0.0,0.0,0.11,matthew schilleman,
-ENGL,3140,7,Technical Writing,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,
-ENGL,3140,9,Technical Writing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,3140,10,Technical Writing,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,11,Technical Writing,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,12,Technical Writing,0.3,0.55,0.1,0.0,0.05,0.0,0.0,0.0,katalin beck,
-ENGL,3140,13,Technical Writing,0.2,0.55,0.25,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,16,Technical Writing,0.75,0.15,0.05,0.0,0.05,0.0,0.0,0.0,lauren woolbright,
-ENGL,3140,17,Technical Writing,0.73,0.14,0.05,0.05,0.05,0.0,0.0,0.0,lauren woolbright,
-ENGL,3140,18,Technical Writing,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,3140,19,Technical Writing,0.78,0.17,0.0,0.06,0.0,0.0,0.0,0.0,matthew jose osborn,
-ENGL,3140,20,Technical Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
-ENGL,3140,21,Technical Writing,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,22,Technical Writing,0.82,0.05,0.05,0.0,0.09,0.0,0.0,0.0,john conway,
-ENGL,3140,23,Technical Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,3150,1,Sci Writing & Comm,0.85,0.05,0.0,0.0,0.1,0.0,0.0,0.0,philip randall,
-ENGL,3150,5,Sci Writing & Comm,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3150,6,Sci Writing & Comm,0.4,0.4,0.1,0.05,0.0,0.0,0.0,0.05,william pulley,
-ENGL,3150,7,Sci Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,3150,19,Sci Writing & Comm,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,3150,20,Sci Writing & Comm,0.9,0.0,0.0,0.05,0.0,0.0,0.0,0.05,john conway,
-ENGL,3320,1,Visual Communication,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,megan eatman,
-ENGL,3450,1,Structure of Fiction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
-ENGL,3460,1,Structure of Poetry,0.75,0.1,0.1,0.0,0.05,0.0,0.0,0.0,john logan pursley,
-ENGL,3480,1,Structure Screenplay,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,joshua nei waggoner,
-ENGL,3490,1,Tech/Pop Imagination,0.26,0.58,0.05,0.0,0.05,0.0,0.0,0.05,lindsay carr thomas,
-ENGL,3530,1,Ethnic Am Lit,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,angela naimou,
-ENGL,3570,1,Film,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3850,1,Children's Lit,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,megan no macalystre,
-ENGL,3960,1,Brit Lit Survey I,0.2,0.3,0.4,0.0,0.05,0.0,0.0,0.05,erin marina goss,
-ENGL,3960,2,Brit Lit Survey I,0.25,0.15,0.4,0.05,0.0,0.0,0.0,0.15,erin marina goss,
-ENGL,3960,3,Brit Lit Survey I,0.35,0.2,0.15,0.15,0.1,0.0,0.0,0.05,erin marina goss,
-ENGL,3970,1,Brit Lit Survey II,0.52,0.33,0.1,0.0,0.05,0.0,0.0,0.0,david sweene coombs,
-ENGL,3980,1,Amer Lit Survey I,0.15,0.5,0.3,0.0,0.05,0.0,0.0,0.0,susanna ashton,
-ENGL,3990,1,Amer Lit Survey II,0.26,0.42,0.26,0.0,0.0,0.0,0.0,0.05,rhondda robi thomas,
-ENGL,4080,1,Chaucer,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,andrew lemons,
-ENGL,4110,1,Shakespeare,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william stockton,
-ENGL,4170,1,Victorian Period,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,
-ENGL,4200,1,Amer Lit to 1799,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,jonathan beec field,
-ENGL,4310,1,Modern Poetry,0.16,0.68,0.05,0.0,0.0,0.0,0.0,0.11,adrian paterson,
-ENGL,4320,1,Modern Fiction,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,angela naimou,
-ENGL,4400,1,Literary Theory,0.29,0.48,0.24,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,
-ENGL,4410,1,Literary Editing,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,wayne chapman,
-ENGL,4450,1,Fiction Workshop,0.46,0.31,0.15,0.08,0.0,0.0,0.0,0.0,keith morris,
-ENGL,4590,2,Spec Top Lang Criticism Theory,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
-ENGL,4780,1,Digital Literacy,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
-ENGL,4830,1,Af Am Lit 1920-Pres,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,garry bertholf,
-ENGL,4890,1,Topics Write & Publ,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,david blakesley,
-ENGL,4960,1,Senior Seminar,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,jonathan beec field,
-ENGL,4960,3,Senior Seminar,0.8,0.1,0.05,0.0,0.05,0.0,0.0,0.0,sean morey,
-ENGL,7000,1,Child Lit for Teach,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,lienne federico,
-ENGL,8080,1,Top Renaiss & Restoration Lit,0.5,0.25,0.13,0.0,0.13,0.0,0.0,0.0,william stockton,
-ENGL,8230,1,Topics American Lit Since 1865,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,8500,1,Methods Prof Comm,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,tharon howard,
-ENGR,1050,311,Engr Discipline & Skills I,0.18,0.23,0.25,0.2,0.07,0.0,0.0,0.08,john minor,
-ENGR,1050,312,Engr Discipline & Skills I,0.15,0.38,0.18,0.18,0.08,0.0,0.0,0.03,michael giebner,
-ENGR,1060,141,Engr Discipline & Skills II,0.07,0.36,0.32,0.07,0.11,0.0,0.0,0.07,steven brandon,
-ENGR,1060,241,Engr Discipline & Skills II,0.1,0.41,0.35,0.06,0.06,0.0,0.0,0.02,matthew kent miller,
-ENGR,1060,242,Engr Discipline & Skills II,0.1,0.3,0.36,0.06,0.08,0.0,0.0,0.1,matthew kent miller,
-ENGR,1060,311,Engr Discipline & Skills II,0.11,0.22,0.31,0.11,0.16,0.0,0.0,0.09,ashley childers,
-ENGR,1060,312,Engr Discipline & Skills II,0.15,0.12,0.22,0.22,0.12,0.0,0.0,0.17,michael giebner,
-ENGR,1060,341,Engr Discipline & Skills II,0.11,0.36,0.36,0.14,0.03,0.0,0.0,0.0,ashley childers,
-ENGR,1060,342,Engr Discipline & Skills II,0.15,0.4,0.31,0.1,0.02,0.0,0.0,0.02,ashley childers,
-ENGR,1060,343,Engr Discipline & Skills II,0.13,0.4,0.27,0.09,0.04,0.0,0.0,0.07,ashley childers,
-ENGR,1060,345,Engr Discipline & Skills II,0.06,0.38,0.34,0.06,0.03,0.0,0.0,0.13,elizabeth stephan,
-ENGR,1070,121,Program & Prob Solv I,0.04,0.31,0.38,0.19,0.04,0.0,0.0,0.04,erin jennife mccave,
-ENGR,1070,122,Program & Prob Solv I,0.17,0.29,0.35,0.15,0.02,0.0,0.0,0.02,erin jennife mccave,
-ENGR,1070,123,Program & Prob Solv I,0.15,0.38,0.23,0.15,0.02,0.0,0.0,0.08,christopher norfolk,
-ENGR,1070,124,Program & Prob Solv I,0.1,0.48,0.31,0.04,0.04,0.0,0.0,0.02,christopher norfolk,
-ENGR,1070,125,Program & Prob Solv I,0.13,0.26,0.38,0.13,0.0,0.0,0.0,0.11,erin jennife mccave,
-ENGR,1070,126,Program & Prob Solv I,0.17,0.27,0.31,0.15,0.0,0.0,0.0,0.1,erin jennife mccave,
-ENGR,1070,127,Program & Prob Solv I,0.21,0.34,0.32,0.06,0.04,0.0,0.0,0.02,william martin,
-ENGR,1070,128,Program & Prob Solv I,0.2,0.35,0.28,0.09,0.04,0.0,0.0,0.04,steven brandon,
-ENGR,1070,221,Programming & Prob Solving I,0.05,0.35,0.27,0.2,0.07,0.0,0.0,0.05,william martin,
-ENGR,1070,222,Programming & Prob Solving I,0.22,0.33,0.31,0.07,0.02,0.0,0.0,0.05,william martin,
-ENGR,1070,223,Programming & Prob Solving I,0.16,0.38,0.22,0.16,0.02,0.0,0.0,0.05,steven brandon,
-ENGR,1070,224,Programming & Prob Solving I,0.18,0.4,0.18,0.18,0.0,0.0,0.0,0.05,steven brandon,
-ENGR,1070,225,Programming & Prob Solving I,0.15,0.44,0.35,0.04,0.0,0.0,0.0,0.04,richard watkins,
-ENGR,1070,226,Programming & Prob Solving I,0.24,0.3,0.3,0.11,0.02,0.0,0.0,0.04,david ewing,
-ENGR,1070,241,Programming & Prob Solving I,0.07,0.49,0.36,0.0,0.04,0.0,0.0,0.04,matthew kent miller,
-ENGR,1070,242,Programming & Prob Solving I,0.0,0.34,0.44,0.13,0.06,0.0,0.0,0.03,matthew kent miller,
-ENGR,1070,321,Programming & Prob Solving I,0.15,0.38,0.36,0.02,0.02,0.0,0.0,0.08,william th kolodzey,
-ENGR,1070,322,Programming & Prob Solving I,0.33,0.3,0.2,0.1,0.05,0.0,0.0,0.02,elizabeth stephan,
-ENGR,1070,323,Programming & Prob Solving I,0.15,0.36,0.33,0.11,0.02,0.0,0.0,0.04,surya sharma,
-ENGR,1070,324,Programming & Prob Solving I,0.22,0.37,0.22,0.07,0.04,0.0,0.0,0.07,william park,
-ENGR,1070,325,Programming & Prob Solving I,0.21,0.44,0.19,0.1,0.0,0.0,0.0,0.06,william park,
-ENGR,1070,341,Programming & Prob Solving I,0.0,0.26,0.52,0.13,0.1,0.0,0.0,0.0,william martin,
-ENGR,1070,621,Program & Prob Solv I (HON),0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,david ewing,True
-ENGR,1070,622,Program & Prob Solv I (HON),0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,david ewing,True
-ENGR,1080,121,Program & Prob Solv II,0.06,0.31,0.39,0.14,0.06,0.0,0.0,0.06,erin jennife mccave,
-ENGR,1080,122,Program & Prob Solv II,0.08,0.47,0.21,0.21,0.03,0.0,0.0,0.0,erin jennife mccave,
-ENGR,1080,123,Program & Prob Solv II,0.05,0.36,0.31,0.15,0.05,0.0,0.0,0.08,christopher norfolk,
-ENGR,1080,124,Program & Prob Solv II,0.12,0.29,0.34,0.12,0.12,0.0,0.0,0.0,christopher norfolk,
-ENGR,1080,125,Program & Prob Solv II,0.11,0.28,0.36,0.11,0.14,0.0,0.0,0.0,erin jennife mccave,
-ENGR,1080,126,Program & Prob Solv II,0.16,0.43,0.3,0.08,0.03,0.0,0.0,0.0,erin jennife mccave,
-ENGR,1080,127,Program & Prob Solv II,0.12,0.49,0.2,0.12,0.05,0.0,0.0,0.02,christopher norfolk,
-ENGR,1080,128,Program & Prob Solv II,0.23,0.43,0.14,0.11,0.06,0.0,0.0,0.03,steven brandon,
-ENGR,1080,221,Programming & Prob Solving II,0.14,0.39,0.36,0.06,0.03,0.0,0.0,0.03,elizabeth stephan,
-ENGR,1080,222,Programming & Prob Solving II,0.21,0.32,0.26,0.15,0.04,0.0,0.0,0.02,steven brandon,
-ENGR,1080,223,Programming & Prob Solving II,0.14,0.5,0.21,0.02,0.1,0.0,0.0,0.02,elizabeth stephan,
-ENGR,1080,224,Programming & Prob Solving II,0.2,0.42,0.27,0.09,0.0,0.0,0.0,0.02,steven brandon,
-ENGR,1080,225,Programming & Prob Solving II,0.24,0.33,0.25,0.14,0.02,0.0,0.0,0.02,richard watkins,
-ENGR,1080,226,Programming & Prob Solving II,0.3,0.32,0.21,0.15,0.02,0.0,0.0,0.0,david ewing,
-ENGR,1080,321,Programming & Prob Solving II,0.09,0.29,0.22,0.27,0.11,0.0,0.0,0.02,william th kolodzey,
-ENGR,1080,322,Programming & Prob Solving II,0.33,0.35,0.25,0.04,0.0,0.0,0.0,0.02,elizabeth stephan,
-ENGR,1080,323,Programming & Prob Solving II,0.18,0.34,0.28,0.08,0.1,0.0,0.0,0.02,surya sharma,
-ENGR,1080,324,Programming & Prob Solving II,0.07,0.26,0.33,0.19,0.1,0.0,0.0,0.05,william park,
-ENGR,1080,325,Programming & Prob Solving II,0.07,0.42,0.24,0.13,0.07,0.0,0.0,0.07,william park,
-ENGR,1080,621,Program & Prob Solv II (HON),0.5,0.44,0.0,0.0,0.06,0.0,0.0,0.0,david ewing,True
-ENGR,1080,622,Program & Prob Solv II (HON),0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,david ewing,True
-ENGR,1090,132,Prog/Problem Solv Apps (RISE),0.23,0.66,0.05,0.02,0.0,0.0,0.0,0.05,christopher norfolk,
-ENGR,1090,133,Prog/Problem Solv Apps (RISE),0.24,0.59,0.17,0.0,0.0,0.0,0.0,0.0,surya sharma,
-ENGR,1090,134,Prog/Problem Solv Apps (RISE),0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,david ewing,
-ENGR,1090,231,Prog/Problem Solving Apps,0.28,0.51,0.21,0.0,0.0,0.0,0.0,0.0,william martin,
-ENGR,1090,232,Prog/Problem Solving Apps,0.41,0.52,0.07,0.0,0.0,0.0,0.0,0.0,william martin,
-ENGR,1090,233,Prog/Problem Solving Apps,0.38,0.47,0.06,0.04,0.0,0.0,0.0,0.04,david ewing,
-ENGR,1090,234,Prog/Problem Solving Apps,0.26,0.42,0.21,0.02,0.02,0.0,0.0,0.07,steven brandon,
-ENGR,1090,331,Prog/Problem Solving Apps,0.45,0.47,0.03,0.0,0.0,0.0,0.0,0.05,william th kolodzey,
-ENGR,1090,332,Prog/Problem Solving Apps,0.2,0.52,0.19,0.0,0.0,0.0,0.0,0.09,john minor,
-ENGR,1090,333,Prog/Problem Solving Apps,0.25,0.52,0.17,0.02,0.02,0.0,0.0,0.03,william park,
-ENGR,1090,334,Prog/Problem Solving Apps,0.11,0.26,0.57,0.06,0.0,0.0,0.0,0.0,william park,
-ENGR,1090,335,Prog/Problem Solving Apps,0.37,0.49,0.12,0.01,0.0,0.0,0.0,0.0,steven brandon,
-ENGR,1090,336,Prog/Problem Solving Apps,0.28,0.48,0.17,0.0,0.03,0.0,0.0,0.03,william park,
-ENGR,1090,337,Prog/Problem Solving Apps,0.41,0.54,0.05,0.0,0.0,0.0,0.0,0.0,steven brandon,
-ENGR,1090,338,Prog/Problem Solving Apps,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,william park,
-ENGR,1490,501,Introduction to Engineering,0.41,0.14,0.18,0.09,0.18,0.0,0.0,0.0,matthew kent miller,
-ENGR,1510,501,Engineering Skills,0.59,0.06,0.18,0.06,0.12,0.0,0.0,0.0,matthew kent miller,
-ENGR,1510,502,Engineering Skills,0.5,0.13,0.13,0.06,0.13,0.0,0.0,0.06,matthew kent miller,
-ENGR,1640,502,Engineering MATLAB Programming,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,2080,181,Engr Graphics & Machine Design,0.52,0.31,0.12,0.02,0.02,0.0,0.0,0.0,john minor,
-ENGR,2080,182,Engr Graphics & Machine Design,0.55,0.32,0.07,0.02,0.02,0.0,0.0,0.02,sarah grigg,
-ENGR,2080,183,Engr Graphics & Machine Design,0.14,0.52,0.12,0.05,0.1,0.0,0.0,0.07,sarah grigg,
-ENGR,2080,184,Engr Graphics & Machine Design,0.34,0.41,0.09,0.05,0.02,0.0,0.0,0.09,sarah grigg,
-ENGR,2080,185,Engr Graphics & Machine Design,0.51,0.27,0.09,0.0,0.02,0.0,0.0,0.11,jonathan maier,
-ENGR,2080,281,Engr Graphics & Machine Design,0.67,0.22,0.07,0.0,0.02,0.0,0.0,0.03,john minor,
-ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.25,0.08,0.02,0.02,0.0,0.0,0.02,john minor,
-ENGR,2080,283,Engr Graphics & Machine Design,0.32,0.36,0.17,0.02,0.05,0.0,0.0,0.08,anthony pau garland,
-ENGR,2080,284,Engr Graphics & Machine Design,0.18,0.4,0.25,0.05,0.04,0.0,0.0,0.09,anthony pau garland,
-ENGR,2080,381,Engr Graphics & Machine Design,0.52,0.23,0.12,0.02,0.03,0.0,0.0,0.08,jonathan maier,
-ENGR,2100,101,CAD & Engineering Apllications,0.42,0.31,0.11,0.03,0.06,0.0,0.0,0.08,william martin,
-ENGR,2100,201,CAD & Engineering Apllications,0.76,0.1,0.02,0.02,0.02,0.0,0.0,0.08,mary kayla kilgo,
-ENGR,2100,202,CAD & Engineering Apllications,0.76,0.18,0.02,0.02,0.02,0.0,0.0,0.0,nighat yasmin,
-ENGR,2100,203,CAD & Engineering Apllications,0.62,0.28,0.04,0.0,0.02,0.0,0.0,0.04,nighat yasmin,
-ENGR,2200,1,Evaluating Innovations,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,sarah grigg,
-ENR,3020,1,Nat Res Measurements,0.33,0.42,0.18,0.03,0.03,0.0,0.0,0.0,lawrence gering,
-ENR,4500,1,Conservation Issues,0.5,0.31,0.09,0.03,0.03,0.0,0.0,0.03,alan johnson,
-ENR,4500,2,Conservation Issues,0.54,0.15,0.23,0.04,0.04,0.0,0.0,0.0,alan johnson,
-ENSP,2000,1,Intro Environ Sci,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,scott brame,
-ENSP,2000,2,Intro Environ Sci,0.67,0.23,0.06,0.0,0.0,0.0,0.0,0.04,elizabeth carraway,
-ENSP,2000,3,Intro Environ Sci,0.79,0.15,0.06,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENT,2000,1,Six-Legged Science,0.49,0.37,0.11,0.0,0.0,0.0,0.0,0.03,suellen pometto,
-ENT,8100,3,Conservation Genetics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michael caterino,
-ESED,8710,1,Engr & Sci Educ Research Meth,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,charity watson,
-FCS,8340,3,Research Methods in FCS II,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0,james mcdonell,
-FDSC,1020,1,Persp Food Nutrition,0.6,0.36,0.03,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-FDSC,2140,1,Fd Resources & Soc,0.66,0.24,0.08,0.0,0.01,0.0,0.0,0.01,paul dawson,
-FDSC,2150,1,Culinary Fundamental,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,aubrey dean coffee,
-FDSC,4020,1,Food Chem II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4030,1,Food Ch & Analysis,0.94,0.05,0.02,0.0,0.0,0.0,0.0,0.0,paul dawson,
-FDSC,4080,1,Food Process Eng,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,felix barron,
-FDSC,4090,1,TQM for Food & Pckg Industries,0.67,0.26,0.06,0.01,0.0,0.0,0.0,0.0,john mcgregor,
-FIN,3040,1,Risk & Insurance,0.13,0.45,0.37,0.05,0.0,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.21,0.29,0.36,0.05,0.07,0.0,0.0,0.02,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.17,0.38,0.32,0.04,0.06,0.0,0.0,0.02,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.19,0.51,0.28,0.02,0.0,0.0,0.0,0.0,kerri mcmillan,
-FIN,3060,1,Corporation Finance,0.08,0.15,0.33,0.12,0.15,0.0,0.0,0.17,william hol johnson,
-FIN,3060,2,Corporation Finance,0.1,0.12,0.16,0.22,0.16,0.0,0.0,0.22,william hol johnson,
-FIN,3060,3,Corporation Finance,0.2,0.28,0.38,0.11,0.02,0.0,0.0,0.02,neil waller,
-FIN,3060,4,Corporation Finance,0.26,0.38,0.27,0.08,0.0,0.0,0.0,0.02,neil waller,
-FIN,3060,5,Corporation Finance,0.06,0.2,0.23,0.17,0.16,0.0,0.0,0.17,william hol johnson,
-FIN,3060,6,Corporation Finance,0.28,0.37,0.19,0.07,0.05,0.0,0.0,0.04,neil waller,
-FIN,3060,7,Corporation Finance,0.28,0.3,0.3,0.05,0.04,0.0,0.0,0.04,neil waller,
-FIN,3070,1,Prin of Real Estate,0.24,0.22,0.35,0.13,0.07,0.0,0.0,0.0,ramon tolb franklin,
-FIN,3070,2,Prin of Real Estate,0.21,0.26,0.39,0.11,0.0,0.02,0.0,0.02,thomas springer,
-FIN,3080,1,Fin Inst & Mkts,0.3,0.34,0.32,0.05,0.0,0.0,0.0,0.0,daniel thoma greene,
-FIN,3080,2,Fin Inst & Mkts,0.41,0.41,0.15,0.0,0.0,0.0,0.0,0.03,daniel thoma greene,
-FIN,3080,3,Fin Inst & Mkts,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.05,daniel thoma greene,
-FIN,3110,1,Financial Management I,0.13,0.2,0.37,0.09,0.07,0.0,0.0,0.15,jack wolf,
-FIN,3110,2,Financial Management I,0.19,0.33,0.37,0.02,0.0,0.0,0.0,0.09,george bra lockhart,
-FIN,3110,3,Financial Management I,0.37,0.29,0.2,0.05,0.02,0.0,0.0,0.07,george bra lockhart,
-FIN,3110,4,Financial Management I,0.23,0.43,0.28,0.0,0.0,0.0,0.0,0.08,george bra lockhart,
-FIN,3120,1,Financial Mgt II,0.22,0.49,0.22,0.04,0.02,0.0,0.0,0.02,vincent intintoli,
-FIN,3120,2,Financial Mgt II,0.14,0.34,0.26,0.09,0.09,0.0,0.0,0.09,angela morgan,
-FIN,3120,3,Financial Mgt II,0.16,0.29,0.32,0.13,0.05,0.0,0.0,0.05,angela morgan,
-FIN,3120,4,Financial Mgt II,0.15,0.45,0.27,0.03,0.09,0.0,0.0,0.0,vincent intintoli,
-FIN,4040,1,Financial Modeling,0.12,0.38,0.35,0.15,0.0,0.0,0.0,0.0,jack wolf,
-FIN,4040,2,Financial Modeling,0.27,0.56,0.17,0.0,0.0,0.0,0.0,0.0,jared daniel smith,
-FIN,4040,3,Financial Modeling,0.15,0.59,0.24,0.03,0.0,0.0,0.0,0.0,jared daniel smith,
-FIN,4050,1,Port Mgt and Theory,0.14,0.33,0.19,0.14,0.05,0.0,0.0,0.14,john alexander,
-FIN,4050,2,Port Mgt and Theory,0.08,0.54,0.08,0.31,0.0,0.0,0.0,0.0,john alexander,
-FIN,4080,1,Mgt of Fin Inst,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4080,2,Mgt of Fin Inst,0.5,0.19,0.31,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4110,1,Int Fin Mgt,0.1,0.41,0.33,0.13,0.03,0.0,0.0,0.0,tilan tang,
-FIN,4110,2,Int Fin Mgt,0.11,0.37,0.31,0.06,0.03,0.0,0.0,0.11,tilan tang,
-FIN,4150,1,Real Estate Investmt,0.29,0.5,0.14,0.0,0.07,0.0,0.0,0.0,thomas springer,
-FIN,4160,1,Real Estate Val,0.58,0.08,0.33,0.0,0.0,0.0,0.0,0.0,ramon tolb franklin,
-FNR,4700,35,Aquaponics,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,lance edwar beecher,
-FNR,4990,1,Natural Resources Seminar,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william roc english,
-FNR,4990,3,Natural Resources Seminar,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,william roc english,
-FOR,1010,1,Intro to Forestry,0.69,0.23,0.0,0.08,0.0,0.0,0.0,0.0,lawrence gering,
-FOR,2060,1,Forest Ecology,0.27,0.41,0.22,0.02,0.06,0.0,0.0,0.02,donald hagan,
-FOR,3080,1,Remote Sensing,0.28,0.44,0.16,0.12,0.0,0.0,0.0,0.0,lawrence gering,
-FOR,4060,1,For Watershed Mgmt,0.92,0.05,0.0,0.0,0.0,0.0,0.0,0.03,william roc english,
-FOR,4080,1,Wood & Paper Product,0.5,0.37,0.1,0.03,0.0,0.0,0.0,0.0,patricia layton,
-FOR,4150,1,For Wildlife Mgmt,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,james davis,
-FOR,4180,1,For Res Valuation,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4250,1,For Res Mgt Plans,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4340,1,GIS for Landscape Planning,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,robert frit baldwin,
-FOR,4650,1,Silviculture,0.29,0.38,0.29,0.04,0.0,0.0,0.0,0.0,gaofeng wang,
-FOR,8930,22,Ecotoxicology,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john rodgers,
-FR,1010,1,Elementary French,0.53,0.35,0.0,0.06,0.06,0.0,0.0,0.0,julian hamil killey,
-FR,1020,2,Elementary French,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,1020,3,Elementary French,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,amy lyn grif sawyer,
-FR,2010,1,Intermediate French,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,2,Intermediate French,0.6,0.25,0.05,0.05,0.05,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,4,Intermediate French,0.08,0.75,0.17,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,2020,1,Intermediate French,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,2020,2,Intermediate French,0.55,0.27,0.09,0.09,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,2020,3,Intermediate French,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,kelly digby peebles,
-FR,2020,4,Intermediate French,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
-FR,3050,1,Int Fr Con & Comp I,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
-FR,3120,1,Writing in French I,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,kenneth dav widgren,
-FR,3160,1,Fr for Intl Trade,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,eric touya,
-FR,4100,1,Francophone Lit,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,True
-GC,1010,1,Orientation to G C,0.76,0.13,0.03,0.0,0.03,0.0,0.0,0.05,kern cox,
-GC,1020,1,Comp Art & Cad Found,0.38,0.29,0.05,0.1,0.14,0.0,0.0,0.05,charles tabor weiss,
-GC,1020,2,Comp Art & Cad Found,0.64,0.18,0.09,0.05,0.0,0.0,0.0,0.05,carol jones,
-GC,1030,1,G C I for Pkgsc,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,john jacobs,
-GC,1030,2,G C I for Pkgsc,0.08,0.54,0.23,0.08,0.08,0.0,0.0,0.0,john jacobs,
-GC,1040,1,Graphic Communications I,0.53,0.31,0.09,0.03,0.02,0.0,0.0,0.01,rebecca suza edlein,
-GC,1990,4,CI in GC I-J Lay CS,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,janice ann lay,
-GC,2070,1,Graphic Communications II,0.6,0.31,0.06,0.0,0.03,0.0,0.0,0.0,patrick gee rose,
-GC,3400,1,Digital Img & Emedia,0.44,0.4,0.13,0.0,0.02,0.0,0.0,0.02,erica black walker,
-GC,4060,1,Package and Specialty Printing,0.25,0.6,0.1,0.0,0.03,0.0,0.0,0.03,kern cox,
-GC,4400,1,Commercial Printing,0.62,0.35,0.0,0.0,0.0,0.0,0.0,0.03,eric weisenmiller,
-GC,4440,1,Current Dev in G C,0.24,0.41,0.28,0.07,0.0,0.0,0.0,0.0,liam henry 'hara,
-GC,4460,1,Ink & Substrates,0.13,0.71,0.09,0.04,0.0,0.0,0.0,0.02,liam henry 'hara,
-GC,4480,1,Plan and Cont Print,0.8,0.1,0.05,0.05,0.0,0.0,0.0,0.0,john leininger,
-GC,4900,2,G C Selected Topics-Sales,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,john leininger,
-GEN,3000,1,Fundamental Genetics,0.33,0.27,0.27,0.08,0.02,0.0,0.0,0.04,kate leanne wi tsai,
-GEN,3000,2,Fundamental Genetics,0.4,0.4,0.13,0.04,0.01,0.0,0.0,0.02,haiying liang,
-GEN,4100,1,Population & Quant Genetics,0.4,0.4,0.03,0.09,0.06,0.0,0.0,0.03,amy lou lawton rauh,
-GEN,4110,1,Popultn & Quant Genetics Lab,0.6,0.2,0.0,0.1,0.0,0.0,0.0,0.1,amy lou lawton rauh,
-GEN,4110,2,Popultn & Quant Genetics Lab,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,amy lou lawton rauh,
-GEN,4110,3,Population and Quant Gen Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
-GEN,4700,1,Human Genetics,0.46,0.38,0.11,0.03,0.0,0.0,0.0,0.03,leigh anne clark,
-GEOG,1010,1,Intro to Geography,0.28,0.4,0.28,0.05,0.0,0.0,0.0,0.0,christa smith,
-GEOG,1030,1,World Regional Geog,0.82,0.12,0.04,0.02,0.0,0.0,0.0,0.0,lance forres howard,
-GEOG,1030,2,World Regional Geog,0.38,0.35,0.15,0.03,0.0,0.0,0.0,0.1,william churc terry,
-GEOG,3050,1,Cultural Geography,0.83,0.06,0.0,0.06,0.06,0.0,0.0,0.0,lance forres howard,
-GEOL,1010,1,Physical Geology,0.39,0.32,0.14,0.06,0.05,0.0,0.0,0.03,alan coulson,
-GEOL,1010,2,Physical Geology,0.38,0.36,0.17,0.03,0.01,0.0,0.0,0.05,alan coulson,
-GEOL,1030,1,Physical Geol Lab,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.3,0.57,0.09,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.3,0.52,0.13,0.04,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.52,0.22,0.17,0.04,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.59,0.18,0.14,0.0,0.0,0.0,0.0,0.09,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.27,0.5,0.18,0.0,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.42,0.46,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.54,0.29,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,
-GEOL,1120,1,Earth Resources,0.72,0.19,0.09,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,1140,1,Earth Resources Lab,0.68,0.1,0.16,0.03,0.0,0.0,0.0,0.03,scott brame,
-GEOL,2020,1,Earth History,0.17,0.44,0.17,0.06,0.11,0.0,0.0,0.06,alan coulson,
-GEOL,3750,1,Bahamian Field Study,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,james castle,
-GEOL,4050,1,Surficial Geology,0.31,0.38,0.25,0.0,0.06,0.0,0.0,0.0,james castle,
-GEOL,4090,1,Envir & Exploration Geophysics,0.53,0.18,0.06,0.0,0.12,0.0,0.0,0.12,stephen mich moysey,
-GEOL,4210,1,Gis in Geology,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,6210,1,Gis in Geology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,7900,501,Biogeography & Geology of SC,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
-GEOL,8080,1,Groundwater Modeling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
-GER,1010,1,Elementary German,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,oswald harris king,
-GER,1010,2,Elementary German,0.55,0.25,0.1,0.0,0.0,0.0,0.0,0.1,oswald harris king,
-GER,1020,1,Elementary German,0.06,0.38,0.19,0.19,0.19,0.0,0.0,0.0, lee ferrell,
-GER,1020,2,Elementary German,0.18,0.29,0.41,0.06,0.0,0.0,0.0,0.06, lee ferrell,
-GER,2010,1,Intermediate German,0.3,0.2,0.3,0.1,0.0,0.0,0.0,0.1,gabriela stoicea,
-GER,2010,2,Intermediate German,0.21,0.29,0.36,0.0,0.0,0.0,0.0,0.14,gabriela stoicea,
-GER,2020,1,Intermediate German,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,3160,1,Ger for Intl Trade I,0.58,0.0,0.33,0.08,0.0,0.0,0.0,0.0, lee ferrell,
-GER,3400,1,German Culture,0.45,0.25,0.1,0.05,0.0,0.0,0.0,0.15,oswald harris king,
-HCC,8810,1,Affective Computing,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,shaundra daily,
-HCC,8810,3,Measurement & Eval,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
-HEHD,3990,2,Students Helping Students Peer,0.85,0.1,0.03,0.0,0.0,0.0,0.0,0.03,mary mcp von kaenel,
-HEHD,4000,1,Intro Leadership Theor & Conc,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lori marlise pindar,
-HEHD,4990,5,The Global Community,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mark small,
-HEHD,8010,230,Child/Adolescent Dev,0.76,0.14,0.05,0.0,0.0,0.0,0.0,0.05,edmond patri bowers,
-HEHD,8040,230,Assessment/Eval,0.61,0.26,0.04,0.0,0.0,0.0,0.0,0.09,barry garst,
-HEHD,8880,400,Special Topics Youth Dev Ldshp,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,
-HIST,1010,1,Hist of the U S,0.41,0.43,0.11,0.0,0.05,0.0,0.0,0.0,lee brady wilson,
-HIST,1220,1,"Hist, Tech & Society",0.41,0.32,0.13,0.02,0.06,0.0,0.0,0.06,pamela mack,
-HIST,1240,1,Environmental Hist,0.14,0.54,0.27,0.03,0.0,0.0,0.0,0.03,james brad jeffries,
-HIST,1240,2,Environmental Hist,0.05,0.38,0.4,0.03,0.05,0.0,0.0,0.1,james brad jeffries,
-HIST,1720,1,The West and the World I,0.26,0.41,0.18,0.08,0.03,0.0,0.0,0.05,caroline dunn clark,
-HIST,1730,1,The West and the World II,0.3,0.32,0.21,0.0,0.1,0.0,0.0,0.07, alan grubb,
-HIST,1730,2,The West and the World II,0.32,0.24,0.27,0.07,0.04,0.0,0.0,0.07,richard saunders,
-HIST,1730,3,The West and the World II,0.25,0.44,0.2,0.02,0.07,0.0,0.0,0.02,steven marks,
-HIST,2990,1,Historian's Craft,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth carney,
-HIST,2990,2,Historian's Craft,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,rachel anne moore,
-HIST,3010,1,Am Rev & New Nation,0.26,0.19,0.33,0.0,0.15,0.0,0.0,0.07,james brad jeffries,
-HIST,3080,1,US: Reagan/Clinton 1975-Pres,0.4,0.27,0.18,0.0,0.13,0.0,0.0,0.02,richard saunders,
-HIST,3110,1,African American Hist to 1877,0.35,0.43,0.08,0.08,0.05,0.0,0.0,0.03,abel bartley,
-HIST,3240,1,Hist of the South II,0.32,0.49,0.08,0.03,0.05,0.0,0.0,0.03,john andrew,
-HIST,3260,1,Hist Am Transport,0.38,0.31,0.23,0.0,0.0,0.0,0.0,0.08, roger grant,
-HIST,3290,1,US Legal History Since 1890,0.15,0.05,0.2,0.2,0.0,0.0,0.0,0.4,maribel morey,
-HIST,3380,1,Africa to 1875,0.63,0.2,0.07,0.1,0.0,0.0,0.0,0.0,james burns,
-HIST,3410,1,Modern Mexico,0.49,0.4,0.0,0.03,0.06,0.0,0.0,0.03,rachel anne moore,
-HIST,3870,1,Russian Rev,0.37,0.33,0.23,0.0,0.0,0.0,0.0,0.07,steven marks,
-HIST,3890,2,Monarchs & Courtiers,0.77,0.15,0.0,0.08,0.0,0.0,0.0,0.0,caroline dunn clark,
-HIST,3900,1,Mod Mil Hist,0.19,0.31,0.36,0.08,0.03,0.0,0.0,0.03,edwin moise,
-HIST,3970,1,Modern Middle East,0.62,0.32,0.03,0.0,0.0,0.0,0.0,0.03,amit bein,
-HIST,4000,1,Battleground/Bloodfield RecnSC,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,paul chris anderson,
-HIST,4170,1,History and Tourism,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,leslie white,
-HIST,4510,1,Alexander the Great,0.45,0.25,0.2,0.0,0.1,0.0,0.0,0.0,elizabeth carney,
-HIST,4710,1,20th C France,0.57,0.21,0.0,0.0,0.0,0.0,0.0,0.21, alan grubb,
-HIST,4900,3,Food In Preindus,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,
-HIST,4900,4,Why Germans > Nazi?,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,michael meng,
-HIST,4920,1,US Iraq Wars,0.1,0.6,0.1,0.0,0.0,0.0,0.0,0.2,edwin moise,
-HIST,4930,1,Native American History - 1840,0.4,0.3,0.2,0.1,0.0,0.0,0.0,0.0,james brad jeffries,
-HIST,8200,1,Amer Historiography,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,john andrew,
-HLTH,2020,1,Introduction to Public Health,0.46,0.35,0.15,0.0,0.04,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,2,Introduction to Public Health,0.38,0.35,0.19,0.05,0.0,0.0,0.0,0.03,jeffrey kingree,
-HLTH,2020,400,Introduction to Public Health,0.57,0.24,0.05,0.0,0.1,0.0,0.0,0.05,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.74,0.23,0.0,0.0,0.0,0.0,0.0,0.03,ralph stewart welsh,
-HLTH,2030,2,Health Care Sys,0.38,0.48,0.12,0.0,0.0,0.0,0.0,0.02,frederic fraizer,
-HLTH,2030,400,Health Care Sys,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2030,401,Health Care Sys,0.78,0.06,0.0,0.0,0.06,0.0,0.0,0.11,ralph stewart welsh,
-HLTH,2400,1,Deter of Hlth Behav,0.29,0.51,0.15,0.03,0.03,0.0,0.0,0.0,joel edwar williams,
-HLTH,2980,1,Human Hlth & Disease,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,2980,2,Human Hlth & Disease,0.74,0.21,0.02,0.0,0.0,0.0,0.0,0.02,annah kamugiz amani,
-HLTH,3100,1,Women's Hlth Issues,0.5,0.41,0.03,0.03,0.0,0.0,0.0,0.03,rachel mayo,
-HLTH,3150,1,Social Epidemiology,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-HLTH,3800,1,Epidemiology,0.37,0.34,0.17,0.05,0.02,0.0,0.0,0.05,rachel mayo,
-HLTH,3800,2,Epidemiology,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,3980,2,Hlth Appraisal Sklls,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4000,1,Health Systems Reform,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lingling zhang,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.44,0.34,0.12,0.05,0.02,0.0,0.0,0.02,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,kathleen meyer,
-HLTH,4300,1,Hlth Prom of Aged,0.52,0.22,0.17,0.04,0.0,0.0,0.0,0.04,cheryl jo dye,
-HLTH,4310,1,Public & Environ Hlt,0.53,0.36,0.11,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,4600,1,Health Info Systems,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,ronald gimbel,
-HLTH,4780,1,Hlth Pol Ehtics Law,0.07,0.45,0.31,0.03,0.03,0.0,0.0,0.1,hugh spitler,
-HLTH,4790,1,Fin Mgmt & Hlth Budg,0.22,0.52,0.13,0.04,0.09,0.0,0.0,0.0,khoa dang truong,
-HLTH,4800,1,Comm Hlth Promotion,0.24,0.74,0.0,0.0,0.0,0.0,0.0,0.03,sarah griffin,
-HLTH,4900,1,Res Eval St Pub Hlth,0.87,0.06,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,
-HLTH,4900,2,Res Eval St Pub Hlth,0.37,0.53,0.1,0.0,0.0,0.0,0.0,0.0,lingling zhang,
-HLTH,4970,1,Creative Inq in Public Health,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,karen kemper,
-HLTH,4970,4,Creative Inq in Public Health,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,george clay,
-HLTH,8110,1,Health Care Delivery Systems,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,khoa dang truong,
-HLTH,8310,1,Quantitative Analy in Hlth I,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,lu shi,
-HON,2060,1,Intro to Nanotechnology,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,christophe kitchens,
-HON,2210,1,Beauty in Western Literature,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,johannes schmidt,
-HON,2210,3,Reading Data,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,lindsay carr thomas,
-HON,2220,2,Doubles and Doppelgangers,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,
-HORT,1010,1,Horticulture,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,
-HORT,2110,1,Growing Spring Plnts,0.15,0.3,0.45,0.05,0.0,0.0,0.0,0.05,james emerson faust,
-HORT,4000,4,Vegetable Crops,0.73,0.21,0.06,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,
-HORT,4040,1,Plant Propagation,0.13,0.25,0.46,0.08,0.04,0.0,0.0,0.04,jeffrey adelberg,
-HORT,4050,1,Plant Propagation Techniq Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
-HORT,4050,2,Plant Propagation Techniq Lab,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,jeffrey adelberg,
-HORT,4270,1,Urban Tree Care,0.24,0.36,0.2,0.08,0.08,0.0,0.0,0.04,robert polomski,
-HORT,4330,1,Turf Weed Management,0.16,0.52,0.24,0.04,0.04,0.0,0.0,0.0,ted whitwell,
-HRD,8470,405,Instru System Design,0.75,0.0,0.0,0.0,0.25,0.0,0.0,0.0,philip mcgee,
-HRD,8490,402,Eval of T&D/Hrd Prog,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,
-HRD,8490,405,Eval of T&D/Hrd Prog,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,philip mcgee,
-HRD,8490,406,Eval of T&D/Hrd Prog,0.38,0.38,0.13,0.0,0.13,0.0,0.0,0.0,philip mcgee,
-HRD,8800,404,Research Concepts,0.94,0.0,0.0,0.0,0.06,0.0,0.0,0.0,jon fr christiansen,
-HRD,8970,402,Appl Resear & Devel,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,cynthia sims,
-HRD,8970,403,Appl Resear & Devel,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,cynthia sims,
-IE,2010,1,Systems Design I,0.74,0.24,0.0,0.0,0.0,0.0,0.0,0.01,robert james riggs,
-IE,2100,1,Des Analysis Wrk Sys,0.16,0.52,0.24,0.04,0.02,0.0,0.0,0.02,david neyens,
-IE,2800,1,Deterministic Operations Rsrch,0.2,0.25,0.38,0.09,0.04,0.0,0.0,0.05,burak eksioglu,
-IE,3610,1,Industrial App of Prob/Stat II,0.42,0.42,0.09,0.03,0.03,0.0,0.0,0.0,joel greenstein,
-IE,3810,1,Probabilistic Operations Rsrch,0.26,0.44,0.2,0.06,0.05,0.0,0.0,0.0,amin khademi,
-IE,3840,1,Engr Econ Analysis,0.29,0.23,0.12,0.07,0.1,0.0,0.0,0.18,brian melloy,
-IE,3860,1,Prod Plan & Cont,0.43,0.41,0.11,0.02,0.02,0.0,0.0,0.01,robert james riggs,
-IE,4570,1,Transp/Logistic Engr,0.34,0.4,0.11,0.14,0.0,0.0,0.0,0.0,sandra dun eksioglu,
-IE,4620,1,Six Sigma Quality,0.25,0.39,0.27,0.03,0.0,0.04,0.0,0.01,byung rae cho,
-IE,4670,1,System Design II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,
-IE,4860,1,Scheduling,0.29,0.5,0.14,0.07,0.0,0.0,0.0,0.0,scott jenning mason,
-IE,4910,2,HF in Transportation Systems,0.64,0.26,0.1,0.0,0.0,0.0,0.0,0.0,david neyens,
-IE,6810,1,App of Prob Models in Ind Engr,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,brian melloy,
-IE,6860,1,Scheduling,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-IE,8010,1,Human-Machine Sys,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,
-IE,8040,1,Mfg Sys Plan & Des,0.12,0.31,0.19,0.0,0.19,0.0,0.0,0.19,william ferrell,
-IE,8050,1,Found Qual Engr,0.42,0.46,0.13,0.0,0.0,0.0,0.0,0.0,byung rae cho,
-IE,8150,1,Research Methods in Ergonomics,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,sara lu riggs,
-IE,8520,1,Model Decis Making,0.8,0.15,0.02,0.0,0.0,0.0,0.0,0.02,jonathan cole smith,
-IE,8540,1,Fund of Sc and Log,0.74,0.14,0.05,0.0,0.0,0.0,0.0,0.07,william ferrell,
-IE,8580,1,Case Stu Cap Prof Sc,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-IE,8810,1,Metaheuristics,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,
-IE,8880,1,Adv Prob Methods,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,burak eksioglu,
-INT,1010,5,UPIC 1st Part Time Internship,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.01,troy nunamaker,
-INT,2020,5,UPIC 2nd Full Time Internship,0.0,0.0,0.0,0.0,0.0,0.77,0.15,0.08,troy nunamaker,
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.84,0.12,0.03,meredith fan wilson,
-IS,2100,615,Sel Topics Int Study,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sallie bro turnbull,
-ITAL,1010,1,Elementary Italian,0.48,0.29,0.1,0.0,0.05,0.0,0.0,0.1,julia schmidt,
-ITAL,1020,1,Elementary Italian,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,luca barattoni,
-ITAL,1020,3,Elementary Italian,0.33,0.4,0.27,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,2010,1,Intermediate Italian,0.23,0.38,0.31,0.08,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,2020,1,Intermediate Italian,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,2020,2,Intermediate Italian,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-JAPN,1010,1,Elementary Japanese,0.43,0.0,0.21,0.07,0.07,0.0,0.0,0.21,kazuko shoji,
-JAPN,1010,2,Elementary Japanese,0.53,0.24,0.06,0.06,0.0,0.0,0.0,0.12,toshiko kishimoto,
-JAPN,1020,1,Elementary Japanese,0.5,0.25,0.08,0.0,0.08,0.0,0.0,0.08,toshiko joerger,
-JAPN,1020,2,Elementary Japanese,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,toshiko joerger,
-JAPN,2020,1,Intermed Japanese,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,kazuko shoji,
-JAPN,3060,1,Japanese Conversation & Comp,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,toshiko kishimoto,
-LARC,1160,1,History of Landscape Architect,0.39,0.3,0.16,0.08,0.01,0.0,0.0,0.06,hala fouad nassar,
-LARC,1160,2,History of Larch,0.59,0.35,0.02,0.04,0.0,0.0,0.0,0.0,martin john holland,
-LARC,1520,1,Basic Design II,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,paul russell,
-LARC,4280,1,Comput Aided Design,0.5,0.44,0.0,0.0,0.06,0.0,0.0,0.0,shan jiang,
-LARC,6530,1,Key Issues in Larch,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,
-LARC,8300,1,Grad Seminar I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-LAW,3220,1,Legal Env of Bus,0.3,0.6,0.08,0.02,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,2,Legal Env of Bus,0.32,0.48,0.12,0.06,0.02,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,3,Legal Env of Bus,0.39,0.52,0.06,0.03,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,4,Legal Env of Bus,0.45,0.38,0.14,0.03,0.0,0.0,0.0,0.0,melvin stith,
-LAW,3220,5,Legal Env of Bus,0.44,0.34,0.13,0.05,0.03,0.0,0.0,0.02,melvin stith,
-LAW,3220,6,Legal Env of Bus,0.16,0.3,0.21,0.09,0.05,0.0,0.0,0.19,virgini ward-vaughn,
-LAW,3220,7,Legal Env of Bus,0.11,0.54,0.19,0.05,0.03,0.0,0.0,0.08,virgini ward-vaughn,
-LAW,3220,8,Legal Env of Bus,0.06,0.42,0.32,0.0,0.1,0.0,0.0,0.1,virgini ward-vaughn,
-LAW,3220,10,Legal Env of Bus,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LAW,3220,11,Legal Env of Bus,0.09,0.53,0.27,0.08,0.03,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,12,Legal Env of Bus,0.16,0.37,0.3,0.16,0.02,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,13,Legal Env of Bus,0.25,0.49,0.19,0.02,0.0,0.0,0.0,0.05,john hine,
-LAW,3220,14,Legal Env of Bus,0.23,0.59,0.16,0.0,0.0,0.0,0.0,0.02,john hine,
-LAW,3330,1,Real Estate Law,0.15,0.5,0.32,0.0,0.03,0.0,0.0,0.0,michael bra burrell,
-LAW,4060,1,Sports Law,0.63,0.29,0.0,0.0,0.04,0.04,0.0,0.0,terry don phillips,
-LAW,8480,1,Law Real Estate Prof,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,maurie lou lawrence,
-LAW,8500,1,Law for Prof Accts,0.45,0.52,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LAW,8500,2,Law for Prof Accts,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LS,1000,2,Fitness Leadership,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,patricia figueroa,
-LS,1000,7,Intro to Photography,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sarah elizab mudder,
-LS,1000,9,Intro to Salsa Dance,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,
-LS,1000,12,Intermediate Rock Climbing,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,glenn dav middleton,
-LS,1000,22,Intermediate Ashtanga Yoga,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
-LS,1000,27,Beg. Non-competitive Karate,0.73,0.0,0.0,0.09,0.0,0.0,0.0,0.18,june pilcher,
-LS,1130,1,Wood Carving,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,daniel mor anderson,
-LS,1410,2,Top Rope Climbing,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,glenn dav middleton,
-LS,1580,2,Archery,0.8,0.0,0.07,0.0,0.0,0.0,0.0,0.13,herbert strickland,
-LS,1650,3,Inland Kayak Touring,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,george wal thompson,
-LS,1830,1,Intro to Rugby,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,justin hickey,
-LS,1870,2,Frisbee Sports,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,craig goodman,
-LS,1940,1,Racquetball,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,raymond petersen,
-LS,1940,2,Racquetball,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,raymond petersen,
-LS,1990,1,Intermediate Golf,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,jason jordan,
-LS,2100,2,Learn to Dance,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,matthew lee krabbe,
-LS,2100,4,Learn to Dance,0.74,0.07,0.15,0.0,0.0,0.0,0.0,0.04,paul hoke,
-LS,2110,2,Introduction to Belly Dance,0.82,0.05,0.05,0.0,0.0,0.0,0.0,0.09,stephanie pack,
-LS,2190,1,Country West Dance,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.1,matthew lee krabbe,
-LS,2200,6,Shag,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,broadus fleming,
-LS,2200,8,Shag,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,
-LS,2270,1,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.03,0.0,0.0,0.03,paul hoke,
-LS,2270,4,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,paul hoke,
-LS,2320,1,Core Training,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,diane moreno,
-LS,2350,2,Basic Yoga,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
-LS,2350,3,Basic Yoga,0.83,0.04,0.09,0.04,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2350,4,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2350,5,Basic Yoga,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2350,6,Basic Yoga,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
-LS,2360,1,Power/Ashtanga Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
-LS,2360,2,Power/Ashtanga Yoga,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,ani reina-nunnelley,
-LS,2370,3,Kripalu Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,
-LS,2370,4,Kripalu Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,
-LS,2370,5,Kripalu Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,
-LS,2380,4,Vinyasa Flow Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jenefer nadenicek,
-LS,2420,2,Meditation and Relax,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
-LS,2420,3,Meditation and Relax,0.79,0.05,0.0,0.0,0.0,0.0,0.0,0.16,ranjanbala dil amin,
-LS,2420,4,Meditation and Relax,0.82,0.05,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,
-LS,2420,6,Meditation and Relax,0.65,0.13,0.0,0.04,0.0,0.0,0.0,0.17,renee warren gahan,
-LS,2450,1,Pilates,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,melanie ivey job,
-LS,2500,1,Marathon Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,john walston dunn,True
-LS,2510,2,Running & Jogging,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,corey dou brookover,
-LS,2660,1,Hapkido,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,kelly smith,
-MATH,1010,1,Essen Math for Informed Soc,0.4,0.32,0.12,0.04,0.0,0.0,0.0,0.12,marilyn reba,
-MATH,1010,2,Essen Math for Informed Soc,0.42,0.17,0.31,0.11,0.0,0.0,0.0,0.0,judith cottingham,
-MATH,1010,3,Essen Math for Informed Soc,0.47,0.21,0.16,0.11,0.0,0.0,0.0,0.05,paran rebeka norton,
-MATH,1010,4,Essen Math for Informed Soc,0.32,0.27,0.16,0.14,0.03,0.0,0.0,0.08,judith cottingham,
-MATH,1010,5,Essen Math for Informed Soc,0.12,0.29,0.29,0.0,0.29,0.0,0.0,0.0,sergey charnyi,
-MATH,1010,6,Essen Math for Informed Soc,0.38,0.29,0.21,0.03,0.03,0.0,0.0,0.06,megan elizabet ryan,
-MATH,1010,7,Essen Math for Informed Soc,0.32,0.32,0.16,0.11,0.05,0.0,0.0,0.05,merle glick,
-MATH,1020,1,Intro to Mathematical Analysis,0.24,0.14,0.1,0.24,0.14,0.0,0.0,0.14,vito capuano,
-MATH,1020,2,Intro to Mathematical Analysis,0.07,0.24,0.2,0.24,0.12,0.0,0.0,0.12,thanh thien to,
-MATH,1020,3,Intro to Mathematical Analysis,0.13,0.22,0.2,0.07,0.33,0.0,0.0,0.04,matthew harr menard,
-MATH,1020,4,Intro to Mathematical Analysis,0.15,0.18,0.21,0.13,0.26,0.0,0.0,0.08,liu zhu,
-MATH,1020,5,Intro to Mathematical Analysis,0.13,0.41,0.22,0.09,0.13,0.0,0.0,0.02,randy davidson,
-MATH,1020,6,Intro to Mathematical Analysis,0.15,0.3,0.25,0.1,0.1,0.0,0.0,0.1,david james rea,
-MATH,1020,7,Intro to Mathematical Analysis,0.15,0.37,0.2,0.04,0.22,0.0,0.0,0.02,abigail bowers,
-MATH,1020,8,Intro to Mathematical Analysis,0.11,0.18,0.27,0.14,0.27,0.0,0.0,0.02,samuel jose shesman,
-MATH,1020,9,Intro to Mathematical Analysis,0.2,0.3,0.3,0.07,0.11,0.0,0.0,0.02,abigail bowers,
-MATH,1020,10,Intro to Mathematical Analysis,0.19,0.33,0.29,0.07,0.07,0.0,0.0,0.05,randy davidson,
-MATH,1020,11,Intro to Mathematical Analysis,0.18,0.46,0.1,0.1,0.05,0.0,0.0,0.1,randy davidson,
-MATH,1020,12,Intro to Mathematical Analysis,0.2,0.2,0.3,0.15,0.1,0.0,0.0,0.05,isaac justus,
-MATH,1020,13,Intro to Mathematical Analysis,0.14,0.23,0.27,0.09,0.18,0.0,0.0,0.09,"rodriguez esperanza,",
-MATH,1020,14,Intro to Mathematical Analysis,0.16,0.2,0.38,0.09,0.09,0.0,0.0,0.09,abigail bowers,
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.28,0.67,0.05, morales hernandez,
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.19,0.72,0.09,javier ruiz ramirez,
-MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.56,0.44,0.0,eliza dar gallagher,
-MATH,1060,1,Calculus of One Variable I,0.02,0.14,0.24,0.14,0.24,0.0,0.0,0.22,charity watson,
-MATH,1060,2,Calculus of One Variable I,0.0,0.04,0.2,0.16,0.43,0.0,0.0,0.16,sanwar ahmad,
-MATH,1060,3,Calculus of One Variable I,0.03,0.39,0.12,0.12,0.18,0.0,0.0,0.15,allen anderso guest,
-MATH,1060,4,Calculus of One Variable I,0.06,0.12,0.33,0.27,0.09,0.0,0.0,0.12,allen anderso guest,
-MATH,1060,5,Calculus of One Variable I,0.04,0.17,0.25,0.15,0.23,0.0,0.0,0.17,honghai xu,
-MATH,1060,6,Calculus of One Variable I,0.0,0.17,0.21,0.26,0.23,0.0,0.0,0.13,charity watson,
-MATH,1060,7,Calculus of One Variable I,0.02,0.09,0.3,0.22,0.35,0.0,0.0,0.02,abdullah al mamun,
-MATH,1060,201,Calculus of One Variable I,0.25,0.08,0.25,0.0,0.33,0.0,0.0,0.08,james peterson,
-MATH,1070,1,Differen and Integral Calculus,0.18,0.48,0.27,0.03,0.0,0.0,0.0,0.03,donna simms,
-MATH,1070,2,Differen and Integral Calculus,0.11,0.36,0.33,0.17,0.0,0.0,0.0,0.03,donna simms,
-MATH,1070,3,Differen and Integral Calculus,0.0,0.14,0.5,0.21,0.07,0.0,0.0,0.07,sherry biggers,
-MATH,1070,4,Differen and Integral Calculus,0.08,0.29,0.29,0.26,0.08,0.0,0.0,0.0,sherry biggers,
-MATH,1070,5,Differen and Integral Calculus,0.03,0.32,0.29,0.23,0.06,0.0,0.0,0.06,sherry biggers,
-MATH,1070,6,Differen and Integral Calculus,0.09,0.23,0.36,0.14,0.09,0.0,0.0,0.09,jason to hedetniemi,
-MATH,1070,7,Differen and Integral Calculus,0.09,0.45,0.18,0.09,0.09,0.0,0.0,0.09,fiona may knoll,
-MATH,1080,1,Calculus of One Variable II,0.07,0.19,0.19,0.05,0.17,0.0,0.0,0.33,christa con johnson,
-MATH,1080,2,Calculus of One Variable II,0.05,0.07,0.14,0.05,0.33,0.0,0.0,0.36,sarah eliz anderson,
-MATH,1080,3,Calculus of One Variable II,0.04,0.24,0.22,0.11,0.18,0.0,0.0,0.2,christa con johnson,
-MATH,1080,4,Calculus of One Variable II,0.19,0.17,0.26,0.09,0.11,0.0,0.0,0.19,meredith nicol burr,
-MATH,1080,5,Calculus of One Variable II,0.02,0.3,0.17,0.13,0.04,0.0,0.0,0.33,audrey nico devries,
-MATH,1080,6,Calculus of One Variable II,0.09,0.19,0.28,0.07,0.09,0.0,0.0,0.28,meredith nicol burr,
-MATH,1080,7,Calculus of One Variable II,0.02,0.05,0.23,0.16,0.3,0.0,0.0,0.23,terri johnson,
-MATH,1080,8,Calculus of One Variable II,0.0,0.14,0.05,0.19,0.21,0.0,0.0,0.42,alistair bentley,
-MATH,1080,9,Calculus of One Variable II,0.05,0.17,0.2,0.15,0.17,0.0,0.0,0.27,karyn muir,
-MATH,1080,10,Calculus of One Variable II,0.16,0.2,0.24,0.13,0.09,0.0,0.0,0.18,meredith nicol burr,
-MATH,1080,11,Calculus of One Variable II,0.11,0.24,0.2,0.09,0.11,0.0,0.0,0.24,shih-wei chao,
-MATH,1080,12,Calculus of One Variable II,0.0,0.14,0.16,0.14,0.19,0.0,0.0,0.37,rebecca ramos,
-MATH,1080,13,Calculus of One Variable II,0.0,0.19,0.31,0.16,0.13,0.0,0.0,0.22,marilyn reba,
-MATH,1080,14,Calculus of One Variable II,0.13,0.23,0.23,0.1,0.0,0.0,0.0,0.32,marilyn reba,
-MATH,1080,15,Calculus of One Variable II,0.0,0.11,0.14,0.02,0.23,0.0,0.0,0.5,stefan adam bock,
-MATH,1150,1,Contemp Math for Elem Teach I,0.44,0.46,0.08,0.0,0.0,0.0,0.0,0.03,allison stoddard,
-MATH,1160,1,Contemp Math for Elem Teach II,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1160,2,Contemp Math for Elem Teach II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.87,0.11,0.02,marion hanna,
-MATH,2060,1,Calculus of Several Variables,0.14,0.26,0.23,0.09,0.14,0.0,0.0,0.14,patrick buckingham,
-MATH,2060,2,Calculus of Several Variables,0.19,0.06,0.1,0.06,0.19,0.0,0.0,0.39,dania moham zantout,
-MATH,2060,3,Calculus of Several Variables,0.37,0.4,0.17,0.0,0.06,0.0,0.0,0.0,chanseok park,
-MATH,2060,4,Calculus of Several Variables,0.76,0.14,0.08,0.03,0.0,0.0,0.0,0.0,martin joha schmoll,
-MATH,2060,5,Calculus of Several Variables,0.06,0.38,0.29,0.12,0.12,0.0,0.0,0.03,charles johnson,
-MATH,2060,6,Calculus of Several Variables,0.18,0.15,0.06,0.15,0.21,0.0,0.0,0.26,dania moham zantout,
-MATH,2060,7,Calculus of Several Variables,0.41,0.44,0.09,0.0,0.06,0.0,0.0,0.0,sofya alekseeva,
-MATH,2060,8,Calculus of Several Variables,0.07,0.17,0.28,0.03,0.24,0.0,0.0,0.21,dania moham zantout,
-MATH,2060,10,Calculus of Several Variables,0.14,0.31,0.19,0.22,0.11,0.0,0.0,0.03,charles johnson,
-MATH,2060,12,Calculus of Several Variables,0.32,0.41,0.12,0.0,0.09,0.0,0.0,0.06,sofya alekseeva,
-MATH,2060,100,Calc of Several Variable (HON),0.54,0.38,0.0,0.0,0.08,0.0,0.0,0.0,james brown,True
-MATH,2070,1,Multivariable Calculus,0.16,0.26,0.21,0.16,0.16,0.0,0.0,0.05,elaine ma sotherden,
-MATH,2070,2,Multivariable Calculus,0.26,0.26,0.26,0.11,0.11,0.0,0.0,0.0,garrett dranichak,
-MATH,2070,4,Multivariable Calculus,0.14,0.27,0.23,0.09,0.14,0.0,0.0,0.14,amy christine grady,
-MATH,2070,5,Multivariable Calculus,0.27,0.22,0.22,0.15,0.1,0.0,0.0,0.05,jennifer mari hanna,
-MATH,2070,6,Multivariable Calculus,0.19,0.43,0.21,0.07,0.02,0.0,0.0,0.07,judith irene mcknew,
-MATH,2070,7,Multivariable Calculus,0.36,0.26,0.19,0.12,0.05,0.0,0.0,0.02,jennifer mari hanna,
-MATH,2070,9,Multivariable Calculus,0.15,0.32,0.17,0.05,0.2,0.0,0.0,0.12,grady mcgowa thomas,
-MATH,2070,10,Multivariable Calculus,0.14,0.14,0.36,0.02,0.24,0.0,0.0,0.1,liem nguyen,
-MATH,2070,11,Multivariable Calculus,0.32,0.27,0.27,0.0,0.09,0.0,0.0,0.05,tony thanh nguyen,
-MATH,2070,12,Multivariable Calculus,0.27,0.32,0.23,0.0,0.14,0.0,0.0,0.05,kara ail stasikelis,
-MATH,2070,13,Multivariable Calculus,0.15,0.55,0.2,0.1,0.0,0.0,0.0,0.0,mengying xiao,
-MATH,2070,14,Multivariable Calculus,0.4,0.2,0.1,0.05,0.2,0.0,0.0,0.05,luke marti giberson,
-MATH,2070,15,Multivariable Calculus,0.31,0.21,0.21,0.14,0.05,0.0,0.0,0.07,judith irene mcknew,
-MATH,2070,16,Multivariable Calculus,0.2,0.35,0.2,0.05,0.1,0.0,0.0,0.1,kevin wayne dettman,
-MATH,2070,17,Multivariable Calculus,0.14,0.38,0.33,0.0,0.05,0.0,0.0,0.1,fawwaz taw batayneh,
-MATH,2070,19,Multivariable Calculus,0.33,0.21,0.26,0.05,0.14,0.0,0.0,0.02,margaret milliken,
-MATH,2070,20,Multivariable Calculus,0.33,0.28,0.22,0.0,0.11,0.0,0.0,0.06, ushijima-mwesigwa,
-MATH,2070,21,Multivariable Calculus,0.24,0.37,0.17,0.1,0.07,0.0,0.0,0.05,jennifer mari hanna,
-MATH,2070,22,Multivariable Calculus,0.17,0.33,0.06,0.06,0.17,0.0,0.0,0.22,trevor scot vilardi,
-MATH,2070,24,Multivariable Calculus,0.21,0.21,0.26,0.0,0.16,0.0,0.0,0.16,qijun he,
-MATH,2070,25,Multivariable Calculus,0.34,0.2,0.2,0.12,0.07,0.0,0.0,0.07,jennifer mari hanna,
-MATH,2070,26,Multivariable Calculus,0.06,0.24,0.29,0.12,0.18,0.0,0.0,0.12,yisu jia,
-MATH,2080,1,Intro to Ordin Diff Equations,0.08,0.3,0.18,0.15,0.1,0.0,0.0,0.2,terri johnson,
-MATH,2080,3,Intro to Ordin Diff Equations,0.09,0.26,0.13,0.11,0.2,0.0,0.0,0.2,timothy fra parrott,
-MATH,2080,4,Intro to Ordin Diff Equations,0.13,0.32,0.06,0.06,0.19,0.0,0.0,0.23,shari prevost,
-MATH,2080,5,Intro to Ordin Diff Equations,0.3,0.3,0.16,0.05,0.16,0.0,0.0,0.05,minerva rios-adams,
-MATH,2080,6,Intro to Ordin Diff Equations,0.21,0.45,0.13,0.11,0.08,0.0,0.0,0.03,minerva rios-adams,
-MATH,2080,7,Intro to Ordin Diff Equations,0.2,0.24,0.34,0.0,0.15,0.0,0.0,0.07,julie lassiter,
-MATH,2080,8,Intro to Ordin Diff Equations,0.41,0.15,0.26,0.0,0.04,0.0,0.0,0.13,timothy fra parrott,
-MATH,2080,9,Intro to Ordin Diff Equations,0.49,0.22,0.22,0.04,0.0,0.0,0.0,0.02,timothy ch teitloff,
-MATH,2080,10,Intro to Ordin Diff Equations,0.21,0.21,0.15,0.18,0.12,0.0,0.0,0.15,shari prevost,
-MATH,2080,11,Intro to Ordin Diff Equations,0.36,0.29,0.09,0.09,0.09,0.0,0.0,0.09,timothy fra parrott,
-MATH,2080,12,Intro to Ordin Diff Equations,0.31,0.22,0.31,0.14,0.0,0.0,0.0,0.03,timothy ch teitloff,
-MATH,2080,13,Intro to Ordin Diff Equations,0.24,0.24,0.33,0.15,0.03,0.0,0.0,0.0,julie lassiter,
-MATH,2080,14,Intro to Ordin Diff Equations,0.39,0.29,0.2,0.05,0.0,0.0,0.0,0.07,nathan jos adelgren,
-MATH,2080,15,Intro to Ordin Diff Equations,0.53,0.27,0.16,0.02,0.02,0.0,0.0,0.0,timothy ch teitloff,
-MATH,2080,16,Intro to Ordin Diff Equations,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,irina viktorova,
-MATH,2080,17,Intro to Ordin Diff Equations,0.3,0.51,0.11,0.0,0.03,0.0,0.0,0.05,brandon gra goodell,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,james brannan,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.57,0.4,0.0,0.0,0.03,0.0,0.0,0.0,allison stoddard,
-MATH,3020,1,Stat for Science & Engineering,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,christopher wilson,
-MATH,3020,2,Stat for Science & Engineering,0.7,0.14,0.05,0.04,0.05,0.0,0.0,0.02,dominique morgan,
-MATH,3020,3,Stat for Science & Engineering,0.45,0.25,0.07,0.05,0.14,0.0,0.0,0.05,christopher mcmahan,
-MATH,3020,4,Stat for Science & Engineering,0.69,0.21,0.05,0.05,0.0,0.0,0.0,0.0,xiaoqian sun,
-MATH,3020,5,Stat for Science & Engineering,0.19,0.35,0.26,0.06,0.04,0.0,0.0,0.11,michael thom finney,
-MATH,3080,1,College Geometry,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,eliza dar gallagher,
-MATH,3110,1,Linear Algebra,0.38,0.22,0.14,0.14,0.11,0.0,0.0,0.03,elena sta dimitrova,
-MATH,3110,2,Linear Algebra,0.5,0.34,0.13,0.03,0.0,0.0,0.0,0.0,judith cottingham,
-MATH,3110,3,Linear Algebra,0.21,0.24,0.41,0.03,0.06,0.0,0.0,0.06,svetlan poznanovikj,
-MATH,3110,4,Linear Algebra,0.31,0.11,0.23,0.06,0.17,0.0,0.0,0.11,xuhong gao,
-MATH,3110,5,Linear Algebra,0.56,0.16,0.08,0.0,0.08,0.0,0.0,0.12,xuhong gao,
-MATH,3150,1,Adv Top in Math for Elem Teach,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,3190,1,Introduction to Proof,0.35,0.26,0.17,0.0,0.13,0.0,0.0,0.09,kevin james,
-MATH,3190,2,Introduction to Proof,0.4,0.3,0.1,0.0,0.1,0.0,0.0,0.1,michael adam burr,
-MATH,3600,1,Intermediate Math Computing,0.63,0.2,0.05,0.0,0.07,0.0,0.0,0.05,neil calkin,
-MATH,3650,1,Numerical Mthds for Engineers,0.72,0.26,0.02,0.0,0.0,0.0,0.0,0.0,abigail bowers,
-MATH,3650,2,Numerical Mthds for Engineers,0.17,0.22,0.33,0.14,0.08,0.0,0.0,0.06,christopher cox,
-MATH,3650,3,Numerical Mthds for Engineers,0.19,0.31,0.33,0.06,0.06,0.0,0.0,0.06,christopher cox,
-MATH,4000,1,Theory of Probability,0.5,0.21,0.11,0.04,0.11,0.0,0.0,0.04,yingbo li,
-MATH,4030,1,Intro to Statistical Theory,0.36,0.23,0.23,0.05,0.09,0.0,0.0,0.05,xiaoqian sun,
-MATH,4070,1,Regress & Time-Series Analysis,0.5,0.29,0.21,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,4100,1,Number Theory,0.4,0.25,0.15,0.15,0.05,0.0,0.0,0.0,charles johnson,
-MATH,4120,1,Intro to Modern Algebra,0.28,0.21,0.21,0.1,0.1,0.0,0.0,0.1,elena sta dimitrova,
-MATH,4190,1,Discrete Math Structures I,0.44,0.31,0.11,0.02,0.02,0.0,0.0,0.09,beth novick,
-MATH,4300,1,Actuarial Science Seminar I,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,mark cawood,
-MATH,4310,1,Theory of Interest,0.23,0.41,0.23,0.14,0.0,0.0,0.0,0.0, erwin walker,
-MATH,4340,1,Adv Engineering Mathematics,0.29,0.31,0.17,0.06,0.09,0.0,0.0,0.09,qingshan chen,
-MATH,4340,2,Adv Engineering Mathematics,0.46,0.21,0.13,0.0,0.04,0.0,0.0,0.17,daniel warner,
-MATH,4400,1,Linear Programming,0.43,0.1,0.14,0.05,0.1,0.0,0.0,0.19,warren adams,
-MATH,4530,1,Advanced Calculus I,0.13,0.13,0.2,0.2,0.2,0.0,0.0,0.13,jeong rock yoon,
-MATH,4540,1,Advanced Calculus II,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,taufiquar rahm khan,
-MATH,6340,1,Adv Engineering Mathematics,0.4,0.3,0.1,0.0,0.05,0.0,0.0,0.15,hyesuk lee,
-MATH,8030,1,Stochastic Processes,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
-MATH,8050,1,Data Analysis,0.48,0.35,0.09,0.0,0.0,0.0,0.0,0.09,derek brown,
-MATH,8090,1,Time Series Analysis,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,colin gallagher,
-MATH,8100,1,Mathematical Programming,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
-MATH,8110,1,Nonlinear Programming,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,
-MATH,8130,1,Advanced Linear Programming,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,warren adams,
-MATH,8210,1,Linear Analysis,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,
-MATH,8260,1,Partial Differential Equations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,
-MATH,8520,1,Abstract Algebra II,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,james brown,
-MATH,8530,1,Matrix Analysis,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,matthew macauley,
-MATH,8570,1,Cryptography,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,felice manganiello,
-MATH,8600,1,Intro to Scientific Computing,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,leo rebholz,
-MATH,8660,1,Finite Element Method,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
-MATH,8810,1,Mathematical Statistics,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,
-MATH,9830,1,Sel Top in Computational Math,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timo johann heister,
-MBA,8030,1,Stat Analy of Bus Op,0.82,0.15,0.0,0.0,0.0,0.0,0.0,0.03,matthew charl klein,
-MBA,8060,1,Operations Mgt,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06, sridharan,
-MBA,8070,1,Financial Management,0.83,0.18,0.0,0.0,0.0,0.0,0.0,0.0,fei xie,
-MBA,8070,2,Financial Management,0.46,0.49,0.03,0.0,0.0,0.0,0.0,0.03,fei xie,
-MBA,8090,1,Org Beh & Hum Res Mg,0.65,0.33,0.0,0.0,0.0,0.0,0.0,0.02,thomas jo zagenczyk,
-MBA,8190,1,Intro to Acc and Fin,0.53,0.35,0.09,0.0,0.02,0.0,0.0,0.0,jeffrey mcmillan,
-MBA,8290,1,Marketing Foundation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MBA,8370,1,Legal Environ of Bus,0.53,0.42,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8410,1,Real Estate Finance,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,james pow mckissick,
-MBA,8430,10,MBAePT Entrepreneurial Acct,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
-MBA,8450,1,MBAe FT Tech & Innova Mgt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david orr,
-MBA,8470,1,MBAe FT New Venture Creation,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
-MBA,8540,1,Mgrl Accounting,0.84,0.11,0.03,0.0,0.0,0.0,0.0,0.03,henry anderson,
-MBA,8540,2,Mgrl Accounting,0.8,0.1,0.02,0.0,0.02,0.0,0.0,0.05,henry anderson,
-MBA,8590,1,Mgr Decision Model,0.45,0.21,0.06,0.0,0.04,0.0,0.0,0.23,mark mcknew,
-MBA,8590,3,Mgr Decision Model,0.38,0.33,0.15,0.0,0.05,0.0,0.0,0.1,sara elizabet yoder,
-MBA,8600,1,Advanced Marketing Strategy,0.36,0.46,0.18,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8610,1,Information Systems,0.38,0.52,0.0,0.0,0.03,0.0,0.0,0.07,varun grover,
-MBA,8610,2,Information Systems,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,heshan sun,
-MBA,8620,1,Managerial Economics,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,
-MBA,8720,1,MBAe FT Entrepr Finance,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,
-MBA,8750,1,Enterprise Develpmnt,0.66,0.29,0.03,0.0,0.0,0.0,0.0,0.03,michael george mino,
-MBA,8990,1,Advanced Leadership,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,gail depriest,
-ME,2000,1,Sophomore Seminar,0.84,0.11,0.01,0.0,0.01,0.0,0.0,0.03,donald beasley,
-ME,2010,1,Statics & Dynamics,0.02,0.12,0.23,0.16,0.36,0.0,0.0,0.1,sherrill biggers,
-ME,2010,2,Statics & Dynamics,0.11,0.31,0.26,0.11,0.15,0.0,0.0,0.06,paul joseph,
-ME,2030,1,Founda Th/Fl Syst,0.29,0.42,0.1,0.13,0.02,0.0,0.0,0.04,richard figliola,
-ME,2030,2,Founda Th/Fl Syst,0.14,0.27,0.41,0.1,0.06,0.0,0.0,0.02,chenning tong,
-ME,2030,3,Founda Th/Fl Syst,0.44,0.42,0.1,0.0,0.01,0.0,0.0,0.02,david zumbrunnen,
-ME,2040,1,Mechanics of Materials,0.27,0.33,0.21,0.09,0.05,0.0,0.0,0.05,michael porter,
-ME,2040,2,Mechanics of Materials,0.09,0.54,0.21,0.04,0.07,0.0,0.0,0.04,todd schweisinger,
-ME,2220,1,Mech Engr Lab I,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,2,Mech Engr Lab I,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,3,Mech Engr Lab I,0.2,0.5,0.25,0.05,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,4,Mech Engr Lab I,0.27,0.6,0.07,0.07,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,5,Mech Engr Lab I,0.15,0.8,0.0,0.0,0.05,0.0,0.0,0.0,todd schweisinger,
-ME,2220,6,Mech Engr Lab I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,7,Mech Engr Lab I,0.21,0.74,0.0,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
-ME,2220,8,Mech Engr Lab I,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3030,1,Thermodynamics,0.12,0.29,0.33,0.16,0.04,0.0,0.0,0.07,jay ochterbeck,
-ME,3040,1,Heat Transfer,0.4,0.28,0.25,0.03,0.02,0.0,0.0,0.02,donald beasley,
-ME,3040,2,Heat Transfer,0.22,0.44,0.15,0.06,0.06,0.0,0.0,0.07,xin zhao,
-ME,3050,1,Model/an Dy Syst,0.18,0.38,0.2,0.09,0.09,0.0,0.0,0.07,phanin tallapragada,
-ME,3050,2,Model/an Dy Syst,0.21,0.58,0.17,0.02,0.0,0.0,0.0,0.02,yue wang,
-ME,3060,1,Fund Machine Design,0.32,0.47,0.15,0.05,0.02,0.0,0.0,0.0,oliver myers,
-ME,3060,2,Fund Machine Design,0.47,0.36,0.09,0.06,0.0,0.0,0.0,0.02,paul jeffrey meyer,
-ME,3070,1,Found of Mechanical Systems,0.54,0.32,0.04,0.04,0.04,0.0,0.0,0.04,lonny thompson,
-ME,3070,2,Found of Mechanical Systems,0.14,0.32,0.36,0.11,0.0,0.0,0.0,0.07,gregory mocko,
-ME,3080,1,Fluid Mechanics,0.0,0.28,0.33,0.19,0.14,0.0,0.0,0.06,jean-marc delhaye,
-ME,3080,2,Fluid Mechanics,0.09,0.4,0.33,0.11,0.02,0.0,0.0,0.04,ethan kung,
-ME,3100,1,Thermo/Heat Transfer,0.19,0.32,0.22,0.12,0.01,0.0,0.0,0.13,xiangchun xuan,
-ME,3120,1,Manuf Processes,0.46,0.35,0.08,0.08,0.02,0.0,0.0,0.0,hong seok choi,
-ME,3330,1,Mech Engr Lab II,0.38,0.44,0.13,0.06,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,2,Mech Engr Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,3,Mech Engr Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,4,Mech Engr Lab II,0.19,0.44,0.25,0.0,0.06,0.0,0.0,0.06,todd schweisinger,
-ME,3330,5,Mech Engr Lab II,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
-ME,3330,6,Mech Engr Lab II,0.21,0.53,0.16,0.05,0.05,0.0,0.0,0.0,todd schweisinger,
-ME,3330,7,Mech Engr Lab II,0.22,0.56,0.11,0.06,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,3330,8,Mech Engr Lab II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4000,1,Senior Seminar,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0, ramasubramanian,
-ME,4010,1,Mech Engr Design,0.18,0.69,0.09,0.02,0.02,0.0,0.0,0.0,joshua summers,
-ME,4020,1,Intern in Engr Des,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4020,3,Intern in Engr Des,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,4,Intern in Engr Des,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,ethan kung,
-ME,4020,7,Intern in Engr Des,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,4030,1,Control Dynamic Syst,0.4,0.33,0.13,0.13,0.0,0.0,0.0,0.0,hamed saeidi,
-ME,4030,2,Control Dynamic Syst,0.05,0.19,0.3,0.24,0.16,0.0,0.0,0.05,kalyan chakr katuri,
-ME,4170,1,Mechatronic Sys,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4220,1,Design Gas Turbines,0.46,0.31,0.15,0.0,0.0,0.0,0.0,0.08,abhijit som,
-ME,4230,1,Intro Aerodynamics,0.15,0.18,0.5,0.12,0.06,0.0,0.0,0.0,richard figliola,
-ME,4260,1,Nuclear Energy,0.26,0.26,0.29,0.12,0.03,0.0,0.0,0.03,david zumbrunnen,
-ME,4320,1,Adv Strength of Matl,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,gang li,
-ME,4440,3,Mech Engr Lab III,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,5,Mech Engr Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4930,5,SelectedTopics ME (RapidProto),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4930,29,Selected Topics ME (Solar E),0.62,0.34,0.0,0.0,0.0,0.0,0.0,0.03,daniel fant,
-ME,6170,1,Mechatronic Sys,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,6320,1,Adv Strength of Matl,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,gang li,
-ME,6930,5,SelectedTopics ME (RapidProto),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,6930,11,Selected Topics ME (MicroFab),0.44,0.38,0.06,0.0,0.13,0.0,0.0,0.0,rod martinez-duarte,
-ME,6930,29,Selected Topics ME (Solar E),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,8120,1,Exp Meth Thermal Sci,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
-ME,8190,1,Cp Meth in Therm Sc,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,richard miller,
-ME,8200,1,Mod Cont Engr,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,
-ME,8310,1,Convective Ht Trans,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,john saylor,
-ME,8360,1,Fracture Mech,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,8520,1,Adv Finite Ele Ana,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,lonny thompson,
-ME,8610,1,Matl Sel Engr Design,0.86,0.11,0.02,0.0,0.0,0.0,0.0,0.02,mica grujicic,
-ME,8930,1,Sel Topics in ME (Scaling),0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,8930,27,Sel Top - Optimal Estimation,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,ardalan vahidi,
-MGT,2010,1,Principles of Mgt,0.36,0.3,0.21,0.05,0.04,0.0,0.0,0.05,katherine clark,
-MGT,2010,2,Principles of Mgt,0.23,0.47,0.23,0.02,0.04,0.0,0.0,0.0,katherine clark,
-MGT,2010,3,Principles of Mgt,0.21,0.36,0.24,0.04,0.08,0.0,0.0,0.07,katherine clark,
-MGT,2010,4,Principles of Mgt,0.22,0.38,0.19,0.12,0.01,0.0,0.0,0.08,katherine clark,
-MGT,2010,5,Principles of Mgt,0.27,0.34,0.25,0.05,0.0,0.0,0.0,0.08,tina robbins,
-MGT,2010,6,Principles of Mgt,0.26,0.54,0.12,0.05,0.01,0.0,0.0,0.01,tina robbins,
-MGT,2010,7,Principles of Mgt,0.29,0.45,0.21,0.03,0.0,0.0,0.0,0.03,tina robbins,
-MGT,2010,8,Principles of Mgt,0.27,0.36,0.18,0.08,0.05,0.0,0.0,0.06,tina robbins,
-MGT,2180,1,Management PC Applications,0.53,0.3,0.08,0.02,0.04,0.0,0.0,0.02,ryan toole,
-MGT,2180,2,Management PC Applications,0.55,0.28,0.08,0.02,0.04,0.0,0.0,0.03,ryan toole,
-MGT,2180,3,Management PC Applications,0.57,0.32,0.06,0.03,0.01,0.0,0.0,0.02,ryan toole,
-MGT,2180,4,Management PC Applications,0.57,0.25,0.1,0.02,0.02,0.0,0.0,0.05,ryan toole,
-MGT,3070,1,Human Resource Management,0.64,0.27,0.05,0.0,0.0,0.0,0.0,0.05,priscilla harrison,
-MGT,3070,2,Human Resource Management,0.48,0.48,0.03,0.0,0.03,0.0,0.0,0.0,michael cole,
-MGT,3070,3,Human Resource Management,0.17,0.78,0.03,0.0,0.03,0.0,0.0,0.0,kristin dam scott,
-MGT,3070,4,Human Resource Management,0.4,0.48,0.08,0.0,0.0,0.0,0.0,0.05,michael cole,
-MGT,3070,5,Human Resource Management,0.08,0.56,0.31,0.05,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,6,Human Resource Management,0.18,0.67,0.15,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3100,1,Intermed Business Statistics,0.32,0.39,0.16,0.0,0.02,0.0,0.0,0.11,james walsh,
-MGT,3100,2,Intermed Business Statistics,0.66,0.13,0.11,0.05,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3100,3,Intermed Business Statistics,0.58,0.25,0.1,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3100,4,Intermed Business Statistics,0.12,0.32,0.27,0.17,0.05,0.0,0.0,0.07,sara elizabet yoder,
-MGT,3100,5,Intermed Business Statistics,0.44,0.28,0.19,0.0,0.06,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3100,6,Intermed Business Statistics,0.44,0.36,0.11,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3100,7,Intermed Business Statistics,0.16,0.17,0.24,0.14,0.08,0.0,0.0,0.21,sara elizabet yoder,
-MGT,3100,8,Intermed Business Statistics,0.14,0.23,0.14,0.27,0.14,0.0,0.0,0.09,sara elizabet yoder,
-MGT,3100,10,Intermed Business Statistics,0.24,0.45,0.24,0.05,0.0,0.0,0.0,0.02,yuhong he,
-MGT,3120,1,Decision Models for Management,0.3,0.4,0.23,0.02,0.05,0.0,0.0,0.0,mark mcknew,
-MGT,3120,2,Decision Models for Management,0.13,0.41,0.35,0.04,0.0,0.0,0.0,0.07,mark mcknew,
-MGT,3120,3,Decision Models for Management,0.13,0.5,0.24,0.0,0.11,0.0,0.0,0.02,mark mcknew,
-MGT,3150,1,New Venture Creation,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
-MGT,3180,1,Mgt of Info Systems,0.51,0.36,0.05,0.05,0.03,0.0,0.0,0.0,dan jiang,
-MGT,3180,2,Mgt of Info Systems,0.33,0.38,0.3,0.0,0.0,0.0,0.0,0.0,tina marie esposito,
-MGT,3180,3,Mgt of Info Systems,0.21,0.44,0.33,0.0,0.03,0.0,0.0,0.0,roopa raman,
-MGT,3180,4,Mgt of Info Systems,0.13,0.37,0.47,0.0,0.0,0.0,0.0,0.03,roopa raman,
-MGT,3900,2,Ops Mgt,0.36,0.2,0.32,0.08,0.0,0.0,0.0,0.04,min kyung lee,
-MGT,3900,3,Ops Mgt,0.35,0.35,0.25,0.0,0.03,0.0,0.0,0.03,zachary mo leffakis,
-MGT,3900,4,Ops Mgt,0.18,0.35,0.28,0.03,0.05,0.0,0.0,0.13,zachary mo leffakis,
-MGT,3900,5,Ops Mgt,0.24,0.5,0.15,0.06,0.03,0.0,0.0,0.03,shouqiang wang,
-MGT,3900,6,Ops Mgt,0.24,0.43,0.24,0.05,0.03,0.0,0.0,0.0,yuhong he,
-MGT,4000,2,Mgt of Organizational Behavior,0.26,0.51,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MGT,4000,3,Mgt of Organizational Behavior,0.25,0.45,0.25,0.0,0.03,0.0,0.0,0.03,philip roth,
-MGT,4000,4,Mgt of Organizational Behavior,0.51,0.31,0.11,0.03,0.0,0.0,0.0,0.03,michael cole,
-MGT,4020,1,Ops Pln and Ctl,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4030,1,Intro to Business Analytics,0.33,0.46,0.13,0.04,0.0,0.0,0.0,0.04,siyuan li,
-MGT,4030,3,Advanced Business Analytics,0.13,0.53,0.33,0.0,0.0,0.0,0.0,0.0,heshan sun,
-MGT,4080,1,Lean Operations,0.21,0.29,0.46,0.0,0.04,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4110,1,Project Management,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,russell purvis,
-MGT,4110,2,Project Management,0.22,0.57,0.22,0.0,0.0,0.0,0.0,0.0,russell purvis,
-MGT,4120,1,Supplier Management,0.1,0.4,0.47,0.0,0.0,0.0,0.0,0.03,shouqiang wang,
-MGT,4150,1,Business Strategy,0.09,0.66,0.23,0.0,0.03,0.0,0.0,0.0,peter gianiodis,
-MGT,4150,2,Business Strategy,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
-MGT,4150,3,Business Strategy,0.73,0.23,0.0,0.03,0.0,0.0,0.0,0.03,john edward hopkins,
-MGT,4150,4,Business Strategy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,5,Business Strategy,0.27,0.56,0.16,0.02,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,6,Business Strategy,0.16,0.69,0.11,0.0,0.04,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,7,Business Strategy,0.17,0.59,0.24,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,
-MGT,4150,8,Business Strategy,0.2,0.7,0.11,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,
-MGT,4160,1,Special Topics Hr,0.31,0.64,0.06,0.0,0.0,0.0,0.0,0.0,kristin dam scott,
-MGT,4230,1,Intern Bus Mgt,0.09,0.22,0.61,0.04,0.04,0.0,0.0,0.0,wayne stewart,
-MGT,4230,2,Intern Bus Mgt,0.15,0.28,0.33,0.07,0.09,0.0,0.0,0.09,wayne stewart,
-MGT,4230,3,Intern Bus Mgt,0.36,0.48,0.17,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4230,4,Intern Bus Mgt,0.03,0.78,0.14,0.0,0.03,0.0,0.0,0.03,janis miller,
-MGT,4240,1,Global Supply Chain,0.14,0.41,0.36,0.05,0.05,0.0,0.0,0.0,yann ferrand,
-MGT,4270,1,Managing Improvement,0.4,0.43,0.13,0.0,0.0,0.0,0.0,0.03,james liddle,
-MGT,4300,1,Bus Application Development,0.56,0.13,0.19,0.0,0.0,0.0,0.0,0.13,jerry kermi bilbrey,
-MGT,4310,1,Emp Rights & Resp,0.38,0.48,0.13,0.0,0.0,0.0,0.0,0.03,leonard jos spooner,
-MGT,4350,1,Pers Interviewing,0.33,0.4,0.18,0.08,0.03,0.0,0.0,0.0,philip roth,
-MGT,4520,1,Business Analysis,0.18,0.55,0.18,0.06,0.03,0.0,0.0,0.0,roopa raman,
-MGT,4550,1,Emerging I T Trends,0.39,0.52,0.1,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MGT,4560,1,Business Info Mgt,0.27,0.53,0.07,0.0,0.0,0.0,0.0,0.13,siyuan li,
-MGT,8120,1,Supply Chain Mgt,0.29,0.55,0.16,0.0,0.0,0.0,0.0,0.0,yann ferrand,
-MICR,3050,1,General Microbiology,0.41,0.39,0.14,0.04,0.01,0.0,0.0,0.01,kristi ja whitehead,
-MICR,3050,2,General Microbiology,0.46,0.36,0.12,0.02,0.02,0.0,0.0,0.02,krista barr rudolph,
-MICR,3050,3,General Microbiology,0.55,0.37,0.05,0.03,0.0,0.0,0.0,0.0,krista barr rudolph,
-MICR,4000,1,Public Health Micro,0.37,0.38,0.17,0.05,0.02,0.0,0.0,0.02,kristi ja whitehead,
-MICR,4020,1,Environmental Micro,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,john michael henson,
-MICR,4070,1,Food and Dairy Micro,0.37,0.49,0.14,0.0,0.0,0.0,0.0,0.0,xiuping jiang,
-MICR,4110,1,Pathogenic Bact,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
-MICR,4120,1,Bacterial Physiology,0.26,0.29,0.16,0.13,0.16,0.0,0.0,0.0,thomas hughes,
-MICR,4130,1,Industrial Micro,0.32,0.58,0.04,0.02,0.02,0.0,0.0,0.02,tzuen-rong je tzeng,
-MICR,4140,1,Basic Immunology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,
-MICR,4170,1,Cancer and Aging,0.65,0.29,0.0,0.06,0.0,0.0,0.0,0.0,yuqing dong,
-MICR,4210,1,Path Bac Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
-MICR,4210,2,Path Bac Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
-MICR,4500,2,Advanced Microbiology I,0.5,0.45,0.0,0.0,0.05,0.0,0.0,0.0,harry kurtz,
-MICR,4500,3,Advanced Microbiology I,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MKT,3010,1,Prin of Marketing,0.15,0.49,0.27,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,
-MKT,3010,2,Prin of Marketing,0.21,0.47,0.23,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,
-MKT,3010,3,Prin of Marketing,0.21,0.37,0.25,0.1,0.04,0.0,0.0,0.03,amanda cooper fine,
-MKT,3010,4,Prin of Marketing,0.27,0.43,0.2,0.09,0.02,0.0,0.0,0.0,amanda cooper fine,
-MKT,3010,5,Prin of Marketing,0.36,0.4,0.19,0.03,0.01,0.0,0.0,0.02,james gaubert,
-MKT,3010,6,Prin of Marketing,0.42,0.38,0.17,0.03,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,3020,1,Consumer Behavior,0.45,0.38,0.09,0.05,0.02,0.0,0.0,0.02,jennifer di siemens,
-MKT,3020,2,Consumer Behavior,0.46,0.41,0.11,0.02,0.0,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,3,Consumer Behavior,0.26,0.49,0.18,0.05,0.02,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3020,4,Consumer Behavior,0.42,0.39,0.11,0.07,0.02,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3210,1,Sports Marketing,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3980,1,Sales Experiential,0.82,0.11,0.05,0.0,0.02,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4200,1,Professional Selling,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,2,Professional Selling,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,3,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4200,4,Professional Selling,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,gary hunter,
-MKT,4230,1,Promotional Strategy,0.21,0.52,0.17,0.05,0.02,0.0,0.0,0.02,patricia knowles,
-MKT,4240,1,Sales Management,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4260,1,Business-to-Business,0.38,0.58,0.02,0.0,0.02,0.0,0.0,0.0,james gaubert,
-MKT,4270,1,International Mktg,0.11,0.54,0.34,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
-MKT,4270,2,International Mktg,0.29,0.42,0.29,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
-MKT,4270,3,International Mktg,0.26,0.5,0.21,0.02,0.0,0.0,0.0,0.0,roger gomes,
-MKT,4270,4,International Mktg,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,roger gomes,
-MKT,4270,5,International Mktg,0.22,0.46,0.27,0.02,0.0,0.0,0.0,0.02,roger gomes,
-MKT,4280,1,Services Marketing,0.15,0.55,0.25,0.03,0.03,0.0,0.0,0.0,mary anne raymond,
-MKT,4280,2,Services Marketing,0.28,0.52,0.08,0.04,0.04,0.0,0.0,0.04,mary anne raymond,
-MKT,4310,1,Marketing Research,0.28,0.66,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,2,Marketing Research,0.37,0.56,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,3,Marketing Research,0.21,0.64,0.11,0.04,0.0,0.0,0.0,0.0,william kilbourne,
-MKT,4330,1,Sport Mkt Strategy,0.33,0.57,0.05,0.0,0.0,0.0,0.0,0.05,amanda cooper fine,
-MKT,4430,1,Advertising Strategy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,albert neil cameron,
-MKT,4450,1,Macromarketing,0.44,0.48,0.04,0.0,0.0,0.04,0.0,0.0,william kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,2,Strategic Mktg Mgt,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4500,3,Strategic Mktg Mgt,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,4500,4,Strategic Mktg Mgt,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4950,1,Selected Topics,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,peter weathers,
-MKT,8620,1,Quant Methods in Mkt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
-MKT,8650,1,Seminar in Mkt Mgmt,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MKT,8660,1,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-ML,1020,1,Leadership Fund II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert rozetar,
-ML,1020,2,Leadership Fund II,0.82,0.09,0.0,0.0,0.05,0.0,0.0,0.05,robert rozetar,
-ML,2020,2,Leadership Dev II,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,
-ML,3020,2,Adv Leadership II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,
-ML,4020,1,Org Leadership II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
-ML,4020,3,Org Leadership II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
-MSE,2100,1,Intro to Mat Science,0.4,0.27,0.19,0.06,0.06,0.0,0.0,0.03,marian kennedy,
-MSE,2100,2,Intro to Mat Science,0.5,0.24,0.13,0.04,0.01,0.0,0.0,0.08,eric skaar,
-MSE,2100,3,Intro to Mat Science,0.22,0.34,0.22,0.11,0.09,0.0,0.0,0.02,julie patric martin,
-MSE,2500,1,Polymer & Fiber Materials I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,
-MSE,2500,2,Polymer & Fiber Materials I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,
-MSE,3260,1,Thermo of Materials,0.19,0.32,0.27,0.15,0.03,0.0,0.0,0.03,gary lickfield,
-MSE,3280,1,Phase Diagrams,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,eric skaar,
-MSE,3610,1,Proc of Metals & Com,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,marian kennedy,
-MSE,4160,1,Electronic Materials,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
-MSE,4220,1,Mech Behavior of Mat,0.35,0.54,0.11,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
-MSE,4240,1,Optical Materials,0.23,0.38,0.38,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,4330,1,Comb Sys & Env Emiss,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,
-MSE,4560,1,Polymer & Fiber Materials II,0.27,0.46,0.27,0.0,0.0,0.0,0.0,0.0,gary lickfield,
-MSE,4590,1,Color Science Lab,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,philip brown,
-MSE,8280,1,Phase Transformation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,
-MUSC,1110,7,Beginning Class Guitar,0.8,0.1,0.0,0.1,0.0,0.0,0.0,0.0,david stevenson,
-MUSC,1110,9,Beginning Class Guitar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,david stevenson,
-MUSC,1420,1,Music Theory I,0.58,0.17,0.0,0.0,0.08,0.0,0.0,0.17,david conley,
-MUSC,1430,1,Aural Skills I,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,david conley,
-MUSC,1510,15,Applied Music - Piano,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,cindy roden goodloe,
-MUSC,1800,1,Intro to Music Tech,0.36,0.36,0.18,0.0,0.0,0.0,0.0,0.09,hamilton altstatt,
-MUSC,2100,1,Music in West World,0.72,0.22,0.03,0.0,0.03,0.0,0.0,0.0,eric lapin,
-MUSC,2100,2,Music in West World,0.56,0.25,0.06,0.03,0.0,0.0,0.0,0.09,lisa sain odom,
-MUSC,2100,3,Music in West World,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,2100,4,Music in West World,0.47,0.31,0.19,0.0,0.0,0.0,0.0,0.03,linda li-bleuel,
-MUSC,2100,5,Music in West World,0.61,0.26,0.06,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
-MUSC,2100,6,Music in West World,0.77,0.16,0.0,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
-MUSC,2100,7,Music in West World,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
-MUSC,2100,12,Music in West World,0.55,0.35,0.06,0.0,0.0,0.0,0.0,0.03,lea kibler,
-MUSC,2100,13,Music in West World,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,linda dzuris,
-MUSC,3110,1,History of American Music,0.5,0.34,0.09,0.03,0.0,0.0,0.0,0.03,ned hosler,
-MUSC,3120,1,History of Jazz,0.44,0.28,0.22,0.06,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,3170,1,Hist of Country Mus,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,ned hosler,
-MUSC,3310,1,Pep Band - Men,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,
-MUSC,3690,1,Symphony Orchestra,0.91,0.07,0.0,0.0,0.0,0.0,0.0,0.02,andrew levin,True
-MUSC,4160,1,Mus Hist Since 1750,0.35,0.09,0.3,0.0,0.17,0.0,0.0,0.09,linda li-bleuel,
-MUSC,4300,1,Conducting,0.3,0.3,0.2,0.0,0.2,0.0,0.0,0.0,justin durham,
-NPL,3010,2,NPL Stakeholders,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,tracy diane lamb,
-NURS,3030,1,Nursing of Adults,0.35,0.57,0.06,0.02,0.0,0.0,0.0,0.0,leslie anne  ravan,
-NURS,3030,400,Nursing of Adults,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,wanda leigh taylor,
-NURS,3040,1,Pathophysiology,0.33,0.58,0.03,0.06,0.0,0.0,0.0,0.0,catherine si murton,
-NURS,3040,401,Pathophysiology for RN,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
-NURS,3100,1,Health Assessment,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3120,1,Foundations of Nurs,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,angela pye,
-NURS,3190,400,Health Assessment for RNs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,
-NURS,3200,1,Prof in Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-NURS,3400,1,Pharmther Nursing,0.37,0.59,0.02,0.02,0.0,0.0,0.0,0.0,catherine si murton,
-NURS,4010,1,Mental Health Nurs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NURS,4030,1,Complex Nursing of Adults,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
-NURS,4110,1,Nursing of Children,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,heide temples,
-NURS,4120,1,Nurs Women and Fam,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4250,400,Community Nursing,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
-NURS,8080,400,Nurs Res Stat Analys,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,8190,400,Developing Family,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,
-NURS,8200,400,Child & Adol Nursing,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,heide temples,
-NURS,8210,400,Adult Nursing,0.69,0.29,0.03,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8850,400,Mental Health in Primary Care,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.44,0.39,0.12,0.01,0.0,0.0,0.0,0.03,deborah an hutcheon,
-NUTR,2040,1,Nutrition Across Life Cycle,0.4,0.42,0.11,0.07,0.0,0.0,0.0,0.0,deborah an hutcheon,
-NUTR,4250,1,Medica Nutr Thera II,0.55,0.39,0.04,0.0,0.02,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4260,1,Community Nutrition,0.49,0.45,0.06,0.0,0.0,0.0,0.0,0.0,rita haliena,
-NUTR,4550,1,Nutr Metabolism,0.36,0.38,0.12,0.08,0.0,0.0,0.0,0.06,elliot jesch,
-PA,2800,1,Perf Arts Pract II,0.35,0.29,0.06,0.0,0.12,0.0,0.0,0.18,kenneth moore,
-PA,4010,1,Capstone Project,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,anthony penna,
-PADM,8220,400,Public Policy Process,0.77,0.08,0.0,0.0,0.08,0.0,0.0,0.08,mark daniel mellott,
-PADM,8410,400,Public Data Analysis,0.17,0.75,0.0,0.0,0.08,0.0,0.0,0.0,ronald chrestman,
-PADM,8410,401,Public Data Analysis,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,ronald chrestman,
-PADM,8500,400,Homeland Security Fundamentals,0.44,0.22,0.0,0.0,0.11,0.0,0.0,0.22,david leigh cook,
-PADM,8650,400,Leadership in the Nonprft Sect,0.67,0.0,0.0,0.0,0.11,0.0,0.0,0.22,renee salic nichols,
-PES,2020,1,Soils,0.27,0.35,0.27,0.06,0.04,0.0,0.0,0.0,dara michelle park,
-PES,4330,1,Landscape & Turf Weed Mgt,0.14,0.64,0.14,0.0,0.0,0.0,0.0,0.07,ted whitwell,
-PES,4520,1,Soil Fertility and Management,0.29,0.57,0.0,0.0,0.07,0.0,0.0,0.07,haibo liu,
-PES,6520,1,Soil Fertility and Management,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,haibo liu,
-PHIL,1010,1,Intro to Phil Prob,0.5,0.26,0.15,0.0,0.03,0.0,0.0,0.06,christopher grau,
-PHIL,1010,2,Intro to Phil Prob,0.57,0.23,0.11,0.0,0.06,0.0,0.0,0.03,david stegall,
-PHIL,1010,3,Intro to Phil Prob,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.03,david stegall,
-PHIL,1020,1,Intro to Logic,0.58,0.17,0.06,0.17,0.0,0.0,0.0,0.03,michael hal hannen,
-PHIL,1020,2,Intro to Logic,0.83,0.09,0.0,0.09,0.0,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,3,Intro to Logic,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.03,gregory scott moss,
-PHIL,1020,4,Intro to Logic,0.63,0.29,0.06,0.03,0.0,0.0,0.0,0.0,gregory scott moss,
-PHIL,1020,5,Intro to Logic,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,gregory scott moss,
-PHIL,1020,6,Intro to Logic,0.57,0.37,0.03,0.03,0.0,0.0,0.0,0.0,kelly smith,
-PHIL,1030,1,Intro to Ethics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True
-PHIL,1030,2,Intro to Ethics,0.59,0.35,0.0,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
-PHIL,1030,3,Intro to Ethics,0.65,0.29,0.03,0.0,0.0,0.0,0.0,0.03,ryan lake,
-PHIL,1030,4,Intro to Ethics,0.46,0.4,0.09,0.0,0.03,0.0,0.0,0.03,ryan lake,
-PHIL,1030,5,Intro to Ethics,0.35,0.56,0.06,0.0,0.0,0.0,0.0,0.03,ryan lake,
-PHIL,1030,6,Intro to Ethics,0.44,0.35,0.15,0.0,0.03,0.0,0.0,0.03,stephen satris,
-PHIL,3030,1,Phil of Religion,0.34,0.57,0.03,0.0,0.0,0.0,0.0,0.06,gregory scott moss,
-PHIL,3140,1,Comp East West Phil,0.32,0.26,0.26,0.0,0.05,0.0,0.0,0.11,yanming an,
-PHIL,3150,1,Ancient Philosophy,0.28,0.31,0.21,0.03,0.03,0.0,0.0,0.14,jennifer ingle,
-PHIL,3160,1,Mod Phil,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,michael hal hannen,
-PHIL,3260,1,Science and Values,0.4,0.49,0.0,0.0,0.06,0.0,0.0,0.06,andrew garnar,
-PHIL,3260,2,Science and Values,0.4,0.51,0.03,0.03,0.0,0.0,0.0,0.03,andrew garnar,
-PHIL,3260,3,Science and Values,0.46,0.43,0.09,0.0,0.0,0.0,0.0,0.03,andrew garnar,
-PHIL,3330,1,Metaphysics,0.91,0.04,0.0,0.0,0.04,0.0,0.0,0.0,david stegall,
-PHIL,3430,1,Phil of Law,0.82,0.12,0.0,0.0,0.03,0.0,0.0,0.03,david stegall,
-PHIL,3440,1,Business Ethics,0.13,0.56,0.18,0.03,0.0,0.0,0.0,0.1,diane perpich,
-PHIL,3450,1,Environmental Ethics,0.39,0.5,0.08,0.0,0.03,0.0,0.0,0.0,jennifer ingle,
-PHIL,3510,1,Phil of Emotion,0.21,0.39,0.21,0.04,0.04,0.0,0.0,0.11,charles starkey,
-PHIL,3550,1,Phil Mind & Cog Sci,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,ryan lake,
-PHSC,1170,1,Intro Chem & Earth,0.82,0.17,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics With Cal I,0.16,0.38,0.24,0.08,0.1,0.0,0.0,0.04,lih-sin the,
-PHYS,1220,2,Physics With Cal I,0.24,0.4,0.24,0.05,0.02,0.0,0.0,0.03,lih-sin the,
-PHYS,1220,3,Physics With Cal I,0.28,0.41,0.21,0.05,0.02,0.0,0.0,0.03,lih-sin the,
-PHYS,1220,4,Physics With Cal I,0.34,0.35,0.18,0.05,0.03,0.0,0.0,0.05,ramakrishna podila,
-PHYS,1220,5,Physics With Cal I,0.21,0.42,0.27,0.05,0.03,0.0,0.0,0.02,mark leising,
-PHYS,1220,8,Physics With Cal I (HON),0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,joan marler,True
-PHYS,1240,1,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,2,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,3,Physics Lab I,0.18,0.71,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
-PHYS,1240,4,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,5,Physics Lab I,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,6,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,7,Physics Lab I,0.4,0.53,0.0,0.07,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,8,Physics Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,
-PHYS,1240,9,Physics Lab I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,10,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,11,Physics Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,12,Physics Lab I,0.17,0.72,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,13,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,14,Physics Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,15,Physics Lab I,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,16,Physics Lab I,0.06,0.89,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,17,Physics Lab I,0.22,0.67,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,18,Physics Lab I,0.17,0.61,0.11,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,19,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,20,Physics Lab I,0.33,0.44,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,21,Physics Lab I,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,22,Physics Lab I,0.44,0.31,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,
-PHYS,1240,23,Physics Lab I,0.41,0.47,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,
-PHYS,1240,24,Physics Lab I,0.28,0.61,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,25,Physics Lab I,0.31,0.44,0.19,0.0,0.06,0.0,0.0,0.0,jerry hester,
-PHYS,1240,26,Physics Lab I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,27,Physics Lab I,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,28,Physics Lab I,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jerry hester,
-PHYS,1240,29,Physics Lab I,0.12,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2000,1,Introductory Physics,0.46,0.39,0.07,0.07,0.0,0.0,0.0,0.02,sean brittain,
-PHYS,2070,1,General Physics I,0.36,0.36,0.15,0.08,0.03,0.0,0.0,0.03,pooja puneet,
-PHYS,2080,1,General Physics II,0.46,0.35,0.11,0.03,0.02,0.0,0.0,0.02,amy liann pope,
-PHYS,2080,2,General Physics II,0.64,0.29,0.04,0.01,0.0,0.0,0.0,0.01,amy liann pope,
-PHYS,2090,1,Gen Phys Lab I,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,2,Gen Phys Lab I,0.36,0.5,0.05,0.0,0.05,0.0,0.0,0.05,jerry hester,
-PHYS,2090,3,Gen Phys Lab I,0.7,0.13,0.09,0.0,0.04,0.0,0.0,0.04,jerry hester,
-PHYS,2090,4,Gen Phys Lab I,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,5,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,
-PHYS,2090,6,Gen Phys Lab I,0.17,0.75,0.0,0.0,0.04,0.0,0.0,0.04,jerry hester,
-PHYS,2090,7,Gen Phys Lab I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,8,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,9,Gen Phys Lab I,0.5,0.29,0.13,0.08,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,10,Gen Phys Lab I,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,1,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,2,Gen Phys Lab II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,3,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,4,Gen Phys Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,5,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,6,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,7,Gen Phys Lab II,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,8,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,9,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,10,Gen Phys Lab II,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,11,Gen Phys Lab II,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,12,Gen Phys Lab II,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,13,Gen Phys Lab II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,14,Gen Phys Lab II,0.14,0.55,0.14,0.0,0.05,0.0,0.0,0.14,jerry hester,
-PHYS,2100,15,Gen Phys Lab II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,16,Gen Phys Lab II,0.1,0.5,0.3,0.05,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2100,17,Gen Phys Lab II,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,
-PHYS,2210,1,Physics With Cal II,0.32,0.34,0.21,0.06,0.03,0.0,0.0,0.03,jason stratfo brown,
-PHYS,2210,2,Physics With Cal II,0.22,0.38,0.2,0.08,0.08,0.0,0.0,0.03,jason stratfo brown,
-PHYS,2210,3,Physics With Cal II,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,murray daw,
-PHYS,2220,1,Phys With Cal III,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,jian he,
-PHYS,2230,1,Physics Lab II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,2,Physics Lab II,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,3,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,4,Physics Lab II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,5,Physics Lab II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,6,Physics Lab II,0.36,0.5,0.0,0.0,0.07,0.0,0.0,0.07,jerry hester,
-PHYS,2230,7,Physics Lab II,0.25,0.63,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,8,Physics Lab II,0.18,0.71,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,9,Physics Lab II,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2240,1,Physics Lab III,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2400,1,Phys of Weather,0.3,0.3,0.18,0.05,0.05,0.0,0.0,0.13,miguel larsen,
-PHYS,3110,1,Methods Theor Phys,0.64,0.09,0.0,0.18,0.09,0.0,0.0,0.0,hye jung kang,
-PHYS,3260,1,Exper Physics II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,chad sosolik,
-PHYS,3560,1,Modern Physics,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,chad sosolik,
-PHYS,4560,1,Quantum Physics II,0.0,0.5,0.5,0.0,0.0,0.0,0.0,0.0,antony valentini,
-PHYS,4650,1,Thermo and Stat Mech,0.21,0.36,0.14,0.21,0.0,0.0,0.0,0.07,jens oberheide,
-PHYS,8150,1,Statistical Therm I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
-PHYS,8410,1,Electrodynamics I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-PHYS,9520,1,Quantum Mech II,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
-PKSC,1020,1,Intro to Pkg Sci,0.14,0.39,0.31,0.07,0.06,0.0,0.0,0.03,heather batt,
-PKSC,2010,1,Pkg Perishable Prod,0.15,0.42,0.23,0.12,0.07,0.0,0.0,0.01,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.81,0.03,0.1,0.0,0.06,0.0,0.0,0.0,robert truett moore,
-PKSC,2040,1,Container Systems,0.74,0.19,0.07,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2060,1,Container Sys Lab,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2060,2,Container Sys Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2060,3,Container Sys Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2200,1,Product & Pkg Design,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,william aaro snyder,
-PKSC,3200,1,Pkg Design Theory,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,rupert hurley,
-PKSC,3680,1,Pkg and Society,0.41,0.38,0.15,0.03,0.03,0.0,0.0,0.0,heather batt,
-PKSC,4030,1,Pkg Career Prep,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4200,1,Pkg Design & Dev,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4300,1,Converting Flex Pkg,0.32,0.53,0.12,0.02,0.0,0.0,0.0,0.02,duncan darby,
-PKSC,4400,1,Packaging for Distribution,0.31,0.46,0.19,0.04,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1,Fd & Hc Pkg Systems,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,kay cooksey,
-PKSC,8510,1,Pkg Sci Seminar,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,anthony lou pometto,
-PLPA,2130,1,Fungi & Civilization,0.45,0.3,0.18,0.01,0.01,0.0,0.0,0.05,julia loui kerrigan,
-PLPA,8090,1,Analytical Technique,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,tharayil-santhakumar,
-POSC,1010,1,Amer National Govt,0.23,0.49,0.1,0.03,0.05,0.0,0.0,0.1,joseph earl stewart,
-POSC,1010,2,Amer National Govt,0.08,0.28,0.31,0.15,0.13,0.0,0.0,0.05,adam warber,
-POSC,1020,1,Intro Intl Relations,0.08,0.47,0.38,0.06,0.0,0.0,0.0,0.0,aron geo tannenbaum,
-POSC,1020,2,Intro Intl Relations,0.14,0.39,0.31,0.06,0.06,0.0,0.0,0.04,zeynep taydas,
-POSC,1020,3,Intro Intl Relations,0.25,0.48,0.19,0.01,0.04,0.0,0.0,0.03,lydia loui lundgren,
-POSC,1030,1,Intro to Political Theory,0.27,0.3,0.27,0.08,0.05,0.0,0.0,0.03,brandon turner,
-POSC,1040,1,Intro Compar Pol,0.11,0.45,0.23,0.14,0.0,0.0,0.0,0.07,colin pearce,
-POSC,1040,2,Intro Compar Pol,0.29,0.5,0.1,0.02,0.02,0.0,0.0,0.06,katherine am curtis,
-POSC,1990,1,Intro Pol Sci,0.42,0.21,0.25,0.06,0.04,0.0,0.0,0.02,meredith petersheim,
-POSC,3020,1,State and Loc Gov,0.1,0.51,0.27,0.02,0.05,0.0,0.0,0.05,bruce ransom,
-POSC,3210,1,Public Admin,0.1,0.38,0.43,0.02,0.07,0.0,0.0,0.0,james woodard,
-POSC,3610,1,Intl Pol in Crisis,0.47,0.37,0.1,0.0,0.03,0.0,0.0,0.03,vladimir matic,
-POSC,3610,2,Intl Pol in Crisis,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,jeremy fortier,
-POSC,3630,1,Us Foreign Policy,0.26,0.35,0.24,0.03,0.12,0.0,0.0,0.0,steven vince miller,
-POSC,3710,1,European Politics,0.29,0.5,0.19,0.02,0.0,0.0,0.0,0.0,katherine am curtis,
-POSC,3750,1,European Integration,0.08,0.23,0.46,0.0,0.08,0.0,0.0,0.15,zeynep taydas,
-POSC,3890,1,Rel. Liberty & Constitution,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,
-POSC,4030,1,United States Congress,0.32,0.52,0.08,0.0,0.04,0.0,0.0,0.04,jeffrey scott peake,
-POSC,4050,1,American Presidency,0.05,0.23,0.32,0.09,0.18,0.0,0.0,0.14,adam warber,
-POSC,4360,1,Law Courts Politics,0.79,0.08,0.04,0.0,0.04,0.0,0.0,0.04,joseph earl stewart,
-POSC,4370,1,Constitut Law: Rights & Libert,0.48,0.42,0.0,0.0,0.03,0.0,0.0,0.06,daniel frost,
-POSC,4490,1,Political Theory of Capitalism,0.23,0.3,0.23,0.07,0.07,0.0,0.0,0.1,brandon turner,
-POSC,4530,1,American Political Thought,0.22,0.56,0.17,0.03,0.03,0.0,0.0,0.0, bradley thompson,
-POSC,4540,1,Southern Politics,0.07,0.47,0.4,0.0,0.07,0.0,0.0,0.0,james woodard,
-POSC,4570,1,Political Terrorism,0.37,0.44,0.15,0.02,0.0,0.0,0.0,0.02,aron geo tannenbaum,
-POSC,4760,1,Middle East Politics,0.36,0.45,0.05,0.05,0.05,0.0,0.0,0.05,vladimir matic,
-POSC,4820,1,Political Novel and Film,0.13,0.39,0.39,0.04,0.0,0.0,0.0,0.04,james woodard,
-PRTM,2000,7,Prof & Prac in PRTM,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,brandon harris,
-PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,
-PRTM,2200,2,Foundations of PRTM,0.28,0.55,0.14,0.0,0.0,0.0,0.0,0.03,teresa walto tucker,
-PRTM,2200,3,Foundations of PRTM,0.47,0.37,0.07,0.07,0.0,0.0,0.0,0.03,gwynn powell,
-PRTM,2200,4,Foundations of PRTM,0.41,0.38,0.17,0.03,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2200,5,Foundations of PRTM,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,cindy hartman,
-PRTM,2200,6,Foundations of PRTM,0.72,0.12,0.12,0.04,0.0,0.0,0.0,0.0,katherine an jordan,
-PRTM,2200,7,Foundations of PRTM,0.62,0.28,0.03,0.07,0.0,0.0,0.0,0.0,brandon harris,
-PRTM,2410,1,Intro to CRSCM,0.25,0.52,0.2,0.03,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2600,1,Found of Recreational Therapy,0.87,0.07,0.02,0.0,0.04,0.0,0.0,0.0,anna-mar chancellor,
-PRTM,2650,1,Terminology in RT Practice,0.73,0.13,0.07,0.02,0.05,0.0,0.0,0.0,stephen thoma lewis,
-PRTM,2700,1,Intro Rec Res Mgt,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,lincoln larson,
-PRTM,2810,1,Intro to Golf Mgt,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,2820,1,Principle Golfer Dev,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,2830,1,Adv Mth Golf Teachng,0.5,0.25,0.08,0.17,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,2980,4,Creative Inquiry in PRTM II,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2980,7,Creative Inquiry in PRTM II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2980,8,Creative Inquiry in PRTM II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.4,0.31,0.17,0.06,0.06,0.0,0.0,0.0,daniel mor anderson,
-PRTM,3070,1,Facility Operations,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,craig goodman,
-PRTM,3250,1,Global Persp in Rec,0.08,0.7,0.15,0.03,0.03,0.0,0.0,0.03,teresa walto tucker,
-PRTM,3270,1,RT Impl & Eval: Ment Hlth Cond,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3420,1,Intro to Tourism,0.55,0.31,0.1,0.0,0.02,0.0,0.0,0.02,william norman,
-PRTM,3420,2,Intro to Tourism,0.56,0.31,0.03,0.0,0.03,0.0,0.0,0.06,maloud shakona,
-PRTM,3440,1,Tourism Markets,0.45,0.23,0.23,0.05,0.0,0.0,0.0,0.05,sheila backman,
-PRTM,3440,2,Tourism Markets,0.55,0.29,0.14,0.0,0.0,0.0,0.0,0.02,sheila backman,
-PRTM,3450,1,Tourism Management,0.81,0.1,0.06,0.0,0.0,0.0,0.0,0.03,lauren duffy,
-PRTM,3460,1,Heritage Tourism,0.47,0.38,0.09,0.02,0.0,0.0,0.0,0.04,gregory phi ramshaw,
-PRTM,3470,1,Sport Tourism,0.33,0.36,0.21,0.03,0.03,0.0,0.0,0.03,gregory phi ramshaw,
-PRTM,3530,1,Foundations of Camp Counseling,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,gwynn powell,
-PRTM,3550,1,Trends & Issues in Camp Mgt,0.64,0.14,0.14,0.0,0.0,0.0,0.0,0.07,teresa walto tucker,
-PRTM,3830,1,Golf Shop Operations,0.54,0.23,0.15,0.08,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,3910,2,Intro to GIS for PRTM,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,david lawrenc white,
-PRTM,4210,1,Rec Fin Resc Mgt,0.35,0.32,0.16,0.06,0.03,0.0,0.0,0.06,daniel mor anderson,
-PRTM,4260,1,Trends & Issues in Rec Therapy,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,4300,1,World Geog Parks,0.23,0.6,0.17,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
-PRTM,4310,1,Methods Envir Inter,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,4450,1,Conventions,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,jeffery martin,
-PRTM,4460,2,Community Tourism,0.19,0.63,0.15,0.0,0.0,0.0,0.0,0.04,herbert chancellor,
-PRTM,4470,1,Perspect Intl Travel,0.61,0.23,0.13,0.0,0.0,0.0,0.0,0.03,lauren duffy,
-PRTM,4510,1,Seminar in CRSCM,0.26,0.56,0.15,0.0,0.03,0.0,0.0,0.0,cindy hartman,
-PRTM,4540,1,Trends in Sport Mgt,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,
-PRTM,4550,1,Adv Program Planning,0.58,0.25,0.0,0.17,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,4980,2,Creative Inquiry in PRTM IV,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
-PRTM,4980,3,Creative Inquiry in PRTM IV,0.8,0.0,0.0,0.0,0.2,0.0,0.0,0.0,kellie aman walters,
-PRTM,4980,6,Creative Inquiry in PRTM IV,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,4980,8,Creative Inquiry in PRTM IV,0.5,0.1,0.4,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
-PRTM,8030,1,Sem Rec & Park Admin,0.63,0.21,0.0,0.0,0.13,0.0,0.0,0.04,skye arthur-banning,
-PRTM,8110,2,Research Methods,0.81,0.12,0.0,0.0,0.04,0.0,0.0,0.04,jeffrey charl hallo,
-PRTM,8210,1,Alt Funding for PRTM,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,8250,1,Populations in PRTM,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
-PRTM,8400,2,Tourism Planning,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,william norman,
-PSYC,2010,1,Intro to Psychology,0.31,0.31,0.2,0.08,0.05,0.0,0.0,0.06,jo anne jorgensen,
-PSYC,2010,2,Intro to Psychology,0.28,0.38,0.23,0.05,0.04,0.0,0.0,0.02,edwin brainerd,
-PSYC,2010,3,Intro to Psychology,0.39,0.24,0.23,0.06,0.04,0.0,0.0,0.04,mary taylor,
-PSYC,2010,4,Intro to Psychology,0.41,0.35,0.13,0.03,0.04,0.0,0.0,0.04,mary taylor,
-PSYC,2010,5,Intro to Psychology,0.3,0.44,0.1,0.06,0.06,0.0,0.0,0.04,fred switzer,
-PSYC,2010,20,Intro to Psychology (HON),0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,robin mari kowalski,True
-PSYC,2020,1,Intro Psychology Lab,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,eric mckibben,
-PSYC,2020,3,Intro Psychology Lab,0.84,0.12,0.0,0.0,0.04,0.0,0.0,0.0,eric mckibben,
-PSYC,2020,4,Intro Psychology Lab,0.86,0.0,0.1,0.0,0.05,0.0,0.0,0.0,eric mckibben,
-PSYC,2020,6,Intro Psychology Lab,0.82,0.05,0.0,0.0,0.09,0.0,0.0,0.05,lauren elizab ellis,
-PSYC,3060,1,Human Sexual Beh,0.62,0.19,0.11,0.04,0.03,0.0,0.0,0.01,bruce michael king,
-PSYC,3090,100,Intro Exp Psych,0.27,0.34,0.22,0.05,0.07,0.0,0.0,0.05,richard tyrrell,
-PSYC,3090,200,Intro Exp Psych,0.41,0.31,0.17,0.03,0.07,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3090,300,Intro Exp Psych,0.77,0.13,0.07,0.0,0.0,0.0,0.0,0.03,allison lei wallace,
-PSYC,3100,100,Advanced Experimental Psych,0.45,0.35,0.05,0.0,0.05,0.0,0.0,0.1,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3100,300,Advanced Experimental Psych,0.5,0.22,0.11,0.11,0.06,0.0,0.0,0.0,thomas britt,
-PSYC,3100,400,Advanced Experimental Psych,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,robert campbell,
-PSYC,3100,500,Advanced Experimental Psych,0.53,0.32,0.05,0.05,0.05,0.0,0.0,0.0,benjamin stephens,
-PSYC,3100,600,Advanced Experimental Psych,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3240,1,Physiological Psych,0.3,0.31,0.25,0.08,0.01,0.0,0.0,0.04,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.35,0.4,0.11,0.09,0.02,0.0,0.0,0.03,june pilcher,
-PSYC,3330,1,Cognitive Psych,0.77,0.14,0.05,0.04,0.0,0.0,0.0,0.0,paul steven merritt,
-PSYC,3330,2,Cognitive Psych,0.71,0.2,0.04,0.01,0.03,0.0,0.0,0.01,paul steven merritt,
-PSYC,3340,1,Cognitive Psych Lab,0.6,0.25,0.1,0.0,0.0,0.0,0.0,0.05,phillip weis jasper,
-PSYC,3340,2,Cognitive Psych Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,brian day,
-PSYC,3340,3,Cognitive Psych Lab,0.63,0.21,0.0,0.05,0.05,0.0,0.0,0.05,ashley ann sewall,
-PSYC,3400,1,Lifespan Developmental Psych,0.27,0.41,0.2,0.06,0.03,0.0,0.0,0.03,pamela alley,
-PSYC,3520,1,Social Psychology,0.38,0.35,0.13,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,
-PSYC,3520,2,Social Psychology,0.39,0.3,0.19,0.06,0.03,0.0,0.0,0.04,jo anne jorgensen,
-PSYC,3640,1,Industrial Psych,0.49,0.44,0.03,0.0,0.0,0.0,0.0,0.04,fred switzer,
-PSYC,3680,1,Organizational Psych,0.41,0.41,0.16,0.01,0.0,0.0,0.0,0.01,eric mckibben,
-PSYC,3680,2,Organizational Psych,0.46,0.39,0.14,0.0,0.01,0.0,0.0,0.0,eric mckibben,
-PSYC,3690,1,Leadership in Orgs,0.27,0.27,0.21,0.15,0.02,0.0,0.0,0.08,patrick raymark,
-PSYC,3700,1,Personality,0.49,0.24,0.13,0.1,0.03,0.0,0.0,0.01,william kramer,
-PSYC,3830,1,Abnormal Psychology,0.16,0.42,0.28,0.08,0.02,0.0,0.0,0.04,cynthia pury,
-PSYC,3830,2,Abnormal Psychology,0.14,0.43,0.2,0.06,0.14,0.0,0.0,0.03,pamela alley,
-PSYC,3830,3,Abnormal Psychology,0.31,0.4,0.11,0.09,0.09,0.0,0.0,0.0,pamela alley,
-PSYC,4080,1,Women and Psychology,0.64,0.2,0.08,0.0,0.0,0.0,0.0,0.08,robin mari kowalski,
-PSYC,4150,1,Systems and Theories,0.35,0.3,0.18,0.0,0.13,0.0,0.0,0.05,edwin brainerd,
-PSYC,4150,2,Systems and Theories,0.27,0.24,0.24,0.03,0.09,0.0,0.0,0.12,edwin brainerd,
-PSYC,4220,1,Perception,0.28,0.38,0.21,0.07,0.0,0.0,0.0,0.07,claudio cantalupo,
-PSYC,4220,2,Perception,0.25,0.21,0.36,0.18,0.0,0.0,0.0,0.0,christopher pagano,
-PSYC,4220,3,Perception,0.4,0.12,0.24,0.12,0.04,0.0,0.0,0.08,claudio cantalupo,
-PSYC,4430,1,Infant & Child Dev,0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,4430,2,Infant & Child Dev,0.33,0.37,0.19,0.07,0.04,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,4470,1,Moral Development,0.33,0.58,0.0,0.0,0.08,0.0,0.0,0.0,robert campbell,
-PSYC,4560,1,Psychophysiology,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,james nathan salley,
-PSYC,4800,1,Health Psychology,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,
-PSYC,4880,1,Psychotherapy,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,lucinda sorci quick,
-PSYC,4890,1,Science of Sleep,0.39,0.57,0.0,0.0,0.04,0.0,0.0,0.0,june pilcher,
-PSYC,4920,4,Senior Laboratory,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brooke bake allison,
-PSYC,4920,5,Senior Laboratory,0.68,0.14,0.0,0.05,0.09,0.0,0.0,0.05,jessica anne stahl,
-PSYC,4930,100,Pract Clinical Psych,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,heidi marie zinzow,
-PSYC,8110,1,Research Design II,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,patrick rosopa,
-PSYC,8130,1,Research Design III,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, dewayne moore,
-PSYC,8140,1,Quantitative Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06, dewayne moore,
-PSYC,8370,1,Ergonomics Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,
-PSYC,8820,1,Occupat Health Psy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,
-RED,8010,1,Market Analysis,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,john terrenc farris,
-RED,8120,1,Real Estate Technology,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,robert cre benedict,
-RED,8130,1,Strat in Real Estate,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,
-REL,1010,1,Intro to Religion,0.86,0.06,0.03,0.0,0.0,0.0,0.0,0.06,robert stephens,
-REL,1010,2,Intro to Religion,0.82,0.06,0.06,0.0,0.0,0.0,0.0,0.06,robert stephens,
-REL,1010,3,Intro to Religion,0.74,0.06,0.06,0.0,0.03,0.03,0.0,0.09,robert stephens,
-REL,1020,1,World Religions,0.2,0.37,0.29,0.09,0.0,0.0,0.0,0.06,peter cohen,
-REL,1020,2,World Religions,0.25,0.28,0.19,0.14,0.08,0.0,0.0,0.06,peter cohen,
-REL,1020,4,World Religions,0.24,0.48,0.09,0.06,0.09,0.0,0.0,0.03,peter cohen,
-REL,3000,1,Studying Religion,0.17,0.33,0.29,0.08,0.04,0.0,0.0,0.08,benjamin white,
-REL,3010,1,Old Testament,0.56,0.31,0.08,0.06,0.0,0.0,0.0,0.0,steven grosby,
-REL,3020,1,New Testament Lit,0.34,0.44,0.16,0.03,0.0,0.0,0.0,0.03,benjamin white,
-REL,3030,1,The Quran,0.29,0.57,0.05,0.0,0.1,0.0,0.0,0.0,mashal saif,
-REL,3060,1,Judaism,0.58,0.32,0.0,0.0,0.03,0.0,0.0,0.06,steven grosby,
-REL,3130,1,Buddhism,0.86,0.06,0.06,0.03,0.0,0.0,0.0,0.0,robert stephens,
-REL,3150,1,Islam,0.14,0.48,0.14,0.0,0.1,0.0,0.0,0.14,mashal saif,
-RS,3010,1,Rural Sociology,0.3,0.56,0.12,0.0,0.0,0.0,0.0,0.02,kenneth robinson,
-RS,4590,1,The Community,0.4,0.4,0.1,0.0,0.1,0.0,0.0,0.0,kenneth robinson,
-RUSS,1020,1,Elementary Russian,0.3,0.6,0.0,0.0,0.0,0.0,0.0,0.1,joan bridgwood,
-RUSS,3400,1,19th C Russ Culture,0.44,0.38,0.0,0.06,0.0,0.0,0.0,0.13,joan bridgwood,
-SOC,2010,2,Introduction to Sociology,0.42,0.33,0.23,0.0,0.0,0.0,0.0,0.02,mary louise barr,
-SOC,2010,3,Introduction to Sociology,0.45,0.39,0.16,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,4,Introduction to Sociology,0.43,0.26,0.26,0.0,0.0,0.0,0.0,0.04,mary louise barr,
-SOC,2010,5,Introduction to Sociology,0.37,0.38,0.25,0.0,0.0,0.0,0.0,0.0,mary louise barr,
-SOC,2010,6,Introduction to Sociology,0.3,0.37,0.3,0.0,0.02,0.0,0.0,0.0,mary louise barr,
-SOC,2010,7,Introduction to Sociology,0.51,0.35,0.12,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,8,Introduction to Sociology,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
-SOC,2010,9,Introduction to Sociology,0.66,0.27,0.05,0.0,0.0,0.0,0.0,0.01,jeffrey edwards,
-SOC,2020,1,Social Problems,0.61,0.22,0.0,0.11,0.0,0.0,0.0,0.06,stephani southworth,
-SOC,2020,2,Social Problems,0.36,0.4,0.13,0.04,0.04,0.0,0.0,0.02,stephani southworth,
-SOC,2050,1,Sociology Lab,0.52,0.14,0.05,0.1,0.1,0.0,0.0,0.1,brenda vander mey,
-SOC,3020,1,Research Methods I,0.28,0.2,0.36,0.08,0.08,0.0,0.0,0.0,andrew whitehead,
-SOC,3040,1,Social Research Methods II,0.14,0.52,0.28,0.0,0.03,0.0,0.0,0.03,ye luo,
-SOC,3100,1,Marriage & Intimacy,0.7,0.28,0.02,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
-SOC,3310,1,Urban Sociology,0.34,0.32,0.17,0.06,0.09,0.0,0.0,0.02,stephani southworth,
-SOC,3500,1,Self & Society,0.23,0.45,0.28,0.04,0.0,0.0,0.0,0.0,ellen granberg,
-SOC,3600,1,Class & Poverty,0.57,0.3,0.04,0.09,0.0,0.0,0.0,0.0,william haller,
-SOC,3800,1,Intro Social Service,0.43,0.43,0.11,0.02,0.0,0.0,0.0,0.02,jennifer le holland,
-SOC,3880,1,Criminal Justice,0.12,0.33,0.33,0.12,0.08,0.0,0.0,0.02,margaret tina britz,
-SOC,3890,1,Criminology,0.14,0.31,0.19,0.12,0.1,0.0,0.0,0.14,william white,
-SOC,3910,1,Soc of Deviance,0.3,0.35,0.26,0.05,0.02,0.0,0.0,0.02,stephani southworth,
-SOC,3920,1,Juvenile Delinquency,0.14,0.27,0.16,0.23,0.16,0.0,0.0,0.05,william white,
-SOC,3970,1,Substance Abuse,0.66,0.28,0.03,0.0,0.0,0.0,0.0,0.03,jeffrey edwards,
-SOC,4030,1,"Technol, Environment & Society",0.27,0.32,0.27,0.05,0.0,0.0,0.0,0.09, catherine mobley,
-SOC,4040,1,Soc Theory,0.49,0.29,0.11,0.09,0.03,0.0,0.0,0.0,william wentworth,
-SOC,4320,1,Soc of Religion,0.32,0.28,0.12,0.12,0.12,0.0,0.0,0.04,andrew whitehead,
-SOC,4440,1,Sociology of Educ,0.24,0.35,0.18,0.18,0.06,0.0,0.0,0.0,stephani southworth,
-SOC,4590,1,The Community,0.44,0.44,0.0,0.13,0.0,0.0,0.0,0.0,kenneth robinson,
-SOC,4600,1,Race & Ethnicity,0.38,0.21,0.24,0.1,0.03,0.0,0.0,0.03,brenda vander mey,
-SOC,4610,1,Sex & Gender,0.24,0.24,0.27,0.19,0.0,0.0,0.0,0.05,sarah evely winslow,
-SOC,4800,1,Medical Sociology,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,william wentworth,
-SOC,4840,1,Child Abuse,0.42,0.31,0.23,0.02,0.0,0.0,0.0,0.02,douglas sturkie,
-SOC,4860,5,Creative Inquiry in Sociology,0.5,0.28,0.17,0.0,0.06,0.0,0.0,0.0,margaret tina britz,
-SOC,4860,6,Creative Inquiry in Sociology,0.62,0.14,0.1,0.05,0.1,0.0,0.0,0.0,margaret tina britz,
-SOC,4930,1,Soc of Corrections,0.3,0.3,0.3,0.1,0.0,0.0,0.0,0.0,william white,
-SOC,4940,1,Organized Crimes,0.62,0.15,0.23,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
-SOC,4970,1,Senior Lab,0.53,0.18,0.12,0.12,0.06,0.0,0.0,0.0,brenda vander mey,
-SOC,4970,2,Senior Lab,0.48,0.28,0.08,0.04,0.12,0.0,0.0,0.0,brenda vander mey,
-SPAN,1010,1,Elementary Spanish,0.35,0.35,0.29,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,1010,2,Elementary Spanish,0.44,0.17,0.33,0.0,0.06,0.0,0.0,0.0,heidi montes,
-SPAN,1020,1,Elementary Spanish,0.17,0.17,0.22,0.06,0.28,0.0,0.0,0.11,roger simpson,
-SPAN,1020,2,Elementary Spanish,0.21,0.26,0.16,0.21,0.0,0.0,0.0,0.16,roger simpson,
-SPAN,1020,3,Elementary Spanish,0.47,0.24,0.18,0.0,0.0,0.0,0.0,0.12,roger simpson,
-SPAN,1020,4,Elementary Spanish,0.26,0.32,0.26,0.0,0.05,0.0,0.0,0.11,roger simpson,
-SPAN,1020,5,Elementary Spanish,0.15,0.25,0.2,0.15,0.15,0.0,0.0,0.1,roger simpson,
-SPAN,1020,6,Elementary Spanish,0.5,0.17,0.22,0.06,0.0,0.0,0.0,0.06,cathy robison,
-SPAN,1020,7,Elementary Spanish,0.44,0.22,0.11,0.11,0.06,0.0,0.0,0.06,cathy robison,
-SPAN,1020,8,Elementary Spanish,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,melva margu persico,
-SPAN,1020,9,Elementary Spanish,0.11,0.16,0.42,0.26,0.0,0.0,0.0,0.05,melva margu persico,
-SPAN,1020,10,Elementary Spanish,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,kari daus carson,
-SPAN,1020,11,Elementary Spanish,0.47,0.18,0.29,0.06,0.0,0.0,0.0,0.0,kari daus carson,
-SPAN,2010,1,Intermediate Spanish,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,2,Intermediate Spanish,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,cathy robison,
-SPAN,2010,3,Intermediate Spanish,0.28,0.67,0.0,0.0,0.06,0.0,0.0,0.0,maureen zamora,
-SPAN,2010,4,Intermediate Spanish,0.39,0.44,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,
-SPAN,2010,5,Intermediate Spanish,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,ricardo tremolada,
-SPAN,2010,6,Intermediate Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,
-SPAN,2010,7,Intermediate Spanish,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,ricardo tremolada,
-SPAN,2010,8,Intermediate Spanish,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,9,Intermediate Spanish,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2010,10,Intermediate Spanish,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,ellory schmucker,
-SPAN,2010,11,Intermediate Spanish,0.72,0.11,0.17,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,2010,12,Intermediate Spanish,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,2010,13,Intermediate Spanish,0.29,0.59,0.0,0.06,0.0,0.0,0.0,0.06,juana martin-armas,
-SPAN,2010,14,Intermediate Spanish,0.27,0.41,0.09,0.09,0.09,0.0,0.0,0.05,allison ann hinds,
-SPAN,2010,15,Intermediate Spanish,0.28,0.28,0.06,0.11,0.17,0.0,0.0,0.11,ricardo tremolada,
-SPAN,2020,1,Intermediate Spanish,0.1,0.48,0.29,0.05,0.05,0.0,0.0,0.05,melva margu persico,
-SPAN,2020,2,Intermediate Spanish,0.35,0.35,0.25,0.05,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,2020,3,Intermediate Spanish,0.35,0.45,0.15,0.0,0.05,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,4,Intermediate Spanish,0.2,0.35,0.25,0.1,0.05,0.0,0.0,0.05,juana martin-armas,
-SPAN,2020,5,Intermediate Spanish,0.3,0.35,0.2,0.0,0.05,0.0,0.0,0.1,juana martin-armas,
-SPAN,2020,6,Intermediate Spanish,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,ze cruz valderramos,
-SPAN,2020,7,Intermediate Spanish,0.41,0.36,0.05,0.14,0.0,0.0,0.0,0.05,allison ann hinds,
-SPAN,2020,8,Intermediate Spanish,0.32,0.32,0.32,0.0,0.0,0.0,0.0,0.05,allison ann hinds,
-SPAN,2020,9,Intermediate Spanish,0.2,0.5,0.15,0.15,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,10,Intermediate Spanish,0.55,0.1,0.2,0.15,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,11,Intermediate Spanish,0.38,0.38,0.14,0.05,0.0,0.0,0.0,0.05,ellory schmucker,
-SPAN,2020,12,Intermediate Spanish,0.23,0.27,0.45,0.05,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,3020,1,Int Spn Gram & Comp,0.47,0.37,0.0,0.05,0.0,0.0,0.0,0.11,george palacios,
-SPAN,3020,2,Int Spn Gram & Comp,0.57,0.38,0.0,0.05,0.0,0.0,0.0,0.0,george palacios,
-SPAN,3040,1,Intro Hisp Lit Forms,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,george palacios,
-SPAN,3050,4,Int Con Comp Span I,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,filiberto hernandez,
-SPAN,3060,1,Span Comp for Bus,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,3070,1,Hispanic World: Sp,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,
-SPAN,3070,2,Hispanic World: Sp,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,
-SPAN,3080,1,Hispanic World: La,0.15,0.45,0.25,0.05,0.05,0.0,0.0,0.05,tiffany dawn miller,
-SPAN,3160,1,Span for Intl Trade,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,4060,1,Narrative Fiction,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,salvador oropesa,
-SPAN,4150,1,Span for Health Prof,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,4200,1,Hispanic Drama,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,tiffany dawn miller,
-STAT,2220,1,Statistics in Everyday Life,0.39,0.2,0.17,0.15,0.09,0.0,0.0,0.0,ros martinez-dawson,
-STAT,2220,2,Statistics in Everyday Life,0.46,0.26,0.19,0.06,0.0,0.0,0.0,0.04,ros martinez-dawson,
-STAT,2220,3,Statistics in Everyday Life,0.43,0.39,0.15,0.04,0.0,0.0,0.0,0.0,james espey,
-STAT,2220,4,Statistics in Everyday Life,0.35,0.48,0.13,0.04,0.0,0.0,0.0,0.0,april thomas,
-STAT,2220,5,Statistics in Everyday Life,0.31,0.42,0.16,0.07,0.0,0.0,0.0,0.04,emily marie nystrom,
-STAT,2300,1,Statistical Methods I,0.37,0.31,0.15,0.09,0.06,0.0,0.0,0.01,christy jenki brown,
-STAT,2300,2,Statistical Methods I,0.33,0.35,0.14,0.04,0.14,0.0,0.0,0.01,benjamin sharp,
-STAT,2300,3,Statistical Methods I,0.46,0.25,0.16,0.09,0.04,0.0,0.0,0.0,christy jenki brown,
-STAT,2300,4,Statistical Methods I,0.3,0.35,0.18,0.13,0.03,0.0,0.0,0.03,marion hanna,
-STAT,2300,5,Statistical Methods I,0.28,0.37,0.22,0.05,0.06,0.0,0.0,0.03, erwin walker,
-STAT,2300,6,Statistical Methods I,0.23,0.43,0.14,0.11,0.09,0.0,0.0,0.01, erwin walker,
-STAT,2300,7,Statistical Methods I,0.48,0.34,0.11,0.05,0.0,0.0,0.0,0.01,christy jenki brown,
-STAT,2300,8,Statistical Methods I,0.44,0.27,0.18,0.03,0.08,0.0,0.0,0.01,marion hanna,
-STAT,3090,1,Introductory Business Stats,0.08,0.25,0.33,0.11,0.06,0.0,0.0,0.17,paul james cubre,
-STAT,3090,2,Introductory Business Stats,0.15,0.26,0.21,0.1,0.18,0.0,0.0,0.1,janie caro mcdonald,
-STAT,3090,3,Introductory Business Stats,0.31,0.18,0.36,0.08,0.08,0.0,0.0,0.0,gary fellers,
-STAT,3090,4,Introductory Business Stats,0.34,0.2,0.37,0.03,0.03,0.0,0.0,0.03,ellen hepfe breazel,
-STAT,3090,5,Introductory Business Stats,0.23,0.34,0.2,0.06,0.17,0.0,0.0,0.0,ellen hepfe breazel,
-STAT,3090,6,Introductory Business Stats,0.38,0.28,0.13,0.15,0.03,0.0,0.0,0.05,lucas waddell,
-STAT,3090,7,Introductory Business Stats,0.28,0.38,0.18,0.13,0.0,0.0,0.0,0.05,gary fellers,
-STAT,3090,8,Introductory Business Stats,0.11,0.24,0.32,0.13,0.13,0.0,0.0,0.08,tao yang,
-STAT,3090,9,Introductory Business Stats,0.05,0.23,0.28,0.13,0.18,0.0,0.0,0.13,ziwen cheng,
-STAT,3090,10,Introductory Business Stats,0.21,0.33,0.31,0.0,0.1,0.0,0.0,0.05,gary fellers,
-STAT,3090,11,Introductory Business Stats,0.1,0.45,0.3,0.05,0.03,0.0,0.0,0.08,gary fellers,
-STAT,3090,12,Introductory Business Stats,0.09,0.46,0.23,0.14,0.03,0.0,0.0,0.06,laura jane shick,
-STAT,3300,1,Statistical Methods II,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,ros martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.45,0.27,0.09,0.0,0.0,0.09,0.0,0.09,julia lynn sharp,
-STAT,4110,1,Stat Mthds for Process Control,0.26,0.32,0.26,0.1,0.06,0.0,0.0,0.0,james rieck,
-STAT,4110,2,Stat Mthds for Process Control,0.36,0.32,0.14,0.07,0.11,0.0,0.0,0.0,william bridges,
-STAT,8010,1,Statistical Methods I,0.43,0.27,0.1,0.0,0.17,0.0,0.0,0.03,james rieck,
-STAT,8010,2,Statistical Methods I,0.41,0.44,0.12,0.0,0.0,0.0,0.0,0.03,patrick gerard,
-STAT,8010,3,Statistical Methods I,0.69,0.16,0.09,0.0,0.0,0.0,0.0,0.06,jun luo,
-STAT,8040,1,Sampling,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-STAT,8050,1,Design & Anlys of Experiments,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,william bridges,
-STAT,8420,230,Intro to Statistical Methods,0.29,0.29,0.14,0.0,0.14,0.0,0.0,0.14,julia lynn sharp,
-STS,1010,1,Survey of S T S,0.42,0.33,0.24,0.0,0.0,0.0,0.0,0.0,thomas oberdan,
-STS,1010,2,Survey of S T S,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,scott brame,
-STS,1010,3,Survey of S T S,0.34,0.49,0.09,0.03,0.03,0.0,0.0,0.03,elizabeth stansell,
-STS,1010,4,Survey of S T S,0.5,0.31,0.14,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,
-STS,1010,5,Survey of S T S,0.12,0.36,0.15,0.06,0.0,0.0,0.0,0.3,david charles foltz,
-STS,1010,6,Survey of S T S,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,david stubblefield,
-STS,1010,7,Survey of S T S,0.76,0.16,0.05,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
-STS,1010,8,Survey of S T S,0.23,0.34,0.2,0.03,0.0,0.0,0.0,0.2,allison ann hinds,
-STS,1010,20,Survey of S T S,0.38,0.41,0.13,0.03,0.0,0.0,0.0,0.06,thomas oberdan,
-STS,2150,1,Crit Appr to Tech Revolutions,0.47,0.37,0.05,0.05,0.0,0.0,0.0,0.05,thomas oberdan,
-THEA,2100,1,Theatre Appreciation,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,richard st. peter,
-THEA,2100,2,Theatre Appreciation,0.91,0.06,0.0,0.0,0.03,0.0,0.0,0.0,kerrie kath seymour,
-THEA,2100,3,Theatre Appreciation,0.59,0.28,0.09,0.03,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,2100,4,Theatre Appreciation,0.63,0.28,0.09,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,2100,5,Theatre Appreciation,0.45,0.3,0.18,0.03,0.0,0.0,0.0,0.03,carol collins,
-THEA,2100,6,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,
-THEA,2100,7,Theatre Appreciation,0.53,0.34,0.06,0.0,0.03,0.0,0.0,0.03,jason adkins,
-THEA,2770,1,Prod Studies in Thea,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david hartmann,
-THEA,2790,1,Theatre Practicum,0.62,0.08,0.15,0.0,0.08,0.0,0.0,0.08,matthew leckenbusch,
-THEA,3160,1,Theatre History II,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,richard st. peter,
-THEA,3180,1,Afri-Amer Thea II,0.68,0.19,0.1,0.0,0.0,0.0,0.0,0.03,kendra lyne johnson,
-THEA,3470,1,Structure of Drama,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
-THEA,3740,1,Movement for Actors,0.69,0.15,0.08,0.0,0.08,0.0,0.0,0.0,kerrie kath seymour,
-WFB,3010,1,Wildlife Biology Lab,0.29,0.5,0.14,0.0,0.0,0.0,0.0,0.07,shari lyn rodriguez,
-WFB,3130,1,Conservation Biology,0.45,0.25,0.16,0.06,0.06,0.0,0.0,0.02,shari lyn rodriguez,
-WFB,3130,2,Conservation Biology,0.17,0.37,0.26,0.11,0.06,0.0,0.0,0.03,shari lyn rodriguez,
-WFB,3500,1,Prin Fish Wildl Biol,0.21,0.51,0.21,0.05,0.02,0.0,0.0,0.0,james davis,
-WFB,3500,2,Prin Fish Wildl Biol,0.28,0.26,0.38,0.03,0.05,0.0,0.0,0.0,james davis,
-WFB,4160,1,Fishery Biology,0.36,0.36,0.17,0.09,0.0,0.0,0.0,0.02,yoichiro kanno,
-WFB,4300,1,Wildl Conserv Policy,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.04,joseph lanham,
-WFB,4400,1,Non-Game Wildl Mgmt,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,4620,1,Wetland Wildl Biol,0.45,0.38,0.12,0.05,0.0,0.0,0.0,0.0,russell barrett,
-WS,1030,1,Women Global Perspec,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,
-WS,2300,1,Women and Leadership,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,saadiqa kumanyika,
-WS,3010,1,Intro Women's Studies,0.76,0.14,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth ros adams,
-WS,3010,2,Intro Women's Studies,0.43,0.48,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth ros adams,
-YDP,3100,400,Youth Developmt and the Family,0.79,0.07,0.07,0.0,0.07,0.0,0.0,0.0,william quinn,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1020,1,Survey of Art & Arch Hist II,0.4,0.49,0.09,0.0,0.0,0.0,0.0,0.01,beth ann lauritis,,AAH-1020,2015
+AAH,2060,1,Art History and Theory II,0.48,0.29,0.24,0.0,0.0,0.0,0.0,0.0,andrea feeser,,AAH-2060,2015
+AAH,2100,1,Intro to Art and Architecture,0.39,0.32,0.14,0.04,0.07,0.0,0.0,0.04,lydia jane dorsey,,AAH-2100,2015
+AAH,2100,2,Intro to Art and Architecture,0.29,0.36,0.29,0.0,0.04,0.0,0.0,0.04,lydia jane dorsey,,AAH-2100,2015
+AAH,2100,3,Intro to Art and Architecture,0.21,0.54,0.11,0.07,0.0,0.0,0.0,0.07,lydia jane dorsey,,AAH-2100,2015
+AAH,2100,4,Intro to Art and Architecture,0.22,0.22,0.26,0.11,0.0,0.0,0.0,0.19,lydia jane dorsey,,AAH-2100,2015
+ACCT,2010,1,Financial Accounting Concepts,0.19,0.3,0.21,0.12,0.09,0.0,0.0,0.09,suzanne pearse,,ACCT-2010,2015
+ACCT,2010,2,Financial Accounting Concepts,0.32,0.17,0.13,0.09,0.09,0.0,0.0,0.21,lydia lan schleifer,,ACCT-2010,2015
+ACCT,2010,3,Financial Accounting Concepts,0.18,0.32,0.25,0.02,0.09,0.0,0.0,0.14,suzanne pearse,,ACCT-2010,2015
+ACCT,2010,4,Financial Accounting Concepts,0.12,0.2,0.3,0.16,0.1,0.0,0.0,0.12,philip maiberger,,ACCT-2010,2015
+ACCT,2010,5,Financial Accounting Concepts,0.12,0.37,0.24,0.04,0.06,0.0,0.0,0.16,philip maiberger,,ACCT-2010,2015
+ACCT,2010,6,Financial Accounting Concepts,0.29,0.38,0.1,0.05,0.05,0.0,0.0,0.14,suzanne pearse,,ACCT-2010,2015
+ACCT,2010,7,Financial Accounting Concepts,0.3,0.13,0.22,0.15,0.04,0.0,0.0,0.15,lydia lan schleifer,,ACCT-2010,2015
+ACCT,2010,8,Financial Accounting Concepts,0.31,0.2,0.2,0.11,0.11,0.0,0.0,0.07,lydia lan schleifer,,ACCT-2010,2015
+ACCT,2010,9,Financial Accounting Concepts,0.09,0.23,0.36,0.16,0.0,0.0,0.0,0.16,the estate  guffey,,ACCT-2010,2015
+ACCT,2010,10,Financial Accounting Concepts,0.17,0.27,0.23,0.03,0.1,0.0,0.0,0.2,the estate  guffey,,ACCT-2010,2015
+ACCT,2010,11,Financial Accounting Concepts,0.13,0.3,0.16,0.13,0.14,0.0,0.0,0.14,jeffrey mcmillan,,ACCT-2010,2015
+ACCT,2010,12,Financial Accounting Concepts,0.16,0.14,0.2,0.26,0.08,0.0,0.0,0.16,philip maiberger,,ACCT-2010,2015
+ACCT,2010,13,Fin Acct Concepts (HON),0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True,ACCT-2010,2015
+ACCT,2020,1,Managerial Accounting Concepts,0.22,0.33,0.2,0.12,0.02,0.0,0.0,0.1,annieka philo,,ACCT-2020,2015
+ACCT,2020,2,Managerial Accounting Concepts,0.33,0.3,0.24,0.06,0.06,0.0,0.0,0.02,annieka philo,,ACCT-2020,2015
+ACCT,2020,3,Managerial Accounting Concepts,0.35,0.24,0.28,0.04,0.04,0.0,0.0,0.06,annieka philo,,ACCT-2020,2015
+ACCT,2020,4,Managerial Accounting Concepts,0.33,0.35,0.15,0.09,0.04,0.0,0.0,0.04,annieka philo,,ACCT-2020,2015
+ACCT,2020,5,Managerial Accounting Concepts,0.14,0.18,0.39,0.05,0.0,0.0,0.0,0.25,henry anderson,,ACCT-2020,2015
+ACCT,2020,6,Managerial Accounting Concepts,0.26,0.3,0.2,0.07,0.02,0.0,0.0,0.15,henry anderson,,ACCT-2020,2015
+ACCT,2020,8,Managerial Accounting Concepts,0.14,0.11,0.2,0.17,0.09,0.0,0.0,0.29,henry anderson,,ACCT-2020,2015
+ACCT,3030,1,Cost Accounting,0.28,0.35,0.23,0.05,0.02,0.0,0.0,0.06,frances kennedy,,ACCT-3030,2015
+ACCT,3030,3,Cost Accounting,0.35,0.43,0.14,0.05,0.0,0.0,0.0,0.03,holly rhiannio hawk,,ACCT-3030,2015
+ACCT,3030,4,Cost Accounting,0.24,0.5,0.13,0.0,0.03,0.0,0.0,0.11,holly rhiannio hawk,,ACCT-3030,2015
+ACCT,3110,1,Intermed Financial Acct I,0.2,0.5,0.2,0.03,0.0,0.0,0.0,0.08,terry daniel knause,,ACCT-3110,2015
+ACCT,3110,2,Intermed Financial Acct I,0.41,0.44,0.15,0.0,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3110,2015
+ACCT,3110,3,Intermed Financial Acct I,0.22,0.45,0.29,0.02,0.0,0.0,0.0,0.02,terry daniel knause,,ACCT-3110,2015
+ACCT,3110,4,Intermed Financial Acct I,0.31,0.57,0.09,0.02,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3110,2015
+ACCT,3120,1,Intermed Financial Acct II,0.33,0.45,0.18,0.03,0.0,0.0,0.0,0.03, russell madray,,ACCT-3120,2015
+ACCT,3120,2,Intermed Financial Acct II,0.32,0.38,0.15,0.04,0.04,0.0,0.0,0.06, russell madray,,ACCT-3120,2015
+ACCT,3120,3,Intermed Financial Acct II,0.05,0.28,0.21,0.26,0.18,0.0,0.0,0.03,brian todd carver,,ACCT-3120,2015
+ACCT,3120,4,Intermed Financial Acct II,0.03,0.18,0.38,0.24,0.18,0.0,0.0,0.0,brian todd carver,,ACCT-3120,2015
+ACCT,3130,1,Intermed Financial Acct III,0.28,0.38,0.31,0.03,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2015
+ACCT,3130,2,Intermed Financial Acct III,0.27,0.41,0.24,0.03,0.05,0.0,0.0,0.0, russell madray,,ACCT-3130,2015
+ACCT,3130,3,Intermed Financial Acct III,0.11,0.48,0.26,0.11,0.04,0.0,0.0,0.0,james irving,,ACCT-3130,2015
+ACCT,3130,4,Intermed Financial Acct III,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,james irving,,ACCT-3130,2015
+ACCT,3220,1,Accounting Information Systems,0.28,0.28,0.4,0.03,0.0,0.0,0.0,0.03,nancy lee harp,,ACCT-3220,2015
+ACCT,3220,2,Accounting Information Systems,0.26,0.18,0.38,0.08,0.08,0.0,0.0,0.03,nancy lee harp,,ACCT-3220,2015
+ACCT,3220,3,Accounting Information Systems,0.19,0.49,0.19,0.11,0.0,0.0,0.0,0.03,nancy lee harp,,ACCT-3220,2015
+ACCT,4040,1,Individual Taxation,0.76,0.18,0.03,0.0,0.03,0.0,0.0,0.0,sarah martin,,ACCT-4040,2015
+ACCT,4040,2,Individual Taxation,0.88,0.05,0.07,0.0,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2015
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.36,0.46,0.13,0.0,0.0,0.0,0.0,0.05,james mil kohlmeyer,,ACCT-4100,2015
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.19,0.73,0.08,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,,ACCT-4100,2015
+ACCT,4150,1,Auditing,0.16,0.46,0.27,0.08,0.0,0.0,0.0,0.03,suzanne pearse,,ACCT-4150,2015
+ACCT,4150,2,Auditing,0.29,0.48,0.19,0.03,0.0,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2015
+ACCT,8520,1,Fin Acct Theory/Res,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8520,2015
+ACCT,8520,2,Fin Acct Theory/Res,0.32,0.58,0.1,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8520,2015
+ACCT,8540,1,Prof Responsibility,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,,ACCT-8540,2015
+ACCT,8710,1,Corporate Taxation,0.46,0.51,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2015
+ACCT,8710,2,Corporate Taxation,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2015
+AGED,1000,1,Orientation & Field Experience,0.85,0.07,0.04,0.0,0.0,0.0,0.0,0.04,philip fravel,,AGED-1000,2015
+AGED,2030,1,Teaching Agriscience,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-2030,2015
+AGED,4160,1,Ethics and Issues,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,,AGED-4160,2015
+AGM,2050,1,Prin of Fabrication,0.13,0.45,0.3,0.05,0.0,0.0,0.0,0.07,hunter massey,,AGM-2050,2015
+AGM,2060,1,Machinery Mgt,0.15,0.36,0.3,0.09,0.03,0.0,0.0,0.06,hunter massey,,AGM-2060,2015
+AGM,2210,1,Land Measurements,0.31,0.42,0.19,0.08,0.0,0.0,0.0,0.0,charles privette,,AGM-2210,2015
+AGM,3030,1,Cal for Mech Ag,0.48,0.4,0.1,0.0,0.0,0.0,0.0,0.02,young han,,AGM-3030,2015
+AGM,4020,1,Land Drain and Irrig,0.1,0.55,0.3,0.05,0.0,0.0,0.0,0.0,charles privette,,AGM-4020,2015
+AGM,4100,1,Precision Ag Tech,0.24,0.44,0.22,0.1,0.0,0.0,0.0,0.0,hunter massey,,AGM-4100,2015
+AGM,4520,1,Mobile Power,0.24,0.44,0.24,0.05,0.0,0.0,0.0,0.02,hunter massey,,AGM-4520,2015
+AGM,4720,1,Capstone,0.07,0.36,0.57,0.0,0.0,0.0,0.0,0.0,john chastain,,AGM-4720,2015
+AL,3490,400,Principles of Coaching,0.41,0.22,0.33,0.0,0.0,0.0,0.0,0.04,deborah cadorette,,AL-3490,2015
+AL,3490,401,Principles of Coaching,0.31,0.52,0.1,0.03,0.03,0.0,0.0,0.0,deborah cadorette,,AL-3490,2015
+AL,3490,402,Principles of Coaching,0.52,0.28,0.04,0.08,0.04,0.0,0.0,0.04,julia wright,,AL-3490,2015
+AL,3490,403,Principles of Coaching,0.67,0.26,0.04,0.0,0.04,0.0,0.0,0.0,clyde keith connor,,AL-3490,2015
+AL,3490,404,Principles of Coaching,0.5,0.31,0.12,0.04,0.04,0.0,0.0,0.0,clyde keith connor,,AL-3490,2015
+AL,3490,405,Principles of Coaching,0.74,0.11,0.0,0.07,0.04,0.0,0.0,0.04,edmond fry,,AL-3490,2015
+AL,3500,400,Sci Basis I/Ex Phy,0.22,0.19,0.26,0.22,0.07,0.0,0.0,0.04,michael godfrey,,AL-3500,2015
+AL,3500,401,Sci Basis I/Ex Phy,0.36,0.16,0.32,0.08,0.04,0.0,0.0,0.04,michael godfrey,,AL-3500,2015
+AL,3520,400,Kinesiology,0.42,0.05,0.16,0.16,0.11,0.0,0.0,0.11,michael godfrey,,AL-3520,2015
+AL,3530,400,Athletic Injuries,0.42,0.15,0.27,0.15,0.0,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2015
+AL,3530,401,Athletic Injuries,0.22,0.22,0.22,0.17,0.13,0.0,0.0,0.04,isaac sean colbert,,AL-3530,2015
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.38,0.19,0.05,0.05,0.0,0.0,0.0,clyde keith connor,,AL-3600,2015
+AL,3610,400,Admin/Org of Athletic Programs,0.81,0.12,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2015
+AL,3610,401,Admin/Org of Athletic Programs,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2015
+AL,3610,402,Admin/Org of Athletic Programs,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,henry oates,,AL-3610,2015
+AL,3620,400,Psychology of Coaching,0.44,0.24,0.12,0.16,0.04,0.0,0.0,0.0,natalie anne carter,,AL-3620,2015
+AL,3620,401,Psychology of Coaching,0.18,0.3,0.27,0.15,0.06,0.0,0.0,0.03,natalie anne carter,,AL-3620,2015
+AL,3710,400,Coaching Baseball,0.65,0.1,0.1,0.1,0.05,0.0,0.0,0.0,justin hickey,,AL-3710,2015
+AL,3720,400,Coaching Basketball,0.5,0.08,0.17,0.04,0.13,0.0,0.0,0.08,edmond fry,,AL-3720,2015
+AL,3740,400,Coaching Football,0.54,0.21,0.08,0.0,0.17,0.0,0.0,0.0,edmond fry,,AL-3740,2015
+AL,3760,400,Coaching Strength/Conditioning,0.58,0.17,0.04,0.08,0.04,0.0,0.0,0.08,edmond fry,,AL-3760,2015
+AL,4380,400,Creative Inquire C&A,0.47,0.27,0.13,0.07,0.07,0.0,0.0,0.0,deborah cadorette,,AL-4380,2015
+AL,4380,410,Coaching Rugby,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,deborah cadorette,,AL-4380,2015
+AL,8640,400,Ethical Iss in Collegiate Athl,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,james satterfield,,AL-8640,2015
+ANTH,2010,1,Introduction to Anthropology,0.05,0.25,0.37,0.15,0.08,0.0,0.0,0.1,john coggeshall,,ANTH-2010,2015
+ANTH,2010,2,Introduction to Anthropology,0.37,0.44,0.14,0.03,0.01,0.0,0.0,0.01,katherine weisensee,,ANTH-2010,2015
+ANTH,2010,3,Introduction to Anthropology,0.55,0.21,0.07,0.04,0.02,0.0,0.0,0.11,lisa rapaport,,ANTH-2010,2015
+ANTH,3200,1,North American Indian Cultures,0.3,0.4,0.2,0.0,0.0,0.0,0.0,0.1,john coggeshall,,ANTH-3200,2015
+ANTH,3310,1,Archaeology,0.24,0.35,0.35,0.06,0.0,0.0,0.0,0.0,melissa vogel,,ANTH-3310,2015
+ANTH,3510,1,Biological Anthropology,0.35,0.4,0.2,0.05,0.0,0.0,0.0,0.0,katherine weisensee,,ANTH-3510,2015
+ANTH,4230,1,Women in the Developing World,0.61,0.33,0.0,0.06,0.0,0.0,0.0,0.0,melissa vogel,,ANTH-4230,2015
+APEC,2020,1,Agric Economics,0.87,0.11,0.02,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,,APEC-2020,2015
+APEC,2050,1,Agric and Society,0.39,0.38,0.18,0.04,0.0,0.0,0.0,0.02,michael vassalos,,APEC-2050,2015
+APEC,3190,1,Agribusiness Mgt,0.34,0.3,0.26,0.04,0.02,0.0,0.0,0.04,michael vassalos,,APEC-3190,2015
+APEC,3570,1,Nat Resource Econ,0.29,0.19,0.27,0.19,0.02,0.0,0.0,0.04,david brian willis,,APEC-3570,2015
+APEC,4560,1,Prices,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,,APEC-4560,2015
+ARAB,1010,1,Elementary Arabic I,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sulafa abou-samra,,ARAB-1010,2015
+ARAB,1020,1,Elementary Arabic II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sulafa abou-samra,,ARAB-1020,2015
+ARCH,1510,1,Arch Communication,0.53,0.41,0.0,0.0,0.06,0.0,0.0,0.0,sal hambright-belue,,ARCH-1510,2015
+ARCH,1510,2,Arch Communication,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,robert silance,,ARCH-1510,2015
+ARCH,1510,3,Arch Communication,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,junichi satoh,,ARCH-1510,2015
+ARCH,1510,4,Arch Communication,0.58,0.21,0.05,0.05,0.0,0.0,0.0,0.11,clarissa mendez,,ARCH-1510,2015
+ARCH,2520,1,Arch Foundations II,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,david lee,,ARCH-2520,2015
+ARCH,2520,2,Arch Foundations II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-2520,2015
+ARCH,2520,4,Arch Foundations II,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2520,2015
+ARCH,2700,1,Structures I,0.43,0.36,0.14,0.07,0.0,0.0,0.0,0.0,robert john hogan,,ARCH-2700,2015
+ARCH,2700,2,Structures I,0.47,0.47,0.0,0.0,0.06,0.0,0.0,0.0,robert john hogan,,ARCH-2700,2015
+ARCH,2710,1,Structures II,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,michael carl kleiss,,ARCH-2710,2015
+ARCH,3530,1,Studio Genoa,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,,ARCH-3530,2015
+ARCH,4010,1,Arch Portfolio,0.5,0.14,0.18,0.0,0.05,0.0,0.0,0.14,arash soleimani,,ARCH-4010,2015
+ARCH,4520,1,Synthesis Studio,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-4520,2015
+ARCH,4520,2,Synthesis Studio,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-4520,2015
+ARCH,4520,3,Synthesis Studio,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,criss mills,,ARCH-4520,2015
+ARCH,6880,1,Arch Programming,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-6880,2015
+ARCH,6990,2,Glass as a Modern Material,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-6990,2015
+ARCH,8110,1,Visualization II,0.38,0.5,0.0,0.0,0.06,0.0,0.0,0.06,douglas hecker,,ARCH-8110,2015
+ARCH,8200,1,Bldg Design & Constr,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,dennis bausman,,ARCH-8200,2015
+ARCH,8420,1,Arch Studio II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,,ARCH-8420,2015
+ARCH,8420,2,Arch Studio II,0.22,0.44,0.11,0.0,0.11,0.0,0.0,0.11,junichi satoh,,ARCH-8420,2015
+ARCH,8610,1,History/Theory II,0.4,0.47,0.0,0.0,0.07,0.0,0.0,0.07,robert bruhns,,ARCH-8610,2015
+ARCH,8710,1,Structures II,0.45,0.41,0.09,0.0,0.0,0.0,0.0,0.05,dustin gra albright,,ARCH-8710,2015
+ARCH,8730,1,Environmental Sys,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,vincent yves blouin,,ARCH-8730,2015
+ARCH,8740,1,Building Process:TR,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john jacques,,ARCH-8740,2015
+ARCH,8740,2,Building Process:TR,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,john jacques,,ARCH-8740,2015
+ARCH,8820,1,Building Economics,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-8820,2015
+ARCH,8900,1,Directed Studies,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,anjali joseph,,ARCH-8900,2015
+ARCH,8920,2,Comprehensive Studio,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-8920,2015
+ARCH,8920,3,Comprehensive Studio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,,ARCH-8920,2015
+ARCH,8920,4,Comprehensive Studio,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-8920,2015
+ARCH,8920,5,Comprehensive Studio,0.0,0.7,0.3,0.0,0.0,0.0,0.0,0.0,keith green,,ARCH-8920,2015
+ARCH,8960,1,A+H Studio: Tectonic,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-8960,2015
+ART,1060,1,Foundation Drawing II,0.52,0.24,0.14,0.0,0.05,0.0,0.0,0.05,kathleen ann thum,,ART-1060,2015
+ART,1520,1,Foundations Art II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,,ART-1520,2015
+ART,2050,1,Beginning Life Drawing,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,alexandra giannell,,ART-2050,2015
+ART,2070,1,Beginning Painting,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,hilary erin siber,,ART-2070,2015
+ART,2090,1,Beginning Sculpture,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,tanna burchinal,,ART-2090,2015
+ART,2130,1,Begin Photography,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,,ART-2130,2015
+ART,2170,1,Beginning Ceramics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lindsey ann elsey,,ART-2170,2015
+AS,1100,2,Air Force Today II,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,steven price jordan,,AS-1100,2015
+AS,2100,3,Dev of Air Power II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,christopher mann,,AS-2100,2015
+ASL,1010,2,Am Sign Lang I,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,william alton brant,,ASL-1010,2015
+ASL,1020,2,Am Sign Lang I,0.71,0.07,0.21,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-1020,2015
+ASL,2020,1,Am Sign Lang II,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-2020,2015
+ASTR,1010,1,Solar System Astr,0.47,0.22,0.15,0.07,0.03,0.0,0.0,0.05,sean brittain,,ASTR-1010,2015
+ASTR,1020,1,Stellar Astronomy,0.22,0.49,0.18,0.02,0.02,0.0,0.0,0.06,phillip flower,,ASTR-1020,2015
+ASTR,1020,2,Stellar Astronomy,0.17,0.52,0.2,0.01,0.01,0.0,0.0,0.09,phillip flower,,ASTR-1020,2015
+ASTR,1020,3,Stellar Astronomy,0.18,0.38,0.34,0.04,0.04,0.0,0.0,0.01,phillip flower,,ASTR-1020,2015
+ASTR,1030,1,Solar Systm Astr Lab,0.58,0.19,0.04,0.0,0.08,0.0,0.0,0.12,mark leising,,ASTR-1030,2015
+ASTR,1030,2,Solar Systm Astr Lab,0.5,0.15,0.05,0.05,0.15,0.0,0.0,0.1,mark leising,,ASTR-1030,2015
+ASTR,1040,1,Stellar Astr Lab,0.44,0.32,0.2,0.0,0.04,0.0,0.0,0.0,mark leising,,ASTR-1040,2015
+ASTR,1040,2,Stellar Astr Lab,0.35,0.45,0.15,0.0,0.05,0.0,0.0,0.0,mark leising,,ASTR-1040,2015
+ASTR,1040,3,Stellar Astr Lab,0.64,0.28,0.0,0.0,0.0,0.0,0.0,0.08,mark leising,,ASTR-1040,2015
+ASTR,1040,5,Stellar Astr Lab,0.33,0.33,0.17,0.0,0.11,0.0,0.0,0.06,mark leising,,ASTR-1040,2015
+ASTR,1040,6,Stellar Astr Lab,0.14,0.52,0.24,0.0,0.1,0.0,0.0,0.0,mark leising,,ASTR-1040,2015
+AUD,2850,1,Acoustics of Music,0.2,0.47,0.27,0.0,0.0,0.0,0.0,0.07,hamilton altstatt,,AUD-2850,2015
+AUE,8160,1,Eng Combustion Emiss,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8160,2015
+AUE,8170,3,Alt Energy Sources,0.37,0.59,0.05,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8170,2015
+AUE,8500,6,Stability/Safety Sys,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8500,2015
+AUE,8550,16,Auto Struct Analysis,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,,AUE-8550,2015
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8690,2015
+AUE,8770,9,Light-Weight Design,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,,AUE-8770,2015
+AUE,8820,10,Systems Integration Method,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,,AUE-8820,2015
+AUE,8860,11,Noise Vibration,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,imtiaz ul haque,,AUE-8860,2015
+AUE,8930,15,Innov & Entrepreneurship,0.56,0.42,0.0,0.0,0.0,0.0,0.0,0.02,david leo bodde,,AUE-8930,2015
+AUE,8930,16,Fundamentals of Injection Mold,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,,AUE-8930,2015
+AVS,2010,1,Poultry Techniques,0.93,0.04,0.0,0.04,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-2010,2015
+AVS,2050,1,Horsemanship Techniques,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,,AVS-2050,2015
+AVS,2060,1,Swine Techniques,0.83,0.11,0.02,0.0,0.02,0.0,0.0,0.02,richelle lor miller,,AVS-2060,2015
+AVS,2090,1,Livestock Exhibition Technique,0.93,0.06,0.0,0.0,0.0,0.0,0.0,0.01,richelle lor miller,,AVS-2090,2015
+AVS,2110,1,Meat Processing Techniques,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brian bolt,,AVS-2110,2015
+AVS,2120,1,Small Ruminant Techniques,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,heather walker dunn,,AVS-2120,2015
+AVS,3010,1,Anat & Phys Dom Ani,0.4,0.29,0.22,0.04,0.04,0.0,0.0,0.02,tiffany wilmoth,,AVS-3010,2015
+AVS,3100,1,Animal Health,0.71,0.16,0.06,0.02,0.03,0.0,0.0,0.02,thomas scott,,AVS-3100,2015
+AVS,3150,1,Animal Welfare,0.27,0.36,0.27,0.05,0.05,0.0,0.0,0.0,peter skewes,,AVS-3150,2015
+AVS,3700,1,Prin Animal Nutr,0.1,0.18,0.4,0.11,0.18,0.0,0.0,0.03,nathan long,,AVS-3700,2015
+AVS,3750,1,Appl Animal Nutr,0.4,0.34,0.18,0.06,0.0,0.0,0.0,0.02,gustavo jos lascano,,AVS-3750,2015
+AVS,4000,1,AVS Professional Development,0.62,0.24,0.0,0.12,0.0,0.0,0.0,0.03,johanna joh lascano,,AVS-4000,2015
+AVS,4060,1,Seminars & Relat Top,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2015
+AVS,4090,2,Selected Topics/CAFLS Plus,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,thomas scott,,AVS-4090,2015
+AVS,4090,7,Sel Topics- Scientific Writing,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4090,2015
+AVS,4100,1,Domestic Ani Behav,0.37,0.39,0.18,0.03,0.02,0.0,0.0,0.01,peter skewes,,AVS-4100,2015
+AVS,4110,400,Ani Growth & Develop,0.62,0.15,0.15,0.0,0.08,0.0,0.0,0.0,susan kay duckett,,AVS-4110,2015
+AVS,4120,1,Adv Equine Mgmt,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-4120,2015
+AVS,4130,1,Animal Products,0.78,0.21,0.01,0.0,0.0,0.0,0.0,0.0,brian bolt,,AVS-4130,2015
+AVS,4170,1,Animal Agribusiness Develpmnt,0.23,0.68,0.09,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-4170,2015
+AVS,4220,2,Special Problems/CAFLS Plus,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,thomas scott,,AVS-4220,2015
+AVS,4530,1,Animal Reproduction,0.5,0.31,0.17,0.0,0.0,0.0,0.0,0.02,glenn birrenkott,,AVS-4530,2015
+AVS,4530,400,Animal Reproduction,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-4530,2015
+AVS,6110,1,Ani Growth & Develop,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,,AVS-6110,2015
+BCHM,3010,1,Molecular Biochem,0.25,0.21,0.25,0.13,0.06,0.0,0.0,0.1,meredith tei morris,,BCHM-3010,2015
+BCHM,3010,2,Molecular Biochem(HON),0.68,0.15,0.15,0.0,0.0,0.0,0.0,0.03,meredith tei morris,True,BCHM-3010,2015
+BCHM,3020,1,Molecular Biochemistry Lab,0.77,0.08,0.08,0.0,0.0,0.0,0.0,0.08,meredith tei morris,,BCHM-3020,2015
+BCHM,3020,2,Molecular Biochemistry Lab,0.56,0.25,0.06,0.13,0.0,0.0,0.0,0.0,meredith tei morris,,BCHM-3020,2015
+BCHM,3020,3,Molecular Biochemistry Lab,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,meredith tei morris,,BCHM-3020,2015
+BCHM,3050,1,Essen Elements Bioch,0.32,0.36,0.18,0.05,0.05,0.0,0.0,0.04,srik chandrasekaran,,BCHM-3050,2015
+BCHM,3050,2,Essen Elements Bioch,0.4,0.37,0.13,0.07,0.01,0.0,0.0,0.03,liangjiang wang,,BCHM-3050,2015
+BCHM,4060,1,Physiological Chem,0.41,0.25,0.25,0.02,0.04,0.0,0.0,0.02,ashby burges bodine,,BCHM-4060,2015
+BCHM,4320,1,Bioch of Metabolism,0.61,0.35,0.0,0.03,0.0,0.0,0.0,0.0,kimberly paul,,BCHM-4320,2015
+BCHM,4340,1,General Biochemistry Lab II,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,kimberly paul,,BCHM-4340,2015
+BCHM,4340,2,General Biochemistry Lab II,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,kimberly paul,,BCHM-4340,2015
+BCHM,4360,1,Genes to Proteins,0.23,0.41,0.27,0.0,0.05,0.0,0.0,0.05,michael glen sehorn,,BCHM-4360,2015
+BCHM,4360,2,Genes to Proteins(HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True,BCHM-4360,2015
+BCHM,4900,1,Strategic Markting Relay 4 Lif,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,michael glen sehorn,,BCHM-4900,2015
+BE,2100,1,Intro to Biosystems Engr,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,yi zheng,,BE-2100,2015
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.29,0.33,0.29,0.04,0.04,0.0,0.0,0.0,tom owino,,BE-3220,2015
+BE,4120,1,Be Heat Mass Trans,0.48,0.29,0.1,0.1,0.05,0.0,0.0,0.0,caye marie drapcho,,BE-4120,2015
+BE,4240,1,Ecological Engr,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,,BE-4240,2015
+BE,4380,1,Bioprocess Engineering Design,0.52,0.29,0.0,0.14,0.05,0.0,0.0,0.0,terry walker,,BE-4380,2015
+BIOE,2010,1,Intro Biomed Engr,0.47,0.31,0.16,0.0,0.0,0.0,0.0,0.06,charles webb,,BIOE-2010,2015
+BIOE,3020,1,Biomaterials,0.53,0.33,0.08,0.01,0.01,0.0,0.0,0.03,vladimir vla reukov,,BIOE-3020,2015
+BIOE,3200,1,Biomechanics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,,BIOE-3200,2015
+BIOE,3210,1,Biofluid Mechanics,0.34,0.43,0.12,0.05,0.0,0.0,0.0,0.06,sarah harcum,,BIOE-3210,2015
+BIOE,3700,1,Bioinst & Imaging,0.29,0.53,0.11,0.0,0.02,0.0,0.0,0.05,david kwartowitz,,BIOE-3700,2015
+BIOE,4030,1,Applied Bio E Design,0.97,0.01,0.0,0.01,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4030,2015
+BIOE,4200,1,Sports Engineering,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,,BIOE-4200,2015
+BIOE,4510,33,CI-Og Design,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,john desjardins,,BIOE-4510,2015
+BIOE,6350,1,Modeling of Multiphysics Prob,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,guigen zhang,,BIOE-6350,2015
+BIOE,8020,410,Biocompatibility,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,,BIOE-8020,2015
+BIOE,8150,410,Design Manuf Medical Devices,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,,BIOE-8150,2015
+BIOE,8500,401,"Cells, Stem Cells & Dev't",0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ann catherine foley,,BIOE-8500,2015
+BIOL,1040,1,General Biology II,0.24,0.31,0.25,0.12,0.05,0.0,0.0,0.05,nora espinoza,,BIOL-1040,2015
+BIOL,1040,2,General Biology II,0.15,0.32,0.28,0.12,0.09,0.0,0.0,0.04,kalan ickes,,BIOL-1040,2015
+BIOL,1040,3,General Biology II,0.46,0.33,0.14,0.05,0.01,0.0,0.0,0.0,william surver,,BIOL-1040,2015
+BIOL,1040,4,General Biology II (HON),0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True,BIOL-1040,2015
+BIOL,1060,1,Gen Biology Lab II,0.25,0.25,0.15,0.25,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,2,Gen Biology Lab II,0.11,0.26,0.21,0.32,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,3,Gen Biology Lab II,0.15,0.5,0.15,0.1,0.1,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,4,Gen Biology Lab II,0.2,0.2,0.25,0.25,0.0,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,5,Gen Biology Lab II,0.2,0.2,0.35,0.15,0.1,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,6,Gen Biology Lab II,0.2,0.25,0.15,0.2,0.2,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,7,Gen Biology Lab II,0.25,0.3,0.15,0.25,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,10,Gen Biology Lab II,0.0,0.3,0.3,0.25,0.05,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,11,Gen Biology Lab II,0.1,0.2,0.3,0.2,0.1,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,12,Gen Biology Lab II,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,13,Gen Biology Lab II,0.35,0.3,0.2,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,14,Gen Biology Lab II,0.1,0.25,0.35,0.2,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,15,Gen Biology Lab II,0.4,0.2,0.35,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,16,Gen Biology Lab II,0.25,0.35,0.15,0.15,0.1,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,17,Gen Biology Lab II,0.1,0.65,0.2,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,18,Gen Biology Lab II,0.3,0.3,0.2,0.1,0.1,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,19,Gen Biology Lab II,0.3,0.25,0.3,0.0,0.0,0.0,0.0,0.15,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,21,Gen Biology Lab II,0.15,0.55,0.2,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,22,Gen Biology Lab II,0.35,0.35,0.25,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,25,Gen Biology Lab II,0.3,0.45,0.15,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,26,Gen Biology Lab II,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,27,Gen Biology Lab II,0.3,0.25,0.25,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,28,Gen Biology Lab II,0.35,0.25,0.25,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,29,Gen Biology Lab II,0.35,0.15,0.3,0.15,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,30,Gen Biology Lab II,0.2,0.2,0.3,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,31,Gen Biology Lab II,0.3,0.45,0.15,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,34,Gen Biology Lab II,0.26,0.53,0.16,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,36,Gen Biology Lab II,0.25,0.35,0.15,0.05,0.2,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,37,Gen Biology Lab II,0.32,0.32,0.21,0.05,0.11,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,38,Gen Biology Lab II,0.21,0.37,0.21,0.0,0.05,0.0,0.0,0.16,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,39,Gen Biology Lab II,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,40,Gen Biology Lab II,0.3,0.25,0.2,0.05,0.1,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,41,Gen Biology Lab II,0.37,0.05,0.21,0.05,0.32,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1060,42,Gen Biology Lab II,0.3,0.25,0.15,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2015
+BIOL,1090,1,Intro to Life Sci,0.67,0.19,0.14,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,,BIOL-1090,2015
+BIOL,1110,1,Prin of Biol II,0.26,0.51,0.12,0.08,0.01,0.0,0.0,0.02,robert kosinski,,BIOL-1110,2015
+BIOL,1110,2,Prin of Biol II,0.43,0.35,0.18,0.0,0.03,0.0,0.0,0.01,dylan dittrich-reed,,BIOL-1110,2015
+BIOL,1110,4,Prin of Biol II  (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True,BIOL-1110,2015
+BIOL,1200,4,Biological Inq Lab,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,5,Biological Inq Lab,0.67,0.17,0.0,0.11,0.06,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,6,Biological Inq Lab,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1200,9,Biological Inq Lab,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,,BIOL-1200,2015
+BIOL,1200,12,Biological Inq Lab,0.5,0.33,0.06,0.0,0.11,0.0,0.0,0.0, christine minor,,BIOL-1200,2015
+BIOL,1220,1,Keys to Biodiversity,0.36,0.2,0.16,0.12,0.12,0.0,0.0,0.04,kalan ickes,,BIOL-1220,2015
+BIOL,1230,1,Keys to Human Biol,0.26,0.33,0.28,0.09,0.04,0.0,0.0,0.01, christine minor,,BIOL-1230,2015
+BIOL,2000,2,Biology in the News,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-2000,2015
+BIOL,2000,4,Biology in the News,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,david tonkyn,,BIOL-2000,2015
+BIOL,2000,5,Biology in the News,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,,BIOL-2000,2015
+BIOL,2000,8,Biology in the News,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,min cao,,BIOL-2000,2015
+BIOL,2000,9,Biology in the News,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,michael sears,,BIOL-2000,2015
+BIOL,2030,1,Human Disease & Soc,0.79,0.14,0.02,0.0,0.0,0.0,0.0,0.05, christine minor,,BIOL-2030,2015
+BIOL,2040,1,"Environ, Energy and Society",0.47,0.26,0.13,0.11,0.01,0.0,0.0,0.02,john jenkins hains,,BIOL-2040,2015
+BIOL,2110,1,Introduction to Toxicology,0.26,0.56,0.12,0.0,0.03,0.0,0.0,0.03,peter van den hurk,,BIOL-2110,2015
+BIOL,2230,1,Human Anat and Physiology II,0.37,0.3,0.18,0.1,0.04,0.0,0.0,0.02,john cummings,,BIOL-2230,2015
+BIOL,2230,2,Human Anat and Physiology II,0.51,0.31,0.15,0.01,0.0,0.0,0.0,0.02,john cummings,,BIOL-2230,2015
+BIOL,3020,1,Invertebrate Biology,0.16,0.42,0.24,0.05,0.05,0.0,0.0,0.08,juan baeza migueles,,BIOL-3020,2015
+BIOL,3040,1,Biology of Plants,0.6,0.29,0.1,0.0,0.02,0.0,0.0,0.0,christina wells,,BIOL-3040,2015
+BIOL,3060,2,Invertebrate Biology Lab,0.05,0.5,0.3,0.1,0.05,0.0,0.0,0.0,juan baeza migueles,,BIOL-3060,2015
+BIOL,3060,4,Invertebrate Biology Lab,0.18,0.35,0.29,0.06,0.0,0.0,0.0,0.12,juan baeza migueles,,BIOL-3060,2015
+BIOL,3080,2,Biology of Plants Practicum,0.63,0.21,0.11,0.0,0.05,0.0,0.0,0.0,robert edwa ballard,,BIOL-3080,2015
+BIOL,3080,3,Biology of Plants Practicum,0.71,0.18,0.06,0.0,0.06,0.0,0.0,0.0,robert edwa ballard,,BIOL-3080,2015
+BIOL,3080,4,Biology of Plants Practicum,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert edwa ballard,,BIOL-3080,2015
+BIOL,3130,1,Conservation Biology,0.28,0.44,0.16,0.12,0.0,0.0,0.0,0.0,shari lyn rodriguez,,BIOL-3130,2015
+BIOL,3130,2,Conservation Biology,0.21,0.37,0.26,0.11,0.0,0.0,0.0,0.05,shari lyn rodriguez,,BIOL-3130,2015
+BIOL,3160,1,Human Physiology,0.29,0.45,0.23,0.02,0.01,0.0,0.0,0.01,tamara mcnutt-scott,,BIOL-3160,2015
+BIOL,3200,1,Field Botany,0.13,0.31,0.28,0.11,0.11,0.0,0.0,0.06,timothy spira,,BIOL-3200,2015
+BIOL,3350,1,Evolutionary Biology,0.19,0.44,0.19,0.06,0.03,0.0,0.0,0.09,lisa rapaport,,BIOL-3350,2015
+BIOL,3510,1,Biological Anthropology,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,katherine weisensee,,BIOL-3510,2015
+BIOL,4010,1,Plant Physiology,0.16,0.19,0.41,0.22,0.03,0.0,0.0,0.0,douglas bielenberg,,BIOL-4010,2015
+BIOL,4020,2,Plant Physiology Lab,0.38,0.5,0.0,0.06,0.06,0.0,0.0,0.0,douglas bielenberg,,BIOL-4020,2015
+BIOL,4020,4,Plant Physiology Lab,0.53,0.24,0.18,0.06,0.0,0.0,0.0,0.0,douglas bielenberg,,BIOL-4020,2015
+BIOL,4030,3,Intro to Applied Genomics,0.18,0.18,0.27,0.0,0.09,0.0,0.0,0.27,vincent pa richards,,BIOL-4030,2015
+BIOL,4100,1,Limnology,0.4,0.25,0.18,0.05,0.0,0.0,0.0,0.13,john jenkins hains,,BIOL-4100,2015
+BIOL,4140,1,Basic Immunology,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,charles rice,,BIOL-4140,2015
+BIOL,4340,1,Biological Chem Lab Techniques,0.17,0.25,0.5,0.08,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2015
+BIOL,4340,2,Biological Chem Lab Techniques,0.0,0.58,0.33,0.08,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2015
+BIOL,4340,3,Biological Chem Lab Techniques,0.09,0.36,0.27,0.09,0.18,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2015
+BIOL,4340,4,Biological Chem Lab Techniques,0.2,0.2,0.3,0.2,0.0,0.0,0.0,0.1,salvatore sparace,,BIOL-4340,2015
+BIOL,4340,5,Biological Chem Lab Techniques,0.0,0.55,0.36,0.09,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2015
+BIOL,4340,6,Biological Chem Lab Techniques,0.1,0.4,0.3,0.0,0.1,0.0,0.0,0.1,salvatore sparace,,BIOL-4340,2015
+BIOL,4400,1,Developmental Animal Biology,0.67,0.07,0.07,0.0,0.0,0.0,0.0,0.2,susan carol chapman,,BIOL-4400,2015
+BIOL,4610,1,Cell Biology,0.23,0.3,0.26,0.14,0.05,0.0,0.0,0.03,lisa bain,,BIOL-4610,2015
+BIOL,4610,2,Cell Biology (HON),0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,lisa bain,True,BIOL-4610,2015
+BIOL,4620,1,Cell Biology Lab (Lec),0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,2,Cell Biology Lab (Lec),0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,3,Cell Biology Lab (Lec),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,4,Cell Biology Lab (Lec),0.44,0.5,0.0,0.06,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,5,Cell Biology Lab (Lec),0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,6,Cell Biology Lab (Lec),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,7,Cell Biology Lab (Lec),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,8,Cell Biology Lab (Lec),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,,BIOL-4620,2015
+BIOL,4620,9,Cell Biology Lab (Lec),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2015
+BIOL,4640,1,Mammalogy,0.06,0.39,0.22,0.11,0.11,0.0,0.0,0.11,john cummings,,BIOL-4640,2015
+BIOL,4670,1,Principles of Hematology,0.83,0.07,0.09,0.0,0.02,0.0,0.0,0.0,vincent gallicchio,,BIOL-4670,2015
+BIOL,4700,1,Behavioral Ecology,0.37,0.42,0.11,0.02,0.06,0.0,0.0,0.01,michael childress,,BIOL-4700,2015
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,michael childress,,BIOL-4710,2015
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.53,0.2,0.0,0.07,0.0,0.0,0.0,0.2,michael childress,,BIOL-4710,2015
+BIOL,4710,3,Behavioral Ecology Lab (Lec),0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,michael childress,,BIOL-4710,2015
+BIOL,4710,4,Behavioral Ecology Lab (Lec),0.69,0.15,0.08,0.0,0.0,0.0,0.0,0.08,michael childress,,BIOL-4710,2015
+BIOL,4930,2,Oceans End & Climate Sr Sem,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,andrew mount,,BIOL-4930,2015
+BIOL,4930,4,Adv Cancer Research Sr Sem,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,,BIOL-4930,2015
+BIOL,6800,1,Vertebrate Endocrinology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,,BIOL-6800,2015
+BIOL,8430,1,Underst Genetics & Evol Biol,0.91,0.05,0.01,0.0,0.02,0.0,0.0,0.01,renea chri hardwick,,BIOL-8430,2015
+BIOL,8450,1,Understanding Vertebrate Biol,0.9,0.08,0.0,0.0,0.02,0.0,0.0,0.0,tamara mcnutt-scott,,BIOL-8450,2015
+BIOL,8470,1,Understanding Microbiology,0.53,0.43,0.03,0.0,0.01,0.0,0.0,0.0,harry kurtz,,BIOL-8470,2015
+BMOL,4250,1,Biomolecular Engineering,0.3,0.4,0.1,0.0,0.0,0.0,0.0,0.2,mark alan blenner,,BMOL-4250,2015
+BUS,1010,1,Business Foundations,0.13,0.4,0.18,0.08,0.05,0.0,0.0,0.15,michael giebner,,BUS-1010,2015
+BUS,1010,2,Business Foundations,0.19,0.51,0.19,0.05,0.02,0.0,0.0,0.05,michael giebner,,BUS-1010,2015
+BUS,1010,3,Business Foundations,0.14,0.52,0.1,0.1,0.1,0.0,0.0,0.03,william ern tumblin,,BUS-1010,2015
+BUS,1010,4,Business Foundations,0.2,0.5,0.17,0.03,0.03,0.0,0.0,0.07,william ern tumblin,,BUS-1010,2015
+BUS,1010,6,Business Foundations,0.13,0.45,0.32,0.03,0.03,0.0,0.0,0.03,william ern tumblin,,BUS-1010,2015
+CE,2010,1,Statics,0.45,0.2,0.16,0.09,0.02,0.0,0.0,0.07,nighat yasmin,,CE-2010,2015
+CE,2010,2,Statics,0.27,0.25,0.23,0.07,0.09,0.0,0.0,0.09,michael pa esposito,,CE-2010,2015
+CE,2010,3,Statics,0.34,0.27,0.2,0.02,0.09,0.0,0.0,0.07,md akhter hossain,,CE-2010,2015
+CE,2010,4,Statics,0.15,0.22,0.27,0.12,0.15,0.0,0.0,0.1,melissa sternhagen,,CE-2010,2015
+CE,2010,5,Statics,0.7,0.16,0.09,0.0,0.02,0.0,0.0,0.02,nighat yasmin,,CE-2010,2015
+CE,2010,6,Statics,0.44,0.23,0.03,0.1,0.08,0.0,0.0,0.13,michael pa esposito,,CE-2010,2015
+CE,2010,7,Statics,0.18,0.12,0.18,0.12,0.24,0.0,0.0,0.18,thomas edfo cousins,,CE-2010,2015
+CE,2060,1,Structural Mechanics,0.19,0.47,0.19,0.13,0.03,0.0,0.0,0.0,bryant nielson,,CE-2060,2015
+CE,2060,2,Structural Mechanics,0.22,0.44,0.27,0.03,0.02,0.0,0.0,0.02,bryant nielson,,CE-2060,2015
+CE,2080,1,Dynamics,0.32,0.43,0.23,0.0,0.0,0.0,0.0,0.02,melissa sternhagen,,CE-2080,2015
+CE,2080,2,Dynamics,0.2,0.59,0.14,0.04,0.0,0.0,0.0,0.02,melissa sternhagen,,CE-2080,2015
+CE,2080,3,Dynamics,0.15,0.63,0.15,0.03,0.0,0.0,0.0,0.05,melissa sternhagen,,CE-2080,2015
+CE,2550,1,Geomatics,0.25,0.42,0.22,0.06,0.01,0.0,0.0,0.04,wayne sarasua,,CE-2550,2015
+CE,3010,1,Structural Analysis,0.22,0.3,0.22,0.16,0.1,0.0,0.0,0.0,stephen csernak,,CE-3010,2015
+CE,3110,1,Transportation Engr,0.22,0.51,0.21,0.01,0.0,0.0,0.0,0.04,wayne sarasua,,CE-3110,2015
+CE,3210,1,Geotechnical Engineering,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,,CE-3210,2015
+CE,3210,2,Geotechnical Engineering,0.3,0.3,0.28,0.1,0.03,0.0,0.0,0.0,charng-hsein juang,,CE-3210,2015
+CE,3310,1,Constr Engr & Mgmnt,0.28,0.36,0.26,0.08,0.0,0.0,0.0,0.02,james burati,,CE-3310,2015
+CE,3410,1,Intro to Fluid Mech,0.15,0.41,0.29,0.07,0.05,0.0,0.0,0.02,nigel gregory kaye,,CE-3410,2015
+CE,3420,1,Hydraulics & Hydro,0.12,0.39,0.27,0.09,0.03,0.0,0.0,0.09,abdul khan,,CE-3420,2015
+CE,3420,2,Hydraulics & Hydro,0.5,0.38,0.1,0.0,0.0,0.0,0.0,0.03,ashok mishra,,CE-3420,2015
+CE,3510,1,Civil Engineering Materials,0.33,0.56,0.05,0.05,0.02,0.0,0.0,0.0,prasada rangaraju,,CE-3510,2015
+CE,3520,1,Econ Eval of Proj,0.35,0.23,0.2,0.15,0.05,0.0,0.0,0.02,yongxi huang,,CE-3520,2015
+CE,3520,2,Econ Eval of Proj,0.53,0.31,0.14,0.02,0.0,0.0,0.0,0.0,bradley putman,,CE-3520,2015
+CE,3530,1,Professional Seminar,0.92,0.06,0.01,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-3530,2015
+CE,4010,1,Matrix Str Analysis,0.08,0.5,0.0,0.08,0.17,0.0,0.0,0.17,bryant nielson,,CE-4010,2015
+CE,4020,1,Reinfor Con Design,0.42,0.36,0.16,0.04,0.02,0.0,0.0,0.0,brandon ross,,CE-4020,2015
+CE,4040,1,Masonry Struct Des,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,atamturktur russcher,,CE-4040,2015
+CE,4110,1,Roadway Geo Design,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ogle,,CE-4110,2015
+CE,4120,1,Urban Transport Plan,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,mashrur chowdhury,,CE-4120,2015
+CE,4210,1,Geotechnical Design,0.26,0.57,0.11,0.06,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-4210,2015
+CE,4330,1,Const Plan & Sched,0.39,0.42,0.15,0.01,0.01,0.0,0.0,0.01, kent nilsson,,CE-4330,2015
+CE,4340,1,Const Est Proj Cont,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4340,2015
+CE,4470,1,Stormwater Managemnt,0.36,0.52,0.08,0.0,0.0,0.0,0.0,0.04,nigel gregory kaye,,CE-4470,2015
+CE,4590,1,Capstone Design Proj,0.52,0.44,0.05,0.0,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2015
+CE,4590,100,Capstone Design Proj,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,,CE-4590,2015
+CE,6010,1,Matrix Str Analysis,0.29,0.52,0.14,0.0,0.05,0.0,0.0,0.0,bryant nielson,,CE-6010,2015
+CE,6040,1,Masonry Struct Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,,CE-6040,2015
+CE,6210,1,Geotechnical Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-6210,2015
+CE,6330,1,Const Plan & Sched,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0, kent nilsson,,CE-6330,2015
+CE,8040,1,Prestressed Concrete,0.49,0.41,0.1,0.0,0.0,0.0,0.0,0.0,brandon ross,,CE-8040,2015
+CE,8080,1,Earthquake Engr,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-8080,2015
+CE,8250,1,Geotech Equake Engr,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-8250,2015
+CE,8270,1,Spec Cements & Concr,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,prasada rangaraju,,CE-8270,2015
+CE,8530,1,Apps in Traffic En,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-8530,2015
+CE,8930,2,Selec Topics in C E - Construc,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,james burati,,CE-8930,2015
+CE,9910,19,Doctoral Dissertation Research,0.0,0.0,0.0,0.0,0.0,0.8,0.2,0.0,leidy klotz,,CE-9910,2015
+CH,1010,1,General Chemistry,0.09,0.23,0.3,0.2,0.12,0.0,0.0,0.06,ava kreider-mueller,,CH-1010,2015
+CH,1010,2,General Chemistry,0.07,0.21,0.3,0.2,0.14,0.0,0.0,0.08,ava kreider-mueller,,CH-1010,2015
+CH,1010,3,General Chemistry,0.17,0.29,0.28,0.11,0.1,0.0,0.0,0.05,dennis taylor,,CH-1010,2015
+CH,1010,4,General Chemistry,0.1,0.19,0.25,0.25,0.13,0.0,0.0,0.08,joseph stu thrasher,,CH-1010,2015
+CH,1010,400,General Chemistry (ONLINE),0.21,0.19,0.36,0.08,0.13,0.0,0.0,0.03,stephe schvaneveldt,,CH-1010,2015
+CH,1020,1,General Chemistry,0.2,0.25,0.2,0.18,0.08,0.0,0.0,0.1,christopher wilson,,CH-1020,2015
+CH,1020,2,General Chemistry,0.19,0.26,0.26,0.12,0.04,0.0,0.0,0.14,christopher wilson,,CH-1020,2015
+CH,1020,3,General Chemistry,0.29,0.38,0.25,0.03,0.01,0.0,0.0,0.03,dennis taylor,,CH-1020,2015
+CH,1020,4,General Chemistry,0.25,0.42,0.22,0.06,0.03,0.0,0.0,0.03,dennis taylor,,CH-1020,2015
+CH,1020,5,General Chemistry,0.15,0.39,0.31,0.07,0.04,0.0,0.0,0.04,olt geiculescu,,CH-1020,2015
+CH,1020,7,General Chemistry,0.21,0.53,0.16,0.06,0.02,0.0,0.0,0.03,kenneth wi rillings,,CH-1020,2015
+CH,1020,8,General Chemistry,0.23,0.4,0.26,0.06,0.02,0.0,0.0,0.03,kenneth wi rillings,,CH-1020,2015
+CH,1020,9,General Chemistry,0.24,0.41,0.23,0.05,0.05,0.0,0.0,0.02,ava kreider-mueller,,CH-1020,2015
+CH,1020,10,General Chemistry,0.21,0.42,0.32,0.04,0.02,0.0,0.0,0.0,kenneth wi rillings,,CH-1020,2015
+CH,1020,11,General Chemistry (CH majors),0.55,0.18,0.24,0.0,0.0,0.0,0.0,0.03,stephe schvaneveldt,,CH-1020,2015
+CH,1020,12,General Chemistry (CLUE),0.36,0.5,0.07,0.02,0.0,0.0,0.0,0.05,kenneth christensen,,CH-1020,2015
+CH,1020,51,General Chemistry (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True,CH-1020,2015
+CH,1020,52,General Chemistry (HON),0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,shiou-jyh hwu,True,CH-1020,2015
+CH,1050,1,Chem in Context I,0.27,0.45,0.24,0.03,0.0,0.0,0.0,0.01,thomas hickman,,CH-1050,2015
+CH,1060,1,Chem in Context II,0.36,0.61,0.0,0.0,0.04,0.0,0.0,0.0,olt geiculescu,,CH-1060,2015
+CH,1060,2,Chem in Context II,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,olt geiculescu,,CH-1060,2015
+CH,1520,1,Chem Commun I,0.83,0.02,0.02,0.0,0.0,0.0,0.0,0.13,richard marcus,,CH-1520,2015
+CH,2010,1,Survey of Organic Chemistry,0.37,0.26,0.19,0.1,0.04,0.0,0.0,0.03,tania issa houjeiry,,CH-2010,2015
+CH,2020,1,Surv of Organic Chemistry Lab,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,,CH-2020,2015
+CH,2020,2,Surv of Organic Chemistry Lab,0.53,0.29,0.12,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2020,2015
+CH,2020,3,Surv of Organic Chemistry Lab,0.71,0.18,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,,CH-2020,2015
+CH,2050,1,Intro Inorg Chem,0.54,0.29,0.17,0.0,0.0,0.0,0.0,0.0,william pennington,,CH-2050,2015
+CH,2230,1,Organic Chemistry,0.23,0.3,0.12,0.12,0.17,0.0,0.0,0.07,jacob schroeder,,CH-2230,2015
+CH,2230,2,Organic Chemistry,0.44,0.27,0.14,0.06,0.03,0.0,0.0,0.06,jacob schroeder,,CH-2230,2015
+CH,2230,3,Organic Chemistry,0.35,0.33,0.08,0.07,0.11,0.0,0.0,0.07,jacob schroeder,,CH-2230,2015
+CH,2240,1,Organic Chemistry,0.39,0.43,0.12,0.05,0.0,0.0,0.0,0.01,tania issa houjeiry,,CH-2240,2015
+CH,2240,2,Organic Chemistry,0.29,0.57,0.09,0.03,0.02,0.0,0.0,0.0,thomas hickman,,CH-2240,2015
+CH,2240,3,Organic Chemistry,0.22,0.39,0.24,0.1,0.02,0.0,0.0,0.04,thomas hickman,,CH-2240,2015
+CH,2240,4,Organic Chemistry,0.37,0.26,0.09,0.12,0.07,0.0,0.0,0.09,rhett smith,,CH-2240,2015
+CH,2240,5,Organic Chemistry,0.33,0.4,0.18,0.02,0.04,0.0,0.0,0.04,jacob schroeder,,CH-2240,2015
+CH,2270,1,Organic Chem Lab,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2015
+CH,2270,5,Organic Chem Lab,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2015
+CH,2270,8,Organic Chem Lab,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2015
+CH,2270,9,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2015
+CH,2280,1,Organic Chem Lab,0.62,0.08,0.0,0.0,0.0,0.0,0.0,0.31,sean 'connor,,CH-2280,2015
+CH,2280,2,Organic Chem Lab,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,,CH-2280,2015
+CH,2280,3,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2280,2015
+CH,2280,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2280,2015
+CH,2280,7,Organic Chem Lab,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2280,2015
+CH,2280,8,Organic Chem Lab,0.73,0.13,0.0,0.07,0.0,0.0,0.0,0.07,sean 'connor,,CH-2280,2015
+CH,2280,12,Organic Chem Lab,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2015
+CH,2280,21,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,sean 'connor,,CH-2280,2015
+CH,2280,24,Organic Chem Lab,0.63,0.19,0.13,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2280,2015
+CH,2290,3,Organic Chem Lab,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2290,2015
+CH,3310,1,Physical Chemistry,0.42,0.32,0.11,0.05,0.0,0.0,0.0,0.11,arkady kholodenko,,CH-3310,2015
+CH,3320,1,Physical Chemistry (ENGR only),0.49,0.33,0.13,0.03,0.01,0.0,0.0,0.0,steven stuart,,CH-3320,2015
+CH,3320,2,Physical Chemistry (CH majors),0.42,0.29,0.21,0.04,0.04,0.0,0.0,0.0,jason mcneill,,CH-3320,2015
+CH,3400,2,Physical Chem Lab,0.78,0.17,0.0,0.06,0.0,0.0,0.0,0.0,christopher wilson,,CH-3400,2015
+CH,3400,3,Physical Chem Lab,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,christopher wilson,,CH-3400,2015
+CH,3400,4,Physical Chem Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,,CH-3400,2015
+CH,3600,1,Chemical Biology,0.38,0.27,0.17,0.1,0.0,0.0,0.0,0.08,modi wetzler,,CH-3600,2015
+CH,4110,1,Instrumental Analy,0.23,0.32,0.09,0.18,0.18,0.0,0.0,0.0,george chumanov,,CH-4110,2015
+CH,4120,1,Instr Analysis Lab,0.33,0.25,0.25,0.08,0.08,0.0,0.0,0.0,jeffrey natha anker,,CH-4120,2015
+CH,4120,2,Instr Analysis Lab,0.55,0.27,0.09,0.09,0.0,0.0,0.0,0.0,jeffrey natha anker,,CH-4120,2015
+CH,4130,1,Chem Aqueous Systems,0.42,0.32,0.11,0.0,0.0,0.0,0.0,0.16,cindy lee,,CH-4130,2015
+CH,4500,1,Chemistry Capstone,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,,CH-4500,2015
+CH,8090,1,Chem App/X-Ray Cryst,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,,CH-8090,2015
+CH,8130,1,Electrochem Sci,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,stephen creager,,CH-8130,2015
+CH,8510,1,Grad Student Seminar,0.82,0.07,0.07,0.0,0.04,0.0,0.0,0.0,joseph stu thrasher,,CH-8510,2015
+CHE,1300,1,Chemical Eng Tools,0.27,0.41,0.14,0.02,0.08,0.0,0.0,0.08,christopher norfolk,,CHE-1300,2015
+CHE,1300,2,Chemical Eng Tools,0.35,0.33,0.15,0.09,0.03,0.0,0.0,0.05,christopher norfolk,,CHE-1300,2015
+CHE,2200,1,Ch E Thermo I,0.22,0.2,0.27,0.1,0.16,0.0,0.0,0.06,mark thies,,CHE-2200,2015
+CHE,2200,2,Ch E Thermo I,0.25,0.19,0.25,0.17,0.14,0.0,0.0,0.0,mark thies,,CHE-2200,2015
+CHE,2300,1,Fluids/Heat Transfer,0.12,0.22,0.41,0.14,0.06,0.0,0.0,0.04,douglas hirt,,CHE-2300,2015
+CHE,2300,2,Fluids/Heat Transfer,0.19,0.33,0.19,0.19,0.08,0.0,0.0,0.0,douglas hirt,,CHE-2300,2015
+CHE,3210,1,Ch E Thermo II,0.23,0.23,0.39,0.09,0.07,0.0,0.0,0.0,christophe kitchens,,CHE-3210,2015
+CHE,3300,1,Mass Trans & Seprtn,0.23,0.32,0.25,0.08,0.12,0.0,0.0,0.0,mark alan blenner,,CHE-3300,2015
+CHE,3530,1,Proc Dyn & Control,0.22,0.49,0.24,0.04,0.02,0.0,0.0,0.0,mark roberts,,CHE-3530,2015
+CHE,4330,1,Process Design II,0.57,0.37,0.06,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4330,2015
+CHE,4990,14,CI- Membrane Separations,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,scott husson,,CHE-4990,2015
+CHIN,1010,1,Elementary Chinese,0.47,0.26,0.16,0.11,0.0,0.0,0.0,0.0,yanhua zhang,,CHIN-1010,2015
+CHIN,1020,1,Elementary Chinese,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,yanming an,,CHIN-1020,2015
+COM,1500,1,Intro to Human Com,0.89,0.07,0.01,0.0,0.01,0.0,0.0,0.03,eddie smith,,COM-1500,2015
+COM,1500,2,Intro to Human Com,0.49,0.44,0.03,0.01,0.01,0.0,0.0,0.01,daniel lelan fecher,,COM-1500,2015
+COM,1500,3,Intro to Human Com,0.85,0.13,0.0,0.0,0.01,0.0,0.0,0.01,eddie smith,,COM-1500,2015
+COM,1500,4,Intro to Human Com,0.78,0.16,0.02,0.01,0.01,0.0,0.0,0.02,marianne her glaser,,COM-1500,2015
+COM,1500,5,Intro to Human Com,0.66,0.28,0.03,0.01,0.0,0.0,0.0,0.02,marianne her glaser,,COM-1500,2015
+COM,1500,6,Intro to Human Com,0.54,0.41,0.04,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,,COM-1500,2015
+COM,1500,6,Intro to Human Communication,0.54,0.41,0.04,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,,COM-1500,2015
+COM,2010,1,Intr to Comm Studies,0.44,0.36,0.2,0.0,0.0,0.0,0.0,0.0,brenden kendall,,COM-2010,2015
+COM,2010,2,Intr to Comm Studies,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-2010,2015
+COM,2500,1,Public Speaking,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2015
+COM,2500,2,Public Speaking,0.47,0.32,0.05,0.05,0.0,0.0,0.0,0.11,marilyn denise pugh,,COM-2500,2015
+COM,2500,3,Public Speaking,0.5,0.45,0.0,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2015
+COM,2500,4,Public Speaking,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2015
+COM,2500,5,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2015
+COM,2500,6,Public Speaking,0.45,0.4,0.1,0.0,0.05,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2015
+COM,2500,7,Public Speaking,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2015
+COM,2500,8,Public Speaking,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2015
+COM,2500,10,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2015
+COM,2500,11,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,,COM-2500,2015
+COM,2500,13,Public Speaking,0.26,0.53,0.16,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,,COM-2500,2015
+COM,2500,14,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,,COM-2500,2015
+COM,2500,15,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,,COM-2500,2015
+COM,2500,16,Public Speaking,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,the estate  geddes,,COM-2500,2015
+COM,2500,17,Public Speaking,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,pauline matthey,,COM-2500,2015
+COM,2500,18,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2015
+COM,2500,19,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2015
+COM,2500,20,Public Speaking,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,pauline matthey,,COM-2500,2015
+COM,2500,21,Public Speaking,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2015
+COM,2500,22,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2015
+COM,2500,23,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2015
+COM,2500,24,Public Speaking,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,pauline matthey,,COM-2500,2015
+COM,2500,28,Public Speaking,0.26,0.53,0.05,0.05,0.0,0.0,0.0,0.11,marilyn denise pugh,,COM-2500,2015
+COM,2500,400,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2015
+COM,2500,401,Public Speaking,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2015
+COM,2500,402,Public Speaking,0.72,0.11,0.0,0.06,0.0,0.0,0.0,0.11,alexis zachar davis,,COM-2500,2015
+COM,2500,403,Public Speaking,0.63,0.26,0.0,0.05,0.05,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2015
+COM,2500,500,Public Speaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2015
+COM,2500,501,Public Speaking,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2015
+COM,3010,1,Comm Theory,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-3010,2015
+COM,3020,1,Mass Comm Theory,0.62,0.3,0.04,0.04,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3020,2015
+COM,3080,1,Pub Comm & Pop Cult,0.29,0.42,0.19,0.03,0.0,0.0,0.0,0.06,chenjerai kumanyika,,COM-3080,2015
+COM,3100,1,Quant Comm Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3100,2015
+COM,3110,1,Qual Comm Methods,0.58,0.25,0.13,0.0,0.04,0.0,0.0,0.0,stephanie pangborn,,COM-3110,2015
+COM,3200,1,Bdcst Production,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,wanda johnson,,COM-3200,2015
+COM,3260,1,Pr in Sports,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2015
+COM,3480,1,Interpersonal Comm,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,melinda ra weathers,,COM-3480,2015
+COM,3500,1,Sm Group & Team Comm,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,joseph mazer,,COM-3500,2015
+COM,3560,1,Stakeholder Comm,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3560,2015
+COM,3660,1,EP: Advertising & Media,0.56,0.32,0.04,0.04,0.0,0.0,0.0,0.04,william reynolds,,COM-3660,2015
+COM,3660,2,EP: Building the Brand,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,andrew mendelsohn,,COM-3660,2015
+COM,3660,3,Live Broadcast Production,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,michael rodgers,,COM-3660,2015
+COM,3680,1,Applied Digital Communication,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,,COM-3680,2015
+COM,3990,6,CI: Tigers Talk Ethics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,,COM-3990,2015
+COM,4260,1,Social Media and Sports Comm,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4260,2015
+COM,4260,2,Social Media and Sports Comm,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4260,2015
+COM,4700,1,Comm & Health,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,stephanie pangborn,,COM-4700,2015
+COM,4950,1,Sr. Capstone: Agenda Building,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,bryan denham,,COM-4950,2015
+COM,4950,2,Sr. Capstone: Advert. & Sport,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4950,2015
+COM,8110,1,Comm Research Methods II,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,chenjerai kumanyika,,COM-8110,2015
+CPSC,1010,1,Computer Science I,0.19,0.18,0.19,0.12,0.14,0.0,0.0,0.18,catherine hochrine,,CPSC-1010,2015
+CPSC,1010,2,Computer Science I,0.61,0.24,0.1,0.0,0.0,0.0,0.0,0.05,lauren elizab dukes,,CPSC-1010,2015
+CPSC,1020,1,Computer Science II,0.48,0.24,0.08,0.0,0.08,0.0,0.0,0.12,catherine hochrine,,CPSC-1020,2015
+CPSC,1020,2,Computer Science II,0.62,0.12,0.04,0.0,0.04,0.0,0.0,0.19,yvon feaster,,CPSC-1020,2015
+CPSC,1020,3,Computer Science II,0.68,0.04,0.08,0.0,0.08,0.0,0.0,0.12,yvon feaster,,CPSC-1020,2015
+CPSC,1020,4,Computer Science II,0.33,0.24,0.14,0.05,0.05,0.0,0.0,0.19,joshua levine,,CPSC-1020,2015
+CPSC,1110,1,Intro to Programming in C,0.68,0.25,0.0,0.0,0.04,0.0,0.0,0.04,patrick sterling,,CPSC-1110,2015
+CPSC,1110,2,Intro to Programming in C,0.77,0.1,0.07,0.03,0.0,0.0,0.0,0.03,patrick sterling,,CPSC-1110,2015
+CPSC,1110,3,Intro to Programming in C,0.57,0.2,0.07,0.07,0.03,0.0,0.0,0.07,patrick sterling,,CPSC-1110,2015
+CPSC,1110,4,Intro to Programming in C,0.63,0.04,0.04,0.04,0.15,0.0,0.0,0.11,toni bloodwor pence,,CPSC-1110,2015
+CPSC,1200,1,Intro Info Tech,0.82,0.06,0.0,0.0,0.06,0.0,0.0,0.06,renee lambert,,CPSC-1200,2015
+CPSC,2070,1,Discrete Structures,0.34,0.25,0.18,0.02,0.09,0.0,0.0,0.11,sandra hedetniemi,,CPSC-2070,2015
+CPSC,2070,401,Discrete Structures,0.2,0.34,0.25,0.13,0.05,0.0,0.0,0.04,larry hodges,,CPSC-2070,2015
+CPSC,2100,1,Progrmng Methodology,0.23,0.23,0.23,0.06,0.2,0.0,0.0,0.06,rose lowe,,CPSC-2100,2015
+CPSC,2120,1,Algs/Data Structures,0.36,0.31,0.16,0.05,0.12,0.0,0.0,0.01,wayne goddard,,CPSC-2120,2015
+CPSC,2150,1,Software Dev Fndtns,0.35,0.39,0.15,0.07,0.02,0.0,0.0,0.02,yu-shan sun,,CPSC-2150,2015
+CPSC,2150,2,Software Dev Fndtns,0.23,0.21,0.32,0.06,0.11,0.0,0.0,0.06,blair madiso durkee,,CPSC-2150,2015
+CPSC,2200,1,Microcomputer Appl,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,patrick sterling,,CPSC-2200,2015
+CPSC,2310,1,Intro Computer Org,0.21,0.31,0.36,0.05,0.05,0.0,0.0,0.03,rose lowe,,CPSC-2310,2015
+CPSC,2310,2,Intro Computer Org,0.32,0.32,0.24,0.0,0.09,0.0,0.0,0.03,rose lowe,,CPSC-2310,2015
+CPSC,2910,2,Prof Issues I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,renee lambert,,CPSC-2910,2015
+CPSC,2910,3,Prof Issues I,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,renee lambert,,CPSC-2910,2015
+CPSC,2910,4,Prof Issues I,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,renee lambert,,CPSC-2910,2015
+CPSC,2910,5,Prof Issues I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james jones,,CPSC-2910,2015
+CPSC,2910,6,Prof Issues I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,james jones,,CPSC-2910,2015
+CPSC,2910,7,Prof Issues I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,james jones,,CPSC-2910,2015
+CPSC,3220,1,Intro to Operating Systems,0.26,0.21,0.23,0.05,0.18,0.0,0.0,0.08,jacob sorber,,CPSC-3220,2015
+CPSC,3220,2,Intro to Operating Systems,0.17,0.14,0.2,0.09,0.17,0.0,0.0,0.23,jacob sorber,,CPSC-3220,2015
+CPSC,3300,1,Computer Systems Org,0.27,0.24,0.26,0.06,0.1,0.0,0.0,0.06,mark smotherman,,CPSC-3300,2015
+CPSC,3500,1,Foundations of Computer Sci,0.15,0.23,0.37,0.1,0.06,0.0,0.0,0.1,ilya mark safro,,CPSC-3500,2015
+CPSC,3520,1,Programming Systems,0.41,0.3,0.05,0.0,0.09,0.0,0.0,0.16,robert schalkoff,,CPSC-3520,2015
+CPSC,3600,1,Network Programming,0.16,0.27,0.25,0.16,0.1,0.0,0.0,0.06,sekou lionel remy,,CPSC-3600,2015
+CPSC,3620,1,Distributed Computng,0.29,0.38,0.15,0.08,0.04,0.0,0.0,0.06,linh bao ngo,,CPSC-3620,2015
+CPSC,3720,1,Software Engineering,0.17,0.39,0.3,0.04,0.04,0.0,0.0,0.04,stephen schaub,,CPSC-3720,2015
+CPSC,3720,2,Software Engineering,0.26,0.29,0.29,0.1,0.03,0.0,0.0,0.03,stephen schaub,,CPSC-3720,2015
+CPSC,4050,1,Computer Graphics,0.26,0.52,0.13,0.04,0.0,0.0,0.0,0.04,robert geist,,CPSC-4050,2015
+CPSC,4140,1,Human and Computer Interaction,0.35,0.48,0.04,0.04,0.09,0.0,0.0,0.0,sabarish venka babu,,CPSC-4140,2015
+CPSC,4140,2,Human and Computer Interaction,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,kelly caine,,CPSC-4140,2015
+CPSC,4160,1,2-D Game Engine Construction,0.5,0.33,0.1,0.0,0.07,0.0,0.0,0.0,brian malloy,,CPSC-4160,2015
+CPSC,4240,1,System Admin and Security,0.15,0.58,0.19,0.04,0.04,0.0,0.0,0.0,james martin,,CPSC-4240,2015
+CPSC,4620,1,Database Management Systems,0.22,0.44,0.22,0.07,0.04,0.0,0.0,0.0,zijun wang,,CPSC-4620,2015
+CPSC,4820,1,Design & Implementation,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,christina sop joerg,,CPSC-4820,2015
+CPSC,4820,2,Mobile Device,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,roy pargas,,CPSC-4820,2015
+CPSC,4910,1,Prof Issues II,0.93,0.04,0.0,0.0,0.02,0.0,0.0,0.0,james jones,,CPSC-4910,2015
+CPSC,6050,1,Computer Graphics,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,robert geist,,CPSC-6050,2015
+CPSC,6140,1,Human and Computer Interaction,0.57,0.29,0.07,0.0,0.0,0.0,0.0,0.07,sabarish venka babu,,CPSC-6140,2015
+CPSC,6140,2,Human and Computer Interaction,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,kelly caine,,CPSC-6140,2015
+CPSC,6160,1,2-D Game Engine Construction,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,brian malloy,,CPSC-6160,2015
+CPSC,6240,1,System Admin and Security,0.57,0.29,0.07,0.0,0.0,0.0,0.0,0.07,james martin,,CPSC-6240,2015
+CPSC,6620,1,Database Management Systems,0.46,0.27,0.19,0.0,0.08,0.0,0.0,0.0,zijun wang,,CPSC-6620,2015
+CPSC,6820,1,Special Topics:Design & Imple,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,CPSC-6820,2015
+CPSC,8080,1,Advanced Animation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,,CPSC-8080,2015
+CPSC,8090,1,Render and Shade,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,,CPSC-8090,2015
+CPSC,8220,1,Case Study in Operating Sys,0.27,0.67,0.0,0.0,0.0,0.0,0.0,0.07,robert geist,,CPSC-8220,2015
+CPSC,8280,1,Theory of Program. Languages,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,murali sitaraman,,CPSC-8280,2015
+CPSC,8550,1,Embedded Network Sys,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,yvon feaster,,CPSC-8550,2015
+CPSC,8620,1,Database Mngmt System Design,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,zijun wang,,CPSC-8620,2015
+CPSC,8630,1,Multimedia Sys/Apps,0.27,0.5,0.14,0.0,0.05,0.0,0.0,0.05,zijun wang,,CPSC-8630,2015
+CPSC,8750,1,Software Architectur,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,john mcgregor,,CPSC-8750,2015
+CPSC,8810,1,Topic:Info Retrieval,0.23,0.65,0.1,0.0,0.0,0.0,0.0,0.03,feng luo,,CPSC-8810,2015
+CPSC,8810,2,Advanced Networking & Security,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,hongxin hu,,CPSC-8810,2015
+CRP,8020,1,Site Planning,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,clifford dona ellis,,CRP-8020,2015
+CRP,8040,1,Land Use Analysis,0.82,0.0,0.12,0.0,0.0,0.0,0.0,0.06,stephen sperry,,CRP-8040,2015
+CRP,8050,1,Plning Theory & Hist,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,mickey lauria,,CRP-8050,2015
+CRP,8090,1,Current Issues,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,,CRP-8090,2015
+CRP,8130,1,Transportation Plan,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,,CRP-8130,2015
+CRP,8200,1,Negotiation,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,,CRP-8200,2015
+CRP,8220,1,Urban Design,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,CRP-8220,2015
+CSM,1500,1,Constr Prob Solving,0.39,0.56,0.0,0.0,0.06,0.0,0.0,0.0,jason lucas,,CSM-1500,2015
+CSM,1500,2,Constr Prob Solving,0.57,0.24,0.19,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-1500,2015
+CSM,1500,3,Constr Prob Solving,0.3,0.6,0.05,0.05,0.0,0.0,0.0,0.0,jason lucas,,CSM-1500,2015
+CSM,2020,1,Structures II,0.24,0.38,0.24,0.14,0.0,0.0,0.0,0.0,shima clarke,,CSM-2020,2015
+CSM,2020,2,Structures II,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,shima clarke,,CSM-2020,2015
+CSM,2040,1,Cont Documents,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2040,2015
+CSM,2040,2,Cont Documents,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2040,2015
+CSM,2050,1,Mats & Methods II,0.37,0.33,0.22,0.07,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2050,2015
+CSM,2050,2,Mats & Methods II,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2050,2015
+CSM,3050,1,Envir Systems II,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3050,2015
+CSM,3050,2,Envir Systems II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3050,2015
+CSM,3520,1,Const Scheduling,0.2,0.5,0.25,0.0,0.0,0.0,0.0,0.05,christine piper,,CSM-3520,2015
+CSM,3520,2,Const Scheduling,0.16,0.32,0.53,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-3520,2015
+CSM,3530,1,Const Estimating II,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,james packer smith,,CSM-3530,2015
+CSM,3530,2,Const Estimating II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,james packer smith,,CSM-3530,2015
+CSM,4540,1,Const Capstone,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4540,2015
+CSM,4540,2,Const Capstone,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4540,2015
+CSM,8610,1,Construction Control Systems,0.07,0.67,0.27,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-8610,2015
+CSM,8610,400,Construction Control Systems,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,christine piper,,CSM-8610,2015
+CSM,8810,1,Professional Seminar,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-8810,2015
+CSM,8810,400,Professional Seminar,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-8810,2015
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.06,0.03,jeffrey appling,,CU-1000,2015
+CU,1010,1,Univ Success Skills,0.83,0.04,0.04,0.04,0.0,0.0,0.0,0.04,rise jean sheriff,,CU-1010,2015
+CU,1010,2,Univ Success Skills,0.68,0.05,0.14,0.05,0.0,0.0,0.0,0.09,cecelia hamby,,CU-1010,2015
+CU,1010,3,Univ Success Skills,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,matthew james kirk,,CU-1010,2015
+CU,1010,4,Univ Success Skills,0.41,0.55,0.0,0.0,0.03,0.0,0.0,0.0,matthew james kirk,,CU-1010,2015
+CU,1010,5,Univ Success Skills,0.54,0.33,0.04,0.0,0.0,0.0,0.0,0.08,mary mcp von kaenel,,CU-1010,2015
+CU,1010,6,Univ Success Skills,0.65,0.17,0.13,0.0,0.04,0.0,0.0,0.0,robert dav brackett,,CU-1010,2015
+CU,1010,7,Univ Success Skills,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,deborah ann vaughn,,CU-1010,2015
+CU,2010,1,Sustainability Leadership,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,,CU-2010,2015
+DPA,3070,1,Method 3d Production,0.52,0.19,0.05,0.1,0.0,0.0,0.0,0.14,virginia ba nearing,,DPA-3070,2015
+DPA,8600,1,Production Studio,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,,DPA-8600,2015
+DPA,8600,2,Production Studio,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,,DPA-8600,2015
+ECE,2010,1,Logic & Comp Device,0.19,0.32,0.18,0.19,0.09,0.0,0.0,0.04,lin zhu,,ECE-2010,2015
+ECE,2020,1,Electric Circuits I,0.14,0.22,0.29,0.18,0.12,0.0,0.0,0.04,william harrell,,ECE-2020,2015
+ECE,2070,1,Basic Electrical Engineering,0.44,0.24,0.14,0.05,0.04,0.0,0.0,0.09,surya sharma,,ECE-2070,2015
+ECE,2070,2,Basic Electrical Engineering,0.56,0.33,0.1,0.01,0.0,0.0,0.0,0.0,hai xiao,,ECE-2070,2015
+ECE,2070,3,Basic Electrical Engineering,0.89,0.04,0.05,0.0,0.0,0.0,0.0,0.01,sung- kim,,ECE-2070,2015
+ECE,2080,5,Electrical Engineering Lab I,0.8,0.1,0.0,0.05,0.0,0.0,0.0,0.05,william harrell,,ECE-2080,2015
+ECE,2080,8,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,william harrell,,ECE-2080,2015
+ECE,2080,13,Electrical Engineering Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,,ECE-2080,2015
+ECE,2080,17,Electrical Engineering Lab I,0.78,0.06,0.06,0.0,0.06,0.0,0.0,0.06,william harrell,,ECE-2080,2015
+ECE,2080,18,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,william harrell,,ECE-2080,2015
+ECE,2080,20,Electrical Engineering Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2080,2015
+ECE,2090,4,Logic Lab,0.67,0.08,0.08,0.08,0.0,0.0,0.0,0.08,william harrell,,ECE-2090,2015
+ECE,2220,1,Syst Prog Concept,0.23,0.21,0.23,0.12,0.1,0.0,0.0,0.12,william reid,,ECE-2220,2015
+ECE,2230,1,Comp Sys Eng,0.2,0.12,0.32,0.05,0.15,0.0,0.0,0.17,harlan russell,,ECE-2230,2015
+ECE,2620,1,Elec Circuits II,0.33,0.27,0.23,0.09,0.07,0.0,0.0,0.01,richard groff,,ECE-2620,2015
+ECE,2620,2,Elec Circuits II (HON),0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True,ECE-2620,2015
+ECE,2720,1,Comp Organization,0.28,0.31,0.25,0.11,0.05,0.0,0.0,0.0,william reid,,ECE-2720,2015
+ECE,2720,1,,0.28,0.31,0.25,0.11,0.05,0.0,0.0,0.0,william reid,,ECE-2720,2015
+ECE,2730,1,Computer Org Lab,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2730,2015
+ECE,2730,3,Computer Org Lab,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,william harrell,,ECE-2730,2015
+ECE,2730,4,Computer Org Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2730,2015
+ECE,2730,5,Computer Org Lab,0.71,0.14,0.07,0.0,0.07,0.0,0.0,0.0,william harrell,,ECE-2730,2015
+ECE,2730,6,Computer Org Lab,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2730,2015
+ECE,2730,7,Computer Org Lab,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-2730,2015
+ECE,3110,1,Electrical Engineering Lab III,0.56,0.13,0.0,0.13,0.13,0.0,0.0,0.06,william harrell,,ECE-3110,2015
+ECE,3110,4,Electrical Engineering Lab III,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,william harrell,,ECE-3110,2015
+ECE,3110,5,Electrical Engineering Lab III,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,,ECE-3110,2015
+ECE,3170,1,Rand Signal Analysis,0.16,0.34,0.2,0.09,0.13,0.0,0.0,0.08,stephen hubbard,,ECE-3170,2015
+ECE,3170,2,Rand Signal Analysis (HON),0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,carl baum,True,ECE-3170,2015
+ECE,3200,1,Electronics I,0.28,0.22,0.15,0.13,0.2,0.0,0.0,0.03,stephen hubbard,,ECE-3200,2015
+ECE,3210,1,Electronics II,0.55,0.27,0.09,0.02,0.08,0.0,0.0,0.0,stephen hubbard,,ECE-3210,2015
+ECE,3220,1,Intro Operating Sys,0.06,0.41,0.35,0.06,0.0,0.0,0.0,0.12,jacob sorber,,ECE-3220,2015
+ECE,3220,2,Intro Operating Sys,0.05,0.35,0.4,0.05,0.05,0.0,0.0,0.1,jacob sorber,,ECE-3220,2015
+ECE,3270,1,Dig Comp Design,0.1,0.26,0.26,0.08,0.08,0.0,0.0,0.23,melissa crawl smith,,ECE-3270,2015
+ECE,3300,1,Signals & Systems,0.21,0.19,0.23,0.14,0.14,0.0,0.0,0.08,carl baum,,ECE-3300,2015
+ECE,3520,1,Programming Systems,0.28,0.48,0.14,0.03,0.0,0.0,0.0,0.07,robert schalkoff,,ECE-3520,2015
+ECE,3600,1,Elect Power Engr,0.25,0.29,0.25,0.06,0.06,0.0,0.0,0.08,edward collins,,ECE-3600,2015
+ECE,3710,1,Microcontr Interface,0.4,0.38,0.2,0.01,0.01,0.0,0.0,0.0,william reid,,ECE-3710,2015
+ECE,3720,6,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-3720,2015
+ECE,3800,1,Electromagnetics,0.23,0.18,0.36,0.13,0.1,0.0,0.0,0.0,anthony martin,,ECE-3800,2015
+ECE,3810,1,Field Waves & Ckts,0.45,0.33,0.16,0.04,0.02,0.0,0.0,0.0,eric gordon johnson,,ECE-3810,2015
+ECE,4090,1,Cont & Discrete Sys,0.37,0.4,0.17,0.06,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4090,2015
+ECE,4190,1,Elec Mach and Drives,0.28,0.38,0.21,0.0,0.03,0.0,0.0,0.1,keith corzine,,ECE-4190,2015
+ECE,4270,1,Communications Sys,0.24,0.29,0.3,0.09,0.05,0.0,0.0,0.03,madhabi manandhar,,ECE-4270,2015
+ECE,4380,1,Computer Commun,0.28,0.18,0.23,0.13,0.05,0.0,0.0,0.15,harlan russell,,ECE-4380,2015
+ECE,4680,1,Embedded Computing,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,adam hoover,,ECE-4680,2015
+ECE,4700,1,Vehicle Electronics,0.54,0.35,0.06,0.04,0.0,0.0,0.0,0.0,todd hubing,,ECE-4700,2015
+ECE,4950,1,Int Sys Design I,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4950,2015
+ECE,4960,1,Int Sys Design II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2015
+ECE,6190,1,Elec Mach and Drives,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,keith corzine,,ECE-6190,2015
+ECE,6380,1,Computer Commun,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,,ECE-6380,2015
+ECE,6460,1,Antennas,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,anthony martin,,ECE-6460,2015
+ECE,6680,1,Embedded Computing,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,adam hoover,,ECE-6680,2015
+ECE,6930,1,MEMS,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,,ECE-6930,2015
+ECE,8070,1,Comp Meth Pwr Anal,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,gan venayagamoorthy,,ECE-8070,2015
+ECE,8160,1,Elec Power Distr Sys Engr,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,elham makram,,ECE-8160,2015
+ECE,8300,1,Electromagnetics I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,anthony martin,,ECE-8300,2015
+ECE,8400,1,Semicond Devices,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-8400,2015
+ECE,8440,1,Digital Signal Proc,0.43,0.52,0.05,0.0,0.0,0.0,0.0,0.0,john gowdy,,ECE-8440,2015
+ECE,8560,1,Pattern Recognition,0.37,0.46,0.11,0.0,0.0,0.0,0.0,0.06,robert schalkoff,,ECE-8560,2015
+ECE,8930,3,HPC with GPUs,0.32,0.52,0.08,0.0,0.0,0.0,0.0,0.08,melissa crawl smith,,ECE-8930,2015
+ECE,8930,4,Distributed Dynamical Systems,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,yongqiang wang,,ECE-8930,2015
+ECON,2000,1,Economic Concepts,0.05,0.35,0.23,0.1,0.18,0.0,0.0,0.1,mallika garg,,ECON-2000,2015
+ECON,2000,2,Economic Concepts,0.31,0.39,0.17,0.08,0.03,0.0,0.0,0.03,mallika garg,,ECON-2000,2015
+ECON,2000,3,Economic Concepts,0.3,0.28,0.15,0.08,0.15,0.0,0.0,0.05,miren ivankovic,,ECON-2000,2015
+ECON,2110,1,Principles of Microeconomics,0.36,0.21,0.33,0.03,0.03,0.0,0.0,0.05,robert dew tollison,,ECON-2110,2015
+ECON,2110,2,Principles of Microeconomics,0.15,0.48,0.3,0.03,0.03,0.0,0.0,0.03,alexander fiore,,ECON-2110,2015
+ECON,2110,3,Principles of Microeconomics,0.14,0.49,0.25,0.07,0.03,0.0,0.0,0.03,adam millsap,,ECON-2110,2015
+ECON,2110,4,Principles of Microeconomics,0.32,0.37,0.15,0.05,0.02,0.0,0.0,0.1,amanda caitlin kerr,,ECON-2110,2015
+ECON,2110,5,Principles of Microeconomics,0.18,0.38,0.4,0.0,0.03,0.0,0.0,0.03,molly espey,,ECON-2110,2015
+ECON,2110,6,Principles of Microeconomics,0.29,0.26,0.14,0.1,0.14,0.0,0.0,0.07,andew swanson,,ECON-2110,2015
+ECON,2110,7,Principles of Microeconomics,0.28,0.41,0.24,0.03,0.03,0.0,0.0,0.02,alexander fiore,,ECON-2110,2015
+ECON,2110,8,Principles of Microeconomics,0.29,0.26,0.26,0.08,0.05,0.0,0.0,0.06,timothy andr bersak,,ECON-2110,2015
+ECON,2110,10,Principles of Microeconomics,0.23,0.34,0.26,0.06,0.0,0.0,0.0,0.11,anne anders,,ECON-2110,2015
+ECON,2110,11,Principles of Microeconomics,0.39,0.32,0.23,0.07,0.0,0.0,0.0,0.0,amanda caitlin kerr,,ECON-2110,2015
+ECON,2110,12,Principles of Microeconomics,0.1,0.58,0.25,0.05,0.0,0.0,0.0,0.03,molly espey,,ECON-2110,2015
+ECON,2120,1,Principles of Macro,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,2,Principles of Macro,0.17,0.22,0.56,0.06,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,3,Principles of Macro,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,4,Principles of Macro,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,5,Principles of Macro,0.41,0.24,0.29,0.0,0.0,0.0,0.0,0.06,scott baier,,ECON-2120,2015
+ECON,2120,6,Principles of Macro,0.11,0.56,0.22,0.0,0.06,0.0,0.0,0.06,scott baier,,ECON-2120,2015
+ECON,2120,7,Principles of Macro,0.21,0.16,0.53,0.05,0.0,0.0,0.0,0.05,scott baier,,ECON-2120,2015
+ECON,2120,8,Principles of Macro,0.37,0.16,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,9,Principles of Macro,0.2,0.25,0.35,0.05,0.05,0.0,0.0,0.1,scott baier,,ECON-2120,2015
+ECON,2120,10,Principles of Macro,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,11,Principles of Macro,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,12,Principles of Macro,0.26,0.37,0.32,0.0,0.0,0.0,0.0,0.05,scott baier,,ECON-2120,2015
+ECON,2120,13,Principles of Macro,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,14,Principles of Macro,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,15,Principles of Macro,0.29,0.43,0.24,0.0,0.0,0.0,0.0,0.05,scott baier,,ECON-2120,2015
+ECON,2120,16,Principles of Macro,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,17,Principles of Macro,0.32,0.37,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,18,Principles of Macro,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,scott baier,,ECON-2120,2015
+ECON,2120,19,Principles of Macro,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2015
+ECON,2120,20,Principles of Macro,0.26,0.36,0.3,0.04,0.02,0.0,0.0,0.02,peter david lorenz,,ECON-2120,2015
+ECON,2120,21,Principles of Macro,0.25,0.51,0.2,0.03,0.0,0.0,0.0,0.02,peter david lorenz,,ECON-2120,2015
+ECON,2120,22,Principles of Macro,0.35,0.25,0.33,0.03,0.0,0.0,0.0,0.05,yukun sun,,ECON-2120,2015
+ECON,2120,23,Principles of Macro,0.45,0.38,0.18,0.0,0.0,0.0,0.0,0.0,yukun sun,,ECON-2120,2015
+ECON,2120,24,Principles of Macro,0.21,0.52,0.17,0.05,0.04,0.0,0.0,0.01,scott barkowski,,ECON-2120,2015
+ECON,2120,25,Principles of Macro,0.17,0.64,0.17,0.0,0.03,0.0,0.0,0.0,scott barkowski,,ECON-2120,2015
+ECON,2120,26,Principles of Macro,0.22,0.08,0.27,0.05,0.22,0.0,0.0,0.16,ralph charles allen,,ECON-2120,2015
+ECON,3020,1,Money and Banking,0.23,0.23,0.3,0.13,0.05,0.0,0.0,0.08,danielle zanzalari,,ECON-3020,2015
+ECON,3060,1,Managerial Economics,0.28,0.31,0.25,0.03,0.06,0.0,0.0,0.06,jacob burgdorf,,ECON-3060,2015
+ECON,3100,1,International Econ,0.26,0.33,0.17,0.17,0.02,0.0,0.0,0.05,ayse mujde erdogan,,ECON-3100,2015
+ECON,3140,1,Intermediate Micro,0.23,0.28,0.21,0.08,0.05,0.0,0.0,0.15,patrick warren,,ECON-3140,2015
+ECON,3140,2,Intermediate Micro,0.13,0.19,0.29,0.13,0.03,0.0,0.0,0.23,robert kennet fleck,,ECON-3140,2015
+ECON,3140,3,Intermediate Micro,0.17,0.19,0.33,0.08,0.17,0.0,0.0,0.06,frederick hanssen,,ECON-3140,2015
+ECON,3150,1,Intermediate Macro,0.36,0.26,0.22,0.07,0.03,0.0,0.0,0.06,ayse mujde erdogan,,ECON-3150,2015
+ECON,3150,2,Intermediate Macro,0.31,0.26,0.26,0.0,0.03,0.0,0.0,0.14,sergey vla mityakov,,ECON-3150,2015
+ECON,3440,1,Property Rights,0.11,0.3,0.26,0.07,0.07,0.0,0.0,0.19,dar litsukova-bokar,,ECON-3440,2015
+ECON,3600,1,Public Choice,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,robert dew tollison,,ECON-3600,2015
+ECON,4010,1,Labor Mkt Analysis,0.38,0.38,0.15,0.0,0.04,0.0,0.0,0.04,curtis simon,,ECON-4010,2015
+ECON,4020,1,Law and Economics,0.42,0.25,0.21,0.08,0.0,0.0,0.0,0.04,thomas wins hazlett,,ECON-4020,2015
+ECON,4050,1,Intro to Econometric,0.22,0.3,0.28,0.08,0.08,0.0,0.0,0.04,jaqueline oliveira,,ECON-4050,2015
+ECON,4100,1,Economic Development,0.4,0.32,0.12,0.04,0.0,0.0,0.0,0.12,robert tamura,,ECON-4100,2015
+ECON,4200,1,Pub Sector Econ,0.29,0.29,0.24,0.0,0.0,0.0,0.0,0.19,william dougan,,ECON-4200,2015
+ECON,4240,1,Organization of Ind,0.36,0.39,0.14,0.04,0.04,0.0,0.0,0.04,matthew lewis,,ECON-4240,2015
+ECON,4260,1,Sem Sport Economics,0.71,0.19,0.0,0.0,0.0,0.0,0.0,0.1,raymond sauer,,ECON-4260,2015
+ECON,4270,1,Dev American Economy,0.34,0.28,0.19,0.13,0.0,0.0,0.0,0.06,howard ne bodenhorn,,ECON-4270,2015
+ECON,4290,1,Economics of Energy Markets,0.48,0.38,0.0,0.0,0.0,0.0,0.0,0.14,matthew lewis,,ECON-4290,2015
+ECON,4400,1,Game Theory,0.47,0.37,0.0,0.0,0.0,0.0,0.0,0.16,daniel wood,,ECON-4400,2015
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.38,0.25,0.13,0.19,0.0,0.0,0.0,0.06,scott templeton,,ECON-4570,2015
+ECON,8020,1,Adv Econ Concepts and Applic I,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,,ECON-8020,2015
+ECON,8050,1,Macroeconomic Theory,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-8050,2015
+ECON,8070,1,Econometrics II,0.1,0.65,0.25,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,,ECON-8070,2015
+ECON,8200,1,Public Finance,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william dougan,,ECON-8200,2015
+ECON,8990,1,Sel Topics-Appl Welfare Econ,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,arnold harberger,,ECON-8990,2015
+ECON,9010,1,Price Theory,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,daniel wood,,ECON-9010,2015
+ECON,9090,1,Time-Series Econ,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,,ECON-9090,2015
+ED,1050,1,Educ Orientation,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,rory phil tannebaum,,ED-1050,2015
+ED,1050,3,Educ Orientation,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,rory phil tannebaum,,ED-1050,2015
+ED,8380,400,Astronomy - Middle School Tch,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard dallm white,,ED-8380,2015
+ED,8380,534,Literacy Lessons for Indiv II,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,jennifer adams,,ED-8380,2015
+ED,8380,537,Literacy Lessons for Indiv II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,,ED-8380,2015
+ED,8380,539,Literacy Lessons for Indiv II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jean ridley,,ED-8380,2015
+ED,8600,400,Action Research,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,,ED-8600,2015
+EDC,8060,1,Student Aff Issues,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,,EDC-8060,2015
+EDC,8190,1,Cont College Student,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,,EDC-8190,2015
+EDEC,4200,1,Early Childhood Science,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,,EDEC-4200,2015
+EDEC,4500,1,EC Curric & Soc Stud Methods,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-4500,2015
+EDEL,3100,2,Arts in Ele School,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alison eliz leonard,,EDEL-3100,2015
+EDEL,3210,1,Pe for the Elem Tchr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2015
+EDEL,4510,1,Elem Methods in Science Tchg,0.5,0.44,0.0,0.06,0.0,0.0,0.0,0.0,cynthia chri deaton,,EDEL-4510,2015
+EDEL,4520,1,Elem Methods Math Teaching,0.71,0.19,0.0,0.1,0.0,0.0,0.0,0.0,andrew mic tyminski,,EDEL-4520,2015
+EDEL,4670,1,Tchng Esol: Elem Sch,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDEL-4670,2015
+EDF,3010,1,Principles of American Educat,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,suzanne rosenblith,,EDF-3010,2015
+EDF,3010,2,Principles of American Educat,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,patrick womac,,EDF-3010,2015
+EDF,3020,1,Educ Psych,0.35,0.42,0.13,0.1,0.0,0.0,0.0,0.0,penelope mar vargas,,EDF-3020,2015
+EDF,3340,1,Child Growth and Dev,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,,EDF-3340,2015
+EDF,3350,1,Adol Growth & Dev,0.77,0.16,0.03,0.03,0.0,0.0,0.0,0.0,david barrett,,EDF-3350,2015
+EDF,4800,3,Digital Media & Learning,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2015
+EDF,8770,500,Research Meth in Education I,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,david fleming,,EDF-8770,2015
+EDF,8800,400,Dig Media for Mid Sch Teachers,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,ryan visser,,EDF-8800,2015
+EDF,9270,1,Quant Rsrch & Stats for Ed,0.71,0.17,0.13,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,,EDF-9270,2015
+EDF,9710,1,Cse Stdy Ethnog Mthd,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,cynthia chri deaton,,EDF-9710,2015
+EDL,7150,500,Sch & Comm Relations,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth reynolds,,EDL-7150,2015
+EDL,7300,501,Techniq of Supervision-Pub Sch,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,,EDL-7300,2015
+EDL,7500,503,El Prin & Spv Ex I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,frederick buskey,,EDL-7500,2015
+EDL,9050,400,Thry/Prac Ed Ldrshp,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,james satterfield,,EDL-9050,2015
+EDL,9100,400,Intro Phd Seminar,0.62,0.23,0.0,0.0,0.0,0.0,0.0,0.15,leslie gonzales,,EDL-9100,2015
+EDL,9110,400,Systematic Inq Ed L,0.76,0.06,0.06,0.0,0.0,0.0,0.0,0.12,jane lindle,,EDL-9110,2015
+EDL,9760,1,External Effect He,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,leslie gonzales,,EDL-9760,2015
+EDLT,4580,1,Early Literacy: Birth-Kindergn,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,barbara everson,,EDLT-4580,2015
+EDLT,4620,1,Reading Children's Lit in Elem,0.68,0.23,0.05,0.05,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4620,2015
+EDLT,4620,2,Reading Children's Lit in Elem,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4620,2015
+EDLT,4630,1,Teaching Rdg/Writing for ELLs,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-4630,2015
+EDLT,8100,501,Foundations of Literacy,0.63,0.0,0.0,0.0,0.0,0.0,0.0,0.38,linda gambrell,,EDLT-8100,2015
+EDLT,8670,400,Middle School Reading,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,phillip mich wilder,,EDLT-8670,2015
+EDLT,8810,506,Reading Recovery Teacher II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vicki steadman,,EDLT-8810,2015
+EDLT,8810,509,Reading Recovery Teacher II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jean floyd,,EDLT-8810,2015
+EDLT,8830,506,Read Recovery Practicum II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vicki steadman,,EDLT-8830,2015
+EDLT,8830,509,Read Recovery Practicum II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jean floyd,,EDLT-8830,2015
+EDSC,4370,1,Technology in Math,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,corrie leigh martin,,EDSC-4370,2015
+EDSP,3700,2,Intro to Special Ed,0.74,0.2,0.06,0.0,0.0,0.0,0.0,0.0,pamela stecker,,EDSP-3700,2015
+EDSP,3700,3,Intro to Special Ed,0.77,0.14,0.06,0.0,0.03,0.0,0.0,0.0,joseph benedic ryan,,EDSP-3700,2015
+EDSP,3730,1,Char & Instr of ID & Autism,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,,EDSP-3730,2015
+EDSP,4910,1,Ed Assess Ind W/Dis,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,,EDSP-4910,2015
+EDSP,8230,400,Tch Integrated Set,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,,EDSP-8230,2015
+EES,2020,1,Environ Engr Fundamentals II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,,EES-2020,2015
+EES,4010,1,Environmental Engr,0.51,0.44,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth carraway,,EES-4010,2015
+EES,4010,2,Environmental Engr,0.24,0.59,0.15,0.0,0.02,0.0,0.0,0.0,mark schlautman,,EES-4010,2015
+EES,4020,1,Water & Waste Water Treatment,0.44,0.25,0.13,0.0,0.06,0.0,0.0,0.13,david allen ladner,,EES-4020,2015
+EES,4750,1,Capstone Design Project,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-4750,2015
+EES,4840,1,Solid Waste Mgt,0.35,0.35,0.23,0.07,0.0,0.0,0.0,0.0,thomas overcamp,,EES-4840,2015
+EES,4850,1,Hazard Waste Management,0.19,0.5,0.25,0.06,0.0,0.0,0.0,0.0,mark schlautman,,EES-4850,2015
+EES,8030,1,Phy/Chem Ops W/WW T,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,ezra lucas ho cates,,EES-8030,2015
+EES,8040,1,Biochem Ops WW Trt,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,,EES-8040,2015
+EES,8160,1,Technical Nuclear Forensics,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,lin shuller-nickles,,EES-8160,2015
+EES,8420,1,Actinide Chemistry,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,brian powell,,EES-8420,2015
+EES,8450,1,Environ Organic Chem,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,cindy lee,,EES-8450,2015
+ELE,3010,1,Intro to Entre,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,ELE-3010,2015
+ELE,3010,2,Intro to Entre,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,ashley will parnell,,ELE-3010,2015
+ELE,3010,3,Intro to Entre,0.77,0.2,0.03,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,ELE-3010,2015
+ELE,4010,1,Exec Lead & Entr II,0.78,0.23,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,,ELE-4010,2015
+ENGL,1030,1,Accelerated Composition,0.52,0.38,0.05,0.0,0.05,0.0,0.0,0.0,andrew mathas,,ENGL-1030,2015
+ENGL,1030,2,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,,ENGL-1030,2015
+ENGL,1030,3,Accelerated Composition,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,chelsea mari clarey,,ENGL-1030,2015
+ENGL,1030,4,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,dustin cleag mosley,,ENGL-1030,2015
+ENGL,1030,5,Accelerated Composition,0.44,0.33,0.06,0.0,0.11,0.0,0.0,0.06,sarah ashto wickham,,ENGL-1030,2015
+ENGL,1030,6,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,matthew mar russell,,ENGL-1030,2015
+ENGL,1030,7,Accelerated Composition,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,,ENGL-1030,2015
+ENGL,1030,8,Accelerated Composition,0.6,0.25,0.05,0.05,0.0,0.0,0.0,0.05,chelsea mari clarey,,ENGL-1030,2015
+ENGL,1030,10,Accelerated Composition,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,sarah ashto wickham,,ENGL-1030,2015
+ENGL,1030,13,Accelerated Composition,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,molly brian collins,,ENGL-1030,2015
+ENGL,1030,16,Accelerated Composition,0.65,0.2,0.05,0.0,0.0,0.0,0.0,0.1,molly brian collins,,ENGL-1030,2015
+ENGL,1030,17,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,,ENGL-1030,2015
+ENGL,1030,18,Accelerated Composition,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,justin all holliday,,ENGL-1030,2015
+ENGL,1030,19,Accelerated Composition,0.85,0.05,0.0,0.0,0.1,0.0,0.0,0.0,daniel frank,,ENGL-1030,2015
+ENGL,1030,21,Accelerated Composition,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,katherine elrick,,ENGL-1030,2015
+ENGL,1030,23,Accelerated Composition,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,adrian carson,,ENGL-1030,2015
+ENGL,1030,24,Accelerated Composition,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,eda ozyesilpinar,,ENGL-1030,2015
+ENGL,1030,25,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,,ENGL-1030,2015
+ENGL,1030,26,Accelerated Composition,0.68,0.05,0.0,0.11,0.16,0.0,0.0,0.0,adrian carson,,ENGL-1030,2015
+ENGL,1030,27,Accelerated Composition,0.68,0.05,0.21,0.0,0.0,0.0,0.0,0.05,daniel frank,,ENGL-1030,2015
+ENGL,1030,28,Accelerated Composition,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,katherine elrick,,ENGL-1030,2015
+ENGL,1030,29,Accelerated Composition,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,lauren taylo stukes,,ENGL-1030,2015
+ENGL,1030,30,Accelerated Composition,0.89,0.0,0.05,0.05,0.0,0.0,0.0,0.0,joshua wood,,ENGL-1030,2015
+ENGL,1030,32,Accelerated Composition,0.67,0.22,0.0,0.06,0.06,0.0,0.0,0.0,sarah michel naciuk,,ENGL-1030,2015
+ENGL,1030,37,Accelerated Composition,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,,ENGL-1030,2015
+ENGL,1030,39,Accelerated Composition,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,stephanie mic heath,,ENGL-1030,2015
+ENGL,1030,42,Accelerated Composition,0.85,0.05,0.05,0.0,0.05,0.0,0.0,0.0,stephanie mic heath,,ENGL-1030,2015
+ENGL,1030,44,Accelerated Composition,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,carlisle an sargent,,ENGL-1030,2015
+ENGL,1030,47,Accelerated Composition,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,sarah kath melchers,,ENGL-1030,2015
+ENGL,1030,49,Accelerated Composition,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,hayley ren zertuche,,ENGL-1030,2015
+ENGL,1030,53,Accelerated Composition,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,hannah conl vaughan,,ENGL-1030,2015
+ENGL,1030,54,Accelerated Composition,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,,ENGL-1030,2015
+ENGL,1030,56,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,nathan riggs,,ENGL-1030,2015
+ENGL,1030,57,Accelerated Composition,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katherine hanzalik,,ENGL-1030,2015
+ENGL,1030,58,Accelerated Composition,0.18,0.18,0.29,0.06,0.24,0.0,0.0,0.06,justin all holliday,,ENGL-1030,2015
+ENGL,1030,60,Accelerated Composition,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kristen gay,,ENGL-1030,2015
+ENGL,1030,61,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2015
+ENGL,2120,1,World Literature,0.52,0.38,0.0,0.07,0.0,0.0,0.0,0.03,christopher benson,,ENGL-2120,2015
+ENGL,2120,2,World Literature,0.76,0.1,0.05,0.0,0.1,0.0,0.0,0.0,andrew lemons,,ENGL-2120,2015
+ENGL,2120,3,World Literature,0.17,0.38,0.21,0.0,0.17,0.0,0.0,0.08,david charles foltz,,ENGL-2120,2015
+ENGL,2120,4,World Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-2120,2015
+ENGL,2120,5,World Literature,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-2120,2015
+ENGL,2120,7,World Literature,0.12,0.54,0.15,0.04,0.0,0.0,0.0,0.15,david charles foltz,,ENGL-2120,2015
+ENGL,2120,9,World Literature,0.38,0.45,0.07,0.1,0.0,0.0,0.0,0.0,joshua nei waggoner,,ENGL-2120,2015
+ENGL,2120,10,World Literature,0.14,0.61,0.21,0.0,0.0,0.0,0.0,0.04,joshua nei waggoner,,ENGL-2120,2015
+ENGL,2120,11,World Literature,0.32,0.4,0.04,0.04,0.12,0.0,0.0,0.08,karen kettnich,,ENGL-2120,2015
+ENGL,2120,12,World Literature,0.16,0.64,0.04,0.16,0.0,0.0,0.0,0.0,karen kettnich,,ENGL-2120,2015
+ENGL,2120,13,World Literature,0.3,0.37,0.26,0.04,0.04,0.0,0.0,0.0,meg woosley-goodman,,ENGL-2120,2015
+ENGL,2120,14,World Literature,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,meg woosley-goodman,,ENGL-2120,2015
+ENGL,2120,15,World Literature,0.27,0.5,0.23,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2120,2015
+ENGL,2120,16,World Literature,0.48,0.33,0.15,0.04,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2120,2015
+ENGL,2120,17,World Literature,0.37,0.41,0.04,0.0,0.15,0.0,0.0,0.04,joshua nei waggoner,,ENGL-2120,2015
+ENGL,2120,18,World Literature,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,,ENGL-2120,2015
+ENGL,2130,1,British Literature,0.36,0.54,0.04,0.0,0.0,0.0,0.0,0.07,adrian paterson,,ENGL-2130,2015
+ENGL,2130,2,British Literature,0.69,0.12,0.15,0.04,0.0,0.0,0.0,0.0,april susanne pelt,,ENGL-2130,2015
+ENGL,2130,3,British Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,april susanne pelt,,ENGL-2130,2015
+ENGL,2130,4,British Literature,0.54,0.32,0.04,0.07,0.0,0.0,0.0,0.04,april susanne pelt,,ENGL-2130,2015
+ENGL,2130,5,British Literature,0.62,0.19,0.12,0.04,0.0,0.0,0.0,0.04,april susanne pelt,,ENGL-2130,2015
+ENGL,2130,6,British Literature,0.2,0.44,0.2,0.0,0.08,0.0,0.0,0.08,meg woosley-goodman,,ENGL-2130,2015
+ENGL,2130,7,British Literature,0.46,0.32,0.07,0.0,0.07,0.0,0.0,0.07,meg woosley-goodman,,ENGL-2130,2015
+ENGL,2130,10,British Literature,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,,ENGL-2130,2015
+ENGL,2130,11,British Literature,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2015
+ENGL,2130,12,British Literature,0.68,0.25,0.0,0.0,0.04,0.0,0.0,0.04,lucian ghita,,ENGL-2130,2015
+ENGL,2130,13,British Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2015
+ENGL,2140,1,American Literature,0.04,0.71,0.25,0.0,0.0,0.0,0.0,0.0,rhondda robi thomas,,ENGL-2140,2015
+ENGL,2140,2,American Literature,0.11,0.32,0.29,0.11,0.14,0.0,0.0,0.04,barbara ramirez,,ENGL-2140,2015
+ENGL,2140,3,American Literature,0.12,0.46,0.35,0.04,0.04,0.0,0.0,0.0,barbara ramirez,,ENGL-2140,2015
+ENGL,2140,4,American Literature,0.66,0.24,0.03,0.03,0.03,0.0,0.0,0.0,sharon kathl nalley,,ENGL-2140,2015
+ENGL,2140,5,American Literature,0.76,0.17,0.0,0.03,0.03,0.0,0.0,0.0,sharon kathl nalley,,ENGL-2140,2015
+ENGL,2140,6,American Literature,0.39,0.39,0.11,0.04,0.04,0.0,0.0,0.04,william stanton,,ENGL-2140,2015
+ENGL,2140,7,American Literature,0.54,0.36,0.07,0.0,0.04,0.0,0.0,0.0,william stanton,,ENGL-2140,2015
+ENGL,2140,8,American Literature,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,david stubblefield,,ENGL-2140,2015
+ENGL,2140,9,American Literature,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,david stubblefield,,ENGL-2140,2015
+ENGL,2140,11,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,,ENGL-2140,2015
+ENGL,2140,12,American Literature,0.75,0.11,0.11,0.04,0.0,0.0,0.0,0.0,david stubblefield,,ENGL-2140,2015
+ENGL,2140,13,American Literature,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-2140,2015
+ENGL,2140,14,American Literature,0.1,0.41,0.48,0.0,0.0,0.0,0.0,0.0,barbara ramirez,,ENGL-2140,2015
+ENGL,2140,15,American Literature,0.44,0.19,0.19,0.11,0.0,0.0,0.0,0.07,meredith mccarroll,,ENGL-2140,2015
+ENGL,2140,16,American Literature,0.29,0.43,0.21,0.0,0.04,0.0,0.0,0.04,susanna ashton,,ENGL-2140,2015
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.72,0.24,0.0,0.0,0.03,0.0,0.0,0.0,nicholas chri brown,,ENGL-2150,2015
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.0,0.48,0.44,0.04,0.0,0.0,0.0,0.04,amy monaghan,,ENGL-2150,2015
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.04,0.52,0.41,0.0,0.04,0.0,0.0,0.0,amy monaghan,,ENGL-2150,2015
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.52,0.33,0.11,0.0,0.04,0.0,0.0,0.0,sarah lauro,,ENGL-2150,2015
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,sarah lauro,,ENGL-2150,2015
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.14,0.48,0.28,0.0,0.0,0.0,0.0,0.1,david charles foltz,,ENGL-2150,2015
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.61,0.25,0.07,0.07,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2015
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.57,0.32,0.07,0.04,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2015
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.83,0.07,0.03,0.0,0.07,0.0,0.0,0.0,alexander kudera,,ENGL-2150,2015
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.2,0.68,0.04,0.0,0.0,0.0,0.0,0.08,david charles foltz,,ENGL-2150,2015
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.45,0.31,0.1,0.1,0.03,0.0,0.0,0.0,andrew mathas,,ENGL-2150,2015
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.55,0.28,0.07,0.03,0.07,0.0,0.0,0.0,andrew mathas,,ENGL-2150,2015
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.31,0.5,0.12,0.04,0.04,0.0,0.0,0.0,matthew schilleman,,ENGL-2150,2015
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.36,0.21,0.25,0.04,0.07,0.0,0.0,0.07,andrew mathas,,ENGL-2150,2015
+ENGL,3000,1,Professional Develop,0.7,0.13,0.13,0.0,0.03,0.0,0.0,0.0,cameron fa bushnell,,ENGL-3000,2015
+ENGL,3040,2,Business Writing,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,,ENGL-3040,2015
+ENGL,3040,3,Business Writing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,,ENGL-3040,2015
+ENGL,3040,4,Business Writing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3040,2015
+ENGL,3040,5,Business Writing,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3040,2015
+ENGL,3040,14,Business Writing,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-3040,2015
+ENGL,3040,15,Business Writing,0.7,0.15,0.1,0.0,0.0,0.0,0.0,0.05,philip randall,,ENGL-3040,2015
+ENGL,3040,17,Business Writing,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-3040,2015
+ENGL,3040,18,Business Writing,0.4,0.5,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,,ENGL-3040,2015
+ENGL,3100,1,Crit Writ Lit,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,david sweene coombs,,ENGL-3100,2015
+ENGL,3100,2,Crit Writ Lit,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,dominic mastroianni,,ENGL-3100,2015
+ENGL,3100,4,Crit Writ Lit,0.38,0.29,0.19,0.0,0.05,0.0,0.0,0.1,erin marina goss,,ENGL-3100,2015
+ENGL,3120,1,Advanced Composition,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2015
+ENGL,3120,2,Advanced Composition,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2015
+ENGL,3140,2,Technical Writing,0.25,0.6,0.1,0.0,0.0,0.0,0.0,0.05,william pulley,,ENGL-3140,2015
+ENGL,3140,3,Technical Writing,0.15,0.5,0.1,0.05,0.15,0.0,0.0,0.05,william pulley,,ENGL-3140,2015
+ENGL,3140,4,Technical Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew schilleman,,ENGL-3140,2015
+ENGL,3140,5,Technical Writing,0.32,0.58,0.0,0.0,0.0,0.0,0.0,0.11,matthew schilleman,,ENGL-3140,2015
+ENGL,3140,7,Technical Writing,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,,ENGL-3140,2015
+ENGL,3140,9,Technical Writing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-3140,2015
+ENGL,3140,10,Technical Writing,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2015
+ENGL,3140,11,Technical Writing,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2015
+ENGL,3140,12,Technical Writing,0.3,0.55,0.1,0.0,0.05,0.0,0.0,0.0,katalin beck,,ENGL-3140,2015
+ENGL,3140,13,Technical Writing,0.2,0.55,0.25,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2015
+ENGL,3140,16,Technical Writing,0.75,0.15,0.05,0.0,0.05,0.0,0.0,0.0,lauren woolbright,,ENGL-3140,2015
+ENGL,3140,17,Technical Writing,0.73,0.14,0.05,0.05,0.05,0.0,0.0,0.0,lauren woolbright,,ENGL-3140,2015
+ENGL,3140,18,Technical Writing,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-3140,2015
+ENGL,3140,19,Technical Writing,0.78,0.17,0.0,0.06,0.0,0.0,0.0,0.0,matthew jose osborn,,ENGL-3140,2015
+ENGL,3140,20,Technical Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,,ENGL-3140,2015
+ENGL,3140,21,Technical Writing,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3140,2015
+ENGL,3140,22,Technical Writing,0.82,0.05,0.05,0.0,0.09,0.0,0.0,0.0,john conway,,ENGL-3140,2015
+ENGL,3140,23,Technical Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-3140,2015
+ENGL,3150,1,Sci Writing & Comm,0.85,0.05,0.0,0.0,0.1,0.0,0.0,0.0,philip randall,,ENGL-3150,2015
+ENGL,3150,5,Sci Writing & Comm,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3150,2015
+ENGL,3150,6,Sci Writing & Comm,0.4,0.4,0.1,0.05,0.0,0.0,0.0,0.05,william pulley,,ENGL-3150,2015
+ENGL,3150,7,Sci Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-3150,2015
+ENGL,3150,19,Sci Writing & Comm,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-3150,2015
+ENGL,3150,20,Sci Writing & Comm,0.9,0.0,0.0,0.05,0.0,0.0,0.0,0.05,john conway,,ENGL-3150,2015
+ENGL,3320,1,Visual Communication,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,megan eatman,,ENGL-3320,2015
+ENGL,3450,1,Structure of Fiction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,,ENGL-3450,2015
+ENGL,3460,1,Structure of Poetry,0.75,0.1,0.1,0.0,0.05,0.0,0.0,0.0,john logan pursley,,ENGL-3460,2015
+ENGL,3480,1,Structure Screenplay,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,joshua nei waggoner,,ENGL-3480,2015
+ENGL,3490,1,Tech/Pop Imagination,0.26,0.58,0.05,0.0,0.05,0.0,0.0,0.05,lindsay carr thomas,,ENGL-3490,2015
+ENGL,3530,1,Ethnic Am Lit,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,angela naimou,,ENGL-3530,2015
+ENGL,3570,1,Film,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2015
+ENGL,3850,1,Children's Lit,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,megan no macalystre,,ENGL-3850,2015
+ENGL,3960,1,Brit Lit Survey I,0.2,0.3,0.4,0.0,0.05,0.0,0.0,0.05,erin marina goss,,ENGL-3960,2015
+ENGL,3960,2,Brit Lit Survey I,0.25,0.15,0.4,0.05,0.0,0.0,0.0,0.15,erin marina goss,,ENGL-3960,2015
+ENGL,3960,3,Brit Lit Survey I,0.35,0.2,0.15,0.15,0.1,0.0,0.0,0.05,erin marina goss,,ENGL-3960,2015
+ENGL,3970,1,Brit Lit Survey II,0.52,0.33,0.1,0.0,0.05,0.0,0.0,0.0,david sweene coombs,,ENGL-3970,2015
+ENGL,3980,1,Amer Lit Survey I,0.15,0.5,0.3,0.0,0.05,0.0,0.0,0.0,susanna ashton,,ENGL-3980,2015
+ENGL,3990,1,Amer Lit Survey II,0.26,0.42,0.26,0.0,0.0,0.0,0.0,0.05,rhondda robi thomas,,ENGL-3990,2015
+ENGL,4080,1,Chaucer,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,andrew lemons,,ENGL-4080,2015
+ENGL,4110,1,Shakespeare,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william stockton,,ENGL-4110,2015
+ENGL,4170,1,Victorian Period,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,,ENGL-4170,2015
+ENGL,4200,1,Amer Lit to 1799,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,jonathan beec field,,ENGL-4200,2015
+ENGL,4310,1,Modern Poetry,0.16,0.68,0.05,0.0,0.0,0.0,0.0,0.11,adrian paterson,,ENGL-4310,2015
+ENGL,4320,1,Modern Fiction,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,angela naimou,,ENGL-4320,2015
+ENGL,4400,1,Literary Theory,0.29,0.48,0.24,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,,ENGL-4400,2015
+ENGL,4410,1,Literary Editing,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,wayne chapman,,ENGL-4410,2015
+ENGL,4450,1,Fiction Workshop,0.46,0.31,0.15,0.08,0.0,0.0,0.0,0.0,keith morris,,ENGL-4450,2015
+ENGL,4590,2,Spec Top Lang Criticism Theory,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,,ENGL-4590,2015
+ENGL,4780,1,Digital Literacy,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,,ENGL-4780,2015
+ENGL,4830,1,Af Am Lit 1920-Pres,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,garry bertholf,,ENGL-4830,2015
+ENGL,4890,1,Topics Write & Publ,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,david blakesley,,ENGL-4890,2015
+ENGL,4960,1,Senior Seminar,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,jonathan beec field,,ENGL-4960,2015
+ENGL,4960,3,Senior Seminar,0.8,0.1,0.05,0.0,0.05,0.0,0.0,0.0,sean morey,,ENGL-4960,2015
+ENGL,7000,1,Child Lit for Teach,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,lienne federico,,ENGL-7000,2015
+ENGL,8080,1,Top Renaiss & Restoration Lit,0.5,0.25,0.13,0.0,0.13,0.0,0.0,0.0,william stockton,,ENGL-8080,2015
+ENGL,8230,1,Topics American Lit Since 1865,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-8230,2015
+ENGL,8500,1,Methods Prof Comm,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,tharon howard,,ENGL-8500,2015
+ENGR,1050,311,Engr Discipline & Skills I,0.18,0.23,0.25,0.2,0.07,0.0,0.0,0.08,john minor,,ENGR-1050,2015
+ENGR,1050,312,Engr Discipline & Skills I,0.15,0.38,0.18,0.18,0.08,0.0,0.0,0.03,michael giebner,,ENGR-1050,2015
+ENGR,1060,141,Engr Discipline & Skills II,0.07,0.36,0.32,0.07,0.11,0.0,0.0,0.07,steven brandon,,ENGR-1060,2015
+ENGR,1060,241,Engr Discipline & Skills II,0.1,0.41,0.35,0.06,0.06,0.0,0.0,0.02,matthew kent miller,,ENGR-1060,2015
+ENGR,1060,242,Engr Discipline & Skills II,0.1,0.3,0.36,0.06,0.08,0.0,0.0,0.1,matthew kent miller,,ENGR-1060,2015
+ENGR,1060,311,Engr Discipline & Skills II,0.11,0.22,0.31,0.11,0.16,0.0,0.0,0.09,ashley childers,,ENGR-1060,2015
+ENGR,1060,312,Engr Discipline & Skills II,0.15,0.12,0.22,0.22,0.12,0.0,0.0,0.17,michael giebner,,ENGR-1060,2015
+ENGR,1060,341,Engr Discipline & Skills II,0.11,0.36,0.36,0.14,0.03,0.0,0.0,0.0,ashley childers,,ENGR-1060,2015
+ENGR,1060,342,Engr Discipline & Skills II,0.15,0.4,0.31,0.1,0.02,0.0,0.0,0.02,ashley childers,,ENGR-1060,2015
+ENGR,1060,343,Engr Discipline & Skills II,0.13,0.4,0.27,0.09,0.04,0.0,0.0,0.07,ashley childers,,ENGR-1060,2015
+ENGR,1060,345,Engr Discipline & Skills II,0.06,0.38,0.34,0.06,0.03,0.0,0.0,0.13,elizabeth stephan,,ENGR-1060,2015
+ENGR,1070,121,Program & Prob Solv I,0.04,0.31,0.38,0.19,0.04,0.0,0.0,0.04,erin jennife mccave,,ENGR-1070,2015
+ENGR,1070,122,Program & Prob Solv I,0.17,0.29,0.35,0.15,0.02,0.0,0.0,0.02,erin jennife mccave,,ENGR-1070,2015
+ENGR,1070,123,Program & Prob Solv I,0.15,0.38,0.23,0.15,0.02,0.0,0.0,0.08,christopher norfolk,,ENGR-1070,2015
+ENGR,1070,124,Program & Prob Solv I,0.1,0.48,0.31,0.04,0.04,0.0,0.0,0.02,christopher norfolk,,ENGR-1070,2015
+ENGR,1070,125,Program & Prob Solv I,0.13,0.26,0.38,0.13,0.0,0.0,0.0,0.11,erin jennife mccave,,ENGR-1070,2015
+ENGR,1070,126,Program & Prob Solv I,0.17,0.27,0.31,0.15,0.0,0.0,0.0,0.1,erin jennife mccave,,ENGR-1070,2015
+ENGR,1070,127,Program & Prob Solv I,0.21,0.34,0.32,0.06,0.04,0.0,0.0,0.02,william martin,,ENGR-1070,2015
+ENGR,1070,128,Program & Prob Solv I,0.2,0.35,0.28,0.09,0.04,0.0,0.0,0.04,steven brandon,,ENGR-1070,2015
+ENGR,1070,221,Programming & Prob Solving I,0.05,0.35,0.27,0.2,0.07,0.0,0.0,0.05,william martin,,ENGR-1070,2015
+ENGR,1070,222,Programming & Prob Solving I,0.22,0.33,0.31,0.07,0.02,0.0,0.0,0.05,william martin,,ENGR-1070,2015
+ENGR,1070,223,Programming & Prob Solving I,0.16,0.38,0.22,0.16,0.02,0.0,0.0,0.05,steven brandon,,ENGR-1070,2015
+ENGR,1070,224,Programming & Prob Solving I,0.18,0.4,0.18,0.18,0.0,0.0,0.0,0.05,steven brandon,,ENGR-1070,2015
+ENGR,1070,225,Programming & Prob Solving I,0.15,0.44,0.35,0.04,0.0,0.0,0.0,0.04,richard watkins,,ENGR-1070,2015
+ENGR,1070,226,Programming & Prob Solving I,0.24,0.3,0.3,0.11,0.02,0.0,0.0,0.04,david ewing,,ENGR-1070,2015
+ENGR,1070,241,Programming & Prob Solving I,0.07,0.49,0.36,0.0,0.04,0.0,0.0,0.04,matthew kent miller,,ENGR-1070,2015
+ENGR,1070,242,Programming & Prob Solving I,0.0,0.34,0.44,0.13,0.06,0.0,0.0,0.03,matthew kent miller,,ENGR-1070,2015
+ENGR,1070,321,Programming & Prob Solving I,0.15,0.38,0.36,0.02,0.02,0.0,0.0,0.08,william th kolodzey,,ENGR-1070,2015
+ENGR,1070,322,Programming & Prob Solving I,0.33,0.3,0.2,0.1,0.05,0.0,0.0,0.02,elizabeth stephan,,ENGR-1070,2015
+ENGR,1070,323,Programming & Prob Solving I,0.15,0.36,0.33,0.11,0.02,0.0,0.0,0.04,surya sharma,,ENGR-1070,2015
+ENGR,1070,324,Programming & Prob Solving I,0.22,0.37,0.22,0.07,0.04,0.0,0.0,0.07,william park,,ENGR-1070,2015
+ENGR,1070,325,Programming & Prob Solving I,0.21,0.44,0.19,0.1,0.0,0.0,0.0,0.06,william park,,ENGR-1070,2015
+ENGR,1070,341,Programming & Prob Solving I,0.0,0.26,0.52,0.13,0.1,0.0,0.0,0.0,william martin,,ENGR-1070,2015
+ENGR,1070,621,Program & Prob Solv I (HON),0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,david ewing,True,ENGR-1070,2015
+ENGR,1070,622,Program & Prob Solv I (HON),0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,david ewing,True,ENGR-1070,2015
+ENGR,1080,121,Program & Prob Solv II,0.06,0.31,0.39,0.14,0.06,0.0,0.0,0.06,erin jennife mccave,,ENGR-1080,2015
+ENGR,1080,122,Program & Prob Solv II,0.08,0.47,0.21,0.21,0.03,0.0,0.0,0.0,erin jennife mccave,,ENGR-1080,2015
+ENGR,1080,123,Program & Prob Solv II,0.05,0.36,0.31,0.15,0.05,0.0,0.0,0.08,christopher norfolk,,ENGR-1080,2015
+ENGR,1080,124,Program & Prob Solv II,0.12,0.29,0.34,0.12,0.12,0.0,0.0,0.0,christopher norfolk,,ENGR-1080,2015
+ENGR,1080,125,Program & Prob Solv II,0.11,0.28,0.36,0.11,0.14,0.0,0.0,0.0,erin jennife mccave,,ENGR-1080,2015
+ENGR,1080,126,Program & Prob Solv II,0.16,0.43,0.3,0.08,0.03,0.0,0.0,0.0,erin jennife mccave,,ENGR-1080,2015
+ENGR,1080,127,Program & Prob Solv II,0.12,0.49,0.2,0.12,0.05,0.0,0.0,0.02,christopher norfolk,,ENGR-1080,2015
+ENGR,1080,128,Program & Prob Solv II,0.23,0.43,0.14,0.11,0.06,0.0,0.0,0.03,steven brandon,,ENGR-1080,2015
+ENGR,1080,221,Programming & Prob Solving II,0.14,0.39,0.36,0.06,0.03,0.0,0.0,0.03,elizabeth stephan,,ENGR-1080,2015
+ENGR,1080,222,Programming & Prob Solving II,0.21,0.32,0.26,0.15,0.04,0.0,0.0,0.02,steven brandon,,ENGR-1080,2015
+ENGR,1080,223,Programming & Prob Solving II,0.14,0.5,0.21,0.02,0.1,0.0,0.0,0.02,elizabeth stephan,,ENGR-1080,2015
+ENGR,1080,224,Programming & Prob Solving II,0.2,0.42,0.27,0.09,0.0,0.0,0.0,0.02,steven brandon,,ENGR-1080,2015
+ENGR,1080,225,Programming & Prob Solving II,0.24,0.33,0.25,0.14,0.02,0.0,0.0,0.02,richard watkins,,ENGR-1080,2015
+ENGR,1080,226,Programming & Prob Solving II,0.3,0.32,0.21,0.15,0.02,0.0,0.0,0.0,david ewing,,ENGR-1080,2015
+ENGR,1080,321,Programming & Prob Solving II,0.09,0.29,0.22,0.27,0.11,0.0,0.0,0.02,william th kolodzey,,ENGR-1080,2015
+ENGR,1080,322,Programming & Prob Solving II,0.33,0.35,0.25,0.04,0.0,0.0,0.0,0.02,elizabeth stephan,,ENGR-1080,2015
+ENGR,1080,323,Programming & Prob Solving II,0.18,0.34,0.28,0.08,0.1,0.0,0.0,0.02,surya sharma,,ENGR-1080,2015
+ENGR,1080,324,Programming & Prob Solving II,0.07,0.26,0.33,0.19,0.1,0.0,0.0,0.05,william park,,ENGR-1080,2015
+ENGR,1080,325,Programming & Prob Solving II,0.07,0.42,0.24,0.13,0.07,0.0,0.0,0.07,william park,,ENGR-1080,2015
+ENGR,1080,621,Program & Prob Solv II (HON),0.5,0.44,0.0,0.0,0.06,0.0,0.0,0.0,david ewing,True,ENGR-1080,2015
+ENGR,1080,622,Program & Prob Solv II (HON),0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,david ewing,True,ENGR-1080,2015
+ENGR,1090,132,Prog/Problem Solv Apps (RISE),0.23,0.66,0.05,0.02,0.0,0.0,0.0,0.05,christopher norfolk,,ENGR-1090,2015
+ENGR,1090,133,Prog/Problem Solv Apps (RISE),0.24,0.59,0.17,0.0,0.0,0.0,0.0,0.0,surya sharma,,ENGR-1090,2015
+ENGR,1090,134,Prog/Problem Solv Apps (RISE),0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,david ewing,,ENGR-1090,2015
+ENGR,1090,231,Prog/Problem Solving Apps,0.28,0.51,0.21,0.0,0.0,0.0,0.0,0.0,william martin,,ENGR-1090,2015
+ENGR,1090,232,Prog/Problem Solving Apps,0.41,0.52,0.07,0.0,0.0,0.0,0.0,0.0,william martin,,ENGR-1090,2015
+ENGR,1090,233,Prog/Problem Solving Apps,0.38,0.47,0.06,0.04,0.0,0.0,0.0,0.04,david ewing,,ENGR-1090,2015
+ENGR,1090,234,Prog/Problem Solving Apps,0.26,0.42,0.21,0.02,0.02,0.0,0.0,0.07,steven brandon,,ENGR-1090,2015
+ENGR,1090,331,Prog/Problem Solving Apps,0.45,0.47,0.03,0.0,0.0,0.0,0.0,0.05,william th kolodzey,,ENGR-1090,2015
+ENGR,1090,332,Prog/Problem Solving Apps,0.2,0.52,0.19,0.0,0.0,0.0,0.0,0.09,john minor,,ENGR-1090,2015
+ENGR,1090,333,Prog/Problem Solving Apps,0.25,0.52,0.17,0.02,0.02,0.0,0.0,0.03,william park,,ENGR-1090,2015
+ENGR,1090,334,Prog/Problem Solving Apps,0.11,0.26,0.57,0.06,0.0,0.0,0.0,0.0,william park,,ENGR-1090,2015
+ENGR,1090,335,Prog/Problem Solving Apps,0.37,0.49,0.12,0.01,0.0,0.0,0.0,0.0,steven brandon,,ENGR-1090,2015
+ENGR,1090,336,Prog/Problem Solving Apps,0.28,0.48,0.17,0.0,0.03,0.0,0.0,0.03,william park,,ENGR-1090,2015
+ENGR,1090,337,Prog/Problem Solving Apps,0.41,0.54,0.05,0.0,0.0,0.0,0.0,0.0,steven brandon,,ENGR-1090,2015
+ENGR,1090,338,Prog/Problem Solving Apps,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,william park,,ENGR-1090,2015
+ENGR,1490,501,Introduction to Engineering,0.41,0.14,0.18,0.09,0.18,0.0,0.0,0.0,matthew kent miller,,ENGR-1490,2015
+ENGR,1510,501,Engineering Skills,0.59,0.06,0.18,0.06,0.12,0.0,0.0,0.0,matthew kent miller,,ENGR-1510,2015
+ENGR,1510,502,Engineering Skills,0.5,0.13,0.13,0.06,0.13,0.0,0.0,0.06,matthew kent miller,,ENGR-1510,2015
+ENGR,1640,502,Engineering MATLAB Programming,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1640,2015
+ENGR,2080,181,Engr Graphics & Machine Design,0.52,0.31,0.12,0.02,0.02,0.0,0.0,0.0,john minor,,ENGR-2080,2015
+ENGR,2080,182,Engr Graphics & Machine Design,0.55,0.32,0.07,0.02,0.02,0.0,0.0,0.02,sarah grigg,,ENGR-2080,2015
+ENGR,2080,183,Engr Graphics & Machine Design,0.14,0.52,0.12,0.05,0.1,0.0,0.0,0.07,sarah grigg,,ENGR-2080,2015
+ENGR,2080,184,Engr Graphics & Machine Design,0.34,0.41,0.09,0.05,0.02,0.0,0.0,0.09,sarah grigg,,ENGR-2080,2015
+ENGR,2080,185,Engr Graphics & Machine Design,0.51,0.27,0.09,0.0,0.02,0.0,0.0,0.11,jonathan maier,,ENGR-2080,2015
+ENGR,2080,281,Engr Graphics & Machine Design,0.67,0.22,0.07,0.0,0.02,0.0,0.0,0.03,john minor,,ENGR-2080,2015
+ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.25,0.08,0.02,0.02,0.0,0.0,0.02,john minor,,ENGR-2080,2015
+ENGR,2080,283,Engr Graphics & Machine Design,0.32,0.36,0.17,0.02,0.05,0.0,0.0,0.08,anthony pau garland,,ENGR-2080,2015
+ENGR,2080,284,Engr Graphics & Machine Design,0.18,0.4,0.25,0.05,0.04,0.0,0.0,0.09,anthony pau garland,,ENGR-2080,2015
+ENGR,2080,381,Engr Graphics & Machine Design,0.52,0.23,0.12,0.02,0.03,0.0,0.0,0.08,jonathan maier,,ENGR-2080,2015
+ENGR,2100,101,CAD & Engineering Apllications,0.42,0.31,0.11,0.03,0.06,0.0,0.0,0.08,william martin,,ENGR-2100,2015
+ENGR,2100,201,CAD & Engineering Apllications,0.76,0.1,0.02,0.02,0.02,0.0,0.0,0.08,mary kayla kilgo,,ENGR-2100,2015
+ENGR,2100,202,CAD & Engineering Apllications,0.76,0.18,0.02,0.02,0.02,0.0,0.0,0.0,nighat yasmin,,ENGR-2100,2015
+ENGR,2100,203,CAD & Engineering Apllications,0.62,0.28,0.04,0.0,0.02,0.0,0.0,0.04,nighat yasmin,,ENGR-2100,2015
+ENGR,2200,1,Evaluating Innovations,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,sarah grigg,,ENGR-2200,2015
+ENR,3020,1,Nat Res Measurements,0.33,0.42,0.18,0.03,0.03,0.0,0.0,0.0,lawrence gering,,ENR-3020,2015
+ENR,4500,1,Conservation Issues,0.5,0.31,0.09,0.03,0.03,0.0,0.0,0.03,alan johnson,,ENR-4500,2015
+ENR,4500,2,Conservation Issues,0.54,0.15,0.23,0.04,0.04,0.0,0.0,0.0,alan johnson,,ENR-4500,2015
+ENSP,2000,1,Intro Environ Sci,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,scott brame,,ENSP-2000,2015
+ENSP,2000,2,Intro Environ Sci,0.67,0.23,0.06,0.0,0.0,0.0,0.0,0.04,elizabeth carraway,,ENSP-2000,2015
+ENSP,2000,3,Intro Environ Sci,0.79,0.15,0.06,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2015
+ENT,2000,1,Six-Legged Science,0.49,0.37,0.11,0.0,0.0,0.0,0.0,0.03,suellen pometto,,ENT-2000,2015
+ENT,8100,3,Conservation Genetics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michael caterino,,ENT-8100,2015
+ESED,8710,1,Engr & Sci Educ Research Meth,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,charity watson,,ESED-8710,2015
+FCS,8340,3,Research Methods in FCS II,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0,james mcdonell,,FCS-8340,2015
+FDSC,1020,1,Persp Food Nutrition,0.6,0.36,0.03,0.0,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-1020,2015
+FDSC,2140,1,Fd Resources & Soc,0.66,0.24,0.08,0.0,0.01,0.0,0.0,0.01,paul dawson,,FDSC-2140,2015
+FDSC,2150,1,Culinary Fundamental,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,aubrey dean coffee,,FDSC-2150,2015
+FDSC,4020,1,Food Chem II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,feng chen,,FDSC-4020,2015
+FDSC,4030,1,Food Ch & Analysis,0.94,0.05,0.02,0.0,0.0,0.0,0.0,0.0,paul dawson,,FDSC-4030,2015
+FDSC,4080,1,Food Process Eng,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,felix barron,,FDSC-4080,2015
+FDSC,4090,1,TQM for Food & Pckg Industries,0.67,0.26,0.06,0.01,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-4090,2015
+FIN,3040,1,Risk & Insurance,0.13,0.45,0.37,0.05,0.0,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2015
+FIN,3050,1,Investment Analysis,0.21,0.29,0.36,0.05,0.07,0.0,0.0,0.02,kerri mcmillan,,FIN-3050,2015
+FIN,3050,2,Investment Analysis,0.17,0.38,0.32,0.04,0.06,0.0,0.0,0.02,kerri mcmillan,,FIN-3050,2015
+FIN,3050,3,Investment Analysis,0.19,0.51,0.28,0.02,0.0,0.0,0.0,0.0,kerri mcmillan,,FIN-3050,2015
+FIN,3060,1,Corporation Finance,0.08,0.15,0.33,0.12,0.15,0.0,0.0,0.17,william hol johnson,,FIN-3060,2015
+FIN,3060,2,Corporation Finance,0.1,0.12,0.16,0.22,0.16,0.0,0.0,0.22,william hol johnson,,FIN-3060,2015
+FIN,3060,3,Corporation Finance,0.2,0.28,0.38,0.11,0.02,0.0,0.0,0.02,neil waller,,FIN-3060,2015
+FIN,3060,4,Corporation Finance,0.26,0.38,0.27,0.08,0.0,0.0,0.0,0.02,neil waller,,FIN-3060,2015
+FIN,3060,5,Corporation Finance,0.06,0.2,0.23,0.17,0.16,0.0,0.0,0.17,william hol johnson,,FIN-3060,2015
+FIN,3060,6,Corporation Finance,0.28,0.37,0.19,0.07,0.05,0.0,0.0,0.04,neil waller,,FIN-3060,2015
+FIN,3060,7,Corporation Finance,0.28,0.3,0.3,0.05,0.04,0.0,0.0,0.04,neil waller,,FIN-3060,2015
+FIN,3070,1,Prin of Real Estate,0.24,0.22,0.35,0.13,0.07,0.0,0.0,0.0,ramon tolb franklin,,FIN-3070,2015
+FIN,3070,2,Prin of Real Estate,0.21,0.26,0.39,0.11,0.0,0.02,0.0,0.02,thomas springer,,FIN-3070,2015
+FIN,3080,1,Fin Inst & Mkts,0.3,0.34,0.32,0.05,0.0,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2015
+FIN,3080,2,Fin Inst & Mkts,0.41,0.41,0.15,0.0,0.0,0.0,0.0,0.03,daniel thoma greene,,FIN-3080,2015
+FIN,3080,3,Fin Inst & Mkts,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.05,daniel thoma greene,,FIN-3080,2015
+FIN,3110,1,Financial Management I,0.13,0.2,0.37,0.09,0.07,0.0,0.0,0.15,jack wolf,,FIN-3110,2015
+FIN,3110,2,Financial Management I,0.19,0.33,0.37,0.02,0.0,0.0,0.0,0.09,george bra lockhart,,FIN-3110,2015
+FIN,3110,3,Financial Management I,0.37,0.29,0.2,0.05,0.02,0.0,0.0,0.07,george bra lockhart,,FIN-3110,2015
+FIN,3110,4,Financial Management I,0.23,0.43,0.28,0.0,0.0,0.0,0.0,0.08,george bra lockhart,,FIN-3110,2015
+FIN,3120,1,Financial Mgt II,0.22,0.49,0.22,0.04,0.02,0.0,0.0,0.02,vincent intintoli,,FIN-3120,2015
+FIN,3120,2,Financial Mgt II,0.14,0.34,0.26,0.09,0.09,0.0,0.0,0.09,angela morgan,,FIN-3120,2015
+FIN,3120,3,Financial Mgt II,0.16,0.29,0.32,0.13,0.05,0.0,0.0,0.05,angela morgan,,FIN-3120,2015
+FIN,3120,4,Financial Mgt II,0.15,0.45,0.27,0.03,0.09,0.0,0.0,0.0,vincent intintoli,,FIN-3120,2015
+FIN,4040,1,Financial Modeling,0.12,0.38,0.35,0.15,0.0,0.0,0.0,0.0,jack wolf,,FIN-4040,2015
+FIN,4040,2,Financial Modeling,0.27,0.56,0.17,0.0,0.0,0.0,0.0,0.0,jared daniel smith,,FIN-4040,2015
+FIN,4040,3,Financial Modeling,0.15,0.59,0.24,0.03,0.0,0.0,0.0,0.0,jared daniel smith,,FIN-4040,2015
+FIN,4050,1,Port Mgt and Theory,0.14,0.33,0.19,0.14,0.05,0.0,0.0,0.14,john alexander,,FIN-4050,2015
+FIN,4050,2,Port Mgt and Theory,0.08,0.54,0.08,0.31,0.0,0.0,0.0,0.0,john alexander,,FIN-4050,2015
+FIN,4080,1,Mgt of Fin Inst,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2015
+FIN,4080,2,Mgt of Fin Inst,0.5,0.19,0.31,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2015
+FIN,4110,1,Int Fin Mgt,0.1,0.41,0.33,0.13,0.03,0.0,0.0,0.0,tilan tang,,FIN-4110,2015
+FIN,4110,2,Int Fin Mgt,0.11,0.37,0.31,0.06,0.03,0.0,0.0,0.11,tilan tang,,FIN-4110,2015
+FIN,4150,1,Real Estate Investmt,0.29,0.5,0.14,0.0,0.07,0.0,0.0,0.0,thomas springer,,FIN-4150,2015
+FIN,4160,1,Real Estate Val,0.58,0.08,0.33,0.0,0.0,0.0,0.0,0.0,ramon tolb franklin,,FIN-4160,2015
+FNR,4700,35,Aquaponics,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,lance edwar beecher,,FNR-4700,2015
+FNR,4990,1,Natural Resources Seminar,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william roc english,,FNR-4990,2015
+FNR,4990,3,Natural Resources Seminar,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,william roc english,,FNR-4990,2015
+FOR,1010,1,Intro to Forestry,0.69,0.23,0.0,0.08,0.0,0.0,0.0,0.0,lawrence gering,,FOR-1010,2015
+FOR,2060,1,Forest Ecology,0.27,0.41,0.22,0.02,0.06,0.0,0.0,0.02,donald hagan,,FOR-2060,2015
+FOR,3080,1,Remote Sensing,0.28,0.44,0.16,0.12,0.0,0.0,0.0,0.0,lawrence gering,,FOR-3080,2015
+FOR,4060,1,For Watershed Mgmt,0.92,0.05,0.0,0.0,0.0,0.0,0.0,0.03,william roc english,,FOR-4060,2015
+FOR,4080,1,Wood & Paper Product,0.5,0.37,0.1,0.03,0.0,0.0,0.0,0.0,patricia layton,,FOR-4080,2015
+FOR,4150,1,For Wildlife Mgmt,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,james davis,,FOR-4150,2015
+FOR,4180,1,For Res Valuation,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,thomas straka,,FOR-4180,2015
+FOR,4250,1,For Res Mgt Plans,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,thomas straka,,FOR-4250,2015
+FOR,4340,1,GIS for Landscape Planning,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,robert frit baldwin,,FOR-4340,2015
+FOR,4650,1,Silviculture,0.29,0.38,0.29,0.04,0.0,0.0,0.0,0.0,gaofeng wang,,FOR-4650,2015
+FOR,8930,22,Ecotoxicology,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john rodgers,,FOR-8930,2015
+FR,1010,1,Elementary French,0.53,0.35,0.0,0.06,0.06,0.0,0.0,0.0,julian hamil killey,,FR-1010,2015
+FR,1020,2,Elementary French,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2015
+FR,1020,3,Elementary French,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,amy lyn grif sawyer,,FR-1020,2015
+FR,2010,1,Intermediate French,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2010,2015
+FR,2010,2,Intermediate French,0.6,0.25,0.05,0.05,0.05,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2010,2015
+FR,2010,4,Intermediate French,0.08,0.75,0.17,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-2010,2015
+FR,2020,1,Intermediate French,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-2020,2015
+FR,2020,2,Intermediate French,0.55,0.27,0.09,0.09,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-2020,2015
+FR,2020,3,Intermediate French,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,kelly digby peebles,,FR-2020,2015
+FR,2020,4,Intermediate French,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,,FR-2020,2015
+FR,3050,1,Int Fr Con & Comp I,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,,FR-3050,2015
+FR,3120,1,Writing in French I,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,kenneth dav widgren,,FR-3120,2015
+FR,3160,1,Fr for Intl Trade,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-3160,2015
+FR,4100,1,Francophone Lit,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,True,FR-4100,2015
+GC,1010,1,Orientation to G C,0.76,0.13,0.03,0.0,0.03,0.0,0.0,0.05,kern cox,,GC-1010,2015
+GC,1020,1,Comp Art & Cad Found,0.38,0.29,0.05,0.1,0.14,0.0,0.0,0.05,charles tabor weiss,,GC-1020,2015
+GC,1020,2,Comp Art & Cad Found,0.64,0.18,0.09,0.05,0.0,0.0,0.0,0.05,carol jones,,GC-1020,2015
+GC,1030,1,G C I for Pkgsc,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,john jacobs,,GC-1030,2015
+GC,1030,2,G C I for Pkgsc,0.08,0.54,0.23,0.08,0.08,0.0,0.0,0.0,john jacobs,,GC-1030,2015
+GC,1040,1,Graphic Communications I,0.53,0.31,0.09,0.03,0.02,0.0,0.0,0.01,rebecca suza edlein,,GC-1040,2015
+GC,1990,4,CI in GC I-J Lay CS,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,janice ann lay,,GC-1990,2015
+GC,2070,1,Graphic Communications II,0.6,0.31,0.06,0.0,0.03,0.0,0.0,0.0,patrick gee rose,,GC-2070,2015
+GC,3400,1,Digital Img & Emedia,0.44,0.4,0.13,0.0,0.02,0.0,0.0,0.02,erica black walker,,GC-3400,2015
+GC,4060,1,Package and Specialty Printing,0.25,0.6,0.1,0.0,0.03,0.0,0.0,0.03,kern cox,,GC-4060,2015
+GC,4400,1,Commercial Printing,0.62,0.35,0.0,0.0,0.0,0.0,0.0,0.03,eric weisenmiller,,GC-4400,2015
+GC,4440,1,Current Dev in G C,0.24,0.41,0.28,0.07,0.0,0.0,0.0,0.0,liam henry 'hara,,GC-4440,2015
+GC,4460,1,Ink & Substrates,0.13,0.71,0.09,0.04,0.0,0.0,0.0,0.02,liam henry 'hara,,GC-4460,2015
+GC,4480,1,Plan and Cont Print,0.8,0.1,0.05,0.05,0.0,0.0,0.0,0.0,john leininger,,GC-4480,2015
+GC,4900,2,G C Selected Topics-Sales,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,john leininger,,GC-4900,2015
+GEN,3000,1,Fundamental Genetics,0.33,0.27,0.27,0.08,0.02,0.0,0.0,0.04,kate leanne wi tsai,,GEN-3000,2015
+GEN,3000,2,Fundamental Genetics,0.4,0.4,0.13,0.04,0.01,0.0,0.0,0.02,haiying liang,,GEN-3000,2015
+GEN,4100,1,Population & Quant Genetics,0.4,0.4,0.03,0.09,0.06,0.0,0.0,0.03,amy lou lawton rauh,,GEN-4100,2015
+GEN,4110,1,Popultn & Quant Genetics Lab,0.6,0.2,0.0,0.1,0.0,0.0,0.0,0.1,amy lou lawton rauh,,GEN-4110,2015
+GEN,4110,2,Popultn & Quant Genetics Lab,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,amy lou lawton rauh,,GEN-4110,2015
+GEN,4110,3,Population and Quant Gen Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,,GEN-4110,2015
+GEN,4700,1,Human Genetics,0.46,0.38,0.11,0.03,0.0,0.0,0.0,0.03,leigh anne clark,,GEN-4700,2015
+GEOG,1010,1,Intro to Geography,0.28,0.4,0.28,0.05,0.0,0.0,0.0,0.0,christa smith,,GEOG-1010,2015
+GEOG,1030,1,World Regional Geog,0.82,0.12,0.04,0.02,0.0,0.0,0.0,0.0,lance forres howard,,GEOG-1030,2015
+GEOG,1030,2,World Regional Geog,0.38,0.35,0.15,0.03,0.0,0.0,0.0,0.1,william churc terry,,GEOG-1030,2015
+GEOG,3050,1,Cultural Geography,0.83,0.06,0.0,0.06,0.06,0.0,0.0,0.0,lance forres howard,,GEOG-3050,2015
+GEOL,1010,1,Physical Geology,0.39,0.32,0.14,0.06,0.05,0.0,0.0,0.03,alan coulson,,GEOL-1010,2015
+GEOL,1010,2,Physical Geology,0.38,0.36,0.17,0.03,0.01,0.0,0.0,0.05,alan coulson,,GEOL-1010,2015
+GEOL,1030,1,Physical Geol Lab,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2015
+GEOL,1030,2,Physical Geol Lab,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2015
+GEOL,1030,3,Physical Geol Lab,0.3,0.57,0.09,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2015
+GEOL,1030,4,Physical Geol Lab,0.3,0.52,0.13,0.04,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2015
+GEOL,1030,5,Physical Geol Lab,0.52,0.22,0.17,0.04,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2015
+GEOL,1030,6,Physical Geol Lab,0.59,0.18,0.14,0.0,0.0,0.0,0.0,0.09,alan coulson,,GEOL-1030,2015
+GEOL,1030,7,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2015
+GEOL,1030,8,Physical Geol Lab,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2015
+GEOL,1030,9,Physical Geol Lab,0.27,0.5,0.18,0.0,0.0,0.0,0.0,0.05,alan coulson,,GEOL-1030,2015
+GEOL,1030,10,Physical Geol Lab,0.42,0.46,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2015
+GEOL,1030,11,Physical Geol Lab,0.54,0.29,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,,GEOL-1030,2015
+GEOL,1120,1,Earth Resources,0.72,0.19,0.09,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-1120,2015
+GEOL,1140,1,Earth Resources Lab,0.68,0.1,0.16,0.03,0.0,0.0,0.0,0.03,scott brame,,GEOL-1140,2015
+GEOL,2020,1,Earth History,0.17,0.44,0.17,0.06,0.11,0.0,0.0,0.06,alan coulson,,GEOL-2020,2015
+GEOL,3750,1,Bahamian Field Study,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,james castle,,GEOL-3750,2015
+GEOL,4050,1,Surficial Geology,0.31,0.38,0.25,0.0,0.06,0.0,0.0,0.0,james castle,,GEOL-4050,2015
+GEOL,4090,1,Envir & Exploration Geophysics,0.53,0.18,0.06,0.0,0.12,0.0,0.0,0.12,stephen mich moysey,,GEOL-4090,2015
+GEOL,4210,1,Gis in Geology,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-4210,2015
+GEOL,6210,1,Gis in Geology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-6210,2015
+GEOL,7900,501,Biogeography & Geology of SC,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,,GEOL-7900,2015
+GEOL,8080,1,Groundwater Modeling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,,GEOL-8080,2015
+GER,1010,1,Elementary German,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,oswald harris king,,GER-1010,2015
+GER,1010,2,Elementary German,0.55,0.25,0.1,0.0,0.0,0.0,0.0,0.1,oswald harris king,,GER-1010,2015
+GER,1020,1,Elementary German,0.06,0.38,0.19,0.19,0.19,0.0,0.0,0.0, lee ferrell,,GER-1020,2015
+GER,1020,2,Elementary German,0.18,0.29,0.41,0.06,0.0,0.0,0.0,0.06, lee ferrell,,GER-1020,2015
+GER,2010,1,Intermediate German,0.3,0.2,0.3,0.1,0.0,0.0,0.0,0.1,gabriela stoicea,,GER-2010,2015
+GER,2010,2,Intermediate German,0.21,0.29,0.36,0.0,0.0,0.0,0.0,0.14,gabriela stoicea,,GER-2010,2015
+GER,2020,1,Intermediate German,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-2020,2015
+GER,3160,1,Ger for Intl Trade I,0.58,0.0,0.33,0.08,0.0,0.0,0.0,0.0, lee ferrell,,GER-3160,2015
+GER,3400,1,German Culture,0.45,0.25,0.1,0.05,0.0,0.0,0.0,0.15,oswald harris king,,GER-3400,2015
+HCC,8810,1,Affective Computing,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,shaundra daily,,HCC-8810,2015
+HCC,8810,3,Measurement & Eval,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,,HCC-8810,2015
+HEHD,3990,2,Students Helping Students Peer,0.85,0.1,0.03,0.0,0.0,0.0,0.0,0.03,mary mcp von kaenel,,HEHD-3990,2015
+HEHD,4000,1,Intro Leadership Theor & Conc,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lori marlise pindar,,HEHD-4000,2015
+HEHD,4990,5,The Global Community,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mark small,,HEHD-4990,2015
+HEHD,8010,230,Child/Adolescent Dev,0.76,0.14,0.05,0.0,0.0,0.0,0.0,0.05,edmond patri bowers,,HEHD-8010,2015
+HEHD,8040,230,Assessment/Eval,0.61,0.26,0.04,0.0,0.0,0.0,0.0,0.09,barry garst,,HEHD-8040,2015
+HEHD,8880,400,Special Topics Youth Dev Ldshp,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,,HEHD-8880,2015
+HIST,1010,1,Hist of the U S,0.41,0.43,0.11,0.0,0.05,0.0,0.0,0.0,lee brady wilson,,HIST-1010,2015
+HIST,1220,1,"Hist, Tech & Society",0.41,0.32,0.13,0.02,0.06,0.0,0.0,0.06,pamela mack,,HIST-1220,2015
+HIST,1240,1,Environmental Hist,0.14,0.54,0.27,0.03,0.0,0.0,0.0,0.03,james brad jeffries,,HIST-1240,2015
+HIST,1240,2,Environmental Hist,0.05,0.38,0.4,0.03,0.05,0.0,0.0,0.1,james brad jeffries,,HIST-1240,2015
+HIST,1720,1,The West and the World I,0.26,0.41,0.18,0.08,0.03,0.0,0.0,0.05,caroline dunn clark,,HIST-1720,2015
+HIST,1730,1,The West and the World II,0.3,0.32,0.21,0.0,0.1,0.0,0.0,0.07, alan grubb,,HIST-1730,2015
+HIST,1730,2,The West and the World II,0.32,0.24,0.27,0.07,0.04,0.0,0.0,0.07,richard saunders,,HIST-1730,2015
+HIST,1730,3,The West and the World II,0.25,0.44,0.2,0.02,0.07,0.0,0.0,0.02,steven marks,,HIST-1730,2015
+HIST,2990,1,Historian's Craft,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth carney,,HIST-2990,2015
+HIST,2990,2,Historian's Craft,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,rachel anne moore,,HIST-2990,2015
+HIST,3010,1,Am Rev & New Nation,0.26,0.19,0.33,0.0,0.15,0.0,0.0,0.07,james brad jeffries,,HIST-3010,2015
+HIST,3080,1,US: Reagan/Clinton 1975-Pres,0.4,0.27,0.18,0.0,0.13,0.0,0.0,0.02,richard saunders,,HIST-3080,2015
+HIST,3110,1,African American Hist to 1877,0.35,0.43,0.08,0.08,0.05,0.0,0.0,0.03,abel bartley,,HIST-3110,2015
+HIST,3240,1,Hist of the South II,0.32,0.49,0.08,0.03,0.05,0.0,0.0,0.03,john andrew,,HIST-3240,2015
+HIST,3260,1,Hist Am Transport,0.38,0.31,0.23,0.0,0.0,0.0,0.0,0.08, roger grant,,HIST-3260,2015
+HIST,3290,1,US Legal History Since 1890,0.15,0.05,0.2,0.2,0.0,0.0,0.0,0.4,maribel morey,,HIST-3290,2015
+HIST,3380,1,Africa to 1875,0.63,0.2,0.07,0.1,0.0,0.0,0.0,0.0,james burns,,HIST-3380,2015
+HIST,3410,1,Modern Mexico,0.49,0.4,0.0,0.03,0.06,0.0,0.0,0.03,rachel anne moore,,HIST-3410,2015
+HIST,3870,1,Russian Rev,0.37,0.33,0.23,0.0,0.0,0.0,0.0,0.07,steven marks,,HIST-3870,2015
+HIST,3890,2,Monarchs & Courtiers,0.77,0.15,0.0,0.08,0.0,0.0,0.0,0.0,caroline dunn clark,,HIST-3890,2015
+HIST,3900,1,Mod Mil Hist,0.19,0.31,0.36,0.08,0.03,0.0,0.0,0.03,edwin moise,,HIST-3900,2015
+HIST,3970,1,Modern Middle East,0.62,0.32,0.03,0.0,0.0,0.0,0.0,0.03,amit bein,,HIST-3970,2015
+HIST,4000,1,Battleground/Bloodfield RecnSC,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,paul chris anderson,,HIST-4000,2015
+HIST,4170,1,History and Tourism,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,leslie white,,HIST-4170,2015
+HIST,4510,1,Alexander the Great,0.45,0.25,0.2,0.0,0.1,0.0,0.0,0.0,elizabeth carney,,HIST-4510,2015
+HIST,4710,1,20th C France,0.57,0.21,0.0,0.0,0.0,0.0,0.0,0.21, alan grubb,,HIST-4710,2015
+HIST,4900,3,Food In Preindus,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,,HIST-4900,2015
+HIST,4900,4,Why Germans > Nazi?,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,michael meng,,HIST-4900,2015
+HIST,4920,1,US Iraq Wars,0.1,0.6,0.1,0.0,0.0,0.0,0.0,0.2,edwin moise,,HIST-4920,2015
+HIST,4930,1,Native American History - 1840,0.4,0.3,0.2,0.1,0.0,0.0,0.0,0.0,james brad jeffries,,HIST-4930,2015
+HIST,8200,1,Amer Historiography,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,john andrew,,HIST-8200,2015
+HLTH,2020,1,Introduction to Public Health,0.46,0.35,0.15,0.0,0.04,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2015
+HLTH,2020,2,Introduction to Public Health,0.38,0.35,0.19,0.05,0.0,0.0,0.0,0.03,jeffrey kingree,,HLTH-2020,2015
+HLTH,2020,400,Introduction to Public Health,0.57,0.24,0.05,0.0,0.1,0.0,0.0,0.05,ralph stewart welsh,,HLTH-2020,2015
+HLTH,2030,1,Health Care Sys,0.74,0.23,0.0,0.0,0.0,0.0,0.0,0.03,ralph stewart welsh,,HLTH-2030,2015
+HLTH,2030,2,Health Care Sys,0.38,0.48,0.12,0.0,0.0,0.0,0.0,0.02,frederic fraizer,,HLTH-2030,2015
+HLTH,2030,400,Health Care Sys,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2030,2015
+HLTH,2030,401,Health Care Sys,0.78,0.06,0.0,0.0,0.06,0.0,0.0,0.11,ralph stewart welsh,,HLTH-2030,2015
+HLTH,2400,1,Deter of Hlth Behav,0.29,0.51,0.15,0.03,0.03,0.0,0.0,0.0,joel edwar williams,,HLTH-2400,2015
+HLTH,2980,1,Human Hlth & Disease,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,,HLTH-2980,2015
+HLTH,2980,2,Human Hlth & Disease,0.74,0.21,0.02,0.0,0.0,0.0,0.0,0.02,annah kamugiz amani,,HLTH-2980,2015
+HLTH,3100,1,Women's Hlth Issues,0.5,0.41,0.03,0.03,0.0,0.0,0.0,0.03,rachel mayo,,HLTH-3100,2015
+HLTH,3150,1,Social Epidemiology,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,HLTH-3150,2015
+HLTH,3800,1,Epidemiology,0.37,0.34,0.17,0.05,0.02,0.0,0.0,0.05,rachel mayo,,HLTH-3800,2015
+HLTH,3800,2,Epidemiology,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-3800,2015
+HLTH,3980,2,Hlth Appraisal Sklls,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2015
+HLTH,4000,1,Health Systems Reform,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lingling zhang,,HLTH-4000,2015
+HLTH,4190,1,Health Sci Internship Prep Sem,0.44,0.34,0.12,0.05,0.02,0.0,0.0,0.02,kathleen meyer,,HLTH-4190,2015
+HLTH,4200,1,Hlth Science Intern,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,kathleen meyer,,HLTH-4200,2015
+HLTH,4300,1,Hlth Prom of Aged,0.52,0.22,0.17,0.04,0.0,0.0,0.0,0.04,cheryl jo dye,,HLTH-4300,2015
+HLTH,4310,1,Public & Environ Hlt,0.53,0.36,0.11,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-4310,2015
+HLTH,4600,1,Health Info Systems,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,ronald gimbel,,HLTH-4600,2015
+HLTH,4780,1,Hlth Pol Ehtics Law,0.07,0.45,0.31,0.03,0.03,0.0,0.0,0.1,hugh spitler,,HLTH-4780,2015
+HLTH,4790,1,Fin Mgmt & Hlth Budg,0.22,0.52,0.13,0.04,0.09,0.0,0.0,0.0,khoa dang truong,,HLTH-4790,2015
+HLTH,4800,1,Comm Hlth Promotion,0.24,0.74,0.0,0.0,0.0,0.0,0.0,0.03,sarah griffin,,HLTH-4800,2015
+HLTH,4900,1,Res Eval St Pub Hlth,0.87,0.06,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,,HLTH-4900,2015
+HLTH,4900,2,Res Eval St Pub Hlth,0.37,0.53,0.1,0.0,0.0,0.0,0.0,0.0,lingling zhang,,HLTH-4900,2015
+HLTH,4970,1,Creative Inq in Public Health,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,karen kemper,,HLTH-4970,2015
+HLTH,4970,4,Creative Inq in Public Health,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,george clay,,HLTH-4970,2015
+HLTH,8110,1,Health Care Delivery Systems,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,khoa dang truong,,HLTH-8110,2015
+HLTH,8310,1,Quantitative Analy in Hlth I,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,lu shi,,HLTH-8310,2015
+HON,2060,1,Intro to Nanotechnology,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,christophe kitchens,,HON-2060,2015
+HON,2210,1,Beauty in Western Literature,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,johannes schmidt,,HON-2210,2015
+HON,2210,3,Reading Data,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,lindsay carr thomas,,HON-2210,2015
+HON,2220,2,Doubles and Doppelgangers,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,,HON-2220,2015
+HORT,1010,1,Horticulture,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,,HORT-1010,2015
+HORT,2110,1,Growing Spring Plnts,0.15,0.3,0.45,0.05,0.0,0.0,0.0,0.05,james emerson faust,,HORT-2110,2015
+HORT,4000,4,Vegetable Crops,0.73,0.21,0.06,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,,HORT-4000,2015
+HORT,4040,1,Plant Propagation,0.13,0.25,0.46,0.08,0.04,0.0,0.0,0.04,jeffrey adelberg,,HORT-4040,2015
+HORT,4050,1,Plant Propagation Techniq Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,,HORT-4050,2015
+HORT,4050,2,Plant Propagation Techniq Lab,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,jeffrey adelberg,,HORT-4050,2015
+HORT,4270,1,Urban Tree Care,0.24,0.36,0.2,0.08,0.08,0.0,0.0,0.04,robert polomski,,HORT-4270,2015
+HORT,4330,1,Turf Weed Management,0.16,0.52,0.24,0.04,0.04,0.0,0.0,0.0,ted whitwell,,HORT-4330,2015
+HRD,8470,405,Instru System Design,0.75,0.0,0.0,0.0,0.25,0.0,0.0,0.0,philip mcgee,,HRD-8470,2015
+HRD,8490,402,Eval of T&D/Hrd Prog,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,,HRD-8490,2015
+HRD,8490,405,Eval of T&D/Hrd Prog,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,philip mcgee,,HRD-8490,2015
+HRD,8490,406,Eval of T&D/Hrd Prog,0.38,0.38,0.13,0.0,0.13,0.0,0.0,0.0,philip mcgee,,HRD-8490,2015
+HRD,8800,404,Research Concepts,0.94,0.0,0.0,0.0,0.06,0.0,0.0,0.0,jon fr christiansen,,HRD-8800,2015
+HRD,8970,402,Appl Resear & Devel,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,cynthia sims,,HRD-8970,2015
+HRD,8970,403,Appl Resear & Devel,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,cynthia sims,,HRD-8970,2015
+IE,2010,1,Systems Design I,0.74,0.24,0.0,0.0,0.0,0.0,0.0,0.01,robert james riggs,,IE-2010,2015
+IE,2100,1,Des Analysis Wrk Sys,0.16,0.52,0.24,0.04,0.02,0.0,0.0,0.02,david neyens,,IE-2100,2015
+IE,2800,1,Deterministic Operations Rsrch,0.2,0.25,0.38,0.09,0.04,0.0,0.0,0.05,burak eksioglu,,IE-2800,2015
+IE,3610,1,Industrial App of Prob/Stat II,0.42,0.42,0.09,0.03,0.03,0.0,0.0,0.0,joel greenstein,,IE-3610,2015
+IE,3810,1,Probabilistic Operations Rsrch,0.26,0.44,0.2,0.06,0.05,0.0,0.0,0.0,amin khademi,,IE-3810,2015
+IE,3840,1,Engr Econ Analysis,0.29,0.23,0.12,0.07,0.1,0.0,0.0,0.18,brian melloy,,IE-3840,2015
+IE,3860,1,Prod Plan & Cont,0.43,0.41,0.11,0.02,0.02,0.0,0.0,0.01,robert james riggs,,IE-3860,2015
+IE,4570,1,Transp/Logistic Engr,0.34,0.4,0.11,0.14,0.0,0.0,0.0,0.0,sandra dun eksioglu,,IE-4570,2015
+IE,4620,1,Six Sigma Quality,0.25,0.39,0.27,0.03,0.0,0.04,0.0,0.01,byung rae cho,,IE-4620,2015
+IE,4670,1,System Design II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,,IE-4670,2015
+IE,4860,1,Scheduling,0.29,0.5,0.14,0.07,0.0,0.0,0.0,0.0,scott jenning mason,,IE-4860,2015
+IE,4910,2,HF in Transportation Systems,0.64,0.26,0.1,0.0,0.0,0.0,0.0,0.0,david neyens,,IE-4910,2015
+IE,6810,1,App of Prob Models in Ind Engr,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,brian melloy,,IE-6810,2015
+IE,6860,1,Scheduling,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-6860,2015
+IE,8010,1,Human-Machine Sys,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,,IE-8010,2015
+IE,8040,1,Mfg Sys Plan & Des,0.12,0.31,0.19,0.0,0.19,0.0,0.0,0.19,william ferrell,,IE-8040,2015
+IE,8050,1,Found Qual Engr,0.42,0.46,0.13,0.0,0.0,0.0,0.0,0.0,byung rae cho,,IE-8050,2015
+IE,8150,1,Research Methods in Ergonomics,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,sara lu riggs,,IE-8150,2015
+IE,8520,1,Model Decis Making,0.8,0.15,0.02,0.0,0.0,0.0,0.0,0.02,jonathan cole smith,,IE-8520,2015
+IE,8540,1,Fund of Sc and Log,0.74,0.14,0.05,0.0,0.0,0.0,0.0,0.07,william ferrell,,IE-8540,2015
+IE,8580,1,Case Stu Cap Prof Sc,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-8580,2015
+IE,8810,1,Metaheuristics,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,,IE-8810,2015
+IE,8880,1,Adv Prob Methods,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,burak eksioglu,,IE-8880,2015
+INT,1010,5,UPIC 1st Part Time Internship,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.01,troy nunamaker,,INT-1010,2015
+INT,2020,5,UPIC 2nd Full Time Internship,0.0,0.0,0.0,0.0,0.0,0.77,0.15,0.08,troy nunamaker,,INT-2020,2015
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.84,0.12,0.03,meredith fan wilson,,IS-1010,2015
+IS,2100,615,Sel Topics Int Study,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sallie bro turnbull,,IS-2100,2015
+ITAL,1010,1,Elementary Italian,0.48,0.29,0.1,0.0,0.05,0.0,0.0,0.1,julia schmidt,,ITAL-1010,2015
+ITAL,1020,1,Elementary Italian,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,luca barattoni,,ITAL-1020,2015
+ITAL,1020,3,Elementary Italian,0.33,0.4,0.27,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-1020,2015
+ITAL,2010,1,Intermediate Italian,0.23,0.38,0.31,0.08,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2010,2015
+ITAL,2020,1,Intermediate Italian,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2020,2015
+ITAL,2020,2,Intermediate Italian,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2020,2015
+JAPN,1010,1,Elementary Japanese,0.43,0.0,0.21,0.07,0.07,0.0,0.0,0.21,kazuko shoji,,JAPN-1010,2015
+JAPN,1010,2,Elementary Japanese,0.53,0.24,0.06,0.06,0.0,0.0,0.0,0.12,toshiko kishimoto,,JAPN-1010,2015
+JAPN,1020,1,Elementary Japanese,0.5,0.25,0.08,0.0,0.08,0.0,0.0,0.08,toshiko joerger,,JAPN-1020,2015
+JAPN,1020,2,Elementary Japanese,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,toshiko joerger,,JAPN-1020,2015
+JAPN,2020,1,Intermed Japanese,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,kazuko shoji,,JAPN-2020,2015
+JAPN,3060,1,Japanese Conversation & Comp,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,toshiko kishimoto,,JAPN-3060,2015
+LARC,1160,1,History of Landscape Architect,0.39,0.3,0.16,0.08,0.01,0.0,0.0,0.06,hala fouad nassar,,LARC-1160,2015
+LARC,1160,2,History of Larch,0.59,0.35,0.02,0.04,0.0,0.0,0.0,0.0,martin john holland,,LARC-1160,2015
+LARC,1520,1,Basic Design II,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,paul russell,,LARC-1520,2015
+LARC,4280,1,Comput Aided Design,0.5,0.44,0.0,0.0,0.06,0.0,0.0,0.0,shan jiang,,LARC-4280,2015
+LARC,6530,1,Key Issues in Larch,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,,LARC-6530,2015
+LARC,8300,1,Grad Seminar I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,LARC-8300,2015
+LAW,3220,1,Legal Env of Bus,0.3,0.6,0.08,0.02,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2015
+LAW,3220,2,Legal Env of Bus,0.32,0.48,0.12,0.06,0.02,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2015
+LAW,3220,3,Legal Env of Bus,0.39,0.52,0.06,0.03,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2015
+LAW,3220,4,Legal Env of Bus,0.45,0.38,0.14,0.03,0.0,0.0,0.0,0.0,melvin stith,,LAW-3220,2015
+LAW,3220,5,Legal Env of Bus,0.44,0.34,0.13,0.05,0.03,0.0,0.0,0.02,melvin stith,,LAW-3220,2015
+LAW,3220,6,Legal Env of Bus,0.16,0.3,0.21,0.09,0.05,0.0,0.0,0.19,virgini ward-vaughn,,LAW-3220,2015
+LAW,3220,7,Legal Env of Bus,0.11,0.54,0.19,0.05,0.03,0.0,0.0,0.08,virgini ward-vaughn,,LAW-3220,2015
+LAW,3220,8,Legal Env of Bus,0.06,0.42,0.32,0.0,0.1,0.0,0.0,0.1,virgini ward-vaughn,,LAW-3220,2015
+LAW,3220,10,Legal Env of Bus,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-3220,2015
+LAW,3220,11,Legal Env of Bus,0.09,0.53,0.27,0.08,0.03,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2015
+LAW,3220,12,Legal Env of Bus,0.16,0.37,0.3,0.16,0.02,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2015
+LAW,3220,13,Legal Env of Bus,0.25,0.49,0.19,0.02,0.0,0.0,0.0,0.05,john hine,,LAW-3220,2015
+LAW,3220,14,Legal Env of Bus,0.23,0.59,0.16,0.0,0.0,0.0,0.0,0.02,john hine,,LAW-3220,2015
+LAW,3330,1,Real Estate Law,0.15,0.5,0.32,0.0,0.03,0.0,0.0,0.0,michael bra burrell,,LAW-3330,2015
+LAW,4060,1,Sports Law,0.63,0.29,0.0,0.0,0.04,0.04,0.0,0.0,terry don phillips,,LAW-4060,2015
+LAW,8480,1,Law Real Estate Prof,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,maurie lou lawrence,,LAW-8480,2015
+LAW,8500,1,Law for Prof Accts,0.45,0.52,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-8500,2015
+LAW,8500,2,Law for Prof Accts,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-8500,2015
+LS,1000,2,Fitness Leadership,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,patricia figueroa,,LS-1000,2015
+LS,1000,7,Intro to Photography,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sarah elizab mudder,,LS-1000,2015
+LS,1000,9,Intro to Salsa Dance,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,,LS-1000,2015
+LS,1000,12,Intermediate Rock Climbing,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,glenn dav middleton,,LS-1000,2015
+LS,1000,22,Intermediate Ashtanga Yoga,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,,LS-1000,2015
+LS,1000,27,Beg. Non-competitive Karate,0.73,0.0,0.0,0.09,0.0,0.0,0.0,0.18,june pilcher,,LS-1000,2015
+LS,1130,1,Wood Carving,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,daniel mor anderson,,LS-1130,2015
+LS,1410,2,Top Rope Climbing,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,glenn dav middleton,,LS-1410,2015
+LS,1580,2,Archery,0.8,0.0,0.07,0.0,0.0,0.0,0.0,0.13,herbert strickland,,LS-1580,2015
+LS,1650,3,Inland Kayak Touring,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,george wal thompson,,LS-1650,2015
+LS,1830,1,Intro to Rugby,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,justin hickey,,LS-1830,2015
+LS,1870,2,Frisbee Sports,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,craig goodman,,LS-1870,2015
+LS,1940,1,Racquetball,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,raymond petersen,,LS-1940,2015
+LS,1940,2,Racquetball,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,raymond petersen,,LS-1940,2015
+LS,1990,1,Intermediate Golf,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,jason jordan,,LS-1990,2015
+LS,2100,2,Learn to Dance,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,matthew lee krabbe,,LS-2100,2015
+LS,2100,4,Learn to Dance,0.74,0.07,0.15,0.0,0.0,0.0,0.0,0.04,paul hoke,,LS-2100,2015
+LS,2110,2,Introduction to Belly Dance,0.82,0.05,0.05,0.0,0.0,0.0,0.0,0.09,stephanie pack,,LS-2110,2015
+LS,2190,1,Country West Dance,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.1,matthew lee krabbe,,LS-2190,2015
+LS,2200,6,Shag,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,broadus fleming,,LS-2200,2015
+LS,2200,8,Shag,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,,LS-2200,2015
+LS,2270,1,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.03,0.0,0.0,0.03,paul hoke,,LS-2270,2015
+LS,2270,4,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,paul hoke,,LS-2270,2015
+LS,2320,1,Core Training,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,diane moreno,,LS-2320,2015
+LS,2350,2,Basic Yoga,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,,LS-2350,2015
+LS,2350,3,Basic Yoga,0.83,0.04,0.09,0.04,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2015
+LS,2350,4,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2015
+LS,2350,5,Basic Yoga,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2350,2015
+LS,2350,6,Basic Yoga,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,,LS-2350,2015
+LS,2360,1,Power/Ashtanga Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,,LS-2360,2015
+LS,2360,2,Power/Ashtanga Yoga,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,ani reina-nunnelley,,LS-2360,2015
+LS,2370,3,Kripalu Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,,LS-2370,2015
+LS,2370,4,Kripalu Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,,LS-2370,2015
+LS,2370,5,Kripalu Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,,LS-2370,2015
+LS,2380,4,Vinyasa Flow Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jenefer nadenicek,,LS-2380,2015
+LS,2420,2,Meditation and Relax,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,,LS-2420,2015
+LS,2420,3,Meditation and Relax,0.79,0.05,0.0,0.0,0.0,0.0,0.0,0.16,ranjanbala dil amin,,LS-2420,2015
+LS,2420,4,Meditation and Relax,0.82,0.05,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,,LS-2420,2015
+LS,2420,6,Meditation and Relax,0.65,0.13,0.0,0.04,0.0,0.0,0.0,0.17,renee warren gahan,,LS-2420,2015
+LS,2450,1,Pilates,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,melanie ivey job,,LS-2450,2015
+LS,2500,1,Marathon Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,john walston dunn,True,LS-2500,2015
+LS,2510,2,Running & Jogging,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,corey dou brookover,,LS-2510,2015
+LS,2660,1,Hapkido,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,kelly smith,,LS-2660,2015
+MATH,1010,1,Essen Math for Informed Soc,0.4,0.32,0.12,0.04,0.0,0.0,0.0,0.12,marilyn reba,,MATH-1010,2015
+MATH,1010,2,Essen Math for Informed Soc,0.42,0.17,0.31,0.11,0.0,0.0,0.0,0.0,judith cottingham,,MATH-1010,2015
+MATH,1010,3,Essen Math for Informed Soc,0.47,0.21,0.16,0.11,0.0,0.0,0.0,0.05,paran rebeka norton,,MATH-1010,2015
+MATH,1010,4,Essen Math for Informed Soc,0.32,0.27,0.16,0.14,0.03,0.0,0.0,0.08,judith cottingham,,MATH-1010,2015
+MATH,1010,5,Essen Math for Informed Soc,0.12,0.29,0.29,0.0,0.29,0.0,0.0,0.0,sergey charnyi,,MATH-1010,2015
+MATH,1010,6,Essen Math for Informed Soc,0.38,0.29,0.21,0.03,0.03,0.0,0.0,0.06,megan elizabet ryan,,MATH-1010,2015
+MATH,1010,7,Essen Math for Informed Soc,0.32,0.32,0.16,0.11,0.05,0.0,0.0,0.05,merle glick,,MATH-1010,2015
+MATH,1020,1,Intro to Mathematical Analysis,0.24,0.14,0.1,0.24,0.14,0.0,0.0,0.14,vito capuano,,MATH-1020,2015
+MATH,1020,2,Intro to Mathematical Analysis,0.07,0.24,0.2,0.24,0.12,0.0,0.0,0.12,thanh thien to,,MATH-1020,2015
+MATH,1020,3,Intro to Mathematical Analysis,0.13,0.22,0.2,0.07,0.33,0.0,0.0,0.04,matthew harr menard,,MATH-1020,2015
+MATH,1020,4,Intro to Mathematical Analysis,0.15,0.18,0.21,0.13,0.26,0.0,0.0,0.08,liu zhu,,MATH-1020,2015
+MATH,1020,5,Intro to Mathematical Analysis,0.13,0.41,0.22,0.09,0.13,0.0,0.0,0.02,randy davidson,,MATH-1020,2015
+MATH,1020,6,Intro to Mathematical Analysis,0.15,0.3,0.25,0.1,0.1,0.0,0.0,0.1,david james rea,,MATH-1020,2015
+MATH,1020,7,Intro to Mathematical Analysis,0.15,0.37,0.2,0.04,0.22,0.0,0.0,0.02,abigail bowers,,MATH-1020,2015
+MATH,1020,8,Intro to Mathematical Analysis,0.11,0.18,0.27,0.14,0.27,0.0,0.0,0.02,samuel jose shesman,,MATH-1020,2015
+MATH,1020,9,Intro to Mathematical Analysis,0.2,0.3,0.3,0.07,0.11,0.0,0.0,0.02,abigail bowers,,MATH-1020,2015
+MATH,1020,10,Intro to Mathematical Analysis,0.19,0.33,0.29,0.07,0.07,0.0,0.0,0.05,randy davidson,,MATH-1020,2015
+MATH,1020,11,Intro to Mathematical Analysis,0.18,0.46,0.1,0.1,0.05,0.0,0.0,0.1,randy davidson,,MATH-1020,2015
+MATH,1020,12,Intro to Mathematical Analysis,0.2,0.2,0.3,0.15,0.1,0.0,0.0,0.05,isaac justus,,MATH-1020,2015
+MATH,1020,13,Intro to Mathematical Analysis,0.14,0.23,0.27,0.09,0.18,0.0,0.0,0.09,"rodriguez esperanza,",,MATH-1020,2015
+MATH,1020,14,Intro to Mathematical Analysis,0.16,0.2,0.38,0.09,0.09,0.0,0.0,0.09,abigail bowers,,MATH-1020,2015
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.28,0.67,0.05, morales hernandez,,MATH-1040,2015
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.19,0.72,0.09,javier ruiz ramirez,,MATH-1040,2015
+MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.56,0.44,0.0,eliza dar gallagher,,MATH-1050,2015
+MATH,1060,1,Calculus of One Variable I,0.02,0.14,0.24,0.14,0.24,0.0,0.0,0.22,charity watson,,MATH-1060,2015
+MATH,1060,2,Calculus of One Variable I,0.0,0.04,0.2,0.16,0.43,0.0,0.0,0.16,sanwar ahmad,,MATH-1060,2015
+MATH,1060,3,Calculus of One Variable I,0.03,0.39,0.12,0.12,0.18,0.0,0.0,0.15,allen anderso guest,,MATH-1060,2015
+MATH,1060,4,Calculus of One Variable I,0.06,0.12,0.33,0.27,0.09,0.0,0.0,0.12,allen anderso guest,,MATH-1060,2015
+MATH,1060,5,Calculus of One Variable I,0.04,0.17,0.25,0.15,0.23,0.0,0.0,0.17,honghai xu,,MATH-1060,2015
+MATH,1060,6,Calculus of One Variable I,0.0,0.17,0.21,0.26,0.23,0.0,0.0,0.13,charity watson,,MATH-1060,2015
+MATH,1060,7,Calculus of One Variable I,0.02,0.09,0.3,0.22,0.35,0.0,0.0,0.02,abdullah al mamun,,MATH-1060,2015
+MATH,1060,201,Calculus of One Variable I,0.25,0.08,0.25,0.0,0.33,0.0,0.0,0.08,james peterson,,MATH-1060,2015
+MATH,1070,1,Differen and Integral Calculus,0.18,0.48,0.27,0.03,0.0,0.0,0.0,0.03,donna simms,,MATH-1070,2015
+MATH,1070,2,Differen and Integral Calculus,0.11,0.36,0.33,0.17,0.0,0.0,0.0,0.03,donna simms,,MATH-1070,2015
+MATH,1070,3,Differen and Integral Calculus,0.0,0.14,0.5,0.21,0.07,0.0,0.0,0.07,sherry biggers,,MATH-1070,2015
+MATH,1070,4,Differen and Integral Calculus,0.08,0.29,0.29,0.26,0.08,0.0,0.0,0.0,sherry biggers,,MATH-1070,2015
+MATH,1070,5,Differen and Integral Calculus,0.03,0.32,0.29,0.23,0.06,0.0,0.0,0.06,sherry biggers,,MATH-1070,2015
+MATH,1070,6,Differen and Integral Calculus,0.09,0.23,0.36,0.14,0.09,0.0,0.0,0.09,jason to hedetniemi,,MATH-1070,2015
+MATH,1070,7,Differen and Integral Calculus,0.09,0.45,0.18,0.09,0.09,0.0,0.0,0.09,fiona may knoll,,MATH-1070,2015
+MATH,1080,1,Calculus of One Variable II,0.07,0.19,0.19,0.05,0.17,0.0,0.0,0.33,christa con johnson,,MATH-1080,2015
+MATH,1080,2,Calculus of One Variable II,0.05,0.07,0.14,0.05,0.33,0.0,0.0,0.36,sarah eliz anderson,,MATH-1080,2015
+MATH,1080,3,Calculus of One Variable II,0.04,0.24,0.22,0.11,0.18,0.0,0.0,0.2,christa con johnson,,MATH-1080,2015
+MATH,1080,4,Calculus of One Variable II,0.19,0.17,0.26,0.09,0.11,0.0,0.0,0.19,meredith nicol burr,,MATH-1080,2015
+MATH,1080,5,Calculus of One Variable II,0.02,0.3,0.17,0.13,0.04,0.0,0.0,0.33,audrey nico devries,,MATH-1080,2015
+MATH,1080,6,Calculus of One Variable II,0.09,0.19,0.28,0.07,0.09,0.0,0.0,0.28,meredith nicol burr,,MATH-1080,2015
+MATH,1080,7,Calculus of One Variable II,0.02,0.05,0.23,0.16,0.3,0.0,0.0,0.23,terri johnson,,MATH-1080,2015
+MATH,1080,8,Calculus of One Variable II,0.0,0.14,0.05,0.19,0.21,0.0,0.0,0.42,alistair bentley,,MATH-1080,2015
+MATH,1080,9,Calculus of One Variable II,0.05,0.17,0.2,0.15,0.17,0.0,0.0,0.27,karyn muir,,MATH-1080,2015
+MATH,1080,10,Calculus of One Variable II,0.16,0.2,0.24,0.13,0.09,0.0,0.0,0.18,meredith nicol burr,,MATH-1080,2015
+MATH,1080,11,Calculus of One Variable II,0.11,0.24,0.2,0.09,0.11,0.0,0.0,0.24,shih-wei chao,,MATH-1080,2015
+MATH,1080,12,Calculus of One Variable II,0.0,0.14,0.16,0.14,0.19,0.0,0.0,0.37,rebecca ramos,,MATH-1080,2015
+MATH,1080,13,Calculus of One Variable II,0.0,0.19,0.31,0.16,0.13,0.0,0.0,0.22,marilyn reba,,MATH-1080,2015
+MATH,1080,14,Calculus of One Variable II,0.13,0.23,0.23,0.1,0.0,0.0,0.0,0.32,marilyn reba,,MATH-1080,2015
+MATH,1080,15,Calculus of One Variable II,0.0,0.11,0.14,0.02,0.23,0.0,0.0,0.5,stefan adam bock,,MATH-1080,2015
+MATH,1150,1,Contemp Math for Elem Teach I,0.44,0.46,0.08,0.0,0.0,0.0,0.0,0.03,allison stoddard,,MATH-1150,2015
+MATH,1160,1,Contemp Math for Elem Teach II,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1160,2015
+MATH,1160,2,Contemp Math for Elem Teach II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1160,2015
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.87,0.11,0.02,marion hanna,,MATH-1990,2015
+MATH,2060,1,Calculus of Several Variables,0.14,0.26,0.23,0.09,0.14,0.0,0.0,0.14,patrick buckingham,,MATH-2060,2015
+MATH,2060,2,Calculus of Several Variables,0.19,0.06,0.1,0.06,0.19,0.0,0.0,0.39,dania moham zantout,,MATH-2060,2015
+MATH,2060,3,Calculus of Several Variables,0.37,0.4,0.17,0.0,0.06,0.0,0.0,0.0,chanseok park,,MATH-2060,2015
+MATH,2060,4,Calculus of Several Variables,0.76,0.14,0.08,0.03,0.0,0.0,0.0,0.0,martin joha schmoll,,MATH-2060,2015
+MATH,2060,5,Calculus of Several Variables,0.06,0.38,0.29,0.12,0.12,0.0,0.0,0.03,charles johnson,,MATH-2060,2015
+MATH,2060,6,Calculus of Several Variables,0.18,0.15,0.06,0.15,0.21,0.0,0.0,0.26,dania moham zantout,,MATH-2060,2015
+MATH,2060,7,Calculus of Several Variables,0.41,0.44,0.09,0.0,0.06,0.0,0.0,0.0,sofya alekseeva,,MATH-2060,2015
+MATH,2060,8,Calculus of Several Variables,0.07,0.17,0.28,0.03,0.24,0.0,0.0,0.21,dania moham zantout,,MATH-2060,2015
+MATH,2060,10,Calculus of Several Variables,0.14,0.31,0.19,0.22,0.11,0.0,0.0,0.03,charles johnson,,MATH-2060,2015
+MATH,2060,12,Calculus of Several Variables,0.32,0.41,0.12,0.0,0.09,0.0,0.0,0.06,sofya alekseeva,,MATH-2060,2015
+MATH,2060,100,Calc of Several Variable (HON),0.54,0.38,0.0,0.0,0.08,0.0,0.0,0.0,james brown,True,MATH-2060,2015
+MATH,2070,1,Multivariable Calculus,0.16,0.26,0.21,0.16,0.16,0.0,0.0,0.05,elaine ma sotherden,,MATH-2070,2015
+MATH,2070,2,Multivariable Calculus,0.26,0.26,0.26,0.11,0.11,0.0,0.0,0.0,garrett dranichak,,MATH-2070,2015
+MATH,2070,4,Multivariable Calculus,0.14,0.27,0.23,0.09,0.14,0.0,0.0,0.14,amy christine grady,,MATH-2070,2015
+MATH,2070,5,Multivariable Calculus,0.27,0.22,0.22,0.15,0.1,0.0,0.0,0.05,jennifer mari hanna,,MATH-2070,2015
+MATH,2070,6,Multivariable Calculus,0.19,0.43,0.21,0.07,0.02,0.0,0.0,0.07,judith irene mcknew,,MATH-2070,2015
+MATH,2070,7,Multivariable Calculus,0.36,0.26,0.19,0.12,0.05,0.0,0.0,0.02,jennifer mari hanna,,MATH-2070,2015
+MATH,2070,9,Multivariable Calculus,0.15,0.32,0.17,0.05,0.2,0.0,0.0,0.12,grady mcgowa thomas,,MATH-2070,2015
+MATH,2070,10,Multivariable Calculus,0.14,0.14,0.36,0.02,0.24,0.0,0.0,0.1,liem nguyen,,MATH-2070,2015
+MATH,2070,11,Multivariable Calculus,0.32,0.27,0.27,0.0,0.09,0.0,0.0,0.05,tony thanh nguyen,,MATH-2070,2015
+MATH,2070,12,Multivariable Calculus,0.27,0.32,0.23,0.0,0.14,0.0,0.0,0.05,kara ail stasikelis,,MATH-2070,2015
+MATH,2070,13,Multivariable Calculus,0.15,0.55,0.2,0.1,0.0,0.0,0.0,0.0,mengying xiao,,MATH-2070,2015
+MATH,2070,14,Multivariable Calculus,0.4,0.2,0.1,0.05,0.2,0.0,0.0,0.05,luke marti giberson,,MATH-2070,2015
+MATH,2070,15,Multivariable Calculus,0.31,0.21,0.21,0.14,0.05,0.0,0.0,0.07,judith irene mcknew,,MATH-2070,2015
+MATH,2070,16,Multivariable Calculus,0.2,0.35,0.2,0.05,0.1,0.0,0.0,0.1,kevin wayne dettman,,MATH-2070,2015
+MATH,2070,17,Multivariable Calculus,0.14,0.38,0.33,0.0,0.05,0.0,0.0,0.1,fawwaz taw batayneh,,MATH-2070,2015
+MATH,2070,19,Multivariable Calculus,0.33,0.21,0.26,0.05,0.14,0.0,0.0,0.02,margaret milliken,,MATH-2070,2015
+MATH,2070,20,Multivariable Calculus,0.33,0.28,0.22,0.0,0.11,0.0,0.0,0.06, ushijima-mwesigwa,,MATH-2070,2015
+MATH,2070,21,Multivariable Calculus,0.24,0.37,0.17,0.1,0.07,0.0,0.0,0.05,jennifer mari hanna,,MATH-2070,2015
+MATH,2070,22,Multivariable Calculus,0.17,0.33,0.06,0.06,0.17,0.0,0.0,0.22,trevor scot vilardi,,MATH-2070,2015
+MATH,2070,24,Multivariable Calculus,0.21,0.21,0.26,0.0,0.16,0.0,0.0,0.16,qijun he,,MATH-2070,2015
+MATH,2070,25,Multivariable Calculus,0.34,0.2,0.2,0.12,0.07,0.0,0.0,0.07,jennifer mari hanna,,MATH-2070,2015
+MATH,2070,26,Multivariable Calculus,0.06,0.24,0.29,0.12,0.18,0.0,0.0,0.12,yisu jia,,MATH-2070,2015
+MATH,2080,1,Intro to Ordin Diff Equations,0.08,0.3,0.18,0.15,0.1,0.0,0.0,0.2,terri johnson,,MATH-2080,2015
+MATH,2080,3,Intro to Ordin Diff Equations,0.09,0.26,0.13,0.11,0.2,0.0,0.0,0.2,timothy fra parrott,,MATH-2080,2015
+MATH,2080,4,Intro to Ordin Diff Equations,0.13,0.32,0.06,0.06,0.19,0.0,0.0,0.23,shari prevost,,MATH-2080,2015
+MATH,2080,5,Intro to Ordin Diff Equations,0.3,0.3,0.16,0.05,0.16,0.0,0.0,0.05,minerva rios-adams,,MATH-2080,2015
+MATH,2080,6,Intro to Ordin Diff Equations,0.21,0.45,0.13,0.11,0.08,0.0,0.0,0.03,minerva rios-adams,,MATH-2080,2015
+MATH,2080,7,Intro to Ordin Diff Equations,0.2,0.24,0.34,0.0,0.15,0.0,0.0,0.07,julie lassiter,,MATH-2080,2015
+MATH,2080,8,Intro to Ordin Diff Equations,0.41,0.15,0.26,0.0,0.04,0.0,0.0,0.13,timothy fra parrott,,MATH-2080,2015
+MATH,2080,9,Intro to Ordin Diff Equations,0.49,0.22,0.22,0.04,0.0,0.0,0.0,0.02,timothy ch teitloff,,MATH-2080,2015
+MATH,2080,10,Intro to Ordin Diff Equations,0.21,0.21,0.15,0.18,0.12,0.0,0.0,0.15,shari prevost,,MATH-2080,2015
+MATH,2080,11,Intro to Ordin Diff Equations,0.36,0.29,0.09,0.09,0.09,0.0,0.0,0.09,timothy fra parrott,,MATH-2080,2015
+MATH,2080,12,Intro to Ordin Diff Equations,0.31,0.22,0.31,0.14,0.0,0.0,0.0,0.03,timothy ch teitloff,,MATH-2080,2015
+MATH,2080,13,Intro to Ordin Diff Equations,0.24,0.24,0.33,0.15,0.03,0.0,0.0,0.0,julie lassiter,,MATH-2080,2015
+MATH,2080,14,Intro to Ordin Diff Equations,0.39,0.29,0.2,0.05,0.0,0.0,0.0,0.07,nathan jos adelgren,,MATH-2080,2015
+MATH,2080,15,Intro to Ordin Diff Equations,0.53,0.27,0.16,0.02,0.02,0.0,0.0,0.0,timothy ch teitloff,,MATH-2080,2015
+MATH,2080,16,Intro to Ordin Diff Equations,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,irina viktorova,,MATH-2080,2015
+MATH,2080,17,Intro to Ordin Diff Equations,0.3,0.51,0.11,0.0,0.03,0.0,0.0,0.05,brandon gra goodell,,MATH-2080,2015
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,james brannan,True,MATH-2080,2015
+MATH,2160,1,Geometry for Elem Sch Teachers,0.57,0.4,0.0,0.0,0.03,0.0,0.0,0.0,allison stoddard,,MATH-2160,2015
+MATH,3020,1,Stat for Science & Engineering,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,christopher wilson,,MATH-3020,2015
+MATH,3020,2,Stat for Science & Engineering,0.7,0.14,0.05,0.04,0.05,0.0,0.0,0.02,dominique morgan,,MATH-3020,2015
+MATH,3020,3,Stat for Science & Engineering,0.45,0.25,0.07,0.05,0.14,0.0,0.0,0.05,christopher mcmahan,,MATH-3020,2015
+MATH,3020,4,Stat for Science & Engineering,0.69,0.21,0.05,0.05,0.0,0.0,0.0,0.0,xiaoqian sun,,MATH-3020,2015
+MATH,3020,5,Stat for Science & Engineering,0.19,0.35,0.26,0.06,0.04,0.0,0.0,0.11,michael thom finney,,MATH-3020,2015
+MATH,3080,1,College Geometry,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,eliza dar gallagher,,MATH-3080,2015
+MATH,3110,1,Linear Algebra,0.38,0.22,0.14,0.14,0.11,0.0,0.0,0.03,elena sta dimitrova,,MATH-3110,2015
+MATH,3110,2,Linear Algebra,0.5,0.34,0.13,0.03,0.0,0.0,0.0,0.0,judith cottingham,,MATH-3110,2015
+MATH,3110,3,Linear Algebra,0.21,0.24,0.41,0.03,0.06,0.0,0.0,0.06,svetlan poznanovikj,,MATH-3110,2015
+MATH,3110,4,Linear Algebra,0.31,0.11,0.23,0.06,0.17,0.0,0.0,0.11,xuhong gao,,MATH-3110,2015
+MATH,3110,5,Linear Algebra,0.56,0.16,0.08,0.0,0.08,0.0,0.0,0.12,xuhong gao,,MATH-3110,2015
+MATH,3150,1,Adv Top in Math for Elem Teach,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-3150,2015
+MATH,3190,1,Introduction to Proof,0.35,0.26,0.17,0.0,0.13,0.0,0.0,0.09,kevin james,,MATH-3190,2015
+MATH,3190,2,Introduction to Proof,0.4,0.3,0.1,0.0,0.1,0.0,0.0,0.1,michael adam burr,,MATH-3190,2015
+MATH,3600,1,Intermediate Math Computing,0.63,0.2,0.05,0.0,0.07,0.0,0.0,0.05,neil calkin,,MATH-3600,2015
+MATH,3650,1,Numerical Mthds for Engineers,0.72,0.26,0.02,0.0,0.0,0.0,0.0,0.0,abigail bowers,,MATH-3650,2015
+MATH,3650,2,Numerical Mthds for Engineers,0.17,0.22,0.33,0.14,0.08,0.0,0.0,0.06,christopher cox,,MATH-3650,2015
+MATH,3650,3,Numerical Mthds for Engineers,0.19,0.31,0.33,0.06,0.06,0.0,0.0,0.06,christopher cox,,MATH-3650,2015
+MATH,4000,1,Theory of Probability,0.5,0.21,0.11,0.04,0.11,0.0,0.0,0.04,yingbo li,,MATH-4000,2015
+MATH,4030,1,Intro to Statistical Theory,0.36,0.23,0.23,0.05,0.09,0.0,0.0,0.05,xiaoqian sun,,MATH-4030,2015
+MATH,4070,1,Regress & Time-Series Analysis,0.5,0.29,0.21,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-4070,2015
+MATH,4100,1,Number Theory,0.4,0.25,0.15,0.15,0.05,0.0,0.0,0.0,charles johnson,,MATH-4100,2015
+MATH,4120,1,Intro to Modern Algebra,0.28,0.21,0.21,0.1,0.1,0.0,0.0,0.1,elena sta dimitrova,,MATH-4120,2015
+MATH,4190,1,Discrete Math Structures I,0.44,0.31,0.11,0.02,0.02,0.0,0.0,0.09,beth novick,,MATH-4190,2015
+MATH,4300,1,Actuarial Science Seminar I,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,mark cawood,,MATH-4300,2015
+MATH,4310,1,Theory of Interest,0.23,0.41,0.23,0.14,0.0,0.0,0.0,0.0, erwin walker,,MATH-4310,2015
+MATH,4340,1,Adv Engineering Mathematics,0.29,0.31,0.17,0.06,0.09,0.0,0.0,0.09,qingshan chen,,MATH-4340,2015
+MATH,4340,2,Adv Engineering Mathematics,0.46,0.21,0.13,0.0,0.04,0.0,0.0,0.17,daniel warner,,MATH-4340,2015
+MATH,4400,1,Linear Programming,0.43,0.1,0.14,0.05,0.1,0.0,0.0,0.19,warren adams,,MATH-4400,2015
+MATH,4530,1,Advanced Calculus I,0.13,0.13,0.2,0.2,0.2,0.0,0.0,0.13,jeong rock yoon,,MATH-4530,2015
+MATH,4540,1,Advanced Calculus II,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,taufiquar rahm khan,,MATH-4540,2015
+MATH,6340,1,Adv Engineering Mathematics,0.4,0.3,0.1,0.0,0.05,0.0,0.0,0.15,hyesuk lee,,MATH-6340,2015
+MATH,8030,1,Stochastic Processes,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,,MATH-8030,2015
+MATH,8050,1,Data Analysis,0.48,0.35,0.09,0.0,0.0,0.0,0.0,0.09,derek brown,,MATH-8050,2015
+MATH,8090,1,Time Series Analysis,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,colin gallagher,,MATH-8090,2015
+MATH,8100,1,Mathematical Programming,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,,MATH-8100,2015
+MATH,8110,1,Nonlinear Programming,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,,MATH-8110,2015
+MATH,8130,1,Advanced Linear Programming,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,warren adams,,MATH-8130,2015
+MATH,8210,1,Linear Analysis,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,,MATH-8210,2015
+MATH,8260,1,Partial Differential Equations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,,MATH-8260,2015
+MATH,8520,1,Abstract Algebra II,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,james brown,,MATH-8520,2015
+MATH,8530,1,Matrix Analysis,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,matthew macauley,,MATH-8530,2015
+MATH,8570,1,Cryptography,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,felice manganiello,,MATH-8570,2015
+MATH,8600,1,Intro to Scientific Computing,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,leo rebholz,,MATH-8600,2015
+MATH,8660,1,Finite Element Method,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,hyesuk lee,,MATH-8660,2015
+MATH,8810,1,Mathematical Statistics,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,,MATH-8810,2015
+MATH,9830,1,Sel Top in Computational Math,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timo johann heister,,MATH-9830,2015
+MBA,8030,1,Stat Analy of Bus Op,0.82,0.15,0.0,0.0,0.0,0.0,0.0,0.03,matthew charl klein,,MBA-8030,2015
+MBA,8060,1,Operations Mgt,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06, sridharan,,MBA-8060,2015
+MBA,8070,1,Financial Management,0.83,0.18,0.0,0.0,0.0,0.0,0.0,0.0,fei xie,,MBA-8070,2015
+MBA,8070,2,Financial Management,0.46,0.49,0.03,0.0,0.0,0.0,0.0,0.03,fei xie,,MBA-8070,2015
+MBA,8090,1,Org Beh & Hum Res Mg,0.65,0.33,0.0,0.0,0.0,0.0,0.0,0.02,thomas jo zagenczyk,,MBA-8090,2015
+MBA,8190,1,Intro to Acc and Fin,0.53,0.35,0.09,0.0,0.02,0.0,0.0,0.0,jeffrey mcmillan,,MBA-8190,2015
+MBA,8290,1,Marketing Foundation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MBA-8290,2015
+MBA,8370,1,Legal Environ of Bus,0.53,0.42,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2015
+MBA,8410,1,Real Estate Finance,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,james pow mckissick,,MBA-8410,2015
+MBA,8430,10,MBAePT Entrepreneurial Acct,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sally kathr widener,,MBA-8430,2015
+MBA,8450,1,MBAe FT Tech & Innova Mgt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david orr,,MBA-8450,2015
+MBA,8470,1,MBAe FT New Venture Creation,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,,MBA-8470,2015
+MBA,8540,1,Mgrl Accounting,0.84,0.11,0.03,0.0,0.0,0.0,0.0,0.03,henry anderson,,MBA-8540,2015
+MBA,8540,2,Mgrl Accounting,0.8,0.1,0.02,0.0,0.02,0.0,0.0,0.05,henry anderson,,MBA-8540,2015
+MBA,8590,1,Mgr Decision Model,0.45,0.21,0.06,0.0,0.04,0.0,0.0,0.23,mark mcknew,,MBA-8590,2015
+MBA,8590,3,Mgr Decision Model,0.38,0.33,0.15,0.0,0.05,0.0,0.0,0.1,sara elizabet yoder,,MBA-8590,2015
+MBA,8600,1,Advanced Marketing Strategy,0.36,0.46,0.18,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2015
+MBA,8610,1,Information Systems,0.38,0.52,0.0,0.0,0.03,0.0,0.0,0.07,varun grover,,MBA-8610,2015
+MBA,8610,2,Information Systems,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,heshan sun,,MBA-8610,2015
+MBA,8620,1,Managerial Economics,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,,MBA-8620,2015
+MBA,8720,1,MBAe FT Entrepr Finance,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,,MBA-8720,2015
+MBA,8750,1,Enterprise Develpmnt,0.66,0.29,0.03,0.0,0.0,0.0,0.0,0.03,michael george mino,,MBA-8750,2015
+MBA,8990,1,Advanced Leadership,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,gail depriest,,MBA-8990,2015
+ME,2000,1,Sophomore Seminar,0.84,0.11,0.01,0.0,0.01,0.0,0.0,0.03,donald beasley,,ME-2000,2015
+ME,2010,1,Statics & Dynamics,0.02,0.12,0.23,0.16,0.36,0.0,0.0,0.1,sherrill biggers,,ME-2010,2015
+ME,2010,2,Statics & Dynamics,0.11,0.31,0.26,0.11,0.15,0.0,0.0,0.06,paul joseph,,ME-2010,2015
+ME,2030,1,Founda Th/Fl Syst,0.29,0.42,0.1,0.13,0.02,0.0,0.0,0.04,richard figliola,,ME-2030,2015
+ME,2030,2,Founda Th/Fl Syst,0.14,0.27,0.41,0.1,0.06,0.0,0.0,0.02,chenning tong,,ME-2030,2015
+ME,2030,3,Founda Th/Fl Syst,0.44,0.42,0.1,0.0,0.01,0.0,0.0,0.02,david zumbrunnen,,ME-2030,2015
+ME,2040,1,Mechanics of Materials,0.27,0.33,0.21,0.09,0.05,0.0,0.0,0.05,michael porter,,ME-2040,2015
+ME,2040,2,Mechanics of Materials,0.09,0.54,0.21,0.04,0.07,0.0,0.0,0.04,todd schweisinger,,ME-2040,2015
+ME,2220,1,Mech Engr Lab I,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,2,Mech Engr Lab I,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,3,Mech Engr Lab I,0.2,0.5,0.25,0.05,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,4,Mech Engr Lab I,0.27,0.6,0.07,0.07,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,5,Mech Engr Lab I,0.15,0.8,0.0,0.0,0.05,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,6,Mech Engr Lab I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,2220,7,Mech Engr Lab I,0.21,0.74,0.0,0.0,0.0,0.0,0.0,0.05,todd schweisinger,,ME-2220,2015
+ME,2220,8,Mech Engr Lab I,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2015
+ME,3030,1,Thermodynamics,0.12,0.29,0.33,0.16,0.04,0.0,0.0,0.07,jay ochterbeck,,ME-3030,2015
+ME,3040,1,Heat Transfer,0.4,0.28,0.25,0.03,0.02,0.0,0.0,0.02,donald beasley,,ME-3040,2015
+ME,3040,2,Heat Transfer,0.22,0.44,0.15,0.06,0.06,0.0,0.0,0.07,xin zhao,,ME-3040,2015
+ME,3050,1,Model/an Dy Syst,0.18,0.38,0.2,0.09,0.09,0.0,0.0,0.07,phanin tallapragada,,ME-3050,2015
+ME,3050,2,Model/an Dy Syst,0.21,0.58,0.17,0.02,0.0,0.0,0.0,0.02,yue wang,,ME-3050,2015
+ME,3060,1,Fund Machine Design,0.32,0.47,0.15,0.05,0.02,0.0,0.0,0.0,oliver myers,,ME-3060,2015
+ME,3060,2,Fund Machine Design,0.47,0.36,0.09,0.06,0.0,0.0,0.0,0.02,paul jeffrey meyer,,ME-3060,2015
+ME,3070,1,Found of Mechanical Systems,0.54,0.32,0.04,0.04,0.04,0.0,0.0,0.04,lonny thompson,,ME-3070,2015
+ME,3070,2,Found of Mechanical Systems,0.14,0.32,0.36,0.11,0.0,0.0,0.0,0.07,gregory mocko,,ME-3070,2015
+ME,3080,1,Fluid Mechanics,0.0,0.28,0.33,0.19,0.14,0.0,0.0,0.06,jean-marc delhaye,,ME-3080,2015
+ME,3080,2,Fluid Mechanics,0.09,0.4,0.33,0.11,0.02,0.0,0.0,0.04,ethan kung,,ME-3080,2015
+ME,3100,1,Thermo/Heat Transfer,0.19,0.32,0.22,0.12,0.01,0.0,0.0,0.13,xiangchun xuan,,ME-3100,2015
+ME,3120,1,Manuf Processes,0.46,0.35,0.08,0.08,0.02,0.0,0.0,0.0,hong seok choi,,ME-3120,2015
+ME,3330,1,Mech Engr Lab II,0.38,0.44,0.13,0.06,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,3330,2,Mech Engr Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,3330,3,Mech Engr Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,3330,4,Mech Engr Lab II,0.19,0.44,0.25,0.0,0.06,0.0,0.0,0.06,todd schweisinger,,ME-3330,2015
+ME,3330,5,Mech Engr Lab II,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,,ME-3330,2015
+ME,3330,6,Mech Engr Lab II,0.21,0.53,0.16,0.05,0.05,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,3330,7,Mech Engr Lab II,0.22,0.56,0.11,0.06,0.0,0.0,0.0,0.06,todd schweisinger,,ME-3330,2015
+ME,3330,8,Mech Engr Lab II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2015
+ME,4000,1,Senior Seminar,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0, ramasubramanian,,ME-4000,2015
+ME,4010,1,Mech Engr Design,0.18,0.69,0.09,0.02,0.02,0.0,0.0,0.0,joshua summers,,ME-4010,2015
+ME,4020,1,Intern in Engr Des,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4020,2015
+ME,4020,3,Intern in Engr Des,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2015
+ME,4020,4,Intern in Engr Des,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,ethan kung,,ME-4020,2015
+ME,4020,7,Intern in Engr Des,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-4020,2015
+ME,4030,1,Control Dynamic Syst,0.4,0.33,0.13,0.13,0.0,0.0,0.0,0.0,hamed saeidi,,ME-4030,2015
+ME,4030,2,Control Dynamic Syst,0.05,0.19,0.3,0.24,0.16,0.0,0.0,0.05,kalyan chakr katuri,,ME-4030,2015
+ME,4170,1,Mechatronic Sys,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4170,2015
+ME,4220,1,Design Gas Turbines,0.46,0.31,0.15,0.0,0.0,0.0,0.0,0.08,abhijit som,,ME-4220,2015
+ME,4230,1,Intro Aerodynamics,0.15,0.18,0.5,0.12,0.06,0.0,0.0,0.0,richard figliola,,ME-4230,2015
+ME,4260,1,Nuclear Energy,0.26,0.26,0.29,0.12,0.03,0.0,0.0,0.03,david zumbrunnen,,ME-4260,2015
+ME,4320,1,Adv Strength of Matl,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,gang li,,ME-4320,2015
+ME,4440,3,Mech Engr Lab III,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2015
+ME,4440,5,Mech Engr Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2015
+ME,4930,5,SelectedTopics ME (RapidProto),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4930,2015
+ME,4930,29,Selected Topics ME (Solar E),0.62,0.34,0.0,0.0,0.0,0.0,0.0,0.03,daniel fant,,ME-4930,2015
+ME,6170,1,Mechatronic Sys,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-6170,2015
+ME,6320,1,Adv Strength of Matl,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,gang li,,ME-6320,2015
+ME,6930,5,SelectedTopics ME (RapidProto),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-6930,2015
+ME,6930,11,Selected Topics ME (MicroFab),0.44,0.38,0.06,0.0,0.13,0.0,0.0,0.0,rod martinez-duarte,,ME-6930,2015
+ME,6930,29,Selected Topics ME (Solar E),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-6930,2015
+ME,8120,1,Exp Meth Thermal Sci,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,,ME-8120,2015
+ME,8190,1,Cp Meth in Therm Sc,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,richard miller,,ME-8190,2015
+ME,8200,1,Mod Cont Engr,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,,ME-8200,2015
+ME,8310,1,Convective Ht Trans,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,john saylor,,ME-8310,2015
+ME,8360,1,Fracture Mech,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,huijuan zhao,,ME-8360,2015
+ME,8520,1,Adv Finite Ele Ana,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,lonny thompson,,ME-8520,2015
+ME,8610,1,Matl Sel Engr Design,0.86,0.11,0.02,0.0,0.0,0.0,0.0,0.02,mica grujicic,,ME-8610,2015
+ME,8930,1,Sel Topics in ME (Scaling),0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-8930,2015
+ME,8930,27,Sel Top - Optimal Estimation,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,ardalan vahidi,,ME-8930,2015
+MGT,2010,1,Principles of Mgt,0.36,0.3,0.21,0.05,0.04,0.0,0.0,0.05,katherine clark,,MGT-2010,2015
+MGT,2010,2,Principles of Mgt,0.23,0.47,0.23,0.02,0.04,0.0,0.0,0.0,katherine clark,,MGT-2010,2015
+MGT,2010,3,Principles of Mgt,0.21,0.36,0.24,0.04,0.08,0.0,0.0,0.07,katherine clark,,MGT-2010,2015
+MGT,2010,4,Principles of Mgt,0.22,0.38,0.19,0.12,0.01,0.0,0.0,0.08,katherine clark,,MGT-2010,2015
+MGT,2010,5,Principles of Mgt,0.27,0.34,0.25,0.05,0.0,0.0,0.0,0.08,tina robbins,,MGT-2010,2015
+MGT,2010,6,Principles of Mgt,0.26,0.54,0.12,0.05,0.01,0.0,0.0,0.01,tina robbins,,MGT-2010,2015
+MGT,2010,7,Principles of Mgt,0.29,0.45,0.21,0.03,0.0,0.0,0.0,0.03,tina robbins,,MGT-2010,2015
+MGT,2010,8,Principles of Mgt,0.27,0.36,0.18,0.08,0.05,0.0,0.0,0.06,tina robbins,,MGT-2010,2015
+MGT,2180,1,Management PC Applications,0.53,0.3,0.08,0.02,0.04,0.0,0.0,0.02,ryan toole,,MGT-2180,2015
+MGT,2180,2,Management PC Applications,0.55,0.28,0.08,0.02,0.04,0.0,0.0,0.03,ryan toole,,MGT-2180,2015
+MGT,2180,3,Management PC Applications,0.57,0.32,0.06,0.03,0.01,0.0,0.0,0.02,ryan toole,,MGT-2180,2015
+MGT,2180,4,Management PC Applications,0.57,0.25,0.1,0.02,0.02,0.0,0.0,0.05,ryan toole,,MGT-2180,2015
+MGT,3070,1,Human Resource Management,0.64,0.27,0.05,0.0,0.0,0.0,0.0,0.05,priscilla harrison,,MGT-3070,2015
+MGT,3070,2,Human Resource Management,0.48,0.48,0.03,0.0,0.03,0.0,0.0,0.0,michael cole,,MGT-3070,2015
+MGT,3070,3,Human Resource Management,0.17,0.78,0.03,0.0,0.03,0.0,0.0,0.0,kristin dam scott,,MGT-3070,2015
+MGT,3070,4,Human Resource Management,0.4,0.48,0.08,0.0,0.0,0.0,0.0,0.05,michael cole,,MGT-3070,2015
+MGT,3070,5,Human Resource Management,0.08,0.56,0.31,0.05,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2015
+MGT,3070,6,Human Resource Management,0.18,0.67,0.15,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2015
+MGT,3100,1,Intermed Business Statistics,0.32,0.39,0.16,0.0,0.02,0.0,0.0,0.11,james walsh,,MGT-3100,2015
+MGT,3100,2,Intermed Business Statistics,0.66,0.13,0.11,0.05,0.03,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3100,2015
+MGT,3100,3,Intermed Business Statistics,0.58,0.25,0.1,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3100,2015
+MGT,3100,4,Intermed Business Statistics,0.12,0.32,0.27,0.17,0.05,0.0,0.0,0.07,sara elizabet yoder,,MGT-3100,2015
+MGT,3100,5,Intermed Business Statistics,0.44,0.28,0.19,0.0,0.06,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3100,2015
+MGT,3100,6,Intermed Business Statistics,0.44,0.36,0.11,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3100,2015
+MGT,3100,7,Intermed Business Statistics,0.16,0.17,0.24,0.14,0.08,0.0,0.0,0.21,sara elizabet yoder,,MGT-3100,2015
+MGT,3100,8,Intermed Business Statistics,0.14,0.23,0.14,0.27,0.14,0.0,0.0,0.09,sara elizabet yoder,,MGT-3100,2015
+MGT,3100,10,Intermed Business Statistics,0.24,0.45,0.24,0.05,0.0,0.0,0.0,0.02,yuhong he,,MGT-3100,2015
+MGT,3120,1,Decision Models for Management,0.3,0.4,0.23,0.02,0.05,0.0,0.0,0.0,mark mcknew,,MGT-3120,2015
+MGT,3120,2,Decision Models for Management,0.13,0.41,0.35,0.04,0.0,0.0,0.0,0.07,mark mcknew,,MGT-3120,2015
+MGT,3120,3,Decision Models for Management,0.13,0.5,0.24,0.0,0.11,0.0,0.0,0.02,mark mcknew,,MGT-3120,2015
+MGT,3150,1,New Venture Creation,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,,MGT-3150,2015
+MGT,3180,1,Mgt of Info Systems,0.51,0.36,0.05,0.05,0.03,0.0,0.0,0.0,dan jiang,,MGT-3180,2015
+MGT,3180,2,Mgt of Info Systems,0.33,0.38,0.3,0.0,0.0,0.0,0.0,0.0,tina marie esposito,,MGT-3180,2015
+MGT,3180,3,Mgt of Info Systems,0.21,0.44,0.33,0.0,0.03,0.0,0.0,0.0,roopa raman,,MGT-3180,2015
+MGT,3180,4,Mgt of Info Systems,0.13,0.37,0.47,0.0,0.0,0.0,0.0,0.03,roopa raman,,MGT-3180,2015
+MGT,3900,2,Ops Mgt,0.36,0.2,0.32,0.08,0.0,0.0,0.0,0.04,min kyung lee,,MGT-3900,2015
+MGT,3900,3,Ops Mgt,0.35,0.35,0.25,0.0,0.03,0.0,0.0,0.03,zachary mo leffakis,,MGT-3900,2015
+MGT,3900,4,Ops Mgt,0.18,0.35,0.28,0.03,0.05,0.0,0.0,0.13,zachary mo leffakis,,MGT-3900,2015
+MGT,3900,5,Ops Mgt,0.24,0.5,0.15,0.06,0.03,0.0,0.0,0.03,shouqiang wang,,MGT-3900,2015
+MGT,3900,6,Ops Mgt,0.24,0.43,0.24,0.05,0.03,0.0,0.0,0.0,yuhong he,,MGT-3900,2015
+MGT,4000,2,Mgt of Organizational Behavior,0.26,0.51,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MGT-4000,2015
+MGT,4000,3,Mgt of Organizational Behavior,0.25,0.45,0.25,0.0,0.03,0.0,0.0,0.03,philip roth,,MGT-4000,2015
+MGT,4000,4,Mgt of Organizational Behavior,0.51,0.31,0.11,0.03,0.0,0.0,0.0,0.03,michael cole,,MGT-4000,2015
+MGT,4020,1,Ops Pln and Ctl,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4020,2015
+MGT,4030,1,Intro to Business Analytics,0.33,0.46,0.13,0.04,0.0,0.0,0.0,0.04,siyuan li,,MGT-4030,2015
+MGT,4030,3,Advanced Business Analytics,0.13,0.53,0.33,0.0,0.0,0.0,0.0,0.0,heshan sun,,MGT-4030,2015
+MGT,4080,1,Lean Operations,0.21,0.29,0.46,0.0,0.04,0.0,0.0,0.0,zachary mo leffakis,,MGT-4080,2015
+MGT,4110,1,Project Management,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,russell purvis,,MGT-4110,2015
+MGT,4110,2,Project Management,0.22,0.57,0.22,0.0,0.0,0.0,0.0,0.0,russell purvis,,MGT-4110,2015
+MGT,4120,1,Supplier Management,0.1,0.4,0.47,0.0,0.0,0.0,0.0,0.03,shouqiang wang,,MGT-4120,2015
+MGT,4150,1,Business Strategy,0.09,0.66,0.23,0.0,0.03,0.0,0.0,0.0,peter gianiodis,,MGT-4150,2015
+MGT,4150,2,Business Strategy,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,peter gianiodis,,MGT-4150,2015
+MGT,4150,3,Business Strategy,0.73,0.23,0.0,0.03,0.0,0.0,0.0,0.03,john edward hopkins,,MGT-4150,2015
+MGT,4150,4,Business Strategy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2015
+MGT,4150,5,Business Strategy,0.27,0.56,0.16,0.02,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2015
+MGT,4150,6,Business Strategy,0.16,0.69,0.11,0.0,0.04,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2015
+MGT,4150,7,Business Strategy,0.17,0.59,0.24,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,,MGT-4150,2015
+MGT,4150,8,Business Strategy,0.2,0.7,0.11,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,,MGT-4150,2015
+MGT,4160,1,Special Topics Hr,0.31,0.64,0.06,0.0,0.0,0.0,0.0,0.0,kristin dam scott,,MGT-4160,2015
+MGT,4230,1,Intern Bus Mgt,0.09,0.22,0.61,0.04,0.04,0.0,0.0,0.0,wayne stewart,,MGT-4230,2015
+MGT,4230,2,Intern Bus Mgt,0.15,0.28,0.33,0.07,0.09,0.0,0.0,0.09,wayne stewart,,MGT-4230,2015
+MGT,4230,3,Intern Bus Mgt,0.36,0.48,0.17,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4230,2015
+MGT,4230,4,Intern Bus Mgt,0.03,0.78,0.14,0.0,0.03,0.0,0.0,0.03,janis miller,,MGT-4230,2015
+MGT,4240,1,Global Supply Chain,0.14,0.41,0.36,0.05,0.05,0.0,0.0,0.0,yann ferrand,,MGT-4240,2015
+MGT,4270,1,Managing Improvement,0.4,0.43,0.13,0.0,0.0,0.0,0.0,0.03,james liddle,,MGT-4270,2015
+MGT,4300,1,Bus Application Development,0.56,0.13,0.19,0.0,0.0,0.0,0.0,0.13,jerry kermi bilbrey,,MGT-4300,2015
+MGT,4310,1,Emp Rights & Resp,0.38,0.48,0.13,0.0,0.0,0.0,0.0,0.03,leonard jos spooner,,MGT-4310,2015
+MGT,4350,1,Pers Interviewing,0.33,0.4,0.18,0.08,0.03,0.0,0.0,0.0,philip roth,,MGT-4350,2015
+MGT,4520,1,Business Analysis,0.18,0.55,0.18,0.06,0.03,0.0,0.0,0.0,roopa raman,,MGT-4520,2015
+MGT,4550,1,Emerging I T Trends,0.39,0.52,0.1,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MGT-4550,2015
+MGT,4560,1,Business Info Mgt,0.27,0.53,0.07,0.0,0.0,0.0,0.0,0.13,siyuan li,,MGT-4560,2015
+MGT,8120,1,Supply Chain Mgt,0.29,0.55,0.16,0.0,0.0,0.0,0.0,0.0,yann ferrand,,MGT-8120,2015
+MICR,3050,1,General Microbiology,0.41,0.39,0.14,0.04,0.01,0.0,0.0,0.01,kristi ja whitehead,,MICR-3050,2015
+MICR,3050,2,General Microbiology,0.46,0.36,0.12,0.02,0.02,0.0,0.0,0.02,krista barr rudolph,,MICR-3050,2015
+MICR,3050,3,General Microbiology,0.55,0.37,0.05,0.03,0.0,0.0,0.0,0.0,krista barr rudolph,,MICR-3050,2015
+MICR,4000,1,Public Health Micro,0.37,0.38,0.17,0.05,0.02,0.0,0.0,0.02,kristi ja whitehead,,MICR-4000,2015
+MICR,4020,1,Environmental Micro,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,john michael henson,,MICR-4020,2015
+MICR,4070,1,Food and Dairy Micro,0.37,0.49,0.14,0.0,0.0,0.0,0.0,0.0,xiuping jiang,,MICR-4070,2015
+MICR,4110,1,Pathogenic Bact,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,,MICR-4110,2015
+MICR,4120,1,Bacterial Physiology,0.26,0.29,0.16,0.13,0.16,0.0,0.0,0.0,thomas hughes,,MICR-4120,2015
+MICR,4130,1,Industrial Micro,0.32,0.58,0.04,0.02,0.02,0.0,0.0,0.02,tzuen-rong je tzeng,,MICR-4130,2015
+MICR,4140,1,Basic Immunology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,,MICR-4140,2015
+MICR,4170,1,Cancer and Aging,0.65,0.29,0.0,0.06,0.0,0.0,0.0,0.0,yuqing dong,,MICR-4170,2015
+MICR,4210,1,Path Bac Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,,MICR-4210,2015
+MICR,4210,2,Path Bac Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,,MICR-4210,2015
+MICR,4500,2,Advanced Microbiology I,0.5,0.45,0.0,0.0,0.05,0.0,0.0,0.0,harry kurtz,,MICR-4500,2015
+MICR,4500,3,Advanced Microbiology I,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2015
+MKT,3010,1,Prin of Marketing,0.15,0.49,0.27,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,,MKT-3010,2015
+MKT,3010,2,Prin of Marketing,0.21,0.47,0.23,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,,MKT-3010,2015
+MKT,3010,3,Prin of Marketing,0.21,0.37,0.25,0.1,0.04,0.0,0.0,0.03,amanda cooper fine,,MKT-3010,2015
+MKT,3010,4,Prin of Marketing,0.27,0.43,0.2,0.09,0.02,0.0,0.0,0.0,amanda cooper fine,,MKT-3010,2015
+MKT,3010,5,Prin of Marketing,0.36,0.4,0.19,0.03,0.01,0.0,0.0,0.02,james gaubert,,MKT-3010,2015
+MKT,3010,6,Prin of Marketing,0.42,0.38,0.17,0.03,0.0,0.0,0.0,0.0,patricia knowles,,MKT-3010,2015
+MKT,3020,1,Consumer Behavior,0.45,0.38,0.09,0.05,0.02,0.0,0.0,0.02,jennifer di siemens,,MKT-3020,2015
+MKT,3020,2,Consumer Behavior,0.46,0.41,0.11,0.02,0.0,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2015
+MKT,3020,3,Consumer Behavior,0.26,0.49,0.18,0.05,0.02,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2015
+MKT,3020,4,Consumer Behavior,0.42,0.39,0.11,0.07,0.02,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2015
+MKT,3210,1,Sports Marketing,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2015
+MKT,3980,1,Sales Experiential,0.82,0.11,0.05,0.0,0.02,0.0,0.0,0.0,carter wil mcelveen,,MKT-3980,2015
+MKT,4200,1,Professional Selling,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2015
+MKT,4200,2,Professional Selling,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2015
+MKT,4200,3,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,,MKT-4200,2015
+MKT,4200,4,Professional Selling,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,gary hunter,,MKT-4200,2015
+MKT,4230,1,Promotional Strategy,0.21,0.52,0.17,0.05,0.02,0.0,0.0,0.02,patricia knowles,,MKT-4230,2015
+MKT,4240,1,Sales Management,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4240,2015
+MKT,4260,1,Business-to-Business,0.38,0.58,0.02,0.0,0.02,0.0,0.0,0.0,james gaubert,,MKT-4260,2015
+MKT,4270,1,International Mktg,0.11,0.54,0.34,0.0,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-4270,2015
+MKT,4270,2,International Mktg,0.29,0.42,0.29,0.0,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-4270,2015
+MKT,4270,3,International Mktg,0.26,0.5,0.21,0.02,0.0,0.0,0.0,0.0,roger gomes,,MKT-4270,2015
+MKT,4270,4,International Mktg,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,roger gomes,,MKT-4270,2015
+MKT,4270,5,International Mktg,0.22,0.46,0.27,0.02,0.0,0.0,0.0,0.02,roger gomes,,MKT-4270,2015
+MKT,4280,1,Services Marketing,0.15,0.55,0.25,0.03,0.03,0.0,0.0,0.0,mary anne raymond,,MKT-4280,2015
+MKT,4280,2,Services Marketing,0.28,0.52,0.08,0.04,0.04,0.0,0.0,0.04,mary anne raymond,,MKT-4280,2015
+MKT,4310,1,Marketing Research,0.28,0.66,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2015
+MKT,4310,2,Marketing Research,0.37,0.56,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2015
+MKT,4310,3,Marketing Research,0.21,0.64,0.11,0.04,0.0,0.0,0.0,0.0,william kilbourne,,MKT-4310,2015
+MKT,4330,1,Sport Mkt Strategy,0.33,0.57,0.05,0.0,0.0,0.0,0.0,0.05,amanda cooper fine,,MKT-4330,2015
+MKT,4430,1,Advertising Strategy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,albert neil cameron,,MKT-4430,2015
+MKT,4450,1,Macromarketing,0.44,0.48,0.04,0.0,0.0,0.04,0.0,0.0,william kilbourne,,MKT-4450,2015
+MKT,4500,1,Strategic Mktg Mgt,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2015
+MKT,4500,2,Strategic Mktg Mgt,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2015
+MKT,4500,3,Strategic Mktg Mgt,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-4500,2015
+MKT,4500,4,Strategic Mktg Mgt,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2015
+MKT,4950,1,Selected Topics,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,peter weathers,,MKT-4950,2015
+MKT,8620,1,Quant Methods in Mkt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,,MKT-8620,2015
+MKT,8650,1,Seminar in Mkt Mgmt,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MKT-8650,2015
+MKT,8660,1,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-8660,2015
+ML,1020,1,Leadership Fund II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert rozetar,,ML-1020,2015
+ML,1020,2,Leadership Fund II,0.82,0.09,0.0,0.0,0.05,0.0,0.0,0.05,robert rozetar,,ML-1020,2015
+ML,2020,2,Leadership Dev II,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,,ML-2020,2015
+ML,3020,2,Adv Leadership II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,,ML-3020,2015
+ML,4020,1,Org Leadership II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,,ML-4020,2015
+ML,4020,3,Org Leadership II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,,ML-4020,2015
+MSE,2100,1,Intro to Mat Science,0.4,0.27,0.19,0.06,0.06,0.0,0.0,0.03,marian kennedy,,MSE-2100,2015
+MSE,2100,2,Intro to Mat Science,0.5,0.24,0.13,0.04,0.01,0.0,0.0,0.08,eric skaar,,MSE-2100,2015
+MSE,2100,3,Intro to Mat Science,0.22,0.34,0.22,0.11,0.09,0.0,0.0,0.02,julie patric martin,,MSE-2100,2015
+MSE,2500,1,Polymer & Fiber Materials I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,,MSE-2500,2015
+MSE,2500,2,Polymer & Fiber Materials I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,,MSE-2500,2015
+MSE,3260,1,Thermo of Materials,0.19,0.32,0.27,0.15,0.03,0.0,0.0,0.03,gary lickfield,,MSE-3260,2015
+MSE,3280,1,Phase Diagrams,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,eric skaar,,MSE-3280,2015
+MSE,3610,1,Proc of Metals & Com,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,marian kennedy,,MSE-3610,2015
+MSE,4160,1,Electronic Materials,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,kyle brinkman,,MSE-4160,2015
+MSE,4220,1,Mech Behavior of Mat,0.35,0.54,0.11,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,,MSE-4220,2015
+MSE,4240,1,Optical Materials,0.23,0.38,0.38,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-4240,2015
+MSE,4330,1,Comb Sys & Env Emiss,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,,MSE-4330,2015
+MSE,4560,1,Polymer & Fiber Materials II,0.27,0.46,0.27,0.0,0.0,0.0,0.0,0.0,gary lickfield,,MSE-4560,2015
+MSE,4590,1,Color Science Lab,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,philip brown,,MSE-4590,2015
+MSE,8280,1,Phase Transformation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,,MSE-8280,2015
+MUSC,1110,7,Beginning Class Guitar,0.8,0.1,0.0,0.1,0.0,0.0,0.0,0.0,david stevenson,,MUSC-1110,2015
+MUSC,1110,9,Beginning Class Guitar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,david stevenson,,MUSC-1110,2015
+MUSC,1420,1,Music Theory I,0.58,0.17,0.0,0.0,0.08,0.0,0.0,0.17,david conley,,MUSC-1420,2015
+MUSC,1430,1,Aural Skills I,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,david conley,,MUSC-1430,2015
+MUSC,1510,15,Applied Music - Piano,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,cindy roden goodloe,,MUSC-1510,2015
+MUSC,1800,1,Intro to Music Tech,0.36,0.36,0.18,0.0,0.0,0.0,0.0,0.09,hamilton altstatt,,MUSC-1800,2015
+MUSC,2100,1,Music in West World,0.72,0.22,0.03,0.0,0.03,0.0,0.0,0.0,eric lapin,,MUSC-2100,2015
+MUSC,2100,2,Music in West World,0.56,0.25,0.06,0.03,0.0,0.0,0.0,0.09,lisa sain odom,,MUSC-2100,2015
+MUSC,2100,3,Music in West World,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-2100,2015
+MUSC,2100,4,Music in West World,0.47,0.31,0.19,0.0,0.0,0.0,0.0,0.03,linda li-bleuel,,MUSC-2100,2015
+MUSC,2100,5,Music in West World,0.61,0.26,0.06,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,,MUSC-2100,2015
+MUSC,2100,6,Music in West World,0.77,0.16,0.0,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,,MUSC-2100,2015
+MUSC,2100,7,Music in West World,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,,MUSC-2100,2015
+MUSC,2100,12,Music in West World,0.55,0.35,0.06,0.0,0.0,0.0,0.0,0.03,lea kibler,,MUSC-2100,2015
+MUSC,2100,13,Music in West World,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,linda dzuris,,MUSC-2100,2015
+MUSC,3110,1,History of American Music,0.5,0.34,0.09,0.03,0.0,0.0,0.0,0.03,ned hosler,,MUSC-3110,2015
+MUSC,3120,1,History of Jazz,0.44,0.28,0.22,0.06,0.0,0.0,0.0,0.0,eric lapin,,MUSC-3120,2015
+MUSC,3170,1,Hist of Country Mus,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,ned hosler,,MUSC-3170,2015
+MUSC,3310,1,Pep Band - Men,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,,MUSC-3310,2015
+MUSC,3690,1,Symphony Orchestra,0.91,0.07,0.0,0.0,0.0,0.0,0.0,0.02,andrew levin,True,MUSC-3690,2015
+MUSC,4160,1,Mus Hist Since 1750,0.35,0.09,0.3,0.0,0.17,0.0,0.0,0.09,linda li-bleuel,,MUSC-4160,2015
+MUSC,4300,1,Conducting,0.3,0.3,0.2,0.0,0.2,0.0,0.0,0.0,justin durham,,MUSC-4300,2015
+NPL,3010,2,NPL Stakeholders,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,tracy diane lamb,,NPL-3010,2015
+NURS,3030,1,Nursing of Adults,0.35,0.57,0.06,0.02,0.0,0.0,0.0,0.0,leslie anne  ravan,,NURS-3030,2015
+NURS,3030,400,Nursing of Adults,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,wanda leigh taylor,,NURS-3030,2015
+NURS,3040,1,Pathophysiology,0.33,0.58,0.03,0.06,0.0,0.0,0.0,0.0,catherine si murton,,NURS-3040,2015
+NURS,3040,401,Pathophysiology for RN,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,,NURS-3040,2015
+NURS,3100,1,Health Assessment,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3100,2015
+NURS,3120,1,Foundations of Nurs,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,angela pye,,NURS-3120,2015
+NURS,3190,400,Health Assessment for RNs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,,NURS-3190,2015
+NURS,3200,1,Prof in Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,NURS-3200,2015
+NURS,3400,1,Pharmther Nursing,0.37,0.59,0.02,0.02,0.0,0.0,0.0,0.0,catherine si murton,,NURS-3400,2015
+NURS,4010,1,Mental Health Nurs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-4010,2015
+NURS,4030,1,Complex Nursing of Adults,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,,NURS-4030,2015
+NURS,4110,1,Nursing of Children,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-4110,2015
+NURS,4120,1,Nurs Women and Fam,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2015
+NURS,4250,400,Community Nursing,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,roxanne amerson,,NURS-4250,2015
+NURS,8080,400,Nurs Res Stat Analys,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-8080,2015
+NURS,8190,400,Developing Family,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,,NURS-8190,2015
+NURS,8200,400,Child & Adol Nursing,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-8200,2015
+NURS,8210,400,Adult Nursing,0.69,0.29,0.03,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8210,2015
+NURS,8850,400,Mental Health in Primary Care,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-8850,2015
+NUTR,2030,1,Intro Princ of Human Nutrition,0.44,0.39,0.12,0.01,0.0,0.0,0.0,0.03,deborah an hutcheon,,NUTR-2030,2015
+NUTR,2040,1,Nutrition Across Life Cycle,0.4,0.42,0.11,0.07,0.0,0.0,0.0,0.0,deborah an hutcheon,,NUTR-2040,2015
+NUTR,4250,1,Medica Nutr Thera II,0.55,0.39,0.04,0.0,0.02,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4250,2015
+NUTR,4260,1,Community Nutrition,0.49,0.45,0.06,0.0,0.0,0.0,0.0,0.0,rita haliena,,NUTR-4260,2015
+NUTR,4550,1,Nutr Metabolism,0.36,0.38,0.12,0.08,0.0,0.0,0.0,0.06,elliot jesch,,NUTR-4550,2015
+PA,2800,1,Perf Arts Pract II,0.35,0.29,0.06,0.0,0.12,0.0,0.0,0.18,kenneth moore,,PA-2800,2015
+PA,4010,1,Capstone Project,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,anthony penna,,PA-4010,2015
+PADM,8220,400,Public Policy Process,0.77,0.08,0.0,0.0,0.08,0.0,0.0,0.08,mark daniel mellott,,PADM-8220,2015
+PADM,8410,400,Public Data Analysis,0.17,0.75,0.0,0.0,0.08,0.0,0.0,0.0,ronald chrestman,,PADM-8410,2015
+PADM,8410,401,Public Data Analysis,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,ronald chrestman,,PADM-8410,2015
+PADM,8500,400,Homeland Security Fundamentals,0.44,0.22,0.0,0.0,0.11,0.0,0.0,0.22,david leigh cook,,PADM-8500,2015
+PADM,8650,400,Leadership in the Nonprft Sect,0.67,0.0,0.0,0.0,0.11,0.0,0.0,0.22,renee salic nichols,,PADM-8650,2015
+PES,2020,1,Soils,0.27,0.35,0.27,0.06,0.04,0.0,0.0,0.0,dara michelle park,,PES-2020,2015
+PES,4330,1,Landscape & Turf Weed Mgt,0.14,0.64,0.14,0.0,0.0,0.0,0.0,0.07,ted whitwell,,PES-4330,2015
+PES,4520,1,Soil Fertility and Management,0.29,0.57,0.0,0.0,0.07,0.0,0.0,0.07,haibo liu,,PES-4520,2015
+PES,6520,1,Soil Fertility and Management,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,haibo liu,,PES-6520,2015
+PHIL,1010,1,Intro to Phil Prob,0.5,0.26,0.15,0.0,0.03,0.0,0.0,0.06,christopher grau,,PHIL-1010,2015
+PHIL,1010,2,Intro to Phil Prob,0.57,0.23,0.11,0.0,0.06,0.0,0.0,0.03,david stegall,,PHIL-1010,2015
+PHIL,1010,3,Intro to Phil Prob,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.03,david stegall,,PHIL-1010,2015
+PHIL,1020,1,Intro to Logic,0.58,0.17,0.06,0.17,0.0,0.0,0.0,0.03,michael hal hannen,,PHIL-1020,2015
+PHIL,1020,2,Intro to Logic,0.83,0.09,0.0,0.09,0.0,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2015
+PHIL,1020,3,Intro to Logic,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.03,gregory scott moss,,PHIL-1020,2015
+PHIL,1020,4,Intro to Logic,0.63,0.29,0.06,0.03,0.0,0.0,0.0,0.0,gregory scott moss,,PHIL-1020,2015
+PHIL,1020,5,Intro to Logic,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,gregory scott moss,,PHIL-1020,2015
+PHIL,1020,6,Intro to Logic,0.57,0.37,0.03,0.03,0.0,0.0,0.0,0.0,kelly smith,,PHIL-1020,2015
+PHIL,1030,1,Intro to Ethics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True,PHIL-1030,2015
+PHIL,1030,2,Intro to Ethics,0.59,0.35,0.0,0.0,0.03,0.0,0.0,0.03,michael hal hannen,,PHIL-1030,2015
+PHIL,1030,3,Intro to Ethics,0.65,0.29,0.03,0.0,0.0,0.0,0.0,0.03,ryan lake,,PHIL-1030,2015
+PHIL,1030,4,Intro to Ethics,0.46,0.4,0.09,0.0,0.03,0.0,0.0,0.03,ryan lake,,PHIL-1030,2015
+PHIL,1030,5,Intro to Ethics,0.35,0.56,0.06,0.0,0.0,0.0,0.0,0.03,ryan lake,,PHIL-1030,2015
+PHIL,1030,6,Intro to Ethics,0.44,0.35,0.15,0.0,0.03,0.0,0.0,0.03,stephen satris,,PHIL-1030,2015
+PHIL,3030,1,Phil of Religion,0.34,0.57,0.03,0.0,0.0,0.0,0.0,0.06,gregory scott moss,,PHIL-3030,2015
+PHIL,3140,1,Comp East West Phil,0.32,0.26,0.26,0.0,0.05,0.0,0.0,0.11,yanming an,,PHIL-3140,2015
+PHIL,3150,1,Ancient Philosophy,0.28,0.31,0.21,0.03,0.03,0.0,0.0,0.14,jennifer ingle,,PHIL-3150,2015
+PHIL,3160,1,Mod Phil,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,michael hal hannen,,PHIL-3160,2015
+PHIL,3260,1,Science and Values,0.4,0.49,0.0,0.0,0.06,0.0,0.0,0.06,andrew garnar,,PHIL-3260,2015
+PHIL,3260,2,Science and Values,0.4,0.51,0.03,0.03,0.0,0.0,0.0,0.03,andrew garnar,,PHIL-3260,2015
+PHIL,3260,3,Science and Values,0.46,0.43,0.09,0.0,0.0,0.0,0.0,0.03,andrew garnar,,PHIL-3260,2015
+PHIL,3330,1,Metaphysics,0.91,0.04,0.0,0.0,0.04,0.0,0.0,0.0,david stegall,,PHIL-3330,2015
+PHIL,3430,1,Phil of Law,0.82,0.12,0.0,0.0,0.03,0.0,0.0,0.03,david stegall,,PHIL-3430,2015
+PHIL,3440,1,Business Ethics,0.13,0.56,0.18,0.03,0.0,0.0,0.0,0.1,diane perpich,,PHIL-3440,2015
+PHIL,3450,1,Environmental Ethics,0.39,0.5,0.08,0.0,0.03,0.0,0.0,0.0,jennifer ingle,,PHIL-3450,2015
+PHIL,3510,1,Phil of Emotion,0.21,0.39,0.21,0.04,0.04,0.0,0.0,0.11,charles starkey,,PHIL-3510,2015
+PHIL,3550,1,Phil Mind & Cog Sci,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,ryan lake,,PHIL-3550,2015
+PHSC,1170,1,Intro Chem & Earth,0.82,0.17,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1170,2015
+PHYS,1220,1,Physics With Cal I,0.16,0.38,0.24,0.08,0.1,0.0,0.0,0.04,lih-sin the,,PHYS-1220,2015
+PHYS,1220,2,Physics With Cal I,0.24,0.4,0.24,0.05,0.02,0.0,0.0,0.03,lih-sin the,,PHYS-1220,2015
+PHYS,1220,3,Physics With Cal I,0.28,0.41,0.21,0.05,0.02,0.0,0.0,0.03,lih-sin the,,PHYS-1220,2015
+PHYS,1220,4,Physics With Cal I,0.34,0.35,0.18,0.05,0.03,0.0,0.0,0.05,ramakrishna podila,,PHYS-1220,2015
+PHYS,1220,5,Physics With Cal I,0.21,0.42,0.27,0.05,0.03,0.0,0.0,0.02,mark leising,,PHYS-1220,2015
+PHYS,1220,8,Physics With Cal I (HON),0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,joan marler,True,PHYS-1220,2015
+PHYS,1240,1,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,2,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,3,Physics Lab I,0.18,0.71,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,,PHYS-1240,2015
+PHYS,1240,4,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,5,Physics Lab I,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,6,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,7,Physics Lab I,0.4,0.53,0.0,0.07,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,8,Physics Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,,PHYS-1240,2015
+PHYS,1240,9,Physics Lab I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,10,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,11,Physics Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,12,Physics Lab I,0.17,0.72,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,13,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,14,Physics Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,15,Physics Lab I,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,16,Physics Lab I,0.06,0.89,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,17,Physics Lab I,0.22,0.67,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,18,Physics Lab I,0.17,0.61,0.11,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2015
+PHYS,1240,19,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,20,Physics Lab I,0.33,0.44,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,21,Physics Lab I,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,22,Physics Lab I,0.44,0.31,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,,PHYS-1240,2015
+PHYS,1240,23,Physics Lab I,0.41,0.47,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,24,Physics Lab I,0.28,0.61,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,25,Physics Lab I,0.31,0.44,0.19,0.0,0.06,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,26,Physics Lab I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,1240,27,Physics Lab I,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2015
+PHYS,1240,28,Physics Lab I,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jerry hester,,PHYS-1240,2015
+PHYS,1240,29,Physics Lab I,0.12,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2015
+PHYS,2000,1,Introductory Physics,0.46,0.39,0.07,0.07,0.0,0.0,0.0,0.02,sean brittain,,PHYS-2000,2015
+PHYS,2070,1,General Physics I,0.36,0.36,0.15,0.08,0.03,0.0,0.0,0.03,pooja puneet,,PHYS-2070,2015
+PHYS,2080,1,General Physics II,0.46,0.35,0.11,0.03,0.02,0.0,0.0,0.02,amy liann pope,,PHYS-2080,2015
+PHYS,2080,2,General Physics II,0.64,0.29,0.04,0.01,0.0,0.0,0.0,0.01,amy liann pope,,PHYS-2080,2015
+PHYS,2090,1,Gen Phys Lab I,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,2,Gen Phys Lab I,0.36,0.5,0.05,0.0,0.05,0.0,0.0,0.05,jerry hester,,PHYS-2090,2015
+PHYS,2090,3,Gen Phys Lab I,0.7,0.13,0.09,0.0,0.04,0.0,0.0,0.04,jerry hester,,PHYS-2090,2015
+PHYS,2090,4,Gen Phys Lab I,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2015
+PHYS,2090,5,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,6,Gen Phys Lab I,0.17,0.75,0.0,0.0,0.04,0.0,0.0,0.04,jerry hester,,PHYS-2090,2015
+PHYS,2090,7,Gen Phys Lab I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,8,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,9,Gen Phys Lab I,0.5,0.29,0.13,0.08,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2090,10,Gen Phys Lab I,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2015
+PHYS,2100,1,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,2,Gen Phys Lab II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,3,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,4,Gen Phys Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,5,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,6,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,7,Gen Phys Lab II,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,8,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,9,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,10,Gen Phys Lab II,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2015
+PHYS,2100,11,Gen Phys Lab II,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,12,Gen Phys Lab II,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,13,Gen Phys Lab II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,14,Gen Phys Lab II,0.14,0.55,0.14,0.0,0.05,0.0,0.0,0.14,jerry hester,,PHYS-2100,2015
+PHYS,2100,15,Gen Phys Lab II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2100,16,Gen Phys Lab II,0.1,0.5,0.3,0.05,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2100,2015
+PHYS,2100,17,Gen Phys Lab II,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,,PHYS-2100,2015
+PHYS,2210,1,Physics With Cal II,0.32,0.34,0.21,0.06,0.03,0.0,0.0,0.03,jason stratfo brown,,PHYS-2210,2015
+PHYS,2210,2,Physics With Cal II,0.22,0.38,0.2,0.08,0.08,0.0,0.0,0.03,jason stratfo brown,,PHYS-2210,2015
+PHYS,2210,3,Physics With Cal II,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,murray daw,,PHYS-2210,2015
+PHYS,2220,1,Phys With Cal III,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,jian he,,PHYS-2220,2015
+PHYS,2230,1,Physics Lab II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,2,Physics Lab II,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2015
+PHYS,2230,3,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,4,Physics Lab II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,5,Physics Lab II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2230,6,Physics Lab II,0.36,0.5,0.0,0.0,0.07,0.0,0.0,0.07,jerry hester,,PHYS-2230,2015
+PHYS,2230,7,Physics Lab II,0.25,0.63,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2015
+PHYS,2230,8,Physics Lab II,0.18,0.71,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2015
+PHYS,2230,9,Physics Lab II,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2015
+PHYS,2240,1,Physics Lab III,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2240,2015
+PHYS,2400,1,Phys of Weather,0.3,0.3,0.18,0.05,0.05,0.0,0.0,0.13,miguel larsen,,PHYS-2400,2015
+PHYS,3110,1,Methods Theor Phys,0.64,0.09,0.0,0.18,0.09,0.0,0.0,0.0,hye jung kang,,PHYS-3110,2015
+PHYS,3260,1,Exper Physics II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,chad sosolik,,PHYS-3260,2015
+PHYS,3560,1,Modern Physics,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,chad sosolik,,PHYS-3560,2015
+PHYS,4560,1,Quantum Physics II,0.0,0.5,0.5,0.0,0.0,0.0,0.0,0.0,antony valentini,,PHYS-4560,2015
+PHYS,4650,1,Thermo and Stat Mech,0.21,0.36,0.14,0.21,0.0,0.0,0.0,0.07,jens oberheide,,PHYS-4650,2015
+PHYS,8150,1,Statistical Therm I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,,PHYS-8150,2015
+PHYS,8410,1,Electrodynamics I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,,PHYS-8410,2015
+PHYS,9520,1,Quantum Mech II,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,,PHYS-9520,2015
+PKSC,1020,1,Intro to Pkg Sci,0.14,0.39,0.31,0.07,0.06,0.0,0.0,0.03,heather batt,,PKSC-1020,2015
+PKSC,2010,1,Pkg Perishable Prod,0.15,0.42,0.23,0.12,0.07,0.0,0.0,0.01,heather batt,,PKSC-2010,2015
+PKSC,2020,1,Packaging Mtl & Mfg,0.81,0.03,0.1,0.0,0.06,0.0,0.0,0.0,robert truett moore,,PKSC-2020,2015
+PKSC,2040,1,Container Systems,0.74,0.19,0.07,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2040,2015
+PKSC,2060,1,Container Sys Lab,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2060,2015
+PKSC,2060,2,Container Sys Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2060,2015
+PKSC,2060,3,Container Sys Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2060,2015
+PKSC,2200,1,Product & Pkg Design,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,william aaro snyder,,PKSC-2200,2015
+PKSC,3200,1,Pkg Design Theory,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,rupert hurley,,PKSC-3200,2015
+PKSC,3680,1,Pkg and Society,0.41,0.38,0.15,0.03,0.03,0.0,0.0,0.0,heather batt,,PKSC-3680,2015
+PKSC,4030,1,Pkg Career Prep,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2015
+PKSC,4200,1,Pkg Design & Dev,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2015
+PKSC,4300,1,Converting Flex Pkg,0.32,0.53,0.12,0.02,0.0,0.0,0.0,0.02,duncan darby,,PKSC-4300,2015
+PKSC,4400,1,Packaging for Distribution,0.31,0.46,0.19,0.04,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4400,2015
+PKSC,4640,1,Fd & Hc Pkg Systems,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2015
+PKSC,8510,1,Pkg Sci Seminar,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,anthony lou pometto,,PKSC-8510,2015
+PLPA,2130,1,Fungi & Civilization,0.45,0.3,0.18,0.01,0.01,0.0,0.0,0.05,julia loui kerrigan,,PLPA-2130,2015
+PLPA,8090,1,Analytical Technique,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,tharayil-santhakumar,,PLPA-8090,2015
+POSC,1010,1,Amer National Govt,0.23,0.49,0.1,0.03,0.05,0.0,0.0,0.1,joseph earl stewart,,POSC-1010,2015
+POSC,1010,2,Amer National Govt,0.08,0.28,0.31,0.15,0.13,0.0,0.0,0.05,adam warber,,POSC-1010,2015
+POSC,1020,1,Intro Intl Relations,0.08,0.47,0.38,0.06,0.0,0.0,0.0,0.0,aron geo tannenbaum,,POSC-1020,2015
+POSC,1020,2,Intro Intl Relations,0.14,0.39,0.31,0.06,0.06,0.0,0.0,0.04,zeynep taydas,,POSC-1020,2015
+POSC,1020,3,Intro Intl Relations,0.25,0.48,0.19,0.01,0.04,0.0,0.0,0.03,lydia loui lundgren,,POSC-1020,2015
+POSC,1030,1,Intro to Political Theory,0.27,0.3,0.27,0.08,0.05,0.0,0.0,0.03,brandon turner,,POSC-1030,2015
+POSC,1040,1,Intro Compar Pol,0.11,0.45,0.23,0.14,0.0,0.0,0.0,0.07,colin pearce,,POSC-1040,2015
+POSC,1040,2,Intro Compar Pol,0.29,0.5,0.1,0.02,0.02,0.0,0.0,0.06,katherine am curtis,,POSC-1040,2015
+POSC,1990,1,Intro Pol Sci,0.42,0.21,0.25,0.06,0.04,0.0,0.0,0.02,meredith petersheim,,POSC-1990,2015
+POSC,3020,1,State and Loc Gov,0.1,0.51,0.27,0.02,0.05,0.0,0.0,0.05,bruce ransom,,POSC-3020,2015
+POSC,3210,1,Public Admin,0.1,0.38,0.43,0.02,0.07,0.0,0.0,0.0,james woodard,,POSC-3210,2015
+POSC,3610,1,Intl Pol in Crisis,0.47,0.37,0.1,0.0,0.03,0.0,0.0,0.03,vladimir matic,,POSC-3610,2015
+POSC,3610,2,Intl Pol in Crisis,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,jeremy fortier,,POSC-3610,2015
+POSC,3630,1,Us Foreign Policy,0.26,0.35,0.24,0.03,0.12,0.0,0.0,0.0,steven vince miller,,POSC-3630,2015
+POSC,3710,1,European Politics,0.29,0.5,0.19,0.02,0.0,0.0,0.0,0.0,katherine am curtis,,POSC-3710,2015
+POSC,3750,1,European Integration,0.08,0.23,0.46,0.0,0.08,0.0,0.0,0.15,zeynep taydas,,POSC-3750,2015
+POSC,3890,1,Rel. Liberty & Constitution,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,,POSC-3890,2015
+POSC,4030,1,United States Congress,0.32,0.52,0.08,0.0,0.04,0.0,0.0,0.04,jeffrey scott peake,,POSC-4030,2015
+POSC,4050,1,American Presidency,0.05,0.23,0.32,0.09,0.18,0.0,0.0,0.14,adam warber,,POSC-4050,2015
+POSC,4360,1,Law Courts Politics,0.79,0.08,0.04,0.0,0.04,0.0,0.0,0.04,joseph earl stewart,,POSC-4360,2015
+POSC,4370,1,Constitut Law: Rights & Libert,0.48,0.42,0.0,0.0,0.03,0.0,0.0,0.06,daniel frost,,POSC-4370,2015
+POSC,4490,1,Political Theory of Capitalism,0.23,0.3,0.23,0.07,0.07,0.0,0.0,0.1,brandon turner,,POSC-4490,2015
+POSC,4530,1,American Political Thought,0.22,0.56,0.17,0.03,0.03,0.0,0.0,0.0, bradley thompson,,POSC-4530,2015
+POSC,4540,1,Southern Politics,0.07,0.47,0.4,0.0,0.07,0.0,0.0,0.0,james woodard,,POSC-4540,2015
+POSC,4570,1,Political Terrorism,0.37,0.44,0.15,0.02,0.0,0.0,0.0,0.02,aron geo tannenbaum,,POSC-4570,2015
+POSC,4760,1,Middle East Politics,0.36,0.45,0.05,0.05,0.05,0.0,0.0,0.05,vladimir matic,,POSC-4760,2015
+POSC,4820,1,Political Novel and Film,0.13,0.39,0.39,0.04,0.0,0.0,0.0,0.04,james woodard,,POSC-4820,2015
+PRTM,2000,7,Prof & Prac in PRTM,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,brandon harris,,PRTM-2000,2015
+PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,,PRTM-2070,2015
+PRTM,2200,2,Foundations of PRTM,0.28,0.55,0.14,0.0,0.0,0.0,0.0,0.03,teresa walto tucker,,PRTM-2200,2015
+PRTM,2200,3,Foundations of PRTM,0.47,0.37,0.07,0.07,0.0,0.0,0.0,0.03,gwynn powell,,PRTM-2200,2015
+PRTM,2200,4,Foundations of PRTM,0.41,0.38,0.17,0.03,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2200,2015
+PRTM,2200,5,Foundations of PRTM,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,cindy hartman,,PRTM-2200,2015
+PRTM,2200,6,Foundations of PRTM,0.72,0.12,0.12,0.04,0.0,0.0,0.0,0.0,katherine an jordan,,PRTM-2200,2015
+PRTM,2200,7,Foundations of PRTM,0.62,0.28,0.03,0.07,0.0,0.0,0.0,0.0,brandon harris,,PRTM-2200,2015
+PRTM,2410,1,Intro to CRSCM,0.25,0.52,0.2,0.03,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2410,2015
+PRTM,2600,1,Found of Recreational Therapy,0.87,0.07,0.02,0.0,0.04,0.0,0.0,0.0,anna-mar chancellor,,PRTM-2600,2015
+PRTM,2650,1,Terminology in RT Practice,0.73,0.13,0.07,0.02,0.05,0.0,0.0,0.0,stephen thoma lewis,,PRTM-2650,2015
+PRTM,2700,1,Intro Rec Res Mgt,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,lincoln larson,,PRTM-2700,2015
+PRTM,2810,1,Intro to Golf Mgt,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-2810,2015
+PRTM,2820,1,Principle Golfer Dev,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-2820,2015
+PRTM,2830,1,Adv Mth Golf Teachng,0.5,0.25,0.08,0.17,0.0,0.0,0.0,0.0,adam savedra,,PRTM-2830,2015
+PRTM,2980,4,Creative Inquiry in PRTM II,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2980,2015
+PRTM,2980,7,Creative Inquiry in PRTM II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2980,2015
+PRTM,2980,8,Creative Inquiry in PRTM II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2980,2015
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.4,0.31,0.17,0.06,0.06,0.0,0.0,0.0,daniel mor anderson,,PRTM-3050,2015
+PRTM,3070,1,Facility Operations,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,craig goodman,,PRTM-3070,2015
+PRTM,3250,1,Global Persp in Rec,0.08,0.7,0.15,0.03,0.03,0.0,0.0,0.03,teresa walto tucker,,PRTM-3250,2015
+PRTM,3270,1,RT Impl & Eval: Ment Hlth Cond,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3270,2015
+PRTM,3420,1,Intro to Tourism,0.55,0.31,0.1,0.0,0.02,0.0,0.0,0.02,william norman,,PRTM-3420,2015
+PRTM,3420,2,Intro to Tourism,0.56,0.31,0.03,0.0,0.03,0.0,0.0,0.06,maloud shakona,,PRTM-3420,2015
+PRTM,3440,1,Tourism Markets,0.45,0.23,0.23,0.05,0.0,0.0,0.0,0.05,sheila backman,,PRTM-3440,2015
+PRTM,3440,2,Tourism Markets,0.55,0.29,0.14,0.0,0.0,0.0,0.0,0.02,sheila backman,,PRTM-3440,2015
+PRTM,3450,1,Tourism Management,0.81,0.1,0.06,0.0,0.0,0.0,0.0,0.03,lauren duffy,,PRTM-3450,2015
+PRTM,3460,1,Heritage Tourism,0.47,0.38,0.09,0.02,0.0,0.0,0.0,0.04,gregory phi ramshaw,,PRTM-3460,2015
+PRTM,3470,1,Sport Tourism,0.33,0.36,0.21,0.03,0.03,0.0,0.0,0.03,gregory phi ramshaw,,PRTM-3470,2015
+PRTM,3530,1,Foundations of Camp Counseling,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,gwynn powell,,PRTM-3530,2015
+PRTM,3550,1,Trends & Issues in Camp Mgt,0.64,0.14,0.14,0.0,0.0,0.0,0.0,0.07,teresa walto tucker,,PRTM-3550,2015
+PRTM,3830,1,Golf Shop Operations,0.54,0.23,0.15,0.08,0.0,0.0,0.0,0.0,richard lucas,,PRTM-3830,2015
+PRTM,3910,2,Intro to GIS for PRTM,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,david lawrenc white,,PRTM-3910,2015
+PRTM,4210,1,Rec Fin Resc Mgt,0.35,0.32,0.16,0.06,0.03,0.0,0.0,0.06,daniel mor anderson,,PRTM-4210,2015
+PRTM,4260,1,Trends & Issues in Rec Therapy,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-4260,2015
+PRTM,4300,1,World Geog Parks,0.23,0.6,0.17,0.0,0.0,0.0,0.0,0.0,robert baxte powell,,PRTM-4300,2015
+PRTM,4310,1,Methods Envir Inter,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-4310,2015
+PRTM,4450,1,Conventions,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,jeffery martin,,PRTM-4450,2015
+PRTM,4460,2,Community Tourism,0.19,0.63,0.15,0.0,0.0,0.0,0.0,0.04,herbert chancellor,,PRTM-4460,2015
+PRTM,4470,1,Perspect Intl Travel,0.61,0.23,0.13,0.0,0.0,0.0,0.0,0.03,lauren duffy,,PRTM-4470,2015
+PRTM,4510,1,Seminar in CRSCM,0.26,0.56,0.15,0.0,0.03,0.0,0.0,0.0,cindy hartman,,PRTM-4510,2015
+PRTM,4540,1,Trends in Sport Mgt,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,,PRTM-4540,2015
+PRTM,4550,1,Adv Program Planning,0.58,0.25,0.0,0.17,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-4550,2015
+PRTM,4980,2,Creative Inquiry in PRTM IV,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,,PRTM-4980,2015
+PRTM,4980,3,Creative Inquiry in PRTM IV,0.8,0.0,0.0,0.0,0.2,0.0,0.0,0.0,kellie aman walters,,PRTM-4980,2015
+PRTM,4980,6,Creative Inquiry in PRTM IV,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-4980,2015
+PRTM,4980,8,Creative Inquiry in PRTM IV,0.5,0.1,0.4,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,,PRTM-4980,2015
+PRTM,8030,1,Sem Rec & Park Admin,0.63,0.21,0.0,0.0,0.13,0.0,0.0,0.04,skye arthur-banning,,PRTM-8030,2015
+PRTM,8110,2,Research Methods,0.81,0.12,0.0,0.0,0.04,0.0,0.0,0.04,jeffrey charl hallo,,PRTM-8110,2015
+PRTM,8210,1,Alt Funding for PRTM,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-8210,2015
+PRTM,8250,1,Populations in PRTM,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,,PRTM-8250,2015
+PRTM,8400,2,Tourism Planning,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,william norman,,PRTM-8400,2015
+PSYC,2010,1,Intro to Psychology,0.31,0.31,0.2,0.08,0.05,0.0,0.0,0.06,jo anne jorgensen,,PSYC-2010,2015
+PSYC,2010,2,Intro to Psychology,0.28,0.38,0.23,0.05,0.04,0.0,0.0,0.02,edwin brainerd,,PSYC-2010,2015
+PSYC,2010,3,Intro to Psychology,0.39,0.24,0.23,0.06,0.04,0.0,0.0,0.04,mary taylor,,PSYC-2010,2015
+PSYC,2010,4,Intro to Psychology,0.41,0.35,0.13,0.03,0.04,0.0,0.0,0.04,mary taylor,,PSYC-2010,2015
+PSYC,2010,5,Intro to Psychology,0.3,0.44,0.1,0.06,0.06,0.0,0.0,0.04,fred switzer,,PSYC-2010,2015
+PSYC,2010,20,Intro to Psychology (HON),0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,robin mari kowalski,True,PSYC-2010,2015
+PSYC,2020,1,Intro Psychology Lab,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,eric mckibben,,PSYC-2020,2015
+PSYC,2020,3,Intro Psychology Lab,0.84,0.12,0.0,0.0,0.04,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2015
+PSYC,2020,4,Intro Psychology Lab,0.86,0.0,0.1,0.0,0.05,0.0,0.0,0.0,eric mckibben,,PSYC-2020,2015
+PSYC,2020,6,Intro Psychology Lab,0.82,0.05,0.0,0.0,0.09,0.0,0.0,0.05,lauren elizab ellis,,PSYC-2020,2015
+PSYC,3060,1,Human Sexual Beh,0.62,0.19,0.11,0.04,0.03,0.0,0.0,0.01,bruce michael king,,PSYC-3060,2015
+PSYC,3090,100,Intro Exp Psych,0.27,0.34,0.22,0.05,0.07,0.0,0.0,0.05,richard tyrrell,,PSYC-3090,2015
+PSYC,3090,200,Intro Exp Psych,0.41,0.31,0.17,0.03,0.07,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3090,2015
+PSYC,3090,300,Intro Exp Psych,0.77,0.13,0.07,0.0,0.0,0.0,0.0,0.03,allison lei wallace,,PSYC-3090,2015
+PSYC,3100,100,Advanced Experimental Psych,0.45,0.35,0.05,0.0,0.05,0.0,0.0,0.1,jennifer bai bisson,,PSYC-3100,2015
+PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2015
+PSYC,3100,300,Advanced Experimental Psych,0.5,0.22,0.11,0.11,0.06,0.0,0.0,0.0,thomas britt,,PSYC-3100,2015
+PSYC,3100,400,Advanced Experimental Psych,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,robert campbell,,PSYC-3100,2015
+PSYC,3100,500,Advanced Experimental Psych,0.53,0.32,0.05,0.05,0.05,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2015
+PSYC,3100,600,Advanced Experimental Psych,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3100,2015
+PSYC,3240,1,Physiological Psych,0.3,0.31,0.25,0.08,0.01,0.0,0.0,0.04,claudio cantalupo,,PSYC-3240,2015
+PSYC,3240,2,Physiological Psych,0.35,0.4,0.11,0.09,0.02,0.0,0.0,0.03,june pilcher,,PSYC-3240,2015
+PSYC,3330,1,Cognitive Psych,0.77,0.14,0.05,0.04,0.0,0.0,0.0,0.0,paul steven merritt,,PSYC-3330,2015
+PSYC,3330,2,Cognitive Psych,0.71,0.2,0.04,0.01,0.03,0.0,0.0,0.01,paul steven merritt,,PSYC-3330,2015
+PSYC,3340,1,Cognitive Psych Lab,0.6,0.25,0.1,0.0,0.0,0.0,0.0,0.05,phillip weis jasper,,PSYC-3340,2015
+PSYC,3340,2,Cognitive Psych Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,brian day,,PSYC-3340,2015
+PSYC,3340,3,Cognitive Psych Lab,0.63,0.21,0.0,0.05,0.05,0.0,0.0,0.05,ashley ann sewall,,PSYC-3340,2015
+PSYC,3400,1,Lifespan Developmental Psych,0.27,0.41,0.2,0.06,0.03,0.0,0.0,0.03,pamela alley,,PSYC-3400,2015
+PSYC,3520,1,Social Psychology,0.38,0.35,0.13,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,,PSYC-3520,2015
+PSYC,3520,2,Social Psychology,0.39,0.3,0.19,0.06,0.03,0.0,0.0,0.04,jo anne jorgensen,,PSYC-3520,2015
+PSYC,3640,1,Industrial Psych,0.49,0.44,0.03,0.0,0.0,0.0,0.0,0.04,fred switzer,,PSYC-3640,2015
+PSYC,3680,1,Organizational Psych,0.41,0.41,0.16,0.01,0.0,0.0,0.0,0.01,eric mckibben,,PSYC-3680,2015
+PSYC,3680,2,Organizational Psych,0.46,0.39,0.14,0.0,0.01,0.0,0.0,0.0,eric mckibben,,PSYC-3680,2015
+PSYC,3690,1,Leadership in Orgs,0.27,0.27,0.21,0.15,0.02,0.0,0.0,0.08,patrick raymark,,PSYC-3690,2015
+PSYC,3700,1,Personality,0.49,0.24,0.13,0.1,0.03,0.0,0.0,0.01,william kramer,,PSYC-3700,2015
+PSYC,3830,1,Abnormal Psychology,0.16,0.42,0.28,0.08,0.02,0.0,0.0,0.04,cynthia pury,,PSYC-3830,2015
+PSYC,3830,2,Abnormal Psychology,0.14,0.43,0.2,0.06,0.14,0.0,0.0,0.03,pamela alley,,PSYC-3830,2015
+PSYC,3830,3,Abnormal Psychology,0.31,0.4,0.11,0.09,0.09,0.0,0.0,0.0,pamela alley,,PSYC-3830,2015
+PSYC,4080,1,Women and Psychology,0.64,0.2,0.08,0.0,0.0,0.0,0.0,0.08,robin mari kowalski,,PSYC-4080,2015
+PSYC,4150,1,Systems and Theories,0.35,0.3,0.18,0.0,0.13,0.0,0.0,0.05,edwin brainerd,,PSYC-4150,2015
+PSYC,4150,2,Systems and Theories,0.27,0.24,0.24,0.03,0.09,0.0,0.0,0.12,edwin brainerd,,PSYC-4150,2015
+PSYC,4220,1,Perception,0.28,0.38,0.21,0.07,0.0,0.0,0.0,0.07,claudio cantalupo,,PSYC-4220,2015
+PSYC,4220,2,Perception,0.25,0.21,0.36,0.18,0.0,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2015
+PSYC,4220,3,Perception,0.4,0.12,0.24,0.12,0.04,0.0,0.0,0.08,claudio cantalupo,,PSYC-4220,2015
+PSYC,4430,1,Infant & Child Dev,0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-4430,2015
+PSYC,4430,2,Infant & Child Dev,0.33,0.37,0.19,0.07,0.04,0.0,0.0,0.0,sarah mae sanborn,,PSYC-4430,2015
+PSYC,4470,1,Moral Development,0.33,0.58,0.0,0.0,0.08,0.0,0.0,0.0,robert campbell,,PSYC-4470,2015
+PSYC,4560,1,Psychophysiology,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,james nathan salley,,PSYC-4560,2015
+PSYC,4800,1,Health Psychology,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2015
+PSYC,4880,1,Psychotherapy,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,lucinda sorci quick,,PSYC-4880,2015
+PSYC,4890,1,Science of Sleep,0.39,0.57,0.0,0.0,0.04,0.0,0.0,0.0,june pilcher,,PSYC-4890,2015
+PSYC,4920,4,Senior Laboratory,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brooke bake allison,,PSYC-4920,2015
+PSYC,4920,5,Senior Laboratory,0.68,0.14,0.0,0.05,0.09,0.0,0.0,0.05,jessica anne stahl,,PSYC-4920,2015
+PSYC,4930,100,Pract Clinical Psych,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,heidi marie zinzow,,PSYC-4930,2015
+PSYC,8110,1,Research Design II,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,patrick rosopa,,PSYC-8110,2015
+PSYC,8130,1,Research Design III,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, dewayne moore,,PSYC-8130,2015
+PSYC,8140,1,Quantitative Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06, dewayne moore,,PSYC-8140,2015
+PSYC,8370,1,Ergonomics Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,,PSYC-8370,2015
+PSYC,8820,1,Occupat Health Psy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,,PSYC-8820,2015
+RED,8010,1,Market Analysis,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,john terrenc farris,,RED-8010,2015
+RED,8120,1,Real Estate Technology,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,robert cre benedict,,RED-8120,2015
+RED,8130,1,Strat in Real Estate,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,,RED-8130,2015
+REL,1010,1,Intro to Religion,0.86,0.06,0.03,0.0,0.0,0.0,0.0,0.06,robert stephens,,REL-1010,2015
+REL,1010,2,Intro to Religion,0.82,0.06,0.06,0.0,0.0,0.0,0.0,0.06,robert stephens,,REL-1010,2015
+REL,1010,3,Intro to Religion,0.74,0.06,0.06,0.0,0.03,0.03,0.0,0.09,robert stephens,,REL-1010,2015
+REL,1020,1,World Religions,0.2,0.37,0.29,0.09,0.0,0.0,0.0,0.06,peter cohen,,REL-1020,2015
+REL,1020,2,World Religions,0.25,0.28,0.19,0.14,0.08,0.0,0.0,0.06,peter cohen,,REL-1020,2015
+REL,1020,4,World Religions,0.24,0.48,0.09,0.06,0.09,0.0,0.0,0.03,peter cohen,,REL-1020,2015
+REL,3000,1,Studying Religion,0.17,0.33,0.29,0.08,0.04,0.0,0.0,0.08,benjamin white,,REL-3000,2015
+REL,3010,1,Old Testament,0.56,0.31,0.08,0.06,0.0,0.0,0.0,0.0,steven grosby,,REL-3010,2015
+REL,3020,1,New Testament Lit,0.34,0.44,0.16,0.03,0.0,0.0,0.0,0.03,benjamin white,,REL-3020,2015
+REL,3030,1,The Quran,0.29,0.57,0.05,0.0,0.1,0.0,0.0,0.0,mashal saif,,REL-3030,2015
+REL,3060,1,Judaism,0.58,0.32,0.0,0.0,0.03,0.0,0.0,0.06,steven grosby,,REL-3060,2015
+REL,3130,1,Buddhism,0.86,0.06,0.06,0.03,0.0,0.0,0.0,0.0,robert stephens,,REL-3130,2015
+REL,3150,1,Islam,0.14,0.48,0.14,0.0,0.1,0.0,0.0,0.14,mashal saif,,REL-3150,2015
+RS,3010,1,Rural Sociology,0.3,0.56,0.12,0.0,0.0,0.0,0.0,0.02,kenneth robinson,,RS-3010,2015
+RS,4590,1,The Community,0.4,0.4,0.1,0.0,0.1,0.0,0.0,0.0,kenneth robinson,,RS-4590,2015
+RUSS,1020,1,Elementary Russian,0.3,0.6,0.0,0.0,0.0,0.0,0.0,0.1,joan bridgwood,,RUSS-1020,2015
+RUSS,3400,1,19th C Russ Culture,0.44,0.38,0.0,0.06,0.0,0.0,0.0,0.13,joan bridgwood,,RUSS-3400,2015
+SOC,2010,2,Introduction to Sociology,0.42,0.33,0.23,0.0,0.0,0.0,0.0,0.02,mary louise barr,,SOC-2010,2015
+SOC,2010,3,Introduction to Sociology,0.45,0.39,0.16,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2015
+SOC,2010,4,Introduction to Sociology,0.43,0.26,0.26,0.0,0.0,0.0,0.0,0.04,mary louise barr,,SOC-2010,2015
+SOC,2010,5,Introduction to Sociology,0.37,0.38,0.25,0.0,0.0,0.0,0.0,0.0,mary louise barr,,SOC-2010,2015
+SOC,2010,6,Introduction to Sociology,0.3,0.37,0.3,0.0,0.02,0.0,0.0,0.0,mary louise barr,,SOC-2010,2015
+SOC,2010,7,Introduction to Sociology,0.51,0.35,0.12,0.02,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2015
+SOC,2010,8,Introduction to Sociology,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,,SOC-2010,2015
+SOC,2010,9,Introduction to Sociology,0.66,0.27,0.05,0.0,0.0,0.0,0.0,0.01,jeffrey edwards,,SOC-2010,2015
+SOC,2020,1,Social Problems,0.61,0.22,0.0,0.11,0.0,0.0,0.0,0.06,stephani southworth,,SOC-2020,2015
+SOC,2020,2,Social Problems,0.36,0.4,0.13,0.04,0.04,0.0,0.0,0.02,stephani southworth,,SOC-2020,2015
+SOC,2050,1,Sociology Lab,0.52,0.14,0.05,0.1,0.1,0.0,0.0,0.1,brenda vander mey,,SOC-2050,2015
+SOC,3020,1,Research Methods I,0.28,0.2,0.36,0.08,0.08,0.0,0.0,0.0,andrew whitehead,,SOC-3020,2015
+SOC,3040,1,Social Research Methods II,0.14,0.52,0.28,0.0,0.03,0.0,0.0,0.03,ye luo,,SOC-3040,2015
+SOC,3100,1,Marriage & Intimacy,0.7,0.28,0.02,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,,SOC-3100,2015
+SOC,3310,1,Urban Sociology,0.34,0.32,0.17,0.06,0.09,0.0,0.0,0.02,stephani southworth,,SOC-3310,2015
+SOC,3500,1,Self & Society,0.23,0.45,0.28,0.04,0.0,0.0,0.0,0.0,ellen granberg,,SOC-3500,2015
+SOC,3600,1,Class & Poverty,0.57,0.3,0.04,0.09,0.0,0.0,0.0,0.0,william haller,,SOC-3600,2015
+SOC,3800,1,Intro Social Service,0.43,0.43,0.11,0.02,0.0,0.0,0.0,0.02,jennifer le holland,,SOC-3800,2015
+SOC,3880,1,Criminal Justice,0.12,0.33,0.33,0.12,0.08,0.0,0.0,0.02,margaret tina britz,,SOC-3880,2015
+SOC,3890,1,Criminology,0.14,0.31,0.19,0.12,0.1,0.0,0.0,0.14,william white,,SOC-3890,2015
+SOC,3910,1,Soc of Deviance,0.3,0.35,0.26,0.05,0.02,0.0,0.0,0.02,stephani southworth,,SOC-3910,2015
+SOC,3920,1,Juvenile Delinquency,0.14,0.27,0.16,0.23,0.16,0.0,0.0,0.05,william white,,SOC-3920,2015
+SOC,3970,1,Substance Abuse,0.66,0.28,0.03,0.0,0.0,0.0,0.0,0.03,jeffrey edwards,,SOC-3970,2015
+SOC,4030,1,"Technol, Environment & Society",0.27,0.32,0.27,0.05,0.0,0.0,0.0,0.09, catherine mobley,,SOC-4030,2015
+SOC,4040,1,Soc Theory,0.49,0.29,0.11,0.09,0.03,0.0,0.0,0.0,william wentworth,,SOC-4040,2015
+SOC,4320,1,Soc of Religion,0.32,0.28,0.12,0.12,0.12,0.0,0.0,0.04,andrew whitehead,,SOC-4320,2015
+SOC,4440,1,Sociology of Educ,0.24,0.35,0.18,0.18,0.06,0.0,0.0,0.0,stephani southworth,,SOC-4440,2015
+SOC,4590,1,The Community,0.44,0.44,0.0,0.13,0.0,0.0,0.0,0.0,kenneth robinson,,SOC-4590,2015
+SOC,4600,1,Race & Ethnicity,0.38,0.21,0.24,0.1,0.03,0.0,0.0,0.03,brenda vander mey,,SOC-4600,2015
+SOC,4610,1,Sex & Gender,0.24,0.24,0.27,0.19,0.0,0.0,0.0,0.05,sarah evely winslow,,SOC-4610,2015
+SOC,4800,1,Medical Sociology,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,william wentworth,,SOC-4800,2015
+SOC,4840,1,Child Abuse,0.42,0.31,0.23,0.02,0.0,0.0,0.0,0.02,douglas sturkie,,SOC-4840,2015
+SOC,4860,5,Creative Inquiry in Sociology,0.5,0.28,0.17,0.0,0.06,0.0,0.0,0.0,margaret tina britz,,SOC-4860,2015
+SOC,4860,6,Creative Inquiry in Sociology,0.62,0.14,0.1,0.05,0.1,0.0,0.0,0.0,margaret tina britz,,SOC-4860,2015
+SOC,4930,1,Soc of Corrections,0.3,0.3,0.3,0.1,0.0,0.0,0.0,0.0,william white,,SOC-4930,2015
+SOC,4940,1,Organized Crimes,0.62,0.15,0.23,0.0,0.0,0.0,0.0,0.0,margaret tina britz,,SOC-4940,2015
+SOC,4970,1,Senior Lab,0.53,0.18,0.12,0.12,0.06,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2015
+SOC,4970,2,Senior Lab,0.48,0.28,0.08,0.04,0.12,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2015
+SPAN,1010,1,Elementary Spanish,0.35,0.35,0.29,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-1010,2015
+SPAN,1010,2,Elementary Spanish,0.44,0.17,0.33,0.0,0.06,0.0,0.0,0.0,heidi montes,,SPAN-1010,2015
+SPAN,1020,1,Elementary Spanish,0.17,0.17,0.22,0.06,0.28,0.0,0.0,0.11,roger simpson,,SPAN-1020,2015
+SPAN,1020,2,Elementary Spanish,0.21,0.26,0.16,0.21,0.0,0.0,0.0,0.16,roger simpson,,SPAN-1020,2015
+SPAN,1020,3,Elementary Spanish,0.47,0.24,0.18,0.0,0.0,0.0,0.0,0.12,roger simpson,,SPAN-1020,2015
+SPAN,1020,4,Elementary Spanish,0.26,0.32,0.26,0.0,0.05,0.0,0.0,0.11,roger simpson,,SPAN-1020,2015
+SPAN,1020,5,Elementary Spanish,0.15,0.25,0.2,0.15,0.15,0.0,0.0,0.1,roger simpson,,SPAN-1020,2015
+SPAN,1020,6,Elementary Spanish,0.5,0.17,0.22,0.06,0.0,0.0,0.0,0.06,cathy robison,,SPAN-1020,2015
+SPAN,1020,7,Elementary Spanish,0.44,0.22,0.11,0.11,0.06,0.0,0.0,0.06,cathy robison,,SPAN-1020,2015
+SPAN,1020,8,Elementary Spanish,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,melva margu persico,,SPAN-1020,2015
+SPAN,1020,9,Elementary Spanish,0.11,0.16,0.42,0.26,0.0,0.0,0.0,0.05,melva margu persico,,SPAN-1020,2015
+SPAN,1020,10,Elementary Spanish,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,kari daus carson,,SPAN-1020,2015
+SPAN,1020,11,Elementary Spanish,0.47,0.18,0.29,0.06,0.0,0.0,0.0,0.0,kari daus carson,,SPAN-1020,2015
+SPAN,2010,1,Intermediate Spanish,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2015
+SPAN,2010,2,Intermediate Spanish,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,cathy robison,,SPAN-2010,2015
+SPAN,2010,3,Intermediate Spanish,0.28,0.67,0.0,0.0,0.06,0.0,0.0,0.0,maureen zamora,,SPAN-2010,2015
+SPAN,2010,4,Intermediate Spanish,0.39,0.44,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,,SPAN-2010,2015
+SPAN,2010,5,Intermediate Spanish,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,ricardo tremolada,,SPAN-2010,2015
+SPAN,2010,6,Intermediate Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,,SPAN-2010,2015
+SPAN,2010,7,Intermediate Spanish,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,ricardo tremolada,,SPAN-2010,2015
+SPAN,2010,8,Intermediate Spanish,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2015
+SPAN,2010,9,Intermediate Spanish,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2010,2015
+SPAN,2010,10,Intermediate Spanish,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,ellory schmucker,,SPAN-2010,2015
+SPAN,2010,11,Intermediate Spanish,0.72,0.11,0.17,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-2010,2015
+SPAN,2010,12,Intermediate Spanish,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-2010,2015
+SPAN,2010,13,Intermediate Spanish,0.29,0.59,0.0,0.06,0.0,0.0,0.0,0.06,juana martin-armas,,SPAN-2010,2015
+SPAN,2010,14,Intermediate Spanish,0.27,0.41,0.09,0.09,0.09,0.0,0.0,0.05,allison ann hinds,,SPAN-2010,2015
+SPAN,2010,15,Intermediate Spanish,0.28,0.28,0.06,0.11,0.17,0.0,0.0,0.11,ricardo tremolada,,SPAN-2010,2015
+SPAN,2020,1,Intermediate Spanish,0.1,0.48,0.29,0.05,0.05,0.0,0.0,0.05,melva margu persico,,SPAN-2020,2015
+SPAN,2020,2,Intermediate Spanish,0.35,0.35,0.25,0.05,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-2020,2015
+SPAN,2020,3,Intermediate Spanish,0.35,0.45,0.15,0.0,0.05,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2015
+SPAN,2020,4,Intermediate Spanish,0.2,0.35,0.25,0.1,0.05,0.0,0.0,0.05,juana martin-armas,,SPAN-2020,2015
+SPAN,2020,5,Intermediate Spanish,0.3,0.35,0.2,0.0,0.05,0.0,0.0,0.1,juana martin-armas,,SPAN-2020,2015
+SPAN,2020,6,Intermediate Spanish,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,ze cruz valderramos,,SPAN-2020,2015
+SPAN,2020,7,Intermediate Spanish,0.41,0.36,0.05,0.14,0.0,0.0,0.0,0.05,allison ann hinds,,SPAN-2020,2015
+SPAN,2020,8,Intermediate Spanish,0.32,0.32,0.32,0.0,0.0,0.0,0.0,0.05,allison ann hinds,,SPAN-2020,2015
+SPAN,2020,9,Intermediate Spanish,0.2,0.5,0.15,0.15,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2020,2015
+SPAN,2020,10,Intermediate Spanish,0.55,0.1,0.2,0.15,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2020,2015
+SPAN,2020,11,Intermediate Spanish,0.38,0.38,0.14,0.05,0.0,0.0,0.0,0.05,ellory schmucker,,SPAN-2020,2015
+SPAN,2020,12,Intermediate Spanish,0.23,0.27,0.45,0.05,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2020,2015
+SPAN,3020,1,Int Spn Gram & Comp,0.47,0.37,0.0,0.05,0.0,0.0,0.0,0.11,george palacios,,SPAN-3020,2015
+SPAN,3020,2,Int Spn Gram & Comp,0.57,0.38,0.0,0.05,0.0,0.0,0.0,0.0,george palacios,,SPAN-3020,2015
+SPAN,3040,1,Intro Hisp Lit Forms,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,george palacios,,SPAN-3040,2015
+SPAN,3050,4,Int Con Comp Span I,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,filiberto hernandez,,SPAN-3050,2015
+SPAN,3060,1,Span Comp for Bus,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-3060,2015
+SPAN,3070,1,Hispanic World: Sp,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,,SPAN-3070,2015
+SPAN,3070,2,Hispanic World: Sp,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,,SPAN-3070,2015
+SPAN,3080,1,Hispanic World: La,0.15,0.45,0.25,0.05,0.05,0.0,0.0,0.05,tiffany dawn miller,,SPAN-3080,2015
+SPAN,3160,1,Span for Intl Trade,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-3160,2015
+SPAN,4060,1,Narrative Fiction,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,salvador oropesa,,SPAN-4060,2015
+SPAN,4150,1,Span for Health Prof,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,,SPAN-4150,2015
+SPAN,4200,1,Hispanic Drama,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,tiffany dawn miller,,SPAN-4200,2015
+STAT,2220,1,Statistics in Everyday Life,0.39,0.2,0.17,0.15,0.09,0.0,0.0,0.0,ros martinez-dawson,,STAT-2220,2015
+STAT,2220,2,Statistics in Everyday Life,0.46,0.26,0.19,0.06,0.0,0.0,0.0,0.04,ros martinez-dawson,,STAT-2220,2015
+STAT,2220,3,Statistics in Everyday Life,0.43,0.39,0.15,0.04,0.0,0.0,0.0,0.0,james espey,,STAT-2220,2015
+STAT,2220,4,Statistics in Everyday Life,0.35,0.48,0.13,0.04,0.0,0.0,0.0,0.0,april thomas,,STAT-2220,2015
+STAT,2220,5,Statistics in Everyday Life,0.31,0.42,0.16,0.07,0.0,0.0,0.0,0.04,emily marie nystrom,,STAT-2220,2015
+STAT,2300,1,Statistical Methods I,0.37,0.31,0.15,0.09,0.06,0.0,0.0,0.01,christy jenki brown,,STAT-2300,2015
+STAT,2300,2,Statistical Methods I,0.33,0.35,0.14,0.04,0.14,0.0,0.0,0.01,benjamin sharp,,STAT-2300,2015
+STAT,2300,3,Statistical Methods I,0.46,0.25,0.16,0.09,0.04,0.0,0.0,0.0,christy jenki brown,,STAT-2300,2015
+STAT,2300,4,Statistical Methods I,0.3,0.35,0.18,0.13,0.03,0.0,0.0,0.03,marion hanna,,STAT-2300,2015
+STAT,2300,5,Statistical Methods I,0.28,0.37,0.22,0.05,0.06,0.0,0.0,0.03, erwin walker,,STAT-2300,2015
+STAT,2300,6,Statistical Methods I,0.23,0.43,0.14,0.11,0.09,0.0,0.0,0.01, erwin walker,,STAT-2300,2015
+STAT,2300,7,Statistical Methods I,0.48,0.34,0.11,0.05,0.0,0.0,0.0,0.01,christy jenki brown,,STAT-2300,2015
+STAT,2300,8,Statistical Methods I,0.44,0.27,0.18,0.03,0.08,0.0,0.0,0.01,marion hanna,,STAT-2300,2015
+STAT,3090,1,Introductory Business Stats,0.08,0.25,0.33,0.11,0.06,0.0,0.0,0.17,paul james cubre,,STAT-3090,2015
+STAT,3090,2,Introductory Business Stats,0.15,0.26,0.21,0.1,0.18,0.0,0.0,0.1,janie caro mcdonald,,STAT-3090,2015
+STAT,3090,3,Introductory Business Stats,0.31,0.18,0.36,0.08,0.08,0.0,0.0,0.0,gary fellers,,STAT-3090,2015
+STAT,3090,4,Introductory Business Stats,0.34,0.2,0.37,0.03,0.03,0.0,0.0,0.03,ellen hepfe breazel,,STAT-3090,2015
+STAT,3090,5,Introductory Business Stats,0.23,0.34,0.2,0.06,0.17,0.0,0.0,0.0,ellen hepfe breazel,,STAT-3090,2015
+STAT,3090,6,Introductory Business Stats,0.38,0.28,0.13,0.15,0.03,0.0,0.0,0.05,lucas waddell,,STAT-3090,2015
+STAT,3090,7,Introductory Business Stats,0.28,0.38,0.18,0.13,0.0,0.0,0.0,0.05,gary fellers,,STAT-3090,2015
+STAT,3090,8,Introductory Business Stats,0.11,0.24,0.32,0.13,0.13,0.0,0.0,0.08,tao yang,,STAT-3090,2015
+STAT,3090,9,Introductory Business Stats,0.05,0.23,0.28,0.13,0.18,0.0,0.0,0.13,ziwen cheng,,STAT-3090,2015
+STAT,3090,10,Introductory Business Stats,0.21,0.33,0.31,0.0,0.1,0.0,0.0,0.05,gary fellers,,STAT-3090,2015
+STAT,3090,11,Introductory Business Stats,0.1,0.45,0.3,0.05,0.03,0.0,0.0,0.08,gary fellers,,STAT-3090,2015
+STAT,3090,12,Introductory Business Stats,0.09,0.46,0.23,0.14,0.03,0.0,0.0,0.06,laura jane shick,,STAT-3090,2015
+STAT,3300,1,Statistical Methods II,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,ros martinez-dawson,,STAT-3300,2015
+STAT,4020,1,Intro to Statistical Computing,0.45,0.27,0.09,0.0,0.0,0.09,0.0,0.09,julia lynn sharp,,STAT-4020,2015
+STAT,4110,1,Stat Mthds for Process Control,0.26,0.32,0.26,0.1,0.06,0.0,0.0,0.0,james rieck,,STAT-4110,2015
+STAT,4110,2,Stat Mthds for Process Control,0.36,0.32,0.14,0.07,0.11,0.0,0.0,0.0,william bridges,,STAT-4110,2015
+STAT,8010,1,Statistical Methods I,0.43,0.27,0.1,0.0,0.17,0.0,0.0,0.03,james rieck,,STAT-8010,2015
+STAT,8010,2,Statistical Methods I,0.41,0.44,0.12,0.0,0.0,0.0,0.0,0.03,patrick gerard,,STAT-8010,2015
+STAT,8010,3,Statistical Methods I,0.69,0.16,0.09,0.0,0.0,0.0,0.0,0.06,jun luo,,STAT-8010,2015
+STAT,8040,1,Sampling,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,patrick gerard,,STAT-8040,2015
+STAT,8050,1,Design & Anlys of Experiments,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,william bridges,,STAT-8050,2015
+STAT,8420,230,Intro to Statistical Methods,0.29,0.29,0.14,0.0,0.14,0.0,0.0,0.14,julia lynn sharp,,STAT-8420,2015
+STS,1010,1,Survey of S T S,0.42,0.33,0.24,0.0,0.0,0.0,0.0,0.0,thomas oberdan,,STS-1010,2015
+STS,1010,2,Survey of S T S,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,scott brame,,STS-1010,2015
+STS,1010,3,Survey of S T S,0.34,0.49,0.09,0.03,0.03,0.0,0.0,0.03,elizabeth stansell,,STS-1010,2015
+STS,1010,4,Survey of S T S,0.5,0.31,0.14,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,,STS-1010,2015
+STS,1010,5,Survey of S T S,0.12,0.36,0.15,0.06,0.0,0.0,0.0,0.3,david charles foltz,,STS-1010,2015
+STS,1010,6,Survey of S T S,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,david stubblefield,,STS-1010,2015
+STS,1010,7,Survey of S T S,0.76,0.16,0.05,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,,STS-1010,2015
+STS,1010,8,Survey of S T S,0.23,0.34,0.2,0.03,0.0,0.0,0.0,0.2,allison ann hinds,,STS-1010,2015
+STS,1010,20,Survey of S T S,0.38,0.41,0.13,0.03,0.0,0.0,0.0,0.06,thomas oberdan,,STS-1010,2015
+STS,2150,1,Crit Appr to Tech Revolutions,0.47,0.37,0.05,0.05,0.0,0.0,0.0,0.05,thomas oberdan,,STS-2150,2015
+THEA,2100,1,Theatre Appreciation,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,richard st. peter,,THEA-2100,2015
+THEA,2100,2,Theatre Appreciation,0.91,0.06,0.0,0.0,0.03,0.0,0.0,0.0,kerrie kath seymour,,THEA-2100,2015
+THEA,2100,3,Theatre Appreciation,0.59,0.28,0.09,0.03,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-2100,2015
+THEA,2100,4,Theatre Appreciation,0.63,0.28,0.09,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-2100,2015
+THEA,2100,5,Theatre Appreciation,0.45,0.3,0.18,0.03,0.0,0.0,0.0,0.03,carol collins,,THEA-2100,2015
+THEA,2100,6,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,,THEA-2100,2015
+THEA,2100,7,Theatre Appreciation,0.53,0.34,0.06,0.0,0.03,0.0,0.0,0.03,jason adkins,,THEA-2100,2015
+THEA,2770,1,Prod Studies in Thea,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david hartmann,,THEA-2770,2015
+THEA,2790,1,Theatre Practicum,0.62,0.08,0.15,0.0,0.08,0.0,0.0,0.08,matthew leckenbusch,,THEA-2790,2015
+THEA,3160,1,Theatre History II,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,richard st. peter,,THEA-3160,2015
+THEA,3180,1,Afri-Amer Thea II,0.68,0.19,0.1,0.0,0.0,0.0,0.0,0.03,kendra lyne johnson,,THEA-3180,2015
+THEA,3470,1,Structure of Drama,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-3470,2015
+THEA,3740,1,Movement for Actors,0.69,0.15,0.08,0.0,0.08,0.0,0.0,0.0,kerrie kath seymour,,THEA-3740,2015
+WFB,3010,1,Wildlife Biology Lab,0.29,0.5,0.14,0.0,0.0,0.0,0.0,0.07,shari lyn rodriguez,,WFB-3010,2015
+WFB,3130,1,Conservation Biology,0.45,0.25,0.16,0.06,0.06,0.0,0.0,0.02,shari lyn rodriguez,,WFB-3130,2015
+WFB,3130,2,Conservation Biology,0.17,0.37,0.26,0.11,0.06,0.0,0.0,0.03,shari lyn rodriguez,,WFB-3130,2015
+WFB,3500,1,Prin Fish Wildl Biol,0.21,0.51,0.21,0.05,0.02,0.0,0.0,0.0,james davis,,WFB-3500,2015
+WFB,3500,2,Prin Fish Wildl Biol,0.28,0.26,0.38,0.03,0.05,0.0,0.0,0.0,james davis,,WFB-3500,2015
+WFB,4160,1,Fishery Biology,0.36,0.36,0.17,0.09,0.0,0.0,0.0,0.02,yoichiro kanno,,WFB-4160,2015
+WFB,4300,1,Wildl Conserv Policy,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.04,joseph lanham,,WFB-4300,2015
+WFB,4400,1,Non-Game Wildl Mgmt,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-4400,2015
+WFB,4620,1,Wetland Wildl Biol,0.45,0.38,0.12,0.05,0.0,0.0,0.0,0.0,russell barrett,,WFB-4620,2015
+WS,1030,1,Women Global Perspec,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,,WS-1030,2015
+WS,2300,1,Women and Leadership,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,saadiqa kumanyika,,WS-2300,2015
+WS,3010,1,Intro Women's Studies,0.76,0.14,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2015
+WS,3010,2,Intro Women's Studies,0.43,0.48,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2015
+YDP,3100,400,Youth Developmt and the Family,0.79,0.07,0.07,0.0,0.07,0.0,0.0,0.0,william quinn,,YDP-3100,2015

--- a/bot/cogs/grades_cog/assets/2015_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2015_Spring.csv
@@ -1,2316 +1,2316 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1020,1,Survey of Art & Arch Hist II,0.4,0.49,0.09,0.0,0.0,0.0,0.0,0.01,beth ann lauritis,AAH-1020,2015
-AAH,2060,1,Art History and Theory II,0.48,0.29,0.24,0.0,0.0,0.0,0.0,0.0,andrea feeser,AAH-2060,2015
-AAH,2100,1,Intro to Art and Architecture,0.39,0.32,0.14,0.04,0.07,0.0,0.0,0.04,lydia jane dorsey,AAH-2100,2015
-AAH,2100,2,Intro to Art and Architecture,0.29,0.36,0.29,0.0,0.04,0.0,0.0,0.04,lydia jane dorsey,AAH-2100,2015
-AAH,2100,3,Intro to Art and Architecture,0.21,0.54,0.11,0.07,0.0,0.0,0.0,0.07,lydia jane dorsey,AAH-2100,2015
-AAH,2100,4,Intro to Art and Architecture,0.22,0.22,0.26,0.11,0.0,0.0,0.0,0.19,lydia jane dorsey,AAH-2100,2015
-ACCT,2010,1,Financial Accounting Concepts,0.19,0.3,0.21,0.12,0.09,0.0,0.0,0.09,suzanne pearse,ACCT-2010,2015
-ACCT,2010,2,Financial Accounting Concepts,0.32,0.17,0.13,0.09,0.09,0.0,0.0,0.21,lydia lan schleifer,ACCT-2010,2015
-ACCT,2010,3,Financial Accounting Concepts,0.18,0.32,0.25,0.02,0.09,0.0,0.0,0.14,suzanne pearse,ACCT-2010,2015
-ACCT,2010,4,Financial Accounting Concepts,0.12,0.2,0.3,0.16,0.1,0.0,0.0,0.12,philip maiberger,ACCT-2010,2015
-ACCT,2010,5,Financial Accounting Concepts,0.12,0.37,0.24,0.04,0.06,0.0,0.0,0.16,philip maiberger,ACCT-2010,2015
-ACCT,2010,6,Financial Accounting Concepts,0.29,0.38,0.1,0.05,0.05,0.0,0.0,0.14,suzanne pearse,ACCT-2010,2015
-ACCT,2010,7,Financial Accounting Concepts,0.3,0.13,0.22,0.15,0.04,0.0,0.0,0.15,lydia lan schleifer,ACCT-2010,2015
-ACCT,2010,8,Financial Accounting Concepts,0.31,0.2,0.2,0.11,0.11,0.0,0.0,0.07,lydia lan schleifer,ACCT-2010,2015
-ACCT,2010,9,Financial Accounting Concepts,0.09,0.23,0.36,0.16,0.0,0.0,0.0,0.16,the estate  guffey,ACCT-2010,2015
-ACCT,2010,10,Financial Accounting Concepts,0.17,0.27,0.23,0.03,0.1,0.0,0.0,0.2,the estate  guffey,ACCT-2010,2015
-ACCT,2010,11,Financial Accounting Concepts,0.13,0.3,0.16,0.13,0.14,0.0,0.0,0.14,jeffrey mcmillan,ACCT-2010,2015
-ACCT,2010,12,Financial Accounting Concepts,0.16,0.14,0.2,0.26,0.08,0.0,0.0,0.16,philip maiberger,ACCT-2010,2015
-ACCT,2010,13,Fin Acct Concepts (HON),0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,the estate  guffey,ACCT-2010,2015
-ACCT,2020,1,Managerial Accounting Concepts,0.22,0.33,0.2,0.12,0.02,0.0,0.0,0.1,annieka philo,ACCT-2020,2015
-ACCT,2020,2,Managerial Accounting Concepts,0.33,0.3,0.24,0.06,0.06,0.0,0.0,0.02,annieka philo,ACCT-2020,2015
-ACCT,2020,3,Managerial Accounting Concepts,0.35,0.24,0.28,0.04,0.04,0.0,0.0,0.06,annieka philo,ACCT-2020,2015
-ACCT,2020,4,Managerial Accounting Concepts,0.33,0.35,0.15,0.09,0.04,0.0,0.0,0.04,annieka philo,ACCT-2020,2015
-ACCT,2020,5,Managerial Accounting Concepts,0.14,0.18,0.39,0.05,0.0,0.0,0.0,0.25,henry anderson,ACCT-2020,2015
-ACCT,2020,6,Managerial Accounting Concepts,0.26,0.3,0.2,0.07,0.02,0.0,0.0,0.15,henry anderson,ACCT-2020,2015
-ACCT,2020,8,Managerial Accounting Concepts,0.14,0.11,0.2,0.17,0.09,0.0,0.0,0.29,henry anderson,ACCT-2020,2015
-ACCT,3030,1,Cost Accounting,0.28,0.35,0.23,0.05,0.02,0.0,0.0,0.06,frances kennedy,ACCT-3030,2015
-ACCT,3030,3,Cost Accounting,0.35,0.43,0.14,0.05,0.0,0.0,0.0,0.03,holly rhiannio hawk,ACCT-3030,2015
-ACCT,3030,4,Cost Accounting,0.24,0.5,0.13,0.0,0.03,0.0,0.0,0.11,holly rhiannio hawk,ACCT-3030,2015
-ACCT,3110,1,Intermed Financial Acct I,0.2,0.5,0.2,0.03,0.0,0.0,0.0,0.08,terry daniel knause,ACCT-3110,2015
-ACCT,3110,2,Intermed Financial Acct I,0.41,0.44,0.15,0.0,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3110,2015
-ACCT,3110,3,Intermed Financial Acct I,0.22,0.45,0.29,0.02,0.0,0.0,0.0,0.02,terry daniel knause,ACCT-3110,2015
-ACCT,3110,4,Intermed Financial Acct I,0.31,0.57,0.09,0.02,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3110,2015
-ACCT,3120,1,Intermed Financial Acct II,0.33,0.45,0.18,0.03,0.0,0.0,0.0,0.03, russell madray,ACCT-3120,2015
-ACCT,3120,2,Intermed Financial Acct II,0.32,0.38,0.15,0.04,0.04,0.0,0.0,0.06, russell madray,ACCT-3120,2015
-ACCT,3120,3,Intermed Financial Acct II,0.05,0.28,0.21,0.26,0.18,0.0,0.0,0.03,brian todd carver,ACCT-3120,2015
-ACCT,3120,4,Intermed Financial Acct II,0.03,0.18,0.38,0.24,0.18,0.0,0.0,0.0,brian todd carver,ACCT-3120,2015
-ACCT,3130,1,Intermed Financial Acct III,0.28,0.38,0.31,0.03,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2015
-ACCT,3130,2,Intermed Financial Acct III,0.27,0.41,0.24,0.03,0.05,0.0,0.0,0.0, russell madray,ACCT-3130,2015
-ACCT,3130,3,Intermed Financial Acct III,0.11,0.48,0.26,0.11,0.04,0.0,0.0,0.0,james irving,ACCT-3130,2015
-ACCT,3130,4,Intermed Financial Acct III,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,james irving,ACCT-3130,2015
-ACCT,3220,1,Accounting Information Systems,0.28,0.28,0.4,0.03,0.0,0.0,0.0,0.03,nancy lee harp,ACCT-3220,2015
-ACCT,3220,2,Accounting Information Systems,0.26,0.18,0.38,0.08,0.08,0.0,0.0,0.03,nancy lee harp,ACCT-3220,2015
-ACCT,3220,3,Accounting Information Systems,0.19,0.49,0.19,0.11,0.0,0.0,0.0,0.03,nancy lee harp,ACCT-3220,2015
-ACCT,4040,1,Individual Taxation,0.76,0.18,0.03,0.0,0.03,0.0,0.0,0.0,sarah martin,ACCT-4040,2015
-ACCT,4040,2,Individual Taxation,0.88,0.05,0.07,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2015
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.36,0.46,0.13,0.0,0.0,0.0,0.0,0.05,james mil kohlmeyer,ACCT-4100,2015
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.19,0.73,0.08,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,ACCT-4100,2015
-ACCT,4150,1,Auditing,0.16,0.46,0.27,0.08,0.0,0.0,0.0,0.03,suzanne pearse,ACCT-4150,2015
-ACCT,4150,2,Auditing,0.29,0.48,0.19,0.03,0.0,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2015
-ACCT,8520,1,Fin Acct Theory/Res,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8520,2015
-ACCT,8520,2,Fin Acct Theory/Res,0.32,0.58,0.1,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8520,2015
-ACCT,8540,1,Prof Responsibility,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,ACCT-8540,2015
-ACCT,8710,1,Corporate Taxation,0.46,0.51,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2015
-ACCT,8710,2,Corporate Taxation,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2015
-AGED,1000,1,Orientation & Field Experience,0.85,0.07,0.04,0.0,0.0,0.0,0.0,0.04,philip fravel,AGED-1000,2015
-AGED,2030,1,Teaching Agriscience,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-2030,2015
-AGED,4160,1,Ethics and Issues,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,AGED-4160,2015
-AGM,2050,1,Prin of Fabrication,0.13,0.45,0.3,0.05,0.0,0.0,0.0,0.07,hunter massey,AGM-2050,2015
-AGM,2060,1,Machinery Mgt,0.15,0.36,0.3,0.09,0.03,0.0,0.0,0.06,hunter massey,AGM-2060,2015
-AGM,2210,1,Land Measurements,0.31,0.42,0.19,0.08,0.0,0.0,0.0,0.0,charles privette,AGM-2210,2015
-AGM,3030,1,Cal for Mech Ag,0.48,0.4,0.1,0.0,0.0,0.0,0.0,0.02,young han,AGM-3030,2015
-AGM,4020,1,Land Drain and Irrig,0.1,0.55,0.3,0.05,0.0,0.0,0.0,0.0,charles privette,AGM-4020,2015
-AGM,4100,1,Precision Ag Tech,0.24,0.44,0.22,0.1,0.0,0.0,0.0,0.0,hunter massey,AGM-4100,2015
-AGM,4520,1,Mobile Power,0.24,0.44,0.24,0.05,0.0,0.0,0.0,0.02,hunter massey,AGM-4520,2015
-AGM,4720,1,Capstone,0.07,0.36,0.57,0.0,0.0,0.0,0.0,0.0,john chastain,AGM-4720,2015
-AL,3490,400,Principles of Coaching,0.41,0.22,0.33,0.0,0.0,0.0,0.0,0.04,deborah cadorette,AL-3490,2015
-AL,3490,401,Principles of Coaching,0.31,0.52,0.1,0.03,0.03,0.0,0.0,0.0,deborah cadorette,AL-3490,2015
-AL,3490,402,Principles of Coaching,0.52,0.28,0.04,0.08,0.04,0.0,0.0,0.04,julia wright,AL-3490,2015
-AL,3490,403,Principles of Coaching,0.67,0.26,0.04,0.0,0.04,0.0,0.0,0.0,clyde keith connor,AL-3490,2015
-AL,3490,404,Principles of Coaching,0.5,0.31,0.12,0.04,0.04,0.0,0.0,0.0,clyde keith connor,AL-3490,2015
-AL,3490,405,Principles of Coaching,0.74,0.11,0.0,0.07,0.04,0.0,0.0,0.04,edmond fry,AL-3490,2015
-AL,3500,400,Sci Basis I/Ex Phy,0.22,0.19,0.26,0.22,0.07,0.0,0.0,0.04,michael godfrey,AL-3500,2015
-AL,3500,401,Sci Basis I/Ex Phy,0.36,0.16,0.32,0.08,0.04,0.0,0.0,0.04,michael godfrey,AL-3500,2015
-AL,3520,400,Kinesiology,0.42,0.05,0.16,0.16,0.11,0.0,0.0,0.11,michael godfrey,AL-3520,2015
-AL,3530,400,Athletic Injuries,0.42,0.15,0.27,0.15,0.0,0.0,0.0,0.0,isaac sean colbert,AL-3530,2015
-AL,3530,401,Athletic Injuries,0.22,0.22,0.22,0.17,0.13,0.0,0.0,0.04,isaac sean colbert,AL-3530,2015
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.38,0.19,0.05,0.05,0.0,0.0,0.0,clyde keith connor,AL-3600,2015
-AL,3610,400,Admin/Org of Athletic Programs,0.81,0.12,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2015
-AL,3610,401,Admin/Org of Athletic Programs,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2015
-AL,3610,402,Admin/Org of Athletic Programs,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,henry oates,AL-3610,2015
-AL,3620,400,Psychology of Coaching,0.44,0.24,0.12,0.16,0.04,0.0,0.0,0.0,natalie anne carter,AL-3620,2015
-AL,3620,401,Psychology of Coaching,0.18,0.3,0.27,0.15,0.06,0.0,0.0,0.03,natalie anne carter,AL-3620,2015
-AL,3710,400,Coaching Baseball,0.65,0.1,0.1,0.1,0.05,0.0,0.0,0.0,justin hickey,AL-3710,2015
-AL,3720,400,Coaching Basketball,0.5,0.08,0.17,0.04,0.13,0.0,0.0,0.08,edmond fry,AL-3720,2015
-AL,3740,400,Coaching Football,0.54,0.21,0.08,0.0,0.17,0.0,0.0,0.0,edmond fry,AL-3740,2015
-AL,3760,400,Coaching Strength/Conditioning,0.58,0.17,0.04,0.08,0.04,0.0,0.0,0.08,edmond fry,AL-3760,2015
-AL,4380,400,Creative Inquire C&A,0.47,0.27,0.13,0.07,0.07,0.0,0.0,0.0,deborah cadorette,AL-4380,2015
-AL,4380,410,Coaching Rugby,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,deborah cadorette,AL-4380,2015
-AL,8640,400,Ethical Iss in Collegiate Athl,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,james satterfield,AL-8640,2015
-ANTH,2010,1,Introduction to Anthropology,0.05,0.25,0.37,0.15,0.08,0.0,0.0,0.1,john coggeshall,ANTH-2010,2015
-ANTH,2010,2,Introduction to Anthropology,0.37,0.44,0.14,0.03,0.01,0.0,0.0,0.01,katherine weisensee,ANTH-2010,2015
-ANTH,2010,3,Introduction to Anthropology,0.55,0.21,0.07,0.04,0.02,0.0,0.0,0.11,lisa rapaport,ANTH-2010,2015
-ANTH,3200,1,North American Indian Cultures,0.3,0.4,0.2,0.0,0.0,0.0,0.0,0.1,john coggeshall,ANTH-3200,2015
-ANTH,3310,1,Archaeology,0.24,0.35,0.35,0.06,0.0,0.0,0.0,0.0,melissa vogel,ANTH-3310,2015
-ANTH,3510,1,Biological Anthropology,0.35,0.4,0.2,0.05,0.0,0.0,0.0,0.0,katherine weisensee,ANTH-3510,2015
-ANTH,4230,1,Women in the Developing World,0.61,0.33,0.0,0.06,0.0,0.0,0.0,0.0,melissa vogel,ANTH-4230,2015
-APEC,2020,1,Agric Economics,0.87,0.11,0.02,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,APEC-2020,2015
-APEC,2050,1,Agric and Society,0.39,0.38,0.18,0.04,0.0,0.0,0.0,0.02,michael vassalos,APEC-2050,2015
-APEC,3190,1,Agribusiness Mgt,0.34,0.3,0.26,0.04,0.02,0.0,0.0,0.04,michael vassalos,APEC-3190,2015
-APEC,3570,1,Nat Resource Econ,0.29,0.19,0.27,0.19,0.02,0.0,0.0,0.04,david brian willis,APEC-3570,2015
-APEC,4560,1,Prices,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,APEC-4560,2015
-ARAB,1010,1,Elementary Arabic I,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sulafa abou-samra,ARAB-1010,2015
-ARAB,1020,1,Elementary Arabic II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sulafa abou-samra,ARAB-1020,2015
-ARCH,1510,1,Arch Communication,0.53,0.41,0.0,0.0,0.06,0.0,0.0,0.0,sal hambright-belue,ARCH-1510,2015
-ARCH,1510,2,Arch Communication,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,robert silance,ARCH-1510,2015
-ARCH,1510,3,Arch Communication,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,junichi satoh,ARCH-1510,2015
-ARCH,1510,4,Arch Communication,0.58,0.21,0.05,0.05,0.0,0.0,0.0,0.11,clarissa mendez,ARCH-1510,2015
-ARCH,2520,1,Arch Foundations II,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,david lee,ARCH-2520,2015
-ARCH,2520,2,Arch Foundations II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-2520,2015
-ARCH,2520,4,Arch Foundations II,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2520,2015
-ARCH,2700,1,Structures I,0.43,0.36,0.14,0.07,0.0,0.0,0.0,0.0,robert john hogan,ARCH-2700,2015
-ARCH,2700,2,Structures I,0.47,0.47,0.0,0.0,0.06,0.0,0.0,0.0,robert john hogan,ARCH-2700,2015
-ARCH,2710,1,Structures II,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,michael carl kleiss,ARCH-2710,2015
-ARCH,3530,1,Studio Genoa,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,ARCH-3530,2015
-ARCH,4010,1,Arch Portfolio,0.5,0.14,0.18,0.0,0.05,0.0,0.0,0.14,arash soleimani,ARCH-4010,2015
-ARCH,4520,1,Synthesis Studio,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-4520,2015
-ARCH,4520,2,Synthesis Studio,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-4520,2015
-ARCH,4520,3,Synthesis Studio,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,criss mills,ARCH-4520,2015
-ARCH,6880,1,Arch Programming,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-6880,2015
-ARCH,6990,2,Glass as a Modern Material,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-6990,2015
-ARCH,8110,1,Visualization II,0.38,0.5,0.0,0.0,0.06,0.0,0.0,0.06,douglas hecker,ARCH-8110,2015
-ARCH,8200,1,Bldg Design & Constr,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,dennis bausman,ARCH-8200,2015
-ARCH,8420,1,Arch Studio II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,ARCH-8420,2015
-ARCH,8420,2,Arch Studio II,0.22,0.44,0.11,0.0,0.11,0.0,0.0,0.11,junichi satoh,ARCH-8420,2015
-ARCH,8610,1,History/Theory II,0.4,0.47,0.0,0.0,0.07,0.0,0.0,0.07,robert bruhns,ARCH-8610,2015
-ARCH,8710,1,Structures II,0.45,0.41,0.09,0.0,0.0,0.0,0.0,0.05,dustin gra albright,ARCH-8710,2015
-ARCH,8730,1,Environmental Sys,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,vincent yves blouin,ARCH-8730,2015
-ARCH,8740,1,Building Process:TR,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john jacques,ARCH-8740,2015
-ARCH,8740,2,Building Process:TR,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,john jacques,ARCH-8740,2015
-ARCH,8820,1,Building Economics,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-8820,2015
-ARCH,8900,1,Directed Studies,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,anjali joseph,ARCH-8900,2015
-ARCH,8920,2,Comprehensive Studio,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-8920,2015
-ARCH,8920,3,Comprehensive Studio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,ARCH-8920,2015
-ARCH,8920,4,Comprehensive Studio,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-8920,2015
-ARCH,8920,5,Comprehensive Studio,0.0,0.7,0.3,0.0,0.0,0.0,0.0,0.0,keith green,ARCH-8920,2015
-ARCH,8960,1,A+H Studio: Tectonic,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-8960,2015
-ART,1060,1,Foundation Drawing II,0.52,0.24,0.14,0.0,0.05,0.0,0.0,0.05,kathleen ann thum,ART-1060,2015
-ART,1520,1,Foundations Art II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,ART-1520,2015
-ART,2050,1,Beginning Life Drawing,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,alexandra giannell,ART-2050,2015
-ART,2070,1,Beginning Painting,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,hilary erin siber,ART-2070,2015
-ART,2090,1,Beginning Sculpture,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,tanna burchinal,ART-2090,2015
-ART,2130,1,Begin Photography,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,ART-2130,2015
-ART,2170,1,Beginning Ceramics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lindsey ann elsey,ART-2170,2015
-AS,1100,2,Air Force Today II,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,steven price jordan,AS-1100,2015
-AS,2100,3,Dev of Air Power II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,christopher mann,AS-2100,2015
-ASL,1010,2,Am Sign Lang I,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,william alton brant,ASL-1010,2015
-ASL,1020,2,Am Sign Lang I,0.71,0.07,0.21,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-1020,2015
-ASL,2020,1,Am Sign Lang II,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-2020,2015
-ASTR,1010,1,Solar System Astr,0.47,0.22,0.15,0.07,0.03,0.0,0.0,0.05,sean brittain,ASTR-1010,2015
-ASTR,1020,1,Stellar Astronomy,0.22,0.49,0.18,0.02,0.02,0.0,0.0,0.06,phillip flower,ASTR-1020,2015
-ASTR,1020,2,Stellar Astronomy,0.17,0.52,0.2,0.01,0.01,0.0,0.0,0.09,phillip flower,ASTR-1020,2015
-ASTR,1020,3,Stellar Astronomy,0.18,0.38,0.34,0.04,0.04,0.0,0.0,0.01,phillip flower,ASTR-1020,2015
-ASTR,1030,1,Solar Systm Astr Lab,0.58,0.19,0.04,0.0,0.08,0.0,0.0,0.12,mark leising,ASTR-1030,2015
-ASTR,1030,2,Solar Systm Astr Lab,0.5,0.15,0.05,0.05,0.15,0.0,0.0,0.1,mark leising,ASTR-1030,2015
-ASTR,1040,1,Stellar Astr Lab,0.44,0.32,0.2,0.0,0.04,0.0,0.0,0.0,mark leising,ASTR-1040,2015
-ASTR,1040,2,Stellar Astr Lab,0.35,0.45,0.15,0.0,0.05,0.0,0.0,0.0,mark leising,ASTR-1040,2015
-ASTR,1040,3,Stellar Astr Lab,0.64,0.28,0.0,0.0,0.0,0.0,0.0,0.08,mark leising,ASTR-1040,2015
-ASTR,1040,5,Stellar Astr Lab,0.33,0.33,0.17,0.0,0.11,0.0,0.0,0.06,mark leising,ASTR-1040,2015
-ASTR,1040,6,Stellar Astr Lab,0.14,0.52,0.24,0.0,0.1,0.0,0.0,0.0,mark leising,ASTR-1040,2015
-AUD,2850,1,Acoustics of Music,0.2,0.47,0.27,0.0,0.0,0.0,0.0,0.07,hamilton altstatt,AUD-2850,2015
-AUE,8160,1,Eng Combustion Emiss,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8160,2015
-AUE,8170,3,Alt Energy Sources,0.37,0.59,0.05,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8170,2015
-AUE,8500,6,Stability/Safety Sys,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8500,2015
-AUE,8550,16,Auto Struct Analysis,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,AUE-8550,2015
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8690,2015
-AUE,8770,9,Light-Weight Design,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,AUE-8770,2015
-AUE,8820,10,Systems Integration Method,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,AUE-8820,2015
-AUE,8860,11,Noise Vibration,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,imtiaz ul haque,AUE-8860,2015
-AUE,8930,15,Innov & Entrepreneurship,0.56,0.42,0.0,0.0,0.0,0.0,0.0,0.02,david leo bodde,AUE-8930,2015
-AUE,8930,16,Fundamentals of Injection Mold,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,AUE-8930,2015
-AVS,2010,1,Poultry Techniques,0.93,0.04,0.0,0.04,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-2010,2015
-AVS,2050,1,Horsemanship Techniques,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,AVS-2050,2015
-AVS,2060,1,Swine Techniques,0.83,0.11,0.02,0.0,0.02,0.0,0.0,0.02,richelle lor miller,AVS-2060,2015
-AVS,2090,1,Livestock Exhibition Technique,0.93,0.06,0.0,0.0,0.0,0.0,0.0,0.01,richelle lor miller,AVS-2090,2015
-AVS,2110,1,Meat Processing Techniques,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brian bolt,AVS-2110,2015
-AVS,2120,1,Small Ruminant Techniques,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,heather walker dunn,AVS-2120,2015
-AVS,3010,1,Anat & Phys Dom Ani,0.4,0.29,0.22,0.04,0.04,0.0,0.0,0.02,tiffany wilmoth,AVS-3010,2015
-AVS,3100,1,Animal Health,0.71,0.16,0.06,0.02,0.03,0.0,0.0,0.02,thomas scott,AVS-3100,2015
-AVS,3150,1,Animal Welfare,0.27,0.36,0.27,0.05,0.05,0.0,0.0,0.0,peter skewes,AVS-3150,2015
-AVS,3700,1,Prin Animal Nutr,0.1,0.18,0.4,0.11,0.18,0.0,0.0,0.03,nathan long,AVS-3700,2015
-AVS,3750,1,Appl Animal Nutr,0.4,0.34,0.18,0.06,0.0,0.0,0.0,0.02,gustavo jos lascano,AVS-3750,2015
-AVS,4000,1,AVS Professional Development,0.62,0.24,0.0,0.12,0.0,0.0,0.0,0.03,johanna joh lascano,AVS-4000,2015
-AVS,4060,1,Seminars & Relat Top,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2015
-AVS,4090,2,Selected Topics/CAFLS Plus,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,thomas scott,AVS-4090,2015
-AVS,4090,7,Sel Topics- Scientific Writing,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4090,2015
-AVS,4100,1,Domestic Ani Behav,0.37,0.39,0.18,0.03,0.02,0.0,0.0,0.01,peter skewes,AVS-4100,2015
-AVS,4110,400,Ani Growth & Develop,0.62,0.15,0.15,0.0,0.08,0.0,0.0,0.0,susan kay duckett,AVS-4110,2015
-AVS,4120,1,Adv Equine Mgmt,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-4120,2015
-AVS,4130,1,Animal Products,0.78,0.21,0.01,0.0,0.0,0.0,0.0,0.0,brian bolt,AVS-4130,2015
-AVS,4170,1,Animal Agribusiness Develpmnt,0.23,0.68,0.09,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-4170,2015
-AVS,4220,2,Special Problems/CAFLS Plus,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,thomas scott,AVS-4220,2015
-AVS,4530,1,Animal Reproduction,0.5,0.31,0.17,0.0,0.0,0.0,0.0,0.02,glenn birrenkott,AVS-4530,2015
-AVS,4530,400,Animal Reproduction,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-4530,2015
-AVS,6110,1,Ani Growth & Develop,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,AVS-6110,2015
-BCHM,3010,1,Molecular Biochem,0.25,0.21,0.25,0.13,0.06,0.0,0.0,0.1,meredith tei morris,BCHM-3010,2015
-BCHM,3010,2,Molecular Biochem(HON),0.68,0.15,0.15,0.0,0.0,0.0,0.0,0.03,meredith tei morris,BCHM-3010,2015
-BCHM,3020,1,Molecular Biochemistry Lab,0.77,0.08,0.08,0.0,0.0,0.0,0.0,0.08,meredith tei morris,BCHM-3020,2015
-BCHM,3020,2,Molecular Biochemistry Lab,0.56,0.25,0.06,0.13,0.0,0.0,0.0,0.0,meredith tei morris,BCHM-3020,2015
-BCHM,3020,3,Molecular Biochemistry Lab,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,meredith tei morris,BCHM-3020,2015
-BCHM,3050,1,Essen Elements Bioch,0.32,0.36,0.18,0.05,0.05,0.0,0.0,0.04,srik chandrasekaran,BCHM-3050,2015
-BCHM,3050,2,Essen Elements Bioch,0.4,0.37,0.13,0.07,0.01,0.0,0.0,0.03,liangjiang wang,BCHM-3050,2015
-BCHM,4060,1,Physiological Chem,0.41,0.25,0.25,0.02,0.04,0.0,0.0,0.02,ashby burges bodine,BCHM-4060,2015
-BCHM,4320,1,Bioch of Metabolism,0.61,0.35,0.0,0.03,0.0,0.0,0.0,0.0,kimberly paul,BCHM-4320,2015
-BCHM,4340,1,General Biochemistry Lab II,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,kimberly paul,BCHM-4340,2015
-BCHM,4340,2,General Biochemistry Lab II,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,kimberly paul,BCHM-4340,2015
-BCHM,4360,1,Genes to Proteins,0.23,0.41,0.27,0.0,0.05,0.0,0.0,0.05,michael glen sehorn,BCHM-4360,2015
-BCHM,4360,2,Genes to Proteins(HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,BCHM-4360,2015
-BCHM,4900,1,Strategic Markting Relay 4 Lif,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,michael glen sehorn,BCHM-4900,2015
-BE,2100,1,Intro to Biosystems Engr,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,yi zheng,BE-2100,2015
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.29,0.33,0.29,0.04,0.04,0.0,0.0,0.0,tom owino,BE-3220,2015
-BE,4120,1,Be Heat Mass Trans,0.48,0.29,0.1,0.1,0.05,0.0,0.0,0.0,caye marie drapcho,BE-4120,2015
-BE,4240,1,Ecological Engr,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,BE-4240,2015
-BE,4380,1,Bioprocess Engineering Design,0.52,0.29,0.0,0.14,0.05,0.0,0.0,0.0,terry walker,BE-4380,2015
-BIOE,2010,1,Intro Biomed Engr,0.47,0.31,0.16,0.0,0.0,0.0,0.0,0.06,charles webb,BIOE-2010,2015
-BIOE,3020,1,Biomaterials,0.53,0.33,0.08,0.01,0.01,0.0,0.0,0.03,vladimir vla reukov,BIOE-3020,2015
-BIOE,3200,1,Biomechanics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,BIOE-3200,2015
-BIOE,3210,1,Biofluid Mechanics,0.34,0.43,0.12,0.05,0.0,0.0,0.0,0.06,sarah harcum,BIOE-3210,2015
-BIOE,3700,1,Bioinst & Imaging,0.29,0.53,0.11,0.0,0.02,0.0,0.0,0.05,david kwartowitz,BIOE-3700,2015
-BIOE,4030,1,Applied Bio E Design,0.97,0.01,0.0,0.01,0.0,0.0,0.0,0.0,john desjardins,BIOE-4030,2015
-BIOE,4200,1,Sports Engineering,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,BIOE-4200,2015
-BIOE,4510,33,CI-Og Design,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,john desjardins,BIOE-4510,2015
-BIOE,6350,1,Modeling of Multiphysics Prob,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,guigen zhang,BIOE-6350,2015
-BIOE,8020,410,Biocompatibility,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,BIOE-8020,2015
-BIOE,8150,410,Design Manuf Medical Devices,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,BIOE-8150,2015
-BIOE,8500,401,"Cells, Stem Cells & Dev't",0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ann catherine foley,BIOE-8500,2015
-BIOL,1040,1,General Biology II,0.24,0.31,0.25,0.12,0.05,0.0,0.0,0.05,nora espinoza,BIOL-1040,2015
-BIOL,1040,2,General Biology II,0.15,0.32,0.28,0.12,0.09,0.0,0.0,0.04,kalan ickes,BIOL-1040,2015
-BIOL,1040,3,General Biology II,0.46,0.33,0.14,0.05,0.01,0.0,0.0,0.0,william surver,BIOL-1040,2015
-BIOL,1040,4,General Biology II (HON),0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,BIOL-1040,2015
-BIOL,1060,1,Gen Biology Lab II,0.25,0.25,0.15,0.25,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,2,Gen Biology Lab II,0.11,0.26,0.21,0.32,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,3,Gen Biology Lab II,0.15,0.5,0.15,0.1,0.1,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,4,Gen Biology Lab II,0.2,0.2,0.25,0.25,0.0,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,5,Gen Biology Lab II,0.2,0.2,0.35,0.15,0.1,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,6,Gen Biology Lab II,0.2,0.25,0.15,0.2,0.2,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,7,Gen Biology Lab II,0.25,0.3,0.15,0.25,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,10,Gen Biology Lab II,0.0,0.3,0.3,0.25,0.05,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,11,Gen Biology Lab II,0.1,0.2,0.3,0.2,0.1,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,12,Gen Biology Lab II,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,13,Gen Biology Lab II,0.35,0.3,0.2,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,14,Gen Biology Lab II,0.1,0.25,0.35,0.2,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,15,Gen Biology Lab II,0.4,0.2,0.35,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,16,Gen Biology Lab II,0.25,0.35,0.15,0.15,0.1,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,17,Gen Biology Lab II,0.1,0.65,0.2,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,18,Gen Biology Lab II,0.3,0.3,0.2,0.1,0.1,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,19,Gen Biology Lab II,0.3,0.25,0.3,0.0,0.0,0.0,0.0,0.15,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,21,Gen Biology Lab II,0.15,0.55,0.2,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,22,Gen Biology Lab II,0.35,0.35,0.25,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,25,Gen Biology Lab II,0.3,0.45,0.15,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,26,Gen Biology Lab II,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,27,Gen Biology Lab II,0.3,0.25,0.25,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,28,Gen Biology Lab II,0.35,0.25,0.25,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,29,Gen Biology Lab II,0.35,0.15,0.3,0.15,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,30,Gen Biology Lab II,0.2,0.2,0.3,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,31,Gen Biology Lab II,0.3,0.45,0.15,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,34,Gen Biology Lab II,0.26,0.53,0.16,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,36,Gen Biology Lab II,0.25,0.35,0.15,0.05,0.2,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,37,Gen Biology Lab II,0.32,0.32,0.21,0.05,0.11,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,38,Gen Biology Lab II,0.21,0.37,0.21,0.0,0.05,0.0,0.0,0.16,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,39,Gen Biology Lab II,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,40,Gen Biology Lab II,0.3,0.25,0.2,0.05,0.1,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,41,Gen Biology Lab II,0.37,0.05,0.21,0.05,0.32,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1060,42,Gen Biology Lab II,0.3,0.25,0.15,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2015
-BIOL,1090,1,Intro to Life Sci,0.67,0.19,0.14,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,BIOL-1090,2015
-BIOL,1110,1,Prin of Biol II,0.26,0.51,0.12,0.08,0.01,0.0,0.0,0.02,robert kosinski,BIOL-1110,2015
-BIOL,1110,2,Prin of Biol II,0.43,0.35,0.18,0.0,0.03,0.0,0.0,0.01,dylan dittrich-reed,BIOL-1110,2015
-BIOL,1110,4,Prin of Biol II  (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,BIOL-1110,2015
-BIOL,1200,4,Biological Inq Lab,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,5,Biological Inq Lab,0.67,0.17,0.0,0.11,0.06,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,6,Biological Inq Lab,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1200,9,Biological Inq Lab,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,BIOL-1200,2015
-BIOL,1200,12,Biological Inq Lab,0.5,0.33,0.06,0.0,0.11,0.0,0.0,0.0, christine minor,BIOL-1200,2015
-BIOL,1220,1,Keys to Biodiversity,0.36,0.2,0.16,0.12,0.12,0.0,0.0,0.04,kalan ickes,BIOL-1220,2015
-BIOL,1230,1,Keys to Human Biol,0.26,0.33,0.28,0.09,0.04,0.0,0.0,0.01, christine minor,BIOL-1230,2015
-BIOL,2000,2,Biology in the News,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-2000,2015
-BIOL,2000,4,Biology in the News,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,david tonkyn,BIOL-2000,2015
-BIOL,2000,5,Biology in the News,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,BIOL-2000,2015
-BIOL,2000,8,Biology in the News,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,min cao,BIOL-2000,2015
-BIOL,2000,9,Biology in the News,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,michael sears,BIOL-2000,2015
-BIOL,2030,1,Human Disease & Soc,0.79,0.14,0.02,0.0,0.0,0.0,0.0,0.05, christine minor,BIOL-2030,2015
-BIOL,2040,1,"Environ, Energy and Society",0.47,0.26,0.13,0.11,0.01,0.0,0.0,0.02,john jenkins hains,BIOL-2040,2015
-BIOL,2110,1,Introduction to Toxicology,0.26,0.56,0.12,0.0,0.03,0.0,0.0,0.03,peter van den hurk,BIOL-2110,2015
-BIOL,2230,1,Human Anat and Physiology II,0.37,0.3,0.18,0.1,0.04,0.0,0.0,0.02,john cummings,BIOL-2230,2015
-BIOL,2230,2,Human Anat and Physiology II,0.51,0.31,0.15,0.01,0.0,0.0,0.0,0.02,john cummings,BIOL-2230,2015
-BIOL,3020,1,Invertebrate Biology,0.16,0.42,0.24,0.05,0.05,0.0,0.0,0.08,juan baeza migueles,BIOL-3020,2015
-BIOL,3040,1,Biology of Plants,0.6,0.29,0.1,0.0,0.02,0.0,0.0,0.0,christina wells,BIOL-3040,2015
-BIOL,3060,2,Invertebrate Biology Lab,0.05,0.5,0.3,0.1,0.05,0.0,0.0,0.0,juan baeza migueles,BIOL-3060,2015
-BIOL,3060,4,Invertebrate Biology Lab,0.18,0.35,0.29,0.06,0.0,0.0,0.0,0.12,juan baeza migueles,BIOL-3060,2015
-BIOL,3080,2,Biology of Plants Practicum,0.63,0.21,0.11,0.0,0.05,0.0,0.0,0.0,robert edwa ballard,BIOL-3080,2015
-BIOL,3080,3,Biology of Plants Practicum,0.71,0.18,0.06,0.0,0.06,0.0,0.0,0.0,robert edwa ballard,BIOL-3080,2015
-BIOL,3080,4,Biology of Plants Practicum,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert edwa ballard,BIOL-3080,2015
-BIOL,3130,1,Conservation Biology,0.28,0.44,0.16,0.12,0.0,0.0,0.0,0.0,shari lyn rodriguez,BIOL-3130,2015
-BIOL,3130,2,Conservation Biology,0.21,0.37,0.26,0.11,0.0,0.0,0.0,0.05,shari lyn rodriguez,BIOL-3130,2015
-BIOL,3160,1,Human Physiology,0.29,0.45,0.23,0.02,0.01,0.0,0.0,0.01,tamara mcnutt-scott,BIOL-3160,2015
-BIOL,3200,1,Field Botany,0.13,0.31,0.28,0.11,0.11,0.0,0.0,0.06,timothy spira,BIOL-3200,2015
-BIOL,3350,1,Evolutionary Biology,0.19,0.44,0.19,0.06,0.03,0.0,0.0,0.09,lisa rapaport,BIOL-3350,2015
-BIOL,3510,1,Biological Anthropology,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,katherine weisensee,BIOL-3510,2015
-BIOL,4010,1,Plant Physiology,0.16,0.19,0.41,0.22,0.03,0.0,0.0,0.0,douglas bielenberg,BIOL-4010,2015
-BIOL,4020,2,Plant Physiology Lab,0.38,0.5,0.0,0.06,0.06,0.0,0.0,0.0,douglas bielenberg,BIOL-4020,2015
-BIOL,4020,4,Plant Physiology Lab,0.53,0.24,0.18,0.06,0.0,0.0,0.0,0.0,douglas bielenberg,BIOL-4020,2015
-BIOL,4030,3,Intro to Applied Genomics,0.18,0.18,0.27,0.0,0.09,0.0,0.0,0.27,vincent pa richards,BIOL-4030,2015
-BIOL,4100,1,Limnology,0.4,0.25,0.18,0.05,0.0,0.0,0.0,0.13,john jenkins hains,BIOL-4100,2015
-BIOL,4140,1,Basic Immunology,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,charles rice,BIOL-4140,2015
-BIOL,4340,1,Biological Chem Lab Techniques,0.17,0.25,0.5,0.08,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2015
-BIOL,4340,2,Biological Chem Lab Techniques,0.0,0.58,0.33,0.08,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2015
-BIOL,4340,3,Biological Chem Lab Techniques,0.09,0.36,0.27,0.09,0.18,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2015
-BIOL,4340,4,Biological Chem Lab Techniques,0.2,0.2,0.3,0.2,0.0,0.0,0.0,0.1,salvatore sparace,BIOL-4340,2015
-BIOL,4340,5,Biological Chem Lab Techniques,0.0,0.55,0.36,0.09,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2015
-BIOL,4340,6,Biological Chem Lab Techniques,0.1,0.4,0.3,0.0,0.1,0.0,0.0,0.1,salvatore sparace,BIOL-4340,2015
-BIOL,4400,1,Developmental Animal Biology,0.67,0.07,0.07,0.0,0.0,0.0,0.0,0.2,susan carol chapman,BIOL-4400,2015
-BIOL,4610,1,Cell Biology,0.23,0.3,0.26,0.14,0.05,0.0,0.0,0.03,lisa bain,BIOL-4610,2015
-BIOL,4610,2,Cell Biology (HON),0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,lisa bain,BIOL-4610,2015
-BIOL,4620,1,Cell Biology Lab (Lec),0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,2,Cell Biology Lab (Lec),0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,xianzhong yu,BIOL-4620,2015
-BIOL,4620,3,Cell Biology Lab (Lec),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,4,Cell Biology Lab (Lec),0.44,0.5,0.0,0.06,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,5,Cell Biology Lab (Lec),0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,6,Cell Biology Lab (Lec),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,7,Cell Biology Lab (Lec),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4620,8,Cell Biology Lab (Lec),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,BIOL-4620,2015
-BIOL,4620,9,Cell Biology Lab (Lec),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2015
-BIOL,4640,1,Mammalogy,0.06,0.39,0.22,0.11,0.11,0.0,0.0,0.11,john cummings,BIOL-4640,2015
-BIOL,4670,1,Principles of Hematology,0.83,0.07,0.09,0.0,0.02,0.0,0.0,0.0,vincent gallicchio,BIOL-4670,2015
-BIOL,4700,1,Behavioral Ecology,0.37,0.42,0.11,0.02,0.06,0.0,0.0,0.01,michael childress,BIOL-4700,2015
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,michael childress,BIOL-4710,2015
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.53,0.2,0.0,0.07,0.0,0.0,0.0,0.2,michael childress,BIOL-4710,2015
-BIOL,4710,3,Behavioral Ecology Lab (Lec),0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,michael childress,BIOL-4710,2015
-BIOL,4710,4,Behavioral Ecology Lab (Lec),0.69,0.15,0.08,0.0,0.0,0.0,0.0,0.08,michael childress,BIOL-4710,2015
-BIOL,4930,2,Oceans End & Climate Sr Sem,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,andrew mount,BIOL-4930,2015
-BIOL,4930,4,Adv Cancer Research Sr Sem,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,BIOL-4930,2015
-BIOL,6800,1,Vertebrate Endocrinology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,BIOL-6800,2015
-BIOL,8430,1,Underst Genetics & Evol Biol,0.91,0.05,0.01,0.0,0.02,0.0,0.0,0.01,renea chri hardwick,BIOL-8430,2015
-BIOL,8450,1,Understanding Vertebrate Biol,0.9,0.08,0.0,0.0,0.02,0.0,0.0,0.0,tamara mcnutt-scott,BIOL-8450,2015
-BIOL,8470,1,Understanding Microbiology,0.53,0.43,0.03,0.0,0.01,0.0,0.0,0.0,harry kurtz,BIOL-8470,2015
-BMOL,4250,1,Biomolecular Engineering,0.3,0.4,0.1,0.0,0.0,0.0,0.0,0.2,mark alan blenner,BMOL-4250,2015
-BUS,1010,1,Business Foundations,0.13,0.4,0.18,0.08,0.05,0.0,0.0,0.15,michael giebner,BUS-1010,2015
-BUS,1010,2,Business Foundations,0.19,0.51,0.19,0.05,0.02,0.0,0.0,0.05,michael giebner,BUS-1010,2015
-BUS,1010,3,Business Foundations,0.14,0.52,0.1,0.1,0.1,0.0,0.0,0.03,william ern tumblin,BUS-1010,2015
-BUS,1010,4,Business Foundations,0.2,0.5,0.17,0.03,0.03,0.0,0.0,0.07,william ern tumblin,BUS-1010,2015
-BUS,1010,6,Business Foundations,0.13,0.45,0.32,0.03,0.03,0.0,0.0,0.03,william ern tumblin,BUS-1010,2015
-CE,2010,1,Statics,0.45,0.2,0.16,0.09,0.02,0.0,0.0,0.07,nighat yasmin,CE-2010,2015
-CE,2010,2,Statics,0.27,0.25,0.23,0.07,0.09,0.0,0.0,0.09,michael pa esposito,CE-2010,2015
-CE,2010,3,Statics,0.34,0.27,0.2,0.02,0.09,0.0,0.0,0.07,md akhter hossain,CE-2010,2015
-CE,2010,4,Statics,0.15,0.22,0.27,0.12,0.15,0.0,0.0,0.1,melissa sternhagen,CE-2010,2015
-CE,2010,5,Statics,0.7,0.16,0.09,0.0,0.02,0.0,0.0,0.02,nighat yasmin,CE-2010,2015
-CE,2010,6,Statics,0.44,0.23,0.03,0.1,0.08,0.0,0.0,0.13,michael pa esposito,CE-2010,2015
-CE,2010,7,Statics,0.18,0.12,0.18,0.12,0.24,0.0,0.0,0.18,thomas edfo cousins,CE-2010,2015
-CE,2060,1,Structural Mechanics,0.19,0.47,0.19,0.13,0.03,0.0,0.0,0.0,bryant nielson,CE-2060,2015
-CE,2060,2,Structural Mechanics,0.22,0.44,0.27,0.03,0.02,0.0,0.0,0.02,bryant nielson,CE-2060,2015
-CE,2080,1,Dynamics,0.32,0.43,0.23,0.0,0.0,0.0,0.0,0.02,melissa sternhagen,CE-2080,2015
-CE,2080,2,Dynamics,0.2,0.59,0.14,0.04,0.0,0.0,0.0,0.02,melissa sternhagen,CE-2080,2015
-CE,2080,3,Dynamics,0.15,0.63,0.15,0.03,0.0,0.0,0.0,0.05,melissa sternhagen,CE-2080,2015
-CE,2550,1,Geomatics,0.25,0.42,0.22,0.06,0.01,0.0,0.0,0.04,wayne sarasua,CE-2550,2015
-CE,3010,1,Structural Analysis,0.22,0.3,0.22,0.16,0.1,0.0,0.0,0.0,stephen csernak,CE-3010,2015
-CE,3110,1,Transportation Engr,0.22,0.51,0.21,0.01,0.0,0.0,0.0,0.04,wayne sarasua,CE-3110,2015
-CE,3210,1,Geotechnical Engineering,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,CE-3210,2015
-CE,3210,2,Geotechnical Engineering,0.3,0.3,0.28,0.1,0.03,0.0,0.0,0.0,charng-hsein juang,CE-3210,2015
-CE,3310,1,Constr Engr & Mgmnt,0.28,0.36,0.26,0.08,0.0,0.0,0.0,0.02,james burati,CE-3310,2015
-CE,3410,1,Intro to Fluid Mech,0.15,0.41,0.29,0.07,0.05,0.0,0.0,0.02,nigel gregory kaye,CE-3410,2015
-CE,3420,1,Hydraulics & Hydro,0.12,0.39,0.27,0.09,0.03,0.0,0.0,0.09,abdul khan,CE-3420,2015
-CE,3420,2,Hydraulics & Hydro,0.5,0.38,0.1,0.0,0.0,0.0,0.0,0.03,ashok mishra,CE-3420,2015
-CE,3510,1,Civil Engineering Materials,0.33,0.56,0.05,0.05,0.02,0.0,0.0,0.0,prasada rangaraju,CE-3510,2015
-CE,3520,1,Econ Eval of Proj,0.35,0.23,0.2,0.15,0.05,0.0,0.0,0.02,yongxi huang,CE-3520,2015
-CE,3520,2,Econ Eval of Proj,0.53,0.31,0.14,0.02,0.0,0.0,0.0,0.0,bradley putman,CE-3520,2015
-CE,3530,1,Professional Seminar,0.92,0.06,0.01,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-3530,2015
-CE,4010,1,Matrix Str Analysis,0.08,0.5,0.0,0.08,0.17,0.0,0.0,0.17,bryant nielson,CE-4010,2015
-CE,4020,1,Reinfor Con Design,0.42,0.36,0.16,0.04,0.02,0.0,0.0,0.0,brandon ross,CE-4020,2015
-CE,4040,1,Masonry Struct Des,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,atamturktur russcher,CE-4040,2015
-CE,4110,1,Roadway Geo Design,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ogle,CE-4110,2015
-CE,4120,1,Urban Transport Plan,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,mashrur chowdhury,CE-4120,2015
-CE,4210,1,Geotechnical Design,0.26,0.57,0.11,0.06,0.0,0.0,0.0,0.0,nadara ravichandran,CE-4210,2015
-CE,4330,1,Const Plan & Sched,0.39,0.42,0.15,0.01,0.01,0.0,0.0,0.01, kent nilsson,CE-4330,2015
-CE,4340,1,Const Est Proj Cont,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4340,2015
-CE,4470,1,Stormwater Managemnt,0.36,0.52,0.08,0.0,0.0,0.0,0.0,0.04,nigel gregory kaye,CE-4470,2015
-CE,4590,1,Capstone Design Proj,0.52,0.44,0.05,0.0,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2015
-CE,4590,100,Capstone Design Proj,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,CE-4590,2015
-CE,6010,1,Matrix Str Analysis,0.29,0.52,0.14,0.0,0.05,0.0,0.0,0.0,bryant nielson,CE-6010,2015
-CE,6040,1,Masonry Struct Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,CE-6040,2015
-CE,6210,1,Geotechnical Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,CE-6210,2015
-CE,6330,1,Const Plan & Sched,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0, kent nilsson,CE-6330,2015
-CE,8040,1,Prestressed Concrete,0.49,0.41,0.1,0.0,0.0,0.0,0.0,0.0,brandon ross,CE-8040,2015
-CE,8080,1,Earthquake Engr,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-8080,2015
-CE,8250,1,Geotech Equake Engr,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-8250,2015
-CE,8270,1,Spec Cements & Concr,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,prasada rangaraju,CE-8270,2015
-CE,8530,1,Apps in Traffic En,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-8530,2015
-CE,8930,2,Selec Topics in C E - Construc,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,james burati,CE-8930,2015
-CE,9910,19,Doctoral Dissertation Research,0.0,0.0,0.0,0.0,0.0,0.8,0.2,0.0,leidy klotz,CE-9910,2015
-CH,1010,1,General Chemistry,0.09,0.23,0.3,0.2,0.12,0.0,0.0,0.06,ava kreider-mueller,CH-1010,2015
-CH,1010,2,General Chemistry,0.07,0.21,0.3,0.2,0.14,0.0,0.0,0.08,ava kreider-mueller,CH-1010,2015
-CH,1010,3,General Chemistry,0.17,0.29,0.28,0.11,0.1,0.0,0.0,0.05,dennis taylor,CH-1010,2015
-CH,1010,4,General Chemistry,0.1,0.19,0.25,0.25,0.13,0.0,0.0,0.08,joseph stu thrasher,CH-1010,2015
-CH,1010,400,General Chemistry (ONLINE),0.21,0.19,0.36,0.08,0.13,0.0,0.0,0.03,stephe schvaneveldt,CH-1010,2015
-CH,1020,1,General Chemistry,0.2,0.25,0.2,0.18,0.08,0.0,0.0,0.1,christopher wilson,CH-1020,2015
-CH,1020,2,General Chemistry,0.19,0.26,0.26,0.12,0.04,0.0,0.0,0.14,christopher wilson,CH-1020,2015
-CH,1020,3,General Chemistry,0.29,0.38,0.25,0.03,0.01,0.0,0.0,0.03,dennis taylor,CH-1020,2015
-CH,1020,4,General Chemistry,0.25,0.42,0.22,0.06,0.03,0.0,0.0,0.03,dennis taylor,CH-1020,2015
-CH,1020,5,General Chemistry,0.15,0.39,0.31,0.07,0.04,0.0,0.0,0.04,olt geiculescu,CH-1020,2015
-CH,1020,7,General Chemistry,0.21,0.53,0.16,0.06,0.02,0.0,0.0,0.03,kenneth wi rillings,CH-1020,2015
-CH,1020,8,General Chemistry,0.23,0.4,0.26,0.06,0.02,0.0,0.0,0.03,kenneth wi rillings,CH-1020,2015
-CH,1020,9,General Chemistry,0.24,0.41,0.23,0.05,0.05,0.0,0.0,0.02,ava kreider-mueller,CH-1020,2015
-CH,1020,10,General Chemistry,0.21,0.42,0.32,0.04,0.02,0.0,0.0,0.0,kenneth wi rillings,CH-1020,2015
-CH,1020,11,General Chemistry (CH majors),0.55,0.18,0.24,0.0,0.0,0.0,0.0,0.03,stephe schvaneveldt,CH-1020,2015
-CH,1020,12,General Chemistry (CLUE),0.36,0.5,0.07,0.02,0.0,0.0,0.0,0.05,kenneth christensen,CH-1020,2015
-CH,1020,51,General Chemistry (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,CH-1020,2015
-CH,1020,52,General Chemistry (HON),0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,shiou-jyh hwu,CH-1020,2015
-CH,1050,1,Chem in Context I,0.27,0.45,0.24,0.03,0.0,0.0,0.0,0.01,thomas hickman,CH-1050,2015
-CH,1060,1,Chem in Context II,0.36,0.61,0.0,0.0,0.04,0.0,0.0,0.0,olt geiculescu,CH-1060,2015
-CH,1060,2,Chem in Context II,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,olt geiculescu,CH-1060,2015
-CH,1520,1,Chem Commun I,0.83,0.02,0.02,0.0,0.0,0.0,0.0,0.13,richard marcus,CH-1520,2015
-CH,2010,1,Survey of Organic Chemistry,0.37,0.26,0.19,0.1,0.04,0.0,0.0,0.03,tania issa houjeiry,CH-2010,2015
-CH,2020,1,Surv of Organic Chemistry Lab,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,CH-2020,2015
-CH,2020,2,Surv of Organic Chemistry Lab,0.53,0.29,0.12,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2020,2015
-CH,2020,3,Surv of Organic Chemistry Lab,0.71,0.18,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,CH-2020,2015
-CH,2050,1,Intro Inorg Chem,0.54,0.29,0.17,0.0,0.0,0.0,0.0,0.0,william pennington,CH-2050,2015
-CH,2230,1,Organic Chemistry,0.23,0.3,0.12,0.12,0.17,0.0,0.0,0.07,jacob schroeder,CH-2230,2015
-CH,2230,2,Organic Chemistry,0.44,0.27,0.14,0.06,0.03,0.0,0.0,0.06,jacob schroeder,CH-2230,2015
-CH,2230,3,Organic Chemistry,0.35,0.33,0.08,0.07,0.11,0.0,0.0,0.07,jacob schroeder,CH-2230,2015
-CH,2240,1,Organic Chemistry,0.39,0.43,0.12,0.05,0.0,0.0,0.0,0.01,tania issa houjeiry,CH-2240,2015
-CH,2240,2,Organic Chemistry,0.29,0.57,0.09,0.03,0.02,0.0,0.0,0.0,thomas hickman,CH-2240,2015
-CH,2240,3,Organic Chemistry,0.22,0.39,0.24,0.1,0.02,0.0,0.0,0.04,thomas hickman,CH-2240,2015
-CH,2240,4,Organic Chemistry,0.37,0.26,0.09,0.12,0.07,0.0,0.0,0.09,rhett smith,CH-2240,2015
-CH,2240,5,Organic Chemistry,0.33,0.4,0.18,0.02,0.04,0.0,0.0,0.04,jacob schroeder,CH-2240,2015
-CH,2270,1,Organic Chem Lab,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2015
-CH,2270,5,Organic Chem Lab,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2015
-CH,2270,8,Organic Chem Lab,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2015
-CH,2270,9,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2015
-CH,2280,1,Organic Chem Lab,0.62,0.08,0.0,0.0,0.0,0.0,0.0,0.31,sean 'connor,CH-2280,2015
-CH,2280,2,Organic Chem Lab,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,CH-2280,2015
-CH,2280,3,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2280,2015
-CH,2280,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2280,2015
-CH,2280,7,Organic Chem Lab,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2280,2015
-CH,2280,8,Organic Chem Lab,0.73,0.13,0.0,0.07,0.0,0.0,0.0,0.07,sean 'connor,CH-2280,2015
-CH,2280,12,Organic Chem Lab,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2015
-CH,2280,21,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,sean 'connor,CH-2280,2015
-CH,2280,24,Organic Chem Lab,0.63,0.19,0.13,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2280,2015
-CH,2290,3,Organic Chem Lab,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2290,2015
-CH,3310,1,Physical Chemistry,0.42,0.32,0.11,0.05,0.0,0.0,0.0,0.11,arkady kholodenko,CH-3310,2015
-CH,3320,1,Physical Chemistry (ENGR only),0.49,0.33,0.13,0.03,0.01,0.0,0.0,0.0,steven stuart,CH-3320,2015
-CH,3320,2,Physical Chemistry (CH majors),0.42,0.29,0.21,0.04,0.04,0.0,0.0,0.0,jason mcneill,CH-3320,2015
-CH,3400,2,Physical Chem Lab,0.78,0.17,0.0,0.06,0.0,0.0,0.0,0.0,christopher wilson,CH-3400,2015
-CH,3400,3,Physical Chem Lab,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,christopher wilson,CH-3400,2015
-CH,3400,4,Physical Chem Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,CH-3400,2015
-CH,3600,1,Chemical Biology,0.38,0.27,0.17,0.1,0.0,0.0,0.0,0.08,modi wetzler,CH-3600,2015
-CH,4110,1,Instrumental Analy,0.23,0.32,0.09,0.18,0.18,0.0,0.0,0.0,george chumanov,CH-4110,2015
-CH,4120,1,Instr Analysis Lab,0.33,0.25,0.25,0.08,0.08,0.0,0.0,0.0,jeffrey natha anker,CH-4120,2015
-CH,4120,2,Instr Analysis Lab,0.55,0.27,0.09,0.09,0.0,0.0,0.0,0.0,jeffrey natha anker,CH-4120,2015
-CH,4130,1,Chem Aqueous Systems,0.42,0.32,0.11,0.0,0.0,0.0,0.0,0.16,cindy lee,CH-4130,2015
-CH,4500,1,Chemistry Capstone,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,CH-4500,2015
-CH,8090,1,Chem App/X-Ray Cryst,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,CH-8090,2015
-CH,8130,1,Electrochem Sci,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,stephen creager,CH-8130,2015
-CH,8510,1,Grad Student Seminar,0.82,0.07,0.07,0.0,0.04,0.0,0.0,0.0,joseph stu thrasher,CH-8510,2015
-CHE,1300,1,Chemical Eng Tools,0.27,0.41,0.14,0.02,0.08,0.0,0.0,0.08,christopher norfolk,CHE-1300,2015
-CHE,1300,2,Chemical Eng Tools,0.35,0.33,0.15,0.09,0.03,0.0,0.0,0.05,christopher norfolk,CHE-1300,2015
-CHE,2200,1,Ch E Thermo I,0.22,0.2,0.27,0.1,0.16,0.0,0.0,0.06,mark thies,CHE-2200,2015
-CHE,2200,2,Ch E Thermo I,0.25,0.19,0.25,0.17,0.14,0.0,0.0,0.0,mark thies,CHE-2200,2015
-CHE,2300,1,Fluids/Heat Transfer,0.12,0.22,0.41,0.14,0.06,0.0,0.0,0.04,douglas hirt,CHE-2300,2015
-CHE,2300,2,Fluids/Heat Transfer,0.19,0.33,0.19,0.19,0.08,0.0,0.0,0.0,douglas hirt,CHE-2300,2015
-CHE,3210,1,Ch E Thermo II,0.23,0.23,0.39,0.09,0.07,0.0,0.0,0.0,christophe kitchens,CHE-3210,2015
-CHE,3300,1,Mass Trans & Seprtn,0.23,0.32,0.25,0.08,0.12,0.0,0.0,0.0,mark alan blenner,CHE-3300,2015
-CHE,3530,1,Proc Dyn & Control,0.22,0.49,0.24,0.04,0.02,0.0,0.0,0.0,mark roberts,CHE-3530,2015
-CHE,4330,1,Process Design II,0.57,0.37,0.06,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4330,2015
-CHE,4990,14,CI- Membrane Separations,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,scott husson,CHE-4990,2015
-CHIN,1010,1,Elementary Chinese,0.47,0.26,0.16,0.11,0.0,0.0,0.0,0.0,yanhua zhang,CHIN-1010,2015
-CHIN,1020,1,Elementary Chinese,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,yanming an,CHIN-1020,2015
-COM,1500,1,Intro to Human Com,0.89,0.07,0.01,0.0,0.01,0.0,0.0,0.03,eddie smith,COM-1500,2015
-COM,1500,2,Intro to Human Com,0.49,0.44,0.03,0.01,0.01,0.0,0.0,0.01,daniel lelan fecher,COM-1500,2015
-COM,1500,3,Intro to Human Com,0.85,0.13,0.0,0.0,0.01,0.0,0.0,0.01,eddie smith,COM-1500,2015
-COM,1500,4,Intro to Human Com,0.78,0.16,0.02,0.01,0.01,0.0,0.0,0.02,marianne her glaser,COM-1500,2015
-COM,1500,5,Intro to Human Com,0.66,0.28,0.03,0.01,0.0,0.0,0.0,0.02,marianne her glaser,COM-1500,2015
-COM,1500,6,Intro to Human Com,0.54,0.41,0.04,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,COM-1500,2015
-COM,1500,6,Intro to Human Communication,0.54,0.41,0.04,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,COM-1500,2015
-COM,2010,1,Intr to Comm Studies,0.44,0.36,0.2,0.0,0.0,0.0,0.0,0.0,brenden kendall,COM-2010,2015
-COM,2010,2,Intr to Comm Studies,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-2010,2015
-COM,2500,1,Public Speaking,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2015
-COM,2500,2,Public Speaking,0.47,0.32,0.05,0.05,0.0,0.0,0.0,0.11,marilyn denise pugh,COM-2500,2015
-COM,2500,3,Public Speaking,0.5,0.45,0.0,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2015
-COM,2500,4,Public Speaking,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2015
-COM,2500,5,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2015
-COM,2500,6,Public Speaking,0.45,0.4,0.1,0.0,0.05,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2015
-COM,2500,7,Public Speaking,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2015
-COM,2500,8,Public Speaking,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2015
-COM,2500,10,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2015
-COM,2500,11,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,COM-2500,2015
-COM,2500,13,Public Speaking,0.26,0.53,0.16,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,COM-2500,2015
-COM,2500,14,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,COM-2500,2015
-COM,2500,15,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,COM-2500,2015
-COM,2500,16,Public Speaking,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,the estate  geddes,COM-2500,2015
-COM,2500,17,Public Speaking,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,pauline matthey,COM-2500,2015
-COM,2500,18,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2015
-COM,2500,19,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2015
-COM,2500,20,Public Speaking,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2015
-COM,2500,21,Public Speaking,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2015
-COM,2500,22,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2015
-COM,2500,23,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2015
-COM,2500,24,Public Speaking,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2015
-COM,2500,28,Public Speaking,0.26,0.53,0.05,0.05,0.0,0.0,0.0,0.11,marilyn denise pugh,COM-2500,2015
-COM,2500,400,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2015
-COM,2500,401,Public Speaking,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2015
-COM,2500,402,Public Speaking,0.72,0.11,0.0,0.06,0.0,0.0,0.0,0.11,alexis zachar davis,COM-2500,2015
-COM,2500,403,Public Speaking,0.63,0.26,0.0,0.05,0.05,0.0,0.0,0.0,alexis zachar davis,COM-2500,2015
-COM,2500,500,Public Speaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2015
-COM,2500,501,Public Speaking,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2015
-COM,3010,1,Comm Theory,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-3010,2015
-COM,3020,1,Mass Comm Theory,0.62,0.3,0.04,0.04,0.0,0.0,0.0,0.0,erin michelle ash,COM-3020,2015
-COM,3080,1,Pub Comm & Pop Cult,0.29,0.42,0.19,0.03,0.0,0.0,0.0,0.06,chenjerai kumanyika,COM-3080,2015
-COM,3100,1,Quant Comm Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3100,2015
-COM,3110,1,Qual Comm Methods,0.58,0.25,0.13,0.0,0.04,0.0,0.0,0.0,stephanie pangborn,COM-3110,2015
-COM,3200,1,Bdcst Production,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,wanda johnson,COM-3200,2015
-COM,3260,1,Pr in Sports,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2015
-COM,3480,1,Interpersonal Comm,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,melinda ra weathers,COM-3480,2015
-COM,3500,1,Sm Group & Team Comm,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,joseph mazer,COM-3500,2015
-COM,3560,1,Stakeholder Comm,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3560,2015
-COM,3660,1,EP: Advertising & Media,0.56,0.32,0.04,0.04,0.0,0.0,0.0,0.04,william reynolds,COM-3660,2015
-COM,3660,2,EP: Building the Brand,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,andrew mendelsohn,COM-3660,2015
-COM,3660,3,Live Broadcast Production,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,michael rodgers,COM-3660,2015
-COM,3680,1,Applied Digital Communication,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,COM-3680,2015
-COM,3990,6,CI: Tigers Talk Ethics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,COM-3990,2015
-COM,4260,1,Social Media and Sports Comm,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4260,2015
-COM,4260,2,Social Media and Sports Comm,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4260,2015
-COM,4700,1,Comm & Health,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,stephanie pangborn,COM-4700,2015
-COM,4950,1,Sr. Capstone: Agenda Building,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,bryan denham,COM-4950,2015
-COM,4950,2,Sr. Capstone: Advert. & Sport,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4950,2015
-COM,8110,1,Comm Research Methods II,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,chenjerai kumanyika,COM-8110,2015
-CPSC,1010,1,Computer Science I,0.19,0.18,0.19,0.12,0.14,0.0,0.0,0.18,catherine hochrine,CPSC-1010,2015
-CPSC,1010,2,Computer Science I,0.61,0.24,0.1,0.0,0.0,0.0,0.0,0.05,lauren elizab dukes,CPSC-1010,2015
-CPSC,1020,1,Computer Science II,0.48,0.24,0.08,0.0,0.08,0.0,0.0,0.12,catherine hochrine,CPSC-1020,2015
-CPSC,1020,2,Computer Science II,0.62,0.12,0.04,0.0,0.04,0.0,0.0,0.19,yvon feaster,CPSC-1020,2015
-CPSC,1020,3,Computer Science II,0.68,0.04,0.08,0.0,0.08,0.0,0.0,0.12,yvon feaster,CPSC-1020,2015
-CPSC,1020,4,Computer Science II,0.33,0.24,0.14,0.05,0.05,0.0,0.0,0.19,joshua levine,CPSC-1020,2015
-CPSC,1110,1,Intro to Programming in C,0.68,0.25,0.0,0.0,0.04,0.0,0.0,0.04,patrick sterling,CPSC-1110,2015
-CPSC,1110,2,Intro to Programming in C,0.77,0.1,0.07,0.03,0.0,0.0,0.0,0.03,patrick sterling,CPSC-1110,2015
-CPSC,1110,3,Intro to Programming in C,0.57,0.2,0.07,0.07,0.03,0.0,0.0,0.07,patrick sterling,CPSC-1110,2015
-CPSC,1110,4,Intro to Programming in C,0.63,0.04,0.04,0.04,0.15,0.0,0.0,0.11,toni bloodwor pence,CPSC-1110,2015
-CPSC,1200,1,Intro Info Tech,0.82,0.06,0.0,0.0,0.06,0.0,0.0,0.06,renee lambert,CPSC-1200,2015
-CPSC,2070,1,Discrete Structures,0.34,0.25,0.18,0.02,0.09,0.0,0.0,0.11,sandra hedetniemi,CPSC-2070,2015
-CPSC,2070,401,Discrete Structures,0.2,0.34,0.25,0.13,0.05,0.0,0.0,0.04,larry hodges,CPSC-2070,2015
-CPSC,2100,1,Progrmng Methodology,0.23,0.23,0.23,0.06,0.2,0.0,0.0,0.06,rose lowe,CPSC-2100,2015
-CPSC,2120,1,Algs/Data Structures,0.36,0.31,0.16,0.05,0.12,0.0,0.0,0.01,wayne goddard,CPSC-2120,2015
-CPSC,2150,1,Software Dev Fndtns,0.35,0.39,0.15,0.07,0.02,0.0,0.0,0.02,yu-shan sun,CPSC-2150,2015
-CPSC,2150,2,Software Dev Fndtns,0.23,0.21,0.32,0.06,0.11,0.0,0.0,0.06,blair madiso durkee,CPSC-2150,2015
-CPSC,2200,1,Microcomputer Appl,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,patrick sterling,CPSC-2200,2015
-CPSC,2310,1,Intro Computer Org,0.21,0.31,0.36,0.05,0.05,0.0,0.0,0.03,rose lowe,CPSC-2310,2015
-CPSC,2310,2,Intro Computer Org,0.32,0.32,0.24,0.0,0.09,0.0,0.0,0.03,rose lowe,CPSC-2310,2015
-CPSC,2910,2,Prof Issues I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,renee lambert,CPSC-2910,2015
-CPSC,2910,3,Prof Issues I,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,renee lambert,CPSC-2910,2015
-CPSC,2910,4,Prof Issues I,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,renee lambert,CPSC-2910,2015
-CPSC,2910,5,Prof Issues I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james jones,CPSC-2910,2015
-CPSC,2910,6,Prof Issues I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,james jones,CPSC-2910,2015
-CPSC,2910,7,Prof Issues I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,james jones,CPSC-2910,2015
-CPSC,3220,1,Intro to Operating Systems,0.26,0.21,0.23,0.05,0.18,0.0,0.0,0.08,jacob sorber,CPSC-3220,2015
-CPSC,3220,2,Intro to Operating Systems,0.17,0.14,0.2,0.09,0.17,0.0,0.0,0.23,jacob sorber,CPSC-3220,2015
-CPSC,3300,1,Computer Systems Org,0.27,0.24,0.26,0.06,0.1,0.0,0.0,0.06,mark smotherman,CPSC-3300,2015
-CPSC,3500,1,Foundations of Computer Sci,0.15,0.23,0.37,0.1,0.06,0.0,0.0,0.1,ilya mark safro,CPSC-3500,2015
-CPSC,3520,1,Programming Systems,0.41,0.3,0.05,0.0,0.09,0.0,0.0,0.16,robert schalkoff,CPSC-3520,2015
-CPSC,3600,1,Network Programming,0.16,0.27,0.25,0.16,0.1,0.0,0.0,0.06,sekou lionel remy,CPSC-3600,2015
-CPSC,3620,1,Distributed Computng,0.29,0.38,0.15,0.08,0.04,0.0,0.0,0.06,linh bao ngo,CPSC-3620,2015
-CPSC,3720,1,Software Engineering,0.17,0.39,0.3,0.04,0.04,0.0,0.0,0.04,stephen schaub,CPSC-3720,2015
-CPSC,3720,2,Software Engineering,0.26,0.29,0.29,0.1,0.03,0.0,0.0,0.03,stephen schaub,CPSC-3720,2015
-CPSC,4050,1,Computer Graphics,0.26,0.52,0.13,0.04,0.0,0.0,0.0,0.04,robert geist,CPSC-4050,2015
-CPSC,4140,1,Human and Computer Interaction,0.35,0.48,0.04,0.04,0.09,0.0,0.0,0.0,sabarish venka babu,CPSC-4140,2015
-CPSC,4140,2,Human and Computer Interaction,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,kelly caine,CPSC-4140,2015
-CPSC,4160,1,2-D Game Engine Construction,0.5,0.33,0.1,0.0,0.07,0.0,0.0,0.0,brian malloy,CPSC-4160,2015
-CPSC,4240,1,System Admin and Security,0.15,0.58,0.19,0.04,0.04,0.0,0.0,0.0,james martin,CPSC-4240,2015
-CPSC,4620,1,Database Management Systems,0.22,0.44,0.22,0.07,0.04,0.0,0.0,0.0,zijun wang,CPSC-4620,2015
-CPSC,4820,1,Design & Implementation,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,christina sop joerg,CPSC-4820,2015
-CPSC,4820,2,Mobile Device,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,roy pargas,CPSC-4820,2015
-CPSC,4910,1,Prof Issues II,0.93,0.04,0.0,0.0,0.02,0.0,0.0,0.0,james jones,CPSC-4910,2015
-CPSC,6050,1,Computer Graphics,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,robert geist,CPSC-6050,2015
-CPSC,6140,1,Human and Computer Interaction,0.57,0.29,0.07,0.0,0.0,0.0,0.0,0.07,sabarish venka babu,CPSC-6140,2015
-CPSC,6140,2,Human and Computer Interaction,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,kelly caine,CPSC-6140,2015
-CPSC,6160,1,2-D Game Engine Construction,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,brian malloy,CPSC-6160,2015
-CPSC,6240,1,System Admin and Security,0.57,0.29,0.07,0.0,0.0,0.0,0.0,0.07,james martin,CPSC-6240,2015
-CPSC,6620,1,Database Management Systems,0.46,0.27,0.19,0.0,0.08,0.0,0.0,0.0,zijun wang,CPSC-6620,2015
-CPSC,6820,1,Special Topics:Design & Imple,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,CPSC-6820,2015
-CPSC,8080,1,Advanced Animation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,CPSC-8080,2015
-CPSC,8090,1,Render and Shade,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,CPSC-8090,2015
-CPSC,8220,1,Case Study in Operating Sys,0.27,0.67,0.0,0.0,0.0,0.0,0.0,0.07,robert geist,CPSC-8220,2015
-CPSC,8280,1,Theory of Program. Languages,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,murali sitaraman,CPSC-8280,2015
-CPSC,8550,1,Embedded Network Sys,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,yvon feaster,CPSC-8550,2015
-CPSC,8620,1,Database Mngmt System Design,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,zijun wang,CPSC-8620,2015
-CPSC,8630,1,Multimedia Sys/Apps,0.27,0.5,0.14,0.0,0.05,0.0,0.0,0.05,zijun wang,CPSC-8630,2015
-CPSC,8750,1,Software Architectur,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,john mcgregor,CPSC-8750,2015
-CPSC,8810,1,Topic:Info Retrieval,0.23,0.65,0.1,0.0,0.0,0.0,0.0,0.03,feng luo,CPSC-8810,2015
-CPSC,8810,2,Advanced Networking & Security,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,hongxin hu,CPSC-8810,2015
-CRP,8020,1,Site Planning,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,clifford dona ellis,CRP-8020,2015
-CRP,8040,1,Land Use Analysis,0.82,0.0,0.12,0.0,0.0,0.0,0.0,0.06,stephen sperry,CRP-8040,2015
-CRP,8050,1,Plning Theory & Hist,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,mickey lauria,CRP-8050,2015
-CRP,8090,1,Current Issues,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,CRP-8090,2015
-CRP,8130,1,Transportation Plan,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,CRP-8130,2015
-CRP,8200,1,Negotiation,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,CRP-8200,2015
-CRP,8220,1,Urban Design,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,CRP-8220,2015
-CSM,1500,1,Constr Prob Solving,0.39,0.56,0.0,0.0,0.06,0.0,0.0,0.0,jason lucas,CSM-1500,2015
-CSM,1500,2,Constr Prob Solving,0.57,0.24,0.19,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-1500,2015
-CSM,1500,3,Constr Prob Solving,0.3,0.6,0.05,0.05,0.0,0.0,0.0,0.0,jason lucas,CSM-1500,2015
-CSM,2020,1,Structures II,0.24,0.38,0.24,0.14,0.0,0.0,0.0,0.0,shima clarke,CSM-2020,2015
-CSM,2020,2,Structures II,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,shima clarke,CSM-2020,2015
-CSM,2040,1,Cont Documents,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2040,2015
-CSM,2040,2,Cont Documents,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2040,2015
-CSM,2050,1,Mats & Methods II,0.37,0.33,0.22,0.07,0.0,0.0,0.0,0.0,joseph wintz,CSM-2050,2015
-CSM,2050,2,Mats & Methods II,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2050,2015
-CSM,3050,1,Envir Systems II,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3050,2015
-CSM,3050,2,Envir Systems II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3050,2015
-CSM,3520,1,Const Scheduling,0.2,0.5,0.25,0.0,0.0,0.0,0.0,0.05,christine piper,CSM-3520,2015
-CSM,3520,2,Const Scheduling,0.16,0.32,0.53,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-3520,2015
-CSM,3530,1,Const Estimating II,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,james packer smith,CSM-3530,2015
-CSM,3530,2,Const Estimating II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,james packer smith,CSM-3530,2015
-CSM,4540,1,Const Capstone,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4540,2015
-CSM,4540,2,Const Capstone,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4540,2015
-CSM,8610,1,Construction Control Systems,0.07,0.67,0.27,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-8610,2015
-CSM,8610,400,Construction Control Systems,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,christine piper,CSM-8610,2015
-CSM,8810,1,Professional Seminar,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-8810,2015
-CSM,8810,400,Professional Seminar,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-8810,2015
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.06,0.03,jeffrey appling,CU-1000,2015
-CU,1010,1,Univ Success Skills,0.83,0.04,0.04,0.04,0.0,0.0,0.0,0.04,rise jean sheriff,CU-1010,2015
-CU,1010,2,Univ Success Skills,0.68,0.05,0.14,0.05,0.0,0.0,0.0,0.09,cecelia hamby,CU-1010,2015
-CU,1010,3,Univ Success Skills,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,matthew james kirk,CU-1010,2015
-CU,1010,4,Univ Success Skills,0.41,0.55,0.0,0.0,0.03,0.0,0.0,0.0,matthew james kirk,CU-1010,2015
-CU,1010,5,Univ Success Skills,0.54,0.33,0.04,0.0,0.0,0.0,0.0,0.08,mary mcp von kaenel,CU-1010,2015
-CU,1010,6,Univ Success Skills,0.65,0.17,0.13,0.0,0.04,0.0,0.0,0.0,robert dav brackett,CU-1010,2015
-CU,1010,7,Univ Success Skills,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,deborah ann vaughn,CU-1010,2015
-CU,2010,1,Sustainability Leadership,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,CU-2010,2015
-DPA,3070,1,Method 3d Production,0.52,0.19,0.05,0.1,0.0,0.0,0.0,0.14,virginia ba nearing,DPA-3070,2015
-DPA,8600,1,Production Studio,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,DPA-8600,2015
-DPA,8600,2,Production Studio,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,DPA-8600,2015
-ECE,2010,1,Logic & Comp Device,0.19,0.32,0.18,0.19,0.09,0.0,0.0,0.04,lin zhu,ECE-2010,2015
-ECE,2020,1,Electric Circuits I,0.14,0.22,0.29,0.18,0.12,0.0,0.0,0.04,william harrell,ECE-2020,2015
-ECE,2070,1,Basic Electrical Engineering,0.44,0.24,0.14,0.05,0.04,0.0,0.0,0.09,surya sharma,ECE-2070,2015
-ECE,2070,2,Basic Electrical Engineering,0.56,0.33,0.1,0.01,0.0,0.0,0.0,0.0,hai xiao,ECE-2070,2015
-ECE,2070,3,Basic Electrical Engineering,0.89,0.04,0.05,0.0,0.0,0.0,0.0,0.01,sung- kim,ECE-2070,2015
-ECE,2080,5,Electrical Engineering Lab I,0.8,0.1,0.0,0.05,0.0,0.0,0.0,0.05,william harrell,ECE-2080,2015
-ECE,2080,8,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,william harrell,ECE-2080,2015
-ECE,2080,13,Electrical Engineering Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,ECE-2080,2015
-ECE,2080,17,Electrical Engineering Lab I,0.78,0.06,0.06,0.0,0.06,0.0,0.0,0.06,william harrell,ECE-2080,2015
-ECE,2080,18,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,william harrell,ECE-2080,2015
-ECE,2080,20,Electrical Engineering Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2080,2015
-ECE,2090,4,Logic Lab,0.67,0.08,0.08,0.08,0.0,0.0,0.0,0.08,william harrell,ECE-2090,2015
-ECE,2220,1,Syst Prog Concept,0.23,0.21,0.23,0.12,0.1,0.0,0.0,0.12,william reid,ECE-2220,2015
-ECE,2230,1,Comp Sys Eng,0.2,0.12,0.32,0.05,0.15,0.0,0.0,0.17,harlan russell,ECE-2230,2015
-ECE,2620,1,Elec Circuits II,0.33,0.27,0.23,0.09,0.07,0.0,0.0,0.01,richard groff,ECE-2620,2015
-ECE,2620,2,Elec Circuits II (HON),0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2620,2015
-ECE,2720,1,Comp Organization,0.28,0.31,0.25,0.11,0.05,0.0,0.0,0.0,william reid,ECE-2720,2015
-ECE,2720,1,,0.28,0.31,0.25,0.11,0.05,0.0,0.0,0.0,william reid,ECE-2720,2015
-ECE,2730,1,Computer Org Lab,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2730,2015
-ECE,2730,3,Computer Org Lab,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,william harrell,ECE-2730,2015
-ECE,2730,4,Computer Org Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2730,2015
-ECE,2730,5,Computer Org Lab,0.71,0.14,0.07,0.0,0.07,0.0,0.0,0.0,william harrell,ECE-2730,2015
-ECE,2730,6,Computer Org Lab,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2730,2015
-ECE,2730,7,Computer Org Lab,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-2730,2015
-ECE,3110,1,Electrical Engineering Lab III,0.56,0.13,0.0,0.13,0.13,0.0,0.0,0.06,william harrell,ECE-3110,2015
-ECE,3110,4,Electrical Engineering Lab III,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,william harrell,ECE-3110,2015
-ECE,3110,5,Electrical Engineering Lab III,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,ECE-3110,2015
-ECE,3170,1,Rand Signal Analysis,0.16,0.34,0.2,0.09,0.13,0.0,0.0,0.08,stephen hubbard,ECE-3170,2015
-ECE,3170,2,Rand Signal Analysis (HON),0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,carl baum,ECE-3170,2015
-ECE,3200,1,Electronics I,0.28,0.22,0.15,0.13,0.2,0.0,0.0,0.03,stephen hubbard,ECE-3200,2015
-ECE,3210,1,Electronics II,0.55,0.27,0.09,0.02,0.08,0.0,0.0,0.0,stephen hubbard,ECE-3210,2015
-ECE,3220,1,Intro Operating Sys,0.06,0.41,0.35,0.06,0.0,0.0,0.0,0.12,jacob sorber,ECE-3220,2015
-ECE,3220,2,Intro Operating Sys,0.05,0.35,0.4,0.05,0.05,0.0,0.0,0.1,jacob sorber,ECE-3220,2015
-ECE,3270,1,Dig Comp Design,0.1,0.26,0.26,0.08,0.08,0.0,0.0,0.23,melissa crawl smith,ECE-3270,2015
-ECE,3300,1,Signals & Systems,0.21,0.19,0.23,0.14,0.14,0.0,0.0,0.08,carl baum,ECE-3300,2015
-ECE,3520,1,Programming Systems,0.28,0.48,0.14,0.03,0.0,0.0,0.0,0.07,robert schalkoff,ECE-3520,2015
-ECE,3600,1,Elect Power Engr,0.25,0.29,0.25,0.06,0.06,0.0,0.0,0.08,edward collins,ECE-3600,2015
-ECE,3710,1,Microcontr Interface,0.4,0.38,0.2,0.01,0.01,0.0,0.0,0.0,william reid,ECE-3710,2015
-ECE,3720,6,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-3720,2015
-ECE,3800,1,Electromagnetics,0.23,0.18,0.36,0.13,0.1,0.0,0.0,0.0,anthony martin,ECE-3800,2015
-ECE,3810,1,Field Waves & Ckts,0.45,0.33,0.16,0.04,0.02,0.0,0.0,0.0,eric gordon johnson,ECE-3810,2015
-ECE,4090,1,Cont & Discrete Sys,0.37,0.4,0.17,0.06,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-4090,2015
-ECE,4190,1,Elec Mach and Drives,0.28,0.38,0.21,0.0,0.03,0.0,0.0,0.1,keith corzine,ECE-4190,2015
-ECE,4270,1,Communications Sys,0.24,0.29,0.3,0.09,0.05,0.0,0.0,0.03,madhabi manandhar,ECE-4270,2015
-ECE,4380,1,Computer Commun,0.28,0.18,0.23,0.13,0.05,0.0,0.0,0.15,harlan russell,ECE-4380,2015
-ECE,4680,1,Embedded Computing,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,adam hoover,ECE-4680,2015
-ECE,4700,1,Vehicle Electronics,0.54,0.35,0.06,0.04,0.0,0.0,0.0,0.0,todd hubing,ECE-4700,2015
-ECE,4950,1,Int Sys Design I,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-4950,2015
-ECE,4960,1,Int Sys Design II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2015
-ECE,6190,1,Elec Mach and Drives,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,keith corzine,ECE-6190,2015
-ECE,6380,1,Computer Commun,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,ECE-6380,2015
-ECE,6460,1,Antennas,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,anthony martin,ECE-6460,2015
-ECE,6680,1,Embedded Computing,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,adam hoover,ECE-6680,2015
-ECE,6930,1,MEMS,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,ECE-6930,2015
-ECE,8070,1,Comp Meth Pwr Anal,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,gan venayagamoorthy,ECE-8070,2015
-ECE,8160,1,Elec Power Distr Sys Engr,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,elham makram,ECE-8160,2015
-ECE,8300,1,Electromagnetics I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,anthony martin,ECE-8300,2015
-ECE,8400,1,Semicond Devices,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-8400,2015
-ECE,8440,1,Digital Signal Proc,0.43,0.52,0.05,0.0,0.0,0.0,0.0,0.0,john gowdy,ECE-8440,2015
-ECE,8560,1,Pattern Recognition,0.37,0.46,0.11,0.0,0.0,0.0,0.0,0.06,robert schalkoff,ECE-8560,2015
-ECE,8930,3,HPC with GPUs,0.32,0.52,0.08,0.0,0.0,0.0,0.0,0.08,melissa crawl smith,ECE-8930,2015
-ECE,8930,4,Distributed Dynamical Systems,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,yongqiang wang,ECE-8930,2015
-ECON,2000,1,Economic Concepts,0.05,0.35,0.23,0.1,0.18,0.0,0.0,0.1,mallika garg,ECON-2000,2015
-ECON,2000,2,Economic Concepts,0.31,0.39,0.17,0.08,0.03,0.0,0.0,0.03,mallika garg,ECON-2000,2015
-ECON,2000,3,Economic Concepts,0.3,0.28,0.15,0.08,0.15,0.0,0.0,0.05,miren ivankovic,ECON-2000,2015
-ECON,2110,1,Principles of Microeconomics,0.36,0.21,0.33,0.03,0.03,0.0,0.0,0.05,robert dew tollison,ECON-2110,2015
-ECON,2110,2,Principles of Microeconomics,0.15,0.48,0.3,0.03,0.03,0.0,0.0,0.03,alexander fiore,ECON-2110,2015
-ECON,2110,3,Principles of Microeconomics,0.14,0.49,0.25,0.07,0.03,0.0,0.0,0.03,adam millsap,ECON-2110,2015
-ECON,2110,4,Principles of Microeconomics,0.32,0.37,0.15,0.05,0.02,0.0,0.0,0.1,amanda caitlin kerr,ECON-2110,2015
-ECON,2110,5,Principles of Microeconomics,0.18,0.38,0.4,0.0,0.03,0.0,0.0,0.03,molly espey,ECON-2110,2015
-ECON,2110,6,Principles of Microeconomics,0.29,0.26,0.14,0.1,0.14,0.0,0.0,0.07,andew swanson,ECON-2110,2015
-ECON,2110,7,Principles of Microeconomics,0.28,0.41,0.24,0.03,0.03,0.0,0.0,0.02,alexander fiore,ECON-2110,2015
-ECON,2110,8,Principles of Microeconomics,0.29,0.26,0.26,0.08,0.05,0.0,0.0,0.06,timothy andr bersak,ECON-2110,2015
-ECON,2110,10,Principles of Microeconomics,0.23,0.34,0.26,0.06,0.0,0.0,0.0,0.11,anne anders,ECON-2110,2015
-ECON,2110,11,Principles of Microeconomics,0.39,0.32,0.23,0.07,0.0,0.0,0.0,0.0,amanda caitlin kerr,ECON-2110,2015
-ECON,2110,12,Principles of Microeconomics,0.1,0.58,0.25,0.05,0.0,0.0,0.0,0.03,molly espey,ECON-2110,2015
-ECON,2120,1,Principles of Macro,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,2,Principles of Macro,0.17,0.22,0.56,0.06,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,3,Principles of Macro,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,4,Principles of Macro,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,5,Principles of Macro,0.41,0.24,0.29,0.0,0.0,0.0,0.0,0.06,scott baier,ECON-2120,2015
-ECON,2120,6,Principles of Macro,0.11,0.56,0.22,0.0,0.06,0.0,0.0,0.06,scott baier,ECON-2120,2015
-ECON,2120,7,Principles of Macro,0.21,0.16,0.53,0.05,0.0,0.0,0.0,0.05,scott baier,ECON-2120,2015
-ECON,2120,8,Principles of Macro,0.37,0.16,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,9,Principles of Macro,0.2,0.25,0.35,0.05,0.05,0.0,0.0,0.1,scott baier,ECON-2120,2015
-ECON,2120,10,Principles of Macro,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,11,Principles of Macro,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,12,Principles of Macro,0.26,0.37,0.32,0.0,0.0,0.0,0.0,0.05,scott baier,ECON-2120,2015
-ECON,2120,13,Principles of Macro,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,14,Principles of Macro,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,15,Principles of Macro,0.29,0.43,0.24,0.0,0.0,0.0,0.0,0.05,scott baier,ECON-2120,2015
-ECON,2120,16,Principles of Macro,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,17,Principles of Macro,0.32,0.37,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,18,Principles of Macro,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,scott baier,ECON-2120,2015
-ECON,2120,19,Principles of Macro,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2015
-ECON,2120,20,Principles of Macro,0.26,0.36,0.3,0.04,0.02,0.0,0.0,0.02,peter david lorenz,ECON-2120,2015
-ECON,2120,21,Principles of Macro,0.25,0.51,0.2,0.03,0.0,0.0,0.0,0.02,peter david lorenz,ECON-2120,2015
-ECON,2120,22,Principles of Macro,0.35,0.25,0.33,0.03,0.0,0.0,0.0,0.05,yukun sun,ECON-2120,2015
-ECON,2120,23,Principles of Macro,0.45,0.38,0.18,0.0,0.0,0.0,0.0,0.0,yukun sun,ECON-2120,2015
-ECON,2120,24,Principles of Macro,0.21,0.52,0.17,0.05,0.04,0.0,0.0,0.01,scott barkowski,ECON-2120,2015
-ECON,2120,25,Principles of Macro,0.17,0.64,0.17,0.0,0.03,0.0,0.0,0.0,scott barkowski,ECON-2120,2015
-ECON,2120,26,Principles of Macro,0.22,0.08,0.27,0.05,0.22,0.0,0.0,0.16,ralph charles allen,ECON-2120,2015
-ECON,3020,1,Money and Banking,0.23,0.23,0.3,0.13,0.05,0.0,0.0,0.08,danielle zanzalari,ECON-3020,2015
-ECON,3060,1,Managerial Economics,0.28,0.31,0.25,0.03,0.06,0.0,0.0,0.06,jacob burgdorf,ECON-3060,2015
-ECON,3100,1,International Econ,0.26,0.33,0.17,0.17,0.02,0.0,0.0,0.05,ayse mujde erdogan,ECON-3100,2015
-ECON,3140,1,Intermediate Micro,0.23,0.28,0.21,0.08,0.05,0.0,0.0,0.15,patrick warren,ECON-3140,2015
-ECON,3140,2,Intermediate Micro,0.13,0.19,0.29,0.13,0.03,0.0,0.0,0.23,robert kennet fleck,ECON-3140,2015
-ECON,3140,3,Intermediate Micro,0.17,0.19,0.33,0.08,0.17,0.0,0.0,0.06,frederick hanssen,ECON-3140,2015
-ECON,3150,1,Intermediate Macro,0.36,0.26,0.22,0.07,0.03,0.0,0.0,0.06,ayse mujde erdogan,ECON-3150,2015
-ECON,3150,2,Intermediate Macro,0.31,0.26,0.26,0.0,0.03,0.0,0.0,0.14,sergey vla mityakov,ECON-3150,2015
-ECON,3440,1,Property Rights,0.11,0.3,0.26,0.07,0.07,0.0,0.0,0.19,dar litsukova-bokar,ECON-3440,2015
-ECON,3600,1,Public Choice,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,robert dew tollison,ECON-3600,2015
-ECON,4010,1,Labor Mkt Analysis,0.38,0.38,0.15,0.0,0.04,0.0,0.0,0.04,curtis simon,ECON-4010,2015
-ECON,4020,1,Law and Economics,0.42,0.25,0.21,0.08,0.0,0.0,0.0,0.04,thomas wins hazlett,ECON-4020,2015
-ECON,4050,1,Intro to Econometric,0.22,0.3,0.28,0.08,0.08,0.0,0.0,0.04,jaqueline oliveira,ECON-4050,2015
-ECON,4100,1,Economic Development,0.4,0.32,0.12,0.04,0.0,0.0,0.0,0.12,robert tamura,ECON-4100,2015
-ECON,4200,1,Pub Sector Econ,0.29,0.29,0.24,0.0,0.0,0.0,0.0,0.19,william dougan,ECON-4200,2015
-ECON,4240,1,Organization of Ind,0.36,0.39,0.14,0.04,0.04,0.0,0.0,0.04,matthew lewis,ECON-4240,2015
-ECON,4260,1,Sem Sport Economics,0.71,0.19,0.0,0.0,0.0,0.0,0.0,0.1,raymond sauer,ECON-4260,2015
-ECON,4270,1,Dev American Economy,0.34,0.28,0.19,0.13,0.0,0.0,0.0,0.06,howard ne bodenhorn,ECON-4270,2015
-ECON,4290,1,Economics of Energy Markets,0.48,0.38,0.0,0.0,0.0,0.0,0.0,0.14,matthew lewis,ECON-4290,2015
-ECON,4400,1,Game Theory,0.47,0.37,0.0,0.0,0.0,0.0,0.0,0.16,daniel wood,ECON-4400,2015
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.38,0.25,0.13,0.19,0.0,0.0,0.0,0.06,scott templeton,ECON-4570,2015
-ECON,8020,1,Adv Econ Concepts and Applic I,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,ECON-8020,2015
-ECON,8050,1,Macroeconomic Theory,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-8050,2015
-ECON,8070,1,Econometrics II,0.1,0.65,0.25,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,ECON-8070,2015
-ECON,8200,1,Public Finance,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william dougan,ECON-8200,2015
-ECON,8990,1,Sel Topics-Appl Welfare Econ,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,arnold harberger,ECON-8990,2015
-ECON,9010,1,Price Theory,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,daniel wood,ECON-9010,2015
-ECON,9090,1,Time-Series Econ,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,ECON-9090,2015
-ED,1050,1,Educ Orientation,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,rory phil tannebaum,ED-1050,2015
-ED,1050,3,Educ Orientation,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,rory phil tannebaum,ED-1050,2015
-ED,8380,400,Astronomy - Middle School Tch,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard dallm white,ED-8380,2015
-ED,8380,534,Literacy Lessons for Indiv II,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,jennifer adams,ED-8380,2015
-ED,8380,537,Literacy Lessons for Indiv II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,ED-8380,2015
-ED,8380,539,Literacy Lessons for Indiv II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jean ridley,ED-8380,2015
-ED,8600,400,Action Research,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,ED-8600,2015
-EDC,8060,1,Student Aff Issues,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,EDC-8060,2015
-EDC,8190,1,Cont College Student,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,EDC-8190,2015
-EDEC,4200,1,Early Childhood Science,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,EDEC-4200,2015
-EDEC,4500,1,EC Curric & Soc Stud Methods,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-4500,2015
-EDEL,3100,2,Arts in Ele School,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alison eliz leonard,EDEL-3100,2015
-EDEL,3210,1,Pe for the Elem Tchr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2015
-EDEL,4510,1,Elem Methods in Science Tchg,0.5,0.44,0.0,0.06,0.0,0.0,0.0,0.0,cynthia chri deaton,EDEL-4510,2015
-EDEL,4520,1,Elem Methods Math Teaching,0.71,0.19,0.0,0.1,0.0,0.0,0.0,0.0,andrew mic tyminski,EDEL-4520,2015
-EDEL,4670,1,Tchng Esol: Elem Sch,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDEL-4670,2015
-EDF,3010,1,Principles of American Educat,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,suzanne rosenblith,EDF-3010,2015
-EDF,3010,2,Principles of American Educat,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,patrick womac,EDF-3010,2015
-EDF,3020,1,Educ Psych,0.35,0.42,0.13,0.1,0.0,0.0,0.0,0.0,penelope mar vargas,EDF-3020,2015
-EDF,3340,1,Child Growth and Dev,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,EDF-3340,2015
-EDF,3350,1,Adol Growth & Dev,0.77,0.16,0.03,0.03,0.0,0.0,0.0,0.0,david barrett,EDF-3350,2015
-EDF,4800,3,Digital Media & Learning,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2015
-EDF,8770,500,Research Meth in Education I,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,david fleming,EDF-8770,2015
-EDF,8800,400,Dig Media for Mid Sch Teachers,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,ryan visser,EDF-8800,2015
-EDF,9270,1,Quant Rsrch & Stats for Ed,0.71,0.17,0.13,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,EDF-9270,2015
-EDF,9710,1,Cse Stdy Ethnog Mthd,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,cynthia chri deaton,EDF-9710,2015
-EDL,7150,500,Sch & Comm Relations,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth reynolds,EDL-7150,2015
-EDL,7300,501,Techniq of Supervision-Pub Sch,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,EDL-7300,2015
-EDL,7500,503,El Prin & Spv Ex I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,frederick buskey,EDL-7500,2015
-EDL,9050,400,Thry/Prac Ed Ldrshp,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,james satterfield,EDL-9050,2015
-EDL,9100,400,Intro Phd Seminar,0.62,0.23,0.0,0.0,0.0,0.0,0.0,0.15,leslie gonzales,EDL-9100,2015
-EDL,9110,400,Systematic Inq Ed L,0.76,0.06,0.06,0.0,0.0,0.0,0.0,0.12,jane lindle,EDL-9110,2015
-EDL,9760,1,External Effect He,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,leslie gonzales,EDL-9760,2015
-EDLT,4580,1,Early Literacy: Birth-Kindergn,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,barbara everson,EDLT-4580,2015
-EDLT,4620,1,Reading Children's Lit in Elem,0.68,0.23,0.05,0.05,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4620,2015
-EDLT,4620,2,Reading Children's Lit in Elem,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4620,2015
-EDLT,4630,1,Teaching Rdg/Writing for ELLs,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-4630,2015
-EDLT,8100,501,Foundations of Literacy,0.63,0.0,0.0,0.0,0.0,0.0,0.0,0.38,linda gambrell,EDLT-8100,2015
-EDLT,8670,400,Middle School Reading,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,phillip mich wilder,EDLT-8670,2015
-EDLT,8810,506,Reading Recovery Teacher II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vicki steadman,EDLT-8810,2015
-EDLT,8810,509,Reading Recovery Teacher II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jean floyd,EDLT-8810,2015
-EDLT,8830,506,Read Recovery Practicum II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vicki steadman,EDLT-8830,2015
-EDLT,8830,509,Read Recovery Practicum II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jean floyd,EDLT-8830,2015
-EDSC,4370,1,Technology in Math,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,corrie leigh martin,EDSC-4370,2015
-EDSP,3700,2,Intro to Special Ed,0.74,0.2,0.06,0.0,0.0,0.0,0.0,0.0,pamela stecker,EDSP-3700,2015
-EDSP,3700,3,Intro to Special Ed,0.77,0.14,0.06,0.0,0.03,0.0,0.0,0.0,joseph benedic ryan,EDSP-3700,2015
-EDSP,3730,1,Char & Instr of ID & Autism,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,EDSP-3730,2015
-EDSP,4910,1,Ed Assess Ind W/Dis,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,EDSP-4910,2015
-EDSP,8230,400,Tch Integrated Set,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,EDSP-8230,2015
-EES,2020,1,Environ Engr Fundamentals II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,EES-2020,2015
-EES,4010,1,Environmental Engr,0.51,0.44,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth carraway,EES-4010,2015
-EES,4010,2,Environmental Engr,0.24,0.59,0.15,0.0,0.02,0.0,0.0,0.0,mark schlautman,EES-4010,2015
-EES,4020,1,Water & Waste Water Treatment,0.44,0.25,0.13,0.0,0.06,0.0,0.0,0.13,david allen ladner,EES-4020,2015
-EES,4750,1,Capstone Design Project,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-4750,2015
-EES,4840,1,Solid Waste Mgt,0.35,0.35,0.23,0.07,0.0,0.0,0.0,0.0,thomas overcamp,EES-4840,2015
-EES,4850,1,Hazard Waste Management,0.19,0.5,0.25,0.06,0.0,0.0,0.0,0.0,mark schlautman,EES-4850,2015
-EES,8030,1,Phy/Chem Ops W/WW T,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,ezra lucas ho cates,EES-8030,2015
-EES,8040,1,Biochem Ops WW Trt,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,EES-8040,2015
-EES,8160,1,Technical Nuclear Forensics,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,lin shuller-nickles,EES-8160,2015
-EES,8420,1,Actinide Chemistry,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,brian powell,EES-8420,2015
-EES,8450,1,Environ Organic Chem,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,cindy lee,EES-8450,2015
-ELE,3010,1,Intro to Entre,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,ELE-3010,2015
-ELE,3010,2,Intro to Entre,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,ashley will parnell,ELE-3010,2015
-ELE,3010,3,Intro to Entre,0.77,0.2,0.03,0.0,0.0,0.0,0.0,0.0,john edward hopkins,ELE-3010,2015
-ELE,4010,1,Exec Lead & Entr II,0.78,0.23,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,ELE-4010,2015
-ENGL,1030,1,Accelerated Composition,0.52,0.38,0.05,0.0,0.05,0.0,0.0,0.0,andrew mathas,ENGL-1030,2015
-ENGL,1030,2,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,ENGL-1030,2015
-ENGL,1030,3,Accelerated Composition,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,chelsea mari clarey,ENGL-1030,2015
-ENGL,1030,4,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,dustin cleag mosley,ENGL-1030,2015
-ENGL,1030,5,Accelerated Composition,0.44,0.33,0.06,0.0,0.11,0.0,0.0,0.06,sarah ashto wickham,ENGL-1030,2015
-ENGL,1030,6,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,matthew mar russell,ENGL-1030,2015
-ENGL,1030,7,Accelerated Composition,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,ENGL-1030,2015
-ENGL,1030,8,Accelerated Composition,0.6,0.25,0.05,0.05,0.0,0.0,0.0,0.05,chelsea mari clarey,ENGL-1030,2015
-ENGL,1030,10,Accelerated Composition,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,sarah ashto wickham,ENGL-1030,2015
-ENGL,1030,13,Accelerated Composition,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,molly brian collins,ENGL-1030,2015
-ENGL,1030,16,Accelerated Composition,0.65,0.2,0.05,0.0,0.0,0.0,0.0,0.1,molly brian collins,ENGL-1030,2015
-ENGL,1030,17,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,ENGL-1030,2015
-ENGL,1030,18,Accelerated Composition,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,justin all holliday,ENGL-1030,2015
-ENGL,1030,19,Accelerated Composition,0.85,0.05,0.0,0.0,0.1,0.0,0.0,0.0,daniel frank,ENGL-1030,2015
-ENGL,1030,21,Accelerated Composition,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,katherine elrick,ENGL-1030,2015
-ENGL,1030,23,Accelerated Composition,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,adrian carson,ENGL-1030,2015
-ENGL,1030,24,Accelerated Composition,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,eda ozyesilpinar,ENGL-1030,2015
-ENGL,1030,25,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,ENGL-1030,2015
-ENGL,1030,26,Accelerated Composition,0.68,0.05,0.0,0.11,0.16,0.0,0.0,0.0,adrian carson,ENGL-1030,2015
-ENGL,1030,27,Accelerated Composition,0.68,0.05,0.21,0.0,0.0,0.0,0.0,0.05,daniel frank,ENGL-1030,2015
-ENGL,1030,28,Accelerated Composition,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,katherine elrick,ENGL-1030,2015
-ENGL,1030,29,Accelerated Composition,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,lauren taylo stukes,ENGL-1030,2015
-ENGL,1030,30,Accelerated Composition,0.89,0.0,0.05,0.05,0.0,0.0,0.0,0.0,joshua wood,ENGL-1030,2015
-ENGL,1030,32,Accelerated Composition,0.67,0.22,0.0,0.06,0.06,0.0,0.0,0.0,sarah michel naciuk,ENGL-1030,2015
-ENGL,1030,37,Accelerated Composition,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,ENGL-1030,2015
-ENGL,1030,39,Accelerated Composition,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,stephanie mic heath,ENGL-1030,2015
-ENGL,1030,42,Accelerated Composition,0.85,0.05,0.05,0.0,0.05,0.0,0.0,0.0,stephanie mic heath,ENGL-1030,2015
-ENGL,1030,44,Accelerated Composition,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,carlisle an sargent,ENGL-1030,2015
-ENGL,1030,47,Accelerated Composition,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,sarah kath melchers,ENGL-1030,2015
-ENGL,1030,49,Accelerated Composition,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,hayley ren zertuche,ENGL-1030,2015
-ENGL,1030,53,Accelerated Composition,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,hannah conl vaughan,ENGL-1030,2015
-ENGL,1030,54,Accelerated Composition,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,ENGL-1030,2015
-ENGL,1030,56,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,nathan riggs,ENGL-1030,2015
-ENGL,1030,57,Accelerated Composition,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katherine hanzalik,ENGL-1030,2015
-ENGL,1030,58,Accelerated Composition,0.18,0.18,0.29,0.06,0.24,0.0,0.0,0.06,justin all holliday,ENGL-1030,2015
-ENGL,1030,60,Accelerated Composition,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kristen gay,ENGL-1030,2015
-ENGL,1030,61,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-1030,2015
-ENGL,2120,1,World Literature,0.52,0.38,0.0,0.07,0.0,0.0,0.0,0.03,christopher benson,ENGL-2120,2015
-ENGL,2120,2,World Literature,0.76,0.1,0.05,0.0,0.1,0.0,0.0,0.0,andrew lemons,ENGL-2120,2015
-ENGL,2120,3,World Literature,0.17,0.38,0.21,0.0,0.17,0.0,0.0,0.08,david charles foltz,ENGL-2120,2015
-ENGL,2120,4,World Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-2120,2015
-ENGL,2120,5,World Literature,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-2120,2015
-ENGL,2120,7,World Literature,0.12,0.54,0.15,0.04,0.0,0.0,0.0,0.15,david charles foltz,ENGL-2120,2015
-ENGL,2120,9,World Literature,0.38,0.45,0.07,0.1,0.0,0.0,0.0,0.0,joshua nei waggoner,ENGL-2120,2015
-ENGL,2120,10,World Literature,0.14,0.61,0.21,0.0,0.0,0.0,0.0,0.04,joshua nei waggoner,ENGL-2120,2015
-ENGL,2120,11,World Literature,0.32,0.4,0.04,0.04,0.12,0.0,0.0,0.08,karen kettnich,ENGL-2120,2015
-ENGL,2120,12,World Literature,0.16,0.64,0.04,0.16,0.0,0.0,0.0,0.0,karen kettnich,ENGL-2120,2015
-ENGL,2120,13,World Literature,0.3,0.37,0.26,0.04,0.04,0.0,0.0,0.0,meg woosley-goodman,ENGL-2120,2015
-ENGL,2120,14,World Literature,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,meg woosley-goodman,ENGL-2120,2015
-ENGL,2120,15,World Literature,0.27,0.5,0.23,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2120,2015
-ENGL,2120,16,World Literature,0.48,0.33,0.15,0.04,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2120,2015
-ENGL,2120,17,World Literature,0.37,0.41,0.04,0.0,0.15,0.0,0.0,0.04,joshua nei waggoner,ENGL-2120,2015
-ENGL,2120,18,World Literature,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,ENGL-2120,2015
-ENGL,2130,1,British Literature,0.36,0.54,0.04,0.0,0.0,0.0,0.0,0.07,adrian paterson,ENGL-2130,2015
-ENGL,2130,2,British Literature,0.69,0.12,0.15,0.04,0.0,0.0,0.0,0.0,april susanne pelt,ENGL-2130,2015
-ENGL,2130,3,British Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,april susanne pelt,ENGL-2130,2015
-ENGL,2130,4,British Literature,0.54,0.32,0.04,0.07,0.0,0.0,0.0,0.04,april susanne pelt,ENGL-2130,2015
-ENGL,2130,5,British Literature,0.62,0.19,0.12,0.04,0.0,0.0,0.0,0.04,april susanne pelt,ENGL-2130,2015
-ENGL,2130,6,British Literature,0.2,0.44,0.2,0.0,0.08,0.0,0.0,0.08,meg woosley-goodman,ENGL-2130,2015
-ENGL,2130,7,British Literature,0.46,0.32,0.07,0.0,0.07,0.0,0.0,0.07,meg woosley-goodman,ENGL-2130,2015
-ENGL,2130,10,British Literature,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,ENGL-2130,2015
-ENGL,2130,11,British Literature,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2015
-ENGL,2130,12,British Literature,0.68,0.25,0.0,0.0,0.04,0.0,0.0,0.04,lucian ghita,ENGL-2130,2015
-ENGL,2130,13,British Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2015
-ENGL,2140,1,American Literature,0.04,0.71,0.25,0.0,0.0,0.0,0.0,0.0,rhondda robi thomas,ENGL-2140,2015
-ENGL,2140,2,American Literature,0.11,0.32,0.29,0.11,0.14,0.0,0.0,0.04,barbara ramirez,ENGL-2140,2015
-ENGL,2140,3,American Literature,0.12,0.46,0.35,0.04,0.04,0.0,0.0,0.0,barbara ramirez,ENGL-2140,2015
-ENGL,2140,4,American Literature,0.66,0.24,0.03,0.03,0.03,0.0,0.0,0.0,sharon kathl nalley,ENGL-2140,2015
-ENGL,2140,5,American Literature,0.76,0.17,0.0,0.03,0.03,0.0,0.0,0.0,sharon kathl nalley,ENGL-2140,2015
-ENGL,2140,6,American Literature,0.39,0.39,0.11,0.04,0.04,0.0,0.0,0.04,william stanton,ENGL-2140,2015
-ENGL,2140,7,American Literature,0.54,0.36,0.07,0.0,0.04,0.0,0.0,0.0,william stanton,ENGL-2140,2015
-ENGL,2140,8,American Literature,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,david stubblefield,ENGL-2140,2015
-ENGL,2140,9,American Literature,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,david stubblefield,ENGL-2140,2015
-ENGL,2140,11,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,ENGL-2140,2015
-ENGL,2140,12,American Literature,0.75,0.11,0.11,0.04,0.0,0.0,0.0,0.0,david stubblefield,ENGL-2140,2015
-ENGL,2140,13,American Literature,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-2140,2015
-ENGL,2140,14,American Literature,0.1,0.41,0.48,0.0,0.0,0.0,0.0,0.0,barbara ramirez,ENGL-2140,2015
-ENGL,2140,15,American Literature,0.44,0.19,0.19,0.11,0.0,0.0,0.0,0.07,meredith mccarroll,ENGL-2140,2015
-ENGL,2140,16,American Literature,0.29,0.43,0.21,0.0,0.04,0.0,0.0,0.04,susanna ashton,ENGL-2140,2015
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.72,0.24,0.0,0.0,0.03,0.0,0.0,0.0,nicholas chri brown,ENGL-2150,2015
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.0,0.48,0.44,0.04,0.0,0.0,0.0,0.04,amy monaghan,ENGL-2150,2015
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.04,0.52,0.41,0.0,0.04,0.0,0.0,0.0,amy monaghan,ENGL-2150,2015
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.52,0.33,0.11,0.0,0.04,0.0,0.0,0.0,sarah lauro,ENGL-2150,2015
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,sarah lauro,ENGL-2150,2015
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.14,0.48,0.28,0.0,0.0,0.0,0.0,0.1,david charles foltz,ENGL-2150,2015
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.61,0.25,0.07,0.07,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2015
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.57,0.32,0.07,0.04,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2015
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.83,0.07,0.03,0.0,0.07,0.0,0.0,0.0,alexander kudera,ENGL-2150,2015
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.2,0.68,0.04,0.0,0.0,0.0,0.0,0.08,david charles foltz,ENGL-2150,2015
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.45,0.31,0.1,0.1,0.03,0.0,0.0,0.0,andrew mathas,ENGL-2150,2015
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.55,0.28,0.07,0.03,0.07,0.0,0.0,0.0,andrew mathas,ENGL-2150,2015
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.31,0.5,0.12,0.04,0.04,0.0,0.0,0.0,matthew schilleman,ENGL-2150,2015
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.36,0.21,0.25,0.04,0.07,0.0,0.0,0.07,andrew mathas,ENGL-2150,2015
-ENGL,3000,1,Professional Develop,0.7,0.13,0.13,0.0,0.03,0.0,0.0,0.0,cameron fa bushnell,ENGL-3000,2015
-ENGL,3040,2,Business Writing,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,ENGL-3040,2015
-ENGL,3040,3,Business Writing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,ENGL-3040,2015
-ENGL,3040,4,Business Writing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3040,2015
-ENGL,3040,5,Business Writing,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3040,2015
-ENGL,3040,14,Business Writing,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-3040,2015
-ENGL,3040,15,Business Writing,0.7,0.15,0.1,0.0,0.0,0.0,0.0,0.05,philip randall,ENGL-3040,2015
-ENGL,3040,17,Business Writing,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-3040,2015
-ENGL,3040,18,Business Writing,0.4,0.5,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,ENGL-3040,2015
-ENGL,3100,1,Crit Writ Lit,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,david sweene coombs,ENGL-3100,2015
-ENGL,3100,2,Crit Writ Lit,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,dominic mastroianni,ENGL-3100,2015
-ENGL,3100,4,Crit Writ Lit,0.38,0.29,0.19,0.0,0.05,0.0,0.0,0.1,erin marina goss,ENGL-3100,2015
-ENGL,3120,1,Advanced Composition,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2015
-ENGL,3120,2,Advanced Composition,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2015
-ENGL,3140,2,Technical Writing,0.25,0.6,0.1,0.0,0.0,0.0,0.0,0.05,william pulley,ENGL-3140,2015
-ENGL,3140,3,Technical Writing,0.15,0.5,0.1,0.05,0.15,0.0,0.0,0.05,william pulley,ENGL-3140,2015
-ENGL,3140,4,Technical Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew schilleman,ENGL-3140,2015
-ENGL,3140,5,Technical Writing,0.32,0.58,0.0,0.0,0.0,0.0,0.0,0.11,matthew schilleman,ENGL-3140,2015
-ENGL,3140,7,Technical Writing,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,ENGL-3140,2015
-ENGL,3140,9,Technical Writing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-3140,2015
-ENGL,3140,10,Technical Writing,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2015
-ENGL,3140,11,Technical Writing,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2015
-ENGL,3140,12,Technical Writing,0.3,0.55,0.1,0.0,0.05,0.0,0.0,0.0,katalin beck,ENGL-3140,2015
-ENGL,3140,13,Technical Writing,0.2,0.55,0.25,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2015
-ENGL,3140,16,Technical Writing,0.75,0.15,0.05,0.0,0.05,0.0,0.0,0.0,lauren woolbright,ENGL-3140,2015
-ENGL,3140,17,Technical Writing,0.73,0.14,0.05,0.05,0.05,0.0,0.0,0.0,lauren woolbright,ENGL-3140,2015
-ENGL,3140,18,Technical Writing,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-3140,2015
-ENGL,3140,19,Technical Writing,0.78,0.17,0.0,0.06,0.0,0.0,0.0,0.0,matthew jose osborn,ENGL-3140,2015
-ENGL,3140,20,Technical Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,ENGL-3140,2015
-ENGL,3140,21,Technical Writing,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3140,2015
-ENGL,3140,22,Technical Writing,0.82,0.05,0.05,0.0,0.09,0.0,0.0,0.0,john conway,ENGL-3140,2015
-ENGL,3140,23,Technical Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-3140,2015
-ENGL,3150,1,Sci Writing & Comm,0.85,0.05,0.0,0.0,0.1,0.0,0.0,0.0,philip randall,ENGL-3150,2015
-ENGL,3150,5,Sci Writing & Comm,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3150,2015
-ENGL,3150,6,Sci Writing & Comm,0.4,0.4,0.1,0.05,0.0,0.0,0.0,0.05,william pulley,ENGL-3150,2015
-ENGL,3150,7,Sci Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-3150,2015
-ENGL,3150,19,Sci Writing & Comm,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-3150,2015
-ENGL,3150,20,Sci Writing & Comm,0.9,0.0,0.0,0.05,0.0,0.0,0.0,0.05,john conway,ENGL-3150,2015
-ENGL,3320,1,Visual Communication,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,megan eatman,ENGL-3320,2015
-ENGL,3450,1,Structure of Fiction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,ENGL-3450,2015
-ENGL,3460,1,Structure of Poetry,0.75,0.1,0.1,0.0,0.05,0.0,0.0,0.0,john logan pursley,ENGL-3460,2015
-ENGL,3480,1,Structure Screenplay,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,joshua nei waggoner,ENGL-3480,2015
-ENGL,3490,1,Tech/Pop Imagination,0.26,0.58,0.05,0.0,0.05,0.0,0.0,0.05,lindsay carr thomas,ENGL-3490,2015
-ENGL,3530,1,Ethnic Am Lit,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,angela naimou,ENGL-3530,2015
-ENGL,3570,1,Film,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2015
-ENGL,3850,1,Children's Lit,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,megan no macalystre,ENGL-3850,2015
-ENGL,3960,1,Brit Lit Survey I,0.2,0.3,0.4,0.0,0.05,0.0,0.0,0.05,erin marina goss,ENGL-3960,2015
-ENGL,3960,2,Brit Lit Survey I,0.25,0.15,0.4,0.05,0.0,0.0,0.0,0.15,erin marina goss,ENGL-3960,2015
-ENGL,3960,3,Brit Lit Survey I,0.35,0.2,0.15,0.15,0.1,0.0,0.0,0.05,erin marina goss,ENGL-3960,2015
-ENGL,3970,1,Brit Lit Survey II,0.52,0.33,0.1,0.0,0.05,0.0,0.0,0.0,david sweene coombs,ENGL-3970,2015
-ENGL,3980,1,Amer Lit Survey I,0.15,0.5,0.3,0.0,0.05,0.0,0.0,0.0,susanna ashton,ENGL-3980,2015
-ENGL,3990,1,Amer Lit Survey II,0.26,0.42,0.26,0.0,0.0,0.0,0.0,0.05,rhondda robi thomas,ENGL-3990,2015
-ENGL,4080,1,Chaucer,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,andrew lemons,ENGL-4080,2015
-ENGL,4110,1,Shakespeare,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william stockton,ENGL-4110,2015
-ENGL,4170,1,Victorian Period,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,ENGL-4170,2015
-ENGL,4200,1,Amer Lit to 1799,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,jonathan beec field,ENGL-4200,2015
-ENGL,4310,1,Modern Poetry,0.16,0.68,0.05,0.0,0.0,0.0,0.0,0.11,adrian paterson,ENGL-4310,2015
-ENGL,4320,1,Modern Fiction,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,angela naimou,ENGL-4320,2015
-ENGL,4400,1,Literary Theory,0.29,0.48,0.24,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,ENGL-4400,2015
-ENGL,4410,1,Literary Editing,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,wayne chapman,ENGL-4410,2015
-ENGL,4450,1,Fiction Workshop,0.46,0.31,0.15,0.08,0.0,0.0,0.0,0.0,keith morris,ENGL-4450,2015
-ENGL,4590,2,Spec Top Lang Criticism Theory,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,ENGL-4590,2015
-ENGL,4780,1,Digital Literacy,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,ENGL-4780,2015
-ENGL,4830,1,Af Am Lit 1920-Pres,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,garry bertholf,ENGL-4830,2015
-ENGL,4890,1,Topics Write & Publ,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,david blakesley,ENGL-4890,2015
-ENGL,4960,1,Senior Seminar,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,jonathan beec field,ENGL-4960,2015
-ENGL,4960,3,Senior Seminar,0.8,0.1,0.05,0.0,0.05,0.0,0.0,0.0,sean morey,ENGL-4960,2015
-ENGL,7000,1,Child Lit for Teach,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,lienne federico,ENGL-7000,2015
-ENGL,8080,1,Top Renaiss & Restoration Lit,0.5,0.25,0.13,0.0,0.13,0.0,0.0,0.0,william stockton,ENGL-8080,2015
-ENGL,8230,1,Topics American Lit Since 1865,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-8230,2015
-ENGL,8500,1,Methods Prof Comm,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,tharon howard,ENGL-8500,2015
-ENGR,1050,311,Engr Discipline & Skills I,0.18,0.23,0.25,0.2,0.07,0.0,0.0,0.08,john minor,ENGR-1050,2015
-ENGR,1050,312,Engr Discipline & Skills I,0.15,0.38,0.18,0.18,0.08,0.0,0.0,0.03,michael giebner,ENGR-1050,2015
-ENGR,1060,141,Engr Discipline & Skills II,0.07,0.36,0.32,0.07,0.11,0.0,0.0,0.07,steven brandon,ENGR-1060,2015
-ENGR,1060,241,Engr Discipline & Skills II,0.1,0.41,0.35,0.06,0.06,0.0,0.0,0.02,matthew kent miller,ENGR-1060,2015
-ENGR,1060,242,Engr Discipline & Skills II,0.1,0.3,0.36,0.06,0.08,0.0,0.0,0.1,matthew kent miller,ENGR-1060,2015
-ENGR,1060,311,Engr Discipline & Skills II,0.11,0.22,0.31,0.11,0.16,0.0,0.0,0.09,ashley childers,ENGR-1060,2015
-ENGR,1060,312,Engr Discipline & Skills II,0.15,0.12,0.22,0.22,0.12,0.0,0.0,0.17,michael giebner,ENGR-1060,2015
-ENGR,1060,341,Engr Discipline & Skills II,0.11,0.36,0.36,0.14,0.03,0.0,0.0,0.0,ashley childers,ENGR-1060,2015
-ENGR,1060,342,Engr Discipline & Skills II,0.15,0.4,0.31,0.1,0.02,0.0,0.0,0.02,ashley childers,ENGR-1060,2015
-ENGR,1060,343,Engr Discipline & Skills II,0.13,0.4,0.27,0.09,0.04,0.0,0.0,0.07,ashley childers,ENGR-1060,2015
-ENGR,1060,345,Engr Discipline & Skills II,0.06,0.38,0.34,0.06,0.03,0.0,0.0,0.13,elizabeth stephan,ENGR-1060,2015
-ENGR,1070,121,Program & Prob Solv I,0.04,0.31,0.38,0.19,0.04,0.0,0.0,0.04,erin jennife mccave,ENGR-1070,2015
-ENGR,1070,122,Program & Prob Solv I,0.17,0.29,0.35,0.15,0.02,0.0,0.0,0.02,erin jennife mccave,ENGR-1070,2015
-ENGR,1070,123,Program & Prob Solv I,0.15,0.38,0.23,0.15,0.02,0.0,0.0,0.08,christopher norfolk,ENGR-1070,2015
-ENGR,1070,124,Program & Prob Solv I,0.1,0.48,0.31,0.04,0.04,0.0,0.0,0.02,christopher norfolk,ENGR-1070,2015
-ENGR,1070,125,Program & Prob Solv I,0.13,0.26,0.38,0.13,0.0,0.0,0.0,0.11,erin jennife mccave,ENGR-1070,2015
-ENGR,1070,126,Program & Prob Solv I,0.17,0.27,0.31,0.15,0.0,0.0,0.0,0.1,erin jennife mccave,ENGR-1070,2015
-ENGR,1070,127,Program & Prob Solv I,0.21,0.34,0.32,0.06,0.04,0.0,0.0,0.02,william martin,ENGR-1070,2015
-ENGR,1070,128,Program & Prob Solv I,0.2,0.35,0.28,0.09,0.04,0.0,0.0,0.04,steven brandon,ENGR-1070,2015
-ENGR,1070,221,Programming & Prob Solving I,0.05,0.35,0.27,0.2,0.07,0.0,0.0,0.05,william martin,ENGR-1070,2015
-ENGR,1070,222,Programming & Prob Solving I,0.22,0.33,0.31,0.07,0.02,0.0,0.0,0.05,william martin,ENGR-1070,2015
-ENGR,1070,223,Programming & Prob Solving I,0.16,0.38,0.22,0.16,0.02,0.0,0.0,0.05,steven brandon,ENGR-1070,2015
-ENGR,1070,224,Programming & Prob Solving I,0.18,0.4,0.18,0.18,0.0,0.0,0.0,0.05,steven brandon,ENGR-1070,2015
-ENGR,1070,225,Programming & Prob Solving I,0.15,0.44,0.35,0.04,0.0,0.0,0.0,0.04,richard watkins,ENGR-1070,2015
-ENGR,1070,226,Programming & Prob Solving I,0.24,0.3,0.3,0.11,0.02,0.0,0.0,0.04,david ewing,ENGR-1070,2015
-ENGR,1070,241,Programming & Prob Solving I,0.07,0.49,0.36,0.0,0.04,0.0,0.0,0.04,matthew kent miller,ENGR-1070,2015
-ENGR,1070,242,Programming & Prob Solving I,0.0,0.34,0.44,0.13,0.06,0.0,0.0,0.03,matthew kent miller,ENGR-1070,2015
-ENGR,1070,321,Programming & Prob Solving I,0.15,0.38,0.36,0.02,0.02,0.0,0.0,0.08,william th kolodzey,ENGR-1070,2015
-ENGR,1070,322,Programming & Prob Solving I,0.33,0.3,0.2,0.1,0.05,0.0,0.0,0.02,elizabeth stephan,ENGR-1070,2015
-ENGR,1070,323,Programming & Prob Solving I,0.15,0.36,0.33,0.11,0.02,0.0,0.0,0.04,surya sharma,ENGR-1070,2015
-ENGR,1070,324,Programming & Prob Solving I,0.22,0.37,0.22,0.07,0.04,0.0,0.0,0.07,william park,ENGR-1070,2015
-ENGR,1070,325,Programming & Prob Solving I,0.21,0.44,0.19,0.1,0.0,0.0,0.0,0.06,william park,ENGR-1070,2015
-ENGR,1070,341,Programming & Prob Solving I,0.0,0.26,0.52,0.13,0.1,0.0,0.0,0.0,william martin,ENGR-1070,2015
-ENGR,1070,621,Program & Prob Solv I (HON),0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,david ewing,ENGR-1070,2015
-ENGR,1070,622,Program & Prob Solv I (HON),0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,david ewing,ENGR-1070,2015
-ENGR,1080,121,Program & Prob Solv II,0.06,0.31,0.39,0.14,0.06,0.0,0.0,0.06,erin jennife mccave,ENGR-1080,2015
-ENGR,1080,122,Program & Prob Solv II,0.08,0.47,0.21,0.21,0.03,0.0,0.0,0.0,erin jennife mccave,ENGR-1080,2015
-ENGR,1080,123,Program & Prob Solv II,0.05,0.36,0.31,0.15,0.05,0.0,0.0,0.08,christopher norfolk,ENGR-1080,2015
-ENGR,1080,124,Program & Prob Solv II,0.12,0.29,0.34,0.12,0.12,0.0,0.0,0.0,christopher norfolk,ENGR-1080,2015
-ENGR,1080,125,Program & Prob Solv II,0.11,0.28,0.36,0.11,0.14,0.0,0.0,0.0,erin jennife mccave,ENGR-1080,2015
-ENGR,1080,126,Program & Prob Solv II,0.16,0.43,0.3,0.08,0.03,0.0,0.0,0.0,erin jennife mccave,ENGR-1080,2015
-ENGR,1080,127,Program & Prob Solv II,0.12,0.49,0.2,0.12,0.05,0.0,0.0,0.02,christopher norfolk,ENGR-1080,2015
-ENGR,1080,128,Program & Prob Solv II,0.23,0.43,0.14,0.11,0.06,0.0,0.0,0.03,steven brandon,ENGR-1080,2015
-ENGR,1080,221,Programming & Prob Solving II,0.14,0.39,0.36,0.06,0.03,0.0,0.0,0.03,elizabeth stephan,ENGR-1080,2015
-ENGR,1080,222,Programming & Prob Solving II,0.21,0.32,0.26,0.15,0.04,0.0,0.0,0.02,steven brandon,ENGR-1080,2015
-ENGR,1080,223,Programming & Prob Solving II,0.14,0.5,0.21,0.02,0.1,0.0,0.0,0.02,elizabeth stephan,ENGR-1080,2015
-ENGR,1080,224,Programming & Prob Solving II,0.2,0.42,0.27,0.09,0.0,0.0,0.0,0.02,steven brandon,ENGR-1080,2015
-ENGR,1080,225,Programming & Prob Solving II,0.24,0.33,0.25,0.14,0.02,0.0,0.0,0.02,richard watkins,ENGR-1080,2015
-ENGR,1080,226,Programming & Prob Solving II,0.3,0.32,0.21,0.15,0.02,0.0,0.0,0.0,david ewing,ENGR-1080,2015
-ENGR,1080,321,Programming & Prob Solving II,0.09,0.29,0.22,0.27,0.11,0.0,0.0,0.02,william th kolodzey,ENGR-1080,2015
-ENGR,1080,322,Programming & Prob Solving II,0.33,0.35,0.25,0.04,0.0,0.0,0.0,0.02,elizabeth stephan,ENGR-1080,2015
-ENGR,1080,323,Programming & Prob Solving II,0.18,0.34,0.28,0.08,0.1,0.0,0.0,0.02,surya sharma,ENGR-1080,2015
-ENGR,1080,324,Programming & Prob Solving II,0.07,0.26,0.33,0.19,0.1,0.0,0.0,0.05,william park,ENGR-1080,2015
-ENGR,1080,325,Programming & Prob Solving II,0.07,0.42,0.24,0.13,0.07,0.0,0.0,0.07,william park,ENGR-1080,2015
-ENGR,1080,621,Program & Prob Solv II (HON),0.5,0.44,0.0,0.0,0.06,0.0,0.0,0.0,david ewing,ENGR-1080,2015
-ENGR,1080,622,Program & Prob Solv II (HON),0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,david ewing,ENGR-1080,2015
-ENGR,1090,132,Prog/Problem Solv Apps (RISE),0.23,0.66,0.05,0.02,0.0,0.0,0.0,0.05,christopher norfolk,ENGR-1090,2015
-ENGR,1090,133,Prog/Problem Solv Apps (RISE),0.24,0.59,0.17,0.0,0.0,0.0,0.0,0.0,surya sharma,ENGR-1090,2015
-ENGR,1090,134,Prog/Problem Solv Apps (RISE),0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,david ewing,ENGR-1090,2015
-ENGR,1090,231,Prog/Problem Solving Apps,0.28,0.51,0.21,0.0,0.0,0.0,0.0,0.0,william martin,ENGR-1090,2015
-ENGR,1090,232,Prog/Problem Solving Apps,0.41,0.52,0.07,0.0,0.0,0.0,0.0,0.0,william martin,ENGR-1090,2015
-ENGR,1090,233,Prog/Problem Solving Apps,0.38,0.47,0.06,0.04,0.0,0.0,0.0,0.04,david ewing,ENGR-1090,2015
-ENGR,1090,234,Prog/Problem Solving Apps,0.26,0.42,0.21,0.02,0.02,0.0,0.0,0.07,steven brandon,ENGR-1090,2015
-ENGR,1090,331,Prog/Problem Solving Apps,0.45,0.47,0.03,0.0,0.0,0.0,0.0,0.05,william th kolodzey,ENGR-1090,2015
-ENGR,1090,332,Prog/Problem Solving Apps,0.2,0.52,0.19,0.0,0.0,0.0,0.0,0.09,john minor,ENGR-1090,2015
-ENGR,1090,333,Prog/Problem Solving Apps,0.25,0.52,0.17,0.02,0.02,0.0,0.0,0.03,william park,ENGR-1090,2015
-ENGR,1090,334,Prog/Problem Solving Apps,0.11,0.26,0.57,0.06,0.0,0.0,0.0,0.0,william park,ENGR-1090,2015
-ENGR,1090,335,Prog/Problem Solving Apps,0.37,0.49,0.12,0.01,0.0,0.0,0.0,0.0,steven brandon,ENGR-1090,2015
-ENGR,1090,336,Prog/Problem Solving Apps,0.28,0.48,0.17,0.0,0.03,0.0,0.0,0.03,william park,ENGR-1090,2015
-ENGR,1090,337,Prog/Problem Solving Apps,0.41,0.54,0.05,0.0,0.0,0.0,0.0,0.0,steven brandon,ENGR-1090,2015
-ENGR,1090,338,Prog/Problem Solving Apps,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,william park,ENGR-1090,2015
-ENGR,1490,501,Introduction to Engineering,0.41,0.14,0.18,0.09,0.18,0.0,0.0,0.0,matthew kent miller,ENGR-1490,2015
-ENGR,1510,501,Engineering Skills,0.59,0.06,0.18,0.06,0.12,0.0,0.0,0.0,matthew kent miller,ENGR-1510,2015
-ENGR,1510,502,Engineering Skills,0.5,0.13,0.13,0.06,0.13,0.0,0.0,0.06,matthew kent miller,ENGR-1510,2015
-ENGR,1640,502,Engineering MATLAB Programming,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1640,2015
-ENGR,2080,181,Engr Graphics & Machine Design,0.52,0.31,0.12,0.02,0.02,0.0,0.0,0.0,john minor,ENGR-2080,2015
-ENGR,2080,182,Engr Graphics & Machine Design,0.55,0.32,0.07,0.02,0.02,0.0,0.0,0.02,sarah grigg,ENGR-2080,2015
-ENGR,2080,183,Engr Graphics & Machine Design,0.14,0.52,0.12,0.05,0.1,0.0,0.0,0.07,sarah grigg,ENGR-2080,2015
-ENGR,2080,184,Engr Graphics & Machine Design,0.34,0.41,0.09,0.05,0.02,0.0,0.0,0.09,sarah grigg,ENGR-2080,2015
-ENGR,2080,185,Engr Graphics & Machine Design,0.51,0.27,0.09,0.0,0.02,0.0,0.0,0.11,jonathan maier,ENGR-2080,2015
-ENGR,2080,281,Engr Graphics & Machine Design,0.67,0.22,0.07,0.0,0.02,0.0,0.0,0.03,john minor,ENGR-2080,2015
-ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.25,0.08,0.02,0.02,0.0,0.0,0.02,john minor,ENGR-2080,2015
-ENGR,2080,283,Engr Graphics & Machine Design,0.32,0.36,0.17,0.02,0.05,0.0,0.0,0.08,anthony pau garland,ENGR-2080,2015
-ENGR,2080,284,Engr Graphics & Machine Design,0.18,0.4,0.25,0.05,0.04,0.0,0.0,0.09,anthony pau garland,ENGR-2080,2015
-ENGR,2080,381,Engr Graphics & Machine Design,0.52,0.23,0.12,0.02,0.03,0.0,0.0,0.08,jonathan maier,ENGR-2080,2015
-ENGR,2100,101,CAD & Engineering Apllications,0.42,0.31,0.11,0.03,0.06,0.0,0.0,0.08,william martin,ENGR-2100,2015
-ENGR,2100,201,CAD & Engineering Apllications,0.76,0.1,0.02,0.02,0.02,0.0,0.0,0.08,mary kayla kilgo,ENGR-2100,2015
-ENGR,2100,202,CAD & Engineering Apllications,0.76,0.18,0.02,0.02,0.02,0.0,0.0,0.0,nighat yasmin,ENGR-2100,2015
-ENGR,2100,203,CAD & Engineering Apllications,0.62,0.28,0.04,0.0,0.02,0.0,0.0,0.04,nighat yasmin,ENGR-2100,2015
-ENGR,2200,1,Evaluating Innovations,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,sarah grigg,ENGR-2200,2015
-ENR,3020,1,Nat Res Measurements,0.33,0.42,0.18,0.03,0.03,0.0,0.0,0.0,lawrence gering,ENR-3020,2015
-ENR,4500,1,Conservation Issues,0.5,0.31,0.09,0.03,0.03,0.0,0.0,0.03,alan johnson,ENR-4500,2015
-ENR,4500,2,Conservation Issues,0.54,0.15,0.23,0.04,0.04,0.0,0.0,0.0,alan johnson,ENR-4500,2015
-ENSP,2000,1,Intro Environ Sci,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,scott brame,ENSP-2000,2015
-ENSP,2000,2,Intro Environ Sci,0.67,0.23,0.06,0.0,0.0,0.0,0.0,0.04,elizabeth carraway,ENSP-2000,2015
-ENSP,2000,3,Intro Environ Sci,0.79,0.15,0.06,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2015
-ENT,2000,1,Six-Legged Science,0.49,0.37,0.11,0.0,0.0,0.0,0.0,0.03,suellen pometto,ENT-2000,2015
-ENT,8100,3,Conservation Genetics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michael caterino,ENT-8100,2015
-ESED,8710,1,Engr & Sci Educ Research Meth,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,charity watson,ESED-8710,2015
-FCS,8340,3,Research Methods in FCS II,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0,james mcdonell,FCS-8340,2015
-FDSC,1020,1,Persp Food Nutrition,0.6,0.36,0.03,0.0,0.0,0.0,0.0,0.0,john mcgregor,FDSC-1020,2015
-FDSC,2140,1,Fd Resources & Soc,0.66,0.24,0.08,0.0,0.01,0.0,0.0,0.01,paul dawson,FDSC-2140,2015
-FDSC,2150,1,Culinary Fundamental,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,aubrey dean coffee,FDSC-2150,2015
-FDSC,4020,1,Food Chem II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,feng chen,FDSC-4020,2015
-FDSC,4030,1,Food Ch & Analysis,0.94,0.05,0.02,0.0,0.0,0.0,0.0,0.0,paul dawson,FDSC-4030,2015
-FDSC,4080,1,Food Process Eng,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,felix barron,FDSC-4080,2015
-FDSC,4090,1,TQM for Food & Pckg Industries,0.67,0.26,0.06,0.01,0.0,0.0,0.0,0.0,john mcgregor,FDSC-4090,2015
-FIN,3040,1,Risk & Insurance,0.13,0.45,0.37,0.05,0.0,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2015
-FIN,3050,1,Investment Analysis,0.21,0.29,0.36,0.05,0.07,0.0,0.0,0.02,kerri mcmillan,FIN-3050,2015
-FIN,3050,2,Investment Analysis,0.17,0.38,0.32,0.04,0.06,0.0,0.0,0.02,kerri mcmillan,FIN-3050,2015
-FIN,3050,3,Investment Analysis,0.19,0.51,0.28,0.02,0.0,0.0,0.0,0.0,kerri mcmillan,FIN-3050,2015
-FIN,3060,1,Corporation Finance,0.08,0.15,0.33,0.12,0.15,0.0,0.0,0.17,william hol johnson,FIN-3060,2015
-FIN,3060,2,Corporation Finance,0.1,0.12,0.16,0.22,0.16,0.0,0.0,0.22,william hol johnson,FIN-3060,2015
-FIN,3060,3,Corporation Finance,0.2,0.28,0.38,0.11,0.02,0.0,0.0,0.02,neil waller,FIN-3060,2015
-FIN,3060,4,Corporation Finance,0.26,0.38,0.27,0.08,0.0,0.0,0.0,0.02,neil waller,FIN-3060,2015
-FIN,3060,5,Corporation Finance,0.06,0.2,0.23,0.17,0.16,0.0,0.0,0.17,william hol johnson,FIN-3060,2015
-FIN,3060,6,Corporation Finance,0.28,0.37,0.19,0.07,0.05,0.0,0.0,0.04,neil waller,FIN-3060,2015
-FIN,3060,7,Corporation Finance,0.28,0.3,0.3,0.05,0.04,0.0,0.0,0.04,neil waller,FIN-3060,2015
-FIN,3070,1,Prin of Real Estate,0.24,0.22,0.35,0.13,0.07,0.0,0.0,0.0,ramon tolb franklin,FIN-3070,2015
-FIN,3070,2,Prin of Real Estate,0.21,0.26,0.39,0.11,0.0,0.02,0.0,0.02,thomas springer,FIN-3070,2015
-FIN,3080,1,Fin Inst & Mkts,0.3,0.34,0.32,0.05,0.0,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2015
-FIN,3080,2,Fin Inst & Mkts,0.41,0.41,0.15,0.0,0.0,0.0,0.0,0.03,daniel thoma greene,FIN-3080,2015
-FIN,3080,3,Fin Inst & Mkts,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.05,daniel thoma greene,FIN-3080,2015
-FIN,3110,1,Financial Management I,0.13,0.2,0.37,0.09,0.07,0.0,0.0,0.15,jack wolf,FIN-3110,2015
-FIN,3110,2,Financial Management I,0.19,0.33,0.37,0.02,0.0,0.0,0.0,0.09,george bra lockhart,FIN-3110,2015
-FIN,3110,3,Financial Management I,0.37,0.29,0.2,0.05,0.02,0.0,0.0,0.07,george bra lockhart,FIN-3110,2015
-FIN,3110,4,Financial Management I,0.23,0.43,0.28,0.0,0.0,0.0,0.0,0.08,george bra lockhart,FIN-3110,2015
-FIN,3120,1,Financial Mgt II,0.22,0.49,0.22,0.04,0.02,0.0,0.0,0.02,vincent intintoli,FIN-3120,2015
-FIN,3120,2,Financial Mgt II,0.14,0.34,0.26,0.09,0.09,0.0,0.0,0.09,angela morgan,FIN-3120,2015
-FIN,3120,3,Financial Mgt II,0.16,0.29,0.32,0.13,0.05,0.0,0.0,0.05,angela morgan,FIN-3120,2015
-FIN,3120,4,Financial Mgt II,0.15,0.45,0.27,0.03,0.09,0.0,0.0,0.0,vincent intintoli,FIN-3120,2015
-FIN,4040,1,Financial Modeling,0.12,0.38,0.35,0.15,0.0,0.0,0.0,0.0,jack wolf,FIN-4040,2015
-FIN,4040,2,Financial Modeling,0.27,0.56,0.17,0.0,0.0,0.0,0.0,0.0,jared daniel smith,FIN-4040,2015
-FIN,4040,3,Financial Modeling,0.15,0.59,0.24,0.03,0.0,0.0,0.0,0.0,jared daniel smith,FIN-4040,2015
-FIN,4050,1,Port Mgt and Theory,0.14,0.33,0.19,0.14,0.05,0.0,0.0,0.14,john alexander,FIN-4050,2015
-FIN,4050,2,Port Mgt and Theory,0.08,0.54,0.08,0.31,0.0,0.0,0.0,0.0,john alexander,FIN-4050,2015
-FIN,4080,1,Mgt of Fin Inst,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2015
-FIN,4080,2,Mgt of Fin Inst,0.5,0.19,0.31,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2015
-FIN,4110,1,Int Fin Mgt,0.1,0.41,0.33,0.13,0.03,0.0,0.0,0.0,tilan tang,FIN-4110,2015
-FIN,4110,2,Int Fin Mgt,0.11,0.37,0.31,0.06,0.03,0.0,0.0,0.11,tilan tang,FIN-4110,2015
-FIN,4150,1,Real Estate Investmt,0.29,0.5,0.14,0.0,0.07,0.0,0.0,0.0,thomas springer,FIN-4150,2015
-FIN,4160,1,Real Estate Val,0.58,0.08,0.33,0.0,0.0,0.0,0.0,0.0,ramon tolb franklin,FIN-4160,2015
-FNR,4700,35,Aquaponics,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,lance edwar beecher,FNR-4700,2015
-FNR,4990,1,Natural Resources Seminar,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william roc english,FNR-4990,2015
-FNR,4990,3,Natural Resources Seminar,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,william roc english,FNR-4990,2015
-FOR,1010,1,Intro to Forestry,0.69,0.23,0.0,0.08,0.0,0.0,0.0,0.0,lawrence gering,FOR-1010,2015
-FOR,2060,1,Forest Ecology,0.27,0.41,0.22,0.02,0.06,0.0,0.0,0.02,donald hagan,FOR-2060,2015
-FOR,3080,1,Remote Sensing,0.28,0.44,0.16,0.12,0.0,0.0,0.0,0.0,lawrence gering,FOR-3080,2015
-FOR,4060,1,For Watershed Mgmt,0.92,0.05,0.0,0.0,0.0,0.0,0.0,0.03,william roc english,FOR-4060,2015
-FOR,4080,1,Wood & Paper Product,0.5,0.37,0.1,0.03,0.0,0.0,0.0,0.0,patricia layton,FOR-4080,2015
-FOR,4150,1,For Wildlife Mgmt,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,james davis,FOR-4150,2015
-FOR,4180,1,For Res Valuation,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,thomas straka,FOR-4180,2015
-FOR,4250,1,For Res Mgt Plans,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,thomas straka,FOR-4250,2015
-FOR,4340,1,GIS for Landscape Planning,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,robert frit baldwin,FOR-4340,2015
-FOR,4650,1,Silviculture,0.29,0.38,0.29,0.04,0.0,0.0,0.0,0.0,gaofeng wang,FOR-4650,2015
-FOR,8930,22,Ecotoxicology,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john rodgers,FOR-8930,2015
-FR,1010,1,Elementary French,0.53,0.35,0.0,0.06,0.06,0.0,0.0,0.0,julian hamil killey,FR-1010,2015
-FR,1020,2,Elementary French,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2015
-FR,1020,3,Elementary French,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,amy lyn grif sawyer,FR-1020,2015
-FR,2010,1,Intermediate French,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2010,2015
-FR,2010,2,Intermediate French,0.6,0.25,0.05,0.05,0.05,0.0,0.0,0.0,amy lyn grif sawyer,FR-2010,2015
-FR,2010,4,Intermediate French,0.08,0.75,0.17,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-2010,2015
-FR,2020,1,Intermediate French,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-2020,2015
-FR,2020,2,Intermediate French,0.55,0.27,0.09,0.09,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-2020,2015
-FR,2020,3,Intermediate French,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,kelly digby peebles,FR-2020,2015
-FR,2020,4,Intermediate French,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,FR-2020,2015
-FR,3050,1,Int Fr Con & Comp I,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,FR-3050,2015
-FR,3120,1,Writing in French I,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,kenneth dav widgren,FR-3120,2015
-FR,3160,1,Fr for Intl Trade,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,eric touya,FR-3160,2015
-FR,4100,1,Francophone Lit,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,FR-4100,2015
-GC,1010,1,Orientation to G C,0.76,0.13,0.03,0.0,0.03,0.0,0.0,0.05,kern cox,GC-1010,2015
-GC,1020,1,Comp Art & Cad Found,0.38,0.29,0.05,0.1,0.14,0.0,0.0,0.05,charles tabor weiss,GC-1020,2015
-GC,1020,2,Comp Art & Cad Found,0.64,0.18,0.09,0.05,0.0,0.0,0.0,0.05,carol jones,GC-1020,2015
-GC,1030,1,G C I for Pkgsc,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,john jacobs,GC-1030,2015
-GC,1030,2,G C I for Pkgsc,0.08,0.54,0.23,0.08,0.08,0.0,0.0,0.0,john jacobs,GC-1030,2015
-GC,1040,1,Graphic Communications I,0.53,0.31,0.09,0.03,0.02,0.0,0.0,0.01,rebecca suza edlein,GC-1040,2015
-GC,1990,4,CI in GC I-J Lay CS,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,janice ann lay,GC-1990,2015
-GC,2070,1,Graphic Communications II,0.6,0.31,0.06,0.0,0.03,0.0,0.0,0.0,patrick gee rose,GC-2070,2015
-GC,3400,1,Digital Img & Emedia,0.44,0.4,0.13,0.0,0.02,0.0,0.0,0.02,erica black walker,GC-3400,2015
-GC,4060,1,Package and Specialty Printing,0.25,0.6,0.1,0.0,0.03,0.0,0.0,0.03,kern cox,GC-4060,2015
-GC,4400,1,Commercial Printing,0.62,0.35,0.0,0.0,0.0,0.0,0.0,0.03,eric weisenmiller,GC-4400,2015
-GC,4440,1,Current Dev in G C,0.24,0.41,0.28,0.07,0.0,0.0,0.0,0.0,liam henry 'hara,GC-4440,2015
-GC,4460,1,Ink & Substrates,0.13,0.71,0.09,0.04,0.0,0.0,0.0,0.02,liam henry 'hara,GC-4460,2015
-GC,4480,1,Plan and Cont Print,0.8,0.1,0.05,0.05,0.0,0.0,0.0,0.0,john leininger,GC-4480,2015
-GC,4900,2,G C Selected Topics-Sales,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,john leininger,GC-4900,2015
-GEN,3000,1,Fundamental Genetics,0.33,0.27,0.27,0.08,0.02,0.0,0.0,0.04,kate leanne wi tsai,GEN-3000,2015
-GEN,3000,2,Fundamental Genetics,0.4,0.4,0.13,0.04,0.01,0.0,0.0,0.02,haiying liang,GEN-3000,2015
-GEN,4100,1,Population & Quant Genetics,0.4,0.4,0.03,0.09,0.06,0.0,0.0,0.03,amy lou lawton rauh,GEN-4100,2015
-GEN,4110,1,Popultn & Quant Genetics Lab,0.6,0.2,0.0,0.1,0.0,0.0,0.0,0.1,amy lou lawton rauh,GEN-4110,2015
-GEN,4110,2,Popultn & Quant Genetics Lab,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,amy lou lawton rauh,GEN-4110,2015
-GEN,4110,3,Population and Quant Gen Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,GEN-4110,2015
-GEN,4700,1,Human Genetics,0.46,0.38,0.11,0.03,0.0,0.0,0.0,0.03,leigh anne clark,GEN-4700,2015
-GEOG,1010,1,Intro to Geography,0.28,0.4,0.28,0.05,0.0,0.0,0.0,0.0,christa smith,GEOG-1010,2015
-GEOG,1030,1,World Regional Geog,0.82,0.12,0.04,0.02,0.0,0.0,0.0,0.0,lance forres howard,GEOG-1030,2015
-GEOG,1030,2,World Regional Geog,0.38,0.35,0.15,0.03,0.0,0.0,0.0,0.1,william churc terry,GEOG-1030,2015
-GEOG,3050,1,Cultural Geography,0.83,0.06,0.0,0.06,0.06,0.0,0.0,0.0,lance forres howard,GEOG-3050,2015
-GEOL,1010,1,Physical Geology,0.39,0.32,0.14,0.06,0.05,0.0,0.0,0.03,alan coulson,GEOL-1010,2015
-GEOL,1010,2,Physical Geology,0.38,0.36,0.17,0.03,0.01,0.0,0.0,0.05,alan coulson,GEOL-1010,2015
-GEOL,1030,1,Physical Geol Lab,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2015
-GEOL,1030,2,Physical Geol Lab,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2015
-GEOL,1030,3,Physical Geol Lab,0.3,0.57,0.09,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2015
-GEOL,1030,4,Physical Geol Lab,0.3,0.52,0.13,0.04,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2015
-GEOL,1030,5,Physical Geol Lab,0.52,0.22,0.17,0.04,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2015
-GEOL,1030,6,Physical Geol Lab,0.59,0.18,0.14,0.0,0.0,0.0,0.0,0.09,alan coulson,GEOL-1030,2015
-GEOL,1030,7,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2015
-GEOL,1030,8,Physical Geol Lab,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2015
-GEOL,1030,9,Physical Geol Lab,0.27,0.5,0.18,0.0,0.0,0.0,0.0,0.05,alan coulson,GEOL-1030,2015
-GEOL,1030,10,Physical Geol Lab,0.42,0.46,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2015
-GEOL,1030,11,Physical Geol Lab,0.54,0.29,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,GEOL-1030,2015
-GEOL,1120,1,Earth Resources,0.72,0.19,0.09,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-1120,2015
-GEOL,1140,1,Earth Resources Lab,0.68,0.1,0.16,0.03,0.0,0.0,0.0,0.03,scott brame,GEOL-1140,2015
-GEOL,2020,1,Earth History,0.17,0.44,0.17,0.06,0.11,0.0,0.0,0.06,alan coulson,GEOL-2020,2015
-GEOL,3750,1,Bahamian Field Study,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,james castle,GEOL-3750,2015
-GEOL,4050,1,Surficial Geology,0.31,0.38,0.25,0.0,0.06,0.0,0.0,0.0,james castle,GEOL-4050,2015
-GEOL,4090,1,Envir & Exploration Geophysics,0.53,0.18,0.06,0.0,0.12,0.0,0.0,0.12,stephen mich moysey,GEOL-4090,2015
-GEOL,4210,1,Gis in Geology,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-4210,2015
-GEOL,6210,1,Gis in Geology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-6210,2015
-GEOL,7900,501,Biogeography & Geology of SC,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,GEOL-7900,2015
-GEOL,8080,1,Groundwater Modeling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,GEOL-8080,2015
-GER,1010,1,Elementary German,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,oswald harris king,GER-1010,2015
-GER,1010,2,Elementary German,0.55,0.25,0.1,0.0,0.0,0.0,0.0,0.1,oswald harris king,GER-1010,2015
-GER,1020,1,Elementary German,0.06,0.38,0.19,0.19,0.19,0.0,0.0,0.0, lee ferrell,GER-1020,2015
-GER,1020,2,Elementary German,0.18,0.29,0.41,0.06,0.0,0.0,0.0,0.06, lee ferrell,GER-1020,2015
-GER,2010,1,Intermediate German,0.3,0.2,0.3,0.1,0.0,0.0,0.0,0.1,gabriela stoicea,GER-2010,2015
-GER,2010,2,Intermediate German,0.21,0.29,0.36,0.0,0.0,0.0,0.0,0.14,gabriela stoicea,GER-2010,2015
-GER,2020,1,Intermediate German,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-2020,2015
-GER,3160,1,Ger for Intl Trade I,0.58,0.0,0.33,0.08,0.0,0.0,0.0,0.0, lee ferrell,GER-3160,2015
-GER,3400,1,German Culture,0.45,0.25,0.1,0.05,0.0,0.0,0.0,0.15,oswald harris king,GER-3400,2015
-HCC,8810,1,Affective Computing,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,shaundra daily,HCC-8810,2015
-HCC,8810,3,Measurement & Eval,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,HCC-8810,2015
-HEHD,3990,2,Students Helping Students Peer,0.85,0.1,0.03,0.0,0.0,0.0,0.0,0.03,mary mcp von kaenel,HEHD-3990,2015
-HEHD,4000,1,Intro Leadership Theor & Conc,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lori marlise pindar,HEHD-4000,2015
-HEHD,4990,5,The Global Community,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mark small,HEHD-4990,2015
-HEHD,8010,230,Child/Adolescent Dev,0.76,0.14,0.05,0.0,0.0,0.0,0.0,0.05,edmond patri bowers,HEHD-8010,2015
-HEHD,8040,230,Assessment/Eval,0.61,0.26,0.04,0.0,0.0,0.0,0.0,0.09,barry garst,HEHD-8040,2015
-HEHD,8880,400,Special Topics Youth Dev Ldshp,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,HEHD-8880,2015
-HIST,1010,1,Hist of the U S,0.41,0.43,0.11,0.0,0.05,0.0,0.0,0.0,lee brady wilson,HIST-1010,2015
-HIST,1220,1,"Hist, Tech & Society",0.41,0.32,0.13,0.02,0.06,0.0,0.0,0.06,pamela mack,HIST-1220,2015
-HIST,1240,1,Environmental Hist,0.14,0.54,0.27,0.03,0.0,0.0,0.0,0.03,james brad jeffries,HIST-1240,2015
-HIST,1240,2,Environmental Hist,0.05,0.38,0.4,0.03,0.05,0.0,0.0,0.1,james brad jeffries,HIST-1240,2015
-HIST,1720,1,The West and the World I,0.26,0.41,0.18,0.08,0.03,0.0,0.0,0.05,caroline dunn clark,HIST-1720,2015
-HIST,1730,1,The West and the World II,0.3,0.32,0.21,0.0,0.1,0.0,0.0,0.07, alan grubb,HIST-1730,2015
-HIST,1730,2,The West and the World II,0.32,0.24,0.27,0.07,0.04,0.0,0.0,0.07,richard saunders,HIST-1730,2015
-HIST,1730,3,The West and the World II,0.25,0.44,0.2,0.02,0.07,0.0,0.0,0.02,steven marks,HIST-1730,2015
-HIST,2990,1,Historian's Craft,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth carney,HIST-2990,2015
-HIST,2990,2,Historian's Craft,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,rachel anne moore,HIST-2990,2015
-HIST,3010,1,Am Rev & New Nation,0.26,0.19,0.33,0.0,0.15,0.0,0.0,0.07,james brad jeffries,HIST-3010,2015
-HIST,3080,1,US: Reagan/Clinton 1975-Pres,0.4,0.27,0.18,0.0,0.13,0.0,0.0,0.02,richard saunders,HIST-3080,2015
-HIST,3110,1,African American Hist to 1877,0.35,0.43,0.08,0.08,0.05,0.0,0.0,0.03,abel bartley,HIST-3110,2015
-HIST,3240,1,Hist of the South II,0.32,0.49,0.08,0.03,0.05,0.0,0.0,0.03,john andrew,HIST-3240,2015
-HIST,3260,1,Hist Am Transport,0.38,0.31,0.23,0.0,0.0,0.0,0.0,0.08, roger grant,HIST-3260,2015
-HIST,3290,1,US Legal History Since 1890,0.15,0.05,0.2,0.2,0.0,0.0,0.0,0.4,maribel morey,HIST-3290,2015
-HIST,3380,1,Africa to 1875,0.63,0.2,0.07,0.1,0.0,0.0,0.0,0.0,james burns,HIST-3380,2015
-HIST,3410,1,Modern Mexico,0.49,0.4,0.0,0.03,0.06,0.0,0.0,0.03,rachel anne moore,HIST-3410,2015
-HIST,3870,1,Russian Rev,0.37,0.33,0.23,0.0,0.0,0.0,0.0,0.07,steven marks,HIST-3870,2015
-HIST,3890,2,Monarchs & Courtiers,0.77,0.15,0.0,0.08,0.0,0.0,0.0,0.0,caroline dunn clark,HIST-3890,2015
-HIST,3900,1,Mod Mil Hist,0.19,0.31,0.36,0.08,0.03,0.0,0.0,0.03,edwin moise,HIST-3900,2015
-HIST,3970,1,Modern Middle East,0.62,0.32,0.03,0.0,0.0,0.0,0.0,0.03,amit bein,HIST-3970,2015
-HIST,4000,1,Battleground/Bloodfield RecnSC,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,paul chris anderson,HIST-4000,2015
-HIST,4170,1,History and Tourism,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,leslie white,HIST-4170,2015
-HIST,4510,1,Alexander the Great,0.45,0.25,0.2,0.0,0.1,0.0,0.0,0.0,elizabeth carney,HIST-4510,2015
-HIST,4710,1,20th C France,0.57,0.21,0.0,0.0,0.0,0.0,0.0,0.21, alan grubb,HIST-4710,2015
-HIST,4900,3,Food In Preindus,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,HIST-4900,2015
-HIST,4900,4,Why Germans > Nazi?,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,michael meng,HIST-4900,2015
-HIST,4920,1,US Iraq Wars,0.1,0.6,0.1,0.0,0.0,0.0,0.0,0.2,edwin moise,HIST-4920,2015
-HIST,4930,1,Native American History - 1840,0.4,0.3,0.2,0.1,0.0,0.0,0.0,0.0,james brad jeffries,HIST-4930,2015
-HIST,8200,1,Amer Historiography,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,john andrew,HIST-8200,2015
-HLTH,2020,1,Introduction to Public Health,0.46,0.35,0.15,0.0,0.04,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2015
-HLTH,2020,2,Introduction to Public Health,0.38,0.35,0.19,0.05,0.0,0.0,0.0,0.03,jeffrey kingree,HLTH-2020,2015
-HLTH,2020,400,Introduction to Public Health,0.57,0.24,0.05,0.0,0.1,0.0,0.0,0.05,ralph stewart welsh,HLTH-2020,2015
-HLTH,2030,1,Health Care Sys,0.74,0.23,0.0,0.0,0.0,0.0,0.0,0.03,ralph stewart welsh,HLTH-2030,2015
-HLTH,2030,2,Health Care Sys,0.38,0.48,0.12,0.0,0.0,0.0,0.0,0.02,frederic fraizer,HLTH-2030,2015
-HLTH,2030,400,Health Care Sys,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,HLTH-2030,2015
-HLTH,2030,401,Health Care Sys,0.78,0.06,0.0,0.0,0.06,0.0,0.0,0.11,ralph stewart welsh,HLTH-2030,2015
-HLTH,2400,1,Deter of Hlth Behav,0.29,0.51,0.15,0.03,0.03,0.0,0.0,0.0,joel edwar williams,HLTH-2400,2015
-HLTH,2980,1,Human Hlth & Disease,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,HLTH-2980,2015
-HLTH,2980,2,Human Hlth & Disease,0.74,0.21,0.02,0.0,0.0,0.0,0.0,0.02,annah kamugiz amani,HLTH-2980,2015
-HLTH,3100,1,Women's Hlth Issues,0.5,0.41,0.03,0.03,0.0,0.0,0.0,0.03,rachel mayo,HLTH-3100,2015
-HLTH,3150,1,Social Epidemiology,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,lee alden crandall,HLTH-3150,2015
-HLTH,3800,1,Epidemiology,0.37,0.34,0.17,0.05,0.02,0.0,0.0,0.05,rachel mayo,HLTH-3800,2015
-HLTH,3800,2,Epidemiology,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-3800,2015
-HLTH,3980,2,Hlth Appraisal Sklls,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2015
-HLTH,4000,1,Health Systems Reform,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lingling zhang,HLTH-4000,2015
-HLTH,4190,1,Health Sci Internship Prep Sem,0.44,0.34,0.12,0.05,0.02,0.0,0.0,0.02,kathleen meyer,HLTH-4190,2015
-HLTH,4200,1,Hlth Science Intern,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,kathleen meyer,HLTH-4200,2015
-HLTH,4300,1,Hlth Prom of Aged,0.52,0.22,0.17,0.04,0.0,0.0,0.0,0.04,cheryl jo dye,HLTH-4300,2015
-HLTH,4310,1,Public & Environ Hlt,0.53,0.36,0.11,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-4310,2015
-HLTH,4600,1,Health Info Systems,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,ronald gimbel,HLTH-4600,2015
-HLTH,4780,1,Hlth Pol Ehtics Law,0.07,0.45,0.31,0.03,0.03,0.0,0.0,0.1,hugh spitler,HLTH-4780,2015
-HLTH,4790,1,Fin Mgmt & Hlth Budg,0.22,0.52,0.13,0.04,0.09,0.0,0.0,0.0,khoa dang truong,HLTH-4790,2015
-HLTH,4800,1,Comm Hlth Promotion,0.24,0.74,0.0,0.0,0.0,0.0,0.0,0.03,sarah griffin,HLTH-4800,2015
-HLTH,4900,1,Res Eval St Pub Hlth,0.87,0.06,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,HLTH-4900,2015
-HLTH,4900,2,Res Eval St Pub Hlth,0.37,0.53,0.1,0.0,0.0,0.0,0.0,0.0,lingling zhang,HLTH-4900,2015
-HLTH,4970,1,Creative Inq in Public Health,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,karen kemper,HLTH-4970,2015
-HLTH,4970,4,Creative Inq in Public Health,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,george clay,HLTH-4970,2015
-HLTH,8110,1,Health Care Delivery Systems,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,khoa dang truong,HLTH-8110,2015
-HLTH,8310,1,Quantitative Analy in Hlth I,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,lu shi,HLTH-8310,2015
-HON,2060,1,Intro to Nanotechnology,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,christophe kitchens,HON-2060,2015
-HON,2210,1,Beauty in Western Literature,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,johannes schmidt,HON-2210,2015
-HON,2210,3,Reading Data,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,lindsay carr thomas,HON-2210,2015
-HON,2220,2,Doubles and Doppelgangers,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,HON-2220,2015
-HORT,1010,1,Horticulture,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,HORT-1010,2015
-HORT,2110,1,Growing Spring Plnts,0.15,0.3,0.45,0.05,0.0,0.0,0.0,0.05,james emerson faust,HORT-2110,2015
-HORT,4000,4,Vegetable Crops,0.73,0.21,0.06,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,HORT-4000,2015
-HORT,4040,1,Plant Propagation,0.13,0.25,0.46,0.08,0.04,0.0,0.0,0.04,jeffrey adelberg,HORT-4040,2015
-HORT,4050,1,Plant Propagation Techniq Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,HORT-4050,2015
-HORT,4050,2,Plant Propagation Techniq Lab,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,jeffrey adelberg,HORT-4050,2015
-HORT,4270,1,Urban Tree Care,0.24,0.36,0.2,0.08,0.08,0.0,0.0,0.04,robert polomski,HORT-4270,2015
-HORT,4330,1,Turf Weed Management,0.16,0.52,0.24,0.04,0.04,0.0,0.0,0.0,ted whitwell,HORT-4330,2015
-HRD,8470,405,Instru System Design,0.75,0.0,0.0,0.0,0.25,0.0,0.0,0.0,philip mcgee,HRD-8470,2015
-HRD,8490,402,Eval of T&D/Hrd Prog,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,HRD-8490,2015
-HRD,8490,405,Eval of T&D/Hrd Prog,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,philip mcgee,HRD-8490,2015
-HRD,8490,406,Eval of T&D/Hrd Prog,0.38,0.38,0.13,0.0,0.13,0.0,0.0,0.0,philip mcgee,HRD-8490,2015
-HRD,8800,404,Research Concepts,0.94,0.0,0.0,0.0,0.06,0.0,0.0,0.0,jon fr christiansen,HRD-8800,2015
-HRD,8970,402,Appl Resear & Devel,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,cynthia sims,HRD-8970,2015
-HRD,8970,403,Appl Resear & Devel,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,cynthia sims,HRD-8970,2015
-IE,2010,1,Systems Design I,0.74,0.24,0.0,0.0,0.0,0.0,0.0,0.01,robert james riggs,IE-2010,2015
-IE,2100,1,Des Analysis Wrk Sys,0.16,0.52,0.24,0.04,0.02,0.0,0.0,0.02,david neyens,IE-2100,2015
-IE,2800,1,Deterministic Operations Rsrch,0.2,0.25,0.38,0.09,0.04,0.0,0.0,0.05,burak eksioglu,IE-2800,2015
-IE,3610,1,Industrial App of Prob/Stat II,0.42,0.42,0.09,0.03,0.03,0.0,0.0,0.0,joel greenstein,IE-3610,2015
-IE,3810,1,Probabilistic Operations Rsrch,0.26,0.44,0.2,0.06,0.05,0.0,0.0,0.0,amin khademi,IE-3810,2015
-IE,3840,1,Engr Econ Analysis,0.29,0.23,0.12,0.07,0.1,0.0,0.0,0.18,brian melloy,IE-3840,2015
-IE,3860,1,Prod Plan & Cont,0.43,0.41,0.11,0.02,0.02,0.0,0.0,0.01,robert james riggs,IE-3860,2015
-IE,4570,1,Transp/Logistic Engr,0.34,0.4,0.11,0.14,0.0,0.0,0.0,0.0,sandra dun eksioglu,IE-4570,2015
-IE,4620,1,Six Sigma Quality,0.25,0.39,0.27,0.03,0.0,0.04,0.0,0.01,byung rae cho,IE-4620,2015
-IE,4670,1,System Design II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,IE-4670,2015
-IE,4860,1,Scheduling,0.29,0.5,0.14,0.07,0.0,0.0,0.0,0.0,scott jenning mason,IE-4860,2015
-IE,4910,2,HF in Transportation Systems,0.64,0.26,0.1,0.0,0.0,0.0,0.0,0.0,david neyens,IE-4910,2015
-IE,6810,1,App of Prob Models in Ind Engr,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,brian melloy,IE-6810,2015
-IE,6860,1,Scheduling,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-6860,2015
-IE,8010,1,Human-Machine Sys,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,IE-8010,2015
-IE,8040,1,Mfg Sys Plan & Des,0.12,0.31,0.19,0.0,0.19,0.0,0.0,0.19,william ferrell,IE-8040,2015
-IE,8050,1,Found Qual Engr,0.42,0.46,0.13,0.0,0.0,0.0,0.0,0.0,byung rae cho,IE-8050,2015
-IE,8150,1,Research Methods in Ergonomics,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,sara lu riggs,IE-8150,2015
-IE,8520,1,Model Decis Making,0.8,0.15,0.02,0.0,0.0,0.0,0.0,0.02,jonathan cole smith,IE-8520,2015
-IE,8540,1,Fund of Sc and Log,0.74,0.14,0.05,0.0,0.0,0.0,0.0,0.07,william ferrell,IE-8540,2015
-IE,8580,1,Case Stu Cap Prof Sc,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-8580,2015
-IE,8810,1,Metaheuristics,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,IE-8810,2015
-IE,8880,1,Adv Prob Methods,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,burak eksioglu,IE-8880,2015
-INT,1010,5,UPIC 1st Part Time Internship,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.01,troy nunamaker,INT-1010,2015
-INT,2020,5,UPIC 2nd Full Time Internship,0.0,0.0,0.0,0.0,0.0,0.77,0.15,0.08,troy nunamaker,INT-2020,2015
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.84,0.12,0.03,meredith fan wilson,IS-1010,2015
-IS,2100,615,Sel Topics Int Study,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sallie bro turnbull,IS-2100,2015
-ITAL,1010,1,Elementary Italian,0.48,0.29,0.1,0.0,0.05,0.0,0.0,0.1,julia schmidt,ITAL-1010,2015
-ITAL,1020,1,Elementary Italian,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,luca barattoni,ITAL-1020,2015
-ITAL,1020,3,Elementary Italian,0.33,0.4,0.27,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-1020,2015
-ITAL,2010,1,Intermediate Italian,0.23,0.38,0.31,0.08,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2010,2015
-ITAL,2020,1,Intermediate Italian,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2020,2015
-ITAL,2020,2,Intermediate Italian,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2020,2015
-JAPN,1010,1,Elementary Japanese,0.43,0.0,0.21,0.07,0.07,0.0,0.0,0.21,kazuko shoji,JAPN-1010,2015
-JAPN,1010,2,Elementary Japanese,0.53,0.24,0.06,0.06,0.0,0.0,0.0,0.12,toshiko kishimoto,JAPN-1010,2015
-JAPN,1020,1,Elementary Japanese,0.5,0.25,0.08,0.0,0.08,0.0,0.0,0.08,toshiko joerger,JAPN-1020,2015
-JAPN,1020,2,Elementary Japanese,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,toshiko joerger,JAPN-1020,2015
-JAPN,2020,1,Intermed Japanese,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,kazuko shoji,JAPN-2020,2015
-JAPN,3060,1,Japanese Conversation & Comp,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,toshiko kishimoto,JAPN-3060,2015
-LARC,1160,1,History of Landscape Architect,0.39,0.3,0.16,0.08,0.01,0.0,0.0,0.06,hala fouad nassar,LARC-1160,2015
-LARC,1160,2,History of Larch,0.59,0.35,0.02,0.04,0.0,0.0,0.0,0.0,martin john holland,LARC-1160,2015
-LARC,1520,1,Basic Design II,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,paul russell,LARC-1520,2015
-LARC,4280,1,Comput Aided Design,0.5,0.44,0.0,0.0,0.06,0.0,0.0,0.0,shan jiang,LARC-4280,2015
-LARC,6530,1,Key Issues in Larch,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,LARC-6530,2015
-LARC,8300,1,Grad Seminar I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,LARC-8300,2015
-LAW,3220,1,Legal Env of Bus,0.3,0.6,0.08,0.02,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2015
-LAW,3220,2,Legal Env of Bus,0.32,0.48,0.12,0.06,0.02,0.0,0.0,0.0,edward ray claggett,LAW-3220,2015
-LAW,3220,3,Legal Env of Bus,0.39,0.52,0.06,0.03,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2015
-LAW,3220,4,Legal Env of Bus,0.45,0.38,0.14,0.03,0.0,0.0,0.0,0.0,melvin stith,LAW-3220,2015
-LAW,3220,5,Legal Env of Bus,0.44,0.34,0.13,0.05,0.03,0.0,0.0,0.02,melvin stith,LAW-3220,2015
-LAW,3220,6,Legal Env of Bus,0.16,0.3,0.21,0.09,0.05,0.0,0.0,0.19,virgini ward-vaughn,LAW-3220,2015
-LAW,3220,7,Legal Env of Bus,0.11,0.54,0.19,0.05,0.03,0.0,0.0,0.08,virgini ward-vaughn,LAW-3220,2015
-LAW,3220,8,Legal Env of Bus,0.06,0.42,0.32,0.0,0.1,0.0,0.0,0.1,virgini ward-vaughn,LAW-3220,2015
-LAW,3220,10,Legal Env of Bus,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-3220,2015
-LAW,3220,11,Legal Env of Bus,0.09,0.53,0.27,0.08,0.03,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2015
-LAW,3220,12,Legal Env of Bus,0.16,0.37,0.3,0.16,0.02,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2015
-LAW,3220,13,Legal Env of Bus,0.25,0.49,0.19,0.02,0.0,0.0,0.0,0.05,john hine,LAW-3220,2015
-LAW,3220,14,Legal Env of Bus,0.23,0.59,0.16,0.0,0.0,0.0,0.0,0.02,john hine,LAW-3220,2015
-LAW,3330,1,Real Estate Law,0.15,0.5,0.32,0.0,0.03,0.0,0.0,0.0,michael bra burrell,LAW-3330,2015
-LAW,4060,1,Sports Law,0.63,0.29,0.0,0.0,0.04,0.04,0.0,0.0,terry don phillips,LAW-4060,2015
-LAW,8480,1,Law Real Estate Prof,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,maurie lou lawrence,LAW-8480,2015
-LAW,8500,1,Law for Prof Accts,0.45,0.52,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-8500,2015
-LAW,8500,2,Law for Prof Accts,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-8500,2015
-LS,1000,2,Fitness Leadership,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,patricia figueroa,LS-1000,2015
-LS,1000,7,Intro to Photography,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sarah elizab mudder,LS-1000,2015
-LS,1000,9,Intro to Salsa Dance,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,LS-1000,2015
-LS,1000,12,Intermediate Rock Climbing,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,glenn dav middleton,LS-1000,2015
-LS,1000,22,Intermediate Ashtanga Yoga,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,LS-1000,2015
-LS,1000,27,Beg. Non-competitive Karate,0.73,0.0,0.0,0.09,0.0,0.0,0.0,0.18,june pilcher,LS-1000,2015
-LS,1130,1,Wood Carving,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,daniel mor anderson,LS-1130,2015
-LS,1410,2,Top Rope Climbing,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,glenn dav middleton,LS-1410,2015
-LS,1580,2,Archery,0.8,0.0,0.07,0.0,0.0,0.0,0.0,0.13,herbert strickland,LS-1580,2015
-LS,1650,3,Inland Kayak Touring,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,george wal thompson,LS-1650,2015
-LS,1830,1,Intro to Rugby,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,justin hickey,LS-1830,2015
-LS,1870,2,Frisbee Sports,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,craig goodman,LS-1870,2015
-LS,1940,1,Racquetball,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,raymond petersen,LS-1940,2015
-LS,1940,2,Racquetball,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,raymond petersen,LS-1940,2015
-LS,1990,1,Intermediate Golf,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,jason jordan,LS-1990,2015
-LS,2100,2,Learn to Dance,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,matthew lee krabbe,LS-2100,2015
-LS,2100,4,Learn to Dance,0.74,0.07,0.15,0.0,0.0,0.0,0.0,0.04,paul hoke,LS-2100,2015
-LS,2110,2,Introduction to Belly Dance,0.82,0.05,0.05,0.0,0.0,0.0,0.0,0.09,stephanie pack,LS-2110,2015
-LS,2190,1,Country West Dance,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.1,matthew lee krabbe,LS-2190,2015
-LS,2200,6,Shag,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,broadus fleming,LS-2200,2015
-LS,2200,8,Shag,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,LS-2200,2015
-LS,2270,1,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.03,0.0,0.0,0.03,paul hoke,LS-2270,2015
-LS,2270,4,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,paul hoke,LS-2270,2015
-LS,2320,1,Core Training,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,diane moreno,LS-2320,2015
-LS,2350,2,Basic Yoga,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,LS-2350,2015
-LS,2350,3,Basic Yoga,0.83,0.04,0.09,0.04,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2015
-LS,2350,4,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2015
-LS,2350,5,Basic Yoga,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2350,2015
-LS,2350,6,Basic Yoga,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,LS-2350,2015
-LS,2360,1,Power/Ashtanga Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,LS-2360,2015
-LS,2360,2,Power/Ashtanga Yoga,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,ani reina-nunnelley,LS-2360,2015
-LS,2370,3,Kripalu Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,LS-2370,2015
-LS,2370,4,Kripalu Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,LS-2370,2015
-LS,2370,5,Kripalu Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,LS-2370,2015
-LS,2380,4,Vinyasa Flow Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jenefer nadenicek,LS-2380,2015
-LS,2420,2,Meditation and Relax,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,LS-2420,2015
-LS,2420,3,Meditation and Relax,0.79,0.05,0.0,0.0,0.0,0.0,0.0,0.16,ranjanbala dil amin,LS-2420,2015
-LS,2420,4,Meditation and Relax,0.82,0.05,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,LS-2420,2015
-LS,2420,6,Meditation and Relax,0.65,0.13,0.0,0.04,0.0,0.0,0.0,0.17,renee warren gahan,LS-2420,2015
-LS,2450,1,Pilates,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,melanie ivey job,LS-2450,2015
-LS,2500,1,Marathon Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,john walston dunn,LS-2500,2015
-LS,2510,2,Running & Jogging,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,corey dou brookover,LS-2510,2015
-LS,2660,1,Hapkido,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,kelly smith,LS-2660,2015
-MATH,1010,1,Essen Math for Informed Soc,0.4,0.32,0.12,0.04,0.0,0.0,0.0,0.12,marilyn reba,MATH-1010,2015
-MATH,1010,2,Essen Math for Informed Soc,0.42,0.17,0.31,0.11,0.0,0.0,0.0,0.0,judith cottingham,MATH-1010,2015
-MATH,1010,3,Essen Math for Informed Soc,0.47,0.21,0.16,0.11,0.0,0.0,0.0,0.05,paran rebeka norton,MATH-1010,2015
-MATH,1010,4,Essen Math for Informed Soc,0.32,0.27,0.16,0.14,0.03,0.0,0.0,0.08,judith cottingham,MATH-1010,2015
-MATH,1010,5,Essen Math for Informed Soc,0.12,0.29,0.29,0.0,0.29,0.0,0.0,0.0,sergey charnyi,MATH-1010,2015
-MATH,1010,6,Essen Math for Informed Soc,0.38,0.29,0.21,0.03,0.03,0.0,0.0,0.06,megan elizabet ryan,MATH-1010,2015
-MATH,1010,7,Essen Math for Informed Soc,0.32,0.32,0.16,0.11,0.05,0.0,0.0,0.05,merle glick,MATH-1010,2015
-MATH,1020,1,Intro to Mathematical Analysis,0.24,0.14,0.1,0.24,0.14,0.0,0.0,0.14,vito capuano,MATH-1020,2015
-MATH,1020,2,Intro to Mathematical Analysis,0.07,0.24,0.2,0.24,0.12,0.0,0.0,0.12,thanh thien to,MATH-1020,2015
-MATH,1020,3,Intro to Mathematical Analysis,0.13,0.22,0.2,0.07,0.33,0.0,0.0,0.04,matthew harr menard,MATH-1020,2015
-MATH,1020,4,Intro to Mathematical Analysis,0.15,0.18,0.21,0.13,0.26,0.0,0.0,0.08,liu zhu,MATH-1020,2015
-MATH,1020,5,Intro to Mathematical Analysis,0.13,0.41,0.22,0.09,0.13,0.0,0.0,0.02,randy davidson,MATH-1020,2015
-MATH,1020,6,Intro to Mathematical Analysis,0.15,0.3,0.25,0.1,0.1,0.0,0.0,0.1,david james rea,MATH-1020,2015
-MATH,1020,7,Intro to Mathematical Analysis,0.15,0.37,0.2,0.04,0.22,0.0,0.0,0.02,abigail bowers,MATH-1020,2015
-MATH,1020,8,Intro to Mathematical Analysis,0.11,0.18,0.27,0.14,0.27,0.0,0.0,0.02,samuel jose shesman,MATH-1020,2015
-MATH,1020,9,Intro to Mathematical Analysis,0.2,0.3,0.3,0.07,0.11,0.0,0.0,0.02,abigail bowers,MATH-1020,2015
-MATH,1020,10,Intro to Mathematical Analysis,0.19,0.33,0.29,0.07,0.07,0.0,0.0,0.05,randy davidson,MATH-1020,2015
-MATH,1020,11,Intro to Mathematical Analysis,0.18,0.46,0.1,0.1,0.05,0.0,0.0,0.1,randy davidson,MATH-1020,2015
-MATH,1020,12,Intro to Mathematical Analysis,0.2,0.2,0.3,0.15,0.1,0.0,0.0,0.05,isaac justus,MATH-1020,2015
-MATH,1020,13,Intro to Mathematical Analysis,0.14,0.23,0.27,0.09,0.18,0.0,0.0,0.09,"rodriguez esperanza,",MATH-1020,2015
-MATH,1020,14,Intro to Mathematical Analysis,0.16,0.2,0.38,0.09,0.09,0.0,0.0,0.09,abigail bowers,MATH-1020,2015
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.28,0.67,0.05, morales hernandez,MATH-1040,2015
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.19,0.72,0.09,javier ruiz ramirez,MATH-1040,2015
-MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.56,0.44,0.0,eliza dar gallagher,MATH-1050,2015
-MATH,1060,1,Calculus of One Variable I,0.02,0.14,0.24,0.14,0.24,0.0,0.0,0.22,charity watson,MATH-1060,2015
-MATH,1060,2,Calculus of One Variable I,0.0,0.04,0.2,0.16,0.43,0.0,0.0,0.16,sanwar ahmad,MATH-1060,2015
-MATH,1060,3,Calculus of One Variable I,0.03,0.39,0.12,0.12,0.18,0.0,0.0,0.15,allen anderso guest,MATH-1060,2015
-MATH,1060,4,Calculus of One Variable I,0.06,0.12,0.33,0.27,0.09,0.0,0.0,0.12,allen anderso guest,MATH-1060,2015
-MATH,1060,5,Calculus of One Variable I,0.04,0.17,0.25,0.15,0.23,0.0,0.0,0.17,honghai xu,MATH-1060,2015
-MATH,1060,6,Calculus of One Variable I,0.0,0.17,0.21,0.26,0.23,0.0,0.0,0.13,charity watson,MATH-1060,2015
-MATH,1060,7,Calculus of One Variable I,0.02,0.09,0.3,0.22,0.35,0.0,0.0,0.02,abdullah al mamun,MATH-1060,2015
-MATH,1060,201,Calculus of One Variable I,0.25,0.08,0.25,0.0,0.33,0.0,0.0,0.08,james peterson,MATH-1060,2015
-MATH,1070,1,Differen and Integral Calculus,0.18,0.48,0.27,0.03,0.0,0.0,0.0,0.03,donna simms,MATH-1070,2015
-MATH,1070,2,Differen and Integral Calculus,0.11,0.36,0.33,0.17,0.0,0.0,0.0,0.03,donna simms,MATH-1070,2015
-MATH,1070,3,Differen and Integral Calculus,0.0,0.14,0.5,0.21,0.07,0.0,0.0,0.07,sherry biggers,MATH-1070,2015
-MATH,1070,4,Differen and Integral Calculus,0.08,0.29,0.29,0.26,0.08,0.0,0.0,0.0,sherry biggers,MATH-1070,2015
-MATH,1070,5,Differen and Integral Calculus,0.03,0.32,0.29,0.23,0.06,0.0,0.0,0.06,sherry biggers,MATH-1070,2015
-MATH,1070,6,Differen and Integral Calculus,0.09,0.23,0.36,0.14,0.09,0.0,0.0,0.09,jason to hedetniemi,MATH-1070,2015
-MATH,1070,7,Differen and Integral Calculus,0.09,0.45,0.18,0.09,0.09,0.0,0.0,0.09,fiona may knoll,MATH-1070,2015
-MATH,1080,1,Calculus of One Variable II,0.07,0.19,0.19,0.05,0.17,0.0,0.0,0.33,christa con johnson,MATH-1080,2015
-MATH,1080,2,Calculus of One Variable II,0.05,0.07,0.14,0.05,0.33,0.0,0.0,0.36,sarah eliz anderson,MATH-1080,2015
-MATH,1080,3,Calculus of One Variable II,0.04,0.24,0.22,0.11,0.18,0.0,0.0,0.2,christa con johnson,MATH-1080,2015
-MATH,1080,4,Calculus of One Variable II,0.19,0.17,0.26,0.09,0.11,0.0,0.0,0.19,meredith nicol burr,MATH-1080,2015
-MATH,1080,5,Calculus of One Variable II,0.02,0.3,0.17,0.13,0.04,0.0,0.0,0.33,audrey nico devries,MATH-1080,2015
-MATH,1080,6,Calculus of One Variable II,0.09,0.19,0.28,0.07,0.09,0.0,0.0,0.28,meredith nicol burr,MATH-1080,2015
-MATH,1080,7,Calculus of One Variable II,0.02,0.05,0.23,0.16,0.3,0.0,0.0,0.23,terri johnson,MATH-1080,2015
-MATH,1080,8,Calculus of One Variable II,0.0,0.14,0.05,0.19,0.21,0.0,0.0,0.42,alistair bentley,MATH-1080,2015
-MATH,1080,9,Calculus of One Variable II,0.05,0.17,0.2,0.15,0.17,0.0,0.0,0.27,karyn muir,MATH-1080,2015
-MATH,1080,10,Calculus of One Variable II,0.16,0.2,0.24,0.13,0.09,0.0,0.0,0.18,meredith nicol burr,MATH-1080,2015
-MATH,1080,11,Calculus of One Variable II,0.11,0.24,0.2,0.09,0.11,0.0,0.0,0.24,shih-wei chao,MATH-1080,2015
-MATH,1080,12,Calculus of One Variable II,0.0,0.14,0.16,0.14,0.19,0.0,0.0,0.37,rebecca ramos,MATH-1080,2015
-MATH,1080,13,Calculus of One Variable II,0.0,0.19,0.31,0.16,0.13,0.0,0.0,0.22,marilyn reba,MATH-1080,2015
-MATH,1080,14,Calculus of One Variable II,0.13,0.23,0.23,0.1,0.0,0.0,0.0,0.32,marilyn reba,MATH-1080,2015
-MATH,1080,15,Calculus of One Variable II,0.0,0.11,0.14,0.02,0.23,0.0,0.0,0.5,stefan adam bock,MATH-1080,2015
-MATH,1150,1,Contemp Math for Elem Teach I,0.44,0.46,0.08,0.0,0.0,0.0,0.0,0.03,allison stoddard,MATH-1150,2015
-MATH,1160,1,Contemp Math for Elem Teach II,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1160,2015
-MATH,1160,2,Contemp Math for Elem Teach II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1160,2015
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.87,0.11,0.02,marion hanna,MATH-1990,2015
-MATH,2060,1,Calculus of Several Variables,0.14,0.26,0.23,0.09,0.14,0.0,0.0,0.14,patrick buckingham,MATH-2060,2015
-MATH,2060,2,Calculus of Several Variables,0.19,0.06,0.1,0.06,0.19,0.0,0.0,0.39,dania moham zantout,MATH-2060,2015
-MATH,2060,3,Calculus of Several Variables,0.37,0.4,0.17,0.0,0.06,0.0,0.0,0.0,chanseok park,MATH-2060,2015
-MATH,2060,4,Calculus of Several Variables,0.76,0.14,0.08,0.03,0.0,0.0,0.0,0.0,martin joha schmoll,MATH-2060,2015
-MATH,2060,5,Calculus of Several Variables,0.06,0.38,0.29,0.12,0.12,0.0,0.0,0.03,charles johnson,MATH-2060,2015
-MATH,2060,6,Calculus of Several Variables,0.18,0.15,0.06,0.15,0.21,0.0,0.0,0.26,dania moham zantout,MATH-2060,2015
-MATH,2060,7,Calculus of Several Variables,0.41,0.44,0.09,0.0,0.06,0.0,0.0,0.0,sofya alekseeva,MATH-2060,2015
-MATH,2060,8,Calculus of Several Variables,0.07,0.17,0.28,0.03,0.24,0.0,0.0,0.21,dania moham zantout,MATH-2060,2015
-MATH,2060,10,Calculus of Several Variables,0.14,0.31,0.19,0.22,0.11,0.0,0.0,0.03,charles johnson,MATH-2060,2015
-MATH,2060,12,Calculus of Several Variables,0.32,0.41,0.12,0.0,0.09,0.0,0.0,0.06,sofya alekseeva,MATH-2060,2015
-MATH,2060,100,Calc of Several Variable (HON),0.54,0.38,0.0,0.0,0.08,0.0,0.0,0.0,james brown,MATH-2060,2015
-MATH,2070,1,Multivariable Calculus,0.16,0.26,0.21,0.16,0.16,0.0,0.0,0.05,elaine ma sotherden,MATH-2070,2015
-MATH,2070,2,Multivariable Calculus,0.26,0.26,0.26,0.11,0.11,0.0,0.0,0.0,garrett dranichak,MATH-2070,2015
-MATH,2070,4,Multivariable Calculus,0.14,0.27,0.23,0.09,0.14,0.0,0.0,0.14,amy christine grady,MATH-2070,2015
-MATH,2070,5,Multivariable Calculus,0.27,0.22,0.22,0.15,0.1,0.0,0.0,0.05,jennifer mari hanna,MATH-2070,2015
-MATH,2070,6,Multivariable Calculus,0.19,0.43,0.21,0.07,0.02,0.0,0.0,0.07,judith irene mcknew,MATH-2070,2015
-MATH,2070,7,Multivariable Calculus,0.36,0.26,0.19,0.12,0.05,0.0,0.0,0.02,jennifer mari hanna,MATH-2070,2015
-MATH,2070,9,Multivariable Calculus,0.15,0.32,0.17,0.05,0.2,0.0,0.0,0.12,grady mcgowa thomas,MATH-2070,2015
-MATH,2070,10,Multivariable Calculus,0.14,0.14,0.36,0.02,0.24,0.0,0.0,0.1,liem nguyen,MATH-2070,2015
-MATH,2070,11,Multivariable Calculus,0.32,0.27,0.27,0.0,0.09,0.0,0.0,0.05,tony thanh nguyen,MATH-2070,2015
-MATH,2070,12,Multivariable Calculus,0.27,0.32,0.23,0.0,0.14,0.0,0.0,0.05,kara ail stasikelis,MATH-2070,2015
-MATH,2070,13,Multivariable Calculus,0.15,0.55,0.2,0.1,0.0,0.0,0.0,0.0,mengying xiao,MATH-2070,2015
-MATH,2070,14,Multivariable Calculus,0.4,0.2,0.1,0.05,0.2,0.0,0.0,0.05,luke marti giberson,MATH-2070,2015
-MATH,2070,15,Multivariable Calculus,0.31,0.21,0.21,0.14,0.05,0.0,0.0,0.07,judith irene mcknew,MATH-2070,2015
-MATH,2070,16,Multivariable Calculus,0.2,0.35,0.2,0.05,0.1,0.0,0.0,0.1,kevin wayne dettman,MATH-2070,2015
-MATH,2070,17,Multivariable Calculus,0.14,0.38,0.33,0.0,0.05,0.0,0.0,0.1,fawwaz taw batayneh,MATH-2070,2015
-MATH,2070,19,Multivariable Calculus,0.33,0.21,0.26,0.05,0.14,0.0,0.0,0.02,margaret milliken,MATH-2070,2015
-MATH,2070,20,Multivariable Calculus,0.33,0.28,0.22,0.0,0.11,0.0,0.0,0.06, ushijima-mwesigwa,MATH-2070,2015
-MATH,2070,21,Multivariable Calculus,0.24,0.37,0.17,0.1,0.07,0.0,0.0,0.05,jennifer mari hanna,MATH-2070,2015
-MATH,2070,22,Multivariable Calculus,0.17,0.33,0.06,0.06,0.17,0.0,0.0,0.22,trevor scot vilardi,MATH-2070,2015
-MATH,2070,24,Multivariable Calculus,0.21,0.21,0.26,0.0,0.16,0.0,0.0,0.16,qijun he,MATH-2070,2015
-MATH,2070,25,Multivariable Calculus,0.34,0.2,0.2,0.12,0.07,0.0,0.0,0.07,jennifer mari hanna,MATH-2070,2015
-MATH,2070,26,Multivariable Calculus,0.06,0.24,0.29,0.12,0.18,0.0,0.0,0.12,yisu jia,MATH-2070,2015
-MATH,2080,1,Intro to Ordin Diff Equations,0.08,0.3,0.18,0.15,0.1,0.0,0.0,0.2,terri johnson,MATH-2080,2015
-MATH,2080,3,Intro to Ordin Diff Equations,0.09,0.26,0.13,0.11,0.2,0.0,0.0,0.2,timothy fra parrott,MATH-2080,2015
-MATH,2080,4,Intro to Ordin Diff Equations,0.13,0.32,0.06,0.06,0.19,0.0,0.0,0.23,shari prevost,MATH-2080,2015
-MATH,2080,5,Intro to Ordin Diff Equations,0.3,0.3,0.16,0.05,0.16,0.0,0.0,0.05,minerva rios-adams,MATH-2080,2015
-MATH,2080,6,Intro to Ordin Diff Equations,0.21,0.45,0.13,0.11,0.08,0.0,0.0,0.03,minerva rios-adams,MATH-2080,2015
-MATH,2080,7,Intro to Ordin Diff Equations,0.2,0.24,0.34,0.0,0.15,0.0,0.0,0.07,julie lassiter,MATH-2080,2015
-MATH,2080,8,Intro to Ordin Diff Equations,0.41,0.15,0.26,0.0,0.04,0.0,0.0,0.13,timothy fra parrott,MATH-2080,2015
-MATH,2080,9,Intro to Ordin Diff Equations,0.49,0.22,0.22,0.04,0.0,0.0,0.0,0.02,timothy ch teitloff,MATH-2080,2015
-MATH,2080,10,Intro to Ordin Diff Equations,0.21,0.21,0.15,0.18,0.12,0.0,0.0,0.15,shari prevost,MATH-2080,2015
-MATH,2080,11,Intro to Ordin Diff Equations,0.36,0.29,0.09,0.09,0.09,0.0,0.0,0.09,timothy fra parrott,MATH-2080,2015
-MATH,2080,12,Intro to Ordin Diff Equations,0.31,0.22,0.31,0.14,0.0,0.0,0.0,0.03,timothy ch teitloff,MATH-2080,2015
-MATH,2080,13,Intro to Ordin Diff Equations,0.24,0.24,0.33,0.15,0.03,0.0,0.0,0.0,julie lassiter,MATH-2080,2015
-MATH,2080,14,Intro to Ordin Diff Equations,0.39,0.29,0.2,0.05,0.0,0.0,0.0,0.07,nathan jos adelgren,MATH-2080,2015
-MATH,2080,15,Intro to Ordin Diff Equations,0.53,0.27,0.16,0.02,0.02,0.0,0.0,0.0,timothy ch teitloff,MATH-2080,2015
-MATH,2080,16,Intro to Ordin Diff Equations,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,irina viktorova,MATH-2080,2015
-MATH,2080,17,Intro to Ordin Diff Equations,0.3,0.51,0.11,0.0,0.03,0.0,0.0,0.05,brandon gra goodell,MATH-2080,2015
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,james brannan,MATH-2080,2015
-MATH,2160,1,Geometry for Elem Sch Teachers,0.57,0.4,0.0,0.0,0.03,0.0,0.0,0.0,allison stoddard,MATH-2160,2015
-MATH,3020,1,Stat for Science & Engineering,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,christopher wilson,MATH-3020,2015
-MATH,3020,2,Stat for Science & Engineering,0.7,0.14,0.05,0.04,0.05,0.0,0.0,0.02,dominique morgan,MATH-3020,2015
-MATH,3020,3,Stat for Science & Engineering,0.45,0.25,0.07,0.05,0.14,0.0,0.0,0.05,christopher mcmahan,MATH-3020,2015
-MATH,3020,4,Stat for Science & Engineering,0.69,0.21,0.05,0.05,0.0,0.0,0.0,0.0,xiaoqian sun,MATH-3020,2015
-MATH,3020,5,Stat for Science & Engineering,0.19,0.35,0.26,0.06,0.04,0.0,0.0,0.11,michael thom finney,MATH-3020,2015
-MATH,3080,1,College Geometry,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,eliza dar gallagher,MATH-3080,2015
-MATH,3110,1,Linear Algebra,0.38,0.22,0.14,0.14,0.11,0.0,0.0,0.03,elena sta dimitrova,MATH-3110,2015
-MATH,3110,2,Linear Algebra,0.5,0.34,0.13,0.03,0.0,0.0,0.0,0.0,judith cottingham,MATH-3110,2015
-MATH,3110,3,Linear Algebra,0.21,0.24,0.41,0.03,0.06,0.0,0.0,0.06,svetlan poznanovikj,MATH-3110,2015
-MATH,3110,4,Linear Algebra,0.31,0.11,0.23,0.06,0.17,0.0,0.0,0.11,xuhong gao,MATH-3110,2015
-MATH,3110,5,Linear Algebra,0.56,0.16,0.08,0.0,0.08,0.0,0.0,0.12,xuhong gao,MATH-3110,2015
-MATH,3150,1,Adv Top in Math for Elem Teach,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-3150,2015
-MATH,3190,1,Introduction to Proof,0.35,0.26,0.17,0.0,0.13,0.0,0.0,0.09,kevin james,MATH-3190,2015
-MATH,3190,2,Introduction to Proof,0.4,0.3,0.1,0.0,0.1,0.0,0.0,0.1,michael adam burr,MATH-3190,2015
-MATH,3600,1,Intermediate Math Computing,0.63,0.2,0.05,0.0,0.07,0.0,0.0,0.05,neil calkin,MATH-3600,2015
-MATH,3650,1,Numerical Mthds for Engineers,0.72,0.26,0.02,0.0,0.0,0.0,0.0,0.0,abigail bowers,MATH-3650,2015
-MATH,3650,2,Numerical Mthds for Engineers,0.17,0.22,0.33,0.14,0.08,0.0,0.0,0.06,christopher cox,MATH-3650,2015
-MATH,3650,3,Numerical Mthds for Engineers,0.19,0.31,0.33,0.06,0.06,0.0,0.0,0.06,christopher cox,MATH-3650,2015
-MATH,4000,1,Theory of Probability,0.5,0.21,0.11,0.04,0.11,0.0,0.0,0.04,yingbo li,MATH-4000,2015
-MATH,4030,1,Intro to Statistical Theory,0.36,0.23,0.23,0.05,0.09,0.0,0.0,0.05,xiaoqian sun,MATH-4030,2015
-MATH,4070,1,Regress & Time-Series Analysis,0.5,0.29,0.21,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-4070,2015
-MATH,4100,1,Number Theory,0.4,0.25,0.15,0.15,0.05,0.0,0.0,0.0,charles johnson,MATH-4100,2015
-MATH,4120,1,Intro to Modern Algebra,0.28,0.21,0.21,0.1,0.1,0.0,0.0,0.1,elena sta dimitrova,MATH-4120,2015
-MATH,4190,1,Discrete Math Structures I,0.44,0.31,0.11,0.02,0.02,0.0,0.0,0.09,beth novick,MATH-4190,2015
-MATH,4300,1,Actuarial Science Seminar I,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,mark cawood,MATH-4300,2015
-MATH,4310,1,Theory of Interest,0.23,0.41,0.23,0.14,0.0,0.0,0.0,0.0, erwin walker,MATH-4310,2015
-MATH,4340,1,Adv Engineering Mathematics,0.29,0.31,0.17,0.06,0.09,0.0,0.0,0.09,qingshan chen,MATH-4340,2015
-MATH,4340,2,Adv Engineering Mathematics,0.46,0.21,0.13,0.0,0.04,0.0,0.0,0.17,daniel warner,MATH-4340,2015
-MATH,4400,1,Linear Programming,0.43,0.1,0.14,0.05,0.1,0.0,0.0,0.19,warren adams,MATH-4400,2015
-MATH,4530,1,Advanced Calculus I,0.13,0.13,0.2,0.2,0.2,0.0,0.0,0.13,jeong rock yoon,MATH-4530,2015
-MATH,4540,1,Advanced Calculus II,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,taufiquar rahm khan,MATH-4540,2015
-MATH,6340,1,Adv Engineering Mathematics,0.4,0.3,0.1,0.0,0.05,0.0,0.0,0.15,hyesuk lee,MATH-6340,2015
-MATH,8030,1,Stochastic Processes,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,MATH-8030,2015
-MATH,8050,1,Data Analysis,0.48,0.35,0.09,0.0,0.0,0.0,0.0,0.09,derek brown,MATH-8050,2015
-MATH,8090,1,Time Series Analysis,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,colin gallagher,MATH-8090,2015
-MATH,8100,1,Mathematical Programming,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,MATH-8100,2015
-MATH,8110,1,Nonlinear Programming,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,MATH-8110,2015
-MATH,8130,1,Advanced Linear Programming,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,warren adams,MATH-8130,2015
-MATH,8210,1,Linear Analysis,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,MATH-8210,2015
-MATH,8260,1,Partial Differential Equations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,MATH-8260,2015
-MATH,8520,1,Abstract Algebra II,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,james brown,MATH-8520,2015
-MATH,8530,1,Matrix Analysis,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,matthew macauley,MATH-8530,2015
-MATH,8570,1,Cryptography,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,felice manganiello,MATH-8570,2015
-MATH,8600,1,Intro to Scientific Computing,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,leo rebholz,MATH-8600,2015
-MATH,8660,1,Finite Element Method,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,hyesuk lee,MATH-8660,2015
-MATH,8810,1,Mathematical Statistics,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,MATH-8810,2015
-MATH,9830,1,Sel Top in Computational Math,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timo johann heister,MATH-9830,2015
-MBA,8030,1,Stat Analy of Bus Op,0.82,0.15,0.0,0.0,0.0,0.0,0.0,0.03,matthew charl klein,MBA-8030,2015
-MBA,8060,1,Operations Mgt,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06, sridharan,MBA-8060,2015
-MBA,8070,1,Financial Management,0.83,0.18,0.0,0.0,0.0,0.0,0.0,0.0,fei xie,MBA-8070,2015
-MBA,8070,2,Financial Management,0.46,0.49,0.03,0.0,0.0,0.0,0.0,0.03,fei xie,MBA-8070,2015
-MBA,8090,1,Org Beh & Hum Res Mg,0.65,0.33,0.0,0.0,0.0,0.0,0.0,0.02,thomas jo zagenczyk,MBA-8090,2015
-MBA,8190,1,Intro to Acc and Fin,0.53,0.35,0.09,0.0,0.02,0.0,0.0,0.0,jeffrey mcmillan,MBA-8190,2015
-MBA,8290,1,Marketing Foundation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MBA-8290,2015
-MBA,8370,1,Legal Environ of Bus,0.53,0.42,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2015
-MBA,8410,1,Real Estate Finance,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,james pow mckissick,MBA-8410,2015
-MBA,8430,10,MBAePT Entrepreneurial Acct,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sally kathr widener,MBA-8430,2015
-MBA,8450,1,MBAe FT Tech & Innova Mgt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david orr,MBA-8450,2015
-MBA,8470,1,MBAe FT New Venture Creation,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,MBA-8470,2015
-MBA,8540,1,Mgrl Accounting,0.84,0.11,0.03,0.0,0.0,0.0,0.0,0.03,henry anderson,MBA-8540,2015
-MBA,8540,2,Mgrl Accounting,0.8,0.1,0.02,0.0,0.02,0.0,0.0,0.05,henry anderson,MBA-8540,2015
-MBA,8590,1,Mgr Decision Model,0.45,0.21,0.06,0.0,0.04,0.0,0.0,0.23,mark mcknew,MBA-8590,2015
-MBA,8590,3,Mgr Decision Model,0.38,0.33,0.15,0.0,0.05,0.0,0.0,0.1,sara elizabet yoder,MBA-8590,2015
-MBA,8600,1,Advanced Marketing Strategy,0.36,0.46,0.18,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2015
-MBA,8610,1,Information Systems,0.38,0.52,0.0,0.0,0.03,0.0,0.0,0.07,varun grover,MBA-8610,2015
-MBA,8610,2,Information Systems,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,heshan sun,MBA-8610,2015
-MBA,8620,1,Managerial Economics,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,MBA-8620,2015
-MBA,8720,1,MBAe FT Entrepr Finance,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,MBA-8720,2015
-MBA,8750,1,Enterprise Develpmnt,0.66,0.29,0.03,0.0,0.0,0.0,0.0,0.03,michael george mino,MBA-8750,2015
-MBA,8990,1,Advanced Leadership,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,gail depriest,MBA-8990,2015
-ME,2000,1,Sophomore Seminar,0.84,0.11,0.01,0.0,0.01,0.0,0.0,0.03,donald beasley,ME-2000,2015
-ME,2010,1,Statics & Dynamics,0.02,0.12,0.23,0.16,0.36,0.0,0.0,0.1,sherrill biggers,ME-2010,2015
-ME,2010,2,Statics & Dynamics,0.11,0.31,0.26,0.11,0.15,0.0,0.0,0.06,paul joseph,ME-2010,2015
-ME,2030,1,Founda Th/Fl Syst,0.29,0.42,0.1,0.13,0.02,0.0,0.0,0.04,richard figliola,ME-2030,2015
-ME,2030,2,Founda Th/Fl Syst,0.14,0.27,0.41,0.1,0.06,0.0,0.0,0.02,chenning tong,ME-2030,2015
-ME,2030,3,Founda Th/Fl Syst,0.44,0.42,0.1,0.0,0.01,0.0,0.0,0.02,david zumbrunnen,ME-2030,2015
-ME,2040,1,Mechanics of Materials,0.27,0.33,0.21,0.09,0.05,0.0,0.0,0.05,michael porter,ME-2040,2015
-ME,2040,2,Mechanics of Materials,0.09,0.54,0.21,0.04,0.07,0.0,0.0,0.04,todd schweisinger,ME-2040,2015
-ME,2220,1,Mech Engr Lab I,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,2,Mech Engr Lab I,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,3,Mech Engr Lab I,0.2,0.5,0.25,0.05,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,4,Mech Engr Lab I,0.27,0.6,0.07,0.07,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,5,Mech Engr Lab I,0.15,0.8,0.0,0.0,0.05,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,6,Mech Engr Lab I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,2220,7,Mech Engr Lab I,0.21,0.74,0.0,0.0,0.0,0.0,0.0,0.05,todd schweisinger,ME-2220,2015
-ME,2220,8,Mech Engr Lab I,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2015
-ME,3030,1,Thermodynamics,0.12,0.29,0.33,0.16,0.04,0.0,0.0,0.07,jay ochterbeck,ME-3030,2015
-ME,3040,1,Heat Transfer,0.4,0.28,0.25,0.03,0.02,0.0,0.0,0.02,donald beasley,ME-3040,2015
-ME,3040,2,Heat Transfer,0.22,0.44,0.15,0.06,0.06,0.0,0.0,0.07,xin zhao,ME-3040,2015
-ME,3050,1,Model/an Dy Syst,0.18,0.38,0.2,0.09,0.09,0.0,0.0,0.07,phanin tallapragada,ME-3050,2015
-ME,3050,2,Model/an Dy Syst,0.21,0.58,0.17,0.02,0.0,0.0,0.0,0.02,yue wang,ME-3050,2015
-ME,3060,1,Fund Machine Design,0.32,0.47,0.15,0.05,0.02,0.0,0.0,0.0,oliver myers,ME-3060,2015
-ME,3060,2,Fund Machine Design,0.47,0.36,0.09,0.06,0.0,0.0,0.0,0.02,paul jeffrey meyer,ME-3060,2015
-ME,3070,1,Found of Mechanical Systems,0.54,0.32,0.04,0.04,0.04,0.0,0.0,0.04,lonny thompson,ME-3070,2015
-ME,3070,2,Found of Mechanical Systems,0.14,0.32,0.36,0.11,0.0,0.0,0.0,0.07,gregory mocko,ME-3070,2015
-ME,3080,1,Fluid Mechanics,0.0,0.28,0.33,0.19,0.14,0.0,0.0,0.06,jean-marc delhaye,ME-3080,2015
-ME,3080,2,Fluid Mechanics,0.09,0.4,0.33,0.11,0.02,0.0,0.0,0.04,ethan kung,ME-3080,2015
-ME,3100,1,Thermo/Heat Transfer,0.19,0.32,0.22,0.12,0.01,0.0,0.0,0.13,xiangchun xuan,ME-3100,2015
-ME,3120,1,Manuf Processes,0.46,0.35,0.08,0.08,0.02,0.0,0.0,0.0,hong seok choi,ME-3120,2015
-ME,3330,1,Mech Engr Lab II,0.38,0.44,0.13,0.06,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,3330,2,Mech Engr Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,3330,3,Mech Engr Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,3330,4,Mech Engr Lab II,0.19,0.44,0.25,0.0,0.06,0.0,0.0,0.06,todd schweisinger,ME-3330,2015
-ME,3330,5,Mech Engr Lab II,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,ME-3330,2015
-ME,3330,6,Mech Engr Lab II,0.21,0.53,0.16,0.05,0.05,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,3330,7,Mech Engr Lab II,0.22,0.56,0.11,0.06,0.0,0.0,0.0,0.06,todd schweisinger,ME-3330,2015
-ME,3330,8,Mech Engr Lab II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2015
-ME,4000,1,Senior Seminar,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0, ramasubramanian,ME-4000,2015
-ME,4010,1,Mech Engr Design,0.18,0.69,0.09,0.02,0.02,0.0,0.0,0.0,joshua summers,ME-4010,2015
-ME,4020,1,Intern in Engr Des,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4020,2015
-ME,4020,3,Intern in Engr Des,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2015
-ME,4020,4,Intern in Engr Des,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,ethan kung,ME-4020,2015
-ME,4020,7,Intern in Engr Des,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-4020,2015
-ME,4030,1,Control Dynamic Syst,0.4,0.33,0.13,0.13,0.0,0.0,0.0,0.0,hamed saeidi,ME-4030,2015
-ME,4030,2,Control Dynamic Syst,0.05,0.19,0.3,0.24,0.16,0.0,0.0,0.05,kalyan chakr katuri,ME-4030,2015
-ME,4170,1,Mechatronic Sys,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4170,2015
-ME,4220,1,Design Gas Turbines,0.46,0.31,0.15,0.0,0.0,0.0,0.0,0.08,abhijit som,ME-4220,2015
-ME,4230,1,Intro Aerodynamics,0.15,0.18,0.5,0.12,0.06,0.0,0.0,0.0,richard figliola,ME-4230,2015
-ME,4260,1,Nuclear Energy,0.26,0.26,0.29,0.12,0.03,0.0,0.0,0.03,david zumbrunnen,ME-4260,2015
-ME,4320,1,Adv Strength of Matl,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,gang li,ME-4320,2015
-ME,4440,3,Mech Engr Lab III,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2015
-ME,4440,5,Mech Engr Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2015
-ME,4930,5,SelectedTopics ME (RapidProto),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4930,2015
-ME,4930,29,Selected Topics ME (Solar E),0.62,0.34,0.0,0.0,0.0,0.0,0.0,0.03,daniel fant,ME-4930,2015
-ME,6170,1,Mechatronic Sys,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,john wagner,ME-6170,2015
-ME,6320,1,Adv Strength of Matl,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,gang li,ME-6320,2015
-ME,6930,5,SelectedTopics ME (RapidProto),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-6930,2015
-ME,6930,11,Selected Topics ME (MicroFab),0.44,0.38,0.06,0.0,0.13,0.0,0.0,0.0,rod martinez-duarte,ME-6930,2015
-ME,6930,29,Selected Topics ME (Solar E),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-6930,2015
-ME,8120,1,Exp Meth Thermal Sci,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,ME-8120,2015
-ME,8190,1,Cp Meth in Therm Sc,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,richard miller,ME-8190,2015
-ME,8200,1,Mod Cont Engr,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,ME-8200,2015
-ME,8310,1,Convective Ht Trans,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,john saylor,ME-8310,2015
-ME,8360,1,Fracture Mech,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,huijuan zhao,ME-8360,2015
-ME,8520,1,Adv Finite Ele Ana,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,lonny thompson,ME-8520,2015
-ME,8610,1,Matl Sel Engr Design,0.86,0.11,0.02,0.0,0.0,0.0,0.0,0.02,mica grujicic,ME-8610,2015
-ME,8930,1,Sel Topics in ME (Scaling),0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-8930,2015
-ME,8930,27,Sel Top - Optimal Estimation,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,ardalan vahidi,ME-8930,2015
-MGT,2010,1,Principles of Mgt,0.36,0.3,0.21,0.05,0.04,0.0,0.0,0.05,katherine clark,MGT-2010,2015
-MGT,2010,2,Principles of Mgt,0.23,0.47,0.23,0.02,0.04,0.0,0.0,0.0,katherine clark,MGT-2010,2015
-MGT,2010,3,Principles of Mgt,0.21,0.36,0.24,0.04,0.08,0.0,0.0,0.07,katherine clark,MGT-2010,2015
-MGT,2010,4,Principles of Mgt,0.22,0.38,0.19,0.12,0.01,0.0,0.0,0.08,katherine clark,MGT-2010,2015
-MGT,2010,5,Principles of Mgt,0.27,0.34,0.25,0.05,0.0,0.0,0.0,0.08,tina robbins,MGT-2010,2015
-MGT,2010,6,Principles of Mgt,0.26,0.54,0.12,0.05,0.01,0.0,0.0,0.01,tina robbins,MGT-2010,2015
-MGT,2010,7,Principles of Mgt,0.29,0.45,0.21,0.03,0.0,0.0,0.0,0.03,tina robbins,MGT-2010,2015
-MGT,2010,8,Principles of Mgt,0.27,0.36,0.18,0.08,0.05,0.0,0.0,0.06,tina robbins,MGT-2010,2015
-MGT,2180,1,Management PC Applications,0.53,0.3,0.08,0.02,0.04,0.0,0.0,0.02,ryan toole,MGT-2180,2015
-MGT,2180,2,Management PC Applications,0.55,0.28,0.08,0.02,0.04,0.0,0.0,0.03,ryan toole,MGT-2180,2015
-MGT,2180,3,Management PC Applications,0.57,0.32,0.06,0.03,0.01,0.0,0.0,0.02,ryan toole,MGT-2180,2015
-MGT,2180,4,Management PC Applications,0.57,0.25,0.1,0.02,0.02,0.0,0.0,0.05,ryan toole,MGT-2180,2015
-MGT,3070,1,Human Resource Management,0.64,0.27,0.05,0.0,0.0,0.0,0.0,0.05,priscilla harrison,MGT-3070,2015
-MGT,3070,2,Human Resource Management,0.48,0.48,0.03,0.0,0.03,0.0,0.0,0.0,michael cole,MGT-3070,2015
-MGT,3070,3,Human Resource Management,0.17,0.78,0.03,0.0,0.03,0.0,0.0,0.0,kristin dam scott,MGT-3070,2015
-MGT,3070,4,Human Resource Management,0.4,0.48,0.08,0.0,0.0,0.0,0.0,0.05,michael cole,MGT-3070,2015
-MGT,3070,5,Human Resource Management,0.08,0.56,0.31,0.05,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2015
-MGT,3070,6,Human Resource Management,0.18,0.67,0.15,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2015
-MGT,3100,1,Intermed Business Statistics,0.32,0.39,0.16,0.0,0.02,0.0,0.0,0.11,james walsh,MGT-3100,2015
-MGT,3100,2,Intermed Business Statistics,0.66,0.13,0.11,0.05,0.03,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3100,2015
-MGT,3100,3,Intermed Business Statistics,0.58,0.25,0.1,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3100,2015
-MGT,3100,4,Intermed Business Statistics,0.12,0.32,0.27,0.17,0.05,0.0,0.0,0.07,sara elizabet yoder,MGT-3100,2015
-MGT,3100,5,Intermed Business Statistics,0.44,0.28,0.19,0.0,0.06,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3100,2015
-MGT,3100,6,Intermed Business Statistics,0.44,0.36,0.11,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3100,2015
-MGT,3100,7,Intermed Business Statistics,0.16,0.17,0.24,0.14,0.08,0.0,0.0,0.21,sara elizabet yoder,MGT-3100,2015
-MGT,3100,8,Intermed Business Statistics,0.14,0.23,0.14,0.27,0.14,0.0,0.0,0.09,sara elizabet yoder,MGT-3100,2015
-MGT,3100,10,Intermed Business Statistics,0.24,0.45,0.24,0.05,0.0,0.0,0.0,0.02,yuhong he,MGT-3100,2015
-MGT,3120,1,Decision Models for Management,0.3,0.4,0.23,0.02,0.05,0.0,0.0,0.0,mark mcknew,MGT-3120,2015
-MGT,3120,2,Decision Models for Management,0.13,0.41,0.35,0.04,0.0,0.0,0.0,0.07,mark mcknew,MGT-3120,2015
-MGT,3120,3,Decision Models for Management,0.13,0.5,0.24,0.0,0.11,0.0,0.0,0.02,mark mcknew,MGT-3120,2015
-MGT,3150,1,New Venture Creation,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,MGT-3150,2015
-MGT,3180,1,Mgt of Info Systems,0.51,0.36,0.05,0.05,0.03,0.0,0.0,0.0,dan jiang,MGT-3180,2015
-MGT,3180,2,Mgt of Info Systems,0.33,0.38,0.3,0.0,0.0,0.0,0.0,0.0,tina marie esposito,MGT-3180,2015
-MGT,3180,3,Mgt of Info Systems,0.21,0.44,0.33,0.0,0.03,0.0,0.0,0.0,roopa raman,MGT-3180,2015
-MGT,3180,4,Mgt of Info Systems,0.13,0.37,0.47,0.0,0.0,0.0,0.0,0.03,roopa raman,MGT-3180,2015
-MGT,3900,2,Ops Mgt,0.36,0.2,0.32,0.08,0.0,0.0,0.0,0.04,min kyung lee,MGT-3900,2015
-MGT,3900,3,Ops Mgt,0.35,0.35,0.25,0.0,0.03,0.0,0.0,0.03,zachary mo leffakis,MGT-3900,2015
-MGT,3900,4,Ops Mgt,0.18,0.35,0.28,0.03,0.05,0.0,0.0,0.13,zachary mo leffakis,MGT-3900,2015
-MGT,3900,5,Ops Mgt,0.24,0.5,0.15,0.06,0.03,0.0,0.0,0.03,shouqiang wang,MGT-3900,2015
-MGT,3900,6,Ops Mgt,0.24,0.43,0.24,0.05,0.03,0.0,0.0,0.0,yuhong he,MGT-3900,2015
-MGT,4000,2,Mgt of Organizational Behavior,0.26,0.51,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MGT-4000,2015
-MGT,4000,3,Mgt of Organizational Behavior,0.25,0.45,0.25,0.0,0.03,0.0,0.0,0.03,philip roth,MGT-4000,2015
-MGT,4000,4,Mgt of Organizational Behavior,0.51,0.31,0.11,0.03,0.0,0.0,0.0,0.03,michael cole,MGT-4000,2015
-MGT,4020,1,Ops Pln and Ctl,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4020,2015
-MGT,4030,1,Intro to Business Analytics,0.33,0.46,0.13,0.04,0.0,0.0,0.0,0.04,siyuan li,MGT-4030,2015
-MGT,4030,3,Advanced Business Analytics,0.13,0.53,0.33,0.0,0.0,0.0,0.0,0.0,heshan sun,MGT-4030,2015
-MGT,4080,1,Lean Operations,0.21,0.29,0.46,0.0,0.04,0.0,0.0,0.0,zachary mo leffakis,MGT-4080,2015
-MGT,4110,1,Project Management,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,russell purvis,MGT-4110,2015
-MGT,4110,2,Project Management,0.22,0.57,0.22,0.0,0.0,0.0,0.0,0.0,russell purvis,MGT-4110,2015
-MGT,4120,1,Supplier Management,0.1,0.4,0.47,0.0,0.0,0.0,0.0,0.03,shouqiang wang,MGT-4120,2015
-MGT,4150,1,Business Strategy,0.09,0.66,0.23,0.0,0.03,0.0,0.0,0.0,peter gianiodis,MGT-4150,2015
-MGT,4150,2,Business Strategy,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,peter gianiodis,MGT-4150,2015
-MGT,4150,3,Business Strategy,0.73,0.23,0.0,0.03,0.0,0.0,0.0,0.03,john edward hopkins,MGT-4150,2015
-MGT,4150,4,Business Strategy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2015
-MGT,4150,5,Business Strategy,0.27,0.56,0.16,0.02,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2015
-MGT,4150,6,Business Strategy,0.16,0.69,0.11,0.0,0.04,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2015
-MGT,4150,7,Business Strategy,0.17,0.59,0.24,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,MGT-4150,2015
-MGT,4150,8,Business Strategy,0.2,0.7,0.11,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,MGT-4150,2015
-MGT,4160,1,Special Topics Hr,0.31,0.64,0.06,0.0,0.0,0.0,0.0,0.0,kristin dam scott,MGT-4160,2015
-MGT,4230,1,Intern Bus Mgt,0.09,0.22,0.61,0.04,0.04,0.0,0.0,0.0,wayne stewart,MGT-4230,2015
-MGT,4230,2,Intern Bus Mgt,0.15,0.28,0.33,0.07,0.09,0.0,0.0,0.09,wayne stewart,MGT-4230,2015
-MGT,4230,3,Intern Bus Mgt,0.36,0.48,0.17,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4230,2015
-MGT,4230,4,Intern Bus Mgt,0.03,0.78,0.14,0.0,0.03,0.0,0.0,0.03,janis miller,MGT-4230,2015
-MGT,4240,1,Global Supply Chain,0.14,0.41,0.36,0.05,0.05,0.0,0.0,0.0,yann ferrand,MGT-4240,2015
-MGT,4270,1,Managing Improvement,0.4,0.43,0.13,0.0,0.0,0.0,0.0,0.03,james liddle,MGT-4270,2015
-MGT,4300,1,Bus Application Development,0.56,0.13,0.19,0.0,0.0,0.0,0.0,0.13,jerry kermi bilbrey,MGT-4300,2015
-MGT,4310,1,Emp Rights & Resp,0.38,0.48,0.13,0.0,0.0,0.0,0.0,0.03,leonard jos spooner,MGT-4310,2015
-MGT,4350,1,Pers Interviewing,0.33,0.4,0.18,0.08,0.03,0.0,0.0,0.0,philip roth,MGT-4350,2015
-MGT,4520,1,Business Analysis,0.18,0.55,0.18,0.06,0.03,0.0,0.0,0.0,roopa raman,MGT-4520,2015
-MGT,4550,1,Emerging I T Trends,0.39,0.52,0.1,0.0,0.0,0.0,0.0,0.0,jason thatcher,MGT-4550,2015
-MGT,4560,1,Business Info Mgt,0.27,0.53,0.07,0.0,0.0,0.0,0.0,0.13,siyuan li,MGT-4560,2015
-MGT,8120,1,Supply Chain Mgt,0.29,0.55,0.16,0.0,0.0,0.0,0.0,0.0,yann ferrand,MGT-8120,2015
-MICR,3050,1,General Microbiology,0.41,0.39,0.14,0.04,0.01,0.0,0.0,0.01,kristi ja whitehead,MICR-3050,2015
-MICR,3050,2,General Microbiology,0.46,0.36,0.12,0.02,0.02,0.0,0.0,0.02,krista barr rudolph,MICR-3050,2015
-MICR,3050,3,General Microbiology,0.55,0.37,0.05,0.03,0.0,0.0,0.0,0.0,krista barr rudolph,MICR-3050,2015
-MICR,4000,1,Public Health Micro,0.37,0.38,0.17,0.05,0.02,0.0,0.0,0.02,kristi ja whitehead,MICR-4000,2015
-MICR,4020,1,Environmental Micro,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,john michael henson,MICR-4020,2015
-MICR,4070,1,Food and Dairy Micro,0.37,0.49,0.14,0.0,0.0,0.0,0.0,0.0,xiuping jiang,MICR-4070,2015
-MICR,4110,1,Pathogenic Bact,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,MICR-4110,2015
-MICR,4120,1,Bacterial Physiology,0.26,0.29,0.16,0.13,0.16,0.0,0.0,0.0,thomas hughes,MICR-4120,2015
-MICR,4130,1,Industrial Micro,0.32,0.58,0.04,0.02,0.02,0.0,0.0,0.02,tzuen-rong je tzeng,MICR-4130,2015
-MICR,4140,1,Basic Immunology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,MICR-4140,2015
-MICR,4170,1,Cancer and Aging,0.65,0.29,0.0,0.06,0.0,0.0,0.0,0.0,yuqing dong,MICR-4170,2015
-MICR,4210,1,Path Bac Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,MICR-4210,2015
-MICR,4210,2,Path Bac Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,MICR-4210,2015
-MICR,4500,2,Advanced Microbiology I,0.5,0.45,0.0,0.0,0.05,0.0,0.0,0.0,harry kurtz,MICR-4500,2015
-MICR,4500,3,Advanced Microbiology I,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2015
-MKT,3010,1,Prin of Marketing,0.15,0.49,0.27,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,MKT-3010,2015
-MKT,3010,2,Prin of Marketing,0.21,0.47,0.23,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,MKT-3010,2015
-MKT,3010,3,Prin of Marketing,0.21,0.37,0.25,0.1,0.04,0.0,0.0,0.03,amanda cooper fine,MKT-3010,2015
-MKT,3010,4,Prin of Marketing,0.27,0.43,0.2,0.09,0.02,0.0,0.0,0.0,amanda cooper fine,MKT-3010,2015
-MKT,3010,5,Prin of Marketing,0.36,0.4,0.19,0.03,0.01,0.0,0.0,0.02,james gaubert,MKT-3010,2015
-MKT,3010,6,Prin of Marketing,0.42,0.38,0.17,0.03,0.0,0.0,0.0,0.0,patricia knowles,MKT-3010,2015
-MKT,3020,1,Consumer Behavior,0.45,0.38,0.09,0.05,0.02,0.0,0.0,0.02,jennifer di siemens,MKT-3020,2015
-MKT,3020,2,Consumer Behavior,0.46,0.41,0.11,0.02,0.0,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2015
-MKT,3020,3,Consumer Behavior,0.26,0.49,0.18,0.05,0.02,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2015
-MKT,3020,4,Consumer Behavior,0.42,0.39,0.11,0.07,0.02,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2015
-MKT,3210,1,Sports Marketing,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2015
-MKT,3980,1,Sales Experiential,0.82,0.11,0.05,0.0,0.02,0.0,0.0,0.0,carter wil mcelveen,MKT-3980,2015
-MKT,4200,1,Professional Selling,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2015
-MKT,4200,2,Professional Selling,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2015
-MKT,4200,3,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,MKT-4200,2015
-MKT,4200,4,Professional Selling,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,gary hunter,MKT-4200,2015
-MKT,4230,1,Promotional Strategy,0.21,0.52,0.17,0.05,0.02,0.0,0.0,0.02,patricia knowles,MKT-4230,2015
-MKT,4240,1,Sales Management,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4240,2015
-MKT,4260,1,Business-to-Business,0.38,0.58,0.02,0.0,0.02,0.0,0.0,0.0,james gaubert,MKT-4260,2015
-MKT,4270,1,International Mktg,0.11,0.54,0.34,0.0,0.0,0.0,0.0,0.0,thomas poehlman,MKT-4270,2015
-MKT,4270,2,International Mktg,0.29,0.42,0.29,0.0,0.0,0.0,0.0,0.0,thomas poehlman,MKT-4270,2015
-MKT,4270,3,International Mktg,0.26,0.5,0.21,0.02,0.0,0.0,0.0,0.0,roger gomes,MKT-4270,2015
-MKT,4270,4,International Mktg,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,roger gomes,MKT-4270,2015
-MKT,4270,5,International Mktg,0.22,0.46,0.27,0.02,0.0,0.0,0.0,0.02,roger gomes,MKT-4270,2015
-MKT,4280,1,Services Marketing,0.15,0.55,0.25,0.03,0.03,0.0,0.0,0.0,mary anne raymond,MKT-4280,2015
-MKT,4280,2,Services Marketing,0.28,0.52,0.08,0.04,0.04,0.0,0.0,0.04,mary anne raymond,MKT-4280,2015
-MKT,4310,1,Marketing Research,0.28,0.66,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2015
-MKT,4310,2,Marketing Research,0.37,0.56,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2015
-MKT,4310,3,Marketing Research,0.21,0.64,0.11,0.04,0.0,0.0,0.0,0.0,william kilbourne,MKT-4310,2015
-MKT,4330,1,Sport Mkt Strategy,0.33,0.57,0.05,0.0,0.0,0.0,0.0,0.05,amanda cooper fine,MKT-4330,2015
-MKT,4430,1,Advertising Strategy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,albert neil cameron,MKT-4430,2015
-MKT,4450,1,Macromarketing,0.44,0.48,0.04,0.0,0.0,0.04,0.0,0.0,william kilbourne,MKT-4450,2015
-MKT,4500,1,Strategic Mktg Mgt,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2015
-MKT,4500,2,Strategic Mktg Mgt,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4500,2015
-MKT,4500,3,Strategic Mktg Mgt,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-4500,2015
-MKT,4500,4,Strategic Mktg Mgt,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4500,2015
-MKT,4950,1,Selected Topics,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,peter weathers,MKT-4950,2015
-MKT,8620,1,Quant Methods in Mkt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,MKT-8620,2015
-MKT,8650,1,Seminar in Mkt Mgmt,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,MKT-8650,2015
-MKT,8660,1,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-8660,2015
-ML,1020,1,Leadership Fund II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert rozetar,ML-1020,2015
-ML,1020,2,Leadership Fund II,0.82,0.09,0.0,0.0,0.05,0.0,0.0,0.05,robert rozetar,ML-1020,2015
-ML,2020,2,Leadership Dev II,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,ML-2020,2015
-ML,3020,2,Adv Leadership II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,ML-3020,2015
-ML,4020,1,Org Leadership II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,ML-4020,2015
-ML,4020,3,Org Leadership II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,ML-4020,2015
-MSE,2100,1,Intro to Mat Science,0.4,0.27,0.19,0.06,0.06,0.0,0.0,0.03,marian kennedy,MSE-2100,2015
-MSE,2100,2,Intro to Mat Science,0.5,0.24,0.13,0.04,0.01,0.0,0.0,0.08,eric skaar,MSE-2100,2015
-MSE,2100,3,Intro to Mat Science,0.22,0.34,0.22,0.11,0.09,0.0,0.0,0.02,julie patric martin,MSE-2100,2015
-MSE,2500,1,Polymer & Fiber Materials I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,MSE-2500,2015
-MSE,2500,2,Polymer & Fiber Materials I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,MSE-2500,2015
-MSE,3260,1,Thermo of Materials,0.19,0.32,0.27,0.15,0.03,0.0,0.0,0.03,gary lickfield,MSE-3260,2015
-MSE,3280,1,Phase Diagrams,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,eric skaar,MSE-3280,2015
-MSE,3610,1,Proc of Metals & Com,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,marian kennedy,MSE-3610,2015
-MSE,4160,1,Electronic Materials,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,kyle brinkman,MSE-4160,2015
-MSE,4220,1,Mech Behavior of Mat,0.35,0.54,0.11,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,MSE-4220,2015
-MSE,4240,1,Optical Materials,0.23,0.38,0.38,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,MSE-4240,2015
-MSE,4330,1,Comb Sys & Env Emiss,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,MSE-4330,2015
-MSE,4560,1,Polymer & Fiber Materials II,0.27,0.46,0.27,0.0,0.0,0.0,0.0,0.0,gary lickfield,MSE-4560,2015
-MSE,4590,1,Color Science Lab,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,philip brown,MSE-4590,2015
-MSE,8280,1,Phase Transformation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,MSE-8280,2015
-MUSC,1110,7,Beginning Class Guitar,0.8,0.1,0.0,0.1,0.0,0.0,0.0,0.0,david stevenson,MUSC-1110,2015
-MUSC,1110,9,Beginning Class Guitar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,david stevenson,MUSC-1110,2015
-MUSC,1420,1,Music Theory I,0.58,0.17,0.0,0.0,0.08,0.0,0.0,0.17,david conley,MUSC-1420,2015
-MUSC,1430,1,Aural Skills I,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,david conley,MUSC-1430,2015
-MUSC,1510,15,Applied Music - Piano,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,cindy roden goodloe,MUSC-1510,2015
-MUSC,1800,1,Intro to Music Tech,0.36,0.36,0.18,0.0,0.0,0.0,0.0,0.09,hamilton altstatt,MUSC-1800,2015
-MUSC,2100,1,Music in West World,0.72,0.22,0.03,0.0,0.03,0.0,0.0,0.0,eric lapin,MUSC-2100,2015
-MUSC,2100,2,Music in West World,0.56,0.25,0.06,0.03,0.0,0.0,0.0,0.09,lisa sain odom,MUSC-2100,2015
-MUSC,2100,3,Music in West World,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-2100,2015
-MUSC,2100,4,Music in West World,0.47,0.31,0.19,0.0,0.0,0.0,0.0,0.03,linda li-bleuel,MUSC-2100,2015
-MUSC,2100,5,Music in West World,0.61,0.26,0.06,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,MUSC-2100,2015
-MUSC,2100,6,Music in West World,0.77,0.16,0.0,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,MUSC-2100,2015
-MUSC,2100,7,Music in West World,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,MUSC-2100,2015
-MUSC,2100,12,Music in West World,0.55,0.35,0.06,0.0,0.0,0.0,0.0,0.03,lea kibler,MUSC-2100,2015
-MUSC,2100,13,Music in West World,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,linda dzuris,MUSC-2100,2015
-MUSC,3110,1,History of American Music,0.5,0.34,0.09,0.03,0.0,0.0,0.0,0.03,ned hosler,MUSC-3110,2015
-MUSC,3120,1,History of Jazz,0.44,0.28,0.22,0.06,0.0,0.0,0.0,0.0,eric lapin,MUSC-3120,2015
-MUSC,3170,1,Hist of Country Mus,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,ned hosler,MUSC-3170,2015
-MUSC,3310,1,Pep Band - Men,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,MUSC-3310,2015
-MUSC,3690,1,Symphony Orchestra,0.91,0.07,0.0,0.0,0.0,0.0,0.0,0.02,andrew levin,MUSC-3690,2015
-MUSC,4160,1,Mus Hist Since 1750,0.35,0.09,0.3,0.0,0.17,0.0,0.0,0.09,linda li-bleuel,MUSC-4160,2015
-MUSC,4300,1,Conducting,0.3,0.3,0.2,0.0,0.2,0.0,0.0,0.0,justin durham,MUSC-4300,2015
-NPL,3010,2,NPL Stakeholders,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,tracy diane lamb,NPL-3010,2015
-NURS,3030,1,Nursing of Adults,0.35,0.57,0.06,0.02,0.0,0.0,0.0,0.0,leslie anne  ravan,NURS-3030,2015
-NURS,3030,400,Nursing of Adults,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,wanda leigh taylor,NURS-3030,2015
-NURS,3040,1,Pathophysiology,0.33,0.58,0.03,0.06,0.0,0.0,0.0,0.0,catherine si murton,NURS-3040,2015
-NURS,3040,401,Pathophysiology for RN,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,NURS-3040,2015
-NURS,3100,1,Health Assessment,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3100,2015
-NURS,3120,1,Foundations of Nurs,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,angela pye,NURS-3120,2015
-NURS,3190,400,Health Assessment for RNs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,NURS-3190,2015
-NURS,3200,1,Prof in Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,NURS-3200,2015
-NURS,3400,1,Pharmther Nursing,0.37,0.59,0.02,0.02,0.0,0.0,0.0,0.0,catherine si murton,NURS-3400,2015
-NURS,4010,1,Mental Health Nurs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-4010,2015
-NURS,4030,1,Complex Nursing of Adults,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,NURS-4030,2015
-NURS,4110,1,Nursing of Children,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-4110,2015
-NURS,4120,1,Nurs Women and Fam,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2015
-NURS,4250,400,Community Nursing,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,roxanne amerson,NURS-4250,2015
-NURS,8080,400,Nurs Res Stat Analys,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-8080,2015
-NURS,8190,400,Developing Family,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,NURS-8190,2015
-NURS,8200,400,Child & Adol Nursing,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-8200,2015
-NURS,8210,400,Adult Nursing,0.69,0.29,0.03,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8210,2015
-NURS,8850,400,Mental Health in Primary Care,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-8850,2015
-NUTR,2030,1,Intro Princ of Human Nutrition,0.44,0.39,0.12,0.01,0.0,0.0,0.0,0.03,deborah an hutcheon,NUTR-2030,2015
-NUTR,2040,1,Nutrition Across Life Cycle,0.4,0.42,0.11,0.07,0.0,0.0,0.0,0.0,deborah an hutcheon,NUTR-2040,2015
-NUTR,4250,1,Medica Nutr Thera II,0.55,0.39,0.04,0.0,0.02,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4250,2015
-NUTR,4260,1,Community Nutrition,0.49,0.45,0.06,0.0,0.0,0.0,0.0,0.0,rita haliena,NUTR-4260,2015
-NUTR,4550,1,Nutr Metabolism,0.36,0.38,0.12,0.08,0.0,0.0,0.0,0.06,elliot jesch,NUTR-4550,2015
-PA,2800,1,Perf Arts Pract II,0.35,0.29,0.06,0.0,0.12,0.0,0.0,0.18,kenneth moore,PA-2800,2015
-PA,4010,1,Capstone Project,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,anthony penna,PA-4010,2015
-PADM,8220,400,Public Policy Process,0.77,0.08,0.0,0.0,0.08,0.0,0.0,0.08,mark daniel mellott,PADM-8220,2015
-PADM,8410,400,Public Data Analysis,0.17,0.75,0.0,0.0,0.08,0.0,0.0,0.0,ronald chrestman,PADM-8410,2015
-PADM,8410,401,Public Data Analysis,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,ronald chrestman,PADM-8410,2015
-PADM,8500,400,Homeland Security Fundamentals,0.44,0.22,0.0,0.0,0.11,0.0,0.0,0.22,david leigh cook,PADM-8500,2015
-PADM,8650,400,Leadership in the Nonprft Sect,0.67,0.0,0.0,0.0,0.11,0.0,0.0,0.22,renee salic nichols,PADM-8650,2015
-PES,2020,1,Soils,0.27,0.35,0.27,0.06,0.04,0.0,0.0,0.0,dara michelle park,PES-2020,2015
-PES,4330,1,Landscape & Turf Weed Mgt,0.14,0.64,0.14,0.0,0.0,0.0,0.0,0.07,ted whitwell,PES-4330,2015
-PES,4520,1,Soil Fertility and Management,0.29,0.57,0.0,0.0,0.07,0.0,0.0,0.07,haibo liu,PES-4520,2015
-PES,6520,1,Soil Fertility and Management,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,haibo liu,PES-6520,2015
-PHIL,1010,1,Intro to Phil Prob,0.5,0.26,0.15,0.0,0.03,0.0,0.0,0.06,christopher grau,PHIL-1010,2015
-PHIL,1010,2,Intro to Phil Prob,0.57,0.23,0.11,0.0,0.06,0.0,0.0,0.03,david stegall,PHIL-1010,2015
-PHIL,1010,3,Intro to Phil Prob,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.03,david stegall,PHIL-1010,2015
-PHIL,1020,1,Intro to Logic,0.58,0.17,0.06,0.17,0.0,0.0,0.0,0.03,michael hal hannen,PHIL-1020,2015
-PHIL,1020,2,Intro to Logic,0.83,0.09,0.0,0.09,0.0,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2015
-PHIL,1020,3,Intro to Logic,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.03,gregory scott moss,PHIL-1020,2015
-PHIL,1020,4,Intro to Logic,0.63,0.29,0.06,0.03,0.0,0.0,0.0,0.0,gregory scott moss,PHIL-1020,2015
-PHIL,1020,5,Intro to Logic,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,gregory scott moss,PHIL-1020,2015
-PHIL,1020,6,Intro to Logic,0.57,0.37,0.03,0.03,0.0,0.0,0.0,0.0,kelly smith,PHIL-1020,2015
-PHIL,1030,1,Intro to Ethics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,PHIL-1030,2015
-PHIL,1030,2,Intro to Ethics,0.59,0.35,0.0,0.0,0.03,0.0,0.0,0.03,michael hal hannen,PHIL-1030,2015
-PHIL,1030,3,Intro to Ethics,0.65,0.29,0.03,0.0,0.0,0.0,0.0,0.03,ryan lake,PHIL-1030,2015
-PHIL,1030,4,Intro to Ethics,0.46,0.4,0.09,0.0,0.03,0.0,0.0,0.03,ryan lake,PHIL-1030,2015
-PHIL,1030,5,Intro to Ethics,0.35,0.56,0.06,0.0,0.0,0.0,0.0,0.03,ryan lake,PHIL-1030,2015
-PHIL,1030,6,Intro to Ethics,0.44,0.35,0.15,0.0,0.03,0.0,0.0,0.03,stephen satris,PHIL-1030,2015
-PHIL,3030,1,Phil of Religion,0.34,0.57,0.03,0.0,0.0,0.0,0.0,0.06,gregory scott moss,PHIL-3030,2015
-PHIL,3140,1,Comp East West Phil,0.32,0.26,0.26,0.0,0.05,0.0,0.0,0.11,yanming an,PHIL-3140,2015
-PHIL,3150,1,Ancient Philosophy,0.28,0.31,0.21,0.03,0.03,0.0,0.0,0.14,jennifer ingle,PHIL-3150,2015
-PHIL,3160,1,Mod Phil,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,michael hal hannen,PHIL-3160,2015
-PHIL,3260,1,Science and Values,0.4,0.49,0.0,0.0,0.06,0.0,0.0,0.06,andrew garnar,PHIL-3260,2015
-PHIL,3260,2,Science and Values,0.4,0.51,0.03,0.03,0.0,0.0,0.0,0.03,andrew garnar,PHIL-3260,2015
-PHIL,3260,3,Science and Values,0.46,0.43,0.09,0.0,0.0,0.0,0.0,0.03,andrew garnar,PHIL-3260,2015
-PHIL,3330,1,Metaphysics,0.91,0.04,0.0,0.0,0.04,0.0,0.0,0.0,david stegall,PHIL-3330,2015
-PHIL,3430,1,Phil of Law,0.82,0.12,0.0,0.0,0.03,0.0,0.0,0.03,david stegall,PHIL-3430,2015
-PHIL,3440,1,Business Ethics,0.13,0.56,0.18,0.03,0.0,0.0,0.0,0.1,diane perpich,PHIL-3440,2015
-PHIL,3450,1,Environmental Ethics,0.39,0.5,0.08,0.0,0.03,0.0,0.0,0.0,jennifer ingle,PHIL-3450,2015
-PHIL,3510,1,Phil of Emotion,0.21,0.39,0.21,0.04,0.04,0.0,0.0,0.11,charles starkey,PHIL-3510,2015
-PHIL,3550,1,Phil Mind & Cog Sci,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,ryan lake,PHIL-3550,2015
-PHSC,1170,1,Intro Chem & Earth,0.82,0.17,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1170,2015
-PHYS,1220,1,Physics With Cal I,0.16,0.38,0.24,0.08,0.1,0.0,0.0,0.04,lih-sin the,PHYS-1220,2015
-PHYS,1220,2,Physics With Cal I,0.24,0.4,0.24,0.05,0.02,0.0,0.0,0.03,lih-sin the,PHYS-1220,2015
-PHYS,1220,3,Physics With Cal I,0.28,0.41,0.21,0.05,0.02,0.0,0.0,0.03,lih-sin the,PHYS-1220,2015
-PHYS,1220,4,Physics With Cal I,0.34,0.35,0.18,0.05,0.03,0.0,0.0,0.05,ramakrishna podila,PHYS-1220,2015
-PHYS,1220,5,Physics With Cal I,0.21,0.42,0.27,0.05,0.03,0.0,0.0,0.02,mark leising,PHYS-1220,2015
-PHYS,1220,8,Physics With Cal I (HON),0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,joan marler,PHYS-1220,2015
-PHYS,1240,1,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,2,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,3,Physics Lab I,0.18,0.71,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,PHYS-1240,2015
-PHYS,1240,4,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,5,Physics Lab I,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,6,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,7,Physics Lab I,0.4,0.53,0.0,0.07,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,8,Physics Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,PHYS-1240,2015
-PHYS,1240,9,Physics Lab I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,10,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,11,Physics Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,12,Physics Lab I,0.17,0.72,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,13,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,14,Physics Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,15,Physics Lab I,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,16,Physics Lab I,0.06,0.89,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,17,Physics Lab I,0.22,0.67,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,18,Physics Lab I,0.17,0.61,0.11,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2015
-PHYS,1240,19,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,20,Physics Lab I,0.33,0.44,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,21,Physics Lab I,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,22,Physics Lab I,0.44,0.31,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,PHYS-1240,2015
-PHYS,1240,23,Physics Lab I,0.41,0.47,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,24,Physics Lab I,0.28,0.61,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,25,Physics Lab I,0.31,0.44,0.19,0.0,0.06,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,26,Physics Lab I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,1240,27,Physics Lab I,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2015
-PHYS,1240,28,Physics Lab I,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jerry hester,PHYS-1240,2015
-PHYS,1240,29,Physics Lab I,0.12,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2015
-PHYS,2000,1,Introductory Physics,0.46,0.39,0.07,0.07,0.0,0.0,0.0,0.02,sean brittain,PHYS-2000,2015
-PHYS,2070,1,General Physics I,0.36,0.36,0.15,0.08,0.03,0.0,0.0,0.03,pooja puneet,PHYS-2070,2015
-PHYS,2080,1,General Physics II,0.46,0.35,0.11,0.03,0.02,0.0,0.0,0.02,amy liann pope,PHYS-2080,2015
-PHYS,2080,2,General Physics II,0.64,0.29,0.04,0.01,0.0,0.0,0.0,0.01,amy liann pope,PHYS-2080,2015
-PHYS,2090,1,Gen Phys Lab I,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,2,Gen Phys Lab I,0.36,0.5,0.05,0.0,0.05,0.0,0.0,0.05,jerry hester,PHYS-2090,2015
-PHYS,2090,3,Gen Phys Lab I,0.7,0.13,0.09,0.0,0.04,0.0,0.0,0.04,jerry hester,PHYS-2090,2015
-PHYS,2090,4,Gen Phys Lab I,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2015
-PHYS,2090,5,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,6,Gen Phys Lab I,0.17,0.75,0.0,0.0,0.04,0.0,0.0,0.04,jerry hester,PHYS-2090,2015
-PHYS,2090,7,Gen Phys Lab I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,8,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,9,Gen Phys Lab I,0.5,0.29,0.13,0.08,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2090,10,Gen Phys Lab I,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2015
-PHYS,2100,1,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,2,Gen Phys Lab II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,3,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,4,Gen Phys Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,5,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,6,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,7,Gen Phys Lab II,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,8,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,9,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,10,Gen Phys Lab II,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2015
-PHYS,2100,11,Gen Phys Lab II,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,12,Gen Phys Lab II,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,13,Gen Phys Lab II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,14,Gen Phys Lab II,0.14,0.55,0.14,0.0,0.05,0.0,0.0,0.14,jerry hester,PHYS-2100,2015
-PHYS,2100,15,Gen Phys Lab II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2100,16,Gen Phys Lab II,0.1,0.5,0.3,0.05,0.0,0.0,0.0,0.05,jerry hester,PHYS-2100,2015
-PHYS,2100,17,Gen Phys Lab II,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,PHYS-2100,2015
-PHYS,2210,1,Physics With Cal II,0.32,0.34,0.21,0.06,0.03,0.0,0.0,0.03,jason stratfo brown,PHYS-2210,2015
-PHYS,2210,2,Physics With Cal II,0.22,0.38,0.2,0.08,0.08,0.0,0.0,0.03,jason stratfo brown,PHYS-2210,2015
-PHYS,2210,3,Physics With Cal II,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,murray daw,PHYS-2210,2015
-PHYS,2220,1,Phys With Cal III,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,jian he,PHYS-2220,2015
-PHYS,2230,1,Physics Lab II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,2,Physics Lab II,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2015
-PHYS,2230,3,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,4,Physics Lab II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,5,Physics Lab II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2230,6,Physics Lab II,0.36,0.5,0.0,0.0,0.07,0.0,0.0,0.07,jerry hester,PHYS-2230,2015
-PHYS,2230,7,Physics Lab II,0.25,0.63,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2015
-PHYS,2230,8,Physics Lab II,0.18,0.71,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2015
-PHYS,2230,9,Physics Lab II,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2015
-PHYS,2240,1,Physics Lab III,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2240,2015
-PHYS,2400,1,Phys of Weather,0.3,0.3,0.18,0.05,0.05,0.0,0.0,0.13,miguel larsen,PHYS-2400,2015
-PHYS,3110,1,Methods Theor Phys,0.64,0.09,0.0,0.18,0.09,0.0,0.0,0.0,hye jung kang,PHYS-3110,2015
-PHYS,3260,1,Exper Physics II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,chad sosolik,PHYS-3260,2015
-PHYS,3560,1,Modern Physics,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,chad sosolik,PHYS-3560,2015
-PHYS,4560,1,Quantum Physics II,0.0,0.5,0.5,0.0,0.0,0.0,0.0,0.0,antony valentini,PHYS-4560,2015
-PHYS,4650,1,Thermo and Stat Mech,0.21,0.36,0.14,0.21,0.0,0.0,0.0,0.07,jens oberheide,PHYS-4650,2015
-PHYS,8150,1,Statistical Therm I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,PHYS-8150,2015
-PHYS,8410,1,Electrodynamics I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,PHYS-8410,2015
-PHYS,9520,1,Quantum Mech II,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,PHYS-9520,2015
-PKSC,1020,1,Intro to Pkg Sci,0.14,0.39,0.31,0.07,0.06,0.0,0.0,0.03,heather batt,PKSC-1020,2015
-PKSC,2010,1,Pkg Perishable Prod,0.15,0.42,0.23,0.12,0.07,0.0,0.0,0.01,heather batt,PKSC-2010,2015
-PKSC,2020,1,Packaging Mtl & Mfg,0.81,0.03,0.1,0.0,0.06,0.0,0.0,0.0,robert truett moore,PKSC-2020,2015
-PKSC,2040,1,Container Systems,0.74,0.19,0.07,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2040,2015
-PKSC,2060,1,Container Sys Lab,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2060,2015
-PKSC,2060,2,Container Sys Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2060,2015
-PKSC,2060,3,Container Sys Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2060,2015
-PKSC,2200,1,Product & Pkg Design,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,william aaro snyder,PKSC-2200,2015
-PKSC,3200,1,Pkg Design Theory,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,rupert hurley,PKSC-3200,2015
-PKSC,3680,1,Pkg and Society,0.41,0.38,0.15,0.03,0.03,0.0,0.0,0.0,heather batt,PKSC-3680,2015
-PKSC,4030,1,Pkg Career Prep,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2015
-PKSC,4200,1,Pkg Design & Dev,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2015
-PKSC,4300,1,Converting Flex Pkg,0.32,0.53,0.12,0.02,0.0,0.0,0.0,0.02,duncan darby,PKSC-4300,2015
-PKSC,4400,1,Packaging for Distribution,0.31,0.46,0.19,0.04,0.0,0.0,0.0,0.0,gregory batt,PKSC-4400,2015
-PKSC,4640,1,Fd & Hc Pkg Systems,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2015
-PKSC,8510,1,Pkg Sci Seminar,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,anthony lou pometto,PKSC-8510,2015
-PLPA,2130,1,Fungi & Civilization,0.45,0.3,0.18,0.01,0.01,0.0,0.0,0.05,julia loui kerrigan,PLPA-2130,2015
-PLPA,8090,1,Analytical Technique,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,tharayil-santhakumar,PLPA-8090,2015
-POSC,1010,1,Amer National Govt,0.23,0.49,0.1,0.03,0.05,0.0,0.0,0.1,joseph earl stewart,POSC-1010,2015
-POSC,1010,2,Amer National Govt,0.08,0.28,0.31,0.15,0.13,0.0,0.0,0.05,adam warber,POSC-1010,2015
-POSC,1020,1,Intro Intl Relations,0.08,0.47,0.38,0.06,0.0,0.0,0.0,0.0,aron geo tannenbaum,POSC-1020,2015
-POSC,1020,2,Intro Intl Relations,0.14,0.39,0.31,0.06,0.06,0.0,0.0,0.04,zeynep taydas,POSC-1020,2015
-POSC,1020,3,Intro Intl Relations,0.25,0.48,0.19,0.01,0.04,0.0,0.0,0.03,lydia loui lundgren,POSC-1020,2015
-POSC,1030,1,Intro to Political Theory,0.27,0.3,0.27,0.08,0.05,0.0,0.0,0.03,brandon turner,POSC-1030,2015
-POSC,1040,1,Intro Compar Pol,0.11,0.45,0.23,0.14,0.0,0.0,0.0,0.07,colin pearce,POSC-1040,2015
-POSC,1040,2,Intro Compar Pol,0.29,0.5,0.1,0.02,0.02,0.0,0.0,0.06,katherine am curtis,POSC-1040,2015
-POSC,1990,1,Intro Pol Sci,0.42,0.21,0.25,0.06,0.04,0.0,0.0,0.02,meredith petersheim,POSC-1990,2015
-POSC,3020,1,State and Loc Gov,0.1,0.51,0.27,0.02,0.05,0.0,0.0,0.05,bruce ransom,POSC-3020,2015
-POSC,3210,1,Public Admin,0.1,0.38,0.43,0.02,0.07,0.0,0.0,0.0,james woodard,POSC-3210,2015
-POSC,3610,1,Intl Pol in Crisis,0.47,0.37,0.1,0.0,0.03,0.0,0.0,0.03,vladimir matic,POSC-3610,2015
-POSC,3610,2,Intl Pol in Crisis,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,jeremy fortier,POSC-3610,2015
-POSC,3630,1,Us Foreign Policy,0.26,0.35,0.24,0.03,0.12,0.0,0.0,0.0,steven vince miller,POSC-3630,2015
-POSC,3710,1,European Politics,0.29,0.5,0.19,0.02,0.0,0.0,0.0,0.0,katherine am curtis,POSC-3710,2015
-POSC,3750,1,European Integration,0.08,0.23,0.46,0.0,0.08,0.0,0.0,0.15,zeynep taydas,POSC-3750,2015
-POSC,3890,1,Rel. Liberty & Constitution,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,POSC-3890,2015
-POSC,4030,1,United States Congress,0.32,0.52,0.08,0.0,0.04,0.0,0.0,0.04,jeffrey scott peake,POSC-4030,2015
-POSC,4050,1,American Presidency,0.05,0.23,0.32,0.09,0.18,0.0,0.0,0.14,adam warber,POSC-4050,2015
-POSC,4360,1,Law Courts Politics,0.79,0.08,0.04,0.0,0.04,0.0,0.0,0.04,joseph earl stewart,POSC-4360,2015
-POSC,4370,1,Constitut Law: Rights & Libert,0.48,0.42,0.0,0.0,0.03,0.0,0.0,0.06,daniel frost,POSC-4370,2015
-POSC,4490,1,Political Theory of Capitalism,0.23,0.3,0.23,0.07,0.07,0.0,0.0,0.1,brandon turner,POSC-4490,2015
-POSC,4530,1,American Political Thought,0.22,0.56,0.17,0.03,0.03,0.0,0.0,0.0, bradley thompson,POSC-4530,2015
-POSC,4540,1,Southern Politics,0.07,0.47,0.4,0.0,0.07,0.0,0.0,0.0,james woodard,POSC-4540,2015
-POSC,4570,1,Political Terrorism,0.37,0.44,0.15,0.02,0.0,0.0,0.0,0.02,aron geo tannenbaum,POSC-4570,2015
-POSC,4760,1,Middle East Politics,0.36,0.45,0.05,0.05,0.05,0.0,0.0,0.05,vladimir matic,POSC-4760,2015
-POSC,4820,1,Political Novel and Film,0.13,0.39,0.39,0.04,0.0,0.0,0.0,0.04,james woodard,POSC-4820,2015
-PRTM,2000,7,Prof & Prac in PRTM,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,brandon harris,PRTM-2000,2015
-PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,PRTM-2070,2015
-PRTM,2200,2,Foundations of PRTM,0.28,0.55,0.14,0.0,0.0,0.0,0.0,0.03,teresa walto tucker,PRTM-2200,2015
-PRTM,2200,3,Foundations of PRTM,0.47,0.37,0.07,0.07,0.0,0.0,0.0,0.03,gwynn powell,PRTM-2200,2015
-PRTM,2200,4,Foundations of PRTM,0.41,0.38,0.17,0.03,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2200,2015
-PRTM,2200,5,Foundations of PRTM,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,cindy hartman,PRTM-2200,2015
-PRTM,2200,6,Foundations of PRTM,0.72,0.12,0.12,0.04,0.0,0.0,0.0,0.0,katherine an jordan,PRTM-2200,2015
-PRTM,2200,7,Foundations of PRTM,0.62,0.28,0.03,0.07,0.0,0.0,0.0,0.0,brandon harris,PRTM-2200,2015
-PRTM,2410,1,Intro to CRSCM,0.25,0.52,0.2,0.03,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2410,2015
-PRTM,2600,1,Found of Recreational Therapy,0.87,0.07,0.02,0.0,0.04,0.0,0.0,0.0,anna-mar chancellor,PRTM-2600,2015
-PRTM,2650,1,Terminology in RT Practice,0.73,0.13,0.07,0.02,0.05,0.0,0.0,0.0,stephen thoma lewis,PRTM-2650,2015
-PRTM,2700,1,Intro Rec Res Mgt,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,lincoln larson,PRTM-2700,2015
-PRTM,2810,1,Intro to Golf Mgt,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-2810,2015
-PRTM,2820,1,Principle Golfer Dev,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-2820,2015
-PRTM,2830,1,Adv Mth Golf Teachng,0.5,0.25,0.08,0.17,0.0,0.0,0.0,0.0,adam savedra,PRTM-2830,2015
-PRTM,2980,4,Creative Inquiry in PRTM II,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2980,2015
-PRTM,2980,7,Creative Inquiry in PRTM II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2980,2015
-PRTM,2980,8,Creative Inquiry in PRTM II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2980,2015
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.4,0.31,0.17,0.06,0.06,0.0,0.0,0.0,daniel mor anderson,PRTM-3050,2015
-PRTM,3070,1,Facility Operations,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,craig goodman,PRTM-3070,2015
-PRTM,3250,1,Global Persp in Rec,0.08,0.7,0.15,0.03,0.03,0.0,0.0,0.03,teresa walto tucker,PRTM-3250,2015
-PRTM,3270,1,RT Impl & Eval: Ment Hlth Cond,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3270,2015
-PRTM,3420,1,Intro to Tourism,0.55,0.31,0.1,0.0,0.02,0.0,0.0,0.02,william norman,PRTM-3420,2015
-PRTM,3420,2,Intro to Tourism,0.56,0.31,0.03,0.0,0.03,0.0,0.0,0.06,maloud shakona,PRTM-3420,2015
-PRTM,3440,1,Tourism Markets,0.45,0.23,0.23,0.05,0.0,0.0,0.0,0.05,sheila backman,PRTM-3440,2015
-PRTM,3440,2,Tourism Markets,0.55,0.29,0.14,0.0,0.0,0.0,0.0,0.02,sheila backman,PRTM-3440,2015
-PRTM,3450,1,Tourism Management,0.81,0.1,0.06,0.0,0.0,0.0,0.0,0.03,lauren duffy,PRTM-3450,2015
-PRTM,3460,1,Heritage Tourism,0.47,0.38,0.09,0.02,0.0,0.0,0.0,0.04,gregory phi ramshaw,PRTM-3460,2015
-PRTM,3470,1,Sport Tourism,0.33,0.36,0.21,0.03,0.03,0.0,0.0,0.03,gregory phi ramshaw,PRTM-3470,2015
-PRTM,3530,1,Foundations of Camp Counseling,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,gwynn powell,PRTM-3530,2015
-PRTM,3550,1,Trends & Issues in Camp Mgt,0.64,0.14,0.14,0.0,0.0,0.0,0.0,0.07,teresa walto tucker,PRTM-3550,2015
-PRTM,3830,1,Golf Shop Operations,0.54,0.23,0.15,0.08,0.0,0.0,0.0,0.0,richard lucas,PRTM-3830,2015
-PRTM,3910,2,Intro to GIS for PRTM,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,david lawrenc white,PRTM-3910,2015
-PRTM,4210,1,Rec Fin Resc Mgt,0.35,0.32,0.16,0.06,0.03,0.0,0.0,0.06,daniel mor anderson,PRTM-4210,2015
-PRTM,4260,1,Trends & Issues in Rec Therapy,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-4260,2015
-PRTM,4300,1,World Geog Parks,0.23,0.6,0.17,0.0,0.0,0.0,0.0,0.0,robert baxte powell,PRTM-4300,2015
-PRTM,4310,1,Methods Envir Inter,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-4310,2015
-PRTM,4450,1,Conventions,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,jeffery martin,PRTM-4450,2015
-PRTM,4460,2,Community Tourism,0.19,0.63,0.15,0.0,0.0,0.0,0.0,0.04,herbert chancellor,PRTM-4460,2015
-PRTM,4470,1,Perspect Intl Travel,0.61,0.23,0.13,0.0,0.0,0.0,0.0,0.03,lauren duffy,PRTM-4470,2015
-PRTM,4510,1,Seminar in CRSCM,0.26,0.56,0.15,0.0,0.03,0.0,0.0,0.0,cindy hartman,PRTM-4510,2015
-PRTM,4540,1,Trends in Sport Mgt,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,PRTM-4540,2015
-PRTM,4550,1,Adv Program Planning,0.58,0.25,0.0,0.17,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-4550,2015
-PRTM,4980,2,Creative Inquiry in PRTM IV,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,PRTM-4980,2015
-PRTM,4980,3,Creative Inquiry in PRTM IV,0.8,0.0,0.0,0.0,0.2,0.0,0.0,0.0,kellie aman walters,PRTM-4980,2015
-PRTM,4980,6,Creative Inquiry in PRTM IV,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-4980,2015
-PRTM,4980,8,Creative Inquiry in PRTM IV,0.5,0.1,0.4,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,PRTM-4980,2015
-PRTM,8030,1,Sem Rec & Park Admin,0.63,0.21,0.0,0.0,0.13,0.0,0.0,0.04,skye arthur-banning,PRTM-8030,2015
-PRTM,8110,2,Research Methods,0.81,0.12,0.0,0.0,0.04,0.0,0.0,0.04,jeffrey charl hallo,PRTM-8110,2015
-PRTM,8210,1,Alt Funding for PRTM,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-8210,2015
-PRTM,8250,1,Populations in PRTM,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,PRTM-8250,2015
-PRTM,8400,2,Tourism Planning,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,william norman,PRTM-8400,2015
-PSYC,2010,1,Intro to Psychology,0.31,0.31,0.2,0.08,0.05,0.0,0.0,0.06,jo anne jorgensen,PSYC-2010,2015
-PSYC,2010,2,Intro to Psychology,0.28,0.38,0.23,0.05,0.04,0.0,0.0,0.02,edwin brainerd,PSYC-2010,2015
-PSYC,2010,3,Intro to Psychology,0.39,0.24,0.23,0.06,0.04,0.0,0.0,0.04,mary taylor,PSYC-2010,2015
-PSYC,2010,4,Intro to Psychology,0.41,0.35,0.13,0.03,0.04,0.0,0.0,0.04,mary taylor,PSYC-2010,2015
-PSYC,2010,5,Intro to Psychology,0.3,0.44,0.1,0.06,0.06,0.0,0.0,0.04,fred switzer,PSYC-2010,2015
-PSYC,2010,20,Intro to Psychology (HON),0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,robin mari kowalski,PSYC-2010,2015
-PSYC,2020,1,Intro Psychology Lab,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,eric mckibben,PSYC-2020,2015
-PSYC,2020,3,Intro Psychology Lab,0.84,0.12,0.0,0.0,0.04,0.0,0.0,0.0,eric mckibben,PSYC-2020,2015
-PSYC,2020,4,Intro Psychology Lab,0.86,0.0,0.1,0.0,0.05,0.0,0.0,0.0,eric mckibben,PSYC-2020,2015
-PSYC,2020,6,Intro Psychology Lab,0.82,0.05,0.0,0.0,0.09,0.0,0.0,0.05,lauren elizab ellis,PSYC-2020,2015
-PSYC,3060,1,Human Sexual Beh,0.62,0.19,0.11,0.04,0.03,0.0,0.0,0.01,bruce michael king,PSYC-3060,2015
-PSYC,3090,100,Intro Exp Psych,0.27,0.34,0.22,0.05,0.07,0.0,0.0,0.05,richard tyrrell,PSYC-3090,2015
-PSYC,3090,200,Intro Exp Psych,0.41,0.31,0.17,0.03,0.07,0.0,0.0,0.0,jennifer bai bisson,PSYC-3090,2015
-PSYC,3090,300,Intro Exp Psych,0.77,0.13,0.07,0.0,0.0,0.0,0.0,0.03,allison lei wallace,PSYC-3090,2015
-PSYC,3100,100,Advanced Experimental Psych,0.45,0.35,0.05,0.0,0.05,0.0,0.0,0.1,jennifer bai bisson,PSYC-3100,2015
-PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2015
-PSYC,3100,300,Advanced Experimental Psych,0.5,0.22,0.11,0.11,0.06,0.0,0.0,0.0,thomas britt,PSYC-3100,2015
-PSYC,3100,400,Advanced Experimental Psych,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,robert campbell,PSYC-3100,2015
-PSYC,3100,500,Advanced Experimental Psych,0.53,0.32,0.05,0.05,0.05,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2015
-PSYC,3100,600,Advanced Experimental Psych,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3100,2015
-PSYC,3240,1,Physiological Psych,0.3,0.31,0.25,0.08,0.01,0.0,0.0,0.04,claudio cantalupo,PSYC-3240,2015
-PSYC,3240,2,Physiological Psych,0.35,0.4,0.11,0.09,0.02,0.0,0.0,0.03,june pilcher,PSYC-3240,2015
-PSYC,3330,1,Cognitive Psych,0.77,0.14,0.05,0.04,0.0,0.0,0.0,0.0,paul steven merritt,PSYC-3330,2015
-PSYC,3330,2,Cognitive Psych,0.71,0.2,0.04,0.01,0.03,0.0,0.0,0.01,paul steven merritt,PSYC-3330,2015
-PSYC,3340,1,Cognitive Psych Lab,0.6,0.25,0.1,0.0,0.0,0.0,0.0,0.05,phillip weis jasper,PSYC-3340,2015
-PSYC,3340,2,Cognitive Psych Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,brian day,PSYC-3340,2015
-PSYC,3340,3,Cognitive Psych Lab,0.63,0.21,0.0,0.05,0.05,0.0,0.0,0.05,ashley ann sewall,PSYC-3340,2015
-PSYC,3400,1,Lifespan Developmental Psych,0.27,0.41,0.2,0.06,0.03,0.0,0.0,0.03,pamela alley,PSYC-3400,2015
-PSYC,3520,1,Social Psychology,0.38,0.35,0.13,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,PSYC-3520,2015
-PSYC,3520,2,Social Psychology,0.39,0.3,0.19,0.06,0.03,0.0,0.0,0.04,jo anne jorgensen,PSYC-3520,2015
-PSYC,3640,1,Industrial Psych,0.49,0.44,0.03,0.0,0.0,0.0,0.0,0.04,fred switzer,PSYC-3640,2015
-PSYC,3680,1,Organizational Psych,0.41,0.41,0.16,0.01,0.0,0.0,0.0,0.01,eric mckibben,PSYC-3680,2015
-PSYC,3680,2,Organizational Psych,0.46,0.39,0.14,0.0,0.01,0.0,0.0,0.0,eric mckibben,PSYC-3680,2015
-PSYC,3690,1,Leadership in Orgs,0.27,0.27,0.21,0.15,0.02,0.0,0.0,0.08,patrick raymark,PSYC-3690,2015
-PSYC,3700,1,Personality,0.49,0.24,0.13,0.1,0.03,0.0,0.0,0.01,william kramer,PSYC-3700,2015
-PSYC,3830,1,Abnormal Psychology,0.16,0.42,0.28,0.08,0.02,0.0,0.0,0.04,cynthia pury,PSYC-3830,2015
-PSYC,3830,2,Abnormal Psychology,0.14,0.43,0.2,0.06,0.14,0.0,0.0,0.03,pamela alley,PSYC-3830,2015
-PSYC,3830,3,Abnormal Psychology,0.31,0.4,0.11,0.09,0.09,0.0,0.0,0.0,pamela alley,PSYC-3830,2015
-PSYC,4080,1,Women and Psychology,0.64,0.2,0.08,0.0,0.0,0.0,0.0,0.08,robin mari kowalski,PSYC-4080,2015
-PSYC,4150,1,Systems and Theories,0.35,0.3,0.18,0.0,0.13,0.0,0.0,0.05,edwin brainerd,PSYC-4150,2015
-PSYC,4150,2,Systems and Theories,0.27,0.24,0.24,0.03,0.09,0.0,0.0,0.12,edwin brainerd,PSYC-4150,2015
-PSYC,4220,1,Perception,0.28,0.38,0.21,0.07,0.0,0.0,0.0,0.07,claudio cantalupo,PSYC-4220,2015
-PSYC,4220,2,Perception,0.25,0.21,0.36,0.18,0.0,0.0,0.0,0.0,christopher pagano,PSYC-4220,2015
-PSYC,4220,3,Perception,0.4,0.12,0.24,0.12,0.04,0.0,0.0,0.08,claudio cantalupo,PSYC-4220,2015
-PSYC,4430,1,Infant & Child Dev,0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-4430,2015
-PSYC,4430,2,Infant & Child Dev,0.33,0.37,0.19,0.07,0.04,0.0,0.0,0.0,sarah mae sanborn,PSYC-4430,2015
-PSYC,4470,1,Moral Development,0.33,0.58,0.0,0.0,0.08,0.0,0.0,0.0,robert campbell,PSYC-4470,2015
-PSYC,4560,1,Psychophysiology,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,james nathan salley,PSYC-4560,2015
-PSYC,4800,1,Health Psychology,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,PSYC-4800,2015
-PSYC,4880,1,Psychotherapy,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,lucinda sorci quick,PSYC-4880,2015
-PSYC,4890,1,Science of Sleep,0.39,0.57,0.0,0.0,0.04,0.0,0.0,0.0,june pilcher,PSYC-4890,2015
-PSYC,4920,4,Senior Laboratory,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brooke bake allison,PSYC-4920,2015
-PSYC,4920,5,Senior Laboratory,0.68,0.14,0.0,0.05,0.09,0.0,0.0,0.05,jessica anne stahl,PSYC-4920,2015
-PSYC,4930,100,Pract Clinical Psych,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,heidi marie zinzow,PSYC-4930,2015
-PSYC,8110,1,Research Design II,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,patrick rosopa,PSYC-8110,2015
-PSYC,8130,1,Research Design III,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, dewayne moore,PSYC-8130,2015
-PSYC,8140,1,Quantitative Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06, dewayne moore,PSYC-8140,2015
-PSYC,8370,1,Ergonomics Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,PSYC-8370,2015
-PSYC,8820,1,Occupat Health Psy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,PSYC-8820,2015
-RED,8010,1,Market Analysis,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,john terrenc farris,RED-8010,2015
-RED,8120,1,Real Estate Technology,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,robert cre benedict,RED-8120,2015
-RED,8130,1,Strat in Real Estate,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,RED-8130,2015
-REL,1010,1,Intro to Religion,0.86,0.06,0.03,0.0,0.0,0.0,0.0,0.06,robert stephens,REL-1010,2015
-REL,1010,2,Intro to Religion,0.82,0.06,0.06,0.0,0.0,0.0,0.0,0.06,robert stephens,REL-1010,2015
-REL,1010,3,Intro to Religion,0.74,0.06,0.06,0.0,0.03,0.03,0.0,0.09,robert stephens,REL-1010,2015
-REL,1020,1,World Religions,0.2,0.37,0.29,0.09,0.0,0.0,0.0,0.06,peter cohen,REL-1020,2015
-REL,1020,2,World Religions,0.25,0.28,0.19,0.14,0.08,0.0,0.0,0.06,peter cohen,REL-1020,2015
-REL,1020,4,World Religions,0.24,0.48,0.09,0.06,0.09,0.0,0.0,0.03,peter cohen,REL-1020,2015
-REL,3000,1,Studying Religion,0.17,0.33,0.29,0.08,0.04,0.0,0.0,0.08,benjamin white,REL-3000,2015
-REL,3010,1,Old Testament,0.56,0.31,0.08,0.06,0.0,0.0,0.0,0.0,steven grosby,REL-3010,2015
-REL,3020,1,New Testament Lit,0.34,0.44,0.16,0.03,0.0,0.0,0.0,0.03,benjamin white,REL-3020,2015
-REL,3030,1,The Quran,0.29,0.57,0.05,0.0,0.1,0.0,0.0,0.0,mashal saif,REL-3030,2015
-REL,3060,1,Judaism,0.58,0.32,0.0,0.0,0.03,0.0,0.0,0.06,steven grosby,REL-3060,2015
-REL,3130,1,Buddhism,0.86,0.06,0.06,0.03,0.0,0.0,0.0,0.0,robert stephens,REL-3130,2015
-REL,3150,1,Islam,0.14,0.48,0.14,0.0,0.1,0.0,0.0,0.14,mashal saif,REL-3150,2015
-RS,3010,1,Rural Sociology,0.3,0.56,0.12,0.0,0.0,0.0,0.0,0.02,kenneth robinson,RS-3010,2015
-RS,4590,1,The Community,0.4,0.4,0.1,0.0,0.1,0.0,0.0,0.0,kenneth robinson,RS-4590,2015
-RUSS,1020,1,Elementary Russian,0.3,0.6,0.0,0.0,0.0,0.0,0.0,0.1,joan bridgwood,RUSS-1020,2015
-RUSS,3400,1,19th C Russ Culture,0.44,0.38,0.0,0.06,0.0,0.0,0.0,0.13,joan bridgwood,RUSS-3400,2015
-SOC,2010,2,Introduction to Sociology,0.42,0.33,0.23,0.0,0.0,0.0,0.0,0.02,mary louise barr,SOC-2010,2015
-SOC,2010,3,Introduction to Sociology,0.45,0.39,0.16,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2015
-SOC,2010,4,Introduction to Sociology,0.43,0.26,0.26,0.0,0.0,0.0,0.0,0.04,mary louise barr,SOC-2010,2015
-SOC,2010,5,Introduction to Sociology,0.37,0.38,0.25,0.0,0.0,0.0,0.0,0.0,mary louise barr,SOC-2010,2015
-SOC,2010,6,Introduction to Sociology,0.3,0.37,0.3,0.0,0.02,0.0,0.0,0.0,mary louise barr,SOC-2010,2015
-SOC,2010,7,Introduction to Sociology,0.51,0.35,0.12,0.02,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2015
-SOC,2010,8,Introduction to Sociology,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,SOC-2010,2015
-SOC,2010,9,Introduction to Sociology,0.66,0.27,0.05,0.0,0.0,0.0,0.0,0.01,jeffrey edwards,SOC-2010,2015
-SOC,2020,1,Social Problems,0.61,0.22,0.0,0.11,0.0,0.0,0.0,0.06,stephani southworth,SOC-2020,2015
-SOC,2020,2,Social Problems,0.36,0.4,0.13,0.04,0.04,0.0,0.0,0.02,stephani southworth,SOC-2020,2015
-SOC,2050,1,Sociology Lab,0.52,0.14,0.05,0.1,0.1,0.0,0.0,0.1,brenda vander mey,SOC-2050,2015
-SOC,3020,1,Research Methods I,0.28,0.2,0.36,0.08,0.08,0.0,0.0,0.0,andrew whitehead,SOC-3020,2015
-SOC,3040,1,Social Research Methods II,0.14,0.52,0.28,0.0,0.03,0.0,0.0,0.03,ye luo,SOC-3040,2015
-SOC,3100,1,Marriage & Intimacy,0.7,0.28,0.02,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,SOC-3100,2015
-SOC,3310,1,Urban Sociology,0.34,0.32,0.17,0.06,0.09,0.0,0.0,0.02,stephani southworth,SOC-3310,2015
-SOC,3500,1,Self & Society,0.23,0.45,0.28,0.04,0.0,0.0,0.0,0.0,ellen granberg,SOC-3500,2015
-SOC,3600,1,Class & Poverty,0.57,0.3,0.04,0.09,0.0,0.0,0.0,0.0,william haller,SOC-3600,2015
-SOC,3800,1,Intro Social Service,0.43,0.43,0.11,0.02,0.0,0.0,0.0,0.02,jennifer le holland,SOC-3800,2015
-SOC,3880,1,Criminal Justice,0.12,0.33,0.33,0.12,0.08,0.0,0.0,0.02,margaret tina britz,SOC-3880,2015
-SOC,3890,1,Criminology,0.14,0.31,0.19,0.12,0.1,0.0,0.0,0.14,william white,SOC-3890,2015
-SOC,3910,1,Soc of Deviance,0.3,0.35,0.26,0.05,0.02,0.0,0.0,0.02,stephani southworth,SOC-3910,2015
-SOC,3920,1,Juvenile Delinquency,0.14,0.27,0.16,0.23,0.16,0.0,0.0,0.05,william white,SOC-3920,2015
-SOC,3970,1,Substance Abuse,0.66,0.28,0.03,0.0,0.0,0.0,0.0,0.03,jeffrey edwards,SOC-3970,2015
-SOC,4030,1,"Technol, Environment & Society",0.27,0.32,0.27,0.05,0.0,0.0,0.0,0.09, catherine mobley,SOC-4030,2015
-SOC,4040,1,Soc Theory,0.49,0.29,0.11,0.09,0.03,0.0,0.0,0.0,william wentworth,SOC-4040,2015
-SOC,4320,1,Soc of Religion,0.32,0.28,0.12,0.12,0.12,0.0,0.0,0.04,andrew whitehead,SOC-4320,2015
-SOC,4440,1,Sociology of Educ,0.24,0.35,0.18,0.18,0.06,0.0,0.0,0.0,stephani southworth,SOC-4440,2015
-SOC,4590,1,The Community,0.44,0.44,0.0,0.13,0.0,0.0,0.0,0.0,kenneth robinson,SOC-4590,2015
-SOC,4600,1,Race & Ethnicity,0.38,0.21,0.24,0.1,0.03,0.0,0.0,0.03,brenda vander mey,SOC-4600,2015
-SOC,4610,1,Sex & Gender,0.24,0.24,0.27,0.19,0.0,0.0,0.0,0.05,sarah evely winslow,SOC-4610,2015
-SOC,4800,1,Medical Sociology,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,william wentworth,SOC-4800,2015
-SOC,4840,1,Child Abuse,0.42,0.31,0.23,0.02,0.0,0.0,0.0,0.02,douglas sturkie,SOC-4840,2015
-SOC,4860,5,Creative Inquiry in Sociology,0.5,0.28,0.17,0.0,0.06,0.0,0.0,0.0,margaret tina britz,SOC-4860,2015
-SOC,4860,6,Creative Inquiry in Sociology,0.62,0.14,0.1,0.05,0.1,0.0,0.0,0.0,margaret tina britz,SOC-4860,2015
-SOC,4930,1,Soc of Corrections,0.3,0.3,0.3,0.1,0.0,0.0,0.0,0.0,william white,SOC-4930,2015
-SOC,4940,1,Organized Crimes,0.62,0.15,0.23,0.0,0.0,0.0,0.0,0.0,margaret tina britz,SOC-4940,2015
-SOC,4970,1,Senior Lab,0.53,0.18,0.12,0.12,0.06,0.0,0.0,0.0,brenda vander mey,SOC-4970,2015
-SOC,4970,2,Senior Lab,0.48,0.28,0.08,0.04,0.12,0.0,0.0,0.0,brenda vander mey,SOC-4970,2015
-SPAN,1010,1,Elementary Spanish,0.35,0.35,0.29,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-1010,2015
-SPAN,1010,2,Elementary Spanish,0.44,0.17,0.33,0.0,0.06,0.0,0.0,0.0,heidi montes,SPAN-1010,2015
-SPAN,1020,1,Elementary Spanish,0.17,0.17,0.22,0.06,0.28,0.0,0.0,0.11,roger simpson,SPAN-1020,2015
-SPAN,1020,2,Elementary Spanish,0.21,0.26,0.16,0.21,0.0,0.0,0.0,0.16,roger simpson,SPAN-1020,2015
-SPAN,1020,3,Elementary Spanish,0.47,0.24,0.18,0.0,0.0,0.0,0.0,0.12,roger simpson,SPAN-1020,2015
-SPAN,1020,4,Elementary Spanish,0.26,0.32,0.26,0.0,0.05,0.0,0.0,0.11,roger simpson,SPAN-1020,2015
-SPAN,1020,5,Elementary Spanish,0.15,0.25,0.2,0.15,0.15,0.0,0.0,0.1,roger simpson,SPAN-1020,2015
-SPAN,1020,6,Elementary Spanish,0.5,0.17,0.22,0.06,0.0,0.0,0.0,0.06,cathy robison,SPAN-1020,2015
-SPAN,1020,7,Elementary Spanish,0.44,0.22,0.11,0.11,0.06,0.0,0.0,0.06,cathy robison,SPAN-1020,2015
-SPAN,1020,8,Elementary Spanish,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,melva margu persico,SPAN-1020,2015
-SPAN,1020,9,Elementary Spanish,0.11,0.16,0.42,0.26,0.0,0.0,0.0,0.05,melva margu persico,SPAN-1020,2015
-SPAN,1020,10,Elementary Spanish,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,kari daus carson,SPAN-1020,2015
-SPAN,1020,11,Elementary Spanish,0.47,0.18,0.29,0.06,0.0,0.0,0.0,0.0,kari daus carson,SPAN-1020,2015
-SPAN,2010,1,Intermediate Spanish,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2015
-SPAN,2010,2,Intermediate Spanish,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,cathy robison,SPAN-2010,2015
-SPAN,2010,3,Intermediate Spanish,0.28,0.67,0.0,0.0,0.06,0.0,0.0,0.0,maureen zamora,SPAN-2010,2015
-SPAN,2010,4,Intermediate Spanish,0.39,0.44,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,SPAN-2010,2015
-SPAN,2010,5,Intermediate Spanish,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,ricardo tremolada,SPAN-2010,2015
-SPAN,2010,6,Intermediate Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,SPAN-2010,2015
-SPAN,2010,7,Intermediate Spanish,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,ricardo tremolada,SPAN-2010,2015
-SPAN,2010,8,Intermediate Spanish,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2015
-SPAN,2010,9,Intermediate Spanish,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2010,2015
-SPAN,2010,10,Intermediate Spanish,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,ellory schmucker,SPAN-2010,2015
-SPAN,2010,11,Intermediate Spanish,0.72,0.11,0.17,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-2010,2015
-SPAN,2010,12,Intermediate Spanish,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-2010,2015
-SPAN,2010,13,Intermediate Spanish,0.29,0.59,0.0,0.06,0.0,0.0,0.0,0.06,juana martin-armas,SPAN-2010,2015
-SPAN,2010,14,Intermediate Spanish,0.27,0.41,0.09,0.09,0.09,0.0,0.0,0.05,allison ann hinds,SPAN-2010,2015
-SPAN,2010,15,Intermediate Spanish,0.28,0.28,0.06,0.11,0.17,0.0,0.0,0.11,ricardo tremolada,SPAN-2010,2015
-SPAN,2020,1,Intermediate Spanish,0.1,0.48,0.29,0.05,0.05,0.0,0.0,0.05,melva margu persico,SPAN-2020,2015
-SPAN,2020,2,Intermediate Spanish,0.35,0.35,0.25,0.05,0.0,0.0,0.0,0.0,melva margu persico,SPAN-2020,2015
-SPAN,2020,3,Intermediate Spanish,0.35,0.45,0.15,0.0,0.05,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2015
-SPAN,2020,4,Intermediate Spanish,0.2,0.35,0.25,0.1,0.05,0.0,0.0,0.05,juana martin-armas,SPAN-2020,2015
-SPAN,2020,5,Intermediate Spanish,0.3,0.35,0.2,0.0,0.05,0.0,0.0,0.1,juana martin-armas,SPAN-2020,2015
-SPAN,2020,6,Intermediate Spanish,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,ze cruz valderramos,SPAN-2020,2015
-SPAN,2020,7,Intermediate Spanish,0.41,0.36,0.05,0.14,0.0,0.0,0.0,0.05,allison ann hinds,SPAN-2020,2015
-SPAN,2020,8,Intermediate Spanish,0.32,0.32,0.32,0.0,0.0,0.0,0.0,0.05,allison ann hinds,SPAN-2020,2015
-SPAN,2020,9,Intermediate Spanish,0.2,0.5,0.15,0.15,0.0,0.0,0.0,0.0,heidi montes,SPAN-2020,2015
-SPAN,2020,10,Intermediate Spanish,0.55,0.1,0.2,0.15,0.0,0.0,0.0,0.0,heidi montes,SPAN-2020,2015
-SPAN,2020,11,Intermediate Spanish,0.38,0.38,0.14,0.05,0.0,0.0,0.0,0.05,ellory schmucker,SPAN-2020,2015
-SPAN,2020,12,Intermediate Spanish,0.23,0.27,0.45,0.05,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2020,2015
-SPAN,3020,1,Int Spn Gram & Comp,0.47,0.37,0.0,0.05,0.0,0.0,0.0,0.11,george palacios,SPAN-3020,2015
-SPAN,3020,2,Int Spn Gram & Comp,0.57,0.38,0.0,0.05,0.0,0.0,0.0,0.0,george palacios,SPAN-3020,2015
-SPAN,3040,1,Intro Hisp Lit Forms,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,george palacios,SPAN-3040,2015
-SPAN,3050,4,Int Con Comp Span I,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,filiberto hernandez,SPAN-3050,2015
-SPAN,3060,1,Span Comp for Bus,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-3060,2015
-SPAN,3070,1,Hispanic World: Sp,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,SPAN-3070,2015
-SPAN,3070,2,Hispanic World: Sp,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,SPAN-3070,2015
-SPAN,3080,1,Hispanic World: La,0.15,0.45,0.25,0.05,0.05,0.0,0.0,0.05,tiffany dawn miller,SPAN-3080,2015
-SPAN,3160,1,Span for Intl Trade,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-3160,2015
-SPAN,4060,1,Narrative Fiction,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,salvador oropesa,SPAN-4060,2015
-SPAN,4150,1,Span for Health Prof,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,SPAN-4150,2015
-SPAN,4200,1,Hispanic Drama,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,tiffany dawn miller,SPAN-4200,2015
-STAT,2220,1,Statistics in Everyday Life,0.39,0.2,0.17,0.15,0.09,0.0,0.0,0.0,ros martinez-dawson,STAT-2220,2015
-STAT,2220,2,Statistics in Everyday Life,0.46,0.26,0.19,0.06,0.0,0.0,0.0,0.04,ros martinez-dawson,STAT-2220,2015
-STAT,2220,3,Statistics in Everyday Life,0.43,0.39,0.15,0.04,0.0,0.0,0.0,0.0,james espey,STAT-2220,2015
-STAT,2220,4,Statistics in Everyday Life,0.35,0.48,0.13,0.04,0.0,0.0,0.0,0.0,april thomas,STAT-2220,2015
-STAT,2220,5,Statistics in Everyday Life,0.31,0.42,0.16,0.07,0.0,0.0,0.0,0.04,emily marie nystrom,STAT-2220,2015
-STAT,2300,1,Statistical Methods I,0.37,0.31,0.15,0.09,0.06,0.0,0.0,0.01,christy jenki brown,STAT-2300,2015
-STAT,2300,2,Statistical Methods I,0.33,0.35,0.14,0.04,0.14,0.0,0.0,0.01,benjamin sharp,STAT-2300,2015
-STAT,2300,3,Statistical Methods I,0.46,0.25,0.16,0.09,0.04,0.0,0.0,0.0,christy jenki brown,STAT-2300,2015
-STAT,2300,4,Statistical Methods I,0.3,0.35,0.18,0.13,0.03,0.0,0.0,0.03,marion hanna,STAT-2300,2015
-STAT,2300,5,Statistical Methods I,0.28,0.37,0.22,0.05,0.06,0.0,0.0,0.03, erwin walker,STAT-2300,2015
-STAT,2300,6,Statistical Methods I,0.23,0.43,0.14,0.11,0.09,0.0,0.0,0.01, erwin walker,STAT-2300,2015
-STAT,2300,7,Statistical Methods I,0.48,0.34,0.11,0.05,0.0,0.0,0.0,0.01,christy jenki brown,STAT-2300,2015
-STAT,2300,8,Statistical Methods I,0.44,0.27,0.18,0.03,0.08,0.0,0.0,0.01,marion hanna,STAT-2300,2015
-STAT,3090,1,Introductory Business Stats,0.08,0.25,0.33,0.11,0.06,0.0,0.0,0.17,paul james cubre,STAT-3090,2015
-STAT,3090,2,Introductory Business Stats,0.15,0.26,0.21,0.1,0.18,0.0,0.0,0.1,janie caro mcdonald,STAT-3090,2015
-STAT,3090,3,Introductory Business Stats,0.31,0.18,0.36,0.08,0.08,0.0,0.0,0.0,gary fellers,STAT-3090,2015
-STAT,3090,4,Introductory Business Stats,0.34,0.2,0.37,0.03,0.03,0.0,0.0,0.03,ellen hepfe breazel,STAT-3090,2015
-STAT,3090,5,Introductory Business Stats,0.23,0.34,0.2,0.06,0.17,0.0,0.0,0.0,ellen hepfe breazel,STAT-3090,2015
-STAT,3090,6,Introductory Business Stats,0.38,0.28,0.13,0.15,0.03,0.0,0.0,0.05,lucas waddell,STAT-3090,2015
-STAT,3090,7,Introductory Business Stats,0.28,0.38,0.18,0.13,0.0,0.0,0.0,0.05,gary fellers,STAT-3090,2015
-STAT,3090,8,Introductory Business Stats,0.11,0.24,0.32,0.13,0.13,0.0,0.0,0.08,tao yang,STAT-3090,2015
-STAT,3090,9,Introductory Business Stats,0.05,0.23,0.28,0.13,0.18,0.0,0.0,0.13,ziwen cheng,STAT-3090,2015
-STAT,3090,10,Introductory Business Stats,0.21,0.33,0.31,0.0,0.1,0.0,0.0,0.05,gary fellers,STAT-3090,2015
-STAT,3090,11,Introductory Business Stats,0.1,0.45,0.3,0.05,0.03,0.0,0.0,0.08,gary fellers,STAT-3090,2015
-STAT,3090,12,Introductory Business Stats,0.09,0.46,0.23,0.14,0.03,0.0,0.0,0.06,laura jane shick,STAT-3090,2015
-STAT,3300,1,Statistical Methods II,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,ros martinez-dawson,STAT-3300,2015
-STAT,4020,1,Intro to Statistical Computing,0.45,0.27,0.09,0.0,0.0,0.09,0.0,0.09,julia lynn sharp,STAT-4020,2015
-STAT,4110,1,Stat Mthds for Process Control,0.26,0.32,0.26,0.1,0.06,0.0,0.0,0.0,james rieck,STAT-4110,2015
-STAT,4110,2,Stat Mthds for Process Control,0.36,0.32,0.14,0.07,0.11,0.0,0.0,0.0,william bridges,STAT-4110,2015
-STAT,8010,1,Statistical Methods I,0.43,0.27,0.1,0.0,0.17,0.0,0.0,0.03,james rieck,STAT-8010,2015
-STAT,8010,2,Statistical Methods I,0.41,0.44,0.12,0.0,0.0,0.0,0.0,0.03,patrick gerard,STAT-8010,2015
-STAT,8010,3,Statistical Methods I,0.69,0.16,0.09,0.0,0.0,0.0,0.0,0.06,jun luo,STAT-8010,2015
-STAT,8040,1,Sampling,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,patrick gerard,STAT-8040,2015
-STAT,8050,1,Design & Anlys of Experiments,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,william bridges,STAT-8050,2015
-STAT,8420,230,Intro to Statistical Methods,0.29,0.29,0.14,0.0,0.14,0.0,0.0,0.14,julia lynn sharp,STAT-8420,2015
-STS,1010,1,Survey of S T S,0.42,0.33,0.24,0.0,0.0,0.0,0.0,0.0,thomas oberdan,STS-1010,2015
-STS,1010,2,Survey of S T S,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,scott brame,STS-1010,2015
-STS,1010,3,Survey of S T S,0.34,0.49,0.09,0.03,0.03,0.0,0.0,0.03,elizabeth stansell,STS-1010,2015
-STS,1010,4,Survey of S T S,0.5,0.31,0.14,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,STS-1010,2015
-STS,1010,5,Survey of S T S,0.12,0.36,0.15,0.06,0.0,0.0,0.0,0.3,david charles foltz,STS-1010,2015
-STS,1010,6,Survey of S T S,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,david stubblefield,STS-1010,2015
-STS,1010,7,Survey of S T S,0.76,0.16,0.05,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,STS-1010,2015
-STS,1010,8,Survey of S T S,0.23,0.34,0.2,0.03,0.0,0.0,0.0,0.2,allison ann hinds,STS-1010,2015
-STS,1010,20,Survey of S T S,0.38,0.41,0.13,0.03,0.0,0.0,0.0,0.06,thomas oberdan,STS-1010,2015
-STS,2150,1,Crit Appr to Tech Revolutions,0.47,0.37,0.05,0.05,0.0,0.0,0.0,0.05,thomas oberdan,STS-2150,2015
-THEA,2100,1,Theatre Appreciation,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,richard st. peter,THEA-2100,2015
-THEA,2100,2,Theatre Appreciation,0.91,0.06,0.0,0.0,0.03,0.0,0.0,0.0,kerrie kath seymour,THEA-2100,2015
-THEA,2100,3,Theatre Appreciation,0.59,0.28,0.09,0.03,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-2100,2015
-THEA,2100,4,Theatre Appreciation,0.63,0.28,0.09,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-2100,2015
-THEA,2100,5,Theatre Appreciation,0.45,0.3,0.18,0.03,0.0,0.0,0.0,0.03,carol collins,THEA-2100,2015
-THEA,2100,6,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,THEA-2100,2015
-THEA,2100,7,Theatre Appreciation,0.53,0.34,0.06,0.0,0.03,0.0,0.0,0.03,jason adkins,THEA-2100,2015
-THEA,2770,1,Prod Studies in Thea,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david hartmann,THEA-2770,2015
-THEA,2790,1,Theatre Practicum,0.62,0.08,0.15,0.0,0.08,0.0,0.0,0.08,matthew leckenbusch,THEA-2790,2015
-THEA,3160,1,Theatre History II,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,richard st. peter,THEA-3160,2015
-THEA,3180,1,Afri-Amer Thea II,0.68,0.19,0.1,0.0,0.0,0.0,0.0,0.03,kendra lyne johnson,THEA-3180,2015
-THEA,3470,1,Structure of Drama,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-3470,2015
-THEA,3740,1,Movement for Actors,0.69,0.15,0.08,0.0,0.08,0.0,0.0,0.0,kerrie kath seymour,THEA-3740,2015
-WFB,3010,1,Wildlife Biology Lab,0.29,0.5,0.14,0.0,0.0,0.0,0.0,0.07,shari lyn rodriguez,WFB-3010,2015
-WFB,3130,1,Conservation Biology,0.45,0.25,0.16,0.06,0.06,0.0,0.0,0.02,shari lyn rodriguez,WFB-3130,2015
-WFB,3130,2,Conservation Biology,0.17,0.37,0.26,0.11,0.06,0.0,0.0,0.03,shari lyn rodriguez,WFB-3130,2015
-WFB,3500,1,Prin Fish Wildl Biol,0.21,0.51,0.21,0.05,0.02,0.0,0.0,0.0,james davis,WFB-3500,2015
-WFB,3500,2,Prin Fish Wildl Biol,0.28,0.26,0.38,0.03,0.05,0.0,0.0,0.0,james davis,WFB-3500,2015
-WFB,4160,1,Fishery Biology,0.36,0.36,0.17,0.09,0.0,0.0,0.0,0.02,yoichiro kanno,WFB-4160,2015
-WFB,4300,1,Wildl Conserv Policy,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.04,joseph lanham,WFB-4300,2015
-WFB,4400,1,Non-Game Wildl Mgmt,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-4400,2015
-WFB,4620,1,Wetland Wildl Biol,0.45,0.38,0.12,0.05,0.0,0.0,0.0,0.0,russell barrett,WFB-4620,2015
-WS,1030,1,Women Global Perspec,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,WS-1030,2015
-WS,2300,1,Women and Leadership,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,saadiqa kumanyika,WS-2300,2015
-WS,3010,1,Intro Women's Studies,0.76,0.14,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2015
-WS,3010,2,Intro Women's Studies,0.43,0.48,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2015
-YDP,3100,400,Youth Developmt and the Family,0.79,0.07,0.07,0.0,0.07,0.0,0.0,0.0,william quinn,YDP-3100,2015
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1020,1,Survey of Art & Arch Hist II,0.4,0.49,0.09,0.0,0.0,0.0,0.0,0.01,beth ann lauritis,
+AAH,2060,1,Art History and Theory II,0.48,0.29,0.24,0.0,0.0,0.0,0.0,0.0,andrea feeser,
+AAH,2100,1,Intro to Art and Architecture,0.39,0.32,0.14,0.04,0.07,0.0,0.0,0.04,lydia jane dorsey,
+AAH,2100,2,Intro to Art and Architecture,0.29,0.36,0.29,0.0,0.04,0.0,0.0,0.04,lydia jane dorsey,
+AAH,2100,3,Intro to Art and Architecture,0.21,0.54,0.11,0.07,0.0,0.0,0.0,0.07,lydia jane dorsey,
+AAH,2100,4,Intro to Art and Architecture,0.22,0.22,0.26,0.11,0.0,0.0,0.0,0.19,lydia jane dorsey,
+ACCT,2010,1,Financial Accounting Concepts,0.19,0.3,0.21,0.12,0.09,0.0,0.0,0.09,suzanne pearse,
+ACCT,2010,2,Financial Accounting Concepts,0.32,0.17,0.13,0.09,0.09,0.0,0.0,0.21,lydia lan schleifer,
+ACCT,2010,3,Financial Accounting Concepts,0.18,0.32,0.25,0.02,0.09,0.0,0.0,0.14,suzanne pearse,
+ACCT,2010,4,Financial Accounting Concepts,0.12,0.2,0.3,0.16,0.1,0.0,0.0,0.12,philip maiberger,
+ACCT,2010,5,Financial Accounting Concepts,0.12,0.37,0.24,0.04,0.06,0.0,0.0,0.16,philip maiberger,
+ACCT,2010,6,Financial Accounting Concepts,0.29,0.38,0.1,0.05,0.05,0.0,0.0,0.14,suzanne pearse,
+ACCT,2010,7,Financial Accounting Concepts,0.3,0.13,0.22,0.15,0.04,0.0,0.0,0.15,lydia lan schleifer,
+ACCT,2010,8,Financial Accounting Concepts,0.31,0.2,0.2,0.11,0.11,0.0,0.0,0.07,lydia lan schleifer,
+ACCT,2010,9,Financial Accounting Concepts,0.09,0.23,0.36,0.16,0.0,0.0,0.0,0.16,the estate  guffey,
+ACCT,2010,10,Financial Accounting Concepts,0.17,0.27,0.23,0.03,0.1,0.0,0.0,0.2,the estate  guffey,
+ACCT,2010,11,Financial Accounting Concepts,0.13,0.3,0.16,0.13,0.14,0.0,0.0,0.14,jeffrey mcmillan,
+ACCT,2010,12,Financial Accounting Concepts,0.16,0.14,0.2,0.26,0.08,0.0,0.0,0.16,philip maiberger,
+ACCT,2010,13,Fin Acct Concepts (HON),0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True
+ACCT,2020,1,Managerial Accounting Concepts,0.22,0.33,0.2,0.12,0.02,0.0,0.0,0.1,annieka philo,
+ACCT,2020,2,Managerial Accounting Concepts,0.33,0.3,0.24,0.06,0.06,0.0,0.0,0.02,annieka philo,
+ACCT,2020,3,Managerial Accounting Concepts,0.35,0.24,0.28,0.04,0.04,0.0,0.0,0.06,annieka philo,
+ACCT,2020,4,Managerial Accounting Concepts,0.33,0.35,0.15,0.09,0.04,0.0,0.0,0.04,annieka philo,
+ACCT,2020,5,Managerial Accounting Concepts,0.14,0.18,0.39,0.05,0.0,0.0,0.0,0.25,henry anderson,
+ACCT,2020,6,Managerial Accounting Concepts,0.26,0.3,0.2,0.07,0.02,0.0,0.0,0.15,henry anderson,
+ACCT,2020,8,Managerial Accounting Concepts,0.14,0.11,0.2,0.17,0.09,0.0,0.0,0.29,henry anderson,
+ACCT,3030,1,Cost Accounting,0.28,0.35,0.23,0.05,0.02,0.0,0.0,0.06,frances kennedy,
+ACCT,3030,3,Cost Accounting,0.35,0.43,0.14,0.05,0.0,0.0,0.0,0.03,holly rhiannio hawk,
+ACCT,3030,4,Cost Accounting,0.24,0.5,0.13,0.0,0.03,0.0,0.0,0.11,holly rhiannio hawk,
+ACCT,3110,1,Intermed Financial Acct I,0.2,0.5,0.2,0.03,0.0,0.0,0.0,0.08,terry daniel knause,
+ACCT,3110,2,Intermed Financial Acct I,0.41,0.44,0.15,0.0,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3110,3,Intermed Financial Acct I,0.22,0.45,0.29,0.02,0.0,0.0,0.0,0.02,terry daniel knause,
+ACCT,3110,4,Intermed Financial Acct I,0.31,0.57,0.09,0.02,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3120,1,Intermed Financial Acct II,0.33,0.45,0.18,0.03,0.0,0.0,0.0,0.03, russell madray,
+ACCT,3120,2,Intermed Financial Acct II,0.32,0.38,0.15,0.04,0.04,0.0,0.0,0.06, russell madray,
+ACCT,3120,3,Intermed Financial Acct II,0.05,0.28,0.21,0.26,0.18,0.0,0.0,0.03,brian todd carver,
+ACCT,3120,4,Intermed Financial Acct II,0.03,0.18,0.38,0.24,0.18,0.0,0.0,0.0,brian todd carver,
+ACCT,3130,1,Intermed Financial Acct III,0.28,0.38,0.31,0.03,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3130,2,Intermed Financial Acct III,0.27,0.41,0.24,0.03,0.05,0.0,0.0,0.0, russell madray,
+ACCT,3130,3,Intermed Financial Acct III,0.11,0.48,0.26,0.11,0.04,0.0,0.0,0.0,james irving,
+ACCT,3130,4,Intermed Financial Acct III,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,james irving,
+ACCT,3220,1,Accounting Information Systems,0.28,0.28,0.4,0.03,0.0,0.0,0.0,0.03,nancy lee harp,
+ACCT,3220,2,Accounting Information Systems,0.26,0.18,0.38,0.08,0.08,0.0,0.0,0.03,nancy lee harp,
+ACCT,3220,3,Accounting Information Systems,0.19,0.49,0.19,0.11,0.0,0.0,0.0,0.03,nancy lee harp,
+ACCT,4040,1,Individual Taxation,0.76,0.18,0.03,0.0,0.03,0.0,0.0,0.0,sarah martin,
+ACCT,4040,2,Individual Taxation,0.88,0.05,0.07,0.0,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.36,0.46,0.13,0.0,0.0,0.0,0.0,0.05,james mil kohlmeyer,
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.19,0.73,0.08,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,
+ACCT,4150,1,Auditing,0.16,0.46,0.27,0.08,0.0,0.0,0.0,0.03,suzanne pearse,
+ACCT,4150,2,Auditing,0.29,0.48,0.19,0.03,0.0,0.0,0.0,0.0,carl hollingsworth,
+ACCT,8520,1,Fin Acct Theory/Res,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8520,2,Fin Acct Theory/Res,0.32,0.58,0.1,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8540,1,Prof Responsibility,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,
+ACCT,8710,1,Corporate Taxation,0.46,0.51,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,2,Corporate Taxation,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,derek dalton,
+AGED,1000,1,Orientation & Field Experience,0.85,0.07,0.04,0.0,0.0,0.0,0.0,0.04,philip fravel,
+AGED,2030,1,Teaching Agriscience,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGED,4160,1,Ethics and Issues,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,
+AGM,2050,1,Prin of Fabrication,0.13,0.45,0.3,0.05,0.0,0.0,0.0,0.07,hunter massey,
+AGM,2060,1,Machinery Mgt,0.15,0.36,0.3,0.09,0.03,0.0,0.0,0.06,hunter massey,
+AGM,2210,1,Land Measurements,0.31,0.42,0.19,0.08,0.0,0.0,0.0,0.0,charles privette,
+AGM,3030,1,Cal for Mech Ag,0.48,0.4,0.1,0.0,0.0,0.0,0.0,0.02,young han,
+AGM,4020,1,Land Drain and Irrig,0.1,0.55,0.3,0.05,0.0,0.0,0.0,0.0,charles privette,
+AGM,4100,1,Precision Ag Tech,0.24,0.44,0.22,0.1,0.0,0.0,0.0,0.0,hunter massey,
+AGM,4520,1,Mobile Power,0.24,0.44,0.24,0.05,0.0,0.0,0.0,0.02,hunter massey,
+AGM,4720,1,Capstone,0.07,0.36,0.57,0.0,0.0,0.0,0.0,0.0,john chastain,
+AL,3490,400,Principles of Coaching,0.41,0.22,0.33,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
+AL,3490,401,Principles of Coaching,0.31,0.52,0.1,0.03,0.03,0.0,0.0,0.0,deborah cadorette,
+AL,3490,402,Principles of Coaching,0.52,0.28,0.04,0.08,0.04,0.0,0.0,0.04,julia wright,
+AL,3490,403,Principles of Coaching,0.67,0.26,0.04,0.0,0.04,0.0,0.0,0.0,clyde keith connor,
+AL,3490,404,Principles of Coaching,0.5,0.31,0.12,0.04,0.04,0.0,0.0,0.0,clyde keith connor,
+AL,3490,405,Principles of Coaching,0.74,0.11,0.0,0.07,0.04,0.0,0.0,0.04,edmond fry,
+AL,3500,400,Sci Basis I/Ex Phy,0.22,0.19,0.26,0.22,0.07,0.0,0.0,0.04,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.36,0.16,0.32,0.08,0.04,0.0,0.0,0.04,michael godfrey,
+AL,3520,400,Kinesiology,0.42,0.05,0.16,0.16,0.11,0.0,0.0,0.11,michael godfrey,
+AL,3530,400,Athletic Injuries,0.42,0.15,0.27,0.15,0.0,0.0,0.0,0.0,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.22,0.22,0.22,0.17,0.13,0.0,0.0,0.04,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.38,0.19,0.05,0.05,0.0,0.0,0.0,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.81,0.12,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,401,Admin/Org of Athletic Programs,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,Admin/Org of Athletic Programs,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,henry oates,
+AL,3620,400,Psychology of Coaching,0.44,0.24,0.12,0.16,0.04,0.0,0.0,0.0,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.18,0.3,0.27,0.15,0.06,0.0,0.0,0.03,natalie anne carter,
+AL,3710,400,Coaching Baseball,0.65,0.1,0.1,0.1,0.05,0.0,0.0,0.0,justin hickey,
+AL,3720,400,Coaching Basketball,0.5,0.08,0.17,0.04,0.13,0.0,0.0,0.08,edmond fry,
+AL,3740,400,Coaching Football,0.54,0.21,0.08,0.0,0.17,0.0,0.0,0.0,edmond fry,
+AL,3760,400,Coaching Strength/Conditioning,0.58,0.17,0.04,0.08,0.04,0.0,0.0,0.08,edmond fry,
+AL,4380,400,Creative Inquire C&A,0.47,0.27,0.13,0.07,0.07,0.0,0.0,0.0,deborah cadorette,
+AL,4380,410,Coaching Rugby,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,deborah cadorette,
+AL,8640,400,Ethical Iss in Collegiate Athl,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,james satterfield,
+ANTH,2010,1,Introduction to Anthropology,0.05,0.25,0.37,0.15,0.08,0.0,0.0,0.1,john coggeshall,
+ANTH,2010,2,Introduction to Anthropology,0.37,0.44,0.14,0.03,0.01,0.0,0.0,0.01,katherine weisensee,
+ANTH,2010,3,Introduction to Anthropology,0.55,0.21,0.07,0.04,0.02,0.0,0.0,0.11,lisa rapaport,
+ANTH,3200,1,North American Indian Cultures,0.3,0.4,0.2,0.0,0.0,0.0,0.0,0.1,john coggeshall,
+ANTH,3310,1,Archaeology,0.24,0.35,0.35,0.06,0.0,0.0,0.0,0.0,melissa vogel,
+ANTH,3510,1,Biological Anthropology,0.35,0.4,0.2,0.05,0.0,0.0,0.0,0.0,katherine weisensee,
+ANTH,4230,1,Women in the Developing World,0.61,0.33,0.0,0.06,0.0,0.0,0.0,0.0,melissa vogel,
+APEC,2020,1,Agric Economics,0.87,0.11,0.02,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
+APEC,2050,1,Agric and Society,0.39,0.38,0.18,0.04,0.0,0.0,0.0,0.02,michael vassalos,
+APEC,3190,1,Agribusiness Mgt,0.34,0.3,0.26,0.04,0.02,0.0,0.0,0.04,michael vassalos,
+APEC,3570,1,Nat Resource Econ,0.29,0.19,0.27,0.19,0.02,0.0,0.0,0.04,david brian willis,
+APEC,4560,1,Prices,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
+ARAB,1010,1,Elementary Arabic I,0.69,0.19,0.0,0.0,0.0,0.0,0.0,0.13,sulafa abou-samra,
+ARAB,1020,1,Elementary Arabic II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sulafa abou-samra,
+ARCH,1510,1,Arch Communication,0.53,0.41,0.0,0.0,0.06,0.0,0.0,0.0,sal hambright-belue,
+ARCH,1510,2,Arch Communication,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,robert silance,
+ARCH,1510,3,Arch Communication,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,junichi satoh,
+ARCH,1510,4,Arch Communication,0.58,0.21,0.05,0.05,0.0,0.0,0.0,0.11,clarissa mendez,
+ARCH,2520,1,Arch Foundations II,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,david lee,
+ARCH,2520,2,Arch Foundations II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,2520,4,Arch Foundations II,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2700,1,Structures I,0.43,0.36,0.14,0.07,0.0,0.0,0.0,0.0,robert john hogan,
+ARCH,2700,2,Structures I,0.47,0.47,0.0,0.0,0.06,0.0,0.0,0.0,robert john hogan,
+ARCH,2710,1,Structures II,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,michael carl kleiss,
+ARCH,3530,1,Studio Genoa,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
+ARCH,4010,1,Arch Portfolio,0.5,0.14,0.18,0.0,0.05,0.0,0.0,0.14,arash soleimani,
+ARCH,4520,1,Synthesis Studio,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,4520,2,Synthesis Studio,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,4520,3,Synthesis Studio,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,criss mills,
+ARCH,6880,1,Arch Programming,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ARCH,6990,2,Glass as a Modern Material,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8110,1,Visualization II,0.38,0.5,0.0,0.0,0.06,0.0,0.0,0.06,douglas hecker,
+ARCH,8200,1,Bldg Design & Constr,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,dennis bausman,
+ARCH,8420,1,Arch Studio II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,
+ARCH,8420,2,Arch Studio II,0.22,0.44,0.11,0.0,0.11,0.0,0.0,0.11,junichi satoh,
+ARCH,8610,1,History/Theory II,0.4,0.47,0.0,0.0,0.07,0.0,0.0,0.07,robert bruhns,
+ARCH,8710,1,Structures II,0.45,0.41,0.09,0.0,0.0,0.0,0.0,0.05,dustin gra albright,
+ARCH,8730,1,Environmental Sys,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,vincent yves blouin,
+ARCH,8740,1,Building Process:TR,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john jacques,
+ARCH,8740,2,Building Process:TR,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,john jacques,
+ARCH,8820,1,Building Economics,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,8900,1,Directed Studies,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,anjali joseph,
+ARCH,8920,2,Comprehensive Studio,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,8920,3,Comprehensive Studio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
+ARCH,8920,4,Comprehensive Studio,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,8920,5,Comprehensive Studio,0.0,0.7,0.3,0.0,0.0,0.0,0.0,0.0,keith green,
+ARCH,8960,1,A+H Studio: Tectonic,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ART,1060,1,Foundation Drawing II,0.52,0.24,0.14,0.0,0.05,0.0,0.0,0.05,kathleen ann thum,
+ART,1520,1,Foundations Art II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
+ART,2050,1,Beginning Life Drawing,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,alexandra giannell,
+ART,2070,1,Beginning Painting,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,hilary erin siber,
+ART,2090,1,Beginning Sculpture,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,tanna burchinal,
+ART,2130,1,Begin Photography,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,
+ART,2170,1,Beginning Ceramics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lindsey ann elsey,
+AS,1100,2,Air Force Today II,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,steven price jordan,
+AS,2100,3,Dev of Air Power II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,christopher mann,
+ASL,1010,2,Am Sign Lang I,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,william alton brant,
+ASL,1020,2,Am Sign Lang I,0.71,0.07,0.21,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2020,1,Am Sign Lang II,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASTR,1010,1,Solar System Astr,0.47,0.22,0.15,0.07,0.03,0.0,0.0,0.05,sean brittain,
+ASTR,1020,1,Stellar Astronomy,0.22,0.49,0.18,0.02,0.02,0.0,0.0,0.06,phillip flower,
+ASTR,1020,2,Stellar Astronomy,0.17,0.52,0.2,0.01,0.01,0.0,0.0,0.09,phillip flower,
+ASTR,1020,3,Stellar Astronomy,0.18,0.38,0.34,0.04,0.04,0.0,0.0,0.01,phillip flower,
+ASTR,1030,1,Solar Systm Astr Lab,0.58,0.19,0.04,0.0,0.08,0.0,0.0,0.12,mark leising,
+ASTR,1030,2,Solar Systm Astr Lab,0.5,0.15,0.05,0.05,0.15,0.0,0.0,0.1,mark leising,
+ASTR,1040,1,Stellar Astr Lab,0.44,0.32,0.2,0.0,0.04,0.0,0.0,0.0,mark leising,
+ASTR,1040,2,Stellar Astr Lab,0.35,0.45,0.15,0.0,0.05,0.0,0.0,0.0,mark leising,
+ASTR,1040,3,Stellar Astr Lab,0.64,0.28,0.0,0.0,0.0,0.0,0.0,0.08,mark leising,
+ASTR,1040,5,Stellar Astr Lab,0.33,0.33,0.17,0.0,0.11,0.0,0.0,0.06,mark leising,
+ASTR,1040,6,Stellar Astr Lab,0.14,0.52,0.24,0.0,0.1,0.0,0.0,0.0,mark leising,
+AUD,2850,1,Acoustics of Music,0.2,0.47,0.27,0.0,0.0,0.0,0.0,0.07,hamilton altstatt,
+AUE,8160,1,Eng Combustion Emiss,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8170,3,Alt Energy Sources,0.37,0.59,0.05,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8500,6,Stability/Safety Sys,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8550,16,Auto Struct Analysis,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8770,9,Light-Weight Design,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,
+AUE,8820,10,Systems Integration Method,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,paul venhovens,
+AUE,8860,11,Noise Vibration,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8930,15,Innov & Entrepreneurship,0.56,0.42,0.0,0.0,0.0,0.0,0.0,0.02,david leo bodde,
+AUE,8930,16,Fundamentals of Injection Mold,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
+AVS,2010,1,Poultry Techniques,0.93,0.04,0.0,0.04,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,2050,1,Horsemanship Techniques,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,anna rebecca baxley,
+AVS,2060,1,Swine Techniques,0.83,0.11,0.02,0.0,0.02,0.0,0.0,0.02,richelle lor miller,
+AVS,2090,1,Livestock Exhibition Technique,0.93,0.06,0.0,0.0,0.0,0.0,0.0,0.01,richelle lor miller,
+AVS,2110,1,Meat Processing Techniques,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brian bolt,
+AVS,2120,1,Small Ruminant Techniques,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,heather walker dunn,
+AVS,3010,1,Anat & Phys Dom Ani,0.4,0.29,0.22,0.04,0.04,0.0,0.0,0.02,tiffany wilmoth,
+AVS,3100,1,Animal Health,0.71,0.16,0.06,0.02,0.03,0.0,0.0,0.02,thomas scott,
+AVS,3150,1,Animal Welfare,0.27,0.36,0.27,0.05,0.05,0.0,0.0,0.0,peter skewes,
+AVS,3700,1,Prin Animal Nutr,0.1,0.18,0.4,0.11,0.18,0.0,0.0,0.03,nathan long,
+AVS,3750,1,Appl Animal Nutr,0.4,0.34,0.18,0.06,0.0,0.0,0.0,0.02,gustavo jos lascano,
+AVS,4000,1,AVS Professional Development,0.62,0.24,0.0,0.12,0.0,0.0,0.0,0.03,johanna joh lascano,
+AVS,4060,1,Seminars & Relat Top,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4090,2,Selected Topics/CAFLS Plus,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,thomas scott,
+AVS,4090,7,Sel Topics- Scientific Writing,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4100,1,Domestic Ani Behav,0.37,0.39,0.18,0.03,0.02,0.0,0.0,0.01,peter skewes,
+AVS,4110,400,Ani Growth & Develop,0.62,0.15,0.15,0.0,0.08,0.0,0.0,0.0,susan kay duckett,
+AVS,4120,1,Adv Equine Mgmt,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,4130,1,Animal Products,0.78,0.21,0.01,0.0,0.0,0.0,0.0,0.0,brian bolt,
+AVS,4170,1,Animal Agribusiness Develpmnt,0.23,0.68,0.09,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,4220,2,Special Problems/CAFLS Plus,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,thomas scott,
+AVS,4530,1,Animal Reproduction,0.5,0.31,0.17,0.0,0.0,0.0,0.0,0.02,glenn birrenkott,
+AVS,4530,400,Animal Reproduction,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,6110,1,Ani Growth & Develop,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,susan kay duckett,
+BCHM,3010,1,Molecular Biochem,0.25,0.21,0.25,0.13,0.06,0.0,0.0,0.1,meredith tei morris,
+BCHM,3010,2,Molecular Biochem(HON),0.68,0.15,0.15,0.0,0.0,0.0,0.0,0.03,meredith tei morris,True
+BCHM,3020,1,Molecular Biochemistry Lab,0.77,0.08,0.08,0.0,0.0,0.0,0.0,0.08,meredith tei morris,
+BCHM,3020,2,Molecular Biochemistry Lab,0.56,0.25,0.06,0.13,0.0,0.0,0.0,0.0,meredith tei morris,
+BCHM,3020,3,Molecular Biochemistry Lab,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,meredith tei morris,
+BCHM,3050,1,Essen Elements Bioch,0.32,0.36,0.18,0.05,0.05,0.0,0.0,0.04,srik chandrasekaran,
+BCHM,3050,2,Essen Elements Bioch,0.4,0.37,0.13,0.07,0.01,0.0,0.0,0.03,liangjiang wang,
+BCHM,4060,1,Physiological Chem,0.41,0.25,0.25,0.02,0.04,0.0,0.0,0.02,ashby burges bodine,
+BCHM,4320,1,Bioch of Metabolism,0.61,0.35,0.0,0.03,0.0,0.0,0.0,0.0,kimberly paul,
+BCHM,4340,1,General Biochemistry Lab II,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,kimberly paul,
+BCHM,4340,2,General Biochemistry Lab II,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,kimberly paul,
+BCHM,4360,1,Genes to Proteins,0.23,0.41,0.27,0.0,0.05,0.0,0.0,0.05,michael glen sehorn,
+BCHM,4360,2,Genes to Proteins(HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True
+BCHM,4900,1,Strategic Markting Relay 4 Lif,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,michael glen sehorn,
+BE,2100,1,Intro to Biosystems Engr,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,yi zheng,
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.29,0.33,0.29,0.04,0.04,0.0,0.0,0.0,tom owino,
+BE,4120,1,Be Heat Mass Trans,0.48,0.29,0.1,0.1,0.05,0.0,0.0,0.0,caye marie drapcho,
+BE,4240,1,Ecological Engr,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,
+BE,4380,1,Bioprocess Engineering Design,0.52,0.29,0.0,0.14,0.05,0.0,0.0,0.0,terry walker,
+BIOE,2010,1,Intro Biomed Engr,0.47,0.31,0.16,0.0,0.0,0.0,0.0,0.06,charles webb,
+BIOE,3020,1,Biomaterials,0.53,0.33,0.08,0.01,0.01,0.0,0.0,0.03,vladimir vla reukov,
+BIOE,3200,1,Biomechanics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,
+BIOE,3210,1,Biofluid Mechanics,0.34,0.43,0.12,0.05,0.0,0.0,0.0,0.06,sarah harcum,
+BIOE,3700,1,Bioinst & Imaging,0.29,0.53,0.11,0.0,0.02,0.0,0.0,0.05,david kwartowitz,
+BIOE,4030,1,Applied Bio E Design,0.97,0.01,0.0,0.01,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4200,1,Sports Engineering,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
+BIOE,4510,33,CI-Og Design,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,john desjardins,
+BIOE,6350,1,Modeling of Multiphysics Prob,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,guigen zhang,
+BIOE,8020,410,Biocompatibility,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
+BIOE,8150,410,Design Manuf Medical Devices,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,
+BIOE,8500,401,"Cells, Stem Cells & Dev't",0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ann catherine foley,
+BIOL,1040,1,General Biology II,0.24,0.31,0.25,0.12,0.05,0.0,0.0,0.05,nora espinoza,
+BIOL,1040,2,General Biology II,0.15,0.32,0.28,0.12,0.09,0.0,0.0,0.04,kalan ickes,
+BIOL,1040,3,General Biology II,0.46,0.33,0.14,0.05,0.01,0.0,0.0,0.0,william surver,
+BIOL,1040,4,General Biology II (HON),0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True
+BIOL,1060,1,Gen Biology Lab II,0.25,0.25,0.15,0.25,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,2,Gen Biology Lab II,0.11,0.26,0.21,0.32,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,3,Gen Biology Lab II,0.15,0.5,0.15,0.1,0.1,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,4,Gen Biology Lab II,0.2,0.2,0.25,0.25,0.0,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,5,Gen Biology Lab II,0.2,0.2,0.35,0.15,0.1,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,6,Gen Biology Lab II,0.2,0.25,0.15,0.2,0.2,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,7,Gen Biology Lab II,0.25,0.3,0.15,0.25,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,10,Gen Biology Lab II,0.0,0.3,0.3,0.25,0.05,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,11,Gen Biology Lab II,0.1,0.2,0.3,0.2,0.1,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,12,Gen Biology Lab II,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,13,Gen Biology Lab II,0.35,0.3,0.2,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,14,Gen Biology Lab II,0.1,0.25,0.35,0.2,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,15,Gen Biology Lab II,0.4,0.2,0.35,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,16,Gen Biology Lab II,0.25,0.35,0.15,0.15,0.1,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,17,Gen Biology Lab II,0.1,0.65,0.2,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,18,Gen Biology Lab II,0.3,0.3,0.2,0.1,0.1,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,19,Gen Biology Lab II,0.3,0.25,0.3,0.0,0.0,0.0,0.0,0.15,tafadzwa kaisa,
+BIOL,1060,21,Gen Biology Lab II,0.15,0.55,0.2,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,22,Gen Biology Lab II,0.35,0.35,0.25,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,25,Gen Biology Lab II,0.3,0.45,0.15,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,26,Gen Biology Lab II,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,27,Gen Biology Lab II,0.3,0.25,0.25,0.1,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,28,Gen Biology Lab II,0.35,0.25,0.25,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,29,Gen Biology Lab II,0.35,0.15,0.3,0.15,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,30,Gen Biology Lab II,0.2,0.2,0.3,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,31,Gen Biology Lab II,0.3,0.45,0.15,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,34,Gen Biology Lab II,0.26,0.53,0.16,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,36,Gen Biology Lab II,0.25,0.35,0.15,0.05,0.2,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,37,Gen Biology Lab II,0.32,0.32,0.21,0.05,0.11,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,38,Gen Biology Lab II,0.21,0.37,0.21,0.0,0.05,0.0,0.0,0.16,tafadzwa kaisa,
+BIOL,1060,39,Gen Biology Lab II,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,40,Gen Biology Lab II,0.3,0.25,0.2,0.05,0.1,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,41,Gen Biology Lab II,0.37,0.05,0.21,0.05,0.32,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,42,Gen Biology Lab II,0.3,0.25,0.15,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1090,1,Intro to Life Sci,0.67,0.19,0.14,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
+BIOL,1110,1,Prin of Biol II,0.26,0.51,0.12,0.08,0.01,0.0,0.0,0.02,robert kosinski,
+BIOL,1110,2,Prin of Biol II,0.43,0.35,0.18,0.0,0.03,0.0,0.0,0.01,dylan dittrich-reed,
+BIOL,1110,4,Prin of Biol II  (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True
+BIOL,1200,4,Biological Inq Lab,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,5,Biological Inq Lab,0.67,0.17,0.0,0.11,0.06,0.0,0.0,0.0, christine minor,
+BIOL,1200,6,Biological Inq Lab,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,9,Biological Inq Lab,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,
+BIOL,1200,12,Biological Inq Lab,0.5,0.33,0.06,0.0,0.11,0.0,0.0,0.0, christine minor,
+BIOL,1220,1,Keys to Biodiversity,0.36,0.2,0.16,0.12,0.12,0.0,0.0,0.04,kalan ickes,
+BIOL,1230,1,Keys to Human Biol,0.26,0.33,0.28,0.09,0.04,0.0,0.0,0.01, christine minor,
+BIOL,2000,2,Biology in the News,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,2000,4,Biology in the News,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,david tonkyn,
+BIOL,2000,5,Biology in the News,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
+BIOL,2000,8,Biology in the News,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,min cao,
+BIOL,2000,9,Biology in the News,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,michael sears,
+BIOL,2030,1,Human Disease & Soc,0.79,0.14,0.02,0.0,0.0,0.0,0.0,0.05, christine minor,
+BIOL,2040,1,"Environ, Energy and Society",0.47,0.26,0.13,0.11,0.01,0.0,0.0,0.02,john jenkins hains,
+BIOL,2110,1,Introduction to Toxicology,0.26,0.56,0.12,0.0,0.03,0.0,0.0,0.03,peter van den hurk,
+BIOL,2230,1,Human Anat and Physiology II,0.37,0.3,0.18,0.1,0.04,0.0,0.0,0.02,john cummings,
+BIOL,2230,2,Human Anat and Physiology II,0.51,0.31,0.15,0.01,0.0,0.0,0.0,0.02,john cummings,
+BIOL,3020,1,Invertebrate Biology,0.16,0.42,0.24,0.05,0.05,0.0,0.0,0.08,juan baeza migueles,
+BIOL,3040,1,Biology of Plants,0.6,0.29,0.1,0.0,0.02,0.0,0.0,0.0,christina wells,
+BIOL,3060,2,Invertebrate Biology Lab,0.05,0.5,0.3,0.1,0.05,0.0,0.0,0.0,juan baeza migueles,
+BIOL,3060,4,Invertebrate Biology Lab,0.18,0.35,0.29,0.06,0.0,0.0,0.0,0.12,juan baeza migueles,
+BIOL,3080,2,Biology of Plants Practicum,0.63,0.21,0.11,0.0,0.05,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3080,3,Biology of Plants Practicum,0.71,0.18,0.06,0.0,0.06,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3080,4,Biology of Plants Practicum,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert edwa ballard,
+BIOL,3130,1,Conservation Biology,0.28,0.44,0.16,0.12,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+BIOL,3130,2,Conservation Biology,0.21,0.37,0.26,0.11,0.0,0.0,0.0,0.05,shari lyn rodriguez,
+BIOL,3160,1,Human Physiology,0.29,0.45,0.23,0.02,0.01,0.0,0.0,0.01,tamara mcnutt-scott,
+BIOL,3200,1,Field Botany,0.13,0.31,0.28,0.11,0.11,0.0,0.0,0.06,timothy spira,
+BIOL,3350,1,Evolutionary Biology,0.19,0.44,0.19,0.06,0.03,0.0,0.0,0.09,lisa rapaport,
+BIOL,3510,1,Biological Anthropology,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
+BIOL,4010,1,Plant Physiology,0.16,0.19,0.41,0.22,0.03,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4020,2,Plant Physiology Lab,0.38,0.5,0.0,0.06,0.06,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4020,4,Plant Physiology Lab,0.53,0.24,0.18,0.06,0.0,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4030,3,Intro to Applied Genomics,0.18,0.18,0.27,0.0,0.09,0.0,0.0,0.27,vincent pa richards,
+BIOL,4100,1,Limnology,0.4,0.25,0.18,0.05,0.0,0.0,0.0,0.13,john jenkins hains,
+BIOL,4140,1,Basic Immunology,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,charles rice,
+BIOL,4340,1,Biological Chem Lab Techniques,0.17,0.25,0.5,0.08,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,2,Biological Chem Lab Techniques,0.0,0.58,0.33,0.08,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,3,Biological Chem Lab Techniques,0.09,0.36,0.27,0.09,0.18,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,4,Biological Chem Lab Techniques,0.2,0.2,0.3,0.2,0.0,0.0,0.0,0.1,salvatore sparace,
+BIOL,4340,5,Biological Chem Lab Techniques,0.0,0.55,0.36,0.09,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,6,Biological Chem Lab Techniques,0.1,0.4,0.3,0.0,0.1,0.0,0.0,0.1,salvatore sparace,
+BIOL,4400,1,Developmental Animal Biology,0.67,0.07,0.07,0.0,0.0,0.0,0.0,0.2,susan carol chapman,
+BIOL,4610,1,Cell Biology,0.23,0.3,0.26,0.14,0.05,0.0,0.0,0.03,lisa bain,
+BIOL,4610,2,Cell Biology (HON),0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,lisa bain,True
+BIOL,4620,1,Cell Biology Lab (Lec),0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,2,Cell Biology Lab (Lec),0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
+BIOL,4620,3,Cell Biology Lab (Lec),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,4,Cell Biology Lab (Lec),0.44,0.5,0.0,0.06,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,7,Cell Biology Lab (Lec),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,8,Cell Biology Lab (Lec),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,xianzhong yu,
+BIOL,4620,9,Cell Biology Lab (Lec),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4640,1,Mammalogy,0.06,0.39,0.22,0.11,0.11,0.0,0.0,0.11,john cummings,
+BIOL,4670,1,Principles of Hematology,0.83,0.07,0.09,0.0,0.02,0.0,0.0,0.0,vincent gallicchio,
+BIOL,4700,1,Behavioral Ecology,0.37,0.42,0.11,0.02,0.06,0.0,0.0,0.01,michael childress,
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,michael childress,
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.53,0.2,0.0,0.07,0.0,0.0,0.0,0.2,michael childress,
+BIOL,4710,3,Behavioral Ecology Lab (Lec),0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,michael childress,
+BIOL,4710,4,Behavioral Ecology Lab (Lec),0.69,0.15,0.08,0.0,0.0,0.0,0.0,0.08,michael childress,
+BIOL,4930,2,Oceans End & Climate Sr Sem,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,andrew mount,
+BIOL,4930,4,Adv Cancer Research Sr Sem,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
+BIOL,6800,1,Vertebrate Endocrinology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,
+BIOL,8430,1,Underst Genetics & Evol Biol,0.91,0.05,0.01,0.0,0.02,0.0,0.0,0.01,renea chri hardwick,
+BIOL,8450,1,Understanding Vertebrate Biol,0.9,0.08,0.0,0.0,0.02,0.0,0.0,0.0,tamara mcnutt-scott,
+BIOL,8470,1,Understanding Microbiology,0.53,0.43,0.03,0.0,0.01,0.0,0.0,0.0,harry kurtz,
+BMOL,4250,1,Biomolecular Engineering,0.3,0.4,0.1,0.0,0.0,0.0,0.0,0.2,mark alan blenner,
+BUS,1010,1,Business Foundations,0.13,0.4,0.18,0.08,0.05,0.0,0.0,0.15,michael giebner,
+BUS,1010,2,Business Foundations,0.19,0.51,0.19,0.05,0.02,0.0,0.0,0.05,michael giebner,
+BUS,1010,3,Business Foundations,0.14,0.52,0.1,0.1,0.1,0.0,0.0,0.03,william ern tumblin,
+BUS,1010,4,Business Foundations,0.2,0.5,0.17,0.03,0.03,0.0,0.0,0.07,william ern tumblin,
+BUS,1010,6,Business Foundations,0.13,0.45,0.32,0.03,0.03,0.0,0.0,0.03,william ern tumblin,
+CE,2010,1,Statics,0.45,0.2,0.16,0.09,0.02,0.0,0.0,0.07,nighat yasmin,
+CE,2010,2,Statics,0.27,0.25,0.23,0.07,0.09,0.0,0.0,0.09,michael pa esposito,
+CE,2010,3,Statics,0.34,0.27,0.2,0.02,0.09,0.0,0.0,0.07,md akhter hossain,
+CE,2010,4,Statics,0.15,0.22,0.27,0.12,0.15,0.0,0.0,0.1,melissa sternhagen,
+CE,2010,5,Statics,0.7,0.16,0.09,0.0,0.02,0.0,0.0,0.02,nighat yasmin,
+CE,2010,6,Statics,0.44,0.23,0.03,0.1,0.08,0.0,0.0,0.13,michael pa esposito,
+CE,2010,7,Statics,0.18,0.12,0.18,0.12,0.24,0.0,0.0,0.18,thomas edfo cousins,
+CE,2060,1,Structural Mechanics,0.19,0.47,0.19,0.13,0.03,0.0,0.0,0.0,bryant nielson,
+CE,2060,2,Structural Mechanics,0.22,0.44,0.27,0.03,0.02,0.0,0.0,0.02,bryant nielson,
+CE,2080,1,Dynamics,0.32,0.43,0.23,0.0,0.0,0.0,0.0,0.02,melissa sternhagen,
+CE,2080,2,Dynamics,0.2,0.59,0.14,0.04,0.0,0.0,0.0,0.02,melissa sternhagen,
+CE,2080,3,Dynamics,0.15,0.63,0.15,0.03,0.0,0.0,0.0,0.05,melissa sternhagen,
+CE,2550,1,Geomatics,0.25,0.42,0.22,0.06,0.01,0.0,0.0,0.04,wayne sarasua,
+CE,3010,1,Structural Analysis,0.22,0.3,0.22,0.16,0.1,0.0,0.0,0.0,stephen csernak,
+CE,3110,1,Transportation Engr,0.22,0.51,0.21,0.01,0.0,0.0,0.0,0.04,wayne sarasua,
+CE,3210,1,Geotechnical Engineering,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
+CE,3210,2,Geotechnical Engineering,0.3,0.3,0.28,0.1,0.03,0.0,0.0,0.0,charng-hsein juang,
+CE,3310,1,Constr Engr & Mgmnt,0.28,0.36,0.26,0.08,0.0,0.0,0.0,0.02,james burati,
+CE,3410,1,Intro to Fluid Mech,0.15,0.41,0.29,0.07,0.05,0.0,0.0,0.02,nigel gregory kaye,
+CE,3420,1,Hydraulics & Hydro,0.12,0.39,0.27,0.09,0.03,0.0,0.0,0.09,abdul khan,
+CE,3420,2,Hydraulics & Hydro,0.5,0.38,0.1,0.0,0.0,0.0,0.0,0.03,ashok mishra,
+CE,3510,1,Civil Engineering Materials,0.33,0.56,0.05,0.05,0.02,0.0,0.0,0.0,prasada rangaraju,
+CE,3520,1,Econ Eval of Proj,0.35,0.23,0.2,0.15,0.05,0.0,0.0,0.02,yongxi huang,
+CE,3520,2,Econ Eval of Proj,0.53,0.31,0.14,0.02,0.0,0.0,0.0,0.0,bradley putman,
+CE,3530,1,Professional Seminar,0.92,0.06,0.01,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,4010,1,Matrix Str Analysis,0.08,0.5,0.0,0.08,0.17,0.0,0.0,0.17,bryant nielson,
+CE,4020,1,Reinfor Con Design,0.42,0.36,0.16,0.04,0.02,0.0,0.0,0.0,brandon ross,
+CE,4040,1,Masonry Struct Des,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,atamturktur russcher,
+CE,4110,1,Roadway Geo Design,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
+CE,4120,1,Urban Transport Plan,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,mashrur chowdhury,
+CE,4210,1,Geotechnical Design,0.26,0.57,0.11,0.06,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,4330,1,Const Plan & Sched,0.39,0.42,0.15,0.01,0.01,0.0,0.0,0.01, kent nilsson,
+CE,4340,1,Const Est Proj Cont,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,4470,1,Stormwater Managemnt,0.36,0.52,0.08,0.0,0.0,0.0,0.0,0.04,nigel gregory kaye,
+CE,4590,1,Capstone Design Proj,0.52,0.44,0.05,0.0,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4590,100,Capstone Design Proj,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,
+CE,6010,1,Matrix Str Analysis,0.29,0.52,0.14,0.0,0.05,0.0,0.0,0.0,bryant nielson,
+CE,6040,1,Masonry Struct Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,atamturktur russcher,
+CE,6210,1,Geotechnical Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,6330,1,Const Plan & Sched,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0, kent nilsson,
+CE,8040,1,Prestressed Concrete,0.49,0.41,0.1,0.0,0.0,0.0,0.0,0.0,brandon ross,
+CE,8080,1,Earthquake Engr,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CE,8250,1,Geotech Equake Engr,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,8270,1,Spec Cements & Concr,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,prasada rangaraju,
+CE,8530,1,Apps in Traffic En,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CE,8930,2,Selec Topics in C E - Construc,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,james burati,
+CE,9910,19,Doctoral Dissertation Research,0.0,0.0,0.0,0.0,0.0,0.8,0.2,0.0,leidy klotz,
+CH,1010,1,General Chemistry,0.09,0.23,0.3,0.2,0.12,0.0,0.0,0.06,ava kreider-mueller,
+CH,1010,2,General Chemistry,0.07,0.21,0.3,0.2,0.14,0.0,0.0,0.08,ava kreider-mueller,
+CH,1010,3,General Chemistry,0.17,0.29,0.28,0.11,0.1,0.0,0.0,0.05,dennis taylor,
+CH,1010,4,General Chemistry,0.1,0.19,0.25,0.25,0.13,0.0,0.0,0.08,joseph stu thrasher,
+CH,1010,400,General Chemistry (ONLINE),0.21,0.19,0.36,0.08,0.13,0.0,0.0,0.03,stephe schvaneveldt,
+CH,1020,1,General Chemistry,0.2,0.25,0.2,0.18,0.08,0.0,0.0,0.1,christopher wilson,
+CH,1020,2,General Chemistry,0.19,0.26,0.26,0.12,0.04,0.0,0.0,0.14,christopher wilson,
+CH,1020,3,General Chemistry,0.29,0.38,0.25,0.03,0.01,0.0,0.0,0.03,dennis taylor,
+CH,1020,4,General Chemistry,0.25,0.42,0.22,0.06,0.03,0.0,0.0,0.03,dennis taylor,
+CH,1020,5,General Chemistry,0.15,0.39,0.31,0.07,0.04,0.0,0.0,0.04,olt geiculescu,
+CH,1020,7,General Chemistry,0.21,0.53,0.16,0.06,0.02,0.0,0.0,0.03,kenneth wi rillings,
+CH,1020,8,General Chemistry,0.23,0.4,0.26,0.06,0.02,0.0,0.0,0.03,kenneth wi rillings,
+CH,1020,9,General Chemistry,0.24,0.41,0.23,0.05,0.05,0.0,0.0,0.02,ava kreider-mueller,
+CH,1020,10,General Chemistry,0.21,0.42,0.32,0.04,0.02,0.0,0.0,0.0,kenneth wi rillings,
+CH,1020,11,General Chemistry (CH majors),0.55,0.18,0.24,0.0,0.0,0.0,0.0,0.03,stephe schvaneveldt,
+CH,1020,12,General Chemistry (CLUE),0.36,0.5,0.07,0.02,0.0,0.0,0.0,0.05,kenneth christensen,
+CH,1020,51,General Chemistry (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
+CH,1020,52,General Chemistry (HON),0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,shiou-jyh hwu,True
+CH,1050,1,Chem in Context I,0.27,0.45,0.24,0.03,0.0,0.0,0.0,0.01,thomas hickman,
+CH,1060,1,Chem in Context II,0.36,0.61,0.0,0.0,0.04,0.0,0.0,0.0,olt geiculescu,
+CH,1060,2,Chem in Context II,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,olt geiculescu,
+CH,1520,1,Chem Commun I,0.83,0.02,0.02,0.0,0.0,0.0,0.0,0.13,richard marcus,
+CH,2010,1,Survey of Organic Chemistry,0.37,0.26,0.19,0.1,0.04,0.0,0.0,0.03,tania issa houjeiry,
+CH,2020,1,Surv of Organic Chemistry Lab,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,
+CH,2020,2,Surv of Organic Chemistry Lab,0.53,0.29,0.12,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2020,3,Surv of Organic Chemistry Lab,0.71,0.18,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2050,1,Intro Inorg Chem,0.54,0.29,0.17,0.0,0.0,0.0,0.0,0.0,william pennington,
+CH,2230,1,Organic Chemistry,0.23,0.3,0.12,0.12,0.17,0.0,0.0,0.07,jacob schroeder,
+CH,2230,2,Organic Chemistry,0.44,0.27,0.14,0.06,0.03,0.0,0.0,0.06,jacob schroeder,
+CH,2230,3,Organic Chemistry,0.35,0.33,0.08,0.07,0.11,0.0,0.0,0.07,jacob schroeder,
+CH,2240,1,Organic Chemistry,0.39,0.43,0.12,0.05,0.0,0.0,0.0,0.01,tania issa houjeiry,
+CH,2240,2,Organic Chemistry,0.29,0.57,0.09,0.03,0.02,0.0,0.0,0.0,thomas hickman,
+CH,2240,3,Organic Chemistry,0.22,0.39,0.24,0.1,0.02,0.0,0.0,0.04,thomas hickman,
+CH,2240,4,Organic Chemistry,0.37,0.26,0.09,0.12,0.07,0.0,0.0,0.09,rhett smith,
+CH,2240,5,Organic Chemistry,0.33,0.4,0.18,0.02,0.04,0.0,0.0,0.04,jacob schroeder,
+CH,2270,1,Organic Chem Lab,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,5,Organic Chem Lab,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,8,Organic Chem Lab,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,9,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,1,Organic Chem Lab,0.62,0.08,0.0,0.0,0.0,0.0,0.0,0.31,sean 'connor,
+CH,2280,2,Organic Chem Lab,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,sean 'connor,
+CH,2280,3,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2280,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,7,Organic Chem Lab,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2280,8,Organic Chem Lab,0.73,0.13,0.0,0.07,0.0,0.0,0.0,0.07,sean 'connor,
+CH,2280,12,Organic Chem Lab,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,21,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,sean 'connor,
+CH,2280,24,Organic Chem Lab,0.63,0.19,0.13,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2290,3,Organic Chem Lab,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,3310,1,Physical Chemistry,0.42,0.32,0.11,0.05,0.0,0.0,0.0,0.11,arkady kholodenko,
+CH,3320,1,Physical Chemistry (ENGR only),0.49,0.33,0.13,0.03,0.01,0.0,0.0,0.0,steven stuart,
+CH,3320,2,Physical Chemistry (CH majors),0.42,0.29,0.21,0.04,0.04,0.0,0.0,0.0,jason mcneill,
+CH,3400,2,Physical Chem Lab,0.78,0.17,0.0,0.06,0.0,0.0,0.0,0.0,christopher wilson,
+CH,3400,3,Physical Chem Lab,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,christopher wilson,
+CH,3400,4,Physical Chem Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,christopher wilson,
+CH,3600,1,Chemical Biology,0.38,0.27,0.17,0.1,0.0,0.0,0.0,0.08,modi wetzler,
+CH,4110,1,Instrumental Analy,0.23,0.32,0.09,0.18,0.18,0.0,0.0,0.0,george chumanov,
+CH,4120,1,Instr Analysis Lab,0.33,0.25,0.25,0.08,0.08,0.0,0.0,0.0,jeffrey natha anker,
+CH,4120,2,Instr Analysis Lab,0.55,0.27,0.09,0.09,0.0,0.0,0.0,0.0,jeffrey natha anker,
+CH,4130,1,Chem Aqueous Systems,0.42,0.32,0.11,0.0,0.0,0.0,0.0,0.16,cindy lee,
+CH,4500,1,Chemistry Capstone,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
+CH,8090,1,Chem App/X-Ray Cryst,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,
+CH,8130,1,Electrochem Sci,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,stephen creager,
+CH,8510,1,Grad Student Seminar,0.82,0.07,0.07,0.0,0.04,0.0,0.0,0.0,joseph stu thrasher,
+CHE,1300,1,Chemical Eng Tools,0.27,0.41,0.14,0.02,0.08,0.0,0.0,0.08,christopher norfolk,
+CHE,1300,2,Chemical Eng Tools,0.35,0.33,0.15,0.09,0.03,0.0,0.0,0.05,christopher norfolk,
+CHE,2200,1,Ch E Thermo I,0.22,0.2,0.27,0.1,0.16,0.0,0.0,0.06,mark thies,
+CHE,2200,2,Ch E Thermo I,0.25,0.19,0.25,0.17,0.14,0.0,0.0,0.0,mark thies,
+CHE,2300,1,Fluids/Heat Transfer,0.12,0.22,0.41,0.14,0.06,0.0,0.0,0.04,douglas hirt,
+CHE,2300,2,Fluids/Heat Transfer,0.19,0.33,0.19,0.19,0.08,0.0,0.0,0.0,douglas hirt,
+CHE,3210,1,Ch E Thermo II,0.23,0.23,0.39,0.09,0.07,0.0,0.0,0.0,christophe kitchens,
+CHE,3300,1,Mass Trans & Seprtn,0.23,0.32,0.25,0.08,0.12,0.0,0.0,0.0,mark alan blenner,
+CHE,3530,1,Proc Dyn & Control,0.22,0.49,0.24,0.04,0.02,0.0,0.0,0.0,mark roberts,
+CHE,4330,1,Process Design II,0.57,0.37,0.06,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,4990,14,CI- Membrane Separations,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,scott husson,
+CHIN,1010,1,Elementary Chinese,0.47,0.26,0.16,0.11,0.0,0.0,0.0,0.0,yanhua zhang,
+CHIN,1020,1,Elementary Chinese,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,yanming an,
+COM,1500,1,Intro to Human Com,0.89,0.07,0.01,0.0,0.01,0.0,0.0,0.03,eddie smith,
+COM,1500,2,Intro to Human Com,0.49,0.44,0.03,0.01,0.01,0.0,0.0,0.01,daniel lelan fecher,
+COM,1500,3,Intro to Human Com,0.85,0.13,0.0,0.0,0.01,0.0,0.0,0.01,eddie smith,
+COM,1500,4,Intro to Human Com,0.78,0.16,0.02,0.01,0.01,0.0,0.0,0.02,marianne her glaser,
+COM,1500,5,Intro to Human Com,0.66,0.28,0.03,0.01,0.0,0.0,0.0,0.02,marianne her glaser,
+COM,1500,6,Intro to Human Com,0.54,0.41,0.04,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,
+COM,1500,6,Intro to Human Communication,0.54,0.41,0.04,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,
+COM,2010,1,Intr to Comm Studies,0.44,0.36,0.2,0.0,0.0,0.0,0.0,0.0,brenden kendall,
+COM,2010,2,Intr to Comm Studies,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,2500,1,Public Speaking,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,2,Public Speaking,0.47,0.32,0.05,0.05,0.0,0.0,0.0,0.11,marilyn denise pugh,
+COM,2500,3,Public Speaking,0.5,0.45,0.0,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,4,Public Speaking,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,5,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,6,Public Speaking,0.45,0.4,0.1,0.0,0.05,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,7,Public Speaking,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,8,Public Speaking,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,10,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,11,Public Speaking,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,
+COM,2500,13,Public Speaking,0.26,0.53,0.16,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
+COM,2500,14,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,
+COM,2500,15,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,
+COM,2500,16,Public Speaking,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,the estate  geddes,
+COM,2500,17,Public Speaking,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,pauline matthey,
+COM,2500,18,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,19,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,20,Public Speaking,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,pauline matthey,
+COM,2500,21,Public Speaking,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,22,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,23,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,24,Public Speaking,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,pauline matthey,
+COM,2500,28,Public Speaking,0.26,0.53,0.05,0.05,0.0,0.0,0.0,0.11,marilyn denise pugh,
+COM,2500,400,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,401,Public Speaking,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,402,Public Speaking,0.72,0.11,0.0,0.06,0.0,0.0,0.0,0.11,alexis zachar davis,
+COM,2500,403,Public Speaking,0.63,0.26,0.0,0.05,0.05,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,500,Public Speaking,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,501,Public Speaking,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,3010,1,Comm Theory,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,3020,1,Mass Comm Theory,0.62,0.3,0.04,0.04,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3080,1,Pub Comm & Pop Cult,0.29,0.42,0.19,0.03,0.0,0.0,0.0,0.06,chenjerai kumanyika,
+COM,3100,1,Quant Comm Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3110,1,Qual Comm Methods,0.58,0.25,0.13,0.0,0.04,0.0,0.0,0.0,stephanie pangborn,
+COM,3200,1,Bdcst Production,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,wanda johnson,
+COM,3260,1,Pr in Sports,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3480,1,Interpersonal Comm,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,melinda ra weathers,
+COM,3500,1,Sm Group & Team Comm,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,joseph mazer,
+COM,3560,1,Stakeholder Comm,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3660,1,EP: Advertising & Media,0.56,0.32,0.04,0.04,0.0,0.0,0.0,0.04,william reynolds,
+COM,3660,2,EP: Building the Brand,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,andrew mendelsohn,
+COM,3660,3,Live Broadcast Production,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,michael rodgers,
+COM,3680,1,Applied Digital Communication,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,
+COM,3990,6,CI: Tigers Talk Ethics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,
+COM,4260,1,Social Media and Sports Comm,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4260,2,Social Media and Sports Comm,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4700,1,Comm & Health,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,stephanie pangborn,
+COM,4950,1,Sr. Capstone: Agenda Building,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,bryan denham,
+COM,4950,2,Sr. Capstone: Advert. & Sport,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,8110,1,Comm Research Methods II,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,chenjerai kumanyika,
+CPSC,1010,1,Computer Science I,0.19,0.18,0.19,0.12,0.14,0.0,0.0,0.18,catherine hochrine,
+CPSC,1010,2,Computer Science I,0.61,0.24,0.1,0.0,0.0,0.0,0.0,0.05,lauren elizab dukes,
+CPSC,1020,1,Computer Science II,0.48,0.24,0.08,0.0,0.08,0.0,0.0,0.12,catherine hochrine,
+CPSC,1020,2,Computer Science II,0.62,0.12,0.04,0.0,0.04,0.0,0.0,0.19,yvon feaster,
+CPSC,1020,3,Computer Science II,0.68,0.04,0.08,0.0,0.08,0.0,0.0,0.12,yvon feaster,
+CPSC,1020,4,Computer Science II,0.33,0.24,0.14,0.05,0.05,0.0,0.0,0.19,joshua levine,
+CPSC,1110,1,Intro to Programming in C,0.68,0.25,0.0,0.0,0.04,0.0,0.0,0.04,patrick sterling,
+CPSC,1110,2,Intro to Programming in C,0.77,0.1,0.07,0.03,0.0,0.0,0.0,0.03,patrick sterling,
+CPSC,1110,3,Intro to Programming in C,0.57,0.2,0.07,0.07,0.03,0.0,0.0,0.07,patrick sterling,
+CPSC,1110,4,Intro to Programming in C,0.63,0.04,0.04,0.04,0.15,0.0,0.0,0.11,toni bloodwor pence,
+CPSC,1200,1,Intro Info Tech,0.82,0.06,0.0,0.0,0.06,0.0,0.0,0.06,renee lambert,
+CPSC,2070,1,Discrete Structures,0.34,0.25,0.18,0.02,0.09,0.0,0.0,0.11,sandra hedetniemi,
+CPSC,2070,401,Discrete Structures,0.2,0.34,0.25,0.13,0.05,0.0,0.0,0.04,larry hodges,
+CPSC,2100,1,Progrmng Methodology,0.23,0.23,0.23,0.06,0.2,0.0,0.0,0.06,rose lowe,
+CPSC,2120,1,Algs/Data Structures,0.36,0.31,0.16,0.05,0.12,0.0,0.0,0.01,wayne goddard,
+CPSC,2150,1,Software Dev Fndtns,0.35,0.39,0.15,0.07,0.02,0.0,0.0,0.02,yu-shan sun,
+CPSC,2150,2,Software Dev Fndtns,0.23,0.21,0.32,0.06,0.11,0.0,0.0,0.06,blair madiso durkee,
+CPSC,2200,1,Microcomputer Appl,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,patrick sterling,
+CPSC,2310,1,Intro Computer Org,0.21,0.31,0.36,0.05,0.05,0.0,0.0,0.03,rose lowe,
+CPSC,2310,2,Intro Computer Org,0.32,0.32,0.24,0.0,0.09,0.0,0.0,0.03,rose lowe,
+CPSC,2910,2,Prof Issues I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,renee lambert,
+CPSC,2910,3,Prof Issues I,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,renee lambert,
+CPSC,2910,4,Prof Issues I,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,renee lambert,
+CPSC,2910,5,Prof Issues I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
+CPSC,2910,6,Prof Issues I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,james jones,
+CPSC,2910,7,Prof Issues I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,james jones,
+CPSC,3220,1,Intro to Operating Systems,0.26,0.21,0.23,0.05,0.18,0.0,0.0,0.08,jacob sorber,
+CPSC,3220,2,Intro to Operating Systems,0.17,0.14,0.2,0.09,0.17,0.0,0.0,0.23,jacob sorber,
+CPSC,3300,1,Computer Systems Org,0.27,0.24,0.26,0.06,0.1,0.0,0.0,0.06,mark smotherman,
+CPSC,3500,1,Foundations of Computer Sci,0.15,0.23,0.37,0.1,0.06,0.0,0.0,0.1,ilya mark safro,
+CPSC,3520,1,Programming Systems,0.41,0.3,0.05,0.0,0.09,0.0,0.0,0.16,robert schalkoff,
+CPSC,3600,1,Network Programming,0.16,0.27,0.25,0.16,0.1,0.0,0.0,0.06,sekou lionel remy,
+CPSC,3620,1,Distributed Computng,0.29,0.38,0.15,0.08,0.04,0.0,0.0,0.06,linh bao ngo,
+CPSC,3720,1,Software Engineering,0.17,0.39,0.3,0.04,0.04,0.0,0.0,0.04,stephen schaub,
+CPSC,3720,2,Software Engineering,0.26,0.29,0.29,0.1,0.03,0.0,0.0,0.03,stephen schaub,
+CPSC,4050,1,Computer Graphics,0.26,0.52,0.13,0.04,0.0,0.0,0.0,0.04,robert geist,
+CPSC,4140,1,Human and Computer Interaction,0.35,0.48,0.04,0.04,0.09,0.0,0.0,0.0,sabarish venka babu,
+CPSC,4140,2,Human and Computer Interaction,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,kelly caine,
+CPSC,4160,1,2-D Game Engine Construction,0.5,0.33,0.1,0.0,0.07,0.0,0.0,0.0,brian malloy,
+CPSC,4240,1,System Admin and Security,0.15,0.58,0.19,0.04,0.04,0.0,0.0,0.0,james martin,
+CPSC,4620,1,Database Management Systems,0.22,0.44,0.22,0.07,0.04,0.0,0.0,0.0,zijun wang,
+CPSC,4820,1,Design & Implementation,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,christina sop joerg,
+CPSC,4820,2,Mobile Device,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,roy pargas,
+CPSC,4910,1,Prof Issues II,0.93,0.04,0.0,0.0,0.02,0.0,0.0,0.0,james jones,
+CPSC,6050,1,Computer Graphics,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,robert geist,
+CPSC,6140,1,Human and Computer Interaction,0.57,0.29,0.07,0.0,0.0,0.0,0.0,0.07,sabarish venka babu,
+CPSC,6140,2,Human and Computer Interaction,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,kelly caine,
+CPSC,6160,1,2-D Game Engine Construction,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,brian malloy,
+CPSC,6240,1,System Admin and Security,0.57,0.29,0.07,0.0,0.0,0.0,0.0,0.07,james martin,
+CPSC,6620,1,Database Management Systems,0.46,0.27,0.19,0.0,0.08,0.0,0.0,0.0,zijun wang,
+CPSC,6820,1,Special Topics:Design & Imple,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+CPSC,8080,1,Advanced Animation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
+CPSC,8090,1,Render and Shade,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,timothy davis,
+CPSC,8220,1,Case Study in Operating Sys,0.27,0.67,0.0,0.0,0.0,0.0,0.0,0.07,robert geist,
+CPSC,8280,1,Theory of Program. Languages,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,murali sitaraman,
+CPSC,8550,1,Embedded Network Sys,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,yvon feaster,
+CPSC,8620,1,Database Mngmt System Design,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,zijun wang,
+CPSC,8630,1,Multimedia Sys/Apps,0.27,0.5,0.14,0.0,0.05,0.0,0.0,0.05,zijun wang,
+CPSC,8750,1,Software Architectur,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+CPSC,8810,1,Topic:Info Retrieval,0.23,0.65,0.1,0.0,0.0,0.0,0.0,0.03,feng luo,
+CPSC,8810,2,Advanced Networking & Security,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,hongxin hu,
+CRP,8020,1,Site Planning,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,clifford dona ellis,
+CRP,8040,1,Land Use Analysis,0.82,0.0,0.12,0.0,0.0,0.0,0.0,0.06,stephen sperry,
+CRP,8050,1,Plning Theory & Hist,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,mickey lauria,
+CRP,8090,1,Current Issues,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
+CRP,8130,1,Transportation Plan,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
+CRP,8200,1,Negotiation,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
+CRP,8220,1,Urban Design,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+CSM,1500,1,Constr Prob Solving,0.39,0.56,0.0,0.0,0.06,0.0,0.0,0.0,jason lucas,
+CSM,1500,2,Constr Prob Solving,0.57,0.24,0.19,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,1500,3,Constr Prob Solving,0.3,0.6,0.05,0.05,0.0,0.0,0.0,0.0,jason lucas,
+CSM,2020,1,Structures II,0.24,0.38,0.24,0.14,0.0,0.0,0.0,0.0,shima clarke,
+CSM,2020,2,Structures II,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,shima clarke,
+CSM,2040,1,Cont Documents,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2040,2,Cont Documents,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2050,1,Mats & Methods II,0.37,0.33,0.22,0.07,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2050,2,Mats & Methods II,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,3050,1,Envir Systems II,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3050,2,Envir Systems II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3520,1,Const Scheduling,0.2,0.5,0.25,0.0,0.0,0.0,0.0,0.05,christine piper,
+CSM,3520,2,Const Scheduling,0.16,0.32,0.53,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,3530,1,Const Estimating II,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,james packer smith,
+CSM,3530,2,Const Estimating II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,james packer smith,
+CSM,4540,1,Const Capstone,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4540,2,Const Capstone,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8610,1,Construction Control Systems,0.07,0.67,0.27,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8610,400,Construction Control Systems,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,christine piper,
+CSM,8810,1,Professional Seminar,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CSM,8810,400,Professional Seminar,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.91,0.06,0.03,jeffrey appling,
+CU,1010,1,Univ Success Skills,0.83,0.04,0.04,0.04,0.0,0.0,0.0,0.04,rise jean sheriff,
+CU,1010,2,Univ Success Skills,0.68,0.05,0.14,0.05,0.0,0.0,0.0,0.09,cecelia hamby,
+CU,1010,3,Univ Success Skills,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,matthew james kirk,
+CU,1010,4,Univ Success Skills,0.41,0.55,0.0,0.0,0.03,0.0,0.0,0.0,matthew james kirk,
+CU,1010,5,Univ Success Skills,0.54,0.33,0.04,0.0,0.0,0.0,0.0,0.08,mary mcp von kaenel,
+CU,1010,6,Univ Success Skills,0.65,0.17,0.13,0.0,0.04,0.0,0.0,0.0,robert dav brackett,
+CU,1010,7,Univ Success Skills,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,deborah ann vaughn,
+CU,2010,1,Sustainability Leadership,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,
+DPA,3070,1,Method 3d Production,0.52,0.19,0.05,0.1,0.0,0.0,0.0,0.14,virginia ba nearing,
+DPA,8600,1,Production Studio,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,
+DPA,8600,2,Production Studio,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jerry tessendorf,
+ECE,2010,1,Logic & Comp Device,0.19,0.32,0.18,0.19,0.09,0.0,0.0,0.04,lin zhu,
+ECE,2020,1,Electric Circuits I,0.14,0.22,0.29,0.18,0.12,0.0,0.0,0.04,william harrell,
+ECE,2070,1,Basic Electrical Engineering,0.44,0.24,0.14,0.05,0.04,0.0,0.0,0.09,surya sharma,
+ECE,2070,2,Basic Electrical Engineering,0.56,0.33,0.1,0.01,0.0,0.0,0.0,0.0,hai xiao,
+ECE,2070,3,Basic Electrical Engineering,0.89,0.04,0.05,0.0,0.0,0.0,0.0,0.01,sung- kim,
+ECE,2080,5,Electrical Engineering Lab I,0.8,0.1,0.0,0.05,0.0,0.0,0.0,0.05,william harrell,
+ECE,2080,8,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,william harrell,
+ECE,2080,13,Electrical Engineering Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,william harrell,
+ECE,2080,17,Electrical Engineering Lab I,0.78,0.06,0.06,0.0,0.06,0.0,0.0,0.06,william harrell,
+ECE,2080,18,Electrical Engineering Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,william harrell,
+ECE,2080,20,Electrical Engineering Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2090,4,Logic Lab,0.67,0.08,0.08,0.08,0.0,0.0,0.0,0.08,william harrell,
+ECE,2220,1,Syst Prog Concept,0.23,0.21,0.23,0.12,0.1,0.0,0.0,0.12,william reid,
+ECE,2230,1,Comp Sys Eng,0.2,0.12,0.32,0.05,0.15,0.0,0.0,0.17,harlan russell,
+ECE,2620,1,Elec Circuits II,0.33,0.27,0.23,0.09,0.07,0.0,0.0,0.01,richard groff,
+ECE,2620,2,Elec Circuits II (HON),0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,True
+ECE,2720,1,Comp Organization,0.28,0.31,0.25,0.11,0.05,0.0,0.0,0.0,william reid,
+ECE,2720,1,,0.28,0.31,0.25,0.11,0.05,0.0,0.0,0.0,william reid,
+ECE,2730,1,Computer Org Lab,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2730,3,Computer Org Lab,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,william harrell,
+ECE,2730,4,Computer Org Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2730,5,Computer Org Lab,0.71,0.14,0.07,0.0,0.07,0.0,0.0,0.0,william harrell,
+ECE,2730,6,Computer Org Lab,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,2730,7,Computer Org Lab,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,3110,1,Electrical Engineering Lab III,0.56,0.13,0.0,0.13,0.13,0.0,0.0,0.06,william harrell,
+ECE,3110,4,Electrical Engineering Lab III,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,william harrell,
+ECE,3110,5,Electrical Engineering Lab III,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,
+ECE,3170,1,Rand Signal Analysis,0.16,0.34,0.2,0.09,0.13,0.0,0.0,0.08,stephen hubbard,
+ECE,3170,2,Rand Signal Analysis (HON),0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,carl baum,True
+ECE,3200,1,Electronics I,0.28,0.22,0.15,0.13,0.2,0.0,0.0,0.03,stephen hubbard,
+ECE,3210,1,Electronics II,0.55,0.27,0.09,0.02,0.08,0.0,0.0,0.0,stephen hubbard,
+ECE,3220,1,Intro Operating Sys,0.06,0.41,0.35,0.06,0.0,0.0,0.0,0.12,jacob sorber,
+ECE,3220,2,Intro Operating Sys,0.05,0.35,0.4,0.05,0.05,0.0,0.0,0.1,jacob sorber,
+ECE,3270,1,Dig Comp Design,0.1,0.26,0.26,0.08,0.08,0.0,0.0,0.23,melissa crawl smith,
+ECE,3300,1,Signals & Systems,0.21,0.19,0.23,0.14,0.14,0.0,0.0,0.08,carl baum,
+ECE,3520,1,Programming Systems,0.28,0.48,0.14,0.03,0.0,0.0,0.0,0.07,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.25,0.29,0.25,0.06,0.06,0.0,0.0,0.08,edward collins,
+ECE,3710,1,Microcontr Interface,0.4,0.38,0.2,0.01,0.01,0.0,0.0,0.0,william reid,
+ECE,3720,6,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,3800,1,Electromagnetics,0.23,0.18,0.36,0.13,0.1,0.0,0.0,0.0,anthony martin,
+ECE,3810,1,Field Waves & Ckts,0.45,0.33,0.16,0.04,0.02,0.0,0.0,0.0,eric gordon johnson,
+ECE,4090,1,Cont & Discrete Sys,0.37,0.4,0.17,0.06,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4190,1,Elec Mach and Drives,0.28,0.38,0.21,0.0,0.03,0.0,0.0,0.1,keith corzine,
+ECE,4270,1,Communications Sys,0.24,0.29,0.3,0.09,0.05,0.0,0.0,0.03,madhabi manandhar,
+ECE,4380,1,Computer Commun,0.28,0.18,0.23,0.13,0.05,0.0,0.0,0.15,harlan russell,
+ECE,4680,1,Embedded Computing,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,adam hoover,
+ECE,4700,1,Vehicle Electronics,0.54,0.35,0.06,0.04,0.0,0.0,0.0,0.0,todd hubing,
+ECE,4950,1,Int Sys Design I,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4960,1,Int Sys Design II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,richard groff,
+ECE,6190,1,Elec Mach and Drives,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,keith corzine,
+ECE,6380,1,Computer Commun,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
+ECE,6460,1,Antennas,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,anthony martin,
+ECE,6680,1,Embedded Computing,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,adam hoover,
+ECE,6930,1,MEMS,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pingshan wang,
+ECE,8070,1,Comp Meth Pwr Anal,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,gan venayagamoorthy,
+ECE,8160,1,Elec Power Distr Sys Engr,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,elham makram,
+ECE,8300,1,Electromagnetics I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,anthony martin,
+ECE,8400,1,Semicond Devices,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,8440,1,Digital Signal Proc,0.43,0.52,0.05,0.0,0.0,0.0,0.0,0.0,john gowdy,
+ECE,8560,1,Pattern Recognition,0.37,0.46,0.11,0.0,0.0,0.0,0.0,0.06,robert schalkoff,
+ECE,8930,3,HPC with GPUs,0.32,0.52,0.08,0.0,0.0,0.0,0.0,0.08,melissa crawl smith,
+ECE,8930,4,Distributed Dynamical Systems,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,yongqiang wang,
+ECON,2000,1,Economic Concepts,0.05,0.35,0.23,0.1,0.18,0.0,0.0,0.1,mallika garg,
+ECON,2000,2,Economic Concepts,0.31,0.39,0.17,0.08,0.03,0.0,0.0,0.03,mallika garg,
+ECON,2000,3,Economic Concepts,0.3,0.28,0.15,0.08,0.15,0.0,0.0,0.05,miren ivankovic,
+ECON,2110,1,Principles of Microeconomics,0.36,0.21,0.33,0.03,0.03,0.0,0.0,0.05,robert dew tollison,
+ECON,2110,2,Principles of Microeconomics,0.15,0.48,0.3,0.03,0.03,0.0,0.0,0.03,alexander fiore,
+ECON,2110,3,Principles of Microeconomics,0.14,0.49,0.25,0.07,0.03,0.0,0.0,0.03,adam millsap,
+ECON,2110,4,Principles of Microeconomics,0.32,0.37,0.15,0.05,0.02,0.0,0.0,0.1,amanda caitlin kerr,
+ECON,2110,5,Principles of Microeconomics,0.18,0.38,0.4,0.0,0.03,0.0,0.0,0.03,molly espey,
+ECON,2110,6,Principles of Microeconomics,0.29,0.26,0.14,0.1,0.14,0.0,0.0,0.07,andew swanson,
+ECON,2110,7,Principles of Microeconomics,0.28,0.41,0.24,0.03,0.03,0.0,0.0,0.02,alexander fiore,
+ECON,2110,8,Principles of Microeconomics,0.29,0.26,0.26,0.08,0.05,0.0,0.0,0.06,timothy andr bersak,
+ECON,2110,10,Principles of Microeconomics,0.23,0.34,0.26,0.06,0.0,0.0,0.0,0.11,anne anders,
+ECON,2110,11,Principles of Microeconomics,0.39,0.32,0.23,0.07,0.0,0.0,0.0,0.0,amanda caitlin kerr,
+ECON,2110,12,Principles of Microeconomics,0.1,0.58,0.25,0.05,0.0,0.0,0.0,0.03,molly espey,
+ECON,2120,1,Principles of Macro,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,2,Principles of Macro,0.17,0.22,0.56,0.06,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,3,Principles of Macro,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,4,Principles of Macro,0.21,0.47,0.26,0.0,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,5,Principles of Macro,0.41,0.24,0.29,0.0,0.0,0.0,0.0,0.06,scott baier,
+ECON,2120,6,Principles of Macro,0.11,0.56,0.22,0.0,0.06,0.0,0.0,0.06,scott baier,
+ECON,2120,7,Principles of Macro,0.21,0.16,0.53,0.05,0.0,0.0,0.0,0.05,scott baier,
+ECON,2120,8,Principles of Macro,0.37,0.16,0.47,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,9,Principles of Macro,0.2,0.25,0.35,0.05,0.05,0.0,0.0,0.1,scott baier,
+ECON,2120,10,Principles of Macro,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,11,Principles of Macro,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,12,Principles of Macro,0.26,0.37,0.32,0.0,0.0,0.0,0.0,0.05,scott baier,
+ECON,2120,13,Principles of Macro,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,14,Principles of Macro,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,15,Principles of Macro,0.29,0.43,0.24,0.0,0.0,0.0,0.0,0.05,scott baier,
+ECON,2120,16,Principles of Macro,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,17,Principles of Macro,0.32,0.37,0.32,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,18,Principles of Macro,0.16,0.53,0.26,0.0,0.0,0.0,0.0,0.05,scott baier,
+ECON,2120,19,Principles of Macro,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,20,Principles of Macro,0.26,0.36,0.3,0.04,0.02,0.0,0.0,0.02,peter david lorenz,
+ECON,2120,21,Principles of Macro,0.25,0.51,0.2,0.03,0.0,0.0,0.0,0.02,peter david lorenz,
+ECON,2120,22,Principles of Macro,0.35,0.25,0.33,0.03,0.0,0.0,0.0,0.05,yukun sun,
+ECON,2120,23,Principles of Macro,0.45,0.38,0.18,0.0,0.0,0.0,0.0,0.0,yukun sun,
+ECON,2120,24,Principles of Macro,0.21,0.52,0.17,0.05,0.04,0.0,0.0,0.01,scott barkowski,
+ECON,2120,25,Principles of Macro,0.17,0.64,0.17,0.0,0.03,0.0,0.0,0.0,scott barkowski,
+ECON,2120,26,Principles of Macro,0.22,0.08,0.27,0.05,0.22,0.0,0.0,0.16,ralph charles allen,
+ECON,3020,1,Money and Banking,0.23,0.23,0.3,0.13,0.05,0.0,0.0,0.08,danielle zanzalari,
+ECON,3060,1,Managerial Economics,0.28,0.31,0.25,0.03,0.06,0.0,0.0,0.06,jacob burgdorf,
+ECON,3100,1,International Econ,0.26,0.33,0.17,0.17,0.02,0.0,0.0,0.05,ayse mujde erdogan,
+ECON,3140,1,Intermediate Micro,0.23,0.28,0.21,0.08,0.05,0.0,0.0,0.15,patrick warren,
+ECON,3140,2,Intermediate Micro,0.13,0.19,0.29,0.13,0.03,0.0,0.0,0.23,robert kennet fleck,
+ECON,3140,3,Intermediate Micro,0.17,0.19,0.33,0.08,0.17,0.0,0.0,0.06,frederick hanssen,
+ECON,3150,1,Intermediate Macro,0.36,0.26,0.22,0.07,0.03,0.0,0.0,0.06,ayse mujde erdogan,
+ECON,3150,2,Intermediate Macro,0.31,0.26,0.26,0.0,0.03,0.0,0.0,0.14,sergey vla mityakov,
+ECON,3440,1,Property Rights,0.11,0.3,0.26,0.07,0.07,0.0,0.0,0.19,dar litsukova-bokar,
+ECON,3600,1,Public Choice,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,robert dew tollison,
+ECON,4010,1,Labor Mkt Analysis,0.38,0.38,0.15,0.0,0.04,0.0,0.0,0.04,curtis simon,
+ECON,4020,1,Law and Economics,0.42,0.25,0.21,0.08,0.0,0.0,0.0,0.04,thomas wins hazlett,
+ECON,4050,1,Intro to Econometric,0.22,0.3,0.28,0.08,0.08,0.0,0.0,0.04,jaqueline oliveira,
+ECON,4100,1,Economic Development,0.4,0.32,0.12,0.04,0.0,0.0,0.0,0.12,robert tamura,
+ECON,4200,1,Pub Sector Econ,0.29,0.29,0.24,0.0,0.0,0.0,0.0,0.19,william dougan,
+ECON,4240,1,Organization of Ind,0.36,0.39,0.14,0.04,0.04,0.0,0.0,0.04,matthew lewis,
+ECON,4260,1,Sem Sport Economics,0.71,0.19,0.0,0.0,0.0,0.0,0.0,0.1,raymond sauer,
+ECON,4270,1,Dev American Economy,0.34,0.28,0.19,0.13,0.0,0.0,0.0,0.06,howard ne bodenhorn,
+ECON,4290,1,Economics of Energy Markets,0.48,0.38,0.0,0.0,0.0,0.0,0.0,0.14,matthew lewis,
+ECON,4400,1,Game Theory,0.47,0.37,0.0,0.0,0.0,0.0,0.0,0.16,daniel wood,
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.38,0.25,0.13,0.19,0.0,0.0,0.0,0.06,scott templeton,
+ECON,8020,1,Adv Econ Concepts and Applic I,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
+ECON,8050,1,Macroeconomic Theory,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,8070,1,Econometrics II,0.1,0.65,0.25,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,
+ECON,8200,1,Public Finance,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,william dougan,
+ECON,8990,1,Sel Topics-Appl Welfare Econ,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,arnold harberger,
+ECON,9010,1,Price Theory,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,daniel wood,
+ECON,9090,1,Time-Series Econ,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
+ED,1050,1,Educ Orientation,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,rory phil tannebaum,
+ED,1050,3,Educ Orientation,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,rory phil tannebaum,
+ED,8380,400,Astronomy - Middle School Tch,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard dallm white,
+ED,8380,534,Literacy Lessons for Indiv II,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,jennifer adams,
+ED,8380,537,Literacy Lessons for Indiv II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,vicki steadman,
+ED,8380,539,Literacy Lessons for Indiv II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jean ridley,
+ED,8600,400,Action Research,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,
+EDC,8060,1,Student Aff Issues,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
+EDC,8190,1,Cont College Student,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
+EDEC,4200,1,Early Childhood Science,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dolores an stegelin,
+EDEC,4500,1,EC Curric & Soc Stud Methods,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEL,3100,2,Arts in Ele School,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alison eliz leonard,
+EDEL,3210,1,Pe for the Elem Tchr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4510,1,Elem Methods in Science Tchg,0.5,0.44,0.0,0.06,0.0,0.0,0.0,0.0,cynthia chri deaton,
+EDEL,4520,1,Elem Methods Math Teaching,0.71,0.19,0.0,0.1,0.0,0.0,0.0,0.0,andrew mic tyminski,
+EDEL,4670,1,Tchng Esol: Elem Sch,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDF,3010,1,Principles of American Educat,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,suzanne rosenblith,
+EDF,3010,2,Principles of American Educat,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,patrick womac,
+EDF,3020,1,Educ Psych,0.35,0.42,0.13,0.1,0.0,0.0,0.0,0.0,penelope mar vargas,
+EDF,3340,1,Child Growth and Dev,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
+EDF,3350,1,Adol Growth & Dev,0.77,0.16,0.03,0.03,0.0,0.0,0.0,0.0,david barrett,
+EDF,4800,3,Digital Media & Learning,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,8770,500,Research Meth in Education I,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,david fleming,
+EDF,8800,400,Dig Media for Mid Sch Teachers,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,ryan visser,
+EDF,9270,1,Quant Rsrch & Stats for Ed,0.71,0.17,0.13,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,
+EDF,9710,1,Cse Stdy Ethnog Mthd,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,cynthia chri deaton,
+EDL,7150,500,Sch & Comm Relations,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth reynolds,
+EDL,7300,501,Techniq of Supervision-Pub Sch,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,
+EDL,7500,503,El Prin & Spv Ex I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,frederick buskey,
+EDL,9050,400,Thry/Prac Ed Ldrshp,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,james satterfield,
+EDL,9100,400,Intro Phd Seminar,0.62,0.23,0.0,0.0,0.0,0.0,0.0,0.15,leslie gonzales,
+EDL,9110,400,Systematic Inq Ed L,0.76,0.06,0.06,0.0,0.0,0.0,0.0,0.12,jane lindle,
+EDL,9760,1,External Effect He,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,leslie gonzales,
+EDLT,4580,1,Early Literacy: Birth-Kindergn,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,barbara everson,
+EDLT,4620,1,Reading Children's Lit in Elem,0.68,0.23,0.05,0.05,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4620,2,Reading Children's Lit in Elem,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4630,1,Teaching Rdg/Writing for ELLs,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDLT,8100,501,Foundations of Literacy,0.63,0.0,0.0,0.0,0.0,0.0,0.0,0.38,linda gambrell,
+EDLT,8670,400,Middle School Reading,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,phillip mich wilder,
+EDLT,8810,506,Reading Recovery Teacher II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vicki steadman,
+EDLT,8810,509,Reading Recovery Teacher II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jean floyd,
+EDLT,8830,506,Read Recovery Practicum II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,vicki steadman,
+EDLT,8830,509,Read Recovery Practicum II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jean floyd,
+EDSC,4370,1,Technology in Math,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,corrie leigh martin,
+EDSP,3700,2,Intro to Special Ed,0.74,0.2,0.06,0.0,0.0,0.0,0.0,0.0,pamela stecker,
+EDSP,3700,3,Intro to Special Ed,0.77,0.14,0.06,0.0,0.03,0.0,0.0,0.0,joseph benedic ryan,
+EDSP,3730,1,Char & Instr of ID & Autism,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
+EDSP,4910,1,Ed Assess Ind W/Dis,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
+EDSP,8230,400,Tch Integrated Set,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,
+EES,2020,1,Environ Engr Fundamentals II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
+EES,4010,1,Environmental Engr,0.51,0.44,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.24,0.59,0.15,0.0,0.02,0.0,0.0,0.0,mark schlautman,
+EES,4020,1,Water & Waste Water Treatment,0.44,0.25,0.13,0.0,0.06,0.0,0.0,0.13,david allen ladner,
+EES,4750,1,Capstone Design Project,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,4840,1,Solid Waste Mgt,0.35,0.35,0.23,0.07,0.0,0.0,0.0,0.0,thomas overcamp,
+EES,4850,1,Hazard Waste Management,0.19,0.5,0.25,0.06,0.0,0.0,0.0,0.0,mark schlautman,
+EES,8030,1,Phy/Chem Ops W/WW T,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,ezra lucas ho cates,
+EES,8040,1,Biochem Ops WW Trt,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,
+EES,8160,1,Technical Nuclear Forensics,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,lin shuller-nickles,
+EES,8420,1,Actinide Chemistry,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,brian powell,
+EES,8450,1,Environ Organic Chem,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,cindy lee,
+ELE,3010,1,Intro to Entre,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+ELE,3010,2,Intro to Entre,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,ashley will parnell,
+ELE,3010,3,Intro to Entre,0.77,0.2,0.03,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+ELE,4010,1,Exec Lead & Entr II,0.78,0.23,0.0,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
+ENGL,1030,1,Accelerated Composition,0.52,0.38,0.05,0.0,0.05,0.0,0.0,0.0,andrew mathas,
+ENGL,1030,2,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,
+ENGL,1030,3,Accelerated Composition,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,chelsea mari clarey,
+ENGL,1030,4,Accelerated Composition,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,dustin cleag mosley,
+ENGL,1030,5,Accelerated Composition,0.44,0.33,0.06,0.0,0.11,0.0,0.0,0.06,sarah ashto wickham,
+ENGL,1030,6,Accelerated Composition,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,matthew mar russell,
+ENGL,1030,7,Accelerated Composition,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,andrew mar barrocas,
+ENGL,1030,8,Accelerated Composition,0.6,0.25,0.05,0.05,0.0,0.0,0.0,0.05,chelsea mari clarey,
+ENGL,1030,10,Accelerated Composition,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,sarah ashto wickham,
+ENGL,1030,13,Accelerated Composition,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,molly brian collins,
+ENGL,1030,16,Accelerated Composition,0.65,0.2,0.05,0.0,0.0,0.0,0.0,0.1,molly brian collins,
+ENGL,1030,17,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,joslyn mc vonkaenel,
+ENGL,1030,18,Accelerated Composition,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,justin all holliday,
+ENGL,1030,19,Accelerated Composition,0.85,0.05,0.0,0.0,0.1,0.0,0.0,0.0,daniel frank,
+ENGL,1030,21,Accelerated Composition,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,katherine elrick,
+ENGL,1030,23,Accelerated Composition,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,adrian carson,
+ENGL,1030,24,Accelerated Composition,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,eda ozyesilpinar,
+ENGL,1030,25,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
+ENGL,1030,26,Accelerated Composition,0.68,0.05,0.0,0.11,0.16,0.0,0.0,0.0,adrian carson,
+ENGL,1030,27,Accelerated Composition,0.68,0.05,0.21,0.0,0.0,0.0,0.0,0.05,daniel frank,
+ENGL,1030,28,Accelerated Composition,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,katherine elrick,
+ENGL,1030,29,Accelerated Composition,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,lauren taylo stukes,
+ENGL,1030,30,Accelerated Composition,0.89,0.0,0.05,0.05,0.0,0.0,0.0,0.0,joshua wood,
+ENGL,1030,32,Accelerated Composition,0.67,0.22,0.0,0.06,0.06,0.0,0.0,0.0,sarah michel naciuk,
+ENGL,1030,37,Accelerated Composition,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,sarah michel naciuk,
+ENGL,1030,39,Accelerated Composition,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,stephanie mic heath,
+ENGL,1030,42,Accelerated Composition,0.85,0.05,0.05,0.0,0.05,0.0,0.0,0.0,stephanie mic heath,
+ENGL,1030,44,Accelerated Composition,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,carlisle an sargent,
+ENGL,1030,47,Accelerated Composition,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,sarah kath melchers,
+ENGL,1030,49,Accelerated Composition,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,hayley ren zertuche,
+ENGL,1030,53,Accelerated Composition,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,hannah conl vaughan,
+ENGL,1030,54,Accelerated Composition,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,
+ENGL,1030,56,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,nathan riggs,
+ENGL,1030,57,Accelerated Composition,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katherine hanzalik,
+ENGL,1030,58,Accelerated Composition,0.18,0.18,0.29,0.06,0.24,0.0,0.0,0.06,justin all holliday,
+ENGL,1030,60,Accelerated Composition,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kristen gay,
+ENGL,1030,61,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,2120,1,World Literature,0.52,0.38,0.0,0.07,0.0,0.0,0.0,0.03,christopher benson,
+ENGL,2120,2,World Literature,0.76,0.1,0.05,0.0,0.1,0.0,0.0,0.0,andrew lemons,
+ENGL,2120,3,World Literature,0.17,0.38,0.21,0.0,0.17,0.0,0.0,0.08,david charles foltz,
+ENGL,2120,4,World Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,2120,5,World Literature,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,2120,7,World Literature,0.12,0.54,0.15,0.04,0.0,0.0,0.0,0.15,david charles foltz,
+ENGL,2120,9,World Literature,0.38,0.45,0.07,0.1,0.0,0.0,0.0,0.0,joshua nei waggoner,
+ENGL,2120,10,World Literature,0.14,0.61,0.21,0.0,0.0,0.0,0.0,0.04,joshua nei waggoner,
+ENGL,2120,11,World Literature,0.32,0.4,0.04,0.04,0.12,0.0,0.0,0.08,karen kettnich,
+ENGL,2120,12,World Literature,0.16,0.64,0.04,0.16,0.0,0.0,0.0,0.0,karen kettnich,
+ENGL,2120,13,World Literature,0.3,0.37,0.26,0.04,0.04,0.0,0.0,0.0,meg woosley-goodman,
+ENGL,2120,14,World Literature,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,meg woosley-goodman,
+ENGL,2120,15,World Literature,0.27,0.5,0.23,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2120,16,World Literature,0.48,0.33,0.15,0.04,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2120,17,World Literature,0.37,0.41,0.04,0.0,0.15,0.0,0.0,0.04,joshua nei waggoner,
+ENGL,2120,18,World Literature,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
+ENGL,2130,1,British Literature,0.36,0.54,0.04,0.0,0.0,0.0,0.0,0.07,adrian paterson,
+ENGL,2130,2,British Literature,0.69,0.12,0.15,0.04,0.0,0.0,0.0,0.0,april susanne pelt,
+ENGL,2130,3,British Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,april susanne pelt,
+ENGL,2130,4,British Literature,0.54,0.32,0.04,0.07,0.0,0.0,0.0,0.04,april susanne pelt,
+ENGL,2130,5,British Literature,0.62,0.19,0.12,0.04,0.0,0.0,0.0,0.04,april susanne pelt,
+ENGL,2130,6,British Literature,0.2,0.44,0.2,0.0,0.08,0.0,0.0,0.08,meg woosley-goodman,
+ENGL,2130,7,British Literature,0.46,0.32,0.07,0.0,0.07,0.0,0.0,0.07,meg woosley-goodman,
+ENGL,2130,10,British Literature,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,
+ENGL,2130,11,British Literature,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,12,British Literature,0.68,0.25,0.0,0.0,0.04,0.0,0.0,0.04,lucian ghita,
+ENGL,2130,13,British Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2140,1,American Literature,0.04,0.71,0.25,0.0,0.0,0.0,0.0,0.0,rhondda robi thomas,
+ENGL,2140,2,American Literature,0.11,0.32,0.29,0.11,0.14,0.0,0.0,0.04,barbara ramirez,
+ENGL,2140,3,American Literature,0.12,0.46,0.35,0.04,0.04,0.0,0.0,0.0,barbara ramirez,
+ENGL,2140,4,American Literature,0.66,0.24,0.03,0.03,0.03,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,2140,5,American Literature,0.76,0.17,0.0,0.03,0.03,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,2140,6,American Literature,0.39,0.39,0.11,0.04,0.04,0.0,0.0,0.04,william stanton,
+ENGL,2140,7,American Literature,0.54,0.36,0.07,0.0,0.04,0.0,0.0,0.0,william stanton,
+ENGL,2140,8,American Literature,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,david stubblefield,
+ENGL,2140,9,American Literature,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,david stubblefield,
+ENGL,2140,11,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david stubblefield,
+ENGL,2140,12,American Literature,0.75,0.11,0.11,0.04,0.0,0.0,0.0,0.0,david stubblefield,
+ENGL,2140,13,American Literature,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,2140,14,American Literature,0.1,0.41,0.48,0.0,0.0,0.0,0.0,0.0,barbara ramirez,
+ENGL,2140,15,American Literature,0.44,0.19,0.19,0.11,0.0,0.0,0.0,0.07,meredith mccarroll,
+ENGL,2140,16,American Literature,0.29,0.43,0.21,0.0,0.04,0.0,0.0,0.04,susanna ashton,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.72,0.24,0.0,0.0,0.03,0.0,0.0,0.0,nicholas chri brown,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.0,0.48,0.44,0.04,0.0,0.0,0.0,0.04,amy monaghan,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.04,0.52,0.41,0.0,0.04,0.0,0.0,0.0,amy monaghan,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.52,0.33,0.11,0.0,0.04,0.0,0.0,0.0,sarah lauro,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,sarah lauro,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.14,0.48,0.28,0.0,0.0,0.0,0.0,0.1,david charles foltz,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.61,0.25,0.07,0.07,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.57,0.32,0.07,0.04,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.83,0.07,0.03,0.0,0.07,0.0,0.0,0.0,alexander kudera,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.2,0.68,0.04,0.0,0.0,0.0,0.0,0.08,david charles foltz,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.45,0.31,0.1,0.1,0.03,0.0,0.0,0.0,andrew mathas,
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.55,0.28,0.07,0.03,0.07,0.0,0.0,0.0,andrew mathas,
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.31,0.5,0.12,0.04,0.04,0.0,0.0,0.0,matthew schilleman,
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.36,0.21,0.25,0.04,0.07,0.0,0.0,0.07,andrew mathas,
+ENGL,3000,1,Professional Develop,0.7,0.13,0.13,0.0,0.03,0.0,0.0,0.0,cameron fa bushnell,
+ENGL,3040,2,Business Writing,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,
+ENGL,3040,3,Business Writing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,
+ENGL,3040,4,Business Writing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3040,5,Business Writing,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3040,14,Business Writing,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,3040,15,Business Writing,0.7,0.15,0.1,0.0,0.0,0.0,0.0,0.05,philip randall,
+ENGL,3040,17,Business Writing,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,3040,18,Business Writing,0.4,0.5,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,
+ENGL,3100,1,Crit Writ Lit,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
+ENGL,3100,2,Crit Writ Lit,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,dominic mastroianni,
+ENGL,3100,4,Crit Writ Lit,0.38,0.29,0.19,0.0,0.05,0.0,0.0,0.1,erin marina goss,
+ENGL,3120,1,Advanced Composition,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3120,2,Advanced Composition,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,2,Technical Writing,0.25,0.6,0.1,0.0,0.0,0.0,0.0,0.05,william pulley,
+ENGL,3140,3,Technical Writing,0.15,0.5,0.1,0.05,0.15,0.0,0.0,0.05,william pulley,
+ENGL,3140,4,Technical Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew schilleman,
+ENGL,3140,5,Technical Writing,0.32,0.58,0.0,0.0,0.0,0.0,0.0,0.11,matthew schilleman,
+ENGL,3140,7,Technical Writing,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,
+ENGL,3140,9,Technical Writing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,3140,10,Technical Writing,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,11,Technical Writing,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,12,Technical Writing,0.3,0.55,0.1,0.0,0.05,0.0,0.0,0.0,katalin beck,
+ENGL,3140,13,Technical Writing,0.2,0.55,0.25,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,16,Technical Writing,0.75,0.15,0.05,0.0,0.05,0.0,0.0,0.0,lauren woolbright,
+ENGL,3140,17,Technical Writing,0.73,0.14,0.05,0.05,0.05,0.0,0.0,0.0,lauren woolbright,
+ENGL,3140,18,Technical Writing,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,3140,19,Technical Writing,0.78,0.17,0.0,0.06,0.0,0.0,0.0,0.0,matthew jose osborn,
+ENGL,3140,20,Technical Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
+ENGL,3140,21,Technical Writing,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,22,Technical Writing,0.82,0.05,0.05,0.0,0.09,0.0,0.0,0.0,john conway,
+ENGL,3140,23,Technical Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,3150,1,Sci Writing & Comm,0.85,0.05,0.0,0.0,0.1,0.0,0.0,0.0,philip randall,
+ENGL,3150,5,Sci Writing & Comm,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3150,6,Sci Writing & Comm,0.4,0.4,0.1,0.05,0.0,0.0,0.0,0.05,william pulley,
+ENGL,3150,7,Sci Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,3150,19,Sci Writing & Comm,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,3150,20,Sci Writing & Comm,0.9,0.0,0.0,0.05,0.0,0.0,0.0,0.05,john conway,
+ENGL,3320,1,Visual Communication,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,megan eatman,
+ENGL,3450,1,Structure of Fiction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
+ENGL,3460,1,Structure of Poetry,0.75,0.1,0.1,0.0,0.05,0.0,0.0,0.0,john logan pursley,
+ENGL,3480,1,Structure Screenplay,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,joshua nei waggoner,
+ENGL,3490,1,Tech/Pop Imagination,0.26,0.58,0.05,0.0,0.05,0.0,0.0,0.05,lindsay carr thomas,
+ENGL,3530,1,Ethnic Am Lit,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,angela naimou,
+ENGL,3570,1,Film,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3850,1,Children's Lit,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,megan no macalystre,
+ENGL,3960,1,Brit Lit Survey I,0.2,0.3,0.4,0.0,0.05,0.0,0.0,0.05,erin marina goss,
+ENGL,3960,2,Brit Lit Survey I,0.25,0.15,0.4,0.05,0.0,0.0,0.0,0.15,erin marina goss,
+ENGL,3960,3,Brit Lit Survey I,0.35,0.2,0.15,0.15,0.1,0.0,0.0,0.05,erin marina goss,
+ENGL,3970,1,Brit Lit Survey II,0.52,0.33,0.1,0.0,0.05,0.0,0.0,0.0,david sweene coombs,
+ENGL,3980,1,Amer Lit Survey I,0.15,0.5,0.3,0.0,0.05,0.0,0.0,0.0,susanna ashton,
+ENGL,3990,1,Amer Lit Survey II,0.26,0.42,0.26,0.0,0.0,0.0,0.0,0.05,rhondda robi thomas,
+ENGL,4080,1,Chaucer,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,andrew lemons,
+ENGL,4110,1,Shakespeare,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william stockton,
+ENGL,4170,1,Victorian Period,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,kimberly manganelli,
+ENGL,4200,1,Amer Lit to 1799,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,jonathan beec field,
+ENGL,4310,1,Modern Poetry,0.16,0.68,0.05,0.0,0.0,0.0,0.0,0.11,adrian paterson,
+ENGL,4320,1,Modern Fiction,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,angela naimou,
+ENGL,4400,1,Literary Theory,0.29,0.48,0.24,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,
+ENGL,4410,1,Literary Editing,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,wayne chapman,
+ENGL,4450,1,Fiction Workshop,0.46,0.31,0.15,0.08,0.0,0.0,0.0,0.0,keith morris,
+ENGL,4590,2,Spec Top Lang Criticism Theory,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
+ENGL,4780,1,Digital Literacy,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
+ENGL,4830,1,Af Am Lit 1920-Pres,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,garry bertholf,
+ENGL,4890,1,Topics Write & Publ,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,david blakesley,
+ENGL,4960,1,Senior Seminar,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,jonathan beec field,
+ENGL,4960,3,Senior Seminar,0.8,0.1,0.05,0.0,0.05,0.0,0.0,0.0,sean morey,
+ENGL,7000,1,Child Lit for Teach,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,lienne federico,
+ENGL,8080,1,Top Renaiss & Restoration Lit,0.5,0.25,0.13,0.0,0.13,0.0,0.0,0.0,william stockton,
+ENGL,8230,1,Topics American Lit Since 1865,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,8500,1,Methods Prof Comm,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,tharon howard,
+ENGR,1050,311,Engr Discipline & Skills I,0.18,0.23,0.25,0.2,0.07,0.0,0.0,0.08,john minor,
+ENGR,1050,312,Engr Discipline & Skills I,0.15,0.38,0.18,0.18,0.08,0.0,0.0,0.03,michael giebner,
+ENGR,1060,141,Engr Discipline & Skills II,0.07,0.36,0.32,0.07,0.11,0.0,0.0,0.07,steven brandon,
+ENGR,1060,241,Engr Discipline & Skills II,0.1,0.41,0.35,0.06,0.06,0.0,0.0,0.02,matthew kent miller,
+ENGR,1060,242,Engr Discipline & Skills II,0.1,0.3,0.36,0.06,0.08,0.0,0.0,0.1,matthew kent miller,
+ENGR,1060,311,Engr Discipline & Skills II,0.11,0.22,0.31,0.11,0.16,0.0,0.0,0.09,ashley childers,
+ENGR,1060,312,Engr Discipline & Skills II,0.15,0.12,0.22,0.22,0.12,0.0,0.0,0.17,michael giebner,
+ENGR,1060,341,Engr Discipline & Skills II,0.11,0.36,0.36,0.14,0.03,0.0,0.0,0.0,ashley childers,
+ENGR,1060,342,Engr Discipline & Skills II,0.15,0.4,0.31,0.1,0.02,0.0,0.0,0.02,ashley childers,
+ENGR,1060,343,Engr Discipline & Skills II,0.13,0.4,0.27,0.09,0.04,0.0,0.0,0.07,ashley childers,
+ENGR,1060,345,Engr Discipline & Skills II,0.06,0.38,0.34,0.06,0.03,0.0,0.0,0.13,elizabeth stephan,
+ENGR,1070,121,Program & Prob Solv I,0.04,0.31,0.38,0.19,0.04,0.0,0.0,0.04,erin jennife mccave,
+ENGR,1070,122,Program & Prob Solv I,0.17,0.29,0.35,0.15,0.02,0.0,0.0,0.02,erin jennife mccave,
+ENGR,1070,123,Program & Prob Solv I,0.15,0.38,0.23,0.15,0.02,0.0,0.0,0.08,christopher norfolk,
+ENGR,1070,124,Program & Prob Solv I,0.1,0.48,0.31,0.04,0.04,0.0,0.0,0.02,christopher norfolk,
+ENGR,1070,125,Program & Prob Solv I,0.13,0.26,0.38,0.13,0.0,0.0,0.0,0.11,erin jennife mccave,
+ENGR,1070,126,Program & Prob Solv I,0.17,0.27,0.31,0.15,0.0,0.0,0.0,0.1,erin jennife mccave,
+ENGR,1070,127,Program & Prob Solv I,0.21,0.34,0.32,0.06,0.04,0.0,0.0,0.02,william martin,
+ENGR,1070,128,Program & Prob Solv I,0.2,0.35,0.28,0.09,0.04,0.0,0.0,0.04,steven brandon,
+ENGR,1070,221,Programming & Prob Solving I,0.05,0.35,0.27,0.2,0.07,0.0,0.0,0.05,william martin,
+ENGR,1070,222,Programming & Prob Solving I,0.22,0.33,0.31,0.07,0.02,0.0,0.0,0.05,william martin,
+ENGR,1070,223,Programming & Prob Solving I,0.16,0.38,0.22,0.16,0.02,0.0,0.0,0.05,steven brandon,
+ENGR,1070,224,Programming & Prob Solving I,0.18,0.4,0.18,0.18,0.0,0.0,0.0,0.05,steven brandon,
+ENGR,1070,225,Programming & Prob Solving I,0.15,0.44,0.35,0.04,0.0,0.0,0.0,0.04,richard watkins,
+ENGR,1070,226,Programming & Prob Solving I,0.24,0.3,0.3,0.11,0.02,0.0,0.0,0.04,david ewing,
+ENGR,1070,241,Programming & Prob Solving I,0.07,0.49,0.36,0.0,0.04,0.0,0.0,0.04,matthew kent miller,
+ENGR,1070,242,Programming & Prob Solving I,0.0,0.34,0.44,0.13,0.06,0.0,0.0,0.03,matthew kent miller,
+ENGR,1070,321,Programming & Prob Solving I,0.15,0.38,0.36,0.02,0.02,0.0,0.0,0.08,william th kolodzey,
+ENGR,1070,322,Programming & Prob Solving I,0.33,0.3,0.2,0.1,0.05,0.0,0.0,0.02,elizabeth stephan,
+ENGR,1070,323,Programming & Prob Solving I,0.15,0.36,0.33,0.11,0.02,0.0,0.0,0.04,surya sharma,
+ENGR,1070,324,Programming & Prob Solving I,0.22,0.37,0.22,0.07,0.04,0.0,0.0,0.07,william park,
+ENGR,1070,325,Programming & Prob Solving I,0.21,0.44,0.19,0.1,0.0,0.0,0.0,0.06,william park,
+ENGR,1070,341,Programming & Prob Solving I,0.0,0.26,0.52,0.13,0.1,0.0,0.0,0.0,william martin,
+ENGR,1070,621,Program & Prob Solv I (HON),0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,david ewing,True
+ENGR,1070,622,Program & Prob Solv I (HON),0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,david ewing,True
+ENGR,1080,121,Program & Prob Solv II,0.06,0.31,0.39,0.14,0.06,0.0,0.0,0.06,erin jennife mccave,
+ENGR,1080,122,Program & Prob Solv II,0.08,0.47,0.21,0.21,0.03,0.0,0.0,0.0,erin jennife mccave,
+ENGR,1080,123,Program & Prob Solv II,0.05,0.36,0.31,0.15,0.05,0.0,0.0,0.08,christopher norfolk,
+ENGR,1080,124,Program & Prob Solv II,0.12,0.29,0.34,0.12,0.12,0.0,0.0,0.0,christopher norfolk,
+ENGR,1080,125,Program & Prob Solv II,0.11,0.28,0.36,0.11,0.14,0.0,0.0,0.0,erin jennife mccave,
+ENGR,1080,126,Program & Prob Solv II,0.16,0.43,0.3,0.08,0.03,0.0,0.0,0.0,erin jennife mccave,
+ENGR,1080,127,Program & Prob Solv II,0.12,0.49,0.2,0.12,0.05,0.0,0.0,0.02,christopher norfolk,
+ENGR,1080,128,Program & Prob Solv II,0.23,0.43,0.14,0.11,0.06,0.0,0.0,0.03,steven brandon,
+ENGR,1080,221,Programming & Prob Solving II,0.14,0.39,0.36,0.06,0.03,0.0,0.0,0.03,elizabeth stephan,
+ENGR,1080,222,Programming & Prob Solving II,0.21,0.32,0.26,0.15,0.04,0.0,0.0,0.02,steven brandon,
+ENGR,1080,223,Programming & Prob Solving II,0.14,0.5,0.21,0.02,0.1,0.0,0.0,0.02,elizabeth stephan,
+ENGR,1080,224,Programming & Prob Solving II,0.2,0.42,0.27,0.09,0.0,0.0,0.0,0.02,steven brandon,
+ENGR,1080,225,Programming & Prob Solving II,0.24,0.33,0.25,0.14,0.02,0.0,0.0,0.02,richard watkins,
+ENGR,1080,226,Programming & Prob Solving II,0.3,0.32,0.21,0.15,0.02,0.0,0.0,0.0,david ewing,
+ENGR,1080,321,Programming & Prob Solving II,0.09,0.29,0.22,0.27,0.11,0.0,0.0,0.02,william th kolodzey,
+ENGR,1080,322,Programming & Prob Solving II,0.33,0.35,0.25,0.04,0.0,0.0,0.0,0.02,elizabeth stephan,
+ENGR,1080,323,Programming & Prob Solving II,0.18,0.34,0.28,0.08,0.1,0.0,0.0,0.02,surya sharma,
+ENGR,1080,324,Programming & Prob Solving II,0.07,0.26,0.33,0.19,0.1,0.0,0.0,0.05,william park,
+ENGR,1080,325,Programming & Prob Solving II,0.07,0.42,0.24,0.13,0.07,0.0,0.0,0.07,william park,
+ENGR,1080,621,Program & Prob Solv II (HON),0.5,0.44,0.0,0.0,0.06,0.0,0.0,0.0,david ewing,True
+ENGR,1080,622,Program & Prob Solv II (HON),0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,david ewing,True
+ENGR,1090,132,Prog/Problem Solv Apps (RISE),0.23,0.66,0.05,0.02,0.0,0.0,0.0,0.05,christopher norfolk,
+ENGR,1090,133,Prog/Problem Solv Apps (RISE),0.24,0.59,0.17,0.0,0.0,0.0,0.0,0.0,surya sharma,
+ENGR,1090,134,Prog/Problem Solv Apps (RISE),0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,david ewing,
+ENGR,1090,231,Prog/Problem Solving Apps,0.28,0.51,0.21,0.0,0.0,0.0,0.0,0.0,william martin,
+ENGR,1090,232,Prog/Problem Solving Apps,0.41,0.52,0.07,0.0,0.0,0.0,0.0,0.0,william martin,
+ENGR,1090,233,Prog/Problem Solving Apps,0.38,0.47,0.06,0.04,0.0,0.0,0.0,0.04,david ewing,
+ENGR,1090,234,Prog/Problem Solving Apps,0.26,0.42,0.21,0.02,0.02,0.0,0.0,0.07,steven brandon,
+ENGR,1090,331,Prog/Problem Solving Apps,0.45,0.47,0.03,0.0,0.0,0.0,0.0,0.05,william th kolodzey,
+ENGR,1090,332,Prog/Problem Solving Apps,0.2,0.52,0.19,0.0,0.0,0.0,0.0,0.09,john minor,
+ENGR,1090,333,Prog/Problem Solving Apps,0.25,0.52,0.17,0.02,0.02,0.0,0.0,0.03,william park,
+ENGR,1090,334,Prog/Problem Solving Apps,0.11,0.26,0.57,0.06,0.0,0.0,0.0,0.0,william park,
+ENGR,1090,335,Prog/Problem Solving Apps,0.37,0.49,0.12,0.01,0.0,0.0,0.0,0.0,steven brandon,
+ENGR,1090,336,Prog/Problem Solving Apps,0.28,0.48,0.17,0.0,0.03,0.0,0.0,0.03,william park,
+ENGR,1090,337,Prog/Problem Solving Apps,0.41,0.54,0.05,0.0,0.0,0.0,0.0,0.0,steven brandon,
+ENGR,1090,338,Prog/Problem Solving Apps,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,william park,
+ENGR,1490,501,Introduction to Engineering,0.41,0.14,0.18,0.09,0.18,0.0,0.0,0.0,matthew kent miller,
+ENGR,1510,501,Engineering Skills,0.59,0.06,0.18,0.06,0.12,0.0,0.0,0.0,matthew kent miller,
+ENGR,1510,502,Engineering Skills,0.5,0.13,0.13,0.06,0.13,0.0,0.0,0.06,matthew kent miller,
+ENGR,1640,502,Engineering MATLAB Programming,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,2080,181,Engr Graphics & Machine Design,0.52,0.31,0.12,0.02,0.02,0.0,0.0,0.0,john minor,
+ENGR,2080,182,Engr Graphics & Machine Design,0.55,0.32,0.07,0.02,0.02,0.0,0.0,0.02,sarah grigg,
+ENGR,2080,183,Engr Graphics & Machine Design,0.14,0.52,0.12,0.05,0.1,0.0,0.0,0.07,sarah grigg,
+ENGR,2080,184,Engr Graphics & Machine Design,0.34,0.41,0.09,0.05,0.02,0.0,0.0,0.09,sarah grigg,
+ENGR,2080,185,Engr Graphics & Machine Design,0.51,0.27,0.09,0.0,0.02,0.0,0.0,0.11,jonathan maier,
+ENGR,2080,281,Engr Graphics & Machine Design,0.67,0.22,0.07,0.0,0.02,0.0,0.0,0.03,john minor,
+ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.25,0.08,0.02,0.02,0.0,0.0,0.02,john minor,
+ENGR,2080,283,Engr Graphics & Machine Design,0.32,0.36,0.17,0.02,0.05,0.0,0.0,0.08,anthony pau garland,
+ENGR,2080,284,Engr Graphics & Machine Design,0.18,0.4,0.25,0.05,0.04,0.0,0.0,0.09,anthony pau garland,
+ENGR,2080,381,Engr Graphics & Machine Design,0.52,0.23,0.12,0.02,0.03,0.0,0.0,0.08,jonathan maier,
+ENGR,2100,101,CAD & Engineering Apllications,0.42,0.31,0.11,0.03,0.06,0.0,0.0,0.08,william martin,
+ENGR,2100,201,CAD & Engineering Apllications,0.76,0.1,0.02,0.02,0.02,0.0,0.0,0.08,mary kayla kilgo,
+ENGR,2100,202,CAD & Engineering Apllications,0.76,0.18,0.02,0.02,0.02,0.0,0.0,0.0,nighat yasmin,
+ENGR,2100,203,CAD & Engineering Apllications,0.62,0.28,0.04,0.0,0.02,0.0,0.0,0.04,nighat yasmin,
+ENGR,2200,1,Evaluating Innovations,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,sarah grigg,
+ENR,3020,1,Nat Res Measurements,0.33,0.42,0.18,0.03,0.03,0.0,0.0,0.0,lawrence gering,
+ENR,4500,1,Conservation Issues,0.5,0.31,0.09,0.03,0.03,0.0,0.0,0.03,alan johnson,
+ENR,4500,2,Conservation Issues,0.54,0.15,0.23,0.04,0.04,0.0,0.0,0.0,alan johnson,
+ENSP,2000,1,Intro Environ Sci,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,scott brame,
+ENSP,2000,2,Intro Environ Sci,0.67,0.23,0.06,0.0,0.0,0.0,0.0,0.04,elizabeth carraway,
+ENSP,2000,3,Intro Environ Sci,0.79,0.15,0.06,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENT,2000,1,Six-Legged Science,0.49,0.37,0.11,0.0,0.0,0.0,0.0,0.03,suellen pometto,
+ENT,8100,3,Conservation Genetics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michael caterino,
+ESED,8710,1,Engr & Sci Educ Research Meth,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,charity watson,
+FCS,8340,3,Research Methods in FCS II,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0,james mcdonell,
+FDSC,1020,1,Persp Food Nutrition,0.6,0.36,0.03,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+FDSC,2140,1,Fd Resources & Soc,0.66,0.24,0.08,0.0,0.01,0.0,0.0,0.01,paul dawson,
+FDSC,2150,1,Culinary Fundamental,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,aubrey dean coffee,
+FDSC,4020,1,Food Chem II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4030,1,Food Ch & Analysis,0.94,0.05,0.02,0.0,0.0,0.0,0.0,0.0,paul dawson,
+FDSC,4080,1,Food Process Eng,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,felix barron,
+FDSC,4090,1,TQM for Food & Pckg Industries,0.67,0.26,0.06,0.01,0.0,0.0,0.0,0.0,john mcgregor,
+FIN,3040,1,Risk & Insurance,0.13,0.45,0.37,0.05,0.0,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.21,0.29,0.36,0.05,0.07,0.0,0.0,0.02,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.17,0.38,0.32,0.04,0.06,0.0,0.0,0.02,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.19,0.51,0.28,0.02,0.0,0.0,0.0,0.0,kerri mcmillan,
+FIN,3060,1,Corporation Finance,0.08,0.15,0.33,0.12,0.15,0.0,0.0,0.17,william hol johnson,
+FIN,3060,2,Corporation Finance,0.1,0.12,0.16,0.22,0.16,0.0,0.0,0.22,william hol johnson,
+FIN,3060,3,Corporation Finance,0.2,0.28,0.38,0.11,0.02,0.0,0.0,0.02,neil waller,
+FIN,3060,4,Corporation Finance,0.26,0.38,0.27,0.08,0.0,0.0,0.0,0.02,neil waller,
+FIN,3060,5,Corporation Finance,0.06,0.2,0.23,0.17,0.16,0.0,0.0,0.17,william hol johnson,
+FIN,3060,6,Corporation Finance,0.28,0.37,0.19,0.07,0.05,0.0,0.0,0.04,neil waller,
+FIN,3060,7,Corporation Finance,0.28,0.3,0.3,0.05,0.04,0.0,0.0,0.04,neil waller,
+FIN,3070,1,Prin of Real Estate,0.24,0.22,0.35,0.13,0.07,0.0,0.0,0.0,ramon tolb franklin,
+FIN,3070,2,Prin of Real Estate,0.21,0.26,0.39,0.11,0.0,0.02,0.0,0.02,thomas springer,
+FIN,3080,1,Fin Inst & Mkts,0.3,0.34,0.32,0.05,0.0,0.0,0.0,0.0,daniel thoma greene,
+FIN,3080,2,Fin Inst & Mkts,0.41,0.41,0.15,0.0,0.0,0.0,0.0,0.03,daniel thoma greene,
+FIN,3080,3,Fin Inst & Mkts,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.05,daniel thoma greene,
+FIN,3110,1,Financial Management I,0.13,0.2,0.37,0.09,0.07,0.0,0.0,0.15,jack wolf,
+FIN,3110,2,Financial Management I,0.19,0.33,0.37,0.02,0.0,0.0,0.0,0.09,george bra lockhart,
+FIN,3110,3,Financial Management I,0.37,0.29,0.2,0.05,0.02,0.0,0.0,0.07,george bra lockhart,
+FIN,3110,4,Financial Management I,0.23,0.43,0.28,0.0,0.0,0.0,0.0,0.08,george bra lockhart,
+FIN,3120,1,Financial Mgt II,0.22,0.49,0.22,0.04,0.02,0.0,0.0,0.02,vincent intintoli,
+FIN,3120,2,Financial Mgt II,0.14,0.34,0.26,0.09,0.09,0.0,0.0,0.09,angela morgan,
+FIN,3120,3,Financial Mgt II,0.16,0.29,0.32,0.13,0.05,0.0,0.0,0.05,angela morgan,
+FIN,3120,4,Financial Mgt II,0.15,0.45,0.27,0.03,0.09,0.0,0.0,0.0,vincent intintoli,
+FIN,4040,1,Financial Modeling,0.12,0.38,0.35,0.15,0.0,0.0,0.0,0.0,jack wolf,
+FIN,4040,2,Financial Modeling,0.27,0.56,0.17,0.0,0.0,0.0,0.0,0.0,jared daniel smith,
+FIN,4040,3,Financial Modeling,0.15,0.59,0.24,0.03,0.0,0.0,0.0,0.0,jared daniel smith,
+FIN,4050,1,Port Mgt and Theory,0.14,0.33,0.19,0.14,0.05,0.0,0.0,0.14,john alexander,
+FIN,4050,2,Port Mgt and Theory,0.08,0.54,0.08,0.31,0.0,0.0,0.0,0.0,john alexander,
+FIN,4080,1,Mgt of Fin Inst,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4080,2,Mgt of Fin Inst,0.5,0.19,0.31,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4110,1,Int Fin Mgt,0.1,0.41,0.33,0.13,0.03,0.0,0.0,0.0,tilan tang,
+FIN,4110,2,Int Fin Mgt,0.11,0.37,0.31,0.06,0.03,0.0,0.0,0.11,tilan tang,
+FIN,4150,1,Real Estate Investmt,0.29,0.5,0.14,0.0,0.07,0.0,0.0,0.0,thomas springer,
+FIN,4160,1,Real Estate Val,0.58,0.08,0.33,0.0,0.0,0.0,0.0,0.0,ramon tolb franklin,
+FNR,4700,35,Aquaponics,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,lance edwar beecher,
+FNR,4990,1,Natural Resources Seminar,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william roc english,
+FNR,4990,3,Natural Resources Seminar,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,william roc english,
+FOR,1010,1,Intro to Forestry,0.69,0.23,0.0,0.08,0.0,0.0,0.0,0.0,lawrence gering,
+FOR,2060,1,Forest Ecology,0.27,0.41,0.22,0.02,0.06,0.0,0.0,0.02,donald hagan,
+FOR,3080,1,Remote Sensing,0.28,0.44,0.16,0.12,0.0,0.0,0.0,0.0,lawrence gering,
+FOR,4060,1,For Watershed Mgmt,0.92,0.05,0.0,0.0,0.0,0.0,0.0,0.03,william roc english,
+FOR,4080,1,Wood & Paper Product,0.5,0.37,0.1,0.03,0.0,0.0,0.0,0.0,patricia layton,
+FOR,4150,1,For Wildlife Mgmt,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,james davis,
+FOR,4180,1,For Res Valuation,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4250,1,For Res Mgt Plans,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4340,1,GIS for Landscape Planning,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,robert frit baldwin,
+FOR,4650,1,Silviculture,0.29,0.38,0.29,0.04,0.0,0.0,0.0,0.0,gaofeng wang,
+FOR,8930,22,Ecotoxicology,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john rodgers,
+FR,1010,1,Elementary French,0.53,0.35,0.0,0.06,0.06,0.0,0.0,0.0,julian hamil killey,
+FR,1020,2,Elementary French,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,1020,3,Elementary French,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,amy lyn grif sawyer,
+FR,2010,1,Intermediate French,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,2,Intermediate French,0.6,0.25,0.05,0.05,0.05,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,4,Intermediate French,0.08,0.75,0.17,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,2020,1,Intermediate French,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,2020,2,Intermediate French,0.55,0.27,0.09,0.09,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,2020,3,Intermediate French,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,kelly digby peebles,
+FR,2020,4,Intermediate French,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
+FR,3050,1,Int Fr Con & Comp I,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
+FR,3120,1,Writing in French I,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,kenneth dav widgren,
+FR,3160,1,Fr for Intl Trade,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,eric touya,
+FR,4100,1,Francophone Lit,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,True
+GC,1010,1,Orientation to G C,0.76,0.13,0.03,0.0,0.03,0.0,0.0,0.05,kern cox,
+GC,1020,1,Comp Art & Cad Found,0.38,0.29,0.05,0.1,0.14,0.0,0.0,0.05,charles tabor weiss,
+GC,1020,2,Comp Art & Cad Found,0.64,0.18,0.09,0.05,0.0,0.0,0.0,0.05,carol jones,
+GC,1030,1,G C I for Pkgsc,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,john jacobs,
+GC,1030,2,G C I for Pkgsc,0.08,0.54,0.23,0.08,0.08,0.0,0.0,0.0,john jacobs,
+GC,1040,1,Graphic Communications I,0.53,0.31,0.09,0.03,0.02,0.0,0.0,0.01,rebecca suza edlein,
+GC,1990,4,CI in GC I-J Lay CS,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,janice ann lay,
+GC,2070,1,Graphic Communications II,0.6,0.31,0.06,0.0,0.03,0.0,0.0,0.0,patrick gee rose,
+GC,3400,1,Digital Img & Emedia,0.44,0.4,0.13,0.0,0.02,0.0,0.0,0.02,erica black walker,
+GC,4060,1,Package and Specialty Printing,0.25,0.6,0.1,0.0,0.03,0.0,0.0,0.03,kern cox,
+GC,4400,1,Commercial Printing,0.62,0.35,0.0,0.0,0.0,0.0,0.0,0.03,eric weisenmiller,
+GC,4440,1,Current Dev in G C,0.24,0.41,0.28,0.07,0.0,0.0,0.0,0.0,liam henry 'hara,
+GC,4460,1,Ink & Substrates,0.13,0.71,0.09,0.04,0.0,0.0,0.0,0.02,liam henry 'hara,
+GC,4480,1,Plan and Cont Print,0.8,0.1,0.05,0.05,0.0,0.0,0.0,0.0,john leininger,
+GC,4900,2,G C Selected Topics-Sales,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,john leininger,
+GEN,3000,1,Fundamental Genetics,0.33,0.27,0.27,0.08,0.02,0.0,0.0,0.04,kate leanne wi tsai,
+GEN,3000,2,Fundamental Genetics,0.4,0.4,0.13,0.04,0.01,0.0,0.0,0.02,haiying liang,
+GEN,4100,1,Population & Quant Genetics,0.4,0.4,0.03,0.09,0.06,0.0,0.0,0.03,amy lou lawton rauh,
+GEN,4110,1,Popultn & Quant Genetics Lab,0.6,0.2,0.0,0.1,0.0,0.0,0.0,0.1,amy lou lawton rauh,
+GEN,4110,2,Popultn & Quant Genetics Lab,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,amy lou lawton rauh,
+GEN,4110,3,Population and Quant Gen Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
+GEN,4700,1,Human Genetics,0.46,0.38,0.11,0.03,0.0,0.0,0.0,0.03,leigh anne clark,
+GEOG,1010,1,Intro to Geography,0.28,0.4,0.28,0.05,0.0,0.0,0.0,0.0,christa smith,
+GEOG,1030,1,World Regional Geog,0.82,0.12,0.04,0.02,0.0,0.0,0.0,0.0,lance forres howard,
+GEOG,1030,2,World Regional Geog,0.38,0.35,0.15,0.03,0.0,0.0,0.0,0.1,william churc terry,
+GEOG,3050,1,Cultural Geography,0.83,0.06,0.0,0.06,0.06,0.0,0.0,0.0,lance forres howard,
+GEOL,1010,1,Physical Geology,0.39,0.32,0.14,0.06,0.05,0.0,0.0,0.03,alan coulson,
+GEOL,1010,2,Physical Geology,0.38,0.36,0.17,0.03,0.01,0.0,0.0,0.05,alan coulson,
+GEOL,1030,1,Physical Geol Lab,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.3,0.57,0.09,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.3,0.52,0.13,0.04,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.52,0.22,0.17,0.04,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.59,0.18,0.14,0.0,0.0,0.0,0.0,0.09,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.27,0.5,0.18,0.0,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.42,0.46,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.54,0.29,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,
+GEOL,1120,1,Earth Resources,0.72,0.19,0.09,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,1140,1,Earth Resources Lab,0.68,0.1,0.16,0.03,0.0,0.0,0.0,0.03,scott brame,
+GEOL,2020,1,Earth History,0.17,0.44,0.17,0.06,0.11,0.0,0.0,0.06,alan coulson,
+GEOL,3750,1,Bahamian Field Study,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,james castle,
+GEOL,4050,1,Surficial Geology,0.31,0.38,0.25,0.0,0.06,0.0,0.0,0.0,james castle,
+GEOL,4090,1,Envir & Exploration Geophysics,0.53,0.18,0.06,0.0,0.12,0.0,0.0,0.12,stephen mich moysey,
+GEOL,4210,1,Gis in Geology,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,6210,1,Gis in Geology,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,7900,501,Biogeography & Geology of SC,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
+GEOL,8080,1,Groundwater Modeling,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
+GER,1010,1,Elementary German,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,oswald harris king,
+GER,1010,2,Elementary German,0.55,0.25,0.1,0.0,0.0,0.0,0.0,0.1,oswald harris king,
+GER,1020,1,Elementary German,0.06,0.38,0.19,0.19,0.19,0.0,0.0,0.0, lee ferrell,
+GER,1020,2,Elementary German,0.18,0.29,0.41,0.06,0.0,0.0,0.0,0.06, lee ferrell,
+GER,2010,1,Intermediate German,0.3,0.2,0.3,0.1,0.0,0.0,0.0,0.1,gabriela stoicea,
+GER,2010,2,Intermediate German,0.21,0.29,0.36,0.0,0.0,0.0,0.0,0.14,gabriela stoicea,
+GER,2020,1,Intermediate German,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,3160,1,Ger for Intl Trade I,0.58,0.0,0.33,0.08,0.0,0.0,0.0,0.0, lee ferrell,
+GER,3400,1,German Culture,0.45,0.25,0.1,0.05,0.0,0.0,0.0,0.15,oswald harris king,
+HCC,8810,1,Affective Computing,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,shaundra daily,
+HCC,8810,3,Measurement & Eval,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
+HEHD,3990,2,Students Helping Students Peer,0.85,0.1,0.03,0.0,0.0,0.0,0.0,0.03,mary mcp von kaenel,
+HEHD,4000,1,Intro Leadership Theor & Conc,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lori marlise pindar,
+HEHD,4990,5,The Global Community,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mark small,
+HEHD,8010,230,Child/Adolescent Dev,0.76,0.14,0.05,0.0,0.0,0.0,0.0,0.05,edmond patri bowers,
+HEHD,8040,230,Assessment/Eval,0.61,0.26,0.04,0.0,0.0,0.0,0.0,0.09,barry garst,
+HEHD,8880,400,Special Topics Youth Dev Ldshp,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,
+HIST,1010,1,Hist of the U S,0.41,0.43,0.11,0.0,0.05,0.0,0.0,0.0,lee brady wilson,
+HIST,1220,1,"Hist, Tech & Society",0.41,0.32,0.13,0.02,0.06,0.0,0.0,0.06,pamela mack,
+HIST,1240,1,Environmental Hist,0.14,0.54,0.27,0.03,0.0,0.0,0.0,0.03,james brad jeffries,
+HIST,1240,2,Environmental Hist,0.05,0.38,0.4,0.03,0.05,0.0,0.0,0.1,james brad jeffries,
+HIST,1720,1,The West and the World I,0.26,0.41,0.18,0.08,0.03,0.0,0.0,0.05,caroline dunn clark,
+HIST,1730,1,The West and the World II,0.3,0.32,0.21,0.0,0.1,0.0,0.0,0.07, alan grubb,
+HIST,1730,2,The West and the World II,0.32,0.24,0.27,0.07,0.04,0.0,0.0,0.07,richard saunders,
+HIST,1730,3,The West and the World II,0.25,0.44,0.2,0.02,0.07,0.0,0.0,0.02,steven marks,
+HIST,2990,1,Historian's Craft,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth carney,
+HIST,2990,2,Historian's Craft,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,rachel anne moore,
+HIST,3010,1,Am Rev & New Nation,0.26,0.19,0.33,0.0,0.15,0.0,0.0,0.07,james brad jeffries,
+HIST,3080,1,US: Reagan/Clinton 1975-Pres,0.4,0.27,0.18,0.0,0.13,0.0,0.0,0.02,richard saunders,
+HIST,3110,1,African American Hist to 1877,0.35,0.43,0.08,0.08,0.05,0.0,0.0,0.03,abel bartley,
+HIST,3240,1,Hist of the South II,0.32,0.49,0.08,0.03,0.05,0.0,0.0,0.03,john andrew,
+HIST,3260,1,Hist Am Transport,0.38,0.31,0.23,0.0,0.0,0.0,0.0,0.08, roger grant,
+HIST,3290,1,US Legal History Since 1890,0.15,0.05,0.2,0.2,0.0,0.0,0.0,0.4,maribel morey,
+HIST,3380,1,Africa to 1875,0.63,0.2,0.07,0.1,0.0,0.0,0.0,0.0,james burns,
+HIST,3410,1,Modern Mexico,0.49,0.4,0.0,0.03,0.06,0.0,0.0,0.03,rachel anne moore,
+HIST,3870,1,Russian Rev,0.37,0.33,0.23,0.0,0.0,0.0,0.0,0.07,steven marks,
+HIST,3890,2,Monarchs & Courtiers,0.77,0.15,0.0,0.08,0.0,0.0,0.0,0.0,caroline dunn clark,
+HIST,3900,1,Mod Mil Hist,0.19,0.31,0.36,0.08,0.03,0.0,0.0,0.03,edwin moise,
+HIST,3970,1,Modern Middle East,0.62,0.32,0.03,0.0,0.0,0.0,0.0,0.03,amit bein,
+HIST,4000,1,Battleground/Bloodfield RecnSC,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,paul chris anderson,
+HIST,4170,1,History and Tourism,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,leslie white,
+HIST,4510,1,Alexander the Great,0.45,0.25,0.2,0.0,0.1,0.0,0.0,0.0,elizabeth carney,
+HIST,4710,1,20th C France,0.57,0.21,0.0,0.0,0.0,0.0,0.0,0.21, alan grubb,
+HIST,4900,3,Food In Preindus,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,
+HIST,4900,4,Why Germans > Nazi?,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,michael meng,
+HIST,4920,1,US Iraq Wars,0.1,0.6,0.1,0.0,0.0,0.0,0.0,0.2,edwin moise,
+HIST,4930,1,Native American History - 1840,0.4,0.3,0.2,0.1,0.0,0.0,0.0,0.0,james brad jeffries,
+HIST,8200,1,Amer Historiography,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,john andrew,
+HLTH,2020,1,Introduction to Public Health,0.46,0.35,0.15,0.0,0.04,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,2,Introduction to Public Health,0.38,0.35,0.19,0.05,0.0,0.0,0.0,0.03,jeffrey kingree,
+HLTH,2020,400,Introduction to Public Health,0.57,0.24,0.05,0.0,0.1,0.0,0.0,0.05,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.74,0.23,0.0,0.0,0.0,0.0,0.0,0.03,ralph stewart welsh,
+HLTH,2030,2,Health Care Sys,0.38,0.48,0.12,0.0,0.0,0.0,0.0,0.02,frederic fraizer,
+HLTH,2030,400,Health Care Sys,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2030,401,Health Care Sys,0.78,0.06,0.0,0.0,0.06,0.0,0.0,0.11,ralph stewart welsh,
+HLTH,2400,1,Deter of Hlth Behav,0.29,0.51,0.15,0.03,0.03,0.0,0.0,0.0,joel edwar williams,
+HLTH,2980,1,Human Hlth & Disease,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,2980,2,Human Hlth & Disease,0.74,0.21,0.02,0.0,0.0,0.0,0.0,0.02,annah kamugiz amani,
+HLTH,3100,1,Women's Hlth Issues,0.5,0.41,0.03,0.03,0.0,0.0,0.0,0.03,rachel mayo,
+HLTH,3150,1,Social Epidemiology,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+HLTH,3800,1,Epidemiology,0.37,0.34,0.17,0.05,0.02,0.0,0.0,0.05,rachel mayo,
+HLTH,3800,2,Epidemiology,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,3980,2,Hlth Appraisal Sklls,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4000,1,Health Systems Reform,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lingling zhang,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.44,0.34,0.12,0.05,0.02,0.0,0.0,0.02,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,kathleen meyer,
+HLTH,4300,1,Hlth Prom of Aged,0.52,0.22,0.17,0.04,0.0,0.0,0.0,0.04,cheryl jo dye,
+HLTH,4310,1,Public & Environ Hlt,0.53,0.36,0.11,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,4600,1,Health Info Systems,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,ronald gimbel,
+HLTH,4780,1,Hlth Pol Ehtics Law,0.07,0.45,0.31,0.03,0.03,0.0,0.0,0.1,hugh spitler,
+HLTH,4790,1,Fin Mgmt & Hlth Budg,0.22,0.52,0.13,0.04,0.09,0.0,0.0,0.0,khoa dang truong,
+HLTH,4800,1,Comm Hlth Promotion,0.24,0.74,0.0,0.0,0.0,0.0,0.0,0.03,sarah griffin,
+HLTH,4900,1,Res Eval St Pub Hlth,0.87,0.06,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,
+HLTH,4900,2,Res Eval St Pub Hlth,0.37,0.53,0.1,0.0,0.0,0.0,0.0,0.0,lingling zhang,
+HLTH,4970,1,Creative Inq in Public Health,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,karen kemper,
+HLTH,4970,4,Creative Inq in Public Health,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,george clay,
+HLTH,8110,1,Health Care Delivery Systems,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,khoa dang truong,
+HLTH,8310,1,Quantitative Analy in Hlth I,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,lu shi,
+HON,2060,1,Intro to Nanotechnology,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,christophe kitchens,
+HON,2210,1,Beauty in Western Literature,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,johannes schmidt,
+HON,2210,3,Reading Data,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,lindsay carr thomas,
+HON,2220,2,Doubles and Doppelgangers,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,
+HORT,1010,1,Horticulture,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,
+HORT,2110,1,Growing Spring Plnts,0.15,0.3,0.45,0.05,0.0,0.0,0.0,0.05,james emerson faust,
+HORT,4000,4,Vegetable Crops,0.73,0.21,0.06,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,
+HORT,4040,1,Plant Propagation,0.13,0.25,0.46,0.08,0.04,0.0,0.0,0.04,jeffrey adelberg,
+HORT,4050,1,Plant Propagation Techniq Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
+HORT,4050,2,Plant Propagation Techniq Lab,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,jeffrey adelberg,
+HORT,4270,1,Urban Tree Care,0.24,0.36,0.2,0.08,0.08,0.0,0.0,0.04,robert polomski,
+HORT,4330,1,Turf Weed Management,0.16,0.52,0.24,0.04,0.04,0.0,0.0,0.0,ted whitwell,
+HRD,8470,405,Instru System Design,0.75,0.0,0.0,0.0,0.25,0.0,0.0,0.0,philip mcgee,
+HRD,8490,402,Eval of T&D/Hrd Prog,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,philip mcgee,
+HRD,8490,405,Eval of T&D/Hrd Prog,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,philip mcgee,
+HRD,8490,406,Eval of T&D/Hrd Prog,0.38,0.38,0.13,0.0,0.13,0.0,0.0,0.0,philip mcgee,
+HRD,8800,404,Research Concepts,0.94,0.0,0.0,0.0,0.06,0.0,0.0,0.0,jon fr christiansen,
+HRD,8970,402,Appl Resear & Devel,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,cynthia sims,
+HRD,8970,403,Appl Resear & Devel,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,cynthia sims,
+IE,2010,1,Systems Design I,0.74,0.24,0.0,0.0,0.0,0.0,0.0,0.01,robert james riggs,
+IE,2100,1,Des Analysis Wrk Sys,0.16,0.52,0.24,0.04,0.02,0.0,0.0,0.02,david neyens,
+IE,2800,1,Deterministic Operations Rsrch,0.2,0.25,0.38,0.09,0.04,0.0,0.0,0.05,burak eksioglu,
+IE,3610,1,Industrial App of Prob/Stat II,0.42,0.42,0.09,0.03,0.03,0.0,0.0,0.0,joel greenstein,
+IE,3810,1,Probabilistic Operations Rsrch,0.26,0.44,0.2,0.06,0.05,0.0,0.0,0.0,amin khademi,
+IE,3840,1,Engr Econ Analysis,0.29,0.23,0.12,0.07,0.1,0.0,0.0,0.18,brian melloy,
+IE,3860,1,Prod Plan & Cont,0.43,0.41,0.11,0.02,0.02,0.0,0.0,0.01,robert james riggs,
+IE,4570,1,Transp/Logistic Engr,0.34,0.4,0.11,0.14,0.0,0.0,0.0,0.0,sandra dun eksioglu,
+IE,4620,1,Six Sigma Quality,0.25,0.39,0.27,0.03,0.0,0.04,0.0,0.01,byung rae cho,
+IE,4670,1,System Design II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,
+IE,4860,1,Scheduling,0.29,0.5,0.14,0.07,0.0,0.0,0.0,0.0,scott jenning mason,
+IE,4910,2,HF in Transportation Systems,0.64,0.26,0.1,0.0,0.0,0.0,0.0,0.0,david neyens,
+IE,6810,1,App of Prob Models in Ind Engr,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,brian melloy,
+IE,6860,1,Scheduling,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+IE,8010,1,Human-Machine Sys,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,
+IE,8040,1,Mfg Sys Plan & Des,0.12,0.31,0.19,0.0,0.19,0.0,0.0,0.19,william ferrell,
+IE,8050,1,Found Qual Engr,0.42,0.46,0.13,0.0,0.0,0.0,0.0,0.0,byung rae cho,
+IE,8150,1,Research Methods in Ergonomics,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,sara lu riggs,
+IE,8520,1,Model Decis Making,0.8,0.15,0.02,0.0,0.0,0.0,0.0,0.02,jonathan cole smith,
+IE,8540,1,Fund of Sc and Log,0.74,0.14,0.05,0.0,0.0,0.0,0.0,0.07,william ferrell,
+IE,8580,1,Case Stu Cap Prof Sc,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+IE,8810,1,Metaheuristics,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,sandra dun eksioglu,
+IE,8880,1,Adv Prob Methods,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,burak eksioglu,
+INT,1010,5,UPIC 1st Part Time Internship,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.01,troy nunamaker,
+INT,2020,5,UPIC 2nd Full Time Internship,0.0,0.0,0.0,0.0,0.0,0.77,0.15,0.08,troy nunamaker,
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.84,0.12,0.03,meredith fan wilson,
+IS,2100,615,Sel Topics Int Study,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sallie bro turnbull,
+ITAL,1010,1,Elementary Italian,0.48,0.29,0.1,0.0,0.05,0.0,0.0,0.1,julia schmidt,
+ITAL,1020,1,Elementary Italian,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,luca barattoni,
+ITAL,1020,3,Elementary Italian,0.33,0.4,0.27,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,2010,1,Intermediate Italian,0.23,0.38,0.31,0.08,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,2020,1,Intermediate Italian,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,2020,2,Intermediate Italian,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+JAPN,1010,1,Elementary Japanese,0.43,0.0,0.21,0.07,0.07,0.0,0.0,0.21,kazuko shoji,
+JAPN,1010,2,Elementary Japanese,0.53,0.24,0.06,0.06,0.0,0.0,0.0,0.12,toshiko kishimoto,
+JAPN,1020,1,Elementary Japanese,0.5,0.25,0.08,0.0,0.08,0.0,0.0,0.08,toshiko joerger,
+JAPN,1020,2,Elementary Japanese,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,toshiko joerger,
+JAPN,2020,1,Intermed Japanese,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,kazuko shoji,
+JAPN,3060,1,Japanese Conversation & Comp,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,toshiko kishimoto,
+LARC,1160,1,History of Landscape Architect,0.39,0.3,0.16,0.08,0.01,0.0,0.0,0.06,hala fouad nassar,
+LARC,1160,2,History of Larch,0.59,0.35,0.02,0.04,0.0,0.0,0.0,0.0,martin john holland,
+LARC,1520,1,Basic Design II,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,paul russell,
+LARC,4280,1,Comput Aided Design,0.5,0.44,0.0,0.0,0.06,0.0,0.0,0.0,shan jiang,
+LARC,6530,1,Key Issues in Larch,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,hyejung chang,
+LARC,8300,1,Grad Seminar I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+LAW,3220,1,Legal Env of Bus,0.3,0.6,0.08,0.02,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,2,Legal Env of Bus,0.32,0.48,0.12,0.06,0.02,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,3,Legal Env of Bus,0.39,0.52,0.06,0.03,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,4,Legal Env of Bus,0.45,0.38,0.14,0.03,0.0,0.0,0.0,0.0,melvin stith,
+LAW,3220,5,Legal Env of Bus,0.44,0.34,0.13,0.05,0.03,0.0,0.0,0.02,melvin stith,
+LAW,3220,6,Legal Env of Bus,0.16,0.3,0.21,0.09,0.05,0.0,0.0,0.19,virgini ward-vaughn,
+LAW,3220,7,Legal Env of Bus,0.11,0.54,0.19,0.05,0.03,0.0,0.0,0.08,virgini ward-vaughn,
+LAW,3220,8,Legal Env of Bus,0.06,0.42,0.32,0.0,0.1,0.0,0.0,0.1,virgini ward-vaughn,
+LAW,3220,10,Legal Env of Bus,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LAW,3220,11,Legal Env of Bus,0.09,0.53,0.27,0.08,0.03,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,12,Legal Env of Bus,0.16,0.37,0.3,0.16,0.02,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,13,Legal Env of Bus,0.25,0.49,0.19,0.02,0.0,0.0,0.0,0.05,john hine,
+LAW,3220,14,Legal Env of Bus,0.23,0.59,0.16,0.0,0.0,0.0,0.0,0.02,john hine,
+LAW,3330,1,Real Estate Law,0.15,0.5,0.32,0.0,0.03,0.0,0.0,0.0,michael bra burrell,
+LAW,4060,1,Sports Law,0.63,0.29,0.0,0.0,0.04,0.04,0.0,0.0,terry don phillips,
+LAW,8480,1,Law Real Estate Prof,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,maurie lou lawrence,
+LAW,8500,1,Law for Prof Accts,0.45,0.52,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LAW,8500,2,Law for Prof Accts,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LS,1000,2,Fitness Leadership,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,patricia figueroa,
+LS,1000,7,Intro to Photography,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sarah elizab mudder,
+LS,1000,9,Intro to Salsa Dance,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,
+LS,1000,12,Intermediate Rock Climbing,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,glenn dav middleton,
+LS,1000,22,Intermediate Ashtanga Yoga,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
+LS,1000,27,Beg. Non-competitive Karate,0.73,0.0,0.0,0.09,0.0,0.0,0.0,0.18,june pilcher,
+LS,1130,1,Wood Carving,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,daniel mor anderson,
+LS,1410,2,Top Rope Climbing,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,glenn dav middleton,
+LS,1580,2,Archery,0.8,0.0,0.07,0.0,0.0,0.0,0.0,0.13,herbert strickland,
+LS,1650,3,Inland Kayak Touring,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,george wal thompson,
+LS,1830,1,Intro to Rugby,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,justin hickey,
+LS,1870,2,Frisbee Sports,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,craig goodman,
+LS,1940,1,Racquetball,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,raymond petersen,
+LS,1940,2,Racquetball,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,raymond petersen,
+LS,1990,1,Intermediate Golf,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,jason jordan,
+LS,2100,2,Learn to Dance,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,matthew lee krabbe,
+LS,2100,4,Learn to Dance,0.74,0.07,0.15,0.0,0.0,0.0,0.0,0.04,paul hoke,
+LS,2110,2,Introduction to Belly Dance,0.82,0.05,0.05,0.0,0.0,0.0,0.0,0.09,stephanie pack,
+LS,2190,1,Country West Dance,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.1,matthew lee krabbe,
+LS,2200,6,Shag,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,broadus fleming,
+LS,2200,8,Shag,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,matthew lee krabbe,
+LS,2270,1,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.03,0.0,0.0,0.03,paul hoke,
+LS,2270,4,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,paul hoke,
+LS,2320,1,Core Training,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,diane moreno,
+LS,2350,2,Basic Yoga,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
+LS,2350,3,Basic Yoga,0.83,0.04,0.09,0.04,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2350,4,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2350,5,Basic Yoga,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2350,6,Basic Yoga,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
+LS,2360,1,Power/Ashtanga Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
+LS,2360,2,Power/Ashtanga Yoga,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,ani reina-nunnelley,
+LS,2370,3,Kripalu Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,
+LS,2370,4,Kripalu Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ashley austi lester,
+LS,2370,5,Kripalu Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ashley austi lester,
+LS,2380,4,Vinyasa Flow Yoga,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jenefer nadenicek,
+LS,2420,2,Meditation and Relax,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
+LS,2420,3,Meditation and Relax,0.79,0.05,0.0,0.0,0.0,0.0,0.0,0.16,ranjanbala dil amin,
+LS,2420,4,Meditation and Relax,0.82,0.05,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,
+LS,2420,6,Meditation and Relax,0.65,0.13,0.0,0.04,0.0,0.0,0.0,0.17,renee warren gahan,
+LS,2450,1,Pilates,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,melanie ivey job,
+LS,2500,1,Marathon Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,john walston dunn,True
+LS,2510,2,Running & Jogging,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,corey dou brookover,
+LS,2660,1,Hapkido,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,kelly smith,
+MATH,1010,1,Essen Math for Informed Soc,0.4,0.32,0.12,0.04,0.0,0.0,0.0,0.12,marilyn reba,
+MATH,1010,2,Essen Math for Informed Soc,0.42,0.17,0.31,0.11,0.0,0.0,0.0,0.0,judith cottingham,
+MATH,1010,3,Essen Math for Informed Soc,0.47,0.21,0.16,0.11,0.0,0.0,0.0,0.05,paran rebeka norton,
+MATH,1010,4,Essen Math for Informed Soc,0.32,0.27,0.16,0.14,0.03,0.0,0.0,0.08,judith cottingham,
+MATH,1010,5,Essen Math for Informed Soc,0.12,0.29,0.29,0.0,0.29,0.0,0.0,0.0,sergey charnyi,
+MATH,1010,6,Essen Math for Informed Soc,0.38,0.29,0.21,0.03,0.03,0.0,0.0,0.06,megan elizabet ryan,
+MATH,1010,7,Essen Math for Informed Soc,0.32,0.32,0.16,0.11,0.05,0.0,0.0,0.05,merle glick,
+MATH,1020,1,Intro to Mathematical Analysis,0.24,0.14,0.1,0.24,0.14,0.0,0.0,0.14,vito capuano,
+MATH,1020,2,Intro to Mathematical Analysis,0.07,0.24,0.2,0.24,0.12,0.0,0.0,0.12,thanh thien to,
+MATH,1020,3,Intro to Mathematical Analysis,0.13,0.22,0.2,0.07,0.33,0.0,0.0,0.04,matthew harr menard,
+MATH,1020,4,Intro to Mathematical Analysis,0.15,0.18,0.21,0.13,0.26,0.0,0.0,0.08,liu zhu,
+MATH,1020,5,Intro to Mathematical Analysis,0.13,0.41,0.22,0.09,0.13,0.0,0.0,0.02,randy davidson,
+MATH,1020,6,Intro to Mathematical Analysis,0.15,0.3,0.25,0.1,0.1,0.0,0.0,0.1,david james rea,
+MATH,1020,7,Intro to Mathematical Analysis,0.15,0.37,0.2,0.04,0.22,0.0,0.0,0.02,abigail bowers,
+MATH,1020,8,Intro to Mathematical Analysis,0.11,0.18,0.27,0.14,0.27,0.0,0.0,0.02,samuel jose shesman,
+MATH,1020,9,Intro to Mathematical Analysis,0.2,0.3,0.3,0.07,0.11,0.0,0.0,0.02,abigail bowers,
+MATH,1020,10,Intro to Mathematical Analysis,0.19,0.33,0.29,0.07,0.07,0.0,0.0,0.05,randy davidson,
+MATH,1020,11,Intro to Mathematical Analysis,0.18,0.46,0.1,0.1,0.05,0.0,0.0,0.1,randy davidson,
+MATH,1020,12,Intro to Mathematical Analysis,0.2,0.2,0.3,0.15,0.1,0.0,0.0,0.05,isaac justus,
+MATH,1020,13,Intro to Mathematical Analysis,0.14,0.23,0.27,0.09,0.18,0.0,0.0,0.09,"rodriguez esperanza,",
+MATH,1020,14,Intro to Mathematical Analysis,0.16,0.2,0.38,0.09,0.09,0.0,0.0,0.09,abigail bowers,
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.28,0.67,0.05, morales hernandez,
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.19,0.72,0.09,javier ruiz ramirez,
+MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.56,0.44,0.0,eliza dar gallagher,
+MATH,1060,1,Calculus of One Variable I,0.02,0.14,0.24,0.14,0.24,0.0,0.0,0.22,charity watson,
+MATH,1060,2,Calculus of One Variable I,0.0,0.04,0.2,0.16,0.43,0.0,0.0,0.16,sanwar ahmad,
+MATH,1060,3,Calculus of One Variable I,0.03,0.39,0.12,0.12,0.18,0.0,0.0,0.15,allen anderso guest,
+MATH,1060,4,Calculus of One Variable I,0.06,0.12,0.33,0.27,0.09,0.0,0.0,0.12,allen anderso guest,
+MATH,1060,5,Calculus of One Variable I,0.04,0.17,0.25,0.15,0.23,0.0,0.0,0.17,honghai xu,
+MATH,1060,6,Calculus of One Variable I,0.0,0.17,0.21,0.26,0.23,0.0,0.0,0.13,charity watson,
+MATH,1060,7,Calculus of One Variable I,0.02,0.09,0.3,0.22,0.35,0.0,0.0,0.02,abdullah al mamun,
+MATH,1060,201,Calculus of One Variable I,0.25,0.08,0.25,0.0,0.33,0.0,0.0,0.08,james peterson,
+MATH,1070,1,Differen and Integral Calculus,0.18,0.48,0.27,0.03,0.0,0.0,0.0,0.03,donna simms,
+MATH,1070,2,Differen and Integral Calculus,0.11,0.36,0.33,0.17,0.0,0.0,0.0,0.03,donna simms,
+MATH,1070,3,Differen and Integral Calculus,0.0,0.14,0.5,0.21,0.07,0.0,0.0,0.07,sherry biggers,
+MATH,1070,4,Differen and Integral Calculus,0.08,0.29,0.29,0.26,0.08,0.0,0.0,0.0,sherry biggers,
+MATH,1070,5,Differen and Integral Calculus,0.03,0.32,0.29,0.23,0.06,0.0,0.0,0.06,sherry biggers,
+MATH,1070,6,Differen and Integral Calculus,0.09,0.23,0.36,0.14,0.09,0.0,0.0,0.09,jason to hedetniemi,
+MATH,1070,7,Differen and Integral Calculus,0.09,0.45,0.18,0.09,0.09,0.0,0.0,0.09,fiona may knoll,
+MATH,1080,1,Calculus of One Variable II,0.07,0.19,0.19,0.05,0.17,0.0,0.0,0.33,christa con johnson,
+MATH,1080,2,Calculus of One Variable II,0.05,0.07,0.14,0.05,0.33,0.0,0.0,0.36,sarah eliz anderson,
+MATH,1080,3,Calculus of One Variable II,0.04,0.24,0.22,0.11,0.18,0.0,0.0,0.2,christa con johnson,
+MATH,1080,4,Calculus of One Variable II,0.19,0.17,0.26,0.09,0.11,0.0,0.0,0.19,meredith nicol burr,
+MATH,1080,5,Calculus of One Variable II,0.02,0.3,0.17,0.13,0.04,0.0,0.0,0.33,audrey nico devries,
+MATH,1080,6,Calculus of One Variable II,0.09,0.19,0.28,0.07,0.09,0.0,0.0,0.28,meredith nicol burr,
+MATH,1080,7,Calculus of One Variable II,0.02,0.05,0.23,0.16,0.3,0.0,0.0,0.23,terri johnson,
+MATH,1080,8,Calculus of One Variable II,0.0,0.14,0.05,0.19,0.21,0.0,0.0,0.42,alistair bentley,
+MATH,1080,9,Calculus of One Variable II,0.05,0.17,0.2,0.15,0.17,0.0,0.0,0.27,karyn muir,
+MATH,1080,10,Calculus of One Variable II,0.16,0.2,0.24,0.13,0.09,0.0,0.0,0.18,meredith nicol burr,
+MATH,1080,11,Calculus of One Variable II,0.11,0.24,0.2,0.09,0.11,0.0,0.0,0.24,shih-wei chao,
+MATH,1080,12,Calculus of One Variable II,0.0,0.14,0.16,0.14,0.19,0.0,0.0,0.37,rebecca ramos,
+MATH,1080,13,Calculus of One Variable II,0.0,0.19,0.31,0.16,0.13,0.0,0.0,0.22,marilyn reba,
+MATH,1080,14,Calculus of One Variable II,0.13,0.23,0.23,0.1,0.0,0.0,0.0,0.32,marilyn reba,
+MATH,1080,15,Calculus of One Variable II,0.0,0.11,0.14,0.02,0.23,0.0,0.0,0.5,stefan adam bock,
+MATH,1150,1,Contemp Math for Elem Teach I,0.44,0.46,0.08,0.0,0.0,0.0,0.0,0.03,allison stoddard,
+MATH,1160,1,Contemp Math for Elem Teach II,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1160,2,Contemp Math for Elem Teach II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.87,0.11,0.02,marion hanna,
+MATH,2060,1,Calculus of Several Variables,0.14,0.26,0.23,0.09,0.14,0.0,0.0,0.14,patrick buckingham,
+MATH,2060,2,Calculus of Several Variables,0.19,0.06,0.1,0.06,0.19,0.0,0.0,0.39,dania moham zantout,
+MATH,2060,3,Calculus of Several Variables,0.37,0.4,0.17,0.0,0.06,0.0,0.0,0.0,chanseok park,
+MATH,2060,4,Calculus of Several Variables,0.76,0.14,0.08,0.03,0.0,0.0,0.0,0.0,martin joha schmoll,
+MATH,2060,5,Calculus of Several Variables,0.06,0.38,0.29,0.12,0.12,0.0,0.0,0.03,charles johnson,
+MATH,2060,6,Calculus of Several Variables,0.18,0.15,0.06,0.15,0.21,0.0,0.0,0.26,dania moham zantout,
+MATH,2060,7,Calculus of Several Variables,0.41,0.44,0.09,0.0,0.06,0.0,0.0,0.0,sofya alekseeva,
+MATH,2060,8,Calculus of Several Variables,0.07,0.17,0.28,0.03,0.24,0.0,0.0,0.21,dania moham zantout,
+MATH,2060,10,Calculus of Several Variables,0.14,0.31,0.19,0.22,0.11,0.0,0.0,0.03,charles johnson,
+MATH,2060,12,Calculus of Several Variables,0.32,0.41,0.12,0.0,0.09,0.0,0.0,0.06,sofya alekseeva,
+MATH,2060,100,Calc of Several Variable (HON),0.54,0.38,0.0,0.0,0.08,0.0,0.0,0.0,james brown,True
+MATH,2070,1,Multivariable Calculus,0.16,0.26,0.21,0.16,0.16,0.0,0.0,0.05,elaine ma sotherden,
+MATH,2070,2,Multivariable Calculus,0.26,0.26,0.26,0.11,0.11,0.0,0.0,0.0,garrett dranichak,
+MATH,2070,4,Multivariable Calculus,0.14,0.27,0.23,0.09,0.14,0.0,0.0,0.14,amy christine grady,
+MATH,2070,5,Multivariable Calculus,0.27,0.22,0.22,0.15,0.1,0.0,0.0,0.05,jennifer mari hanna,
+MATH,2070,6,Multivariable Calculus,0.19,0.43,0.21,0.07,0.02,0.0,0.0,0.07,judith irene mcknew,
+MATH,2070,7,Multivariable Calculus,0.36,0.26,0.19,0.12,0.05,0.0,0.0,0.02,jennifer mari hanna,
+MATH,2070,9,Multivariable Calculus,0.15,0.32,0.17,0.05,0.2,0.0,0.0,0.12,grady mcgowa thomas,
+MATH,2070,10,Multivariable Calculus,0.14,0.14,0.36,0.02,0.24,0.0,0.0,0.1,liem nguyen,
+MATH,2070,11,Multivariable Calculus,0.32,0.27,0.27,0.0,0.09,0.0,0.0,0.05,tony thanh nguyen,
+MATH,2070,12,Multivariable Calculus,0.27,0.32,0.23,0.0,0.14,0.0,0.0,0.05,kara ail stasikelis,
+MATH,2070,13,Multivariable Calculus,0.15,0.55,0.2,0.1,0.0,0.0,0.0,0.0,mengying xiao,
+MATH,2070,14,Multivariable Calculus,0.4,0.2,0.1,0.05,0.2,0.0,0.0,0.05,luke marti giberson,
+MATH,2070,15,Multivariable Calculus,0.31,0.21,0.21,0.14,0.05,0.0,0.0,0.07,judith irene mcknew,
+MATH,2070,16,Multivariable Calculus,0.2,0.35,0.2,0.05,0.1,0.0,0.0,0.1,kevin wayne dettman,
+MATH,2070,17,Multivariable Calculus,0.14,0.38,0.33,0.0,0.05,0.0,0.0,0.1,fawwaz taw batayneh,
+MATH,2070,19,Multivariable Calculus,0.33,0.21,0.26,0.05,0.14,0.0,0.0,0.02,margaret milliken,
+MATH,2070,20,Multivariable Calculus,0.33,0.28,0.22,0.0,0.11,0.0,0.0,0.06, ushijima-mwesigwa,
+MATH,2070,21,Multivariable Calculus,0.24,0.37,0.17,0.1,0.07,0.0,0.0,0.05,jennifer mari hanna,
+MATH,2070,22,Multivariable Calculus,0.17,0.33,0.06,0.06,0.17,0.0,0.0,0.22,trevor scot vilardi,
+MATH,2070,24,Multivariable Calculus,0.21,0.21,0.26,0.0,0.16,0.0,0.0,0.16,qijun he,
+MATH,2070,25,Multivariable Calculus,0.34,0.2,0.2,0.12,0.07,0.0,0.0,0.07,jennifer mari hanna,
+MATH,2070,26,Multivariable Calculus,0.06,0.24,0.29,0.12,0.18,0.0,0.0,0.12,yisu jia,
+MATH,2080,1,Intro to Ordin Diff Equations,0.08,0.3,0.18,0.15,0.1,0.0,0.0,0.2,terri johnson,
+MATH,2080,3,Intro to Ordin Diff Equations,0.09,0.26,0.13,0.11,0.2,0.0,0.0,0.2,timothy fra parrott,
+MATH,2080,4,Intro to Ordin Diff Equations,0.13,0.32,0.06,0.06,0.19,0.0,0.0,0.23,shari prevost,
+MATH,2080,5,Intro to Ordin Diff Equations,0.3,0.3,0.16,0.05,0.16,0.0,0.0,0.05,minerva rios-adams,
+MATH,2080,6,Intro to Ordin Diff Equations,0.21,0.45,0.13,0.11,0.08,0.0,0.0,0.03,minerva rios-adams,
+MATH,2080,7,Intro to Ordin Diff Equations,0.2,0.24,0.34,0.0,0.15,0.0,0.0,0.07,julie lassiter,
+MATH,2080,8,Intro to Ordin Diff Equations,0.41,0.15,0.26,0.0,0.04,0.0,0.0,0.13,timothy fra parrott,
+MATH,2080,9,Intro to Ordin Diff Equations,0.49,0.22,0.22,0.04,0.0,0.0,0.0,0.02,timothy ch teitloff,
+MATH,2080,10,Intro to Ordin Diff Equations,0.21,0.21,0.15,0.18,0.12,0.0,0.0,0.15,shari prevost,
+MATH,2080,11,Intro to Ordin Diff Equations,0.36,0.29,0.09,0.09,0.09,0.0,0.0,0.09,timothy fra parrott,
+MATH,2080,12,Intro to Ordin Diff Equations,0.31,0.22,0.31,0.14,0.0,0.0,0.0,0.03,timothy ch teitloff,
+MATH,2080,13,Intro to Ordin Diff Equations,0.24,0.24,0.33,0.15,0.03,0.0,0.0,0.0,julie lassiter,
+MATH,2080,14,Intro to Ordin Diff Equations,0.39,0.29,0.2,0.05,0.0,0.0,0.0,0.07,nathan jos adelgren,
+MATH,2080,15,Intro to Ordin Diff Equations,0.53,0.27,0.16,0.02,0.02,0.0,0.0,0.0,timothy ch teitloff,
+MATH,2080,16,Intro to Ordin Diff Equations,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,irina viktorova,
+MATH,2080,17,Intro to Ordin Diff Equations,0.3,0.51,0.11,0.0,0.03,0.0,0.0,0.05,brandon gra goodell,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,james brannan,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.57,0.4,0.0,0.0,0.03,0.0,0.0,0.0,allison stoddard,
+MATH,3020,1,Stat for Science & Engineering,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,christopher wilson,
+MATH,3020,2,Stat for Science & Engineering,0.7,0.14,0.05,0.04,0.05,0.0,0.0,0.02,dominique morgan,
+MATH,3020,3,Stat for Science & Engineering,0.45,0.25,0.07,0.05,0.14,0.0,0.0,0.05,christopher mcmahan,
+MATH,3020,4,Stat for Science & Engineering,0.69,0.21,0.05,0.05,0.0,0.0,0.0,0.0,xiaoqian sun,
+MATH,3020,5,Stat for Science & Engineering,0.19,0.35,0.26,0.06,0.04,0.0,0.0,0.11,michael thom finney,
+MATH,3080,1,College Geometry,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,eliza dar gallagher,
+MATH,3110,1,Linear Algebra,0.38,0.22,0.14,0.14,0.11,0.0,0.0,0.03,elena sta dimitrova,
+MATH,3110,2,Linear Algebra,0.5,0.34,0.13,0.03,0.0,0.0,0.0,0.0,judith cottingham,
+MATH,3110,3,Linear Algebra,0.21,0.24,0.41,0.03,0.06,0.0,0.0,0.06,svetlan poznanovikj,
+MATH,3110,4,Linear Algebra,0.31,0.11,0.23,0.06,0.17,0.0,0.0,0.11,xuhong gao,
+MATH,3110,5,Linear Algebra,0.56,0.16,0.08,0.0,0.08,0.0,0.0,0.12,xuhong gao,
+MATH,3150,1,Adv Top in Math for Elem Teach,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,3190,1,Introduction to Proof,0.35,0.26,0.17,0.0,0.13,0.0,0.0,0.09,kevin james,
+MATH,3190,2,Introduction to Proof,0.4,0.3,0.1,0.0,0.1,0.0,0.0,0.1,michael adam burr,
+MATH,3600,1,Intermediate Math Computing,0.63,0.2,0.05,0.0,0.07,0.0,0.0,0.05,neil calkin,
+MATH,3650,1,Numerical Mthds for Engineers,0.72,0.26,0.02,0.0,0.0,0.0,0.0,0.0,abigail bowers,
+MATH,3650,2,Numerical Mthds for Engineers,0.17,0.22,0.33,0.14,0.08,0.0,0.0,0.06,christopher cox,
+MATH,3650,3,Numerical Mthds for Engineers,0.19,0.31,0.33,0.06,0.06,0.0,0.0,0.06,christopher cox,
+MATH,4000,1,Theory of Probability,0.5,0.21,0.11,0.04,0.11,0.0,0.0,0.04,yingbo li,
+MATH,4030,1,Intro to Statistical Theory,0.36,0.23,0.23,0.05,0.09,0.0,0.0,0.05,xiaoqian sun,
+MATH,4070,1,Regress & Time-Series Analysis,0.5,0.29,0.21,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,4100,1,Number Theory,0.4,0.25,0.15,0.15,0.05,0.0,0.0,0.0,charles johnson,
+MATH,4120,1,Intro to Modern Algebra,0.28,0.21,0.21,0.1,0.1,0.0,0.0,0.1,elena sta dimitrova,
+MATH,4190,1,Discrete Math Structures I,0.44,0.31,0.11,0.02,0.02,0.0,0.0,0.09,beth novick,
+MATH,4300,1,Actuarial Science Seminar I,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,mark cawood,
+MATH,4310,1,Theory of Interest,0.23,0.41,0.23,0.14,0.0,0.0,0.0,0.0, erwin walker,
+MATH,4340,1,Adv Engineering Mathematics,0.29,0.31,0.17,0.06,0.09,0.0,0.0,0.09,qingshan chen,
+MATH,4340,2,Adv Engineering Mathematics,0.46,0.21,0.13,0.0,0.04,0.0,0.0,0.17,daniel warner,
+MATH,4400,1,Linear Programming,0.43,0.1,0.14,0.05,0.1,0.0,0.0,0.19,warren adams,
+MATH,4530,1,Advanced Calculus I,0.13,0.13,0.2,0.2,0.2,0.0,0.0,0.13,jeong rock yoon,
+MATH,4540,1,Advanced Calculus II,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,taufiquar rahm khan,
+MATH,6340,1,Adv Engineering Mathematics,0.4,0.3,0.1,0.0,0.05,0.0,0.0,0.15,hyesuk lee,
+MATH,8030,1,Stochastic Processes,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
+MATH,8050,1,Data Analysis,0.48,0.35,0.09,0.0,0.0,0.0,0.0,0.09,derek brown,
+MATH,8090,1,Time Series Analysis,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,colin gallagher,
+MATH,8100,1,Mathematical Programming,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
+MATH,8110,1,Nonlinear Programming,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,margaret mar wiecek,
+MATH,8130,1,Advanced Linear Programming,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,warren adams,
+MATH,8210,1,Linear Analysis,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,
+MATH,8260,1,Partial Differential Equations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,
+MATH,8520,1,Abstract Algebra II,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,james brown,
+MATH,8530,1,Matrix Analysis,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,matthew macauley,
+MATH,8570,1,Cryptography,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,felice manganiello,
+MATH,8600,1,Intro to Scientific Computing,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,leo rebholz,
+MATH,8660,1,Finite Element Method,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
+MATH,8810,1,Mathematical Statistics,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,
+MATH,9830,1,Sel Top in Computational Math,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,timo johann heister,
+MBA,8030,1,Stat Analy of Bus Op,0.82,0.15,0.0,0.0,0.0,0.0,0.0,0.03,matthew charl klein,
+MBA,8060,1,Operations Mgt,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06, sridharan,
+MBA,8070,1,Financial Management,0.83,0.18,0.0,0.0,0.0,0.0,0.0,0.0,fei xie,
+MBA,8070,2,Financial Management,0.46,0.49,0.03,0.0,0.0,0.0,0.0,0.03,fei xie,
+MBA,8090,1,Org Beh & Hum Res Mg,0.65,0.33,0.0,0.0,0.0,0.0,0.0,0.02,thomas jo zagenczyk,
+MBA,8190,1,Intro to Acc and Fin,0.53,0.35,0.09,0.0,0.02,0.0,0.0,0.0,jeffrey mcmillan,
+MBA,8290,1,Marketing Foundation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MBA,8370,1,Legal Environ of Bus,0.53,0.42,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8410,1,Real Estate Finance,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,james pow mckissick,
+MBA,8430,10,MBAePT Entrepreneurial Acct,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
+MBA,8450,1,MBAe FT Tech & Innova Mgt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david orr,
+MBA,8470,1,MBAe FT New Venture Creation,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
+MBA,8540,1,Mgrl Accounting,0.84,0.11,0.03,0.0,0.0,0.0,0.0,0.03,henry anderson,
+MBA,8540,2,Mgrl Accounting,0.8,0.1,0.02,0.0,0.02,0.0,0.0,0.05,henry anderson,
+MBA,8590,1,Mgr Decision Model,0.45,0.21,0.06,0.0,0.04,0.0,0.0,0.23,mark mcknew,
+MBA,8590,3,Mgr Decision Model,0.38,0.33,0.15,0.0,0.05,0.0,0.0,0.1,sara elizabet yoder,
+MBA,8600,1,Advanced Marketing Strategy,0.36,0.46,0.18,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8610,1,Information Systems,0.38,0.52,0.0,0.0,0.03,0.0,0.0,0.07,varun grover,
+MBA,8610,2,Information Systems,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,heshan sun,
+MBA,8620,1,Managerial Economics,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,
+MBA,8720,1,MBAe FT Entrepr Finance,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,
+MBA,8750,1,Enterprise Develpmnt,0.66,0.29,0.03,0.0,0.0,0.0,0.0,0.03,michael george mino,
+MBA,8990,1,Advanced Leadership,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,gail depriest,
+ME,2000,1,Sophomore Seminar,0.84,0.11,0.01,0.0,0.01,0.0,0.0,0.03,donald beasley,
+ME,2010,1,Statics & Dynamics,0.02,0.12,0.23,0.16,0.36,0.0,0.0,0.1,sherrill biggers,
+ME,2010,2,Statics & Dynamics,0.11,0.31,0.26,0.11,0.15,0.0,0.0,0.06,paul joseph,
+ME,2030,1,Founda Th/Fl Syst,0.29,0.42,0.1,0.13,0.02,0.0,0.0,0.04,richard figliola,
+ME,2030,2,Founda Th/Fl Syst,0.14,0.27,0.41,0.1,0.06,0.0,0.0,0.02,chenning tong,
+ME,2030,3,Founda Th/Fl Syst,0.44,0.42,0.1,0.0,0.01,0.0,0.0,0.02,david zumbrunnen,
+ME,2040,1,Mechanics of Materials,0.27,0.33,0.21,0.09,0.05,0.0,0.0,0.05,michael porter,
+ME,2040,2,Mechanics of Materials,0.09,0.54,0.21,0.04,0.07,0.0,0.0,0.04,todd schweisinger,
+ME,2220,1,Mech Engr Lab I,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,2,Mech Engr Lab I,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,3,Mech Engr Lab I,0.2,0.5,0.25,0.05,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,4,Mech Engr Lab I,0.27,0.6,0.07,0.07,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,5,Mech Engr Lab I,0.15,0.8,0.0,0.0,0.05,0.0,0.0,0.0,todd schweisinger,
+ME,2220,6,Mech Engr Lab I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,7,Mech Engr Lab I,0.21,0.74,0.0,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
+ME,2220,8,Mech Engr Lab I,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3030,1,Thermodynamics,0.12,0.29,0.33,0.16,0.04,0.0,0.0,0.07,jay ochterbeck,
+ME,3040,1,Heat Transfer,0.4,0.28,0.25,0.03,0.02,0.0,0.0,0.02,donald beasley,
+ME,3040,2,Heat Transfer,0.22,0.44,0.15,0.06,0.06,0.0,0.0,0.07,xin zhao,
+ME,3050,1,Model/an Dy Syst,0.18,0.38,0.2,0.09,0.09,0.0,0.0,0.07,phanin tallapragada,
+ME,3050,2,Model/an Dy Syst,0.21,0.58,0.17,0.02,0.0,0.0,0.0,0.02,yue wang,
+ME,3060,1,Fund Machine Design,0.32,0.47,0.15,0.05,0.02,0.0,0.0,0.0,oliver myers,
+ME,3060,2,Fund Machine Design,0.47,0.36,0.09,0.06,0.0,0.0,0.0,0.02,paul jeffrey meyer,
+ME,3070,1,Found of Mechanical Systems,0.54,0.32,0.04,0.04,0.04,0.0,0.0,0.04,lonny thompson,
+ME,3070,2,Found of Mechanical Systems,0.14,0.32,0.36,0.11,0.0,0.0,0.0,0.07,gregory mocko,
+ME,3080,1,Fluid Mechanics,0.0,0.28,0.33,0.19,0.14,0.0,0.0,0.06,jean-marc delhaye,
+ME,3080,2,Fluid Mechanics,0.09,0.4,0.33,0.11,0.02,0.0,0.0,0.04,ethan kung,
+ME,3100,1,Thermo/Heat Transfer,0.19,0.32,0.22,0.12,0.01,0.0,0.0,0.13,xiangchun xuan,
+ME,3120,1,Manuf Processes,0.46,0.35,0.08,0.08,0.02,0.0,0.0,0.0,hong seok choi,
+ME,3330,1,Mech Engr Lab II,0.38,0.44,0.13,0.06,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,2,Mech Engr Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,3,Mech Engr Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,4,Mech Engr Lab II,0.19,0.44,0.25,0.0,0.06,0.0,0.0,0.06,todd schweisinger,
+ME,3330,5,Mech Engr Lab II,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
+ME,3330,6,Mech Engr Lab II,0.21,0.53,0.16,0.05,0.05,0.0,0.0,0.0,todd schweisinger,
+ME,3330,7,Mech Engr Lab II,0.22,0.56,0.11,0.06,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,3330,8,Mech Engr Lab II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4000,1,Senior Seminar,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0, ramasubramanian,
+ME,4010,1,Mech Engr Design,0.18,0.69,0.09,0.02,0.02,0.0,0.0,0.0,joshua summers,
+ME,4020,1,Intern in Engr Des,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4020,3,Intern in Engr Des,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,4,Intern in Engr Des,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,ethan kung,
+ME,4020,7,Intern in Engr Des,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,4030,1,Control Dynamic Syst,0.4,0.33,0.13,0.13,0.0,0.0,0.0,0.0,hamed saeidi,
+ME,4030,2,Control Dynamic Syst,0.05,0.19,0.3,0.24,0.16,0.0,0.0,0.05,kalyan chakr katuri,
+ME,4170,1,Mechatronic Sys,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4220,1,Design Gas Turbines,0.46,0.31,0.15,0.0,0.0,0.0,0.0,0.08,abhijit som,
+ME,4230,1,Intro Aerodynamics,0.15,0.18,0.5,0.12,0.06,0.0,0.0,0.0,richard figliola,
+ME,4260,1,Nuclear Energy,0.26,0.26,0.29,0.12,0.03,0.0,0.0,0.03,david zumbrunnen,
+ME,4320,1,Adv Strength of Matl,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.08,gang li,
+ME,4440,3,Mech Engr Lab III,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,5,Mech Engr Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4930,5,SelectedTopics ME (RapidProto),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4930,29,Selected Topics ME (Solar E),0.62,0.34,0.0,0.0,0.0,0.0,0.0,0.03,daniel fant,
+ME,6170,1,Mechatronic Sys,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,6320,1,Adv Strength of Matl,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,gang li,
+ME,6930,5,SelectedTopics ME (RapidProto),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,6930,11,Selected Topics ME (MicroFab),0.44,0.38,0.06,0.0,0.13,0.0,0.0,0.0,rod martinez-duarte,
+ME,6930,29,Selected Topics ME (Solar E),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,8120,1,Exp Meth Thermal Sci,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
+ME,8190,1,Cp Meth in Therm Sc,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,richard miller,
+ME,8200,1,Mod Cont Engr,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,
+ME,8310,1,Convective Ht Trans,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,john saylor,
+ME,8360,1,Fracture Mech,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,8520,1,Adv Finite Ele Ana,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,lonny thompson,
+ME,8610,1,Matl Sel Engr Design,0.86,0.11,0.02,0.0,0.0,0.0,0.0,0.02,mica grujicic,
+ME,8930,1,Sel Topics in ME (Scaling),0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,8930,27,Sel Top - Optimal Estimation,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,ardalan vahidi,
+MGT,2010,1,Principles of Mgt,0.36,0.3,0.21,0.05,0.04,0.0,0.0,0.05,katherine clark,
+MGT,2010,2,Principles of Mgt,0.23,0.47,0.23,0.02,0.04,0.0,0.0,0.0,katherine clark,
+MGT,2010,3,Principles of Mgt,0.21,0.36,0.24,0.04,0.08,0.0,0.0,0.07,katherine clark,
+MGT,2010,4,Principles of Mgt,0.22,0.38,0.19,0.12,0.01,0.0,0.0,0.08,katherine clark,
+MGT,2010,5,Principles of Mgt,0.27,0.34,0.25,0.05,0.0,0.0,0.0,0.08,tina robbins,
+MGT,2010,6,Principles of Mgt,0.26,0.54,0.12,0.05,0.01,0.0,0.0,0.01,tina robbins,
+MGT,2010,7,Principles of Mgt,0.29,0.45,0.21,0.03,0.0,0.0,0.0,0.03,tina robbins,
+MGT,2010,8,Principles of Mgt,0.27,0.36,0.18,0.08,0.05,0.0,0.0,0.06,tina robbins,
+MGT,2180,1,Management PC Applications,0.53,0.3,0.08,0.02,0.04,0.0,0.0,0.02,ryan toole,
+MGT,2180,2,Management PC Applications,0.55,0.28,0.08,0.02,0.04,0.0,0.0,0.03,ryan toole,
+MGT,2180,3,Management PC Applications,0.57,0.32,0.06,0.03,0.01,0.0,0.0,0.02,ryan toole,
+MGT,2180,4,Management PC Applications,0.57,0.25,0.1,0.02,0.02,0.0,0.0,0.05,ryan toole,
+MGT,3070,1,Human Resource Management,0.64,0.27,0.05,0.0,0.0,0.0,0.0,0.05,priscilla harrison,
+MGT,3070,2,Human Resource Management,0.48,0.48,0.03,0.0,0.03,0.0,0.0,0.0,michael cole,
+MGT,3070,3,Human Resource Management,0.17,0.78,0.03,0.0,0.03,0.0,0.0,0.0,kristin dam scott,
+MGT,3070,4,Human Resource Management,0.4,0.48,0.08,0.0,0.0,0.0,0.0,0.05,michael cole,
+MGT,3070,5,Human Resource Management,0.08,0.56,0.31,0.05,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,6,Human Resource Management,0.18,0.67,0.15,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3100,1,Intermed Business Statistics,0.32,0.39,0.16,0.0,0.02,0.0,0.0,0.11,james walsh,
+MGT,3100,2,Intermed Business Statistics,0.66,0.13,0.11,0.05,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3100,3,Intermed Business Statistics,0.58,0.25,0.1,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3100,4,Intermed Business Statistics,0.12,0.32,0.27,0.17,0.05,0.0,0.0,0.07,sara elizabet yoder,
+MGT,3100,5,Intermed Business Statistics,0.44,0.28,0.19,0.0,0.06,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3100,6,Intermed Business Statistics,0.44,0.36,0.11,0.03,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3100,7,Intermed Business Statistics,0.16,0.17,0.24,0.14,0.08,0.0,0.0,0.21,sara elizabet yoder,
+MGT,3100,8,Intermed Business Statistics,0.14,0.23,0.14,0.27,0.14,0.0,0.0,0.09,sara elizabet yoder,
+MGT,3100,10,Intermed Business Statistics,0.24,0.45,0.24,0.05,0.0,0.0,0.0,0.02,yuhong he,
+MGT,3120,1,Decision Models for Management,0.3,0.4,0.23,0.02,0.05,0.0,0.0,0.0,mark mcknew,
+MGT,3120,2,Decision Models for Management,0.13,0.41,0.35,0.04,0.0,0.0,0.0,0.07,mark mcknew,
+MGT,3120,3,Decision Models for Management,0.13,0.5,0.24,0.0,0.11,0.0,0.0,0.02,mark mcknew,
+MGT,3150,1,New Venture Creation,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
+MGT,3180,1,Mgt of Info Systems,0.51,0.36,0.05,0.05,0.03,0.0,0.0,0.0,dan jiang,
+MGT,3180,2,Mgt of Info Systems,0.33,0.38,0.3,0.0,0.0,0.0,0.0,0.0,tina marie esposito,
+MGT,3180,3,Mgt of Info Systems,0.21,0.44,0.33,0.0,0.03,0.0,0.0,0.0,roopa raman,
+MGT,3180,4,Mgt of Info Systems,0.13,0.37,0.47,0.0,0.0,0.0,0.0,0.03,roopa raman,
+MGT,3900,2,Ops Mgt,0.36,0.2,0.32,0.08,0.0,0.0,0.0,0.04,min kyung lee,
+MGT,3900,3,Ops Mgt,0.35,0.35,0.25,0.0,0.03,0.0,0.0,0.03,zachary mo leffakis,
+MGT,3900,4,Ops Mgt,0.18,0.35,0.28,0.03,0.05,0.0,0.0,0.13,zachary mo leffakis,
+MGT,3900,5,Ops Mgt,0.24,0.5,0.15,0.06,0.03,0.0,0.0,0.03,shouqiang wang,
+MGT,3900,6,Ops Mgt,0.24,0.43,0.24,0.05,0.03,0.0,0.0,0.0,yuhong he,
+MGT,4000,2,Mgt of Organizational Behavior,0.26,0.51,0.23,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MGT,4000,3,Mgt of Organizational Behavior,0.25,0.45,0.25,0.0,0.03,0.0,0.0,0.03,philip roth,
+MGT,4000,4,Mgt of Organizational Behavior,0.51,0.31,0.11,0.03,0.0,0.0,0.0,0.03,michael cole,
+MGT,4020,1,Ops Pln and Ctl,0.32,0.47,0.21,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4030,1,Intro to Business Analytics,0.33,0.46,0.13,0.04,0.0,0.0,0.0,0.04,siyuan li,
+MGT,4030,3,Advanced Business Analytics,0.13,0.53,0.33,0.0,0.0,0.0,0.0,0.0,heshan sun,
+MGT,4080,1,Lean Operations,0.21,0.29,0.46,0.0,0.04,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4110,1,Project Management,0.2,0.6,0.17,0.0,0.0,0.0,0.0,0.03,russell purvis,
+MGT,4110,2,Project Management,0.22,0.57,0.22,0.0,0.0,0.0,0.0,0.0,russell purvis,
+MGT,4120,1,Supplier Management,0.1,0.4,0.47,0.0,0.0,0.0,0.0,0.03,shouqiang wang,
+MGT,4150,1,Business Strategy,0.09,0.66,0.23,0.0,0.03,0.0,0.0,0.0,peter gianiodis,
+MGT,4150,2,Business Strategy,0.22,0.65,0.14,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
+MGT,4150,3,Business Strategy,0.73,0.23,0.0,0.03,0.0,0.0,0.0,0.03,john edward hopkins,
+MGT,4150,4,Business Strategy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,5,Business Strategy,0.27,0.56,0.16,0.02,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,6,Business Strategy,0.16,0.69,0.11,0.0,0.04,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,7,Business Strategy,0.17,0.59,0.24,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,
+MGT,4150,8,Business Strategy,0.2,0.7,0.11,0.0,0.0,0.0,0.0,0.0,jason wayne ridge,
+MGT,4160,1,Special Topics Hr,0.31,0.64,0.06,0.0,0.0,0.0,0.0,0.0,kristin dam scott,
+MGT,4230,1,Intern Bus Mgt,0.09,0.22,0.61,0.04,0.04,0.0,0.0,0.0,wayne stewart,
+MGT,4230,2,Intern Bus Mgt,0.15,0.28,0.33,0.07,0.09,0.0,0.0,0.09,wayne stewart,
+MGT,4230,3,Intern Bus Mgt,0.36,0.48,0.17,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4230,4,Intern Bus Mgt,0.03,0.78,0.14,0.0,0.03,0.0,0.0,0.03,janis miller,
+MGT,4240,1,Global Supply Chain,0.14,0.41,0.36,0.05,0.05,0.0,0.0,0.0,yann ferrand,
+MGT,4270,1,Managing Improvement,0.4,0.43,0.13,0.0,0.0,0.0,0.0,0.03,james liddle,
+MGT,4300,1,Bus Application Development,0.56,0.13,0.19,0.0,0.0,0.0,0.0,0.13,jerry kermi bilbrey,
+MGT,4310,1,Emp Rights & Resp,0.38,0.48,0.13,0.0,0.0,0.0,0.0,0.03,leonard jos spooner,
+MGT,4350,1,Pers Interviewing,0.33,0.4,0.18,0.08,0.03,0.0,0.0,0.0,philip roth,
+MGT,4520,1,Business Analysis,0.18,0.55,0.18,0.06,0.03,0.0,0.0,0.0,roopa raman,
+MGT,4550,1,Emerging I T Trends,0.39,0.52,0.1,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MGT,4560,1,Business Info Mgt,0.27,0.53,0.07,0.0,0.0,0.0,0.0,0.13,siyuan li,
+MGT,8120,1,Supply Chain Mgt,0.29,0.55,0.16,0.0,0.0,0.0,0.0,0.0,yann ferrand,
+MICR,3050,1,General Microbiology,0.41,0.39,0.14,0.04,0.01,0.0,0.0,0.01,kristi ja whitehead,
+MICR,3050,2,General Microbiology,0.46,0.36,0.12,0.02,0.02,0.0,0.0,0.02,krista barr rudolph,
+MICR,3050,3,General Microbiology,0.55,0.37,0.05,0.03,0.0,0.0,0.0,0.0,krista barr rudolph,
+MICR,4000,1,Public Health Micro,0.37,0.38,0.17,0.05,0.02,0.0,0.0,0.02,kristi ja whitehead,
+MICR,4020,1,Environmental Micro,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,john michael henson,
+MICR,4070,1,Food and Dairy Micro,0.37,0.49,0.14,0.0,0.0,0.0,0.0,0.0,xiuping jiang,
+MICR,4110,1,Pathogenic Bact,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
+MICR,4120,1,Bacterial Physiology,0.26,0.29,0.16,0.13,0.16,0.0,0.0,0.0,thomas hughes,
+MICR,4130,1,Industrial Micro,0.32,0.58,0.04,0.02,0.02,0.0,0.0,0.02,tzuen-rong je tzeng,
+MICR,4140,1,Basic Immunology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,
+MICR,4170,1,Cancer and Aging,0.65,0.29,0.0,0.06,0.0,0.0,0.0,0.0,yuqing dong,
+MICR,4210,1,Path Bac Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
+MICR,4210,2,Path Bac Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tamara lyn mcnealy,
+MICR,4500,2,Advanced Microbiology I,0.5,0.45,0.0,0.0,0.05,0.0,0.0,0.0,harry kurtz,
+MICR,4500,3,Advanced Microbiology I,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MKT,3010,1,Prin of Marketing,0.15,0.49,0.27,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,
+MKT,3010,2,Prin of Marketing,0.21,0.47,0.23,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,
+MKT,3010,3,Prin of Marketing,0.21,0.37,0.25,0.1,0.04,0.0,0.0,0.03,amanda cooper fine,
+MKT,3010,4,Prin of Marketing,0.27,0.43,0.2,0.09,0.02,0.0,0.0,0.0,amanda cooper fine,
+MKT,3010,5,Prin of Marketing,0.36,0.4,0.19,0.03,0.01,0.0,0.0,0.02,james gaubert,
+MKT,3010,6,Prin of Marketing,0.42,0.38,0.17,0.03,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,3020,1,Consumer Behavior,0.45,0.38,0.09,0.05,0.02,0.0,0.0,0.02,jennifer di siemens,
+MKT,3020,2,Consumer Behavior,0.46,0.41,0.11,0.02,0.0,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,3,Consumer Behavior,0.26,0.49,0.18,0.05,0.02,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3020,4,Consumer Behavior,0.42,0.39,0.11,0.07,0.02,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3210,1,Sports Marketing,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3980,1,Sales Experiential,0.82,0.11,0.05,0.0,0.02,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4200,1,Professional Selling,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,2,Professional Selling,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,3,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4200,4,Professional Selling,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,gary hunter,
+MKT,4230,1,Promotional Strategy,0.21,0.52,0.17,0.05,0.02,0.0,0.0,0.02,patricia knowles,
+MKT,4240,1,Sales Management,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4260,1,Business-to-Business,0.38,0.58,0.02,0.0,0.02,0.0,0.0,0.0,james gaubert,
+MKT,4270,1,International Mktg,0.11,0.54,0.34,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
+MKT,4270,2,International Mktg,0.29,0.42,0.29,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
+MKT,4270,3,International Mktg,0.26,0.5,0.21,0.02,0.0,0.0,0.0,0.0,roger gomes,
+MKT,4270,4,International Mktg,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,roger gomes,
+MKT,4270,5,International Mktg,0.22,0.46,0.27,0.02,0.0,0.0,0.0,0.02,roger gomes,
+MKT,4280,1,Services Marketing,0.15,0.55,0.25,0.03,0.03,0.0,0.0,0.0,mary anne raymond,
+MKT,4280,2,Services Marketing,0.28,0.52,0.08,0.04,0.04,0.0,0.0,0.04,mary anne raymond,
+MKT,4310,1,Marketing Research,0.28,0.66,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,2,Marketing Research,0.37,0.56,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,3,Marketing Research,0.21,0.64,0.11,0.04,0.0,0.0,0.0,0.0,william kilbourne,
+MKT,4330,1,Sport Mkt Strategy,0.33,0.57,0.05,0.0,0.0,0.0,0.0,0.05,amanda cooper fine,
+MKT,4430,1,Advertising Strategy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,albert neil cameron,
+MKT,4450,1,Macromarketing,0.44,0.48,0.04,0.0,0.0,0.04,0.0,0.0,william kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,2,Strategic Mktg Mgt,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4500,3,Strategic Mktg Mgt,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,4500,4,Strategic Mktg Mgt,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4950,1,Selected Topics,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,peter weathers,
+MKT,8620,1,Quant Methods in Mkt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
+MKT,8650,1,Seminar in Mkt Mgmt,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MKT,8660,1,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+ML,1020,1,Leadership Fund II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert rozetar,
+ML,1020,2,Leadership Fund II,0.82,0.09,0.0,0.0,0.05,0.0,0.0,0.05,robert rozetar,
+ML,2020,2,Leadership Dev II,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,charles co crawford,
+ML,3020,2,Adv Leadership II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kelly rodric norris,
+ML,4020,1,Org Leadership II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
+ML,4020,3,Org Leadership II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
+MSE,2100,1,Intro to Mat Science,0.4,0.27,0.19,0.06,0.06,0.0,0.0,0.03,marian kennedy,
+MSE,2100,2,Intro to Mat Science,0.5,0.24,0.13,0.04,0.01,0.0,0.0,0.08,eric skaar,
+MSE,2100,3,Intro to Mat Science,0.22,0.34,0.22,0.11,0.09,0.0,0.0,0.02,julie patric martin,
+MSE,2500,1,Polymer & Fiber Materials I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,
+MSE,2500,2,Polymer & Fiber Materials I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,
+MSE,3260,1,Thermo of Materials,0.19,0.32,0.27,0.15,0.03,0.0,0.0,0.03,gary lickfield,
+MSE,3280,1,Phase Diagrams,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,eric skaar,
+MSE,3610,1,Proc of Metals & Com,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,marian kennedy,
+MSE,4160,1,Electronic Materials,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
+MSE,4220,1,Mech Behavior of Mat,0.35,0.54,0.11,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
+MSE,4240,1,Optical Materials,0.23,0.38,0.38,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,4330,1,Comb Sys & Env Emiss,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,denis brosnan,
+MSE,4560,1,Polymer & Fiber Materials II,0.27,0.46,0.27,0.0,0.0,0.0,0.0,0.0,gary lickfield,
+MSE,4590,1,Color Science Lab,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,philip brown,
+MSE,8280,1,Phase Transformation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,fei peng,
+MUSC,1110,7,Beginning Class Guitar,0.8,0.1,0.0,0.1,0.0,0.0,0.0,0.0,david stevenson,
+MUSC,1110,9,Beginning Class Guitar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,david stevenson,
+MUSC,1420,1,Music Theory I,0.58,0.17,0.0,0.0,0.08,0.0,0.0,0.17,david conley,
+MUSC,1430,1,Aural Skills I,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,david conley,
+MUSC,1510,15,Applied Music - Piano,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,cindy roden goodloe,
+MUSC,1800,1,Intro to Music Tech,0.36,0.36,0.18,0.0,0.0,0.0,0.0,0.09,hamilton altstatt,
+MUSC,2100,1,Music in West World,0.72,0.22,0.03,0.0,0.03,0.0,0.0,0.0,eric lapin,
+MUSC,2100,2,Music in West World,0.56,0.25,0.06,0.03,0.0,0.0,0.0,0.09,lisa sain odom,
+MUSC,2100,3,Music in West World,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,2100,4,Music in West World,0.47,0.31,0.19,0.0,0.0,0.0,0.0,0.03,linda li-bleuel,
+MUSC,2100,5,Music in West World,0.61,0.26,0.06,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
+MUSC,2100,6,Music in West World,0.77,0.16,0.0,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
+MUSC,2100,7,Music in West World,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
+MUSC,2100,12,Music in West World,0.55,0.35,0.06,0.0,0.0,0.0,0.0,0.03,lea kibler,
+MUSC,2100,13,Music in West World,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,linda dzuris,
+MUSC,3110,1,History of American Music,0.5,0.34,0.09,0.03,0.0,0.0,0.0,0.03,ned hosler,
+MUSC,3120,1,History of Jazz,0.44,0.28,0.22,0.06,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,3170,1,Hist of Country Mus,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,ned hosler,
+MUSC,3310,1,Pep Band - Men,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,
+MUSC,3690,1,Symphony Orchestra,0.91,0.07,0.0,0.0,0.0,0.0,0.0,0.02,andrew levin,True
+MUSC,4160,1,Mus Hist Since 1750,0.35,0.09,0.3,0.0,0.17,0.0,0.0,0.09,linda li-bleuel,
+MUSC,4300,1,Conducting,0.3,0.3,0.2,0.0,0.2,0.0,0.0,0.0,justin durham,
+NPL,3010,2,NPL Stakeholders,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,tracy diane lamb,
+NURS,3030,1,Nursing of Adults,0.35,0.57,0.06,0.02,0.0,0.0,0.0,0.0,leslie anne  ravan,
+NURS,3030,400,Nursing of Adults,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,wanda leigh taylor,
+NURS,3040,1,Pathophysiology,0.33,0.58,0.03,0.06,0.0,0.0,0.0,0.0,catherine si murton,
+NURS,3040,401,Pathophysiology for RN,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
+NURS,3100,1,Health Assessment,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3120,1,Foundations of Nurs,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,angela pye,
+NURS,3190,400,Health Assessment for RNs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,
+NURS,3200,1,Prof in Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+NURS,3400,1,Pharmther Nursing,0.37,0.59,0.02,0.02,0.0,0.0,0.0,0.0,catherine si murton,
+NURS,4010,1,Mental Health Nurs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NURS,4030,1,Complex Nursing of Adults,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
+NURS,4110,1,Nursing of Children,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,heide temples,
+NURS,4120,1,Nurs Women and Fam,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4250,400,Community Nursing,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
+NURS,8080,400,Nurs Res Stat Analys,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,8190,400,Developing Family,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,
+NURS,8200,400,Child & Adol Nursing,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,heide temples,
+NURS,8210,400,Adult Nursing,0.69,0.29,0.03,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8850,400,Mental Health in Primary Care,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.44,0.39,0.12,0.01,0.0,0.0,0.0,0.03,deborah an hutcheon,
+NUTR,2040,1,Nutrition Across Life Cycle,0.4,0.42,0.11,0.07,0.0,0.0,0.0,0.0,deborah an hutcheon,
+NUTR,4250,1,Medica Nutr Thera II,0.55,0.39,0.04,0.0,0.02,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4260,1,Community Nutrition,0.49,0.45,0.06,0.0,0.0,0.0,0.0,0.0,rita haliena,
+NUTR,4550,1,Nutr Metabolism,0.36,0.38,0.12,0.08,0.0,0.0,0.0,0.06,elliot jesch,
+PA,2800,1,Perf Arts Pract II,0.35,0.29,0.06,0.0,0.12,0.0,0.0,0.18,kenneth moore,
+PA,4010,1,Capstone Project,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,anthony penna,
+PADM,8220,400,Public Policy Process,0.77,0.08,0.0,0.0,0.08,0.0,0.0,0.08,mark daniel mellott,
+PADM,8410,400,Public Data Analysis,0.17,0.75,0.0,0.0,0.08,0.0,0.0,0.0,ronald chrestman,
+PADM,8410,401,Public Data Analysis,0.33,0.56,0.0,0.0,0.0,0.0,0.0,0.11,ronald chrestman,
+PADM,8500,400,Homeland Security Fundamentals,0.44,0.22,0.0,0.0,0.11,0.0,0.0,0.22,david leigh cook,
+PADM,8650,400,Leadership in the Nonprft Sect,0.67,0.0,0.0,0.0,0.11,0.0,0.0,0.22,renee salic nichols,
+PES,2020,1,Soils,0.27,0.35,0.27,0.06,0.04,0.0,0.0,0.0,dara michelle park,
+PES,4330,1,Landscape & Turf Weed Mgt,0.14,0.64,0.14,0.0,0.0,0.0,0.0,0.07,ted whitwell,
+PES,4520,1,Soil Fertility and Management,0.29,0.57,0.0,0.0,0.07,0.0,0.0,0.07,haibo liu,
+PES,6520,1,Soil Fertility and Management,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,haibo liu,
+PHIL,1010,1,Intro to Phil Prob,0.5,0.26,0.15,0.0,0.03,0.0,0.0,0.06,christopher grau,
+PHIL,1010,2,Intro to Phil Prob,0.57,0.23,0.11,0.0,0.06,0.0,0.0,0.03,david stegall,
+PHIL,1010,3,Intro to Phil Prob,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.03,david stegall,
+PHIL,1020,1,Intro to Logic,0.58,0.17,0.06,0.17,0.0,0.0,0.0,0.03,michael hal hannen,
+PHIL,1020,2,Intro to Logic,0.83,0.09,0.0,0.09,0.0,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,3,Intro to Logic,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.03,gregory scott moss,
+PHIL,1020,4,Intro to Logic,0.63,0.29,0.06,0.03,0.0,0.0,0.0,0.0,gregory scott moss,
+PHIL,1020,5,Intro to Logic,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,gregory scott moss,
+PHIL,1020,6,Intro to Logic,0.57,0.37,0.03,0.03,0.0,0.0,0.0,0.0,kelly smith,
+PHIL,1030,1,Intro to Ethics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,True
+PHIL,1030,2,Intro to Ethics,0.59,0.35,0.0,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
+PHIL,1030,3,Intro to Ethics,0.65,0.29,0.03,0.0,0.0,0.0,0.0,0.03,ryan lake,
+PHIL,1030,4,Intro to Ethics,0.46,0.4,0.09,0.0,0.03,0.0,0.0,0.03,ryan lake,
+PHIL,1030,5,Intro to Ethics,0.35,0.56,0.06,0.0,0.0,0.0,0.0,0.03,ryan lake,
+PHIL,1030,6,Intro to Ethics,0.44,0.35,0.15,0.0,0.03,0.0,0.0,0.03,stephen satris,
+PHIL,3030,1,Phil of Religion,0.34,0.57,0.03,0.0,0.0,0.0,0.0,0.06,gregory scott moss,
+PHIL,3140,1,Comp East West Phil,0.32,0.26,0.26,0.0,0.05,0.0,0.0,0.11,yanming an,
+PHIL,3150,1,Ancient Philosophy,0.28,0.31,0.21,0.03,0.03,0.0,0.0,0.14,jennifer ingle,
+PHIL,3160,1,Mod Phil,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,michael hal hannen,
+PHIL,3260,1,Science and Values,0.4,0.49,0.0,0.0,0.06,0.0,0.0,0.06,andrew garnar,
+PHIL,3260,2,Science and Values,0.4,0.51,0.03,0.03,0.0,0.0,0.0,0.03,andrew garnar,
+PHIL,3260,3,Science and Values,0.46,0.43,0.09,0.0,0.0,0.0,0.0,0.03,andrew garnar,
+PHIL,3330,1,Metaphysics,0.91,0.04,0.0,0.0,0.04,0.0,0.0,0.0,david stegall,
+PHIL,3430,1,Phil of Law,0.82,0.12,0.0,0.0,0.03,0.0,0.0,0.03,david stegall,
+PHIL,3440,1,Business Ethics,0.13,0.56,0.18,0.03,0.0,0.0,0.0,0.1,diane perpich,
+PHIL,3450,1,Environmental Ethics,0.39,0.5,0.08,0.0,0.03,0.0,0.0,0.0,jennifer ingle,
+PHIL,3510,1,Phil of Emotion,0.21,0.39,0.21,0.04,0.04,0.0,0.0,0.11,charles starkey,
+PHIL,3550,1,Phil Mind & Cog Sci,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,ryan lake,
+PHSC,1170,1,Intro Chem & Earth,0.82,0.17,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics With Cal I,0.16,0.38,0.24,0.08,0.1,0.0,0.0,0.04,lih-sin the,
+PHYS,1220,2,Physics With Cal I,0.24,0.4,0.24,0.05,0.02,0.0,0.0,0.03,lih-sin the,
+PHYS,1220,3,Physics With Cal I,0.28,0.41,0.21,0.05,0.02,0.0,0.0,0.03,lih-sin the,
+PHYS,1220,4,Physics With Cal I,0.34,0.35,0.18,0.05,0.03,0.0,0.0,0.05,ramakrishna podila,
+PHYS,1220,5,Physics With Cal I,0.21,0.42,0.27,0.05,0.03,0.0,0.0,0.02,mark leising,
+PHYS,1220,8,Physics With Cal I (HON),0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,joan marler,True
+PHYS,1240,1,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,2,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,3,Physics Lab I,0.18,0.71,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
+PHYS,1240,4,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,5,Physics Lab I,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,6,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,7,Physics Lab I,0.4,0.53,0.0,0.07,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,8,Physics Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,
+PHYS,1240,9,Physics Lab I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,10,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,11,Physics Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,12,Physics Lab I,0.17,0.72,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,13,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,14,Physics Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,15,Physics Lab I,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,16,Physics Lab I,0.06,0.89,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,17,Physics Lab I,0.22,0.67,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,18,Physics Lab I,0.17,0.61,0.11,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,19,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,20,Physics Lab I,0.33,0.44,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,21,Physics Lab I,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,22,Physics Lab I,0.44,0.31,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,
+PHYS,1240,23,Physics Lab I,0.41,0.47,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,
+PHYS,1240,24,Physics Lab I,0.28,0.61,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,25,Physics Lab I,0.31,0.44,0.19,0.0,0.06,0.0,0.0,0.0,jerry hester,
+PHYS,1240,26,Physics Lab I,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,27,Physics Lab I,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,28,Physics Lab I,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jerry hester,
+PHYS,1240,29,Physics Lab I,0.12,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2000,1,Introductory Physics,0.46,0.39,0.07,0.07,0.0,0.0,0.0,0.02,sean brittain,
+PHYS,2070,1,General Physics I,0.36,0.36,0.15,0.08,0.03,0.0,0.0,0.03,pooja puneet,
+PHYS,2080,1,General Physics II,0.46,0.35,0.11,0.03,0.02,0.0,0.0,0.02,amy liann pope,
+PHYS,2080,2,General Physics II,0.64,0.29,0.04,0.01,0.0,0.0,0.0,0.01,amy liann pope,
+PHYS,2090,1,Gen Phys Lab I,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,2,Gen Phys Lab I,0.36,0.5,0.05,0.0,0.05,0.0,0.0,0.05,jerry hester,
+PHYS,2090,3,Gen Phys Lab I,0.7,0.13,0.09,0.0,0.04,0.0,0.0,0.04,jerry hester,
+PHYS,2090,4,Gen Phys Lab I,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,5,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,
+PHYS,2090,6,Gen Phys Lab I,0.17,0.75,0.0,0.0,0.04,0.0,0.0,0.04,jerry hester,
+PHYS,2090,7,Gen Phys Lab I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,8,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,9,Gen Phys Lab I,0.5,0.29,0.13,0.08,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,10,Gen Phys Lab I,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,1,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,2,Gen Phys Lab II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,3,Gen Phys Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,4,Gen Phys Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,5,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,6,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,7,Gen Phys Lab II,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,8,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,9,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,10,Gen Phys Lab II,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,11,Gen Phys Lab II,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,12,Gen Phys Lab II,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,13,Gen Phys Lab II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,14,Gen Phys Lab II,0.14,0.55,0.14,0.0,0.05,0.0,0.0,0.14,jerry hester,
+PHYS,2100,15,Gen Phys Lab II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,16,Gen Phys Lab II,0.1,0.5,0.3,0.05,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2100,17,Gen Phys Lab II,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,jerry hester,
+PHYS,2210,1,Physics With Cal II,0.32,0.34,0.21,0.06,0.03,0.0,0.0,0.03,jason stratfo brown,
+PHYS,2210,2,Physics With Cal II,0.22,0.38,0.2,0.08,0.08,0.0,0.0,0.03,jason stratfo brown,
+PHYS,2210,3,Physics With Cal II,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,murray daw,
+PHYS,2220,1,Phys With Cal III,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,jian he,
+PHYS,2230,1,Physics Lab II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,2,Physics Lab II,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,3,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,4,Physics Lab II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,5,Physics Lab II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,6,Physics Lab II,0.36,0.5,0.0,0.0,0.07,0.0,0.0,0.07,jerry hester,
+PHYS,2230,7,Physics Lab II,0.25,0.63,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,8,Physics Lab II,0.18,0.71,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,9,Physics Lab II,0.25,0.5,0.17,0.08,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2240,1,Physics Lab III,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2400,1,Phys of Weather,0.3,0.3,0.18,0.05,0.05,0.0,0.0,0.13,miguel larsen,
+PHYS,3110,1,Methods Theor Phys,0.64,0.09,0.0,0.18,0.09,0.0,0.0,0.0,hye jung kang,
+PHYS,3260,1,Exper Physics II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,chad sosolik,
+PHYS,3560,1,Modern Physics,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,chad sosolik,
+PHYS,4560,1,Quantum Physics II,0.0,0.5,0.5,0.0,0.0,0.0,0.0,0.0,antony valentini,
+PHYS,4650,1,Thermo and Stat Mech,0.21,0.36,0.14,0.21,0.0,0.0,0.0,0.07,jens oberheide,
+PHYS,8150,1,Statistical Therm I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
+PHYS,8410,1,Electrodynamics I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+PHYS,9520,1,Quantum Mech II,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
+PKSC,1020,1,Intro to Pkg Sci,0.14,0.39,0.31,0.07,0.06,0.0,0.0,0.03,heather batt,
+PKSC,2010,1,Pkg Perishable Prod,0.15,0.42,0.23,0.12,0.07,0.0,0.0,0.01,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.81,0.03,0.1,0.0,0.06,0.0,0.0,0.0,robert truett moore,
+PKSC,2040,1,Container Systems,0.74,0.19,0.07,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2060,1,Container Sys Lab,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2060,2,Container Sys Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2060,3,Container Sys Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2200,1,Product & Pkg Design,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,william aaro snyder,
+PKSC,3200,1,Pkg Design Theory,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,rupert hurley,
+PKSC,3680,1,Pkg and Society,0.41,0.38,0.15,0.03,0.03,0.0,0.0,0.0,heather batt,
+PKSC,4030,1,Pkg Career Prep,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4200,1,Pkg Design & Dev,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4300,1,Converting Flex Pkg,0.32,0.53,0.12,0.02,0.0,0.0,0.0,0.02,duncan darby,
+PKSC,4400,1,Packaging for Distribution,0.31,0.46,0.19,0.04,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1,Fd & Hc Pkg Systems,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,kay cooksey,
+PKSC,8510,1,Pkg Sci Seminar,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,anthony lou pometto,
+PLPA,2130,1,Fungi & Civilization,0.45,0.3,0.18,0.01,0.01,0.0,0.0,0.05,julia loui kerrigan,
+PLPA,8090,1,Analytical Technique,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,tharayil-santhakumar,
+POSC,1010,1,Amer National Govt,0.23,0.49,0.1,0.03,0.05,0.0,0.0,0.1,joseph earl stewart,
+POSC,1010,2,Amer National Govt,0.08,0.28,0.31,0.15,0.13,0.0,0.0,0.05,adam warber,
+POSC,1020,1,Intro Intl Relations,0.08,0.47,0.38,0.06,0.0,0.0,0.0,0.0,aron geo tannenbaum,
+POSC,1020,2,Intro Intl Relations,0.14,0.39,0.31,0.06,0.06,0.0,0.0,0.04,zeynep taydas,
+POSC,1020,3,Intro Intl Relations,0.25,0.48,0.19,0.01,0.04,0.0,0.0,0.03,lydia loui lundgren,
+POSC,1030,1,Intro to Political Theory,0.27,0.3,0.27,0.08,0.05,0.0,0.0,0.03,brandon turner,
+POSC,1040,1,Intro Compar Pol,0.11,0.45,0.23,0.14,0.0,0.0,0.0,0.07,colin pearce,
+POSC,1040,2,Intro Compar Pol,0.29,0.5,0.1,0.02,0.02,0.0,0.0,0.06,katherine am curtis,
+POSC,1990,1,Intro Pol Sci,0.42,0.21,0.25,0.06,0.04,0.0,0.0,0.02,meredith petersheim,
+POSC,3020,1,State and Loc Gov,0.1,0.51,0.27,0.02,0.05,0.0,0.0,0.05,bruce ransom,
+POSC,3210,1,Public Admin,0.1,0.38,0.43,0.02,0.07,0.0,0.0,0.0,james woodard,
+POSC,3610,1,Intl Pol in Crisis,0.47,0.37,0.1,0.0,0.03,0.0,0.0,0.03,vladimir matic,
+POSC,3610,2,Intl Pol in Crisis,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,jeremy fortier,
+POSC,3630,1,Us Foreign Policy,0.26,0.35,0.24,0.03,0.12,0.0,0.0,0.0,steven vince miller,
+POSC,3710,1,European Politics,0.29,0.5,0.19,0.02,0.0,0.0,0.0,0.0,katherine am curtis,
+POSC,3750,1,European Integration,0.08,0.23,0.46,0.0,0.08,0.0,0.0,0.15,zeynep taydas,
+POSC,3890,1,Rel. Liberty & Constitution,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,
+POSC,4030,1,United States Congress,0.32,0.52,0.08,0.0,0.04,0.0,0.0,0.04,jeffrey scott peake,
+POSC,4050,1,American Presidency,0.05,0.23,0.32,0.09,0.18,0.0,0.0,0.14,adam warber,
+POSC,4360,1,Law Courts Politics,0.79,0.08,0.04,0.0,0.04,0.0,0.0,0.04,joseph earl stewart,
+POSC,4370,1,Constitut Law: Rights & Libert,0.48,0.42,0.0,0.0,0.03,0.0,0.0,0.06,daniel frost,
+POSC,4490,1,Political Theory of Capitalism,0.23,0.3,0.23,0.07,0.07,0.0,0.0,0.1,brandon turner,
+POSC,4530,1,American Political Thought,0.22,0.56,0.17,0.03,0.03,0.0,0.0,0.0, bradley thompson,
+POSC,4540,1,Southern Politics,0.07,0.47,0.4,0.0,0.07,0.0,0.0,0.0,james woodard,
+POSC,4570,1,Political Terrorism,0.37,0.44,0.15,0.02,0.0,0.0,0.0,0.02,aron geo tannenbaum,
+POSC,4760,1,Middle East Politics,0.36,0.45,0.05,0.05,0.05,0.0,0.0,0.05,vladimir matic,
+POSC,4820,1,Political Novel and Film,0.13,0.39,0.39,0.04,0.0,0.0,0.0,0.04,james woodard,
+PRTM,2000,7,Prof & Prac in PRTM,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,brandon harris,
+PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,
+PRTM,2200,2,Foundations of PRTM,0.28,0.55,0.14,0.0,0.0,0.0,0.0,0.03,teresa walto tucker,
+PRTM,2200,3,Foundations of PRTM,0.47,0.37,0.07,0.07,0.0,0.0,0.0,0.03,gwynn powell,
+PRTM,2200,4,Foundations of PRTM,0.41,0.38,0.17,0.03,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2200,5,Foundations of PRTM,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,cindy hartman,
+PRTM,2200,6,Foundations of PRTM,0.72,0.12,0.12,0.04,0.0,0.0,0.0,0.0,katherine an jordan,
+PRTM,2200,7,Foundations of PRTM,0.62,0.28,0.03,0.07,0.0,0.0,0.0,0.0,brandon harris,
+PRTM,2410,1,Intro to CRSCM,0.25,0.52,0.2,0.03,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2600,1,Found of Recreational Therapy,0.87,0.07,0.02,0.0,0.04,0.0,0.0,0.0,anna-mar chancellor,
+PRTM,2650,1,Terminology in RT Practice,0.73,0.13,0.07,0.02,0.05,0.0,0.0,0.0,stephen thoma lewis,
+PRTM,2700,1,Intro Rec Res Mgt,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,lincoln larson,
+PRTM,2810,1,Intro to Golf Mgt,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,2820,1,Principle Golfer Dev,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,2830,1,Adv Mth Golf Teachng,0.5,0.25,0.08,0.17,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,2980,4,Creative Inquiry in PRTM II,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2980,7,Creative Inquiry in PRTM II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2980,8,Creative Inquiry in PRTM II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.4,0.31,0.17,0.06,0.06,0.0,0.0,0.0,daniel mor anderson,
+PRTM,3070,1,Facility Operations,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,craig goodman,
+PRTM,3250,1,Global Persp in Rec,0.08,0.7,0.15,0.03,0.03,0.0,0.0,0.03,teresa walto tucker,
+PRTM,3270,1,RT Impl & Eval: Ment Hlth Cond,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3420,1,Intro to Tourism,0.55,0.31,0.1,0.0,0.02,0.0,0.0,0.02,william norman,
+PRTM,3420,2,Intro to Tourism,0.56,0.31,0.03,0.0,0.03,0.0,0.0,0.06,maloud shakona,
+PRTM,3440,1,Tourism Markets,0.45,0.23,0.23,0.05,0.0,0.0,0.0,0.05,sheila backman,
+PRTM,3440,2,Tourism Markets,0.55,0.29,0.14,0.0,0.0,0.0,0.0,0.02,sheila backman,
+PRTM,3450,1,Tourism Management,0.81,0.1,0.06,0.0,0.0,0.0,0.0,0.03,lauren duffy,
+PRTM,3460,1,Heritage Tourism,0.47,0.38,0.09,0.02,0.0,0.0,0.0,0.04,gregory phi ramshaw,
+PRTM,3470,1,Sport Tourism,0.33,0.36,0.21,0.03,0.03,0.0,0.0,0.03,gregory phi ramshaw,
+PRTM,3530,1,Foundations of Camp Counseling,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,gwynn powell,
+PRTM,3550,1,Trends & Issues in Camp Mgt,0.64,0.14,0.14,0.0,0.0,0.0,0.0,0.07,teresa walto tucker,
+PRTM,3830,1,Golf Shop Operations,0.54,0.23,0.15,0.08,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,3910,2,Intro to GIS for PRTM,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,david lawrenc white,
+PRTM,4210,1,Rec Fin Resc Mgt,0.35,0.32,0.16,0.06,0.03,0.0,0.0,0.06,daniel mor anderson,
+PRTM,4260,1,Trends & Issues in Rec Therapy,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,4300,1,World Geog Parks,0.23,0.6,0.17,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
+PRTM,4310,1,Methods Envir Inter,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,4450,1,Conventions,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,jeffery martin,
+PRTM,4460,2,Community Tourism,0.19,0.63,0.15,0.0,0.0,0.0,0.0,0.04,herbert chancellor,
+PRTM,4470,1,Perspect Intl Travel,0.61,0.23,0.13,0.0,0.0,0.0,0.0,0.03,lauren duffy,
+PRTM,4510,1,Seminar in CRSCM,0.26,0.56,0.15,0.0,0.03,0.0,0.0,0.0,cindy hartman,
+PRTM,4540,1,Trends in Sport Mgt,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,
+PRTM,4550,1,Adv Program Planning,0.58,0.25,0.0,0.17,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,4980,2,Creative Inquiry in PRTM IV,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
+PRTM,4980,3,Creative Inquiry in PRTM IV,0.8,0.0,0.0,0.0,0.2,0.0,0.0,0.0,kellie aman walters,
+PRTM,4980,6,Creative Inquiry in PRTM IV,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,4980,8,Creative Inquiry in PRTM IV,0.5,0.1,0.4,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
+PRTM,8030,1,Sem Rec & Park Admin,0.63,0.21,0.0,0.0,0.13,0.0,0.0,0.04,skye arthur-banning,
+PRTM,8110,2,Research Methods,0.81,0.12,0.0,0.0,0.04,0.0,0.0,0.04,jeffrey charl hallo,
+PRTM,8210,1,Alt Funding for PRTM,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,8250,1,Populations in PRTM,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
+PRTM,8400,2,Tourism Planning,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,william norman,
+PSYC,2010,1,Intro to Psychology,0.31,0.31,0.2,0.08,0.05,0.0,0.0,0.06,jo anne jorgensen,
+PSYC,2010,2,Intro to Psychology,0.28,0.38,0.23,0.05,0.04,0.0,0.0,0.02,edwin brainerd,
+PSYC,2010,3,Intro to Psychology,0.39,0.24,0.23,0.06,0.04,0.0,0.0,0.04,mary taylor,
+PSYC,2010,4,Intro to Psychology,0.41,0.35,0.13,0.03,0.04,0.0,0.0,0.04,mary taylor,
+PSYC,2010,5,Intro to Psychology,0.3,0.44,0.1,0.06,0.06,0.0,0.0,0.04,fred switzer,
+PSYC,2010,20,Intro to Psychology (HON),0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,robin mari kowalski,True
+PSYC,2020,1,Intro Psychology Lab,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,eric mckibben,
+PSYC,2020,3,Intro Psychology Lab,0.84,0.12,0.0,0.0,0.04,0.0,0.0,0.0,eric mckibben,
+PSYC,2020,4,Intro Psychology Lab,0.86,0.0,0.1,0.0,0.05,0.0,0.0,0.0,eric mckibben,
+PSYC,2020,6,Intro Psychology Lab,0.82,0.05,0.0,0.0,0.09,0.0,0.0,0.05,lauren elizab ellis,
+PSYC,3060,1,Human Sexual Beh,0.62,0.19,0.11,0.04,0.03,0.0,0.0,0.01,bruce michael king,
+PSYC,3090,100,Intro Exp Psych,0.27,0.34,0.22,0.05,0.07,0.0,0.0,0.05,richard tyrrell,
+PSYC,3090,200,Intro Exp Psych,0.41,0.31,0.17,0.03,0.07,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3090,300,Intro Exp Psych,0.77,0.13,0.07,0.0,0.0,0.0,0.0,0.03,allison lei wallace,
+PSYC,3100,100,Advanced Experimental Psych,0.45,0.35,0.05,0.0,0.05,0.0,0.0,0.1,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3100,300,Advanced Experimental Psych,0.5,0.22,0.11,0.11,0.06,0.0,0.0,0.0,thomas britt,
+PSYC,3100,400,Advanced Experimental Psych,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,robert campbell,
+PSYC,3100,500,Advanced Experimental Psych,0.53,0.32,0.05,0.05,0.05,0.0,0.0,0.0,benjamin stephens,
+PSYC,3100,600,Advanced Experimental Psych,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3240,1,Physiological Psych,0.3,0.31,0.25,0.08,0.01,0.0,0.0,0.04,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.35,0.4,0.11,0.09,0.02,0.0,0.0,0.03,june pilcher,
+PSYC,3330,1,Cognitive Psych,0.77,0.14,0.05,0.04,0.0,0.0,0.0,0.0,paul steven merritt,
+PSYC,3330,2,Cognitive Psych,0.71,0.2,0.04,0.01,0.03,0.0,0.0,0.01,paul steven merritt,
+PSYC,3340,1,Cognitive Psych Lab,0.6,0.25,0.1,0.0,0.0,0.0,0.0,0.05,phillip weis jasper,
+PSYC,3340,2,Cognitive Psych Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,brian day,
+PSYC,3340,3,Cognitive Psych Lab,0.63,0.21,0.0,0.05,0.05,0.0,0.0,0.05,ashley ann sewall,
+PSYC,3400,1,Lifespan Developmental Psych,0.27,0.41,0.2,0.06,0.03,0.0,0.0,0.03,pamela alley,
+PSYC,3520,1,Social Psychology,0.38,0.35,0.13,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,
+PSYC,3520,2,Social Psychology,0.39,0.3,0.19,0.06,0.03,0.0,0.0,0.04,jo anne jorgensen,
+PSYC,3640,1,Industrial Psych,0.49,0.44,0.03,0.0,0.0,0.0,0.0,0.04,fred switzer,
+PSYC,3680,1,Organizational Psych,0.41,0.41,0.16,0.01,0.0,0.0,0.0,0.01,eric mckibben,
+PSYC,3680,2,Organizational Psych,0.46,0.39,0.14,0.0,0.01,0.0,0.0,0.0,eric mckibben,
+PSYC,3690,1,Leadership in Orgs,0.27,0.27,0.21,0.15,0.02,0.0,0.0,0.08,patrick raymark,
+PSYC,3700,1,Personality,0.49,0.24,0.13,0.1,0.03,0.0,0.0,0.01,william kramer,
+PSYC,3830,1,Abnormal Psychology,0.16,0.42,0.28,0.08,0.02,0.0,0.0,0.04,cynthia pury,
+PSYC,3830,2,Abnormal Psychology,0.14,0.43,0.2,0.06,0.14,0.0,0.0,0.03,pamela alley,
+PSYC,3830,3,Abnormal Psychology,0.31,0.4,0.11,0.09,0.09,0.0,0.0,0.0,pamela alley,
+PSYC,4080,1,Women and Psychology,0.64,0.2,0.08,0.0,0.0,0.0,0.0,0.08,robin mari kowalski,
+PSYC,4150,1,Systems and Theories,0.35,0.3,0.18,0.0,0.13,0.0,0.0,0.05,edwin brainerd,
+PSYC,4150,2,Systems and Theories,0.27,0.24,0.24,0.03,0.09,0.0,0.0,0.12,edwin brainerd,
+PSYC,4220,1,Perception,0.28,0.38,0.21,0.07,0.0,0.0,0.0,0.07,claudio cantalupo,
+PSYC,4220,2,Perception,0.25,0.21,0.36,0.18,0.0,0.0,0.0,0.0,christopher pagano,
+PSYC,4220,3,Perception,0.4,0.12,0.24,0.12,0.04,0.0,0.0,0.08,claudio cantalupo,
+PSYC,4430,1,Infant & Child Dev,0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,4430,2,Infant & Child Dev,0.33,0.37,0.19,0.07,0.04,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,4470,1,Moral Development,0.33,0.58,0.0,0.0,0.08,0.0,0.0,0.0,robert campbell,
+PSYC,4560,1,Psychophysiology,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,james nathan salley,
+PSYC,4800,1,Health Psychology,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,
+PSYC,4880,1,Psychotherapy,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,lucinda sorci quick,
+PSYC,4890,1,Science of Sleep,0.39,0.57,0.0,0.0,0.04,0.0,0.0,0.0,june pilcher,
+PSYC,4920,4,Senior Laboratory,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brooke bake allison,
+PSYC,4920,5,Senior Laboratory,0.68,0.14,0.0,0.05,0.09,0.0,0.0,0.05,jessica anne stahl,
+PSYC,4930,100,Pract Clinical Psych,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,heidi marie zinzow,
+PSYC,8110,1,Research Design II,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,patrick rosopa,
+PSYC,8130,1,Research Design III,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, dewayne moore,
+PSYC,8140,1,Quantitative Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06, dewayne moore,
+PSYC,8370,1,Ergonomics Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,
+PSYC,8820,1,Occupat Health Psy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,
+RED,8010,1,Market Analysis,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,john terrenc farris,
+RED,8120,1,Real Estate Technology,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,robert cre benedict,
+RED,8130,1,Strat in Real Estate,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,
+REL,1010,1,Intro to Religion,0.86,0.06,0.03,0.0,0.0,0.0,0.0,0.06,robert stephens,
+REL,1010,2,Intro to Religion,0.82,0.06,0.06,0.0,0.0,0.0,0.0,0.06,robert stephens,
+REL,1010,3,Intro to Religion,0.74,0.06,0.06,0.0,0.03,0.03,0.0,0.09,robert stephens,
+REL,1020,1,World Religions,0.2,0.37,0.29,0.09,0.0,0.0,0.0,0.06,peter cohen,
+REL,1020,2,World Religions,0.25,0.28,0.19,0.14,0.08,0.0,0.0,0.06,peter cohen,
+REL,1020,4,World Religions,0.24,0.48,0.09,0.06,0.09,0.0,0.0,0.03,peter cohen,
+REL,3000,1,Studying Religion,0.17,0.33,0.29,0.08,0.04,0.0,0.0,0.08,benjamin white,
+REL,3010,1,Old Testament,0.56,0.31,0.08,0.06,0.0,0.0,0.0,0.0,steven grosby,
+REL,3020,1,New Testament Lit,0.34,0.44,0.16,0.03,0.0,0.0,0.0,0.03,benjamin white,
+REL,3030,1,The Quran,0.29,0.57,0.05,0.0,0.1,0.0,0.0,0.0,mashal saif,
+REL,3060,1,Judaism,0.58,0.32,0.0,0.0,0.03,0.0,0.0,0.06,steven grosby,
+REL,3130,1,Buddhism,0.86,0.06,0.06,0.03,0.0,0.0,0.0,0.0,robert stephens,
+REL,3150,1,Islam,0.14,0.48,0.14,0.0,0.1,0.0,0.0,0.14,mashal saif,
+RS,3010,1,Rural Sociology,0.3,0.56,0.12,0.0,0.0,0.0,0.0,0.02,kenneth robinson,
+RS,4590,1,The Community,0.4,0.4,0.1,0.0,0.1,0.0,0.0,0.0,kenneth robinson,
+RUSS,1020,1,Elementary Russian,0.3,0.6,0.0,0.0,0.0,0.0,0.0,0.1,joan bridgwood,
+RUSS,3400,1,19th C Russ Culture,0.44,0.38,0.0,0.06,0.0,0.0,0.0,0.13,joan bridgwood,
+SOC,2010,2,Introduction to Sociology,0.42,0.33,0.23,0.0,0.0,0.0,0.0,0.02,mary louise barr,
+SOC,2010,3,Introduction to Sociology,0.45,0.39,0.16,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,4,Introduction to Sociology,0.43,0.26,0.26,0.0,0.0,0.0,0.0,0.04,mary louise barr,
+SOC,2010,5,Introduction to Sociology,0.37,0.38,0.25,0.0,0.0,0.0,0.0,0.0,mary louise barr,
+SOC,2010,6,Introduction to Sociology,0.3,0.37,0.3,0.0,0.02,0.0,0.0,0.0,mary louise barr,
+SOC,2010,7,Introduction to Sociology,0.51,0.35,0.12,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,8,Introduction to Sociology,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
+SOC,2010,9,Introduction to Sociology,0.66,0.27,0.05,0.0,0.0,0.0,0.0,0.01,jeffrey edwards,
+SOC,2020,1,Social Problems,0.61,0.22,0.0,0.11,0.0,0.0,0.0,0.06,stephani southworth,
+SOC,2020,2,Social Problems,0.36,0.4,0.13,0.04,0.04,0.0,0.0,0.02,stephani southworth,
+SOC,2050,1,Sociology Lab,0.52,0.14,0.05,0.1,0.1,0.0,0.0,0.1,brenda vander mey,
+SOC,3020,1,Research Methods I,0.28,0.2,0.36,0.08,0.08,0.0,0.0,0.0,andrew whitehead,
+SOC,3040,1,Social Research Methods II,0.14,0.52,0.28,0.0,0.03,0.0,0.0,0.03,ye luo,
+SOC,3100,1,Marriage & Intimacy,0.7,0.28,0.02,0.0,0.0,0.0,0.0,0.0,jeffrey edwards,
+SOC,3310,1,Urban Sociology,0.34,0.32,0.17,0.06,0.09,0.0,0.0,0.02,stephani southworth,
+SOC,3500,1,Self & Society,0.23,0.45,0.28,0.04,0.0,0.0,0.0,0.0,ellen granberg,
+SOC,3600,1,Class & Poverty,0.57,0.3,0.04,0.09,0.0,0.0,0.0,0.0,william haller,
+SOC,3800,1,Intro Social Service,0.43,0.43,0.11,0.02,0.0,0.0,0.0,0.02,jennifer le holland,
+SOC,3880,1,Criminal Justice,0.12,0.33,0.33,0.12,0.08,0.0,0.0,0.02,margaret tina britz,
+SOC,3890,1,Criminology,0.14,0.31,0.19,0.12,0.1,0.0,0.0,0.14,william white,
+SOC,3910,1,Soc of Deviance,0.3,0.35,0.26,0.05,0.02,0.0,0.0,0.02,stephani southworth,
+SOC,3920,1,Juvenile Delinquency,0.14,0.27,0.16,0.23,0.16,0.0,0.0,0.05,william white,
+SOC,3970,1,Substance Abuse,0.66,0.28,0.03,0.0,0.0,0.0,0.0,0.03,jeffrey edwards,
+SOC,4030,1,"Technol, Environment & Society",0.27,0.32,0.27,0.05,0.0,0.0,0.0,0.09, catherine mobley,
+SOC,4040,1,Soc Theory,0.49,0.29,0.11,0.09,0.03,0.0,0.0,0.0,william wentworth,
+SOC,4320,1,Soc of Religion,0.32,0.28,0.12,0.12,0.12,0.0,0.0,0.04,andrew whitehead,
+SOC,4440,1,Sociology of Educ,0.24,0.35,0.18,0.18,0.06,0.0,0.0,0.0,stephani southworth,
+SOC,4590,1,The Community,0.44,0.44,0.0,0.13,0.0,0.0,0.0,0.0,kenneth robinson,
+SOC,4600,1,Race & Ethnicity,0.38,0.21,0.24,0.1,0.03,0.0,0.0,0.03,brenda vander mey,
+SOC,4610,1,Sex & Gender,0.24,0.24,0.27,0.19,0.0,0.0,0.0,0.05,sarah evely winslow,
+SOC,4800,1,Medical Sociology,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,william wentworth,
+SOC,4840,1,Child Abuse,0.42,0.31,0.23,0.02,0.0,0.0,0.0,0.02,douglas sturkie,
+SOC,4860,5,Creative Inquiry in Sociology,0.5,0.28,0.17,0.0,0.06,0.0,0.0,0.0,margaret tina britz,
+SOC,4860,6,Creative Inquiry in Sociology,0.62,0.14,0.1,0.05,0.1,0.0,0.0,0.0,margaret tina britz,
+SOC,4930,1,Soc of Corrections,0.3,0.3,0.3,0.1,0.0,0.0,0.0,0.0,william white,
+SOC,4940,1,Organized Crimes,0.62,0.15,0.23,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
+SOC,4970,1,Senior Lab,0.53,0.18,0.12,0.12,0.06,0.0,0.0,0.0,brenda vander mey,
+SOC,4970,2,Senior Lab,0.48,0.28,0.08,0.04,0.12,0.0,0.0,0.0,brenda vander mey,
+SPAN,1010,1,Elementary Spanish,0.35,0.35,0.29,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,1010,2,Elementary Spanish,0.44,0.17,0.33,0.0,0.06,0.0,0.0,0.0,heidi montes,
+SPAN,1020,1,Elementary Spanish,0.17,0.17,0.22,0.06,0.28,0.0,0.0,0.11,roger simpson,
+SPAN,1020,2,Elementary Spanish,0.21,0.26,0.16,0.21,0.0,0.0,0.0,0.16,roger simpson,
+SPAN,1020,3,Elementary Spanish,0.47,0.24,0.18,0.0,0.0,0.0,0.0,0.12,roger simpson,
+SPAN,1020,4,Elementary Spanish,0.26,0.32,0.26,0.0,0.05,0.0,0.0,0.11,roger simpson,
+SPAN,1020,5,Elementary Spanish,0.15,0.25,0.2,0.15,0.15,0.0,0.0,0.1,roger simpson,
+SPAN,1020,6,Elementary Spanish,0.5,0.17,0.22,0.06,0.0,0.0,0.0,0.06,cathy robison,
+SPAN,1020,7,Elementary Spanish,0.44,0.22,0.11,0.11,0.06,0.0,0.0,0.06,cathy robison,
+SPAN,1020,8,Elementary Spanish,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,melva margu persico,
+SPAN,1020,9,Elementary Spanish,0.11,0.16,0.42,0.26,0.0,0.0,0.0,0.05,melva margu persico,
+SPAN,1020,10,Elementary Spanish,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,kari daus carson,
+SPAN,1020,11,Elementary Spanish,0.47,0.18,0.29,0.06,0.0,0.0,0.0,0.0,kari daus carson,
+SPAN,2010,1,Intermediate Spanish,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,2,Intermediate Spanish,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,cathy robison,
+SPAN,2010,3,Intermediate Spanish,0.28,0.67,0.0,0.0,0.06,0.0,0.0,0.0,maureen zamora,
+SPAN,2010,4,Intermediate Spanish,0.39,0.44,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,
+SPAN,2010,5,Intermediate Spanish,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,ricardo tremolada,
+SPAN,2010,6,Intermediate Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,ricardo tremolada,
+SPAN,2010,7,Intermediate Spanish,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,ricardo tremolada,
+SPAN,2010,8,Intermediate Spanish,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,9,Intermediate Spanish,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2010,10,Intermediate Spanish,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,ellory schmucker,
+SPAN,2010,11,Intermediate Spanish,0.72,0.11,0.17,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,2010,12,Intermediate Spanish,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,2010,13,Intermediate Spanish,0.29,0.59,0.0,0.06,0.0,0.0,0.0,0.06,juana martin-armas,
+SPAN,2010,14,Intermediate Spanish,0.27,0.41,0.09,0.09,0.09,0.0,0.0,0.05,allison ann hinds,
+SPAN,2010,15,Intermediate Spanish,0.28,0.28,0.06,0.11,0.17,0.0,0.0,0.11,ricardo tremolada,
+SPAN,2020,1,Intermediate Spanish,0.1,0.48,0.29,0.05,0.05,0.0,0.0,0.05,melva margu persico,
+SPAN,2020,2,Intermediate Spanish,0.35,0.35,0.25,0.05,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,2020,3,Intermediate Spanish,0.35,0.45,0.15,0.0,0.05,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,4,Intermediate Spanish,0.2,0.35,0.25,0.1,0.05,0.0,0.0,0.05,juana martin-armas,
+SPAN,2020,5,Intermediate Spanish,0.3,0.35,0.2,0.0,0.05,0.0,0.0,0.1,juana martin-armas,
+SPAN,2020,6,Intermediate Spanish,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,ze cruz valderramos,
+SPAN,2020,7,Intermediate Spanish,0.41,0.36,0.05,0.14,0.0,0.0,0.0,0.05,allison ann hinds,
+SPAN,2020,8,Intermediate Spanish,0.32,0.32,0.32,0.0,0.0,0.0,0.0,0.05,allison ann hinds,
+SPAN,2020,9,Intermediate Spanish,0.2,0.5,0.15,0.15,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,10,Intermediate Spanish,0.55,0.1,0.2,0.15,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,11,Intermediate Spanish,0.38,0.38,0.14,0.05,0.0,0.0,0.0,0.05,ellory schmucker,
+SPAN,2020,12,Intermediate Spanish,0.23,0.27,0.45,0.05,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,3020,1,Int Spn Gram & Comp,0.47,0.37,0.0,0.05,0.0,0.0,0.0,0.11,george palacios,
+SPAN,3020,2,Int Spn Gram & Comp,0.57,0.38,0.0,0.05,0.0,0.0,0.0,0.0,george palacios,
+SPAN,3040,1,Intro Hisp Lit Forms,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,george palacios,
+SPAN,3050,4,Int Con Comp Span I,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,filiberto hernandez,
+SPAN,3060,1,Span Comp for Bus,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,3070,1,Hispanic World: Sp,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,
+SPAN,3070,2,Hispanic World: Sp,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,
+SPAN,3080,1,Hispanic World: La,0.15,0.45,0.25,0.05,0.05,0.0,0.0,0.05,tiffany dawn miller,
+SPAN,3160,1,Span for Intl Trade,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,4060,1,Narrative Fiction,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,salvador oropesa,
+SPAN,4150,1,Span for Health Prof,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,4200,1,Hispanic Drama,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,tiffany dawn miller,
+STAT,2220,1,Statistics in Everyday Life,0.39,0.2,0.17,0.15,0.09,0.0,0.0,0.0,ros martinez-dawson,
+STAT,2220,2,Statistics in Everyday Life,0.46,0.26,0.19,0.06,0.0,0.0,0.0,0.04,ros martinez-dawson,
+STAT,2220,3,Statistics in Everyday Life,0.43,0.39,0.15,0.04,0.0,0.0,0.0,0.0,james espey,
+STAT,2220,4,Statistics in Everyday Life,0.35,0.48,0.13,0.04,0.0,0.0,0.0,0.0,april thomas,
+STAT,2220,5,Statistics in Everyday Life,0.31,0.42,0.16,0.07,0.0,0.0,0.0,0.04,emily marie nystrom,
+STAT,2300,1,Statistical Methods I,0.37,0.31,0.15,0.09,0.06,0.0,0.0,0.01,christy jenki brown,
+STAT,2300,2,Statistical Methods I,0.33,0.35,0.14,0.04,0.14,0.0,0.0,0.01,benjamin sharp,
+STAT,2300,3,Statistical Methods I,0.46,0.25,0.16,0.09,0.04,0.0,0.0,0.0,christy jenki brown,
+STAT,2300,4,Statistical Methods I,0.3,0.35,0.18,0.13,0.03,0.0,0.0,0.03,marion hanna,
+STAT,2300,5,Statistical Methods I,0.28,0.37,0.22,0.05,0.06,0.0,0.0,0.03, erwin walker,
+STAT,2300,6,Statistical Methods I,0.23,0.43,0.14,0.11,0.09,0.0,0.0,0.01, erwin walker,
+STAT,2300,7,Statistical Methods I,0.48,0.34,0.11,0.05,0.0,0.0,0.0,0.01,christy jenki brown,
+STAT,2300,8,Statistical Methods I,0.44,0.27,0.18,0.03,0.08,0.0,0.0,0.01,marion hanna,
+STAT,3090,1,Introductory Business Stats,0.08,0.25,0.33,0.11,0.06,0.0,0.0,0.17,paul james cubre,
+STAT,3090,2,Introductory Business Stats,0.15,0.26,0.21,0.1,0.18,0.0,0.0,0.1,janie caro mcdonald,
+STAT,3090,3,Introductory Business Stats,0.31,0.18,0.36,0.08,0.08,0.0,0.0,0.0,gary fellers,
+STAT,3090,4,Introductory Business Stats,0.34,0.2,0.37,0.03,0.03,0.0,0.0,0.03,ellen hepfe breazel,
+STAT,3090,5,Introductory Business Stats,0.23,0.34,0.2,0.06,0.17,0.0,0.0,0.0,ellen hepfe breazel,
+STAT,3090,6,Introductory Business Stats,0.38,0.28,0.13,0.15,0.03,0.0,0.0,0.05,lucas waddell,
+STAT,3090,7,Introductory Business Stats,0.28,0.38,0.18,0.13,0.0,0.0,0.0,0.05,gary fellers,
+STAT,3090,8,Introductory Business Stats,0.11,0.24,0.32,0.13,0.13,0.0,0.0,0.08,tao yang,
+STAT,3090,9,Introductory Business Stats,0.05,0.23,0.28,0.13,0.18,0.0,0.0,0.13,ziwen cheng,
+STAT,3090,10,Introductory Business Stats,0.21,0.33,0.31,0.0,0.1,0.0,0.0,0.05,gary fellers,
+STAT,3090,11,Introductory Business Stats,0.1,0.45,0.3,0.05,0.03,0.0,0.0,0.08,gary fellers,
+STAT,3090,12,Introductory Business Stats,0.09,0.46,0.23,0.14,0.03,0.0,0.0,0.06,laura jane shick,
+STAT,3300,1,Statistical Methods II,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,ros martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.45,0.27,0.09,0.0,0.0,0.09,0.0,0.09,julia lynn sharp,
+STAT,4110,1,Stat Mthds for Process Control,0.26,0.32,0.26,0.1,0.06,0.0,0.0,0.0,james rieck,
+STAT,4110,2,Stat Mthds for Process Control,0.36,0.32,0.14,0.07,0.11,0.0,0.0,0.0,william bridges,
+STAT,8010,1,Statistical Methods I,0.43,0.27,0.1,0.0,0.17,0.0,0.0,0.03,james rieck,
+STAT,8010,2,Statistical Methods I,0.41,0.44,0.12,0.0,0.0,0.0,0.0,0.03,patrick gerard,
+STAT,8010,3,Statistical Methods I,0.69,0.16,0.09,0.0,0.0,0.0,0.0,0.06,jun luo,
+STAT,8040,1,Sampling,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+STAT,8050,1,Design & Anlys of Experiments,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,william bridges,
+STAT,8420,230,Intro to Statistical Methods,0.29,0.29,0.14,0.0,0.14,0.0,0.0,0.14,julia lynn sharp,
+STS,1010,1,Survey of S T S,0.42,0.33,0.24,0.0,0.0,0.0,0.0,0.0,thomas oberdan,
+STS,1010,2,Survey of S T S,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,scott brame,
+STS,1010,3,Survey of S T S,0.34,0.49,0.09,0.03,0.03,0.0,0.0,0.03,elizabeth stansell,
+STS,1010,4,Survey of S T S,0.5,0.31,0.14,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,
+STS,1010,5,Survey of S T S,0.12,0.36,0.15,0.06,0.0,0.0,0.0,0.3,david charles foltz,
+STS,1010,6,Survey of S T S,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,david stubblefield,
+STS,1010,7,Survey of S T S,0.76,0.16,0.05,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
+STS,1010,8,Survey of S T S,0.23,0.34,0.2,0.03,0.0,0.0,0.0,0.2,allison ann hinds,
+STS,1010,20,Survey of S T S,0.38,0.41,0.13,0.03,0.0,0.0,0.0,0.06,thomas oberdan,
+STS,2150,1,Crit Appr to Tech Revolutions,0.47,0.37,0.05,0.05,0.0,0.0,0.0,0.05,thomas oberdan,
+THEA,2100,1,Theatre Appreciation,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,richard st. peter,
+THEA,2100,2,Theatre Appreciation,0.91,0.06,0.0,0.0,0.03,0.0,0.0,0.0,kerrie kath seymour,
+THEA,2100,3,Theatre Appreciation,0.59,0.28,0.09,0.03,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,2100,4,Theatre Appreciation,0.63,0.28,0.09,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,2100,5,Theatre Appreciation,0.45,0.3,0.18,0.03,0.0,0.0,0.0,0.03,carol collins,
+THEA,2100,6,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,
+THEA,2100,7,Theatre Appreciation,0.53,0.34,0.06,0.0,0.03,0.0,0.0,0.03,jason adkins,
+THEA,2770,1,Prod Studies in Thea,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david hartmann,
+THEA,2790,1,Theatre Practicum,0.62,0.08,0.15,0.0,0.08,0.0,0.0,0.08,matthew leckenbusch,
+THEA,3160,1,Theatre History II,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,richard st. peter,
+THEA,3180,1,Afri-Amer Thea II,0.68,0.19,0.1,0.0,0.0,0.0,0.0,0.03,kendra lyne johnson,
+THEA,3470,1,Structure of Drama,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
+THEA,3740,1,Movement for Actors,0.69,0.15,0.08,0.0,0.08,0.0,0.0,0.0,kerrie kath seymour,
+WFB,3010,1,Wildlife Biology Lab,0.29,0.5,0.14,0.0,0.0,0.0,0.0,0.07,shari lyn rodriguez,
+WFB,3130,1,Conservation Biology,0.45,0.25,0.16,0.06,0.06,0.0,0.0,0.02,shari lyn rodriguez,
+WFB,3130,2,Conservation Biology,0.17,0.37,0.26,0.11,0.06,0.0,0.0,0.03,shari lyn rodriguez,
+WFB,3500,1,Prin Fish Wildl Biol,0.21,0.51,0.21,0.05,0.02,0.0,0.0,0.0,james davis,
+WFB,3500,2,Prin Fish Wildl Biol,0.28,0.26,0.38,0.03,0.05,0.0,0.0,0.0,james davis,
+WFB,4160,1,Fishery Biology,0.36,0.36,0.17,0.09,0.0,0.0,0.0,0.02,yoichiro kanno,
+WFB,4300,1,Wildl Conserv Policy,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.04,joseph lanham,
+WFB,4400,1,Non-Game Wildl Mgmt,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,4620,1,Wetland Wildl Biol,0.45,0.38,0.12,0.05,0.0,0.0,0.0,0.0,russell barrett,
+WS,1030,1,Women Global Perspec,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,
+WS,2300,1,Women and Leadership,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,saadiqa kumanyika,
+WS,3010,1,Intro Women's Studies,0.76,0.14,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth ros adams,
+WS,3010,2,Intro Women's Studies,0.43,0.48,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth ros adams,
+YDP,3100,400,Youth Developmt and the Family,0.79,0.07,0.07,0.0,0.07,0.0,0.0,0.0,william quinn,

--- a/bot/cogs/grades_cog/assets/2016_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2016_Fall.csv
@@ -1,2784 +1,2784 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1010,1,Survey of Art & Arch History I,0.31,0.44,0.23,0.02,0.0,0.0,0.0,0.01,beth ann lauritis,AAH-1010,2016
-AAH,2050,1,Art History and Theory I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,beth ann lauritis,AAH-2050,2016
-ACCT,2010,1,Financial Accounting Concepts,0.03,0.25,0.35,0.15,0.08,0.0,0.0,0.15,philip maiberger,ACCT-2010,2016
-ACCT,2010,2,Financial Accounting Concepts,0.18,0.38,0.28,0.05,0.03,0.0,0.0,0.08,philip maiberger,ACCT-2010,2016
-ACCT,2010,3,Financial Accounting Concepts,0.24,0.44,0.2,0.04,0.04,0.0,0.0,0.04,lydia lan schleifer,ACCT-2010,2016
-ACCT,2010,4,Financial Accounting Concepts,0.2,0.33,0.2,0.1,0.08,0.0,0.0,0.1,annieka philo,ACCT-2010,2016
-ACCT,2010,5,Financial Accounting Concepts,0.24,0.43,0.2,0.06,0.04,0.0,0.0,0.02,lydia lan schleifer,ACCT-2010,2016
-ACCT,2010,6,Financial Accounting Concepts,0.12,0.52,0.21,0.03,0.09,0.0,0.0,0.03,the estate  guffey,ACCT-2010,2016
-ACCT,2010,7,Financial Accounting Concepts,0.26,0.36,0.16,0.08,0.04,0.0,0.0,0.1,annieka philo,ACCT-2010,2016
-ACCT,2010,9,Financial Accounting Concepts,0.32,0.15,0.23,0.04,0.11,0.0,0.0,0.15,lydia lan schleifer,ACCT-2010,2016
-ACCT,2010,10,Financial Accounting Concepts,0.17,0.26,0.26,0.13,0.11,0.0,0.0,0.07,lydia lan schleifer,ACCT-2010,2016
-ACCT,2010,11,Financial Accounting Concepts,0.13,0.33,0.29,0.06,0.1,0.0,0.0,0.08,annieka philo,ACCT-2010,2016
-ACCT,2010,12,Financial Accounting Concepts,0.07,0.29,0.29,0.09,0.16,0.0,0.0,0.11,annieka philo,ACCT-2010,2016
-ACCT,2010,13,Financial Accounting Concepts,0.09,0.33,0.24,0.04,0.04,0.0,0.0,0.24,mary ann  prater,ACCT-2010,2016
-ACCT,2010,14,Financial Accounting Concepts,0.19,0.19,0.14,0.07,0.12,0.0,0.0,0.29,mary ann  prater,ACCT-2010,2016
-ACCT,2010,15,Financial Accounting Concepts,0.15,0.33,0.11,0.19,0.15,0.0,0.0,0.07,charles tegen,ACCT-2010,2016
-ACCT,2010,100,Fin Accounting Concepts (HON),0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,the estate  guffey,ACCT-2010,2016
-ACCT,2010,101,Fin Accounting Concepts (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,ACCT-2010,2016
-ACCT,2010,400,Financial Accounting Concepts,0.23,0.35,0.16,0.05,0.1,0.0,0.0,0.11,jeffrey mcmillan,ACCT-2010,2016
-ACCT,2020,1,Managerial Accounting Concepts,0.15,0.27,0.33,0.12,0.06,0.0,0.0,0.06,henry anderson,ACCT-2020,2016
-ACCT,2020,2,Managerial Accounting Concepts,0.19,0.21,0.17,0.17,0.1,0.0,0.0,0.17,henry anderson,ACCT-2020,2016
-ACCT,2020,3,Managerial Accounting Concepts,0.44,0.24,0.2,0.06,0.03,0.0,0.0,0.03,sarah martin,ACCT-2020,2016
-ACCT,2020,4,Managerial Accounting Concepts,0.18,0.32,0.2,0.08,0.08,0.0,0.0,0.14,the estate  guffey,ACCT-2020,2016
-ACCT,2020,5,Managerial Accounting Concepts,0.1,0.45,0.19,0.06,0.1,0.0,0.0,0.1,brian todd carver,ACCT-2020,2016
-ACCT,2020,7,Managerial Accounting Concepts,0.23,0.42,0.23,0.07,0.02,0.0,0.0,0.02,derek dalton,ACCT-2020,2016
-ACCT,2020,8,Managerial Accounting Concepts,0.23,0.34,0.32,0.07,0.02,0.0,0.0,0.02,nancy lee harp,ACCT-2020,2016
-ACCT,2020,400,Managerial Accounting Concepts,0.12,0.24,0.25,0.1,0.06,0.0,0.0,0.24,henry anderson,ACCT-2020,2016
-ACCT,3030,1,Cost Accounting,0.35,0.4,0.17,0.04,0.04,0.0,0.0,0.0,robin radtke,ACCT-3030,2016
-ACCT,3030,2,Cost Accounting,0.4,0.36,0.14,0.05,0.02,0.0,0.0,0.02,robin radtke,ACCT-3030,2016
-ACCT,3030,3,Cost Accounting,0.44,0.23,0.17,0.02,0.06,0.0,0.0,0.08,jace garrett,ACCT-3030,2016
-ACCT,3030,4,Cost Accounting,0.31,0.31,0.12,0.12,0.0,0.0,0.0,0.15,jace garrett,ACCT-3030,2016
-ACCT,3110,1,Intermediate Financial Acct I,0.41,0.32,0.08,0.08,0.08,0.0,0.0,0.03,terry daniel knause,ACCT-3110,2016
-ACCT,3110,2,Intermediate Financial Acct I,0.41,0.24,0.15,0.05,0.02,0.0,0.0,0.12,terry daniel knause,ACCT-3110,2016
-ACCT,3110,3,Intermediate Financial Acct I,0.39,0.24,0.24,0.06,0.03,0.0,0.0,0.03,terry daniel knause,ACCT-3110,2016
-ACCT,3110,4,Intermediate Financial Acct I,0.31,0.45,0.21,0.02,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3110,2016
-ACCT,3110,5,Intermediate Financial Acct I,0.26,0.16,0.21,0.03,0.26,0.0,0.0,0.08,henry anderson,ACCT-3110,2016
-ACCT,3110,400,Intermediate Financial Acct I,0.16,0.24,0.12,0.04,0.28,0.0,0.0,0.16,henry anderson,ACCT-3110,2016
-ACCT,3120,1,Intermediate Financial Acct II,0.06,0.31,0.29,0.2,0.06,0.0,0.0,0.09,brian todd carver,ACCT-3120,2016
-ACCT,3120,2,Intermediate Financial Acct II,0.21,0.31,0.23,0.18,0.05,0.0,0.0,0.03,brian todd carver,ACCT-3120,2016
-ACCT,3120,3,Intermediate Financial Acct II,0.08,0.49,0.26,0.13,0.03,0.0,0.0,0.03,jeremy micha vinson,ACCT-3120,2016
-ACCT,3120,4,Intermediate Financial Acct II,0.35,0.28,0.23,0.1,0.05,0.0,0.0,0.0,jeremy micha vinson,ACCT-3120,2016
-ACCT,3120,5,Intermediate Financial Acct II,0.13,0.58,0.24,0.0,0.0,0.0,0.0,0.05,jeremy micha vinson,ACCT-3120,2016
-ACCT,3130,1,Intermediate Fin Acct III,0.31,0.47,0.14,0.0,0.06,0.0,0.0,0.03, russell madray,ACCT-3130,2016
-ACCT,3130,2,Intermediate Fin Acct III,0.63,0.21,0.12,0.02,0.0,0.0,0.0,0.02, russell madray,ACCT-3130,2016
-ACCT,3130,3,Intermediate Fin Acct III,0.52,0.33,0.12,0.0,0.02,0.0,0.0,0.0, russell madray,ACCT-3130,2016
-ACCT,3130,4,Intermediate Fin Acct III,0.56,0.34,0.05,0.0,0.05,0.0,0.0,0.0, russell madray,ACCT-3130,2016
-ACCT,3220,2,Accounting Information Systems,0.23,0.5,0.19,0.04,0.04,0.0,0.0,0.0,nancy lee harp,ACCT-3220,2016
-ACCT,3220,3,Accounting Information Systems,0.12,0.38,0.24,0.14,0.05,0.0,0.0,0.07,nancy lee harp,ACCT-3220,2016
-ACCT,4040,1,Individual Taxation,0.74,0.12,0.03,0.06,0.06,0.0,0.0,0.0,sarah martin,ACCT-4040,2016
-ACCT,4040,2,Individual Taxation,0.82,0.08,0.05,0.05,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2016
-ACCT,4040,3,Individual Taxation,0.21,0.44,0.26,0.05,0.0,0.0,0.0,0.05,derek dalton,ACCT-4040,2016
-ACCT,4080,1,Retire & Estate Plan,0.27,0.5,0.18,0.0,0.05,0.0,0.0,0.0,john hine,ACCT-4080,2016
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.31,0.44,0.21,0.03,0.03,0.0,0.0,0.0,sally kathr widener,ACCT-4100,2016
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.08,0.44,0.32,0.04,0.04,0.0,0.0,0.08,sally kathr widener,ACCT-4100,2016
-ACCT,4150,1,Auditing,0.52,0.28,0.2,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2016
-ACCT,4150,2,Auditing,0.06,0.44,0.38,0.06,0.0,0.0,0.0,0.06,carl hollingsworth,ACCT-4150,2016
-ACCT,8510,1,Tax Research,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2016
-ACCT,8510,2,Tax Research,0.22,0.68,0.08,0.0,0.0,0.0,0.0,0.03,thomas dickens,ACCT-8510,2016
-ACCT,8510,3,Tax Research,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2016
-ACCT,8530,1,Adv Acct Problems,0.56,0.38,0.03,0.0,0.0,0.0,0.0,0.03,ralph welton,ACCT-8530,2016
-ACCT,8530,2,Adv Acct Problems,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8530,2016
-ACCT,8530,3,Adv Acct Problems,0.62,0.32,0.03,0.0,0.03,0.0,0.0,0.0,suzanne pearse,ACCT-8530,2016
-ACCT,8550,1,Gov't and Nonprofit Accounting,0.6,0.37,0.04,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2016
-ACCT,8550,2,Gov't and Nonprofit Accounting,0.65,0.33,0.0,0.0,0.0,0.0,0.0,0.02,james barnes,ACCT-8550,2016
-ACCT,8630,1,Forensics Analysis,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,philip maiberger,ACCT-8630,2016
-ACCT,8630,2,Forensics Analysis,0.44,0.49,0.05,0.0,0.0,0.0,0.0,0.03,philip maiberger,ACCT-8630,2016
-ACCT,8650,1,Tax & Bus Decisions,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,ACCT-8650,2016
-ACCT,8720,1,Tax of Flowthroughs,0.17,0.43,0.33,0.0,0.07,0.0,0.0,0.0,thomas dickens,ACCT-8720,2016
-AGED,1020,1,Freshman Seminar,0.68,0.21,0.07,0.0,0.0,0.0,0.0,0.04,catheri dibenedetto,AGED-1020,2016
-AGED,2010,1,Intro to Agric Educ,0.43,0.24,0.24,0.05,0.05,0.0,0.0,0.0,philip fravel,AGED-2010,2016
-AGED,2040,1,App Ag Calculations,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2040,2016
-AGED,3030,1,Ag Ed Mech Tech,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-3030,2016
-AGED,3650,1,Multiculturalism in Agric Educ,0.9,0.03,0.03,0.0,0.03,0.0,0.0,0.0,alex byrd,AGED-3650,2016
-AGED,4030,1,Prin Adult/Ext Ed,0.77,0.09,0.14,0.0,0.0,0.0,0.0,0.0,kevin layfield,AGED-4030,2016
-AGM,1010,1,Intro Ag Mech & Bus,0.41,0.32,0.16,0.04,0.04,0.0,0.0,0.04,hunter massey,AGM-1010,2016
-AGM,2050,1,Prin of Fabrication,0.14,0.57,0.16,0.03,0.07,0.0,0.0,0.03,hunter massey,AGM-2050,2016
-AGM,2060,1,Machinery Mgt,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,hunter massey,AGM-2060,2016
-AGM,2190,1,Agribusiness and Food Systems,0.49,0.4,0.1,0.0,0.01,0.0,0.0,0.0,nicholas gra rogers,AGM-2190,2016
-AGM,2210,1,Land Measurements,0.17,0.32,0.33,0.14,0.03,0.0,0.0,0.01,charles privette,AGM-2210,2016
-AGM,3010,1,Soil Water Conserv,0.44,0.29,0.16,0.06,0.03,0.0,0.0,0.02,calvin sawyer,AGM-3010,2016
-AGM,3710,1,Agric Mechanization Practicum,0.0,0.0,0.0,0.0,0.0,0.89,0.05,0.05,hunter massey,AGM-3710,2016
-AGM,4000,1,Seminar in Ag Mech & Business,0.53,0.31,0.06,0.03,0.03,0.0,0.0,0.03,john chastain,AGM-4000,2016
-AGM,4050,1,Env Cont in Anim Str,0.14,0.46,0.3,0.1,0.0,0.0,0.0,0.0,john chastain,AGM-4050,2016
-AGM,4060,1,Mech & Hydraulic Sys,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4060,2016
-AGM,4520,1,Mobile Power,0.41,0.41,0.14,0.05,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4520,2016
-AGM,4600,1,Electrical Systems,0.45,0.36,0.13,0.06,0.0,0.0,0.0,0.0,young han,AGM-4600,2016
-AGM,4730,1,Peanut Harvesting Machinery,0.88,0.0,0.0,0.0,0.12,0.0,0.0,0.0,hunter massey,AGM-4730,2016
-AGRB,2020,1,Agricultural Economics,0.19,0.35,0.23,0.13,0.08,0.0,0.0,0.02,george apperson,AGRB-2020,2016
-AGRB,2020,2,Agricultural Economics,0.21,0.31,0.27,0.08,0.08,0.0,0.0,0.04,george apperson,AGRB-2020,2016
-AGRB,2050,1,Agriculture and Society,0.42,0.38,0.12,0.04,0.02,0.0,0.0,0.02,michael vassalos,AGRB-2050,2016
-AGRB,3020,1,Economics of Farm Management,0.28,0.35,0.27,0.09,0.0,0.0,0.0,0.01,michael vassalos,AGRB-3020,2016
-AGRB,3080,1,Quant Agribusiness Analysis I,0.19,0.23,0.32,0.19,0.03,0.0,0.0,0.03,lisha zhang,AGRB-3080,2016
-AGRB,3090,1,Econ of Agricultural Marketing,0.83,0.15,0.0,0.0,0.03,0.0,0.0,0.0,yuliya val bolotova,AGRB-3090,2016
-AGRB,3570,1,Natural Resources Economics,0.29,0.31,0.18,0.11,0.07,0.0,0.0,0.04,david brian willis,AGRB-3570,2016
-AGRB,4090,1,Commodity Futures Markets,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,AGRB-4090,2016
-AGRB,4120,1,Reg Econ Devel Theory & Policy,0.55,0.3,0.1,0.0,0.05,0.0,0.0,0.0,robert carey,AGRB-4120,2016
-AGRB,4600,1,Agricultural Finance,0.33,0.33,0.22,0.11,0.0,0.0,0.0,0.0,lisha zhang,AGRB-4600,2016
-AL,3490,400,Principles of Coaching,0.65,0.15,0.12,0.0,0.0,0.0,0.0,0.08,deborah cadorette,AL-3490,2016
-AL,3490,401,Principles of Coaching,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2016
-AL,3490,402,Principles of Coaching,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,julia wright,AL-3490,2016
-AL,3490,403,Principles of Coaching,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,clyde keith connor,AL-3490,2016
-AL,3490,404,Principles of Coaching,0.84,0.08,0.0,0.0,0.0,0.0,0.0,0.08,edmond fry,AL-3490,2016
-AL,3500,400,Sci Basis I/Ex Phy,0.33,0.08,0.33,0.13,0.04,0.0,0.0,0.08,michael godfrey,AL-3500,2016
-AL,3500,401,Sci Basis I/Ex Phy,0.13,0.3,0.22,0.13,0.13,0.0,0.0,0.09,michael godfrey,AL-3500,2016
-AL,3530,400,Athletic Injuries,0.23,0.27,0.32,0.14,0.0,0.0,0.0,0.05,isaac sean colbert,AL-3530,2016
-AL,3530,401,Athletic Injuries,0.16,0.32,0.37,0.11,0.05,0.0,0.0,0.0,isaac sean colbert,AL-3530,2016
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.42,0.25,0.25,0.08,0.0,0.0,0.0,0.0,clyde keith connor,AL-3600,2016
-AL,3610,400,Admin/Org of Athletic Programs,0.73,0.2,0.0,0.07,0.0,0.0,0.0,0.0,henry oates,AL-3610,2016
-AL,3610,401,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2016
-AL,3610,402,Admin/Org of Athletic Programs,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,henry oates,AL-3610,2016
-AL,3620,400,Psychology of Coaching,0.31,0.31,0.19,0.13,0.06,0.0,0.0,0.0,natalie anne carter,AL-3620,2016
-AL,3620,401,Psychology of Coaching,0.44,0.31,0.13,0.13,0.0,0.0,0.0,0.0,natalie anne carter,AL-3620,2016
-AL,3620,402,Psychology of Coaching,0.26,0.39,0.26,0.09,0.0,0.0,0.0,0.0,natalie anne carter,AL-3620,2016
-AL,3740,400,Coaching Football,0.58,0.21,0.04,0.04,0.08,0.0,0.0,0.04,edmond fry,AL-3740,2016
-AL,3760,400,Coaching Strength/Conditioning,0.61,0.22,0.13,0.04,0.0,0.0,0.0,0.0,edmond fry,AL-3760,2016
-AL,3760,401,Coaching Strength/Conditioning,0.5,0.3,0.1,0.0,0.05,0.0,0.0,0.05,edmond fry,AL-3760,2016
-AL,4380,400,Coaching Women,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,misty soles,AL-4380,2016
-AL,4380,402,Coaching the Inner Athlete,0.7,0.17,0.09,0.0,0.04,0.0,0.0,0.0,deborah cadorette,AL-4380,2016
-AL,8490,400,Athletic Leadership Dev,0.6,0.28,0.08,0.0,0.04,0.0,0.0,0.0,michael godfrey,AL-8490,2016
-AL,8490,401,Athletic Leadership Dev,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8490,2016
-AL,8500,400,Principles Strength and Condit,0.59,0.31,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8500,2016
-AL,8650,400,Mkt and Comm Respon Interc Ath,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,misty soles,AL-8650,2016
-ANTH,2010,1,Introduction to Anthropology,0.49,0.28,0.13,0.02,0.02,0.0,0.0,0.06,yi wu,ANTH-2010,2016
-ANTH,2010,2,Introduction to Anthropology,0.07,0.2,0.44,0.15,0.05,0.0,0.0,0.1,john coggeshall,ANTH-2010,2016
-ANTH,2010,3,Introduction to Anthropology,0.06,0.35,0.39,0.06,0.1,0.0,0.0,0.05,john coggeshall,ANTH-2010,2016
-ANTH,2010,4,Introduction to Anthropology,0.38,0.42,0.09,0.04,0.07,0.0,0.0,0.0,katherine weisensee,ANTH-2010,2016
-ANTH,2010,5,Introduction to Anthropology,0.44,0.42,0.08,0.02,0.02,0.0,0.0,0.02,lisa rapaport,ANTH-2010,2016
-ANTH,2010,6,Introduction to Anthropology,0.27,0.3,0.18,0.09,0.07,0.0,0.0,0.09,yi wu,ANTH-2010,2016
-ANTH,3010,1,Cultural Anthropology,0.09,0.41,0.18,0.14,0.05,0.0,0.0,0.14,john coggeshall,ANTH-3010,2016
-ANTH,3320,1,World Archaeology,0.17,0.3,0.22,0.17,0.0,0.0,0.0,0.13,melissa vogel,ANTH-3320,2016
-ANTH,3510,1,Biological Anthropology,0.5,0.33,0.06,0.0,0.06,0.0,0.0,0.06,lisa rapaport,ANTH-3510,2016
-ANTH,3530,1,Forensic Anthropology,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,katherine weisensee,ANTH-3530,2016
-ANTH,4230,1,Women in the Developing World,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,melissa vogel,ANTH-4230,2016
-ARCH,1010,1,Intro to Architecture,0.63,0.26,0.04,0.02,0.03,0.0,0.0,0.02,sal hambright-belue,ARCH-1010,2016
-ARCH,2040,1,Hist of Modern Arch,0.28,0.42,0.25,0.03,0.03,0.0,0.0,0.0,robert bruhns,ARCH-2040,2016
-ARCH,2510,1,Arch Foundations I,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-2510,2016
-ARCH,2510,2,Arch Foundations I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-2510,2016
-ARCH,2510,3,Arch Foundations I,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2510,2016
-ARCH,2510,4,Arch Foundations I,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,james barker,ARCH-2510,2016
-ARCH,2510,5,Arch Foundations I,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-2510,2016
-ARCH,2700,1,Structures I,0.36,0.41,0.18,0.0,0.05,0.0,0.0,0.0,dustin gra albright,ARCH-2700,2016
-ARCH,3500,1,Intro to Urban Contexts,0.08,0.62,0.31,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-3500,2016
-ARCH,3500,2,Intro to Urban Contexts,0.33,0.33,0.25,0.0,0.08,0.0,0.0,0.0,julie poe wilkerson,ARCH-3500,2016
-ARCH,3500,3,Intro to Urban Contexts,0.0,0.17,0.83,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-3500,2016
-ARCH,3500,4,Intro to Urban Contexts,0.17,0.42,0.42,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-3500,2016
-ARCH,4010,1,Architectural Portfolio SENIOR,0.67,0.19,0.05,0.0,0.05,0.0,0.0,0.05,clarissa mendez,ARCH-4010,2016
-ARCH,4010,2,Architectural Portfolio JUNIOR,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4010,2016
-ARCH,4010,3,Architectural Portfolio JUNIOR,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,maryam hamidpour,ARCH-4010,2016
-ARCH,6120,2,History Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-6120,2016
-ARCH,6990,9,Freehand Drawing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,ARCH-6990,2016
-ARCH,8100,1,Visualization I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-8100,2016
-ARCH,8210,1,Research Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-8210,2016
-ARCH,8410,1,Arch Studio I,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,peter laurence,ARCH-8410,2016
-ARCH,8410,2,Arch Studio I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,ARCH-8410,2016
-ARCH,8510,1,Design Studio III,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-8510,2016
-ARCH,8510,2,Design Studio III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-8510,2016
-ARCH,8510,3,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8510,2016
-ARCH,8600,1,History/Theory I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-8600,2016
-ARCH,8810,1,Pro Practice Survey,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,ARCH-8810,2016
-ARCH,8950,2,A+H Studio: Projects,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-8950,2016
-ART,1050,1,Foundation Drawing I,0.29,0.57,0.0,0.07,0.07,0.0,0.0,0.0,kathleen ann thum,ART-1050,2016
-ART,1510,1,Foundations Art I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kymberly ann day,ART-1510,2016
-ART,2070,1,Beginning Painting,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,todd mcdonald,ART-2070,2016
-ART,2100,400,Art Appreciation,0.61,0.29,0.04,0.07,0.0,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2016
-ART,2100,401,Art Appreciation,0.41,0.3,0.19,0.07,0.04,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2016
-ART,2100,402,Art Appreciation,0.48,0.45,0.07,0.0,0.0,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2016
-ART,2100,403,Art Appreciation,0.37,0.41,0.11,0.04,0.07,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2016
-AS,1090,1,Air Force Today I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,AS-1090,2016
-AS,1090,3,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher mann,AS-1090,2016
-AS,2090,2,Dev of Air Power I,0.6,0.27,0.07,0.07,0.0,0.0,0.0,0.0,christopher mann,AS-2090,2016
-AS,2090,3,Dev of Air Power I,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,christopher mann,AS-2090,2016
-ASL,1010,1,Am Sign Lang I,0.17,0.39,0.28,0.06,0.11,0.0,0.0,0.0,william alton brant,ASL-1010,2016
-ASL,1010,2,Am Sign Lang I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-1010,2016
-ASL,1010,3,Am Sign Lang I,0.28,0.39,0.11,0.11,0.0,0.0,0.0,0.11,michael alb barrett,ASL-1010,2016
-ASL,1010,4,Am Sign Lang I,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,michael alb barrett,ASL-1010,2016
-ASL,1020,1,Am Sign Lang I,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-1020,2016
-ASL,2010,1,Am Sign Lang II,0.28,0.39,0.22,0.11,0.0,0.0,0.0,0.0,michael alb barrett,ASL-2010,2016
-ASL,2010,2,Am Sign Lang II,0.13,0.19,0.38,0.31,0.0,0.0,0.0,0.0,michael alb barrett,ASL-2010,2016
-ASL,3010,1,Advanced A S L I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-3010,2016
-ASL,3150,1,Survey Interpreting,0.25,0.42,0.17,0.0,0.0,0.0,0.0,0.17,stephen fitzmaurice,ASL-3150,2016
-ASTR,1010,1,Solar System Astronomy,0.19,0.39,0.17,0.12,0.08,0.0,0.0,0.05,lih-sin the,ASTR-1010,2016
-ASTR,1010,2,Solar System Astronomy,0.28,0.36,0.19,0.04,0.06,0.0,0.0,0.07,lih-sin the,ASTR-1010,2016
-ASTR,1020,1,Stellar Astronomy,0.39,0.32,0.11,0.06,0.02,0.0,0.0,0.1,amber porter,ASTR-1020,2016
-ASTR,1030,1,Solar Systm Astr Lab,0.54,0.27,0.15,0.0,0.04,0.0,0.0,0.0,amber porter,ASTR-1030,2016
-ASTR,1030,2,Solar Systm Astr Lab,0.38,0.31,0.04,0.08,0.08,0.0,0.0,0.12,amber porter,ASTR-1030,2016
-ASTR,1030,4,Solar Systm Astr Lab,0.6,0.24,0.0,0.08,0.0,0.0,0.0,0.08,amber porter,ASTR-1030,2016
-ASTR,1030,5,Solar Systm Astr Lab,0.63,0.17,0.08,0.08,0.0,0.0,0.0,0.04,amber porter,ASTR-1030,2016
-ASTR,1030,6,Solar Systm Astr Lab,0.4,0.4,0.05,0.15,0.0,0.0,0.0,0.0,amber porter,ASTR-1030,2016
-ASTR,1030,7,Solar Systm Astr Lab,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,amber porter,ASTR-1030,2016
-ASTR,1030,8,Solar Systm Astr Lab,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,amber porter,ASTR-1030,2016
-ASTR,1030,9,Solar Systm Astr Lab,0.54,0.21,0.08,0.0,0.08,0.0,0.0,0.08,amber porter,ASTR-1030,2016
-ASTR,1030,10,Solar Systm Astr Lab,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,amber porter,ASTR-1030,2016
-ASTR,1040,1,Stellar Astr Lab,0.52,0.36,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,ASTR-1040,2016
-ASTR,1040,2,Stellar Astr Lab,0.14,0.52,0.05,0.0,0.14,0.0,0.0,0.14,amber porter,ASTR-1040,2016
-ASTR,1040,4,Stellar Astr Lab,0.46,0.42,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,ASTR-1040,2016
-AUD,1850,1,Intro to Audio Tech,0.18,0.73,0.09,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-1850,2016
-AUD,2800,1,Sound Reinforcement,0.09,0.36,0.45,0.0,0.09,0.0,0.0,0.0,kenneth moore,AUD-2800,2016
-AUE,8270,5,Auto Cntrl Sys Des,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8270,2016
-AUE,8280,1,Driveline/Powertrain,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8280,2016
-AUE,8330,30,Auto Manuf Proc Devl,0.47,0.51,0.03,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8330,2016
-AUE,8350,100,Auto Electronics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,AUE-8350,2016
-AUE,8670,1,Veh Manuf Proc I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8670,2016
-AUE,8800,2,Vehicle Project Mngt,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett,AUE-8800,2016
-AUE,8810,3,Automotive Systems Overview,0.37,0.6,0.02,0.0,0.01,0.0,0.0,0.0,david wil schmueser,AUE-8810,2016
-AUE,8830,9,Applied Integration,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8830,2016
-AUE,8870,8,Meth Vehicle Testing,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8870,2016
-AUE,8930,13,Engine Analysis,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8930,2016
-AUE,8930,14,Advanced Composites,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,AUE-8930,2016
-AUE,8930,16,Light-Weight Automotive Design,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,david wil schmueser,AUE-8930,2016
-AUE,8930,17,Hybrids,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,simona onori,AUE-8930,2016
-AUE,8930,18,Adv IC Engine Concept,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-8930,2016
-AUE,8930,78,Ground Vehicle Performance,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,AUE-8930,2016
-AUE,8930,100,Slide Mode Controls,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8930,2016
-AVS,1000,1,Orientation to AVS,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,AVS-1000,2016
-AVS,1500,1,Intro Animal Science,0.19,0.57,0.19,0.02,0.01,0.0,0.0,0.02,marie owens bolt,AVS-1500,2016
-AVS,1510,1,Intro Ani Sci Lab,0.65,0.23,0.04,0.0,0.0,0.0,0.0,0.08,richelle lor miller,AVS-1510,2016
-AVS,1510,2,Intro Ani Sci Lab,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-1510,2016
-AVS,1510,3,Intro Ani Sci Lab,0.6,0.32,0.0,0.0,0.0,0.0,0.0,0.08,richelle lor miller,AVS-1510,2016
-AVS,1510,4,Intro Ani Sci Lab,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,louisa elaine koch,AVS-1510,2016
-AVS,1510,5,Intro Ani Sci Lab,0.21,0.67,0.13,0.0,0.0,0.0,0.0,0.0,marie owens bolt,AVS-1510,2016
-AVS,1510,6,Intro Ani Sci Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-1510,2016
-AVS,1510,7,Intro Ani Sci Lab,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,brandon michae koch,AVS-1510,2016
-AVS,1510,8,Intro Ani Sci Lab,0.29,0.5,0.07,0.07,0.0,0.0,0.0,0.07,marie owens bolt,AVS-1510,2016
-AVS,2030,1,Dairy Sci Techniques,0.95,0.0,0.02,0.02,0.0,0.0,0.0,0.0,heather walker dunn,AVS-2030,2016
-AVS,2040,1,Horse Care Techniques,0.44,0.46,0.1,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-2040,2016
-AVS,2060,1,Swine Techniques,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-2060,2016
-AVS,3010,1,Anat & Phys Dom Ani,0.46,0.19,0.17,0.12,0.03,0.0,0.0,0.04,glenn birrenkott,AVS-3010,2016
-AVS,3010,400,Anat & Phys Dom Ani,0.46,0.27,0.15,0.12,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2016
-AVS,3020,1,Livestk Sel Eval I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-3020,2016
-AVS,3090,1,Equine Evaluation,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-3090,2016
-AVS,3100,1,Animal Health,0.68,0.22,0.07,0.01,0.01,0.0,0.0,0.0,thomas scott,AVS-3100,2016
-AVS,3700,1,Principles of Animal Nutrition,0.64,0.2,0.09,0.04,0.02,0.0,0.0,0.01,james ro strickland,AVS-3700,2016
-AVS,3750,1,Applied Animal Nutrition,0.19,0.42,0.25,0.11,0.0,0.0,0.0,0.03,gustavo jos lascano,AVS-3750,2016
-AVS,4000,1,AVS Professional Development,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,johanna joh lascano,AVS-4000,2016
-AVS,4000,2,AVS Professional Development,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,AVS-4000,2016
-AVS,4060,1,Seminars & Related Topics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2016
-AVS,4060,2,Seminars & Related Topics,0.41,0.52,0.03,0.0,0.0,0.0,0.0,0.03,jeryl jones,AVS-4060,2016
-AVS,4150,1,Contemporary Issues in AVS,0.06,0.39,0.38,0.08,0.05,0.0,0.0,0.05,peter skewes,AVS-4150,2016
-AVS,4160,1,Equine Exercise Phys,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-4160,2016
-AVS,4530,1,Animal Reproduction,0.48,0.34,0.11,0.05,0.02,0.0,0.0,0.0,tiffany wilmoth,AVS-4530,2016
-AVS,8200,1,Graduate Seminar,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,AVS-8200,2016
-BCHM,1030,1,Careers in Bioch/Gen,0.68,0.24,0.01,0.06,0.0,0.0,0.0,0.01,alison starr-moss,BCHM-1030,2016
-BCHM,3010,1,Molecular Biochem,0.26,0.49,0.2,0.0,0.0,0.0,0.0,0.06,kerry smith,BCHM-3010,2016
-BCHM,3050,1,Essen Elements Bioch,0.21,0.33,0.25,0.11,0.02,0.0,0.0,0.08,srik chandrasekaran,BCHM-3050,2016
-BCHM,3050,2,Essen Elements Bioch,0.28,0.35,0.22,0.07,0.03,0.0,0.0,0.05,srik chandrasekaran,BCHM-3050,2016
-BCHM,4310,1,Physical Approach to Biochem,0.11,0.55,0.28,0.02,0.04,0.0,0.0,0.0,weiguo cao,BCHM-4310,2016
-BCHM,4310,2,Phys App to Bioch (HON),0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4310,2016
-BCHM,4330,1,Physical Biochemistry Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4330,2016
-BCHM,4330,3,Physical Biochemistry Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,weiguo cao,BCHM-4330,2016
-BCHM,4330,4,Physical Biochemistry Lab,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4330,2016
-BCHM,4400,1,Bioinformatics,0.78,0.15,0.0,0.07,0.0,0.0,0.0,0.0,frank alexan feltus,BCHM-4400,2016
-BCHM,4430,1,Mol Basis Disease,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,james morris,BCHM-4430,2016
-BCHM,4900,7,C-MED,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,michael glen sehorn,BCHM-4900,2016
-BCHM,4930,1,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,BCHM-4930,2016
-BE,2120,1,Fundamentals of Biosys Engr,0.55,0.4,0.0,0.0,0.05,0.0,0.0,0.0,caye marie drapcho,BE-2120,2016
-BE,3200,1,Principles & Prac of Geomatics,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,tom owino,BE-3200,2016
-BE,4100,1,Biological Kinetics,0.38,0.29,0.33,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4100,2016
-BE,4210,1,Engr Sys Sw Mgmt,0.59,0.35,0.0,0.0,0.06,0.0,0.0,0.0,christophe darnault,BE-4210,2016
-BE,4280,1,Biochem Engr,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4280,2016
-BE,4740,1,B E Design/Proj Mgt,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,tom owino,BE-4740,2016
-BE,4750,1,B E Capstone Design,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4750,2016
-BIOE,1010,1,Biol for Bioengr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,vladimir vla reukov,BIOE-1010,2016
-BIOE,2010,1,Intro Biomed Engr,0.82,0.16,0.02,0.0,0.0,0.0,0.0,0.0,charles webb,BIOE-2010,2016
-BIOE,2010,2,Intro Biomed Engr,0.76,0.21,0.01,0.0,0.0,0.0,0.0,0.01,frank alexis,BIOE-2010,2016
-BIOE,3020,1,Biomaterials,0.57,0.23,0.04,0.02,0.06,0.0,0.0,0.09,alexey ale vertegel,BIOE-3020,2016
-BIOE,3200,1,Biomechanics,0.79,0.17,0.02,0.0,0.02,0.0,0.0,0.0,lisa benson,BIOE-3200,2016
-BIOE,3210,1,Biofluid Mechanics,0.46,0.38,0.14,0.0,0.0,0.0,0.0,0.03,zhi gao,BIOE-3210,2016
-BIOE,3700,1,Bioinst & Imaging,0.64,0.27,0.07,0.0,0.0,0.0,0.0,0.02,delphine dean,BIOE-3700,2016
-BIOE,4010,1,Bioengineering Design Theory,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,BIOE-4010,2016
-BIOE,4010,2,Bioengineering Design Theory,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,BIOE-4010,2016
-BIOE,4030,1,Applied Bio E Design,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,BIOE-4030,2016
-BIOE,4120,1,Orthopaedic Engr and Pathology,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,melinda harman,BIOE-4120,2016
-BIOE,4500,3,Biofabrication,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,BIOE-4500,2016
-BIOE,6120,1,Orthopaedic Engr & Pathology,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,melinda harman,BIOE-6120,2016
-BIOE,6400,1,Biopharmaceutical Engineering,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,sarah harcum,BIOE-6400,2016
-BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,martine laberge,BIOE-8000,2016
-BIOE,8010,1,Bio Materials,0.33,0.6,0.03,0.0,0.03,0.0,0.0,0.0,robert latour,BIOE-8010,2016
-BIOE,8600,401,Biomed Engr Design Innovation,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,BIOE-8600,2016
-BIOL,1010,1,Frontiers in Biology I,0.8,0.1,0.06,0.02,0.01,0.0,0.0,0.01,robert edwa ballard,BIOL-1010,2016
-BIOL,1010,2,Frontiers in Biology I,0.55,0.27,0.11,0.03,0.04,0.0,0.0,0.0,thomas hughes,BIOL-1010,2016
-BIOL,1030,1,General Biology I,0.23,0.28,0.22,0.11,0.1,0.0,0.0,0.07,nora espinoza,BIOL-1030,2016
-BIOL,1030,2,General Biology I,0.11,0.27,0.31,0.18,0.07,0.0,0.0,0.07,william baldwin,BIOL-1030,2016
-BIOL,1030,3,General Biology I,0.26,0.3,0.22,0.1,0.07,0.0,0.0,0.06,william surver,BIOL-1030,2016
-BIOL,1030,4,General Biology I,0.14,0.26,0.32,0.12,0.08,0.0,0.0,0.08,salvatore sparace,BIOL-1030,2016
-BIOL,1030,5,General Biology I (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,BIOL-1030,2016
-BIOL,1050,1,General Biology Lab I,0.17,0.33,0.25,0.08,0.08,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,2,General Biology Lab I,0.17,0.29,0.25,0.17,0.0,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,3,General Biology Lab I,0.04,0.26,0.26,0.17,0.09,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,4,General Biology Lab I,0.29,0.17,0.33,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,5,General Biology Lab I,0.04,0.13,0.3,0.3,0.04,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,6,General Biology Lab I,0.08,0.21,0.17,0.38,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,7,General Biology Lab I,0.1,0.14,0.19,0.33,0.14,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,8,General Biology Lab I,0.1,0.25,0.35,0.1,0.05,0.0,0.0,0.15,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,9,General Biology Lab I,0.09,0.22,0.35,0.22,0.04,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,10,General Biology Lab I,0.04,0.5,0.42,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,11,General Biology Lab I,0.17,0.33,0.33,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,12,General Biology Lab I,0.04,0.29,0.25,0.29,0.13,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,13,General Biology Lab I,0.13,0.5,0.17,0.08,0.13,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,14,General Biology Lab I,0.21,0.38,0.29,0.08,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,15,General Biology Lab I,0.26,0.22,0.3,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,16,General Biology Lab I,0.17,0.42,0.29,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,17,General Biology Lab I,0.17,0.29,0.25,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,18,General Biology Lab I,0.08,0.38,0.33,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,19,General Biology Lab I,0.26,0.17,0.13,0.26,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,20,General Biology Lab I,0.08,0.13,0.38,0.21,0.13,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,21,General Biology Lab I,0.08,0.21,0.29,0.13,0.25,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,22,General Biology Lab I,0.13,0.42,0.17,0.17,0.08,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,23,General Biology Lab I,0.25,0.42,0.08,0.17,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,24,General Biology Lab I,0.21,0.29,0.25,0.08,0.08,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,25,General Biology Lab I,0.0,0.17,0.3,0.22,0.22,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,26,General Biology Lab I,0.21,0.29,0.17,0.21,0.08,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,27,General Biology Lab I,0.08,0.29,0.29,0.29,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,28,General Biology Lab I,0.04,0.46,0.17,0.17,0.08,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,29,General Biology Lab I,0.04,0.35,0.22,0.22,0.09,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,30,General Biology Lab I,0.21,0.25,0.29,0.21,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,31,General Biology Lab I,0.0,0.15,0.25,0.2,0.25,0.0,0.0,0.15,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,32,General Biology Lab I,0.25,0.31,0.13,0.25,0.06,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,33,General Biology Lab I,0.0,0.15,0.4,0.15,0.15,0.0,0.0,0.15,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,34,General Biology Lab I,0.17,0.5,0.08,0.21,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,35,General Biology Lab I,0.29,0.29,0.29,0.13,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,36,General Biology Lab I,0.21,0.29,0.38,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,37,General Biology Lab I,0.21,0.33,0.21,0.13,0.08,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,38,General Biology Lab I,0.08,0.5,0.33,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,39,General Biology Lab I,0.14,0.45,0.23,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,40,General Biology Lab I,0.38,0.17,0.25,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,41,General Biology Lab I,0.13,0.42,0.29,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,42,General Biology Lab I,0.09,0.39,0.39,0.0,0.04,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,43,General Biology Lab I,0.04,0.21,0.33,0.25,0.08,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,44,General Biology Lab I,0.21,0.21,0.38,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,45,General Biology Lab I,0.04,0.43,0.22,0.22,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1050,46,General Biology Lab I,0.12,0.28,0.4,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2016
-BIOL,1090,1,Intro to Life Sci,0.78,0.18,0.05,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,BIOL-1090,2016
-BIOL,1100,1,Principles of Biology I,0.12,0.43,0.28,0.07,0.03,0.0,0.0,0.07,robert kosinski,BIOL-1100,2016
-BIOL,1100,2,Principles of Biology I,0.48,0.37,0.06,0.03,0.05,0.0,0.0,0.02,dylan dittrich-reed,BIOL-1100,2016
-BIOL,1100,3,Prin of Biology I (HON),0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,robert kosinski,BIOL-1100,2016
-BIOL,1100,4,Prin of Biology I (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,BIOL-1100,2016
-BIOL,1100,5,Principles of Biology I,0.48,0.43,0.08,0.03,0.0,0.0,0.0,0.0,dylan dittrich-reed,BIOL-1100,2016
-BIOL,1200,1,Biological Inq Lab,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,2,Biological Inq Lab,0.59,0.24,0.12,0.0,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2016
-BIOL,1200,3,Biological Inq Lab,0.5,0.28,0.11,0.0,0.06,0.0,0.0,0.06, christine minor,BIOL-1200,2016
-BIOL,1200,4,Biological Inq Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,5,Biological Inq Lab,0.61,0.22,0.11,0.06,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,6,Biological Inq Lab,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,7,Biological Inq Lab,0.45,0.45,0.0,0.1,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,8,Biological Inq Lab,0.39,0.28,0.22,0.06,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2016
-BIOL,1200,9,Biological Inq Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,11,Biological Inq Lab,0.41,0.47,0.06,0.0,0.06,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,12,Biological Inq Lab,0.5,0.22,0.17,0.06,0.06,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,13,Biological Inq Lab,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,14,Biological Inq Lab,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2016
-BIOL,1200,15,Biological Inq Lab,0.56,0.28,0.06,0.06,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2016
-BIOL,1230,1,Keys to Human Biol,0.28,0.37,0.24,0.06,0.04,0.0,0.0,0.01, christine minor,BIOL-1230,2016
-BIOL,1230,2,Keys to Human Biol,0.28,0.38,0.19,0.08,0.02,0.0,0.0,0.04, christine minor,BIOL-1230,2016
-BIOL,2000,2,Biology in the News,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-2000,2016
-BIOL,2000,6,Biology in the News,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,william surver,BIOL-2000,2016
-BIOL,2040,1,"Environ, Energy and Society",0.73,0.14,0.05,0.02,0.0,0.0,0.0,0.05,john jenkins hains,BIOL-2040,2016
-BIOL,2040,2,"Environ, Energy and Society",0.68,0.14,0.05,0.03,0.0,0.0,0.0,0.11,john jenkins hains,BIOL-2040,2016
-BIOL,2110,1,Introduction to Toxicology,0.45,0.42,0.1,0.0,0.03,0.0,0.0,0.0,peter van den hurk,BIOL-2110,2016
-BIOL,2220,1,Human Anat and Physiology I,0.18,0.32,0.24,0.08,0.09,0.0,0.0,0.09,john cummings,BIOL-2220,2016
-BIOL,2220,2,Human Anat and Physiology I,0.27,0.4,0.15,0.08,0.03,0.0,0.0,0.07,john cummings,BIOL-2220,2016
-BIOL,3030,1,Vertebrate Biology,0.29,0.25,0.25,0.15,0.03,0.0,0.0,0.03,richard blob,BIOL-3030,2016
-BIOL,3030,2,Vertebrate Biology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3030,2016
-BIOL,3040,1,Biology of Plants,0.46,0.22,0.22,0.03,0.03,0.0,0.0,0.03,christina wells,BIOL-3040,2016
-BIOL,3070,1,Vertebrate Biology Lab,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,2,Vertebrate Biology Lab,0.7,0.15,0.1,0.05,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,3,Vertebrate Biology Lab,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2016
-BIOL,3070,4,Vertebrate Biology Lab,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,5,Vertebrate Biology Lab,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,6,Vertebrate Biology Lab,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,7,Vertebrate Biology Lab,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,8,Vertebrate Biology Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,9,Vertebrate Biology Lab,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2016
-BIOL,3070,10,Vertebrate Biology Lab,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,11,Vertebrate Biology Lab,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2016
-BIOL,3070,12,Vertebrate Biology Lab,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,13,Vertebrate Biology Lab,0.25,0.5,0.2,0.05,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3070,14,Vertebrate Biology Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2016
-BIOL,3080,1,Biology of Plants Practicum,0.5,0.25,0.15,0.05,0.0,0.0,0.0,0.05,christina wells,BIOL-3080,2016
-BIOL,3080,2,Biology of Plants Practicum,0.15,0.55,0.2,0.05,0.0,0.0,0.0,0.05,christina wells,BIOL-3080,2016
-BIOL,3080,3,Biology of Plants Practicum,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,christina wells,BIOL-3080,2016
-BIOL,3080,4,Biology of Plants Practicum,0.11,0.39,0.33,0.06,0.06,0.0,0.0,0.06,christina wells,BIOL-3080,2016
-BIOL,3150,1,Functional Human Anatomy,0.23,0.4,0.23,0.07,0.02,0.0,0.0,0.05,tamara mcnutt-scott,BIOL-3150,2016
-BIOL,3200,1,Field Botany,0.21,0.21,0.21,0.24,0.03,0.0,0.0,0.1,robert edwa ballard,BIOL-3200,2016
-BIOL,3350,1,Evolutionary Biology,0.26,0.44,0.2,0.07,0.02,0.0,0.0,0.01,margaret ptacek,BIOL-3350,2016
-BIOL,3510,1,Biological Anthropology,0.33,0.47,0.07,0.07,0.07,0.0,0.0,0.0,lisa rapaport,BIOL-3510,2016
-BIOL,3530,1,Forensic Anthropology,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,katherine weisensee,BIOL-3530,2016
-BIOL,4140,1,Basic Immunology,0.12,0.29,0.41,0.12,0.0,0.0,0.0,0.06,yanzhang wei,BIOL-4140,2016
-BIOL,4200,1,Neurobiology,0.51,0.44,0.05,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4200,2016
-BIOL,4250,1,Introductory Mycology,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,julia loui kerrigan,BIOL-4250,2016
-BIOL,4260,1,Mycology Practicum,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,BIOL-4260,2016
-BIOL,4340,1,Biological Chem Lab Techniques,0.18,0.27,0.18,0.36,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2016
-BIOL,4340,2,Biological Chem Lab Techniques,0.15,0.15,0.46,0.15,0.08,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2016
-BIOL,4340,3,Biological Chem Lab Techniques,0.0,0.64,0.21,0.07,0.07,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2016
-BIOL,4340,4,Biological Chem Lab Techniques,0.0,0.15,0.54,0.15,0.08,0.0,0.0,0.08,salvatore sparace,BIOL-4340,2016
-BIOL,4410,1,Ecology,0.21,0.26,0.35,0.12,0.0,0.0,0.0,0.06,david tonkyn,BIOL-4410,2016
-BIOL,4430,1,Freshwater Ecology,0.61,0.31,0.05,0.01,0.0,0.0,0.0,0.02,john jenkins hains,BIOL-4430,2016
-BIOL,4440,2,Freshwater Ecology Lab (Lec),0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,john jenkins hains,BIOL-4440,2016
-BIOL,4450,2,Ecology Laboratory (Lec),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,BIOL-4450,2016
-BIOL,4610,1,Cell Biology,0.31,0.42,0.21,0.04,0.01,0.0,0.0,0.01,susan carol chapman,BIOL-4610,2016
-BIOL,4610,2,Cell Biology (HON),0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,susan carol chapman,BIOL-4610,2016
-BIOL,4620,2,Cell Biology Lab (Lec),0.54,0.42,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,3,Cell Biology Lab (Lec),0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,4,Cell Biology Lab (Lec),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,5,Cell Biology Lab (Lec),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,6,Cell Biology Lab (Lec),0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,7,Cell Biology Lab (Lec),0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,8,Cell Biology Lab (Lec),0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,xianzhong yu,BIOL-4620,2016
-BIOL,4670,1,Principles of Hematology,0.89,0.04,0.0,0.0,0.07,0.0,0.0,0.0,vincent gallicchio,BIOL-4670,2016
-BIOL,4930,3,Senior Seminar,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,BIOL-4930,2016
-BIOL,4930,6,Senior Seminar,0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,kara elizabe powder,BIOL-4930,2016
-BIOL,6030,1,Intro to Applied Genomics,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,vincent pa richards,BIOL-6030,2016
-BIOL,8200,1,Community Ecology,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,saara dewalt,BIOL-8200,2016
-BIOL,8400,1,Understanding Biological Inq,0.82,0.09,0.02,0.0,0.05,0.0,0.0,0.03,michael childress,BIOL-8400,2016
-BIOL,8420,1,Understand Cellular Processes,0.45,0.39,0.11,0.0,0.03,0.0,0.0,0.01,patricia leota tate,BIOL-8420,2016
-BIOL,8440,1,Understanding the Human Body,0.6,0.29,0.08,0.0,0.02,0.0,0.0,0.01,william baldwin,BIOL-8440,2016
-BIOL,8480,1,Understanding Scientific Rsrch,0.9,0.0,0.0,0.0,0.06,0.0,0.0,0.03,robert edwa ballard,BIOL-8480,2016
-BUS,1010,1,Business Foundations,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2016
-BUS,1010,2,Business Foundations,0.32,0.47,0.11,0.05,0.05,0.0,0.0,0.0,william ern tumblin,BUS-1010,2016
-BUS,1010,3,Business Foundations,0.63,0.21,0.0,0.05,0.05,0.0,0.0,0.05,william ern tumblin,BUS-1010,2016
-BUS,1010,4,Business Foundations,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2016
-BUS,1010,5,Business Foundations,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2016
-BUS,1010,6,Business Foundations,0.42,0.37,0.05,0.0,0.16,0.0,0.0,0.0,william ern tumblin,BUS-1010,2016
-BUS,1010,7,Business Foundations,0.44,0.33,0.11,0.06,0.0,0.0,0.0,0.06,william ern tumblin,BUS-1010,2016
-BUS,1010,8,Business Foundations,0.0,0.58,0.21,0.05,0.11,0.0,0.0,0.05,william ern tumblin,BUS-1010,2016
-BUS,1010,9,Business Foundations,0.37,0.32,0.11,0.05,0.05,0.0,0.0,0.11,william ern tumblin,BUS-1010,2016
-BUS,1010,10,Business Foundations,0.58,0.21,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,BUS-1010,2016
-BUS,1010,11,Business Foundations,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2016
-BUS,1010,12,Business Foundations,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,james mullinax,BUS-1010,2016
-BUS,1010,13,Business Foundations,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,14,Business Foundations,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,15,Business Foundations,0.41,0.24,0.29,0.06,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,16,Business Foundations,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,17,Business Foundations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,18,Business Foundations,0.17,0.33,0.33,0.06,0.06,0.0,0.0,0.06,donna mccubbin,BUS-1010,2016
-BUS,1010,19,Business Foundations,0.22,0.5,0.17,0.06,0.06,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,20,Business Foundations,0.33,0.17,0.39,0.06,0.0,0.0,0.0,0.06,donna mccubbin,BUS-1010,2016
-BUS,1010,21,Business Foundations,0.42,0.35,0.12,0.07,0.02,0.0,0.0,0.02,donna mccubbin,BUS-1010,2016
-BUS,1010,22,Business Foundations,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,23,Business Foundations,0.44,0.28,0.11,0.06,0.0,0.0,0.0,0.11,sandy edge,BUS-1010,2016
-BUS,1010,24,Business Foundations,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,sandy edge,BUS-1010,2016
-BUS,1010,25,Business Foundations,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2016
-BUS,1010,26,Business Foundations,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2016
-BUS,1010,27,Business Foundations,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2016
-BUS,1010,28,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,BUS-1010,2016
-BUS,1010,29,Business Foundations,0.19,0.36,0.23,0.11,0.04,0.0,0.0,0.06,michael mendonca,BUS-1010,2016
-BUS,1010,30,Business Foundations,0.23,0.43,0.3,0.02,0.02,0.0,0.0,0.0,michael mendonca,BUS-1010,2016
-BUS,1010,31,Business Foundations,0.21,0.53,0.16,0.05,0.0,0.0,0.0,0.05,michael mendonca,BUS-1010,2016
-BUS,1010,33,Business Foundations,0.55,0.34,0.07,0.0,0.0,0.0,0.0,0.03,james mullinax,BUS-1010,2016
-BUS,1010,34,Business Foundations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,BUS-1010,2016
-CE,1990,2,Cr Inq in Civil Engineering,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,weichiang pang,CE-1990,2016
-CE,2010,1,Statics,0.18,0.28,0.18,0.0,0.05,0.0,0.0,0.33,melissa sternhagen,CE-2010,2016
-CE,2010,2,Statics,0.12,0.29,0.31,0.1,0.12,0.0,0.0,0.07,melissa sternhagen,CE-2010,2016
-CE,2010,3,Statics,0.34,0.31,0.16,0.09,0.07,0.0,0.0,0.03,qiushi chen,CE-2010,2016
-CE,2010,4,Statics,0.23,0.3,0.23,0.05,0.05,0.0,0.0,0.14,melissa sternhagen,CE-2010,2016
-CE,2010,5,Statics,0.23,0.33,0.16,0.05,0.12,0.0,0.0,0.12,"rashidian dezfouli,",CE-2010,2016
-CE,2010,6,Statics,0.12,0.35,0.19,0.07,0.14,0.0,0.0,0.14,melissa sternhagen,CE-2010,2016
-CE,2010,7,Statics (HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,melissa sternhagen,CE-2010,2016
-CE,2060,1,Structural Mechanics,0.19,0.35,0.25,0.14,0.02,0.0,0.0,0.05,bryant nielson,CE-2060,2016
-CE,2080,1,Dynamics,0.13,0.25,0.3,0.18,0.07,0.0,0.0,0.07,nigel gregory kaye,CE-2080,2016
-CE,2550,1,Geomatics,0.34,0.52,0.1,0.02,0.01,0.0,0.0,0.01,wayne sarasua,CE-2550,2016
-CE,3010,1,Structural Analysis,0.32,0.26,0.24,0.12,0.03,0.0,0.0,0.03,stephen csernak,CE-3010,2016
-CE,3010,2,Structural Analysis,0.4,0.28,0.25,0.08,0.0,0.0,0.0,0.0,bryant nielson,CE-3010,2016
-CE,3110,1,Transportation Engr,0.58,0.33,0.07,0.0,0.02,0.0,0.0,0.0,jennifer ogle,CE-3110,2016
-CE,3210,1,Geotechnical Engineering,0.42,0.24,0.32,0.0,0.03,0.0,0.0,0.0,qiushi chen,CE-3210,2016
-CE,3310,1,Constr Engr & Mgmnt,0.4,0.32,0.2,0.04,0.01,0.0,0.0,0.04,james burati,CE-3310,2016
-CE,3410,1,Intro to Fluid Mech,0.26,0.44,0.26,0.04,0.0,0.0,0.0,0.0,nigel gregory kaye,CE-3410,2016
-CE,3410,2,Intro to Fluid Mech,0.27,0.36,0.22,0.07,0.05,0.0,0.0,0.02,abdul khan,CE-3410,2016
-CE,3420,1,Hydraulics & Hydro,0.43,0.43,0.15,0.0,0.0,0.0,0.0,0.0,ashok mishra,CE-3420,2016
-CE,3510,1,Civil Engineering Materials,0.55,0.43,0.0,0.0,0.0,0.0,0.0,0.03,ami esmaeilpoursaee,CE-3510,2016
-CE,3510,2,Civil Engineering Materials,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kimberly rene lyons,CE-3510,2016
-CE,3520,1,Econ Eval of Proj,0.32,0.29,0.2,0.05,0.05,0.0,0.0,0.08,zoraya rolda rockow,CE-3520,2016
-CE,4010,1,Matrix Str Analysis,0.74,0.15,0.07,0.0,0.04,0.0,0.0,0.0,atamturktur russcher,CE-4010,2016
-CE,4020,1,Reinfor Con Design,0.27,0.5,0.07,0.07,0.0,0.0,0.0,0.1,thomas edfo cousins,CE-4020,2016
-CE,4060,1,Struct Steel Design,0.31,0.47,0.14,0.06,0.02,0.0,0.0,0.0,stephen csernak,CE-4060,2016
-CE,4100,1,Traffic Engr Oper,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,sakib khan,CE-4100,2016
-CE,4240,1,Earth Slopes & Struc,0.3,0.35,0.3,0.0,0.03,0.0,0.0,0.03,nadara ravichandran,CE-4240,2016
-CE,4330,1,Const Plan & Sched,0.41,0.41,0.15,0.02,0.0,0.0,0.0,0.0,steve richa sanders,CE-4330,2016
-CE,4370,2,Sustainable Energy Proj Design,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,CE-4370,2016
-CE,4390,1,Con Eqpmt Sel & Main,0.41,0.46,0.1,0.0,0.0,0.0,0.0,0.02,james burati,CE-4390,2016
-CE,4460,1,Flood Haz & Prot Des,0.19,0.5,0.25,0.0,0.0,0.0,0.0,0.06,nadim aziz,CE-4460,2016
-CE,4560,1,Pave Design & Constr,0.39,0.59,0.0,0.0,0.0,0.0,0.0,0.02,bradley putman,CE-4560,2016
-CE,4590,1,Capstone Design Proj,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2016
-CE,4910,1,BIM in Construction Management,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,kalyan ram piratla,CE-4910,2016
-CE,6010,1,Matrix Str Analysis,0.71,0.18,0.0,0.0,0.12,0.0,0.0,0.0,atamturktur russcher,CE-6010,2016
-CE,6100,1,Traffic Engr Oper,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-6100,2016
-CE,6330,1,Const Plan & Sched,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,steve richa sanders,CE-6330,2016
-CE,6370,2,Sustainable Energy Proj Design,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,CE-6370,2016
-CE,6460,1,Flood Haz & Prot Des,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,nadim aziz,CE-6460,2016
-CE,6910,1,BIM in Construction Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-6910,2016
-CE,8040,1,Prestressed Concrete,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,brandon ross,CE-8040,2016
-CE,8050,1,Adv Struc Mech,0.29,0.5,0.0,0.0,0.0,0.0,0.0,0.21,bryant nielson,CE-8050,2016
-CE,8080,1,Earthquake Engr,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-8080,2016
-CE,8220,1,Foundation Engr,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,CE-8220,2016
-CE,8230,1,Asphalt Conc Prop,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,CE-8230,2016
-CE,8240,1,Infrastructure Corrosion,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,CE-8240,2016
-CE,8540,1,Travl Demnd Forecast,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wayne sarasua,CE-8540,2016
-CE,8570,500,Uncertainty Modeling Risk Engr,0.63,0.26,0.04,0.0,0.0,0.0,0.0,0.07,bryant nielson,CE-8570,2016
-CE,8930,3,Automated Vehicle System,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-8930,2016
-CH,1010,1,General Chemistry,0.22,0.35,0.3,0.06,0.05,0.0,0.0,0.01,tania issa houjeiry,CH-1010,2016
-CH,1010,2,General Chemistry,0.1,0.35,0.28,0.09,0.09,0.0,0.0,0.08,princess mycia cox,CH-1010,2016
-CH,1010,3,General Chemistry,0.26,0.37,0.19,0.06,0.09,0.0,0.0,0.03,thomas hickman,CH-1010,2016
-CH,1010,4,General Chemistry,0.19,0.27,0.26,0.12,0.11,0.0,0.0,0.04,dennis taylor,CH-1010,2016
-CH,1010,5,General Chemistry,0.19,0.38,0.22,0.12,0.04,0.0,0.0,0.04,princess mycia cox,CH-1010,2016
-CH,1010,6,General Chemistry,0.2,0.34,0.25,0.1,0.08,0.0,0.0,0.03,dennis taylor,CH-1010,2016
-CH,1010,7,General Chemistry,0.05,0.3,0.39,0.1,0.12,0.0,0.0,0.05,william mcwhorter,CH-1010,2016
-CH,1010,8,General Chemistry,0.23,0.27,0.28,0.1,0.08,0.0,0.0,0.04,dennis taylor,CH-1010,2016
-CH,1010,9,General Chemistry,0.13,0.34,0.27,0.14,0.1,0.0,0.0,0.03,olt geiculescu,CH-1010,2016
-CH,1010,10,General Chemistry,0.07,0.32,0.31,0.16,0.1,0.0,0.0,0.04,william mcwhorter,CH-1010,2016
-CH,1010,11,General Chemistry,0.16,0.33,0.3,0.13,0.07,0.0,0.0,0.01,william mcwhorter,CH-1010,2016
-CH,1010,12,General Chemistry,0.24,0.41,0.24,0.05,0.05,0.0,0.0,0.01,tania issa houjeiry,CH-1010,2016
-CH,1010,13,General Chemistry,0.21,0.29,0.25,0.1,0.09,0.0,0.0,0.05,laura lanni,CH-1010,2016
-CH,1010,14,General Chemistry,0.16,0.38,0.24,0.13,0.05,0.0,0.0,0.03,elliot ennis,CH-1010,2016
-CH,1010,20,General Chemistry,0.29,0.37,0.24,0.05,0.03,0.0,0.0,0.02,tania issa houjeiry,CH-1010,2016
-CH,1010,21,General Chemistry,0.2,0.41,0.22,0.05,0.09,0.0,0.0,0.03,elliot ennis,CH-1010,2016
-CH,1010,22,General Chemistry,0.17,0.37,0.28,0.12,0.05,0.0,0.0,0.01,laura lanni,CH-1010,2016
-CH,1010,50,General Chemistry,0.17,0.38,0.38,0.04,0.04,0.0,0.0,0.0,shiou-jyh hwu,CH-1010,2016
-CH,1010,51,General Chemistry (HON),0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,william pennington,CH-1010,2016
-CH,1010,52,General Chemistry (HON),0.62,0.32,0.05,0.0,0.0,0.0,0.0,0.0,joseph stu thrasher,CH-1010,2016
-CH,1010,501,General Chemistry,0.44,0.29,0.27,0.0,0.0,0.0,0.0,0.0,brian gloor,CH-1010,2016
-CH,1020,1,General Chemistry,0.3,0.3,0.25,0.1,0.04,0.0,0.0,0.02,stephe schvaneveldt,CH-1020,2016
-CH,1020,2,General Chemistry,0.28,0.34,0.13,0.11,0.09,0.0,0.0,0.05,stephe schvaneveldt,CH-1020,2016
-CH,1020,3,General Chemistry,0.24,0.34,0.23,0.09,0.06,0.0,0.0,0.03,stephe schvaneveldt,CH-1020,2016
-CH,1020,400,General Chemistry,0.08,0.08,0.41,0.25,0.11,0.0,0.0,0.08,stephe schvaneveldt,CH-1020,2016
-CH,1050,1,Chemistry in Context I,0.27,0.56,0.16,0.01,0.01,0.0,0.0,0.0,olt geiculescu,CH-1050,2016
-CH,1050,2,Chemistry in Context I,0.35,0.43,0.15,0.05,0.01,0.0,0.0,0.01,olt geiculescu,CH-1050,2016
-CH,2010,1,Survey of Organic Chemistry,0.29,0.3,0.23,0.09,0.06,0.0,0.0,0.03,thomas hickman,CH-2010,2016
-CH,2010,2,Survey of Organic Chemistry,0.31,0.39,0.22,0.02,0.04,0.0,0.0,0.0,thomas hickman,CH-2010,2016
-CH,2020,1,Surv of Organic Chemistry Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,sean 'connor,CH-2020,2016
-CH,2020,2,Surv of Organic Chemistry Lab,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2020,2016
-CH,2020,3,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2020,2016
-CH,2020,5,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2020,2016
-CH,2020,7,Surv of Organic Chemistry Lab,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2020,2016
-CH,2020,8,Surv of Organic Chemistry Lab,0.6,0.2,0.07,0.0,0.07,0.0,0.0,0.07,sean 'connor,CH-2020,2016
-CH,2230,1,Organic Chemistry,0.32,0.34,0.12,0.13,0.04,0.0,0.0,0.05,modi wetzler,CH-2230,2016
-CH,2230,2,Organic Chemistry,0.41,0.31,0.13,0.06,0.06,0.0,0.0,0.03,modi wetzler,CH-2230,2016
-CH,2230,3,Organic Chemistry,0.24,0.33,0.26,0.06,0.06,0.0,0.0,0.04,jacob schroeder,CH-2230,2016
-CH,2230,4,Organic Chemistry,0.37,0.31,0.18,0.06,0.04,0.0,0.0,0.04,laura lanni,CH-2230,2016
-CH,2230,5,Organic Chemistry,0.28,0.39,0.17,0.05,0.09,0.0,0.0,0.01,elliot ennis,CH-2230,2016
-CH,2230,6,Organic Chemistry,0.32,0.27,0.13,0.08,0.11,0.0,0.0,0.08,rhett smith,CH-2230,2016
-CH,2230,7,Organic Chemistry,0.23,0.36,0.21,0.06,0.07,0.0,0.0,0.08,dev priya arya,CH-2230,2016
-CH,2240,1,Organic Chemistry,0.24,0.37,0.16,0.08,0.05,0.0,0.0,0.1,jacob schroeder,CH-2240,2016
-CH,2240,2,Organic Chemistry,0.29,0.38,0.16,0.09,0.06,0.0,0.0,0.02,jacob schroeder,CH-2240,2016
-CH,2270,1,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2016
-CH,2270,3,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,4,Organic Chem Lab,0.69,0.13,0.06,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2016
-CH,2270,8,Organic Chem Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,12,Organic Chem Lab,0.81,0.0,0.13,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,14,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,15,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2016
-CH,2270,19,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2016
-CH,2270,21,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,26,Organic Chem Lab,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2016
-CH,2270,28,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2016
-CH,2270,29,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2016
-CH,2270,30,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2016
-CH,2270,31,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2016
-CH,2270,32,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2016
-CH,2270,34,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2016
-CH,2270,35,Organic Chem Lab,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2280,4,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,CH-2280,2016
-CH,2280,5,Organic Chem Lab,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2016
-CH,2280,6,Organic Chem Lab,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,sean 'connor,CH-2280,2016
-CH,2280,7,Organic Chem Lab,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2016
-CH,2280,8,Organic Chem Lab,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,CH-2280,2016
-CH,2280,9,Organic Chem Lab,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15,sean 'connor,CH-2280,2016
-CH,2280,10,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2016
-CH,3130,1,Quantitative Analys,0.49,0.24,0.16,0.03,0.0,0.0,0.0,0.08,stephen creager,CH-3130,2016
-CH,3300,1,Intro to Phys Chem,0.29,0.43,0.21,0.06,0.0,0.0,0.0,0.01,brian dominy,CH-3300,2016
-CH,3310,1,Physical Chemistry,0.38,0.19,0.19,0.19,0.0,0.0,0.0,0.06,jason mcneill,CH-3310,2016
-CH,3310,2,Physical Chemistry,0.25,0.25,0.21,0.08,0.17,0.0,0.0,0.04,leah bec casabianca,CH-3310,2016
-CH,3320,1,Physical Chemistry,0.18,0.41,0.32,0.0,0.05,0.0,0.0,0.05,arkady kholodenko,CH-3320,2016
-CH,3390,2,Physical Chem Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2016
-CH,3390,3,Physical Chem Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2016
-CH,3390,4,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2016
-CH,4010,1,Organometallic Chemistry,0.58,0.33,0.03,0.0,0.03,0.0,0.0,0.03,andrew gre tennyson,CH-4010,2016
-CH,4020,1,Inorganic Chemistry,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,joseph kolis,CH-4020,2016
-CH,4210,1,Advanced Organic Chemistry,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,daniel whitehead,CH-4210,2016
-CH,8070,1,Chem Trans Elem,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,CH-8070,2016
-CH,8090,1,Chem App/X-Ray Cryst,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,CH-8090,2016
-CH,8120,1,Chemical Spectroscopic Methods,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,george chumanov,CH-8120,2016
-CH,8150,1,Mass Spectrometry,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,richard marcus,CH-8150,2016
-CH,8210,1,Organic Chem I,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0, karl dieter,CH-8210,2016
-CH,8300,1,Fund Phys Chem,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,CH-8300,2016
-CH,8510,1,Grad Student Seminar,0.71,0.24,0.03,0.0,0.03,0.0,0.0,0.0,joseph stu thrasher,CH-8510,2016
-CH,8510,2,Grad Student Seminar,0.91,0.03,0.0,0.0,0.0,0.0,0.0,0.06,steven stuart,CH-8510,2016
-CHE,2110,1,Mass and Energy Balances,0.24,0.2,0.24,0.08,0.2,0.0,0.0,0.04,mark roberts,CHE-2110,2016
-CHE,2110,2,Mass and Energy Balances,0.28,0.43,0.13,0.03,0.07,0.0,0.0,0.04,mark roberts,CHE-2110,2016
-CHE,3210,1,Ch E Thermo II,0.14,0.14,0.35,0.21,0.12,0.0,0.0,0.05,sapna sarupria,CHE-3210,2016
-CHE,3210,2,Ch E Thermo II,0.2,0.31,0.23,0.17,0.09,0.0,0.0,0.0,sapna sarupria,CHE-3210,2016
-CHE,3300,1,Mass Trans & Seprtn,0.19,0.15,0.43,0.06,0.09,0.0,0.0,0.08,mark thies,CHE-3300,2016
-CHE,4070,1,Unit Op Lab II,0.14,0.75,0.11,0.0,0.0,0.0,0.0,0.0,christopher norfolk,CHE-4070,2016
-CHE,4310,1,Process Design I,0.2,0.45,0.35,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4310,2016
-CHE,4500,1,Chem Reaction Engr,0.45,0.26,0.16,0.12,0.0,0.0,0.0,0.0,rachel getman,CHE-4500,2016
-CHE,8030,1,Advanced Transport,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,eric mikel davis,CHE-8030,2016
-CHE,8040,1,Ch E Thermodynamics,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,christophe kitchens,CHE-8040,2016
-CHE,8050,1,Ch E Kinetics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,mark alan blenner,CHE-8050,2016
-CHE,8140,1,Numerical Methods,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,joseph scott,CHE-8140,2016
-CHIN,1010,1,Elementary Chinese,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,ling rao,CHIN-1010,2016
-CHIN,1010,2,Elementary Chinese,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,ling rao,CHIN-1010,2016
-CHIN,1020,1,Elementary Chinese,0.42,0.17,0.33,0.08,0.0,0.0,0.0,0.0,ling rao,CHIN-1020,2016
-CHIN,2010,1,Intermediate Chinese,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,su- chen,CHIN-2010,2016
-CHIN,2020,1,Intermediate Chinese,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,yanhua zhang,CHIN-2020,2016
-CHIN,4010,1,Pre-Modern Chinese Literature,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,yanming an,CHIN-4010,2016
-COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,eddie smith,COM-1010,2016
-COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,eddie smith,COM-1010,2016
-COM,1500,1,Intro to Human Communication,0.71,0.25,0.03,0.0,0.0,0.0,0.0,0.01,eddie smith,COM-1500,2016
-COM,1500,2,Intro to Human Communication,0.66,0.25,0.04,0.01,0.01,0.0,0.0,0.04,daniel lelan fecher,COM-1500,2016
-COM,1500,3,Intro to Human Communication,0.71,0.26,0.01,0.0,0.0,0.0,0.0,0.02,eddie smith,COM-1500,2016
-COM,1500,4,Intro to Human Communication,0.68,0.23,0.05,0.01,0.01,0.0,0.0,0.01,marianne her glaser,COM-1500,2016
-COM,1500,5,Intro to Human Communication,0.7,0.22,0.05,0.02,0.0,0.0,0.0,0.01,marianne her glaser,COM-1500,2016
-COM,1500,6,Intro to Human Communication,0.65,0.25,0.07,0.0,0.0,0.0,0.0,0.03,marianne her glaser,COM-1500,2016
-COM,1500,7,Intro to Human Communication,0.4,0.43,0.03,0.03,0.08,0.0,0.0,0.03,daniel lelan fecher,COM-1500,2016
-COM,2010,1,Intr to Comm Studies,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-2010,2016
-COM,2010,2,Intr to Comm Studies,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-2010,2016
-COM,2500,1,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2016
-COM,2500,2,Public Speaking,0.39,0.33,0.11,0.06,0.06,0.0,0.0,0.06,marilyn denise pugh,COM-2500,2016
-COM,2500,3,Public Speaking,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2016
-COM,2500,4,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2016
-COM,2500,5,Public Speaking,0.26,0.58,0.16,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2016
-COM,2500,6,Public Speaking,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,COM-2500,2016
-COM,2500,7,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2016
-COM,2500,8,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2016
-COM,2500,9,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2016
-COM,2500,10,Public Speaking,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2016
-COM,2500,11,Public Speaking,0.47,0.32,0.05,0.05,0.05,0.0,0.0,0.05,sara grumbl crocker,COM-2500,2016
-COM,2500,12,Public Speaking,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2016
-COM,2500,13,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2016
-COM,2500,14,Public Speaking,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,vanessa anne condon,COM-2500,2016
-COM,2500,15,Public Speaking,0.17,0.39,0.44,0.0,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2016
-COM,2500,16,Public Speaking,0.29,0.35,0.12,0.0,0.0,0.0,0.0,0.24,pauline matthey,COM-2500,2016
-COM,2500,17,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,the estate  geddes,COM-2500,2016
-COM,2500,19,Public Speaking,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,vanessa anne condon,COM-2500,2016
-COM,2500,20,Public Speaking,0.21,0.58,0.11,0.0,0.0,0.0,0.0,0.11,pauline matthey,COM-2500,2016
-COM,2500,21,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2016
-COM,2500,22,Public Speaking,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,vanessa anne condon,COM-2500,2016
-COM,2500,23,Public Speaking,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2016
-COM,2500,28,Public Speaking,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2016
-COM,2500,29,Public Speaking,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,COM-2500,2016
-COM,2500,30,Public Speaking,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,sara grumbl crocker,COM-2500,2016
-COM,2500,31,Public Speaking,0.21,0.42,0.16,0.05,0.05,0.0,0.0,0.11,marilyn denise pugh,COM-2500,2016
-COM,2500,32,Public Speaking,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,COM-2500,2016
-COM,2500,33,Public Speaking,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2016
-COM,2500,34,Public Speaking,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,COM-2500,2016
-COM,2500,35,Public Speaking,0.37,0.37,0.11,0.0,0.11,0.0,0.0,0.05,jumah patrici taweh,COM-2500,2016
-COM,2500,400,Public Speaking,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,COM-2500,2016
-COM,2500,401,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,COM-2500,2016
-COM,2500,402,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2016
-COM,2500,403,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2016
-COM,3010,1,Comm Theory,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,COM-3010,2016
-COM,3050,1,Persuasion,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-3050,2016
-COM,3060,1,Crit-Cultural Rsrch Methods,0.47,0.29,0.12,0.06,0.06,0.0,0.0,0.0,chenjerai kumanyika,COM-3060,2016
-COM,3080,1,Pub Comm & Pop Cult,0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,chenjerai kumanyika,COM-3080,2016
-COM,3080,2,Pub Comm & Pop Cult,0.44,0.33,0.17,0.06,0.0,0.0,0.0,0.0,chenjerai kumanyika,COM-3080,2016
-COM,3110,1,Qual Comm Methods,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,angela pratt,COM-3110,2016
-COM,3150,1,Critical-Cultural Comm Theory,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,david travers scott,COM-3150,2016
-COM,3200,1,Bdcst Production,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,wanda johnson,COM-3200,2016
-COM,3220,1,Communication Design,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,COM-3220,2016
-COM,3240,1,"Communication, Sport & Society",0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,COM-3240,2016
-COM,3240,2,"Communication, Sport & Society",0.28,0.56,0.06,0.11,0.0,0.0,0.0,0.0,gregory kei cranmer,COM-3240,2016
-COM,3260,1,Pr in Sports,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2016
-COM,3260,2,Pr in Sports,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2016
-COM,3270,1,Sports Media Criticism,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,brandon boatwright,COM-3270,2016
-COM,3660,3,Video Comm with Adobe CC,0.83,0.06,0.0,0.06,0.0,0.0,0.0,0.06,michael rodgers,COM-3660,2016
-COM,3690,1,Political Comm,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3690,2016
-COM,3690,2,Political Comm,0.42,0.42,0.11,0.0,0.05,0.0,0.0,0.0,erin michelle ash,COM-3690,2016
-COM,3700,1,Survey of Brand Communications,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,lisa willi papenfus,COM-3700,2016
-COM,3720,1,Digital Analytics in Brand Com,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alicia ni littleton,COM-3720,2016
-COM,3740,1,Brand Comm and Media Strategy,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,roger beasley,COM-3740,2016
-COM,4020,1,Mass Com: His & Crit,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,COM-4020,2016
-COM,4250,1,Adv Sports Comm,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4250,2016
-COM,4250,2,Adv Sports Comm,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4250,2016
-COM,4300,1,Legal Communication,0.28,0.61,0.0,0.0,0.0,0.0,0.0,0.11,james isaac roberts,COM-4300,2016
-COM,4560,1,PR for Assoc & Nonprofits,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-4560,2016
-COM,4660,1,Narrative Res. for Soc. Change,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4660,2016
-COM,4950,1,Senior Capstone Seminar,0.72,0.06,0.22,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4950,2016
-COM,8010,1,Communication Theory I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,andrew stephen pyle,COM-8010,2016
-COM,8030,1,Comm Technology Studies Survey,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-8030,2016
-COM,8100,1,Comm Research Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-8100,2016
-COOP,1020,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey frank neal,COOP-1020,2016
-COOP,1030,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey frank neal,COOP-1030,2016
-CPSC,1010,1,Computer Science I,0.2,0.32,0.14,0.07,0.2,0.0,0.0,0.07,eileen ther kraemer,CPSC-1010,2016
-CPSC,1020,1,Computer Science II,0.23,0.33,0.22,0.07,0.09,0.0,0.0,0.06,yvon feaster,CPSC-1020,2016
-CPSC,1040,1,Intro Computer Prog,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,aubrey miche lawson,CPSC-1040,2016
-CPSC,1060,1,Intro to Programming in Java,0.28,0.28,0.22,0.0,0.11,0.0,0.0,0.11,salvatore lamarca,CPSC-1060,2016
-CPSC,1060,2,Intro to Programming in Java,0.13,0.27,0.07,0.27,0.2,0.0,0.0,0.07,salvatore lamarca,CPSC-1060,2016
-CPSC,1070,1,Programming Methodology,0.42,0.26,0.11,0.05,0.11,0.0,0.0,0.05,rose lowe,CPSC-1070,2016
-CPSC,1070,2,Programming Methodology,0.5,0.22,0.17,0.0,0.06,0.0,0.0,0.06,rose lowe,CPSC-1070,2016
-CPSC,1110,1,Intro to Programming in C,0.25,0.35,0.27,0.05,0.04,0.0,0.0,0.04,catherine hochrine,CPSC-1110,2016
-CPSC,1110,2,Intro to Programming in C,0.27,0.37,0.17,0.02,0.1,0.0,0.0,0.08,catherine hochrine,CPSC-1110,2016
-CPSC,1110,3,Intro to Programming in C,0.6,0.15,0.13,0.04,0.06,0.0,0.0,0.02,tania roy,CPSC-1110,2016
-CPSC,1200,1,Intro Info Tech,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john junius porter,CPSC-1200,2016
-CPSC,2070,1,Discrete Structures,0.27,0.27,0.24,0.08,0.09,0.0,0.0,0.04,larry hodges,CPSC-2070,2016
-CPSC,2120,1,Algs/Data Structures,0.27,0.21,0.28,0.06,0.09,0.0,0.0,0.08,brian christop dean,CPSC-2120,2016
-CPSC,2120,2,Algs/Data Structures,0.1,0.0,0.18,0.14,0.24,0.0,0.0,0.34,pradip srimani,CPSC-2120,2016
-CPSC,2150,1,Software Dev Foundations,0.2,0.38,0.28,0.04,0.05,0.0,0.0,0.05,murali sitaraman,CPSC-2150,2016
-CPSC,2200,1,Microcomputer Appl,0.27,0.36,0.12,0.1,0.03,0.0,0.0,0.12,kevin anton plis,CPSC-2200,2016
-CPSC,2310,1,Intro Computer Org,0.21,0.32,0.37,0.01,0.05,0.0,0.0,0.05,rose lowe,CPSC-2310,2016
-CPSC,2810,2,Sel Topics: Tech and Tools Sem,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,brian christop dean,CPSC-2810,2016
-CPSC,2910,1,Prof Issues I,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,james jones,CPSC-2910,2016
-CPSC,2910,3,Prof Issues I,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,yvon feaster,CPSC-2910,2016
-CPSC,2910,4,Prof Issues I,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,yvon feaster,CPSC-2910,2016
-CPSC,2910,5,Prof Issues I,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,yvon feaster,CPSC-2910,2016
-CPSC,2910,6,Prof Issues I,0.53,0.26,0.11,0.0,0.0,0.0,0.0,0.11,yvon feaster,CPSC-2910,2016
-CPSC,2920,1,"Computing, Ethics & Society",0.26,0.42,0.16,0.0,0.16,0.0,0.0,0.0,christopher plaue,CPSC-2920,2016
-CPSC,2920,2,"Computing, Ethics & Society",0.43,0.21,0.21,0.07,0.07,0.0,0.0,0.0,christopher plaue,CPSC-2920,2016
-CPSC,3220,1,Intro to Operating Systems,0.13,0.26,0.39,0.09,0.04,0.0,0.0,0.09,mark smotherman,CPSC-3220,2016
-CPSC,3220,2,Intro to Operating Systems,0.1,0.32,0.26,0.1,0.1,0.0,0.0,0.13,pradip srimani,CPSC-3220,2016
-CPSC,3300,1,Computer Systems Org,0.28,0.35,0.23,0.06,0.02,0.0,0.0,0.06,rong ge,CPSC-3300,2016
-CPSC,3500,1,Foundations of Computer Sci,0.14,0.34,0.3,0.04,0.09,0.0,0.0,0.09,ilya mark safro,CPSC-3500,2016
-CPSC,3520,1,Programming Systems,0.36,0.43,0.03,0.09,0.05,0.0,0.0,0.03,robert schalkoff,CPSC-3520,2016
-CPSC,3600,2,Network Programming,0.46,0.4,0.14,0.0,0.0,0.0,0.0,0.0,lanny sitanayah,CPSC-3600,2016
-CPSC,3600,3,Network Programming,0.51,0.29,0.11,0.0,0.03,0.0,0.0,0.06,lanny sitanayah,CPSC-3600,2016
-CPSC,3620,1,Distributed/Cluster Computing,0.22,0.35,0.38,0.03,0.0,0.0,0.0,0.03,linh bao ngo,CPSC-3620,2016
-CPSC,3720,1,Software Engineering,0.26,0.63,0.09,0.0,0.02,0.0,0.0,0.0,john mcgregor,CPSC-3720,2016
-CPSC,3720,2,Software Engineering,0.21,0.53,0.16,0.0,0.05,0.0,0.0,0.05,kevin anton plis,CPSC-3720,2016
-CPSC,3720,3,Software Engineering,0.39,0.39,0.14,0.04,0.04,0.0,0.0,0.0,kevin anton plis,CPSC-3720,2016
-CPSC,3720,4,Software Engineering,0.08,0.42,0.25,0.0,0.08,0.0,0.0,0.17,kevin anton plis,CPSC-3720,2016
-CPSC,3990,1,Adv CI: Extreme Orange,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james martin,CPSC-3990,2016
-CPSC,4050,1,Computer Graphics,0.33,0.25,0.17,0.0,0.0,0.0,0.0,0.25,robert geist,CPSC-4050,2016
-CPSC,4110,1,Virtual Reality Systems,0.4,0.33,0.17,0.03,0.07,0.0,0.0,0.0,sabarish venka babu,CPSC-4110,2016
-CPSC,4120,1,Eye Tracking Methodology,0.35,0.55,0.05,0.0,0.0,0.0,0.0,0.05,andrew duchowski,CPSC-4120,2016
-CPSC,4160,1,2-D Game Engine Construction,0.46,0.42,0.04,0.0,0.08,0.0,0.0,0.0,brian malloy,CPSC-4160,2016
-CPSC,4200,1,Computer Security Principles,0.78,0.19,0.0,0.0,0.03,0.0,0.0,0.0,hongxin hu,CPSC-4200,2016
-CPSC,4620,1,Database Management Systems,0.08,0.21,0.13,0.04,0.17,0.0,0.0,0.38,pradip srimani,CPSC-4620,2016
-CPSC,4820,1,Spec Top:Mobile Device Sftware,0.74,0.17,0.04,0.04,0.0,0.0,0.0,0.0,roy pargas,CPSC-4820,2016
-CPSC,4820,5,Spec Topics: Privacy and Secur,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,kelly caine,CPSC-4820,2016
-CPSC,4820,6,Special Topics: Info to AI,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,feng luo,CPSC-4820,2016
-CPSC,4820,9,Special Topics: Data Science,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,CPSC-4820,2016
-CPSC,6040,1,Cptr Graphics Image,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,donald henry house,CPSC-6040,2016
-CPSC,6110,1,Virtual Reality Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,CPSC-6110,2016
-CPSC,6160,1,2-D Game Engine Construction,0.59,0.23,0.18,0.0,0.0,0.0,0.0,0.0,brian malloy,CPSC-6160,2016
-CPSC,6200,1,Computer Security Principles,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,hongxin hu,CPSC-6200,2016
-CPSC,6620,1,Database Management Systems,0.41,0.12,0.35,0.0,0.0,0.0,0.0,0.12,pradip srimani,CPSC-6620,2016
-CPSC,6780,1,Gen Purpose Computation on GPU,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,CPSC-6780,2016
-CPSC,6810,1,Sel Top:Programming Team,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,brian christop dean,CPSC-6810,2016
-CPSC,6820,5,Spec Topics: Privacy and Secur,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,CPSC-6820,2016
-CPSC,6820,9,Special Topics: Data Science,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,eileen ther kraemer,CPSC-6820,2016
-CPSC,8070,1,3d Model Animation,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,CPSC-8070,2016
-CPSC,8070,2,3d Model Animation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,CPSC-8070,2016
-CPSC,8150,1,Fx Compositing,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,eric patterson,CPSC-8150,2016
-CPSC,8170,1,Physically Based Animation,0.33,0.48,0.14,0.0,0.0,0.0,0.0,0.05,donald henry house,CPSC-8170,2016
-CPSC,8200,1,Parallel Architechture,0.71,0.23,0.03,0.0,0.0,0.0,0.0,0.03,amy apon,CPSC-8200,2016
-CPSC,8270,1,Translation of Progr Languages,0.42,0.35,0.15,0.0,0.02,0.0,0.0,0.06,brian malloy,CPSC-8270,2016
-CPSC,8380,1,Adv Data Structures,0.17,0.17,0.17,0.0,0.5,0.0,0.0,0.0,sandra hedetniemi,CPSC-8380,2016
-CPSC,8480,1,Network Science,0.42,0.38,0.12,0.0,0.04,0.0,0.0,0.04,ilya mark safro,CPSC-8480,2016
-CPSC,8510,1,Soft Sys Data Comm,0.3,0.33,0.3,0.0,0.03,0.0,0.0,0.03,james martin,CPSC-8510,2016
-CPSC,8580,1,Security in Emerging Systems,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.02,hongxin hu,CPSC-8580,2016
-CPSC,8700,1,Software Design,0.5,0.18,0.1,0.0,0.05,0.0,0.0,0.18,philippa mign brown,CPSC-8700,2016
-CPSC,8730,1,"Software Verif, Valid & Measur",0.33,0.59,0.05,0.0,0.03,0.0,0.0,0.0,john mcgregor,CPSC-8730,2016
-CPSC,8810,2,Selected Topics: 3D Game Devel,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,CPSC-8810,2016
-CPSC,8810,3,Sel Top: Adv 3D Model and Scul,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,insun kwon,CPSC-8810,2016
-CRP,8010,1,Planning Process & Legal Found,0.42,0.46,0.0,0.0,0.08,0.0,0.0,0.04,caitlin dyckman,CRP-8010,2016
-CRP,8020,1,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,CRP-8020,2016
-CRP,8030,1,Quant Analysis,0.71,0.21,0.0,0.0,0.04,0.0,0.0,0.04,stephen sperry,CRP-8030,2016
-CRP,8060,1,Urban & Reg Econ for Planners,0.73,0.15,0.0,0.0,0.08,0.0,0.0,0.04,timothy green,CRP-8060,2016
-CRP,8140,1,Public Transit,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,CRP-8140,2016
-CRP,8580,2,Research Design,0.84,0.0,0.0,0.0,0.11,0.0,0.0,0.05,timothy green,CRP-8580,2016
-CRP,8600,3,Terminal Proj/Thesis Proposal,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,clifford dona ellis,CRP-8600,2016
-CRP,8600,6,Terminal Proj/Thesis Proposal,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,eric morris,CRP-8600,2016
-CRP,8720,1,Housing in the U S,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,miller cunningham,CRP-8720,2016
-CRP,8900,4,Dir Studies in City & Reg Plan,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,clifford dona ellis,CRP-8900,2016
-CSM,1000,1,Intro to Construct,0.25,0.48,0.23,0.02,0.02,0.0,0.0,0.0,jason lucas,CSM-1000,2016
-CSM,2010,1,Structures I,0.19,0.35,0.19,0.12,0.12,0.0,0.0,0.04,shima clarke,CSM-2010,2016
-CSM,2010,2,Structures I,0.33,0.17,0.29,0.08,0.08,0.0,0.0,0.04,shima clarke,CSM-2010,2016
-CSM,2030,1,Mats & Meth of Const,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,jason lucas,CSM-2030,2016
-CSM,2030,2,Mats & Meth of Const,0.32,0.5,0.11,0.0,0.0,0.0,0.0,0.07,jason lucas,CSM-2030,2016
-CSM,3030,1,Soils & Foundations,0.63,0.28,0.09,0.0,0.0,0.0,0.0,0.0,shima clarke,CSM-3030,2016
-CSM,3030,2,Soils & Foundations,0.56,0.34,0.09,0.0,0.0,0.0,0.0,0.0,shima clarke,CSM-3030,2016
-CSM,3040,1,Envir Systems I,0.23,0.48,0.23,0.06,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2016
-CSM,3040,2,Envir Systems I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2016
-CSM,3510,1,Const Estimating,0.23,0.5,0.27,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,CSM-3510,2016
-CSM,3510,2,Const Estimating,0.23,0.5,0.23,0.0,0.0,0.0,0.0,0.03,seyed mousavi rizi,CSM-3510,2016
-CSM,4110,1,Safety in Bldg Const,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,david devita,CSM-4110,2016
-CSM,4500,1,Construction Intern,0.38,0.32,0.1,0.0,0.2,0.0,0.0,0.0,roger william liska,CSM-4500,2016
-CSM,4530,1,Const Proj Mgmt,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-4530,2016
-CSM,4530,2,Const Proj Mgmt,0.08,0.58,0.33,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-4530,2016
-CSM,4610,1,Const Econ Seminar,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4610,2016
-CSM,4610,2,Const Econ Seminar,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4610,2016
-CSM,8600,1,Constr Finan Plan & Analysis,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8600,2016
-CSM,8600,400,Constr Finan Plan & Analysis,0.38,0.38,0.0,0.0,0.0,0.0,0.0,0.25,dennis bausman,CSM-8600,2016
-CSM,8630,1,Adv Plan/Sched,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-8630,2016
-CSM,8630,400,Adv Plan/Sched,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-8630,2016
-CSM,8660,1,Role in Development,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8660,2016
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.01,susan whorton,CU-1000,2016
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.25,0.0,susan whorton,CU-1000,2016
-CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.71,0.29,0.0,susan whorton,CU-1000,2016
-CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.21,0.02,susan whorton,CU-1000,2016
-CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.01,susan whorton,CU-1000,2016
-CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.71,0.29,0.0,susan whorton,CU-1000,2016
-CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.25,0.0,susan whorton,CU-1000,2016
-CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.69,0.3,0.01,susan whorton,CU-1000,2016
-CU,1000,9,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.66,0.34,0.01,susan whorton,CU-1000,2016
-CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.61,0.38,0.01,susan whorton,CU-1000,2016
-CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.59,0.41,0.01,susan whorton,CU-1000,2016
-CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.51,0.47,0.01,susan whorton,CU-1000,2016
-CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.51,0.48,0.01,susan whorton,CU-1000,2016
-CU,1000,15,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.41,0.58,0.01,susan whorton,CU-1000,2016
-CU,1010,2,Univ Success Skills,0.11,0.32,0.21,0.0,0.16,0.0,0.0,0.21,matthew james kirk,CU-1010,2016
-CU,1010,3,Univ Success Skills,0.69,0.06,0.06,0.13,0.0,0.0,0.0,0.06,mary mcp von kaenel,CU-1010,2016
-CU,1010,5,Univ Success Skills,0.32,0.05,0.32,0.16,0.16,0.0,0.0,0.0,cari allyn brooks,CU-1010,2016
-CU,1010,6,Univ Success Skills,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,mary mcp von kaenel,CU-1010,2016
-CU,2010,1,Sustainability Leadership,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,CU-2010,2016
-DANC,1400,1,Jazz Dance I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,cheryl hosler,DANC-1400,2016
-DPA,3070,1,Method 3d Production,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,summer 'nea benton,DPA-3070,2016
-DPA,4000,1,Tech Foundations I,0.0,0.0,0.09,0.0,0.64,0.0,0.0,0.27,andrew duchowski,DPA-4000,2016
-DPA,4020,2,Vis Foundations I,0.79,0.0,0.14,0.0,0.07,0.0,0.0,0.0,erik reed,DPA-4020,2016
-DPA,4020,3,Vis Foundations I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,pratham karnik,DPA-4020,2016
-ECE,2010,1,Logic and Computing Devices,0.24,0.25,0.27,0.08,0.12,0.0,0.0,0.04,william reid,ECE-2010,2016
-ECE,2020,1,Electric Circuits I,0.28,0.35,0.21,0.1,0.06,0.0,0.0,0.0,william harrell,ECE-2020,2016
-ECE,2020,3,Electric Circuits I,0.12,0.3,0.33,0.09,0.09,0.0,0.0,0.06,daniel bla cutshall,ECE-2020,2016
-ECE,2070,1,Basic Electrical Engineering,0.36,0.33,0.13,0.06,0.04,0.0,0.0,0.07,william th kolodzey,ECE-2070,2016
-ECE,2070,2,Basic Electrical Engineering,0.21,0.38,0.26,0.0,0.09,0.0,0.0,0.06,timothy anglea,ECE-2070,2016
-ECE,2070,3,Basic Electrical Engineering,0.46,0.29,0.12,0.02,0.02,0.0,0.0,0.1,amir ahmed asif,ECE-2070,2016
-ECE,2080,1,Basic Electrical Engr Lab,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,5,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,6,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,7,Basic Electrical Engr Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,8,Basic Electrical Engr Lab,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,10,Basic Electrical Engr Lab,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,12,Basic Electrical Engr Lab,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,13,Basic Electrical Engr Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,ECE-2080,2016
-ECE,2090,1,Logic Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2016
-ECE,2090,2,Logic Lab,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-2090,2016
-ECE,2090,3,Logic Lab,0.67,0.17,0.0,0.08,0.08,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2016
-ECE,2090,4,Logic Lab,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2016
-ECE,2090,5,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-2090,2016
-ECE,2090,7,Logic Lab,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-2090,2016
-ECE,2090,9,Logic Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2016
-ECE,2090,10,Logic Lab,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-2090,2016
-ECE,2110,1,Elec Engr Lab I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2110,2016
-ECE,2110,5,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2110,2016
-ECE,2110,6,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2110,2016
-ECE,2110,7,Elec Engr Lab I,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,ECE-2110,2016
-ECE,2110,9,Elec Engr Lab I,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,ECE-2110,2016
-ECE,2120,1,Electrical Engineering Lab II,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,apoorva dee kapadia,ECE-2120,2016
-ECE,2120,3,Electrical Engineering Lab II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,ECE-2120,2016
-ECE,2220,1,Syst Prog Concept,0.14,0.38,0.14,0.08,0.08,0.0,0.0,0.19,harlan russell,ECE-2220,2016
-ECE,2230,1,Comp Sys Eng,0.26,0.31,0.18,0.05,0.1,0.0,0.0,0.1,harlan russell,ECE-2230,2016
-ECE,2620,1,Electric Circuits II,0.26,0.19,0.3,0.09,0.12,0.0,0.0,0.05,liang dong,ECE-2620,2016
-ECE,2720,1,Comp Organization,0.17,0.37,0.29,0.12,0.05,0.0,0.0,0.0,william reid,ECE-2720,2016
-ECE,2730,2,Computer Org Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2016
-ECE,2730,3,Computer Org Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2016
-ECE,3110,2,Electrical Engineering Lab III,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2016
-ECE,3110,4,Electrical Engineering Lab III,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,apoorva dee kapadia,ECE-3110,2016
-ECE,3170,1,Rand Signal Analysis,0.16,0.4,0.31,0.07,0.04,0.0,0.0,0.02,stephen hubbard,ECE-3170,2016
-ECE,3200,1,Electronics I,0.12,0.31,0.31,0.12,0.13,0.0,0.0,0.03,stephen hubbard,ECE-3200,2016
-ECE,3200,2,Electronics I (HON),0.36,0.43,0.14,0.0,0.07,0.0,0.0,0.0,stephen hubbard,ECE-3200,2016
-ECE,3210,1,Electronics II,0.19,0.41,0.31,0.03,0.03,0.0,0.0,0.03,stephen hubbard,ECE-3210,2016
-ECE,3220,2,Intro Operating Sys,0.15,0.25,0.35,0.15,0.0,0.0,0.0,0.1,pradip srimani,ECE-3220,2016
-ECE,3270,1,Dig Comp Design,0.26,0.22,0.3,0.04,0.09,0.0,0.0,0.09,melissa crawl smith,ECE-3270,2016
-ECE,3300,1,Signals & Systems,0.13,0.23,0.32,0.18,0.08,0.0,0.0,0.06,carl baum,ECE-3300,2016
-ECE,3300,2,Signals & Systems (HON),0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,ECE-3300,2016
-ECE,3520,1,Programming Systems,0.43,0.29,0.0,0.07,0.14,0.0,0.0,0.07,robert schalkoff,ECE-3520,2016
-ECE,3600,1,Elect Power Engr,0.42,0.28,0.2,0.04,0.03,0.0,0.0,0.03,edward collins,ECE-3600,2016
-ECE,3710,1,Microcontr Interface,0.34,0.34,0.27,0.01,0.01,0.0,0.0,0.01,william reid,ECE-3710,2016
-ECE,3720,1,Micro Int Lab,0.42,0.33,0.17,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2016
-ECE,3720,2,Micro Int Lab,0.08,0.5,0.42,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2016
-ECE,3720,3,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-3720,2016
-ECE,3720,4,Micro Int Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-3720,2016
-ECE,3720,6,Micro Int Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-3720,2016
-ECE,3800,1,Electromagnetics,0.42,0.33,0.12,0.03,0.03,0.0,0.0,0.07,hai xiao,ECE-3800,2016
-ECE,3810,1,Field Waves & Ckts,0.09,0.43,0.31,0.09,0.09,0.0,0.0,0.0,anthony martin,ECE-3810,2016
-ECE,4090,1,Intr to Linear Control Systems,0.39,0.36,0.16,0.02,0.04,0.0,0.0,0.02,apoorva dee kapadia,ECE-4090,2016
-ECE,4180,1,Power Syst Analysis,0.35,0.27,0.27,0.04,0.04,0.0,0.0,0.04,elham makram,ECE-4180,2016
-ECE,4270,1,Communications Sys,0.37,0.27,0.13,0.15,0.08,0.0,0.0,0.0,madhabi manandhar,ECE-4270,2016
-ECE,4420,1,Knowledge Engr,0.33,0.38,0.05,0.1,0.0,0.0,0.0,0.14,robert schalkoff,ECE-4420,2016
-ECE,4490,1,Comp Ntwrk Security,0.32,0.42,0.03,0.0,0.05,0.0,0.0,0.18,richard brooks,ECE-4490,2016
-ECE,4610,1,Fundamentals of Solar Energy,0.47,0.39,0.08,0.03,0.03,0.0,0.0,0.0,rajendra singh,ECE-4610,2016
-ECE,4670,1,Intro to Dig Sig Pro,0.24,0.24,0.29,0.06,0.06,0.0,0.0,0.12,john gowdy,ECE-4670,2016
-ECE,4730,1,Intro Parallel Sys,0.15,0.69,0.15,0.0,0.0,0.0,0.0,0.0,walter ligon,ECE-4730,2016
-ECE,4950,1,Int Sys Design I,0.73,0.24,0.03,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-4950,2016
-ECE,4960,1,Int Sys Design II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2016
-ECE,6040,1,Semiconductor Devices,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-6040,2016
-ECE,6420,1,Knowledge Engr,0.41,0.31,0.14,0.0,0.14,0.0,0.0,0.0,robert schalkoff,ECE-6420,2016
-ECE,6490,1,Comp Ntwrk Security,0.31,0.38,0.13,0.0,0.13,0.0,0.0,0.06,lu yu,ECE-6490,2016
-ECE,6670,1,Intro to Dig Sig Pro,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,john gowdy,ECE-6670,2016
-ECE,6730,1,Intro Parallel Sys,0.33,0.25,0.0,0.0,0.33,0.0,0.0,0.08,walter ligon,ECE-6730,2016
-ECE,6930,5,Network science,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,ECE-6930,2016
-ECE,8010,1,Analysis of Lin Sys,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,richard groff,ECE-8010,2016
-ECE,8170,1,Power System Transients,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,ramtin hadidi,ECE-8170,2016
-ECE,8180,1,Rand Proc Appl Engr,0.46,0.38,0.0,0.0,0.15,0.0,0.0,0.0,carl baum,ECE-8180,2016
-ECE,8910,30,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,0.6,0.4,0.0,robert schalkoff,ECE-8910,2016
-ECON,2000,1,Economic Concepts,0.4,0.35,0.15,0.08,0.0,0.0,0.0,0.03,jonathan orr ernest,ECON-2000,2016
-ECON,2000,2,Economic Concepts,0.5,0.25,0.13,0.05,0.03,0.0,0.0,0.05,jonathan orr ernest,ECON-2000,2016
-ECON,2000,3,Economic Concepts,0.3,0.35,0.2,0.13,0.03,0.0,0.0,0.0,miren ivankovic,ECON-2000,2016
-ECON,2110,1,Principles of Microeconomics,0.17,0.61,0.11,0.0,0.11,0.0,0.0,0.0,frederick hanssen,ECON-2110,2016
-ECON,2110,2,Principles of Microeconomics,0.11,0.16,0.16,0.21,0.32,0.0,0.0,0.05,frederick hanssen,ECON-2110,2016
-ECON,2110,3,Principles of Microeconomics,0.06,0.44,0.28,0.11,0.06,0.0,0.0,0.06,frederick hanssen,ECON-2110,2016
-ECON,2110,4,Principles of Microeconomics,0.11,0.37,0.42,0.0,0.0,0.0,0.0,0.11,frederick hanssen,ECON-2110,2016
-ECON,2110,5,Principles of Microeconomics,0.0,0.37,0.26,0.26,0.05,0.0,0.0,0.05,frederick hanssen,ECON-2110,2016
-ECON,2110,6,Principles of Microeconomics,0.11,0.21,0.42,0.11,0.11,0.0,0.0,0.05,frederick hanssen,ECON-2110,2016
-ECON,2110,7,Principles of Microeconomics,0.11,0.47,0.11,0.05,0.16,0.0,0.0,0.11,frederick hanssen,ECON-2110,2016
-ECON,2110,8,Principles of Microeconomics,0.05,0.32,0.53,0.05,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2016
-ECON,2110,9,Principles of Microeconomics,0.11,0.47,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2016
-ECON,2110,10,Principles of Microeconomics,0.26,0.26,0.37,0.05,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2016
-ECON,2110,11,Principles of Microeconomics,0.06,0.56,0.22,0.11,0.0,0.0,0.0,0.06,frederick hanssen,ECON-2110,2016
-ECON,2110,12,Principles of Microeconomics,0.21,0.37,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2016
-ECON,2110,13,Principles of Microeconomics,0.13,0.44,0.31,0.0,0.06,0.0,0.0,0.06,frederick hanssen,ECON-2110,2016
-ECON,2110,14,Principles of Microeconomics,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,frederick hanssen,ECON-2110,2016
-ECON,2110,15,Principles of Microeconomics,0.16,0.47,0.26,0.0,0.11,0.0,0.0,0.0,frederick hanssen,ECON-2110,2016
-ECON,2110,16,Principles of Microeconomics,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2016
-ECON,2110,17,Principles of Microeconomics,0.05,0.53,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2016
-ECON,2110,18,Principles of Microeconomics,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,frederick hanssen,ECON-2110,2016
-ECON,2110,19,Principles of Microeconomics,0.05,0.47,0.21,0.16,0.05,0.0,0.0,0.05,frederick hanssen,ECON-2110,2016
-ECON,2110,20,Principles of Microeconomics,0.26,0.42,0.22,0.05,0.04,0.0,0.0,0.01,kelsey vict roberts,ECON-2110,2016
-ECON,2110,21,Principles of Microeconomics,0.18,0.41,0.35,0.02,0.0,0.0,0.0,0.04,bradley keith hobbs,ECON-2110,2016
-ECON,2110,22,Principles of Microeconomics,0.45,0.27,0.16,0.05,0.05,0.0,0.0,0.02,benjamin jo schwall,ECON-2110,2016
-ECON,2110,23,Principles of Microeconomics,0.24,0.4,0.16,0.09,0.06,0.0,0.0,0.04,leah jacq kitashima,ECON-2110,2016
-ECON,2110,24,Principles of Microeconomics,0.27,0.31,0.2,0.08,0.08,0.0,0.0,0.06,amanda caitlin kerr,ECON-2110,2016
-ECON,2110,25,Principles of Microeconomics,0.23,0.5,0.1,0.03,0.05,0.0,0.0,0.1,roksan ghanbariamin,ECON-2110,2016
-ECON,2110,26,Principles of Microeconomics,0.38,0.29,0.13,0.09,0.02,0.0,0.0,0.09,steven johnson,ECON-2110,2016
-ECON,2110,31,Principles of Microeconomics,0.44,0.36,0.1,0.04,0.03,0.0,0.0,0.04,maria droganova,ECON-2110,2016
-ECON,2110,32,Principles of Microeconomics,0.29,0.36,0.29,0.07,0.0,0.0,0.0,0.0,zhiqi zhao,ECON-2110,2016
-ECON,2110,33,Principles of Microeconomics,0.38,0.28,0.15,0.08,0.03,0.0,0.0,0.08,liuna issagholian,ECON-2110,2016
-ECON,2110,34,Principles of Microeconomics,0.33,0.26,0.28,0.08,0.0,0.0,0.0,0.05,liuna issagholian,ECON-2110,2016
-ECON,2110,35,Principles of Microeconomics,0.38,0.38,0.13,0.08,0.03,0.0,0.0,0.03,roksan ghanbariamin,ECON-2110,2016
-ECON,2110,38,Principles of Microeconomics,0.21,0.6,0.14,0.0,0.02,0.0,0.0,0.02,chen wang,ECON-2110,2016
-ECON,2110,40,Principles of Micro (HON),0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,charles thomas,ECON-2110,2016
-ECON,2110,41,Principles of Microeconomics,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,chen wang,ECON-2110,2016
-ECON,2120,1,Principles of Macroeconomics,0.07,0.16,0.16,0.16,0.16,0.0,0.0,0.29,ralph charles allen,ECON-2120,2016
-ECON,2120,2,Principles of Macroeconomics,0.32,0.39,0.16,0.07,0.02,0.0,0.0,0.05,wing yin chung,ECON-2120,2016
-ECON,2120,3,Principles of Macroeconomics,0.11,0.21,0.23,0.18,0.13,0.0,0.0,0.14,ralph charles allen,ECON-2120,2016
-ECON,2120,4,Principles of Macroeconomics,0.22,0.22,0.32,0.07,0.12,0.0,0.0,0.05,peter david lorenz,ECON-2120,2016
-ECON,2120,5,Principles of Macroeconomics,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,huili li,ECON-2120,2016
-ECON,2120,6,Principles of Macroeconomics,0.78,0.2,0.03,0.0,0.0,0.0,0.0,0.0,huili li,ECON-2120,2016
-ECON,2120,7,Principles of Macroeconomics,0.28,0.35,0.25,0.13,0.0,0.0,0.0,0.0,peter david lorenz,ECON-2120,2016
-ECON,2120,8,Principles of Macroeconomics,0.18,0.44,0.24,0.08,0.02,0.0,0.0,0.05,ce castellon chicas,ECON-2120,2016
-ECON,2120,9,Principles of Macroeconomics,0.43,0.32,0.14,0.05,0.0,0.0,0.0,0.05,jordan adamson,ECON-2120,2016
-ECON,2120,10,Principles of Macroeconomics,0.17,0.42,0.22,0.11,0.06,0.0,0.0,0.03,andrew chaffee,ECON-2120,2016
-ECON,3020,1,Money and Banking,0.24,0.22,0.3,0.08,0.08,0.0,0.0,0.08,smriti bhargava,ECON-3020,2016
-ECON,3060,1,Managerial Economics,0.21,0.34,0.29,0.08,0.05,0.0,0.0,0.03,timothy jay bacon,ECON-3060,2016
-ECON,3100,1,International Econ,0.32,0.41,0.13,0.01,0.07,0.0,0.0,0.06,scott baier,ECON-3100,2016
-ECON,3140,1,Intermediate Micro,0.38,0.11,0.3,0.09,0.09,0.0,0.0,0.02,patrick warren,ECON-3140,2016
-ECON,3140,2,Intermediate Micro,0.32,0.44,0.19,0.02,0.0,0.0,0.0,0.03,molly espey,ECON-3140,2016
-ECON,3140,3,Intermediate Micro,0.28,0.21,0.28,0.09,0.06,0.0,0.0,0.09,robert kennet fleck,ECON-3140,2016
-ECON,3150,1,Intermediate Macro,0.22,0.29,0.24,0.04,0.06,0.0,0.0,0.16,sergey vla mityakov,ECON-3150,2016
-ECON,3150,2,Intermediate Macro,0.22,0.34,0.2,0.17,0.05,0.0,0.0,0.02,michal jerzmanowski,ECON-3150,2016
-ECON,3190,1,Environmental Econ,0.05,0.46,0.35,0.08,0.05,0.0,0.0,0.0,molly espey,ECON-3190,2016
-ECON,3500,1,Moral & Ethical Econ,0.1,0.33,0.29,0.05,0.1,0.0,0.0,0.14,bradley keith hobbs,ECON-3500,2016
-ECON,3600,1,Public Choice,0.41,0.15,0.15,0.17,0.02,0.0,0.0,0.1,michael makowsky,ECON-3600,2016
-ECON,4010,1,Labor Mkt Analysis,0.42,0.21,0.16,0.16,0.05,0.0,0.0,0.0,chungsang lam,ECON-4010,2016
-ECON,4040,1,Comp Econ Systems,0.22,0.19,0.15,0.07,0.19,0.0,0.0,0.19,dar litsukova-bokar,ECON-4040,2016
-ECON,4050,5,Intro to Econometric,0.18,0.34,0.24,0.04,0.1,0.0,0.0,0.1,scott barkowski,ECON-4050,2016
-ECON,4100,1,Economic Development,0.44,0.19,0.04,0.0,0.07,0.0,0.0,0.26,robert tamura,ECON-4100,2016
-ECON,4110,2,Econ of Education,0.27,0.5,0.08,0.0,0.04,0.0,0.0,0.12,peter quarter blair,ECON-4110,2016
-ECON,4120,1,International Micro,0.42,0.36,0.13,0.07,0.0,0.0,0.0,0.02,richard alan sessa,ECON-4120,2016
-ECON,4220,1,Monetary Economics,0.45,0.42,0.09,0.0,0.03,0.0,0.0,0.0,gerald dwyer,ECON-4220,2016
-ECON,6060,1,Advanced Econometric,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,ECON-6060,2016
-ECON,8010,1,Microeconomic Theory,0.26,0.37,0.26,0.0,0.05,0.0,0.0,0.05,william dougan,ECON-8010,2016
-ECON,8040,1,Applied Math Econ,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,ECON-8040,2016
-ECON,8060,1,Econometrics I,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,ECON-8060,2016
-ECON,8080,1,Econometrics III,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,paul wayne wilson,ECON-8080,2016
-ECON,8160,1,Labor Economics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,ECON-8160,2016
-ECON,8210,1,Public Choice,0.5,0.17,0.17,0.0,0.17,0.0,0.0,0.0,patrick warren,ECON-8210,2016
-ECON,8230,1,Microecon Pub Pol,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,ECON-8230,2016
-ECON,8240,1,Org of Industry,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew lewis,ECON-8240,2016
-ECON,8260,1,Econ Theory of Govt Regulation,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,ECON-8260,2016
-ECON,8550,1,Financial Economics,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,sergey vla mityakov,ECON-8550,2016
-ECON,9010,1,Price Theory,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,charles thomas,ECON-9010,2016
-ED,1970,1,Student of Color Experience CI,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2016
-ED,1970,2,Student of Color Experience CI,0.76,0.1,0.05,0.0,0.1,0.0,0.0,0.0,deonte brown,ED-1970,2016
-ED,1970,3,Student of Color Experience CI,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,deonte brown,ED-1970,2016
-ED,8700,1,STEAM Instructional Design,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,cassie fay quigley,ED-8700,2016
-ED,8720,500,STEAM Enacted and Evaluated,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,danielle chri herro,ED-8720,2016
-EDC,8050,1,Clinical Mh Couns,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,david scott,EDC-8050,2016
-EDC,8130,400,Appraisal Procedures,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,jennifer lyn brooks,EDC-8130,2016
-EDEC,8200,500,Adv Ece Curriculum,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-8200,2016
-EDEL,3210,1,Pe for the Elem Tchr,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2016
-EDEL,3210,2,Pe for the Elem Tchr,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,deborah smith,EDEL-3210,2016
-EDEL,4510,1,Elem Methods in Science Tchg,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,EDEL-4510,2016
-EDEL,4870,1,Ele Meth Soc Studies,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,EDEL-4870,2016
-EDEL,4880,1,Elem Meth La Tchng,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,EDEL-4880,2016
-EDF,3010,1,Principles of American Educat,0.52,0.22,0.17,0.09,0.0,0.0,0.0,0.0,suzanne rosenblith,EDF-3010,2016
-EDF,3020,1,Educational Psychology,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.03,heather rog brooker,EDF-3020,2016
-EDF,3080,1,Classroom Assessment,0.56,0.32,0.08,0.0,0.0,0.0,0.0,0.04,deborah switzer,EDF-3080,2016
-EDF,3080,2,Classroom Assessment,0.71,0.19,0.1,0.0,0.0,0.0,0.0,0.0,deborah switzer,EDF-3080,2016
-EDF,3340,3,Child Growth and Development,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,faiza marghoo jamil,EDF-3340,2016
-EDF,3350,1,Adolescent Growth & Develop,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,EDF-3350,2016
-EDF,4800,1,Digital Media & Learning,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,ryan visser,EDF-4800,2016
-EDF,4800,2,Digital Media & Learning,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2016
-EDF,4800,3,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,danielle chri herro,EDF-4800,2016
-EDF,4800,300,Digital Media & Learning,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,ryan visser,EDF-4800,2016
-EDF,8770,300,Research Meth in Education I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,carleton dew salley,EDF-8770,2016
-EDF,9270,1,Quant Rsrch & Stats for Ed,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,EDF-9270,2016
-EDF,9270,2,Quant Rsrch & Stats for Ed,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,jennie lynn farmer,EDF-9270,2016
-EDF,9810,1,Design-Based Research Methods,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,david paul reinking,EDF-9810,2016
-EDHD,8310,500,Lit Outcomes for Child w disab,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,vicki steadman,EDHD-8310,2016
-EDL,7000,501,Public School Adm,0.79,0.07,0.0,0.0,0.14,0.0,0.0,0.0,frederick buskey,EDL-7000,2016
-EDL,7200,400,School Personnel Adm,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,kathryn le 'andrea,EDL-7200,2016
-EDL,7500,500,El Prin & Spv Ex I,0.71,0.0,0.0,0.0,0.29,0.0,0.0,0.0,frederick buskey,EDL-7500,2016
-EDL,8150,501,The Superintendency,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,elizabeth reynolds,EDL-8150,2016
-EDL,8390,401,Research in Ed L,0.42,0.42,0.0,0.0,0.17,0.0,0.0,0.0,kristin kelly frady,EDL-8390,2016
-EDL,8510,501,School Sys Prac II,0.21,0.0,0.0,0.0,0.79,0.0,0.0,0.0,elizabeth reynolds,EDL-8510,2016
-EDL,8850,512,STEM - School Admin,0.44,0.0,0.0,0.0,0.56,0.0,0.0,0.0,william havice,EDL-8850,2016
-EDL,9100,400,Intro Phd Seminar,0.82,0.0,0.0,0.0,0.18,0.0,0.0,0.0,jane lindle,EDL-9100,2016
-EDL,9650,1,Higher Ed Finance,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,EDL-9650,2016
-EDLT,4600,1,Teaching Reading Grades 2-6,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,EDLT-4600,2016
-EDLT,4600,3,Teaching Reading Grades 2-6,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4600,2016
-EDLT,4600,5,Teaching Reading Grades 2-6,0.69,0.19,0.04,0.0,0.0,0.0,0.0,0.08,pamela dunston,EDLT-4600,2016
-EDLT,4610,1,Content Area Rdg: Grades 2-6,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-4610,2016
-EDLT,4980,1,Secondary Content Area Reading,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,corrie leigh martin,EDLT-4980,2016
-EDLT,8160,500,Literacy Instruction Practicum,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,EDLT-8160,2016
-EDLT,8400,500,Early Literacy Assessment I,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,andrea chri overton,EDLT-8400,2016
-EDLT,8400,504,Early Literacy Assessment I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,EDLT-8400,2016
-EDLT,9370,501,Reading Recovery Theory I,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,celeste compt bates,EDLT-9370,2016
-EDML,8340,400,Envir Sci for Mid Sch Teachers,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,michelle patri cook,EDML-8340,2016
-EDSA,8030,1,Student Dev Servc in Higher Ed,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,EDSA-8030,2016
-EDSA,8030,2,Student Dev Servc in Higher Ed,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,EDSA-8030,2016
-EDSC,2260,1,Pr Apprch to Sec Alg,0.31,0.54,0.08,0.0,0.08,0.0,0.0,0.0,stacy megan che,EDSC-2260,2016
-EDSC,3240,1,Practicum Sec Engl,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,EDSC-3240,2016
-EDSC,4260,1,Tchng Sec Math,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,carlos gomez,EDSC-4260,2016
-EDSC,8610,400,Mthds & Strt Secondary Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,EDSC-8610,2016
-EDSP,3700,2,Intro to Special Education,0.79,0.15,0.06,0.0,0.0,0.0,0.0,0.0,tracy denis garrett,EDSP-3700,2016
-EDSP,3700,3,Intro to Special Education,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,jennifer my- counts,EDSP-3700,2016
-EDSP,3700,4,Intro to Special Education,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,michelle lee popham,EDSP-3700,2016
-EDSP,3740,1,Char & Strat Emot/Behav Disord,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,EDSP-3740,2016
-EDSP,4920,1,Math Inst Ind W/Dis,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela stecker,EDSP-4920,2016
-EDSP,4940,1,Tchg Rdg Mild Dis,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,EDSP-4940,2016
-EDSP,8220,400,Tchg Math Indv W/Dis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,EDSP-8220,2016
-EDSP,8530,1,Legal/Pol Issu Sp Ed,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,antonis katsiyannis,EDSP-8530,2016
-EES,2010,1,Environ Engr Fundamentals I,0.38,0.27,0.17,0.04,0.1,0.0,0.0,0.04,david freedman,EES-2010,2016
-EES,3030,1,Water Treatment Systems,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3030,2016
-EES,3040,1,Wastewater Treatment Systems,0.43,0.39,0.18,0.0,0.0,0.0,0.0,0.0,sudeep popat,EES-3040,2016
-EES,3050,1,Water/Wastewater Treatment Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2016
-EES,3050,2,Water/Wastewater Treatment Lab,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2016
-EES,4010,1,Environmental Engr,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,elizabeth carraway,EES-4010,2016
-EES,4010,2,Environmental Engr,0.17,0.26,0.43,0.13,0.0,0.0,0.0,0.0,mark schlautman,EES-4010,2016
-EES,4100,1,Environ Radiation Protection I,0.27,0.36,0.09,0.18,0.0,0.0,0.0,0.09,nicole eli martinez,EES-4100,2016
-EES,4300,1,Air Pollution Engineering,0.21,0.54,0.21,0.04,0.0,0.0,0.0,0.0,thomas overcamp,EES-4300,2016
-EES,4800,1,Environmental Risk Assessment,0.58,0.19,0.22,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,EES-4800,2016
-EES,4860,5,Environmental Sustainability,0.6,0.23,0.14,0.0,0.0,0.0,0.0,0.03,michael anthon dale,EES-4860,2016
-EES,8020,1,Environ Eng Prin,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-8020,2016
-EES,8430,1,Environmental Chem,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,EES-8430,2016
-EES,8510,1,Biol Prin Envir Engr,0.66,0.28,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,EES-8510,2016
-EES,8610,1,Env Engr&Sci Seminar,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,ezra lucas ho cates,EES-8610,2016
-EES,8800,1,Env Risk Assessment,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,EES-8800,2016
-ELE,3010,1,Intro to Entre,0.59,0.23,0.13,0.05,0.0,0.0,0.0,0.0,christina kyprianou,ELE-3010,2016
-ELE,3010,2,Intro to Entre,0.51,0.38,0.03,0.03,0.0,0.0,0.0,0.05,christina kyprianou,ELE-3010,2016
-ELE,3010,3,Intro to Entre,0.11,0.45,0.42,0.0,0.03,0.0,0.0,0.0,ashley will parnell,ELE-3010,2016
-ELE,4010,1,Exec Lead & Entr II,0.04,0.29,0.51,0.11,0.0,0.0,0.0,0.04,ashley will parnell,ELE-4010,2016
-ENGL,1030,1,Accelerated Composition,0.0,0.79,0.16,0.0,0.0,0.0,0.0,0.05,renesha moniq poole,ENGL-1030,2016
-ENGL,1030,2,Accelerated Composition,0.42,0.47,0.0,0.05,0.05,0.0,0.0,0.0,renesha moniq poole,ENGL-1030,2016
-ENGL,1030,3,Accelerated Composition,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,christa kettlewell,ENGL-1030,2016
-ENGL,1030,4,Accelerated Composition,0.63,0.11,0.05,0.05,0.11,0.0,0.0,0.05,chloe helene cahill,ENGL-1030,2016
-ENGL,1030,5,Accelerated Composition,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,laurie pfister epps,ENGL-1030,2016
-ENGL,1030,7,Accelerated Composition,0.5,0.28,0.06,0.11,0.06,0.0,0.0,0.0,robert brissey,ENGL-1030,2016
-ENGL,1030,8,Accelerated Composition,0.42,0.47,0.05,0.0,0.05,0.0,0.0,0.0,christa kettlewell,ENGL-1030,2016
-ENGL,1030,9,Accelerated Composition,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,chloe helene cahill,ENGL-1030,2016
-ENGL,1030,10,Accelerated Composition,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,laurie pfister epps,ENGL-1030,2016
-ENGL,1030,12,Accelerated Composition,0.37,0.37,0.16,0.0,0.11,0.0,0.0,0.0,robert brissey,ENGL-1030,2016
-ENGL,1030,15,Accelerated Composition,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,karen kettnich,ENGL-1030,2016
-ENGL,1030,17,Accelerated Composition,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,matthew scot duncan,ENGL-1030,2016
-ENGL,1030,18,Accelerated Composition,0.74,0.11,0.0,0.0,0.0,0.0,0.0,0.16,parker elizabe king,ENGL-1030,2016
-ENGL,1030,19,Accelerated Composition,0.42,0.32,0.05,0.16,0.05,0.0,0.0,0.0,jennifer forsberg,ENGL-1030,2016
-ENGL,1030,21,Accelerated Composition,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulo green,ENGL-1030,2016
-ENGL,1030,22,Accelerated Composition,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,benjamin hudson,ENGL-1030,2016
-ENGL,1030,23,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,katie jo vann,ENGL-1030,2016
-ENGL,1030,24,Accelerated Composition,0.35,0.47,0.06,0.0,0.06,0.0,0.0,0.06,matthew scot duncan,ENGL-1030,2016
-ENGL,1030,25,Accelerated Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,parker elizabe king,ENGL-1030,2016
-ENGL,1030,26,Accelerated Composition,0.53,0.37,0.0,0.0,0.11,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2016
-ENGL,1030,27,Accelerated Composition,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2016
-ENGL,1030,29,Accelerated Composition,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,dia quaglia beltran,ENGL-1030,2016
-ENGL,1030,30,Accelerated Composition,0.32,0.42,0.11,0.0,0.16,0.0,0.0,0.0,la'cresha ulo green,ENGL-1030,2016
-ENGL,1030,31,Accelerated Composition,0.67,0.17,0.06,0.06,0.06,0.0,0.0,0.0,brian lee gaines,ENGL-1030,2016
-ENGL,1030,32,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kala parker,ENGL-1030,2016
-ENGL,1030,33,Accelerated Composition,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,michael davi measel,ENGL-1030,2016
-ENGL,1030,34,Accelerated Composition,0.6,0.27,0.07,0.0,0.07,0.0,0.0,0.0,charlotte est lucke,ENGL-1030,2016
-ENGL,1030,35,Accelerated Composition,0.87,0.0,0.07,0.0,0.07,0.0,0.0,0.0,kala parker,ENGL-1030,2016
-ENGL,1030,37,Accelerated Composition,0.6,0.13,0.07,0.07,0.07,0.0,0.0,0.07,brian lee gaines,ENGL-1030,2016
-ENGL,1030,38,Accelerated Composition,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2016
-ENGL,1030,39,Accelerated Composition,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,yvonne kao,ENGL-1030,2016
-ENGL,1030,41,Accelerated Composition,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,ENGL-1030,2016
-ENGL,1030,42,Accelerated Composition,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,benjamin hudson,ENGL-1030,2016
-ENGL,1030,43,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,eric stephens,ENGL-1030,2016
-ENGL,1030,44,Accelerated Composition,0.89,0.0,0.05,0.0,0.05,0.0,0.0,0.0,daniel frank,ENGL-1030,2016
-ENGL,1030,45,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen quigley,ENGL-1030,2016
-ENGL,1030,46,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,april obrien,ENGL-1030,2016
-ENGL,1030,47,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,samuel jacks fuller,ENGL-1030,2016
-ENGL,1030,49,Accelerated Composition,0.56,0.28,0.0,0.0,0.11,0.0,0.0,0.06,karen kettnich,ENGL-1030,2016
-ENGL,1030,50,Accelerated Composition,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,michael russo,ENGL-1030,2016
-ENGL,1030,51,Accelerated Composition,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,april obrien,ENGL-1030,2016
-ENGL,1030,52,Accelerated Composition,0.53,0.37,0.0,0.05,0.0,0.0,0.0,0.05,eric stephens,ENGL-1030,2016
-ENGL,1030,53,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,ENGL-1030,2016
-ENGL,1030,55,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,whitney jorda adams,ENGL-1030,2016
-ENGL,1030,57,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2016
-ENGL,1030,58,Accelerated Composition,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-1030,2016
-ENGL,1030,59,Accelerated Composition,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,charlotte est lucke,ENGL-1030,2016
-ENGL,1030,61,Accelerated Composition,0.84,0.0,0.11,0.05,0.0,0.0,0.0,0.0,stephen quigley,ENGL-1030,2016
-ENGL,1030,64,Accelerated Composition,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,christopher stuart,ENGL-1030,2016
-ENGL,1030,65,Accelerated Composition,0.07,0.79,0.0,0.0,0.07,0.0,0.0,0.07,barbara ramirez,ENGL-1030,2016
-ENGL,1030,67,Accelerated Composition,0.63,0.21,0.05,0.0,0.05,0.0,0.0,0.05,daniel scott citro,ENGL-1030,2016
-ENGL,1030,69,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-1030,2016
-ENGL,1030,70,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,ENGL-1030,2016
-ENGL,1030,71,Accelerated Composition,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,joshua wood,ENGL-1030,2016
-ENGL,1030,72,Accelerated Composition,0.42,0.26,0.0,0.05,0.05,0.0,0.0,0.21,joshua wood,ENGL-1030,2016
-ENGL,1030,73,Accelerated Composition,0.69,0.0,0.08,0.0,0.23,0.0,0.0,0.0,jennifer forsberg,ENGL-1030,2016
-ENGL,1030,75,Accelerated Composition,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,yvonne kao,ENGL-1030,2016
-ENGL,1030,76,Accelerated Composition,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,katie jo vann,ENGL-1030,2016
-ENGL,1030,77,Accelerated Composition,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,michael davi measel,ENGL-1030,2016
-ENGL,1030,79,Accelerated Composition,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-1030,2016
-ENGL,1030,80,Accelerated Composition,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,christopher stuart,ENGL-1030,2016
-ENGL,1030,81,Accelerated Composition,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,sharif youssef,ENGL-1030,2016
-ENGL,1030,84,Accelerated Composition,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,erica mich marquard,ENGL-1030,2016
-ENGL,1030,85,Accelerated Composition,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,erica mich marquard,ENGL-1030,2016
-ENGL,1030,86,Accelerated Composition,0.11,0.78,0.0,0.0,0.06,0.0,0.0,0.06,barbara ramirez,ENGL-1030,2016
-ENGL,1030,501,Accelerated Composition,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-1030,2016
-ENGL,2120,3,World Literature,0.63,0.26,0.0,0.04,0.0,0.0,0.0,0.07,sharif youssef,ENGL-2120,2016
-ENGL,2120,4,World Literature,0.72,0.1,0.14,0.0,0.0,0.0,0.0,0.03,allen swords,ENGL-2120,2016
-ENGL,2120,5,World Literature,0.86,0.0,0.11,0.0,0.0,0.0,0.0,0.04,allen swords,ENGL-2120,2016
-ENGL,2120,6,World Literature,0.41,0.3,0.11,0.11,0.04,0.0,0.0,0.04,krist aldebol-hazle,ENGL-2120,2016
-ENGL,2120,7,World Literature,0.54,0.14,0.04,0.07,0.18,0.0,0.0,0.04,krist aldebol-hazle,ENGL-2120,2016
-ENGL,2120,8,World Literature,0.57,0.29,0.04,0.04,0.04,0.0,0.0,0.04,sharif youssef,ENGL-2120,2016
-ENGL,2120,9,World Literature,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,stephanie stripling,ENGL-2120,2016
-ENGL,2120,10,World Literature,0.93,0.04,0.0,0.0,0.04,0.0,0.0,0.0,stephanie stripling,ENGL-2120,2016
-ENGL,2120,11,World Literature,0.41,0.37,0.11,0.04,0.07,0.0,0.0,0.0,andrew mathas,ENGL-2120,2016
-ENGL,2120,12,World Literature,0.31,0.31,0.24,0.03,0.0,0.0,0.0,0.1,karen kettnich,ENGL-2120,2016
-ENGL,2120,13,World Literature,0.16,0.56,0.12,0.04,0.0,0.0,0.0,0.12,karen kettnich,ENGL-2120,2016
-ENGL,2120,14,World Literature,0.17,0.21,0.42,0.04,0.04,0.0,0.0,0.13,david charles foltz,ENGL-2120,2016
-ENGL,2120,15,World Literature,0.32,0.28,0.16,0.08,0.04,0.0,0.0,0.12,david charles foltz,ENGL-2120,2016
-ENGL,2120,16,World Literature,0.59,0.33,0.04,0.04,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2120,2016
-ENGL,2120,17,World Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2120,2016
-ENGL,2120,18,World Literature,0.68,0.25,0.04,0.0,0.0,0.0,0.0,0.04,lucian ghita,ENGL-2120,2016
-ENGL,2120,19,World Literature,0.33,0.37,0.15,0.0,0.07,0.0,0.0,0.07,andrew mathas,ENGL-2120,2016
-ENGL,2120,20,World Literature,0.64,0.21,0.0,0.04,0.04,0.0,0.0,0.07,sharif youssef,ENGL-2120,2016
-ENGL,2120,21,World Literature (Majors),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michelle renee ty,ENGL-2120,2016
-ENGL,2130,1,British Literature,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,ENGL-2130,2016
-ENGL,2130,3,British Literature,0.57,0.32,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-2130,2016
-ENGL,2130,4,British Literature,0.56,0.41,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,ENGL-2130,2016
-ENGL,2130,5,British Literature,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,christopher benson,ENGL-2130,2016
-ENGL,2130,7,British Literature,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,ENGL-2130,2016
-ENGL,2130,9,British Literature,0.68,0.14,0.07,0.04,0.0,0.0,0.0,0.07,krist aldebol-hazle,ENGL-2130,2016
-ENGL,2130,10,British Literature,0.36,0.43,0.14,0.0,0.04,0.0,0.0,0.04,christopher benson,ENGL-2130,2016
-ENGL,2130,11,British Literature,0.89,0.04,0.0,0.04,0.04,0.0,0.0,0.0,stephanie stripling,ENGL-2130,2016
-ENGL,2130,12,British Literature,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,stephanie stripling,ENGL-2130,2016
-ENGL,2130,13,British Literature,0.68,0.29,0.0,0.0,0.04,0.0,0.0,0.0,lucian ghita,ENGL-2130,2016
-ENGL,2140,1,American Literature,0.5,0.15,0.0,0.04,0.08,0.0,0.0,0.23,candace wiley,ENGL-2140,2016
-ENGL,2140,5,American Literature,0.39,0.43,0.04,0.07,0.04,0.0,0.0,0.04,erin nicholson gale,ENGL-2140,2016
-ENGL,2140,6,American Literature,0.41,0.33,0.11,0.04,0.04,0.0,0.0,0.07,erin nicholson gale,ENGL-2140,2016
-ENGL,2140,7,American Literature,0.46,0.25,0.21,0.0,0.04,0.0,0.0,0.04,john logan pursley,ENGL-2140,2016
-ENGL,2140,8,American Literature,0.46,0.12,0.0,0.08,0.0,0.0,0.0,0.35,candace wiley,ENGL-2140,2016
-ENGL,2140,9,American Literature,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2140,2016
-ENGL,2140,14,American Literature,0.56,0.26,0.07,0.0,0.04,0.0,0.0,0.07,adrian carson,ENGL-2140,2016
-ENGL,2140,15,American Literature,0.26,0.41,0.22,0.04,0.0,0.0,0.0,0.07,susanna ashton,ENGL-2140,2016
-ENGL,2140,16,American Literature,0.61,0.29,0.11,0.0,0.0,0.0,0.0,0.0,austin gorman,ENGL-2140,2016
-ENGL,2140,17,American Literature,0.48,0.12,0.2,0.08,0.08,0.0,0.0,0.04,adrian carson,ENGL-2140,2016
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.59,0.19,0.11,0.04,0.0,0.0,0.0,0.07,jennifer forsberg,ENGL-2150,2016
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.63,0.22,0.11,0.0,0.04,0.0,0.0,0.0,jennifer forsberg,ENGL-2150,2016
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.32,0.26,0.16,0.11,0.05,0.0,0.0,0.11,candace wiley,ENGL-2150,2016
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.22,0.56,0.11,0.0,0.04,0.0,0.0,0.07,david charles foltz,ENGL-2150,2016
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.15,0.37,0.26,0.0,0.11,0.0,0.0,0.11,david charles foltz,ENGL-2150,2016
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.57,0.17,0.04,0.04,0.04,0.0,0.0,0.13,candace wiley,ENGL-2150,2016
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-2150,2016
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.39,0.5,0.07,0.04,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2150,2016
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2150,2016
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.65,0.23,0.08,0.0,0.04,0.0,0.0,0.0,erin nicholson gale,ENGL-2150,2016
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.54,0.35,0.0,0.04,0.0,0.0,0.0,0.08,erin nicholson gale,ENGL-2150,2016
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.79,0.14,0.04,0.0,0.0,0.0,0.0,0.04,katie jo vann,ENGL-2150,2016
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.36,0.29,0.21,0.04,0.04,0.0,0.0,0.07,megan no macalystre,ENGL-2150,2016
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.5,0.29,0.11,0.07,0.04,0.0,0.0,0.0,megan no macalystre,ENGL-2150,2016
-ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.48,0.26,0.22,0.04,0.0,0.0,0.0,0.0,andrew mathas,ENGL-2150,2016
-ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.5,0.21,0.04,0.11,0.07,0.0,0.0,0.07,andrew mathas,ENGL-2150,2016
-ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.82,0.0,0.04,0.0,0.07,0.0,0.0,0.07,katie jo vann,ENGL-2150,2016
-ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,benjamin hudson,ENGL-2150,2016
-ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.74,0.19,0.0,0.0,0.0,0.0,0.0,0.07,benjamin hudson,ENGL-2150,2016
-ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-2150,2016
-ENGL,2150,100,20th - 21st Century Lit (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-2150,2016
-ENGL,3010,1,Grt Books West World,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,eric allison,ENGL-3010,2016
-ENGL,3040,3,Business Writing,0.84,0.05,0.05,0.05,0.0,0.0,0.0,0.0,melissa dugan,ENGL-3040,2016
-ENGL,3040,5,Business Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3040,2016
-ENGL,3040,11,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-3040,2016
-ENGL,3040,13,Business Writing,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,ENGL-3040,2016
-ENGL,3040,15,Business Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3040,2016
-ENGL,3040,19,Business Writing,0.37,0.47,0.05,0.0,0.0,0.0,0.0,0.11,katalin beck,ENGL-3040,2016
-ENGL,3040,20,Business Writing,0.26,0.58,0.05,0.0,0.05,0.0,0.0,0.05,katalin beck,ENGL-3040,2016
-ENGL,3040,400,Business Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-3040,2016
-ENGL,3040,401,Business Writing,0.61,0.28,0.06,0.0,0.06,0.0,0.0,0.0,jillian weise,ENGL-3040,2016
-ENGL,3040,402,Business Writing,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,hayley ren zertuche,ENGL-3040,2016
-ENGL,3040,403,Business Writing,0.76,0.06,0.0,0.0,0.06,0.0,0.0,0.12,hayley ren zertuche,ENGL-3040,2016
-ENGL,3040,404,Business Writing,0.56,0.19,0.06,0.0,0.06,0.0,0.0,0.13,hayley ren zertuche,ENGL-3040,2016
-ENGL,3040,405,Business Writing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,ENGL-3040,2016
-ENGL,3040,406,Business Writing,0.27,0.47,0.27,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,ENGL-3040,2016
-ENGL,3040,407,Business Writing,0.07,0.6,0.07,0.07,0.07,0.0,0.0,0.13,steph kartalopoulos,ENGL-3040,2016
-ENGL,3040,408,Business Writing,0.29,0.35,0.0,0.12,0.12,0.0,0.0,0.12,steph kartalopoulos,ENGL-3040,2016
-ENGL,3040,409,Business Writing,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,steph kartalopoulos,ENGL-3040,2016
-ENGL,3100,1,Crit Writ Lit,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,david sweene coombs,ENGL-3100,2016
-ENGL,3100,3,Crit Writ Lit,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,michelle renee ty,ENGL-3100,2016
-ENGL,3100,4,Crit Writ Lit,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,michael lemahieu,ENGL-3100,2016
-ENGL,3120,1,Advanced Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2016
-ENGL,3120,2,Advanced Composition,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2016
-ENGL,3140,1,Technical Writing,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,katherine hanzalik,ENGL-3140,2016
-ENGL,3140,2,Technical Writing,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,katherine hanzalik,ENGL-3140,2016
-ENGL,3140,3,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,ENGL-3140,2016
-ENGL,3140,5,Technical Writing,0.42,0.47,0.05,0.0,0.05,0.0,0.0,0.0,katalin beck,ENGL-3140,2016
-ENGL,3140,6,Technical Writing,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,william pulley,ENGL-3140,2016
-ENGL,3140,7,Technical Writing,0.47,0.26,0.05,0.05,0.11,0.0,0.0,0.05,william pulley,ENGL-3140,2016
-ENGL,3140,9,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2016
-ENGL,3140,10,Technical Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,melissa dugan,ENGL-3140,2016
-ENGL,3140,11,Technical Writing,0.79,0.05,0.05,0.0,0.11,0.0,0.0,0.0,melissa dugan,ENGL-3140,2016
-ENGL,3140,12,Technical Writing,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,katalin beck,ENGL-3140,2016
-ENGL,3140,14,Technical Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2016
-ENGL,3140,15,Technical Writing,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,crystal pa stephens,ENGL-3140,2016
-ENGL,3140,16,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3140,2016
-ENGL,3140,19,Technical Writing,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,geveryl le robinson,ENGL-3140,2016
-ENGL,3140,20,Technical Writing,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,geveryl le robinson,ENGL-3140,2016
-ENGL,3140,22,Technical Writing,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,ENGL-3140,2016
-ENGL,3140,400,Technical Writing,0.21,0.57,0.07,0.0,0.14,0.0,0.0,0.0,la'cresha ulo green,ENGL-3140,2016
-ENGL,3150,1,Scientific Writing & Comm,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,christopher benson,ENGL-3150,2016
-ENGL,3150,3,Scientific Writing & Comm,0.42,0.21,0.05,0.05,0.05,0.0,0.0,0.21,william pulley,ENGL-3150,2016
-ENGL,3150,4,Scientific Writing & Comm,0.58,0.16,0.11,0.0,0.0,0.0,0.0,0.16,william pulley,ENGL-3150,2016
-ENGL,3150,402,Sci Writing & Comm (NURSING),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2016
-ENGL,3150,403,Sci Writing & Comm (NURSING),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2016
-ENGL,3330,1,Writing News Media,0.6,0.13,0.07,0.0,0.0,0.0,0.0,0.2,geveryl le robinson,ENGL-3330,2016
-ENGL,3450,1,Structure of Fiction,0.42,0.47,0.0,0.0,0.05,0.0,0.0,0.05,keith morris,ENGL-3450,2016
-ENGL,3480,1,Structure Screenplay,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,nicholas chri brown,ENGL-3480,2016
-ENGL,3540,1,Lit Middle East & North Africa,0.38,0.19,0.06,0.0,0.19,0.0,0.0,0.19,angela naimou,ENGL-3540,2016
-ENGL,3570,1,Film,0.11,0.61,0.22,0.0,0.06,0.0,0.0,0.0,amy monaghan,ENGL-3570,2016
-ENGL,3570,2,Film,0.0,0.72,0.28,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2016
-ENGL,3570,3,Film,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2016
-ENGL,3850,1,Children's Lit,0.72,0.17,0.0,0.0,0.11,0.0,0.0,0.0,megan no macalystre,ENGL-3850,2016
-ENGL,3860,1,Adolescent Lit,0.06,0.88,0.0,0.0,0.06,0.0,0.0,0.0,amy monaghan,ENGL-3860,2016
-ENGL,3960,1,Brit Lit Survey I,0.38,0.19,0.19,0.13,0.06,0.0,0.0,0.06,erin marina goss,ENGL-3960,2016
-ENGL,3960,2,Brit Lit Survey I,0.36,0.36,0.29,0.0,0.0,0.0,0.0,0.0,erin marina goss,ENGL-3960,2016
-ENGL,3960,3,Brit Lit Survey I,0.14,0.36,0.21,0.0,0.14,0.0,0.0,0.14,erin marina goss,ENGL-3960,2016
-ENGL,3970,1,Brit Lit Survey II,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,john morgenstern,ENGL-3970,2016
-ENGL,3970,2,Brit Lit Survey II,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,david sweene coombs,ENGL-3970,2016
-ENGL,3980,2,Amer Lit Survey I,0.38,0.44,0.06,0.0,0.06,0.0,0.0,0.06,jonathan beec field,ENGL-3980,2016
-ENGL,4110,1,Shakespeare,0.39,0.56,0.0,0.06,0.0,0.0,0.0,0.0,andrew lemons,ENGL-4110,2016
-ENGL,4110,2,Shakespeare,0.42,0.11,0.37,0.05,0.05,0.0,0.0,0.0,william stockton,ENGL-4110,2016
-ENGL,4110,3,Shakespeare,0.21,0.63,0.11,0.05,0.0,0.0,0.0,0.0,brian mcgrath,ENGL-4110,2016
-ENGL,4140,1,Milton,0.08,0.77,0.15,0.0,0.0,0.0,0.0,0.0,lee morrissey,ENGL-4140,2016
-ENGL,4190,1,Post Col & World Lit,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,cameron fa bushnell,ENGL-4190,2016
-ENGL,4210,1,Amer Lit 1800-1899,0.33,0.33,0.13,0.07,0.13,0.0,0.0,0.0,dominic mastroianni,ENGL-4210,2016
-ENGL,4250,1,American Novel,0.25,0.42,0.08,0.08,0.08,0.0,0.0,0.08,susanna ashton,ENGL-4250,2016
-ENGL,4260,1,Southern Literature,0.29,0.43,0.14,0.0,0.07,0.0,0.0,0.07,cameron fa bushnell,ENGL-4260,2016
-ENGL,4280,1,Contemporary Literature,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,michael lemahieu,ENGL-4280,2016
-ENGL,4350,1,Literary Criticism,0.31,0.5,0.13,0.0,0.06,0.0,0.0,0.0,jonathan beec field,ENGL-4350,2016
-ENGL,4360,1,Feminist Literary Criticism,0.39,0.56,0.0,0.0,0.06,0.0,0.0,0.0,erin marina goss,ENGL-4360,2016
-ENGL,4400,1,Literary Theory,0.42,0.32,0.16,0.0,0.11,0.0,0.0,0.0,walter edgar hunter,ENGL-4400,2016
-ENGL,4410,1,Literary Editing,0.28,0.5,0.06,0.06,0.06,0.0,0.0,0.06,gabriel and hankins,ENGL-4410,2016
-ENGL,4420,1,Cultural Studies,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,garry bertholf,ENGL-4420,2016
-ENGL,4500,1,Film Genres,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07, barton palmer,ENGL-4500,2016
-ENGL,4510,1,Film Theo/Criticism,0.75,0.06,0.13,0.0,0.0,0.0,0.0,0.06, barton palmer,ENGL-4510,2016
-ENGL,4630,1,Topics in Literature to 1699,0.18,0.55,0.18,0.0,0.0,0.0,0.0,0.09,andrew lemons,ENGL-4630,2016
-ENGL,4750,1,Writing for Media,0.31,0.38,0.13,0.0,0.13,0.0,0.0,0.06,megan eatman,ENGL-4750,2016
-ENGL,4780,1,Digital Literacy,0.18,0.55,0.18,0.0,0.09,0.0,0.0,0.0,gabriel and hankins,ENGL-4780,2016
-ENGL,4820,1,Afr Am Lit to 1920,0.0,0.6,0.1,0.0,0.3,0.0,0.0,0.0,rhondda robi thomas,ENGL-4820,2016
-ENGL,4960,1,Senior Seminar,0.69,0.15,0.0,0.0,0.15,0.0,0.0,0.0,dominic mastroianni,ENGL-4960,2016
-ENGL,4960,2,Senior Seminar,0.42,0.42,0.0,0.0,0.08,0.0,0.0,0.08,rhondda robi thomas,ENGL-4960,2016
-ENGL,4960,3,Senior Seminar,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-4960,2016
-ENGL,8080,1,Top Renaiss & Restoration Lit,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-8080,2016
-ENGR,1000,101,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,steven brandon,ENGR-1000,2016
-ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.01,steven brandon,ENGR-1000,2016
-ENGR,1020,117,Engineering Discipl & Skills,0.42,0.27,0.16,0.02,0.04,0.0,0.0,0.09,matthew kent miller,ENGR-1020,2016
-ENGR,1020,118,Engineering Discipl & Skills,0.15,0.53,0.11,0.02,0.02,0.0,0.0,0.17,matthew kent miller,ENGR-1020,2016
-ENGR,1020,312,Engineering Discipl & Skills,0.27,0.47,0.16,0.08,0.02,0.0,0.0,0.0,irene marie ferrara,ENGR-1020,2016
-ENGR,1020,313,Engineering Discipl & Skills,0.21,0.4,0.15,0.06,0.06,0.0,0.0,0.12,michael giebner,ENGR-1020,2016
-ENGR,1020,314,Engineering Discipl & Skills,0.32,0.32,0.16,0.0,0.02,0.0,0.0,0.18,michael giebner,ENGR-1020,2016
-ENGR,1020,316,Engineering Discipl & Skills,0.16,0.53,0.12,0.1,0.0,0.0,0.0,0.1,roksana mahmud,ENGR-1020,2016
-ENGR,1020,317,Engineering Discipl & Skills,0.16,0.45,0.16,0.06,0.02,0.0,0.0,0.16,jonathan maier,ENGR-1020,2016
-ENGR,1020,611,Engineering Discipl & Skills,0.1,0.45,0.24,0.08,0.06,0.0,0.0,0.08,john minor,ENGR-1020,2016
-ENGR,1020,612,Engineering Discipl & Skills,0.28,0.49,0.13,0.06,0.0,0.0,0.0,0.04,john minor,ENGR-1020,2016
-ENGR,1020,613,Engineering Discipl & Skills,0.19,0.4,0.19,0.08,0.0,0.0,0.0,0.13,mariah magagnotti,ENGR-1020,2016
-ENGR,1020,614,Engineering Discipl & Skills,0.29,0.4,0.21,0.04,0.02,0.0,0.0,0.04,irene marie ferrara,ENGR-1020,2016
-ENGR,1020,615,Engineering Discipl & Skills,0.35,0.39,0.18,0.0,0.0,0.0,0.0,0.08,irene marie ferrara,ENGR-1020,2016
-ENGR,1020,616,Engineering Discipl & Skills,0.17,0.42,0.23,0.04,0.02,0.0,0.0,0.13,sheikh moniruz moni,ENGR-1020,2016
-ENGR,1020,617,Engineering Discipl & Skills,0.28,0.3,0.18,0.06,0.06,0.0,0.0,0.12,andrew isaa neptune,ENGR-1020,2016
-ENGR,1020,618,Engineering Discipl & Skills,0.24,0.35,0.17,0.11,0.04,0.0,0.0,0.09,andrew isaa neptune,ENGR-1020,2016
-ENGR,1020,811,Engineering Discipl & Skills,0.34,0.38,0.15,0.09,0.0,0.0,0.0,0.04,ashley childers,ENGR-1020,2016
-ENGR,1020,812,Engineering Discipl & Skills,0.39,0.3,0.22,0.0,0.04,0.0,0.0,0.04,ashley childers,ENGR-1020,2016
-ENGR,1020,813,Engineering Discipl & Skills,0.21,0.42,0.21,0.04,0.02,0.0,0.0,0.1,elizabeth stephan,ENGR-1020,2016
-ENGR,1020,814,Engineering Discipl & Skills,0.4,0.36,0.13,0.04,0.02,0.0,0.0,0.04,andrew isaa neptune,ENGR-1020,2016
-ENGR,1020,815,Engineering Discipl & Skills,0.15,0.45,0.21,0.06,0.0,0.0,0.0,0.13,mariah magagnotti,ENGR-1020,2016
-ENGR,1020,816,Engineering Discipl & Skills,0.19,0.32,0.3,0.06,0.02,0.0,0.0,0.11,mariah magagnotti,ENGR-1020,2016
-ENGR,1020,817,Engineering Discipl & Skills,0.23,0.45,0.17,0.06,0.02,0.0,0.0,0.06,sarah grigg,ENGR-1020,2016
-ENGR,1020,818,Engineering Discipl & Skills,0.32,0.36,0.16,0.05,0.0,0.0,0.0,0.11,sarah grigg,ENGR-1020,2016
-ENGR,1020,831,Engr Discipl & Skills (HON),0.72,0.24,0.02,0.0,0.0,0.0,0.0,0.02,steven brandon,ENGR-1020,2016
-ENGR,1020,832,Engr Discipl & Skills (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,ENGR-1020,2016
-ENGR,1050,246,Engr Discipline & Skills I,0.04,0.32,0.36,0.08,0.2,0.0,0.0,0.0,matthew kent miller,ENGR-1050,2016
-ENGR,1050,400,Engr Discipline & Skills I,0.07,0.07,0.29,0.25,0.18,0.0,0.0,0.14,matthew kent miller,ENGR-1050,2016
-ENGR,1060,246,Engr Discipline & Skills II,0.04,0.29,0.25,0.29,0.13,0.0,0.0,0.0,matthew kent miller,ENGR-1060,2016
-ENGR,1060,400,Engr Discipline & Skills II,0.12,0.24,0.29,0.06,0.24,0.0,0.0,0.06,matthew kent miller,ENGR-1060,2016
-ENGR,1150,500,Engineering Design & Modeling,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,john minor,ENGR-1150,2016
-ENGR,1410,225,Programming & Problem Solving,0.06,0.3,0.26,0.09,0.19,0.0,0.0,0.11,richard watkins,ENGR-1410,2016
-ENGR,1410,226,Programming & Problem Solving,0.16,0.24,0.2,0.08,0.2,0.0,0.0,0.14,elizabeth stephan,ENGR-1410,2016
-ENGR,1410,227,Programming & Problem Solving,0.08,0.29,0.29,0.06,0.12,0.0,0.0,0.17,william martin,ENGR-1410,2016
-ENGR,1410,228,Programming & Problem Solving,0.08,0.24,0.33,0.18,0.04,0.0,0.0,0.12,william martin,ENGR-1410,2016
-ENGR,1520,501,Engineering Computer Skills,0.29,0.52,0.19,0.0,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1520,2016
-ENGR,1520,502,Engineering Computer Skills,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1520,2016
-ENGR,1900,10,CI in Engr I Robotics,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,michael benj wooten,ENGR-1900,2016
-ENGR,1900,77,CI in ENGR Human Powered Veh,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,gregory mocko,ENGR-1900,2016
-ENGR,2080,681,Engr Graphics & Machine Design,0.43,0.23,0.09,0.09,0.15,0.0,0.0,0.02,nighat yasmin,ENGR-2080,2016
-ENGR,2080,682,Engr Graphics & Machine Design,0.31,0.25,0.25,0.06,0.04,0.0,0.0,0.08,amaninder sing gill,ENGR-2080,2016
-ENGR,2080,684,Engr Graphics & Machine Design,0.21,0.21,0.21,0.06,0.23,0.0,0.0,0.08,amaninder sing gill,ENGR-2080,2016
-ENGR,2080,685,Engr Graphics & Machine Design,0.31,0.22,0.22,0.08,0.08,0.0,0.0,0.08,anthony pau garland,ENGR-2080,2016
-ENGR,2080,686,Engr Graphics & Machine Design,0.5,0.24,0.11,0.02,0.04,0.0,0.0,0.09,anthony pau garland,ENGR-2080,2016
-ENGR,2100,804,CAD & Engineering Applications,0.43,0.37,0.07,0.0,0.04,0.0,0.0,0.09,nighat yasmin,ENGR-2100,2016
-ENGR,2100,805,CAD & Engineering Applications,0.33,0.41,0.22,0.02,0.02,0.0,0.0,0.0,nighat yasmin,ENGR-2100,2016
-ENGR,2100,806,CAD & Engineering Applications,0.36,0.33,0.13,0.05,0.03,0.0,0.0,0.1, shams esfandabadi,ENGR-2100,2016
-ENGR,2200,106,Evaluating Innovations,0.55,0.39,0.05,0.0,0.0,0.0,0.0,0.0,sarah grigg,ENGR-2200,2016
-ENR,1010,1,Intro to Envir & Natur Res I,0.75,0.15,0.03,0.03,0.03,0.0,0.0,0.01,alan johnson,ENR-1010,2016
-ENR,1010,2,Intro to Envir & Natur Res I,0.5,0.31,0.13,0.04,0.02,0.0,0.0,0.0,alan johnson,ENR-1010,2016
-ENR,4290,1,Environ Law & Policy,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,ENR-4290,2016
-ENSP,2000,1,Intro Environ Sci,0.23,0.52,0.16,0.05,0.0,0.0,0.0,0.05,scott brame,ENSP-2000,2016
-ENSP,2000,2,Intro Environ Sci,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2016
-ENSP,2000,3,Intro Environ Sci,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2016
-ENSP,2000,4,Intro Environ Sci,0.34,0.5,0.09,0.0,0.05,0.0,0.0,0.02,elizabeth carraway,ENSP-2000,2016
-ENSP,4000,1,Studies in Environmental Sci,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,margaret thompson,ENSP-4000,2016
-ENT,2000,1,Six-Legged Science,0.68,0.17,0.1,0.0,0.0,0.0,0.0,0.05,suellen pometto,ENT-2000,2016
-ENT,3010,1,Insect Biology and Diversity,0.33,0.33,0.29,0.0,0.05,0.0,0.0,0.0,eric benson,ENT-3010,2016
-ENTR,1010,1,Entrepreneurial Mindset,0.48,0.39,0.07,0.01,0.03,0.0,0.0,0.02,john michael hannon,ENTR-1010,2016
-ESED,8790,1,Curr Top STEM Education Policy,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,julie patric martin,ESED-8790,2016
-FCS,8130,1,Research Methods in FCS I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,FCS-8130,2016
-FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.67,0.19,0.05,0.02,0.03,0.0,0.0,0.04,aubrey dean coffee,FDSC-1010,2016
-FDSC,4010,1,Food Chemistry I,0.58,0.33,0.09,0.0,0.0,0.0,0.0,0.0,feng chen,FDSC-4010,2016
-FDSC,4040,1,Food Prsv & Process,0.53,0.43,0.04,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,FDSC-4040,2016
-FDSC,4070,1,Quantity Food Production,0.78,0.14,0.03,0.0,0.03,0.0,0.0,0.02,heather batt,FDSC-4070,2016
-FDSC,4170,1,Seminar,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,aubrey dean coffee,FDSC-4170,2016
-FDSC,4200,1,Food Regulation and Policy,0.91,0.06,0.01,0.0,0.01,0.0,0.0,0.01, rhodehamel,FDSC-4200,2016
-FDSC,4300,1,Dairy Process & Sant,0.44,0.28,0.22,0.0,0.06,0.0,0.0,0.0,john mcgregor,FDSC-4300,2016
-FDSC,8120,1,Microbial Food Syst,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,xiuping jiang,FDSC-8120,2016
-FIN,2010,401,Intro to Personal Finance,0.55,0.24,0.05,0.02,0.05,0.0,0.0,0.1,joshua harris,FIN-2010,2016
-FIN,2010,402,Intro to Personal Finance,0.35,0.23,0.14,0.07,0.05,0.0,0.0,0.16,joshua harris,FIN-2010,2016
-FIN,2010,403,Intro to Personal Finance,0.4,0.33,0.14,0.02,0.09,0.0,0.0,0.02,joshua harris,FIN-2010,2016
-FIN,2010,404,Intro to Personal Finance,0.56,0.26,0.04,0.02,0.08,0.0,0.0,0.04,joshua harris,FIN-2010,2016
-FIN,2010,405,Intro to Personal Finance,0.55,0.26,0.02,0.06,0.04,0.0,0.0,0.06,joshua harris,FIN-2010,2016
-FIN,2010,406,Intro to Personal Finance,0.64,0.2,0.05,0.02,0.05,0.0,0.0,0.05,joshua harris,FIN-2010,2016
-FIN,3040,1,Risk & Insurance,0.2,0.33,0.4,0.07,0.0,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2016
-FIN,3040,2,Risk & Insurance,0.19,0.19,0.58,0.03,0.0,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2016
-FIN,3050,1,Investment Analysis,0.18,0.32,0.37,0.05,0.03,0.0,0.0,0.05,kerri mcmillan,FIN-3050,2016
-FIN,3050,2,Investment Analysis,0.15,0.51,0.23,0.05,0.03,0.0,0.0,0.03,kerri mcmillan,FIN-3050,2016
-FIN,3050,3,Investment Analysis,0.54,0.21,0.21,0.0,0.05,0.0,0.0,0.0,thomas albe wessels,FIN-3050,2016
-FIN,3050,4,Investment Analysis,0.27,0.27,0.36,0.09,0.0,0.0,0.0,0.0,thomas albe wessels,FIN-3050,2016
-FIN,3060,2,Corporation Finance,0.16,0.05,0.22,0.22,0.11,0.0,0.0,0.24,william hol johnson,FIN-3060,2016
-FIN,3060,3,Corporation Finance,0.18,0.13,0.24,0.18,0.24,0.0,0.0,0.03,william hol johnson,FIN-3060,2016
-FIN,3060,4,Corporation Finance,0.0,0.25,0.15,0.28,0.3,0.0,0.0,0.03,william hol johnson,FIN-3060,2016
-FIN,3060,5,Corporation Finance,0.26,0.32,0.19,0.14,0.05,0.0,0.0,0.04,ramon tolb franklin,FIN-3060,2016
-FIN,3060,6,Corporation Finance,0.24,0.31,0.24,0.07,0.05,0.0,0.0,0.09,ramon tolb franklin,FIN-3060,2016
-FIN,3060,7,Corporation Finance,0.22,0.29,0.22,0.19,0.05,0.0,0.0,0.03,ramon tolb franklin,FIN-3060,2016
-FIN,3060,8,Corporation Finance,0.18,0.1,0.41,0.25,0.04,0.0,0.0,0.02,melvin stith,FIN-3060,2016
-FIN,3060,9,Corporation Finance,0.14,0.27,0.31,0.18,0.06,0.0,0.0,0.04,melvin stith,FIN-3060,2016
-FIN,3060,10,Corporation Finance,0.15,0.33,0.22,0.15,0.11,0.0,0.0,0.04,ramon tolb franklin,FIN-3060,2016
-FIN,3060,11,Corporation Finance,0.05,0.13,0.43,0.15,0.2,0.0,0.0,0.05,william hol johnson,FIN-3060,2016
-FIN,3070,1,Prin of Real Estate,0.2,0.33,0.25,0.1,0.1,0.0,0.0,0.03,thomas springer,FIN-3070,2016
-FIN,3070,2,Prin of Real Estate,0.15,0.4,0.3,0.05,0.1,0.0,0.0,0.0,thomas springer,FIN-3070,2016
-FIN,3070,3,Prin of Real Estate,0.21,0.5,0.21,0.02,0.02,0.0,0.0,0.02,yannan shen,FIN-3070,2016
-FIN,3080,1,Fin Inst & Mkts,0.23,0.55,0.17,0.02,0.0,0.0,0.0,0.02,lyudmila chernykh,FIN-3080,2016
-FIN,3080,2,Fin Inst & Mkts,0.2,0.57,0.22,0.0,0.0,0.0,0.0,0.02,lyudmila chernykh,FIN-3080,2016
-FIN,3080,3,Fin Inst & Mkts,0.25,0.38,0.31,0.06,0.0,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2016
-FIN,3110,1,Financial Management I,0.06,0.06,0.21,0.03,0.29,0.0,0.0,0.35,jack wolf,FIN-3110,2016
-FIN,3110,2,Financial Management I,0.13,0.17,0.27,0.13,0.15,0.0,0.0,0.17,jack wolf,FIN-3110,2016
-FIN,3110,3,Financial Management I,0.21,0.3,0.34,0.13,0.0,0.0,0.0,0.02,weike xu,FIN-3110,2016
-FIN,3110,4,Financial Management I,0.16,0.22,0.2,0.14,0.16,0.0,0.0,0.12,john alexander,FIN-3110,2016
-FIN,3120,1,Financial Management II,0.08,0.47,0.26,0.05,0.08,0.0,0.0,0.05,vincent intintoli,FIN-3120,2016
-FIN,3120,2,Financial Management II,0.13,0.46,0.19,0.13,0.07,0.0,0.0,0.02,vincent intintoli,FIN-3120,2016
-FIN,3120,3,Financial Management II,0.24,0.48,0.19,0.02,0.05,0.0,0.0,0.02,blerina zykaj,FIN-3120,2016
-FIN,3120,4,Financial Management II,0.24,0.49,0.17,0.05,0.05,0.0,0.0,0.0,weike xu,FIN-3120,2016
-FIN,4010,1,Corporate Financial Analysis,0.36,0.4,0.16,0.04,0.04,0.0,0.0,0.0,george bra lockhart,FIN-4010,2016
-FIN,4020,1,Corporate Valuation,0.23,0.45,0.32,0.0,0.0,0.0,0.0,0.0,angela morgan,FIN-4020,2016
-FIN,4020,2,Corporate Valuation,0.29,0.29,0.29,0.1,0.03,0.0,0.0,0.0,angela morgan,FIN-4020,2016
-FIN,4050,1,Portfolio Management & Theory,0.18,0.21,0.43,0.11,0.04,0.0,0.0,0.04,john alexander,FIN-4050,2016
-FIN,4060,1,Derivatives Analysis,0.21,0.35,0.32,0.06,0.03,0.0,0.0,0.03,blerina zykaj,FIN-4060,2016
-FIN,4110,1,Int Fin Mgt,0.12,0.62,0.21,0.0,0.0,0.0,0.0,0.06,luke asher devault,FIN-4110,2016
-FIN,4110,2,Int Fin Mgt,0.17,0.52,0.22,0.04,0.0,0.0,0.0,0.04,luke asher devault,FIN-4110,2016
-FIN,4170,1,Real Estate Finance,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,yannan shen,FIN-4170,2016
-FIN,4980,3,Creative Inquiry in Finance,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,angela morgan,FIN-4980,2016
-FNR,2040,1,Soil Information Systems,0.9,0.08,0.0,0.02,0.0,0.0,0.0,0.0,elena mikhailova,FNR-2040,2016
-FNR,4700,1,Kennedy Waterfowl CI,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,FNR-4700,2016
-FNR,4990,1,Natural Resources Seminar,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,susan talley guynn,FNR-4990,2016
-FOR,2050,1,Dendrology,0.32,0.34,0.16,0.05,0.08,0.0,0.0,0.05,donald hagan,FOR-2050,2016
-FOR,2050,2,Dendrology,0.24,0.24,0.21,0.06,0.15,0.0,0.0,0.09,donald hagan,FOR-2050,2016
-FOR,2050,3,Dendrology,0.31,0.36,0.16,0.07,0.0,0.0,0.0,0.11,donald hagan,FOR-2050,2016
-FOR,2210,1,Forest Biology,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,thomas adam coates,FOR-2210,2016
-FOR,3020,1,Forest Biometrics,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,lawrence gering,FOR-3020,2016
-FOR,3040,1,Forest Resource Economics,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,puskar khanal,FOR-3040,2016
-FOR,4100,1,Harvesting Processes,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,patrick hiesl,FOR-4100,2016
-FOR,4160,1,Forest Policy and Admin,0.23,0.52,0.21,0.03,0.0,0.0,0.0,0.01,thomas straka,FOR-4160,2016
-FOR,4170,1,Forest Resource Mgt & Regulatn,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,FOR-4170,2016
-FOR,4310,1,Recreation Res Plan in For Mgt,0.54,0.33,0.13,0.0,0.0,0.0,0.0,0.0,robert baxte powell,FOR-4310,2016
-FOR,4340,1,GIS for Natural Resources,0.67,0.28,0.04,0.0,0.0,0.0,0.0,0.0,christopher post,FOR-4340,2016
-FOR,8930,7,Statistical Methods in Nat Res,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,patrick hiesl,FOR-8930,2016
-FR,1010,1,Elementary French,0.26,0.47,0.16,0.0,0.05,0.0,0.0,0.05,anne salces  nedeo,FR-1010,2016
-FR,1020,1,Elementary French,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,FR-1020,2016
-FR,1020,2,Elementary French,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2016
-FR,2010,1,Intermediate French,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,paulin de tholozany,FR-2010,2016
-FR,2010,2,Intermediate French,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-2010,2016
-FR,2010,4,Intermediate French,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,paulin de tholozany,FR-2010,2016
-FR,2020,1,Intermediate French,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2020,2016
-FR,2020,2,Intermediate French,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,eric touya,FR-2020,2016
-FR,2020,3,Intermediate French,0.47,0.18,0.29,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,FR-2020,2016
-FR,2020,4,Intermediate French,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2020,2016
-FR,3000,1,Survey of French Lit,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,FR-3000,2016
-FR,3050,1,Int Fr Con & Comp I,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,anne salces  nedeo,FR-3050,2016
-FR,3050,2,Int Fr Con & Comp I,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,FR-3050,2016
-FR,3070,1,French Civilization,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,FR-3070,2016
-FR,4160,1,Fr for Intl Trade II,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,eric touya,FR-4160,2016
-GC,1010,1,Orientation to G C,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,nona woolbright,GC-1010,2016
-GC,1010,2,Orientation to G C,0.71,0.16,0.02,0.04,0.04,0.0,0.0,0.02,carol jones,GC-1010,2016
-GC,1020,1,Computer Art & CAD Foundations,0.39,0.39,0.11,0.06,0.04,0.0,0.0,0.02,carol jones,GC-1020,2016
-GC,1020,2,Computer Art & CAD Foundations,0.53,0.33,0.07,0.0,0.05,0.0,0.0,0.02,nona woolbright,GC-1020,2016
-GC,1030,1,G C I for Pkgsc,0.32,0.42,0.11,0.05,0.05,0.0,0.0,0.05,john jacobs,GC-1030,2016
-GC,1040,1,Graphic Communications I,0.54,0.25,0.11,0.0,0.07,0.0,0.0,0.04,rebecca suza edlein,GC-1040,2016
-GC,2070,1,Graphic Communications II,0.66,0.24,0.03,0.02,0.03,0.0,0.0,0.02,charles tabor weiss,GC-2070,2016
-GC,2400,1,Intro to Web Design and Dev,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,erica black walker,GC-2400,2016
-GC,3400,1,Digital Imaging and eMedia,0.34,0.53,0.11,0.0,0.0,0.0,0.0,0.03,erica black walker,GC-3400,2016
-GC,3460,1,Ink and Substrates,0.26,0.56,0.11,0.03,0.04,0.0,0.0,0.0,liam henry 'hara,GC-3460,2016
-GC,4060,1,Package and Specialty Printing,0.8,0.11,0.0,0.0,0.05,0.0,0.0,0.05,kern cox,GC-4060,2016
-GC,4400,1,Commercial Printing,0.43,0.43,0.04,0.0,0.07,0.0,0.0,0.04,eric weisenmiller,GC-4400,2016
-GC,4400,2,Commercial Printing,0.39,0.43,0.09,0.0,0.04,0.0,0.0,0.04,eric weisenmiller,GC-4400,2016
-GC,4440,1,Current Dev/Trends in Gr Comm,0.79,0.16,0.0,0.0,0.03,0.0,0.0,0.03,samuel ingram,GC-4440,2016
-GC,4480,1,Plan & Cont Printing Functions,0.49,0.38,0.08,0.05,0.0,0.0,0.0,0.0,john leininger,GC-4480,2016
-GC,4800,1,Senior Seminar in GC,0.63,0.32,0.02,0.02,0.0,0.0,0.0,0.0,charles edwa tonkin,GC-4800,2016
-GC,4900,230,G C Selected Topics-GC Sales,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,GC-4900,2016
-GEN,1030,1,Careers in Bioch/Gen,0.8,0.15,0.04,0.0,0.0,0.0,0.0,0.01,alison starr-moss,GEN-1030,2016
-GEN,3000,1,Fundamental Genetics,0.29,0.37,0.18,0.11,0.02,0.0,0.0,0.03,kate leanne wi tsai,GEN-3000,2016
-GEN,3000,2,Fundamental Genetics,0.21,0.4,0.25,0.06,0.03,0.0,0.0,0.05,kate leanne wi tsai,GEN-3000,2016
-GEN,3020,1,Molecular & General Genetics,0.4,0.35,0.15,0.04,0.02,0.0,0.0,0.04,lukasz kozubowski,GEN-3020,2016
-GEN,3020,2,Molec & General Genetics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,GEN-3020,2016
-GEN,3020,4,Molecular & General Genetics,0.35,0.42,0.14,0.05,0.0,0.0,0.0,0.05,haiying liang,GEN-3020,2016
-GEN,4200,1,Molecular Genetics & Gene Reg,0.27,0.51,0.19,0.0,0.0,0.0,0.0,0.03,julia frugoli,GEN-4200,2016
-GEN,4200,2,Molecular Genetics & Gen (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,GEN-4200,2016
-GEN,4400,1,Bioinformatics,0.73,0.09,0.05,0.0,0.0,0.0,0.0,0.14,frank alexan feltus,GEN-4400,2016
-GEN,4500,1,Comparative Genetics,0.3,0.54,0.14,0.0,0.03,0.0,0.0,0.0,leigh anne clark,GEN-4500,2016
-GEN,4900,1,Epigenetics,0.42,0.17,0.25,0.0,0.08,0.0,0.0,0.08,rajandeep si sekhon,GEN-4900,2016
-GEN,6200,1,Molecular Genetics & Gene Reg,0.0,0.67,0.17,0.0,0.0,0.0,0.0,0.17,julia frugoli,GEN-6200,2016
-GEN,6400,1,Bioinformatics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,GEN-6400,2016
-GEN,8140,1,Advanced Genetics,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,GEN-8140,2016
-GEOG,1010,1,Intro to Geography,0.3,0.45,0.2,0.05,0.0,0.0,0.0,0.0,william churc terry,GEOG-1010,2016
-GEOG,1030,1,World Regional Geog,0.78,0.12,0.06,0.0,0.02,0.0,0.0,0.02,lance forres howard,GEOG-1030,2016
-GEOG,1030,2,World Regional Geog,0.8,0.18,0.0,0.03,0.0,0.0,0.0,0.0,lance forres howard,GEOG-1030,2016
-GEOG,1060,1,Geog Phys Envt,0.42,0.16,0.21,0.11,0.11,0.0,0.0,0.0,william churc terry,GEOG-1060,2016
-GEOL,1010,1,Physical Geology,0.27,0.32,0.24,0.08,0.05,0.0,0.0,0.03,alan coulson,GEOL-1010,2016
-GEOL,1010,2,Physical Geology,0.24,0.31,0.24,0.09,0.07,0.0,0.0,0.05,alan coulson,GEOL-1010,2016
-GEOL,1010,3,Physical Geology,0.49,0.2,0.14,0.06,0.1,0.0,0.0,0.0,kelly best lazar,GEOL-1010,2016
-GEOL,1030,1,Physical Geol Lab,0.54,0.33,0.04,0.0,0.08,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,2,Physical Geol Lab,0.48,0.3,0.13,0.0,0.0,0.0,0.0,0.09,alan coulson,GEOL-1030,2016
-GEOL,1030,3,Physical Geol Lab,0.64,0.23,0.05,0.0,0.05,0.0,0.0,0.05,alan coulson,GEOL-1030,2016
-GEOL,1030,4,Physical Geol Lab,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,5,Physical Geol Lab,0.22,0.43,0.26,0.0,0.04,0.0,0.0,0.04,alan coulson,GEOL-1030,2016
-GEOL,1030,6,Physical Geol Lab,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2016
-GEOL,1030,7,Physical Geol Lab,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,8,Physical Geol Lab,0.38,0.38,0.04,0.04,0.08,0.0,0.0,0.08,alan coulson,GEOL-1030,2016
-GEOL,1030,9,Physical Geol Lab,0.38,0.57,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,10,Physical Geol Lab,0.04,0.58,0.21,0.0,0.04,0.0,0.0,0.13,alan coulson,GEOL-1030,2016
-GEOL,1030,11,Physical Geol Lab,0.2,0.5,0.15,0.1,0.0,0.0,0.0,0.05,alan coulson,GEOL-1030,2016
-GEOL,1030,12,Physical Geol Lab,0.67,0.0,0.2,0.0,0.0,0.0,0.0,0.13,alan coulson,GEOL-1030,2016
-GEOL,2050,1,Mineralogy & Intro Petrology,0.45,0.18,0.36,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-2050,2016
-GEOL,2070,1,Min & Intro Pet Lab,0.09,0.18,0.45,0.18,0.09,0.0,0.0,0.0,alan coulson,GEOL-2070,2016
-GEOL,2700,1,Sustainable Water,0.83,0.06,0.03,0.03,0.0,0.0,0.0,0.06,stephen mich moysey,GEOL-2700,2016
-GEOL,2750,1,Field Methods,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,scott brame,GEOL-2750,2016
-GEOL,3000,1,Environmental Geology,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-3000,2016
-GEOL,3020,1,Structural Geology,0.27,0.27,0.36,0.09,0.0,0.0,0.0,0.0,james castle,GEOL-3020,2016
-GEOL,4110,2,Exploring Sustainability,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.08,kelly best lazar,GEOL-4110,2016
-GEOL,4110,8,CI - Community Outreach,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,john robert wagner,GEOL-4110,2016
-GEOL,4820,1,Groundwater & Contam Transport,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,lawrence murdoch,GEOL-4820,2016
-GEOL,4910,1,Research Synthesis I,0.5,0.33,0.08,0.0,0.08,0.0,0.0,0.0,alan coulson,GEOL-4910,2016
-GEOL,6150,1,Analysis Geological Processes,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,GEOL-6150,2016
-GEOL,8080,1,Groundwater Modeling,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,GEOL-8080,2016
-GER,1010,1,Elementary German,0.21,0.29,0.36,0.0,0.07,0.0,0.0,0.07, lee ferrell,GER-1010,2016
-GER,1010,2,Elementary German,0.13,0.5,0.25,0.06,0.0,0.0,0.0,0.06, lee ferrell,GER-1010,2016
-GER,1020,1,Elementary German,0.38,0.38,0.08,0.08,0.0,0.0,0.0,0.08,oswald harris king,GER-1020,2016
-GER,1020,2,Elementary German,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-1020,2016
-GER,2010,1,Intermediate German,0.53,0.27,0.07,0.13,0.0,0.0,0.0,0.0,oswald harris king,GER-2010,2016
-GER,2010,2,Intermediate German,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-2010,2016
-GER,2020,1,Intermediate German,0.13,0.33,0.27,0.13,0.13,0.0,0.0,0.0,gabriela stoicea,GER-2020,2016
-GER,3050,1,Ger Conv & Comp,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0, lee ferrell,GER-3050,2016
-GER,3400,1,German Culture,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,oswald harris king,GER-3400,2016
-GER,4170,1,Topics Ger Intl TR,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0, lee ferrell,GER-4170,2016
-HCC,8310,1,Fundamentals of Hcc,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,bart knijnenburg,HCC-8310,2016
-HCC,8330,1,HCC Research Methods,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,HCC-8330,2016
-HCG,9890,403,Interdisiplinary Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,julia eggert,HCG-9890,2016
-HEHD,8030,400,Ethical Leadership,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,HEHD-8030,2016
-HEHD,8050,1,Yth Dev in Families,0.71,0.12,0.12,0.0,0.0,0.0,0.0,0.06,william quinn,HEHD-8050,2016
-HEHD,8060,230,Diverse Society,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,ann marie gillard,HEHD-8060,2016
-HIST,1010,1,Hist of the U S,0.33,0.48,0.1,0.01,0.03,0.0,0.0,0.05,james brad jeffries,HIST-1010,2016
-HIST,1020,1,Hist of the U S,0.37,0.27,0.14,0.12,0.04,0.0,0.0,0.06,john andrew,HIST-1020,2016
-HIST,1220,1,"Hist, Tech & Society",0.09,0.55,0.29,0.03,0.02,0.0,0.0,0.02,pamela mack,HIST-1220,2016
-HIST,1240,1,Environmental History Survey,0.3,0.45,0.21,0.0,0.0,0.0,0.0,0.03,james brad jeffries,HIST-1240,2016
-HIST,1240,2,Environmental History Survey,0.3,0.45,0.15,0.0,0.06,0.0,0.0,0.03,james brad jeffries,HIST-1240,2016
-HIST,1720,1,The West and the World I,0.15,0.38,0.22,0.07,0.1,0.0,0.0,0.07,caroline dunn clark,HIST-1720,2016
-HIST,1720,2,The West and the World I,0.26,0.54,0.14,0.03,0.02,0.0,0.0,0.02,steven marks,HIST-1720,2016
-HIST,1730,1,The West and the World II,0.41,0.37,0.08,0.02,0.09,0.0,0.0,0.04, alan grubb,HIST-1730,2016
-HIST,1730,2,The West and the World II,0.41,0.27,0.18,0.09,0.05,0.0,0.0,0.0,subah dayal,HIST-1730,2016
-HIST,2990,1,Historian's Craft,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,michael silvestri,HIST-2990,2016
-HIST,2990,2,Historian's Craft,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,elizabeth carney,HIST-2990,2016
-HIST,2990,3,Historian's Craft,0.54,0.31,0.0,0.0,0.0,0.0,0.0,0.15,rachel anne moore,HIST-2990,2016
-HIST,3040,1,Indus & Progr Era,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0, roger grant,HIST-3040,2016
-HIST,3120,1,Afr Amer Hist 1877 to Present,0.68,0.21,0.0,0.0,0.11,0.0,0.0,0.0,abel bartley,HIST-3120,2016
-HIST,3140,1,Hist of the South I,0.24,0.59,0.0,0.0,0.07,0.0,0.0,0.1,paul chris anderson,HIST-3140,2016
-HIST,3290,1,US Legal History Since 1890,0.44,0.33,0.11,0.0,0.06,0.0,0.0,0.06,renee roux,HIST-3290,2016
-HIST,3380,1,Africa to 1875,0.6,0.2,0.15,0.0,0.05,0.0,0.0,0.0,james burns,HIST-3380,2016
-HIST,3400,1,Latin America I,0.63,0.17,0.07,0.03,0.03,0.0,0.0,0.07,rachel anne moore,HIST-3400,2016
-HIST,3550,1,Roman World,0.33,0.56,0.04,0.0,0.04,0.0,0.0,0.04,elizabeth carney,HIST-3550,2016
-HIST,3630,1,Britain Since 1688,0.28,0.38,0.13,0.16,0.06,0.0,0.0,0.0,stephani barczewski,HIST-3630,2016
-HIST,3670,1,Modern Ireland,0.44,0.29,0.09,0.0,0.12,0.0,0.0,0.06,michael silvestri,HIST-3670,2016
-HIST,3700,1,Medieval History,0.27,0.5,0.13,0.0,0.0,0.0,0.0,0.1,caroline dunn clark,HIST-3700,2016
-HIST,3720,1,Renaissance,0.33,0.39,0.11,0.06,0.0,0.0,0.0,0.11,thomas kuehn,HIST-3720,2016
-HIST,3890,7,Mitchelville,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,abel bartley,HIST-3890,2016
-HIST,3890,8,The Churches of Mitchelville,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,abel bartley,HIST-3890,2016
-HIST,3900,1,Modern Military History,0.22,0.3,0.22,0.04,0.19,0.0,0.0,0.04,edwin moise,HIST-3900,2016
-HIST,3980,1,American Military History,0.31,0.38,0.24,0.0,0.03,0.0,0.0,0.03,john andrew,HIST-3980,2016
-HIST,4140,1,Study of Hist Museum,0.25,0.5,0.06,0.13,0.06,0.0,0.0,0.0,meg taylor-shockley,HIST-4140,2016
-HIST,4360,1,Vietnam Wars,0.05,0.37,0.37,0.0,0.11,0.0,0.0,0.11,edwin moise,HIST-4360,2016
-HIST,4710,1,The Great War,0.55,0.17,0.03,0.0,0.1,0.0,0.0,0.14, alan grubb,HIST-4710,2016
-HIST,4900,3,Europe's Age of Dictators,0.42,0.47,0.05,0.0,0.0,0.0,0.0,0.05,amit bein,HIST-4900,2016
-HIST,8000,2,Historical Methods,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,paul chris anderson,HIST-8000,2016
-HIST,8100,3,Capitalism,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,HIST-8100,2016
-HLTH,2020,1,Introduction to Public Health,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2016
-HLTH,2020,2,Introduction to Public Health,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2016
-HLTH,2020,3,Introduction to Public Health,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2016
-HLTH,2020,4,Introduction to Public Health,0.43,0.43,0.13,0.03,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2016
-HLTH,2020,5,Introduction to Public Health,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2016
-HLTH,2020,400,Introduction to Public Health,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,ralph stewart welsh,HLTH-2020,2016
-HLTH,2030,1,Health Care Sys,0.57,0.26,0.09,0.0,0.04,0.0,0.0,0.04,frederic fraizer,HLTH-2030,2016
-HLTH,2030,2,Health Care Sys,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,lee alden crandall,HLTH-2030,2016
-HLTH,2400,1,Deter of Hlth Behav,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,johnny long,HLTH-2400,2016
-HLTH,2400,2,Deter of Hlth Behav,0.36,0.54,0.07,0.04,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2016
-HLTH,2400,3,Deter of Hlth Behav,0.52,0.31,0.17,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2016
-HLTH,2400,400,Deter of Hlth Behav,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,amelia clinkscales,HLTH-2400,2016
-HLTH,2600,1,Medical Terminology & Comm,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kari jea strothmann,HLTH-2600,2016
-HLTH,2980,1,Human Hlth & Disease,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2016
-HLTH,2980,2,Human Hlth & Disease,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2016
-HLTH,2980,3,Human Hlth & Disease,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2980,2016
-HLTH,3050,1,Body Resp Hlth Beh,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brian patric graves,HLTH-3050,2016
-HLTH,3400,1,Hlth Prom Prog Plan,0.39,0.43,0.13,0.0,0.04,0.0,0.0,0.0,brian patric graves,HLTH-3400,2016
-HLTH,3610,1,Int Health Care Econ,0.56,0.29,0.09,0.03,0.0,0.0,0.0,0.03,khoa dang truong,HLTH-3610,2016
-HLTH,3800,1,Epidemiology,0.3,0.36,0.27,0.02,0.02,0.0,0.0,0.02,hugh spitler,HLTH-3800,2016
-HLTH,3800,2,Epidemiology,0.55,0.34,0.1,0.0,0.0,0.0,0.0,0.0,rachel mayo,HLTH-3800,2016
-HLTH,3800,400,Epidemiology,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,deborah alma falta,HLTH-3800,2016
-HLTH,4150,1,Obesity & Eating Dis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,karen kemper,HLTH-4150,2016
-HLTH,4190,1,Health Sci Internship Prep Sem,0.63,0.28,0.1,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4190,2016
-HLTH,4200,1,Hlth Science Intern,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2016
-HLTH,4400,1,Manag Hlth Serv Org,0.37,0.37,0.19,0.04,0.04,0.0,0.0,0.0,frederic fraizer,HLTH-4400,2016
-HLTH,4700,1,Global Health,0.67,0.21,0.08,0.0,0.04,0.0,0.0,0.0,annah kamugiz amani,HLTH-4700,2016
-HLTH,4700,400,Global Health,0.88,0.08,0.0,0.04,0.0,0.0,0.0,0.0,annah kamugiz amani,HLTH-4700,2016
-HLTH,4750,1,Hlthcr Oper Mgmt Res,0.59,0.18,0.18,0.0,0.0,0.0,0.0,0.05,lu shi,HLTH-4750,2016
-HLTH,4900,1,Res Eval St Pub Hlth,0.51,0.37,0.1,0.02,0.0,0.0,0.0,0.0,lingling zhang,HLTH-4900,2016
-HLTH,4900,2,Res Eval St Pub Hlth,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,lingling zhang,HLTH-4900,2016
-HLTH,8090,1,Epidemiological Res,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,liwei chen,HLTH-8090,2016
-HLTH,8120,500,Clinical and Translational Sci,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,ronald gimbel,HLTH-8120,2016
-HON,1910,1,Romanticism and Its Influence,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,HON-1910,2016
-HON,1930,1,World in Crisis,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vladimir matic,HON-1930,2016
-HON,2020,1,Who Decides What's Cool?,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,amanda cooper fine,HON-2020,2016
-HON,2020,2,World of Ideas,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,HON-2020,2016
-HON,2220,1,Almost Human,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,HON-2220,2016
-HORT,1010,1,Horticulture,0.86,0.09,0.02,0.02,0.0,0.0,0.0,0.02,ellen anita vincent,HORT-1010,2016
-HORT,2100,1,Growing Fall Plants,0.26,0.57,0.13,0.0,0.04,0.0,0.0,0.0,james emerson faust,HORT-2100,2016
-HORT,2120,1,Turfgrass Culture,0.52,0.38,0.07,0.0,0.02,0.0,0.0,0.02,haibo liu,HORT-2120,2016
-HORT,2130,1,Turf Culture Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,donald garrett,HORT-2130,2016
-HORT,2130,2,Turf Culture Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,donald garrett,HORT-2130,2016
-HORT,3030,1,Landscape Plants,0.18,0.32,0.35,0.04,0.03,0.0,0.0,0.07,robert polomski,HORT-3030,2016
-HORT,3080,1,Sust Landsc Des Install Maint,0.84,0.12,0.02,0.0,0.0,0.0,0.0,0.02,ellen anita vincent,HORT-3080,2016
-HORT,4330,1,Turf Weed Management,0.21,0.36,0.36,0.07,0.0,0.0,0.0,0.0,ted whitwell,HORT-4330,2016
-HORT,4550,1,Just Fruits,0.39,0.43,0.13,0.0,0.04,0.0,0.0,0.0,gregory reighard,HORT-4550,2016
-HP,8010,1,Preservation Law and Econ,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,richard sidebottom,HP-8010,2016
-HP,8030,1,Building Tech and Pathology,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,amalia leifeste,HP-8030,2016
-HP,8090,400,Historical Research Methods,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,katherine pemberton,HP-8090,2016
-HP,8230,400,Historic American Interiors,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,elizabeth garr ryan,HP-8230,2016
-HRD,8200,400,Human Perform Improv,0.62,0.17,0.0,0.0,0.14,0.0,0.0,0.07,cynthia sims,HRD-8200,2016
-HRD,8300,400,Concepts of H R D,0.46,0.27,0.08,0.0,0.15,0.0,0.0,0.04,charlotte ann chase,HRD-8300,2016
-HRD,8450,400,Needs Assess Ed/Ind,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,philip mcgee,HRD-8450,2016
-HRD,8600,400,Instruc Mat Devel,0.76,0.06,0.03,0.0,0.12,0.0,0.0,0.03,philip mcgee,HRD-8600,2016
-IE,2000,100,Soph Seminar in I E,0.54,0.19,0.12,0.04,0.05,0.0,0.0,0.06,brian melloy,IE-2000,2016
-IE,2100,1,Des Analysis Wrk Sys,0.07,0.39,0.32,0.1,0.05,0.0,0.0,0.06,david neyens,IE-2100,2016
-IE,2800,1,Deterministic Operations Rsrch,0.16,0.4,0.16,0.13,0.08,0.0,0.0,0.07,robert james riggs,IE-2800,2016
-IE,3010,1,Systems Design I,0.47,0.43,0.09,0.0,0.0,0.0,0.0,0.01,robert james riggs,IE-3010,2016
-IE,3600,1,Industrial Apps of Prob/Stat I,0.29,0.27,0.29,0.06,0.08,0.0,0.0,0.02,tugce isik,IE-3600,2016
-IE,3600,2,Industrial Apps of Prob/Stat I,0.18,0.27,0.27,0.18,0.05,0.0,0.0,0.05,tugce isik,IE-3600,2016
-IE,3610,1,Industrial App of Prob/Stat II,0.27,0.27,0.15,0.15,0.12,0.0,0.0,0.04,joel greenstein,IE-3610,2016
-IE,3680,1,Prof Practice in I E,0.87,0.05,0.02,0.03,0.0,0.0,0.0,0.02,brian melloy,IE-3680,2016
-IE,3810,1,Probabilistic Operations Rsrch,0.24,0.32,0.21,0.08,0.13,0.0,0.0,0.03,amin khademi,IE-3810,2016
-IE,3840,1,Engr Econ Analysis,0.21,0.15,0.11,0.12,0.12,0.0,0.0,0.29,brian melloy,IE-3840,2016
-IE,3860,1,Prod Plan & Cont,0.21,0.37,0.17,0.11,0.13,0.0,0.0,0.0,robert james riggs,IE-3860,2016
-IE,4400,1,Decision Support Sys,0.64,0.14,0.09,0.05,0.05,0.0,0.0,0.03,jonathan lowe,IE-4400,2016
-IE,4570,1,Transp/Logistic Engr,0.25,0.59,0.15,0.02,0.0,0.0,0.0,0.0,sandra dun eksioglu,IE-4570,2016
-IE,4610,1,Quality Engineering,0.25,0.28,0.27,0.15,0.03,0.0,0.0,0.03,byung rae cho,IE-4610,2016
-IE,4650,1,Facilities Planning & Design,0.78,0.17,0.03,0.02,0.0,0.0,0.0,0.0,jonathan lowe,IE-4650,2016
-IE,4650,2,Facilities Planning & Design,0.42,0.33,0.13,0.13,0.0,0.0,0.0,0.0,brian melloy,IE-4650,2016
-IE,4820,1,Systems Modeling,0.36,0.39,0.18,0.04,0.01,0.0,0.0,0.01,kevin taaffe,IE-4820,2016
-IE,4820,2,Systems Modeling,0.26,0.55,0.1,0.07,0.0,0.0,0.0,0.02,kevin taaffe,IE-4820,2016
-IE,4910,1,Invest Human Errors Cmplx Sys,0.31,0.31,0.09,0.06,0.03,0.0,0.0,0.2,sara lu riggs,IE-4910,2016
-IE,6910,2,Advanced Math Opt Models,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,IE-6910,2016
-IE,8000,1,Human Factors Eng,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david neyens,IE-8000,2016
-IE,8010,1,Human-Machine Sys,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,IE-8010,2016
-IE,8030,1,Engr Optimization and Apps,0.27,0.5,0.18,0.0,0.0,0.0,0.0,0.05,amin khademi,IE-8030,2016
-IE,8040,1,Mfg Sys Plan & Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,IE-8040,2016
-IE,8090,1,Model Sys Under Risk,0.17,0.61,0.17,0.0,0.0,0.0,0.0,0.06,burak eksioglu,IE-8090,2016
-IE,8510,1,Descriptive Analytics,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,mary elizabeth kurz,IE-8510,2016
-IE,8530,1,Foundations of Quality,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,byung rae cho,IE-8530,2016
-IE,8550,1,SC & Logistics Modeling II,0.8,0.11,0.04,0.0,0.04,0.0,0.0,0.0,kevin taaffe,IE-8550,2016
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.84,0.14,0.02,caren kelley-hall,INT-1510,2016
-INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.92,0.06,0.02,caren kelley-hall,INT-1520,2016
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,INT-1530,2016
-INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.83,0.14,0.03,caren kelley-hall,INT-1540,2016
-INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.82,0.12,0.06,caren kelley-hall,INT-2510,2016
-IPM,4010,1,Principles of I P M,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,robert bellinger,IPM-4010,2016
-IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.86,0.05,0.09,meredith fan wilson,IS-1010,2016
-ITAL,1010,1,Elementary Italian,0.33,0.25,0.25,0.08,0.08,0.0,0.0,0.0,julia schmidt,ITAL-1010,2016
-ITAL,1010,2,Elementary Italian,0.59,0.12,0.06,0.0,0.06,0.0,0.0,0.18,julia schmidt,ITAL-1010,2016
-ITAL,1010,3,Elementary Italian,0.67,0.17,0.0,0.0,0.08,0.0,0.0,0.08,lyudmyla tsykalova,ITAL-1010,2016
-ITAL,1010,4,Elementary Italian,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-1010,2016
-ITAL,2010,1,Intermediate Italian,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,ITAL-2010,2016
-ITAL,2020,1,Intermediate Italian,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,ITAL-2020,2016
-JAPN,1010,1,Elementary Japanese,0.58,0.08,0.17,0.0,0.08,0.0,0.0,0.08,shinichi shoji,JAPN-1010,2016
-JAPN,1010,2,Elementary Japanese,0.53,0.18,0.24,0.0,0.0,0.0,0.0,0.06,shinichi shoji,JAPN-1010,2016
-JAPN,1010,3,Elementary Japanese,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,shinichi shoji,JAPN-1010,2016
-JAPN,2010,1,Intermed Japanese,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,jae allegr takeuchi,JAPN-2010,2016
-JAPN,3050,1,Japanese Conversation & Comp,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,kazuko shoji,JAPN-3050,2016
-JAPN,4010,1,Japanese Lit in Translation,0.76,0.0,0.12,0.0,0.0,0.0,0.0,0.12,jae allegr takeuchi,JAPN-4010,2016
-LANG,3000,1,Intro Linguistics,0.33,0.39,0.06,0.06,0.06,0.0,0.0,0.11,daniel smith,LANG-3000,2016
-LANG,3710,1,Language and Culture,0.3,0.3,0.2,0.1,0.1,0.0,0.0,0.0,yanhua zhang,LANG-3710,2016
-LARC,1150,1,Intro Landscape Architecture,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,LARC-1150,2016
-LARC,1280,1,Technical Graphics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,LARC-1280,2016
-LARC,1510,1,Basic Design I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,LARC-1510,2016
-LARC,2510,1,Larch Design Fund,0.4,0.4,0.05,0.0,0.1,0.0,0.0,0.05,hala fouad nassar,LARC-2510,2016
-LARC,2620,2,Design Impl I,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,yang song,LARC-2620,2016
-LARC,4620,1,Design Implementation III,0.28,0.28,0.28,0.0,0.0,0.0,0.0,0.17,paul russell,LARC-4620,2016
-LARC,8210,1,Research Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,LARC-8210,2016
-LARC,8430,1,Interdisc Design,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,LARC-8430,2016
-LAW,3220,1,Legal Env of Bus,0.44,0.33,0.14,0.02,0.0,0.0,0.0,0.07,edward ray claggett,LAW-3220,2016
-LAW,3220,2,Legal Env of Bus,0.47,0.43,0.11,0.0,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2016
-LAW,3220,3,Legal Env of Bus,0.26,0.38,0.19,0.13,0.02,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2016
-LAW,3220,4,Legal Env of Bus,0.24,0.48,0.22,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2016
-LAW,3220,5,Legal Env of Bus,0.39,0.28,0.22,0.04,0.02,0.0,0.0,0.04,kenneth toussaint,LAW-3220,2016
-LAW,3220,6,Legal Env of Bus,0.33,0.31,0.2,0.09,0.0,0.0,0.0,0.07,kenneth toussaint,LAW-3220,2016
-LAW,3220,7,Legal Env of Bus,0.33,0.4,0.17,0.05,0.02,0.0,0.0,0.02,kath kisska-schulze,LAW-3220,2016
-LAW,3220,8,Legal Env of Bus,0.38,0.6,0.02,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,LAW-3220,2016
-LAW,3220,9,Legal Env of Bus,0.35,0.54,0.09,0.0,0.0,0.0,0.0,0.02,john hine,LAW-3220,2016
-LAW,3220,10,Legal Env of Bus,0.37,0.47,0.14,0.02,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2016
-LAW,3220,400,Legal Env of Bus,0.29,0.29,0.16,0.11,0.04,0.0,0.0,0.11,virgini ward-vaughn,LAW-3220,2016
-LAW,3220,401,Legal Env of Bus,0.41,0.48,0.09,0.02,0.0,0.0,0.0,0.0,virgini ward-vaughn,LAW-3220,2016
-LAW,3220,402,Legal Env of Bus,0.51,0.2,0.06,0.02,0.08,0.0,0.0,0.12,virgini ward-vaughn,LAW-3220,2016
-LAW,3220,403,Legal Env of Bus,0.27,0.32,0.1,0.05,0.07,0.0,0.0,0.2,virgini ward-vaughn,LAW-3220,2016
-LAW,3330,1,Real Estate Law,0.06,0.46,0.29,0.09,0.03,0.0,0.0,0.09,judson jahn,LAW-3330,2016
-LAW,3330,2,Real Estate Law,0.4,0.23,0.33,0.0,0.0,0.0,0.0,0.03,judson jahn,LAW-3330,2016
-LAW,4050,1,Construction Law,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-4050,2016
-LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,eric touya,LIT-1270,2016
-LS,1000,1,Therapeutic Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,LS-1000,2016
-LS,1000,2,Therapeutic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,LS-1000,2016
-LS,1000,3,Therapeutic Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,LS-1000,2016
-LS,1000,4,Intermediate Top-rope,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,corey newe winstead,LS-1000,2016
-LS,1000,11,Organic Gardening,0.81,0.06,0.06,0.0,0.06,0.0,0.0,0.0,shawn jadrnicek,LS-1000,2016
-LS,1000,12,Introduction to Salsa,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,LS-1000,2016
-LS,1000,13,Introduction to Salsa Dance,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,malik lewis baxter,LS-1000,2016
-LS,1000,24,FItness leadership,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,patricia figueroa,LS-1000,2016
-LS,1330,4,Women's Shotgun,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,edward licus prater,LS-1330,2016
-LS,1410,1,Top Rope Climbing,0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,corey newe winstead,LS-1410,2016
-LS,1410,2,Top Rope Climbing,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,corey newe winstead,LS-1410,2016
-LS,1410,3,Top Rope Climbing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,corey newe winstead,LS-1410,2016
-LS,1410,4,Top Rope Climbing,0.71,0.06,0.06,0.06,0.0,0.0,0.0,0.12,corey newe winstead,LS-1410,2016
-LS,1410,5,Top Rope Climbing,0.83,0.06,0.0,0.0,0.11,0.0,0.0,0.0,corey newe winstead,LS-1410,2016
-LS,1560,6,Riflery,0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,herbert strickland,LS-1560,2016
-LS,1580,1,Archery,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,LS-1580,2016
-LS,1580,3,Archery,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,herbert strickland,LS-1580,2016
-LS,1580,5,Archery,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,LS-1580,2016
-LS,1640,1,Whitewater Kayaking,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,cara jill wrenn,LS-1640,2016
-LS,1640,2,Whitewater Kayaking,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,robert taylor,LS-1640,2016
-LS,1790,1,Scuba I,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,robert bogan,LS-1790,2016
-LS,1850,2,Bowling,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,megan elizabet cato,LS-1850,2016
-LS,1850,3,Bowling,0.9,0.07,0.0,0.0,0.03,0.0,0.0,0.0,kathryn ly mitchell,LS-1850,2016
-LS,1850,5,Bowling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,katie dudley,LS-1850,2016
-LS,1850,10,Bowling,0.86,0.07,0.03,0.0,0.03,0.0,0.0,0.0,katie dudley,LS-1850,2016
-LS,1940,1,Racquetball,0.69,0.15,0.0,0.08,0.0,0.0,0.0,0.08,raymond petersen,LS-1940,2016
-LS,1980,5,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jason jordan,LS-1980,2016
-LS,1990,1,Intermediate Golf,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,jason jordan,LS-1990,2016
-LS,2180,1,Ballroom Dance,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,broadus fleming,LS-2180,2016
-LS,2200,9,Shag,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,broadus fleming,LS-2200,2016
-LS,2270,1,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,paul hoke,LS-2270,2016
-LS,2270,2,Intro to Swing Dance,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,paul hoke,LS-2270,2016
-LS,2280,1,Intermediate Swing,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,paul hoke,LS-2280,2016
-LS,2320,1,Core Training,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,LS-2320,2016
-LS,2320,2,Core Training,0.71,0.19,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,LS-2320,2016
-LS,2320,4,Core Training,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,LS-2320,2016
-LS,2320,5,Core Training,0.78,0.13,0.0,0.04,0.0,0.0,0.0,0.04,diane moreno,LS-2320,2016
-LS,2350,1,Basic Yoga,0.71,0.1,0.1,0.05,0.0,0.0,0.0,0.05,renee warren gahan,LS-2350,2016
-LS,2350,2,Basic Yoga,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,renee warren gahan,LS-2350,2016
-LS,2350,3,Basic Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,renee warren gahan,LS-2350,2016
-LS,2350,4,Basic Yoga,0.86,0.05,0.09,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,LS-2350,2016
-LS,2360,1,Power/Ashtanga Yoga,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,silica eliza larkin,LS-2360,2016
-LS,2380,2,Vinyasa Flow Yoga,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,LS-2380,2016
-LS,2420,1,Meditation and Relax,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2016
-LS,2420,2,Meditation and Relax,0.83,0.09,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2016
-LS,2420,6,Meditation and Relax,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2016
-LS,2420,7,Meditation and Relax,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,LS-2420,2016
-LS,2420,8,Meditation and Relax,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,LS-2420,2016
-LS,2450,2,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,LS-2450,2016
-LS,2450,3,Pilates,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,LS-2450,2016
-LS,2450,4,Pilates,0.88,0.0,0.0,0.0,0.04,0.0,0.0,0.08,melanie ivey job,LS-2450,2016
-LS,2450,7,Pilates,0.81,0.05,0.0,0.0,0.05,0.0,0.0,0.1,diane moreno,LS-2450,2016
-LS,2510,3,Running & Jogging,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,robert edwar lawson,LS-2510,2016
-LS,2700,1,Sports Officiating,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,christopher war cox,LS-2700,2016
-LS,2750,9,First Aid/Cpr,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,candice lyn honnold,LS-2750,2016
-LS,2750,10,First Aid/Cpr,0.73,0.07,0.0,0.0,0.0,0.0,0.0,0.2,candice lyn honnold,LS-2750,2016
-MATH,1010,1,Essen Math for Informed Soc,0.23,0.23,0.46,0.0,0.0,0.0,0.0,0.08,thowhida akther,MATH-1010,2016
-MATH,1010,2,Essen Math for Informed Soc,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,thowhida akther,MATH-1010,2016
-MATH,1010,3,Essen Math for Informed Soc,0.5,0.28,0.17,0.06,0.0,0.0,0.0,0.0,xiyan tan,MATH-1010,2016
-MATH,1010,4,Essen Math for Informed Soc,0.31,0.38,0.12,0.07,0.07,0.0,0.0,0.05,judith cottingham,MATH-1010,2016
-MATH,1010,5,Essen Math for Informed Soc,0.21,0.36,0.21,0.14,0.07,0.0,0.0,0.0,xiyan tan,MATH-1010,2016
-MATH,1010,6,Essen Math for Informed Soc,0.33,0.35,0.16,0.07,0.05,0.0,0.0,0.05,judith cottingham,MATH-1010,2016
-MATH,1010,8,Essen Math for Informed Soc,0.17,0.39,0.28,0.11,0.06,0.0,0.0,0.0,tianhui wei,MATH-1010,2016
-MATH,1010,10,Essen Math for Informed Soc,0.54,0.23,0.0,0.0,0.08,0.0,0.0,0.15,tianhui wei,MATH-1010,2016
-MATH,1020,1,Business Calculus I,0.06,0.56,0.17,0.06,0.17,0.0,0.0,0.0,thomas clevenger,MATH-1020,2016
-MATH,1020,2,Business Calculus I,0.21,0.21,0.26,0.11,0.11,0.0,0.0,0.11,bryce pruitt,MATH-1020,2016
-MATH,1020,3,Business Calculus I,0.18,0.18,0.36,0.07,0.18,0.0,0.0,0.02,warren adams,MATH-1020,2016
-MATH,1020,5,Business Calculus I,0.16,0.32,0.37,0.05,0.11,0.0,0.0,0.0,peter westerbaan,MATH-1020,2016
-MATH,1020,6,Business Calculus I,0.16,0.32,0.21,0.0,0.16,0.0,0.0,0.16,jared scott miller,MATH-1020,2016
-MATH,1020,7,Business Calculus I,0.22,0.44,0.17,0.06,0.11,0.0,0.0,0.0,thomas clevenger,MATH-1020,2016
-MATH,1020,8,Business Calculus I,0.16,0.42,0.11,0.11,0.16,0.0,0.0,0.05,bryce pruitt,MATH-1020,2016
-MATH,1020,9,Business Calculus I,0.37,0.21,0.16,0.0,0.16,0.0,0.0,0.11,michael thoma cowen,MATH-1020,2016
-MATH,1020,10,Business Calculus I,0.28,0.33,0.22,0.06,0.06,0.0,0.0,0.06,ashleigh craig,MATH-1020,2016
-MATH,1020,11,Business Calculus I,0.26,0.42,0.16,0.05,0.11,0.0,0.0,0.0,fun choi john chan,MATH-1020,2016
-MATH,1020,12,Business Calculus I,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,peter westerbaan,MATH-1020,2016
-MATH,1020,13,Business Calculus I,0.31,0.26,0.21,0.07,0.07,0.0,0.0,0.07,randy davidson,MATH-1020,2016
-MATH,1020,14,Business Calculus I,0.0,0.37,0.47,0.0,0.11,0.0,0.0,0.05,emily marie nystrom,MATH-1020,2016
-MATH,1020,15,Business Calculus I,0.16,0.42,0.16,0.16,0.05,0.0,0.0,0.05,todd fenstermacher,MATH-1020,2016
-MATH,1020,16,Business Calculus I,0.28,0.11,0.22,0.17,0.22,0.0,0.0,0.0,fun choi john chan,MATH-1020,2016
-MATH,1020,17,Business Calculus I,0.26,0.42,0.16,0.0,0.0,0.0,0.0,0.16,ashleigh craig,MATH-1020,2016
-MATH,1020,18,Business Calculus I,0.11,0.53,0.11,0.21,0.0,0.0,0.0,0.05,michael thoma cowen,MATH-1020,2016
-MATH,1020,19,Business Calculus I,0.31,0.21,0.14,0.12,0.12,0.0,0.0,0.1,randy davidson,MATH-1020,2016
-MATH,1020,20,Business Calculus I,0.21,0.37,0.21,0.05,0.11,0.0,0.0,0.05,emily marie nystrom,MATH-1020,2016
-MATH,1020,21,Business Calculus I,0.16,0.21,0.32,0.0,0.16,0.0,0.0,0.16,todd fenstermacher,MATH-1020,2016
-MATH,1020,22,Business Calculus I,0.42,0.16,0.37,0.05,0.0,0.0,0.0,0.0,john william grant,MATH-1020,2016
-MATH,1020,23,Business Calculus I,0.26,0.32,0.16,0.0,0.21,0.0,0.0,0.05,camille zerfas,MATH-1020,2016
-MATH,1020,24,Business Calculus I,0.28,0.11,0.28,0.22,0.06,0.0,0.0,0.06,aaro ramirez flores,MATH-1020,2016
-MATH,1020,25,Business Calculus I,0.11,0.37,0.26,0.05,0.11,0.0,0.0,0.11,stephen peele,MATH-1020,2016
-MATH,1020,26,Business Calculus I,0.21,0.32,0.37,0.05,0.0,0.0,0.0,0.05,shanshan jia,MATH-1020,2016
-MATH,1020,27,Business Calculus I,0.37,0.05,0.26,0.21,0.05,0.0,0.0,0.05,kara ail stasikelis,MATH-1020,2016
-MATH,1020,28,Business Calculus I,0.53,0.16,0.21,0.11,0.0,0.0,0.0,0.0,stephen peele,MATH-1020,2016
-MATH,1020,29,Business Calculus I,0.32,0.21,0.26,0.05,0.11,0.0,0.0,0.05,camille zerfas,MATH-1020,2016
-MATH,1020,30,Business Calculus I,0.21,0.37,0.26,0.0,0.05,0.0,0.0,0.11,jing li,MATH-1020,2016
-MATH,1020,32,Business Calculus I,0.26,0.21,0.16,0.11,0.26,0.0,0.0,0.0,lu sun,MATH-1020,2016
-MATH,1020,33,Business Calculus I,0.4,0.28,0.13,0.08,0.08,0.0,0.0,0.05,warren adams,MATH-1020,2016
-MATH,1020,34,Business Calculus I,0.35,0.35,0.18,0.0,0.06,0.0,0.0,0.06,shanshan jia,MATH-1020,2016
-MATH,1020,35,Business Calculus I,0.37,0.26,0.21,0.0,0.11,0.0,0.0,0.05,kara ail stasikelis,MATH-1020,2016
-MATH,1020,36,Business Calculus I,0.06,0.25,0.25,0.06,0.25,0.0,0.0,0.13,tianqi zhang,MATH-1020,2016
-MATH,1020,37,Business Calculus I,0.13,0.31,0.25,0.0,0.19,0.0,0.0,0.13,jing li,MATH-1020,2016
-MATH,1020,38,Business Calculus I,0.22,0.33,0.17,0.17,0.06,0.0,0.0,0.06,stephen garth,MATH-1020,2016
-MATH,1020,39,Business Calculus I,0.26,0.29,0.19,0.1,0.05,0.0,0.0,0.12,warren adams,MATH-1020,2016
-MATH,1020,40,Business Calculus I,0.17,0.5,0.11,0.11,0.11,0.0,0.0,0.0,aaro ramirez flores,MATH-1020,2016
-MATH,1020,41,Business Calculus I,0.12,0.29,0.12,0.18,0.18,0.0,0.0,0.12,tianqi zhang,MATH-1020,2016
-MATH,1020,42,Business Calculus I,0.0,0.32,0.26,0.16,0.21,0.0,0.0,0.05,lu sun,MATH-1020,2016
-MATH,1020,44,Business Calculus I,0.0,0.21,0.42,0.0,0.21,0.0,0.0,0.16,stephen garth,MATH-1020,2016
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.56,0.4,0.04,donna simms,MATH-1040,2016
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.32,0.47,0.21,xun dong,MATH-1040,2016
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.46,0.2,haotian feng,MATH-1040,2016
-MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.53,0.43,0.04,tony thanh nguyen,MATH-1040,2016
-MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.56,0.06,chase norman joyner,MATH-1040,2016
-MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.48,0.41,0.11,tony thanh nguyen,MATH-1040,2016
-MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.44,0.18,lauren pai mcintyre,MATH-1040,2016
-MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.64,0.02,tony thanh nguyen,MATH-1040,2016
-MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.48,0.14,liang zhao,MATH-1040,2016
-MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.35,0.56,0.08,nicholas ahlstrom,MATH-1040,2016
-MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.26,0.46,0.28,stefan adam bock,MATH-1040,2016
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.6,0.34,0.06,charity watson,MATH-1050,2016
-MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.52,0.46,0.02,charity watson,MATH-1050,2016
-MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.39,0.02,charity watson,MATH-1050,2016
-MATH,1060,2,Calculus of One Variable I,0.11,0.27,0.13,0.04,0.27,0.0,0.0,0.18,sanwar ahmad,MATH-1060,2016
-MATH,1060,3,Calculus of One Variable I,0.36,0.29,0.21,0.02,0.05,0.0,0.0,0.07,garrett dranichak,MATH-1060,2016
-MATH,1060,4,Calculus of One Variable I,0.2,0.29,0.11,0.14,0.2,0.0,0.0,0.06,jonathon leverenz,MATH-1060,2016
-MATH,1060,5,Calculus of One Variable I,0.13,0.35,0.17,0.02,0.13,0.0,0.0,0.21,michael gl eldredge,MATH-1060,2016
-MATH,1060,7,Calculus of One Variable I,0.1,0.4,0.08,0.03,0.23,0.0,0.0,0.18,shuhan xu,MATH-1060,2016
-MATH,1060,8,Calculus of One Variable I,0.14,0.51,0.11,0.06,0.14,0.0,0.0,0.03,beth novick,MATH-1060,2016
-MATH,1060,10,Calculus of One Variable I,0.14,0.3,0.18,0.02,0.18,0.0,0.0,0.18,sergey charnyi,MATH-1060,2016
-MATH,1060,11,Calculus of One Variable I,0.33,0.26,0.21,0.05,0.05,0.0,0.0,0.1,hugh geller,MATH-1060,2016
-MATH,1060,13,Calculus of One Variable I,0.09,0.2,0.27,0.05,0.16,0.0,0.0,0.23,sofya alekseeva,MATH-1060,2016
-MATH,1060,14,Calculus of One Variable I,0.12,0.33,0.21,0.05,0.14,0.0,0.0,0.14,irina viktorova,MATH-1060,2016
-MATH,1060,15,Calculus of One Variable I,0.24,0.24,0.32,0.06,0.12,0.0,0.0,0.03,marilyn reba,MATH-1060,2016
-MATH,1060,16,Calculus of One Variable I,0.08,0.16,0.45,0.05,0.21,0.0,0.0,0.05,irina viktorova,MATH-1060,2016
-MATH,1060,18,Calculus of One Variable I,0.16,0.27,0.24,0.11,0.11,0.0,0.0,0.11,sofya alekseeva,MATH-1060,2016
-MATH,1060,20,Calculus of One Variable I,0.18,0.39,0.21,0.09,0.06,0.0,0.0,0.06,marilyn reba,MATH-1060,2016
-MATH,1060,21,Calculus of One Variable I,0.11,0.27,0.16,0.13,0.18,0.0,0.0,0.16,rebecca ramos,MATH-1060,2016
-MATH,1060,22,Calculus of One Variable I,0.02,0.2,0.29,0.02,0.2,0.0,0.0,0.27,sofya alekseeva,MATH-1060,2016
-MATH,1060,26,Calculus of One Variable I,0.07,0.34,0.22,0.07,0.2,0.0,0.0,0.1,shuhan xu,MATH-1060,2016
-MATH,1060,100,Calc of One Variable I (HON),0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,beth novick,MATH-1060,2016
-MATH,1060,201,Calculus of One Variable I,0.31,0.35,0.13,0.04,0.06,0.0,0.0,0.1,allen anderso guest,MATH-1060,2016
-MATH,1060,206,Calculus of One Variable I,0.23,0.38,0.19,0.06,0.1,0.0,0.0,0.04,allen anderso guest,MATH-1060,2016
-MATH,1060,209,Calculus of One Variable I,0.27,0.27,0.29,0.02,0.06,0.0,0.0,0.08,james brown,MATH-1060,2016
-MATH,1060,212,Calculus of One Variable I,0.19,0.4,0.27,0.02,0.08,0.0,0.0,0.04,muhamm mohebujjaman,MATH-1060,2016
-MATH,1060,217,Calculus of One Variable I,0.13,0.38,0.29,0.08,0.06,0.0,0.0,0.06,alistair bentley,MATH-1060,2016
-MATH,1060,224,Calculus of One Variable I,0.17,0.33,0.33,0.02,0.07,0.0,0.0,0.07,irina viktorova,MATH-1060,2016
-MATH,1060,225,Calc of One Variable I (RISE),0.24,0.28,0.22,0.02,0.15,0.0,0.0,0.09,"koshy chenthittayil,",MATH-1060,2016
-MATH,1070,1,Differen and Integral Calculus,0.07,0.14,0.59,0.07,0.1,0.0,0.0,0.03,donna simms,MATH-1070,2016
-MATH,1080,1,Calculus of One Variable II,0.09,0.22,0.13,0.04,0.35,0.0,0.0,0.17,terri johnson,MATH-1080,2016
-MATH,1080,2,Calculus of One Variable II,0.03,0.28,0.07,0.0,0.31,0.0,0.0,0.31,timothy fra parrott,MATH-1080,2016
-MATH,1080,5,Calculus of One Variable II,0.06,0.16,0.25,0.03,0.31,0.0,0.0,0.19,honghai xu,MATH-1080,2016
-MATH,1080,6,Calculus of One Variable II,0.05,0.14,0.23,0.11,0.32,0.0,0.0,0.16,meredith nicol burr,MATH-1080,2016
-MATH,1080,7,Calculus of One Variable II,0.13,0.22,0.11,0.07,0.2,0.0,0.0,0.27,meredith nicol burr,MATH-1080,2016
-MATH,1080,8,Calculus of One Variable II,0.03,0.24,0.13,0.11,0.39,0.0,0.0,0.11,timothy fra parrott,MATH-1080,2016
-MATH,1080,10,Calculus of One Variable II,0.0,0.1,0.13,0.13,0.45,0.0,0.0,0.2,mark cawood,MATH-1080,2016
-MATH,1080,11,Calculus of One Variable II,0.08,0.19,0.28,0.06,0.33,0.0,0.0,0.06,honghai xu,MATH-1080,2016
-MATH,1080,12,Calculus of One Variable II,0.06,0.08,0.17,0.06,0.14,0.0,0.0,0.5,nicole alai sinwell,MATH-1080,2016
-MATH,1080,204,Calculus of One Variable II,0.13,0.39,0.1,0.1,0.0,0.0,0.0,0.29,timothy fra parrott,MATH-1080,2016
-MATH,1150,1,Contemp Math for Elem Teach I,0.65,0.27,0.05,0.03,0.0,0.0,0.0,0.0,allison stoddard,MATH-1150,2016
-MATH,1150,2,Contemp Math for Elem Teach I,0.79,0.17,0.03,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1150,2016
-MATH,1160,1,Contemp Math for Elem Teach II,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,carlos gomez,MATH-1160,2016
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.86,0.12,0.02,marion hanna,MATH-1990,2016
-MATH,1990,401,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.04,0.02,marion hanna,MATH-1990,2016
-MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,MATH-1990,2016
-MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.0,marion hanna,MATH-1990,2016
-MATH,2060,1,Calculus of Several Variables,0.31,0.33,0.18,0.03,0.13,0.0,0.0,0.03,akshay sunil gupte,MATH-2060,2016
-MATH,2060,3,Calculus of Several Variables,0.13,0.1,0.28,0.0,0.15,0.0,0.0,0.33,jeong rock yoon,MATH-2060,2016
-MATH,2060,4,Calculus of Several Variables,0.33,0.29,0.24,0.05,0.02,0.0,0.0,0.07,hiram lopez valdez,MATH-2060,2016
-MATH,2060,5,Calculus of Several Variables,0.07,0.18,0.31,0.18,0.13,0.0,0.0,0.13,eleanor jenkins,MATH-2060,2016
-MATH,2060,6,Calculus of Several Variables,0.23,0.27,0.25,0.1,0.08,0.0,0.0,0.06,hyesuk lee,MATH-2060,2016
-MATH,2060,7,Calculus of Several Variables,0.24,0.21,0.32,0.0,0.11,0.0,0.0,0.13,gretchen matthews,MATH-2060,2016
-MATH,2060,8,Calculus of Several Variables,0.14,0.22,0.16,0.14,0.12,0.0,0.0,0.2,shari prevost,MATH-2060,2016
-MATH,2060,9,Calculus of Several Variables,0.24,0.13,0.33,0.13,0.13,0.0,0.0,0.04,hyesuk lee,MATH-2060,2016
-MATH,2060,10,Calculus of Several Variables,0.39,0.13,0.26,0.0,0.13,0.0,0.0,0.08,gretchen matthews,MATH-2060,2016
-MATH,2060,11,Calculus of Several Variables,0.17,0.17,0.1,0.22,0.22,0.0,0.0,0.12,julie lassiter,MATH-2060,2016
-MATH,2060,12,Calculus of Several Variables,0.43,0.32,0.11,0.06,0.02,0.0,0.0,0.06,martin joha schmoll,MATH-2060,2016
-MATH,2060,13,Calculus of Several Variables,0.07,0.18,0.25,0.2,0.18,0.0,0.0,0.11,shari prevost,MATH-2060,2016
-MATH,2060,15,Calculus of Several Variables,0.1,0.19,0.21,0.17,0.14,0.0,0.0,0.19,julie lassiter,MATH-2060,2016
-MATH,2060,16,Calculus of Several Variables,0.36,0.3,0.25,0.07,0.0,0.0,0.0,0.02,yuyuan ouyang,MATH-2060,2016
-MATH,2060,17,Calculus of Several Variables,0.24,0.24,0.24,0.13,0.09,0.0,0.0,0.04,hyesuk lee,MATH-2060,2016
-MATH,2060,18,Calculus of Several Variables,0.07,0.25,0.2,0.18,0.09,0.0,0.0,0.2,shari prevost,MATH-2060,2016
-MATH,2060,20,Calculus of Several Variables,0.05,0.35,0.22,0.22,0.11,0.0,0.0,0.05,michael adam burr,MATH-2060,2016
-MATH,2060,21,Calculus of Several Variables,0.16,0.37,0.13,0.16,0.11,0.0,0.0,0.08,michael adam burr,MATH-2060,2016
-MATH,2060,22,Calculus of Several Variables,0.25,0.3,0.25,0.07,0.09,0.0,0.0,0.05,hiram lopez valdez,MATH-2060,2016
-MATH,2060,23,Calculus of Several Variables,0.36,0.11,0.31,0.06,0.08,0.0,0.0,0.08,yuyuan ouyang,MATH-2060,2016
-MATH,2060,24,Calculus of Several Variables,0.19,0.26,0.26,0.09,0.15,0.0,0.0,0.06,jonathon leverenz,MATH-2060,2016
-MATH,2060,100,Calc of Several Vars (HON),0.52,0.28,0.14,0.0,0.03,0.0,0.0,0.03,james brown,MATH-2060,2016
-MATH,2070,1,Business Calculus II,0.31,0.19,0.19,0.06,0.19,0.0,0.0,0.06,yinggu bao,MATH-2070,2016
-MATH,2070,2,Business Calculus II,0.11,0.28,0.44,0.06,0.11,0.0,0.0,0.0,liu zhu,MATH-2070,2016
-MATH,2070,3,Business Calculus II,0.11,0.39,0.11,0.06,0.11,0.0,0.0,0.22,yinggu bao,MATH-2070,2016
-MATH,2070,4,Business Calculus II,0.18,0.29,0.18,0.24,0.0,0.0,0.0,0.12,liu zhu,MATH-2070,2016
-MATH,2070,5,Business Calculus II,0.26,0.26,0.31,0.02,0.05,0.0,0.0,0.1,jennifer mari hanna,MATH-2070,2016
-MATH,2070,6,Business Calculus II,0.05,0.26,0.21,0.21,0.11,0.0,0.0,0.16,daniel kuzbary,MATH-2070,2016
-MATH,2070,7,Business Calculus II,0.29,0.12,0.24,0.24,0.0,0.0,0.0,0.12,thanh thien to,MATH-2070,2016
-MATH,2070,8,Business Calculus II,0.36,0.19,0.33,0.05,0.02,0.0,0.0,0.05,jennifer mari hanna,MATH-2070,2016
-MATH,2070,9,Business Calculus II,0.26,0.37,0.11,0.11,0.05,0.0,0.0,0.11,travis baumbaugh,MATH-2070,2016
-MATH,2070,10,Business Calculus II,0.21,0.42,0.26,0.0,0.11,0.0,0.0,0.0,tiantian yang,MATH-2070,2016
-MATH,2070,11,Business Calculus II,0.31,0.31,0.31,0.02,0.0,0.0,0.0,0.05,jennifer mari hanna,MATH-2070,2016
-MATH,2070,12,Business Calculus II,0.33,0.26,0.19,0.02,0.07,0.0,0.0,0.12,judith irene mcknew,MATH-2070,2016
-MATH,2070,13,Business Calculus II,0.11,0.44,0.33,0.06,0.0,0.0,0.0,0.06,haodong li,MATH-2070,2016
-MATH,2070,15,Business Calculus II,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,thanh thien to,MATH-2070,2016
-MATH,2070,16,Business Calculus II,0.07,0.27,0.27,0.33,0.0,0.0,0.0,0.07,tiantian yang,MATH-2070,2016
-MATH,2070,17,Business Calculus II,0.33,0.17,0.44,0.06,0.0,0.0,0.0,0.0,daniel kuzbary,MATH-2070,2016
-MATH,2070,18,Business Calculus II,0.16,0.47,0.11,0.05,0.05,0.0,0.0,0.16,travis baumbaugh,MATH-2070,2016
-MATH,2070,19,Business Calculus II,0.17,0.28,0.22,0.17,0.11,0.0,0.0,0.06,yibo xu,MATH-2070,2016
-MATH,2070,20,Business Calculus II,0.06,0.19,0.5,0.13,0.0,0.0,0.0,0.13,haodong li,MATH-2070,2016
-MATH,2070,21,Business Calculus II,0.35,0.24,0.29,0.12,0.0,0.0,0.0,0.0,yibo xu,MATH-2070,2016
-MATH,2080,1,Intro to Ordin Diff Equations,0.08,0.32,0.21,0.03,0.11,0.0,0.0,0.26,oleg yordanov,MATH-2080,2016
-MATH,2080,2,Intro to Ordin Diff Equations,0.19,0.3,0.21,0.06,0.15,0.0,0.0,0.09,timothy ch teitloff,MATH-2080,2016
-MATH,2080,3,Intro to Ordin Diff Equations,0.48,0.15,0.21,0.06,0.06,0.0,0.0,0.03,oleg yordanov,MATH-2080,2016
-MATH,2080,4,Intro to Ordin Diff Equations,0.33,0.26,0.23,0.03,0.05,0.0,0.0,0.1,mishko mitkovski,MATH-2080,2016
-MATH,2080,5,Intro to Ordin Diff Equations,0.34,0.2,0.23,0.03,0.14,0.0,0.0,0.06,mishko mitkovski,MATH-2080,2016
-MATH,2080,6,Intro to Ordin Diff Equations,0.25,0.39,0.08,0.06,0.11,0.0,0.0,0.11,timothy ch teitloff,MATH-2080,2016
-MATH,2080,7,Intro to Ordin Diff Equations,0.14,0.29,0.23,0.11,0.17,0.0,0.0,0.06,timothy ch teitloff,MATH-2080,2016
-MATH,2160,1,Geometry for Elem Sch Teachers,0.59,0.33,0.07,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-2160,2016
-MATH,2160,2,Geometry for Elem Sch Teachers,0.76,0.21,0.0,0.03,0.0,0.0,0.0,0.0,allison stoddard,MATH-2160,2016
-MATH,2500,1,Intro to Mathematical Sciences,0.86,0.13,0.01,0.0,0.0,0.0,0.0,0.0,christopher cox,MATH-2500,2016
-MATH,3020,1,Stat for Science & Engineering,0.16,0.62,0.14,0.0,0.05,0.0,0.0,0.03,taufiquar rahm khan,MATH-3020,2016
-MATH,3020,2,Stat for Science & Engineering,0.74,0.24,0.03,0.0,0.0,0.0,0.0,0.0,xin liu,MATH-3020,2016
-MATH,3020,3,Stat for Science & Engineering,0.53,0.21,0.0,0.05,0.11,0.0,0.0,0.11,yisu jia,MATH-3020,2016
-MATH,3020,4,Stat for Science & Engineering,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,yisu jia,MATH-3020,2016
-MATH,3020,5,Stat for Science & Engineering,0.36,0.36,0.11,0.03,0.11,0.0,0.0,0.03,brandon gra goodell,MATH-3020,2016
-MATH,3020,6,Stat for Science & Engineering,0.36,0.5,0.06,0.0,0.03,0.0,0.0,0.06,calvin williams,MATH-3020,2016
-MATH,3020,7,Stat for Science & Engineering,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.06,xiaoqian sun,MATH-3020,2016
-MATH,3020,8,Stat for Science & Engineering,0.42,0.47,0.05,0.0,0.03,0.0,0.0,0.03,xiaoqian sun,MATH-3020,2016
-MATH,3020,9,Stat for Science & Engineering,0.42,0.32,0.16,0.0,0.0,0.0,0.0,0.11,drew jared lipman,MATH-3020,2016
-MATH,3020,10,Stat for Science & Engineering,0.26,0.37,0.26,0.0,0.05,0.0,0.0,0.05,christopher wilson,MATH-3020,2016
-MATH,3020,11,Stat for Science & Engineering,0.32,0.37,0.16,0.05,0.05,0.0,0.0,0.05,yanbo xia,MATH-3020,2016
-MATH,3020,12,Stat for Science & Engineering,0.29,0.29,0.35,0.0,0.0,0.0,0.0,0.06,yanbo xia,MATH-3020,2016
-MATH,3110,1,Linear Algebra,0.11,0.4,0.26,0.03,0.06,0.0,0.0,0.14,hui xue,MATH-3110,2016
-MATH,3110,2,Linear Algebra,0.12,0.35,0.18,0.15,0.03,0.0,0.0,0.18,felice manganiello,MATH-3110,2016
-MATH,3110,3,Linear Algebra,0.34,0.09,0.2,0.2,0.06,0.0,0.0,0.11,felice manganiello,MATH-3110,2016
-MATH,3110,4,Linear Algebra,0.21,0.49,0.13,0.08,0.08,0.0,0.0,0.03,hui xue,MATH-3110,2016
-MATH,3110,5,Linear Algebra,0.29,0.31,0.23,0.06,0.09,0.0,0.0,0.03,wayne goddard,MATH-3110,2016
-MATH,3110,6,Linear Algebra,0.23,0.37,0.34,0.03,0.0,0.0,0.0,0.03,boshi yang,MATH-3110,2016
-MATH,3110,100,Linear Algebra (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,neil calkin,MATH-3110,2016
-MATH,3110,200,Linear Algebra,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,neil calkin,MATH-3110,2016
-MATH,3160,1,Prob Solving for Math Teachers,0.88,0.09,0.0,0.0,0.0,0.0,0.0,0.02,andrew mic tyminski,MATH-3160,2016
-MATH,3190,1,Introduction to Proof,0.17,0.43,0.17,0.13,0.09,0.0,0.0,0.0,elena sta dimitrova,MATH-3190,2016
-MATH,3190,2,Introduction to Proof,0.52,0.24,0.12,0.0,0.08,0.0,0.0,0.04,elena sta dimitrova,MATH-3190,2016
-MATH,3600,1,Intermediate Math Computing,0.83,0.06,0.0,0.03,0.03,0.0,0.0,0.06,mark cawood,MATH-3600,2016
-MATH,3600,2,Intermediate Math Computing,0.63,0.16,0.0,0.05,0.05,0.0,0.0,0.11,mark cawood,MATH-3600,2016
-MATH,3650,1,Numerical Mthds for Engineers,0.45,0.4,0.11,0.01,0.02,0.0,0.0,0.01,leo rebholz,MATH-3650,2016
-MATH,3650,2,Numerical Mthds for Engineers,0.62,0.32,0.06,0.0,0.0,0.0,0.0,0.0,timo johann heister,MATH-3650,2016
-MATH,4000,1,Theory of Probability,0.5,0.26,0.18,0.0,0.06,0.0,0.0,0.0,peter kiessler,MATH-4000,2016
-MATH,4000,2,Theory of Probability,0.41,0.36,0.18,0.0,0.05,0.0,0.0,0.0,ling ma,MATH-4000,2016
-MATH,4020,1,Stat for Sci & Engineering II,0.6,0.13,0.07,0.07,0.0,0.0,0.0,0.13,colin gallagher,MATH-4020,2016
-MATH,4080,1,Secondary Math Analysis,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,eliza dar gallagher,MATH-4080,2016
-MATH,4120,1,Algebra I,0.37,0.19,0.26,0.04,0.07,0.0,0.0,0.07,kevin james,MATH-4120,2016
-MATH,4190,1,Discrete Math Structures I,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,beth novick,MATH-4190,2016
-MATH,4190,2,Discrete Math Structures I,0.33,0.39,0.06,0.06,0.06,0.0,0.0,0.11,sea sather-wagstaff,MATH-4190,2016
-MATH,4310,1,Theory of Interest,0.5,0.2,0.2,0.1,0.0,0.0,0.0,0.0, erwin walker,MATH-4310,2016
-MATH,4340,1,Adv Engineering Mathematics,0.11,0.14,0.36,0.14,0.08,0.0,0.0,0.17,eleanor jenkins,MATH-4340,2016
-MATH,4340,2,Adv Engineering Mathematics,0.16,0.16,0.26,0.13,0.16,0.0,0.0,0.13,vincent ervin,MATH-4340,2016
-MATH,4350,1,Complex Variables,0.4,0.2,0.1,0.2,0.1,0.0,0.0,0.0,jeong rock yoon,MATH-4350,2016
-MATH,4400,1,Linear Programming,0.22,0.26,0.22,0.07,0.11,0.0,0.0,0.11,boshi yang,MATH-4400,2016
-MATH,4410,1,Intro to Stochastic Models,0.27,0.36,0.27,0.0,0.0,0.0,0.0,0.09,brian fralix,MATH-4410,2016
-MATH,4500,1,Intro to Mathematical Models,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,matthew macauley,MATH-4500,2016
-MATH,4530,1,Advanced Calculus I,0.25,0.29,0.29,0.04,0.08,0.0,0.0,0.04,james peterson,MATH-4530,2016
-MATH,4530,2,Advanced Calculus I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james peterson,MATH-4530,2016
-MATH,4540,1,Advanced Calculus II,0.3,0.2,0.2,0.25,0.0,0.0,0.0,0.05,shitao liu,MATH-4540,2016
-MATH,6340,1,Adv Engineering Mathematics,0.41,0.33,0.22,0.0,0.04,0.0,0.0,0.0,vincent ervin,MATH-6340,2016
-MATH,8000,1,Probability,0.5,0.35,0.05,0.0,0.1,0.0,0.0,0.0,peter kiessler,MATH-8000,2016
-MATH,8010,1,General Linear Hypothesis I,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,derek brown,MATH-8010,2016
-MATH,8050,1,Data Analysis,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,derek brown,MATH-8050,2016
-MATH,8090,1,Time Series Analysis,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-8090,2016
-MATH,8100,1,Mathematical Programming,0.48,0.36,0.04,0.0,0.08,0.0,0.0,0.04,warren adams,MATH-8100,2016
-MATH,8120,1,Discrete Optimization,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,MATH-8120,2016
-MATH,8140,1,Network Flow Programming,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,matthew saltzman,MATH-8140,2016
-MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,MATH-8170,2016
-MATH,8210,1,Linear Analysis,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,shitao liu,MATH-8210,2016
-MATH,8410,1,Applied Mathematics I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,MATH-8410,2016
-MATH,8510,1,Abstract Algebra I,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,sea sather-wagstaff,MATH-8510,2016
-MATH,8530,1,Matrix Analysis,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,matthew macauley,MATH-8530,2016
-MATH,8550,1,Combinatorial Analysis,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,MATH-8550,2016
-MATH,8600,1,Intro to Scientific Computing,0.33,0.33,0.2,0.0,0.07,0.0,0.0,0.07,fei xue,MATH-8600,2016
-MATH,8650,1,Data Structures,0.64,0.23,0.14,0.0,0.0,0.0,0.0,0.0,timo johann heister,MATH-8650,2016
-MATH,9500,1,Commutative Algebra,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james ba coykendall,MATH-9500,2016
-MBA,8030,1,Stat Analy of Bus Op,0.16,0.44,0.21,0.0,0.0,0.0,0.0,0.19,magda gabriela sava,MBA-8030,2016
-MBA,8060,1,Operations Mgt,0.23,0.6,0.18,0.0,0.0,0.0,0.0,0.0, sridharan,MBA-8060,2016
-MBA,8070,1,Financial Management,0.39,0.51,0.07,0.0,0.02,0.0,0.0,0.0,george bra lockhart,MBA-8070,2016
-MBA,8090,1,Org Beh & Hum Res Mg,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2016
-MBA,8090,2,Org Beh & Hum Res Mg,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2016
-MBA,8180,20,Intro Business Intell & Anlytc,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,heshan sun,MBA-8180,2016
-MBA,8190,1,Intro to Acc and Fin,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,melvin stith,MBA-8190,2016
-MBA,8190,2,Intro to Acc and Fin,0.54,0.34,0.07,0.0,0.02,0.0,0.0,0.02,thomas springer,MBA-8190,2016
-MBA,8290,1,Marketing Foundation,0.51,0.43,0.0,0.0,0.0,0.0,0.0,0.05,gary hunter,MBA-8290,2016
-MBA,8310,5,Communications and Sales,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,gregory pickett,MBA-8310,2016
-MBA,8330,1,Real Estate Investmt,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,MBA-8330,2016
-MBA,8360,1,Real Estate Principles,0.35,0.52,0.09,0.0,0.0,0.0,0.0,0.04,jeffrey randolph,MBA-8360,2016
-MBA,8370,1,Legal Environ of Bus,0.47,0.49,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2016
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,MBA-8400,2016
-MBA,8410,1,Real Estate Finance,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,wesley mcf blanding,MBA-8410,2016
-MBA,8430,1,Entrepreneurial Accounting,0.14,0.68,0.18,0.0,0.0,0.0,0.0,0.0,sally kathr widener,MBA-8430,2016
-MBA,8450,1,Technology & Innovation Mgt,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8450,2016
-MBA,8480,1,Entrpr Mkting & Digital Strat,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,MBA-8480,2016
-MBA,8480,5,Entrpr Mkting & Digital Strat,0.81,0.15,0.0,0.0,0.04,0.0,0.0,0.0,bruce snyder,MBA-8480,2016
-MBA,8490,5,Entrepreneurial Strategy,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,matthew charl klein,MBA-8490,2016
-MBA,8510,1,Bus Operations & Logistics,0.23,0.59,0.18,0.0,0.0,0.0,0.0,0.0, sridharan,MBA-8510,2016
-MBA,8540,1,Mgrl Accounting,0.44,0.44,0.07,0.0,0.0,0.0,0.0,0.05,james mil kohlmeyer,MBA-8540,2016
-MBA,8590,1,Mgr Decision Model,0.4,0.33,0.17,0.0,0.0,0.0,0.0,0.1,sara elizabet yoder,MBA-8590,2016
-MBA,8590,2,Mgr Decision Model,0.4,0.31,0.07,0.0,0.07,0.0,0.0,0.16,mark mcknew,MBA-8590,2016
-MBA,8600,1,Advanced Marketing Strategy,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2016
-MBA,8600,2,Advanced Marketing Strategy,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2016
-MBA,8610,1,Information Systems,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,MBA-8610,2016
-MBA,8620,1,Managerial Economics,0.3,0.52,0.12,0.0,0.0,0.0,0.0,0.06,scott templeton,MBA-8620,2016
-MBA,8620,2,Managerial Economics,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,MBA-8620,2016
-MBA,8620,3,Managerial Economics,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,MBA-8620,2016
-MBA,8650,1,Taxation of Business Decisions,0.25,0.63,0.04,0.0,0.04,0.0,0.0,0.04,judson jahn,MBA-8650,2016
-MBA,8700,1,Strategic Management,0.46,0.49,0.03,0.0,0.0,0.0,0.0,0.03,james turner,MBA-8700,2016
-MBA,8990,2,Creativity,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,MBA-8990,2016
-MBA,8990,11,Social Media and Marketing,0.72,0.19,0.06,0.0,0.03,0.0,0.0,0.0,lura forcum,MBA-8990,2016
-ME,2000,1,Sophomore Seminar,0.93,0.05,0.0,0.0,0.01,0.0,0.0,0.01,donald beasley,ME-2000,2016
-ME,2010,1,Statics & Dynamics,0.07,0.25,0.26,0.06,0.2,0.0,0.0,0.16,marisa kikendal orr,ME-2010,2016
-ME,2010,2,Statics & Dynamics,0.09,0.18,0.25,0.07,0.29,0.0,0.0,0.12,jorge iva rodriguez,ME-2010,2016
-ME,2010,3,Statics & Dynamics,0.04,0.13,0.3,0.14,0.28,0.0,0.0,0.1,paul joseph,ME-2010,2016
-ME,2030,1,Founda Th/Fl Syst,0.08,0.1,0.46,0.21,0.1,0.0,0.0,0.04,john saylor,ME-2030,2016
-ME,2030,2,Founda Th/Fl Syst,0.2,0.16,0.38,0.22,0.04,0.0,0.0,0.0,jay ochterbeck,ME-2030,2016
-ME,2040,1,Mechanics of Materials,0.11,0.49,0.3,0.06,0.03,0.0,0.0,0.0,garrett pataky,ME-2040,2016
-ME,2040,3,Mechanics of Materials,0.29,0.5,0.19,0.0,0.0,0.0,0.0,0.02,gang li,ME-2040,2016
-ME,2220,1,Mechanical Engineering Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-2220,2016
-ME,2220,2,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,3,Mechanical Engineering Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,4,Mechanical Engineering Lab I,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,5,Mechanical Engineering Lab I,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,6,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,7,Mechanical Engineering Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,8,Mechanical Engineering Lab I,0.33,0.27,0.4,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,3030,1,Thermodynamics,0.3,0.43,0.21,0.04,0.0,0.0,0.0,0.02,daniel fant,ME-3030,2016
-ME,3030,2,Thermodynamics,0.46,0.33,0.19,0.01,0.01,0.0,0.0,0.0,daniel fant,ME-3030,2016
-ME,3030,3,Thermodynamics,0.18,0.61,0.18,0.0,0.0,0.0,0.0,0.03,yiqiang han,ME-3030,2016
-ME,3040,1,Heat Transfer,0.15,0.45,0.3,0.03,0.03,0.0,0.0,0.05,jean-marc delhaye,ME-3040,2016
-ME,3040,2,Heat Transfer,0.19,0.33,0.34,0.07,0.07,0.0,0.0,0.0,xin zhao,ME-3040,2016
-ME,3050,1,Model/an Dy Syst,0.23,0.42,0.25,0.02,0.05,0.0,0.0,0.03,joshua bostwick,ME-3050,2016
-ME,3050,2,Model/an Dy Syst,0.16,0.4,0.35,0.05,0.0,0.0,0.0,0.05,ardalan vahidi,ME-3050,2016
-ME,3060,1,Fund Machine Design,0.58,0.29,0.1,0.0,0.02,0.0,0.0,0.02,oliver myers,ME-3060,2016
-ME,3060,2,Fund Machine Design,0.23,0.58,0.13,0.0,0.04,0.0,0.0,0.02,paul jeffrey meyer,ME-3060,2016
-ME,3070,1,Found of Mechanical Systems,0.26,0.46,0.16,0.05,0.01,0.0,0.0,0.05,lonny thompson,ME-3070,2016
-ME,3070,2,Found of Mechanical Systems,0.15,0.46,0.26,0.05,0.08,0.0,0.0,0.0,georges fadel,ME-3070,2016
-ME,3080,1,Fluid Mechanics,0.22,0.4,0.32,0.04,0.02,0.0,0.0,0.0,xiangchun xuan,ME-3080,2016
-ME,3080,2,Fluid Mechanics,0.15,0.68,0.15,0.0,0.0,0.0,0.0,0.02,yiqiang han,ME-3080,2016
-ME,3080,3,Fluid Mechanics,0.13,0.25,0.5,0.03,0.08,0.0,0.0,0.0,ethan kung,ME-3080,2016
-ME,3120,2,Manuf Processes,0.69,0.25,0.05,0.0,0.0,0.0,0.0,0.01,rod martinez-duarte,ME-3120,2016
-ME,3330,1,Mechanical Engineering Lab II,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,2,Mechanical Engineering Lab II,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,3,Mechanical Engineering Lab II,0.12,0.71,0.06,0.0,0.0,0.0,0.0,0.12,todd schweisinger,ME-3330,2016
-ME,3330,4,Mechanical Engineering Lab II,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,ME-3330,2016
-ME,3330,5,Mechanical Engineering Lab II,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,6,Mechanical Engineering Lab II,0.14,0.71,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,ME-3330,2016
-ME,3330,7,Mechanical Engineering Lab II,0.44,0.31,0.25,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,8,Mechanical Engineering Lab II,0.3,0.3,0.2,0.0,0.0,0.0,0.0,0.2,todd schweisinger,ME-3330,2016
-ME,4000,1,Senior Seminar,0.83,0.14,0.01,0.01,0.0,0.0,0.0,0.0,donald beasley,ME-4000,2016
-ME,4010,1,Mech Engr Design,0.15,0.63,0.18,0.01,0.03,0.0,0.0,0.0,joshua summers,ME-4010,2016
-ME,4010,2,Mech Engr Design,0.2,0.69,0.05,0.0,0.07,0.0,0.0,0.0,cameron turner,ME-4010,2016
-ME,4020,1,Intern in Engr Des,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,ME-4020,2016
-ME,4020,2,Intern in Engr Des,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,ME-4020,2016
-ME,4020,3,Intern in Engr Des,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-4020,2016
-ME,4020,4,Intern in Engr Des,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4020,2016
-ME,4030,1,Control Dynamic Systems,0.17,0.38,0.4,0.03,0.0,0.0,0.0,0.02,yue wang,ME-4030,2016
-ME,4030,2,Control Dynamic Systems,0.23,0.41,0.22,0.07,0.01,0.0,0.0,0.05,suyi li,ME-4030,2016
-ME,4200,1,Ener Sources/Utiliz,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,donald beasley,ME-4200,2016
-ME,4210,1,Intro to Comp Flow,0.21,0.5,0.14,0.0,0.07,0.0,0.0,0.07,chenning tong,ME-4210,2016
-ME,4320,1,Adv Strength of Matl,0.1,0.39,0.45,0.0,0.03,0.0,0.0,0.03,huijuan zhao,ME-4320,2016
-ME,4400,1,Matls for Aggr Envir,0.88,0.11,0.02,0.0,0.0,0.0,0.0,0.0,ramasw subrahmanian,ME-4400,2016
-ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,3,Mechanical Engineering Lab III,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,4,Mechanical Engineering Lab III,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,5,Mechanical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,6,Mechanical Engineering Lab III,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,7,Mechanical Engineering Lab III,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,8,Mechanical Engineering Lab III,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4540,1,Design of Machine Elements,0.6,0.35,0.03,0.0,0.0,0.0,0.0,0.03,paul jeffrey meyer,ME-4540,2016
-ME,4930,7,Sel.Topics ME - Energy Harvest,0.25,0.4,0.15,0.1,0.0,0.0,0.0,0.1,mohammed fari daqaq,ME-4930,2016
-ME,6210,1,Intro to Comp Flow,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,chenning tong,ME-6210,2016
-ME,6320,1,Adv Strength of Matl,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,huijuan zhao,ME-6320,2016
-ME,6930,13,SelTopics ME-MechSolids&Fluids,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,ME-6930,2016
-ME,8010,1,Found of Fluid Mech,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,richard figliola,ME-8010,2016
-ME,8010,401,Found of Fluid Mech,0.31,0.54,0.0,0.0,0.0,0.0,0.0,0.15,richard figliola,ME-8010,2016
-ME,8100,1,Macroscopic Thermo,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,jay ochterbeck,ME-8100,2016
-ME,8180,1,Intro to Fin Ele Ana,0.27,0.63,0.08,0.0,0.0,0.0,0.0,0.02,gang li,ME-8180,2016
-ME,8230,1,Control Systems,0.37,0.42,0.16,0.0,0.05,0.0,0.0,0.0,yue wang,ME-8230,2016
-ME,8300,1,Cond/Rad Heat Tfr,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,ME-8300,2016
-ME,8460,1,Inter Dynamics,0.4,0.15,0.35,0.0,0.05,0.0,0.0,0.05,phanin tallapragada,ME-8460,2016
-ME,8700,1,Adv Design Methods,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-8700,2016
-ME,8710,1,Engr Optimization,0.61,0.33,0.03,0.0,0.03,0.0,0.0,0.0,georges fadel,ME-8710,2016
-ME,8930,4,SelectedTopics in ME - Adv Mfg,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-8930,2016
-ME,8930,27,Sel Topics in ME - Optimize,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,ME-8930,2016
-MGT,2010,1,Principles of Management,0.39,0.35,0.24,0.02,0.0,0.0,0.0,0.0,katherine clark,MGT-2010,2016
-MGT,2010,2,Principles of Management,0.31,0.47,0.18,0.02,0.01,0.0,0.0,0.0,katherine clark,MGT-2010,2016
-MGT,2010,3,Principles of Management,0.43,0.4,0.11,0.02,0.02,0.0,0.0,0.01,katherine clark,MGT-2010,2016
-MGT,2010,4,Principles of Management,0.2,0.44,0.27,0.05,0.02,0.0,0.0,0.02,katherine clark,MGT-2010,2016
-MGT,2010,5,Principles of Management,0.25,0.37,0.32,0.02,0.01,0.0,0.0,0.02,tina robbins,MGT-2010,2016
-MGT,2010,6,Principles of Management,0.45,0.39,0.11,0.01,0.01,0.0,0.0,0.02,tina robbins,MGT-2010,2016
-MGT,2010,7,Principles of Management,0.57,0.3,0.11,0.0,0.01,0.0,0.0,0.01,tina robbins,MGT-2010,2016
-MGT,2010,8,Principles of Management,0.51,0.37,0.07,0.02,0.0,0.0,0.0,0.02,tina robbins,MGT-2010,2016
-MGT,2010,9,Principles of Mgt(HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,MGT-2010,2016
-MGT,2010,10,Principles of Management,0.26,0.32,0.3,0.06,0.04,0.0,0.0,0.02,ashley will parnell,MGT-2010,2016
-MGT,2010,11,Principles of Management,0.22,0.33,0.33,0.03,0.03,0.0,0.0,0.06,ashley will parnell,MGT-2010,2016
-MGT,2180,1,Management PC Applications,0.83,0.09,0.02,0.02,0.03,0.0,0.0,0.02,ryan toole,MGT-2180,2016
-MGT,2180,2,Management PC Applications,0.8,0.12,0.02,0.01,0.02,0.0,0.0,0.03,ryan toole,MGT-2180,2016
-MGT,2180,3,Management PC Applications,0.77,0.13,0.01,0.05,0.0,0.0,0.0,0.03,ryan toole,MGT-2180,2016
-MGT,2180,4,Management PC Applications,0.76,0.11,0.05,0.01,0.01,0.0,0.0,0.05,ryan toole,MGT-2180,2016
-MGT,3070,1,Human Resource Management,0.23,0.46,0.26,0.03,0.0,0.0,0.0,0.03,priscilla harrison,MGT-3070,2016
-MGT,3070,3,Human Resource Management,0.27,0.38,0.19,0.08,0.0,0.0,0.0,0.08,kristin dam scott,MGT-3070,2016
-MGT,3070,4,Human Resource Management,0.4,0.45,0.08,0.05,0.0,0.0,0.0,0.03,michael cole,MGT-3070,2016
-MGT,3070,5,Human Resource Management,0.58,0.4,0.03,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2016
-MGT,3070,6,Human Resource Management,0.4,0.53,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2016
-MGT,3100,1,Intermed Business Statistics,0.07,0.25,0.11,0.18,0.25,0.0,0.0,0.14,sara elizabet yoder,MGT-3100,2016
-MGT,3100,2,Intermed Business Statistics,0.11,0.19,0.19,0.14,0.22,0.0,0.0,0.16,sara elizabet yoder,MGT-3100,2016
-MGT,3100,3,Intermed Business Statistics,0.1,0.26,0.31,0.1,0.1,0.0,0.0,0.13,sara elizabet yoder,MGT-3100,2016
-MGT,3100,5,Intermed Business Statistics,0.79,0.12,0.06,0.0,0.0,0.0,0.0,0.03,thomas simpson,MGT-3100,2016
-MGT,3100,6,Intermed Business Statistics,0.3,0.33,0.25,0.03,0.05,0.0,0.0,0.05,janis miller,MGT-3100,2016
-MGT,3100,7,Intermed Business Statistics,0.11,0.37,0.21,0.08,0.11,0.0,0.0,0.13,magda gabriela sava,MGT-3100,2016
-MGT,3100,8,Intermed Business Statistics,0.45,0.24,0.12,0.05,0.07,0.0,0.0,0.07,min kyung lee,MGT-3100,2016
-MGT,3100,9,Intermed Business Statistics,0.5,0.25,0.18,0.03,0.03,0.0,0.0,0.03,shih lun tseng,MGT-3100,2016
-MGT,3100,10,Intermed Business Statistics,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,jackie patri london,MGT-3100,2016
-MGT,3100,13,Intermed Business Statistics,0.13,0.3,0.3,0.07,0.03,0.0,0.0,0.17,daniel nielubowicz,MGT-3100,2016
-MGT,3100,14,Intermed Business Statistics,0.32,0.39,0.08,0.11,0.0,0.0,0.0,0.11,iaroslava dutchak,MGT-3100,2016
-MGT,3120,1,Decision Models for Management,0.28,0.17,0.24,0.07,0.15,0.0,0.0,0.09,mark mcknew,MGT-3120,2016
-MGT,3120,2,Decision Models for Management,0.3,0.33,0.28,0.0,0.02,0.0,0.0,0.07,mark mcknew,MGT-3120,2016
-MGT,3120,3,Decision Models for Management,0.27,0.34,0.3,0.02,0.05,0.0,0.0,0.02,mark mcknew,MGT-3120,2016
-MGT,3150,1,New Venture Creation,0.49,0.41,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth er powell,MGT-3150,2016
-MGT,3180,1,Mgt of Info Systems,0.25,0.43,0.28,0.0,0.0,0.0,0.0,0.05,russell purvis,MGT-3180,2016
-MGT,3180,2,Mgt of Info Systems,0.14,0.45,0.38,0.0,0.0,0.0,0.0,0.02,roopa raman,MGT-3180,2016
-MGT,3180,3,Mgt of Info Systems,0.41,0.46,0.1,0.0,0.03,0.0,0.0,0.0,daniel aaron pienta,MGT-3180,2016
-MGT,3180,4,Mgt of Info Systems,0.59,0.3,0.04,0.04,0.0,0.0,0.0,0.02,tina marie esposito,MGT-3180,2016
-MGT,3180,5,Mgt of Info Systems,0.37,0.47,0.05,0.0,0.11,0.0,0.0,0.0,heshan sun,MGT-3180,2016
-MGT,3500,1,Intro to Business Analytics,0.3,0.52,0.11,0.04,0.0,0.0,0.0,0.04,siyuan li,MGT-3500,2016
-MGT,3900,1,Ops Mgt,0.38,0.33,0.2,0.03,0.03,0.0,0.0,0.05,yann ferrand,MGT-3900,2016
-MGT,3900,2,Ops Mgt,0.11,0.44,0.33,0.06,0.0,0.0,0.0,0.06,zachary mo leffakis,MGT-3900,2016
-MGT,3900,3,Ops Mgt,0.08,0.36,0.31,0.08,0.15,0.0,0.0,0.03,berna quiroga gomez,MGT-3900,2016
-MGT,3900,4,Ops Mgt,0.26,0.15,0.36,0.13,0.08,0.0,0.0,0.03,berna quiroga gomez,MGT-3900,2016
-MGT,3900,5,Ops Mgt,0.45,0.32,0.21,0.0,0.0,0.0,0.0,0.03,remi charpin,MGT-3900,2016
-MGT,4000,1,Mgt of Organizational Behavior,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2016
-MGT,4000,2,Mgt of Organizational Behavior,0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2016
-MGT,4000,3,Mgt of Organizational Behavior,0.28,0.53,0.2,0.0,0.0,0.0,0.0,0.0,philip roth,MGT-4000,2016
-MGT,4020,1,Ops Pln and Ctl,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4020,2016
-MGT,4080,1,Lean Operations,0.18,0.39,0.34,0.03,0.03,0.0,0.0,0.03,zachary mo leffakis,MGT-4080,2016
-MGT,4110,1,Project Management,0.22,0.63,0.12,0.0,0.0,0.0,0.0,0.02,russell purvis,MGT-4110,2016
-MGT,4150,1,Business Strategy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,dennis lee lester,MGT-4150,2016
-MGT,4150,2,Business Strategy,0.34,0.64,0.02,0.0,0.0,0.0,0.0,0.0,dane patric blevins,MGT-4150,2016
-MGT,4150,3,Business Strategy,0.51,0.43,0.06,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2016
-MGT,4150,4,Business Strategy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2016
-MGT,4150,6,Business Strategy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dane patric blevins,MGT-4150,2016
-MGT,4150,7,Business Strategy,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2016
-MGT,4150,8,Business Strategy,0.21,0.59,0.21,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2016
-MGT,4150,9,Business Strategy,0.31,0.58,0.09,0.02,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2016
-MGT,4160,1,Special Topics Hr,0.19,0.62,0.08,0.04,0.04,0.0,0.0,0.04,kristin dam scott,MGT-4160,2016
-MGT,4230,1,Intern Bus Mgt,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4230,2016
-MGT,4230,2,Intern Bus Mgt,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4230,2016
-MGT,4230,3,Intern Bus Mgt,0.23,0.4,0.15,0.18,0.05,0.0,0.0,0.0,janis miller,MGT-4230,2016
-MGT,4230,4,Intern Bus Mgt,0.25,0.63,0.1,0.0,0.03,0.0,0.0,0.0,janis miller,MGT-4230,2016
-MGT,4240,1,Global Supply Chain,0.19,0.48,0.29,0.03,0.0,0.0,0.0,0.0,yann ferrand,MGT-4240,2016
-MGT,4270,1,Managing Improvement,0.16,0.53,0.31,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MGT-4270,2016
-MGT,4300,3,Applied Entrepreneurship,0.55,0.3,0.1,0.0,0.0,0.0,0.0,0.05,chad navis,MGT-4300,2016
-MGT,4300,4,Organizational Leadership,0.58,0.26,0.0,0.05,0.05,0.0,0.0,0.05,amy elizabet ingram,MGT-4300,2016
-MGT,4310,1,Emp Rights & Resp,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-4310,2016
-MGT,4350,1,Pers Interviewing,0.38,0.48,0.13,0.0,0.03,0.0,0.0,0.0,philip roth,MGT-4350,2016
-MGT,4520,1,Business Analysis,0.17,0.44,0.33,0.0,0.0,0.0,0.0,0.06,roopa raman,MGT-4520,2016
-MGT,4550,1,Emerging I T Trends,0.59,0.26,0.04,0.0,0.07,0.0,0.0,0.04,jason thatcher,MGT-4550,2016
-MGT,4560,1,Business Info Mgt,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,siyuan li,MGT-4560,2016
-MGT,8690,1,Project Mgt,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,MGT-8690,2016
-MGT,9050,1,Research Methods,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,varun grover,MGT-9050,2016
-MICR,1010,1,Microbes & Hum Aff,0.85,0.11,0.02,0.0,0.0,0.0,0.0,0.02,jessica gale owens,MICR-1010,2016
-MICR,2050,1,Introductory Micro,0.53,0.35,0.07,0.01,0.0,0.0,0.0,0.04,john abercrombie,MICR-2050,2016
-MICR,3000,1,Essential Skills in Microbiol,0.82,0.13,0.02,0.0,0.02,0.0,0.0,0.02,tamara lyn mcnealy,MICR-3000,2016
-MICR,3050,1,General Microbiology,0.44,0.39,0.15,0.01,0.01,0.0,0.0,0.01,krista barr rudolph,MICR-3050,2016
-MICR,3050,2,General Microbiology,0.41,0.41,0.1,0.05,0.03,0.0,0.0,0.0,krista barr rudolph,MICR-3050,2016
-MICR,4010,1,Microbial Diversity & Ecology,0.19,0.49,0.18,0.06,0.03,0.0,0.0,0.04,barbara campbell,MICR-4010,2016
-MICR,4050,1,Adv Microbial Ecol of Humans,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4050,2016
-MICR,4140,1,Basic Immunology,0.52,0.15,0.21,0.0,0.06,0.0,0.0,0.06,yanzhang wei,MICR-4140,2016
-MICR,4150,1,Microbial Genetics,0.15,0.56,0.21,0.06,0.0,0.0,0.0,0.02,min cao,MICR-4150,2016
-MICR,4160,1,Intro Virology,0.96,0.01,0.03,0.0,0.0,0.0,0.0,0.0,simon scott,MICR-4160,2016
-MICR,4510,1,Advanced Microbiology II,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,thomas hughes,MICR-4510,2016
-MICR,4510,3,Advanced Microbiology II,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,thomas hughes,MICR-4510,2016
-MKT,3010,1,Prin of Marketing,0.25,0.35,0.31,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,MKT-3010,2016
-MKT,3010,2,Prin of Marketing,0.3,0.46,0.19,0.02,0.01,0.0,0.0,0.03,carter wil mcelveen,MKT-3010,2016
-MKT,3010,3,Prin of Marketing,0.25,0.43,0.25,0.06,0.01,0.0,0.0,0.0,amanda cooper fine,MKT-3010,2016
-MKT,3010,4,Prin of Marketing,0.25,0.42,0.26,0.05,0.02,0.0,0.0,0.0,amanda cooper fine,MKT-3010,2016
-MKT,3010,5,Prin of Marketing,0.31,0.39,0.2,0.04,0.02,0.0,0.0,0.03,amanda cooper fine,MKT-3010,2016
-MKT,3010,6,Prin of Marketing,0.58,0.3,0.08,0.02,0.0,0.0,0.0,0.02,patricia knowles,MKT-3010,2016
-MKT,3020,1,Consumer Behavior,0.5,0.4,0.06,0.04,0.0,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2016
-MKT,3020,2,Consumer Behavior,0.42,0.4,0.1,0.06,0.02,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2016
-MKT,3020,3,Consumer Behavior,0.32,0.34,0.14,0.1,0.08,0.0,0.0,0.02, thyroff fitzwater,MKT-3020,2016
-MKT,3020,4,Consumer Behavior,0.28,0.58,0.04,0.02,0.04,0.0,0.0,0.04, thyroff fitzwater,MKT-3020,2016
-MKT,3020,5,Consumer Behavior,0.4,0.27,0.18,0.11,0.04,0.0,0.0,0.0,oriana rache aragon,MKT-3020,2016
-MKT,3210,1,Sports Marketing,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2016
-MKT,3210,2,Sports Marketing,0.57,0.41,0.0,0.0,0.0,0.0,0.0,0.02,delancy bennett,MKT-3210,2016
-MKT,3310,1,Marketing Metrics & Analytics,0.74,0.17,0.07,0.0,0.02,0.0,0.0,0.0,oriana rache aragon,MKT-3310,2016
-MKT,4200,1,Professional Selling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,MKT-4200,2016
-MKT,4200,2,Professional Selling,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2016
-MKT,4200,3,Professional Selling,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,jesse moore,MKT-4200,2016
-MKT,4200,4,Professional Selling,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2016
-MKT,4200,5,Professional Selling,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,ryan mullins,MKT-4200,2016
-MKT,4230,1,Promotional Strategy,0.42,0.39,0.12,0.02,0.02,0.0,0.0,0.03,patricia knowles,MKT-4230,2016
-MKT,4240,1,Sales Management,0.5,0.48,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4240,2016
-MKT,4260,1,Business-to-Business,0.38,0.43,0.17,0.02,0.0,0.0,0.0,0.0,james gaubert,MKT-4260,2016
-MKT,4260,2,Business-to-Business,0.47,0.41,0.07,0.0,0.02,0.0,0.0,0.03,james gaubert,MKT-4260,2016
-MKT,4270,1,International Mktg,0.37,0.38,0.19,0.03,0.02,0.0,0.0,0.0,roger gomes,MKT-4270,2016
-MKT,4270,2,International Mktg,0.24,0.42,0.29,0.02,0.0,0.0,0.0,0.02,roger gomes,MKT-4270,2016
-MKT,4270,3,International Mktg,0.39,0.49,0.05,0.05,0.0,0.0,0.0,0.02,thomas poehlman,MKT-4270,2016
-MKT,4280,1,Services Marketing,0.4,0.51,0.06,0.0,0.0,0.0,0.0,0.03,james gaubert,MKT-4280,2016
-MKT,4310,1,Marketing Research,0.17,0.31,0.38,0.1,0.03,0.0,0.0,0.0,peter weathers,MKT-4310,2016
-MKT,4310,2,Marketing Research,0.29,0.54,0.04,0.11,0.04,0.0,0.0,0.0,peter weathers,MKT-4310,2016
-MKT,4310,3,Marketing Research,0.33,0.63,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2016
-MKT,4310,4,Marketing Research,0.48,0.44,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2016
-MKT,4430,1,Advertising Strategy,0.75,0.23,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,MKT-4430,2016
-MKT,4450,1,Macromarketing,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,william kilbourne,MKT-4450,2016
-MKT,4450,2,Macromarketing,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,william kilbourne,MKT-4450,2016
-MKT,4500,1,Strategic Mktg Mgt,0.23,0.55,0.19,0.03,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2016
-MKT,4500,2,Strategic Mktg Mgt,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4500,2016
-MKT,4950,1,Social Media,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-4950,2016
-MKT,8610,1,Marketing Research,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-8610,2016
-MKT,8630,1,Buyer Behavior,0.36,0.61,0.0,0.0,0.0,0.0,0.0,0.04,thomas poehlman,MKT-8630,2016
-ML,1010,3,Leadership Fund I,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,amanda carol kane,ML-1010,2016
-ML,2010,1,Leadership Development I,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,shane allen werst,ML-2010,2016
-ML,2010,2,Leadership Development I,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,shane allen werst,ML-2010,2016
-ML,3010,1,Advanced Leadership I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william cod cleland,ML-3010,2016
-ML,3010,2,Advanced Leadership I,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,william cod cleland,ML-3010,2016
-ML,4010,1,Organizational Leadership I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,ML-4010,2016
-MSE,2100,1,Intro to Mat Science,0.36,0.23,0.23,0.07,0.08,0.0,0.0,0.04,rakhee pani,MSE-2100,2016
-MSE,2100,2,Intro to Mat Science,0.12,0.53,0.2,0.07,0.04,0.0,0.0,0.04,eric skaar,MSE-2100,2016
-MSE,2100,3,Intro to Mat Science,0.23,0.42,0.2,0.05,0.02,0.0,0.0,0.07,eric skaar,MSE-2100,2016
-MSE,2100,4,Intro to Mat Science,0.31,0.3,0.21,0.12,0.01,0.0,0.0,0.05,bradley mat schultz,MSE-2100,2016
-MSE,2100,5,Intro to Mat Science,0.54,0.29,0.11,0.07,0.0,0.0,0.0,0.0,olga kuksenok,MSE-2100,2016
-MSE,3190,1,Materials Proc I,0.32,0.35,0.23,0.03,0.06,0.0,0.0,0.0,olin mefford,MSE-3190,2016
-MSE,3190,2,Materials Proc I,0.62,0.32,0.04,0.0,0.0,0.0,0.0,0.02,olin mefford,MSE-3190,2016
-MSE,3260,1,Thermo of Materials,0.31,0.53,0.14,0.0,0.0,0.0,0.0,0.03,gary lickfield,MSE-3260,2016
-MSE,3260,2,Thermo of Materials,0.21,0.26,0.29,0.15,0.09,0.0,0.0,0.0,gary lickfield,MSE-3260,2016
-MSE,3270,1,Transport Phenomena,0.52,0.36,0.05,0.02,0.01,0.0,0.0,0.04,fei peng,MSE-3270,2016
-MSE,3270,2,Transport Phenomena,0.3,0.28,0.3,0.03,0.06,0.0,0.0,0.03,ulf daniel schiller,MSE-3270,2016
-MSE,4020,1,Solid State Material,0.43,0.26,0.21,0.04,0.04,0.0,0.0,0.02,luiz gust jacobsohn,MSE-4020,2016
-MSE,4070,1,Senior Capstone Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,MSE-4070,2016
-MSE,4130,1,Noncrystalline Materials,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,MSE-4130,2016
-MSE,4150,1,Polymer Sc Engr,0.37,0.28,0.15,0.03,0.03,0.0,0.0,0.13,marek urban,MSE-4150,2016
-MSE,4150,2,Polymer Sc Engr,0.55,0.27,0.11,0.0,0.04,0.0,0.0,0.04,olin mefford,MSE-4150,2016
-MSE,4550,2,Polymer Fiber Lab,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,olin mefford,MSE-4550,2016
-MSE,4550,3,Polymer Fiber Lab,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,olin mefford,MSE-4550,2016
-MSE,4580,1,Surf Phen in Ms&E,0.09,0.52,0.27,0.12,0.0,0.0,0.0,0.0,konstantin kornev,MSE-4580,2016
-MSE,4610,1,Polymer & Fiber Materials III,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,MSE-4610,2016
-MSE,4910,1,Undergraduate Research,0.65,0.26,0.03,0.0,0.03,0.0,0.0,0.03,marian kennedy,MSE-4910,2016
-MSE,8010,1,Grad Sem in Materials Research,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,kyle brinkman,MSE-8010,2016
-MSE,8100,1,Fundamentals of Materials Sci,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,rajendra kum bordia,MSE-8100,2016
-MSE,8260,1,Phase Equil Mat Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,stephen foulger,MSE-8260,2016
-MSE,8270,1,Kin of Phase Tran,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,konstantin kornev,MSE-8270,2016
-MUSC,1510,2,Applied Music,0.5,0.3,0.1,0.0,0.0,0.0,0.0,0.1,jonathan edwa doyel,MUSC-1510,2016
-MUSC,1520,1,Applied Music,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,MUSC-1520,2016
-MUSC,2100,1,Music in the Western World,0.78,0.13,0.06,0.0,0.03,0.0,0.0,0.0,eric lapin,MUSC-2100,2016
-MUSC,2100,2,Music in the Western World,0.53,0.19,0.16,0.03,0.0,0.0,0.0,0.09,lisa sain odom,MUSC-2100,2016
-MUSC,2100,3,Music in the Western World,0.88,0.06,0.03,0.03,0.0,0.0,0.0,0.0,eric lapin,MUSC-2100,2016
-MUSC,2100,4,Music in the Western World,0.47,0.16,0.09,0.19,0.06,0.0,0.0,0.03,linda li-bleuel,MUSC-2100,2016
-MUSC,2100,5,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,MUSC-2100,2016
-MUSC,2100,6,Music in the Western World,0.72,0.19,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,MUSC-2100,2016
-MUSC,2100,7,Music in the Western World,0.41,0.53,0.03,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,MUSC-2100,2016
-MUSC,2100,8,Music in the Western World,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2016
-MUSC,2100,10,Music in the Western World,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda dzuris,MUSC-2100,2016
-MUSC,2100,12,Music in the Western World,0.5,0.28,0.13,0.06,0.0,0.0,0.0,0.03,lea kibler,MUSC-2100,2016
-MUSC,2100,15,Music in West World (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,MUSC-2100,2016
-MUSC,3080,1,Surv of Broadway I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,lisa sain odom,MUSC-3080,2016
-MUSC,3110,1,History of American Music,0.59,0.25,0.09,0.06,0.0,0.0,0.0,0.0,ned hosler,MUSC-3110,2016
-MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,eric lapin,MUSC-3120,2016
-MUSC,3130,1,Hist of Rock & Roll,0.41,0.38,0.09,0.13,0.0,0.0,0.0,0.0,hamilton altstatt,MUSC-3130,2016
-MUSC,3170,1,Hist of Country Mus,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3170,2016
-MUSC,3610,1,Marching Band,0.97,0.01,0.0,0.0,0.0,0.0,0.0,0.02,mark spede,MUSC-3610,2016
-MUSC,3620,1,Symphonic Band,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,mark spede,MUSC-3620,2016
-MUSC,3690,1,Symphony Orchestra,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,andrew levin,MUSC-3690,2016
-MUSC,3700,1,Clemson University Singers,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,justin durham,MUSC-3700,2016
-MUSC,3710,1,Women's Chorus,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,justin durham,MUSC-3710,2016
-MUSC,4150,1,Music Hist to 1750,0.17,0.22,0.22,0.11,0.06,0.0,0.0,0.22,justin durham,MUSC-4150,2016
-NPL,3000,1,Nonprofit Leadership,0.45,0.39,0.03,0.1,0.03,0.0,0.0,0.0,bonnie west stevens,NPL-3000,2016
-NPL,3000,3,Nonprofit Leadership,0.59,0.24,0.14,0.0,0.03,0.0,0.0,0.0,james dougl bennett,NPL-3000,2016
-NPL,3000,4,Nonprofit Leadership,0.87,0.1,0.0,0.03,0.0,0.0,0.0,0.0,christina mar mazer,NPL-3000,2016
-NPL,3000,5,Nonprofit Leadership,0.52,0.24,0.1,0.0,0.05,0.0,0.0,0.1,christina mar mazer,NPL-3000,2016
-NPL,3000,6,Nonprofit Leadership,0.76,0.1,0.05,0.05,0.05,0.0,0.0,0.0,christina mar mazer,NPL-3000,2016
-NPL,3020,1,NPL Fundraising,0.57,0.33,0.05,0.0,0.05,0.0,0.0,0.0,robert frager,NPL-3020,2016
-NPL,3040,1,NPL Risk Management,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,anthony shau catone,NPL-3040,2016
-NURS,3030,1,Nursing of Adults,0.2,0.75,0.05,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2016
-NURS,3040,1,Pathophysiology,0.39,0.43,0.11,0.07,0.0,0.0,0.0,0.0,catherine si murton,NURS-3040,2016
-NURS,3040,400,Pathophysiology,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,NURS-3040,2016
-NURS,3040,401,Pathophysiology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,NURS-3040,2016
-NURS,3100,1,Health Assessment,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,NURS-3100,2016
-NURS,3100,400,Health Assessment,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,NURS-3100,2016
-NURS,3120,1,Foundations of Nursing,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,angela pye,NURS-3120,2016
-NURS,3120,400,Foundations of Nursing,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,NURS-3120,2016
-NURS,3300,1,Research in Nursing,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,veronica parker,NURS-3300,2016
-NURS,3330,400,Health Care Genetics,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,mary steck,NURS-3330,2016
-NURS,3400,1,Pharmther Nursing,0.32,0.52,0.11,0.02,0.04,0.0,0.0,0.0,catherine si murton,NURS-3400,2016
-NURS,3400,400,Pharmther Nursing,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,jenna lyn seawright,NURS-3400,2016
-NURS,4030,200,Complex Nursing of Adults,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,NURS-4030,2016
-NURS,4030,400,Complex Nursing of Adults,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,NURS-4030,2016
-NURS,4110,1,Nursing of Children,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,NURS-4110,2016
-NURS,4120,1,Nurs Women and Fam,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2016
-NURS,4150,1,Community Health Nursing,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jackie gillespie,NURS-4150,2016
-NURS,4250,200,Community Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,NURS-4250,2016
-NURS,8050,400,Pharmaco Adv Nurs,0.77,0.21,0.0,0.0,0.0,0.0,0.0,0.03,tracy king fasolino,NURS-8050,2016
-NURS,8050,401,Pharmaco Adv Nurs,0.67,0.29,0.0,0.0,0.04,0.0,0.0,0.0,tracy king fasolino,NURS-8050,2016
-NURS,8060,400,Advan Assessment for Nursing,0.43,0.52,0.0,0.0,0.05,0.0,0.0,0.0,rosanne pruitt,NURS-8060,2016
-NURS,8090,400,Pathophysiology,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,NURS-8090,2016
-NURS,8180,400,Develop Family in Primary Care,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,NURS-8180,2016
-NURS,8190,400,Developing Family,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,NURS-8190,2016
-NURS,8200,400,Child & Adol Nursing,0.56,0.38,0.0,0.0,0.06,0.0,0.0,0.0,heide temples,NURS-8200,2016
-NURS,8220,400,Gerontology Nursing,0.93,0.0,0.0,0.0,0.08,0.0,0.0,0.0,nicole joy davis,NURS-8220,2016
-NURS,8280,400,The Nurse Educator,0.82,0.05,0.0,0.0,0.05,0.0,0.0,0.09,roxanne amerson,NURS-8280,2016
-NUTR,2030,1,Intro Princ of Human Nutrition,0.5,0.32,0.12,0.04,0.01,0.0,0.0,0.03,deborah an hutcheon,NUTR-2030,2016
-NUTR,2030,2,Intro Princ of Human Nutrition,0.76,0.16,0.03,0.0,0.01,0.0,0.0,0.03,deborah an hutcheon,NUTR-2030,2016
-NUTR,2050,1,Nutrition for Nursing Prof,0.82,0.17,0.01,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,NUTR-2050,2016
-NUTR,2160,1,Evidence-Based Nutrition,0.78,0.15,0.04,0.02,0.0,0.0,0.0,0.0,angela fraser,NUTR-2160,2016
-NUTR,4240,1,Medical Nutr Thera I,0.32,0.54,0.14,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4240,2016
-NUTR,4510,1,Human Nutrition & Metabolism I,0.27,0.38,0.16,0.11,0.05,0.0,0.0,0.03,elliot jesch,NUTR-4510,2016
-PA,1010,1,Intro to Perf Arts,0.57,0.2,0.2,0.03,0.0,0.0,0.0,0.0,david hartmann,PA-1010,2016
-PA,1030,1,Portfolio I,0.71,0.26,0.0,0.03,0.0,0.0,0.0,0.0,linda dzuris,PA-1030,2016
-PA,2010,2,Career Planning and Prof Devel,0.8,0.1,0.0,0.1,0.0,0.0,0.0,0.0,shannon ther robert,PA-2010,2016
-PA,2790,1,Perf Arts Pract I,0.54,0.23,0.12,0.0,0.08,0.0,0.0,0.04,kenneth moore,PA-2790,2016
-PA,2800,1,Perf Arts Pract II,0.47,0.27,0.07,0.0,0.07,0.0,0.0,0.13,kenneth moore,PA-2800,2016
-PA,3010,1,Princip of Arts Administration,0.5,0.33,0.08,0.08,0.0,0.0,0.0,0.0,paul buyer,PA-3010,2016
-PADM,7020,401,Research Methods,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,PADM-7020,2016
-PADM,8210,400,Perspectives on Public Admin,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,PADM-8210,2016
-PADM,8220,400,Public Policy Process,0.73,0.13,0.0,0.0,0.13,0.0,0.0,0.0,ek yazykova mellott,PADM-8220,2016
-PADM,8270,400,Public Personnel Admin,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,lawrence nichols,PADM-8270,2016
-PADM,8290,400,Public Financial Management,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,robert frager,PADM-8290,2016
-PADM,8340,400,Administrative Law,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,andrew moorman,PADM-8340,2016
-PADM,8670,400,State Government Admin,0.31,0.54,0.08,0.0,0.08,0.0,0.0,0.0,alfred bundrick,PADM-8670,2016
-PAS,3010,1,Pan African Studies,0.36,0.36,0.16,0.04,0.03,0.0,0.0,0.05,abel bartley,PAS-3010,2016
-PDBE,8150,1,Research Design in EDP,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mickey lauria,PDBE-8150,2016
-PES,1040,1,Introduction to Plant Sciences,0.64,0.33,0.0,0.0,0.0,0.0,0.0,0.03,paula agudelo,PES-1040,2016
-PES,2020,1,Soils,0.01,0.41,0.39,0.11,0.01,0.0,0.0,0.07,dara michelle park,PES-2020,2016
-PES,4090,1,Biology of Invasive Plants,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,tharayil-santhakumar,PES-4090,2016
-PHIL,1010,1,Intro to Philosophic Problems,0.27,0.69,0.0,0.0,0.04,0.0,0.0,0.0,kelly smith,PHIL-1010,2016
-PHIL,1010,3,Intro to Philosophic Problems,0.5,0.31,0.16,0.03,0.0,0.0,0.0,0.0,christopher grau,PHIL-1010,2016
-PHIL,1010,4,Intro to Philosophic Problems,0.61,0.12,0.09,0.0,0.06,0.0,0.0,0.12,david stegall,PHIL-1010,2016
-PHIL,1010,6,Intro to Philosophic Problems,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david stegall,PHIL-1010,2016
-PHIL,1020,1,Introduction to Logic,0.59,0.19,0.09,0.09,0.03,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2016
-PHIL,1020,2,Introduction to Logic,0.76,0.18,0.03,0.03,0.0,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2016
-PHIL,1020,3,Introduction to Logic,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,PHIL-1020,2016
-PHIL,1020,4,Introduction to Logic,0.8,0.09,0.09,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,PHIL-1020,2016
-PHIL,1020,5,Introduction to Logic,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,PHIL-1020,2016
-PHIL,1020,6,Introduction to Logic,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,michael hal hannen,PHIL-1020,2016
-PHIL,1020,7,Introduction to Logic,0.63,0.29,0.06,0.0,0.03,0.0,0.0,0.0,john randall wolfe,PHIL-1020,2016
-PHIL,1020,8,Introduction to Logic,0.82,0.12,0.03,0.03,0.0,0.0,0.0,0.0,john randall wolfe,PHIL-1020,2016
-PHIL,1020,9,Introduction to Logic,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,john randall wolfe,PHIL-1020,2016
-PHIL,1030,2,Introduction to Ethics,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,william maker,PHIL-1030,2016
-PHIL,1030,3,Introduction to Ethics,0.27,0.43,0.27,0.03,0.0,0.0,0.0,0.0,john jung park,PHIL-1030,2016
-PHIL,1030,4,Introduction to Ethics,0.36,0.43,0.18,0.04,0.0,0.0,0.0,0.0,john jung park,PHIL-1030,2016
-PHIL,1030,5,Introduction to Ethics,0.66,0.25,0.06,0.0,0.03,0.0,0.0,0.0,adam gies,PHIL-1030,2016
-PHIL,1030,7,Introduction to Ethics,0.76,0.15,0.09,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-1030,2016
-PHIL,1030,8,Introduction to Ethics,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-1030,2016
-PHIL,1030,10,Introduction to Ethics,0.18,0.59,0.18,0.06,0.0,0.0,0.0,0.0,john jung park,PHIL-1030,2016
-PHIL,1030,12,Introduction to Ethics,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,john jung park,PHIL-1030,2016
-PHIL,1030,13,Introduction to Ethics,0.35,0.48,0.1,0.0,0.06,0.0,0.0,0.0,daniel wueste,PHIL-1030,2016
-PHIL,3150,1,Ancient Philosophy,0.24,0.27,0.21,0.03,0.15,0.0,0.0,0.09,stephen satris,PHIL-3150,2016
-PHIL,3160,1,Modern Philosophy,0.52,0.33,0.09,0.0,0.03,0.0,0.0,0.03,michael hal hannen,PHIL-3160,2016
-PHIL,3200,1,Soc and Pol Phil,0.53,0.12,0.18,0.0,0.06,0.0,0.0,0.12,john randall wolfe,PHIL-3200,2016
-PHIL,3240,1,Philosophy of Tech,0.44,0.31,0.16,0.09,0.0,0.0,0.0,0.0,william maker,PHIL-3240,2016
-PHIL,3260,1,Science and Values,0.53,0.31,0.06,0.0,0.06,0.0,0.0,0.03,andrew garnar,PHIL-3260,2016
-PHIL,3260,2,Science and Values,0.5,0.35,0.09,0.0,0.03,0.0,0.0,0.03,andrew garnar,PHIL-3260,2016
-PHIL,3330,1,Metaphysics,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,david stegall,PHIL-3330,2016
-PHIL,3440,1,Business Ethics,0.77,0.2,0.0,0.0,0.03,0.0,0.0,0.0,david stegall,PHIL-3440,2016
-PHIL,3450,1,Environmental Ethics,0.48,0.36,0.09,0.0,0.0,0.0,0.0,0.06,jennifer ingle,PHIL-3450,2016
-PHIL,3450,2,Environmental Ethics,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,jennifer ingle,PHIL-3450,2016
-PHIL,3460,1,Medical Ethics,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04,charles starkey,PHIL-3460,2016
-PHIL,3480,1,Philosophies of Art,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,christopher grau,PHIL-3480,2016
-PHIL,3490,1,Gender and Sexuality,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,jennifer ingle,PHIL-3490,2016
-PHIL,4920,1,Creative Inquiry in Philosophy,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,stephen satris,PHIL-4920,2016
-PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.84,0.11,0.03,0.02,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1180,2016
-PHYS,1220,1,Physics with Calculus I,0.26,0.3,0.26,0.12,0.06,0.0,0.0,0.02,pooja puneet,PHYS-1220,2016
-PHYS,1220,2,Physics with Calculus I,0.34,0.28,0.21,0.07,0.06,0.0,0.0,0.04,pooja puneet,PHYS-1220,2016
-PHYS,1220,3,Physics W/Cal I (HON),0.57,0.35,0.04,0.04,0.0,0.0,0.0,0.0,hugo sanabria,PHYS-1220,2016
-PHYS,1220,4,Physics with Calculus I,0.31,0.38,0.31,0.0,0.0,0.0,0.0,0.0,murray daw,PHYS-1220,2016
-PHYS,1220,500,Physics with Calculus I,0.31,0.5,0.19,0.0,0.0,0.0,0.0,0.0,elaine parshall,PHYS-1220,2016
-PHYS,1240,1,Physics Lab I,0.06,0.67,0.11,0.06,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2016
-PHYS,1240,2,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,3,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,4,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,5,Physics Lab I,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2016
-PHYS,1240,6,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,7,Physics Lab I,0.11,0.67,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2016
-PHYS,1240,8,Physics Lab I,0.39,0.56,0.0,0.06,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,9,Physics Lab I,0.56,0.28,0.06,0.0,0.11,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,10,Physics Lab I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,11,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,14,Physics Lab I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,15,Physics Lab I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,16,Physics Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,17,Physics Lab I,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,18,Physics Lab I,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,19,Physics Lab I,0.22,0.61,0.06,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2016
-PHYS,1240,500,Physics Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,elaine parshall,PHYS-1240,2016
-PHYS,2070,1,General Physics I,0.32,0.28,0.19,0.08,0.07,0.0,0.0,0.05,amy liann pope,PHYS-2070,2016
-PHYS,2070,2,General Physics I,0.4,0.44,0.09,0.04,0.01,0.0,0.0,0.02,amy liann pope,PHYS-2070,2016
-PHYS,2070,3,General Physics I,0.43,0.32,0.16,0.05,0.01,0.0,0.0,0.02,amy liann pope,PHYS-2070,2016
-PHYS,2080,1,General Physics II,0.33,0.39,0.18,0.03,0.05,0.0,0.0,0.02,lih-sin the,PHYS-2080,2016
-PHYS,2090,1,Gen Phys Lab I,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,2,Gen Phys Lab I,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,3,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,4,Gen Phys Lab I,0.29,0.63,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,5,Gen Phys Lab I,0.33,0.63,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,6,Gen Phys Lab I,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,7,Gen Phys Lab I,0.33,0.54,0.04,0.0,0.04,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,8,Gen Phys Lab I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,9,Gen Phys Lab I,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,10,Gen Phys Lab I,0.27,0.41,0.14,0.05,0.0,0.0,0.0,0.14,jerry hester,PHYS-2090,2016
-PHYS,2090,11,Gen Phys Lab I,0.38,0.48,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,12,Gen Phys Lab I,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,13,Gen Phys Lab I,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,14,Gen Phys Lab I,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,15,Gen Phys Lab I,0.17,0.63,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,16,Gen Phys Lab I,0.68,0.23,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2016
-PHYS,2090,17,Gen Phys Lab I,0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,18,Gen Phys Lab I,0.67,0.25,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,19,Gen Phys Lab I,0.33,0.58,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,20,Gen Phys Lab I,0.19,0.52,0.24,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2016
-PHYS,2090,21,Gen Phys Lab I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,22,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,23,Gen Phys Lab I,0.33,0.43,0.19,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2016
-PHYS,2090,24,Gen Phys Lab I,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2100,1,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,2,Gen Phys Lab II,0.43,0.21,0.21,0.07,0.0,0.0,0.0,0.07,jerry hester,PHYS-2100,2016
-PHYS,2100,4,Gen Phys Lab II,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,6,Gen Phys Lab II,0.52,0.3,0.09,0.04,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2016
-PHYS,2100,7,Gen Phys Lab II,0.65,0.13,0.13,0.0,0.04,0.0,0.0,0.04,jerry hester,PHYS-2100,2016
-PHYS,2100,8,Gen Phys Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2210,1,Physics with Calculus II,0.13,0.44,0.28,0.1,0.03,0.0,0.0,0.02,jason stratfo brown,PHYS-2210,2016
-PHYS,2210,2,Physics with Calculus II,0.24,0.49,0.19,0.04,0.02,0.0,0.0,0.03,jason stratfo brown,PHYS-2210,2016
-PHYS,2210,3,Physics with Calculus II,0.34,0.53,0.11,0.01,0.01,0.0,0.0,0.0,jason stratfo brown,PHYS-2210,2016
-PHYS,2210,4,Physics with Calculus II,0.18,0.56,0.18,0.04,0.03,0.0,0.0,0.01,pooja puneet,PHYS-2210,2016
-PHYS,2210,7,Physics With Cal II (HON),0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,endre andras takacs,PHYS-2210,2016
-PHYS,2220,1,Physics with Calculus III,0.32,0.35,0.16,0.0,0.03,0.0,0.0,0.13,jian he,PHYS-2220,2016
-PHYS,2230,1,Physics Lab II,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,2,Physics Lab II,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,3,Physics Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,4,Physics Lab II,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-2230,2016
-PHYS,2230,5,Physics Lab II,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2016
-PHYS,2230,6,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,7,Physics Lab II,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,jerry hester,PHYS-2230,2016
-PHYS,2230,9,Physics Lab II,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,10,Physics Lab II,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2016
-PHYS,2230,11,Physics Lab II,0.11,0.89,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,12,Physics Lab II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,13,Physics Lab II,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-2230,2016
-PHYS,2230,17,Physics Lab II,0.07,0.43,0.29,0.0,0.07,0.0,0.0,0.14,jerry hester,PHYS-2230,2016
-PHYS,2450,1,Physics of Climate,0.44,0.26,0.09,0.04,0.04,0.0,0.0,0.14,gerald lehmacher,PHYS-2450,2016
-PHYS,3000,1,Intro to Research,0.76,0.12,0.08,0.0,0.04,0.0,0.0,0.0,hugo sanabria,PHYS-3000,2016
-PHYS,3120,1,Meth Theor Phys II,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,feng ding,PHYS-3120,2016
-PHYS,3150,1,Intro to Computational Physics,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,emil georgie alexov,PHYS-3150,2016
-PHYS,3210,1,Mechanics I,0.16,0.26,0.26,0.16,0.05,0.0,0.0,0.11,joshua alper,PHYS-3210,2016
-PHYS,3250,1,Exper Physics I,0.42,0.47,0.05,0.0,0.0,0.0,0.0,0.05,chad sosolik,PHYS-3250,2016
-PHYS,4410,1,Electromagnetics I,0.27,0.18,0.27,0.18,0.0,0.0,0.0,0.09,joan marler,PHYS-4410,2016
-PHYS,4550,1,Quantum Physics I,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,ramakrishna podila,PHYS-4550,2016
-PHYS,8110,1,Meth of Theor Phys I,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,bradley meyer,PHYS-8110,2016
-PHYS,8210,1,Classical Mech I,0.18,0.55,0.27,0.0,0.0,0.0,0.0,0.0,jens oberheide,PHYS-8210,2016
-PHYS,9510,1,Quantum Mech I,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,domnita marinescu,PHYS-9510,2016
-PKSC,1010,1,Pkgsc Orientation,0.79,0.11,0.08,0.0,0.02,0.0,0.0,0.0,robert truett moore,PKSC-1010,2016
-PKSC,1020,1,Intro to Pkg Sci,0.1,0.33,0.32,0.11,0.09,0.0,0.0,0.04,heather batt,PKSC-1020,2016
-PKSC,2020,1,Packaging Mtl & Mfg,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2020,2016
-PKSC,2200,1,Product & Pkg Design,0.85,0.06,0.02,0.0,0.04,0.0,0.0,0.02,william aaro snyder,PKSC-2200,2016
-PKSC,3200,1,Pkg Design Theory,0.39,0.26,0.3,0.0,0.04,0.0,0.0,0.0,rupert hurley,PKSC-3200,2016
-PKSC,4010,1,Packaging Machinery,0.31,0.41,0.2,0.07,0.01,0.0,0.0,0.0,anthony lou pometto,PKSC-4010,2016
-PKSC,4030,1,Pkg Career Prep,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2016
-PKSC,4040,1,Protective Packaging Prop/Prin,0.28,0.27,0.24,0.1,0.07,0.0,0.0,0.03,gregory batt,PKSC-4040,2016
-PKSC,4160,1,Appl Polymers in Pkg,0.16,0.52,0.23,0.06,0.03,0.0,0.0,0.0,duncan darby,PKSC-4160,2016
-PKSC,4200,1,Pkg Design & Dev,0.54,0.39,0.04,0.0,0.04,0.0,0.0,0.0,robert kimmel,PKSC-4200,2016
-PKSC,4230,400,3D Parametric Design Online,0.77,0.0,0.0,0.0,0.15,0.0,0.0,0.08,rupert hurley,PKSC-4230,2016
-PKSC,4540,1,Prod Pkg Evl Lab,0.38,0.19,0.19,0.13,0.06,0.0,0.0,0.06,gregory batt,PKSC-4540,2016
-PKSC,4540,2,Prod Pkg Evl Lab,0.13,0.25,0.13,0.06,0.38,0.0,0.0,0.06,gregory batt,PKSC-4540,2016
-PKSC,4540,3,Prod Pkg Evl Lab,0.56,0.19,0.06,0.0,0.19,0.0,0.0,0.0,gregory batt,PKSC-4540,2016
-PKSC,4540,4,Prod Pkg Evl Lab,0.25,0.31,0.25,0.0,0.19,0.0,0.0,0.0,gregory batt,PKSC-4540,2016
-PKSC,4640,1,Food & Health Care Pkg Systems,0.53,0.28,0.06,0.0,0.14,0.0,0.0,0.0,kay cooksey,PKSC-4640,2016
-PKSC,6230,400,3D Parametic Design Online,0.67,0.0,0.17,0.0,0.0,0.0,0.0,0.17,rupert hurley,PKSC-6230,2016
-PLPA,3100,1,Principles of Plant Pathology,0.12,0.48,0.4,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,PLPA-3100,2016
-PLPA,8020,1,Ppls of Plant Pathology,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,PLPA-8020,2016
-POSC,1010,1,Amer National Govt,0.08,0.39,0.3,0.1,0.05,0.0,0.0,0.08,joseph earl stewart,POSC-1010,2016
-POSC,1010,2,Amer National Govt,0.24,0.36,0.17,0.1,0.08,0.0,0.0,0.06,jeffrey scott peake,POSC-1010,2016
-POSC,1020,1,Intro Intl Relations,0.33,0.43,0.13,0.06,0.02,0.0,0.0,0.04,tara elizabet trask,POSC-1020,2016
-POSC,1020,2,Intro Intl Relations,0.22,0.26,0.3,0.09,0.05,0.0,0.0,0.08,zeynep taydas,POSC-1020,2016
-POSC,1020,3,Intro Intl Relations,0.16,0.29,0.35,0.11,0.04,0.0,0.0,0.05,zeynep taydas,POSC-1020,2016
-POSC,1020,4,Intro Intl Relations,0.16,0.29,0.36,0.12,0.03,0.0,0.0,0.03,joshua douglas king,POSC-1020,2016
-POSC,1020,5,Intro Intl Relations,0.09,0.47,0.19,0.06,0.09,0.0,0.0,0.09,joshua douglas king,POSC-1020,2016
-POSC,1030,1,Intro to Political Theory,0.05,0.26,0.21,0.37,0.03,0.0,0.0,0.08,james woodard,POSC-1030,2016
-POSC,1030,2,Intro to Political Theory,0.25,0.29,0.25,0.11,0.07,0.0,0.0,0.02,brandon turner,POSC-1030,2016
-POSC,1040,1,Intro Compar Pol,0.36,0.42,0.11,0.06,0.04,0.0,0.0,0.02,tara elizabet trask,POSC-1040,2016
-POSC,1040,2,Intro Compar Pol,0.18,0.35,0.29,0.06,0.06,0.0,0.0,0.06,katherine am curtis,POSC-1040,2016
-POSC,1990,1,Intro Pol Sci,0.4,0.33,0.08,0.09,0.06,0.0,0.0,0.05,meredith petersheim,POSC-1990,2016
-POSC,3020,1,State and Loc Gov,0.12,0.58,0.1,0.02,0.02,0.0,0.0,0.16,bruce ransom,POSC-3020,2016
-POSC,3410,1,Quant Meth in Pol Sc,0.06,0.17,0.33,0.22,0.17,0.0,0.0,0.06,steven vince miller,POSC-3410,2016
-POSC,3610,1,Intl Pol in Crisis,0.4,0.4,0.1,0.04,0.04,0.0,0.0,0.02,vladimir matic,POSC-3610,2016
-POSC,3630,1,Us Foreign Policy,0.29,0.24,0.22,0.14,0.1,0.0,0.0,0.0,steven vince miller,POSC-3630,2016
-POSC,3710,1,European Politics,0.33,0.28,0.22,0.0,0.06,0.0,0.0,0.11,vladimir matic,POSC-3710,2016
-POSC,3890,1,Religious Liberty & the Const.,0.29,0.64,0.0,0.0,0.07,0.0,0.0,0.0,daniel frost,POSC-3890,2016
-POSC,4030,1,United States Congress,0.27,0.37,0.27,0.04,0.04,0.0,0.0,0.02,jeffrey allen fine,POSC-4030,2016
-POSC,4070,1,Religion and Politic,0.17,0.46,0.26,0.03,0.06,0.0,0.0,0.03,laura olson,POSC-4070,2016
-POSC,4210,1,Public Policy,0.06,0.13,0.25,0.19,0.19,0.0,0.0,0.19,adam warber,POSC-4210,2016
-POSC,4230,1,Urban Politics,0.33,0.33,0.0,0.0,0.17,0.0,0.0,0.17,bruce ransom,POSC-4230,2016
-POSC,4360,1,Law Courts Politics,0.66,0.19,0.04,0.0,0.02,0.0,0.0,0.09,joseph earl stewart,POSC-4360,2016
-POSC,4380,1,Constitut Law: Struc of Gov,0.4,0.46,0.13,0.0,0.02,0.0,0.0,0.0,daniel frost,POSC-4380,2016
-POSC,4420,1,Pol Parties & Elect,0.13,0.04,0.42,0.29,0.0,0.0,0.0,0.13,james woodard,POSC-4420,2016
-POSC,4470,1,International Law,0.27,0.35,0.22,0.08,0.05,0.0,0.0,0.03,katherine am curtis,POSC-4470,2016
-POSC,4490,1,Political Theory of Capitalism,0.45,0.14,0.1,0.02,0.2,0.0,0.0,0.08,brandon turner,POSC-4490,2016
-POSC,4550,1,Pol Thght of American Founding,0.32,0.48,0.19,0.0,0.0,0.0,0.0,0.0, bradley thompson,POSC-4550,2016
-POSC,4560,1,Diplomacy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,POSC-4560,2016
-POSC,4760,1,Middle East Politics,0.67,0.13,0.07,0.0,0.0,0.0,0.0,0.13,vladimir matic,POSC-4760,2016
-POSC,4820,1,Political Novel and Film,0.11,0.42,0.47,0.0,0.0,0.0,0.0,0.0,james woodard,POSC-4820,2016
-PRTM,2200,10,Foundations of PRTM,0.45,0.34,0.08,0.02,0.04,0.0,0.0,0.08,jamie lynn cathey,PRTM-2200,2016
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2260,2016
-PRTM,2260,2,Fnd of Mgt Adm PRTM,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,PRTM-2260,2016
-PRTM,2260,3,Fnd of Mgt Adm PRTM,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2260,2016
-PRTM,2260,4,Fnd of Mgt Adm PRTM,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,PRTM-2260,2016
-PRTM,2260,5,Fnd of Mgt Adm PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2260,2016
-PRTM,2260,6,Fnd of Mgt Adm PRTM,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,harrison pinckney,PRTM-2260,2016
-PRTM,2260,7,Fnd of Mgt Adm PRTM,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2260,2016
-PRTM,2260,8,Fnd of Mgt Adm PRTM,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,kellie aman walters,PRTM-2260,2016
-PRTM,2270,1,Prov of Leisure Exp,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2270,2016
-PRTM,2270,2,Prov of Leisure Exp,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,PRTM-2270,2016
-PRTM,2270,3,Prov of Leisure Exp,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2270,2016
-PRTM,2270,4,Prov of Leisure Exp,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,herbert chancellor,PRTM-2270,2016
-PRTM,2270,5,Prov of Leisure Exp,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2270,2016
-PRTM,2270,6,Prov of Leisure Exp,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,harrison pinckney,PRTM-2270,2016
-PRTM,2270,7,Prov of Leisure Exp,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2270,2016
-PRTM,2270,8,Prov of Leisure Exp,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,kellie aman walters,PRTM-2270,2016
-PRTM,2290,1,Competency Integration in PRTM,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2290,2016
-PRTM,2290,2,Competency Integration in PRTM,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,PRTM-2290,2016
-PRTM,2290,3,Competency Integration in PRTM,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2290,2016
-PRTM,2290,4,Competency Integration in PRTM,0.28,0.5,0.17,0.0,0.06,0.0,0.0,0.0,herbert chancellor,PRTM-2290,2016
-PRTM,2290,5,Competency Integration in PRTM,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2290,2016
-PRTM,2290,6,Competency Integration in PRTM,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,harrison pinckney,PRTM-2290,2016
-PRTM,2290,7,Competency Integration in PRTM,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2290,2016
-PRTM,2290,8,Competency Integration in PRTM,0.26,0.53,0.11,0.05,0.05,0.0,0.0,0.0,kellie aman walters,PRTM-2290,2016
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.33,0.3,0.18,0.15,0.03,0.0,0.0,0.03,daniel mor anderson,PRTM-3050,2016
-PRTM,3070,2,Facility Operations,0.83,0.09,0.04,0.04,0.0,0.0,0.0,0.0,raymond dunham,PRTM-3070,2016
-PRTM,3200,1,Recreation Policy,0.25,0.45,0.2,0.1,0.0,0.0,0.0,0.0,lincoln larson,PRTM-3200,2016
-PRTM,3210,1,Recreation Admin,0.71,0.18,0.11,0.0,0.0,0.0,0.0,0.0,mariela fernandez,PRTM-3210,2016
-PRTM,3220,2,Facilitation Techniques in RT,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alysha amber walter,PRTM-3220,2016
-PRTM,3230,1,Prof Prep for RT Practice,0.91,0.0,0.0,0.0,0.05,0.0,0.0,0.04,stephen thoma lewis,PRTM-3230,2016
-PRTM,3240,1,Assessment & Planning in RT,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3240,2016
-PRTM,3240,2,Assessment & Planning in RT,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3240,2016
-PRTM,3250,1,Global Persp in Rec,0.42,0.26,0.19,0.13,0.0,0.0,0.0,0.0,mary price,PRTM-3250,2016
-PRTM,3300,1,Visit Ser & Interp,0.6,0.13,0.27,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-3300,2016
-PRTM,3420,2,Intro to Tourism,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,li-hsin chen,PRTM-3420,2016
-PRTM,3430,1,Spl Asp of Tourist B,0.35,0.48,0.11,0.0,0.05,0.0,0.0,0.0,william norman,PRTM-3430,2016
-PRTM,3470,1,Sport Tourism,0.35,0.35,0.2,0.05,0.0,0.0,0.0,0.05,gregory phi ramshaw,PRTM-3470,2016
-PRTM,3520,1,Camp Org and Admin,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,gwynn powell,PRTM-3520,2016
-PRTM,3900,6,Independent Study in PRTM,0.77,0.08,0.0,0.08,0.0,0.0,0.0,0.08,adam savedra,PRTM-3900,2016
-PRTM,3910,1,Social Media in PRTM,0.78,0.13,0.04,0.0,0.04,0.0,0.0,0.0,sheila backman,PRTM-3910,2016
-PRTM,3910,2,Issues & Trends in Event Mgmt.,0.72,0.16,0.08,0.04,0.0,0.0,0.0,0.0,stephanie per garst,PRTM-3910,2016
-PRTM,3910,3,Resort Management,0.76,0.19,0.0,0.0,0.05,0.0,0.0,0.0,jeffery martin,PRTM-3910,2016
-PRTM,3920,1,Special Event Management,0.69,0.2,0.1,0.0,0.0,0.0,0.0,0.02,kenneth backman,PRTM-3920,2016
-PRTM,3920,2,Special Event Management,0.8,0.16,0.02,0.0,0.0,0.0,0.0,0.02,kenneth backman,PRTM-3920,2016
-PRTM,3950,1,PGM Seminar III,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,adam savedra,PRTM-3950,2016
-PRTM,3980,2,Creative Inquiry in PRTM III,0.67,0.17,0.06,0.0,0.0,0.0,0.0,0.11,denise mar anderson,PRTM-3980,2016
-PRTM,3980,10,Creative Inquiry in PRTM III,0.59,0.21,0.14,0.07,0.0,0.0,0.0,0.0,gwynn powell,PRTM-3980,2016
-PRTM,4030,1,Elem of Rec/Pk Plan,0.43,0.36,0.21,0.0,0.0,0.0,0.0,0.0,robert baxte powell,PRTM-4030,2016
-PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,PRTM-4040,2016
-PRTM,4220,1,Management of RT Services,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,PRTM-4220,2016
-PRTM,4470,1,Perspect Intl Travel,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,lauren duffy,PRTM-4470,2016
-PRTM,4740,2,Adv Rec Resource Mgt,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey koo riungu,PRTM-4740,2016
-PRTM,4830,1,Golf Club Mgt & Ops,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,richard lucas,PRTM-4830,2016
-PRTM,4950,1,Pro Golf Management Seminar IV,0.5,0.25,0.08,0.17,0.0,0.0,0.0,0.0,richard lucas,PRTM-4950,2016
-PRTM,4980,10,Creative Inquiry in PRTM IV,0.59,0.21,0.14,0.07,0.0,0.0,0.0,0.0,gwynn powell,PRTM-4980,2016
-PRTM,8010,1,Phil Found of PRTM,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,PRTM-8010,2016
-PRTM,8010,2,Phil Found of PRTM,0.5,0.36,0.0,0.0,0.05,0.0,0.0,0.09,dorothy schmalz,PRTM-8010,2016
-PRTM,8010,3,Phil Found of PRTM,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,PRTM-8010,2016
-PRTM,8080,1,Behavioral Aspects,0.76,0.16,0.04,0.0,0.04,0.0,0.0,0.0,robert bixler,PRTM-8080,2016
-PRTM,8080,2,Behavioral Aspects,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-8080,2016
-PRTM,8220,2,Strateg Planning in PRTM Orgs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,PRTM-8220,2016
-PRTM,8710,1,Applied Research in Rec Therap,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,PRTM-8710,2016
-PRTM,8710,4,Applied Research in Rec Therap,0.9,0.06,0.03,0.0,0.0,0.0,0.0,0.0,sarah taylor agate,PRTM-8710,2016
-PRTM,8750,1,Program Plan & Consult in RT,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,PRTM-8750,2016
-PRTM,8750,2,Program Plan & Consult in RT,0.33,0.17,0.5,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,PRTM-8750,2016
-PSYC,2010,1,Intro to Psychology,0.36,0.32,0.18,0.06,0.05,0.0,0.0,0.03,jo anne jorgensen,PSYC-2010,2016
-PSYC,2010,2,Intro to Psychology,0.37,0.32,0.17,0.05,0.03,0.0,0.0,0.05,jo anne jorgensen,PSYC-2010,2016
-PSYC,2010,3,Intro to Psychology,0.24,0.34,0.24,0.1,0.06,0.0,0.0,0.02,edwin brainerd,PSYC-2010,2016
-PSYC,2010,4,Intro to Psychology,0.45,0.29,0.16,0.06,0.04,0.0,0.0,0.0,fred switzer,PSYC-2010,2016
-PSYC,2010,5,Intro to Psychology,0.33,0.26,0.21,0.03,0.06,0.0,0.0,0.11,mary taylor,PSYC-2010,2016
-PSYC,2010,6,Intro to Psychology (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,PSYC-2010,2016
-PSYC,2020,1,Intro Psychology Lab,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,jamie fynes,PSYC-2020,2016
-PSYC,2020,4,Intro Psychology Lab,0.8,0.04,0.0,0.04,0.12,0.0,0.0,0.0,madison eliza sauls,PSYC-2020,2016
-PSYC,2020,5,Intro Psychology Lab,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,william leidheiser,PSYC-2020,2016
-PSYC,2020,6,Intro Psychology Lab,0.77,0.15,0.0,0.0,0.04,0.0,0.0,0.04,william leidheiser,PSYC-2020,2016
-PSYC,3060,1,Human Sexual Beh,0.46,0.24,0.15,0.06,0.07,0.0,0.0,0.02,bruce michael king,PSYC-3060,2016
-PSYC,3090,100,Intro Exp Psych,0.51,0.23,0.14,0.08,0.04,0.0,0.0,0.0,patrick rosopa,PSYC-3090,2016
-PSYC,3090,200,Intro Exp Psych,0.4,0.2,0.1,0.03,0.23,0.0,0.0,0.03,jennifer bai bisson,PSYC-3090,2016
-PSYC,3090,300,Intro Exp Psych,0.57,0.23,0.07,0.07,0.03,0.0,0.0,0.03,stephen robertson,PSYC-3090,2016
-PSYC,3100,100,Advanced Experimental Psych,0.32,0.26,0.32,0.05,0.05,0.0,0.0,0.0,jennifer bai bisson,PSYC-3100,2016
-PSYC,3100,200,Advanced Experimental Psych,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,robert campbell,PSYC-3100,2016
-PSYC,3100,300,Advanced Experimental Psych,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2016
-PSYC,3100,400,Advanced Experimental Psych,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,leo gugerty,PSYC-3100,2016
-PSYC,3100,500,Advanced Experimental Psych,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2016
-PSYC,3240,1,Physiological Psych,0.38,0.28,0.17,0.1,0.01,0.0,0.0,0.06,claudio cantalupo,PSYC-3240,2016
-PSYC,3240,2,Physiological Psych,0.34,0.3,0.19,0.07,0.03,0.0,0.0,0.06,june pilcher,PSYC-3240,2016
-PSYC,3330,1,Cognitive Psych,0.42,0.39,0.11,0.03,0.01,0.0,0.0,0.03,leah hartman,PSYC-3330,2016
-PSYC,3330,2,Cognitive Psych,0.21,0.23,0.38,0.15,0.03,0.0,0.0,0.0,thomas alley,PSYC-3330,2016
-PSYC,3330,3,Cognitive Psych,0.16,0.33,0.31,0.16,0.02,0.0,0.0,0.03,thomas alley,PSYC-3330,2016
-PSYC,3340,1,Cognitive Psych Lab,0.68,0.23,0.09,0.0,0.0,0.0,0.0,0.0,laura whitlock,PSYC-3340,2016
-PSYC,3340,2,Cognitive Psych Lab,0.75,0.04,0.04,0.08,0.04,0.0,0.0,0.04,laura whitlock,PSYC-3340,2016
-PSYC,3400,1,Lifespan Developmental Psych,0.21,0.4,0.23,0.06,0.04,0.0,0.0,0.06,pamela alley,PSYC-3400,2016
-PSYC,3400,2,Lifespan Developmental Psych,0.62,0.28,0.09,0.0,0.01,0.0,0.0,0.0,sarah mae sanborn,PSYC-3400,2016
-PSYC,3520,1,Social Psychology,0.39,0.37,0.19,0.04,0.0,0.0,0.0,0.01,eric mckibben,PSYC-3520,2016
-PSYC,3640,1,Industrial Psych,0.3,0.51,0.17,0.0,0.0,0.0,0.0,0.01,eric mckibben,PSYC-3640,2016
-PSYC,3640,2,Industrial Psych,0.4,0.5,0.07,0.01,0.0,0.0,0.0,0.01,eric mckibben,PSYC-3640,2016
-PSYC,3680,1,Organizational Psych,0.34,0.31,0.14,0.07,0.06,0.0,0.0,0.07,thomas britt,PSYC-3680,2016
-PSYC,3680,2,Organizational Psych,0.3,0.35,0.15,0.11,0.07,0.0,0.0,0.02,kristen su jennings,PSYC-3680,2016
-PSYC,3700,1,Personality,0.14,0.49,0.31,0.06,0.0,0.0,0.0,0.0,eric mckibben,PSYC-3700,2016
-PSYC,3830,1,Abnormal Psychology,0.28,0.4,0.14,0.13,0.02,0.0,0.0,0.02,cynthia pury,PSYC-3830,2016
-PSYC,3830,2,Abnormal Psychology,0.17,0.29,0.34,0.09,0.09,0.0,0.0,0.03,pamela alley,PSYC-3830,2016
-PSYC,3830,3,Abnormal Psychology,0.34,0.23,0.26,0.0,0.06,0.0,0.0,0.11,pamela alley,PSYC-3830,2016
-PSYC,3830,4,Abnormal Psychology,0.32,0.43,0.16,0.03,0.01,0.0,0.0,0.04,lucinda sorci quick,PSYC-3830,2016
-PSYC,4080,1,Women and Psychology,0.56,0.32,0.08,0.04,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-4080,2016
-PSYC,4150,1,Systems and Theories,0.27,0.53,0.1,0.07,0.03,0.0,0.0,0.0,brian day,PSYC-4150,2016
-PSYC,4150,2,Systems and Theories,0.41,0.18,0.26,0.06,0.03,0.0,0.0,0.06,edwin brainerd,PSYC-4150,2016
-PSYC,4150,3,Systems and Theories,0.39,0.25,0.25,0.0,0.08,0.0,0.0,0.03,edwin brainerd,PSYC-4150,2016
-PSYC,4220,1,Perception,0.3,0.39,0.09,0.09,0.09,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2016
-PSYC,4220,2,Perception,0.5,0.17,0.21,0.08,0.0,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2016
-PSYC,4220,3,Perception,0.26,0.37,0.22,0.15,0.0,0.0,0.0,0.0,christopher pagano,PSYC-4220,2016
-PSYC,4350,1,Human Factors,0.38,0.17,0.33,0.13,0.0,0.0,0.0,0.0,laura whitlock,PSYC-4350,2016
-PSYC,4430,1,Infant & Child Dev,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-4430,2016
-PSYC,4560,1,Psychophysiology,0.54,0.17,0.04,0.08,0.08,0.0,0.0,0.08,drew michael morris,PSYC-4560,2016
-PSYC,4710,1,Psych of Testing,0.46,0.21,0.21,0.08,0.04,0.0,0.0,0.0,robert ray sinclair,PSYC-4710,2016
-PSYC,4800,1,Health Psychology,0.5,0.38,0.08,0.0,0.04,0.0,0.0,0.0,james mccubbin,PSYC-4800,2016
-PSYC,4800,2,Health Psychology,0.56,0.36,0.0,0.0,0.04,0.0,0.0,0.04,james mccubbin,PSYC-4800,2016
-PSYC,4880,1,Psychotherapy,0.43,0.29,0.07,0.07,0.07,0.0,0.0,0.07,heidi marie zinzow,PSYC-4880,2016
-PSYC,4890,1,Teamwork in 21st Cen,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,william kramer,PSYC-4890,2016
-PSYC,4920,1,Senior Laboratory,0.68,0.2,0.08,0.04,0.0,0.0,0.0,0.0,drea kevin fekety,PSYC-4920,2016
-PSYC,4920,4,Senior Laboratory,0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,miranda pelkey,PSYC-4920,2016
-PSYC,4920,5,Senior Laboratory,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,dana verhoeven,PSYC-4920,2016
-PSYC,4920,6,Senior Laboratory,0.45,0.18,0.09,0.09,0.18,0.0,0.0,0.0,dana verhoeven,PSYC-4920,2016
-PSYC,8100,1,Research Design I,0.61,0.16,0.1,0.0,0.06,0.0,0.0,0.06, dewayne moore,PSYC-8100,2016
-PSYC,8220,1,Percept & Perform,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richard tyrrell,PSYC-8220,2016
-RED,8000,1,Real Estate Dvlpment,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,robert cre benedict,RED-8000,2016
-RED,8010,1,Market Analysis,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,RED-8010,2016
-RED,8130,1,Strat in Real Estate,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,RED-8130,2016
-REL,1010,1,Intro to Religion,0.43,0.43,0.04,0.04,0.04,0.0,0.0,0.0,steven grosby,REL-1010,2016
-REL,1010,2,Intro to Religion,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,robert stephens,REL-1010,2016
-REL,1010,4,Intro to Religion,0.82,0.09,0.06,0.0,0.03,0.0,0.0,0.0,robert stephens,REL-1010,2016
-REL,1010,5,Intro to Religion,0.72,0.09,0.06,0.0,0.0,0.0,0.0,0.13,robert stephens,REL-1010,2016
-REL,1020,2,World Religions,0.22,0.17,0.33,0.06,0.06,0.0,0.0,0.17,peter cohen,REL-1020,2016
-REL,1020,3,World Religions,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,peter cohen,REL-1020,2016
-REL,1020,4,World Religions,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,peter cohen,REL-1020,2016
-REL,1020,5,World Religions,0.35,0.29,0.26,0.0,0.0,0.0,0.0,0.09,brett patterson,REL-1020,2016
-REL,1020,7,World Religions,0.42,0.33,0.17,0.0,0.0,0.0,0.0,0.08,brett patterson,REL-1020,2016
-REL,3010,1,Old Testament,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3010,2016
-REL,3060,1,Judaism,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3060,2016
-REL,3110,1,African American Rel,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,elizabeth jemison,REL-3110,2016
-REL,3130,1,Buddhism,0.68,0.21,0.0,0.05,0.0,0.0,0.0,0.05,robert stephens,REL-3130,2016
-REL,3150,1,Islam,0.5,0.31,0.06,0.0,0.0,0.0,0.0,0.13,mashal saif,REL-3150,2016
-REL,3300,1,Contemporary Issues,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mashal saif,REL-3300,2016
-REL,4010,1,Stud Biblical Literature & Rel,0.41,0.29,0.06,0.0,0.12,0.0,0.0,0.12,benjamin white,REL-4010,2016
-RS,3010,1,Rural Sociology,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,kenneth robinson,RS-3010,2016
-RUSS,1010,1,Elementary Russian,0.26,0.26,0.26,0.11,0.11,0.0,0.0,0.0,olga anatol volkova,RUSS-1010,2016
-RUSS,3400,1,19th C Russ Culture,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,RUSS-3400,2016
-SOC,2010,2,Introduction to Sociology,0.72,0.2,0.06,0.0,0.01,0.0,0.0,0.01,andrew mannheimer,SOC-2010,2016
-SOC,2010,3,Introduction to Sociology,0.73,0.18,0.04,0.02,0.0,0.02,0.0,0.0,andrew mannheimer,SOC-2010,2016
-SOC,2010,4,Introduction to Sociology,0.28,0.51,0.11,0.04,0.01,0.0,0.0,0.04,carolyn can coffman,SOC-2010,2016
-SOC,2010,5,Introduction to Sociology,0.26,0.45,0.23,0.06,0.0,0.0,0.0,0.0,carolyn can coffman,SOC-2010,2016
-SOC,2010,6,Introduction to Sociology,0.28,0.55,0.15,0.02,0.0,0.0,0.0,0.0,carolyn can coffman,SOC-2010,2016
-SOC,2010,7,Introduction to Sociology,0.34,0.4,0.13,0.06,0.0,0.0,0.0,0.06,mary louise barr,SOC-2010,2016
-SOC,2010,8,Introduction to Sociology,0.56,0.27,0.13,0.02,0.02,0.0,0.0,0.0,mary louise barr,SOC-2010,2016
-SOC,2010,9,Introduction to Sociology,0.5,0.3,0.16,0.02,0.0,0.0,0.0,0.02,mary louise barr,SOC-2010,2016
-SOC,2010,10,Introduction to Sociology,0.43,0.39,0.13,0.03,0.0,0.0,0.0,0.01,mary louise barr,SOC-2010,2016
-SOC,2010,11,Introduction to Sociology,0.57,0.3,0.11,0.02,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2016
-SOC,2010,12,Introduction to Sociology,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2016
-SOC,2010,13,Introduction to Sociology,0.6,0.28,0.08,0.01,0.02,0.0,0.0,0.01,shannon mcdonough,SOC-2010,2016
-SOC,2010,14,Introduction to Sociology,0.71,0.2,0.06,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2016
-SOC,2010,15,Introduction to Sociology,0.71,0.21,0.02,0.02,0.02,0.0,0.0,0.02,shannon mcdonough,SOC-2010,2016
-SOC,2010,16,Introduction to Sociology,0.47,0.43,0.04,0.04,0.0,0.0,0.0,0.02,tamela lea eitle,SOC-2010,2016
-SOC,2010,17,Introduction to Sociology,0.4,0.46,0.08,0.02,0.02,0.0,0.0,0.02,tamela lea eitle,SOC-2010,2016
-SOC,2050,1,Sociology Lab,0.54,0.15,0.15,0.0,0.15,0.0,0.0,0.0,brenda vander mey,SOC-2050,2016
-SOC,2050,2,Sociology Lab,0.61,0.11,0.0,0.0,0.28,0.0,0.0,0.0,brenda vander mey,SOC-2050,2016
-SOC,3020,1,Research Methods I,0.09,0.44,0.31,0.13,0.0,0.0,0.0,0.03,andrew whitehead,SOC-3020,2016
-SOC,3040,1,Social Research Methods II,0.32,0.18,0.36,0.05,0.05,0.0,0.0,0.05,ye luo,SOC-3040,2016
-SOC,3100,1,Marriage & Intimacy,0.52,0.17,0.13,0.07,0.04,0.0,0.0,0.07,carolyn can coffman,SOC-3100,2016
-SOC,3110,1,The Family,0.15,0.28,0.26,0.18,0.1,0.0,0.0,0.03,andrew whitehead,SOC-3110,2016
-SOC,3600,1,Class & Poverty,0.86,0.02,0.04,0.08,0.0,0.0,0.0,0.0,william wentworth,SOC-3600,2016
-SOC,3880,1,Criminal Justice,0.32,0.16,0.36,0.16,0.0,0.0,0.0,0.0,margaret tina britz,SOC-3880,2016
-SOC,3890,1,Criminology,0.15,0.21,0.26,0.12,0.06,0.0,0.0,0.21,william white,SOC-3890,2016
-SOC,3910,1,Soc of Deviance,0.45,0.32,0.11,0.05,0.02,0.0,0.0,0.05,william white,SOC-3910,2016
-SOC,3920,1,Juvenile Delinquency,0.41,0.35,0.18,0.0,0.0,0.0,0.0,0.06,william white,SOC-3920,2016
-SOC,3940,1,Sociology of Mental Illness,0.48,0.41,0.02,0.0,0.07,0.0,0.0,0.02,marissa el yingling,SOC-3940,2016
-SOC,3970,1,Substance Abuse,0.57,0.28,0.09,0.04,0.0,0.0,0.0,0.02,shannon mcdonough,SOC-3970,2016
-SOC,4030,1,"Technol, Environment & Society",0.39,0.06,0.39,0.0,0.06,0.0,0.0,0.11, catherine mobley,SOC-4030,2016
-SOC,4040,1,Soc Theory,0.54,0.29,0.15,0.0,0.02,0.0,0.0,0.0,william wentworth,SOC-4040,2016
-SOC,4140,1,Policy&Social Change,0.45,0.25,0.25,0.0,0.05,0.0,0.0,0.0,marissa el yingling,SOC-4140,2016
-SOC,4330,1,Global Social Change,0.77,0.15,0.0,0.04,0.04,0.0,0.0,0.0,william haller,SOC-4330,2016
-SOC,4440,1,Sociology of Educ,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,SOC-4440,2016
-SOC,4600,1,Race & Ethnicity,0.41,0.22,0.3,0.04,0.04,0.0,0.0,0.0,brenda vander mey,SOC-4600,2016
-SOC,4680,1,Criminal Evidence,0.36,0.55,0.05,0.0,0.0,0.0,0.0,0.05,margaret tina britz,SOC-4680,2016
-SOC,4810,1,Aging and Death,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-4810,2016
-SOC,4970,1,Senior Lab,0.6,0.13,0.13,0.0,0.1,0.0,0.0,0.03,brenda vander mey,SOC-4970,2016
-SOC,8030,1,Sur Dsgn App Res Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,SOC-8030,2016
-SPAN,1010,1,Elementary Spanish,0.67,0.27,0.0,0.0,0.07,0.0,0.0,0.0,scott harris,SPAN-1010,2016
-SPAN,1010,2,Elementary Spanish,0.5,0.25,0.19,0.0,0.0,0.0,0.0,0.06,scott harris,SPAN-1010,2016
-SPAN,1010,3,Elementary Spanish,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2016
-SPAN,1020,1,Elementary Spanish,0.26,0.26,0.26,0.0,0.05,0.0,0.0,0.16,maureen zamora,SPAN-1020,2016
-SPAN,1020,2,Elementary Spanish,0.35,0.29,0.12,0.12,0.0,0.0,0.0,0.12,maureen zamora,SPAN-1020,2016
-SPAN,1020,3,Elementary Spanish,0.41,0.18,0.12,0.12,0.0,0.0,0.0,0.18,maureen zamora,SPAN-1020,2016
-SPAN,1020,4,Elementary Spanish,0.29,0.41,0.06,0.0,0.0,0.0,0.0,0.24,maureen zamora,SPAN-1020,2016
-SPAN,1020,5,Elementary Spanish,0.29,0.35,0.0,0.0,0.06,0.0,0.0,0.29,maureen zamora,SPAN-1020,2016
-SPAN,1020,6,Elementary Spanish,0.44,0.25,0.19,0.0,0.06,0.0,0.0,0.06,cathy robison,SPAN-1020,2016
-SPAN,1020,7,Elementary Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,cathy robison,SPAN-1020,2016
-SPAN,1020,8,Elementary Spanish,0.29,0.29,0.24,0.06,0.0,0.0,0.0,0.12,ana paula  miller,SPAN-1020,2016
-SPAN,1020,9,Elementary Spanish,0.31,0.19,0.19,0.13,0.06,0.0,0.0,0.13,ana paula  miller,SPAN-1020,2016
-SPAN,1020,10,Elementary Spanish,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,debra oa williamson,SPAN-1020,2016
-SPAN,1020,11,Elementary Spanish,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-1020,2016
-SPAN,1020,12,Elementary Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-1020,2016
-SPAN,1020,13,Elementary Spanish,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-1020,2016
-SPAN,2010,1,Intermediate Spanish,0.47,0.21,0.26,0.0,0.0,0.0,0.0,0.05,cathy robison,SPAN-2010,2016
-SPAN,2010,2,Intermediate Spanish,0.24,0.59,0.12,0.06,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2016
-SPAN,2010,3,Intermediate Spanish,0.53,0.24,0.24,0.0,0.0,0.0,0.0,0.0,allison ann hinds,SPAN-2010,2016
-SPAN,2010,4,Intermediate Spanish,0.53,0.24,0.12,0.06,0.06,0.0,0.0,0.0,allison ann hinds,SPAN-2010,2016
-SPAN,2010,5,Intermediate Spanish,0.44,0.31,0.13,0.0,0.0,0.0,0.0,0.13,allison ann hinds,SPAN-2010,2016
-SPAN,2010,6,Intermediate Spanish,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,heidi montes,SPAN-2010,2016
-SPAN,2010,7,Intermediate Spanish,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,heidi montes,SPAN-2010,2016
-SPAN,2010,8,Intermediate Spanish,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,melva margu persico,SPAN-2010,2016
-SPAN,2010,9,Intermediate Spanish,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,melva margu persico,SPAN-2010,2016
-SPAN,2010,10,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,SPAN-2010,2016
-SPAN,2010,11,Intermediate Spanish,0.27,0.6,0.13,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-2010,2016
-SPAN,2010,12,Intermediate Spanish,0.59,0.18,0.12,0.0,0.0,0.0,0.0,0.12,debra oa williamson,SPAN-2010,2016
-SPAN,2010,13,Intermediate Spanish,0.47,0.35,0.06,0.0,0.0,0.0,0.0,0.12,maureen zamora,SPAN-2010,2016
-SPAN,2010,14,Intermediate Spanish,0.61,0.22,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,SPAN-2010,2016
-SPAN,2010,15,Intermediate Spanish,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0, buitrago gonzalez,SPAN-2010,2016
-SPAN,2010,16,Intermediate Spanish,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,SPAN-2010,2016
-SPAN,2010,18,Intermediate Spanish,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,nora arostegu logue,SPAN-2010,2016
-SPAN,2010,20,Intermediate Spanish (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,SPAN-2010,2016
-SPAN,2020,1,Intermediate Spanish,0.47,0.33,0.07,0.07,0.0,0.0,0.0,0.07,heidi montes,SPAN-2020,2016
-SPAN,2020,2,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2016
-SPAN,2020,3,Intermediate Spanish,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2016
-SPAN,2020,4,Intermediate Spanish,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,heidi montes,SPAN-2020,2016
-SPAN,2020,5,Intermediate Spanish,0.53,0.16,0.26,0.0,0.05,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2016
-SPAN,2020,6,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-2020,2016
-SPAN,2020,7,Intermediate Spanish,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-2020,2016
-SPAN,2020,8,Intermediate Spanish,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-2020,2016
-SPAN,2020,9,Intermediate Spanish,0.39,0.33,0.22,0.0,0.06,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2016
-SPAN,2020,10,Intermediate Spanish,0.5,0.33,0.11,0.06,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2016
-SPAN,2020,11,Intermediate Spanish,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2016
-SPAN,2020,12,Intermediate Spanish,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,ze cruz valderramos,SPAN-2020,2016
-SPAN,2020,13,Intermediate Spanish,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2016
-SPAN,2020,14,Intermediate Spanish,0.56,0.28,0.11,0.0,0.0,0.0,0.0,0.06,kari daus carson,SPAN-2020,2016
-SPAN,2020,15,Intermediate Spanish,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,kari daus carson,SPAN-2020,2016
-SPAN,3050,1,Int Con Comp Span I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-3050,2016
-SPAN,3050,2,Int Con Comp Span I,0.47,0.4,0.07,0.0,0.0,0.0,0.0,0.07,melva margu persico,SPAN-3050,2016
-SPAN,3050,3,Int Con Comp Span I,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,juana martin-armas,SPAN-3050,2016
-SPAN,3050,4,Int Con Comp Span I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,SPAN-3050,2016
-SPAN,3060,1,Span Comp for Bus,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,maureen zamora,SPAN-3060,2016
-SPAN,3070,1,Hispanic World: Sp,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,salvador oropesa,SPAN-3070,2016
-SPAN,3070,2,Hispanic World: Sp,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-3070,2016
-SPAN,3080,1,Hispanic World: La,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,george palacios,SPAN-3080,2016
-SPAN,3130,1,Span Lit Survey I,0.32,0.16,0.0,0.0,0.05,0.0,0.0,0.47,mon rojas-de-massei,SPAN-3130,2016
-SPAN,3130,2,Span Lit Survey I,0.43,0.07,0.21,0.07,0.0,0.0,0.0,0.21,mon rojas-de-massei,SPAN-3130,2016
-SPAN,3140,1,Hispanic Linguistics,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,daniel smith,SPAN-3140,2016
-SPAN,3180,1,Span Through Culture,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,SPAN-3180,2016
-SPAN,4060,2,Narrative Fiction,0.44,0.19,0.38,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,SPAN-4060,2016
-SPAN,4090,1,Comp Writ in Span,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,SPAN-4090,2016
-SPAN,4160,1,Span Intl Trade II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-4160,2016
-SPAN,4210,1,Sp-Am Mod & Postmod,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-4210,2016
-SPAN,4220,1,Contem Span Am Novel,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,danie garcia vieyra,SPAN-4220,2016
-STAT,2220,1,Statistics in Everyday Life,0.35,0.35,0.15,0.1,0.03,0.0,0.0,0.02,james espey,STAT-2220,2016
-STAT,2220,2,Statistics in Everyday Life,0.41,0.42,0.14,0.03,0.0,0.0,0.0,0.0,james espey,STAT-2220,2016
-STAT,2220,3,Statistics in Everyday Life,0.45,0.23,0.3,0.0,0.02,0.0,0.0,0.0,james espey,STAT-2220,2016
-STAT,2220,4,Statistics in Everyday Life,0.37,0.33,0.13,0.14,0.02,0.0,0.0,0.03,james espey,STAT-2220,2016
-STAT,2220,5,Statistics in Everyday Life,0.33,0.41,0.17,0.07,0.0,0.0,0.0,0.02,ros martinez-dawson,STAT-2220,2016
-STAT,2220,6,Statistics in Everyday Life,0.4,0.36,0.1,0.08,0.03,0.0,0.0,0.02,ros martinez-dawson,STAT-2220,2016
-STAT,2220,7,Statistics in Everyday Life,0.32,0.42,0.16,0.05,0.05,0.0,0.0,0.0,andrew walton green,STAT-2220,2016
-STAT,2220,8,Statistics in Everyday Life,0.32,0.37,0.16,0.05,0.0,0.0,0.0,0.11,lauren reig lembcke,STAT-2220,2016
-STAT,2300,1,Statistical Methods I,0.26,0.3,0.18,0.13,0.09,0.0,0.0,0.04,christy jenki brown,STAT-2300,2016
-STAT,2300,2,Statistical Methods I,0.26,0.36,0.23,0.08,0.06,0.0,0.0,0.02,christy jenki brown,STAT-2300,2016
-STAT,2300,3,Statistical Methods I,0.3,0.38,0.15,0.12,0.04,0.0,0.0,0.0,christy jenki brown,STAT-2300,2016
-STAT,2300,4,Statistical Methods I,0.29,0.34,0.17,0.08,0.08,0.0,0.0,0.03, erwin walker,STAT-2300,2016
-STAT,2300,5,Statistical Methods I,0.22,0.4,0.21,0.08,0.04,0.0,0.0,0.03, erwin walker,STAT-2300,2016
-STAT,2300,6,Statistical Methods I,0.19,0.3,0.25,0.09,0.11,0.0,0.0,0.06,april thomas,STAT-2300,2016
-STAT,2300,8,Statistical Methods I,0.17,0.25,0.29,0.11,0.12,0.0,0.0,0.07,april thomas,STAT-2300,2016
-STAT,3090,1,Introductory Business Stats,0.16,0.32,0.21,0.11,0.05,0.0,0.0,0.16,yijun chen,STAT-3090,2016
-STAT,3090,2,Introductory Business Stats,0.21,0.42,0.16,0.0,0.05,0.0,0.0,0.16, morales hernandez,STAT-3090,2016
-STAT,3090,4,Introductory Business Stats,0.28,0.19,0.33,0.14,0.03,0.0,0.0,0.03,sharon marie evans,STAT-3090,2016
-STAT,3090,5,Introductory Business Stats,0.38,0.41,0.18,0.0,0.0,0.0,0.0,0.03,jennifer van dyken,STAT-3090,2016
-STAT,3090,6,Introductory Business Stats,0.17,0.26,0.29,0.17,0.09,0.0,0.0,0.03,sharon marie evans,STAT-3090,2016
-STAT,3090,7,Introductory Business Stats,0.37,0.32,0.11,0.16,0.0,0.0,0.0,0.05,yijun chen,STAT-3090,2016
-STAT,3090,8,Introductory Business Stats,0.39,0.17,0.33,0.0,0.11,0.0,0.0,0.0, morales hernandez,STAT-3090,2016
-STAT,3090,9,Introductory Business Stats,0.14,0.34,0.26,0.09,0.11,0.0,0.0,0.06,sharon marie evans,STAT-3090,2016
-STAT,3090,10,Introductory Business Stats,0.06,0.33,0.39,0.11,0.06,0.0,0.0,0.06,andrew pangia,STAT-3090,2016
-STAT,3090,11,Introductory Business Stats,0.28,0.25,0.22,0.11,0.08,0.0,0.0,0.06,sharon marie evans,STAT-3090,2016
-STAT,3090,12,Introductory Business Stats,0.0,0.41,0.18,0.29,0.12,0.0,0.0,0.0,mengcong ren,STAT-3090,2016
-STAT,3090,13,Introductory Business Stats,0.05,0.26,0.21,0.21,0.11,0.0,0.0,0.16,andrew pangia,STAT-3090,2016
-STAT,3090,14,Introductory Business Stats,0.16,0.05,0.32,0.16,0.05,0.0,0.0,0.26,rui gong,STAT-3090,2016
-STAT,3090,15,Introductory Business Stats,0.06,0.17,0.33,0.22,0.22,0.0,0.0,0.0,mengcong ren,STAT-3090,2016
-STAT,3090,16,Introductory Business Stats,0.24,0.18,0.29,0.12,0.18,0.0,0.0,0.0,rui gong,STAT-3090,2016
-STAT,3090,17,Introductory Business Stats,0.16,0.21,0.32,0.05,0.16,0.0,0.0,0.11,kayla doris javier,STAT-3090,2016
-STAT,3090,18,Introductory Business Stats,0.13,0.44,0.19,0.25,0.0,0.0,0.0,0.0,sanjog arv kulkarni,STAT-3090,2016
-STAT,3090,19,Introductory Business Stats,0.21,0.37,0.26,0.05,0.05,0.0,0.0,0.05,jason alexande kurz,STAT-3090,2016
-STAT,3090,20,Introductory Business Stats,0.26,0.37,0.26,0.06,0.06,0.0,0.0,0.0,ellen hepfe breazel,STAT-3090,2016
-STAT,3090,21,Introductory Business Stats,0.16,0.26,0.37,0.11,0.05,0.0,0.0,0.05,kayla doris javier,STAT-3090,2016
-STAT,3090,22,Introductory Business Stats,0.32,0.32,0.16,0.05,0.11,0.0,0.0,0.05,boyoung hur,STAT-3090,2016
-STAT,3090,23,Introductory Business Stats,0.23,0.29,0.4,0.06,0.03,0.0,0.0,0.0,ellen hepfe breazel,STAT-3090,2016
-STAT,3090,24,Introductory Business Stats,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,sanjog arv kulkarni,STAT-3090,2016
-STAT,3090,25,Introductory Business Stats,0.22,0.33,0.33,0.06,0.06,0.0,0.0,0.0,tao yang,STAT-3090,2016
-STAT,3090,26,Introductory Business Stats,0.16,0.47,0.32,0.0,0.0,0.0,0.0,0.05,dilhani marasinghe,STAT-3090,2016
-STAT,3090,27,Introductory Business Stats,0.21,0.21,0.26,0.16,0.0,0.0,0.0,0.16,paul james cubre,STAT-3090,2016
-STAT,3090,28,Introductory Business Stats,0.16,0.32,0.26,0.11,0.11,0.0,0.0,0.05,boyoung hur,STAT-3090,2016
-STAT,3090,29,Introductory Business Stats,0.26,0.26,0.32,0.05,0.11,0.0,0.0,0.0,jayasekara merenchig,STAT-3090,2016
-STAT,3090,30,Introductory Business Stats,0.32,0.26,0.11,0.0,0.26,0.0,0.0,0.05,paul james cubre,STAT-3090,2016
-STAT,3090,31,Introductory Business Stats,0.32,0.26,0.11,0.05,0.16,0.0,0.0,0.11,tao yang,STAT-3090,2016
-STAT,3090,32,Introductory Business Stats,0.42,0.16,0.26,0.0,0.05,0.0,0.0,0.11,jason alexande kurz,STAT-3090,2016
-STAT,3090,33,Introductory Business Stats,0.16,0.53,0.21,0.05,0.0,0.0,0.0,0.05,jayasekara merenchig,STAT-3090,2016
-STAT,3090,34,Introductory Business Stats,0.11,0.42,0.37,0.0,0.05,0.0,0.0,0.05,dilhani marasinghe,STAT-3090,2016
-STAT,3300,1,Statistical Methods II,0.32,0.23,0.09,0.14,0.05,0.0,0.0,0.18,ros martinez-dawson,STAT-3300,2016
-STAT,4020,1,Intro to Statistical Computing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-4020,2016
-STAT,4110,1,Stat Mthds for Process Control,0.82,0.16,0.0,0.0,0.03,0.0,0.0,0.0,richard stev dubsky,STAT-4110,2016
-STAT,4110,2,Stat Mthds for Process Control,0.48,0.35,0.13,0.0,0.03,0.0,0.0,0.0,james rieck,STAT-4110,2016
-STAT,4110,3,Stat Mthds for Process Control,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,STAT-4110,2016
-STAT,6020,1,Intro to Statistical Computing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-6020,2016
-STAT,8010,1,Statistical Methods I,0.44,0.28,0.09,0.0,0.0,0.0,0.0,0.19,brook thaye russell,STAT-8010,2016
-STAT,8010,2,Statistical Methods I,0.33,0.45,0.12,0.0,0.06,0.0,0.0,0.03,james rieck,STAT-8010,2016
-STAT,8010,3,Statistical Methods I,0.49,0.29,0.11,0.0,0.09,0.0,0.0,0.03,jun luo,STAT-8010,2016
-STAT,8010,4,Statistical Methods I,0.61,0.19,0.1,0.0,0.1,0.0,0.0,0.0,jun luo,STAT-8010,2016
-STAT,8020,1,Statistical Methods II,0.61,0.36,0.0,0.0,0.0,0.0,0.0,0.04,william bridges,STAT-8020,2016
-STS,1010,1,Survey of S T S,0.62,0.24,0.15,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,STS-1010,2016
-STS,1010,2,Survey of S T S,0.6,0.29,0.06,0.0,0.0,0.0,0.0,0.06,philip randall,STS-1010,2016
-STS,1010,3,Survey of S T S,0.42,0.52,0.03,0.03,0.0,0.0,0.0,0.0,scott brame,STS-1010,2016
-STS,1010,5,Survey of S T S,0.66,0.26,0.06,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,STS-1010,2016
-STS,1010,6,Survey of S T S,0.33,0.39,0.19,0.06,0.03,0.0,0.0,0.0,allison ann hinds,STS-1010,2016
-STS,1010,7,Survey of S T S,0.15,0.5,0.24,0.03,0.03,0.0,0.0,0.06,david charles foltz,STS-1010,2016
-STS,1010,8,Survey of S T S,0.36,0.5,0.06,0.0,0.0,0.0,0.0,0.08,megan no macalystre,STS-1010,2016
-STS,1010,9,Survey of S T S,0.6,0.29,0.06,0.03,0.03,0.0,0.0,0.0,sarah mae cooper,STS-1010,2016
-STS,1010,10,Survey of S T S,0.8,0.14,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,STS-1010,2016
-THEA,2100,1,Theatre Appreciation,0.94,0.0,0.03,0.0,0.03,0.0,0.0,0.0,richard st. peter,THEA-2100,2016
-THEA,2100,2,Theatre Appreciation,0.84,0.03,0.06,0.0,0.06,0.0,0.0,0.0,kerrie kath seymour,THEA-2100,2016
-THEA,2100,3,Theatre Appreciation,0.53,0.22,0.25,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-2100,2016
-THEA,2100,4,Theatre Appreciation,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,carol collins,THEA-2100,2016
-THEA,2100,5,Theatre Appreciation,0.87,0.03,0.03,0.0,0.0,0.0,0.0,0.07,shannon ther robert,THEA-2100,2016
-THEA,2100,6,Theatre Appreciation,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,THEA-2100,2016
-THEA,2100,7,Theatre Appreciation,0.56,0.31,0.09,0.0,0.0,0.0,0.0,0.03,jason adkins,THEA-2100,2016
-THEA,2780,1,Acting I,0.76,0.06,0.06,0.06,0.06,0.0,0.0,0.0,kerrie kath seymour,THEA-2780,2016
-THEA,2790,1,Theatre Practicum,0.5,0.0,0.0,0.0,0.29,0.0,0.0,0.21,matthew leckenbusch,THEA-2790,2016
-THEA,3170,1,African-Amer Thea I,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,kendra lyne johnson,THEA-3170,2016
-THEA,4290,1,Dramatic Literature I,0.74,0.11,0.05,0.0,0.05,0.0,0.0,0.05,richard st. peter,THEA-4290,2016
-THEA,4800,1,Advanced Scene Study,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,kerrie kath seymour,THEA-4800,2016
-WFB,3000,1,Wildlife Biology,0.52,0.29,0.14,0.0,0.03,0.0,0.0,0.02,catherine jachowski,WFB-3000,2016
-WFB,3000,2,Wildlife Biology,0.56,0.28,0.05,0.05,0.04,0.0,0.0,0.01,catherine jachowski,WFB-3000,2016
-WFB,3010,2,Wildlife Biology Lab,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2016
-WFB,4100,2,Wildlife Management Techniques,0.1,0.44,0.4,0.04,0.0,0.0,0.0,0.02,james davis,WFB-4100,2016
-WFB,4180,1,Fishery Conservation,0.67,0.19,0.1,0.0,0.05,0.0,0.0,0.0,yoichiro kanno,WFB-4180,2016
-WFB,4440,1,Wildlife Damage Management,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,james davis,WFB-4440,2016
-WFB,4930,1,Waterfowl Ecology & Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,WFB-4930,2016
-WFB,4930,2,Plant & Flora ID/Systematics,0.46,0.41,0.11,0.02,0.0,0.0,0.0,0.0,patrick mcmillan,WFB-4930,2016
-WS,1030,1,Women in Global Perspective,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,laura foxworth,WS-1030,2016
-WS,1030,2,Women in Global Perspective,0.79,0.18,0.0,0.0,0.03,0.0,0.0,0.0,laura foxworth,WS-1030,2016
-WS,2300,1,Women and Leadership,0.64,0.14,0.0,0.07,0.14,0.0,0.0,0.0,diane perpich,WS-2300,2016
-WS,3010,1,Intro Women's Studies,0.63,0.17,0.06,0.03,0.03,0.0,0.0,0.09,elizabeth ros adams,WS-3010,2016
-WS,3010,2,Intro Women's Studies,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,elizabeth ros adams,WS-3010,2016
-WS,4900,1,Creative Inquiry,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,diane perpich,WS-4900,2016
-YDP,3000,400,Youth Development in Society,0.82,0.06,0.06,0.0,0.0,0.0,0.0,0.06,barry garst,YDP-3000,2016
-YDP,3050,400,Theory/Phil of Youth Dev Work,0.63,0.19,0.06,0.06,0.0,0.0,0.0,0.06,edmond patri bowers,YDP-3050,2016
-YDP,3450,1,Creative Activities for Youth,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kimberly pe johnson,YDP-3450,2016
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1010,1,Survey of Art & Arch History I,0.31,0.44,0.23,0.02,0.0,0.0,0.0,0.01,beth ann lauritis,
+AAH,2050,1,Art History and Theory I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,beth ann lauritis,
+ACCT,2010,1,Financial Accounting Concepts,0.03,0.25,0.35,0.15,0.08,0.0,0.0,0.15,philip maiberger,
+ACCT,2010,2,Financial Accounting Concepts,0.18,0.38,0.28,0.05,0.03,0.0,0.0,0.08,philip maiberger,
+ACCT,2010,3,Financial Accounting Concepts,0.24,0.44,0.2,0.04,0.04,0.0,0.0,0.04,lydia lan schleifer,
+ACCT,2010,4,Financial Accounting Concepts,0.2,0.33,0.2,0.1,0.08,0.0,0.0,0.1,annieka philo,
+ACCT,2010,5,Financial Accounting Concepts,0.24,0.43,0.2,0.06,0.04,0.0,0.0,0.02,lydia lan schleifer,
+ACCT,2010,6,Financial Accounting Concepts,0.12,0.52,0.21,0.03,0.09,0.0,0.0,0.03,the estate  guffey,
+ACCT,2010,7,Financial Accounting Concepts,0.26,0.36,0.16,0.08,0.04,0.0,0.0,0.1,annieka philo,
+ACCT,2010,9,Financial Accounting Concepts,0.32,0.15,0.23,0.04,0.11,0.0,0.0,0.15,lydia lan schleifer,
+ACCT,2010,10,Financial Accounting Concepts,0.17,0.26,0.26,0.13,0.11,0.0,0.0,0.07,lydia lan schleifer,
+ACCT,2010,11,Financial Accounting Concepts,0.13,0.33,0.29,0.06,0.1,0.0,0.0,0.08,annieka philo,
+ACCT,2010,12,Financial Accounting Concepts,0.07,0.29,0.29,0.09,0.16,0.0,0.0,0.11,annieka philo,
+ACCT,2010,13,Financial Accounting Concepts,0.09,0.33,0.24,0.04,0.04,0.0,0.0,0.24,mary ann  prater,
+ACCT,2010,14,Financial Accounting Concepts,0.19,0.19,0.14,0.07,0.12,0.0,0.0,0.29,mary ann  prater,
+ACCT,2010,15,Financial Accounting Concepts,0.15,0.33,0.11,0.19,0.15,0.0,0.0,0.07,charles tegen,
+ACCT,2010,100,Fin Accounting Concepts (HON),0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,the estate  guffey,True
+ACCT,2010,101,Fin Accounting Concepts (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True
+ACCT,2010,400,Financial Accounting Concepts,0.23,0.35,0.16,0.05,0.1,0.0,0.0,0.11,jeffrey mcmillan,
+ACCT,2020,1,Managerial Accounting Concepts,0.15,0.27,0.33,0.12,0.06,0.0,0.0,0.06,henry anderson,
+ACCT,2020,2,Managerial Accounting Concepts,0.19,0.21,0.17,0.17,0.1,0.0,0.0,0.17,henry anderson,
+ACCT,2020,3,Managerial Accounting Concepts,0.44,0.24,0.2,0.06,0.03,0.0,0.0,0.03,sarah martin,
+ACCT,2020,4,Managerial Accounting Concepts,0.18,0.32,0.2,0.08,0.08,0.0,0.0,0.14,the estate  guffey,
+ACCT,2020,5,Managerial Accounting Concepts,0.1,0.45,0.19,0.06,0.1,0.0,0.0,0.1,brian todd carver,
+ACCT,2020,7,Managerial Accounting Concepts,0.23,0.42,0.23,0.07,0.02,0.0,0.0,0.02,derek dalton,
+ACCT,2020,8,Managerial Accounting Concepts,0.23,0.34,0.32,0.07,0.02,0.0,0.0,0.02,nancy lee harp,
+ACCT,2020,400,Managerial Accounting Concepts,0.12,0.24,0.25,0.1,0.06,0.0,0.0,0.24,henry anderson,
+ACCT,3030,1,Cost Accounting,0.35,0.4,0.17,0.04,0.04,0.0,0.0,0.0,robin radtke,
+ACCT,3030,2,Cost Accounting,0.4,0.36,0.14,0.05,0.02,0.0,0.0,0.02,robin radtke,
+ACCT,3030,3,Cost Accounting,0.44,0.23,0.17,0.02,0.06,0.0,0.0,0.08,jace garrett,
+ACCT,3030,4,Cost Accounting,0.31,0.31,0.12,0.12,0.0,0.0,0.0,0.15,jace garrett,
+ACCT,3110,1,Intermediate Financial Acct I,0.41,0.32,0.08,0.08,0.08,0.0,0.0,0.03,terry daniel knause,
+ACCT,3110,2,Intermediate Financial Acct I,0.41,0.24,0.15,0.05,0.02,0.0,0.0,0.12,terry daniel knause,
+ACCT,3110,3,Intermediate Financial Acct I,0.39,0.24,0.24,0.06,0.03,0.0,0.0,0.03,terry daniel knause,
+ACCT,3110,4,Intermediate Financial Acct I,0.31,0.45,0.21,0.02,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3110,5,Intermediate Financial Acct I,0.26,0.16,0.21,0.03,0.26,0.0,0.0,0.08,henry anderson,
+ACCT,3110,400,Intermediate Financial Acct I,0.16,0.24,0.12,0.04,0.28,0.0,0.0,0.16,henry anderson,
+ACCT,3120,1,Intermediate Financial Acct II,0.06,0.31,0.29,0.2,0.06,0.0,0.0,0.09,brian todd carver,
+ACCT,3120,2,Intermediate Financial Acct II,0.21,0.31,0.23,0.18,0.05,0.0,0.0,0.03,brian todd carver,
+ACCT,3120,3,Intermediate Financial Acct II,0.08,0.49,0.26,0.13,0.03,0.0,0.0,0.03,jeremy micha vinson,
+ACCT,3120,4,Intermediate Financial Acct II,0.35,0.28,0.23,0.1,0.05,0.0,0.0,0.0,jeremy micha vinson,
+ACCT,3120,5,Intermediate Financial Acct II,0.13,0.58,0.24,0.0,0.0,0.0,0.0,0.05,jeremy micha vinson,
+ACCT,3130,1,Intermediate Fin Acct III,0.31,0.47,0.14,0.0,0.06,0.0,0.0,0.03, russell madray,
+ACCT,3130,2,Intermediate Fin Acct III,0.63,0.21,0.12,0.02,0.0,0.0,0.0,0.02, russell madray,
+ACCT,3130,3,Intermediate Fin Acct III,0.52,0.33,0.12,0.0,0.02,0.0,0.0,0.0, russell madray,
+ACCT,3130,4,Intermediate Fin Acct III,0.56,0.34,0.05,0.0,0.05,0.0,0.0,0.0, russell madray,
+ACCT,3220,2,Accounting Information Systems,0.23,0.5,0.19,0.04,0.04,0.0,0.0,0.0,nancy lee harp,
+ACCT,3220,3,Accounting Information Systems,0.12,0.38,0.24,0.14,0.05,0.0,0.0,0.07,nancy lee harp,
+ACCT,4040,1,Individual Taxation,0.74,0.12,0.03,0.06,0.06,0.0,0.0,0.0,sarah martin,
+ACCT,4040,2,Individual Taxation,0.82,0.08,0.05,0.05,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,3,Individual Taxation,0.21,0.44,0.26,0.05,0.0,0.0,0.0,0.05,derek dalton,
+ACCT,4080,1,Retire & Estate Plan,0.27,0.5,0.18,0.0,0.05,0.0,0.0,0.0,john hine,
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.31,0.44,0.21,0.03,0.03,0.0,0.0,0.0,sally kathr widener,
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.08,0.44,0.32,0.04,0.04,0.0,0.0,0.08,sally kathr widener,
+ACCT,4150,1,Auditing,0.52,0.28,0.2,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,
+ACCT,4150,2,Auditing,0.06,0.44,0.38,0.06,0.0,0.0,0.0,0.06,carl hollingsworth,
+ACCT,8510,1,Tax Research,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8510,2,Tax Research,0.22,0.68,0.08,0.0,0.0,0.0,0.0,0.03,thomas dickens,
+ACCT,8510,3,Tax Research,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8530,1,Adv Acct Problems,0.56,0.38,0.03,0.0,0.0,0.0,0.0,0.03,ralph welton,
+ACCT,8530,2,Adv Acct Problems,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8530,3,Adv Acct Problems,0.62,0.32,0.03,0.0,0.03,0.0,0.0,0.0,suzanne pearse,
+ACCT,8550,1,Gov't and Nonprofit Accounting,0.6,0.37,0.04,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8550,2,Gov't and Nonprofit Accounting,0.65,0.33,0.0,0.0,0.0,0.0,0.0,0.02,james barnes,
+ACCT,8630,1,Forensics Analysis,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,philip maiberger,
+ACCT,8630,2,Forensics Analysis,0.44,0.49,0.05,0.0,0.0,0.0,0.0,0.03,philip maiberger,
+ACCT,8650,1,Tax & Bus Decisions,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
+ACCT,8720,1,Tax of Flowthroughs,0.17,0.43,0.33,0.0,0.07,0.0,0.0,0.0,thomas dickens,
+AGED,1020,1,Freshman Seminar,0.68,0.21,0.07,0.0,0.0,0.0,0.0,0.04,catheri dibenedetto,
+AGED,2010,1,Intro to Agric Educ,0.43,0.24,0.24,0.05,0.05,0.0,0.0,0.0,philip fravel,
+AGED,2040,1,App Ag Calculations,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,3030,1,Ag Ed Mech Tech,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGED,3650,1,Multiculturalism in Agric Educ,0.9,0.03,0.03,0.0,0.03,0.0,0.0,0.0,alex byrd,
+AGED,4030,1,Prin Adult/Ext Ed,0.77,0.09,0.14,0.0,0.0,0.0,0.0,0.0,kevin layfield,
+AGM,1010,1,Intro Ag Mech & Bus,0.41,0.32,0.16,0.04,0.04,0.0,0.0,0.04,hunter massey,
+AGM,2050,1,Prin of Fabrication,0.14,0.57,0.16,0.03,0.07,0.0,0.0,0.03,hunter massey,
+AGM,2060,1,Machinery Mgt,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,hunter massey,
+AGM,2190,1,Agribusiness and Food Systems,0.49,0.4,0.1,0.0,0.01,0.0,0.0,0.0,nicholas gra rogers,
+AGM,2210,1,Land Measurements,0.17,0.32,0.33,0.14,0.03,0.0,0.0,0.01,charles privette,
+AGM,3010,1,Soil Water Conserv,0.44,0.29,0.16,0.06,0.03,0.0,0.0,0.02,calvin sawyer,
+AGM,3710,1,Agric Mechanization Practicum,0.0,0.0,0.0,0.0,0.0,0.89,0.05,0.05,hunter massey,
+AGM,4000,1,Seminar in Ag Mech & Business,0.53,0.31,0.06,0.03,0.03,0.0,0.0,0.03,john chastain,
+AGM,4050,1,Env Cont in Anim Str,0.14,0.46,0.3,0.1,0.0,0.0,0.0,0.0,john chastain,
+AGM,4060,1,Mech & Hydraulic Sys,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4520,1,Mobile Power,0.41,0.41,0.14,0.05,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4600,1,Electrical Systems,0.45,0.36,0.13,0.06,0.0,0.0,0.0,0.0,young han,
+AGM,4730,1,Peanut Harvesting Machinery,0.88,0.0,0.0,0.0,0.12,0.0,0.0,0.0,hunter massey,
+AGRB,2020,1,Agricultural Economics,0.19,0.35,0.23,0.13,0.08,0.0,0.0,0.02,george apperson,
+AGRB,2020,2,Agricultural Economics,0.21,0.31,0.27,0.08,0.08,0.0,0.0,0.04,george apperson,
+AGRB,2050,1,Agriculture and Society,0.42,0.38,0.12,0.04,0.02,0.0,0.0,0.02,michael vassalos,
+AGRB,3020,1,Economics of Farm Management,0.28,0.35,0.27,0.09,0.0,0.0,0.0,0.01,michael vassalos,
+AGRB,3080,1,Quant Agribusiness Analysis I,0.19,0.23,0.32,0.19,0.03,0.0,0.0,0.03,lisha zhang,
+AGRB,3090,1,Econ of Agricultural Marketing,0.83,0.15,0.0,0.0,0.03,0.0,0.0,0.0,yuliya val bolotova,
+AGRB,3570,1,Natural Resources Economics,0.29,0.31,0.18,0.11,0.07,0.0,0.0,0.04,david brian willis,
+AGRB,4090,1,Commodity Futures Markets,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
+AGRB,4120,1,Reg Econ Devel Theory & Policy,0.55,0.3,0.1,0.0,0.05,0.0,0.0,0.0,robert carey,
+AGRB,4600,1,Agricultural Finance,0.33,0.33,0.22,0.11,0.0,0.0,0.0,0.0,lisha zhang,
+AL,3490,400,Principles of Coaching,0.65,0.15,0.12,0.0,0.0,0.0,0.0,0.08,deborah cadorette,
+AL,3490,401,Principles of Coaching,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,402,Principles of Coaching,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,julia wright,
+AL,3490,403,Principles of Coaching,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,clyde keith connor,
+AL,3490,404,Principles of Coaching,0.84,0.08,0.0,0.0,0.0,0.0,0.0,0.08,edmond fry,
+AL,3500,400,Sci Basis I/Ex Phy,0.33,0.08,0.33,0.13,0.04,0.0,0.0,0.08,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.13,0.3,0.22,0.13,0.13,0.0,0.0,0.09,michael godfrey,
+AL,3530,400,Athletic Injuries,0.23,0.27,0.32,0.14,0.0,0.0,0.0,0.05,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.16,0.32,0.37,0.11,0.05,0.0,0.0,0.0,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.42,0.25,0.25,0.08,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.73,0.2,0.0,0.07,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,401,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,Admin/Org of Athletic Programs,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,henry oates,
+AL,3620,400,Psychology of Coaching,0.31,0.31,0.19,0.13,0.06,0.0,0.0,0.0,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.44,0.31,0.13,0.13,0.0,0.0,0.0,0.0,natalie anne carter,
+AL,3620,402,Psychology of Coaching,0.26,0.39,0.26,0.09,0.0,0.0,0.0,0.0,natalie anne carter,
+AL,3740,400,Coaching Football,0.58,0.21,0.04,0.04,0.08,0.0,0.0,0.04,edmond fry,
+AL,3760,400,Coaching Strength/Conditioning,0.61,0.22,0.13,0.04,0.0,0.0,0.0,0.0,edmond fry,
+AL,3760,401,Coaching Strength/Conditioning,0.5,0.3,0.1,0.0,0.05,0.0,0.0,0.05,edmond fry,
+AL,4380,400,Coaching Women,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,4380,402,Coaching the Inner Athlete,0.7,0.17,0.09,0.0,0.04,0.0,0.0,0.0,deborah cadorette,
+AL,8490,400,Athletic Leadership Dev,0.6,0.28,0.08,0.0,0.04,0.0,0.0,0.0,michael godfrey,
+AL,8490,401,Athletic Leadership Dev,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8500,400,Principles Strength and Condit,0.59,0.31,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8650,400,Mkt and Comm Respon Interc Ath,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,misty soles,
+ANTH,2010,1,Introduction to Anthropology,0.49,0.28,0.13,0.02,0.02,0.0,0.0,0.06,yi wu,
+ANTH,2010,2,Introduction to Anthropology,0.07,0.2,0.44,0.15,0.05,0.0,0.0,0.1,john coggeshall,
+ANTH,2010,3,Introduction to Anthropology,0.06,0.35,0.39,0.06,0.1,0.0,0.0,0.05,john coggeshall,
+ANTH,2010,4,Introduction to Anthropology,0.38,0.42,0.09,0.04,0.07,0.0,0.0,0.0,katherine weisensee,
+ANTH,2010,5,Introduction to Anthropology,0.44,0.42,0.08,0.02,0.02,0.0,0.0,0.02,lisa rapaport,
+ANTH,2010,6,Introduction to Anthropology,0.27,0.3,0.18,0.09,0.07,0.0,0.0,0.09,yi wu,
+ANTH,3010,1,Cultural Anthropology,0.09,0.41,0.18,0.14,0.05,0.0,0.0,0.14,john coggeshall,
+ANTH,3320,1,World Archaeology,0.17,0.3,0.22,0.17,0.0,0.0,0.0,0.13,melissa vogel,
+ANTH,3510,1,Biological Anthropology,0.5,0.33,0.06,0.0,0.06,0.0,0.0,0.06,lisa rapaport,
+ANTH,3530,1,Forensic Anthropology,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,katherine weisensee,
+ANTH,4230,1,Women in the Developing World,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,melissa vogel,
+ARCH,1010,1,Intro to Architecture,0.63,0.26,0.04,0.02,0.03,0.0,0.0,0.02,sal hambright-belue,
+ARCH,2040,1,Hist of Modern Arch,0.28,0.42,0.25,0.03,0.03,0.0,0.0,0.0,robert bruhns,
+ARCH,2510,1,Arch Foundations I,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,2510,2,Arch Foundations I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,2510,3,Arch Foundations I,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2510,4,Arch Foundations I,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,james barker,
+ARCH,2510,5,Arch Foundations I,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,2700,1,Structures I,0.36,0.41,0.18,0.0,0.05,0.0,0.0,0.0,dustin gra albright,
+ARCH,3500,1,Intro to Urban Contexts,0.08,0.62,0.31,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,3500,2,Intro to Urban Contexts,0.33,0.33,0.25,0.0,0.08,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,3500,3,Intro to Urban Contexts,0.0,0.17,0.83,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,3500,4,Intro to Urban Contexts,0.17,0.42,0.42,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,4010,1,Architectural Portfolio SENIOR,0.67,0.19,0.05,0.0,0.05,0.0,0.0,0.05,clarissa mendez,
+ARCH,4010,2,Architectural Portfolio JUNIOR,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4010,3,Architectural Portfolio JUNIOR,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,maryam hamidpour,
+ARCH,6120,2,History Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,6990,9,Freehand Drawing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,
+ARCH,8100,1,Visualization I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,8210,1,Research Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8410,1,Arch Studio I,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,peter laurence,
+ARCH,8410,2,Arch Studio I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
+ARCH,8510,1,Design Studio III,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,8510,2,Design Studio III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,8510,3,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8600,1,History/Theory I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,8810,1,Pro Practice Survey,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,
+ARCH,8950,2,A+H Studio: Projects,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ART,1050,1,Foundation Drawing I,0.29,0.57,0.0,0.07,0.07,0.0,0.0,0.0,kathleen ann thum,
+ART,1510,1,Foundations Art I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kymberly ann day,
+ART,2070,1,Beginning Painting,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,todd mcdonald,
+ART,2100,400,Art Appreciation,0.61,0.29,0.04,0.07,0.0,0.0,0.0,0.0,lydia jane dorsey,
+ART,2100,401,Art Appreciation,0.41,0.3,0.19,0.07,0.04,0.0,0.0,0.0,lydia jane dorsey,
+ART,2100,402,Art Appreciation,0.48,0.45,0.07,0.0,0.0,0.0,0.0,0.0,lydia jane dorsey,
+ART,2100,403,Art Appreciation,0.37,0.41,0.11,0.04,0.07,0.0,0.0,0.0,lydia jane dorsey,
+AS,1090,1,Air Force Today I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,
+AS,1090,3,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher mann,
+AS,2090,2,Dev of Air Power I,0.6,0.27,0.07,0.07,0.0,0.0,0.0,0.0,christopher mann,
+AS,2090,3,Dev of Air Power I,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,christopher mann,
+ASL,1010,1,Am Sign Lang I,0.17,0.39,0.28,0.06,0.11,0.0,0.0,0.0,william alton brant,
+ASL,1010,2,Am Sign Lang I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,1010,3,Am Sign Lang I,0.28,0.39,0.11,0.11,0.0,0.0,0.0,0.11,michael alb barrett,
+ASL,1010,4,Am Sign Lang I,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,michael alb barrett,
+ASL,1020,1,Am Sign Lang I,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2010,1,Am Sign Lang II,0.28,0.39,0.22,0.11,0.0,0.0,0.0,0.0,michael alb barrett,
+ASL,2010,2,Am Sign Lang II,0.13,0.19,0.38,0.31,0.0,0.0,0.0,0.0,michael alb barrett,
+ASL,3010,1,Advanced A S L I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,3150,1,Survey Interpreting,0.25,0.42,0.17,0.0,0.0,0.0,0.0,0.17,stephen fitzmaurice,
+ASTR,1010,1,Solar System Astronomy,0.19,0.39,0.17,0.12,0.08,0.0,0.0,0.05,lih-sin the,
+ASTR,1010,2,Solar System Astronomy,0.28,0.36,0.19,0.04,0.06,0.0,0.0,0.07,lih-sin the,
+ASTR,1020,1,Stellar Astronomy,0.39,0.32,0.11,0.06,0.02,0.0,0.0,0.1,amber porter,
+ASTR,1030,1,Solar Systm Astr Lab,0.54,0.27,0.15,0.0,0.04,0.0,0.0,0.0,amber porter,
+ASTR,1030,2,Solar Systm Astr Lab,0.38,0.31,0.04,0.08,0.08,0.0,0.0,0.12,amber porter,
+ASTR,1030,4,Solar Systm Astr Lab,0.6,0.24,0.0,0.08,0.0,0.0,0.0,0.08,amber porter,
+ASTR,1030,5,Solar Systm Astr Lab,0.63,0.17,0.08,0.08,0.0,0.0,0.0,0.04,amber porter,
+ASTR,1030,6,Solar Systm Astr Lab,0.4,0.4,0.05,0.15,0.0,0.0,0.0,0.0,amber porter,
+ASTR,1030,7,Solar Systm Astr Lab,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,amber porter,
+ASTR,1030,8,Solar Systm Astr Lab,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,amber porter,
+ASTR,1030,9,Solar Systm Astr Lab,0.54,0.21,0.08,0.0,0.08,0.0,0.0,0.08,amber porter,
+ASTR,1030,10,Solar Systm Astr Lab,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,amber porter,
+ASTR,1040,1,Stellar Astr Lab,0.52,0.36,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,
+ASTR,1040,2,Stellar Astr Lab,0.14,0.52,0.05,0.0,0.14,0.0,0.0,0.14,amber porter,
+ASTR,1040,4,Stellar Astr Lab,0.46,0.42,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,
+AUD,1850,1,Intro to Audio Tech,0.18,0.73,0.09,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUD,2800,1,Sound Reinforcement,0.09,0.36,0.45,0.0,0.09,0.0,0.0,0.0,kenneth moore,
+AUE,8270,5,Auto Cntrl Sys Des,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8280,1,Driveline/Powertrain,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8330,30,Auto Manuf Proc Devl,0.47,0.51,0.03,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8350,100,Auto Electronics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,
+AUE,8670,1,Veh Manuf Proc I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8800,2,Vehicle Project Mngt,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett,
+AUE,8810,3,Automotive Systems Overview,0.37,0.6,0.02,0.0,0.01,0.0,0.0,0.0,david wil schmueser,
+AUE,8830,9,Applied Integration,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8870,8,Meth Vehicle Testing,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8930,13,Engine Analysis,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8930,14,Advanced Composites,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
+AUE,8930,16,Light-Weight Automotive Design,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,david wil schmueser,
+AUE,8930,17,Hybrids,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,simona onori,
+AUE,8930,18,Adv IC Engine Concept,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,8930,78,Ground Vehicle Performance,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8930,100,Slide Mode Controls,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AVS,1000,1,Orientation to AVS,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
+AVS,1500,1,Intro Animal Science,0.19,0.57,0.19,0.02,0.01,0.0,0.0,0.02,marie owens bolt,
+AVS,1510,1,Intro Ani Sci Lab,0.65,0.23,0.04,0.0,0.0,0.0,0.0,0.08,richelle lor miller,
+AVS,1510,2,Intro Ani Sci Lab,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,1510,3,Intro Ani Sci Lab,0.6,0.32,0.0,0.0,0.0,0.0,0.0,0.08,richelle lor miller,
+AVS,1510,4,Intro Ani Sci Lab,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,louisa elaine koch,
+AVS,1510,5,Intro Ani Sci Lab,0.21,0.67,0.13,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
+AVS,1510,6,Intro Ani Sci Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,1510,7,Intro Ani Sci Lab,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,brandon michae koch,
+AVS,1510,8,Intro Ani Sci Lab,0.29,0.5,0.07,0.07,0.0,0.0,0.0,0.07,marie owens bolt,
+AVS,2030,1,Dairy Sci Techniques,0.95,0.0,0.02,0.02,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,2040,1,Horse Care Techniques,0.44,0.46,0.1,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,2060,1,Swine Techniques,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3010,1,Anat & Phys Dom Ani,0.46,0.19,0.17,0.12,0.03,0.0,0.0,0.04,glenn birrenkott,
+AVS,3010,400,Anat & Phys Dom Ani,0.46,0.27,0.15,0.12,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,3020,1,Livestk Sel Eval I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3090,1,Equine Evaluation,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,3100,1,Animal Health,0.68,0.22,0.07,0.01,0.01,0.0,0.0,0.0,thomas scott,
+AVS,3700,1,Principles of Animal Nutrition,0.64,0.2,0.09,0.04,0.02,0.0,0.0,0.01,james ro strickland,
+AVS,3750,1,Applied Animal Nutrition,0.19,0.42,0.25,0.11,0.0,0.0,0.0,0.03,gustavo jos lascano,
+AVS,4000,1,AVS Professional Development,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,johanna joh lascano,
+AVS,4000,2,AVS Professional Development,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
+AVS,4060,1,Seminars & Related Topics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4060,2,Seminars & Related Topics,0.41,0.52,0.03,0.0,0.0,0.0,0.0,0.03,jeryl jones,
+AVS,4150,1,Contemporary Issues in AVS,0.06,0.39,0.38,0.08,0.05,0.0,0.0,0.05,peter skewes,
+AVS,4160,1,Equine Exercise Phys,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,4530,1,Animal Reproduction,0.48,0.34,0.11,0.05,0.02,0.0,0.0,0.0,tiffany wilmoth,
+AVS,8200,1,Graduate Seminar,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,
+BCHM,1030,1,Careers in Bioch/Gen,0.68,0.24,0.01,0.06,0.0,0.0,0.0,0.01,alison starr-moss,
+BCHM,3010,1,Molecular Biochem,0.26,0.49,0.2,0.0,0.0,0.0,0.0,0.06,kerry smith,
+BCHM,3050,1,Essen Elements Bioch,0.21,0.33,0.25,0.11,0.02,0.0,0.0,0.08,srik chandrasekaran,
+BCHM,3050,2,Essen Elements Bioch,0.28,0.35,0.22,0.07,0.03,0.0,0.0,0.05,srik chandrasekaran,
+BCHM,4310,1,Physical Approach to Biochem,0.11,0.55,0.28,0.02,0.04,0.0,0.0,0.0,weiguo cao,
+BCHM,4310,2,Phys App to Bioch (HON),0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,True
+BCHM,4330,1,Physical Biochemistry Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,weiguo cao,
+BCHM,4330,3,Physical Biochemistry Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,weiguo cao,
+BCHM,4330,4,Physical Biochemistry Lab,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,weiguo cao,
+BCHM,4400,1,Bioinformatics,0.78,0.15,0.0,0.07,0.0,0.0,0.0,0.0,frank alexan feltus,
+BCHM,4430,1,Mol Basis Disease,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,james morris,
+BCHM,4900,7,C-MED,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,michael glen sehorn,
+BCHM,4930,1,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,
+BE,2120,1,Fundamentals of Biosys Engr,0.55,0.4,0.0,0.0,0.05,0.0,0.0,0.0,caye marie drapcho,
+BE,3200,1,Principles & Prac of Geomatics,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,tom owino,
+BE,4100,1,Biological Kinetics,0.38,0.29,0.33,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,4210,1,Engr Sys Sw Mgmt,0.59,0.35,0.0,0.0,0.06,0.0,0.0,0.0,christophe darnault,
+BE,4280,1,Biochem Engr,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,terry walker,
+BE,4740,1,B E Design/Proj Mgt,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,tom owino,
+BE,4750,1,B E Capstone Design,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BIOE,1010,1,Biol for Bioengr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,vladimir vla reukov,
+BIOE,2010,1,Intro Biomed Engr,0.82,0.16,0.02,0.0,0.0,0.0,0.0,0.0,charles webb,
+BIOE,2010,2,Intro Biomed Engr,0.76,0.21,0.01,0.0,0.0,0.0,0.0,0.01,frank alexis,
+BIOE,3020,1,Biomaterials,0.57,0.23,0.04,0.02,0.06,0.0,0.0,0.09,alexey ale vertegel,
+BIOE,3200,1,Biomechanics,0.79,0.17,0.02,0.0,0.02,0.0,0.0,0.0,lisa benson,
+BIOE,3210,1,Biofluid Mechanics,0.46,0.38,0.14,0.0,0.0,0.0,0.0,0.03,zhi gao,
+BIOE,3700,1,Bioinst & Imaging,0.64,0.27,0.07,0.0,0.0,0.0,0.0,0.02,delphine dean,
+BIOE,4010,1,Bioengineering Design Theory,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4010,2,Bioengineering Design Theory,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4030,1,Applied Bio E Design,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
+BIOE,4120,1,Orthopaedic Engr and Pathology,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,melinda harman,
+BIOE,4500,3,Biofabrication,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
+BIOE,6120,1,Orthopaedic Engr & Pathology,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,melinda harman,
+BIOE,6400,1,Biopharmaceutical Engineering,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,sarah harcum,
+BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,martine laberge,
+BIOE,8010,1,Bio Materials,0.33,0.6,0.03,0.0,0.03,0.0,0.0,0.0,robert latour,
+BIOE,8600,401,Biomed Engr Design Innovation,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
+BIOL,1010,1,Frontiers in Biology I,0.8,0.1,0.06,0.02,0.01,0.0,0.0,0.01,robert edwa ballard,
+BIOL,1010,2,Frontiers in Biology I,0.55,0.27,0.11,0.03,0.04,0.0,0.0,0.0,thomas hughes,
+BIOL,1030,1,General Biology I,0.23,0.28,0.22,0.11,0.1,0.0,0.0,0.07,nora espinoza,
+BIOL,1030,2,General Biology I,0.11,0.27,0.31,0.18,0.07,0.0,0.0,0.07,william baldwin,
+BIOL,1030,3,General Biology I,0.26,0.3,0.22,0.1,0.07,0.0,0.0,0.06,william surver,
+BIOL,1030,4,General Biology I,0.14,0.26,0.32,0.12,0.08,0.0,0.0,0.08,salvatore sparace,
+BIOL,1030,5,General Biology I (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
+BIOL,1050,1,General Biology Lab I,0.17,0.33,0.25,0.08,0.08,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,2,General Biology Lab I,0.17,0.29,0.25,0.17,0.0,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,3,General Biology Lab I,0.04,0.26,0.26,0.17,0.09,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,4,General Biology Lab I,0.29,0.17,0.33,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,5,General Biology Lab I,0.04,0.13,0.3,0.3,0.04,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,6,General Biology Lab I,0.08,0.21,0.17,0.38,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,7,General Biology Lab I,0.1,0.14,0.19,0.33,0.14,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1050,8,General Biology Lab I,0.1,0.25,0.35,0.1,0.05,0.0,0.0,0.15,tafadzwa kaisa,
+BIOL,1050,9,General Biology Lab I,0.09,0.22,0.35,0.22,0.04,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,10,General Biology Lab I,0.04,0.5,0.42,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,11,General Biology Lab I,0.17,0.33,0.33,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,12,General Biology Lab I,0.04,0.29,0.25,0.29,0.13,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,13,General Biology Lab I,0.13,0.5,0.17,0.08,0.13,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,14,General Biology Lab I,0.21,0.38,0.29,0.08,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,15,General Biology Lab I,0.26,0.22,0.3,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,16,General Biology Lab I,0.17,0.42,0.29,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,17,General Biology Lab I,0.17,0.29,0.25,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,18,General Biology Lab I,0.08,0.38,0.33,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,19,General Biology Lab I,0.26,0.17,0.13,0.26,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,20,General Biology Lab I,0.08,0.13,0.38,0.21,0.13,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,21,General Biology Lab I,0.08,0.21,0.29,0.13,0.25,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,22,General Biology Lab I,0.13,0.42,0.17,0.17,0.08,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,23,General Biology Lab I,0.25,0.42,0.08,0.17,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,24,General Biology Lab I,0.21,0.29,0.25,0.08,0.08,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,25,General Biology Lab I,0.0,0.17,0.3,0.22,0.22,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,26,General Biology Lab I,0.21,0.29,0.17,0.21,0.08,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,27,General Biology Lab I,0.08,0.29,0.29,0.29,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,28,General Biology Lab I,0.04,0.46,0.17,0.17,0.08,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,29,General Biology Lab I,0.04,0.35,0.22,0.22,0.09,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,30,General Biology Lab I,0.21,0.25,0.29,0.21,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,31,General Biology Lab I,0.0,0.15,0.25,0.2,0.25,0.0,0.0,0.15,tafadzwa kaisa,
+BIOL,1050,32,General Biology Lab I,0.25,0.31,0.13,0.25,0.06,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,33,General Biology Lab I,0.0,0.15,0.4,0.15,0.15,0.0,0.0,0.15,tafadzwa kaisa,
+BIOL,1050,34,General Biology Lab I,0.17,0.5,0.08,0.21,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,35,General Biology Lab I,0.29,0.29,0.29,0.13,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,36,General Biology Lab I,0.21,0.29,0.38,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,37,General Biology Lab I,0.21,0.33,0.21,0.13,0.08,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,38,General Biology Lab I,0.08,0.5,0.33,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,39,General Biology Lab I,0.14,0.45,0.23,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,40,General Biology Lab I,0.38,0.17,0.25,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,41,General Biology Lab I,0.13,0.42,0.29,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,42,General Biology Lab I,0.09,0.39,0.39,0.0,0.04,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,43,General Biology Lab I,0.04,0.21,0.33,0.25,0.08,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,44,General Biology Lab I,0.21,0.21,0.38,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,45,General Biology Lab I,0.04,0.43,0.22,0.22,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,46,General Biology Lab I,0.12,0.28,0.4,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1090,1,Intro to Life Sci,0.78,0.18,0.05,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
+BIOL,1100,1,Principles of Biology I,0.12,0.43,0.28,0.07,0.03,0.0,0.0,0.07,robert kosinski,
+BIOL,1100,2,Principles of Biology I,0.48,0.37,0.06,0.03,0.05,0.0,0.0,0.02,dylan dittrich-reed,
+BIOL,1100,3,Prin of Biology I (HON),0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,robert kosinski,True
+BIOL,1100,4,Prin of Biology I (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True
+BIOL,1100,5,Principles of Biology I,0.48,0.43,0.08,0.03,0.0,0.0,0.0,0.0,dylan dittrich-reed,
+BIOL,1200,1,Biological Inq Lab,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,2,Biological Inq Lab,0.59,0.24,0.12,0.0,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1200,3,Biological Inq Lab,0.5,0.28,0.11,0.0,0.06,0.0,0.0,0.06, christine minor,
+BIOL,1200,4,Biological Inq Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,5,Biological Inq Lab,0.61,0.22,0.11,0.06,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,6,Biological Inq Lab,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,7,Biological Inq Lab,0.45,0.45,0.0,0.1,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,8,Biological Inq Lab,0.39,0.28,0.22,0.06,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1200,9,Biological Inq Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,11,Biological Inq Lab,0.41,0.47,0.06,0.0,0.06,0.0,0.0,0.0, christine minor,
+BIOL,1200,12,Biological Inq Lab,0.5,0.22,0.17,0.06,0.06,0.0,0.0,0.0, christine minor,
+BIOL,1200,13,Biological Inq Lab,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,14,Biological Inq Lab,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1200,15,Biological Inq Lab,0.56,0.28,0.06,0.06,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1230,1,Keys to Human Biol,0.28,0.37,0.24,0.06,0.04,0.0,0.0,0.01, christine minor,
+BIOL,1230,2,Keys to Human Biol,0.28,0.38,0.19,0.08,0.02,0.0,0.0,0.04, christine minor,
+BIOL,2000,2,Biology in the News,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,2000,6,Biology in the News,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,william surver,
+BIOL,2040,1,"Environ, Energy and Society",0.73,0.14,0.05,0.02,0.0,0.0,0.0,0.05,john jenkins hains,
+BIOL,2040,2,"Environ, Energy and Society",0.68,0.14,0.05,0.03,0.0,0.0,0.0,0.11,john jenkins hains,
+BIOL,2110,1,Introduction to Toxicology,0.45,0.42,0.1,0.0,0.03,0.0,0.0,0.0,peter van den hurk,
+BIOL,2220,1,Human Anat and Physiology I,0.18,0.32,0.24,0.08,0.09,0.0,0.0,0.09,john cummings,
+BIOL,2220,2,Human Anat and Physiology I,0.27,0.4,0.15,0.08,0.03,0.0,0.0,0.07,john cummings,
+BIOL,3030,1,Vertebrate Biology,0.29,0.25,0.25,0.15,0.03,0.0,0.0,0.03,richard blob,
+BIOL,3030,2,Vertebrate Biology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True
+BIOL,3040,1,Biology of Plants,0.46,0.22,0.22,0.03,0.03,0.0,0.0,0.03,christina wells,
+BIOL,3070,1,Vertebrate Biology Lab,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,2,Vertebrate Biology Lab,0.7,0.15,0.1,0.05,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,3,Vertebrate Biology Lab,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,4,Vertebrate Biology Lab,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,5,Vertebrate Biology Lab,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,6,Vertebrate Biology Lab,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,7,Vertebrate Biology Lab,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,8,Vertebrate Biology Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,9,Vertebrate Biology Lab,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,10,Vertebrate Biology Lab,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,11,Vertebrate Biology Lab,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,12,Vertebrate Biology Lab,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,13,Vertebrate Biology Lab,0.25,0.5,0.2,0.05,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,14,Vertebrate Biology Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3080,1,Biology of Plants Practicum,0.5,0.25,0.15,0.05,0.0,0.0,0.0,0.05,christina wells,
+BIOL,3080,2,Biology of Plants Practicum,0.15,0.55,0.2,0.05,0.0,0.0,0.0,0.05,christina wells,
+BIOL,3080,3,Biology of Plants Practicum,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,christina wells,
+BIOL,3080,4,Biology of Plants Practicum,0.11,0.39,0.33,0.06,0.06,0.0,0.0,0.06,christina wells,
+BIOL,3150,1,Functional Human Anatomy,0.23,0.4,0.23,0.07,0.02,0.0,0.0,0.05,tamara mcnutt-scott,
+BIOL,3200,1,Field Botany,0.21,0.21,0.21,0.24,0.03,0.0,0.0,0.1,robert edwa ballard,
+BIOL,3350,1,Evolutionary Biology,0.26,0.44,0.2,0.07,0.02,0.0,0.0,0.01,margaret ptacek,
+BIOL,3510,1,Biological Anthropology,0.33,0.47,0.07,0.07,0.07,0.0,0.0,0.0,lisa rapaport,
+BIOL,3530,1,Forensic Anthropology,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
+BIOL,4140,1,Basic Immunology,0.12,0.29,0.41,0.12,0.0,0.0,0.0,0.06,yanzhang wei,
+BIOL,4200,1,Neurobiology,0.51,0.44,0.05,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4250,1,Introductory Mycology,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,julia loui kerrigan,
+BIOL,4260,1,Mycology Practicum,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,
+BIOL,4340,1,Biological Chem Lab Techniques,0.18,0.27,0.18,0.36,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,2,Biological Chem Lab Techniques,0.15,0.15,0.46,0.15,0.08,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,3,Biological Chem Lab Techniques,0.0,0.64,0.21,0.07,0.07,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,4,Biological Chem Lab Techniques,0.0,0.15,0.54,0.15,0.08,0.0,0.0,0.08,salvatore sparace,
+BIOL,4410,1,Ecology,0.21,0.26,0.35,0.12,0.0,0.0,0.0,0.06,david tonkyn,
+BIOL,4430,1,Freshwater Ecology,0.61,0.31,0.05,0.01,0.0,0.0,0.0,0.02,john jenkins hains,
+BIOL,4440,2,Freshwater Ecology Lab (Lec),0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,john jenkins hains,
+BIOL,4450,2,Ecology Laboratory (Lec),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
+BIOL,4610,1,Cell Biology,0.31,0.42,0.21,0.04,0.01,0.0,0.0,0.01,susan carol chapman,
+BIOL,4610,2,Cell Biology (HON),0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True
+BIOL,4620,2,Cell Biology Lab (Lec),0.54,0.42,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,3,Cell Biology Lab (Lec),0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,4,Cell Biology Lab (Lec),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,7,Cell Biology Lab (Lec),0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,8,Cell Biology Lab (Lec),0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
+BIOL,4670,1,Principles of Hematology,0.89,0.04,0.0,0.0,0.07,0.0,0.0,0.0,vincent gallicchio,
+BIOL,4930,3,Senior Seminar,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
+BIOL,4930,6,Senior Seminar,0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,kara elizabe powder,
+BIOL,6030,1,Intro to Applied Genomics,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,vincent pa richards,
+BIOL,8200,1,Community Ecology,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,saara dewalt,
+BIOL,8400,1,Understanding Biological Inq,0.82,0.09,0.02,0.0,0.05,0.0,0.0,0.03,michael childress,
+BIOL,8420,1,Understand Cellular Processes,0.45,0.39,0.11,0.0,0.03,0.0,0.0,0.01,patricia leota tate,
+BIOL,8440,1,Understanding the Human Body,0.6,0.29,0.08,0.0,0.02,0.0,0.0,0.01,william baldwin,
+BIOL,8480,1,Understanding Scientific Rsrch,0.9,0.0,0.0,0.0,0.06,0.0,0.0,0.03,robert edwa ballard,
+BUS,1010,1,Business Foundations,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,2,Business Foundations,0.32,0.47,0.11,0.05,0.05,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,3,Business Foundations,0.63,0.21,0.0,0.05,0.05,0.0,0.0,0.05,william ern tumblin,
+BUS,1010,4,Business Foundations,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,5,Business Foundations,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,6,Business Foundations,0.42,0.37,0.05,0.0,0.16,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,7,Business Foundations,0.44,0.33,0.11,0.06,0.0,0.0,0.0,0.06,william ern tumblin,
+BUS,1010,8,Business Foundations,0.0,0.58,0.21,0.05,0.11,0.0,0.0,0.05,william ern tumblin,
+BUS,1010,9,Business Foundations,0.37,0.32,0.11,0.05,0.05,0.0,0.0,0.11,william ern tumblin,
+BUS,1010,10,Business Foundations,0.58,0.21,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
+BUS,1010,11,Business Foundations,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,12,Business Foundations,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,james mullinax,
+BUS,1010,13,Business Foundations,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,14,Business Foundations,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,15,Business Foundations,0.41,0.24,0.29,0.06,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,16,Business Foundations,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,17,Business Foundations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,18,Business Foundations,0.17,0.33,0.33,0.06,0.06,0.0,0.0,0.06,donna mccubbin,
+BUS,1010,19,Business Foundations,0.22,0.5,0.17,0.06,0.06,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,20,Business Foundations,0.33,0.17,0.39,0.06,0.0,0.0,0.0,0.06,donna mccubbin,
+BUS,1010,21,Business Foundations,0.42,0.35,0.12,0.07,0.02,0.0,0.0,0.02,donna mccubbin,
+BUS,1010,22,Business Foundations,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,23,Business Foundations,0.44,0.28,0.11,0.06,0.0,0.0,0.0,0.11,sandy edge,
+BUS,1010,24,Business Foundations,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,sandy edge,
+BUS,1010,25,Business Foundations,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,26,Business Foundations,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,27,Business Foundations,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,28,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
+BUS,1010,29,Business Foundations,0.19,0.36,0.23,0.11,0.04,0.0,0.0,0.06,michael mendonca,
+BUS,1010,30,Business Foundations,0.23,0.43,0.3,0.02,0.02,0.0,0.0,0.0,michael mendonca,
+BUS,1010,31,Business Foundations,0.21,0.53,0.16,0.05,0.0,0.0,0.0,0.05,michael mendonca,
+BUS,1010,33,Business Foundations,0.55,0.34,0.07,0.0,0.0,0.0,0.0,0.03,james mullinax,
+BUS,1010,34,Business Foundations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
+CE,1990,2,Cr Inq in Civil Engineering,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,weichiang pang,
+CE,2010,1,Statics,0.18,0.28,0.18,0.0,0.05,0.0,0.0,0.33,melissa sternhagen,
+CE,2010,2,Statics,0.12,0.29,0.31,0.1,0.12,0.0,0.0,0.07,melissa sternhagen,
+CE,2010,3,Statics,0.34,0.31,0.16,0.09,0.07,0.0,0.0,0.03,qiushi chen,
+CE,2010,4,Statics,0.23,0.3,0.23,0.05,0.05,0.0,0.0,0.14,melissa sternhagen,
+CE,2010,5,Statics,0.23,0.33,0.16,0.05,0.12,0.0,0.0,0.12,"rashidian dezfouli,",
+CE,2010,6,Statics,0.12,0.35,0.19,0.07,0.14,0.0,0.0,0.14,melissa sternhagen,
+CE,2010,7,Statics (HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,melissa sternhagen,True
+CE,2060,1,Structural Mechanics,0.19,0.35,0.25,0.14,0.02,0.0,0.0,0.05,bryant nielson,
+CE,2080,1,Dynamics,0.13,0.25,0.3,0.18,0.07,0.0,0.0,0.07,nigel gregory kaye,
+CE,2550,1,Geomatics,0.34,0.52,0.1,0.02,0.01,0.0,0.0,0.01,wayne sarasua,
+CE,3010,1,Structural Analysis,0.32,0.26,0.24,0.12,0.03,0.0,0.0,0.03,stephen csernak,
+CE,3010,2,Structural Analysis,0.4,0.28,0.25,0.08,0.0,0.0,0.0,0.0,bryant nielson,
+CE,3110,1,Transportation Engr,0.58,0.33,0.07,0.0,0.02,0.0,0.0,0.0,jennifer ogle,
+CE,3210,1,Geotechnical Engineering,0.42,0.24,0.32,0.0,0.03,0.0,0.0,0.0,qiushi chen,
+CE,3310,1,Constr Engr & Mgmnt,0.4,0.32,0.2,0.04,0.01,0.0,0.0,0.04,james burati,
+CE,3410,1,Intro to Fluid Mech,0.26,0.44,0.26,0.04,0.0,0.0,0.0,0.0,nigel gregory kaye,
+CE,3410,2,Intro to Fluid Mech,0.27,0.36,0.22,0.07,0.05,0.0,0.0,0.02,abdul khan,
+CE,3420,1,Hydraulics & Hydro,0.43,0.43,0.15,0.0,0.0,0.0,0.0,0.0,ashok mishra,
+CE,3510,1,Civil Engineering Materials,0.55,0.43,0.0,0.0,0.0,0.0,0.0,0.03,ami esmaeilpoursaee,
+CE,3510,2,Civil Engineering Materials,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kimberly rene lyons,
+CE,3520,1,Econ Eval of Proj,0.32,0.29,0.2,0.05,0.05,0.0,0.0,0.08,zoraya rolda rockow,
+CE,4010,1,Matrix Str Analysis,0.74,0.15,0.07,0.0,0.04,0.0,0.0,0.0,atamturktur russcher,
+CE,4020,1,Reinfor Con Design,0.27,0.5,0.07,0.07,0.0,0.0,0.0,0.1,thomas edfo cousins,
+CE,4060,1,Struct Steel Design,0.31,0.47,0.14,0.06,0.02,0.0,0.0,0.0,stephen csernak,
+CE,4100,1,Traffic Engr Oper,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,sakib khan,
+CE,4240,1,Earth Slopes & Struc,0.3,0.35,0.3,0.0,0.03,0.0,0.0,0.03,nadara ravichandran,
+CE,4330,1,Const Plan & Sched,0.41,0.41,0.15,0.02,0.0,0.0,0.0,0.0,steve richa sanders,
+CE,4370,2,Sustainable Energy Proj Design,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
+CE,4390,1,Con Eqpmt Sel & Main,0.41,0.46,0.1,0.0,0.0,0.0,0.0,0.02,james burati,
+CE,4460,1,Flood Haz & Prot Des,0.19,0.5,0.25,0.0,0.0,0.0,0.0,0.06,nadim aziz,
+CE,4560,1,Pave Design & Constr,0.39,0.59,0.0,0.0,0.0,0.0,0.0,0.02,bradley putman,
+CE,4590,1,Capstone Design Proj,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4910,1,BIM in Construction Management,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,kalyan ram piratla,
+CE,6010,1,Matrix Str Analysis,0.71,0.18,0.0,0.0,0.12,0.0,0.0,0.0,atamturktur russcher,
+CE,6100,1,Traffic Engr Oper,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CE,6330,1,Const Plan & Sched,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+CE,6370,2,Sustainable Energy Proj Design,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
+CE,6460,1,Flood Haz & Prot Des,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,nadim aziz,
+CE,6910,1,BIM in Construction Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,8040,1,Prestressed Concrete,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,brandon ross,
+CE,8050,1,Adv Struc Mech,0.29,0.5,0.0,0.0,0.0,0.0,0.0,0.21,bryant nielson,
+CE,8080,1,Earthquake Engr,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CE,8220,1,Foundation Engr,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,8230,1,Asphalt Conc Prop,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,
+CE,8240,1,Infrastructure Corrosion,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,
+CE,8540,1,Travl Demnd Forecast,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
+CE,8570,500,Uncertainty Modeling Risk Engr,0.63,0.26,0.04,0.0,0.0,0.0,0.0,0.07,bryant nielson,
+CE,8930,3,Automated Vehicle System,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CH,1010,1,General Chemistry,0.22,0.35,0.3,0.06,0.05,0.0,0.0,0.01,tania issa houjeiry,
+CH,1010,2,General Chemistry,0.1,0.35,0.28,0.09,0.09,0.0,0.0,0.08,princess mycia cox,
+CH,1010,3,General Chemistry,0.26,0.37,0.19,0.06,0.09,0.0,0.0,0.03,thomas hickman,
+CH,1010,4,General Chemistry,0.19,0.27,0.26,0.12,0.11,0.0,0.0,0.04,dennis taylor,
+CH,1010,5,General Chemistry,0.19,0.38,0.22,0.12,0.04,0.0,0.0,0.04,princess mycia cox,
+CH,1010,6,General Chemistry,0.2,0.34,0.25,0.1,0.08,0.0,0.0,0.03,dennis taylor,
+CH,1010,7,General Chemistry,0.05,0.3,0.39,0.1,0.12,0.0,0.0,0.05,william mcwhorter,
+CH,1010,8,General Chemistry,0.23,0.27,0.28,0.1,0.08,0.0,0.0,0.04,dennis taylor,
+CH,1010,9,General Chemistry,0.13,0.34,0.27,0.14,0.1,0.0,0.0,0.03,olt geiculescu,
+CH,1010,10,General Chemistry,0.07,0.32,0.31,0.16,0.1,0.0,0.0,0.04,william mcwhorter,
+CH,1010,11,General Chemistry,0.16,0.33,0.3,0.13,0.07,0.0,0.0,0.01,william mcwhorter,
+CH,1010,12,General Chemistry,0.24,0.41,0.24,0.05,0.05,0.0,0.0,0.01,tania issa houjeiry,
+CH,1010,13,General Chemistry,0.21,0.29,0.25,0.1,0.09,0.0,0.0,0.05,laura lanni,
+CH,1010,14,General Chemistry,0.16,0.38,0.24,0.13,0.05,0.0,0.0,0.03,elliot ennis,
+CH,1010,20,General Chemistry,0.29,0.37,0.24,0.05,0.03,0.0,0.0,0.02,tania issa houjeiry,
+CH,1010,21,General Chemistry,0.2,0.41,0.22,0.05,0.09,0.0,0.0,0.03,elliot ennis,
+CH,1010,22,General Chemistry,0.17,0.37,0.28,0.12,0.05,0.0,0.0,0.01,laura lanni,
+CH,1010,50,General Chemistry,0.17,0.38,0.38,0.04,0.04,0.0,0.0,0.0,shiou-jyh hwu,
+CH,1010,51,General Chemistry (HON),0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,william pennington,True
+CH,1010,52,General Chemistry (HON),0.62,0.32,0.05,0.0,0.0,0.0,0.0,0.0,joseph stu thrasher,True
+CH,1010,501,General Chemistry,0.44,0.29,0.27,0.0,0.0,0.0,0.0,0.0,brian gloor,
+CH,1020,1,General Chemistry,0.3,0.3,0.25,0.1,0.04,0.0,0.0,0.02,stephe schvaneveldt,
+CH,1020,2,General Chemistry,0.28,0.34,0.13,0.11,0.09,0.0,0.0,0.05,stephe schvaneveldt,
+CH,1020,3,General Chemistry,0.24,0.34,0.23,0.09,0.06,0.0,0.0,0.03,stephe schvaneveldt,
+CH,1020,400,General Chemistry,0.08,0.08,0.41,0.25,0.11,0.0,0.0,0.08,stephe schvaneveldt,
+CH,1050,1,Chemistry in Context I,0.27,0.56,0.16,0.01,0.01,0.0,0.0,0.0,olt geiculescu,
+CH,1050,2,Chemistry in Context I,0.35,0.43,0.15,0.05,0.01,0.0,0.0,0.01,olt geiculescu,
+CH,2010,1,Survey of Organic Chemistry,0.29,0.3,0.23,0.09,0.06,0.0,0.0,0.03,thomas hickman,
+CH,2010,2,Survey of Organic Chemistry,0.31,0.39,0.22,0.02,0.04,0.0,0.0,0.0,thomas hickman,
+CH,2020,1,Surv of Organic Chemistry Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,sean 'connor,
+CH,2020,2,Surv of Organic Chemistry Lab,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2020,3,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2020,5,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2020,7,Surv of Organic Chemistry Lab,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2020,8,Surv of Organic Chemistry Lab,0.6,0.2,0.07,0.0,0.07,0.0,0.0,0.07,sean 'connor,
+CH,2230,1,Organic Chemistry,0.32,0.34,0.12,0.13,0.04,0.0,0.0,0.05,modi wetzler,
+CH,2230,2,Organic Chemistry,0.41,0.31,0.13,0.06,0.06,0.0,0.0,0.03,modi wetzler,
+CH,2230,3,Organic Chemistry,0.24,0.33,0.26,0.06,0.06,0.0,0.0,0.04,jacob schroeder,
+CH,2230,4,Organic Chemistry,0.37,0.31,0.18,0.06,0.04,0.0,0.0,0.04,laura lanni,
+CH,2230,5,Organic Chemistry,0.28,0.39,0.17,0.05,0.09,0.0,0.0,0.01,elliot ennis,
+CH,2230,6,Organic Chemistry,0.32,0.27,0.13,0.08,0.11,0.0,0.0,0.08,rhett smith,
+CH,2230,7,Organic Chemistry,0.23,0.36,0.21,0.06,0.07,0.0,0.0,0.08,dev priya arya,
+CH,2240,1,Organic Chemistry,0.24,0.37,0.16,0.08,0.05,0.0,0.0,0.1,jacob schroeder,
+CH,2240,2,Organic Chemistry,0.29,0.38,0.16,0.09,0.06,0.0,0.0,0.02,jacob schroeder,
+CH,2270,1,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,3,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,4,Organic Chem Lab,0.69,0.13,0.06,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,8,Organic Chem Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,12,Organic Chem Lab,0.81,0.0,0.13,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2270,14,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,15,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,19,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,21,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,26,Organic Chem Lab,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,28,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,29,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,30,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,31,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,32,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,34,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,35,Organic Chem Lab,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,4,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
+CH,2280,5,Organic Chem Lab,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,6,Organic Chem Lab,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,sean 'connor,
+CH,2280,7,Organic Chem Lab,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,8,Organic Chem Lab,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
+CH,2280,9,Organic Chem Lab,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15,sean 'connor,
+CH,2280,10,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,3130,1,Quantitative Analys,0.49,0.24,0.16,0.03,0.0,0.0,0.0,0.08,stephen creager,
+CH,3300,1,Intro to Phys Chem,0.29,0.43,0.21,0.06,0.0,0.0,0.0,0.01,brian dominy,
+CH,3310,1,Physical Chemistry,0.38,0.19,0.19,0.19,0.0,0.0,0.0,0.06,jason mcneill,
+CH,3310,2,Physical Chemistry,0.25,0.25,0.21,0.08,0.17,0.0,0.0,0.04,leah bec casabianca,
+CH,3320,1,Physical Chemistry,0.18,0.41,0.32,0.0,0.05,0.0,0.0,0.05,arkady kholodenko,
+CH,3390,2,Physical Chem Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,3,Physical Chem Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,4,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,4010,1,Organometallic Chemistry,0.58,0.33,0.03,0.0,0.03,0.0,0.0,0.03,andrew gre tennyson,
+CH,4020,1,Inorganic Chemistry,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,joseph kolis,
+CH,4210,1,Advanced Organic Chemistry,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,daniel whitehead,
+CH,8070,1,Chem Trans Elem,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
+CH,8090,1,Chem App/X-Ray Cryst,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,
+CH,8120,1,Chemical Spectroscopic Methods,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,george chumanov,
+CH,8150,1,Mass Spectrometry,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,richard marcus,
+CH,8210,1,Organic Chem I,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0, karl dieter,
+CH,8300,1,Fund Phys Chem,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,
+CH,8510,1,Grad Student Seminar,0.71,0.24,0.03,0.0,0.03,0.0,0.0,0.0,joseph stu thrasher,
+CH,8510,2,Grad Student Seminar,0.91,0.03,0.0,0.0,0.0,0.0,0.0,0.06,steven stuart,
+CHE,2110,1,Mass and Energy Balances,0.24,0.2,0.24,0.08,0.2,0.0,0.0,0.04,mark roberts,
+CHE,2110,2,Mass and Energy Balances,0.28,0.43,0.13,0.03,0.07,0.0,0.0,0.04,mark roberts,
+CHE,3210,1,Ch E Thermo II,0.14,0.14,0.35,0.21,0.12,0.0,0.0,0.05,sapna sarupria,
+CHE,3210,2,Ch E Thermo II,0.2,0.31,0.23,0.17,0.09,0.0,0.0,0.0,sapna sarupria,
+CHE,3300,1,Mass Trans & Seprtn,0.19,0.15,0.43,0.06,0.09,0.0,0.0,0.08,mark thies,
+CHE,4070,1,Unit Op Lab II,0.14,0.75,0.11,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
+CHE,4310,1,Process Design I,0.2,0.45,0.35,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,4500,1,Chem Reaction Engr,0.45,0.26,0.16,0.12,0.0,0.0,0.0,0.0,rachel getman,
+CHE,8030,1,Advanced Transport,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,eric mikel davis,
+CHE,8040,1,Ch E Thermodynamics,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,christophe kitchens,
+CHE,8050,1,Ch E Kinetics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,mark alan blenner,
+CHE,8140,1,Numerical Methods,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,joseph scott,
+CHIN,1010,1,Elementary Chinese,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,ling rao,
+CHIN,1010,2,Elementary Chinese,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,ling rao,
+CHIN,1020,1,Elementary Chinese,0.42,0.17,0.33,0.08,0.0,0.0,0.0,0.0,ling rao,
+CHIN,2010,1,Intermediate Chinese,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,su- chen,
+CHIN,2020,1,Intermediate Chinese,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
+CHIN,4010,1,Pre-Modern Chinese Literature,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,yanming an,
+COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,eddie smith,
+COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,eddie smith,
+COM,1500,1,Intro to Human Communication,0.71,0.25,0.03,0.0,0.0,0.0,0.0,0.01,eddie smith,
+COM,1500,2,Intro to Human Communication,0.66,0.25,0.04,0.01,0.01,0.0,0.0,0.04,daniel lelan fecher,
+COM,1500,3,Intro to Human Communication,0.71,0.26,0.01,0.0,0.0,0.0,0.0,0.02,eddie smith,
+COM,1500,4,Intro to Human Communication,0.68,0.23,0.05,0.01,0.01,0.0,0.0,0.01,marianne her glaser,
+COM,1500,5,Intro to Human Communication,0.7,0.22,0.05,0.02,0.0,0.0,0.0,0.01,marianne her glaser,
+COM,1500,6,Intro to Human Communication,0.65,0.25,0.07,0.0,0.0,0.0,0.0,0.03,marianne her glaser,
+COM,1500,7,Intro to Human Communication,0.4,0.43,0.03,0.03,0.08,0.0,0.0,0.03,daniel lelan fecher,
+COM,2010,1,Intr to Comm Studies,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,2010,2,Intr to Comm Studies,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,2500,1,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,2,Public Speaking,0.39,0.33,0.11,0.06,0.06,0.0,0.0,0.06,marilyn denise pugh,
+COM,2500,3,Public Speaking,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,4,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,5,Public Speaking,0.26,0.58,0.16,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,6,Public Speaking,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
+COM,2500,7,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,8,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,9,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,10,Public Speaking,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,11,Public Speaking,0.47,0.32,0.05,0.05,0.05,0.0,0.0,0.05,sara grumbl crocker,
+COM,2500,12,Public Speaking,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,13,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,14,Public Speaking,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,vanessa anne condon,
+COM,2500,15,Public Speaking,0.17,0.39,0.44,0.0,0.0,0.0,0.0,0.0,pauline matthey,
+COM,2500,16,Public Speaking,0.29,0.35,0.12,0.0,0.0,0.0,0.0,0.24,pauline matthey,
+COM,2500,17,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,the estate  geddes,
+COM,2500,19,Public Speaking,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,vanessa anne condon,
+COM,2500,20,Public Speaking,0.21,0.58,0.11,0.0,0.0,0.0,0.0,0.11,pauline matthey,
+COM,2500,21,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,22,Public Speaking,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,vanessa anne condon,
+COM,2500,23,Public Speaking,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,28,Public Speaking,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,29,Public Speaking,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,
+COM,2500,30,Public Speaking,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,sara grumbl crocker,
+COM,2500,31,Public Speaking,0.21,0.42,0.16,0.05,0.05,0.0,0.0,0.11,marilyn denise pugh,
+COM,2500,32,Public Speaking,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,
+COM,2500,33,Public Speaking,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,34,Public Speaking,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
+COM,2500,35,Public Speaking,0.37,0.37,0.11,0.0,0.11,0.0,0.0,0.05,jumah patrici taweh,
+COM,2500,400,Public Speaking,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,
+COM,2500,401,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,
+COM,2500,402,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,403,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,3010,1,Comm Theory,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,
+COM,3050,1,Persuasion,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
+COM,3060,1,Crit-Cultural Rsrch Methods,0.47,0.29,0.12,0.06,0.06,0.0,0.0,0.0,chenjerai kumanyika,
+COM,3080,1,Pub Comm & Pop Cult,0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,chenjerai kumanyika,
+COM,3080,2,Pub Comm & Pop Cult,0.44,0.33,0.17,0.06,0.0,0.0,0.0,0.0,chenjerai kumanyika,
+COM,3110,1,Qual Comm Methods,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,angela pratt,
+COM,3150,1,Critical-Cultural Comm Theory,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,david travers scott,
+COM,3200,1,Bdcst Production,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,wanda johnson,
+COM,3220,1,Communication Design,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,
+COM,3240,1,"Communication, Sport & Society",0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,
+COM,3240,2,"Communication, Sport & Society",0.28,0.56,0.06,0.11,0.0,0.0,0.0,0.0,gregory kei cranmer,
+COM,3260,1,Pr in Sports,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3260,2,Pr in Sports,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3270,1,Sports Media Criticism,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,brandon boatwright,
+COM,3660,3,Video Comm with Adobe CC,0.83,0.06,0.0,0.06,0.0,0.0,0.0,0.06,michael rodgers,
+COM,3690,1,Political Comm,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3690,2,Political Comm,0.42,0.42,0.11,0.0,0.05,0.0,0.0,0.0,erin michelle ash,
+COM,3700,1,Survey of Brand Communications,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,lisa willi papenfus,
+COM,3720,1,Digital Analytics in Brand Com,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alicia ni littleton,
+COM,3740,1,Brand Comm and Media Strategy,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,roger beasley,
+COM,4020,1,Mass Com: His & Crit,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
+COM,4250,1,Adv Sports Comm,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4250,2,Adv Sports Comm,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4300,1,Legal Communication,0.28,0.61,0.0,0.0,0.0,0.0,0.0,0.11,james isaac roberts,
+COM,4560,1,PR for Assoc & Nonprofits,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,4660,1,Narrative Res. for Soc. Change,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,4950,1,Senior Capstone Seminar,0.72,0.06,0.22,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,8010,1,Communication Theory I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,andrew stephen pyle,
+COM,8030,1,Comm Technology Studies Survey,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,8100,1,Comm Research Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COOP,1020,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey frank neal,
+COOP,1030,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey frank neal,
+CPSC,1010,1,Computer Science I,0.2,0.32,0.14,0.07,0.2,0.0,0.0,0.07,eileen ther kraemer,
+CPSC,1020,1,Computer Science II,0.23,0.33,0.22,0.07,0.09,0.0,0.0,0.06,yvon feaster,
+CPSC,1040,1,Intro Computer Prog,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,aubrey miche lawson,
+CPSC,1060,1,Intro to Programming in Java,0.28,0.28,0.22,0.0,0.11,0.0,0.0,0.11,salvatore lamarca,
+CPSC,1060,2,Intro to Programming in Java,0.13,0.27,0.07,0.27,0.2,0.0,0.0,0.07,salvatore lamarca,
+CPSC,1070,1,Programming Methodology,0.42,0.26,0.11,0.05,0.11,0.0,0.0,0.05,rose lowe,
+CPSC,1070,2,Programming Methodology,0.5,0.22,0.17,0.0,0.06,0.0,0.0,0.06,rose lowe,
+CPSC,1110,1,Intro to Programming in C,0.25,0.35,0.27,0.05,0.04,0.0,0.0,0.04,catherine hochrine,
+CPSC,1110,2,Intro to Programming in C,0.27,0.37,0.17,0.02,0.1,0.0,0.0,0.08,catherine hochrine,
+CPSC,1110,3,Intro to Programming in C,0.6,0.15,0.13,0.04,0.06,0.0,0.0,0.02,tania roy,
+CPSC,1200,1,Intro Info Tech,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john junius porter,
+CPSC,2070,1,Discrete Structures,0.27,0.27,0.24,0.08,0.09,0.0,0.0,0.04,larry hodges,
+CPSC,2120,1,Algs/Data Structures,0.27,0.21,0.28,0.06,0.09,0.0,0.0,0.08,brian christop dean,
+CPSC,2120,2,Algs/Data Structures,0.1,0.0,0.18,0.14,0.24,0.0,0.0,0.34,pradip srimani,
+CPSC,2150,1,Software Dev Foundations,0.2,0.38,0.28,0.04,0.05,0.0,0.0,0.05,murali sitaraman,
+CPSC,2200,1,Microcomputer Appl,0.27,0.36,0.12,0.1,0.03,0.0,0.0,0.12,kevin anton plis,
+CPSC,2310,1,Intro Computer Org,0.21,0.32,0.37,0.01,0.05,0.0,0.0,0.05,rose lowe,
+CPSC,2810,2,Sel Topics: Tech and Tools Sem,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,brian christop dean,
+CPSC,2910,1,Prof Issues I,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,james jones,
+CPSC,2910,3,Prof Issues I,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,yvon feaster,
+CPSC,2910,4,Prof Issues I,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,yvon feaster,
+CPSC,2910,5,Prof Issues I,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,yvon feaster,
+CPSC,2910,6,Prof Issues I,0.53,0.26,0.11,0.0,0.0,0.0,0.0,0.11,yvon feaster,
+CPSC,2920,1,"Computing, Ethics & Society",0.26,0.42,0.16,0.0,0.16,0.0,0.0,0.0,christopher plaue,
+CPSC,2920,2,"Computing, Ethics & Society",0.43,0.21,0.21,0.07,0.07,0.0,0.0,0.0,christopher plaue,
+CPSC,3220,1,Intro to Operating Systems,0.13,0.26,0.39,0.09,0.04,0.0,0.0,0.09,mark smotherman,
+CPSC,3220,2,Intro to Operating Systems,0.1,0.32,0.26,0.1,0.1,0.0,0.0,0.13,pradip srimani,
+CPSC,3300,1,Computer Systems Org,0.28,0.35,0.23,0.06,0.02,0.0,0.0,0.06,rong ge,
+CPSC,3500,1,Foundations of Computer Sci,0.14,0.34,0.3,0.04,0.09,0.0,0.0,0.09,ilya mark safro,
+CPSC,3520,1,Programming Systems,0.36,0.43,0.03,0.09,0.05,0.0,0.0,0.03,robert schalkoff,
+CPSC,3600,2,Network Programming,0.46,0.4,0.14,0.0,0.0,0.0,0.0,0.0,lanny sitanayah,
+CPSC,3600,3,Network Programming,0.51,0.29,0.11,0.0,0.03,0.0,0.0,0.06,lanny sitanayah,
+CPSC,3620,1,Distributed/Cluster Computing,0.22,0.35,0.38,0.03,0.0,0.0,0.0,0.03,linh bao ngo,
+CPSC,3720,1,Software Engineering,0.26,0.63,0.09,0.0,0.02,0.0,0.0,0.0,john mcgregor,
+CPSC,3720,2,Software Engineering,0.21,0.53,0.16,0.0,0.05,0.0,0.0,0.05,kevin anton plis,
+CPSC,3720,3,Software Engineering,0.39,0.39,0.14,0.04,0.04,0.0,0.0,0.0,kevin anton plis,
+CPSC,3720,4,Software Engineering,0.08,0.42,0.25,0.0,0.08,0.0,0.0,0.17,kevin anton plis,
+CPSC,3990,1,Adv CI: Extreme Orange,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james martin,
+CPSC,4050,1,Computer Graphics,0.33,0.25,0.17,0.0,0.0,0.0,0.0,0.25,robert geist,
+CPSC,4110,1,Virtual Reality Systems,0.4,0.33,0.17,0.03,0.07,0.0,0.0,0.0,sabarish venka babu,
+CPSC,4120,1,Eye Tracking Methodology,0.35,0.55,0.05,0.0,0.0,0.0,0.0,0.05,andrew duchowski,
+CPSC,4160,1,2-D Game Engine Construction,0.46,0.42,0.04,0.0,0.08,0.0,0.0,0.0,brian malloy,
+CPSC,4200,1,Computer Security Principles,0.78,0.19,0.0,0.0,0.03,0.0,0.0,0.0,hongxin hu,
+CPSC,4620,1,Database Management Systems,0.08,0.21,0.13,0.04,0.17,0.0,0.0,0.38,pradip srimani,
+CPSC,4820,1,Spec Top:Mobile Device Sftware,0.74,0.17,0.04,0.04,0.0,0.0,0.0,0.0,roy pargas,
+CPSC,4820,5,Spec Topics: Privacy and Secur,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,kelly caine,
+CPSC,4820,6,Special Topics: Info to AI,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,feng luo,
+CPSC,4820,9,Special Topics: Data Science,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,
+CPSC,6040,1,Cptr Graphics Image,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,donald henry house,
+CPSC,6110,1,Virtual Reality Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
+CPSC,6160,1,2-D Game Engine Construction,0.59,0.23,0.18,0.0,0.0,0.0,0.0,0.0,brian malloy,
+CPSC,6200,1,Computer Security Principles,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,hongxin hu,
+CPSC,6620,1,Database Management Systems,0.41,0.12,0.35,0.0,0.0,0.0,0.0,0.12,pradip srimani,
+CPSC,6780,1,Gen Purpose Computation on GPU,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,
+CPSC,6810,1,Sel Top:Programming Team,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,brian christop dean,
+CPSC,6820,5,Spec Topics: Privacy and Secur,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
+CPSC,6820,9,Special Topics: Data Science,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,eileen ther kraemer,
+CPSC,8070,1,3d Model Animation,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+CPSC,8070,2,3d Model Animation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+CPSC,8150,1,Fx Compositing,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,eric patterson,
+CPSC,8170,1,Physically Based Animation,0.33,0.48,0.14,0.0,0.0,0.0,0.0,0.05,donald henry house,
+CPSC,8200,1,Parallel Architechture,0.71,0.23,0.03,0.0,0.0,0.0,0.0,0.03,amy apon,
+CPSC,8270,1,Translation of Progr Languages,0.42,0.35,0.15,0.0,0.02,0.0,0.0,0.06,brian malloy,
+CPSC,8380,1,Adv Data Structures,0.17,0.17,0.17,0.0,0.5,0.0,0.0,0.0,sandra hedetniemi,
+CPSC,8480,1,Network Science,0.42,0.38,0.12,0.0,0.04,0.0,0.0,0.04,ilya mark safro,
+CPSC,8510,1,Soft Sys Data Comm,0.3,0.33,0.3,0.0,0.03,0.0,0.0,0.03,james martin,
+CPSC,8580,1,Security in Emerging Systems,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.02,hongxin hu,
+CPSC,8700,1,Software Design,0.5,0.18,0.1,0.0,0.05,0.0,0.0,0.18,philippa mign brown,
+CPSC,8730,1,"Software Verif, Valid & Measur",0.33,0.59,0.05,0.0,0.03,0.0,0.0,0.0,john mcgregor,
+CPSC,8810,2,Selected Topics: 3D Game Devel,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+CPSC,8810,3,Sel Top: Adv 3D Model and Scul,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,insun kwon,
+CRP,8010,1,Planning Process & Legal Found,0.42,0.46,0.0,0.0,0.08,0.0,0.0,0.04,caitlin dyckman,
+CRP,8020,1,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
+CRP,8030,1,Quant Analysis,0.71,0.21,0.0,0.0,0.04,0.0,0.0,0.04,stephen sperry,
+CRP,8060,1,Urban & Reg Econ for Planners,0.73,0.15,0.0,0.0,0.08,0.0,0.0,0.04,timothy green,
+CRP,8140,1,Public Transit,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
+CRP,8580,2,Research Design,0.84,0.0,0.0,0.0,0.11,0.0,0.0,0.05,timothy green,
+CRP,8600,3,Terminal Proj/Thesis Proposal,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,clifford dona ellis,
+CRP,8600,6,Terminal Proj/Thesis Proposal,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,eric morris,
+CRP,8720,1,Housing in the U S,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,miller cunningham,
+CRP,8900,4,Dir Studies in City & Reg Plan,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,clifford dona ellis,
+CSM,1000,1,Intro to Construct,0.25,0.48,0.23,0.02,0.02,0.0,0.0,0.0,jason lucas,
+CSM,2010,1,Structures I,0.19,0.35,0.19,0.12,0.12,0.0,0.0,0.04,shima clarke,
+CSM,2010,2,Structures I,0.33,0.17,0.29,0.08,0.08,0.0,0.0,0.04,shima clarke,
+CSM,2030,1,Mats & Meth of Const,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,jason lucas,
+CSM,2030,2,Mats & Meth of Const,0.32,0.5,0.11,0.0,0.0,0.0,0.0,0.07,jason lucas,
+CSM,3030,1,Soils & Foundations,0.63,0.28,0.09,0.0,0.0,0.0,0.0,0.0,shima clarke,
+CSM,3030,2,Soils & Foundations,0.56,0.34,0.09,0.0,0.0,0.0,0.0,0.0,shima clarke,
+CSM,3040,1,Envir Systems I,0.23,0.48,0.23,0.06,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3040,2,Envir Systems I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3510,1,Const Estimating,0.23,0.5,0.27,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,
+CSM,3510,2,Const Estimating,0.23,0.5,0.23,0.0,0.0,0.0,0.0,0.03,seyed mousavi rizi,
+CSM,4110,1,Safety in Bldg Const,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,david devita,
+CSM,4500,1,Construction Intern,0.38,0.32,0.1,0.0,0.2,0.0,0.0,0.0,roger william liska,
+CSM,4530,1,Const Proj Mgmt,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,4530,2,Const Proj Mgmt,0.08,0.58,0.33,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,4610,1,Const Econ Seminar,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4610,2,Const Econ Seminar,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8600,1,Constr Finan Plan & Analysis,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8600,400,Constr Finan Plan & Analysis,0.38,0.38,0.0,0.0,0.0,0.0,0.0,0.25,dennis bausman,
+CSM,8630,1,Adv Plan/Sched,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8630,400,Adv Plan/Sched,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8660,1,Role in Development,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.01,susan whorton,
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.25,0.0,susan whorton,
+CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.71,0.29,0.0,susan whorton,
+CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.21,0.02,susan whorton,
+CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.01,susan whorton,
+CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.71,0.29,0.0,susan whorton,
+CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.25,0.0,susan whorton,
+CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.69,0.3,0.01,susan whorton,
+CU,1000,9,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.66,0.34,0.01,susan whorton,
+CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.61,0.38,0.01,susan whorton,
+CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.59,0.41,0.01,susan whorton,
+CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.51,0.47,0.01,susan whorton,
+CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.51,0.48,0.01,susan whorton,
+CU,1000,15,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.41,0.58,0.01,susan whorton,
+CU,1010,2,Univ Success Skills,0.11,0.32,0.21,0.0,0.16,0.0,0.0,0.21,matthew james kirk,
+CU,1010,3,Univ Success Skills,0.69,0.06,0.06,0.13,0.0,0.0,0.0,0.06,mary mcp von kaenel,
+CU,1010,5,Univ Success Skills,0.32,0.05,0.32,0.16,0.16,0.0,0.0,0.0,cari allyn brooks,
+CU,1010,6,Univ Success Skills,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,mary mcp von kaenel,
+CU,2010,1,Sustainability Leadership,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,
+DANC,1400,1,Jazz Dance I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,cheryl hosler,
+DPA,3070,1,Method 3d Production,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,summer 'nea benton,
+DPA,4000,1,Tech Foundations I,0.0,0.0,0.09,0.0,0.64,0.0,0.0,0.27,andrew duchowski,
+DPA,4020,2,Vis Foundations I,0.79,0.0,0.14,0.0,0.07,0.0,0.0,0.0,erik reed,
+DPA,4020,3,Vis Foundations I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,pratham karnik,
+ECE,2010,1,Logic and Computing Devices,0.24,0.25,0.27,0.08,0.12,0.0,0.0,0.04,william reid,
+ECE,2020,1,Electric Circuits I,0.28,0.35,0.21,0.1,0.06,0.0,0.0,0.0,william harrell,
+ECE,2020,3,Electric Circuits I,0.12,0.3,0.33,0.09,0.09,0.0,0.0,0.06,daniel bla cutshall,
+ECE,2070,1,Basic Electrical Engineering,0.36,0.33,0.13,0.06,0.04,0.0,0.0,0.07,william th kolodzey,
+ECE,2070,2,Basic Electrical Engineering,0.21,0.38,0.26,0.0,0.09,0.0,0.0,0.06,timothy anglea,
+ECE,2070,3,Basic Electrical Engineering,0.46,0.29,0.12,0.02,0.02,0.0,0.0,0.1,amir ahmed asif,
+ECE,2080,1,Basic Electrical Engr Lab,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,5,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,6,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,7,Basic Electrical Engr Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,8,Basic Electrical Engr Lab,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,10,Basic Electrical Engr Lab,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,
+ECE,2080,12,Basic Electrical Engr Lab,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
+ECE,2080,13,Basic Electrical Engr Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
+ECE,2090,1,Logic Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,2,Logic Lab,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2090,3,Logic Lab,0.67,0.17,0.0,0.08,0.08,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,4,Logic Lab,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,5,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2090,7,Logic Lab,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2090,9,Logic Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,10,Logic Lab,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2110,1,Elec Engr Lab I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2110,5,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2110,6,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2110,7,Elec Engr Lab I,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
+ECE,2110,9,Elec Engr Lab I,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2120,1,Electrical Engineering Lab II,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,apoorva dee kapadia,
+ECE,2120,3,Electrical Engineering Lab II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
+ECE,2220,1,Syst Prog Concept,0.14,0.38,0.14,0.08,0.08,0.0,0.0,0.19,harlan russell,
+ECE,2230,1,Comp Sys Eng,0.26,0.31,0.18,0.05,0.1,0.0,0.0,0.1,harlan russell,
+ECE,2620,1,Electric Circuits II,0.26,0.19,0.3,0.09,0.12,0.0,0.0,0.05,liang dong,
+ECE,2720,1,Comp Organization,0.17,0.37,0.29,0.12,0.05,0.0,0.0,0.0,william reid,
+ECE,2730,2,Computer Org Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2730,3,Computer Org Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,2,Electrical Engineering Lab III,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,4,Electrical Engineering Lab III,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,apoorva dee kapadia,
+ECE,3170,1,Rand Signal Analysis,0.16,0.4,0.31,0.07,0.04,0.0,0.0,0.02,stephen hubbard,
+ECE,3200,1,Electronics I,0.12,0.31,0.31,0.12,0.13,0.0,0.0,0.03,stephen hubbard,
+ECE,3200,2,Electronics I (HON),0.36,0.43,0.14,0.0,0.07,0.0,0.0,0.0,stephen hubbard,True
+ECE,3210,1,Electronics II,0.19,0.41,0.31,0.03,0.03,0.0,0.0,0.03,stephen hubbard,
+ECE,3220,2,Intro Operating Sys,0.15,0.25,0.35,0.15,0.0,0.0,0.0,0.1,pradip srimani,
+ECE,3270,1,Dig Comp Design,0.26,0.22,0.3,0.04,0.09,0.0,0.0,0.09,melissa crawl smith,
+ECE,3300,1,Signals & Systems,0.13,0.23,0.32,0.18,0.08,0.0,0.0,0.06,carl baum,
+ECE,3300,2,Signals & Systems (HON),0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
+ECE,3520,1,Programming Systems,0.43,0.29,0.0,0.07,0.14,0.0,0.0,0.07,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.42,0.28,0.2,0.04,0.03,0.0,0.0,0.03,edward collins,
+ECE,3710,1,Microcontr Interface,0.34,0.34,0.27,0.01,0.01,0.0,0.0,0.01,william reid,
+ECE,3720,1,Micro Int Lab,0.42,0.33,0.17,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,2,Micro Int Lab,0.08,0.5,0.42,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,3,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,3720,4,Micro Int Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,3720,6,Micro Int Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,3800,1,Electromagnetics,0.42,0.33,0.12,0.03,0.03,0.0,0.0,0.07,hai xiao,
+ECE,3810,1,Field Waves & Ckts,0.09,0.43,0.31,0.09,0.09,0.0,0.0,0.0,anthony martin,
+ECE,4090,1,Intr to Linear Control Systems,0.39,0.36,0.16,0.02,0.04,0.0,0.0,0.02,apoorva dee kapadia,
+ECE,4180,1,Power Syst Analysis,0.35,0.27,0.27,0.04,0.04,0.0,0.0,0.04,elham makram,
+ECE,4270,1,Communications Sys,0.37,0.27,0.13,0.15,0.08,0.0,0.0,0.0,madhabi manandhar,
+ECE,4420,1,Knowledge Engr,0.33,0.38,0.05,0.1,0.0,0.0,0.0,0.14,robert schalkoff,
+ECE,4490,1,Comp Ntwrk Security,0.32,0.42,0.03,0.0,0.05,0.0,0.0,0.18,richard brooks,
+ECE,4610,1,Fundamentals of Solar Energy,0.47,0.39,0.08,0.03,0.03,0.0,0.0,0.0,rajendra singh,
+ECE,4670,1,Intro to Dig Sig Pro,0.24,0.24,0.29,0.06,0.06,0.0,0.0,0.12,john gowdy,
+ECE,4730,1,Intro Parallel Sys,0.15,0.69,0.15,0.0,0.0,0.0,0.0,0.0,walter ligon,
+ECE,4950,1,Int Sys Design I,0.73,0.24,0.03,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4960,1,Int Sys Design II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard groff,
+ECE,6040,1,Semiconductor Devices,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,6420,1,Knowledge Engr,0.41,0.31,0.14,0.0,0.14,0.0,0.0,0.0,robert schalkoff,
+ECE,6490,1,Comp Ntwrk Security,0.31,0.38,0.13,0.0,0.13,0.0,0.0,0.06,lu yu,
+ECE,6670,1,Intro to Dig Sig Pro,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,john gowdy,
+ECE,6730,1,Intro Parallel Sys,0.33,0.25,0.0,0.0,0.33,0.0,0.0,0.08,walter ligon,
+ECE,6930,5,Network science,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,
+ECE,8010,1,Analysis of Lin Sys,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,richard groff,
+ECE,8170,1,Power System Transients,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,ramtin hadidi,
+ECE,8180,1,Rand Proc Appl Engr,0.46,0.38,0.0,0.0,0.15,0.0,0.0,0.0,carl baum,
+ECE,8910,30,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,0.6,0.4,0.0,robert schalkoff,
+ECON,2000,1,Economic Concepts,0.4,0.35,0.15,0.08,0.0,0.0,0.0,0.03,jonathan orr ernest,
+ECON,2000,2,Economic Concepts,0.5,0.25,0.13,0.05,0.03,0.0,0.0,0.05,jonathan orr ernest,
+ECON,2000,3,Economic Concepts,0.3,0.35,0.2,0.13,0.03,0.0,0.0,0.0,miren ivankovic,
+ECON,2110,1,Principles of Microeconomics,0.17,0.61,0.11,0.0,0.11,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,2,Principles of Microeconomics,0.11,0.16,0.16,0.21,0.32,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,3,Principles of Microeconomics,0.06,0.44,0.28,0.11,0.06,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,4,Principles of Microeconomics,0.11,0.37,0.42,0.0,0.0,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,5,Principles of Microeconomics,0.0,0.37,0.26,0.26,0.05,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,6,Principles of Microeconomics,0.11,0.21,0.42,0.11,0.11,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,7,Principles of Microeconomics,0.11,0.47,0.11,0.05,0.16,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,8,Principles of Microeconomics,0.05,0.32,0.53,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,9,Principles of Microeconomics,0.11,0.47,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,10,Principles of Microeconomics,0.26,0.26,0.37,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,11,Principles of Microeconomics,0.06,0.56,0.22,0.11,0.0,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,12,Principles of Microeconomics,0.21,0.37,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,13,Principles of Microeconomics,0.13,0.44,0.31,0.0,0.06,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,14,Principles of Microeconomics,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,15,Principles of Microeconomics,0.16,0.47,0.26,0.0,0.11,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,16,Principles of Microeconomics,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,17,Principles of Microeconomics,0.05,0.53,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,18,Principles of Microeconomics,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,19,Principles of Microeconomics,0.05,0.47,0.21,0.16,0.05,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,20,Principles of Microeconomics,0.26,0.42,0.22,0.05,0.04,0.0,0.0,0.01,kelsey vict roberts,
+ECON,2110,21,Principles of Microeconomics,0.18,0.41,0.35,0.02,0.0,0.0,0.0,0.04,bradley keith hobbs,
+ECON,2110,22,Principles of Microeconomics,0.45,0.27,0.16,0.05,0.05,0.0,0.0,0.02,benjamin jo schwall,
+ECON,2110,23,Principles of Microeconomics,0.24,0.4,0.16,0.09,0.06,0.0,0.0,0.04,leah jacq kitashima,
+ECON,2110,24,Principles of Microeconomics,0.27,0.31,0.2,0.08,0.08,0.0,0.0,0.06,amanda caitlin kerr,
+ECON,2110,25,Principles of Microeconomics,0.23,0.5,0.1,0.03,0.05,0.0,0.0,0.1,roksan ghanbariamin,
+ECON,2110,26,Principles of Microeconomics,0.38,0.29,0.13,0.09,0.02,0.0,0.0,0.09,steven johnson,
+ECON,2110,31,Principles of Microeconomics,0.44,0.36,0.1,0.04,0.03,0.0,0.0,0.04,maria droganova,
+ECON,2110,32,Principles of Microeconomics,0.29,0.36,0.29,0.07,0.0,0.0,0.0,0.0,zhiqi zhao,
+ECON,2110,33,Principles of Microeconomics,0.38,0.28,0.15,0.08,0.03,0.0,0.0,0.08,liuna issagholian,
+ECON,2110,34,Principles of Microeconomics,0.33,0.26,0.28,0.08,0.0,0.0,0.0,0.05,liuna issagholian,
+ECON,2110,35,Principles of Microeconomics,0.38,0.38,0.13,0.08,0.03,0.0,0.0,0.03,roksan ghanbariamin,
+ECON,2110,38,Principles of Microeconomics,0.21,0.6,0.14,0.0,0.02,0.0,0.0,0.02,chen wang,
+ECON,2110,40,Principles of Micro (HON),0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,charles thomas,True
+ECON,2110,41,Principles of Microeconomics,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,chen wang,
+ECON,2120,1,Principles of Macroeconomics,0.07,0.16,0.16,0.16,0.16,0.0,0.0,0.29,ralph charles allen,
+ECON,2120,2,Principles of Macroeconomics,0.32,0.39,0.16,0.07,0.02,0.0,0.0,0.05,wing yin chung,
+ECON,2120,3,Principles of Macroeconomics,0.11,0.21,0.23,0.18,0.13,0.0,0.0,0.14,ralph charles allen,
+ECON,2120,4,Principles of Macroeconomics,0.22,0.22,0.32,0.07,0.12,0.0,0.0,0.05,peter david lorenz,
+ECON,2120,5,Principles of Macroeconomics,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,huili li,
+ECON,2120,6,Principles of Macroeconomics,0.78,0.2,0.03,0.0,0.0,0.0,0.0,0.0,huili li,
+ECON,2120,7,Principles of Macroeconomics,0.28,0.35,0.25,0.13,0.0,0.0,0.0,0.0,peter david lorenz,
+ECON,2120,8,Principles of Macroeconomics,0.18,0.44,0.24,0.08,0.02,0.0,0.0,0.05,ce castellon chicas,
+ECON,2120,9,Principles of Macroeconomics,0.43,0.32,0.14,0.05,0.0,0.0,0.0,0.05,jordan adamson,
+ECON,2120,10,Principles of Macroeconomics,0.17,0.42,0.22,0.11,0.06,0.0,0.0,0.03,andrew chaffee,
+ECON,3020,1,Money and Banking,0.24,0.22,0.3,0.08,0.08,0.0,0.0,0.08,smriti bhargava,
+ECON,3060,1,Managerial Economics,0.21,0.34,0.29,0.08,0.05,0.0,0.0,0.03,timothy jay bacon,
+ECON,3100,1,International Econ,0.32,0.41,0.13,0.01,0.07,0.0,0.0,0.06,scott baier,
+ECON,3140,1,Intermediate Micro,0.38,0.11,0.3,0.09,0.09,0.0,0.0,0.02,patrick warren,
+ECON,3140,2,Intermediate Micro,0.32,0.44,0.19,0.02,0.0,0.0,0.0,0.03,molly espey,
+ECON,3140,3,Intermediate Micro,0.28,0.21,0.28,0.09,0.06,0.0,0.0,0.09,robert kennet fleck,
+ECON,3150,1,Intermediate Macro,0.22,0.29,0.24,0.04,0.06,0.0,0.0,0.16,sergey vla mityakov,
+ECON,3150,2,Intermediate Macro,0.22,0.34,0.2,0.17,0.05,0.0,0.0,0.02,michal jerzmanowski,
+ECON,3190,1,Environmental Econ,0.05,0.46,0.35,0.08,0.05,0.0,0.0,0.0,molly espey,
+ECON,3500,1,Moral & Ethical Econ,0.1,0.33,0.29,0.05,0.1,0.0,0.0,0.14,bradley keith hobbs,
+ECON,3600,1,Public Choice,0.41,0.15,0.15,0.17,0.02,0.0,0.0,0.1,michael makowsky,
+ECON,4010,1,Labor Mkt Analysis,0.42,0.21,0.16,0.16,0.05,0.0,0.0,0.0,chungsang lam,
+ECON,4040,1,Comp Econ Systems,0.22,0.19,0.15,0.07,0.19,0.0,0.0,0.19,dar litsukova-bokar,
+ECON,4050,5,Intro to Econometric,0.18,0.34,0.24,0.04,0.1,0.0,0.0,0.1,scott barkowski,
+ECON,4100,1,Economic Development,0.44,0.19,0.04,0.0,0.07,0.0,0.0,0.26,robert tamura,
+ECON,4110,2,Econ of Education,0.27,0.5,0.08,0.0,0.04,0.0,0.0,0.12,peter quarter blair,
+ECON,4120,1,International Micro,0.42,0.36,0.13,0.07,0.0,0.0,0.0,0.02,richard alan sessa,
+ECON,4220,1,Monetary Economics,0.45,0.42,0.09,0.0,0.03,0.0,0.0,0.0,gerald dwyer,
+ECON,6060,1,Advanced Econometric,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,
+ECON,8010,1,Microeconomic Theory,0.26,0.37,0.26,0.0,0.05,0.0,0.0,0.05,william dougan,
+ECON,8040,1,Applied Math Econ,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
+ECON,8060,1,Econometrics I,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,
+ECON,8080,1,Econometrics III,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,paul wayne wilson,
+ECON,8160,1,Labor Economics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
+ECON,8210,1,Public Choice,0.5,0.17,0.17,0.0,0.17,0.0,0.0,0.0,patrick warren,
+ECON,8230,1,Microecon Pub Pol,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,
+ECON,8240,1,Org of Industry,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,8260,1,Econ Theory of Govt Regulation,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,
+ECON,8550,1,Financial Economics,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,sergey vla mityakov,
+ECON,9010,1,Price Theory,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,charles thomas,
+ED,1970,1,Student of Color Experience CI,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,2,Student of Color Experience CI,0.76,0.1,0.05,0.0,0.1,0.0,0.0,0.0,deonte brown,
+ED,1970,3,Student of Color Experience CI,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,deonte brown,
+ED,8700,1,STEAM Instructional Design,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,cassie fay quigley,
+ED,8720,500,STEAM Enacted and Evaluated,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,danielle chri herro,
+EDC,8050,1,Clinical Mh Couns,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,david scott,
+EDC,8130,400,Appraisal Procedures,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,jennifer lyn brooks,
+EDEC,8200,500,Adv Ece Curriculum,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEL,3210,1,Pe for the Elem Tchr,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,3210,2,Pe for the Elem Tchr,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,deborah smith,
+EDEL,4510,1,Elem Methods in Science Tchg,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
+EDEL,4870,1,Ele Meth Soc Studies,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
+EDEL,4880,1,Elem Meth La Tchng,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
+EDF,3010,1,Principles of American Educat,0.52,0.22,0.17,0.09,0.0,0.0,0.0,0.0,suzanne rosenblith,
+EDF,3020,1,Educational Psychology,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.03,heather rog brooker,
+EDF,3080,1,Classroom Assessment,0.56,0.32,0.08,0.0,0.0,0.0,0.0,0.04,deborah switzer,
+EDF,3080,2,Classroom Assessment,0.71,0.19,0.1,0.0,0.0,0.0,0.0,0.0,deborah switzer,
+EDF,3340,3,Child Growth and Development,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,faiza marghoo jamil,
+EDF,3350,1,Adolescent Growth & Develop,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
+EDF,4800,1,Digital Media & Learning,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,ryan visser,
+EDF,4800,2,Digital Media & Learning,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,3,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,danielle chri herro,
+EDF,4800,300,Digital Media & Learning,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,ryan visser,
+EDF,8770,300,Research Meth in Education I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,carleton dew salley,
+EDF,9270,1,Quant Rsrch & Stats for Ed,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,
+EDF,9270,2,Quant Rsrch & Stats for Ed,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,jennie lynn farmer,
+EDF,9810,1,Design-Based Research Methods,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,david paul reinking,
+EDHD,8310,500,Lit Outcomes for Child w disab,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,vicki steadman,
+EDL,7000,501,Public School Adm,0.79,0.07,0.0,0.0,0.14,0.0,0.0,0.0,frederick buskey,
+EDL,7200,400,School Personnel Adm,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,kathryn le 'andrea,
+EDL,7500,500,El Prin & Spv Ex I,0.71,0.0,0.0,0.0,0.29,0.0,0.0,0.0,frederick buskey,
+EDL,8150,501,The Superintendency,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,elizabeth reynolds,
+EDL,8390,401,Research in Ed L,0.42,0.42,0.0,0.0,0.17,0.0,0.0,0.0,kristin kelly frady,
+EDL,8510,501,School Sys Prac II,0.21,0.0,0.0,0.0,0.79,0.0,0.0,0.0,elizabeth reynolds,
+EDL,8850,512,STEM - School Admin,0.44,0.0,0.0,0.0,0.56,0.0,0.0,0.0,william havice,
+EDL,9100,400,Intro Phd Seminar,0.82,0.0,0.0,0.0,0.18,0.0,0.0,0.0,jane lindle,
+EDL,9650,1,Higher Ed Finance,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,
+EDLT,4600,1,Teaching Reading Grades 2-6,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,
+EDLT,4600,3,Teaching Reading Grades 2-6,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4600,5,Teaching Reading Grades 2-6,0.69,0.19,0.04,0.0,0.0,0.0,0.0,0.08,pamela dunston,
+EDLT,4610,1,Content Area Rdg: Grades 2-6,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,4980,1,Secondary Content Area Reading,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,corrie leigh martin,
+EDLT,8160,500,Literacy Instruction Practicum,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
+EDLT,8400,500,Early Literacy Assessment I,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,andrea chri overton,
+EDLT,8400,504,Early Literacy Assessment I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
+EDLT,9370,501,Reading Recovery Theory I,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,celeste compt bates,
+EDML,8340,400,Envir Sci for Mid Sch Teachers,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,michelle patri cook,
+EDSA,8030,1,Student Dev Servc in Higher Ed,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
+EDSA,8030,2,Student Dev Servc in Higher Ed,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
+EDSC,2260,1,Pr Apprch to Sec Alg,0.31,0.54,0.08,0.0,0.08,0.0,0.0,0.0,stacy megan che,
+EDSC,3240,1,Practicum Sec Engl,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,
+EDSC,4260,1,Tchng Sec Math,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,carlos gomez,
+EDSC,8610,400,Mthds & Strt Secondary Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,
+EDSP,3700,2,Intro to Special Education,0.79,0.15,0.06,0.0,0.0,0.0,0.0,0.0,tracy denis garrett,
+EDSP,3700,3,Intro to Special Education,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,jennifer my- counts,
+EDSP,3700,4,Intro to Special Education,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,michelle lee popham,
+EDSP,3740,1,Char & Strat Emot/Behav Disord,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,
+EDSP,4920,1,Math Inst Ind W/Dis,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela stecker,
+EDSP,4940,1,Tchg Rdg Mild Dis,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
+EDSP,8220,400,Tchg Math Indv W/Dis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,
+EDSP,8530,1,Legal/Pol Issu Sp Ed,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,antonis katsiyannis,
+EES,2010,1,Environ Engr Fundamentals I,0.38,0.27,0.17,0.04,0.1,0.0,0.0,0.04,david freedman,
+EES,3030,1,Water Treatment Systems,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3040,1,Wastewater Treatment Systems,0.43,0.39,0.18,0.0,0.0,0.0,0.0,0.0,sudeep popat,
+EES,3050,1,Water/Wastewater Treatment Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3050,2,Water/Wastewater Treatment Lab,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,4010,1,Environmental Engr,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.17,0.26,0.43,0.13,0.0,0.0,0.0,0.0,mark schlautman,
+EES,4100,1,Environ Radiation Protection I,0.27,0.36,0.09,0.18,0.0,0.0,0.0,0.09,nicole eli martinez,
+EES,4300,1,Air Pollution Engineering,0.21,0.54,0.21,0.04,0.0,0.0,0.0,0.0,thomas overcamp,
+EES,4800,1,Environmental Risk Assessment,0.58,0.19,0.22,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,
+EES,4860,5,Environmental Sustainability,0.6,0.23,0.14,0.0,0.0,0.0,0.0,0.03,michael anthon dale,
+EES,8020,1,Environ Eng Prin,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,8430,1,Environmental Chem,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,
+EES,8510,1,Biol Prin Envir Engr,0.66,0.28,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
+EES,8610,1,Env Engr&Sci Seminar,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,ezra lucas ho cates,
+EES,8800,1,Env Risk Assessment,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,
+ELE,3010,1,Intro to Entre,0.59,0.23,0.13,0.05,0.0,0.0,0.0,0.0,christina kyprianou,
+ELE,3010,2,Intro to Entre,0.51,0.38,0.03,0.03,0.0,0.0,0.0,0.05,christina kyprianou,
+ELE,3010,3,Intro to Entre,0.11,0.45,0.42,0.0,0.03,0.0,0.0,0.0,ashley will parnell,
+ELE,4010,1,Exec Lead & Entr II,0.04,0.29,0.51,0.11,0.0,0.0,0.0,0.04,ashley will parnell,
+ENGL,1030,1,Accelerated Composition,0.0,0.79,0.16,0.0,0.0,0.0,0.0,0.05,renesha moniq poole,
+ENGL,1030,2,Accelerated Composition,0.42,0.47,0.0,0.05,0.05,0.0,0.0,0.0,renesha moniq poole,
+ENGL,1030,3,Accelerated Composition,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,christa kettlewell,
+ENGL,1030,4,Accelerated Composition,0.63,0.11,0.05,0.05,0.11,0.0,0.0,0.05,chloe helene cahill,
+ENGL,1030,5,Accelerated Composition,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,laurie pfister epps,
+ENGL,1030,7,Accelerated Composition,0.5,0.28,0.06,0.11,0.06,0.0,0.0,0.0,robert brissey,
+ENGL,1030,8,Accelerated Composition,0.42,0.47,0.05,0.0,0.05,0.0,0.0,0.0,christa kettlewell,
+ENGL,1030,9,Accelerated Composition,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,chloe helene cahill,
+ENGL,1030,10,Accelerated Composition,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,laurie pfister epps,
+ENGL,1030,12,Accelerated Composition,0.37,0.37,0.16,0.0,0.11,0.0,0.0,0.0,robert brissey,
+ENGL,1030,15,Accelerated Composition,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,karen kettnich,
+ENGL,1030,17,Accelerated Composition,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,matthew scot duncan,
+ENGL,1030,18,Accelerated Composition,0.74,0.11,0.0,0.0,0.0,0.0,0.0,0.16,parker elizabe king,
+ENGL,1030,19,Accelerated Composition,0.42,0.32,0.05,0.16,0.05,0.0,0.0,0.0,jennifer forsberg,
+ENGL,1030,21,Accelerated Composition,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulo green,
+ENGL,1030,22,Accelerated Composition,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,benjamin hudson,
+ENGL,1030,23,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,katie jo vann,
+ENGL,1030,24,Accelerated Composition,0.35,0.47,0.06,0.0,0.06,0.0,0.0,0.06,matthew scot duncan,
+ENGL,1030,25,Accelerated Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,parker elizabe king,
+ENGL,1030,26,Accelerated Composition,0.53,0.37,0.0,0.0,0.11,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,27,Accelerated Composition,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,29,Accelerated Composition,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,dia quaglia beltran,
+ENGL,1030,30,Accelerated Composition,0.32,0.42,0.11,0.0,0.16,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,1030,31,Accelerated Composition,0.67,0.17,0.06,0.06,0.06,0.0,0.0,0.0,brian lee gaines,
+ENGL,1030,32,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kala parker,
+ENGL,1030,33,Accelerated Composition,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,michael davi measel,
+ENGL,1030,34,Accelerated Composition,0.6,0.27,0.07,0.0,0.07,0.0,0.0,0.0,charlotte est lucke,
+ENGL,1030,35,Accelerated Composition,0.87,0.0,0.07,0.0,0.07,0.0,0.0,0.0,kala parker,
+ENGL,1030,37,Accelerated Composition,0.6,0.13,0.07,0.07,0.07,0.0,0.0,0.07,brian lee gaines,
+ENGL,1030,38,Accelerated Composition,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,39,Accelerated Composition,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,yvonne kao,
+ENGL,1030,41,Accelerated Composition,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,1030,42,Accelerated Composition,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,benjamin hudson,
+ENGL,1030,43,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,eric stephens,
+ENGL,1030,44,Accelerated Composition,0.89,0.0,0.05,0.0,0.05,0.0,0.0,0.0,daniel frank,
+ENGL,1030,45,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen quigley,
+ENGL,1030,46,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,april obrien,
+ENGL,1030,47,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,samuel jacks fuller,
+ENGL,1030,49,Accelerated Composition,0.56,0.28,0.0,0.0,0.11,0.0,0.0,0.06,karen kettnich,
+ENGL,1030,50,Accelerated Composition,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,michael russo,
+ENGL,1030,51,Accelerated Composition,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,april obrien,
+ENGL,1030,52,Accelerated Composition,0.53,0.37,0.0,0.05,0.0,0.0,0.0,0.05,eric stephens,
+ENGL,1030,53,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
+ENGL,1030,55,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,whitney jorda adams,
+ENGL,1030,57,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,58,Accelerated Composition,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,1030,59,Accelerated Composition,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,charlotte est lucke,
+ENGL,1030,61,Accelerated Composition,0.84,0.0,0.11,0.05,0.0,0.0,0.0,0.0,stephen quigley,
+ENGL,1030,64,Accelerated Composition,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,christopher stuart,
+ENGL,1030,65,Accelerated Composition,0.07,0.79,0.0,0.0,0.07,0.0,0.0,0.07,barbara ramirez,
+ENGL,1030,67,Accelerated Composition,0.63,0.21,0.05,0.0,0.05,0.0,0.0,0.05,daniel scott citro,
+ENGL,1030,69,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,1030,70,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,
+ENGL,1030,71,Accelerated Composition,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,joshua wood,
+ENGL,1030,72,Accelerated Composition,0.42,0.26,0.0,0.05,0.05,0.0,0.0,0.21,joshua wood,
+ENGL,1030,73,Accelerated Composition,0.69,0.0,0.08,0.0,0.23,0.0,0.0,0.0,jennifer forsberg,
+ENGL,1030,75,Accelerated Composition,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,yvonne kao,
+ENGL,1030,76,Accelerated Composition,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,katie jo vann,
+ENGL,1030,77,Accelerated Composition,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,michael davi measel,
+ENGL,1030,79,Accelerated Composition,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,1030,80,Accelerated Composition,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,christopher stuart,
+ENGL,1030,81,Accelerated Composition,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,sharif youssef,
+ENGL,1030,84,Accelerated Composition,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,erica mich marquard,
+ENGL,1030,85,Accelerated Composition,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,erica mich marquard,
+ENGL,1030,86,Accelerated Composition,0.11,0.78,0.0,0.0,0.06,0.0,0.0,0.06,barbara ramirez,
+ENGL,1030,501,Accelerated Composition,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,2120,3,World Literature,0.63,0.26,0.0,0.04,0.0,0.0,0.0,0.07,sharif youssef,
+ENGL,2120,4,World Literature,0.72,0.1,0.14,0.0,0.0,0.0,0.0,0.03,allen swords,
+ENGL,2120,5,World Literature,0.86,0.0,0.11,0.0,0.0,0.0,0.0,0.04,allen swords,
+ENGL,2120,6,World Literature,0.41,0.3,0.11,0.11,0.04,0.0,0.0,0.04,krist aldebol-hazle,
+ENGL,2120,7,World Literature,0.54,0.14,0.04,0.07,0.18,0.0,0.0,0.04,krist aldebol-hazle,
+ENGL,2120,8,World Literature,0.57,0.29,0.04,0.04,0.04,0.0,0.0,0.04,sharif youssef,
+ENGL,2120,9,World Literature,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,stephanie stripling,
+ENGL,2120,10,World Literature,0.93,0.04,0.0,0.0,0.04,0.0,0.0,0.0,stephanie stripling,
+ENGL,2120,11,World Literature,0.41,0.37,0.11,0.04,0.07,0.0,0.0,0.0,andrew mathas,
+ENGL,2120,12,World Literature,0.31,0.31,0.24,0.03,0.0,0.0,0.0,0.1,karen kettnich,
+ENGL,2120,13,World Literature,0.16,0.56,0.12,0.04,0.0,0.0,0.0,0.12,karen kettnich,
+ENGL,2120,14,World Literature,0.17,0.21,0.42,0.04,0.04,0.0,0.0,0.13,david charles foltz,
+ENGL,2120,15,World Literature,0.32,0.28,0.16,0.08,0.04,0.0,0.0,0.12,david charles foltz,
+ENGL,2120,16,World Literature,0.59,0.33,0.04,0.04,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2120,17,World Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2120,18,World Literature,0.68,0.25,0.04,0.0,0.0,0.0,0.0,0.04,lucian ghita,
+ENGL,2120,19,World Literature,0.33,0.37,0.15,0.0,0.07,0.0,0.0,0.07,andrew mathas,
+ENGL,2120,20,World Literature,0.64,0.21,0.0,0.04,0.04,0.0,0.0,0.07,sharif youssef,
+ENGL,2120,21,World Literature (Majors),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michelle renee ty,
+ENGL,2130,1,British Literature,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
+ENGL,2130,3,British Literature,0.57,0.32,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,2130,4,British Literature,0.56,0.41,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
+ENGL,2130,5,British Literature,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,christopher benson,
+ENGL,2130,7,British Literature,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,2130,9,British Literature,0.68,0.14,0.07,0.04,0.0,0.0,0.0,0.07,krist aldebol-hazle,
+ENGL,2130,10,British Literature,0.36,0.43,0.14,0.0,0.04,0.0,0.0,0.04,christopher benson,
+ENGL,2130,11,British Literature,0.89,0.04,0.0,0.04,0.04,0.0,0.0,0.0,stephanie stripling,
+ENGL,2130,12,British Literature,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,stephanie stripling,
+ENGL,2130,13,British Literature,0.68,0.29,0.0,0.0,0.04,0.0,0.0,0.0,lucian ghita,
+ENGL,2140,1,American Literature,0.5,0.15,0.0,0.04,0.08,0.0,0.0,0.23,candace wiley,
+ENGL,2140,5,American Literature,0.39,0.43,0.04,0.07,0.04,0.0,0.0,0.04,erin nicholson gale,
+ENGL,2140,6,American Literature,0.41,0.33,0.11,0.04,0.04,0.0,0.0,0.07,erin nicholson gale,
+ENGL,2140,7,American Literature,0.46,0.25,0.21,0.0,0.04,0.0,0.0,0.04,john logan pursley,
+ENGL,2140,8,American Literature,0.46,0.12,0.0,0.08,0.0,0.0,0.0,0.35,candace wiley,
+ENGL,2140,9,American Literature,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2140,14,American Literature,0.56,0.26,0.07,0.0,0.04,0.0,0.0,0.07,adrian carson,
+ENGL,2140,15,American Literature,0.26,0.41,0.22,0.04,0.0,0.0,0.0,0.07,susanna ashton,
+ENGL,2140,16,American Literature,0.61,0.29,0.11,0.0,0.0,0.0,0.0,0.0,austin gorman,
+ENGL,2140,17,American Literature,0.48,0.12,0.2,0.08,0.08,0.0,0.0,0.04,adrian carson,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.59,0.19,0.11,0.04,0.0,0.0,0.0,0.07,jennifer forsberg,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.63,0.22,0.11,0.0,0.04,0.0,0.0,0.0,jennifer forsberg,
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.32,0.26,0.16,0.11,0.05,0.0,0.0,0.11,candace wiley,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.22,0.56,0.11,0.0,0.04,0.0,0.0,0.07,david charles foltz,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.15,0.37,0.26,0.0,0.11,0.0,0.0,0.11,david charles foltz,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.57,0.17,0.04,0.04,0.04,0.0,0.0,0.13,candace wiley,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.39,0.5,0.07,0.04,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.65,0.23,0.08,0.0,0.04,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.54,0.35,0.0,0.04,0.0,0.0,0.0,0.08,erin nicholson gale,
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.79,0.14,0.04,0.0,0.0,0.0,0.0,0.04,katie jo vann,
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.36,0.29,0.21,0.04,0.04,0.0,0.0,0.07,megan no macalystre,
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.5,0.29,0.11,0.07,0.04,0.0,0.0,0.0,megan no macalystre,
+ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.48,0.26,0.22,0.04,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.5,0.21,0.04,0.11,0.07,0.0,0.0,0.07,andrew mathas,
+ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.82,0.0,0.04,0.0,0.07,0.0,0.0,0.07,katie jo vann,
+ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,benjamin hudson,
+ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.74,0.19,0.0,0.0,0.0,0.0,0.0,0.07,benjamin hudson,
+ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,2150,100,20th - 21st Century Lit (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,True
+ENGL,3010,1,Grt Books West World,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,eric allison,
+ENGL,3040,3,Business Writing,0.84,0.05,0.05,0.05,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,3040,5,Business Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3040,11,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,3040,13,Business Writing,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,
+ENGL,3040,15,Business Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3040,19,Business Writing,0.37,0.47,0.05,0.0,0.0,0.0,0.0,0.11,katalin beck,
+ENGL,3040,20,Business Writing,0.26,0.58,0.05,0.0,0.05,0.0,0.0,0.05,katalin beck,
+ENGL,3040,400,Business Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,3040,401,Business Writing,0.61,0.28,0.06,0.0,0.06,0.0,0.0,0.0,jillian weise,
+ENGL,3040,402,Business Writing,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,hayley ren zertuche,
+ENGL,3040,403,Business Writing,0.76,0.06,0.0,0.0,0.06,0.0,0.0,0.12,hayley ren zertuche,
+ENGL,3040,404,Business Writing,0.56,0.19,0.06,0.0,0.06,0.0,0.0,0.13,hayley ren zertuche,
+ENGL,3040,405,Business Writing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,
+ENGL,3040,406,Business Writing,0.27,0.47,0.27,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,
+ENGL,3040,407,Business Writing,0.07,0.6,0.07,0.07,0.07,0.0,0.0,0.13,steph kartalopoulos,
+ENGL,3040,408,Business Writing,0.29,0.35,0.0,0.12,0.12,0.0,0.0,0.12,steph kartalopoulos,
+ENGL,3040,409,Business Writing,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,steph kartalopoulos,
+ENGL,3100,1,Crit Writ Lit,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,david sweene coombs,
+ENGL,3100,3,Crit Writ Lit,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,michelle renee ty,
+ENGL,3100,4,Crit Writ Lit,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,michael lemahieu,
+ENGL,3120,1,Advanced Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3120,2,Advanced Composition,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,1,Technical Writing,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,katherine hanzalik,
+ENGL,3140,2,Technical Writing,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,katherine hanzalik,
+ENGL,3140,3,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
+ENGL,3140,5,Technical Writing,0.42,0.47,0.05,0.0,0.05,0.0,0.0,0.0,katalin beck,
+ENGL,3140,6,Technical Writing,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,william pulley,
+ENGL,3140,7,Technical Writing,0.47,0.26,0.05,0.05,0.11,0.0,0.0,0.05,william pulley,
+ENGL,3140,9,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,10,Technical Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,melissa dugan,
+ENGL,3140,11,Technical Writing,0.79,0.05,0.05,0.0,0.11,0.0,0.0,0.0,melissa dugan,
+ENGL,3140,12,Technical Writing,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,katalin beck,
+ENGL,3140,14,Technical Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,15,Technical Writing,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,crystal pa stephens,
+ENGL,3140,16,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3140,19,Technical Writing,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,geveryl le robinson,
+ENGL,3140,20,Technical Writing,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,geveryl le robinson,
+ENGL,3140,22,Technical Writing,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
+ENGL,3140,400,Technical Writing,0.21,0.57,0.07,0.0,0.14,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,3150,1,Scientific Writing & Comm,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,christopher benson,
+ENGL,3150,3,Scientific Writing & Comm,0.42,0.21,0.05,0.05,0.05,0.0,0.0,0.21,william pulley,
+ENGL,3150,4,Scientific Writing & Comm,0.58,0.16,0.11,0.0,0.0,0.0,0.0,0.16,william pulley,
+ENGL,3150,402,Sci Writing & Comm (NURSING),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,403,Sci Writing & Comm (NURSING),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3330,1,Writing News Media,0.6,0.13,0.07,0.0,0.0,0.0,0.0,0.2,geveryl le robinson,
+ENGL,3450,1,Structure of Fiction,0.42,0.47,0.0,0.0,0.05,0.0,0.0,0.05,keith morris,
+ENGL,3480,1,Structure Screenplay,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,nicholas chri brown,
+ENGL,3540,1,Lit Middle East & North Africa,0.38,0.19,0.06,0.0,0.19,0.0,0.0,0.19,angela naimou,
+ENGL,3570,1,Film,0.11,0.61,0.22,0.0,0.06,0.0,0.0,0.0,amy monaghan,
+ENGL,3570,2,Film,0.0,0.72,0.28,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3570,3,Film,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3850,1,Children's Lit,0.72,0.17,0.0,0.0,0.11,0.0,0.0,0.0,megan no macalystre,
+ENGL,3860,1,Adolescent Lit,0.06,0.88,0.0,0.0,0.06,0.0,0.0,0.0,amy monaghan,
+ENGL,3960,1,Brit Lit Survey I,0.38,0.19,0.19,0.13,0.06,0.0,0.0,0.06,erin marina goss,
+ENGL,3960,2,Brit Lit Survey I,0.36,0.36,0.29,0.0,0.0,0.0,0.0,0.0,erin marina goss,
+ENGL,3960,3,Brit Lit Survey I,0.14,0.36,0.21,0.0,0.14,0.0,0.0,0.14,erin marina goss,
+ENGL,3970,1,Brit Lit Survey II,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,john morgenstern,
+ENGL,3970,2,Brit Lit Survey II,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
+ENGL,3980,2,Amer Lit Survey I,0.38,0.44,0.06,0.0,0.06,0.0,0.0,0.06,jonathan beec field,
+ENGL,4110,1,Shakespeare,0.39,0.56,0.0,0.06,0.0,0.0,0.0,0.0,andrew lemons,
+ENGL,4110,2,Shakespeare,0.42,0.11,0.37,0.05,0.05,0.0,0.0,0.0,william stockton,
+ENGL,4110,3,Shakespeare,0.21,0.63,0.11,0.05,0.0,0.0,0.0,0.0,brian mcgrath,
+ENGL,4140,1,Milton,0.08,0.77,0.15,0.0,0.0,0.0,0.0,0.0,lee morrissey,
+ENGL,4190,1,Post Col & World Lit,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,cameron fa bushnell,
+ENGL,4210,1,Amer Lit 1800-1899,0.33,0.33,0.13,0.07,0.13,0.0,0.0,0.0,dominic mastroianni,
+ENGL,4250,1,American Novel,0.25,0.42,0.08,0.08,0.08,0.0,0.0,0.08,susanna ashton,
+ENGL,4260,1,Southern Literature,0.29,0.43,0.14,0.0,0.07,0.0,0.0,0.07,cameron fa bushnell,
+ENGL,4280,1,Contemporary Literature,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,michael lemahieu,
+ENGL,4350,1,Literary Criticism,0.31,0.5,0.13,0.0,0.06,0.0,0.0,0.0,jonathan beec field,
+ENGL,4360,1,Feminist Literary Criticism,0.39,0.56,0.0,0.0,0.06,0.0,0.0,0.0,erin marina goss,
+ENGL,4400,1,Literary Theory,0.42,0.32,0.16,0.0,0.11,0.0,0.0,0.0,walter edgar hunter,
+ENGL,4410,1,Literary Editing,0.28,0.5,0.06,0.06,0.06,0.0,0.0,0.06,gabriel and hankins,
+ENGL,4420,1,Cultural Studies,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,garry bertholf,
+ENGL,4500,1,Film Genres,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07, barton palmer,
+ENGL,4510,1,Film Theo/Criticism,0.75,0.06,0.13,0.0,0.0,0.0,0.0,0.06, barton palmer,
+ENGL,4630,1,Topics in Literature to 1699,0.18,0.55,0.18,0.0,0.0,0.0,0.0,0.09,andrew lemons,
+ENGL,4750,1,Writing for Media,0.31,0.38,0.13,0.0,0.13,0.0,0.0,0.06,megan eatman,
+ENGL,4780,1,Digital Literacy,0.18,0.55,0.18,0.0,0.09,0.0,0.0,0.0,gabriel and hankins,
+ENGL,4820,1,Afr Am Lit to 1920,0.0,0.6,0.1,0.0,0.3,0.0,0.0,0.0,rhondda robi thomas,
+ENGL,4960,1,Senior Seminar,0.69,0.15,0.0,0.0,0.15,0.0,0.0,0.0,dominic mastroianni,
+ENGL,4960,2,Senior Seminar,0.42,0.42,0.0,0.0,0.08,0.0,0.0,0.08,rhondda robi thomas,
+ENGL,4960,3,Senior Seminar,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,8080,1,Top Renaiss & Restoration Lit,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGR,1000,101,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,steven brandon,
+ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.01,steven brandon,
+ENGR,1020,117,Engineering Discipl & Skills,0.42,0.27,0.16,0.02,0.04,0.0,0.0,0.09,matthew kent miller,
+ENGR,1020,118,Engineering Discipl & Skills,0.15,0.53,0.11,0.02,0.02,0.0,0.0,0.17,matthew kent miller,
+ENGR,1020,312,Engineering Discipl & Skills,0.27,0.47,0.16,0.08,0.02,0.0,0.0,0.0,irene marie ferrara,
+ENGR,1020,313,Engineering Discipl & Skills,0.21,0.4,0.15,0.06,0.06,0.0,0.0,0.12,michael giebner,
+ENGR,1020,314,Engineering Discipl & Skills,0.32,0.32,0.16,0.0,0.02,0.0,0.0,0.18,michael giebner,
+ENGR,1020,316,Engineering Discipl & Skills,0.16,0.53,0.12,0.1,0.0,0.0,0.0,0.1,roksana mahmud,
+ENGR,1020,317,Engineering Discipl & Skills,0.16,0.45,0.16,0.06,0.02,0.0,0.0,0.16,jonathan maier,
+ENGR,1020,611,Engineering Discipl & Skills,0.1,0.45,0.24,0.08,0.06,0.0,0.0,0.08,john minor,
+ENGR,1020,612,Engineering Discipl & Skills,0.28,0.49,0.13,0.06,0.0,0.0,0.0,0.04,john minor,
+ENGR,1020,613,Engineering Discipl & Skills,0.19,0.4,0.19,0.08,0.0,0.0,0.0,0.13,mariah magagnotti,
+ENGR,1020,614,Engineering Discipl & Skills,0.29,0.4,0.21,0.04,0.02,0.0,0.0,0.04,irene marie ferrara,
+ENGR,1020,615,Engineering Discipl & Skills,0.35,0.39,0.18,0.0,0.0,0.0,0.0,0.08,irene marie ferrara,
+ENGR,1020,616,Engineering Discipl & Skills,0.17,0.42,0.23,0.04,0.02,0.0,0.0,0.13,sheikh moniruz moni,
+ENGR,1020,617,Engineering Discipl & Skills,0.28,0.3,0.18,0.06,0.06,0.0,0.0,0.12,andrew isaa neptune,
+ENGR,1020,618,Engineering Discipl & Skills,0.24,0.35,0.17,0.11,0.04,0.0,0.0,0.09,andrew isaa neptune,
+ENGR,1020,811,Engineering Discipl & Skills,0.34,0.38,0.15,0.09,0.0,0.0,0.0,0.04,ashley childers,
+ENGR,1020,812,Engineering Discipl & Skills,0.39,0.3,0.22,0.0,0.04,0.0,0.0,0.04,ashley childers,
+ENGR,1020,813,Engineering Discipl & Skills,0.21,0.42,0.21,0.04,0.02,0.0,0.0,0.1,elizabeth stephan,
+ENGR,1020,814,Engineering Discipl & Skills,0.4,0.36,0.13,0.04,0.02,0.0,0.0,0.04,andrew isaa neptune,
+ENGR,1020,815,Engineering Discipl & Skills,0.15,0.45,0.21,0.06,0.0,0.0,0.0,0.13,mariah magagnotti,
+ENGR,1020,816,Engineering Discipl & Skills,0.19,0.32,0.3,0.06,0.02,0.0,0.0,0.11,mariah magagnotti,
+ENGR,1020,817,Engineering Discipl & Skills,0.23,0.45,0.17,0.06,0.02,0.0,0.0,0.06,sarah grigg,
+ENGR,1020,818,Engineering Discipl & Skills,0.32,0.36,0.16,0.05,0.0,0.0,0.0,0.11,sarah grigg,
+ENGR,1020,831,Engr Discipl & Skills (HON),0.72,0.24,0.02,0.0,0.0,0.0,0.0,0.02,steven brandon,True
+ENGR,1020,832,Engr Discipl & Skills (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True
+ENGR,1050,246,Engr Discipline & Skills I,0.04,0.32,0.36,0.08,0.2,0.0,0.0,0.0,matthew kent miller,
+ENGR,1050,400,Engr Discipline & Skills I,0.07,0.07,0.29,0.25,0.18,0.0,0.0,0.14,matthew kent miller,
+ENGR,1060,246,Engr Discipline & Skills II,0.04,0.29,0.25,0.29,0.13,0.0,0.0,0.0,matthew kent miller,
+ENGR,1060,400,Engr Discipline & Skills II,0.12,0.24,0.29,0.06,0.24,0.0,0.0,0.06,matthew kent miller,
+ENGR,1150,500,Engineering Design & Modeling,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,john minor,
+ENGR,1410,225,Programming & Problem Solving,0.06,0.3,0.26,0.09,0.19,0.0,0.0,0.11,richard watkins,
+ENGR,1410,226,Programming & Problem Solving,0.16,0.24,0.2,0.08,0.2,0.0,0.0,0.14,elizabeth stephan,
+ENGR,1410,227,Programming & Problem Solving,0.08,0.29,0.29,0.06,0.12,0.0,0.0,0.17,william martin,
+ENGR,1410,228,Programming & Problem Solving,0.08,0.24,0.33,0.18,0.04,0.0,0.0,0.12,william martin,
+ENGR,1520,501,Engineering Computer Skills,0.29,0.52,0.19,0.0,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,1520,502,Engineering Computer Skills,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,1900,10,CI in Engr I Robotics,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,michael benj wooten,
+ENGR,1900,77,CI in ENGR Human Powered Veh,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,gregory mocko,
+ENGR,2080,681,Engr Graphics & Machine Design,0.43,0.23,0.09,0.09,0.15,0.0,0.0,0.02,nighat yasmin,
+ENGR,2080,682,Engr Graphics & Machine Design,0.31,0.25,0.25,0.06,0.04,0.0,0.0,0.08,amaninder sing gill,
+ENGR,2080,684,Engr Graphics & Machine Design,0.21,0.21,0.21,0.06,0.23,0.0,0.0,0.08,amaninder sing gill,
+ENGR,2080,685,Engr Graphics & Machine Design,0.31,0.22,0.22,0.08,0.08,0.0,0.0,0.08,anthony pau garland,
+ENGR,2080,686,Engr Graphics & Machine Design,0.5,0.24,0.11,0.02,0.04,0.0,0.0,0.09,anthony pau garland,
+ENGR,2100,804,CAD & Engineering Applications,0.43,0.37,0.07,0.0,0.04,0.0,0.0,0.09,nighat yasmin,
+ENGR,2100,805,CAD & Engineering Applications,0.33,0.41,0.22,0.02,0.02,0.0,0.0,0.0,nighat yasmin,
+ENGR,2100,806,CAD & Engineering Applications,0.36,0.33,0.13,0.05,0.03,0.0,0.0,0.1, shams esfandabadi,
+ENGR,2200,106,Evaluating Innovations,0.55,0.39,0.05,0.0,0.0,0.0,0.0,0.0,sarah grigg,
+ENR,1010,1,Intro to Envir & Natur Res I,0.75,0.15,0.03,0.03,0.03,0.0,0.0,0.01,alan johnson,
+ENR,1010,2,Intro to Envir & Natur Res I,0.5,0.31,0.13,0.04,0.02,0.0,0.0,0.0,alan johnson,
+ENR,4290,1,Environ Law & Policy,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
+ENSP,2000,1,Intro Environ Sci,0.23,0.52,0.16,0.05,0.0,0.0,0.0,0.05,scott brame,
+ENSP,2000,2,Intro Environ Sci,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2000,3,Intro Environ Sci,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2000,4,Intro Environ Sci,0.34,0.5,0.09,0.0,0.05,0.0,0.0,0.02,elizabeth carraway,
+ENSP,4000,1,Studies in Environmental Sci,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,margaret thompson,
+ENT,2000,1,Six-Legged Science,0.68,0.17,0.1,0.0,0.0,0.0,0.0,0.05,suellen pometto,
+ENT,3010,1,Insect Biology and Diversity,0.33,0.33,0.29,0.0,0.05,0.0,0.0,0.0,eric benson,
+ENTR,1010,1,Entrepreneurial Mindset,0.48,0.39,0.07,0.01,0.03,0.0,0.0,0.02,john michael hannon,
+ESED,8790,1,Curr Top STEM Education Policy,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,julie patric martin,
+FCS,8130,1,Research Methods in FCS I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,
+FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.67,0.19,0.05,0.02,0.03,0.0,0.0,0.04,aubrey dean coffee,
+FDSC,4010,1,Food Chemistry I,0.58,0.33,0.09,0.0,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4040,1,Food Prsv & Process,0.53,0.43,0.04,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,
+FDSC,4070,1,Quantity Food Production,0.78,0.14,0.03,0.0,0.03,0.0,0.0,0.02,heather batt,
+FDSC,4170,1,Seminar,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,aubrey dean coffee,
+FDSC,4200,1,Food Regulation and Policy,0.91,0.06,0.01,0.0,0.01,0.0,0.0,0.01, rhodehamel,
+FDSC,4300,1,Dairy Process & Sant,0.44,0.28,0.22,0.0,0.06,0.0,0.0,0.0,john mcgregor,
+FDSC,8120,1,Microbial Food Syst,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,xiuping jiang,
+FIN,2010,401,Intro to Personal Finance,0.55,0.24,0.05,0.02,0.05,0.0,0.0,0.1,joshua harris,
+FIN,2010,402,Intro to Personal Finance,0.35,0.23,0.14,0.07,0.05,0.0,0.0,0.16,joshua harris,
+FIN,2010,403,Intro to Personal Finance,0.4,0.33,0.14,0.02,0.09,0.0,0.0,0.02,joshua harris,
+FIN,2010,404,Intro to Personal Finance,0.56,0.26,0.04,0.02,0.08,0.0,0.0,0.04,joshua harris,
+FIN,2010,405,Intro to Personal Finance,0.55,0.26,0.02,0.06,0.04,0.0,0.0,0.06,joshua harris,
+FIN,2010,406,Intro to Personal Finance,0.64,0.2,0.05,0.02,0.05,0.0,0.0,0.05,joshua harris,
+FIN,3040,1,Risk & Insurance,0.2,0.33,0.4,0.07,0.0,0.0,0.0,0.0,kerri mcmillan,
+FIN,3040,2,Risk & Insurance,0.19,0.19,0.58,0.03,0.0,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.18,0.32,0.37,0.05,0.03,0.0,0.0,0.05,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.15,0.51,0.23,0.05,0.03,0.0,0.0,0.03,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.54,0.21,0.21,0.0,0.05,0.0,0.0,0.0,thomas albe wessels,
+FIN,3050,4,Investment Analysis,0.27,0.27,0.36,0.09,0.0,0.0,0.0,0.0,thomas albe wessels,
+FIN,3060,2,Corporation Finance,0.16,0.05,0.22,0.22,0.11,0.0,0.0,0.24,william hol johnson,
+FIN,3060,3,Corporation Finance,0.18,0.13,0.24,0.18,0.24,0.0,0.0,0.03,william hol johnson,
+FIN,3060,4,Corporation Finance,0.0,0.25,0.15,0.28,0.3,0.0,0.0,0.03,william hol johnson,
+FIN,3060,5,Corporation Finance,0.26,0.32,0.19,0.14,0.05,0.0,0.0,0.04,ramon tolb franklin,
+FIN,3060,6,Corporation Finance,0.24,0.31,0.24,0.07,0.05,0.0,0.0,0.09,ramon tolb franklin,
+FIN,3060,7,Corporation Finance,0.22,0.29,0.22,0.19,0.05,0.0,0.0,0.03,ramon tolb franklin,
+FIN,3060,8,Corporation Finance,0.18,0.1,0.41,0.25,0.04,0.0,0.0,0.02,melvin stith,
+FIN,3060,9,Corporation Finance,0.14,0.27,0.31,0.18,0.06,0.0,0.0,0.04,melvin stith,
+FIN,3060,10,Corporation Finance,0.15,0.33,0.22,0.15,0.11,0.0,0.0,0.04,ramon tolb franklin,
+FIN,3060,11,Corporation Finance,0.05,0.13,0.43,0.15,0.2,0.0,0.0,0.05,william hol johnson,
+FIN,3070,1,Prin of Real Estate,0.2,0.33,0.25,0.1,0.1,0.0,0.0,0.03,thomas springer,
+FIN,3070,2,Prin of Real Estate,0.15,0.4,0.3,0.05,0.1,0.0,0.0,0.0,thomas springer,
+FIN,3070,3,Prin of Real Estate,0.21,0.5,0.21,0.02,0.02,0.0,0.0,0.02,yannan shen,
+FIN,3080,1,Fin Inst & Mkts,0.23,0.55,0.17,0.02,0.0,0.0,0.0,0.02,lyudmila chernykh,
+FIN,3080,2,Fin Inst & Mkts,0.2,0.57,0.22,0.0,0.0,0.0,0.0,0.02,lyudmila chernykh,
+FIN,3080,3,Fin Inst & Mkts,0.25,0.38,0.31,0.06,0.0,0.0,0.0,0.0,daniel thoma greene,
+FIN,3110,1,Financial Management I,0.06,0.06,0.21,0.03,0.29,0.0,0.0,0.35,jack wolf,
+FIN,3110,2,Financial Management I,0.13,0.17,0.27,0.13,0.15,0.0,0.0,0.17,jack wolf,
+FIN,3110,3,Financial Management I,0.21,0.3,0.34,0.13,0.0,0.0,0.0,0.02,weike xu,
+FIN,3110,4,Financial Management I,0.16,0.22,0.2,0.14,0.16,0.0,0.0,0.12,john alexander,
+FIN,3120,1,Financial Management II,0.08,0.47,0.26,0.05,0.08,0.0,0.0,0.05,vincent intintoli,
+FIN,3120,2,Financial Management II,0.13,0.46,0.19,0.13,0.07,0.0,0.0,0.02,vincent intintoli,
+FIN,3120,3,Financial Management II,0.24,0.48,0.19,0.02,0.05,0.0,0.0,0.02,blerina zykaj,
+FIN,3120,4,Financial Management II,0.24,0.49,0.17,0.05,0.05,0.0,0.0,0.0,weike xu,
+FIN,4010,1,Corporate Financial Analysis,0.36,0.4,0.16,0.04,0.04,0.0,0.0,0.0,george bra lockhart,
+FIN,4020,1,Corporate Valuation,0.23,0.45,0.32,0.0,0.0,0.0,0.0,0.0,angela morgan,
+FIN,4020,2,Corporate Valuation,0.29,0.29,0.29,0.1,0.03,0.0,0.0,0.0,angela morgan,
+FIN,4050,1,Portfolio Management & Theory,0.18,0.21,0.43,0.11,0.04,0.0,0.0,0.04,john alexander,
+FIN,4060,1,Derivatives Analysis,0.21,0.35,0.32,0.06,0.03,0.0,0.0,0.03,blerina zykaj,
+FIN,4110,1,Int Fin Mgt,0.12,0.62,0.21,0.0,0.0,0.0,0.0,0.06,luke asher devault,
+FIN,4110,2,Int Fin Mgt,0.17,0.52,0.22,0.04,0.0,0.0,0.0,0.04,luke asher devault,
+FIN,4170,1,Real Estate Finance,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,yannan shen,
+FIN,4980,3,Creative Inquiry in Finance,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,angela morgan,
+FNR,2040,1,Soil Information Systems,0.9,0.08,0.0,0.02,0.0,0.0,0.0,0.0,elena mikhailova,
+FNR,4700,1,Kennedy Waterfowl CI,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
+FNR,4990,1,Natural Resources Seminar,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
+FOR,2050,1,Dendrology,0.32,0.34,0.16,0.05,0.08,0.0,0.0,0.05,donald hagan,
+FOR,2050,2,Dendrology,0.24,0.24,0.21,0.06,0.15,0.0,0.0,0.09,donald hagan,
+FOR,2050,3,Dendrology,0.31,0.36,0.16,0.07,0.0,0.0,0.0,0.11,donald hagan,
+FOR,2210,1,Forest Biology,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,thomas adam coates,
+FOR,3020,1,Forest Biometrics,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,lawrence gering,
+FOR,3040,1,Forest Resource Economics,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,puskar khanal,
+FOR,4100,1,Harvesting Processes,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,patrick hiesl,
+FOR,4160,1,Forest Policy and Admin,0.23,0.52,0.21,0.03,0.0,0.0,0.0,0.01,thomas straka,
+FOR,4170,1,Forest Resource Mgt & Regulatn,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,
+FOR,4310,1,Recreation Res Plan in For Mgt,0.54,0.33,0.13,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
+FOR,4340,1,GIS for Natural Resources,0.67,0.28,0.04,0.0,0.0,0.0,0.0,0.0,christopher post,
+FOR,8930,7,Statistical Methods in Nat Res,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,patrick hiesl,
+FR,1010,1,Elementary French,0.26,0.47,0.16,0.0,0.05,0.0,0.0,0.05,anne salces  nedeo,
+FR,1020,1,Elementary French,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,
+FR,1020,2,Elementary French,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,1,Intermediate French,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,paulin de tholozany,
+FR,2010,2,Intermediate French,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,2010,4,Intermediate French,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,paulin de tholozany,
+FR,2020,1,Intermediate French,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2020,2,Intermediate French,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,eric touya,
+FR,2020,3,Intermediate French,0.47,0.18,0.29,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,
+FR,2020,4,Intermediate French,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,3000,1,Survey of French Lit,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
+FR,3050,1,Int Fr Con & Comp I,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,anne salces  nedeo,
+FR,3050,2,Int Fr Con & Comp I,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
+FR,3070,1,French Civilization,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
+FR,4160,1,Fr for Intl Trade II,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,eric touya,
+GC,1010,1,Orientation to G C,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,nona woolbright,
+GC,1010,2,Orientation to G C,0.71,0.16,0.02,0.04,0.04,0.0,0.0,0.02,carol jones,
+GC,1020,1,Computer Art & CAD Foundations,0.39,0.39,0.11,0.06,0.04,0.0,0.0,0.02,carol jones,
+GC,1020,2,Computer Art & CAD Foundations,0.53,0.33,0.07,0.0,0.05,0.0,0.0,0.02,nona woolbright,
+GC,1030,1,G C I for Pkgsc,0.32,0.42,0.11,0.05,0.05,0.0,0.0,0.05,john jacobs,
+GC,1040,1,Graphic Communications I,0.54,0.25,0.11,0.0,0.07,0.0,0.0,0.04,rebecca suza edlein,
+GC,2070,1,Graphic Communications II,0.66,0.24,0.03,0.02,0.03,0.0,0.0,0.02,charles tabor weiss,
+GC,2400,1,Intro to Web Design and Dev,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,erica black walker,
+GC,3400,1,Digital Imaging and eMedia,0.34,0.53,0.11,0.0,0.0,0.0,0.0,0.03,erica black walker,
+GC,3460,1,Ink and Substrates,0.26,0.56,0.11,0.03,0.04,0.0,0.0,0.0,liam henry 'hara,
+GC,4060,1,Package and Specialty Printing,0.8,0.11,0.0,0.0,0.05,0.0,0.0,0.05,kern cox,
+GC,4400,1,Commercial Printing,0.43,0.43,0.04,0.0,0.07,0.0,0.0,0.04,eric weisenmiller,
+GC,4400,2,Commercial Printing,0.39,0.43,0.09,0.0,0.04,0.0,0.0,0.04,eric weisenmiller,
+GC,4440,1,Current Dev/Trends in Gr Comm,0.79,0.16,0.0,0.0,0.03,0.0,0.0,0.03,samuel ingram,
+GC,4480,1,Plan & Cont Printing Functions,0.49,0.38,0.08,0.05,0.0,0.0,0.0,0.0,john leininger,
+GC,4800,1,Senior Seminar in GC,0.63,0.32,0.02,0.02,0.0,0.0,0.0,0.0,charles edwa tonkin,
+GC,4900,230,G C Selected Topics-GC Sales,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,
+GEN,1030,1,Careers in Bioch/Gen,0.8,0.15,0.04,0.0,0.0,0.0,0.0,0.01,alison starr-moss,
+GEN,3000,1,Fundamental Genetics,0.29,0.37,0.18,0.11,0.02,0.0,0.0,0.03,kate leanne wi tsai,
+GEN,3000,2,Fundamental Genetics,0.21,0.4,0.25,0.06,0.03,0.0,0.0,0.05,kate leanne wi tsai,
+GEN,3020,1,Molecular & General Genetics,0.4,0.35,0.15,0.04,0.02,0.0,0.0,0.04,lukasz kozubowski,
+GEN,3020,2,Molec & General Genetics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True
+GEN,3020,4,Molecular & General Genetics,0.35,0.42,0.14,0.05,0.0,0.0,0.0,0.05,haiying liang,
+GEN,4200,1,Molecular Genetics & Gene Reg,0.27,0.51,0.19,0.0,0.0,0.0,0.0,0.03,julia frugoli,
+GEN,4200,2,Molecular Genetics & Gen (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True
+GEN,4400,1,Bioinformatics,0.73,0.09,0.05,0.0,0.0,0.0,0.0,0.14,frank alexan feltus,
+GEN,4500,1,Comparative Genetics,0.3,0.54,0.14,0.0,0.03,0.0,0.0,0.0,leigh anne clark,
+GEN,4900,1,Epigenetics,0.42,0.17,0.25,0.0,0.08,0.0,0.0,0.08,rajandeep si sekhon,
+GEN,6200,1,Molecular Genetics & Gene Reg,0.0,0.67,0.17,0.0,0.0,0.0,0.0,0.17,julia frugoli,
+GEN,6400,1,Bioinformatics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
+GEN,8140,1,Advanced Genetics,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
+GEOG,1010,1,Intro to Geography,0.3,0.45,0.2,0.05,0.0,0.0,0.0,0.0,william churc terry,
+GEOG,1030,1,World Regional Geog,0.78,0.12,0.06,0.0,0.02,0.0,0.0,0.02,lance forres howard,
+GEOG,1030,2,World Regional Geog,0.8,0.18,0.0,0.03,0.0,0.0,0.0,0.0,lance forres howard,
+GEOG,1060,1,Geog Phys Envt,0.42,0.16,0.21,0.11,0.11,0.0,0.0,0.0,william churc terry,
+GEOL,1010,1,Physical Geology,0.27,0.32,0.24,0.08,0.05,0.0,0.0,0.03,alan coulson,
+GEOL,1010,2,Physical Geology,0.24,0.31,0.24,0.09,0.07,0.0,0.0,0.05,alan coulson,
+GEOL,1010,3,Physical Geology,0.49,0.2,0.14,0.06,0.1,0.0,0.0,0.0,kelly best lazar,
+GEOL,1030,1,Physical Geol Lab,0.54,0.33,0.04,0.0,0.08,0.0,0.0,0.0,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.48,0.3,0.13,0.0,0.0,0.0,0.0,0.09,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.64,0.23,0.05,0.0,0.05,0.0,0.0,0.05,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.22,0.43,0.26,0.0,0.04,0.0,0.0,0.04,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.38,0.38,0.04,0.04,0.08,0.0,0.0,0.08,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.38,0.57,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.04,0.58,0.21,0.0,0.04,0.0,0.0,0.13,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.2,0.5,0.15,0.1,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.67,0.0,0.2,0.0,0.0,0.0,0.0,0.13,alan coulson,
+GEOL,2050,1,Mineralogy & Intro Petrology,0.45,0.18,0.36,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,2070,1,Min & Intro Pet Lab,0.09,0.18,0.45,0.18,0.09,0.0,0.0,0.0,alan coulson,
+GEOL,2700,1,Sustainable Water,0.83,0.06,0.03,0.03,0.0,0.0,0.0,0.06,stephen mich moysey,
+GEOL,2750,1,Field Methods,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,scott brame,
+GEOL,3000,1,Environmental Geology,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,3020,1,Structural Geology,0.27,0.27,0.36,0.09,0.0,0.0,0.0,0.0,james castle,
+GEOL,4110,2,Exploring Sustainability,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.08,kelly best lazar,
+GEOL,4110,8,CI - Community Outreach,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,john robert wagner,
+GEOL,4820,1,Groundwater & Contam Transport,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,lawrence murdoch,
+GEOL,4910,1,Research Synthesis I,0.5,0.33,0.08,0.0,0.08,0.0,0.0,0.0,alan coulson,
+GEOL,6150,1,Analysis Geological Processes,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
+GEOL,8080,1,Groundwater Modeling,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
+GER,1010,1,Elementary German,0.21,0.29,0.36,0.0,0.07,0.0,0.0,0.07, lee ferrell,
+GER,1010,2,Elementary German,0.13,0.5,0.25,0.06,0.0,0.0,0.0,0.06, lee ferrell,
+GER,1020,1,Elementary German,0.38,0.38,0.08,0.08,0.0,0.0,0.0,0.08,oswald harris king,
+GER,1020,2,Elementary German,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,2010,1,Intermediate German,0.53,0.27,0.07,0.13,0.0,0.0,0.0,0.0,oswald harris king,
+GER,2010,2,Intermediate German,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,2020,1,Intermediate German,0.13,0.33,0.27,0.13,0.13,0.0,0.0,0.0,gabriela stoicea,
+GER,3050,1,Ger Conv & Comp,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0, lee ferrell,
+GER,3400,1,German Culture,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,oswald harris king,
+GER,4170,1,Topics Ger Intl TR,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0, lee ferrell,
+HCC,8310,1,Fundamentals of Hcc,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,bart knijnenburg,
+HCC,8330,1,HCC Research Methods,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
+HCG,9890,403,Interdisiplinary Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,julia eggert,
+HEHD,8030,400,Ethical Leadership,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,
+HEHD,8050,1,Yth Dev in Families,0.71,0.12,0.12,0.0,0.0,0.0,0.0,0.06,william quinn,
+HEHD,8060,230,Diverse Society,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,ann marie gillard,
+HIST,1010,1,Hist of the U S,0.33,0.48,0.1,0.01,0.03,0.0,0.0,0.05,james brad jeffries,
+HIST,1020,1,Hist of the U S,0.37,0.27,0.14,0.12,0.04,0.0,0.0,0.06,john andrew,
+HIST,1220,1,"Hist, Tech & Society",0.09,0.55,0.29,0.03,0.02,0.0,0.0,0.02,pamela mack,
+HIST,1240,1,Environmental History Survey,0.3,0.45,0.21,0.0,0.0,0.0,0.0,0.03,james brad jeffries,
+HIST,1240,2,Environmental History Survey,0.3,0.45,0.15,0.0,0.06,0.0,0.0,0.03,james brad jeffries,
+HIST,1720,1,The West and the World I,0.15,0.38,0.22,0.07,0.1,0.0,0.0,0.07,caroline dunn clark,
+HIST,1720,2,The West and the World I,0.26,0.54,0.14,0.03,0.02,0.0,0.0,0.02,steven marks,
+HIST,1730,1,The West and the World II,0.41,0.37,0.08,0.02,0.09,0.0,0.0,0.04, alan grubb,
+HIST,1730,2,The West and the World II,0.41,0.27,0.18,0.09,0.05,0.0,0.0,0.0,subah dayal,
+HIST,2990,1,Historian's Craft,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,michael silvestri,
+HIST,2990,2,Historian's Craft,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,elizabeth carney,
+HIST,2990,3,Historian's Craft,0.54,0.31,0.0,0.0,0.0,0.0,0.0,0.15,rachel anne moore,
+HIST,3040,1,Indus & Progr Era,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0, roger grant,
+HIST,3120,1,Afr Amer Hist 1877 to Present,0.68,0.21,0.0,0.0,0.11,0.0,0.0,0.0,abel bartley,
+HIST,3140,1,Hist of the South I,0.24,0.59,0.0,0.0,0.07,0.0,0.0,0.1,paul chris anderson,
+HIST,3290,1,US Legal History Since 1890,0.44,0.33,0.11,0.0,0.06,0.0,0.0,0.06,renee roux,
+HIST,3380,1,Africa to 1875,0.6,0.2,0.15,0.0,0.05,0.0,0.0,0.0,james burns,
+HIST,3400,1,Latin America I,0.63,0.17,0.07,0.03,0.03,0.0,0.0,0.07,rachel anne moore,
+HIST,3550,1,Roman World,0.33,0.56,0.04,0.0,0.04,0.0,0.0,0.04,elizabeth carney,
+HIST,3630,1,Britain Since 1688,0.28,0.38,0.13,0.16,0.06,0.0,0.0,0.0,stephani barczewski,
+HIST,3670,1,Modern Ireland,0.44,0.29,0.09,0.0,0.12,0.0,0.0,0.06,michael silvestri,
+HIST,3700,1,Medieval History,0.27,0.5,0.13,0.0,0.0,0.0,0.0,0.1,caroline dunn clark,
+HIST,3720,1,Renaissance,0.33,0.39,0.11,0.06,0.0,0.0,0.0,0.11,thomas kuehn,
+HIST,3890,7,Mitchelville,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,abel bartley,
+HIST,3890,8,The Churches of Mitchelville,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,abel bartley,
+HIST,3900,1,Modern Military History,0.22,0.3,0.22,0.04,0.19,0.0,0.0,0.04,edwin moise,
+HIST,3980,1,American Military History,0.31,0.38,0.24,0.0,0.03,0.0,0.0,0.03,john andrew,
+HIST,4140,1,Study of Hist Museum,0.25,0.5,0.06,0.13,0.06,0.0,0.0,0.0,meg taylor-shockley,
+HIST,4360,1,Vietnam Wars,0.05,0.37,0.37,0.0,0.11,0.0,0.0,0.11,edwin moise,
+HIST,4710,1,The Great War,0.55,0.17,0.03,0.0,0.1,0.0,0.0,0.14, alan grubb,
+HIST,4900,3,Europe's Age of Dictators,0.42,0.47,0.05,0.0,0.0,0.0,0.0,0.05,amit bein,
+HIST,8000,2,Historical Methods,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,paul chris anderson,
+HIST,8100,3,Capitalism,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,
+HLTH,2020,1,Introduction to Public Health,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,2,Introduction to Public Health,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,3,Introduction to Public Health,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,4,Introduction to Public Health,0.43,0.43,0.13,0.03,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,5,Introduction to Public Health,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,400,Introduction to Public Health,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.57,0.26,0.09,0.0,0.04,0.0,0.0,0.04,frederic fraizer,
+HLTH,2030,2,Health Care Sys,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,lee alden crandall,
+HLTH,2400,1,Deter of Hlth Behav,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,johnny long,
+HLTH,2400,2,Deter of Hlth Behav,0.36,0.54,0.07,0.04,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2400,3,Deter of Hlth Behav,0.52,0.31,0.17,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2400,400,Deter of Hlth Behav,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,amelia clinkscales,
+HLTH,2600,1,Medical Terminology & Comm,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kari jea strothmann,
+HLTH,2980,1,Human Hlth & Disease,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,2980,2,Human Hlth & Disease,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,2980,3,Human Hlth & Disease,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,3050,1,Body Resp Hlth Beh,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brian patric graves,
+HLTH,3400,1,Hlth Prom Prog Plan,0.39,0.43,0.13,0.0,0.04,0.0,0.0,0.0,brian patric graves,
+HLTH,3610,1,Int Health Care Econ,0.56,0.29,0.09,0.03,0.0,0.0,0.0,0.03,khoa dang truong,
+HLTH,3800,1,Epidemiology,0.3,0.36,0.27,0.02,0.02,0.0,0.0,0.02,hugh spitler,
+HLTH,3800,2,Epidemiology,0.55,0.34,0.1,0.0,0.0,0.0,0.0,0.0,rachel mayo,
+HLTH,3800,400,Epidemiology,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,deborah alma falta,
+HLTH,4150,1,Obesity & Eating Dis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,karen kemper,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.63,0.28,0.1,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4400,1,Manag Hlth Serv Org,0.37,0.37,0.19,0.04,0.04,0.0,0.0,0.0,frederic fraizer,
+HLTH,4700,1,Global Health,0.67,0.21,0.08,0.0,0.04,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,4700,400,Global Health,0.88,0.08,0.0,0.04,0.0,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,4750,1,Hlthcr Oper Mgmt Res,0.59,0.18,0.18,0.0,0.0,0.0,0.0,0.05,lu shi,
+HLTH,4900,1,Res Eval St Pub Hlth,0.51,0.37,0.1,0.02,0.0,0.0,0.0,0.0,lingling zhang,
+HLTH,4900,2,Res Eval St Pub Hlth,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,lingling zhang,
+HLTH,8090,1,Epidemiological Res,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,liwei chen,
+HLTH,8120,500,Clinical and Translational Sci,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,ronald gimbel,
+HON,1910,1,Romanticism and Its Influence,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,
+HON,1930,1,World in Crisis,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vladimir matic,
+HON,2020,1,Who Decides What's Cool?,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,amanda cooper fine,
+HON,2020,2,World of Ideas,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,
+HON,2220,1,Almost Human,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,
+HORT,1010,1,Horticulture,0.86,0.09,0.02,0.02,0.0,0.0,0.0,0.02,ellen anita vincent,
+HORT,2100,1,Growing Fall Plants,0.26,0.57,0.13,0.0,0.04,0.0,0.0,0.0,james emerson faust,
+HORT,2120,1,Turfgrass Culture,0.52,0.38,0.07,0.0,0.02,0.0,0.0,0.02,haibo liu,
+HORT,2130,1,Turf Culture Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,donald garrett,
+HORT,2130,2,Turf Culture Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,donald garrett,
+HORT,3030,1,Landscape Plants,0.18,0.32,0.35,0.04,0.03,0.0,0.0,0.07,robert polomski,
+HORT,3080,1,Sust Landsc Des Install Maint,0.84,0.12,0.02,0.0,0.0,0.0,0.0,0.02,ellen anita vincent,
+HORT,4330,1,Turf Weed Management,0.21,0.36,0.36,0.07,0.0,0.0,0.0,0.0,ted whitwell,
+HORT,4550,1,Just Fruits,0.39,0.43,0.13,0.0,0.04,0.0,0.0,0.0,gregory reighard,
+HP,8010,1,Preservation Law and Econ,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,richard sidebottom,
+HP,8030,1,Building Tech and Pathology,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,amalia leifeste,
+HP,8090,400,Historical Research Methods,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,katherine pemberton,
+HP,8230,400,Historic American Interiors,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,elizabeth garr ryan,
+HRD,8200,400,Human Perform Improv,0.62,0.17,0.0,0.0,0.14,0.0,0.0,0.07,cynthia sims,
+HRD,8300,400,Concepts of H R D,0.46,0.27,0.08,0.0,0.15,0.0,0.0,0.04,charlotte ann chase,
+HRD,8450,400,Needs Assess Ed/Ind,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,philip mcgee,
+HRD,8600,400,Instruc Mat Devel,0.76,0.06,0.03,0.0,0.12,0.0,0.0,0.03,philip mcgee,
+IE,2000,100,Soph Seminar in I E,0.54,0.19,0.12,0.04,0.05,0.0,0.0,0.06,brian melloy,
+IE,2100,1,Des Analysis Wrk Sys,0.07,0.39,0.32,0.1,0.05,0.0,0.0,0.06,david neyens,
+IE,2800,1,Deterministic Operations Rsrch,0.16,0.4,0.16,0.13,0.08,0.0,0.0,0.07,robert james riggs,
+IE,3010,1,Systems Design I,0.47,0.43,0.09,0.0,0.0,0.0,0.0,0.01,robert james riggs,
+IE,3600,1,Industrial Apps of Prob/Stat I,0.29,0.27,0.29,0.06,0.08,0.0,0.0,0.02,tugce isik,
+IE,3600,2,Industrial Apps of Prob/Stat I,0.18,0.27,0.27,0.18,0.05,0.0,0.0,0.05,tugce isik,
+IE,3610,1,Industrial App of Prob/Stat II,0.27,0.27,0.15,0.15,0.12,0.0,0.0,0.04,joel greenstein,
+IE,3680,1,Prof Practice in I E,0.87,0.05,0.02,0.03,0.0,0.0,0.0,0.02,brian melloy,
+IE,3810,1,Probabilistic Operations Rsrch,0.24,0.32,0.21,0.08,0.13,0.0,0.0,0.03,amin khademi,
+IE,3840,1,Engr Econ Analysis,0.21,0.15,0.11,0.12,0.12,0.0,0.0,0.29,brian melloy,
+IE,3860,1,Prod Plan & Cont,0.21,0.37,0.17,0.11,0.13,0.0,0.0,0.0,robert james riggs,
+IE,4400,1,Decision Support Sys,0.64,0.14,0.09,0.05,0.05,0.0,0.0,0.03,jonathan lowe,
+IE,4570,1,Transp/Logistic Engr,0.25,0.59,0.15,0.02,0.0,0.0,0.0,0.0,sandra dun eksioglu,
+IE,4610,1,Quality Engineering,0.25,0.28,0.27,0.15,0.03,0.0,0.0,0.03,byung rae cho,
+IE,4650,1,Facilities Planning & Design,0.78,0.17,0.03,0.02,0.0,0.0,0.0,0.0,jonathan lowe,
+IE,4650,2,Facilities Planning & Design,0.42,0.33,0.13,0.13,0.0,0.0,0.0,0.0,brian melloy,
+IE,4820,1,Systems Modeling,0.36,0.39,0.18,0.04,0.01,0.0,0.0,0.01,kevin taaffe,
+IE,4820,2,Systems Modeling,0.26,0.55,0.1,0.07,0.0,0.0,0.0,0.02,kevin taaffe,
+IE,4910,1,Invest Human Errors Cmplx Sys,0.31,0.31,0.09,0.06,0.03,0.0,0.0,0.2,sara lu riggs,
+IE,6910,2,Advanced Math Opt Models,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
+IE,8000,1,Human Factors Eng,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david neyens,
+IE,8010,1,Human-Machine Sys,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,
+IE,8030,1,Engr Optimization and Apps,0.27,0.5,0.18,0.0,0.0,0.0,0.0,0.05,amin khademi,
+IE,8040,1,Mfg Sys Plan & Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,
+IE,8090,1,Model Sys Under Risk,0.17,0.61,0.17,0.0,0.0,0.0,0.0,0.06,burak eksioglu,
+IE,8510,1,Descriptive Analytics,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,mary elizabeth kurz,
+IE,8530,1,Foundations of Quality,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,byung rae cho,
+IE,8550,1,SC & Logistics Modeling II,0.8,0.11,0.04,0.0,0.04,0.0,0.0,0.0,kevin taaffe,
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.84,0.14,0.02,caren kelley-hall,
+INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.92,0.06,0.02,caren kelley-hall,
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,
+INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.83,0.14,0.03,caren kelley-hall,
+INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.82,0.12,0.06,caren kelley-hall,
+IPM,4010,1,Principles of I P M,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,robert bellinger,
+IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.86,0.05,0.09,meredith fan wilson,
+ITAL,1010,1,Elementary Italian,0.33,0.25,0.25,0.08,0.08,0.0,0.0,0.0,julia schmidt,
+ITAL,1010,2,Elementary Italian,0.59,0.12,0.06,0.0,0.06,0.0,0.0,0.18,julia schmidt,
+ITAL,1010,3,Elementary Italian,0.67,0.17,0.0,0.0,0.08,0.0,0.0,0.08,lyudmyla tsykalova,
+ITAL,1010,4,Elementary Italian,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+ITAL,2010,1,Intermediate Italian,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
+ITAL,2020,1,Intermediate Italian,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
+JAPN,1010,1,Elementary Japanese,0.58,0.08,0.17,0.0,0.08,0.0,0.0,0.08,shinichi shoji,
+JAPN,1010,2,Elementary Japanese,0.53,0.18,0.24,0.0,0.0,0.0,0.0,0.06,shinichi shoji,
+JAPN,1010,3,Elementary Japanese,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,shinichi shoji,
+JAPN,2010,1,Intermed Japanese,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,jae allegr takeuchi,
+JAPN,3050,1,Japanese Conversation & Comp,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,kazuko shoji,
+JAPN,4010,1,Japanese Lit in Translation,0.76,0.0,0.12,0.0,0.0,0.0,0.0,0.12,jae allegr takeuchi,
+LANG,3000,1,Intro Linguistics,0.33,0.39,0.06,0.06,0.06,0.0,0.0,0.11,daniel smith,
+LANG,3710,1,Language and Culture,0.3,0.3,0.2,0.1,0.1,0.0,0.0,0.0,yanhua zhang,
+LARC,1150,1,Intro Landscape Architecture,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
+LARC,1280,1,Technical Graphics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
+LARC,1510,1,Basic Design I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
+LARC,2510,1,Larch Design Fund,0.4,0.4,0.05,0.0,0.1,0.0,0.0,0.05,hala fouad nassar,
+LARC,2620,2,Design Impl I,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,yang song,
+LARC,4620,1,Design Implementation III,0.28,0.28,0.28,0.0,0.0,0.0,0.0,0.17,paul russell,
+LARC,8210,1,Research Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,
+LARC,8430,1,Interdisc Design,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,
+LAW,3220,1,Legal Env of Bus,0.44,0.33,0.14,0.02,0.0,0.0,0.0,0.07,edward ray claggett,
+LAW,3220,2,Legal Env of Bus,0.47,0.43,0.11,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,3,Legal Env of Bus,0.26,0.38,0.19,0.13,0.02,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,4,Legal Env of Bus,0.24,0.48,0.22,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,5,Legal Env of Bus,0.39,0.28,0.22,0.04,0.02,0.0,0.0,0.04,kenneth toussaint,
+LAW,3220,6,Legal Env of Bus,0.33,0.31,0.2,0.09,0.0,0.0,0.0,0.07,kenneth toussaint,
+LAW,3220,7,Legal Env of Bus,0.33,0.4,0.17,0.05,0.02,0.0,0.0,0.02,kath kisska-schulze,
+LAW,3220,8,Legal Env of Bus,0.38,0.6,0.02,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,
+LAW,3220,9,Legal Env of Bus,0.35,0.54,0.09,0.0,0.0,0.0,0.0,0.02,john hine,
+LAW,3220,10,Legal Env of Bus,0.37,0.47,0.14,0.02,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,400,Legal Env of Bus,0.29,0.29,0.16,0.11,0.04,0.0,0.0,0.11,virgini ward-vaughn,
+LAW,3220,401,Legal Env of Bus,0.41,0.48,0.09,0.02,0.0,0.0,0.0,0.0,virgini ward-vaughn,
+LAW,3220,402,Legal Env of Bus,0.51,0.2,0.06,0.02,0.08,0.0,0.0,0.12,virgini ward-vaughn,
+LAW,3220,403,Legal Env of Bus,0.27,0.32,0.1,0.05,0.07,0.0,0.0,0.2,virgini ward-vaughn,
+LAW,3330,1,Real Estate Law,0.06,0.46,0.29,0.09,0.03,0.0,0.0,0.09,judson jahn,
+LAW,3330,2,Real Estate Law,0.4,0.23,0.33,0.0,0.0,0.0,0.0,0.03,judson jahn,
+LAW,4050,1,Construction Law,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,eric touya,
+LS,1000,1,Therapeutic Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
+LS,1000,2,Therapeutic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
+LS,1000,3,Therapeutic Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
+LS,1000,4,Intermediate Top-rope,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,corey newe winstead,
+LS,1000,11,Organic Gardening,0.81,0.06,0.06,0.0,0.06,0.0,0.0,0.0,shawn jadrnicek,
+LS,1000,12,Introduction to Salsa,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,
+LS,1000,13,Introduction to Salsa Dance,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,malik lewis baxter,
+LS,1000,24,FItness leadership,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,patricia figueroa,
+LS,1330,4,Women's Shotgun,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,edward licus prater,
+LS,1410,1,Top Rope Climbing,0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,corey newe winstead,
+LS,1410,2,Top Rope Climbing,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,corey newe winstead,
+LS,1410,3,Top Rope Climbing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,corey newe winstead,
+LS,1410,4,Top Rope Climbing,0.71,0.06,0.06,0.06,0.0,0.0,0.0,0.12,corey newe winstead,
+LS,1410,5,Top Rope Climbing,0.83,0.06,0.0,0.0,0.11,0.0,0.0,0.0,corey newe winstead,
+LS,1560,6,Riflery,0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1580,1,Archery,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1580,3,Archery,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,herbert strickland,
+LS,1580,5,Archery,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1640,1,Whitewater Kayaking,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,cara jill wrenn,
+LS,1640,2,Whitewater Kayaking,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,robert taylor,
+LS,1790,1,Scuba I,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,robert bogan,
+LS,1850,2,Bowling,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,megan elizabet cato,
+LS,1850,3,Bowling,0.9,0.07,0.0,0.0,0.03,0.0,0.0,0.0,kathryn ly mitchell,
+LS,1850,5,Bowling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,katie dudley,
+LS,1850,10,Bowling,0.86,0.07,0.03,0.0,0.03,0.0,0.0,0.0,katie dudley,
+LS,1940,1,Racquetball,0.69,0.15,0.0,0.08,0.0,0.0,0.0,0.08,raymond petersen,
+LS,1980,5,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jason jordan,
+LS,1990,1,Intermediate Golf,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,jason jordan,
+LS,2180,1,Ballroom Dance,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,broadus fleming,
+LS,2200,9,Shag,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,broadus fleming,
+LS,2270,1,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,paul hoke,
+LS,2270,2,Intro to Swing Dance,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,paul hoke,
+LS,2280,1,Intermediate Swing,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,paul hoke,
+LS,2320,1,Core Training,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,
+LS,2320,2,Core Training,0.71,0.19,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,
+LS,2320,4,Core Training,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,
+LS,2320,5,Core Training,0.78,0.13,0.0,0.04,0.0,0.0,0.0,0.04,diane moreno,
+LS,2350,1,Basic Yoga,0.71,0.1,0.1,0.05,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2350,2,Basic Yoga,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,renee warren gahan,
+LS,2350,3,Basic Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,renee warren gahan,
+LS,2350,4,Basic Yoga,0.86,0.05,0.09,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2360,1,Power/Ashtanga Yoga,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,silica eliza larkin,
+LS,2380,2,Vinyasa Flow Yoga,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
+LS,2420,1,Meditation and Relax,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,2,Meditation and Relax,0.83,0.09,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,6,Meditation and Relax,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,7,Meditation and Relax,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2420,8,Meditation and Relax,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
+LS,2450,2,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
+LS,2450,3,Pilates,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
+LS,2450,4,Pilates,0.88,0.0,0.0,0.0,0.04,0.0,0.0,0.08,melanie ivey job,
+LS,2450,7,Pilates,0.81,0.05,0.0,0.0,0.05,0.0,0.0,0.1,diane moreno,
+LS,2510,3,Running & Jogging,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,robert edwar lawson,
+LS,2700,1,Sports Officiating,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,christopher war cox,
+LS,2750,9,First Aid/Cpr,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,candice lyn honnold,
+LS,2750,10,First Aid/Cpr,0.73,0.07,0.0,0.0,0.0,0.0,0.0,0.2,candice lyn honnold,
+MATH,1010,1,Essen Math for Informed Soc,0.23,0.23,0.46,0.0,0.0,0.0,0.0,0.08,thowhida akther,
+MATH,1010,2,Essen Math for Informed Soc,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,thowhida akther,
+MATH,1010,3,Essen Math for Informed Soc,0.5,0.28,0.17,0.06,0.0,0.0,0.0,0.0,xiyan tan,
+MATH,1010,4,Essen Math for Informed Soc,0.31,0.38,0.12,0.07,0.07,0.0,0.0,0.05,judith cottingham,
+MATH,1010,5,Essen Math for Informed Soc,0.21,0.36,0.21,0.14,0.07,0.0,0.0,0.0,xiyan tan,
+MATH,1010,6,Essen Math for Informed Soc,0.33,0.35,0.16,0.07,0.05,0.0,0.0,0.05,judith cottingham,
+MATH,1010,8,Essen Math for Informed Soc,0.17,0.39,0.28,0.11,0.06,0.0,0.0,0.0,tianhui wei,
+MATH,1010,10,Essen Math for Informed Soc,0.54,0.23,0.0,0.0,0.08,0.0,0.0,0.15,tianhui wei,
+MATH,1020,1,Business Calculus I,0.06,0.56,0.17,0.06,0.17,0.0,0.0,0.0,thomas clevenger,
+MATH,1020,2,Business Calculus I,0.21,0.21,0.26,0.11,0.11,0.0,0.0,0.11,bryce pruitt,
+MATH,1020,3,Business Calculus I,0.18,0.18,0.36,0.07,0.18,0.0,0.0,0.02,warren adams,
+MATH,1020,5,Business Calculus I,0.16,0.32,0.37,0.05,0.11,0.0,0.0,0.0,peter westerbaan,
+MATH,1020,6,Business Calculus I,0.16,0.32,0.21,0.0,0.16,0.0,0.0,0.16,jared scott miller,
+MATH,1020,7,Business Calculus I,0.22,0.44,0.17,0.06,0.11,0.0,0.0,0.0,thomas clevenger,
+MATH,1020,8,Business Calculus I,0.16,0.42,0.11,0.11,0.16,0.0,0.0,0.05,bryce pruitt,
+MATH,1020,9,Business Calculus I,0.37,0.21,0.16,0.0,0.16,0.0,0.0,0.11,michael thoma cowen,
+MATH,1020,10,Business Calculus I,0.28,0.33,0.22,0.06,0.06,0.0,0.0,0.06,ashleigh craig,
+MATH,1020,11,Business Calculus I,0.26,0.42,0.16,0.05,0.11,0.0,0.0,0.0,fun choi john chan,
+MATH,1020,12,Business Calculus I,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,peter westerbaan,
+MATH,1020,13,Business Calculus I,0.31,0.26,0.21,0.07,0.07,0.0,0.0,0.07,randy davidson,
+MATH,1020,14,Business Calculus I,0.0,0.37,0.47,0.0,0.11,0.0,0.0,0.05,emily marie nystrom,
+MATH,1020,15,Business Calculus I,0.16,0.42,0.16,0.16,0.05,0.0,0.0,0.05,todd fenstermacher,
+MATH,1020,16,Business Calculus I,0.28,0.11,0.22,0.17,0.22,0.0,0.0,0.0,fun choi john chan,
+MATH,1020,17,Business Calculus I,0.26,0.42,0.16,0.0,0.0,0.0,0.0,0.16,ashleigh craig,
+MATH,1020,18,Business Calculus I,0.11,0.53,0.11,0.21,0.0,0.0,0.0,0.05,michael thoma cowen,
+MATH,1020,19,Business Calculus I,0.31,0.21,0.14,0.12,0.12,0.0,0.0,0.1,randy davidson,
+MATH,1020,20,Business Calculus I,0.21,0.37,0.21,0.05,0.11,0.0,0.0,0.05,emily marie nystrom,
+MATH,1020,21,Business Calculus I,0.16,0.21,0.32,0.0,0.16,0.0,0.0,0.16,todd fenstermacher,
+MATH,1020,22,Business Calculus I,0.42,0.16,0.37,0.05,0.0,0.0,0.0,0.0,john william grant,
+MATH,1020,23,Business Calculus I,0.26,0.32,0.16,0.0,0.21,0.0,0.0,0.05,camille zerfas,
+MATH,1020,24,Business Calculus I,0.28,0.11,0.28,0.22,0.06,0.0,0.0,0.06,aaro ramirez flores,
+MATH,1020,25,Business Calculus I,0.11,0.37,0.26,0.05,0.11,0.0,0.0,0.11,stephen peele,
+MATH,1020,26,Business Calculus I,0.21,0.32,0.37,0.05,0.0,0.0,0.0,0.05,shanshan jia,
+MATH,1020,27,Business Calculus I,0.37,0.05,0.26,0.21,0.05,0.0,0.0,0.05,kara ail stasikelis,
+MATH,1020,28,Business Calculus I,0.53,0.16,0.21,0.11,0.0,0.0,0.0,0.0,stephen peele,
+MATH,1020,29,Business Calculus I,0.32,0.21,0.26,0.05,0.11,0.0,0.0,0.05,camille zerfas,
+MATH,1020,30,Business Calculus I,0.21,0.37,0.26,0.0,0.05,0.0,0.0,0.11,jing li,
+MATH,1020,32,Business Calculus I,0.26,0.21,0.16,0.11,0.26,0.0,0.0,0.0,lu sun,
+MATH,1020,33,Business Calculus I,0.4,0.28,0.13,0.08,0.08,0.0,0.0,0.05,warren adams,
+MATH,1020,34,Business Calculus I,0.35,0.35,0.18,0.0,0.06,0.0,0.0,0.06,shanshan jia,
+MATH,1020,35,Business Calculus I,0.37,0.26,0.21,0.0,0.11,0.0,0.0,0.05,kara ail stasikelis,
+MATH,1020,36,Business Calculus I,0.06,0.25,0.25,0.06,0.25,0.0,0.0,0.13,tianqi zhang,
+MATH,1020,37,Business Calculus I,0.13,0.31,0.25,0.0,0.19,0.0,0.0,0.13,jing li,
+MATH,1020,38,Business Calculus I,0.22,0.33,0.17,0.17,0.06,0.0,0.0,0.06,stephen garth,
+MATH,1020,39,Business Calculus I,0.26,0.29,0.19,0.1,0.05,0.0,0.0,0.12,warren adams,
+MATH,1020,40,Business Calculus I,0.17,0.5,0.11,0.11,0.11,0.0,0.0,0.0,aaro ramirez flores,
+MATH,1020,41,Business Calculus I,0.12,0.29,0.12,0.18,0.18,0.0,0.0,0.12,tianqi zhang,
+MATH,1020,42,Business Calculus I,0.0,0.32,0.26,0.16,0.21,0.0,0.0,0.05,lu sun,
+MATH,1020,44,Business Calculus I,0.0,0.21,0.42,0.0,0.21,0.0,0.0,0.16,stephen garth,
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.56,0.4,0.04,donna simms,
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.32,0.47,0.21,xun dong,
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.46,0.2,haotian feng,
+MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.53,0.43,0.04,tony thanh nguyen,
+MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.56,0.06,chase norman joyner,
+MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.48,0.41,0.11,tony thanh nguyen,
+MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.44,0.18,lauren pai mcintyre,
+MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.64,0.02,tony thanh nguyen,
+MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.48,0.14,liang zhao,
+MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.35,0.56,0.08,nicholas ahlstrom,
+MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.26,0.46,0.28,stefan adam bock,
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.6,0.34,0.06,charity watson,
+MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.52,0.46,0.02,charity watson,
+MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.39,0.02,charity watson,
+MATH,1060,2,Calculus of One Variable I,0.11,0.27,0.13,0.04,0.27,0.0,0.0,0.18,sanwar ahmad,
+MATH,1060,3,Calculus of One Variable I,0.36,0.29,0.21,0.02,0.05,0.0,0.0,0.07,garrett dranichak,
+MATH,1060,4,Calculus of One Variable I,0.2,0.29,0.11,0.14,0.2,0.0,0.0,0.06,jonathon leverenz,
+MATH,1060,5,Calculus of One Variable I,0.13,0.35,0.17,0.02,0.13,0.0,0.0,0.21,michael gl eldredge,
+MATH,1060,7,Calculus of One Variable I,0.1,0.4,0.08,0.03,0.23,0.0,0.0,0.18,shuhan xu,
+MATH,1060,8,Calculus of One Variable I,0.14,0.51,0.11,0.06,0.14,0.0,0.0,0.03,beth novick,
+MATH,1060,10,Calculus of One Variable I,0.14,0.3,0.18,0.02,0.18,0.0,0.0,0.18,sergey charnyi,
+MATH,1060,11,Calculus of One Variable I,0.33,0.26,0.21,0.05,0.05,0.0,0.0,0.1,hugh geller,
+MATH,1060,13,Calculus of One Variable I,0.09,0.2,0.27,0.05,0.16,0.0,0.0,0.23,sofya alekseeva,
+MATH,1060,14,Calculus of One Variable I,0.12,0.33,0.21,0.05,0.14,0.0,0.0,0.14,irina viktorova,
+MATH,1060,15,Calculus of One Variable I,0.24,0.24,0.32,0.06,0.12,0.0,0.0,0.03,marilyn reba,
+MATH,1060,16,Calculus of One Variable I,0.08,0.16,0.45,0.05,0.21,0.0,0.0,0.05,irina viktorova,
+MATH,1060,18,Calculus of One Variable I,0.16,0.27,0.24,0.11,0.11,0.0,0.0,0.11,sofya alekseeva,
+MATH,1060,20,Calculus of One Variable I,0.18,0.39,0.21,0.09,0.06,0.0,0.0,0.06,marilyn reba,
+MATH,1060,21,Calculus of One Variable I,0.11,0.27,0.16,0.13,0.18,0.0,0.0,0.16,rebecca ramos,
+MATH,1060,22,Calculus of One Variable I,0.02,0.2,0.29,0.02,0.2,0.0,0.0,0.27,sofya alekseeva,
+MATH,1060,26,Calculus of One Variable I,0.07,0.34,0.22,0.07,0.2,0.0,0.0,0.1,shuhan xu,
+MATH,1060,100,Calc of One Variable I (HON),0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,beth novick,True
+MATH,1060,201,Calculus of One Variable I,0.31,0.35,0.13,0.04,0.06,0.0,0.0,0.1,allen anderso guest,
+MATH,1060,206,Calculus of One Variable I,0.23,0.38,0.19,0.06,0.1,0.0,0.0,0.04,allen anderso guest,
+MATH,1060,209,Calculus of One Variable I,0.27,0.27,0.29,0.02,0.06,0.0,0.0,0.08,james brown,
+MATH,1060,212,Calculus of One Variable I,0.19,0.4,0.27,0.02,0.08,0.0,0.0,0.04,muhamm mohebujjaman,
+MATH,1060,217,Calculus of One Variable I,0.13,0.38,0.29,0.08,0.06,0.0,0.0,0.06,alistair bentley,
+MATH,1060,224,Calculus of One Variable I,0.17,0.33,0.33,0.02,0.07,0.0,0.0,0.07,irina viktorova,
+MATH,1060,225,Calc of One Variable I (RISE),0.24,0.28,0.22,0.02,0.15,0.0,0.0,0.09,"koshy chenthittayil,",
+MATH,1070,1,Differen and Integral Calculus,0.07,0.14,0.59,0.07,0.1,0.0,0.0,0.03,donna simms,
+MATH,1080,1,Calculus of One Variable II,0.09,0.22,0.13,0.04,0.35,0.0,0.0,0.17,terri johnson,
+MATH,1080,2,Calculus of One Variable II,0.03,0.28,0.07,0.0,0.31,0.0,0.0,0.31,timothy fra parrott,
+MATH,1080,5,Calculus of One Variable II,0.06,0.16,0.25,0.03,0.31,0.0,0.0,0.19,honghai xu,
+MATH,1080,6,Calculus of One Variable II,0.05,0.14,0.23,0.11,0.32,0.0,0.0,0.16,meredith nicol burr,
+MATH,1080,7,Calculus of One Variable II,0.13,0.22,0.11,0.07,0.2,0.0,0.0,0.27,meredith nicol burr,
+MATH,1080,8,Calculus of One Variable II,0.03,0.24,0.13,0.11,0.39,0.0,0.0,0.11,timothy fra parrott,
+MATH,1080,10,Calculus of One Variable II,0.0,0.1,0.13,0.13,0.45,0.0,0.0,0.2,mark cawood,
+MATH,1080,11,Calculus of One Variable II,0.08,0.19,0.28,0.06,0.33,0.0,0.0,0.06,honghai xu,
+MATH,1080,12,Calculus of One Variable II,0.06,0.08,0.17,0.06,0.14,0.0,0.0,0.5,nicole alai sinwell,
+MATH,1080,204,Calculus of One Variable II,0.13,0.39,0.1,0.1,0.0,0.0,0.0,0.29,timothy fra parrott,
+MATH,1150,1,Contemp Math for Elem Teach I,0.65,0.27,0.05,0.03,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1150,2,Contemp Math for Elem Teach I,0.79,0.17,0.03,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1160,1,Contemp Math for Elem Teach II,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,carlos gomez,
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.86,0.12,0.02,marion hanna,
+MATH,1990,401,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.04,0.02,marion hanna,
+MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,
+MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.0,marion hanna,
+MATH,2060,1,Calculus of Several Variables,0.31,0.33,0.18,0.03,0.13,0.0,0.0,0.03,akshay sunil gupte,
+MATH,2060,3,Calculus of Several Variables,0.13,0.1,0.28,0.0,0.15,0.0,0.0,0.33,jeong rock yoon,
+MATH,2060,4,Calculus of Several Variables,0.33,0.29,0.24,0.05,0.02,0.0,0.0,0.07,hiram lopez valdez,
+MATH,2060,5,Calculus of Several Variables,0.07,0.18,0.31,0.18,0.13,0.0,0.0,0.13,eleanor jenkins,
+MATH,2060,6,Calculus of Several Variables,0.23,0.27,0.25,0.1,0.08,0.0,0.0,0.06,hyesuk lee,
+MATH,2060,7,Calculus of Several Variables,0.24,0.21,0.32,0.0,0.11,0.0,0.0,0.13,gretchen matthews,
+MATH,2060,8,Calculus of Several Variables,0.14,0.22,0.16,0.14,0.12,0.0,0.0,0.2,shari prevost,
+MATH,2060,9,Calculus of Several Variables,0.24,0.13,0.33,0.13,0.13,0.0,0.0,0.04,hyesuk lee,
+MATH,2060,10,Calculus of Several Variables,0.39,0.13,0.26,0.0,0.13,0.0,0.0,0.08,gretchen matthews,
+MATH,2060,11,Calculus of Several Variables,0.17,0.17,0.1,0.22,0.22,0.0,0.0,0.12,julie lassiter,
+MATH,2060,12,Calculus of Several Variables,0.43,0.32,0.11,0.06,0.02,0.0,0.0,0.06,martin joha schmoll,
+MATH,2060,13,Calculus of Several Variables,0.07,0.18,0.25,0.2,0.18,0.0,0.0,0.11,shari prevost,
+MATH,2060,15,Calculus of Several Variables,0.1,0.19,0.21,0.17,0.14,0.0,0.0,0.19,julie lassiter,
+MATH,2060,16,Calculus of Several Variables,0.36,0.3,0.25,0.07,0.0,0.0,0.0,0.02,yuyuan ouyang,
+MATH,2060,17,Calculus of Several Variables,0.24,0.24,0.24,0.13,0.09,0.0,0.0,0.04,hyesuk lee,
+MATH,2060,18,Calculus of Several Variables,0.07,0.25,0.2,0.18,0.09,0.0,0.0,0.2,shari prevost,
+MATH,2060,20,Calculus of Several Variables,0.05,0.35,0.22,0.22,0.11,0.0,0.0,0.05,michael adam burr,
+MATH,2060,21,Calculus of Several Variables,0.16,0.37,0.13,0.16,0.11,0.0,0.0,0.08,michael adam burr,
+MATH,2060,22,Calculus of Several Variables,0.25,0.3,0.25,0.07,0.09,0.0,0.0,0.05,hiram lopez valdez,
+MATH,2060,23,Calculus of Several Variables,0.36,0.11,0.31,0.06,0.08,0.0,0.0,0.08,yuyuan ouyang,
+MATH,2060,24,Calculus of Several Variables,0.19,0.26,0.26,0.09,0.15,0.0,0.0,0.06,jonathon leverenz,
+MATH,2060,100,Calc of Several Vars (HON),0.52,0.28,0.14,0.0,0.03,0.0,0.0,0.03,james brown,True
+MATH,2070,1,Business Calculus II,0.31,0.19,0.19,0.06,0.19,0.0,0.0,0.06,yinggu bao,
+MATH,2070,2,Business Calculus II,0.11,0.28,0.44,0.06,0.11,0.0,0.0,0.0,liu zhu,
+MATH,2070,3,Business Calculus II,0.11,0.39,0.11,0.06,0.11,0.0,0.0,0.22,yinggu bao,
+MATH,2070,4,Business Calculus II,0.18,0.29,0.18,0.24,0.0,0.0,0.0,0.12,liu zhu,
+MATH,2070,5,Business Calculus II,0.26,0.26,0.31,0.02,0.05,0.0,0.0,0.1,jennifer mari hanna,
+MATH,2070,6,Business Calculus II,0.05,0.26,0.21,0.21,0.11,0.0,0.0,0.16,daniel kuzbary,
+MATH,2070,7,Business Calculus II,0.29,0.12,0.24,0.24,0.0,0.0,0.0,0.12,thanh thien to,
+MATH,2070,8,Business Calculus II,0.36,0.19,0.33,0.05,0.02,0.0,0.0,0.05,jennifer mari hanna,
+MATH,2070,9,Business Calculus II,0.26,0.37,0.11,0.11,0.05,0.0,0.0,0.11,travis baumbaugh,
+MATH,2070,10,Business Calculus II,0.21,0.42,0.26,0.0,0.11,0.0,0.0,0.0,tiantian yang,
+MATH,2070,11,Business Calculus II,0.31,0.31,0.31,0.02,0.0,0.0,0.0,0.05,jennifer mari hanna,
+MATH,2070,12,Business Calculus II,0.33,0.26,0.19,0.02,0.07,0.0,0.0,0.12,judith irene mcknew,
+MATH,2070,13,Business Calculus II,0.11,0.44,0.33,0.06,0.0,0.0,0.0,0.06,haodong li,
+MATH,2070,15,Business Calculus II,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,thanh thien to,
+MATH,2070,16,Business Calculus II,0.07,0.27,0.27,0.33,0.0,0.0,0.0,0.07,tiantian yang,
+MATH,2070,17,Business Calculus II,0.33,0.17,0.44,0.06,0.0,0.0,0.0,0.0,daniel kuzbary,
+MATH,2070,18,Business Calculus II,0.16,0.47,0.11,0.05,0.05,0.0,0.0,0.16,travis baumbaugh,
+MATH,2070,19,Business Calculus II,0.17,0.28,0.22,0.17,0.11,0.0,0.0,0.06,yibo xu,
+MATH,2070,20,Business Calculus II,0.06,0.19,0.5,0.13,0.0,0.0,0.0,0.13,haodong li,
+MATH,2070,21,Business Calculus II,0.35,0.24,0.29,0.12,0.0,0.0,0.0,0.0,yibo xu,
+MATH,2080,1,Intro to Ordin Diff Equations,0.08,0.32,0.21,0.03,0.11,0.0,0.0,0.26,oleg yordanov,
+MATH,2080,2,Intro to Ordin Diff Equations,0.19,0.3,0.21,0.06,0.15,0.0,0.0,0.09,timothy ch teitloff,
+MATH,2080,3,Intro to Ordin Diff Equations,0.48,0.15,0.21,0.06,0.06,0.0,0.0,0.03,oleg yordanov,
+MATH,2080,4,Intro to Ordin Diff Equations,0.33,0.26,0.23,0.03,0.05,0.0,0.0,0.1,mishko mitkovski,
+MATH,2080,5,Intro to Ordin Diff Equations,0.34,0.2,0.23,0.03,0.14,0.0,0.0,0.06,mishko mitkovski,
+MATH,2080,6,Intro to Ordin Diff Equations,0.25,0.39,0.08,0.06,0.11,0.0,0.0,0.11,timothy ch teitloff,
+MATH,2080,7,Intro to Ordin Diff Equations,0.14,0.29,0.23,0.11,0.17,0.0,0.0,0.06,timothy ch teitloff,
+MATH,2160,1,Geometry for Elem Sch Teachers,0.59,0.33,0.07,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,2160,2,Geometry for Elem Sch Teachers,0.76,0.21,0.0,0.03,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,2500,1,Intro to Mathematical Sciences,0.86,0.13,0.01,0.0,0.0,0.0,0.0,0.0,christopher cox,
+MATH,3020,1,Stat for Science & Engineering,0.16,0.62,0.14,0.0,0.05,0.0,0.0,0.03,taufiquar rahm khan,
+MATH,3020,2,Stat for Science & Engineering,0.74,0.24,0.03,0.0,0.0,0.0,0.0,0.0,xin liu,
+MATH,3020,3,Stat for Science & Engineering,0.53,0.21,0.0,0.05,0.11,0.0,0.0,0.11,yisu jia,
+MATH,3020,4,Stat for Science & Engineering,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,yisu jia,
+MATH,3020,5,Stat for Science & Engineering,0.36,0.36,0.11,0.03,0.11,0.0,0.0,0.03,brandon gra goodell,
+MATH,3020,6,Stat for Science & Engineering,0.36,0.5,0.06,0.0,0.03,0.0,0.0,0.06,calvin williams,
+MATH,3020,7,Stat for Science & Engineering,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.06,xiaoqian sun,
+MATH,3020,8,Stat for Science & Engineering,0.42,0.47,0.05,0.0,0.03,0.0,0.0,0.03,xiaoqian sun,
+MATH,3020,9,Stat for Science & Engineering,0.42,0.32,0.16,0.0,0.0,0.0,0.0,0.11,drew jared lipman,
+MATH,3020,10,Stat for Science & Engineering,0.26,0.37,0.26,0.0,0.05,0.0,0.0,0.05,christopher wilson,
+MATH,3020,11,Stat for Science & Engineering,0.32,0.37,0.16,0.05,0.05,0.0,0.0,0.05,yanbo xia,
+MATH,3020,12,Stat for Science & Engineering,0.29,0.29,0.35,0.0,0.0,0.0,0.0,0.06,yanbo xia,
+MATH,3110,1,Linear Algebra,0.11,0.4,0.26,0.03,0.06,0.0,0.0,0.14,hui xue,
+MATH,3110,2,Linear Algebra,0.12,0.35,0.18,0.15,0.03,0.0,0.0,0.18,felice manganiello,
+MATH,3110,3,Linear Algebra,0.34,0.09,0.2,0.2,0.06,0.0,0.0,0.11,felice manganiello,
+MATH,3110,4,Linear Algebra,0.21,0.49,0.13,0.08,0.08,0.0,0.0,0.03,hui xue,
+MATH,3110,5,Linear Algebra,0.29,0.31,0.23,0.06,0.09,0.0,0.0,0.03,wayne goddard,
+MATH,3110,6,Linear Algebra,0.23,0.37,0.34,0.03,0.0,0.0,0.0,0.03,boshi yang,
+MATH,3110,100,Linear Algebra (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,neil calkin,True
+MATH,3110,200,Linear Algebra,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,neil calkin,
+MATH,3160,1,Prob Solving for Math Teachers,0.88,0.09,0.0,0.0,0.0,0.0,0.0,0.02,andrew mic tyminski,
+MATH,3190,1,Introduction to Proof,0.17,0.43,0.17,0.13,0.09,0.0,0.0,0.0,elena sta dimitrova,
+MATH,3190,2,Introduction to Proof,0.52,0.24,0.12,0.0,0.08,0.0,0.0,0.04,elena sta dimitrova,
+MATH,3600,1,Intermediate Math Computing,0.83,0.06,0.0,0.03,0.03,0.0,0.0,0.06,mark cawood,
+MATH,3600,2,Intermediate Math Computing,0.63,0.16,0.0,0.05,0.05,0.0,0.0,0.11,mark cawood,
+MATH,3650,1,Numerical Mthds for Engineers,0.45,0.4,0.11,0.01,0.02,0.0,0.0,0.01,leo rebholz,
+MATH,3650,2,Numerical Mthds for Engineers,0.62,0.32,0.06,0.0,0.0,0.0,0.0,0.0,timo johann heister,
+MATH,4000,1,Theory of Probability,0.5,0.26,0.18,0.0,0.06,0.0,0.0,0.0,peter kiessler,
+MATH,4000,2,Theory of Probability,0.41,0.36,0.18,0.0,0.05,0.0,0.0,0.0,ling ma,
+MATH,4020,1,Stat for Sci & Engineering II,0.6,0.13,0.07,0.07,0.0,0.0,0.0,0.13,colin gallagher,
+MATH,4080,1,Secondary Math Analysis,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,eliza dar gallagher,
+MATH,4120,1,Algebra I,0.37,0.19,0.26,0.04,0.07,0.0,0.0,0.07,kevin james,
+MATH,4190,1,Discrete Math Structures I,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,beth novick,
+MATH,4190,2,Discrete Math Structures I,0.33,0.39,0.06,0.06,0.06,0.0,0.0,0.11,sea sather-wagstaff,
+MATH,4310,1,Theory of Interest,0.5,0.2,0.2,0.1,0.0,0.0,0.0,0.0, erwin walker,
+MATH,4340,1,Adv Engineering Mathematics,0.11,0.14,0.36,0.14,0.08,0.0,0.0,0.17,eleanor jenkins,
+MATH,4340,2,Adv Engineering Mathematics,0.16,0.16,0.26,0.13,0.16,0.0,0.0,0.13,vincent ervin,
+MATH,4350,1,Complex Variables,0.4,0.2,0.1,0.2,0.1,0.0,0.0,0.0,jeong rock yoon,
+MATH,4400,1,Linear Programming,0.22,0.26,0.22,0.07,0.11,0.0,0.0,0.11,boshi yang,
+MATH,4410,1,Intro to Stochastic Models,0.27,0.36,0.27,0.0,0.0,0.0,0.0,0.09,brian fralix,
+MATH,4500,1,Intro to Mathematical Models,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,matthew macauley,
+MATH,4530,1,Advanced Calculus I,0.25,0.29,0.29,0.04,0.08,0.0,0.0,0.04,james peterson,
+MATH,4530,2,Advanced Calculus I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james peterson,
+MATH,4540,1,Advanced Calculus II,0.3,0.2,0.2,0.25,0.0,0.0,0.0,0.05,shitao liu,
+MATH,6340,1,Adv Engineering Mathematics,0.41,0.33,0.22,0.0,0.04,0.0,0.0,0.0,vincent ervin,
+MATH,8000,1,Probability,0.5,0.35,0.05,0.0,0.1,0.0,0.0,0.0,peter kiessler,
+MATH,8010,1,General Linear Hypothesis I,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,derek brown,
+MATH,8050,1,Data Analysis,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,derek brown,
+MATH,8090,1,Time Series Analysis,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,8100,1,Mathematical Programming,0.48,0.36,0.04,0.0,0.08,0.0,0.0,0.04,warren adams,
+MATH,8120,1,Discrete Optimization,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
+MATH,8140,1,Network Flow Programming,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,matthew saltzman,
+MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
+MATH,8210,1,Linear Analysis,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,shitao liu,
+MATH,8410,1,Applied Mathematics I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,
+MATH,8510,1,Abstract Algebra I,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,sea sather-wagstaff,
+MATH,8530,1,Matrix Analysis,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,matthew macauley,
+MATH,8550,1,Combinatorial Analysis,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,
+MATH,8600,1,Intro to Scientific Computing,0.33,0.33,0.2,0.0,0.07,0.0,0.0,0.07,fei xue,
+MATH,8650,1,Data Structures,0.64,0.23,0.14,0.0,0.0,0.0,0.0,0.0,timo johann heister,
+MATH,9500,1,Commutative Algebra,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james ba coykendall,
+MBA,8030,1,Stat Analy of Bus Op,0.16,0.44,0.21,0.0,0.0,0.0,0.0,0.19,magda gabriela sava,
+MBA,8060,1,Operations Mgt,0.23,0.6,0.18,0.0,0.0,0.0,0.0,0.0, sridharan,
+MBA,8070,1,Financial Management,0.39,0.51,0.07,0.0,0.02,0.0,0.0,0.0,george bra lockhart,
+MBA,8090,1,Org Beh & Hum Res Mg,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8090,2,Org Beh & Hum Res Mg,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8180,20,Intro Business Intell & Anlytc,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,heshan sun,
+MBA,8190,1,Intro to Acc and Fin,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,melvin stith,
+MBA,8190,2,Intro to Acc and Fin,0.54,0.34,0.07,0.0,0.02,0.0,0.0,0.02,thomas springer,
+MBA,8290,1,Marketing Foundation,0.51,0.43,0.0,0.0,0.0,0.0,0.0,0.05,gary hunter,
+MBA,8310,5,Communications and Sales,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,gregory pickett,
+MBA,8330,1,Real Estate Investmt,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,
+MBA,8360,1,Real Estate Principles,0.35,0.52,0.09,0.0,0.0,0.0,0.0,0.04,jeffrey randolph,
+MBA,8370,1,Legal Environ of Bus,0.47,0.49,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
+MBA,8410,1,Real Estate Finance,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,wesley mcf blanding,
+MBA,8430,1,Entrepreneurial Accounting,0.14,0.68,0.18,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
+MBA,8450,1,Technology & Innovation Mgt,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8480,1,Entrpr Mkting & Digital Strat,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,
+MBA,8480,5,Entrpr Mkting & Digital Strat,0.81,0.15,0.0,0.0,0.04,0.0,0.0,0.0,bruce snyder,
+MBA,8490,5,Entrepreneurial Strategy,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,matthew charl klein,
+MBA,8510,1,Bus Operations & Logistics,0.23,0.59,0.18,0.0,0.0,0.0,0.0,0.0, sridharan,
+MBA,8540,1,Mgrl Accounting,0.44,0.44,0.07,0.0,0.0,0.0,0.0,0.05,james mil kohlmeyer,
+MBA,8590,1,Mgr Decision Model,0.4,0.33,0.17,0.0,0.0,0.0,0.0,0.1,sara elizabet yoder,
+MBA,8590,2,Mgr Decision Model,0.4,0.31,0.07,0.0,0.07,0.0,0.0,0.16,mark mcknew,
+MBA,8600,1,Advanced Marketing Strategy,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8600,2,Advanced Marketing Strategy,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8610,1,Information Systems,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MBA,8620,1,Managerial Economics,0.3,0.52,0.12,0.0,0.0,0.0,0.0,0.06,scott templeton,
+MBA,8620,2,Managerial Economics,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,
+MBA,8620,3,Managerial Economics,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,
+MBA,8650,1,Taxation of Business Decisions,0.25,0.63,0.04,0.0,0.04,0.0,0.0,0.04,judson jahn,
+MBA,8700,1,Strategic Management,0.46,0.49,0.03,0.0,0.0,0.0,0.0,0.03,james turner,
+MBA,8990,2,Creativity,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,
+MBA,8990,11,Social Media and Marketing,0.72,0.19,0.06,0.0,0.03,0.0,0.0,0.0,lura forcum,
+ME,2000,1,Sophomore Seminar,0.93,0.05,0.0,0.0,0.01,0.0,0.0,0.01,donald beasley,
+ME,2010,1,Statics & Dynamics,0.07,0.25,0.26,0.06,0.2,0.0,0.0,0.16,marisa kikendal orr,
+ME,2010,2,Statics & Dynamics,0.09,0.18,0.25,0.07,0.29,0.0,0.0,0.12,jorge iva rodriguez,
+ME,2010,3,Statics & Dynamics,0.04,0.13,0.3,0.14,0.28,0.0,0.0,0.1,paul joseph,
+ME,2030,1,Founda Th/Fl Syst,0.08,0.1,0.46,0.21,0.1,0.0,0.0,0.04,john saylor,
+ME,2030,2,Founda Th/Fl Syst,0.2,0.16,0.38,0.22,0.04,0.0,0.0,0.0,jay ochterbeck,
+ME,2040,1,Mechanics of Materials,0.11,0.49,0.3,0.06,0.03,0.0,0.0,0.0,garrett pataky,
+ME,2040,3,Mechanics of Materials,0.29,0.5,0.19,0.0,0.0,0.0,0.0,0.02,gang li,
+ME,2220,1,Mechanical Engineering Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,2220,2,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,3,Mechanical Engineering Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,4,Mechanical Engineering Lab I,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,5,Mechanical Engineering Lab I,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,6,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,7,Mechanical Engineering Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,8,Mechanical Engineering Lab I,0.33,0.27,0.4,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3030,1,Thermodynamics,0.3,0.43,0.21,0.04,0.0,0.0,0.0,0.02,daniel fant,
+ME,3030,2,Thermodynamics,0.46,0.33,0.19,0.01,0.01,0.0,0.0,0.0,daniel fant,
+ME,3030,3,Thermodynamics,0.18,0.61,0.18,0.0,0.0,0.0,0.0,0.03,yiqiang han,
+ME,3040,1,Heat Transfer,0.15,0.45,0.3,0.03,0.03,0.0,0.0,0.05,jean-marc delhaye,
+ME,3040,2,Heat Transfer,0.19,0.33,0.34,0.07,0.07,0.0,0.0,0.0,xin zhao,
+ME,3050,1,Model/an Dy Syst,0.23,0.42,0.25,0.02,0.05,0.0,0.0,0.03,joshua bostwick,
+ME,3050,2,Model/an Dy Syst,0.16,0.4,0.35,0.05,0.0,0.0,0.0,0.05,ardalan vahidi,
+ME,3060,1,Fund Machine Design,0.58,0.29,0.1,0.0,0.02,0.0,0.0,0.02,oliver myers,
+ME,3060,2,Fund Machine Design,0.23,0.58,0.13,0.0,0.04,0.0,0.0,0.02,paul jeffrey meyer,
+ME,3070,1,Found of Mechanical Systems,0.26,0.46,0.16,0.05,0.01,0.0,0.0,0.05,lonny thompson,
+ME,3070,2,Found of Mechanical Systems,0.15,0.46,0.26,0.05,0.08,0.0,0.0,0.0,georges fadel,
+ME,3080,1,Fluid Mechanics,0.22,0.4,0.32,0.04,0.02,0.0,0.0,0.0,xiangchun xuan,
+ME,3080,2,Fluid Mechanics,0.15,0.68,0.15,0.0,0.0,0.0,0.0,0.02,yiqiang han,
+ME,3080,3,Fluid Mechanics,0.13,0.25,0.5,0.03,0.08,0.0,0.0,0.0,ethan kung,
+ME,3120,2,Manuf Processes,0.69,0.25,0.05,0.0,0.0,0.0,0.0,0.01,rod martinez-duarte,
+ME,3330,1,Mechanical Engineering Lab II,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,2,Mechanical Engineering Lab II,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,3,Mechanical Engineering Lab II,0.12,0.71,0.06,0.0,0.0,0.0,0.0,0.12,todd schweisinger,
+ME,3330,4,Mechanical Engineering Lab II,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
+ME,3330,5,Mechanical Engineering Lab II,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,6,Mechanical Engineering Lab II,0.14,0.71,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
+ME,3330,7,Mechanical Engineering Lab II,0.44,0.31,0.25,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,8,Mechanical Engineering Lab II,0.3,0.3,0.2,0.0,0.0,0.0,0.0,0.2,todd schweisinger,
+ME,4000,1,Senior Seminar,0.83,0.14,0.01,0.01,0.0,0.0,0.0,0.0,donald beasley,
+ME,4010,1,Mech Engr Design,0.15,0.63,0.18,0.01,0.03,0.0,0.0,0.0,joshua summers,
+ME,4010,2,Mech Engr Design,0.2,0.69,0.05,0.0,0.07,0.0,0.0,0.0,cameron turner,
+ME,4020,1,Intern in Engr Des,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,
+ME,4020,2,Intern in Engr Des,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,
+ME,4020,3,Intern in Engr Des,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,4020,4,Intern in Engr Des,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4030,1,Control Dynamic Systems,0.17,0.38,0.4,0.03,0.0,0.0,0.0,0.02,yue wang,
+ME,4030,2,Control Dynamic Systems,0.23,0.41,0.22,0.07,0.01,0.0,0.0,0.05,suyi li,
+ME,4200,1,Ener Sources/Utiliz,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,donald beasley,
+ME,4210,1,Intro to Comp Flow,0.21,0.5,0.14,0.0,0.07,0.0,0.0,0.07,chenning tong,
+ME,4320,1,Adv Strength of Matl,0.1,0.39,0.45,0.0,0.03,0.0,0.0,0.03,huijuan zhao,
+ME,4400,1,Matls for Aggr Envir,0.88,0.11,0.02,0.0,0.0,0.0,0.0,0.0,ramasw subrahmanian,
+ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,3,Mechanical Engineering Lab III,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,4,Mechanical Engineering Lab III,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,5,Mechanical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,6,Mechanical Engineering Lab III,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,7,Mechanical Engineering Lab III,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,8,Mechanical Engineering Lab III,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4540,1,Design of Machine Elements,0.6,0.35,0.03,0.0,0.0,0.0,0.0,0.03,paul jeffrey meyer,
+ME,4930,7,Sel.Topics ME - Energy Harvest,0.25,0.4,0.15,0.1,0.0,0.0,0.0,0.1,mohammed fari daqaq,
+ME,6210,1,Intro to Comp Flow,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,chenning tong,
+ME,6320,1,Adv Strength of Matl,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,6930,13,SelTopics ME-MechSolids&Fluids,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
+ME,8010,1,Found of Fluid Mech,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,richard figliola,
+ME,8010,401,Found of Fluid Mech,0.31,0.54,0.0,0.0,0.0,0.0,0.0,0.15,richard figliola,
+ME,8100,1,Macroscopic Thermo,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,jay ochterbeck,
+ME,8180,1,Intro to Fin Ele Ana,0.27,0.63,0.08,0.0,0.0,0.0,0.0,0.02,gang li,
+ME,8230,1,Control Systems,0.37,0.42,0.16,0.0,0.05,0.0,0.0,0.0,yue wang,
+ME,8300,1,Cond/Rad Heat Tfr,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,
+ME,8460,1,Inter Dynamics,0.4,0.15,0.35,0.0,0.05,0.0,0.0,0.05,phanin tallapragada,
+ME,8700,1,Adv Design Methods,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,8710,1,Engr Optimization,0.61,0.33,0.03,0.0,0.03,0.0,0.0,0.0,georges fadel,
+ME,8930,4,SelectedTopics in ME - Adv Mfg,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+ME,8930,27,Sel Topics in ME - Optimize,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
+MGT,2010,1,Principles of Management,0.39,0.35,0.24,0.02,0.0,0.0,0.0,0.0,katherine clark,
+MGT,2010,2,Principles of Management,0.31,0.47,0.18,0.02,0.01,0.0,0.0,0.0,katherine clark,
+MGT,2010,3,Principles of Management,0.43,0.4,0.11,0.02,0.02,0.0,0.0,0.01,katherine clark,
+MGT,2010,4,Principles of Management,0.2,0.44,0.27,0.05,0.02,0.0,0.0,0.02,katherine clark,
+MGT,2010,5,Principles of Management,0.25,0.37,0.32,0.02,0.01,0.0,0.0,0.02,tina robbins,
+MGT,2010,6,Principles of Management,0.45,0.39,0.11,0.01,0.01,0.0,0.0,0.02,tina robbins,
+MGT,2010,7,Principles of Management,0.57,0.3,0.11,0.0,0.01,0.0,0.0,0.01,tina robbins,
+MGT,2010,8,Principles of Management,0.51,0.37,0.07,0.02,0.0,0.0,0.0,0.02,tina robbins,
+MGT,2010,9,Principles of Mgt(HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
+MGT,2010,10,Principles of Management,0.26,0.32,0.3,0.06,0.04,0.0,0.0,0.02,ashley will parnell,
+MGT,2010,11,Principles of Management,0.22,0.33,0.33,0.03,0.03,0.0,0.0,0.06,ashley will parnell,
+MGT,2180,1,Management PC Applications,0.83,0.09,0.02,0.02,0.03,0.0,0.0,0.02,ryan toole,
+MGT,2180,2,Management PC Applications,0.8,0.12,0.02,0.01,0.02,0.0,0.0,0.03,ryan toole,
+MGT,2180,3,Management PC Applications,0.77,0.13,0.01,0.05,0.0,0.0,0.0,0.03,ryan toole,
+MGT,2180,4,Management PC Applications,0.76,0.11,0.05,0.01,0.01,0.0,0.0,0.05,ryan toole,
+MGT,3070,1,Human Resource Management,0.23,0.46,0.26,0.03,0.0,0.0,0.0,0.03,priscilla harrison,
+MGT,3070,3,Human Resource Management,0.27,0.38,0.19,0.08,0.0,0.0,0.0,0.08,kristin dam scott,
+MGT,3070,4,Human Resource Management,0.4,0.45,0.08,0.05,0.0,0.0,0.0,0.03,michael cole,
+MGT,3070,5,Human Resource Management,0.58,0.4,0.03,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,6,Human Resource Management,0.4,0.53,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3100,1,Intermed Business Statistics,0.07,0.25,0.11,0.18,0.25,0.0,0.0,0.14,sara elizabet yoder,
+MGT,3100,2,Intermed Business Statistics,0.11,0.19,0.19,0.14,0.22,0.0,0.0,0.16,sara elizabet yoder,
+MGT,3100,3,Intermed Business Statistics,0.1,0.26,0.31,0.1,0.1,0.0,0.0,0.13,sara elizabet yoder,
+MGT,3100,5,Intermed Business Statistics,0.79,0.12,0.06,0.0,0.0,0.0,0.0,0.03,thomas simpson,
+MGT,3100,6,Intermed Business Statistics,0.3,0.33,0.25,0.03,0.05,0.0,0.0,0.05,janis miller,
+MGT,3100,7,Intermed Business Statistics,0.11,0.37,0.21,0.08,0.11,0.0,0.0,0.13,magda gabriela sava,
+MGT,3100,8,Intermed Business Statistics,0.45,0.24,0.12,0.05,0.07,0.0,0.0,0.07,min kyung lee,
+MGT,3100,9,Intermed Business Statistics,0.5,0.25,0.18,0.03,0.03,0.0,0.0,0.03,shih lun tseng,
+MGT,3100,10,Intermed Business Statistics,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,jackie patri london,
+MGT,3100,13,Intermed Business Statistics,0.13,0.3,0.3,0.07,0.03,0.0,0.0,0.17,daniel nielubowicz,
+MGT,3100,14,Intermed Business Statistics,0.32,0.39,0.08,0.11,0.0,0.0,0.0,0.11,iaroslava dutchak,
+MGT,3120,1,Decision Models for Management,0.28,0.17,0.24,0.07,0.15,0.0,0.0,0.09,mark mcknew,
+MGT,3120,2,Decision Models for Management,0.3,0.33,0.28,0.0,0.02,0.0,0.0,0.07,mark mcknew,
+MGT,3120,3,Decision Models for Management,0.27,0.34,0.3,0.02,0.05,0.0,0.0,0.02,mark mcknew,
+MGT,3150,1,New Venture Creation,0.49,0.41,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth er powell,
+MGT,3180,1,Mgt of Info Systems,0.25,0.43,0.28,0.0,0.0,0.0,0.0,0.05,russell purvis,
+MGT,3180,2,Mgt of Info Systems,0.14,0.45,0.38,0.0,0.0,0.0,0.0,0.02,roopa raman,
+MGT,3180,3,Mgt of Info Systems,0.41,0.46,0.1,0.0,0.03,0.0,0.0,0.0,daniel aaron pienta,
+MGT,3180,4,Mgt of Info Systems,0.59,0.3,0.04,0.04,0.0,0.0,0.0,0.02,tina marie esposito,
+MGT,3180,5,Mgt of Info Systems,0.37,0.47,0.05,0.0,0.11,0.0,0.0,0.0,heshan sun,
+MGT,3500,1,Intro to Business Analytics,0.3,0.52,0.11,0.04,0.0,0.0,0.0,0.04,siyuan li,
+MGT,3900,1,Ops Mgt,0.38,0.33,0.2,0.03,0.03,0.0,0.0,0.05,yann ferrand,
+MGT,3900,2,Ops Mgt,0.11,0.44,0.33,0.06,0.0,0.0,0.0,0.06,zachary mo leffakis,
+MGT,3900,3,Ops Mgt,0.08,0.36,0.31,0.08,0.15,0.0,0.0,0.03,berna quiroga gomez,
+MGT,3900,4,Ops Mgt,0.26,0.15,0.36,0.13,0.08,0.0,0.0,0.03,berna quiroga gomez,
+MGT,3900,5,Ops Mgt,0.45,0.32,0.21,0.0,0.0,0.0,0.0,0.03,remi charpin,
+MGT,4000,1,Mgt of Organizational Behavior,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,2,Mgt of Organizational Behavior,0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,3,Mgt of Organizational Behavior,0.28,0.53,0.2,0.0,0.0,0.0,0.0,0.0,philip roth,
+MGT,4020,1,Ops Pln and Ctl,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4080,1,Lean Operations,0.18,0.39,0.34,0.03,0.03,0.0,0.0,0.03,zachary mo leffakis,
+MGT,4110,1,Project Management,0.22,0.63,0.12,0.0,0.0,0.0,0.0,0.02,russell purvis,
+MGT,4150,1,Business Strategy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,dennis lee lester,
+MGT,4150,2,Business Strategy,0.34,0.64,0.02,0.0,0.0,0.0,0.0,0.0,dane patric blevins,
+MGT,4150,3,Business Strategy,0.51,0.43,0.06,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,4,Business Strategy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,6,Business Strategy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dane patric blevins,
+MGT,4150,7,Business Strategy,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,8,Business Strategy,0.21,0.59,0.21,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,9,Business Strategy,0.31,0.58,0.09,0.02,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4160,1,Special Topics Hr,0.19,0.62,0.08,0.04,0.04,0.0,0.0,0.04,kristin dam scott,
+MGT,4230,1,Intern Bus Mgt,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4230,2,Intern Bus Mgt,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4230,3,Intern Bus Mgt,0.23,0.4,0.15,0.18,0.05,0.0,0.0,0.0,janis miller,
+MGT,4230,4,Intern Bus Mgt,0.25,0.63,0.1,0.0,0.03,0.0,0.0,0.0,janis miller,
+MGT,4240,1,Global Supply Chain,0.19,0.48,0.29,0.03,0.0,0.0,0.0,0.0,yann ferrand,
+MGT,4270,1,Managing Improvement,0.16,0.53,0.31,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MGT,4300,3,Applied Entrepreneurship,0.55,0.3,0.1,0.0,0.0,0.0,0.0,0.05,chad navis,
+MGT,4300,4,Organizational Leadership,0.58,0.26,0.0,0.05,0.05,0.0,0.0,0.05,amy elizabet ingram,
+MGT,4310,1,Emp Rights & Resp,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,4350,1,Pers Interviewing,0.38,0.48,0.13,0.0,0.03,0.0,0.0,0.0,philip roth,
+MGT,4520,1,Business Analysis,0.17,0.44,0.33,0.0,0.0,0.0,0.0,0.06,roopa raman,
+MGT,4550,1,Emerging I T Trends,0.59,0.26,0.04,0.0,0.07,0.0,0.0,0.04,jason thatcher,
+MGT,4560,1,Business Info Mgt,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,siyuan li,
+MGT,8690,1,Project Mgt,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
+MGT,9050,1,Research Methods,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,varun grover,
+MICR,1010,1,Microbes & Hum Aff,0.85,0.11,0.02,0.0,0.0,0.0,0.0,0.02,jessica gale owens,
+MICR,2050,1,Introductory Micro,0.53,0.35,0.07,0.01,0.0,0.0,0.0,0.04,john abercrombie,
+MICR,3000,1,Essential Skills in Microbiol,0.82,0.13,0.02,0.0,0.02,0.0,0.0,0.02,tamara lyn mcnealy,
+MICR,3050,1,General Microbiology,0.44,0.39,0.15,0.01,0.01,0.0,0.0,0.01,krista barr rudolph,
+MICR,3050,2,General Microbiology,0.41,0.41,0.1,0.05,0.03,0.0,0.0,0.0,krista barr rudolph,
+MICR,4010,1,Microbial Diversity & Ecology,0.19,0.49,0.18,0.06,0.03,0.0,0.0,0.04,barbara campbell,
+MICR,4050,1,Adv Microbial Ecol of Humans,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4140,1,Basic Immunology,0.52,0.15,0.21,0.0,0.06,0.0,0.0,0.06,yanzhang wei,
+MICR,4150,1,Microbial Genetics,0.15,0.56,0.21,0.06,0.0,0.0,0.0,0.02,min cao,
+MICR,4160,1,Intro Virology,0.96,0.01,0.03,0.0,0.0,0.0,0.0,0.0,simon scott,
+MICR,4510,1,Advanced Microbiology II,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,thomas hughes,
+MICR,4510,3,Advanced Microbiology II,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,thomas hughes,
+MKT,3010,1,Prin of Marketing,0.25,0.35,0.31,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,
+MKT,3010,2,Prin of Marketing,0.3,0.46,0.19,0.02,0.01,0.0,0.0,0.03,carter wil mcelveen,
+MKT,3010,3,Prin of Marketing,0.25,0.43,0.25,0.06,0.01,0.0,0.0,0.0,amanda cooper fine,
+MKT,3010,4,Prin of Marketing,0.25,0.42,0.26,0.05,0.02,0.0,0.0,0.0,amanda cooper fine,
+MKT,3010,5,Prin of Marketing,0.31,0.39,0.2,0.04,0.02,0.0,0.0,0.03,amanda cooper fine,
+MKT,3010,6,Prin of Marketing,0.58,0.3,0.08,0.02,0.0,0.0,0.0,0.02,patricia knowles,
+MKT,3020,1,Consumer Behavior,0.5,0.4,0.06,0.04,0.0,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,2,Consumer Behavior,0.42,0.4,0.1,0.06,0.02,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,3,Consumer Behavior,0.32,0.34,0.14,0.1,0.08,0.0,0.0,0.02, thyroff fitzwater,
+MKT,3020,4,Consumer Behavior,0.28,0.58,0.04,0.02,0.04,0.0,0.0,0.04, thyroff fitzwater,
+MKT,3020,5,Consumer Behavior,0.4,0.27,0.18,0.11,0.04,0.0,0.0,0.0,oriana rache aragon,
+MKT,3210,1,Sports Marketing,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3210,2,Sports Marketing,0.57,0.41,0.0,0.0,0.0,0.0,0.0,0.02,delancy bennett,
+MKT,3310,1,Marketing Metrics & Analytics,0.74,0.17,0.07,0.0,0.02,0.0,0.0,0.0,oriana rache aragon,
+MKT,4200,1,Professional Selling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4200,2,Professional Selling,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,3,Professional Selling,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,jesse moore,
+MKT,4200,4,Professional Selling,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4200,5,Professional Selling,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,ryan mullins,
+MKT,4230,1,Promotional Strategy,0.42,0.39,0.12,0.02,0.02,0.0,0.0,0.03,patricia knowles,
+MKT,4240,1,Sales Management,0.5,0.48,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4260,1,Business-to-Business,0.38,0.43,0.17,0.02,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4260,2,Business-to-Business,0.47,0.41,0.07,0.0,0.02,0.0,0.0,0.03,james gaubert,
+MKT,4270,1,International Mktg,0.37,0.38,0.19,0.03,0.02,0.0,0.0,0.0,roger gomes,
+MKT,4270,2,International Mktg,0.24,0.42,0.29,0.02,0.0,0.0,0.0,0.02,roger gomes,
+MKT,4270,3,International Mktg,0.39,0.49,0.05,0.05,0.0,0.0,0.0,0.02,thomas poehlman,
+MKT,4280,1,Services Marketing,0.4,0.51,0.06,0.0,0.0,0.0,0.0,0.03,james gaubert,
+MKT,4310,1,Marketing Research,0.17,0.31,0.38,0.1,0.03,0.0,0.0,0.0,peter weathers,
+MKT,4310,2,Marketing Research,0.29,0.54,0.04,0.11,0.04,0.0,0.0,0.0,peter weathers,
+MKT,4310,3,Marketing Research,0.33,0.63,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,4,Marketing Research,0.48,0.44,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4430,1,Advertising Strategy,0.75,0.23,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,
+MKT,4450,1,Macromarketing,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,william kilbourne,
+MKT,4450,2,Macromarketing,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,william kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.23,0.55,0.19,0.03,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,2,Strategic Mktg Mgt,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4950,1,Social Media,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,8610,1,Marketing Research,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,8630,1,Buyer Behavior,0.36,0.61,0.0,0.0,0.0,0.0,0.0,0.04,thomas poehlman,
+ML,1010,3,Leadership Fund I,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,amanda carol kane,
+ML,2010,1,Leadership Development I,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,shane allen werst,
+ML,2010,2,Leadership Development I,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,shane allen werst,
+ML,3010,1,Advanced Leadership I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william cod cleland,
+ML,3010,2,Advanced Leadership I,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,william cod cleland,
+ML,4010,1,Organizational Leadership I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
+MSE,2100,1,Intro to Mat Science,0.36,0.23,0.23,0.07,0.08,0.0,0.0,0.04,rakhee pani,
+MSE,2100,2,Intro to Mat Science,0.12,0.53,0.2,0.07,0.04,0.0,0.0,0.04,eric skaar,
+MSE,2100,3,Intro to Mat Science,0.23,0.42,0.2,0.05,0.02,0.0,0.0,0.07,eric skaar,
+MSE,2100,4,Intro to Mat Science,0.31,0.3,0.21,0.12,0.01,0.0,0.0,0.05,bradley mat schultz,
+MSE,2100,5,Intro to Mat Science,0.54,0.29,0.11,0.07,0.0,0.0,0.0,0.0,olga kuksenok,
+MSE,3190,1,Materials Proc I,0.32,0.35,0.23,0.03,0.06,0.0,0.0,0.0,olin mefford,
+MSE,3190,2,Materials Proc I,0.62,0.32,0.04,0.0,0.0,0.0,0.0,0.02,olin mefford,
+MSE,3260,1,Thermo of Materials,0.31,0.53,0.14,0.0,0.0,0.0,0.0,0.03,gary lickfield,
+MSE,3260,2,Thermo of Materials,0.21,0.26,0.29,0.15,0.09,0.0,0.0,0.0,gary lickfield,
+MSE,3270,1,Transport Phenomena,0.52,0.36,0.05,0.02,0.01,0.0,0.0,0.04,fei peng,
+MSE,3270,2,Transport Phenomena,0.3,0.28,0.3,0.03,0.06,0.0,0.0,0.03,ulf daniel schiller,
+MSE,4020,1,Solid State Material,0.43,0.26,0.21,0.04,0.04,0.0,0.0,0.02,luiz gust jacobsohn,
+MSE,4070,1,Senior Capstone Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,
+MSE,4130,1,Noncrystalline Materials,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
+MSE,4150,1,Polymer Sc Engr,0.37,0.28,0.15,0.03,0.03,0.0,0.0,0.13,marek urban,
+MSE,4150,2,Polymer Sc Engr,0.55,0.27,0.11,0.0,0.04,0.0,0.0,0.04,olin mefford,
+MSE,4550,2,Polymer Fiber Lab,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,olin mefford,
+MSE,4550,3,Polymer Fiber Lab,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,olin mefford,
+MSE,4580,1,Surf Phen in Ms&E,0.09,0.52,0.27,0.12,0.0,0.0,0.0,0.0,konstantin kornev,
+MSE,4610,1,Polymer & Fiber Materials III,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,
+MSE,4910,1,Undergraduate Research,0.65,0.26,0.03,0.0,0.03,0.0,0.0,0.03,marian kennedy,
+MSE,8010,1,Grad Sem in Materials Research,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,kyle brinkman,
+MSE,8100,1,Fundamentals of Materials Sci,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,rajendra kum bordia,
+MSE,8260,1,Phase Equil Mat Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,stephen foulger,
+MSE,8270,1,Kin of Phase Tran,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,konstantin kornev,
+MUSC,1510,2,Applied Music,0.5,0.3,0.1,0.0,0.0,0.0,0.0,0.1,jonathan edwa doyel,
+MUSC,1520,1,Applied Music,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
+MUSC,2100,1,Music in the Western World,0.78,0.13,0.06,0.0,0.03,0.0,0.0,0.0,eric lapin,
+MUSC,2100,2,Music in the Western World,0.53,0.19,0.16,0.03,0.0,0.0,0.0,0.09,lisa sain odom,
+MUSC,2100,3,Music in the Western World,0.88,0.06,0.03,0.03,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,2100,4,Music in the Western World,0.47,0.16,0.09,0.19,0.06,0.0,0.0,0.03,linda li-bleuel,
+MUSC,2100,5,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,
+MUSC,2100,6,Music in the Western World,0.72,0.19,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
+MUSC,2100,7,Music in the Western World,0.41,0.53,0.03,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
+MUSC,2100,8,Music in the Western World,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,10,Music in the Western World,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda dzuris,
+MUSC,2100,12,Music in the Western World,0.5,0.28,0.13,0.06,0.0,0.0,0.0,0.03,lea kibler,
+MUSC,2100,15,Music in West World (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,True
+MUSC,3080,1,Surv of Broadway I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,lisa sain odom,
+MUSC,3110,1,History of American Music,0.59,0.25,0.09,0.06,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,3130,1,Hist of Rock & Roll,0.41,0.38,0.09,0.13,0.0,0.0,0.0,0.0,hamilton altstatt,
+MUSC,3170,1,Hist of Country Mus,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3610,1,Marching Band,0.97,0.01,0.0,0.0,0.0,0.0,0.0,0.02,mark spede,
+MUSC,3620,1,Symphonic Band,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,mark spede,True
+MUSC,3690,1,Symphony Orchestra,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,andrew levin,True
+MUSC,3700,1,Clemson University Singers,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,justin durham,
+MUSC,3710,1,Women's Chorus,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,justin durham,
+MUSC,4150,1,Music Hist to 1750,0.17,0.22,0.22,0.11,0.06,0.0,0.0,0.22,justin durham,
+NPL,3000,1,Nonprofit Leadership,0.45,0.39,0.03,0.1,0.03,0.0,0.0,0.0,bonnie west stevens,
+NPL,3000,3,Nonprofit Leadership,0.59,0.24,0.14,0.0,0.03,0.0,0.0,0.0,james dougl bennett,
+NPL,3000,4,Nonprofit Leadership,0.87,0.1,0.0,0.03,0.0,0.0,0.0,0.0,christina mar mazer,
+NPL,3000,5,Nonprofit Leadership,0.52,0.24,0.1,0.0,0.05,0.0,0.0,0.1,christina mar mazer,
+NPL,3000,6,Nonprofit Leadership,0.76,0.1,0.05,0.05,0.05,0.0,0.0,0.0,christina mar mazer,
+NPL,3020,1,NPL Fundraising,0.57,0.33,0.05,0.0,0.05,0.0,0.0,0.0,robert frager,
+NPL,3040,1,NPL Risk Management,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,anthony shau catone,
+NURS,3030,1,Nursing of Adults,0.2,0.75,0.05,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3040,1,Pathophysiology,0.39,0.43,0.11,0.07,0.0,0.0,0.0,0.0,catherine si murton,
+NURS,3040,400,Pathophysiology,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
+NURS,3040,401,Pathophysiology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
+NURS,3100,1,Health Assessment,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
+NURS,3100,400,Health Assessment,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,
+NURS,3120,1,Foundations of Nursing,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,angela pye,
+NURS,3120,400,Foundations of Nursing,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,
+NURS,3300,1,Research in Nursing,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,veronica parker,
+NURS,3330,400,Health Care Genetics,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,mary steck,
+NURS,3400,1,Pharmther Nursing,0.32,0.52,0.11,0.02,0.04,0.0,0.0,0.0,catherine si murton,
+NURS,3400,400,Pharmther Nursing,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,jenna lyn seawright,
+NURS,4030,200,Complex Nursing of Adults,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
+NURS,4030,400,Complex Nursing of Adults,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,
+NURS,4110,1,Nursing of Children,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,
+NURS,4120,1,Nurs Women and Fam,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4150,1,Community Health Nursing,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jackie gillespie,
+NURS,4250,200,Community Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
+NURS,8050,400,Pharmaco Adv Nurs,0.77,0.21,0.0,0.0,0.0,0.0,0.0,0.03,tracy king fasolino,
+NURS,8050,401,Pharmaco Adv Nurs,0.67,0.29,0.0,0.0,0.04,0.0,0.0,0.0,tracy king fasolino,
+NURS,8060,400,Advan Assessment for Nursing,0.43,0.52,0.0,0.0,0.05,0.0,0.0,0.0,rosanne pruitt,
+NURS,8090,400,Pathophysiology,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
+NURS,8180,400,Develop Family in Primary Care,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,
+NURS,8190,400,Developing Family,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,
+NURS,8200,400,Child & Adol Nursing,0.56,0.38,0.0,0.0,0.06,0.0,0.0,0.0,heide temples,
+NURS,8220,400,Gerontology Nursing,0.93,0.0,0.0,0.0,0.08,0.0,0.0,0.0,nicole joy davis,
+NURS,8280,400,The Nurse Educator,0.82,0.05,0.0,0.0,0.05,0.0,0.0,0.09,roxanne amerson,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.5,0.32,0.12,0.04,0.01,0.0,0.0,0.03,deborah an hutcheon,
+NUTR,2030,2,Intro Princ of Human Nutrition,0.76,0.16,0.03,0.0,0.01,0.0,0.0,0.03,deborah an hutcheon,
+NUTR,2050,1,Nutrition for Nursing Prof,0.82,0.17,0.01,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
+NUTR,2160,1,Evidence-Based Nutrition,0.78,0.15,0.04,0.02,0.0,0.0,0.0,0.0,angela fraser,
+NUTR,4240,1,Medical Nutr Thera I,0.32,0.54,0.14,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4510,1,Human Nutrition & Metabolism I,0.27,0.38,0.16,0.11,0.05,0.0,0.0,0.03,elliot jesch,
+PA,1010,1,Intro to Perf Arts,0.57,0.2,0.2,0.03,0.0,0.0,0.0,0.0,david hartmann,
+PA,1030,1,Portfolio I,0.71,0.26,0.0,0.03,0.0,0.0,0.0,0.0,linda dzuris,
+PA,2010,2,Career Planning and Prof Devel,0.8,0.1,0.0,0.1,0.0,0.0,0.0,0.0,shannon ther robert,
+PA,2790,1,Perf Arts Pract I,0.54,0.23,0.12,0.0,0.08,0.0,0.0,0.04,kenneth moore,
+PA,2800,1,Perf Arts Pract II,0.47,0.27,0.07,0.0,0.07,0.0,0.0,0.13,kenneth moore,
+PA,3010,1,Princip of Arts Administration,0.5,0.33,0.08,0.08,0.0,0.0,0.0,0.0,paul buyer,
+PADM,7020,401,Research Methods,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
+PADM,8210,400,Perspectives on Public Admin,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,
+PADM,8220,400,Public Policy Process,0.73,0.13,0.0,0.0,0.13,0.0,0.0,0.0,ek yazykova mellott,
+PADM,8270,400,Public Personnel Admin,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,lawrence nichols,
+PADM,8290,400,Public Financial Management,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,robert frager,
+PADM,8340,400,Administrative Law,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,andrew moorman,
+PADM,8670,400,State Government Admin,0.31,0.54,0.08,0.0,0.08,0.0,0.0,0.0,alfred bundrick,
+PAS,3010,1,Pan African Studies,0.36,0.36,0.16,0.04,0.03,0.0,0.0,0.05,abel bartley,
+PDBE,8150,1,Research Design in EDP,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mickey lauria,
+PES,1040,1,Introduction to Plant Sciences,0.64,0.33,0.0,0.0,0.0,0.0,0.0,0.03,paula agudelo,
+PES,2020,1,Soils,0.01,0.41,0.39,0.11,0.01,0.0,0.0,0.07,dara michelle park,
+PES,4090,1,Biology of Invasive Plants,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,tharayil-santhakumar,
+PHIL,1010,1,Intro to Philosophic Problems,0.27,0.69,0.0,0.0,0.04,0.0,0.0,0.0,kelly smith,
+PHIL,1010,3,Intro to Philosophic Problems,0.5,0.31,0.16,0.03,0.0,0.0,0.0,0.0,christopher grau,
+PHIL,1010,4,Intro to Philosophic Problems,0.61,0.12,0.09,0.0,0.06,0.0,0.0,0.12,david stegall,
+PHIL,1010,6,Intro to Philosophic Problems,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david stegall,
+PHIL,1020,1,Introduction to Logic,0.59,0.19,0.09,0.09,0.03,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,2,Introduction to Logic,0.76,0.18,0.03,0.03,0.0,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,3,Introduction to Logic,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
+PHIL,1020,4,Introduction to Logic,0.8,0.09,0.09,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,
+PHIL,1020,5,Introduction to Logic,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,
+PHIL,1020,6,Introduction to Logic,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,michael hal hannen,
+PHIL,1020,7,Introduction to Logic,0.63,0.29,0.06,0.0,0.03,0.0,0.0,0.0,john randall wolfe,
+PHIL,1020,8,Introduction to Logic,0.82,0.12,0.03,0.03,0.0,0.0,0.0,0.0,john randall wolfe,
+PHIL,1020,9,Introduction to Logic,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
+PHIL,1030,2,Introduction to Ethics,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,william maker,
+PHIL,1030,3,Introduction to Ethics,0.27,0.43,0.27,0.03,0.0,0.0,0.0,0.0,john jung park,
+PHIL,1030,4,Introduction to Ethics,0.36,0.43,0.18,0.04,0.0,0.0,0.0,0.0,john jung park,
+PHIL,1030,5,Introduction to Ethics,0.66,0.25,0.06,0.0,0.03,0.0,0.0,0.0,adam gies,
+PHIL,1030,7,Introduction to Ethics,0.76,0.15,0.09,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1030,8,Introduction to Ethics,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1030,10,Introduction to Ethics,0.18,0.59,0.18,0.06,0.0,0.0,0.0,0.0,john jung park,
+PHIL,1030,12,Introduction to Ethics,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,john jung park,
+PHIL,1030,13,Introduction to Ethics,0.35,0.48,0.1,0.0,0.06,0.0,0.0,0.0,daniel wueste,
+PHIL,3150,1,Ancient Philosophy,0.24,0.27,0.21,0.03,0.15,0.0,0.0,0.09,stephen satris,
+PHIL,3160,1,Modern Philosophy,0.52,0.33,0.09,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
+PHIL,3200,1,Soc and Pol Phil,0.53,0.12,0.18,0.0,0.06,0.0,0.0,0.12,john randall wolfe,
+PHIL,3240,1,Philosophy of Tech,0.44,0.31,0.16,0.09,0.0,0.0,0.0,0.0,william maker,
+PHIL,3260,1,Science and Values,0.53,0.31,0.06,0.0,0.06,0.0,0.0,0.03,andrew garnar,
+PHIL,3260,2,Science and Values,0.5,0.35,0.09,0.0,0.03,0.0,0.0,0.03,andrew garnar,
+PHIL,3330,1,Metaphysics,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,david stegall,
+PHIL,3440,1,Business Ethics,0.77,0.2,0.0,0.0,0.03,0.0,0.0,0.0,david stegall,
+PHIL,3450,1,Environmental Ethics,0.48,0.36,0.09,0.0,0.0,0.0,0.0,0.06,jennifer ingle,
+PHIL,3450,2,Environmental Ethics,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,jennifer ingle,
+PHIL,3460,1,Medical Ethics,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04,charles starkey,
+PHIL,3480,1,Philosophies of Art,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,christopher grau,
+PHIL,3490,1,Gender and Sexuality,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,jennifer ingle,
+PHIL,4920,1,Creative Inquiry in Philosophy,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,stephen satris,
+PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.84,0.11,0.03,0.02,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics with Calculus I,0.26,0.3,0.26,0.12,0.06,0.0,0.0,0.02,pooja puneet,
+PHYS,1220,2,Physics with Calculus I,0.34,0.28,0.21,0.07,0.06,0.0,0.0,0.04,pooja puneet,
+PHYS,1220,3,Physics W/Cal I (HON),0.57,0.35,0.04,0.04,0.0,0.0,0.0,0.0,hugo sanabria,True
+PHYS,1220,4,Physics with Calculus I,0.31,0.38,0.31,0.0,0.0,0.0,0.0,0.0,murray daw,
+PHYS,1220,500,Physics with Calculus I,0.31,0.5,0.19,0.0,0.0,0.0,0.0,0.0,elaine parshall,
+PHYS,1240,1,Physics Lab I,0.06,0.67,0.11,0.06,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,2,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,3,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,4,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,5,Physics Lab I,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,6,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,7,Physics Lab I,0.11,0.67,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,8,Physics Lab I,0.39,0.56,0.0,0.06,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,9,Physics Lab I,0.56,0.28,0.06,0.0,0.11,0.0,0.0,0.0,jerry hester,
+PHYS,1240,10,Physics Lab I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,11,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,14,Physics Lab I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,15,Physics Lab I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,16,Physics Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,17,Physics Lab I,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,18,Physics Lab I,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,19,Physics Lab I,0.22,0.61,0.06,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,500,Physics Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,elaine parshall,
+PHYS,2070,1,General Physics I,0.32,0.28,0.19,0.08,0.07,0.0,0.0,0.05,amy liann pope,
+PHYS,2070,2,General Physics I,0.4,0.44,0.09,0.04,0.01,0.0,0.0,0.02,amy liann pope,
+PHYS,2070,3,General Physics I,0.43,0.32,0.16,0.05,0.01,0.0,0.0,0.02,amy liann pope,
+PHYS,2080,1,General Physics II,0.33,0.39,0.18,0.03,0.05,0.0,0.0,0.02,lih-sin the,
+PHYS,2090,1,Gen Phys Lab I,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,2,Gen Phys Lab I,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,3,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,4,Gen Phys Lab I,0.29,0.63,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,5,Gen Phys Lab I,0.33,0.63,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,6,Gen Phys Lab I,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,7,Gen Phys Lab I,0.33,0.54,0.04,0.0,0.04,0.0,0.0,0.04,jerry hester,
+PHYS,2090,8,Gen Phys Lab I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,9,Gen Phys Lab I,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,10,Gen Phys Lab I,0.27,0.41,0.14,0.05,0.0,0.0,0.0,0.14,jerry hester,
+PHYS,2090,11,Gen Phys Lab I,0.38,0.48,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,12,Gen Phys Lab I,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,13,Gen Phys Lab I,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,14,Gen Phys Lab I,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,15,Gen Phys Lab I,0.17,0.63,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,16,Gen Phys Lab I,0.68,0.23,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,17,Gen Phys Lab I,0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,18,Gen Phys Lab I,0.67,0.25,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,19,Gen Phys Lab I,0.33,0.58,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,20,Gen Phys Lab I,0.19,0.52,0.24,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,21,Gen Phys Lab I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,22,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,
+PHYS,2090,23,Gen Phys Lab I,0.33,0.43,0.19,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,24,Gen Phys Lab I,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,1,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,2,Gen Phys Lab II,0.43,0.21,0.21,0.07,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,2100,4,Gen Phys Lab II,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,6,Gen Phys Lab II,0.52,0.3,0.09,0.04,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,7,Gen Phys Lab II,0.65,0.13,0.13,0.0,0.04,0.0,0.0,0.04,jerry hester,
+PHYS,2100,8,Gen Phys Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2210,1,Physics with Calculus II,0.13,0.44,0.28,0.1,0.03,0.0,0.0,0.02,jason stratfo brown,
+PHYS,2210,2,Physics with Calculus II,0.24,0.49,0.19,0.04,0.02,0.0,0.0,0.03,jason stratfo brown,
+PHYS,2210,3,Physics with Calculus II,0.34,0.53,0.11,0.01,0.01,0.0,0.0,0.0,jason stratfo brown,
+PHYS,2210,4,Physics with Calculus II,0.18,0.56,0.18,0.04,0.03,0.0,0.0,0.01,pooja puneet,
+PHYS,2210,7,Physics With Cal II (HON),0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,endre andras takacs,True
+PHYS,2220,1,Physics with Calculus III,0.32,0.35,0.16,0.0,0.03,0.0,0.0,0.13,jian he,
+PHYS,2230,1,Physics Lab II,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,2,Physics Lab II,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,3,Physics Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,4,Physics Lab II,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,2230,5,Physics Lab II,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,6,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,7,Physics Lab II,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,jerry hester,
+PHYS,2230,9,Physics Lab II,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,10,Physics Lab II,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,11,Physics Lab II,0.11,0.89,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,12,Physics Lab II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,13,Physics Lab II,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,2230,17,Physics Lab II,0.07,0.43,0.29,0.0,0.07,0.0,0.0,0.14,jerry hester,
+PHYS,2450,1,Physics of Climate,0.44,0.26,0.09,0.04,0.04,0.0,0.0,0.14,gerald lehmacher,
+PHYS,3000,1,Intro to Research,0.76,0.12,0.08,0.0,0.04,0.0,0.0,0.0,hugo sanabria,
+PHYS,3120,1,Meth Theor Phys II,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,feng ding,
+PHYS,3150,1,Intro to Computational Physics,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,emil georgie alexov,
+PHYS,3210,1,Mechanics I,0.16,0.26,0.26,0.16,0.05,0.0,0.0,0.11,joshua alper,
+PHYS,3250,1,Exper Physics I,0.42,0.47,0.05,0.0,0.0,0.0,0.0,0.05,chad sosolik,
+PHYS,4410,1,Electromagnetics I,0.27,0.18,0.27,0.18,0.0,0.0,0.0,0.09,joan marler,
+PHYS,4550,1,Quantum Physics I,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,ramakrishna podila,
+PHYS,8110,1,Meth of Theor Phys I,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,bradley meyer,
+PHYS,8210,1,Classical Mech I,0.18,0.55,0.27,0.0,0.0,0.0,0.0,0.0,jens oberheide,
+PHYS,9510,1,Quantum Mech I,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
+PKSC,1010,1,Pkgsc Orientation,0.79,0.11,0.08,0.0,0.02,0.0,0.0,0.0,robert truett moore,
+PKSC,1020,1,Intro to Pkg Sci,0.1,0.33,0.32,0.11,0.09,0.0,0.0,0.04,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2200,1,Product & Pkg Design,0.85,0.06,0.02,0.0,0.04,0.0,0.0,0.02,william aaro snyder,
+PKSC,3200,1,Pkg Design Theory,0.39,0.26,0.3,0.0,0.04,0.0,0.0,0.0,rupert hurley,
+PKSC,4010,1,Packaging Machinery,0.31,0.41,0.2,0.07,0.01,0.0,0.0,0.0,anthony lou pometto,
+PKSC,4030,1,Pkg Career Prep,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4040,1,Protective Packaging Prop/Prin,0.28,0.27,0.24,0.1,0.07,0.0,0.0,0.03,gregory batt,
+PKSC,4160,1,Appl Polymers in Pkg,0.16,0.52,0.23,0.06,0.03,0.0,0.0,0.0,duncan darby,
+PKSC,4200,1,Pkg Design & Dev,0.54,0.39,0.04,0.0,0.04,0.0,0.0,0.0,robert kimmel,
+PKSC,4230,400,3D Parametric Design Online,0.77,0.0,0.0,0.0,0.15,0.0,0.0,0.08,rupert hurley,
+PKSC,4540,1,Prod Pkg Evl Lab,0.38,0.19,0.19,0.13,0.06,0.0,0.0,0.06,gregory batt,
+PKSC,4540,2,Prod Pkg Evl Lab,0.13,0.25,0.13,0.06,0.38,0.0,0.0,0.06,gregory batt,
+PKSC,4540,3,Prod Pkg Evl Lab,0.56,0.19,0.06,0.0,0.19,0.0,0.0,0.0,gregory batt,
+PKSC,4540,4,Prod Pkg Evl Lab,0.25,0.31,0.25,0.0,0.19,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1,Food & Health Care Pkg Systems,0.53,0.28,0.06,0.0,0.14,0.0,0.0,0.0,kay cooksey,
+PKSC,6230,400,3D Parametic Design Online,0.67,0.0,0.17,0.0,0.0,0.0,0.0,0.17,rupert hurley,
+PLPA,3100,1,Principles of Plant Pathology,0.12,0.48,0.4,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,
+PLPA,8020,1,Ppls of Plant Pathology,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,
+POSC,1010,1,Amer National Govt,0.08,0.39,0.3,0.1,0.05,0.0,0.0,0.08,joseph earl stewart,
+POSC,1010,2,Amer National Govt,0.24,0.36,0.17,0.1,0.08,0.0,0.0,0.06,jeffrey scott peake,
+POSC,1020,1,Intro Intl Relations,0.33,0.43,0.13,0.06,0.02,0.0,0.0,0.04,tara elizabet trask,
+POSC,1020,2,Intro Intl Relations,0.22,0.26,0.3,0.09,0.05,0.0,0.0,0.08,zeynep taydas,
+POSC,1020,3,Intro Intl Relations,0.16,0.29,0.35,0.11,0.04,0.0,0.0,0.05,zeynep taydas,
+POSC,1020,4,Intro Intl Relations,0.16,0.29,0.36,0.12,0.03,0.0,0.0,0.03,joshua douglas king,
+POSC,1020,5,Intro Intl Relations,0.09,0.47,0.19,0.06,0.09,0.0,0.0,0.09,joshua douglas king,
+POSC,1030,1,Intro to Political Theory,0.05,0.26,0.21,0.37,0.03,0.0,0.0,0.08,james woodard,
+POSC,1030,2,Intro to Political Theory,0.25,0.29,0.25,0.11,0.07,0.0,0.0,0.02,brandon turner,
+POSC,1040,1,Intro Compar Pol,0.36,0.42,0.11,0.06,0.04,0.0,0.0,0.02,tara elizabet trask,
+POSC,1040,2,Intro Compar Pol,0.18,0.35,0.29,0.06,0.06,0.0,0.0,0.06,katherine am curtis,
+POSC,1990,1,Intro Pol Sci,0.4,0.33,0.08,0.09,0.06,0.0,0.0,0.05,meredith petersheim,
+POSC,3020,1,State and Loc Gov,0.12,0.58,0.1,0.02,0.02,0.0,0.0,0.16,bruce ransom,
+POSC,3410,1,Quant Meth in Pol Sc,0.06,0.17,0.33,0.22,0.17,0.0,0.0,0.06,steven vince miller,
+POSC,3610,1,Intl Pol in Crisis,0.4,0.4,0.1,0.04,0.04,0.0,0.0,0.02,vladimir matic,
+POSC,3630,1,Us Foreign Policy,0.29,0.24,0.22,0.14,0.1,0.0,0.0,0.0,steven vince miller,
+POSC,3710,1,European Politics,0.33,0.28,0.22,0.0,0.06,0.0,0.0,0.11,vladimir matic,
+POSC,3890,1,Religious Liberty & the Const.,0.29,0.64,0.0,0.0,0.07,0.0,0.0,0.0,daniel frost,
+POSC,4030,1,United States Congress,0.27,0.37,0.27,0.04,0.04,0.0,0.0,0.02,jeffrey allen fine,
+POSC,4070,1,Religion and Politic,0.17,0.46,0.26,0.03,0.06,0.0,0.0,0.03,laura olson,
+POSC,4210,1,Public Policy,0.06,0.13,0.25,0.19,0.19,0.0,0.0,0.19,adam warber,
+POSC,4230,1,Urban Politics,0.33,0.33,0.0,0.0,0.17,0.0,0.0,0.17,bruce ransom,
+POSC,4360,1,Law Courts Politics,0.66,0.19,0.04,0.0,0.02,0.0,0.0,0.09,joseph earl stewart,
+POSC,4380,1,Constitut Law: Struc of Gov,0.4,0.46,0.13,0.0,0.02,0.0,0.0,0.0,daniel frost,
+POSC,4420,1,Pol Parties & Elect,0.13,0.04,0.42,0.29,0.0,0.0,0.0,0.13,james woodard,
+POSC,4470,1,International Law,0.27,0.35,0.22,0.08,0.05,0.0,0.0,0.03,katherine am curtis,
+POSC,4490,1,Political Theory of Capitalism,0.45,0.14,0.1,0.02,0.2,0.0,0.0,0.08,brandon turner,
+POSC,4550,1,Pol Thght of American Founding,0.32,0.48,0.19,0.0,0.0,0.0,0.0,0.0, bradley thompson,
+POSC,4560,1,Diplomacy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
+POSC,4760,1,Middle East Politics,0.67,0.13,0.07,0.0,0.0,0.0,0.0,0.13,vladimir matic,
+POSC,4820,1,Political Novel and Film,0.11,0.42,0.47,0.0,0.0,0.0,0.0,0.0,james woodard,
+PRTM,2200,10,Foundations of PRTM,0.45,0.34,0.08,0.02,0.04,0.0,0.0,0.08,jamie lynn cathey,
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2260,2,Fnd of Mgt Adm PRTM,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,
+PRTM,2260,3,Fnd of Mgt Adm PRTM,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2260,4,Fnd of Mgt Adm PRTM,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
+PRTM,2260,5,Fnd of Mgt Adm PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2260,6,Fnd of Mgt Adm PRTM,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,harrison pinckney,
+PRTM,2260,7,Fnd of Mgt Adm PRTM,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2260,8,Fnd of Mgt Adm PRTM,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,kellie aman walters,
+PRTM,2270,1,Prov of Leisure Exp,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2270,2,Prov of Leisure Exp,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,
+PRTM,2270,3,Prov of Leisure Exp,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2270,4,Prov of Leisure Exp,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
+PRTM,2270,5,Prov of Leisure Exp,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2270,6,Prov of Leisure Exp,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,harrison pinckney,
+PRTM,2270,7,Prov of Leisure Exp,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2270,8,Prov of Leisure Exp,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,kellie aman walters,
+PRTM,2290,1,Competency Integration in PRTM,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2290,2,Competency Integration in PRTM,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,
+PRTM,2290,3,Competency Integration in PRTM,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2290,4,Competency Integration in PRTM,0.28,0.5,0.17,0.0,0.06,0.0,0.0,0.0,herbert chancellor,
+PRTM,2290,5,Competency Integration in PRTM,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2290,6,Competency Integration in PRTM,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,harrison pinckney,
+PRTM,2290,7,Competency Integration in PRTM,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2290,8,Competency Integration in PRTM,0.26,0.53,0.11,0.05,0.05,0.0,0.0,0.0,kellie aman walters,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.33,0.3,0.18,0.15,0.03,0.0,0.0,0.03,daniel mor anderson,
+PRTM,3070,2,Facility Operations,0.83,0.09,0.04,0.04,0.0,0.0,0.0,0.0,raymond dunham,
+PRTM,3200,1,Recreation Policy,0.25,0.45,0.2,0.1,0.0,0.0,0.0,0.0,lincoln larson,
+PRTM,3210,1,Recreation Admin,0.71,0.18,0.11,0.0,0.0,0.0,0.0,0.0,mariela fernandez,
+PRTM,3220,2,Facilitation Techniques in RT,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alysha amber walter,
+PRTM,3230,1,Prof Prep for RT Practice,0.91,0.0,0.0,0.0,0.05,0.0,0.0,0.04,stephen thoma lewis,
+PRTM,3240,1,Assessment & Planning in RT,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3240,2,Assessment & Planning in RT,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3250,1,Global Persp in Rec,0.42,0.26,0.19,0.13,0.0,0.0,0.0,0.0,mary price,
+PRTM,3300,1,Visit Ser & Interp,0.6,0.13,0.27,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,3420,2,Intro to Tourism,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,li-hsin chen,
+PRTM,3430,1,Spl Asp of Tourist B,0.35,0.48,0.11,0.0,0.05,0.0,0.0,0.0,william norman,
+PRTM,3470,1,Sport Tourism,0.35,0.35,0.2,0.05,0.0,0.0,0.0,0.05,gregory phi ramshaw,
+PRTM,3520,1,Camp Org and Admin,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,3900,6,Independent Study in PRTM,0.77,0.08,0.0,0.08,0.0,0.0,0.0,0.08,adam savedra,
+PRTM,3910,1,Social Media in PRTM,0.78,0.13,0.04,0.0,0.04,0.0,0.0,0.0,sheila backman,
+PRTM,3910,2,Issues & Trends in Event Mgmt.,0.72,0.16,0.08,0.04,0.0,0.0,0.0,0.0,stephanie per garst,
+PRTM,3910,3,Resort Management,0.76,0.19,0.0,0.0,0.05,0.0,0.0,0.0,jeffery martin,
+PRTM,3920,1,Special Event Management,0.69,0.2,0.1,0.0,0.0,0.0,0.0,0.02,kenneth backman,
+PRTM,3920,2,Special Event Management,0.8,0.16,0.02,0.0,0.0,0.0,0.0,0.02,kenneth backman,
+PRTM,3950,1,PGM Seminar III,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3980,2,Creative Inquiry in PRTM III,0.67,0.17,0.06,0.0,0.0,0.0,0.0,0.11,denise mar anderson,
+PRTM,3980,10,Creative Inquiry in PRTM III,0.59,0.21,0.14,0.07,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,4030,1,Elem of Rec/Pk Plan,0.43,0.36,0.21,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
+PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,
+PRTM,4220,1,Management of RT Services,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
+PRTM,4470,1,Perspect Intl Travel,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,lauren duffy,
+PRTM,4740,2,Adv Rec Resource Mgt,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey koo riungu,
+PRTM,4830,1,Golf Club Mgt & Ops,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,4950,1,Pro Golf Management Seminar IV,0.5,0.25,0.08,0.17,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,4980,10,Creative Inquiry in PRTM IV,0.59,0.21,0.14,0.07,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,8010,1,Phil Found of PRTM,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
+PRTM,8010,2,Phil Found of PRTM,0.5,0.36,0.0,0.0,0.05,0.0,0.0,0.09,dorothy schmalz,
+PRTM,8010,3,Phil Found of PRTM,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
+PRTM,8080,1,Behavioral Aspects,0.76,0.16,0.04,0.0,0.04,0.0,0.0,0.0,robert bixler,
+PRTM,8080,2,Behavioral Aspects,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,8220,2,Strateg Planning in PRTM Orgs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,
+PRTM,8710,1,Applied Research in Rec Therap,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
+PRTM,8710,4,Applied Research in Rec Therap,0.9,0.06,0.03,0.0,0.0,0.0,0.0,0.0,sarah taylor agate,
+PRTM,8750,1,Program Plan & Consult in RT,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
+PRTM,8750,2,Program Plan & Consult in RT,0.33,0.17,0.5,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
+PSYC,2010,1,Intro to Psychology,0.36,0.32,0.18,0.06,0.05,0.0,0.0,0.03,jo anne jorgensen,
+PSYC,2010,2,Intro to Psychology,0.37,0.32,0.17,0.05,0.03,0.0,0.0,0.05,jo anne jorgensen,
+PSYC,2010,3,Intro to Psychology,0.24,0.34,0.24,0.1,0.06,0.0,0.0,0.02,edwin brainerd,
+PSYC,2010,4,Intro to Psychology,0.45,0.29,0.16,0.06,0.04,0.0,0.0,0.0,fred switzer,
+PSYC,2010,5,Intro to Psychology,0.33,0.26,0.21,0.03,0.06,0.0,0.0,0.11,mary taylor,
+PSYC,2010,6,Intro to Psychology (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
+PSYC,2020,1,Intro Psychology Lab,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,jamie fynes,
+PSYC,2020,4,Intro Psychology Lab,0.8,0.04,0.0,0.04,0.12,0.0,0.0,0.0,madison eliza sauls,
+PSYC,2020,5,Intro Psychology Lab,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,william leidheiser,
+PSYC,2020,6,Intro Psychology Lab,0.77,0.15,0.0,0.0,0.04,0.0,0.0,0.04,william leidheiser,
+PSYC,3060,1,Human Sexual Beh,0.46,0.24,0.15,0.06,0.07,0.0,0.0,0.02,bruce michael king,
+PSYC,3090,100,Intro Exp Psych,0.51,0.23,0.14,0.08,0.04,0.0,0.0,0.0,patrick rosopa,
+PSYC,3090,200,Intro Exp Psych,0.4,0.2,0.1,0.03,0.23,0.0,0.0,0.03,jennifer bai bisson,
+PSYC,3090,300,Intro Exp Psych,0.57,0.23,0.07,0.07,0.03,0.0,0.0,0.03,stephen robertson,
+PSYC,3100,100,Advanced Experimental Psych,0.32,0.26,0.32,0.05,0.05,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimental Psych,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,robert campbell,
+PSYC,3100,300,Advanced Experimental Psych,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,benjamin stephens,
+PSYC,3100,400,Advanced Experimental Psych,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,leo gugerty,
+PSYC,3100,500,Advanced Experimental Psych,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3240,1,Physiological Psych,0.38,0.28,0.17,0.1,0.01,0.0,0.0,0.06,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.34,0.3,0.19,0.07,0.03,0.0,0.0,0.06,june pilcher,
+PSYC,3330,1,Cognitive Psych,0.42,0.39,0.11,0.03,0.01,0.0,0.0,0.03,leah hartman,
+PSYC,3330,2,Cognitive Psych,0.21,0.23,0.38,0.15,0.03,0.0,0.0,0.0,thomas alley,
+PSYC,3330,3,Cognitive Psych,0.16,0.33,0.31,0.16,0.02,0.0,0.0,0.03,thomas alley,
+PSYC,3340,1,Cognitive Psych Lab,0.68,0.23,0.09,0.0,0.0,0.0,0.0,0.0,laura whitlock,
+PSYC,3340,2,Cognitive Psych Lab,0.75,0.04,0.04,0.08,0.04,0.0,0.0,0.04,laura whitlock,
+PSYC,3400,1,Lifespan Developmental Psych,0.21,0.4,0.23,0.06,0.04,0.0,0.0,0.06,pamela alley,
+PSYC,3400,2,Lifespan Developmental Psych,0.62,0.28,0.09,0.0,0.01,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3520,1,Social Psychology,0.39,0.37,0.19,0.04,0.0,0.0,0.0,0.01,eric mckibben,
+PSYC,3640,1,Industrial Psych,0.3,0.51,0.17,0.0,0.0,0.0,0.0,0.01,eric mckibben,
+PSYC,3640,2,Industrial Psych,0.4,0.5,0.07,0.01,0.0,0.0,0.0,0.01,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.34,0.31,0.14,0.07,0.06,0.0,0.0,0.07,thomas britt,
+PSYC,3680,2,Organizational Psych,0.3,0.35,0.15,0.11,0.07,0.0,0.0,0.02,kristen su jennings,
+PSYC,3700,1,Personality,0.14,0.49,0.31,0.06,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,3830,1,Abnormal Psychology,0.28,0.4,0.14,0.13,0.02,0.0,0.0,0.02,cynthia pury,
+PSYC,3830,2,Abnormal Psychology,0.17,0.29,0.34,0.09,0.09,0.0,0.0,0.03,pamela alley,
+PSYC,3830,3,Abnormal Psychology,0.34,0.23,0.26,0.0,0.06,0.0,0.0,0.11,pamela alley,
+PSYC,3830,4,Abnormal Psychology,0.32,0.43,0.16,0.03,0.01,0.0,0.0,0.04,lucinda sorci quick,
+PSYC,4080,1,Women and Psychology,0.56,0.32,0.08,0.04,0.0,0.0,0.0,0.0,robin mari kowalski,
+PSYC,4150,1,Systems and Theories,0.27,0.53,0.1,0.07,0.03,0.0,0.0,0.0,brian day,
+PSYC,4150,2,Systems and Theories,0.41,0.18,0.26,0.06,0.03,0.0,0.0,0.06,edwin brainerd,
+PSYC,4150,3,Systems and Theories,0.39,0.25,0.25,0.0,0.08,0.0,0.0,0.03,edwin brainerd,
+PSYC,4220,1,Perception,0.3,0.39,0.09,0.09,0.09,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4220,2,Perception,0.5,0.17,0.21,0.08,0.0,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4220,3,Perception,0.26,0.37,0.22,0.15,0.0,0.0,0.0,0.0,christopher pagano,
+PSYC,4350,1,Human Factors,0.38,0.17,0.33,0.13,0.0,0.0,0.0,0.0,laura whitlock,
+PSYC,4430,1,Infant & Child Dev,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,4560,1,Psychophysiology,0.54,0.17,0.04,0.08,0.08,0.0,0.0,0.08,drew michael morris,
+PSYC,4710,1,Psych of Testing,0.46,0.21,0.21,0.08,0.04,0.0,0.0,0.0,robert ray sinclair,
+PSYC,4800,1,Health Psychology,0.5,0.38,0.08,0.0,0.04,0.0,0.0,0.0,james mccubbin,
+PSYC,4800,2,Health Psychology,0.56,0.36,0.0,0.0,0.04,0.0,0.0,0.04,james mccubbin,
+PSYC,4880,1,Psychotherapy,0.43,0.29,0.07,0.07,0.07,0.0,0.0,0.07,heidi marie zinzow,
+PSYC,4890,1,Teamwork in 21st Cen,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,william kramer,
+PSYC,4920,1,Senior Laboratory,0.68,0.2,0.08,0.04,0.0,0.0,0.0,0.0,drea kevin fekety,
+PSYC,4920,4,Senior Laboratory,0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,miranda pelkey,
+PSYC,4920,5,Senior Laboratory,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,dana verhoeven,
+PSYC,4920,6,Senior Laboratory,0.45,0.18,0.09,0.09,0.18,0.0,0.0,0.0,dana verhoeven,
+PSYC,8100,1,Research Design I,0.61,0.16,0.1,0.0,0.06,0.0,0.0,0.06, dewayne moore,
+PSYC,8220,1,Percept & Perform,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richard tyrrell,
+RED,8000,1,Real Estate Dvlpment,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,robert cre benedict,
+RED,8010,1,Market Analysis,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
+RED,8130,1,Strat in Real Estate,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,
+REL,1010,1,Intro to Religion,0.43,0.43,0.04,0.04,0.04,0.0,0.0,0.0,steven grosby,
+REL,1010,2,Intro to Religion,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,robert stephens,
+REL,1010,4,Intro to Religion,0.82,0.09,0.06,0.0,0.03,0.0,0.0,0.0,robert stephens,
+REL,1010,5,Intro to Religion,0.72,0.09,0.06,0.0,0.0,0.0,0.0,0.13,robert stephens,
+REL,1020,2,World Religions,0.22,0.17,0.33,0.06,0.06,0.0,0.0,0.17,peter cohen,
+REL,1020,3,World Religions,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,peter cohen,
+REL,1020,4,World Religions,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,peter cohen,
+REL,1020,5,World Religions,0.35,0.29,0.26,0.0,0.0,0.0,0.0,0.09,brett patterson,
+REL,1020,7,World Religions,0.42,0.33,0.17,0.0,0.0,0.0,0.0,0.08,brett patterson,
+REL,3010,1,Old Testament,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3060,1,Judaism,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3110,1,African American Rel,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,elizabeth jemison,
+REL,3130,1,Buddhism,0.68,0.21,0.0,0.05,0.0,0.0,0.0,0.05,robert stephens,
+REL,3150,1,Islam,0.5,0.31,0.06,0.0,0.0,0.0,0.0,0.13,mashal saif,
+REL,3300,1,Contemporary Issues,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mashal saif,
+REL,4010,1,Stud Biblical Literature & Rel,0.41,0.29,0.06,0.0,0.12,0.0,0.0,0.12,benjamin white,
+RS,3010,1,Rural Sociology,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
+RUSS,1010,1,Elementary Russian,0.26,0.26,0.26,0.11,0.11,0.0,0.0,0.0,olga anatol volkova,
+RUSS,3400,1,19th C Russ Culture,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,
+SOC,2010,2,Introduction to Sociology,0.72,0.2,0.06,0.0,0.01,0.0,0.0,0.01,andrew mannheimer,
+SOC,2010,3,Introduction to Sociology,0.73,0.18,0.04,0.02,0.0,0.02,0.0,0.0,andrew mannheimer,
+SOC,2010,4,Introduction to Sociology,0.28,0.51,0.11,0.04,0.01,0.0,0.0,0.04,carolyn can coffman,
+SOC,2010,5,Introduction to Sociology,0.26,0.45,0.23,0.06,0.0,0.0,0.0,0.0,carolyn can coffman,
+SOC,2010,6,Introduction to Sociology,0.28,0.55,0.15,0.02,0.0,0.0,0.0,0.0,carolyn can coffman,
+SOC,2010,7,Introduction to Sociology,0.34,0.4,0.13,0.06,0.0,0.0,0.0,0.06,mary louise barr,
+SOC,2010,8,Introduction to Sociology,0.56,0.27,0.13,0.02,0.02,0.0,0.0,0.0,mary louise barr,
+SOC,2010,9,Introduction to Sociology,0.5,0.3,0.16,0.02,0.0,0.0,0.0,0.02,mary louise barr,
+SOC,2010,10,Introduction to Sociology,0.43,0.39,0.13,0.03,0.0,0.0,0.0,0.01,mary louise barr,
+SOC,2010,11,Introduction to Sociology,0.57,0.3,0.11,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,12,Introduction to Sociology,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,13,Introduction to Sociology,0.6,0.28,0.08,0.01,0.02,0.0,0.0,0.01,shannon mcdonough,
+SOC,2010,14,Introduction to Sociology,0.71,0.2,0.06,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,15,Introduction to Sociology,0.71,0.21,0.02,0.02,0.02,0.0,0.0,0.02,shannon mcdonough,
+SOC,2010,16,Introduction to Sociology,0.47,0.43,0.04,0.04,0.0,0.0,0.0,0.02,tamela lea eitle,
+SOC,2010,17,Introduction to Sociology,0.4,0.46,0.08,0.02,0.02,0.0,0.0,0.02,tamela lea eitle,
+SOC,2050,1,Sociology Lab,0.54,0.15,0.15,0.0,0.15,0.0,0.0,0.0,brenda vander mey,
+SOC,2050,2,Sociology Lab,0.61,0.11,0.0,0.0,0.28,0.0,0.0,0.0,brenda vander mey,
+SOC,3020,1,Research Methods I,0.09,0.44,0.31,0.13,0.0,0.0,0.0,0.03,andrew whitehead,
+SOC,3040,1,Social Research Methods II,0.32,0.18,0.36,0.05,0.05,0.0,0.0,0.05,ye luo,
+SOC,3100,1,Marriage & Intimacy,0.52,0.17,0.13,0.07,0.04,0.0,0.0,0.07,carolyn can coffman,
+SOC,3110,1,The Family,0.15,0.28,0.26,0.18,0.1,0.0,0.0,0.03,andrew whitehead,
+SOC,3600,1,Class & Poverty,0.86,0.02,0.04,0.08,0.0,0.0,0.0,0.0,william wentworth,
+SOC,3880,1,Criminal Justice,0.32,0.16,0.36,0.16,0.0,0.0,0.0,0.0,margaret tina britz,
+SOC,3890,1,Criminology,0.15,0.21,0.26,0.12,0.06,0.0,0.0,0.21,william white,
+SOC,3910,1,Soc of Deviance,0.45,0.32,0.11,0.05,0.02,0.0,0.0,0.05,william white,
+SOC,3920,1,Juvenile Delinquency,0.41,0.35,0.18,0.0,0.0,0.0,0.0,0.06,william white,
+SOC,3940,1,Sociology of Mental Illness,0.48,0.41,0.02,0.0,0.07,0.0,0.0,0.02,marissa el yingling,
+SOC,3970,1,Substance Abuse,0.57,0.28,0.09,0.04,0.0,0.0,0.0,0.02,shannon mcdonough,
+SOC,4030,1,"Technol, Environment & Society",0.39,0.06,0.39,0.0,0.06,0.0,0.0,0.11, catherine mobley,
+SOC,4040,1,Soc Theory,0.54,0.29,0.15,0.0,0.02,0.0,0.0,0.0,william wentworth,
+SOC,4140,1,Policy&Social Change,0.45,0.25,0.25,0.0,0.05,0.0,0.0,0.0,marissa el yingling,
+SOC,4330,1,Global Social Change,0.77,0.15,0.0,0.04,0.04,0.0,0.0,0.0,william haller,
+SOC,4440,1,Sociology of Educ,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,
+SOC,4600,1,Race & Ethnicity,0.41,0.22,0.3,0.04,0.04,0.0,0.0,0.0,brenda vander mey,
+SOC,4680,1,Criminal Evidence,0.36,0.55,0.05,0.0,0.0,0.0,0.0,0.05,margaret tina britz,
+SOC,4810,1,Aging and Death,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,4970,1,Senior Lab,0.6,0.13,0.13,0.0,0.1,0.0,0.0,0.03,brenda vander mey,
+SOC,8030,1,Sur Dsgn App Res Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,
+SPAN,1010,1,Elementary Spanish,0.67,0.27,0.0,0.0,0.07,0.0,0.0,0.0,scott harris,
+SPAN,1010,2,Elementary Spanish,0.5,0.25,0.19,0.0,0.0,0.0,0.0,0.06,scott harris,
+SPAN,1010,3,Elementary Spanish,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1020,1,Elementary Spanish,0.26,0.26,0.26,0.0,0.05,0.0,0.0,0.16,maureen zamora,
+SPAN,1020,2,Elementary Spanish,0.35,0.29,0.12,0.12,0.0,0.0,0.0,0.12,maureen zamora,
+SPAN,1020,3,Elementary Spanish,0.41,0.18,0.12,0.12,0.0,0.0,0.0,0.18,maureen zamora,
+SPAN,1020,4,Elementary Spanish,0.29,0.41,0.06,0.0,0.0,0.0,0.0,0.24,maureen zamora,
+SPAN,1020,5,Elementary Spanish,0.29,0.35,0.0,0.0,0.06,0.0,0.0,0.29,maureen zamora,
+SPAN,1020,6,Elementary Spanish,0.44,0.25,0.19,0.0,0.06,0.0,0.0,0.06,cathy robison,
+SPAN,1020,7,Elementary Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,1020,8,Elementary Spanish,0.29,0.29,0.24,0.06,0.0,0.0,0.0,0.12,ana paula  miller,
+SPAN,1020,9,Elementary Spanish,0.31,0.19,0.19,0.13,0.06,0.0,0.0,0.13,ana paula  miller,
+SPAN,1020,10,Elementary Spanish,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,debra oa williamson,
+SPAN,1020,11,Elementary Spanish,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,1020,12,Elementary Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,1020,13,Elementary Spanish,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2010,1,Intermediate Spanish,0.47,0.21,0.26,0.0,0.0,0.0,0.0,0.05,cathy robison,
+SPAN,2010,2,Intermediate Spanish,0.24,0.59,0.12,0.06,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,3,Intermediate Spanish,0.53,0.24,0.24,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
+SPAN,2010,4,Intermediate Spanish,0.53,0.24,0.12,0.06,0.06,0.0,0.0,0.0,allison ann hinds,
+SPAN,2010,5,Intermediate Spanish,0.44,0.31,0.13,0.0,0.0,0.0,0.0,0.13,allison ann hinds,
+SPAN,2010,6,Intermediate Spanish,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,heidi montes,
+SPAN,2010,7,Intermediate Spanish,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,heidi montes,
+SPAN,2010,8,Intermediate Spanish,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,2010,9,Intermediate Spanish,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,2010,10,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
+SPAN,2010,11,Intermediate Spanish,0.27,0.6,0.13,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,2010,12,Intermediate Spanish,0.59,0.18,0.12,0.0,0.0,0.0,0.0,0.12,debra oa williamson,
+SPAN,2010,13,Intermediate Spanish,0.47,0.35,0.06,0.0,0.0,0.0,0.0,0.12,maureen zamora,
+SPAN,2010,14,Intermediate Spanish,0.61,0.22,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,
+SPAN,2010,15,Intermediate Spanish,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0, buitrago gonzalez,
+SPAN,2010,16,Intermediate Spanish,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
+SPAN,2010,18,Intermediate Spanish,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,nora arostegu logue,
+SPAN,2010,20,Intermediate Spanish (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,True
+SPAN,2020,1,Intermediate Spanish,0.47,0.33,0.07,0.07,0.0,0.0,0.0,0.07,heidi montes,
+SPAN,2020,2,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,3,Intermediate Spanish,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,4,Intermediate Spanish,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,heidi montes,
+SPAN,2020,5,Intermediate Spanish,0.53,0.16,0.26,0.0,0.05,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,6,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,2020,7,Intermediate Spanish,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,2020,8,Intermediate Spanish,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,2020,9,Intermediate Spanish,0.39,0.33,0.22,0.0,0.06,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,10,Intermediate Spanish,0.5,0.33,0.11,0.06,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,11,Intermediate Spanish,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,12,Intermediate Spanish,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,ze cruz valderramos,
+SPAN,2020,13,Intermediate Spanish,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,14,Intermediate Spanish,0.56,0.28,0.11,0.0,0.0,0.0,0.0,0.06,kari daus carson,
+SPAN,2020,15,Intermediate Spanish,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,kari daus carson,
+SPAN,3050,1,Int Con Comp Span I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,3050,2,Int Con Comp Span I,0.47,0.4,0.07,0.0,0.0,0.0,0.0,0.07,melva margu persico,
+SPAN,3050,3,Int Con Comp Span I,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,juana martin-armas,
+SPAN,3050,4,Int Con Comp Span I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,3060,1,Span Comp for Bus,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,maureen zamora,
+SPAN,3070,1,Hispanic World: Sp,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,salvador oropesa,
+SPAN,3070,2,Hispanic World: Sp,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,3080,1,Hispanic World: La,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,george palacios,
+SPAN,3130,1,Span Lit Survey I,0.32,0.16,0.0,0.0,0.05,0.0,0.0,0.47,mon rojas-de-massei,
+SPAN,3130,2,Span Lit Survey I,0.43,0.07,0.21,0.07,0.0,0.0,0.0,0.21,mon rojas-de-massei,
+SPAN,3140,1,Hispanic Linguistics,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,daniel smith,
+SPAN,3180,1,Span Through Culture,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,
+SPAN,4060,2,Narrative Fiction,0.44,0.19,0.38,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,
+SPAN,4090,1,Comp Writ in Span,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
+SPAN,4160,1,Span Intl Trade II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,4210,1,Sp-Am Mod & Postmod,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+SPAN,4220,1,Contem Span Am Novel,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,danie garcia vieyra,
+STAT,2220,1,Statistics in Everyday Life,0.35,0.35,0.15,0.1,0.03,0.0,0.0,0.02,james espey,
+STAT,2220,2,Statistics in Everyday Life,0.41,0.42,0.14,0.03,0.0,0.0,0.0,0.0,james espey,
+STAT,2220,3,Statistics in Everyday Life,0.45,0.23,0.3,0.0,0.02,0.0,0.0,0.0,james espey,
+STAT,2220,4,Statistics in Everyday Life,0.37,0.33,0.13,0.14,0.02,0.0,0.0,0.03,james espey,
+STAT,2220,5,Statistics in Everyday Life,0.33,0.41,0.17,0.07,0.0,0.0,0.0,0.02,ros martinez-dawson,
+STAT,2220,6,Statistics in Everyday Life,0.4,0.36,0.1,0.08,0.03,0.0,0.0,0.02,ros martinez-dawson,
+STAT,2220,7,Statistics in Everyday Life,0.32,0.42,0.16,0.05,0.05,0.0,0.0,0.0,andrew walton green,
+STAT,2220,8,Statistics in Everyday Life,0.32,0.37,0.16,0.05,0.0,0.0,0.0,0.11,lauren reig lembcke,
+STAT,2300,1,Statistical Methods I,0.26,0.3,0.18,0.13,0.09,0.0,0.0,0.04,christy jenki brown,
+STAT,2300,2,Statistical Methods I,0.26,0.36,0.23,0.08,0.06,0.0,0.0,0.02,christy jenki brown,
+STAT,2300,3,Statistical Methods I,0.3,0.38,0.15,0.12,0.04,0.0,0.0,0.0,christy jenki brown,
+STAT,2300,4,Statistical Methods I,0.29,0.34,0.17,0.08,0.08,0.0,0.0,0.03, erwin walker,
+STAT,2300,5,Statistical Methods I,0.22,0.4,0.21,0.08,0.04,0.0,0.0,0.03, erwin walker,
+STAT,2300,6,Statistical Methods I,0.19,0.3,0.25,0.09,0.11,0.0,0.0,0.06,april thomas,
+STAT,2300,8,Statistical Methods I,0.17,0.25,0.29,0.11,0.12,0.0,0.0,0.07,april thomas,
+STAT,3090,1,Introductory Business Stats,0.16,0.32,0.21,0.11,0.05,0.0,0.0,0.16,yijun chen,
+STAT,3090,2,Introductory Business Stats,0.21,0.42,0.16,0.0,0.05,0.0,0.0,0.16, morales hernandez,
+STAT,3090,4,Introductory Business Stats,0.28,0.19,0.33,0.14,0.03,0.0,0.0,0.03,sharon marie evans,
+STAT,3090,5,Introductory Business Stats,0.38,0.41,0.18,0.0,0.0,0.0,0.0,0.03,jennifer van dyken,
+STAT,3090,6,Introductory Business Stats,0.17,0.26,0.29,0.17,0.09,0.0,0.0,0.03,sharon marie evans,
+STAT,3090,7,Introductory Business Stats,0.37,0.32,0.11,0.16,0.0,0.0,0.0,0.05,yijun chen,
+STAT,3090,8,Introductory Business Stats,0.39,0.17,0.33,0.0,0.11,0.0,0.0,0.0, morales hernandez,
+STAT,3090,9,Introductory Business Stats,0.14,0.34,0.26,0.09,0.11,0.0,0.0,0.06,sharon marie evans,
+STAT,3090,10,Introductory Business Stats,0.06,0.33,0.39,0.11,0.06,0.0,0.0,0.06,andrew pangia,
+STAT,3090,11,Introductory Business Stats,0.28,0.25,0.22,0.11,0.08,0.0,0.0,0.06,sharon marie evans,
+STAT,3090,12,Introductory Business Stats,0.0,0.41,0.18,0.29,0.12,0.0,0.0,0.0,mengcong ren,
+STAT,3090,13,Introductory Business Stats,0.05,0.26,0.21,0.21,0.11,0.0,0.0,0.16,andrew pangia,
+STAT,3090,14,Introductory Business Stats,0.16,0.05,0.32,0.16,0.05,0.0,0.0,0.26,rui gong,
+STAT,3090,15,Introductory Business Stats,0.06,0.17,0.33,0.22,0.22,0.0,0.0,0.0,mengcong ren,
+STAT,3090,16,Introductory Business Stats,0.24,0.18,0.29,0.12,0.18,0.0,0.0,0.0,rui gong,
+STAT,3090,17,Introductory Business Stats,0.16,0.21,0.32,0.05,0.16,0.0,0.0,0.11,kayla doris javier,
+STAT,3090,18,Introductory Business Stats,0.13,0.44,0.19,0.25,0.0,0.0,0.0,0.0,sanjog arv kulkarni,
+STAT,3090,19,Introductory Business Stats,0.21,0.37,0.26,0.05,0.05,0.0,0.0,0.05,jason alexande kurz,
+STAT,3090,20,Introductory Business Stats,0.26,0.37,0.26,0.06,0.06,0.0,0.0,0.0,ellen hepfe breazel,
+STAT,3090,21,Introductory Business Stats,0.16,0.26,0.37,0.11,0.05,0.0,0.0,0.05,kayla doris javier,
+STAT,3090,22,Introductory Business Stats,0.32,0.32,0.16,0.05,0.11,0.0,0.0,0.05,boyoung hur,
+STAT,3090,23,Introductory Business Stats,0.23,0.29,0.4,0.06,0.03,0.0,0.0,0.0,ellen hepfe breazel,
+STAT,3090,24,Introductory Business Stats,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,sanjog arv kulkarni,
+STAT,3090,25,Introductory Business Stats,0.22,0.33,0.33,0.06,0.06,0.0,0.0,0.0,tao yang,
+STAT,3090,26,Introductory Business Stats,0.16,0.47,0.32,0.0,0.0,0.0,0.0,0.05,dilhani marasinghe,
+STAT,3090,27,Introductory Business Stats,0.21,0.21,0.26,0.16,0.0,0.0,0.0,0.16,paul james cubre,
+STAT,3090,28,Introductory Business Stats,0.16,0.32,0.26,0.11,0.11,0.0,0.0,0.05,boyoung hur,
+STAT,3090,29,Introductory Business Stats,0.26,0.26,0.32,0.05,0.11,0.0,0.0,0.0,jayasekara merenchig,
+STAT,3090,30,Introductory Business Stats,0.32,0.26,0.11,0.0,0.26,0.0,0.0,0.05,paul james cubre,
+STAT,3090,31,Introductory Business Stats,0.32,0.26,0.11,0.05,0.16,0.0,0.0,0.11,tao yang,
+STAT,3090,32,Introductory Business Stats,0.42,0.16,0.26,0.0,0.05,0.0,0.0,0.11,jason alexande kurz,
+STAT,3090,33,Introductory Business Stats,0.16,0.53,0.21,0.05,0.0,0.0,0.0,0.05,jayasekara merenchig,
+STAT,3090,34,Introductory Business Stats,0.11,0.42,0.37,0.0,0.05,0.0,0.0,0.05,dilhani marasinghe,
+STAT,3300,1,Statistical Methods II,0.32,0.23,0.09,0.14,0.05,0.0,0.0,0.18,ros martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,4110,1,Stat Mthds for Process Control,0.82,0.16,0.0,0.0,0.03,0.0,0.0,0.0,richard stev dubsky,
+STAT,4110,2,Stat Mthds for Process Control,0.48,0.35,0.13,0.0,0.03,0.0,0.0,0.0,james rieck,
+STAT,4110,3,Stat Mthds for Process Control,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,
+STAT,6020,1,Intro to Statistical Computing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,8010,1,Statistical Methods I,0.44,0.28,0.09,0.0,0.0,0.0,0.0,0.19,brook thaye russell,
+STAT,8010,2,Statistical Methods I,0.33,0.45,0.12,0.0,0.06,0.0,0.0,0.03,james rieck,
+STAT,8010,3,Statistical Methods I,0.49,0.29,0.11,0.0,0.09,0.0,0.0,0.03,jun luo,
+STAT,8010,4,Statistical Methods I,0.61,0.19,0.1,0.0,0.1,0.0,0.0,0.0,jun luo,
+STAT,8020,1,Statistical Methods II,0.61,0.36,0.0,0.0,0.0,0.0,0.0,0.04,william bridges,
+STS,1010,1,Survey of S T S,0.62,0.24,0.15,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+STS,1010,2,Survey of S T S,0.6,0.29,0.06,0.0,0.0,0.0,0.0,0.06,philip randall,
+STS,1010,3,Survey of S T S,0.42,0.52,0.03,0.03,0.0,0.0,0.0,0.0,scott brame,
+STS,1010,5,Survey of S T S,0.66,0.26,0.06,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,
+STS,1010,6,Survey of S T S,0.33,0.39,0.19,0.06,0.03,0.0,0.0,0.0,allison ann hinds,
+STS,1010,7,Survey of S T S,0.15,0.5,0.24,0.03,0.03,0.0,0.0,0.06,david charles foltz,
+STS,1010,8,Survey of S T S,0.36,0.5,0.06,0.0,0.0,0.0,0.0,0.08,megan no macalystre,
+STS,1010,9,Survey of S T S,0.6,0.29,0.06,0.03,0.03,0.0,0.0,0.0,sarah mae cooper,
+STS,1010,10,Survey of S T S,0.8,0.14,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
+THEA,2100,1,Theatre Appreciation,0.94,0.0,0.03,0.0,0.03,0.0,0.0,0.0,richard st. peter,
+THEA,2100,2,Theatre Appreciation,0.84,0.03,0.06,0.0,0.06,0.0,0.0,0.0,kerrie kath seymour,
+THEA,2100,3,Theatre Appreciation,0.53,0.22,0.25,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,2100,4,Theatre Appreciation,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,carol collins,
+THEA,2100,5,Theatre Appreciation,0.87,0.03,0.03,0.0,0.0,0.0,0.0,0.07,shannon ther robert,
+THEA,2100,6,Theatre Appreciation,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,
+THEA,2100,7,Theatre Appreciation,0.56,0.31,0.09,0.0,0.0,0.0,0.0,0.03,jason adkins,
+THEA,2780,1,Acting I,0.76,0.06,0.06,0.06,0.06,0.0,0.0,0.0,kerrie kath seymour,
+THEA,2790,1,Theatre Practicum,0.5,0.0,0.0,0.0,0.29,0.0,0.0,0.21,matthew leckenbusch,
+THEA,3170,1,African-Amer Thea I,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,kendra lyne johnson,
+THEA,4290,1,Dramatic Literature I,0.74,0.11,0.05,0.0,0.05,0.0,0.0,0.05,richard st. peter,
+THEA,4800,1,Advanced Scene Study,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,kerrie kath seymour,
+WFB,3000,1,Wildlife Biology,0.52,0.29,0.14,0.0,0.03,0.0,0.0,0.02,catherine jachowski,
+WFB,3000,2,Wildlife Biology,0.56,0.28,0.05,0.05,0.04,0.0,0.0,0.01,catherine jachowski,
+WFB,3010,2,Wildlife Biology Lab,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,4100,2,Wildlife Management Techniques,0.1,0.44,0.4,0.04,0.0,0.0,0.0,0.02,james davis,
+WFB,4180,1,Fishery Conservation,0.67,0.19,0.1,0.0,0.05,0.0,0.0,0.0,yoichiro kanno,
+WFB,4440,1,Wildlife Damage Management,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,james davis,
+WFB,4930,1,Waterfowl Ecology & Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
+WFB,4930,2,Plant & Flora ID/Systematics,0.46,0.41,0.11,0.02,0.0,0.0,0.0,0.0,patrick mcmillan,
+WS,1030,1,Women in Global Perspective,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,laura foxworth,
+WS,1030,2,Women in Global Perspective,0.79,0.18,0.0,0.0,0.03,0.0,0.0,0.0,laura foxworth,
+WS,2300,1,Women and Leadership,0.64,0.14,0.0,0.07,0.14,0.0,0.0,0.0,diane perpich,
+WS,3010,1,Intro Women's Studies,0.63,0.17,0.06,0.03,0.03,0.0,0.0,0.09,elizabeth ros adams,
+WS,3010,2,Intro Women's Studies,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,elizabeth ros adams,
+WS,4900,1,Creative Inquiry,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,diane perpich,
+YDP,3000,400,Youth Development in Society,0.82,0.06,0.06,0.0,0.0,0.0,0.0,0.06,barry garst,
+YDP,3050,400,Theory/Phil of Youth Dev Work,0.63,0.19,0.06,0.06,0.0,0.0,0.0,0.06,edmond patri bowers,
+YDP,3450,1,Creative Activities for Youth,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kimberly pe johnson,

--- a/bot/cogs/grades_cog/assets/2016_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2016_Fall.csv
@@ -1,2784 +1,2784 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1010,1,Survey of Art & Arch History I,0.31,0.44,0.23,0.02,0.0,0.0,0.0,0.01,beth ann lauritis,
-AAH,2050,1,Art History and Theory I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,beth ann lauritis,
-ACCT,2010,1,Financial Accounting Concepts,0.03,0.25,0.35,0.15,0.08,0.0,0.0,0.15,philip maiberger,
-ACCT,2010,2,Financial Accounting Concepts,0.18,0.38,0.28,0.05,0.03,0.0,0.0,0.08,philip maiberger,
-ACCT,2010,3,Financial Accounting Concepts,0.24,0.44,0.2,0.04,0.04,0.0,0.0,0.04,lydia lan schleifer,
-ACCT,2010,4,Financial Accounting Concepts,0.2,0.33,0.2,0.1,0.08,0.0,0.0,0.1,annieka philo,
-ACCT,2010,5,Financial Accounting Concepts,0.24,0.43,0.2,0.06,0.04,0.0,0.0,0.02,lydia lan schleifer,
-ACCT,2010,6,Financial Accounting Concepts,0.12,0.52,0.21,0.03,0.09,0.0,0.0,0.03,the estate  guffey,
-ACCT,2010,7,Financial Accounting Concepts,0.26,0.36,0.16,0.08,0.04,0.0,0.0,0.1,annieka philo,
-ACCT,2010,9,Financial Accounting Concepts,0.32,0.15,0.23,0.04,0.11,0.0,0.0,0.15,lydia lan schleifer,
-ACCT,2010,10,Financial Accounting Concepts,0.17,0.26,0.26,0.13,0.11,0.0,0.0,0.07,lydia lan schleifer,
-ACCT,2010,11,Financial Accounting Concepts,0.13,0.33,0.29,0.06,0.1,0.0,0.0,0.08,annieka philo,
-ACCT,2010,12,Financial Accounting Concepts,0.07,0.29,0.29,0.09,0.16,0.0,0.0,0.11,annieka philo,
-ACCT,2010,13,Financial Accounting Concepts,0.09,0.33,0.24,0.04,0.04,0.0,0.0,0.24,mary ann  prater,
-ACCT,2010,14,Financial Accounting Concepts,0.19,0.19,0.14,0.07,0.12,0.0,0.0,0.29,mary ann  prater,
-ACCT,2010,15,Financial Accounting Concepts,0.15,0.33,0.11,0.19,0.15,0.0,0.0,0.07,charles tegen,
-ACCT,2010,100,Fin Accounting Concepts (HON),0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,the estate  guffey,True
-ACCT,2010,101,Fin Accounting Concepts (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True
-ACCT,2010,400,Financial Accounting Concepts,0.23,0.35,0.16,0.05,0.1,0.0,0.0,0.11,jeffrey mcmillan,
-ACCT,2020,1,Managerial Accounting Concepts,0.15,0.27,0.33,0.12,0.06,0.0,0.0,0.06,henry anderson,
-ACCT,2020,2,Managerial Accounting Concepts,0.19,0.21,0.17,0.17,0.1,0.0,0.0,0.17,henry anderson,
-ACCT,2020,3,Managerial Accounting Concepts,0.44,0.24,0.2,0.06,0.03,0.0,0.0,0.03,sarah martin,
-ACCT,2020,4,Managerial Accounting Concepts,0.18,0.32,0.2,0.08,0.08,0.0,0.0,0.14,the estate  guffey,
-ACCT,2020,5,Managerial Accounting Concepts,0.1,0.45,0.19,0.06,0.1,0.0,0.0,0.1,brian todd carver,
-ACCT,2020,7,Managerial Accounting Concepts,0.23,0.42,0.23,0.07,0.02,0.0,0.0,0.02,derek dalton,
-ACCT,2020,8,Managerial Accounting Concepts,0.23,0.34,0.32,0.07,0.02,0.0,0.0,0.02,nancy lee harp,
-ACCT,2020,400,Managerial Accounting Concepts,0.12,0.24,0.25,0.1,0.06,0.0,0.0,0.24,henry anderson,
-ACCT,3030,1,Cost Accounting,0.35,0.4,0.17,0.04,0.04,0.0,0.0,0.0,robin radtke,
-ACCT,3030,2,Cost Accounting,0.4,0.36,0.14,0.05,0.02,0.0,0.0,0.02,robin radtke,
-ACCT,3030,3,Cost Accounting,0.44,0.23,0.17,0.02,0.06,0.0,0.0,0.08,jace garrett,
-ACCT,3030,4,Cost Accounting,0.31,0.31,0.12,0.12,0.0,0.0,0.0,0.15,jace garrett,
-ACCT,3110,1,Intermediate Financial Acct I,0.41,0.32,0.08,0.08,0.08,0.0,0.0,0.03,terry daniel knause,
-ACCT,3110,2,Intermediate Financial Acct I,0.41,0.24,0.15,0.05,0.02,0.0,0.0,0.12,terry daniel knause,
-ACCT,3110,3,Intermediate Financial Acct I,0.39,0.24,0.24,0.06,0.03,0.0,0.0,0.03,terry daniel knause,
-ACCT,3110,4,Intermediate Financial Acct I,0.31,0.45,0.21,0.02,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3110,5,Intermediate Financial Acct I,0.26,0.16,0.21,0.03,0.26,0.0,0.0,0.08,henry anderson,
-ACCT,3110,400,Intermediate Financial Acct I,0.16,0.24,0.12,0.04,0.28,0.0,0.0,0.16,henry anderson,
-ACCT,3120,1,Intermediate Financial Acct II,0.06,0.31,0.29,0.2,0.06,0.0,0.0,0.09,brian todd carver,
-ACCT,3120,2,Intermediate Financial Acct II,0.21,0.31,0.23,0.18,0.05,0.0,0.0,0.03,brian todd carver,
-ACCT,3120,3,Intermediate Financial Acct II,0.08,0.49,0.26,0.13,0.03,0.0,0.0,0.03,jeremy micha vinson,
-ACCT,3120,4,Intermediate Financial Acct II,0.35,0.28,0.23,0.1,0.05,0.0,0.0,0.0,jeremy micha vinson,
-ACCT,3120,5,Intermediate Financial Acct II,0.13,0.58,0.24,0.0,0.0,0.0,0.0,0.05,jeremy micha vinson,
-ACCT,3130,1,Intermediate Fin Acct III,0.31,0.47,0.14,0.0,0.06,0.0,0.0,0.03, russell madray,
-ACCT,3130,2,Intermediate Fin Acct III,0.63,0.21,0.12,0.02,0.0,0.0,0.0,0.02, russell madray,
-ACCT,3130,3,Intermediate Fin Acct III,0.52,0.33,0.12,0.0,0.02,0.0,0.0,0.0, russell madray,
-ACCT,3130,4,Intermediate Fin Acct III,0.56,0.34,0.05,0.0,0.05,0.0,0.0,0.0, russell madray,
-ACCT,3220,2,Accounting Information Systems,0.23,0.5,0.19,0.04,0.04,0.0,0.0,0.0,nancy lee harp,
-ACCT,3220,3,Accounting Information Systems,0.12,0.38,0.24,0.14,0.05,0.0,0.0,0.07,nancy lee harp,
-ACCT,4040,1,Individual Taxation,0.74,0.12,0.03,0.06,0.06,0.0,0.0,0.0,sarah martin,
-ACCT,4040,2,Individual Taxation,0.82,0.08,0.05,0.05,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,3,Individual Taxation,0.21,0.44,0.26,0.05,0.0,0.0,0.0,0.05,derek dalton,
-ACCT,4080,1,Retire & Estate Plan,0.27,0.5,0.18,0.0,0.05,0.0,0.0,0.0,john hine,
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.31,0.44,0.21,0.03,0.03,0.0,0.0,0.0,sally kathr widener,
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.08,0.44,0.32,0.04,0.04,0.0,0.0,0.08,sally kathr widener,
-ACCT,4150,1,Auditing,0.52,0.28,0.2,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,
-ACCT,4150,2,Auditing,0.06,0.44,0.38,0.06,0.0,0.0,0.0,0.06,carl hollingsworth,
-ACCT,8510,1,Tax Research,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8510,2,Tax Research,0.22,0.68,0.08,0.0,0.0,0.0,0.0,0.03,thomas dickens,
-ACCT,8510,3,Tax Research,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8530,1,Adv Acct Problems,0.56,0.38,0.03,0.0,0.0,0.0,0.0,0.03,ralph welton,
-ACCT,8530,2,Adv Acct Problems,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8530,3,Adv Acct Problems,0.62,0.32,0.03,0.0,0.03,0.0,0.0,0.0,suzanne pearse,
-ACCT,8550,1,Gov't and Nonprofit Accounting,0.6,0.37,0.04,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8550,2,Gov't and Nonprofit Accounting,0.65,0.33,0.0,0.0,0.0,0.0,0.0,0.02,james barnes,
-ACCT,8630,1,Forensics Analysis,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,philip maiberger,
-ACCT,8630,2,Forensics Analysis,0.44,0.49,0.05,0.0,0.0,0.0,0.0,0.03,philip maiberger,
-ACCT,8650,1,Tax & Bus Decisions,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
-ACCT,8720,1,Tax of Flowthroughs,0.17,0.43,0.33,0.0,0.07,0.0,0.0,0.0,thomas dickens,
-AGED,1020,1,Freshman Seminar,0.68,0.21,0.07,0.0,0.0,0.0,0.0,0.04,catheri dibenedetto,
-AGED,2010,1,Intro to Agric Educ,0.43,0.24,0.24,0.05,0.05,0.0,0.0,0.0,philip fravel,
-AGED,2040,1,App Ag Calculations,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,3030,1,Ag Ed Mech Tech,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGED,3650,1,Multiculturalism in Agric Educ,0.9,0.03,0.03,0.0,0.03,0.0,0.0,0.0,alex byrd,
-AGED,4030,1,Prin Adult/Ext Ed,0.77,0.09,0.14,0.0,0.0,0.0,0.0,0.0,kevin layfield,
-AGM,1010,1,Intro Ag Mech & Bus,0.41,0.32,0.16,0.04,0.04,0.0,0.0,0.04,hunter massey,
-AGM,2050,1,Prin of Fabrication,0.14,0.57,0.16,0.03,0.07,0.0,0.0,0.03,hunter massey,
-AGM,2060,1,Machinery Mgt,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,hunter massey,
-AGM,2190,1,Agribusiness and Food Systems,0.49,0.4,0.1,0.0,0.01,0.0,0.0,0.0,nicholas gra rogers,
-AGM,2210,1,Land Measurements,0.17,0.32,0.33,0.14,0.03,0.0,0.0,0.01,charles privette,
-AGM,3010,1,Soil Water Conserv,0.44,0.29,0.16,0.06,0.03,0.0,0.0,0.02,calvin sawyer,
-AGM,3710,1,Agric Mechanization Practicum,0.0,0.0,0.0,0.0,0.0,0.89,0.05,0.05,hunter massey,
-AGM,4000,1,Seminar in Ag Mech & Business,0.53,0.31,0.06,0.03,0.03,0.0,0.0,0.03,john chastain,
-AGM,4050,1,Env Cont in Anim Str,0.14,0.46,0.3,0.1,0.0,0.0,0.0,0.0,john chastain,
-AGM,4060,1,Mech & Hydraulic Sys,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4520,1,Mobile Power,0.41,0.41,0.14,0.05,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4600,1,Electrical Systems,0.45,0.36,0.13,0.06,0.0,0.0,0.0,0.0,young han,
-AGM,4730,1,Peanut Harvesting Machinery,0.88,0.0,0.0,0.0,0.12,0.0,0.0,0.0,hunter massey,
-AGRB,2020,1,Agricultural Economics,0.19,0.35,0.23,0.13,0.08,0.0,0.0,0.02,george apperson,
-AGRB,2020,2,Agricultural Economics,0.21,0.31,0.27,0.08,0.08,0.0,0.0,0.04,george apperson,
-AGRB,2050,1,Agriculture and Society,0.42,0.38,0.12,0.04,0.02,0.0,0.0,0.02,michael vassalos,
-AGRB,3020,1,Economics of Farm Management,0.28,0.35,0.27,0.09,0.0,0.0,0.0,0.01,michael vassalos,
-AGRB,3080,1,Quant Agribusiness Analysis I,0.19,0.23,0.32,0.19,0.03,0.0,0.0,0.03,lisha zhang,
-AGRB,3090,1,Econ of Agricultural Marketing,0.83,0.15,0.0,0.0,0.03,0.0,0.0,0.0,yuliya val bolotova,
-AGRB,3570,1,Natural Resources Economics,0.29,0.31,0.18,0.11,0.07,0.0,0.0,0.04,david brian willis,
-AGRB,4090,1,Commodity Futures Markets,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
-AGRB,4120,1,Reg Econ Devel Theory & Policy,0.55,0.3,0.1,0.0,0.05,0.0,0.0,0.0,robert carey,
-AGRB,4600,1,Agricultural Finance,0.33,0.33,0.22,0.11,0.0,0.0,0.0,0.0,lisha zhang,
-AL,3490,400,Principles of Coaching,0.65,0.15,0.12,0.0,0.0,0.0,0.0,0.08,deborah cadorette,
-AL,3490,401,Principles of Coaching,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,402,Principles of Coaching,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,julia wright,
-AL,3490,403,Principles of Coaching,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,clyde keith connor,
-AL,3490,404,Principles of Coaching,0.84,0.08,0.0,0.0,0.0,0.0,0.0,0.08,edmond fry,
-AL,3500,400,Sci Basis I/Ex Phy,0.33,0.08,0.33,0.13,0.04,0.0,0.0,0.08,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.13,0.3,0.22,0.13,0.13,0.0,0.0,0.09,michael godfrey,
-AL,3530,400,Athletic Injuries,0.23,0.27,0.32,0.14,0.0,0.0,0.0,0.05,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.16,0.32,0.37,0.11,0.05,0.0,0.0,0.0,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.42,0.25,0.25,0.08,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.73,0.2,0.0,0.07,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,401,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,Admin/Org of Athletic Programs,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,henry oates,
-AL,3620,400,Psychology of Coaching,0.31,0.31,0.19,0.13,0.06,0.0,0.0,0.0,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.44,0.31,0.13,0.13,0.0,0.0,0.0,0.0,natalie anne carter,
-AL,3620,402,Psychology of Coaching,0.26,0.39,0.26,0.09,0.0,0.0,0.0,0.0,natalie anne carter,
-AL,3740,400,Coaching Football,0.58,0.21,0.04,0.04,0.08,0.0,0.0,0.04,edmond fry,
-AL,3760,400,Coaching Strength/Conditioning,0.61,0.22,0.13,0.04,0.0,0.0,0.0,0.0,edmond fry,
-AL,3760,401,Coaching Strength/Conditioning,0.5,0.3,0.1,0.0,0.05,0.0,0.0,0.05,edmond fry,
-AL,4380,400,Coaching Women,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,4380,402,Coaching the Inner Athlete,0.7,0.17,0.09,0.0,0.04,0.0,0.0,0.0,deborah cadorette,
-AL,8490,400,Athletic Leadership Dev,0.6,0.28,0.08,0.0,0.04,0.0,0.0,0.0,michael godfrey,
-AL,8490,401,Athletic Leadership Dev,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8500,400,Principles Strength and Condit,0.59,0.31,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8650,400,Mkt and Comm Respon Interc Ath,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,misty soles,
-ANTH,2010,1,Introduction to Anthropology,0.49,0.28,0.13,0.02,0.02,0.0,0.0,0.06,yi wu,
-ANTH,2010,2,Introduction to Anthropology,0.07,0.2,0.44,0.15,0.05,0.0,0.0,0.1,john coggeshall,
-ANTH,2010,3,Introduction to Anthropology,0.06,0.35,0.39,0.06,0.1,0.0,0.0,0.05,john coggeshall,
-ANTH,2010,4,Introduction to Anthropology,0.38,0.42,0.09,0.04,0.07,0.0,0.0,0.0,katherine weisensee,
-ANTH,2010,5,Introduction to Anthropology,0.44,0.42,0.08,0.02,0.02,0.0,0.0,0.02,lisa rapaport,
-ANTH,2010,6,Introduction to Anthropology,0.27,0.3,0.18,0.09,0.07,0.0,0.0,0.09,yi wu,
-ANTH,3010,1,Cultural Anthropology,0.09,0.41,0.18,0.14,0.05,0.0,0.0,0.14,john coggeshall,
-ANTH,3320,1,World Archaeology,0.17,0.3,0.22,0.17,0.0,0.0,0.0,0.13,melissa vogel,
-ANTH,3510,1,Biological Anthropology,0.5,0.33,0.06,0.0,0.06,0.0,0.0,0.06,lisa rapaport,
-ANTH,3530,1,Forensic Anthropology,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,katherine weisensee,
-ANTH,4230,1,Women in the Developing World,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,melissa vogel,
-ARCH,1010,1,Intro to Architecture,0.63,0.26,0.04,0.02,0.03,0.0,0.0,0.02,sal hambright-belue,
-ARCH,2040,1,Hist of Modern Arch,0.28,0.42,0.25,0.03,0.03,0.0,0.0,0.0,robert bruhns,
-ARCH,2510,1,Arch Foundations I,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,2510,2,Arch Foundations I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,2510,3,Arch Foundations I,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2510,4,Arch Foundations I,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,james barker,
-ARCH,2510,5,Arch Foundations I,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,2700,1,Structures I,0.36,0.41,0.18,0.0,0.05,0.0,0.0,0.0,dustin gra albright,
-ARCH,3500,1,Intro to Urban Contexts,0.08,0.62,0.31,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,3500,2,Intro to Urban Contexts,0.33,0.33,0.25,0.0,0.08,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,3500,3,Intro to Urban Contexts,0.0,0.17,0.83,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,3500,4,Intro to Urban Contexts,0.17,0.42,0.42,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,4010,1,Architectural Portfolio SENIOR,0.67,0.19,0.05,0.0,0.05,0.0,0.0,0.05,clarissa mendez,
-ARCH,4010,2,Architectural Portfolio JUNIOR,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4010,3,Architectural Portfolio JUNIOR,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,maryam hamidpour,
-ARCH,6120,2,History Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,6990,9,Freehand Drawing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,
-ARCH,8100,1,Visualization I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,8210,1,Research Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8410,1,Arch Studio I,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,peter laurence,
-ARCH,8410,2,Arch Studio I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
-ARCH,8510,1,Design Studio III,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,8510,2,Design Studio III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,8510,3,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8600,1,History/Theory I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,8810,1,Pro Practice Survey,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,
-ARCH,8950,2,A+H Studio: Projects,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ART,1050,1,Foundation Drawing I,0.29,0.57,0.0,0.07,0.07,0.0,0.0,0.0,kathleen ann thum,
-ART,1510,1,Foundations Art I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kymberly ann day,
-ART,2070,1,Beginning Painting,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,todd mcdonald,
-ART,2100,400,Art Appreciation,0.61,0.29,0.04,0.07,0.0,0.0,0.0,0.0,lydia jane dorsey,
-ART,2100,401,Art Appreciation,0.41,0.3,0.19,0.07,0.04,0.0,0.0,0.0,lydia jane dorsey,
-ART,2100,402,Art Appreciation,0.48,0.45,0.07,0.0,0.0,0.0,0.0,0.0,lydia jane dorsey,
-ART,2100,403,Art Appreciation,0.37,0.41,0.11,0.04,0.07,0.0,0.0,0.0,lydia jane dorsey,
-AS,1090,1,Air Force Today I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,
-AS,1090,3,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher mann,
-AS,2090,2,Dev of Air Power I,0.6,0.27,0.07,0.07,0.0,0.0,0.0,0.0,christopher mann,
-AS,2090,3,Dev of Air Power I,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,christopher mann,
-ASL,1010,1,Am Sign Lang I,0.17,0.39,0.28,0.06,0.11,0.0,0.0,0.0,william alton brant,
-ASL,1010,2,Am Sign Lang I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,1010,3,Am Sign Lang I,0.28,0.39,0.11,0.11,0.0,0.0,0.0,0.11,michael alb barrett,
-ASL,1010,4,Am Sign Lang I,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,michael alb barrett,
-ASL,1020,1,Am Sign Lang I,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2010,1,Am Sign Lang II,0.28,0.39,0.22,0.11,0.0,0.0,0.0,0.0,michael alb barrett,
-ASL,2010,2,Am Sign Lang II,0.13,0.19,0.38,0.31,0.0,0.0,0.0,0.0,michael alb barrett,
-ASL,3010,1,Advanced A S L I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,3150,1,Survey Interpreting,0.25,0.42,0.17,0.0,0.0,0.0,0.0,0.17,stephen fitzmaurice,
-ASTR,1010,1,Solar System Astronomy,0.19,0.39,0.17,0.12,0.08,0.0,0.0,0.05,lih-sin the,
-ASTR,1010,2,Solar System Astronomy,0.28,0.36,0.19,0.04,0.06,0.0,0.0,0.07,lih-sin the,
-ASTR,1020,1,Stellar Astronomy,0.39,0.32,0.11,0.06,0.02,0.0,0.0,0.1,amber porter,
-ASTR,1030,1,Solar Systm Astr Lab,0.54,0.27,0.15,0.0,0.04,0.0,0.0,0.0,amber porter,
-ASTR,1030,2,Solar Systm Astr Lab,0.38,0.31,0.04,0.08,0.08,0.0,0.0,0.12,amber porter,
-ASTR,1030,4,Solar Systm Astr Lab,0.6,0.24,0.0,0.08,0.0,0.0,0.0,0.08,amber porter,
-ASTR,1030,5,Solar Systm Astr Lab,0.63,0.17,0.08,0.08,0.0,0.0,0.0,0.04,amber porter,
-ASTR,1030,6,Solar Systm Astr Lab,0.4,0.4,0.05,0.15,0.0,0.0,0.0,0.0,amber porter,
-ASTR,1030,7,Solar Systm Astr Lab,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,amber porter,
-ASTR,1030,8,Solar Systm Astr Lab,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,amber porter,
-ASTR,1030,9,Solar Systm Astr Lab,0.54,0.21,0.08,0.0,0.08,0.0,0.0,0.08,amber porter,
-ASTR,1030,10,Solar Systm Astr Lab,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,amber porter,
-ASTR,1040,1,Stellar Astr Lab,0.52,0.36,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,
-ASTR,1040,2,Stellar Astr Lab,0.14,0.52,0.05,0.0,0.14,0.0,0.0,0.14,amber porter,
-ASTR,1040,4,Stellar Astr Lab,0.46,0.42,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,
-AUD,1850,1,Intro to Audio Tech,0.18,0.73,0.09,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUD,2800,1,Sound Reinforcement,0.09,0.36,0.45,0.0,0.09,0.0,0.0,0.0,kenneth moore,
-AUE,8270,5,Auto Cntrl Sys Des,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8280,1,Driveline/Powertrain,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8330,30,Auto Manuf Proc Devl,0.47,0.51,0.03,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8350,100,Auto Electronics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,
-AUE,8670,1,Veh Manuf Proc I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8800,2,Vehicle Project Mngt,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett,
-AUE,8810,3,Automotive Systems Overview,0.37,0.6,0.02,0.0,0.01,0.0,0.0,0.0,david wil schmueser,
-AUE,8830,9,Applied Integration,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8870,8,Meth Vehicle Testing,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8930,13,Engine Analysis,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8930,14,Advanced Composites,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
-AUE,8930,16,Light-Weight Automotive Design,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,david wil schmueser,
-AUE,8930,17,Hybrids,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,simona onori,
-AUE,8930,18,Adv IC Engine Concept,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,8930,78,Ground Vehicle Performance,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8930,100,Slide Mode Controls,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AVS,1000,1,Orientation to AVS,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
-AVS,1500,1,Intro Animal Science,0.19,0.57,0.19,0.02,0.01,0.0,0.0,0.02,marie owens bolt,
-AVS,1510,1,Intro Ani Sci Lab,0.65,0.23,0.04,0.0,0.0,0.0,0.0,0.08,richelle lor miller,
-AVS,1510,2,Intro Ani Sci Lab,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,1510,3,Intro Ani Sci Lab,0.6,0.32,0.0,0.0,0.0,0.0,0.0,0.08,richelle lor miller,
-AVS,1510,4,Intro Ani Sci Lab,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,louisa elaine koch,
-AVS,1510,5,Intro Ani Sci Lab,0.21,0.67,0.13,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
-AVS,1510,6,Intro Ani Sci Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,1510,7,Intro Ani Sci Lab,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,brandon michae koch,
-AVS,1510,8,Intro Ani Sci Lab,0.29,0.5,0.07,0.07,0.0,0.0,0.0,0.07,marie owens bolt,
-AVS,2030,1,Dairy Sci Techniques,0.95,0.0,0.02,0.02,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,2040,1,Horse Care Techniques,0.44,0.46,0.1,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,2060,1,Swine Techniques,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3010,1,Anat & Phys Dom Ani,0.46,0.19,0.17,0.12,0.03,0.0,0.0,0.04,glenn birrenkott,
-AVS,3010,400,Anat & Phys Dom Ani,0.46,0.27,0.15,0.12,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,3020,1,Livestk Sel Eval I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3090,1,Equine Evaluation,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,3100,1,Animal Health,0.68,0.22,0.07,0.01,0.01,0.0,0.0,0.0,thomas scott,
-AVS,3700,1,Principles of Animal Nutrition,0.64,0.2,0.09,0.04,0.02,0.0,0.0,0.01,james ro strickland,
-AVS,3750,1,Applied Animal Nutrition,0.19,0.42,0.25,0.11,0.0,0.0,0.0,0.03,gustavo jos lascano,
-AVS,4000,1,AVS Professional Development,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,johanna joh lascano,
-AVS,4000,2,AVS Professional Development,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
-AVS,4060,1,Seminars & Related Topics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4060,2,Seminars & Related Topics,0.41,0.52,0.03,0.0,0.0,0.0,0.0,0.03,jeryl jones,
-AVS,4150,1,Contemporary Issues in AVS,0.06,0.39,0.38,0.08,0.05,0.0,0.0,0.05,peter skewes,
-AVS,4160,1,Equine Exercise Phys,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,4530,1,Animal Reproduction,0.48,0.34,0.11,0.05,0.02,0.0,0.0,0.0,tiffany wilmoth,
-AVS,8200,1,Graduate Seminar,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,
-BCHM,1030,1,Careers in Bioch/Gen,0.68,0.24,0.01,0.06,0.0,0.0,0.0,0.01,alison starr-moss,
-BCHM,3010,1,Molecular Biochem,0.26,0.49,0.2,0.0,0.0,0.0,0.0,0.06,kerry smith,
-BCHM,3050,1,Essen Elements Bioch,0.21,0.33,0.25,0.11,0.02,0.0,0.0,0.08,srik chandrasekaran,
-BCHM,3050,2,Essen Elements Bioch,0.28,0.35,0.22,0.07,0.03,0.0,0.0,0.05,srik chandrasekaran,
-BCHM,4310,1,Physical Approach to Biochem,0.11,0.55,0.28,0.02,0.04,0.0,0.0,0.0,weiguo cao,
-BCHM,4310,2,Phys App to Bioch (HON),0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,True
-BCHM,4330,1,Physical Biochemistry Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,weiguo cao,
-BCHM,4330,3,Physical Biochemistry Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,weiguo cao,
-BCHM,4330,4,Physical Biochemistry Lab,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,weiguo cao,
-BCHM,4400,1,Bioinformatics,0.78,0.15,0.0,0.07,0.0,0.0,0.0,0.0,frank alexan feltus,
-BCHM,4430,1,Mol Basis Disease,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,james morris,
-BCHM,4900,7,C-MED,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,michael glen sehorn,
-BCHM,4930,1,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,
-BE,2120,1,Fundamentals of Biosys Engr,0.55,0.4,0.0,0.0,0.05,0.0,0.0,0.0,caye marie drapcho,
-BE,3200,1,Principles & Prac of Geomatics,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,tom owino,
-BE,4100,1,Biological Kinetics,0.38,0.29,0.33,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,4210,1,Engr Sys Sw Mgmt,0.59,0.35,0.0,0.0,0.06,0.0,0.0,0.0,christophe darnault,
-BE,4280,1,Biochem Engr,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,terry walker,
-BE,4740,1,B E Design/Proj Mgt,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,tom owino,
-BE,4750,1,B E Capstone Design,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BIOE,1010,1,Biol for Bioengr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,vladimir vla reukov,
-BIOE,2010,1,Intro Biomed Engr,0.82,0.16,0.02,0.0,0.0,0.0,0.0,0.0,charles webb,
-BIOE,2010,2,Intro Biomed Engr,0.76,0.21,0.01,0.0,0.0,0.0,0.0,0.01,frank alexis,
-BIOE,3020,1,Biomaterials,0.57,0.23,0.04,0.02,0.06,0.0,0.0,0.09,alexey ale vertegel,
-BIOE,3200,1,Biomechanics,0.79,0.17,0.02,0.0,0.02,0.0,0.0,0.0,lisa benson,
-BIOE,3210,1,Biofluid Mechanics,0.46,0.38,0.14,0.0,0.0,0.0,0.0,0.03,zhi gao,
-BIOE,3700,1,Bioinst & Imaging,0.64,0.27,0.07,0.0,0.0,0.0,0.0,0.02,delphine dean,
-BIOE,4010,1,Bioengineering Design Theory,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4010,2,Bioengineering Design Theory,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4030,1,Applied Bio E Design,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
-BIOE,4120,1,Orthopaedic Engr and Pathology,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,melinda harman,
-BIOE,4500,3,Biofabrication,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
-BIOE,6120,1,Orthopaedic Engr & Pathology,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,melinda harman,
-BIOE,6400,1,Biopharmaceutical Engineering,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,sarah harcum,
-BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,martine laberge,
-BIOE,8010,1,Bio Materials,0.33,0.6,0.03,0.0,0.03,0.0,0.0,0.0,robert latour,
-BIOE,8600,401,Biomed Engr Design Innovation,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
-BIOL,1010,1,Frontiers in Biology I,0.8,0.1,0.06,0.02,0.01,0.0,0.0,0.01,robert edwa ballard,
-BIOL,1010,2,Frontiers in Biology I,0.55,0.27,0.11,0.03,0.04,0.0,0.0,0.0,thomas hughes,
-BIOL,1030,1,General Biology I,0.23,0.28,0.22,0.11,0.1,0.0,0.0,0.07,nora espinoza,
-BIOL,1030,2,General Biology I,0.11,0.27,0.31,0.18,0.07,0.0,0.0,0.07,william baldwin,
-BIOL,1030,3,General Biology I,0.26,0.3,0.22,0.1,0.07,0.0,0.0,0.06,william surver,
-BIOL,1030,4,General Biology I,0.14,0.26,0.32,0.12,0.08,0.0,0.0,0.08,salvatore sparace,
-BIOL,1030,5,General Biology I (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
-BIOL,1050,1,General Biology Lab I,0.17,0.33,0.25,0.08,0.08,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,2,General Biology Lab I,0.17,0.29,0.25,0.17,0.0,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,3,General Biology Lab I,0.04,0.26,0.26,0.17,0.09,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,4,General Biology Lab I,0.29,0.17,0.33,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,5,General Biology Lab I,0.04,0.13,0.3,0.3,0.04,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,6,General Biology Lab I,0.08,0.21,0.17,0.38,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,7,General Biology Lab I,0.1,0.14,0.19,0.33,0.14,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1050,8,General Biology Lab I,0.1,0.25,0.35,0.1,0.05,0.0,0.0,0.15,tafadzwa kaisa,
-BIOL,1050,9,General Biology Lab I,0.09,0.22,0.35,0.22,0.04,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,10,General Biology Lab I,0.04,0.5,0.42,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,11,General Biology Lab I,0.17,0.33,0.33,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,12,General Biology Lab I,0.04,0.29,0.25,0.29,0.13,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,13,General Biology Lab I,0.13,0.5,0.17,0.08,0.13,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,14,General Biology Lab I,0.21,0.38,0.29,0.08,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,15,General Biology Lab I,0.26,0.22,0.3,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,16,General Biology Lab I,0.17,0.42,0.29,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,17,General Biology Lab I,0.17,0.29,0.25,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,18,General Biology Lab I,0.08,0.38,0.33,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,19,General Biology Lab I,0.26,0.17,0.13,0.26,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,20,General Biology Lab I,0.08,0.13,0.38,0.21,0.13,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,21,General Biology Lab I,0.08,0.21,0.29,0.13,0.25,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,22,General Biology Lab I,0.13,0.42,0.17,0.17,0.08,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,23,General Biology Lab I,0.25,0.42,0.08,0.17,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,24,General Biology Lab I,0.21,0.29,0.25,0.08,0.08,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,25,General Biology Lab I,0.0,0.17,0.3,0.22,0.22,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,26,General Biology Lab I,0.21,0.29,0.17,0.21,0.08,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,27,General Biology Lab I,0.08,0.29,0.29,0.29,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,28,General Biology Lab I,0.04,0.46,0.17,0.17,0.08,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,29,General Biology Lab I,0.04,0.35,0.22,0.22,0.09,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,30,General Biology Lab I,0.21,0.25,0.29,0.21,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,31,General Biology Lab I,0.0,0.15,0.25,0.2,0.25,0.0,0.0,0.15,tafadzwa kaisa,
-BIOL,1050,32,General Biology Lab I,0.25,0.31,0.13,0.25,0.06,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,33,General Biology Lab I,0.0,0.15,0.4,0.15,0.15,0.0,0.0,0.15,tafadzwa kaisa,
-BIOL,1050,34,General Biology Lab I,0.17,0.5,0.08,0.21,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,35,General Biology Lab I,0.29,0.29,0.29,0.13,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,36,General Biology Lab I,0.21,0.29,0.38,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,37,General Biology Lab I,0.21,0.33,0.21,0.13,0.08,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,38,General Biology Lab I,0.08,0.5,0.33,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,39,General Biology Lab I,0.14,0.45,0.23,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,40,General Biology Lab I,0.38,0.17,0.25,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,41,General Biology Lab I,0.13,0.42,0.29,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,42,General Biology Lab I,0.09,0.39,0.39,0.0,0.04,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,43,General Biology Lab I,0.04,0.21,0.33,0.25,0.08,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,44,General Biology Lab I,0.21,0.21,0.38,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,45,General Biology Lab I,0.04,0.43,0.22,0.22,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,46,General Biology Lab I,0.12,0.28,0.4,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1090,1,Intro to Life Sci,0.78,0.18,0.05,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
-BIOL,1100,1,Principles of Biology I,0.12,0.43,0.28,0.07,0.03,0.0,0.0,0.07,robert kosinski,
-BIOL,1100,2,Principles of Biology I,0.48,0.37,0.06,0.03,0.05,0.0,0.0,0.02,dylan dittrich-reed,
-BIOL,1100,3,Prin of Biology I (HON),0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,robert kosinski,True
-BIOL,1100,4,Prin of Biology I (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True
-BIOL,1100,5,Principles of Biology I,0.48,0.43,0.08,0.03,0.0,0.0,0.0,0.0,dylan dittrich-reed,
-BIOL,1200,1,Biological Inq Lab,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,2,Biological Inq Lab,0.59,0.24,0.12,0.0,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1200,3,Biological Inq Lab,0.5,0.28,0.11,0.0,0.06,0.0,0.0,0.06, christine minor,
-BIOL,1200,4,Biological Inq Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,5,Biological Inq Lab,0.61,0.22,0.11,0.06,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,6,Biological Inq Lab,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,7,Biological Inq Lab,0.45,0.45,0.0,0.1,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,8,Biological Inq Lab,0.39,0.28,0.22,0.06,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1200,9,Biological Inq Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,11,Biological Inq Lab,0.41,0.47,0.06,0.0,0.06,0.0,0.0,0.0, christine minor,
-BIOL,1200,12,Biological Inq Lab,0.5,0.22,0.17,0.06,0.06,0.0,0.0,0.0, christine minor,
-BIOL,1200,13,Biological Inq Lab,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,14,Biological Inq Lab,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1200,15,Biological Inq Lab,0.56,0.28,0.06,0.06,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1230,1,Keys to Human Biol,0.28,0.37,0.24,0.06,0.04,0.0,0.0,0.01, christine minor,
-BIOL,1230,2,Keys to Human Biol,0.28,0.38,0.19,0.08,0.02,0.0,0.0,0.04, christine minor,
-BIOL,2000,2,Biology in the News,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,2000,6,Biology in the News,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,william surver,
-BIOL,2040,1,"Environ, Energy and Society",0.73,0.14,0.05,0.02,0.0,0.0,0.0,0.05,john jenkins hains,
-BIOL,2040,2,"Environ, Energy and Society",0.68,0.14,0.05,0.03,0.0,0.0,0.0,0.11,john jenkins hains,
-BIOL,2110,1,Introduction to Toxicology,0.45,0.42,0.1,0.0,0.03,0.0,0.0,0.0,peter van den hurk,
-BIOL,2220,1,Human Anat and Physiology I,0.18,0.32,0.24,0.08,0.09,0.0,0.0,0.09,john cummings,
-BIOL,2220,2,Human Anat and Physiology I,0.27,0.4,0.15,0.08,0.03,0.0,0.0,0.07,john cummings,
-BIOL,3030,1,Vertebrate Biology,0.29,0.25,0.25,0.15,0.03,0.0,0.0,0.03,richard blob,
-BIOL,3030,2,Vertebrate Biology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True
-BIOL,3040,1,Biology of Plants,0.46,0.22,0.22,0.03,0.03,0.0,0.0,0.03,christina wells,
-BIOL,3070,1,Vertebrate Biology Lab,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,2,Vertebrate Biology Lab,0.7,0.15,0.1,0.05,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,3,Vertebrate Biology Lab,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,4,Vertebrate Biology Lab,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,5,Vertebrate Biology Lab,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,6,Vertebrate Biology Lab,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,7,Vertebrate Biology Lab,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,8,Vertebrate Biology Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,9,Vertebrate Biology Lab,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,10,Vertebrate Biology Lab,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,11,Vertebrate Biology Lab,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,12,Vertebrate Biology Lab,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,13,Vertebrate Biology Lab,0.25,0.5,0.2,0.05,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,14,Vertebrate Biology Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3080,1,Biology of Plants Practicum,0.5,0.25,0.15,0.05,0.0,0.0,0.0,0.05,christina wells,
-BIOL,3080,2,Biology of Plants Practicum,0.15,0.55,0.2,0.05,0.0,0.0,0.0,0.05,christina wells,
-BIOL,3080,3,Biology of Plants Practicum,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,christina wells,
-BIOL,3080,4,Biology of Plants Practicum,0.11,0.39,0.33,0.06,0.06,0.0,0.0,0.06,christina wells,
-BIOL,3150,1,Functional Human Anatomy,0.23,0.4,0.23,0.07,0.02,0.0,0.0,0.05,tamara mcnutt-scott,
-BIOL,3200,1,Field Botany,0.21,0.21,0.21,0.24,0.03,0.0,0.0,0.1,robert edwa ballard,
-BIOL,3350,1,Evolutionary Biology,0.26,0.44,0.2,0.07,0.02,0.0,0.0,0.01,margaret ptacek,
-BIOL,3510,1,Biological Anthropology,0.33,0.47,0.07,0.07,0.07,0.0,0.0,0.0,lisa rapaport,
-BIOL,3530,1,Forensic Anthropology,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
-BIOL,4140,1,Basic Immunology,0.12,0.29,0.41,0.12,0.0,0.0,0.0,0.06,yanzhang wei,
-BIOL,4200,1,Neurobiology,0.51,0.44,0.05,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4250,1,Introductory Mycology,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,julia loui kerrigan,
-BIOL,4260,1,Mycology Practicum,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,
-BIOL,4340,1,Biological Chem Lab Techniques,0.18,0.27,0.18,0.36,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,2,Biological Chem Lab Techniques,0.15,0.15,0.46,0.15,0.08,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,3,Biological Chem Lab Techniques,0.0,0.64,0.21,0.07,0.07,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,4,Biological Chem Lab Techniques,0.0,0.15,0.54,0.15,0.08,0.0,0.0,0.08,salvatore sparace,
-BIOL,4410,1,Ecology,0.21,0.26,0.35,0.12,0.0,0.0,0.0,0.06,david tonkyn,
-BIOL,4430,1,Freshwater Ecology,0.61,0.31,0.05,0.01,0.0,0.0,0.0,0.02,john jenkins hains,
-BIOL,4440,2,Freshwater Ecology Lab (Lec),0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,john jenkins hains,
-BIOL,4450,2,Ecology Laboratory (Lec),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
-BIOL,4610,1,Cell Biology,0.31,0.42,0.21,0.04,0.01,0.0,0.0,0.01,susan carol chapman,
-BIOL,4610,2,Cell Biology (HON),0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True
-BIOL,4620,2,Cell Biology Lab (Lec),0.54,0.42,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,3,Cell Biology Lab (Lec),0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,4,Cell Biology Lab (Lec),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,7,Cell Biology Lab (Lec),0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,8,Cell Biology Lab (Lec),0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
-BIOL,4670,1,Principles of Hematology,0.89,0.04,0.0,0.0,0.07,0.0,0.0,0.0,vincent gallicchio,
-BIOL,4930,3,Senior Seminar,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
-BIOL,4930,6,Senior Seminar,0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,kara elizabe powder,
-BIOL,6030,1,Intro to Applied Genomics,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,vincent pa richards,
-BIOL,8200,1,Community Ecology,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,saara dewalt,
-BIOL,8400,1,Understanding Biological Inq,0.82,0.09,0.02,0.0,0.05,0.0,0.0,0.03,michael childress,
-BIOL,8420,1,Understand Cellular Processes,0.45,0.39,0.11,0.0,0.03,0.0,0.0,0.01,patricia leota tate,
-BIOL,8440,1,Understanding the Human Body,0.6,0.29,0.08,0.0,0.02,0.0,0.0,0.01,william baldwin,
-BIOL,8480,1,Understanding Scientific Rsrch,0.9,0.0,0.0,0.0,0.06,0.0,0.0,0.03,robert edwa ballard,
-BUS,1010,1,Business Foundations,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,2,Business Foundations,0.32,0.47,0.11,0.05,0.05,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,3,Business Foundations,0.63,0.21,0.0,0.05,0.05,0.0,0.0,0.05,william ern tumblin,
-BUS,1010,4,Business Foundations,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,5,Business Foundations,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,6,Business Foundations,0.42,0.37,0.05,0.0,0.16,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,7,Business Foundations,0.44,0.33,0.11,0.06,0.0,0.0,0.0,0.06,william ern tumblin,
-BUS,1010,8,Business Foundations,0.0,0.58,0.21,0.05,0.11,0.0,0.0,0.05,william ern tumblin,
-BUS,1010,9,Business Foundations,0.37,0.32,0.11,0.05,0.05,0.0,0.0,0.11,william ern tumblin,
-BUS,1010,10,Business Foundations,0.58,0.21,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
-BUS,1010,11,Business Foundations,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,12,Business Foundations,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,james mullinax,
-BUS,1010,13,Business Foundations,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,14,Business Foundations,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,15,Business Foundations,0.41,0.24,0.29,0.06,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,16,Business Foundations,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,17,Business Foundations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,18,Business Foundations,0.17,0.33,0.33,0.06,0.06,0.0,0.0,0.06,donna mccubbin,
-BUS,1010,19,Business Foundations,0.22,0.5,0.17,0.06,0.06,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,20,Business Foundations,0.33,0.17,0.39,0.06,0.0,0.0,0.0,0.06,donna mccubbin,
-BUS,1010,21,Business Foundations,0.42,0.35,0.12,0.07,0.02,0.0,0.0,0.02,donna mccubbin,
-BUS,1010,22,Business Foundations,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,23,Business Foundations,0.44,0.28,0.11,0.06,0.0,0.0,0.0,0.11,sandy edge,
-BUS,1010,24,Business Foundations,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,sandy edge,
-BUS,1010,25,Business Foundations,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,26,Business Foundations,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,27,Business Foundations,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,28,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,
-BUS,1010,29,Business Foundations,0.19,0.36,0.23,0.11,0.04,0.0,0.0,0.06,michael mendonca,
-BUS,1010,30,Business Foundations,0.23,0.43,0.3,0.02,0.02,0.0,0.0,0.0,michael mendonca,
-BUS,1010,31,Business Foundations,0.21,0.53,0.16,0.05,0.0,0.0,0.0,0.05,michael mendonca,
-BUS,1010,33,Business Foundations,0.55,0.34,0.07,0.0,0.0,0.0,0.0,0.03,james mullinax,
-BUS,1010,34,Business Foundations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,
-CE,1990,2,Cr Inq in Civil Engineering,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,weichiang pang,
-CE,2010,1,Statics,0.18,0.28,0.18,0.0,0.05,0.0,0.0,0.33,melissa sternhagen,
-CE,2010,2,Statics,0.12,0.29,0.31,0.1,0.12,0.0,0.0,0.07,melissa sternhagen,
-CE,2010,3,Statics,0.34,0.31,0.16,0.09,0.07,0.0,0.0,0.03,qiushi chen,
-CE,2010,4,Statics,0.23,0.3,0.23,0.05,0.05,0.0,0.0,0.14,melissa sternhagen,
-CE,2010,5,Statics,0.23,0.33,0.16,0.05,0.12,0.0,0.0,0.12,"rashidian dezfouli,",
-CE,2010,6,Statics,0.12,0.35,0.19,0.07,0.14,0.0,0.0,0.14,melissa sternhagen,
-CE,2010,7,Statics (HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,melissa sternhagen,True
-CE,2060,1,Structural Mechanics,0.19,0.35,0.25,0.14,0.02,0.0,0.0,0.05,bryant nielson,
-CE,2080,1,Dynamics,0.13,0.25,0.3,0.18,0.07,0.0,0.0,0.07,nigel gregory kaye,
-CE,2550,1,Geomatics,0.34,0.52,0.1,0.02,0.01,0.0,0.0,0.01,wayne sarasua,
-CE,3010,1,Structural Analysis,0.32,0.26,0.24,0.12,0.03,0.0,0.0,0.03,stephen csernak,
-CE,3010,2,Structural Analysis,0.4,0.28,0.25,0.08,0.0,0.0,0.0,0.0,bryant nielson,
-CE,3110,1,Transportation Engr,0.58,0.33,0.07,0.0,0.02,0.0,0.0,0.0,jennifer ogle,
-CE,3210,1,Geotechnical Engineering,0.42,0.24,0.32,0.0,0.03,0.0,0.0,0.0,qiushi chen,
-CE,3310,1,Constr Engr & Mgmnt,0.4,0.32,0.2,0.04,0.01,0.0,0.0,0.04,james burati,
-CE,3410,1,Intro to Fluid Mech,0.26,0.44,0.26,0.04,0.0,0.0,0.0,0.0,nigel gregory kaye,
-CE,3410,2,Intro to Fluid Mech,0.27,0.36,0.22,0.07,0.05,0.0,0.0,0.02,abdul khan,
-CE,3420,1,Hydraulics & Hydro,0.43,0.43,0.15,0.0,0.0,0.0,0.0,0.0,ashok mishra,
-CE,3510,1,Civil Engineering Materials,0.55,0.43,0.0,0.0,0.0,0.0,0.0,0.03,ami esmaeilpoursaee,
-CE,3510,2,Civil Engineering Materials,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kimberly rene lyons,
-CE,3520,1,Econ Eval of Proj,0.32,0.29,0.2,0.05,0.05,0.0,0.0,0.08,zoraya rolda rockow,
-CE,4010,1,Matrix Str Analysis,0.74,0.15,0.07,0.0,0.04,0.0,0.0,0.0,atamturktur russcher,
-CE,4020,1,Reinfor Con Design,0.27,0.5,0.07,0.07,0.0,0.0,0.0,0.1,thomas edfo cousins,
-CE,4060,1,Struct Steel Design,0.31,0.47,0.14,0.06,0.02,0.0,0.0,0.0,stephen csernak,
-CE,4100,1,Traffic Engr Oper,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,sakib khan,
-CE,4240,1,Earth Slopes & Struc,0.3,0.35,0.3,0.0,0.03,0.0,0.0,0.03,nadara ravichandran,
-CE,4330,1,Const Plan & Sched,0.41,0.41,0.15,0.02,0.0,0.0,0.0,0.0,steve richa sanders,
-CE,4370,2,Sustainable Energy Proj Design,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
-CE,4390,1,Con Eqpmt Sel & Main,0.41,0.46,0.1,0.0,0.0,0.0,0.0,0.02,james burati,
-CE,4460,1,Flood Haz & Prot Des,0.19,0.5,0.25,0.0,0.0,0.0,0.0,0.06,nadim aziz,
-CE,4560,1,Pave Design & Constr,0.39,0.59,0.0,0.0,0.0,0.0,0.0,0.02,bradley putman,
-CE,4590,1,Capstone Design Proj,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4910,1,BIM in Construction Management,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,kalyan ram piratla,
-CE,6010,1,Matrix Str Analysis,0.71,0.18,0.0,0.0,0.12,0.0,0.0,0.0,atamturktur russcher,
-CE,6100,1,Traffic Engr Oper,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CE,6330,1,Const Plan & Sched,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-CE,6370,2,Sustainable Energy Proj Design,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
-CE,6460,1,Flood Haz & Prot Des,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,nadim aziz,
-CE,6910,1,BIM in Construction Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,8040,1,Prestressed Concrete,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,brandon ross,
-CE,8050,1,Adv Struc Mech,0.29,0.5,0.0,0.0,0.0,0.0,0.0,0.21,bryant nielson,
-CE,8080,1,Earthquake Engr,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CE,8220,1,Foundation Engr,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,8230,1,Asphalt Conc Prop,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,
-CE,8240,1,Infrastructure Corrosion,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,
-CE,8540,1,Travl Demnd Forecast,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
-CE,8570,500,Uncertainty Modeling Risk Engr,0.63,0.26,0.04,0.0,0.0,0.0,0.0,0.07,bryant nielson,
-CE,8930,3,Automated Vehicle System,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CH,1010,1,General Chemistry,0.22,0.35,0.3,0.06,0.05,0.0,0.0,0.01,tania issa houjeiry,
-CH,1010,2,General Chemistry,0.1,0.35,0.28,0.09,0.09,0.0,0.0,0.08,princess mycia cox,
-CH,1010,3,General Chemistry,0.26,0.37,0.19,0.06,0.09,0.0,0.0,0.03,thomas hickman,
-CH,1010,4,General Chemistry,0.19,0.27,0.26,0.12,0.11,0.0,0.0,0.04,dennis taylor,
-CH,1010,5,General Chemistry,0.19,0.38,0.22,0.12,0.04,0.0,0.0,0.04,princess mycia cox,
-CH,1010,6,General Chemistry,0.2,0.34,0.25,0.1,0.08,0.0,0.0,0.03,dennis taylor,
-CH,1010,7,General Chemistry,0.05,0.3,0.39,0.1,0.12,0.0,0.0,0.05,william mcwhorter,
-CH,1010,8,General Chemistry,0.23,0.27,0.28,0.1,0.08,0.0,0.0,0.04,dennis taylor,
-CH,1010,9,General Chemistry,0.13,0.34,0.27,0.14,0.1,0.0,0.0,0.03,olt geiculescu,
-CH,1010,10,General Chemistry,0.07,0.32,0.31,0.16,0.1,0.0,0.0,0.04,william mcwhorter,
-CH,1010,11,General Chemistry,0.16,0.33,0.3,0.13,0.07,0.0,0.0,0.01,william mcwhorter,
-CH,1010,12,General Chemistry,0.24,0.41,0.24,0.05,0.05,0.0,0.0,0.01,tania issa houjeiry,
-CH,1010,13,General Chemistry,0.21,0.29,0.25,0.1,0.09,0.0,0.0,0.05,laura lanni,
-CH,1010,14,General Chemistry,0.16,0.38,0.24,0.13,0.05,0.0,0.0,0.03,elliot ennis,
-CH,1010,20,General Chemistry,0.29,0.37,0.24,0.05,0.03,0.0,0.0,0.02,tania issa houjeiry,
-CH,1010,21,General Chemistry,0.2,0.41,0.22,0.05,0.09,0.0,0.0,0.03,elliot ennis,
-CH,1010,22,General Chemistry,0.17,0.37,0.28,0.12,0.05,0.0,0.0,0.01,laura lanni,
-CH,1010,50,General Chemistry,0.17,0.38,0.38,0.04,0.04,0.0,0.0,0.0,shiou-jyh hwu,
-CH,1010,51,General Chemistry (HON),0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,william pennington,True
-CH,1010,52,General Chemistry (HON),0.62,0.32,0.05,0.0,0.0,0.0,0.0,0.0,joseph stu thrasher,True
-CH,1010,501,General Chemistry,0.44,0.29,0.27,0.0,0.0,0.0,0.0,0.0,brian gloor,
-CH,1020,1,General Chemistry,0.3,0.3,0.25,0.1,0.04,0.0,0.0,0.02,stephe schvaneveldt,
-CH,1020,2,General Chemistry,0.28,0.34,0.13,0.11,0.09,0.0,0.0,0.05,stephe schvaneveldt,
-CH,1020,3,General Chemistry,0.24,0.34,0.23,0.09,0.06,0.0,0.0,0.03,stephe schvaneveldt,
-CH,1020,400,General Chemistry,0.08,0.08,0.41,0.25,0.11,0.0,0.0,0.08,stephe schvaneveldt,
-CH,1050,1,Chemistry in Context I,0.27,0.56,0.16,0.01,0.01,0.0,0.0,0.0,olt geiculescu,
-CH,1050,2,Chemistry in Context I,0.35,0.43,0.15,0.05,0.01,0.0,0.0,0.01,olt geiculescu,
-CH,2010,1,Survey of Organic Chemistry,0.29,0.3,0.23,0.09,0.06,0.0,0.0,0.03,thomas hickman,
-CH,2010,2,Survey of Organic Chemistry,0.31,0.39,0.22,0.02,0.04,0.0,0.0,0.0,thomas hickman,
-CH,2020,1,Surv of Organic Chemistry Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,sean 'connor,
-CH,2020,2,Surv of Organic Chemistry Lab,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2020,3,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2020,5,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2020,7,Surv of Organic Chemistry Lab,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2020,8,Surv of Organic Chemistry Lab,0.6,0.2,0.07,0.0,0.07,0.0,0.0,0.07,sean 'connor,
-CH,2230,1,Organic Chemistry,0.32,0.34,0.12,0.13,0.04,0.0,0.0,0.05,modi wetzler,
-CH,2230,2,Organic Chemistry,0.41,0.31,0.13,0.06,0.06,0.0,0.0,0.03,modi wetzler,
-CH,2230,3,Organic Chemistry,0.24,0.33,0.26,0.06,0.06,0.0,0.0,0.04,jacob schroeder,
-CH,2230,4,Organic Chemistry,0.37,0.31,0.18,0.06,0.04,0.0,0.0,0.04,laura lanni,
-CH,2230,5,Organic Chemistry,0.28,0.39,0.17,0.05,0.09,0.0,0.0,0.01,elliot ennis,
-CH,2230,6,Organic Chemistry,0.32,0.27,0.13,0.08,0.11,0.0,0.0,0.08,rhett smith,
-CH,2230,7,Organic Chemistry,0.23,0.36,0.21,0.06,0.07,0.0,0.0,0.08,dev priya arya,
-CH,2240,1,Organic Chemistry,0.24,0.37,0.16,0.08,0.05,0.0,0.0,0.1,jacob schroeder,
-CH,2240,2,Organic Chemistry,0.29,0.38,0.16,0.09,0.06,0.0,0.0,0.02,jacob schroeder,
-CH,2270,1,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,3,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,4,Organic Chem Lab,0.69,0.13,0.06,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,8,Organic Chem Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,12,Organic Chem Lab,0.81,0.0,0.13,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2270,14,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,15,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,19,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,21,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,26,Organic Chem Lab,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,28,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,29,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,30,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,31,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,32,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,34,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,35,Organic Chem Lab,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,4,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
-CH,2280,5,Organic Chem Lab,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,6,Organic Chem Lab,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,sean 'connor,
-CH,2280,7,Organic Chem Lab,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,8,Organic Chem Lab,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,
-CH,2280,9,Organic Chem Lab,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15,sean 'connor,
-CH,2280,10,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,3130,1,Quantitative Analys,0.49,0.24,0.16,0.03,0.0,0.0,0.0,0.08,stephen creager,
-CH,3300,1,Intro to Phys Chem,0.29,0.43,0.21,0.06,0.0,0.0,0.0,0.01,brian dominy,
-CH,3310,1,Physical Chemistry,0.38,0.19,0.19,0.19,0.0,0.0,0.0,0.06,jason mcneill,
-CH,3310,2,Physical Chemistry,0.25,0.25,0.21,0.08,0.17,0.0,0.0,0.04,leah bec casabianca,
-CH,3320,1,Physical Chemistry,0.18,0.41,0.32,0.0,0.05,0.0,0.0,0.05,arkady kholodenko,
-CH,3390,2,Physical Chem Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,3,Physical Chem Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,4,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,4010,1,Organometallic Chemistry,0.58,0.33,0.03,0.0,0.03,0.0,0.0,0.03,andrew gre tennyson,
-CH,4020,1,Inorganic Chemistry,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,joseph kolis,
-CH,4210,1,Advanced Organic Chemistry,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,daniel whitehead,
-CH,8070,1,Chem Trans Elem,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
-CH,8090,1,Chem App/X-Ray Cryst,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,
-CH,8120,1,Chemical Spectroscopic Methods,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,george chumanov,
-CH,8150,1,Mass Spectrometry,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,richard marcus,
-CH,8210,1,Organic Chem I,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0, karl dieter,
-CH,8300,1,Fund Phys Chem,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,
-CH,8510,1,Grad Student Seminar,0.71,0.24,0.03,0.0,0.03,0.0,0.0,0.0,joseph stu thrasher,
-CH,8510,2,Grad Student Seminar,0.91,0.03,0.0,0.0,0.0,0.0,0.0,0.06,steven stuart,
-CHE,2110,1,Mass and Energy Balances,0.24,0.2,0.24,0.08,0.2,0.0,0.0,0.04,mark roberts,
-CHE,2110,2,Mass and Energy Balances,0.28,0.43,0.13,0.03,0.07,0.0,0.0,0.04,mark roberts,
-CHE,3210,1,Ch E Thermo II,0.14,0.14,0.35,0.21,0.12,0.0,0.0,0.05,sapna sarupria,
-CHE,3210,2,Ch E Thermo II,0.2,0.31,0.23,0.17,0.09,0.0,0.0,0.0,sapna sarupria,
-CHE,3300,1,Mass Trans & Seprtn,0.19,0.15,0.43,0.06,0.09,0.0,0.0,0.08,mark thies,
-CHE,4070,1,Unit Op Lab II,0.14,0.75,0.11,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
-CHE,4310,1,Process Design I,0.2,0.45,0.35,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,4500,1,Chem Reaction Engr,0.45,0.26,0.16,0.12,0.0,0.0,0.0,0.0,rachel getman,
-CHE,8030,1,Advanced Transport,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,eric mikel davis,
-CHE,8040,1,Ch E Thermodynamics,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,christophe kitchens,
-CHE,8050,1,Ch E Kinetics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,mark alan blenner,
-CHE,8140,1,Numerical Methods,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,joseph scott,
-CHIN,1010,1,Elementary Chinese,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,ling rao,
-CHIN,1010,2,Elementary Chinese,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,ling rao,
-CHIN,1020,1,Elementary Chinese,0.42,0.17,0.33,0.08,0.0,0.0,0.0,0.0,ling rao,
-CHIN,2010,1,Intermediate Chinese,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,su- chen,
-CHIN,2020,1,Intermediate Chinese,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
-CHIN,4010,1,Pre-Modern Chinese Literature,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,yanming an,
-COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,eddie smith,
-COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,eddie smith,
-COM,1500,1,Intro to Human Communication,0.71,0.25,0.03,0.0,0.0,0.0,0.0,0.01,eddie smith,
-COM,1500,2,Intro to Human Communication,0.66,0.25,0.04,0.01,0.01,0.0,0.0,0.04,daniel lelan fecher,
-COM,1500,3,Intro to Human Communication,0.71,0.26,0.01,0.0,0.0,0.0,0.0,0.02,eddie smith,
-COM,1500,4,Intro to Human Communication,0.68,0.23,0.05,0.01,0.01,0.0,0.0,0.01,marianne her glaser,
-COM,1500,5,Intro to Human Communication,0.7,0.22,0.05,0.02,0.0,0.0,0.0,0.01,marianne her glaser,
-COM,1500,6,Intro to Human Communication,0.65,0.25,0.07,0.0,0.0,0.0,0.0,0.03,marianne her glaser,
-COM,1500,7,Intro to Human Communication,0.4,0.43,0.03,0.03,0.08,0.0,0.0,0.03,daniel lelan fecher,
-COM,2010,1,Intr to Comm Studies,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,2010,2,Intr to Comm Studies,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,2500,1,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,2,Public Speaking,0.39,0.33,0.11,0.06,0.06,0.0,0.0,0.06,marilyn denise pugh,
-COM,2500,3,Public Speaking,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,4,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,5,Public Speaking,0.26,0.58,0.16,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,6,Public Speaking,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
-COM,2500,7,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,8,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,9,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,10,Public Speaking,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,11,Public Speaking,0.47,0.32,0.05,0.05,0.05,0.0,0.0,0.05,sara grumbl crocker,
-COM,2500,12,Public Speaking,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,13,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,14,Public Speaking,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,vanessa anne condon,
-COM,2500,15,Public Speaking,0.17,0.39,0.44,0.0,0.0,0.0,0.0,0.0,pauline matthey,
-COM,2500,16,Public Speaking,0.29,0.35,0.12,0.0,0.0,0.0,0.0,0.24,pauline matthey,
-COM,2500,17,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,the estate  geddes,
-COM,2500,19,Public Speaking,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,vanessa anne condon,
-COM,2500,20,Public Speaking,0.21,0.58,0.11,0.0,0.0,0.0,0.0,0.11,pauline matthey,
-COM,2500,21,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,22,Public Speaking,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,vanessa anne condon,
-COM,2500,23,Public Speaking,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,28,Public Speaking,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,29,Public Speaking,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,
-COM,2500,30,Public Speaking,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,sara grumbl crocker,
-COM,2500,31,Public Speaking,0.21,0.42,0.16,0.05,0.05,0.0,0.0,0.11,marilyn denise pugh,
-COM,2500,32,Public Speaking,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,
-COM,2500,33,Public Speaking,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,34,Public Speaking,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
-COM,2500,35,Public Speaking,0.37,0.37,0.11,0.0,0.11,0.0,0.0,0.05,jumah patrici taweh,
-COM,2500,400,Public Speaking,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,
-COM,2500,401,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,
-COM,2500,402,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,403,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,3010,1,Comm Theory,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,
-COM,3050,1,Persuasion,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
-COM,3060,1,Crit-Cultural Rsrch Methods,0.47,0.29,0.12,0.06,0.06,0.0,0.0,0.0,chenjerai kumanyika,
-COM,3080,1,Pub Comm & Pop Cult,0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,chenjerai kumanyika,
-COM,3080,2,Pub Comm & Pop Cult,0.44,0.33,0.17,0.06,0.0,0.0,0.0,0.0,chenjerai kumanyika,
-COM,3110,1,Qual Comm Methods,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,angela pratt,
-COM,3150,1,Critical-Cultural Comm Theory,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,david travers scott,
-COM,3200,1,Bdcst Production,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,wanda johnson,
-COM,3220,1,Communication Design,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,
-COM,3240,1,"Communication, Sport & Society",0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,
-COM,3240,2,"Communication, Sport & Society",0.28,0.56,0.06,0.11,0.0,0.0,0.0,0.0,gregory kei cranmer,
-COM,3260,1,Pr in Sports,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3260,2,Pr in Sports,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3270,1,Sports Media Criticism,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,brandon boatwright,
-COM,3660,3,Video Comm with Adobe CC,0.83,0.06,0.0,0.06,0.0,0.0,0.0,0.06,michael rodgers,
-COM,3690,1,Political Comm,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3690,2,Political Comm,0.42,0.42,0.11,0.0,0.05,0.0,0.0,0.0,erin michelle ash,
-COM,3700,1,Survey of Brand Communications,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,lisa willi papenfus,
-COM,3720,1,Digital Analytics in Brand Com,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alicia ni littleton,
-COM,3740,1,Brand Comm and Media Strategy,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,roger beasley,
-COM,4020,1,Mass Com: His & Crit,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
-COM,4250,1,Adv Sports Comm,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4250,2,Adv Sports Comm,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4300,1,Legal Communication,0.28,0.61,0.0,0.0,0.0,0.0,0.0,0.11,james isaac roberts,
-COM,4560,1,PR for Assoc & Nonprofits,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,4660,1,Narrative Res. for Soc. Change,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,4950,1,Senior Capstone Seminar,0.72,0.06,0.22,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,8010,1,Communication Theory I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,andrew stephen pyle,
-COM,8030,1,Comm Technology Studies Survey,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,8100,1,Comm Research Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COOP,1020,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey frank neal,
-COOP,1030,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey frank neal,
-CPSC,1010,1,Computer Science I,0.2,0.32,0.14,0.07,0.2,0.0,0.0,0.07,eileen ther kraemer,
-CPSC,1020,1,Computer Science II,0.23,0.33,0.22,0.07,0.09,0.0,0.0,0.06,yvon feaster,
-CPSC,1040,1,Intro Computer Prog,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,aubrey miche lawson,
-CPSC,1060,1,Intro to Programming in Java,0.28,0.28,0.22,0.0,0.11,0.0,0.0,0.11,salvatore lamarca,
-CPSC,1060,2,Intro to Programming in Java,0.13,0.27,0.07,0.27,0.2,0.0,0.0,0.07,salvatore lamarca,
-CPSC,1070,1,Programming Methodology,0.42,0.26,0.11,0.05,0.11,0.0,0.0,0.05,rose lowe,
-CPSC,1070,2,Programming Methodology,0.5,0.22,0.17,0.0,0.06,0.0,0.0,0.06,rose lowe,
-CPSC,1110,1,Intro to Programming in C,0.25,0.35,0.27,0.05,0.04,0.0,0.0,0.04,catherine hochrine,
-CPSC,1110,2,Intro to Programming in C,0.27,0.37,0.17,0.02,0.1,0.0,0.0,0.08,catherine hochrine,
-CPSC,1110,3,Intro to Programming in C,0.6,0.15,0.13,0.04,0.06,0.0,0.0,0.02,tania roy,
-CPSC,1200,1,Intro Info Tech,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john junius porter,
-CPSC,2070,1,Discrete Structures,0.27,0.27,0.24,0.08,0.09,0.0,0.0,0.04,larry hodges,
-CPSC,2120,1,Algs/Data Structures,0.27,0.21,0.28,0.06,0.09,0.0,0.0,0.08,brian christop dean,
-CPSC,2120,2,Algs/Data Structures,0.1,0.0,0.18,0.14,0.24,0.0,0.0,0.34,pradip srimani,
-CPSC,2150,1,Software Dev Foundations,0.2,0.38,0.28,0.04,0.05,0.0,0.0,0.05,murali sitaraman,
-CPSC,2200,1,Microcomputer Appl,0.27,0.36,0.12,0.1,0.03,0.0,0.0,0.12,kevin anton plis,
-CPSC,2310,1,Intro Computer Org,0.21,0.32,0.37,0.01,0.05,0.0,0.0,0.05,rose lowe,
-CPSC,2810,2,Sel Topics: Tech and Tools Sem,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,brian christop dean,
-CPSC,2910,1,Prof Issues I,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,james jones,
-CPSC,2910,3,Prof Issues I,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,yvon feaster,
-CPSC,2910,4,Prof Issues I,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,yvon feaster,
-CPSC,2910,5,Prof Issues I,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,yvon feaster,
-CPSC,2910,6,Prof Issues I,0.53,0.26,0.11,0.0,0.0,0.0,0.0,0.11,yvon feaster,
-CPSC,2920,1,"Computing, Ethics & Society",0.26,0.42,0.16,0.0,0.16,0.0,0.0,0.0,christopher plaue,
-CPSC,2920,2,"Computing, Ethics & Society",0.43,0.21,0.21,0.07,0.07,0.0,0.0,0.0,christopher plaue,
-CPSC,3220,1,Intro to Operating Systems,0.13,0.26,0.39,0.09,0.04,0.0,0.0,0.09,mark smotherman,
-CPSC,3220,2,Intro to Operating Systems,0.1,0.32,0.26,0.1,0.1,0.0,0.0,0.13,pradip srimani,
-CPSC,3300,1,Computer Systems Org,0.28,0.35,0.23,0.06,0.02,0.0,0.0,0.06,rong ge,
-CPSC,3500,1,Foundations of Computer Sci,0.14,0.34,0.3,0.04,0.09,0.0,0.0,0.09,ilya mark safro,
-CPSC,3520,1,Programming Systems,0.36,0.43,0.03,0.09,0.05,0.0,0.0,0.03,robert schalkoff,
-CPSC,3600,2,Network Programming,0.46,0.4,0.14,0.0,0.0,0.0,0.0,0.0,lanny sitanayah,
-CPSC,3600,3,Network Programming,0.51,0.29,0.11,0.0,0.03,0.0,0.0,0.06,lanny sitanayah,
-CPSC,3620,1,Distributed/Cluster Computing,0.22,0.35,0.38,0.03,0.0,0.0,0.0,0.03,linh bao ngo,
-CPSC,3720,1,Software Engineering,0.26,0.63,0.09,0.0,0.02,0.0,0.0,0.0,john mcgregor,
-CPSC,3720,2,Software Engineering,0.21,0.53,0.16,0.0,0.05,0.0,0.0,0.05,kevin anton plis,
-CPSC,3720,3,Software Engineering,0.39,0.39,0.14,0.04,0.04,0.0,0.0,0.0,kevin anton plis,
-CPSC,3720,4,Software Engineering,0.08,0.42,0.25,0.0,0.08,0.0,0.0,0.17,kevin anton plis,
-CPSC,3990,1,Adv CI: Extreme Orange,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james martin,
-CPSC,4050,1,Computer Graphics,0.33,0.25,0.17,0.0,0.0,0.0,0.0,0.25,robert geist,
-CPSC,4110,1,Virtual Reality Systems,0.4,0.33,0.17,0.03,0.07,0.0,0.0,0.0,sabarish venka babu,
-CPSC,4120,1,Eye Tracking Methodology,0.35,0.55,0.05,0.0,0.0,0.0,0.0,0.05,andrew duchowski,
-CPSC,4160,1,2-D Game Engine Construction,0.46,0.42,0.04,0.0,0.08,0.0,0.0,0.0,brian malloy,
-CPSC,4200,1,Computer Security Principles,0.78,0.19,0.0,0.0,0.03,0.0,0.0,0.0,hongxin hu,
-CPSC,4620,1,Database Management Systems,0.08,0.21,0.13,0.04,0.17,0.0,0.0,0.38,pradip srimani,
-CPSC,4820,1,Spec Top:Mobile Device Sftware,0.74,0.17,0.04,0.04,0.0,0.0,0.0,0.0,roy pargas,
-CPSC,4820,5,Spec Topics: Privacy and Secur,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,kelly caine,
-CPSC,4820,6,Special Topics: Info to AI,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,feng luo,
-CPSC,4820,9,Special Topics: Data Science,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,
-CPSC,6040,1,Cptr Graphics Image,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,donald henry house,
-CPSC,6110,1,Virtual Reality Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
-CPSC,6160,1,2-D Game Engine Construction,0.59,0.23,0.18,0.0,0.0,0.0,0.0,0.0,brian malloy,
-CPSC,6200,1,Computer Security Principles,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,hongxin hu,
-CPSC,6620,1,Database Management Systems,0.41,0.12,0.35,0.0,0.0,0.0,0.0,0.12,pradip srimani,
-CPSC,6780,1,Gen Purpose Computation on GPU,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,
-CPSC,6810,1,Sel Top:Programming Team,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,brian christop dean,
-CPSC,6820,5,Spec Topics: Privacy and Secur,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
-CPSC,6820,9,Special Topics: Data Science,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,eileen ther kraemer,
-CPSC,8070,1,3d Model Animation,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-CPSC,8070,2,3d Model Animation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-CPSC,8150,1,Fx Compositing,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,eric patterson,
-CPSC,8170,1,Physically Based Animation,0.33,0.48,0.14,0.0,0.0,0.0,0.0,0.05,donald henry house,
-CPSC,8200,1,Parallel Architechture,0.71,0.23,0.03,0.0,0.0,0.0,0.0,0.03,amy apon,
-CPSC,8270,1,Translation of Progr Languages,0.42,0.35,0.15,0.0,0.02,0.0,0.0,0.06,brian malloy,
-CPSC,8380,1,Adv Data Structures,0.17,0.17,0.17,0.0,0.5,0.0,0.0,0.0,sandra hedetniemi,
-CPSC,8480,1,Network Science,0.42,0.38,0.12,0.0,0.04,0.0,0.0,0.04,ilya mark safro,
-CPSC,8510,1,Soft Sys Data Comm,0.3,0.33,0.3,0.0,0.03,0.0,0.0,0.03,james martin,
-CPSC,8580,1,Security in Emerging Systems,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.02,hongxin hu,
-CPSC,8700,1,Software Design,0.5,0.18,0.1,0.0,0.05,0.0,0.0,0.18,philippa mign brown,
-CPSC,8730,1,"Software Verif, Valid & Measur",0.33,0.59,0.05,0.0,0.03,0.0,0.0,0.0,john mcgregor,
-CPSC,8810,2,Selected Topics: 3D Game Devel,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-CPSC,8810,3,Sel Top: Adv 3D Model and Scul,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,insun kwon,
-CRP,8010,1,Planning Process & Legal Found,0.42,0.46,0.0,0.0,0.08,0.0,0.0,0.04,caitlin dyckman,
-CRP,8020,1,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
-CRP,8030,1,Quant Analysis,0.71,0.21,0.0,0.0,0.04,0.0,0.0,0.04,stephen sperry,
-CRP,8060,1,Urban & Reg Econ for Planners,0.73,0.15,0.0,0.0,0.08,0.0,0.0,0.04,timothy green,
-CRP,8140,1,Public Transit,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
-CRP,8580,2,Research Design,0.84,0.0,0.0,0.0,0.11,0.0,0.0,0.05,timothy green,
-CRP,8600,3,Terminal Proj/Thesis Proposal,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,clifford dona ellis,
-CRP,8600,6,Terminal Proj/Thesis Proposal,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,eric morris,
-CRP,8720,1,Housing in the U S,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,miller cunningham,
-CRP,8900,4,Dir Studies in City & Reg Plan,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,clifford dona ellis,
-CSM,1000,1,Intro to Construct,0.25,0.48,0.23,0.02,0.02,0.0,0.0,0.0,jason lucas,
-CSM,2010,1,Structures I,0.19,0.35,0.19,0.12,0.12,0.0,0.0,0.04,shima clarke,
-CSM,2010,2,Structures I,0.33,0.17,0.29,0.08,0.08,0.0,0.0,0.04,shima clarke,
-CSM,2030,1,Mats & Meth of Const,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,jason lucas,
-CSM,2030,2,Mats & Meth of Const,0.32,0.5,0.11,0.0,0.0,0.0,0.0,0.07,jason lucas,
-CSM,3030,1,Soils & Foundations,0.63,0.28,0.09,0.0,0.0,0.0,0.0,0.0,shima clarke,
-CSM,3030,2,Soils & Foundations,0.56,0.34,0.09,0.0,0.0,0.0,0.0,0.0,shima clarke,
-CSM,3040,1,Envir Systems I,0.23,0.48,0.23,0.06,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3040,2,Envir Systems I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3510,1,Const Estimating,0.23,0.5,0.27,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,
-CSM,3510,2,Const Estimating,0.23,0.5,0.23,0.0,0.0,0.0,0.0,0.03,seyed mousavi rizi,
-CSM,4110,1,Safety in Bldg Const,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,david devita,
-CSM,4500,1,Construction Intern,0.38,0.32,0.1,0.0,0.2,0.0,0.0,0.0,roger william liska,
-CSM,4530,1,Const Proj Mgmt,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,4530,2,Const Proj Mgmt,0.08,0.58,0.33,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,4610,1,Const Econ Seminar,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4610,2,Const Econ Seminar,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8600,1,Constr Finan Plan & Analysis,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8600,400,Constr Finan Plan & Analysis,0.38,0.38,0.0,0.0,0.0,0.0,0.0,0.25,dennis bausman,
-CSM,8630,1,Adv Plan/Sched,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8630,400,Adv Plan/Sched,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8660,1,Role in Development,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.01,susan whorton,
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.25,0.0,susan whorton,
-CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.71,0.29,0.0,susan whorton,
-CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.21,0.02,susan whorton,
-CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.01,susan whorton,
-CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.71,0.29,0.0,susan whorton,
-CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.25,0.0,susan whorton,
-CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.69,0.3,0.01,susan whorton,
-CU,1000,9,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.66,0.34,0.01,susan whorton,
-CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.61,0.38,0.01,susan whorton,
-CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.59,0.41,0.01,susan whorton,
-CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.51,0.47,0.01,susan whorton,
-CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.51,0.48,0.01,susan whorton,
-CU,1000,15,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.41,0.58,0.01,susan whorton,
-CU,1010,2,Univ Success Skills,0.11,0.32,0.21,0.0,0.16,0.0,0.0,0.21,matthew james kirk,
-CU,1010,3,Univ Success Skills,0.69,0.06,0.06,0.13,0.0,0.0,0.0,0.06,mary mcp von kaenel,
-CU,1010,5,Univ Success Skills,0.32,0.05,0.32,0.16,0.16,0.0,0.0,0.0,cari allyn brooks,
-CU,1010,6,Univ Success Skills,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,mary mcp von kaenel,
-CU,2010,1,Sustainability Leadership,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,
-DANC,1400,1,Jazz Dance I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,cheryl hosler,
-DPA,3070,1,Method 3d Production,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,summer 'nea benton,
-DPA,4000,1,Tech Foundations I,0.0,0.0,0.09,0.0,0.64,0.0,0.0,0.27,andrew duchowski,
-DPA,4020,2,Vis Foundations I,0.79,0.0,0.14,0.0,0.07,0.0,0.0,0.0,erik reed,
-DPA,4020,3,Vis Foundations I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,pratham karnik,
-ECE,2010,1,Logic and Computing Devices,0.24,0.25,0.27,0.08,0.12,0.0,0.0,0.04,william reid,
-ECE,2020,1,Electric Circuits I,0.28,0.35,0.21,0.1,0.06,0.0,0.0,0.0,william harrell,
-ECE,2020,3,Electric Circuits I,0.12,0.3,0.33,0.09,0.09,0.0,0.0,0.06,daniel bla cutshall,
-ECE,2070,1,Basic Electrical Engineering,0.36,0.33,0.13,0.06,0.04,0.0,0.0,0.07,william th kolodzey,
-ECE,2070,2,Basic Electrical Engineering,0.21,0.38,0.26,0.0,0.09,0.0,0.0,0.06,timothy anglea,
-ECE,2070,3,Basic Electrical Engineering,0.46,0.29,0.12,0.02,0.02,0.0,0.0,0.1,amir ahmed asif,
-ECE,2080,1,Basic Electrical Engr Lab,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,5,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,6,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,7,Basic Electrical Engr Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,8,Basic Electrical Engr Lab,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,10,Basic Electrical Engr Lab,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,
-ECE,2080,12,Basic Electrical Engr Lab,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
-ECE,2080,13,Basic Electrical Engr Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
-ECE,2090,1,Logic Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,2,Logic Lab,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2090,3,Logic Lab,0.67,0.17,0.0,0.08,0.08,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,4,Logic Lab,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,5,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2090,7,Logic Lab,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2090,9,Logic Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,10,Logic Lab,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2110,1,Elec Engr Lab I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2110,5,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2110,6,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2110,7,Elec Engr Lab I,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
-ECE,2110,9,Elec Engr Lab I,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2120,1,Electrical Engineering Lab II,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,apoorva dee kapadia,
-ECE,2120,3,Electrical Engineering Lab II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
-ECE,2220,1,Syst Prog Concept,0.14,0.38,0.14,0.08,0.08,0.0,0.0,0.19,harlan russell,
-ECE,2230,1,Comp Sys Eng,0.26,0.31,0.18,0.05,0.1,0.0,0.0,0.1,harlan russell,
-ECE,2620,1,Electric Circuits II,0.26,0.19,0.3,0.09,0.12,0.0,0.0,0.05,liang dong,
-ECE,2720,1,Comp Organization,0.17,0.37,0.29,0.12,0.05,0.0,0.0,0.0,william reid,
-ECE,2730,2,Computer Org Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2730,3,Computer Org Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,2,Electrical Engineering Lab III,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,4,Electrical Engineering Lab III,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,apoorva dee kapadia,
-ECE,3170,1,Rand Signal Analysis,0.16,0.4,0.31,0.07,0.04,0.0,0.0,0.02,stephen hubbard,
-ECE,3200,1,Electronics I,0.12,0.31,0.31,0.12,0.13,0.0,0.0,0.03,stephen hubbard,
-ECE,3200,2,Electronics I (HON),0.36,0.43,0.14,0.0,0.07,0.0,0.0,0.0,stephen hubbard,True
-ECE,3210,1,Electronics II,0.19,0.41,0.31,0.03,0.03,0.0,0.0,0.03,stephen hubbard,
-ECE,3220,2,Intro Operating Sys,0.15,0.25,0.35,0.15,0.0,0.0,0.0,0.1,pradip srimani,
-ECE,3270,1,Dig Comp Design,0.26,0.22,0.3,0.04,0.09,0.0,0.0,0.09,melissa crawl smith,
-ECE,3300,1,Signals & Systems,0.13,0.23,0.32,0.18,0.08,0.0,0.0,0.06,carl baum,
-ECE,3300,2,Signals & Systems (HON),0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
-ECE,3520,1,Programming Systems,0.43,0.29,0.0,0.07,0.14,0.0,0.0,0.07,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.42,0.28,0.2,0.04,0.03,0.0,0.0,0.03,edward collins,
-ECE,3710,1,Microcontr Interface,0.34,0.34,0.27,0.01,0.01,0.0,0.0,0.01,william reid,
-ECE,3720,1,Micro Int Lab,0.42,0.33,0.17,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,2,Micro Int Lab,0.08,0.5,0.42,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,3,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,3720,4,Micro Int Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,3720,6,Micro Int Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,3800,1,Electromagnetics,0.42,0.33,0.12,0.03,0.03,0.0,0.0,0.07,hai xiao,
-ECE,3810,1,Field Waves & Ckts,0.09,0.43,0.31,0.09,0.09,0.0,0.0,0.0,anthony martin,
-ECE,4090,1,Intr to Linear Control Systems,0.39,0.36,0.16,0.02,0.04,0.0,0.0,0.02,apoorva dee kapadia,
-ECE,4180,1,Power Syst Analysis,0.35,0.27,0.27,0.04,0.04,0.0,0.0,0.04,elham makram,
-ECE,4270,1,Communications Sys,0.37,0.27,0.13,0.15,0.08,0.0,0.0,0.0,madhabi manandhar,
-ECE,4420,1,Knowledge Engr,0.33,0.38,0.05,0.1,0.0,0.0,0.0,0.14,robert schalkoff,
-ECE,4490,1,Comp Ntwrk Security,0.32,0.42,0.03,0.0,0.05,0.0,0.0,0.18,richard brooks,
-ECE,4610,1,Fundamentals of Solar Energy,0.47,0.39,0.08,0.03,0.03,0.0,0.0,0.0,rajendra singh,
-ECE,4670,1,Intro to Dig Sig Pro,0.24,0.24,0.29,0.06,0.06,0.0,0.0,0.12,john gowdy,
-ECE,4730,1,Intro Parallel Sys,0.15,0.69,0.15,0.0,0.0,0.0,0.0,0.0,walter ligon,
-ECE,4950,1,Int Sys Design I,0.73,0.24,0.03,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4960,1,Int Sys Design II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard groff,
-ECE,6040,1,Semiconductor Devices,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,6420,1,Knowledge Engr,0.41,0.31,0.14,0.0,0.14,0.0,0.0,0.0,robert schalkoff,
-ECE,6490,1,Comp Ntwrk Security,0.31,0.38,0.13,0.0,0.13,0.0,0.0,0.06,lu yu,
-ECE,6670,1,Intro to Dig Sig Pro,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,john gowdy,
-ECE,6730,1,Intro Parallel Sys,0.33,0.25,0.0,0.0,0.33,0.0,0.0,0.08,walter ligon,
-ECE,6930,5,Network science,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,
-ECE,8010,1,Analysis of Lin Sys,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,richard groff,
-ECE,8170,1,Power System Transients,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,ramtin hadidi,
-ECE,8180,1,Rand Proc Appl Engr,0.46,0.38,0.0,0.0,0.15,0.0,0.0,0.0,carl baum,
-ECE,8910,30,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,0.6,0.4,0.0,robert schalkoff,
-ECON,2000,1,Economic Concepts,0.4,0.35,0.15,0.08,0.0,0.0,0.0,0.03,jonathan orr ernest,
-ECON,2000,2,Economic Concepts,0.5,0.25,0.13,0.05,0.03,0.0,0.0,0.05,jonathan orr ernest,
-ECON,2000,3,Economic Concepts,0.3,0.35,0.2,0.13,0.03,0.0,0.0,0.0,miren ivankovic,
-ECON,2110,1,Principles of Microeconomics,0.17,0.61,0.11,0.0,0.11,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,2,Principles of Microeconomics,0.11,0.16,0.16,0.21,0.32,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,3,Principles of Microeconomics,0.06,0.44,0.28,0.11,0.06,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,4,Principles of Microeconomics,0.11,0.37,0.42,0.0,0.0,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,5,Principles of Microeconomics,0.0,0.37,0.26,0.26,0.05,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,6,Principles of Microeconomics,0.11,0.21,0.42,0.11,0.11,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,7,Principles of Microeconomics,0.11,0.47,0.11,0.05,0.16,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,8,Principles of Microeconomics,0.05,0.32,0.53,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,9,Principles of Microeconomics,0.11,0.47,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,10,Principles of Microeconomics,0.26,0.26,0.37,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,11,Principles of Microeconomics,0.06,0.56,0.22,0.11,0.0,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,12,Principles of Microeconomics,0.21,0.37,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,13,Principles of Microeconomics,0.13,0.44,0.31,0.0,0.06,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,14,Principles of Microeconomics,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,15,Principles of Microeconomics,0.16,0.47,0.26,0.0,0.11,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,16,Principles of Microeconomics,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,17,Principles of Microeconomics,0.05,0.53,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,18,Principles of Microeconomics,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,19,Principles of Microeconomics,0.05,0.47,0.21,0.16,0.05,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,20,Principles of Microeconomics,0.26,0.42,0.22,0.05,0.04,0.0,0.0,0.01,kelsey vict roberts,
-ECON,2110,21,Principles of Microeconomics,0.18,0.41,0.35,0.02,0.0,0.0,0.0,0.04,bradley keith hobbs,
-ECON,2110,22,Principles of Microeconomics,0.45,0.27,0.16,0.05,0.05,0.0,0.0,0.02,benjamin jo schwall,
-ECON,2110,23,Principles of Microeconomics,0.24,0.4,0.16,0.09,0.06,0.0,0.0,0.04,leah jacq kitashima,
-ECON,2110,24,Principles of Microeconomics,0.27,0.31,0.2,0.08,0.08,0.0,0.0,0.06,amanda caitlin kerr,
-ECON,2110,25,Principles of Microeconomics,0.23,0.5,0.1,0.03,0.05,0.0,0.0,0.1,roksan ghanbariamin,
-ECON,2110,26,Principles of Microeconomics,0.38,0.29,0.13,0.09,0.02,0.0,0.0,0.09,steven johnson,
-ECON,2110,31,Principles of Microeconomics,0.44,0.36,0.1,0.04,0.03,0.0,0.0,0.04,maria droganova,
-ECON,2110,32,Principles of Microeconomics,0.29,0.36,0.29,0.07,0.0,0.0,0.0,0.0,zhiqi zhao,
-ECON,2110,33,Principles of Microeconomics,0.38,0.28,0.15,0.08,0.03,0.0,0.0,0.08,liuna issagholian,
-ECON,2110,34,Principles of Microeconomics,0.33,0.26,0.28,0.08,0.0,0.0,0.0,0.05,liuna issagholian,
-ECON,2110,35,Principles of Microeconomics,0.38,0.38,0.13,0.08,0.03,0.0,0.0,0.03,roksan ghanbariamin,
-ECON,2110,38,Principles of Microeconomics,0.21,0.6,0.14,0.0,0.02,0.0,0.0,0.02,chen wang,
-ECON,2110,40,Principles of Micro (HON),0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,charles thomas,True
-ECON,2110,41,Principles of Microeconomics,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,chen wang,
-ECON,2120,1,Principles of Macroeconomics,0.07,0.16,0.16,0.16,0.16,0.0,0.0,0.29,ralph charles allen,
-ECON,2120,2,Principles of Macroeconomics,0.32,0.39,0.16,0.07,0.02,0.0,0.0,0.05,wing yin chung,
-ECON,2120,3,Principles of Macroeconomics,0.11,0.21,0.23,0.18,0.13,0.0,0.0,0.14,ralph charles allen,
-ECON,2120,4,Principles of Macroeconomics,0.22,0.22,0.32,0.07,0.12,0.0,0.0,0.05,peter david lorenz,
-ECON,2120,5,Principles of Macroeconomics,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,huili li,
-ECON,2120,6,Principles of Macroeconomics,0.78,0.2,0.03,0.0,0.0,0.0,0.0,0.0,huili li,
-ECON,2120,7,Principles of Macroeconomics,0.28,0.35,0.25,0.13,0.0,0.0,0.0,0.0,peter david lorenz,
-ECON,2120,8,Principles of Macroeconomics,0.18,0.44,0.24,0.08,0.02,0.0,0.0,0.05,ce castellon chicas,
-ECON,2120,9,Principles of Macroeconomics,0.43,0.32,0.14,0.05,0.0,0.0,0.0,0.05,jordan adamson,
-ECON,2120,10,Principles of Macroeconomics,0.17,0.42,0.22,0.11,0.06,0.0,0.0,0.03,andrew chaffee,
-ECON,3020,1,Money and Banking,0.24,0.22,0.3,0.08,0.08,0.0,0.0,0.08,smriti bhargava,
-ECON,3060,1,Managerial Economics,0.21,0.34,0.29,0.08,0.05,0.0,0.0,0.03,timothy jay bacon,
-ECON,3100,1,International Econ,0.32,0.41,0.13,0.01,0.07,0.0,0.0,0.06,scott baier,
-ECON,3140,1,Intermediate Micro,0.38,0.11,0.3,0.09,0.09,0.0,0.0,0.02,patrick warren,
-ECON,3140,2,Intermediate Micro,0.32,0.44,0.19,0.02,0.0,0.0,0.0,0.03,molly espey,
-ECON,3140,3,Intermediate Micro,0.28,0.21,0.28,0.09,0.06,0.0,0.0,0.09,robert kennet fleck,
-ECON,3150,1,Intermediate Macro,0.22,0.29,0.24,0.04,0.06,0.0,0.0,0.16,sergey vla mityakov,
-ECON,3150,2,Intermediate Macro,0.22,0.34,0.2,0.17,0.05,0.0,0.0,0.02,michal jerzmanowski,
-ECON,3190,1,Environmental Econ,0.05,0.46,0.35,0.08,0.05,0.0,0.0,0.0,molly espey,
-ECON,3500,1,Moral & Ethical Econ,0.1,0.33,0.29,0.05,0.1,0.0,0.0,0.14,bradley keith hobbs,
-ECON,3600,1,Public Choice,0.41,0.15,0.15,0.17,0.02,0.0,0.0,0.1,michael makowsky,
-ECON,4010,1,Labor Mkt Analysis,0.42,0.21,0.16,0.16,0.05,0.0,0.0,0.0,chungsang lam,
-ECON,4040,1,Comp Econ Systems,0.22,0.19,0.15,0.07,0.19,0.0,0.0,0.19,dar litsukova-bokar,
-ECON,4050,5,Intro to Econometric,0.18,0.34,0.24,0.04,0.1,0.0,0.0,0.1,scott barkowski,
-ECON,4100,1,Economic Development,0.44,0.19,0.04,0.0,0.07,0.0,0.0,0.26,robert tamura,
-ECON,4110,2,Econ of Education,0.27,0.5,0.08,0.0,0.04,0.0,0.0,0.12,peter quarter blair,
-ECON,4120,1,International Micro,0.42,0.36,0.13,0.07,0.0,0.0,0.0,0.02,richard alan sessa,
-ECON,4220,1,Monetary Economics,0.45,0.42,0.09,0.0,0.03,0.0,0.0,0.0,gerald dwyer,
-ECON,6060,1,Advanced Econometric,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,
-ECON,8010,1,Microeconomic Theory,0.26,0.37,0.26,0.0,0.05,0.0,0.0,0.05,william dougan,
-ECON,8040,1,Applied Math Econ,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
-ECON,8060,1,Econometrics I,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,
-ECON,8080,1,Econometrics III,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,paul wayne wilson,
-ECON,8160,1,Labor Economics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
-ECON,8210,1,Public Choice,0.5,0.17,0.17,0.0,0.17,0.0,0.0,0.0,patrick warren,
-ECON,8230,1,Microecon Pub Pol,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,
-ECON,8240,1,Org of Industry,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,8260,1,Econ Theory of Govt Regulation,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,
-ECON,8550,1,Financial Economics,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,sergey vla mityakov,
-ECON,9010,1,Price Theory,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,charles thomas,
-ED,1970,1,Student of Color Experience CI,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,2,Student of Color Experience CI,0.76,0.1,0.05,0.0,0.1,0.0,0.0,0.0,deonte brown,
-ED,1970,3,Student of Color Experience CI,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,deonte brown,
-ED,8700,1,STEAM Instructional Design,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,cassie fay quigley,
-ED,8720,500,STEAM Enacted and Evaluated,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,danielle chri herro,
-EDC,8050,1,Clinical Mh Couns,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,david scott,
-EDC,8130,400,Appraisal Procedures,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,jennifer lyn brooks,
-EDEC,8200,500,Adv Ece Curriculum,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEL,3210,1,Pe for the Elem Tchr,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,3210,2,Pe for the Elem Tchr,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,deborah smith,
-EDEL,4510,1,Elem Methods in Science Tchg,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
-EDEL,4870,1,Ele Meth Soc Studies,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
-EDEL,4880,1,Elem Meth La Tchng,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
-EDF,3010,1,Principles of American Educat,0.52,0.22,0.17,0.09,0.0,0.0,0.0,0.0,suzanne rosenblith,
-EDF,3020,1,Educational Psychology,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.03,heather rog brooker,
-EDF,3080,1,Classroom Assessment,0.56,0.32,0.08,0.0,0.0,0.0,0.0,0.04,deborah switzer,
-EDF,3080,2,Classroom Assessment,0.71,0.19,0.1,0.0,0.0,0.0,0.0,0.0,deborah switzer,
-EDF,3340,3,Child Growth and Development,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,faiza marghoo jamil,
-EDF,3350,1,Adolescent Growth & Develop,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
-EDF,4800,1,Digital Media & Learning,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,ryan visser,
-EDF,4800,2,Digital Media & Learning,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,3,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,danielle chri herro,
-EDF,4800,300,Digital Media & Learning,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,ryan visser,
-EDF,8770,300,Research Meth in Education I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,carleton dew salley,
-EDF,9270,1,Quant Rsrch & Stats for Ed,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,
-EDF,9270,2,Quant Rsrch & Stats for Ed,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,jennie lynn farmer,
-EDF,9810,1,Design-Based Research Methods,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,david paul reinking,
-EDHD,8310,500,Lit Outcomes for Child w disab,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,vicki steadman,
-EDL,7000,501,Public School Adm,0.79,0.07,0.0,0.0,0.14,0.0,0.0,0.0,frederick buskey,
-EDL,7200,400,School Personnel Adm,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,kathryn le 'andrea,
-EDL,7500,500,El Prin & Spv Ex I,0.71,0.0,0.0,0.0,0.29,0.0,0.0,0.0,frederick buskey,
-EDL,8150,501,The Superintendency,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,elizabeth reynolds,
-EDL,8390,401,Research in Ed L,0.42,0.42,0.0,0.0,0.17,0.0,0.0,0.0,kristin kelly frady,
-EDL,8510,501,School Sys Prac II,0.21,0.0,0.0,0.0,0.79,0.0,0.0,0.0,elizabeth reynolds,
-EDL,8850,512,STEM - School Admin,0.44,0.0,0.0,0.0,0.56,0.0,0.0,0.0,william havice,
-EDL,9100,400,Intro Phd Seminar,0.82,0.0,0.0,0.0,0.18,0.0,0.0,0.0,jane lindle,
-EDL,9650,1,Higher Ed Finance,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,
-EDLT,4600,1,Teaching Reading Grades 2-6,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,
-EDLT,4600,3,Teaching Reading Grades 2-6,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4600,5,Teaching Reading Grades 2-6,0.69,0.19,0.04,0.0,0.0,0.0,0.0,0.08,pamela dunston,
-EDLT,4610,1,Content Area Rdg: Grades 2-6,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,4980,1,Secondary Content Area Reading,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,corrie leigh martin,
-EDLT,8160,500,Literacy Instruction Practicum,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
-EDLT,8400,500,Early Literacy Assessment I,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,andrea chri overton,
-EDLT,8400,504,Early Literacy Assessment I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
-EDLT,9370,501,Reading Recovery Theory I,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,celeste compt bates,
-EDML,8340,400,Envir Sci for Mid Sch Teachers,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,michelle patri cook,
-EDSA,8030,1,Student Dev Servc in Higher Ed,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
-EDSA,8030,2,Student Dev Servc in Higher Ed,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
-EDSC,2260,1,Pr Apprch to Sec Alg,0.31,0.54,0.08,0.0,0.08,0.0,0.0,0.0,stacy megan che,
-EDSC,3240,1,Practicum Sec Engl,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,
-EDSC,4260,1,Tchng Sec Math,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,carlos gomez,
-EDSC,8610,400,Mthds & Strt Secondary Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,
-EDSP,3700,2,Intro to Special Education,0.79,0.15,0.06,0.0,0.0,0.0,0.0,0.0,tracy denis garrett,
-EDSP,3700,3,Intro to Special Education,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,jennifer my- counts,
-EDSP,3700,4,Intro to Special Education,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,michelle lee popham,
-EDSP,3740,1,Char & Strat Emot/Behav Disord,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,
-EDSP,4920,1,Math Inst Ind W/Dis,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela stecker,
-EDSP,4940,1,Tchg Rdg Mild Dis,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
-EDSP,8220,400,Tchg Math Indv W/Dis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,
-EDSP,8530,1,Legal/Pol Issu Sp Ed,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,antonis katsiyannis,
-EES,2010,1,Environ Engr Fundamentals I,0.38,0.27,0.17,0.04,0.1,0.0,0.0,0.04,david freedman,
-EES,3030,1,Water Treatment Systems,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3040,1,Wastewater Treatment Systems,0.43,0.39,0.18,0.0,0.0,0.0,0.0,0.0,sudeep popat,
-EES,3050,1,Water/Wastewater Treatment Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3050,2,Water/Wastewater Treatment Lab,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,4010,1,Environmental Engr,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.17,0.26,0.43,0.13,0.0,0.0,0.0,0.0,mark schlautman,
-EES,4100,1,Environ Radiation Protection I,0.27,0.36,0.09,0.18,0.0,0.0,0.0,0.09,nicole eli martinez,
-EES,4300,1,Air Pollution Engineering,0.21,0.54,0.21,0.04,0.0,0.0,0.0,0.0,thomas overcamp,
-EES,4800,1,Environmental Risk Assessment,0.58,0.19,0.22,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,
-EES,4860,5,Environmental Sustainability,0.6,0.23,0.14,0.0,0.0,0.0,0.0,0.03,michael anthon dale,
-EES,8020,1,Environ Eng Prin,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,8430,1,Environmental Chem,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,
-EES,8510,1,Biol Prin Envir Engr,0.66,0.28,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
-EES,8610,1,Env Engr&Sci Seminar,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,ezra lucas ho cates,
-EES,8800,1,Env Risk Assessment,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,
-ELE,3010,1,Intro to Entre,0.59,0.23,0.13,0.05,0.0,0.0,0.0,0.0,christina kyprianou,
-ELE,3010,2,Intro to Entre,0.51,0.38,0.03,0.03,0.0,0.0,0.0,0.05,christina kyprianou,
-ELE,3010,3,Intro to Entre,0.11,0.45,0.42,0.0,0.03,0.0,0.0,0.0,ashley will parnell,
-ELE,4010,1,Exec Lead & Entr II,0.04,0.29,0.51,0.11,0.0,0.0,0.0,0.04,ashley will parnell,
-ENGL,1030,1,Accelerated Composition,0.0,0.79,0.16,0.0,0.0,0.0,0.0,0.05,renesha moniq poole,
-ENGL,1030,2,Accelerated Composition,0.42,0.47,0.0,0.05,0.05,0.0,0.0,0.0,renesha moniq poole,
-ENGL,1030,3,Accelerated Composition,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,christa kettlewell,
-ENGL,1030,4,Accelerated Composition,0.63,0.11,0.05,0.05,0.11,0.0,0.0,0.05,chloe helene cahill,
-ENGL,1030,5,Accelerated Composition,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,laurie pfister epps,
-ENGL,1030,7,Accelerated Composition,0.5,0.28,0.06,0.11,0.06,0.0,0.0,0.0,robert brissey,
-ENGL,1030,8,Accelerated Composition,0.42,0.47,0.05,0.0,0.05,0.0,0.0,0.0,christa kettlewell,
-ENGL,1030,9,Accelerated Composition,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,chloe helene cahill,
-ENGL,1030,10,Accelerated Composition,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,laurie pfister epps,
-ENGL,1030,12,Accelerated Composition,0.37,0.37,0.16,0.0,0.11,0.0,0.0,0.0,robert brissey,
-ENGL,1030,15,Accelerated Composition,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,karen kettnich,
-ENGL,1030,17,Accelerated Composition,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,matthew scot duncan,
-ENGL,1030,18,Accelerated Composition,0.74,0.11,0.0,0.0,0.0,0.0,0.0,0.16,parker elizabe king,
-ENGL,1030,19,Accelerated Composition,0.42,0.32,0.05,0.16,0.05,0.0,0.0,0.0,jennifer forsberg,
-ENGL,1030,21,Accelerated Composition,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulo green,
-ENGL,1030,22,Accelerated Composition,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,benjamin hudson,
-ENGL,1030,23,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,katie jo vann,
-ENGL,1030,24,Accelerated Composition,0.35,0.47,0.06,0.0,0.06,0.0,0.0,0.06,matthew scot duncan,
-ENGL,1030,25,Accelerated Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,parker elizabe king,
-ENGL,1030,26,Accelerated Composition,0.53,0.37,0.0,0.0,0.11,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,27,Accelerated Composition,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,29,Accelerated Composition,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,dia quaglia beltran,
-ENGL,1030,30,Accelerated Composition,0.32,0.42,0.11,0.0,0.16,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,1030,31,Accelerated Composition,0.67,0.17,0.06,0.06,0.06,0.0,0.0,0.0,brian lee gaines,
-ENGL,1030,32,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kala parker,
-ENGL,1030,33,Accelerated Composition,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,michael davi measel,
-ENGL,1030,34,Accelerated Composition,0.6,0.27,0.07,0.0,0.07,0.0,0.0,0.0,charlotte est lucke,
-ENGL,1030,35,Accelerated Composition,0.87,0.0,0.07,0.0,0.07,0.0,0.0,0.0,kala parker,
-ENGL,1030,37,Accelerated Composition,0.6,0.13,0.07,0.07,0.07,0.0,0.0,0.07,brian lee gaines,
-ENGL,1030,38,Accelerated Composition,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,39,Accelerated Composition,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,yvonne kao,
-ENGL,1030,41,Accelerated Composition,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,1030,42,Accelerated Composition,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,benjamin hudson,
-ENGL,1030,43,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,eric stephens,
-ENGL,1030,44,Accelerated Composition,0.89,0.0,0.05,0.0,0.05,0.0,0.0,0.0,daniel frank,
-ENGL,1030,45,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen quigley,
-ENGL,1030,46,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,april obrien,
-ENGL,1030,47,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,samuel jacks fuller,
-ENGL,1030,49,Accelerated Composition,0.56,0.28,0.0,0.0,0.11,0.0,0.0,0.06,karen kettnich,
-ENGL,1030,50,Accelerated Composition,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,michael russo,
-ENGL,1030,51,Accelerated Composition,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,april obrien,
-ENGL,1030,52,Accelerated Composition,0.53,0.37,0.0,0.05,0.0,0.0,0.0,0.05,eric stephens,
-ENGL,1030,53,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
-ENGL,1030,55,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,whitney jorda adams,
-ENGL,1030,57,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,58,Accelerated Composition,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,1030,59,Accelerated Composition,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,charlotte est lucke,
-ENGL,1030,61,Accelerated Composition,0.84,0.0,0.11,0.05,0.0,0.0,0.0,0.0,stephen quigley,
-ENGL,1030,64,Accelerated Composition,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,christopher stuart,
-ENGL,1030,65,Accelerated Composition,0.07,0.79,0.0,0.0,0.07,0.0,0.0,0.07,barbara ramirez,
-ENGL,1030,67,Accelerated Composition,0.63,0.21,0.05,0.0,0.05,0.0,0.0,0.05,daniel scott citro,
-ENGL,1030,69,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,1030,70,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,
-ENGL,1030,71,Accelerated Composition,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,joshua wood,
-ENGL,1030,72,Accelerated Composition,0.42,0.26,0.0,0.05,0.05,0.0,0.0,0.21,joshua wood,
-ENGL,1030,73,Accelerated Composition,0.69,0.0,0.08,0.0,0.23,0.0,0.0,0.0,jennifer forsberg,
-ENGL,1030,75,Accelerated Composition,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,yvonne kao,
-ENGL,1030,76,Accelerated Composition,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,katie jo vann,
-ENGL,1030,77,Accelerated Composition,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,michael davi measel,
-ENGL,1030,79,Accelerated Composition,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,1030,80,Accelerated Composition,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,christopher stuart,
-ENGL,1030,81,Accelerated Composition,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,sharif youssef,
-ENGL,1030,84,Accelerated Composition,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,erica mich marquard,
-ENGL,1030,85,Accelerated Composition,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,erica mich marquard,
-ENGL,1030,86,Accelerated Composition,0.11,0.78,0.0,0.0,0.06,0.0,0.0,0.06,barbara ramirez,
-ENGL,1030,501,Accelerated Composition,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,2120,3,World Literature,0.63,0.26,0.0,0.04,0.0,0.0,0.0,0.07,sharif youssef,
-ENGL,2120,4,World Literature,0.72,0.1,0.14,0.0,0.0,0.0,0.0,0.03,allen swords,
-ENGL,2120,5,World Literature,0.86,0.0,0.11,0.0,0.0,0.0,0.0,0.04,allen swords,
-ENGL,2120,6,World Literature,0.41,0.3,0.11,0.11,0.04,0.0,0.0,0.04,krist aldebol-hazle,
-ENGL,2120,7,World Literature,0.54,0.14,0.04,0.07,0.18,0.0,0.0,0.04,krist aldebol-hazle,
-ENGL,2120,8,World Literature,0.57,0.29,0.04,0.04,0.04,0.0,0.0,0.04,sharif youssef,
-ENGL,2120,9,World Literature,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,stephanie stripling,
-ENGL,2120,10,World Literature,0.93,0.04,0.0,0.0,0.04,0.0,0.0,0.0,stephanie stripling,
-ENGL,2120,11,World Literature,0.41,0.37,0.11,0.04,0.07,0.0,0.0,0.0,andrew mathas,
-ENGL,2120,12,World Literature,0.31,0.31,0.24,0.03,0.0,0.0,0.0,0.1,karen kettnich,
-ENGL,2120,13,World Literature,0.16,0.56,0.12,0.04,0.0,0.0,0.0,0.12,karen kettnich,
-ENGL,2120,14,World Literature,0.17,0.21,0.42,0.04,0.04,0.0,0.0,0.13,david charles foltz,
-ENGL,2120,15,World Literature,0.32,0.28,0.16,0.08,0.04,0.0,0.0,0.12,david charles foltz,
-ENGL,2120,16,World Literature,0.59,0.33,0.04,0.04,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2120,17,World Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2120,18,World Literature,0.68,0.25,0.04,0.0,0.0,0.0,0.0,0.04,lucian ghita,
-ENGL,2120,19,World Literature,0.33,0.37,0.15,0.0,0.07,0.0,0.0,0.07,andrew mathas,
-ENGL,2120,20,World Literature,0.64,0.21,0.0,0.04,0.04,0.0,0.0,0.07,sharif youssef,
-ENGL,2120,21,World Literature (Majors),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michelle renee ty,
-ENGL,2130,1,British Literature,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
-ENGL,2130,3,British Literature,0.57,0.32,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,2130,4,British Literature,0.56,0.41,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
-ENGL,2130,5,British Literature,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,christopher benson,
-ENGL,2130,7,British Literature,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,2130,9,British Literature,0.68,0.14,0.07,0.04,0.0,0.0,0.0,0.07,krist aldebol-hazle,
-ENGL,2130,10,British Literature,0.36,0.43,0.14,0.0,0.04,0.0,0.0,0.04,christopher benson,
-ENGL,2130,11,British Literature,0.89,0.04,0.0,0.04,0.04,0.0,0.0,0.0,stephanie stripling,
-ENGL,2130,12,British Literature,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,stephanie stripling,
-ENGL,2130,13,British Literature,0.68,0.29,0.0,0.0,0.04,0.0,0.0,0.0,lucian ghita,
-ENGL,2140,1,American Literature,0.5,0.15,0.0,0.04,0.08,0.0,0.0,0.23,candace wiley,
-ENGL,2140,5,American Literature,0.39,0.43,0.04,0.07,0.04,0.0,0.0,0.04,erin nicholson gale,
-ENGL,2140,6,American Literature,0.41,0.33,0.11,0.04,0.04,0.0,0.0,0.07,erin nicholson gale,
-ENGL,2140,7,American Literature,0.46,0.25,0.21,0.0,0.04,0.0,0.0,0.04,john logan pursley,
-ENGL,2140,8,American Literature,0.46,0.12,0.0,0.08,0.0,0.0,0.0,0.35,candace wiley,
-ENGL,2140,9,American Literature,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2140,14,American Literature,0.56,0.26,0.07,0.0,0.04,0.0,0.0,0.07,adrian carson,
-ENGL,2140,15,American Literature,0.26,0.41,0.22,0.04,0.0,0.0,0.0,0.07,susanna ashton,
-ENGL,2140,16,American Literature,0.61,0.29,0.11,0.0,0.0,0.0,0.0,0.0,austin gorman,
-ENGL,2140,17,American Literature,0.48,0.12,0.2,0.08,0.08,0.0,0.0,0.04,adrian carson,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.59,0.19,0.11,0.04,0.0,0.0,0.0,0.07,jennifer forsberg,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.63,0.22,0.11,0.0,0.04,0.0,0.0,0.0,jennifer forsberg,
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.32,0.26,0.16,0.11,0.05,0.0,0.0,0.11,candace wiley,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.22,0.56,0.11,0.0,0.04,0.0,0.0,0.07,david charles foltz,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.15,0.37,0.26,0.0,0.11,0.0,0.0,0.11,david charles foltz,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.57,0.17,0.04,0.04,0.04,0.0,0.0,0.13,candace wiley,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.39,0.5,0.07,0.04,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.65,0.23,0.08,0.0,0.04,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.54,0.35,0.0,0.04,0.0,0.0,0.0,0.08,erin nicholson gale,
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.79,0.14,0.04,0.0,0.0,0.0,0.0,0.04,katie jo vann,
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.36,0.29,0.21,0.04,0.04,0.0,0.0,0.07,megan no macalystre,
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.5,0.29,0.11,0.07,0.04,0.0,0.0,0.0,megan no macalystre,
-ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.48,0.26,0.22,0.04,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.5,0.21,0.04,0.11,0.07,0.0,0.0,0.07,andrew mathas,
-ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.82,0.0,0.04,0.0,0.07,0.0,0.0,0.07,katie jo vann,
-ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,benjamin hudson,
-ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.74,0.19,0.0,0.0,0.0,0.0,0.0,0.07,benjamin hudson,
-ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,2150,100,20th - 21st Century Lit (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,True
-ENGL,3010,1,Grt Books West World,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,eric allison,
-ENGL,3040,3,Business Writing,0.84,0.05,0.05,0.05,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,3040,5,Business Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3040,11,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,3040,13,Business Writing,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,
-ENGL,3040,15,Business Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3040,19,Business Writing,0.37,0.47,0.05,0.0,0.0,0.0,0.0,0.11,katalin beck,
-ENGL,3040,20,Business Writing,0.26,0.58,0.05,0.0,0.05,0.0,0.0,0.05,katalin beck,
-ENGL,3040,400,Business Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,3040,401,Business Writing,0.61,0.28,0.06,0.0,0.06,0.0,0.0,0.0,jillian weise,
-ENGL,3040,402,Business Writing,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,hayley ren zertuche,
-ENGL,3040,403,Business Writing,0.76,0.06,0.0,0.0,0.06,0.0,0.0,0.12,hayley ren zertuche,
-ENGL,3040,404,Business Writing,0.56,0.19,0.06,0.0,0.06,0.0,0.0,0.13,hayley ren zertuche,
-ENGL,3040,405,Business Writing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,
-ENGL,3040,406,Business Writing,0.27,0.47,0.27,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,
-ENGL,3040,407,Business Writing,0.07,0.6,0.07,0.07,0.07,0.0,0.0,0.13,steph kartalopoulos,
-ENGL,3040,408,Business Writing,0.29,0.35,0.0,0.12,0.12,0.0,0.0,0.12,steph kartalopoulos,
-ENGL,3040,409,Business Writing,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,steph kartalopoulos,
-ENGL,3100,1,Crit Writ Lit,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,david sweene coombs,
-ENGL,3100,3,Crit Writ Lit,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,michelle renee ty,
-ENGL,3100,4,Crit Writ Lit,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,michael lemahieu,
-ENGL,3120,1,Advanced Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3120,2,Advanced Composition,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,1,Technical Writing,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,katherine hanzalik,
-ENGL,3140,2,Technical Writing,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,katherine hanzalik,
-ENGL,3140,3,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
-ENGL,3140,5,Technical Writing,0.42,0.47,0.05,0.0,0.05,0.0,0.0,0.0,katalin beck,
-ENGL,3140,6,Technical Writing,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,william pulley,
-ENGL,3140,7,Technical Writing,0.47,0.26,0.05,0.05,0.11,0.0,0.0,0.05,william pulley,
-ENGL,3140,9,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,10,Technical Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,melissa dugan,
-ENGL,3140,11,Technical Writing,0.79,0.05,0.05,0.0,0.11,0.0,0.0,0.0,melissa dugan,
-ENGL,3140,12,Technical Writing,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,katalin beck,
-ENGL,3140,14,Technical Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,15,Technical Writing,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,crystal pa stephens,
-ENGL,3140,16,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3140,19,Technical Writing,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,geveryl le robinson,
-ENGL,3140,20,Technical Writing,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,geveryl le robinson,
-ENGL,3140,22,Technical Writing,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
-ENGL,3140,400,Technical Writing,0.21,0.57,0.07,0.0,0.14,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,3150,1,Scientific Writing & Comm,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,christopher benson,
-ENGL,3150,3,Scientific Writing & Comm,0.42,0.21,0.05,0.05,0.05,0.0,0.0,0.21,william pulley,
-ENGL,3150,4,Scientific Writing & Comm,0.58,0.16,0.11,0.0,0.0,0.0,0.0,0.16,william pulley,
-ENGL,3150,402,Sci Writing & Comm (NURSING),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,403,Sci Writing & Comm (NURSING),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3330,1,Writing News Media,0.6,0.13,0.07,0.0,0.0,0.0,0.0,0.2,geveryl le robinson,
-ENGL,3450,1,Structure of Fiction,0.42,0.47,0.0,0.0,0.05,0.0,0.0,0.05,keith morris,
-ENGL,3480,1,Structure Screenplay,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,nicholas chri brown,
-ENGL,3540,1,Lit Middle East & North Africa,0.38,0.19,0.06,0.0,0.19,0.0,0.0,0.19,angela naimou,
-ENGL,3570,1,Film,0.11,0.61,0.22,0.0,0.06,0.0,0.0,0.0,amy monaghan,
-ENGL,3570,2,Film,0.0,0.72,0.28,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3570,3,Film,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3850,1,Children's Lit,0.72,0.17,0.0,0.0,0.11,0.0,0.0,0.0,megan no macalystre,
-ENGL,3860,1,Adolescent Lit,0.06,0.88,0.0,0.0,0.06,0.0,0.0,0.0,amy monaghan,
-ENGL,3960,1,Brit Lit Survey I,0.38,0.19,0.19,0.13,0.06,0.0,0.0,0.06,erin marina goss,
-ENGL,3960,2,Brit Lit Survey I,0.36,0.36,0.29,0.0,0.0,0.0,0.0,0.0,erin marina goss,
-ENGL,3960,3,Brit Lit Survey I,0.14,0.36,0.21,0.0,0.14,0.0,0.0,0.14,erin marina goss,
-ENGL,3970,1,Brit Lit Survey II,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,john morgenstern,
-ENGL,3970,2,Brit Lit Survey II,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
-ENGL,3980,2,Amer Lit Survey I,0.38,0.44,0.06,0.0,0.06,0.0,0.0,0.06,jonathan beec field,
-ENGL,4110,1,Shakespeare,0.39,0.56,0.0,0.06,0.0,0.0,0.0,0.0,andrew lemons,
-ENGL,4110,2,Shakespeare,0.42,0.11,0.37,0.05,0.05,0.0,0.0,0.0,william stockton,
-ENGL,4110,3,Shakespeare,0.21,0.63,0.11,0.05,0.0,0.0,0.0,0.0,brian mcgrath,
-ENGL,4140,1,Milton,0.08,0.77,0.15,0.0,0.0,0.0,0.0,0.0,lee morrissey,
-ENGL,4190,1,Post Col & World Lit,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,cameron fa bushnell,
-ENGL,4210,1,Amer Lit 1800-1899,0.33,0.33,0.13,0.07,0.13,0.0,0.0,0.0,dominic mastroianni,
-ENGL,4250,1,American Novel,0.25,0.42,0.08,0.08,0.08,0.0,0.0,0.08,susanna ashton,
-ENGL,4260,1,Southern Literature,0.29,0.43,0.14,0.0,0.07,0.0,0.0,0.07,cameron fa bushnell,
-ENGL,4280,1,Contemporary Literature,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,michael lemahieu,
-ENGL,4350,1,Literary Criticism,0.31,0.5,0.13,0.0,0.06,0.0,0.0,0.0,jonathan beec field,
-ENGL,4360,1,Feminist Literary Criticism,0.39,0.56,0.0,0.0,0.06,0.0,0.0,0.0,erin marina goss,
-ENGL,4400,1,Literary Theory,0.42,0.32,0.16,0.0,0.11,0.0,0.0,0.0,walter edgar hunter,
-ENGL,4410,1,Literary Editing,0.28,0.5,0.06,0.06,0.06,0.0,0.0,0.06,gabriel and hankins,
-ENGL,4420,1,Cultural Studies,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,garry bertholf,
-ENGL,4500,1,Film Genres,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07, barton palmer,
-ENGL,4510,1,Film Theo/Criticism,0.75,0.06,0.13,0.0,0.0,0.0,0.0,0.06, barton palmer,
-ENGL,4630,1,Topics in Literature to 1699,0.18,0.55,0.18,0.0,0.0,0.0,0.0,0.09,andrew lemons,
-ENGL,4750,1,Writing for Media,0.31,0.38,0.13,0.0,0.13,0.0,0.0,0.06,megan eatman,
-ENGL,4780,1,Digital Literacy,0.18,0.55,0.18,0.0,0.09,0.0,0.0,0.0,gabriel and hankins,
-ENGL,4820,1,Afr Am Lit to 1920,0.0,0.6,0.1,0.0,0.3,0.0,0.0,0.0,rhondda robi thomas,
-ENGL,4960,1,Senior Seminar,0.69,0.15,0.0,0.0,0.15,0.0,0.0,0.0,dominic mastroianni,
-ENGL,4960,2,Senior Seminar,0.42,0.42,0.0,0.0,0.08,0.0,0.0,0.08,rhondda robi thomas,
-ENGL,4960,3,Senior Seminar,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,8080,1,Top Renaiss & Restoration Lit,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGR,1000,101,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,steven brandon,
-ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.01,steven brandon,
-ENGR,1020,117,Engineering Discipl & Skills,0.42,0.27,0.16,0.02,0.04,0.0,0.0,0.09,matthew kent miller,
-ENGR,1020,118,Engineering Discipl & Skills,0.15,0.53,0.11,0.02,0.02,0.0,0.0,0.17,matthew kent miller,
-ENGR,1020,312,Engineering Discipl & Skills,0.27,0.47,0.16,0.08,0.02,0.0,0.0,0.0,irene marie ferrara,
-ENGR,1020,313,Engineering Discipl & Skills,0.21,0.4,0.15,0.06,0.06,0.0,0.0,0.12,michael giebner,
-ENGR,1020,314,Engineering Discipl & Skills,0.32,0.32,0.16,0.0,0.02,0.0,0.0,0.18,michael giebner,
-ENGR,1020,316,Engineering Discipl & Skills,0.16,0.53,0.12,0.1,0.0,0.0,0.0,0.1,roksana mahmud,
-ENGR,1020,317,Engineering Discipl & Skills,0.16,0.45,0.16,0.06,0.02,0.0,0.0,0.16,jonathan maier,
-ENGR,1020,611,Engineering Discipl & Skills,0.1,0.45,0.24,0.08,0.06,0.0,0.0,0.08,john minor,
-ENGR,1020,612,Engineering Discipl & Skills,0.28,0.49,0.13,0.06,0.0,0.0,0.0,0.04,john minor,
-ENGR,1020,613,Engineering Discipl & Skills,0.19,0.4,0.19,0.08,0.0,0.0,0.0,0.13,mariah magagnotti,
-ENGR,1020,614,Engineering Discipl & Skills,0.29,0.4,0.21,0.04,0.02,0.0,0.0,0.04,irene marie ferrara,
-ENGR,1020,615,Engineering Discipl & Skills,0.35,0.39,0.18,0.0,0.0,0.0,0.0,0.08,irene marie ferrara,
-ENGR,1020,616,Engineering Discipl & Skills,0.17,0.42,0.23,0.04,0.02,0.0,0.0,0.13,sheikh moniruz moni,
-ENGR,1020,617,Engineering Discipl & Skills,0.28,0.3,0.18,0.06,0.06,0.0,0.0,0.12,andrew isaa neptune,
-ENGR,1020,618,Engineering Discipl & Skills,0.24,0.35,0.17,0.11,0.04,0.0,0.0,0.09,andrew isaa neptune,
-ENGR,1020,811,Engineering Discipl & Skills,0.34,0.38,0.15,0.09,0.0,0.0,0.0,0.04,ashley childers,
-ENGR,1020,812,Engineering Discipl & Skills,0.39,0.3,0.22,0.0,0.04,0.0,0.0,0.04,ashley childers,
-ENGR,1020,813,Engineering Discipl & Skills,0.21,0.42,0.21,0.04,0.02,0.0,0.0,0.1,elizabeth stephan,
-ENGR,1020,814,Engineering Discipl & Skills,0.4,0.36,0.13,0.04,0.02,0.0,0.0,0.04,andrew isaa neptune,
-ENGR,1020,815,Engineering Discipl & Skills,0.15,0.45,0.21,0.06,0.0,0.0,0.0,0.13,mariah magagnotti,
-ENGR,1020,816,Engineering Discipl & Skills,0.19,0.32,0.3,0.06,0.02,0.0,0.0,0.11,mariah magagnotti,
-ENGR,1020,817,Engineering Discipl & Skills,0.23,0.45,0.17,0.06,0.02,0.0,0.0,0.06,sarah grigg,
-ENGR,1020,818,Engineering Discipl & Skills,0.32,0.36,0.16,0.05,0.0,0.0,0.0,0.11,sarah grigg,
-ENGR,1020,831,Engr Discipl & Skills (HON),0.72,0.24,0.02,0.0,0.0,0.0,0.0,0.02,steven brandon,True
-ENGR,1020,832,Engr Discipl & Skills (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True
-ENGR,1050,246,Engr Discipline & Skills I,0.04,0.32,0.36,0.08,0.2,0.0,0.0,0.0,matthew kent miller,
-ENGR,1050,400,Engr Discipline & Skills I,0.07,0.07,0.29,0.25,0.18,0.0,0.0,0.14,matthew kent miller,
-ENGR,1060,246,Engr Discipline & Skills II,0.04,0.29,0.25,0.29,0.13,0.0,0.0,0.0,matthew kent miller,
-ENGR,1060,400,Engr Discipline & Skills II,0.12,0.24,0.29,0.06,0.24,0.0,0.0,0.06,matthew kent miller,
-ENGR,1150,500,Engineering Design & Modeling,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,john minor,
-ENGR,1410,225,Programming & Problem Solving,0.06,0.3,0.26,0.09,0.19,0.0,0.0,0.11,richard watkins,
-ENGR,1410,226,Programming & Problem Solving,0.16,0.24,0.2,0.08,0.2,0.0,0.0,0.14,elizabeth stephan,
-ENGR,1410,227,Programming & Problem Solving,0.08,0.29,0.29,0.06,0.12,0.0,0.0,0.17,william martin,
-ENGR,1410,228,Programming & Problem Solving,0.08,0.24,0.33,0.18,0.04,0.0,0.0,0.12,william martin,
-ENGR,1520,501,Engineering Computer Skills,0.29,0.52,0.19,0.0,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,1520,502,Engineering Computer Skills,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,1900,10,CI in Engr I Robotics,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,michael benj wooten,
-ENGR,1900,77,CI in ENGR Human Powered Veh,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,gregory mocko,
-ENGR,2080,681,Engr Graphics & Machine Design,0.43,0.23,0.09,0.09,0.15,0.0,0.0,0.02,nighat yasmin,
-ENGR,2080,682,Engr Graphics & Machine Design,0.31,0.25,0.25,0.06,0.04,0.0,0.0,0.08,amaninder sing gill,
-ENGR,2080,684,Engr Graphics & Machine Design,0.21,0.21,0.21,0.06,0.23,0.0,0.0,0.08,amaninder sing gill,
-ENGR,2080,685,Engr Graphics & Machine Design,0.31,0.22,0.22,0.08,0.08,0.0,0.0,0.08,anthony pau garland,
-ENGR,2080,686,Engr Graphics & Machine Design,0.5,0.24,0.11,0.02,0.04,0.0,0.0,0.09,anthony pau garland,
-ENGR,2100,804,CAD & Engineering Applications,0.43,0.37,0.07,0.0,0.04,0.0,0.0,0.09,nighat yasmin,
-ENGR,2100,805,CAD & Engineering Applications,0.33,0.41,0.22,0.02,0.02,0.0,0.0,0.0,nighat yasmin,
-ENGR,2100,806,CAD & Engineering Applications,0.36,0.33,0.13,0.05,0.03,0.0,0.0,0.1, shams esfandabadi,
-ENGR,2200,106,Evaluating Innovations,0.55,0.39,0.05,0.0,0.0,0.0,0.0,0.0,sarah grigg,
-ENR,1010,1,Intro to Envir & Natur Res I,0.75,0.15,0.03,0.03,0.03,0.0,0.0,0.01,alan johnson,
-ENR,1010,2,Intro to Envir & Natur Res I,0.5,0.31,0.13,0.04,0.02,0.0,0.0,0.0,alan johnson,
-ENR,4290,1,Environ Law & Policy,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
-ENSP,2000,1,Intro Environ Sci,0.23,0.52,0.16,0.05,0.0,0.0,0.0,0.05,scott brame,
-ENSP,2000,2,Intro Environ Sci,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2000,3,Intro Environ Sci,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2000,4,Intro Environ Sci,0.34,0.5,0.09,0.0,0.05,0.0,0.0,0.02,elizabeth carraway,
-ENSP,4000,1,Studies in Environmental Sci,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,margaret thompson,
-ENT,2000,1,Six-Legged Science,0.68,0.17,0.1,0.0,0.0,0.0,0.0,0.05,suellen pometto,
-ENT,3010,1,Insect Biology and Diversity,0.33,0.33,0.29,0.0,0.05,0.0,0.0,0.0,eric benson,
-ENTR,1010,1,Entrepreneurial Mindset,0.48,0.39,0.07,0.01,0.03,0.0,0.0,0.02,john michael hannon,
-ESED,8790,1,Curr Top STEM Education Policy,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,julie patric martin,
-FCS,8130,1,Research Methods in FCS I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,
-FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.67,0.19,0.05,0.02,0.03,0.0,0.0,0.04,aubrey dean coffee,
-FDSC,4010,1,Food Chemistry I,0.58,0.33,0.09,0.0,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4040,1,Food Prsv & Process,0.53,0.43,0.04,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,
-FDSC,4070,1,Quantity Food Production,0.78,0.14,0.03,0.0,0.03,0.0,0.0,0.02,heather batt,
-FDSC,4170,1,Seminar,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,aubrey dean coffee,
-FDSC,4200,1,Food Regulation and Policy,0.91,0.06,0.01,0.0,0.01,0.0,0.0,0.01, rhodehamel,
-FDSC,4300,1,Dairy Process & Sant,0.44,0.28,0.22,0.0,0.06,0.0,0.0,0.0,john mcgregor,
-FDSC,8120,1,Microbial Food Syst,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,xiuping jiang,
-FIN,2010,401,Intro to Personal Finance,0.55,0.24,0.05,0.02,0.05,0.0,0.0,0.1,joshua harris,
-FIN,2010,402,Intro to Personal Finance,0.35,0.23,0.14,0.07,0.05,0.0,0.0,0.16,joshua harris,
-FIN,2010,403,Intro to Personal Finance,0.4,0.33,0.14,0.02,0.09,0.0,0.0,0.02,joshua harris,
-FIN,2010,404,Intro to Personal Finance,0.56,0.26,0.04,0.02,0.08,0.0,0.0,0.04,joshua harris,
-FIN,2010,405,Intro to Personal Finance,0.55,0.26,0.02,0.06,0.04,0.0,0.0,0.06,joshua harris,
-FIN,2010,406,Intro to Personal Finance,0.64,0.2,0.05,0.02,0.05,0.0,0.0,0.05,joshua harris,
-FIN,3040,1,Risk & Insurance,0.2,0.33,0.4,0.07,0.0,0.0,0.0,0.0,kerri mcmillan,
-FIN,3040,2,Risk & Insurance,0.19,0.19,0.58,0.03,0.0,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.18,0.32,0.37,0.05,0.03,0.0,0.0,0.05,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.15,0.51,0.23,0.05,0.03,0.0,0.0,0.03,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.54,0.21,0.21,0.0,0.05,0.0,0.0,0.0,thomas albe wessels,
-FIN,3050,4,Investment Analysis,0.27,0.27,0.36,0.09,0.0,0.0,0.0,0.0,thomas albe wessels,
-FIN,3060,2,Corporation Finance,0.16,0.05,0.22,0.22,0.11,0.0,0.0,0.24,william hol johnson,
-FIN,3060,3,Corporation Finance,0.18,0.13,0.24,0.18,0.24,0.0,0.0,0.03,william hol johnson,
-FIN,3060,4,Corporation Finance,0.0,0.25,0.15,0.28,0.3,0.0,0.0,0.03,william hol johnson,
-FIN,3060,5,Corporation Finance,0.26,0.32,0.19,0.14,0.05,0.0,0.0,0.04,ramon tolb franklin,
-FIN,3060,6,Corporation Finance,0.24,0.31,0.24,0.07,0.05,0.0,0.0,0.09,ramon tolb franklin,
-FIN,3060,7,Corporation Finance,0.22,0.29,0.22,0.19,0.05,0.0,0.0,0.03,ramon tolb franklin,
-FIN,3060,8,Corporation Finance,0.18,0.1,0.41,0.25,0.04,0.0,0.0,0.02,melvin stith,
-FIN,3060,9,Corporation Finance,0.14,0.27,0.31,0.18,0.06,0.0,0.0,0.04,melvin stith,
-FIN,3060,10,Corporation Finance,0.15,0.33,0.22,0.15,0.11,0.0,0.0,0.04,ramon tolb franklin,
-FIN,3060,11,Corporation Finance,0.05,0.13,0.43,0.15,0.2,0.0,0.0,0.05,william hol johnson,
-FIN,3070,1,Prin of Real Estate,0.2,0.33,0.25,0.1,0.1,0.0,0.0,0.03,thomas springer,
-FIN,3070,2,Prin of Real Estate,0.15,0.4,0.3,0.05,0.1,0.0,0.0,0.0,thomas springer,
-FIN,3070,3,Prin of Real Estate,0.21,0.5,0.21,0.02,0.02,0.0,0.0,0.02,yannan shen,
-FIN,3080,1,Fin Inst & Mkts,0.23,0.55,0.17,0.02,0.0,0.0,0.0,0.02,lyudmila chernykh,
-FIN,3080,2,Fin Inst & Mkts,0.2,0.57,0.22,0.0,0.0,0.0,0.0,0.02,lyudmila chernykh,
-FIN,3080,3,Fin Inst & Mkts,0.25,0.38,0.31,0.06,0.0,0.0,0.0,0.0,daniel thoma greene,
-FIN,3110,1,Financial Management I,0.06,0.06,0.21,0.03,0.29,0.0,0.0,0.35,jack wolf,
-FIN,3110,2,Financial Management I,0.13,0.17,0.27,0.13,0.15,0.0,0.0,0.17,jack wolf,
-FIN,3110,3,Financial Management I,0.21,0.3,0.34,0.13,0.0,0.0,0.0,0.02,weike xu,
-FIN,3110,4,Financial Management I,0.16,0.22,0.2,0.14,0.16,0.0,0.0,0.12,john alexander,
-FIN,3120,1,Financial Management II,0.08,0.47,0.26,0.05,0.08,0.0,0.0,0.05,vincent intintoli,
-FIN,3120,2,Financial Management II,0.13,0.46,0.19,0.13,0.07,0.0,0.0,0.02,vincent intintoli,
-FIN,3120,3,Financial Management II,0.24,0.48,0.19,0.02,0.05,0.0,0.0,0.02,blerina zykaj,
-FIN,3120,4,Financial Management II,0.24,0.49,0.17,0.05,0.05,0.0,0.0,0.0,weike xu,
-FIN,4010,1,Corporate Financial Analysis,0.36,0.4,0.16,0.04,0.04,0.0,0.0,0.0,george bra lockhart,
-FIN,4020,1,Corporate Valuation,0.23,0.45,0.32,0.0,0.0,0.0,0.0,0.0,angela morgan,
-FIN,4020,2,Corporate Valuation,0.29,0.29,0.29,0.1,0.03,0.0,0.0,0.0,angela morgan,
-FIN,4050,1,Portfolio Management & Theory,0.18,0.21,0.43,0.11,0.04,0.0,0.0,0.04,john alexander,
-FIN,4060,1,Derivatives Analysis,0.21,0.35,0.32,0.06,0.03,0.0,0.0,0.03,blerina zykaj,
-FIN,4110,1,Int Fin Mgt,0.12,0.62,0.21,0.0,0.0,0.0,0.0,0.06,luke asher devault,
-FIN,4110,2,Int Fin Mgt,0.17,0.52,0.22,0.04,0.0,0.0,0.0,0.04,luke asher devault,
-FIN,4170,1,Real Estate Finance,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,yannan shen,
-FIN,4980,3,Creative Inquiry in Finance,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,angela morgan,
-FNR,2040,1,Soil Information Systems,0.9,0.08,0.0,0.02,0.0,0.0,0.0,0.0,elena mikhailova,
-FNR,4700,1,Kennedy Waterfowl CI,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
-FNR,4990,1,Natural Resources Seminar,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
-FOR,2050,1,Dendrology,0.32,0.34,0.16,0.05,0.08,0.0,0.0,0.05,donald hagan,
-FOR,2050,2,Dendrology,0.24,0.24,0.21,0.06,0.15,0.0,0.0,0.09,donald hagan,
-FOR,2050,3,Dendrology,0.31,0.36,0.16,0.07,0.0,0.0,0.0,0.11,donald hagan,
-FOR,2210,1,Forest Biology,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,thomas adam coates,
-FOR,3020,1,Forest Biometrics,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,lawrence gering,
-FOR,3040,1,Forest Resource Economics,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,puskar khanal,
-FOR,4100,1,Harvesting Processes,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,patrick hiesl,
-FOR,4160,1,Forest Policy and Admin,0.23,0.52,0.21,0.03,0.0,0.0,0.0,0.01,thomas straka,
-FOR,4170,1,Forest Resource Mgt & Regulatn,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,
-FOR,4310,1,Recreation Res Plan in For Mgt,0.54,0.33,0.13,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
-FOR,4340,1,GIS for Natural Resources,0.67,0.28,0.04,0.0,0.0,0.0,0.0,0.0,christopher post,
-FOR,8930,7,Statistical Methods in Nat Res,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,patrick hiesl,
-FR,1010,1,Elementary French,0.26,0.47,0.16,0.0,0.05,0.0,0.0,0.05,anne salces  nedeo,
-FR,1020,1,Elementary French,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,
-FR,1020,2,Elementary French,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,1,Intermediate French,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,paulin de tholozany,
-FR,2010,2,Intermediate French,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,2010,4,Intermediate French,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,paulin de tholozany,
-FR,2020,1,Intermediate French,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2020,2,Intermediate French,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,eric touya,
-FR,2020,3,Intermediate French,0.47,0.18,0.29,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,
-FR,2020,4,Intermediate French,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,3000,1,Survey of French Lit,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
-FR,3050,1,Int Fr Con & Comp I,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,anne salces  nedeo,
-FR,3050,2,Int Fr Con & Comp I,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
-FR,3070,1,French Civilization,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
-FR,4160,1,Fr for Intl Trade II,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,eric touya,
-GC,1010,1,Orientation to G C,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,nona woolbright,
-GC,1010,2,Orientation to G C,0.71,0.16,0.02,0.04,0.04,0.0,0.0,0.02,carol jones,
-GC,1020,1,Computer Art & CAD Foundations,0.39,0.39,0.11,0.06,0.04,0.0,0.0,0.02,carol jones,
-GC,1020,2,Computer Art & CAD Foundations,0.53,0.33,0.07,0.0,0.05,0.0,0.0,0.02,nona woolbright,
-GC,1030,1,G C I for Pkgsc,0.32,0.42,0.11,0.05,0.05,0.0,0.0,0.05,john jacobs,
-GC,1040,1,Graphic Communications I,0.54,0.25,0.11,0.0,0.07,0.0,0.0,0.04,rebecca suza edlein,
-GC,2070,1,Graphic Communications II,0.66,0.24,0.03,0.02,0.03,0.0,0.0,0.02,charles tabor weiss,
-GC,2400,1,Intro to Web Design and Dev,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,erica black walker,
-GC,3400,1,Digital Imaging and eMedia,0.34,0.53,0.11,0.0,0.0,0.0,0.0,0.03,erica black walker,
-GC,3460,1,Ink and Substrates,0.26,0.56,0.11,0.03,0.04,0.0,0.0,0.0,liam henry 'hara,
-GC,4060,1,Package and Specialty Printing,0.8,0.11,0.0,0.0,0.05,0.0,0.0,0.05,kern cox,
-GC,4400,1,Commercial Printing,0.43,0.43,0.04,0.0,0.07,0.0,0.0,0.04,eric weisenmiller,
-GC,4400,2,Commercial Printing,0.39,0.43,0.09,0.0,0.04,0.0,0.0,0.04,eric weisenmiller,
-GC,4440,1,Current Dev/Trends in Gr Comm,0.79,0.16,0.0,0.0,0.03,0.0,0.0,0.03,samuel ingram,
-GC,4480,1,Plan & Cont Printing Functions,0.49,0.38,0.08,0.05,0.0,0.0,0.0,0.0,john leininger,
-GC,4800,1,Senior Seminar in GC,0.63,0.32,0.02,0.02,0.0,0.0,0.0,0.0,charles edwa tonkin,
-GC,4900,230,G C Selected Topics-GC Sales,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,
-GEN,1030,1,Careers in Bioch/Gen,0.8,0.15,0.04,0.0,0.0,0.0,0.0,0.01,alison starr-moss,
-GEN,3000,1,Fundamental Genetics,0.29,0.37,0.18,0.11,0.02,0.0,0.0,0.03,kate leanne wi tsai,
-GEN,3000,2,Fundamental Genetics,0.21,0.4,0.25,0.06,0.03,0.0,0.0,0.05,kate leanne wi tsai,
-GEN,3020,1,Molecular & General Genetics,0.4,0.35,0.15,0.04,0.02,0.0,0.0,0.04,lukasz kozubowski,
-GEN,3020,2,Molec & General Genetics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True
-GEN,3020,4,Molecular & General Genetics,0.35,0.42,0.14,0.05,0.0,0.0,0.0,0.05,haiying liang,
-GEN,4200,1,Molecular Genetics & Gene Reg,0.27,0.51,0.19,0.0,0.0,0.0,0.0,0.03,julia frugoli,
-GEN,4200,2,Molecular Genetics & Gen (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True
-GEN,4400,1,Bioinformatics,0.73,0.09,0.05,0.0,0.0,0.0,0.0,0.14,frank alexan feltus,
-GEN,4500,1,Comparative Genetics,0.3,0.54,0.14,0.0,0.03,0.0,0.0,0.0,leigh anne clark,
-GEN,4900,1,Epigenetics,0.42,0.17,0.25,0.0,0.08,0.0,0.0,0.08,rajandeep si sekhon,
-GEN,6200,1,Molecular Genetics & Gene Reg,0.0,0.67,0.17,0.0,0.0,0.0,0.0,0.17,julia frugoli,
-GEN,6400,1,Bioinformatics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
-GEN,8140,1,Advanced Genetics,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
-GEOG,1010,1,Intro to Geography,0.3,0.45,0.2,0.05,0.0,0.0,0.0,0.0,william churc terry,
-GEOG,1030,1,World Regional Geog,0.78,0.12,0.06,0.0,0.02,0.0,0.0,0.02,lance forres howard,
-GEOG,1030,2,World Regional Geog,0.8,0.18,0.0,0.03,0.0,0.0,0.0,0.0,lance forres howard,
-GEOG,1060,1,Geog Phys Envt,0.42,0.16,0.21,0.11,0.11,0.0,0.0,0.0,william churc terry,
-GEOL,1010,1,Physical Geology,0.27,0.32,0.24,0.08,0.05,0.0,0.0,0.03,alan coulson,
-GEOL,1010,2,Physical Geology,0.24,0.31,0.24,0.09,0.07,0.0,0.0,0.05,alan coulson,
-GEOL,1010,3,Physical Geology,0.49,0.2,0.14,0.06,0.1,0.0,0.0,0.0,kelly best lazar,
-GEOL,1030,1,Physical Geol Lab,0.54,0.33,0.04,0.0,0.08,0.0,0.0,0.0,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.48,0.3,0.13,0.0,0.0,0.0,0.0,0.09,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.64,0.23,0.05,0.0,0.05,0.0,0.0,0.05,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.22,0.43,0.26,0.0,0.04,0.0,0.0,0.04,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.38,0.38,0.04,0.04,0.08,0.0,0.0,0.08,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.38,0.57,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.04,0.58,0.21,0.0,0.04,0.0,0.0,0.13,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.2,0.5,0.15,0.1,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.67,0.0,0.2,0.0,0.0,0.0,0.0,0.13,alan coulson,
-GEOL,2050,1,Mineralogy & Intro Petrology,0.45,0.18,0.36,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,2070,1,Min & Intro Pet Lab,0.09,0.18,0.45,0.18,0.09,0.0,0.0,0.0,alan coulson,
-GEOL,2700,1,Sustainable Water,0.83,0.06,0.03,0.03,0.0,0.0,0.0,0.06,stephen mich moysey,
-GEOL,2750,1,Field Methods,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,scott brame,
-GEOL,3000,1,Environmental Geology,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,3020,1,Structural Geology,0.27,0.27,0.36,0.09,0.0,0.0,0.0,0.0,james castle,
-GEOL,4110,2,Exploring Sustainability,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.08,kelly best lazar,
-GEOL,4110,8,CI - Community Outreach,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,john robert wagner,
-GEOL,4820,1,Groundwater & Contam Transport,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,lawrence murdoch,
-GEOL,4910,1,Research Synthesis I,0.5,0.33,0.08,0.0,0.08,0.0,0.0,0.0,alan coulson,
-GEOL,6150,1,Analysis Geological Processes,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
-GEOL,8080,1,Groundwater Modeling,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
-GER,1010,1,Elementary German,0.21,0.29,0.36,0.0,0.07,0.0,0.0,0.07, lee ferrell,
-GER,1010,2,Elementary German,0.13,0.5,0.25,0.06,0.0,0.0,0.0,0.06, lee ferrell,
-GER,1020,1,Elementary German,0.38,0.38,0.08,0.08,0.0,0.0,0.0,0.08,oswald harris king,
-GER,1020,2,Elementary German,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,2010,1,Intermediate German,0.53,0.27,0.07,0.13,0.0,0.0,0.0,0.0,oswald harris king,
-GER,2010,2,Intermediate German,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,2020,1,Intermediate German,0.13,0.33,0.27,0.13,0.13,0.0,0.0,0.0,gabriela stoicea,
-GER,3050,1,Ger Conv & Comp,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0, lee ferrell,
-GER,3400,1,German Culture,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,oswald harris king,
-GER,4170,1,Topics Ger Intl TR,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0, lee ferrell,
-HCC,8310,1,Fundamentals of Hcc,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,bart knijnenburg,
-HCC,8330,1,HCC Research Methods,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
-HCG,9890,403,Interdisiplinary Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,julia eggert,
-HEHD,8030,400,Ethical Leadership,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,
-HEHD,8050,1,Yth Dev in Families,0.71,0.12,0.12,0.0,0.0,0.0,0.0,0.06,william quinn,
-HEHD,8060,230,Diverse Society,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,ann marie gillard,
-HIST,1010,1,Hist of the U S,0.33,0.48,0.1,0.01,0.03,0.0,0.0,0.05,james brad jeffries,
-HIST,1020,1,Hist of the U S,0.37,0.27,0.14,0.12,0.04,0.0,0.0,0.06,john andrew,
-HIST,1220,1,"Hist, Tech & Society",0.09,0.55,0.29,0.03,0.02,0.0,0.0,0.02,pamela mack,
-HIST,1240,1,Environmental History Survey,0.3,0.45,0.21,0.0,0.0,0.0,0.0,0.03,james brad jeffries,
-HIST,1240,2,Environmental History Survey,0.3,0.45,0.15,0.0,0.06,0.0,0.0,0.03,james brad jeffries,
-HIST,1720,1,The West and the World I,0.15,0.38,0.22,0.07,0.1,0.0,0.0,0.07,caroline dunn clark,
-HIST,1720,2,The West and the World I,0.26,0.54,0.14,0.03,0.02,0.0,0.0,0.02,steven marks,
-HIST,1730,1,The West and the World II,0.41,0.37,0.08,0.02,0.09,0.0,0.0,0.04, alan grubb,
-HIST,1730,2,The West and the World II,0.41,0.27,0.18,0.09,0.05,0.0,0.0,0.0,subah dayal,
-HIST,2990,1,Historian's Craft,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,michael silvestri,
-HIST,2990,2,Historian's Craft,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,elizabeth carney,
-HIST,2990,3,Historian's Craft,0.54,0.31,0.0,0.0,0.0,0.0,0.0,0.15,rachel anne moore,
-HIST,3040,1,Indus & Progr Era,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0, roger grant,
-HIST,3120,1,Afr Amer Hist 1877 to Present,0.68,0.21,0.0,0.0,0.11,0.0,0.0,0.0,abel bartley,
-HIST,3140,1,Hist of the South I,0.24,0.59,0.0,0.0,0.07,0.0,0.0,0.1,paul chris anderson,
-HIST,3290,1,US Legal History Since 1890,0.44,0.33,0.11,0.0,0.06,0.0,0.0,0.06,renee roux,
-HIST,3380,1,Africa to 1875,0.6,0.2,0.15,0.0,0.05,0.0,0.0,0.0,james burns,
-HIST,3400,1,Latin America I,0.63,0.17,0.07,0.03,0.03,0.0,0.0,0.07,rachel anne moore,
-HIST,3550,1,Roman World,0.33,0.56,0.04,0.0,0.04,0.0,0.0,0.04,elizabeth carney,
-HIST,3630,1,Britain Since 1688,0.28,0.38,0.13,0.16,0.06,0.0,0.0,0.0,stephani barczewski,
-HIST,3670,1,Modern Ireland,0.44,0.29,0.09,0.0,0.12,0.0,0.0,0.06,michael silvestri,
-HIST,3700,1,Medieval History,0.27,0.5,0.13,0.0,0.0,0.0,0.0,0.1,caroline dunn clark,
-HIST,3720,1,Renaissance,0.33,0.39,0.11,0.06,0.0,0.0,0.0,0.11,thomas kuehn,
-HIST,3890,7,Mitchelville,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,abel bartley,
-HIST,3890,8,The Churches of Mitchelville,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,abel bartley,
-HIST,3900,1,Modern Military History,0.22,0.3,0.22,0.04,0.19,0.0,0.0,0.04,edwin moise,
-HIST,3980,1,American Military History,0.31,0.38,0.24,0.0,0.03,0.0,0.0,0.03,john andrew,
-HIST,4140,1,Study of Hist Museum,0.25,0.5,0.06,0.13,0.06,0.0,0.0,0.0,meg taylor-shockley,
-HIST,4360,1,Vietnam Wars,0.05,0.37,0.37,0.0,0.11,0.0,0.0,0.11,edwin moise,
-HIST,4710,1,The Great War,0.55,0.17,0.03,0.0,0.1,0.0,0.0,0.14, alan grubb,
-HIST,4900,3,Europe's Age of Dictators,0.42,0.47,0.05,0.0,0.0,0.0,0.0,0.05,amit bein,
-HIST,8000,2,Historical Methods,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,paul chris anderson,
-HIST,8100,3,Capitalism,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,
-HLTH,2020,1,Introduction to Public Health,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,2,Introduction to Public Health,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,3,Introduction to Public Health,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,4,Introduction to Public Health,0.43,0.43,0.13,0.03,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,5,Introduction to Public Health,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,400,Introduction to Public Health,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.57,0.26,0.09,0.0,0.04,0.0,0.0,0.04,frederic fraizer,
-HLTH,2030,2,Health Care Sys,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,lee alden crandall,
-HLTH,2400,1,Deter of Hlth Behav,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,johnny long,
-HLTH,2400,2,Deter of Hlth Behav,0.36,0.54,0.07,0.04,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2400,3,Deter of Hlth Behav,0.52,0.31,0.17,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2400,400,Deter of Hlth Behav,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,amelia clinkscales,
-HLTH,2600,1,Medical Terminology & Comm,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kari jea strothmann,
-HLTH,2980,1,Human Hlth & Disease,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,2980,2,Human Hlth & Disease,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,2980,3,Human Hlth & Disease,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,3050,1,Body Resp Hlth Beh,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brian patric graves,
-HLTH,3400,1,Hlth Prom Prog Plan,0.39,0.43,0.13,0.0,0.04,0.0,0.0,0.0,brian patric graves,
-HLTH,3610,1,Int Health Care Econ,0.56,0.29,0.09,0.03,0.0,0.0,0.0,0.03,khoa dang truong,
-HLTH,3800,1,Epidemiology,0.3,0.36,0.27,0.02,0.02,0.0,0.0,0.02,hugh spitler,
-HLTH,3800,2,Epidemiology,0.55,0.34,0.1,0.0,0.0,0.0,0.0,0.0,rachel mayo,
-HLTH,3800,400,Epidemiology,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,deborah alma falta,
-HLTH,4150,1,Obesity & Eating Dis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,karen kemper,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.63,0.28,0.1,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4400,1,Manag Hlth Serv Org,0.37,0.37,0.19,0.04,0.04,0.0,0.0,0.0,frederic fraizer,
-HLTH,4700,1,Global Health,0.67,0.21,0.08,0.0,0.04,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,4700,400,Global Health,0.88,0.08,0.0,0.04,0.0,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,4750,1,Hlthcr Oper Mgmt Res,0.59,0.18,0.18,0.0,0.0,0.0,0.0,0.05,lu shi,
-HLTH,4900,1,Res Eval St Pub Hlth,0.51,0.37,0.1,0.02,0.0,0.0,0.0,0.0,lingling zhang,
-HLTH,4900,2,Res Eval St Pub Hlth,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,lingling zhang,
-HLTH,8090,1,Epidemiological Res,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,liwei chen,
-HLTH,8120,500,Clinical and Translational Sci,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,ronald gimbel,
-HON,1910,1,Romanticism and Its Influence,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,
-HON,1930,1,World in Crisis,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vladimir matic,
-HON,2020,1,Who Decides What's Cool?,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,amanda cooper fine,
-HON,2020,2,World of Ideas,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,
-HON,2220,1,Almost Human,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,
-HORT,1010,1,Horticulture,0.86,0.09,0.02,0.02,0.0,0.0,0.0,0.02,ellen anita vincent,
-HORT,2100,1,Growing Fall Plants,0.26,0.57,0.13,0.0,0.04,0.0,0.0,0.0,james emerson faust,
-HORT,2120,1,Turfgrass Culture,0.52,0.38,0.07,0.0,0.02,0.0,0.0,0.02,haibo liu,
-HORT,2130,1,Turf Culture Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,donald garrett,
-HORT,2130,2,Turf Culture Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,donald garrett,
-HORT,3030,1,Landscape Plants,0.18,0.32,0.35,0.04,0.03,0.0,0.0,0.07,robert polomski,
-HORT,3080,1,Sust Landsc Des Install Maint,0.84,0.12,0.02,0.0,0.0,0.0,0.0,0.02,ellen anita vincent,
-HORT,4330,1,Turf Weed Management,0.21,0.36,0.36,0.07,0.0,0.0,0.0,0.0,ted whitwell,
-HORT,4550,1,Just Fruits,0.39,0.43,0.13,0.0,0.04,0.0,0.0,0.0,gregory reighard,
-HP,8010,1,Preservation Law and Econ,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,richard sidebottom,
-HP,8030,1,Building Tech and Pathology,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,amalia leifeste,
-HP,8090,400,Historical Research Methods,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,katherine pemberton,
-HP,8230,400,Historic American Interiors,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,elizabeth garr ryan,
-HRD,8200,400,Human Perform Improv,0.62,0.17,0.0,0.0,0.14,0.0,0.0,0.07,cynthia sims,
-HRD,8300,400,Concepts of H R D,0.46,0.27,0.08,0.0,0.15,0.0,0.0,0.04,charlotte ann chase,
-HRD,8450,400,Needs Assess Ed/Ind,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,philip mcgee,
-HRD,8600,400,Instruc Mat Devel,0.76,0.06,0.03,0.0,0.12,0.0,0.0,0.03,philip mcgee,
-IE,2000,100,Soph Seminar in I E,0.54,0.19,0.12,0.04,0.05,0.0,0.0,0.06,brian melloy,
-IE,2100,1,Des Analysis Wrk Sys,0.07,0.39,0.32,0.1,0.05,0.0,0.0,0.06,david neyens,
-IE,2800,1,Deterministic Operations Rsrch,0.16,0.4,0.16,0.13,0.08,0.0,0.0,0.07,robert james riggs,
-IE,3010,1,Systems Design I,0.47,0.43,0.09,0.0,0.0,0.0,0.0,0.01,robert james riggs,
-IE,3600,1,Industrial Apps of Prob/Stat I,0.29,0.27,0.29,0.06,0.08,0.0,0.0,0.02,tugce isik,
-IE,3600,2,Industrial Apps of Prob/Stat I,0.18,0.27,0.27,0.18,0.05,0.0,0.0,0.05,tugce isik,
-IE,3610,1,Industrial App of Prob/Stat II,0.27,0.27,0.15,0.15,0.12,0.0,0.0,0.04,joel greenstein,
-IE,3680,1,Prof Practice in I E,0.87,0.05,0.02,0.03,0.0,0.0,0.0,0.02,brian melloy,
-IE,3810,1,Probabilistic Operations Rsrch,0.24,0.32,0.21,0.08,0.13,0.0,0.0,0.03,amin khademi,
-IE,3840,1,Engr Econ Analysis,0.21,0.15,0.11,0.12,0.12,0.0,0.0,0.29,brian melloy,
-IE,3860,1,Prod Plan & Cont,0.21,0.37,0.17,0.11,0.13,0.0,0.0,0.0,robert james riggs,
-IE,4400,1,Decision Support Sys,0.64,0.14,0.09,0.05,0.05,0.0,0.0,0.03,jonathan lowe,
-IE,4570,1,Transp/Logistic Engr,0.25,0.59,0.15,0.02,0.0,0.0,0.0,0.0,sandra dun eksioglu,
-IE,4610,1,Quality Engineering,0.25,0.28,0.27,0.15,0.03,0.0,0.0,0.03,byung rae cho,
-IE,4650,1,Facilities Planning & Design,0.78,0.17,0.03,0.02,0.0,0.0,0.0,0.0,jonathan lowe,
-IE,4650,2,Facilities Planning & Design,0.42,0.33,0.13,0.13,0.0,0.0,0.0,0.0,brian melloy,
-IE,4820,1,Systems Modeling,0.36,0.39,0.18,0.04,0.01,0.0,0.0,0.01,kevin taaffe,
-IE,4820,2,Systems Modeling,0.26,0.55,0.1,0.07,0.0,0.0,0.0,0.02,kevin taaffe,
-IE,4910,1,Invest Human Errors Cmplx Sys,0.31,0.31,0.09,0.06,0.03,0.0,0.0,0.2,sara lu riggs,
-IE,6910,2,Advanced Math Opt Models,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
-IE,8000,1,Human Factors Eng,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david neyens,
-IE,8010,1,Human-Machine Sys,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,
-IE,8030,1,Engr Optimization and Apps,0.27,0.5,0.18,0.0,0.0,0.0,0.0,0.05,amin khademi,
-IE,8040,1,Mfg Sys Plan & Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,
-IE,8090,1,Model Sys Under Risk,0.17,0.61,0.17,0.0,0.0,0.0,0.0,0.06,burak eksioglu,
-IE,8510,1,Descriptive Analytics,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,mary elizabeth kurz,
-IE,8530,1,Foundations of Quality,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,byung rae cho,
-IE,8550,1,SC & Logistics Modeling II,0.8,0.11,0.04,0.0,0.04,0.0,0.0,0.0,kevin taaffe,
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.84,0.14,0.02,caren kelley-hall,
-INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.92,0.06,0.02,caren kelley-hall,
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,
-INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.83,0.14,0.03,caren kelley-hall,
-INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.82,0.12,0.06,caren kelley-hall,
-IPM,4010,1,Principles of I P M,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,robert bellinger,
-IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.86,0.05,0.09,meredith fan wilson,
-ITAL,1010,1,Elementary Italian,0.33,0.25,0.25,0.08,0.08,0.0,0.0,0.0,julia schmidt,
-ITAL,1010,2,Elementary Italian,0.59,0.12,0.06,0.0,0.06,0.0,0.0,0.18,julia schmidt,
-ITAL,1010,3,Elementary Italian,0.67,0.17,0.0,0.0,0.08,0.0,0.0,0.08,lyudmyla tsykalova,
-ITAL,1010,4,Elementary Italian,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-ITAL,2010,1,Intermediate Italian,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
-ITAL,2020,1,Intermediate Italian,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
-JAPN,1010,1,Elementary Japanese,0.58,0.08,0.17,0.0,0.08,0.0,0.0,0.08,shinichi shoji,
-JAPN,1010,2,Elementary Japanese,0.53,0.18,0.24,0.0,0.0,0.0,0.0,0.06,shinichi shoji,
-JAPN,1010,3,Elementary Japanese,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,shinichi shoji,
-JAPN,2010,1,Intermed Japanese,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,jae allegr takeuchi,
-JAPN,3050,1,Japanese Conversation & Comp,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,kazuko shoji,
-JAPN,4010,1,Japanese Lit in Translation,0.76,0.0,0.12,0.0,0.0,0.0,0.0,0.12,jae allegr takeuchi,
-LANG,3000,1,Intro Linguistics,0.33,0.39,0.06,0.06,0.06,0.0,0.0,0.11,daniel smith,
-LANG,3710,1,Language and Culture,0.3,0.3,0.2,0.1,0.1,0.0,0.0,0.0,yanhua zhang,
-LARC,1150,1,Intro Landscape Architecture,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
-LARC,1280,1,Technical Graphics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
-LARC,1510,1,Basic Design I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,
-LARC,2510,1,Larch Design Fund,0.4,0.4,0.05,0.0,0.1,0.0,0.0,0.05,hala fouad nassar,
-LARC,2620,2,Design Impl I,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,yang song,
-LARC,4620,1,Design Implementation III,0.28,0.28,0.28,0.0,0.0,0.0,0.0,0.17,paul russell,
-LARC,8210,1,Research Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,
-LARC,8430,1,Interdisc Design,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,
-LAW,3220,1,Legal Env of Bus,0.44,0.33,0.14,0.02,0.0,0.0,0.0,0.07,edward ray claggett,
-LAW,3220,2,Legal Env of Bus,0.47,0.43,0.11,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,3,Legal Env of Bus,0.26,0.38,0.19,0.13,0.02,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,4,Legal Env of Bus,0.24,0.48,0.22,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,5,Legal Env of Bus,0.39,0.28,0.22,0.04,0.02,0.0,0.0,0.04,kenneth toussaint,
-LAW,3220,6,Legal Env of Bus,0.33,0.31,0.2,0.09,0.0,0.0,0.0,0.07,kenneth toussaint,
-LAW,3220,7,Legal Env of Bus,0.33,0.4,0.17,0.05,0.02,0.0,0.0,0.02,kath kisska-schulze,
-LAW,3220,8,Legal Env of Bus,0.38,0.6,0.02,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,
-LAW,3220,9,Legal Env of Bus,0.35,0.54,0.09,0.0,0.0,0.0,0.0,0.02,john hine,
-LAW,3220,10,Legal Env of Bus,0.37,0.47,0.14,0.02,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,400,Legal Env of Bus,0.29,0.29,0.16,0.11,0.04,0.0,0.0,0.11,virgini ward-vaughn,
-LAW,3220,401,Legal Env of Bus,0.41,0.48,0.09,0.02,0.0,0.0,0.0,0.0,virgini ward-vaughn,
-LAW,3220,402,Legal Env of Bus,0.51,0.2,0.06,0.02,0.08,0.0,0.0,0.12,virgini ward-vaughn,
-LAW,3220,403,Legal Env of Bus,0.27,0.32,0.1,0.05,0.07,0.0,0.0,0.2,virgini ward-vaughn,
-LAW,3330,1,Real Estate Law,0.06,0.46,0.29,0.09,0.03,0.0,0.0,0.09,judson jahn,
-LAW,3330,2,Real Estate Law,0.4,0.23,0.33,0.0,0.0,0.0,0.0,0.03,judson jahn,
-LAW,4050,1,Construction Law,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,eric touya,
-LS,1000,1,Therapeutic Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
-LS,1000,2,Therapeutic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
-LS,1000,3,Therapeutic Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
-LS,1000,4,Intermediate Top-rope,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,corey newe winstead,
-LS,1000,11,Organic Gardening,0.81,0.06,0.06,0.0,0.06,0.0,0.0,0.0,shawn jadrnicek,
-LS,1000,12,Introduction to Salsa,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,
-LS,1000,13,Introduction to Salsa Dance,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,malik lewis baxter,
-LS,1000,24,FItness leadership,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,patricia figueroa,
-LS,1330,4,Women's Shotgun,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,edward licus prater,
-LS,1410,1,Top Rope Climbing,0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,corey newe winstead,
-LS,1410,2,Top Rope Climbing,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,corey newe winstead,
-LS,1410,3,Top Rope Climbing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,corey newe winstead,
-LS,1410,4,Top Rope Climbing,0.71,0.06,0.06,0.06,0.0,0.0,0.0,0.12,corey newe winstead,
-LS,1410,5,Top Rope Climbing,0.83,0.06,0.0,0.0,0.11,0.0,0.0,0.0,corey newe winstead,
-LS,1560,6,Riflery,0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1580,1,Archery,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1580,3,Archery,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,herbert strickland,
-LS,1580,5,Archery,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1640,1,Whitewater Kayaking,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,cara jill wrenn,
-LS,1640,2,Whitewater Kayaking,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,robert taylor,
-LS,1790,1,Scuba I,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,robert bogan,
-LS,1850,2,Bowling,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,megan elizabet cato,
-LS,1850,3,Bowling,0.9,0.07,0.0,0.0,0.03,0.0,0.0,0.0,kathryn ly mitchell,
-LS,1850,5,Bowling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,katie dudley,
-LS,1850,10,Bowling,0.86,0.07,0.03,0.0,0.03,0.0,0.0,0.0,katie dudley,
-LS,1940,1,Racquetball,0.69,0.15,0.0,0.08,0.0,0.0,0.0,0.08,raymond petersen,
-LS,1980,5,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jason jordan,
-LS,1990,1,Intermediate Golf,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,jason jordan,
-LS,2180,1,Ballroom Dance,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,broadus fleming,
-LS,2200,9,Shag,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,broadus fleming,
-LS,2270,1,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,paul hoke,
-LS,2270,2,Intro to Swing Dance,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,paul hoke,
-LS,2280,1,Intermediate Swing,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,paul hoke,
-LS,2320,1,Core Training,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,
-LS,2320,2,Core Training,0.71,0.19,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,
-LS,2320,4,Core Training,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,
-LS,2320,5,Core Training,0.78,0.13,0.0,0.04,0.0,0.0,0.0,0.04,diane moreno,
-LS,2350,1,Basic Yoga,0.71,0.1,0.1,0.05,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2350,2,Basic Yoga,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,renee warren gahan,
-LS,2350,3,Basic Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,renee warren gahan,
-LS,2350,4,Basic Yoga,0.86,0.05,0.09,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2360,1,Power/Ashtanga Yoga,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,silica eliza larkin,
-LS,2380,2,Vinyasa Flow Yoga,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,
-LS,2420,1,Meditation and Relax,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,2,Meditation and Relax,0.83,0.09,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,6,Meditation and Relax,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,7,Meditation and Relax,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2420,8,Meditation and Relax,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
-LS,2450,2,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
-LS,2450,3,Pilates,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
-LS,2450,4,Pilates,0.88,0.0,0.0,0.0,0.04,0.0,0.0,0.08,melanie ivey job,
-LS,2450,7,Pilates,0.81,0.05,0.0,0.0,0.05,0.0,0.0,0.1,diane moreno,
-LS,2510,3,Running & Jogging,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,robert edwar lawson,
-LS,2700,1,Sports Officiating,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,christopher war cox,
-LS,2750,9,First Aid/Cpr,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,candice lyn honnold,
-LS,2750,10,First Aid/Cpr,0.73,0.07,0.0,0.0,0.0,0.0,0.0,0.2,candice lyn honnold,
-MATH,1010,1,Essen Math for Informed Soc,0.23,0.23,0.46,0.0,0.0,0.0,0.0,0.08,thowhida akther,
-MATH,1010,2,Essen Math for Informed Soc,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,thowhida akther,
-MATH,1010,3,Essen Math for Informed Soc,0.5,0.28,0.17,0.06,0.0,0.0,0.0,0.0,xiyan tan,
-MATH,1010,4,Essen Math for Informed Soc,0.31,0.38,0.12,0.07,0.07,0.0,0.0,0.05,judith cottingham,
-MATH,1010,5,Essen Math for Informed Soc,0.21,0.36,0.21,0.14,0.07,0.0,0.0,0.0,xiyan tan,
-MATH,1010,6,Essen Math for Informed Soc,0.33,0.35,0.16,0.07,0.05,0.0,0.0,0.05,judith cottingham,
-MATH,1010,8,Essen Math for Informed Soc,0.17,0.39,0.28,0.11,0.06,0.0,0.0,0.0,tianhui wei,
-MATH,1010,10,Essen Math for Informed Soc,0.54,0.23,0.0,0.0,0.08,0.0,0.0,0.15,tianhui wei,
-MATH,1020,1,Business Calculus I,0.06,0.56,0.17,0.06,0.17,0.0,0.0,0.0,thomas clevenger,
-MATH,1020,2,Business Calculus I,0.21,0.21,0.26,0.11,0.11,0.0,0.0,0.11,bryce pruitt,
-MATH,1020,3,Business Calculus I,0.18,0.18,0.36,0.07,0.18,0.0,0.0,0.02,warren adams,
-MATH,1020,5,Business Calculus I,0.16,0.32,0.37,0.05,0.11,0.0,0.0,0.0,peter westerbaan,
-MATH,1020,6,Business Calculus I,0.16,0.32,0.21,0.0,0.16,0.0,0.0,0.16,jared scott miller,
-MATH,1020,7,Business Calculus I,0.22,0.44,0.17,0.06,0.11,0.0,0.0,0.0,thomas clevenger,
-MATH,1020,8,Business Calculus I,0.16,0.42,0.11,0.11,0.16,0.0,0.0,0.05,bryce pruitt,
-MATH,1020,9,Business Calculus I,0.37,0.21,0.16,0.0,0.16,0.0,0.0,0.11,michael thoma cowen,
-MATH,1020,10,Business Calculus I,0.28,0.33,0.22,0.06,0.06,0.0,0.0,0.06,ashleigh craig,
-MATH,1020,11,Business Calculus I,0.26,0.42,0.16,0.05,0.11,0.0,0.0,0.0,fun choi john chan,
-MATH,1020,12,Business Calculus I,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,peter westerbaan,
-MATH,1020,13,Business Calculus I,0.31,0.26,0.21,0.07,0.07,0.0,0.0,0.07,randy davidson,
-MATH,1020,14,Business Calculus I,0.0,0.37,0.47,0.0,0.11,0.0,0.0,0.05,emily marie nystrom,
-MATH,1020,15,Business Calculus I,0.16,0.42,0.16,0.16,0.05,0.0,0.0,0.05,todd fenstermacher,
-MATH,1020,16,Business Calculus I,0.28,0.11,0.22,0.17,0.22,0.0,0.0,0.0,fun choi john chan,
-MATH,1020,17,Business Calculus I,0.26,0.42,0.16,0.0,0.0,0.0,0.0,0.16,ashleigh craig,
-MATH,1020,18,Business Calculus I,0.11,0.53,0.11,0.21,0.0,0.0,0.0,0.05,michael thoma cowen,
-MATH,1020,19,Business Calculus I,0.31,0.21,0.14,0.12,0.12,0.0,0.0,0.1,randy davidson,
-MATH,1020,20,Business Calculus I,0.21,0.37,0.21,0.05,0.11,0.0,0.0,0.05,emily marie nystrom,
-MATH,1020,21,Business Calculus I,0.16,0.21,0.32,0.0,0.16,0.0,0.0,0.16,todd fenstermacher,
-MATH,1020,22,Business Calculus I,0.42,0.16,0.37,0.05,0.0,0.0,0.0,0.0,john william grant,
-MATH,1020,23,Business Calculus I,0.26,0.32,0.16,0.0,0.21,0.0,0.0,0.05,camille zerfas,
-MATH,1020,24,Business Calculus I,0.28,0.11,0.28,0.22,0.06,0.0,0.0,0.06,aaro ramirez flores,
-MATH,1020,25,Business Calculus I,0.11,0.37,0.26,0.05,0.11,0.0,0.0,0.11,stephen peele,
-MATH,1020,26,Business Calculus I,0.21,0.32,0.37,0.05,0.0,0.0,0.0,0.05,shanshan jia,
-MATH,1020,27,Business Calculus I,0.37,0.05,0.26,0.21,0.05,0.0,0.0,0.05,kara ail stasikelis,
-MATH,1020,28,Business Calculus I,0.53,0.16,0.21,0.11,0.0,0.0,0.0,0.0,stephen peele,
-MATH,1020,29,Business Calculus I,0.32,0.21,0.26,0.05,0.11,0.0,0.0,0.05,camille zerfas,
-MATH,1020,30,Business Calculus I,0.21,0.37,0.26,0.0,0.05,0.0,0.0,0.11,jing li,
-MATH,1020,32,Business Calculus I,0.26,0.21,0.16,0.11,0.26,0.0,0.0,0.0,lu sun,
-MATH,1020,33,Business Calculus I,0.4,0.28,0.13,0.08,0.08,0.0,0.0,0.05,warren adams,
-MATH,1020,34,Business Calculus I,0.35,0.35,0.18,0.0,0.06,0.0,0.0,0.06,shanshan jia,
-MATH,1020,35,Business Calculus I,0.37,0.26,0.21,0.0,0.11,0.0,0.0,0.05,kara ail stasikelis,
-MATH,1020,36,Business Calculus I,0.06,0.25,0.25,0.06,0.25,0.0,0.0,0.13,tianqi zhang,
-MATH,1020,37,Business Calculus I,0.13,0.31,0.25,0.0,0.19,0.0,0.0,0.13,jing li,
-MATH,1020,38,Business Calculus I,0.22,0.33,0.17,0.17,0.06,0.0,0.0,0.06,stephen garth,
-MATH,1020,39,Business Calculus I,0.26,0.29,0.19,0.1,0.05,0.0,0.0,0.12,warren adams,
-MATH,1020,40,Business Calculus I,0.17,0.5,0.11,0.11,0.11,0.0,0.0,0.0,aaro ramirez flores,
-MATH,1020,41,Business Calculus I,0.12,0.29,0.12,0.18,0.18,0.0,0.0,0.12,tianqi zhang,
-MATH,1020,42,Business Calculus I,0.0,0.32,0.26,0.16,0.21,0.0,0.0,0.05,lu sun,
-MATH,1020,44,Business Calculus I,0.0,0.21,0.42,0.0,0.21,0.0,0.0,0.16,stephen garth,
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.56,0.4,0.04,donna simms,
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.32,0.47,0.21,xun dong,
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.46,0.2,haotian feng,
-MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.53,0.43,0.04,tony thanh nguyen,
-MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.56,0.06,chase norman joyner,
-MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.48,0.41,0.11,tony thanh nguyen,
-MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.44,0.18,lauren pai mcintyre,
-MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.64,0.02,tony thanh nguyen,
-MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.48,0.14,liang zhao,
-MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.35,0.56,0.08,nicholas ahlstrom,
-MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.26,0.46,0.28,stefan adam bock,
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.6,0.34,0.06,charity watson,
-MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.52,0.46,0.02,charity watson,
-MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.39,0.02,charity watson,
-MATH,1060,2,Calculus of One Variable I,0.11,0.27,0.13,0.04,0.27,0.0,0.0,0.18,sanwar ahmad,
-MATH,1060,3,Calculus of One Variable I,0.36,0.29,0.21,0.02,0.05,0.0,0.0,0.07,garrett dranichak,
-MATH,1060,4,Calculus of One Variable I,0.2,0.29,0.11,0.14,0.2,0.0,0.0,0.06,jonathon leverenz,
-MATH,1060,5,Calculus of One Variable I,0.13,0.35,0.17,0.02,0.13,0.0,0.0,0.21,michael gl eldredge,
-MATH,1060,7,Calculus of One Variable I,0.1,0.4,0.08,0.03,0.23,0.0,0.0,0.18,shuhan xu,
-MATH,1060,8,Calculus of One Variable I,0.14,0.51,0.11,0.06,0.14,0.0,0.0,0.03,beth novick,
-MATH,1060,10,Calculus of One Variable I,0.14,0.3,0.18,0.02,0.18,0.0,0.0,0.18,sergey charnyi,
-MATH,1060,11,Calculus of One Variable I,0.33,0.26,0.21,0.05,0.05,0.0,0.0,0.1,hugh geller,
-MATH,1060,13,Calculus of One Variable I,0.09,0.2,0.27,0.05,0.16,0.0,0.0,0.23,sofya alekseeva,
-MATH,1060,14,Calculus of One Variable I,0.12,0.33,0.21,0.05,0.14,0.0,0.0,0.14,irina viktorova,
-MATH,1060,15,Calculus of One Variable I,0.24,0.24,0.32,0.06,0.12,0.0,0.0,0.03,marilyn reba,
-MATH,1060,16,Calculus of One Variable I,0.08,0.16,0.45,0.05,0.21,0.0,0.0,0.05,irina viktorova,
-MATH,1060,18,Calculus of One Variable I,0.16,0.27,0.24,0.11,0.11,0.0,0.0,0.11,sofya alekseeva,
-MATH,1060,20,Calculus of One Variable I,0.18,0.39,0.21,0.09,0.06,0.0,0.0,0.06,marilyn reba,
-MATH,1060,21,Calculus of One Variable I,0.11,0.27,0.16,0.13,0.18,0.0,0.0,0.16,rebecca ramos,
-MATH,1060,22,Calculus of One Variable I,0.02,0.2,0.29,0.02,0.2,0.0,0.0,0.27,sofya alekseeva,
-MATH,1060,26,Calculus of One Variable I,0.07,0.34,0.22,0.07,0.2,0.0,0.0,0.1,shuhan xu,
-MATH,1060,100,Calc of One Variable I (HON),0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,beth novick,True
-MATH,1060,201,Calculus of One Variable I,0.31,0.35,0.13,0.04,0.06,0.0,0.0,0.1,allen anderso guest,
-MATH,1060,206,Calculus of One Variable I,0.23,0.38,0.19,0.06,0.1,0.0,0.0,0.04,allen anderso guest,
-MATH,1060,209,Calculus of One Variable I,0.27,0.27,0.29,0.02,0.06,0.0,0.0,0.08,james brown,
-MATH,1060,212,Calculus of One Variable I,0.19,0.4,0.27,0.02,0.08,0.0,0.0,0.04,muhamm mohebujjaman,
-MATH,1060,217,Calculus of One Variable I,0.13,0.38,0.29,0.08,0.06,0.0,0.0,0.06,alistair bentley,
-MATH,1060,224,Calculus of One Variable I,0.17,0.33,0.33,0.02,0.07,0.0,0.0,0.07,irina viktorova,
-MATH,1060,225,Calc of One Variable I (RISE),0.24,0.28,0.22,0.02,0.15,0.0,0.0,0.09,"koshy chenthittayil,",
-MATH,1070,1,Differen and Integral Calculus,0.07,0.14,0.59,0.07,0.1,0.0,0.0,0.03,donna simms,
-MATH,1080,1,Calculus of One Variable II,0.09,0.22,0.13,0.04,0.35,0.0,0.0,0.17,terri johnson,
-MATH,1080,2,Calculus of One Variable II,0.03,0.28,0.07,0.0,0.31,0.0,0.0,0.31,timothy fra parrott,
-MATH,1080,5,Calculus of One Variable II,0.06,0.16,0.25,0.03,0.31,0.0,0.0,0.19,honghai xu,
-MATH,1080,6,Calculus of One Variable II,0.05,0.14,0.23,0.11,0.32,0.0,0.0,0.16,meredith nicol burr,
-MATH,1080,7,Calculus of One Variable II,0.13,0.22,0.11,0.07,0.2,0.0,0.0,0.27,meredith nicol burr,
-MATH,1080,8,Calculus of One Variable II,0.03,0.24,0.13,0.11,0.39,0.0,0.0,0.11,timothy fra parrott,
-MATH,1080,10,Calculus of One Variable II,0.0,0.1,0.13,0.13,0.45,0.0,0.0,0.2,mark cawood,
-MATH,1080,11,Calculus of One Variable II,0.08,0.19,0.28,0.06,0.33,0.0,0.0,0.06,honghai xu,
-MATH,1080,12,Calculus of One Variable II,0.06,0.08,0.17,0.06,0.14,0.0,0.0,0.5,nicole alai sinwell,
-MATH,1080,204,Calculus of One Variable II,0.13,0.39,0.1,0.1,0.0,0.0,0.0,0.29,timothy fra parrott,
-MATH,1150,1,Contemp Math for Elem Teach I,0.65,0.27,0.05,0.03,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1150,2,Contemp Math for Elem Teach I,0.79,0.17,0.03,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1160,1,Contemp Math for Elem Teach II,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,carlos gomez,
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.86,0.12,0.02,marion hanna,
-MATH,1990,401,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.04,0.02,marion hanna,
-MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,
-MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.0,marion hanna,
-MATH,2060,1,Calculus of Several Variables,0.31,0.33,0.18,0.03,0.13,0.0,0.0,0.03,akshay sunil gupte,
-MATH,2060,3,Calculus of Several Variables,0.13,0.1,0.28,0.0,0.15,0.0,0.0,0.33,jeong rock yoon,
-MATH,2060,4,Calculus of Several Variables,0.33,0.29,0.24,0.05,0.02,0.0,0.0,0.07,hiram lopez valdez,
-MATH,2060,5,Calculus of Several Variables,0.07,0.18,0.31,0.18,0.13,0.0,0.0,0.13,eleanor jenkins,
-MATH,2060,6,Calculus of Several Variables,0.23,0.27,0.25,0.1,0.08,0.0,0.0,0.06,hyesuk lee,
-MATH,2060,7,Calculus of Several Variables,0.24,0.21,0.32,0.0,0.11,0.0,0.0,0.13,gretchen matthews,
-MATH,2060,8,Calculus of Several Variables,0.14,0.22,0.16,0.14,0.12,0.0,0.0,0.2,shari prevost,
-MATH,2060,9,Calculus of Several Variables,0.24,0.13,0.33,0.13,0.13,0.0,0.0,0.04,hyesuk lee,
-MATH,2060,10,Calculus of Several Variables,0.39,0.13,0.26,0.0,0.13,0.0,0.0,0.08,gretchen matthews,
-MATH,2060,11,Calculus of Several Variables,0.17,0.17,0.1,0.22,0.22,0.0,0.0,0.12,julie lassiter,
-MATH,2060,12,Calculus of Several Variables,0.43,0.32,0.11,0.06,0.02,0.0,0.0,0.06,martin joha schmoll,
-MATH,2060,13,Calculus of Several Variables,0.07,0.18,0.25,0.2,0.18,0.0,0.0,0.11,shari prevost,
-MATH,2060,15,Calculus of Several Variables,0.1,0.19,0.21,0.17,0.14,0.0,0.0,0.19,julie lassiter,
-MATH,2060,16,Calculus of Several Variables,0.36,0.3,0.25,0.07,0.0,0.0,0.0,0.02,yuyuan ouyang,
-MATH,2060,17,Calculus of Several Variables,0.24,0.24,0.24,0.13,0.09,0.0,0.0,0.04,hyesuk lee,
-MATH,2060,18,Calculus of Several Variables,0.07,0.25,0.2,0.18,0.09,0.0,0.0,0.2,shari prevost,
-MATH,2060,20,Calculus of Several Variables,0.05,0.35,0.22,0.22,0.11,0.0,0.0,0.05,michael adam burr,
-MATH,2060,21,Calculus of Several Variables,0.16,0.37,0.13,0.16,0.11,0.0,0.0,0.08,michael adam burr,
-MATH,2060,22,Calculus of Several Variables,0.25,0.3,0.25,0.07,0.09,0.0,0.0,0.05,hiram lopez valdez,
-MATH,2060,23,Calculus of Several Variables,0.36,0.11,0.31,0.06,0.08,0.0,0.0,0.08,yuyuan ouyang,
-MATH,2060,24,Calculus of Several Variables,0.19,0.26,0.26,0.09,0.15,0.0,0.0,0.06,jonathon leverenz,
-MATH,2060,100,Calc of Several Vars (HON),0.52,0.28,0.14,0.0,0.03,0.0,0.0,0.03,james brown,True
-MATH,2070,1,Business Calculus II,0.31,0.19,0.19,0.06,0.19,0.0,0.0,0.06,yinggu bao,
-MATH,2070,2,Business Calculus II,0.11,0.28,0.44,0.06,0.11,0.0,0.0,0.0,liu zhu,
-MATH,2070,3,Business Calculus II,0.11,0.39,0.11,0.06,0.11,0.0,0.0,0.22,yinggu bao,
-MATH,2070,4,Business Calculus II,0.18,0.29,0.18,0.24,0.0,0.0,0.0,0.12,liu zhu,
-MATH,2070,5,Business Calculus II,0.26,0.26,0.31,0.02,0.05,0.0,0.0,0.1,jennifer mari hanna,
-MATH,2070,6,Business Calculus II,0.05,0.26,0.21,0.21,0.11,0.0,0.0,0.16,daniel kuzbary,
-MATH,2070,7,Business Calculus II,0.29,0.12,0.24,0.24,0.0,0.0,0.0,0.12,thanh thien to,
-MATH,2070,8,Business Calculus II,0.36,0.19,0.33,0.05,0.02,0.0,0.0,0.05,jennifer mari hanna,
-MATH,2070,9,Business Calculus II,0.26,0.37,0.11,0.11,0.05,0.0,0.0,0.11,travis baumbaugh,
-MATH,2070,10,Business Calculus II,0.21,0.42,0.26,0.0,0.11,0.0,0.0,0.0,tiantian yang,
-MATH,2070,11,Business Calculus II,0.31,0.31,0.31,0.02,0.0,0.0,0.0,0.05,jennifer mari hanna,
-MATH,2070,12,Business Calculus II,0.33,0.26,0.19,0.02,0.07,0.0,0.0,0.12,judith irene mcknew,
-MATH,2070,13,Business Calculus II,0.11,0.44,0.33,0.06,0.0,0.0,0.0,0.06,haodong li,
-MATH,2070,15,Business Calculus II,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,thanh thien to,
-MATH,2070,16,Business Calculus II,0.07,0.27,0.27,0.33,0.0,0.0,0.0,0.07,tiantian yang,
-MATH,2070,17,Business Calculus II,0.33,0.17,0.44,0.06,0.0,0.0,0.0,0.0,daniel kuzbary,
-MATH,2070,18,Business Calculus II,0.16,0.47,0.11,0.05,0.05,0.0,0.0,0.16,travis baumbaugh,
-MATH,2070,19,Business Calculus II,0.17,0.28,0.22,0.17,0.11,0.0,0.0,0.06,yibo xu,
-MATH,2070,20,Business Calculus II,0.06,0.19,0.5,0.13,0.0,0.0,0.0,0.13,haodong li,
-MATH,2070,21,Business Calculus II,0.35,0.24,0.29,0.12,0.0,0.0,0.0,0.0,yibo xu,
-MATH,2080,1,Intro to Ordin Diff Equations,0.08,0.32,0.21,0.03,0.11,0.0,0.0,0.26,oleg yordanov,
-MATH,2080,2,Intro to Ordin Diff Equations,0.19,0.3,0.21,0.06,0.15,0.0,0.0,0.09,timothy ch teitloff,
-MATH,2080,3,Intro to Ordin Diff Equations,0.48,0.15,0.21,0.06,0.06,0.0,0.0,0.03,oleg yordanov,
-MATH,2080,4,Intro to Ordin Diff Equations,0.33,0.26,0.23,0.03,0.05,0.0,0.0,0.1,mishko mitkovski,
-MATH,2080,5,Intro to Ordin Diff Equations,0.34,0.2,0.23,0.03,0.14,0.0,0.0,0.06,mishko mitkovski,
-MATH,2080,6,Intro to Ordin Diff Equations,0.25,0.39,0.08,0.06,0.11,0.0,0.0,0.11,timothy ch teitloff,
-MATH,2080,7,Intro to Ordin Diff Equations,0.14,0.29,0.23,0.11,0.17,0.0,0.0,0.06,timothy ch teitloff,
-MATH,2160,1,Geometry for Elem Sch Teachers,0.59,0.33,0.07,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,2160,2,Geometry for Elem Sch Teachers,0.76,0.21,0.0,0.03,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,2500,1,Intro to Mathematical Sciences,0.86,0.13,0.01,0.0,0.0,0.0,0.0,0.0,christopher cox,
-MATH,3020,1,Stat for Science & Engineering,0.16,0.62,0.14,0.0,0.05,0.0,0.0,0.03,taufiquar rahm khan,
-MATH,3020,2,Stat for Science & Engineering,0.74,0.24,0.03,0.0,0.0,0.0,0.0,0.0,xin liu,
-MATH,3020,3,Stat for Science & Engineering,0.53,0.21,0.0,0.05,0.11,0.0,0.0,0.11,yisu jia,
-MATH,3020,4,Stat for Science & Engineering,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,yisu jia,
-MATH,3020,5,Stat for Science & Engineering,0.36,0.36,0.11,0.03,0.11,0.0,0.0,0.03,brandon gra goodell,
-MATH,3020,6,Stat for Science & Engineering,0.36,0.5,0.06,0.0,0.03,0.0,0.0,0.06,calvin williams,
-MATH,3020,7,Stat for Science & Engineering,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.06,xiaoqian sun,
-MATH,3020,8,Stat for Science & Engineering,0.42,0.47,0.05,0.0,0.03,0.0,0.0,0.03,xiaoqian sun,
-MATH,3020,9,Stat for Science & Engineering,0.42,0.32,0.16,0.0,0.0,0.0,0.0,0.11,drew jared lipman,
-MATH,3020,10,Stat for Science & Engineering,0.26,0.37,0.26,0.0,0.05,0.0,0.0,0.05,christopher wilson,
-MATH,3020,11,Stat for Science & Engineering,0.32,0.37,0.16,0.05,0.05,0.0,0.0,0.05,yanbo xia,
-MATH,3020,12,Stat for Science & Engineering,0.29,0.29,0.35,0.0,0.0,0.0,0.0,0.06,yanbo xia,
-MATH,3110,1,Linear Algebra,0.11,0.4,0.26,0.03,0.06,0.0,0.0,0.14,hui xue,
-MATH,3110,2,Linear Algebra,0.12,0.35,0.18,0.15,0.03,0.0,0.0,0.18,felice manganiello,
-MATH,3110,3,Linear Algebra,0.34,0.09,0.2,0.2,0.06,0.0,0.0,0.11,felice manganiello,
-MATH,3110,4,Linear Algebra,0.21,0.49,0.13,0.08,0.08,0.0,0.0,0.03,hui xue,
-MATH,3110,5,Linear Algebra,0.29,0.31,0.23,0.06,0.09,0.0,0.0,0.03,wayne goddard,
-MATH,3110,6,Linear Algebra,0.23,0.37,0.34,0.03,0.0,0.0,0.0,0.03,boshi yang,
-MATH,3110,100,Linear Algebra (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,neil calkin,True
-MATH,3110,200,Linear Algebra,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,neil calkin,
-MATH,3160,1,Prob Solving for Math Teachers,0.88,0.09,0.0,0.0,0.0,0.0,0.0,0.02,andrew mic tyminski,
-MATH,3190,1,Introduction to Proof,0.17,0.43,0.17,0.13,0.09,0.0,0.0,0.0,elena sta dimitrova,
-MATH,3190,2,Introduction to Proof,0.52,0.24,0.12,0.0,0.08,0.0,0.0,0.04,elena sta dimitrova,
-MATH,3600,1,Intermediate Math Computing,0.83,0.06,0.0,0.03,0.03,0.0,0.0,0.06,mark cawood,
-MATH,3600,2,Intermediate Math Computing,0.63,0.16,0.0,0.05,0.05,0.0,0.0,0.11,mark cawood,
-MATH,3650,1,Numerical Mthds for Engineers,0.45,0.4,0.11,0.01,0.02,0.0,0.0,0.01,leo rebholz,
-MATH,3650,2,Numerical Mthds for Engineers,0.62,0.32,0.06,0.0,0.0,0.0,0.0,0.0,timo johann heister,
-MATH,4000,1,Theory of Probability,0.5,0.26,0.18,0.0,0.06,0.0,0.0,0.0,peter kiessler,
-MATH,4000,2,Theory of Probability,0.41,0.36,0.18,0.0,0.05,0.0,0.0,0.0,ling ma,
-MATH,4020,1,Stat for Sci & Engineering II,0.6,0.13,0.07,0.07,0.0,0.0,0.0,0.13,colin gallagher,
-MATH,4080,1,Secondary Math Analysis,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,eliza dar gallagher,
-MATH,4120,1,Algebra I,0.37,0.19,0.26,0.04,0.07,0.0,0.0,0.07,kevin james,
-MATH,4190,1,Discrete Math Structures I,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,beth novick,
-MATH,4190,2,Discrete Math Structures I,0.33,0.39,0.06,0.06,0.06,0.0,0.0,0.11,sea sather-wagstaff,
-MATH,4310,1,Theory of Interest,0.5,0.2,0.2,0.1,0.0,0.0,0.0,0.0, erwin walker,
-MATH,4340,1,Adv Engineering Mathematics,0.11,0.14,0.36,0.14,0.08,0.0,0.0,0.17,eleanor jenkins,
-MATH,4340,2,Adv Engineering Mathematics,0.16,0.16,0.26,0.13,0.16,0.0,0.0,0.13,vincent ervin,
-MATH,4350,1,Complex Variables,0.4,0.2,0.1,0.2,0.1,0.0,0.0,0.0,jeong rock yoon,
-MATH,4400,1,Linear Programming,0.22,0.26,0.22,0.07,0.11,0.0,0.0,0.11,boshi yang,
-MATH,4410,1,Intro to Stochastic Models,0.27,0.36,0.27,0.0,0.0,0.0,0.0,0.09,brian fralix,
-MATH,4500,1,Intro to Mathematical Models,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,matthew macauley,
-MATH,4530,1,Advanced Calculus I,0.25,0.29,0.29,0.04,0.08,0.0,0.0,0.04,james peterson,
-MATH,4530,2,Advanced Calculus I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james peterson,
-MATH,4540,1,Advanced Calculus II,0.3,0.2,0.2,0.25,0.0,0.0,0.0,0.05,shitao liu,
-MATH,6340,1,Adv Engineering Mathematics,0.41,0.33,0.22,0.0,0.04,0.0,0.0,0.0,vincent ervin,
-MATH,8000,1,Probability,0.5,0.35,0.05,0.0,0.1,0.0,0.0,0.0,peter kiessler,
-MATH,8010,1,General Linear Hypothesis I,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,derek brown,
-MATH,8050,1,Data Analysis,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,derek brown,
-MATH,8090,1,Time Series Analysis,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,8100,1,Mathematical Programming,0.48,0.36,0.04,0.0,0.08,0.0,0.0,0.04,warren adams,
-MATH,8120,1,Discrete Optimization,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
-MATH,8140,1,Network Flow Programming,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,matthew saltzman,
-MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
-MATH,8210,1,Linear Analysis,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,shitao liu,
-MATH,8410,1,Applied Mathematics I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,
-MATH,8510,1,Abstract Algebra I,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,sea sather-wagstaff,
-MATH,8530,1,Matrix Analysis,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,matthew macauley,
-MATH,8550,1,Combinatorial Analysis,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,
-MATH,8600,1,Intro to Scientific Computing,0.33,0.33,0.2,0.0,0.07,0.0,0.0,0.07,fei xue,
-MATH,8650,1,Data Structures,0.64,0.23,0.14,0.0,0.0,0.0,0.0,0.0,timo johann heister,
-MATH,9500,1,Commutative Algebra,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james ba coykendall,
-MBA,8030,1,Stat Analy of Bus Op,0.16,0.44,0.21,0.0,0.0,0.0,0.0,0.19,magda gabriela sava,
-MBA,8060,1,Operations Mgt,0.23,0.6,0.18,0.0,0.0,0.0,0.0,0.0, sridharan,
-MBA,8070,1,Financial Management,0.39,0.51,0.07,0.0,0.02,0.0,0.0,0.0,george bra lockhart,
-MBA,8090,1,Org Beh & Hum Res Mg,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8090,2,Org Beh & Hum Res Mg,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8180,20,Intro Business Intell & Anlytc,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,heshan sun,
-MBA,8190,1,Intro to Acc and Fin,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,melvin stith,
-MBA,8190,2,Intro to Acc and Fin,0.54,0.34,0.07,0.0,0.02,0.0,0.0,0.02,thomas springer,
-MBA,8290,1,Marketing Foundation,0.51,0.43,0.0,0.0,0.0,0.0,0.0,0.05,gary hunter,
-MBA,8310,5,Communications and Sales,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,gregory pickett,
-MBA,8330,1,Real Estate Investmt,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,
-MBA,8360,1,Real Estate Principles,0.35,0.52,0.09,0.0,0.0,0.0,0.0,0.04,jeffrey randolph,
-MBA,8370,1,Legal Environ of Bus,0.47,0.49,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
-MBA,8410,1,Real Estate Finance,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,wesley mcf blanding,
-MBA,8430,1,Entrepreneurial Accounting,0.14,0.68,0.18,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
-MBA,8450,1,Technology & Innovation Mgt,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8480,1,Entrpr Mkting & Digital Strat,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,
-MBA,8480,5,Entrpr Mkting & Digital Strat,0.81,0.15,0.0,0.0,0.04,0.0,0.0,0.0,bruce snyder,
-MBA,8490,5,Entrepreneurial Strategy,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,matthew charl klein,
-MBA,8510,1,Bus Operations & Logistics,0.23,0.59,0.18,0.0,0.0,0.0,0.0,0.0, sridharan,
-MBA,8540,1,Mgrl Accounting,0.44,0.44,0.07,0.0,0.0,0.0,0.0,0.05,james mil kohlmeyer,
-MBA,8590,1,Mgr Decision Model,0.4,0.33,0.17,0.0,0.0,0.0,0.0,0.1,sara elizabet yoder,
-MBA,8590,2,Mgr Decision Model,0.4,0.31,0.07,0.0,0.07,0.0,0.0,0.16,mark mcknew,
-MBA,8600,1,Advanced Marketing Strategy,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8600,2,Advanced Marketing Strategy,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8610,1,Information Systems,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MBA,8620,1,Managerial Economics,0.3,0.52,0.12,0.0,0.0,0.0,0.0,0.06,scott templeton,
-MBA,8620,2,Managerial Economics,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,
-MBA,8620,3,Managerial Economics,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,
-MBA,8650,1,Taxation of Business Decisions,0.25,0.63,0.04,0.0,0.04,0.0,0.0,0.04,judson jahn,
-MBA,8700,1,Strategic Management,0.46,0.49,0.03,0.0,0.0,0.0,0.0,0.03,james turner,
-MBA,8990,2,Creativity,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,
-MBA,8990,11,Social Media and Marketing,0.72,0.19,0.06,0.0,0.03,0.0,0.0,0.0,lura forcum,
-ME,2000,1,Sophomore Seminar,0.93,0.05,0.0,0.0,0.01,0.0,0.0,0.01,donald beasley,
-ME,2010,1,Statics & Dynamics,0.07,0.25,0.26,0.06,0.2,0.0,0.0,0.16,marisa kikendal orr,
-ME,2010,2,Statics & Dynamics,0.09,0.18,0.25,0.07,0.29,0.0,0.0,0.12,jorge iva rodriguez,
-ME,2010,3,Statics & Dynamics,0.04,0.13,0.3,0.14,0.28,0.0,0.0,0.1,paul joseph,
-ME,2030,1,Founda Th/Fl Syst,0.08,0.1,0.46,0.21,0.1,0.0,0.0,0.04,john saylor,
-ME,2030,2,Founda Th/Fl Syst,0.2,0.16,0.38,0.22,0.04,0.0,0.0,0.0,jay ochterbeck,
-ME,2040,1,Mechanics of Materials,0.11,0.49,0.3,0.06,0.03,0.0,0.0,0.0,garrett pataky,
-ME,2040,3,Mechanics of Materials,0.29,0.5,0.19,0.0,0.0,0.0,0.0,0.02,gang li,
-ME,2220,1,Mechanical Engineering Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,2220,2,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,3,Mechanical Engineering Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,4,Mechanical Engineering Lab I,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,5,Mechanical Engineering Lab I,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,6,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,7,Mechanical Engineering Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,8,Mechanical Engineering Lab I,0.33,0.27,0.4,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3030,1,Thermodynamics,0.3,0.43,0.21,0.04,0.0,0.0,0.0,0.02,daniel fant,
-ME,3030,2,Thermodynamics,0.46,0.33,0.19,0.01,0.01,0.0,0.0,0.0,daniel fant,
-ME,3030,3,Thermodynamics,0.18,0.61,0.18,0.0,0.0,0.0,0.0,0.03,yiqiang han,
-ME,3040,1,Heat Transfer,0.15,0.45,0.3,0.03,0.03,0.0,0.0,0.05,jean-marc delhaye,
-ME,3040,2,Heat Transfer,0.19,0.33,0.34,0.07,0.07,0.0,0.0,0.0,xin zhao,
-ME,3050,1,Model/an Dy Syst,0.23,0.42,0.25,0.02,0.05,0.0,0.0,0.03,joshua bostwick,
-ME,3050,2,Model/an Dy Syst,0.16,0.4,0.35,0.05,0.0,0.0,0.0,0.05,ardalan vahidi,
-ME,3060,1,Fund Machine Design,0.58,0.29,0.1,0.0,0.02,0.0,0.0,0.02,oliver myers,
-ME,3060,2,Fund Machine Design,0.23,0.58,0.13,0.0,0.04,0.0,0.0,0.02,paul jeffrey meyer,
-ME,3070,1,Found of Mechanical Systems,0.26,0.46,0.16,0.05,0.01,0.0,0.0,0.05,lonny thompson,
-ME,3070,2,Found of Mechanical Systems,0.15,0.46,0.26,0.05,0.08,0.0,0.0,0.0,georges fadel,
-ME,3080,1,Fluid Mechanics,0.22,0.4,0.32,0.04,0.02,0.0,0.0,0.0,xiangchun xuan,
-ME,3080,2,Fluid Mechanics,0.15,0.68,0.15,0.0,0.0,0.0,0.0,0.02,yiqiang han,
-ME,3080,3,Fluid Mechanics,0.13,0.25,0.5,0.03,0.08,0.0,0.0,0.0,ethan kung,
-ME,3120,2,Manuf Processes,0.69,0.25,0.05,0.0,0.0,0.0,0.0,0.01,rod martinez-duarte,
-ME,3330,1,Mechanical Engineering Lab II,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,2,Mechanical Engineering Lab II,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,3,Mechanical Engineering Lab II,0.12,0.71,0.06,0.0,0.0,0.0,0.0,0.12,todd schweisinger,
-ME,3330,4,Mechanical Engineering Lab II,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
-ME,3330,5,Mechanical Engineering Lab II,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,6,Mechanical Engineering Lab II,0.14,0.71,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
-ME,3330,7,Mechanical Engineering Lab II,0.44,0.31,0.25,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,8,Mechanical Engineering Lab II,0.3,0.3,0.2,0.0,0.0,0.0,0.0,0.2,todd schweisinger,
-ME,4000,1,Senior Seminar,0.83,0.14,0.01,0.01,0.0,0.0,0.0,0.0,donald beasley,
-ME,4010,1,Mech Engr Design,0.15,0.63,0.18,0.01,0.03,0.0,0.0,0.0,joshua summers,
-ME,4010,2,Mech Engr Design,0.2,0.69,0.05,0.0,0.07,0.0,0.0,0.0,cameron turner,
-ME,4020,1,Intern in Engr Des,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,
-ME,4020,2,Intern in Engr Des,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,
-ME,4020,3,Intern in Engr Des,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,4020,4,Intern in Engr Des,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4030,1,Control Dynamic Systems,0.17,0.38,0.4,0.03,0.0,0.0,0.0,0.02,yue wang,
-ME,4030,2,Control Dynamic Systems,0.23,0.41,0.22,0.07,0.01,0.0,0.0,0.05,suyi li,
-ME,4200,1,Ener Sources/Utiliz,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,donald beasley,
-ME,4210,1,Intro to Comp Flow,0.21,0.5,0.14,0.0,0.07,0.0,0.0,0.07,chenning tong,
-ME,4320,1,Adv Strength of Matl,0.1,0.39,0.45,0.0,0.03,0.0,0.0,0.03,huijuan zhao,
-ME,4400,1,Matls for Aggr Envir,0.88,0.11,0.02,0.0,0.0,0.0,0.0,0.0,ramasw subrahmanian,
-ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,3,Mechanical Engineering Lab III,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,4,Mechanical Engineering Lab III,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,5,Mechanical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,6,Mechanical Engineering Lab III,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,7,Mechanical Engineering Lab III,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,8,Mechanical Engineering Lab III,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4540,1,Design of Machine Elements,0.6,0.35,0.03,0.0,0.0,0.0,0.0,0.03,paul jeffrey meyer,
-ME,4930,7,Sel.Topics ME - Energy Harvest,0.25,0.4,0.15,0.1,0.0,0.0,0.0,0.1,mohammed fari daqaq,
-ME,6210,1,Intro to Comp Flow,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,chenning tong,
-ME,6320,1,Adv Strength of Matl,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,6930,13,SelTopics ME-MechSolids&Fluids,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
-ME,8010,1,Found of Fluid Mech,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,richard figliola,
-ME,8010,401,Found of Fluid Mech,0.31,0.54,0.0,0.0,0.0,0.0,0.0,0.15,richard figliola,
-ME,8100,1,Macroscopic Thermo,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,jay ochterbeck,
-ME,8180,1,Intro to Fin Ele Ana,0.27,0.63,0.08,0.0,0.0,0.0,0.0,0.02,gang li,
-ME,8230,1,Control Systems,0.37,0.42,0.16,0.0,0.05,0.0,0.0,0.0,yue wang,
-ME,8300,1,Cond/Rad Heat Tfr,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,
-ME,8460,1,Inter Dynamics,0.4,0.15,0.35,0.0,0.05,0.0,0.0,0.05,phanin tallapragada,
-ME,8700,1,Adv Design Methods,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,8710,1,Engr Optimization,0.61,0.33,0.03,0.0,0.03,0.0,0.0,0.0,georges fadel,
-ME,8930,4,SelectedTopics in ME - Adv Mfg,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-ME,8930,27,Sel Topics in ME - Optimize,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
-MGT,2010,1,Principles of Management,0.39,0.35,0.24,0.02,0.0,0.0,0.0,0.0,katherine clark,
-MGT,2010,2,Principles of Management,0.31,0.47,0.18,0.02,0.01,0.0,0.0,0.0,katherine clark,
-MGT,2010,3,Principles of Management,0.43,0.4,0.11,0.02,0.02,0.0,0.0,0.01,katherine clark,
-MGT,2010,4,Principles of Management,0.2,0.44,0.27,0.05,0.02,0.0,0.0,0.02,katherine clark,
-MGT,2010,5,Principles of Management,0.25,0.37,0.32,0.02,0.01,0.0,0.0,0.02,tina robbins,
-MGT,2010,6,Principles of Management,0.45,0.39,0.11,0.01,0.01,0.0,0.0,0.02,tina robbins,
-MGT,2010,7,Principles of Management,0.57,0.3,0.11,0.0,0.01,0.0,0.0,0.01,tina robbins,
-MGT,2010,8,Principles of Management,0.51,0.37,0.07,0.02,0.0,0.0,0.0,0.02,tina robbins,
-MGT,2010,9,Principles of Mgt(HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
-MGT,2010,10,Principles of Management,0.26,0.32,0.3,0.06,0.04,0.0,0.0,0.02,ashley will parnell,
-MGT,2010,11,Principles of Management,0.22,0.33,0.33,0.03,0.03,0.0,0.0,0.06,ashley will parnell,
-MGT,2180,1,Management PC Applications,0.83,0.09,0.02,0.02,0.03,0.0,0.0,0.02,ryan toole,
-MGT,2180,2,Management PC Applications,0.8,0.12,0.02,0.01,0.02,0.0,0.0,0.03,ryan toole,
-MGT,2180,3,Management PC Applications,0.77,0.13,0.01,0.05,0.0,0.0,0.0,0.03,ryan toole,
-MGT,2180,4,Management PC Applications,0.76,0.11,0.05,0.01,0.01,0.0,0.0,0.05,ryan toole,
-MGT,3070,1,Human Resource Management,0.23,0.46,0.26,0.03,0.0,0.0,0.0,0.03,priscilla harrison,
-MGT,3070,3,Human Resource Management,0.27,0.38,0.19,0.08,0.0,0.0,0.0,0.08,kristin dam scott,
-MGT,3070,4,Human Resource Management,0.4,0.45,0.08,0.05,0.0,0.0,0.0,0.03,michael cole,
-MGT,3070,5,Human Resource Management,0.58,0.4,0.03,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,6,Human Resource Management,0.4,0.53,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3100,1,Intermed Business Statistics,0.07,0.25,0.11,0.18,0.25,0.0,0.0,0.14,sara elizabet yoder,
-MGT,3100,2,Intermed Business Statistics,0.11,0.19,0.19,0.14,0.22,0.0,0.0,0.16,sara elizabet yoder,
-MGT,3100,3,Intermed Business Statistics,0.1,0.26,0.31,0.1,0.1,0.0,0.0,0.13,sara elizabet yoder,
-MGT,3100,5,Intermed Business Statistics,0.79,0.12,0.06,0.0,0.0,0.0,0.0,0.03,thomas simpson,
-MGT,3100,6,Intermed Business Statistics,0.3,0.33,0.25,0.03,0.05,0.0,0.0,0.05,janis miller,
-MGT,3100,7,Intermed Business Statistics,0.11,0.37,0.21,0.08,0.11,0.0,0.0,0.13,magda gabriela sava,
-MGT,3100,8,Intermed Business Statistics,0.45,0.24,0.12,0.05,0.07,0.0,0.0,0.07,min kyung lee,
-MGT,3100,9,Intermed Business Statistics,0.5,0.25,0.18,0.03,0.03,0.0,0.0,0.03,shih lun tseng,
-MGT,3100,10,Intermed Business Statistics,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,jackie patri london,
-MGT,3100,13,Intermed Business Statistics,0.13,0.3,0.3,0.07,0.03,0.0,0.0,0.17,daniel nielubowicz,
-MGT,3100,14,Intermed Business Statistics,0.32,0.39,0.08,0.11,0.0,0.0,0.0,0.11,iaroslava dutchak,
-MGT,3120,1,Decision Models for Management,0.28,0.17,0.24,0.07,0.15,0.0,0.0,0.09,mark mcknew,
-MGT,3120,2,Decision Models for Management,0.3,0.33,0.28,0.0,0.02,0.0,0.0,0.07,mark mcknew,
-MGT,3120,3,Decision Models for Management,0.27,0.34,0.3,0.02,0.05,0.0,0.0,0.02,mark mcknew,
-MGT,3150,1,New Venture Creation,0.49,0.41,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth er powell,
-MGT,3180,1,Mgt of Info Systems,0.25,0.43,0.28,0.0,0.0,0.0,0.0,0.05,russell purvis,
-MGT,3180,2,Mgt of Info Systems,0.14,0.45,0.38,0.0,0.0,0.0,0.0,0.02,roopa raman,
-MGT,3180,3,Mgt of Info Systems,0.41,0.46,0.1,0.0,0.03,0.0,0.0,0.0,daniel aaron pienta,
-MGT,3180,4,Mgt of Info Systems,0.59,0.3,0.04,0.04,0.0,0.0,0.0,0.02,tina marie esposito,
-MGT,3180,5,Mgt of Info Systems,0.37,0.47,0.05,0.0,0.11,0.0,0.0,0.0,heshan sun,
-MGT,3500,1,Intro to Business Analytics,0.3,0.52,0.11,0.04,0.0,0.0,0.0,0.04,siyuan li,
-MGT,3900,1,Ops Mgt,0.38,0.33,0.2,0.03,0.03,0.0,0.0,0.05,yann ferrand,
-MGT,3900,2,Ops Mgt,0.11,0.44,0.33,0.06,0.0,0.0,0.0,0.06,zachary mo leffakis,
-MGT,3900,3,Ops Mgt,0.08,0.36,0.31,0.08,0.15,0.0,0.0,0.03,berna quiroga gomez,
-MGT,3900,4,Ops Mgt,0.26,0.15,0.36,0.13,0.08,0.0,0.0,0.03,berna quiroga gomez,
-MGT,3900,5,Ops Mgt,0.45,0.32,0.21,0.0,0.0,0.0,0.0,0.03,remi charpin,
-MGT,4000,1,Mgt of Organizational Behavior,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,2,Mgt of Organizational Behavior,0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,3,Mgt of Organizational Behavior,0.28,0.53,0.2,0.0,0.0,0.0,0.0,0.0,philip roth,
-MGT,4020,1,Ops Pln and Ctl,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4080,1,Lean Operations,0.18,0.39,0.34,0.03,0.03,0.0,0.0,0.03,zachary mo leffakis,
-MGT,4110,1,Project Management,0.22,0.63,0.12,0.0,0.0,0.0,0.0,0.02,russell purvis,
-MGT,4150,1,Business Strategy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,dennis lee lester,
-MGT,4150,2,Business Strategy,0.34,0.64,0.02,0.0,0.0,0.0,0.0,0.0,dane patric blevins,
-MGT,4150,3,Business Strategy,0.51,0.43,0.06,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,4,Business Strategy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,6,Business Strategy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dane patric blevins,
-MGT,4150,7,Business Strategy,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,8,Business Strategy,0.21,0.59,0.21,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,9,Business Strategy,0.31,0.58,0.09,0.02,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4160,1,Special Topics Hr,0.19,0.62,0.08,0.04,0.04,0.0,0.0,0.04,kristin dam scott,
-MGT,4230,1,Intern Bus Mgt,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4230,2,Intern Bus Mgt,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4230,3,Intern Bus Mgt,0.23,0.4,0.15,0.18,0.05,0.0,0.0,0.0,janis miller,
-MGT,4230,4,Intern Bus Mgt,0.25,0.63,0.1,0.0,0.03,0.0,0.0,0.0,janis miller,
-MGT,4240,1,Global Supply Chain,0.19,0.48,0.29,0.03,0.0,0.0,0.0,0.0,yann ferrand,
-MGT,4270,1,Managing Improvement,0.16,0.53,0.31,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MGT,4300,3,Applied Entrepreneurship,0.55,0.3,0.1,0.0,0.0,0.0,0.0,0.05,chad navis,
-MGT,4300,4,Organizational Leadership,0.58,0.26,0.0,0.05,0.05,0.0,0.0,0.05,amy elizabet ingram,
-MGT,4310,1,Emp Rights & Resp,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,4350,1,Pers Interviewing,0.38,0.48,0.13,0.0,0.03,0.0,0.0,0.0,philip roth,
-MGT,4520,1,Business Analysis,0.17,0.44,0.33,0.0,0.0,0.0,0.0,0.06,roopa raman,
-MGT,4550,1,Emerging I T Trends,0.59,0.26,0.04,0.0,0.07,0.0,0.0,0.04,jason thatcher,
-MGT,4560,1,Business Info Mgt,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,siyuan li,
-MGT,8690,1,Project Mgt,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
-MGT,9050,1,Research Methods,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,varun grover,
-MICR,1010,1,Microbes & Hum Aff,0.85,0.11,0.02,0.0,0.0,0.0,0.0,0.02,jessica gale owens,
-MICR,2050,1,Introductory Micro,0.53,0.35,0.07,0.01,0.0,0.0,0.0,0.04,john abercrombie,
-MICR,3000,1,Essential Skills in Microbiol,0.82,0.13,0.02,0.0,0.02,0.0,0.0,0.02,tamara lyn mcnealy,
-MICR,3050,1,General Microbiology,0.44,0.39,0.15,0.01,0.01,0.0,0.0,0.01,krista barr rudolph,
-MICR,3050,2,General Microbiology,0.41,0.41,0.1,0.05,0.03,0.0,0.0,0.0,krista barr rudolph,
-MICR,4010,1,Microbial Diversity & Ecology,0.19,0.49,0.18,0.06,0.03,0.0,0.0,0.04,barbara campbell,
-MICR,4050,1,Adv Microbial Ecol of Humans,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4140,1,Basic Immunology,0.52,0.15,0.21,0.0,0.06,0.0,0.0,0.06,yanzhang wei,
-MICR,4150,1,Microbial Genetics,0.15,0.56,0.21,0.06,0.0,0.0,0.0,0.02,min cao,
-MICR,4160,1,Intro Virology,0.96,0.01,0.03,0.0,0.0,0.0,0.0,0.0,simon scott,
-MICR,4510,1,Advanced Microbiology II,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,thomas hughes,
-MICR,4510,3,Advanced Microbiology II,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,thomas hughes,
-MKT,3010,1,Prin of Marketing,0.25,0.35,0.31,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,
-MKT,3010,2,Prin of Marketing,0.3,0.46,0.19,0.02,0.01,0.0,0.0,0.03,carter wil mcelveen,
-MKT,3010,3,Prin of Marketing,0.25,0.43,0.25,0.06,0.01,0.0,0.0,0.0,amanda cooper fine,
-MKT,3010,4,Prin of Marketing,0.25,0.42,0.26,0.05,0.02,0.0,0.0,0.0,amanda cooper fine,
-MKT,3010,5,Prin of Marketing,0.31,0.39,0.2,0.04,0.02,0.0,0.0,0.03,amanda cooper fine,
-MKT,3010,6,Prin of Marketing,0.58,0.3,0.08,0.02,0.0,0.0,0.0,0.02,patricia knowles,
-MKT,3020,1,Consumer Behavior,0.5,0.4,0.06,0.04,0.0,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,2,Consumer Behavior,0.42,0.4,0.1,0.06,0.02,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,3,Consumer Behavior,0.32,0.34,0.14,0.1,0.08,0.0,0.0,0.02, thyroff fitzwater,
-MKT,3020,4,Consumer Behavior,0.28,0.58,0.04,0.02,0.04,0.0,0.0,0.04, thyroff fitzwater,
-MKT,3020,5,Consumer Behavior,0.4,0.27,0.18,0.11,0.04,0.0,0.0,0.0,oriana rache aragon,
-MKT,3210,1,Sports Marketing,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3210,2,Sports Marketing,0.57,0.41,0.0,0.0,0.0,0.0,0.0,0.02,delancy bennett,
-MKT,3310,1,Marketing Metrics & Analytics,0.74,0.17,0.07,0.0,0.02,0.0,0.0,0.0,oriana rache aragon,
-MKT,4200,1,Professional Selling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4200,2,Professional Selling,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,3,Professional Selling,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,jesse moore,
-MKT,4200,4,Professional Selling,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4200,5,Professional Selling,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,ryan mullins,
-MKT,4230,1,Promotional Strategy,0.42,0.39,0.12,0.02,0.02,0.0,0.0,0.03,patricia knowles,
-MKT,4240,1,Sales Management,0.5,0.48,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4260,1,Business-to-Business,0.38,0.43,0.17,0.02,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4260,2,Business-to-Business,0.47,0.41,0.07,0.0,0.02,0.0,0.0,0.03,james gaubert,
-MKT,4270,1,International Mktg,0.37,0.38,0.19,0.03,0.02,0.0,0.0,0.0,roger gomes,
-MKT,4270,2,International Mktg,0.24,0.42,0.29,0.02,0.0,0.0,0.0,0.02,roger gomes,
-MKT,4270,3,International Mktg,0.39,0.49,0.05,0.05,0.0,0.0,0.0,0.02,thomas poehlman,
-MKT,4280,1,Services Marketing,0.4,0.51,0.06,0.0,0.0,0.0,0.0,0.03,james gaubert,
-MKT,4310,1,Marketing Research,0.17,0.31,0.38,0.1,0.03,0.0,0.0,0.0,peter weathers,
-MKT,4310,2,Marketing Research,0.29,0.54,0.04,0.11,0.04,0.0,0.0,0.0,peter weathers,
-MKT,4310,3,Marketing Research,0.33,0.63,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,4,Marketing Research,0.48,0.44,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4430,1,Advertising Strategy,0.75,0.23,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,
-MKT,4450,1,Macromarketing,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,william kilbourne,
-MKT,4450,2,Macromarketing,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,william kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.23,0.55,0.19,0.03,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,2,Strategic Mktg Mgt,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4950,1,Social Media,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,8610,1,Marketing Research,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,8630,1,Buyer Behavior,0.36,0.61,0.0,0.0,0.0,0.0,0.0,0.04,thomas poehlman,
-ML,1010,3,Leadership Fund I,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,amanda carol kane,
-ML,2010,1,Leadership Development I,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,shane allen werst,
-ML,2010,2,Leadership Development I,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,shane allen werst,
-ML,3010,1,Advanced Leadership I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william cod cleland,
-ML,3010,2,Advanced Leadership I,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,william cod cleland,
-ML,4010,1,Organizational Leadership I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
-MSE,2100,1,Intro to Mat Science,0.36,0.23,0.23,0.07,0.08,0.0,0.0,0.04,rakhee pani,
-MSE,2100,2,Intro to Mat Science,0.12,0.53,0.2,0.07,0.04,0.0,0.0,0.04,eric skaar,
-MSE,2100,3,Intro to Mat Science,0.23,0.42,0.2,0.05,0.02,0.0,0.0,0.07,eric skaar,
-MSE,2100,4,Intro to Mat Science,0.31,0.3,0.21,0.12,0.01,0.0,0.0,0.05,bradley mat schultz,
-MSE,2100,5,Intro to Mat Science,0.54,0.29,0.11,0.07,0.0,0.0,0.0,0.0,olga kuksenok,
-MSE,3190,1,Materials Proc I,0.32,0.35,0.23,0.03,0.06,0.0,0.0,0.0,olin mefford,
-MSE,3190,2,Materials Proc I,0.62,0.32,0.04,0.0,0.0,0.0,0.0,0.02,olin mefford,
-MSE,3260,1,Thermo of Materials,0.31,0.53,0.14,0.0,0.0,0.0,0.0,0.03,gary lickfield,
-MSE,3260,2,Thermo of Materials,0.21,0.26,0.29,0.15,0.09,0.0,0.0,0.0,gary lickfield,
-MSE,3270,1,Transport Phenomena,0.52,0.36,0.05,0.02,0.01,0.0,0.0,0.04,fei peng,
-MSE,3270,2,Transport Phenomena,0.3,0.28,0.3,0.03,0.06,0.0,0.0,0.03,ulf daniel schiller,
-MSE,4020,1,Solid State Material,0.43,0.26,0.21,0.04,0.04,0.0,0.0,0.02,luiz gust jacobsohn,
-MSE,4070,1,Senior Capstone Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,
-MSE,4130,1,Noncrystalline Materials,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
-MSE,4150,1,Polymer Sc Engr,0.37,0.28,0.15,0.03,0.03,0.0,0.0,0.13,marek urban,
-MSE,4150,2,Polymer Sc Engr,0.55,0.27,0.11,0.0,0.04,0.0,0.0,0.04,olin mefford,
-MSE,4550,2,Polymer Fiber Lab,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,olin mefford,
-MSE,4550,3,Polymer Fiber Lab,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,olin mefford,
-MSE,4580,1,Surf Phen in Ms&E,0.09,0.52,0.27,0.12,0.0,0.0,0.0,0.0,konstantin kornev,
-MSE,4610,1,Polymer & Fiber Materials III,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,
-MSE,4910,1,Undergraduate Research,0.65,0.26,0.03,0.0,0.03,0.0,0.0,0.03,marian kennedy,
-MSE,8010,1,Grad Sem in Materials Research,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,kyle brinkman,
-MSE,8100,1,Fundamentals of Materials Sci,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,rajendra kum bordia,
-MSE,8260,1,Phase Equil Mat Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,stephen foulger,
-MSE,8270,1,Kin of Phase Tran,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,konstantin kornev,
-MUSC,1510,2,Applied Music,0.5,0.3,0.1,0.0,0.0,0.0,0.0,0.1,jonathan edwa doyel,
-MUSC,1520,1,Applied Music,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
-MUSC,2100,1,Music in the Western World,0.78,0.13,0.06,0.0,0.03,0.0,0.0,0.0,eric lapin,
-MUSC,2100,2,Music in the Western World,0.53,0.19,0.16,0.03,0.0,0.0,0.0,0.09,lisa sain odom,
-MUSC,2100,3,Music in the Western World,0.88,0.06,0.03,0.03,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,2100,4,Music in the Western World,0.47,0.16,0.09,0.19,0.06,0.0,0.0,0.03,linda li-bleuel,
-MUSC,2100,5,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,
-MUSC,2100,6,Music in the Western World,0.72,0.19,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
-MUSC,2100,7,Music in the Western World,0.41,0.53,0.03,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
-MUSC,2100,8,Music in the Western World,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,10,Music in the Western World,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda dzuris,
-MUSC,2100,12,Music in the Western World,0.5,0.28,0.13,0.06,0.0,0.0,0.0,0.03,lea kibler,
-MUSC,2100,15,Music in West World (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,True
-MUSC,3080,1,Surv of Broadway I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,lisa sain odom,
-MUSC,3110,1,History of American Music,0.59,0.25,0.09,0.06,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,3130,1,Hist of Rock & Roll,0.41,0.38,0.09,0.13,0.0,0.0,0.0,0.0,hamilton altstatt,
-MUSC,3170,1,Hist of Country Mus,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3610,1,Marching Band,0.97,0.01,0.0,0.0,0.0,0.0,0.0,0.02,mark spede,
-MUSC,3620,1,Symphonic Band,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,mark spede,True
-MUSC,3690,1,Symphony Orchestra,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,andrew levin,True
-MUSC,3700,1,Clemson University Singers,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,justin durham,
-MUSC,3710,1,Women's Chorus,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,justin durham,
-MUSC,4150,1,Music Hist to 1750,0.17,0.22,0.22,0.11,0.06,0.0,0.0,0.22,justin durham,
-NPL,3000,1,Nonprofit Leadership,0.45,0.39,0.03,0.1,0.03,0.0,0.0,0.0,bonnie west stevens,
-NPL,3000,3,Nonprofit Leadership,0.59,0.24,0.14,0.0,0.03,0.0,0.0,0.0,james dougl bennett,
-NPL,3000,4,Nonprofit Leadership,0.87,0.1,0.0,0.03,0.0,0.0,0.0,0.0,christina mar mazer,
-NPL,3000,5,Nonprofit Leadership,0.52,0.24,0.1,0.0,0.05,0.0,0.0,0.1,christina mar mazer,
-NPL,3000,6,Nonprofit Leadership,0.76,0.1,0.05,0.05,0.05,0.0,0.0,0.0,christina mar mazer,
-NPL,3020,1,NPL Fundraising,0.57,0.33,0.05,0.0,0.05,0.0,0.0,0.0,robert frager,
-NPL,3040,1,NPL Risk Management,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,anthony shau catone,
-NURS,3030,1,Nursing of Adults,0.2,0.75,0.05,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3040,1,Pathophysiology,0.39,0.43,0.11,0.07,0.0,0.0,0.0,0.0,catherine si murton,
-NURS,3040,400,Pathophysiology,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
-NURS,3040,401,Pathophysiology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
-NURS,3100,1,Health Assessment,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
-NURS,3100,400,Health Assessment,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,
-NURS,3120,1,Foundations of Nursing,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,angela pye,
-NURS,3120,400,Foundations of Nursing,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,
-NURS,3300,1,Research in Nursing,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,veronica parker,
-NURS,3330,400,Health Care Genetics,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,mary steck,
-NURS,3400,1,Pharmther Nursing,0.32,0.52,0.11,0.02,0.04,0.0,0.0,0.0,catherine si murton,
-NURS,3400,400,Pharmther Nursing,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,jenna lyn seawright,
-NURS,4030,200,Complex Nursing of Adults,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
-NURS,4030,400,Complex Nursing of Adults,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,
-NURS,4110,1,Nursing of Children,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,
-NURS,4120,1,Nurs Women and Fam,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4150,1,Community Health Nursing,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jackie gillespie,
-NURS,4250,200,Community Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
-NURS,8050,400,Pharmaco Adv Nurs,0.77,0.21,0.0,0.0,0.0,0.0,0.0,0.03,tracy king fasolino,
-NURS,8050,401,Pharmaco Adv Nurs,0.67,0.29,0.0,0.0,0.04,0.0,0.0,0.0,tracy king fasolino,
-NURS,8060,400,Advan Assessment for Nursing,0.43,0.52,0.0,0.0,0.05,0.0,0.0,0.0,rosanne pruitt,
-NURS,8090,400,Pathophysiology,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
-NURS,8180,400,Develop Family in Primary Care,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,
-NURS,8190,400,Developing Family,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,
-NURS,8200,400,Child & Adol Nursing,0.56,0.38,0.0,0.0,0.06,0.0,0.0,0.0,heide temples,
-NURS,8220,400,Gerontology Nursing,0.93,0.0,0.0,0.0,0.08,0.0,0.0,0.0,nicole joy davis,
-NURS,8280,400,The Nurse Educator,0.82,0.05,0.0,0.0,0.05,0.0,0.0,0.09,roxanne amerson,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.5,0.32,0.12,0.04,0.01,0.0,0.0,0.03,deborah an hutcheon,
-NUTR,2030,2,Intro Princ of Human Nutrition,0.76,0.16,0.03,0.0,0.01,0.0,0.0,0.03,deborah an hutcheon,
-NUTR,2050,1,Nutrition for Nursing Prof,0.82,0.17,0.01,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
-NUTR,2160,1,Evidence-Based Nutrition,0.78,0.15,0.04,0.02,0.0,0.0,0.0,0.0,angela fraser,
-NUTR,4240,1,Medical Nutr Thera I,0.32,0.54,0.14,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4510,1,Human Nutrition & Metabolism I,0.27,0.38,0.16,0.11,0.05,0.0,0.0,0.03,elliot jesch,
-PA,1010,1,Intro to Perf Arts,0.57,0.2,0.2,0.03,0.0,0.0,0.0,0.0,david hartmann,
-PA,1030,1,Portfolio I,0.71,0.26,0.0,0.03,0.0,0.0,0.0,0.0,linda dzuris,
-PA,2010,2,Career Planning and Prof Devel,0.8,0.1,0.0,0.1,0.0,0.0,0.0,0.0,shannon ther robert,
-PA,2790,1,Perf Arts Pract I,0.54,0.23,0.12,0.0,0.08,0.0,0.0,0.04,kenneth moore,
-PA,2800,1,Perf Arts Pract II,0.47,0.27,0.07,0.0,0.07,0.0,0.0,0.13,kenneth moore,
-PA,3010,1,Princip of Arts Administration,0.5,0.33,0.08,0.08,0.0,0.0,0.0,0.0,paul buyer,
-PADM,7020,401,Research Methods,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
-PADM,8210,400,Perspectives on Public Admin,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,
-PADM,8220,400,Public Policy Process,0.73,0.13,0.0,0.0,0.13,0.0,0.0,0.0,ek yazykova mellott,
-PADM,8270,400,Public Personnel Admin,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,lawrence nichols,
-PADM,8290,400,Public Financial Management,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,robert frager,
-PADM,8340,400,Administrative Law,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,andrew moorman,
-PADM,8670,400,State Government Admin,0.31,0.54,0.08,0.0,0.08,0.0,0.0,0.0,alfred bundrick,
-PAS,3010,1,Pan African Studies,0.36,0.36,0.16,0.04,0.03,0.0,0.0,0.05,abel bartley,
-PDBE,8150,1,Research Design in EDP,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mickey lauria,
-PES,1040,1,Introduction to Plant Sciences,0.64,0.33,0.0,0.0,0.0,0.0,0.0,0.03,paula agudelo,
-PES,2020,1,Soils,0.01,0.41,0.39,0.11,0.01,0.0,0.0,0.07,dara michelle park,
-PES,4090,1,Biology of Invasive Plants,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,tharayil-santhakumar,
-PHIL,1010,1,Intro to Philosophic Problems,0.27,0.69,0.0,0.0,0.04,0.0,0.0,0.0,kelly smith,
-PHIL,1010,3,Intro to Philosophic Problems,0.5,0.31,0.16,0.03,0.0,0.0,0.0,0.0,christopher grau,
-PHIL,1010,4,Intro to Philosophic Problems,0.61,0.12,0.09,0.0,0.06,0.0,0.0,0.12,david stegall,
-PHIL,1010,6,Intro to Philosophic Problems,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david stegall,
-PHIL,1020,1,Introduction to Logic,0.59,0.19,0.09,0.09,0.03,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,2,Introduction to Logic,0.76,0.18,0.03,0.03,0.0,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,3,Introduction to Logic,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
-PHIL,1020,4,Introduction to Logic,0.8,0.09,0.09,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,
-PHIL,1020,5,Introduction to Logic,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,
-PHIL,1020,6,Introduction to Logic,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,michael hal hannen,
-PHIL,1020,7,Introduction to Logic,0.63,0.29,0.06,0.0,0.03,0.0,0.0,0.0,john randall wolfe,
-PHIL,1020,8,Introduction to Logic,0.82,0.12,0.03,0.03,0.0,0.0,0.0,0.0,john randall wolfe,
-PHIL,1020,9,Introduction to Logic,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
-PHIL,1030,2,Introduction to Ethics,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,william maker,
-PHIL,1030,3,Introduction to Ethics,0.27,0.43,0.27,0.03,0.0,0.0,0.0,0.0,john jung park,
-PHIL,1030,4,Introduction to Ethics,0.36,0.43,0.18,0.04,0.0,0.0,0.0,0.0,john jung park,
-PHIL,1030,5,Introduction to Ethics,0.66,0.25,0.06,0.0,0.03,0.0,0.0,0.0,adam gies,
-PHIL,1030,7,Introduction to Ethics,0.76,0.15,0.09,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1030,8,Introduction to Ethics,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1030,10,Introduction to Ethics,0.18,0.59,0.18,0.06,0.0,0.0,0.0,0.0,john jung park,
-PHIL,1030,12,Introduction to Ethics,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,john jung park,
-PHIL,1030,13,Introduction to Ethics,0.35,0.48,0.1,0.0,0.06,0.0,0.0,0.0,daniel wueste,
-PHIL,3150,1,Ancient Philosophy,0.24,0.27,0.21,0.03,0.15,0.0,0.0,0.09,stephen satris,
-PHIL,3160,1,Modern Philosophy,0.52,0.33,0.09,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
-PHIL,3200,1,Soc and Pol Phil,0.53,0.12,0.18,0.0,0.06,0.0,0.0,0.12,john randall wolfe,
-PHIL,3240,1,Philosophy of Tech,0.44,0.31,0.16,0.09,0.0,0.0,0.0,0.0,william maker,
-PHIL,3260,1,Science and Values,0.53,0.31,0.06,0.0,0.06,0.0,0.0,0.03,andrew garnar,
-PHIL,3260,2,Science and Values,0.5,0.35,0.09,0.0,0.03,0.0,0.0,0.03,andrew garnar,
-PHIL,3330,1,Metaphysics,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,david stegall,
-PHIL,3440,1,Business Ethics,0.77,0.2,0.0,0.0,0.03,0.0,0.0,0.0,david stegall,
-PHIL,3450,1,Environmental Ethics,0.48,0.36,0.09,0.0,0.0,0.0,0.0,0.06,jennifer ingle,
-PHIL,3450,2,Environmental Ethics,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,jennifer ingle,
-PHIL,3460,1,Medical Ethics,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04,charles starkey,
-PHIL,3480,1,Philosophies of Art,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,christopher grau,
-PHIL,3490,1,Gender and Sexuality,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,jennifer ingle,
-PHIL,4920,1,Creative Inquiry in Philosophy,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,stephen satris,
-PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.84,0.11,0.03,0.02,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics with Calculus I,0.26,0.3,0.26,0.12,0.06,0.0,0.0,0.02,pooja puneet,
-PHYS,1220,2,Physics with Calculus I,0.34,0.28,0.21,0.07,0.06,0.0,0.0,0.04,pooja puneet,
-PHYS,1220,3,Physics W/Cal I (HON),0.57,0.35,0.04,0.04,0.0,0.0,0.0,0.0,hugo sanabria,True
-PHYS,1220,4,Physics with Calculus I,0.31,0.38,0.31,0.0,0.0,0.0,0.0,0.0,murray daw,
-PHYS,1220,500,Physics with Calculus I,0.31,0.5,0.19,0.0,0.0,0.0,0.0,0.0,elaine parshall,
-PHYS,1240,1,Physics Lab I,0.06,0.67,0.11,0.06,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,2,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,3,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,4,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,5,Physics Lab I,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,6,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,7,Physics Lab I,0.11,0.67,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,8,Physics Lab I,0.39,0.56,0.0,0.06,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,9,Physics Lab I,0.56,0.28,0.06,0.0,0.11,0.0,0.0,0.0,jerry hester,
-PHYS,1240,10,Physics Lab I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,11,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,14,Physics Lab I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,15,Physics Lab I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,16,Physics Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,17,Physics Lab I,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,18,Physics Lab I,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,19,Physics Lab I,0.22,0.61,0.06,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,500,Physics Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,elaine parshall,
-PHYS,2070,1,General Physics I,0.32,0.28,0.19,0.08,0.07,0.0,0.0,0.05,amy liann pope,
-PHYS,2070,2,General Physics I,0.4,0.44,0.09,0.04,0.01,0.0,0.0,0.02,amy liann pope,
-PHYS,2070,3,General Physics I,0.43,0.32,0.16,0.05,0.01,0.0,0.0,0.02,amy liann pope,
-PHYS,2080,1,General Physics II,0.33,0.39,0.18,0.03,0.05,0.0,0.0,0.02,lih-sin the,
-PHYS,2090,1,Gen Phys Lab I,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,2,Gen Phys Lab I,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,3,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,4,Gen Phys Lab I,0.29,0.63,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,5,Gen Phys Lab I,0.33,0.63,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,6,Gen Phys Lab I,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,7,Gen Phys Lab I,0.33,0.54,0.04,0.0,0.04,0.0,0.0,0.04,jerry hester,
-PHYS,2090,8,Gen Phys Lab I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,9,Gen Phys Lab I,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,10,Gen Phys Lab I,0.27,0.41,0.14,0.05,0.0,0.0,0.0,0.14,jerry hester,
-PHYS,2090,11,Gen Phys Lab I,0.38,0.48,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,12,Gen Phys Lab I,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,13,Gen Phys Lab I,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,14,Gen Phys Lab I,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,15,Gen Phys Lab I,0.17,0.63,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,16,Gen Phys Lab I,0.68,0.23,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,17,Gen Phys Lab I,0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,18,Gen Phys Lab I,0.67,0.25,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,19,Gen Phys Lab I,0.33,0.58,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,20,Gen Phys Lab I,0.19,0.52,0.24,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,21,Gen Phys Lab I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,22,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,
-PHYS,2090,23,Gen Phys Lab I,0.33,0.43,0.19,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,24,Gen Phys Lab I,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,1,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,2,Gen Phys Lab II,0.43,0.21,0.21,0.07,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,2100,4,Gen Phys Lab II,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,6,Gen Phys Lab II,0.52,0.3,0.09,0.04,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,7,Gen Phys Lab II,0.65,0.13,0.13,0.0,0.04,0.0,0.0,0.04,jerry hester,
-PHYS,2100,8,Gen Phys Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2210,1,Physics with Calculus II,0.13,0.44,0.28,0.1,0.03,0.0,0.0,0.02,jason stratfo brown,
-PHYS,2210,2,Physics with Calculus II,0.24,0.49,0.19,0.04,0.02,0.0,0.0,0.03,jason stratfo brown,
-PHYS,2210,3,Physics with Calculus II,0.34,0.53,0.11,0.01,0.01,0.0,0.0,0.0,jason stratfo brown,
-PHYS,2210,4,Physics with Calculus II,0.18,0.56,0.18,0.04,0.03,0.0,0.0,0.01,pooja puneet,
-PHYS,2210,7,Physics With Cal II (HON),0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,endre andras takacs,True
-PHYS,2220,1,Physics with Calculus III,0.32,0.35,0.16,0.0,0.03,0.0,0.0,0.13,jian he,
-PHYS,2230,1,Physics Lab II,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,2,Physics Lab II,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,3,Physics Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,4,Physics Lab II,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,2230,5,Physics Lab II,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,6,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,7,Physics Lab II,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,jerry hester,
-PHYS,2230,9,Physics Lab II,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,10,Physics Lab II,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,11,Physics Lab II,0.11,0.89,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,12,Physics Lab II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,13,Physics Lab II,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,2230,17,Physics Lab II,0.07,0.43,0.29,0.0,0.07,0.0,0.0,0.14,jerry hester,
-PHYS,2450,1,Physics of Climate,0.44,0.26,0.09,0.04,0.04,0.0,0.0,0.14,gerald lehmacher,
-PHYS,3000,1,Intro to Research,0.76,0.12,0.08,0.0,0.04,0.0,0.0,0.0,hugo sanabria,
-PHYS,3120,1,Meth Theor Phys II,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,feng ding,
-PHYS,3150,1,Intro to Computational Physics,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,emil georgie alexov,
-PHYS,3210,1,Mechanics I,0.16,0.26,0.26,0.16,0.05,0.0,0.0,0.11,joshua alper,
-PHYS,3250,1,Exper Physics I,0.42,0.47,0.05,0.0,0.0,0.0,0.0,0.05,chad sosolik,
-PHYS,4410,1,Electromagnetics I,0.27,0.18,0.27,0.18,0.0,0.0,0.0,0.09,joan marler,
-PHYS,4550,1,Quantum Physics I,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,ramakrishna podila,
-PHYS,8110,1,Meth of Theor Phys I,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,bradley meyer,
-PHYS,8210,1,Classical Mech I,0.18,0.55,0.27,0.0,0.0,0.0,0.0,0.0,jens oberheide,
-PHYS,9510,1,Quantum Mech I,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
-PKSC,1010,1,Pkgsc Orientation,0.79,0.11,0.08,0.0,0.02,0.0,0.0,0.0,robert truett moore,
-PKSC,1020,1,Intro to Pkg Sci,0.1,0.33,0.32,0.11,0.09,0.0,0.0,0.04,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2200,1,Product & Pkg Design,0.85,0.06,0.02,0.0,0.04,0.0,0.0,0.02,william aaro snyder,
-PKSC,3200,1,Pkg Design Theory,0.39,0.26,0.3,0.0,0.04,0.0,0.0,0.0,rupert hurley,
-PKSC,4010,1,Packaging Machinery,0.31,0.41,0.2,0.07,0.01,0.0,0.0,0.0,anthony lou pometto,
-PKSC,4030,1,Pkg Career Prep,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4040,1,Protective Packaging Prop/Prin,0.28,0.27,0.24,0.1,0.07,0.0,0.0,0.03,gregory batt,
-PKSC,4160,1,Appl Polymers in Pkg,0.16,0.52,0.23,0.06,0.03,0.0,0.0,0.0,duncan darby,
-PKSC,4200,1,Pkg Design & Dev,0.54,0.39,0.04,0.0,0.04,0.0,0.0,0.0,robert kimmel,
-PKSC,4230,400,3D Parametric Design Online,0.77,0.0,0.0,0.0,0.15,0.0,0.0,0.08,rupert hurley,
-PKSC,4540,1,Prod Pkg Evl Lab,0.38,0.19,0.19,0.13,0.06,0.0,0.0,0.06,gregory batt,
-PKSC,4540,2,Prod Pkg Evl Lab,0.13,0.25,0.13,0.06,0.38,0.0,0.0,0.06,gregory batt,
-PKSC,4540,3,Prod Pkg Evl Lab,0.56,0.19,0.06,0.0,0.19,0.0,0.0,0.0,gregory batt,
-PKSC,4540,4,Prod Pkg Evl Lab,0.25,0.31,0.25,0.0,0.19,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1,Food & Health Care Pkg Systems,0.53,0.28,0.06,0.0,0.14,0.0,0.0,0.0,kay cooksey,
-PKSC,6230,400,3D Parametic Design Online,0.67,0.0,0.17,0.0,0.0,0.0,0.0,0.17,rupert hurley,
-PLPA,3100,1,Principles of Plant Pathology,0.12,0.48,0.4,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,
-PLPA,8020,1,Ppls of Plant Pathology,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,
-POSC,1010,1,Amer National Govt,0.08,0.39,0.3,0.1,0.05,0.0,0.0,0.08,joseph earl stewart,
-POSC,1010,2,Amer National Govt,0.24,0.36,0.17,0.1,0.08,0.0,0.0,0.06,jeffrey scott peake,
-POSC,1020,1,Intro Intl Relations,0.33,0.43,0.13,0.06,0.02,0.0,0.0,0.04,tara elizabet trask,
-POSC,1020,2,Intro Intl Relations,0.22,0.26,0.3,0.09,0.05,0.0,0.0,0.08,zeynep taydas,
-POSC,1020,3,Intro Intl Relations,0.16,0.29,0.35,0.11,0.04,0.0,0.0,0.05,zeynep taydas,
-POSC,1020,4,Intro Intl Relations,0.16,0.29,0.36,0.12,0.03,0.0,0.0,0.03,joshua douglas king,
-POSC,1020,5,Intro Intl Relations,0.09,0.47,0.19,0.06,0.09,0.0,0.0,0.09,joshua douglas king,
-POSC,1030,1,Intro to Political Theory,0.05,0.26,0.21,0.37,0.03,0.0,0.0,0.08,james woodard,
-POSC,1030,2,Intro to Political Theory,0.25,0.29,0.25,0.11,0.07,0.0,0.0,0.02,brandon turner,
-POSC,1040,1,Intro Compar Pol,0.36,0.42,0.11,0.06,0.04,0.0,0.0,0.02,tara elizabet trask,
-POSC,1040,2,Intro Compar Pol,0.18,0.35,0.29,0.06,0.06,0.0,0.0,0.06,katherine am curtis,
-POSC,1990,1,Intro Pol Sci,0.4,0.33,0.08,0.09,0.06,0.0,0.0,0.05,meredith petersheim,
-POSC,3020,1,State and Loc Gov,0.12,0.58,0.1,0.02,0.02,0.0,0.0,0.16,bruce ransom,
-POSC,3410,1,Quant Meth in Pol Sc,0.06,0.17,0.33,0.22,0.17,0.0,0.0,0.06,steven vince miller,
-POSC,3610,1,Intl Pol in Crisis,0.4,0.4,0.1,0.04,0.04,0.0,0.0,0.02,vladimir matic,
-POSC,3630,1,Us Foreign Policy,0.29,0.24,0.22,0.14,0.1,0.0,0.0,0.0,steven vince miller,
-POSC,3710,1,European Politics,0.33,0.28,0.22,0.0,0.06,0.0,0.0,0.11,vladimir matic,
-POSC,3890,1,Religious Liberty & the Const.,0.29,0.64,0.0,0.0,0.07,0.0,0.0,0.0,daniel frost,
-POSC,4030,1,United States Congress,0.27,0.37,0.27,0.04,0.04,0.0,0.0,0.02,jeffrey allen fine,
-POSC,4070,1,Religion and Politic,0.17,0.46,0.26,0.03,0.06,0.0,0.0,0.03,laura olson,
-POSC,4210,1,Public Policy,0.06,0.13,0.25,0.19,0.19,0.0,0.0,0.19,adam warber,
-POSC,4230,1,Urban Politics,0.33,0.33,0.0,0.0,0.17,0.0,0.0,0.17,bruce ransom,
-POSC,4360,1,Law Courts Politics,0.66,0.19,0.04,0.0,0.02,0.0,0.0,0.09,joseph earl stewart,
-POSC,4380,1,Constitut Law: Struc of Gov,0.4,0.46,0.13,0.0,0.02,0.0,0.0,0.0,daniel frost,
-POSC,4420,1,Pol Parties & Elect,0.13,0.04,0.42,0.29,0.0,0.0,0.0,0.13,james woodard,
-POSC,4470,1,International Law,0.27,0.35,0.22,0.08,0.05,0.0,0.0,0.03,katherine am curtis,
-POSC,4490,1,Political Theory of Capitalism,0.45,0.14,0.1,0.02,0.2,0.0,0.0,0.08,brandon turner,
-POSC,4550,1,Pol Thght of American Founding,0.32,0.48,0.19,0.0,0.0,0.0,0.0,0.0, bradley thompson,
-POSC,4560,1,Diplomacy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
-POSC,4760,1,Middle East Politics,0.67,0.13,0.07,0.0,0.0,0.0,0.0,0.13,vladimir matic,
-POSC,4820,1,Political Novel and Film,0.11,0.42,0.47,0.0,0.0,0.0,0.0,0.0,james woodard,
-PRTM,2200,10,Foundations of PRTM,0.45,0.34,0.08,0.02,0.04,0.0,0.0,0.08,jamie lynn cathey,
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2260,2,Fnd of Mgt Adm PRTM,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,
-PRTM,2260,3,Fnd of Mgt Adm PRTM,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2260,4,Fnd of Mgt Adm PRTM,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
-PRTM,2260,5,Fnd of Mgt Adm PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2260,6,Fnd of Mgt Adm PRTM,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,harrison pinckney,
-PRTM,2260,7,Fnd of Mgt Adm PRTM,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2260,8,Fnd of Mgt Adm PRTM,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,kellie aman walters,
-PRTM,2270,1,Prov of Leisure Exp,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2270,2,Prov of Leisure Exp,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,
-PRTM,2270,3,Prov of Leisure Exp,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2270,4,Prov of Leisure Exp,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
-PRTM,2270,5,Prov of Leisure Exp,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2270,6,Prov of Leisure Exp,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,harrison pinckney,
-PRTM,2270,7,Prov of Leisure Exp,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2270,8,Prov of Leisure Exp,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,kellie aman walters,
-PRTM,2290,1,Competency Integration in PRTM,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2290,2,Competency Integration in PRTM,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,
-PRTM,2290,3,Competency Integration in PRTM,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2290,4,Competency Integration in PRTM,0.28,0.5,0.17,0.0,0.06,0.0,0.0,0.0,herbert chancellor,
-PRTM,2290,5,Competency Integration in PRTM,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2290,6,Competency Integration in PRTM,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,harrison pinckney,
-PRTM,2290,7,Competency Integration in PRTM,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2290,8,Competency Integration in PRTM,0.26,0.53,0.11,0.05,0.05,0.0,0.0,0.0,kellie aman walters,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.33,0.3,0.18,0.15,0.03,0.0,0.0,0.03,daniel mor anderson,
-PRTM,3070,2,Facility Operations,0.83,0.09,0.04,0.04,0.0,0.0,0.0,0.0,raymond dunham,
-PRTM,3200,1,Recreation Policy,0.25,0.45,0.2,0.1,0.0,0.0,0.0,0.0,lincoln larson,
-PRTM,3210,1,Recreation Admin,0.71,0.18,0.11,0.0,0.0,0.0,0.0,0.0,mariela fernandez,
-PRTM,3220,2,Facilitation Techniques in RT,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alysha amber walter,
-PRTM,3230,1,Prof Prep for RT Practice,0.91,0.0,0.0,0.0,0.05,0.0,0.0,0.04,stephen thoma lewis,
-PRTM,3240,1,Assessment & Planning in RT,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3240,2,Assessment & Planning in RT,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3250,1,Global Persp in Rec,0.42,0.26,0.19,0.13,0.0,0.0,0.0,0.0,mary price,
-PRTM,3300,1,Visit Ser & Interp,0.6,0.13,0.27,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,3420,2,Intro to Tourism,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,li-hsin chen,
-PRTM,3430,1,Spl Asp of Tourist B,0.35,0.48,0.11,0.0,0.05,0.0,0.0,0.0,william norman,
-PRTM,3470,1,Sport Tourism,0.35,0.35,0.2,0.05,0.0,0.0,0.0,0.05,gregory phi ramshaw,
-PRTM,3520,1,Camp Org and Admin,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,3900,6,Independent Study in PRTM,0.77,0.08,0.0,0.08,0.0,0.0,0.0,0.08,adam savedra,
-PRTM,3910,1,Social Media in PRTM,0.78,0.13,0.04,0.0,0.04,0.0,0.0,0.0,sheila backman,
-PRTM,3910,2,Issues & Trends in Event Mgmt.,0.72,0.16,0.08,0.04,0.0,0.0,0.0,0.0,stephanie per garst,
-PRTM,3910,3,Resort Management,0.76,0.19,0.0,0.0,0.05,0.0,0.0,0.0,jeffery martin,
-PRTM,3920,1,Special Event Management,0.69,0.2,0.1,0.0,0.0,0.0,0.0,0.02,kenneth backman,
-PRTM,3920,2,Special Event Management,0.8,0.16,0.02,0.0,0.0,0.0,0.0,0.02,kenneth backman,
-PRTM,3950,1,PGM Seminar III,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3980,2,Creative Inquiry in PRTM III,0.67,0.17,0.06,0.0,0.0,0.0,0.0,0.11,denise mar anderson,
-PRTM,3980,10,Creative Inquiry in PRTM III,0.59,0.21,0.14,0.07,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,4030,1,Elem of Rec/Pk Plan,0.43,0.36,0.21,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
-PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,
-PRTM,4220,1,Management of RT Services,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
-PRTM,4470,1,Perspect Intl Travel,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,lauren duffy,
-PRTM,4740,2,Adv Rec Resource Mgt,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey koo riungu,
-PRTM,4830,1,Golf Club Mgt & Ops,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,4950,1,Pro Golf Management Seminar IV,0.5,0.25,0.08,0.17,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,4980,10,Creative Inquiry in PRTM IV,0.59,0.21,0.14,0.07,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,8010,1,Phil Found of PRTM,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
-PRTM,8010,2,Phil Found of PRTM,0.5,0.36,0.0,0.0,0.05,0.0,0.0,0.09,dorothy schmalz,
-PRTM,8010,3,Phil Found of PRTM,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
-PRTM,8080,1,Behavioral Aspects,0.76,0.16,0.04,0.0,0.04,0.0,0.0,0.0,robert bixler,
-PRTM,8080,2,Behavioral Aspects,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,8220,2,Strateg Planning in PRTM Orgs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,
-PRTM,8710,1,Applied Research in Rec Therap,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
-PRTM,8710,4,Applied Research in Rec Therap,0.9,0.06,0.03,0.0,0.0,0.0,0.0,0.0,sarah taylor agate,
-PRTM,8750,1,Program Plan & Consult in RT,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
-PRTM,8750,2,Program Plan & Consult in RT,0.33,0.17,0.5,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
-PSYC,2010,1,Intro to Psychology,0.36,0.32,0.18,0.06,0.05,0.0,0.0,0.03,jo anne jorgensen,
-PSYC,2010,2,Intro to Psychology,0.37,0.32,0.17,0.05,0.03,0.0,0.0,0.05,jo anne jorgensen,
-PSYC,2010,3,Intro to Psychology,0.24,0.34,0.24,0.1,0.06,0.0,0.0,0.02,edwin brainerd,
-PSYC,2010,4,Intro to Psychology,0.45,0.29,0.16,0.06,0.04,0.0,0.0,0.0,fred switzer,
-PSYC,2010,5,Intro to Psychology,0.33,0.26,0.21,0.03,0.06,0.0,0.0,0.11,mary taylor,
-PSYC,2010,6,Intro to Psychology (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
-PSYC,2020,1,Intro Psychology Lab,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,jamie fynes,
-PSYC,2020,4,Intro Psychology Lab,0.8,0.04,0.0,0.04,0.12,0.0,0.0,0.0,madison eliza sauls,
-PSYC,2020,5,Intro Psychology Lab,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,william leidheiser,
-PSYC,2020,6,Intro Psychology Lab,0.77,0.15,0.0,0.0,0.04,0.0,0.0,0.04,william leidheiser,
-PSYC,3060,1,Human Sexual Beh,0.46,0.24,0.15,0.06,0.07,0.0,0.0,0.02,bruce michael king,
-PSYC,3090,100,Intro Exp Psych,0.51,0.23,0.14,0.08,0.04,0.0,0.0,0.0,patrick rosopa,
-PSYC,3090,200,Intro Exp Psych,0.4,0.2,0.1,0.03,0.23,0.0,0.0,0.03,jennifer bai bisson,
-PSYC,3090,300,Intro Exp Psych,0.57,0.23,0.07,0.07,0.03,0.0,0.0,0.03,stephen robertson,
-PSYC,3100,100,Advanced Experimental Psych,0.32,0.26,0.32,0.05,0.05,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimental Psych,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,robert campbell,
-PSYC,3100,300,Advanced Experimental Psych,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,benjamin stephens,
-PSYC,3100,400,Advanced Experimental Psych,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,leo gugerty,
-PSYC,3100,500,Advanced Experimental Psych,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3240,1,Physiological Psych,0.38,0.28,0.17,0.1,0.01,0.0,0.0,0.06,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.34,0.3,0.19,0.07,0.03,0.0,0.0,0.06,june pilcher,
-PSYC,3330,1,Cognitive Psych,0.42,0.39,0.11,0.03,0.01,0.0,0.0,0.03,leah hartman,
-PSYC,3330,2,Cognitive Psych,0.21,0.23,0.38,0.15,0.03,0.0,0.0,0.0,thomas alley,
-PSYC,3330,3,Cognitive Psych,0.16,0.33,0.31,0.16,0.02,0.0,0.0,0.03,thomas alley,
-PSYC,3340,1,Cognitive Psych Lab,0.68,0.23,0.09,0.0,0.0,0.0,0.0,0.0,laura whitlock,
-PSYC,3340,2,Cognitive Psych Lab,0.75,0.04,0.04,0.08,0.04,0.0,0.0,0.04,laura whitlock,
-PSYC,3400,1,Lifespan Developmental Psych,0.21,0.4,0.23,0.06,0.04,0.0,0.0,0.06,pamela alley,
-PSYC,3400,2,Lifespan Developmental Psych,0.62,0.28,0.09,0.0,0.01,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3520,1,Social Psychology,0.39,0.37,0.19,0.04,0.0,0.0,0.0,0.01,eric mckibben,
-PSYC,3640,1,Industrial Psych,0.3,0.51,0.17,0.0,0.0,0.0,0.0,0.01,eric mckibben,
-PSYC,3640,2,Industrial Psych,0.4,0.5,0.07,0.01,0.0,0.0,0.0,0.01,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.34,0.31,0.14,0.07,0.06,0.0,0.0,0.07,thomas britt,
-PSYC,3680,2,Organizational Psych,0.3,0.35,0.15,0.11,0.07,0.0,0.0,0.02,kristen su jennings,
-PSYC,3700,1,Personality,0.14,0.49,0.31,0.06,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,3830,1,Abnormal Psychology,0.28,0.4,0.14,0.13,0.02,0.0,0.0,0.02,cynthia pury,
-PSYC,3830,2,Abnormal Psychology,0.17,0.29,0.34,0.09,0.09,0.0,0.0,0.03,pamela alley,
-PSYC,3830,3,Abnormal Psychology,0.34,0.23,0.26,0.0,0.06,0.0,0.0,0.11,pamela alley,
-PSYC,3830,4,Abnormal Psychology,0.32,0.43,0.16,0.03,0.01,0.0,0.0,0.04,lucinda sorci quick,
-PSYC,4080,1,Women and Psychology,0.56,0.32,0.08,0.04,0.0,0.0,0.0,0.0,robin mari kowalski,
-PSYC,4150,1,Systems and Theories,0.27,0.53,0.1,0.07,0.03,0.0,0.0,0.0,brian day,
-PSYC,4150,2,Systems and Theories,0.41,0.18,0.26,0.06,0.03,0.0,0.0,0.06,edwin brainerd,
-PSYC,4150,3,Systems and Theories,0.39,0.25,0.25,0.0,0.08,0.0,0.0,0.03,edwin brainerd,
-PSYC,4220,1,Perception,0.3,0.39,0.09,0.09,0.09,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4220,2,Perception,0.5,0.17,0.21,0.08,0.0,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4220,3,Perception,0.26,0.37,0.22,0.15,0.0,0.0,0.0,0.0,christopher pagano,
-PSYC,4350,1,Human Factors,0.38,0.17,0.33,0.13,0.0,0.0,0.0,0.0,laura whitlock,
-PSYC,4430,1,Infant & Child Dev,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,4560,1,Psychophysiology,0.54,0.17,0.04,0.08,0.08,0.0,0.0,0.08,drew michael morris,
-PSYC,4710,1,Psych of Testing,0.46,0.21,0.21,0.08,0.04,0.0,0.0,0.0,robert ray sinclair,
-PSYC,4800,1,Health Psychology,0.5,0.38,0.08,0.0,0.04,0.0,0.0,0.0,james mccubbin,
-PSYC,4800,2,Health Psychology,0.56,0.36,0.0,0.0,0.04,0.0,0.0,0.04,james mccubbin,
-PSYC,4880,1,Psychotherapy,0.43,0.29,0.07,0.07,0.07,0.0,0.0,0.07,heidi marie zinzow,
-PSYC,4890,1,Teamwork in 21st Cen,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,william kramer,
-PSYC,4920,1,Senior Laboratory,0.68,0.2,0.08,0.04,0.0,0.0,0.0,0.0,drea kevin fekety,
-PSYC,4920,4,Senior Laboratory,0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,miranda pelkey,
-PSYC,4920,5,Senior Laboratory,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,dana verhoeven,
-PSYC,4920,6,Senior Laboratory,0.45,0.18,0.09,0.09,0.18,0.0,0.0,0.0,dana verhoeven,
-PSYC,8100,1,Research Design I,0.61,0.16,0.1,0.0,0.06,0.0,0.0,0.06, dewayne moore,
-PSYC,8220,1,Percept & Perform,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richard tyrrell,
-RED,8000,1,Real Estate Dvlpment,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,robert cre benedict,
-RED,8010,1,Market Analysis,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
-RED,8130,1,Strat in Real Estate,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,
-REL,1010,1,Intro to Religion,0.43,0.43,0.04,0.04,0.04,0.0,0.0,0.0,steven grosby,
-REL,1010,2,Intro to Religion,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,robert stephens,
-REL,1010,4,Intro to Religion,0.82,0.09,0.06,0.0,0.03,0.0,0.0,0.0,robert stephens,
-REL,1010,5,Intro to Religion,0.72,0.09,0.06,0.0,0.0,0.0,0.0,0.13,robert stephens,
-REL,1020,2,World Religions,0.22,0.17,0.33,0.06,0.06,0.0,0.0,0.17,peter cohen,
-REL,1020,3,World Religions,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,peter cohen,
-REL,1020,4,World Religions,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,peter cohen,
-REL,1020,5,World Religions,0.35,0.29,0.26,0.0,0.0,0.0,0.0,0.09,brett patterson,
-REL,1020,7,World Religions,0.42,0.33,0.17,0.0,0.0,0.0,0.0,0.08,brett patterson,
-REL,3010,1,Old Testament,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3060,1,Judaism,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3110,1,African American Rel,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,elizabeth jemison,
-REL,3130,1,Buddhism,0.68,0.21,0.0,0.05,0.0,0.0,0.0,0.05,robert stephens,
-REL,3150,1,Islam,0.5,0.31,0.06,0.0,0.0,0.0,0.0,0.13,mashal saif,
-REL,3300,1,Contemporary Issues,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mashal saif,
-REL,4010,1,Stud Biblical Literature & Rel,0.41,0.29,0.06,0.0,0.12,0.0,0.0,0.12,benjamin white,
-RS,3010,1,Rural Sociology,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
-RUSS,1010,1,Elementary Russian,0.26,0.26,0.26,0.11,0.11,0.0,0.0,0.0,olga anatol volkova,
-RUSS,3400,1,19th C Russ Culture,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,
-SOC,2010,2,Introduction to Sociology,0.72,0.2,0.06,0.0,0.01,0.0,0.0,0.01,andrew mannheimer,
-SOC,2010,3,Introduction to Sociology,0.73,0.18,0.04,0.02,0.0,0.02,0.0,0.0,andrew mannheimer,
-SOC,2010,4,Introduction to Sociology,0.28,0.51,0.11,0.04,0.01,0.0,0.0,0.04,carolyn can coffman,
-SOC,2010,5,Introduction to Sociology,0.26,0.45,0.23,0.06,0.0,0.0,0.0,0.0,carolyn can coffman,
-SOC,2010,6,Introduction to Sociology,0.28,0.55,0.15,0.02,0.0,0.0,0.0,0.0,carolyn can coffman,
-SOC,2010,7,Introduction to Sociology,0.34,0.4,0.13,0.06,0.0,0.0,0.0,0.06,mary louise barr,
-SOC,2010,8,Introduction to Sociology,0.56,0.27,0.13,0.02,0.02,0.0,0.0,0.0,mary louise barr,
-SOC,2010,9,Introduction to Sociology,0.5,0.3,0.16,0.02,0.0,0.0,0.0,0.02,mary louise barr,
-SOC,2010,10,Introduction to Sociology,0.43,0.39,0.13,0.03,0.0,0.0,0.0,0.01,mary louise barr,
-SOC,2010,11,Introduction to Sociology,0.57,0.3,0.11,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,12,Introduction to Sociology,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,13,Introduction to Sociology,0.6,0.28,0.08,0.01,0.02,0.0,0.0,0.01,shannon mcdonough,
-SOC,2010,14,Introduction to Sociology,0.71,0.2,0.06,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,15,Introduction to Sociology,0.71,0.21,0.02,0.02,0.02,0.0,0.0,0.02,shannon mcdonough,
-SOC,2010,16,Introduction to Sociology,0.47,0.43,0.04,0.04,0.0,0.0,0.0,0.02,tamela lea eitle,
-SOC,2010,17,Introduction to Sociology,0.4,0.46,0.08,0.02,0.02,0.0,0.0,0.02,tamela lea eitle,
-SOC,2050,1,Sociology Lab,0.54,0.15,0.15,0.0,0.15,0.0,0.0,0.0,brenda vander mey,
-SOC,2050,2,Sociology Lab,0.61,0.11,0.0,0.0,0.28,0.0,0.0,0.0,brenda vander mey,
-SOC,3020,1,Research Methods I,0.09,0.44,0.31,0.13,0.0,0.0,0.0,0.03,andrew whitehead,
-SOC,3040,1,Social Research Methods II,0.32,0.18,0.36,0.05,0.05,0.0,0.0,0.05,ye luo,
-SOC,3100,1,Marriage & Intimacy,0.52,0.17,0.13,0.07,0.04,0.0,0.0,0.07,carolyn can coffman,
-SOC,3110,1,The Family,0.15,0.28,0.26,0.18,0.1,0.0,0.0,0.03,andrew whitehead,
-SOC,3600,1,Class & Poverty,0.86,0.02,0.04,0.08,0.0,0.0,0.0,0.0,william wentworth,
-SOC,3880,1,Criminal Justice,0.32,0.16,0.36,0.16,0.0,0.0,0.0,0.0,margaret tina britz,
-SOC,3890,1,Criminology,0.15,0.21,0.26,0.12,0.06,0.0,0.0,0.21,william white,
-SOC,3910,1,Soc of Deviance,0.45,0.32,0.11,0.05,0.02,0.0,0.0,0.05,william white,
-SOC,3920,1,Juvenile Delinquency,0.41,0.35,0.18,0.0,0.0,0.0,0.0,0.06,william white,
-SOC,3940,1,Sociology of Mental Illness,0.48,0.41,0.02,0.0,0.07,0.0,0.0,0.02,marissa el yingling,
-SOC,3970,1,Substance Abuse,0.57,0.28,0.09,0.04,0.0,0.0,0.0,0.02,shannon mcdonough,
-SOC,4030,1,"Technol, Environment & Society",0.39,0.06,0.39,0.0,0.06,0.0,0.0,0.11, catherine mobley,
-SOC,4040,1,Soc Theory,0.54,0.29,0.15,0.0,0.02,0.0,0.0,0.0,william wentworth,
-SOC,4140,1,Policy&Social Change,0.45,0.25,0.25,0.0,0.05,0.0,0.0,0.0,marissa el yingling,
-SOC,4330,1,Global Social Change,0.77,0.15,0.0,0.04,0.04,0.0,0.0,0.0,william haller,
-SOC,4440,1,Sociology of Educ,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,
-SOC,4600,1,Race & Ethnicity,0.41,0.22,0.3,0.04,0.04,0.0,0.0,0.0,brenda vander mey,
-SOC,4680,1,Criminal Evidence,0.36,0.55,0.05,0.0,0.0,0.0,0.0,0.05,margaret tina britz,
-SOC,4810,1,Aging and Death,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,4970,1,Senior Lab,0.6,0.13,0.13,0.0,0.1,0.0,0.0,0.03,brenda vander mey,
-SOC,8030,1,Sur Dsgn App Res Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,
-SPAN,1010,1,Elementary Spanish,0.67,0.27,0.0,0.0,0.07,0.0,0.0,0.0,scott harris,
-SPAN,1010,2,Elementary Spanish,0.5,0.25,0.19,0.0,0.0,0.0,0.0,0.06,scott harris,
-SPAN,1010,3,Elementary Spanish,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1020,1,Elementary Spanish,0.26,0.26,0.26,0.0,0.05,0.0,0.0,0.16,maureen zamora,
-SPAN,1020,2,Elementary Spanish,0.35,0.29,0.12,0.12,0.0,0.0,0.0,0.12,maureen zamora,
-SPAN,1020,3,Elementary Spanish,0.41,0.18,0.12,0.12,0.0,0.0,0.0,0.18,maureen zamora,
-SPAN,1020,4,Elementary Spanish,0.29,0.41,0.06,0.0,0.0,0.0,0.0,0.24,maureen zamora,
-SPAN,1020,5,Elementary Spanish,0.29,0.35,0.0,0.0,0.06,0.0,0.0,0.29,maureen zamora,
-SPAN,1020,6,Elementary Spanish,0.44,0.25,0.19,0.0,0.06,0.0,0.0,0.06,cathy robison,
-SPAN,1020,7,Elementary Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,1020,8,Elementary Spanish,0.29,0.29,0.24,0.06,0.0,0.0,0.0,0.12,ana paula  miller,
-SPAN,1020,9,Elementary Spanish,0.31,0.19,0.19,0.13,0.06,0.0,0.0,0.13,ana paula  miller,
-SPAN,1020,10,Elementary Spanish,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,debra oa williamson,
-SPAN,1020,11,Elementary Spanish,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,1020,12,Elementary Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,1020,13,Elementary Spanish,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2010,1,Intermediate Spanish,0.47,0.21,0.26,0.0,0.0,0.0,0.0,0.05,cathy robison,
-SPAN,2010,2,Intermediate Spanish,0.24,0.59,0.12,0.06,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,3,Intermediate Spanish,0.53,0.24,0.24,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
-SPAN,2010,4,Intermediate Spanish,0.53,0.24,0.12,0.06,0.06,0.0,0.0,0.0,allison ann hinds,
-SPAN,2010,5,Intermediate Spanish,0.44,0.31,0.13,0.0,0.0,0.0,0.0,0.13,allison ann hinds,
-SPAN,2010,6,Intermediate Spanish,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,heidi montes,
-SPAN,2010,7,Intermediate Spanish,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,heidi montes,
-SPAN,2010,8,Intermediate Spanish,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,2010,9,Intermediate Spanish,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,2010,10,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
-SPAN,2010,11,Intermediate Spanish,0.27,0.6,0.13,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,2010,12,Intermediate Spanish,0.59,0.18,0.12,0.0,0.0,0.0,0.0,0.12,debra oa williamson,
-SPAN,2010,13,Intermediate Spanish,0.47,0.35,0.06,0.0,0.0,0.0,0.0,0.12,maureen zamora,
-SPAN,2010,14,Intermediate Spanish,0.61,0.22,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,
-SPAN,2010,15,Intermediate Spanish,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0, buitrago gonzalez,
-SPAN,2010,16,Intermediate Spanish,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
-SPAN,2010,18,Intermediate Spanish,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,nora arostegu logue,
-SPAN,2010,20,Intermediate Spanish (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,True
-SPAN,2020,1,Intermediate Spanish,0.47,0.33,0.07,0.07,0.0,0.0,0.0,0.07,heidi montes,
-SPAN,2020,2,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,3,Intermediate Spanish,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,4,Intermediate Spanish,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,heidi montes,
-SPAN,2020,5,Intermediate Spanish,0.53,0.16,0.26,0.0,0.05,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,6,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,2020,7,Intermediate Spanish,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,2020,8,Intermediate Spanish,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,2020,9,Intermediate Spanish,0.39,0.33,0.22,0.0,0.06,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,10,Intermediate Spanish,0.5,0.33,0.11,0.06,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,11,Intermediate Spanish,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,12,Intermediate Spanish,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,ze cruz valderramos,
-SPAN,2020,13,Intermediate Spanish,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,14,Intermediate Spanish,0.56,0.28,0.11,0.0,0.0,0.0,0.0,0.06,kari daus carson,
-SPAN,2020,15,Intermediate Spanish,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,kari daus carson,
-SPAN,3050,1,Int Con Comp Span I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,3050,2,Int Con Comp Span I,0.47,0.4,0.07,0.0,0.0,0.0,0.0,0.07,melva margu persico,
-SPAN,3050,3,Int Con Comp Span I,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,juana martin-armas,
-SPAN,3050,4,Int Con Comp Span I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,3060,1,Span Comp for Bus,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,maureen zamora,
-SPAN,3070,1,Hispanic World: Sp,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,salvador oropesa,
-SPAN,3070,2,Hispanic World: Sp,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,3080,1,Hispanic World: La,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,george palacios,
-SPAN,3130,1,Span Lit Survey I,0.32,0.16,0.0,0.0,0.05,0.0,0.0,0.47,mon rojas-de-massei,
-SPAN,3130,2,Span Lit Survey I,0.43,0.07,0.21,0.07,0.0,0.0,0.0,0.21,mon rojas-de-massei,
-SPAN,3140,1,Hispanic Linguistics,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,daniel smith,
-SPAN,3180,1,Span Through Culture,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,
-SPAN,4060,2,Narrative Fiction,0.44,0.19,0.38,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,
-SPAN,4090,1,Comp Writ in Span,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
-SPAN,4160,1,Span Intl Trade II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,4210,1,Sp-Am Mod & Postmod,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-SPAN,4220,1,Contem Span Am Novel,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,danie garcia vieyra,
-STAT,2220,1,Statistics in Everyday Life,0.35,0.35,0.15,0.1,0.03,0.0,0.0,0.02,james espey,
-STAT,2220,2,Statistics in Everyday Life,0.41,0.42,0.14,0.03,0.0,0.0,0.0,0.0,james espey,
-STAT,2220,3,Statistics in Everyday Life,0.45,0.23,0.3,0.0,0.02,0.0,0.0,0.0,james espey,
-STAT,2220,4,Statistics in Everyday Life,0.37,0.33,0.13,0.14,0.02,0.0,0.0,0.03,james espey,
-STAT,2220,5,Statistics in Everyday Life,0.33,0.41,0.17,0.07,0.0,0.0,0.0,0.02,ros martinez-dawson,
-STAT,2220,6,Statistics in Everyday Life,0.4,0.36,0.1,0.08,0.03,0.0,0.0,0.02,ros martinez-dawson,
-STAT,2220,7,Statistics in Everyday Life,0.32,0.42,0.16,0.05,0.05,0.0,0.0,0.0,andrew walton green,
-STAT,2220,8,Statistics in Everyday Life,0.32,0.37,0.16,0.05,0.0,0.0,0.0,0.11,lauren reig lembcke,
-STAT,2300,1,Statistical Methods I,0.26,0.3,0.18,0.13,0.09,0.0,0.0,0.04,christy jenki brown,
-STAT,2300,2,Statistical Methods I,0.26,0.36,0.23,0.08,0.06,0.0,0.0,0.02,christy jenki brown,
-STAT,2300,3,Statistical Methods I,0.3,0.38,0.15,0.12,0.04,0.0,0.0,0.0,christy jenki brown,
-STAT,2300,4,Statistical Methods I,0.29,0.34,0.17,0.08,0.08,0.0,0.0,0.03, erwin walker,
-STAT,2300,5,Statistical Methods I,0.22,0.4,0.21,0.08,0.04,0.0,0.0,0.03, erwin walker,
-STAT,2300,6,Statistical Methods I,0.19,0.3,0.25,0.09,0.11,0.0,0.0,0.06,april thomas,
-STAT,2300,8,Statistical Methods I,0.17,0.25,0.29,0.11,0.12,0.0,0.0,0.07,april thomas,
-STAT,3090,1,Introductory Business Stats,0.16,0.32,0.21,0.11,0.05,0.0,0.0,0.16,yijun chen,
-STAT,3090,2,Introductory Business Stats,0.21,0.42,0.16,0.0,0.05,0.0,0.0,0.16, morales hernandez,
-STAT,3090,4,Introductory Business Stats,0.28,0.19,0.33,0.14,0.03,0.0,0.0,0.03,sharon marie evans,
-STAT,3090,5,Introductory Business Stats,0.38,0.41,0.18,0.0,0.0,0.0,0.0,0.03,jennifer van dyken,
-STAT,3090,6,Introductory Business Stats,0.17,0.26,0.29,0.17,0.09,0.0,0.0,0.03,sharon marie evans,
-STAT,3090,7,Introductory Business Stats,0.37,0.32,0.11,0.16,0.0,0.0,0.0,0.05,yijun chen,
-STAT,3090,8,Introductory Business Stats,0.39,0.17,0.33,0.0,0.11,0.0,0.0,0.0, morales hernandez,
-STAT,3090,9,Introductory Business Stats,0.14,0.34,0.26,0.09,0.11,0.0,0.0,0.06,sharon marie evans,
-STAT,3090,10,Introductory Business Stats,0.06,0.33,0.39,0.11,0.06,0.0,0.0,0.06,andrew pangia,
-STAT,3090,11,Introductory Business Stats,0.28,0.25,0.22,0.11,0.08,0.0,0.0,0.06,sharon marie evans,
-STAT,3090,12,Introductory Business Stats,0.0,0.41,0.18,0.29,0.12,0.0,0.0,0.0,mengcong ren,
-STAT,3090,13,Introductory Business Stats,0.05,0.26,0.21,0.21,0.11,0.0,0.0,0.16,andrew pangia,
-STAT,3090,14,Introductory Business Stats,0.16,0.05,0.32,0.16,0.05,0.0,0.0,0.26,rui gong,
-STAT,3090,15,Introductory Business Stats,0.06,0.17,0.33,0.22,0.22,0.0,0.0,0.0,mengcong ren,
-STAT,3090,16,Introductory Business Stats,0.24,0.18,0.29,0.12,0.18,0.0,0.0,0.0,rui gong,
-STAT,3090,17,Introductory Business Stats,0.16,0.21,0.32,0.05,0.16,0.0,0.0,0.11,kayla doris javier,
-STAT,3090,18,Introductory Business Stats,0.13,0.44,0.19,0.25,0.0,0.0,0.0,0.0,sanjog arv kulkarni,
-STAT,3090,19,Introductory Business Stats,0.21,0.37,0.26,0.05,0.05,0.0,0.0,0.05,jason alexande kurz,
-STAT,3090,20,Introductory Business Stats,0.26,0.37,0.26,0.06,0.06,0.0,0.0,0.0,ellen hepfe breazel,
-STAT,3090,21,Introductory Business Stats,0.16,0.26,0.37,0.11,0.05,0.0,0.0,0.05,kayla doris javier,
-STAT,3090,22,Introductory Business Stats,0.32,0.32,0.16,0.05,0.11,0.0,0.0,0.05,boyoung hur,
-STAT,3090,23,Introductory Business Stats,0.23,0.29,0.4,0.06,0.03,0.0,0.0,0.0,ellen hepfe breazel,
-STAT,3090,24,Introductory Business Stats,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,sanjog arv kulkarni,
-STAT,3090,25,Introductory Business Stats,0.22,0.33,0.33,0.06,0.06,0.0,0.0,0.0,tao yang,
-STAT,3090,26,Introductory Business Stats,0.16,0.47,0.32,0.0,0.0,0.0,0.0,0.05,dilhani marasinghe,
-STAT,3090,27,Introductory Business Stats,0.21,0.21,0.26,0.16,0.0,0.0,0.0,0.16,paul james cubre,
-STAT,3090,28,Introductory Business Stats,0.16,0.32,0.26,0.11,0.11,0.0,0.0,0.05,boyoung hur,
-STAT,3090,29,Introductory Business Stats,0.26,0.26,0.32,0.05,0.11,0.0,0.0,0.0,jayasekara merenchig,
-STAT,3090,30,Introductory Business Stats,0.32,0.26,0.11,0.0,0.26,0.0,0.0,0.05,paul james cubre,
-STAT,3090,31,Introductory Business Stats,0.32,0.26,0.11,0.05,0.16,0.0,0.0,0.11,tao yang,
-STAT,3090,32,Introductory Business Stats,0.42,0.16,0.26,0.0,0.05,0.0,0.0,0.11,jason alexande kurz,
-STAT,3090,33,Introductory Business Stats,0.16,0.53,0.21,0.05,0.0,0.0,0.0,0.05,jayasekara merenchig,
-STAT,3090,34,Introductory Business Stats,0.11,0.42,0.37,0.0,0.05,0.0,0.0,0.05,dilhani marasinghe,
-STAT,3300,1,Statistical Methods II,0.32,0.23,0.09,0.14,0.05,0.0,0.0,0.18,ros martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,4110,1,Stat Mthds for Process Control,0.82,0.16,0.0,0.0,0.03,0.0,0.0,0.0,richard stev dubsky,
-STAT,4110,2,Stat Mthds for Process Control,0.48,0.35,0.13,0.0,0.03,0.0,0.0,0.0,james rieck,
-STAT,4110,3,Stat Mthds for Process Control,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,
-STAT,6020,1,Intro to Statistical Computing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,8010,1,Statistical Methods I,0.44,0.28,0.09,0.0,0.0,0.0,0.0,0.19,brook thaye russell,
-STAT,8010,2,Statistical Methods I,0.33,0.45,0.12,0.0,0.06,0.0,0.0,0.03,james rieck,
-STAT,8010,3,Statistical Methods I,0.49,0.29,0.11,0.0,0.09,0.0,0.0,0.03,jun luo,
-STAT,8010,4,Statistical Methods I,0.61,0.19,0.1,0.0,0.1,0.0,0.0,0.0,jun luo,
-STAT,8020,1,Statistical Methods II,0.61,0.36,0.0,0.0,0.0,0.0,0.0,0.04,william bridges,
-STS,1010,1,Survey of S T S,0.62,0.24,0.15,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-STS,1010,2,Survey of S T S,0.6,0.29,0.06,0.0,0.0,0.0,0.0,0.06,philip randall,
-STS,1010,3,Survey of S T S,0.42,0.52,0.03,0.03,0.0,0.0,0.0,0.0,scott brame,
-STS,1010,5,Survey of S T S,0.66,0.26,0.06,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,
-STS,1010,6,Survey of S T S,0.33,0.39,0.19,0.06,0.03,0.0,0.0,0.0,allison ann hinds,
-STS,1010,7,Survey of S T S,0.15,0.5,0.24,0.03,0.03,0.0,0.0,0.06,david charles foltz,
-STS,1010,8,Survey of S T S,0.36,0.5,0.06,0.0,0.0,0.0,0.0,0.08,megan no macalystre,
-STS,1010,9,Survey of S T S,0.6,0.29,0.06,0.03,0.03,0.0,0.0,0.0,sarah mae cooper,
-STS,1010,10,Survey of S T S,0.8,0.14,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
-THEA,2100,1,Theatre Appreciation,0.94,0.0,0.03,0.0,0.03,0.0,0.0,0.0,richard st. peter,
-THEA,2100,2,Theatre Appreciation,0.84,0.03,0.06,0.0,0.06,0.0,0.0,0.0,kerrie kath seymour,
-THEA,2100,3,Theatre Appreciation,0.53,0.22,0.25,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,2100,4,Theatre Appreciation,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,carol collins,
-THEA,2100,5,Theatre Appreciation,0.87,0.03,0.03,0.0,0.0,0.0,0.0,0.07,shannon ther robert,
-THEA,2100,6,Theatre Appreciation,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,
-THEA,2100,7,Theatre Appreciation,0.56,0.31,0.09,0.0,0.0,0.0,0.0,0.03,jason adkins,
-THEA,2780,1,Acting I,0.76,0.06,0.06,0.06,0.06,0.0,0.0,0.0,kerrie kath seymour,
-THEA,2790,1,Theatre Practicum,0.5,0.0,0.0,0.0,0.29,0.0,0.0,0.21,matthew leckenbusch,
-THEA,3170,1,African-Amer Thea I,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,kendra lyne johnson,
-THEA,4290,1,Dramatic Literature I,0.74,0.11,0.05,0.0,0.05,0.0,0.0,0.05,richard st. peter,
-THEA,4800,1,Advanced Scene Study,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,kerrie kath seymour,
-WFB,3000,1,Wildlife Biology,0.52,0.29,0.14,0.0,0.03,0.0,0.0,0.02,catherine jachowski,
-WFB,3000,2,Wildlife Biology,0.56,0.28,0.05,0.05,0.04,0.0,0.0,0.01,catherine jachowski,
-WFB,3010,2,Wildlife Biology Lab,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,4100,2,Wildlife Management Techniques,0.1,0.44,0.4,0.04,0.0,0.0,0.0,0.02,james davis,
-WFB,4180,1,Fishery Conservation,0.67,0.19,0.1,0.0,0.05,0.0,0.0,0.0,yoichiro kanno,
-WFB,4440,1,Wildlife Damage Management,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,james davis,
-WFB,4930,1,Waterfowl Ecology & Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
-WFB,4930,2,Plant & Flora ID/Systematics,0.46,0.41,0.11,0.02,0.0,0.0,0.0,0.0,patrick mcmillan,
-WS,1030,1,Women in Global Perspective,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,laura foxworth,
-WS,1030,2,Women in Global Perspective,0.79,0.18,0.0,0.0,0.03,0.0,0.0,0.0,laura foxworth,
-WS,2300,1,Women and Leadership,0.64,0.14,0.0,0.07,0.14,0.0,0.0,0.0,diane perpich,
-WS,3010,1,Intro Women's Studies,0.63,0.17,0.06,0.03,0.03,0.0,0.0,0.09,elizabeth ros adams,
-WS,3010,2,Intro Women's Studies,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,elizabeth ros adams,
-WS,4900,1,Creative Inquiry,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,diane perpich,
-YDP,3000,400,Youth Development in Society,0.82,0.06,0.06,0.0,0.0,0.0,0.0,0.06,barry garst,
-YDP,3050,400,Theory/Phil of Youth Dev Work,0.63,0.19,0.06,0.06,0.0,0.0,0.0,0.06,edmond patri bowers,
-YDP,3450,1,Creative Activities for Youth,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kimberly pe johnson,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1010,1,Survey of Art & Arch History I,0.31,0.44,0.23,0.02,0.0,0.0,0.0,0.01,beth ann lauritis,,AAH-1010,2016
+AAH,2050,1,Art History and Theory I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,beth ann lauritis,,AAH-2050,2016
+ACCT,2010,1,Financial Accounting Concepts,0.03,0.25,0.35,0.15,0.08,0.0,0.0,0.15,philip maiberger,,ACCT-2010,2016
+ACCT,2010,2,Financial Accounting Concepts,0.18,0.38,0.28,0.05,0.03,0.0,0.0,0.08,philip maiberger,,ACCT-2010,2016
+ACCT,2010,3,Financial Accounting Concepts,0.24,0.44,0.2,0.04,0.04,0.0,0.0,0.04,lydia lan schleifer,,ACCT-2010,2016
+ACCT,2010,4,Financial Accounting Concepts,0.2,0.33,0.2,0.1,0.08,0.0,0.0,0.1,annieka philo,,ACCT-2010,2016
+ACCT,2010,5,Financial Accounting Concepts,0.24,0.43,0.2,0.06,0.04,0.0,0.0,0.02,lydia lan schleifer,,ACCT-2010,2016
+ACCT,2010,6,Financial Accounting Concepts,0.12,0.52,0.21,0.03,0.09,0.0,0.0,0.03,the estate  guffey,,ACCT-2010,2016
+ACCT,2010,7,Financial Accounting Concepts,0.26,0.36,0.16,0.08,0.04,0.0,0.0,0.1,annieka philo,,ACCT-2010,2016
+ACCT,2010,9,Financial Accounting Concepts,0.32,0.15,0.23,0.04,0.11,0.0,0.0,0.15,lydia lan schleifer,,ACCT-2010,2016
+ACCT,2010,10,Financial Accounting Concepts,0.17,0.26,0.26,0.13,0.11,0.0,0.0,0.07,lydia lan schleifer,,ACCT-2010,2016
+ACCT,2010,11,Financial Accounting Concepts,0.13,0.33,0.29,0.06,0.1,0.0,0.0,0.08,annieka philo,,ACCT-2010,2016
+ACCT,2010,12,Financial Accounting Concepts,0.07,0.29,0.29,0.09,0.16,0.0,0.0,0.11,annieka philo,,ACCT-2010,2016
+ACCT,2010,13,Financial Accounting Concepts,0.09,0.33,0.24,0.04,0.04,0.0,0.0,0.24,mary ann  prater,,ACCT-2010,2016
+ACCT,2010,14,Financial Accounting Concepts,0.19,0.19,0.14,0.07,0.12,0.0,0.0,0.29,mary ann  prater,,ACCT-2010,2016
+ACCT,2010,15,Financial Accounting Concepts,0.15,0.33,0.11,0.19,0.15,0.0,0.0,0.07,charles tegen,,ACCT-2010,2016
+ACCT,2010,100,Fin Accounting Concepts (HON),0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,the estate  guffey,True,ACCT-2010,2016
+ACCT,2010,101,Fin Accounting Concepts (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,the estate  guffey,True,ACCT-2010,2016
+ACCT,2010,400,Financial Accounting Concepts,0.23,0.35,0.16,0.05,0.1,0.0,0.0,0.11,jeffrey mcmillan,,ACCT-2010,2016
+ACCT,2020,1,Managerial Accounting Concepts,0.15,0.27,0.33,0.12,0.06,0.0,0.0,0.06,henry anderson,,ACCT-2020,2016
+ACCT,2020,2,Managerial Accounting Concepts,0.19,0.21,0.17,0.17,0.1,0.0,0.0,0.17,henry anderson,,ACCT-2020,2016
+ACCT,2020,3,Managerial Accounting Concepts,0.44,0.24,0.2,0.06,0.03,0.0,0.0,0.03,sarah martin,,ACCT-2020,2016
+ACCT,2020,4,Managerial Accounting Concepts,0.18,0.32,0.2,0.08,0.08,0.0,0.0,0.14,the estate  guffey,,ACCT-2020,2016
+ACCT,2020,5,Managerial Accounting Concepts,0.1,0.45,0.19,0.06,0.1,0.0,0.0,0.1,brian todd carver,,ACCT-2020,2016
+ACCT,2020,7,Managerial Accounting Concepts,0.23,0.42,0.23,0.07,0.02,0.0,0.0,0.02,derek dalton,,ACCT-2020,2016
+ACCT,2020,8,Managerial Accounting Concepts,0.23,0.34,0.32,0.07,0.02,0.0,0.0,0.02,nancy lee harp,,ACCT-2020,2016
+ACCT,2020,400,Managerial Accounting Concepts,0.12,0.24,0.25,0.1,0.06,0.0,0.0,0.24,henry anderson,,ACCT-2020,2016
+ACCT,3030,1,Cost Accounting,0.35,0.4,0.17,0.04,0.04,0.0,0.0,0.0,robin radtke,,ACCT-3030,2016
+ACCT,3030,2,Cost Accounting,0.4,0.36,0.14,0.05,0.02,0.0,0.0,0.02,robin radtke,,ACCT-3030,2016
+ACCT,3030,3,Cost Accounting,0.44,0.23,0.17,0.02,0.06,0.0,0.0,0.08,jace garrett,,ACCT-3030,2016
+ACCT,3030,4,Cost Accounting,0.31,0.31,0.12,0.12,0.0,0.0,0.0,0.15,jace garrett,,ACCT-3030,2016
+ACCT,3110,1,Intermediate Financial Acct I,0.41,0.32,0.08,0.08,0.08,0.0,0.0,0.03,terry daniel knause,,ACCT-3110,2016
+ACCT,3110,2,Intermediate Financial Acct I,0.41,0.24,0.15,0.05,0.02,0.0,0.0,0.12,terry daniel knause,,ACCT-3110,2016
+ACCT,3110,3,Intermediate Financial Acct I,0.39,0.24,0.24,0.06,0.03,0.0,0.0,0.03,terry daniel knause,,ACCT-3110,2016
+ACCT,3110,4,Intermediate Financial Acct I,0.31,0.45,0.21,0.02,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3110,2016
+ACCT,3110,5,Intermediate Financial Acct I,0.26,0.16,0.21,0.03,0.26,0.0,0.0,0.08,henry anderson,,ACCT-3110,2016
+ACCT,3110,400,Intermediate Financial Acct I,0.16,0.24,0.12,0.04,0.28,0.0,0.0,0.16,henry anderson,,ACCT-3110,2016
+ACCT,3120,1,Intermediate Financial Acct II,0.06,0.31,0.29,0.2,0.06,0.0,0.0,0.09,brian todd carver,,ACCT-3120,2016
+ACCT,3120,2,Intermediate Financial Acct II,0.21,0.31,0.23,0.18,0.05,0.0,0.0,0.03,brian todd carver,,ACCT-3120,2016
+ACCT,3120,3,Intermediate Financial Acct II,0.08,0.49,0.26,0.13,0.03,0.0,0.0,0.03,jeremy micha vinson,,ACCT-3120,2016
+ACCT,3120,4,Intermediate Financial Acct II,0.35,0.28,0.23,0.1,0.05,0.0,0.0,0.0,jeremy micha vinson,,ACCT-3120,2016
+ACCT,3120,5,Intermediate Financial Acct II,0.13,0.58,0.24,0.0,0.0,0.0,0.0,0.05,jeremy micha vinson,,ACCT-3120,2016
+ACCT,3130,1,Intermediate Fin Acct III,0.31,0.47,0.14,0.0,0.06,0.0,0.0,0.03, russell madray,,ACCT-3130,2016
+ACCT,3130,2,Intermediate Fin Acct III,0.63,0.21,0.12,0.02,0.0,0.0,0.0,0.02, russell madray,,ACCT-3130,2016
+ACCT,3130,3,Intermediate Fin Acct III,0.52,0.33,0.12,0.0,0.02,0.0,0.0,0.0, russell madray,,ACCT-3130,2016
+ACCT,3130,4,Intermediate Fin Acct III,0.56,0.34,0.05,0.0,0.05,0.0,0.0,0.0, russell madray,,ACCT-3130,2016
+ACCT,3220,2,Accounting Information Systems,0.23,0.5,0.19,0.04,0.04,0.0,0.0,0.0,nancy lee harp,,ACCT-3220,2016
+ACCT,3220,3,Accounting Information Systems,0.12,0.38,0.24,0.14,0.05,0.0,0.0,0.07,nancy lee harp,,ACCT-3220,2016
+ACCT,4040,1,Individual Taxation,0.74,0.12,0.03,0.06,0.06,0.0,0.0,0.0,sarah martin,,ACCT-4040,2016
+ACCT,4040,2,Individual Taxation,0.82,0.08,0.05,0.05,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2016
+ACCT,4040,3,Individual Taxation,0.21,0.44,0.26,0.05,0.0,0.0,0.0,0.05,derek dalton,,ACCT-4040,2016
+ACCT,4080,1,Retire & Estate Plan,0.27,0.5,0.18,0.0,0.05,0.0,0.0,0.0,john hine,,ACCT-4080,2016
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.31,0.44,0.21,0.03,0.03,0.0,0.0,0.0,sally kathr widener,,ACCT-4100,2016
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.08,0.44,0.32,0.04,0.04,0.0,0.0,0.08,sally kathr widener,,ACCT-4100,2016
+ACCT,4150,1,Auditing,0.52,0.28,0.2,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2016
+ACCT,4150,2,Auditing,0.06,0.44,0.38,0.06,0.0,0.0,0.0,0.06,carl hollingsworth,,ACCT-4150,2016
+ACCT,8510,1,Tax Research,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2016
+ACCT,8510,2,Tax Research,0.22,0.68,0.08,0.0,0.0,0.0,0.0,0.03,thomas dickens,,ACCT-8510,2016
+ACCT,8510,3,Tax Research,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2016
+ACCT,8530,1,Adv Acct Problems,0.56,0.38,0.03,0.0,0.0,0.0,0.0,0.03,ralph welton,,ACCT-8530,2016
+ACCT,8530,2,Adv Acct Problems,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8530,2016
+ACCT,8530,3,Adv Acct Problems,0.62,0.32,0.03,0.0,0.03,0.0,0.0,0.0,suzanne pearse,,ACCT-8530,2016
+ACCT,8550,1,Gov't and Nonprofit Accounting,0.6,0.37,0.04,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2016
+ACCT,8550,2,Gov't and Nonprofit Accounting,0.65,0.33,0.0,0.0,0.0,0.0,0.0,0.02,james barnes,,ACCT-8550,2016
+ACCT,8630,1,Forensics Analysis,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,philip maiberger,,ACCT-8630,2016
+ACCT,8630,2,Forensics Analysis,0.44,0.49,0.05,0.0,0.0,0.0,0.0,0.03,philip maiberger,,ACCT-8630,2016
+ACCT,8650,1,Tax & Bus Decisions,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,,ACCT-8650,2016
+ACCT,8720,1,Tax of Flowthroughs,0.17,0.43,0.33,0.0,0.07,0.0,0.0,0.0,thomas dickens,,ACCT-8720,2016
+AGED,1020,1,Freshman Seminar,0.68,0.21,0.07,0.0,0.0,0.0,0.0,0.04,catheri dibenedetto,,AGED-1020,2016
+AGED,2010,1,Intro to Agric Educ,0.43,0.24,0.24,0.05,0.05,0.0,0.0,0.0,philip fravel,,AGED-2010,2016
+AGED,2040,1,App Ag Calculations,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2040,2016
+AGED,3030,1,Ag Ed Mech Tech,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-3030,2016
+AGED,3650,1,Multiculturalism in Agric Educ,0.9,0.03,0.03,0.0,0.03,0.0,0.0,0.0,alex byrd,,AGED-3650,2016
+AGED,4030,1,Prin Adult/Ext Ed,0.77,0.09,0.14,0.0,0.0,0.0,0.0,0.0,kevin layfield,,AGED-4030,2016
+AGM,1010,1,Intro Ag Mech & Bus,0.41,0.32,0.16,0.04,0.04,0.0,0.0,0.04,hunter massey,,AGM-1010,2016
+AGM,2050,1,Prin of Fabrication,0.14,0.57,0.16,0.03,0.07,0.0,0.0,0.03,hunter massey,,AGM-2050,2016
+AGM,2060,1,Machinery Mgt,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,hunter massey,,AGM-2060,2016
+AGM,2190,1,Agribusiness and Food Systems,0.49,0.4,0.1,0.0,0.01,0.0,0.0,0.0,nicholas gra rogers,,AGM-2190,2016
+AGM,2210,1,Land Measurements,0.17,0.32,0.33,0.14,0.03,0.0,0.0,0.01,charles privette,,AGM-2210,2016
+AGM,3010,1,Soil Water Conserv,0.44,0.29,0.16,0.06,0.03,0.0,0.0,0.02,calvin sawyer,,AGM-3010,2016
+AGM,3710,1,Agric Mechanization Practicum,0.0,0.0,0.0,0.0,0.0,0.89,0.05,0.05,hunter massey,,AGM-3710,2016
+AGM,4000,1,Seminar in Ag Mech & Business,0.53,0.31,0.06,0.03,0.03,0.0,0.0,0.03,john chastain,,AGM-4000,2016
+AGM,4050,1,Env Cont in Anim Str,0.14,0.46,0.3,0.1,0.0,0.0,0.0,0.0,john chastain,,AGM-4050,2016
+AGM,4060,1,Mech & Hydraulic Sys,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4060,2016
+AGM,4520,1,Mobile Power,0.41,0.41,0.14,0.05,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4520,2016
+AGM,4600,1,Electrical Systems,0.45,0.36,0.13,0.06,0.0,0.0,0.0,0.0,young han,,AGM-4600,2016
+AGM,4730,1,Peanut Harvesting Machinery,0.88,0.0,0.0,0.0,0.12,0.0,0.0,0.0,hunter massey,,AGM-4730,2016
+AGRB,2020,1,Agricultural Economics,0.19,0.35,0.23,0.13,0.08,0.0,0.0,0.02,george apperson,,AGRB-2020,2016
+AGRB,2020,2,Agricultural Economics,0.21,0.31,0.27,0.08,0.08,0.0,0.0,0.04,george apperson,,AGRB-2020,2016
+AGRB,2050,1,Agriculture and Society,0.42,0.38,0.12,0.04,0.02,0.0,0.0,0.02,michael vassalos,,AGRB-2050,2016
+AGRB,3020,1,Economics of Farm Management,0.28,0.35,0.27,0.09,0.0,0.0,0.0,0.01,michael vassalos,,AGRB-3020,2016
+AGRB,3080,1,Quant Agribusiness Analysis I,0.19,0.23,0.32,0.19,0.03,0.0,0.0,0.03,lisha zhang,,AGRB-3080,2016
+AGRB,3090,1,Econ of Agricultural Marketing,0.83,0.15,0.0,0.0,0.03,0.0,0.0,0.0,yuliya val bolotova,,AGRB-3090,2016
+AGRB,3570,1,Natural Resources Economics,0.29,0.31,0.18,0.11,0.07,0.0,0.0,0.04,david brian willis,,AGRB-3570,2016
+AGRB,4090,1,Commodity Futures Markets,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,,AGRB-4090,2016
+AGRB,4120,1,Reg Econ Devel Theory & Policy,0.55,0.3,0.1,0.0,0.05,0.0,0.0,0.0,robert carey,,AGRB-4120,2016
+AGRB,4600,1,Agricultural Finance,0.33,0.33,0.22,0.11,0.0,0.0,0.0,0.0,lisha zhang,,AGRB-4600,2016
+AL,3490,400,Principles of Coaching,0.65,0.15,0.12,0.0,0.0,0.0,0.0,0.08,deborah cadorette,,AL-3490,2016
+AL,3490,401,Principles of Coaching,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2016
+AL,3490,402,Principles of Coaching,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,julia wright,,AL-3490,2016
+AL,3490,403,Principles of Coaching,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,clyde keith connor,,AL-3490,2016
+AL,3490,404,Principles of Coaching,0.84,0.08,0.0,0.0,0.0,0.0,0.0,0.08,edmond fry,,AL-3490,2016
+AL,3500,400,Sci Basis I/Ex Phy,0.33,0.08,0.33,0.13,0.04,0.0,0.0,0.08,michael godfrey,,AL-3500,2016
+AL,3500,401,Sci Basis I/Ex Phy,0.13,0.3,0.22,0.13,0.13,0.0,0.0,0.09,michael godfrey,,AL-3500,2016
+AL,3530,400,Athletic Injuries,0.23,0.27,0.32,0.14,0.0,0.0,0.0,0.05,isaac sean colbert,,AL-3530,2016
+AL,3530,401,Athletic Injuries,0.16,0.32,0.37,0.11,0.05,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2016
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.42,0.25,0.25,0.08,0.0,0.0,0.0,0.0,clyde keith connor,,AL-3600,2016
+AL,3610,400,Admin/Org of Athletic Programs,0.73,0.2,0.0,0.07,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2016
+AL,3610,401,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2016
+AL,3610,402,Admin/Org of Athletic Programs,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,henry oates,,AL-3610,2016
+AL,3620,400,Psychology of Coaching,0.31,0.31,0.19,0.13,0.06,0.0,0.0,0.0,natalie anne carter,,AL-3620,2016
+AL,3620,401,Psychology of Coaching,0.44,0.31,0.13,0.13,0.0,0.0,0.0,0.0,natalie anne carter,,AL-3620,2016
+AL,3620,402,Psychology of Coaching,0.26,0.39,0.26,0.09,0.0,0.0,0.0,0.0,natalie anne carter,,AL-3620,2016
+AL,3740,400,Coaching Football,0.58,0.21,0.04,0.04,0.08,0.0,0.0,0.04,edmond fry,,AL-3740,2016
+AL,3760,400,Coaching Strength/Conditioning,0.61,0.22,0.13,0.04,0.0,0.0,0.0,0.0,edmond fry,,AL-3760,2016
+AL,3760,401,Coaching Strength/Conditioning,0.5,0.3,0.1,0.0,0.05,0.0,0.0,0.05,edmond fry,,AL-3760,2016
+AL,4380,400,Coaching Women,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-4380,2016
+AL,4380,402,Coaching the Inner Athlete,0.7,0.17,0.09,0.0,0.04,0.0,0.0,0.0,deborah cadorette,,AL-4380,2016
+AL,8490,400,Athletic Leadership Dev,0.6,0.28,0.08,0.0,0.04,0.0,0.0,0.0,michael godfrey,,AL-8490,2016
+AL,8490,401,Athletic Leadership Dev,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8490,2016
+AL,8500,400,Principles Strength and Condit,0.59,0.31,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8500,2016
+AL,8650,400,Mkt and Comm Respon Interc Ath,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,misty soles,,AL-8650,2016
+ANTH,2010,1,Introduction to Anthropology,0.49,0.28,0.13,0.02,0.02,0.0,0.0,0.06,yi wu,,ANTH-2010,2016
+ANTH,2010,2,Introduction to Anthropology,0.07,0.2,0.44,0.15,0.05,0.0,0.0,0.1,john coggeshall,,ANTH-2010,2016
+ANTH,2010,3,Introduction to Anthropology,0.06,0.35,0.39,0.06,0.1,0.0,0.0,0.05,john coggeshall,,ANTH-2010,2016
+ANTH,2010,4,Introduction to Anthropology,0.38,0.42,0.09,0.04,0.07,0.0,0.0,0.0,katherine weisensee,,ANTH-2010,2016
+ANTH,2010,5,Introduction to Anthropology,0.44,0.42,0.08,0.02,0.02,0.0,0.0,0.02,lisa rapaport,,ANTH-2010,2016
+ANTH,2010,6,Introduction to Anthropology,0.27,0.3,0.18,0.09,0.07,0.0,0.0,0.09,yi wu,,ANTH-2010,2016
+ANTH,3010,1,Cultural Anthropology,0.09,0.41,0.18,0.14,0.05,0.0,0.0,0.14,john coggeshall,,ANTH-3010,2016
+ANTH,3320,1,World Archaeology,0.17,0.3,0.22,0.17,0.0,0.0,0.0,0.13,melissa vogel,,ANTH-3320,2016
+ANTH,3510,1,Biological Anthropology,0.5,0.33,0.06,0.0,0.06,0.0,0.0,0.06,lisa rapaport,,ANTH-3510,2016
+ANTH,3530,1,Forensic Anthropology,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,katherine weisensee,,ANTH-3530,2016
+ANTH,4230,1,Women in the Developing World,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,melissa vogel,,ANTH-4230,2016
+ARCH,1010,1,Intro to Architecture,0.63,0.26,0.04,0.02,0.03,0.0,0.0,0.02,sal hambright-belue,,ARCH-1010,2016
+ARCH,2040,1,Hist of Modern Arch,0.28,0.42,0.25,0.03,0.03,0.0,0.0,0.0,robert bruhns,,ARCH-2040,2016
+ARCH,2510,1,Arch Foundations I,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-2510,2016
+ARCH,2510,2,Arch Foundations I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-2510,2016
+ARCH,2510,3,Arch Foundations I,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2510,2016
+ARCH,2510,4,Arch Foundations I,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,james barker,,ARCH-2510,2016
+ARCH,2510,5,Arch Foundations I,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-2510,2016
+ARCH,2700,1,Structures I,0.36,0.41,0.18,0.0,0.05,0.0,0.0,0.0,dustin gra albright,,ARCH-2700,2016
+ARCH,3500,1,Intro to Urban Contexts,0.08,0.62,0.31,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-3500,2016
+ARCH,3500,2,Intro to Urban Contexts,0.33,0.33,0.25,0.0,0.08,0.0,0.0,0.0,julie poe wilkerson,,ARCH-3500,2016
+ARCH,3500,3,Intro to Urban Contexts,0.0,0.17,0.83,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-3500,2016
+ARCH,3500,4,Intro to Urban Contexts,0.17,0.42,0.42,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-3500,2016
+ARCH,4010,1,Architectural Portfolio SENIOR,0.67,0.19,0.05,0.0,0.05,0.0,0.0,0.05,clarissa mendez,,ARCH-4010,2016
+ARCH,4010,2,Architectural Portfolio JUNIOR,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4010,2016
+ARCH,4010,3,Architectural Portfolio JUNIOR,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,maryam hamidpour,,ARCH-4010,2016
+ARCH,6120,2,History Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-6120,2016
+ARCH,6990,9,Freehand Drawing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,,ARCH-6990,2016
+ARCH,8100,1,Visualization I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-8100,2016
+ARCH,8210,1,Research Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-8210,2016
+ARCH,8410,1,Arch Studio I,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,peter laurence,,ARCH-8410,2016
+ARCH,8410,2,Arch Studio I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,,ARCH-8410,2016
+ARCH,8510,1,Design Studio III,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-8510,2016
+ARCH,8510,2,Design Studio III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-8510,2016
+ARCH,8510,3,Design Studio III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8510,2016
+ARCH,8600,1,History/Theory I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-8600,2016
+ARCH,8810,1,Pro Practice Survey,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,,ARCH-8810,2016
+ARCH,8950,2,A+H Studio: Projects,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-8950,2016
+ART,1050,1,Foundation Drawing I,0.29,0.57,0.0,0.07,0.07,0.0,0.0,0.0,kathleen ann thum,,ART-1050,2016
+ART,1510,1,Foundations Art I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kymberly ann day,,ART-1510,2016
+ART,2070,1,Beginning Painting,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,todd mcdonald,,ART-2070,2016
+ART,2100,400,Art Appreciation,0.61,0.29,0.04,0.07,0.0,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2016
+ART,2100,401,Art Appreciation,0.41,0.3,0.19,0.07,0.04,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2016
+ART,2100,402,Art Appreciation,0.48,0.45,0.07,0.0,0.0,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2016
+ART,2100,403,Art Appreciation,0.37,0.41,0.11,0.04,0.07,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2016
+AS,1090,1,Air Force Today I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,,AS-1090,2016
+AS,1090,3,Air Force Today I,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher mann,,AS-1090,2016
+AS,2090,2,Dev of Air Power I,0.6,0.27,0.07,0.07,0.0,0.0,0.0,0.0,christopher mann,,AS-2090,2016
+AS,2090,3,Dev of Air Power I,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,christopher mann,,AS-2090,2016
+ASL,1010,1,Am Sign Lang I,0.17,0.39,0.28,0.06,0.11,0.0,0.0,0.0,william alton brant,,ASL-1010,2016
+ASL,1010,2,Am Sign Lang I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-1010,2016
+ASL,1010,3,Am Sign Lang I,0.28,0.39,0.11,0.11,0.0,0.0,0.0,0.11,michael alb barrett,,ASL-1010,2016
+ASL,1010,4,Am Sign Lang I,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,michael alb barrett,,ASL-1010,2016
+ASL,1020,1,Am Sign Lang I,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-1020,2016
+ASL,2010,1,Am Sign Lang II,0.28,0.39,0.22,0.11,0.0,0.0,0.0,0.0,michael alb barrett,,ASL-2010,2016
+ASL,2010,2,Am Sign Lang II,0.13,0.19,0.38,0.31,0.0,0.0,0.0,0.0,michael alb barrett,,ASL-2010,2016
+ASL,3010,1,Advanced A S L I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-3010,2016
+ASL,3150,1,Survey Interpreting,0.25,0.42,0.17,0.0,0.0,0.0,0.0,0.17,stephen fitzmaurice,,ASL-3150,2016
+ASTR,1010,1,Solar System Astronomy,0.19,0.39,0.17,0.12,0.08,0.0,0.0,0.05,lih-sin the,,ASTR-1010,2016
+ASTR,1010,2,Solar System Astronomy,0.28,0.36,0.19,0.04,0.06,0.0,0.0,0.07,lih-sin the,,ASTR-1010,2016
+ASTR,1020,1,Stellar Astronomy,0.39,0.32,0.11,0.06,0.02,0.0,0.0,0.1,amber porter,,ASTR-1020,2016
+ASTR,1030,1,Solar Systm Astr Lab,0.54,0.27,0.15,0.0,0.04,0.0,0.0,0.0,amber porter,,ASTR-1030,2016
+ASTR,1030,2,Solar Systm Astr Lab,0.38,0.31,0.04,0.08,0.08,0.0,0.0,0.12,amber porter,,ASTR-1030,2016
+ASTR,1030,4,Solar Systm Astr Lab,0.6,0.24,0.0,0.08,0.0,0.0,0.0,0.08,amber porter,,ASTR-1030,2016
+ASTR,1030,5,Solar Systm Astr Lab,0.63,0.17,0.08,0.08,0.0,0.0,0.0,0.04,amber porter,,ASTR-1030,2016
+ASTR,1030,6,Solar Systm Astr Lab,0.4,0.4,0.05,0.15,0.0,0.0,0.0,0.0,amber porter,,ASTR-1030,2016
+ASTR,1030,7,Solar Systm Astr Lab,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,amber porter,,ASTR-1030,2016
+ASTR,1030,8,Solar Systm Astr Lab,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,amber porter,,ASTR-1030,2016
+ASTR,1030,9,Solar Systm Astr Lab,0.54,0.21,0.08,0.0,0.08,0.0,0.0,0.08,amber porter,,ASTR-1030,2016
+ASTR,1030,10,Solar Systm Astr Lab,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,amber porter,,ASTR-1030,2016
+ASTR,1040,1,Stellar Astr Lab,0.52,0.36,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,,ASTR-1040,2016
+ASTR,1040,2,Stellar Astr Lab,0.14,0.52,0.05,0.0,0.14,0.0,0.0,0.14,amber porter,,ASTR-1040,2016
+ASTR,1040,4,Stellar Astr Lab,0.46,0.42,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,,ASTR-1040,2016
+AUD,1850,1,Intro to Audio Tech,0.18,0.73,0.09,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-1850,2016
+AUD,2800,1,Sound Reinforcement,0.09,0.36,0.45,0.0,0.09,0.0,0.0,0.0,kenneth moore,,AUD-2800,2016
+AUE,8270,5,Auto Cntrl Sys Des,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8270,2016
+AUE,8280,1,Driveline/Powertrain,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8280,2016
+AUE,8330,30,Auto Manuf Proc Devl,0.47,0.51,0.03,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8330,2016
+AUE,8350,100,Auto Electronics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,,AUE-8350,2016
+AUE,8670,1,Veh Manuf Proc I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8670,2016
+AUE,8800,2,Vehicle Project Mngt,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett,,AUE-8800,2016
+AUE,8810,3,Automotive Systems Overview,0.37,0.6,0.02,0.0,0.01,0.0,0.0,0.0,david wil schmueser,,AUE-8810,2016
+AUE,8830,9,Applied Integration,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8830,2016
+AUE,8870,8,Meth Vehicle Testing,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8870,2016
+AUE,8930,13,Engine Analysis,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8930,2016
+AUE,8930,14,Advanced Composites,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,,AUE-8930,2016
+AUE,8930,16,Light-Weight Automotive Design,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,david wil schmueser,,AUE-8930,2016
+AUE,8930,17,Hybrids,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,simona onori,,AUE-8930,2016
+AUE,8930,18,Adv IC Engine Concept,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-8930,2016
+AUE,8930,78,Ground Vehicle Performance,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,,AUE-8930,2016
+AUE,8930,100,Slide Mode Controls,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8930,2016
+AVS,1000,1,Orientation to AVS,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,,AVS-1000,2016
+AVS,1500,1,Intro Animal Science,0.19,0.57,0.19,0.02,0.01,0.0,0.0,0.02,marie owens bolt,,AVS-1500,2016
+AVS,1510,1,Intro Ani Sci Lab,0.65,0.23,0.04,0.0,0.0,0.0,0.0,0.08,richelle lor miller,,AVS-1510,2016
+AVS,1510,2,Intro Ani Sci Lab,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-1510,2016
+AVS,1510,3,Intro Ani Sci Lab,0.6,0.32,0.0,0.0,0.0,0.0,0.0,0.08,richelle lor miller,,AVS-1510,2016
+AVS,1510,4,Intro Ani Sci Lab,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,louisa elaine koch,,AVS-1510,2016
+AVS,1510,5,Intro Ani Sci Lab,0.21,0.67,0.13,0.0,0.0,0.0,0.0,0.0,marie owens bolt,,AVS-1510,2016
+AVS,1510,6,Intro Ani Sci Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-1510,2016
+AVS,1510,7,Intro Ani Sci Lab,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,brandon michae koch,,AVS-1510,2016
+AVS,1510,8,Intro Ani Sci Lab,0.29,0.5,0.07,0.07,0.0,0.0,0.0,0.07,marie owens bolt,,AVS-1510,2016
+AVS,2030,1,Dairy Sci Techniques,0.95,0.0,0.02,0.02,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-2030,2016
+AVS,2040,1,Horse Care Techniques,0.44,0.46,0.1,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-2040,2016
+AVS,2060,1,Swine Techniques,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-2060,2016
+AVS,3010,1,Anat & Phys Dom Ani,0.46,0.19,0.17,0.12,0.03,0.0,0.0,0.04,glenn birrenkott,,AVS-3010,2016
+AVS,3010,400,Anat & Phys Dom Ani,0.46,0.27,0.15,0.12,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2016
+AVS,3020,1,Livestk Sel Eval I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-3020,2016
+AVS,3090,1,Equine Evaluation,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-3090,2016
+AVS,3100,1,Animal Health,0.68,0.22,0.07,0.01,0.01,0.0,0.0,0.0,thomas scott,,AVS-3100,2016
+AVS,3700,1,Principles of Animal Nutrition,0.64,0.2,0.09,0.04,0.02,0.0,0.0,0.01,james ro strickland,,AVS-3700,2016
+AVS,3750,1,Applied Animal Nutrition,0.19,0.42,0.25,0.11,0.0,0.0,0.0,0.03,gustavo jos lascano,,AVS-3750,2016
+AVS,4000,1,AVS Professional Development,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,johanna joh lascano,,AVS-4000,2016
+AVS,4000,2,AVS Professional Development,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,,AVS-4000,2016
+AVS,4060,1,Seminars & Related Topics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2016
+AVS,4060,2,Seminars & Related Topics,0.41,0.52,0.03,0.0,0.0,0.0,0.0,0.03,jeryl jones,,AVS-4060,2016
+AVS,4150,1,Contemporary Issues in AVS,0.06,0.39,0.38,0.08,0.05,0.0,0.0,0.05,peter skewes,,AVS-4150,2016
+AVS,4160,1,Equine Exercise Phys,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-4160,2016
+AVS,4530,1,Animal Reproduction,0.48,0.34,0.11,0.05,0.02,0.0,0.0,0.0,tiffany wilmoth,,AVS-4530,2016
+AVS,8200,1,Graduate Seminar,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,,AVS-8200,2016
+BCHM,1030,1,Careers in Bioch/Gen,0.68,0.24,0.01,0.06,0.0,0.0,0.0,0.01,alison starr-moss,,BCHM-1030,2016
+BCHM,3010,1,Molecular Biochem,0.26,0.49,0.2,0.0,0.0,0.0,0.0,0.06,kerry smith,,BCHM-3010,2016
+BCHM,3050,1,Essen Elements Bioch,0.21,0.33,0.25,0.11,0.02,0.0,0.0,0.08,srik chandrasekaran,,BCHM-3050,2016
+BCHM,3050,2,Essen Elements Bioch,0.28,0.35,0.22,0.07,0.03,0.0,0.0,0.05,srik chandrasekaran,,BCHM-3050,2016
+BCHM,4310,1,Physical Approach to Biochem,0.11,0.55,0.28,0.02,0.04,0.0,0.0,0.0,weiguo cao,,BCHM-4310,2016
+BCHM,4310,2,Phys App to Bioch (HON),0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,True,BCHM-4310,2016
+BCHM,4330,1,Physical Biochemistry Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,weiguo cao,,BCHM-4330,2016
+BCHM,4330,3,Physical Biochemistry Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,weiguo cao,,BCHM-4330,2016
+BCHM,4330,4,Physical Biochemistry Lab,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,weiguo cao,,BCHM-4330,2016
+BCHM,4400,1,Bioinformatics,0.78,0.15,0.0,0.07,0.0,0.0,0.0,0.0,frank alexan feltus,,BCHM-4400,2016
+BCHM,4430,1,Mol Basis Disease,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,james morris,,BCHM-4430,2016
+BCHM,4900,7,C-MED,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,michael glen sehorn,,BCHM-4900,2016
+BCHM,4930,1,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,liangjiang wang,,BCHM-4930,2016
+BE,2120,1,Fundamentals of Biosys Engr,0.55,0.4,0.0,0.0,0.05,0.0,0.0,0.0,caye marie drapcho,,BE-2120,2016
+BE,3200,1,Principles & Prac of Geomatics,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,tom owino,,BE-3200,2016
+BE,4100,1,Biological Kinetics,0.38,0.29,0.33,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4100,2016
+BE,4210,1,Engr Sys Sw Mgmt,0.59,0.35,0.0,0.0,0.06,0.0,0.0,0.0,christophe darnault,,BE-4210,2016
+BE,4280,1,Biochem Engr,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4280,2016
+BE,4740,1,B E Design/Proj Mgt,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,tom owino,,BE-4740,2016
+BE,4750,1,B E Capstone Design,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4750,2016
+BIOE,1010,1,Biol for Bioengr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,vladimir vla reukov,,BIOE-1010,2016
+BIOE,2010,1,Intro Biomed Engr,0.82,0.16,0.02,0.0,0.0,0.0,0.0,0.0,charles webb,,BIOE-2010,2016
+BIOE,2010,2,Intro Biomed Engr,0.76,0.21,0.01,0.0,0.0,0.0,0.0,0.01,frank alexis,,BIOE-2010,2016
+BIOE,3020,1,Biomaterials,0.57,0.23,0.04,0.02,0.06,0.0,0.0,0.09,alexey ale vertegel,,BIOE-3020,2016
+BIOE,3200,1,Biomechanics,0.79,0.17,0.02,0.0,0.02,0.0,0.0,0.0,lisa benson,,BIOE-3200,2016
+BIOE,3210,1,Biofluid Mechanics,0.46,0.38,0.14,0.0,0.0,0.0,0.0,0.03,zhi gao,,BIOE-3210,2016
+BIOE,3700,1,Bioinst & Imaging,0.64,0.27,0.07,0.0,0.0,0.0,0.0,0.02,delphine dean,,BIOE-3700,2016
+BIOE,4010,1,Bioengineering Design Theory,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4010,2016
+BIOE,4010,2,Bioengineering Design Theory,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4010,2016
+BIOE,4030,1,Applied Bio E Design,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,,BIOE-4030,2016
+BIOE,4120,1,Orthopaedic Engr and Pathology,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,melinda harman,,BIOE-4120,2016
+BIOE,4500,3,Biofabrication,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,,BIOE-4500,2016
+BIOE,6120,1,Orthopaedic Engr & Pathology,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,melinda harman,,BIOE-6120,2016
+BIOE,6400,1,Biopharmaceutical Engineering,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,sarah harcum,,BIOE-6400,2016
+BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.94,0.03,0.03,martine laberge,,BIOE-8000,2016
+BIOE,8010,1,Bio Materials,0.33,0.6,0.03,0.0,0.03,0.0,0.0,0.0,robert latour,,BIOE-8010,2016
+BIOE,8600,401,Biomed Engr Design Innovation,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,,BIOE-8600,2016
+BIOL,1010,1,Frontiers in Biology I,0.8,0.1,0.06,0.02,0.01,0.0,0.0,0.01,robert edwa ballard,,BIOL-1010,2016
+BIOL,1010,2,Frontiers in Biology I,0.55,0.27,0.11,0.03,0.04,0.0,0.0,0.0,thomas hughes,,BIOL-1010,2016
+BIOL,1030,1,General Biology I,0.23,0.28,0.22,0.11,0.1,0.0,0.0,0.07,nora espinoza,,BIOL-1030,2016
+BIOL,1030,2,General Biology I,0.11,0.27,0.31,0.18,0.07,0.0,0.0,0.07,william baldwin,,BIOL-1030,2016
+BIOL,1030,3,General Biology I,0.26,0.3,0.22,0.1,0.07,0.0,0.0,0.06,william surver,,BIOL-1030,2016
+BIOL,1030,4,General Biology I,0.14,0.26,0.32,0.12,0.08,0.0,0.0,0.08,salvatore sparace,,BIOL-1030,2016
+BIOL,1030,5,General Biology I (HON),0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True,BIOL-1030,2016
+BIOL,1050,1,General Biology Lab I,0.17,0.33,0.25,0.08,0.08,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,2,General Biology Lab I,0.17,0.29,0.25,0.17,0.0,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,3,General Biology Lab I,0.04,0.26,0.26,0.17,0.09,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,4,General Biology Lab I,0.29,0.17,0.33,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,5,General Biology Lab I,0.04,0.13,0.3,0.3,0.04,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,6,General Biology Lab I,0.08,0.21,0.17,0.38,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,7,General Biology Lab I,0.1,0.14,0.19,0.33,0.14,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,8,General Biology Lab I,0.1,0.25,0.35,0.1,0.05,0.0,0.0,0.15,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,9,General Biology Lab I,0.09,0.22,0.35,0.22,0.04,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,10,General Biology Lab I,0.04,0.5,0.42,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,11,General Biology Lab I,0.17,0.33,0.33,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,12,General Biology Lab I,0.04,0.29,0.25,0.29,0.13,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,13,General Biology Lab I,0.13,0.5,0.17,0.08,0.13,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,14,General Biology Lab I,0.21,0.38,0.29,0.08,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,15,General Biology Lab I,0.26,0.22,0.3,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,16,General Biology Lab I,0.17,0.42,0.29,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,17,General Biology Lab I,0.17,0.29,0.25,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,18,General Biology Lab I,0.08,0.38,0.33,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,19,General Biology Lab I,0.26,0.17,0.13,0.26,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,20,General Biology Lab I,0.08,0.13,0.38,0.21,0.13,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,21,General Biology Lab I,0.08,0.21,0.29,0.13,0.25,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,22,General Biology Lab I,0.13,0.42,0.17,0.17,0.08,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,23,General Biology Lab I,0.25,0.42,0.08,0.17,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,24,General Biology Lab I,0.21,0.29,0.25,0.08,0.08,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,25,General Biology Lab I,0.0,0.17,0.3,0.22,0.22,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,26,General Biology Lab I,0.21,0.29,0.17,0.21,0.08,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,27,General Biology Lab I,0.08,0.29,0.29,0.29,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,28,General Biology Lab I,0.04,0.46,0.17,0.17,0.08,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,29,General Biology Lab I,0.04,0.35,0.22,0.22,0.09,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,30,General Biology Lab I,0.21,0.25,0.29,0.21,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,31,General Biology Lab I,0.0,0.15,0.25,0.2,0.25,0.0,0.0,0.15,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,32,General Biology Lab I,0.25,0.31,0.13,0.25,0.06,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,33,General Biology Lab I,0.0,0.15,0.4,0.15,0.15,0.0,0.0,0.15,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,34,General Biology Lab I,0.17,0.5,0.08,0.21,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,35,General Biology Lab I,0.29,0.29,0.29,0.13,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,36,General Biology Lab I,0.21,0.29,0.38,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,37,General Biology Lab I,0.21,0.33,0.21,0.13,0.08,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,38,General Biology Lab I,0.08,0.5,0.33,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,39,General Biology Lab I,0.14,0.45,0.23,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,40,General Biology Lab I,0.38,0.17,0.25,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,41,General Biology Lab I,0.13,0.42,0.29,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,42,General Biology Lab I,0.09,0.39,0.39,0.0,0.04,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,43,General Biology Lab I,0.04,0.21,0.33,0.25,0.08,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,44,General Biology Lab I,0.21,0.21,0.38,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,45,General Biology Lab I,0.04,0.43,0.22,0.22,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1050,46,General Biology Lab I,0.12,0.28,0.4,0.08,0.08,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2016
+BIOL,1090,1,Intro to Life Sci,0.78,0.18,0.05,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,,BIOL-1090,2016
+BIOL,1100,1,Principles of Biology I,0.12,0.43,0.28,0.07,0.03,0.0,0.0,0.07,robert kosinski,,BIOL-1100,2016
+BIOL,1100,2,Principles of Biology I,0.48,0.37,0.06,0.03,0.05,0.0,0.0,0.02,dylan dittrich-reed,,BIOL-1100,2016
+BIOL,1100,3,Prin of Biology I (HON),0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,robert kosinski,True,BIOL-1100,2016
+BIOL,1100,4,Prin of Biology I (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,True,BIOL-1100,2016
+BIOL,1100,5,Principles of Biology I,0.48,0.43,0.08,0.03,0.0,0.0,0.0,0.0,dylan dittrich-reed,,BIOL-1100,2016
+BIOL,1200,1,Biological Inq Lab,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,2,Biological Inq Lab,0.59,0.24,0.12,0.0,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2016
+BIOL,1200,3,Biological Inq Lab,0.5,0.28,0.11,0.0,0.06,0.0,0.0,0.06, christine minor,,BIOL-1200,2016
+BIOL,1200,4,Biological Inq Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,5,Biological Inq Lab,0.61,0.22,0.11,0.06,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,6,Biological Inq Lab,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,7,Biological Inq Lab,0.45,0.45,0.0,0.1,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,8,Biological Inq Lab,0.39,0.28,0.22,0.06,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2016
+BIOL,1200,9,Biological Inq Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,11,Biological Inq Lab,0.41,0.47,0.06,0.0,0.06,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,12,Biological Inq Lab,0.5,0.22,0.17,0.06,0.06,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,13,Biological Inq Lab,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,14,Biological Inq Lab,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2016
+BIOL,1200,15,Biological Inq Lab,0.56,0.28,0.06,0.06,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2016
+BIOL,1230,1,Keys to Human Biol,0.28,0.37,0.24,0.06,0.04,0.0,0.0,0.01, christine minor,,BIOL-1230,2016
+BIOL,1230,2,Keys to Human Biol,0.28,0.38,0.19,0.08,0.02,0.0,0.0,0.04, christine minor,,BIOL-1230,2016
+BIOL,2000,2,Biology in the News,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-2000,2016
+BIOL,2000,6,Biology in the News,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,william surver,,BIOL-2000,2016
+BIOL,2040,1,"Environ, Energy and Society",0.73,0.14,0.05,0.02,0.0,0.0,0.0,0.05,john jenkins hains,,BIOL-2040,2016
+BIOL,2040,2,"Environ, Energy and Society",0.68,0.14,0.05,0.03,0.0,0.0,0.0,0.11,john jenkins hains,,BIOL-2040,2016
+BIOL,2110,1,Introduction to Toxicology,0.45,0.42,0.1,0.0,0.03,0.0,0.0,0.0,peter van den hurk,,BIOL-2110,2016
+BIOL,2220,1,Human Anat and Physiology I,0.18,0.32,0.24,0.08,0.09,0.0,0.0,0.09,john cummings,,BIOL-2220,2016
+BIOL,2220,2,Human Anat and Physiology I,0.27,0.4,0.15,0.08,0.03,0.0,0.0,0.07,john cummings,,BIOL-2220,2016
+BIOL,3030,1,Vertebrate Biology,0.29,0.25,0.25,0.15,0.03,0.0,0.0,0.03,richard blob,,BIOL-3030,2016
+BIOL,3030,2,Vertebrate Biology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True,BIOL-3030,2016
+BIOL,3040,1,Biology of Plants,0.46,0.22,0.22,0.03,0.03,0.0,0.0,0.03,christina wells,,BIOL-3040,2016
+BIOL,3070,1,Vertebrate Biology Lab,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,2,Vertebrate Biology Lab,0.7,0.15,0.1,0.05,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,3,Vertebrate Biology Lab,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2016
+BIOL,3070,4,Vertebrate Biology Lab,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,5,Vertebrate Biology Lab,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,6,Vertebrate Biology Lab,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,7,Vertebrate Biology Lab,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,8,Vertebrate Biology Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,9,Vertebrate Biology Lab,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2016
+BIOL,3070,10,Vertebrate Biology Lab,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,11,Vertebrate Biology Lab,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2016
+BIOL,3070,12,Vertebrate Biology Lab,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,13,Vertebrate Biology Lab,0.25,0.5,0.2,0.05,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3070,14,Vertebrate Biology Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2016
+BIOL,3080,1,Biology of Plants Practicum,0.5,0.25,0.15,0.05,0.0,0.0,0.0,0.05,christina wells,,BIOL-3080,2016
+BIOL,3080,2,Biology of Plants Practicum,0.15,0.55,0.2,0.05,0.0,0.0,0.0,0.05,christina wells,,BIOL-3080,2016
+BIOL,3080,3,Biology of Plants Practicum,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,christina wells,,BIOL-3080,2016
+BIOL,3080,4,Biology of Plants Practicum,0.11,0.39,0.33,0.06,0.06,0.0,0.0,0.06,christina wells,,BIOL-3080,2016
+BIOL,3150,1,Functional Human Anatomy,0.23,0.4,0.23,0.07,0.02,0.0,0.0,0.05,tamara mcnutt-scott,,BIOL-3150,2016
+BIOL,3200,1,Field Botany,0.21,0.21,0.21,0.24,0.03,0.0,0.0,0.1,robert edwa ballard,,BIOL-3200,2016
+BIOL,3350,1,Evolutionary Biology,0.26,0.44,0.2,0.07,0.02,0.0,0.0,0.01,margaret ptacek,,BIOL-3350,2016
+BIOL,3510,1,Biological Anthropology,0.33,0.47,0.07,0.07,0.07,0.0,0.0,0.0,lisa rapaport,,BIOL-3510,2016
+BIOL,3530,1,Forensic Anthropology,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,katherine weisensee,,BIOL-3530,2016
+BIOL,4140,1,Basic Immunology,0.12,0.29,0.41,0.12,0.0,0.0,0.0,0.06,yanzhang wei,,BIOL-4140,2016
+BIOL,4200,1,Neurobiology,0.51,0.44,0.05,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4200,2016
+BIOL,4250,1,Introductory Mycology,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,julia loui kerrigan,,BIOL-4250,2016
+BIOL,4260,1,Mycology Practicum,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,,BIOL-4260,2016
+BIOL,4340,1,Biological Chem Lab Techniques,0.18,0.27,0.18,0.36,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2016
+BIOL,4340,2,Biological Chem Lab Techniques,0.15,0.15,0.46,0.15,0.08,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2016
+BIOL,4340,3,Biological Chem Lab Techniques,0.0,0.64,0.21,0.07,0.07,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2016
+BIOL,4340,4,Biological Chem Lab Techniques,0.0,0.15,0.54,0.15,0.08,0.0,0.0,0.08,salvatore sparace,,BIOL-4340,2016
+BIOL,4410,1,Ecology,0.21,0.26,0.35,0.12,0.0,0.0,0.0,0.06,david tonkyn,,BIOL-4410,2016
+BIOL,4430,1,Freshwater Ecology,0.61,0.31,0.05,0.01,0.0,0.0,0.0,0.02,john jenkins hains,,BIOL-4430,2016
+BIOL,4440,2,Freshwater Ecology Lab (Lec),0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,john jenkins hains,,BIOL-4440,2016
+BIOL,4450,2,Ecology Laboratory (Lec),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,,BIOL-4450,2016
+BIOL,4610,1,Cell Biology,0.31,0.42,0.21,0.04,0.01,0.0,0.0,0.01,susan carol chapman,,BIOL-4610,2016
+BIOL,4610,2,Cell Biology (HON),0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True,BIOL-4610,2016
+BIOL,4620,2,Cell Biology Lab (Lec),0.54,0.42,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,3,Cell Biology Lab (Lec),0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,4,Cell Biology Lab (Lec),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,5,Cell Biology Lab (Lec),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,6,Cell Biology Lab (Lec),0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,7,Cell Biology Lab (Lec),0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,8,Cell Biology Lab (Lec),0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,xianzhong yu,,BIOL-4620,2016
+BIOL,4670,1,Principles of Hematology,0.89,0.04,0.0,0.0,0.07,0.0,0.0,0.0,vincent gallicchio,,BIOL-4670,2016
+BIOL,4930,3,Senior Seminar,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,,BIOL-4930,2016
+BIOL,4930,6,Senior Seminar,0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,kara elizabe powder,,BIOL-4930,2016
+BIOL,6030,1,Intro to Applied Genomics,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,vincent pa richards,,BIOL-6030,2016
+BIOL,8200,1,Community Ecology,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,saara dewalt,,BIOL-8200,2016
+BIOL,8400,1,Understanding Biological Inq,0.82,0.09,0.02,0.0,0.05,0.0,0.0,0.03,michael childress,,BIOL-8400,2016
+BIOL,8420,1,Understand Cellular Processes,0.45,0.39,0.11,0.0,0.03,0.0,0.0,0.01,patricia leota tate,,BIOL-8420,2016
+BIOL,8440,1,Understanding the Human Body,0.6,0.29,0.08,0.0,0.02,0.0,0.0,0.01,william baldwin,,BIOL-8440,2016
+BIOL,8480,1,Understanding Scientific Rsrch,0.9,0.0,0.0,0.0,0.06,0.0,0.0,0.03,robert edwa ballard,,BIOL-8480,2016
+BUS,1010,1,Business Foundations,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2016
+BUS,1010,2,Business Foundations,0.32,0.47,0.11,0.05,0.05,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2016
+BUS,1010,3,Business Foundations,0.63,0.21,0.0,0.05,0.05,0.0,0.0,0.05,william ern tumblin,,BUS-1010,2016
+BUS,1010,4,Business Foundations,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2016
+BUS,1010,5,Business Foundations,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2016
+BUS,1010,6,Business Foundations,0.42,0.37,0.05,0.0,0.16,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2016
+BUS,1010,7,Business Foundations,0.44,0.33,0.11,0.06,0.0,0.0,0.0,0.06,william ern tumblin,,BUS-1010,2016
+BUS,1010,8,Business Foundations,0.0,0.58,0.21,0.05,0.11,0.0,0.0,0.05,william ern tumblin,,BUS-1010,2016
+BUS,1010,9,Business Foundations,0.37,0.32,0.11,0.05,0.05,0.0,0.0,0.11,william ern tumblin,,BUS-1010,2016
+BUS,1010,10,Business Foundations,0.58,0.21,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,,BUS-1010,2016
+BUS,1010,11,Business Foundations,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2016
+BUS,1010,12,Business Foundations,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,james mullinax,,BUS-1010,2016
+BUS,1010,13,Business Foundations,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,14,Business Foundations,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,15,Business Foundations,0.41,0.24,0.29,0.06,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,16,Business Foundations,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,17,Business Foundations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,18,Business Foundations,0.17,0.33,0.33,0.06,0.06,0.0,0.0,0.06,donna mccubbin,,BUS-1010,2016
+BUS,1010,19,Business Foundations,0.22,0.5,0.17,0.06,0.06,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,20,Business Foundations,0.33,0.17,0.39,0.06,0.0,0.0,0.0,0.06,donna mccubbin,,BUS-1010,2016
+BUS,1010,21,Business Foundations,0.42,0.35,0.12,0.07,0.02,0.0,0.0,0.02,donna mccubbin,,BUS-1010,2016
+BUS,1010,22,Business Foundations,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,23,Business Foundations,0.44,0.28,0.11,0.06,0.0,0.0,0.0,0.11,sandy edge,,BUS-1010,2016
+BUS,1010,24,Business Foundations,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,sandy edge,,BUS-1010,2016
+BUS,1010,25,Business Foundations,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2016
+BUS,1010,26,Business Foundations,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2016
+BUS,1010,27,Business Foundations,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2016
+BUS,1010,28,Business Foundations,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,edward bar de iulio,,BUS-1010,2016
+BUS,1010,29,Business Foundations,0.19,0.36,0.23,0.11,0.04,0.0,0.0,0.06,michael mendonca,,BUS-1010,2016
+BUS,1010,30,Business Foundations,0.23,0.43,0.3,0.02,0.02,0.0,0.0,0.0,michael mendonca,,BUS-1010,2016
+BUS,1010,31,Business Foundations,0.21,0.53,0.16,0.05,0.0,0.0,0.0,0.05,michael mendonca,,BUS-1010,2016
+BUS,1010,33,Business Foundations,0.55,0.34,0.07,0.0,0.0,0.0,0.0,0.03,james mullinax,,BUS-1010,2016
+BUS,1010,34,Business Foundations,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james mullinax,,BUS-1010,2016
+CE,1990,2,Cr Inq in Civil Engineering,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,weichiang pang,,CE-1990,2016
+CE,2010,1,Statics,0.18,0.28,0.18,0.0,0.05,0.0,0.0,0.33,melissa sternhagen,,CE-2010,2016
+CE,2010,2,Statics,0.12,0.29,0.31,0.1,0.12,0.0,0.0,0.07,melissa sternhagen,,CE-2010,2016
+CE,2010,3,Statics,0.34,0.31,0.16,0.09,0.07,0.0,0.0,0.03,qiushi chen,,CE-2010,2016
+CE,2010,4,Statics,0.23,0.3,0.23,0.05,0.05,0.0,0.0,0.14,melissa sternhagen,,CE-2010,2016
+CE,2010,5,Statics,0.23,0.33,0.16,0.05,0.12,0.0,0.0,0.12,"rashidian dezfouli,",,CE-2010,2016
+CE,2010,6,Statics,0.12,0.35,0.19,0.07,0.14,0.0,0.0,0.14,melissa sternhagen,,CE-2010,2016
+CE,2010,7,Statics (HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,melissa sternhagen,True,CE-2010,2016
+CE,2060,1,Structural Mechanics,0.19,0.35,0.25,0.14,0.02,0.0,0.0,0.05,bryant nielson,,CE-2060,2016
+CE,2080,1,Dynamics,0.13,0.25,0.3,0.18,0.07,0.0,0.0,0.07,nigel gregory kaye,,CE-2080,2016
+CE,2550,1,Geomatics,0.34,0.52,0.1,0.02,0.01,0.0,0.0,0.01,wayne sarasua,,CE-2550,2016
+CE,3010,1,Structural Analysis,0.32,0.26,0.24,0.12,0.03,0.0,0.0,0.03,stephen csernak,,CE-3010,2016
+CE,3010,2,Structural Analysis,0.4,0.28,0.25,0.08,0.0,0.0,0.0,0.0,bryant nielson,,CE-3010,2016
+CE,3110,1,Transportation Engr,0.58,0.33,0.07,0.0,0.02,0.0,0.0,0.0,jennifer ogle,,CE-3110,2016
+CE,3210,1,Geotechnical Engineering,0.42,0.24,0.32,0.0,0.03,0.0,0.0,0.0,qiushi chen,,CE-3210,2016
+CE,3310,1,Constr Engr & Mgmnt,0.4,0.32,0.2,0.04,0.01,0.0,0.0,0.04,james burati,,CE-3310,2016
+CE,3410,1,Intro to Fluid Mech,0.26,0.44,0.26,0.04,0.0,0.0,0.0,0.0,nigel gregory kaye,,CE-3410,2016
+CE,3410,2,Intro to Fluid Mech,0.27,0.36,0.22,0.07,0.05,0.0,0.0,0.02,abdul khan,,CE-3410,2016
+CE,3420,1,Hydraulics & Hydro,0.43,0.43,0.15,0.0,0.0,0.0,0.0,0.0,ashok mishra,,CE-3420,2016
+CE,3510,1,Civil Engineering Materials,0.55,0.43,0.0,0.0,0.0,0.0,0.0,0.03,ami esmaeilpoursaee,,CE-3510,2016
+CE,3510,2,Civil Engineering Materials,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kimberly rene lyons,,CE-3510,2016
+CE,3520,1,Econ Eval of Proj,0.32,0.29,0.2,0.05,0.05,0.0,0.0,0.08,zoraya rolda rockow,,CE-3520,2016
+CE,4010,1,Matrix Str Analysis,0.74,0.15,0.07,0.0,0.04,0.0,0.0,0.0,atamturktur russcher,,CE-4010,2016
+CE,4020,1,Reinfor Con Design,0.27,0.5,0.07,0.07,0.0,0.0,0.0,0.1,thomas edfo cousins,,CE-4020,2016
+CE,4060,1,Struct Steel Design,0.31,0.47,0.14,0.06,0.02,0.0,0.0,0.0,stephen csernak,,CE-4060,2016
+CE,4100,1,Traffic Engr Oper,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,sakib khan,,CE-4100,2016
+CE,4240,1,Earth Slopes & Struc,0.3,0.35,0.3,0.0,0.03,0.0,0.0,0.03,nadara ravichandran,,CE-4240,2016
+CE,4330,1,Const Plan & Sched,0.41,0.41,0.15,0.02,0.0,0.0,0.0,0.0,steve richa sanders,,CE-4330,2016
+CE,4370,2,Sustainable Energy Proj Design,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,,CE-4370,2016
+CE,4390,1,Con Eqpmt Sel & Main,0.41,0.46,0.1,0.0,0.0,0.0,0.0,0.02,james burati,,CE-4390,2016
+CE,4460,1,Flood Haz & Prot Des,0.19,0.5,0.25,0.0,0.0,0.0,0.0,0.06,nadim aziz,,CE-4460,2016
+CE,4560,1,Pave Design & Constr,0.39,0.59,0.0,0.0,0.0,0.0,0.0,0.02,bradley putman,,CE-4560,2016
+CE,4590,1,Capstone Design Proj,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2016
+CE,4910,1,BIM in Construction Management,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,kalyan ram piratla,,CE-4910,2016
+CE,6010,1,Matrix Str Analysis,0.71,0.18,0.0,0.0,0.12,0.0,0.0,0.0,atamturktur russcher,,CE-6010,2016
+CE,6100,1,Traffic Engr Oper,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-6100,2016
+CE,6330,1,Const Plan & Sched,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,CE-6330,2016
+CE,6370,2,Sustainable Energy Proj Design,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,,CE-6370,2016
+CE,6460,1,Flood Haz & Prot Des,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,nadim aziz,,CE-6460,2016
+CE,6910,1,BIM in Construction Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-6910,2016
+CE,8040,1,Prestressed Concrete,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,brandon ross,,CE-8040,2016
+CE,8050,1,Adv Struc Mech,0.29,0.5,0.0,0.0,0.0,0.0,0.0,0.21,bryant nielson,,CE-8050,2016
+CE,8080,1,Earthquake Engr,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-8080,2016
+CE,8220,1,Foundation Engr,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-8220,2016
+CE,8230,1,Asphalt Conc Prop,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,,CE-8230,2016
+CE,8240,1,Infrastructure Corrosion,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,,CE-8240,2016
+CE,8540,1,Travl Demnd Forecast,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wayne sarasua,,CE-8540,2016
+CE,8570,500,Uncertainty Modeling Risk Engr,0.63,0.26,0.04,0.0,0.0,0.0,0.0,0.07,bryant nielson,,CE-8570,2016
+CE,8930,3,Automated Vehicle System,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-8930,2016
+CH,1010,1,General Chemistry,0.22,0.35,0.3,0.06,0.05,0.0,0.0,0.01,tania issa houjeiry,,CH-1010,2016
+CH,1010,2,General Chemistry,0.1,0.35,0.28,0.09,0.09,0.0,0.0,0.08,princess mycia cox,,CH-1010,2016
+CH,1010,3,General Chemistry,0.26,0.37,0.19,0.06,0.09,0.0,0.0,0.03,thomas hickman,,CH-1010,2016
+CH,1010,4,General Chemistry,0.19,0.27,0.26,0.12,0.11,0.0,0.0,0.04,dennis taylor,,CH-1010,2016
+CH,1010,5,General Chemistry,0.19,0.38,0.22,0.12,0.04,0.0,0.0,0.04,princess mycia cox,,CH-1010,2016
+CH,1010,6,General Chemistry,0.2,0.34,0.25,0.1,0.08,0.0,0.0,0.03,dennis taylor,,CH-1010,2016
+CH,1010,7,General Chemistry,0.05,0.3,0.39,0.1,0.12,0.0,0.0,0.05,william mcwhorter,,CH-1010,2016
+CH,1010,8,General Chemistry,0.23,0.27,0.28,0.1,0.08,0.0,0.0,0.04,dennis taylor,,CH-1010,2016
+CH,1010,9,General Chemistry,0.13,0.34,0.27,0.14,0.1,0.0,0.0,0.03,olt geiculescu,,CH-1010,2016
+CH,1010,10,General Chemistry,0.07,0.32,0.31,0.16,0.1,0.0,0.0,0.04,william mcwhorter,,CH-1010,2016
+CH,1010,11,General Chemistry,0.16,0.33,0.3,0.13,0.07,0.0,0.0,0.01,william mcwhorter,,CH-1010,2016
+CH,1010,12,General Chemistry,0.24,0.41,0.24,0.05,0.05,0.0,0.0,0.01,tania issa houjeiry,,CH-1010,2016
+CH,1010,13,General Chemistry,0.21,0.29,0.25,0.1,0.09,0.0,0.0,0.05,laura lanni,,CH-1010,2016
+CH,1010,14,General Chemistry,0.16,0.38,0.24,0.13,0.05,0.0,0.0,0.03,elliot ennis,,CH-1010,2016
+CH,1010,20,General Chemistry,0.29,0.37,0.24,0.05,0.03,0.0,0.0,0.02,tania issa houjeiry,,CH-1010,2016
+CH,1010,21,General Chemistry,0.2,0.41,0.22,0.05,0.09,0.0,0.0,0.03,elliot ennis,,CH-1010,2016
+CH,1010,22,General Chemistry,0.17,0.37,0.28,0.12,0.05,0.0,0.0,0.01,laura lanni,,CH-1010,2016
+CH,1010,50,General Chemistry,0.17,0.38,0.38,0.04,0.04,0.0,0.0,0.0,shiou-jyh hwu,,CH-1010,2016
+CH,1010,51,General Chemistry (HON),0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,william pennington,True,CH-1010,2016
+CH,1010,52,General Chemistry (HON),0.62,0.32,0.05,0.0,0.0,0.0,0.0,0.0,joseph stu thrasher,True,CH-1010,2016
+CH,1010,501,General Chemistry,0.44,0.29,0.27,0.0,0.0,0.0,0.0,0.0,brian gloor,,CH-1010,2016
+CH,1020,1,General Chemistry,0.3,0.3,0.25,0.1,0.04,0.0,0.0,0.02,stephe schvaneveldt,,CH-1020,2016
+CH,1020,2,General Chemistry,0.28,0.34,0.13,0.11,0.09,0.0,0.0,0.05,stephe schvaneveldt,,CH-1020,2016
+CH,1020,3,General Chemistry,0.24,0.34,0.23,0.09,0.06,0.0,0.0,0.03,stephe schvaneveldt,,CH-1020,2016
+CH,1020,400,General Chemistry,0.08,0.08,0.41,0.25,0.11,0.0,0.0,0.08,stephe schvaneveldt,,CH-1020,2016
+CH,1050,1,Chemistry in Context I,0.27,0.56,0.16,0.01,0.01,0.0,0.0,0.0,olt geiculescu,,CH-1050,2016
+CH,1050,2,Chemistry in Context I,0.35,0.43,0.15,0.05,0.01,0.0,0.0,0.01,olt geiculescu,,CH-1050,2016
+CH,2010,1,Survey of Organic Chemistry,0.29,0.3,0.23,0.09,0.06,0.0,0.0,0.03,thomas hickman,,CH-2010,2016
+CH,2010,2,Survey of Organic Chemistry,0.31,0.39,0.22,0.02,0.04,0.0,0.0,0.0,thomas hickman,,CH-2010,2016
+CH,2020,1,Surv of Organic Chemistry Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,sean 'connor,,CH-2020,2016
+CH,2020,2,Surv of Organic Chemistry Lab,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2020,2016
+CH,2020,3,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2020,2016
+CH,2020,5,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2020,2016
+CH,2020,7,Surv of Organic Chemistry Lab,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2020,2016
+CH,2020,8,Surv of Organic Chemistry Lab,0.6,0.2,0.07,0.0,0.07,0.0,0.0,0.07,sean 'connor,,CH-2020,2016
+CH,2230,1,Organic Chemistry,0.32,0.34,0.12,0.13,0.04,0.0,0.0,0.05,modi wetzler,,CH-2230,2016
+CH,2230,2,Organic Chemistry,0.41,0.31,0.13,0.06,0.06,0.0,0.0,0.03,modi wetzler,,CH-2230,2016
+CH,2230,3,Organic Chemistry,0.24,0.33,0.26,0.06,0.06,0.0,0.0,0.04,jacob schroeder,,CH-2230,2016
+CH,2230,4,Organic Chemistry,0.37,0.31,0.18,0.06,0.04,0.0,0.0,0.04,laura lanni,,CH-2230,2016
+CH,2230,5,Organic Chemistry,0.28,0.39,0.17,0.05,0.09,0.0,0.0,0.01,elliot ennis,,CH-2230,2016
+CH,2230,6,Organic Chemistry,0.32,0.27,0.13,0.08,0.11,0.0,0.0,0.08,rhett smith,,CH-2230,2016
+CH,2230,7,Organic Chemistry,0.23,0.36,0.21,0.06,0.07,0.0,0.0,0.08,dev priya arya,,CH-2230,2016
+CH,2240,1,Organic Chemistry,0.24,0.37,0.16,0.08,0.05,0.0,0.0,0.1,jacob schroeder,,CH-2240,2016
+CH,2240,2,Organic Chemistry,0.29,0.38,0.16,0.09,0.06,0.0,0.0,0.02,jacob schroeder,,CH-2240,2016
+CH,2270,1,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2016
+CH,2270,3,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,4,Organic Chem Lab,0.69,0.13,0.06,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2016
+CH,2270,8,Organic Chem Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,12,Organic Chem Lab,0.81,0.0,0.13,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,14,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,15,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2016
+CH,2270,19,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2016
+CH,2270,21,Organic Chem Lab,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,26,Organic Chem Lab,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2016
+CH,2270,28,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2016
+CH,2270,29,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2016
+CH,2270,30,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2016
+CH,2270,31,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2016
+CH,2270,32,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2016
+CH,2270,34,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2016
+CH,2270,35,Organic Chem Lab,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2280,4,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,,CH-2280,2016
+CH,2280,5,Organic Chem Lab,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2016
+CH,2280,6,Organic Chem Lab,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,sean 'connor,,CH-2280,2016
+CH,2280,7,Organic Chem Lab,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2016
+CH,2280,8,Organic Chem Lab,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,sean 'connor,,CH-2280,2016
+CH,2280,9,Organic Chem Lab,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15,sean 'connor,,CH-2280,2016
+CH,2280,10,Organic Chem Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2016
+CH,3130,1,Quantitative Analys,0.49,0.24,0.16,0.03,0.0,0.0,0.0,0.08,stephen creager,,CH-3130,2016
+CH,3300,1,Intro to Phys Chem,0.29,0.43,0.21,0.06,0.0,0.0,0.0,0.01,brian dominy,,CH-3300,2016
+CH,3310,1,Physical Chemistry,0.38,0.19,0.19,0.19,0.0,0.0,0.0,0.06,jason mcneill,,CH-3310,2016
+CH,3310,2,Physical Chemistry,0.25,0.25,0.21,0.08,0.17,0.0,0.0,0.04,leah bec casabianca,,CH-3310,2016
+CH,3320,1,Physical Chemistry,0.18,0.41,0.32,0.0,0.05,0.0,0.0,0.05,arkady kholodenko,,CH-3320,2016
+CH,3390,2,Physical Chem Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2016
+CH,3390,3,Physical Chem Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2016
+CH,3390,4,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2016
+CH,4010,1,Organometallic Chemistry,0.58,0.33,0.03,0.0,0.03,0.0,0.0,0.03,andrew gre tennyson,,CH-4010,2016
+CH,4020,1,Inorganic Chemistry,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,joseph kolis,,CH-4020,2016
+CH,4210,1,Advanced Organic Chemistry,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,daniel whitehead,,CH-4210,2016
+CH,8070,1,Chem Trans Elem,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,julia brumaghim,,CH-8070,2016
+CH,8090,1,Chem App/X-Ray Cryst,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,,CH-8090,2016
+CH,8120,1,Chemical Spectroscopic Methods,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,george chumanov,,CH-8120,2016
+CH,8150,1,Mass Spectrometry,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,richard marcus,,CH-8150,2016
+CH,8210,1,Organic Chem I,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0, karl dieter,,CH-8210,2016
+CH,8300,1,Fund Phys Chem,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,,CH-8300,2016
+CH,8510,1,Grad Student Seminar,0.71,0.24,0.03,0.0,0.03,0.0,0.0,0.0,joseph stu thrasher,,CH-8510,2016
+CH,8510,2,Grad Student Seminar,0.91,0.03,0.0,0.0,0.0,0.0,0.0,0.06,steven stuart,,CH-8510,2016
+CHE,2110,1,Mass and Energy Balances,0.24,0.2,0.24,0.08,0.2,0.0,0.0,0.04,mark roberts,,CHE-2110,2016
+CHE,2110,2,Mass and Energy Balances,0.28,0.43,0.13,0.03,0.07,0.0,0.0,0.04,mark roberts,,CHE-2110,2016
+CHE,3210,1,Ch E Thermo II,0.14,0.14,0.35,0.21,0.12,0.0,0.0,0.05,sapna sarupria,,CHE-3210,2016
+CHE,3210,2,Ch E Thermo II,0.2,0.31,0.23,0.17,0.09,0.0,0.0,0.0,sapna sarupria,,CHE-3210,2016
+CHE,3300,1,Mass Trans & Seprtn,0.19,0.15,0.43,0.06,0.09,0.0,0.0,0.08,mark thies,,CHE-3300,2016
+CHE,4070,1,Unit Op Lab II,0.14,0.75,0.11,0.0,0.0,0.0,0.0,0.0,christopher norfolk,,CHE-4070,2016
+CHE,4310,1,Process Design I,0.2,0.45,0.35,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4310,2016
+CHE,4500,1,Chem Reaction Engr,0.45,0.26,0.16,0.12,0.0,0.0,0.0,0.0,rachel getman,,CHE-4500,2016
+CHE,8030,1,Advanced Transport,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,eric mikel davis,,CHE-8030,2016
+CHE,8040,1,Ch E Thermodynamics,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,christophe kitchens,,CHE-8040,2016
+CHE,8050,1,Ch E Kinetics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,mark alan blenner,,CHE-8050,2016
+CHE,8140,1,Numerical Methods,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,joseph scott,,CHE-8140,2016
+CHIN,1010,1,Elementary Chinese,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,ling rao,,CHIN-1010,2016
+CHIN,1010,2,Elementary Chinese,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,ling rao,,CHIN-1010,2016
+CHIN,1020,1,Elementary Chinese,0.42,0.17,0.33,0.08,0.0,0.0,0.0,0.0,ling rao,,CHIN-1020,2016
+CHIN,2010,1,Intermediate Chinese,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,su- chen,,CHIN-2010,2016
+CHIN,2020,1,Intermediate Chinese,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,yanhua zhang,,CHIN-2020,2016
+CHIN,4010,1,Pre-Modern Chinese Literature,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,yanming an,,CHIN-4010,2016
+COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,eddie smith,,COM-1010,2016
+COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,eddie smith,,COM-1010,2016
+COM,1500,1,Intro to Human Communication,0.71,0.25,0.03,0.0,0.0,0.0,0.0,0.01,eddie smith,,COM-1500,2016
+COM,1500,2,Intro to Human Communication,0.66,0.25,0.04,0.01,0.01,0.0,0.0,0.04,daniel lelan fecher,,COM-1500,2016
+COM,1500,3,Intro to Human Communication,0.71,0.26,0.01,0.0,0.0,0.0,0.0,0.02,eddie smith,,COM-1500,2016
+COM,1500,4,Intro to Human Communication,0.68,0.23,0.05,0.01,0.01,0.0,0.0,0.01,marianne her glaser,,COM-1500,2016
+COM,1500,5,Intro to Human Communication,0.7,0.22,0.05,0.02,0.0,0.0,0.0,0.01,marianne her glaser,,COM-1500,2016
+COM,1500,6,Intro to Human Communication,0.65,0.25,0.07,0.0,0.0,0.0,0.0,0.03,marianne her glaser,,COM-1500,2016
+COM,1500,7,Intro to Human Communication,0.4,0.43,0.03,0.03,0.08,0.0,0.0,0.03,daniel lelan fecher,,COM-1500,2016
+COM,2010,1,Intr to Comm Studies,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-2010,2016
+COM,2010,2,Intr to Comm Studies,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-2010,2016
+COM,2500,1,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2016
+COM,2500,2,Public Speaking,0.39,0.33,0.11,0.06,0.06,0.0,0.0,0.06,marilyn denise pugh,,COM-2500,2016
+COM,2500,3,Public Speaking,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2016
+COM,2500,4,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2016
+COM,2500,5,Public Speaking,0.26,0.58,0.16,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2016
+COM,2500,6,Public Speaking,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,,COM-2500,2016
+COM,2500,7,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2016
+COM,2500,8,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2016
+COM,2500,9,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2016
+COM,2500,10,Public Speaking,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2016
+COM,2500,11,Public Speaking,0.47,0.32,0.05,0.05,0.05,0.0,0.0,0.05,sara grumbl crocker,,COM-2500,2016
+COM,2500,12,Public Speaking,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2016
+COM,2500,13,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2016
+COM,2500,14,Public Speaking,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,vanessa anne condon,,COM-2500,2016
+COM,2500,15,Public Speaking,0.17,0.39,0.44,0.0,0.0,0.0,0.0,0.0,pauline matthey,,COM-2500,2016
+COM,2500,16,Public Speaking,0.29,0.35,0.12,0.0,0.0,0.0,0.0,0.24,pauline matthey,,COM-2500,2016
+COM,2500,17,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,the estate  geddes,,COM-2500,2016
+COM,2500,19,Public Speaking,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,vanessa anne condon,,COM-2500,2016
+COM,2500,20,Public Speaking,0.21,0.58,0.11,0.0,0.0,0.0,0.0,0.11,pauline matthey,,COM-2500,2016
+COM,2500,21,Public Speaking,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2016
+COM,2500,22,Public Speaking,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,vanessa anne condon,,COM-2500,2016
+COM,2500,23,Public Speaking,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2016
+COM,2500,28,Public Speaking,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2016
+COM,2500,29,Public Speaking,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,,COM-2500,2016
+COM,2500,30,Public Speaking,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,sara grumbl crocker,,COM-2500,2016
+COM,2500,31,Public Speaking,0.21,0.42,0.16,0.05,0.05,0.0,0.0,0.11,marilyn denise pugh,,COM-2500,2016
+COM,2500,32,Public Speaking,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,,COM-2500,2016
+COM,2500,33,Public Speaking,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2016
+COM,2500,34,Public Speaking,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,,COM-2500,2016
+COM,2500,35,Public Speaking,0.37,0.37,0.11,0.0,0.11,0.0,0.0,0.05,jumah patrici taweh,,COM-2500,2016
+COM,2500,400,Public Speaking,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,,COM-2500,2016
+COM,2500,401,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachar davis,,COM-2500,2016
+COM,2500,402,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2016
+COM,2500,403,Public Speaking,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2016
+COM,3010,1,Comm Theory,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,,COM-3010,2016
+COM,3050,1,Persuasion,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,,COM-3050,2016
+COM,3060,1,Crit-Cultural Rsrch Methods,0.47,0.29,0.12,0.06,0.06,0.0,0.0,0.0,chenjerai kumanyika,,COM-3060,2016
+COM,3080,1,Pub Comm & Pop Cult,0.47,0.29,0.18,0.06,0.0,0.0,0.0,0.0,chenjerai kumanyika,,COM-3080,2016
+COM,3080,2,Pub Comm & Pop Cult,0.44,0.33,0.17,0.06,0.0,0.0,0.0,0.0,chenjerai kumanyika,,COM-3080,2016
+COM,3110,1,Qual Comm Methods,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,angela pratt,,COM-3110,2016
+COM,3150,1,Critical-Cultural Comm Theory,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,david travers scott,,COM-3150,2016
+COM,3200,1,Bdcst Production,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,wanda johnson,,COM-3200,2016
+COM,3220,1,Communication Design,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,,COM-3220,2016
+COM,3240,1,"Communication, Sport & Society",0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,,COM-3240,2016
+COM,3240,2,"Communication, Sport & Society",0.28,0.56,0.06,0.11,0.0,0.0,0.0,0.0,gregory kei cranmer,,COM-3240,2016
+COM,3260,1,Pr in Sports,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2016
+COM,3260,2,Pr in Sports,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2016
+COM,3270,1,Sports Media Criticism,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,brandon boatwright,,COM-3270,2016
+COM,3660,3,Video Comm with Adobe CC,0.83,0.06,0.0,0.06,0.0,0.0,0.0,0.06,michael rodgers,,COM-3660,2016
+COM,3690,1,Political Comm,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3690,2016
+COM,3690,2,Political Comm,0.42,0.42,0.11,0.0,0.05,0.0,0.0,0.0,erin michelle ash,,COM-3690,2016
+COM,3700,1,Survey of Brand Communications,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,lisa willi papenfus,,COM-3700,2016
+COM,3720,1,Digital Analytics in Brand Com,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alicia ni littleton,,COM-3720,2016
+COM,3740,1,Brand Comm and Media Strategy,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,roger beasley,,COM-3740,2016
+COM,4020,1,Mass Com: His & Crit,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,,COM-4020,2016
+COM,4250,1,Adv Sports Comm,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4250,2016
+COM,4250,2,Adv Sports Comm,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4250,2016
+COM,4300,1,Legal Communication,0.28,0.61,0.0,0.0,0.0,0.0,0.0,0.11,james isaac roberts,,COM-4300,2016
+COM,4560,1,PR for Assoc & Nonprofits,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-4560,2016
+COM,4660,1,Narrative Res. for Soc. Change,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4660,2016
+COM,4950,1,Senior Capstone Seminar,0.72,0.06,0.22,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4950,2016
+COM,8010,1,Communication Theory I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,andrew stephen pyle,,COM-8010,2016
+COM,8030,1,Comm Technology Studies Survey,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-8030,2016
+COM,8100,1,Comm Research Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-8100,2016
+COOP,1020,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey frank neal,,COOP-1020,2016
+COOP,1030,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,jeffrey frank neal,,COOP-1030,2016
+CPSC,1010,1,Computer Science I,0.2,0.32,0.14,0.07,0.2,0.0,0.0,0.07,eileen ther kraemer,,CPSC-1010,2016
+CPSC,1020,1,Computer Science II,0.23,0.33,0.22,0.07,0.09,0.0,0.0,0.06,yvon feaster,,CPSC-1020,2016
+CPSC,1040,1,Intro Computer Prog,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,aubrey miche lawson,,CPSC-1040,2016
+CPSC,1060,1,Intro to Programming in Java,0.28,0.28,0.22,0.0,0.11,0.0,0.0,0.11,salvatore lamarca,,CPSC-1060,2016
+CPSC,1060,2,Intro to Programming in Java,0.13,0.27,0.07,0.27,0.2,0.0,0.0,0.07,salvatore lamarca,,CPSC-1060,2016
+CPSC,1070,1,Programming Methodology,0.42,0.26,0.11,0.05,0.11,0.0,0.0,0.05,rose lowe,,CPSC-1070,2016
+CPSC,1070,2,Programming Methodology,0.5,0.22,0.17,0.0,0.06,0.0,0.0,0.06,rose lowe,,CPSC-1070,2016
+CPSC,1110,1,Intro to Programming in C,0.25,0.35,0.27,0.05,0.04,0.0,0.0,0.04,catherine hochrine,,CPSC-1110,2016
+CPSC,1110,2,Intro to Programming in C,0.27,0.37,0.17,0.02,0.1,0.0,0.0,0.08,catherine hochrine,,CPSC-1110,2016
+CPSC,1110,3,Intro to Programming in C,0.6,0.15,0.13,0.04,0.06,0.0,0.0,0.02,tania roy,,CPSC-1110,2016
+CPSC,1200,1,Intro Info Tech,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john junius porter,,CPSC-1200,2016
+CPSC,2070,1,Discrete Structures,0.27,0.27,0.24,0.08,0.09,0.0,0.0,0.04,larry hodges,,CPSC-2070,2016
+CPSC,2120,1,Algs/Data Structures,0.27,0.21,0.28,0.06,0.09,0.0,0.0,0.08,brian christop dean,,CPSC-2120,2016
+CPSC,2120,2,Algs/Data Structures,0.1,0.0,0.18,0.14,0.24,0.0,0.0,0.34,pradip srimani,,CPSC-2120,2016
+CPSC,2150,1,Software Dev Foundations,0.2,0.38,0.28,0.04,0.05,0.0,0.0,0.05,murali sitaraman,,CPSC-2150,2016
+CPSC,2200,1,Microcomputer Appl,0.27,0.36,0.12,0.1,0.03,0.0,0.0,0.12,kevin anton plis,,CPSC-2200,2016
+CPSC,2310,1,Intro Computer Org,0.21,0.32,0.37,0.01,0.05,0.0,0.0,0.05,rose lowe,,CPSC-2310,2016
+CPSC,2810,2,Sel Topics: Tech and Tools Sem,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,brian christop dean,,CPSC-2810,2016
+CPSC,2910,1,Prof Issues I,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,james jones,,CPSC-2910,2016
+CPSC,2910,3,Prof Issues I,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,yvon feaster,,CPSC-2910,2016
+CPSC,2910,4,Prof Issues I,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,yvon feaster,,CPSC-2910,2016
+CPSC,2910,5,Prof Issues I,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,yvon feaster,,CPSC-2910,2016
+CPSC,2910,6,Prof Issues I,0.53,0.26,0.11,0.0,0.0,0.0,0.0,0.11,yvon feaster,,CPSC-2910,2016
+CPSC,2920,1,"Computing, Ethics & Society",0.26,0.42,0.16,0.0,0.16,0.0,0.0,0.0,christopher plaue,,CPSC-2920,2016
+CPSC,2920,2,"Computing, Ethics & Society",0.43,0.21,0.21,0.07,0.07,0.0,0.0,0.0,christopher plaue,,CPSC-2920,2016
+CPSC,3220,1,Intro to Operating Systems,0.13,0.26,0.39,0.09,0.04,0.0,0.0,0.09,mark smotherman,,CPSC-3220,2016
+CPSC,3220,2,Intro to Operating Systems,0.1,0.32,0.26,0.1,0.1,0.0,0.0,0.13,pradip srimani,,CPSC-3220,2016
+CPSC,3300,1,Computer Systems Org,0.28,0.35,0.23,0.06,0.02,0.0,0.0,0.06,rong ge,,CPSC-3300,2016
+CPSC,3500,1,Foundations of Computer Sci,0.14,0.34,0.3,0.04,0.09,0.0,0.0,0.09,ilya mark safro,,CPSC-3500,2016
+CPSC,3520,1,Programming Systems,0.36,0.43,0.03,0.09,0.05,0.0,0.0,0.03,robert schalkoff,,CPSC-3520,2016
+CPSC,3600,2,Network Programming,0.46,0.4,0.14,0.0,0.0,0.0,0.0,0.0,lanny sitanayah,,CPSC-3600,2016
+CPSC,3600,3,Network Programming,0.51,0.29,0.11,0.0,0.03,0.0,0.0,0.06,lanny sitanayah,,CPSC-3600,2016
+CPSC,3620,1,Distributed/Cluster Computing,0.22,0.35,0.38,0.03,0.0,0.0,0.0,0.03,linh bao ngo,,CPSC-3620,2016
+CPSC,3720,1,Software Engineering,0.26,0.63,0.09,0.0,0.02,0.0,0.0,0.0,john mcgregor,,CPSC-3720,2016
+CPSC,3720,2,Software Engineering,0.21,0.53,0.16,0.0,0.05,0.0,0.0,0.05,kevin anton plis,,CPSC-3720,2016
+CPSC,3720,3,Software Engineering,0.39,0.39,0.14,0.04,0.04,0.0,0.0,0.0,kevin anton plis,,CPSC-3720,2016
+CPSC,3720,4,Software Engineering,0.08,0.42,0.25,0.0,0.08,0.0,0.0,0.17,kevin anton plis,,CPSC-3720,2016
+CPSC,3990,1,Adv CI: Extreme Orange,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james martin,,CPSC-3990,2016
+CPSC,4050,1,Computer Graphics,0.33,0.25,0.17,0.0,0.0,0.0,0.0,0.25,robert geist,,CPSC-4050,2016
+CPSC,4110,1,Virtual Reality Systems,0.4,0.33,0.17,0.03,0.07,0.0,0.0,0.0,sabarish venka babu,,CPSC-4110,2016
+CPSC,4120,1,Eye Tracking Methodology,0.35,0.55,0.05,0.0,0.0,0.0,0.0,0.05,andrew duchowski,,CPSC-4120,2016
+CPSC,4160,1,2-D Game Engine Construction,0.46,0.42,0.04,0.0,0.08,0.0,0.0,0.0,brian malloy,,CPSC-4160,2016
+CPSC,4200,1,Computer Security Principles,0.78,0.19,0.0,0.0,0.03,0.0,0.0,0.0,hongxin hu,,CPSC-4200,2016
+CPSC,4620,1,Database Management Systems,0.08,0.21,0.13,0.04,0.17,0.0,0.0,0.38,pradip srimani,,CPSC-4620,2016
+CPSC,4820,1,Spec Top:Mobile Device Sftware,0.74,0.17,0.04,0.04,0.0,0.0,0.0,0.0,roy pargas,,CPSC-4820,2016
+CPSC,4820,5,Spec Topics: Privacy and Secur,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,kelly caine,,CPSC-4820,2016
+CPSC,4820,6,Special Topics: Info to AI,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,feng luo,,CPSC-4820,2016
+CPSC,4820,9,Special Topics: Data Science,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,,CPSC-4820,2016
+CPSC,6040,1,Cptr Graphics Image,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,donald henry house,,CPSC-6040,2016
+CPSC,6110,1,Virtual Reality Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,,CPSC-6110,2016
+CPSC,6160,1,2-D Game Engine Construction,0.59,0.23,0.18,0.0,0.0,0.0,0.0,0.0,brian malloy,,CPSC-6160,2016
+CPSC,6200,1,Computer Security Principles,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,hongxin hu,,CPSC-6200,2016
+CPSC,6620,1,Database Management Systems,0.41,0.12,0.35,0.0,0.0,0.0,0.0,0.12,pradip srimani,,CPSC-6620,2016
+CPSC,6780,1,Gen Purpose Computation on GPU,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,,CPSC-6780,2016
+CPSC,6810,1,Sel Top:Programming Team,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,brian christop dean,,CPSC-6810,2016
+CPSC,6820,5,Spec Topics: Privacy and Secur,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,,CPSC-6820,2016
+CPSC,6820,9,Special Topics: Data Science,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,eileen ther kraemer,,CPSC-6820,2016
+CPSC,8070,1,3d Model Animation,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,CPSC-8070,2016
+CPSC,8070,2,3d Model Animation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,CPSC-8070,2016
+CPSC,8150,1,Fx Compositing,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,eric patterson,,CPSC-8150,2016
+CPSC,8170,1,Physically Based Animation,0.33,0.48,0.14,0.0,0.0,0.0,0.0,0.05,donald henry house,,CPSC-8170,2016
+CPSC,8200,1,Parallel Architechture,0.71,0.23,0.03,0.0,0.0,0.0,0.0,0.03,amy apon,,CPSC-8200,2016
+CPSC,8270,1,Translation of Progr Languages,0.42,0.35,0.15,0.0,0.02,0.0,0.0,0.06,brian malloy,,CPSC-8270,2016
+CPSC,8380,1,Adv Data Structures,0.17,0.17,0.17,0.0,0.5,0.0,0.0,0.0,sandra hedetniemi,,CPSC-8380,2016
+CPSC,8480,1,Network Science,0.42,0.38,0.12,0.0,0.04,0.0,0.0,0.04,ilya mark safro,,CPSC-8480,2016
+CPSC,8510,1,Soft Sys Data Comm,0.3,0.33,0.3,0.0,0.03,0.0,0.0,0.03,james martin,,CPSC-8510,2016
+CPSC,8580,1,Security in Emerging Systems,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.02,hongxin hu,,CPSC-8580,2016
+CPSC,8700,1,Software Design,0.5,0.18,0.1,0.0,0.05,0.0,0.0,0.18,philippa mign brown,,CPSC-8700,2016
+CPSC,8730,1,"Software Verif, Valid & Measur",0.33,0.59,0.05,0.0,0.03,0.0,0.0,0.0,john mcgregor,,CPSC-8730,2016
+CPSC,8810,2,Selected Topics: 3D Game Devel,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,CPSC-8810,2016
+CPSC,8810,3,Sel Top: Adv 3D Model and Scul,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,insun kwon,,CPSC-8810,2016
+CRP,8010,1,Planning Process & Legal Found,0.42,0.46,0.0,0.0,0.08,0.0,0.0,0.04,caitlin dyckman,,CRP-8010,2016
+CRP,8020,1,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,,CRP-8020,2016
+CRP,8030,1,Quant Analysis,0.71,0.21,0.0,0.0,0.04,0.0,0.0,0.04,stephen sperry,,CRP-8030,2016
+CRP,8060,1,Urban & Reg Econ for Planners,0.73,0.15,0.0,0.0,0.08,0.0,0.0,0.04,timothy green,,CRP-8060,2016
+CRP,8140,1,Public Transit,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,,CRP-8140,2016
+CRP,8580,2,Research Design,0.84,0.0,0.0,0.0,0.11,0.0,0.0,0.05,timothy green,,CRP-8580,2016
+CRP,8600,3,Terminal Proj/Thesis Proposal,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,clifford dona ellis,,CRP-8600,2016
+CRP,8600,6,Terminal Proj/Thesis Proposal,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,eric morris,,CRP-8600,2016
+CRP,8720,1,Housing in the U S,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,miller cunningham,,CRP-8720,2016
+CRP,8900,4,Dir Studies in City & Reg Plan,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,clifford dona ellis,,CRP-8900,2016
+CSM,1000,1,Intro to Construct,0.25,0.48,0.23,0.02,0.02,0.0,0.0,0.0,jason lucas,,CSM-1000,2016
+CSM,2010,1,Structures I,0.19,0.35,0.19,0.12,0.12,0.0,0.0,0.04,shima clarke,,CSM-2010,2016
+CSM,2010,2,Structures I,0.33,0.17,0.29,0.08,0.08,0.0,0.0,0.04,shima clarke,,CSM-2010,2016
+CSM,2030,1,Mats & Meth of Const,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,jason lucas,,CSM-2030,2016
+CSM,2030,2,Mats & Meth of Const,0.32,0.5,0.11,0.0,0.0,0.0,0.0,0.07,jason lucas,,CSM-2030,2016
+CSM,3030,1,Soils & Foundations,0.63,0.28,0.09,0.0,0.0,0.0,0.0,0.0,shima clarke,,CSM-3030,2016
+CSM,3030,2,Soils & Foundations,0.56,0.34,0.09,0.0,0.0,0.0,0.0,0.0,shima clarke,,CSM-3030,2016
+CSM,3040,1,Envir Systems I,0.23,0.48,0.23,0.06,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2016
+CSM,3040,2,Envir Systems I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2016
+CSM,3510,1,Const Estimating,0.23,0.5,0.27,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,,CSM-3510,2016
+CSM,3510,2,Const Estimating,0.23,0.5,0.23,0.0,0.0,0.0,0.0,0.03,seyed mousavi rizi,,CSM-3510,2016
+CSM,4110,1,Safety in Bldg Const,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,david devita,,CSM-4110,2016
+CSM,4500,1,Construction Intern,0.38,0.32,0.1,0.0,0.2,0.0,0.0,0.0,roger william liska,,CSM-4500,2016
+CSM,4530,1,Const Proj Mgmt,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-4530,2016
+CSM,4530,2,Const Proj Mgmt,0.08,0.58,0.33,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-4530,2016
+CSM,4610,1,Const Econ Seminar,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4610,2016
+CSM,4610,2,Const Econ Seminar,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4610,2016
+CSM,8600,1,Constr Finan Plan & Analysis,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8600,2016
+CSM,8600,400,Constr Finan Plan & Analysis,0.38,0.38,0.0,0.0,0.0,0.0,0.0,0.25,dennis bausman,,CSM-8600,2016
+CSM,8630,1,Adv Plan/Sched,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-8630,2016
+CSM,8630,400,Adv Plan/Sched,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-8630,2016
+CSM,8660,1,Role in Development,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8660,2016
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.01,susan whorton,,CU-1000,2016
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.25,0.0,susan whorton,,CU-1000,2016
+CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.71,0.29,0.0,susan whorton,,CU-1000,2016
+CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.21,0.02,susan whorton,,CU-1000,2016
+CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.01,susan whorton,,CU-1000,2016
+CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.71,0.29,0.0,susan whorton,,CU-1000,2016
+CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.25,0.0,susan whorton,,CU-1000,2016
+CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.69,0.3,0.01,susan whorton,,CU-1000,2016
+CU,1000,9,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.66,0.34,0.01,susan whorton,,CU-1000,2016
+CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.61,0.38,0.01,susan whorton,,CU-1000,2016
+CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.59,0.41,0.01,susan whorton,,CU-1000,2016
+CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.51,0.47,0.01,susan whorton,,CU-1000,2016
+CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.51,0.48,0.01,susan whorton,,CU-1000,2016
+CU,1000,15,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.41,0.58,0.01,susan whorton,,CU-1000,2016
+CU,1010,2,Univ Success Skills,0.11,0.32,0.21,0.0,0.16,0.0,0.0,0.21,matthew james kirk,,CU-1010,2016
+CU,1010,3,Univ Success Skills,0.69,0.06,0.06,0.13,0.0,0.0,0.0,0.06,mary mcp von kaenel,,CU-1010,2016
+CU,1010,5,Univ Success Skills,0.32,0.05,0.32,0.16,0.16,0.0,0.0,0.0,cari allyn brooks,,CU-1010,2016
+CU,1010,6,Univ Success Skills,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,mary mcp von kaenel,,CU-1010,2016
+CU,2010,1,Sustainability Leadership,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,,CU-2010,2016
+DANC,1400,1,Jazz Dance I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,cheryl hosler,,DANC-1400,2016
+DPA,3070,1,Method 3d Production,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,summer 'nea benton,,DPA-3070,2016
+DPA,4000,1,Tech Foundations I,0.0,0.0,0.09,0.0,0.64,0.0,0.0,0.27,andrew duchowski,,DPA-4000,2016
+DPA,4020,2,Vis Foundations I,0.79,0.0,0.14,0.0,0.07,0.0,0.0,0.0,erik reed,,DPA-4020,2016
+DPA,4020,3,Vis Foundations I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,pratham karnik,,DPA-4020,2016
+ECE,2010,1,Logic and Computing Devices,0.24,0.25,0.27,0.08,0.12,0.0,0.0,0.04,william reid,,ECE-2010,2016
+ECE,2020,1,Electric Circuits I,0.28,0.35,0.21,0.1,0.06,0.0,0.0,0.0,william harrell,,ECE-2020,2016
+ECE,2020,3,Electric Circuits I,0.12,0.3,0.33,0.09,0.09,0.0,0.0,0.06,daniel bla cutshall,,ECE-2020,2016
+ECE,2070,1,Basic Electrical Engineering,0.36,0.33,0.13,0.06,0.04,0.0,0.0,0.07,william th kolodzey,,ECE-2070,2016
+ECE,2070,2,Basic Electrical Engineering,0.21,0.38,0.26,0.0,0.09,0.0,0.0,0.06,timothy anglea,,ECE-2070,2016
+ECE,2070,3,Basic Electrical Engineering,0.46,0.29,0.12,0.02,0.02,0.0,0.0,0.1,amir ahmed asif,,ECE-2070,2016
+ECE,2080,1,Basic Electrical Engr Lab,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,5,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,6,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,7,Basic Electrical Engr Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,8,Basic Electrical Engr Lab,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,10,Basic Electrical Engr Lab,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,12,Basic Electrical Engr Lab,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,13,Basic Electrical Engr Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,,ECE-2080,2016
+ECE,2090,1,Logic Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2016
+ECE,2090,2,Logic Lab,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2090,2016
+ECE,2090,3,Logic Lab,0.67,0.17,0.0,0.08,0.08,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2016
+ECE,2090,4,Logic Lab,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2016
+ECE,2090,5,Logic Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2090,2016
+ECE,2090,7,Logic Lab,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2090,2016
+ECE,2090,9,Logic Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2016
+ECE,2090,10,Logic Lab,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2090,2016
+ECE,2110,1,Elec Engr Lab I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2110,2016
+ECE,2110,5,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2110,2016
+ECE,2110,6,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2110,2016
+ECE,2110,7,Elec Engr Lab I,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,,ECE-2110,2016
+ECE,2110,9,Elec Engr Lab I,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2110,2016
+ECE,2120,1,Electrical Engineering Lab II,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,apoorva dee kapadia,,ECE-2120,2016
+ECE,2120,3,Electrical Engineering Lab II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,,ECE-2120,2016
+ECE,2220,1,Syst Prog Concept,0.14,0.38,0.14,0.08,0.08,0.0,0.0,0.19,harlan russell,,ECE-2220,2016
+ECE,2230,1,Comp Sys Eng,0.26,0.31,0.18,0.05,0.1,0.0,0.0,0.1,harlan russell,,ECE-2230,2016
+ECE,2620,1,Electric Circuits II,0.26,0.19,0.3,0.09,0.12,0.0,0.0,0.05,liang dong,,ECE-2620,2016
+ECE,2720,1,Comp Organization,0.17,0.37,0.29,0.12,0.05,0.0,0.0,0.0,william reid,,ECE-2720,2016
+ECE,2730,2,Computer Org Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2016
+ECE,2730,3,Computer Org Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2016
+ECE,3110,2,Electrical Engineering Lab III,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2016
+ECE,3110,4,Electrical Engineering Lab III,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,apoorva dee kapadia,,ECE-3110,2016
+ECE,3170,1,Rand Signal Analysis,0.16,0.4,0.31,0.07,0.04,0.0,0.0,0.02,stephen hubbard,,ECE-3170,2016
+ECE,3200,1,Electronics I,0.12,0.31,0.31,0.12,0.13,0.0,0.0,0.03,stephen hubbard,,ECE-3200,2016
+ECE,3200,2,Electronics I (HON),0.36,0.43,0.14,0.0,0.07,0.0,0.0,0.0,stephen hubbard,True,ECE-3200,2016
+ECE,3210,1,Electronics II,0.19,0.41,0.31,0.03,0.03,0.0,0.0,0.03,stephen hubbard,,ECE-3210,2016
+ECE,3220,2,Intro Operating Sys,0.15,0.25,0.35,0.15,0.0,0.0,0.0,0.1,pradip srimani,,ECE-3220,2016
+ECE,3270,1,Dig Comp Design,0.26,0.22,0.3,0.04,0.09,0.0,0.0,0.09,melissa crawl smith,,ECE-3270,2016
+ECE,3300,1,Signals & Systems,0.13,0.23,0.32,0.18,0.08,0.0,0.0,0.06,carl baum,,ECE-3300,2016
+ECE,3300,2,Signals & Systems (HON),0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True,ECE-3300,2016
+ECE,3520,1,Programming Systems,0.43,0.29,0.0,0.07,0.14,0.0,0.0,0.07,robert schalkoff,,ECE-3520,2016
+ECE,3600,1,Elect Power Engr,0.42,0.28,0.2,0.04,0.03,0.0,0.0,0.03,edward collins,,ECE-3600,2016
+ECE,3710,1,Microcontr Interface,0.34,0.34,0.27,0.01,0.01,0.0,0.0,0.01,william reid,,ECE-3710,2016
+ECE,3720,1,Micro Int Lab,0.42,0.33,0.17,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2016
+ECE,3720,2,Micro Int Lab,0.08,0.5,0.42,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2016
+ECE,3720,3,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-3720,2016
+ECE,3720,4,Micro Int Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-3720,2016
+ECE,3720,6,Micro Int Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-3720,2016
+ECE,3800,1,Electromagnetics,0.42,0.33,0.12,0.03,0.03,0.0,0.0,0.07,hai xiao,,ECE-3800,2016
+ECE,3810,1,Field Waves & Ckts,0.09,0.43,0.31,0.09,0.09,0.0,0.0,0.0,anthony martin,,ECE-3810,2016
+ECE,4090,1,Intr to Linear Control Systems,0.39,0.36,0.16,0.02,0.04,0.0,0.0,0.02,apoorva dee kapadia,,ECE-4090,2016
+ECE,4180,1,Power Syst Analysis,0.35,0.27,0.27,0.04,0.04,0.0,0.0,0.04,elham makram,,ECE-4180,2016
+ECE,4270,1,Communications Sys,0.37,0.27,0.13,0.15,0.08,0.0,0.0,0.0,madhabi manandhar,,ECE-4270,2016
+ECE,4420,1,Knowledge Engr,0.33,0.38,0.05,0.1,0.0,0.0,0.0,0.14,robert schalkoff,,ECE-4420,2016
+ECE,4490,1,Comp Ntwrk Security,0.32,0.42,0.03,0.0,0.05,0.0,0.0,0.18,richard brooks,,ECE-4490,2016
+ECE,4610,1,Fundamentals of Solar Energy,0.47,0.39,0.08,0.03,0.03,0.0,0.0,0.0,rajendra singh,,ECE-4610,2016
+ECE,4670,1,Intro to Dig Sig Pro,0.24,0.24,0.29,0.06,0.06,0.0,0.0,0.12,john gowdy,,ECE-4670,2016
+ECE,4730,1,Intro Parallel Sys,0.15,0.69,0.15,0.0,0.0,0.0,0.0,0.0,walter ligon,,ECE-4730,2016
+ECE,4950,1,Int Sys Design I,0.73,0.24,0.03,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4950,2016
+ECE,4960,1,Int Sys Design II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2016
+ECE,6040,1,Semiconductor Devices,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-6040,2016
+ECE,6420,1,Knowledge Engr,0.41,0.31,0.14,0.0,0.14,0.0,0.0,0.0,robert schalkoff,,ECE-6420,2016
+ECE,6490,1,Comp Ntwrk Security,0.31,0.38,0.13,0.0,0.13,0.0,0.0,0.06,lu yu,,ECE-6490,2016
+ECE,6670,1,Intro to Dig Sig Pro,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,john gowdy,,ECE-6670,2016
+ECE,6730,1,Intro Parallel Sys,0.33,0.25,0.0,0.0,0.33,0.0,0.0,0.08,walter ligon,,ECE-6730,2016
+ECE,6930,5,Network science,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,,ECE-6930,2016
+ECE,8010,1,Analysis of Lin Sys,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,richard groff,,ECE-8010,2016
+ECE,8170,1,Power System Transients,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,ramtin hadidi,,ECE-8170,2016
+ECE,8180,1,Rand Proc Appl Engr,0.46,0.38,0.0,0.0,0.15,0.0,0.0,0.0,carl baum,,ECE-8180,2016
+ECE,8910,30,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,0.6,0.4,0.0,robert schalkoff,,ECE-8910,2016
+ECON,2000,1,Economic Concepts,0.4,0.35,0.15,0.08,0.0,0.0,0.0,0.03,jonathan orr ernest,,ECON-2000,2016
+ECON,2000,2,Economic Concepts,0.5,0.25,0.13,0.05,0.03,0.0,0.0,0.05,jonathan orr ernest,,ECON-2000,2016
+ECON,2000,3,Economic Concepts,0.3,0.35,0.2,0.13,0.03,0.0,0.0,0.0,miren ivankovic,,ECON-2000,2016
+ECON,2110,1,Principles of Microeconomics,0.17,0.61,0.11,0.0,0.11,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2016
+ECON,2110,2,Principles of Microeconomics,0.11,0.16,0.16,0.21,0.32,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2016
+ECON,2110,3,Principles of Microeconomics,0.06,0.44,0.28,0.11,0.06,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2016
+ECON,2110,4,Principles of Microeconomics,0.11,0.37,0.42,0.0,0.0,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2016
+ECON,2110,5,Principles of Microeconomics,0.0,0.37,0.26,0.26,0.05,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2016
+ECON,2110,6,Principles of Microeconomics,0.11,0.21,0.42,0.11,0.11,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2016
+ECON,2110,7,Principles of Microeconomics,0.11,0.47,0.11,0.05,0.16,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2016
+ECON,2110,8,Principles of Microeconomics,0.05,0.32,0.53,0.05,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2016
+ECON,2110,9,Principles of Microeconomics,0.11,0.47,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2016
+ECON,2110,10,Principles of Microeconomics,0.26,0.26,0.37,0.05,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2016
+ECON,2110,11,Principles of Microeconomics,0.06,0.56,0.22,0.11,0.0,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2016
+ECON,2110,12,Principles of Microeconomics,0.21,0.37,0.32,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2016
+ECON,2110,13,Principles of Microeconomics,0.13,0.44,0.31,0.0,0.06,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2016
+ECON,2110,14,Principles of Microeconomics,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2016
+ECON,2110,15,Principles of Microeconomics,0.16,0.47,0.26,0.0,0.11,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2016
+ECON,2110,16,Principles of Microeconomics,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2016
+ECON,2110,17,Principles of Microeconomics,0.05,0.53,0.37,0.0,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2016
+ECON,2110,18,Principles of Microeconomics,0.16,0.37,0.32,0.05,0.05,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2016
+ECON,2110,19,Principles of Microeconomics,0.05,0.47,0.21,0.16,0.05,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2016
+ECON,2110,20,Principles of Microeconomics,0.26,0.42,0.22,0.05,0.04,0.0,0.0,0.01,kelsey vict roberts,,ECON-2110,2016
+ECON,2110,21,Principles of Microeconomics,0.18,0.41,0.35,0.02,0.0,0.0,0.0,0.04,bradley keith hobbs,,ECON-2110,2016
+ECON,2110,22,Principles of Microeconomics,0.45,0.27,0.16,0.05,0.05,0.0,0.0,0.02,benjamin jo schwall,,ECON-2110,2016
+ECON,2110,23,Principles of Microeconomics,0.24,0.4,0.16,0.09,0.06,0.0,0.0,0.04,leah jacq kitashima,,ECON-2110,2016
+ECON,2110,24,Principles of Microeconomics,0.27,0.31,0.2,0.08,0.08,0.0,0.0,0.06,amanda caitlin kerr,,ECON-2110,2016
+ECON,2110,25,Principles of Microeconomics,0.23,0.5,0.1,0.03,0.05,0.0,0.0,0.1,roksan ghanbariamin,,ECON-2110,2016
+ECON,2110,26,Principles of Microeconomics,0.38,0.29,0.13,0.09,0.02,0.0,0.0,0.09,steven johnson,,ECON-2110,2016
+ECON,2110,31,Principles of Microeconomics,0.44,0.36,0.1,0.04,0.03,0.0,0.0,0.04,maria droganova,,ECON-2110,2016
+ECON,2110,32,Principles of Microeconomics,0.29,0.36,0.29,0.07,0.0,0.0,0.0,0.0,zhiqi zhao,,ECON-2110,2016
+ECON,2110,33,Principles of Microeconomics,0.38,0.28,0.15,0.08,0.03,0.0,0.0,0.08,liuna issagholian,,ECON-2110,2016
+ECON,2110,34,Principles of Microeconomics,0.33,0.26,0.28,0.08,0.0,0.0,0.0,0.05,liuna issagholian,,ECON-2110,2016
+ECON,2110,35,Principles of Microeconomics,0.38,0.38,0.13,0.08,0.03,0.0,0.0,0.03,roksan ghanbariamin,,ECON-2110,2016
+ECON,2110,38,Principles of Microeconomics,0.21,0.6,0.14,0.0,0.02,0.0,0.0,0.02,chen wang,,ECON-2110,2016
+ECON,2110,40,Principles of Micro (HON),0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,charles thomas,True,ECON-2110,2016
+ECON,2110,41,Principles of Microeconomics,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,chen wang,,ECON-2110,2016
+ECON,2120,1,Principles of Macroeconomics,0.07,0.16,0.16,0.16,0.16,0.0,0.0,0.29,ralph charles allen,,ECON-2120,2016
+ECON,2120,2,Principles of Macroeconomics,0.32,0.39,0.16,0.07,0.02,0.0,0.0,0.05,wing yin chung,,ECON-2120,2016
+ECON,2120,3,Principles of Macroeconomics,0.11,0.21,0.23,0.18,0.13,0.0,0.0,0.14,ralph charles allen,,ECON-2120,2016
+ECON,2120,4,Principles of Macroeconomics,0.22,0.22,0.32,0.07,0.12,0.0,0.0,0.05,peter david lorenz,,ECON-2120,2016
+ECON,2120,5,Principles of Macroeconomics,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,huili li,,ECON-2120,2016
+ECON,2120,6,Principles of Macroeconomics,0.78,0.2,0.03,0.0,0.0,0.0,0.0,0.0,huili li,,ECON-2120,2016
+ECON,2120,7,Principles of Macroeconomics,0.28,0.35,0.25,0.13,0.0,0.0,0.0,0.0,peter david lorenz,,ECON-2120,2016
+ECON,2120,8,Principles of Macroeconomics,0.18,0.44,0.24,0.08,0.02,0.0,0.0,0.05,ce castellon chicas,,ECON-2120,2016
+ECON,2120,9,Principles of Macroeconomics,0.43,0.32,0.14,0.05,0.0,0.0,0.0,0.05,jordan adamson,,ECON-2120,2016
+ECON,2120,10,Principles of Macroeconomics,0.17,0.42,0.22,0.11,0.06,0.0,0.0,0.03,andrew chaffee,,ECON-2120,2016
+ECON,3020,1,Money and Banking,0.24,0.22,0.3,0.08,0.08,0.0,0.0,0.08,smriti bhargava,,ECON-3020,2016
+ECON,3060,1,Managerial Economics,0.21,0.34,0.29,0.08,0.05,0.0,0.0,0.03,timothy jay bacon,,ECON-3060,2016
+ECON,3100,1,International Econ,0.32,0.41,0.13,0.01,0.07,0.0,0.0,0.06,scott baier,,ECON-3100,2016
+ECON,3140,1,Intermediate Micro,0.38,0.11,0.3,0.09,0.09,0.0,0.0,0.02,patrick warren,,ECON-3140,2016
+ECON,3140,2,Intermediate Micro,0.32,0.44,0.19,0.02,0.0,0.0,0.0,0.03,molly espey,,ECON-3140,2016
+ECON,3140,3,Intermediate Micro,0.28,0.21,0.28,0.09,0.06,0.0,0.0,0.09,robert kennet fleck,,ECON-3140,2016
+ECON,3150,1,Intermediate Macro,0.22,0.29,0.24,0.04,0.06,0.0,0.0,0.16,sergey vla mityakov,,ECON-3150,2016
+ECON,3150,2,Intermediate Macro,0.22,0.34,0.2,0.17,0.05,0.0,0.0,0.02,michal jerzmanowski,,ECON-3150,2016
+ECON,3190,1,Environmental Econ,0.05,0.46,0.35,0.08,0.05,0.0,0.0,0.0,molly espey,,ECON-3190,2016
+ECON,3500,1,Moral & Ethical Econ,0.1,0.33,0.29,0.05,0.1,0.0,0.0,0.14,bradley keith hobbs,,ECON-3500,2016
+ECON,3600,1,Public Choice,0.41,0.15,0.15,0.17,0.02,0.0,0.0,0.1,michael makowsky,,ECON-3600,2016
+ECON,4010,1,Labor Mkt Analysis,0.42,0.21,0.16,0.16,0.05,0.0,0.0,0.0,chungsang lam,,ECON-4010,2016
+ECON,4040,1,Comp Econ Systems,0.22,0.19,0.15,0.07,0.19,0.0,0.0,0.19,dar litsukova-bokar,,ECON-4040,2016
+ECON,4050,5,Intro to Econometric,0.18,0.34,0.24,0.04,0.1,0.0,0.0,0.1,scott barkowski,,ECON-4050,2016
+ECON,4100,1,Economic Development,0.44,0.19,0.04,0.0,0.07,0.0,0.0,0.26,robert tamura,,ECON-4100,2016
+ECON,4110,2,Econ of Education,0.27,0.5,0.08,0.0,0.04,0.0,0.0,0.12,peter quarter blair,,ECON-4110,2016
+ECON,4120,1,International Micro,0.42,0.36,0.13,0.07,0.0,0.0,0.0,0.02,richard alan sessa,,ECON-4120,2016
+ECON,4220,1,Monetary Economics,0.45,0.42,0.09,0.0,0.03,0.0,0.0,0.0,gerald dwyer,,ECON-4220,2016
+ECON,6060,1,Advanced Econometric,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,,ECON-6060,2016
+ECON,8010,1,Microeconomic Theory,0.26,0.37,0.26,0.0,0.05,0.0,0.0,0.05,william dougan,,ECON-8010,2016
+ECON,8040,1,Applied Math Econ,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,,ECON-8040,2016
+ECON,8060,1,Econometrics I,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,paul wayne wilson,,ECON-8060,2016
+ECON,8080,1,Econometrics III,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,paul wayne wilson,,ECON-8080,2016
+ECON,8160,1,Labor Economics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,,ECON-8160,2016
+ECON,8210,1,Public Choice,0.5,0.17,0.17,0.0,0.17,0.0,0.0,0.0,patrick warren,,ECON-8210,2016
+ECON,8230,1,Microecon Pub Pol,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,,ECON-8230,2016
+ECON,8240,1,Org of Industry,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew lewis,,ECON-8240,2016
+ECON,8260,1,Econ Theory of Govt Regulation,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,,ECON-8260,2016
+ECON,8550,1,Financial Economics,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,sergey vla mityakov,,ECON-8550,2016
+ECON,9010,1,Price Theory,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,charles thomas,,ECON-9010,2016
+ED,1970,1,Student of Color Experience CI,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2016
+ED,1970,2,Student of Color Experience CI,0.76,0.1,0.05,0.0,0.1,0.0,0.0,0.0,deonte brown,,ED-1970,2016
+ED,1970,3,Student of Color Experience CI,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,deonte brown,,ED-1970,2016
+ED,8700,1,STEAM Instructional Design,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,cassie fay quigley,,ED-8700,2016
+ED,8720,500,STEAM Enacted and Evaluated,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,danielle chri herro,,ED-8720,2016
+EDC,8050,1,Clinical Mh Couns,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,david scott,,EDC-8050,2016
+EDC,8130,400,Appraisal Procedures,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,jennifer lyn brooks,,EDC-8130,2016
+EDEC,8200,500,Adv Ece Curriculum,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-8200,2016
+EDEL,3210,1,Pe for the Elem Tchr,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2016
+EDEL,3210,2,Pe for the Elem Tchr,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,deborah smith,,EDEL-3210,2016
+EDEL,4510,1,Elem Methods in Science Tchg,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,,EDEL-4510,2016
+EDEL,4870,1,Ele Meth Soc Studies,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,,EDEL-4870,2016
+EDEL,4880,1,Elem Meth La Tchng,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,,EDEL-4880,2016
+EDF,3010,1,Principles of American Educat,0.52,0.22,0.17,0.09,0.0,0.0,0.0,0.0,suzanne rosenblith,,EDF-3010,2016
+EDF,3020,1,Educational Psychology,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.03,heather rog brooker,,EDF-3020,2016
+EDF,3080,1,Classroom Assessment,0.56,0.32,0.08,0.0,0.0,0.0,0.0,0.04,deborah switzer,,EDF-3080,2016
+EDF,3080,2,Classroom Assessment,0.71,0.19,0.1,0.0,0.0,0.0,0.0,0.0,deborah switzer,,EDF-3080,2016
+EDF,3340,3,Child Growth and Development,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,faiza marghoo jamil,,EDF-3340,2016
+EDF,3350,1,Adolescent Growth & Develop,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,,EDF-3350,2016
+EDF,4800,1,Digital Media & Learning,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,ryan visser,,EDF-4800,2016
+EDF,4800,2,Digital Media & Learning,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2016
+EDF,4800,3,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,danielle chri herro,,EDF-4800,2016
+EDF,4800,300,Digital Media & Learning,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,ryan visser,,EDF-4800,2016
+EDF,8770,300,Research Meth in Education I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,carleton dew salley,,EDF-8770,2016
+EDF,9270,1,Quant Rsrch & Stats for Ed,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jennie lynn farmer,,EDF-9270,2016
+EDF,9270,2,Quant Rsrch & Stats for Ed,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,jennie lynn farmer,,EDF-9270,2016
+EDF,9810,1,Design-Based Research Methods,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,david paul reinking,,EDF-9810,2016
+EDHD,8310,500,Lit Outcomes for Child w disab,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,vicki steadman,,EDHD-8310,2016
+EDL,7000,501,Public School Adm,0.79,0.07,0.0,0.0,0.14,0.0,0.0,0.0,frederick buskey,,EDL-7000,2016
+EDL,7200,400,School Personnel Adm,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,kathryn le 'andrea,,EDL-7200,2016
+EDL,7500,500,El Prin & Spv Ex I,0.71,0.0,0.0,0.0,0.29,0.0,0.0,0.0,frederick buskey,,EDL-7500,2016
+EDL,8150,501,The Superintendency,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,elizabeth reynolds,,EDL-8150,2016
+EDL,8390,401,Research in Ed L,0.42,0.42,0.0,0.0,0.17,0.0,0.0,0.0,kristin kelly frady,,EDL-8390,2016
+EDL,8510,501,School Sys Prac II,0.21,0.0,0.0,0.0,0.79,0.0,0.0,0.0,elizabeth reynolds,,EDL-8510,2016
+EDL,8850,512,STEM - School Admin,0.44,0.0,0.0,0.0,0.56,0.0,0.0,0.0,william havice,,EDL-8850,2016
+EDL,9100,400,Intro Phd Seminar,0.82,0.0,0.0,0.0,0.18,0.0,0.0,0.0,jane lindle,,EDL-9100,2016
+EDL,9650,1,Higher Ed Finance,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,,EDL-9650,2016
+EDLT,4600,1,Teaching Reading Grades 2-6,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rebecca kaminski,,EDLT-4600,2016
+EDLT,4600,3,Teaching Reading Grades 2-6,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4600,2016
+EDLT,4600,5,Teaching Reading Grades 2-6,0.69,0.19,0.04,0.0,0.0,0.0,0.0,0.08,pamela dunston,,EDLT-4600,2016
+EDLT,4610,1,Content Area Rdg: Grades 2-6,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-4610,2016
+EDLT,4980,1,Secondary Content Area Reading,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,corrie leigh martin,,EDLT-4980,2016
+EDLT,8160,500,Literacy Instruction Practicum,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,,EDLT-8160,2016
+EDLT,8400,500,Early Literacy Assessment I,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,andrea chri overton,,EDLT-8400,2016
+EDLT,8400,504,Early Literacy Assessment I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,,EDLT-8400,2016
+EDLT,9370,501,Reading Recovery Theory I,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,celeste compt bates,,EDLT-9370,2016
+EDML,8340,400,Envir Sci for Mid Sch Teachers,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,michelle patri cook,,EDML-8340,2016
+EDSA,8030,1,Student Dev Servc in Higher Ed,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,,EDSA-8030,2016
+EDSA,8030,2,Student Dev Servc in Higher Ed,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,,EDSA-8030,2016
+EDSC,2260,1,Pr Apprch to Sec Alg,0.31,0.54,0.08,0.0,0.08,0.0,0.0,0.0,stacy megan che,,EDSC-2260,2016
+EDSC,3240,1,Practicum Sec Engl,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,,EDSC-3240,2016
+EDSC,4260,1,Tchng Sec Math,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,carlos gomez,,EDSC-4260,2016
+EDSC,8610,400,Mthds & Strt Secondary Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,,EDSC-8610,2016
+EDSP,3700,2,Intro to Special Education,0.79,0.15,0.06,0.0,0.0,0.0,0.0,0.0,tracy denis garrett,,EDSP-3700,2016
+EDSP,3700,3,Intro to Special Education,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,jennifer my- counts,,EDSP-3700,2016
+EDSP,3700,4,Intro to Special Education,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,michelle lee popham,,EDSP-3700,2016
+EDSP,3740,1,Char & Strat Emot/Behav Disord,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,,EDSP-3740,2016
+EDSP,4920,1,Math Inst Ind W/Dis,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,pamela stecker,,EDSP-4920,2016
+EDSP,4940,1,Tchg Rdg Mild Dis,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,,EDSP-4940,2016
+EDSP,8220,400,Tchg Math Indv W/Dis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,,EDSP-8220,2016
+EDSP,8530,1,Legal/Pol Issu Sp Ed,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,antonis katsiyannis,,EDSP-8530,2016
+EES,2010,1,Environ Engr Fundamentals I,0.38,0.27,0.17,0.04,0.1,0.0,0.0,0.04,david freedman,,EES-2010,2016
+EES,3030,1,Water Treatment Systems,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3030,2016
+EES,3040,1,Wastewater Treatment Systems,0.43,0.39,0.18,0.0,0.0,0.0,0.0,0.0,sudeep popat,,EES-3040,2016
+EES,3050,1,Water/Wastewater Treatment Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2016
+EES,3050,2,Water/Wastewater Treatment Lab,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2016
+EES,4010,1,Environmental Engr,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,elizabeth carraway,,EES-4010,2016
+EES,4010,2,Environmental Engr,0.17,0.26,0.43,0.13,0.0,0.0,0.0,0.0,mark schlautman,,EES-4010,2016
+EES,4100,1,Environ Radiation Protection I,0.27,0.36,0.09,0.18,0.0,0.0,0.0,0.09,nicole eli martinez,,EES-4100,2016
+EES,4300,1,Air Pollution Engineering,0.21,0.54,0.21,0.04,0.0,0.0,0.0,0.0,thomas overcamp,,EES-4300,2016
+EES,4800,1,Environmental Risk Assessment,0.58,0.19,0.22,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,,EES-4800,2016
+EES,4860,5,Environmental Sustainability,0.6,0.23,0.14,0.0,0.0,0.0,0.0,0.03,michael anthon dale,,EES-4860,2016
+EES,8020,1,Environ Eng Prin,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-8020,2016
+EES,8430,1,Environmental Chem,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,,EES-8430,2016
+EES,8510,1,Biol Prin Envir Engr,0.66,0.28,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,,EES-8510,2016
+EES,8610,1,Env Engr&Sci Seminar,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,ezra lucas ho cates,,EES-8610,2016
+EES,8800,1,Env Risk Assessment,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,,EES-8800,2016
+ELE,3010,1,Intro to Entre,0.59,0.23,0.13,0.05,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2016
+ELE,3010,2,Intro to Entre,0.51,0.38,0.03,0.03,0.0,0.0,0.0,0.05,christina kyprianou,,ELE-3010,2016
+ELE,3010,3,Intro to Entre,0.11,0.45,0.42,0.0,0.03,0.0,0.0,0.0,ashley will parnell,,ELE-3010,2016
+ELE,4010,1,Exec Lead & Entr II,0.04,0.29,0.51,0.11,0.0,0.0,0.0,0.04,ashley will parnell,,ELE-4010,2016
+ENGL,1030,1,Accelerated Composition,0.0,0.79,0.16,0.0,0.0,0.0,0.0,0.05,renesha moniq poole,,ENGL-1030,2016
+ENGL,1030,2,Accelerated Composition,0.42,0.47,0.0,0.05,0.05,0.0,0.0,0.0,renesha moniq poole,,ENGL-1030,2016
+ENGL,1030,3,Accelerated Composition,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,christa kettlewell,,ENGL-1030,2016
+ENGL,1030,4,Accelerated Composition,0.63,0.11,0.05,0.05,0.11,0.0,0.0,0.05,chloe helene cahill,,ENGL-1030,2016
+ENGL,1030,5,Accelerated Composition,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,laurie pfister epps,,ENGL-1030,2016
+ENGL,1030,7,Accelerated Composition,0.5,0.28,0.06,0.11,0.06,0.0,0.0,0.0,robert brissey,,ENGL-1030,2016
+ENGL,1030,8,Accelerated Composition,0.42,0.47,0.05,0.0,0.05,0.0,0.0,0.0,christa kettlewell,,ENGL-1030,2016
+ENGL,1030,9,Accelerated Composition,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,chloe helene cahill,,ENGL-1030,2016
+ENGL,1030,10,Accelerated Composition,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,laurie pfister epps,,ENGL-1030,2016
+ENGL,1030,12,Accelerated Composition,0.37,0.37,0.16,0.0,0.11,0.0,0.0,0.0,robert brissey,,ENGL-1030,2016
+ENGL,1030,15,Accelerated Composition,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,karen kettnich,,ENGL-1030,2016
+ENGL,1030,17,Accelerated Composition,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,matthew scot duncan,,ENGL-1030,2016
+ENGL,1030,18,Accelerated Composition,0.74,0.11,0.0,0.0,0.0,0.0,0.0,0.16,parker elizabe king,,ENGL-1030,2016
+ENGL,1030,19,Accelerated Composition,0.42,0.32,0.05,0.16,0.05,0.0,0.0,0.0,jennifer forsberg,,ENGL-1030,2016
+ENGL,1030,21,Accelerated Composition,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulo green,,ENGL-1030,2016
+ENGL,1030,22,Accelerated Composition,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,benjamin hudson,,ENGL-1030,2016
+ENGL,1030,23,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,katie jo vann,,ENGL-1030,2016
+ENGL,1030,24,Accelerated Composition,0.35,0.47,0.06,0.0,0.06,0.0,0.0,0.06,matthew scot duncan,,ENGL-1030,2016
+ENGL,1030,25,Accelerated Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,parker elizabe king,,ENGL-1030,2016
+ENGL,1030,26,Accelerated Composition,0.53,0.37,0.0,0.0,0.11,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2016
+ENGL,1030,27,Accelerated Composition,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2016
+ENGL,1030,29,Accelerated Composition,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,dia quaglia beltran,,ENGL-1030,2016
+ENGL,1030,30,Accelerated Composition,0.32,0.42,0.11,0.0,0.16,0.0,0.0,0.0,la'cresha ulo green,,ENGL-1030,2016
+ENGL,1030,31,Accelerated Composition,0.67,0.17,0.06,0.06,0.06,0.0,0.0,0.0,brian lee gaines,,ENGL-1030,2016
+ENGL,1030,32,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kala parker,,ENGL-1030,2016
+ENGL,1030,33,Accelerated Composition,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,michael davi measel,,ENGL-1030,2016
+ENGL,1030,34,Accelerated Composition,0.6,0.27,0.07,0.0,0.07,0.0,0.0,0.0,charlotte est lucke,,ENGL-1030,2016
+ENGL,1030,35,Accelerated Composition,0.87,0.0,0.07,0.0,0.07,0.0,0.0,0.0,kala parker,,ENGL-1030,2016
+ENGL,1030,37,Accelerated Composition,0.6,0.13,0.07,0.07,0.07,0.0,0.0,0.07,brian lee gaines,,ENGL-1030,2016
+ENGL,1030,38,Accelerated Composition,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2016
+ENGL,1030,39,Accelerated Composition,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,yvonne kao,,ENGL-1030,2016
+ENGL,1030,41,Accelerated Composition,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,,ENGL-1030,2016
+ENGL,1030,42,Accelerated Composition,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,benjamin hudson,,ENGL-1030,2016
+ENGL,1030,43,Accelerated Composition,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,eric stephens,,ENGL-1030,2016
+ENGL,1030,44,Accelerated Composition,0.89,0.0,0.05,0.0,0.05,0.0,0.0,0.0,daniel frank,,ENGL-1030,2016
+ENGL,1030,45,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen quigley,,ENGL-1030,2016
+ENGL,1030,46,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,april obrien,,ENGL-1030,2016
+ENGL,1030,47,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,samuel jacks fuller,,ENGL-1030,2016
+ENGL,1030,49,Accelerated Composition,0.56,0.28,0.0,0.0,0.11,0.0,0.0,0.06,karen kettnich,,ENGL-1030,2016
+ENGL,1030,50,Accelerated Composition,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,michael russo,,ENGL-1030,2016
+ENGL,1030,51,Accelerated Composition,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,april obrien,,ENGL-1030,2016
+ENGL,1030,52,Accelerated Composition,0.53,0.37,0.0,0.05,0.0,0.0,0.0,0.05,eric stephens,,ENGL-1030,2016
+ENGL,1030,53,Accelerated Composition,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,,ENGL-1030,2016
+ENGL,1030,55,Accelerated Composition,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,whitney jorda adams,,ENGL-1030,2016
+ENGL,1030,57,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2016
+ENGL,1030,58,Accelerated Composition,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2016
+ENGL,1030,59,Accelerated Composition,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,charlotte est lucke,,ENGL-1030,2016
+ENGL,1030,61,Accelerated Composition,0.84,0.0,0.11,0.05,0.0,0.0,0.0,0.0,stephen quigley,,ENGL-1030,2016
+ENGL,1030,64,Accelerated Composition,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,christopher stuart,,ENGL-1030,2016
+ENGL,1030,65,Accelerated Composition,0.07,0.79,0.0,0.0,0.07,0.0,0.0,0.07,barbara ramirez,,ENGL-1030,2016
+ENGL,1030,67,Accelerated Composition,0.63,0.21,0.05,0.0,0.05,0.0,0.0,0.05,daniel scott citro,,ENGL-1030,2016
+ENGL,1030,69,Accelerated Composition,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-1030,2016
+ENGL,1030,70,Accelerated Composition,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,,ENGL-1030,2016
+ENGL,1030,71,Accelerated Composition,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,joshua wood,,ENGL-1030,2016
+ENGL,1030,72,Accelerated Composition,0.42,0.26,0.0,0.05,0.05,0.0,0.0,0.21,joshua wood,,ENGL-1030,2016
+ENGL,1030,73,Accelerated Composition,0.69,0.0,0.08,0.0,0.23,0.0,0.0,0.0,jennifer forsberg,,ENGL-1030,2016
+ENGL,1030,75,Accelerated Composition,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,yvonne kao,,ENGL-1030,2016
+ENGL,1030,76,Accelerated Composition,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,katie jo vann,,ENGL-1030,2016
+ENGL,1030,77,Accelerated Composition,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,michael davi measel,,ENGL-1030,2016
+ENGL,1030,79,Accelerated Composition,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2016
+ENGL,1030,80,Accelerated Composition,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,christopher stuart,,ENGL-1030,2016
+ENGL,1030,81,Accelerated Composition,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,sharif youssef,,ENGL-1030,2016
+ENGL,1030,84,Accelerated Composition,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,erica mich marquard,,ENGL-1030,2016
+ENGL,1030,85,Accelerated Composition,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,erica mich marquard,,ENGL-1030,2016
+ENGL,1030,86,Accelerated Composition,0.11,0.78,0.0,0.0,0.06,0.0,0.0,0.06,barbara ramirez,,ENGL-1030,2016
+ENGL,1030,501,Accelerated Composition,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-1030,2016
+ENGL,2120,3,World Literature,0.63,0.26,0.0,0.04,0.0,0.0,0.0,0.07,sharif youssef,,ENGL-2120,2016
+ENGL,2120,4,World Literature,0.72,0.1,0.14,0.0,0.0,0.0,0.0,0.03,allen swords,,ENGL-2120,2016
+ENGL,2120,5,World Literature,0.86,0.0,0.11,0.0,0.0,0.0,0.0,0.04,allen swords,,ENGL-2120,2016
+ENGL,2120,6,World Literature,0.41,0.3,0.11,0.11,0.04,0.0,0.0,0.04,krist aldebol-hazle,,ENGL-2120,2016
+ENGL,2120,7,World Literature,0.54,0.14,0.04,0.07,0.18,0.0,0.0,0.04,krist aldebol-hazle,,ENGL-2120,2016
+ENGL,2120,8,World Literature,0.57,0.29,0.04,0.04,0.04,0.0,0.0,0.04,sharif youssef,,ENGL-2120,2016
+ENGL,2120,9,World Literature,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,stephanie stripling,,ENGL-2120,2016
+ENGL,2120,10,World Literature,0.93,0.04,0.0,0.0,0.04,0.0,0.0,0.0,stephanie stripling,,ENGL-2120,2016
+ENGL,2120,11,World Literature,0.41,0.37,0.11,0.04,0.07,0.0,0.0,0.0,andrew mathas,,ENGL-2120,2016
+ENGL,2120,12,World Literature,0.31,0.31,0.24,0.03,0.0,0.0,0.0,0.1,karen kettnich,,ENGL-2120,2016
+ENGL,2120,13,World Literature,0.16,0.56,0.12,0.04,0.0,0.0,0.0,0.12,karen kettnich,,ENGL-2120,2016
+ENGL,2120,14,World Literature,0.17,0.21,0.42,0.04,0.04,0.0,0.0,0.13,david charles foltz,,ENGL-2120,2016
+ENGL,2120,15,World Literature,0.32,0.28,0.16,0.08,0.04,0.0,0.0,0.12,david charles foltz,,ENGL-2120,2016
+ENGL,2120,16,World Literature,0.59,0.33,0.04,0.04,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2120,2016
+ENGL,2120,17,World Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2120,2016
+ENGL,2120,18,World Literature,0.68,0.25,0.04,0.0,0.0,0.0,0.0,0.04,lucian ghita,,ENGL-2120,2016
+ENGL,2120,19,World Literature,0.33,0.37,0.15,0.0,0.07,0.0,0.0,0.07,andrew mathas,,ENGL-2120,2016
+ENGL,2120,20,World Literature,0.64,0.21,0.0,0.04,0.04,0.0,0.0,0.07,sharif youssef,,ENGL-2120,2016
+ENGL,2120,21,World Literature (Majors),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michelle renee ty,,ENGL-2120,2016
+ENGL,2130,1,British Literature,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,,ENGL-2130,2016
+ENGL,2130,3,British Literature,0.57,0.32,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-2130,2016
+ENGL,2130,4,British Literature,0.56,0.41,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,,ENGL-2130,2016
+ENGL,2130,5,British Literature,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,christopher benson,,ENGL-2130,2016
+ENGL,2130,7,British Literature,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-2130,2016
+ENGL,2130,9,British Literature,0.68,0.14,0.07,0.04,0.0,0.0,0.0,0.07,krist aldebol-hazle,,ENGL-2130,2016
+ENGL,2130,10,British Literature,0.36,0.43,0.14,0.0,0.04,0.0,0.0,0.04,christopher benson,,ENGL-2130,2016
+ENGL,2130,11,British Literature,0.89,0.04,0.0,0.04,0.04,0.0,0.0,0.0,stephanie stripling,,ENGL-2130,2016
+ENGL,2130,12,British Literature,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,stephanie stripling,,ENGL-2130,2016
+ENGL,2130,13,British Literature,0.68,0.29,0.0,0.0,0.04,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2016
+ENGL,2140,1,American Literature,0.5,0.15,0.0,0.04,0.08,0.0,0.0,0.23,candace wiley,,ENGL-2140,2016
+ENGL,2140,5,American Literature,0.39,0.43,0.04,0.07,0.04,0.0,0.0,0.04,erin nicholson gale,,ENGL-2140,2016
+ENGL,2140,6,American Literature,0.41,0.33,0.11,0.04,0.04,0.0,0.0,0.07,erin nicholson gale,,ENGL-2140,2016
+ENGL,2140,7,American Literature,0.46,0.25,0.21,0.0,0.04,0.0,0.0,0.04,john logan pursley,,ENGL-2140,2016
+ENGL,2140,8,American Literature,0.46,0.12,0.0,0.08,0.0,0.0,0.0,0.35,candace wiley,,ENGL-2140,2016
+ENGL,2140,9,American Literature,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2140,2016
+ENGL,2140,14,American Literature,0.56,0.26,0.07,0.0,0.04,0.0,0.0,0.07,adrian carson,,ENGL-2140,2016
+ENGL,2140,15,American Literature,0.26,0.41,0.22,0.04,0.0,0.0,0.0,0.07,susanna ashton,,ENGL-2140,2016
+ENGL,2140,16,American Literature,0.61,0.29,0.11,0.0,0.0,0.0,0.0,0.0,austin gorman,,ENGL-2140,2016
+ENGL,2140,17,American Literature,0.48,0.12,0.2,0.08,0.08,0.0,0.0,0.04,adrian carson,,ENGL-2140,2016
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.59,0.19,0.11,0.04,0.0,0.0,0.0,0.07,jennifer forsberg,,ENGL-2150,2016
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.63,0.22,0.11,0.0,0.04,0.0,0.0,0.0,jennifer forsberg,,ENGL-2150,2016
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.32,0.26,0.16,0.11,0.05,0.0,0.0,0.11,candace wiley,,ENGL-2150,2016
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.22,0.56,0.11,0.0,0.04,0.0,0.0,0.07,david charles foltz,,ENGL-2150,2016
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.15,0.37,0.26,0.0,0.11,0.0,0.0,0.11,david charles foltz,,ENGL-2150,2016
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.57,0.17,0.04,0.04,0.04,0.0,0.0,0.13,candace wiley,,ENGL-2150,2016
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-2150,2016
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.39,0.5,0.07,0.04,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2150,2016
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2150,2016
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.65,0.23,0.08,0.0,0.04,0.0,0.0,0.0,erin nicholson gale,,ENGL-2150,2016
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.54,0.35,0.0,0.04,0.0,0.0,0.0,0.08,erin nicholson gale,,ENGL-2150,2016
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.79,0.14,0.04,0.0,0.0,0.0,0.0,0.04,katie jo vann,,ENGL-2150,2016
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.36,0.29,0.21,0.04,0.04,0.0,0.0,0.07,megan no macalystre,,ENGL-2150,2016
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.5,0.29,0.11,0.07,0.04,0.0,0.0,0.0,megan no macalystre,,ENGL-2150,2016
+ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.48,0.26,0.22,0.04,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-2150,2016
+ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.5,0.21,0.04,0.11,0.07,0.0,0.0,0.07,andrew mathas,,ENGL-2150,2016
+ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.82,0.0,0.04,0.0,0.07,0.0,0.0,0.07,katie jo vann,,ENGL-2150,2016
+ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,benjamin hudson,,ENGL-2150,2016
+ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.74,0.19,0.0,0.0,0.0,0.0,0.0,0.07,benjamin hudson,,ENGL-2150,2016
+ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-2150,2016
+ENGL,2150,100,20th - 21st Century Lit (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,True,ENGL-2150,2016
+ENGL,3010,1,Grt Books West World,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,eric allison,,ENGL-3010,2016
+ENGL,3040,3,Business Writing,0.84,0.05,0.05,0.05,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-3040,2016
+ENGL,3040,5,Business Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3040,2016
+ENGL,3040,11,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-3040,2016
+ENGL,3040,13,Business Writing,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,,ENGL-3040,2016
+ENGL,3040,15,Business Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3040,2016
+ENGL,3040,19,Business Writing,0.37,0.47,0.05,0.0,0.0,0.0,0.0,0.11,katalin beck,,ENGL-3040,2016
+ENGL,3040,20,Business Writing,0.26,0.58,0.05,0.0,0.05,0.0,0.0,0.05,katalin beck,,ENGL-3040,2016
+ENGL,3040,400,Business Writing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-3040,2016
+ENGL,3040,401,Business Writing,0.61,0.28,0.06,0.0,0.06,0.0,0.0,0.0,jillian weise,,ENGL-3040,2016
+ENGL,3040,402,Business Writing,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,hayley ren zertuche,,ENGL-3040,2016
+ENGL,3040,403,Business Writing,0.76,0.06,0.0,0.0,0.06,0.0,0.0,0.12,hayley ren zertuche,,ENGL-3040,2016
+ENGL,3040,404,Business Writing,0.56,0.19,0.06,0.0,0.06,0.0,0.0,0.13,hayley ren zertuche,,ENGL-3040,2016
+ENGL,3040,405,Business Writing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,,ENGL-3040,2016
+ENGL,3040,406,Business Writing,0.27,0.47,0.27,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,,ENGL-3040,2016
+ENGL,3040,407,Business Writing,0.07,0.6,0.07,0.07,0.07,0.0,0.0,0.13,steph kartalopoulos,,ENGL-3040,2016
+ENGL,3040,408,Business Writing,0.29,0.35,0.0,0.12,0.12,0.0,0.0,0.12,steph kartalopoulos,,ENGL-3040,2016
+ENGL,3040,409,Business Writing,0.19,0.69,0.0,0.06,0.0,0.0,0.0,0.06,steph kartalopoulos,,ENGL-3040,2016
+ENGL,3100,1,Crit Writ Lit,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,david sweene coombs,,ENGL-3100,2016
+ENGL,3100,3,Crit Writ Lit,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,michelle renee ty,,ENGL-3100,2016
+ENGL,3100,4,Crit Writ Lit,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,michael lemahieu,,ENGL-3100,2016
+ENGL,3120,1,Advanced Composition,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2016
+ENGL,3120,2,Advanced Composition,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2016
+ENGL,3140,1,Technical Writing,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,katherine hanzalik,,ENGL-3140,2016
+ENGL,3140,2,Technical Writing,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,katherine hanzalik,,ENGL-3140,2016
+ENGL,3140,3,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,,ENGL-3140,2016
+ENGL,3140,5,Technical Writing,0.42,0.47,0.05,0.0,0.05,0.0,0.0,0.0,katalin beck,,ENGL-3140,2016
+ENGL,3140,6,Technical Writing,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,william pulley,,ENGL-3140,2016
+ENGL,3140,7,Technical Writing,0.47,0.26,0.05,0.05,0.11,0.0,0.0,0.05,william pulley,,ENGL-3140,2016
+ENGL,3140,9,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2016
+ENGL,3140,10,Technical Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,melissa dugan,,ENGL-3140,2016
+ENGL,3140,11,Technical Writing,0.79,0.05,0.05,0.0,0.11,0.0,0.0,0.0,melissa dugan,,ENGL-3140,2016
+ENGL,3140,12,Technical Writing,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,katalin beck,,ENGL-3140,2016
+ENGL,3140,14,Technical Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2016
+ENGL,3140,15,Technical Writing,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,crystal pa stephens,,ENGL-3140,2016
+ENGL,3140,16,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3140,2016
+ENGL,3140,19,Technical Writing,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,geveryl le robinson,,ENGL-3140,2016
+ENGL,3140,20,Technical Writing,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,geveryl le robinson,,ENGL-3140,2016
+ENGL,3140,22,Technical Writing,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,,ENGL-3140,2016
+ENGL,3140,400,Technical Writing,0.21,0.57,0.07,0.0,0.14,0.0,0.0,0.0,la'cresha ulo green,,ENGL-3140,2016
+ENGL,3150,1,Scientific Writing & Comm,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,christopher benson,,ENGL-3150,2016
+ENGL,3150,3,Scientific Writing & Comm,0.42,0.21,0.05,0.05,0.05,0.0,0.0,0.21,william pulley,,ENGL-3150,2016
+ENGL,3150,4,Scientific Writing & Comm,0.58,0.16,0.11,0.0,0.0,0.0,0.0,0.16,william pulley,,ENGL-3150,2016
+ENGL,3150,402,Sci Writing & Comm (NURSING),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2016
+ENGL,3150,403,Sci Writing & Comm (NURSING),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2016
+ENGL,3330,1,Writing News Media,0.6,0.13,0.07,0.0,0.0,0.0,0.0,0.2,geveryl le robinson,,ENGL-3330,2016
+ENGL,3450,1,Structure of Fiction,0.42,0.47,0.0,0.0,0.05,0.0,0.0,0.05,keith morris,,ENGL-3450,2016
+ENGL,3480,1,Structure Screenplay,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,nicholas chri brown,,ENGL-3480,2016
+ENGL,3540,1,Lit Middle East & North Africa,0.38,0.19,0.06,0.0,0.19,0.0,0.0,0.19,angela naimou,,ENGL-3540,2016
+ENGL,3570,1,Film,0.11,0.61,0.22,0.0,0.06,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2016
+ENGL,3570,2,Film,0.0,0.72,0.28,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2016
+ENGL,3570,3,Film,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2016
+ENGL,3850,1,Children's Lit,0.72,0.17,0.0,0.0,0.11,0.0,0.0,0.0,megan no macalystre,,ENGL-3850,2016
+ENGL,3860,1,Adolescent Lit,0.06,0.88,0.0,0.0,0.06,0.0,0.0,0.0,amy monaghan,,ENGL-3860,2016
+ENGL,3960,1,Brit Lit Survey I,0.38,0.19,0.19,0.13,0.06,0.0,0.0,0.06,erin marina goss,,ENGL-3960,2016
+ENGL,3960,2,Brit Lit Survey I,0.36,0.36,0.29,0.0,0.0,0.0,0.0,0.0,erin marina goss,,ENGL-3960,2016
+ENGL,3960,3,Brit Lit Survey I,0.14,0.36,0.21,0.0,0.14,0.0,0.0,0.14,erin marina goss,,ENGL-3960,2016
+ENGL,3970,1,Brit Lit Survey II,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,john morgenstern,,ENGL-3970,2016
+ENGL,3970,2,Brit Lit Survey II,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,david sweene coombs,,ENGL-3970,2016
+ENGL,3980,2,Amer Lit Survey I,0.38,0.44,0.06,0.0,0.06,0.0,0.0,0.06,jonathan beec field,,ENGL-3980,2016
+ENGL,4110,1,Shakespeare,0.39,0.56,0.0,0.06,0.0,0.0,0.0,0.0,andrew lemons,,ENGL-4110,2016
+ENGL,4110,2,Shakespeare,0.42,0.11,0.37,0.05,0.05,0.0,0.0,0.0,william stockton,,ENGL-4110,2016
+ENGL,4110,3,Shakespeare,0.21,0.63,0.11,0.05,0.0,0.0,0.0,0.0,brian mcgrath,,ENGL-4110,2016
+ENGL,4140,1,Milton,0.08,0.77,0.15,0.0,0.0,0.0,0.0,0.0,lee morrissey,,ENGL-4140,2016
+ENGL,4190,1,Post Col & World Lit,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,cameron fa bushnell,,ENGL-4190,2016
+ENGL,4210,1,Amer Lit 1800-1899,0.33,0.33,0.13,0.07,0.13,0.0,0.0,0.0,dominic mastroianni,,ENGL-4210,2016
+ENGL,4250,1,American Novel,0.25,0.42,0.08,0.08,0.08,0.0,0.0,0.08,susanna ashton,,ENGL-4250,2016
+ENGL,4260,1,Southern Literature,0.29,0.43,0.14,0.0,0.07,0.0,0.0,0.07,cameron fa bushnell,,ENGL-4260,2016
+ENGL,4280,1,Contemporary Literature,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,michael lemahieu,,ENGL-4280,2016
+ENGL,4350,1,Literary Criticism,0.31,0.5,0.13,0.0,0.06,0.0,0.0,0.0,jonathan beec field,,ENGL-4350,2016
+ENGL,4360,1,Feminist Literary Criticism,0.39,0.56,0.0,0.0,0.06,0.0,0.0,0.0,erin marina goss,,ENGL-4360,2016
+ENGL,4400,1,Literary Theory,0.42,0.32,0.16,0.0,0.11,0.0,0.0,0.0,walter edgar hunter,,ENGL-4400,2016
+ENGL,4410,1,Literary Editing,0.28,0.5,0.06,0.06,0.06,0.0,0.0,0.06,gabriel and hankins,,ENGL-4410,2016
+ENGL,4420,1,Cultural Studies,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,garry bertholf,,ENGL-4420,2016
+ENGL,4500,1,Film Genres,0.67,0.2,0.07,0.0,0.0,0.0,0.0,0.07, barton palmer,,ENGL-4500,2016
+ENGL,4510,1,Film Theo/Criticism,0.75,0.06,0.13,0.0,0.0,0.0,0.0,0.06, barton palmer,,ENGL-4510,2016
+ENGL,4630,1,Topics in Literature to 1699,0.18,0.55,0.18,0.0,0.0,0.0,0.0,0.09,andrew lemons,,ENGL-4630,2016
+ENGL,4750,1,Writing for Media,0.31,0.38,0.13,0.0,0.13,0.0,0.0,0.06,megan eatman,,ENGL-4750,2016
+ENGL,4780,1,Digital Literacy,0.18,0.55,0.18,0.0,0.09,0.0,0.0,0.0,gabriel and hankins,,ENGL-4780,2016
+ENGL,4820,1,Afr Am Lit to 1920,0.0,0.6,0.1,0.0,0.3,0.0,0.0,0.0,rhondda robi thomas,,ENGL-4820,2016
+ENGL,4960,1,Senior Seminar,0.69,0.15,0.0,0.0,0.15,0.0,0.0,0.0,dominic mastroianni,,ENGL-4960,2016
+ENGL,4960,2,Senior Seminar,0.42,0.42,0.0,0.0,0.08,0.0,0.0,0.08,rhondda robi thomas,,ENGL-4960,2016
+ENGL,4960,3,Senior Seminar,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-4960,2016
+ENGL,8080,1,Top Renaiss & Restoration Lit,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-8080,2016
+ENGR,1000,101,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,steven brandon,,ENGR-1000,2016
+ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.95,0.04,0.01,steven brandon,,ENGR-1000,2016
+ENGR,1020,117,Engineering Discipl & Skills,0.42,0.27,0.16,0.02,0.04,0.0,0.0,0.09,matthew kent miller,,ENGR-1020,2016
+ENGR,1020,118,Engineering Discipl & Skills,0.15,0.53,0.11,0.02,0.02,0.0,0.0,0.17,matthew kent miller,,ENGR-1020,2016
+ENGR,1020,312,Engineering Discipl & Skills,0.27,0.47,0.16,0.08,0.02,0.0,0.0,0.0,irene marie ferrara,,ENGR-1020,2016
+ENGR,1020,313,Engineering Discipl & Skills,0.21,0.4,0.15,0.06,0.06,0.0,0.0,0.12,michael giebner,,ENGR-1020,2016
+ENGR,1020,314,Engineering Discipl & Skills,0.32,0.32,0.16,0.0,0.02,0.0,0.0,0.18,michael giebner,,ENGR-1020,2016
+ENGR,1020,316,Engineering Discipl & Skills,0.16,0.53,0.12,0.1,0.0,0.0,0.0,0.1,roksana mahmud,,ENGR-1020,2016
+ENGR,1020,317,Engineering Discipl & Skills,0.16,0.45,0.16,0.06,0.02,0.0,0.0,0.16,jonathan maier,,ENGR-1020,2016
+ENGR,1020,611,Engineering Discipl & Skills,0.1,0.45,0.24,0.08,0.06,0.0,0.0,0.08,john minor,,ENGR-1020,2016
+ENGR,1020,612,Engineering Discipl & Skills,0.28,0.49,0.13,0.06,0.0,0.0,0.0,0.04,john minor,,ENGR-1020,2016
+ENGR,1020,613,Engineering Discipl & Skills,0.19,0.4,0.19,0.08,0.0,0.0,0.0,0.13,mariah magagnotti,,ENGR-1020,2016
+ENGR,1020,614,Engineering Discipl & Skills,0.29,0.4,0.21,0.04,0.02,0.0,0.0,0.04,irene marie ferrara,,ENGR-1020,2016
+ENGR,1020,615,Engineering Discipl & Skills,0.35,0.39,0.18,0.0,0.0,0.0,0.0,0.08,irene marie ferrara,,ENGR-1020,2016
+ENGR,1020,616,Engineering Discipl & Skills,0.17,0.42,0.23,0.04,0.02,0.0,0.0,0.13,sheikh moniruz moni,,ENGR-1020,2016
+ENGR,1020,617,Engineering Discipl & Skills,0.28,0.3,0.18,0.06,0.06,0.0,0.0,0.12,andrew isaa neptune,,ENGR-1020,2016
+ENGR,1020,618,Engineering Discipl & Skills,0.24,0.35,0.17,0.11,0.04,0.0,0.0,0.09,andrew isaa neptune,,ENGR-1020,2016
+ENGR,1020,811,Engineering Discipl & Skills,0.34,0.38,0.15,0.09,0.0,0.0,0.0,0.04,ashley childers,,ENGR-1020,2016
+ENGR,1020,812,Engineering Discipl & Skills,0.39,0.3,0.22,0.0,0.04,0.0,0.0,0.04,ashley childers,,ENGR-1020,2016
+ENGR,1020,813,Engineering Discipl & Skills,0.21,0.42,0.21,0.04,0.02,0.0,0.0,0.1,elizabeth stephan,,ENGR-1020,2016
+ENGR,1020,814,Engineering Discipl & Skills,0.4,0.36,0.13,0.04,0.02,0.0,0.0,0.04,andrew isaa neptune,,ENGR-1020,2016
+ENGR,1020,815,Engineering Discipl & Skills,0.15,0.45,0.21,0.06,0.0,0.0,0.0,0.13,mariah magagnotti,,ENGR-1020,2016
+ENGR,1020,816,Engineering Discipl & Skills,0.19,0.32,0.3,0.06,0.02,0.0,0.0,0.11,mariah magagnotti,,ENGR-1020,2016
+ENGR,1020,817,Engineering Discipl & Skills,0.23,0.45,0.17,0.06,0.02,0.0,0.0,0.06,sarah grigg,,ENGR-1020,2016
+ENGR,1020,818,Engineering Discipl & Skills,0.32,0.36,0.16,0.05,0.0,0.0,0.0,0.11,sarah grigg,,ENGR-1020,2016
+ENGR,1020,831,Engr Discipl & Skills (HON),0.72,0.24,0.02,0.0,0.0,0.0,0.0,0.02,steven brandon,True,ENGR-1020,2016
+ENGR,1020,832,Engr Discipl & Skills (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steven brandon,True,ENGR-1020,2016
+ENGR,1050,246,Engr Discipline & Skills I,0.04,0.32,0.36,0.08,0.2,0.0,0.0,0.0,matthew kent miller,,ENGR-1050,2016
+ENGR,1050,400,Engr Discipline & Skills I,0.07,0.07,0.29,0.25,0.18,0.0,0.0,0.14,matthew kent miller,,ENGR-1050,2016
+ENGR,1060,246,Engr Discipline & Skills II,0.04,0.29,0.25,0.29,0.13,0.0,0.0,0.0,matthew kent miller,,ENGR-1060,2016
+ENGR,1060,400,Engr Discipline & Skills II,0.12,0.24,0.29,0.06,0.24,0.0,0.0,0.06,matthew kent miller,,ENGR-1060,2016
+ENGR,1150,500,Engineering Design & Modeling,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,john minor,,ENGR-1150,2016
+ENGR,1410,225,Programming & Problem Solving,0.06,0.3,0.26,0.09,0.19,0.0,0.0,0.11,richard watkins,,ENGR-1410,2016
+ENGR,1410,226,Programming & Problem Solving,0.16,0.24,0.2,0.08,0.2,0.0,0.0,0.14,elizabeth stephan,,ENGR-1410,2016
+ENGR,1410,227,Programming & Problem Solving,0.08,0.29,0.29,0.06,0.12,0.0,0.0,0.17,william martin,,ENGR-1410,2016
+ENGR,1410,228,Programming & Problem Solving,0.08,0.24,0.33,0.18,0.04,0.0,0.0,0.12,william martin,,ENGR-1410,2016
+ENGR,1520,501,Engineering Computer Skills,0.29,0.52,0.19,0.0,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1520,2016
+ENGR,1520,502,Engineering Computer Skills,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1520,2016
+ENGR,1900,10,CI in Engr I Robotics,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,michael benj wooten,,ENGR-1900,2016
+ENGR,1900,77,CI in ENGR Human Powered Veh,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,gregory mocko,,ENGR-1900,2016
+ENGR,2080,681,Engr Graphics & Machine Design,0.43,0.23,0.09,0.09,0.15,0.0,0.0,0.02,nighat yasmin,,ENGR-2080,2016
+ENGR,2080,682,Engr Graphics & Machine Design,0.31,0.25,0.25,0.06,0.04,0.0,0.0,0.08,amaninder sing gill,,ENGR-2080,2016
+ENGR,2080,684,Engr Graphics & Machine Design,0.21,0.21,0.21,0.06,0.23,0.0,0.0,0.08,amaninder sing gill,,ENGR-2080,2016
+ENGR,2080,685,Engr Graphics & Machine Design,0.31,0.22,0.22,0.08,0.08,0.0,0.0,0.08,anthony pau garland,,ENGR-2080,2016
+ENGR,2080,686,Engr Graphics & Machine Design,0.5,0.24,0.11,0.02,0.04,0.0,0.0,0.09,anthony pau garland,,ENGR-2080,2016
+ENGR,2100,804,CAD & Engineering Applications,0.43,0.37,0.07,0.0,0.04,0.0,0.0,0.09,nighat yasmin,,ENGR-2100,2016
+ENGR,2100,805,CAD & Engineering Applications,0.33,0.41,0.22,0.02,0.02,0.0,0.0,0.0,nighat yasmin,,ENGR-2100,2016
+ENGR,2100,806,CAD & Engineering Applications,0.36,0.33,0.13,0.05,0.03,0.0,0.0,0.1, shams esfandabadi,,ENGR-2100,2016
+ENGR,2200,106,Evaluating Innovations,0.55,0.39,0.05,0.0,0.0,0.0,0.0,0.0,sarah grigg,,ENGR-2200,2016
+ENR,1010,1,Intro to Envir & Natur Res I,0.75,0.15,0.03,0.03,0.03,0.0,0.0,0.01,alan johnson,,ENR-1010,2016
+ENR,1010,2,Intro to Envir & Natur Res I,0.5,0.31,0.13,0.04,0.02,0.0,0.0,0.0,alan johnson,,ENR-1010,2016
+ENR,4290,1,Environ Law & Policy,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,,ENR-4290,2016
+ENSP,2000,1,Intro Environ Sci,0.23,0.52,0.16,0.05,0.0,0.0,0.0,0.05,scott brame,,ENSP-2000,2016
+ENSP,2000,2,Intro Environ Sci,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2016
+ENSP,2000,3,Intro Environ Sci,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2016
+ENSP,2000,4,Intro Environ Sci,0.34,0.5,0.09,0.0,0.05,0.0,0.0,0.02,elizabeth carraway,,ENSP-2000,2016
+ENSP,4000,1,Studies in Environmental Sci,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,margaret thompson,,ENSP-4000,2016
+ENT,2000,1,Six-Legged Science,0.68,0.17,0.1,0.0,0.0,0.0,0.0,0.05,suellen pometto,,ENT-2000,2016
+ENT,3010,1,Insect Biology and Diversity,0.33,0.33,0.29,0.0,0.05,0.0,0.0,0.0,eric benson,,ENT-3010,2016
+ENTR,1010,1,Entrepreneurial Mindset,0.48,0.39,0.07,0.01,0.03,0.0,0.0,0.02,john michael hannon,,ENTR-1010,2016
+ESED,8790,1,Curr Top STEM Education Policy,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,julie patric martin,,ESED-8790,2016
+FCS,8130,1,Research Methods in FCS I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,,FCS-8130,2016
+FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.67,0.19,0.05,0.02,0.03,0.0,0.0,0.04,aubrey dean coffee,,FDSC-1010,2016
+FDSC,4010,1,Food Chemistry I,0.58,0.33,0.09,0.0,0.0,0.0,0.0,0.0,feng chen,,FDSC-4010,2016
+FDSC,4040,1,Food Prsv & Process,0.53,0.43,0.04,0.0,0.0,0.0,0.0,0.0,anthony lou pometto,,FDSC-4040,2016
+FDSC,4070,1,Quantity Food Production,0.78,0.14,0.03,0.0,0.03,0.0,0.0,0.02,heather batt,,FDSC-4070,2016
+FDSC,4170,1,Seminar,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,aubrey dean coffee,,FDSC-4170,2016
+FDSC,4200,1,Food Regulation and Policy,0.91,0.06,0.01,0.0,0.01,0.0,0.0,0.01, rhodehamel,,FDSC-4200,2016
+FDSC,4300,1,Dairy Process & Sant,0.44,0.28,0.22,0.0,0.06,0.0,0.0,0.0,john mcgregor,,FDSC-4300,2016
+FDSC,8120,1,Microbial Food Syst,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,xiuping jiang,,FDSC-8120,2016
+FIN,2010,401,Intro to Personal Finance,0.55,0.24,0.05,0.02,0.05,0.0,0.0,0.1,joshua harris,,FIN-2010,2016
+FIN,2010,402,Intro to Personal Finance,0.35,0.23,0.14,0.07,0.05,0.0,0.0,0.16,joshua harris,,FIN-2010,2016
+FIN,2010,403,Intro to Personal Finance,0.4,0.33,0.14,0.02,0.09,0.0,0.0,0.02,joshua harris,,FIN-2010,2016
+FIN,2010,404,Intro to Personal Finance,0.56,0.26,0.04,0.02,0.08,0.0,0.0,0.04,joshua harris,,FIN-2010,2016
+FIN,2010,405,Intro to Personal Finance,0.55,0.26,0.02,0.06,0.04,0.0,0.0,0.06,joshua harris,,FIN-2010,2016
+FIN,2010,406,Intro to Personal Finance,0.64,0.2,0.05,0.02,0.05,0.0,0.0,0.05,joshua harris,,FIN-2010,2016
+FIN,3040,1,Risk & Insurance,0.2,0.33,0.4,0.07,0.0,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2016
+FIN,3040,2,Risk & Insurance,0.19,0.19,0.58,0.03,0.0,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2016
+FIN,3050,1,Investment Analysis,0.18,0.32,0.37,0.05,0.03,0.0,0.0,0.05,kerri mcmillan,,FIN-3050,2016
+FIN,3050,2,Investment Analysis,0.15,0.51,0.23,0.05,0.03,0.0,0.0,0.03,kerri mcmillan,,FIN-3050,2016
+FIN,3050,3,Investment Analysis,0.54,0.21,0.21,0.0,0.05,0.0,0.0,0.0,thomas albe wessels,,FIN-3050,2016
+FIN,3050,4,Investment Analysis,0.27,0.27,0.36,0.09,0.0,0.0,0.0,0.0,thomas albe wessels,,FIN-3050,2016
+FIN,3060,2,Corporation Finance,0.16,0.05,0.22,0.22,0.11,0.0,0.0,0.24,william hol johnson,,FIN-3060,2016
+FIN,3060,3,Corporation Finance,0.18,0.13,0.24,0.18,0.24,0.0,0.0,0.03,william hol johnson,,FIN-3060,2016
+FIN,3060,4,Corporation Finance,0.0,0.25,0.15,0.28,0.3,0.0,0.0,0.03,william hol johnson,,FIN-3060,2016
+FIN,3060,5,Corporation Finance,0.26,0.32,0.19,0.14,0.05,0.0,0.0,0.04,ramon tolb franklin,,FIN-3060,2016
+FIN,3060,6,Corporation Finance,0.24,0.31,0.24,0.07,0.05,0.0,0.0,0.09,ramon tolb franklin,,FIN-3060,2016
+FIN,3060,7,Corporation Finance,0.22,0.29,0.22,0.19,0.05,0.0,0.0,0.03,ramon tolb franklin,,FIN-3060,2016
+FIN,3060,8,Corporation Finance,0.18,0.1,0.41,0.25,0.04,0.0,0.0,0.02,melvin stith,,FIN-3060,2016
+FIN,3060,9,Corporation Finance,0.14,0.27,0.31,0.18,0.06,0.0,0.0,0.04,melvin stith,,FIN-3060,2016
+FIN,3060,10,Corporation Finance,0.15,0.33,0.22,0.15,0.11,0.0,0.0,0.04,ramon tolb franklin,,FIN-3060,2016
+FIN,3060,11,Corporation Finance,0.05,0.13,0.43,0.15,0.2,0.0,0.0,0.05,william hol johnson,,FIN-3060,2016
+FIN,3070,1,Prin of Real Estate,0.2,0.33,0.25,0.1,0.1,0.0,0.0,0.03,thomas springer,,FIN-3070,2016
+FIN,3070,2,Prin of Real Estate,0.15,0.4,0.3,0.05,0.1,0.0,0.0,0.0,thomas springer,,FIN-3070,2016
+FIN,3070,3,Prin of Real Estate,0.21,0.5,0.21,0.02,0.02,0.0,0.0,0.02,yannan shen,,FIN-3070,2016
+FIN,3080,1,Fin Inst & Mkts,0.23,0.55,0.17,0.02,0.0,0.0,0.0,0.02,lyudmila chernykh,,FIN-3080,2016
+FIN,3080,2,Fin Inst & Mkts,0.2,0.57,0.22,0.0,0.0,0.0,0.0,0.02,lyudmila chernykh,,FIN-3080,2016
+FIN,3080,3,Fin Inst & Mkts,0.25,0.38,0.31,0.06,0.0,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2016
+FIN,3110,1,Financial Management I,0.06,0.06,0.21,0.03,0.29,0.0,0.0,0.35,jack wolf,,FIN-3110,2016
+FIN,3110,2,Financial Management I,0.13,0.17,0.27,0.13,0.15,0.0,0.0,0.17,jack wolf,,FIN-3110,2016
+FIN,3110,3,Financial Management I,0.21,0.3,0.34,0.13,0.0,0.0,0.0,0.02,weike xu,,FIN-3110,2016
+FIN,3110,4,Financial Management I,0.16,0.22,0.2,0.14,0.16,0.0,0.0,0.12,john alexander,,FIN-3110,2016
+FIN,3120,1,Financial Management II,0.08,0.47,0.26,0.05,0.08,0.0,0.0,0.05,vincent intintoli,,FIN-3120,2016
+FIN,3120,2,Financial Management II,0.13,0.46,0.19,0.13,0.07,0.0,0.0,0.02,vincent intintoli,,FIN-3120,2016
+FIN,3120,3,Financial Management II,0.24,0.48,0.19,0.02,0.05,0.0,0.0,0.02,blerina zykaj,,FIN-3120,2016
+FIN,3120,4,Financial Management II,0.24,0.49,0.17,0.05,0.05,0.0,0.0,0.0,weike xu,,FIN-3120,2016
+FIN,4010,1,Corporate Financial Analysis,0.36,0.4,0.16,0.04,0.04,0.0,0.0,0.0,george bra lockhart,,FIN-4010,2016
+FIN,4020,1,Corporate Valuation,0.23,0.45,0.32,0.0,0.0,0.0,0.0,0.0,angela morgan,,FIN-4020,2016
+FIN,4020,2,Corporate Valuation,0.29,0.29,0.29,0.1,0.03,0.0,0.0,0.0,angela morgan,,FIN-4020,2016
+FIN,4050,1,Portfolio Management & Theory,0.18,0.21,0.43,0.11,0.04,0.0,0.0,0.04,john alexander,,FIN-4050,2016
+FIN,4060,1,Derivatives Analysis,0.21,0.35,0.32,0.06,0.03,0.0,0.0,0.03,blerina zykaj,,FIN-4060,2016
+FIN,4110,1,Int Fin Mgt,0.12,0.62,0.21,0.0,0.0,0.0,0.0,0.06,luke asher devault,,FIN-4110,2016
+FIN,4110,2,Int Fin Mgt,0.17,0.52,0.22,0.04,0.0,0.0,0.0,0.04,luke asher devault,,FIN-4110,2016
+FIN,4170,1,Real Estate Finance,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,yannan shen,,FIN-4170,2016
+FIN,4980,3,Creative Inquiry in Finance,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,angela morgan,,FIN-4980,2016
+FNR,2040,1,Soil Information Systems,0.9,0.08,0.0,0.02,0.0,0.0,0.0,0.0,elena mikhailova,,FNR-2040,2016
+FNR,4700,1,Kennedy Waterfowl CI,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,,FNR-4700,2016
+FNR,4990,1,Natural Resources Seminar,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,susan talley guynn,,FNR-4990,2016
+FOR,2050,1,Dendrology,0.32,0.34,0.16,0.05,0.08,0.0,0.0,0.05,donald hagan,,FOR-2050,2016
+FOR,2050,2,Dendrology,0.24,0.24,0.21,0.06,0.15,0.0,0.0,0.09,donald hagan,,FOR-2050,2016
+FOR,2050,3,Dendrology,0.31,0.36,0.16,0.07,0.0,0.0,0.0,0.11,donald hagan,,FOR-2050,2016
+FOR,2210,1,Forest Biology,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,thomas adam coates,,FOR-2210,2016
+FOR,3020,1,Forest Biometrics,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,lawrence gering,,FOR-3020,2016
+FOR,3040,1,Forest Resource Economics,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,puskar khanal,,FOR-3040,2016
+FOR,4100,1,Harvesting Processes,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,patrick hiesl,,FOR-4100,2016
+FOR,4160,1,Forest Policy and Admin,0.23,0.52,0.21,0.03,0.0,0.0,0.0,0.01,thomas straka,,FOR-4160,2016
+FOR,4170,1,Forest Resource Mgt & Regulatn,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,,FOR-4170,2016
+FOR,4310,1,Recreation Res Plan in For Mgt,0.54,0.33,0.13,0.0,0.0,0.0,0.0,0.0,robert baxte powell,,FOR-4310,2016
+FOR,4340,1,GIS for Natural Resources,0.67,0.28,0.04,0.0,0.0,0.0,0.0,0.0,christopher post,,FOR-4340,2016
+FOR,8930,7,Statistical Methods in Nat Res,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,patrick hiesl,,FOR-8930,2016
+FR,1010,1,Elementary French,0.26,0.47,0.16,0.0,0.05,0.0,0.0,0.05,anne salces  nedeo,,FR-1010,2016
+FR,1020,1,Elementary French,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,,FR-1020,2016
+FR,1020,2,Elementary French,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2016
+FR,2010,1,Intermediate French,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,paulin de tholozany,,FR-2010,2016
+FR,2010,2,Intermediate French,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-2010,2016
+FR,2010,4,Intermediate French,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,paulin de tholozany,,FR-2010,2016
+FR,2020,1,Intermediate French,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2020,2016
+FR,2020,2,Intermediate French,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,eric touya,,FR-2020,2016
+FR,2020,3,Intermediate French,0.47,0.18,0.29,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,,FR-2020,2016
+FR,2020,4,Intermediate French,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2020,2016
+FR,3000,1,Survey of French Lit,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,,FR-3000,2016
+FR,3050,1,Int Fr Con & Comp I,0.29,0.59,0.06,0.0,0.06,0.0,0.0,0.0,anne salces  nedeo,,FR-3050,2016
+FR,3050,2,Int Fr Con & Comp I,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,,FR-3050,2016
+FR,3070,1,French Civilization,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,,FR-3070,2016
+FR,4160,1,Fr for Intl Trade II,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-4160,2016
+GC,1010,1,Orientation to G C,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,nona woolbright,,GC-1010,2016
+GC,1010,2,Orientation to G C,0.71,0.16,0.02,0.04,0.04,0.0,0.0,0.02,carol jones,,GC-1010,2016
+GC,1020,1,Computer Art & CAD Foundations,0.39,0.39,0.11,0.06,0.04,0.0,0.0,0.02,carol jones,,GC-1020,2016
+GC,1020,2,Computer Art & CAD Foundations,0.53,0.33,0.07,0.0,0.05,0.0,0.0,0.02,nona woolbright,,GC-1020,2016
+GC,1030,1,G C I for Pkgsc,0.32,0.42,0.11,0.05,0.05,0.0,0.0,0.05,john jacobs,,GC-1030,2016
+GC,1040,1,Graphic Communications I,0.54,0.25,0.11,0.0,0.07,0.0,0.0,0.04,rebecca suza edlein,,GC-1040,2016
+GC,2070,1,Graphic Communications II,0.66,0.24,0.03,0.02,0.03,0.0,0.0,0.02,charles tabor weiss,,GC-2070,2016
+GC,2400,1,Intro to Web Design and Dev,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,erica black walker,,GC-2400,2016
+GC,3400,1,Digital Imaging and eMedia,0.34,0.53,0.11,0.0,0.0,0.0,0.0,0.03,erica black walker,,GC-3400,2016
+GC,3460,1,Ink and Substrates,0.26,0.56,0.11,0.03,0.04,0.0,0.0,0.0,liam henry 'hara,,GC-3460,2016
+GC,4060,1,Package and Specialty Printing,0.8,0.11,0.0,0.0,0.05,0.0,0.0,0.05,kern cox,,GC-4060,2016
+GC,4400,1,Commercial Printing,0.43,0.43,0.04,0.0,0.07,0.0,0.0,0.04,eric weisenmiller,,GC-4400,2016
+GC,4400,2,Commercial Printing,0.39,0.43,0.09,0.0,0.04,0.0,0.0,0.04,eric weisenmiller,,GC-4400,2016
+GC,4440,1,Current Dev/Trends in Gr Comm,0.79,0.16,0.0,0.0,0.03,0.0,0.0,0.03,samuel ingram,,GC-4440,2016
+GC,4480,1,Plan & Cont Printing Functions,0.49,0.38,0.08,0.05,0.0,0.0,0.0,0.0,john leininger,,GC-4480,2016
+GC,4800,1,Senior Seminar in GC,0.63,0.32,0.02,0.02,0.0,0.0,0.0,0.0,charles edwa tonkin,,GC-4800,2016
+GC,4900,230,G C Selected Topics-GC Sales,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,,GC-4900,2016
+GEN,1030,1,Careers in Bioch/Gen,0.8,0.15,0.04,0.0,0.0,0.0,0.0,0.01,alison starr-moss,,GEN-1030,2016
+GEN,3000,1,Fundamental Genetics,0.29,0.37,0.18,0.11,0.02,0.0,0.0,0.03,kate leanne wi tsai,,GEN-3000,2016
+GEN,3000,2,Fundamental Genetics,0.21,0.4,0.25,0.06,0.03,0.0,0.0,0.05,kate leanne wi tsai,,GEN-3000,2016
+GEN,3020,1,Molecular & General Genetics,0.4,0.35,0.15,0.04,0.02,0.0,0.0,0.04,lukasz kozubowski,,GEN-3020,2016
+GEN,3020,2,Molec & General Genetics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True,GEN-3020,2016
+GEN,3020,4,Molecular & General Genetics,0.35,0.42,0.14,0.05,0.0,0.0,0.0,0.05,haiying liang,,GEN-3020,2016
+GEN,4200,1,Molecular Genetics & Gene Reg,0.27,0.51,0.19,0.0,0.0,0.0,0.0,0.03,julia frugoli,,GEN-4200,2016
+GEN,4200,2,Molecular Genetics & Gen (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True,GEN-4200,2016
+GEN,4400,1,Bioinformatics,0.73,0.09,0.05,0.0,0.0,0.0,0.0,0.14,frank alexan feltus,,GEN-4400,2016
+GEN,4500,1,Comparative Genetics,0.3,0.54,0.14,0.0,0.03,0.0,0.0,0.0,leigh anne clark,,GEN-4500,2016
+GEN,4900,1,Epigenetics,0.42,0.17,0.25,0.0,0.08,0.0,0.0,0.08,rajandeep si sekhon,,GEN-4900,2016
+GEN,6200,1,Molecular Genetics & Gene Reg,0.0,0.67,0.17,0.0,0.0,0.0,0.0,0.17,julia frugoli,,GEN-6200,2016
+GEN,6400,1,Bioinformatics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,,GEN-6400,2016
+GEN,8140,1,Advanced Genetics,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,,GEN-8140,2016
+GEOG,1010,1,Intro to Geography,0.3,0.45,0.2,0.05,0.0,0.0,0.0,0.0,william churc terry,,GEOG-1010,2016
+GEOG,1030,1,World Regional Geog,0.78,0.12,0.06,0.0,0.02,0.0,0.0,0.02,lance forres howard,,GEOG-1030,2016
+GEOG,1030,2,World Regional Geog,0.8,0.18,0.0,0.03,0.0,0.0,0.0,0.0,lance forres howard,,GEOG-1030,2016
+GEOG,1060,1,Geog Phys Envt,0.42,0.16,0.21,0.11,0.11,0.0,0.0,0.0,william churc terry,,GEOG-1060,2016
+GEOL,1010,1,Physical Geology,0.27,0.32,0.24,0.08,0.05,0.0,0.0,0.03,alan coulson,,GEOL-1010,2016
+GEOL,1010,2,Physical Geology,0.24,0.31,0.24,0.09,0.07,0.0,0.0,0.05,alan coulson,,GEOL-1010,2016
+GEOL,1010,3,Physical Geology,0.49,0.2,0.14,0.06,0.1,0.0,0.0,0.0,kelly best lazar,,GEOL-1010,2016
+GEOL,1030,1,Physical Geol Lab,0.54,0.33,0.04,0.0,0.08,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,2,Physical Geol Lab,0.48,0.3,0.13,0.0,0.0,0.0,0.0,0.09,alan coulson,,GEOL-1030,2016
+GEOL,1030,3,Physical Geol Lab,0.64,0.23,0.05,0.0,0.05,0.0,0.0,0.05,alan coulson,,GEOL-1030,2016
+GEOL,1030,4,Physical Geol Lab,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,5,Physical Geol Lab,0.22,0.43,0.26,0.0,0.04,0.0,0.0,0.04,alan coulson,,GEOL-1030,2016
+GEOL,1030,6,Physical Geol Lab,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2016
+GEOL,1030,7,Physical Geol Lab,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,8,Physical Geol Lab,0.38,0.38,0.04,0.04,0.08,0.0,0.0,0.08,alan coulson,,GEOL-1030,2016
+GEOL,1030,9,Physical Geol Lab,0.38,0.57,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,10,Physical Geol Lab,0.04,0.58,0.21,0.0,0.04,0.0,0.0,0.13,alan coulson,,GEOL-1030,2016
+GEOL,1030,11,Physical Geol Lab,0.2,0.5,0.15,0.1,0.0,0.0,0.0,0.05,alan coulson,,GEOL-1030,2016
+GEOL,1030,12,Physical Geol Lab,0.67,0.0,0.2,0.0,0.0,0.0,0.0,0.13,alan coulson,,GEOL-1030,2016
+GEOL,2050,1,Mineralogy & Intro Petrology,0.45,0.18,0.36,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-2050,2016
+GEOL,2070,1,Min & Intro Pet Lab,0.09,0.18,0.45,0.18,0.09,0.0,0.0,0.0,alan coulson,,GEOL-2070,2016
+GEOL,2700,1,Sustainable Water,0.83,0.06,0.03,0.03,0.0,0.0,0.0,0.06,stephen mich moysey,,GEOL-2700,2016
+GEOL,2750,1,Field Methods,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,scott brame,,GEOL-2750,2016
+GEOL,3000,1,Environmental Geology,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-3000,2016
+GEOL,3020,1,Structural Geology,0.27,0.27,0.36,0.09,0.0,0.0,0.0,0.0,james castle,,GEOL-3020,2016
+GEOL,4110,2,Exploring Sustainability,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.08,kelly best lazar,,GEOL-4110,2016
+GEOL,4110,8,CI - Community Outreach,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,john robert wagner,,GEOL-4110,2016
+GEOL,4820,1,Groundwater & Contam Transport,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,lawrence murdoch,,GEOL-4820,2016
+GEOL,4910,1,Research Synthesis I,0.5,0.33,0.08,0.0,0.08,0.0,0.0,0.0,alan coulson,,GEOL-4910,2016
+GEOL,6150,1,Analysis Geological Processes,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,,GEOL-6150,2016
+GEOL,8080,1,Groundwater Modeling,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,,GEOL-8080,2016
+GER,1010,1,Elementary German,0.21,0.29,0.36,0.0,0.07,0.0,0.0,0.07, lee ferrell,,GER-1010,2016
+GER,1010,2,Elementary German,0.13,0.5,0.25,0.06,0.0,0.0,0.0,0.06, lee ferrell,,GER-1010,2016
+GER,1020,1,Elementary German,0.38,0.38,0.08,0.08,0.0,0.0,0.0,0.08,oswald harris king,,GER-1020,2016
+GER,1020,2,Elementary German,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-1020,2016
+GER,2010,1,Intermediate German,0.53,0.27,0.07,0.13,0.0,0.0,0.0,0.0,oswald harris king,,GER-2010,2016
+GER,2010,2,Intermediate German,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-2010,2016
+GER,2020,1,Intermediate German,0.13,0.33,0.27,0.13,0.13,0.0,0.0,0.0,gabriela stoicea,,GER-2020,2016
+GER,3050,1,Ger Conv & Comp,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0, lee ferrell,,GER-3050,2016
+GER,3400,1,German Culture,0.69,0.19,0.0,0.0,0.06,0.0,0.0,0.06,oswald harris king,,GER-3400,2016
+GER,4170,1,Topics Ger Intl TR,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0, lee ferrell,,GER-4170,2016
+HCC,8310,1,Fundamentals of Hcc,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,bart knijnenburg,,HCC-8310,2016
+HCC,8330,1,HCC Research Methods,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,,HCC-8330,2016
+HCG,9890,403,Interdisiplinary Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,julia eggert,,HCG-9890,2016
+HEHD,8030,400,Ethical Leadership,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,,HEHD-8030,2016
+HEHD,8050,1,Yth Dev in Families,0.71,0.12,0.12,0.0,0.0,0.0,0.0,0.06,william quinn,,HEHD-8050,2016
+HEHD,8060,230,Diverse Society,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,ann marie gillard,,HEHD-8060,2016
+HIST,1010,1,Hist of the U S,0.33,0.48,0.1,0.01,0.03,0.0,0.0,0.05,james brad jeffries,,HIST-1010,2016
+HIST,1020,1,Hist of the U S,0.37,0.27,0.14,0.12,0.04,0.0,0.0,0.06,john andrew,,HIST-1020,2016
+HIST,1220,1,"Hist, Tech & Society",0.09,0.55,0.29,0.03,0.02,0.0,0.0,0.02,pamela mack,,HIST-1220,2016
+HIST,1240,1,Environmental History Survey,0.3,0.45,0.21,0.0,0.0,0.0,0.0,0.03,james brad jeffries,,HIST-1240,2016
+HIST,1240,2,Environmental History Survey,0.3,0.45,0.15,0.0,0.06,0.0,0.0,0.03,james brad jeffries,,HIST-1240,2016
+HIST,1720,1,The West and the World I,0.15,0.38,0.22,0.07,0.1,0.0,0.0,0.07,caroline dunn clark,,HIST-1720,2016
+HIST,1720,2,The West and the World I,0.26,0.54,0.14,0.03,0.02,0.0,0.0,0.02,steven marks,,HIST-1720,2016
+HIST,1730,1,The West and the World II,0.41,0.37,0.08,0.02,0.09,0.0,0.0,0.04, alan grubb,,HIST-1730,2016
+HIST,1730,2,The West and the World II,0.41,0.27,0.18,0.09,0.05,0.0,0.0,0.0,subah dayal,,HIST-1730,2016
+HIST,2990,1,Historian's Craft,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,michael silvestri,,HIST-2990,2016
+HIST,2990,2,Historian's Craft,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,elizabeth carney,,HIST-2990,2016
+HIST,2990,3,Historian's Craft,0.54,0.31,0.0,0.0,0.0,0.0,0.0,0.15,rachel anne moore,,HIST-2990,2016
+HIST,3040,1,Indus & Progr Era,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0, roger grant,,HIST-3040,2016
+HIST,3120,1,Afr Amer Hist 1877 to Present,0.68,0.21,0.0,0.0,0.11,0.0,0.0,0.0,abel bartley,,HIST-3120,2016
+HIST,3140,1,Hist of the South I,0.24,0.59,0.0,0.0,0.07,0.0,0.0,0.1,paul chris anderson,,HIST-3140,2016
+HIST,3290,1,US Legal History Since 1890,0.44,0.33,0.11,0.0,0.06,0.0,0.0,0.06,renee roux,,HIST-3290,2016
+HIST,3380,1,Africa to 1875,0.6,0.2,0.15,0.0,0.05,0.0,0.0,0.0,james burns,,HIST-3380,2016
+HIST,3400,1,Latin America I,0.63,0.17,0.07,0.03,0.03,0.0,0.0,0.07,rachel anne moore,,HIST-3400,2016
+HIST,3550,1,Roman World,0.33,0.56,0.04,0.0,0.04,0.0,0.0,0.04,elizabeth carney,,HIST-3550,2016
+HIST,3630,1,Britain Since 1688,0.28,0.38,0.13,0.16,0.06,0.0,0.0,0.0,stephani barczewski,,HIST-3630,2016
+HIST,3670,1,Modern Ireland,0.44,0.29,0.09,0.0,0.12,0.0,0.0,0.06,michael silvestri,,HIST-3670,2016
+HIST,3700,1,Medieval History,0.27,0.5,0.13,0.0,0.0,0.0,0.0,0.1,caroline dunn clark,,HIST-3700,2016
+HIST,3720,1,Renaissance,0.33,0.39,0.11,0.06,0.0,0.0,0.0,0.11,thomas kuehn,,HIST-3720,2016
+HIST,3890,7,Mitchelville,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,abel bartley,,HIST-3890,2016
+HIST,3890,8,The Churches of Mitchelville,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,abel bartley,,HIST-3890,2016
+HIST,3900,1,Modern Military History,0.22,0.3,0.22,0.04,0.19,0.0,0.0,0.04,edwin moise,,HIST-3900,2016
+HIST,3980,1,American Military History,0.31,0.38,0.24,0.0,0.03,0.0,0.0,0.03,john andrew,,HIST-3980,2016
+HIST,4140,1,Study of Hist Museum,0.25,0.5,0.06,0.13,0.06,0.0,0.0,0.0,meg taylor-shockley,,HIST-4140,2016
+HIST,4360,1,Vietnam Wars,0.05,0.37,0.37,0.0,0.11,0.0,0.0,0.11,edwin moise,,HIST-4360,2016
+HIST,4710,1,The Great War,0.55,0.17,0.03,0.0,0.1,0.0,0.0,0.14, alan grubb,,HIST-4710,2016
+HIST,4900,3,Europe's Age of Dictators,0.42,0.47,0.05,0.0,0.0,0.0,0.0,0.05,amit bein,,HIST-4900,2016
+HIST,8000,2,Historical Methods,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,paul chris anderson,,HIST-8000,2016
+HIST,8100,3,Capitalism,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,,HIST-8100,2016
+HLTH,2020,1,Introduction to Public Health,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2016
+HLTH,2020,2,Introduction to Public Health,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2016
+HLTH,2020,3,Introduction to Public Health,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2016
+HLTH,2020,4,Introduction to Public Health,0.43,0.43,0.13,0.03,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2016
+HLTH,2020,5,Introduction to Public Health,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2016
+HLTH,2020,400,Introduction to Public Health,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,ralph stewart welsh,,HLTH-2020,2016
+HLTH,2030,1,Health Care Sys,0.57,0.26,0.09,0.0,0.04,0.0,0.0,0.04,frederic fraizer,,HLTH-2030,2016
+HLTH,2030,2,Health Care Sys,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,lee alden crandall,,HLTH-2030,2016
+HLTH,2400,1,Deter of Hlth Behav,0.67,0.28,0.0,0.0,0.06,0.0,0.0,0.0,johnny long,,HLTH-2400,2016
+HLTH,2400,2,Deter of Hlth Behav,0.36,0.54,0.07,0.04,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2016
+HLTH,2400,3,Deter of Hlth Behav,0.52,0.31,0.17,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2016
+HLTH,2400,400,Deter of Hlth Behav,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,amelia clinkscales,,HLTH-2400,2016
+HLTH,2600,1,Medical Terminology & Comm,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kari jea strothmann,,HLTH-2600,2016
+HLTH,2980,1,Human Hlth & Disease,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2016
+HLTH,2980,2,Human Hlth & Disease,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2016
+HLTH,2980,3,Human Hlth & Disease,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2980,2016
+HLTH,3050,1,Body Resp Hlth Beh,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,brian patric graves,,HLTH-3050,2016
+HLTH,3400,1,Hlth Prom Prog Plan,0.39,0.43,0.13,0.0,0.04,0.0,0.0,0.0,brian patric graves,,HLTH-3400,2016
+HLTH,3610,1,Int Health Care Econ,0.56,0.29,0.09,0.03,0.0,0.0,0.0,0.03,khoa dang truong,,HLTH-3610,2016
+HLTH,3800,1,Epidemiology,0.3,0.36,0.27,0.02,0.02,0.0,0.0,0.02,hugh spitler,,HLTH-3800,2016
+HLTH,3800,2,Epidemiology,0.55,0.34,0.1,0.0,0.0,0.0,0.0,0.0,rachel mayo,,HLTH-3800,2016
+HLTH,3800,400,Epidemiology,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,deborah alma falta,,HLTH-3800,2016
+HLTH,4150,1,Obesity & Eating Dis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,karen kemper,,HLTH-4150,2016
+HLTH,4190,1,Health Sci Internship Prep Sem,0.63,0.28,0.1,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4190,2016
+HLTH,4200,1,Hlth Science Intern,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2016
+HLTH,4400,1,Manag Hlth Serv Org,0.37,0.37,0.19,0.04,0.04,0.0,0.0,0.0,frederic fraizer,,HLTH-4400,2016
+HLTH,4700,1,Global Health,0.67,0.21,0.08,0.0,0.04,0.0,0.0,0.0,annah kamugiz amani,,HLTH-4700,2016
+HLTH,4700,400,Global Health,0.88,0.08,0.0,0.04,0.0,0.0,0.0,0.0,annah kamugiz amani,,HLTH-4700,2016
+HLTH,4750,1,Hlthcr Oper Mgmt Res,0.59,0.18,0.18,0.0,0.0,0.0,0.0,0.05,lu shi,,HLTH-4750,2016
+HLTH,4900,1,Res Eval St Pub Hlth,0.51,0.37,0.1,0.02,0.0,0.0,0.0,0.0,lingling zhang,,HLTH-4900,2016
+HLTH,4900,2,Res Eval St Pub Hlth,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,lingling zhang,,HLTH-4900,2016
+HLTH,8090,1,Epidemiological Res,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,liwei chen,,HLTH-8090,2016
+HLTH,8120,500,Clinical and Translational Sci,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,ronald gimbel,,HLTH-8120,2016
+HON,1910,1,Romanticism and Its Influence,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,,HON-1910,2016
+HON,1930,1,World in Crisis,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vladimir matic,,HON-1930,2016
+HON,2020,1,Who Decides What's Cool?,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,amanda cooper fine,,HON-2020,2016
+HON,2020,2,World of Ideas,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,,HON-2020,2016
+HON,2220,1,Almost Human,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,,HON-2220,2016
+HORT,1010,1,Horticulture,0.86,0.09,0.02,0.02,0.0,0.0,0.0,0.02,ellen anita vincent,,HORT-1010,2016
+HORT,2100,1,Growing Fall Plants,0.26,0.57,0.13,0.0,0.04,0.0,0.0,0.0,james emerson faust,,HORT-2100,2016
+HORT,2120,1,Turfgrass Culture,0.52,0.38,0.07,0.0,0.02,0.0,0.0,0.02,haibo liu,,HORT-2120,2016
+HORT,2130,1,Turf Culture Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,donald garrett,,HORT-2130,2016
+HORT,2130,2,Turf Culture Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,donald garrett,,HORT-2130,2016
+HORT,3030,1,Landscape Plants,0.18,0.32,0.35,0.04,0.03,0.0,0.0,0.07,robert polomski,,HORT-3030,2016
+HORT,3080,1,Sust Landsc Des Install Maint,0.84,0.12,0.02,0.0,0.0,0.0,0.0,0.02,ellen anita vincent,,HORT-3080,2016
+HORT,4330,1,Turf Weed Management,0.21,0.36,0.36,0.07,0.0,0.0,0.0,0.0,ted whitwell,,HORT-4330,2016
+HORT,4550,1,Just Fruits,0.39,0.43,0.13,0.0,0.04,0.0,0.0,0.0,gregory reighard,,HORT-4550,2016
+HP,8010,1,Preservation Law and Econ,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,richard sidebottom,,HP-8010,2016
+HP,8030,1,Building Tech and Pathology,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,amalia leifeste,,HP-8030,2016
+HP,8090,400,Historical Research Methods,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,katherine pemberton,,HP-8090,2016
+HP,8230,400,Historic American Interiors,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,elizabeth garr ryan,,HP-8230,2016
+HRD,8200,400,Human Perform Improv,0.62,0.17,0.0,0.0,0.14,0.0,0.0,0.07,cynthia sims,,HRD-8200,2016
+HRD,8300,400,Concepts of H R D,0.46,0.27,0.08,0.0,0.15,0.0,0.0,0.04,charlotte ann chase,,HRD-8300,2016
+HRD,8450,400,Needs Assess Ed/Ind,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,philip mcgee,,HRD-8450,2016
+HRD,8600,400,Instruc Mat Devel,0.76,0.06,0.03,0.0,0.12,0.0,0.0,0.03,philip mcgee,,HRD-8600,2016
+IE,2000,100,Soph Seminar in I E,0.54,0.19,0.12,0.04,0.05,0.0,0.0,0.06,brian melloy,,IE-2000,2016
+IE,2100,1,Des Analysis Wrk Sys,0.07,0.39,0.32,0.1,0.05,0.0,0.0,0.06,david neyens,,IE-2100,2016
+IE,2800,1,Deterministic Operations Rsrch,0.16,0.4,0.16,0.13,0.08,0.0,0.0,0.07,robert james riggs,,IE-2800,2016
+IE,3010,1,Systems Design I,0.47,0.43,0.09,0.0,0.0,0.0,0.0,0.01,robert james riggs,,IE-3010,2016
+IE,3600,1,Industrial Apps of Prob/Stat I,0.29,0.27,0.29,0.06,0.08,0.0,0.0,0.02,tugce isik,,IE-3600,2016
+IE,3600,2,Industrial Apps of Prob/Stat I,0.18,0.27,0.27,0.18,0.05,0.0,0.0,0.05,tugce isik,,IE-3600,2016
+IE,3610,1,Industrial App of Prob/Stat II,0.27,0.27,0.15,0.15,0.12,0.0,0.0,0.04,joel greenstein,,IE-3610,2016
+IE,3680,1,Prof Practice in I E,0.87,0.05,0.02,0.03,0.0,0.0,0.0,0.02,brian melloy,,IE-3680,2016
+IE,3810,1,Probabilistic Operations Rsrch,0.24,0.32,0.21,0.08,0.13,0.0,0.0,0.03,amin khademi,,IE-3810,2016
+IE,3840,1,Engr Econ Analysis,0.21,0.15,0.11,0.12,0.12,0.0,0.0,0.29,brian melloy,,IE-3840,2016
+IE,3860,1,Prod Plan & Cont,0.21,0.37,0.17,0.11,0.13,0.0,0.0,0.0,robert james riggs,,IE-3860,2016
+IE,4400,1,Decision Support Sys,0.64,0.14,0.09,0.05,0.05,0.0,0.0,0.03,jonathan lowe,,IE-4400,2016
+IE,4570,1,Transp/Logistic Engr,0.25,0.59,0.15,0.02,0.0,0.0,0.0,0.0,sandra dun eksioglu,,IE-4570,2016
+IE,4610,1,Quality Engineering,0.25,0.28,0.27,0.15,0.03,0.0,0.0,0.03,byung rae cho,,IE-4610,2016
+IE,4650,1,Facilities Planning & Design,0.78,0.17,0.03,0.02,0.0,0.0,0.0,0.0,jonathan lowe,,IE-4650,2016
+IE,4650,2,Facilities Planning & Design,0.42,0.33,0.13,0.13,0.0,0.0,0.0,0.0,brian melloy,,IE-4650,2016
+IE,4820,1,Systems Modeling,0.36,0.39,0.18,0.04,0.01,0.0,0.0,0.01,kevin taaffe,,IE-4820,2016
+IE,4820,2,Systems Modeling,0.26,0.55,0.1,0.07,0.0,0.0,0.0,0.02,kevin taaffe,,IE-4820,2016
+IE,4910,1,Invest Human Errors Cmplx Sys,0.31,0.31,0.09,0.06,0.03,0.0,0.0,0.2,sara lu riggs,,IE-4910,2016
+IE,6910,2,Advanced Math Opt Models,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,,IE-6910,2016
+IE,8000,1,Human Factors Eng,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david neyens,,IE-8000,2016
+IE,8010,1,Human-Machine Sys,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,,IE-8010,2016
+IE,8030,1,Engr Optimization and Apps,0.27,0.5,0.18,0.0,0.0,0.0,0.0,0.05,amin khademi,,IE-8030,2016
+IE,8040,1,Mfg Sys Plan & Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,,IE-8040,2016
+IE,8090,1,Model Sys Under Risk,0.17,0.61,0.17,0.0,0.0,0.0,0.0,0.06,burak eksioglu,,IE-8090,2016
+IE,8510,1,Descriptive Analytics,0.92,0.0,0.0,0.0,0.08,0.0,0.0,0.0,mary elizabeth kurz,,IE-8510,2016
+IE,8530,1,Foundations of Quality,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,byung rae cho,,IE-8530,2016
+IE,8550,1,SC & Logistics Modeling II,0.8,0.11,0.04,0.0,0.04,0.0,0.0,0.0,kevin taaffe,,IE-8550,2016
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.84,0.14,0.02,caren kelley-hall,,INT-1510,2016
+INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.92,0.06,0.02,caren kelley-hall,,INT-1520,2016
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,,INT-1530,2016
+INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.83,0.14,0.03,caren kelley-hall,,INT-1540,2016
+INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.82,0.12,0.06,caren kelley-hall,,INT-2510,2016
+IPM,4010,1,Principles of I P M,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,robert bellinger,,IPM-4010,2016
+IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.86,0.05,0.09,meredith fan wilson,,IS-1010,2016
+ITAL,1010,1,Elementary Italian,0.33,0.25,0.25,0.08,0.08,0.0,0.0,0.0,julia schmidt,,ITAL-1010,2016
+ITAL,1010,2,Elementary Italian,0.59,0.12,0.06,0.0,0.06,0.0,0.0,0.18,julia schmidt,,ITAL-1010,2016
+ITAL,1010,3,Elementary Italian,0.67,0.17,0.0,0.0,0.08,0.0,0.0,0.08,lyudmyla tsykalova,,ITAL-1010,2016
+ITAL,1010,4,Elementary Italian,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-1010,2016
+ITAL,2010,1,Intermediate Italian,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,,ITAL-2010,2016
+ITAL,2020,1,Intermediate Italian,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,,ITAL-2020,2016
+JAPN,1010,1,Elementary Japanese,0.58,0.08,0.17,0.0,0.08,0.0,0.0,0.08,shinichi shoji,,JAPN-1010,2016
+JAPN,1010,2,Elementary Japanese,0.53,0.18,0.24,0.0,0.0,0.0,0.0,0.06,shinichi shoji,,JAPN-1010,2016
+JAPN,1010,3,Elementary Japanese,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,shinichi shoji,,JAPN-1010,2016
+JAPN,2010,1,Intermed Japanese,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,jae allegr takeuchi,,JAPN-2010,2016
+JAPN,3050,1,Japanese Conversation & Comp,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,kazuko shoji,,JAPN-3050,2016
+JAPN,4010,1,Japanese Lit in Translation,0.76,0.0,0.12,0.0,0.0,0.0,0.0,0.12,jae allegr takeuchi,,JAPN-4010,2016
+LANG,3000,1,Intro Linguistics,0.33,0.39,0.06,0.06,0.06,0.0,0.0,0.11,daniel smith,,LANG-3000,2016
+LANG,3710,1,Language and Culture,0.3,0.3,0.2,0.1,0.1,0.0,0.0,0.0,yanhua zhang,,LANG-3710,2016
+LARC,1150,1,Intro Landscape Architecture,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,,LARC-1150,2016
+LARC,1280,1,Technical Graphics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,,LARC-1280,2016
+LARC,1510,1,Basic Design I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,martin john holland,,LARC-1510,2016
+LARC,2510,1,Larch Design Fund,0.4,0.4,0.05,0.0,0.1,0.0,0.0,0.05,hala fouad nassar,,LARC-2510,2016
+LARC,2620,2,Design Impl I,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,yang song,,LARC-2620,2016
+LARC,4620,1,Design Implementation III,0.28,0.28,0.28,0.0,0.0,0.0,0.0,0.17,paul russell,,LARC-4620,2016
+LARC,8210,1,Research Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,,LARC-8210,2016
+LARC,8430,1,Interdisc Design,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,,LARC-8430,2016
+LAW,3220,1,Legal Env of Bus,0.44,0.33,0.14,0.02,0.0,0.0,0.0,0.07,edward ray claggett,,LAW-3220,2016
+LAW,3220,2,Legal Env of Bus,0.47,0.43,0.11,0.0,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2016
+LAW,3220,3,Legal Env of Bus,0.26,0.38,0.19,0.13,0.02,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2016
+LAW,3220,4,Legal Env of Bus,0.24,0.48,0.22,0.02,0.02,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2016
+LAW,3220,5,Legal Env of Bus,0.39,0.28,0.22,0.04,0.02,0.0,0.0,0.04,kenneth toussaint,,LAW-3220,2016
+LAW,3220,6,Legal Env of Bus,0.33,0.31,0.2,0.09,0.0,0.0,0.0,0.07,kenneth toussaint,,LAW-3220,2016
+LAW,3220,7,Legal Env of Bus,0.33,0.4,0.17,0.05,0.02,0.0,0.0,0.02,kath kisska-schulze,,LAW-3220,2016
+LAW,3220,8,Legal Env of Bus,0.38,0.6,0.02,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,,LAW-3220,2016
+LAW,3220,9,Legal Env of Bus,0.35,0.54,0.09,0.0,0.0,0.0,0.0,0.02,john hine,,LAW-3220,2016
+LAW,3220,10,Legal Env of Bus,0.37,0.47,0.14,0.02,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2016
+LAW,3220,400,Legal Env of Bus,0.29,0.29,0.16,0.11,0.04,0.0,0.0,0.11,virgini ward-vaughn,,LAW-3220,2016
+LAW,3220,401,Legal Env of Bus,0.41,0.48,0.09,0.02,0.0,0.0,0.0,0.0,virgini ward-vaughn,,LAW-3220,2016
+LAW,3220,402,Legal Env of Bus,0.51,0.2,0.06,0.02,0.08,0.0,0.0,0.12,virgini ward-vaughn,,LAW-3220,2016
+LAW,3220,403,Legal Env of Bus,0.27,0.32,0.1,0.05,0.07,0.0,0.0,0.2,virgini ward-vaughn,,LAW-3220,2016
+LAW,3330,1,Real Estate Law,0.06,0.46,0.29,0.09,0.03,0.0,0.0,0.09,judson jahn,,LAW-3330,2016
+LAW,3330,2,Real Estate Law,0.4,0.23,0.33,0.0,0.0,0.0,0.0,0.03,judson jahn,,LAW-3330,2016
+LAW,4050,1,Construction Law,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-4050,2016
+LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,eric touya,,LIT-1270,2016
+LS,1000,1,Therapeutic Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,,LS-1000,2016
+LS,1000,2,Therapeutic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,,LS-1000,2016
+LS,1000,3,Therapeutic Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,,LS-1000,2016
+LS,1000,4,Intermediate Top-rope,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,corey newe winstead,,LS-1000,2016
+LS,1000,11,Organic Gardening,0.81,0.06,0.06,0.0,0.06,0.0,0.0,0.0,shawn jadrnicek,,LS-1000,2016
+LS,1000,12,Introduction to Salsa,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,,LS-1000,2016
+LS,1000,13,Introduction to Salsa Dance,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,malik lewis baxter,,LS-1000,2016
+LS,1000,24,FItness leadership,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,patricia figueroa,,LS-1000,2016
+LS,1330,4,Women's Shotgun,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,edward licus prater,,LS-1330,2016
+LS,1410,1,Top Rope Climbing,0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,corey newe winstead,,LS-1410,2016
+LS,1410,2,Top Rope Climbing,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,corey newe winstead,,LS-1410,2016
+LS,1410,3,Top Rope Climbing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,corey newe winstead,,LS-1410,2016
+LS,1410,4,Top Rope Climbing,0.71,0.06,0.06,0.06,0.0,0.0,0.0,0.12,corey newe winstead,,LS-1410,2016
+LS,1410,5,Top Rope Climbing,0.83,0.06,0.0,0.0,0.11,0.0,0.0,0.0,corey newe winstead,,LS-1410,2016
+LS,1560,6,Riflery,0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,herbert strickland,,LS-1560,2016
+LS,1580,1,Archery,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,,LS-1580,2016
+LS,1580,3,Archery,0.81,0.0,0.0,0.0,0.0,0.0,0.0,0.19,herbert strickland,,LS-1580,2016
+LS,1580,5,Archery,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,herbert strickland,,LS-1580,2016
+LS,1640,1,Whitewater Kayaking,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,cara jill wrenn,,LS-1640,2016
+LS,1640,2,Whitewater Kayaking,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,robert taylor,,LS-1640,2016
+LS,1790,1,Scuba I,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,robert bogan,,LS-1790,2016
+LS,1850,2,Bowling,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,megan elizabet cato,,LS-1850,2016
+LS,1850,3,Bowling,0.9,0.07,0.0,0.0,0.03,0.0,0.0,0.0,kathryn ly mitchell,,LS-1850,2016
+LS,1850,5,Bowling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,katie dudley,,LS-1850,2016
+LS,1850,10,Bowling,0.86,0.07,0.03,0.0,0.03,0.0,0.0,0.0,katie dudley,,LS-1850,2016
+LS,1940,1,Racquetball,0.69,0.15,0.0,0.08,0.0,0.0,0.0,0.08,raymond petersen,,LS-1940,2016
+LS,1980,5,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jason jordan,,LS-1980,2016
+LS,1990,1,Intermediate Golf,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,jason jordan,,LS-1990,2016
+LS,2180,1,Ballroom Dance,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,broadus fleming,,LS-2180,2016
+LS,2200,9,Shag,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,broadus fleming,,LS-2200,2016
+LS,2270,1,Intro to Swing Dance,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,paul hoke,,LS-2270,2016
+LS,2270,2,Intro to Swing Dance,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,paul hoke,,LS-2270,2016
+LS,2280,1,Intermediate Swing,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,paul hoke,,LS-2280,2016
+LS,2320,1,Core Training,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,,LS-2320,2016
+LS,2320,2,Core Training,0.71,0.19,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,,LS-2320,2016
+LS,2320,4,Core Training,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,,LS-2320,2016
+LS,2320,5,Core Training,0.78,0.13,0.0,0.04,0.0,0.0,0.0,0.04,diane moreno,,LS-2320,2016
+LS,2350,1,Basic Yoga,0.71,0.1,0.1,0.05,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2350,2016
+LS,2350,2,Basic Yoga,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,renee warren gahan,,LS-2350,2016
+LS,2350,3,Basic Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,renee warren gahan,,LS-2350,2016
+LS,2350,4,Basic Yoga,0.86,0.05,0.09,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,,LS-2350,2016
+LS,2360,1,Power/Ashtanga Yoga,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,silica eliza larkin,,LS-2360,2016
+LS,2380,2,Vinyasa Flow Yoga,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ani reina-nunnelley,,LS-2380,2016
+LS,2420,1,Meditation and Relax,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2016
+LS,2420,2,Meditation and Relax,0.83,0.09,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2016
+LS,2420,6,Meditation and Relax,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2016
+LS,2420,7,Meditation and Relax,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2420,2016
+LS,2420,8,Meditation and Relax,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,,LS-2420,2016
+LS,2450,2,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,,LS-2450,2016
+LS,2450,3,Pilates,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,,LS-2450,2016
+LS,2450,4,Pilates,0.88,0.0,0.0,0.0,0.04,0.0,0.0,0.08,melanie ivey job,,LS-2450,2016
+LS,2450,7,Pilates,0.81,0.05,0.0,0.0,0.05,0.0,0.0,0.1,diane moreno,,LS-2450,2016
+LS,2510,3,Running & Jogging,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,robert edwar lawson,,LS-2510,2016
+LS,2700,1,Sports Officiating,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,christopher war cox,,LS-2700,2016
+LS,2750,9,First Aid/Cpr,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,candice lyn honnold,,LS-2750,2016
+LS,2750,10,First Aid/Cpr,0.73,0.07,0.0,0.0,0.0,0.0,0.0,0.2,candice lyn honnold,,LS-2750,2016
+MATH,1010,1,Essen Math for Informed Soc,0.23,0.23,0.46,0.0,0.0,0.0,0.0,0.08,thowhida akther,,MATH-1010,2016
+MATH,1010,2,Essen Math for Informed Soc,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,thowhida akther,,MATH-1010,2016
+MATH,1010,3,Essen Math for Informed Soc,0.5,0.28,0.17,0.06,0.0,0.0,0.0,0.0,xiyan tan,,MATH-1010,2016
+MATH,1010,4,Essen Math for Informed Soc,0.31,0.38,0.12,0.07,0.07,0.0,0.0,0.05,judith cottingham,,MATH-1010,2016
+MATH,1010,5,Essen Math for Informed Soc,0.21,0.36,0.21,0.14,0.07,0.0,0.0,0.0,xiyan tan,,MATH-1010,2016
+MATH,1010,6,Essen Math for Informed Soc,0.33,0.35,0.16,0.07,0.05,0.0,0.0,0.05,judith cottingham,,MATH-1010,2016
+MATH,1010,8,Essen Math for Informed Soc,0.17,0.39,0.28,0.11,0.06,0.0,0.0,0.0,tianhui wei,,MATH-1010,2016
+MATH,1010,10,Essen Math for Informed Soc,0.54,0.23,0.0,0.0,0.08,0.0,0.0,0.15,tianhui wei,,MATH-1010,2016
+MATH,1020,1,Business Calculus I,0.06,0.56,0.17,0.06,0.17,0.0,0.0,0.0,thomas clevenger,,MATH-1020,2016
+MATH,1020,2,Business Calculus I,0.21,0.21,0.26,0.11,0.11,0.0,0.0,0.11,bryce pruitt,,MATH-1020,2016
+MATH,1020,3,Business Calculus I,0.18,0.18,0.36,0.07,0.18,0.0,0.0,0.02,warren adams,,MATH-1020,2016
+MATH,1020,5,Business Calculus I,0.16,0.32,0.37,0.05,0.11,0.0,0.0,0.0,peter westerbaan,,MATH-1020,2016
+MATH,1020,6,Business Calculus I,0.16,0.32,0.21,0.0,0.16,0.0,0.0,0.16,jared scott miller,,MATH-1020,2016
+MATH,1020,7,Business Calculus I,0.22,0.44,0.17,0.06,0.11,0.0,0.0,0.0,thomas clevenger,,MATH-1020,2016
+MATH,1020,8,Business Calculus I,0.16,0.42,0.11,0.11,0.16,0.0,0.0,0.05,bryce pruitt,,MATH-1020,2016
+MATH,1020,9,Business Calculus I,0.37,0.21,0.16,0.0,0.16,0.0,0.0,0.11,michael thoma cowen,,MATH-1020,2016
+MATH,1020,10,Business Calculus I,0.28,0.33,0.22,0.06,0.06,0.0,0.0,0.06,ashleigh craig,,MATH-1020,2016
+MATH,1020,11,Business Calculus I,0.26,0.42,0.16,0.05,0.11,0.0,0.0,0.0,fun choi john chan,,MATH-1020,2016
+MATH,1020,12,Business Calculus I,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,peter westerbaan,,MATH-1020,2016
+MATH,1020,13,Business Calculus I,0.31,0.26,0.21,0.07,0.07,0.0,0.0,0.07,randy davidson,,MATH-1020,2016
+MATH,1020,14,Business Calculus I,0.0,0.37,0.47,0.0,0.11,0.0,0.0,0.05,emily marie nystrom,,MATH-1020,2016
+MATH,1020,15,Business Calculus I,0.16,0.42,0.16,0.16,0.05,0.0,0.0,0.05,todd fenstermacher,,MATH-1020,2016
+MATH,1020,16,Business Calculus I,0.28,0.11,0.22,0.17,0.22,0.0,0.0,0.0,fun choi john chan,,MATH-1020,2016
+MATH,1020,17,Business Calculus I,0.26,0.42,0.16,0.0,0.0,0.0,0.0,0.16,ashleigh craig,,MATH-1020,2016
+MATH,1020,18,Business Calculus I,0.11,0.53,0.11,0.21,0.0,0.0,0.0,0.05,michael thoma cowen,,MATH-1020,2016
+MATH,1020,19,Business Calculus I,0.31,0.21,0.14,0.12,0.12,0.0,0.0,0.1,randy davidson,,MATH-1020,2016
+MATH,1020,20,Business Calculus I,0.21,0.37,0.21,0.05,0.11,0.0,0.0,0.05,emily marie nystrom,,MATH-1020,2016
+MATH,1020,21,Business Calculus I,0.16,0.21,0.32,0.0,0.16,0.0,0.0,0.16,todd fenstermacher,,MATH-1020,2016
+MATH,1020,22,Business Calculus I,0.42,0.16,0.37,0.05,0.0,0.0,0.0,0.0,john william grant,,MATH-1020,2016
+MATH,1020,23,Business Calculus I,0.26,0.32,0.16,0.0,0.21,0.0,0.0,0.05,camille zerfas,,MATH-1020,2016
+MATH,1020,24,Business Calculus I,0.28,0.11,0.28,0.22,0.06,0.0,0.0,0.06,aaro ramirez flores,,MATH-1020,2016
+MATH,1020,25,Business Calculus I,0.11,0.37,0.26,0.05,0.11,0.0,0.0,0.11,stephen peele,,MATH-1020,2016
+MATH,1020,26,Business Calculus I,0.21,0.32,0.37,0.05,0.0,0.0,0.0,0.05,shanshan jia,,MATH-1020,2016
+MATH,1020,27,Business Calculus I,0.37,0.05,0.26,0.21,0.05,0.0,0.0,0.05,kara ail stasikelis,,MATH-1020,2016
+MATH,1020,28,Business Calculus I,0.53,0.16,0.21,0.11,0.0,0.0,0.0,0.0,stephen peele,,MATH-1020,2016
+MATH,1020,29,Business Calculus I,0.32,0.21,0.26,0.05,0.11,0.0,0.0,0.05,camille zerfas,,MATH-1020,2016
+MATH,1020,30,Business Calculus I,0.21,0.37,0.26,0.0,0.05,0.0,0.0,0.11,jing li,,MATH-1020,2016
+MATH,1020,32,Business Calculus I,0.26,0.21,0.16,0.11,0.26,0.0,0.0,0.0,lu sun,,MATH-1020,2016
+MATH,1020,33,Business Calculus I,0.4,0.28,0.13,0.08,0.08,0.0,0.0,0.05,warren adams,,MATH-1020,2016
+MATH,1020,34,Business Calculus I,0.35,0.35,0.18,0.0,0.06,0.0,0.0,0.06,shanshan jia,,MATH-1020,2016
+MATH,1020,35,Business Calculus I,0.37,0.26,0.21,0.0,0.11,0.0,0.0,0.05,kara ail stasikelis,,MATH-1020,2016
+MATH,1020,36,Business Calculus I,0.06,0.25,0.25,0.06,0.25,0.0,0.0,0.13,tianqi zhang,,MATH-1020,2016
+MATH,1020,37,Business Calculus I,0.13,0.31,0.25,0.0,0.19,0.0,0.0,0.13,jing li,,MATH-1020,2016
+MATH,1020,38,Business Calculus I,0.22,0.33,0.17,0.17,0.06,0.0,0.0,0.06,stephen garth,,MATH-1020,2016
+MATH,1020,39,Business Calculus I,0.26,0.29,0.19,0.1,0.05,0.0,0.0,0.12,warren adams,,MATH-1020,2016
+MATH,1020,40,Business Calculus I,0.17,0.5,0.11,0.11,0.11,0.0,0.0,0.0,aaro ramirez flores,,MATH-1020,2016
+MATH,1020,41,Business Calculus I,0.12,0.29,0.12,0.18,0.18,0.0,0.0,0.12,tianqi zhang,,MATH-1020,2016
+MATH,1020,42,Business Calculus I,0.0,0.32,0.26,0.16,0.21,0.0,0.0,0.05,lu sun,,MATH-1020,2016
+MATH,1020,44,Business Calculus I,0.0,0.21,0.42,0.0,0.21,0.0,0.0,0.16,stephen garth,,MATH-1020,2016
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.56,0.4,0.04,donna simms,,MATH-1040,2016
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.32,0.47,0.21,xun dong,,MATH-1040,2016
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.46,0.2,haotian feng,,MATH-1040,2016
+MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.53,0.43,0.04,tony thanh nguyen,,MATH-1040,2016
+MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.56,0.06,chase norman joyner,,MATH-1040,2016
+MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.48,0.41,0.11,tony thanh nguyen,,MATH-1040,2016
+MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.44,0.18,lauren pai mcintyre,,MATH-1040,2016
+MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.64,0.02,tony thanh nguyen,,MATH-1040,2016
+MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.48,0.14,liang zhao,,MATH-1040,2016
+MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.35,0.56,0.08,nicholas ahlstrom,,MATH-1040,2016
+MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.26,0.46,0.28,stefan adam bock,,MATH-1040,2016
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.6,0.34,0.06,charity watson,,MATH-1050,2016
+MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.52,0.46,0.02,charity watson,,MATH-1050,2016
+MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.39,0.02,charity watson,,MATH-1050,2016
+MATH,1060,2,Calculus of One Variable I,0.11,0.27,0.13,0.04,0.27,0.0,0.0,0.18,sanwar ahmad,,MATH-1060,2016
+MATH,1060,3,Calculus of One Variable I,0.36,0.29,0.21,0.02,0.05,0.0,0.0,0.07,garrett dranichak,,MATH-1060,2016
+MATH,1060,4,Calculus of One Variable I,0.2,0.29,0.11,0.14,0.2,0.0,0.0,0.06,jonathon leverenz,,MATH-1060,2016
+MATH,1060,5,Calculus of One Variable I,0.13,0.35,0.17,0.02,0.13,0.0,0.0,0.21,michael gl eldredge,,MATH-1060,2016
+MATH,1060,7,Calculus of One Variable I,0.1,0.4,0.08,0.03,0.23,0.0,0.0,0.18,shuhan xu,,MATH-1060,2016
+MATH,1060,8,Calculus of One Variable I,0.14,0.51,0.11,0.06,0.14,0.0,0.0,0.03,beth novick,,MATH-1060,2016
+MATH,1060,10,Calculus of One Variable I,0.14,0.3,0.18,0.02,0.18,0.0,0.0,0.18,sergey charnyi,,MATH-1060,2016
+MATH,1060,11,Calculus of One Variable I,0.33,0.26,0.21,0.05,0.05,0.0,0.0,0.1,hugh geller,,MATH-1060,2016
+MATH,1060,13,Calculus of One Variable I,0.09,0.2,0.27,0.05,0.16,0.0,0.0,0.23,sofya alekseeva,,MATH-1060,2016
+MATH,1060,14,Calculus of One Variable I,0.12,0.33,0.21,0.05,0.14,0.0,0.0,0.14,irina viktorova,,MATH-1060,2016
+MATH,1060,15,Calculus of One Variable I,0.24,0.24,0.32,0.06,0.12,0.0,0.0,0.03,marilyn reba,,MATH-1060,2016
+MATH,1060,16,Calculus of One Variable I,0.08,0.16,0.45,0.05,0.21,0.0,0.0,0.05,irina viktorova,,MATH-1060,2016
+MATH,1060,18,Calculus of One Variable I,0.16,0.27,0.24,0.11,0.11,0.0,0.0,0.11,sofya alekseeva,,MATH-1060,2016
+MATH,1060,20,Calculus of One Variable I,0.18,0.39,0.21,0.09,0.06,0.0,0.0,0.06,marilyn reba,,MATH-1060,2016
+MATH,1060,21,Calculus of One Variable I,0.11,0.27,0.16,0.13,0.18,0.0,0.0,0.16,rebecca ramos,,MATH-1060,2016
+MATH,1060,22,Calculus of One Variable I,0.02,0.2,0.29,0.02,0.2,0.0,0.0,0.27,sofya alekseeva,,MATH-1060,2016
+MATH,1060,26,Calculus of One Variable I,0.07,0.34,0.22,0.07,0.2,0.0,0.0,0.1,shuhan xu,,MATH-1060,2016
+MATH,1060,100,Calc of One Variable I (HON),0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,beth novick,True,MATH-1060,2016
+MATH,1060,201,Calculus of One Variable I,0.31,0.35,0.13,0.04,0.06,0.0,0.0,0.1,allen anderso guest,,MATH-1060,2016
+MATH,1060,206,Calculus of One Variable I,0.23,0.38,0.19,0.06,0.1,0.0,0.0,0.04,allen anderso guest,,MATH-1060,2016
+MATH,1060,209,Calculus of One Variable I,0.27,0.27,0.29,0.02,0.06,0.0,0.0,0.08,james brown,,MATH-1060,2016
+MATH,1060,212,Calculus of One Variable I,0.19,0.4,0.27,0.02,0.08,0.0,0.0,0.04,muhamm mohebujjaman,,MATH-1060,2016
+MATH,1060,217,Calculus of One Variable I,0.13,0.38,0.29,0.08,0.06,0.0,0.0,0.06,alistair bentley,,MATH-1060,2016
+MATH,1060,224,Calculus of One Variable I,0.17,0.33,0.33,0.02,0.07,0.0,0.0,0.07,irina viktorova,,MATH-1060,2016
+MATH,1060,225,Calc of One Variable I (RISE),0.24,0.28,0.22,0.02,0.15,0.0,0.0,0.09,"koshy chenthittayil,",,MATH-1060,2016
+MATH,1070,1,Differen and Integral Calculus,0.07,0.14,0.59,0.07,0.1,0.0,0.0,0.03,donna simms,,MATH-1070,2016
+MATH,1080,1,Calculus of One Variable II,0.09,0.22,0.13,0.04,0.35,0.0,0.0,0.17,terri johnson,,MATH-1080,2016
+MATH,1080,2,Calculus of One Variable II,0.03,0.28,0.07,0.0,0.31,0.0,0.0,0.31,timothy fra parrott,,MATH-1080,2016
+MATH,1080,5,Calculus of One Variable II,0.06,0.16,0.25,0.03,0.31,0.0,0.0,0.19,honghai xu,,MATH-1080,2016
+MATH,1080,6,Calculus of One Variable II,0.05,0.14,0.23,0.11,0.32,0.0,0.0,0.16,meredith nicol burr,,MATH-1080,2016
+MATH,1080,7,Calculus of One Variable II,0.13,0.22,0.11,0.07,0.2,0.0,0.0,0.27,meredith nicol burr,,MATH-1080,2016
+MATH,1080,8,Calculus of One Variable II,0.03,0.24,0.13,0.11,0.39,0.0,0.0,0.11,timothy fra parrott,,MATH-1080,2016
+MATH,1080,10,Calculus of One Variable II,0.0,0.1,0.13,0.13,0.45,0.0,0.0,0.2,mark cawood,,MATH-1080,2016
+MATH,1080,11,Calculus of One Variable II,0.08,0.19,0.28,0.06,0.33,0.0,0.0,0.06,honghai xu,,MATH-1080,2016
+MATH,1080,12,Calculus of One Variable II,0.06,0.08,0.17,0.06,0.14,0.0,0.0,0.5,nicole alai sinwell,,MATH-1080,2016
+MATH,1080,204,Calculus of One Variable II,0.13,0.39,0.1,0.1,0.0,0.0,0.0,0.29,timothy fra parrott,,MATH-1080,2016
+MATH,1150,1,Contemp Math for Elem Teach I,0.65,0.27,0.05,0.03,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1150,2016
+MATH,1150,2,Contemp Math for Elem Teach I,0.79,0.17,0.03,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1150,2016
+MATH,1160,1,Contemp Math for Elem Teach II,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,carlos gomez,,MATH-1160,2016
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.86,0.12,0.02,marion hanna,,MATH-1990,2016
+MATH,1990,401,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.04,0.02,marion hanna,,MATH-1990,2016
+MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,,MATH-1990,2016
+MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.0,marion hanna,,MATH-1990,2016
+MATH,2060,1,Calculus of Several Variables,0.31,0.33,0.18,0.03,0.13,0.0,0.0,0.03,akshay sunil gupte,,MATH-2060,2016
+MATH,2060,3,Calculus of Several Variables,0.13,0.1,0.28,0.0,0.15,0.0,0.0,0.33,jeong rock yoon,,MATH-2060,2016
+MATH,2060,4,Calculus of Several Variables,0.33,0.29,0.24,0.05,0.02,0.0,0.0,0.07,hiram lopez valdez,,MATH-2060,2016
+MATH,2060,5,Calculus of Several Variables,0.07,0.18,0.31,0.18,0.13,0.0,0.0,0.13,eleanor jenkins,,MATH-2060,2016
+MATH,2060,6,Calculus of Several Variables,0.23,0.27,0.25,0.1,0.08,0.0,0.0,0.06,hyesuk lee,,MATH-2060,2016
+MATH,2060,7,Calculus of Several Variables,0.24,0.21,0.32,0.0,0.11,0.0,0.0,0.13,gretchen matthews,,MATH-2060,2016
+MATH,2060,8,Calculus of Several Variables,0.14,0.22,0.16,0.14,0.12,0.0,0.0,0.2,shari prevost,,MATH-2060,2016
+MATH,2060,9,Calculus of Several Variables,0.24,0.13,0.33,0.13,0.13,0.0,0.0,0.04,hyesuk lee,,MATH-2060,2016
+MATH,2060,10,Calculus of Several Variables,0.39,0.13,0.26,0.0,0.13,0.0,0.0,0.08,gretchen matthews,,MATH-2060,2016
+MATH,2060,11,Calculus of Several Variables,0.17,0.17,0.1,0.22,0.22,0.0,0.0,0.12,julie lassiter,,MATH-2060,2016
+MATH,2060,12,Calculus of Several Variables,0.43,0.32,0.11,0.06,0.02,0.0,0.0,0.06,martin joha schmoll,,MATH-2060,2016
+MATH,2060,13,Calculus of Several Variables,0.07,0.18,0.25,0.2,0.18,0.0,0.0,0.11,shari prevost,,MATH-2060,2016
+MATH,2060,15,Calculus of Several Variables,0.1,0.19,0.21,0.17,0.14,0.0,0.0,0.19,julie lassiter,,MATH-2060,2016
+MATH,2060,16,Calculus of Several Variables,0.36,0.3,0.25,0.07,0.0,0.0,0.0,0.02,yuyuan ouyang,,MATH-2060,2016
+MATH,2060,17,Calculus of Several Variables,0.24,0.24,0.24,0.13,0.09,0.0,0.0,0.04,hyesuk lee,,MATH-2060,2016
+MATH,2060,18,Calculus of Several Variables,0.07,0.25,0.2,0.18,0.09,0.0,0.0,0.2,shari prevost,,MATH-2060,2016
+MATH,2060,20,Calculus of Several Variables,0.05,0.35,0.22,0.22,0.11,0.0,0.0,0.05,michael adam burr,,MATH-2060,2016
+MATH,2060,21,Calculus of Several Variables,0.16,0.37,0.13,0.16,0.11,0.0,0.0,0.08,michael adam burr,,MATH-2060,2016
+MATH,2060,22,Calculus of Several Variables,0.25,0.3,0.25,0.07,0.09,0.0,0.0,0.05,hiram lopez valdez,,MATH-2060,2016
+MATH,2060,23,Calculus of Several Variables,0.36,0.11,0.31,0.06,0.08,0.0,0.0,0.08,yuyuan ouyang,,MATH-2060,2016
+MATH,2060,24,Calculus of Several Variables,0.19,0.26,0.26,0.09,0.15,0.0,0.0,0.06,jonathon leverenz,,MATH-2060,2016
+MATH,2060,100,Calc of Several Vars (HON),0.52,0.28,0.14,0.0,0.03,0.0,0.0,0.03,james brown,True,MATH-2060,2016
+MATH,2070,1,Business Calculus II,0.31,0.19,0.19,0.06,0.19,0.0,0.0,0.06,yinggu bao,,MATH-2070,2016
+MATH,2070,2,Business Calculus II,0.11,0.28,0.44,0.06,0.11,0.0,0.0,0.0,liu zhu,,MATH-2070,2016
+MATH,2070,3,Business Calculus II,0.11,0.39,0.11,0.06,0.11,0.0,0.0,0.22,yinggu bao,,MATH-2070,2016
+MATH,2070,4,Business Calculus II,0.18,0.29,0.18,0.24,0.0,0.0,0.0,0.12,liu zhu,,MATH-2070,2016
+MATH,2070,5,Business Calculus II,0.26,0.26,0.31,0.02,0.05,0.0,0.0,0.1,jennifer mari hanna,,MATH-2070,2016
+MATH,2070,6,Business Calculus II,0.05,0.26,0.21,0.21,0.11,0.0,0.0,0.16,daniel kuzbary,,MATH-2070,2016
+MATH,2070,7,Business Calculus II,0.29,0.12,0.24,0.24,0.0,0.0,0.0,0.12,thanh thien to,,MATH-2070,2016
+MATH,2070,8,Business Calculus II,0.36,0.19,0.33,0.05,0.02,0.0,0.0,0.05,jennifer mari hanna,,MATH-2070,2016
+MATH,2070,9,Business Calculus II,0.26,0.37,0.11,0.11,0.05,0.0,0.0,0.11,travis baumbaugh,,MATH-2070,2016
+MATH,2070,10,Business Calculus II,0.21,0.42,0.26,0.0,0.11,0.0,0.0,0.0,tiantian yang,,MATH-2070,2016
+MATH,2070,11,Business Calculus II,0.31,0.31,0.31,0.02,0.0,0.0,0.0,0.05,jennifer mari hanna,,MATH-2070,2016
+MATH,2070,12,Business Calculus II,0.33,0.26,0.19,0.02,0.07,0.0,0.0,0.12,judith irene mcknew,,MATH-2070,2016
+MATH,2070,13,Business Calculus II,0.11,0.44,0.33,0.06,0.0,0.0,0.0,0.06,haodong li,,MATH-2070,2016
+MATH,2070,15,Business Calculus II,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,thanh thien to,,MATH-2070,2016
+MATH,2070,16,Business Calculus II,0.07,0.27,0.27,0.33,0.0,0.0,0.0,0.07,tiantian yang,,MATH-2070,2016
+MATH,2070,17,Business Calculus II,0.33,0.17,0.44,0.06,0.0,0.0,0.0,0.0,daniel kuzbary,,MATH-2070,2016
+MATH,2070,18,Business Calculus II,0.16,0.47,0.11,0.05,0.05,0.0,0.0,0.16,travis baumbaugh,,MATH-2070,2016
+MATH,2070,19,Business Calculus II,0.17,0.28,0.22,0.17,0.11,0.0,0.0,0.06,yibo xu,,MATH-2070,2016
+MATH,2070,20,Business Calculus II,0.06,0.19,0.5,0.13,0.0,0.0,0.0,0.13,haodong li,,MATH-2070,2016
+MATH,2070,21,Business Calculus II,0.35,0.24,0.29,0.12,0.0,0.0,0.0,0.0,yibo xu,,MATH-2070,2016
+MATH,2080,1,Intro to Ordin Diff Equations,0.08,0.32,0.21,0.03,0.11,0.0,0.0,0.26,oleg yordanov,,MATH-2080,2016
+MATH,2080,2,Intro to Ordin Diff Equations,0.19,0.3,0.21,0.06,0.15,0.0,0.0,0.09,timothy ch teitloff,,MATH-2080,2016
+MATH,2080,3,Intro to Ordin Diff Equations,0.48,0.15,0.21,0.06,0.06,0.0,0.0,0.03,oleg yordanov,,MATH-2080,2016
+MATH,2080,4,Intro to Ordin Diff Equations,0.33,0.26,0.23,0.03,0.05,0.0,0.0,0.1,mishko mitkovski,,MATH-2080,2016
+MATH,2080,5,Intro to Ordin Diff Equations,0.34,0.2,0.23,0.03,0.14,0.0,0.0,0.06,mishko mitkovski,,MATH-2080,2016
+MATH,2080,6,Intro to Ordin Diff Equations,0.25,0.39,0.08,0.06,0.11,0.0,0.0,0.11,timothy ch teitloff,,MATH-2080,2016
+MATH,2080,7,Intro to Ordin Diff Equations,0.14,0.29,0.23,0.11,0.17,0.0,0.0,0.06,timothy ch teitloff,,MATH-2080,2016
+MATH,2160,1,Geometry for Elem Sch Teachers,0.59,0.33,0.07,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-2160,2016
+MATH,2160,2,Geometry for Elem Sch Teachers,0.76,0.21,0.0,0.03,0.0,0.0,0.0,0.0,allison stoddard,,MATH-2160,2016
+MATH,2500,1,Intro to Mathematical Sciences,0.86,0.13,0.01,0.0,0.0,0.0,0.0,0.0,christopher cox,,MATH-2500,2016
+MATH,3020,1,Stat for Science & Engineering,0.16,0.62,0.14,0.0,0.05,0.0,0.0,0.03,taufiquar rahm khan,,MATH-3020,2016
+MATH,3020,2,Stat for Science & Engineering,0.74,0.24,0.03,0.0,0.0,0.0,0.0,0.0,xin liu,,MATH-3020,2016
+MATH,3020,3,Stat for Science & Engineering,0.53,0.21,0.0,0.05,0.11,0.0,0.0,0.11,yisu jia,,MATH-3020,2016
+MATH,3020,4,Stat for Science & Engineering,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,yisu jia,,MATH-3020,2016
+MATH,3020,5,Stat for Science & Engineering,0.36,0.36,0.11,0.03,0.11,0.0,0.0,0.03,brandon gra goodell,,MATH-3020,2016
+MATH,3020,6,Stat for Science & Engineering,0.36,0.5,0.06,0.0,0.03,0.0,0.0,0.06,calvin williams,,MATH-3020,2016
+MATH,3020,7,Stat for Science & Engineering,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.06,xiaoqian sun,,MATH-3020,2016
+MATH,3020,8,Stat for Science & Engineering,0.42,0.47,0.05,0.0,0.03,0.0,0.0,0.03,xiaoqian sun,,MATH-3020,2016
+MATH,3020,9,Stat for Science & Engineering,0.42,0.32,0.16,0.0,0.0,0.0,0.0,0.11,drew jared lipman,,MATH-3020,2016
+MATH,3020,10,Stat for Science & Engineering,0.26,0.37,0.26,0.0,0.05,0.0,0.0,0.05,christopher wilson,,MATH-3020,2016
+MATH,3020,11,Stat for Science & Engineering,0.32,0.37,0.16,0.05,0.05,0.0,0.0,0.05,yanbo xia,,MATH-3020,2016
+MATH,3020,12,Stat for Science & Engineering,0.29,0.29,0.35,0.0,0.0,0.0,0.0,0.06,yanbo xia,,MATH-3020,2016
+MATH,3110,1,Linear Algebra,0.11,0.4,0.26,0.03,0.06,0.0,0.0,0.14,hui xue,,MATH-3110,2016
+MATH,3110,2,Linear Algebra,0.12,0.35,0.18,0.15,0.03,0.0,0.0,0.18,felice manganiello,,MATH-3110,2016
+MATH,3110,3,Linear Algebra,0.34,0.09,0.2,0.2,0.06,0.0,0.0,0.11,felice manganiello,,MATH-3110,2016
+MATH,3110,4,Linear Algebra,0.21,0.49,0.13,0.08,0.08,0.0,0.0,0.03,hui xue,,MATH-3110,2016
+MATH,3110,5,Linear Algebra,0.29,0.31,0.23,0.06,0.09,0.0,0.0,0.03,wayne goddard,,MATH-3110,2016
+MATH,3110,6,Linear Algebra,0.23,0.37,0.34,0.03,0.0,0.0,0.0,0.03,boshi yang,,MATH-3110,2016
+MATH,3110,100,Linear Algebra (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,neil calkin,True,MATH-3110,2016
+MATH,3110,200,Linear Algebra,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.06,neil calkin,,MATH-3110,2016
+MATH,3160,1,Prob Solving for Math Teachers,0.88,0.09,0.0,0.0,0.0,0.0,0.0,0.02,andrew mic tyminski,,MATH-3160,2016
+MATH,3190,1,Introduction to Proof,0.17,0.43,0.17,0.13,0.09,0.0,0.0,0.0,elena sta dimitrova,,MATH-3190,2016
+MATH,3190,2,Introduction to Proof,0.52,0.24,0.12,0.0,0.08,0.0,0.0,0.04,elena sta dimitrova,,MATH-3190,2016
+MATH,3600,1,Intermediate Math Computing,0.83,0.06,0.0,0.03,0.03,0.0,0.0,0.06,mark cawood,,MATH-3600,2016
+MATH,3600,2,Intermediate Math Computing,0.63,0.16,0.0,0.05,0.05,0.0,0.0,0.11,mark cawood,,MATH-3600,2016
+MATH,3650,1,Numerical Mthds for Engineers,0.45,0.4,0.11,0.01,0.02,0.0,0.0,0.01,leo rebholz,,MATH-3650,2016
+MATH,3650,2,Numerical Mthds for Engineers,0.62,0.32,0.06,0.0,0.0,0.0,0.0,0.0,timo johann heister,,MATH-3650,2016
+MATH,4000,1,Theory of Probability,0.5,0.26,0.18,0.0,0.06,0.0,0.0,0.0,peter kiessler,,MATH-4000,2016
+MATH,4000,2,Theory of Probability,0.41,0.36,0.18,0.0,0.05,0.0,0.0,0.0,ling ma,,MATH-4000,2016
+MATH,4020,1,Stat for Sci & Engineering II,0.6,0.13,0.07,0.07,0.0,0.0,0.0,0.13,colin gallagher,,MATH-4020,2016
+MATH,4080,1,Secondary Math Analysis,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,eliza dar gallagher,,MATH-4080,2016
+MATH,4120,1,Algebra I,0.37,0.19,0.26,0.04,0.07,0.0,0.0,0.07,kevin james,,MATH-4120,2016
+MATH,4190,1,Discrete Math Structures I,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,beth novick,,MATH-4190,2016
+MATH,4190,2,Discrete Math Structures I,0.33,0.39,0.06,0.06,0.06,0.0,0.0,0.11,sea sather-wagstaff,,MATH-4190,2016
+MATH,4310,1,Theory of Interest,0.5,0.2,0.2,0.1,0.0,0.0,0.0,0.0, erwin walker,,MATH-4310,2016
+MATH,4340,1,Adv Engineering Mathematics,0.11,0.14,0.36,0.14,0.08,0.0,0.0,0.17,eleanor jenkins,,MATH-4340,2016
+MATH,4340,2,Adv Engineering Mathematics,0.16,0.16,0.26,0.13,0.16,0.0,0.0,0.13,vincent ervin,,MATH-4340,2016
+MATH,4350,1,Complex Variables,0.4,0.2,0.1,0.2,0.1,0.0,0.0,0.0,jeong rock yoon,,MATH-4350,2016
+MATH,4400,1,Linear Programming,0.22,0.26,0.22,0.07,0.11,0.0,0.0,0.11,boshi yang,,MATH-4400,2016
+MATH,4410,1,Intro to Stochastic Models,0.27,0.36,0.27,0.0,0.0,0.0,0.0,0.09,brian fralix,,MATH-4410,2016
+MATH,4500,1,Intro to Mathematical Models,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,matthew macauley,,MATH-4500,2016
+MATH,4530,1,Advanced Calculus I,0.25,0.29,0.29,0.04,0.08,0.0,0.0,0.04,james peterson,,MATH-4530,2016
+MATH,4530,2,Advanced Calculus I,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james peterson,,MATH-4530,2016
+MATH,4540,1,Advanced Calculus II,0.3,0.2,0.2,0.25,0.0,0.0,0.0,0.05,shitao liu,,MATH-4540,2016
+MATH,6340,1,Adv Engineering Mathematics,0.41,0.33,0.22,0.0,0.04,0.0,0.0,0.0,vincent ervin,,MATH-6340,2016
+MATH,8000,1,Probability,0.5,0.35,0.05,0.0,0.1,0.0,0.0,0.0,peter kiessler,,MATH-8000,2016
+MATH,8010,1,General Linear Hypothesis I,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,derek brown,,MATH-8010,2016
+MATH,8050,1,Data Analysis,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,derek brown,,MATH-8050,2016
+MATH,8090,1,Time Series Analysis,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-8090,2016
+MATH,8100,1,Mathematical Programming,0.48,0.36,0.04,0.0,0.08,0.0,0.0,0.04,warren adams,,MATH-8100,2016
+MATH,8120,1,Discrete Optimization,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,,MATH-8120,2016
+MATH,8140,1,Network Flow Programming,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,matthew saltzman,,MATH-8140,2016
+MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,,MATH-8170,2016
+MATH,8210,1,Linear Analysis,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,shitao liu,,MATH-8210,2016
+MATH,8410,1,Applied Mathematics I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,james brannan,,MATH-8410,2016
+MATH,8510,1,Abstract Algebra I,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,sea sather-wagstaff,,MATH-8510,2016
+MATH,8530,1,Matrix Analysis,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,matthew macauley,,MATH-8530,2016
+MATH,8550,1,Combinatorial Analysis,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,,MATH-8550,2016
+MATH,8600,1,Intro to Scientific Computing,0.33,0.33,0.2,0.0,0.07,0.0,0.0,0.07,fei xue,,MATH-8600,2016
+MATH,8650,1,Data Structures,0.64,0.23,0.14,0.0,0.0,0.0,0.0,0.0,timo johann heister,,MATH-8650,2016
+MATH,9500,1,Commutative Algebra,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james ba coykendall,,MATH-9500,2016
+MBA,8030,1,Stat Analy of Bus Op,0.16,0.44,0.21,0.0,0.0,0.0,0.0,0.19,magda gabriela sava,,MBA-8030,2016
+MBA,8060,1,Operations Mgt,0.23,0.6,0.18,0.0,0.0,0.0,0.0,0.0, sridharan,,MBA-8060,2016
+MBA,8070,1,Financial Management,0.39,0.51,0.07,0.0,0.02,0.0,0.0,0.0,george bra lockhart,,MBA-8070,2016
+MBA,8090,1,Org Beh & Hum Res Mg,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2016
+MBA,8090,2,Org Beh & Hum Res Mg,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2016
+MBA,8180,20,Intro Business Intell & Anlytc,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,heshan sun,,MBA-8180,2016
+MBA,8190,1,Intro to Acc and Fin,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,melvin stith,,MBA-8190,2016
+MBA,8190,2,Intro to Acc and Fin,0.54,0.34,0.07,0.0,0.02,0.0,0.0,0.02,thomas springer,,MBA-8190,2016
+MBA,8290,1,Marketing Foundation,0.51,0.43,0.0,0.0,0.0,0.0,0.0,0.05,gary hunter,,MBA-8290,2016
+MBA,8310,5,Communications and Sales,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,gregory pickett,,MBA-8310,2016
+MBA,8330,1,Real Estate Investmt,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,,MBA-8330,2016
+MBA,8360,1,Real Estate Principles,0.35,0.52,0.09,0.0,0.0,0.0,0.0,0.04,jeffrey randolph,,MBA-8360,2016
+MBA,8370,1,Legal Environ of Bus,0.47,0.49,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2016
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,,MBA-8400,2016
+MBA,8410,1,Real Estate Finance,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,wesley mcf blanding,,MBA-8410,2016
+MBA,8430,1,Entrepreneurial Accounting,0.14,0.68,0.18,0.0,0.0,0.0,0.0,0.0,sally kathr widener,,MBA-8430,2016
+MBA,8450,1,Technology & Innovation Mgt,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8450,2016
+MBA,8480,1,Entrpr Mkting & Digital Strat,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,,MBA-8480,2016
+MBA,8480,5,Entrpr Mkting & Digital Strat,0.81,0.15,0.0,0.0,0.04,0.0,0.0,0.0,bruce snyder,,MBA-8480,2016
+MBA,8490,5,Entrepreneurial Strategy,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,matthew charl klein,,MBA-8490,2016
+MBA,8510,1,Bus Operations & Logistics,0.23,0.59,0.18,0.0,0.0,0.0,0.0,0.0, sridharan,,MBA-8510,2016
+MBA,8540,1,Mgrl Accounting,0.44,0.44,0.07,0.0,0.0,0.0,0.0,0.05,james mil kohlmeyer,,MBA-8540,2016
+MBA,8590,1,Mgr Decision Model,0.4,0.33,0.17,0.0,0.0,0.0,0.0,0.1,sara elizabet yoder,,MBA-8590,2016
+MBA,8590,2,Mgr Decision Model,0.4,0.31,0.07,0.0,0.07,0.0,0.0,0.16,mark mcknew,,MBA-8590,2016
+MBA,8600,1,Advanced Marketing Strategy,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2016
+MBA,8600,2,Advanced Marketing Strategy,0.35,0.5,0.15,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2016
+MBA,8610,1,Information Systems,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MBA-8610,2016
+MBA,8620,1,Managerial Economics,0.3,0.52,0.12,0.0,0.0,0.0,0.0,0.06,scott templeton,,MBA-8620,2016
+MBA,8620,2,Managerial Economics,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,,MBA-8620,2016
+MBA,8620,3,Managerial Economics,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,,MBA-8620,2016
+MBA,8650,1,Taxation of Business Decisions,0.25,0.63,0.04,0.0,0.04,0.0,0.0,0.04,judson jahn,,MBA-8650,2016
+MBA,8700,1,Strategic Management,0.46,0.49,0.03,0.0,0.0,0.0,0.0,0.03,james turner,,MBA-8700,2016
+MBA,8990,2,Creativity,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,,MBA-8990,2016
+MBA,8990,11,Social Media and Marketing,0.72,0.19,0.06,0.0,0.03,0.0,0.0,0.0,lura forcum,,MBA-8990,2016
+ME,2000,1,Sophomore Seminar,0.93,0.05,0.0,0.0,0.01,0.0,0.0,0.01,donald beasley,,ME-2000,2016
+ME,2010,1,Statics & Dynamics,0.07,0.25,0.26,0.06,0.2,0.0,0.0,0.16,marisa kikendal orr,,ME-2010,2016
+ME,2010,2,Statics & Dynamics,0.09,0.18,0.25,0.07,0.29,0.0,0.0,0.12,jorge iva rodriguez,,ME-2010,2016
+ME,2010,3,Statics & Dynamics,0.04,0.13,0.3,0.14,0.28,0.0,0.0,0.1,paul joseph,,ME-2010,2016
+ME,2030,1,Founda Th/Fl Syst,0.08,0.1,0.46,0.21,0.1,0.0,0.0,0.04,john saylor,,ME-2030,2016
+ME,2030,2,Founda Th/Fl Syst,0.2,0.16,0.38,0.22,0.04,0.0,0.0,0.0,jay ochterbeck,,ME-2030,2016
+ME,2040,1,Mechanics of Materials,0.11,0.49,0.3,0.06,0.03,0.0,0.0,0.0,garrett pataky,,ME-2040,2016
+ME,2040,3,Mechanics of Materials,0.29,0.5,0.19,0.0,0.0,0.0,0.0,0.02,gang li,,ME-2040,2016
+ME,2220,1,Mechanical Engineering Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-2220,2016
+ME,2220,2,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,3,Mechanical Engineering Lab I,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,4,Mechanical Engineering Lab I,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,5,Mechanical Engineering Lab I,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,6,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,7,Mechanical Engineering Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,8,Mechanical Engineering Lab I,0.33,0.27,0.4,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,3030,1,Thermodynamics,0.3,0.43,0.21,0.04,0.0,0.0,0.0,0.02,daniel fant,,ME-3030,2016
+ME,3030,2,Thermodynamics,0.46,0.33,0.19,0.01,0.01,0.0,0.0,0.0,daniel fant,,ME-3030,2016
+ME,3030,3,Thermodynamics,0.18,0.61,0.18,0.0,0.0,0.0,0.0,0.03,yiqiang han,,ME-3030,2016
+ME,3040,1,Heat Transfer,0.15,0.45,0.3,0.03,0.03,0.0,0.0,0.05,jean-marc delhaye,,ME-3040,2016
+ME,3040,2,Heat Transfer,0.19,0.33,0.34,0.07,0.07,0.0,0.0,0.0,xin zhao,,ME-3040,2016
+ME,3050,1,Model/an Dy Syst,0.23,0.42,0.25,0.02,0.05,0.0,0.0,0.03,joshua bostwick,,ME-3050,2016
+ME,3050,2,Model/an Dy Syst,0.16,0.4,0.35,0.05,0.0,0.0,0.0,0.05,ardalan vahidi,,ME-3050,2016
+ME,3060,1,Fund Machine Design,0.58,0.29,0.1,0.0,0.02,0.0,0.0,0.02,oliver myers,,ME-3060,2016
+ME,3060,2,Fund Machine Design,0.23,0.58,0.13,0.0,0.04,0.0,0.0,0.02,paul jeffrey meyer,,ME-3060,2016
+ME,3070,1,Found of Mechanical Systems,0.26,0.46,0.16,0.05,0.01,0.0,0.0,0.05,lonny thompson,,ME-3070,2016
+ME,3070,2,Found of Mechanical Systems,0.15,0.46,0.26,0.05,0.08,0.0,0.0,0.0,georges fadel,,ME-3070,2016
+ME,3080,1,Fluid Mechanics,0.22,0.4,0.32,0.04,0.02,0.0,0.0,0.0,xiangchun xuan,,ME-3080,2016
+ME,3080,2,Fluid Mechanics,0.15,0.68,0.15,0.0,0.0,0.0,0.0,0.02,yiqiang han,,ME-3080,2016
+ME,3080,3,Fluid Mechanics,0.13,0.25,0.5,0.03,0.08,0.0,0.0,0.0,ethan kung,,ME-3080,2016
+ME,3120,2,Manuf Processes,0.69,0.25,0.05,0.0,0.0,0.0,0.0,0.01,rod martinez-duarte,,ME-3120,2016
+ME,3330,1,Mechanical Engineering Lab II,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,2,Mechanical Engineering Lab II,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,3,Mechanical Engineering Lab II,0.12,0.71,0.06,0.0,0.0,0.0,0.0,0.12,todd schweisinger,,ME-3330,2016
+ME,3330,4,Mechanical Engineering Lab II,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,,ME-3330,2016
+ME,3330,5,Mechanical Engineering Lab II,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,6,Mechanical Engineering Lab II,0.14,0.71,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,,ME-3330,2016
+ME,3330,7,Mechanical Engineering Lab II,0.44,0.31,0.25,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,8,Mechanical Engineering Lab II,0.3,0.3,0.2,0.0,0.0,0.0,0.0,0.2,todd schweisinger,,ME-3330,2016
+ME,4000,1,Senior Seminar,0.83,0.14,0.01,0.01,0.0,0.0,0.0,0.0,donald beasley,,ME-4000,2016
+ME,4010,1,Mech Engr Design,0.15,0.63,0.18,0.01,0.03,0.0,0.0,0.0,joshua summers,,ME-4010,2016
+ME,4010,2,Mech Engr Design,0.2,0.69,0.05,0.0,0.07,0.0,0.0,0.0,cameron turner,,ME-4010,2016
+ME,4020,1,Intern in Engr Des,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,,ME-4020,2016
+ME,4020,2,Intern in Engr Des,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,,ME-4020,2016
+ME,4020,3,Intern in Engr Des,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-4020,2016
+ME,4020,4,Intern in Engr Des,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4020,2016
+ME,4030,1,Control Dynamic Systems,0.17,0.38,0.4,0.03,0.0,0.0,0.0,0.02,yue wang,,ME-4030,2016
+ME,4030,2,Control Dynamic Systems,0.23,0.41,0.22,0.07,0.01,0.0,0.0,0.05,suyi li,,ME-4030,2016
+ME,4200,1,Ener Sources/Utiliz,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,donald beasley,,ME-4200,2016
+ME,4210,1,Intro to Comp Flow,0.21,0.5,0.14,0.0,0.07,0.0,0.0,0.07,chenning tong,,ME-4210,2016
+ME,4320,1,Adv Strength of Matl,0.1,0.39,0.45,0.0,0.03,0.0,0.0,0.03,huijuan zhao,,ME-4320,2016
+ME,4400,1,Matls for Aggr Envir,0.88,0.11,0.02,0.0,0.0,0.0,0.0,0.0,ramasw subrahmanian,,ME-4400,2016
+ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,3,Mechanical Engineering Lab III,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,4,Mechanical Engineering Lab III,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,5,Mechanical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,6,Mechanical Engineering Lab III,0.14,0.86,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,7,Mechanical Engineering Lab III,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,8,Mechanical Engineering Lab III,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4540,1,Design of Machine Elements,0.6,0.35,0.03,0.0,0.0,0.0,0.0,0.03,paul jeffrey meyer,,ME-4540,2016
+ME,4930,7,Sel.Topics ME - Energy Harvest,0.25,0.4,0.15,0.1,0.0,0.0,0.0,0.1,mohammed fari daqaq,,ME-4930,2016
+ME,6210,1,Intro to Comp Flow,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,chenning tong,,ME-6210,2016
+ME,6320,1,Adv Strength of Matl,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,huijuan zhao,,ME-6320,2016
+ME,6930,13,SelTopics ME-MechSolids&Fluids,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,,ME-6930,2016
+ME,8010,1,Found of Fluid Mech,0.38,0.5,0.06,0.0,0.0,0.0,0.0,0.06,richard figliola,,ME-8010,2016
+ME,8010,401,Found of Fluid Mech,0.31,0.54,0.0,0.0,0.0,0.0,0.0,0.15,richard figliola,,ME-8010,2016
+ME,8100,1,Macroscopic Thermo,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,jay ochterbeck,,ME-8100,2016
+ME,8180,1,Intro to Fin Ele Ana,0.27,0.63,0.08,0.0,0.0,0.0,0.0,0.02,gang li,,ME-8180,2016
+ME,8230,1,Control Systems,0.37,0.42,0.16,0.0,0.05,0.0,0.0,0.0,yue wang,,ME-8230,2016
+ME,8300,1,Cond/Rad Heat Tfr,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,,ME-8300,2016
+ME,8460,1,Inter Dynamics,0.4,0.15,0.35,0.0,0.05,0.0,0.0,0.05,phanin tallapragada,,ME-8460,2016
+ME,8700,1,Adv Design Methods,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-8700,2016
+ME,8710,1,Engr Optimization,0.61,0.33,0.03,0.0,0.03,0.0,0.0,0.0,georges fadel,,ME-8710,2016
+ME,8930,4,SelectedTopics in ME - Adv Mfg,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-8930,2016
+ME,8930,27,Sel Topics in ME - Optimize,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,,ME-8930,2016
+MGT,2010,1,Principles of Management,0.39,0.35,0.24,0.02,0.0,0.0,0.0,0.0,katherine clark,,MGT-2010,2016
+MGT,2010,2,Principles of Management,0.31,0.47,0.18,0.02,0.01,0.0,0.0,0.0,katherine clark,,MGT-2010,2016
+MGT,2010,3,Principles of Management,0.43,0.4,0.11,0.02,0.02,0.0,0.0,0.01,katherine clark,,MGT-2010,2016
+MGT,2010,4,Principles of Management,0.2,0.44,0.27,0.05,0.02,0.0,0.0,0.02,katherine clark,,MGT-2010,2016
+MGT,2010,5,Principles of Management,0.25,0.37,0.32,0.02,0.01,0.0,0.0,0.02,tina robbins,,MGT-2010,2016
+MGT,2010,6,Principles of Management,0.45,0.39,0.11,0.01,0.01,0.0,0.0,0.02,tina robbins,,MGT-2010,2016
+MGT,2010,7,Principles of Management,0.57,0.3,0.11,0.0,0.01,0.0,0.0,0.01,tina robbins,,MGT-2010,2016
+MGT,2010,8,Principles of Management,0.51,0.37,0.07,0.02,0.0,0.0,0.0,0.02,tina robbins,,MGT-2010,2016
+MGT,2010,9,Principles of Mgt(HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True,MGT-2010,2016
+MGT,2010,10,Principles of Management,0.26,0.32,0.3,0.06,0.04,0.0,0.0,0.02,ashley will parnell,,MGT-2010,2016
+MGT,2010,11,Principles of Management,0.22,0.33,0.33,0.03,0.03,0.0,0.0,0.06,ashley will parnell,,MGT-2010,2016
+MGT,2180,1,Management PC Applications,0.83,0.09,0.02,0.02,0.03,0.0,0.0,0.02,ryan toole,,MGT-2180,2016
+MGT,2180,2,Management PC Applications,0.8,0.12,0.02,0.01,0.02,0.0,0.0,0.03,ryan toole,,MGT-2180,2016
+MGT,2180,3,Management PC Applications,0.77,0.13,0.01,0.05,0.0,0.0,0.0,0.03,ryan toole,,MGT-2180,2016
+MGT,2180,4,Management PC Applications,0.76,0.11,0.05,0.01,0.01,0.0,0.0,0.05,ryan toole,,MGT-2180,2016
+MGT,3070,1,Human Resource Management,0.23,0.46,0.26,0.03,0.0,0.0,0.0,0.03,priscilla harrison,,MGT-3070,2016
+MGT,3070,3,Human Resource Management,0.27,0.38,0.19,0.08,0.0,0.0,0.0,0.08,kristin dam scott,,MGT-3070,2016
+MGT,3070,4,Human Resource Management,0.4,0.45,0.08,0.05,0.0,0.0,0.0,0.03,michael cole,,MGT-3070,2016
+MGT,3070,5,Human Resource Management,0.58,0.4,0.03,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2016
+MGT,3070,6,Human Resource Management,0.4,0.53,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2016
+MGT,3100,1,Intermed Business Statistics,0.07,0.25,0.11,0.18,0.25,0.0,0.0,0.14,sara elizabet yoder,,MGT-3100,2016
+MGT,3100,2,Intermed Business Statistics,0.11,0.19,0.19,0.14,0.22,0.0,0.0,0.16,sara elizabet yoder,,MGT-3100,2016
+MGT,3100,3,Intermed Business Statistics,0.1,0.26,0.31,0.1,0.1,0.0,0.0,0.13,sara elizabet yoder,,MGT-3100,2016
+MGT,3100,5,Intermed Business Statistics,0.79,0.12,0.06,0.0,0.0,0.0,0.0,0.03,thomas simpson,,MGT-3100,2016
+MGT,3100,6,Intermed Business Statistics,0.3,0.33,0.25,0.03,0.05,0.0,0.0,0.05,janis miller,,MGT-3100,2016
+MGT,3100,7,Intermed Business Statistics,0.11,0.37,0.21,0.08,0.11,0.0,0.0,0.13,magda gabriela sava,,MGT-3100,2016
+MGT,3100,8,Intermed Business Statistics,0.45,0.24,0.12,0.05,0.07,0.0,0.0,0.07,min kyung lee,,MGT-3100,2016
+MGT,3100,9,Intermed Business Statistics,0.5,0.25,0.18,0.03,0.03,0.0,0.0,0.03,shih lun tseng,,MGT-3100,2016
+MGT,3100,10,Intermed Business Statistics,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,jackie patri london,,MGT-3100,2016
+MGT,3100,13,Intermed Business Statistics,0.13,0.3,0.3,0.07,0.03,0.0,0.0,0.17,daniel nielubowicz,,MGT-3100,2016
+MGT,3100,14,Intermed Business Statistics,0.32,0.39,0.08,0.11,0.0,0.0,0.0,0.11,iaroslava dutchak,,MGT-3100,2016
+MGT,3120,1,Decision Models for Management,0.28,0.17,0.24,0.07,0.15,0.0,0.0,0.09,mark mcknew,,MGT-3120,2016
+MGT,3120,2,Decision Models for Management,0.3,0.33,0.28,0.0,0.02,0.0,0.0,0.07,mark mcknew,,MGT-3120,2016
+MGT,3120,3,Decision Models for Management,0.27,0.34,0.3,0.02,0.05,0.0,0.0,0.02,mark mcknew,,MGT-3120,2016
+MGT,3150,1,New Venture Creation,0.49,0.41,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth er powell,,MGT-3150,2016
+MGT,3180,1,Mgt of Info Systems,0.25,0.43,0.28,0.0,0.0,0.0,0.0,0.05,russell purvis,,MGT-3180,2016
+MGT,3180,2,Mgt of Info Systems,0.14,0.45,0.38,0.0,0.0,0.0,0.0,0.02,roopa raman,,MGT-3180,2016
+MGT,3180,3,Mgt of Info Systems,0.41,0.46,0.1,0.0,0.03,0.0,0.0,0.0,daniel aaron pienta,,MGT-3180,2016
+MGT,3180,4,Mgt of Info Systems,0.59,0.3,0.04,0.04,0.0,0.0,0.0,0.02,tina marie esposito,,MGT-3180,2016
+MGT,3180,5,Mgt of Info Systems,0.37,0.47,0.05,0.0,0.11,0.0,0.0,0.0,heshan sun,,MGT-3180,2016
+MGT,3500,1,Intro to Business Analytics,0.3,0.52,0.11,0.04,0.0,0.0,0.0,0.04,siyuan li,,MGT-3500,2016
+MGT,3900,1,Ops Mgt,0.38,0.33,0.2,0.03,0.03,0.0,0.0,0.05,yann ferrand,,MGT-3900,2016
+MGT,3900,2,Ops Mgt,0.11,0.44,0.33,0.06,0.0,0.0,0.0,0.06,zachary mo leffakis,,MGT-3900,2016
+MGT,3900,3,Ops Mgt,0.08,0.36,0.31,0.08,0.15,0.0,0.0,0.03,berna quiroga gomez,,MGT-3900,2016
+MGT,3900,4,Ops Mgt,0.26,0.15,0.36,0.13,0.08,0.0,0.0,0.03,berna quiroga gomez,,MGT-3900,2016
+MGT,3900,5,Ops Mgt,0.45,0.32,0.21,0.0,0.0,0.0,0.0,0.03,remi charpin,,MGT-3900,2016
+MGT,4000,1,Mgt of Organizational Behavior,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2016
+MGT,4000,2,Mgt of Organizational Behavior,0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2016
+MGT,4000,3,Mgt of Organizational Behavior,0.28,0.53,0.2,0.0,0.0,0.0,0.0,0.0,philip roth,,MGT-4000,2016
+MGT,4020,1,Ops Pln and Ctl,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4020,2016
+MGT,4080,1,Lean Operations,0.18,0.39,0.34,0.03,0.03,0.0,0.0,0.03,zachary mo leffakis,,MGT-4080,2016
+MGT,4110,1,Project Management,0.22,0.63,0.12,0.0,0.0,0.0,0.0,0.02,russell purvis,,MGT-4110,2016
+MGT,4150,1,Business Strategy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,dennis lee lester,,MGT-4150,2016
+MGT,4150,2,Business Strategy,0.34,0.64,0.02,0.0,0.0,0.0,0.0,0.0,dane patric blevins,,MGT-4150,2016
+MGT,4150,3,Business Strategy,0.51,0.43,0.06,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2016
+MGT,4150,4,Business Strategy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2016
+MGT,4150,6,Business Strategy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,dane patric blevins,,MGT-4150,2016
+MGT,4150,7,Business Strategy,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2016
+MGT,4150,8,Business Strategy,0.21,0.59,0.21,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2016
+MGT,4150,9,Business Strategy,0.31,0.58,0.09,0.02,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2016
+MGT,4160,1,Special Topics Hr,0.19,0.62,0.08,0.04,0.04,0.0,0.0,0.04,kristin dam scott,,MGT-4160,2016
+MGT,4230,1,Intern Bus Mgt,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4230,2016
+MGT,4230,2,Intern Bus Mgt,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4230,2016
+MGT,4230,3,Intern Bus Mgt,0.23,0.4,0.15,0.18,0.05,0.0,0.0,0.0,janis miller,,MGT-4230,2016
+MGT,4230,4,Intern Bus Mgt,0.25,0.63,0.1,0.0,0.03,0.0,0.0,0.0,janis miller,,MGT-4230,2016
+MGT,4240,1,Global Supply Chain,0.19,0.48,0.29,0.03,0.0,0.0,0.0,0.0,yann ferrand,,MGT-4240,2016
+MGT,4270,1,Managing Improvement,0.16,0.53,0.31,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MGT-4270,2016
+MGT,4300,3,Applied Entrepreneurship,0.55,0.3,0.1,0.0,0.0,0.0,0.0,0.05,chad navis,,MGT-4300,2016
+MGT,4300,4,Organizational Leadership,0.58,0.26,0.0,0.05,0.05,0.0,0.0,0.05,amy elizabet ingram,,MGT-4300,2016
+MGT,4310,1,Emp Rights & Resp,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-4310,2016
+MGT,4350,1,Pers Interviewing,0.38,0.48,0.13,0.0,0.03,0.0,0.0,0.0,philip roth,,MGT-4350,2016
+MGT,4520,1,Business Analysis,0.17,0.44,0.33,0.0,0.0,0.0,0.0,0.06,roopa raman,,MGT-4520,2016
+MGT,4550,1,Emerging I T Trends,0.59,0.26,0.04,0.0,0.07,0.0,0.0,0.04,jason thatcher,,MGT-4550,2016
+MGT,4560,1,Business Info Mgt,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,siyuan li,,MGT-4560,2016
+MGT,8690,1,Project Mgt,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,,MGT-8690,2016
+MGT,9050,1,Research Methods,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,varun grover,,MGT-9050,2016
+MICR,1010,1,Microbes & Hum Aff,0.85,0.11,0.02,0.0,0.0,0.0,0.0,0.02,jessica gale owens,,MICR-1010,2016
+MICR,2050,1,Introductory Micro,0.53,0.35,0.07,0.01,0.0,0.0,0.0,0.04,john abercrombie,,MICR-2050,2016
+MICR,3000,1,Essential Skills in Microbiol,0.82,0.13,0.02,0.0,0.02,0.0,0.0,0.02,tamara lyn mcnealy,,MICR-3000,2016
+MICR,3050,1,General Microbiology,0.44,0.39,0.15,0.01,0.01,0.0,0.0,0.01,krista barr rudolph,,MICR-3050,2016
+MICR,3050,2,General Microbiology,0.41,0.41,0.1,0.05,0.03,0.0,0.0,0.0,krista barr rudolph,,MICR-3050,2016
+MICR,4010,1,Microbial Diversity & Ecology,0.19,0.49,0.18,0.06,0.03,0.0,0.0,0.04,barbara campbell,,MICR-4010,2016
+MICR,4050,1,Adv Microbial Ecol of Humans,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4050,2016
+MICR,4140,1,Basic Immunology,0.52,0.15,0.21,0.0,0.06,0.0,0.0,0.06,yanzhang wei,,MICR-4140,2016
+MICR,4150,1,Microbial Genetics,0.15,0.56,0.21,0.06,0.0,0.0,0.0,0.02,min cao,,MICR-4150,2016
+MICR,4160,1,Intro Virology,0.96,0.01,0.03,0.0,0.0,0.0,0.0,0.0,simon scott,,MICR-4160,2016
+MICR,4510,1,Advanced Microbiology II,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,thomas hughes,,MICR-4510,2016
+MICR,4510,3,Advanced Microbiology II,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,thomas hughes,,MICR-4510,2016
+MKT,3010,1,Prin of Marketing,0.25,0.35,0.31,0.06,0.01,0.0,0.0,0.02,carter wil mcelveen,,MKT-3010,2016
+MKT,3010,2,Prin of Marketing,0.3,0.46,0.19,0.02,0.01,0.0,0.0,0.03,carter wil mcelveen,,MKT-3010,2016
+MKT,3010,3,Prin of Marketing,0.25,0.43,0.25,0.06,0.01,0.0,0.0,0.0,amanda cooper fine,,MKT-3010,2016
+MKT,3010,4,Prin of Marketing,0.25,0.42,0.26,0.05,0.02,0.0,0.0,0.0,amanda cooper fine,,MKT-3010,2016
+MKT,3010,5,Prin of Marketing,0.31,0.39,0.2,0.04,0.02,0.0,0.0,0.03,amanda cooper fine,,MKT-3010,2016
+MKT,3010,6,Prin of Marketing,0.58,0.3,0.08,0.02,0.0,0.0,0.0,0.02,patricia knowles,,MKT-3010,2016
+MKT,3020,1,Consumer Behavior,0.5,0.4,0.06,0.04,0.0,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2016
+MKT,3020,2,Consumer Behavior,0.42,0.4,0.1,0.06,0.02,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2016
+MKT,3020,3,Consumer Behavior,0.32,0.34,0.14,0.1,0.08,0.0,0.0,0.02, thyroff fitzwater,,MKT-3020,2016
+MKT,3020,4,Consumer Behavior,0.28,0.58,0.04,0.02,0.04,0.0,0.0,0.04, thyroff fitzwater,,MKT-3020,2016
+MKT,3020,5,Consumer Behavior,0.4,0.27,0.18,0.11,0.04,0.0,0.0,0.0,oriana rache aragon,,MKT-3020,2016
+MKT,3210,1,Sports Marketing,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2016
+MKT,3210,2,Sports Marketing,0.57,0.41,0.0,0.0,0.0,0.0,0.0,0.02,delancy bennett,,MKT-3210,2016
+MKT,3310,1,Marketing Metrics & Analytics,0.74,0.17,0.07,0.0,0.02,0.0,0.0,0.0,oriana rache aragon,,MKT-3310,2016
+MKT,4200,1,Professional Selling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,,MKT-4200,2016
+MKT,4200,2,Professional Selling,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2016
+MKT,4200,3,Professional Selling,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,jesse moore,,MKT-4200,2016
+MKT,4200,4,Professional Selling,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2016
+MKT,4200,5,Professional Selling,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,ryan mullins,,MKT-4200,2016
+MKT,4230,1,Promotional Strategy,0.42,0.39,0.12,0.02,0.02,0.0,0.0,0.03,patricia knowles,,MKT-4230,2016
+MKT,4240,1,Sales Management,0.5,0.48,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4240,2016
+MKT,4260,1,Business-to-Business,0.38,0.43,0.17,0.02,0.0,0.0,0.0,0.0,james gaubert,,MKT-4260,2016
+MKT,4260,2,Business-to-Business,0.47,0.41,0.07,0.0,0.02,0.0,0.0,0.03,james gaubert,,MKT-4260,2016
+MKT,4270,1,International Mktg,0.37,0.38,0.19,0.03,0.02,0.0,0.0,0.0,roger gomes,,MKT-4270,2016
+MKT,4270,2,International Mktg,0.24,0.42,0.29,0.02,0.0,0.0,0.0,0.02,roger gomes,,MKT-4270,2016
+MKT,4270,3,International Mktg,0.39,0.49,0.05,0.05,0.0,0.0,0.0,0.02,thomas poehlman,,MKT-4270,2016
+MKT,4280,1,Services Marketing,0.4,0.51,0.06,0.0,0.0,0.0,0.0,0.03,james gaubert,,MKT-4280,2016
+MKT,4310,1,Marketing Research,0.17,0.31,0.38,0.1,0.03,0.0,0.0,0.0,peter weathers,,MKT-4310,2016
+MKT,4310,2,Marketing Research,0.29,0.54,0.04,0.11,0.04,0.0,0.0,0.0,peter weathers,,MKT-4310,2016
+MKT,4310,3,Marketing Research,0.33,0.63,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2016
+MKT,4310,4,Marketing Research,0.48,0.44,0.07,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2016
+MKT,4430,1,Advertising Strategy,0.75,0.23,0.0,0.0,0.0,0.0,0.0,0.02,albert neil cameron,,MKT-4430,2016
+MKT,4450,1,Macromarketing,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,william kilbourne,,MKT-4450,2016
+MKT,4450,2,Macromarketing,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,william kilbourne,,MKT-4450,2016
+MKT,4500,1,Strategic Mktg Mgt,0.23,0.55,0.19,0.03,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2016
+MKT,4500,2,Strategic Mktg Mgt,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2016
+MKT,4950,1,Social Media,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-4950,2016
+MKT,8610,1,Marketing Research,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-8610,2016
+MKT,8630,1,Buyer Behavior,0.36,0.61,0.0,0.0,0.0,0.0,0.0,0.04,thomas poehlman,,MKT-8630,2016
+ML,1010,3,Leadership Fund I,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,amanda carol kane,,ML-1010,2016
+ML,2010,1,Leadership Development I,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,shane allen werst,,ML-2010,2016
+ML,2010,2,Leadership Development I,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,shane allen werst,,ML-2010,2016
+ML,3010,1,Advanced Leadership I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william cod cleland,,ML-3010,2016
+ML,3010,2,Advanced Leadership I,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,william cod cleland,,ML-3010,2016
+ML,4010,1,Organizational Leadership I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,,ML-4010,2016
+MSE,2100,1,Intro to Mat Science,0.36,0.23,0.23,0.07,0.08,0.0,0.0,0.04,rakhee pani,,MSE-2100,2016
+MSE,2100,2,Intro to Mat Science,0.12,0.53,0.2,0.07,0.04,0.0,0.0,0.04,eric skaar,,MSE-2100,2016
+MSE,2100,3,Intro to Mat Science,0.23,0.42,0.2,0.05,0.02,0.0,0.0,0.07,eric skaar,,MSE-2100,2016
+MSE,2100,4,Intro to Mat Science,0.31,0.3,0.21,0.12,0.01,0.0,0.0,0.05,bradley mat schultz,,MSE-2100,2016
+MSE,2100,5,Intro to Mat Science,0.54,0.29,0.11,0.07,0.0,0.0,0.0,0.0,olga kuksenok,,MSE-2100,2016
+MSE,3190,1,Materials Proc I,0.32,0.35,0.23,0.03,0.06,0.0,0.0,0.0,olin mefford,,MSE-3190,2016
+MSE,3190,2,Materials Proc I,0.62,0.32,0.04,0.0,0.0,0.0,0.0,0.02,olin mefford,,MSE-3190,2016
+MSE,3260,1,Thermo of Materials,0.31,0.53,0.14,0.0,0.0,0.0,0.0,0.03,gary lickfield,,MSE-3260,2016
+MSE,3260,2,Thermo of Materials,0.21,0.26,0.29,0.15,0.09,0.0,0.0,0.0,gary lickfield,,MSE-3260,2016
+MSE,3270,1,Transport Phenomena,0.52,0.36,0.05,0.02,0.01,0.0,0.0,0.04,fei peng,,MSE-3270,2016
+MSE,3270,2,Transport Phenomena,0.3,0.28,0.3,0.03,0.06,0.0,0.0,0.03,ulf daniel schiller,,MSE-3270,2016
+MSE,4020,1,Solid State Material,0.43,0.26,0.21,0.04,0.04,0.0,0.0,0.02,luiz gust jacobsohn,,MSE-4020,2016
+MSE,4070,1,Senior Capstone Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,,MSE-4070,2016
+MSE,4130,1,Noncrystalline Materials,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,,MSE-4130,2016
+MSE,4150,1,Polymer Sc Engr,0.37,0.28,0.15,0.03,0.03,0.0,0.0,0.13,marek urban,,MSE-4150,2016
+MSE,4150,2,Polymer Sc Engr,0.55,0.27,0.11,0.0,0.04,0.0,0.0,0.04,olin mefford,,MSE-4150,2016
+MSE,4550,2,Polymer Fiber Lab,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,olin mefford,,MSE-4550,2016
+MSE,4550,3,Polymer Fiber Lab,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,olin mefford,,MSE-4550,2016
+MSE,4580,1,Surf Phen in Ms&E,0.09,0.52,0.27,0.12,0.0,0.0,0.0,0.0,konstantin kornev,,MSE-4580,2016
+MSE,4610,1,Polymer & Fiber Materials III,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,kathryn ann stevens,,MSE-4610,2016
+MSE,4910,1,Undergraduate Research,0.65,0.26,0.03,0.0,0.03,0.0,0.0,0.03,marian kennedy,,MSE-4910,2016
+MSE,8010,1,Grad Sem in Materials Research,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,kyle brinkman,,MSE-8010,2016
+MSE,8100,1,Fundamentals of Materials Sci,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,rajendra kum bordia,,MSE-8100,2016
+MSE,8260,1,Phase Equil Mat Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,stephen foulger,,MSE-8260,2016
+MSE,8270,1,Kin of Phase Tran,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,konstantin kornev,,MSE-8270,2016
+MUSC,1510,2,Applied Music,0.5,0.3,0.1,0.0,0.0,0.0,0.0,0.1,jonathan edwa doyel,,MUSC-1510,2016
+MUSC,1520,1,Applied Music,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,,MUSC-1520,2016
+MUSC,2100,1,Music in the Western World,0.78,0.13,0.06,0.0,0.03,0.0,0.0,0.0,eric lapin,,MUSC-2100,2016
+MUSC,2100,2,Music in the Western World,0.53,0.19,0.16,0.03,0.0,0.0,0.0,0.09,lisa sain odom,,MUSC-2100,2016
+MUSC,2100,3,Music in the Western World,0.88,0.06,0.03,0.03,0.0,0.0,0.0,0.0,eric lapin,,MUSC-2100,2016
+MUSC,2100,4,Music in the Western World,0.47,0.16,0.09,0.19,0.06,0.0,0.0,0.03,linda li-bleuel,,MUSC-2100,2016
+MUSC,2100,5,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,,MUSC-2100,2016
+MUSC,2100,6,Music in the Western World,0.72,0.19,0.03,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,,MUSC-2100,2016
+MUSC,2100,7,Music in the Western World,0.41,0.53,0.03,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,,MUSC-2100,2016
+MUSC,2100,8,Music in the Western World,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2016
+MUSC,2100,10,Music in the Western World,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda dzuris,,MUSC-2100,2016
+MUSC,2100,12,Music in the Western World,0.5,0.28,0.13,0.06,0.0,0.0,0.0,0.03,lea kibler,,MUSC-2100,2016
+MUSC,2100,15,Music in West World (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,True,MUSC-2100,2016
+MUSC,3080,1,Surv of Broadway I,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,lisa sain odom,,MUSC-3080,2016
+MUSC,3110,1,History of American Music,0.59,0.25,0.09,0.06,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3110,2016
+MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,eric lapin,,MUSC-3120,2016
+MUSC,3130,1,Hist of Rock & Roll,0.41,0.38,0.09,0.13,0.0,0.0,0.0,0.0,hamilton altstatt,,MUSC-3130,2016
+MUSC,3170,1,Hist of Country Mus,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3170,2016
+MUSC,3610,1,Marching Band,0.97,0.01,0.0,0.0,0.0,0.0,0.0,0.02,mark spede,,MUSC-3610,2016
+MUSC,3620,1,Symphonic Band,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,mark spede,True,MUSC-3620,2016
+MUSC,3690,1,Symphony Orchestra,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,andrew levin,True,MUSC-3690,2016
+MUSC,3700,1,Clemson University Singers,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,justin durham,,MUSC-3700,2016
+MUSC,3710,1,Women's Chorus,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,justin durham,,MUSC-3710,2016
+MUSC,4150,1,Music Hist to 1750,0.17,0.22,0.22,0.11,0.06,0.0,0.0,0.22,justin durham,,MUSC-4150,2016
+NPL,3000,1,Nonprofit Leadership,0.45,0.39,0.03,0.1,0.03,0.0,0.0,0.0,bonnie west stevens,,NPL-3000,2016
+NPL,3000,3,Nonprofit Leadership,0.59,0.24,0.14,0.0,0.03,0.0,0.0,0.0,james dougl bennett,,NPL-3000,2016
+NPL,3000,4,Nonprofit Leadership,0.87,0.1,0.0,0.03,0.0,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2016
+NPL,3000,5,Nonprofit Leadership,0.52,0.24,0.1,0.0,0.05,0.0,0.0,0.1,christina mar mazer,,NPL-3000,2016
+NPL,3000,6,Nonprofit Leadership,0.76,0.1,0.05,0.05,0.05,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2016
+NPL,3020,1,NPL Fundraising,0.57,0.33,0.05,0.0,0.05,0.0,0.0,0.0,robert frager,,NPL-3020,2016
+NPL,3040,1,NPL Risk Management,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,anthony shau catone,,NPL-3040,2016
+NURS,3030,1,Nursing of Adults,0.2,0.75,0.05,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2016
+NURS,3040,1,Pathophysiology,0.39,0.43,0.11,0.07,0.0,0.0,0.0,0.0,catherine si murton,,NURS-3040,2016
+NURS,3040,400,Pathophysiology,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,,NURS-3040,2016
+NURS,3040,401,Pathophysiology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,,NURS-3040,2016
+NURS,3100,1,Health Assessment,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,,NURS-3100,2016
+NURS,3100,400,Health Assessment,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,,NURS-3100,2016
+NURS,3120,1,Foundations of Nursing,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,angela pye,,NURS-3120,2016
+NURS,3120,400,Foundations of Nursing,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,,NURS-3120,2016
+NURS,3300,1,Research in Nursing,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,veronica parker,,NURS-3300,2016
+NURS,3330,400,Health Care Genetics,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,mary steck,,NURS-3330,2016
+NURS,3400,1,Pharmther Nursing,0.32,0.52,0.11,0.02,0.04,0.0,0.0,0.0,catherine si murton,,NURS-3400,2016
+NURS,3400,400,Pharmther Nursing,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,jenna lyn seawright,,NURS-3400,2016
+NURS,4030,200,Complex Nursing of Adults,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,,NURS-4030,2016
+NURS,4030,400,Complex Nursing of Adults,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,,NURS-4030,2016
+NURS,4110,1,Nursing of Children,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,,NURS-4110,2016
+NURS,4120,1,Nurs Women and Fam,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2016
+NURS,4150,1,Community Health Nursing,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jackie gillespie,,NURS-4150,2016
+NURS,4250,200,Community Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,,NURS-4250,2016
+NURS,8050,400,Pharmaco Adv Nurs,0.77,0.21,0.0,0.0,0.0,0.0,0.0,0.03,tracy king fasolino,,NURS-8050,2016
+NURS,8050,401,Pharmaco Adv Nurs,0.67,0.29,0.0,0.0,0.04,0.0,0.0,0.0,tracy king fasolino,,NURS-8050,2016
+NURS,8060,400,Advan Assessment for Nursing,0.43,0.52,0.0,0.0,0.05,0.0,0.0,0.0,rosanne pruitt,,NURS-8060,2016
+NURS,8090,400,Pathophysiology,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,,NURS-8090,2016
+NURS,8180,400,Develop Family in Primary Care,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,,NURS-8180,2016
+NURS,8190,400,Developing Family,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paula watt,,NURS-8190,2016
+NURS,8200,400,Child & Adol Nursing,0.56,0.38,0.0,0.0,0.06,0.0,0.0,0.0,heide temples,,NURS-8200,2016
+NURS,8220,400,Gerontology Nursing,0.93,0.0,0.0,0.0,0.08,0.0,0.0,0.0,nicole joy davis,,NURS-8220,2016
+NURS,8280,400,The Nurse Educator,0.82,0.05,0.0,0.0,0.05,0.0,0.0,0.09,roxanne amerson,,NURS-8280,2016
+NUTR,2030,1,Intro Princ of Human Nutrition,0.5,0.32,0.12,0.04,0.01,0.0,0.0,0.03,deborah an hutcheon,,NUTR-2030,2016
+NUTR,2030,2,Intro Princ of Human Nutrition,0.76,0.16,0.03,0.0,0.01,0.0,0.0,0.03,deborah an hutcheon,,NUTR-2030,2016
+NUTR,2050,1,Nutrition for Nursing Prof,0.82,0.17,0.01,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,,NUTR-2050,2016
+NUTR,2160,1,Evidence-Based Nutrition,0.78,0.15,0.04,0.02,0.0,0.0,0.0,0.0,angela fraser,,NUTR-2160,2016
+NUTR,4240,1,Medical Nutr Thera I,0.32,0.54,0.14,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4240,2016
+NUTR,4510,1,Human Nutrition & Metabolism I,0.27,0.38,0.16,0.11,0.05,0.0,0.0,0.03,elliot jesch,,NUTR-4510,2016
+PA,1010,1,Intro to Perf Arts,0.57,0.2,0.2,0.03,0.0,0.0,0.0,0.0,david hartmann,,PA-1010,2016
+PA,1030,1,Portfolio I,0.71,0.26,0.0,0.03,0.0,0.0,0.0,0.0,linda dzuris,,PA-1030,2016
+PA,2010,2,Career Planning and Prof Devel,0.8,0.1,0.0,0.1,0.0,0.0,0.0,0.0,shannon ther robert,,PA-2010,2016
+PA,2790,1,Perf Arts Pract I,0.54,0.23,0.12,0.0,0.08,0.0,0.0,0.04,kenneth moore,,PA-2790,2016
+PA,2800,1,Perf Arts Pract II,0.47,0.27,0.07,0.0,0.07,0.0,0.0,0.13,kenneth moore,,PA-2800,2016
+PA,3010,1,Princip of Arts Administration,0.5,0.33,0.08,0.08,0.0,0.0,0.0,0.0,paul buyer,,PA-3010,2016
+PADM,7020,401,Research Methods,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ronald chrestman,,PADM-7020,2016
+PADM,8210,400,Perspectives on Public Admin,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,,PADM-8210,2016
+PADM,8220,400,Public Policy Process,0.73,0.13,0.0,0.0,0.13,0.0,0.0,0.0,ek yazykova mellott,,PADM-8220,2016
+PADM,8270,400,Public Personnel Admin,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,lawrence nichols,,PADM-8270,2016
+PADM,8290,400,Public Financial Management,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,robert frager,,PADM-8290,2016
+PADM,8340,400,Administrative Law,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,andrew moorman,,PADM-8340,2016
+PADM,8670,400,State Government Admin,0.31,0.54,0.08,0.0,0.08,0.0,0.0,0.0,alfred bundrick,,PADM-8670,2016
+PAS,3010,1,Pan African Studies,0.36,0.36,0.16,0.04,0.03,0.0,0.0,0.05,abel bartley,,PAS-3010,2016
+PDBE,8150,1,Research Design in EDP,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mickey lauria,,PDBE-8150,2016
+PES,1040,1,Introduction to Plant Sciences,0.64,0.33,0.0,0.0,0.0,0.0,0.0,0.03,paula agudelo,,PES-1040,2016
+PES,2020,1,Soils,0.01,0.41,0.39,0.11,0.01,0.0,0.0,0.07,dara michelle park,,PES-2020,2016
+PES,4090,1,Biology of Invasive Plants,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,tharayil-santhakumar,,PES-4090,2016
+PHIL,1010,1,Intro to Philosophic Problems,0.27,0.69,0.0,0.0,0.04,0.0,0.0,0.0,kelly smith,,PHIL-1010,2016
+PHIL,1010,3,Intro to Philosophic Problems,0.5,0.31,0.16,0.03,0.0,0.0,0.0,0.0,christopher grau,,PHIL-1010,2016
+PHIL,1010,4,Intro to Philosophic Problems,0.61,0.12,0.09,0.0,0.06,0.0,0.0,0.12,david stegall,,PHIL-1010,2016
+PHIL,1010,6,Intro to Philosophic Problems,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david stegall,,PHIL-1010,2016
+PHIL,1020,1,Introduction to Logic,0.59,0.19,0.09,0.09,0.03,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2016
+PHIL,1020,2,Introduction to Logic,0.76,0.18,0.03,0.03,0.0,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2016
+PHIL,1020,3,Introduction to Logic,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,,PHIL-1020,2016
+PHIL,1020,4,Introduction to Logic,0.8,0.09,0.09,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,,PHIL-1020,2016
+PHIL,1020,5,Introduction to Logic,0.75,0.16,0.06,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,,PHIL-1020,2016
+PHIL,1020,6,Introduction to Logic,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,michael hal hannen,,PHIL-1020,2016
+PHIL,1020,7,Introduction to Logic,0.63,0.29,0.06,0.0,0.03,0.0,0.0,0.0,john randall wolfe,,PHIL-1020,2016
+PHIL,1020,8,Introduction to Logic,0.82,0.12,0.03,0.03,0.0,0.0,0.0,0.0,john randall wolfe,,PHIL-1020,2016
+PHIL,1020,9,Introduction to Logic,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,john randall wolfe,,PHIL-1020,2016
+PHIL,1030,2,Introduction to Ethics,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,william maker,,PHIL-1030,2016
+PHIL,1030,3,Introduction to Ethics,0.27,0.43,0.27,0.03,0.0,0.0,0.0,0.0,john jung park,,PHIL-1030,2016
+PHIL,1030,4,Introduction to Ethics,0.36,0.43,0.18,0.04,0.0,0.0,0.0,0.0,john jung park,,PHIL-1030,2016
+PHIL,1030,5,Introduction to Ethics,0.66,0.25,0.06,0.0,0.03,0.0,0.0,0.0,adam gies,,PHIL-1030,2016
+PHIL,1030,7,Introduction to Ethics,0.76,0.15,0.09,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-1030,2016
+PHIL,1030,8,Introduction to Ethics,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-1030,2016
+PHIL,1030,10,Introduction to Ethics,0.18,0.59,0.18,0.06,0.0,0.0,0.0,0.0,john jung park,,PHIL-1030,2016
+PHIL,1030,12,Introduction to Ethics,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,john jung park,,PHIL-1030,2016
+PHIL,1030,13,Introduction to Ethics,0.35,0.48,0.1,0.0,0.06,0.0,0.0,0.0,daniel wueste,,PHIL-1030,2016
+PHIL,3150,1,Ancient Philosophy,0.24,0.27,0.21,0.03,0.15,0.0,0.0,0.09,stephen satris,,PHIL-3150,2016
+PHIL,3160,1,Modern Philosophy,0.52,0.33,0.09,0.0,0.03,0.0,0.0,0.03,michael hal hannen,,PHIL-3160,2016
+PHIL,3200,1,Soc and Pol Phil,0.53,0.12,0.18,0.0,0.06,0.0,0.0,0.12,john randall wolfe,,PHIL-3200,2016
+PHIL,3240,1,Philosophy of Tech,0.44,0.31,0.16,0.09,0.0,0.0,0.0,0.0,william maker,,PHIL-3240,2016
+PHIL,3260,1,Science and Values,0.53,0.31,0.06,0.0,0.06,0.0,0.0,0.03,andrew garnar,,PHIL-3260,2016
+PHIL,3260,2,Science and Values,0.5,0.35,0.09,0.0,0.03,0.0,0.0,0.03,andrew garnar,,PHIL-3260,2016
+PHIL,3330,1,Metaphysics,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,david stegall,,PHIL-3330,2016
+PHIL,3440,1,Business Ethics,0.77,0.2,0.0,0.0,0.03,0.0,0.0,0.0,david stegall,,PHIL-3440,2016
+PHIL,3450,1,Environmental Ethics,0.48,0.36,0.09,0.0,0.0,0.0,0.0,0.06,jennifer ingle,,PHIL-3450,2016
+PHIL,3450,2,Environmental Ethics,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,jennifer ingle,,PHIL-3450,2016
+PHIL,3460,1,Medical Ethics,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04,charles starkey,,PHIL-3460,2016
+PHIL,3480,1,Philosophies of Art,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,christopher grau,,PHIL-3480,2016
+PHIL,3490,1,Gender and Sexuality,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,jennifer ingle,,PHIL-3490,2016
+PHIL,4920,1,Creative Inquiry in Philosophy,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,stephen satris,,PHIL-4920,2016
+PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.84,0.11,0.03,0.02,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1180,2016
+PHYS,1220,1,Physics with Calculus I,0.26,0.3,0.26,0.12,0.06,0.0,0.0,0.02,pooja puneet,,PHYS-1220,2016
+PHYS,1220,2,Physics with Calculus I,0.34,0.28,0.21,0.07,0.06,0.0,0.0,0.04,pooja puneet,,PHYS-1220,2016
+PHYS,1220,3,Physics W/Cal I (HON),0.57,0.35,0.04,0.04,0.0,0.0,0.0,0.0,hugo sanabria,True,PHYS-1220,2016
+PHYS,1220,4,Physics with Calculus I,0.31,0.38,0.31,0.0,0.0,0.0,0.0,0.0,murray daw,,PHYS-1220,2016
+PHYS,1220,500,Physics with Calculus I,0.31,0.5,0.19,0.0,0.0,0.0,0.0,0.0,elaine parshall,,PHYS-1220,2016
+PHYS,1240,1,Physics Lab I,0.06,0.67,0.11,0.06,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2016
+PHYS,1240,2,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,3,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,4,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,5,Physics Lab I,0.65,0.18,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2016
+PHYS,1240,6,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,7,Physics Lab I,0.11,0.67,0.17,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2016
+PHYS,1240,8,Physics Lab I,0.39,0.56,0.0,0.06,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,9,Physics Lab I,0.56,0.28,0.06,0.0,0.11,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,10,Physics Lab I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,11,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,14,Physics Lab I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,15,Physics Lab I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,16,Physics Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,17,Physics Lab I,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,18,Physics Lab I,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,19,Physics Lab I,0.22,0.61,0.06,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2016
+PHYS,1240,500,Physics Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,elaine parshall,,PHYS-1240,2016
+PHYS,2070,1,General Physics I,0.32,0.28,0.19,0.08,0.07,0.0,0.0,0.05,amy liann pope,,PHYS-2070,2016
+PHYS,2070,2,General Physics I,0.4,0.44,0.09,0.04,0.01,0.0,0.0,0.02,amy liann pope,,PHYS-2070,2016
+PHYS,2070,3,General Physics I,0.43,0.32,0.16,0.05,0.01,0.0,0.0,0.02,amy liann pope,,PHYS-2070,2016
+PHYS,2080,1,General Physics II,0.33,0.39,0.18,0.03,0.05,0.0,0.0,0.02,lih-sin the,,PHYS-2080,2016
+PHYS,2090,1,Gen Phys Lab I,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,2,Gen Phys Lab I,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,3,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,4,Gen Phys Lab I,0.29,0.63,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,5,Gen Phys Lab I,0.33,0.63,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,6,Gen Phys Lab I,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,7,Gen Phys Lab I,0.33,0.54,0.04,0.0,0.04,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,8,Gen Phys Lab I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,9,Gen Phys Lab I,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,10,Gen Phys Lab I,0.27,0.41,0.14,0.05,0.0,0.0,0.0,0.14,jerry hester,,PHYS-2090,2016
+PHYS,2090,11,Gen Phys Lab I,0.38,0.48,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,12,Gen Phys Lab I,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,13,Gen Phys Lab I,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,14,Gen Phys Lab I,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,15,Gen Phys Lab I,0.17,0.63,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,16,Gen Phys Lab I,0.68,0.23,0.05,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2016
+PHYS,2090,17,Gen Phys Lab I,0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,18,Gen Phys Lab I,0.67,0.25,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,19,Gen Phys Lab I,0.33,0.58,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,20,Gen Phys Lab I,0.19,0.52,0.24,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2016
+PHYS,2090,21,Gen Phys Lab I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,22,Gen Phys Lab I,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,23,Gen Phys Lab I,0.33,0.43,0.19,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2016
+PHYS,2090,24,Gen Phys Lab I,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2100,1,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,2,Gen Phys Lab II,0.43,0.21,0.21,0.07,0.0,0.0,0.0,0.07,jerry hester,,PHYS-2100,2016
+PHYS,2100,4,Gen Phys Lab II,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,6,Gen Phys Lab II,0.52,0.3,0.09,0.04,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2016
+PHYS,2100,7,Gen Phys Lab II,0.65,0.13,0.13,0.0,0.04,0.0,0.0,0.04,jerry hester,,PHYS-2100,2016
+PHYS,2100,8,Gen Phys Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2210,1,Physics with Calculus II,0.13,0.44,0.28,0.1,0.03,0.0,0.0,0.02,jason stratfo brown,,PHYS-2210,2016
+PHYS,2210,2,Physics with Calculus II,0.24,0.49,0.19,0.04,0.02,0.0,0.0,0.03,jason stratfo brown,,PHYS-2210,2016
+PHYS,2210,3,Physics with Calculus II,0.34,0.53,0.11,0.01,0.01,0.0,0.0,0.0,jason stratfo brown,,PHYS-2210,2016
+PHYS,2210,4,Physics with Calculus II,0.18,0.56,0.18,0.04,0.03,0.0,0.0,0.01,pooja puneet,,PHYS-2210,2016
+PHYS,2210,7,Physics With Cal II (HON),0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,endre andras takacs,True,PHYS-2210,2016
+PHYS,2220,1,Physics with Calculus III,0.32,0.35,0.16,0.0,0.03,0.0,0.0,0.13,jian he,,PHYS-2220,2016
+PHYS,2230,1,Physics Lab II,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,2,Physics Lab II,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,3,Physics Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,4,Physics Lab II,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-2230,2016
+PHYS,2230,5,Physics Lab II,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2016
+PHYS,2230,6,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,7,Physics Lab II,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,jerry hester,,PHYS-2230,2016
+PHYS,2230,9,Physics Lab II,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,10,Physics Lab II,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2016
+PHYS,2230,11,Physics Lab II,0.11,0.89,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,12,Physics Lab II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,13,Physics Lab II,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-2230,2016
+PHYS,2230,17,Physics Lab II,0.07,0.43,0.29,0.0,0.07,0.0,0.0,0.14,jerry hester,,PHYS-2230,2016
+PHYS,2450,1,Physics of Climate,0.44,0.26,0.09,0.04,0.04,0.0,0.0,0.14,gerald lehmacher,,PHYS-2450,2016
+PHYS,3000,1,Intro to Research,0.76,0.12,0.08,0.0,0.04,0.0,0.0,0.0,hugo sanabria,,PHYS-3000,2016
+PHYS,3120,1,Meth Theor Phys II,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,feng ding,,PHYS-3120,2016
+PHYS,3150,1,Intro to Computational Physics,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,emil georgie alexov,,PHYS-3150,2016
+PHYS,3210,1,Mechanics I,0.16,0.26,0.26,0.16,0.05,0.0,0.0,0.11,joshua alper,,PHYS-3210,2016
+PHYS,3250,1,Exper Physics I,0.42,0.47,0.05,0.0,0.0,0.0,0.0,0.05,chad sosolik,,PHYS-3250,2016
+PHYS,4410,1,Electromagnetics I,0.27,0.18,0.27,0.18,0.0,0.0,0.0,0.09,joan marler,,PHYS-4410,2016
+PHYS,4550,1,Quantum Physics I,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,ramakrishna podila,,PHYS-4550,2016
+PHYS,8110,1,Meth of Theor Phys I,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,bradley meyer,,PHYS-8110,2016
+PHYS,8210,1,Classical Mech I,0.18,0.55,0.27,0.0,0.0,0.0,0.0,0.0,jens oberheide,,PHYS-8210,2016
+PHYS,9510,1,Quantum Mech I,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,domnita marinescu,,PHYS-9510,2016
+PKSC,1010,1,Pkgsc Orientation,0.79,0.11,0.08,0.0,0.02,0.0,0.0,0.0,robert truett moore,,PKSC-1010,2016
+PKSC,1020,1,Intro to Pkg Sci,0.1,0.33,0.32,0.11,0.09,0.0,0.0,0.04,heather batt,,PKSC-1020,2016
+PKSC,2020,1,Packaging Mtl & Mfg,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2020,2016
+PKSC,2200,1,Product & Pkg Design,0.85,0.06,0.02,0.0,0.04,0.0,0.0,0.02,william aaro snyder,,PKSC-2200,2016
+PKSC,3200,1,Pkg Design Theory,0.39,0.26,0.3,0.0,0.04,0.0,0.0,0.0,rupert hurley,,PKSC-3200,2016
+PKSC,4010,1,Packaging Machinery,0.31,0.41,0.2,0.07,0.01,0.0,0.0,0.0,anthony lou pometto,,PKSC-4010,2016
+PKSC,4030,1,Pkg Career Prep,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2016
+PKSC,4040,1,Protective Packaging Prop/Prin,0.28,0.27,0.24,0.1,0.07,0.0,0.0,0.03,gregory batt,,PKSC-4040,2016
+PKSC,4160,1,Appl Polymers in Pkg,0.16,0.52,0.23,0.06,0.03,0.0,0.0,0.0,duncan darby,,PKSC-4160,2016
+PKSC,4200,1,Pkg Design & Dev,0.54,0.39,0.04,0.0,0.04,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2016
+PKSC,4230,400,3D Parametric Design Online,0.77,0.0,0.0,0.0,0.15,0.0,0.0,0.08,rupert hurley,,PKSC-4230,2016
+PKSC,4540,1,Prod Pkg Evl Lab,0.38,0.19,0.19,0.13,0.06,0.0,0.0,0.06,gregory batt,,PKSC-4540,2016
+PKSC,4540,2,Prod Pkg Evl Lab,0.13,0.25,0.13,0.06,0.38,0.0,0.0,0.06,gregory batt,,PKSC-4540,2016
+PKSC,4540,3,Prod Pkg Evl Lab,0.56,0.19,0.06,0.0,0.19,0.0,0.0,0.0,gregory batt,,PKSC-4540,2016
+PKSC,4540,4,Prod Pkg Evl Lab,0.25,0.31,0.25,0.0,0.19,0.0,0.0,0.0,gregory batt,,PKSC-4540,2016
+PKSC,4640,1,Food & Health Care Pkg Systems,0.53,0.28,0.06,0.0,0.14,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2016
+PKSC,6230,400,3D Parametic Design Online,0.67,0.0,0.17,0.0,0.0,0.0,0.0,0.17,rupert hurley,,PKSC-6230,2016
+PLPA,3100,1,Principles of Plant Pathology,0.12,0.48,0.4,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,,PLPA-3100,2016
+PLPA,8020,1,Ppls of Plant Pathology,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,,PLPA-8020,2016
+POSC,1010,1,Amer National Govt,0.08,0.39,0.3,0.1,0.05,0.0,0.0,0.08,joseph earl stewart,,POSC-1010,2016
+POSC,1010,2,Amer National Govt,0.24,0.36,0.17,0.1,0.08,0.0,0.0,0.06,jeffrey scott peake,,POSC-1010,2016
+POSC,1020,1,Intro Intl Relations,0.33,0.43,0.13,0.06,0.02,0.0,0.0,0.04,tara elizabet trask,,POSC-1020,2016
+POSC,1020,2,Intro Intl Relations,0.22,0.26,0.3,0.09,0.05,0.0,0.0,0.08,zeynep taydas,,POSC-1020,2016
+POSC,1020,3,Intro Intl Relations,0.16,0.29,0.35,0.11,0.04,0.0,0.0,0.05,zeynep taydas,,POSC-1020,2016
+POSC,1020,4,Intro Intl Relations,0.16,0.29,0.36,0.12,0.03,0.0,0.0,0.03,joshua douglas king,,POSC-1020,2016
+POSC,1020,5,Intro Intl Relations,0.09,0.47,0.19,0.06,0.09,0.0,0.0,0.09,joshua douglas king,,POSC-1020,2016
+POSC,1030,1,Intro to Political Theory,0.05,0.26,0.21,0.37,0.03,0.0,0.0,0.08,james woodard,,POSC-1030,2016
+POSC,1030,2,Intro to Political Theory,0.25,0.29,0.25,0.11,0.07,0.0,0.0,0.02,brandon turner,,POSC-1030,2016
+POSC,1040,1,Intro Compar Pol,0.36,0.42,0.11,0.06,0.04,0.0,0.0,0.02,tara elizabet trask,,POSC-1040,2016
+POSC,1040,2,Intro Compar Pol,0.18,0.35,0.29,0.06,0.06,0.0,0.0,0.06,katherine am curtis,,POSC-1040,2016
+POSC,1990,1,Intro Pol Sci,0.4,0.33,0.08,0.09,0.06,0.0,0.0,0.05,meredith petersheim,,POSC-1990,2016
+POSC,3020,1,State and Loc Gov,0.12,0.58,0.1,0.02,0.02,0.0,0.0,0.16,bruce ransom,,POSC-3020,2016
+POSC,3410,1,Quant Meth in Pol Sc,0.06,0.17,0.33,0.22,0.17,0.0,0.0,0.06,steven vince miller,,POSC-3410,2016
+POSC,3610,1,Intl Pol in Crisis,0.4,0.4,0.1,0.04,0.04,0.0,0.0,0.02,vladimir matic,,POSC-3610,2016
+POSC,3630,1,Us Foreign Policy,0.29,0.24,0.22,0.14,0.1,0.0,0.0,0.0,steven vince miller,,POSC-3630,2016
+POSC,3710,1,European Politics,0.33,0.28,0.22,0.0,0.06,0.0,0.0,0.11,vladimir matic,,POSC-3710,2016
+POSC,3890,1,Religious Liberty & the Const.,0.29,0.64,0.0,0.0,0.07,0.0,0.0,0.0,daniel frost,,POSC-3890,2016
+POSC,4030,1,United States Congress,0.27,0.37,0.27,0.04,0.04,0.0,0.0,0.02,jeffrey allen fine,,POSC-4030,2016
+POSC,4070,1,Religion and Politic,0.17,0.46,0.26,0.03,0.06,0.0,0.0,0.03,laura olson,,POSC-4070,2016
+POSC,4210,1,Public Policy,0.06,0.13,0.25,0.19,0.19,0.0,0.0,0.19,adam warber,,POSC-4210,2016
+POSC,4230,1,Urban Politics,0.33,0.33,0.0,0.0,0.17,0.0,0.0,0.17,bruce ransom,,POSC-4230,2016
+POSC,4360,1,Law Courts Politics,0.66,0.19,0.04,0.0,0.02,0.0,0.0,0.09,joseph earl stewart,,POSC-4360,2016
+POSC,4380,1,Constitut Law: Struc of Gov,0.4,0.46,0.13,0.0,0.02,0.0,0.0,0.0,daniel frost,,POSC-4380,2016
+POSC,4420,1,Pol Parties & Elect,0.13,0.04,0.42,0.29,0.0,0.0,0.0,0.13,james woodard,,POSC-4420,2016
+POSC,4470,1,International Law,0.27,0.35,0.22,0.08,0.05,0.0,0.0,0.03,katherine am curtis,,POSC-4470,2016
+POSC,4490,1,Political Theory of Capitalism,0.45,0.14,0.1,0.02,0.2,0.0,0.0,0.08,brandon turner,,POSC-4490,2016
+POSC,4550,1,Pol Thght of American Founding,0.32,0.48,0.19,0.0,0.0,0.0,0.0,0.0, bradley thompson,,POSC-4550,2016
+POSC,4560,1,Diplomacy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,,POSC-4560,2016
+POSC,4760,1,Middle East Politics,0.67,0.13,0.07,0.0,0.0,0.0,0.0,0.13,vladimir matic,,POSC-4760,2016
+POSC,4820,1,Political Novel and Film,0.11,0.42,0.47,0.0,0.0,0.0,0.0,0.0,james woodard,,POSC-4820,2016
+PRTM,2200,10,Foundations of PRTM,0.45,0.34,0.08,0.02,0.04,0.0,0.0,0.08,jamie lynn cathey,,PRTM-2200,2016
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2260,2016
+PRTM,2260,2,Fnd of Mgt Adm PRTM,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,,PRTM-2260,2016
+PRTM,2260,3,Fnd of Mgt Adm PRTM,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2260,2016
+PRTM,2260,4,Fnd of Mgt Adm PRTM,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,,PRTM-2260,2016
+PRTM,2260,5,Fnd of Mgt Adm PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2260,2016
+PRTM,2260,6,Fnd of Mgt Adm PRTM,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,harrison pinckney,,PRTM-2260,2016
+PRTM,2260,7,Fnd of Mgt Adm PRTM,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2260,2016
+PRTM,2260,8,Fnd of Mgt Adm PRTM,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,kellie aman walters,,PRTM-2260,2016
+PRTM,2270,1,Prov of Leisure Exp,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2270,2016
+PRTM,2270,2,Prov of Leisure Exp,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,,PRTM-2270,2016
+PRTM,2270,3,Prov of Leisure Exp,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2270,2016
+PRTM,2270,4,Prov of Leisure Exp,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,herbert chancellor,,PRTM-2270,2016
+PRTM,2270,5,Prov of Leisure Exp,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2270,2016
+PRTM,2270,6,Prov of Leisure Exp,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,harrison pinckney,,PRTM-2270,2016
+PRTM,2270,7,Prov of Leisure Exp,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2270,2016
+PRTM,2270,8,Prov of Leisure Exp,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,kellie aman walters,,PRTM-2270,2016
+PRTM,2290,1,Competency Integration in PRTM,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2290,2016
+PRTM,2290,2,Competency Integration in PRTM,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth baldwin,,PRTM-2290,2016
+PRTM,2290,3,Competency Integration in PRTM,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2290,2016
+PRTM,2290,4,Competency Integration in PRTM,0.28,0.5,0.17,0.0,0.06,0.0,0.0,0.0,herbert chancellor,,PRTM-2290,2016
+PRTM,2290,5,Competency Integration in PRTM,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2290,2016
+PRTM,2290,6,Competency Integration in PRTM,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,harrison pinckney,,PRTM-2290,2016
+PRTM,2290,7,Competency Integration in PRTM,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2290,2016
+PRTM,2290,8,Competency Integration in PRTM,0.26,0.53,0.11,0.05,0.05,0.0,0.0,0.0,kellie aman walters,,PRTM-2290,2016
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.33,0.3,0.18,0.15,0.03,0.0,0.0,0.03,daniel mor anderson,,PRTM-3050,2016
+PRTM,3070,2,Facility Operations,0.83,0.09,0.04,0.04,0.0,0.0,0.0,0.0,raymond dunham,,PRTM-3070,2016
+PRTM,3200,1,Recreation Policy,0.25,0.45,0.2,0.1,0.0,0.0,0.0,0.0,lincoln larson,,PRTM-3200,2016
+PRTM,3210,1,Recreation Admin,0.71,0.18,0.11,0.0,0.0,0.0,0.0,0.0,mariela fernandez,,PRTM-3210,2016
+PRTM,3220,2,Facilitation Techniques in RT,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alysha amber walter,,PRTM-3220,2016
+PRTM,3230,1,Prof Prep for RT Practice,0.91,0.0,0.0,0.0,0.05,0.0,0.0,0.04,stephen thoma lewis,,PRTM-3230,2016
+PRTM,3240,1,Assessment & Planning in RT,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3240,2016
+PRTM,3240,2,Assessment & Planning in RT,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3240,2016
+PRTM,3250,1,Global Persp in Rec,0.42,0.26,0.19,0.13,0.0,0.0,0.0,0.0,mary price,,PRTM-3250,2016
+PRTM,3300,1,Visit Ser & Interp,0.6,0.13,0.27,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-3300,2016
+PRTM,3420,2,Intro to Tourism,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,li-hsin chen,,PRTM-3420,2016
+PRTM,3430,1,Spl Asp of Tourist B,0.35,0.48,0.11,0.0,0.05,0.0,0.0,0.0,william norman,,PRTM-3430,2016
+PRTM,3470,1,Sport Tourism,0.35,0.35,0.2,0.05,0.0,0.0,0.0,0.05,gregory phi ramshaw,,PRTM-3470,2016
+PRTM,3520,1,Camp Org and Admin,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-3520,2016
+PRTM,3900,6,Independent Study in PRTM,0.77,0.08,0.0,0.08,0.0,0.0,0.0,0.08,adam savedra,,PRTM-3900,2016
+PRTM,3910,1,Social Media in PRTM,0.78,0.13,0.04,0.0,0.04,0.0,0.0,0.0,sheila backman,,PRTM-3910,2016
+PRTM,3910,2,Issues & Trends in Event Mgmt.,0.72,0.16,0.08,0.04,0.0,0.0,0.0,0.0,stephanie per garst,,PRTM-3910,2016
+PRTM,3910,3,Resort Management,0.76,0.19,0.0,0.0,0.05,0.0,0.0,0.0,jeffery martin,,PRTM-3910,2016
+PRTM,3920,1,Special Event Management,0.69,0.2,0.1,0.0,0.0,0.0,0.0,0.02,kenneth backman,,PRTM-3920,2016
+PRTM,3920,2,Special Event Management,0.8,0.16,0.02,0.0,0.0,0.0,0.0,0.02,kenneth backman,,PRTM-3920,2016
+PRTM,3950,1,PGM Seminar III,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3950,2016
+PRTM,3980,2,Creative Inquiry in PRTM III,0.67,0.17,0.06,0.0,0.0,0.0,0.0,0.11,denise mar anderson,,PRTM-3980,2016
+PRTM,3980,10,Creative Inquiry in PRTM III,0.59,0.21,0.14,0.07,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-3980,2016
+PRTM,4030,1,Elem of Rec/Pk Plan,0.43,0.36,0.21,0.0,0.0,0.0,0.0,0.0,robert baxte powell,,PRTM-4030,2016
+PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,daniel mor anderson,,PRTM-4040,2016
+PRTM,4220,1,Management of RT Services,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,,PRTM-4220,2016
+PRTM,4470,1,Perspect Intl Travel,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,lauren duffy,,PRTM-4470,2016
+PRTM,4740,2,Adv Rec Resource Mgt,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey koo riungu,,PRTM-4740,2016
+PRTM,4830,1,Golf Club Mgt & Ops,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,richard lucas,,PRTM-4830,2016
+PRTM,4950,1,Pro Golf Management Seminar IV,0.5,0.25,0.08,0.17,0.0,0.0,0.0,0.0,richard lucas,,PRTM-4950,2016
+PRTM,4980,10,Creative Inquiry in PRTM IV,0.59,0.21,0.14,0.07,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-4980,2016
+PRTM,8010,1,Phil Found of PRTM,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,,PRTM-8010,2016
+PRTM,8010,2,Phil Found of PRTM,0.5,0.36,0.0,0.0,0.05,0.0,0.0,0.09,dorothy schmalz,,PRTM-8010,2016
+PRTM,8010,3,Phil Found of PRTM,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,,PRTM-8010,2016
+PRTM,8080,1,Behavioral Aspects,0.76,0.16,0.04,0.0,0.04,0.0,0.0,0.0,robert bixler,,PRTM-8080,2016
+PRTM,8080,2,Behavioral Aspects,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-8080,2016
+PRTM,8220,2,Strateg Planning in PRTM Orgs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,lincoln larson,,PRTM-8220,2016
+PRTM,8710,1,Applied Research in Rec Therap,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,,PRTM-8710,2016
+PRTM,8710,4,Applied Research in Rec Therap,0.9,0.06,0.03,0.0,0.0,0.0,0.0,0.0,sarah taylor agate,,PRTM-8710,2016
+PRTM,8750,1,Program Plan & Consult in RT,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,,PRTM-8750,2016
+PRTM,8750,2,Program Plan & Consult in RT,0.33,0.17,0.5,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,,PRTM-8750,2016
+PSYC,2010,1,Intro to Psychology,0.36,0.32,0.18,0.06,0.05,0.0,0.0,0.03,jo anne jorgensen,,PSYC-2010,2016
+PSYC,2010,2,Intro to Psychology,0.37,0.32,0.17,0.05,0.03,0.0,0.0,0.05,jo anne jorgensen,,PSYC-2010,2016
+PSYC,2010,3,Intro to Psychology,0.24,0.34,0.24,0.1,0.06,0.0,0.0,0.02,edwin brainerd,,PSYC-2010,2016
+PSYC,2010,4,Intro to Psychology,0.45,0.29,0.16,0.06,0.04,0.0,0.0,0.0,fred switzer,,PSYC-2010,2016
+PSYC,2010,5,Intro to Psychology,0.33,0.26,0.21,0.03,0.06,0.0,0.0,0.11,mary taylor,,PSYC-2010,2016
+PSYC,2010,6,Intro to Psychology (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True,PSYC-2010,2016
+PSYC,2020,1,Intro Psychology Lab,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,jamie fynes,,PSYC-2020,2016
+PSYC,2020,4,Intro Psychology Lab,0.8,0.04,0.0,0.04,0.12,0.0,0.0,0.0,madison eliza sauls,,PSYC-2020,2016
+PSYC,2020,5,Intro Psychology Lab,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,william leidheiser,,PSYC-2020,2016
+PSYC,2020,6,Intro Psychology Lab,0.77,0.15,0.0,0.0,0.04,0.0,0.0,0.04,william leidheiser,,PSYC-2020,2016
+PSYC,3060,1,Human Sexual Beh,0.46,0.24,0.15,0.06,0.07,0.0,0.0,0.02,bruce michael king,,PSYC-3060,2016
+PSYC,3090,100,Intro Exp Psych,0.51,0.23,0.14,0.08,0.04,0.0,0.0,0.0,patrick rosopa,,PSYC-3090,2016
+PSYC,3090,200,Intro Exp Psych,0.4,0.2,0.1,0.03,0.23,0.0,0.0,0.03,jennifer bai bisson,,PSYC-3090,2016
+PSYC,3090,300,Intro Exp Psych,0.57,0.23,0.07,0.07,0.03,0.0,0.0,0.03,stephen robertson,,PSYC-3090,2016
+PSYC,3100,100,Advanced Experimental Psych,0.32,0.26,0.32,0.05,0.05,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3100,2016
+PSYC,3100,200,Advanced Experimental Psych,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,robert campbell,,PSYC-3100,2016
+PSYC,3100,300,Advanced Experimental Psych,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2016
+PSYC,3100,400,Advanced Experimental Psych,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,leo gugerty,,PSYC-3100,2016
+PSYC,3100,500,Advanced Experimental Psych,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2016
+PSYC,3240,1,Physiological Psych,0.38,0.28,0.17,0.1,0.01,0.0,0.0,0.06,claudio cantalupo,,PSYC-3240,2016
+PSYC,3240,2,Physiological Psych,0.34,0.3,0.19,0.07,0.03,0.0,0.0,0.06,june pilcher,,PSYC-3240,2016
+PSYC,3330,1,Cognitive Psych,0.42,0.39,0.11,0.03,0.01,0.0,0.0,0.03,leah hartman,,PSYC-3330,2016
+PSYC,3330,2,Cognitive Psych,0.21,0.23,0.38,0.15,0.03,0.0,0.0,0.0,thomas alley,,PSYC-3330,2016
+PSYC,3330,3,Cognitive Psych,0.16,0.33,0.31,0.16,0.02,0.0,0.0,0.03,thomas alley,,PSYC-3330,2016
+PSYC,3340,1,Cognitive Psych Lab,0.68,0.23,0.09,0.0,0.0,0.0,0.0,0.0,laura whitlock,,PSYC-3340,2016
+PSYC,3340,2,Cognitive Psych Lab,0.75,0.04,0.04,0.08,0.04,0.0,0.0,0.04,laura whitlock,,PSYC-3340,2016
+PSYC,3400,1,Lifespan Developmental Psych,0.21,0.4,0.23,0.06,0.04,0.0,0.0,0.06,pamela alley,,PSYC-3400,2016
+PSYC,3400,2,Lifespan Developmental Psych,0.62,0.28,0.09,0.0,0.01,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3400,2016
+PSYC,3520,1,Social Psychology,0.39,0.37,0.19,0.04,0.0,0.0,0.0,0.01,eric mckibben,,PSYC-3520,2016
+PSYC,3640,1,Industrial Psych,0.3,0.51,0.17,0.0,0.0,0.0,0.0,0.01,eric mckibben,,PSYC-3640,2016
+PSYC,3640,2,Industrial Psych,0.4,0.5,0.07,0.01,0.0,0.0,0.0,0.01,eric mckibben,,PSYC-3640,2016
+PSYC,3680,1,Organizational Psych,0.34,0.31,0.14,0.07,0.06,0.0,0.0,0.07,thomas britt,,PSYC-3680,2016
+PSYC,3680,2,Organizational Psych,0.3,0.35,0.15,0.11,0.07,0.0,0.0,0.02,kristen su jennings,,PSYC-3680,2016
+PSYC,3700,1,Personality,0.14,0.49,0.31,0.06,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-3700,2016
+PSYC,3830,1,Abnormal Psychology,0.28,0.4,0.14,0.13,0.02,0.0,0.0,0.02,cynthia pury,,PSYC-3830,2016
+PSYC,3830,2,Abnormal Psychology,0.17,0.29,0.34,0.09,0.09,0.0,0.0,0.03,pamela alley,,PSYC-3830,2016
+PSYC,3830,3,Abnormal Psychology,0.34,0.23,0.26,0.0,0.06,0.0,0.0,0.11,pamela alley,,PSYC-3830,2016
+PSYC,3830,4,Abnormal Psychology,0.32,0.43,0.16,0.03,0.01,0.0,0.0,0.04,lucinda sorci quick,,PSYC-3830,2016
+PSYC,4080,1,Women and Psychology,0.56,0.32,0.08,0.04,0.0,0.0,0.0,0.0,robin mari kowalski,,PSYC-4080,2016
+PSYC,4150,1,Systems and Theories,0.27,0.53,0.1,0.07,0.03,0.0,0.0,0.0,brian day,,PSYC-4150,2016
+PSYC,4150,2,Systems and Theories,0.41,0.18,0.26,0.06,0.03,0.0,0.0,0.06,edwin brainerd,,PSYC-4150,2016
+PSYC,4150,3,Systems and Theories,0.39,0.25,0.25,0.0,0.08,0.0,0.0,0.03,edwin brainerd,,PSYC-4150,2016
+PSYC,4220,1,Perception,0.3,0.39,0.09,0.09,0.09,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2016
+PSYC,4220,2,Perception,0.5,0.17,0.21,0.08,0.0,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2016
+PSYC,4220,3,Perception,0.26,0.37,0.22,0.15,0.0,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2016
+PSYC,4350,1,Human Factors,0.38,0.17,0.33,0.13,0.0,0.0,0.0,0.0,laura whitlock,,PSYC-4350,2016
+PSYC,4430,1,Infant & Child Dev,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-4430,2016
+PSYC,4560,1,Psychophysiology,0.54,0.17,0.04,0.08,0.08,0.0,0.0,0.08,drew michael morris,,PSYC-4560,2016
+PSYC,4710,1,Psych of Testing,0.46,0.21,0.21,0.08,0.04,0.0,0.0,0.0,robert ray sinclair,,PSYC-4710,2016
+PSYC,4800,1,Health Psychology,0.5,0.38,0.08,0.0,0.04,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2016
+PSYC,4800,2,Health Psychology,0.56,0.36,0.0,0.0,0.04,0.0,0.0,0.04,james mccubbin,,PSYC-4800,2016
+PSYC,4880,1,Psychotherapy,0.43,0.29,0.07,0.07,0.07,0.0,0.0,0.07,heidi marie zinzow,,PSYC-4880,2016
+PSYC,4890,1,Teamwork in 21st Cen,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,william kramer,,PSYC-4890,2016
+PSYC,4920,1,Senior Laboratory,0.68,0.2,0.08,0.04,0.0,0.0,0.0,0.0,drea kevin fekety,,PSYC-4920,2016
+PSYC,4920,4,Senior Laboratory,0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,miranda pelkey,,PSYC-4920,2016
+PSYC,4920,5,Senior Laboratory,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,dana verhoeven,,PSYC-4920,2016
+PSYC,4920,6,Senior Laboratory,0.45,0.18,0.09,0.09,0.18,0.0,0.0,0.0,dana verhoeven,,PSYC-4920,2016
+PSYC,8100,1,Research Design I,0.61,0.16,0.1,0.0,0.06,0.0,0.0,0.06, dewayne moore,,PSYC-8100,2016
+PSYC,8220,1,Percept & Perform,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,richard tyrrell,,PSYC-8220,2016
+RED,8000,1,Real Estate Dvlpment,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,robert cre benedict,,RED-8000,2016
+RED,8010,1,Market Analysis,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,,RED-8010,2016
+RED,8130,1,Strat in Real Estate,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,,RED-8130,2016
+REL,1010,1,Intro to Religion,0.43,0.43,0.04,0.04,0.04,0.0,0.0,0.0,steven grosby,,REL-1010,2016
+REL,1010,2,Intro to Religion,0.94,0.03,0.0,0.0,0.03,0.0,0.0,0.0,robert stephens,,REL-1010,2016
+REL,1010,4,Intro to Religion,0.82,0.09,0.06,0.0,0.03,0.0,0.0,0.0,robert stephens,,REL-1010,2016
+REL,1010,5,Intro to Religion,0.72,0.09,0.06,0.0,0.0,0.0,0.0,0.13,robert stephens,,REL-1010,2016
+REL,1020,2,World Religions,0.22,0.17,0.33,0.06,0.06,0.0,0.0,0.17,peter cohen,,REL-1020,2016
+REL,1020,3,World Religions,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,peter cohen,,REL-1020,2016
+REL,1020,4,World Religions,0.28,0.61,0.11,0.0,0.0,0.0,0.0,0.0,peter cohen,,REL-1020,2016
+REL,1020,5,World Religions,0.35,0.29,0.26,0.0,0.0,0.0,0.0,0.09,brett patterson,,REL-1020,2016
+REL,1020,7,World Religions,0.42,0.33,0.17,0.0,0.0,0.0,0.0,0.08,brett patterson,,REL-1020,2016
+REL,3010,1,Old Testament,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3010,2016
+REL,3060,1,Judaism,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3060,2016
+REL,3110,1,African American Rel,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,elizabeth jemison,,REL-3110,2016
+REL,3130,1,Buddhism,0.68,0.21,0.0,0.05,0.0,0.0,0.0,0.05,robert stephens,,REL-3130,2016
+REL,3150,1,Islam,0.5,0.31,0.06,0.0,0.0,0.0,0.0,0.13,mashal saif,,REL-3150,2016
+REL,3300,1,Contemporary Issues,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mashal saif,,REL-3300,2016
+REL,4010,1,Stud Biblical Literature & Rel,0.41,0.29,0.06,0.0,0.12,0.0,0.0,0.12,benjamin white,,REL-4010,2016
+RS,3010,1,Rural Sociology,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,kenneth robinson,,RS-3010,2016
+RUSS,1010,1,Elementary Russian,0.26,0.26,0.26,0.11,0.11,0.0,0.0,0.0,olga anatol volkova,,RUSS-1010,2016
+RUSS,3400,1,19th C Russ Culture,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,,RUSS-3400,2016
+SOC,2010,2,Introduction to Sociology,0.72,0.2,0.06,0.0,0.01,0.0,0.0,0.01,andrew mannheimer,,SOC-2010,2016
+SOC,2010,3,Introduction to Sociology,0.73,0.18,0.04,0.02,0.0,0.02,0.0,0.0,andrew mannheimer,,SOC-2010,2016
+SOC,2010,4,Introduction to Sociology,0.28,0.51,0.11,0.04,0.01,0.0,0.0,0.04,carolyn can coffman,,SOC-2010,2016
+SOC,2010,5,Introduction to Sociology,0.26,0.45,0.23,0.06,0.0,0.0,0.0,0.0,carolyn can coffman,,SOC-2010,2016
+SOC,2010,6,Introduction to Sociology,0.28,0.55,0.15,0.02,0.0,0.0,0.0,0.0,carolyn can coffman,,SOC-2010,2016
+SOC,2010,7,Introduction to Sociology,0.34,0.4,0.13,0.06,0.0,0.0,0.0,0.06,mary louise barr,,SOC-2010,2016
+SOC,2010,8,Introduction to Sociology,0.56,0.27,0.13,0.02,0.02,0.0,0.0,0.0,mary louise barr,,SOC-2010,2016
+SOC,2010,9,Introduction to Sociology,0.5,0.3,0.16,0.02,0.0,0.0,0.0,0.02,mary louise barr,,SOC-2010,2016
+SOC,2010,10,Introduction to Sociology,0.43,0.39,0.13,0.03,0.0,0.0,0.0,0.01,mary louise barr,,SOC-2010,2016
+SOC,2010,11,Introduction to Sociology,0.57,0.3,0.11,0.02,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2016
+SOC,2010,12,Introduction to Sociology,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2016
+SOC,2010,13,Introduction to Sociology,0.6,0.28,0.08,0.01,0.02,0.0,0.0,0.01,shannon mcdonough,,SOC-2010,2016
+SOC,2010,14,Introduction to Sociology,0.71,0.2,0.06,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2016
+SOC,2010,15,Introduction to Sociology,0.71,0.21,0.02,0.02,0.02,0.0,0.0,0.02,shannon mcdonough,,SOC-2010,2016
+SOC,2010,16,Introduction to Sociology,0.47,0.43,0.04,0.04,0.0,0.0,0.0,0.02,tamela lea eitle,,SOC-2010,2016
+SOC,2010,17,Introduction to Sociology,0.4,0.46,0.08,0.02,0.02,0.0,0.0,0.02,tamela lea eitle,,SOC-2010,2016
+SOC,2050,1,Sociology Lab,0.54,0.15,0.15,0.0,0.15,0.0,0.0,0.0,brenda vander mey,,SOC-2050,2016
+SOC,2050,2,Sociology Lab,0.61,0.11,0.0,0.0,0.28,0.0,0.0,0.0,brenda vander mey,,SOC-2050,2016
+SOC,3020,1,Research Methods I,0.09,0.44,0.31,0.13,0.0,0.0,0.0,0.03,andrew whitehead,,SOC-3020,2016
+SOC,3040,1,Social Research Methods II,0.32,0.18,0.36,0.05,0.05,0.0,0.0,0.05,ye luo,,SOC-3040,2016
+SOC,3100,1,Marriage & Intimacy,0.52,0.17,0.13,0.07,0.04,0.0,0.0,0.07,carolyn can coffman,,SOC-3100,2016
+SOC,3110,1,The Family,0.15,0.28,0.26,0.18,0.1,0.0,0.0,0.03,andrew whitehead,,SOC-3110,2016
+SOC,3600,1,Class & Poverty,0.86,0.02,0.04,0.08,0.0,0.0,0.0,0.0,william wentworth,,SOC-3600,2016
+SOC,3880,1,Criminal Justice,0.32,0.16,0.36,0.16,0.0,0.0,0.0,0.0,margaret tina britz,,SOC-3880,2016
+SOC,3890,1,Criminology,0.15,0.21,0.26,0.12,0.06,0.0,0.0,0.21,william white,,SOC-3890,2016
+SOC,3910,1,Soc of Deviance,0.45,0.32,0.11,0.05,0.02,0.0,0.0,0.05,william white,,SOC-3910,2016
+SOC,3920,1,Juvenile Delinquency,0.41,0.35,0.18,0.0,0.0,0.0,0.0,0.06,william white,,SOC-3920,2016
+SOC,3940,1,Sociology of Mental Illness,0.48,0.41,0.02,0.0,0.07,0.0,0.0,0.02,marissa el yingling,,SOC-3940,2016
+SOC,3970,1,Substance Abuse,0.57,0.28,0.09,0.04,0.0,0.0,0.0,0.02,shannon mcdonough,,SOC-3970,2016
+SOC,4030,1,"Technol, Environment & Society",0.39,0.06,0.39,0.0,0.06,0.0,0.0,0.11, catherine mobley,,SOC-4030,2016
+SOC,4040,1,Soc Theory,0.54,0.29,0.15,0.0,0.02,0.0,0.0,0.0,william wentworth,,SOC-4040,2016
+SOC,4140,1,Policy&Social Change,0.45,0.25,0.25,0.0,0.05,0.0,0.0,0.0,marissa el yingling,,SOC-4140,2016
+SOC,4330,1,Global Social Change,0.77,0.15,0.0,0.04,0.04,0.0,0.0,0.0,william haller,,SOC-4330,2016
+SOC,4440,1,Sociology of Educ,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,,SOC-4440,2016
+SOC,4600,1,Race & Ethnicity,0.41,0.22,0.3,0.04,0.04,0.0,0.0,0.0,brenda vander mey,,SOC-4600,2016
+SOC,4680,1,Criminal Evidence,0.36,0.55,0.05,0.0,0.0,0.0,0.0,0.05,margaret tina britz,,SOC-4680,2016
+SOC,4810,1,Aging and Death,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-4810,2016
+SOC,4970,1,Senior Lab,0.6,0.13,0.13,0.0,0.1,0.0,0.0,0.03,brenda vander mey,,SOC-4970,2016
+SOC,8030,1,Sur Dsgn App Res Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,,SOC-8030,2016
+SPAN,1010,1,Elementary Spanish,0.67,0.27,0.0,0.0,0.07,0.0,0.0,0.0,scott harris,,SPAN-1010,2016
+SPAN,1010,2,Elementary Spanish,0.5,0.25,0.19,0.0,0.0,0.0,0.0,0.06,scott harris,,SPAN-1010,2016
+SPAN,1010,3,Elementary Spanish,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2016
+SPAN,1020,1,Elementary Spanish,0.26,0.26,0.26,0.0,0.05,0.0,0.0,0.16,maureen zamora,,SPAN-1020,2016
+SPAN,1020,2,Elementary Spanish,0.35,0.29,0.12,0.12,0.0,0.0,0.0,0.12,maureen zamora,,SPAN-1020,2016
+SPAN,1020,3,Elementary Spanish,0.41,0.18,0.12,0.12,0.0,0.0,0.0,0.18,maureen zamora,,SPAN-1020,2016
+SPAN,1020,4,Elementary Spanish,0.29,0.41,0.06,0.0,0.0,0.0,0.0,0.24,maureen zamora,,SPAN-1020,2016
+SPAN,1020,5,Elementary Spanish,0.29,0.35,0.0,0.0,0.06,0.0,0.0,0.29,maureen zamora,,SPAN-1020,2016
+SPAN,1020,6,Elementary Spanish,0.44,0.25,0.19,0.0,0.06,0.0,0.0,0.06,cathy robison,,SPAN-1020,2016
+SPAN,1020,7,Elementary Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,cathy robison,,SPAN-1020,2016
+SPAN,1020,8,Elementary Spanish,0.29,0.29,0.24,0.06,0.0,0.0,0.0,0.12,ana paula  miller,,SPAN-1020,2016
+SPAN,1020,9,Elementary Spanish,0.31,0.19,0.19,0.13,0.06,0.0,0.0,0.13,ana paula  miller,,SPAN-1020,2016
+SPAN,1020,10,Elementary Spanish,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,debra oa williamson,,SPAN-1020,2016
+SPAN,1020,11,Elementary Spanish,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-1020,2016
+SPAN,1020,12,Elementary Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-1020,2016
+SPAN,1020,13,Elementary Spanish,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-1020,2016
+SPAN,2010,1,Intermediate Spanish,0.47,0.21,0.26,0.0,0.0,0.0,0.0,0.05,cathy robison,,SPAN-2010,2016
+SPAN,2010,2,Intermediate Spanish,0.24,0.59,0.12,0.06,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2016
+SPAN,2010,3,Intermediate Spanish,0.53,0.24,0.24,0.0,0.0,0.0,0.0,0.0,allison ann hinds,,SPAN-2010,2016
+SPAN,2010,4,Intermediate Spanish,0.53,0.24,0.12,0.06,0.06,0.0,0.0,0.0,allison ann hinds,,SPAN-2010,2016
+SPAN,2010,5,Intermediate Spanish,0.44,0.31,0.13,0.0,0.0,0.0,0.0,0.13,allison ann hinds,,SPAN-2010,2016
+SPAN,2010,6,Intermediate Spanish,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,heidi montes,,SPAN-2010,2016
+SPAN,2010,7,Intermediate Spanish,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,heidi montes,,SPAN-2010,2016
+SPAN,2010,8,Intermediate Spanish,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-2010,2016
+SPAN,2010,9,Intermediate Spanish,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-2010,2016
+SPAN,2010,10,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,,SPAN-2010,2016
+SPAN,2010,11,Intermediate Spanish,0.27,0.6,0.13,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-2010,2016
+SPAN,2010,12,Intermediate Spanish,0.59,0.18,0.12,0.0,0.0,0.0,0.0,0.12,debra oa williamson,,SPAN-2010,2016
+SPAN,2010,13,Intermediate Spanish,0.47,0.35,0.06,0.0,0.0,0.0,0.0,0.12,maureen zamora,,SPAN-2010,2016
+SPAN,2010,14,Intermediate Spanish,0.61,0.22,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,,SPAN-2010,2016
+SPAN,2010,15,Intermediate Spanish,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0, buitrago gonzalez,,SPAN-2010,2016
+SPAN,2010,16,Intermediate Spanish,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,,SPAN-2010,2016
+SPAN,2010,18,Intermediate Spanish,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,nora arostegu logue,,SPAN-2010,2016
+SPAN,2010,20,Intermediate Spanish (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,True,SPAN-2010,2016
+SPAN,2020,1,Intermediate Spanish,0.47,0.33,0.07,0.07,0.0,0.0,0.0,0.07,heidi montes,,SPAN-2020,2016
+SPAN,2020,2,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2016
+SPAN,2020,3,Intermediate Spanish,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2016
+SPAN,2020,4,Intermediate Spanish,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,heidi montes,,SPAN-2020,2016
+SPAN,2020,5,Intermediate Spanish,0.53,0.16,0.26,0.0,0.05,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2016
+SPAN,2020,6,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-2020,2016
+SPAN,2020,7,Intermediate Spanish,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-2020,2016
+SPAN,2020,8,Intermediate Spanish,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-2020,2016
+SPAN,2020,9,Intermediate Spanish,0.39,0.33,0.22,0.0,0.06,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2016
+SPAN,2020,10,Intermediate Spanish,0.5,0.33,0.11,0.06,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2016
+SPAN,2020,11,Intermediate Spanish,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2016
+SPAN,2020,12,Intermediate Spanish,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,ze cruz valderramos,,SPAN-2020,2016
+SPAN,2020,13,Intermediate Spanish,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2016
+SPAN,2020,14,Intermediate Spanish,0.56,0.28,0.11,0.0,0.0,0.0,0.0,0.06,kari daus carson,,SPAN-2020,2016
+SPAN,2020,15,Intermediate Spanish,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,kari daus carson,,SPAN-2020,2016
+SPAN,3050,1,Int Con Comp Span I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-3050,2016
+SPAN,3050,2,Int Con Comp Span I,0.47,0.4,0.07,0.0,0.0,0.0,0.0,0.07,melva margu persico,,SPAN-3050,2016
+SPAN,3050,3,Int Con Comp Span I,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,juana martin-armas,,SPAN-3050,2016
+SPAN,3050,4,Int Con Comp Span I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-3050,2016
+SPAN,3060,1,Span Comp for Bus,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,maureen zamora,,SPAN-3060,2016
+SPAN,3070,1,Hispanic World: Sp,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,salvador oropesa,,SPAN-3070,2016
+SPAN,3070,2,Hispanic World: Sp,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-3070,2016
+SPAN,3080,1,Hispanic World: La,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,george palacios,,SPAN-3080,2016
+SPAN,3130,1,Span Lit Survey I,0.32,0.16,0.0,0.0,0.05,0.0,0.0,0.47,mon rojas-de-massei,,SPAN-3130,2016
+SPAN,3130,2,Span Lit Survey I,0.43,0.07,0.21,0.07,0.0,0.0,0.0,0.21,mon rojas-de-massei,,SPAN-3130,2016
+SPAN,3140,1,Hispanic Linguistics,0.78,0.11,0.0,0.0,0.06,0.0,0.0,0.06,daniel smith,,SPAN-3140,2016
+SPAN,3180,1,Span Through Culture,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,,SPAN-3180,2016
+SPAN,4060,2,Narrative Fiction,0.44,0.19,0.38,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,,SPAN-4060,2016
+SPAN,4090,1,Comp Writ in Span,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,,SPAN-4090,2016
+SPAN,4160,1,Span Intl Trade II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-4160,2016
+SPAN,4210,1,Sp-Am Mod & Postmod,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-4210,2016
+SPAN,4220,1,Contem Span Am Novel,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,danie garcia vieyra,,SPAN-4220,2016
+STAT,2220,1,Statistics in Everyday Life,0.35,0.35,0.15,0.1,0.03,0.0,0.0,0.02,james espey,,STAT-2220,2016
+STAT,2220,2,Statistics in Everyday Life,0.41,0.42,0.14,0.03,0.0,0.0,0.0,0.0,james espey,,STAT-2220,2016
+STAT,2220,3,Statistics in Everyday Life,0.45,0.23,0.3,0.0,0.02,0.0,0.0,0.0,james espey,,STAT-2220,2016
+STAT,2220,4,Statistics in Everyday Life,0.37,0.33,0.13,0.14,0.02,0.0,0.0,0.03,james espey,,STAT-2220,2016
+STAT,2220,5,Statistics in Everyday Life,0.33,0.41,0.17,0.07,0.0,0.0,0.0,0.02,ros martinez-dawson,,STAT-2220,2016
+STAT,2220,6,Statistics in Everyday Life,0.4,0.36,0.1,0.08,0.03,0.0,0.0,0.02,ros martinez-dawson,,STAT-2220,2016
+STAT,2220,7,Statistics in Everyday Life,0.32,0.42,0.16,0.05,0.05,0.0,0.0,0.0,andrew walton green,,STAT-2220,2016
+STAT,2220,8,Statistics in Everyday Life,0.32,0.37,0.16,0.05,0.0,0.0,0.0,0.11,lauren reig lembcke,,STAT-2220,2016
+STAT,2300,1,Statistical Methods I,0.26,0.3,0.18,0.13,0.09,0.0,0.0,0.04,christy jenki brown,,STAT-2300,2016
+STAT,2300,2,Statistical Methods I,0.26,0.36,0.23,0.08,0.06,0.0,0.0,0.02,christy jenki brown,,STAT-2300,2016
+STAT,2300,3,Statistical Methods I,0.3,0.38,0.15,0.12,0.04,0.0,0.0,0.0,christy jenki brown,,STAT-2300,2016
+STAT,2300,4,Statistical Methods I,0.29,0.34,0.17,0.08,0.08,0.0,0.0,0.03, erwin walker,,STAT-2300,2016
+STAT,2300,5,Statistical Methods I,0.22,0.4,0.21,0.08,0.04,0.0,0.0,0.03, erwin walker,,STAT-2300,2016
+STAT,2300,6,Statistical Methods I,0.19,0.3,0.25,0.09,0.11,0.0,0.0,0.06,april thomas,,STAT-2300,2016
+STAT,2300,8,Statistical Methods I,0.17,0.25,0.29,0.11,0.12,0.0,0.0,0.07,april thomas,,STAT-2300,2016
+STAT,3090,1,Introductory Business Stats,0.16,0.32,0.21,0.11,0.05,0.0,0.0,0.16,yijun chen,,STAT-3090,2016
+STAT,3090,2,Introductory Business Stats,0.21,0.42,0.16,0.0,0.05,0.0,0.0,0.16, morales hernandez,,STAT-3090,2016
+STAT,3090,4,Introductory Business Stats,0.28,0.19,0.33,0.14,0.03,0.0,0.0,0.03,sharon marie evans,,STAT-3090,2016
+STAT,3090,5,Introductory Business Stats,0.38,0.41,0.18,0.0,0.0,0.0,0.0,0.03,jennifer van dyken,,STAT-3090,2016
+STAT,3090,6,Introductory Business Stats,0.17,0.26,0.29,0.17,0.09,0.0,0.0,0.03,sharon marie evans,,STAT-3090,2016
+STAT,3090,7,Introductory Business Stats,0.37,0.32,0.11,0.16,0.0,0.0,0.0,0.05,yijun chen,,STAT-3090,2016
+STAT,3090,8,Introductory Business Stats,0.39,0.17,0.33,0.0,0.11,0.0,0.0,0.0, morales hernandez,,STAT-3090,2016
+STAT,3090,9,Introductory Business Stats,0.14,0.34,0.26,0.09,0.11,0.0,0.0,0.06,sharon marie evans,,STAT-3090,2016
+STAT,3090,10,Introductory Business Stats,0.06,0.33,0.39,0.11,0.06,0.0,0.0,0.06,andrew pangia,,STAT-3090,2016
+STAT,3090,11,Introductory Business Stats,0.28,0.25,0.22,0.11,0.08,0.0,0.0,0.06,sharon marie evans,,STAT-3090,2016
+STAT,3090,12,Introductory Business Stats,0.0,0.41,0.18,0.29,0.12,0.0,0.0,0.0,mengcong ren,,STAT-3090,2016
+STAT,3090,13,Introductory Business Stats,0.05,0.26,0.21,0.21,0.11,0.0,0.0,0.16,andrew pangia,,STAT-3090,2016
+STAT,3090,14,Introductory Business Stats,0.16,0.05,0.32,0.16,0.05,0.0,0.0,0.26,rui gong,,STAT-3090,2016
+STAT,3090,15,Introductory Business Stats,0.06,0.17,0.33,0.22,0.22,0.0,0.0,0.0,mengcong ren,,STAT-3090,2016
+STAT,3090,16,Introductory Business Stats,0.24,0.18,0.29,0.12,0.18,0.0,0.0,0.0,rui gong,,STAT-3090,2016
+STAT,3090,17,Introductory Business Stats,0.16,0.21,0.32,0.05,0.16,0.0,0.0,0.11,kayla doris javier,,STAT-3090,2016
+STAT,3090,18,Introductory Business Stats,0.13,0.44,0.19,0.25,0.0,0.0,0.0,0.0,sanjog arv kulkarni,,STAT-3090,2016
+STAT,3090,19,Introductory Business Stats,0.21,0.37,0.26,0.05,0.05,0.0,0.0,0.05,jason alexande kurz,,STAT-3090,2016
+STAT,3090,20,Introductory Business Stats,0.26,0.37,0.26,0.06,0.06,0.0,0.0,0.0,ellen hepfe breazel,,STAT-3090,2016
+STAT,3090,21,Introductory Business Stats,0.16,0.26,0.37,0.11,0.05,0.0,0.0,0.05,kayla doris javier,,STAT-3090,2016
+STAT,3090,22,Introductory Business Stats,0.32,0.32,0.16,0.05,0.11,0.0,0.0,0.05,boyoung hur,,STAT-3090,2016
+STAT,3090,23,Introductory Business Stats,0.23,0.29,0.4,0.06,0.03,0.0,0.0,0.0,ellen hepfe breazel,,STAT-3090,2016
+STAT,3090,24,Introductory Business Stats,0.37,0.37,0.16,0.0,0.05,0.0,0.0,0.05,sanjog arv kulkarni,,STAT-3090,2016
+STAT,3090,25,Introductory Business Stats,0.22,0.33,0.33,0.06,0.06,0.0,0.0,0.0,tao yang,,STAT-3090,2016
+STAT,3090,26,Introductory Business Stats,0.16,0.47,0.32,0.0,0.0,0.0,0.0,0.05,dilhani marasinghe,,STAT-3090,2016
+STAT,3090,27,Introductory Business Stats,0.21,0.21,0.26,0.16,0.0,0.0,0.0,0.16,paul james cubre,,STAT-3090,2016
+STAT,3090,28,Introductory Business Stats,0.16,0.32,0.26,0.11,0.11,0.0,0.0,0.05,boyoung hur,,STAT-3090,2016
+STAT,3090,29,Introductory Business Stats,0.26,0.26,0.32,0.05,0.11,0.0,0.0,0.0,jayasekara merenchig,,STAT-3090,2016
+STAT,3090,30,Introductory Business Stats,0.32,0.26,0.11,0.0,0.26,0.0,0.0,0.05,paul james cubre,,STAT-3090,2016
+STAT,3090,31,Introductory Business Stats,0.32,0.26,0.11,0.05,0.16,0.0,0.0,0.11,tao yang,,STAT-3090,2016
+STAT,3090,32,Introductory Business Stats,0.42,0.16,0.26,0.0,0.05,0.0,0.0,0.11,jason alexande kurz,,STAT-3090,2016
+STAT,3090,33,Introductory Business Stats,0.16,0.53,0.21,0.05,0.0,0.0,0.0,0.05,jayasekara merenchig,,STAT-3090,2016
+STAT,3090,34,Introductory Business Stats,0.11,0.42,0.37,0.0,0.05,0.0,0.0,0.05,dilhani marasinghe,,STAT-3090,2016
+STAT,3300,1,Statistical Methods II,0.32,0.23,0.09,0.14,0.05,0.0,0.0,0.18,ros martinez-dawson,,STAT-3300,2016
+STAT,4020,1,Intro to Statistical Computing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-4020,2016
+STAT,4110,1,Stat Mthds for Process Control,0.82,0.16,0.0,0.0,0.03,0.0,0.0,0.0,richard stev dubsky,,STAT-4110,2016
+STAT,4110,2,Stat Mthds for Process Control,0.48,0.35,0.13,0.0,0.03,0.0,0.0,0.0,james rieck,,STAT-4110,2016
+STAT,4110,3,Stat Mthds for Process Control,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,,STAT-4110,2016
+STAT,6020,1,Intro to Statistical Computing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-6020,2016
+STAT,8010,1,Statistical Methods I,0.44,0.28,0.09,0.0,0.0,0.0,0.0,0.19,brook thaye russell,,STAT-8010,2016
+STAT,8010,2,Statistical Methods I,0.33,0.45,0.12,0.0,0.06,0.0,0.0,0.03,james rieck,,STAT-8010,2016
+STAT,8010,3,Statistical Methods I,0.49,0.29,0.11,0.0,0.09,0.0,0.0,0.03,jun luo,,STAT-8010,2016
+STAT,8010,4,Statistical Methods I,0.61,0.19,0.1,0.0,0.1,0.0,0.0,0.0,jun luo,,STAT-8010,2016
+STAT,8020,1,Statistical Methods II,0.61,0.36,0.0,0.0,0.0,0.0,0.0,0.04,william bridges,,STAT-8020,2016
+STS,1010,1,Survey of S T S,0.62,0.24,0.15,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,STS-1010,2016
+STS,1010,2,Survey of S T S,0.6,0.29,0.06,0.0,0.0,0.0,0.0,0.06,philip randall,,STS-1010,2016
+STS,1010,3,Survey of S T S,0.42,0.52,0.03,0.03,0.0,0.0,0.0,0.0,scott brame,,STS-1010,2016
+STS,1010,5,Survey of S T S,0.66,0.26,0.06,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,,STS-1010,2016
+STS,1010,6,Survey of S T S,0.33,0.39,0.19,0.06,0.03,0.0,0.0,0.0,allison ann hinds,,STS-1010,2016
+STS,1010,7,Survey of S T S,0.15,0.5,0.24,0.03,0.03,0.0,0.0,0.06,david charles foltz,,STS-1010,2016
+STS,1010,8,Survey of S T S,0.36,0.5,0.06,0.0,0.0,0.0,0.0,0.08,megan no macalystre,,STS-1010,2016
+STS,1010,9,Survey of S T S,0.6,0.29,0.06,0.03,0.03,0.0,0.0,0.0,sarah mae cooper,,STS-1010,2016
+STS,1010,10,Survey of S T S,0.8,0.14,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,,STS-1010,2016
+THEA,2100,1,Theatre Appreciation,0.94,0.0,0.03,0.0,0.03,0.0,0.0,0.0,richard st. peter,,THEA-2100,2016
+THEA,2100,2,Theatre Appreciation,0.84,0.03,0.06,0.0,0.06,0.0,0.0,0.0,kerrie kath seymour,,THEA-2100,2016
+THEA,2100,3,Theatre Appreciation,0.53,0.22,0.25,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-2100,2016
+THEA,2100,4,Theatre Appreciation,0.75,0.22,0.0,0.0,0.0,0.0,0.0,0.03,carol collins,,THEA-2100,2016
+THEA,2100,5,Theatre Appreciation,0.87,0.03,0.03,0.0,0.0,0.0,0.0,0.07,shannon ther robert,,THEA-2100,2016
+THEA,2100,6,Theatre Appreciation,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,,THEA-2100,2016
+THEA,2100,7,Theatre Appreciation,0.56,0.31,0.09,0.0,0.0,0.0,0.0,0.03,jason adkins,,THEA-2100,2016
+THEA,2780,1,Acting I,0.76,0.06,0.06,0.06,0.06,0.0,0.0,0.0,kerrie kath seymour,,THEA-2780,2016
+THEA,2790,1,Theatre Practicum,0.5,0.0,0.0,0.0,0.29,0.0,0.0,0.21,matthew leckenbusch,,THEA-2790,2016
+THEA,3170,1,African-Amer Thea I,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,kendra lyne johnson,,THEA-3170,2016
+THEA,4290,1,Dramatic Literature I,0.74,0.11,0.05,0.0,0.05,0.0,0.0,0.05,richard st. peter,,THEA-4290,2016
+THEA,4800,1,Advanced Scene Study,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,kerrie kath seymour,,THEA-4800,2016
+WFB,3000,1,Wildlife Biology,0.52,0.29,0.14,0.0,0.03,0.0,0.0,0.02,catherine jachowski,,WFB-3000,2016
+WFB,3000,2,Wildlife Biology,0.56,0.28,0.05,0.05,0.04,0.0,0.0,0.01,catherine jachowski,,WFB-3000,2016
+WFB,3010,2,Wildlife Biology Lab,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2016
+WFB,4100,2,Wildlife Management Techniques,0.1,0.44,0.4,0.04,0.0,0.0,0.0,0.02,james davis,,WFB-4100,2016
+WFB,4180,1,Fishery Conservation,0.67,0.19,0.1,0.0,0.05,0.0,0.0,0.0,yoichiro kanno,,WFB-4180,2016
+WFB,4440,1,Wildlife Damage Management,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,james davis,,WFB-4440,2016
+WFB,4930,1,Waterfowl Ecology & Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,,WFB-4930,2016
+WFB,4930,2,Plant & Flora ID/Systematics,0.46,0.41,0.11,0.02,0.0,0.0,0.0,0.0,patrick mcmillan,,WFB-4930,2016
+WS,1030,1,Women in Global Perspective,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,laura foxworth,,WS-1030,2016
+WS,1030,2,Women in Global Perspective,0.79,0.18,0.0,0.0,0.03,0.0,0.0,0.0,laura foxworth,,WS-1030,2016
+WS,2300,1,Women and Leadership,0.64,0.14,0.0,0.07,0.14,0.0,0.0,0.0,diane perpich,,WS-2300,2016
+WS,3010,1,Intro Women's Studies,0.63,0.17,0.06,0.03,0.03,0.0,0.0,0.09,elizabeth ros adams,,WS-3010,2016
+WS,3010,2,Intro Women's Studies,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,elizabeth ros adams,,WS-3010,2016
+WS,4900,1,Creative Inquiry,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,diane perpich,,WS-4900,2016
+YDP,3000,400,Youth Development in Society,0.82,0.06,0.06,0.0,0.0,0.0,0.0,0.06,barry garst,,YDP-3000,2016
+YDP,3050,400,Theory/Phil of Youth Dev Work,0.63,0.19,0.06,0.06,0.0,0.0,0.0,0.06,edmond patri bowers,,YDP-3050,2016
+YDP,3450,1,Creative Activities for Youth,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kimberly pe johnson,,YDP-3450,2016

--- a/bot/cogs/grades_cog/assets/2016_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2016_Spring.csv
@@ -1,2412 +1,2412 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1020,1,Survey of Art & Arch Hist II,0.91,0.07,0.01,0.0,0.0,0.0,0.0,0.01,andrea feeser,
-AAH,2060,1,Art History and Theory II,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,andrea feeser,
-AAH,6320,1,Twentieth Century Art II,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,beth ann lauritis,
-ACCT,2010,1,Financial Accounting Concepts,0.19,0.3,0.32,0.06,0.09,0.0,0.0,0.04,lydia lan schleifer,
-ACCT,2010,2,Financial Accounting Concepts,0.35,0.39,0.14,0.03,0.08,0.0,0.0,0.01,holly rhiannio hawk,
-ACCT,2010,3,Financial Accounting Concepts,0.19,0.24,0.21,0.14,0.1,0.0,0.0,0.12,philip maiberger,
-ACCT,2010,4,Financial Accounting Concepts,0.25,0.24,0.28,0.08,0.06,0.0,0.0,0.08,holly rhiannio hawk,
-ACCT,2010,5,Financial Accounting Concepts,0.3,0.3,0.25,0.05,0.05,0.0,0.0,0.05,lydia lan schleifer,
-ACCT,2010,6,Financial Accounting Concepts,0.26,0.26,0.24,0.05,0.07,0.0,0.0,0.12,lydia lan schleifer,
-ACCT,2010,7,Financial Accounting Concepts,0.11,0.25,0.25,0.07,0.21,0.0,0.0,0.12,tonya dionne smalls,
-ACCT,2010,8,Financial Accounting Concepts,0.35,0.3,0.09,0.07,0.05,0.0,0.0,0.14,mary ann  prater,
-ACCT,2010,9,Financial Accounting Concepts,0.15,0.27,0.31,0.07,0.02,0.0,0.0,0.18,henry anderson,
-ACCT,2010,10,Financial Accounting Concepts,0.27,0.32,0.02,0.07,0.05,0.0,0.0,0.27,mary ann  prater,
-ACCT,2010,11,Financial Accounting Concepts,0.11,0.11,0.32,0.11,0.25,0.0,0.0,0.09,henry anderson,
-ACCT,2010,12,Financial Accounting Concepts,0.14,0.37,0.19,0.11,0.14,0.0,0.0,0.05,tonya dionne smalls,
-ACCT,2010,401,Financial Accounting Concepts,0.14,0.43,0.24,0.08,0.04,0.0,0.0,0.07,jeffrey mcmillan,
-ACCT,2020,1,Managerial Accounting Concepts,0.26,0.34,0.17,0.08,0.06,0.0,0.0,0.09,henry anderson,
-ACCT,2020,2,Managerial Accounting Concepts,0.18,0.39,0.23,0.09,0.02,0.0,0.0,0.09,henry anderson,
-ACCT,2020,3,Managerial Accounting Concepts,0.37,0.24,0.18,0.06,0.08,0.0,0.0,0.06,jace garrett,
-ACCT,2020,4,Managerial Accounting Concepts,0.31,0.31,0.19,0.08,0.05,0.0,0.0,0.06,jace garrett,
-ACCT,2020,5,Managerial Accounting Concepts,0.32,0.29,0.19,0.14,0.0,0.0,0.0,0.07,derek dalton,
-ACCT,2020,401,Managerial Accounting Concepts,0.26,0.21,0.2,0.08,0.1,0.0,0.0,0.16,henry anderson,
-ACCT,3030,1,Cost Accounting,0.22,0.59,0.1,0.0,0.02,0.0,0.0,0.08,robin radtke,
-ACCT,3030,2,Cost Accounting,0.43,0.28,0.17,0.02,0.02,0.0,0.0,0.09,robin radtke,
-ACCT,3030,3,Cost Accounting,0.43,0.33,0.04,0.06,0.02,0.0,0.0,0.12,robin radtke,
-ACCT,3030,5,Cost Accounting,0.15,0.23,0.23,0.08,0.08,0.0,0.0,0.23,tonya dionne smalls,
-ACCT,3110,1,Intermediate Financial Acct I,0.38,0.46,0.08,0.03,0.03,0.0,0.0,0.03,terry daniel knause,
-ACCT,3110,2,Intermediate Financial Acct I,0.06,0.12,0.24,0.15,0.15,0.0,0.0,0.29,brian todd carver,
-ACCT,3110,3,Intermediate Financial Acct I,0.5,0.27,0.14,0.05,0.02,0.0,0.0,0.02,terry daniel knause,
-ACCT,3110,4,Intermediate Financial Acct I,0.28,0.37,0.22,0.02,0.04,0.02,0.0,0.04,terry daniel knause,
-ACCT,3110,5,Intermediate Financial Acct I,0.5,0.25,0.16,0.09,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3120,1,Intermediate Financial Acct II,0.16,0.32,0.26,0.18,0.08,0.0,0.0,0.0,the estate  guffey,
-ACCT,3120,2,Intermediate Financial Acct II,0.11,0.23,0.4,0.14,0.06,0.0,0.0,0.06,the estate  guffey,
-ACCT,3120,3,Intermediate Financial Acct II,0.03,0.18,0.44,0.21,0.13,0.0,0.0,0.03,brian todd carver,
-ACCT,3120,4,Intermediate Financial Acct II,0.03,0.17,0.33,0.23,0.17,0.0,0.0,0.07,brian todd carver,
-ACCT,3120,5,Intermediate Financial Acct II,0.24,0.36,0.31,0.04,0.05,0.0,0.0,0.0,jeremy micha vinson,
-ACCT,3130,1,Intermediate Fin Acct III,0.11,0.4,0.2,0.14,0.03,0.0,0.0,0.11, russell madray,
-ACCT,3130,2,Intermediate Fin Acct III,0.26,0.45,0.21,0.08,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3130,3,Intermediate Fin Acct III,0.38,0.38,0.19,0.03,0.03,0.0,0.0,0.0, russell madray,
-ACCT,3130,4,Intermediate Fin Acct III,0.33,0.36,0.26,0.05,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3220,1,Accounting Information Systems,0.1,0.41,0.29,0.07,0.05,0.0,0.0,0.07,philip maiberger,
-ACCT,3220,2,Accounting Information Systems,0.21,0.48,0.17,0.05,0.0,0.0,0.0,0.1,philip maiberger,
-ACCT,3220,3,Accounting Information Systems,0.14,0.25,0.25,0.07,0.0,0.0,0.0,0.29,philip maiberger,
-ACCT,4040,1,Individual Taxation,0.69,0.16,0.1,0.05,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,2,Individual Taxation,0.71,0.23,0.04,0.02,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.34,0.63,0.03,0.0,0.0,0.0,0.0,0.0,holly rhiannio hawk,
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,holly rhiannio hawk,
-ACCT,4150,1,Auditing,0.26,0.38,0.31,0.05,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,4150,2,Auditing,0.24,0.3,0.3,0.12,0.0,0.0,0.0,0.03,nancy lee harp,
-ACCT,8520,1,Fin Acct Theory/Res,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8520,2,Fin Acct Theory/Res,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8520,3,Fin Acct Theory/Res,0.2,0.63,0.17,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8540,1,Prof Responsibility,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8540,2,Prof Responsibility,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8540,3,Prof Responsibility,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8710,1,Corporate Taxation,0.16,0.76,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,2,Corporate Taxation,0.3,0.65,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,3,Corporate Taxation,0.31,0.67,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,
-AGED,1000,1,Orientation & Field Experience,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,philip fravel,
-AGED,2030,1,Teaching Agriscience,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,catheri dibenedetto,
-AGED,4160,1,Ethics and Issues,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,thomas dobbins,
-AGED,4250,1,Teaching Ag Mechs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGM,2050,1,Prin of Fabrication,0.12,0.53,0.22,0.08,0.02,0.0,0.0,0.03,hunter massey,
-AGM,2060,1,Machinery Mgt,0.08,0.32,0.41,0.08,0.05,0.0,0.0,0.05,hunter massey,
-AGM,2210,1,Land Measurements,0.17,0.52,0.26,0.0,0.04,0.0,0.0,0.0,charles privette,
-AGM,3030,1,Cal for Mech Ag,0.37,0.42,0.22,0.0,0.0,0.0,0.0,0.0,young han,
-AGM,4020,1,Landscape Drainage and Irrig,0.16,0.49,0.26,0.07,0.02,0.0,0.0,0.0,charles privette,
-AGM,4100,1,Precision Ag Tech,0.24,0.58,0.13,0.02,0.02,0.0,0.0,0.0,hunter massey,
-AGM,4520,1,Mobile Power,0.45,0.29,0.21,0.02,0.02,0.0,0.0,0.0,ali bulent koc,
-AGM,4720,1,Capstone,0.18,0.5,0.3,0.02,0.0,0.0,0.0,0.0,john chastain,
-AGRB,2020,1,Agricultural Economics,0.75,0.14,0.03,0.03,0.05,0.0,0.0,0.0,yuliya val bolotova,
-AGRB,2050,1,Agriculture and Society,0.46,0.34,0.16,0.02,0.0,0.0,0.0,0.02,lisha zhang,
-AGRB,3190,1,Agribusiness Management,0.3,0.3,0.24,0.14,0.02,0.0,0.0,0.0,michael vassalos,
-AGRB,3570,1,Natural Resources Economics,0.31,0.15,0.33,0.13,0.04,0.0,0.0,0.04,david brian willis,
-AGRB,4020,1,Production Economics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,michael vassalos,
-AGRB,4080,1,Quantitative Applied Economics,0.21,0.18,0.42,0.11,0.05,0.0,0.0,0.03,lisha zhang,
-AGRB,4520,1,Agricultural Policy,0.35,0.26,0.28,0.09,0.0,0.0,0.0,0.02,michael vassalos,
-AGRB,4560,1,Prices,0.47,0.38,0.16,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
-AL,3490,400,Principles of Coaching,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,401,Principles of Coaching,0.44,0.16,0.28,0.04,0.08,0.0,0.0,0.0,deborah cadorette,
-AL,3490,402,Principles of Coaching,0.72,0.2,0.04,0.04,0.0,0.0,0.0,0.0,julia wright,
-AL,3490,405,Principles of Coaching,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,edmond fry,
-AL,3500,400,Sci Basis I/Ex Phy,0.24,0.2,0.36,0.08,0.04,0.0,0.0,0.08,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.26,0.35,0.17,0.09,0.04,0.0,0.0,0.09,michael godfrey,
-AL,3520,400,Kinesiology,0.4,0.47,0.07,0.07,0.0,0.0,0.0,0.0,michael godfrey,
-AL,3530,400,Athletic Injuries,0.21,0.25,0.33,0.08,0.08,0.0,0.0,0.04,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.27,0.27,0.27,0.15,0.04,0.0,0.0,0.0,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.29,0.33,0.17,0.13,0.04,0.0,0.0,0.04,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.77,0.09,0.05,0.09,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,Admin/Org of Athletic Programs,0.72,0.12,0.16,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,403,Admin/Org of Athletic Programs,0.39,0.43,0.09,0.04,0.04,0.0,0.0,0.0,john plumblee,
-AL,3620,400,Psychology of Coaching,0.38,0.33,0.21,0.04,0.04,0.0,0.0,0.0,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.27,0.42,0.12,0.12,0.04,0.0,0.0,0.04,natalie anne carter,
-AL,3620,402,Psychology of Coaching,0.2,0.4,0.24,0.04,0.08,0.0,0.0,0.04,natalie anne carter,
-AL,3720,400,Coaching Basketball,0.62,0.15,0.12,0.08,0.0,0.0,0.0,0.04,edmond fry,
-AL,3740,400,Coaching Football,0.71,0.08,0.13,0.04,0.04,0.0,0.0,0.0,edmond fry,
-AL,3760,400,Coaching Strength/Conditioning,0.68,0.12,0.16,0.0,0.0,0.0,0.0,0.04,edmond fry,
-AL,4380,400,Coaching Women,0.52,0.33,0.05,0.1,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,4380,410,Coaching Rugby,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,deborah cadorette,
-AL,8530,400,Legal Iss in Intercoll Athlet,0.79,0.08,0.04,0.0,0.08,0.0,0.0,0.0,michael godfrey,
-ANTH,2010,1,Introduction to Anthropology,0.06,0.17,0.32,0.17,0.1,0.0,0.0,0.17,john coggeshall,
-ANTH,2010,2,Introduction to Anthropology,0.15,0.57,0.19,0.06,0.0,0.0,0.0,0.02,yi wu,
-ANTH,2010,3,Introduction to Anthropology,0.24,0.48,0.2,0.07,0.0,0.0,0.0,0.02,yi wu,
-ANTH,3200,1,North American Indian Cultures,0.13,0.38,0.25,0.0,0.06,0.0,0.0,0.19,john coggeshall,
-ANTH,3310,1,Archaeology,0.33,0.38,0.19,0.05,0.0,0.0,0.0,0.05,melissa vogel,
-ANTH,3510,1,Biological Anthropology,0.21,0.42,0.21,0.05,0.11,0.0,0.0,0.0,lisa rapaport,
-ANTH,3530,1,Forensic Anthropology,0.29,0.38,0.21,0.08,0.0,0.0,0.0,0.04,katherine weisensee,
-ANTH,4040,1,Anthropological Theories,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,john coggeshall,
-ANTH,4510,1,Biol Variation in Human Pop,0.47,0.21,0.16,0.0,0.0,0.0,0.0,0.16,katherine weisensee,
-ANTH,4660,1,Evolution of Human Behav,0.21,0.57,0.07,0.0,0.0,0.0,0.0,0.14,lisa rapaport,
-APEC,8220,1,Public Policy Econ,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,david brian willis,
-ARCH,1510,1,Arch Communication,0.33,0.27,0.07,0.07,0.13,0.0,0.0,0.13,sal hambright-belue,
-ARCH,1510,2,Arch Communication,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,robert silance,
-ARCH,1510,3,Arch Communication,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,1510,4,Arch Communication,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,ladan omidvar,
-ARCH,1510,5,Arch Communication,0.36,0.43,0.07,0.14,0.0,0.0,0.0,0.0,sal hambright-belue,
-ARCH,2520,1,Arch Foundations II,0.38,0.38,0.15,0.08,0.0,0.0,0.0,0.0,david lee,
-ARCH,2520,2,Arch Foundations II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,2520,3,Arch Foundations II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2520,4,Arch Foundations II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,james barker,
-ARCH,2520,5,Arch Foundations II,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,ladan omidvar,
-ARCH,2700,1,Structures I,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,robert john hogan,
-ARCH,2700,2,Structures I,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
-ARCH,3530,1,Studio Genoa,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4010,2,Architectural Portfolio,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,yixiao wang,
-ARCH,4520,1,Synthesis Studio,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,4520,2,Synthesis Studio,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,4520,3,Synthesis Studio,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,4520,4,Synthesis Studio,0.1,0.6,0.3,0.0,0.0,0.0,0.0,0.0,criss mills,
-ARCH,4710,1,Arch Hist of Place,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,james thomas,
-ARCH,4890,1,Internship,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,ashley jennings,
-ARCH,4990,13,Biomimicry and Biomimetics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,
-ARCH,6880,1,Arch Programming,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ARCH,8110,1,Visualization II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,8120,1,Comp Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,8200,1,Bldg Design & Constr,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-ARCH,8420,1,Arch Studio II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,
-ARCH,8420,2,Arch Studio II,0.67,0.0,0.33,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,8520,1,Design Studio IV,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,8520,3,Design Studio IV,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,8610,1,History/Theory II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,8620,1,History/Theory III,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,8740,1,Building Process:TR,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,8740,2,Building Process:TR,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,8820,1,Building Economics,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,8900,1,Directed Studies,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,anjali joseph,
-ARCH,8920,1,Comprehensive Studio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ARCH,8920,2,Comprehensive Studio,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,8920,3,Comprehensive Studio,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
-ARCH,8920,4,Comprehensive Studio,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8960,1,A+H Studio: Tectonic,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ART,1060,1,Foundation Drawing II,0.6,0.28,0.12,0.0,0.0,0.0,0.0,0.0,carly drew,
-ART,1520,1,Foundations Art II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
-ART,2050,1,Beginning Life Drawing,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,
-ART,2070,1,Beginning Painting,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,mary jane king,
-ART,2090,1,Beginning Sculpture,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabet cooke,
-ART,2100,400,Art Appreciation,0.54,0.32,0.07,0.04,0.0,0.0,0.0,0.04,lydia jane dorsey,
-ART,2100,401,Art Appreciation,0.45,0.24,0.1,0.0,0.0,0.0,0.0,0.21,lydia jane dorsey,
-ART,2100,402,Art Appreciation,0.57,0.36,0.04,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,
-ART,2100,403,Art Appreciation,0.29,0.5,0.14,0.04,0.0,0.0,0.0,0.04,lydia jane dorsey,
-ART,2110,1,Begin Printmaking,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,todd denni anderson,
-ART,2130,1,Begin Photography,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,gregory wi shelnutt,
-ART,2170,1,Beginning Ceramics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,en iwamura,
-ART,2210,1,Beginning New Media,0.8,0.0,0.13,0.0,0.07,0.0,0.0,0.0,christina nguy hung,
-ART,4750,1,Senior Exhibition Internship,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,
-AS,1100,1,Air Force Today II,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,christopher mann,
-AS,2100,2,Dev of Air Power II,0.5,0.2,0.3,0.0,0.0,0.0,0.0,0.0,christopher mann,
-AS,2100,3,Dev of Air Power II,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,
-ASL,1010,1,Am Sign Lang I,0.39,0.22,0.33,0.06,0.0,0.0,0.0,0.0,william alton brant,
-ASL,1010,2,Am Sign Lang I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,2010,1,Am Sign Lang II,0.43,0.36,0.21,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,2020,1,Am Sign Lang II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2020,2,Am Sign Lang II,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,kim ma misener dunn,
-ASL,3050,1,Deaf Studies,0.47,0.21,0.32,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASTR,1010,1,Solar System Astronomy,0.35,0.34,0.11,0.08,0.06,0.0,0.0,0.04,sean brittain,
-ASTR,1020,1,Stellar Astronomy,0.51,0.31,0.1,0.02,0.04,0.0,0.0,0.02,phillip flower,
-ASTR,1020,2,Stellar Astronomy,0.35,0.4,0.14,0.03,0.02,0.0,0.0,0.05,phillip flower,
-ASTR,1020,3,Stellar Astronomy,0.28,0.39,0.22,0.06,0.0,0.0,0.0,0.06,phillip flower,
-ASTR,1030,1,Solar Systm Astr Lab,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,mark leising,
-ASTR,1030,2,Solar Systm Astr Lab,0.69,0.19,0.0,0.04,0.04,0.0,0.0,0.04,mark leising,
-ASTR,1040,1,Stellar Astr Lab,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,mark leising,
-ASTR,1040,2,Stellar Astr Lab,0.43,0.35,0.04,0.04,0.0,0.0,0.0,0.13,mark leising,
-ASTR,1040,3,Stellar Astr Lab,0.74,0.13,0.04,0.0,0.04,0.0,0.0,0.04,mark leising,
-ASTR,1040,5,Stellar Astr Lab,0.23,0.32,0.14,0.14,0.14,0.0,0.0,0.05,mark leising,
-ASTR,1040,6,Stellar Astr Lab,0.0,0.54,0.23,0.08,0.08,0.0,0.0,0.08,mark leising,
-ASTR,3030,1,Galactic Astrophys,0.35,0.41,0.06,0.06,0.0,0.0,0.0,0.12,marco ajello,
-AUE,8160,1,Eng Combustion Emiss,0.74,0.24,0.0,0.0,0.0,0.0,0.0,0.02,robert prucka,
-AUE,8170,3,Alt Energy Sources,0.34,0.61,0.05,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8290,4,Tire Behavior,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8500,6,Stability/Safety Sys,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,beshah ayalew,
-AUE,8550,16,Auto Struct Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.52,0.33,0.03,0.0,0.09,0.0,0.0,0.03,michael mears,
-AUE,8770,9,Light-Weight Design,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,fadi kama abu-farha,
-AUE,8860,1,Noise Vibration,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,douglas feldmaier,
-AUE,8930,3,Applied Dynamics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8930,4,Mechanics of Composites Struct,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
-AUE,8930,14,Power Electronics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,simona onori,
-AUE,8930,15,Innov & Entrepreneurship,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,
-AVS,2000,1,Beef Cattle Tech,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,nathan long,
-AVS,2010,1,Poultry Techniques,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,2060,1,Swine Techniques,0.63,0.26,0.07,0.0,0.02,0.0,0.0,0.02,richelle lor miller,
-AVS,2090,1,Livestock Exhibition Technique,0.97,0.02,0.02,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3010,1,Anat & Phys Dom Ani,0.67,0.11,0.16,0.04,0.04,0.0,0.0,0.0,tiffany wilmoth,
-AVS,3100,1,Animal Health,0.42,0.35,0.11,0.03,0.02,0.0,0.0,0.08,thomas scott,
-AVS,3150,1,Animal Welfare,0.22,0.22,0.39,0.06,0.06,0.0,0.0,0.06,peter skewes,
-AVS,3700,1,Principles of Animal Nutrition,0.37,0.35,0.18,0.07,0.01,0.0,0.0,0.01,james ro strickland,
-AVS,3750,1,Applied Animal Nutrition,0.24,0.35,0.33,0.07,0.0,0.0,0.0,0.02,gustavo jos lascano,
-AVS,4000,1,AVS Professional Development,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
-AVS,4000,2,AVS Professional Development,0.77,0.15,0.0,0.08,0.0,0.0,0.0,0.0,johanna joh lascano,
-AVS,4060,2,Seminars & Related Topics,0.46,0.39,0.14,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4100,1,Domestic Ani Behav,0.18,0.5,0.26,0.03,0.02,0.0,0.0,0.01,peter skewes,
-AVS,4130,1,Animal Products,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,4140,1,Basic Immunology,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,thomas scott,
-AVS,4170,1,Animal Agribusiness Develpmnt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,4530,1,Animal Reproduction,0.46,0.36,0.12,0.02,0.02,0.0,0.0,0.02,glenn birrenkott,
-AVS,4530,400,Animal Reproduction,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
-BCHM,3010,1,Molecular Biochem,0.29,0.23,0.32,0.08,0.06,0.0,0.0,0.02,cheryl ingram-smith,
-BCHM,3010,2,Molecular Biochem(HON),0.48,0.29,0.16,0.03,0.0,0.0,0.0,0.03,kerry smith,True
-BCHM,3050,1,Essen Elements Bioch,0.37,0.35,0.1,0.06,0.04,0.0,0.0,0.07,srik chandrasekaran,
-BCHM,3050,2,Essen Elements Bioch,0.39,0.34,0.14,0.05,0.03,0.0,0.0,0.05,srik chandrasekaran,
-BCHM,4320,1,Bioch of Metabolism,0.63,0.15,0.12,0.02,0.02,0.0,0.0,0.05,kimberly paul,
-BCHM,4360,1,Genes to Proteins,0.5,0.33,0.1,0.0,0.05,0.0,0.0,0.02,michael glen sehorn,
-BCHM,4400,1,Bioinformatics,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,liangjiang wang,
-BCHM,4930,1,Senior Seminar,0.55,0.39,0.03,0.0,0.03,0.0,0.0,0.0,james morris,
-BE,2100,1,Intro to Biosystems Engr,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,yi zheng,
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.27,0.42,0.23,0.0,0.04,0.0,0.0,0.04,tom owino,
-BE,4120,1,Be Heat Mass Trans,0.52,0.3,0.04,0.0,0.09,0.0,0.0,0.04,caye marie drapcho,
-BE,4150,1,Instr & Control for Biosys Eng,0.67,0.17,0.08,0.04,0.0,0.0,0.0,0.04,yi zheng,
-BE,4380,1,Bioprocess Engineering Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,
-BE,4730,3,Thermodynamics,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,terry walker,
-BIOE,1010,1,Biol for Bioengr,0.51,0.31,0.1,0.02,0.01,0.0,0.0,0.05,vladimir vla reukov,
-BIOE,2010,1,Intro Biomed Engr,0.11,0.72,0.11,0.06,0.0,0.0,0.0,0.0,charles webb,
-BIOE,3020,1,Biomaterials,0.65,0.28,0.01,0.04,0.0,0.0,0.0,0.01,alexey ale vertegel,
-BIOE,3200,1,Biomechanics,0.61,0.26,0.09,0.02,0.0,0.0,0.0,0.02,jiro nagatomi,
-BIOE,3210,1,Biofluid Mechanics,0.47,0.36,0.05,0.05,0.03,0.0,0.0,0.04,sarah harcum,
-BIOE,3700,1,Bioinst & Imaging,0.58,0.4,0.01,0.0,0.0,0.0,0.0,0.0,delphine dean,
-BIOE,4010,1,Bioengineering Design Theory,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
-BIOE,4030,1,Applied Bio E Design,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4200,1,Sports Engineering,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
-BIOE,4230,1,Cardiovascular Engr and Path,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dan simionescu,
-BIOE,4310,1,Medical Imaging,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david kwartowitz,
-BIOE,4490,1,Drug Delivery,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,frank alexis,
-BIOE,6350,1,Modeling of Multiphysics Prob,0.46,0.46,0.0,0.0,0.0,0.0,0.0,0.08,guigen zhang,
-BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,martine laberge,
-BIOE,8020,410,Biocompatibility,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
-BIOE,8130,1,Industrial Bioengineering,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michael taylor,
-BIOE,8410,1,Drug Delivery,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,
-BIOE,8500,401,Toolkit - Cell & Molecular Bio,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ann catherine foley,
-BIOL,1040,1,General Biology II,0.27,0.34,0.22,0.1,0.03,0.0,0.0,0.05,nora espinoza,
-BIOL,1040,2,General Biology II,0.44,0.35,0.12,0.06,0.02,0.0,0.0,0.02,william surver,
-BIOL,1040,3,General Biology II,0.15,0.18,0.39,0.16,0.07,0.0,0.0,0.04,salvatore sparace,
-BIOL,1060,1,Gen Biology Lab II,0.09,0.27,0.36,0.09,0.18,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,2,Gen Biology Lab II,0.09,0.36,0.45,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,3,Gen Biology Lab II,0.27,0.27,0.27,0.09,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,4,Gen Biology Lab II,0.1,0.33,0.14,0.29,0.05,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,5,Gen Biology Lab II,0.14,0.19,0.29,0.19,0.1,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,6,Gen Biology Lab II,0.27,0.18,0.36,0.0,0.14,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,7,Gen Biology Lab II,0.05,0.3,0.2,0.2,0.15,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,8,Gen Biology Lab II,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,9,Gen Biology Lab II,0.11,0.37,0.26,0.16,0.11,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,10,Gen Biology Lab II,0.1,0.57,0.19,0.1,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,11,Gen Biology Lab II,0.23,0.55,0.14,0.09,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,12,Gen Biology Lab II,0.18,0.41,0.23,0.09,0.09,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,13,Gen Biology Lab II,0.18,0.32,0.23,0.09,0.09,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,14,Gen Biology Lab II,0.32,0.32,0.09,0.14,0.05,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,15,Gen Biology Lab II,0.09,0.18,0.36,0.18,0.14,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,16,Gen Biology Lab II,0.09,0.36,0.36,0.14,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,17,Gen Biology Lab II,0.13,0.3,0.3,0.09,0.17,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,18,Gen Biology Lab II,0.09,0.09,0.26,0.35,0.17,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,19,Gen Biology Lab II,0.23,0.18,0.45,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,20,Gen Biology Lab II,0.23,0.36,0.18,0.18,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,21,Gen Biology Lab II,0.14,0.23,0.41,0.05,0.18,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,22,Gen Biology Lab II,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,23,Gen Biology Lab II,0.09,0.27,0.36,0.14,0.14,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,24,Gen Biology Lab II,0.0,0.22,0.39,0.17,0.13,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,26,Gen Biology Lab II,0.18,0.09,0.32,0.27,0.09,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,27,Gen Biology Lab II,0.29,0.43,0.24,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,28,Gen Biology Lab II,0.23,0.32,0.18,0.27,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,29,Gen Biology Lab II,0.09,0.55,0.14,0.14,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,30,Gen Biology Lab II,0.05,0.45,0.32,0.05,0.09,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,31,Gen Biology Lab II,0.23,0.14,0.32,0.09,0.18,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,33,Gen Biology Lab II,0.04,0.33,0.25,0.17,0.17,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,34,Gen Biology Lab II,0.0,0.0,0.4,0.3,0.2,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1090,1,Intro to Life Sci,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
-BIOL,1110,1,Principles of Biology II,0.24,0.44,0.24,0.06,0.0,0.0,0.0,0.02,robert kosinski,
-BIOL,1110,2,Principles of Biology II,0.35,0.36,0.15,0.04,0.02,0.0,0.0,0.07,dylan dittrich-reed,
-BIOL,1200,1,Biological Inq Lab,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1200,2,Biological Inq Lab,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,
-BIOL,1200,3,Biological Inq Lab,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06, christine minor,
-BIOL,1200,5,Biological Inq Lab,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0, christine minor,
-BIOL,1200,6,Biological Inq Lab,0.4,0.4,0.07,0.0,0.07,0.0,0.0,0.07, christine minor,
-BIOL,1230,1,Keys to Human Biol,0.32,0.29,0.22,0.09,0.06,0.0,0.0,0.03, christine minor,
-BIOL,2000,2,Biology in the News,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,2000,3,Biology in the News,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
-BIOL,2000,6,Biology in the News,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,simon scott,
-BIOL,2000,7,Biology in the News,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,john michael henson,
-BIOL,2030,1,Human Disease & Soc,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02, christine minor,
-BIOL,2040,1,"Environ, Energy and Society",0.52,0.36,0.06,0.01,0.03,0.0,0.0,0.01,john jenkins hains,
-BIOL,2040,2,"Environ, Energy and Society",0.48,0.35,0.13,0.0,0.05,0.0,0.0,0.0,john jenkins hains,
-BIOL,2110,1,Introduction to Toxicology,0.45,0.48,0.03,0.0,0.0,0.0,0.0,0.03,peter van den hurk,
-BIOL,2230,1,Human Anat and Physiology II,0.32,0.35,0.17,0.08,0.05,0.0,0.0,0.02,john cummings,
-BIOL,2230,2,Human Anat and Physiology II,0.39,0.38,0.12,0.05,0.03,0.0,0.0,0.03,john cummings,
-BIOL,3020,1,Invertebrate Biology,0.11,0.21,0.37,0.18,0.08,0.0,0.0,0.05,juan baeza migueles,
-BIOL,3040,1,Biology of Plants,0.47,0.38,0.08,0.03,0.0,0.0,0.0,0.04,christina wells,
-BIOL,3060,1,Invertebrate Biology Lab,0.16,0.42,0.21,0.05,0.11,0.0,0.0,0.05,juan baeza migueles,
-BIOL,3060,3,Invertebrate Biology Lab,0.11,0.33,0.39,0.11,0.0,0.0,0.0,0.06,juan baeza migueles,
-BIOL,3080,1,Biology of Plants Practicum,0.24,0.47,0.12,0.0,0.06,0.0,0.0,0.12,christina wells,
-BIOL,3080,2,Biology of Plants Practicum,0.35,0.47,0.0,0.06,0.0,0.0,0.0,0.12,christina wells,
-BIOL,3080,3,Biology of Plants Practicum,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,christina wells,
-BIOL,3080,4,Biology of Plants Practicum,0.28,0.39,0.22,0.0,0.06,0.0,0.0,0.06,christina wells,
-BIOL,3130,1,Conservation Biology,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-BIOL,3130,2,Conservation Biology,0.47,0.21,0.16,0.05,0.11,0.0,0.0,0.0,shari lyn rodriguez,
-BIOL,3160,1,Human Physiology,0.35,0.39,0.21,0.03,0.0,0.0,0.0,0.02,tamara mcnutt-scott,
-BIOL,3350,1,Evolutionary Biology,0.37,0.4,0.17,0.02,0.01,0.0,0.0,0.02,michael sears,
-BIOL,3350,2,Evolutionary Biology (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,margaret ptacek,True
-BIOL,3510,1,Biological Anthropology,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,lisa rapaport,
-BIOL,3530,1,Forensic Anthropology,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
-BIOL,4010,1,Plant Physiology,0.09,0.28,0.3,0.21,0.07,0.0,0.0,0.05,douglas bielenberg,
-BIOL,4020,1,Plant Physiology Lab,0.11,0.28,0.33,0.17,0.06,0.0,0.0,0.06,douglas bielenberg,
-BIOL,4020,2,Plant Physiology Lab,0.63,0.13,0.19,0.0,0.06,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4100,1,Limnology,0.58,0.26,0.1,0.03,0.0,0.0,0.0,0.03,john jenkins hains,
-BIOL,4140,1,Basic Immunology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,
-BIOL,4340,1,Biological Chem Lab Techniques,0.0,0.27,0.27,0.27,0.13,0.0,0.0,0.07,salvatore sparace,
-BIOL,4340,2,Biological Chem Lab Techniques,0.13,0.44,0.38,0.0,0.0,0.0,0.0,0.06,salvatore sparace,
-BIOL,4340,3,Biological Chem Lab Techniques,0.0,0.46,0.38,0.15,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,4,Biological Chem Lab Techniques,0.29,0.43,0.07,0.0,0.07,0.0,0.0,0.14,salvatore sparace,
-BIOL,4610,1,Cell Biology,0.31,0.3,0.18,0.12,0.07,0.0,0.0,0.03,lisa bain,
-BIOL,4610,2,Cell Biology (HON),0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,lisa bain,True
-BIOL,4610,3,Cell Biology,0.25,0.3,0.29,0.05,0.03,0.0,0.0,0.07,zhicheng dou,
-BIOL,4620,1,Cell Biology Lab (Lec),0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,2,Cell Biology Lab (Lec),0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,3,Cell Biology Lab (Lec),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,4,Cell Biology Lab (Lec),0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.75,0.06,0.13,0.0,0.06,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,7,Cell Biology Lab (Lec),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,8,Cell Biology Lab (Lec),0.63,0.0,0.06,0.06,0.0,0.0,0.0,0.25,xianzhong yu,
-BIOL,4640,1,Mammalogy,0.48,0.29,0.1,0.1,0.05,0.0,0.0,0.0,john cummings,
-BIOL,4660,1,Evolution of Human Behavior,0.29,0.41,0.12,0.06,0.06,0.0,0.0,0.06,lisa rapaport,
-BIOL,4700,1,Behavioral Ecology,0.26,0.49,0.19,0.04,0.02,0.0,0.0,0.0,michael childress,
-BIOL,4700,2,Behavioral Ecology (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,True
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.62,0.24,0.05,0.05,0.0,0.0,0.0,0.05,michael childress,
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,michael childress,
-BIOL,4710,3,Behavioral Ecology Lab (Lec),0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,michael childress,
-BIOL,4710,4,Behavioral Ecology Lab (Lec),0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,michael childress,
-BIOL,4930,2,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
-BIOL,4930,4,Senior Seminar,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
-BIOL,4930,5,Senior Seminar,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4930,6,Senior Seminar,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,william baldwin,
-BIOL,4960,1,Biodiversity & Conserv in Asia,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
-BIOL,8430,1,Underst Genetics & Evol Biol,0.85,0.12,0.01,0.0,0.0,0.0,0.0,0.02,margaret ptacek,
-BIOL,8450,1,Understanding Animal Biology,0.86,0.12,0.01,0.0,0.0,0.0,0.0,0.01,matthew turnbull,
-BIOL,8470,1,Understanding Microbiology,0.63,0.28,0.07,0.0,0.01,0.0,0.0,0.01,harry kurtz,
-BIOL,8480,1,Understanding Scientific Rsrch,0.9,0.0,0.0,0.0,0.02,0.0,0.0,0.07,robert edwa ballard,
-BMOL,4250,1,Biomolecular Engineering,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,mark alan blenner,
-BUS,1010,1,Business Foundations,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,2,Business Foundations,0.22,0.52,0.19,0.04,0.0,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,3,Business Foundations,0.35,0.54,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,4,Business Foundations,0.27,0.54,0.12,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
-BUS,1010,5,Business Foundations,0.39,0.43,0.11,0.0,0.0,0.0,0.0,0.07,william ern tumblin,
-BUS,1010,6,Business Foundations,0.22,0.44,0.19,0.04,0.0,0.0,0.0,0.11,william ern tumblin,
-BUS,1010,7,Business Foundations,0.23,0.46,0.19,0.04,0.04,0.0,0.0,0.04,william ern tumblin,
-BUS,1010,8,Business Foundations,0.28,0.52,0.14,0.03,0.0,0.0,0.0,0.03,william ern tumblin,
-BUS,1010,9,Business Foundations,0.33,0.44,0.19,0.0,0.04,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,10,Business Foundations,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-CE,2010,1,Statics,0.66,0.11,0.18,0.0,0.02,0.0,0.0,0.02,sara khoshnevisan,
-CE,2010,2,Statics,0.19,0.35,0.19,0.03,0.08,0.0,0.0,0.16,melissa sternhagen,
-CE,2010,3,Statics,0.43,0.36,0.16,0.05,0.0,0.0,0.0,0.0,thomas edfo cousins,
-CE,2010,4,Statics,0.16,0.26,0.21,0.13,0.11,0.0,0.0,0.13,melissa sternhagen,
-CE,2010,5,Statics,0.53,0.35,0.05,0.0,0.03,0.0,0.0,0.03,mahmoodreza soltani,
-CE,2010,6,Statics,0.24,0.65,0.07,0.02,0.0,0.0,0.0,0.02, kent nilsson,
-CE,2010,7,Statics,0.27,0.38,0.1,0.06,0.02,0.0,0.0,0.17,thomas edfo cousins,
-CE,2060,1,Structural Mechanics,0.28,0.38,0.26,0.03,0.05,0.0,0.0,0.0,bryant nielson,
-CE,2060,2,Structural Mechanics,0.3,0.35,0.25,0.05,0.02,0.0,0.0,0.04,bryant nielson,
-CE,2080,1,Dynamics,0.12,0.42,0.22,0.02,0.08,0.0,0.0,0.14,melissa sternhagen,
-CE,2080,2,Dynamics,0.14,0.36,0.27,0.09,0.05,0.0,0.0,0.09,melissa sternhagen,
-CE,2080,3,Dynamics,0.28,0.38,0.2,0.08,0.0,0.0,0.0,0.08,thomas edfo cousins,
-CE,2550,1,Geomatics,0.32,0.45,0.14,0.0,0.07,0.0,0.0,0.02,wayne sarasua,
-CE,3010,1,Structural Analysis,0.27,0.27,0.3,0.03,0.09,0.0,0.0,0.03,stephen csernak,
-CE,3110,1,Transportation Engr,0.35,0.35,0.18,0.05,0.04,0.0,0.0,0.03,yongxi huang,
-CE,3210,1,Geotechnical Engineering,0.56,0.28,0.08,0.03,0.05,0.0,0.0,0.0,charng-hsein juang,
-CE,3210,2,Geotechnical Engineering,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,sara khoshnevisan,
-CE,3310,1,Constr Engr & Mgmnt,0.33,0.37,0.24,0.02,0.04,0.0,0.0,0.0,james burati,
-CE,3410,1,Intro to Fluid Mech,0.35,0.35,0.23,0.08,0.0,0.0,0.0,0.0,nigel gregory kaye,
-CE,3410,2,Intro to Fluid Mech,0.36,0.42,0.12,0.0,0.06,0.0,0.0,0.03,nigel gregory kaye,
-CE,3420,1,Hydraulics & Hydro,0.21,0.36,0.29,0.05,0.05,0.0,0.0,0.05,abdul khan,
-CE,3420,2,Hydraulics & Hydro,0.51,0.36,0.1,0.0,0.0,0.0,0.0,0.03,ashok mishra,
-CE,3510,1,Civil Engineering Materials,0.31,0.54,0.1,0.0,0.03,0.0,0.0,0.03,prasada rangaraju,
-CE,3520,1,Econ Eval of Proj,0.38,0.4,0.04,0.11,0.02,0.0,0.0,0.04,james burati,
-CE,3520,2,Econ Eval of Proj,0.58,0.25,0.13,0.03,0.0,0.0,0.0,0.03,bradley putman,
-CE,3530,1,Professional Seminar,0.95,0.03,0.02,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,
-CE,4020,1,Reinfor Con Design,0.5,0.3,0.1,0.04,0.03,0.0,0.0,0.03,brandon ross,
-CE,4080,1,Struct Loads & Sys,0.27,0.35,0.19,0.12,0.04,0.0,0.0,0.04,bryant nielson,
-CE,4110,1,Roadway Geo Design,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,jennifer ogle,
-CE,4120,1,Urban Transport Plan,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CE,4210,1,Geotechnical Design,0.28,0.42,0.23,0.02,0.02,0.0,0.0,0.02,nadara ravichandran,
-CE,4340,1,Const Est Proj Cont,0.73,0.21,0.04,0.0,0.01,0.0,0.0,0.0,kalyan ram piratla,
-CE,4360,1,Sustainable Constr,0.83,0.16,0.02,0.0,0.0,0.0,0.0,0.0,leidy klotz,
-CE,4590,1,Capstone Design Proj,0.48,0.46,0.04,0.03,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4910,1,Non-Destructive Evaluation,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,ami esmaeilpoursaee,
-CE,6080,1,Struct Loads & Sys,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,bryant nielson,
-CE,6340,1,Const Est Proj Cont,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,6360,1,Sustainable Constr,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,
-CE,6430,1,Water Resources Engr,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,abdul khan,
-CE,6910,1,Non-Destructive Evaluation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,
-CE,8010,1,Finite Ele Analysis,0.35,0.47,0.06,0.0,0.0,0.0,0.0,0.12,nadara ravichandran,
-CE,8280,1,Rep/Rehab of Con Str,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,prasada rangaraju,
-CE,8530,1,Apps in Traffic En,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,mashrur chowdhury,
-CE,8930,1,Selec Topics in CE - Hwy Bridg,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,
-CE,8930,2,Selec Topics in CE-Risk Assess,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CE,8930,4,Select Topics in CE - Poromech,0.56,0.22,0.0,0.0,0.11,0.0,0.0,0.11,qiushi chen,
-CE,8930,400,Selec Topics in CE-Human Fact,0.71,0.17,0.0,0.0,0.08,0.0,0.0,0.04,kap chalil madathil,
-CH,1010,1,General Chemistry,0.1,0.37,0.25,0.11,0.1,0.0,0.0,0.06,ava kreider-mueller,
-CH,1010,2,General Chemistry,0.23,0.27,0.23,0.15,0.09,0.0,0.0,0.05,ava kreider-mueller,
-CH,1010,3,General Chemistry,0.21,0.31,0.25,0.1,0.1,0.0,0.0,0.04,dennis taylor,
-CH,1010,4,General Chemistry,0.0,0.1,0.13,0.13,0.35,0.0,0.0,0.29,william joh wallace,
-CH,1010,400,General Chemistry,0.17,0.2,0.29,0.2,0.06,0.0,0.0,0.08,stephe schvaneveldt,
-CH,1020,1,General Chemistry,0.32,0.39,0.18,0.05,0.02,0.0,0.0,0.04,tania issa houjeiry,
-CH,1020,2,General Chemistry,0.26,0.42,0.2,0.06,0.02,0.0,0.0,0.04,dennis taylor,
-CH,1020,3,General Chemistry,0.27,0.39,0.23,0.05,0.02,0.0,0.0,0.04,dennis taylor,
-CH,1020,4,General Chemistry,0.02,0.15,0.28,0.17,0.13,0.0,0.0,0.26,william joh wallace,
-CH,1020,5,General Chemistry,0.05,0.35,0.1,0.1,0.3,0.0,0.0,0.1,william joh wallace,
-CH,1020,6,General Chemistry,0.23,0.4,0.22,0.06,0.02,0.0,0.0,0.08,olt geiculescu,
-CH,1020,7,General Chemistry,0.26,0.32,0.25,0.08,0.05,0.0,0.0,0.04,thomas hickman,
-CH,1020,8,General Chemistry,0.14,0.41,0.25,0.08,0.02,0.0,0.0,0.11,elliot ennis,
-CH,1020,9,General Chemistry,0.24,0.46,0.21,0.03,0.03,0.0,0.0,0.03,thomas hickman,
-CH,1020,10,General Chemistry,0.26,0.43,0.21,0.05,0.03,0.0,0.0,0.03,ava kreider-mueller,
-CH,1020,11,General Chemistry,0.16,0.26,0.37,0.0,0.05,0.0,0.0,0.16,christopher wilson,
-CH,1020,13,General Chemistry,0.53,0.37,0.0,0.11,0.0,0.0,0.0,0.0,edward collins,
-CH,1020,50,General Chemistry,0.38,0.19,0.38,0.0,0.0,0.0,0.0,0.05,shiou-jyh hwu,
-CH,1020,51,General Chemistry (HON),0.78,0.11,0.04,0.0,0.0,0.0,0.0,0.07,stephe schvaneveldt,True
-CH,1020,52,General Chemistry (HON),0.8,0.16,0.02,0.0,0.0,0.0,0.0,0.02,stephe schvaneveldt,True
-CH,1050,1,Chemistry in Context I,0.58,0.31,0.05,0.0,0.0,0.0,0.0,0.06,christopher wilson,
-CH,1060,1,Chemistry in Context II,0.42,0.33,0.14,0.08,0.0,0.0,0.0,0.03,olt geiculescu,
-CH,1060,2,Chemistry in Context II,0.38,0.31,0.23,0.08,0.0,0.0,0.0,0.0,olt geiculescu,
-CH,1520,1,Chem Commun I,0.81,0.05,0.05,0.0,0.03,0.0,0.0,0.05,richard marcus,
-CH,2010,1,Survey of Organic Chemistry,0.37,0.34,0.16,0.06,0.05,0.0,0.0,0.02,tania issa houjeiry,
-CH,2020,1,Surv of Organic Chemistry Lab,0.73,0.0,0.07,0.0,0.0,0.0,0.0,0.2,sean 'connor,
-CH,2020,2,Surv of Organic Chemistry Lab,0.5,0.28,0.06,0.0,0.06,0.0,0.0,0.11,sean 'connor,
-CH,2050,1,Intro Inorg Chem,0.44,0.28,0.25,0.0,0.0,0.0,0.0,0.03,william pennington,
-CH,2230,1,Organic Chemistry,0.21,0.32,0.25,0.09,0.05,0.0,0.0,0.07,jacob schroeder,
-CH,2230,2,Organic Chemistry,0.26,0.32,0.2,0.13,0.05,0.0,0.0,0.04,jacob schroeder,
-CH,2230,3,Organic Chemistry,0.13,0.38,0.22,0.13,0.08,0.0,0.0,0.05,jacob schroeder,
-CH,2240,1,Organic Chemistry,0.24,0.4,0.24,0.02,0.05,0.0,0.0,0.04,thomas hickman,
-CH,2240,2,Organic Chemistry,0.34,0.32,0.19,0.09,0.03,0.0,0.0,0.02,elliot ennis,
-CH,2240,3,Organic Chemistry,0.32,0.36,0.25,0.01,0.02,0.0,0.0,0.03,elliot ennis,
-CH,2240,4,Organic Chemistry,0.24,0.36,0.14,0.04,0.1,0.0,0.0,0.13,rhett smith,
-CH,2240,5,Organic Chemistry,0.13,0.23,0.35,0.06,0.03,0.0,0.0,0.19,dev priya arya,
-CH,2270,3,Organic Chem Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,4,Organic Chem Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,5,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,7,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,9,Organic Chem Lab,0.8,0.0,0.07,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,11,Organic Chem Lab,0.81,0.0,0.0,0.0,0.06,0.0,0.0,0.13,sean 'connor,
-CH,2270,12,Organic Chem Lab,0.63,0.31,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
-CH,2270,14,Organic Chem Lab,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,sean 'connor,
-CH,2280,3,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,4,Organic Chem Lab,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2280,6,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2280,11,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,15,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
-CH,2280,16,Organic Chem Lab,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,sean 'connor,
-CH,2280,17,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2280,20,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2280,26,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,
-CH,2280,27,Organic Chem Lab,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,sean 'connor,
-CH,2290,3,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,3310,1,Physical Chemistry,0.47,0.35,0.12,0.0,0.0,0.0,0.0,0.06,arkady kholodenko,
-CH,3320,1,Physical Chemistry,0.31,0.51,0.1,0.04,0.0,0.0,0.0,0.04,steven stuart,
-CH,3320,2,Physical Chemistry,0.39,0.21,0.32,0.05,0.03,0.0,0.0,0.0,jason mcneill,
-CH,3320,3,Physical Chemistry,0.58,0.17,0.13,0.04,0.08,0.0,0.0,0.0,leah bec casabianca,
-CH,3400,5,Physical Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,christopher wilson,
-CH,3600,1,Chemical Biology,0.38,0.36,0.16,0.02,0.02,0.0,0.0,0.07,modi wetzler,
-CH,4110,1,Instrumental Analy,0.26,0.39,0.13,0.09,0.13,0.0,0.0,0.0,george chumanov,
-CH,4120,1,Instr Analysis Lab,0.27,0.45,0.0,0.09,0.18,0.0,0.0,0.0,jeffrey natha anker,
-CH,4130,1,Chemistry of Aqueous Systems,0.43,0.4,0.17,0.0,0.0,0.0,0.0,0.0,cindy lee,
-CH,4250,1,Medicinal Chem,0.33,0.0,0.33,0.0,0.0,0.0,0.0,0.33,dev priya arya,
-CH,4500,1,Chemistry Capstone,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
-CH,6140,1,Bioanalytical Chem,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,carlos garcia perez,
-CH,8050,1,Theor Inorg Chem,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,joseph kolis,
-CH,8180,1,Surface Analysis,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,stephen creager,
-CH,8220,1,Organic Chem II,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,daniel whitehead,
-CH,8340,1,Stat Thermodynamics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,brian dominy,
-CH,8510,1,Grad Student Seminar,0.73,0.13,0.13,0.0,0.0,0.0,0.0,0.0,joseph stu thrasher,
-CHE,1300,1,Chemical Eng Tools,0.16,0.35,0.14,0.11,0.16,0.0,0.0,0.09,christopher norfolk,
-CHE,1300,2,Chemical Eng Tools,0.31,0.18,0.13,0.13,0.16,0.0,0.0,0.08,christopher norfolk,
-CHE,2200,2,Ch E Thermo I,0.18,0.21,0.37,0.06,0.15,0.0,0.0,0.03,joseph scott,
-CHE,2300,1,Fluids/Heat Transfer,0.1,0.33,0.34,0.13,0.07,0.0,0.0,0.03,douglas hirt,
-CHE,2300,2,Fluids/Heat Transfer,0.13,0.24,0.4,0.15,0.04,0.0,0.0,0.05,eric mikel davis,
-CHE,3210,1,Ch E Thermo II,0.13,0.23,0.4,0.18,0.03,0.0,0.0,0.03,sapna sarupria,
-CHE,3300,1,Mass Trans & Seprtn,0.18,0.24,0.35,0.14,0.05,0.0,0.0,0.05,mark thies,
-CHE,3530,1,Proc Dyn & Control,0.24,0.39,0.33,0.02,0.02,0.0,0.0,0.0,mark roberts,
-CHE,4330,1,Process Design II,0.6,0.23,0.17,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,8340,1,CHE Polymer Thermodynamics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark thies,
-CHIN,1010,1,Elementary Chinese,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yanlin wang,
-CHIN,1020,1,Elementary Chinese,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,yanlin wang,
-CHIN,2010,1,Intermediate Chinese,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
-CHIN,4010,1,Pre-Modern Chinese Literature,0.3,0.5,0.15,0.0,0.05,0.0,0.0,0.0,yanming an,
-COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,eddie smith,
-COM,1500,1,Intro to Human Communication,0.81,0.16,0.01,0.0,0.0,0.0,0.0,0.02,eddie smith,
-COM,1500,2,Intro to Human Communication,0.57,0.33,0.05,0.02,0.01,0.0,0.0,0.02,daniel lelan fecher,
-COM,1500,3,Intro to Human Communication,0.82,0.13,0.03,0.0,0.0,0.0,0.0,0.03,eddie smith,
-COM,1500,4,Intro to Human Communication,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
-COM,1500,5,Intro to Human Communication,0.65,0.26,0.04,0.01,0.03,0.0,0.0,0.01,marianne her glaser,
-COM,1500,6,Intro to Human Communication,0.5,0.38,0.05,0.01,0.01,0.0,0.0,0.05,daniel lelan fecher,
-COM,2010,1,Intr to Comm Studies,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,2010,2,Intr to Comm Studies,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,darren linvill,
-COM,2500,1,Public Speaking,0.62,0.24,0.14,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,2,Public Speaking,0.52,0.29,0.1,0.1,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,3,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,2500,4,Public Speaking,0.33,0.38,0.24,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,5,Public Speaking,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,6,Public Speaking,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,7,Public Speaking,0.19,0.57,0.14,0.0,0.0,0.0,0.0,0.1,marilyn denise pugh,
-COM,2500,8,Public Speaking,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,
-COM,2500,9,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,10,Public Speaking,0.76,0.05,0.05,0.05,0.1,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,11,Public Speaking,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,12,Public Speaking,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,13,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,14,Public Speaking,0.62,0.19,0.05,0.05,0.0,0.0,0.0,0.1,vanessa anne condon,
-COM,2500,15,Public Speaking,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,16,Public Speaking,0.37,0.32,0.16,0.0,0.05,0.0,0.0,0.11,pauline matthey,
-COM,2500,17,Public Speaking,0.5,0.35,0.05,0.05,0.0,0.0,0.0,0.05,the estate  geddes,
-COM,2500,18,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,19,Public Speaking,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
-COM,2500,20,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,21,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,22,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,23,Public Speaking,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,25,Public Speaking,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
-COM,2500,26,Public Speaking (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,True
-COM,2500,27,Public Speaking (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,True
-COM,2500,29,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,400,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,401,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,402,Public Speaking,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,alexis zachar davis,
-COM,2500,403,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,500,Public Speaking,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
-COM,3010,1,Comm Theory,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,pauline matthey,
-COM,3020,1,Mass Comm Theory,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,karyn jones,
-COM,3050,1,Persuasion,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,karyn jones,
-COM,3060,1,Discourse & Society,0.4,0.44,0.16,0.0,0.0,0.0,0.0,0.0,david travers scott,
-COM,3100,1,Quant Comm Methods,0.64,0.28,0.0,0.0,0.08,0.0,0.0,0.0,john steven spinda,
-COM,3200,1,Bdcst Production,0.67,0.1,0.1,0.05,0.0,0.0,0.0,0.1,wanda johnson,
-COM,3250,1,Survey of Sports Communication,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3250,2,Survey of Sports Communication,0.83,0.08,0.0,0.0,0.04,0.0,0.0,0.04,angela pratt,
-COM,3300,1,Nonverbal Comm,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,joseph mazer,
-COM,3480,1,Interpersonal Comm,0.43,0.43,0.1,0.0,0.05,0.0,0.0,0.0,melinda ra weathers,
-COM,3560,1,Stakeholder Comm,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3610,1,Argue and Debate,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
-COM,3660,2,EC: Brand Comm & Strategy,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,roger beasley,
-COM,3690,1,Political Comm,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,erin michelle ash,
-COM,3690,2,Political Comm,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3720,1,Digital Analytics in Brand Com,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,alicia ni littleton,
-COM,3730,1,Media Management in Brand Comm,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,william reynolds,
-COM,4040,1,Media Comm & Social Identities,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,chenjerai kumanyika,
-COM,4040,2,Media Comm & Social Identities,0.47,0.2,0.27,0.07,0.0,0.0,0.0,0.0,chenjerai kumanyika,
-COM,4260,1,Social Media and Sports Comm,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,john steven spinda,
-COM,4310,1,Legal Communication Trial,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
-COM,4700,1,Comm & Health,0.29,0.65,0.0,0.06,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,4950,1,Senior Capstone,0.9,0.07,0.0,0.0,0.03,0.0,0.0,0.0,erin michelle ash,
-COM,4980,1,Acad & Prof Dev II,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,joseph mazer,
-COM,8020,1,Communication Theory II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,chenjerai kumanyika,
-COM,8110,1,Comm Research Methods II,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-CPSC,1010,1,Computer Science I,0.24,0.32,0.18,0.12,0.09,0.0,0.0,0.06,catherine hochrine,
-CPSC,1010,2,Computer Science I,0.39,0.13,0.18,0.11,0.11,0.0,0.0,0.08,catherine hochrine,
-CPSC,1010,3,Computer Science I,0.33,0.13,0.24,0.13,0.07,0.0,0.0,0.11,yvon feaster,
-CPSC,1020,1,Computer Science II,0.53,0.3,0.06,0.02,0.04,0.0,0.0,0.04,yvon feaster,
-CPSC,1020,2,Computer Science II,0.31,0.48,0.21,0.0,0.0,0.0,0.0,0.0,lanny sitanayah,
-CPSC,1020,3,Computer Science II,0.32,0.32,0.27,0.07,0.02,0.0,0.0,0.0,christopher plaue,
-CPSC,1110,1,Intro to Programming in C,0.54,0.16,0.11,0.03,0.08,0.0,0.0,0.08,catherine hochrine,
-CPSC,1110,2,Intro to Programming in C,0.78,0.07,0.04,0.0,0.04,0.0,0.0,0.07,wanda moses,
-CPSC,1110,3,Intro to Programming in C,0.68,0.14,0.09,0.0,0.05,0.0,0.0,0.05,wanda moses,
-CPSC,2070,1,Discrete Structures,0.14,0.38,0.31,0.1,0.03,0.0,0.0,0.03,sandra hedetniemi,
-CPSC,2070,401,Discrete Structures,0.43,0.3,0.22,0.0,0.01,0.0,0.0,0.04,larry hodges,
-CPSC,2100,1,Progrmng Methodology,0.43,0.23,0.17,0.07,0.0,0.0,0.0,0.1,rose lowe,
-CPSC,2120,1,Algs/Data Structures,0.36,0.28,0.24,0.07,0.04,0.0,0.0,0.01,wayne goddard,
-CPSC,2150,1,Software Dev,0.24,0.25,0.27,0.12,0.07,0.0,0.0,0.05,blair madiso durkee,
-CPSC,2150,2,Software Dev Foundations,0.66,0.26,0.05,0.0,0.02,0.0,0.0,0.02,joseph isaac,
-CPSC,2200,1,Microcomputer Appl,0.42,0.21,0.21,0.11,0.05,0.0,0.0,0.0,renee lambert,
-CPSC,2200,2,Microcomputer Appl,0.45,0.3,0.05,0.1,0.0,0.0,0.0,0.1,renee lambert,
-CPSC,2310,1,Intro Computer Org,0.44,0.26,0.21,0.07,0.02,0.0,0.0,0.0,rose lowe,
-CPSC,2310,2,Intro Computer Org,0.41,0.24,0.12,0.15,0.07,0.0,0.0,0.0,rose lowe,
-CPSC,2910,1,Prof Issues I,0.86,0.07,0.0,0.07,0.0,0.0,0.0,0.0,renee lambert,
-CPSC,2910,2,Prof Issues I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,renee lambert,
-CPSC,2910,3,Prof Issues I,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,renee lambert,
-CPSC,2910,4,Prof Issues I,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,james jones,
-CPSC,3220,1,Intro to Operating Systems,0.18,0.28,0.21,0.07,0.08,0.0,0.0,0.18,jacob sorber,
-CPSC,3300,1,Computer Systems Org,0.2,0.32,0.33,0.09,0.04,0.0,0.0,0.01,mark smotherman,
-CPSC,3500,1,Foundations of Computer Sci,0.15,0.2,0.48,0.03,0.06,0.0,0.0,0.08,ilya mark safro,
-CPSC,3520,1,Programming Systems,0.42,0.32,0.16,0.0,0.04,0.0,0.0,0.06,robert schalkoff,
-CPSC,3600,1,Network Programming,0.07,0.3,0.29,0.06,0.07,0.0,0.0,0.2,sekou lionel remy,
-CPSC,3620,1,Distributed/Cluster Computing,0.15,0.37,0.42,0.0,0.04,0.0,0.0,0.01,amy apon,
-CPSC,3720,1,Software Engineering,0.39,0.28,0.21,0.04,0.02,0.0,0.0,0.07,stephen schaub,
-CPSC,3990,3,Advanced CI: Extreme Orange,0.59,0.24,0.12,0.0,0.0,0.0,0.0,0.06,james martin,
-CPSC,4050,1,Computer Graphics,0.26,0.26,0.22,0.0,0.19,0.0,0.0,0.07,jerry tessendorf,
-CPSC,4140,1,Human and Computer Interaction,0.41,0.34,0.1,0.0,0.07,0.0,0.0,0.07,sabarish venka babu,
-CPSC,4140,2,Human and Computer Interaction,0.14,0.78,0.03,0.0,0.03,0.0,0.0,0.03,kelly caine,
-CPSC,4160,1,2-D Game Engine Construction,0.24,0.34,0.22,0.07,0.1,0.0,0.0,0.02,brian malloy,
-CPSC,4240,1,System Admin and Security,0.11,0.51,0.26,0.09,0.0,0.0,0.0,0.03,james martin,
-CPSC,4620,1,Database Management Systems,0.24,0.6,0.12,0.0,0.04,0.0,0.0,0.0,zijun wang,
-CPSC,4820,1,Selected Topics: Android Dev,0.56,0.25,0.0,0.0,0.0,0.0,0.0,0.19,roy pargas,
-CPSC,4820,2,Special Topics: Data Science,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,
-CPSC,4910,1,Professional Issues II,0.9,0.02,0.05,0.0,0.02,0.0,0.0,0.02,james jones,
-CPSC,6050,1,Computer Graphics,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,robert geist,
-CPSC,6140,1,Human and Computer Interaction,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
-CPSC,6140,2,Human and Computer Interaction,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
-CPSC,6160,1,2-D Game Engine Construction,0.43,0.35,0.09,0.0,0.0,0.0,0.0,0.13,brian malloy,
-CPSC,6240,1,System Admin and Security,0.31,0.44,0.19,0.0,0.0,0.0,0.0,0.06,james martin,
-CPSC,6550,1,Computational Science,0.5,0.19,0.25,0.0,0.0,0.0,0.0,0.06,xizhou feng,
-CPSC,6620,1,Database Management Systems,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,zijun wang,
-CPSC,6820,1,Selected Topics: Android Dev,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,roy pargas,
-CPSC,6820,2,Special Topics: Data Science,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,
-CPSC,8110,1,Character Animation,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,christina sop joerg,
-CPSC,8220,1,Case Study in Operating Sys,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,
-CPSC,8280,1,Theory of Program. Languages,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,murali sitaraman,
-CPSC,8400,1,Design & Anlys of Algorithms,0.19,0.34,0.34,0.0,0.08,0.0,0.0,0.06,brian christop dean,
-CPSC,8620,1,Database Mngmt System Design,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,
-CPSC,8650,1,Data Mining,0.33,0.46,0.17,0.0,0.0,0.0,0.0,0.04,zijun wang,
-CPSC,8750,1,Software Architectur,0.71,0.2,0.06,0.0,0.0,0.0,0.0,0.02,john mcgregor,
-CRP,8020,1,Site Planning,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,clifford dona ellis,
-CRP,8040,1,Land Use Analysis,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,stephen sperry,
-CRP,8050,1,Plning Theory & Hist,0.48,0.38,0.05,0.0,0.1,0.0,0.0,0.0,mickey lauria,
-CRP,8090,1,Current Issues,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,barry nocks,
-CRP,8130,1,Transportation Plan,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,eric morris,
-CRP,8200,1,Negotiation,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
-CRP,8220,1,Urban Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-CRP,8890,3,Sel Top-Geodesign w/ City Eng,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
-CRP,8900,3,Dir Studies in City & Reg Plan,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,clifford dona ellis,
-CRP,8900,8,Dir Studies in City & Reg Plan,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,stephen sperry,
-CSM,1500,1,Constr Prob Solving,0.52,0.35,0.09,0.0,0.0,0.0,0.0,0.04,jason lucas,
-CSM,1500,2,Constr Prob Solving,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,1500,3,Constr Prob Solving,0.48,0.39,0.13,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,2020,1,Structures II,0.32,0.32,0.19,0.16,0.0,0.0,0.0,0.0,shima clarke,
-CSM,2020,2,Structures II,0.31,0.34,0.21,0.14,0.0,0.0,0.0,0.0,shima clarke,
-CSM,2040,1,Cont Documents,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2040,2,Cont Documents,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2050,1,Mats & Methods II,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,2050,2,Mats & Methods II,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.0,joseph wintz,
-CSM,3050,1,Envir Systems II,0.33,0.42,0.17,0.04,0.0,0.04,0.0,0.0,joseph mich burgett,
-CSM,3050,2,Envir Systems II,0.17,0.63,0.21,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3520,1,Const Scheduling,0.36,0.29,0.18,0.04,0.0,0.14,0.0,0.0,dennis bausman,
-CSM,3520,2,Const Scheduling,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,3530,1,Const Estimating II,0.12,0.69,0.19,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,3530,2,Const Estimating II,0.09,0.73,0.14,0.05,0.0,0.0,0.0,0.0,christine piper,
-CSM,4540,1,Const Capstone,0.43,0.39,0.17,0.0,0.0,0.0,0.0,0.0,james packer smith,
-CSM,4540,2,Const Capstone,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,james packer smith,
-CSM,8620,1,Personnel Mgt & Neg,0.0,0.72,0.28,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CSM,8620,400,Personnel Mgt & Neg,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.65,0.33,0.03,susan whorton,
-CU,1010,1,Univ Success Skills,0.37,0.33,0.1,0.03,0.1,0.0,0.0,0.07,emma reynol reabold,
-CU,1010,2,Univ Success Skills,0.61,0.23,0.03,0.03,0.03,0.0,0.0,0.06,mary mcp von kaenel,
-CU,1010,3,Univ Success Skills,0.43,0.3,0.1,0.07,0.03,0.0,0.0,0.07,cari allyn brooks,
-CU,1010,6,Univ Success Skills,0.32,0.25,0.07,0.04,0.21,0.0,0.0,0.11,ashley crisp,
-CU,1400,1,The Entrepreneurial Mindset,0.46,0.39,0.07,0.0,0.06,0.0,0.0,0.01,john michael hannon,
-CU,1410,1,"Creativity, Innovation & Entr",0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
-CU,1970,1,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.91,0.05,0.05,laurel ann whisler,
-CU,2010,1,Sustainability Leadership,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,jennifer marg goree,
-DANC,1300,1,Tap Dance I,0.75,0.1,0.05,0.0,0.0,0.0,0.0,0.1,cheryl hosler,
-DANC,1400,1,Jazz Dance I,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,cheryl hosler,
-DPA,4010,1,Tech Foundations II,0.09,0.09,0.09,0.27,0.18,0.0,0.0,0.27,donald henry house,
-DPA,4030,1,Vis Foundations II,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,david stewart donar,
-DPA,4030,2,Vis Foundations II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
-ECE,2010,1,Logic and Computing Devices,0.31,0.24,0.17,0.15,0.07,0.0,0.0,0.06,lin zhu,
-ECE,2020,1,Electric Circuits I,0.22,0.26,0.22,0.15,0.09,0.0,0.0,0.06,william harrell,
-ECE,2070,1,Basic Electrical Engineering,0.44,0.3,0.11,0.07,0.04,0.0,0.0,0.03,william th kolodzey,
-ECE,2070,2,Basic Electrical Engineering,0.41,0.37,0.17,0.04,0.0,0.0,0.0,0.01,amir ahmed asif,
-ECE,2070,3,Basic Electrical Engineering,0.17,0.41,0.27,0.03,0.07,0.0,0.0,0.06,hai xiao,
-ECE,2080,2,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,3,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
-ECE,2080,6,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,7,Basic Electrical Engr Lab,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,8,Basic Electrical Engr Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,9,Basic Electrical Engr Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,11,Basic Electrical Engr Lab,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,12,Basic Electrical Engr Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,13,Basic Electrical Engr Lab,0.89,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,20,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2110,1,Elec Engr Lab I,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,apoorva dee kapadia,
-ECE,2110,2,Elec Engr Lab I,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2220,1,Syst Prog Concept,0.29,0.37,0.14,0.04,0.06,0.0,0.0,0.1,william reid,
-ECE,2230,1,Comp Sys Eng,0.14,0.21,0.29,0.11,0.11,0.0,0.0,0.14,harlan russell,
-ECE,2620,1,Electric Circuits II,0.38,0.32,0.22,0.03,0.02,0.0,0.0,0.03,richard groff,
-ECE,2720,1,Comp Organization,0.26,0.4,0.27,0.03,0.03,0.0,0.0,0.02,william reid,
-ECE,2730,1,Computer Org Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2730,2,Computer Org Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2730,6,Computer Org Lab,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
-ECE,2730,8,Computer Org Lab,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2730,9,Computer Org Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,3,Electrical Engineering Lab III,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,4,Electrical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,5,Electrical Engineering Lab III,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3170,1,Rand Signal Analysis,0.15,0.23,0.36,0.12,0.07,0.0,0.0,0.06,stephen hubbard,
-ECE,3200,1,Electronics I,0.16,0.2,0.25,0.19,0.16,0.0,0.0,0.04,stephen hubbard,
-ECE,3210,1,Electronics II,0.35,0.37,0.12,0.1,0.04,0.0,0.0,0.02,stephen hubbard,
-ECE,3220,1,Intro Operating Sys,0.11,0.26,0.3,0.04,0.0,0.0,0.0,0.3,jacob sorber,
-ECE,3270,1,Dig Comp Design,0.09,0.34,0.25,0.13,0.13,0.0,0.0,0.06,melissa crawl smith,
-ECE,3300,1,Signals & Systems,0.17,0.16,0.31,0.19,0.08,0.0,0.0,0.09,carl baum,
-ECE,3520,1,Programming Systems,0.4,0.44,0.12,0.0,0.0,0.0,0.0,0.04,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.36,0.31,0.19,0.06,0.08,0.0,0.0,0.0,edward collins,
-ECE,3710,1,Microcontr Interface,0.4,0.31,0.1,0.09,0.07,0.0,0.0,0.03,william reid,
-ECE,3720,3,Micro Int Lab,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,5,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,7,Micro Int Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3800,1,Electromagnetics,0.11,0.22,0.4,0.13,0.11,0.0,0.0,0.03,anthony martin,
-ECE,3810,1,Field Waves & Ckts,0.32,0.32,0.3,0.05,0.02,0.0,0.0,0.0,eric gordon johnson,
-ECE,4090,1,Intr to Linear Control Systems,0.63,0.24,0.06,0.02,0.02,0.0,0.0,0.02,apoorva dee kapadia,
-ECE,4190,1,Elec Mach and Drives,0.38,0.27,0.27,0.04,0.0,0.0,0.0,0.04,keith corzine,
-ECE,4200,1,Renewable Energy,0.28,0.23,0.23,0.1,0.03,0.0,0.0,0.13,elham makram,
-ECE,4270,1,Communications Sys,0.38,0.21,0.15,0.13,0.09,0.0,0.0,0.04,madhabi manandhar,
-ECE,4380,1,Computer Commun,0.29,0.27,0.29,0.05,0.05,0.0,0.0,0.05,harlan russell,
-ECE,4400,1,Local Computer Nets,0.22,0.57,0.16,0.0,0.0,0.0,0.0,0.05,kuang-ching wang,
-ECE,4460,1,Antennas,0.58,0.25,0.08,0.08,0.0,0.0,0.0,0.0,anthony martin,
-ECE,4680,1,Embedded Computing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,
-ECE,4950,1,Int Sys Design I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4960,1,Int Sys Design II,0.56,0.3,0.13,0.0,0.0,0.0,0.0,0.01,richard groff,
-ECE,4990,14,Creative Inq-Elec & Comp Engr,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,
-ECE,6320,1,Instrumentation,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,goutam koley,
-ECE,6370,1,Microelectromechanical Systems,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,pingshan wang,
-ECE,6380,1,Computer Commun,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
-ECE,6400,1,Local Computer Nets,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,kuang-ching wang,
-ECE,6680,1,Embedded Computing,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,adam hoover,
-ECE,8400,1,Semicond Devices,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,william harrell,
-ECE,8570,1,Coding Theory,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,
-ECE,8630,1,Pwr Sys Dyna & Stab,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,ramtin hadidi,
-ECE,8720,1,Artificial Neurl Net,0.52,0.38,0.05,0.0,0.0,0.0,0.0,0.05,robert schalkoff,
-ECE,8740,1,Adv Nonlinear Cntrl,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,
-ECE,8790,1,FPGA Design & Applications,0.17,0.17,0.57,0.0,0.04,0.0,0.0,0.04,melissa crawl smith,
-ECE,8910,43,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,0.6,0.0,0.4,yongqiang wang,
-ECE,8930,7,Malware Use and Design,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,richard brooks,
-ECON,2000,1,Economic Concepts,0.14,0.39,0.29,0.11,0.0,0.0,0.0,0.07,jonathan orr ernest,
-ECON,2000,2,Economic Concepts,0.35,0.33,0.23,0.05,0.05,0.0,0.0,0.0,jonathan orr ernest,
-ECON,2000,3,Economic Concepts,0.33,0.41,0.13,0.03,0.08,0.0,0.0,0.03,miren ivankovic,
-ECON,2110,1,Principles of Microeconomics,0.39,0.32,0.21,0.03,0.0,0.03,0.0,0.03,robert dew tollison,
-ECON,2110,2,Principles of Microeconomics,0.15,0.36,0.26,0.1,0.08,0.0,0.0,0.05,charles thomas,
-ECON,2110,3,Principles of Microeconomics,0.18,0.28,0.26,0.18,0.1,0.0,0.0,0.0,steven johnson,
-ECON,2110,4,Principles of Microeconomics,0.31,0.26,0.26,0.05,0.1,0.0,0.0,0.02,amanda caitlin kerr,
-ECON,2110,5,Principles of Microeconomics,0.35,0.35,0.28,0.03,0.0,0.0,0.0,0.0,molly espey,
-ECON,2110,6,Principles of Microeconomics,0.24,0.39,0.25,0.01,0.01,0.0,0.0,0.08,benjamin jo schwall,
-ECON,2110,7,Principles of Microeconomics,0.24,0.33,0.2,0.14,0.04,0.0,0.0,0.04,leah jacq kitashima,
-ECON,2110,8,Principles of Microeconomics,0.21,0.42,0.24,0.06,0.03,0.0,0.0,0.03,alexander fiore,
-ECON,2110,10,Principles of Microeconomics,0.16,0.31,0.35,0.08,0.08,0.0,0.0,0.02,richard alan sessa,
-ECON,2110,11,Principles of Microeconomics,0.14,0.35,0.34,0.14,0.0,0.0,0.0,0.03,michael makowsky,
-ECON,2110,12,Principles of Microeconomics,0.28,0.44,0.26,0.03,0.0,0.0,0.0,0.0,molly espey,
-ECON,2120,1,Principles of Macroeconomics,0.11,0.32,0.37,0.16,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,2,Principles of Macroeconomics,0.18,0.12,0.47,0.18,0.0,0.0,0.0,0.06,scott baier,
-ECON,2120,3,Principles of Macroeconomics,0.2,0.3,0.35,0.05,0.1,0.0,0.0,0.0,scott baier,
-ECON,2120,4,Principles of Macroeconomics,0.26,0.32,0.32,0.05,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,5,Principles of Macroeconomics,0.3,0.35,0.25,0.1,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,6,Principles of Macroeconomics,0.17,0.33,0.39,0.06,0.0,0.0,0.0,0.06,scott baier,
-ECON,2120,7,Principles of Macroeconomics,0.28,0.33,0.22,0.17,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,8,Principles of Macroeconomics,0.21,0.37,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,9,Principles of Macroeconomics,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,10,Principles of Macroeconomics,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,scott baier,
-ECON,2120,11,Principles of Macroeconomics,0.26,0.26,0.42,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,12,Principles of Macroeconomics,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,13,Principles of Macroeconomics,0.37,0.11,0.32,0.05,0.11,0.0,0.0,0.05,scott baier,
-ECON,2120,14,Principles of Macroeconomics,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,15,Principles of Macroeconomics,0.43,0.38,0.19,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,16,Principles of Macroeconomics,0.17,0.17,0.67,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,17,Principles of Macroeconomics,0.37,0.37,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,18,Principles of Macroeconomics,0.42,0.26,0.16,0.11,0.0,0.0,0.0,0.05,scott baier,
-ECON,2120,19,Principles of Macroeconomics,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,20,Principles of Macroeconomics,0.25,0.31,0.36,0.07,0.0,0.0,0.0,0.0,peter david lorenz,
-ECON,2120,21,Principles of Macroeconomics,0.61,0.32,0.06,0.0,0.02,0.0,0.0,0.0,mallika garg,
-ECON,2120,22,Principles of Macroeconomics,0.22,0.39,0.27,0.07,0.0,0.0,0.0,0.05,andew swanson,
-ECON,2120,23,Principles of Macroeconomics,0.36,0.39,0.08,0.06,0.08,0.0,0.0,0.03,shan jiang,
-ECON,2120,24,Principles of Macroeconomics,0.2,0.58,0.19,0.03,0.01,0.0,0.0,0.0,scott barkowski,
-ECON,2120,25,Principles of Macroeconomics,0.19,0.56,0.19,0.06,0.0,0.0,0.0,0.0,scott barkowski,
-ECON,2120,26,Principles of Macroeconomics,0.18,0.06,0.15,0.21,0.06,0.0,0.0,0.33,ralph charles allen,
-ECON,2120,27,Principles of Macroeconomics,0.21,0.45,0.27,0.0,0.0,0.0,0.0,0.06,chen wang,
-ECON,3020,1,Money and Banking,0.15,0.36,0.3,0.03,0.0,0.0,0.0,0.15,randall scot cragun,
-ECON,3060,1,Managerial Economics,0.19,0.36,0.17,0.11,0.06,0.0,0.0,0.11,jacob burgdorf,
-ECON,3100,1,International Econ,0.16,0.28,0.19,0.16,0.16,0.0,0.0,0.06,michal jerzmanowski,
-ECON,3140,1,Intermediate Micro,0.17,0.24,0.27,0.15,0.1,0.0,0.0,0.07,robert kennet fleck,
-ECON,3140,2,Intermediate Micro,0.19,0.3,0.35,0.0,0.03,0.0,0.0,0.14,kevin ka kin tsui,
-ECON,3140,3,Intermediate Micro,0.18,0.3,0.25,0.1,0.08,0.0,0.0,0.1,frederick hanssen,
-ECON,3150,1,Intermediate Macro,0.3,0.21,0.21,0.06,0.06,0.0,0.0,0.15,randall scot cragun,
-ECON,3150,2,Intermediate Macro,0.51,0.15,0.18,0.08,0.03,0.0,0.0,0.05,sergey vla mityakov,
-ECON,3190,2,Environmental Econ,0.21,0.43,0.21,0.07,0.04,0.0,0.0,0.04,scott templeton,
-ECON,3400,1,Behavioral Economics,0.51,0.4,0.09,0.0,0.0,0.0,0.0,0.0,daniel wood,
-ECON,3440,1,Property Rights,0.11,0.26,0.3,0.19,0.07,0.0,0.0,0.07,dar litsukova-bokar,
-ECON,3600,1,Public Choice,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,robert dew tollison,
-ECON,4010,1,Labor Mkt Analysis,0.31,0.54,0.12,0.0,0.04,0.0,0.0,0.0,curtis simon,
-ECON,4020,1,Law and Economics,0.23,0.48,0.23,0.0,0.03,0.0,0.0,0.03,thomas wins hazlett,
-ECON,4050,1,Intro to Econometric,0.35,0.31,0.15,0.1,0.08,0.0,0.0,0.02,scott baier,
-ECON,4060,1,Advanced Econometric,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,babur de los santos,
-ECON,4240,1,Organization of Ind,0.42,0.38,0.13,0.04,0.04,0.0,0.0,0.0,matthew lewis,
-ECON,4260,1,Sem Sport Economics,0.52,0.43,0.0,0.0,0.04,0.0,0.0,0.0,raymond sauer,
-ECON,4270,1,Dev American Economy,0.33,0.44,0.15,0.07,0.0,0.0,0.0,0.0,howard ne bodenhorn,
-ECON,4280,1,Cost-Benefit Anlysis,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,william dougan,
-ECON,4290,1,Economics of Energy Markets,0.46,0.35,0.12,0.0,0.04,0.0,0.0,0.04,matthew lewis,
-ECON,4400,1,Game Theory,0.25,0.25,0.42,0.0,0.08,0.0,0.0,0.0,charles thomas,
-ECON,6020,1,Law and Economics,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,
-ECON,6060,1,Advanced Econometric,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,babur de los santos,
-ECON,6400,1,Game Theory,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,charles thomas,
-ECON,8020,2,Adv Econ Concepts and Applic I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
-ECON,8050,1,Macroeconomic Theory,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,
-ECON,8070,1,Econometrics II,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,chungsang lam,
-ECON,8110,1,Econ of Environment,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,scott templeton,
-ECON,8200,1,Public Finance,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,william dougan,
-ECON,8990,4,History of Econ-Modern Macro,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michel devroey,
-ECON,9010,2,Price Theory,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel wood,
-ECON,9090,1,Time-Series Econ,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
-ED,3970,7,Creative Inquiry in Education,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,david matthew boyer,
-ED,3970,28,Creative Inquiry Education,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,8380,504,Becoming a Reflective Praction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,
-ED,8380,531,Literacy Lessons for Indiv II,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,morgan jones bowie,
-ED,8380,539,Literacy Lessons for Indiv II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,andrea chri overton,
-ED,8390,500,Intro to Linguistics,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,daniel smith,
-ED,8670,500,Practicum in ESOL Instruction,0.69,0.08,0.08,0.0,0.08,0.0,0.0,0.08,margaret mar warner,
-EDC,3900,2,Skills for Stu Leads,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,eric pernotto,
-EDC,3900,4,Skills for Stu Leads,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,eric pernotto,
-EDEC,2200,1,Family/School/Com,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEL,4510,1,Elem Methods in Science Tchg,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
-EDEL,4520,1,Elem Methods Math Teaching,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-EDEL,4870,1,Ele Meth Soc Studies,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
-EDF,3010,1,Principles of American Educat,0.66,0.23,0.09,0.0,0.03,0.0,0.0,0.0,suzanne rosenblith,
-EDF,3010,2,Principles of American Educat,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,nafees mohamma khan,
-EDF,3010,3,Principles of American Educat,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
-EDF,3020,1,Educational Psychology,0.41,0.44,0.09,0.06,0.0,0.0,0.0,0.0,penelope mar vargas,
-EDF,3020,3,Educational Psychology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
-EDF,3020,6,Educational Psychology,0.4,0.46,0.14,0.0,0.0,0.0,0.0,0.0,penelope mar vargas,
-EDF,3340,1,Child Growth and Development,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
-EDF,3340,2,Child Growth and Development,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
-EDF,4800,2,Digital Media & Learning,0.91,0.05,0.05,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,300,Digital Media & Learning,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david matthew boyer,
-EDF,8080,300,Ed Tests and Measure,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,deborah switzer,
-EDL,7150,502,Sch & Comm Relations,0.86,0.05,0.0,0.0,0.05,0.0,0.0,0.05,frederick buskey,
-EDL,7350,500,Educational Eval,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,
-EDL,7400,502,Curr Plan: Sch Adm,0.71,0.21,0.0,0.0,0.04,0.0,0.0,0.04,elizabeth reynolds,
-EDL,7510,400,El Prin & Spv Ex II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth reynolds,
-EDL,7650,1,Assessment Hi Edu,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,
-EDL,7650,2,Assessment Hi Edu,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,
-EDL,8390,400,Research in Ed L,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,
-EDL,9110,501,Systematic Inq Ed L,0.47,0.4,0.0,0.0,0.0,0.0,0.0,0.13,jane lindle,
-EDLT,4580,1,Early Literacy: Birth-Kindergn,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4620,1,Reading Children's Lit in Elem,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,8100,400,Foundations: Reading & Writing,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,phillip mich wilder,
-EDLT,8150,500,Guided Reading & Writng Scaffo,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
-EDLT,8270,300,Content Area Rdg/Wtg-MS & HS,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8270,501,Content Area Rdg/Wtg-MS & HS,0.85,0.03,0.0,0.0,0.03,0.0,0.0,0.1,phillip mich wilder,
-EDSA,8190,1,Contemporary College Student,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,michelle boettcher,
-EDSC,4370,1,Technology in Math,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,
-EDSP,3700,2,Intro to Special Education,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,michael wayne riley,
-EDSP,3700,3,Intro to Special Education,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,pamela stecker,
-EDSP,3750,1,Early Intervention Spec Needs,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
-EDSP,4910,1,Ed Assess Ind W/Dis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
-EDSP,4950,1,Comm & Collab Sp Ed,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sara moo mackiewicz,
-EES,2020,1,Environ Engr Fundamentals II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
-EES,3100,2,Intro to Nuclear Engineering,0.2,0.27,0.07,0.0,0.07,0.0,0.0,0.4,timothy devol,
-EES,4010,1,Environmental Engr,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.46,0.34,0.09,0.06,0.0,0.0,0.0,0.06,thomas overcamp,
-EES,4750,1,Capstone Design Project,0.69,0.25,0.03,0.0,0.0,0.0,0.0,0.03,david allen ladner,
-EES,4840,2,Solid Waste Mgt,0.35,0.49,0.16,0.0,0.0,0.0,0.0,0.0,thomas overcamp,
-EES,4850,2,Hazard Waste Management,0.16,0.47,0.29,0.05,0.0,0.0,0.0,0.03,mark schlautman,
-EES,6110,1,Rad Detection Mmt,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,timothy devol,
-EES,8030,1,Phy/Chem Ops W/WW T,0.36,0.55,0.0,0.0,0.09,0.0,0.0,0.0,ezra lucas ho cates,
-EES,8040,1,Biochem Ops WW Trt,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,david freedman,
-EES,8090,1,Subsurface Remed Mod,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,ronald falta,
-EES,8120,1,Env Nuclear Engr,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,lin shuller-nickles,
-ELE,3010,1,Intro to Entre,0.05,0.48,0.4,0.05,0.03,0.0,0.0,0.0,ashley will parnell,
-ELE,3010,2,Intro to Entre,0.32,0.61,0.05,0.0,0.0,0.0,0.0,0.02,chad navis,
-ELE,3010,3,Intro to Entre,0.39,0.59,0.02,0.0,0.0,0.0,0.0,0.0,chad navis,
-ELE,4010,1,Exec Lead & Entr II,0.13,0.38,0.35,0.15,0.0,0.0,0.0,0.0,ashley will parnell,
-ENGL,1030,1,Accelerated Composition,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,emily anne boyter,
-ENGL,1030,2,Accelerated Composition,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,kristen joy hixon,
-ENGL,1030,3,Accelerated Composition,0.35,0.59,0.0,0.0,0.0,0.0,0.0,0.06,mary dickens,
-ENGL,1030,4,Accelerated Composition,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,caroline ca swanson,
-ENGL,1030,7,Accelerated Composition,0.75,0.1,0.0,0.0,0.1,0.0,0.0,0.05,kristen joy hixon,
-ENGL,1030,8,Accelerated Composition,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,todd rossi smith,
-ENGL,1030,9,Accelerated Composition,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,mary dickens,
-ENGL,1030,10,Accelerated Composition,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,teneshia head,
-ENGL,1030,11,Accelerated Composition,0.56,0.39,0.0,0.0,0.06,0.0,0.0,0.0,caroline ca swanson,
-ENGL,1030,12,Accelerated Composition,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,
-ENGL,1030,13,Accelerated Composition,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,rebecca nico shaver,
-ENGL,1030,14,Accelerated Composition,0.33,0.52,0.1,0.05,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,1030,15,Accelerated Composition,0.45,0.2,0.2,0.1,0.0,0.0,0.0,0.05,andrew mathas,
-ENGL,1030,16,Accelerated Composition,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,charlotte powell,
-ENGL,1030,17,Accelerated Composition,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,karen mary stewart,
-ENGL,1030,18,Accelerated Composition,0.8,0.05,0.05,0.0,0.0,0.0,0.0,0.1,daniel frank,
-ENGL,1030,19,Accelerated Composition,0.8,0.1,0.0,0.05,0.0,0.0,0.0,0.05,brian lee gaines,
-ENGL,1030,20,Accelerated Composition,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,rebecca nico shaver,
-ENGL,1030,21,Accelerated Composition,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,charlotte powell,
-ENGL,1030,22,Accelerated Composition,0.8,0.05,0.1,0.0,0.05,0.0,0.0,0.0,samuel jacks fuller,
-ENGL,1030,23,Accelerated Composition,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,shawn andrew stowe,
-ENGL,1030,24,Accelerated Composition,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,1030,25,Accelerated Composition,0.62,0.15,0.08,0.08,0.0,0.0,0.0,0.08,brian lee gaines,
-ENGL,1030,26,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,1030,30,Accelerated Composition,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,eda ozyesilpinar,
-ENGL,1030,31,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kristen gay,
-ENGL,1030,32,Accelerated Composition,0.76,0.0,0.06,0.06,0.0,0.0,0.0,0.12,katie jo vann,
-ENGL,1030,35,Accelerated Composition,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,jack butts,
-ENGL,1030,36,Accelerated Composition,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,april obrien,
-ENGL,1030,37,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kristen gay,
-ENGL,1030,39,Accelerated Composition,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,joshua wood,
-ENGL,1030,41,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,kellie eliz osborne,
-ENGL,1030,42,Accelerated Composition,0.65,0.25,0.05,0.0,0.0,0.0,0.0,0.05,jennifer moeder,
-ENGL,1030,44,Accelerated Composition,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,eric stephens,
-ENGL,1030,46,Accelerated Composition,0.9,0.0,0.05,0.0,0.05,0.0,0.0,0.0,eric stephens,
-ENGL,1030,51,Accelerated Composition,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,danielle shuff,
-ENGL,1030,53,Accelerated Composition,0.7,0.05,0.05,0.15,0.05,0.0,0.0,0.0,kellie eliz osborne,
-ENGL,1030,54,Accelerated Composition,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,jack butts,
-ENGL,1030,55,Accelerated Composition,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,stephen quigley,
-ENGL,1030,56,Accelerated Composition,0.8,0.0,0.1,0.0,0.05,0.0,0.0,0.05,jennifer moeder,
-ENGL,1030,58,Accelerated Composition,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,daniel frank,
-ENGL,1030,60,Accelerated Composition,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,danielle shuff,
-ENGL,1030,64,Accelerated Composition,0.71,0.14,0.07,0.0,0.07,0.0,0.0,0.0,madison ali johnson,
-ENGL,1030,65,Accelerated Composition,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,stephen quigley,
-ENGL,1030,68,Accelerated Composition,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,70,Accelerated Composition,0.63,0.16,0.05,0.0,0.11,0.0,0.0,0.05,joshua wood,
-ENGL,1030,71,Accelerated Composition,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,1030,72,Accelerated Composition,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,madison ali johnson,
-ENGL,1030,73,Accelerated Composition,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,teneshia head,
-ENGL,1030,502,Accelerated Composition,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,edward collins,
-ENGL,2120,1,World Literature,0.17,0.72,0.06,0.0,0.06,0.0,0.0,0.0,gabriel and hankins,
-ENGL,2120,3,World Literature,0.5,0.21,0.04,0.08,0.0,0.0,0.0,0.17,candace wiley,
-ENGL,2120,6,World Literature,0.46,0.35,0.12,0.0,0.0,0.0,0.0,0.08,candace wiley,
-ENGL,2120,7,World Literature,0.37,0.27,0.23,0.07,0.03,0.0,0.0,0.03,andrew mathas,
-ENGL,2120,9,World Literature,0.34,0.34,0.17,0.03,0.07,0.0,0.0,0.03,andrew mathas,
-ENGL,2120,11,World Literature,0.57,0.29,0.11,0.0,0.04,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,2120,12,World Literature,0.66,0.14,0.21,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,2120,13,World Literature,0.27,0.57,0.17,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2120,14,World Literature,0.17,0.45,0.17,0.07,0.03,0.0,0.0,0.1,meg woosley-goodman,
-ENGL,2120,15,World Literature (HON),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,meg woosley-goodman,True
-ENGL,2120,16,World Literature,0.19,0.48,0.22,0.0,0.07,0.0,0.0,0.04,meg woosley-goodman,
-ENGL,2120,17,World Literature,0.63,0.27,0.03,0.0,0.0,0.0,0.0,0.07,lucian ghita,
-ENGL,2120,18,World Literature,0.59,0.21,0.14,0.0,0.0,0.0,0.0,0.07,lucian ghita,
-ENGL,2120,19,World Literature,0.43,0.39,0.04,0.07,0.0,0.0,0.0,0.07,sarah mae cooper,
-ENGL,2130,1,British Literature,0.7,0.23,0.0,0.0,0.0,0.0,0.0,0.07,jeffrey fallis,
-ENGL,2130,2,British Literature,0.45,0.38,0.1,0.0,0.0,0.0,0.0,0.07,christopher benson,
-ENGL,2130,3,British Literature,0.57,0.33,0.07,0.0,0.03,0.0,0.0,0.0,christopher benson,
-ENGL,2130,4,British Literature,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
-ENGL,2130,5,British Literature,0.76,0.14,0.03,0.03,0.0,0.0,0.0,0.03,stephanie stripling,
-ENGL,2130,6,British Literature,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,jeffrey fallis,
-ENGL,2130,7,British Literature,0.66,0.31,0.0,0.0,0.0,0.0,0.0,0.03,jeffrey fallis,
-ENGL,2130,10,British Literature,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,krist aldebol-hazle,
-ENGL,2130,11,British Literature,0.79,0.11,0.04,0.04,0.0,0.0,0.0,0.04,krist aldebol-hazle,
-ENGL,2130,12,British Literature,0.73,0.23,0.0,0.0,0.0,0.0,0.0,0.03,lucian ghita,
-ENGL,2130,13,British Literature,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2140,1,American Literature,0.53,0.27,0.13,0.0,0.03,0.0,0.0,0.03,john morgenstern,
-ENGL,2140,2,American Literature,0.45,0.24,0.14,0.0,0.14,0.0,0.0,0.03,elizabeth stansell,
-ENGL,2140,3,American Literature,0.12,0.31,0.31,0.04,0.04,0.0,0.0,0.19,david charles foltz,
-ENGL,2140,4,American Literature,0.62,0.31,0.03,0.0,0.0,0.0,0.0,0.03,sherri teres allred,
-ENGL,2140,5,American Literature,0.36,0.39,0.04,0.04,0.0,0.0,0.0,0.18,candace wiley,
-ENGL,2140,6,American Literature,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,candace wiley,
-ENGL,2140,7,American Literature,0.62,0.1,0.21,0.03,0.03,0.0,0.0,0.0,sherri teres allred,
-ENGL,2140,8,American Literature,0.84,0.1,0.0,0.0,0.03,0.0,0.0,0.03,geveryl le robinson,
-ENGL,2140,9,American Literature,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,stephanie stripling,
-ENGL,2140,11,American Literature,0.73,0.17,0.03,0.03,0.03,0.0,0.0,0.0,stephanie stripling,
-ENGL,2140,12,American Literature,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
-ENGL,2140,13,American Literature,0.23,0.42,0.31,0.0,0.0,0.0,0.0,0.04,david charles foltz,
-ENGL,2140,14,American Literature,0.07,0.62,0.17,0.0,0.03,0.0,0.0,0.1,rhondda robi thomas,
-ENGL,2140,15,American Literature,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,april susanne pelt,
-ENGL,2140,17,American Literature,0.47,0.33,0.1,0.0,0.03,0.0,0.0,0.07,william stanton,
-ENGL,2140,18,American Literature,0.57,0.23,0.13,0.0,0.03,0.0,0.0,0.03,william stanton,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.53,0.37,0.07,0.03,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.47,0.27,0.17,0.0,0.03,0.0,0.0,0.07,megan no macalystre,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.47,0.33,0.07,0.13,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.8,0.13,0.0,0.0,0.03,0.0,0.0,0.03,alexander kudera,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,alexander kudera,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.22,0.48,0.11,0.0,0.04,0.0,0.0,0.15,karen kettnich,
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.21,0.43,0.25,0.04,0.04,0.0,0.0,0.04,karen kettnich,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.57,0.3,0.1,0.0,0.03,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,sharon kathl nalley,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.23,0.27,0.27,0.04,0.04,0.0,0.0,0.15,david charles foltz,
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.21,0.34,0.31,0.03,0.0,0.0,0.0,0.1,david charles foltz,
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.8,0.13,0.03,0.0,0.0,0.0,0.0,0.03,sharon kathl nalley,
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.0,0.69,0.31,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.38,0.48,0.07,0.03,0.0,0.0,0.0,0.03,john logan pursley,
-ENGL,3000,1,Professional Develop,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,austin gorman,
-ENGL,3040,2,Business Writing,0.73,0.14,0.05,0.0,0.05,0.0,0.0,0.05,philip randall,
-ENGL,3040,3,Business Writing,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,alexander kudera,
-ENGL,3040,5,Business Writing,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3040,13,Business Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3040,14,Business Writing,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,
-ENGL,3040,16,Business Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
-ENGL,3040,17,Business Writing,0.38,0.52,0.0,0.0,0.0,0.0,0.0,0.1,katalin beck,
-ENGL,3040,18,Business Writing,0.24,0.67,0.1,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3040,19,Business Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,3040,20,Business Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
-ENGL,3040,22,Business Writing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,austin gorman,
-ENGL,3040,400,Business Writing,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,3100,1,Crit Writ Lit,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,3100,2,Crit Writ Lit,0.39,0.39,0.22,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,
-ENGL,3100,4,Crit Writ Lit,0.19,0.5,0.19,0.06,0.06,0.0,0.0,0.0,erin marina goss,
-ENGL,3120,1,Advanced Composition,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3120,2,Advanced Composition,0.42,0.32,0.05,0.05,0.16,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,1,Technical Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
-ENGL,3140,2,Technical Writing,0.41,0.5,0.09,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,3,Technical Writing,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,adrian carson,
-ENGL,3140,5,Technical Writing,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,
-ENGL,3140,6,Technical Writing,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,christopher benson,
-ENGL,3140,7,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,3140,9,Technical Writing,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,adrian carson,
-ENGL,3140,10,Technical Writing,0.29,0.57,0.1,0.0,0.05,0.0,0.0,0.0,katalin beck,
-ENGL,3140,12,Technical Writing,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,
-ENGL,3140,13,Technical Writing,0.76,0.1,0.05,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,
-ENGL,3140,15,Technical Writing,0.7,0.15,0.0,0.0,0.05,0.0,0.0,0.1,geveryl le robinson,
-ENGL,3140,16,Technical Writing,0.38,0.52,0.0,0.1,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,17,Technical Writing,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3140,18,Technical Writing,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,19,Technical Writing,0.59,0.23,0.14,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,
-ENGL,3140,20,Technical Writing,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,24,Technical Writing,0.45,0.4,0.05,0.05,0.05,0.0,0.0,0.0,william pulley,
-ENGL,3140,25,Technical Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sean morey,
-ENGL,3150,1,Scientific Writing & Comm,0.5,0.25,0.1,0.05,0.0,0.0,0.0,0.1,william pulley,
-ENGL,3150,2,Scientific Writing & Comm,0.05,0.7,0.1,0.05,0.0,0.0,0.0,0.1,barbara ramirez,
-ENGL,3150,5,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,18,Scientific Writing & Comm,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
-ENGL,3150,21,Scientific Writing & Comm,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,john conway,
-ENGL,3150,23,Scientific Writing & Comm,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,john conway,
-ENGL,3320,1,Visual Communication,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,david blakesley,
-ENGL,3370,3,Creative Inquiry: English,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,susanna ashton,
-ENGL,3450,1,Structure of Fiction,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,nicholas chri brown,
-ENGL,3460,1,Structure of Poetry,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,angela naimou,
-ENGL,3570,1,Film,0.16,0.58,0.11,0.0,0.11,0.0,0.0,0.05,amy monaghan,
-ENGL,3570,2,Film,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,amy monaghan,
-ENGL,3800,1,Women Writers,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,meg woosley-goodman,
-ENGL,3960,1,Brit Lit Survey I,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,brian mcgrath,
-ENGL,3970,1,Brit Lit Survey II,0.45,0.35,0.15,0.0,0.0,0.0,0.0,0.05,david sweene coombs,
-ENGL,3980,1,Amer Lit Survey I,0.55,0.32,0.0,0.0,0.14,0.0,0.0,0.0,dominic mastroianni,
-ENGL,3980,2,Amer Lit Survey I,0.33,0.38,0.24,0.0,0.05,0.0,0.0,0.0,susanna ashton,
-ENGL,3990,1,Amer Lit Survey II,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,4110,1,Shakespeare,0.24,0.52,0.14,0.05,0.05,0.0,0.0,0.0,andrew lemons,
-ENGL,4150,1,Restor & 18th Cent,0.0,0.67,0.22,0.0,0.06,0.0,0.0,0.06,lee morrissey,
-ENGL,4200,1,Amer Lit to 1799,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,jonathan beec field,
-ENGL,4310,1,Modern Poetry,0.38,0.46,0.08,0.0,0.08,0.0,0.0,0.0,wayne chapman,
-ENGL,4320,1,Modern Fiction,0.31,0.5,0.06,0.06,0.06,0.0,0.0,0.0,gabriel and hankins,
-ENGL,4350,1,Literary Criticism,0.42,0.42,0.05,0.0,0.05,0.0,0.0,0.05,jonathan beec field,
-ENGL,4420,1,Cultural Studies,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,garry bertholf,
-ENGL,4450,1,Fiction Workshop,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,4460,1,Poetry Workshop,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,4520,1,Great Directors,0.33,0.33,0.27,0.0,0.0,0.0,0.0,0.07,agnieszka skrodzka,
-ENGL,4530,1,Sexuality and Cinema,0.33,0.53,0.07,0.07,0.0,0.0,0.0,0.0,agnieszka skrodzka,
-ENGL,4590,2,Spec Top Lang Criticism Theory,0.39,0.28,0.28,0.0,0.06,0.0,0.0,0.0,lindsay carr thomas,
-ENGL,4630,1,Lit to 1699: Old English,0.71,0.18,0.06,0.06,0.0,0.0,0.0,0.0,andrew lemons,
-ENGL,4640,1,Topics in Literature 1700-1899,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,erin marina goss,
-ENGL,4650,1,Topics in Literature from 1900,0.65,0.18,0.06,0.0,0.06,0.0,0.0,0.06,angela naimou,
-ENGL,4750,1,Writing for Media,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,tharon howard,
-ENGL,4830,1,Af Am Lit 1920-Pres,0.69,0.13,0.06,0.0,0.0,0.0,0.0,0.13,garry bertholf,
-ENGL,4890,1,Topics Write & Publ,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,megan eatman,
-ENGL,4920,1,Modern Rhetoric,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,brian mcgrath,
-ENGL,4960,1,Senior Seminar,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,michael lemahieu,
-ENGL,4960,2,Senior Seminar,0.62,0.15,0.15,0.0,0.0,0.0,0.0,0.08,david sweene coombs,
-ENGL,4960,3,Senior Seminar,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,8120,1,Digital Approaches-Lit/Cul Stu,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,lindsay carr thomas,
-ENGL,8500,1,Methods Prof Comm,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tharon howard,
-ENGR,1020,615,Engineering Discipl & Skills,0.17,0.32,0.17,0.11,0.13,0.0,0.0,0.09,ashley childers,
-ENGR,1020,618,Engineering Discipl & Skills,0.11,0.22,0.35,0.05,0.08,0.0,0.0,0.19,ashley childers,
-ENGR,1060,400,Engr Discipline & Skills II,0.0,0.21,0.35,0.15,0.24,0.0,0.0,0.06,ashley childers,
-ENGR,1060,402,Engr Discipline & Skills II,0.0,0.17,0.38,0.22,0.03,0.0,0.0,0.2,michael giebner,
-ENGR,1060,615,Engr Discipline & Skills II,0.1,0.4,0.3,0.1,0.1,0.0,0.0,0.0,ashley childers,
-ENGR,1060,618,Engr Discipline & Skills II,0.06,0.47,0.24,0.18,0.0,0.0,0.0,0.06,ashley childers,
-ENGR,1060,643,Engr Discipline & Skills II,0.03,0.34,0.23,0.23,0.03,0.0,0.0,0.13,michael giebner,
-ENGR,1060,648,Engr Discipline & Skills II,0.03,0.24,0.42,0.11,0.02,0.0,0.0,0.18,michael giebner,
-ENGR,1070,648,Programming & Prob Solving I,0.0,0.33,0.25,0.17,0.17,0.0,0.0,0.08,michael giebner,
-ENGR,1410,121,Programming & Problem Solving,0.18,0.3,0.3,0.07,0.09,0.0,0.0,0.07,william martin,
-ENGR,1410,122,Programming & Problem Solving,0.31,0.54,0.04,0.06,0.02,0.0,0.0,0.02,william martin,
-ENGR,1410,123,Programming & Problem Solving,0.21,0.48,0.13,0.08,0.02,0.0,0.0,0.08,mariah magagnotti,
-ENGR,1410,124,Programming & Problem Solving,0.11,0.6,0.22,0.0,0.07,0.0,0.0,0.0,sheikh moniruz moni,
-ENGR,1410,125,Programming & Problem Solving,0.13,0.28,0.43,0.09,0.02,0.0,0.0,0.04,roksana mahmud,
-ENGR,1410,126,Programming & Problem Solving,0.15,0.31,0.31,0.15,0.02,0.0,0.0,0.06,matthew kent miller,
-ENGR,1410,127,Programming & Problem Solving,0.04,0.43,0.28,0.11,0.09,0.0,0.0,0.06,andrew isaa neptune,
-ENGR,1410,128,Programming & Problem Solving,0.09,0.21,0.39,0.15,0.09,0.0,0.0,0.06,andrew isaa neptune,
-ENGR,1410,621,Programming & Problem Solving,0.43,0.34,0.11,0.04,0.06,0.0,0.0,0.02,elizabeth stephan,
-ENGR,1410,622,Programming & Problem Solving,0.44,0.4,0.04,0.07,0.04,0.0,0.0,0.0,elizabeth stephan,
-ENGR,1410,623,Programming & Problem Solving,0.33,0.25,0.25,0.02,0.08,0.0,0.0,0.06,srinivasarangan rang,
-ENGR,1410,624,Programming & Problem Solving,0.23,0.27,0.23,0.06,0.13,0.0,0.0,0.08,srinivasarangan rang,
-ENGR,1410,625,Programming & Problem Solving,0.27,0.48,0.19,0.04,0.0,0.0,0.0,0.02,steven brandon,
-ENGR,1410,626,Programming & Problem Solving,0.48,0.27,0.17,0.02,0.04,0.0,0.0,0.02,steven brandon,
-ENGR,1410,627,Programming & Problem Solving,0.09,0.29,0.38,0.13,0.02,0.0,0.0,0.09,jonathan maier,
-ENGR,1410,631,Programming & Problem Solving,0.06,0.17,0.29,0.17,0.11,0.0,0.0,0.2,matthew kent miller,
-ENGR,1410,632,Programming & Problem Solving,0.17,0.38,0.26,0.13,0.0,0.0,0.0,0.06,matthew kent miller,
-ENGR,1410,634,Programming & Problem Solving,0.08,0.41,0.24,0.1,0.02,0.0,0.0,0.14,andrew isaa neptune,
-ENGR,1410,636,Programming & Problem Solving,0.13,0.45,0.21,0.02,0.04,0.0,0.0,0.15,mariah magagnotti,
-ENGR,1410,637,Programming & Problem Solving,0.02,0.28,0.33,0.22,0.09,0.0,0.0,0.07,mariah magagnotti,
-ENGR,1510,501,Engineering Skills,0.27,0.3,0.24,0.12,0.06,0.0,0.0,0.0,john minor,
-ENGR,1510,502,Engineering Skills,0.33,0.3,0.13,0.07,0.17,0.0,0.0,0.0,john minor,
-ENGR,1640,502,Engineering MATLAB Programming,0.3,0.2,0.4,0.0,0.1,0.0,0.0,0.0,jonathan maier,
-ENGR,1900,79,CI: Engr I Punkin Chunkin,0.81,0.0,0.0,0.0,0.13,0.0,0.0,0.06,huijuan zhao,
-ENGR,2080,181,Engr Graphics & Machine Design,0.45,0.3,0.13,0.06,0.04,0.0,0.0,0.02,nighat yasmin,
-ENGR,2080,681,Engr Graphics & Machine Design,0.69,0.18,0.1,0.0,0.02,0.0,0.0,0.02,john minor,
-ENGR,2080,682,Engr Graphics & Machine Design,0.7,0.17,0.09,0.0,0.04,0.0,0.0,0.0,sarah grigg,
-ENGR,2080,683,Engr Graphics & Machine Design,0.56,0.22,0.09,0.04,0.04,0.0,0.0,0.06,sarah grigg,
-ENGR,2080,684,Engr Graphics & Machine Design,0.61,0.24,0.07,0.0,0.06,0.0,0.0,0.02,sarah grigg,
-ENGR,2080,685,Engr Graphics & Machine Design,0.47,0.32,0.15,0.02,0.02,0.0,0.0,0.02,rahul sharan renu,
-ENGR,2080,686,Engr Graphics & Machine Design,0.44,0.33,0.13,0.02,0.06,0.0,0.0,0.02,rahul sharan renu,
-ENGR,2080,687,Engr Graphics & Machine Design,0.53,0.21,0.11,0.09,0.04,0.0,0.0,0.02,anthony pau garland,
-ENGR,2080,688,Engr Graphics & Machine Design,0.45,0.32,0.06,0.02,0.08,0.0,0.0,0.08,anthony pau garland,
-ENGR,2100,601,CAD & Engineering Applications,0.54,0.3,0.06,0.06,0.02,0.0,0.0,0.02,kweku tekyi brown,
-ENGR,2100,602,CAD & Engineering Applications,0.57,0.15,0.11,0.04,0.06,0.0,0.0,0.06,kweku tekyi brown,
-ENGR,2100,603,CAD & Engineering Applications,0.51,0.37,0.04,0.0,0.04,0.0,0.0,0.04,nighat yasmin,
-ENGR,2100,604,CAD & Engineering Applications,0.55,0.33,0.06,0.0,0.04,0.0,0.0,0.02,nighat yasmin,
-ENGR,2200,1,Evaluating Innovations,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,sarah grigg,
-ENR,1020,1,Intro to Envir & Natur Res II,0.52,0.22,0.1,0.08,0.04,0.0,0.0,0.04,russell barrett,
-ENR,3020,1,Nat Res Measurements,0.5,0.27,0.13,0.1,0.0,0.0,0.0,0.0,lawrence gering,
-ENR,3120,1,Env Risks & Society,0.49,0.32,0.14,0.03,0.0,0.0,0.0,0.03,alan johnson,
-ENR,4130,1,Restoration Ecology,0.31,0.59,0.1,0.0,0.0,0.0,0.0,0.0,althea simone hagan,
-ENR,4500,1,Conservation Issues,0.8,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alan johnson,
-ENR,4500,2,Conservation Issues,0.82,0.09,0.05,0.0,0.0,0.0,0.0,0.05,alan johnson,
-ENSP,2000,1,Intro Environ Sci,0.41,0.34,0.24,0.0,0.0,0.0,0.0,0.0,tom owino,
-ENSP,2000,2,Intro Environ Sci,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-ENSP,2000,3,Intro Environ Sci,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENT,2000,1,Six-Legged Science,0.59,0.29,0.05,0.02,0.02,0.0,0.0,0.02,suellen pometto,
-ETOX,8300,1,Mechanistic Toxicology,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,william baldwin,
-FCS,8340,1,Research Methods in FCS II,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,natallia ser sianko,
-FCS,8920,61,Program Evaluation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark small,
-FDSC,1020,1,Persp Food Nutrition,0.67,0.28,0.04,0.0,0.0,0.0,0.0,0.01,john mcgregor,
-FDSC,2140,1,Fd Resources & Soc,0.56,0.3,0.08,0.02,0.01,0.0,0.0,0.04,paul dawson,
-FDSC,3060,1,Institutional Food Service Mgt,0.62,0.28,0.1,0.0,0.0,0.0,0.0,0.0,angela fraser,
-FDSC,4020,1,Food Chemistry II,0.58,0.33,0.09,0.0,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4030,1,Food Ch & Analysis,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,paul dawson,
-FDSC,4080,1,Food Process Eng,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,felix barron,
-FDSC,4090,1,TQM for Food & Pckg Industries,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-FIN,3040,1,Risk & Insurance,0.2,0.32,0.36,0.12,0.0,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.17,0.39,0.27,0.15,0.0,0.0,0.0,0.02,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.16,0.28,0.33,0.12,0.09,0.0,0.0,0.02,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.16,0.42,0.33,0.05,0.0,0.0,0.0,0.05,kerri mcmillan,
-FIN,3060,1,Corporation Finance,0.14,0.17,0.28,0.17,0.16,0.0,0.0,0.08,william hol johnson,
-FIN,3060,2,Corporation Finance,0.1,0.1,0.14,0.29,0.22,0.0,0.0,0.16,william hol johnson,
-FIN,3060,5,Corporation Finance,0.13,0.16,0.25,0.25,0.11,0.0,0.0,0.1,william hol johnson,
-FIN,3060,400,Corporation Finance,0.16,0.29,0.32,0.16,0.03,0.0,0.0,0.05,jack wolf,
-FIN,3060,401,Corporation Finance,0.15,0.32,0.28,0.15,0.0,0.0,0.0,0.09,jack wolf,
-FIN,3060,402,Corporation Finance,0.13,0.29,0.36,0.11,0.06,0.0,0.0,0.05,jack wolf,
-FIN,3070,1,Prin of Real Estate,0.21,0.38,0.28,0.08,0.05,0.0,0.0,0.0,ramon tolb franklin,
-FIN,3070,2,Prin of Real Estate,0.17,0.31,0.39,0.13,0.0,0.0,0.0,0.0,thomas springer,
-FIN,3080,1,Fin Inst & Mkts,0.24,0.29,0.32,0.1,0.02,0.0,0.0,0.02,daniel thoma greene,
-FIN,3080,2,Fin Inst & Mkts,0.25,0.45,0.23,0.08,0.0,0.0,0.0,0.0,daniel thoma greene,
-FIN,3080,3,Fin Inst & Mkts,0.44,0.28,0.26,0.03,0.0,0.0,0.0,0.0,daniel thoma greene,
-FIN,3110,1,Financial Management I,0.04,0.23,0.38,0.19,0.04,0.0,0.0,0.12,george bra lockhart,
-FIN,3110,2,Financial Management I,0.12,0.28,0.33,0.14,0.07,0.0,0.0,0.07,george bra lockhart,
-FIN,3110,3,Financial Management I,0.06,0.4,0.36,0.02,0.08,0.0,0.0,0.08,ramon tolb franklin,
-FIN,3110,4,Financial Management I,0.17,0.23,0.33,0.04,0.06,0.0,0.0,0.17,george bra lockhart,
-FIN,3120,1,Financial Management II,0.11,0.33,0.31,0.19,0.03,0.0,0.0,0.03,vincent intintoli,
-FIN,3120,2,Financial Management II,0.2,0.34,0.28,0.06,0.06,0.0,0.0,0.06,vincent intintoli,
-FIN,3120,3,Financial Management II,0.24,0.26,0.31,0.16,0.02,0.0,0.0,0.02,angela morgan,
-FIN,4030,1,Spreadsheet Apps in Finance,0.33,0.5,0.08,0.06,0.0,0.0,0.0,0.03,jared daniel smith,
-FIN,4030,2,Spreadsheet Apps in Finance,0.13,0.6,0.17,0.07,0.03,0.0,0.0,0.0,jared daniel smith,
-FIN,4040,1,Financial Modeling,0.1,0.4,0.3,0.0,0.05,0.05,0.0,0.1,jack wolf,
-FIN,4050,1,Portfolio Management & Theory,0.25,0.17,0.29,0.17,0.08,0.0,0.0,0.04,john alexander,
-FIN,4080,1,Mgt of Fin Inst,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4080,2,Mgt of Fin Inst,0.14,0.67,0.1,0.05,0.0,0.0,0.0,0.05,lyudmila chernykh,
-FIN,4090,1,Prof Fin Plan,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william hol johnson,
-FIN,4110,1,Int Fin Mgt,0.34,0.49,0.1,0.05,0.0,0.0,0.0,0.02,tilan tang,
-FIN,4110,2,Int Fin Mgt,0.33,0.46,0.15,0.05,0.0,0.0,0.0,0.0,tilan tang,
-FIN,4150,1,Real Estate Investmt,0.14,0.55,0.18,0.05,0.0,0.0,0.0,0.09,thomas springer,
-FIN,4160,1,Real Estate Val,0.25,0.6,0.1,0.05,0.0,0.0,0.0,0.0,ramon tolb franklin,
-FNR,4700,51,Camera Traps/ Animal Ecology,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,david sco jachowski,
-FNR,4990,1,Natural Resources Seminar,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,greg yarrow,
-FNR,4990,2,Natural Resources Seminar,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,greg yarrow,
-FNR,4990,3,Natural Resources Seminar,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,greg yarrow,
-FOR,1010,1,Intro to Forestry,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,lawrence gering,
-FOR,2060,1,Forestry Ecology,0.31,0.38,0.2,0.06,0.03,0.0,0.0,0.02,donald hagan,
-FOR,3080,1,Remote Sensing in Forestry,0.23,0.46,0.15,0.12,0.04,0.0,0.0,0.0,lawrence gering,
-FOR,4060,1,Forested Watershed Mgmt,0.65,0.29,0.0,0.0,0.02,0.0,0.0,0.04,joanna emily hawley,
-FOR,4080,1,Wood and Paper Products,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,patricia layton,
-FOR,4150,1,Forest Wildlife Managment,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,james davis,
-FOR,4180,1,Forest Resource Valuation,0.23,0.5,0.23,0.04,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4340,1,GIS for Natural Resources,0.51,0.34,0.11,0.0,0.02,0.0,0.0,0.02,robert frit baldwin,
-FOR,4650,1,Silviculture,0.2,0.44,0.24,0.12,0.0,0.0,0.0,0.0,gaofeng wang,
-FOR,8120,1,Fire Ecology and Management,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,gaofeng wang,
-FR,1010,1,Elementary French,0.29,0.53,0.06,0.06,0.0,0.0,0.0,0.06,anne salces  nedeo,
-FR,1020,1,Elementary French,0.09,0.27,0.18,0.18,0.18,0.0,0.0,0.09,anne salces  nedeo,
-FR,1020,2,Elementary French,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,1020,3,Elementary French,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,1,Intermediate French,0.61,0.22,0.11,0.0,0.06,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,2,Intermediate French,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,4,Intermediate French,0.47,0.27,0.13,0.0,0.0,0.0,0.0,0.13,kelly digby peebles,
-FR,2020,1,Intermediate French,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,eric touya,
-FR,2020,2,Intermediate French,0.63,0.26,0.0,0.11,0.0,0.0,0.0,0.0,joseph mai,
-FR,2020,3,Intermediate French,0.71,0.24,0.0,0.06,0.0,0.0,0.0,0.0,joseph mai,
-FR,2020,4,Intermediate French,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,paulin de tholozany,
-FR,3050,1,Int Fr Con & Comp I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
-FR,3160,1,Fr for Intl Trade,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,
-FR,3170,1,Contemp French Civ,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,joseph mai,
-FR,4200,1,French Enlightenment,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
-FR,4760,1,Adv Sem Fr Thought,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,
-GC,1010,1,Orientation to G C,0.41,0.39,0.11,0.02,0.0,0.0,0.0,0.07,carol jones,
-GC,1020,1,Computer Art & CAD Foundations,0.36,0.43,0.16,0.02,0.02,0.0,0.0,0.0,carol jones,
-GC,1030,1,G C I for Pkgsc,0.23,0.54,0.06,0.06,0.06,0.0,0.0,0.06,john jacobs,
-GC,1040,1,Graphic Communications I,0.43,0.51,0.04,0.0,0.0,0.0,0.0,0.01,rebecca suza edlein,
-GC,2070,1,Graphic Communications II,0.53,0.38,0.09,0.0,0.0,0.0,0.0,0.0,patrick gee rose,
-GC,2400,1,Intro to Web Design and Dev,0.56,0.25,0.06,0.0,0.0,0.06,0.0,0.06,erica black walker,
-GC,3400,1,Digital Imaging and eMedia,0.64,0.31,0.05,0.0,0.0,0.0,0.0,0.0,erica black walker,
-GC,3460,1,Ink and Substrates,0.18,0.44,0.29,0.04,0.04,0.0,0.0,0.02,liam henry 'hara,
-GC,4060,1,Package and Specialty Printing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kern cox,
-GC,4400,1,Commercial Printing,0.23,0.49,0.17,0.0,0.03,0.0,0.0,0.09,eric weisenmiller,
-GC,4440,1,Current Dev/Trends in Gr Comm,0.33,0.47,0.14,0.06,0.0,0.0,0.0,0.0,liam henry 'hara,
-GC,4480,1,Plan & Cont Printing Functions,0.6,0.34,0.04,0.02,0.0,0.0,0.0,0.0,john leininger,
-GC,4800,1,Senior Seminar in GC,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,charles edwa tonkin,
-GC,4900,2,G C Selected Topics-Sales,0.62,0.27,0.04,0.0,0.0,0.0,0.0,0.08,john leininger,
-GC,4900,6,G C Selected Topics-The DEN,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,erica black walker,
-GEN,3000,1,Fundamental Genetics,0.23,0.33,0.22,0.11,0.07,0.0,0.0,0.03,kate leanne wi tsai,
-GEN,3000,2,Fundamental Genetics,0.18,0.39,0.24,0.11,0.03,0.0,0.0,0.03,kate leanne wi tsai,
-GEN,3020,1,Molecular & General Genetics,0.33,0.33,0.17,0.04,0.0,0.0,0.0,0.13,meredith tei morris,
-GEN,4100,1,Population & Quant Genetics,0.43,0.38,0.11,0.05,0.03,0.0,0.0,0.0,amy lou lawton rauh,
-GEN,4110,2,Populatn & Quant Genetics Lab,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
-GEN,4400,1,Bioinformatics,0.41,0.35,0.18,0.0,0.0,0.0,0.0,0.06,liangjiang wang,
-GEN,6100,1,Population & Quant Genetics,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
-GEOG,1010,1,Intro to Geography,0.35,0.29,0.29,0.0,0.03,0.0,0.0,0.03,christa smith,
-GEOG,1030,1,World Regional Geol,0.83,0.07,0.03,0.03,0.02,0.0,0.0,0.02,lance forres howard,
-GEOG,1030,2,World Regional Geog,0.4,0.38,0.15,0.08,0.0,0.0,0.0,0.0,william churc terry,
-GEOG,3010,1,Political Geography,0.56,0.28,0.04,0.0,0.04,0.0,0.0,0.08,christa smith,
-GEOL,1010,1,Physical Geology,0.37,0.36,0.17,0.05,0.03,0.0,0.0,0.01,alan coulson,
-GEOL,1010,2,Physical Geology,0.46,0.33,0.12,0.05,0.04,0.0,0.0,0.0,alan coulson,
-GEOL,1030,1,Physical Geol Lab,0.3,0.52,0.13,0.04,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.65,0.13,0.04,0.0,0.09,0.0,0.0,0.09,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.61,0.3,0.04,0.04,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.58,0.33,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.67,0.21,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.75,0.06,0.19,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1120,1,Earth Resources,0.52,0.31,0.15,0.0,0.0,0.0,0.0,0.02,scott brame,
-GEOL,1140,1,Earth Resources Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,2020,1,Earth History,0.25,0.5,0.05,0.1,0.1,0.0,0.0,0.0,alan coulson,
-GEOL,3130,1,Sedimentology & Stratigraphy,0.11,0.44,0.28,0.17,0.0,0.0,0.0,0.0,james castle,
-GEOL,3180,1,Introduction to Geochemistry,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,brian powell,
-GEOL,4210,1,Gis in Geology,0.7,0.26,0.0,0.0,0.0,0.0,0.0,0.04,scott brame,
-GEOL,7900,501,Biogeography & Geology of SC,0.25,0.5,0.13,0.0,0.13,0.0,0.0,0.0,john robert wagner,
-GEOL,8030,1,Geostatistics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,stephen mich moysey,
-GEOL,8160,1,Aquifer Systems,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,lawrence murdoch,
-GER,1010,1,Elementary German,0.32,0.42,0.11,0.05,0.05,0.0,0.0,0.05,oswald harris king,
-GER,1010,2,Elementary German,0.56,0.11,0.11,0.06,0.0,0.0,0.0,0.17,oswald harris king,
-GER,1020,1,Elementary German,0.31,0.31,0.31,0.0,0.0,0.0,0.0,0.08, lee ferrell,
-GER,1020,2,Elementary German,0.21,0.29,0.07,0.0,0.14,0.0,0.0,0.29, lee ferrell,
-GER,2010,1,Intermediate German,0.35,0.53,0.06,0.0,0.0,0.0,0.0,0.06,oswald harris king,
-GER,2020,1,Intermediate German,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,johannes schmidt,
-GER,2020,2,Intermediate German,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,3160,1,Ger for Intl Trade I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0, lee ferrell,
-GER,3610,1,Ger Lit 1832 to Mod,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,johannes schmidt,
-HCC,8810,2,Measurement & Eval,0.57,0.14,0.0,0.0,0.0,0.0,0.0,0.29,bart knijnenburg,
-HCG,9010,1,Adv in Humn Genetics,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,julia eggert,
-HCG,9890,3,Special Topics: Theoretical Fo,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,mary steck,
-HEHD,3990,2,Students Helping Students Peer,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,mary mcp von kaenel,
-HEHD,4000,1,Intro Leadership Theor & Conc,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,william havice,
-HEHD,4200,1,Lead Appli & Exper,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
-HEHD,8010,230,Child/Adolescent Dev,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
-HEHD,8040,230,Assessment/Eval,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,
-HEHD,8880,400,Special Topics Youth Dev Ldshp,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,barry garst,
-HIST,1010,1,Hist of the U S,0.27,0.55,0.12,0.0,0.06,0.0,0.0,0.0,james brad jeffries,
-HIST,1240,1,Environmental History Survey,0.04,0.46,0.31,0.05,0.07,0.0,0.0,0.07,james brad jeffries,
-HIST,1720,3,The West and the World I,0.43,0.46,0.06,0.0,0.0,0.0,0.0,0.06,emily wood,
-HIST,1730,1,The West and the World II,0.27,0.38,0.19,0.0,0.08,0.0,0.0,0.08, alan grubb,
-HIST,1730,2,The West and the World II,0.33,0.28,0.25,0.07,0.03,0.0,0.0,0.03,james burns,
-HIST,1730,3,The West and the World II,0.18,0.43,0.2,0.08,0.05,0.0,0.0,0.07,thomas kuehn,
-HIST,2990,1,Historian's Craft,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,michael silvestri,
-HIST,2990,2,Historian's Craft,0.44,0.38,0.06,0.0,0.06,0.0,0.0,0.06,elizabeth carney,
-HIST,3000,1,Hist Colonial Amer,0.62,0.32,0.03,0.0,0.03,0.0,0.0,0.0,lee brady wilson,
-HIST,3010,1,Am Rev & New Nation,0.21,0.27,0.21,0.06,0.15,0.0,0.0,0.09,james brad jeffries,
-HIST,3100,1,History of Religion in the US,0.27,0.53,0.0,0.07,0.07,0.0,0.0,0.07,elizabeth jemison,
-HIST,3110,1,African American Hist to 1877,0.26,0.55,0.1,0.0,0.06,0.0,0.0,0.03,abel bartley,
-HIST,3180,1,American Women,0.26,0.39,0.23,0.1,0.0,0.0,0.0,0.03,meg taylor-shockley,
-HIST,3210,2,History of Science,0.54,0.34,0.03,0.0,0.03,0.0,0.0,0.06,pamela mack,
-HIST,3240,1,Hist of the South II,0.33,0.52,0.09,0.03,0.0,0.0,0.0,0.03,john andrew,
-HIST,3260,1,Hist Am Transport,0.66,0.23,0.03,0.0,0.09,0.0,0.0,0.0, roger grant,
-HIST,3330,1,Hist of Mod Japan,0.21,0.41,0.26,0.03,0.09,0.0,0.0,0.0,edwin moise,
-HIST,3410,1,Modern Mexico,0.57,0.29,0.06,0.0,0.0,0.0,0.0,0.09,rachel anne moore,
-HIST,3510,1,Ancient Near East,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,steven grosby,
-HIST,3730,2,Age of Protestant Reformation,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,thomas kuehn,
-HIST,3810,1,Germany Since 1918,0.16,0.63,0.16,0.0,0.03,0.0,0.0,0.03,michael meng,
-HIST,3890,3,Mitchelville,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,abel bartley,
-HIST,3890,4,Upstate Black Communities,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,abel bartley,
-HIST,3890,5,Churches of Mitchelville,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,
-HIST,3900,1,Modern Military History,0.11,0.43,0.32,0.04,0.07,0.0,0.0,0.04,edwin moise,
-HIST,3920,1,Hist U S Environment,0.16,0.44,0.09,0.09,0.16,0.0,0.0,0.06,pamela mack,
-HIST,3970,1,Modern Middle East,0.42,0.55,0.0,0.03,0.0,0.0,0.0,0.0,amit bein,
-HIST,4000,1,Colonial South Carolina,0.17,0.28,0.39,0.06,0.06,0.0,0.0,0.06,paul chris anderson,
-HIST,4400,1,Studies in Latin American Hist,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
-HIST,4600,2,British India,0.54,0.31,0.0,0.08,0.0,0.0,0.0,0.08,michael silvestri,
-HIST,4870,1,World War II,0.14,0.57,0.17,0.02,0.05,0.0,0.0,0.05,john andrew,
-HIST,4880,1,Middle Eastern Soc & Culture,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
-HIST,4900,2,Domestic Space & History,0.58,0.33,0.0,0.0,0.08,0.0,0.0,0.0,elizabeth carney,
-HIST,4900,3,Capitalism,0.53,0.13,0.2,0.0,0.07,0.0,0.0,0.07,steven marks,
-HIST,4920,1,African American & Sports,0.31,0.46,0.15,0.0,0.0,0.0,0.0,0.08,abel bartley,
-HLTH,2020,1,Introduction to Public Health,0.57,0.29,0.05,0.05,0.0,0.0,0.0,0.05,jeffrey kingree,
-HLTH,2020,2,Introduction to Public Health,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,3,Introduction to Public Health,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,400,Introduction to Public Health,0.53,0.21,0.11,0.05,0.0,0.0,0.0,0.11,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.45,0.27,0.09,0.09,0.0,0.0,0.0,0.09,frederic fraizer,
-HLTH,2030,2,Health Care Sys,0.48,0.31,0.17,0.0,0.0,0.0,0.0,0.03,frederic fraizer,
-HLTH,2030,3,Health Care Sys,0.79,0.09,0.09,0.0,0.0,0.0,0.0,0.03,lee alden crandall,
-HLTH,2030,400,Health Care Sys,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2400,2,Deter of Hlth Behav,0.47,0.43,0.03,0.0,0.03,0.0,0.0,0.03,amelia clinkscales,
-HLTH,2400,400,Deter of Hlth Behav,0.53,0.33,0.07,0.07,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2980,1,Human Hlth & Disease,0.57,0.35,0.02,0.0,0.04,0.0,0.0,0.02,annah kamugiz amani,
-HLTH,2980,2,Human Hlth & Disease,0.66,0.23,0.09,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,3030,1,Public Health Comm,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,debra mitch charles,
-HLTH,3050,1,Body Resp Hlth Beh,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,brian patric graves,
-HLTH,3100,1,Women's Hlth Issues,0.64,0.24,0.09,0.03,0.0,0.0,0.0,0.0,rachel mayo,
-HLTH,3500,1,Med Terminology/Comm,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kari jea strothmann,
-HLTH,3800,1,Epidemiology,0.27,0.57,0.13,0.0,0.03,0.0,0.0,0.0,hugh spitler,
-HLTH,3800,2,Epidemiology,0.45,0.4,0.1,0.03,0.0,0.0,0.0,0.03,deborah alma falta,
-HLTH,3980,1,Hlth Appraisal Sklls,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,kathleen meyer,
-HLTH,3980,2,Hlth Appraisal Sklls,0.71,0.14,0.07,0.07,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4100,1,Maternal Child Hlth,0.66,0.28,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.45,0.3,0.18,0.03,0.0,0.0,0.0,0.05,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.72,0.26,0.02,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4300,1,Hlth Prom of Aged,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,cheryl jo dye,
-HLTH,4310,1,Public & Environ Hlt,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,4600,1,Health Info Systems,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,4700,400,Global Health,0.58,0.16,0.05,0.0,0.05,0.0,0.0,0.16,annah kamugiz amani,
-HLTH,4780,1,Health Policy Ethics and Law,0.2,0.4,0.35,0.05,0.0,0.0,0.0,0.0,hugh spitler,
-HLTH,4790,1,Fin Mgmt & Hlth Budg,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,lingling zhang,
-HLTH,4800,1,Comm Hlth Promotion,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,joel edwar williams,
-HLTH,4900,1,Res Eval St Pub Hlth,0.59,0.28,0.09,0.03,0.0,0.0,0.0,0.0,khoa dang truong,
-HLTH,4900,2,Res Eval St Pub Hlth,0.44,0.44,0.0,0.06,0.0,0.0,0.0,0.06,khoa dang truong,
-HLTH,4970,4,Creative Inq Hlth - Aspire,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,martha par thompson,
-HLTH,8210,500,Health Research I,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,lee alden crandall,
-HON,2060,1,Intro to Nanotechnology,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,christophe kitchens,
-HON,2060,3,Integrity in Engineering,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,daniel wueste,
-HON,2200,1,Knight of a Different Order,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,emily wood,
-HON,2210,2,"Hamlet, Again",0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-HON,2210,5,Authoring Harry Potter,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,megan no macalystre,
-HORT,1010,1,Horticulture,0.86,0.05,0.04,0.0,0.0,0.0,0.0,0.05,ellen anita vincent,
-HORT,2020,1,Adobe Digital Design,0.75,0.04,0.08,0.0,0.08,0.0,0.0,0.04,janice ann lay,
-HORT,2110,1,Growing Spring Plnts,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,james emerson faust,
-HORT,4040,1,Plant Propagation,0.1,0.38,0.28,0.17,0.03,0.0,0.0,0.03,jeffrey adelberg,
-HORT,4050,1,Plant Propagation Techniq Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
-HORT,4050,2,Plant Propagation Techniq Lab,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,jeffrey adelberg,
-HORT,4270,1,Urban Tree Care,0.23,0.55,0.18,0.0,0.05,0.0,0.0,0.0,robert polomski,
-HORT,4330,1,Turf Weed Management,0.28,0.31,0.34,0.03,0.0,0.0,0.0,0.03,ted whitwell,
-HP,8280,1,Case St in Preservation Engr,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,craig mille bennett,
-HP,8330,1,Cultural and Historical Landsc,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,carter lee hudgins,
-HRD,8490,400,Eval of T&D/Hrd Prog,0.92,0.02,0.0,0.0,0.06,0.0,0.0,0.0,philip mcgee,
-IE,2100,1,Des Analysis Wrk Sys,0.17,0.41,0.2,0.1,0.07,0.0,0.0,0.05,sara lu riggs,
-IE,2800,1,Deterministic Operations Rsrch,0.12,0.41,0.28,0.1,0.03,0.0,0.0,0.05,robert mark curry,
-IE,3010,1,Systems Design I,0.62,0.36,0.02,0.0,0.0,0.0,0.0,0.0,robert james riggs,
-IE,3610,1,Industrial App of Prob/Stat II,0.33,0.37,0.13,0.03,0.13,0.0,0.0,0.0,sandra dun eksioglu,
-IE,3610,2,Industrial App of Prob/Stat II,0.58,0.25,0.12,0.03,0.0,0.0,0.0,0.03,joel greenstein,
-IE,3810,1,Probabilistic Operations Rsrch,0.2,0.31,0.33,0.07,0.09,0.0,0.0,0.0,burak eksioglu,
-IE,3810,2,Probabilistic Operations Rsrch,0.24,0.34,0.19,0.13,0.08,0.0,0.0,0.02,amin khademi,
-IE,3840,1,Engr Econ Analysis,0.55,0.17,0.12,0.04,0.04,0.0,0.0,0.08,brian melloy,
-IE,3860,1,Prod Plan & Cont,0.32,0.36,0.19,0.09,0.02,0.0,0.0,0.03,robert james riggs,
-IE,4020,3,Creative Inq Res,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,anand gramopadhye,
-IE,4620,1,Six Sigma Quality,0.34,0.52,0.14,0.0,0.0,0.0,0.0,0.0,robert james riggs,
-IE,4670,1,System Design II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,
-IE,4910,1,Service Engineering,0.29,0.29,0.18,0.18,0.0,0.0,0.0,0.06,tugce isik,
-IE,4910,3,Invest Human Error Complx Sys,0.4,0.42,0.12,0.03,0.03,0.0,0.0,0.0,sara lu riggs,
-IE,6910,1,Service Engineering,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tugce isik,
-IE,6910,3,Invest Human Error Complx Sys,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,sara lu riggs,
-IE,8010,1,Human-Machine Sys,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,
-IE,8520,1,Prescriptive Analytics,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
-IE,8540,1,SC & Logistics Modeling I,0.73,0.21,0.06,0.0,0.0,0.0,0.0,0.0,william ferrell,
-IE,8580,1,Case Study Supply Chn & Logist,0.83,0.15,0.03,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.02,caren kelley-hall,
-INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.93,0.04,0.03,caren kelley-hall,
-INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,uttiyo raychaudhuri,
-ITAL,1010,1,Elementary Italian,0.65,0.06,0.18,0.0,0.06,0.0,0.0,0.06,julia schmidt,
-ITAL,1020,1,Elementary Italian,0.5,0.39,0.0,0.11,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,1020,2,Elementary Italian,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,valentina lombardi,
-ITAL,1020,3,Elementary Italian,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
-ITAL,2020,1,Intermediate Italian,0.61,0.33,0.0,0.06,0.0,0.0,0.0,0.0,valentina lombardi,
-ITAL,2020,2,Intermediate Italian,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
-JAPN,1010,1,Elementary Japanese,0.44,0.11,0.11,0.0,0.17,0.0,0.0,0.17,kazuko shoji,
-JAPN,1010,2,Elementary Japanese,0.38,0.13,0.19,0.06,0.19,0.0,0.0,0.06,kazuko shoji,
-JAPN,1020,1,Elementary Japanese,0.35,0.24,0.06,0.18,0.12,0.0,0.0,0.06,jae allegr takeuchi,
-JAPN,1020,2,Elementary Japanese,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,jae allegr takeuchi,
-JAPN,2010,1,Intermed Japanese,0.2,0.6,0.1,0.0,0.1,0.0,0.0,0.0,kazuko shoji,
-JAPN,2020,1,Intermed Japanese,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,kazuko shoji,
-JAPN,4170,1,Japanese Culture and Society,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jae allegr takeuchi,
-LARC,1160,1,History of Landscape Arch,0.24,0.29,0.3,0.09,0.03,0.0,0.0,0.05,hala fouad nassar,
-LARC,1520,1,Basic Design II,0.65,0.22,0.09,0.0,0.0,0.0,0.0,0.04,paul russell,
-LARC,2520,1,Site Design,0.36,0.36,0.27,0.0,0.0,0.0,0.0,0.0,martin john holland,
-LARC,3620,1,Design Impl II,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,paul russell,
-LARC,4280,1,Comput Aided Design,0.61,0.11,0.18,0.0,0.0,0.0,0.0,0.11,jessica fernandez,
-LAW,3220,1,Legal Env of Bus,0.35,0.37,0.15,0.02,0.07,0.0,0.0,0.04,kenneth toussaint,
-LAW,3220,2,Legal Env of Bus,0.27,0.56,0.16,0.02,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,3,Legal Env of Bus,0.7,0.24,0.07,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,4,Legal Env of Bus,0.38,0.38,0.22,0.0,0.02,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,5,Legal Env of Bus,0.41,0.34,0.18,0.05,0.0,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,6,Legal Env of Bus,0.42,0.38,0.11,0.04,0.0,0.0,0.0,0.04,edward ray claggett,
-LAW,3220,7,Legal Env of Bus,0.57,0.37,0.04,0.02,0.0,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,8,Legal Env of Bus,0.4,0.37,0.21,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,
-LAW,3220,9,Legal Env of Bus,0.41,0.44,0.1,0.03,0.03,0.0,0.0,0.0,kath kisska-schulze,
-LAW,3220,10,Legal Env of Bus,0.28,0.55,0.12,0.03,0.02,0.0,0.0,0.0,john hine,
-LAW,3220,11,Legal Env of Bus,0.21,0.56,0.15,0.03,0.03,0.0,0.0,0.02,john hine,
-LAW,3220,401,Legal Env of Bus,0.14,0.28,0.16,0.16,0.07,0.0,0.0,0.19,virgini ward-vaughn,
-LAW,3220,402,Legal Env of Bus,0.1,0.25,0.23,0.15,0.13,0.0,0.0,0.15,virgini ward-vaughn,
-LAW,3220,403,Legal Env of Bus,0.23,0.28,0.2,0.18,0.1,0.0,0.0,0.03,virgini ward-vaughn,
-LAW,3220,404,Legal Env of Bus,0.22,0.37,0.15,0.17,0.07,0.0,0.0,0.02,virgini ward-vaughn,
-LAW,3220,601,Legal Env of Bus,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LAW,4990,1,Selected Topics: Cyber Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,8500,1,Law for Prof Accts,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LAW,8500,2,Law for Prof Accts,0.18,0.74,0.09,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LAW,8500,3,Law for Prof Accts,0.49,0.43,0.09,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LS,1000,9,Intro to Salsa Dance,0.64,0.09,0.0,0.0,0.27,0.0,0.0,0.0,malik lewis baxter,
-LS,1000,20,Intro to Volleyball,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,kelly lynn ator,
-LS,1000,22,Intermediate Ashtanga Yoga,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
-LS,1000,23,Therapeutic Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
-LS,1000,24,Therapeutic Yoga,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,
-LS,1000,25,Therapeutic Yoga,0.78,0.09,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,
-LS,1130,1,Wood Carving,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,louwanda jolley,
-LS,1260,1,Group Initiatives,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,christina mar mazer,
-LS,1410,1,Top Rope Climbing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,glenn dav middleton,
-LS,1410,3,Top Rope Climbing,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,glenn dav middleton,
-LS,1450,2,Camping/Backpacking,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,samuel james keith,
-LS,1450,4,Camping/Backpacking,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,samuel james keith,
-LS,1580,2,Archery,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1580,3,Archery,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1580,4,Archery,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,
-LS,1640,1,Whitewater Kayaking,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,robert taylor,
-LS,1850,2,Bowling,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,megan elizabet cato,
-LS,1850,5,Bowling,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.07,katie dudley,
-LS,1850,6,Bowling,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,megan elizabet cato,
-LS,1850,8,Bowling,0.87,0.03,0.0,0.03,0.0,0.0,0.0,0.07,megan elizabet cato,
-LS,1870,1,Frisbee Sports,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,craig goodman,
-LS,1890,1,Tennis,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jose mezapaniagua,
-LS,1940,1,Racquetball,0.79,0.07,0.0,0.07,0.0,0.0,0.0,0.07,raymond petersen,
-LS,1940,3,Racquetball,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,charlie white,
-LS,1980,1,Golf,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jason jordan,
-LS,1980,3,Golf,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jason jordan,
-LS,1980,6,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jason jordan,
-LS,2100,1,Learn to Dance,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,matthew lee krabbe,
-LS,2110,2,Introduction to Belly Dance,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,stephanie pack,
-LS,2110,3,Introduction to Belly Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,stephanie pack,
-LS,2180,1,Ballroom Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,
-LS,2200,1,Shag,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,matthew lee krabbe,
-LS,2200,6,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,matthew lee krabbe,
-LS,2200,7,Shag,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,matthew lee krabbe,
-LS,2270,1,Intro to Swing Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,paul hoke,
-LS,2270,2,Intro to Swing Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,paul hoke,
-LS,2270,4,Intro to Swing Dance,0.93,0.0,0.0,0.04,0.0,0.0,0.0,0.04,paul hoke,
-LS,2320,1,Core Training,0.86,0.05,0.05,0.05,0.0,0.0,0.0,0.0,diane moreno,
-LS,2320,2,Core Training,0.79,0.0,0.04,0.04,0.04,0.0,0.0,0.08,diane moreno,
-LS,2320,3,Core Training,0.7,0.1,0.0,0.0,0.0,0.0,0.0,0.2,diane moreno,
-LS,2350,1,Basic Yoga,0.67,0.14,0.05,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,
-LS,2350,2,Basic Yoga,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
-LS,2350,3,Basic Yoga,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2350,4,Basic Yoga,0.75,0.1,0.0,0.1,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2350,5,Basic Yoga,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,renee warren gahan,
-LS,2350,6,Basic Yoga,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jenefer nadenicek,
-LS,2350,7,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,
-LS,2350,8,Basic Yoga,0.87,0.04,0.0,0.0,0.04,0.0,0.0,0.04,jenefer nadenicek,
-LS,2360,2,Power/Ashtanga Yoga,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,silica eliza larkin,
-LS,2380,1,Vinyasa Flow Yoga,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,
-LS,2380,2,Vinyasa Flow Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,
-LS,2420,1,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2420,2,Meditation and Relax,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,renee warren gahan,
-LS,2420,3,Meditation and Relax,0.75,0.08,0.08,0.04,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,4,Meditation and Relax,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,5,Meditation and Relax,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,2420,6,Meditation and Relax,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,2420,8,Meditation and Relax,0.86,0.0,0.09,0.0,0.05,0.0,0.0,0.0,ani reina-nunnelley,
-LS,2420,9,Meditation and Relax,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
-LS,2450,1,Pilates,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,melanie ivey job,
-LS,2450,2,Pilates,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,melanie ivey job,
-LS,2460,2,Intermediate Pilates,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
-LS,2510,1,Running & Jogging,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,corey dou brookover,
-LS,2700,1,Sports Officiating,0.71,0.0,0.0,0.0,0.06,0.0,0.0,0.24,christopher war cox,
-LS,3580,1,Advanced Shotgun Skeet,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,charles flint,
-MATH,1010,1,Essen Math for Informed Soc,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,marilyn reba,
-MATH,1010,3,Essen Math for Informed Soc,0.26,0.34,0.11,0.17,0.11,0.0,0.0,0.0,judith cottingham,
-MATH,1010,4,Essen Math for Informed Soc,0.5,0.35,0.12,0.0,0.03,0.0,0.0,0.0,judith cottingham,
-MATH,1010,5,Essen Math for Informed Soc,0.29,0.29,0.24,0.18,0.0,0.0,0.0,0.0,xiyan tan,
-MATH,1010,6,Essen Math for Informed Soc,0.23,0.32,0.32,0.1,0.0,0.0,0.0,0.03,judith cottingham,
-MATH,1020,1,Intro to Mathematical Analysis,0.07,0.31,0.24,0.14,0.24,0.0,0.0,0.0,haodong li,
-MATH,1020,2,Intro to Mathematical Analysis,0.18,0.21,0.26,0.16,0.11,0.0,0.0,0.08,stefani ca mokalled,
-MATH,1020,4,Intro to Mathematical Analysis,0.31,0.19,0.25,0.11,0.11,0.0,0.0,0.03,xiaoyuan liu,
-MATH,1020,6,Intro to Mathematical Analysis,0.18,0.31,0.21,0.1,0.13,0.0,0.0,0.08,tony thanh nguyen,
-MATH,1020,7,Intro to Mathematical Analysis,0.16,0.35,0.11,0.14,0.11,0.0,0.0,0.14,jerry lero phillips,
-MATH,1020,8,Intro to Mathematical Analysis,0.21,0.28,0.23,0.13,0.1,0.0,0.0,0.05,tony thanh nguyen,
-MATH,1020,9,Intro to Mathematical Analysis,0.11,0.34,0.24,0.08,0.24,0.0,0.0,0.0,randy davidson,
-MATH,1020,10,Intro to Mathematical Analysis,0.11,0.16,0.24,0.11,0.35,0.0,0.0,0.03,prab withana gamage,
-MATH,1020,11,Intro to Mathematical Analysis,0.2,0.31,0.11,0.17,0.2,0.0,0.0,0.0,kara ail stasikelis,
-MATH,1020,14,Intro to Mathematical Analysis,0.11,0.4,0.34,0.06,0.09,0.0,0.0,0.0,tony thanh nguyen,
-MATH,1020,15,Intro to Mathematical Analysis,0.21,0.26,0.18,0.13,0.11,0.0,0.0,0.11,randy davidson,
-MATH,1020,16,Intro to Mathematical Analysis,0.21,0.26,0.31,0.13,0.05,0.0,0.0,0.05,abigail bowers,
-MATH,1020,18,Intro to Mathematical Analysis,0.32,0.34,0.22,0.0,0.1,0.0,0.0,0.02,randy davidson,
-MATH,1020,19,Intro to Mathematical Analysis,0.05,0.18,0.32,0.08,0.29,0.0,0.0,0.08,aaro ramirez flores,
-MATH,1020,20,Intro to Mathematical Analysis,0.05,0.24,0.41,0.05,0.17,0.0,0.0,0.07,abigail bowers,
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.61,0.03,jason to hedetniemi,
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.41,0.51,0.08,rebecca lynn knoll,
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.49,0.05,patrick buckingham,
-MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.47,0.41,0.12,charity watson,
-MATH,1060,1,Calculus of One Variable I,0.07,0.07,0.37,0.13,0.27,0.0,0.0,0.1,allen anderso guest,
-MATH,1060,2,Calculus of One Variable I,0.06,0.19,0.38,0.09,0.06,0.0,0.0,0.22,allen anderso guest,
-MATH,1060,3,Calculus of One Variable I,0.17,0.24,0.27,0.05,0.2,0.0,0.0,0.07,marion hanna,
-MATH,1060,4,Calculus of One Variable I,0.05,0.14,0.36,0.12,0.19,0.0,0.0,0.14,beth novick,
-MATH,1060,5,Calculus of One Variable I,0.0,0.15,0.28,0.13,0.28,0.0,0.0,0.15,sanwar ahmad,
-MATH,1060,6,Calculus of One Variable I,0.05,0.2,0.34,0.02,0.27,0.0,0.0,0.12,"koshy chenthittayil,",
-MATH,1060,7,Calculus of One Variable I,0.05,0.18,0.37,0.16,0.18,0.0,0.0,0.05,stefan adam bock,
-MATH,1060,8,Calculus of One Variable I,0.05,0.18,0.13,0.1,0.23,0.0,0.0,0.33,michael gl eldredge,
-MATH,1060,9,Calculus of One Variable I,0.65,0.2,0.15,0.0,0.0,0.0,0.0,0.0,edward collins,
-MATH,1070,1,Differen and Integral Calculus,0.18,0.5,0.21,0.05,0.03,0.0,0.0,0.03,donna simms,
-MATH,1070,2,Differen and Integral Calculus,0.12,0.37,0.39,0.05,0.02,0.0,0.0,0.05,donna simms,
-MATH,1070,3,Differen and Integral Calculus,0.0,0.39,0.55,0.0,0.05,0.0,0.0,0.02,patrick buckingham,
-MATH,1070,5,Differen and Integral Calculus,0.07,0.36,0.29,0.07,0.14,0.0,0.0,0.07,tony thanh nguyen,
-MATH,1080,1,Calculus of One Variable II,0.27,0.23,0.23,0.03,0.1,0.0,0.0,0.13,muhamm mohebujjaman,
-MATH,1080,2,Calculus of One Variable II,0.19,0.21,0.24,0.05,0.21,0.0,0.0,0.1,lee andrew jenkins,
-MATH,1080,3,Calculus of One Variable II,0.13,0.22,0.16,0.07,0.18,0.0,0.0,0.24,sea sather-wagstaff,
-MATH,1080,4,Calculus of One Variable II,0.25,0.41,0.14,0.07,0.07,0.0,0.0,0.07,meredith nicol burr,
-MATH,1080,5,Calculus of One Variable II,0.09,0.36,0.36,0.07,0.07,0.0,0.0,0.05,jonathon leverenz,
-MATH,1080,6,Calculus of One Variable II,0.16,0.36,0.2,0.07,0.05,0.0,0.0,0.16,meredith nicol burr,
-MATH,1080,7,Calculus of One Variable II,0.27,0.33,0.18,0.02,0.04,0.0,0.0,0.16,abdullah al mamun,
-MATH,1080,8,Calculus of One Variable II,0.19,0.25,0.25,0.06,0.08,0.0,0.0,0.17,marilyn reba,
-MATH,1080,9,Calculus of One Variable II,0.36,0.4,0.06,0.02,0.13,0.0,0.0,0.02,ryan grove,
-MATH,1080,10,Calculus of One Variable II,0.16,0.29,0.24,0.02,0.04,0.0,0.0,0.24,jonathon leverenz,
-MATH,1080,11,Calculus of One Variable II,0.09,0.37,0.19,0.12,0.14,0.0,0.0,0.09,fiona may knoll,
-MATH,1080,12,Calculus of One Variable II,0.06,0.25,0.41,0.03,0.22,0.0,0.0,0.03,rui gong,
-MATH,1080,13,Calculus of One Variable II,0.02,0.27,0.24,0.0,0.16,0.0,0.0,0.31,rebecca ramos,
-MATH,1080,14,Calculus of One Variable II,0.22,0.28,0.25,0.08,0.03,0.0,0.0,0.14,honghai xu,
-MATH,1080,15,Calculus of One Variable II,0.1,0.33,0.18,0.05,0.15,0.0,0.0,0.18,shuhan xu,
-MATH,1080,16,Calculus of One Variable II,0.15,0.18,0.24,0.03,0.09,0.0,0.0,0.3,marilyn reba,
-MATH,1150,1,Contemp Math for Elem Teach I,0.53,0.29,0.12,0.06,0.0,0.0,0.0,0.0,charity watson,
-MATH,1160,1,Contemp Math for Elem Teach II,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1160,2,Contemp Math for Elem Teach II,0.56,0.33,0.07,0.0,0.0,0.0,0.0,0.04,allison stoddard,
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,marion hanna,
-MATH,2060,1,Calculus of Several Variables,0.16,0.42,0.1,0.06,0.1,0.0,0.0,0.16,akshay sunil gupte,
-MATH,2060,2,Calculus of Several Variables,0.16,0.4,0.2,0.04,0.12,0.0,0.0,0.08,timothy fra parrott,
-MATH,2060,3,Calculus of Several Variables,0.39,0.22,0.08,0.03,0.17,0.0,0.0,0.11,qijun he,
-MATH,2060,4,Calculus of Several Variables,0.57,0.32,0.08,0.0,0.03,0.0,0.0,0.0,sofya alekseeva,
-MATH,2060,5,Calculus of Several Variables,0.17,0.23,0.34,0.14,0.06,0.0,0.0,0.06,jonathon leverenz,
-MATH,2060,6,Calculus of Several Variables,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,sofya alekseeva,
-MATH,2060,7,Calculus of Several Variables,0.0,0.09,0.06,0.12,0.21,0.0,0.0,0.52,javier ruiz ramirez,
-MATH,2060,8,Calculus of Several Variables,0.46,0.43,0.08,0.0,0.03,0.0,0.0,0.0,sofya alekseeva,
-MATH,2060,9,Calculus of Several Variables,0.42,0.26,0.24,0.0,0.05,0.0,0.0,0.03,mark cawood,
-MATH,2060,10,Calculus of Several Variables,0.11,0.19,0.11,0.07,0.19,0.0,0.0,0.33,dania moham zantout,
-MATH,2070,1,Multivariable Calculus,0.22,0.34,0.22,0.13,0.06,0.0,0.0,0.03,judith irene mcknew,
-MATH,2070,2,Multivariable Calculus,0.34,0.31,0.28,0.0,0.03,0.0,0.0,0.03,jennifer mari hanna,
-MATH,2070,4,Multivariable Calculus,0.39,0.26,0.17,0.09,0.09,0.0,0.0,0.0,thanh thien to,
-MATH,2070,5,Multivariable Calculus,0.44,0.31,0.16,0.03,0.03,0.0,0.0,0.03,jennifer mari hanna,
-MATH,2070,7,Multivariable Calculus,0.22,0.47,0.22,0.03,0.03,0.0,0.0,0.03,tao yang,
-MATH,2070,8,Multivariable Calculus,0.23,0.27,0.13,0.17,0.07,0.0,0.0,0.13,yinggu bao,
-MATH,2070,9,Multivariable Calculus,0.44,0.24,0.24,0.03,0.0,0.0,0.0,0.06,jennifer van dyken,
-MATH,2070,10,Multivariable Calculus,0.36,0.18,0.21,0.12,0.09,0.0,0.0,0.03,jennifer mari hanna,
-MATH,2070,11,Multivariable Calculus,0.07,0.37,0.23,0.1,0.07,0.0,0.0,0.17,tiantian yang,
-MATH,2070,14,Multivariable Calculus,0.16,0.34,0.22,0.06,0.06,0.0,0.0,0.16,allison stoddard,
-MATH,2070,15,Multivariable Calculus,0.16,0.38,0.25,0.13,0.09,0.0,0.0,0.0,trevor scot vilardi,
-MATH,2070,17,Multivariable Calculus,0.38,0.38,0.13,0.0,0.03,0.0,0.0,0.09,garrett dranichak,
-MATH,2070,19,Multivariable Calculus,0.12,0.36,0.12,0.15,0.09,0.0,0.0,0.15,yibo xu,
-MATH,2070,20,Multivariable Calculus,0.27,0.3,0.24,0.09,0.03,0.0,0.0,0.06,liu zhu,
-MATH,2070,22,Multivariable Calculus,0.38,0.32,0.24,0.06,0.0,0.0,0.0,0.0,luke marti giberson,
-MATH,2070,23,Multivariable Calculus,0.21,0.21,0.24,0.12,0.15,0.0,0.0,0.06,emily marie nystrom,
-MATH,2070,25,Multivariable Calculus,0.12,0.39,0.3,0.09,0.06,0.0,0.0,0.03,amy christine grady,
-MATH,2070,26,Multivariable Calculus,0.16,0.19,0.13,0.32,0.1,0.0,0.0,0.1,yijun chen,
-MATH,2080,1,Intro to Ordin Diff Equations,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.05,james brannan,
-MATH,2080,2,Intro to Ordin Diff Equations,0.09,0.28,0.31,0.06,0.03,0.0,0.0,0.22,terri johnson,
-MATH,2080,4,Intro to Ordin Diff Equations,0.18,0.18,0.3,0.09,0.18,0.0,0.0,0.06,jeong rock yoon,
-MATH,2080,5,Intro to Ordin Diff Equations,0.05,0.23,0.36,0.05,0.14,0.0,0.0,0.18,terri johnson,
-MATH,2080,6,Intro to Ordin Diff Equations,0.22,0.27,0.22,0.05,0.03,0.0,0.0,0.22,shari prevost,
-MATH,2080,7,Intro to Ordin Diff Equations,0.11,0.32,0.11,0.07,0.11,0.0,0.0,0.29,terri johnson,
-MATH,2080,8,Intro to Ordin Diff Equations,0.19,0.3,0.14,0.11,0.05,0.0,0.0,0.22,jeong rock yoon,
-MATH,2080,9,Intro to Ordin Diff Equations,0.32,0.24,0.16,0.0,0.11,0.0,0.0,0.16,shari prevost,
-MATH,2080,10,Intro to Ordin Diff Equations,0.45,0.13,0.24,0.11,0.05,0.0,0.0,0.03,timothy ch teitloff,
-MATH,2080,11,Intro to Ordin Diff Equations,0.32,0.39,0.13,0.05,0.05,0.0,0.0,0.05,nathan jos adelgren,
-MATH,2080,12,Intro to Ordin Diff Equations,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,irina viktorova,
-MATH,2080,13,Intro to Ordin Diff Equations,0.55,0.13,0.05,0.05,0.05,0.0,0.0,0.16,timothy fra parrott,
-MATH,2080,14,Intro to Ordin Diff Equations,0.18,0.45,0.23,0.0,0.08,0.0,0.0,0.08,timothy ch teitloff,
-MATH,2080,15,Intro to Ordin Diff Equations,0.61,0.26,0.11,0.03,0.0,0.0,0.0,0.0,irina viktorova,
-MATH,2080,16,Intro to Ordin Diff Equations,0.66,0.24,0.05,0.0,0.03,0.0,0.0,0.03,irina viktorova,
-MATH,2080,17,Intro to Ordin Diff Equations,0.35,0.35,0.11,0.08,0.0,0.0,0.0,0.11,timothy fra parrott,
-MATH,2080,18,Intro to Ordin Diff Equations,0.31,0.31,0.25,0.06,0.08,0.0,0.0,0.0,timothy ch teitloff,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.88,0.08,0.0,0.03,0.0,0.0,0.0,0.03,james brannan,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.44,0.39,0.14,0.0,0.0,0.0,0.0,0.03,allison stoddard,
-MATH,3020,1,Stat for Science & Engineering,0.24,0.36,0.14,0.07,0.12,0.0,0.0,0.07,ellen hepfe breazel,
-MATH,3020,2,Stat for Science & Engineering,0.33,0.5,0.05,0.05,0.02,0.0,0.0,0.05,ellen hepfe breazel,
-MATH,3020,3,Stat for Science & Engineering,0.26,0.36,0.19,0.07,0.05,0.0,0.0,0.07,ellen hepfe breazel,
-MATH,3020,4,Stat for Science & Engineering,0.44,0.33,0.15,0.0,0.05,0.0,0.0,0.03,yisu jia,
-MATH,3020,5,Stat for Science & Engineering,0.28,0.31,0.18,0.05,0.05,0.0,0.0,0.13,calvin williams,
-MATH,3020,6,Stat for Science & Engineering,0.53,0.16,0.23,0.0,0.05,0.0,0.0,0.02,yanbo xia,
-MATH,3020,7,Stat for Science & Engineering,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.05,brandon gra goodell,
-MATH,3110,1,Linear Algebra,0.48,0.32,0.16,0.0,0.04,0.0,0.0,0.0,james peterson,
-MATH,3110,2,Linear Algebra,0.19,0.28,0.25,0.11,0.08,0.0,0.0,0.08,xuhong gao,
-MATH,3110,3,Linear Algebra,0.32,0.26,0.09,0.06,0.15,0.0,0.0,0.12,xuhong gao,
-MATH,3110,4,Linear Algebra,0.23,0.26,0.17,0.2,0.09,0.0,0.0,0.06,warren adams,
-MATH,3110,5,Linear Algebra,0.36,0.25,0.14,0.08,0.17,0.0,0.0,0.0,brian fralix,
-MATH,3190,1,Introduction to Proof,0.35,0.31,0.08,0.12,0.12,0.0,0.0,0.04,elena sta dimitrova,
-MATH,3190,2,Introduction to Proof,0.38,0.23,0.19,0.0,0.12,0.0,0.0,0.08,elena sta dimitrova,
-MATH,3600,1,Intermediate Math Computing,0.67,0.13,0.0,0.08,0.08,0.0,0.0,0.04,mark cawood,
-MATH,3600,2,Intermediate Math Computing,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,neil calkin,
-MATH,3650,1,Numerical Mthds for Engineers,0.28,0.41,0.22,0.06,0.0,0.0,0.0,0.03,eleanor jenkins,
-MATH,3650,2,Numerical Mthds for Engineers,0.13,0.31,0.31,0.03,0.03,0.0,0.0,0.19,christopher cox,
-MATH,3650,3,Numerical Mthds for Engineers,0.67,0.31,0.03,0.0,0.0,0.0,0.0,0.0,abigail bowers,
-MATH,3650,4,Numerical Mthds for Engineers,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,abigail bowers,
-MATH,4000,1,Theory of Probability,0.15,0.23,0.38,0.04,0.0,0.0,0.0,0.19,julie lassiter,
-MATH,4000,2,Theory of Probability,0.0,0.26,0.21,0.05,0.26,0.0,0.0,0.21,julie lassiter,
-MATH,4030,1,Intro to Statistical Theory,0.41,0.23,0.32,0.0,0.0,0.0,0.0,0.05,xiaoqian sun,
-MATH,4070,1,Regress & Time-Series Analysis,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,4120,1,Algebra I,0.3,0.33,0.1,0.13,0.05,0.0,0.0,0.1,kevin james,
-MATH,4190,1,Discrete Math Structures I,0.4,0.47,0.07,0.03,0.03,0.0,0.0,0.0,beth novick,
-MATH,4310,1,Theory of Interest,0.33,0.08,0.33,0.25,0.0,0.0,0.0,0.0, erwin walker,
-MATH,4340,1,Adv Engineering Mathematics,0.09,0.32,0.18,0.24,0.12,0.0,0.0,0.06,eleanor jenkins,
-MATH,4340,2,Adv Engineering Mathematics,0.19,0.42,0.04,0.15,0.08,0.0,0.0,0.12,hyesuk lee,
-MATH,4400,1,Linear Programming,0.41,0.36,0.09,0.0,0.09,0.0,0.0,0.05,yuyuan ouyang,
-MATH,4410,1,Intro to Stochastic Models,0.33,0.28,0.22,0.0,0.06,0.0,0.0,0.11,brian fralix,
-MATH,4530,1,Advanced Calculus I,0.29,0.29,0.29,0.05,0.05,0.0,0.0,0.05,peter kiessler,
-MATH,4540,1,Advanced Calculus II,0.36,0.32,0.12,0.08,0.04,0.0,0.0,0.08,james peterson,
-MATH,6340,1,Adv Engineering Mathematics,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,vincent ervin,
-MATH,8030,1,Stochastic Processes,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,robert lund,
-MATH,8040,1,Statistical Inference,0.76,0.0,0.12,0.0,0.0,0.0,0.0,0.12,christopher mcmahan,
-MATH,8050,1,Data Analysis,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,yingbo li,
-MATH,8090,1,Time Series Analysis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
-MATH,8100,1,Mathematical Programming,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,margaret mar wiecek,
-MATH,8130,1,Advanced Linear Programming,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,matthew saltzman,
-MATH,8210,1,Linear Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,
-MATH,8220,1,Measure and Integration,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,
-MATH,8530,1,Matrix Analysis,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,matthew macauley,
-MATH,8540,1,Theory of Graphs,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,wayne goddard,
-MATH,8600,1,Intro to Scientific Computing,0.36,0.57,0.0,0.0,0.0,0.0,0.0,0.07,hyesuk lee,
-MATH,8660,1,Finite Element Method,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,vincent ervin,
-MATH,9860,1,Selected Topics in Geometry,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,
-MBA,8030,1,Stat Analy of Bus Op,0.14,0.54,0.17,0.0,0.03,0.0,0.0,0.11,zachary mo leffakis,
-MBA,8060,1,Operations Mgt,0.09,0.79,0.09,0.0,0.03,0.0,0.0,0.0, sridharan,
-MBA,8070,1,Financial Management,0.66,0.27,0.07,0.0,0.0,0.0,0.0,0.0,melvin stith,
-MBA,8070,2,Financial Management,0.63,0.18,0.13,0.0,0.0,0.0,0.0,0.08,melvin stith,
-MBA,8090,1,Org Beh & Hum Res Mg,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8090,2,Org Beh & Hum Res Mg,0.56,0.42,0.03,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8190,1,Intro to Acc and Fin,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,annieka philo,
-MBA,8190,2,Intro to Acc and Fin,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,
-MBA,8290,1,Marketing Foundation,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MBA,8370,1,Legal Environ of Bus,0.28,0.7,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8430,10,Entrepreneurial Accounting,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,
-MBA,8510,10,Bus Operations & Logistics,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,
-MBA,8540,1,Mgrl Accounting,0.63,0.3,0.0,0.0,0.0,0.0,0.0,0.07,james mil kohlmeyer,
-MBA,8540,2,Mgrl Accounting,0.52,0.39,0.07,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,
-MBA,8590,1,Mgr Decision Model,0.48,0.31,0.1,0.0,0.02,0.0,0.0,0.1,mark mcknew,
-MBA,8590,2,Mgr Decision Model,0.57,0.35,0.0,0.0,0.09,0.0,0.0,0.0,sara elizabet yoder,
-MBA,8600,1,Advanced Marketing Strategy,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8610,1,Information Systems,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,varun grover,
-MBA,8610,2,Information Systems,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,kevin mckenzie,
-MBA,8620,1,Managerial Economics,0.43,0.49,0.03,0.0,0.0,0.0,0.0,0.06,ronald earl gregory,
-MBA,8700,1,Strategic Management,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8720,1,Entrepr Finance,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8750,1,Enterprise Develpmnt,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,michael george mino,
-MBA,8990,1,Advanced Leadership,0.87,0.11,0.0,0.0,0.0,0.0,0.0,0.02,gail depriest,
-MBA,8990,3,Service Innovation,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
-MBA,8990,4,Bus. Sport. Enter.,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.04,john michael hannon,
-ME,2000,1,Sophomore Seminar,0.95,0.02,0.01,0.0,0.01,0.0,0.0,0.02,donald beasley,
-ME,2010,1,Statics & Dynamics,0.06,0.16,0.24,0.22,0.24,0.0,0.0,0.07,paul joseph,
-ME,2010,2,Statics & Dynamics,0.13,0.2,0.18,0.13,0.24,0.0,0.0,0.13,lonny thompson,
-ME,2030,1,Founda Th/Fl Syst,0.09,0.28,0.35,0.11,0.05,0.0,0.0,0.11,jay ochterbeck,
-ME,2030,2,Founda Th/Fl Syst,0.16,0.2,0.28,0.11,0.16,0.0,0.0,0.08,john saylor,
-ME,2030,3,Founda Th/Fl Syst,0.38,0.38,0.11,0.02,0.0,0.0,0.0,0.11,donald beasley,
-ME,2040,1,Mechanics of Materials,0.18,0.43,0.26,0.05,0.05,0.0,0.0,0.03,michael porter,
-ME,2040,2,Mechanics of Materials,0.23,0.4,0.26,0.09,0.03,0.0,0.0,0.0,gang li,
-ME,2040,3,Mechanics of Materials,0.17,0.54,0.22,0.02,0.02,0.0,0.0,0.02,garrett pataky,
-ME,2040,302,Mechanics of Materials (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gang li,True
-ME,2220,1,Mechanical Engineering Lab I,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,2,Mechanical Engineering Lab I,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
-ME,2220,3,Mechanical Engineering Lab I,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
-ME,2220,4,Mechanical Engineering Lab I,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,5,Mechanical Engineering Lab I,0.3,0.65,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,6,Mechanical Engineering Lab I,0.37,0.32,0.21,0.05,0.0,0.0,0.0,0.05,todd schweisinger,
-ME,2220,7,Mechanical Engineering Lab I,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
-ME,2220,8,Mechanical Engineering Lab I,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,9,Mechanical Engineering Lab I,0.25,0.5,0.08,0.0,0.0,0.0,0.0,0.17,todd schweisinger,
-ME,3030,1,Thermodynamics,0.27,0.44,0.22,0.02,0.0,0.0,0.0,0.05,daniel fant,
-ME,3030,2,Thermodynamics,0.13,0.13,0.31,0.15,0.18,0.0,0.0,0.1,richard miller,
-ME,3040,1,Heat Transfer,0.03,0.21,0.49,0.15,0.13,0.0,0.0,0.0,jean-marc delhaye,
-ME,3040,2,Heat Transfer,0.2,0.39,0.32,0.03,0.06,0.0,0.0,0.0,xin zhao,
-ME,3050,1,Model/an Dy Syst,0.18,0.42,0.2,0.05,0.08,0.0,0.0,0.07,phanin tallapragada,
-ME,3050,2,Model/an Dy Syst,0.3,0.26,0.3,0.05,0.06,0.0,0.0,0.03,joshua bostwick,
-ME,3060,1,Fund Machine Design,0.28,0.46,0.19,0.0,0.04,0.0,0.0,0.04,oliver myers,
-ME,3060,2,Fund Machine Design,0.44,0.31,0.21,0.0,0.03,0.0,0.0,0.0,paul jeffrey meyer,
-ME,3070,1,Found of Mechanical Systems,0.27,0.5,0.14,0.02,0.0,0.0,0.0,0.07,lonny thompson,
-ME,3070,2,Found of Mechanical Systems,0.19,0.63,0.14,0.02,0.0,0.0,0.0,0.02,gregory mocko,
-ME,3080,1,Fluid Mechanics,0.05,0.18,0.33,0.2,0.15,0.0,0.0,0.1,jean-marc delhaye,
-ME,3080,2,Fluid Mechanics,0.14,0.3,0.47,0.04,0.04,0.0,0.0,0.02,ethan kung,
-ME,3100,1,Thermo/Heat Transfer,0.28,0.24,0.34,0.03,0.07,0.0,0.0,0.03,xiangchun xuan,
-ME,3120,1,Manuf Processes,0.36,0.45,0.16,0.02,0.0,0.0,0.0,0.01,hong seok choi,
-ME,3330,1,Mechanical Engineering Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,2,Mechanical Engineering Lab II,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,3,Mechanical Engineering Lab II,0.18,0.76,0.0,0.0,0.06,0.0,0.0,0.0,todd schweisinger,
-ME,3330,4,Mechanical Engineering Lab II,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,5,Mechanical Engineering Lab II,0.21,0.57,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,6,Mechanical Engineering Lab II,0.25,0.42,0.17,0.0,0.08,0.0,0.0,0.08,todd schweisinger,
-ME,3330,7,Mechanical Engineering Lab II,0.25,0.56,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,3330,8,Mechanical Engineering Lab II,0.2,0.5,0.2,0.0,0.0,0.0,0.0,0.1,todd schweisinger,
-ME,4010,1,Mech Engr Design,0.49,0.39,0.08,0.03,0.0,0.0,0.0,0.01,cameron turner,
-ME,4020,1,Intern in Engr Des,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,donald beasley,
-ME,4020,3,Intern in Engr Des,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,4,Intern in Engr Des,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
-ME,4020,5,Intern in Engr Des,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4020,7,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,
-ME,4020,8,Intern in Engr Des,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,4020,9,Intern in Engr Des,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,donald beasley,
-ME,4030,1,Control Dynamic Systems,0.18,0.5,0.25,0.03,0.03,0.0,0.0,0.03,suyi li,
-ME,4030,2,Control Dynamic Systems,0.24,0.45,0.31,0.0,0.0,0.0,0.0,0.0,yue wang,
-ME,4170,1,Mechatronic Sys,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4180,1,F E A in M E Design,0.48,0.39,0.09,0.0,0.0,0.0,0.0,0.04,istemi baris ozsoy,
-ME,4220,1,Design Gas Turbines,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,
-ME,4230,1,Intro Aerodynamics,0.34,0.46,0.17,0.0,0.03,0.0,0.0,0.0,richard figliola,
-ME,4260,1,Nuclear Energy,0.44,0.44,0.04,0.04,0.0,0.0,0.0,0.04,richard watkins,
-ME,4300,1,Mech Comp Materials,0.14,0.43,0.38,0.05,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,4440,1,Mechanical Engineering Lab III,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,2,Mechanical Engineering Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,3,Mechanical Engineering Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,4,Mechanical Engineering Lab III,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,5,Mechanical Engineering Lab III,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,7,Mechanical Engineering Lab III,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4930,5,SelectedTopics ME - RapidProto,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4930,11,Selected Topics ME: MicroFab,0.23,0.54,0.15,0.08,0.0,0.0,0.0,0.0,rod martinez-duarte,
-ME,4930,28,Selected Topics ME: HVAC,0.28,0.48,0.12,0.0,0.0,0.0,0.0,0.12,donald willoughby,
-ME,4930,29,Selected Topics ME: Solar E,0.62,0.28,0.07,0.0,0.03,0.0,0.0,0.0,daniel fant,
-ME,6170,1,Mechatronic Sys,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,6300,1,Mech Comp Materials,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,6300,401,Mech Comp Materials,0.44,0.44,0.0,0.0,0.11,0.0,0.0,0.0,huijuan zhao,
-ME,8120,1,Exp Meth Thermal Sci,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
-ME,8190,1,Cp Meth in Therm Sc,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,richard miller,
-ME,8200,1,Mod Cont Engr,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
-ME,8310,1,Convective Ht Trans,0.31,0.19,0.25,0.0,0.25,0.0,0.0,0.0,john saylor,
-ME,8520,1,Adv Finite Ele Ana,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gang li,
-ME,8610,1,Matl Sel Engr Design,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,mica grujicic,
-ME,8730,1,Res Mthds Coll Desgn,0.43,0.43,0.0,0.0,0.14,0.0,0.0,0.0,joshua summers,
-ME,8930,27,Sel Topics in ME - Cont Mech,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
-MGT,2010,1,Principles of Management,0.29,0.38,0.27,0.04,0.01,0.0,0.0,0.01,katherine clark,
-MGT,2010,2,Principles of Management,0.47,0.34,0.14,0.02,0.0,0.0,0.0,0.03,katherine clark,
-MGT,2010,3,Principles of Management,0.4,0.41,0.15,0.01,0.02,0.0,0.0,0.01,katherine clark,
-MGT,2010,4,Principles of Management,0.34,0.39,0.24,0.02,0.0,0.0,0.0,0.01,katherine clark,
-MGT,2010,5,Principles of Management,0.45,0.42,0.12,0.01,0.0,0.0,0.0,0.0,tina robbins,
-MGT,2010,6,Principles of Management,0.46,0.43,0.08,0.01,0.0,0.0,0.0,0.01,tina robbins,
-MGT,2010,7,Principles of Management,0.38,0.39,0.15,0.04,0.01,0.0,0.0,0.02,tina robbins,
-MGT,2010,8,Principles of Management,0.33,0.45,0.16,0.01,0.02,0.0,0.0,0.02,tina robbins,
-MGT,2010,9,Principles of Management (HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
-MGT,2180,1,Management PC Applications,0.45,0.35,0.13,0.01,0.02,0.0,0.0,0.04,ryan toole,
-MGT,2180,2,Management PC Applications,0.49,0.33,0.07,0.03,0.02,0.0,0.0,0.05,ryan toole,
-MGT,2180,3,Management PC Applications,0.56,0.27,0.09,0.02,0.02,0.0,0.0,0.04,ryan toole,
-MGT,2180,4,Management PC Applications,0.42,0.42,0.07,0.04,0.02,0.0,0.0,0.02,ryan toole,
-MGT,2970,1,How to Start a Startup,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,john michael hannon,
-MGT,2970,2,How to Start a Startup,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,john michael hannon,
-MGT,3070,1,Human Resource Management,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,2,Human Resource Management,0.55,0.43,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,3,Human Resource Management,0.53,0.35,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,4,Human Resource Management,0.42,0.33,0.09,0.06,0.06,0.0,0.0,0.03,priscilla harrison,
-MGT,3070,6,Human Resource Management,0.15,0.74,0.12,0.0,0.0,0.0,0.0,0.0,kristin dam scott,
-MGT,3100,1,Intermed Business Statistics,0.5,0.29,0.19,0.0,0.0,0.0,0.0,0.02,jerry kermi bilbrey,
-MGT,3100,2,Intermed Business Statistics,0.25,0.3,0.23,0.03,0.18,0.0,0.0,0.03,ezg akpinar ferrand,
-MGT,3100,3,Intermed Business Statistics,0.36,0.23,0.21,0.08,0.08,0.0,0.0,0.05,ezg akpinar ferrand,
-MGT,3100,4,Intermed Business Statistics,0.18,0.28,0.2,0.28,0.05,0.0,0.0,0.03,sara elizabet yoder,
-MGT,3100,5,Intermed Business Statistics,0.8,0.13,0.04,0.02,0.0,0.0,0.0,0.0,shih lun tseng,
-MGT,3100,6,Intermed Business Statistics,0.44,0.37,0.2,0.0,0.0,0.0,0.0,0.0,jerry kermi bilbrey,
-MGT,3100,7,Intermed Business Statistics,0.17,0.34,0.22,0.1,0.1,0.0,0.0,0.07,sara elizabet yoder,
-MGT,3100,8,Intermed Business Statistics,0.18,0.18,0.38,0.05,0.18,0.0,0.0,0.03,sara elizabet yoder,
-MGT,3100,10,Intermed Business Statistics,0.39,0.42,0.13,0.0,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
-MGT,3100,11,Intermed Business Statistics,0.49,0.18,0.11,0.07,0.09,0.0,0.0,0.07,yunsik choi,
-MGT,3100,12,Intermed Business Statistics,0.21,0.28,0.23,0.05,0.08,0.0,0.0,0.15,dan jiang,
-MGT,3120,1,Decision Models for Management,0.29,0.31,0.29,0.07,0.02,0.0,0.0,0.02,mark mcknew,
-MGT,3120,2,Decision Models for Management,0.22,0.28,0.3,0.09,0.09,0.0,0.0,0.02,mark mcknew,
-MGT,3120,3,Decision Models for Management,0.2,0.32,0.3,0.07,0.07,0.0,0.0,0.05,mark mcknew,
-MGT,3150,1,New Venture Creation,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
-MGT,3180,1,Mgt of Info Systems,0.65,0.25,0.05,0.05,0.0,0.0,0.0,0.0,jackie patri london,
-MGT,3180,2,Mgt of Info Systems,0.78,0.2,0.03,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,
-MGT,3180,3,Mgt of Info Systems,0.18,0.5,0.25,0.0,0.02,0.0,0.0,0.05,russell purvis,
-MGT,3180,4,Mgt of Info Systems,0.39,0.39,0.19,0.03,0.0,0.0,0.0,0.0,roopa raman,
-MGT,3900,2,Ops Mgt,0.23,0.23,0.15,0.15,0.18,0.0,0.0,0.08,niratc tungtisanont,
-MGT,3900,3,Ops Mgt,0.05,0.36,0.36,0.08,0.08,0.0,0.0,0.08,zachary mo leffakis,
-MGT,3900,4,Ops Mgt,0.58,0.23,0.18,0.03,0.0,0.0,0.0,0.0,berna quiroga gomez,
-MGT,3900,5,Ops Mgt,0.18,0.38,0.23,0.13,0.08,0.0,0.0,0.03,shouqiang wang,
-MGT,3900,6,Ops Mgt,0.64,0.26,0.1,0.0,0.0,0.0,0.0,0.0,berna quiroga gomez,
-MGT,4000,2,Mgt of Organizational Behavior,0.53,0.38,0.05,0.0,0.05,0.0,0.0,0.0,michael cole,
-MGT,4000,3,Mgt of Organizational Behavior,0.1,0.46,0.36,0.0,0.08,0.0,0.0,0.0,philip roth,
-MGT,4000,4,Mgt of Organizational Behavior,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4020,1,Ops Pln and Ctl,0.06,0.67,0.22,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,
-MGT,4080,1,Lean Operations,0.29,0.45,0.24,0.0,0.02,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4110,1,Project Management,0.24,0.38,0.29,0.0,0.05,0.0,0.0,0.05,russell purvis,
-MGT,4120,1,Supplier Management,0.18,0.42,0.34,0.05,0.0,0.0,0.0,0.0,shouqiang wang,
-MGT,4150,1,Business Strategy,0.16,0.36,0.4,0.02,0.04,0.0,0.0,0.02,peter gianiodis,
-MGT,4150,2,Business Strategy,0.2,0.56,0.24,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
-MGT,4150,3,Business Strategy,0.36,0.62,0.0,0.0,0.0,0.0,0.0,0.02,john edward hopkins,
-MGT,4150,4,Business Strategy,0.32,0.55,0.13,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,5,Business Strategy,0.48,0.35,0.13,0.02,0.02,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,6,Business Strategy,0.44,0.51,0.04,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4150,7,Business Strategy,0.45,0.52,0.02,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,10,Business Strategy,0.24,0.73,0.02,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
-MGT,4160,1,Special Topics Hr,0.34,0.4,0.26,0.0,0.0,0.0,0.0,0.0,kristin dam scott,
-MGT,4230,1,Intern Bus Mgt,0.08,0.18,0.54,0.05,0.1,0.0,0.0,0.05,wayne stewart,
-MGT,4230,2,Intern Bus Mgt,0.13,0.55,0.3,0.03,0.0,0.0,0.0,0.0,janis miller,
-MGT,4230,3,Intern Bus Mgt,0.14,0.19,0.6,0.05,0.02,0.0,0.0,0.0,wayne stewart,
-MGT,4240,1,Global Supply Chain,0.17,0.58,0.21,0.0,0.04,0.0,0.0,0.0,yann ferrand,
-MGT,4310,1,Emp Rights & Resp,0.31,0.49,0.16,0.02,0.0,0.0,0.0,0.02,leonard jos spooner,
-MGT,4350,1,Pers Interviewing,0.23,0.58,0.13,0.03,0.03,0.0,0.0,0.03,philip roth,
-MGT,4520,1,Business Analysis,0.19,0.43,0.38,0.0,0.0,0.0,0.0,0.0,roopa raman,
-MGT,4550,1,Emerging I T Trends,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MGT,4560,1,Business Info Mgt,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,siyuan li,
-MGT,8120,1,Supply Chain Mgt,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,yann ferrand,
-MICR,3050,1,General Microbiology,0.51,0.34,0.13,0.0,0.0,0.0,0.0,0.01,kristi ja whitehead,
-MICR,3050,2,General Microbiology,0.44,0.37,0.15,0.03,0.01,0.0,0.0,0.01,krista barr rudolph,
-MICR,3050,3,General Microbiology,0.52,0.42,0.02,0.0,0.02,0.0,0.0,0.02,krista barr rudolph,
-MICR,4000,1,Public Health Micro,0.5,0.31,0.09,0.05,0.03,0.0,0.0,0.02,kristi ja whitehead,
-MICR,4020,1,Environmental Micro,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,john michael henson,
-MICR,4070,1,Food and Dairy Micro,0.26,0.46,0.24,0.0,0.0,0.0,0.0,0.04,xiuping jiang,
-MICR,4110,1,Pathogenic Bact,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4120,1,Bacterial Physiology,0.24,0.31,0.22,0.08,0.1,0.0,0.0,0.06,thomas hughes,
-MICR,4130,1,Industrial Micro,0.39,0.37,0.16,0.04,0.01,0.0,0.0,0.03,tzuen-rong je tzeng,
-MICR,4140,1,Basic Immunology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,
-MICR,4170,1,Cancer and Aging,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,yuqing dong,
-MICR,4500,1,Advanced Microbiology I,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4500,2,Advanced Microbiology I,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4500,3,Advanced Microbiology I,0.54,0.15,0.08,0.0,0.08,0.0,0.0,0.15,harry kurtz,
-MICR,4520,1,Advanced Microbiology III,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4930,2,Senior Seminar,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,barbara campbell,
-MKT,3010,1,Prin of Marketing,0.34,0.38,0.17,0.05,0.04,0.0,0.0,0.02,carter wil mcelveen,
-MKT,3010,2,Prin of Marketing,0.26,0.35,0.29,0.05,0.03,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,3,Prin of Marketing,0.21,0.5,0.19,0.03,0.02,0.01,0.0,0.04,james gaubert,
-MKT,3010,4,Prin of Marketing,0.28,0.5,0.19,0.01,0.01,0.0,0.0,0.02,james gaubert,
-MKT,3010,5,Prin of Marketing,0.45,0.38,0.11,0.02,0.04,0.0,0.0,0.0,patricia knowles,
-MKT,3020,1,Consumer Behavior,0.46,0.37,0.12,0.02,0.03,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,2,Consumer Behavior,0.6,0.28,0.09,0.02,0.02,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,3,Consumer Behavior,0.28,0.52,0.13,0.06,0.0,0.0,0.0,0.02, thyroff fitzwater,
-MKT,3020,4,Consumer Behavior,0.35,0.43,0.14,0.05,0.0,0.0,0.0,0.03, thyroff fitzwater,
-MKT,3020,5,Consumer Behavior,0.28,0.48,0.24,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,3210,1,Sports Marketing,0.53,0.39,0.06,0.0,0.02,0.0,0.0,0.0,delancy bennett,
-MKT,3210,2,Sports Marketing,0.5,0.43,0.08,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,
-MKT,3310,1,Marketing Metrics & Analytics,0.26,0.52,0.17,0.04,0.0,0.0,0.0,0.0,peter weathers,
-MKT,3980,1,CI: Sales Experiential,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,
-MKT,4200,1,Professional Selling,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,2,Professional Selling,0.33,0.37,0.17,0.1,0.03,0.0,0.0,0.0,jesse moore,
-MKT,4200,3,Professional Selling,0.84,0.13,0.0,0.0,0.03,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4200,4,Professional Selling,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4230,1,Promotional Strategy,0.44,0.38,0.11,0.02,0.04,0.0,0.0,0.0,patricia knowles,
-MKT,4240,2,Sales Management,0.3,0.66,0.05,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4250,1,Retail Management,0.58,0.38,0.0,0.0,0.02,0.0,0.0,0.02,james gaubert,
-MKT,4270,1,International Mktg,0.2,0.65,0.08,0.03,0.0,0.0,0.0,0.05,thomas poehlman,
-MKT,4270,2,International Mktg,0.23,0.5,0.23,0.02,0.0,0.0,0.0,0.02,roger gomes,
-MKT,4270,3,International Mktg,0.26,0.38,0.33,0.0,0.0,0.0,0.0,0.03,roger gomes,
-MKT,4270,4,International Mktg,0.1,0.49,0.28,0.03,0.08,0.0,0.0,0.03,roger gomes,
-MKT,4270,600,International Mktg,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4280,1,Services Marketing,0.49,0.18,0.23,0.08,0.0,0.0,0.0,0.03,stephen grove,
-MKT,4280,2,Services Marketing,0.28,0.47,0.17,0.08,0.0,0.0,0.0,0.0,stephen grove,
-MKT,4310,1,Marketing Research,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4310,2,Marketing Research,0.25,0.42,0.29,0.0,0.04,0.0,0.0,0.0,william kilbourne,
-MKT,4310,3,Marketing Research,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,4,Marketing Research,0.4,0.48,0.12,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4330,1,Sport Mkt Strategy,0.41,0.48,0.07,0.0,0.0,0.03,0.0,0.0,amanda cooper fine,
-MKT,4430,1,Advertising Strategy,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,albert neil cameron,
-MKT,4450,1,Macromarketing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4500,2,Strategic Mktg Mgt,0.77,0.2,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,
-MKT,4500,3,Strategic Mktg Mgt,0.52,0.41,0.03,0.03,0.0,0.0,0.0,0.0,lura forcum,
-MKT,4500,4,Strategic Mktg Mgt,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,4950,1,Selected Topics: Social Media,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,8620,1,Quant Methods in Mkt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
-MKT,8650,1,Seminar in Mkt Mgmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-ML,1020,1,Leadership Fund II,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,amanda carol kane,
-ML,4020,3,Organizational Leadership II,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,james mullinax,
-MSE,2100,2,Intro to Mat Science,0.16,0.54,0.19,0.02,0.04,0.0,0.0,0.05,kyle brinkman,
-MSE,2100,3,Intro to Mat Science,0.21,0.46,0.16,0.05,0.04,0.0,0.0,0.08,eric skaar,
-MSE,2100,4,Intro to Mat Science,0.4,0.28,0.09,0.09,0.07,0.0,0.0,0.07,olga kuksenok,
-MSE,2100,5,Intro to Mat Science,0.31,0.31,0.27,0.02,0.0,0.0,0.0,0.08,rakhee pani,
-MSE,2410,1,Metrics,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
-MSE,2500,1,Polymer & Fiber Materials I,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,deborah lickfield,
-MSE,2500,2,Polymer & Fiber Materials I,0.36,0.29,0.29,0.0,0.0,0.0,0.0,0.07,deborah lickfield,
-MSE,3260,1,Thermo of Materials,0.15,0.43,0.26,0.08,0.03,0.0,0.0,0.05,gary lickfield,
-MSE,3280,1,Phase Diagrams,0.4,0.37,0.23,0.0,0.0,0.0,0.0,0.0,eric skaar,
-MSE,3610,1,Proc of Metals & Com,0.41,0.36,0.23,0.0,0.0,0.0,0.0,0.0,marian kennedy,
-MSE,4150,1,Polymer Sc Engr,0.33,0.33,0.22,0.07,0.0,0.0,0.0,0.04,igor luzinov,
-MSE,4160,1,Electronic Materials,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
-MSE,4220,1,Mech Behavior of Mat,0.31,0.47,0.17,0.0,0.05,0.0,0.0,0.0,vincent yves blouin,
-MSE,4240,1,Optical Materials,0.28,0.48,0.16,0.08,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,4330,1,Comb Sys & Env Emiss,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,denis brosnan,
-MSE,4560,1,Polymer & Fiber Materials II,0.37,0.41,0.19,0.0,0.0,0.0,0.0,0.04,gary lickfield,
-MSE,4590,2,Color Science Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,philip brown,
-MSE,4910,1,Undergraduate Research,0.59,0.24,0.09,0.03,0.0,0.0,0.0,0.06,marian kennedy,
-MUSC,1110,7,Beginning Class Guitar,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,david stevenson,
-MUSC,1420,1,Music Theory I,0.79,0.07,0.0,0.0,0.07,0.0,0.0,0.07,anthony bernarducci,
-MUSC,1430,1,Aural Skills I,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,anthony bernarducci,
-MUSC,1510,2,Applied Music,0.55,0.0,0.09,0.0,0.09,0.0,0.0,0.27,jonathan edwa doyel,
-MUSC,1800,1,Intro to Music Tech,0.2,0.5,0.1,0.0,0.2,0.0,0.0,0.0,hamilton altstatt,
-MUSC,2100,1,Music in the Western World,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,2100,2,Music in the Western World,0.59,0.22,0.06,0.06,0.0,0.0,0.0,0.06,lisa sain odom,
-MUSC,2100,3,Music in the Western World,0.88,0.06,0.0,0.03,0.03,0.0,0.0,0.0,eric lapin,
-MUSC,2100,4,Music in the Western World,0.65,0.1,0.13,0.06,0.0,0.0,0.0,0.06,linda li-bleuel,
-MUSC,2100,5,Music in the Western World,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,6,Music in the Western World,0.67,0.2,0.07,0.03,0.03,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,7,Music in the Western World,0.48,0.48,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,12,Music in the Western World,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,
-MUSC,2100,13,Music in the Western World,0.84,0.06,0.03,0.0,0.03,0.0,0.0,0.03,linda dzuris,
-MUSC,2100,14,Music in the Western World,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,david conley,
-MUSC,3090,1,Surv of Broadway II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,lisa sain odom,
-MUSC,3110,1,History of American Music,0.78,0.16,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,3170,1,Hist of Country Mus,0.78,0.16,0.0,0.03,0.03,0.0,0.0,0.0,ned hosler,
-MUSC,3180,1,Hist of Audio Tech,0.5,0.21,0.21,0.07,0.0,0.0,0.0,0.0,bruce allen whisler,
-MUSC,3310,1,Pep Band - Men,0.96,0.03,0.0,0.0,0.0,0.0,0.0,0.01,timothy ra hurlburt,
-MUSC,3640,1,Concert Band,0.91,0.01,0.03,0.0,0.0,0.0,0.0,0.04,timothy ra hurlburt,
-MUSC,3690,1,Symphony Orchestra,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,True
-MUSC,3700,1,Clemson University Singers,0.91,0.02,0.05,0.0,0.0,0.0,0.0,0.02,justin durham,
-MUSC,3710,1,Women's Chorus,0.96,0.0,0.02,0.02,0.0,0.0,0.0,0.0,justin durham,
-MUSC,3720,1,Men's Chorus,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,
-MUSC,4160,1,Mus Hist Since 1750,0.39,0.22,0.22,0.06,0.06,0.0,0.0,0.06,linda li-bleuel,
-NPL,3010,2,NPL Stakeholders,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,tracy diane lamb,
-NPL,3030,2,NPL Personnel,0.77,0.09,0.0,0.0,0.09,0.0,0.0,0.05,wendell price,
-NURS,3030,1,Nursing of Adults,0.15,0.75,0.1,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,
-NURS,3030,400,Nursing of Adults,0.08,0.77,0.12,0.0,0.0,0.0,0.0,0.04,lena marie burgess,
-NURS,3040,1,Pathophysiology,0.29,0.47,0.14,0.04,0.02,0.0,0.0,0.04,catherine si murton,
-NURS,3040,401,Pathophysiology for RN,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
-NURS,3100,1,Health Assessment,0.62,0.36,0.0,0.0,0.0,0.0,0.0,0.02,terry kaye busby,
-NURS,3120,1,Foundations of Nursing,0.38,0.51,0.06,0.0,0.02,0.0,0.0,0.02,angela pye,
-NURS,3190,400,Health Assessment for RNs,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,
-NURS,3190,401,Health Assessment for RNs,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kellie davis-hall,
-NURS,3200,1,Prof in Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3300,1,Research in Nursing,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,shirley mae timmons,
-NURS,3330,1,Health Care Genetics,0.93,0.05,0.0,0.02,0.0,0.0,0.0,0.0,jane marie deluca,
-NURS,3330,400,Health Care Genetics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-NURS,3400,1,Pharmther Nursing,0.28,0.53,0.11,0.04,0.0,0.0,0.0,0.04,catherine si murton,
-NURS,3600,400,Social Determinants in Health,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,roxanne amerson,
-NURS,4010,1,Mental Health Nurs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NURS,4100,1,Lead Mgt Practicum,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,
-NURS,4110,1,Nursing of Children,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,
-NURS,4120,1,Nurs Women and Fam,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8010,400,Adv Fam & Comm Nrsng,0.8,0.18,0.02,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
-NURS,8080,400,Nurs Res Stat Analys,0.69,0.28,0.02,0.0,0.02,0.0,0.0,0.0,veronica parker,
-NURS,8190,400,Developing Family,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,paula watt,
-NURS,8200,400,Child & Adol Nursing,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,heide temples,
-NURS,8210,400,Adult Nursing,0.71,0.27,0.0,0.0,0.0,0.0,0.0,0.02,tracy king fasolino,
-NURS,8850,400,Mental Health in Primary Care,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.48,0.32,0.13,0.04,0.02,0.0,0.0,0.02,deborah an hutcheon,
-NUTR,2030,2,Intro Princ of Human Nutrition,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
-NUTR,2040,1,Nutrition Across Life Cycle,0.22,0.53,0.15,0.05,0.03,0.0,0.0,0.02,deborah an hutcheon,
-NUTR,4180,1,Prof Development in Dietetics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
-NUTR,4250,1,Medica Nutr Thera II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4260,1,Community Nutrition,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,katherine cason,
-NUTR,4550,1,Nutr Metabolism,0.34,0.26,0.2,0.14,0.06,0.0,0.0,0.0,elliot jesch,
-NUTR,8030,1,Adv Human Nutr,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,vivian haley-zitlin,
-PA,2800,1,Perf Arts Pract II,0.5,0.29,0.07,0.0,0.0,0.0,0.0,0.14,kenneth moore,
-PA,3010,1,Prin of Arts Admin,0.46,0.23,0.31,0.0,0.0,0.0,0.0,0.0,paul buyer,
-PA,4010,1,Capstone Project,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
-PADM,8210,400,Perspectives on Public Admin,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,
-PADM,8290,400,Public Financial Management,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,
-PADM,8410,400,Public Data Analysis,0.27,0.27,0.18,0.0,0.27,0.0,0.0,0.0,ronald chrestman,
-PADM,8430,400,Info Systems for Public Admin,0.5,0.13,0.13,0.0,0.0,0.0,0.0,0.25,mark daniel mellott,
-PADM,8530,400,Homeland Sec/Emergency Mgt Law,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,david leigh cook,
-PADM,8600,400,American Government,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
-PADM,8720,400,Rural Development,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,
-PADM,8780,400,Nonprofit Marketing & Pub Rel,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,debra nelson,
-PES,2020,1,Soils,0.03,0.5,0.36,0.07,0.0,0.0,0.0,0.03,dara michelle park,
-PES,4050,1,Plant Breeding,0.47,0.33,0.07,0.07,0.0,0.0,0.0,0.07,ksenija gasic,
-PES,4220,1,Major World Crops,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,sruthi naraya kutty,
-PES,4460,1,Soil Management,0.23,0.62,0.08,0.0,0.0,0.0,0.0,0.08,dara michelle park,
-PES,4520,1,Soil Fertility and Management,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,haibo liu,
-PES,4900,1,Soil Organisms in Plant Growth,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,"appukuttan suseela,",
-PES,4960,1,BioIntegrated Greenhouse Sys.,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,geoffrey zehnder,
-PHIL,1010,1,Intro to Philosophic Problems,0.57,0.29,0.09,0.03,0.0,0.0,0.0,0.03,david stegall,
-PHIL,1010,2,Intro to Philosophic Problems,0.56,0.24,0.09,0.06,0.0,0.0,0.0,0.06,david stegall,
-PHIL,1010,5,Intro to Philosophic Problems,0.26,0.4,0.2,0.03,0.06,0.0,0.0,0.06,john randall wolfe,
-PHIL,1010,6,Intro to Philosophic Problems,0.34,0.37,0.14,0.0,0.11,0.0,0.0,0.03,john randall wolfe,
-PHIL,1010,7,Intro to Philosophic Problems,0.44,0.41,0.06,0.03,0.0,0.0,0.0,0.06,john randall wolfe,
-PHIL,1020,1,Introduction to Logic,0.81,0.03,0.13,0.0,0.03,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,2,Introduction to Logic,0.58,0.33,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
-PHIL,1020,3,Introduction to Logic,0.91,0.03,0.0,0.0,0.03,0.0,0.0,0.03,gregory scott moss,
-PHIL,1020,4,Introduction to Logic,0.86,0.09,0.0,0.0,0.03,0.0,0.0,0.03,gregory scott moss,
-PHIL,1020,6,Introduction to Logic,0.45,0.19,0.29,0.06,0.0,0.0,0.0,0.0,stephen satris,
-PHIL,1030,2,Introduction to Ethics,0.17,0.43,0.14,0.11,0.11,0.0,0.0,0.03,malcolm edwa munson,
-PHIL,1030,3,Introduction to Ethics,0.26,0.43,0.29,0.0,0.03,0.0,0.0,0.0,malcolm edwa munson,
-PHIL,1030,5,Introduction to Ethics,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,adam gies,
-PHIL,1030,6,Introduction to Ethics,0.74,0.18,0.03,0.0,0.06,0.0,0.0,0.0,adam gies,
-PHIL,1030,7,Introduction to Ethics,0.41,0.43,0.14,0.03,0.0,0.0,0.0,0.0,ryan lake,
-PHIL,1030,8,Introduction to Ethics,0.41,0.47,0.09,0.03,0.0,0.0,0.0,0.0,ryan lake,
-PHIL,1030,9,Introduction to Ethics,0.47,0.37,0.0,0.0,0.05,0.0,0.0,0.11,ryan lake,
-PHIL,1030,11,Introduction to Ethics,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,jennifer ingle,
-PHIL,1030,12,Introduction to Ethics,0.44,0.41,0.0,0.03,0.0,0.0,0.0,0.12,jennifer ingle,
-PHIL,3030,1,Phil of Religion,0.7,0.23,0.0,0.03,0.0,0.0,0.0,0.03,gregory scott moss,
-PHIL,3150,1,Ancient Philosophy,0.4,0.3,0.13,0.0,0.13,0.0,0.0,0.03,john randall wolfe,
-PHIL,3160,1,Modern Philosophy,0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,michael hal hannen,
-PHIL,3200,1,Soc and Pol Phil,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,david stegall,
-PHIL,3210,1,Crime & Punishment,0.76,0.21,0.0,0.0,0.03,0.0,0.0,0.0,ryan lake,
-PHIL,3260,1,Science and Values,0.53,0.38,0.06,0.0,0.03,0.0,0.0,0.0,andrew garnar,
-PHIL,3260,2,Science and Values,0.53,0.38,0.03,0.0,0.06,0.0,0.0,0.0,andrew garnar,
-PHIL,3430,1,Philosophy of Law,0.7,0.21,0.0,0.0,0.0,0.0,0.0,0.09,david stegall,
-PHIL,3440,1,Business Ethics,0.23,0.69,0.09,0.0,0.0,0.0,0.0,0.0,diane perpich,
-PHIL,3450,1,Environmental Ethics,0.6,0.26,0.06,0.03,0.03,0.0,0.0,0.03,jennifer ingle,
-PHIL,3550,1,Philosophy of Mind & Cog Scien,0.53,0.29,0.0,0.06,0.06,0.0,0.0,0.06,adam gies,
-PHIL,3700,1,Philosophy of War,0.34,0.41,0.13,0.0,0.03,0.0,0.0,0.09,todd may,
-PHIL,4750,1,Philosophy of Film,0.38,0.38,0.06,0.0,0.13,0.06,0.0,0.0,christopher grau,
-PHSC,1170,1,Intro Chem & Earth,0.91,0.08,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics with Calculus I,0.26,0.23,0.26,0.14,0.07,0.0,0.0,0.05,lih-sin the,
-PHYS,1220,2,Physics with Calculus I,0.22,0.35,0.19,0.1,0.06,0.0,0.0,0.08,lih-sin the,
-PHYS,1220,3,Physics with Calculus I,0.27,0.43,0.19,0.06,0.03,0.0,0.0,0.02,lih-sin the,
-PHYS,1220,4,Physics with Calculus I,0.38,0.4,0.14,0.04,0.01,0.0,0.0,0.01,hye jung kang,
-PHYS,1220,5,Physics with Calculus I,0.32,0.37,0.23,0.03,0.03,0.0,0.0,0.02,pooja puneet,
-PHYS,1220,8,Physics With Cal I (HON),0.56,0.26,0.09,0.0,0.0,0.0,0.0,0.09,ramakrishna podila,True
-PHYS,1240,1,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,2,Physics Lab I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,3,Physics Lab I,0.12,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,4,Physics Lab I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,5,Physics Lab I,0.41,0.47,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
-PHYS,1240,6,Physics Lab I,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,7,Physics Lab I,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,8,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,9,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,10,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,11,Physics Lab I,0.22,0.5,0.0,0.0,0.0,0.0,0.0,0.28,jerry hester,
-PHYS,1240,12,Physics Lab I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,13,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,14,Physics Lab I,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,jerry hester,
-PHYS,1240,15,Physics Lab I,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,16,Physics Lab I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,17,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,18,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,19,Physics Lab I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,20,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,21,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,22,Physics Lab I,0.38,0.44,0.0,0.0,0.0,0.0,0.0,0.19,jerry hester,
-PHYS,1240,23,Physics Lab I,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,jerry hester,
-PHYS,1240,24,Physics Lab I,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,25,Physics Lab I,0.24,0.65,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,26,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,27,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,29,Physics Lab I,0.22,0.5,0.17,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,30,Physics Lab I,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2000,1,Introductory Physics,0.26,0.49,0.17,0.09,0.0,0.0,0.0,0.0,sean brittain,
-PHYS,2070,1,General Physics I,0.34,0.36,0.16,0.06,0.03,0.0,0.0,0.05,pooja puneet,
-PHYS,2080,1,General Physics II,0.63,0.25,0.07,0.04,0.0,0.0,0.0,0.0,amy liann pope,
-PHYS,2080,2,General Physics II,0.53,0.31,0.08,0.04,0.03,0.0,0.0,0.0,amy liann pope,
-PHYS,2090,1,Gen Phys Lab I,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,2,Gen Phys Lab I,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,jerry hester,
-PHYS,2090,3,Gen Phys Lab I,0.27,0.55,0.14,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,4,Gen Phys Lab I,0.41,0.41,0.05,0.05,0.0,0.0,0.0,0.09,jerry hester,
-PHYS,2090,5,Gen Phys Lab I,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,6,Gen Phys Lab I,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,7,Gen Phys Lab I,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,8,Gen Phys Lab I,0.57,0.39,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,9,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,10,Gen Phys Lab I,0.14,0.71,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,1,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,2,Gen Phys Lab II,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,3,Gen Phys Lab II,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,5,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,6,Gen Phys Lab II,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,7,Gen Phys Lab II,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,8,Gen Phys Lab II,0.75,0.21,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,9,Gen Phys Lab II,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,10,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,11,Gen Phys Lab II,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,12,Gen Phys Lab II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,13,Gen Phys Lab II,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,14,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,15,Gen Phys Lab II,0.5,0.33,0.08,0.0,0.04,0.0,0.0,0.04,jerry hester,
-PHYS,2100,16,Gen Phys Lab II,0.28,0.61,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,
-PHYS,2100,17,Gen Phys Lab II,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,18,Gen Phys Lab II,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2210,1,Physics with Calculus II,0.28,0.4,0.24,0.04,0.03,0.0,0.0,0.01,jason stratfo brown,
-PHYS,2210,2,Physics with Calculus II,0.33,0.38,0.14,0.11,0.03,0.0,0.0,0.02,jason stratfo brown,
-PHYS,2210,3,Physics with Calculus II,0.36,0.29,0.29,0.0,0.07,0.0,0.0,0.0,murray daw,
-PHYS,2210,5,Physics with Calculus II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,edward collins,
-PHYS,2220,1,Physics with Calculus III,0.36,0.36,0.11,0.0,0.0,0.0,0.0,0.18,jian he,
-PHYS,2230,1,Physics Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,2,Physics Lab II,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,3,Physics Lab II,0.53,0.35,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
-PHYS,2230,4,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,5,Physics Lab II,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,6,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,7,Physics Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,8,Physics Lab II,0.06,0.61,0.17,0.06,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,2230,9,Physics Lab II,0.33,0.4,0.2,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,2230,10,Physics Lab II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,edward collins,
-PHYS,2240,1,Physics Lab III,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,2400,1,Phys of Weather,0.33,0.4,0.18,0.0,0.03,0.0,0.0,0.08,miguel larsen,
-PHYS,3110,1,Methods Theor Phys,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,feng ding,
-PHYS,3220,1,Mechanics II,0.09,0.73,0.09,0.0,0.09,0.0,0.0,0.0,gerald lehmacher,
-PHYS,4650,1,Thermo and Stat Mech,0.33,0.33,0.0,0.08,0.0,0.0,0.0,0.25,jens oberheide,
-PHYS,8150,1,Statistical Therm I,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
-PHYS,8410,1,Electrodynamics I,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-PHYS,9520,1,Quantum Mech II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,sumanta tewari,
-PKSC,1020,1,Intro to Pkg Sci,0.09,0.31,0.32,0.17,0.03,0.0,0.0,0.07,heather batt,
-PKSC,2010,1,Pkg Perishable Prod,0.12,0.41,0.28,0.09,0.08,0.0,0.0,0.03,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2040,1,Container Systems,0.84,0.15,0.01,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2060,1,Container Sys Lab,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2060,2,Container Sys Lab,0.62,0.14,0.24,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2060,3,Container Sys Lab,0.68,0.18,0.14,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2200,1,Product & Pkg Design,0.67,0.21,0.08,0.04,0.0,0.0,0.0,0.0,william aaro snyder,
-PKSC,3200,1,Pkg Design Theory,0.43,0.52,0.02,0.0,0.0,0.0,0.0,0.02,rupert hurley,
-PKSC,3680,1,Pkg and Society,0.57,0.3,0.11,0.02,0.0,0.0,0.0,0.0,heather batt,
-PKSC,4030,1,Pkg Career Prep,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4200,1,Pkg Design & Dev,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4300,1,Converting Flex Pkg,0.25,0.56,0.08,0.08,0.02,0.0,0.0,0.0,duncan darby,
-PKSC,4400,2,Packaging for Distribution,0.25,0.57,0.1,0.04,0.05,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1,Food & Health Care Pkg Systems,0.7,0.22,0.04,0.04,0.0,0.0,0.0,0.0,kay cooksey,
-PLPA,2130,1,Fungi & Civilization,0.42,0.36,0.06,0.08,0.04,0.0,0.0,0.05,julia loui kerrigan,
-PLPA,8090,1,Analytical Technique,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,tharayil-santhakumar,
-POSC,1010,1,Amer National Govt,0.07,0.36,0.27,0.1,0.11,0.0,0.0,0.07,laura olson,
-POSC,1010,2,Amer National Govt,0.1,0.1,0.3,0.3,0.1,0.0,0.0,0.1,adam warber,
-POSC,1020,1,Intro Intl Relations,0.2,0.45,0.18,0.06,0.09,0.0,0.0,0.02,zeynep taydas,
-POSC,1020,2,Intro Intl Relations,0.11,0.29,0.3,0.11,0.12,0.0,0.0,0.06,zeynep taydas,
-POSC,1020,3,Intro Intl Relations,0.17,0.44,0.22,0.05,0.06,0.0,0.0,0.06,aron geo tannenbaum,
-POSC,1030,1,Intro to Political Theory,0.13,0.47,0.21,0.13,0.03,0.0,0.0,0.03,colin pearce,
-POSC,1030,2,Intro to Political Theory,0.18,0.58,0.13,0.0,0.07,0.0,0.0,0.04,kimberly hurd hale,
-POSC,1040,1,Intro Compar Pol,0.38,0.36,0.15,0.07,0.02,0.0,0.0,0.02,katherine am curtis,
-POSC,1040,2,Intro Compar Pol,0.18,0.48,0.1,0.08,0.04,0.0,0.0,0.12,lydia loui lundgren,
-POSC,1990,1,Intro Pol Sci,0.15,0.39,0.15,0.12,0.09,0.0,0.0,0.09,meredith petersheim,
-POSC,3020,1,State and Loc Gov,0.11,0.62,0.16,0.03,0.05,0.0,0.0,0.03,bruce ransom,
-POSC,3210,1,Public Admin,0.05,0.32,0.5,0.05,0.05,0.0,0.0,0.05,james woodard,
-POSC,3410,1,Quant Meth in Pol Sc,0.25,0.17,0.25,0.17,0.08,0.0,0.0,0.08,steven vince miller,
-POSC,3610,1,Intl Pol in Crisis,0.28,0.48,0.18,0.02,0.0,0.0,0.0,0.04,vladimir matic,
-POSC,3620,1,Intl Organizations,0.1,0.2,0.37,0.07,0.13,0.0,0.0,0.13,zeynep taydas,
-POSC,3630,1,Us Foreign Policy,0.16,0.25,0.27,0.14,0.14,0.0,0.0,0.05,steven vince miller,
-POSC,3710,1,European Politics,0.2,0.39,0.27,0.04,0.04,0.0,0.0,0.06,katherine am curtis,
-POSC,4030,1,United States Congress,0.33,0.41,0.22,0.02,0.0,0.0,0.0,0.02,jeffrey scott peake,
-POSC,4050,1,American Presidency,0.07,0.29,0.36,0.07,0.14,0.0,0.0,0.07,adam warber,
-POSC,4160,1,Int Groups & Soc Mov,0.32,0.42,0.16,0.05,0.0,0.0,0.0,0.05,laura olson,
-POSC,4370,1,Constitut Law: Rights & Libert,0.39,0.47,0.04,0.0,0.04,0.0,0.0,0.06,daniel frost,
-POSC,4490,1,Political Theory of Capitalism,0.49,0.23,0.15,0.05,0.08,0.0,0.0,0.0,brandon turner,
-POSC,4500,1,Contemporary Political Thought,0.52,0.36,0.0,0.0,0.04,0.0,0.0,0.08,daniel frost,
-POSC,4570,1,Political Terrorism,0.69,0.21,0.07,0.0,0.02,0.0,0.0,0.0,aron geo tannenbaum,
-POSC,4660,1,African Politics,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,lydia loui lundgren,
-POSC,4760,1,Middle East Politics,0.5,0.31,0.13,0.0,0.06,0.0,0.0,0.0,vladimir matic,
-POSC,4890,1,WW2: World Conflict Ideology,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,james woodard,
-POST,8430,1,Org Theory & Pub Mgt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,
-PRTM,2200,1,Foundations of PRTM,0.41,0.48,0.03,0.0,0.03,0.0,0.0,0.03,teresa walto tucker,
-PRTM,2200,2,Foundations of PRTM,0.67,0.23,0.0,0.07,0.03,0.0,0.0,0.0,gwynn powell,
-PRTM,2200,3,Foundations of PRTM,0.43,0.37,0.1,0.03,0.03,0.0,0.0,0.03,ryan joseph gagnon,
-PRTM,2200,4,Foundations of PRTM,0.22,0.59,0.15,0.0,0.04,0.0,0.0,0.0,dorothy schmalz,
-PRTM,2200,5,Foundations of PRTM,0.63,0.26,0.07,0.0,0.0,0.0,0.0,0.04,william holland,
-PRTM,2200,6,Foundations of PRTM,0.43,0.43,0.11,0.0,0.04,0.0,0.0,0.0,francis mcguire,
-PRTM,2410,1,Intro to CRSCM,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,
-PRTM,2410,2,Intro to CRSCM,0.56,0.29,0.06,0.0,0.03,0.0,0.0,0.06,jeffrey townsend,
-PRTM,2600,1,Found of Recreational Therapy,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
-PRTM,2650,1,Terminology in RT Practice,0.89,0.06,0.03,0.01,0.01,0.0,0.0,0.0,stephen thoma lewis,
-PRTM,2700,1,Intro Rec Res Mgt,0.4,0.43,0.13,0.0,0.03,0.0,0.0,0.0,lincoln larson,
-PRTM,2980,3,Creative Inquiry in PRTM II,0.52,0.39,0.0,0.0,0.04,0.0,0.0,0.04,francis mcguire,
-PRTM,2980,5,Creative Inquiry in PRTM II,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,lawrence allen,
-PRTM,2980,6,Creative Inquiry in PRTM II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brent hawkins,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.34,0.51,0.06,0.03,0.03,0.0,0.0,0.03,daniel mor anderson,
-PRTM,3070,1,Facility Operations,0.79,0.18,0.0,0.0,0.03,0.0,0.0,0.0,craig goodman,
-PRTM,3210,1,Recreation Admin,0.53,0.22,0.19,0.0,0.03,0.0,0.0,0.03,mariela fernandez,
-PRTM,3250,1,Global Persp in Rec,0.31,0.38,0.25,0.0,0.03,0.0,0.0,0.03,teresa walto tucker,
-PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.77,0.2,0.02,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
-PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.36,0.52,0.09,0.02,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3420,1,Intro to Tourism,0.48,0.15,0.22,0.09,0.02,0.0,0.0,0.04,herbert chancellor,
-PRTM,3420,2,Intro to Tourism,0.91,0.07,0.02,0.0,0.0,0.0,0.0,0.0,maloud shakona,
-PRTM,3440,1,Tourism Markets,0.68,0.15,0.1,0.05,0.03,0.0,0.0,0.0,sheila backman,
-PRTM,3440,2,Tourism Markets,0.86,0.07,0.02,0.02,0.0,0.0,0.0,0.02,sheila backman,
-PRTM,3450,1,Tourism Management,0.52,0.24,0.19,0.0,0.05,0.0,0.0,0.0,garrett stone,
-PRTM,3450,2,Tourism Management,0.52,0.23,0.19,0.03,0.03,0.0,0.0,0.0,lauren duffy,
-PRTM,3460,1,Heritage Tourism,0.25,0.44,0.19,0.1,0.02,0.0,0.0,0.0,gregory phi ramshaw,
-PRTM,3530,1,Foundations of Camp Counseling,0.74,0.11,0.16,0.0,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,3900,4,Independent Study in PRTM,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3910,1,Social Media in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james war sanderson,
-PRTM,3910,2,Intro to GIS for PRTM,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0,david lawrenc white,
-PRTM,4210,1,Rec Fin Resc Mgt,0.2,0.3,0.28,0.15,0.03,0.0,0.0,0.05,lawrence allen,
-PRTM,4260,1,Trends & Issues in Rec Therapy,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,4300,1,World Geog Parks,0.27,0.27,0.27,0.09,0.03,0.0,0.0,0.06,robert baxte powell,
-PRTM,4450,1,Conventions,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,jeffery martin,
-PRTM,4460,2,Community Tourism,0.46,0.27,0.04,0.0,0.04,0.0,0.0,0.19,herbert chancellor,
-PRTM,4510,1,Seminar in CRSCM,0.74,0.03,0.13,0.06,0.03,0.0,0.0,0.0,harrison pinckney,
-PRTM,4540,1,Trends in Sport Mgt,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,brandon harris,
-PRTM,4550,1,Adv Program Planning,0.64,0.18,0.14,0.05,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,4980,10,Creative Inquiry in PRTM IV,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
-PRTM,8030,1,Sem Rec & Park Admin,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,teresa walto tucker,
-PRTM,8080,1,Behavioral Aspects,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,8110,1,Research Methods,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,
-PRTM,8110,2,Research Methods,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,lincoln larson,
-PRTM,8210,1,Alt Funding for PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,8250,1,Populations in PRTM,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
-PSYC,2010,1,Intro to Psychology,0.34,0.35,0.22,0.03,0.01,0.0,0.0,0.04,mary taylor,
-PSYC,2010,2,Intro to Psychology,0.31,0.35,0.15,0.11,0.05,0.0,0.0,0.02,jo anne jorgensen,
-PSYC,2010,3,Intro to Psychology,0.39,0.28,0.2,0.06,0.07,0.0,0.0,0.0,mary taylor,
-PSYC,2010,4,Intro to Psychology,0.56,0.27,0.08,0.03,0.03,0.0,0.0,0.02,chong hyon pak,
-PSYC,2010,5,Intro to Psychology,0.23,0.31,0.23,0.06,0.09,0.0,0.0,0.08,edwin brainerd,
-PSYC,2010,6,Intro to Psychology (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True
-PSYC,2020,1,Intro Psychology Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jamie fynes,
-PSYC,2020,4,Intro Psychology Lab,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,natalee kri baldwin,
-PSYC,2020,5,Intro Psychology Lab,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,
-PSYC,2020,6,Intro Psychology Lab,0.85,0.08,0.04,0.0,0.04,0.0,0.0,0.0,madison eliza sauls,
-PSYC,3060,1,Human Sexual Beh,0.53,0.22,0.15,0.05,0.03,0.0,0.0,0.01,bruce michael king,
-PSYC,3090,100,Intro Exp Psych,0.33,0.21,0.21,0.12,0.08,0.0,0.0,0.04,richard tyrrell,
-PSYC,3090,200,Intro Exp Psych,0.83,0.07,0.03,0.03,0.0,0.0,0.0,0.03,alice miche brawley,
-PSYC,3090,300,Intro Exp Psych,0.46,0.36,0.04,0.07,0.0,0.0,0.0,0.07,drew michael morris,
-PSYC,3100,100,Advanced Experimental Psych,0.33,0.52,0.05,0.0,0.0,0.0,0.0,0.1,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimental Psych,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,robert campbell,
-PSYC,3100,300,Advanced Experimental Psych,0.45,0.3,0.1,0.0,0.05,0.0,0.0,0.1,thomas britt,
-PSYC,3100,400,Advanced Experimental Psych,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,3100,500,Advanced Experimental Psych,0.37,0.37,0.26,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3100,600,Advanced Experimental Psych,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3240,1,Physiological Psych,0.27,0.23,0.21,0.09,0.07,0.0,0.0,0.13,june pilcher,
-PSYC,3240,2,Physiological Psych,0.47,0.29,0.11,0.05,0.09,0.0,0.0,0.0,claudio cantalupo,
-PSYC,3330,1,Cognitive Psych,0.32,0.21,0.32,0.15,0.0,0.0,0.0,0.0,thomas alley,
-PSYC,3340,2,Cognitive Psych Lab,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,leo gugerty,
-PSYC,3340,3,Cognitive Psych Lab,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,laura whitlock,
-PSYC,3400,1,Lifespan Developmental Psych,0.29,0.54,0.13,0.01,0.01,0.0,0.0,0.01,jennifer bai bisson,
-PSYC,3400,2,Lifespan Developmental Psych,0.47,0.36,0.13,0.01,0.01,0.0,0.0,0.01,jennifer bai bisson,
-PSYC,3520,1,Social Psychology,0.43,0.35,0.16,0.04,0.01,0.0,0.0,0.0,eric mckibben,
-PSYC,3520,2,Social Psychology,0.5,0.3,0.11,0.07,0.0,0.0,0.0,0.01,eric mckibben,
-PSYC,3520,3,Social Psychology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
-PSYC,3640,1,Industrial Psych,0.43,0.4,0.13,0.03,0.0,0.0,0.0,0.01,eric mckibben,
-PSYC,3640,2,Industrial Psych,0.47,0.4,0.08,0.01,0.01,0.0,0.0,0.01,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.34,0.37,0.19,0.06,0.04,0.0,0.0,0.0,kristen su jennings,
-PSYC,3830,1,Abnormal Psychology,0.54,0.31,0.11,0.03,0.0,0.0,0.0,0.01,jo anne jorgensen,
-PSYC,3830,2,Abnormal Psychology,0.45,0.25,0.2,0.04,0.01,0.0,0.0,0.04,jo anne jorgensen,
-PSYC,3830,3,Abnormal Psychology,0.18,0.38,0.26,0.0,0.09,0.0,0.0,0.09,pamela alley,
-PSYC,3830,4,Abnormal Psychology,0.25,0.36,0.22,0.06,0.08,0.0,0.0,0.03,pamela alley,
-PSYC,4080,1,Women and Psychology,0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,
-PSYC,4150,1,Systems and Theories,0.39,0.43,0.13,0.0,0.0,0.0,0.0,0.04,brian day,
-PSYC,4150,2,Systems and Theories,0.25,0.32,0.18,0.07,0.11,0.0,0.0,0.07,edwin brainerd,
-PSYC,4150,3,Systems and Theories,0.33,0.3,0.11,0.07,0.07,0.0,0.0,0.11,edwin brainerd,
-PSYC,4220,1,Perception,0.1,0.38,0.34,0.1,0.03,0.0,0.0,0.03,christopher pagano,
-PSYC,4220,2,Perception,0.32,0.16,0.36,0.16,0.0,0.0,0.0,0.0,claudio cantalupo,
-PSYC,4220,3,Perception,0.16,0.6,0.04,0.16,0.04,0.0,0.0,0.0,claudio cantalupo,
-PSYC,4350,1,Human Factors,0.64,0.2,0.08,0.08,0.0,0.0,0.0,0.0,laura whitlock,
-PSYC,4710,1,Psych of Testing,0.35,0.5,0.04,0.04,0.04,0.0,0.0,0.04,robert ray sinclair,
-PSYC,4800,1,Health Psychology,0.48,0.44,0.08,0.0,0.0,0.0,0.0,0.0,june pilcher,
-PSYC,4820,1,Positive Psychology,0.46,0.29,0.07,0.07,0.04,0.04,0.0,0.04,cynthia pury,
-PSYC,4880,1,Psychotherapy,0.55,0.18,0.05,0.09,0.05,0.05,0.0,0.05,lucinda sorci quick,
-PSYC,4890,1,Teamwork,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,marissa leig porter,
-PSYC,4890,3,Food & Eating,0.46,0.33,0.13,0.04,0.04,0.0,0.0,0.0,thomas alley,
-PSYC,4920,3,Senior Laboratory,0.88,0.04,0.0,0.08,0.0,0.0,0.0,0.0,stephen robertson,
-PSYC,4920,4,Senior Laboratory,0.83,0.0,0.04,0.0,0.08,0.0,0.0,0.04,stephen robertson,
-PSYC,4920,5,Senior Laboratory,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,leah hartman,
-PSYC,4930,100,Pract Clinical Psych,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,heidi marie zinzow,
-PSYC,8110,1,Research Design II,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,patrick rosopa,
-PSYC,8130,1,Research Design III,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,
-PSYC,8140,1,Quantitative Lab,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,
-PSYC,8330,1,Adv Cog Psych,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,leo gugerty,
-PSYC,8370,1,Ergonomics Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,
-PSYC,8610,1,Personnel Psych,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,fred switzer,
-RCID,8030,1,Emp Res Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
-RED,8010,1,Market Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
-RED,8040,1,Resid Practicum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
-RED,8050,1,Commercial Practicum,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-RED,8120,1,Real Estate Technology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-REL,1010,1,Intro to Religion,0.09,0.25,0.41,0.09,0.13,0.0,0.0,0.03,peter cohen,
-REL,1010,2,Intro to Religion,0.12,0.33,0.33,0.12,0.03,0.0,0.0,0.06,peter cohen,
-REL,1010,3,Intro to Religion,0.03,0.52,0.24,0.09,0.12,0.0,0.0,0.0,peter cohen,
-REL,1020,1,World Religions,0.68,0.22,0.11,0.0,0.0,0.0,0.0,0.0,robert stephens,
-REL,1020,2,World Religions,0.5,0.38,0.09,0.03,0.0,0.0,0.0,0.0,robert stephens,
-REL,1020,4,World Religions,0.47,0.41,0.06,0.06,0.0,0.0,0.0,0.0,robert stephens,
-REL,3010,1,Old Testament,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3030,1,The Quran,0.35,0.39,0.13,0.03,0.06,0.0,0.0,0.03,mashal saif,
-REL,3050,1,Constructing Scripture,0.38,0.38,0.07,0.0,0.03,0.07,0.0,0.07,benjamin white,
-REL,3090,1,Religion of the American South,0.24,0.43,0.19,0.0,0.1,0.0,0.0,0.05,elizabeth jemison,
-REL,3100,1,History of Religion in the US,0.47,0.35,0.06,0.0,0.0,0.0,0.0,0.12,elizabeth jemison,
-REL,3120,1,Hinduism,0.7,0.1,0.0,0.03,0.03,0.0,0.0,0.13,robert stephens,
-REL,3140,1,Buddhism in China,0.35,0.29,0.18,0.0,0.18,0.0,0.0,0.0,yanming an,
-REL,3730,2,Age of Protestant Reformation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,thomas kuehn,
-RS,3010,1,Rural Sociology,0.49,0.24,0.12,0.06,0.0,0.0,0.0,0.08,kenneth robinson,
-SOC,2010,1,Intro to Sociology (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,rachael chatterson,True
-SOC,2010,2,Introduction to Sociology,0.48,0.3,0.09,0.09,0.02,0.0,0.0,0.02,rachael chatterson,
-SOC,2010,3,Introduction to Sociology,0.32,0.43,0.18,0.04,0.01,0.0,0.0,0.01,rachael chatterson,
-SOC,2010,4,Introduction to Sociology,0.63,0.23,0.1,0.0,0.02,0.0,0.0,0.02,shannon mcdonough,
-SOC,2010,5,Introduction to Sociology,0.67,0.23,0.08,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,6,Introduction to Sociology,0.66,0.23,0.05,0.04,0.0,0.0,0.0,0.03,shannon mcdonough,
-SOC,2010,7,Introduction to Sociology,0.28,0.4,0.21,0.02,0.02,0.0,0.0,0.06,mary louise barr,
-SOC,2010,8,Introduction to Sociology,0.43,0.43,0.09,0.0,0.02,0.0,0.0,0.04,mary louise barr,
-SOC,2010,9,Introduction to Sociology,0.44,0.38,0.11,0.0,0.02,0.0,0.0,0.04,mary louise barr,
-SOC,2010,10,Introduction to Sociology,0.45,0.36,0.09,0.04,0.06,0.0,0.0,0.0,mary louise barr,
-SOC,2010,11,Introduction to Sociology,0.61,0.24,0.08,0.04,0.0,0.0,0.0,0.02,jennifer le holland,
-SOC,2010,12,Introduction to Sociology,0.39,0.43,0.15,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2050,1,Sociology Lab,0.56,0.14,0.05,0.07,0.16,0.0,0.0,0.02,brenda vander mey,
-SOC,3020,1,Research Methods I,0.19,0.32,0.38,0.11,0.0,0.0,0.0,0.0,andrew whitehead,
-SOC,3040,1,Social Research Methods II,0.37,0.26,0.26,0.05,0.05,0.0,0.0,0.0,ye luo,
-SOC,3110,1,The Family,0.33,0.29,0.25,0.06,0.02,0.0,0.0,0.04,traci ann hefner,
-SOC,3800,1,Intro Social Service,0.57,0.34,0.06,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,3880,1,Criminal Justice,0.19,0.25,0.27,0.21,0.06,0.0,0.0,0.02,margaret tina britz,
-SOC,3890,1,Criminology,0.41,0.26,0.13,0.09,0.0,0.0,0.0,0.11,william white,
-SOC,3910,1,Soc of Deviance,0.39,0.24,0.2,0.05,0.05,0.0,0.0,0.07,william white,
-SOC,3920,1,Juvenile Delinquency,0.28,0.37,0.28,0.0,0.05,0.0,0.0,0.02,william white,
-SOC,3970,1,Substance Abuse,0.56,0.27,0.08,0.02,0.04,0.0,0.0,0.02,shannon mcdonough,
-SOC,4040,1,Soc Theory,0.47,0.22,0.2,0.09,0.0,0.0,0.0,0.02,william wentworth,
-SOC,4320,1,Soc of Religion,0.33,0.33,0.2,0.1,0.03,0.0,0.0,0.0,andrew whitehead,
-SOC,4330,1,Global Social Change,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,william haller,
-SOC,4590,1,The Community,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
-SOC,4600,1,Race & Ethnicity,0.35,0.46,0.15,0.04,0.0,0.0,0.0,0.0,brenda vander mey,
-SOC,4610,1,Sex & Gender,0.24,0.29,0.29,0.05,0.05,0.0,0.0,0.08,rachael chatterson,
-SOC,4840,1,Child Abuse,0.6,0.19,0.17,0.04,0.0,0.0,0.0,0.0,douglas sturkie,
-SOC,4860,4,Creative Inquiry: Sociology,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,margaret tina britz,
-SOC,4860,5,Creative Inquiry in Sociology,0.65,0.12,0.06,0.0,0.18,0.0,0.0,0.0,margaret tina britz,
-SOC,4930,1,Soc of Corrections,0.5,0.29,0.14,0.0,0.07,0.0,0.0,0.0,william white,
-SOC,4940,1,Organized Crimes,0.27,0.17,0.43,0.07,0.0,0.0,0.0,0.07,margaret tina britz,
-SOC,4950,1,Field Experience,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,4970,1,Senior Lab,0.45,0.27,0.09,0.09,0.09,0.0,0.0,0.0,brenda vander mey,
-SOC,4970,2,Senior Lab,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,brenda vander mey,
-SOC,4990,1,Sel Top Seminar in Contemp Soc,0.57,0.29,0.07,0.07,0.0,0.0,0.0,0.0,david williams,
-SPAN,1010,1,Elementary Spanish,0.39,0.28,0.28,0.0,0.0,0.0,0.0,0.06,scott harris,
-SPAN,1010,2,Elementary Spanish,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1020,1,Elementary Spanish,0.35,0.12,0.24,0.18,0.0,0.0,0.0,0.12,roger simpson,
-SPAN,1020,2,Elementary Spanish,0.42,0.26,0.11,0.11,0.0,0.0,0.0,0.11,roger simpson,
-SPAN,1020,3,Elementary Spanish,0.32,0.37,0.21,0.0,0.05,0.0,0.0,0.05,roger simpson,
-SPAN,1020,4,Elementary Spanish,0.5,0.28,0.11,0.0,0.06,0.0,0.0,0.06,roger simpson,
-SPAN,1020,5,Elementary Spanish,0.35,0.29,0.12,0.06,0.12,0.0,0.0,0.06,roger simpson,
-SPAN,1020,6,Elementary Spanish,0.25,0.25,0.13,0.19,0.13,0.0,0.0,0.06,cathy robison,
-SPAN,1020,7,Elementary Spanish,0.32,0.21,0.26,0.0,0.11,0.0,0.0,0.11,cathy robison,
-SPAN,1020,8,Elementary Spanish,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,ana paula  miller,
-SPAN,1020,9,Elementary Spanish,0.39,0.33,0.06,0.06,0.11,0.0,0.0,0.06,ana paula  miller,
-SPAN,1020,10,Elementary Spanish,0.42,0.17,0.33,0.0,0.0,0.0,0.0,0.08,debra oa williamson,
-SPAN,1020,11,Elementary Spanish,0.26,0.26,0.21,0.16,0.0,0.0,0.0,0.11,debra oa williamson,
-SPAN,2010,1,Intermediate Spanish,0.44,0.28,0.17,0.11,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,2,Intermediate Spanish,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,cathy robison,
-SPAN,2010,3,Intermediate Spanish,0.47,0.16,0.26,0.05,0.05,0.0,0.0,0.0,allison ann hinds,
-SPAN,2010,4,Intermediate Spanish,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
-SPAN,2010,5,Intermediate Spanish,0.33,0.53,0.07,0.07,0.0,0.0,0.0,0.0,allison ann hinds,
-SPAN,2010,6,Intermediate Spanish,0.29,0.29,0.19,0.1,0.1,0.0,0.0,0.05,ricardo tremolada,
-SPAN,2010,7,Intermediate Spanish,0.65,0.15,0.05,0.0,0.0,0.0,0.0,0.15,ricardo tremolada,
-SPAN,2010,8,Intermediate Spanish,0.69,0.13,0.13,0.06,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2010,9,Intermediate Spanish,0.64,0.09,0.09,0.0,0.0,0.0,0.0,0.18,ze cruz valderramos,
-SPAN,2010,10,Intermediate Spanish,0.47,0.26,0.11,0.0,0.0,0.0,0.0,0.16,ricardo tremolada,
-SPAN,2010,11,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2010,12,Intermediate Spanish,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,debra oa williamson,
-SPAN,2010,13,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2010,14,Intermediate Spanish,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2010,15,Intermediate Spanish,0.19,0.63,0.13,0.0,0.0,0.0,0.0,0.06,debra oa williamson,
-SPAN,2020,1,Intermediate Spanish,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,melva margu persico,
-SPAN,2020,2,Intermediate Spanish,0.18,0.47,0.18,0.06,0.06,0.0,0.0,0.06,melva margu persico,
-SPAN,2020,3,Intermediate Spanish,0.5,0.25,0.1,0.1,0.0,0.0,0.0,0.05,juana martin-armas,
-SPAN,2020,4,Intermediate Spanish,0.5,0.22,0.17,0.06,0.06,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,5,Intermediate Spanish,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,6,Intermediate Spanish,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,7,Intermediate Spanish,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,8,Intermediate Spanish,0.22,0.39,0.28,0.06,0.0,0.0,0.0,0.06,heidi montes,
-SPAN,2020,9,Intermediate Spanish,0.41,0.35,0.06,0.12,0.0,0.0,0.0,0.06,heidi montes,
-SPAN,2020,10,Intermediate Spanish,0.5,0.22,0.22,0.06,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,11,Intermediate Spanish,0.45,0.3,0.2,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,12,Intermediate Spanish,0.18,0.5,0.32,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
-SPAN,2020,13,Intermediate Spanish,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,14,Intermediate Spanish,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,19,Intermediate Spanish,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
-SPAN,3020,1,Int Spn Gram & Comp,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,george palacios,
-SPAN,3020,2,Int Spn Gram & Comp,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
-SPAN,3020,3,Int Spn Gram & Comp,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
-SPAN,3040,1,Intro Hisp Lit Forms,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,
-SPAN,3050,1,Int Con Comp Span I,0.31,0.44,0.13,0.06,0.0,0.0,0.0,0.06,raquel anido,
-SPAN,3050,2,Int Con Comp Span I,0.22,0.61,0.06,0.0,0.0,0.0,0.0,0.11,raquel anido,
-SPAN,3050,3,Int Con Comp Span I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,3060,1,Span Comp for Bus,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,3070,1,Hispanic World: Sp,0.29,0.18,0.06,0.06,0.06,0.0,0.0,0.35,juana martin-armas,
-SPAN,3080,1,Hispanic World: La,0.63,0.13,0.13,0.0,0.06,0.0,0.0,0.06,tiffany dawn miller,
-SPAN,3080,2,Hispanic World: La,0.63,0.19,0.13,0.06,0.0,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,3130,1,Span Lit Survey I,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,juana martin-armas,
-SPAN,3140,1,Hispanic Linguistics,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,daniel smith,
-SPAN,3160,1,Span for Intl Trade,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,maureen zamora,
-SPAN,4050,1,Int Trade Film & Lit,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,4060,2,Narrative Fiction,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
-SPAN,4070,1,Hispanic Film,0.42,0.11,0.11,0.16,0.0,0.0,0.0,0.21,raquel anido,
-SPAN,4150,1,Span for Health Prof,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,4150,35,Span for Health Prof,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-SPAN,4170,1,Prof Communication,0.62,0.15,0.23,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,4180,1,Tech Span Health Man,0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,ricardo tremolada,
-SPAN,4350,35,Contemp Hisp Cult,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-STAT,2220,1,Statistics in Everyday Life,0.35,0.39,0.13,0.06,0.04,0.0,0.0,0.04,ros martinez-dawson,
-STAT,2220,2,Statistics in Everyday Life,0.43,0.31,0.09,0.09,0.02,0.0,0.0,0.06,ros martinez-dawson,
-STAT,2220,3,Statistics in Everyday Life,0.57,0.33,0.07,0.0,0.02,0.0,0.0,0.0,gary fellers,
-STAT,2220,4,Statistics in Everyday Life,0.7,0.2,0.06,0.0,0.02,0.0,0.0,0.02,gary fellers,
-STAT,2220,5,Statistics in Everyday Life,0.61,0.24,0.09,0.02,0.02,0.0,0.0,0.02,gary fellers,
-STAT,2220,6,Statistics in Everyday Life,0.54,0.37,0.07,0.0,0.0,0.0,0.0,0.02,gary fellers,
-STAT,2300,1,Statistical Methods I,0.46,0.26,0.15,0.03,0.1,0.0,0.0,0.0,christy jenki brown,
-STAT,2300,2,Statistical Methods I,0.37,0.27,0.19,0.08,0.08,0.0,0.0,0.03,christy jenki brown,
-STAT,2300,3,Statistical Methods I,0.43,0.28,0.16,0.08,0.05,0.0,0.0,0.01,christy jenki brown,
-STAT,2300,4,Statistical Methods I,0.37,0.35,0.1,0.1,0.04,0.0,0.0,0.04,benjamin sharp,
-STAT,2300,5,Statistical Methods I,0.28,0.35,0.16,0.11,0.08,0.0,0.0,0.03,brook thaye russell,
-STAT,2300,6,Statistical Methods I,0.3,0.41,0.19,0.03,0.08,0.0,0.0,0.0, erwin walker,
-STAT,2300,7,Statistical Methods I,0.13,0.38,0.25,0.14,0.06,0.0,0.0,0.05, erwin walker,
-STAT,2300,8,Statistical Methods I,0.2,0.36,0.21,0.11,0.12,0.0,0.0,0.0, erwin walker,
-STAT,3090,1,Introductory Business Stats,0.02,0.29,0.32,0.17,0.1,0.0,0.0,0.1,elaine ma sotherden,
-STAT,3090,2,Introductory Business Stats,0.18,0.29,0.16,0.16,0.11,0.0,0.0,0.11,james espey,
-STAT,3090,3,Introductory Business Stats,0.24,0.26,0.12,0.06,0.15,0.0,0.0,0.18,paul james cubre,
-STAT,3090,4,Introductory Business Stats,0.1,0.32,0.37,0.1,0.07,0.0,0.0,0.05,james espey,
-STAT,3090,5,Introductory Business Stats,0.14,0.33,0.26,0.0,0.21,0.0,0.0,0.05,paul james cubre,
-STAT,3090,6,Introductory Business Stats,0.26,0.29,0.23,0.11,0.06,0.0,0.0,0.06,audrey nico devries,
-STAT,3090,7,Introductory Business Stats,0.13,0.18,0.23,0.13,0.2,0.0,0.0,0.15,drew jared lipman,
-STAT,3090,8,Introductory Business Stats,0.15,0.51,0.15,0.02,0.12,0.0,0.0,0.05,margaret mar wiecek,
-STAT,3090,9,Introductory Business Stats,0.27,0.41,0.22,0.02,0.07,0.0,0.0,0.0,james espey,
-STAT,3090,10,Introductory Business Stats,0.2,0.37,0.2,0.07,0.1,0.0,0.0,0.07,james espey,
-STAT,3090,11,Introductory Business Stats,0.2,0.23,0.33,0.08,0.15,0.0,0.0,0.03,elaine ma sotherden,
-STAT,3090,12,Introductory Business Stats,0.08,0.38,0.18,0.13,0.2,0.0,0.0,0.05,christopher wilson,
-STAT,3090,13,Introductory Business Stats,0.17,0.29,0.17,0.15,0.12,0.0,0.0,0.1,audrey nico devries,
-STAT,3300,1,Statistical Methods II,0.31,0.42,0.08,0.04,0.08,0.0,0.0,0.08,ros martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,4110,1,Stat Mthds for Process Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,
-STAT,4110,2,Stat Mthds for Process Control,0.24,0.52,0.03,0.03,0.06,0.0,0.0,0.12,james rieck,
-STAT,8010,1,Statistical Methods I,0.68,0.19,0.13,0.0,0.0,0.0,0.0,0.0,james rieck,
-STAT,8010,2,Statistical Methods I,0.48,0.39,0.03,0.0,0.0,0.0,0.0,0.09,patrick gerard,
-STAT,8010,3,Statistical Methods I,0.57,0.25,0.04,0.0,0.0,0.0,0.0,0.14,jun luo,
-STAT,8040,1,Sampling,0.35,0.41,0.0,0.0,0.0,0.0,0.0,0.24,patrick gerard,
-STAT,8050,1,Design & Anlys of Experiments,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,8420,230,Intro to Statistical Methods,0.22,0.5,0.11,0.0,0.06,0.0,0.0,0.11,julia lynn sharp,
-STS,1010,1,Survey of S T S,0.44,0.41,0.09,0.0,0.0,0.0,0.0,0.06,allison ann hinds,
-STS,1010,2,Survey of S T S,0.29,0.49,0.09,0.0,0.06,0.0,0.0,0.09,scott brame,
-STS,1010,3,Survey of S T S,0.44,0.28,0.19,0.03,0.03,0.0,0.0,0.03,elizabeth stansell,
-STS,1010,4,Survey of S T S,0.59,0.34,0.03,0.03,0.0,0.0,0.0,0.0,sarah mae cooper,
-STS,1010,5,Survey of S T S,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,philip randall,
-STS,1010,6,Survey of S T S,0.74,0.11,0.11,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
-STS,1010,7,Survey of S T S,0.27,0.46,0.11,0.05,0.03,0.0,0.0,0.08,megan no macalystre,
-STS,1010,8,Survey of S T S,0.23,0.4,0.1,0.1,0.03,0.0,0.0,0.13,david charles foltz,
-THEA,2100,1,Theatre Appreciation,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,richard st. peter,
-THEA,2100,2,Theatre Appreciation,0.87,0.0,0.07,0.0,0.03,0.0,0.0,0.03,kerrie kath seymour,
-THEA,2100,3,Theatre Appreciation,0.76,0.14,0.03,0.03,0.03,0.0,0.0,0.0,kendra lyne johnson,
-THEA,2100,4,Theatre Appreciation,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
-THEA,2100,5,Theatre Appreciation,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
-THEA,2100,6,Theatre Appreciation,0.63,0.34,0.0,0.0,0.0,0.0,0.0,0.03,jason adkins,
-THEA,2670,1,Stage Makeup,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,shannon ther robert,
-THEA,2790,1,Theatre Practicum,0.79,0.0,0.0,0.0,0.14,0.0,0.0,0.07,matthew leckenbusch,
-THEA,3160,1,Theatre History II,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,richard st. peter,
-THEA,3180,1,Afri-Amer Thea II,0.61,0.23,0.13,0.0,0.03,0.0,0.0,0.0,kendra lyne johnson,
-THEA,4790,1,Acting II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,
-THEA,6870,1,Stage Lighting I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
-WFB,3010,1,Wildlife Biology Lab,0.46,0.23,0.31,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3010,2,Wildlife Biology Lab,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,
-WFB,3130,1,Conservation Biology,0.26,0.38,0.29,0.07,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3130,2,Conservation Biology,0.32,0.3,0.26,0.06,0.04,0.0,0.0,0.02,shari lyn rodriguez,
-WFB,3500,1,Princ Fish & Wildlife Biology,0.3,0.43,0.17,0.04,0.04,0.0,0.0,0.04,james davis,
-WFB,3500,2,Princ Fish & Wildlife Biology,0.21,0.41,0.26,0.06,0.03,0.0,0.0,0.03,james davis,
-WFB,4160,1,Fishery Biology,0.21,0.47,0.23,0.04,0.0,0.0,0.0,0.04,yoichiro kanno,
-WFB,4300,1,Wildlife Conservation Policy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,joseph lanham,
-WFB,4620,1,Wetland Wildlife Biology,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,russell barrett,
-WFB,4930,2,Quantitative Ecology,0.37,0.37,0.16,0.02,0.02,0.0,0.0,0.06,david sco jachowski,
-WS,1030,1,Women in Global Perspective,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,
-WS,1030,2,Women in Global Perspective,0.61,0.19,0.08,0.0,0.06,0.0,0.0,0.06,saadiqa kumanyika,
-WS,3010,1,Intro Women's Studies,0.56,0.31,0.08,0.0,0.06,0.0,0.0,0.0,elizabeth ros adams,
-WS,3010,2,Intro Women's Studies,0.41,0.5,0.06,0.0,0.0,0.0,0.0,0.03,elizabeth ros adams,
-YDP,3100,400,Youth Developmt and the Family,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,william quinn,
-YDP,3300,1,Designing Effective Youth Prog,0.7,0.17,0.04,0.0,0.09,0.0,0.0,0.0,kellye rembert,
-YDP,3350,1,Youth Activity Leadership,0.57,0.17,0.04,0.09,0.13,0.0,0.0,0.0,ryan joseph gagnon,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1020,1,Survey of Art & Arch Hist II,0.91,0.07,0.01,0.0,0.0,0.0,0.0,0.01,andrea feeser,,AAH-1020,2016
+AAH,2060,1,Art History and Theory II,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,andrea feeser,,AAH-2060,2016
+AAH,6320,1,Twentieth Century Art II,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,beth ann lauritis,,AAH-6320,2016
+ACCT,2010,1,Financial Accounting Concepts,0.19,0.3,0.32,0.06,0.09,0.0,0.0,0.04,lydia lan schleifer,,ACCT-2010,2016
+ACCT,2010,2,Financial Accounting Concepts,0.35,0.39,0.14,0.03,0.08,0.0,0.0,0.01,holly rhiannio hawk,,ACCT-2010,2016
+ACCT,2010,3,Financial Accounting Concepts,0.19,0.24,0.21,0.14,0.1,0.0,0.0,0.12,philip maiberger,,ACCT-2010,2016
+ACCT,2010,4,Financial Accounting Concepts,0.25,0.24,0.28,0.08,0.06,0.0,0.0,0.08,holly rhiannio hawk,,ACCT-2010,2016
+ACCT,2010,5,Financial Accounting Concepts,0.3,0.3,0.25,0.05,0.05,0.0,0.0,0.05,lydia lan schleifer,,ACCT-2010,2016
+ACCT,2010,6,Financial Accounting Concepts,0.26,0.26,0.24,0.05,0.07,0.0,0.0,0.12,lydia lan schleifer,,ACCT-2010,2016
+ACCT,2010,7,Financial Accounting Concepts,0.11,0.25,0.25,0.07,0.21,0.0,0.0,0.12,tonya dionne smalls,,ACCT-2010,2016
+ACCT,2010,8,Financial Accounting Concepts,0.35,0.3,0.09,0.07,0.05,0.0,0.0,0.14,mary ann  prater,,ACCT-2010,2016
+ACCT,2010,9,Financial Accounting Concepts,0.15,0.27,0.31,0.07,0.02,0.0,0.0,0.18,henry anderson,,ACCT-2010,2016
+ACCT,2010,10,Financial Accounting Concepts,0.27,0.32,0.02,0.07,0.05,0.0,0.0,0.27,mary ann  prater,,ACCT-2010,2016
+ACCT,2010,11,Financial Accounting Concepts,0.11,0.11,0.32,0.11,0.25,0.0,0.0,0.09,henry anderson,,ACCT-2010,2016
+ACCT,2010,12,Financial Accounting Concepts,0.14,0.37,0.19,0.11,0.14,0.0,0.0,0.05,tonya dionne smalls,,ACCT-2010,2016
+ACCT,2010,401,Financial Accounting Concepts,0.14,0.43,0.24,0.08,0.04,0.0,0.0,0.07,jeffrey mcmillan,,ACCT-2010,2016
+ACCT,2020,1,Managerial Accounting Concepts,0.26,0.34,0.17,0.08,0.06,0.0,0.0,0.09,henry anderson,,ACCT-2020,2016
+ACCT,2020,2,Managerial Accounting Concepts,0.18,0.39,0.23,0.09,0.02,0.0,0.0,0.09,henry anderson,,ACCT-2020,2016
+ACCT,2020,3,Managerial Accounting Concepts,0.37,0.24,0.18,0.06,0.08,0.0,0.0,0.06,jace garrett,,ACCT-2020,2016
+ACCT,2020,4,Managerial Accounting Concepts,0.31,0.31,0.19,0.08,0.05,0.0,0.0,0.06,jace garrett,,ACCT-2020,2016
+ACCT,2020,5,Managerial Accounting Concepts,0.32,0.29,0.19,0.14,0.0,0.0,0.0,0.07,derek dalton,,ACCT-2020,2016
+ACCT,2020,401,Managerial Accounting Concepts,0.26,0.21,0.2,0.08,0.1,0.0,0.0,0.16,henry anderson,,ACCT-2020,2016
+ACCT,3030,1,Cost Accounting,0.22,0.59,0.1,0.0,0.02,0.0,0.0,0.08,robin radtke,,ACCT-3030,2016
+ACCT,3030,2,Cost Accounting,0.43,0.28,0.17,0.02,0.02,0.0,0.0,0.09,robin radtke,,ACCT-3030,2016
+ACCT,3030,3,Cost Accounting,0.43,0.33,0.04,0.06,0.02,0.0,0.0,0.12,robin radtke,,ACCT-3030,2016
+ACCT,3030,5,Cost Accounting,0.15,0.23,0.23,0.08,0.08,0.0,0.0,0.23,tonya dionne smalls,,ACCT-3030,2016
+ACCT,3110,1,Intermediate Financial Acct I,0.38,0.46,0.08,0.03,0.03,0.0,0.0,0.03,terry daniel knause,,ACCT-3110,2016
+ACCT,3110,2,Intermediate Financial Acct I,0.06,0.12,0.24,0.15,0.15,0.0,0.0,0.29,brian todd carver,,ACCT-3110,2016
+ACCT,3110,3,Intermediate Financial Acct I,0.5,0.27,0.14,0.05,0.02,0.0,0.0,0.02,terry daniel knause,,ACCT-3110,2016
+ACCT,3110,4,Intermediate Financial Acct I,0.28,0.37,0.22,0.02,0.04,0.02,0.0,0.04,terry daniel knause,,ACCT-3110,2016
+ACCT,3110,5,Intermediate Financial Acct I,0.5,0.25,0.16,0.09,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3110,2016
+ACCT,3120,1,Intermediate Financial Acct II,0.16,0.32,0.26,0.18,0.08,0.0,0.0,0.0,the estate  guffey,,ACCT-3120,2016
+ACCT,3120,2,Intermediate Financial Acct II,0.11,0.23,0.4,0.14,0.06,0.0,0.0,0.06,the estate  guffey,,ACCT-3120,2016
+ACCT,3120,3,Intermediate Financial Acct II,0.03,0.18,0.44,0.21,0.13,0.0,0.0,0.03,brian todd carver,,ACCT-3120,2016
+ACCT,3120,4,Intermediate Financial Acct II,0.03,0.17,0.33,0.23,0.17,0.0,0.0,0.07,brian todd carver,,ACCT-3120,2016
+ACCT,3120,5,Intermediate Financial Acct II,0.24,0.36,0.31,0.04,0.05,0.0,0.0,0.0,jeremy micha vinson,,ACCT-3120,2016
+ACCT,3130,1,Intermediate Fin Acct III,0.11,0.4,0.2,0.14,0.03,0.0,0.0,0.11, russell madray,,ACCT-3130,2016
+ACCT,3130,2,Intermediate Fin Acct III,0.26,0.45,0.21,0.08,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2016
+ACCT,3130,3,Intermediate Fin Acct III,0.38,0.38,0.19,0.03,0.03,0.0,0.0,0.0, russell madray,,ACCT-3130,2016
+ACCT,3130,4,Intermediate Fin Acct III,0.33,0.36,0.26,0.05,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2016
+ACCT,3220,1,Accounting Information Systems,0.1,0.41,0.29,0.07,0.05,0.0,0.0,0.07,philip maiberger,,ACCT-3220,2016
+ACCT,3220,2,Accounting Information Systems,0.21,0.48,0.17,0.05,0.0,0.0,0.0,0.1,philip maiberger,,ACCT-3220,2016
+ACCT,3220,3,Accounting Information Systems,0.14,0.25,0.25,0.07,0.0,0.0,0.0,0.29,philip maiberger,,ACCT-3220,2016
+ACCT,4040,1,Individual Taxation,0.69,0.16,0.1,0.05,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2016
+ACCT,4040,2,Individual Taxation,0.71,0.23,0.04,0.02,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2016
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.34,0.63,0.03,0.0,0.0,0.0,0.0,0.0,holly rhiannio hawk,,ACCT-4100,2016
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,holly rhiannio hawk,,ACCT-4100,2016
+ACCT,4150,1,Auditing,0.26,0.38,0.31,0.05,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-4150,2016
+ACCT,4150,2,Auditing,0.24,0.3,0.3,0.12,0.0,0.0,0.0,0.03,nancy lee harp,,ACCT-4150,2016
+ACCT,8520,1,Fin Acct Theory/Res,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8520,2016
+ACCT,8520,2,Fin Acct Theory/Res,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8520,2016
+ACCT,8520,3,Fin Acct Theory/Res,0.2,0.63,0.17,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8520,2016
+ACCT,8540,1,Prof Responsibility,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2016
+ACCT,8540,2,Prof Responsibility,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2016
+ACCT,8540,3,Prof Responsibility,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2016
+ACCT,8710,1,Corporate Taxation,0.16,0.76,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2016
+ACCT,8710,2,Corporate Taxation,0.3,0.65,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2016
+ACCT,8710,3,Corporate Taxation,0.31,0.67,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2016
+AGED,1000,1,Orientation & Field Experience,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,philip fravel,,AGED-1000,2016
+AGED,2030,1,Teaching Agriscience,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,catheri dibenedetto,,AGED-2030,2016
+AGED,4160,1,Ethics and Issues,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,thomas dobbins,,AGED-4160,2016
+AGED,4250,1,Teaching Ag Mechs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-4250,2016
+AGM,2050,1,Prin of Fabrication,0.12,0.53,0.22,0.08,0.02,0.0,0.0,0.03,hunter massey,,AGM-2050,2016
+AGM,2060,1,Machinery Mgt,0.08,0.32,0.41,0.08,0.05,0.0,0.0,0.05,hunter massey,,AGM-2060,2016
+AGM,2210,1,Land Measurements,0.17,0.52,0.26,0.0,0.04,0.0,0.0,0.0,charles privette,,AGM-2210,2016
+AGM,3030,1,Cal for Mech Ag,0.37,0.42,0.22,0.0,0.0,0.0,0.0,0.0,young han,,AGM-3030,2016
+AGM,4020,1,Landscape Drainage and Irrig,0.16,0.49,0.26,0.07,0.02,0.0,0.0,0.0,charles privette,,AGM-4020,2016
+AGM,4100,1,Precision Ag Tech,0.24,0.58,0.13,0.02,0.02,0.0,0.0,0.0,hunter massey,,AGM-4100,2016
+AGM,4520,1,Mobile Power,0.45,0.29,0.21,0.02,0.02,0.0,0.0,0.0,ali bulent koc,,AGM-4520,2016
+AGM,4720,1,Capstone,0.18,0.5,0.3,0.02,0.0,0.0,0.0,0.0,john chastain,,AGM-4720,2016
+AGRB,2020,1,Agricultural Economics,0.75,0.14,0.03,0.03,0.05,0.0,0.0,0.0,yuliya val bolotova,,AGRB-2020,2016
+AGRB,2050,1,Agriculture and Society,0.46,0.34,0.16,0.02,0.0,0.0,0.0,0.02,lisha zhang,,AGRB-2050,2016
+AGRB,3190,1,Agribusiness Management,0.3,0.3,0.24,0.14,0.02,0.0,0.0,0.0,michael vassalos,,AGRB-3190,2016
+AGRB,3570,1,Natural Resources Economics,0.31,0.15,0.33,0.13,0.04,0.0,0.0,0.04,david brian willis,,AGRB-3570,2016
+AGRB,4020,1,Production Economics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,michael vassalos,,AGRB-4020,2016
+AGRB,4080,1,Quantitative Applied Economics,0.21,0.18,0.42,0.11,0.05,0.0,0.0,0.03,lisha zhang,,AGRB-4080,2016
+AGRB,4520,1,Agricultural Policy,0.35,0.26,0.28,0.09,0.0,0.0,0.0,0.02,michael vassalos,,AGRB-4520,2016
+AGRB,4560,1,Prices,0.47,0.38,0.16,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,,AGRB-4560,2016
+AL,3490,400,Principles of Coaching,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2016
+AL,3490,401,Principles of Coaching,0.44,0.16,0.28,0.04,0.08,0.0,0.0,0.0,deborah cadorette,,AL-3490,2016
+AL,3490,402,Principles of Coaching,0.72,0.2,0.04,0.04,0.0,0.0,0.0,0.0,julia wright,,AL-3490,2016
+AL,3490,405,Principles of Coaching,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,edmond fry,,AL-3490,2016
+AL,3500,400,Sci Basis I/Ex Phy,0.24,0.2,0.36,0.08,0.04,0.0,0.0,0.08,michael godfrey,,AL-3500,2016
+AL,3500,401,Sci Basis I/Ex Phy,0.26,0.35,0.17,0.09,0.04,0.0,0.0,0.09,michael godfrey,,AL-3500,2016
+AL,3520,400,Kinesiology,0.4,0.47,0.07,0.07,0.0,0.0,0.0,0.0,michael godfrey,,AL-3520,2016
+AL,3530,400,Athletic Injuries,0.21,0.25,0.33,0.08,0.08,0.0,0.0,0.04,isaac sean colbert,,AL-3530,2016
+AL,3530,401,Athletic Injuries,0.27,0.27,0.27,0.15,0.04,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2016
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.29,0.33,0.17,0.13,0.04,0.0,0.0,0.04,clyde keith connor,,AL-3600,2016
+AL,3610,400,Admin/Org of Athletic Programs,0.77,0.09,0.05,0.09,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2016
+AL,3610,402,Admin/Org of Athletic Programs,0.72,0.12,0.16,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2016
+AL,3610,403,Admin/Org of Athletic Programs,0.39,0.43,0.09,0.04,0.04,0.0,0.0,0.0,john plumblee,,AL-3610,2016
+AL,3620,400,Psychology of Coaching,0.38,0.33,0.21,0.04,0.04,0.0,0.0,0.0,natalie anne carter,,AL-3620,2016
+AL,3620,401,Psychology of Coaching,0.27,0.42,0.12,0.12,0.04,0.0,0.0,0.04,natalie anne carter,,AL-3620,2016
+AL,3620,402,Psychology of Coaching,0.2,0.4,0.24,0.04,0.08,0.0,0.0,0.04,natalie anne carter,,AL-3620,2016
+AL,3720,400,Coaching Basketball,0.62,0.15,0.12,0.08,0.0,0.0,0.0,0.04,edmond fry,,AL-3720,2016
+AL,3740,400,Coaching Football,0.71,0.08,0.13,0.04,0.04,0.0,0.0,0.0,edmond fry,,AL-3740,2016
+AL,3760,400,Coaching Strength/Conditioning,0.68,0.12,0.16,0.0,0.0,0.0,0.0,0.04,edmond fry,,AL-3760,2016
+AL,4380,400,Coaching Women,0.52,0.33,0.05,0.1,0.0,0.0,0.0,0.0,deborah cadorette,,AL-4380,2016
+AL,4380,410,Coaching Rugby,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,deborah cadorette,,AL-4380,2016
+AL,8530,400,Legal Iss in Intercoll Athlet,0.79,0.08,0.04,0.0,0.08,0.0,0.0,0.0,michael godfrey,,AL-8530,2016
+ANTH,2010,1,Introduction to Anthropology,0.06,0.17,0.32,0.17,0.1,0.0,0.0,0.17,john coggeshall,,ANTH-2010,2016
+ANTH,2010,2,Introduction to Anthropology,0.15,0.57,0.19,0.06,0.0,0.0,0.0,0.02,yi wu,,ANTH-2010,2016
+ANTH,2010,3,Introduction to Anthropology,0.24,0.48,0.2,0.07,0.0,0.0,0.0,0.02,yi wu,,ANTH-2010,2016
+ANTH,3200,1,North American Indian Cultures,0.13,0.38,0.25,0.0,0.06,0.0,0.0,0.19,john coggeshall,,ANTH-3200,2016
+ANTH,3310,1,Archaeology,0.33,0.38,0.19,0.05,0.0,0.0,0.0,0.05,melissa vogel,,ANTH-3310,2016
+ANTH,3510,1,Biological Anthropology,0.21,0.42,0.21,0.05,0.11,0.0,0.0,0.0,lisa rapaport,,ANTH-3510,2016
+ANTH,3530,1,Forensic Anthropology,0.29,0.38,0.21,0.08,0.0,0.0,0.0,0.04,katherine weisensee,,ANTH-3530,2016
+ANTH,4040,1,Anthropological Theories,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,john coggeshall,,ANTH-4040,2016
+ANTH,4510,1,Biol Variation in Human Pop,0.47,0.21,0.16,0.0,0.0,0.0,0.0,0.16,katherine weisensee,,ANTH-4510,2016
+ANTH,4660,1,Evolution of Human Behav,0.21,0.57,0.07,0.0,0.0,0.0,0.0,0.14,lisa rapaport,,ANTH-4660,2016
+APEC,8220,1,Public Policy Econ,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,david brian willis,,APEC-8220,2016
+ARCH,1510,1,Arch Communication,0.33,0.27,0.07,0.07,0.13,0.0,0.0,0.13,sal hambright-belue,,ARCH-1510,2016
+ARCH,1510,2,Arch Communication,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,robert silance,,ARCH-1510,2016
+ARCH,1510,3,Arch Communication,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-1510,2016
+ARCH,1510,4,Arch Communication,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,ladan omidvar,,ARCH-1510,2016
+ARCH,1510,5,Arch Communication,0.36,0.43,0.07,0.14,0.0,0.0,0.0,0.0,sal hambright-belue,,ARCH-1510,2016
+ARCH,2520,1,Arch Foundations II,0.38,0.38,0.15,0.08,0.0,0.0,0.0,0.0,david lee,,ARCH-2520,2016
+ARCH,2520,2,Arch Foundations II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-2520,2016
+ARCH,2520,3,Arch Foundations II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2520,2016
+ARCH,2520,4,Arch Foundations II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,james barker,,ARCH-2520,2016
+ARCH,2520,5,Arch Foundations II,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,ladan omidvar,,ARCH-2520,2016
+ARCH,2700,1,Structures I,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,robert john hogan,,ARCH-2700,2016
+ARCH,2700,2,Structures I,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,dustin gra albright,,ARCH-2700,2016
+ARCH,3530,1,Studio Genoa,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-3530,2016
+ARCH,4010,2,Architectural Portfolio,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,yixiao wang,,ARCH-4010,2016
+ARCH,4520,1,Synthesis Studio,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-4520,2016
+ARCH,4520,2,Synthesis Studio,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-4520,2016
+ARCH,4520,3,Synthesis Studio,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-4520,2016
+ARCH,4520,4,Synthesis Studio,0.1,0.6,0.3,0.0,0.0,0.0,0.0,0.0,criss mills,,ARCH-4520,2016
+ARCH,4710,1,Arch Hist of Place,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,james thomas,,ARCH-4710,2016
+ARCH,4890,1,Internship,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,ashley jennings,,ARCH-4890,2016
+ARCH,4990,13,Biomimicry and Biomimetics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,,ARCH-4990,2016
+ARCH,6880,1,Arch Programming,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-6880,2016
+ARCH,8110,1,Visualization II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-8110,2016
+ARCH,8120,1,Comp Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-8120,2016
+ARCH,8200,1,Bldg Design & Constr,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,ARCH-8200,2016
+ARCH,8420,1,Arch Studio II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,,ARCH-8420,2016
+ARCH,8420,2,Arch Studio II,0.67,0.0,0.33,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-8420,2016
+ARCH,8520,1,Design Studio IV,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,,ARCH-8520,2016
+ARCH,8520,3,Design Studio IV,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-8520,2016
+ARCH,8610,1,History/Theory II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-8610,2016
+ARCH,8620,1,History/Theory III,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-8620,2016
+ARCH,8740,1,Building Process:TR,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,,ARCH-8740,2016
+ARCH,8740,2,Building Process:TR,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,joseph schott,,ARCH-8740,2016
+ARCH,8820,1,Building Economics,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-8820,2016
+ARCH,8900,1,Directed Studies,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,anjali joseph,,ARCH-8900,2016
+ARCH,8920,1,Comprehensive Studio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8920,2016
+ARCH,8920,2,Comprehensive Studio,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-8920,2016
+ARCH,8920,3,Comprehensive Studio,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,,ARCH-8920,2016
+ARCH,8920,4,Comprehensive Studio,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8920,2016
+ARCH,8960,1,A+H Studio: Tectonic,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-8960,2016
+ART,1060,1,Foundation Drawing II,0.6,0.28,0.12,0.0,0.0,0.0,0.0,0.0,carly drew,,ART-1060,2016
+ART,1520,1,Foundations Art II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,,ART-1520,2016
+ART,2050,1,Beginning Life Drawing,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,,ART-2050,2016
+ART,2070,1,Beginning Painting,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,mary jane king,,ART-2070,2016
+ART,2090,1,Beginning Sculpture,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabet cooke,,ART-2090,2016
+ART,2100,400,Art Appreciation,0.54,0.32,0.07,0.04,0.0,0.0,0.0,0.04,lydia jane dorsey,,ART-2100,2016
+ART,2100,401,Art Appreciation,0.45,0.24,0.1,0.0,0.0,0.0,0.0,0.21,lydia jane dorsey,,ART-2100,2016
+ART,2100,402,Art Appreciation,0.57,0.36,0.04,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2016
+ART,2100,403,Art Appreciation,0.29,0.5,0.14,0.04,0.0,0.0,0.0,0.04,lydia jane dorsey,,ART-2100,2016
+ART,2110,1,Begin Printmaking,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,todd denni anderson,,ART-2110,2016
+ART,2130,1,Begin Photography,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,gregory wi shelnutt,,ART-2130,2016
+ART,2170,1,Beginning Ceramics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,en iwamura,,ART-2170,2016
+ART,2210,1,Beginning New Media,0.8,0.0,0.13,0.0,0.07,0.0,0.0,0.0,christina nguy hung,,ART-2210,2016
+ART,4750,1,Senior Exhibition Internship,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,,ART-4750,2016
+AS,1100,1,Air Force Today II,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,christopher mann,,AS-1100,2016
+AS,2100,2,Dev of Air Power II,0.5,0.2,0.3,0.0,0.0,0.0,0.0,0.0,christopher mann,,AS-2100,2016
+AS,2100,3,Dev of Air Power II,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,,AS-2100,2016
+ASL,1010,1,Am Sign Lang I,0.39,0.22,0.33,0.06,0.0,0.0,0.0,0.0,william alton brant,,ASL-1010,2016
+ASL,1010,2,Am Sign Lang I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-1010,2016
+ASL,2010,1,Am Sign Lang II,0.43,0.36,0.21,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-2010,2016
+ASL,2020,1,Am Sign Lang II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-2020,2016
+ASL,2020,2,Am Sign Lang II,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,kim ma misener dunn,,ASL-2020,2016
+ASL,3050,1,Deaf Studies,0.47,0.21,0.32,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-3050,2016
+ASTR,1010,1,Solar System Astronomy,0.35,0.34,0.11,0.08,0.06,0.0,0.0,0.04,sean brittain,,ASTR-1010,2016
+ASTR,1020,1,Stellar Astronomy,0.51,0.31,0.1,0.02,0.04,0.0,0.0,0.02,phillip flower,,ASTR-1020,2016
+ASTR,1020,2,Stellar Astronomy,0.35,0.4,0.14,0.03,0.02,0.0,0.0,0.05,phillip flower,,ASTR-1020,2016
+ASTR,1020,3,Stellar Astronomy,0.28,0.39,0.22,0.06,0.0,0.0,0.0,0.06,phillip flower,,ASTR-1020,2016
+ASTR,1030,1,Solar Systm Astr Lab,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,mark leising,,ASTR-1030,2016
+ASTR,1030,2,Solar Systm Astr Lab,0.69,0.19,0.0,0.04,0.04,0.0,0.0,0.04,mark leising,,ASTR-1030,2016
+ASTR,1040,1,Stellar Astr Lab,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,mark leising,,ASTR-1040,2016
+ASTR,1040,2,Stellar Astr Lab,0.43,0.35,0.04,0.04,0.0,0.0,0.0,0.13,mark leising,,ASTR-1040,2016
+ASTR,1040,3,Stellar Astr Lab,0.74,0.13,0.04,0.0,0.04,0.0,0.0,0.04,mark leising,,ASTR-1040,2016
+ASTR,1040,5,Stellar Astr Lab,0.23,0.32,0.14,0.14,0.14,0.0,0.0,0.05,mark leising,,ASTR-1040,2016
+ASTR,1040,6,Stellar Astr Lab,0.0,0.54,0.23,0.08,0.08,0.0,0.0,0.08,mark leising,,ASTR-1040,2016
+ASTR,3030,1,Galactic Astrophys,0.35,0.41,0.06,0.06,0.0,0.0,0.0,0.12,marco ajello,,ASTR-3030,2016
+AUE,8160,1,Eng Combustion Emiss,0.74,0.24,0.0,0.0,0.0,0.0,0.0,0.02,robert prucka,,AUE-8160,2016
+AUE,8170,3,Alt Energy Sources,0.34,0.61,0.05,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8170,2016
+AUE,8290,4,Tire Behavior,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8290,2016
+AUE,8500,6,Stability/Safety Sys,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,beshah ayalew,,AUE-8500,2016
+AUE,8550,16,Auto Struct Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,,AUE-8550,2016
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.52,0.33,0.03,0.0,0.09,0.0,0.0,0.03,michael mears,,AUE-8690,2016
+AUE,8770,9,Light-Weight Design,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,fadi kama abu-farha,,AUE-8770,2016
+AUE,8860,1,Noise Vibration,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,douglas feldmaier,,AUE-8860,2016
+AUE,8930,3,Applied Dynamics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,,AUE-8930,2016
+AUE,8930,4,Mechanics of Composites Struct,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,,AUE-8930,2016
+AUE,8930,14,Power Electronics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,simona onori,,AUE-8930,2016
+AUE,8930,15,Innov & Entrepreneurship,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,,AUE-8930,2016
+AVS,2000,1,Beef Cattle Tech,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,nathan long,,AVS-2000,2016
+AVS,2010,1,Poultry Techniques,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-2010,2016
+AVS,2060,1,Swine Techniques,0.63,0.26,0.07,0.0,0.02,0.0,0.0,0.02,richelle lor miller,,AVS-2060,2016
+AVS,2090,1,Livestock Exhibition Technique,0.97,0.02,0.02,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-2090,2016
+AVS,3010,1,Anat & Phys Dom Ani,0.67,0.11,0.16,0.04,0.04,0.0,0.0,0.0,tiffany wilmoth,,AVS-3010,2016
+AVS,3100,1,Animal Health,0.42,0.35,0.11,0.03,0.02,0.0,0.0,0.08,thomas scott,,AVS-3100,2016
+AVS,3150,1,Animal Welfare,0.22,0.22,0.39,0.06,0.06,0.0,0.0,0.06,peter skewes,,AVS-3150,2016
+AVS,3700,1,Principles of Animal Nutrition,0.37,0.35,0.18,0.07,0.01,0.0,0.0,0.01,james ro strickland,,AVS-3700,2016
+AVS,3750,1,Applied Animal Nutrition,0.24,0.35,0.33,0.07,0.0,0.0,0.0,0.02,gustavo jos lascano,,AVS-3750,2016
+AVS,4000,1,AVS Professional Development,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,,AVS-4000,2016
+AVS,4000,2,AVS Professional Development,0.77,0.15,0.0,0.08,0.0,0.0,0.0,0.0,johanna joh lascano,,AVS-4000,2016
+AVS,4060,2,Seminars & Related Topics,0.46,0.39,0.14,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2016
+AVS,4100,1,Domestic Ani Behav,0.18,0.5,0.26,0.03,0.02,0.0,0.0,0.01,peter skewes,,AVS-4100,2016
+AVS,4130,1,Animal Products,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-4130,2016
+AVS,4140,1,Basic Immunology,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,thomas scott,,AVS-4140,2016
+AVS,4170,1,Animal Agribusiness Develpmnt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-4170,2016
+AVS,4530,1,Animal Reproduction,0.46,0.36,0.12,0.02,0.02,0.0,0.0,0.02,glenn birrenkott,,AVS-4530,2016
+AVS,4530,400,Animal Reproduction,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-4530,2016
+BCHM,3010,1,Molecular Biochem,0.29,0.23,0.32,0.08,0.06,0.0,0.0,0.02,cheryl ingram-smith,,BCHM-3010,2016
+BCHM,3010,2,Molecular Biochem(HON),0.48,0.29,0.16,0.03,0.0,0.0,0.0,0.03,kerry smith,True,BCHM-3010,2016
+BCHM,3050,1,Essen Elements Bioch,0.37,0.35,0.1,0.06,0.04,0.0,0.0,0.07,srik chandrasekaran,,BCHM-3050,2016
+BCHM,3050,2,Essen Elements Bioch,0.39,0.34,0.14,0.05,0.03,0.0,0.0,0.05,srik chandrasekaran,,BCHM-3050,2016
+BCHM,4320,1,Bioch of Metabolism,0.63,0.15,0.12,0.02,0.02,0.0,0.0,0.05,kimberly paul,,BCHM-4320,2016
+BCHM,4360,1,Genes to Proteins,0.5,0.33,0.1,0.0,0.05,0.0,0.0,0.02,michael glen sehorn,,BCHM-4360,2016
+BCHM,4400,1,Bioinformatics,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,liangjiang wang,,BCHM-4400,2016
+BCHM,4930,1,Senior Seminar,0.55,0.39,0.03,0.0,0.03,0.0,0.0,0.0,james morris,,BCHM-4930,2016
+BE,2100,1,Intro to Biosystems Engr,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,yi zheng,,BE-2100,2016
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.27,0.42,0.23,0.0,0.04,0.0,0.0,0.04,tom owino,,BE-3220,2016
+BE,4120,1,Be Heat Mass Trans,0.52,0.3,0.04,0.0,0.09,0.0,0.0,0.04,caye marie drapcho,,BE-4120,2016
+BE,4150,1,Instr & Control for Biosys Eng,0.67,0.17,0.08,0.04,0.0,0.0,0.0,0.04,yi zheng,,BE-4150,2016
+BE,4380,1,Bioprocess Engineering Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4380,2016
+BE,4730,3,Thermodynamics,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4730,2016
+BIOE,1010,1,Biol for Bioengr,0.51,0.31,0.1,0.02,0.01,0.0,0.0,0.05,vladimir vla reukov,,BIOE-1010,2016
+BIOE,2010,1,Intro Biomed Engr,0.11,0.72,0.11,0.06,0.0,0.0,0.0,0.0,charles webb,,BIOE-2010,2016
+BIOE,3020,1,Biomaterials,0.65,0.28,0.01,0.04,0.0,0.0,0.0,0.01,alexey ale vertegel,,BIOE-3020,2016
+BIOE,3200,1,Biomechanics,0.61,0.26,0.09,0.02,0.0,0.0,0.0,0.02,jiro nagatomi,,BIOE-3200,2016
+BIOE,3210,1,Biofluid Mechanics,0.47,0.36,0.05,0.05,0.03,0.0,0.0,0.04,sarah harcum,,BIOE-3210,2016
+BIOE,3700,1,Bioinst & Imaging,0.58,0.4,0.01,0.0,0.0,0.0,0.0,0.0,delphine dean,,BIOE-3700,2016
+BIOE,4010,1,Bioengineering Design Theory,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,,BIOE-4010,2016
+BIOE,4030,1,Applied Bio E Design,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4030,2016
+BIOE,4200,1,Sports Engineering,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,,BIOE-4200,2016
+BIOE,4230,1,Cardiovascular Engr and Path,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dan simionescu,,BIOE-4230,2016
+BIOE,4310,1,Medical Imaging,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david kwartowitz,,BIOE-4310,2016
+BIOE,4490,1,Drug Delivery,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,frank alexis,,BIOE-4490,2016
+BIOE,6350,1,Modeling of Multiphysics Prob,0.46,0.46,0.0,0.0,0.0,0.0,0.0,0.08,guigen zhang,,BIOE-6350,2016
+BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,martine laberge,,BIOE-8000,2016
+BIOE,8020,410,Biocompatibility,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,,BIOE-8020,2016
+BIOE,8130,1,Industrial Bioengineering,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michael taylor,,BIOE-8130,2016
+BIOE,8410,1,Drug Delivery,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,,BIOE-8410,2016
+BIOE,8500,401,Toolkit - Cell & Molecular Bio,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ann catherine foley,,BIOE-8500,2016
+BIOL,1040,1,General Biology II,0.27,0.34,0.22,0.1,0.03,0.0,0.0,0.05,nora espinoza,,BIOL-1040,2016
+BIOL,1040,2,General Biology II,0.44,0.35,0.12,0.06,0.02,0.0,0.0,0.02,william surver,,BIOL-1040,2016
+BIOL,1040,3,General Biology II,0.15,0.18,0.39,0.16,0.07,0.0,0.0,0.04,salvatore sparace,,BIOL-1040,2016
+BIOL,1060,1,Gen Biology Lab II,0.09,0.27,0.36,0.09,0.18,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,2,Gen Biology Lab II,0.09,0.36,0.45,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,3,Gen Biology Lab II,0.27,0.27,0.27,0.09,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,4,Gen Biology Lab II,0.1,0.33,0.14,0.29,0.05,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,5,Gen Biology Lab II,0.14,0.19,0.29,0.19,0.1,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,6,Gen Biology Lab II,0.27,0.18,0.36,0.0,0.14,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,7,Gen Biology Lab II,0.05,0.3,0.2,0.2,0.15,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,8,Gen Biology Lab II,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,9,Gen Biology Lab II,0.11,0.37,0.26,0.16,0.11,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,10,Gen Biology Lab II,0.1,0.57,0.19,0.1,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,11,Gen Biology Lab II,0.23,0.55,0.14,0.09,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,12,Gen Biology Lab II,0.18,0.41,0.23,0.09,0.09,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,13,Gen Biology Lab II,0.18,0.32,0.23,0.09,0.09,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,14,Gen Biology Lab II,0.32,0.32,0.09,0.14,0.05,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,15,Gen Biology Lab II,0.09,0.18,0.36,0.18,0.14,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,16,Gen Biology Lab II,0.09,0.36,0.36,0.14,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,17,Gen Biology Lab II,0.13,0.3,0.3,0.09,0.17,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,18,Gen Biology Lab II,0.09,0.09,0.26,0.35,0.17,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,19,Gen Biology Lab II,0.23,0.18,0.45,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,20,Gen Biology Lab II,0.23,0.36,0.18,0.18,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,21,Gen Biology Lab II,0.14,0.23,0.41,0.05,0.18,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,22,Gen Biology Lab II,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,23,Gen Biology Lab II,0.09,0.27,0.36,0.14,0.14,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,24,Gen Biology Lab II,0.0,0.22,0.39,0.17,0.13,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,26,Gen Biology Lab II,0.18,0.09,0.32,0.27,0.09,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,27,Gen Biology Lab II,0.29,0.43,0.24,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,28,Gen Biology Lab II,0.23,0.32,0.18,0.27,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,29,Gen Biology Lab II,0.09,0.55,0.14,0.14,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,30,Gen Biology Lab II,0.05,0.45,0.32,0.05,0.09,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,31,Gen Biology Lab II,0.23,0.14,0.32,0.09,0.18,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,33,Gen Biology Lab II,0.04,0.33,0.25,0.17,0.17,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1060,34,Gen Biology Lab II,0.0,0.0,0.4,0.3,0.2,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2016
+BIOL,1090,1,Intro to Life Sci,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,,BIOL-1090,2016
+BIOL,1110,1,Principles of Biology II,0.24,0.44,0.24,0.06,0.0,0.0,0.0,0.02,robert kosinski,,BIOL-1110,2016
+BIOL,1110,2,Principles of Biology II,0.35,0.36,0.15,0.04,0.02,0.0,0.0,0.07,dylan dittrich-reed,,BIOL-1110,2016
+BIOL,1200,1,Biological Inq Lab,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2016
+BIOL,1200,2,Biological Inq Lab,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,,BIOL-1200,2016
+BIOL,1200,3,Biological Inq Lab,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06, christine minor,,BIOL-1200,2016
+BIOL,1200,5,Biological Inq Lab,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0, christine minor,,BIOL-1200,2016
+BIOL,1200,6,Biological Inq Lab,0.4,0.4,0.07,0.0,0.07,0.0,0.0,0.07, christine minor,,BIOL-1200,2016
+BIOL,1230,1,Keys to Human Biol,0.32,0.29,0.22,0.09,0.06,0.0,0.0,0.03, christine minor,,BIOL-1230,2016
+BIOL,2000,2,Biology in the News,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-2000,2016
+BIOL,2000,3,Biology in the News,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,matthew turnbull,,BIOL-2000,2016
+BIOL,2000,6,Biology in the News,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,simon scott,,BIOL-2000,2016
+BIOL,2000,7,Biology in the News,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,john michael henson,,BIOL-2000,2016
+BIOL,2030,1,Human Disease & Soc,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02, christine minor,,BIOL-2030,2016
+BIOL,2040,1,"Environ, Energy and Society",0.52,0.36,0.06,0.01,0.03,0.0,0.0,0.01,john jenkins hains,,BIOL-2040,2016
+BIOL,2040,2,"Environ, Energy and Society",0.48,0.35,0.13,0.0,0.05,0.0,0.0,0.0,john jenkins hains,,BIOL-2040,2016
+BIOL,2110,1,Introduction to Toxicology,0.45,0.48,0.03,0.0,0.0,0.0,0.0,0.03,peter van den hurk,,BIOL-2110,2016
+BIOL,2230,1,Human Anat and Physiology II,0.32,0.35,0.17,0.08,0.05,0.0,0.0,0.02,john cummings,,BIOL-2230,2016
+BIOL,2230,2,Human Anat and Physiology II,0.39,0.38,0.12,0.05,0.03,0.0,0.0,0.03,john cummings,,BIOL-2230,2016
+BIOL,3020,1,Invertebrate Biology,0.11,0.21,0.37,0.18,0.08,0.0,0.0,0.05,juan baeza migueles,,BIOL-3020,2016
+BIOL,3040,1,Biology of Plants,0.47,0.38,0.08,0.03,0.0,0.0,0.0,0.04,christina wells,,BIOL-3040,2016
+BIOL,3060,1,Invertebrate Biology Lab,0.16,0.42,0.21,0.05,0.11,0.0,0.0,0.05,juan baeza migueles,,BIOL-3060,2016
+BIOL,3060,3,Invertebrate Biology Lab,0.11,0.33,0.39,0.11,0.0,0.0,0.0,0.06,juan baeza migueles,,BIOL-3060,2016
+BIOL,3080,1,Biology of Plants Practicum,0.24,0.47,0.12,0.0,0.06,0.0,0.0,0.12,christina wells,,BIOL-3080,2016
+BIOL,3080,2,Biology of Plants Practicum,0.35,0.47,0.0,0.06,0.0,0.0,0.0,0.12,christina wells,,BIOL-3080,2016
+BIOL,3080,3,Biology of Plants Practicum,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,christina wells,,BIOL-3080,2016
+BIOL,3080,4,Biology of Plants Practicum,0.28,0.39,0.22,0.0,0.06,0.0,0.0,0.06,christina wells,,BIOL-3080,2016
+BIOL,3130,1,Conservation Biology,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,BIOL-3130,2016
+BIOL,3130,2,Conservation Biology,0.47,0.21,0.16,0.05,0.11,0.0,0.0,0.0,shari lyn rodriguez,,BIOL-3130,2016
+BIOL,3160,1,Human Physiology,0.35,0.39,0.21,0.03,0.0,0.0,0.0,0.02,tamara mcnutt-scott,,BIOL-3160,2016
+BIOL,3350,1,Evolutionary Biology,0.37,0.4,0.17,0.02,0.01,0.0,0.0,0.02,michael sears,,BIOL-3350,2016
+BIOL,3350,2,Evolutionary Biology (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,margaret ptacek,True,BIOL-3350,2016
+BIOL,3510,1,Biological Anthropology,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,lisa rapaport,,BIOL-3510,2016
+BIOL,3530,1,Forensic Anthropology,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,katherine weisensee,,BIOL-3530,2016
+BIOL,4010,1,Plant Physiology,0.09,0.28,0.3,0.21,0.07,0.0,0.0,0.05,douglas bielenberg,,BIOL-4010,2016
+BIOL,4020,1,Plant Physiology Lab,0.11,0.28,0.33,0.17,0.06,0.0,0.0,0.06,douglas bielenberg,,BIOL-4020,2016
+BIOL,4020,2,Plant Physiology Lab,0.63,0.13,0.19,0.0,0.06,0.0,0.0,0.0,douglas bielenberg,,BIOL-4020,2016
+BIOL,4100,1,Limnology,0.58,0.26,0.1,0.03,0.0,0.0,0.0,0.03,john jenkins hains,,BIOL-4100,2016
+BIOL,4140,1,Basic Immunology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,,BIOL-4140,2016
+BIOL,4340,1,Biological Chem Lab Techniques,0.0,0.27,0.27,0.27,0.13,0.0,0.0,0.07,salvatore sparace,,BIOL-4340,2016
+BIOL,4340,2,Biological Chem Lab Techniques,0.13,0.44,0.38,0.0,0.0,0.0,0.0,0.06,salvatore sparace,,BIOL-4340,2016
+BIOL,4340,3,Biological Chem Lab Techniques,0.0,0.46,0.38,0.15,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2016
+BIOL,4340,4,Biological Chem Lab Techniques,0.29,0.43,0.07,0.0,0.07,0.0,0.0,0.14,salvatore sparace,,BIOL-4340,2016
+BIOL,4610,1,Cell Biology,0.31,0.3,0.18,0.12,0.07,0.0,0.0,0.03,lisa bain,,BIOL-4610,2016
+BIOL,4610,2,Cell Biology (HON),0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,lisa bain,True,BIOL-4610,2016
+BIOL,4610,3,Cell Biology,0.25,0.3,0.29,0.05,0.03,0.0,0.0,0.07,zhicheng dou,,BIOL-4610,2016
+BIOL,4620,1,Cell Biology Lab (Lec),0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,2,Cell Biology Lab (Lec),0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,3,Cell Biology Lab (Lec),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,4,Cell Biology Lab (Lec),0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,5,Cell Biology Lab (Lec),0.75,0.06,0.13,0.0,0.06,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,6,Cell Biology Lab (Lec),0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,7,Cell Biology Lab (Lec),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2016
+BIOL,4620,8,Cell Biology Lab (Lec),0.63,0.0,0.06,0.06,0.0,0.0,0.0,0.25,xianzhong yu,,BIOL-4620,2016
+BIOL,4640,1,Mammalogy,0.48,0.29,0.1,0.1,0.05,0.0,0.0,0.0,john cummings,,BIOL-4640,2016
+BIOL,4660,1,Evolution of Human Behavior,0.29,0.41,0.12,0.06,0.06,0.0,0.0,0.06,lisa rapaport,,BIOL-4660,2016
+BIOL,4700,1,Behavioral Ecology,0.26,0.49,0.19,0.04,0.02,0.0,0.0,0.0,michael childress,,BIOL-4700,2016
+BIOL,4700,2,Behavioral Ecology (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,True,BIOL-4700,2016
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.62,0.24,0.05,0.05,0.0,0.0,0.0,0.05,michael childress,,BIOL-4710,2016
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,michael childress,,BIOL-4710,2016
+BIOL,4710,3,Behavioral Ecology Lab (Lec),0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,michael childress,,BIOL-4710,2016
+BIOL,4710,4,Behavioral Ecology Lab (Lec),0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,michael childress,,BIOL-4710,2016
+BIOL,4930,2,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,,BIOL-4930,2016
+BIOL,4930,4,Senior Seminar,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,,BIOL-4930,2016
+BIOL,4930,5,Senior Seminar,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4930,2016
+BIOL,4930,6,Senior Seminar,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,william baldwin,,BIOL-4930,2016
+BIOL,4960,1,Biodiversity & Conserv in Asia,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,,BIOL-4960,2016
+BIOL,8430,1,Underst Genetics & Evol Biol,0.85,0.12,0.01,0.0,0.0,0.0,0.0,0.02,margaret ptacek,,BIOL-8430,2016
+BIOL,8450,1,Understanding Animal Biology,0.86,0.12,0.01,0.0,0.0,0.0,0.0,0.01,matthew turnbull,,BIOL-8450,2016
+BIOL,8470,1,Understanding Microbiology,0.63,0.28,0.07,0.0,0.01,0.0,0.0,0.01,harry kurtz,,BIOL-8470,2016
+BIOL,8480,1,Understanding Scientific Rsrch,0.9,0.0,0.0,0.0,0.02,0.0,0.0,0.07,robert edwa ballard,,BIOL-8480,2016
+BMOL,4250,1,Biomolecular Engineering,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,mark alan blenner,,BMOL-4250,2016
+BUS,1010,1,Business Foundations,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,2,Business Foundations,0.22,0.52,0.19,0.04,0.0,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2016
+BUS,1010,3,Business Foundations,0.35,0.54,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,4,Business Foundations,0.27,0.54,0.12,0.04,0.0,0.0,0.0,0.04,william ern tumblin,,BUS-1010,2016
+BUS,1010,5,Business Foundations,0.39,0.43,0.11,0.0,0.0,0.0,0.0,0.07,william ern tumblin,,BUS-1010,2016
+BUS,1010,6,Business Foundations,0.22,0.44,0.19,0.04,0.0,0.0,0.0,0.11,william ern tumblin,,BUS-1010,2016
+BUS,1010,7,Business Foundations,0.23,0.46,0.19,0.04,0.04,0.0,0.0,0.04,william ern tumblin,,BUS-1010,2016
+BUS,1010,8,Business Foundations,0.28,0.52,0.14,0.03,0.0,0.0,0.0,0.03,william ern tumblin,,BUS-1010,2016
+BUS,1010,9,Business Foundations,0.33,0.44,0.19,0.0,0.04,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+BUS,1010,10,Business Foundations,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2016
+CE,2010,1,Statics,0.66,0.11,0.18,0.0,0.02,0.0,0.0,0.02,sara khoshnevisan,,CE-2010,2016
+CE,2010,2,Statics,0.19,0.35,0.19,0.03,0.08,0.0,0.0,0.16,melissa sternhagen,,CE-2010,2016
+CE,2010,3,Statics,0.43,0.36,0.16,0.05,0.0,0.0,0.0,0.0,thomas edfo cousins,,CE-2010,2016
+CE,2010,4,Statics,0.16,0.26,0.21,0.13,0.11,0.0,0.0,0.13,melissa sternhagen,,CE-2010,2016
+CE,2010,5,Statics,0.53,0.35,0.05,0.0,0.03,0.0,0.0,0.03,mahmoodreza soltani,,CE-2010,2016
+CE,2010,6,Statics,0.24,0.65,0.07,0.02,0.0,0.0,0.0,0.02, kent nilsson,,CE-2010,2016
+CE,2010,7,Statics,0.27,0.38,0.1,0.06,0.02,0.0,0.0,0.17,thomas edfo cousins,,CE-2010,2016
+CE,2060,1,Structural Mechanics,0.28,0.38,0.26,0.03,0.05,0.0,0.0,0.0,bryant nielson,,CE-2060,2016
+CE,2060,2,Structural Mechanics,0.3,0.35,0.25,0.05,0.02,0.0,0.0,0.04,bryant nielson,,CE-2060,2016
+CE,2080,1,Dynamics,0.12,0.42,0.22,0.02,0.08,0.0,0.0,0.14,melissa sternhagen,,CE-2080,2016
+CE,2080,2,Dynamics,0.14,0.36,0.27,0.09,0.05,0.0,0.0,0.09,melissa sternhagen,,CE-2080,2016
+CE,2080,3,Dynamics,0.28,0.38,0.2,0.08,0.0,0.0,0.0,0.08,thomas edfo cousins,,CE-2080,2016
+CE,2550,1,Geomatics,0.32,0.45,0.14,0.0,0.07,0.0,0.0,0.02,wayne sarasua,,CE-2550,2016
+CE,3010,1,Structural Analysis,0.27,0.27,0.3,0.03,0.09,0.0,0.0,0.03,stephen csernak,,CE-3010,2016
+CE,3110,1,Transportation Engr,0.35,0.35,0.18,0.05,0.04,0.0,0.0,0.03,yongxi huang,,CE-3110,2016
+CE,3210,1,Geotechnical Engineering,0.56,0.28,0.08,0.03,0.05,0.0,0.0,0.0,charng-hsein juang,,CE-3210,2016
+CE,3210,2,Geotechnical Engineering,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,sara khoshnevisan,,CE-3210,2016
+CE,3310,1,Constr Engr & Mgmnt,0.33,0.37,0.24,0.02,0.04,0.0,0.0,0.0,james burati,,CE-3310,2016
+CE,3410,1,Intro to Fluid Mech,0.35,0.35,0.23,0.08,0.0,0.0,0.0,0.0,nigel gregory kaye,,CE-3410,2016
+CE,3410,2,Intro to Fluid Mech,0.36,0.42,0.12,0.0,0.06,0.0,0.0,0.03,nigel gregory kaye,,CE-3410,2016
+CE,3420,1,Hydraulics & Hydro,0.21,0.36,0.29,0.05,0.05,0.0,0.0,0.05,abdul khan,,CE-3420,2016
+CE,3420,2,Hydraulics & Hydro,0.51,0.36,0.1,0.0,0.0,0.0,0.0,0.03,ashok mishra,,CE-3420,2016
+CE,3510,1,Civil Engineering Materials,0.31,0.54,0.1,0.0,0.03,0.0,0.0,0.03,prasada rangaraju,,CE-3510,2016
+CE,3520,1,Econ Eval of Proj,0.38,0.4,0.04,0.11,0.02,0.0,0.0,0.04,james burati,,CE-3520,2016
+CE,3520,2,Econ Eval of Proj,0.58,0.25,0.13,0.03,0.0,0.0,0.0,0.03,bradley putman,,CE-3520,2016
+CE,3530,1,Professional Seminar,0.95,0.03,0.02,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,,CE-3530,2016
+CE,4020,1,Reinfor Con Design,0.5,0.3,0.1,0.04,0.03,0.0,0.0,0.03,brandon ross,,CE-4020,2016
+CE,4080,1,Struct Loads & Sys,0.27,0.35,0.19,0.12,0.04,0.0,0.0,0.04,bryant nielson,,CE-4080,2016
+CE,4110,1,Roadway Geo Design,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,jennifer ogle,,CE-4110,2016
+CE,4120,1,Urban Transport Plan,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-4120,2016
+CE,4210,1,Geotechnical Design,0.28,0.42,0.23,0.02,0.02,0.0,0.0,0.02,nadara ravichandran,,CE-4210,2016
+CE,4340,1,Const Est Proj Cont,0.73,0.21,0.04,0.0,0.01,0.0,0.0,0.0,kalyan ram piratla,,CE-4340,2016
+CE,4360,1,Sustainable Constr,0.83,0.16,0.02,0.0,0.0,0.0,0.0,0.0,leidy klotz,,CE-4360,2016
+CE,4590,1,Capstone Design Proj,0.48,0.46,0.04,0.03,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2016
+CE,4910,1,Non-Destructive Evaluation,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,ami esmaeilpoursaee,,CE-4910,2016
+CE,6080,1,Struct Loads & Sys,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,bryant nielson,,CE-6080,2016
+CE,6340,1,Const Est Proj Cont,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-6340,2016
+CE,6360,1,Sustainable Constr,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,,CE-6360,2016
+CE,6430,1,Water Resources Engr,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,abdul khan,,CE-6430,2016
+CE,6910,1,Non-Destructive Evaluation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,,CE-6910,2016
+CE,8010,1,Finite Ele Analysis,0.35,0.47,0.06,0.0,0.0,0.0,0.0,0.12,nadara ravichandran,,CE-8010,2016
+CE,8280,1,Rep/Rehab of Con Str,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,prasada rangaraju,,CE-8280,2016
+CE,8530,1,Apps in Traffic En,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,mashrur chowdhury,,CE-8530,2016
+CE,8930,1,Selec Topics in CE - Hwy Bridg,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,,CE-8930,2016
+CE,8930,2,Selec Topics in CE-Risk Assess,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-8930,2016
+CE,8930,4,Select Topics in CE - Poromech,0.56,0.22,0.0,0.0,0.11,0.0,0.0,0.11,qiushi chen,,CE-8930,2016
+CE,8930,400,Selec Topics in CE-Human Fact,0.71,0.17,0.0,0.0,0.08,0.0,0.0,0.04,kap chalil madathil,,CE-8930,2016
+CH,1010,1,General Chemistry,0.1,0.37,0.25,0.11,0.1,0.0,0.0,0.06,ava kreider-mueller,,CH-1010,2016
+CH,1010,2,General Chemistry,0.23,0.27,0.23,0.15,0.09,0.0,0.0,0.05,ava kreider-mueller,,CH-1010,2016
+CH,1010,3,General Chemistry,0.21,0.31,0.25,0.1,0.1,0.0,0.0,0.04,dennis taylor,,CH-1010,2016
+CH,1010,4,General Chemistry,0.0,0.1,0.13,0.13,0.35,0.0,0.0,0.29,william joh wallace,,CH-1010,2016
+CH,1010,400,General Chemistry,0.17,0.2,0.29,0.2,0.06,0.0,0.0,0.08,stephe schvaneveldt,,CH-1010,2016
+CH,1020,1,General Chemistry,0.32,0.39,0.18,0.05,0.02,0.0,0.0,0.04,tania issa houjeiry,,CH-1020,2016
+CH,1020,2,General Chemistry,0.26,0.42,0.2,0.06,0.02,0.0,0.0,0.04,dennis taylor,,CH-1020,2016
+CH,1020,3,General Chemistry,0.27,0.39,0.23,0.05,0.02,0.0,0.0,0.04,dennis taylor,,CH-1020,2016
+CH,1020,4,General Chemistry,0.02,0.15,0.28,0.17,0.13,0.0,0.0,0.26,william joh wallace,,CH-1020,2016
+CH,1020,5,General Chemistry,0.05,0.35,0.1,0.1,0.3,0.0,0.0,0.1,william joh wallace,,CH-1020,2016
+CH,1020,6,General Chemistry,0.23,0.4,0.22,0.06,0.02,0.0,0.0,0.08,olt geiculescu,,CH-1020,2016
+CH,1020,7,General Chemistry,0.26,0.32,0.25,0.08,0.05,0.0,0.0,0.04,thomas hickman,,CH-1020,2016
+CH,1020,8,General Chemistry,0.14,0.41,0.25,0.08,0.02,0.0,0.0,0.11,elliot ennis,,CH-1020,2016
+CH,1020,9,General Chemistry,0.24,0.46,0.21,0.03,0.03,0.0,0.0,0.03,thomas hickman,,CH-1020,2016
+CH,1020,10,General Chemistry,0.26,0.43,0.21,0.05,0.03,0.0,0.0,0.03,ava kreider-mueller,,CH-1020,2016
+CH,1020,11,General Chemistry,0.16,0.26,0.37,0.0,0.05,0.0,0.0,0.16,christopher wilson,,CH-1020,2016
+CH,1020,13,General Chemistry,0.53,0.37,0.0,0.11,0.0,0.0,0.0,0.0,edward collins,,CH-1020,2016
+CH,1020,50,General Chemistry,0.38,0.19,0.38,0.0,0.0,0.0,0.0,0.05,shiou-jyh hwu,,CH-1020,2016
+CH,1020,51,General Chemistry (HON),0.78,0.11,0.04,0.0,0.0,0.0,0.0,0.07,stephe schvaneveldt,True,CH-1020,2016
+CH,1020,52,General Chemistry (HON),0.8,0.16,0.02,0.0,0.0,0.0,0.0,0.02,stephe schvaneveldt,True,CH-1020,2016
+CH,1050,1,Chemistry in Context I,0.58,0.31,0.05,0.0,0.0,0.0,0.0,0.06,christopher wilson,,CH-1050,2016
+CH,1060,1,Chemistry in Context II,0.42,0.33,0.14,0.08,0.0,0.0,0.0,0.03,olt geiculescu,,CH-1060,2016
+CH,1060,2,Chemistry in Context II,0.38,0.31,0.23,0.08,0.0,0.0,0.0,0.0,olt geiculescu,,CH-1060,2016
+CH,1520,1,Chem Commun I,0.81,0.05,0.05,0.0,0.03,0.0,0.0,0.05,richard marcus,,CH-1520,2016
+CH,2010,1,Survey of Organic Chemistry,0.37,0.34,0.16,0.06,0.05,0.0,0.0,0.02,tania issa houjeiry,,CH-2010,2016
+CH,2020,1,Surv of Organic Chemistry Lab,0.73,0.0,0.07,0.0,0.0,0.0,0.0,0.2,sean 'connor,,CH-2020,2016
+CH,2020,2,Surv of Organic Chemistry Lab,0.5,0.28,0.06,0.0,0.06,0.0,0.0,0.11,sean 'connor,,CH-2020,2016
+CH,2050,1,Intro Inorg Chem,0.44,0.28,0.25,0.0,0.0,0.0,0.0,0.03,william pennington,,CH-2050,2016
+CH,2230,1,Organic Chemistry,0.21,0.32,0.25,0.09,0.05,0.0,0.0,0.07,jacob schroeder,,CH-2230,2016
+CH,2230,2,Organic Chemistry,0.26,0.32,0.2,0.13,0.05,0.0,0.0,0.04,jacob schroeder,,CH-2230,2016
+CH,2230,3,Organic Chemistry,0.13,0.38,0.22,0.13,0.08,0.0,0.0,0.05,jacob schroeder,,CH-2230,2016
+CH,2240,1,Organic Chemistry,0.24,0.4,0.24,0.02,0.05,0.0,0.0,0.04,thomas hickman,,CH-2240,2016
+CH,2240,2,Organic Chemistry,0.34,0.32,0.19,0.09,0.03,0.0,0.0,0.02,elliot ennis,,CH-2240,2016
+CH,2240,3,Organic Chemistry,0.32,0.36,0.25,0.01,0.02,0.0,0.0,0.03,elliot ennis,,CH-2240,2016
+CH,2240,4,Organic Chemistry,0.24,0.36,0.14,0.04,0.1,0.0,0.0,0.13,rhett smith,,CH-2240,2016
+CH,2240,5,Organic Chemistry,0.13,0.23,0.35,0.06,0.03,0.0,0.0,0.19,dev priya arya,,CH-2240,2016
+CH,2270,3,Organic Chem Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,4,Organic Chem Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,5,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2016
+CH,2270,7,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,9,Organic Chem Lab,0.8,0.0,0.07,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2016
+CH,2270,11,Organic Chem Lab,0.81,0.0,0.0,0.0,0.06,0.0,0.0,0.13,sean 'connor,,CH-2270,2016
+CH,2270,12,Organic Chem Lab,0.63,0.31,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,,CH-2270,2016
+CH,2270,14,Organic Chem Lab,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,sean 'connor,,CH-2270,2016
+CH,2280,3,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2280,2016
+CH,2280,4,Organic Chem Lab,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,,CH-2280,2016
+CH,2280,6,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2280,2016
+CH,2280,11,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2280,2016
+CH,2280,15,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,,CH-2280,2016
+CH,2280,16,Organic Chem Lab,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,sean 'connor,,CH-2280,2016
+CH,2280,17,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2280,2016
+CH,2280,20,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2280,2016
+CH,2280,26,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,,CH-2280,2016
+CH,2280,27,Organic Chem Lab,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,sean 'connor,,CH-2280,2016
+CH,2290,3,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2290,2016
+CH,3310,1,Physical Chemistry,0.47,0.35,0.12,0.0,0.0,0.0,0.0,0.06,arkady kholodenko,,CH-3310,2016
+CH,3320,1,Physical Chemistry,0.31,0.51,0.1,0.04,0.0,0.0,0.0,0.04,steven stuart,,CH-3320,2016
+CH,3320,2,Physical Chemistry,0.39,0.21,0.32,0.05,0.03,0.0,0.0,0.0,jason mcneill,,CH-3320,2016
+CH,3320,3,Physical Chemistry,0.58,0.17,0.13,0.04,0.08,0.0,0.0,0.0,leah bec casabianca,,CH-3320,2016
+CH,3400,5,Physical Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,christopher wilson,,CH-3400,2016
+CH,3600,1,Chemical Biology,0.38,0.36,0.16,0.02,0.02,0.0,0.0,0.07,modi wetzler,,CH-3600,2016
+CH,4110,1,Instrumental Analy,0.26,0.39,0.13,0.09,0.13,0.0,0.0,0.0,george chumanov,,CH-4110,2016
+CH,4120,1,Instr Analysis Lab,0.27,0.45,0.0,0.09,0.18,0.0,0.0,0.0,jeffrey natha anker,,CH-4120,2016
+CH,4130,1,Chemistry of Aqueous Systems,0.43,0.4,0.17,0.0,0.0,0.0,0.0,0.0,cindy lee,,CH-4130,2016
+CH,4250,1,Medicinal Chem,0.33,0.0,0.33,0.0,0.0,0.0,0.0,0.33,dev priya arya,,CH-4250,2016
+CH,4500,1,Chemistry Capstone,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,,CH-4500,2016
+CH,6140,1,Bioanalytical Chem,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,carlos garcia perez,,CH-6140,2016
+CH,8050,1,Theor Inorg Chem,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,joseph kolis,,CH-8050,2016
+CH,8180,1,Surface Analysis,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,stephen creager,,CH-8180,2016
+CH,8220,1,Organic Chem II,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,daniel whitehead,,CH-8220,2016
+CH,8340,1,Stat Thermodynamics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,brian dominy,,CH-8340,2016
+CH,8510,1,Grad Student Seminar,0.73,0.13,0.13,0.0,0.0,0.0,0.0,0.0,joseph stu thrasher,,CH-8510,2016
+CHE,1300,1,Chemical Eng Tools,0.16,0.35,0.14,0.11,0.16,0.0,0.0,0.09,christopher norfolk,,CHE-1300,2016
+CHE,1300,2,Chemical Eng Tools,0.31,0.18,0.13,0.13,0.16,0.0,0.0,0.08,christopher norfolk,,CHE-1300,2016
+CHE,2200,2,Ch E Thermo I,0.18,0.21,0.37,0.06,0.15,0.0,0.0,0.03,joseph scott,,CHE-2200,2016
+CHE,2300,1,Fluids/Heat Transfer,0.1,0.33,0.34,0.13,0.07,0.0,0.0,0.03,douglas hirt,,CHE-2300,2016
+CHE,2300,2,Fluids/Heat Transfer,0.13,0.24,0.4,0.15,0.04,0.0,0.0,0.05,eric mikel davis,,CHE-2300,2016
+CHE,3210,1,Ch E Thermo II,0.13,0.23,0.4,0.18,0.03,0.0,0.0,0.03,sapna sarupria,,CHE-3210,2016
+CHE,3300,1,Mass Trans & Seprtn,0.18,0.24,0.35,0.14,0.05,0.0,0.0,0.05,mark thies,,CHE-3300,2016
+CHE,3530,1,Proc Dyn & Control,0.24,0.39,0.33,0.02,0.02,0.0,0.0,0.0,mark roberts,,CHE-3530,2016
+CHE,4330,1,Process Design II,0.6,0.23,0.17,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4330,2016
+CHE,8340,1,CHE Polymer Thermodynamics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark thies,,CHE-8340,2016
+CHIN,1010,1,Elementary Chinese,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yanlin wang,,CHIN-1010,2016
+CHIN,1020,1,Elementary Chinese,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,yanlin wang,,CHIN-1020,2016
+CHIN,2010,1,Intermediate Chinese,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,yanhua zhang,,CHIN-2010,2016
+CHIN,4010,1,Pre-Modern Chinese Literature,0.3,0.5,0.15,0.0,0.05,0.0,0.0,0.0,yanming an,,CHIN-4010,2016
+COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,eddie smith,,COM-1010,2016
+COM,1500,1,Intro to Human Communication,0.81,0.16,0.01,0.0,0.0,0.0,0.0,0.02,eddie smith,,COM-1500,2016
+COM,1500,2,Intro to Human Communication,0.57,0.33,0.05,0.02,0.01,0.0,0.0,0.02,daniel lelan fecher,,COM-1500,2016
+COM,1500,3,Intro to Human Communication,0.82,0.13,0.03,0.0,0.0,0.0,0.0,0.03,eddie smith,,COM-1500,2016
+COM,1500,4,Intro to Human Communication,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,marianne her glaser,,COM-1500,2016
+COM,1500,5,Intro to Human Communication,0.65,0.26,0.04,0.01,0.03,0.0,0.0,0.01,marianne her glaser,,COM-1500,2016
+COM,1500,6,Intro to Human Communication,0.5,0.38,0.05,0.01,0.01,0.0,0.0,0.05,daniel lelan fecher,,COM-1500,2016
+COM,2010,1,Intr to Comm Studies,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-2010,2016
+COM,2010,2,Intr to Comm Studies,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,darren linvill,,COM-2010,2016
+COM,2500,1,Public Speaking,0.62,0.24,0.14,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2016
+COM,2500,2,Public Speaking,0.52,0.29,0.1,0.1,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2016
+COM,2500,3,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-2500,2016
+COM,2500,4,Public Speaking,0.33,0.38,0.24,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2016
+COM,2500,5,Public Speaking,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2016
+COM,2500,6,Public Speaking,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2016
+COM,2500,7,Public Speaking,0.19,0.57,0.14,0.0,0.0,0.0,0.0,0.1,marilyn denise pugh,,COM-2500,2016
+COM,2500,8,Public Speaking,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,,COM-2500,2016
+COM,2500,9,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2016
+COM,2500,10,Public Speaking,0.76,0.05,0.05,0.05,0.1,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2016
+COM,2500,11,Public Speaking,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2016
+COM,2500,12,Public Speaking,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2016
+COM,2500,13,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2016
+COM,2500,14,Public Speaking,0.62,0.19,0.05,0.05,0.0,0.0,0.0,0.1,vanessa anne condon,,COM-2500,2016
+COM,2500,15,Public Speaking,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2016
+COM,2500,16,Public Speaking,0.37,0.32,0.16,0.0,0.05,0.0,0.0,0.11,pauline matthey,,COM-2500,2016
+COM,2500,17,Public Speaking,0.5,0.35,0.05,0.05,0.0,0.0,0.0,0.05,the estate  geddes,,COM-2500,2016
+COM,2500,18,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2016
+COM,2500,19,Public Speaking,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,,COM-2500,2016
+COM,2500,20,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2016
+COM,2500,21,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2016
+COM,2500,22,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2016
+COM,2500,23,Public Speaking,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2016
+COM,2500,25,Public Speaking,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,,COM-2500,2016
+COM,2500,26,Public Speaking (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,True,COM-2500,2016
+COM,2500,27,Public Speaking (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,True,COM-2500,2016
+COM,2500,29,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2016
+COM,2500,400,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2016
+COM,2500,401,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2016
+COM,2500,402,Public Speaking,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,alexis zachar davis,,COM-2500,2016
+COM,2500,403,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2016
+COM,2500,500,Public Speaking,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2016
+COM,3010,1,Comm Theory,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,pauline matthey,,COM-3010,2016
+COM,3020,1,Mass Comm Theory,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,karyn jones,,COM-3020,2016
+COM,3050,1,Persuasion,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,karyn jones,,COM-3050,2016
+COM,3060,1,Discourse & Society,0.4,0.44,0.16,0.0,0.0,0.0,0.0,0.0,david travers scott,,COM-3060,2016
+COM,3100,1,Quant Comm Methods,0.64,0.28,0.0,0.0,0.08,0.0,0.0,0.0,john steven spinda,,COM-3100,2016
+COM,3200,1,Bdcst Production,0.67,0.1,0.1,0.05,0.0,0.0,0.0,0.1,wanda johnson,,COM-3200,2016
+COM,3250,1,Survey of Sports Communication,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3250,2016
+COM,3250,2,Survey of Sports Communication,0.83,0.08,0.0,0.0,0.04,0.0,0.0,0.04,angela pratt,,COM-3250,2016
+COM,3300,1,Nonverbal Comm,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,joseph mazer,,COM-3300,2016
+COM,3480,1,Interpersonal Comm,0.43,0.43,0.1,0.0,0.05,0.0,0.0,0.0,melinda ra weathers,,COM-3480,2016
+COM,3560,1,Stakeholder Comm,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3560,2016
+COM,3610,1,Argue and Debate,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,,COM-3610,2016
+COM,3660,2,EC: Brand Comm & Strategy,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,roger beasley,,COM-3660,2016
+COM,3690,1,Political Comm,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,erin michelle ash,,COM-3690,2016
+COM,3690,2,Political Comm,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3690,2016
+COM,3720,1,Digital Analytics in Brand Com,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,alicia ni littleton,,COM-3720,2016
+COM,3730,1,Media Management in Brand Comm,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,william reynolds,,COM-3730,2016
+COM,4040,1,Media Comm & Social Identities,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,chenjerai kumanyika,,COM-4040,2016
+COM,4040,2,Media Comm & Social Identities,0.47,0.2,0.27,0.07,0.0,0.0,0.0,0.0,chenjerai kumanyika,,COM-4040,2016
+COM,4260,1,Social Media and Sports Comm,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,john steven spinda,,COM-4260,2016
+COM,4310,1,Legal Communication Trial,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,,COM-4310,2016
+COM,4700,1,Comm & Health,0.29,0.65,0.0,0.06,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4700,2016
+COM,4950,1,Senior Capstone,0.9,0.07,0.0,0.0,0.03,0.0,0.0,0.0,erin michelle ash,,COM-4950,2016
+COM,4980,1,Acad & Prof Dev II,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,joseph mazer,,COM-4980,2016
+COM,8020,1,Communication Theory II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,chenjerai kumanyika,,COM-8020,2016
+COM,8110,1,Comm Research Methods II,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-8110,2016
+CPSC,1010,1,Computer Science I,0.24,0.32,0.18,0.12,0.09,0.0,0.0,0.06,catherine hochrine,,CPSC-1010,2016
+CPSC,1010,2,Computer Science I,0.39,0.13,0.18,0.11,0.11,0.0,0.0,0.08,catherine hochrine,,CPSC-1010,2016
+CPSC,1010,3,Computer Science I,0.33,0.13,0.24,0.13,0.07,0.0,0.0,0.11,yvon feaster,,CPSC-1010,2016
+CPSC,1020,1,Computer Science II,0.53,0.3,0.06,0.02,0.04,0.0,0.0,0.04,yvon feaster,,CPSC-1020,2016
+CPSC,1020,2,Computer Science II,0.31,0.48,0.21,0.0,0.0,0.0,0.0,0.0,lanny sitanayah,,CPSC-1020,2016
+CPSC,1020,3,Computer Science II,0.32,0.32,0.27,0.07,0.02,0.0,0.0,0.0,christopher plaue,,CPSC-1020,2016
+CPSC,1110,1,Intro to Programming in C,0.54,0.16,0.11,0.03,0.08,0.0,0.0,0.08,catherine hochrine,,CPSC-1110,2016
+CPSC,1110,2,Intro to Programming in C,0.78,0.07,0.04,0.0,0.04,0.0,0.0,0.07,wanda moses,,CPSC-1110,2016
+CPSC,1110,3,Intro to Programming in C,0.68,0.14,0.09,0.0,0.05,0.0,0.0,0.05,wanda moses,,CPSC-1110,2016
+CPSC,2070,1,Discrete Structures,0.14,0.38,0.31,0.1,0.03,0.0,0.0,0.03,sandra hedetniemi,,CPSC-2070,2016
+CPSC,2070,401,Discrete Structures,0.43,0.3,0.22,0.0,0.01,0.0,0.0,0.04,larry hodges,,CPSC-2070,2016
+CPSC,2100,1,Progrmng Methodology,0.43,0.23,0.17,0.07,0.0,0.0,0.0,0.1,rose lowe,,CPSC-2100,2016
+CPSC,2120,1,Algs/Data Structures,0.36,0.28,0.24,0.07,0.04,0.0,0.0,0.01,wayne goddard,,CPSC-2120,2016
+CPSC,2150,1,Software Dev,0.24,0.25,0.27,0.12,0.07,0.0,0.0,0.05,blair madiso durkee,,CPSC-2150,2016
+CPSC,2150,2,Software Dev Foundations,0.66,0.26,0.05,0.0,0.02,0.0,0.0,0.02,joseph isaac,,CPSC-2150,2016
+CPSC,2200,1,Microcomputer Appl,0.42,0.21,0.21,0.11,0.05,0.0,0.0,0.0,renee lambert,,CPSC-2200,2016
+CPSC,2200,2,Microcomputer Appl,0.45,0.3,0.05,0.1,0.0,0.0,0.0,0.1,renee lambert,,CPSC-2200,2016
+CPSC,2310,1,Intro Computer Org,0.44,0.26,0.21,0.07,0.02,0.0,0.0,0.0,rose lowe,,CPSC-2310,2016
+CPSC,2310,2,Intro Computer Org,0.41,0.24,0.12,0.15,0.07,0.0,0.0,0.0,rose lowe,,CPSC-2310,2016
+CPSC,2910,1,Prof Issues I,0.86,0.07,0.0,0.07,0.0,0.0,0.0,0.0,renee lambert,,CPSC-2910,2016
+CPSC,2910,2,Prof Issues I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,renee lambert,,CPSC-2910,2016
+CPSC,2910,3,Prof Issues I,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,renee lambert,,CPSC-2910,2016
+CPSC,2910,4,Prof Issues I,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,james jones,,CPSC-2910,2016
+CPSC,3220,1,Intro to Operating Systems,0.18,0.28,0.21,0.07,0.08,0.0,0.0,0.18,jacob sorber,,CPSC-3220,2016
+CPSC,3300,1,Computer Systems Org,0.2,0.32,0.33,0.09,0.04,0.0,0.0,0.01,mark smotherman,,CPSC-3300,2016
+CPSC,3500,1,Foundations of Computer Sci,0.15,0.2,0.48,0.03,0.06,0.0,0.0,0.08,ilya mark safro,,CPSC-3500,2016
+CPSC,3520,1,Programming Systems,0.42,0.32,0.16,0.0,0.04,0.0,0.0,0.06,robert schalkoff,,CPSC-3520,2016
+CPSC,3600,1,Network Programming,0.07,0.3,0.29,0.06,0.07,0.0,0.0,0.2,sekou lionel remy,,CPSC-3600,2016
+CPSC,3620,1,Distributed/Cluster Computing,0.15,0.37,0.42,0.0,0.04,0.0,0.0,0.01,amy apon,,CPSC-3620,2016
+CPSC,3720,1,Software Engineering,0.39,0.28,0.21,0.04,0.02,0.0,0.0,0.07,stephen schaub,,CPSC-3720,2016
+CPSC,3990,3,Advanced CI: Extreme Orange,0.59,0.24,0.12,0.0,0.0,0.0,0.0,0.06,james martin,,CPSC-3990,2016
+CPSC,4050,1,Computer Graphics,0.26,0.26,0.22,0.0,0.19,0.0,0.0,0.07,jerry tessendorf,,CPSC-4050,2016
+CPSC,4140,1,Human and Computer Interaction,0.41,0.34,0.1,0.0,0.07,0.0,0.0,0.07,sabarish venka babu,,CPSC-4140,2016
+CPSC,4140,2,Human and Computer Interaction,0.14,0.78,0.03,0.0,0.03,0.0,0.0,0.03,kelly caine,,CPSC-4140,2016
+CPSC,4160,1,2-D Game Engine Construction,0.24,0.34,0.22,0.07,0.1,0.0,0.0,0.02,brian malloy,,CPSC-4160,2016
+CPSC,4240,1,System Admin and Security,0.11,0.51,0.26,0.09,0.0,0.0,0.0,0.03,james martin,,CPSC-4240,2016
+CPSC,4620,1,Database Management Systems,0.24,0.6,0.12,0.0,0.04,0.0,0.0,0.0,zijun wang,,CPSC-4620,2016
+CPSC,4820,1,Selected Topics: Android Dev,0.56,0.25,0.0,0.0,0.0,0.0,0.0,0.19,roy pargas,,CPSC-4820,2016
+CPSC,4820,2,Special Topics: Data Science,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,,CPSC-4820,2016
+CPSC,4910,1,Professional Issues II,0.9,0.02,0.05,0.0,0.02,0.0,0.0,0.02,james jones,,CPSC-4910,2016
+CPSC,6050,1,Computer Graphics,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,robert geist,,CPSC-6050,2016
+CPSC,6140,1,Human and Computer Interaction,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,,CPSC-6140,2016
+CPSC,6140,2,Human and Computer Interaction,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,,CPSC-6140,2016
+CPSC,6160,1,2-D Game Engine Construction,0.43,0.35,0.09,0.0,0.0,0.0,0.0,0.13,brian malloy,,CPSC-6160,2016
+CPSC,6240,1,System Admin and Security,0.31,0.44,0.19,0.0,0.0,0.0,0.0,0.06,james martin,,CPSC-6240,2016
+CPSC,6550,1,Computational Science,0.5,0.19,0.25,0.0,0.0,0.0,0.0,0.06,xizhou feng,,CPSC-6550,2016
+CPSC,6620,1,Database Management Systems,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,zijun wang,,CPSC-6620,2016
+CPSC,6820,1,Selected Topics: Android Dev,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,roy pargas,,CPSC-6820,2016
+CPSC,6820,2,Special Topics: Data Science,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,,CPSC-6820,2016
+CPSC,8110,1,Character Animation,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,christina sop joerg,,CPSC-8110,2016
+CPSC,8220,1,Case Study in Operating Sys,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,,CPSC-8220,2016
+CPSC,8280,1,Theory of Program. Languages,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,murali sitaraman,,CPSC-8280,2016
+CPSC,8400,1,Design & Anlys of Algorithms,0.19,0.34,0.34,0.0,0.08,0.0,0.0,0.06,brian christop dean,,CPSC-8400,2016
+CPSC,8620,1,Database Mngmt System Design,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,,CPSC-8620,2016
+CPSC,8650,1,Data Mining,0.33,0.46,0.17,0.0,0.0,0.0,0.0,0.04,zijun wang,,CPSC-8650,2016
+CPSC,8750,1,Software Architectur,0.71,0.2,0.06,0.0,0.0,0.0,0.0,0.02,john mcgregor,,CPSC-8750,2016
+CRP,8020,1,Site Planning,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,clifford dona ellis,,CRP-8020,2016
+CRP,8040,1,Land Use Analysis,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,stephen sperry,,CRP-8040,2016
+CRP,8050,1,Plning Theory & Hist,0.48,0.38,0.05,0.0,0.1,0.0,0.0,0.0,mickey lauria,,CRP-8050,2016
+CRP,8090,1,Current Issues,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,barry nocks,,CRP-8090,2016
+CRP,8130,1,Transportation Plan,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,eric morris,,CRP-8130,2016
+CRP,8200,1,Negotiation,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,,CRP-8200,2016
+CRP,8220,1,Urban Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,CRP-8220,2016
+CRP,8890,3,Sel Top-Geodesign w/ City Eng,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,,CRP-8890,2016
+CRP,8900,3,Dir Studies in City & Reg Plan,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,clifford dona ellis,,CRP-8900,2016
+CRP,8900,8,Dir Studies in City & Reg Plan,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,stephen sperry,,CRP-8900,2016
+CSM,1500,1,Constr Prob Solving,0.52,0.35,0.09,0.0,0.0,0.0,0.0,0.04,jason lucas,,CSM-1500,2016
+CSM,1500,2,Constr Prob Solving,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-1500,2016
+CSM,1500,3,Constr Prob Solving,0.48,0.39,0.13,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-1500,2016
+CSM,2020,1,Structures II,0.32,0.32,0.19,0.16,0.0,0.0,0.0,0.0,shima clarke,,CSM-2020,2016
+CSM,2020,2,Structures II,0.31,0.34,0.21,0.14,0.0,0.0,0.0,0.0,shima clarke,,CSM-2020,2016
+CSM,2040,1,Cont Documents,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2040,2016
+CSM,2040,2,Cont Documents,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2040,2016
+CSM,2050,1,Mats & Methods II,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2050,2016
+CSM,2050,2,Mats & Methods II,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.0,joseph wintz,,CSM-2050,2016
+CSM,3050,1,Envir Systems II,0.33,0.42,0.17,0.04,0.0,0.04,0.0,0.0,joseph mich burgett,,CSM-3050,2016
+CSM,3050,2,Envir Systems II,0.17,0.63,0.21,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3050,2016
+CSM,3520,1,Const Scheduling,0.36,0.29,0.18,0.04,0.0,0.14,0.0,0.0,dennis bausman,,CSM-3520,2016
+CSM,3520,2,Const Scheduling,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-3520,2016
+CSM,3530,1,Const Estimating II,0.12,0.69,0.19,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-3530,2016
+CSM,3530,2,Const Estimating II,0.09,0.73,0.14,0.05,0.0,0.0,0.0,0.0,christine piper,,CSM-3530,2016
+CSM,4540,1,Const Capstone,0.43,0.39,0.17,0.0,0.0,0.0,0.0,0.0,james packer smith,,CSM-4540,2016
+CSM,4540,2,Const Capstone,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,james packer smith,,CSM-4540,2016
+CSM,8620,1,Personnel Mgt & Neg,0.0,0.72,0.28,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-8620,2016
+CSM,8620,400,Personnel Mgt & Neg,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-8620,2016
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.65,0.33,0.03,susan whorton,,CU-1000,2016
+CU,1010,1,Univ Success Skills,0.37,0.33,0.1,0.03,0.1,0.0,0.0,0.07,emma reynol reabold,,CU-1010,2016
+CU,1010,2,Univ Success Skills,0.61,0.23,0.03,0.03,0.03,0.0,0.0,0.06,mary mcp von kaenel,,CU-1010,2016
+CU,1010,3,Univ Success Skills,0.43,0.3,0.1,0.07,0.03,0.0,0.0,0.07,cari allyn brooks,,CU-1010,2016
+CU,1010,6,Univ Success Skills,0.32,0.25,0.07,0.04,0.21,0.0,0.0,0.11,ashley crisp,,CU-1010,2016
+CU,1400,1,The Entrepreneurial Mindset,0.46,0.39,0.07,0.0,0.06,0.0,0.0,0.01,john michael hannon,,CU-1400,2016
+CU,1410,1,"Creativity, Innovation & Entr",0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,,CU-1410,2016
+CU,1970,1,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.91,0.05,0.05,laurel ann whisler,,CU-1970,2016
+CU,2010,1,Sustainability Leadership,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,jennifer marg goree,,CU-2010,2016
+DANC,1300,1,Tap Dance I,0.75,0.1,0.05,0.0,0.0,0.0,0.0,0.1,cheryl hosler,,DANC-1300,2016
+DANC,1400,1,Jazz Dance I,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,cheryl hosler,,DANC-1400,2016
+DPA,4010,1,Tech Foundations II,0.09,0.09,0.09,0.27,0.18,0.0,0.0,0.27,donald henry house,,DPA-4010,2016
+DPA,4030,1,Vis Foundations II,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,david stewart donar,,DPA-4030,2016
+DPA,4030,2,Vis Foundations II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,,DPA-4030,2016
+ECE,2010,1,Logic and Computing Devices,0.31,0.24,0.17,0.15,0.07,0.0,0.0,0.06,lin zhu,,ECE-2010,2016
+ECE,2020,1,Electric Circuits I,0.22,0.26,0.22,0.15,0.09,0.0,0.0,0.06,william harrell,,ECE-2020,2016
+ECE,2070,1,Basic Electrical Engineering,0.44,0.3,0.11,0.07,0.04,0.0,0.0,0.03,william th kolodzey,,ECE-2070,2016
+ECE,2070,2,Basic Electrical Engineering,0.41,0.37,0.17,0.04,0.0,0.0,0.0,0.01,amir ahmed asif,,ECE-2070,2016
+ECE,2070,3,Basic Electrical Engineering,0.17,0.41,0.27,0.03,0.07,0.0,0.0,0.06,hai xiao,,ECE-2070,2016
+ECE,2080,2,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,3,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,6,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,7,Basic Electrical Engr Lab,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,8,Basic Electrical Engr Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,9,Basic Electrical Engr Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,11,Basic Electrical Engr Lab,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,12,Basic Electrical Engr Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,13,Basic Electrical Engr Lab,0.89,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2016
+ECE,2080,20,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2016
+ECE,2110,1,Elec Engr Lab I,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,apoorva dee kapadia,,ECE-2110,2016
+ECE,2110,2,Elec Engr Lab I,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2110,2016
+ECE,2220,1,Syst Prog Concept,0.29,0.37,0.14,0.04,0.06,0.0,0.0,0.1,william reid,,ECE-2220,2016
+ECE,2230,1,Comp Sys Eng,0.14,0.21,0.29,0.11,0.11,0.0,0.0,0.14,harlan russell,,ECE-2230,2016
+ECE,2620,1,Electric Circuits II,0.38,0.32,0.22,0.03,0.02,0.0,0.0,0.03,richard groff,,ECE-2620,2016
+ECE,2720,1,Comp Organization,0.26,0.4,0.27,0.03,0.03,0.0,0.0,0.02,william reid,,ECE-2720,2016
+ECE,2730,1,Computer Org Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2016
+ECE,2730,2,Computer Org Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2016
+ECE,2730,6,Computer Org Lab,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,,ECE-2730,2016
+ECE,2730,8,Computer Org Lab,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2016
+ECE,2730,9,Computer Org Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2016
+ECE,3110,3,Electrical Engineering Lab III,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2016
+ECE,3110,4,Electrical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2016
+ECE,3110,5,Electrical Engineering Lab III,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2016
+ECE,3170,1,Rand Signal Analysis,0.15,0.23,0.36,0.12,0.07,0.0,0.0,0.06,stephen hubbard,,ECE-3170,2016
+ECE,3200,1,Electronics I,0.16,0.2,0.25,0.19,0.16,0.0,0.0,0.04,stephen hubbard,,ECE-3200,2016
+ECE,3210,1,Electronics II,0.35,0.37,0.12,0.1,0.04,0.0,0.0,0.02,stephen hubbard,,ECE-3210,2016
+ECE,3220,1,Intro Operating Sys,0.11,0.26,0.3,0.04,0.0,0.0,0.0,0.3,jacob sorber,,ECE-3220,2016
+ECE,3270,1,Dig Comp Design,0.09,0.34,0.25,0.13,0.13,0.0,0.0,0.06,melissa crawl smith,,ECE-3270,2016
+ECE,3300,1,Signals & Systems,0.17,0.16,0.31,0.19,0.08,0.0,0.0,0.09,carl baum,,ECE-3300,2016
+ECE,3520,1,Programming Systems,0.4,0.44,0.12,0.0,0.0,0.0,0.0,0.04,robert schalkoff,,ECE-3520,2016
+ECE,3600,1,Elect Power Engr,0.36,0.31,0.19,0.06,0.08,0.0,0.0,0.0,edward collins,,ECE-3600,2016
+ECE,3710,1,Microcontr Interface,0.4,0.31,0.1,0.09,0.07,0.0,0.0,0.03,william reid,,ECE-3710,2016
+ECE,3720,3,Micro Int Lab,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2016
+ECE,3720,5,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2016
+ECE,3720,7,Micro Int Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2016
+ECE,3800,1,Electromagnetics,0.11,0.22,0.4,0.13,0.11,0.0,0.0,0.03,anthony martin,,ECE-3800,2016
+ECE,3810,1,Field Waves & Ckts,0.32,0.32,0.3,0.05,0.02,0.0,0.0,0.0,eric gordon johnson,,ECE-3810,2016
+ECE,4090,1,Intr to Linear Control Systems,0.63,0.24,0.06,0.02,0.02,0.0,0.0,0.02,apoorva dee kapadia,,ECE-4090,2016
+ECE,4190,1,Elec Mach and Drives,0.38,0.27,0.27,0.04,0.0,0.0,0.0,0.04,keith corzine,,ECE-4190,2016
+ECE,4200,1,Renewable Energy,0.28,0.23,0.23,0.1,0.03,0.0,0.0,0.13,elham makram,,ECE-4200,2016
+ECE,4270,1,Communications Sys,0.38,0.21,0.15,0.13,0.09,0.0,0.0,0.04,madhabi manandhar,,ECE-4270,2016
+ECE,4380,1,Computer Commun,0.29,0.27,0.29,0.05,0.05,0.0,0.0,0.05,harlan russell,,ECE-4380,2016
+ECE,4400,1,Local Computer Nets,0.22,0.57,0.16,0.0,0.0,0.0,0.0,0.05,kuang-ching wang,,ECE-4400,2016
+ECE,4460,1,Antennas,0.58,0.25,0.08,0.08,0.0,0.0,0.0,0.0,anthony martin,,ECE-4460,2016
+ECE,4680,1,Embedded Computing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,,ECE-4680,2016
+ECE,4950,1,Int Sys Design I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4950,2016
+ECE,4960,1,Int Sys Design II,0.56,0.3,0.13,0.0,0.0,0.0,0.0,0.01,richard groff,,ECE-4960,2016
+ECE,4990,14,Creative Inq-Elec & Comp Engr,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,,ECE-4990,2016
+ECE,6320,1,Instrumentation,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,goutam koley,,ECE-6320,2016
+ECE,6370,1,Microelectromechanical Systems,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,pingshan wang,,ECE-6370,2016
+ECE,6380,1,Computer Commun,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,,ECE-6380,2016
+ECE,6400,1,Local Computer Nets,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,kuang-ching wang,,ECE-6400,2016
+ECE,6680,1,Embedded Computing,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,adam hoover,,ECE-6680,2016
+ECE,8400,1,Semicond Devices,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,william harrell,,ECE-8400,2016
+ECE,8570,1,Coding Theory,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,,ECE-8570,2016
+ECE,8630,1,Pwr Sys Dyna & Stab,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,ramtin hadidi,,ECE-8630,2016
+ECE,8720,1,Artificial Neurl Net,0.52,0.38,0.05,0.0,0.0,0.0,0.0,0.05,robert schalkoff,,ECE-8720,2016
+ECE,8740,1,Adv Nonlinear Cntrl,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,,ECE-8740,2016
+ECE,8790,1,FPGA Design & Applications,0.17,0.17,0.57,0.0,0.04,0.0,0.0,0.04,melissa crawl smith,,ECE-8790,2016
+ECE,8910,43,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,0.6,0.0,0.4,yongqiang wang,,ECE-8910,2016
+ECE,8930,7,Malware Use and Design,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,richard brooks,,ECE-8930,2016
+ECON,2000,1,Economic Concepts,0.14,0.39,0.29,0.11,0.0,0.0,0.0,0.07,jonathan orr ernest,,ECON-2000,2016
+ECON,2000,2,Economic Concepts,0.35,0.33,0.23,0.05,0.05,0.0,0.0,0.0,jonathan orr ernest,,ECON-2000,2016
+ECON,2000,3,Economic Concepts,0.33,0.41,0.13,0.03,0.08,0.0,0.0,0.03,miren ivankovic,,ECON-2000,2016
+ECON,2110,1,Principles of Microeconomics,0.39,0.32,0.21,0.03,0.0,0.03,0.0,0.03,robert dew tollison,,ECON-2110,2016
+ECON,2110,2,Principles of Microeconomics,0.15,0.36,0.26,0.1,0.08,0.0,0.0,0.05,charles thomas,,ECON-2110,2016
+ECON,2110,3,Principles of Microeconomics,0.18,0.28,0.26,0.18,0.1,0.0,0.0,0.0,steven johnson,,ECON-2110,2016
+ECON,2110,4,Principles of Microeconomics,0.31,0.26,0.26,0.05,0.1,0.0,0.0,0.02,amanda caitlin kerr,,ECON-2110,2016
+ECON,2110,5,Principles of Microeconomics,0.35,0.35,0.28,0.03,0.0,0.0,0.0,0.0,molly espey,,ECON-2110,2016
+ECON,2110,6,Principles of Microeconomics,0.24,0.39,0.25,0.01,0.01,0.0,0.0,0.08,benjamin jo schwall,,ECON-2110,2016
+ECON,2110,7,Principles of Microeconomics,0.24,0.33,0.2,0.14,0.04,0.0,0.0,0.04,leah jacq kitashima,,ECON-2110,2016
+ECON,2110,8,Principles of Microeconomics,0.21,0.42,0.24,0.06,0.03,0.0,0.0,0.03,alexander fiore,,ECON-2110,2016
+ECON,2110,10,Principles of Microeconomics,0.16,0.31,0.35,0.08,0.08,0.0,0.0,0.02,richard alan sessa,,ECON-2110,2016
+ECON,2110,11,Principles of Microeconomics,0.14,0.35,0.34,0.14,0.0,0.0,0.0,0.03,michael makowsky,,ECON-2110,2016
+ECON,2110,12,Principles of Microeconomics,0.28,0.44,0.26,0.03,0.0,0.0,0.0,0.0,molly espey,,ECON-2110,2016
+ECON,2120,1,Principles of Macroeconomics,0.11,0.32,0.37,0.16,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,2,Principles of Macroeconomics,0.18,0.12,0.47,0.18,0.0,0.0,0.0,0.06,scott baier,,ECON-2120,2016
+ECON,2120,3,Principles of Macroeconomics,0.2,0.3,0.35,0.05,0.1,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,4,Principles of Macroeconomics,0.26,0.32,0.32,0.05,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,5,Principles of Macroeconomics,0.3,0.35,0.25,0.1,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,6,Principles of Macroeconomics,0.17,0.33,0.39,0.06,0.0,0.0,0.0,0.06,scott baier,,ECON-2120,2016
+ECON,2120,7,Principles of Macroeconomics,0.28,0.33,0.22,0.17,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,8,Principles of Macroeconomics,0.21,0.37,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,9,Principles of Macroeconomics,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,10,Principles of Macroeconomics,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,scott baier,,ECON-2120,2016
+ECON,2120,11,Principles of Macroeconomics,0.26,0.26,0.42,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,12,Principles of Macroeconomics,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,13,Principles of Macroeconomics,0.37,0.11,0.32,0.05,0.11,0.0,0.0,0.05,scott baier,,ECON-2120,2016
+ECON,2120,14,Principles of Macroeconomics,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,15,Principles of Macroeconomics,0.43,0.38,0.19,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,16,Principles of Macroeconomics,0.17,0.17,0.67,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,17,Principles of Macroeconomics,0.37,0.37,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,18,Principles of Macroeconomics,0.42,0.26,0.16,0.11,0.0,0.0,0.0,0.05,scott baier,,ECON-2120,2016
+ECON,2120,19,Principles of Macroeconomics,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2016
+ECON,2120,20,Principles of Macroeconomics,0.25,0.31,0.36,0.07,0.0,0.0,0.0,0.0,peter david lorenz,,ECON-2120,2016
+ECON,2120,21,Principles of Macroeconomics,0.61,0.32,0.06,0.0,0.02,0.0,0.0,0.0,mallika garg,,ECON-2120,2016
+ECON,2120,22,Principles of Macroeconomics,0.22,0.39,0.27,0.07,0.0,0.0,0.0,0.05,andew swanson,,ECON-2120,2016
+ECON,2120,23,Principles of Macroeconomics,0.36,0.39,0.08,0.06,0.08,0.0,0.0,0.03,shan jiang,,ECON-2120,2016
+ECON,2120,24,Principles of Macroeconomics,0.2,0.58,0.19,0.03,0.01,0.0,0.0,0.0,scott barkowski,,ECON-2120,2016
+ECON,2120,25,Principles of Macroeconomics,0.19,0.56,0.19,0.06,0.0,0.0,0.0,0.0,scott barkowski,,ECON-2120,2016
+ECON,2120,26,Principles of Macroeconomics,0.18,0.06,0.15,0.21,0.06,0.0,0.0,0.33,ralph charles allen,,ECON-2120,2016
+ECON,2120,27,Principles of Macroeconomics,0.21,0.45,0.27,0.0,0.0,0.0,0.0,0.06,chen wang,,ECON-2120,2016
+ECON,3020,1,Money and Banking,0.15,0.36,0.3,0.03,0.0,0.0,0.0,0.15,randall scot cragun,,ECON-3020,2016
+ECON,3060,1,Managerial Economics,0.19,0.36,0.17,0.11,0.06,0.0,0.0,0.11,jacob burgdorf,,ECON-3060,2016
+ECON,3100,1,International Econ,0.16,0.28,0.19,0.16,0.16,0.0,0.0,0.06,michal jerzmanowski,,ECON-3100,2016
+ECON,3140,1,Intermediate Micro,0.17,0.24,0.27,0.15,0.1,0.0,0.0,0.07,robert kennet fleck,,ECON-3140,2016
+ECON,3140,2,Intermediate Micro,0.19,0.3,0.35,0.0,0.03,0.0,0.0,0.14,kevin ka kin tsui,,ECON-3140,2016
+ECON,3140,3,Intermediate Micro,0.18,0.3,0.25,0.1,0.08,0.0,0.0,0.1,frederick hanssen,,ECON-3140,2016
+ECON,3150,1,Intermediate Macro,0.3,0.21,0.21,0.06,0.06,0.0,0.0,0.15,randall scot cragun,,ECON-3150,2016
+ECON,3150,2,Intermediate Macro,0.51,0.15,0.18,0.08,0.03,0.0,0.0,0.05,sergey vla mityakov,,ECON-3150,2016
+ECON,3190,2,Environmental Econ,0.21,0.43,0.21,0.07,0.04,0.0,0.0,0.04,scott templeton,,ECON-3190,2016
+ECON,3400,1,Behavioral Economics,0.51,0.4,0.09,0.0,0.0,0.0,0.0,0.0,daniel wood,,ECON-3400,2016
+ECON,3440,1,Property Rights,0.11,0.26,0.3,0.19,0.07,0.0,0.0,0.07,dar litsukova-bokar,,ECON-3440,2016
+ECON,3600,1,Public Choice,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,robert dew tollison,,ECON-3600,2016
+ECON,4010,1,Labor Mkt Analysis,0.31,0.54,0.12,0.0,0.04,0.0,0.0,0.0,curtis simon,,ECON-4010,2016
+ECON,4020,1,Law and Economics,0.23,0.48,0.23,0.0,0.03,0.0,0.0,0.03,thomas wins hazlett,,ECON-4020,2016
+ECON,4050,1,Intro to Econometric,0.35,0.31,0.15,0.1,0.08,0.0,0.0,0.02,scott baier,,ECON-4050,2016
+ECON,4060,1,Advanced Econometric,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,babur de los santos,,ECON-4060,2016
+ECON,4240,1,Organization of Ind,0.42,0.38,0.13,0.04,0.04,0.0,0.0,0.0,matthew lewis,,ECON-4240,2016
+ECON,4260,1,Sem Sport Economics,0.52,0.43,0.0,0.0,0.04,0.0,0.0,0.0,raymond sauer,,ECON-4260,2016
+ECON,4270,1,Dev American Economy,0.33,0.44,0.15,0.07,0.0,0.0,0.0,0.0,howard ne bodenhorn,,ECON-4270,2016
+ECON,4280,1,Cost-Benefit Anlysis,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,william dougan,,ECON-4280,2016
+ECON,4290,1,Economics of Energy Markets,0.46,0.35,0.12,0.0,0.04,0.0,0.0,0.04,matthew lewis,,ECON-4290,2016
+ECON,4400,1,Game Theory,0.25,0.25,0.42,0.0,0.08,0.0,0.0,0.0,charles thomas,,ECON-4400,2016
+ECON,6020,1,Law and Economics,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,,ECON-6020,2016
+ECON,6060,1,Advanced Econometric,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,babur de los santos,,ECON-6060,2016
+ECON,6400,1,Game Theory,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,charles thomas,,ECON-6400,2016
+ECON,8020,2,Adv Econ Concepts and Applic I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,,ECON-8020,2016
+ECON,8050,1,Macroeconomic Theory,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,,ECON-8050,2016
+ECON,8070,1,Econometrics II,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,chungsang lam,,ECON-8070,2016
+ECON,8110,1,Econ of Environment,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,scott templeton,,ECON-8110,2016
+ECON,8200,1,Public Finance,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,william dougan,,ECON-8200,2016
+ECON,8990,4,History of Econ-Modern Macro,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michel devroey,,ECON-8990,2016
+ECON,9010,2,Price Theory,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel wood,,ECON-9010,2016
+ECON,9090,1,Time-Series Econ,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,,ECON-9090,2016
+ED,3970,7,Creative Inquiry in Education,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,david matthew boyer,,ED-3970,2016
+ED,3970,28,Creative Inquiry Education,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-3970,2016
+ED,8380,504,Becoming a Reflective Praction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,,ED-8380,2016
+ED,8380,531,Literacy Lessons for Indiv II,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,morgan jones bowie,,ED-8380,2016
+ED,8380,539,Literacy Lessons for Indiv II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,andrea chri overton,,ED-8380,2016
+ED,8390,500,Intro to Linguistics,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,daniel smith,,ED-8390,2016
+ED,8670,500,Practicum in ESOL Instruction,0.69,0.08,0.08,0.0,0.08,0.0,0.0,0.08,margaret mar warner,,ED-8670,2016
+EDC,3900,2,Skills for Stu Leads,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,eric pernotto,,EDC-3900,2016
+EDC,3900,4,Skills for Stu Leads,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,eric pernotto,,EDC-3900,2016
+EDEC,2200,1,Family/School/Com,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-2200,2016
+EDEL,4510,1,Elem Methods in Science Tchg,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,,EDEL-4510,2016
+EDEL,4520,1,Elem Methods Math Teaching,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,EDEL-4520,2016
+EDEL,4870,1,Ele Meth Soc Studies,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,,EDEL-4870,2016
+EDF,3010,1,Principles of American Educat,0.66,0.23,0.09,0.0,0.03,0.0,0.0,0.0,suzanne rosenblith,,EDF-3010,2016
+EDF,3010,2,Principles of American Educat,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,nafees mohamma khan,,EDF-3010,2016
+EDF,3010,3,Principles of American Educat,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,,EDF-3010,2016
+EDF,3020,1,Educational Psychology,0.41,0.44,0.09,0.06,0.0,0.0,0.0,0.0,penelope mar vargas,,EDF-3020,2016
+EDF,3020,3,Educational Psychology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,,EDF-3020,2016
+EDF,3020,6,Educational Psychology,0.4,0.46,0.14,0.0,0.0,0.0,0.0,0.0,penelope mar vargas,,EDF-3020,2016
+EDF,3340,1,Child Growth and Development,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,,EDF-3340,2016
+EDF,3340,2,Child Growth and Development,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,,EDF-3340,2016
+EDF,4800,2,Digital Media & Learning,0.91,0.05,0.05,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2016
+EDF,4800,300,Digital Media & Learning,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david matthew boyer,,EDF-4800,2016
+EDF,8080,300,Ed Tests and Measure,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,deborah switzer,,EDF-8080,2016
+EDL,7150,502,Sch & Comm Relations,0.86,0.05,0.0,0.0,0.05,0.0,0.0,0.05,frederick buskey,,EDL-7150,2016
+EDL,7350,500,Educational Eval,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,,EDL-7350,2016
+EDL,7400,502,Curr Plan: Sch Adm,0.71,0.21,0.0,0.0,0.04,0.0,0.0,0.04,elizabeth reynolds,,EDL-7400,2016
+EDL,7510,400,El Prin & Spv Ex II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth reynolds,,EDL-7510,2016
+EDL,7650,1,Assessment Hi Edu,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,,EDL-7650,2016
+EDL,7650,2,Assessment Hi Edu,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,,EDL-7650,2016
+EDL,8390,400,Research in Ed L,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,,EDL-8390,2016
+EDL,9110,501,Systematic Inq Ed L,0.47,0.4,0.0,0.0,0.0,0.0,0.0,0.13,jane lindle,,EDL-9110,2016
+EDLT,4580,1,Early Literacy: Birth-Kindergn,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4580,2016
+EDLT,4620,1,Reading Children's Lit in Elem,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4620,2016
+EDLT,8100,400,Foundations: Reading & Writing,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,phillip mich wilder,,EDLT-8100,2016
+EDLT,8150,500,Guided Reading & Writng Scaffo,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,,EDLT-8150,2016
+EDLT,8270,300,Content Area Rdg/Wtg-MS & HS,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8270,2016
+EDLT,8270,501,Content Area Rdg/Wtg-MS & HS,0.85,0.03,0.0,0.0,0.03,0.0,0.0,0.1,phillip mich wilder,,EDLT-8270,2016
+EDSA,8190,1,Contemporary College Student,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,michelle boettcher,,EDSA-8190,2016
+EDSC,4370,1,Technology in Math,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,,EDSC-4370,2016
+EDSP,3700,2,Intro to Special Education,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,michael wayne riley,,EDSP-3700,2016
+EDSP,3700,3,Intro to Special Education,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,pamela stecker,,EDSP-3700,2016
+EDSP,3750,1,Early Intervention Spec Needs,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,,EDSP-3750,2016
+EDSP,4910,1,Ed Assess Ind W/Dis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,,EDSP-4910,2016
+EDSP,4950,1,Comm & Collab Sp Ed,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sara moo mackiewicz,,EDSP-4950,2016
+EES,2020,1,Environ Engr Fundamentals II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,,EES-2020,2016
+EES,3100,2,Intro to Nuclear Engineering,0.2,0.27,0.07,0.0,0.07,0.0,0.0,0.4,timothy devol,,EES-3100,2016
+EES,4010,1,Environmental Engr,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth carraway,,EES-4010,2016
+EES,4010,2,Environmental Engr,0.46,0.34,0.09,0.06,0.0,0.0,0.0,0.06,thomas overcamp,,EES-4010,2016
+EES,4750,1,Capstone Design Project,0.69,0.25,0.03,0.0,0.0,0.0,0.0,0.03,david allen ladner,,EES-4750,2016
+EES,4840,2,Solid Waste Mgt,0.35,0.49,0.16,0.0,0.0,0.0,0.0,0.0,thomas overcamp,,EES-4840,2016
+EES,4850,2,Hazard Waste Management,0.16,0.47,0.29,0.05,0.0,0.0,0.0,0.03,mark schlautman,,EES-4850,2016
+EES,6110,1,Rad Detection Mmt,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,timothy devol,,EES-6110,2016
+EES,8030,1,Phy/Chem Ops W/WW T,0.36,0.55,0.0,0.0,0.09,0.0,0.0,0.0,ezra lucas ho cates,,EES-8030,2016
+EES,8040,1,Biochem Ops WW Trt,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,david freedman,,EES-8040,2016
+EES,8090,1,Subsurface Remed Mod,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,ronald falta,,EES-8090,2016
+EES,8120,1,Env Nuclear Engr,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,lin shuller-nickles,,EES-8120,2016
+ELE,3010,1,Intro to Entre,0.05,0.48,0.4,0.05,0.03,0.0,0.0,0.0,ashley will parnell,,ELE-3010,2016
+ELE,3010,2,Intro to Entre,0.32,0.61,0.05,0.0,0.0,0.0,0.0,0.02,chad navis,,ELE-3010,2016
+ELE,3010,3,Intro to Entre,0.39,0.59,0.02,0.0,0.0,0.0,0.0,0.0,chad navis,,ELE-3010,2016
+ELE,4010,1,Exec Lead & Entr II,0.13,0.38,0.35,0.15,0.0,0.0,0.0,0.0,ashley will parnell,,ELE-4010,2016
+ENGL,1030,1,Accelerated Composition,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,emily anne boyter,,ENGL-1030,2016
+ENGL,1030,2,Accelerated Composition,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,kristen joy hixon,,ENGL-1030,2016
+ENGL,1030,3,Accelerated Composition,0.35,0.59,0.0,0.0,0.0,0.0,0.0,0.06,mary dickens,,ENGL-1030,2016
+ENGL,1030,4,Accelerated Composition,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,caroline ca swanson,,ENGL-1030,2016
+ENGL,1030,7,Accelerated Composition,0.75,0.1,0.0,0.0,0.1,0.0,0.0,0.05,kristen joy hixon,,ENGL-1030,2016
+ENGL,1030,8,Accelerated Composition,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,todd rossi smith,,ENGL-1030,2016
+ENGL,1030,9,Accelerated Composition,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,mary dickens,,ENGL-1030,2016
+ENGL,1030,10,Accelerated Composition,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,teneshia head,,ENGL-1030,2016
+ENGL,1030,11,Accelerated Composition,0.56,0.39,0.0,0.0,0.06,0.0,0.0,0.0,caroline ca swanson,,ENGL-1030,2016
+ENGL,1030,12,Accelerated Composition,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,,ENGL-1030,2016
+ENGL,1030,13,Accelerated Composition,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,rebecca nico shaver,,ENGL-1030,2016
+ENGL,1030,14,Accelerated Composition,0.33,0.52,0.1,0.05,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-1030,2016
+ENGL,1030,15,Accelerated Composition,0.45,0.2,0.2,0.1,0.0,0.0,0.0,0.05,andrew mathas,,ENGL-1030,2016
+ENGL,1030,16,Accelerated Composition,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,charlotte powell,,ENGL-1030,2016
+ENGL,1030,17,Accelerated Composition,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,karen mary stewart,,ENGL-1030,2016
+ENGL,1030,18,Accelerated Composition,0.8,0.05,0.05,0.0,0.0,0.0,0.0,0.1,daniel frank,,ENGL-1030,2016
+ENGL,1030,19,Accelerated Composition,0.8,0.1,0.0,0.05,0.0,0.0,0.0,0.05,brian lee gaines,,ENGL-1030,2016
+ENGL,1030,20,Accelerated Composition,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,rebecca nico shaver,,ENGL-1030,2016
+ENGL,1030,21,Accelerated Composition,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,charlotte powell,,ENGL-1030,2016
+ENGL,1030,22,Accelerated Composition,0.8,0.05,0.1,0.0,0.05,0.0,0.0,0.0,samuel jacks fuller,,ENGL-1030,2016
+ENGL,1030,23,Accelerated Composition,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,shawn andrew stowe,,ENGL-1030,2016
+ENGL,1030,24,Accelerated Composition,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2016
+ENGL,1030,25,Accelerated Composition,0.62,0.15,0.08,0.08,0.0,0.0,0.0,0.08,brian lee gaines,,ENGL-1030,2016
+ENGL,1030,26,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-1030,2016
+ENGL,1030,30,Accelerated Composition,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,eda ozyesilpinar,,ENGL-1030,2016
+ENGL,1030,31,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kristen gay,,ENGL-1030,2016
+ENGL,1030,32,Accelerated Composition,0.76,0.0,0.06,0.06,0.0,0.0,0.0,0.12,katie jo vann,,ENGL-1030,2016
+ENGL,1030,35,Accelerated Composition,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,jack butts,,ENGL-1030,2016
+ENGL,1030,36,Accelerated Composition,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,april obrien,,ENGL-1030,2016
+ENGL,1030,37,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kristen gay,,ENGL-1030,2016
+ENGL,1030,39,Accelerated Composition,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,joshua wood,,ENGL-1030,2016
+ENGL,1030,41,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,kellie eliz osborne,,ENGL-1030,2016
+ENGL,1030,42,Accelerated Composition,0.65,0.25,0.05,0.0,0.0,0.0,0.0,0.05,jennifer moeder,,ENGL-1030,2016
+ENGL,1030,44,Accelerated Composition,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,eric stephens,,ENGL-1030,2016
+ENGL,1030,46,Accelerated Composition,0.9,0.0,0.05,0.0,0.05,0.0,0.0,0.0,eric stephens,,ENGL-1030,2016
+ENGL,1030,51,Accelerated Composition,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,danielle shuff,,ENGL-1030,2016
+ENGL,1030,53,Accelerated Composition,0.7,0.05,0.05,0.15,0.05,0.0,0.0,0.0,kellie eliz osborne,,ENGL-1030,2016
+ENGL,1030,54,Accelerated Composition,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,jack butts,,ENGL-1030,2016
+ENGL,1030,55,Accelerated Composition,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,stephen quigley,,ENGL-1030,2016
+ENGL,1030,56,Accelerated Composition,0.8,0.0,0.1,0.0,0.05,0.0,0.0,0.05,jennifer moeder,,ENGL-1030,2016
+ENGL,1030,58,Accelerated Composition,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,daniel frank,,ENGL-1030,2016
+ENGL,1030,60,Accelerated Composition,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,danielle shuff,,ENGL-1030,2016
+ENGL,1030,64,Accelerated Composition,0.71,0.14,0.07,0.0,0.07,0.0,0.0,0.0,madison ali johnson,,ENGL-1030,2016
+ENGL,1030,65,Accelerated Composition,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,stephen quigley,,ENGL-1030,2016
+ENGL,1030,68,Accelerated Composition,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2016
+ENGL,1030,70,Accelerated Composition,0.63,0.16,0.05,0.0,0.11,0.0,0.0,0.05,joshua wood,,ENGL-1030,2016
+ENGL,1030,71,Accelerated Composition,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-1030,2016
+ENGL,1030,72,Accelerated Composition,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,madison ali johnson,,ENGL-1030,2016
+ENGL,1030,73,Accelerated Composition,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,teneshia head,,ENGL-1030,2016
+ENGL,1030,502,Accelerated Composition,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,edward collins,,ENGL-1030,2016
+ENGL,2120,1,World Literature,0.17,0.72,0.06,0.0,0.06,0.0,0.0,0.0,gabriel and hankins,,ENGL-2120,2016
+ENGL,2120,3,World Literature,0.5,0.21,0.04,0.08,0.0,0.0,0.0,0.17,candace wiley,,ENGL-2120,2016
+ENGL,2120,6,World Literature,0.46,0.35,0.12,0.0,0.0,0.0,0.0,0.08,candace wiley,,ENGL-2120,2016
+ENGL,2120,7,World Literature,0.37,0.27,0.23,0.07,0.03,0.0,0.0,0.03,andrew mathas,,ENGL-2120,2016
+ENGL,2120,9,World Literature,0.34,0.34,0.17,0.03,0.07,0.0,0.0,0.03,andrew mathas,,ENGL-2120,2016
+ENGL,2120,11,World Literature,0.57,0.29,0.11,0.0,0.04,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-2120,2016
+ENGL,2120,12,World Literature,0.66,0.14,0.21,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-2120,2016
+ENGL,2120,13,World Literature,0.27,0.57,0.17,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2120,2016
+ENGL,2120,14,World Literature,0.17,0.45,0.17,0.07,0.03,0.0,0.0,0.1,meg woosley-goodman,,ENGL-2120,2016
+ENGL,2120,15,World Literature (HON),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,meg woosley-goodman,True,ENGL-2120,2016
+ENGL,2120,16,World Literature,0.19,0.48,0.22,0.0,0.07,0.0,0.0,0.04,meg woosley-goodman,,ENGL-2120,2016
+ENGL,2120,17,World Literature,0.63,0.27,0.03,0.0,0.0,0.0,0.0,0.07,lucian ghita,,ENGL-2120,2016
+ENGL,2120,18,World Literature,0.59,0.21,0.14,0.0,0.0,0.0,0.0,0.07,lucian ghita,,ENGL-2120,2016
+ENGL,2120,19,World Literature,0.43,0.39,0.04,0.07,0.0,0.0,0.0,0.07,sarah mae cooper,,ENGL-2120,2016
+ENGL,2130,1,British Literature,0.7,0.23,0.0,0.0,0.0,0.0,0.0,0.07,jeffrey fallis,,ENGL-2130,2016
+ENGL,2130,2,British Literature,0.45,0.38,0.1,0.0,0.0,0.0,0.0,0.07,christopher benson,,ENGL-2130,2016
+ENGL,2130,3,British Literature,0.57,0.33,0.07,0.0,0.03,0.0,0.0,0.0,christopher benson,,ENGL-2130,2016
+ENGL,2130,4,British Literature,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,,ENGL-2130,2016
+ENGL,2130,5,British Literature,0.76,0.14,0.03,0.03,0.0,0.0,0.0,0.03,stephanie stripling,,ENGL-2130,2016
+ENGL,2130,6,British Literature,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,jeffrey fallis,,ENGL-2130,2016
+ENGL,2130,7,British Literature,0.66,0.31,0.0,0.0,0.0,0.0,0.0,0.03,jeffrey fallis,,ENGL-2130,2016
+ENGL,2130,10,British Literature,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,krist aldebol-hazle,,ENGL-2130,2016
+ENGL,2130,11,British Literature,0.79,0.11,0.04,0.04,0.0,0.0,0.0,0.04,krist aldebol-hazle,,ENGL-2130,2016
+ENGL,2130,12,British Literature,0.73,0.23,0.0,0.0,0.0,0.0,0.0,0.03,lucian ghita,,ENGL-2130,2016
+ENGL,2130,13,British Literature,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2016
+ENGL,2140,1,American Literature,0.53,0.27,0.13,0.0,0.03,0.0,0.0,0.03,john morgenstern,,ENGL-2140,2016
+ENGL,2140,2,American Literature,0.45,0.24,0.14,0.0,0.14,0.0,0.0,0.03,elizabeth stansell,,ENGL-2140,2016
+ENGL,2140,3,American Literature,0.12,0.31,0.31,0.04,0.04,0.0,0.0,0.19,david charles foltz,,ENGL-2140,2016
+ENGL,2140,4,American Literature,0.62,0.31,0.03,0.0,0.0,0.0,0.0,0.03,sherri teres allred,,ENGL-2140,2016
+ENGL,2140,5,American Literature,0.36,0.39,0.04,0.04,0.0,0.0,0.0,0.18,candace wiley,,ENGL-2140,2016
+ENGL,2140,6,American Literature,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,candace wiley,,ENGL-2140,2016
+ENGL,2140,7,American Literature,0.62,0.1,0.21,0.03,0.03,0.0,0.0,0.0,sherri teres allred,,ENGL-2140,2016
+ENGL,2140,8,American Literature,0.84,0.1,0.0,0.0,0.03,0.0,0.0,0.03,geveryl le robinson,,ENGL-2140,2016
+ENGL,2140,9,American Literature,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,stephanie stripling,,ENGL-2140,2016
+ENGL,2140,11,American Literature,0.73,0.17,0.03,0.03,0.03,0.0,0.0,0.0,stephanie stripling,,ENGL-2140,2016
+ENGL,2140,12,American Literature,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,,ENGL-2140,2016
+ENGL,2140,13,American Literature,0.23,0.42,0.31,0.0,0.0,0.0,0.0,0.04,david charles foltz,,ENGL-2140,2016
+ENGL,2140,14,American Literature,0.07,0.62,0.17,0.0,0.03,0.0,0.0,0.1,rhondda robi thomas,,ENGL-2140,2016
+ENGL,2140,15,American Literature,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,april susanne pelt,,ENGL-2140,2016
+ENGL,2140,17,American Literature,0.47,0.33,0.1,0.0,0.03,0.0,0.0,0.07,william stanton,,ENGL-2140,2016
+ENGL,2140,18,American Literature,0.57,0.23,0.13,0.0,0.03,0.0,0.0,0.03,william stanton,,ENGL-2140,2016
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.53,0.37,0.07,0.03,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2016
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.47,0.27,0.17,0.0,0.03,0.0,0.0,0.07,megan no macalystre,,ENGL-2150,2016
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.47,0.33,0.07,0.13,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-2150,2016
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.8,0.13,0.0,0.0,0.03,0.0,0.0,0.03,alexander kudera,,ENGL-2150,2016
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,alexander kudera,,ENGL-2150,2016
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-2150,2016
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.22,0.48,0.11,0.0,0.04,0.0,0.0,0.15,karen kettnich,,ENGL-2150,2016
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.21,0.43,0.25,0.04,0.04,0.0,0.0,0.04,karen kettnich,,ENGL-2150,2016
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.57,0.3,0.1,0.0,0.03,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2016
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,sharon kathl nalley,,ENGL-2150,2016
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.23,0.27,0.27,0.04,0.04,0.0,0.0,0.15,david charles foltz,,ENGL-2150,2016
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.21,0.34,0.31,0.03,0.0,0.0,0.0,0.1,david charles foltz,,ENGL-2150,2016
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.8,0.13,0.03,0.0,0.0,0.0,0.0,0.03,sharon kathl nalley,,ENGL-2150,2016
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.0,0.69,0.31,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-2150,2016
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.38,0.48,0.07,0.03,0.0,0.0,0.0,0.03,john logan pursley,,ENGL-2150,2016
+ENGL,3000,1,Professional Develop,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,austin gorman,,ENGL-3000,2016
+ENGL,3040,2,Business Writing,0.73,0.14,0.05,0.0,0.05,0.0,0.0,0.05,philip randall,,ENGL-3040,2016
+ENGL,3040,3,Business Writing,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,alexander kudera,,ENGL-3040,2016
+ENGL,3040,5,Business Writing,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,crystal pa stephens,,ENGL-3040,2016
+ENGL,3040,13,Business Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3040,2016
+ENGL,3040,14,Business Writing,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,,ENGL-3040,2016
+ENGL,3040,16,Business Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,,ENGL-3040,2016
+ENGL,3040,17,Business Writing,0.38,0.52,0.0,0.0,0.0,0.0,0.0,0.1,katalin beck,,ENGL-3040,2016
+ENGL,3040,18,Business Writing,0.24,0.67,0.1,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3040,2016
+ENGL,3040,19,Business Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-3040,2016
+ENGL,3040,20,Business Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sherri teres allred,,ENGL-3040,2016
+ENGL,3040,22,Business Writing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,austin gorman,,ENGL-3040,2016
+ENGL,3040,400,Business Writing,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-3040,2016
+ENGL,3100,1,Crit Writ Lit,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-3100,2016
+ENGL,3100,2,Crit Writ Lit,0.39,0.39,0.22,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,,ENGL-3100,2016
+ENGL,3100,4,Crit Writ Lit,0.19,0.5,0.19,0.06,0.06,0.0,0.0,0.0,erin marina goss,,ENGL-3100,2016
+ENGL,3120,1,Advanced Composition,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2016
+ENGL,3120,2,Advanced Composition,0.42,0.32,0.05,0.05,0.16,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2016
+ENGL,3140,1,Technical Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,,ENGL-3140,2016
+ENGL,3140,2,Technical Writing,0.41,0.5,0.09,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2016
+ENGL,3140,3,Technical Writing,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,adrian carson,,ENGL-3140,2016
+ENGL,3140,5,Technical Writing,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,,ENGL-3140,2016
+ENGL,3140,6,Technical Writing,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,christopher benson,,ENGL-3140,2016
+ENGL,3140,7,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-3140,2016
+ENGL,3140,9,Technical Writing,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,adrian carson,,ENGL-3140,2016
+ENGL,3140,10,Technical Writing,0.29,0.57,0.1,0.0,0.05,0.0,0.0,0.0,katalin beck,,ENGL-3140,2016
+ENGL,3140,12,Technical Writing,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,,ENGL-3140,2016
+ENGL,3140,13,Technical Writing,0.76,0.1,0.05,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,,ENGL-3140,2016
+ENGL,3140,15,Technical Writing,0.7,0.15,0.0,0.0,0.05,0.0,0.0,0.1,geveryl le robinson,,ENGL-3140,2016
+ENGL,3140,16,Technical Writing,0.38,0.52,0.0,0.1,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2016
+ENGL,3140,17,Technical Writing,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3140,2016
+ENGL,3140,18,Technical Writing,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2016
+ENGL,3140,19,Technical Writing,0.59,0.23,0.14,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,,ENGL-3140,2016
+ENGL,3140,20,Technical Writing,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2016
+ENGL,3140,24,Technical Writing,0.45,0.4,0.05,0.05,0.05,0.0,0.0,0.0,william pulley,,ENGL-3140,2016
+ENGL,3140,25,Technical Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sean morey,,ENGL-3140,2016
+ENGL,3150,1,Scientific Writing & Comm,0.5,0.25,0.1,0.05,0.0,0.0,0.0,0.1,william pulley,,ENGL-3150,2016
+ENGL,3150,2,Scientific Writing & Comm,0.05,0.7,0.1,0.05,0.0,0.0,0.0,0.1,barbara ramirez,,ENGL-3150,2016
+ENGL,3150,5,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2016
+ENGL,3150,18,Scientific Writing & Comm,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,,ENGL-3150,2016
+ENGL,3150,21,Scientific Writing & Comm,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,john conway,,ENGL-3150,2016
+ENGL,3150,23,Scientific Writing & Comm,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,john conway,,ENGL-3150,2016
+ENGL,3320,1,Visual Communication,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,david blakesley,,ENGL-3320,2016
+ENGL,3370,3,Creative Inquiry: English,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,susanna ashton,,ENGL-3370,2016
+ENGL,3450,1,Structure of Fiction,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,nicholas chri brown,,ENGL-3450,2016
+ENGL,3460,1,Structure of Poetry,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-3460,2016
+ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,angela naimou,,ENGL-3530,2016
+ENGL,3570,1,Film,0.16,0.58,0.11,0.0,0.11,0.0,0.0,0.05,amy monaghan,,ENGL-3570,2016
+ENGL,3570,2,Film,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,amy monaghan,,ENGL-3570,2016
+ENGL,3800,1,Women Writers,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,meg woosley-goodman,,ENGL-3800,2016
+ENGL,3960,1,Brit Lit Survey I,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,brian mcgrath,,ENGL-3960,2016
+ENGL,3970,1,Brit Lit Survey II,0.45,0.35,0.15,0.0,0.0,0.0,0.0,0.05,david sweene coombs,,ENGL-3970,2016
+ENGL,3980,1,Amer Lit Survey I,0.55,0.32,0.0,0.0,0.14,0.0,0.0,0.0,dominic mastroianni,,ENGL-3980,2016
+ENGL,3980,2,Amer Lit Survey I,0.33,0.38,0.24,0.0,0.05,0.0,0.0,0.0,susanna ashton,,ENGL-3980,2016
+ENGL,3990,1,Amer Lit Survey II,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-3990,2016
+ENGL,4110,1,Shakespeare,0.24,0.52,0.14,0.05,0.05,0.0,0.0,0.0,andrew lemons,,ENGL-4110,2016
+ENGL,4150,1,Restor & 18th Cent,0.0,0.67,0.22,0.0,0.06,0.0,0.0,0.06,lee morrissey,,ENGL-4150,2016
+ENGL,4200,1,Amer Lit to 1799,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,jonathan beec field,,ENGL-4200,2016
+ENGL,4310,1,Modern Poetry,0.38,0.46,0.08,0.0,0.08,0.0,0.0,0.0,wayne chapman,,ENGL-4310,2016
+ENGL,4320,1,Modern Fiction,0.31,0.5,0.06,0.06,0.06,0.0,0.0,0.0,gabriel and hankins,,ENGL-4320,2016
+ENGL,4350,1,Literary Criticism,0.42,0.42,0.05,0.0,0.05,0.0,0.0,0.05,jonathan beec field,,ENGL-4350,2016
+ENGL,4420,1,Cultural Studies,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,garry bertholf,,ENGL-4420,2016
+ENGL,4450,1,Fiction Workshop,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-4450,2016
+ENGL,4460,1,Poetry Workshop,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-4460,2016
+ENGL,4520,1,Great Directors,0.33,0.33,0.27,0.0,0.0,0.0,0.0,0.07,agnieszka skrodzka,,ENGL-4520,2016
+ENGL,4530,1,Sexuality and Cinema,0.33,0.53,0.07,0.07,0.0,0.0,0.0,0.0,agnieszka skrodzka,,ENGL-4530,2016
+ENGL,4590,2,Spec Top Lang Criticism Theory,0.39,0.28,0.28,0.0,0.06,0.0,0.0,0.0,lindsay carr thomas,,ENGL-4590,2016
+ENGL,4630,1,Lit to 1699: Old English,0.71,0.18,0.06,0.06,0.0,0.0,0.0,0.0,andrew lemons,,ENGL-4630,2016
+ENGL,4640,1,Topics in Literature 1700-1899,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,erin marina goss,,ENGL-4640,2016
+ENGL,4650,1,Topics in Literature from 1900,0.65,0.18,0.06,0.0,0.06,0.0,0.0,0.06,angela naimou,,ENGL-4650,2016
+ENGL,4750,1,Writing for Media,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,tharon howard,,ENGL-4750,2016
+ENGL,4830,1,Af Am Lit 1920-Pres,0.69,0.13,0.06,0.0,0.0,0.0,0.0,0.13,garry bertholf,,ENGL-4830,2016
+ENGL,4890,1,Topics Write & Publ,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,megan eatman,,ENGL-4890,2016
+ENGL,4920,1,Modern Rhetoric,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,brian mcgrath,,ENGL-4920,2016
+ENGL,4960,1,Senior Seminar,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,michael lemahieu,,ENGL-4960,2016
+ENGL,4960,2,Senior Seminar,0.62,0.15,0.15,0.0,0.0,0.0,0.0,0.08,david sweene coombs,,ENGL-4960,2016
+ENGL,4960,3,Senior Seminar,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4960,2016
+ENGL,8120,1,Digital Approaches-Lit/Cul Stu,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,lindsay carr thomas,,ENGL-8120,2016
+ENGL,8500,1,Methods Prof Comm,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tharon howard,,ENGL-8500,2016
+ENGR,1020,615,Engineering Discipl & Skills,0.17,0.32,0.17,0.11,0.13,0.0,0.0,0.09,ashley childers,,ENGR-1020,2016
+ENGR,1020,618,Engineering Discipl & Skills,0.11,0.22,0.35,0.05,0.08,0.0,0.0,0.19,ashley childers,,ENGR-1020,2016
+ENGR,1060,400,Engr Discipline & Skills II,0.0,0.21,0.35,0.15,0.24,0.0,0.0,0.06,ashley childers,,ENGR-1060,2016
+ENGR,1060,402,Engr Discipline & Skills II,0.0,0.17,0.38,0.22,0.03,0.0,0.0,0.2,michael giebner,,ENGR-1060,2016
+ENGR,1060,615,Engr Discipline & Skills II,0.1,0.4,0.3,0.1,0.1,0.0,0.0,0.0,ashley childers,,ENGR-1060,2016
+ENGR,1060,618,Engr Discipline & Skills II,0.06,0.47,0.24,0.18,0.0,0.0,0.0,0.06,ashley childers,,ENGR-1060,2016
+ENGR,1060,643,Engr Discipline & Skills II,0.03,0.34,0.23,0.23,0.03,0.0,0.0,0.13,michael giebner,,ENGR-1060,2016
+ENGR,1060,648,Engr Discipline & Skills II,0.03,0.24,0.42,0.11,0.02,0.0,0.0,0.18,michael giebner,,ENGR-1060,2016
+ENGR,1070,648,Programming & Prob Solving I,0.0,0.33,0.25,0.17,0.17,0.0,0.0,0.08,michael giebner,,ENGR-1070,2016
+ENGR,1410,121,Programming & Problem Solving,0.18,0.3,0.3,0.07,0.09,0.0,0.0,0.07,william martin,,ENGR-1410,2016
+ENGR,1410,122,Programming & Problem Solving,0.31,0.54,0.04,0.06,0.02,0.0,0.0,0.02,william martin,,ENGR-1410,2016
+ENGR,1410,123,Programming & Problem Solving,0.21,0.48,0.13,0.08,0.02,0.0,0.0,0.08,mariah magagnotti,,ENGR-1410,2016
+ENGR,1410,124,Programming & Problem Solving,0.11,0.6,0.22,0.0,0.07,0.0,0.0,0.0,sheikh moniruz moni,,ENGR-1410,2016
+ENGR,1410,125,Programming & Problem Solving,0.13,0.28,0.43,0.09,0.02,0.0,0.0,0.04,roksana mahmud,,ENGR-1410,2016
+ENGR,1410,126,Programming & Problem Solving,0.15,0.31,0.31,0.15,0.02,0.0,0.0,0.06,matthew kent miller,,ENGR-1410,2016
+ENGR,1410,127,Programming & Problem Solving,0.04,0.43,0.28,0.11,0.09,0.0,0.0,0.06,andrew isaa neptune,,ENGR-1410,2016
+ENGR,1410,128,Programming & Problem Solving,0.09,0.21,0.39,0.15,0.09,0.0,0.0,0.06,andrew isaa neptune,,ENGR-1410,2016
+ENGR,1410,621,Programming & Problem Solving,0.43,0.34,0.11,0.04,0.06,0.0,0.0,0.02,elizabeth stephan,,ENGR-1410,2016
+ENGR,1410,622,Programming & Problem Solving,0.44,0.4,0.04,0.07,0.04,0.0,0.0,0.0,elizabeth stephan,,ENGR-1410,2016
+ENGR,1410,623,Programming & Problem Solving,0.33,0.25,0.25,0.02,0.08,0.0,0.0,0.06,srinivasarangan rang,,ENGR-1410,2016
+ENGR,1410,624,Programming & Problem Solving,0.23,0.27,0.23,0.06,0.13,0.0,0.0,0.08,srinivasarangan rang,,ENGR-1410,2016
+ENGR,1410,625,Programming & Problem Solving,0.27,0.48,0.19,0.04,0.0,0.0,0.0,0.02,steven brandon,,ENGR-1410,2016
+ENGR,1410,626,Programming & Problem Solving,0.48,0.27,0.17,0.02,0.04,0.0,0.0,0.02,steven brandon,,ENGR-1410,2016
+ENGR,1410,627,Programming & Problem Solving,0.09,0.29,0.38,0.13,0.02,0.0,0.0,0.09,jonathan maier,,ENGR-1410,2016
+ENGR,1410,631,Programming & Problem Solving,0.06,0.17,0.29,0.17,0.11,0.0,0.0,0.2,matthew kent miller,,ENGR-1410,2016
+ENGR,1410,632,Programming & Problem Solving,0.17,0.38,0.26,0.13,0.0,0.0,0.0,0.06,matthew kent miller,,ENGR-1410,2016
+ENGR,1410,634,Programming & Problem Solving,0.08,0.41,0.24,0.1,0.02,0.0,0.0,0.14,andrew isaa neptune,,ENGR-1410,2016
+ENGR,1410,636,Programming & Problem Solving,0.13,0.45,0.21,0.02,0.04,0.0,0.0,0.15,mariah magagnotti,,ENGR-1410,2016
+ENGR,1410,637,Programming & Problem Solving,0.02,0.28,0.33,0.22,0.09,0.0,0.0,0.07,mariah magagnotti,,ENGR-1410,2016
+ENGR,1510,501,Engineering Skills,0.27,0.3,0.24,0.12,0.06,0.0,0.0,0.0,john minor,,ENGR-1510,2016
+ENGR,1510,502,Engineering Skills,0.33,0.3,0.13,0.07,0.17,0.0,0.0,0.0,john minor,,ENGR-1510,2016
+ENGR,1640,502,Engineering MATLAB Programming,0.3,0.2,0.4,0.0,0.1,0.0,0.0,0.0,jonathan maier,,ENGR-1640,2016
+ENGR,1900,79,CI: Engr I Punkin Chunkin,0.81,0.0,0.0,0.0,0.13,0.0,0.0,0.06,huijuan zhao,,ENGR-1900,2016
+ENGR,2080,181,Engr Graphics & Machine Design,0.45,0.3,0.13,0.06,0.04,0.0,0.0,0.02,nighat yasmin,,ENGR-2080,2016
+ENGR,2080,681,Engr Graphics & Machine Design,0.69,0.18,0.1,0.0,0.02,0.0,0.0,0.02,john minor,,ENGR-2080,2016
+ENGR,2080,682,Engr Graphics & Machine Design,0.7,0.17,0.09,0.0,0.04,0.0,0.0,0.0,sarah grigg,,ENGR-2080,2016
+ENGR,2080,683,Engr Graphics & Machine Design,0.56,0.22,0.09,0.04,0.04,0.0,0.0,0.06,sarah grigg,,ENGR-2080,2016
+ENGR,2080,684,Engr Graphics & Machine Design,0.61,0.24,0.07,0.0,0.06,0.0,0.0,0.02,sarah grigg,,ENGR-2080,2016
+ENGR,2080,685,Engr Graphics & Machine Design,0.47,0.32,0.15,0.02,0.02,0.0,0.0,0.02,rahul sharan renu,,ENGR-2080,2016
+ENGR,2080,686,Engr Graphics & Machine Design,0.44,0.33,0.13,0.02,0.06,0.0,0.0,0.02,rahul sharan renu,,ENGR-2080,2016
+ENGR,2080,687,Engr Graphics & Machine Design,0.53,0.21,0.11,0.09,0.04,0.0,0.0,0.02,anthony pau garland,,ENGR-2080,2016
+ENGR,2080,688,Engr Graphics & Machine Design,0.45,0.32,0.06,0.02,0.08,0.0,0.0,0.08,anthony pau garland,,ENGR-2080,2016
+ENGR,2100,601,CAD & Engineering Applications,0.54,0.3,0.06,0.06,0.02,0.0,0.0,0.02,kweku tekyi brown,,ENGR-2100,2016
+ENGR,2100,602,CAD & Engineering Applications,0.57,0.15,0.11,0.04,0.06,0.0,0.0,0.06,kweku tekyi brown,,ENGR-2100,2016
+ENGR,2100,603,CAD & Engineering Applications,0.51,0.37,0.04,0.0,0.04,0.0,0.0,0.04,nighat yasmin,,ENGR-2100,2016
+ENGR,2100,604,CAD & Engineering Applications,0.55,0.33,0.06,0.0,0.04,0.0,0.0,0.02,nighat yasmin,,ENGR-2100,2016
+ENGR,2200,1,Evaluating Innovations,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,sarah grigg,,ENGR-2200,2016
+ENR,1020,1,Intro to Envir & Natur Res II,0.52,0.22,0.1,0.08,0.04,0.0,0.0,0.04,russell barrett,,ENR-1020,2016
+ENR,3020,1,Nat Res Measurements,0.5,0.27,0.13,0.1,0.0,0.0,0.0,0.0,lawrence gering,,ENR-3020,2016
+ENR,3120,1,Env Risks & Society,0.49,0.32,0.14,0.03,0.0,0.0,0.0,0.03,alan johnson,,ENR-3120,2016
+ENR,4130,1,Restoration Ecology,0.31,0.59,0.1,0.0,0.0,0.0,0.0,0.0,althea simone hagan,,ENR-4130,2016
+ENR,4500,1,Conservation Issues,0.8,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alan johnson,,ENR-4500,2016
+ENR,4500,2,Conservation Issues,0.82,0.09,0.05,0.0,0.0,0.0,0.0,0.05,alan johnson,,ENR-4500,2016
+ENSP,2000,1,Intro Environ Sci,0.41,0.34,0.24,0.0,0.0,0.0,0.0,0.0,tom owino,,ENSP-2000,2016
+ENSP,2000,2,Intro Environ Sci,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,ENSP-2000,2016
+ENSP,2000,3,Intro Environ Sci,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2016
+ENT,2000,1,Six-Legged Science,0.59,0.29,0.05,0.02,0.02,0.0,0.0,0.02,suellen pometto,,ENT-2000,2016
+ETOX,8300,1,Mechanistic Toxicology,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,william baldwin,,ETOX-8300,2016
+FCS,8340,1,Research Methods in FCS II,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,natallia ser sianko,,FCS-8340,2016
+FCS,8920,61,Program Evaluation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark small,,FCS-8920,2016
+FDSC,1020,1,Persp Food Nutrition,0.67,0.28,0.04,0.0,0.0,0.0,0.0,0.01,john mcgregor,,FDSC-1020,2016
+FDSC,2140,1,Fd Resources & Soc,0.56,0.3,0.08,0.02,0.01,0.0,0.0,0.04,paul dawson,,FDSC-2140,2016
+FDSC,3060,1,Institutional Food Service Mgt,0.62,0.28,0.1,0.0,0.0,0.0,0.0,0.0,angela fraser,,FDSC-3060,2016
+FDSC,4020,1,Food Chemistry II,0.58,0.33,0.09,0.0,0.0,0.0,0.0,0.0,feng chen,,FDSC-4020,2016
+FDSC,4030,1,Food Ch & Analysis,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,paul dawson,,FDSC-4030,2016
+FDSC,4080,1,Food Process Eng,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,felix barron,,FDSC-4080,2016
+FDSC,4090,1,TQM for Food & Pckg Industries,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-4090,2016
+FIN,3040,1,Risk & Insurance,0.2,0.32,0.36,0.12,0.0,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2016
+FIN,3050,1,Investment Analysis,0.17,0.39,0.27,0.15,0.0,0.0,0.0,0.02,kerri mcmillan,,FIN-3050,2016
+FIN,3050,2,Investment Analysis,0.16,0.28,0.33,0.12,0.09,0.0,0.0,0.02,kerri mcmillan,,FIN-3050,2016
+FIN,3050,3,Investment Analysis,0.16,0.42,0.33,0.05,0.0,0.0,0.0,0.05,kerri mcmillan,,FIN-3050,2016
+FIN,3060,1,Corporation Finance,0.14,0.17,0.28,0.17,0.16,0.0,0.0,0.08,william hol johnson,,FIN-3060,2016
+FIN,3060,2,Corporation Finance,0.1,0.1,0.14,0.29,0.22,0.0,0.0,0.16,william hol johnson,,FIN-3060,2016
+FIN,3060,5,Corporation Finance,0.13,0.16,0.25,0.25,0.11,0.0,0.0,0.1,william hol johnson,,FIN-3060,2016
+FIN,3060,400,Corporation Finance,0.16,0.29,0.32,0.16,0.03,0.0,0.0,0.05,jack wolf,,FIN-3060,2016
+FIN,3060,401,Corporation Finance,0.15,0.32,0.28,0.15,0.0,0.0,0.0,0.09,jack wolf,,FIN-3060,2016
+FIN,3060,402,Corporation Finance,0.13,0.29,0.36,0.11,0.06,0.0,0.0,0.05,jack wolf,,FIN-3060,2016
+FIN,3070,1,Prin of Real Estate,0.21,0.38,0.28,0.08,0.05,0.0,0.0,0.0,ramon tolb franklin,,FIN-3070,2016
+FIN,3070,2,Prin of Real Estate,0.17,0.31,0.39,0.13,0.0,0.0,0.0,0.0,thomas springer,,FIN-3070,2016
+FIN,3080,1,Fin Inst & Mkts,0.24,0.29,0.32,0.1,0.02,0.0,0.0,0.02,daniel thoma greene,,FIN-3080,2016
+FIN,3080,2,Fin Inst & Mkts,0.25,0.45,0.23,0.08,0.0,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2016
+FIN,3080,3,Fin Inst & Mkts,0.44,0.28,0.26,0.03,0.0,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2016
+FIN,3110,1,Financial Management I,0.04,0.23,0.38,0.19,0.04,0.0,0.0,0.12,george bra lockhart,,FIN-3110,2016
+FIN,3110,2,Financial Management I,0.12,0.28,0.33,0.14,0.07,0.0,0.0,0.07,george bra lockhart,,FIN-3110,2016
+FIN,3110,3,Financial Management I,0.06,0.4,0.36,0.02,0.08,0.0,0.0,0.08,ramon tolb franklin,,FIN-3110,2016
+FIN,3110,4,Financial Management I,0.17,0.23,0.33,0.04,0.06,0.0,0.0,0.17,george bra lockhart,,FIN-3110,2016
+FIN,3120,1,Financial Management II,0.11,0.33,0.31,0.19,0.03,0.0,0.0,0.03,vincent intintoli,,FIN-3120,2016
+FIN,3120,2,Financial Management II,0.2,0.34,0.28,0.06,0.06,0.0,0.0,0.06,vincent intintoli,,FIN-3120,2016
+FIN,3120,3,Financial Management II,0.24,0.26,0.31,0.16,0.02,0.0,0.0,0.02,angela morgan,,FIN-3120,2016
+FIN,4030,1,Spreadsheet Apps in Finance,0.33,0.5,0.08,0.06,0.0,0.0,0.0,0.03,jared daniel smith,,FIN-4030,2016
+FIN,4030,2,Spreadsheet Apps in Finance,0.13,0.6,0.17,0.07,0.03,0.0,0.0,0.0,jared daniel smith,,FIN-4030,2016
+FIN,4040,1,Financial Modeling,0.1,0.4,0.3,0.0,0.05,0.05,0.0,0.1,jack wolf,,FIN-4040,2016
+FIN,4050,1,Portfolio Management & Theory,0.25,0.17,0.29,0.17,0.08,0.0,0.0,0.04,john alexander,,FIN-4050,2016
+FIN,4080,1,Mgt of Fin Inst,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2016
+FIN,4080,2,Mgt of Fin Inst,0.14,0.67,0.1,0.05,0.0,0.0,0.0,0.05,lyudmila chernykh,,FIN-4080,2016
+FIN,4090,1,Prof Fin Plan,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william hol johnson,,FIN-4090,2016
+FIN,4110,1,Int Fin Mgt,0.34,0.49,0.1,0.05,0.0,0.0,0.0,0.02,tilan tang,,FIN-4110,2016
+FIN,4110,2,Int Fin Mgt,0.33,0.46,0.15,0.05,0.0,0.0,0.0,0.0,tilan tang,,FIN-4110,2016
+FIN,4150,1,Real Estate Investmt,0.14,0.55,0.18,0.05,0.0,0.0,0.0,0.09,thomas springer,,FIN-4150,2016
+FIN,4160,1,Real Estate Val,0.25,0.6,0.1,0.05,0.0,0.0,0.0,0.0,ramon tolb franklin,,FIN-4160,2016
+FNR,4700,51,Camera Traps/ Animal Ecology,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,david sco jachowski,,FNR-4700,2016
+FNR,4990,1,Natural Resources Seminar,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,greg yarrow,,FNR-4990,2016
+FNR,4990,2,Natural Resources Seminar,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,greg yarrow,,FNR-4990,2016
+FNR,4990,3,Natural Resources Seminar,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,greg yarrow,,FNR-4990,2016
+FOR,1010,1,Intro to Forestry,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,lawrence gering,,FOR-1010,2016
+FOR,2060,1,Forestry Ecology,0.31,0.38,0.2,0.06,0.03,0.0,0.0,0.02,donald hagan,,FOR-2060,2016
+FOR,3080,1,Remote Sensing in Forestry,0.23,0.46,0.15,0.12,0.04,0.0,0.0,0.0,lawrence gering,,FOR-3080,2016
+FOR,4060,1,Forested Watershed Mgmt,0.65,0.29,0.0,0.0,0.02,0.0,0.0,0.04,joanna emily hawley,,FOR-4060,2016
+FOR,4080,1,Wood and Paper Products,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,patricia layton,,FOR-4080,2016
+FOR,4150,1,Forest Wildlife Managment,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,james davis,,FOR-4150,2016
+FOR,4180,1,Forest Resource Valuation,0.23,0.5,0.23,0.04,0.0,0.0,0.0,0.0,thomas straka,,FOR-4180,2016
+FOR,4340,1,GIS for Natural Resources,0.51,0.34,0.11,0.0,0.02,0.0,0.0,0.02,robert frit baldwin,,FOR-4340,2016
+FOR,4650,1,Silviculture,0.2,0.44,0.24,0.12,0.0,0.0,0.0,0.0,gaofeng wang,,FOR-4650,2016
+FOR,8120,1,Fire Ecology and Management,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,gaofeng wang,,FOR-8120,2016
+FR,1010,1,Elementary French,0.29,0.53,0.06,0.06,0.0,0.0,0.0,0.06,anne salces  nedeo,,FR-1010,2016
+FR,1020,1,Elementary French,0.09,0.27,0.18,0.18,0.18,0.0,0.0,0.09,anne salces  nedeo,,FR-1020,2016
+FR,1020,2,Elementary French,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2016
+FR,1020,3,Elementary French,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2016
+FR,2010,1,Intermediate French,0.61,0.22,0.11,0.0,0.06,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2010,2016
+FR,2010,2,Intermediate French,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2010,2016
+FR,2010,4,Intermediate French,0.47,0.27,0.13,0.0,0.0,0.0,0.0,0.13,kelly digby peebles,,FR-2010,2016
+FR,2020,1,Intermediate French,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,eric touya,,FR-2020,2016
+FR,2020,2,Intermediate French,0.63,0.26,0.0,0.11,0.0,0.0,0.0,0.0,joseph mai,,FR-2020,2016
+FR,2020,3,Intermediate French,0.71,0.24,0.0,0.06,0.0,0.0,0.0,0.0,joseph mai,,FR-2020,2016
+FR,2020,4,Intermediate French,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,paulin de tholozany,,FR-2020,2016
+FR,3050,1,Int Fr Con & Comp I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,,FR-3050,2016
+FR,3160,1,Fr for Intl Trade,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-3160,2016
+FR,3170,1,Contemp French Civ,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,joseph mai,,FR-3170,2016
+FR,4200,1,French Enlightenment,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,,FR-4200,2016
+FR,4760,1,Adv Sem Fr Thought,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,,FR-4760,2016
+GC,1010,1,Orientation to G C,0.41,0.39,0.11,0.02,0.0,0.0,0.0,0.07,carol jones,,GC-1010,2016
+GC,1020,1,Computer Art & CAD Foundations,0.36,0.43,0.16,0.02,0.02,0.0,0.0,0.0,carol jones,,GC-1020,2016
+GC,1030,1,G C I for Pkgsc,0.23,0.54,0.06,0.06,0.06,0.0,0.0,0.06,john jacobs,,GC-1030,2016
+GC,1040,1,Graphic Communications I,0.43,0.51,0.04,0.0,0.0,0.0,0.0,0.01,rebecca suza edlein,,GC-1040,2016
+GC,2070,1,Graphic Communications II,0.53,0.38,0.09,0.0,0.0,0.0,0.0,0.0,patrick gee rose,,GC-2070,2016
+GC,2400,1,Intro to Web Design and Dev,0.56,0.25,0.06,0.0,0.0,0.06,0.0,0.06,erica black walker,,GC-2400,2016
+GC,3400,1,Digital Imaging and eMedia,0.64,0.31,0.05,0.0,0.0,0.0,0.0,0.0,erica black walker,,GC-3400,2016
+GC,3460,1,Ink and Substrates,0.18,0.44,0.29,0.04,0.04,0.0,0.0,0.02,liam henry 'hara,,GC-3460,2016
+GC,4060,1,Package and Specialty Printing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kern cox,,GC-4060,2016
+GC,4400,1,Commercial Printing,0.23,0.49,0.17,0.0,0.03,0.0,0.0,0.09,eric weisenmiller,,GC-4400,2016
+GC,4440,1,Current Dev/Trends in Gr Comm,0.33,0.47,0.14,0.06,0.0,0.0,0.0,0.0,liam henry 'hara,,GC-4440,2016
+GC,4480,1,Plan & Cont Printing Functions,0.6,0.34,0.04,0.02,0.0,0.0,0.0,0.0,john leininger,,GC-4480,2016
+GC,4800,1,Senior Seminar in GC,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,charles edwa tonkin,,GC-4800,2016
+GC,4900,2,G C Selected Topics-Sales,0.62,0.27,0.04,0.0,0.0,0.0,0.0,0.08,john leininger,,GC-4900,2016
+GC,4900,6,G C Selected Topics-The DEN,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,erica black walker,,GC-4900,2016
+GEN,3000,1,Fundamental Genetics,0.23,0.33,0.22,0.11,0.07,0.0,0.0,0.03,kate leanne wi tsai,,GEN-3000,2016
+GEN,3000,2,Fundamental Genetics,0.18,0.39,0.24,0.11,0.03,0.0,0.0,0.03,kate leanne wi tsai,,GEN-3000,2016
+GEN,3020,1,Molecular & General Genetics,0.33,0.33,0.17,0.04,0.0,0.0,0.0,0.13,meredith tei morris,,GEN-3020,2016
+GEN,4100,1,Population & Quant Genetics,0.43,0.38,0.11,0.05,0.03,0.0,0.0,0.0,amy lou lawton rauh,,GEN-4100,2016
+GEN,4110,2,Populatn & Quant Genetics Lab,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,,GEN-4110,2016
+GEN,4400,1,Bioinformatics,0.41,0.35,0.18,0.0,0.0,0.0,0.0,0.06,liangjiang wang,,GEN-4400,2016
+GEN,6100,1,Population & Quant Genetics,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,,GEN-6100,2016
+GEOG,1010,1,Intro to Geography,0.35,0.29,0.29,0.0,0.03,0.0,0.0,0.03,christa smith,,GEOG-1010,2016
+GEOG,1030,1,World Regional Geol,0.83,0.07,0.03,0.03,0.02,0.0,0.0,0.02,lance forres howard,,GEOG-1030,2016
+GEOG,1030,2,World Regional Geog,0.4,0.38,0.15,0.08,0.0,0.0,0.0,0.0,william churc terry,,GEOG-1030,2016
+GEOG,3010,1,Political Geography,0.56,0.28,0.04,0.0,0.04,0.0,0.0,0.08,christa smith,,GEOG-3010,2016
+GEOL,1010,1,Physical Geology,0.37,0.36,0.17,0.05,0.03,0.0,0.0,0.01,alan coulson,,GEOL-1010,2016
+GEOL,1010,2,Physical Geology,0.46,0.33,0.12,0.05,0.04,0.0,0.0,0.0,alan coulson,,GEOL-1010,2016
+GEOL,1030,1,Physical Geol Lab,0.3,0.52,0.13,0.04,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,2,Physical Geol Lab,0.65,0.13,0.04,0.0,0.09,0.0,0.0,0.09,alan coulson,,GEOL-1030,2016
+GEOL,1030,3,Physical Geol Lab,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2016
+GEOL,1030,5,Physical Geol Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,6,Physical Geol Lab,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,7,Physical Geol Lab,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,alan coulson,,GEOL-1030,2016
+GEOL,1030,8,Physical Geol Lab,0.61,0.3,0.04,0.04,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,9,Physical Geol Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,10,Physical Geol Lab,0.58,0.33,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2016
+GEOL,1030,11,Physical Geol Lab,0.67,0.21,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1030,12,Physical Geol Lab,0.75,0.06,0.19,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2016
+GEOL,1120,1,Earth Resources,0.52,0.31,0.15,0.0,0.0,0.0,0.0,0.02,scott brame,,GEOL-1120,2016
+GEOL,1140,1,Earth Resources Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-1140,2016
+GEOL,2020,1,Earth History,0.25,0.5,0.05,0.1,0.1,0.0,0.0,0.0,alan coulson,,GEOL-2020,2016
+GEOL,3130,1,Sedimentology & Stratigraphy,0.11,0.44,0.28,0.17,0.0,0.0,0.0,0.0,james castle,,GEOL-3130,2016
+GEOL,3180,1,Introduction to Geochemistry,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,brian powell,,GEOL-3180,2016
+GEOL,4210,1,Gis in Geology,0.7,0.26,0.0,0.0,0.0,0.0,0.0,0.04,scott brame,,GEOL-4210,2016
+GEOL,7900,501,Biogeography & Geology of SC,0.25,0.5,0.13,0.0,0.13,0.0,0.0,0.0,john robert wagner,,GEOL-7900,2016
+GEOL,8030,1,Geostatistics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,stephen mich moysey,,GEOL-8030,2016
+GEOL,8160,1,Aquifer Systems,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,lawrence murdoch,,GEOL-8160,2016
+GER,1010,1,Elementary German,0.32,0.42,0.11,0.05,0.05,0.0,0.0,0.05,oswald harris king,,GER-1010,2016
+GER,1010,2,Elementary German,0.56,0.11,0.11,0.06,0.0,0.0,0.0,0.17,oswald harris king,,GER-1010,2016
+GER,1020,1,Elementary German,0.31,0.31,0.31,0.0,0.0,0.0,0.0,0.08, lee ferrell,,GER-1020,2016
+GER,1020,2,Elementary German,0.21,0.29,0.07,0.0,0.14,0.0,0.0,0.29, lee ferrell,,GER-1020,2016
+GER,2010,1,Intermediate German,0.35,0.53,0.06,0.0,0.0,0.0,0.0,0.06,oswald harris king,,GER-2010,2016
+GER,2020,1,Intermediate German,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,johannes schmidt,,GER-2020,2016
+GER,2020,2,Intermediate German,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-2020,2016
+GER,3160,1,Ger for Intl Trade I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0, lee ferrell,,GER-3160,2016
+GER,3610,1,Ger Lit 1832 to Mod,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,johannes schmidt,,GER-3610,2016
+HCC,8810,2,Measurement & Eval,0.57,0.14,0.0,0.0,0.0,0.0,0.0,0.29,bart knijnenburg,,HCC-8810,2016
+HCG,9010,1,Adv in Humn Genetics,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,julia eggert,,HCG-9010,2016
+HCG,9890,3,Special Topics: Theoretical Fo,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,mary steck,,HCG-9890,2016
+HEHD,3990,2,Students Helping Students Peer,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,mary mcp von kaenel,,HEHD-3990,2016
+HEHD,4000,1,Intro Leadership Theor & Conc,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,william havice,,HEHD-4000,2016
+HEHD,4200,1,Lead Appli & Exper,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mary price,,HEHD-4200,2016
+HEHD,8010,230,Child/Adolescent Dev,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,,HEHD-8010,2016
+HEHD,8040,230,Assessment/Eval,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,,HEHD-8040,2016
+HEHD,8880,400,Special Topics Youth Dev Ldshp,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,barry garst,,HEHD-8880,2016
+HIST,1010,1,Hist of the U S,0.27,0.55,0.12,0.0,0.06,0.0,0.0,0.0,james brad jeffries,,HIST-1010,2016
+HIST,1240,1,Environmental History Survey,0.04,0.46,0.31,0.05,0.07,0.0,0.0,0.07,james brad jeffries,,HIST-1240,2016
+HIST,1720,3,The West and the World I,0.43,0.46,0.06,0.0,0.0,0.0,0.0,0.06,emily wood,,HIST-1720,2016
+HIST,1730,1,The West and the World II,0.27,0.38,0.19,0.0,0.08,0.0,0.0,0.08, alan grubb,,HIST-1730,2016
+HIST,1730,2,The West and the World II,0.33,0.28,0.25,0.07,0.03,0.0,0.0,0.03,james burns,,HIST-1730,2016
+HIST,1730,3,The West and the World II,0.18,0.43,0.2,0.08,0.05,0.0,0.0,0.07,thomas kuehn,,HIST-1730,2016
+HIST,2990,1,Historian's Craft,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,michael silvestri,,HIST-2990,2016
+HIST,2990,2,Historian's Craft,0.44,0.38,0.06,0.0,0.06,0.0,0.0,0.06,elizabeth carney,,HIST-2990,2016
+HIST,3000,1,Hist Colonial Amer,0.62,0.32,0.03,0.0,0.03,0.0,0.0,0.0,lee brady wilson,,HIST-3000,2016
+HIST,3010,1,Am Rev & New Nation,0.21,0.27,0.21,0.06,0.15,0.0,0.0,0.09,james brad jeffries,,HIST-3010,2016
+HIST,3100,1,History of Religion in the US,0.27,0.53,0.0,0.07,0.07,0.0,0.0,0.07,elizabeth jemison,,HIST-3100,2016
+HIST,3110,1,African American Hist to 1877,0.26,0.55,0.1,0.0,0.06,0.0,0.0,0.03,abel bartley,,HIST-3110,2016
+HIST,3180,1,American Women,0.26,0.39,0.23,0.1,0.0,0.0,0.0,0.03,meg taylor-shockley,,HIST-3180,2016
+HIST,3210,2,History of Science,0.54,0.34,0.03,0.0,0.03,0.0,0.0,0.06,pamela mack,,HIST-3210,2016
+HIST,3240,1,Hist of the South II,0.33,0.52,0.09,0.03,0.0,0.0,0.0,0.03,john andrew,,HIST-3240,2016
+HIST,3260,1,Hist Am Transport,0.66,0.23,0.03,0.0,0.09,0.0,0.0,0.0, roger grant,,HIST-3260,2016
+HIST,3330,1,Hist of Mod Japan,0.21,0.41,0.26,0.03,0.09,0.0,0.0,0.0,edwin moise,,HIST-3330,2016
+HIST,3410,1,Modern Mexico,0.57,0.29,0.06,0.0,0.0,0.0,0.0,0.09,rachel anne moore,,HIST-3410,2016
+HIST,3510,1,Ancient Near East,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,steven grosby,,HIST-3510,2016
+HIST,3730,2,Age of Protestant Reformation,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,thomas kuehn,,HIST-3730,2016
+HIST,3810,1,Germany Since 1918,0.16,0.63,0.16,0.0,0.03,0.0,0.0,0.03,michael meng,,HIST-3810,2016
+HIST,3890,3,Mitchelville,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,abel bartley,,HIST-3890,2016
+HIST,3890,4,Upstate Black Communities,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,abel bartley,,HIST-3890,2016
+HIST,3890,5,Churches of Mitchelville,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,,HIST-3890,2016
+HIST,3900,1,Modern Military History,0.11,0.43,0.32,0.04,0.07,0.0,0.0,0.04,edwin moise,,HIST-3900,2016
+HIST,3920,1,Hist U S Environment,0.16,0.44,0.09,0.09,0.16,0.0,0.0,0.06,pamela mack,,HIST-3920,2016
+HIST,3970,1,Modern Middle East,0.42,0.55,0.0,0.03,0.0,0.0,0.0,0.0,amit bein,,HIST-3970,2016
+HIST,4000,1,Colonial South Carolina,0.17,0.28,0.39,0.06,0.06,0.0,0.0,0.06,paul chris anderson,,HIST-4000,2016
+HIST,4400,1,Studies in Latin American Hist,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,,HIST-4400,2016
+HIST,4600,2,British India,0.54,0.31,0.0,0.08,0.0,0.0,0.0,0.08,michael silvestri,,HIST-4600,2016
+HIST,4870,1,World War II,0.14,0.57,0.17,0.02,0.05,0.0,0.0,0.05,john andrew,,HIST-4870,2016
+HIST,4880,1,Middle Eastern Soc & Culture,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,,HIST-4880,2016
+HIST,4900,2,Domestic Space & History,0.58,0.33,0.0,0.0,0.08,0.0,0.0,0.0,elizabeth carney,,HIST-4900,2016
+HIST,4900,3,Capitalism,0.53,0.13,0.2,0.0,0.07,0.0,0.0,0.07,steven marks,,HIST-4900,2016
+HIST,4920,1,African American & Sports,0.31,0.46,0.15,0.0,0.0,0.0,0.0,0.08,abel bartley,,HIST-4920,2016
+HLTH,2020,1,Introduction to Public Health,0.57,0.29,0.05,0.05,0.0,0.0,0.0,0.05,jeffrey kingree,,HLTH-2020,2016
+HLTH,2020,2,Introduction to Public Health,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2016
+HLTH,2020,3,Introduction to Public Health,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2016
+HLTH,2020,400,Introduction to Public Health,0.53,0.21,0.11,0.05,0.0,0.0,0.0,0.11,ralph stewart welsh,,HLTH-2020,2016
+HLTH,2030,1,Health Care Sys,0.45,0.27,0.09,0.09,0.0,0.0,0.0,0.09,frederic fraizer,,HLTH-2030,2016
+HLTH,2030,2,Health Care Sys,0.48,0.31,0.17,0.0,0.0,0.0,0.0,0.03,frederic fraizer,,HLTH-2030,2016
+HLTH,2030,3,Health Care Sys,0.79,0.09,0.09,0.0,0.0,0.0,0.0,0.03,lee alden crandall,,HLTH-2030,2016
+HLTH,2030,400,Health Care Sys,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2030,2016
+HLTH,2400,2,Deter of Hlth Behav,0.47,0.43,0.03,0.0,0.03,0.0,0.0,0.03,amelia clinkscales,,HLTH-2400,2016
+HLTH,2400,400,Deter of Hlth Behav,0.53,0.33,0.07,0.07,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2016
+HLTH,2980,1,Human Hlth & Disease,0.57,0.35,0.02,0.0,0.04,0.0,0.0,0.02,annah kamugiz amani,,HLTH-2980,2016
+HLTH,2980,2,Human Hlth & Disease,0.66,0.23,0.09,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,,HLTH-2980,2016
+HLTH,3030,1,Public Health Comm,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,debra mitch charles,,HLTH-3030,2016
+HLTH,3050,1,Body Resp Hlth Beh,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,brian patric graves,,HLTH-3050,2016
+HLTH,3100,1,Women's Hlth Issues,0.64,0.24,0.09,0.03,0.0,0.0,0.0,0.0,rachel mayo,,HLTH-3100,2016
+HLTH,3500,1,Med Terminology/Comm,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kari jea strothmann,,HLTH-3500,2016
+HLTH,3800,1,Epidemiology,0.27,0.57,0.13,0.0,0.03,0.0,0.0,0.0,hugh spitler,,HLTH-3800,2016
+HLTH,3800,2,Epidemiology,0.45,0.4,0.1,0.03,0.0,0.0,0.0,0.03,deborah alma falta,,HLTH-3800,2016
+HLTH,3980,1,Hlth Appraisal Sklls,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,kathleen meyer,,HLTH-3980,2016
+HLTH,3980,2,Hlth Appraisal Sklls,0.71,0.14,0.07,0.07,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2016
+HLTH,4100,1,Maternal Child Hlth,0.66,0.28,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,,HLTH-4100,2016
+HLTH,4190,1,Health Sci Internship Prep Sem,0.45,0.3,0.18,0.03,0.0,0.0,0.0,0.05,kathleen meyer,,HLTH-4190,2016
+HLTH,4200,1,Hlth Science Intern,0.72,0.26,0.02,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2016
+HLTH,4300,1,Hlth Prom of Aged,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,cheryl jo dye,,HLTH-4300,2016
+HLTH,4310,1,Public & Environ Hlt,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-4310,2016
+HLTH,4600,1,Health Info Systems,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-4600,2016
+HLTH,4700,400,Global Health,0.58,0.16,0.05,0.0,0.05,0.0,0.0,0.16,annah kamugiz amani,,HLTH-4700,2016
+HLTH,4780,1,Health Policy Ethics and Law,0.2,0.4,0.35,0.05,0.0,0.0,0.0,0.0,hugh spitler,,HLTH-4780,2016
+HLTH,4790,1,Fin Mgmt & Hlth Budg,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,lingling zhang,,HLTH-4790,2016
+HLTH,4800,1,Comm Hlth Promotion,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,joel edwar williams,,HLTH-4800,2016
+HLTH,4900,1,Res Eval St Pub Hlth,0.59,0.28,0.09,0.03,0.0,0.0,0.0,0.0,khoa dang truong,,HLTH-4900,2016
+HLTH,4900,2,Res Eval St Pub Hlth,0.44,0.44,0.0,0.06,0.0,0.0,0.0,0.06,khoa dang truong,,HLTH-4900,2016
+HLTH,4970,4,Creative Inq Hlth - Aspire,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,martha par thompson,,HLTH-4970,2016
+HLTH,8210,500,Health Research I,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,lee alden crandall,,HLTH-8210,2016
+HON,2060,1,Intro to Nanotechnology,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,christophe kitchens,,HON-2060,2016
+HON,2060,3,Integrity in Engineering,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,daniel wueste,,HON-2060,2016
+HON,2200,1,Knight of a Different Order,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,emily wood,,HON-2200,2016
+HON,2210,2,"Hamlet, Again",0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,HON-2210,2016
+HON,2210,5,Authoring Harry Potter,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,megan no macalystre,,HON-2210,2016
+HORT,1010,1,Horticulture,0.86,0.05,0.04,0.0,0.0,0.0,0.0,0.05,ellen anita vincent,,HORT-1010,2016
+HORT,2020,1,Adobe Digital Design,0.75,0.04,0.08,0.0,0.08,0.0,0.0,0.04,janice ann lay,,HORT-2020,2016
+HORT,2110,1,Growing Spring Plnts,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,james emerson faust,,HORT-2110,2016
+HORT,4040,1,Plant Propagation,0.1,0.38,0.28,0.17,0.03,0.0,0.0,0.03,jeffrey adelberg,,HORT-4040,2016
+HORT,4050,1,Plant Propagation Techniq Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,,HORT-4050,2016
+HORT,4050,2,Plant Propagation Techniq Lab,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,jeffrey adelberg,,HORT-4050,2016
+HORT,4270,1,Urban Tree Care,0.23,0.55,0.18,0.0,0.05,0.0,0.0,0.0,robert polomski,,HORT-4270,2016
+HORT,4330,1,Turf Weed Management,0.28,0.31,0.34,0.03,0.0,0.0,0.0,0.03,ted whitwell,,HORT-4330,2016
+HP,8280,1,Case St in Preservation Engr,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,craig mille bennett,,HP-8280,2016
+HP,8330,1,Cultural and Historical Landsc,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,carter lee hudgins,,HP-8330,2016
+HRD,8490,400,Eval of T&D/Hrd Prog,0.92,0.02,0.0,0.0,0.06,0.0,0.0,0.0,philip mcgee,,HRD-8490,2016
+IE,2100,1,Des Analysis Wrk Sys,0.17,0.41,0.2,0.1,0.07,0.0,0.0,0.05,sara lu riggs,,IE-2100,2016
+IE,2800,1,Deterministic Operations Rsrch,0.12,0.41,0.28,0.1,0.03,0.0,0.0,0.05,robert mark curry,,IE-2800,2016
+IE,3010,1,Systems Design I,0.62,0.36,0.02,0.0,0.0,0.0,0.0,0.0,robert james riggs,,IE-3010,2016
+IE,3610,1,Industrial App of Prob/Stat II,0.33,0.37,0.13,0.03,0.13,0.0,0.0,0.0,sandra dun eksioglu,,IE-3610,2016
+IE,3610,2,Industrial App of Prob/Stat II,0.58,0.25,0.12,0.03,0.0,0.0,0.0,0.03,joel greenstein,,IE-3610,2016
+IE,3810,1,Probabilistic Operations Rsrch,0.2,0.31,0.33,0.07,0.09,0.0,0.0,0.0,burak eksioglu,,IE-3810,2016
+IE,3810,2,Probabilistic Operations Rsrch,0.24,0.34,0.19,0.13,0.08,0.0,0.0,0.02,amin khademi,,IE-3810,2016
+IE,3840,1,Engr Econ Analysis,0.55,0.17,0.12,0.04,0.04,0.0,0.0,0.08,brian melloy,,IE-3840,2016
+IE,3860,1,Prod Plan & Cont,0.32,0.36,0.19,0.09,0.02,0.0,0.0,0.03,robert james riggs,,IE-3860,2016
+IE,4020,3,Creative Inq Res,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,anand gramopadhye,,IE-4020,2016
+IE,4620,1,Six Sigma Quality,0.34,0.52,0.14,0.0,0.0,0.0,0.0,0.0,robert james riggs,,IE-4620,2016
+IE,4670,1,System Design II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,,IE-4670,2016
+IE,4910,1,Service Engineering,0.29,0.29,0.18,0.18,0.0,0.0,0.0,0.06,tugce isik,,IE-4910,2016
+IE,4910,3,Invest Human Error Complx Sys,0.4,0.42,0.12,0.03,0.03,0.0,0.0,0.0,sara lu riggs,,IE-4910,2016
+IE,6910,1,Service Engineering,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tugce isik,,IE-6910,2016
+IE,6910,3,Invest Human Error Complx Sys,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,sara lu riggs,,IE-6910,2016
+IE,8010,1,Human-Machine Sys,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,,IE-8010,2016
+IE,8520,1,Prescriptive Analytics,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,,IE-8520,2016
+IE,8540,1,SC & Logistics Modeling I,0.73,0.21,0.06,0.0,0.0,0.0,0.0,0.0,william ferrell,,IE-8540,2016
+IE,8580,1,Case Study Supply Chn & Logist,0.83,0.15,0.03,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-8580,2016
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.02,caren kelley-hall,,INT-1510,2016
+INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.93,0.04,0.03,caren kelley-hall,,INT-1520,2016
+INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,,INT-2510,2016
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,uttiyo raychaudhuri,,IS-1010,2016
+ITAL,1010,1,Elementary Italian,0.65,0.06,0.18,0.0,0.06,0.0,0.0,0.06,julia schmidt,,ITAL-1010,2016
+ITAL,1020,1,Elementary Italian,0.5,0.39,0.0,0.11,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-1020,2016
+ITAL,1020,2,Elementary Italian,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,valentina lombardi,,ITAL-1020,2016
+ITAL,1020,3,Elementary Italian,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,,ITAL-1020,2016
+ITAL,2020,1,Intermediate Italian,0.61,0.33,0.0,0.06,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2020,2016
+ITAL,2020,2,Intermediate Italian,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,valentina lombardi,,ITAL-2020,2016
+JAPN,1010,1,Elementary Japanese,0.44,0.11,0.11,0.0,0.17,0.0,0.0,0.17,kazuko shoji,,JAPN-1010,2016
+JAPN,1010,2,Elementary Japanese,0.38,0.13,0.19,0.06,0.19,0.0,0.0,0.06,kazuko shoji,,JAPN-1010,2016
+JAPN,1020,1,Elementary Japanese,0.35,0.24,0.06,0.18,0.12,0.0,0.0,0.06,jae allegr takeuchi,,JAPN-1020,2016
+JAPN,1020,2,Elementary Japanese,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,jae allegr takeuchi,,JAPN-1020,2016
+JAPN,2010,1,Intermed Japanese,0.2,0.6,0.1,0.0,0.1,0.0,0.0,0.0,kazuko shoji,,JAPN-2010,2016
+JAPN,2020,1,Intermed Japanese,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,kazuko shoji,,JAPN-2020,2016
+JAPN,4170,1,Japanese Culture and Society,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jae allegr takeuchi,,JAPN-4170,2016
+LARC,1160,1,History of Landscape Arch,0.24,0.29,0.3,0.09,0.03,0.0,0.0,0.05,hala fouad nassar,,LARC-1160,2016
+LARC,1520,1,Basic Design II,0.65,0.22,0.09,0.0,0.0,0.0,0.0,0.04,paul russell,,LARC-1520,2016
+LARC,2520,1,Site Design,0.36,0.36,0.27,0.0,0.0,0.0,0.0,0.0,martin john holland,,LARC-2520,2016
+LARC,3620,1,Design Impl II,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,paul russell,,LARC-3620,2016
+LARC,4280,1,Comput Aided Design,0.61,0.11,0.18,0.0,0.0,0.0,0.0,0.11,jessica fernandez,,LARC-4280,2016
+LAW,3220,1,Legal Env of Bus,0.35,0.37,0.15,0.02,0.07,0.0,0.0,0.04,kenneth toussaint,,LAW-3220,2016
+LAW,3220,2,Legal Env of Bus,0.27,0.56,0.16,0.02,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2016
+LAW,3220,3,Legal Env of Bus,0.7,0.24,0.07,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2016
+LAW,3220,4,Legal Env of Bus,0.38,0.38,0.22,0.0,0.02,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2016
+LAW,3220,5,Legal Env of Bus,0.41,0.34,0.18,0.05,0.0,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2016
+LAW,3220,6,Legal Env of Bus,0.42,0.38,0.11,0.04,0.0,0.0,0.0,0.04,edward ray claggett,,LAW-3220,2016
+LAW,3220,7,Legal Env of Bus,0.57,0.37,0.04,0.02,0.0,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2016
+LAW,3220,8,Legal Env of Bus,0.4,0.37,0.21,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,,LAW-3220,2016
+LAW,3220,9,Legal Env of Bus,0.41,0.44,0.1,0.03,0.03,0.0,0.0,0.0,kath kisska-schulze,,LAW-3220,2016
+LAW,3220,10,Legal Env of Bus,0.28,0.55,0.12,0.03,0.02,0.0,0.0,0.0,john hine,,LAW-3220,2016
+LAW,3220,11,Legal Env of Bus,0.21,0.56,0.15,0.03,0.03,0.0,0.0,0.02,john hine,,LAW-3220,2016
+LAW,3220,401,Legal Env of Bus,0.14,0.28,0.16,0.16,0.07,0.0,0.0,0.19,virgini ward-vaughn,,LAW-3220,2016
+LAW,3220,402,Legal Env of Bus,0.1,0.25,0.23,0.15,0.13,0.0,0.0,0.15,virgini ward-vaughn,,LAW-3220,2016
+LAW,3220,403,Legal Env of Bus,0.23,0.28,0.2,0.18,0.1,0.0,0.0,0.03,virgini ward-vaughn,,LAW-3220,2016
+LAW,3220,404,Legal Env of Bus,0.22,0.37,0.15,0.17,0.07,0.0,0.0,0.02,virgini ward-vaughn,,LAW-3220,2016
+LAW,3220,601,Legal Env of Bus,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-3220,2016
+LAW,4990,1,Selected Topics: Cyber Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-4990,2016
+LAW,8500,1,Law for Prof Accts,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-8500,2016
+LAW,8500,2,Law for Prof Accts,0.18,0.74,0.09,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-8500,2016
+LAW,8500,3,Law for Prof Accts,0.49,0.43,0.09,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-8500,2016
+LS,1000,9,Intro to Salsa Dance,0.64,0.09,0.0,0.0,0.27,0.0,0.0,0.0,malik lewis baxter,,LS-1000,2016
+LS,1000,20,Intro to Volleyball,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,kelly lynn ator,,LS-1000,2016
+LS,1000,22,Intermediate Ashtanga Yoga,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,,LS-1000,2016
+LS,1000,23,Therapeutic Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,,LS-1000,2016
+LS,1000,24,Therapeutic Yoga,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,,LS-1000,2016
+LS,1000,25,Therapeutic Yoga,0.78,0.09,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,,LS-1000,2016
+LS,1130,1,Wood Carving,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,louwanda jolley,,LS-1130,2016
+LS,1260,1,Group Initiatives,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,christina mar mazer,,LS-1260,2016
+LS,1410,1,Top Rope Climbing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,glenn dav middleton,,LS-1410,2016
+LS,1410,3,Top Rope Climbing,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,glenn dav middleton,,LS-1410,2016
+LS,1450,2,Camping/Backpacking,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,samuel james keith,,LS-1450,2016
+LS,1450,4,Camping/Backpacking,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,samuel james keith,,LS-1450,2016
+LS,1580,2,Archery,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,,LS-1580,2016
+LS,1580,3,Archery,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,,LS-1580,2016
+LS,1580,4,Archery,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,,LS-1580,2016
+LS,1640,1,Whitewater Kayaking,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,robert taylor,,LS-1640,2016
+LS,1850,2,Bowling,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,megan elizabet cato,,LS-1850,2016
+LS,1850,5,Bowling,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.07,katie dudley,,LS-1850,2016
+LS,1850,6,Bowling,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,megan elizabet cato,,LS-1850,2016
+LS,1850,8,Bowling,0.87,0.03,0.0,0.03,0.0,0.0,0.0,0.07,megan elizabet cato,,LS-1850,2016
+LS,1870,1,Frisbee Sports,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,craig goodman,,LS-1870,2016
+LS,1890,1,Tennis,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jose mezapaniagua,,LS-1890,2016
+LS,1940,1,Racquetball,0.79,0.07,0.0,0.07,0.0,0.0,0.0,0.07,raymond petersen,,LS-1940,2016
+LS,1940,3,Racquetball,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,charlie white,,LS-1940,2016
+LS,1980,1,Golf,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jason jordan,,LS-1980,2016
+LS,1980,3,Golf,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jason jordan,,LS-1980,2016
+LS,1980,6,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jason jordan,,LS-1980,2016
+LS,2100,1,Learn to Dance,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,matthew lee krabbe,,LS-2100,2016
+LS,2110,2,Introduction to Belly Dance,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,stephanie pack,,LS-2110,2016
+LS,2110,3,Introduction to Belly Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,stephanie pack,,LS-2110,2016
+LS,2180,1,Ballroom Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,,LS-2180,2016
+LS,2200,1,Shag,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,matthew lee krabbe,,LS-2200,2016
+LS,2200,6,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,matthew lee krabbe,,LS-2200,2016
+LS,2200,7,Shag,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,matthew lee krabbe,,LS-2200,2016
+LS,2270,1,Intro to Swing Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,paul hoke,,LS-2270,2016
+LS,2270,2,Intro to Swing Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,paul hoke,,LS-2270,2016
+LS,2270,4,Intro to Swing Dance,0.93,0.0,0.0,0.04,0.0,0.0,0.0,0.04,paul hoke,,LS-2270,2016
+LS,2320,1,Core Training,0.86,0.05,0.05,0.05,0.0,0.0,0.0,0.0,diane moreno,,LS-2320,2016
+LS,2320,2,Core Training,0.79,0.0,0.04,0.04,0.04,0.0,0.0,0.08,diane moreno,,LS-2320,2016
+LS,2320,3,Core Training,0.7,0.1,0.0,0.0,0.0,0.0,0.0,0.2,diane moreno,,LS-2320,2016
+LS,2350,1,Basic Yoga,0.67,0.14,0.05,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,,LS-2350,2016
+LS,2350,2,Basic Yoga,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,,LS-2350,2016
+LS,2350,3,Basic Yoga,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2350,2016
+LS,2350,4,Basic Yoga,0.75,0.1,0.0,0.1,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2350,2016
+LS,2350,5,Basic Yoga,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,renee warren gahan,,LS-2350,2016
+LS,2350,6,Basic Yoga,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jenefer nadenicek,,LS-2350,2016
+LS,2350,7,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,,LS-2350,2016
+LS,2350,8,Basic Yoga,0.87,0.04,0.0,0.0,0.04,0.0,0.0,0.04,jenefer nadenicek,,LS-2350,2016
+LS,2360,2,Power/Ashtanga Yoga,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,silica eliza larkin,,LS-2360,2016
+LS,2380,1,Vinyasa Flow Yoga,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,,LS-2380,2016
+LS,2380,2,Vinyasa Flow Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,,LS-2380,2016
+LS,2420,1,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2420,2016
+LS,2420,2,Meditation and Relax,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,renee warren gahan,,LS-2420,2016
+LS,2420,3,Meditation and Relax,0.75,0.08,0.08,0.04,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2016
+LS,2420,4,Meditation and Relax,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2016
+LS,2420,5,Meditation and Relax,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-2420,2016
+LS,2420,6,Meditation and Relax,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-2420,2016
+LS,2420,8,Meditation and Relax,0.86,0.0,0.09,0.0,0.05,0.0,0.0,0.0,ani reina-nunnelley,,LS-2420,2016
+LS,2420,9,Meditation and Relax,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,,LS-2420,2016
+LS,2450,1,Pilates,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,melanie ivey job,,LS-2450,2016
+LS,2450,2,Pilates,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,melanie ivey job,,LS-2450,2016
+LS,2460,2,Intermediate Pilates,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,melanie ivey job,,LS-2460,2016
+LS,2510,1,Running & Jogging,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,corey dou brookover,,LS-2510,2016
+LS,2700,1,Sports Officiating,0.71,0.0,0.0,0.0,0.06,0.0,0.0,0.24,christopher war cox,,LS-2700,2016
+LS,3580,1,Advanced Shotgun Skeet,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,charles flint,,LS-3580,2016
+MATH,1010,1,Essen Math for Informed Soc,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,marilyn reba,,MATH-1010,2016
+MATH,1010,3,Essen Math for Informed Soc,0.26,0.34,0.11,0.17,0.11,0.0,0.0,0.0,judith cottingham,,MATH-1010,2016
+MATH,1010,4,Essen Math for Informed Soc,0.5,0.35,0.12,0.0,0.03,0.0,0.0,0.0,judith cottingham,,MATH-1010,2016
+MATH,1010,5,Essen Math for Informed Soc,0.29,0.29,0.24,0.18,0.0,0.0,0.0,0.0,xiyan tan,,MATH-1010,2016
+MATH,1010,6,Essen Math for Informed Soc,0.23,0.32,0.32,0.1,0.0,0.0,0.0,0.03,judith cottingham,,MATH-1010,2016
+MATH,1020,1,Intro to Mathematical Analysis,0.07,0.31,0.24,0.14,0.24,0.0,0.0,0.0,haodong li,,MATH-1020,2016
+MATH,1020,2,Intro to Mathematical Analysis,0.18,0.21,0.26,0.16,0.11,0.0,0.0,0.08,stefani ca mokalled,,MATH-1020,2016
+MATH,1020,4,Intro to Mathematical Analysis,0.31,0.19,0.25,0.11,0.11,0.0,0.0,0.03,xiaoyuan liu,,MATH-1020,2016
+MATH,1020,6,Intro to Mathematical Analysis,0.18,0.31,0.21,0.1,0.13,0.0,0.0,0.08,tony thanh nguyen,,MATH-1020,2016
+MATH,1020,7,Intro to Mathematical Analysis,0.16,0.35,0.11,0.14,0.11,0.0,0.0,0.14,jerry lero phillips,,MATH-1020,2016
+MATH,1020,8,Intro to Mathematical Analysis,0.21,0.28,0.23,0.13,0.1,0.0,0.0,0.05,tony thanh nguyen,,MATH-1020,2016
+MATH,1020,9,Intro to Mathematical Analysis,0.11,0.34,0.24,0.08,0.24,0.0,0.0,0.0,randy davidson,,MATH-1020,2016
+MATH,1020,10,Intro to Mathematical Analysis,0.11,0.16,0.24,0.11,0.35,0.0,0.0,0.03,prab withana gamage,,MATH-1020,2016
+MATH,1020,11,Intro to Mathematical Analysis,0.2,0.31,0.11,0.17,0.2,0.0,0.0,0.0,kara ail stasikelis,,MATH-1020,2016
+MATH,1020,14,Intro to Mathematical Analysis,0.11,0.4,0.34,0.06,0.09,0.0,0.0,0.0,tony thanh nguyen,,MATH-1020,2016
+MATH,1020,15,Intro to Mathematical Analysis,0.21,0.26,0.18,0.13,0.11,0.0,0.0,0.11,randy davidson,,MATH-1020,2016
+MATH,1020,16,Intro to Mathematical Analysis,0.21,0.26,0.31,0.13,0.05,0.0,0.0,0.05,abigail bowers,,MATH-1020,2016
+MATH,1020,18,Intro to Mathematical Analysis,0.32,0.34,0.22,0.0,0.1,0.0,0.0,0.02,randy davidson,,MATH-1020,2016
+MATH,1020,19,Intro to Mathematical Analysis,0.05,0.18,0.32,0.08,0.29,0.0,0.0,0.08,aaro ramirez flores,,MATH-1020,2016
+MATH,1020,20,Intro to Mathematical Analysis,0.05,0.24,0.41,0.05,0.17,0.0,0.0,0.07,abigail bowers,,MATH-1020,2016
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.61,0.03,jason to hedetniemi,,MATH-1040,2016
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.41,0.51,0.08,rebecca lynn knoll,,MATH-1040,2016
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.49,0.05,patrick buckingham,,MATH-1040,2016
+MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.47,0.41,0.12,charity watson,,MATH-1050,2016
+MATH,1060,1,Calculus of One Variable I,0.07,0.07,0.37,0.13,0.27,0.0,0.0,0.1,allen anderso guest,,MATH-1060,2016
+MATH,1060,2,Calculus of One Variable I,0.06,0.19,0.38,0.09,0.06,0.0,0.0,0.22,allen anderso guest,,MATH-1060,2016
+MATH,1060,3,Calculus of One Variable I,0.17,0.24,0.27,0.05,0.2,0.0,0.0,0.07,marion hanna,,MATH-1060,2016
+MATH,1060,4,Calculus of One Variable I,0.05,0.14,0.36,0.12,0.19,0.0,0.0,0.14,beth novick,,MATH-1060,2016
+MATH,1060,5,Calculus of One Variable I,0.0,0.15,0.28,0.13,0.28,0.0,0.0,0.15,sanwar ahmad,,MATH-1060,2016
+MATH,1060,6,Calculus of One Variable I,0.05,0.2,0.34,0.02,0.27,0.0,0.0,0.12,"koshy chenthittayil,",,MATH-1060,2016
+MATH,1060,7,Calculus of One Variable I,0.05,0.18,0.37,0.16,0.18,0.0,0.0,0.05,stefan adam bock,,MATH-1060,2016
+MATH,1060,8,Calculus of One Variable I,0.05,0.18,0.13,0.1,0.23,0.0,0.0,0.33,michael gl eldredge,,MATH-1060,2016
+MATH,1060,9,Calculus of One Variable I,0.65,0.2,0.15,0.0,0.0,0.0,0.0,0.0,edward collins,,MATH-1060,2016
+MATH,1070,1,Differen and Integral Calculus,0.18,0.5,0.21,0.05,0.03,0.0,0.0,0.03,donna simms,,MATH-1070,2016
+MATH,1070,2,Differen and Integral Calculus,0.12,0.37,0.39,0.05,0.02,0.0,0.0,0.05,donna simms,,MATH-1070,2016
+MATH,1070,3,Differen and Integral Calculus,0.0,0.39,0.55,0.0,0.05,0.0,0.0,0.02,patrick buckingham,,MATH-1070,2016
+MATH,1070,5,Differen and Integral Calculus,0.07,0.36,0.29,0.07,0.14,0.0,0.0,0.07,tony thanh nguyen,,MATH-1070,2016
+MATH,1080,1,Calculus of One Variable II,0.27,0.23,0.23,0.03,0.1,0.0,0.0,0.13,muhamm mohebujjaman,,MATH-1080,2016
+MATH,1080,2,Calculus of One Variable II,0.19,0.21,0.24,0.05,0.21,0.0,0.0,0.1,lee andrew jenkins,,MATH-1080,2016
+MATH,1080,3,Calculus of One Variable II,0.13,0.22,0.16,0.07,0.18,0.0,0.0,0.24,sea sather-wagstaff,,MATH-1080,2016
+MATH,1080,4,Calculus of One Variable II,0.25,0.41,0.14,0.07,0.07,0.0,0.0,0.07,meredith nicol burr,,MATH-1080,2016
+MATH,1080,5,Calculus of One Variable II,0.09,0.36,0.36,0.07,0.07,0.0,0.0,0.05,jonathon leverenz,,MATH-1080,2016
+MATH,1080,6,Calculus of One Variable II,0.16,0.36,0.2,0.07,0.05,0.0,0.0,0.16,meredith nicol burr,,MATH-1080,2016
+MATH,1080,7,Calculus of One Variable II,0.27,0.33,0.18,0.02,0.04,0.0,0.0,0.16,abdullah al mamun,,MATH-1080,2016
+MATH,1080,8,Calculus of One Variable II,0.19,0.25,0.25,0.06,0.08,0.0,0.0,0.17,marilyn reba,,MATH-1080,2016
+MATH,1080,9,Calculus of One Variable II,0.36,0.4,0.06,0.02,0.13,0.0,0.0,0.02,ryan grove,,MATH-1080,2016
+MATH,1080,10,Calculus of One Variable II,0.16,0.29,0.24,0.02,0.04,0.0,0.0,0.24,jonathon leverenz,,MATH-1080,2016
+MATH,1080,11,Calculus of One Variable II,0.09,0.37,0.19,0.12,0.14,0.0,0.0,0.09,fiona may knoll,,MATH-1080,2016
+MATH,1080,12,Calculus of One Variable II,0.06,0.25,0.41,0.03,0.22,0.0,0.0,0.03,rui gong,,MATH-1080,2016
+MATH,1080,13,Calculus of One Variable II,0.02,0.27,0.24,0.0,0.16,0.0,0.0,0.31,rebecca ramos,,MATH-1080,2016
+MATH,1080,14,Calculus of One Variable II,0.22,0.28,0.25,0.08,0.03,0.0,0.0,0.14,honghai xu,,MATH-1080,2016
+MATH,1080,15,Calculus of One Variable II,0.1,0.33,0.18,0.05,0.15,0.0,0.0,0.18,shuhan xu,,MATH-1080,2016
+MATH,1080,16,Calculus of One Variable II,0.15,0.18,0.24,0.03,0.09,0.0,0.0,0.3,marilyn reba,,MATH-1080,2016
+MATH,1150,1,Contemp Math for Elem Teach I,0.53,0.29,0.12,0.06,0.0,0.0,0.0,0.0,charity watson,,MATH-1150,2016
+MATH,1160,1,Contemp Math for Elem Teach II,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1160,2016
+MATH,1160,2,Contemp Math for Elem Teach II,0.56,0.33,0.07,0.0,0.0,0.0,0.0,0.04,allison stoddard,,MATH-1160,2016
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,marion hanna,,MATH-1990,2016
+MATH,2060,1,Calculus of Several Variables,0.16,0.42,0.1,0.06,0.1,0.0,0.0,0.16,akshay sunil gupte,,MATH-2060,2016
+MATH,2060,2,Calculus of Several Variables,0.16,0.4,0.2,0.04,0.12,0.0,0.0,0.08,timothy fra parrott,,MATH-2060,2016
+MATH,2060,3,Calculus of Several Variables,0.39,0.22,0.08,0.03,0.17,0.0,0.0,0.11,qijun he,,MATH-2060,2016
+MATH,2060,4,Calculus of Several Variables,0.57,0.32,0.08,0.0,0.03,0.0,0.0,0.0,sofya alekseeva,,MATH-2060,2016
+MATH,2060,5,Calculus of Several Variables,0.17,0.23,0.34,0.14,0.06,0.0,0.0,0.06,jonathon leverenz,,MATH-2060,2016
+MATH,2060,6,Calculus of Several Variables,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,sofya alekseeva,,MATH-2060,2016
+MATH,2060,7,Calculus of Several Variables,0.0,0.09,0.06,0.12,0.21,0.0,0.0,0.52,javier ruiz ramirez,,MATH-2060,2016
+MATH,2060,8,Calculus of Several Variables,0.46,0.43,0.08,0.0,0.03,0.0,0.0,0.0,sofya alekseeva,,MATH-2060,2016
+MATH,2060,9,Calculus of Several Variables,0.42,0.26,0.24,0.0,0.05,0.0,0.0,0.03,mark cawood,,MATH-2060,2016
+MATH,2060,10,Calculus of Several Variables,0.11,0.19,0.11,0.07,0.19,0.0,0.0,0.33,dania moham zantout,,MATH-2060,2016
+MATH,2070,1,Multivariable Calculus,0.22,0.34,0.22,0.13,0.06,0.0,0.0,0.03,judith irene mcknew,,MATH-2070,2016
+MATH,2070,2,Multivariable Calculus,0.34,0.31,0.28,0.0,0.03,0.0,0.0,0.03,jennifer mari hanna,,MATH-2070,2016
+MATH,2070,4,Multivariable Calculus,0.39,0.26,0.17,0.09,0.09,0.0,0.0,0.0,thanh thien to,,MATH-2070,2016
+MATH,2070,5,Multivariable Calculus,0.44,0.31,0.16,0.03,0.03,0.0,0.0,0.03,jennifer mari hanna,,MATH-2070,2016
+MATH,2070,7,Multivariable Calculus,0.22,0.47,0.22,0.03,0.03,0.0,0.0,0.03,tao yang,,MATH-2070,2016
+MATH,2070,8,Multivariable Calculus,0.23,0.27,0.13,0.17,0.07,0.0,0.0,0.13,yinggu bao,,MATH-2070,2016
+MATH,2070,9,Multivariable Calculus,0.44,0.24,0.24,0.03,0.0,0.0,0.0,0.06,jennifer van dyken,,MATH-2070,2016
+MATH,2070,10,Multivariable Calculus,0.36,0.18,0.21,0.12,0.09,0.0,0.0,0.03,jennifer mari hanna,,MATH-2070,2016
+MATH,2070,11,Multivariable Calculus,0.07,0.37,0.23,0.1,0.07,0.0,0.0,0.17,tiantian yang,,MATH-2070,2016
+MATH,2070,14,Multivariable Calculus,0.16,0.34,0.22,0.06,0.06,0.0,0.0,0.16,allison stoddard,,MATH-2070,2016
+MATH,2070,15,Multivariable Calculus,0.16,0.38,0.25,0.13,0.09,0.0,0.0,0.0,trevor scot vilardi,,MATH-2070,2016
+MATH,2070,17,Multivariable Calculus,0.38,0.38,0.13,0.0,0.03,0.0,0.0,0.09,garrett dranichak,,MATH-2070,2016
+MATH,2070,19,Multivariable Calculus,0.12,0.36,0.12,0.15,0.09,0.0,0.0,0.15,yibo xu,,MATH-2070,2016
+MATH,2070,20,Multivariable Calculus,0.27,0.3,0.24,0.09,0.03,0.0,0.0,0.06,liu zhu,,MATH-2070,2016
+MATH,2070,22,Multivariable Calculus,0.38,0.32,0.24,0.06,0.0,0.0,0.0,0.0,luke marti giberson,,MATH-2070,2016
+MATH,2070,23,Multivariable Calculus,0.21,0.21,0.24,0.12,0.15,0.0,0.0,0.06,emily marie nystrom,,MATH-2070,2016
+MATH,2070,25,Multivariable Calculus,0.12,0.39,0.3,0.09,0.06,0.0,0.0,0.03,amy christine grady,,MATH-2070,2016
+MATH,2070,26,Multivariable Calculus,0.16,0.19,0.13,0.32,0.1,0.0,0.0,0.1,yijun chen,,MATH-2070,2016
+MATH,2080,1,Intro to Ordin Diff Equations,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.05,james brannan,,MATH-2080,2016
+MATH,2080,2,Intro to Ordin Diff Equations,0.09,0.28,0.31,0.06,0.03,0.0,0.0,0.22,terri johnson,,MATH-2080,2016
+MATH,2080,4,Intro to Ordin Diff Equations,0.18,0.18,0.3,0.09,0.18,0.0,0.0,0.06,jeong rock yoon,,MATH-2080,2016
+MATH,2080,5,Intro to Ordin Diff Equations,0.05,0.23,0.36,0.05,0.14,0.0,0.0,0.18,terri johnson,,MATH-2080,2016
+MATH,2080,6,Intro to Ordin Diff Equations,0.22,0.27,0.22,0.05,0.03,0.0,0.0,0.22,shari prevost,,MATH-2080,2016
+MATH,2080,7,Intro to Ordin Diff Equations,0.11,0.32,0.11,0.07,0.11,0.0,0.0,0.29,terri johnson,,MATH-2080,2016
+MATH,2080,8,Intro to Ordin Diff Equations,0.19,0.3,0.14,0.11,0.05,0.0,0.0,0.22,jeong rock yoon,,MATH-2080,2016
+MATH,2080,9,Intro to Ordin Diff Equations,0.32,0.24,0.16,0.0,0.11,0.0,0.0,0.16,shari prevost,,MATH-2080,2016
+MATH,2080,10,Intro to Ordin Diff Equations,0.45,0.13,0.24,0.11,0.05,0.0,0.0,0.03,timothy ch teitloff,,MATH-2080,2016
+MATH,2080,11,Intro to Ordin Diff Equations,0.32,0.39,0.13,0.05,0.05,0.0,0.0,0.05,nathan jos adelgren,,MATH-2080,2016
+MATH,2080,12,Intro to Ordin Diff Equations,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,irina viktorova,,MATH-2080,2016
+MATH,2080,13,Intro to Ordin Diff Equations,0.55,0.13,0.05,0.05,0.05,0.0,0.0,0.16,timothy fra parrott,,MATH-2080,2016
+MATH,2080,14,Intro to Ordin Diff Equations,0.18,0.45,0.23,0.0,0.08,0.0,0.0,0.08,timothy ch teitloff,,MATH-2080,2016
+MATH,2080,15,Intro to Ordin Diff Equations,0.61,0.26,0.11,0.03,0.0,0.0,0.0,0.0,irina viktorova,,MATH-2080,2016
+MATH,2080,16,Intro to Ordin Diff Equations,0.66,0.24,0.05,0.0,0.03,0.0,0.0,0.03,irina viktorova,,MATH-2080,2016
+MATH,2080,17,Intro to Ordin Diff Equations,0.35,0.35,0.11,0.08,0.0,0.0,0.0,0.11,timothy fra parrott,,MATH-2080,2016
+MATH,2080,18,Intro to Ordin Diff Equations,0.31,0.31,0.25,0.06,0.08,0.0,0.0,0.0,timothy ch teitloff,,MATH-2080,2016
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.88,0.08,0.0,0.03,0.0,0.0,0.0,0.03,james brannan,True,MATH-2080,2016
+MATH,2160,1,Geometry for Elem Sch Teachers,0.44,0.39,0.14,0.0,0.0,0.0,0.0,0.03,allison stoddard,,MATH-2160,2016
+MATH,3020,1,Stat for Science & Engineering,0.24,0.36,0.14,0.07,0.12,0.0,0.0,0.07,ellen hepfe breazel,,MATH-3020,2016
+MATH,3020,2,Stat for Science & Engineering,0.33,0.5,0.05,0.05,0.02,0.0,0.0,0.05,ellen hepfe breazel,,MATH-3020,2016
+MATH,3020,3,Stat for Science & Engineering,0.26,0.36,0.19,0.07,0.05,0.0,0.0,0.07,ellen hepfe breazel,,MATH-3020,2016
+MATH,3020,4,Stat for Science & Engineering,0.44,0.33,0.15,0.0,0.05,0.0,0.0,0.03,yisu jia,,MATH-3020,2016
+MATH,3020,5,Stat for Science & Engineering,0.28,0.31,0.18,0.05,0.05,0.0,0.0,0.13,calvin williams,,MATH-3020,2016
+MATH,3020,6,Stat for Science & Engineering,0.53,0.16,0.23,0.0,0.05,0.0,0.0,0.02,yanbo xia,,MATH-3020,2016
+MATH,3020,7,Stat for Science & Engineering,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.05,brandon gra goodell,,MATH-3020,2016
+MATH,3110,1,Linear Algebra,0.48,0.32,0.16,0.0,0.04,0.0,0.0,0.0,james peterson,,MATH-3110,2016
+MATH,3110,2,Linear Algebra,0.19,0.28,0.25,0.11,0.08,0.0,0.0,0.08,xuhong gao,,MATH-3110,2016
+MATH,3110,3,Linear Algebra,0.32,0.26,0.09,0.06,0.15,0.0,0.0,0.12,xuhong gao,,MATH-3110,2016
+MATH,3110,4,Linear Algebra,0.23,0.26,0.17,0.2,0.09,0.0,0.0,0.06,warren adams,,MATH-3110,2016
+MATH,3110,5,Linear Algebra,0.36,0.25,0.14,0.08,0.17,0.0,0.0,0.0,brian fralix,,MATH-3110,2016
+MATH,3190,1,Introduction to Proof,0.35,0.31,0.08,0.12,0.12,0.0,0.0,0.04,elena sta dimitrova,,MATH-3190,2016
+MATH,3190,2,Introduction to Proof,0.38,0.23,0.19,0.0,0.12,0.0,0.0,0.08,elena sta dimitrova,,MATH-3190,2016
+MATH,3600,1,Intermediate Math Computing,0.67,0.13,0.0,0.08,0.08,0.0,0.0,0.04,mark cawood,,MATH-3600,2016
+MATH,3600,2,Intermediate Math Computing,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,neil calkin,,MATH-3600,2016
+MATH,3650,1,Numerical Mthds for Engineers,0.28,0.41,0.22,0.06,0.0,0.0,0.0,0.03,eleanor jenkins,,MATH-3650,2016
+MATH,3650,2,Numerical Mthds for Engineers,0.13,0.31,0.31,0.03,0.03,0.0,0.0,0.19,christopher cox,,MATH-3650,2016
+MATH,3650,3,Numerical Mthds for Engineers,0.67,0.31,0.03,0.0,0.0,0.0,0.0,0.0,abigail bowers,,MATH-3650,2016
+MATH,3650,4,Numerical Mthds for Engineers,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,abigail bowers,,MATH-3650,2016
+MATH,4000,1,Theory of Probability,0.15,0.23,0.38,0.04,0.0,0.0,0.0,0.19,julie lassiter,,MATH-4000,2016
+MATH,4000,2,Theory of Probability,0.0,0.26,0.21,0.05,0.26,0.0,0.0,0.21,julie lassiter,,MATH-4000,2016
+MATH,4030,1,Intro to Statistical Theory,0.41,0.23,0.32,0.0,0.0,0.0,0.0,0.05,xiaoqian sun,,MATH-4030,2016
+MATH,4070,1,Regress & Time-Series Analysis,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-4070,2016
+MATH,4120,1,Algebra I,0.3,0.33,0.1,0.13,0.05,0.0,0.0,0.1,kevin james,,MATH-4120,2016
+MATH,4190,1,Discrete Math Structures I,0.4,0.47,0.07,0.03,0.03,0.0,0.0,0.0,beth novick,,MATH-4190,2016
+MATH,4310,1,Theory of Interest,0.33,0.08,0.33,0.25,0.0,0.0,0.0,0.0, erwin walker,,MATH-4310,2016
+MATH,4340,1,Adv Engineering Mathematics,0.09,0.32,0.18,0.24,0.12,0.0,0.0,0.06,eleanor jenkins,,MATH-4340,2016
+MATH,4340,2,Adv Engineering Mathematics,0.19,0.42,0.04,0.15,0.08,0.0,0.0,0.12,hyesuk lee,,MATH-4340,2016
+MATH,4400,1,Linear Programming,0.41,0.36,0.09,0.0,0.09,0.0,0.0,0.05,yuyuan ouyang,,MATH-4400,2016
+MATH,4410,1,Intro to Stochastic Models,0.33,0.28,0.22,0.0,0.06,0.0,0.0,0.11,brian fralix,,MATH-4410,2016
+MATH,4530,1,Advanced Calculus I,0.29,0.29,0.29,0.05,0.05,0.0,0.0,0.05,peter kiessler,,MATH-4530,2016
+MATH,4540,1,Advanced Calculus II,0.36,0.32,0.12,0.08,0.04,0.0,0.0,0.08,james peterson,,MATH-4540,2016
+MATH,6340,1,Adv Engineering Mathematics,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,vincent ervin,,MATH-6340,2016
+MATH,8030,1,Stochastic Processes,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,robert lund,,MATH-8030,2016
+MATH,8040,1,Statistical Inference,0.76,0.0,0.12,0.0,0.0,0.0,0.0,0.12,christopher mcmahan,,MATH-8040,2016
+MATH,8050,1,Data Analysis,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,yingbo li,,MATH-8050,2016
+MATH,8090,1,Time Series Analysis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,,MATH-8090,2016
+MATH,8100,1,Mathematical Programming,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,margaret mar wiecek,,MATH-8100,2016
+MATH,8130,1,Advanced Linear Programming,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,matthew saltzman,,MATH-8130,2016
+MATH,8210,1,Linear Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,,MATH-8210,2016
+MATH,8220,1,Measure and Integration,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,,MATH-8220,2016
+MATH,8530,1,Matrix Analysis,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,matthew macauley,,MATH-8530,2016
+MATH,8540,1,Theory of Graphs,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,wayne goddard,,MATH-8540,2016
+MATH,8600,1,Intro to Scientific Computing,0.36,0.57,0.0,0.0,0.0,0.0,0.0,0.07,hyesuk lee,,MATH-8600,2016
+MATH,8660,1,Finite Element Method,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,vincent ervin,,MATH-8660,2016
+MATH,9860,1,Selected Topics in Geometry,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,,MATH-9860,2016
+MBA,8030,1,Stat Analy of Bus Op,0.14,0.54,0.17,0.0,0.03,0.0,0.0,0.11,zachary mo leffakis,,MBA-8030,2016
+MBA,8060,1,Operations Mgt,0.09,0.79,0.09,0.0,0.03,0.0,0.0,0.0, sridharan,,MBA-8060,2016
+MBA,8070,1,Financial Management,0.66,0.27,0.07,0.0,0.0,0.0,0.0,0.0,melvin stith,,MBA-8070,2016
+MBA,8070,2,Financial Management,0.63,0.18,0.13,0.0,0.0,0.0,0.0,0.08,melvin stith,,MBA-8070,2016
+MBA,8090,1,Org Beh & Hum Res Mg,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2016
+MBA,8090,2,Org Beh & Hum Res Mg,0.56,0.42,0.03,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2016
+MBA,8190,1,Intro to Acc and Fin,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,annieka philo,,MBA-8190,2016
+MBA,8190,2,Intro to Acc and Fin,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,,MBA-8190,2016
+MBA,8290,1,Marketing Foundation,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MBA-8290,2016
+MBA,8370,1,Legal Environ of Bus,0.28,0.7,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2016
+MBA,8430,10,Entrepreneurial Accounting,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,,MBA-8430,2016
+MBA,8510,10,Bus Operations & Logistics,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,,MBA-8510,2016
+MBA,8540,1,Mgrl Accounting,0.63,0.3,0.0,0.0,0.0,0.0,0.0,0.07,james mil kohlmeyer,,MBA-8540,2016
+MBA,8540,2,Mgrl Accounting,0.52,0.39,0.07,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,,MBA-8540,2016
+MBA,8590,1,Mgr Decision Model,0.48,0.31,0.1,0.0,0.02,0.0,0.0,0.1,mark mcknew,,MBA-8590,2016
+MBA,8590,2,Mgr Decision Model,0.57,0.35,0.0,0.0,0.09,0.0,0.0,0.0,sara elizabet yoder,,MBA-8590,2016
+MBA,8600,1,Advanced Marketing Strategy,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2016
+MBA,8610,1,Information Systems,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,varun grover,,MBA-8610,2016
+MBA,8610,2,Information Systems,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,kevin mckenzie,,MBA-8610,2016
+MBA,8620,1,Managerial Economics,0.43,0.49,0.03,0.0,0.0,0.0,0.0,0.06,ronald earl gregory,,MBA-8620,2016
+MBA,8700,1,Strategic Management,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8700,2016
+MBA,8720,1,Entrepr Finance,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8720,2016
+MBA,8750,1,Enterprise Develpmnt,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,michael george mino,,MBA-8750,2016
+MBA,8990,1,Advanced Leadership,0.87,0.11,0.0,0.0,0.0,0.0,0.0,0.02,gail depriest,,MBA-8990,2016
+MBA,8990,3,Service Innovation,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,aleda marie roth,,MBA-8990,2016
+MBA,8990,4,Bus. Sport. Enter.,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.04,john michael hannon,,MBA-8990,2016
+ME,2000,1,Sophomore Seminar,0.95,0.02,0.01,0.0,0.01,0.0,0.0,0.02,donald beasley,,ME-2000,2016
+ME,2010,1,Statics & Dynamics,0.06,0.16,0.24,0.22,0.24,0.0,0.0,0.07,paul joseph,,ME-2010,2016
+ME,2010,2,Statics & Dynamics,0.13,0.2,0.18,0.13,0.24,0.0,0.0,0.13,lonny thompson,,ME-2010,2016
+ME,2030,1,Founda Th/Fl Syst,0.09,0.28,0.35,0.11,0.05,0.0,0.0,0.11,jay ochterbeck,,ME-2030,2016
+ME,2030,2,Founda Th/Fl Syst,0.16,0.2,0.28,0.11,0.16,0.0,0.0,0.08,john saylor,,ME-2030,2016
+ME,2030,3,Founda Th/Fl Syst,0.38,0.38,0.11,0.02,0.0,0.0,0.0,0.11,donald beasley,,ME-2030,2016
+ME,2040,1,Mechanics of Materials,0.18,0.43,0.26,0.05,0.05,0.0,0.0,0.03,michael porter,,ME-2040,2016
+ME,2040,2,Mechanics of Materials,0.23,0.4,0.26,0.09,0.03,0.0,0.0,0.0,gang li,,ME-2040,2016
+ME,2040,3,Mechanics of Materials,0.17,0.54,0.22,0.02,0.02,0.0,0.0,0.02,garrett pataky,,ME-2040,2016
+ME,2040,302,Mechanics of Materials (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gang li,True,ME-2040,2016
+ME,2220,1,Mechanical Engineering Lab I,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,2,Mechanical Engineering Lab I,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,todd schweisinger,,ME-2220,2016
+ME,2220,3,Mechanical Engineering Lab I,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,todd schweisinger,,ME-2220,2016
+ME,2220,4,Mechanical Engineering Lab I,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,5,Mechanical Engineering Lab I,0.3,0.65,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,6,Mechanical Engineering Lab I,0.37,0.32,0.21,0.05,0.0,0.0,0.0,0.05,todd schweisinger,,ME-2220,2016
+ME,2220,7,Mechanical Engineering Lab I,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,todd schweisinger,,ME-2220,2016
+ME,2220,8,Mechanical Engineering Lab I,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2016
+ME,2220,9,Mechanical Engineering Lab I,0.25,0.5,0.08,0.0,0.0,0.0,0.0,0.17,todd schweisinger,,ME-2220,2016
+ME,3030,1,Thermodynamics,0.27,0.44,0.22,0.02,0.0,0.0,0.0,0.05,daniel fant,,ME-3030,2016
+ME,3030,2,Thermodynamics,0.13,0.13,0.31,0.15,0.18,0.0,0.0,0.1,richard miller,,ME-3030,2016
+ME,3040,1,Heat Transfer,0.03,0.21,0.49,0.15,0.13,0.0,0.0,0.0,jean-marc delhaye,,ME-3040,2016
+ME,3040,2,Heat Transfer,0.2,0.39,0.32,0.03,0.06,0.0,0.0,0.0,xin zhao,,ME-3040,2016
+ME,3050,1,Model/an Dy Syst,0.18,0.42,0.2,0.05,0.08,0.0,0.0,0.07,phanin tallapragada,,ME-3050,2016
+ME,3050,2,Model/an Dy Syst,0.3,0.26,0.3,0.05,0.06,0.0,0.0,0.03,joshua bostwick,,ME-3050,2016
+ME,3060,1,Fund Machine Design,0.28,0.46,0.19,0.0,0.04,0.0,0.0,0.04,oliver myers,,ME-3060,2016
+ME,3060,2,Fund Machine Design,0.44,0.31,0.21,0.0,0.03,0.0,0.0,0.0,paul jeffrey meyer,,ME-3060,2016
+ME,3070,1,Found of Mechanical Systems,0.27,0.5,0.14,0.02,0.0,0.0,0.0,0.07,lonny thompson,,ME-3070,2016
+ME,3070,2,Found of Mechanical Systems,0.19,0.63,0.14,0.02,0.0,0.0,0.0,0.02,gregory mocko,,ME-3070,2016
+ME,3080,1,Fluid Mechanics,0.05,0.18,0.33,0.2,0.15,0.0,0.0,0.1,jean-marc delhaye,,ME-3080,2016
+ME,3080,2,Fluid Mechanics,0.14,0.3,0.47,0.04,0.04,0.0,0.0,0.02,ethan kung,,ME-3080,2016
+ME,3100,1,Thermo/Heat Transfer,0.28,0.24,0.34,0.03,0.07,0.0,0.0,0.03,xiangchun xuan,,ME-3100,2016
+ME,3120,1,Manuf Processes,0.36,0.45,0.16,0.02,0.0,0.0,0.0,0.01,hong seok choi,,ME-3120,2016
+ME,3330,1,Mechanical Engineering Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,2,Mechanical Engineering Lab II,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,3,Mechanical Engineering Lab II,0.18,0.76,0.0,0.0,0.06,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,4,Mechanical Engineering Lab II,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,5,Mechanical Engineering Lab II,0.21,0.57,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2016
+ME,3330,6,Mechanical Engineering Lab II,0.25,0.42,0.17,0.0,0.08,0.0,0.0,0.08,todd schweisinger,,ME-3330,2016
+ME,3330,7,Mechanical Engineering Lab II,0.25,0.56,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-3330,2016
+ME,3330,8,Mechanical Engineering Lab II,0.2,0.5,0.2,0.0,0.0,0.0,0.0,0.1,todd schweisinger,,ME-3330,2016
+ME,4010,1,Mech Engr Design,0.49,0.39,0.08,0.03,0.0,0.0,0.0,0.01,cameron turner,,ME-4010,2016
+ME,4020,1,Intern in Engr Des,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,donald beasley,,ME-4020,2016
+ME,4020,3,Intern in Engr Des,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2016
+ME,4020,4,Intern in Engr Des,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,,ME-4020,2016
+ME,4020,5,Intern in Engr Des,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4020,2016
+ME,4020,7,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,,ME-4020,2016
+ME,4020,8,Intern in Engr Des,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-4020,2016
+ME,4020,9,Intern in Engr Des,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,donald beasley,,ME-4020,2016
+ME,4030,1,Control Dynamic Systems,0.18,0.5,0.25,0.03,0.03,0.0,0.0,0.03,suyi li,,ME-4030,2016
+ME,4030,2,Control Dynamic Systems,0.24,0.45,0.31,0.0,0.0,0.0,0.0,0.0,yue wang,,ME-4030,2016
+ME,4170,1,Mechatronic Sys,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4170,2016
+ME,4180,1,F E A in M E Design,0.48,0.39,0.09,0.0,0.0,0.0,0.0,0.04,istemi baris ozsoy,,ME-4180,2016
+ME,4220,1,Design Gas Turbines,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,,ME-4220,2016
+ME,4230,1,Intro Aerodynamics,0.34,0.46,0.17,0.0,0.03,0.0,0.0,0.0,richard figliola,,ME-4230,2016
+ME,4260,1,Nuclear Energy,0.44,0.44,0.04,0.04,0.0,0.0,0.0,0.04,richard watkins,,ME-4260,2016
+ME,4300,1,Mech Comp Materials,0.14,0.43,0.38,0.05,0.0,0.0,0.0,0.0,huijuan zhao,,ME-4300,2016
+ME,4440,1,Mechanical Engineering Lab III,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,2,Mechanical Engineering Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,3,Mechanical Engineering Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,4,Mechanical Engineering Lab III,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,5,Mechanical Engineering Lab III,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4440,7,Mechanical Engineering Lab III,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2016
+ME,4930,5,SelectedTopics ME - RapidProto,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4930,2016
+ME,4930,11,Selected Topics ME: MicroFab,0.23,0.54,0.15,0.08,0.0,0.0,0.0,0.0,rod martinez-duarte,,ME-4930,2016
+ME,4930,28,Selected Topics ME: HVAC,0.28,0.48,0.12,0.0,0.0,0.0,0.0,0.12,donald willoughby,,ME-4930,2016
+ME,4930,29,Selected Topics ME: Solar E,0.62,0.28,0.07,0.0,0.03,0.0,0.0,0.0,daniel fant,,ME-4930,2016
+ME,6170,1,Mechatronic Sys,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-6170,2016
+ME,6300,1,Mech Comp Materials,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,huijuan zhao,,ME-6300,2016
+ME,6300,401,Mech Comp Materials,0.44,0.44,0.0,0.0,0.11,0.0,0.0,0.0,huijuan zhao,,ME-6300,2016
+ME,8120,1,Exp Meth Thermal Sci,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,,ME-8120,2016
+ME,8190,1,Cp Meth in Therm Sc,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,richard miller,,ME-8190,2016
+ME,8200,1,Mod Cont Engr,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,,ME-8200,2016
+ME,8310,1,Convective Ht Trans,0.31,0.19,0.25,0.0,0.25,0.0,0.0,0.0,john saylor,,ME-8310,2016
+ME,8520,1,Adv Finite Ele Ana,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gang li,,ME-8520,2016
+ME,8610,1,Matl Sel Engr Design,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,mica grujicic,,ME-8610,2016
+ME,8730,1,Res Mthds Coll Desgn,0.43,0.43,0.0,0.0,0.14,0.0,0.0,0.0,joshua summers,,ME-8730,2016
+ME,8930,27,Sel Topics in ME - Cont Mech,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,,ME-8930,2016
+MGT,2010,1,Principles of Management,0.29,0.38,0.27,0.04,0.01,0.0,0.0,0.01,katherine clark,,MGT-2010,2016
+MGT,2010,2,Principles of Management,0.47,0.34,0.14,0.02,0.0,0.0,0.0,0.03,katherine clark,,MGT-2010,2016
+MGT,2010,3,Principles of Management,0.4,0.41,0.15,0.01,0.02,0.0,0.0,0.01,katherine clark,,MGT-2010,2016
+MGT,2010,4,Principles of Management,0.34,0.39,0.24,0.02,0.0,0.0,0.0,0.01,katherine clark,,MGT-2010,2016
+MGT,2010,5,Principles of Management,0.45,0.42,0.12,0.01,0.0,0.0,0.0,0.0,tina robbins,,MGT-2010,2016
+MGT,2010,6,Principles of Management,0.46,0.43,0.08,0.01,0.0,0.0,0.0,0.01,tina robbins,,MGT-2010,2016
+MGT,2010,7,Principles of Management,0.38,0.39,0.15,0.04,0.01,0.0,0.0,0.02,tina robbins,,MGT-2010,2016
+MGT,2010,8,Principles of Management,0.33,0.45,0.16,0.01,0.02,0.0,0.0,0.02,tina robbins,,MGT-2010,2016
+MGT,2010,9,Principles of Management (HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True,MGT-2010,2016
+MGT,2180,1,Management PC Applications,0.45,0.35,0.13,0.01,0.02,0.0,0.0,0.04,ryan toole,,MGT-2180,2016
+MGT,2180,2,Management PC Applications,0.49,0.33,0.07,0.03,0.02,0.0,0.0,0.05,ryan toole,,MGT-2180,2016
+MGT,2180,3,Management PC Applications,0.56,0.27,0.09,0.02,0.02,0.0,0.0,0.04,ryan toole,,MGT-2180,2016
+MGT,2180,4,Management PC Applications,0.42,0.42,0.07,0.04,0.02,0.0,0.0,0.02,ryan toole,,MGT-2180,2016
+MGT,2970,1,How to Start a Startup,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,john michael hannon,,MGT-2970,2016
+MGT,2970,2,How to Start a Startup,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,john michael hannon,,MGT-2970,2016
+MGT,3070,1,Human Resource Management,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2016
+MGT,3070,2,Human Resource Management,0.55,0.43,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2016
+MGT,3070,3,Human Resource Management,0.53,0.35,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2016
+MGT,3070,4,Human Resource Management,0.42,0.33,0.09,0.06,0.06,0.0,0.0,0.03,priscilla harrison,,MGT-3070,2016
+MGT,3070,6,Human Resource Management,0.15,0.74,0.12,0.0,0.0,0.0,0.0,0.0,kristin dam scott,,MGT-3070,2016
+MGT,3100,1,Intermed Business Statistics,0.5,0.29,0.19,0.0,0.0,0.0,0.0,0.02,jerry kermi bilbrey,,MGT-3100,2016
+MGT,3100,2,Intermed Business Statistics,0.25,0.3,0.23,0.03,0.18,0.0,0.0,0.03,ezg akpinar ferrand,,MGT-3100,2016
+MGT,3100,3,Intermed Business Statistics,0.36,0.23,0.21,0.08,0.08,0.0,0.0,0.05,ezg akpinar ferrand,,MGT-3100,2016
+MGT,3100,4,Intermed Business Statistics,0.18,0.28,0.2,0.28,0.05,0.0,0.0,0.03,sara elizabet yoder,,MGT-3100,2016
+MGT,3100,5,Intermed Business Statistics,0.8,0.13,0.04,0.02,0.0,0.0,0.0,0.0,shih lun tseng,,MGT-3100,2016
+MGT,3100,6,Intermed Business Statistics,0.44,0.37,0.2,0.0,0.0,0.0,0.0,0.0,jerry kermi bilbrey,,MGT-3100,2016
+MGT,3100,7,Intermed Business Statistics,0.17,0.34,0.22,0.1,0.1,0.0,0.0,0.07,sara elizabet yoder,,MGT-3100,2016
+MGT,3100,8,Intermed Business Statistics,0.18,0.18,0.38,0.05,0.18,0.0,0.0,0.03,sara elizabet yoder,,MGT-3100,2016
+MGT,3100,10,Intermed Business Statistics,0.39,0.42,0.13,0.0,0.03,0.0,0.0,0.03,jerry kermi bilbrey,,MGT-3100,2016
+MGT,3100,11,Intermed Business Statistics,0.49,0.18,0.11,0.07,0.09,0.0,0.0,0.07,yunsik choi,,MGT-3100,2016
+MGT,3100,12,Intermed Business Statistics,0.21,0.28,0.23,0.05,0.08,0.0,0.0,0.15,dan jiang,,MGT-3100,2016
+MGT,3120,1,Decision Models for Management,0.29,0.31,0.29,0.07,0.02,0.0,0.0,0.02,mark mcknew,,MGT-3120,2016
+MGT,3120,2,Decision Models for Management,0.22,0.28,0.3,0.09,0.09,0.0,0.0,0.02,mark mcknew,,MGT-3120,2016
+MGT,3120,3,Decision Models for Management,0.2,0.32,0.3,0.07,0.07,0.0,0.0,0.05,mark mcknew,,MGT-3120,2016
+MGT,3150,1,New Venture Creation,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,,MGT-3150,2016
+MGT,3180,1,Mgt of Info Systems,0.65,0.25,0.05,0.05,0.0,0.0,0.0,0.0,jackie patri london,,MGT-3180,2016
+MGT,3180,2,Mgt of Info Systems,0.78,0.2,0.03,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,,MGT-3180,2016
+MGT,3180,3,Mgt of Info Systems,0.18,0.5,0.25,0.0,0.02,0.0,0.0,0.05,russell purvis,,MGT-3180,2016
+MGT,3180,4,Mgt of Info Systems,0.39,0.39,0.19,0.03,0.0,0.0,0.0,0.0,roopa raman,,MGT-3180,2016
+MGT,3900,2,Ops Mgt,0.23,0.23,0.15,0.15,0.18,0.0,0.0,0.08,niratc tungtisanont,,MGT-3900,2016
+MGT,3900,3,Ops Mgt,0.05,0.36,0.36,0.08,0.08,0.0,0.0,0.08,zachary mo leffakis,,MGT-3900,2016
+MGT,3900,4,Ops Mgt,0.58,0.23,0.18,0.03,0.0,0.0,0.0,0.0,berna quiroga gomez,,MGT-3900,2016
+MGT,3900,5,Ops Mgt,0.18,0.38,0.23,0.13,0.08,0.0,0.0,0.03,shouqiang wang,,MGT-3900,2016
+MGT,3900,6,Ops Mgt,0.64,0.26,0.1,0.0,0.0,0.0,0.0,0.0,berna quiroga gomez,,MGT-3900,2016
+MGT,4000,2,Mgt of Organizational Behavior,0.53,0.38,0.05,0.0,0.05,0.0,0.0,0.0,michael cole,,MGT-4000,2016
+MGT,4000,3,Mgt of Organizational Behavior,0.1,0.46,0.36,0.0,0.08,0.0,0.0,0.0,philip roth,,MGT-4000,2016
+MGT,4000,4,Mgt of Organizational Behavior,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2016
+MGT,4020,1,Ops Pln and Ctl,0.06,0.67,0.22,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,,MGT-4020,2016
+MGT,4080,1,Lean Operations,0.29,0.45,0.24,0.0,0.02,0.0,0.0,0.0,zachary mo leffakis,,MGT-4080,2016
+MGT,4110,1,Project Management,0.24,0.38,0.29,0.0,0.05,0.0,0.0,0.05,russell purvis,,MGT-4110,2016
+MGT,4120,1,Supplier Management,0.18,0.42,0.34,0.05,0.0,0.0,0.0,0.0,shouqiang wang,,MGT-4120,2016
+MGT,4150,1,Business Strategy,0.16,0.36,0.4,0.02,0.04,0.0,0.0,0.02,peter gianiodis,,MGT-4150,2016
+MGT,4150,2,Business Strategy,0.2,0.56,0.24,0.0,0.0,0.0,0.0,0.0,peter gianiodis,,MGT-4150,2016
+MGT,4150,3,Business Strategy,0.36,0.62,0.0,0.0,0.0,0.0,0.0,0.02,john edward hopkins,,MGT-4150,2016
+MGT,4150,4,Business Strategy,0.32,0.55,0.13,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2016
+MGT,4150,5,Business Strategy,0.48,0.35,0.13,0.02,0.02,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2016
+MGT,4150,6,Business Strategy,0.44,0.51,0.04,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2016
+MGT,4150,7,Business Strategy,0.45,0.52,0.02,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2016
+MGT,4150,10,Business Strategy,0.24,0.73,0.02,0.0,0.0,0.0,0.0,0.0,john edward hopkins,,MGT-4150,2016
+MGT,4160,1,Special Topics Hr,0.34,0.4,0.26,0.0,0.0,0.0,0.0,0.0,kristin dam scott,,MGT-4160,2016
+MGT,4230,1,Intern Bus Mgt,0.08,0.18,0.54,0.05,0.1,0.0,0.0,0.05,wayne stewart,,MGT-4230,2016
+MGT,4230,2,Intern Bus Mgt,0.13,0.55,0.3,0.03,0.0,0.0,0.0,0.0,janis miller,,MGT-4230,2016
+MGT,4230,3,Intern Bus Mgt,0.14,0.19,0.6,0.05,0.02,0.0,0.0,0.0,wayne stewart,,MGT-4230,2016
+MGT,4240,1,Global Supply Chain,0.17,0.58,0.21,0.0,0.04,0.0,0.0,0.0,yann ferrand,,MGT-4240,2016
+MGT,4310,1,Emp Rights & Resp,0.31,0.49,0.16,0.02,0.0,0.0,0.0,0.02,leonard jos spooner,,MGT-4310,2016
+MGT,4350,1,Pers Interviewing,0.23,0.58,0.13,0.03,0.03,0.0,0.0,0.03,philip roth,,MGT-4350,2016
+MGT,4520,1,Business Analysis,0.19,0.43,0.38,0.0,0.0,0.0,0.0,0.0,roopa raman,,MGT-4520,2016
+MGT,4550,1,Emerging I T Trends,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MGT-4550,2016
+MGT,4560,1,Business Info Mgt,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,siyuan li,,MGT-4560,2016
+MGT,8120,1,Supply Chain Mgt,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,yann ferrand,,MGT-8120,2016
+MICR,3050,1,General Microbiology,0.51,0.34,0.13,0.0,0.0,0.0,0.0,0.01,kristi ja whitehead,,MICR-3050,2016
+MICR,3050,2,General Microbiology,0.44,0.37,0.15,0.03,0.01,0.0,0.0,0.01,krista barr rudolph,,MICR-3050,2016
+MICR,3050,3,General Microbiology,0.52,0.42,0.02,0.0,0.02,0.0,0.0,0.02,krista barr rudolph,,MICR-3050,2016
+MICR,4000,1,Public Health Micro,0.5,0.31,0.09,0.05,0.03,0.0,0.0,0.02,kristi ja whitehead,,MICR-4000,2016
+MICR,4020,1,Environmental Micro,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,john michael henson,,MICR-4020,2016
+MICR,4070,1,Food and Dairy Micro,0.26,0.46,0.24,0.0,0.0,0.0,0.0,0.04,xiuping jiang,,MICR-4070,2016
+MICR,4110,1,Pathogenic Bact,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4110,2016
+MICR,4120,1,Bacterial Physiology,0.24,0.31,0.22,0.08,0.1,0.0,0.0,0.06,thomas hughes,,MICR-4120,2016
+MICR,4130,1,Industrial Micro,0.39,0.37,0.16,0.04,0.01,0.0,0.0,0.03,tzuen-rong je tzeng,,MICR-4130,2016
+MICR,4140,1,Basic Immunology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,,MICR-4140,2016
+MICR,4170,1,Cancer and Aging,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,yuqing dong,,MICR-4170,2016
+MICR,4500,1,Advanced Microbiology I,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2016
+MICR,4500,2,Advanced Microbiology I,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2016
+MICR,4500,3,Advanced Microbiology I,0.54,0.15,0.08,0.0,0.08,0.0,0.0,0.15,harry kurtz,,MICR-4500,2016
+MICR,4520,1,Advanced Microbiology III,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4520,2016
+MICR,4930,2,Senior Seminar,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,barbara campbell,,MICR-4930,2016
+MKT,3010,1,Prin of Marketing,0.34,0.38,0.17,0.05,0.04,0.0,0.0,0.02,carter wil mcelveen,,MKT-3010,2016
+MKT,3010,2,Prin of Marketing,0.26,0.35,0.29,0.05,0.03,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2016
+MKT,3010,3,Prin of Marketing,0.21,0.5,0.19,0.03,0.02,0.01,0.0,0.04,james gaubert,,MKT-3010,2016
+MKT,3010,4,Prin of Marketing,0.28,0.5,0.19,0.01,0.01,0.0,0.0,0.02,james gaubert,,MKT-3010,2016
+MKT,3010,5,Prin of Marketing,0.45,0.38,0.11,0.02,0.04,0.0,0.0,0.0,patricia knowles,,MKT-3010,2016
+MKT,3020,1,Consumer Behavior,0.46,0.37,0.12,0.02,0.03,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2016
+MKT,3020,2,Consumer Behavior,0.6,0.28,0.09,0.02,0.02,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2016
+MKT,3020,3,Consumer Behavior,0.28,0.52,0.13,0.06,0.0,0.0,0.0,0.02, thyroff fitzwater,,MKT-3020,2016
+MKT,3020,4,Consumer Behavior,0.35,0.43,0.14,0.05,0.0,0.0,0.0,0.03, thyroff fitzwater,,MKT-3020,2016
+MKT,3020,5,Consumer Behavior,0.28,0.48,0.24,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-3020,2016
+MKT,3210,1,Sports Marketing,0.53,0.39,0.06,0.0,0.02,0.0,0.0,0.0,delancy bennett,,MKT-3210,2016
+MKT,3210,2,Sports Marketing,0.5,0.43,0.08,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,,MKT-3210,2016
+MKT,3310,1,Marketing Metrics & Analytics,0.26,0.52,0.17,0.04,0.0,0.0,0.0,0.0,peter weathers,,MKT-3310,2016
+MKT,3980,1,CI: Sales Experiential,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,,MKT-3980,2016
+MKT,4200,1,Professional Selling,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2016
+MKT,4200,2,Professional Selling,0.33,0.37,0.17,0.1,0.03,0.0,0.0,0.0,jesse moore,,MKT-4200,2016
+MKT,4200,3,Professional Selling,0.84,0.13,0.0,0.0,0.03,0.0,0.0,0.0,carter wil mcelveen,,MKT-4200,2016
+MKT,4200,4,Professional Selling,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2016
+MKT,4230,1,Promotional Strategy,0.44,0.38,0.11,0.02,0.04,0.0,0.0,0.0,patricia knowles,,MKT-4230,2016
+MKT,4240,2,Sales Management,0.3,0.66,0.05,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4240,2016
+MKT,4250,1,Retail Management,0.58,0.38,0.0,0.0,0.02,0.0,0.0,0.02,james gaubert,,MKT-4250,2016
+MKT,4270,1,International Mktg,0.2,0.65,0.08,0.03,0.0,0.0,0.0,0.05,thomas poehlman,,MKT-4270,2016
+MKT,4270,2,International Mktg,0.23,0.5,0.23,0.02,0.0,0.0,0.0,0.02,roger gomes,,MKT-4270,2016
+MKT,4270,3,International Mktg,0.26,0.38,0.33,0.0,0.0,0.0,0.0,0.03,roger gomes,,MKT-4270,2016
+MKT,4270,4,International Mktg,0.1,0.49,0.28,0.03,0.08,0.0,0.0,0.03,roger gomes,,MKT-4270,2016
+MKT,4270,600,International Mktg,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4270,2016
+MKT,4280,1,Services Marketing,0.49,0.18,0.23,0.08,0.0,0.0,0.0,0.03,stephen grove,,MKT-4280,2016
+MKT,4280,2,Services Marketing,0.28,0.47,0.17,0.08,0.0,0.0,0.0,0.0,stephen grove,,MKT-4280,2016
+MKT,4310,1,Marketing Research,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4310,2016
+MKT,4310,2,Marketing Research,0.25,0.42,0.29,0.0,0.04,0.0,0.0,0.0,william kilbourne,,MKT-4310,2016
+MKT,4310,3,Marketing Research,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2016
+MKT,4310,4,Marketing Research,0.4,0.48,0.12,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2016
+MKT,4330,1,Sport Mkt Strategy,0.41,0.48,0.07,0.0,0.0,0.03,0.0,0.0,amanda cooper fine,,MKT-4330,2016
+MKT,4430,1,Advertising Strategy,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,albert neil cameron,,MKT-4430,2016
+MKT,4450,1,Macromarketing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,,MKT-4450,2016
+MKT,4500,1,Strategic Mktg Mgt,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2016
+MKT,4500,2,Strategic Mktg Mgt,0.77,0.2,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,,MKT-4500,2016
+MKT,4500,3,Strategic Mktg Mgt,0.52,0.41,0.03,0.03,0.0,0.0,0.0,0.0,lura forcum,,MKT-4500,2016
+MKT,4500,4,Strategic Mktg Mgt,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-4500,2016
+MKT,4950,1,Selected Topics: Social Media,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-4950,2016
+MKT,8620,1,Quant Methods in Mkt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,,MKT-8620,2016
+MKT,8650,1,Seminar in Mkt Mgmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MKT-8650,2016
+ML,1020,1,Leadership Fund II,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,amanda carol kane,,ML-1020,2016
+ML,4020,3,Organizational Leadership II,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,james mullinax,,ML-4020,2016
+MSE,2100,2,Intro to Mat Science,0.16,0.54,0.19,0.02,0.04,0.0,0.0,0.05,kyle brinkman,,MSE-2100,2016
+MSE,2100,3,Intro to Mat Science,0.21,0.46,0.16,0.05,0.04,0.0,0.0,0.08,eric skaar,,MSE-2100,2016
+MSE,2100,4,Intro to Mat Science,0.4,0.28,0.09,0.09,0.07,0.0,0.0,0.07,olga kuksenok,,MSE-2100,2016
+MSE,2100,5,Intro to Mat Science,0.31,0.31,0.27,0.02,0.0,0.0,0.0,0.08,rakhee pani,,MSE-2100,2016
+MSE,2410,1,Metrics,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,,MSE-2410,2016
+MSE,2500,1,Polymer & Fiber Materials I,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,deborah lickfield,,MSE-2500,2016
+MSE,2500,2,Polymer & Fiber Materials I,0.36,0.29,0.29,0.0,0.0,0.0,0.0,0.07,deborah lickfield,,MSE-2500,2016
+MSE,3260,1,Thermo of Materials,0.15,0.43,0.26,0.08,0.03,0.0,0.0,0.05,gary lickfield,,MSE-3260,2016
+MSE,3280,1,Phase Diagrams,0.4,0.37,0.23,0.0,0.0,0.0,0.0,0.0,eric skaar,,MSE-3280,2016
+MSE,3610,1,Proc of Metals & Com,0.41,0.36,0.23,0.0,0.0,0.0,0.0,0.0,marian kennedy,,MSE-3610,2016
+MSE,4150,1,Polymer Sc Engr,0.33,0.33,0.22,0.07,0.0,0.0,0.0,0.04,igor luzinov,,MSE-4150,2016
+MSE,4160,1,Electronic Materials,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,kyle brinkman,,MSE-4160,2016
+MSE,4220,1,Mech Behavior of Mat,0.31,0.47,0.17,0.0,0.05,0.0,0.0,0.0,vincent yves blouin,,MSE-4220,2016
+MSE,4240,1,Optical Materials,0.28,0.48,0.16,0.08,0.0,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-4240,2016
+MSE,4330,1,Comb Sys & Env Emiss,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,denis brosnan,,MSE-4330,2016
+MSE,4560,1,Polymer & Fiber Materials II,0.37,0.41,0.19,0.0,0.0,0.0,0.0,0.04,gary lickfield,,MSE-4560,2016
+MSE,4590,2,Color Science Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,philip brown,,MSE-4590,2016
+MSE,4910,1,Undergraduate Research,0.59,0.24,0.09,0.03,0.0,0.0,0.0,0.06,marian kennedy,,MSE-4910,2016
+MUSC,1110,7,Beginning Class Guitar,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,david stevenson,,MUSC-1110,2016
+MUSC,1420,1,Music Theory I,0.79,0.07,0.0,0.0,0.07,0.0,0.0,0.07,anthony bernarducci,,MUSC-1420,2016
+MUSC,1430,1,Aural Skills I,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,anthony bernarducci,,MUSC-1430,2016
+MUSC,1510,2,Applied Music,0.55,0.0,0.09,0.0,0.09,0.0,0.0,0.27,jonathan edwa doyel,,MUSC-1510,2016
+MUSC,1800,1,Intro to Music Tech,0.2,0.5,0.1,0.0,0.2,0.0,0.0,0.0,hamilton altstatt,,MUSC-1800,2016
+MUSC,2100,1,Music in the Western World,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-2100,2016
+MUSC,2100,2,Music in the Western World,0.59,0.22,0.06,0.06,0.0,0.0,0.0,0.06,lisa sain odom,,MUSC-2100,2016
+MUSC,2100,3,Music in the Western World,0.88,0.06,0.0,0.03,0.03,0.0,0.0,0.0,eric lapin,,MUSC-2100,2016
+MUSC,2100,4,Music in the Western World,0.65,0.1,0.13,0.06,0.0,0.0,0.0,0.06,linda li-bleuel,,MUSC-2100,2016
+MUSC,2100,5,Music in the Western World,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2016
+MUSC,2100,6,Music in the Western World,0.67,0.2,0.07,0.03,0.03,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2016
+MUSC,2100,7,Music in the Western World,0.48,0.48,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2016
+MUSC,2100,12,Music in the Western World,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,,MUSC-2100,2016
+MUSC,2100,13,Music in the Western World,0.84,0.06,0.03,0.0,0.03,0.0,0.0,0.03,linda dzuris,,MUSC-2100,2016
+MUSC,2100,14,Music in the Western World,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,david conley,,MUSC-2100,2016
+MUSC,3090,1,Surv of Broadway II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,lisa sain odom,,MUSC-3090,2016
+MUSC,3110,1,History of American Music,0.78,0.16,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3110,2016
+MUSC,3120,1,History of Jazz,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-3120,2016
+MUSC,3170,1,Hist of Country Mus,0.78,0.16,0.0,0.03,0.03,0.0,0.0,0.0,ned hosler,,MUSC-3170,2016
+MUSC,3180,1,Hist of Audio Tech,0.5,0.21,0.21,0.07,0.0,0.0,0.0,0.0,bruce allen whisler,,MUSC-3180,2016
+MUSC,3310,1,Pep Band - Men,0.96,0.03,0.0,0.0,0.0,0.0,0.0,0.01,timothy ra hurlburt,,MUSC-3310,2016
+MUSC,3640,1,Concert Band,0.91,0.01,0.03,0.0,0.0,0.0,0.0,0.04,timothy ra hurlburt,,MUSC-3640,2016
+MUSC,3690,1,Symphony Orchestra,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,True,MUSC-3690,2016
+MUSC,3700,1,Clemson University Singers,0.91,0.02,0.05,0.0,0.0,0.0,0.0,0.02,justin durham,,MUSC-3700,2016
+MUSC,3710,1,Women's Chorus,0.96,0.0,0.02,0.02,0.0,0.0,0.0,0.0,justin durham,,MUSC-3710,2016
+MUSC,3720,1,Men's Chorus,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,,MUSC-3720,2016
+MUSC,4160,1,Mus Hist Since 1750,0.39,0.22,0.22,0.06,0.06,0.0,0.0,0.06,linda li-bleuel,,MUSC-4160,2016
+NPL,3010,2,NPL Stakeholders,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,tracy diane lamb,,NPL-3010,2016
+NPL,3030,2,NPL Personnel,0.77,0.09,0.0,0.0,0.09,0.0,0.0,0.05,wendell price,,NPL-3030,2016
+NURS,3030,1,Nursing of Adults,0.15,0.75,0.1,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,,NURS-3030,2016
+NURS,3030,400,Nursing of Adults,0.08,0.77,0.12,0.0,0.0,0.0,0.0,0.04,lena marie burgess,,NURS-3030,2016
+NURS,3040,1,Pathophysiology,0.29,0.47,0.14,0.04,0.02,0.0,0.0,0.04,catherine si murton,,NURS-3040,2016
+NURS,3040,401,Pathophysiology for RN,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,,NURS-3040,2016
+NURS,3100,1,Health Assessment,0.62,0.36,0.0,0.0,0.0,0.0,0.0,0.02,terry kaye busby,,NURS-3100,2016
+NURS,3120,1,Foundations of Nursing,0.38,0.51,0.06,0.0,0.02,0.0,0.0,0.02,angela pye,,NURS-3120,2016
+NURS,3190,400,Health Assessment for RNs,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,,NURS-3190,2016
+NURS,3190,401,Health Assessment for RNs,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kellie davis-hall,,NURS-3190,2016
+NURS,3200,1,Prof in Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3200,2016
+NURS,3300,1,Research in Nursing,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,shirley mae timmons,,NURS-3300,2016
+NURS,3330,1,Health Care Genetics,0.93,0.05,0.0,0.02,0.0,0.0,0.0,0.0,jane marie deluca,,NURS-3330,2016
+NURS,3330,400,Health Care Genetics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,NURS-3330,2016
+NURS,3400,1,Pharmther Nursing,0.28,0.53,0.11,0.04,0.0,0.0,0.0,0.04,catherine si murton,,NURS-3400,2016
+NURS,3600,400,Social Determinants in Health,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,roxanne amerson,,NURS-3600,2016
+NURS,4010,1,Mental Health Nurs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-4010,2016
+NURS,4100,1,Lead Mgt Practicum,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,,NURS-4100,2016
+NURS,4110,1,Nursing of Children,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,,NURS-4110,2016
+NURS,4120,1,Nurs Women and Fam,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2016
+NURS,8010,400,Adv Fam & Comm Nrsng,0.8,0.18,0.02,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,,NURS-8010,2016
+NURS,8080,400,Nurs Res Stat Analys,0.69,0.28,0.02,0.0,0.02,0.0,0.0,0.0,veronica parker,,NURS-8080,2016
+NURS,8190,400,Developing Family,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,paula watt,,NURS-8190,2016
+NURS,8200,400,Child & Adol Nursing,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-8200,2016
+NURS,8210,400,Adult Nursing,0.71,0.27,0.0,0.0,0.0,0.0,0.0,0.02,tracy king fasolino,,NURS-8210,2016
+NURS,8850,400,Mental Health in Primary Care,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-8850,2016
+NUTR,2030,1,Intro Princ of Human Nutrition,0.48,0.32,0.13,0.04,0.02,0.0,0.0,0.02,deborah an hutcheon,,NUTR-2030,2016
+NUTR,2030,2,Intro Princ of Human Nutrition,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,,NUTR-2030,2016
+NUTR,2040,1,Nutrition Across Life Cycle,0.22,0.53,0.15,0.05,0.03,0.0,0.0,0.02,deborah an hutcheon,,NUTR-2040,2016
+NUTR,4180,1,Prof Development in Dietetics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,,NUTR-4180,2016
+NUTR,4250,1,Medica Nutr Thera II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4250,2016
+NUTR,4260,1,Community Nutrition,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,katherine cason,,NUTR-4260,2016
+NUTR,4550,1,Nutr Metabolism,0.34,0.26,0.2,0.14,0.06,0.0,0.0,0.0,elliot jesch,,NUTR-4550,2016
+NUTR,8030,1,Adv Human Nutr,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,vivian haley-zitlin,,NUTR-8030,2016
+PA,2800,1,Perf Arts Pract II,0.5,0.29,0.07,0.0,0.0,0.0,0.0,0.14,kenneth moore,,PA-2800,2016
+PA,3010,1,Prin of Arts Admin,0.46,0.23,0.31,0.0,0.0,0.0,0.0,0.0,paul buyer,,PA-3010,2016
+PA,4010,1,Capstone Project,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,,PA-4010,2016
+PADM,8210,400,Perspectives on Public Admin,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,,PADM-8210,2016
+PADM,8290,400,Public Financial Management,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,,PADM-8290,2016
+PADM,8410,400,Public Data Analysis,0.27,0.27,0.18,0.0,0.27,0.0,0.0,0.0,ronald chrestman,,PADM-8410,2016
+PADM,8430,400,Info Systems for Public Admin,0.5,0.13,0.13,0.0,0.0,0.0,0.0,0.25,mark daniel mellott,,PADM-8430,2016
+PADM,8530,400,Homeland Sec/Emergency Mgt Law,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,david leigh cook,,PADM-8530,2016
+PADM,8600,400,American Government,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,,PADM-8600,2016
+PADM,8720,400,Rural Development,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,,PADM-8720,2016
+PADM,8780,400,Nonprofit Marketing & Pub Rel,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,debra nelson,,PADM-8780,2016
+PES,2020,1,Soils,0.03,0.5,0.36,0.07,0.0,0.0,0.0,0.03,dara michelle park,,PES-2020,2016
+PES,4050,1,Plant Breeding,0.47,0.33,0.07,0.07,0.0,0.0,0.0,0.07,ksenija gasic,,PES-4050,2016
+PES,4220,1,Major World Crops,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,sruthi naraya kutty,,PES-4220,2016
+PES,4460,1,Soil Management,0.23,0.62,0.08,0.0,0.0,0.0,0.0,0.08,dara michelle park,,PES-4460,2016
+PES,4520,1,Soil Fertility and Management,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,haibo liu,,PES-4520,2016
+PES,4900,1,Soil Organisms in Plant Growth,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,"appukuttan suseela,",,PES-4900,2016
+PES,4960,1,BioIntegrated Greenhouse Sys.,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,geoffrey zehnder,,PES-4960,2016
+PHIL,1010,1,Intro to Philosophic Problems,0.57,0.29,0.09,0.03,0.0,0.0,0.0,0.03,david stegall,,PHIL-1010,2016
+PHIL,1010,2,Intro to Philosophic Problems,0.56,0.24,0.09,0.06,0.0,0.0,0.0,0.06,david stegall,,PHIL-1010,2016
+PHIL,1010,5,Intro to Philosophic Problems,0.26,0.4,0.2,0.03,0.06,0.0,0.0,0.06,john randall wolfe,,PHIL-1010,2016
+PHIL,1010,6,Intro to Philosophic Problems,0.34,0.37,0.14,0.0,0.11,0.0,0.0,0.03,john randall wolfe,,PHIL-1010,2016
+PHIL,1010,7,Intro to Philosophic Problems,0.44,0.41,0.06,0.03,0.0,0.0,0.0,0.06,john randall wolfe,,PHIL-1010,2016
+PHIL,1020,1,Introduction to Logic,0.81,0.03,0.13,0.0,0.03,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2016
+PHIL,1020,2,Introduction to Logic,0.58,0.33,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,,PHIL-1020,2016
+PHIL,1020,3,Introduction to Logic,0.91,0.03,0.0,0.0,0.03,0.0,0.0,0.03,gregory scott moss,,PHIL-1020,2016
+PHIL,1020,4,Introduction to Logic,0.86,0.09,0.0,0.0,0.03,0.0,0.0,0.03,gregory scott moss,,PHIL-1020,2016
+PHIL,1020,6,Introduction to Logic,0.45,0.19,0.29,0.06,0.0,0.0,0.0,0.0,stephen satris,,PHIL-1020,2016
+PHIL,1030,2,Introduction to Ethics,0.17,0.43,0.14,0.11,0.11,0.0,0.0,0.03,malcolm edwa munson,,PHIL-1030,2016
+PHIL,1030,3,Introduction to Ethics,0.26,0.43,0.29,0.0,0.03,0.0,0.0,0.0,malcolm edwa munson,,PHIL-1030,2016
+PHIL,1030,5,Introduction to Ethics,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,adam gies,,PHIL-1030,2016
+PHIL,1030,6,Introduction to Ethics,0.74,0.18,0.03,0.0,0.06,0.0,0.0,0.0,adam gies,,PHIL-1030,2016
+PHIL,1030,7,Introduction to Ethics,0.41,0.43,0.14,0.03,0.0,0.0,0.0,0.0,ryan lake,,PHIL-1030,2016
+PHIL,1030,8,Introduction to Ethics,0.41,0.47,0.09,0.03,0.0,0.0,0.0,0.0,ryan lake,,PHIL-1030,2016
+PHIL,1030,9,Introduction to Ethics,0.47,0.37,0.0,0.0,0.05,0.0,0.0,0.11,ryan lake,,PHIL-1030,2016
+PHIL,1030,11,Introduction to Ethics,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,jennifer ingle,,PHIL-1030,2016
+PHIL,1030,12,Introduction to Ethics,0.44,0.41,0.0,0.03,0.0,0.0,0.0,0.12,jennifer ingle,,PHIL-1030,2016
+PHIL,3030,1,Phil of Religion,0.7,0.23,0.0,0.03,0.0,0.0,0.0,0.03,gregory scott moss,,PHIL-3030,2016
+PHIL,3150,1,Ancient Philosophy,0.4,0.3,0.13,0.0,0.13,0.0,0.0,0.03,john randall wolfe,,PHIL-3150,2016
+PHIL,3160,1,Modern Philosophy,0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,michael hal hannen,,PHIL-3160,2016
+PHIL,3200,1,Soc and Pol Phil,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,david stegall,,PHIL-3200,2016
+PHIL,3210,1,Crime & Punishment,0.76,0.21,0.0,0.0,0.03,0.0,0.0,0.0,ryan lake,,PHIL-3210,2016
+PHIL,3260,1,Science and Values,0.53,0.38,0.06,0.0,0.03,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2016
+PHIL,3260,2,Science and Values,0.53,0.38,0.03,0.0,0.06,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2016
+PHIL,3430,1,Philosophy of Law,0.7,0.21,0.0,0.0,0.0,0.0,0.0,0.09,david stegall,,PHIL-3430,2016
+PHIL,3440,1,Business Ethics,0.23,0.69,0.09,0.0,0.0,0.0,0.0,0.0,diane perpich,,PHIL-3440,2016
+PHIL,3450,1,Environmental Ethics,0.6,0.26,0.06,0.03,0.03,0.0,0.0,0.03,jennifer ingle,,PHIL-3450,2016
+PHIL,3550,1,Philosophy of Mind & Cog Scien,0.53,0.29,0.0,0.06,0.06,0.0,0.0,0.06,adam gies,,PHIL-3550,2016
+PHIL,3700,1,Philosophy of War,0.34,0.41,0.13,0.0,0.03,0.0,0.0,0.09,todd may,,PHIL-3700,2016
+PHIL,4750,1,Philosophy of Film,0.38,0.38,0.06,0.0,0.13,0.06,0.0,0.0,christopher grau,,PHIL-4750,2016
+PHSC,1170,1,Intro Chem & Earth,0.91,0.08,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1170,2016
+PHYS,1220,1,Physics with Calculus I,0.26,0.23,0.26,0.14,0.07,0.0,0.0,0.05,lih-sin the,,PHYS-1220,2016
+PHYS,1220,2,Physics with Calculus I,0.22,0.35,0.19,0.1,0.06,0.0,0.0,0.08,lih-sin the,,PHYS-1220,2016
+PHYS,1220,3,Physics with Calculus I,0.27,0.43,0.19,0.06,0.03,0.0,0.0,0.02,lih-sin the,,PHYS-1220,2016
+PHYS,1220,4,Physics with Calculus I,0.38,0.4,0.14,0.04,0.01,0.0,0.0,0.01,hye jung kang,,PHYS-1220,2016
+PHYS,1220,5,Physics with Calculus I,0.32,0.37,0.23,0.03,0.03,0.0,0.0,0.02,pooja puneet,,PHYS-1220,2016
+PHYS,1220,8,Physics With Cal I (HON),0.56,0.26,0.09,0.0,0.0,0.0,0.0,0.09,ramakrishna podila,True,PHYS-1220,2016
+PHYS,1240,1,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,2,Physics Lab I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2016
+PHYS,1240,3,Physics Lab I,0.12,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,4,Physics Lab I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2016
+PHYS,1240,5,Physics Lab I,0.41,0.47,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,,PHYS-1240,2016
+PHYS,1240,6,Physics Lab I,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,7,Physics Lab I,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,8,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,9,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2016
+PHYS,1240,10,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,11,Physics Lab I,0.22,0.5,0.0,0.0,0.0,0.0,0.0,0.28,jerry hester,,PHYS-1240,2016
+PHYS,1240,12,Physics Lab I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,13,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,14,Physics Lab I,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,15,Physics Lab I,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2016
+PHYS,1240,16,Physics Lab I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,17,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,18,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,19,Physics Lab I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2016
+PHYS,1240,20,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,21,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,22,Physics Lab I,0.38,0.44,0.0,0.0,0.0,0.0,0.0,0.19,jerry hester,,PHYS-1240,2016
+PHYS,1240,23,Physics Lab I,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,24,Physics Lab I,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,25,Physics Lab I,0.24,0.65,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,26,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,27,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,1240,29,Physics Lab I,0.22,0.5,0.17,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2016
+PHYS,1240,30,Physics Lab I,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2016
+PHYS,2000,1,Introductory Physics,0.26,0.49,0.17,0.09,0.0,0.0,0.0,0.0,sean brittain,,PHYS-2000,2016
+PHYS,2070,1,General Physics I,0.34,0.36,0.16,0.06,0.03,0.0,0.0,0.05,pooja puneet,,PHYS-2070,2016
+PHYS,2080,1,General Physics II,0.63,0.25,0.07,0.04,0.0,0.0,0.0,0.0,amy liann pope,,PHYS-2080,2016
+PHYS,2080,2,General Physics II,0.53,0.31,0.08,0.04,0.03,0.0,0.0,0.0,amy liann pope,,PHYS-2080,2016
+PHYS,2090,1,Gen Phys Lab I,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,2,Gen Phys Lab I,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,jerry hester,,PHYS-2090,2016
+PHYS,2090,3,Gen Phys Lab I,0.27,0.55,0.14,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2016
+PHYS,2090,4,Gen Phys Lab I,0.41,0.41,0.05,0.05,0.0,0.0,0.0,0.09,jerry hester,,PHYS-2090,2016
+PHYS,2090,5,Gen Phys Lab I,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,6,Gen Phys Lab I,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2016
+PHYS,2090,7,Gen Phys Lab I,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,8,Gen Phys Lab I,0.57,0.39,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,9,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2090,10,Gen Phys Lab I,0.14,0.71,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2016
+PHYS,2100,1,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,2,Gen Phys Lab II,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,3,Gen Phys Lab II,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,5,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,6,Gen Phys Lab II,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,7,Gen Phys Lab II,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2016
+PHYS,2100,8,Gen Phys Lab II,0.75,0.21,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,9,Gen Phys Lab II,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,10,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,11,Gen Phys Lab II,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,12,Gen Phys Lab II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,13,Gen Phys Lab II,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,14,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,15,Gen Phys Lab II,0.5,0.33,0.08,0.0,0.04,0.0,0.0,0.04,jerry hester,,PHYS-2100,2016
+PHYS,2100,16,Gen Phys Lab II,0.28,0.61,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,,PHYS-2100,2016
+PHYS,2100,17,Gen Phys Lab II,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2100,18,Gen Phys Lab II,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2016
+PHYS,2210,1,Physics with Calculus II,0.28,0.4,0.24,0.04,0.03,0.0,0.0,0.01,jason stratfo brown,,PHYS-2210,2016
+PHYS,2210,2,Physics with Calculus II,0.33,0.38,0.14,0.11,0.03,0.0,0.0,0.02,jason stratfo brown,,PHYS-2210,2016
+PHYS,2210,3,Physics with Calculus II,0.36,0.29,0.29,0.0,0.07,0.0,0.0,0.0,murray daw,,PHYS-2210,2016
+PHYS,2210,5,Physics with Calculus II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,edward collins,,PHYS-2210,2016
+PHYS,2220,1,Physics with Calculus III,0.36,0.36,0.11,0.0,0.0,0.0,0.0,0.18,jian he,,PHYS-2220,2016
+PHYS,2230,1,Physics Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,2,Physics Lab II,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2016
+PHYS,2230,3,Physics Lab II,0.53,0.35,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,,PHYS-2230,2016
+PHYS,2230,4,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,5,Physics Lab II,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,6,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,7,Physics Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2016
+PHYS,2230,8,Physics Lab II,0.06,0.61,0.17,0.06,0.0,0.0,0.0,0.11,jerry hester,,PHYS-2230,2016
+PHYS,2230,9,Physics Lab II,0.33,0.4,0.2,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-2230,2016
+PHYS,2230,10,Physics Lab II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,edward collins,,PHYS-2230,2016
+PHYS,2240,1,Physics Lab III,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-2240,2016
+PHYS,2400,1,Phys of Weather,0.33,0.4,0.18,0.0,0.03,0.0,0.0,0.08,miguel larsen,,PHYS-2400,2016
+PHYS,3110,1,Methods Theor Phys,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,feng ding,,PHYS-3110,2016
+PHYS,3220,1,Mechanics II,0.09,0.73,0.09,0.0,0.09,0.0,0.0,0.0,gerald lehmacher,,PHYS-3220,2016
+PHYS,4650,1,Thermo and Stat Mech,0.33,0.33,0.0,0.08,0.0,0.0,0.0,0.25,jens oberheide,,PHYS-4650,2016
+PHYS,8150,1,Statistical Therm I,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,,PHYS-8150,2016
+PHYS,8410,1,Electrodynamics I,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,,PHYS-8410,2016
+PHYS,9520,1,Quantum Mech II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,sumanta tewari,,PHYS-9520,2016
+PKSC,1020,1,Intro to Pkg Sci,0.09,0.31,0.32,0.17,0.03,0.0,0.0,0.07,heather batt,,PKSC-1020,2016
+PKSC,2010,1,Pkg Perishable Prod,0.12,0.41,0.28,0.09,0.08,0.0,0.0,0.03,heather batt,,PKSC-2010,2016
+PKSC,2020,1,Packaging Mtl & Mfg,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2020,2016
+PKSC,2040,1,Container Systems,0.84,0.15,0.01,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2040,2016
+PKSC,2060,1,Container Sys Lab,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2060,2016
+PKSC,2060,2,Container Sys Lab,0.62,0.14,0.24,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2060,2016
+PKSC,2060,3,Container Sys Lab,0.68,0.18,0.14,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2060,2016
+PKSC,2200,1,Product & Pkg Design,0.67,0.21,0.08,0.04,0.0,0.0,0.0,0.0,william aaro snyder,,PKSC-2200,2016
+PKSC,3200,1,Pkg Design Theory,0.43,0.52,0.02,0.0,0.0,0.0,0.0,0.02,rupert hurley,,PKSC-3200,2016
+PKSC,3680,1,Pkg and Society,0.57,0.3,0.11,0.02,0.0,0.0,0.0,0.0,heather batt,,PKSC-3680,2016
+PKSC,4030,1,Pkg Career Prep,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2016
+PKSC,4200,1,Pkg Design & Dev,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2016
+PKSC,4300,1,Converting Flex Pkg,0.25,0.56,0.08,0.08,0.02,0.0,0.0,0.0,duncan darby,,PKSC-4300,2016
+PKSC,4400,2,Packaging for Distribution,0.25,0.57,0.1,0.04,0.05,0.0,0.0,0.0,gregory batt,,PKSC-4400,2016
+PKSC,4640,1,Food & Health Care Pkg Systems,0.7,0.22,0.04,0.04,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2016
+PLPA,2130,1,Fungi & Civilization,0.42,0.36,0.06,0.08,0.04,0.0,0.0,0.05,julia loui kerrigan,,PLPA-2130,2016
+PLPA,8090,1,Analytical Technique,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,tharayil-santhakumar,,PLPA-8090,2016
+POSC,1010,1,Amer National Govt,0.07,0.36,0.27,0.1,0.11,0.0,0.0,0.07,laura olson,,POSC-1010,2016
+POSC,1010,2,Amer National Govt,0.1,0.1,0.3,0.3,0.1,0.0,0.0,0.1,adam warber,,POSC-1010,2016
+POSC,1020,1,Intro Intl Relations,0.2,0.45,0.18,0.06,0.09,0.0,0.0,0.02,zeynep taydas,,POSC-1020,2016
+POSC,1020,2,Intro Intl Relations,0.11,0.29,0.3,0.11,0.12,0.0,0.0,0.06,zeynep taydas,,POSC-1020,2016
+POSC,1020,3,Intro Intl Relations,0.17,0.44,0.22,0.05,0.06,0.0,0.0,0.06,aron geo tannenbaum,,POSC-1020,2016
+POSC,1030,1,Intro to Political Theory,0.13,0.47,0.21,0.13,0.03,0.0,0.0,0.03,colin pearce,,POSC-1030,2016
+POSC,1030,2,Intro to Political Theory,0.18,0.58,0.13,0.0,0.07,0.0,0.0,0.04,kimberly hurd hale,,POSC-1030,2016
+POSC,1040,1,Intro Compar Pol,0.38,0.36,0.15,0.07,0.02,0.0,0.0,0.02,katherine am curtis,,POSC-1040,2016
+POSC,1040,2,Intro Compar Pol,0.18,0.48,0.1,0.08,0.04,0.0,0.0,0.12,lydia loui lundgren,,POSC-1040,2016
+POSC,1990,1,Intro Pol Sci,0.15,0.39,0.15,0.12,0.09,0.0,0.0,0.09,meredith petersheim,,POSC-1990,2016
+POSC,3020,1,State and Loc Gov,0.11,0.62,0.16,0.03,0.05,0.0,0.0,0.03,bruce ransom,,POSC-3020,2016
+POSC,3210,1,Public Admin,0.05,0.32,0.5,0.05,0.05,0.0,0.0,0.05,james woodard,,POSC-3210,2016
+POSC,3410,1,Quant Meth in Pol Sc,0.25,0.17,0.25,0.17,0.08,0.0,0.0,0.08,steven vince miller,,POSC-3410,2016
+POSC,3610,1,Intl Pol in Crisis,0.28,0.48,0.18,0.02,0.0,0.0,0.0,0.04,vladimir matic,,POSC-3610,2016
+POSC,3620,1,Intl Organizations,0.1,0.2,0.37,0.07,0.13,0.0,0.0,0.13,zeynep taydas,,POSC-3620,2016
+POSC,3630,1,Us Foreign Policy,0.16,0.25,0.27,0.14,0.14,0.0,0.0,0.05,steven vince miller,,POSC-3630,2016
+POSC,3710,1,European Politics,0.2,0.39,0.27,0.04,0.04,0.0,0.0,0.06,katherine am curtis,,POSC-3710,2016
+POSC,4030,1,United States Congress,0.33,0.41,0.22,0.02,0.0,0.0,0.0,0.02,jeffrey scott peake,,POSC-4030,2016
+POSC,4050,1,American Presidency,0.07,0.29,0.36,0.07,0.14,0.0,0.0,0.07,adam warber,,POSC-4050,2016
+POSC,4160,1,Int Groups & Soc Mov,0.32,0.42,0.16,0.05,0.0,0.0,0.0,0.05,laura olson,,POSC-4160,2016
+POSC,4370,1,Constitut Law: Rights & Libert,0.39,0.47,0.04,0.0,0.04,0.0,0.0,0.06,daniel frost,,POSC-4370,2016
+POSC,4490,1,Political Theory of Capitalism,0.49,0.23,0.15,0.05,0.08,0.0,0.0,0.0,brandon turner,,POSC-4490,2016
+POSC,4500,1,Contemporary Political Thought,0.52,0.36,0.0,0.0,0.04,0.0,0.0,0.08,daniel frost,,POSC-4500,2016
+POSC,4570,1,Political Terrorism,0.69,0.21,0.07,0.0,0.02,0.0,0.0,0.0,aron geo tannenbaum,,POSC-4570,2016
+POSC,4660,1,African Politics,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,lydia loui lundgren,,POSC-4660,2016
+POSC,4760,1,Middle East Politics,0.5,0.31,0.13,0.0,0.06,0.0,0.0,0.0,vladimir matic,,POSC-4760,2016
+POSC,4890,1,WW2: World Conflict Ideology,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,james woodard,,POSC-4890,2016
+POST,8430,1,Org Theory & Pub Mgt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,,POST-8430,2016
+PRTM,2200,1,Foundations of PRTM,0.41,0.48,0.03,0.0,0.03,0.0,0.0,0.03,teresa walto tucker,,PRTM-2200,2016
+PRTM,2200,2,Foundations of PRTM,0.67,0.23,0.0,0.07,0.03,0.0,0.0,0.0,gwynn powell,,PRTM-2200,2016
+PRTM,2200,3,Foundations of PRTM,0.43,0.37,0.1,0.03,0.03,0.0,0.0,0.03,ryan joseph gagnon,,PRTM-2200,2016
+PRTM,2200,4,Foundations of PRTM,0.22,0.59,0.15,0.0,0.04,0.0,0.0,0.0,dorothy schmalz,,PRTM-2200,2016
+PRTM,2200,5,Foundations of PRTM,0.63,0.26,0.07,0.0,0.0,0.0,0.0,0.04,william holland,,PRTM-2200,2016
+PRTM,2200,6,Foundations of PRTM,0.43,0.43,0.11,0.0,0.04,0.0,0.0,0.0,francis mcguire,,PRTM-2200,2016
+PRTM,2410,1,Intro to CRSCM,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,,PRTM-2410,2016
+PRTM,2410,2,Intro to CRSCM,0.56,0.29,0.06,0.0,0.03,0.0,0.0,0.06,jeffrey townsend,,PRTM-2410,2016
+PRTM,2600,1,Found of Recreational Therapy,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,,PRTM-2600,2016
+PRTM,2650,1,Terminology in RT Practice,0.89,0.06,0.03,0.01,0.01,0.0,0.0,0.0,stephen thoma lewis,,PRTM-2650,2016
+PRTM,2700,1,Intro Rec Res Mgt,0.4,0.43,0.13,0.0,0.03,0.0,0.0,0.0,lincoln larson,,PRTM-2700,2016
+PRTM,2980,3,Creative Inquiry in PRTM II,0.52,0.39,0.0,0.0,0.04,0.0,0.0,0.04,francis mcguire,,PRTM-2980,2016
+PRTM,2980,5,Creative Inquiry in PRTM II,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,lawrence allen,,PRTM-2980,2016
+PRTM,2980,6,Creative Inquiry in PRTM II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brent hawkins,,PRTM-2980,2016
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.34,0.51,0.06,0.03,0.03,0.0,0.0,0.03,daniel mor anderson,,PRTM-3050,2016
+PRTM,3070,1,Facility Operations,0.79,0.18,0.0,0.0,0.03,0.0,0.0,0.0,craig goodman,,PRTM-3070,2016
+PRTM,3210,1,Recreation Admin,0.53,0.22,0.19,0.0,0.03,0.0,0.0,0.03,mariela fernandez,,PRTM-3210,2016
+PRTM,3250,1,Global Persp in Rec,0.31,0.38,0.25,0.0,0.03,0.0,0.0,0.03,teresa walto tucker,,PRTM-3250,2016
+PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.77,0.2,0.02,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,,PRTM-3260,2016
+PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.36,0.52,0.09,0.02,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3270,2016
+PRTM,3420,1,Intro to Tourism,0.48,0.15,0.22,0.09,0.02,0.0,0.0,0.04,herbert chancellor,,PRTM-3420,2016
+PRTM,3420,2,Intro to Tourism,0.91,0.07,0.02,0.0,0.0,0.0,0.0,0.0,maloud shakona,,PRTM-3420,2016
+PRTM,3440,1,Tourism Markets,0.68,0.15,0.1,0.05,0.03,0.0,0.0,0.0,sheila backman,,PRTM-3440,2016
+PRTM,3440,2,Tourism Markets,0.86,0.07,0.02,0.02,0.0,0.0,0.0,0.02,sheila backman,,PRTM-3440,2016
+PRTM,3450,1,Tourism Management,0.52,0.24,0.19,0.0,0.05,0.0,0.0,0.0,garrett stone,,PRTM-3450,2016
+PRTM,3450,2,Tourism Management,0.52,0.23,0.19,0.03,0.03,0.0,0.0,0.0,lauren duffy,,PRTM-3450,2016
+PRTM,3460,1,Heritage Tourism,0.25,0.44,0.19,0.1,0.02,0.0,0.0,0.0,gregory phi ramshaw,,PRTM-3460,2016
+PRTM,3530,1,Foundations of Camp Counseling,0.74,0.11,0.16,0.0,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-3530,2016
+PRTM,3900,4,Independent Study in PRTM,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3900,2016
+PRTM,3910,1,Social Media in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james war sanderson,,PRTM-3910,2016
+PRTM,3910,2,Intro to GIS for PRTM,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0,david lawrenc white,,PRTM-3910,2016
+PRTM,4210,1,Rec Fin Resc Mgt,0.2,0.3,0.28,0.15,0.03,0.0,0.0,0.05,lawrence allen,,PRTM-4210,2016
+PRTM,4260,1,Trends & Issues in Rec Therapy,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-4260,2016
+PRTM,4300,1,World Geog Parks,0.27,0.27,0.27,0.09,0.03,0.0,0.0,0.06,robert baxte powell,,PRTM-4300,2016
+PRTM,4450,1,Conventions,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,jeffery martin,,PRTM-4450,2016
+PRTM,4460,2,Community Tourism,0.46,0.27,0.04,0.0,0.04,0.0,0.0,0.19,herbert chancellor,,PRTM-4460,2016
+PRTM,4510,1,Seminar in CRSCM,0.74,0.03,0.13,0.06,0.03,0.0,0.0,0.0,harrison pinckney,,PRTM-4510,2016
+PRTM,4540,1,Trends in Sport Mgt,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,brandon harris,,PRTM-4540,2016
+PRTM,4550,1,Adv Program Planning,0.64,0.18,0.14,0.05,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-4550,2016
+PRTM,4980,10,Creative Inquiry in PRTM IV,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,,PRTM-4980,2016
+PRTM,8030,1,Sem Rec & Park Admin,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,teresa walto tucker,,PRTM-8030,2016
+PRTM,8080,1,Behavioral Aspects,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-8080,2016
+PRTM,8110,1,Research Methods,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,,PRTM-8110,2016
+PRTM,8110,2,Research Methods,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,lincoln larson,,PRTM-8110,2016
+PRTM,8210,1,Alt Funding for PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-8210,2016
+PRTM,8250,1,Populations in PRTM,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,,PRTM-8250,2016
+PSYC,2010,1,Intro to Psychology,0.34,0.35,0.22,0.03,0.01,0.0,0.0,0.04,mary taylor,,PSYC-2010,2016
+PSYC,2010,2,Intro to Psychology,0.31,0.35,0.15,0.11,0.05,0.0,0.0,0.02,jo anne jorgensen,,PSYC-2010,2016
+PSYC,2010,3,Intro to Psychology,0.39,0.28,0.2,0.06,0.07,0.0,0.0,0.0,mary taylor,,PSYC-2010,2016
+PSYC,2010,4,Intro to Psychology,0.56,0.27,0.08,0.03,0.03,0.0,0.0,0.02,chong hyon pak,,PSYC-2010,2016
+PSYC,2010,5,Intro to Psychology,0.23,0.31,0.23,0.06,0.09,0.0,0.0,0.08,edwin brainerd,,PSYC-2010,2016
+PSYC,2010,6,Intro to Psychology (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True,PSYC-2010,2016
+PSYC,2020,1,Intro Psychology Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jamie fynes,,PSYC-2020,2016
+PSYC,2020,4,Intro Psychology Lab,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,natalee kri baldwin,,PSYC-2020,2016
+PSYC,2020,5,Intro Psychology Lab,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,,PSYC-2020,2016
+PSYC,2020,6,Intro Psychology Lab,0.85,0.08,0.04,0.0,0.04,0.0,0.0,0.0,madison eliza sauls,,PSYC-2020,2016
+PSYC,3060,1,Human Sexual Beh,0.53,0.22,0.15,0.05,0.03,0.0,0.0,0.01,bruce michael king,,PSYC-3060,2016
+PSYC,3090,100,Intro Exp Psych,0.33,0.21,0.21,0.12,0.08,0.0,0.0,0.04,richard tyrrell,,PSYC-3090,2016
+PSYC,3090,200,Intro Exp Psych,0.83,0.07,0.03,0.03,0.0,0.0,0.0,0.03,alice miche brawley,,PSYC-3090,2016
+PSYC,3090,300,Intro Exp Psych,0.46,0.36,0.04,0.07,0.0,0.0,0.0,0.07,drew michael morris,,PSYC-3090,2016
+PSYC,3100,100,Advanced Experimental Psych,0.33,0.52,0.05,0.0,0.0,0.0,0.0,0.1,jennifer bai bisson,,PSYC-3100,2016
+PSYC,3100,200,Advanced Experimental Psych,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,robert campbell,,PSYC-3100,2016
+PSYC,3100,300,Advanced Experimental Psych,0.45,0.3,0.1,0.0,0.05,0.0,0.0,0.1,thomas britt,,PSYC-3100,2016
+PSYC,3100,400,Advanced Experimental Psych,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2016
+PSYC,3100,500,Advanced Experimental Psych,0.37,0.37,0.26,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2016
+PSYC,3100,600,Advanced Experimental Psych,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2016
+PSYC,3240,1,Physiological Psych,0.27,0.23,0.21,0.09,0.07,0.0,0.0,0.13,june pilcher,,PSYC-3240,2016
+PSYC,3240,2,Physiological Psych,0.47,0.29,0.11,0.05,0.09,0.0,0.0,0.0,claudio cantalupo,,PSYC-3240,2016
+PSYC,3330,1,Cognitive Psych,0.32,0.21,0.32,0.15,0.0,0.0,0.0,0.0,thomas alley,,PSYC-3330,2016
+PSYC,3340,2,Cognitive Psych Lab,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,leo gugerty,,PSYC-3340,2016
+PSYC,3340,3,Cognitive Psych Lab,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,laura whitlock,,PSYC-3340,2016
+PSYC,3400,1,Lifespan Developmental Psych,0.29,0.54,0.13,0.01,0.01,0.0,0.0,0.01,jennifer bai bisson,,PSYC-3400,2016
+PSYC,3400,2,Lifespan Developmental Psych,0.47,0.36,0.13,0.01,0.01,0.0,0.0,0.01,jennifer bai bisson,,PSYC-3400,2016
+PSYC,3520,1,Social Psychology,0.43,0.35,0.16,0.04,0.01,0.0,0.0,0.0,eric mckibben,,PSYC-3520,2016
+PSYC,3520,2,Social Psychology,0.5,0.3,0.11,0.07,0.0,0.0,0.0,0.01,eric mckibben,,PSYC-3520,2016
+PSYC,3520,3,Social Psychology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True,PSYC-3520,2016
+PSYC,3640,1,Industrial Psych,0.43,0.4,0.13,0.03,0.0,0.0,0.0,0.01,eric mckibben,,PSYC-3640,2016
+PSYC,3640,2,Industrial Psych,0.47,0.4,0.08,0.01,0.01,0.0,0.0,0.01,eric mckibben,,PSYC-3640,2016
+PSYC,3680,1,Organizational Psych,0.34,0.37,0.19,0.06,0.04,0.0,0.0,0.0,kristen su jennings,,PSYC-3680,2016
+PSYC,3830,1,Abnormal Psychology,0.54,0.31,0.11,0.03,0.0,0.0,0.0,0.01,jo anne jorgensen,,PSYC-3830,2016
+PSYC,3830,2,Abnormal Psychology,0.45,0.25,0.2,0.04,0.01,0.0,0.0,0.04,jo anne jorgensen,,PSYC-3830,2016
+PSYC,3830,3,Abnormal Psychology,0.18,0.38,0.26,0.0,0.09,0.0,0.0,0.09,pamela alley,,PSYC-3830,2016
+PSYC,3830,4,Abnormal Psychology,0.25,0.36,0.22,0.06,0.08,0.0,0.0,0.03,pamela alley,,PSYC-3830,2016
+PSYC,4080,1,Women and Psychology,0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,,PSYC-4080,2016
+PSYC,4150,1,Systems and Theories,0.39,0.43,0.13,0.0,0.0,0.0,0.0,0.04,brian day,,PSYC-4150,2016
+PSYC,4150,2,Systems and Theories,0.25,0.32,0.18,0.07,0.11,0.0,0.0,0.07,edwin brainerd,,PSYC-4150,2016
+PSYC,4150,3,Systems and Theories,0.33,0.3,0.11,0.07,0.07,0.0,0.0,0.11,edwin brainerd,,PSYC-4150,2016
+PSYC,4220,1,Perception,0.1,0.38,0.34,0.1,0.03,0.0,0.0,0.03,christopher pagano,,PSYC-4220,2016
+PSYC,4220,2,Perception,0.32,0.16,0.36,0.16,0.0,0.0,0.0,0.0,claudio cantalupo,,PSYC-4220,2016
+PSYC,4220,3,Perception,0.16,0.6,0.04,0.16,0.04,0.0,0.0,0.0,claudio cantalupo,,PSYC-4220,2016
+PSYC,4350,1,Human Factors,0.64,0.2,0.08,0.08,0.0,0.0,0.0,0.0,laura whitlock,,PSYC-4350,2016
+PSYC,4710,1,Psych of Testing,0.35,0.5,0.04,0.04,0.04,0.0,0.0,0.04,robert ray sinclair,,PSYC-4710,2016
+PSYC,4800,1,Health Psychology,0.48,0.44,0.08,0.0,0.0,0.0,0.0,0.0,june pilcher,,PSYC-4800,2016
+PSYC,4820,1,Positive Psychology,0.46,0.29,0.07,0.07,0.04,0.04,0.0,0.04,cynthia pury,,PSYC-4820,2016
+PSYC,4880,1,Psychotherapy,0.55,0.18,0.05,0.09,0.05,0.05,0.0,0.05,lucinda sorci quick,,PSYC-4880,2016
+PSYC,4890,1,Teamwork,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,marissa leig porter,,PSYC-4890,2016
+PSYC,4890,3,Food & Eating,0.46,0.33,0.13,0.04,0.04,0.0,0.0,0.0,thomas alley,,PSYC-4890,2016
+PSYC,4920,3,Senior Laboratory,0.88,0.04,0.0,0.08,0.0,0.0,0.0,0.0,stephen robertson,,PSYC-4920,2016
+PSYC,4920,4,Senior Laboratory,0.83,0.0,0.04,0.0,0.08,0.0,0.0,0.04,stephen robertson,,PSYC-4920,2016
+PSYC,4920,5,Senior Laboratory,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,leah hartman,,PSYC-4920,2016
+PSYC,4930,100,Pract Clinical Psych,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,heidi marie zinzow,,PSYC-4930,2016
+PSYC,8110,1,Research Design II,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,patrick rosopa,,PSYC-8110,2016
+PSYC,8130,1,Research Design III,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,,PSYC-8130,2016
+PSYC,8140,1,Quantitative Lab,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,,PSYC-8140,2016
+PSYC,8330,1,Adv Cog Psych,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,leo gugerty,,PSYC-8330,2016
+PSYC,8370,1,Ergonomics Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,,PSYC-8370,2016
+PSYC,8610,1,Personnel Psych,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,fred switzer,,PSYC-8610,2016
+RCID,8030,1,Emp Res Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,,RCID-8030,2016
+RED,8010,1,Market Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,,RED-8010,2016
+RED,8040,1,Resid Practicum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,,RED-8040,2016
+RED,8050,1,Commercial Practicum,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8050,2016
+RED,8120,1,Real Estate Technology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8120,2016
+REL,1010,1,Intro to Religion,0.09,0.25,0.41,0.09,0.13,0.0,0.0,0.03,peter cohen,,REL-1010,2016
+REL,1010,2,Intro to Religion,0.12,0.33,0.33,0.12,0.03,0.0,0.0,0.06,peter cohen,,REL-1010,2016
+REL,1010,3,Intro to Religion,0.03,0.52,0.24,0.09,0.12,0.0,0.0,0.0,peter cohen,,REL-1010,2016
+REL,1020,1,World Religions,0.68,0.22,0.11,0.0,0.0,0.0,0.0,0.0,robert stephens,,REL-1020,2016
+REL,1020,2,World Religions,0.5,0.38,0.09,0.03,0.0,0.0,0.0,0.0,robert stephens,,REL-1020,2016
+REL,1020,4,World Religions,0.47,0.41,0.06,0.06,0.0,0.0,0.0,0.0,robert stephens,,REL-1020,2016
+REL,3010,1,Old Testament,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3010,2016
+REL,3030,1,The Quran,0.35,0.39,0.13,0.03,0.06,0.0,0.0,0.03,mashal saif,,REL-3030,2016
+REL,3050,1,Constructing Scripture,0.38,0.38,0.07,0.0,0.03,0.07,0.0,0.07,benjamin white,,REL-3050,2016
+REL,3090,1,Religion of the American South,0.24,0.43,0.19,0.0,0.1,0.0,0.0,0.05,elizabeth jemison,,REL-3090,2016
+REL,3100,1,History of Religion in the US,0.47,0.35,0.06,0.0,0.0,0.0,0.0,0.12,elizabeth jemison,,REL-3100,2016
+REL,3120,1,Hinduism,0.7,0.1,0.0,0.03,0.03,0.0,0.0,0.13,robert stephens,,REL-3120,2016
+REL,3140,1,Buddhism in China,0.35,0.29,0.18,0.0,0.18,0.0,0.0,0.0,yanming an,,REL-3140,2016
+REL,3730,2,Age of Protestant Reformation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,thomas kuehn,,REL-3730,2016
+RS,3010,1,Rural Sociology,0.49,0.24,0.12,0.06,0.0,0.0,0.0,0.08,kenneth robinson,,RS-3010,2016
+SOC,2010,1,Intro to Sociology (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,rachael chatterson,True,SOC-2010,2016
+SOC,2010,2,Introduction to Sociology,0.48,0.3,0.09,0.09,0.02,0.0,0.0,0.02,rachael chatterson,,SOC-2010,2016
+SOC,2010,3,Introduction to Sociology,0.32,0.43,0.18,0.04,0.01,0.0,0.0,0.01,rachael chatterson,,SOC-2010,2016
+SOC,2010,4,Introduction to Sociology,0.63,0.23,0.1,0.0,0.02,0.0,0.0,0.02,shannon mcdonough,,SOC-2010,2016
+SOC,2010,5,Introduction to Sociology,0.67,0.23,0.08,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2016
+SOC,2010,6,Introduction to Sociology,0.66,0.23,0.05,0.04,0.0,0.0,0.0,0.03,shannon mcdonough,,SOC-2010,2016
+SOC,2010,7,Introduction to Sociology,0.28,0.4,0.21,0.02,0.02,0.0,0.0,0.06,mary louise barr,,SOC-2010,2016
+SOC,2010,8,Introduction to Sociology,0.43,0.43,0.09,0.0,0.02,0.0,0.0,0.04,mary louise barr,,SOC-2010,2016
+SOC,2010,9,Introduction to Sociology,0.44,0.38,0.11,0.0,0.02,0.0,0.0,0.04,mary louise barr,,SOC-2010,2016
+SOC,2010,10,Introduction to Sociology,0.45,0.36,0.09,0.04,0.06,0.0,0.0,0.0,mary louise barr,,SOC-2010,2016
+SOC,2010,11,Introduction to Sociology,0.61,0.24,0.08,0.04,0.0,0.0,0.0,0.02,jennifer le holland,,SOC-2010,2016
+SOC,2010,12,Introduction to Sociology,0.39,0.43,0.15,0.02,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2016
+SOC,2050,1,Sociology Lab,0.56,0.14,0.05,0.07,0.16,0.0,0.0,0.02,brenda vander mey,,SOC-2050,2016
+SOC,3020,1,Research Methods I,0.19,0.32,0.38,0.11,0.0,0.0,0.0,0.0,andrew whitehead,,SOC-3020,2016
+SOC,3040,1,Social Research Methods II,0.37,0.26,0.26,0.05,0.05,0.0,0.0,0.0,ye luo,,SOC-3040,2016
+SOC,3110,1,The Family,0.33,0.29,0.25,0.06,0.02,0.0,0.0,0.04,traci ann hefner,,SOC-3110,2016
+SOC,3800,1,Intro Social Service,0.57,0.34,0.06,0.02,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-3800,2016
+SOC,3880,1,Criminal Justice,0.19,0.25,0.27,0.21,0.06,0.0,0.0,0.02,margaret tina britz,,SOC-3880,2016
+SOC,3890,1,Criminology,0.41,0.26,0.13,0.09,0.0,0.0,0.0,0.11,william white,,SOC-3890,2016
+SOC,3910,1,Soc of Deviance,0.39,0.24,0.2,0.05,0.05,0.0,0.0,0.07,william white,,SOC-3910,2016
+SOC,3920,1,Juvenile Delinquency,0.28,0.37,0.28,0.0,0.05,0.0,0.0,0.02,william white,,SOC-3920,2016
+SOC,3970,1,Substance Abuse,0.56,0.27,0.08,0.02,0.04,0.0,0.0,0.02,shannon mcdonough,,SOC-3970,2016
+SOC,4040,1,Soc Theory,0.47,0.22,0.2,0.09,0.0,0.0,0.0,0.02,william wentworth,,SOC-4040,2016
+SOC,4320,1,Soc of Religion,0.33,0.33,0.2,0.1,0.03,0.0,0.0,0.0,andrew whitehead,,SOC-4320,2016
+SOC,4330,1,Global Social Change,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,william haller,,SOC-4330,2016
+SOC,4590,1,The Community,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,,SOC-4590,2016
+SOC,4600,1,Race & Ethnicity,0.35,0.46,0.15,0.04,0.0,0.0,0.0,0.0,brenda vander mey,,SOC-4600,2016
+SOC,4610,1,Sex & Gender,0.24,0.29,0.29,0.05,0.05,0.0,0.0,0.08,rachael chatterson,,SOC-4610,2016
+SOC,4840,1,Child Abuse,0.6,0.19,0.17,0.04,0.0,0.0,0.0,0.0,douglas sturkie,,SOC-4840,2016
+SOC,4860,4,Creative Inquiry: Sociology,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,margaret tina britz,,SOC-4860,2016
+SOC,4860,5,Creative Inquiry in Sociology,0.65,0.12,0.06,0.0,0.18,0.0,0.0,0.0,margaret tina britz,,SOC-4860,2016
+SOC,4930,1,Soc of Corrections,0.5,0.29,0.14,0.0,0.07,0.0,0.0,0.0,william white,,SOC-4930,2016
+SOC,4940,1,Organized Crimes,0.27,0.17,0.43,0.07,0.0,0.0,0.0,0.07,margaret tina britz,,SOC-4940,2016
+SOC,4950,1,Field Experience,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-4950,2016
+SOC,4970,1,Senior Lab,0.45,0.27,0.09,0.09,0.09,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2016
+SOC,4970,2,Senior Lab,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2016
+SOC,4990,1,Sel Top Seminar in Contemp Soc,0.57,0.29,0.07,0.07,0.0,0.0,0.0,0.0,david williams,,SOC-4990,2016
+SPAN,1010,1,Elementary Spanish,0.39,0.28,0.28,0.0,0.0,0.0,0.0,0.06,scott harris,,SPAN-1010,2016
+SPAN,1010,2,Elementary Spanish,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2016
+SPAN,1020,1,Elementary Spanish,0.35,0.12,0.24,0.18,0.0,0.0,0.0,0.12,roger simpson,,SPAN-1020,2016
+SPAN,1020,2,Elementary Spanish,0.42,0.26,0.11,0.11,0.0,0.0,0.0,0.11,roger simpson,,SPAN-1020,2016
+SPAN,1020,3,Elementary Spanish,0.32,0.37,0.21,0.0,0.05,0.0,0.0,0.05,roger simpson,,SPAN-1020,2016
+SPAN,1020,4,Elementary Spanish,0.5,0.28,0.11,0.0,0.06,0.0,0.0,0.06,roger simpson,,SPAN-1020,2016
+SPAN,1020,5,Elementary Spanish,0.35,0.29,0.12,0.06,0.12,0.0,0.0,0.06,roger simpson,,SPAN-1020,2016
+SPAN,1020,6,Elementary Spanish,0.25,0.25,0.13,0.19,0.13,0.0,0.0,0.06,cathy robison,,SPAN-1020,2016
+SPAN,1020,7,Elementary Spanish,0.32,0.21,0.26,0.0,0.11,0.0,0.0,0.11,cathy robison,,SPAN-1020,2016
+SPAN,1020,8,Elementary Spanish,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,ana paula  miller,,SPAN-1020,2016
+SPAN,1020,9,Elementary Spanish,0.39,0.33,0.06,0.06,0.11,0.0,0.0,0.06,ana paula  miller,,SPAN-1020,2016
+SPAN,1020,10,Elementary Spanish,0.42,0.17,0.33,0.0,0.0,0.0,0.0,0.08,debra oa williamson,,SPAN-1020,2016
+SPAN,1020,11,Elementary Spanish,0.26,0.26,0.21,0.16,0.0,0.0,0.0,0.11,debra oa williamson,,SPAN-1020,2016
+SPAN,2010,1,Intermediate Spanish,0.44,0.28,0.17,0.11,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2016
+SPAN,2010,2,Intermediate Spanish,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,cathy robison,,SPAN-2010,2016
+SPAN,2010,3,Intermediate Spanish,0.47,0.16,0.26,0.05,0.05,0.0,0.0,0.0,allison ann hinds,,SPAN-2010,2016
+SPAN,2010,4,Intermediate Spanish,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,allison ann hinds,,SPAN-2010,2016
+SPAN,2010,5,Intermediate Spanish,0.33,0.53,0.07,0.07,0.0,0.0,0.0,0.0,allison ann hinds,,SPAN-2010,2016
+SPAN,2010,6,Intermediate Spanish,0.29,0.29,0.19,0.1,0.1,0.0,0.0,0.05,ricardo tremolada,,SPAN-2010,2016
+SPAN,2010,7,Intermediate Spanish,0.65,0.15,0.05,0.0,0.0,0.0,0.0,0.15,ricardo tremolada,,SPAN-2010,2016
+SPAN,2010,8,Intermediate Spanish,0.69,0.13,0.13,0.06,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2010,2016
+SPAN,2010,9,Intermediate Spanish,0.64,0.09,0.09,0.0,0.0,0.0,0.0,0.18,ze cruz valderramos,,SPAN-2010,2016
+SPAN,2010,10,Intermediate Spanish,0.47,0.26,0.11,0.0,0.0,0.0,0.0,0.16,ricardo tremolada,,SPAN-2010,2016
+SPAN,2010,11,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2010,2016
+SPAN,2010,12,Intermediate Spanish,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,debra oa williamson,,SPAN-2010,2016
+SPAN,2010,13,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2010,2016
+SPAN,2010,14,Intermediate Spanish,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2010,2016
+SPAN,2010,15,Intermediate Spanish,0.19,0.63,0.13,0.0,0.0,0.0,0.0,0.06,debra oa williamson,,SPAN-2010,2016
+SPAN,2020,1,Intermediate Spanish,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,melva margu persico,,SPAN-2020,2016
+SPAN,2020,2,Intermediate Spanish,0.18,0.47,0.18,0.06,0.06,0.0,0.0,0.06,melva margu persico,,SPAN-2020,2016
+SPAN,2020,3,Intermediate Spanish,0.5,0.25,0.1,0.1,0.0,0.0,0.0,0.05,juana martin-armas,,SPAN-2020,2016
+SPAN,2020,4,Intermediate Spanish,0.5,0.22,0.17,0.06,0.06,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2016
+SPAN,2020,5,Intermediate Spanish,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2016
+SPAN,2020,6,Intermediate Spanish,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2016
+SPAN,2020,7,Intermediate Spanish,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2016
+SPAN,2020,8,Intermediate Spanish,0.22,0.39,0.28,0.06,0.0,0.0,0.0,0.06,heidi montes,,SPAN-2020,2016
+SPAN,2020,9,Intermediate Spanish,0.41,0.35,0.06,0.12,0.0,0.0,0.0,0.06,heidi montes,,SPAN-2020,2016
+SPAN,2020,10,Intermediate Spanish,0.5,0.22,0.22,0.06,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2020,2016
+SPAN,2020,11,Intermediate Spanish,0.45,0.3,0.2,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2016
+SPAN,2020,12,Intermediate Spanish,0.18,0.5,0.32,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,,SPAN-2020,2016
+SPAN,2020,13,Intermediate Spanish,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2016
+SPAN,2020,14,Intermediate Spanish,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2016
+SPAN,2020,19,Intermediate Spanish,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,,SPAN-2020,2016
+SPAN,3020,1,Int Spn Gram & Comp,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,george palacios,,SPAN-3020,2016
+SPAN,3020,2,Int Spn Gram & Comp,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,,SPAN-3020,2016
+SPAN,3020,3,Int Spn Gram & Comp,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,,SPAN-3020,2016
+SPAN,3040,1,Intro Hisp Lit Forms,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,,SPAN-3040,2016
+SPAN,3050,1,Int Con Comp Span I,0.31,0.44,0.13,0.06,0.0,0.0,0.0,0.06,raquel anido,,SPAN-3050,2016
+SPAN,3050,2,Int Con Comp Span I,0.22,0.61,0.06,0.0,0.0,0.0,0.0,0.11,raquel anido,,SPAN-3050,2016
+SPAN,3050,3,Int Con Comp Span I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-3050,2016
+SPAN,3060,1,Span Comp for Bus,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-3060,2016
+SPAN,3070,1,Hispanic World: Sp,0.29,0.18,0.06,0.06,0.06,0.0,0.0,0.35,juana martin-armas,,SPAN-3070,2016
+SPAN,3080,1,Hispanic World: La,0.63,0.13,0.13,0.0,0.06,0.0,0.0,0.06,tiffany dawn miller,,SPAN-3080,2016
+SPAN,3080,2,Hispanic World: La,0.63,0.19,0.13,0.06,0.0,0.0,0.0,0.0,tiffany dawn miller,,SPAN-3080,2016
+SPAN,3130,1,Span Lit Survey I,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,juana martin-armas,,SPAN-3130,2016
+SPAN,3140,1,Hispanic Linguistics,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,daniel smith,,SPAN-3140,2016
+SPAN,3160,1,Span for Intl Trade,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,maureen zamora,,SPAN-3160,2016
+SPAN,4050,1,Int Trade Film & Lit,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-4050,2016
+SPAN,4060,2,Narrative Fiction,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,,SPAN-4060,2016
+SPAN,4070,1,Hispanic Film,0.42,0.11,0.11,0.16,0.0,0.0,0.0,0.21,raquel anido,,SPAN-4070,2016
+SPAN,4150,1,Span for Health Prof,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-4150,2016
+SPAN,4150,35,Span for Health Prof,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-4150,2016
+SPAN,4170,1,Prof Communication,0.62,0.15,0.23,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-4170,2016
+SPAN,4180,1,Tech Span Health Man,0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,ricardo tremolada,,SPAN-4180,2016
+SPAN,4350,35,Contemp Hisp Cult,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-4350,2016
+STAT,2220,1,Statistics in Everyday Life,0.35,0.39,0.13,0.06,0.04,0.0,0.0,0.04,ros martinez-dawson,,STAT-2220,2016
+STAT,2220,2,Statistics in Everyday Life,0.43,0.31,0.09,0.09,0.02,0.0,0.0,0.06,ros martinez-dawson,,STAT-2220,2016
+STAT,2220,3,Statistics in Everyday Life,0.57,0.33,0.07,0.0,0.02,0.0,0.0,0.0,gary fellers,,STAT-2220,2016
+STAT,2220,4,Statistics in Everyday Life,0.7,0.2,0.06,0.0,0.02,0.0,0.0,0.02,gary fellers,,STAT-2220,2016
+STAT,2220,5,Statistics in Everyday Life,0.61,0.24,0.09,0.02,0.02,0.0,0.0,0.02,gary fellers,,STAT-2220,2016
+STAT,2220,6,Statistics in Everyday Life,0.54,0.37,0.07,0.0,0.0,0.0,0.0,0.02,gary fellers,,STAT-2220,2016
+STAT,2300,1,Statistical Methods I,0.46,0.26,0.15,0.03,0.1,0.0,0.0,0.0,christy jenki brown,,STAT-2300,2016
+STAT,2300,2,Statistical Methods I,0.37,0.27,0.19,0.08,0.08,0.0,0.0,0.03,christy jenki brown,,STAT-2300,2016
+STAT,2300,3,Statistical Methods I,0.43,0.28,0.16,0.08,0.05,0.0,0.0,0.01,christy jenki brown,,STAT-2300,2016
+STAT,2300,4,Statistical Methods I,0.37,0.35,0.1,0.1,0.04,0.0,0.0,0.04,benjamin sharp,,STAT-2300,2016
+STAT,2300,5,Statistical Methods I,0.28,0.35,0.16,0.11,0.08,0.0,0.0,0.03,brook thaye russell,,STAT-2300,2016
+STAT,2300,6,Statistical Methods I,0.3,0.41,0.19,0.03,0.08,0.0,0.0,0.0, erwin walker,,STAT-2300,2016
+STAT,2300,7,Statistical Methods I,0.13,0.38,0.25,0.14,0.06,0.0,0.0,0.05, erwin walker,,STAT-2300,2016
+STAT,2300,8,Statistical Methods I,0.2,0.36,0.21,0.11,0.12,0.0,0.0,0.0, erwin walker,,STAT-2300,2016
+STAT,3090,1,Introductory Business Stats,0.02,0.29,0.32,0.17,0.1,0.0,0.0,0.1,elaine ma sotherden,,STAT-3090,2016
+STAT,3090,2,Introductory Business Stats,0.18,0.29,0.16,0.16,0.11,0.0,0.0,0.11,james espey,,STAT-3090,2016
+STAT,3090,3,Introductory Business Stats,0.24,0.26,0.12,0.06,0.15,0.0,0.0,0.18,paul james cubre,,STAT-3090,2016
+STAT,3090,4,Introductory Business Stats,0.1,0.32,0.37,0.1,0.07,0.0,0.0,0.05,james espey,,STAT-3090,2016
+STAT,3090,5,Introductory Business Stats,0.14,0.33,0.26,0.0,0.21,0.0,0.0,0.05,paul james cubre,,STAT-3090,2016
+STAT,3090,6,Introductory Business Stats,0.26,0.29,0.23,0.11,0.06,0.0,0.0,0.06,audrey nico devries,,STAT-3090,2016
+STAT,3090,7,Introductory Business Stats,0.13,0.18,0.23,0.13,0.2,0.0,0.0,0.15,drew jared lipman,,STAT-3090,2016
+STAT,3090,8,Introductory Business Stats,0.15,0.51,0.15,0.02,0.12,0.0,0.0,0.05,margaret mar wiecek,,STAT-3090,2016
+STAT,3090,9,Introductory Business Stats,0.27,0.41,0.22,0.02,0.07,0.0,0.0,0.0,james espey,,STAT-3090,2016
+STAT,3090,10,Introductory Business Stats,0.2,0.37,0.2,0.07,0.1,0.0,0.0,0.07,james espey,,STAT-3090,2016
+STAT,3090,11,Introductory Business Stats,0.2,0.23,0.33,0.08,0.15,0.0,0.0,0.03,elaine ma sotherden,,STAT-3090,2016
+STAT,3090,12,Introductory Business Stats,0.08,0.38,0.18,0.13,0.2,0.0,0.0,0.05,christopher wilson,,STAT-3090,2016
+STAT,3090,13,Introductory Business Stats,0.17,0.29,0.17,0.15,0.12,0.0,0.0,0.1,audrey nico devries,,STAT-3090,2016
+STAT,3300,1,Statistical Methods II,0.31,0.42,0.08,0.04,0.08,0.0,0.0,0.08,ros martinez-dawson,,STAT-3300,2016
+STAT,4020,1,Intro to Statistical Computing,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-4020,2016
+STAT,4110,1,Stat Mthds for Process Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,,STAT-4110,2016
+STAT,4110,2,Stat Mthds for Process Control,0.24,0.52,0.03,0.03,0.06,0.0,0.0,0.12,james rieck,,STAT-4110,2016
+STAT,8010,1,Statistical Methods I,0.68,0.19,0.13,0.0,0.0,0.0,0.0,0.0,james rieck,,STAT-8010,2016
+STAT,8010,2,Statistical Methods I,0.48,0.39,0.03,0.0,0.0,0.0,0.0,0.09,patrick gerard,,STAT-8010,2016
+STAT,8010,3,Statistical Methods I,0.57,0.25,0.04,0.0,0.0,0.0,0.0,0.14,jun luo,,STAT-8010,2016
+STAT,8040,1,Sampling,0.35,0.41,0.0,0.0,0.0,0.0,0.0,0.24,patrick gerard,,STAT-8040,2016
+STAT,8050,1,Design & Anlys of Experiments,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-8050,2016
+STAT,8420,230,Intro to Statistical Methods,0.22,0.5,0.11,0.0,0.06,0.0,0.0,0.11,julia lynn sharp,,STAT-8420,2016
+STS,1010,1,Survey of S T S,0.44,0.41,0.09,0.0,0.0,0.0,0.0,0.06,allison ann hinds,,STS-1010,2016
+STS,1010,2,Survey of S T S,0.29,0.49,0.09,0.0,0.06,0.0,0.0,0.09,scott brame,,STS-1010,2016
+STS,1010,3,Survey of S T S,0.44,0.28,0.19,0.03,0.03,0.0,0.0,0.03,elizabeth stansell,,STS-1010,2016
+STS,1010,4,Survey of S T S,0.59,0.34,0.03,0.03,0.0,0.0,0.0,0.0,sarah mae cooper,,STS-1010,2016
+STS,1010,5,Survey of S T S,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,philip randall,,STS-1010,2016
+STS,1010,6,Survey of S T S,0.74,0.11,0.11,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,,STS-1010,2016
+STS,1010,7,Survey of S T S,0.27,0.46,0.11,0.05,0.03,0.0,0.0,0.08,megan no macalystre,,STS-1010,2016
+STS,1010,8,Survey of S T S,0.23,0.4,0.1,0.1,0.03,0.0,0.0,0.13,david charles foltz,,STS-1010,2016
+THEA,2100,1,Theatre Appreciation,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,richard st. peter,,THEA-2100,2016
+THEA,2100,2,Theatre Appreciation,0.87,0.0,0.07,0.0,0.03,0.0,0.0,0.03,kerrie kath seymour,,THEA-2100,2016
+THEA,2100,3,Theatre Appreciation,0.76,0.14,0.03,0.03,0.03,0.0,0.0,0.0,kendra lyne johnson,,THEA-2100,2016
+THEA,2100,4,Theatre Appreciation,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-2100,2016
+THEA,2100,5,Theatre Appreciation,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,,THEA-2100,2016
+THEA,2100,6,Theatre Appreciation,0.63,0.34,0.0,0.0,0.0,0.0,0.0,0.03,jason adkins,,THEA-2100,2016
+THEA,2670,1,Stage Makeup,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,shannon ther robert,,THEA-2670,2016
+THEA,2790,1,Theatre Practicum,0.79,0.0,0.0,0.0,0.14,0.0,0.0,0.07,matthew leckenbusch,,THEA-2790,2016
+THEA,3160,1,Theatre History II,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,richard st. peter,,THEA-3160,2016
+THEA,3180,1,Afri-Amer Thea II,0.61,0.23,0.13,0.0,0.03,0.0,0.0,0.0,kendra lyne johnson,,THEA-3180,2016
+THEA,4790,1,Acting II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,,THEA-4790,2016
+THEA,6870,1,Stage Lighting I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,,THEA-6870,2016
+WFB,3010,1,Wildlife Biology Lab,0.46,0.23,0.31,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2016
+WFB,3010,2,Wildlife Biology Lab,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,,WFB-3010,2016
+WFB,3130,1,Conservation Biology,0.26,0.38,0.29,0.07,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3130,2016
+WFB,3130,2,Conservation Biology,0.32,0.3,0.26,0.06,0.04,0.0,0.0,0.02,shari lyn rodriguez,,WFB-3130,2016
+WFB,3500,1,Princ Fish & Wildlife Biology,0.3,0.43,0.17,0.04,0.04,0.0,0.0,0.04,james davis,,WFB-3500,2016
+WFB,3500,2,Princ Fish & Wildlife Biology,0.21,0.41,0.26,0.06,0.03,0.0,0.0,0.03,james davis,,WFB-3500,2016
+WFB,4160,1,Fishery Biology,0.21,0.47,0.23,0.04,0.0,0.0,0.0,0.04,yoichiro kanno,,WFB-4160,2016
+WFB,4300,1,Wildlife Conservation Policy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,joseph lanham,,WFB-4300,2016
+WFB,4620,1,Wetland Wildlife Biology,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,russell barrett,,WFB-4620,2016
+WFB,4930,2,Quantitative Ecology,0.37,0.37,0.16,0.02,0.02,0.0,0.0,0.06,david sco jachowski,,WFB-4930,2016
+WS,1030,1,Women in Global Perspective,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,,WS-1030,2016
+WS,1030,2,Women in Global Perspective,0.61,0.19,0.08,0.0,0.06,0.0,0.0,0.06,saadiqa kumanyika,,WS-1030,2016
+WS,3010,1,Intro Women's Studies,0.56,0.31,0.08,0.0,0.06,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2016
+WS,3010,2,Intro Women's Studies,0.41,0.5,0.06,0.0,0.0,0.0,0.0,0.03,elizabeth ros adams,,WS-3010,2016
+YDP,3100,400,Youth Developmt and the Family,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,william quinn,,YDP-3100,2016
+YDP,3300,1,Designing Effective Youth Prog,0.7,0.17,0.04,0.0,0.09,0.0,0.0,0.0,kellye rembert,,YDP-3300,2016
+YDP,3350,1,Youth Activity Leadership,0.57,0.17,0.04,0.09,0.13,0.0,0.0,0.0,ryan joseph gagnon,,YDP-3350,2016

--- a/bot/cogs/grades_cog/assets/2016_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2016_Spring.csv
@@ -1,2412 +1,2412 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1020,1,Survey of Art & Arch Hist II,0.91,0.07,0.01,0.0,0.0,0.0,0.0,0.01,andrea feeser,AAH-1020,2016
-AAH,2060,1,Art History and Theory II,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,andrea feeser,AAH-2060,2016
-AAH,6320,1,Twentieth Century Art II,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,beth ann lauritis,AAH-6320,2016
-ACCT,2010,1,Financial Accounting Concepts,0.19,0.3,0.32,0.06,0.09,0.0,0.0,0.04,lydia lan schleifer,ACCT-2010,2016
-ACCT,2010,2,Financial Accounting Concepts,0.35,0.39,0.14,0.03,0.08,0.0,0.0,0.01,holly rhiannio hawk,ACCT-2010,2016
-ACCT,2010,3,Financial Accounting Concepts,0.19,0.24,0.21,0.14,0.1,0.0,0.0,0.12,philip maiberger,ACCT-2010,2016
-ACCT,2010,4,Financial Accounting Concepts,0.25,0.24,0.28,0.08,0.06,0.0,0.0,0.08,holly rhiannio hawk,ACCT-2010,2016
-ACCT,2010,5,Financial Accounting Concepts,0.3,0.3,0.25,0.05,0.05,0.0,0.0,0.05,lydia lan schleifer,ACCT-2010,2016
-ACCT,2010,6,Financial Accounting Concepts,0.26,0.26,0.24,0.05,0.07,0.0,0.0,0.12,lydia lan schleifer,ACCT-2010,2016
-ACCT,2010,7,Financial Accounting Concepts,0.11,0.25,0.25,0.07,0.21,0.0,0.0,0.12,tonya dionne smalls,ACCT-2010,2016
-ACCT,2010,8,Financial Accounting Concepts,0.35,0.3,0.09,0.07,0.05,0.0,0.0,0.14,mary ann  prater,ACCT-2010,2016
-ACCT,2010,9,Financial Accounting Concepts,0.15,0.27,0.31,0.07,0.02,0.0,0.0,0.18,henry anderson,ACCT-2010,2016
-ACCT,2010,10,Financial Accounting Concepts,0.27,0.32,0.02,0.07,0.05,0.0,0.0,0.27,mary ann  prater,ACCT-2010,2016
-ACCT,2010,11,Financial Accounting Concepts,0.11,0.11,0.32,0.11,0.25,0.0,0.0,0.09,henry anderson,ACCT-2010,2016
-ACCT,2010,12,Financial Accounting Concepts,0.14,0.37,0.19,0.11,0.14,0.0,0.0,0.05,tonya dionne smalls,ACCT-2010,2016
-ACCT,2010,401,Financial Accounting Concepts,0.14,0.43,0.24,0.08,0.04,0.0,0.0,0.07,jeffrey mcmillan,ACCT-2010,2016
-ACCT,2020,1,Managerial Accounting Concepts,0.26,0.34,0.17,0.08,0.06,0.0,0.0,0.09,henry anderson,ACCT-2020,2016
-ACCT,2020,2,Managerial Accounting Concepts,0.18,0.39,0.23,0.09,0.02,0.0,0.0,0.09,henry anderson,ACCT-2020,2016
-ACCT,2020,3,Managerial Accounting Concepts,0.37,0.24,0.18,0.06,0.08,0.0,0.0,0.06,jace garrett,ACCT-2020,2016
-ACCT,2020,4,Managerial Accounting Concepts,0.31,0.31,0.19,0.08,0.05,0.0,0.0,0.06,jace garrett,ACCT-2020,2016
-ACCT,2020,5,Managerial Accounting Concepts,0.32,0.29,0.19,0.14,0.0,0.0,0.0,0.07,derek dalton,ACCT-2020,2016
-ACCT,2020,401,Managerial Accounting Concepts,0.26,0.21,0.2,0.08,0.1,0.0,0.0,0.16,henry anderson,ACCT-2020,2016
-ACCT,3030,1,Cost Accounting,0.22,0.59,0.1,0.0,0.02,0.0,0.0,0.08,robin radtke,ACCT-3030,2016
-ACCT,3030,2,Cost Accounting,0.43,0.28,0.17,0.02,0.02,0.0,0.0,0.09,robin radtke,ACCT-3030,2016
-ACCT,3030,3,Cost Accounting,0.43,0.33,0.04,0.06,0.02,0.0,0.0,0.12,robin radtke,ACCT-3030,2016
-ACCT,3030,5,Cost Accounting,0.15,0.23,0.23,0.08,0.08,0.0,0.0,0.23,tonya dionne smalls,ACCT-3030,2016
-ACCT,3110,1,Intermediate Financial Acct I,0.38,0.46,0.08,0.03,0.03,0.0,0.0,0.03,terry daniel knause,ACCT-3110,2016
-ACCT,3110,2,Intermediate Financial Acct I,0.06,0.12,0.24,0.15,0.15,0.0,0.0,0.29,brian todd carver,ACCT-3110,2016
-ACCT,3110,3,Intermediate Financial Acct I,0.5,0.27,0.14,0.05,0.02,0.0,0.0,0.02,terry daniel knause,ACCT-3110,2016
-ACCT,3110,4,Intermediate Financial Acct I,0.28,0.37,0.22,0.02,0.04,0.02,0.0,0.04,terry daniel knause,ACCT-3110,2016
-ACCT,3110,5,Intermediate Financial Acct I,0.5,0.25,0.16,0.09,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3110,2016
-ACCT,3120,1,Intermediate Financial Acct II,0.16,0.32,0.26,0.18,0.08,0.0,0.0,0.0,the estate  guffey,ACCT-3120,2016
-ACCT,3120,2,Intermediate Financial Acct II,0.11,0.23,0.4,0.14,0.06,0.0,0.0,0.06,the estate  guffey,ACCT-3120,2016
-ACCT,3120,3,Intermediate Financial Acct II,0.03,0.18,0.44,0.21,0.13,0.0,0.0,0.03,brian todd carver,ACCT-3120,2016
-ACCT,3120,4,Intermediate Financial Acct II,0.03,0.17,0.33,0.23,0.17,0.0,0.0,0.07,brian todd carver,ACCT-3120,2016
-ACCT,3120,5,Intermediate Financial Acct II,0.24,0.36,0.31,0.04,0.05,0.0,0.0,0.0,jeremy micha vinson,ACCT-3120,2016
-ACCT,3130,1,Intermediate Fin Acct III,0.11,0.4,0.2,0.14,0.03,0.0,0.0,0.11, russell madray,ACCT-3130,2016
-ACCT,3130,2,Intermediate Fin Acct III,0.26,0.45,0.21,0.08,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2016
-ACCT,3130,3,Intermediate Fin Acct III,0.38,0.38,0.19,0.03,0.03,0.0,0.0,0.0, russell madray,ACCT-3130,2016
-ACCT,3130,4,Intermediate Fin Acct III,0.33,0.36,0.26,0.05,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2016
-ACCT,3220,1,Accounting Information Systems,0.1,0.41,0.29,0.07,0.05,0.0,0.0,0.07,philip maiberger,ACCT-3220,2016
-ACCT,3220,2,Accounting Information Systems,0.21,0.48,0.17,0.05,0.0,0.0,0.0,0.1,philip maiberger,ACCT-3220,2016
-ACCT,3220,3,Accounting Information Systems,0.14,0.25,0.25,0.07,0.0,0.0,0.0,0.29,philip maiberger,ACCT-3220,2016
-ACCT,4040,1,Individual Taxation,0.69,0.16,0.1,0.05,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2016
-ACCT,4040,2,Individual Taxation,0.71,0.23,0.04,0.02,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2016
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.34,0.63,0.03,0.0,0.0,0.0,0.0,0.0,holly rhiannio hawk,ACCT-4100,2016
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,holly rhiannio hawk,ACCT-4100,2016
-ACCT,4150,1,Auditing,0.26,0.38,0.31,0.05,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-4150,2016
-ACCT,4150,2,Auditing,0.24,0.3,0.3,0.12,0.0,0.0,0.0,0.03,nancy lee harp,ACCT-4150,2016
-ACCT,8520,1,Fin Acct Theory/Res,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8520,2016
-ACCT,8520,2,Fin Acct Theory/Res,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8520,2016
-ACCT,8520,3,Fin Acct Theory/Res,0.2,0.63,0.17,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8520,2016
-ACCT,8540,1,Prof Responsibility,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2016
-ACCT,8540,2,Prof Responsibility,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2016
-ACCT,8540,3,Prof Responsibility,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2016
-ACCT,8710,1,Corporate Taxation,0.16,0.76,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2016
-ACCT,8710,2,Corporate Taxation,0.3,0.65,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2016
-ACCT,8710,3,Corporate Taxation,0.31,0.67,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2016
-AGED,1000,1,Orientation & Field Experience,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,philip fravel,AGED-1000,2016
-AGED,2030,1,Teaching Agriscience,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,catheri dibenedetto,AGED-2030,2016
-AGED,4160,1,Ethics and Issues,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,thomas dobbins,AGED-4160,2016
-AGED,4250,1,Teaching Ag Mechs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-4250,2016
-AGM,2050,1,Prin of Fabrication,0.12,0.53,0.22,0.08,0.02,0.0,0.0,0.03,hunter massey,AGM-2050,2016
-AGM,2060,1,Machinery Mgt,0.08,0.32,0.41,0.08,0.05,0.0,0.0,0.05,hunter massey,AGM-2060,2016
-AGM,2210,1,Land Measurements,0.17,0.52,0.26,0.0,0.04,0.0,0.0,0.0,charles privette,AGM-2210,2016
-AGM,3030,1,Cal for Mech Ag,0.37,0.42,0.22,0.0,0.0,0.0,0.0,0.0,young han,AGM-3030,2016
-AGM,4020,1,Landscape Drainage and Irrig,0.16,0.49,0.26,0.07,0.02,0.0,0.0,0.0,charles privette,AGM-4020,2016
-AGM,4100,1,Precision Ag Tech,0.24,0.58,0.13,0.02,0.02,0.0,0.0,0.0,hunter massey,AGM-4100,2016
-AGM,4520,1,Mobile Power,0.45,0.29,0.21,0.02,0.02,0.0,0.0,0.0,ali bulent koc,AGM-4520,2016
-AGM,4720,1,Capstone,0.18,0.5,0.3,0.02,0.0,0.0,0.0,0.0,john chastain,AGM-4720,2016
-AGRB,2020,1,Agricultural Economics,0.75,0.14,0.03,0.03,0.05,0.0,0.0,0.0,yuliya val bolotova,AGRB-2020,2016
-AGRB,2050,1,Agriculture and Society,0.46,0.34,0.16,0.02,0.0,0.0,0.0,0.02,lisha zhang,AGRB-2050,2016
-AGRB,3190,1,Agribusiness Management,0.3,0.3,0.24,0.14,0.02,0.0,0.0,0.0,michael vassalos,AGRB-3190,2016
-AGRB,3570,1,Natural Resources Economics,0.31,0.15,0.33,0.13,0.04,0.0,0.0,0.04,david brian willis,AGRB-3570,2016
-AGRB,4020,1,Production Economics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,michael vassalos,AGRB-4020,2016
-AGRB,4080,1,Quantitative Applied Economics,0.21,0.18,0.42,0.11,0.05,0.0,0.0,0.03,lisha zhang,AGRB-4080,2016
-AGRB,4520,1,Agricultural Policy,0.35,0.26,0.28,0.09,0.0,0.0,0.0,0.02,michael vassalos,AGRB-4520,2016
-AGRB,4560,1,Prices,0.47,0.38,0.16,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,AGRB-4560,2016
-AL,3490,400,Principles of Coaching,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2016
-AL,3490,401,Principles of Coaching,0.44,0.16,0.28,0.04,0.08,0.0,0.0,0.0,deborah cadorette,AL-3490,2016
-AL,3490,402,Principles of Coaching,0.72,0.2,0.04,0.04,0.0,0.0,0.0,0.0,julia wright,AL-3490,2016
-AL,3490,405,Principles of Coaching,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,edmond fry,AL-3490,2016
-AL,3500,400,Sci Basis I/Ex Phy,0.24,0.2,0.36,0.08,0.04,0.0,0.0,0.08,michael godfrey,AL-3500,2016
-AL,3500,401,Sci Basis I/Ex Phy,0.26,0.35,0.17,0.09,0.04,0.0,0.0,0.09,michael godfrey,AL-3500,2016
-AL,3520,400,Kinesiology,0.4,0.47,0.07,0.07,0.0,0.0,0.0,0.0,michael godfrey,AL-3520,2016
-AL,3530,400,Athletic Injuries,0.21,0.25,0.33,0.08,0.08,0.0,0.0,0.04,isaac sean colbert,AL-3530,2016
-AL,3530,401,Athletic Injuries,0.27,0.27,0.27,0.15,0.04,0.0,0.0,0.0,isaac sean colbert,AL-3530,2016
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.29,0.33,0.17,0.13,0.04,0.0,0.0,0.04,clyde keith connor,AL-3600,2016
-AL,3610,400,Admin/Org of Athletic Programs,0.77,0.09,0.05,0.09,0.0,0.0,0.0,0.0,henry oates,AL-3610,2016
-AL,3610,402,Admin/Org of Athletic Programs,0.72,0.12,0.16,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2016
-AL,3610,403,Admin/Org of Athletic Programs,0.39,0.43,0.09,0.04,0.04,0.0,0.0,0.0,john plumblee,AL-3610,2016
-AL,3620,400,Psychology of Coaching,0.38,0.33,0.21,0.04,0.04,0.0,0.0,0.0,natalie anne carter,AL-3620,2016
-AL,3620,401,Psychology of Coaching,0.27,0.42,0.12,0.12,0.04,0.0,0.0,0.04,natalie anne carter,AL-3620,2016
-AL,3620,402,Psychology of Coaching,0.2,0.4,0.24,0.04,0.08,0.0,0.0,0.04,natalie anne carter,AL-3620,2016
-AL,3720,400,Coaching Basketball,0.62,0.15,0.12,0.08,0.0,0.0,0.0,0.04,edmond fry,AL-3720,2016
-AL,3740,400,Coaching Football,0.71,0.08,0.13,0.04,0.04,0.0,0.0,0.0,edmond fry,AL-3740,2016
-AL,3760,400,Coaching Strength/Conditioning,0.68,0.12,0.16,0.0,0.0,0.0,0.0,0.04,edmond fry,AL-3760,2016
-AL,4380,400,Coaching Women,0.52,0.33,0.05,0.1,0.0,0.0,0.0,0.0,deborah cadorette,AL-4380,2016
-AL,4380,410,Coaching Rugby,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,deborah cadorette,AL-4380,2016
-AL,8530,400,Legal Iss in Intercoll Athlet,0.79,0.08,0.04,0.0,0.08,0.0,0.0,0.0,michael godfrey,AL-8530,2016
-ANTH,2010,1,Introduction to Anthropology,0.06,0.17,0.32,0.17,0.1,0.0,0.0,0.17,john coggeshall,ANTH-2010,2016
-ANTH,2010,2,Introduction to Anthropology,0.15,0.57,0.19,0.06,0.0,0.0,0.0,0.02,yi wu,ANTH-2010,2016
-ANTH,2010,3,Introduction to Anthropology,0.24,0.48,0.2,0.07,0.0,0.0,0.0,0.02,yi wu,ANTH-2010,2016
-ANTH,3200,1,North American Indian Cultures,0.13,0.38,0.25,0.0,0.06,0.0,0.0,0.19,john coggeshall,ANTH-3200,2016
-ANTH,3310,1,Archaeology,0.33,0.38,0.19,0.05,0.0,0.0,0.0,0.05,melissa vogel,ANTH-3310,2016
-ANTH,3510,1,Biological Anthropology,0.21,0.42,0.21,0.05,0.11,0.0,0.0,0.0,lisa rapaport,ANTH-3510,2016
-ANTH,3530,1,Forensic Anthropology,0.29,0.38,0.21,0.08,0.0,0.0,0.0,0.04,katherine weisensee,ANTH-3530,2016
-ANTH,4040,1,Anthropological Theories,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,john coggeshall,ANTH-4040,2016
-ANTH,4510,1,Biol Variation in Human Pop,0.47,0.21,0.16,0.0,0.0,0.0,0.0,0.16,katherine weisensee,ANTH-4510,2016
-ANTH,4660,1,Evolution of Human Behav,0.21,0.57,0.07,0.0,0.0,0.0,0.0,0.14,lisa rapaport,ANTH-4660,2016
-APEC,8220,1,Public Policy Econ,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,david brian willis,APEC-8220,2016
-ARCH,1510,1,Arch Communication,0.33,0.27,0.07,0.07,0.13,0.0,0.0,0.13,sal hambright-belue,ARCH-1510,2016
-ARCH,1510,2,Arch Communication,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,robert silance,ARCH-1510,2016
-ARCH,1510,3,Arch Communication,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-1510,2016
-ARCH,1510,4,Arch Communication,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,ladan omidvar,ARCH-1510,2016
-ARCH,1510,5,Arch Communication,0.36,0.43,0.07,0.14,0.0,0.0,0.0,0.0,sal hambright-belue,ARCH-1510,2016
-ARCH,2520,1,Arch Foundations II,0.38,0.38,0.15,0.08,0.0,0.0,0.0,0.0,david lee,ARCH-2520,2016
-ARCH,2520,2,Arch Foundations II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-2520,2016
-ARCH,2520,3,Arch Foundations II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2520,2016
-ARCH,2520,4,Arch Foundations II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,james barker,ARCH-2520,2016
-ARCH,2520,5,Arch Foundations II,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,ladan omidvar,ARCH-2520,2016
-ARCH,2700,1,Structures I,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,robert john hogan,ARCH-2700,2016
-ARCH,2700,2,Structures I,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,dustin gra albright,ARCH-2700,2016
-ARCH,3530,1,Studio Genoa,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-3530,2016
-ARCH,4010,2,Architectural Portfolio,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,yixiao wang,ARCH-4010,2016
-ARCH,4520,1,Synthesis Studio,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-4520,2016
-ARCH,4520,2,Synthesis Studio,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-4520,2016
-ARCH,4520,3,Synthesis Studio,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-4520,2016
-ARCH,4520,4,Synthesis Studio,0.1,0.6,0.3,0.0,0.0,0.0,0.0,0.0,criss mills,ARCH-4520,2016
-ARCH,4710,1,Arch Hist of Place,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,james thomas,ARCH-4710,2016
-ARCH,4890,1,Internship,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,ashley jennings,ARCH-4890,2016
-ARCH,4990,13,Biomimicry and Biomimetics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,ARCH-4990,2016
-ARCH,6880,1,Arch Programming,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-6880,2016
-ARCH,8110,1,Visualization II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-8110,2016
-ARCH,8120,1,Comp Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-8120,2016
-ARCH,8200,1,Bldg Design & Constr,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,ARCH-8200,2016
-ARCH,8420,1,Arch Studio II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,ARCH-8420,2016
-ARCH,8420,2,Arch Studio II,0.67,0.0,0.33,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-8420,2016
-ARCH,8520,1,Design Studio IV,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,ARCH-8520,2016
-ARCH,8520,3,Design Studio IV,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-8520,2016
-ARCH,8610,1,History/Theory II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-8610,2016
-ARCH,8620,1,History/Theory III,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-8620,2016
-ARCH,8740,1,Building Process:TR,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,ARCH-8740,2016
-ARCH,8740,2,Building Process:TR,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,joseph schott,ARCH-8740,2016
-ARCH,8820,1,Building Economics,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-8820,2016
-ARCH,8900,1,Directed Studies,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,anjali joseph,ARCH-8900,2016
-ARCH,8920,1,Comprehensive Studio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8920,2016
-ARCH,8920,2,Comprehensive Studio,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-8920,2016
-ARCH,8920,3,Comprehensive Studio,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,ARCH-8920,2016
-ARCH,8920,4,Comprehensive Studio,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8920,2016
-ARCH,8960,1,A+H Studio: Tectonic,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-8960,2016
-ART,1060,1,Foundation Drawing II,0.6,0.28,0.12,0.0,0.0,0.0,0.0,0.0,carly drew,ART-1060,2016
-ART,1520,1,Foundations Art II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,ART-1520,2016
-ART,2050,1,Beginning Life Drawing,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,ART-2050,2016
-ART,2070,1,Beginning Painting,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,mary jane king,ART-2070,2016
-ART,2090,1,Beginning Sculpture,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabet cooke,ART-2090,2016
-ART,2100,400,Art Appreciation,0.54,0.32,0.07,0.04,0.0,0.0,0.0,0.04,lydia jane dorsey,ART-2100,2016
-ART,2100,401,Art Appreciation,0.45,0.24,0.1,0.0,0.0,0.0,0.0,0.21,lydia jane dorsey,ART-2100,2016
-ART,2100,402,Art Appreciation,0.57,0.36,0.04,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2016
-ART,2100,403,Art Appreciation,0.29,0.5,0.14,0.04,0.0,0.0,0.0,0.04,lydia jane dorsey,ART-2100,2016
-ART,2110,1,Begin Printmaking,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,todd denni anderson,ART-2110,2016
-ART,2130,1,Begin Photography,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,gregory wi shelnutt,ART-2130,2016
-ART,2170,1,Beginning Ceramics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,en iwamura,ART-2170,2016
-ART,2210,1,Beginning New Media,0.8,0.0,0.13,0.0,0.07,0.0,0.0,0.0,christina nguy hung,ART-2210,2016
-ART,4750,1,Senior Exhibition Internship,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,ART-4750,2016
-AS,1100,1,Air Force Today II,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,christopher mann,AS-1100,2016
-AS,2100,2,Dev of Air Power II,0.5,0.2,0.3,0.0,0.0,0.0,0.0,0.0,christopher mann,AS-2100,2016
-AS,2100,3,Dev of Air Power II,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,AS-2100,2016
-ASL,1010,1,Am Sign Lang I,0.39,0.22,0.33,0.06,0.0,0.0,0.0,0.0,william alton brant,ASL-1010,2016
-ASL,1010,2,Am Sign Lang I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-1010,2016
-ASL,2010,1,Am Sign Lang II,0.43,0.36,0.21,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-2010,2016
-ASL,2020,1,Am Sign Lang II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-2020,2016
-ASL,2020,2,Am Sign Lang II,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,kim ma misener dunn,ASL-2020,2016
-ASL,3050,1,Deaf Studies,0.47,0.21,0.32,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-3050,2016
-ASTR,1010,1,Solar System Astronomy,0.35,0.34,0.11,0.08,0.06,0.0,0.0,0.04,sean brittain,ASTR-1010,2016
-ASTR,1020,1,Stellar Astronomy,0.51,0.31,0.1,0.02,0.04,0.0,0.0,0.02,phillip flower,ASTR-1020,2016
-ASTR,1020,2,Stellar Astronomy,0.35,0.4,0.14,0.03,0.02,0.0,0.0,0.05,phillip flower,ASTR-1020,2016
-ASTR,1020,3,Stellar Astronomy,0.28,0.39,0.22,0.06,0.0,0.0,0.0,0.06,phillip flower,ASTR-1020,2016
-ASTR,1030,1,Solar Systm Astr Lab,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,mark leising,ASTR-1030,2016
-ASTR,1030,2,Solar Systm Astr Lab,0.69,0.19,0.0,0.04,0.04,0.0,0.0,0.04,mark leising,ASTR-1030,2016
-ASTR,1040,1,Stellar Astr Lab,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,mark leising,ASTR-1040,2016
-ASTR,1040,2,Stellar Astr Lab,0.43,0.35,0.04,0.04,0.0,0.0,0.0,0.13,mark leising,ASTR-1040,2016
-ASTR,1040,3,Stellar Astr Lab,0.74,0.13,0.04,0.0,0.04,0.0,0.0,0.04,mark leising,ASTR-1040,2016
-ASTR,1040,5,Stellar Astr Lab,0.23,0.32,0.14,0.14,0.14,0.0,0.0,0.05,mark leising,ASTR-1040,2016
-ASTR,1040,6,Stellar Astr Lab,0.0,0.54,0.23,0.08,0.08,0.0,0.0,0.08,mark leising,ASTR-1040,2016
-ASTR,3030,1,Galactic Astrophys,0.35,0.41,0.06,0.06,0.0,0.0,0.0,0.12,marco ajello,ASTR-3030,2016
-AUE,8160,1,Eng Combustion Emiss,0.74,0.24,0.0,0.0,0.0,0.0,0.0,0.02,robert prucka,AUE-8160,2016
-AUE,8170,3,Alt Energy Sources,0.34,0.61,0.05,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8170,2016
-AUE,8290,4,Tire Behavior,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8290,2016
-AUE,8500,6,Stability/Safety Sys,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,beshah ayalew,AUE-8500,2016
-AUE,8550,16,Auto Struct Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,AUE-8550,2016
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.52,0.33,0.03,0.0,0.09,0.0,0.0,0.03,michael mears,AUE-8690,2016
-AUE,8770,9,Light-Weight Design,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,fadi kama abu-farha,AUE-8770,2016
-AUE,8860,1,Noise Vibration,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,douglas feldmaier,AUE-8860,2016
-AUE,8930,3,Applied Dynamics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,AUE-8930,2016
-AUE,8930,4,Mechanics of Composites Struct,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,AUE-8930,2016
-AUE,8930,14,Power Electronics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,simona onori,AUE-8930,2016
-AUE,8930,15,Innov & Entrepreneurship,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,AUE-8930,2016
-AVS,2000,1,Beef Cattle Tech,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,nathan long,AVS-2000,2016
-AVS,2010,1,Poultry Techniques,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-2010,2016
-AVS,2060,1,Swine Techniques,0.63,0.26,0.07,0.0,0.02,0.0,0.0,0.02,richelle lor miller,AVS-2060,2016
-AVS,2090,1,Livestock Exhibition Technique,0.97,0.02,0.02,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-2090,2016
-AVS,3010,1,Anat & Phys Dom Ani,0.67,0.11,0.16,0.04,0.04,0.0,0.0,0.0,tiffany wilmoth,AVS-3010,2016
-AVS,3100,1,Animal Health,0.42,0.35,0.11,0.03,0.02,0.0,0.0,0.08,thomas scott,AVS-3100,2016
-AVS,3150,1,Animal Welfare,0.22,0.22,0.39,0.06,0.06,0.0,0.0,0.06,peter skewes,AVS-3150,2016
-AVS,3700,1,Principles of Animal Nutrition,0.37,0.35,0.18,0.07,0.01,0.0,0.0,0.01,james ro strickland,AVS-3700,2016
-AVS,3750,1,Applied Animal Nutrition,0.24,0.35,0.33,0.07,0.0,0.0,0.0,0.02,gustavo jos lascano,AVS-3750,2016
-AVS,4000,1,AVS Professional Development,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,AVS-4000,2016
-AVS,4000,2,AVS Professional Development,0.77,0.15,0.0,0.08,0.0,0.0,0.0,0.0,johanna joh lascano,AVS-4000,2016
-AVS,4060,2,Seminars & Related Topics,0.46,0.39,0.14,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2016
-AVS,4100,1,Domestic Ani Behav,0.18,0.5,0.26,0.03,0.02,0.0,0.0,0.01,peter skewes,AVS-4100,2016
-AVS,4130,1,Animal Products,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-4130,2016
-AVS,4140,1,Basic Immunology,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,thomas scott,AVS-4140,2016
-AVS,4170,1,Animal Agribusiness Develpmnt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-4170,2016
-AVS,4530,1,Animal Reproduction,0.46,0.36,0.12,0.02,0.02,0.0,0.0,0.02,glenn birrenkott,AVS-4530,2016
-AVS,4530,400,Animal Reproduction,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-4530,2016
-BCHM,3010,1,Molecular Biochem,0.29,0.23,0.32,0.08,0.06,0.0,0.0,0.02,cheryl ingram-smith,BCHM-3010,2016
-BCHM,3010,2,Molecular Biochem(HON),0.48,0.29,0.16,0.03,0.0,0.0,0.0,0.03,kerry smith,BCHM-3010,2016
-BCHM,3050,1,Essen Elements Bioch,0.37,0.35,0.1,0.06,0.04,0.0,0.0,0.07,srik chandrasekaran,BCHM-3050,2016
-BCHM,3050,2,Essen Elements Bioch,0.39,0.34,0.14,0.05,0.03,0.0,0.0,0.05,srik chandrasekaran,BCHM-3050,2016
-BCHM,4320,1,Bioch of Metabolism,0.63,0.15,0.12,0.02,0.02,0.0,0.0,0.05,kimberly paul,BCHM-4320,2016
-BCHM,4360,1,Genes to Proteins,0.5,0.33,0.1,0.0,0.05,0.0,0.0,0.02,michael glen sehorn,BCHM-4360,2016
-BCHM,4400,1,Bioinformatics,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,liangjiang wang,BCHM-4400,2016
-BCHM,4930,1,Senior Seminar,0.55,0.39,0.03,0.0,0.03,0.0,0.0,0.0,james morris,BCHM-4930,2016
-BE,2100,1,Intro to Biosystems Engr,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,yi zheng,BE-2100,2016
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.27,0.42,0.23,0.0,0.04,0.0,0.0,0.04,tom owino,BE-3220,2016
-BE,4120,1,Be Heat Mass Trans,0.52,0.3,0.04,0.0,0.09,0.0,0.0,0.04,caye marie drapcho,BE-4120,2016
-BE,4150,1,Instr & Control for Biosys Eng,0.67,0.17,0.08,0.04,0.0,0.0,0.0,0.04,yi zheng,BE-4150,2016
-BE,4380,1,Bioprocess Engineering Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4380,2016
-BE,4730,3,Thermodynamics,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4730,2016
-BIOE,1010,1,Biol for Bioengr,0.51,0.31,0.1,0.02,0.01,0.0,0.0,0.05,vladimir vla reukov,BIOE-1010,2016
-BIOE,2010,1,Intro Biomed Engr,0.11,0.72,0.11,0.06,0.0,0.0,0.0,0.0,charles webb,BIOE-2010,2016
-BIOE,3020,1,Biomaterials,0.65,0.28,0.01,0.04,0.0,0.0,0.0,0.01,alexey ale vertegel,BIOE-3020,2016
-BIOE,3200,1,Biomechanics,0.61,0.26,0.09,0.02,0.0,0.0,0.0,0.02,jiro nagatomi,BIOE-3200,2016
-BIOE,3210,1,Biofluid Mechanics,0.47,0.36,0.05,0.05,0.03,0.0,0.0,0.04,sarah harcum,BIOE-3210,2016
-BIOE,3700,1,Bioinst & Imaging,0.58,0.4,0.01,0.0,0.0,0.0,0.0,0.0,delphine dean,BIOE-3700,2016
-BIOE,4010,1,Bioengineering Design Theory,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,BIOE-4010,2016
-BIOE,4030,1,Applied Bio E Design,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,BIOE-4030,2016
-BIOE,4200,1,Sports Engineering,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,BIOE-4200,2016
-BIOE,4230,1,Cardiovascular Engr and Path,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dan simionescu,BIOE-4230,2016
-BIOE,4310,1,Medical Imaging,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david kwartowitz,BIOE-4310,2016
-BIOE,4490,1,Drug Delivery,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,frank alexis,BIOE-4490,2016
-BIOE,6350,1,Modeling of Multiphysics Prob,0.46,0.46,0.0,0.0,0.0,0.0,0.0,0.08,guigen zhang,BIOE-6350,2016
-BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,martine laberge,BIOE-8000,2016
-BIOE,8020,410,Biocompatibility,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,BIOE-8020,2016
-BIOE,8130,1,Industrial Bioengineering,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michael taylor,BIOE-8130,2016
-BIOE,8410,1,Drug Delivery,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,BIOE-8410,2016
-BIOE,8500,401,Toolkit - Cell & Molecular Bio,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ann catherine foley,BIOE-8500,2016
-BIOL,1040,1,General Biology II,0.27,0.34,0.22,0.1,0.03,0.0,0.0,0.05,nora espinoza,BIOL-1040,2016
-BIOL,1040,2,General Biology II,0.44,0.35,0.12,0.06,0.02,0.0,0.0,0.02,william surver,BIOL-1040,2016
-BIOL,1040,3,General Biology II,0.15,0.18,0.39,0.16,0.07,0.0,0.0,0.04,salvatore sparace,BIOL-1040,2016
-BIOL,1060,1,Gen Biology Lab II,0.09,0.27,0.36,0.09,0.18,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,2,Gen Biology Lab II,0.09,0.36,0.45,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,3,Gen Biology Lab II,0.27,0.27,0.27,0.09,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,4,Gen Biology Lab II,0.1,0.33,0.14,0.29,0.05,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,5,Gen Biology Lab II,0.14,0.19,0.29,0.19,0.1,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,6,Gen Biology Lab II,0.27,0.18,0.36,0.0,0.14,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,7,Gen Biology Lab II,0.05,0.3,0.2,0.2,0.15,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,8,Gen Biology Lab II,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,9,Gen Biology Lab II,0.11,0.37,0.26,0.16,0.11,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,10,Gen Biology Lab II,0.1,0.57,0.19,0.1,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,11,Gen Biology Lab II,0.23,0.55,0.14,0.09,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,12,Gen Biology Lab II,0.18,0.41,0.23,0.09,0.09,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,13,Gen Biology Lab II,0.18,0.32,0.23,0.09,0.09,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,14,Gen Biology Lab II,0.32,0.32,0.09,0.14,0.05,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,15,Gen Biology Lab II,0.09,0.18,0.36,0.18,0.14,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,16,Gen Biology Lab II,0.09,0.36,0.36,0.14,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,17,Gen Biology Lab II,0.13,0.3,0.3,0.09,0.17,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,18,Gen Biology Lab II,0.09,0.09,0.26,0.35,0.17,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,19,Gen Biology Lab II,0.23,0.18,0.45,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,20,Gen Biology Lab II,0.23,0.36,0.18,0.18,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,21,Gen Biology Lab II,0.14,0.23,0.41,0.05,0.18,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,22,Gen Biology Lab II,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,23,Gen Biology Lab II,0.09,0.27,0.36,0.14,0.14,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,24,Gen Biology Lab II,0.0,0.22,0.39,0.17,0.13,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,26,Gen Biology Lab II,0.18,0.09,0.32,0.27,0.09,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,27,Gen Biology Lab II,0.29,0.43,0.24,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,28,Gen Biology Lab II,0.23,0.32,0.18,0.27,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,29,Gen Biology Lab II,0.09,0.55,0.14,0.14,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,30,Gen Biology Lab II,0.05,0.45,0.32,0.05,0.09,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,31,Gen Biology Lab II,0.23,0.14,0.32,0.09,0.18,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,33,Gen Biology Lab II,0.04,0.33,0.25,0.17,0.17,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1060,34,Gen Biology Lab II,0.0,0.0,0.4,0.3,0.2,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2016
-BIOL,1090,1,Intro to Life Sci,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,BIOL-1090,2016
-BIOL,1110,1,Principles of Biology II,0.24,0.44,0.24,0.06,0.0,0.0,0.0,0.02,robert kosinski,BIOL-1110,2016
-BIOL,1110,2,Principles of Biology II,0.35,0.36,0.15,0.04,0.02,0.0,0.0,0.07,dylan dittrich-reed,BIOL-1110,2016
-BIOL,1200,1,Biological Inq Lab,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2016
-BIOL,1200,2,Biological Inq Lab,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,BIOL-1200,2016
-BIOL,1200,3,Biological Inq Lab,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06, christine minor,BIOL-1200,2016
-BIOL,1200,5,Biological Inq Lab,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0, christine minor,BIOL-1200,2016
-BIOL,1200,6,Biological Inq Lab,0.4,0.4,0.07,0.0,0.07,0.0,0.0,0.07, christine minor,BIOL-1200,2016
-BIOL,1230,1,Keys to Human Biol,0.32,0.29,0.22,0.09,0.06,0.0,0.0,0.03, christine minor,BIOL-1230,2016
-BIOL,2000,2,Biology in the News,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-2000,2016
-BIOL,2000,3,Biology in the News,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,matthew turnbull,BIOL-2000,2016
-BIOL,2000,6,Biology in the News,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,simon scott,BIOL-2000,2016
-BIOL,2000,7,Biology in the News,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,john michael henson,BIOL-2000,2016
-BIOL,2030,1,Human Disease & Soc,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02, christine minor,BIOL-2030,2016
-BIOL,2040,1,"Environ, Energy and Society",0.52,0.36,0.06,0.01,0.03,0.0,0.0,0.01,john jenkins hains,BIOL-2040,2016
-BIOL,2040,2,"Environ, Energy and Society",0.48,0.35,0.13,0.0,0.05,0.0,0.0,0.0,john jenkins hains,BIOL-2040,2016
-BIOL,2110,1,Introduction to Toxicology,0.45,0.48,0.03,0.0,0.0,0.0,0.0,0.03,peter van den hurk,BIOL-2110,2016
-BIOL,2230,1,Human Anat and Physiology II,0.32,0.35,0.17,0.08,0.05,0.0,0.0,0.02,john cummings,BIOL-2230,2016
-BIOL,2230,2,Human Anat and Physiology II,0.39,0.38,0.12,0.05,0.03,0.0,0.0,0.03,john cummings,BIOL-2230,2016
-BIOL,3020,1,Invertebrate Biology,0.11,0.21,0.37,0.18,0.08,0.0,0.0,0.05,juan baeza migueles,BIOL-3020,2016
-BIOL,3040,1,Biology of Plants,0.47,0.38,0.08,0.03,0.0,0.0,0.0,0.04,christina wells,BIOL-3040,2016
-BIOL,3060,1,Invertebrate Biology Lab,0.16,0.42,0.21,0.05,0.11,0.0,0.0,0.05,juan baeza migueles,BIOL-3060,2016
-BIOL,3060,3,Invertebrate Biology Lab,0.11,0.33,0.39,0.11,0.0,0.0,0.0,0.06,juan baeza migueles,BIOL-3060,2016
-BIOL,3080,1,Biology of Plants Practicum,0.24,0.47,0.12,0.0,0.06,0.0,0.0,0.12,christina wells,BIOL-3080,2016
-BIOL,3080,2,Biology of Plants Practicum,0.35,0.47,0.0,0.06,0.0,0.0,0.0,0.12,christina wells,BIOL-3080,2016
-BIOL,3080,3,Biology of Plants Practicum,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,christina wells,BIOL-3080,2016
-BIOL,3080,4,Biology of Plants Practicum,0.28,0.39,0.22,0.0,0.06,0.0,0.0,0.06,christina wells,BIOL-3080,2016
-BIOL,3130,1,Conservation Biology,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,BIOL-3130,2016
-BIOL,3130,2,Conservation Biology,0.47,0.21,0.16,0.05,0.11,0.0,0.0,0.0,shari lyn rodriguez,BIOL-3130,2016
-BIOL,3160,1,Human Physiology,0.35,0.39,0.21,0.03,0.0,0.0,0.0,0.02,tamara mcnutt-scott,BIOL-3160,2016
-BIOL,3350,1,Evolutionary Biology,0.37,0.4,0.17,0.02,0.01,0.0,0.0,0.02,michael sears,BIOL-3350,2016
-BIOL,3350,2,Evolutionary Biology (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,margaret ptacek,BIOL-3350,2016
-BIOL,3510,1,Biological Anthropology,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,lisa rapaport,BIOL-3510,2016
-BIOL,3530,1,Forensic Anthropology,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,katherine weisensee,BIOL-3530,2016
-BIOL,4010,1,Plant Physiology,0.09,0.28,0.3,0.21,0.07,0.0,0.0,0.05,douglas bielenberg,BIOL-4010,2016
-BIOL,4020,1,Plant Physiology Lab,0.11,0.28,0.33,0.17,0.06,0.0,0.0,0.06,douglas bielenberg,BIOL-4020,2016
-BIOL,4020,2,Plant Physiology Lab,0.63,0.13,0.19,0.0,0.06,0.0,0.0,0.0,douglas bielenberg,BIOL-4020,2016
-BIOL,4100,1,Limnology,0.58,0.26,0.1,0.03,0.0,0.0,0.0,0.03,john jenkins hains,BIOL-4100,2016
-BIOL,4140,1,Basic Immunology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,BIOL-4140,2016
-BIOL,4340,1,Biological Chem Lab Techniques,0.0,0.27,0.27,0.27,0.13,0.0,0.0,0.07,salvatore sparace,BIOL-4340,2016
-BIOL,4340,2,Biological Chem Lab Techniques,0.13,0.44,0.38,0.0,0.0,0.0,0.0,0.06,salvatore sparace,BIOL-4340,2016
-BIOL,4340,3,Biological Chem Lab Techniques,0.0,0.46,0.38,0.15,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2016
-BIOL,4340,4,Biological Chem Lab Techniques,0.29,0.43,0.07,0.0,0.07,0.0,0.0,0.14,salvatore sparace,BIOL-4340,2016
-BIOL,4610,1,Cell Biology,0.31,0.3,0.18,0.12,0.07,0.0,0.0,0.03,lisa bain,BIOL-4610,2016
-BIOL,4610,2,Cell Biology (HON),0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,lisa bain,BIOL-4610,2016
-BIOL,4610,3,Cell Biology,0.25,0.3,0.29,0.05,0.03,0.0,0.0,0.07,zhicheng dou,BIOL-4610,2016
-BIOL,4620,1,Cell Biology Lab (Lec),0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,2,Cell Biology Lab (Lec),0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,3,Cell Biology Lab (Lec),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,4,Cell Biology Lab (Lec),0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,5,Cell Biology Lab (Lec),0.75,0.06,0.13,0.0,0.06,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,6,Cell Biology Lab (Lec),0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,7,Cell Biology Lab (Lec),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2016
-BIOL,4620,8,Cell Biology Lab (Lec),0.63,0.0,0.06,0.06,0.0,0.0,0.0,0.25,xianzhong yu,BIOL-4620,2016
-BIOL,4640,1,Mammalogy,0.48,0.29,0.1,0.1,0.05,0.0,0.0,0.0,john cummings,BIOL-4640,2016
-BIOL,4660,1,Evolution of Human Behavior,0.29,0.41,0.12,0.06,0.06,0.0,0.0,0.06,lisa rapaport,BIOL-4660,2016
-BIOL,4700,1,Behavioral Ecology,0.26,0.49,0.19,0.04,0.02,0.0,0.0,0.0,michael childress,BIOL-4700,2016
-BIOL,4700,2,Behavioral Ecology (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,BIOL-4700,2016
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.62,0.24,0.05,0.05,0.0,0.0,0.0,0.05,michael childress,BIOL-4710,2016
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,michael childress,BIOL-4710,2016
-BIOL,4710,3,Behavioral Ecology Lab (Lec),0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,michael childress,BIOL-4710,2016
-BIOL,4710,4,Behavioral Ecology Lab (Lec),0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,michael childress,BIOL-4710,2016
-BIOL,4930,2,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,BIOL-4930,2016
-BIOL,4930,4,Senior Seminar,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4930,2016
-BIOL,4930,5,Senior Seminar,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4930,2016
-BIOL,4930,6,Senior Seminar,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,william baldwin,BIOL-4930,2016
-BIOL,4960,1,Biodiversity & Conserv in Asia,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,BIOL-4960,2016
-BIOL,8430,1,Underst Genetics & Evol Biol,0.85,0.12,0.01,0.0,0.0,0.0,0.0,0.02,margaret ptacek,BIOL-8430,2016
-BIOL,8450,1,Understanding Animal Biology,0.86,0.12,0.01,0.0,0.0,0.0,0.0,0.01,matthew turnbull,BIOL-8450,2016
-BIOL,8470,1,Understanding Microbiology,0.63,0.28,0.07,0.0,0.01,0.0,0.0,0.01,harry kurtz,BIOL-8470,2016
-BIOL,8480,1,Understanding Scientific Rsrch,0.9,0.0,0.0,0.0,0.02,0.0,0.0,0.07,robert edwa ballard,BIOL-8480,2016
-BMOL,4250,1,Biomolecular Engineering,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,mark alan blenner,BMOL-4250,2016
-BUS,1010,1,Business Foundations,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,2,Business Foundations,0.22,0.52,0.19,0.04,0.0,0.0,0.0,0.04,donna mccubbin,BUS-1010,2016
-BUS,1010,3,Business Foundations,0.35,0.54,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,4,Business Foundations,0.27,0.54,0.12,0.04,0.0,0.0,0.0,0.04,william ern tumblin,BUS-1010,2016
-BUS,1010,5,Business Foundations,0.39,0.43,0.11,0.0,0.0,0.0,0.0,0.07,william ern tumblin,BUS-1010,2016
-BUS,1010,6,Business Foundations,0.22,0.44,0.19,0.04,0.0,0.0,0.0,0.11,william ern tumblin,BUS-1010,2016
-BUS,1010,7,Business Foundations,0.23,0.46,0.19,0.04,0.04,0.0,0.0,0.04,william ern tumblin,BUS-1010,2016
-BUS,1010,8,Business Foundations,0.28,0.52,0.14,0.03,0.0,0.0,0.0,0.03,william ern tumblin,BUS-1010,2016
-BUS,1010,9,Business Foundations,0.33,0.44,0.19,0.0,0.04,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-BUS,1010,10,Business Foundations,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2016
-CE,2010,1,Statics,0.66,0.11,0.18,0.0,0.02,0.0,0.0,0.02,sara khoshnevisan,CE-2010,2016
-CE,2010,2,Statics,0.19,0.35,0.19,0.03,0.08,0.0,0.0,0.16,melissa sternhagen,CE-2010,2016
-CE,2010,3,Statics,0.43,0.36,0.16,0.05,0.0,0.0,0.0,0.0,thomas edfo cousins,CE-2010,2016
-CE,2010,4,Statics,0.16,0.26,0.21,0.13,0.11,0.0,0.0,0.13,melissa sternhagen,CE-2010,2016
-CE,2010,5,Statics,0.53,0.35,0.05,0.0,0.03,0.0,0.0,0.03,mahmoodreza soltani,CE-2010,2016
-CE,2010,6,Statics,0.24,0.65,0.07,0.02,0.0,0.0,0.0,0.02, kent nilsson,CE-2010,2016
-CE,2010,7,Statics,0.27,0.38,0.1,0.06,0.02,0.0,0.0,0.17,thomas edfo cousins,CE-2010,2016
-CE,2060,1,Structural Mechanics,0.28,0.38,0.26,0.03,0.05,0.0,0.0,0.0,bryant nielson,CE-2060,2016
-CE,2060,2,Structural Mechanics,0.3,0.35,0.25,0.05,0.02,0.0,0.0,0.04,bryant nielson,CE-2060,2016
-CE,2080,1,Dynamics,0.12,0.42,0.22,0.02,0.08,0.0,0.0,0.14,melissa sternhagen,CE-2080,2016
-CE,2080,2,Dynamics,0.14,0.36,0.27,0.09,0.05,0.0,0.0,0.09,melissa sternhagen,CE-2080,2016
-CE,2080,3,Dynamics,0.28,0.38,0.2,0.08,0.0,0.0,0.0,0.08,thomas edfo cousins,CE-2080,2016
-CE,2550,1,Geomatics,0.32,0.45,0.14,0.0,0.07,0.0,0.0,0.02,wayne sarasua,CE-2550,2016
-CE,3010,1,Structural Analysis,0.27,0.27,0.3,0.03,0.09,0.0,0.0,0.03,stephen csernak,CE-3010,2016
-CE,3110,1,Transportation Engr,0.35,0.35,0.18,0.05,0.04,0.0,0.0,0.03,yongxi huang,CE-3110,2016
-CE,3210,1,Geotechnical Engineering,0.56,0.28,0.08,0.03,0.05,0.0,0.0,0.0,charng-hsein juang,CE-3210,2016
-CE,3210,2,Geotechnical Engineering,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,sara khoshnevisan,CE-3210,2016
-CE,3310,1,Constr Engr & Mgmnt,0.33,0.37,0.24,0.02,0.04,0.0,0.0,0.0,james burati,CE-3310,2016
-CE,3410,1,Intro to Fluid Mech,0.35,0.35,0.23,0.08,0.0,0.0,0.0,0.0,nigel gregory kaye,CE-3410,2016
-CE,3410,2,Intro to Fluid Mech,0.36,0.42,0.12,0.0,0.06,0.0,0.0,0.03,nigel gregory kaye,CE-3410,2016
-CE,3420,1,Hydraulics & Hydro,0.21,0.36,0.29,0.05,0.05,0.0,0.0,0.05,abdul khan,CE-3420,2016
-CE,3420,2,Hydraulics & Hydro,0.51,0.36,0.1,0.0,0.0,0.0,0.0,0.03,ashok mishra,CE-3420,2016
-CE,3510,1,Civil Engineering Materials,0.31,0.54,0.1,0.0,0.03,0.0,0.0,0.03,prasada rangaraju,CE-3510,2016
-CE,3520,1,Econ Eval of Proj,0.38,0.4,0.04,0.11,0.02,0.0,0.0,0.04,james burati,CE-3520,2016
-CE,3520,2,Econ Eval of Proj,0.58,0.25,0.13,0.03,0.0,0.0,0.0,0.03,bradley putman,CE-3520,2016
-CE,3530,1,Professional Seminar,0.95,0.03,0.02,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,CE-3530,2016
-CE,4020,1,Reinfor Con Design,0.5,0.3,0.1,0.04,0.03,0.0,0.0,0.03,brandon ross,CE-4020,2016
-CE,4080,1,Struct Loads & Sys,0.27,0.35,0.19,0.12,0.04,0.0,0.0,0.04,bryant nielson,CE-4080,2016
-CE,4110,1,Roadway Geo Design,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,jennifer ogle,CE-4110,2016
-CE,4120,1,Urban Transport Plan,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-4120,2016
-CE,4210,1,Geotechnical Design,0.28,0.42,0.23,0.02,0.02,0.0,0.0,0.02,nadara ravichandran,CE-4210,2016
-CE,4340,1,Const Est Proj Cont,0.73,0.21,0.04,0.0,0.01,0.0,0.0,0.0,kalyan ram piratla,CE-4340,2016
-CE,4360,1,Sustainable Constr,0.83,0.16,0.02,0.0,0.0,0.0,0.0,0.0,leidy klotz,CE-4360,2016
-CE,4590,1,Capstone Design Proj,0.48,0.46,0.04,0.03,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2016
-CE,4910,1,Non-Destructive Evaluation,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,ami esmaeilpoursaee,CE-4910,2016
-CE,6080,1,Struct Loads & Sys,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,bryant nielson,CE-6080,2016
-CE,6340,1,Const Est Proj Cont,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-6340,2016
-CE,6360,1,Sustainable Constr,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,CE-6360,2016
-CE,6430,1,Water Resources Engr,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,abdul khan,CE-6430,2016
-CE,6910,1,Non-Destructive Evaluation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,CE-6910,2016
-CE,8010,1,Finite Ele Analysis,0.35,0.47,0.06,0.0,0.0,0.0,0.0,0.12,nadara ravichandran,CE-8010,2016
-CE,8280,1,Rep/Rehab of Con Str,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,prasada rangaraju,CE-8280,2016
-CE,8530,1,Apps in Traffic En,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,mashrur chowdhury,CE-8530,2016
-CE,8930,1,Selec Topics in CE - Hwy Bridg,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,CE-8930,2016
-CE,8930,2,Selec Topics in CE-Risk Assess,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-8930,2016
-CE,8930,4,Select Topics in CE - Poromech,0.56,0.22,0.0,0.0,0.11,0.0,0.0,0.11,qiushi chen,CE-8930,2016
-CE,8930,400,Selec Topics in CE-Human Fact,0.71,0.17,0.0,0.0,0.08,0.0,0.0,0.04,kap chalil madathil,CE-8930,2016
-CH,1010,1,General Chemistry,0.1,0.37,0.25,0.11,0.1,0.0,0.0,0.06,ava kreider-mueller,CH-1010,2016
-CH,1010,2,General Chemistry,0.23,0.27,0.23,0.15,0.09,0.0,0.0,0.05,ava kreider-mueller,CH-1010,2016
-CH,1010,3,General Chemistry,0.21,0.31,0.25,0.1,0.1,0.0,0.0,0.04,dennis taylor,CH-1010,2016
-CH,1010,4,General Chemistry,0.0,0.1,0.13,0.13,0.35,0.0,0.0,0.29,william joh wallace,CH-1010,2016
-CH,1010,400,General Chemistry,0.17,0.2,0.29,0.2,0.06,0.0,0.0,0.08,stephe schvaneveldt,CH-1010,2016
-CH,1020,1,General Chemistry,0.32,0.39,0.18,0.05,0.02,0.0,0.0,0.04,tania issa houjeiry,CH-1020,2016
-CH,1020,2,General Chemistry,0.26,0.42,0.2,0.06,0.02,0.0,0.0,0.04,dennis taylor,CH-1020,2016
-CH,1020,3,General Chemistry,0.27,0.39,0.23,0.05,0.02,0.0,0.0,0.04,dennis taylor,CH-1020,2016
-CH,1020,4,General Chemistry,0.02,0.15,0.28,0.17,0.13,0.0,0.0,0.26,william joh wallace,CH-1020,2016
-CH,1020,5,General Chemistry,0.05,0.35,0.1,0.1,0.3,0.0,0.0,0.1,william joh wallace,CH-1020,2016
-CH,1020,6,General Chemistry,0.23,0.4,0.22,0.06,0.02,0.0,0.0,0.08,olt geiculescu,CH-1020,2016
-CH,1020,7,General Chemistry,0.26,0.32,0.25,0.08,0.05,0.0,0.0,0.04,thomas hickman,CH-1020,2016
-CH,1020,8,General Chemistry,0.14,0.41,0.25,0.08,0.02,0.0,0.0,0.11,elliot ennis,CH-1020,2016
-CH,1020,9,General Chemistry,0.24,0.46,0.21,0.03,0.03,0.0,0.0,0.03,thomas hickman,CH-1020,2016
-CH,1020,10,General Chemistry,0.26,0.43,0.21,0.05,0.03,0.0,0.0,0.03,ava kreider-mueller,CH-1020,2016
-CH,1020,11,General Chemistry,0.16,0.26,0.37,0.0,0.05,0.0,0.0,0.16,christopher wilson,CH-1020,2016
-CH,1020,13,General Chemistry,0.53,0.37,0.0,0.11,0.0,0.0,0.0,0.0,edward collins,CH-1020,2016
-CH,1020,50,General Chemistry,0.38,0.19,0.38,0.0,0.0,0.0,0.0,0.05,shiou-jyh hwu,CH-1020,2016
-CH,1020,51,General Chemistry (HON),0.78,0.11,0.04,0.0,0.0,0.0,0.0,0.07,stephe schvaneveldt,CH-1020,2016
-CH,1020,52,General Chemistry (HON),0.8,0.16,0.02,0.0,0.0,0.0,0.0,0.02,stephe schvaneveldt,CH-1020,2016
-CH,1050,1,Chemistry in Context I,0.58,0.31,0.05,0.0,0.0,0.0,0.0,0.06,christopher wilson,CH-1050,2016
-CH,1060,1,Chemistry in Context II,0.42,0.33,0.14,0.08,0.0,0.0,0.0,0.03,olt geiculescu,CH-1060,2016
-CH,1060,2,Chemistry in Context II,0.38,0.31,0.23,0.08,0.0,0.0,0.0,0.0,olt geiculescu,CH-1060,2016
-CH,1520,1,Chem Commun I,0.81,0.05,0.05,0.0,0.03,0.0,0.0,0.05,richard marcus,CH-1520,2016
-CH,2010,1,Survey of Organic Chemistry,0.37,0.34,0.16,0.06,0.05,0.0,0.0,0.02,tania issa houjeiry,CH-2010,2016
-CH,2020,1,Surv of Organic Chemistry Lab,0.73,0.0,0.07,0.0,0.0,0.0,0.0,0.2,sean 'connor,CH-2020,2016
-CH,2020,2,Surv of Organic Chemistry Lab,0.5,0.28,0.06,0.0,0.06,0.0,0.0,0.11,sean 'connor,CH-2020,2016
-CH,2050,1,Intro Inorg Chem,0.44,0.28,0.25,0.0,0.0,0.0,0.0,0.03,william pennington,CH-2050,2016
-CH,2230,1,Organic Chemistry,0.21,0.32,0.25,0.09,0.05,0.0,0.0,0.07,jacob schroeder,CH-2230,2016
-CH,2230,2,Organic Chemistry,0.26,0.32,0.2,0.13,0.05,0.0,0.0,0.04,jacob schroeder,CH-2230,2016
-CH,2230,3,Organic Chemistry,0.13,0.38,0.22,0.13,0.08,0.0,0.0,0.05,jacob schroeder,CH-2230,2016
-CH,2240,1,Organic Chemistry,0.24,0.4,0.24,0.02,0.05,0.0,0.0,0.04,thomas hickman,CH-2240,2016
-CH,2240,2,Organic Chemistry,0.34,0.32,0.19,0.09,0.03,0.0,0.0,0.02,elliot ennis,CH-2240,2016
-CH,2240,3,Organic Chemistry,0.32,0.36,0.25,0.01,0.02,0.0,0.0,0.03,elliot ennis,CH-2240,2016
-CH,2240,4,Organic Chemistry,0.24,0.36,0.14,0.04,0.1,0.0,0.0,0.13,rhett smith,CH-2240,2016
-CH,2240,5,Organic Chemistry,0.13,0.23,0.35,0.06,0.03,0.0,0.0,0.19,dev priya arya,CH-2240,2016
-CH,2270,3,Organic Chem Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,4,Organic Chem Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,5,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2016
-CH,2270,7,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,9,Organic Chem Lab,0.8,0.0,0.07,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2016
-CH,2270,11,Organic Chem Lab,0.81,0.0,0.0,0.0,0.06,0.0,0.0,0.13,sean 'connor,CH-2270,2016
-CH,2270,12,Organic Chem Lab,0.63,0.31,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,CH-2270,2016
-CH,2270,14,Organic Chem Lab,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,sean 'connor,CH-2270,2016
-CH,2280,3,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2280,2016
-CH,2280,4,Organic Chem Lab,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,CH-2280,2016
-CH,2280,6,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2280,2016
-CH,2280,11,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2280,2016
-CH,2280,15,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,CH-2280,2016
-CH,2280,16,Organic Chem Lab,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,sean 'connor,CH-2280,2016
-CH,2280,17,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2280,2016
-CH,2280,20,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2280,2016
-CH,2280,26,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,CH-2280,2016
-CH,2280,27,Organic Chem Lab,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,sean 'connor,CH-2280,2016
-CH,2290,3,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2290,2016
-CH,3310,1,Physical Chemistry,0.47,0.35,0.12,0.0,0.0,0.0,0.0,0.06,arkady kholodenko,CH-3310,2016
-CH,3320,1,Physical Chemistry,0.31,0.51,0.1,0.04,0.0,0.0,0.0,0.04,steven stuart,CH-3320,2016
-CH,3320,2,Physical Chemistry,0.39,0.21,0.32,0.05,0.03,0.0,0.0,0.0,jason mcneill,CH-3320,2016
-CH,3320,3,Physical Chemistry,0.58,0.17,0.13,0.04,0.08,0.0,0.0,0.0,leah bec casabianca,CH-3320,2016
-CH,3400,5,Physical Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,christopher wilson,CH-3400,2016
-CH,3600,1,Chemical Biology,0.38,0.36,0.16,0.02,0.02,0.0,0.0,0.07,modi wetzler,CH-3600,2016
-CH,4110,1,Instrumental Analy,0.26,0.39,0.13,0.09,0.13,0.0,0.0,0.0,george chumanov,CH-4110,2016
-CH,4120,1,Instr Analysis Lab,0.27,0.45,0.0,0.09,0.18,0.0,0.0,0.0,jeffrey natha anker,CH-4120,2016
-CH,4130,1,Chemistry of Aqueous Systems,0.43,0.4,0.17,0.0,0.0,0.0,0.0,0.0,cindy lee,CH-4130,2016
-CH,4250,1,Medicinal Chem,0.33,0.0,0.33,0.0,0.0,0.0,0.0,0.33,dev priya arya,CH-4250,2016
-CH,4500,1,Chemistry Capstone,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,CH-4500,2016
-CH,6140,1,Bioanalytical Chem,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,carlos garcia perez,CH-6140,2016
-CH,8050,1,Theor Inorg Chem,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,joseph kolis,CH-8050,2016
-CH,8180,1,Surface Analysis,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,stephen creager,CH-8180,2016
-CH,8220,1,Organic Chem II,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,daniel whitehead,CH-8220,2016
-CH,8340,1,Stat Thermodynamics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,brian dominy,CH-8340,2016
-CH,8510,1,Grad Student Seminar,0.73,0.13,0.13,0.0,0.0,0.0,0.0,0.0,joseph stu thrasher,CH-8510,2016
-CHE,1300,1,Chemical Eng Tools,0.16,0.35,0.14,0.11,0.16,0.0,0.0,0.09,christopher norfolk,CHE-1300,2016
-CHE,1300,2,Chemical Eng Tools,0.31,0.18,0.13,0.13,0.16,0.0,0.0,0.08,christopher norfolk,CHE-1300,2016
-CHE,2200,2,Ch E Thermo I,0.18,0.21,0.37,0.06,0.15,0.0,0.0,0.03,joseph scott,CHE-2200,2016
-CHE,2300,1,Fluids/Heat Transfer,0.1,0.33,0.34,0.13,0.07,0.0,0.0,0.03,douglas hirt,CHE-2300,2016
-CHE,2300,2,Fluids/Heat Transfer,0.13,0.24,0.4,0.15,0.04,0.0,0.0,0.05,eric mikel davis,CHE-2300,2016
-CHE,3210,1,Ch E Thermo II,0.13,0.23,0.4,0.18,0.03,0.0,0.0,0.03,sapna sarupria,CHE-3210,2016
-CHE,3300,1,Mass Trans & Seprtn,0.18,0.24,0.35,0.14,0.05,0.0,0.0,0.05,mark thies,CHE-3300,2016
-CHE,3530,1,Proc Dyn & Control,0.24,0.39,0.33,0.02,0.02,0.0,0.0,0.0,mark roberts,CHE-3530,2016
-CHE,4330,1,Process Design II,0.6,0.23,0.17,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4330,2016
-CHE,8340,1,CHE Polymer Thermodynamics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark thies,CHE-8340,2016
-CHIN,1010,1,Elementary Chinese,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yanlin wang,CHIN-1010,2016
-CHIN,1020,1,Elementary Chinese,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,yanlin wang,CHIN-1020,2016
-CHIN,2010,1,Intermediate Chinese,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,yanhua zhang,CHIN-2010,2016
-CHIN,4010,1,Pre-Modern Chinese Literature,0.3,0.5,0.15,0.0,0.05,0.0,0.0,0.0,yanming an,CHIN-4010,2016
-COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,eddie smith,COM-1010,2016
-COM,1500,1,Intro to Human Communication,0.81,0.16,0.01,0.0,0.0,0.0,0.0,0.02,eddie smith,COM-1500,2016
-COM,1500,2,Intro to Human Communication,0.57,0.33,0.05,0.02,0.01,0.0,0.0,0.02,daniel lelan fecher,COM-1500,2016
-COM,1500,3,Intro to Human Communication,0.82,0.13,0.03,0.0,0.0,0.0,0.0,0.03,eddie smith,COM-1500,2016
-COM,1500,4,Intro to Human Communication,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,marianne her glaser,COM-1500,2016
-COM,1500,5,Intro to Human Communication,0.65,0.26,0.04,0.01,0.03,0.0,0.0,0.01,marianne her glaser,COM-1500,2016
-COM,1500,6,Intro to Human Communication,0.5,0.38,0.05,0.01,0.01,0.0,0.0,0.05,daniel lelan fecher,COM-1500,2016
-COM,2010,1,Intr to Comm Studies,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-2010,2016
-COM,2010,2,Intr to Comm Studies,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,darren linvill,COM-2010,2016
-COM,2500,1,Public Speaking,0.62,0.24,0.14,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2016
-COM,2500,2,Public Speaking,0.52,0.29,0.1,0.1,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2016
-COM,2500,3,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-2500,2016
-COM,2500,4,Public Speaking,0.33,0.38,0.24,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2016
-COM,2500,5,Public Speaking,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,COM-2500,2016
-COM,2500,6,Public Speaking,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2016
-COM,2500,7,Public Speaking,0.19,0.57,0.14,0.0,0.0,0.0,0.0,0.1,marilyn denise pugh,COM-2500,2016
-COM,2500,8,Public Speaking,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,COM-2500,2016
-COM,2500,9,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2016
-COM,2500,10,Public Speaking,0.76,0.05,0.05,0.05,0.1,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2016
-COM,2500,11,Public Speaking,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2016
-COM,2500,12,Public Speaking,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2016
-COM,2500,13,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2016
-COM,2500,14,Public Speaking,0.62,0.19,0.05,0.05,0.0,0.0,0.0,0.1,vanessa anne condon,COM-2500,2016
-COM,2500,15,Public Speaking,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2016
-COM,2500,16,Public Speaking,0.37,0.32,0.16,0.0,0.05,0.0,0.0,0.11,pauline matthey,COM-2500,2016
-COM,2500,17,Public Speaking,0.5,0.35,0.05,0.05,0.0,0.0,0.0,0.05,the estate  geddes,COM-2500,2016
-COM,2500,18,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2016
-COM,2500,19,Public Speaking,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,COM-2500,2016
-COM,2500,20,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2016
-COM,2500,21,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2016
-COM,2500,22,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2016
-COM,2500,23,Public Speaking,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2016
-COM,2500,25,Public Speaking,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,COM-2500,2016
-COM,2500,26,Public Speaking (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,COM-2500,2016
-COM,2500,27,Public Speaking (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2016
-COM,2500,29,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2016
-COM,2500,400,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2016
-COM,2500,401,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2016
-COM,2500,402,Public Speaking,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,alexis zachar davis,COM-2500,2016
-COM,2500,403,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2016
-COM,2500,500,Public Speaking,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2016
-COM,3010,1,Comm Theory,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,pauline matthey,COM-3010,2016
-COM,3020,1,Mass Comm Theory,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,karyn jones,COM-3020,2016
-COM,3050,1,Persuasion,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,karyn jones,COM-3050,2016
-COM,3060,1,Discourse & Society,0.4,0.44,0.16,0.0,0.0,0.0,0.0,0.0,david travers scott,COM-3060,2016
-COM,3100,1,Quant Comm Methods,0.64,0.28,0.0,0.0,0.08,0.0,0.0,0.0,john steven spinda,COM-3100,2016
-COM,3200,1,Bdcst Production,0.67,0.1,0.1,0.05,0.0,0.0,0.0,0.1,wanda johnson,COM-3200,2016
-COM,3250,1,Survey of Sports Communication,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3250,2016
-COM,3250,2,Survey of Sports Communication,0.83,0.08,0.0,0.0,0.04,0.0,0.0,0.04,angela pratt,COM-3250,2016
-COM,3300,1,Nonverbal Comm,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,joseph mazer,COM-3300,2016
-COM,3480,1,Interpersonal Comm,0.43,0.43,0.1,0.0,0.05,0.0,0.0,0.0,melinda ra weathers,COM-3480,2016
-COM,3560,1,Stakeholder Comm,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3560,2016
-COM,3610,1,Argue and Debate,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-3610,2016
-COM,3660,2,EC: Brand Comm & Strategy,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,roger beasley,COM-3660,2016
-COM,3690,1,Political Comm,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,erin michelle ash,COM-3690,2016
-COM,3690,2,Political Comm,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3690,2016
-COM,3720,1,Digital Analytics in Brand Com,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,alicia ni littleton,COM-3720,2016
-COM,3730,1,Media Management in Brand Comm,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,william reynolds,COM-3730,2016
-COM,4040,1,Media Comm & Social Identities,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,chenjerai kumanyika,COM-4040,2016
-COM,4040,2,Media Comm & Social Identities,0.47,0.2,0.27,0.07,0.0,0.0,0.0,0.0,chenjerai kumanyika,COM-4040,2016
-COM,4260,1,Social Media and Sports Comm,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,john steven spinda,COM-4260,2016
-COM,4310,1,Legal Communication Trial,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,COM-4310,2016
-COM,4700,1,Comm & Health,0.29,0.65,0.0,0.06,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4700,2016
-COM,4950,1,Senior Capstone,0.9,0.07,0.0,0.0,0.03,0.0,0.0,0.0,erin michelle ash,COM-4950,2016
-COM,4980,1,Acad & Prof Dev II,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,joseph mazer,COM-4980,2016
-COM,8020,1,Communication Theory II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,chenjerai kumanyika,COM-8020,2016
-COM,8110,1,Comm Research Methods II,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-8110,2016
-CPSC,1010,1,Computer Science I,0.24,0.32,0.18,0.12,0.09,0.0,0.0,0.06,catherine hochrine,CPSC-1010,2016
-CPSC,1010,2,Computer Science I,0.39,0.13,0.18,0.11,0.11,0.0,0.0,0.08,catherine hochrine,CPSC-1010,2016
-CPSC,1010,3,Computer Science I,0.33,0.13,0.24,0.13,0.07,0.0,0.0,0.11,yvon feaster,CPSC-1010,2016
-CPSC,1020,1,Computer Science II,0.53,0.3,0.06,0.02,0.04,0.0,0.0,0.04,yvon feaster,CPSC-1020,2016
-CPSC,1020,2,Computer Science II,0.31,0.48,0.21,0.0,0.0,0.0,0.0,0.0,lanny sitanayah,CPSC-1020,2016
-CPSC,1020,3,Computer Science II,0.32,0.32,0.27,0.07,0.02,0.0,0.0,0.0,christopher plaue,CPSC-1020,2016
-CPSC,1110,1,Intro to Programming in C,0.54,0.16,0.11,0.03,0.08,0.0,0.0,0.08,catherine hochrine,CPSC-1110,2016
-CPSC,1110,2,Intro to Programming in C,0.78,0.07,0.04,0.0,0.04,0.0,0.0,0.07,wanda moses,CPSC-1110,2016
-CPSC,1110,3,Intro to Programming in C,0.68,0.14,0.09,0.0,0.05,0.0,0.0,0.05,wanda moses,CPSC-1110,2016
-CPSC,2070,1,Discrete Structures,0.14,0.38,0.31,0.1,0.03,0.0,0.0,0.03,sandra hedetniemi,CPSC-2070,2016
-CPSC,2070,401,Discrete Structures,0.43,0.3,0.22,0.0,0.01,0.0,0.0,0.04,larry hodges,CPSC-2070,2016
-CPSC,2100,1,Progrmng Methodology,0.43,0.23,0.17,0.07,0.0,0.0,0.0,0.1,rose lowe,CPSC-2100,2016
-CPSC,2120,1,Algs/Data Structures,0.36,0.28,0.24,0.07,0.04,0.0,0.0,0.01,wayne goddard,CPSC-2120,2016
-CPSC,2150,1,Software Dev,0.24,0.25,0.27,0.12,0.07,0.0,0.0,0.05,blair madiso durkee,CPSC-2150,2016
-CPSC,2150,2,Software Dev Foundations,0.66,0.26,0.05,0.0,0.02,0.0,0.0,0.02,joseph isaac,CPSC-2150,2016
-CPSC,2200,1,Microcomputer Appl,0.42,0.21,0.21,0.11,0.05,0.0,0.0,0.0,renee lambert,CPSC-2200,2016
-CPSC,2200,2,Microcomputer Appl,0.45,0.3,0.05,0.1,0.0,0.0,0.0,0.1,renee lambert,CPSC-2200,2016
-CPSC,2310,1,Intro Computer Org,0.44,0.26,0.21,0.07,0.02,0.0,0.0,0.0,rose lowe,CPSC-2310,2016
-CPSC,2310,2,Intro Computer Org,0.41,0.24,0.12,0.15,0.07,0.0,0.0,0.0,rose lowe,CPSC-2310,2016
-CPSC,2910,1,Prof Issues I,0.86,0.07,0.0,0.07,0.0,0.0,0.0,0.0,renee lambert,CPSC-2910,2016
-CPSC,2910,2,Prof Issues I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,renee lambert,CPSC-2910,2016
-CPSC,2910,3,Prof Issues I,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,renee lambert,CPSC-2910,2016
-CPSC,2910,4,Prof Issues I,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,james jones,CPSC-2910,2016
-CPSC,3220,1,Intro to Operating Systems,0.18,0.28,0.21,0.07,0.08,0.0,0.0,0.18,jacob sorber,CPSC-3220,2016
-CPSC,3300,1,Computer Systems Org,0.2,0.32,0.33,0.09,0.04,0.0,0.0,0.01,mark smotherman,CPSC-3300,2016
-CPSC,3500,1,Foundations of Computer Sci,0.15,0.2,0.48,0.03,0.06,0.0,0.0,0.08,ilya mark safro,CPSC-3500,2016
-CPSC,3520,1,Programming Systems,0.42,0.32,0.16,0.0,0.04,0.0,0.0,0.06,robert schalkoff,CPSC-3520,2016
-CPSC,3600,1,Network Programming,0.07,0.3,0.29,0.06,0.07,0.0,0.0,0.2,sekou lionel remy,CPSC-3600,2016
-CPSC,3620,1,Distributed/Cluster Computing,0.15,0.37,0.42,0.0,0.04,0.0,0.0,0.01,amy apon,CPSC-3620,2016
-CPSC,3720,1,Software Engineering,0.39,0.28,0.21,0.04,0.02,0.0,0.0,0.07,stephen schaub,CPSC-3720,2016
-CPSC,3990,3,Advanced CI: Extreme Orange,0.59,0.24,0.12,0.0,0.0,0.0,0.0,0.06,james martin,CPSC-3990,2016
-CPSC,4050,1,Computer Graphics,0.26,0.26,0.22,0.0,0.19,0.0,0.0,0.07,jerry tessendorf,CPSC-4050,2016
-CPSC,4140,1,Human and Computer Interaction,0.41,0.34,0.1,0.0,0.07,0.0,0.0,0.07,sabarish venka babu,CPSC-4140,2016
-CPSC,4140,2,Human and Computer Interaction,0.14,0.78,0.03,0.0,0.03,0.0,0.0,0.03,kelly caine,CPSC-4140,2016
-CPSC,4160,1,2-D Game Engine Construction,0.24,0.34,0.22,0.07,0.1,0.0,0.0,0.02,brian malloy,CPSC-4160,2016
-CPSC,4240,1,System Admin and Security,0.11,0.51,0.26,0.09,0.0,0.0,0.0,0.03,james martin,CPSC-4240,2016
-CPSC,4620,1,Database Management Systems,0.24,0.6,0.12,0.0,0.04,0.0,0.0,0.0,zijun wang,CPSC-4620,2016
-CPSC,4820,1,Selected Topics: Android Dev,0.56,0.25,0.0,0.0,0.0,0.0,0.0,0.19,roy pargas,CPSC-4820,2016
-CPSC,4820,2,Special Topics: Data Science,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,CPSC-4820,2016
-CPSC,4910,1,Professional Issues II,0.9,0.02,0.05,0.0,0.02,0.0,0.0,0.02,james jones,CPSC-4910,2016
-CPSC,6050,1,Computer Graphics,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,robert geist,CPSC-6050,2016
-CPSC,6140,1,Human and Computer Interaction,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,CPSC-6140,2016
-CPSC,6140,2,Human and Computer Interaction,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,CPSC-6140,2016
-CPSC,6160,1,2-D Game Engine Construction,0.43,0.35,0.09,0.0,0.0,0.0,0.0,0.13,brian malloy,CPSC-6160,2016
-CPSC,6240,1,System Admin and Security,0.31,0.44,0.19,0.0,0.0,0.0,0.0,0.06,james martin,CPSC-6240,2016
-CPSC,6550,1,Computational Science,0.5,0.19,0.25,0.0,0.0,0.0,0.0,0.06,xizhou feng,CPSC-6550,2016
-CPSC,6620,1,Database Management Systems,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,zijun wang,CPSC-6620,2016
-CPSC,6820,1,Selected Topics: Android Dev,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,roy pargas,CPSC-6820,2016
-CPSC,6820,2,Special Topics: Data Science,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,CPSC-6820,2016
-CPSC,8110,1,Character Animation,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,christina sop joerg,CPSC-8110,2016
-CPSC,8220,1,Case Study in Operating Sys,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,CPSC-8220,2016
-CPSC,8280,1,Theory of Program. Languages,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,murali sitaraman,CPSC-8280,2016
-CPSC,8400,1,Design & Anlys of Algorithms,0.19,0.34,0.34,0.0,0.08,0.0,0.0,0.06,brian christop dean,CPSC-8400,2016
-CPSC,8620,1,Database Mngmt System Design,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,CPSC-8620,2016
-CPSC,8650,1,Data Mining,0.33,0.46,0.17,0.0,0.0,0.0,0.0,0.04,zijun wang,CPSC-8650,2016
-CPSC,8750,1,Software Architectur,0.71,0.2,0.06,0.0,0.0,0.0,0.0,0.02,john mcgregor,CPSC-8750,2016
-CRP,8020,1,Site Planning,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,clifford dona ellis,CRP-8020,2016
-CRP,8040,1,Land Use Analysis,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,stephen sperry,CRP-8040,2016
-CRP,8050,1,Plning Theory & Hist,0.48,0.38,0.05,0.0,0.1,0.0,0.0,0.0,mickey lauria,CRP-8050,2016
-CRP,8090,1,Current Issues,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,barry nocks,CRP-8090,2016
-CRP,8130,1,Transportation Plan,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,eric morris,CRP-8130,2016
-CRP,8200,1,Negotiation,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,CRP-8200,2016
-CRP,8220,1,Urban Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,CRP-8220,2016
-CRP,8890,3,Sel Top-Geodesign w/ City Eng,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,CRP-8890,2016
-CRP,8900,3,Dir Studies in City & Reg Plan,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,clifford dona ellis,CRP-8900,2016
-CRP,8900,8,Dir Studies in City & Reg Plan,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,stephen sperry,CRP-8900,2016
-CSM,1500,1,Constr Prob Solving,0.52,0.35,0.09,0.0,0.0,0.0,0.0,0.04,jason lucas,CSM-1500,2016
-CSM,1500,2,Constr Prob Solving,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-1500,2016
-CSM,1500,3,Constr Prob Solving,0.48,0.39,0.13,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-1500,2016
-CSM,2020,1,Structures II,0.32,0.32,0.19,0.16,0.0,0.0,0.0,0.0,shima clarke,CSM-2020,2016
-CSM,2020,2,Structures II,0.31,0.34,0.21,0.14,0.0,0.0,0.0,0.0,shima clarke,CSM-2020,2016
-CSM,2040,1,Cont Documents,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2040,2016
-CSM,2040,2,Cont Documents,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2040,2016
-CSM,2050,1,Mats & Methods II,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2050,2016
-CSM,2050,2,Mats & Methods II,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.0,joseph wintz,CSM-2050,2016
-CSM,3050,1,Envir Systems II,0.33,0.42,0.17,0.04,0.0,0.04,0.0,0.0,joseph mich burgett,CSM-3050,2016
-CSM,3050,2,Envir Systems II,0.17,0.63,0.21,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3050,2016
-CSM,3520,1,Const Scheduling,0.36,0.29,0.18,0.04,0.0,0.14,0.0,0.0,dennis bausman,CSM-3520,2016
-CSM,3520,2,Const Scheduling,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-3520,2016
-CSM,3530,1,Const Estimating II,0.12,0.69,0.19,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-3530,2016
-CSM,3530,2,Const Estimating II,0.09,0.73,0.14,0.05,0.0,0.0,0.0,0.0,christine piper,CSM-3530,2016
-CSM,4540,1,Const Capstone,0.43,0.39,0.17,0.0,0.0,0.0,0.0,0.0,james packer smith,CSM-4540,2016
-CSM,4540,2,Const Capstone,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,james packer smith,CSM-4540,2016
-CSM,8620,1,Personnel Mgt & Neg,0.0,0.72,0.28,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-8620,2016
-CSM,8620,400,Personnel Mgt & Neg,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-8620,2016
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.65,0.33,0.03,susan whorton,CU-1000,2016
-CU,1010,1,Univ Success Skills,0.37,0.33,0.1,0.03,0.1,0.0,0.0,0.07,emma reynol reabold,CU-1010,2016
-CU,1010,2,Univ Success Skills,0.61,0.23,0.03,0.03,0.03,0.0,0.0,0.06,mary mcp von kaenel,CU-1010,2016
-CU,1010,3,Univ Success Skills,0.43,0.3,0.1,0.07,0.03,0.0,0.0,0.07,cari allyn brooks,CU-1010,2016
-CU,1010,6,Univ Success Skills,0.32,0.25,0.07,0.04,0.21,0.0,0.0,0.11,ashley crisp,CU-1010,2016
-CU,1400,1,The Entrepreneurial Mindset,0.46,0.39,0.07,0.0,0.06,0.0,0.0,0.01,john michael hannon,CU-1400,2016
-CU,1410,1,"Creativity, Innovation & Entr",0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,CU-1410,2016
-CU,1970,1,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.91,0.05,0.05,laurel ann whisler,CU-1970,2016
-CU,2010,1,Sustainability Leadership,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,jennifer marg goree,CU-2010,2016
-DANC,1300,1,Tap Dance I,0.75,0.1,0.05,0.0,0.0,0.0,0.0,0.1,cheryl hosler,DANC-1300,2016
-DANC,1400,1,Jazz Dance I,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,cheryl hosler,DANC-1400,2016
-DPA,4010,1,Tech Foundations II,0.09,0.09,0.09,0.27,0.18,0.0,0.0,0.27,donald henry house,DPA-4010,2016
-DPA,4030,1,Vis Foundations II,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,david stewart donar,DPA-4030,2016
-DPA,4030,2,Vis Foundations II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,DPA-4030,2016
-ECE,2010,1,Logic and Computing Devices,0.31,0.24,0.17,0.15,0.07,0.0,0.0,0.06,lin zhu,ECE-2010,2016
-ECE,2020,1,Electric Circuits I,0.22,0.26,0.22,0.15,0.09,0.0,0.0,0.06,william harrell,ECE-2020,2016
-ECE,2070,1,Basic Electrical Engineering,0.44,0.3,0.11,0.07,0.04,0.0,0.0,0.03,william th kolodzey,ECE-2070,2016
-ECE,2070,2,Basic Electrical Engineering,0.41,0.37,0.17,0.04,0.0,0.0,0.0,0.01,amir ahmed asif,ECE-2070,2016
-ECE,2070,3,Basic Electrical Engineering,0.17,0.41,0.27,0.03,0.07,0.0,0.0,0.06,hai xiao,ECE-2070,2016
-ECE,2080,2,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,3,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,6,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,7,Basic Electrical Engr Lab,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,8,Basic Electrical Engr Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,9,Basic Electrical Engr Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,11,Basic Electrical Engr Lab,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,12,Basic Electrical Engr Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,13,Basic Electrical Engr Lab,0.89,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2016
-ECE,2080,20,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2016
-ECE,2110,1,Elec Engr Lab I,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,apoorva dee kapadia,ECE-2110,2016
-ECE,2110,2,Elec Engr Lab I,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2110,2016
-ECE,2220,1,Syst Prog Concept,0.29,0.37,0.14,0.04,0.06,0.0,0.0,0.1,william reid,ECE-2220,2016
-ECE,2230,1,Comp Sys Eng,0.14,0.21,0.29,0.11,0.11,0.0,0.0,0.14,harlan russell,ECE-2230,2016
-ECE,2620,1,Electric Circuits II,0.38,0.32,0.22,0.03,0.02,0.0,0.0,0.03,richard groff,ECE-2620,2016
-ECE,2720,1,Comp Organization,0.26,0.4,0.27,0.03,0.03,0.0,0.0,0.02,william reid,ECE-2720,2016
-ECE,2730,1,Computer Org Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2016
-ECE,2730,2,Computer Org Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2016
-ECE,2730,6,Computer Org Lab,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,ECE-2730,2016
-ECE,2730,8,Computer Org Lab,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2016
-ECE,2730,9,Computer Org Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2016
-ECE,3110,3,Electrical Engineering Lab III,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2016
-ECE,3110,4,Electrical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2016
-ECE,3110,5,Electrical Engineering Lab III,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2016
-ECE,3170,1,Rand Signal Analysis,0.15,0.23,0.36,0.12,0.07,0.0,0.0,0.06,stephen hubbard,ECE-3170,2016
-ECE,3200,1,Electronics I,0.16,0.2,0.25,0.19,0.16,0.0,0.0,0.04,stephen hubbard,ECE-3200,2016
-ECE,3210,1,Electronics II,0.35,0.37,0.12,0.1,0.04,0.0,0.0,0.02,stephen hubbard,ECE-3210,2016
-ECE,3220,1,Intro Operating Sys,0.11,0.26,0.3,0.04,0.0,0.0,0.0,0.3,jacob sorber,ECE-3220,2016
-ECE,3270,1,Dig Comp Design,0.09,0.34,0.25,0.13,0.13,0.0,0.0,0.06,melissa crawl smith,ECE-3270,2016
-ECE,3300,1,Signals & Systems,0.17,0.16,0.31,0.19,0.08,0.0,0.0,0.09,carl baum,ECE-3300,2016
-ECE,3520,1,Programming Systems,0.4,0.44,0.12,0.0,0.0,0.0,0.0,0.04,robert schalkoff,ECE-3520,2016
-ECE,3600,1,Elect Power Engr,0.36,0.31,0.19,0.06,0.08,0.0,0.0,0.0,edward collins,ECE-3600,2016
-ECE,3710,1,Microcontr Interface,0.4,0.31,0.1,0.09,0.07,0.0,0.0,0.03,william reid,ECE-3710,2016
-ECE,3720,3,Micro Int Lab,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2016
-ECE,3720,5,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2016
-ECE,3720,7,Micro Int Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2016
-ECE,3800,1,Electromagnetics,0.11,0.22,0.4,0.13,0.11,0.0,0.0,0.03,anthony martin,ECE-3800,2016
-ECE,3810,1,Field Waves & Ckts,0.32,0.32,0.3,0.05,0.02,0.0,0.0,0.0,eric gordon johnson,ECE-3810,2016
-ECE,4090,1,Intr to Linear Control Systems,0.63,0.24,0.06,0.02,0.02,0.0,0.0,0.02,apoorva dee kapadia,ECE-4090,2016
-ECE,4190,1,Elec Mach and Drives,0.38,0.27,0.27,0.04,0.0,0.0,0.0,0.04,keith corzine,ECE-4190,2016
-ECE,4200,1,Renewable Energy,0.28,0.23,0.23,0.1,0.03,0.0,0.0,0.13,elham makram,ECE-4200,2016
-ECE,4270,1,Communications Sys,0.38,0.21,0.15,0.13,0.09,0.0,0.0,0.04,madhabi manandhar,ECE-4270,2016
-ECE,4380,1,Computer Commun,0.29,0.27,0.29,0.05,0.05,0.0,0.0,0.05,harlan russell,ECE-4380,2016
-ECE,4400,1,Local Computer Nets,0.22,0.57,0.16,0.0,0.0,0.0,0.0,0.05,kuang-ching wang,ECE-4400,2016
-ECE,4460,1,Antennas,0.58,0.25,0.08,0.08,0.0,0.0,0.0,0.0,anthony martin,ECE-4460,2016
-ECE,4680,1,Embedded Computing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,ECE-4680,2016
-ECE,4950,1,Int Sys Design I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-4950,2016
-ECE,4960,1,Int Sys Design II,0.56,0.3,0.13,0.0,0.0,0.0,0.0,0.01,richard groff,ECE-4960,2016
-ECE,4990,14,Creative Inq-Elec & Comp Engr,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,ECE-4990,2016
-ECE,6320,1,Instrumentation,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,goutam koley,ECE-6320,2016
-ECE,6370,1,Microelectromechanical Systems,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,pingshan wang,ECE-6370,2016
-ECE,6380,1,Computer Commun,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,ECE-6380,2016
-ECE,6400,1,Local Computer Nets,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,kuang-ching wang,ECE-6400,2016
-ECE,6680,1,Embedded Computing,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,adam hoover,ECE-6680,2016
-ECE,8400,1,Semicond Devices,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,william harrell,ECE-8400,2016
-ECE,8570,1,Coding Theory,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,ECE-8570,2016
-ECE,8630,1,Pwr Sys Dyna & Stab,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,ramtin hadidi,ECE-8630,2016
-ECE,8720,1,Artificial Neurl Net,0.52,0.38,0.05,0.0,0.0,0.0,0.0,0.05,robert schalkoff,ECE-8720,2016
-ECE,8740,1,Adv Nonlinear Cntrl,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,ECE-8740,2016
-ECE,8790,1,FPGA Design & Applications,0.17,0.17,0.57,0.0,0.04,0.0,0.0,0.04,melissa crawl smith,ECE-8790,2016
-ECE,8910,43,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,0.6,0.0,0.4,yongqiang wang,ECE-8910,2016
-ECE,8930,7,Malware Use and Design,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,richard brooks,ECE-8930,2016
-ECON,2000,1,Economic Concepts,0.14,0.39,0.29,0.11,0.0,0.0,0.0,0.07,jonathan orr ernest,ECON-2000,2016
-ECON,2000,2,Economic Concepts,0.35,0.33,0.23,0.05,0.05,0.0,0.0,0.0,jonathan orr ernest,ECON-2000,2016
-ECON,2000,3,Economic Concepts,0.33,0.41,0.13,0.03,0.08,0.0,0.0,0.03,miren ivankovic,ECON-2000,2016
-ECON,2110,1,Principles of Microeconomics,0.39,0.32,0.21,0.03,0.0,0.03,0.0,0.03,robert dew tollison,ECON-2110,2016
-ECON,2110,2,Principles of Microeconomics,0.15,0.36,0.26,0.1,0.08,0.0,0.0,0.05,charles thomas,ECON-2110,2016
-ECON,2110,3,Principles of Microeconomics,0.18,0.28,0.26,0.18,0.1,0.0,0.0,0.0,steven johnson,ECON-2110,2016
-ECON,2110,4,Principles of Microeconomics,0.31,0.26,0.26,0.05,0.1,0.0,0.0,0.02,amanda caitlin kerr,ECON-2110,2016
-ECON,2110,5,Principles of Microeconomics,0.35,0.35,0.28,0.03,0.0,0.0,0.0,0.0,molly espey,ECON-2110,2016
-ECON,2110,6,Principles of Microeconomics,0.24,0.39,0.25,0.01,0.01,0.0,0.0,0.08,benjamin jo schwall,ECON-2110,2016
-ECON,2110,7,Principles of Microeconomics,0.24,0.33,0.2,0.14,0.04,0.0,0.0,0.04,leah jacq kitashima,ECON-2110,2016
-ECON,2110,8,Principles of Microeconomics,0.21,0.42,0.24,0.06,0.03,0.0,0.0,0.03,alexander fiore,ECON-2110,2016
-ECON,2110,10,Principles of Microeconomics,0.16,0.31,0.35,0.08,0.08,0.0,0.0,0.02,richard alan sessa,ECON-2110,2016
-ECON,2110,11,Principles of Microeconomics,0.14,0.35,0.34,0.14,0.0,0.0,0.0,0.03,michael makowsky,ECON-2110,2016
-ECON,2110,12,Principles of Microeconomics,0.28,0.44,0.26,0.03,0.0,0.0,0.0,0.0,molly espey,ECON-2110,2016
-ECON,2120,1,Principles of Macroeconomics,0.11,0.32,0.37,0.16,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,2,Principles of Macroeconomics,0.18,0.12,0.47,0.18,0.0,0.0,0.0,0.06,scott baier,ECON-2120,2016
-ECON,2120,3,Principles of Macroeconomics,0.2,0.3,0.35,0.05,0.1,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,4,Principles of Macroeconomics,0.26,0.32,0.32,0.05,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,5,Principles of Macroeconomics,0.3,0.35,0.25,0.1,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,6,Principles of Macroeconomics,0.17,0.33,0.39,0.06,0.0,0.0,0.0,0.06,scott baier,ECON-2120,2016
-ECON,2120,7,Principles of Macroeconomics,0.28,0.33,0.22,0.17,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,8,Principles of Macroeconomics,0.21,0.37,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,9,Principles of Macroeconomics,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,10,Principles of Macroeconomics,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,scott baier,ECON-2120,2016
-ECON,2120,11,Principles of Macroeconomics,0.26,0.26,0.42,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,12,Principles of Macroeconomics,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,13,Principles of Macroeconomics,0.37,0.11,0.32,0.05,0.11,0.0,0.0,0.05,scott baier,ECON-2120,2016
-ECON,2120,14,Principles of Macroeconomics,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,15,Principles of Macroeconomics,0.43,0.38,0.19,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,16,Principles of Macroeconomics,0.17,0.17,0.67,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,17,Principles of Macroeconomics,0.37,0.37,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,18,Principles of Macroeconomics,0.42,0.26,0.16,0.11,0.0,0.0,0.0,0.05,scott baier,ECON-2120,2016
-ECON,2120,19,Principles of Macroeconomics,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2016
-ECON,2120,20,Principles of Macroeconomics,0.25,0.31,0.36,0.07,0.0,0.0,0.0,0.0,peter david lorenz,ECON-2120,2016
-ECON,2120,21,Principles of Macroeconomics,0.61,0.32,0.06,0.0,0.02,0.0,0.0,0.0,mallika garg,ECON-2120,2016
-ECON,2120,22,Principles of Macroeconomics,0.22,0.39,0.27,0.07,0.0,0.0,0.0,0.05,andew swanson,ECON-2120,2016
-ECON,2120,23,Principles of Macroeconomics,0.36,0.39,0.08,0.06,0.08,0.0,0.0,0.03,shan jiang,ECON-2120,2016
-ECON,2120,24,Principles of Macroeconomics,0.2,0.58,0.19,0.03,0.01,0.0,0.0,0.0,scott barkowski,ECON-2120,2016
-ECON,2120,25,Principles of Macroeconomics,0.19,0.56,0.19,0.06,0.0,0.0,0.0,0.0,scott barkowski,ECON-2120,2016
-ECON,2120,26,Principles of Macroeconomics,0.18,0.06,0.15,0.21,0.06,0.0,0.0,0.33,ralph charles allen,ECON-2120,2016
-ECON,2120,27,Principles of Macroeconomics,0.21,0.45,0.27,0.0,0.0,0.0,0.0,0.06,chen wang,ECON-2120,2016
-ECON,3020,1,Money and Banking,0.15,0.36,0.3,0.03,0.0,0.0,0.0,0.15,randall scot cragun,ECON-3020,2016
-ECON,3060,1,Managerial Economics,0.19,0.36,0.17,0.11,0.06,0.0,0.0,0.11,jacob burgdorf,ECON-3060,2016
-ECON,3100,1,International Econ,0.16,0.28,0.19,0.16,0.16,0.0,0.0,0.06,michal jerzmanowski,ECON-3100,2016
-ECON,3140,1,Intermediate Micro,0.17,0.24,0.27,0.15,0.1,0.0,0.0,0.07,robert kennet fleck,ECON-3140,2016
-ECON,3140,2,Intermediate Micro,0.19,0.3,0.35,0.0,0.03,0.0,0.0,0.14,kevin ka kin tsui,ECON-3140,2016
-ECON,3140,3,Intermediate Micro,0.18,0.3,0.25,0.1,0.08,0.0,0.0,0.1,frederick hanssen,ECON-3140,2016
-ECON,3150,1,Intermediate Macro,0.3,0.21,0.21,0.06,0.06,0.0,0.0,0.15,randall scot cragun,ECON-3150,2016
-ECON,3150,2,Intermediate Macro,0.51,0.15,0.18,0.08,0.03,0.0,0.0,0.05,sergey vla mityakov,ECON-3150,2016
-ECON,3190,2,Environmental Econ,0.21,0.43,0.21,0.07,0.04,0.0,0.0,0.04,scott templeton,ECON-3190,2016
-ECON,3400,1,Behavioral Economics,0.51,0.4,0.09,0.0,0.0,0.0,0.0,0.0,daniel wood,ECON-3400,2016
-ECON,3440,1,Property Rights,0.11,0.26,0.3,0.19,0.07,0.0,0.0,0.07,dar litsukova-bokar,ECON-3440,2016
-ECON,3600,1,Public Choice,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,robert dew tollison,ECON-3600,2016
-ECON,4010,1,Labor Mkt Analysis,0.31,0.54,0.12,0.0,0.04,0.0,0.0,0.0,curtis simon,ECON-4010,2016
-ECON,4020,1,Law and Economics,0.23,0.48,0.23,0.0,0.03,0.0,0.0,0.03,thomas wins hazlett,ECON-4020,2016
-ECON,4050,1,Intro to Econometric,0.35,0.31,0.15,0.1,0.08,0.0,0.0,0.02,scott baier,ECON-4050,2016
-ECON,4060,1,Advanced Econometric,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,babur de los santos,ECON-4060,2016
-ECON,4240,1,Organization of Ind,0.42,0.38,0.13,0.04,0.04,0.0,0.0,0.0,matthew lewis,ECON-4240,2016
-ECON,4260,1,Sem Sport Economics,0.52,0.43,0.0,0.0,0.04,0.0,0.0,0.0,raymond sauer,ECON-4260,2016
-ECON,4270,1,Dev American Economy,0.33,0.44,0.15,0.07,0.0,0.0,0.0,0.0,howard ne bodenhorn,ECON-4270,2016
-ECON,4280,1,Cost-Benefit Anlysis,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,william dougan,ECON-4280,2016
-ECON,4290,1,Economics of Energy Markets,0.46,0.35,0.12,0.0,0.04,0.0,0.0,0.04,matthew lewis,ECON-4290,2016
-ECON,4400,1,Game Theory,0.25,0.25,0.42,0.0,0.08,0.0,0.0,0.0,charles thomas,ECON-4400,2016
-ECON,6020,1,Law and Economics,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,ECON-6020,2016
-ECON,6060,1,Advanced Econometric,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,babur de los santos,ECON-6060,2016
-ECON,6400,1,Game Theory,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,charles thomas,ECON-6400,2016
-ECON,8020,2,Adv Econ Concepts and Applic I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,ECON-8020,2016
-ECON,8050,1,Macroeconomic Theory,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,ECON-8050,2016
-ECON,8070,1,Econometrics II,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,chungsang lam,ECON-8070,2016
-ECON,8110,1,Econ of Environment,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,scott templeton,ECON-8110,2016
-ECON,8200,1,Public Finance,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,william dougan,ECON-8200,2016
-ECON,8990,4,History of Econ-Modern Macro,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michel devroey,ECON-8990,2016
-ECON,9010,2,Price Theory,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel wood,ECON-9010,2016
-ECON,9090,1,Time-Series Econ,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,ECON-9090,2016
-ED,3970,7,Creative Inquiry in Education,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,david matthew boyer,ED-3970,2016
-ED,3970,28,Creative Inquiry Education,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-3970,2016
-ED,8380,504,Becoming a Reflective Praction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,ED-8380,2016
-ED,8380,531,Literacy Lessons for Indiv II,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,morgan jones bowie,ED-8380,2016
-ED,8380,539,Literacy Lessons for Indiv II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,andrea chri overton,ED-8380,2016
-ED,8390,500,Intro to Linguistics,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,daniel smith,ED-8390,2016
-ED,8670,500,Practicum in ESOL Instruction,0.69,0.08,0.08,0.0,0.08,0.0,0.0,0.08,margaret mar warner,ED-8670,2016
-EDC,3900,2,Skills for Stu Leads,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,eric pernotto,EDC-3900,2016
-EDC,3900,4,Skills for Stu Leads,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,eric pernotto,EDC-3900,2016
-EDEC,2200,1,Family/School/Com,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-2200,2016
-EDEL,4510,1,Elem Methods in Science Tchg,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,EDEL-4510,2016
-EDEL,4520,1,Elem Methods Math Teaching,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,EDEL-4520,2016
-EDEL,4870,1,Ele Meth Soc Studies,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,EDEL-4870,2016
-EDF,3010,1,Principles of American Educat,0.66,0.23,0.09,0.0,0.03,0.0,0.0,0.0,suzanne rosenblith,EDF-3010,2016
-EDF,3010,2,Principles of American Educat,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,nafees mohamma khan,EDF-3010,2016
-EDF,3010,3,Principles of American Educat,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,EDF-3010,2016
-EDF,3020,1,Educational Psychology,0.41,0.44,0.09,0.06,0.0,0.0,0.0,0.0,penelope mar vargas,EDF-3020,2016
-EDF,3020,3,Educational Psychology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,EDF-3020,2016
-EDF,3020,6,Educational Psychology,0.4,0.46,0.14,0.0,0.0,0.0,0.0,0.0,penelope mar vargas,EDF-3020,2016
-EDF,3340,1,Child Growth and Development,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,EDF-3340,2016
-EDF,3340,2,Child Growth and Development,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,EDF-3340,2016
-EDF,4800,2,Digital Media & Learning,0.91,0.05,0.05,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2016
-EDF,4800,300,Digital Media & Learning,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david matthew boyer,EDF-4800,2016
-EDF,8080,300,Ed Tests and Measure,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,deborah switzer,EDF-8080,2016
-EDL,7150,502,Sch & Comm Relations,0.86,0.05,0.0,0.0,0.05,0.0,0.0,0.05,frederick buskey,EDL-7150,2016
-EDL,7350,500,Educational Eval,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,EDL-7350,2016
-EDL,7400,502,Curr Plan: Sch Adm,0.71,0.21,0.0,0.0,0.04,0.0,0.0,0.04,elizabeth reynolds,EDL-7400,2016
-EDL,7510,400,El Prin & Spv Ex II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth reynolds,EDL-7510,2016
-EDL,7650,1,Assessment Hi Edu,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,EDL-7650,2016
-EDL,7650,2,Assessment Hi Edu,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,EDL-7650,2016
-EDL,8390,400,Research in Ed L,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,EDL-8390,2016
-EDL,9110,501,Systematic Inq Ed L,0.47,0.4,0.0,0.0,0.0,0.0,0.0,0.13,jane lindle,EDL-9110,2016
-EDLT,4580,1,Early Literacy: Birth-Kindergn,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4580,2016
-EDLT,4620,1,Reading Children's Lit in Elem,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4620,2016
-EDLT,8100,400,Foundations: Reading & Writing,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,phillip mich wilder,EDLT-8100,2016
-EDLT,8150,500,Guided Reading & Writng Scaffo,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,EDLT-8150,2016
-EDLT,8270,300,Content Area Rdg/Wtg-MS & HS,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8270,2016
-EDLT,8270,501,Content Area Rdg/Wtg-MS & HS,0.85,0.03,0.0,0.0,0.03,0.0,0.0,0.1,phillip mich wilder,EDLT-8270,2016
-EDSA,8190,1,Contemporary College Student,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,michelle boettcher,EDSA-8190,2016
-EDSC,4370,1,Technology in Math,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,EDSC-4370,2016
-EDSP,3700,2,Intro to Special Education,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,michael wayne riley,EDSP-3700,2016
-EDSP,3700,3,Intro to Special Education,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,pamela stecker,EDSP-3700,2016
-EDSP,3750,1,Early Intervention Spec Needs,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,EDSP-3750,2016
-EDSP,4910,1,Ed Assess Ind W/Dis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,EDSP-4910,2016
-EDSP,4950,1,Comm & Collab Sp Ed,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sara moo mackiewicz,EDSP-4950,2016
-EES,2020,1,Environ Engr Fundamentals II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,EES-2020,2016
-EES,3100,2,Intro to Nuclear Engineering,0.2,0.27,0.07,0.0,0.07,0.0,0.0,0.4,timothy devol,EES-3100,2016
-EES,4010,1,Environmental Engr,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth carraway,EES-4010,2016
-EES,4010,2,Environmental Engr,0.46,0.34,0.09,0.06,0.0,0.0,0.0,0.06,thomas overcamp,EES-4010,2016
-EES,4750,1,Capstone Design Project,0.69,0.25,0.03,0.0,0.0,0.0,0.0,0.03,david allen ladner,EES-4750,2016
-EES,4840,2,Solid Waste Mgt,0.35,0.49,0.16,0.0,0.0,0.0,0.0,0.0,thomas overcamp,EES-4840,2016
-EES,4850,2,Hazard Waste Management,0.16,0.47,0.29,0.05,0.0,0.0,0.0,0.03,mark schlautman,EES-4850,2016
-EES,6110,1,Rad Detection Mmt,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,timothy devol,EES-6110,2016
-EES,8030,1,Phy/Chem Ops W/WW T,0.36,0.55,0.0,0.0,0.09,0.0,0.0,0.0,ezra lucas ho cates,EES-8030,2016
-EES,8040,1,Biochem Ops WW Trt,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,david freedman,EES-8040,2016
-EES,8090,1,Subsurface Remed Mod,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,ronald falta,EES-8090,2016
-EES,8120,1,Env Nuclear Engr,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,lin shuller-nickles,EES-8120,2016
-ELE,3010,1,Intro to Entre,0.05,0.48,0.4,0.05,0.03,0.0,0.0,0.0,ashley will parnell,ELE-3010,2016
-ELE,3010,2,Intro to Entre,0.32,0.61,0.05,0.0,0.0,0.0,0.0,0.02,chad navis,ELE-3010,2016
-ELE,3010,3,Intro to Entre,0.39,0.59,0.02,0.0,0.0,0.0,0.0,0.0,chad navis,ELE-3010,2016
-ELE,4010,1,Exec Lead & Entr II,0.13,0.38,0.35,0.15,0.0,0.0,0.0,0.0,ashley will parnell,ELE-4010,2016
-ENGL,1030,1,Accelerated Composition,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,emily anne boyter,ENGL-1030,2016
-ENGL,1030,2,Accelerated Composition,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,kristen joy hixon,ENGL-1030,2016
-ENGL,1030,3,Accelerated Composition,0.35,0.59,0.0,0.0,0.0,0.0,0.0,0.06,mary dickens,ENGL-1030,2016
-ENGL,1030,4,Accelerated Composition,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,caroline ca swanson,ENGL-1030,2016
-ENGL,1030,7,Accelerated Composition,0.75,0.1,0.0,0.0,0.1,0.0,0.0,0.05,kristen joy hixon,ENGL-1030,2016
-ENGL,1030,8,Accelerated Composition,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,todd rossi smith,ENGL-1030,2016
-ENGL,1030,9,Accelerated Composition,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,mary dickens,ENGL-1030,2016
-ENGL,1030,10,Accelerated Composition,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,teneshia head,ENGL-1030,2016
-ENGL,1030,11,Accelerated Composition,0.56,0.39,0.0,0.0,0.06,0.0,0.0,0.0,caroline ca swanson,ENGL-1030,2016
-ENGL,1030,12,Accelerated Composition,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,ENGL-1030,2016
-ENGL,1030,13,Accelerated Composition,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,rebecca nico shaver,ENGL-1030,2016
-ENGL,1030,14,Accelerated Composition,0.33,0.52,0.1,0.05,0.0,0.0,0.0,0.0,andrew mathas,ENGL-1030,2016
-ENGL,1030,15,Accelerated Composition,0.45,0.2,0.2,0.1,0.0,0.0,0.0,0.05,andrew mathas,ENGL-1030,2016
-ENGL,1030,16,Accelerated Composition,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,charlotte powell,ENGL-1030,2016
-ENGL,1030,17,Accelerated Composition,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,karen mary stewart,ENGL-1030,2016
-ENGL,1030,18,Accelerated Composition,0.8,0.05,0.05,0.0,0.0,0.0,0.0,0.1,daniel frank,ENGL-1030,2016
-ENGL,1030,19,Accelerated Composition,0.8,0.1,0.0,0.05,0.0,0.0,0.0,0.05,brian lee gaines,ENGL-1030,2016
-ENGL,1030,20,Accelerated Composition,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,rebecca nico shaver,ENGL-1030,2016
-ENGL,1030,21,Accelerated Composition,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,charlotte powell,ENGL-1030,2016
-ENGL,1030,22,Accelerated Composition,0.8,0.05,0.1,0.0,0.05,0.0,0.0,0.0,samuel jacks fuller,ENGL-1030,2016
-ENGL,1030,23,Accelerated Composition,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,shawn andrew stowe,ENGL-1030,2016
-ENGL,1030,24,Accelerated Composition,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0,nathan riggs,ENGL-1030,2016
-ENGL,1030,25,Accelerated Composition,0.62,0.15,0.08,0.08,0.0,0.0,0.0,0.08,brian lee gaines,ENGL-1030,2016
-ENGL,1030,26,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-1030,2016
-ENGL,1030,30,Accelerated Composition,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,eda ozyesilpinar,ENGL-1030,2016
-ENGL,1030,31,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kristen gay,ENGL-1030,2016
-ENGL,1030,32,Accelerated Composition,0.76,0.0,0.06,0.06,0.0,0.0,0.0,0.12,katie jo vann,ENGL-1030,2016
-ENGL,1030,35,Accelerated Composition,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,jack butts,ENGL-1030,2016
-ENGL,1030,36,Accelerated Composition,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,april obrien,ENGL-1030,2016
-ENGL,1030,37,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kristen gay,ENGL-1030,2016
-ENGL,1030,39,Accelerated Composition,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,joshua wood,ENGL-1030,2016
-ENGL,1030,41,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,kellie eliz osborne,ENGL-1030,2016
-ENGL,1030,42,Accelerated Composition,0.65,0.25,0.05,0.0,0.0,0.0,0.0,0.05,jennifer moeder,ENGL-1030,2016
-ENGL,1030,44,Accelerated Composition,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,eric stephens,ENGL-1030,2016
-ENGL,1030,46,Accelerated Composition,0.9,0.0,0.05,0.0,0.05,0.0,0.0,0.0,eric stephens,ENGL-1030,2016
-ENGL,1030,51,Accelerated Composition,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,danielle shuff,ENGL-1030,2016
-ENGL,1030,53,Accelerated Composition,0.7,0.05,0.05,0.15,0.05,0.0,0.0,0.0,kellie eliz osborne,ENGL-1030,2016
-ENGL,1030,54,Accelerated Composition,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,jack butts,ENGL-1030,2016
-ENGL,1030,55,Accelerated Composition,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,stephen quigley,ENGL-1030,2016
-ENGL,1030,56,Accelerated Composition,0.8,0.0,0.1,0.0,0.05,0.0,0.0,0.05,jennifer moeder,ENGL-1030,2016
-ENGL,1030,58,Accelerated Composition,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,daniel frank,ENGL-1030,2016
-ENGL,1030,60,Accelerated Composition,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,danielle shuff,ENGL-1030,2016
-ENGL,1030,64,Accelerated Composition,0.71,0.14,0.07,0.0,0.07,0.0,0.0,0.0,madison ali johnson,ENGL-1030,2016
-ENGL,1030,65,Accelerated Composition,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,stephen quigley,ENGL-1030,2016
-ENGL,1030,68,Accelerated Composition,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2016
-ENGL,1030,70,Accelerated Composition,0.63,0.16,0.05,0.0,0.11,0.0,0.0,0.05,joshua wood,ENGL-1030,2016
-ENGL,1030,71,Accelerated Composition,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-1030,2016
-ENGL,1030,72,Accelerated Composition,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,madison ali johnson,ENGL-1030,2016
-ENGL,1030,73,Accelerated Composition,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,teneshia head,ENGL-1030,2016
-ENGL,1030,502,Accelerated Composition,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,edward collins,ENGL-1030,2016
-ENGL,2120,1,World Literature,0.17,0.72,0.06,0.0,0.06,0.0,0.0,0.0,gabriel and hankins,ENGL-2120,2016
-ENGL,2120,3,World Literature,0.5,0.21,0.04,0.08,0.0,0.0,0.0,0.17,candace wiley,ENGL-2120,2016
-ENGL,2120,6,World Literature,0.46,0.35,0.12,0.0,0.0,0.0,0.0,0.08,candace wiley,ENGL-2120,2016
-ENGL,2120,7,World Literature,0.37,0.27,0.23,0.07,0.03,0.0,0.0,0.03,andrew mathas,ENGL-2120,2016
-ENGL,2120,9,World Literature,0.34,0.34,0.17,0.03,0.07,0.0,0.0,0.03,andrew mathas,ENGL-2120,2016
-ENGL,2120,11,World Literature,0.57,0.29,0.11,0.0,0.04,0.0,0.0,0.0,krist aldebol-hazle,ENGL-2120,2016
-ENGL,2120,12,World Literature,0.66,0.14,0.21,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,ENGL-2120,2016
-ENGL,2120,13,World Literature,0.27,0.57,0.17,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2120,2016
-ENGL,2120,14,World Literature,0.17,0.45,0.17,0.07,0.03,0.0,0.0,0.1,meg woosley-goodman,ENGL-2120,2016
-ENGL,2120,15,World Literature (HON),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,meg woosley-goodman,ENGL-2120,2016
-ENGL,2120,16,World Literature,0.19,0.48,0.22,0.0,0.07,0.0,0.0,0.04,meg woosley-goodman,ENGL-2120,2016
-ENGL,2120,17,World Literature,0.63,0.27,0.03,0.0,0.0,0.0,0.0,0.07,lucian ghita,ENGL-2120,2016
-ENGL,2120,18,World Literature,0.59,0.21,0.14,0.0,0.0,0.0,0.0,0.07,lucian ghita,ENGL-2120,2016
-ENGL,2120,19,World Literature,0.43,0.39,0.04,0.07,0.0,0.0,0.0,0.07,sarah mae cooper,ENGL-2120,2016
-ENGL,2130,1,British Literature,0.7,0.23,0.0,0.0,0.0,0.0,0.0,0.07,jeffrey fallis,ENGL-2130,2016
-ENGL,2130,2,British Literature,0.45,0.38,0.1,0.0,0.0,0.0,0.0,0.07,christopher benson,ENGL-2130,2016
-ENGL,2130,3,British Literature,0.57,0.33,0.07,0.0,0.03,0.0,0.0,0.0,christopher benson,ENGL-2130,2016
-ENGL,2130,4,British Literature,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,ENGL-2130,2016
-ENGL,2130,5,British Literature,0.76,0.14,0.03,0.03,0.0,0.0,0.0,0.03,stephanie stripling,ENGL-2130,2016
-ENGL,2130,6,British Literature,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,jeffrey fallis,ENGL-2130,2016
-ENGL,2130,7,British Literature,0.66,0.31,0.0,0.0,0.0,0.0,0.0,0.03,jeffrey fallis,ENGL-2130,2016
-ENGL,2130,10,British Literature,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,krist aldebol-hazle,ENGL-2130,2016
-ENGL,2130,11,British Literature,0.79,0.11,0.04,0.04,0.0,0.0,0.0,0.04,krist aldebol-hazle,ENGL-2130,2016
-ENGL,2130,12,British Literature,0.73,0.23,0.0,0.0,0.0,0.0,0.0,0.03,lucian ghita,ENGL-2130,2016
-ENGL,2130,13,British Literature,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2016
-ENGL,2140,1,American Literature,0.53,0.27,0.13,0.0,0.03,0.0,0.0,0.03,john morgenstern,ENGL-2140,2016
-ENGL,2140,2,American Literature,0.45,0.24,0.14,0.0,0.14,0.0,0.0,0.03,elizabeth stansell,ENGL-2140,2016
-ENGL,2140,3,American Literature,0.12,0.31,0.31,0.04,0.04,0.0,0.0,0.19,david charles foltz,ENGL-2140,2016
-ENGL,2140,4,American Literature,0.62,0.31,0.03,0.0,0.0,0.0,0.0,0.03,sherri teres allred,ENGL-2140,2016
-ENGL,2140,5,American Literature,0.36,0.39,0.04,0.04,0.0,0.0,0.0,0.18,candace wiley,ENGL-2140,2016
-ENGL,2140,6,American Literature,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,candace wiley,ENGL-2140,2016
-ENGL,2140,7,American Literature,0.62,0.1,0.21,0.03,0.03,0.0,0.0,0.0,sherri teres allred,ENGL-2140,2016
-ENGL,2140,8,American Literature,0.84,0.1,0.0,0.0,0.03,0.0,0.0,0.03,geveryl le robinson,ENGL-2140,2016
-ENGL,2140,9,American Literature,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,stephanie stripling,ENGL-2140,2016
-ENGL,2140,11,American Literature,0.73,0.17,0.03,0.03,0.03,0.0,0.0,0.0,stephanie stripling,ENGL-2140,2016
-ENGL,2140,12,American Literature,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,ENGL-2140,2016
-ENGL,2140,13,American Literature,0.23,0.42,0.31,0.0,0.0,0.0,0.0,0.04,david charles foltz,ENGL-2140,2016
-ENGL,2140,14,American Literature,0.07,0.62,0.17,0.0,0.03,0.0,0.0,0.1,rhondda robi thomas,ENGL-2140,2016
-ENGL,2140,15,American Literature,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,april susanne pelt,ENGL-2140,2016
-ENGL,2140,17,American Literature,0.47,0.33,0.1,0.0,0.03,0.0,0.0,0.07,william stanton,ENGL-2140,2016
-ENGL,2140,18,American Literature,0.57,0.23,0.13,0.0,0.03,0.0,0.0,0.03,william stanton,ENGL-2140,2016
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.53,0.37,0.07,0.03,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2016
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.47,0.27,0.17,0.0,0.03,0.0,0.0,0.07,megan no macalystre,ENGL-2150,2016
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.47,0.33,0.07,0.13,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-2150,2016
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.8,0.13,0.0,0.0,0.03,0.0,0.0,0.03,alexander kudera,ENGL-2150,2016
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,alexander kudera,ENGL-2150,2016
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-2150,2016
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.22,0.48,0.11,0.0,0.04,0.0,0.0,0.15,karen kettnich,ENGL-2150,2016
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.21,0.43,0.25,0.04,0.04,0.0,0.0,0.04,karen kettnich,ENGL-2150,2016
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.57,0.3,0.1,0.0,0.03,0.0,0.0,0.0,john logan pursley,ENGL-2150,2016
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,sharon kathl nalley,ENGL-2150,2016
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.23,0.27,0.27,0.04,0.04,0.0,0.0,0.15,david charles foltz,ENGL-2150,2016
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.21,0.34,0.31,0.03,0.0,0.0,0.0,0.1,david charles foltz,ENGL-2150,2016
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.8,0.13,0.03,0.0,0.0,0.0,0.0,0.03,sharon kathl nalley,ENGL-2150,2016
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.0,0.69,0.31,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-2150,2016
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.38,0.48,0.07,0.03,0.0,0.0,0.0,0.03,john logan pursley,ENGL-2150,2016
-ENGL,3000,1,Professional Develop,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,austin gorman,ENGL-3000,2016
-ENGL,3040,2,Business Writing,0.73,0.14,0.05,0.0,0.05,0.0,0.0,0.05,philip randall,ENGL-3040,2016
-ENGL,3040,3,Business Writing,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,alexander kudera,ENGL-3040,2016
-ENGL,3040,5,Business Writing,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,crystal pa stephens,ENGL-3040,2016
-ENGL,3040,13,Business Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3040,2016
-ENGL,3040,14,Business Writing,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,ENGL-3040,2016
-ENGL,3040,16,Business Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,ENGL-3040,2016
-ENGL,3040,17,Business Writing,0.38,0.52,0.0,0.0,0.0,0.0,0.0,0.1,katalin beck,ENGL-3040,2016
-ENGL,3040,18,Business Writing,0.24,0.67,0.1,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3040,2016
-ENGL,3040,19,Business Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-3040,2016
-ENGL,3040,20,Business Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sherri teres allred,ENGL-3040,2016
-ENGL,3040,22,Business Writing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,austin gorman,ENGL-3040,2016
-ENGL,3040,400,Business Writing,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-3040,2016
-ENGL,3100,1,Crit Writ Lit,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-3100,2016
-ENGL,3100,2,Crit Writ Lit,0.39,0.39,0.22,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,ENGL-3100,2016
-ENGL,3100,4,Crit Writ Lit,0.19,0.5,0.19,0.06,0.06,0.0,0.0,0.0,erin marina goss,ENGL-3100,2016
-ENGL,3120,1,Advanced Composition,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2016
-ENGL,3120,2,Advanced Composition,0.42,0.32,0.05,0.05,0.16,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2016
-ENGL,3140,1,Technical Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,ENGL-3140,2016
-ENGL,3140,2,Technical Writing,0.41,0.5,0.09,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2016
-ENGL,3140,3,Technical Writing,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,adrian carson,ENGL-3140,2016
-ENGL,3140,5,Technical Writing,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,ENGL-3140,2016
-ENGL,3140,6,Technical Writing,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,christopher benson,ENGL-3140,2016
-ENGL,3140,7,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-3140,2016
-ENGL,3140,9,Technical Writing,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,adrian carson,ENGL-3140,2016
-ENGL,3140,10,Technical Writing,0.29,0.57,0.1,0.0,0.05,0.0,0.0,0.0,katalin beck,ENGL-3140,2016
-ENGL,3140,12,Technical Writing,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,ENGL-3140,2016
-ENGL,3140,13,Technical Writing,0.76,0.1,0.05,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,ENGL-3140,2016
-ENGL,3140,15,Technical Writing,0.7,0.15,0.0,0.0,0.05,0.0,0.0,0.1,geveryl le robinson,ENGL-3140,2016
-ENGL,3140,16,Technical Writing,0.38,0.52,0.0,0.1,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2016
-ENGL,3140,17,Technical Writing,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3140,2016
-ENGL,3140,18,Technical Writing,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2016
-ENGL,3140,19,Technical Writing,0.59,0.23,0.14,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,ENGL-3140,2016
-ENGL,3140,20,Technical Writing,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2016
-ENGL,3140,24,Technical Writing,0.45,0.4,0.05,0.05,0.05,0.0,0.0,0.0,william pulley,ENGL-3140,2016
-ENGL,3140,25,Technical Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sean morey,ENGL-3140,2016
-ENGL,3150,1,Scientific Writing & Comm,0.5,0.25,0.1,0.05,0.0,0.0,0.0,0.1,william pulley,ENGL-3150,2016
-ENGL,3150,2,Scientific Writing & Comm,0.05,0.7,0.1,0.05,0.0,0.0,0.0,0.1,barbara ramirez,ENGL-3150,2016
-ENGL,3150,5,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2016
-ENGL,3150,18,Scientific Writing & Comm,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,ENGL-3150,2016
-ENGL,3150,21,Scientific Writing & Comm,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,john conway,ENGL-3150,2016
-ENGL,3150,23,Scientific Writing & Comm,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,john conway,ENGL-3150,2016
-ENGL,3320,1,Visual Communication,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,david blakesley,ENGL-3320,2016
-ENGL,3370,3,Creative Inquiry: English,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,susanna ashton,ENGL-3370,2016
-ENGL,3450,1,Structure of Fiction,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,nicholas chri brown,ENGL-3450,2016
-ENGL,3460,1,Structure of Poetry,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-3460,2016
-ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,angela naimou,ENGL-3530,2016
-ENGL,3570,1,Film,0.16,0.58,0.11,0.0,0.11,0.0,0.0,0.05,amy monaghan,ENGL-3570,2016
-ENGL,3570,2,Film,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,amy monaghan,ENGL-3570,2016
-ENGL,3800,1,Women Writers,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,meg woosley-goodman,ENGL-3800,2016
-ENGL,3960,1,Brit Lit Survey I,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,brian mcgrath,ENGL-3960,2016
-ENGL,3970,1,Brit Lit Survey II,0.45,0.35,0.15,0.0,0.0,0.0,0.0,0.05,david sweene coombs,ENGL-3970,2016
-ENGL,3980,1,Amer Lit Survey I,0.55,0.32,0.0,0.0,0.14,0.0,0.0,0.0,dominic mastroianni,ENGL-3980,2016
-ENGL,3980,2,Amer Lit Survey I,0.33,0.38,0.24,0.0,0.05,0.0,0.0,0.0,susanna ashton,ENGL-3980,2016
-ENGL,3990,1,Amer Lit Survey II,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-3990,2016
-ENGL,4110,1,Shakespeare,0.24,0.52,0.14,0.05,0.05,0.0,0.0,0.0,andrew lemons,ENGL-4110,2016
-ENGL,4150,1,Restor & 18th Cent,0.0,0.67,0.22,0.0,0.06,0.0,0.0,0.06,lee morrissey,ENGL-4150,2016
-ENGL,4200,1,Amer Lit to 1799,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,jonathan beec field,ENGL-4200,2016
-ENGL,4310,1,Modern Poetry,0.38,0.46,0.08,0.0,0.08,0.0,0.0,0.0,wayne chapman,ENGL-4310,2016
-ENGL,4320,1,Modern Fiction,0.31,0.5,0.06,0.06,0.06,0.0,0.0,0.0,gabriel and hankins,ENGL-4320,2016
-ENGL,4350,1,Literary Criticism,0.42,0.42,0.05,0.0,0.05,0.0,0.0,0.05,jonathan beec field,ENGL-4350,2016
-ENGL,4420,1,Cultural Studies,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,garry bertholf,ENGL-4420,2016
-ENGL,4450,1,Fiction Workshop,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-4450,2016
-ENGL,4460,1,Poetry Workshop,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-4460,2016
-ENGL,4520,1,Great Directors,0.33,0.33,0.27,0.0,0.0,0.0,0.0,0.07,agnieszka skrodzka,ENGL-4520,2016
-ENGL,4530,1,Sexuality and Cinema,0.33,0.53,0.07,0.07,0.0,0.0,0.0,0.0,agnieszka skrodzka,ENGL-4530,2016
-ENGL,4590,2,Spec Top Lang Criticism Theory,0.39,0.28,0.28,0.0,0.06,0.0,0.0,0.0,lindsay carr thomas,ENGL-4590,2016
-ENGL,4630,1,Lit to 1699: Old English,0.71,0.18,0.06,0.06,0.0,0.0,0.0,0.0,andrew lemons,ENGL-4630,2016
-ENGL,4640,1,Topics in Literature 1700-1899,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,erin marina goss,ENGL-4640,2016
-ENGL,4650,1,Topics in Literature from 1900,0.65,0.18,0.06,0.0,0.06,0.0,0.0,0.06,angela naimou,ENGL-4650,2016
-ENGL,4750,1,Writing for Media,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,tharon howard,ENGL-4750,2016
-ENGL,4830,1,Af Am Lit 1920-Pres,0.69,0.13,0.06,0.0,0.0,0.0,0.0,0.13,garry bertholf,ENGL-4830,2016
-ENGL,4890,1,Topics Write & Publ,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,megan eatman,ENGL-4890,2016
-ENGL,4920,1,Modern Rhetoric,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,brian mcgrath,ENGL-4920,2016
-ENGL,4960,1,Senior Seminar,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,michael lemahieu,ENGL-4960,2016
-ENGL,4960,2,Senior Seminar,0.62,0.15,0.15,0.0,0.0,0.0,0.0,0.08,david sweene coombs,ENGL-4960,2016
-ENGL,4960,3,Senior Seminar,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-4960,2016
-ENGL,8120,1,Digital Approaches-Lit/Cul Stu,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,lindsay carr thomas,ENGL-8120,2016
-ENGL,8500,1,Methods Prof Comm,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tharon howard,ENGL-8500,2016
-ENGR,1020,615,Engineering Discipl & Skills,0.17,0.32,0.17,0.11,0.13,0.0,0.0,0.09,ashley childers,ENGR-1020,2016
-ENGR,1020,618,Engineering Discipl & Skills,0.11,0.22,0.35,0.05,0.08,0.0,0.0,0.19,ashley childers,ENGR-1020,2016
-ENGR,1060,400,Engr Discipline & Skills II,0.0,0.21,0.35,0.15,0.24,0.0,0.0,0.06,ashley childers,ENGR-1060,2016
-ENGR,1060,402,Engr Discipline & Skills II,0.0,0.17,0.38,0.22,0.03,0.0,0.0,0.2,michael giebner,ENGR-1060,2016
-ENGR,1060,615,Engr Discipline & Skills II,0.1,0.4,0.3,0.1,0.1,0.0,0.0,0.0,ashley childers,ENGR-1060,2016
-ENGR,1060,618,Engr Discipline & Skills II,0.06,0.47,0.24,0.18,0.0,0.0,0.0,0.06,ashley childers,ENGR-1060,2016
-ENGR,1060,643,Engr Discipline & Skills II,0.03,0.34,0.23,0.23,0.03,0.0,0.0,0.13,michael giebner,ENGR-1060,2016
-ENGR,1060,648,Engr Discipline & Skills II,0.03,0.24,0.42,0.11,0.02,0.0,0.0,0.18,michael giebner,ENGR-1060,2016
-ENGR,1070,648,Programming & Prob Solving I,0.0,0.33,0.25,0.17,0.17,0.0,0.0,0.08,michael giebner,ENGR-1070,2016
-ENGR,1410,121,Programming & Problem Solving,0.18,0.3,0.3,0.07,0.09,0.0,0.0,0.07,william martin,ENGR-1410,2016
-ENGR,1410,122,Programming & Problem Solving,0.31,0.54,0.04,0.06,0.02,0.0,0.0,0.02,william martin,ENGR-1410,2016
-ENGR,1410,123,Programming & Problem Solving,0.21,0.48,0.13,0.08,0.02,0.0,0.0,0.08,mariah magagnotti,ENGR-1410,2016
-ENGR,1410,124,Programming & Problem Solving,0.11,0.6,0.22,0.0,0.07,0.0,0.0,0.0,sheikh moniruz moni,ENGR-1410,2016
-ENGR,1410,125,Programming & Problem Solving,0.13,0.28,0.43,0.09,0.02,0.0,0.0,0.04,roksana mahmud,ENGR-1410,2016
-ENGR,1410,126,Programming & Problem Solving,0.15,0.31,0.31,0.15,0.02,0.0,0.0,0.06,matthew kent miller,ENGR-1410,2016
-ENGR,1410,127,Programming & Problem Solving,0.04,0.43,0.28,0.11,0.09,0.0,0.0,0.06,andrew isaa neptune,ENGR-1410,2016
-ENGR,1410,128,Programming & Problem Solving,0.09,0.21,0.39,0.15,0.09,0.0,0.0,0.06,andrew isaa neptune,ENGR-1410,2016
-ENGR,1410,621,Programming & Problem Solving,0.43,0.34,0.11,0.04,0.06,0.0,0.0,0.02,elizabeth stephan,ENGR-1410,2016
-ENGR,1410,622,Programming & Problem Solving,0.44,0.4,0.04,0.07,0.04,0.0,0.0,0.0,elizabeth stephan,ENGR-1410,2016
-ENGR,1410,623,Programming & Problem Solving,0.33,0.25,0.25,0.02,0.08,0.0,0.0,0.06,srinivasarangan rang,ENGR-1410,2016
-ENGR,1410,624,Programming & Problem Solving,0.23,0.27,0.23,0.06,0.13,0.0,0.0,0.08,srinivasarangan rang,ENGR-1410,2016
-ENGR,1410,625,Programming & Problem Solving,0.27,0.48,0.19,0.04,0.0,0.0,0.0,0.02,steven brandon,ENGR-1410,2016
-ENGR,1410,626,Programming & Problem Solving,0.48,0.27,0.17,0.02,0.04,0.0,0.0,0.02,steven brandon,ENGR-1410,2016
-ENGR,1410,627,Programming & Problem Solving,0.09,0.29,0.38,0.13,0.02,0.0,0.0,0.09,jonathan maier,ENGR-1410,2016
-ENGR,1410,631,Programming & Problem Solving,0.06,0.17,0.29,0.17,0.11,0.0,0.0,0.2,matthew kent miller,ENGR-1410,2016
-ENGR,1410,632,Programming & Problem Solving,0.17,0.38,0.26,0.13,0.0,0.0,0.0,0.06,matthew kent miller,ENGR-1410,2016
-ENGR,1410,634,Programming & Problem Solving,0.08,0.41,0.24,0.1,0.02,0.0,0.0,0.14,andrew isaa neptune,ENGR-1410,2016
-ENGR,1410,636,Programming & Problem Solving,0.13,0.45,0.21,0.02,0.04,0.0,0.0,0.15,mariah magagnotti,ENGR-1410,2016
-ENGR,1410,637,Programming & Problem Solving,0.02,0.28,0.33,0.22,0.09,0.0,0.0,0.07,mariah magagnotti,ENGR-1410,2016
-ENGR,1510,501,Engineering Skills,0.27,0.3,0.24,0.12,0.06,0.0,0.0,0.0,john minor,ENGR-1510,2016
-ENGR,1510,502,Engineering Skills,0.33,0.3,0.13,0.07,0.17,0.0,0.0,0.0,john minor,ENGR-1510,2016
-ENGR,1640,502,Engineering MATLAB Programming,0.3,0.2,0.4,0.0,0.1,0.0,0.0,0.0,jonathan maier,ENGR-1640,2016
-ENGR,1900,79,CI: Engr I Punkin Chunkin,0.81,0.0,0.0,0.0,0.13,0.0,0.0,0.06,huijuan zhao,ENGR-1900,2016
-ENGR,2080,181,Engr Graphics & Machine Design,0.45,0.3,0.13,0.06,0.04,0.0,0.0,0.02,nighat yasmin,ENGR-2080,2016
-ENGR,2080,681,Engr Graphics & Machine Design,0.69,0.18,0.1,0.0,0.02,0.0,0.0,0.02,john minor,ENGR-2080,2016
-ENGR,2080,682,Engr Graphics & Machine Design,0.7,0.17,0.09,0.0,0.04,0.0,0.0,0.0,sarah grigg,ENGR-2080,2016
-ENGR,2080,683,Engr Graphics & Machine Design,0.56,0.22,0.09,0.04,0.04,0.0,0.0,0.06,sarah grigg,ENGR-2080,2016
-ENGR,2080,684,Engr Graphics & Machine Design,0.61,0.24,0.07,0.0,0.06,0.0,0.0,0.02,sarah grigg,ENGR-2080,2016
-ENGR,2080,685,Engr Graphics & Machine Design,0.47,0.32,0.15,0.02,0.02,0.0,0.0,0.02,rahul sharan renu,ENGR-2080,2016
-ENGR,2080,686,Engr Graphics & Machine Design,0.44,0.33,0.13,0.02,0.06,0.0,0.0,0.02,rahul sharan renu,ENGR-2080,2016
-ENGR,2080,687,Engr Graphics & Machine Design,0.53,0.21,0.11,0.09,0.04,0.0,0.0,0.02,anthony pau garland,ENGR-2080,2016
-ENGR,2080,688,Engr Graphics & Machine Design,0.45,0.32,0.06,0.02,0.08,0.0,0.0,0.08,anthony pau garland,ENGR-2080,2016
-ENGR,2100,601,CAD & Engineering Applications,0.54,0.3,0.06,0.06,0.02,0.0,0.0,0.02,kweku tekyi brown,ENGR-2100,2016
-ENGR,2100,602,CAD & Engineering Applications,0.57,0.15,0.11,0.04,0.06,0.0,0.0,0.06,kweku tekyi brown,ENGR-2100,2016
-ENGR,2100,603,CAD & Engineering Applications,0.51,0.37,0.04,0.0,0.04,0.0,0.0,0.04,nighat yasmin,ENGR-2100,2016
-ENGR,2100,604,CAD & Engineering Applications,0.55,0.33,0.06,0.0,0.04,0.0,0.0,0.02,nighat yasmin,ENGR-2100,2016
-ENGR,2200,1,Evaluating Innovations,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,sarah grigg,ENGR-2200,2016
-ENR,1020,1,Intro to Envir & Natur Res II,0.52,0.22,0.1,0.08,0.04,0.0,0.0,0.04,russell barrett,ENR-1020,2016
-ENR,3020,1,Nat Res Measurements,0.5,0.27,0.13,0.1,0.0,0.0,0.0,0.0,lawrence gering,ENR-3020,2016
-ENR,3120,1,Env Risks & Society,0.49,0.32,0.14,0.03,0.0,0.0,0.0,0.03,alan johnson,ENR-3120,2016
-ENR,4130,1,Restoration Ecology,0.31,0.59,0.1,0.0,0.0,0.0,0.0,0.0,althea simone hagan,ENR-4130,2016
-ENR,4500,1,Conservation Issues,0.8,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alan johnson,ENR-4500,2016
-ENR,4500,2,Conservation Issues,0.82,0.09,0.05,0.0,0.0,0.0,0.0,0.05,alan johnson,ENR-4500,2016
-ENSP,2000,1,Intro Environ Sci,0.41,0.34,0.24,0.0,0.0,0.0,0.0,0.0,tom owino,ENSP-2000,2016
-ENSP,2000,2,Intro Environ Sci,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,ENSP-2000,2016
-ENSP,2000,3,Intro Environ Sci,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2016
-ENT,2000,1,Six-Legged Science,0.59,0.29,0.05,0.02,0.02,0.0,0.0,0.02,suellen pometto,ENT-2000,2016
-ETOX,8300,1,Mechanistic Toxicology,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,william baldwin,ETOX-8300,2016
-FCS,8340,1,Research Methods in FCS II,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,natallia ser sianko,FCS-8340,2016
-FCS,8920,61,Program Evaluation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark small,FCS-8920,2016
-FDSC,1020,1,Persp Food Nutrition,0.67,0.28,0.04,0.0,0.0,0.0,0.0,0.01,john mcgregor,FDSC-1020,2016
-FDSC,2140,1,Fd Resources & Soc,0.56,0.3,0.08,0.02,0.01,0.0,0.0,0.04,paul dawson,FDSC-2140,2016
-FDSC,3060,1,Institutional Food Service Mgt,0.62,0.28,0.1,0.0,0.0,0.0,0.0,0.0,angela fraser,FDSC-3060,2016
-FDSC,4020,1,Food Chemistry II,0.58,0.33,0.09,0.0,0.0,0.0,0.0,0.0,feng chen,FDSC-4020,2016
-FDSC,4030,1,Food Ch & Analysis,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,paul dawson,FDSC-4030,2016
-FDSC,4080,1,Food Process Eng,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,felix barron,FDSC-4080,2016
-FDSC,4090,1,TQM for Food & Pckg Industries,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,john mcgregor,FDSC-4090,2016
-FIN,3040,1,Risk & Insurance,0.2,0.32,0.36,0.12,0.0,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2016
-FIN,3050,1,Investment Analysis,0.17,0.39,0.27,0.15,0.0,0.0,0.0,0.02,kerri mcmillan,FIN-3050,2016
-FIN,3050,2,Investment Analysis,0.16,0.28,0.33,0.12,0.09,0.0,0.0,0.02,kerri mcmillan,FIN-3050,2016
-FIN,3050,3,Investment Analysis,0.16,0.42,0.33,0.05,0.0,0.0,0.0,0.05,kerri mcmillan,FIN-3050,2016
-FIN,3060,1,Corporation Finance,0.14,0.17,0.28,0.17,0.16,0.0,0.0,0.08,william hol johnson,FIN-3060,2016
-FIN,3060,2,Corporation Finance,0.1,0.1,0.14,0.29,0.22,0.0,0.0,0.16,william hol johnson,FIN-3060,2016
-FIN,3060,5,Corporation Finance,0.13,0.16,0.25,0.25,0.11,0.0,0.0,0.1,william hol johnson,FIN-3060,2016
-FIN,3060,400,Corporation Finance,0.16,0.29,0.32,0.16,0.03,0.0,0.0,0.05,jack wolf,FIN-3060,2016
-FIN,3060,401,Corporation Finance,0.15,0.32,0.28,0.15,0.0,0.0,0.0,0.09,jack wolf,FIN-3060,2016
-FIN,3060,402,Corporation Finance,0.13,0.29,0.36,0.11,0.06,0.0,0.0,0.05,jack wolf,FIN-3060,2016
-FIN,3070,1,Prin of Real Estate,0.21,0.38,0.28,0.08,0.05,0.0,0.0,0.0,ramon tolb franklin,FIN-3070,2016
-FIN,3070,2,Prin of Real Estate,0.17,0.31,0.39,0.13,0.0,0.0,0.0,0.0,thomas springer,FIN-3070,2016
-FIN,3080,1,Fin Inst & Mkts,0.24,0.29,0.32,0.1,0.02,0.0,0.0,0.02,daniel thoma greene,FIN-3080,2016
-FIN,3080,2,Fin Inst & Mkts,0.25,0.45,0.23,0.08,0.0,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2016
-FIN,3080,3,Fin Inst & Mkts,0.44,0.28,0.26,0.03,0.0,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2016
-FIN,3110,1,Financial Management I,0.04,0.23,0.38,0.19,0.04,0.0,0.0,0.12,george bra lockhart,FIN-3110,2016
-FIN,3110,2,Financial Management I,0.12,0.28,0.33,0.14,0.07,0.0,0.0,0.07,george bra lockhart,FIN-3110,2016
-FIN,3110,3,Financial Management I,0.06,0.4,0.36,0.02,0.08,0.0,0.0,0.08,ramon tolb franklin,FIN-3110,2016
-FIN,3110,4,Financial Management I,0.17,0.23,0.33,0.04,0.06,0.0,0.0,0.17,george bra lockhart,FIN-3110,2016
-FIN,3120,1,Financial Management II,0.11,0.33,0.31,0.19,0.03,0.0,0.0,0.03,vincent intintoli,FIN-3120,2016
-FIN,3120,2,Financial Management II,0.2,0.34,0.28,0.06,0.06,0.0,0.0,0.06,vincent intintoli,FIN-3120,2016
-FIN,3120,3,Financial Management II,0.24,0.26,0.31,0.16,0.02,0.0,0.0,0.02,angela morgan,FIN-3120,2016
-FIN,4030,1,Spreadsheet Apps in Finance,0.33,0.5,0.08,0.06,0.0,0.0,0.0,0.03,jared daniel smith,FIN-4030,2016
-FIN,4030,2,Spreadsheet Apps in Finance,0.13,0.6,0.17,0.07,0.03,0.0,0.0,0.0,jared daniel smith,FIN-4030,2016
-FIN,4040,1,Financial Modeling,0.1,0.4,0.3,0.0,0.05,0.05,0.0,0.1,jack wolf,FIN-4040,2016
-FIN,4050,1,Portfolio Management & Theory,0.25,0.17,0.29,0.17,0.08,0.0,0.0,0.04,john alexander,FIN-4050,2016
-FIN,4080,1,Mgt of Fin Inst,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2016
-FIN,4080,2,Mgt of Fin Inst,0.14,0.67,0.1,0.05,0.0,0.0,0.0,0.05,lyudmila chernykh,FIN-4080,2016
-FIN,4090,1,Prof Fin Plan,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william hol johnson,FIN-4090,2016
-FIN,4110,1,Int Fin Mgt,0.34,0.49,0.1,0.05,0.0,0.0,0.0,0.02,tilan tang,FIN-4110,2016
-FIN,4110,2,Int Fin Mgt,0.33,0.46,0.15,0.05,0.0,0.0,0.0,0.0,tilan tang,FIN-4110,2016
-FIN,4150,1,Real Estate Investmt,0.14,0.55,0.18,0.05,0.0,0.0,0.0,0.09,thomas springer,FIN-4150,2016
-FIN,4160,1,Real Estate Val,0.25,0.6,0.1,0.05,0.0,0.0,0.0,0.0,ramon tolb franklin,FIN-4160,2016
-FNR,4700,51,Camera Traps/ Animal Ecology,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,david sco jachowski,FNR-4700,2016
-FNR,4990,1,Natural Resources Seminar,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,greg yarrow,FNR-4990,2016
-FNR,4990,2,Natural Resources Seminar,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,greg yarrow,FNR-4990,2016
-FNR,4990,3,Natural Resources Seminar,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,greg yarrow,FNR-4990,2016
-FOR,1010,1,Intro to Forestry,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,lawrence gering,FOR-1010,2016
-FOR,2060,1,Forestry Ecology,0.31,0.38,0.2,0.06,0.03,0.0,0.0,0.02,donald hagan,FOR-2060,2016
-FOR,3080,1,Remote Sensing in Forestry,0.23,0.46,0.15,0.12,0.04,0.0,0.0,0.0,lawrence gering,FOR-3080,2016
-FOR,4060,1,Forested Watershed Mgmt,0.65,0.29,0.0,0.0,0.02,0.0,0.0,0.04,joanna emily hawley,FOR-4060,2016
-FOR,4080,1,Wood and Paper Products,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,patricia layton,FOR-4080,2016
-FOR,4150,1,Forest Wildlife Managment,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,james davis,FOR-4150,2016
-FOR,4180,1,Forest Resource Valuation,0.23,0.5,0.23,0.04,0.0,0.0,0.0,0.0,thomas straka,FOR-4180,2016
-FOR,4340,1,GIS for Natural Resources,0.51,0.34,0.11,0.0,0.02,0.0,0.0,0.02,robert frit baldwin,FOR-4340,2016
-FOR,4650,1,Silviculture,0.2,0.44,0.24,0.12,0.0,0.0,0.0,0.0,gaofeng wang,FOR-4650,2016
-FOR,8120,1,Fire Ecology and Management,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,gaofeng wang,FOR-8120,2016
-FR,1010,1,Elementary French,0.29,0.53,0.06,0.06,0.0,0.0,0.0,0.06,anne salces  nedeo,FR-1010,2016
-FR,1020,1,Elementary French,0.09,0.27,0.18,0.18,0.18,0.0,0.0,0.09,anne salces  nedeo,FR-1020,2016
-FR,1020,2,Elementary French,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2016
-FR,1020,3,Elementary French,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2016
-FR,2010,1,Intermediate French,0.61,0.22,0.11,0.0,0.06,0.0,0.0,0.0,amy lyn grif sawyer,FR-2010,2016
-FR,2010,2,Intermediate French,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2010,2016
-FR,2010,4,Intermediate French,0.47,0.27,0.13,0.0,0.0,0.0,0.0,0.13,kelly digby peebles,FR-2010,2016
-FR,2020,1,Intermediate French,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,eric touya,FR-2020,2016
-FR,2020,2,Intermediate French,0.63,0.26,0.0,0.11,0.0,0.0,0.0,0.0,joseph mai,FR-2020,2016
-FR,2020,3,Intermediate French,0.71,0.24,0.0,0.06,0.0,0.0,0.0,0.0,joseph mai,FR-2020,2016
-FR,2020,4,Intermediate French,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,paulin de tholozany,FR-2020,2016
-FR,3050,1,Int Fr Con & Comp I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,FR-3050,2016
-FR,3160,1,Fr for Intl Trade,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,FR-3160,2016
-FR,3170,1,Contemp French Civ,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,joseph mai,FR-3170,2016
-FR,4200,1,French Enlightenment,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,FR-4200,2016
-FR,4760,1,Adv Sem Fr Thought,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,FR-4760,2016
-GC,1010,1,Orientation to G C,0.41,0.39,0.11,0.02,0.0,0.0,0.0,0.07,carol jones,GC-1010,2016
-GC,1020,1,Computer Art & CAD Foundations,0.36,0.43,0.16,0.02,0.02,0.0,0.0,0.0,carol jones,GC-1020,2016
-GC,1030,1,G C I for Pkgsc,0.23,0.54,0.06,0.06,0.06,0.0,0.0,0.06,john jacobs,GC-1030,2016
-GC,1040,1,Graphic Communications I,0.43,0.51,0.04,0.0,0.0,0.0,0.0,0.01,rebecca suza edlein,GC-1040,2016
-GC,2070,1,Graphic Communications II,0.53,0.38,0.09,0.0,0.0,0.0,0.0,0.0,patrick gee rose,GC-2070,2016
-GC,2400,1,Intro to Web Design and Dev,0.56,0.25,0.06,0.0,0.0,0.06,0.0,0.06,erica black walker,GC-2400,2016
-GC,3400,1,Digital Imaging and eMedia,0.64,0.31,0.05,0.0,0.0,0.0,0.0,0.0,erica black walker,GC-3400,2016
-GC,3460,1,Ink and Substrates,0.18,0.44,0.29,0.04,0.04,0.0,0.0,0.02,liam henry 'hara,GC-3460,2016
-GC,4060,1,Package and Specialty Printing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kern cox,GC-4060,2016
-GC,4400,1,Commercial Printing,0.23,0.49,0.17,0.0,0.03,0.0,0.0,0.09,eric weisenmiller,GC-4400,2016
-GC,4440,1,Current Dev/Trends in Gr Comm,0.33,0.47,0.14,0.06,0.0,0.0,0.0,0.0,liam henry 'hara,GC-4440,2016
-GC,4480,1,Plan & Cont Printing Functions,0.6,0.34,0.04,0.02,0.0,0.0,0.0,0.0,john leininger,GC-4480,2016
-GC,4800,1,Senior Seminar in GC,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,charles edwa tonkin,GC-4800,2016
-GC,4900,2,G C Selected Topics-Sales,0.62,0.27,0.04,0.0,0.0,0.0,0.0,0.08,john leininger,GC-4900,2016
-GC,4900,6,G C Selected Topics-The DEN,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,erica black walker,GC-4900,2016
-GEN,3000,1,Fundamental Genetics,0.23,0.33,0.22,0.11,0.07,0.0,0.0,0.03,kate leanne wi tsai,GEN-3000,2016
-GEN,3000,2,Fundamental Genetics,0.18,0.39,0.24,0.11,0.03,0.0,0.0,0.03,kate leanne wi tsai,GEN-3000,2016
-GEN,3020,1,Molecular & General Genetics,0.33,0.33,0.17,0.04,0.0,0.0,0.0,0.13,meredith tei morris,GEN-3020,2016
-GEN,4100,1,Population & Quant Genetics,0.43,0.38,0.11,0.05,0.03,0.0,0.0,0.0,amy lou lawton rauh,GEN-4100,2016
-GEN,4110,2,Populatn & Quant Genetics Lab,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,GEN-4110,2016
-GEN,4400,1,Bioinformatics,0.41,0.35,0.18,0.0,0.0,0.0,0.0,0.06,liangjiang wang,GEN-4400,2016
-GEN,6100,1,Population & Quant Genetics,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,GEN-6100,2016
-GEOG,1010,1,Intro to Geography,0.35,0.29,0.29,0.0,0.03,0.0,0.0,0.03,christa smith,GEOG-1010,2016
-GEOG,1030,1,World Regional Geol,0.83,0.07,0.03,0.03,0.02,0.0,0.0,0.02,lance forres howard,GEOG-1030,2016
-GEOG,1030,2,World Regional Geog,0.4,0.38,0.15,0.08,0.0,0.0,0.0,0.0,william churc terry,GEOG-1030,2016
-GEOG,3010,1,Political Geography,0.56,0.28,0.04,0.0,0.04,0.0,0.0,0.08,christa smith,GEOG-3010,2016
-GEOL,1010,1,Physical Geology,0.37,0.36,0.17,0.05,0.03,0.0,0.0,0.01,alan coulson,GEOL-1010,2016
-GEOL,1010,2,Physical Geology,0.46,0.33,0.12,0.05,0.04,0.0,0.0,0.0,alan coulson,GEOL-1010,2016
-GEOL,1030,1,Physical Geol Lab,0.3,0.52,0.13,0.04,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,2,Physical Geol Lab,0.65,0.13,0.04,0.0,0.09,0.0,0.0,0.09,alan coulson,GEOL-1030,2016
-GEOL,1030,3,Physical Geol Lab,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2016
-GEOL,1030,5,Physical Geol Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,6,Physical Geol Lab,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,7,Physical Geol Lab,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,alan coulson,GEOL-1030,2016
-GEOL,1030,8,Physical Geol Lab,0.61,0.3,0.04,0.04,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,9,Physical Geol Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,10,Physical Geol Lab,0.58,0.33,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2016
-GEOL,1030,11,Physical Geol Lab,0.67,0.21,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1030,12,Physical Geol Lab,0.75,0.06,0.19,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2016
-GEOL,1120,1,Earth Resources,0.52,0.31,0.15,0.0,0.0,0.0,0.0,0.02,scott brame,GEOL-1120,2016
-GEOL,1140,1,Earth Resources Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-1140,2016
-GEOL,2020,1,Earth History,0.25,0.5,0.05,0.1,0.1,0.0,0.0,0.0,alan coulson,GEOL-2020,2016
-GEOL,3130,1,Sedimentology & Stratigraphy,0.11,0.44,0.28,0.17,0.0,0.0,0.0,0.0,james castle,GEOL-3130,2016
-GEOL,3180,1,Introduction to Geochemistry,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,brian powell,GEOL-3180,2016
-GEOL,4210,1,Gis in Geology,0.7,0.26,0.0,0.0,0.0,0.0,0.0,0.04,scott brame,GEOL-4210,2016
-GEOL,7900,501,Biogeography & Geology of SC,0.25,0.5,0.13,0.0,0.13,0.0,0.0,0.0,john robert wagner,GEOL-7900,2016
-GEOL,8030,1,Geostatistics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,stephen mich moysey,GEOL-8030,2016
-GEOL,8160,1,Aquifer Systems,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,lawrence murdoch,GEOL-8160,2016
-GER,1010,1,Elementary German,0.32,0.42,0.11,0.05,0.05,0.0,0.0,0.05,oswald harris king,GER-1010,2016
-GER,1010,2,Elementary German,0.56,0.11,0.11,0.06,0.0,0.0,0.0,0.17,oswald harris king,GER-1010,2016
-GER,1020,1,Elementary German,0.31,0.31,0.31,0.0,0.0,0.0,0.0,0.08, lee ferrell,GER-1020,2016
-GER,1020,2,Elementary German,0.21,0.29,0.07,0.0,0.14,0.0,0.0,0.29, lee ferrell,GER-1020,2016
-GER,2010,1,Intermediate German,0.35,0.53,0.06,0.0,0.0,0.0,0.0,0.06,oswald harris king,GER-2010,2016
-GER,2020,1,Intermediate German,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,johannes schmidt,GER-2020,2016
-GER,2020,2,Intermediate German,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-2020,2016
-GER,3160,1,Ger for Intl Trade I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0, lee ferrell,GER-3160,2016
-GER,3610,1,Ger Lit 1832 to Mod,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,johannes schmidt,GER-3610,2016
-HCC,8810,2,Measurement & Eval,0.57,0.14,0.0,0.0,0.0,0.0,0.0,0.29,bart knijnenburg,HCC-8810,2016
-HCG,9010,1,Adv in Humn Genetics,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,julia eggert,HCG-9010,2016
-HCG,9890,3,Special Topics: Theoretical Fo,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,mary steck,HCG-9890,2016
-HEHD,3990,2,Students Helping Students Peer,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,mary mcp von kaenel,HEHD-3990,2016
-HEHD,4000,1,Intro Leadership Theor & Conc,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,william havice,HEHD-4000,2016
-HEHD,4200,1,Lead Appli & Exper,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mary price,HEHD-4200,2016
-HEHD,8010,230,Child/Adolescent Dev,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,HEHD-8010,2016
-HEHD,8040,230,Assessment/Eval,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,HEHD-8040,2016
-HEHD,8880,400,Special Topics Youth Dev Ldshp,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,barry garst,HEHD-8880,2016
-HIST,1010,1,Hist of the U S,0.27,0.55,0.12,0.0,0.06,0.0,0.0,0.0,james brad jeffries,HIST-1010,2016
-HIST,1240,1,Environmental History Survey,0.04,0.46,0.31,0.05,0.07,0.0,0.0,0.07,james brad jeffries,HIST-1240,2016
-HIST,1720,3,The West and the World I,0.43,0.46,0.06,0.0,0.0,0.0,0.0,0.06,emily wood,HIST-1720,2016
-HIST,1730,1,The West and the World II,0.27,0.38,0.19,0.0,0.08,0.0,0.0,0.08, alan grubb,HIST-1730,2016
-HIST,1730,2,The West and the World II,0.33,0.28,0.25,0.07,0.03,0.0,0.0,0.03,james burns,HIST-1730,2016
-HIST,1730,3,The West and the World II,0.18,0.43,0.2,0.08,0.05,0.0,0.0,0.07,thomas kuehn,HIST-1730,2016
-HIST,2990,1,Historian's Craft,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,michael silvestri,HIST-2990,2016
-HIST,2990,2,Historian's Craft,0.44,0.38,0.06,0.0,0.06,0.0,0.0,0.06,elizabeth carney,HIST-2990,2016
-HIST,3000,1,Hist Colonial Amer,0.62,0.32,0.03,0.0,0.03,0.0,0.0,0.0,lee brady wilson,HIST-3000,2016
-HIST,3010,1,Am Rev & New Nation,0.21,0.27,0.21,0.06,0.15,0.0,0.0,0.09,james brad jeffries,HIST-3010,2016
-HIST,3100,1,History of Religion in the US,0.27,0.53,0.0,0.07,0.07,0.0,0.0,0.07,elizabeth jemison,HIST-3100,2016
-HIST,3110,1,African American Hist to 1877,0.26,0.55,0.1,0.0,0.06,0.0,0.0,0.03,abel bartley,HIST-3110,2016
-HIST,3180,1,American Women,0.26,0.39,0.23,0.1,0.0,0.0,0.0,0.03,meg taylor-shockley,HIST-3180,2016
-HIST,3210,2,History of Science,0.54,0.34,0.03,0.0,0.03,0.0,0.0,0.06,pamela mack,HIST-3210,2016
-HIST,3240,1,Hist of the South II,0.33,0.52,0.09,0.03,0.0,0.0,0.0,0.03,john andrew,HIST-3240,2016
-HIST,3260,1,Hist Am Transport,0.66,0.23,0.03,0.0,0.09,0.0,0.0,0.0, roger grant,HIST-3260,2016
-HIST,3330,1,Hist of Mod Japan,0.21,0.41,0.26,0.03,0.09,0.0,0.0,0.0,edwin moise,HIST-3330,2016
-HIST,3410,1,Modern Mexico,0.57,0.29,0.06,0.0,0.0,0.0,0.0,0.09,rachel anne moore,HIST-3410,2016
-HIST,3510,1,Ancient Near East,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,steven grosby,HIST-3510,2016
-HIST,3730,2,Age of Protestant Reformation,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,thomas kuehn,HIST-3730,2016
-HIST,3810,1,Germany Since 1918,0.16,0.63,0.16,0.0,0.03,0.0,0.0,0.03,michael meng,HIST-3810,2016
-HIST,3890,3,Mitchelville,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,abel bartley,HIST-3890,2016
-HIST,3890,4,Upstate Black Communities,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,abel bartley,HIST-3890,2016
-HIST,3890,5,Churches of Mitchelville,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,HIST-3890,2016
-HIST,3900,1,Modern Military History,0.11,0.43,0.32,0.04,0.07,0.0,0.0,0.04,edwin moise,HIST-3900,2016
-HIST,3920,1,Hist U S Environment,0.16,0.44,0.09,0.09,0.16,0.0,0.0,0.06,pamela mack,HIST-3920,2016
-HIST,3970,1,Modern Middle East,0.42,0.55,0.0,0.03,0.0,0.0,0.0,0.0,amit bein,HIST-3970,2016
-HIST,4000,1,Colonial South Carolina,0.17,0.28,0.39,0.06,0.06,0.0,0.0,0.06,paul chris anderson,HIST-4000,2016
-HIST,4400,1,Studies in Latin American Hist,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,HIST-4400,2016
-HIST,4600,2,British India,0.54,0.31,0.0,0.08,0.0,0.0,0.0,0.08,michael silvestri,HIST-4600,2016
-HIST,4870,1,World War II,0.14,0.57,0.17,0.02,0.05,0.0,0.0,0.05,john andrew,HIST-4870,2016
-HIST,4880,1,Middle Eastern Soc & Culture,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,HIST-4880,2016
-HIST,4900,2,Domestic Space & History,0.58,0.33,0.0,0.0,0.08,0.0,0.0,0.0,elizabeth carney,HIST-4900,2016
-HIST,4900,3,Capitalism,0.53,0.13,0.2,0.0,0.07,0.0,0.0,0.07,steven marks,HIST-4900,2016
-HIST,4920,1,African American & Sports,0.31,0.46,0.15,0.0,0.0,0.0,0.0,0.08,abel bartley,HIST-4920,2016
-HLTH,2020,1,Introduction to Public Health,0.57,0.29,0.05,0.05,0.0,0.0,0.0,0.05,jeffrey kingree,HLTH-2020,2016
-HLTH,2020,2,Introduction to Public Health,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2016
-HLTH,2020,3,Introduction to Public Health,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2016
-HLTH,2020,400,Introduction to Public Health,0.53,0.21,0.11,0.05,0.0,0.0,0.0,0.11,ralph stewart welsh,HLTH-2020,2016
-HLTH,2030,1,Health Care Sys,0.45,0.27,0.09,0.09,0.0,0.0,0.0,0.09,frederic fraizer,HLTH-2030,2016
-HLTH,2030,2,Health Care Sys,0.48,0.31,0.17,0.0,0.0,0.0,0.0,0.03,frederic fraizer,HLTH-2030,2016
-HLTH,2030,3,Health Care Sys,0.79,0.09,0.09,0.0,0.0,0.0,0.0,0.03,lee alden crandall,HLTH-2030,2016
-HLTH,2030,400,Health Care Sys,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2030,2016
-HLTH,2400,2,Deter of Hlth Behav,0.47,0.43,0.03,0.0,0.03,0.0,0.0,0.03,amelia clinkscales,HLTH-2400,2016
-HLTH,2400,400,Deter of Hlth Behav,0.53,0.33,0.07,0.07,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2016
-HLTH,2980,1,Human Hlth & Disease,0.57,0.35,0.02,0.0,0.04,0.0,0.0,0.02,annah kamugiz amani,HLTH-2980,2016
-HLTH,2980,2,Human Hlth & Disease,0.66,0.23,0.09,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,HLTH-2980,2016
-HLTH,3030,1,Public Health Comm,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,debra mitch charles,HLTH-3030,2016
-HLTH,3050,1,Body Resp Hlth Beh,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,brian patric graves,HLTH-3050,2016
-HLTH,3100,1,Women's Hlth Issues,0.64,0.24,0.09,0.03,0.0,0.0,0.0,0.0,rachel mayo,HLTH-3100,2016
-HLTH,3500,1,Med Terminology/Comm,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kari jea strothmann,HLTH-3500,2016
-HLTH,3800,1,Epidemiology,0.27,0.57,0.13,0.0,0.03,0.0,0.0,0.0,hugh spitler,HLTH-3800,2016
-HLTH,3800,2,Epidemiology,0.45,0.4,0.1,0.03,0.0,0.0,0.0,0.03,deborah alma falta,HLTH-3800,2016
-HLTH,3980,1,Hlth Appraisal Sklls,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,kathleen meyer,HLTH-3980,2016
-HLTH,3980,2,Hlth Appraisal Sklls,0.71,0.14,0.07,0.07,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2016
-HLTH,4100,1,Maternal Child Hlth,0.66,0.28,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,HLTH-4100,2016
-HLTH,4190,1,Health Sci Internship Prep Sem,0.45,0.3,0.18,0.03,0.0,0.0,0.0,0.05,kathleen meyer,HLTH-4190,2016
-HLTH,4200,1,Hlth Science Intern,0.72,0.26,0.02,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2016
-HLTH,4300,1,Hlth Prom of Aged,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,cheryl jo dye,HLTH-4300,2016
-HLTH,4310,1,Public & Environ Hlt,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-4310,2016
-HLTH,4600,1,Health Info Systems,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-4600,2016
-HLTH,4700,400,Global Health,0.58,0.16,0.05,0.0,0.05,0.0,0.0,0.16,annah kamugiz amani,HLTH-4700,2016
-HLTH,4780,1,Health Policy Ethics and Law,0.2,0.4,0.35,0.05,0.0,0.0,0.0,0.0,hugh spitler,HLTH-4780,2016
-HLTH,4790,1,Fin Mgmt & Hlth Budg,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,lingling zhang,HLTH-4790,2016
-HLTH,4800,1,Comm Hlth Promotion,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,joel edwar williams,HLTH-4800,2016
-HLTH,4900,1,Res Eval St Pub Hlth,0.59,0.28,0.09,0.03,0.0,0.0,0.0,0.0,khoa dang truong,HLTH-4900,2016
-HLTH,4900,2,Res Eval St Pub Hlth,0.44,0.44,0.0,0.06,0.0,0.0,0.0,0.06,khoa dang truong,HLTH-4900,2016
-HLTH,4970,4,Creative Inq Hlth - Aspire,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,martha par thompson,HLTH-4970,2016
-HLTH,8210,500,Health Research I,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,lee alden crandall,HLTH-8210,2016
-HON,2060,1,Intro to Nanotechnology,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,christophe kitchens,HON-2060,2016
-HON,2060,3,Integrity in Engineering,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,daniel wueste,HON-2060,2016
-HON,2200,1,Knight of a Different Order,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,emily wood,HON-2200,2016
-HON,2210,2,"Hamlet, Again",0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,HON-2210,2016
-HON,2210,5,Authoring Harry Potter,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,megan no macalystre,HON-2210,2016
-HORT,1010,1,Horticulture,0.86,0.05,0.04,0.0,0.0,0.0,0.0,0.05,ellen anita vincent,HORT-1010,2016
-HORT,2020,1,Adobe Digital Design,0.75,0.04,0.08,0.0,0.08,0.0,0.0,0.04,janice ann lay,HORT-2020,2016
-HORT,2110,1,Growing Spring Plnts,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,james emerson faust,HORT-2110,2016
-HORT,4040,1,Plant Propagation,0.1,0.38,0.28,0.17,0.03,0.0,0.0,0.03,jeffrey adelberg,HORT-4040,2016
-HORT,4050,1,Plant Propagation Techniq Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,HORT-4050,2016
-HORT,4050,2,Plant Propagation Techniq Lab,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,jeffrey adelberg,HORT-4050,2016
-HORT,4270,1,Urban Tree Care,0.23,0.55,0.18,0.0,0.05,0.0,0.0,0.0,robert polomski,HORT-4270,2016
-HORT,4330,1,Turf Weed Management,0.28,0.31,0.34,0.03,0.0,0.0,0.0,0.03,ted whitwell,HORT-4330,2016
-HP,8280,1,Case St in Preservation Engr,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,craig mille bennett,HP-8280,2016
-HP,8330,1,Cultural and Historical Landsc,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,carter lee hudgins,HP-8330,2016
-HRD,8490,400,Eval of T&D/Hrd Prog,0.92,0.02,0.0,0.0,0.06,0.0,0.0,0.0,philip mcgee,HRD-8490,2016
-IE,2100,1,Des Analysis Wrk Sys,0.17,0.41,0.2,0.1,0.07,0.0,0.0,0.05,sara lu riggs,IE-2100,2016
-IE,2800,1,Deterministic Operations Rsrch,0.12,0.41,0.28,0.1,0.03,0.0,0.0,0.05,robert mark curry,IE-2800,2016
-IE,3010,1,Systems Design I,0.62,0.36,0.02,0.0,0.0,0.0,0.0,0.0,robert james riggs,IE-3010,2016
-IE,3610,1,Industrial App of Prob/Stat II,0.33,0.37,0.13,0.03,0.13,0.0,0.0,0.0,sandra dun eksioglu,IE-3610,2016
-IE,3610,2,Industrial App of Prob/Stat II,0.58,0.25,0.12,0.03,0.0,0.0,0.0,0.03,joel greenstein,IE-3610,2016
-IE,3810,1,Probabilistic Operations Rsrch,0.2,0.31,0.33,0.07,0.09,0.0,0.0,0.0,burak eksioglu,IE-3810,2016
-IE,3810,2,Probabilistic Operations Rsrch,0.24,0.34,0.19,0.13,0.08,0.0,0.0,0.02,amin khademi,IE-3810,2016
-IE,3840,1,Engr Econ Analysis,0.55,0.17,0.12,0.04,0.04,0.0,0.0,0.08,brian melloy,IE-3840,2016
-IE,3860,1,Prod Plan & Cont,0.32,0.36,0.19,0.09,0.02,0.0,0.0,0.03,robert james riggs,IE-3860,2016
-IE,4020,3,Creative Inq Res,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,anand gramopadhye,IE-4020,2016
-IE,4620,1,Six Sigma Quality,0.34,0.52,0.14,0.0,0.0,0.0,0.0,0.0,robert james riggs,IE-4620,2016
-IE,4670,1,System Design II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,IE-4670,2016
-IE,4910,1,Service Engineering,0.29,0.29,0.18,0.18,0.0,0.0,0.0,0.06,tugce isik,IE-4910,2016
-IE,4910,3,Invest Human Error Complx Sys,0.4,0.42,0.12,0.03,0.03,0.0,0.0,0.0,sara lu riggs,IE-4910,2016
-IE,6910,1,Service Engineering,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tugce isik,IE-6910,2016
-IE,6910,3,Invest Human Error Complx Sys,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,sara lu riggs,IE-6910,2016
-IE,8010,1,Human-Machine Sys,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,IE-8010,2016
-IE,8520,1,Prescriptive Analytics,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,IE-8520,2016
-IE,8540,1,SC & Logistics Modeling I,0.73,0.21,0.06,0.0,0.0,0.0,0.0,0.0,william ferrell,IE-8540,2016
-IE,8580,1,Case Study Supply Chn & Logist,0.83,0.15,0.03,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-8580,2016
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.02,caren kelley-hall,INT-1510,2016
-INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.93,0.04,0.03,caren kelley-hall,INT-1520,2016
-INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,INT-2510,2016
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,uttiyo raychaudhuri,IS-1010,2016
-ITAL,1010,1,Elementary Italian,0.65,0.06,0.18,0.0,0.06,0.0,0.0,0.06,julia schmidt,ITAL-1010,2016
-ITAL,1020,1,Elementary Italian,0.5,0.39,0.0,0.11,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-1020,2016
-ITAL,1020,2,Elementary Italian,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,valentina lombardi,ITAL-1020,2016
-ITAL,1020,3,Elementary Italian,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,ITAL-1020,2016
-ITAL,2020,1,Intermediate Italian,0.61,0.33,0.0,0.06,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2020,2016
-ITAL,2020,2,Intermediate Italian,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,valentina lombardi,ITAL-2020,2016
-JAPN,1010,1,Elementary Japanese,0.44,0.11,0.11,0.0,0.17,0.0,0.0,0.17,kazuko shoji,JAPN-1010,2016
-JAPN,1010,2,Elementary Japanese,0.38,0.13,0.19,0.06,0.19,0.0,0.0,0.06,kazuko shoji,JAPN-1010,2016
-JAPN,1020,1,Elementary Japanese,0.35,0.24,0.06,0.18,0.12,0.0,0.0,0.06,jae allegr takeuchi,JAPN-1020,2016
-JAPN,1020,2,Elementary Japanese,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,jae allegr takeuchi,JAPN-1020,2016
-JAPN,2010,1,Intermed Japanese,0.2,0.6,0.1,0.0,0.1,0.0,0.0,0.0,kazuko shoji,JAPN-2010,2016
-JAPN,2020,1,Intermed Japanese,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,kazuko shoji,JAPN-2020,2016
-JAPN,4170,1,Japanese Culture and Society,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jae allegr takeuchi,JAPN-4170,2016
-LARC,1160,1,History of Landscape Arch,0.24,0.29,0.3,0.09,0.03,0.0,0.0,0.05,hala fouad nassar,LARC-1160,2016
-LARC,1520,1,Basic Design II,0.65,0.22,0.09,0.0,0.0,0.0,0.0,0.04,paul russell,LARC-1520,2016
-LARC,2520,1,Site Design,0.36,0.36,0.27,0.0,0.0,0.0,0.0,0.0,martin john holland,LARC-2520,2016
-LARC,3620,1,Design Impl II,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,paul russell,LARC-3620,2016
-LARC,4280,1,Comput Aided Design,0.61,0.11,0.18,0.0,0.0,0.0,0.0,0.11,jessica fernandez,LARC-4280,2016
-LAW,3220,1,Legal Env of Bus,0.35,0.37,0.15,0.02,0.07,0.0,0.0,0.04,kenneth toussaint,LAW-3220,2016
-LAW,3220,2,Legal Env of Bus,0.27,0.56,0.16,0.02,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2016
-LAW,3220,3,Legal Env of Bus,0.7,0.24,0.07,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2016
-LAW,3220,4,Legal Env of Bus,0.38,0.38,0.22,0.0,0.02,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2016
-LAW,3220,5,Legal Env of Bus,0.41,0.34,0.18,0.05,0.0,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2016
-LAW,3220,6,Legal Env of Bus,0.42,0.38,0.11,0.04,0.0,0.0,0.0,0.04,edward ray claggett,LAW-3220,2016
-LAW,3220,7,Legal Env of Bus,0.57,0.37,0.04,0.02,0.0,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2016
-LAW,3220,8,Legal Env of Bus,0.4,0.37,0.21,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,LAW-3220,2016
-LAW,3220,9,Legal Env of Bus,0.41,0.44,0.1,0.03,0.03,0.0,0.0,0.0,kath kisska-schulze,LAW-3220,2016
-LAW,3220,10,Legal Env of Bus,0.28,0.55,0.12,0.03,0.02,0.0,0.0,0.0,john hine,LAW-3220,2016
-LAW,3220,11,Legal Env of Bus,0.21,0.56,0.15,0.03,0.03,0.0,0.0,0.02,john hine,LAW-3220,2016
-LAW,3220,401,Legal Env of Bus,0.14,0.28,0.16,0.16,0.07,0.0,0.0,0.19,virgini ward-vaughn,LAW-3220,2016
-LAW,3220,402,Legal Env of Bus,0.1,0.25,0.23,0.15,0.13,0.0,0.0,0.15,virgini ward-vaughn,LAW-3220,2016
-LAW,3220,403,Legal Env of Bus,0.23,0.28,0.2,0.18,0.1,0.0,0.0,0.03,virgini ward-vaughn,LAW-3220,2016
-LAW,3220,404,Legal Env of Bus,0.22,0.37,0.15,0.17,0.07,0.0,0.0,0.02,virgini ward-vaughn,LAW-3220,2016
-LAW,3220,601,Legal Env of Bus,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-3220,2016
-LAW,4990,1,Selected Topics: Cyber Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-4990,2016
-LAW,8500,1,Law for Prof Accts,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-8500,2016
-LAW,8500,2,Law for Prof Accts,0.18,0.74,0.09,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-8500,2016
-LAW,8500,3,Law for Prof Accts,0.49,0.43,0.09,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-8500,2016
-LS,1000,9,Intro to Salsa Dance,0.64,0.09,0.0,0.0,0.27,0.0,0.0,0.0,malik lewis baxter,LS-1000,2016
-LS,1000,20,Intro to Volleyball,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,kelly lynn ator,LS-1000,2016
-LS,1000,22,Intermediate Ashtanga Yoga,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,LS-1000,2016
-LS,1000,23,Therapeutic Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,LS-1000,2016
-LS,1000,24,Therapeutic Yoga,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,LS-1000,2016
-LS,1000,25,Therapeutic Yoga,0.78,0.09,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,LS-1000,2016
-LS,1130,1,Wood Carving,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,louwanda jolley,LS-1130,2016
-LS,1260,1,Group Initiatives,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,christina mar mazer,LS-1260,2016
-LS,1410,1,Top Rope Climbing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,glenn dav middleton,LS-1410,2016
-LS,1410,3,Top Rope Climbing,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,glenn dav middleton,LS-1410,2016
-LS,1450,2,Camping/Backpacking,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,samuel james keith,LS-1450,2016
-LS,1450,4,Camping/Backpacking,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,samuel james keith,LS-1450,2016
-LS,1580,2,Archery,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,LS-1580,2016
-LS,1580,3,Archery,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,LS-1580,2016
-LS,1580,4,Archery,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,LS-1580,2016
-LS,1640,1,Whitewater Kayaking,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,robert taylor,LS-1640,2016
-LS,1850,2,Bowling,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,megan elizabet cato,LS-1850,2016
-LS,1850,5,Bowling,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.07,katie dudley,LS-1850,2016
-LS,1850,6,Bowling,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,megan elizabet cato,LS-1850,2016
-LS,1850,8,Bowling,0.87,0.03,0.0,0.03,0.0,0.0,0.0,0.07,megan elizabet cato,LS-1850,2016
-LS,1870,1,Frisbee Sports,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,craig goodman,LS-1870,2016
-LS,1890,1,Tennis,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jose mezapaniagua,LS-1890,2016
-LS,1940,1,Racquetball,0.79,0.07,0.0,0.07,0.0,0.0,0.0,0.07,raymond petersen,LS-1940,2016
-LS,1940,3,Racquetball,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,charlie white,LS-1940,2016
-LS,1980,1,Golf,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jason jordan,LS-1980,2016
-LS,1980,3,Golf,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jason jordan,LS-1980,2016
-LS,1980,6,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jason jordan,LS-1980,2016
-LS,2100,1,Learn to Dance,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,matthew lee krabbe,LS-2100,2016
-LS,2110,2,Introduction to Belly Dance,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,stephanie pack,LS-2110,2016
-LS,2110,3,Introduction to Belly Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,stephanie pack,LS-2110,2016
-LS,2180,1,Ballroom Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,LS-2180,2016
-LS,2200,1,Shag,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,matthew lee krabbe,LS-2200,2016
-LS,2200,6,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,matthew lee krabbe,LS-2200,2016
-LS,2200,7,Shag,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,matthew lee krabbe,LS-2200,2016
-LS,2270,1,Intro to Swing Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,paul hoke,LS-2270,2016
-LS,2270,2,Intro to Swing Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,paul hoke,LS-2270,2016
-LS,2270,4,Intro to Swing Dance,0.93,0.0,0.0,0.04,0.0,0.0,0.0,0.04,paul hoke,LS-2270,2016
-LS,2320,1,Core Training,0.86,0.05,0.05,0.05,0.0,0.0,0.0,0.0,diane moreno,LS-2320,2016
-LS,2320,2,Core Training,0.79,0.0,0.04,0.04,0.04,0.0,0.0,0.08,diane moreno,LS-2320,2016
-LS,2320,3,Core Training,0.7,0.1,0.0,0.0,0.0,0.0,0.0,0.2,diane moreno,LS-2320,2016
-LS,2350,1,Basic Yoga,0.67,0.14,0.05,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,LS-2350,2016
-LS,2350,2,Basic Yoga,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,LS-2350,2016
-LS,2350,3,Basic Yoga,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,LS-2350,2016
-LS,2350,4,Basic Yoga,0.75,0.1,0.0,0.1,0.0,0.0,0.0,0.05,renee warren gahan,LS-2350,2016
-LS,2350,5,Basic Yoga,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,renee warren gahan,LS-2350,2016
-LS,2350,6,Basic Yoga,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jenefer nadenicek,LS-2350,2016
-LS,2350,7,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,LS-2350,2016
-LS,2350,8,Basic Yoga,0.87,0.04,0.0,0.0,0.04,0.0,0.0,0.04,jenefer nadenicek,LS-2350,2016
-LS,2360,2,Power/Ashtanga Yoga,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,silica eliza larkin,LS-2360,2016
-LS,2380,1,Vinyasa Flow Yoga,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,LS-2380,2016
-LS,2380,2,Vinyasa Flow Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,LS-2380,2016
-LS,2420,1,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2420,2016
-LS,2420,2,Meditation and Relax,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,renee warren gahan,LS-2420,2016
-LS,2420,3,Meditation and Relax,0.75,0.08,0.08,0.04,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2016
-LS,2420,4,Meditation and Relax,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2016
-LS,2420,5,Meditation and Relax,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-2420,2016
-LS,2420,6,Meditation and Relax,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-2420,2016
-LS,2420,8,Meditation and Relax,0.86,0.0,0.09,0.0,0.05,0.0,0.0,0.0,ani reina-nunnelley,LS-2420,2016
-LS,2420,9,Meditation and Relax,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,LS-2420,2016
-LS,2450,1,Pilates,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,melanie ivey job,LS-2450,2016
-LS,2450,2,Pilates,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,melanie ivey job,LS-2450,2016
-LS,2460,2,Intermediate Pilates,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,melanie ivey job,LS-2460,2016
-LS,2510,1,Running & Jogging,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,corey dou brookover,LS-2510,2016
-LS,2700,1,Sports Officiating,0.71,0.0,0.0,0.0,0.06,0.0,0.0,0.24,christopher war cox,LS-2700,2016
-LS,3580,1,Advanced Shotgun Skeet,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,charles flint,LS-3580,2016
-MATH,1010,1,Essen Math for Informed Soc,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,marilyn reba,MATH-1010,2016
-MATH,1010,3,Essen Math for Informed Soc,0.26,0.34,0.11,0.17,0.11,0.0,0.0,0.0,judith cottingham,MATH-1010,2016
-MATH,1010,4,Essen Math for Informed Soc,0.5,0.35,0.12,0.0,0.03,0.0,0.0,0.0,judith cottingham,MATH-1010,2016
-MATH,1010,5,Essen Math for Informed Soc,0.29,0.29,0.24,0.18,0.0,0.0,0.0,0.0,xiyan tan,MATH-1010,2016
-MATH,1010,6,Essen Math for Informed Soc,0.23,0.32,0.32,0.1,0.0,0.0,0.0,0.03,judith cottingham,MATH-1010,2016
-MATH,1020,1,Intro to Mathematical Analysis,0.07,0.31,0.24,0.14,0.24,0.0,0.0,0.0,haodong li,MATH-1020,2016
-MATH,1020,2,Intro to Mathematical Analysis,0.18,0.21,0.26,0.16,0.11,0.0,0.0,0.08,stefani ca mokalled,MATH-1020,2016
-MATH,1020,4,Intro to Mathematical Analysis,0.31,0.19,0.25,0.11,0.11,0.0,0.0,0.03,xiaoyuan liu,MATH-1020,2016
-MATH,1020,6,Intro to Mathematical Analysis,0.18,0.31,0.21,0.1,0.13,0.0,0.0,0.08,tony thanh nguyen,MATH-1020,2016
-MATH,1020,7,Intro to Mathematical Analysis,0.16,0.35,0.11,0.14,0.11,0.0,0.0,0.14,jerry lero phillips,MATH-1020,2016
-MATH,1020,8,Intro to Mathematical Analysis,0.21,0.28,0.23,0.13,0.1,0.0,0.0,0.05,tony thanh nguyen,MATH-1020,2016
-MATH,1020,9,Intro to Mathematical Analysis,0.11,0.34,0.24,0.08,0.24,0.0,0.0,0.0,randy davidson,MATH-1020,2016
-MATH,1020,10,Intro to Mathematical Analysis,0.11,0.16,0.24,0.11,0.35,0.0,0.0,0.03,prab withana gamage,MATH-1020,2016
-MATH,1020,11,Intro to Mathematical Analysis,0.2,0.31,0.11,0.17,0.2,0.0,0.0,0.0,kara ail stasikelis,MATH-1020,2016
-MATH,1020,14,Intro to Mathematical Analysis,0.11,0.4,0.34,0.06,0.09,0.0,0.0,0.0,tony thanh nguyen,MATH-1020,2016
-MATH,1020,15,Intro to Mathematical Analysis,0.21,0.26,0.18,0.13,0.11,0.0,0.0,0.11,randy davidson,MATH-1020,2016
-MATH,1020,16,Intro to Mathematical Analysis,0.21,0.26,0.31,0.13,0.05,0.0,0.0,0.05,abigail bowers,MATH-1020,2016
-MATH,1020,18,Intro to Mathematical Analysis,0.32,0.34,0.22,0.0,0.1,0.0,0.0,0.02,randy davidson,MATH-1020,2016
-MATH,1020,19,Intro to Mathematical Analysis,0.05,0.18,0.32,0.08,0.29,0.0,0.0,0.08,aaro ramirez flores,MATH-1020,2016
-MATH,1020,20,Intro to Mathematical Analysis,0.05,0.24,0.41,0.05,0.17,0.0,0.0,0.07,abigail bowers,MATH-1020,2016
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.61,0.03,jason to hedetniemi,MATH-1040,2016
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.41,0.51,0.08,rebecca lynn knoll,MATH-1040,2016
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.49,0.05,patrick buckingham,MATH-1040,2016
-MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.47,0.41,0.12,charity watson,MATH-1050,2016
-MATH,1060,1,Calculus of One Variable I,0.07,0.07,0.37,0.13,0.27,0.0,0.0,0.1,allen anderso guest,MATH-1060,2016
-MATH,1060,2,Calculus of One Variable I,0.06,0.19,0.38,0.09,0.06,0.0,0.0,0.22,allen anderso guest,MATH-1060,2016
-MATH,1060,3,Calculus of One Variable I,0.17,0.24,0.27,0.05,0.2,0.0,0.0,0.07,marion hanna,MATH-1060,2016
-MATH,1060,4,Calculus of One Variable I,0.05,0.14,0.36,0.12,0.19,0.0,0.0,0.14,beth novick,MATH-1060,2016
-MATH,1060,5,Calculus of One Variable I,0.0,0.15,0.28,0.13,0.28,0.0,0.0,0.15,sanwar ahmad,MATH-1060,2016
-MATH,1060,6,Calculus of One Variable I,0.05,0.2,0.34,0.02,0.27,0.0,0.0,0.12,"koshy chenthittayil,",MATH-1060,2016
-MATH,1060,7,Calculus of One Variable I,0.05,0.18,0.37,0.16,0.18,0.0,0.0,0.05,stefan adam bock,MATH-1060,2016
-MATH,1060,8,Calculus of One Variable I,0.05,0.18,0.13,0.1,0.23,0.0,0.0,0.33,michael gl eldredge,MATH-1060,2016
-MATH,1060,9,Calculus of One Variable I,0.65,0.2,0.15,0.0,0.0,0.0,0.0,0.0,edward collins,MATH-1060,2016
-MATH,1070,1,Differen and Integral Calculus,0.18,0.5,0.21,0.05,0.03,0.0,0.0,0.03,donna simms,MATH-1070,2016
-MATH,1070,2,Differen and Integral Calculus,0.12,0.37,0.39,0.05,0.02,0.0,0.0,0.05,donna simms,MATH-1070,2016
-MATH,1070,3,Differen and Integral Calculus,0.0,0.39,0.55,0.0,0.05,0.0,0.0,0.02,patrick buckingham,MATH-1070,2016
-MATH,1070,5,Differen and Integral Calculus,0.07,0.36,0.29,0.07,0.14,0.0,0.0,0.07,tony thanh nguyen,MATH-1070,2016
-MATH,1080,1,Calculus of One Variable II,0.27,0.23,0.23,0.03,0.1,0.0,0.0,0.13,muhamm mohebujjaman,MATH-1080,2016
-MATH,1080,2,Calculus of One Variable II,0.19,0.21,0.24,0.05,0.21,0.0,0.0,0.1,lee andrew jenkins,MATH-1080,2016
-MATH,1080,3,Calculus of One Variable II,0.13,0.22,0.16,0.07,0.18,0.0,0.0,0.24,sea sather-wagstaff,MATH-1080,2016
-MATH,1080,4,Calculus of One Variable II,0.25,0.41,0.14,0.07,0.07,0.0,0.0,0.07,meredith nicol burr,MATH-1080,2016
-MATH,1080,5,Calculus of One Variable II,0.09,0.36,0.36,0.07,0.07,0.0,0.0,0.05,jonathon leverenz,MATH-1080,2016
-MATH,1080,6,Calculus of One Variable II,0.16,0.36,0.2,0.07,0.05,0.0,0.0,0.16,meredith nicol burr,MATH-1080,2016
-MATH,1080,7,Calculus of One Variable II,0.27,0.33,0.18,0.02,0.04,0.0,0.0,0.16,abdullah al mamun,MATH-1080,2016
-MATH,1080,8,Calculus of One Variable II,0.19,0.25,0.25,0.06,0.08,0.0,0.0,0.17,marilyn reba,MATH-1080,2016
-MATH,1080,9,Calculus of One Variable II,0.36,0.4,0.06,0.02,0.13,0.0,0.0,0.02,ryan grove,MATH-1080,2016
-MATH,1080,10,Calculus of One Variable II,0.16,0.29,0.24,0.02,0.04,0.0,0.0,0.24,jonathon leverenz,MATH-1080,2016
-MATH,1080,11,Calculus of One Variable II,0.09,0.37,0.19,0.12,0.14,0.0,0.0,0.09,fiona may knoll,MATH-1080,2016
-MATH,1080,12,Calculus of One Variable II,0.06,0.25,0.41,0.03,0.22,0.0,0.0,0.03,rui gong,MATH-1080,2016
-MATH,1080,13,Calculus of One Variable II,0.02,0.27,0.24,0.0,0.16,0.0,0.0,0.31,rebecca ramos,MATH-1080,2016
-MATH,1080,14,Calculus of One Variable II,0.22,0.28,0.25,0.08,0.03,0.0,0.0,0.14,honghai xu,MATH-1080,2016
-MATH,1080,15,Calculus of One Variable II,0.1,0.33,0.18,0.05,0.15,0.0,0.0,0.18,shuhan xu,MATH-1080,2016
-MATH,1080,16,Calculus of One Variable II,0.15,0.18,0.24,0.03,0.09,0.0,0.0,0.3,marilyn reba,MATH-1080,2016
-MATH,1150,1,Contemp Math for Elem Teach I,0.53,0.29,0.12,0.06,0.0,0.0,0.0,0.0,charity watson,MATH-1150,2016
-MATH,1160,1,Contemp Math for Elem Teach II,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1160,2016
-MATH,1160,2,Contemp Math for Elem Teach II,0.56,0.33,0.07,0.0,0.0,0.0,0.0,0.04,allison stoddard,MATH-1160,2016
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,marion hanna,MATH-1990,2016
-MATH,2060,1,Calculus of Several Variables,0.16,0.42,0.1,0.06,0.1,0.0,0.0,0.16,akshay sunil gupte,MATH-2060,2016
-MATH,2060,2,Calculus of Several Variables,0.16,0.4,0.2,0.04,0.12,0.0,0.0,0.08,timothy fra parrott,MATH-2060,2016
-MATH,2060,3,Calculus of Several Variables,0.39,0.22,0.08,0.03,0.17,0.0,0.0,0.11,qijun he,MATH-2060,2016
-MATH,2060,4,Calculus of Several Variables,0.57,0.32,0.08,0.0,0.03,0.0,0.0,0.0,sofya alekseeva,MATH-2060,2016
-MATH,2060,5,Calculus of Several Variables,0.17,0.23,0.34,0.14,0.06,0.0,0.0,0.06,jonathon leverenz,MATH-2060,2016
-MATH,2060,6,Calculus of Several Variables,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,sofya alekseeva,MATH-2060,2016
-MATH,2060,7,Calculus of Several Variables,0.0,0.09,0.06,0.12,0.21,0.0,0.0,0.52,javier ruiz ramirez,MATH-2060,2016
-MATH,2060,8,Calculus of Several Variables,0.46,0.43,0.08,0.0,0.03,0.0,0.0,0.0,sofya alekseeva,MATH-2060,2016
-MATH,2060,9,Calculus of Several Variables,0.42,0.26,0.24,0.0,0.05,0.0,0.0,0.03,mark cawood,MATH-2060,2016
-MATH,2060,10,Calculus of Several Variables,0.11,0.19,0.11,0.07,0.19,0.0,0.0,0.33,dania moham zantout,MATH-2060,2016
-MATH,2070,1,Multivariable Calculus,0.22,0.34,0.22,0.13,0.06,0.0,0.0,0.03,judith irene mcknew,MATH-2070,2016
-MATH,2070,2,Multivariable Calculus,0.34,0.31,0.28,0.0,0.03,0.0,0.0,0.03,jennifer mari hanna,MATH-2070,2016
-MATH,2070,4,Multivariable Calculus,0.39,0.26,0.17,0.09,0.09,0.0,0.0,0.0,thanh thien to,MATH-2070,2016
-MATH,2070,5,Multivariable Calculus,0.44,0.31,0.16,0.03,0.03,0.0,0.0,0.03,jennifer mari hanna,MATH-2070,2016
-MATH,2070,7,Multivariable Calculus,0.22,0.47,0.22,0.03,0.03,0.0,0.0,0.03,tao yang,MATH-2070,2016
-MATH,2070,8,Multivariable Calculus,0.23,0.27,0.13,0.17,0.07,0.0,0.0,0.13,yinggu bao,MATH-2070,2016
-MATH,2070,9,Multivariable Calculus,0.44,0.24,0.24,0.03,0.0,0.0,0.0,0.06,jennifer van dyken,MATH-2070,2016
-MATH,2070,10,Multivariable Calculus,0.36,0.18,0.21,0.12,0.09,0.0,0.0,0.03,jennifer mari hanna,MATH-2070,2016
-MATH,2070,11,Multivariable Calculus,0.07,0.37,0.23,0.1,0.07,0.0,0.0,0.17,tiantian yang,MATH-2070,2016
-MATH,2070,14,Multivariable Calculus,0.16,0.34,0.22,0.06,0.06,0.0,0.0,0.16,allison stoddard,MATH-2070,2016
-MATH,2070,15,Multivariable Calculus,0.16,0.38,0.25,0.13,0.09,0.0,0.0,0.0,trevor scot vilardi,MATH-2070,2016
-MATH,2070,17,Multivariable Calculus,0.38,0.38,0.13,0.0,0.03,0.0,0.0,0.09,garrett dranichak,MATH-2070,2016
-MATH,2070,19,Multivariable Calculus,0.12,0.36,0.12,0.15,0.09,0.0,0.0,0.15,yibo xu,MATH-2070,2016
-MATH,2070,20,Multivariable Calculus,0.27,0.3,0.24,0.09,0.03,0.0,0.0,0.06,liu zhu,MATH-2070,2016
-MATH,2070,22,Multivariable Calculus,0.38,0.32,0.24,0.06,0.0,0.0,0.0,0.0,luke marti giberson,MATH-2070,2016
-MATH,2070,23,Multivariable Calculus,0.21,0.21,0.24,0.12,0.15,0.0,0.0,0.06,emily marie nystrom,MATH-2070,2016
-MATH,2070,25,Multivariable Calculus,0.12,0.39,0.3,0.09,0.06,0.0,0.0,0.03,amy christine grady,MATH-2070,2016
-MATH,2070,26,Multivariable Calculus,0.16,0.19,0.13,0.32,0.1,0.0,0.0,0.1,yijun chen,MATH-2070,2016
-MATH,2080,1,Intro to Ordin Diff Equations,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.05,james brannan,MATH-2080,2016
-MATH,2080,2,Intro to Ordin Diff Equations,0.09,0.28,0.31,0.06,0.03,0.0,0.0,0.22,terri johnson,MATH-2080,2016
-MATH,2080,4,Intro to Ordin Diff Equations,0.18,0.18,0.3,0.09,0.18,0.0,0.0,0.06,jeong rock yoon,MATH-2080,2016
-MATH,2080,5,Intro to Ordin Diff Equations,0.05,0.23,0.36,0.05,0.14,0.0,0.0,0.18,terri johnson,MATH-2080,2016
-MATH,2080,6,Intro to Ordin Diff Equations,0.22,0.27,0.22,0.05,0.03,0.0,0.0,0.22,shari prevost,MATH-2080,2016
-MATH,2080,7,Intro to Ordin Diff Equations,0.11,0.32,0.11,0.07,0.11,0.0,0.0,0.29,terri johnson,MATH-2080,2016
-MATH,2080,8,Intro to Ordin Diff Equations,0.19,0.3,0.14,0.11,0.05,0.0,0.0,0.22,jeong rock yoon,MATH-2080,2016
-MATH,2080,9,Intro to Ordin Diff Equations,0.32,0.24,0.16,0.0,0.11,0.0,0.0,0.16,shari prevost,MATH-2080,2016
-MATH,2080,10,Intro to Ordin Diff Equations,0.45,0.13,0.24,0.11,0.05,0.0,0.0,0.03,timothy ch teitloff,MATH-2080,2016
-MATH,2080,11,Intro to Ordin Diff Equations,0.32,0.39,0.13,0.05,0.05,0.0,0.0,0.05,nathan jos adelgren,MATH-2080,2016
-MATH,2080,12,Intro to Ordin Diff Equations,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,irina viktorova,MATH-2080,2016
-MATH,2080,13,Intro to Ordin Diff Equations,0.55,0.13,0.05,0.05,0.05,0.0,0.0,0.16,timothy fra parrott,MATH-2080,2016
-MATH,2080,14,Intro to Ordin Diff Equations,0.18,0.45,0.23,0.0,0.08,0.0,0.0,0.08,timothy ch teitloff,MATH-2080,2016
-MATH,2080,15,Intro to Ordin Diff Equations,0.61,0.26,0.11,0.03,0.0,0.0,0.0,0.0,irina viktorova,MATH-2080,2016
-MATH,2080,16,Intro to Ordin Diff Equations,0.66,0.24,0.05,0.0,0.03,0.0,0.0,0.03,irina viktorova,MATH-2080,2016
-MATH,2080,17,Intro to Ordin Diff Equations,0.35,0.35,0.11,0.08,0.0,0.0,0.0,0.11,timothy fra parrott,MATH-2080,2016
-MATH,2080,18,Intro to Ordin Diff Equations,0.31,0.31,0.25,0.06,0.08,0.0,0.0,0.0,timothy ch teitloff,MATH-2080,2016
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.88,0.08,0.0,0.03,0.0,0.0,0.0,0.03,james brannan,MATH-2080,2016
-MATH,2160,1,Geometry for Elem Sch Teachers,0.44,0.39,0.14,0.0,0.0,0.0,0.0,0.03,allison stoddard,MATH-2160,2016
-MATH,3020,1,Stat for Science & Engineering,0.24,0.36,0.14,0.07,0.12,0.0,0.0,0.07,ellen hepfe breazel,MATH-3020,2016
-MATH,3020,2,Stat for Science & Engineering,0.33,0.5,0.05,0.05,0.02,0.0,0.0,0.05,ellen hepfe breazel,MATH-3020,2016
-MATH,3020,3,Stat for Science & Engineering,0.26,0.36,0.19,0.07,0.05,0.0,0.0,0.07,ellen hepfe breazel,MATH-3020,2016
-MATH,3020,4,Stat for Science & Engineering,0.44,0.33,0.15,0.0,0.05,0.0,0.0,0.03,yisu jia,MATH-3020,2016
-MATH,3020,5,Stat for Science & Engineering,0.28,0.31,0.18,0.05,0.05,0.0,0.0,0.13,calvin williams,MATH-3020,2016
-MATH,3020,6,Stat for Science & Engineering,0.53,0.16,0.23,0.0,0.05,0.0,0.0,0.02,yanbo xia,MATH-3020,2016
-MATH,3020,7,Stat for Science & Engineering,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.05,brandon gra goodell,MATH-3020,2016
-MATH,3110,1,Linear Algebra,0.48,0.32,0.16,0.0,0.04,0.0,0.0,0.0,james peterson,MATH-3110,2016
-MATH,3110,2,Linear Algebra,0.19,0.28,0.25,0.11,0.08,0.0,0.0,0.08,xuhong gao,MATH-3110,2016
-MATH,3110,3,Linear Algebra,0.32,0.26,0.09,0.06,0.15,0.0,0.0,0.12,xuhong gao,MATH-3110,2016
-MATH,3110,4,Linear Algebra,0.23,0.26,0.17,0.2,0.09,0.0,0.0,0.06,warren adams,MATH-3110,2016
-MATH,3110,5,Linear Algebra,0.36,0.25,0.14,0.08,0.17,0.0,0.0,0.0,brian fralix,MATH-3110,2016
-MATH,3190,1,Introduction to Proof,0.35,0.31,0.08,0.12,0.12,0.0,0.0,0.04,elena sta dimitrova,MATH-3190,2016
-MATH,3190,2,Introduction to Proof,0.38,0.23,0.19,0.0,0.12,0.0,0.0,0.08,elena sta dimitrova,MATH-3190,2016
-MATH,3600,1,Intermediate Math Computing,0.67,0.13,0.0,0.08,0.08,0.0,0.0,0.04,mark cawood,MATH-3600,2016
-MATH,3600,2,Intermediate Math Computing,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,neil calkin,MATH-3600,2016
-MATH,3650,1,Numerical Mthds for Engineers,0.28,0.41,0.22,0.06,0.0,0.0,0.0,0.03,eleanor jenkins,MATH-3650,2016
-MATH,3650,2,Numerical Mthds for Engineers,0.13,0.31,0.31,0.03,0.03,0.0,0.0,0.19,christopher cox,MATH-3650,2016
-MATH,3650,3,Numerical Mthds for Engineers,0.67,0.31,0.03,0.0,0.0,0.0,0.0,0.0,abigail bowers,MATH-3650,2016
-MATH,3650,4,Numerical Mthds for Engineers,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,abigail bowers,MATH-3650,2016
-MATH,4000,1,Theory of Probability,0.15,0.23,0.38,0.04,0.0,0.0,0.0,0.19,julie lassiter,MATH-4000,2016
-MATH,4000,2,Theory of Probability,0.0,0.26,0.21,0.05,0.26,0.0,0.0,0.21,julie lassiter,MATH-4000,2016
-MATH,4030,1,Intro to Statistical Theory,0.41,0.23,0.32,0.0,0.0,0.0,0.0,0.05,xiaoqian sun,MATH-4030,2016
-MATH,4070,1,Regress & Time-Series Analysis,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-4070,2016
-MATH,4120,1,Algebra I,0.3,0.33,0.1,0.13,0.05,0.0,0.0,0.1,kevin james,MATH-4120,2016
-MATH,4190,1,Discrete Math Structures I,0.4,0.47,0.07,0.03,0.03,0.0,0.0,0.0,beth novick,MATH-4190,2016
-MATH,4310,1,Theory of Interest,0.33,0.08,0.33,0.25,0.0,0.0,0.0,0.0, erwin walker,MATH-4310,2016
-MATH,4340,1,Adv Engineering Mathematics,0.09,0.32,0.18,0.24,0.12,0.0,0.0,0.06,eleanor jenkins,MATH-4340,2016
-MATH,4340,2,Adv Engineering Mathematics,0.19,0.42,0.04,0.15,0.08,0.0,0.0,0.12,hyesuk lee,MATH-4340,2016
-MATH,4400,1,Linear Programming,0.41,0.36,0.09,0.0,0.09,0.0,0.0,0.05,yuyuan ouyang,MATH-4400,2016
-MATH,4410,1,Intro to Stochastic Models,0.33,0.28,0.22,0.0,0.06,0.0,0.0,0.11,brian fralix,MATH-4410,2016
-MATH,4530,1,Advanced Calculus I,0.29,0.29,0.29,0.05,0.05,0.0,0.0,0.05,peter kiessler,MATH-4530,2016
-MATH,4540,1,Advanced Calculus II,0.36,0.32,0.12,0.08,0.04,0.0,0.0,0.08,james peterson,MATH-4540,2016
-MATH,6340,1,Adv Engineering Mathematics,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,vincent ervin,MATH-6340,2016
-MATH,8030,1,Stochastic Processes,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,robert lund,MATH-8030,2016
-MATH,8040,1,Statistical Inference,0.76,0.0,0.12,0.0,0.0,0.0,0.0,0.12,christopher mcmahan,MATH-8040,2016
-MATH,8050,1,Data Analysis,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,yingbo li,MATH-8050,2016
-MATH,8090,1,Time Series Analysis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,MATH-8090,2016
-MATH,8100,1,Mathematical Programming,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,margaret mar wiecek,MATH-8100,2016
-MATH,8130,1,Advanced Linear Programming,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,matthew saltzman,MATH-8130,2016
-MATH,8210,1,Linear Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,MATH-8210,2016
-MATH,8220,1,Measure and Integration,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,MATH-8220,2016
-MATH,8530,1,Matrix Analysis,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,matthew macauley,MATH-8530,2016
-MATH,8540,1,Theory of Graphs,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,wayne goddard,MATH-8540,2016
-MATH,8600,1,Intro to Scientific Computing,0.36,0.57,0.0,0.0,0.0,0.0,0.0,0.07,hyesuk lee,MATH-8600,2016
-MATH,8660,1,Finite Element Method,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,vincent ervin,MATH-8660,2016
-MATH,9860,1,Selected Topics in Geometry,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,MATH-9860,2016
-MBA,8030,1,Stat Analy of Bus Op,0.14,0.54,0.17,0.0,0.03,0.0,0.0,0.11,zachary mo leffakis,MBA-8030,2016
-MBA,8060,1,Operations Mgt,0.09,0.79,0.09,0.0,0.03,0.0,0.0,0.0, sridharan,MBA-8060,2016
-MBA,8070,1,Financial Management,0.66,0.27,0.07,0.0,0.0,0.0,0.0,0.0,melvin stith,MBA-8070,2016
-MBA,8070,2,Financial Management,0.63,0.18,0.13,0.0,0.0,0.0,0.0,0.08,melvin stith,MBA-8070,2016
-MBA,8090,1,Org Beh & Hum Res Mg,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2016
-MBA,8090,2,Org Beh & Hum Res Mg,0.56,0.42,0.03,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2016
-MBA,8190,1,Intro to Acc and Fin,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,annieka philo,MBA-8190,2016
-MBA,8190,2,Intro to Acc and Fin,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,MBA-8190,2016
-MBA,8290,1,Marketing Foundation,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MBA-8290,2016
-MBA,8370,1,Legal Environ of Bus,0.28,0.7,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2016
-MBA,8430,10,Entrepreneurial Accounting,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,MBA-8430,2016
-MBA,8510,10,Bus Operations & Logistics,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,MBA-8510,2016
-MBA,8540,1,Mgrl Accounting,0.63,0.3,0.0,0.0,0.0,0.0,0.0,0.07,james mil kohlmeyer,MBA-8540,2016
-MBA,8540,2,Mgrl Accounting,0.52,0.39,0.07,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,MBA-8540,2016
-MBA,8590,1,Mgr Decision Model,0.48,0.31,0.1,0.0,0.02,0.0,0.0,0.1,mark mcknew,MBA-8590,2016
-MBA,8590,2,Mgr Decision Model,0.57,0.35,0.0,0.0,0.09,0.0,0.0,0.0,sara elizabet yoder,MBA-8590,2016
-MBA,8600,1,Advanced Marketing Strategy,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2016
-MBA,8610,1,Information Systems,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,varun grover,MBA-8610,2016
-MBA,8610,2,Information Systems,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,kevin mckenzie,MBA-8610,2016
-MBA,8620,1,Managerial Economics,0.43,0.49,0.03,0.0,0.0,0.0,0.0,0.06,ronald earl gregory,MBA-8620,2016
-MBA,8700,1,Strategic Management,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8700,2016
-MBA,8720,1,Entrepr Finance,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8720,2016
-MBA,8750,1,Enterprise Develpmnt,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,michael george mino,MBA-8750,2016
-MBA,8990,1,Advanced Leadership,0.87,0.11,0.0,0.0,0.0,0.0,0.0,0.02,gail depriest,MBA-8990,2016
-MBA,8990,3,Service Innovation,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,aleda marie roth,MBA-8990,2016
-MBA,8990,4,Bus. Sport. Enter.,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.04,john michael hannon,MBA-8990,2016
-ME,2000,1,Sophomore Seminar,0.95,0.02,0.01,0.0,0.01,0.0,0.0,0.02,donald beasley,ME-2000,2016
-ME,2010,1,Statics & Dynamics,0.06,0.16,0.24,0.22,0.24,0.0,0.0,0.07,paul joseph,ME-2010,2016
-ME,2010,2,Statics & Dynamics,0.13,0.2,0.18,0.13,0.24,0.0,0.0,0.13,lonny thompson,ME-2010,2016
-ME,2030,1,Founda Th/Fl Syst,0.09,0.28,0.35,0.11,0.05,0.0,0.0,0.11,jay ochterbeck,ME-2030,2016
-ME,2030,2,Founda Th/Fl Syst,0.16,0.2,0.28,0.11,0.16,0.0,0.0,0.08,john saylor,ME-2030,2016
-ME,2030,3,Founda Th/Fl Syst,0.38,0.38,0.11,0.02,0.0,0.0,0.0,0.11,donald beasley,ME-2030,2016
-ME,2040,1,Mechanics of Materials,0.18,0.43,0.26,0.05,0.05,0.0,0.0,0.03,michael porter,ME-2040,2016
-ME,2040,2,Mechanics of Materials,0.23,0.4,0.26,0.09,0.03,0.0,0.0,0.0,gang li,ME-2040,2016
-ME,2040,3,Mechanics of Materials,0.17,0.54,0.22,0.02,0.02,0.0,0.0,0.02,garrett pataky,ME-2040,2016
-ME,2040,302,Mechanics of Materials (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gang li,ME-2040,2016
-ME,2220,1,Mechanical Engineering Lab I,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,2,Mechanical Engineering Lab I,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,todd schweisinger,ME-2220,2016
-ME,2220,3,Mechanical Engineering Lab I,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,todd schweisinger,ME-2220,2016
-ME,2220,4,Mechanical Engineering Lab I,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,5,Mechanical Engineering Lab I,0.3,0.65,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,6,Mechanical Engineering Lab I,0.37,0.32,0.21,0.05,0.0,0.0,0.0,0.05,todd schweisinger,ME-2220,2016
-ME,2220,7,Mechanical Engineering Lab I,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,todd schweisinger,ME-2220,2016
-ME,2220,8,Mechanical Engineering Lab I,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2016
-ME,2220,9,Mechanical Engineering Lab I,0.25,0.5,0.08,0.0,0.0,0.0,0.0,0.17,todd schweisinger,ME-2220,2016
-ME,3030,1,Thermodynamics,0.27,0.44,0.22,0.02,0.0,0.0,0.0,0.05,daniel fant,ME-3030,2016
-ME,3030,2,Thermodynamics,0.13,0.13,0.31,0.15,0.18,0.0,0.0,0.1,richard miller,ME-3030,2016
-ME,3040,1,Heat Transfer,0.03,0.21,0.49,0.15,0.13,0.0,0.0,0.0,jean-marc delhaye,ME-3040,2016
-ME,3040,2,Heat Transfer,0.2,0.39,0.32,0.03,0.06,0.0,0.0,0.0,xin zhao,ME-3040,2016
-ME,3050,1,Model/an Dy Syst,0.18,0.42,0.2,0.05,0.08,0.0,0.0,0.07,phanin tallapragada,ME-3050,2016
-ME,3050,2,Model/an Dy Syst,0.3,0.26,0.3,0.05,0.06,0.0,0.0,0.03,joshua bostwick,ME-3050,2016
-ME,3060,1,Fund Machine Design,0.28,0.46,0.19,0.0,0.04,0.0,0.0,0.04,oliver myers,ME-3060,2016
-ME,3060,2,Fund Machine Design,0.44,0.31,0.21,0.0,0.03,0.0,0.0,0.0,paul jeffrey meyer,ME-3060,2016
-ME,3070,1,Found of Mechanical Systems,0.27,0.5,0.14,0.02,0.0,0.0,0.0,0.07,lonny thompson,ME-3070,2016
-ME,3070,2,Found of Mechanical Systems,0.19,0.63,0.14,0.02,0.0,0.0,0.0,0.02,gregory mocko,ME-3070,2016
-ME,3080,1,Fluid Mechanics,0.05,0.18,0.33,0.2,0.15,0.0,0.0,0.1,jean-marc delhaye,ME-3080,2016
-ME,3080,2,Fluid Mechanics,0.14,0.3,0.47,0.04,0.04,0.0,0.0,0.02,ethan kung,ME-3080,2016
-ME,3100,1,Thermo/Heat Transfer,0.28,0.24,0.34,0.03,0.07,0.0,0.0,0.03,xiangchun xuan,ME-3100,2016
-ME,3120,1,Manuf Processes,0.36,0.45,0.16,0.02,0.0,0.0,0.0,0.01,hong seok choi,ME-3120,2016
-ME,3330,1,Mechanical Engineering Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,2,Mechanical Engineering Lab II,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,3,Mechanical Engineering Lab II,0.18,0.76,0.0,0.0,0.06,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,4,Mechanical Engineering Lab II,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,5,Mechanical Engineering Lab II,0.21,0.57,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2016
-ME,3330,6,Mechanical Engineering Lab II,0.25,0.42,0.17,0.0,0.08,0.0,0.0,0.08,todd schweisinger,ME-3330,2016
-ME,3330,7,Mechanical Engineering Lab II,0.25,0.56,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-3330,2016
-ME,3330,8,Mechanical Engineering Lab II,0.2,0.5,0.2,0.0,0.0,0.0,0.0,0.1,todd schweisinger,ME-3330,2016
-ME,4010,1,Mech Engr Design,0.49,0.39,0.08,0.03,0.0,0.0,0.0,0.01,cameron turner,ME-4010,2016
-ME,4020,1,Intern in Engr Des,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,donald beasley,ME-4020,2016
-ME,4020,3,Intern in Engr Des,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2016
-ME,4020,4,Intern in Engr Des,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,ME-4020,2016
-ME,4020,5,Intern in Engr Des,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4020,2016
-ME,4020,7,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,ME-4020,2016
-ME,4020,8,Intern in Engr Des,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-4020,2016
-ME,4020,9,Intern in Engr Des,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,donald beasley,ME-4020,2016
-ME,4030,1,Control Dynamic Systems,0.18,0.5,0.25,0.03,0.03,0.0,0.0,0.03,suyi li,ME-4030,2016
-ME,4030,2,Control Dynamic Systems,0.24,0.45,0.31,0.0,0.0,0.0,0.0,0.0,yue wang,ME-4030,2016
-ME,4170,1,Mechatronic Sys,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4170,2016
-ME,4180,1,F E A in M E Design,0.48,0.39,0.09,0.0,0.0,0.0,0.0,0.04,istemi baris ozsoy,ME-4180,2016
-ME,4220,1,Design Gas Turbines,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,ME-4220,2016
-ME,4230,1,Intro Aerodynamics,0.34,0.46,0.17,0.0,0.03,0.0,0.0,0.0,richard figliola,ME-4230,2016
-ME,4260,1,Nuclear Energy,0.44,0.44,0.04,0.04,0.0,0.0,0.0,0.04,richard watkins,ME-4260,2016
-ME,4300,1,Mech Comp Materials,0.14,0.43,0.38,0.05,0.0,0.0,0.0,0.0,huijuan zhao,ME-4300,2016
-ME,4440,1,Mechanical Engineering Lab III,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,2,Mechanical Engineering Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,3,Mechanical Engineering Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,4,Mechanical Engineering Lab III,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,5,Mechanical Engineering Lab III,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4440,7,Mechanical Engineering Lab III,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2016
-ME,4930,5,SelectedTopics ME - RapidProto,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4930,2016
-ME,4930,11,Selected Topics ME: MicroFab,0.23,0.54,0.15,0.08,0.0,0.0,0.0,0.0,rod martinez-duarte,ME-4930,2016
-ME,4930,28,Selected Topics ME: HVAC,0.28,0.48,0.12,0.0,0.0,0.0,0.0,0.12,donald willoughby,ME-4930,2016
-ME,4930,29,Selected Topics ME: Solar E,0.62,0.28,0.07,0.0,0.03,0.0,0.0,0.0,daniel fant,ME-4930,2016
-ME,6170,1,Mechatronic Sys,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-6170,2016
-ME,6300,1,Mech Comp Materials,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,huijuan zhao,ME-6300,2016
-ME,6300,401,Mech Comp Materials,0.44,0.44,0.0,0.0,0.11,0.0,0.0,0.0,huijuan zhao,ME-6300,2016
-ME,8120,1,Exp Meth Thermal Sci,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,ME-8120,2016
-ME,8190,1,Cp Meth in Therm Sc,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,richard miller,ME-8190,2016
-ME,8200,1,Mod Cont Engr,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,ME-8200,2016
-ME,8310,1,Convective Ht Trans,0.31,0.19,0.25,0.0,0.25,0.0,0.0,0.0,john saylor,ME-8310,2016
-ME,8520,1,Adv Finite Ele Ana,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gang li,ME-8520,2016
-ME,8610,1,Matl Sel Engr Design,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,mica grujicic,ME-8610,2016
-ME,8730,1,Res Mthds Coll Desgn,0.43,0.43,0.0,0.0,0.14,0.0,0.0,0.0,joshua summers,ME-8730,2016
-ME,8930,27,Sel Topics in ME - Cont Mech,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,ME-8930,2016
-MGT,2010,1,Principles of Management,0.29,0.38,0.27,0.04,0.01,0.0,0.0,0.01,katherine clark,MGT-2010,2016
-MGT,2010,2,Principles of Management,0.47,0.34,0.14,0.02,0.0,0.0,0.0,0.03,katherine clark,MGT-2010,2016
-MGT,2010,3,Principles of Management,0.4,0.41,0.15,0.01,0.02,0.0,0.0,0.01,katherine clark,MGT-2010,2016
-MGT,2010,4,Principles of Management,0.34,0.39,0.24,0.02,0.0,0.0,0.0,0.01,katherine clark,MGT-2010,2016
-MGT,2010,5,Principles of Management,0.45,0.42,0.12,0.01,0.0,0.0,0.0,0.0,tina robbins,MGT-2010,2016
-MGT,2010,6,Principles of Management,0.46,0.43,0.08,0.01,0.0,0.0,0.0,0.01,tina robbins,MGT-2010,2016
-MGT,2010,7,Principles of Management,0.38,0.39,0.15,0.04,0.01,0.0,0.0,0.02,tina robbins,MGT-2010,2016
-MGT,2010,8,Principles of Management,0.33,0.45,0.16,0.01,0.02,0.0,0.0,0.02,tina robbins,MGT-2010,2016
-MGT,2010,9,Principles of Management (HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,MGT-2010,2016
-MGT,2180,1,Management PC Applications,0.45,0.35,0.13,0.01,0.02,0.0,0.0,0.04,ryan toole,MGT-2180,2016
-MGT,2180,2,Management PC Applications,0.49,0.33,0.07,0.03,0.02,0.0,0.0,0.05,ryan toole,MGT-2180,2016
-MGT,2180,3,Management PC Applications,0.56,0.27,0.09,0.02,0.02,0.0,0.0,0.04,ryan toole,MGT-2180,2016
-MGT,2180,4,Management PC Applications,0.42,0.42,0.07,0.04,0.02,0.0,0.0,0.02,ryan toole,MGT-2180,2016
-MGT,2970,1,How to Start a Startup,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,john michael hannon,MGT-2970,2016
-MGT,2970,2,How to Start a Startup,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,john michael hannon,MGT-2970,2016
-MGT,3070,1,Human Resource Management,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2016
-MGT,3070,2,Human Resource Management,0.55,0.43,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2016
-MGT,3070,3,Human Resource Management,0.53,0.35,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2016
-MGT,3070,4,Human Resource Management,0.42,0.33,0.09,0.06,0.06,0.0,0.0,0.03,priscilla harrison,MGT-3070,2016
-MGT,3070,6,Human Resource Management,0.15,0.74,0.12,0.0,0.0,0.0,0.0,0.0,kristin dam scott,MGT-3070,2016
-MGT,3100,1,Intermed Business Statistics,0.5,0.29,0.19,0.0,0.0,0.0,0.0,0.02,jerry kermi bilbrey,MGT-3100,2016
-MGT,3100,2,Intermed Business Statistics,0.25,0.3,0.23,0.03,0.18,0.0,0.0,0.03,ezg akpinar ferrand,MGT-3100,2016
-MGT,3100,3,Intermed Business Statistics,0.36,0.23,0.21,0.08,0.08,0.0,0.0,0.05,ezg akpinar ferrand,MGT-3100,2016
-MGT,3100,4,Intermed Business Statistics,0.18,0.28,0.2,0.28,0.05,0.0,0.0,0.03,sara elizabet yoder,MGT-3100,2016
-MGT,3100,5,Intermed Business Statistics,0.8,0.13,0.04,0.02,0.0,0.0,0.0,0.0,shih lun tseng,MGT-3100,2016
-MGT,3100,6,Intermed Business Statistics,0.44,0.37,0.2,0.0,0.0,0.0,0.0,0.0,jerry kermi bilbrey,MGT-3100,2016
-MGT,3100,7,Intermed Business Statistics,0.17,0.34,0.22,0.1,0.1,0.0,0.0,0.07,sara elizabet yoder,MGT-3100,2016
-MGT,3100,8,Intermed Business Statistics,0.18,0.18,0.38,0.05,0.18,0.0,0.0,0.03,sara elizabet yoder,MGT-3100,2016
-MGT,3100,10,Intermed Business Statistics,0.39,0.42,0.13,0.0,0.03,0.0,0.0,0.03,jerry kermi bilbrey,MGT-3100,2016
-MGT,3100,11,Intermed Business Statistics,0.49,0.18,0.11,0.07,0.09,0.0,0.0,0.07,yunsik choi,MGT-3100,2016
-MGT,3100,12,Intermed Business Statistics,0.21,0.28,0.23,0.05,0.08,0.0,0.0,0.15,dan jiang,MGT-3100,2016
-MGT,3120,1,Decision Models for Management,0.29,0.31,0.29,0.07,0.02,0.0,0.0,0.02,mark mcknew,MGT-3120,2016
-MGT,3120,2,Decision Models for Management,0.22,0.28,0.3,0.09,0.09,0.0,0.0,0.02,mark mcknew,MGT-3120,2016
-MGT,3120,3,Decision Models for Management,0.2,0.32,0.3,0.07,0.07,0.0,0.0,0.05,mark mcknew,MGT-3120,2016
-MGT,3150,1,New Venture Creation,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,MGT-3150,2016
-MGT,3180,1,Mgt of Info Systems,0.65,0.25,0.05,0.05,0.0,0.0,0.0,0.0,jackie patri london,MGT-3180,2016
-MGT,3180,2,Mgt of Info Systems,0.78,0.2,0.03,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,MGT-3180,2016
-MGT,3180,3,Mgt of Info Systems,0.18,0.5,0.25,0.0,0.02,0.0,0.0,0.05,russell purvis,MGT-3180,2016
-MGT,3180,4,Mgt of Info Systems,0.39,0.39,0.19,0.03,0.0,0.0,0.0,0.0,roopa raman,MGT-3180,2016
-MGT,3900,2,Ops Mgt,0.23,0.23,0.15,0.15,0.18,0.0,0.0,0.08,niratc tungtisanont,MGT-3900,2016
-MGT,3900,3,Ops Mgt,0.05,0.36,0.36,0.08,0.08,0.0,0.0,0.08,zachary mo leffakis,MGT-3900,2016
-MGT,3900,4,Ops Mgt,0.58,0.23,0.18,0.03,0.0,0.0,0.0,0.0,berna quiroga gomez,MGT-3900,2016
-MGT,3900,5,Ops Mgt,0.18,0.38,0.23,0.13,0.08,0.0,0.0,0.03,shouqiang wang,MGT-3900,2016
-MGT,3900,6,Ops Mgt,0.64,0.26,0.1,0.0,0.0,0.0,0.0,0.0,berna quiroga gomez,MGT-3900,2016
-MGT,4000,2,Mgt of Organizational Behavior,0.53,0.38,0.05,0.0,0.05,0.0,0.0,0.0,michael cole,MGT-4000,2016
-MGT,4000,3,Mgt of Organizational Behavior,0.1,0.46,0.36,0.0,0.08,0.0,0.0,0.0,philip roth,MGT-4000,2016
-MGT,4000,4,Mgt of Organizational Behavior,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2016
-MGT,4020,1,Ops Pln and Ctl,0.06,0.67,0.22,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,MGT-4020,2016
-MGT,4080,1,Lean Operations,0.29,0.45,0.24,0.0,0.02,0.0,0.0,0.0,zachary mo leffakis,MGT-4080,2016
-MGT,4110,1,Project Management,0.24,0.38,0.29,0.0,0.05,0.0,0.0,0.05,russell purvis,MGT-4110,2016
-MGT,4120,1,Supplier Management,0.18,0.42,0.34,0.05,0.0,0.0,0.0,0.0,shouqiang wang,MGT-4120,2016
-MGT,4150,1,Business Strategy,0.16,0.36,0.4,0.02,0.04,0.0,0.0,0.02,peter gianiodis,MGT-4150,2016
-MGT,4150,2,Business Strategy,0.2,0.56,0.24,0.0,0.0,0.0,0.0,0.0,peter gianiodis,MGT-4150,2016
-MGT,4150,3,Business Strategy,0.36,0.62,0.0,0.0,0.0,0.0,0.0,0.02,john edward hopkins,MGT-4150,2016
-MGT,4150,4,Business Strategy,0.32,0.55,0.13,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2016
-MGT,4150,5,Business Strategy,0.48,0.35,0.13,0.02,0.02,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2016
-MGT,4150,6,Business Strategy,0.44,0.51,0.04,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2016
-MGT,4150,7,Business Strategy,0.45,0.52,0.02,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2016
-MGT,4150,10,Business Strategy,0.24,0.73,0.02,0.0,0.0,0.0,0.0,0.0,john edward hopkins,MGT-4150,2016
-MGT,4160,1,Special Topics Hr,0.34,0.4,0.26,0.0,0.0,0.0,0.0,0.0,kristin dam scott,MGT-4160,2016
-MGT,4230,1,Intern Bus Mgt,0.08,0.18,0.54,0.05,0.1,0.0,0.0,0.05,wayne stewart,MGT-4230,2016
-MGT,4230,2,Intern Bus Mgt,0.13,0.55,0.3,0.03,0.0,0.0,0.0,0.0,janis miller,MGT-4230,2016
-MGT,4230,3,Intern Bus Mgt,0.14,0.19,0.6,0.05,0.02,0.0,0.0,0.0,wayne stewart,MGT-4230,2016
-MGT,4240,1,Global Supply Chain,0.17,0.58,0.21,0.0,0.04,0.0,0.0,0.0,yann ferrand,MGT-4240,2016
-MGT,4310,1,Emp Rights & Resp,0.31,0.49,0.16,0.02,0.0,0.0,0.0,0.02,leonard jos spooner,MGT-4310,2016
-MGT,4350,1,Pers Interviewing,0.23,0.58,0.13,0.03,0.03,0.0,0.0,0.03,philip roth,MGT-4350,2016
-MGT,4520,1,Business Analysis,0.19,0.43,0.38,0.0,0.0,0.0,0.0,0.0,roopa raman,MGT-4520,2016
-MGT,4550,1,Emerging I T Trends,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jason thatcher,MGT-4550,2016
-MGT,4560,1,Business Info Mgt,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,siyuan li,MGT-4560,2016
-MGT,8120,1,Supply Chain Mgt,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,yann ferrand,MGT-8120,2016
-MICR,3050,1,General Microbiology,0.51,0.34,0.13,0.0,0.0,0.0,0.0,0.01,kristi ja whitehead,MICR-3050,2016
-MICR,3050,2,General Microbiology,0.44,0.37,0.15,0.03,0.01,0.0,0.0,0.01,krista barr rudolph,MICR-3050,2016
-MICR,3050,3,General Microbiology,0.52,0.42,0.02,0.0,0.02,0.0,0.0,0.02,krista barr rudolph,MICR-3050,2016
-MICR,4000,1,Public Health Micro,0.5,0.31,0.09,0.05,0.03,0.0,0.0,0.02,kristi ja whitehead,MICR-4000,2016
-MICR,4020,1,Environmental Micro,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,john michael henson,MICR-4020,2016
-MICR,4070,1,Food and Dairy Micro,0.26,0.46,0.24,0.0,0.0,0.0,0.0,0.04,xiuping jiang,MICR-4070,2016
-MICR,4110,1,Pathogenic Bact,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4110,2016
-MICR,4120,1,Bacterial Physiology,0.24,0.31,0.22,0.08,0.1,0.0,0.0,0.06,thomas hughes,MICR-4120,2016
-MICR,4130,1,Industrial Micro,0.39,0.37,0.16,0.04,0.01,0.0,0.0,0.03,tzuen-rong je tzeng,MICR-4130,2016
-MICR,4140,1,Basic Immunology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,MICR-4140,2016
-MICR,4170,1,Cancer and Aging,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,yuqing dong,MICR-4170,2016
-MICR,4500,1,Advanced Microbiology I,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2016
-MICR,4500,2,Advanced Microbiology I,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2016
-MICR,4500,3,Advanced Microbiology I,0.54,0.15,0.08,0.0,0.08,0.0,0.0,0.15,harry kurtz,MICR-4500,2016
-MICR,4520,1,Advanced Microbiology III,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4520,2016
-MICR,4930,2,Senior Seminar,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,barbara campbell,MICR-4930,2016
-MKT,3010,1,Prin of Marketing,0.34,0.38,0.17,0.05,0.04,0.0,0.0,0.02,carter wil mcelveen,MKT-3010,2016
-MKT,3010,2,Prin of Marketing,0.26,0.35,0.29,0.05,0.03,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2016
-MKT,3010,3,Prin of Marketing,0.21,0.5,0.19,0.03,0.02,0.01,0.0,0.04,james gaubert,MKT-3010,2016
-MKT,3010,4,Prin of Marketing,0.28,0.5,0.19,0.01,0.01,0.0,0.0,0.02,james gaubert,MKT-3010,2016
-MKT,3010,5,Prin of Marketing,0.45,0.38,0.11,0.02,0.04,0.0,0.0,0.0,patricia knowles,MKT-3010,2016
-MKT,3020,1,Consumer Behavior,0.46,0.37,0.12,0.02,0.03,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2016
-MKT,3020,2,Consumer Behavior,0.6,0.28,0.09,0.02,0.02,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2016
-MKT,3020,3,Consumer Behavior,0.28,0.52,0.13,0.06,0.0,0.0,0.0,0.02, thyroff fitzwater,MKT-3020,2016
-MKT,3020,4,Consumer Behavior,0.35,0.43,0.14,0.05,0.0,0.0,0.0,0.03, thyroff fitzwater,MKT-3020,2016
-MKT,3020,5,Consumer Behavior,0.28,0.48,0.24,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-3020,2016
-MKT,3210,1,Sports Marketing,0.53,0.39,0.06,0.0,0.02,0.0,0.0,0.0,delancy bennett,MKT-3210,2016
-MKT,3210,2,Sports Marketing,0.5,0.43,0.08,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,MKT-3210,2016
-MKT,3310,1,Marketing Metrics & Analytics,0.26,0.52,0.17,0.04,0.0,0.0,0.0,0.0,peter weathers,MKT-3310,2016
-MKT,3980,1,CI: Sales Experiential,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,MKT-3980,2016
-MKT,4200,1,Professional Selling,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2016
-MKT,4200,2,Professional Selling,0.33,0.37,0.17,0.1,0.03,0.0,0.0,0.0,jesse moore,MKT-4200,2016
-MKT,4200,3,Professional Selling,0.84,0.13,0.0,0.0,0.03,0.0,0.0,0.0,carter wil mcelveen,MKT-4200,2016
-MKT,4200,4,Professional Selling,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2016
-MKT,4230,1,Promotional Strategy,0.44,0.38,0.11,0.02,0.04,0.0,0.0,0.0,patricia knowles,MKT-4230,2016
-MKT,4240,2,Sales Management,0.3,0.66,0.05,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4240,2016
-MKT,4250,1,Retail Management,0.58,0.38,0.0,0.0,0.02,0.0,0.0,0.02,james gaubert,MKT-4250,2016
-MKT,4270,1,International Mktg,0.2,0.65,0.08,0.03,0.0,0.0,0.0,0.05,thomas poehlman,MKT-4270,2016
-MKT,4270,2,International Mktg,0.23,0.5,0.23,0.02,0.0,0.0,0.0,0.02,roger gomes,MKT-4270,2016
-MKT,4270,3,International Mktg,0.26,0.38,0.33,0.0,0.0,0.0,0.0,0.03,roger gomes,MKT-4270,2016
-MKT,4270,4,International Mktg,0.1,0.49,0.28,0.03,0.08,0.0,0.0,0.03,roger gomes,MKT-4270,2016
-MKT,4270,600,International Mktg,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4270,2016
-MKT,4280,1,Services Marketing,0.49,0.18,0.23,0.08,0.0,0.0,0.0,0.03,stephen grove,MKT-4280,2016
-MKT,4280,2,Services Marketing,0.28,0.47,0.17,0.08,0.0,0.0,0.0,0.0,stephen grove,MKT-4280,2016
-MKT,4310,1,Marketing Research,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4310,2016
-MKT,4310,2,Marketing Research,0.25,0.42,0.29,0.0,0.04,0.0,0.0,0.0,william kilbourne,MKT-4310,2016
-MKT,4310,3,Marketing Research,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2016
-MKT,4310,4,Marketing Research,0.4,0.48,0.12,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2016
-MKT,4330,1,Sport Mkt Strategy,0.41,0.48,0.07,0.0,0.0,0.03,0.0,0.0,amanda cooper fine,MKT-4330,2016
-MKT,4430,1,Advertising Strategy,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,albert neil cameron,MKT-4430,2016
-MKT,4450,1,Macromarketing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,MKT-4450,2016
-MKT,4500,1,Strategic Mktg Mgt,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4500,2016
-MKT,4500,2,Strategic Mktg Mgt,0.77,0.2,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,MKT-4500,2016
-MKT,4500,3,Strategic Mktg Mgt,0.52,0.41,0.03,0.03,0.0,0.0,0.0,0.0,lura forcum,MKT-4500,2016
-MKT,4500,4,Strategic Mktg Mgt,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-4500,2016
-MKT,4950,1,Selected Topics: Social Media,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-4950,2016
-MKT,8620,1,Quant Methods in Mkt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,MKT-8620,2016
-MKT,8650,1,Seminar in Mkt Mgmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,MKT-8650,2016
-ML,1020,1,Leadership Fund II,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,amanda carol kane,ML-1020,2016
-ML,4020,3,Organizational Leadership II,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,james mullinax,ML-4020,2016
-MSE,2100,2,Intro to Mat Science,0.16,0.54,0.19,0.02,0.04,0.0,0.0,0.05,kyle brinkman,MSE-2100,2016
-MSE,2100,3,Intro to Mat Science,0.21,0.46,0.16,0.05,0.04,0.0,0.0,0.08,eric skaar,MSE-2100,2016
-MSE,2100,4,Intro to Mat Science,0.4,0.28,0.09,0.09,0.07,0.0,0.0,0.07,olga kuksenok,MSE-2100,2016
-MSE,2100,5,Intro to Mat Science,0.31,0.31,0.27,0.02,0.0,0.0,0.0,0.08,rakhee pani,MSE-2100,2016
-MSE,2410,1,Metrics,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,MSE-2410,2016
-MSE,2500,1,Polymer & Fiber Materials I,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,deborah lickfield,MSE-2500,2016
-MSE,2500,2,Polymer & Fiber Materials I,0.36,0.29,0.29,0.0,0.0,0.0,0.0,0.07,deborah lickfield,MSE-2500,2016
-MSE,3260,1,Thermo of Materials,0.15,0.43,0.26,0.08,0.03,0.0,0.0,0.05,gary lickfield,MSE-3260,2016
-MSE,3280,1,Phase Diagrams,0.4,0.37,0.23,0.0,0.0,0.0,0.0,0.0,eric skaar,MSE-3280,2016
-MSE,3610,1,Proc of Metals & Com,0.41,0.36,0.23,0.0,0.0,0.0,0.0,0.0,marian kennedy,MSE-3610,2016
-MSE,4150,1,Polymer Sc Engr,0.33,0.33,0.22,0.07,0.0,0.0,0.0,0.04,igor luzinov,MSE-4150,2016
-MSE,4160,1,Electronic Materials,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,kyle brinkman,MSE-4160,2016
-MSE,4220,1,Mech Behavior of Mat,0.31,0.47,0.17,0.0,0.05,0.0,0.0,0.0,vincent yves blouin,MSE-4220,2016
-MSE,4240,1,Optical Materials,0.28,0.48,0.16,0.08,0.0,0.0,0.0,0.0,luiz gust jacobsohn,MSE-4240,2016
-MSE,4330,1,Comb Sys & Env Emiss,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,denis brosnan,MSE-4330,2016
-MSE,4560,1,Polymer & Fiber Materials II,0.37,0.41,0.19,0.0,0.0,0.0,0.0,0.04,gary lickfield,MSE-4560,2016
-MSE,4590,2,Color Science Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,philip brown,MSE-4590,2016
-MSE,4910,1,Undergraduate Research,0.59,0.24,0.09,0.03,0.0,0.0,0.0,0.06,marian kennedy,MSE-4910,2016
-MUSC,1110,7,Beginning Class Guitar,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,david stevenson,MUSC-1110,2016
-MUSC,1420,1,Music Theory I,0.79,0.07,0.0,0.0,0.07,0.0,0.0,0.07,anthony bernarducci,MUSC-1420,2016
-MUSC,1430,1,Aural Skills I,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,anthony bernarducci,MUSC-1430,2016
-MUSC,1510,2,Applied Music,0.55,0.0,0.09,0.0,0.09,0.0,0.0,0.27,jonathan edwa doyel,MUSC-1510,2016
-MUSC,1800,1,Intro to Music Tech,0.2,0.5,0.1,0.0,0.2,0.0,0.0,0.0,hamilton altstatt,MUSC-1800,2016
-MUSC,2100,1,Music in the Western World,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-2100,2016
-MUSC,2100,2,Music in the Western World,0.59,0.22,0.06,0.06,0.0,0.0,0.0,0.06,lisa sain odom,MUSC-2100,2016
-MUSC,2100,3,Music in the Western World,0.88,0.06,0.0,0.03,0.03,0.0,0.0,0.0,eric lapin,MUSC-2100,2016
-MUSC,2100,4,Music in the Western World,0.65,0.1,0.13,0.06,0.0,0.0,0.0,0.06,linda li-bleuel,MUSC-2100,2016
-MUSC,2100,5,Music in the Western World,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2016
-MUSC,2100,6,Music in the Western World,0.67,0.2,0.07,0.03,0.03,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2016
-MUSC,2100,7,Music in the Western World,0.48,0.48,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2016
-MUSC,2100,12,Music in the Western World,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,MUSC-2100,2016
-MUSC,2100,13,Music in the Western World,0.84,0.06,0.03,0.0,0.03,0.0,0.0,0.03,linda dzuris,MUSC-2100,2016
-MUSC,2100,14,Music in the Western World,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,david conley,MUSC-2100,2016
-MUSC,3090,1,Surv of Broadway II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,lisa sain odom,MUSC-3090,2016
-MUSC,3110,1,History of American Music,0.78,0.16,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3110,2016
-MUSC,3120,1,History of Jazz,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-3120,2016
-MUSC,3170,1,Hist of Country Mus,0.78,0.16,0.0,0.03,0.03,0.0,0.0,0.0,ned hosler,MUSC-3170,2016
-MUSC,3180,1,Hist of Audio Tech,0.5,0.21,0.21,0.07,0.0,0.0,0.0,0.0,bruce allen whisler,MUSC-3180,2016
-MUSC,3310,1,Pep Band - Men,0.96,0.03,0.0,0.0,0.0,0.0,0.0,0.01,timothy ra hurlburt,MUSC-3310,2016
-MUSC,3640,1,Concert Band,0.91,0.01,0.03,0.0,0.0,0.0,0.0,0.04,timothy ra hurlburt,MUSC-3640,2016
-MUSC,3690,1,Symphony Orchestra,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,MUSC-3690,2016
-MUSC,3700,1,Clemson University Singers,0.91,0.02,0.05,0.0,0.0,0.0,0.0,0.02,justin durham,MUSC-3700,2016
-MUSC,3710,1,Women's Chorus,0.96,0.0,0.02,0.02,0.0,0.0,0.0,0.0,justin durham,MUSC-3710,2016
-MUSC,3720,1,Men's Chorus,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,MUSC-3720,2016
-MUSC,4160,1,Mus Hist Since 1750,0.39,0.22,0.22,0.06,0.06,0.0,0.0,0.06,linda li-bleuel,MUSC-4160,2016
-NPL,3010,2,NPL Stakeholders,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,tracy diane lamb,NPL-3010,2016
-NPL,3030,2,NPL Personnel,0.77,0.09,0.0,0.0,0.09,0.0,0.0,0.05,wendell price,NPL-3030,2016
-NURS,3030,1,Nursing of Adults,0.15,0.75,0.1,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,NURS-3030,2016
-NURS,3030,400,Nursing of Adults,0.08,0.77,0.12,0.0,0.0,0.0,0.0,0.04,lena marie burgess,NURS-3030,2016
-NURS,3040,1,Pathophysiology,0.29,0.47,0.14,0.04,0.02,0.0,0.0,0.04,catherine si murton,NURS-3040,2016
-NURS,3040,401,Pathophysiology for RN,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,NURS-3040,2016
-NURS,3100,1,Health Assessment,0.62,0.36,0.0,0.0,0.0,0.0,0.0,0.02,terry kaye busby,NURS-3100,2016
-NURS,3120,1,Foundations of Nursing,0.38,0.51,0.06,0.0,0.02,0.0,0.0,0.02,angela pye,NURS-3120,2016
-NURS,3190,400,Health Assessment for RNs,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,NURS-3190,2016
-NURS,3190,401,Health Assessment for RNs,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kellie davis-hall,NURS-3190,2016
-NURS,3200,1,Prof in Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3200,2016
-NURS,3300,1,Research in Nursing,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,shirley mae timmons,NURS-3300,2016
-NURS,3330,1,Health Care Genetics,0.93,0.05,0.0,0.02,0.0,0.0,0.0,0.0,jane marie deluca,NURS-3330,2016
-NURS,3330,400,Health Care Genetics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,NURS-3330,2016
-NURS,3400,1,Pharmther Nursing,0.28,0.53,0.11,0.04,0.0,0.0,0.0,0.04,catherine si murton,NURS-3400,2016
-NURS,3600,400,Social Determinants in Health,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,roxanne amerson,NURS-3600,2016
-NURS,4010,1,Mental Health Nurs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-4010,2016
-NURS,4100,1,Lead Mgt Practicum,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,NURS-4100,2016
-NURS,4110,1,Nursing of Children,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,NURS-4110,2016
-NURS,4120,1,Nurs Women and Fam,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2016
-NURS,8010,400,Adv Fam & Comm Nrsng,0.8,0.18,0.02,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,NURS-8010,2016
-NURS,8080,400,Nurs Res Stat Analys,0.69,0.28,0.02,0.0,0.02,0.0,0.0,0.0,veronica parker,NURS-8080,2016
-NURS,8190,400,Developing Family,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,paula watt,NURS-8190,2016
-NURS,8200,400,Child & Adol Nursing,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-8200,2016
-NURS,8210,400,Adult Nursing,0.71,0.27,0.0,0.0,0.0,0.0,0.0,0.02,tracy king fasolino,NURS-8210,2016
-NURS,8850,400,Mental Health in Primary Care,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-8850,2016
-NUTR,2030,1,Intro Princ of Human Nutrition,0.48,0.32,0.13,0.04,0.02,0.0,0.0,0.02,deborah an hutcheon,NUTR-2030,2016
-NUTR,2030,2,Intro Princ of Human Nutrition,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,NUTR-2030,2016
-NUTR,2040,1,Nutrition Across Life Cycle,0.22,0.53,0.15,0.05,0.03,0.0,0.0,0.02,deborah an hutcheon,NUTR-2040,2016
-NUTR,4180,1,Prof Development in Dietetics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,NUTR-4180,2016
-NUTR,4250,1,Medica Nutr Thera II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4250,2016
-NUTR,4260,1,Community Nutrition,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,katherine cason,NUTR-4260,2016
-NUTR,4550,1,Nutr Metabolism,0.34,0.26,0.2,0.14,0.06,0.0,0.0,0.0,elliot jesch,NUTR-4550,2016
-NUTR,8030,1,Adv Human Nutr,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,vivian haley-zitlin,NUTR-8030,2016
-PA,2800,1,Perf Arts Pract II,0.5,0.29,0.07,0.0,0.0,0.0,0.0,0.14,kenneth moore,PA-2800,2016
-PA,3010,1,Prin of Arts Admin,0.46,0.23,0.31,0.0,0.0,0.0,0.0,0.0,paul buyer,PA-3010,2016
-PA,4010,1,Capstone Project,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,PA-4010,2016
-PADM,8210,400,Perspectives on Public Admin,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,PADM-8210,2016
-PADM,8290,400,Public Financial Management,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,PADM-8290,2016
-PADM,8410,400,Public Data Analysis,0.27,0.27,0.18,0.0,0.27,0.0,0.0,0.0,ronald chrestman,PADM-8410,2016
-PADM,8430,400,Info Systems for Public Admin,0.5,0.13,0.13,0.0,0.0,0.0,0.0,0.25,mark daniel mellott,PADM-8430,2016
-PADM,8530,400,Homeland Sec/Emergency Mgt Law,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,david leigh cook,PADM-8530,2016
-PADM,8600,400,American Government,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,PADM-8600,2016
-PADM,8720,400,Rural Development,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,PADM-8720,2016
-PADM,8780,400,Nonprofit Marketing & Pub Rel,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,debra nelson,PADM-8780,2016
-PES,2020,1,Soils,0.03,0.5,0.36,0.07,0.0,0.0,0.0,0.03,dara michelle park,PES-2020,2016
-PES,4050,1,Plant Breeding,0.47,0.33,0.07,0.07,0.0,0.0,0.0,0.07,ksenija gasic,PES-4050,2016
-PES,4220,1,Major World Crops,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,sruthi naraya kutty,PES-4220,2016
-PES,4460,1,Soil Management,0.23,0.62,0.08,0.0,0.0,0.0,0.0,0.08,dara michelle park,PES-4460,2016
-PES,4520,1,Soil Fertility and Management,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,haibo liu,PES-4520,2016
-PES,4900,1,Soil Organisms in Plant Growth,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,"appukuttan suseela,",PES-4900,2016
-PES,4960,1,BioIntegrated Greenhouse Sys.,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,geoffrey zehnder,PES-4960,2016
-PHIL,1010,1,Intro to Philosophic Problems,0.57,0.29,0.09,0.03,0.0,0.0,0.0,0.03,david stegall,PHIL-1010,2016
-PHIL,1010,2,Intro to Philosophic Problems,0.56,0.24,0.09,0.06,0.0,0.0,0.0,0.06,david stegall,PHIL-1010,2016
-PHIL,1010,5,Intro to Philosophic Problems,0.26,0.4,0.2,0.03,0.06,0.0,0.0,0.06,john randall wolfe,PHIL-1010,2016
-PHIL,1010,6,Intro to Philosophic Problems,0.34,0.37,0.14,0.0,0.11,0.0,0.0,0.03,john randall wolfe,PHIL-1010,2016
-PHIL,1010,7,Intro to Philosophic Problems,0.44,0.41,0.06,0.03,0.0,0.0,0.0,0.06,john randall wolfe,PHIL-1010,2016
-PHIL,1020,1,Introduction to Logic,0.81,0.03,0.13,0.0,0.03,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2016
-PHIL,1020,2,Introduction to Logic,0.58,0.33,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,PHIL-1020,2016
-PHIL,1020,3,Introduction to Logic,0.91,0.03,0.0,0.0,0.03,0.0,0.0,0.03,gregory scott moss,PHIL-1020,2016
-PHIL,1020,4,Introduction to Logic,0.86,0.09,0.0,0.0,0.03,0.0,0.0,0.03,gregory scott moss,PHIL-1020,2016
-PHIL,1020,6,Introduction to Logic,0.45,0.19,0.29,0.06,0.0,0.0,0.0,0.0,stephen satris,PHIL-1020,2016
-PHIL,1030,2,Introduction to Ethics,0.17,0.43,0.14,0.11,0.11,0.0,0.0,0.03,malcolm edwa munson,PHIL-1030,2016
-PHIL,1030,3,Introduction to Ethics,0.26,0.43,0.29,0.0,0.03,0.0,0.0,0.0,malcolm edwa munson,PHIL-1030,2016
-PHIL,1030,5,Introduction to Ethics,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,adam gies,PHIL-1030,2016
-PHIL,1030,6,Introduction to Ethics,0.74,0.18,0.03,0.0,0.06,0.0,0.0,0.0,adam gies,PHIL-1030,2016
-PHIL,1030,7,Introduction to Ethics,0.41,0.43,0.14,0.03,0.0,0.0,0.0,0.0,ryan lake,PHIL-1030,2016
-PHIL,1030,8,Introduction to Ethics,0.41,0.47,0.09,0.03,0.0,0.0,0.0,0.0,ryan lake,PHIL-1030,2016
-PHIL,1030,9,Introduction to Ethics,0.47,0.37,0.0,0.0,0.05,0.0,0.0,0.11,ryan lake,PHIL-1030,2016
-PHIL,1030,11,Introduction to Ethics,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,jennifer ingle,PHIL-1030,2016
-PHIL,1030,12,Introduction to Ethics,0.44,0.41,0.0,0.03,0.0,0.0,0.0,0.12,jennifer ingle,PHIL-1030,2016
-PHIL,3030,1,Phil of Religion,0.7,0.23,0.0,0.03,0.0,0.0,0.0,0.03,gregory scott moss,PHIL-3030,2016
-PHIL,3150,1,Ancient Philosophy,0.4,0.3,0.13,0.0,0.13,0.0,0.0,0.03,john randall wolfe,PHIL-3150,2016
-PHIL,3160,1,Modern Philosophy,0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,michael hal hannen,PHIL-3160,2016
-PHIL,3200,1,Soc and Pol Phil,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,david stegall,PHIL-3200,2016
-PHIL,3210,1,Crime & Punishment,0.76,0.21,0.0,0.0,0.03,0.0,0.0,0.0,ryan lake,PHIL-3210,2016
-PHIL,3260,1,Science and Values,0.53,0.38,0.06,0.0,0.03,0.0,0.0,0.0,andrew garnar,PHIL-3260,2016
-PHIL,3260,2,Science and Values,0.53,0.38,0.03,0.0,0.06,0.0,0.0,0.0,andrew garnar,PHIL-3260,2016
-PHIL,3430,1,Philosophy of Law,0.7,0.21,0.0,0.0,0.0,0.0,0.0,0.09,david stegall,PHIL-3430,2016
-PHIL,3440,1,Business Ethics,0.23,0.69,0.09,0.0,0.0,0.0,0.0,0.0,diane perpich,PHIL-3440,2016
-PHIL,3450,1,Environmental Ethics,0.6,0.26,0.06,0.03,0.03,0.0,0.0,0.03,jennifer ingle,PHIL-3450,2016
-PHIL,3550,1,Philosophy of Mind & Cog Scien,0.53,0.29,0.0,0.06,0.06,0.0,0.0,0.06,adam gies,PHIL-3550,2016
-PHIL,3700,1,Philosophy of War,0.34,0.41,0.13,0.0,0.03,0.0,0.0,0.09,todd may,PHIL-3700,2016
-PHIL,4750,1,Philosophy of Film,0.38,0.38,0.06,0.0,0.13,0.06,0.0,0.0,christopher grau,PHIL-4750,2016
-PHSC,1170,1,Intro Chem & Earth,0.91,0.08,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1170,2016
-PHYS,1220,1,Physics with Calculus I,0.26,0.23,0.26,0.14,0.07,0.0,0.0,0.05,lih-sin the,PHYS-1220,2016
-PHYS,1220,2,Physics with Calculus I,0.22,0.35,0.19,0.1,0.06,0.0,0.0,0.08,lih-sin the,PHYS-1220,2016
-PHYS,1220,3,Physics with Calculus I,0.27,0.43,0.19,0.06,0.03,0.0,0.0,0.02,lih-sin the,PHYS-1220,2016
-PHYS,1220,4,Physics with Calculus I,0.38,0.4,0.14,0.04,0.01,0.0,0.0,0.01,hye jung kang,PHYS-1220,2016
-PHYS,1220,5,Physics with Calculus I,0.32,0.37,0.23,0.03,0.03,0.0,0.0,0.02,pooja puneet,PHYS-1220,2016
-PHYS,1220,8,Physics With Cal I (HON),0.56,0.26,0.09,0.0,0.0,0.0,0.0,0.09,ramakrishna podila,PHYS-1220,2016
-PHYS,1240,1,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,2,Physics Lab I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2016
-PHYS,1240,3,Physics Lab I,0.12,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,4,Physics Lab I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2016
-PHYS,1240,5,Physics Lab I,0.41,0.47,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,PHYS-1240,2016
-PHYS,1240,6,Physics Lab I,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,7,Physics Lab I,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,8,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,9,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2016
-PHYS,1240,10,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,11,Physics Lab I,0.22,0.5,0.0,0.0,0.0,0.0,0.0,0.28,jerry hester,PHYS-1240,2016
-PHYS,1240,12,Physics Lab I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,13,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,14,Physics Lab I,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,15,Physics Lab I,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2016
-PHYS,1240,16,Physics Lab I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,17,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,18,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,19,Physics Lab I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2016
-PHYS,1240,20,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,21,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,22,Physics Lab I,0.38,0.44,0.0,0.0,0.0,0.0,0.0,0.19,jerry hester,PHYS-1240,2016
-PHYS,1240,23,Physics Lab I,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,24,Physics Lab I,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,25,Physics Lab I,0.24,0.65,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,26,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,27,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,1240,29,Physics Lab I,0.22,0.5,0.17,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2016
-PHYS,1240,30,Physics Lab I,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2016
-PHYS,2000,1,Introductory Physics,0.26,0.49,0.17,0.09,0.0,0.0,0.0,0.0,sean brittain,PHYS-2000,2016
-PHYS,2070,1,General Physics I,0.34,0.36,0.16,0.06,0.03,0.0,0.0,0.05,pooja puneet,PHYS-2070,2016
-PHYS,2080,1,General Physics II,0.63,0.25,0.07,0.04,0.0,0.0,0.0,0.0,amy liann pope,PHYS-2080,2016
-PHYS,2080,2,General Physics II,0.53,0.31,0.08,0.04,0.03,0.0,0.0,0.0,amy liann pope,PHYS-2080,2016
-PHYS,2090,1,Gen Phys Lab I,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,2,Gen Phys Lab I,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,jerry hester,PHYS-2090,2016
-PHYS,2090,3,Gen Phys Lab I,0.27,0.55,0.14,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2016
-PHYS,2090,4,Gen Phys Lab I,0.41,0.41,0.05,0.05,0.0,0.0,0.0,0.09,jerry hester,PHYS-2090,2016
-PHYS,2090,5,Gen Phys Lab I,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,6,Gen Phys Lab I,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2016
-PHYS,2090,7,Gen Phys Lab I,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,8,Gen Phys Lab I,0.57,0.39,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,9,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2090,10,Gen Phys Lab I,0.14,0.71,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2016
-PHYS,2100,1,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,2,Gen Phys Lab II,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,3,Gen Phys Lab II,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,5,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,6,Gen Phys Lab II,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,7,Gen Phys Lab II,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2016
-PHYS,2100,8,Gen Phys Lab II,0.75,0.21,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,9,Gen Phys Lab II,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,10,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,11,Gen Phys Lab II,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,12,Gen Phys Lab II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,13,Gen Phys Lab II,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,14,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,15,Gen Phys Lab II,0.5,0.33,0.08,0.0,0.04,0.0,0.0,0.04,jerry hester,PHYS-2100,2016
-PHYS,2100,16,Gen Phys Lab II,0.28,0.61,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,PHYS-2100,2016
-PHYS,2100,17,Gen Phys Lab II,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2100,18,Gen Phys Lab II,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2016
-PHYS,2210,1,Physics with Calculus II,0.28,0.4,0.24,0.04,0.03,0.0,0.0,0.01,jason stratfo brown,PHYS-2210,2016
-PHYS,2210,2,Physics with Calculus II,0.33,0.38,0.14,0.11,0.03,0.0,0.0,0.02,jason stratfo brown,PHYS-2210,2016
-PHYS,2210,3,Physics with Calculus II,0.36,0.29,0.29,0.0,0.07,0.0,0.0,0.0,murray daw,PHYS-2210,2016
-PHYS,2210,5,Physics with Calculus II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,edward collins,PHYS-2210,2016
-PHYS,2220,1,Physics with Calculus III,0.36,0.36,0.11,0.0,0.0,0.0,0.0,0.18,jian he,PHYS-2220,2016
-PHYS,2230,1,Physics Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,2,Physics Lab II,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2016
-PHYS,2230,3,Physics Lab II,0.53,0.35,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,PHYS-2230,2016
-PHYS,2230,4,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,5,Physics Lab II,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,6,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,7,Physics Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2016
-PHYS,2230,8,Physics Lab II,0.06,0.61,0.17,0.06,0.0,0.0,0.0,0.11,jerry hester,PHYS-2230,2016
-PHYS,2230,9,Physics Lab II,0.33,0.4,0.2,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-2230,2016
-PHYS,2230,10,Physics Lab II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,edward collins,PHYS-2230,2016
-PHYS,2240,1,Physics Lab III,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-2240,2016
-PHYS,2400,1,Phys of Weather,0.33,0.4,0.18,0.0,0.03,0.0,0.0,0.08,miguel larsen,PHYS-2400,2016
-PHYS,3110,1,Methods Theor Phys,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,feng ding,PHYS-3110,2016
-PHYS,3220,1,Mechanics II,0.09,0.73,0.09,0.0,0.09,0.0,0.0,0.0,gerald lehmacher,PHYS-3220,2016
-PHYS,4650,1,Thermo and Stat Mech,0.33,0.33,0.0,0.08,0.0,0.0,0.0,0.25,jens oberheide,PHYS-4650,2016
-PHYS,8150,1,Statistical Therm I,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,PHYS-8150,2016
-PHYS,8410,1,Electrodynamics I,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,PHYS-8410,2016
-PHYS,9520,1,Quantum Mech II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,sumanta tewari,PHYS-9520,2016
-PKSC,1020,1,Intro to Pkg Sci,0.09,0.31,0.32,0.17,0.03,0.0,0.0,0.07,heather batt,PKSC-1020,2016
-PKSC,2010,1,Pkg Perishable Prod,0.12,0.41,0.28,0.09,0.08,0.0,0.0,0.03,heather batt,PKSC-2010,2016
-PKSC,2020,1,Packaging Mtl & Mfg,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2020,2016
-PKSC,2040,1,Container Systems,0.84,0.15,0.01,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2040,2016
-PKSC,2060,1,Container Sys Lab,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2060,2016
-PKSC,2060,2,Container Sys Lab,0.62,0.14,0.24,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2060,2016
-PKSC,2060,3,Container Sys Lab,0.68,0.18,0.14,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2060,2016
-PKSC,2200,1,Product & Pkg Design,0.67,0.21,0.08,0.04,0.0,0.0,0.0,0.0,william aaro snyder,PKSC-2200,2016
-PKSC,3200,1,Pkg Design Theory,0.43,0.52,0.02,0.0,0.0,0.0,0.0,0.02,rupert hurley,PKSC-3200,2016
-PKSC,3680,1,Pkg and Society,0.57,0.3,0.11,0.02,0.0,0.0,0.0,0.0,heather batt,PKSC-3680,2016
-PKSC,4030,1,Pkg Career Prep,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2016
-PKSC,4200,1,Pkg Design & Dev,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2016
-PKSC,4300,1,Converting Flex Pkg,0.25,0.56,0.08,0.08,0.02,0.0,0.0,0.0,duncan darby,PKSC-4300,2016
-PKSC,4400,2,Packaging for Distribution,0.25,0.57,0.1,0.04,0.05,0.0,0.0,0.0,gregory batt,PKSC-4400,2016
-PKSC,4640,1,Food & Health Care Pkg Systems,0.7,0.22,0.04,0.04,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2016
-PLPA,2130,1,Fungi & Civilization,0.42,0.36,0.06,0.08,0.04,0.0,0.0,0.05,julia loui kerrigan,PLPA-2130,2016
-PLPA,8090,1,Analytical Technique,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,tharayil-santhakumar,PLPA-8090,2016
-POSC,1010,1,Amer National Govt,0.07,0.36,0.27,0.1,0.11,0.0,0.0,0.07,laura olson,POSC-1010,2016
-POSC,1010,2,Amer National Govt,0.1,0.1,0.3,0.3,0.1,0.0,0.0,0.1,adam warber,POSC-1010,2016
-POSC,1020,1,Intro Intl Relations,0.2,0.45,0.18,0.06,0.09,0.0,0.0,0.02,zeynep taydas,POSC-1020,2016
-POSC,1020,2,Intro Intl Relations,0.11,0.29,0.3,0.11,0.12,0.0,0.0,0.06,zeynep taydas,POSC-1020,2016
-POSC,1020,3,Intro Intl Relations,0.17,0.44,0.22,0.05,0.06,0.0,0.0,0.06,aron geo tannenbaum,POSC-1020,2016
-POSC,1030,1,Intro to Political Theory,0.13,0.47,0.21,0.13,0.03,0.0,0.0,0.03,colin pearce,POSC-1030,2016
-POSC,1030,2,Intro to Political Theory,0.18,0.58,0.13,0.0,0.07,0.0,0.0,0.04,kimberly hurd hale,POSC-1030,2016
-POSC,1040,1,Intro Compar Pol,0.38,0.36,0.15,0.07,0.02,0.0,0.0,0.02,katherine am curtis,POSC-1040,2016
-POSC,1040,2,Intro Compar Pol,0.18,0.48,0.1,0.08,0.04,0.0,0.0,0.12,lydia loui lundgren,POSC-1040,2016
-POSC,1990,1,Intro Pol Sci,0.15,0.39,0.15,0.12,0.09,0.0,0.0,0.09,meredith petersheim,POSC-1990,2016
-POSC,3020,1,State and Loc Gov,0.11,0.62,0.16,0.03,0.05,0.0,0.0,0.03,bruce ransom,POSC-3020,2016
-POSC,3210,1,Public Admin,0.05,0.32,0.5,0.05,0.05,0.0,0.0,0.05,james woodard,POSC-3210,2016
-POSC,3410,1,Quant Meth in Pol Sc,0.25,0.17,0.25,0.17,0.08,0.0,0.0,0.08,steven vince miller,POSC-3410,2016
-POSC,3610,1,Intl Pol in Crisis,0.28,0.48,0.18,0.02,0.0,0.0,0.0,0.04,vladimir matic,POSC-3610,2016
-POSC,3620,1,Intl Organizations,0.1,0.2,0.37,0.07,0.13,0.0,0.0,0.13,zeynep taydas,POSC-3620,2016
-POSC,3630,1,Us Foreign Policy,0.16,0.25,0.27,0.14,0.14,0.0,0.0,0.05,steven vince miller,POSC-3630,2016
-POSC,3710,1,European Politics,0.2,0.39,0.27,0.04,0.04,0.0,0.0,0.06,katherine am curtis,POSC-3710,2016
-POSC,4030,1,United States Congress,0.33,0.41,0.22,0.02,0.0,0.0,0.0,0.02,jeffrey scott peake,POSC-4030,2016
-POSC,4050,1,American Presidency,0.07,0.29,0.36,0.07,0.14,0.0,0.0,0.07,adam warber,POSC-4050,2016
-POSC,4160,1,Int Groups & Soc Mov,0.32,0.42,0.16,0.05,0.0,0.0,0.0,0.05,laura olson,POSC-4160,2016
-POSC,4370,1,Constitut Law: Rights & Libert,0.39,0.47,0.04,0.0,0.04,0.0,0.0,0.06,daniel frost,POSC-4370,2016
-POSC,4490,1,Political Theory of Capitalism,0.49,0.23,0.15,0.05,0.08,0.0,0.0,0.0,brandon turner,POSC-4490,2016
-POSC,4500,1,Contemporary Political Thought,0.52,0.36,0.0,0.0,0.04,0.0,0.0,0.08,daniel frost,POSC-4500,2016
-POSC,4570,1,Political Terrorism,0.69,0.21,0.07,0.0,0.02,0.0,0.0,0.0,aron geo tannenbaum,POSC-4570,2016
-POSC,4660,1,African Politics,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,lydia loui lundgren,POSC-4660,2016
-POSC,4760,1,Middle East Politics,0.5,0.31,0.13,0.0,0.06,0.0,0.0,0.0,vladimir matic,POSC-4760,2016
-POSC,4890,1,WW2: World Conflict Ideology,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,james woodard,POSC-4890,2016
-POST,8430,1,Org Theory & Pub Mgt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,POST-8430,2016
-PRTM,2200,1,Foundations of PRTM,0.41,0.48,0.03,0.0,0.03,0.0,0.0,0.03,teresa walto tucker,PRTM-2200,2016
-PRTM,2200,2,Foundations of PRTM,0.67,0.23,0.0,0.07,0.03,0.0,0.0,0.0,gwynn powell,PRTM-2200,2016
-PRTM,2200,3,Foundations of PRTM,0.43,0.37,0.1,0.03,0.03,0.0,0.0,0.03,ryan joseph gagnon,PRTM-2200,2016
-PRTM,2200,4,Foundations of PRTM,0.22,0.59,0.15,0.0,0.04,0.0,0.0,0.0,dorothy schmalz,PRTM-2200,2016
-PRTM,2200,5,Foundations of PRTM,0.63,0.26,0.07,0.0,0.0,0.0,0.0,0.04,william holland,PRTM-2200,2016
-PRTM,2200,6,Foundations of PRTM,0.43,0.43,0.11,0.0,0.04,0.0,0.0,0.0,francis mcguire,PRTM-2200,2016
-PRTM,2410,1,Intro to CRSCM,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,PRTM-2410,2016
-PRTM,2410,2,Intro to CRSCM,0.56,0.29,0.06,0.0,0.03,0.0,0.0,0.06,jeffrey townsend,PRTM-2410,2016
-PRTM,2600,1,Found of Recreational Therapy,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,PRTM-2600,2016
-PRTM,2650,1,Terminology in RT Practice,0.89,0.06,0.03,0.01,0.01,0.0,0.0,0.0,stephen thoma lewis,PRTM-2650,2016
-PRTM,2700,1,Intro Rec Res Mgt,0.4,0.43,0.13,0.0,0.03,0.0,0.0,0.0,lincoln larson,PRTM-2700,2016
-PRTM,2980,3,Creative Inquiry in PRTM II,0.52,0.39,0.0,0.0,0.04,0.0,0.0,0.04,francis mcguire,PRTM-2980,2016
-PRTM,2980,5,Creative Inquiry in PRTM II,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,lawrence allen,PRTM-2980,2016
-PRTM,2980,6,Creative Inquiry in PRTM II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brent hawkins,PRTM-2980,2016
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.34,0.51,0.06,0.03,0.03,0.0,0.0,0.03,daniel mor anderson,PRTM-3050,2016
-PRTM,3070,1,Facility Operations,0.79,0.18,0.0,0.0,0.03,0.0,0.0,0.0,craig goodman,PRTM-3070,2016
-PRTM,3210,1,Recreation Admin,0.53,0.22,0.19,0.0,0.03,0.0,0.0,0.03,mariela fernandez,PRTM-3210,2016
-PRTM,3250,1,Global Persp in Rec,0.31,0.38,0.25,0.0,0.03,0.0,0.0,0.03,teresa walto tucker,PRTM-3250,2016
-PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.77,0.2,0.02,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,PRTM-3260,2016
-PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.36,0.52,0.09,0.02,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3270,2016
-PRTM,3420,1,Intro to Tourism,0.48,0.15,0.22,0.09,0.02,0.0,0.0,0.04,herbert chancellor,PRTM-3420,2016
-PRTM,3420,2,Intro to Tourism,0.91,0.07,0.02,0.0,0.0,0.0,0.0,0.0,maloud shakona,PRTM-3420,2016
-PRTM,3440,1,Tourism Markets,0.68,0.15,0.1,0.05,0.03,0.0,0.0,0.0,sheila backman,PRTM-3440,2016
-PRTM,3440,2,Tourism Markets,0.86,0.07,0.02,0.02,0.0,0.0,0.0,0.02,sheila backman,PRTM-3440,2016
-PRTM,3450,1,Tourism Management,0.52,0.24,0.19,0.0,0.05,0.0,0.0,0.0,garrett stone,PRTM-3450,2016
-PRTM,3450,2,Tourism Management,0.52,0.23,0.19,0.03,0.03,0.0,0.0,0.0,lauren duffy,PRTM-3450,2016
-PRTM,3460,1,Heritage Tourism,0.25,0.44,0.19,0.1,0.02,0.0,0.0,0.0,gregory phi ramshaw,PRTM-3460,2016
-PRTM,3530,1,Foundations of Camp Counseling,0.74,0.11,0.16,0.0,0.0,0.0,0.0,0.0,gwynn powell,PRTM-3530,2016
-PRTM,3900,4,Independent Study in PRTM,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3900,2016
-PRTM,3910,1,Social Media in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james war sanderson,PRTM-3910,2016
-PRTM,3910,2,Intro to GIS for PRTM,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0,david lawrenc white,PRTM-3910,2016
-PRTM,4210,1,Rec Fin Resc Mgt,0.2,0.3,0.28,0.15,0.03,0.0,0.0,0.05,lawrence allen,PRTM-4210,2016
-PRTM,4260,1,Trends & Issues in Rec Therapy,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-4260,2016
-PRTM,4300,1,World Geog Parks,0.27,0.27,0.27,0.09,0.03,0.0,0.0,0.06,robert baxte powell,PRTM-4300,2016
-PRTM,4450,1,Conventions,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,jeffery martin,PRTM-4450,2016
-PRTM,4460,2,Community Tourism,0.46,0.27,0.04,0.0,0.04,0.0,0.0,0.19,herbert chancellor,PRTM-4460,2016
-PRTM,4510,1,Seminar in CRSCM,0.74,0.03,0.13,0.06,0.03,0.0,0.0,0.0,harrison pinckney,PRTM-4510,2016
-PRTM,4540,1,Trends in Sport Mgt,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,brandon harris,PRTM-4540,2016
-PRTM,4550,1,Adv Program Planning,0.64,0.18,0.14,0.05,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-4550,2016
-PRTM,4980,10,Creative Inquiry in PRTM IV,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,PRTM-4980,2016
-PRTM,8030,1,Sem Rec & Park Admin,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,teresa walto tucker,PRTM-8030,2016
-PRTM,8080,1,Behavioral Aspects,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-8080,2016
-PRTM,8110,1,Research Methods,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,PRTM-8110,2016
-PRTM,8110,2,Research Methods,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,lincoln larson,PRTM-8110,2016
-PRTM,8210,1,Alt Funding for PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-8210,2016
-PRTM,8250,1,Populations in PRTM,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,PRTM-8250,2016
-PSYC,2010,1,Intro to Psychology,0.34,0.35,0.22,0.03,0.01,0.0,0.0,0.04,mary taylor,PSYC-2010,2016
-PSYC,2010,2,Intro to Psychology,0.31,0.35,0.15,0.11,0.05,0.0,0.0,0.02,jo anne jorgensen,PSYC-2010,2016
-PSYC,2010,3,Intro to Psychology,0.39,0.28,0.2,0.06,0.07,0.0,0.0,0.0,mary taylor,PSYC-2010,2016
-PSYC,2010,4,Intro to Psychology,0.56,0.27,0.08,0.03,0.03,0.0,0.0,0.02,chong hyon pak,PSYC-2010,2016
-PSYC,2010,5,Intro to Psychology,0.23,0.31,0.23,0.06,0.09,0.0,0.0,0.08,edwin brainerd,PSYC-2010,2016
-PSYC,2010,6,Intro to Psychology (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,PSYC-2010,2016
-PSYC,2020,1,Intro Psychology Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jamie fynes,PSYC-2020,2016
-PSYC,2020,4,Intro Psychology Lab,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,natalee kri baldwin,PSYC-2020,2016
-PSYC,2020,5,Intro Psychology Lab,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,PSYC-2020,2016
-PSYC,2020,6,Intro Psychology Lab,0.85,0.08,0.04,0.0,0.04,0.0,0.0,0.0,madison eliza sauls,PSYC-2020,2016
-PSYC,3060,1,Human Sexual Beh,0.53,0.22,0.15,0.05,0.03,0.0,0.0,0.01,bruce michael king,PSYC-3060,2016
-PSYC,3090,100,Intro Exp Psych,0.33,0.21,0.21,0.12,0.08,0.0,0.0,0.04,richard tyrrell,PSYC-3090,2016
-PSYC,3090,200,Intro Exp Psych,0.83,0.07,0.03,0.03,0.0,0.0,0.0,0.03,alice miche brawley,PSYC-3090,2016
-PSYC,3090,300,Intro Exp Psych,0.46,0.36,0.04,0.07,0.0,0.0,0.0,0.07,drew michael morris,PSYC-3090,2016
-PSYC,3100,100,Advanced Experimental Psych,0.33,0.52,0.05,0.0,0.0,0.0,0.0,0.1,jennifer bai bisson,PSYC-3100,2016
-PSYC,3100,200,Advanced Experimental Psych,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,robert campbell,PSYC-3100,2016
-PSYC,3100,300,Advanced Experimental Psych,0.45,0.3,0.1,0.0,0.05,0.0,0.0,0.1,thomas britt,PSYC-3100,2016
-PSYC,3100,400,Advanced Experimental Psych,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2016
-PSYC,3100,500,Advanced Experimental Psych,0.37,0.37,0.26,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2016
-PSYC,3100,600,Advanced Experimental Psych,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2016
-PSYC,3240,1,Physiological Psych,0.27,0.23,0.21,0.09,0.07,0.0,0.0,0.13,june pilcher,PSYC-3240,2016
-PSYC,3240,2,Physiological Psych,0.47,0.29,0.11,0.05,0.09,0.0,0.0,0.0,claudio cantalupo,PSYC-3240,2016
-PSYC,3330,1,Cognitive Psych,0.32,0.21,0.32,0.15,0.0,0.0,0.0,0.0,thomas alley,PSYC-3330,2016
-PSYC,3340,2,Cognitive Psych Lab,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,leo gugerty,PSYC-3340,2016
-PSYC,3340,3,Cognitive Psych Lab,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,laura whitlock,PSYC-3340,2016
-PSYC,3400,1,Lifespan Developmental Psych,0.29,0.54,0.13,0.01,0.01,0.0,0.0,0.01,jennifer bai bisson,PSYC-3400,2016
-PSYC,3400,2,Lifespan Developmental Psych,0.47,0.36,0.13,0.01,0.01,0.0,0.0,0.01,jennifer bai bisson,PSYC-3400,2016
-PSYC,3520,1,Social Psychology,0.43,0.35,0.16,0.04,0.01,0.0,0.0,0.0,eric mckibben,PSYC-3520,2016
-PSYC,3520,2,Social Psychology,0.5,0.3,0.11,0.07,0.0,0.0,0.0,0.01,eric mckibben,PSYC-3520,2016
-PSYC,3520,3,Social Psychology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-3520,2016
-PSYC,3640,1,Industrial Psych,0.43,0.4,0.13,0.03,0.0,0.0,0.0,0.01,eric mckibben,PSYC-3640,2016
-PSYC,3640,2,Industrial Psych,0.47,0.4,0.08,0.01,0.01,0.0,0.0,0.01,eric mckibben,PSYC-3640,2016
-PSYC,3680,1,Organizational Psych,0.34,0.37,0.19,0.06,0.04,0.0,0.0,0.0,kristen su jennings,PSYC-3680,2016
-PSYC,3830,1,Abnormal Psychology,0.54,0.31,0.11,0.03,0.0,0.0,0.0,0.01,jo anne jorgensen,PSYC-3830,2016
-PSYC,3830,2,Abnormal Psychology,0.45,0.25,0.2,0.04,0.01,0.0,0.0,0.04,jo anne jorgensen,PSYC-3830,2016
-PSYC,3830,3,Abnormal Psychology,0.18,0.38,0.26,0.0,0.09,0.0,0.0,0.09,pamela alley,PSYC-3830,2016
-PSYC,3830,4,Abnormal Psychology,0.25,0.36,0.22,0.06,0.08,0.0,0.0,0.03,pamela alley,PSYC-3830,2016
-PSYC,4080,1,Women and Psychology,0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-4080,2016
-PSYC,4150,1,Systems and Theories,0.39,0.43,0.13,0.0,0.0,0.0,0.0,0.04,brian day,PSYC-4150,2016
-PSYC,4150,2,Systems and Theories,0.25,0.32,0.18,0.07,0.11,0.0,0.0,0.07,edwin brainerd,PSYC-4150,2016
-PSYC,4150,3,Systems and Theories,0.33,0.3,0.11,0.07,0.07,0.0,0.0,0.11,edwin brainerd,PSYC-4150,2016
-PSYC,4220,1,Perception,0.1,0.38,0.34,0.1,0.03,0.0,0.0,0.03,christopher pagano,PSYC-4220,2016
-PSYC,4220,2,Perception,0.32,0.16,0.36,0.16,0.0,0.0,0.0,0.0,claudio cantalupo,PSYC-4220,2016
-PSYC,4220,3,Perception,0.16,0.6,0.04,0.16,0.04,0.0,0.0,0.0,claudio cantalupo,PSYC-4220,2016
-PSYC,4350,1,Human Factors,0.64,0.2,0.08,0.08,0.0,0.0,0.0,0.0,laura whitlock,PSYC-4350,2016
-PSYC,4710,1,Psych of Testing,0.35,0.5,0.04,0.04,0.04,0.0,0.0,0.04,robert ray sinclair,PSYC-4710,2016
-PSYC,4800,1,Health Psychology,0.48,0.44,0.08,0.0,0.0,0.0,0.0,0.0,june pilcher,PSYC-4800,2016
-PSYC,4820,1,Positive Psychology,0.46,0.29,0.07,0.07,0.04,0.04,0.0,0.04,cynthia pury,PSYC-4820,2016
-PSYC,4880,1,Psychotherapy,0.55,0.18,0.05,0.09,0.05,0.05,0.0,0.05,lucinda sorci quick,PSYC-4880,2016
-PSYC,4890,1,Teamwork,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,marissa leig porter,PSYC-4890,2016
-PSYC,4890,3,Food & Eating,0.46,0.33,0.13,0.04,0.04,0.0,0.0,0.0,thomas alley,PSYC-4890,2016
-PSYC,4920,3,Senior Laboratory,0.88,0.04,0.0,0.08,0.0,0.0,0.0,0.0,stephen robertson,PSYC-4920,2016
-PSYC,4920,4,Senior Laboratory,0.83,0.0,0.04,0.0,0.08,0.0,0.0,0.04,stephen robertson,PSYC-4920,2016
-PSYC,4920,5,Senior Laboratory,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,leah hartman,PSYC-4920,2016
-PSYC,4930,100,Pract Clinical Psych,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,heidi marie zinzow,PSYC-4930,2016
-PSYC,8110,1,Research Design II,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,patrick rosopa,PSYC-8110,2016
-PSYC,8130,1,Research Design III,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,PSYC-8130,2016
-PSYC,8140,1,Quantitative Lab,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,PSYC-8140,2016
-PSYC,8330,1,Adv Cog Psych,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,leo gugerty,PSYC-8330,2016
-PSYC,8370,1,Ergonomics Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,PSYC-8370,2016
-PSYC,8610,1,Personnel Psych,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,fred switzer,PSYC-8610,2016
-RCID,8030,1,Emp Res Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,RCID-8030,2016
-RED,8010,1,Market Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,RED-8010,2016
-RED,8040,1,Resid Practicum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,RED-8040,2016
-RED,8050,1,Commercial Practicum,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8050,2016
-RED,8120,1,Real Estate Technology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8120,2016
-REL,1010,1,Intro to Religion,0.09,0.25,0.41,0.09,0.13,0.0,0.0,0.03,peter cohen,REL-1010,2016
-REL,1010,2,Intro to Religion,0.12,0.33,0.33,0.12,0.03,0.0,0.0,0.06,peter cohen,REL-1010,2016
-REL,1010,3,Intro to Religion,0.03,0.52,0.24,0.09,0.12,0.0,0.0,0.0,peter cohen,REL-1010,2016
-REL,1020,1,World Religions,0.68,0.22,0.11,0.0,0.0,0.0,0.0,0.0,robert stephens,REL-1020,2016
-REL,1020,2,World Religions,0.5,0.38,0.09,0.03,0.0,0.0,0.0,0.0,robert stephens,REL-1020,2016
-REL,1020,4,World Religions,0.47,0.41,0.06,0.06,0.0,0.0,0.0,0.0,robert stephens,REL-1020,2016
-REL,3010,1,Old Testament,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3010,2016
-REL,3030,1,The Quran,0.35,0.39,0.13,0.03,0.06,0.0,0.0,0.03,mashal saif,REL-3030,2016
-REL,3050,1,Constructing Scripture,0.38,0.38,0.07,0.0,0.03,0.07,0.0,0.07,benjamin white,REL-3050,2016
-REL,3090,1,Religion of the American South,0.24,0.43,0.19,0.0,0.1,0.0,0.0,0.05,elizabeth jemison,REL-3090,2016
-REL,3100,1,History of Religion in the US,0.47,0.35,0.06,0.0,0.0,0.0,0.0,0.12,elizabeth jemison,REL-3100,2016
-REL,3120,1,Hinduism,0.7,0.1,0.0,0.03,0.03,0.0,0.0,0.13,robert stephens,REL-3120,2016
-REL,3140,1,Buddhism in China,0.35,0.29,0.18,0.0,0.18,0.0,0.0,0.0,yanming an,REL-3140,2016
-REL,3730,2,Age of Protestant Reformation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,thomas kuehn,REL-3730,2016
-RS,3010,1,Rural Sociology,0.49,0.24,0.12,0.06,0.0,0.0,0.0,0.08,kenneth robinson,RS-3010,2016
-SOC,2010,1,Intro to Sociology (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,rachael chatterson,SOC-2010,2016
-SOC,2010,2,Introduction to Sociology,0.48,0.3,0.09,0.09,0.02,0.0,0.0,0.02,rachael chatterson,SOC-2010,2016
-SOC,2010,3,Introduction to Sociology,0.32,0.43,0.18,0.04,0.01,0.0,0.0,0.01,rachael chatterson,SOC-2010,2016
-SOC,2010,4,Introduction to Sociology,0.63,0.23,0.1,0.0,0.02,0.0,0.0,0.02,shannon mcdonough,SOC-2010,2016
-SOC,2010,5,Introduction to Sociology,0.67,0.23,0.08,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2016
-SOC,2010,6,Introduction to Sociology,0.66,0.23,0.05,0.04,0.0,0.0,0.0,0.03,shannon mcdonough,SOC-2010,2016
-SOC,2010,7,Introduction to Sociology,0.28,0.4,0.21,0.02,0.02,0.0,0.0,0.06,mary louise barr,SOC-2010,2016
-SOC,2010,8,Introduction to Sociology,0.43,0.43,0.09,0.0,0.02,0.0,0.0,0.04,mary louise barr,SOC-2010,2016
-SOC,2010,9,Introduction to Sociology,0.44,0.38,0.11,0.0,0.02,0.0,0.0,0.04,mary louise barr,SOC-2010,2016
-SOC,2010,10,Introduction to Sociology,0.45,0.36,0.09,0.04,0.06,0.0,0.0,0.0,mary louise barr,SOC-2010,2016
-SOC,2010,11,Introduction to Sociology,0.61,0.24,0.08,0.04,0.0,0.0,0.0,0.02,jennifer le holland,SOC-2010,2016
-SOC,2010,12,Introduction to Sociology,0.39,0.43,0.15,0.02,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2016
-SOC,2050,1,Sociology Lab,0.56,0.14,0.05,0.07,0.16,0.0,0.0,0.02,brenda vander mey,SOC-2050,2016
-SOC,3020,1,Research Methods I,0.19,0.32,0.38,0.11,0.0,0.0,0.0,0.0,andrew whitehead,SOC-3020,2016
-SOC,3040,1,Social Research Methods II,0.37,0.26,0.26,0.05,0.05,0.0,0.0,0.0,ye luo,SOC-3040,2016
-SOC,3110,1,The Family,0.33,0.29,0.25,0.06,0.02,0.0,0.0,0.04,traci ann hefner,SOC-3110,2016
-SOC,3800,1,Intro Social Service,0.57,0.34,0.06,0.02,0.0,0.0,0.0,0.0,jennifer le holland,SOC-3800,2016
-SOC,3880,1,Criminal Justice,0.19,0.25,0.27,0.21,0.06,0.0,0.0,0.02,margaret tina britz,SOC-3880,2016
-SOC,3890,1,Criminology,0.41,0.26,0.13,0.09,0.0,0.0,0.0,0.11,william white,SOC-3890,2016
-SOC,3910,1,Soc of Deviance,0.39,0.24,0.2,0.05,0.05,0.0,0.0,0.07,william white,SOC-3910,2016
-SOC,3920,1,Juvenile Delinquency,0.28,0.37,0.28,0.0,0.05,0.0,0.0,0.02,william white,SOC-3920,2016
-SOC,3970,1,Substance Abuse,0.56,0.27,0.08,0.02,0.04,0.0,0.0,0.02,shannon mcdonough,SOC-3970,2016
-SOC,4040,1,Soc Theory,0.47,0.22,0.2,0.09,0.0,0.0,0.0,0.02,william wentworth,SOC-4040,2016
-SOC,4320,1,Soc of Religion,0.33,0.33,0.2,0.1,0.03,0.0,0.0,0.0,andrew whitehead,SOC-4320,2016
-SOC,4330,1,Global Social Change,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,william haller,SOC-4330,2016
-SOC,4590,1,The Community,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,SOC-4590,2016
-SOC,4600,1,Race & Ethnicity,0.35,0.46,0.15,0.04,0.0,0.0,0.0,0.0,brenda vander mey,SOC-4600,2016
-SOC,4610,1,Sex & Gender,0.24,0.29,0.29,0.05,0.05,0.0,0.0,0.08,rachael chatterson,SOC-4610,2016
-SOC,4840,1,Child Abuse,0.6,0.19,0.17,0.04,0.0,0.0,0.0,0.0,douglas sturkie,SOC-4840,2016
-SOC,4860,4,Creative Inquiry: Sociology,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,margaret tina britz,SOC-4860,2016
-SOC,4860,5,Creative Inquiry in Sociology,0.65,0.12,0.06,0.0,0.18,0.0,0.0,0.0,margaret tina britz,SOC-4860,2016
-SOC,4930,1,Soc of Corrections,0.5,0.29,0.14,0.0,0.07,0.0,0.0,0.0,william white,SOC-4930,2016
-SOC,4940,1,Organized Crimes,0.27,0.17,0.43,0.07,0.0,0.0,0.0,0.07,margaret tina britz,SOC-4940,2016
-SOC,4950,1,Field Experience,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-4950,2016
-SOC,4970,1,Senior Lab,0.45,0.27,0.09,0.09,0.09,0.0,0.0,0.0,brenda vander mey,SOC-4970,2016
-SOC,4970,2,Senior Lab,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,brenda vander mey,SOC-4970,2016
-SOC,4990,1,Sel Top Seminar in Contemp Soc,0.57,0.29,0.07,0.07,0.0,0.0,0.0,0.0,david williams,SOC-4990,2016
-SPAN,1010,1,Elementary Spanish,0.39,0.28,0.28,0.0,0.0,0.0,0.0,0.06,scott harris,SPAN-1010,2016
-SPAN,1010,2,Elementary Spanish,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2016
-SPAN,1020,1,Elementary Spanish,0.35,0.12,0.24,0.18,0.0,0.0,0.0,0.12,roger simpson,SPAN-1020,2016
-SPAN,1020,2,Elementary Spanish,0.42,0.26,0.11,0.11,0.0,0.0,0.0,0.11,roger simpson,SPAN-1020,2016
-SPAN,1020,3,Elementary Spanish,0.32,0.37,0.21,0.0,0.05,0.0,0.0,0.05,roger simpson,SPAN-1020,2016
-SPAN,1020,4,Elementary Spanish,0.5,0.28,0.11,0.0,0.06,0.0,0.0,0.06,roger simpson,SPAN-1020,2016
-SPAN,1020,5,Elementary Spanish,0.35,0.29,0.12,0.06,0.12,0.0,0.0,0.06,roger simpson,SPAN-1020,2016
-SPAN,1020,6,Elementary Spanish,0.25,0.25,0.13,0.19,0.13,0.0,0.0,0.06,cathy robison,SPAN-1020,2016
-SPAN,1020,7,Elementary Spanish,0.32,0.21,0.26,0.0,0.11,0.0,0.0,0.11,cathy robison,SPAN-1020,2016
-SPAN,1020,8,Elementary Spanish,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,ana paula  miller,SPAN-1020,2016
-SPAN,1020,9,Elementary Spanish,0.39,0.33,0.06,0.06,0.11,0.0,0.0,0.06,ana paula  miller,SPAN-1020,2016
-SPAN,1020,10,Elementary Spanish,0.42,0.17,0.33,0.0,0.0,0.0,0.0,0.08,debra oa williamson,SPAN-1020,2016
-SPAN,1020,11,Elementary Spanish,0.26,0.26,0.21,0.16,0.0,0.0,0.0,0.11,debra oa williamson,SPAN-1020,2016
-SPAN,2010,1,Intermediate Spanish,0.44,0.28,0.17,0.11,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2016
-SPAN,2010,2,Intermediate Spanish,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,cathy robison,SPAN-2010,2016
-SPAN,2010,3,Intermediate Spanish,0.47,0.16,0.26,0.05,0.05,0.0,0.0,0.0,allison ann hinds,SPAN-2010,2016
-SPAN,2010,4,Intermediate Spanish,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,allison ann hinds,SPAN-2010,2016
-SPAN,2010,5,Intermediate Spanish,0.33,0.53,0.07,0.07,0.0,0.0,0.0,0.0,allison ann hinds,SPAN-2010,2016
-SPAN,2010,6,Intermediate Spanish,0.29,0.29,0.19,0.1,0.1,0.0,0.0,0.05,ricardo tremolada,SPAN-2010,2016
-SPAN,2010,7,Intermediate Spanish,0.65,0.15,0.05,0.0,0.0,0.0,0.0,0.15,ricardo tremolada,SPAN-2010,2016
-SPAN,2010,8,Intermediate Spanish,0.69,0.13,0.13,0.06,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2010,2016
-SPAN,2010,9,Intermediate Spanish,0.64,0.09,0.09,0.0,0.0,0.0,0.0,0.18,ze cruz valderramos,SPAN-2010,2016
-SPAN,2010,10,Intermediate Spanish,0.47,0.26,0.11,0.0,0.0,0.0,0.0,0.16,ricardo tremolada,SPAN-2010,2016
-SPAN,2010,11,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-2010,2016
-SPAN,2010,12,Intermediate Spanish,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,debra oa williamson,SPAN-2010,2016
-SPAN,2010,13,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2010,2016
-SPAN,2010,14,Intermediate Spanish,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2010,2016
-SPAN,2010,15,Intermediate Spanish,0.19,0.63,0.13,0.0,0.0,0.0,0.0,0.06,debra oa williamson,SPAN-2010,2016
-SPAN,2020,1,Intermediate Spanish,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,melva margu persico,SPAN-2020,2016
-SPAN,2020,2,Intermediate Spanish,0.18,0.47,0.18,0.06,0.06,0.0,0.0,0.06,melva margu persico,SPAN-2020,2016
-SPAN,2020,3,Intermediate Spanish,0.5,0.25,0.1,0.1,0.0,0.0,0.0,0.05,juana martin-armas,SPAN-2020,2016
-SPAN,2020,4,Intermediate Spanish,0.5,0.22,0.17,0.06,0.06,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2016
-SPAN,2020,5,Intermediate Spanish,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2016
-SPAN,2020,6,Intermediate Spanish,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2016
-SPAN,2020,7,Intermediate Spanish,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2016
-SPAN,2020,8,Intermediate Spanish,0.22,0.39,0.28,0.06,0.0,0.0,0.0,0.06,heidi montes,SPAN-2020,2016
-SPAN,2020,9,Intermediate Spanish,0.41,0.35,0.06,0.12,0.0,0.0,0.0,0.06,heidi montes,SPAN-2020,2016
-SPAN,2020,10,Intermediate Spanish,0.5,0.22,0.22,0.06,0.0,0.0,0.0,0.0,heidi montes,SPAN-2020,2016
-SPAN,2020,11,Intermediate Spanish,0.45,0.3,0.2,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2016
-SPAN,2020,12,Intermediate Spanish,0.18,0.5,0.32,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,SPAN-2020,2016
-SPAN,2020,13,Intermediate Spanish,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2016
-SPAN,2020,14,Intermediate Spanish,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2016
-SPAN,2020,19,Intermediate Spanish,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,SPAN-2020,2016
-SPAN,3020,1,Int Spn Gram & Comp,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,george palacios,SPAN-3020,2016
-SPAN,3020,2,Int Spn Gram & Comp,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,SPAN-3020,2016
-SPAN,3020,3,Int Spn Gram & Comp,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,SPAN-3020,2016
-SPAN,3040,1,Intro Hisp Lit Forms,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,SPAN-3040,2016
-SPAN,3050,1,Int Con Comp Span I,0.31,0.44,0.13,0.06,0.0,0.0,0.0,0.06,raquel anido,SPAN-3050,2016
-SPAN,3050,2,Int Con Comp Span I,0.22,0.61,0.06,0.0,0.0,0.0,0.0,0.11,raquel anido,SPAN-3050,2016
-SPAN,3050,3,Int Con Comp Span I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,SPAN-3050,2016
-SPAN,3060,1,Span Comp for Bus,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-3060,2016
-SPAN,3070,1,Hispanic World: Sp,0.29,0.18,0.06,0.06,0.06,0.0,0.0,0.35,juana martin-armas,SPAN-3070,2016
-SPAN,3080,1,Hispanic World: La,0.63,0.13,0.13,0.0,0.06,0.0,0.0,0.06,tiffany dawn miller,SPAN-3080,2016
-SPAN,3080,2,Hispanic World: La,0.63,0.19,0.13,0.06,0.0,0.0,0.0,0.0,tiffany dawn miller,SPAN-3080,2016
-SPAN,3130,1,Span Lit Survey I,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,juana martin-armas,SPAN-3130,2016
-SPAN,3140,1,Hispanic Linguistics,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,daniel smith,SPAN-3140,2016
-SPAN,3160,1,Span for Intl Trade,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,maureen zamora,SPAN-3160,2016
-SPAN,4050,1,Int Trade Film & Lit,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-4050,2016
-SPAN,4060,2,Narrative Fiction,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,SPAN-4060,2016
-SPAN,4070,1,Hispanic Film,0.42,0.11,0.11,0.16,0.0,0.0,0.0,0.21,raquel anido,SPAN-4070,2016
-SPAN,4150,1,Span for Health Prof,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-4150,2016
-SPAN,4150,35,Span for Health Prof,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-4150,2016
-SPAN,4170,1,Prof Communication,0.62,0.15,0.23,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-4170,2016
-SPAN,4180,1,Tech Span Health Man,0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,ricardo tremolada,SPAN-4180,2016
-SPAN,4350,35,Contemp Hisp Cult,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-4350,2016
-STAT,2220,1,Statistics in Everyday Life,0.35,0.39,0.13,0.06,0.04,0.0,0.0,0.04,ros martinez-dawson,STAT-2220,2016
-STAT,2220,2,Statistics in Everyday Life,0.43,0.31,0.09,0.09,0.02,0.0,0.0,0.06,ros martinez-dawson,STAT-2220,2016
-STAT,2220,3,Statistics in Everyday Life,0.57,0.33,0.07,0.0,0.02,0.0,0.0,0.0,gary fellers,STAT-2220,2016
-STAT,2220,4,Statistics in Everyday Life,0.7,0.2,0.06,0.0,0.02,0.0,0.0,0.02,gary fellers,STAT-2220,2016
-STAT,2220,5,Statistics in Everyday Life,0.61,0.24,0.09,0.02,0.02,0.0,0.0,0.02,gary fellers,STAT-2220,2016
-STAT,2220,6,Statistics in Everyday Life,0.54,0.37,0.07,0.0,0.0,0.0,0.0,0.02,gary fellers,STAT-2220,2016
-STAT,2300,1,Statistical Methods I,0.46,0.26,0.15,0.03,0.1,0.0,0.0,0.0,christy jenki brown,STAT-2300,2016
-STAT,2300,2,Statistical Methods I,0.37,0.27,0.19,0.08,0.08,0.0,0.0,0.03,christy jenki brown,STAT-2300,2016
-STAT,2300,3,Statistical Methods I,0.43,0.28,0.16,0.08,0.05,0.0,0.0,0.01,christy jenki brown,STAT-2300,2016
-STAT,2300,4,Statistical Methods I,0.37,0.35,0.1,0.1,0.04,0.0,0.0,0.04,benjamin sharp,STAT-2300,2016
-STAT,2300,5,Statistical Methods I,0.28,0.35,0.16,0.11,0.08,0.0,0.0,0.03,brook thaye russell,STAT-2300,2016
-STAT,2300,6,Statistical Methods I,0.3,0.41,0.19,0.03,0.08,0.0,0.0,0.0, erwin walker,STAT-2300,2016
-STAT,2300,7,Statistical Methods I,0.13,0.38,0.25,0.14,0.06,0.0,0.0,0.05, erwin walker,STAT-2300,2016
-STAT,2300,8,Statistical Methods I,0.2,0.36,0.21,0.11,0.12,0.0,0.0,0.0, erwin walker,STAT-2300,2016
-STAT,3090,1,Introductory Business Stats,0.02,0.29,0.32,0.17,0.1,0.0,0.0,0.1,elaine ma sotherden,STAT-3090,2016
-STAT,3090,2,Introductory Business Stats,0.18,0.29,0.16,0.16,0.11,0.0,0.0,0.11,james espey,STAT-3090,2016
-STAT,3090,3,Introductory Business Stats,0.24,0.26,0.12,0.06,0.15,0.0,0.0,0.18,paul james cubre,STAT-3090,2016
-STAT,3090,4,Introductory Business Stats,0.1,0.32,0.37,0.1,0.07,0.0,0.0,0.05,james espey,STAT-3090,2016
-STAT,3090,5,Introductory Business Stats,0.14,0.33,0.26,0.0,0.21,0.0,0.0,0.05,paul james cubre,STAT-3090,2016
-STAT,3090,6,Introductory Business Stats,0.26,0.29,0.23,0.11,0.06,0.0,0.0,0.06,audrey nico devries,STAT-3090,2016
-STAT,3090,7,Introductory Business Stats,0.13,0.18,0.23,0.13,0.2,0.0,0.0,0.15,drew jared lipman,STAT-3090,2016
-STAT,3090,8,Introductory Business Stats,0.15,0.51,0.15,0.02,0.12,0.0,0.0,0.05,margaret mar wiecek,STAT-3090,2016
-STAT,3090,9,Introductory Business Stats,0.27,0.41,0.22,0.02,0.07,0.0,0.0,0.0,james espey,STAT-3090,2016
-STAT,3090,10,Introductory Business Stats,0.2,0.37,0.2,0.07,0.1,0.0,0.0,0.07,james espey,STAT-3090,2016
-STAT,3090,11,Introductory Business Stats,0.2,0.23,0.33,0.08,0.15,0.0,0.0,0.03,elaine ma sotherden,STAT-3090,2016
-STAT,3090,12,Introductory Business Stats,0.08,0.38,0.18,0.13,0.2,0.0,0.0,0.05,christopher wilson,STAT-3090,2016
-STAT,3090,13,Introductory Business Stats,0.17,0.29,0.17,0.15,0.12,0.0,0.0,0.1,audrey nico devries,STAT-3090,2016
-STAT,3300,1,Statistical Methods II,0.31,0.42,0.08,0.04,0.08,0.0,0.0,0.08,ros martinez-dawson,STAT-3300,2016
-STAT,4020,1,Intro to Statistical Computing,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-4020,2016
-STAT,4110,1,Stat Mthds for Process Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,STAT-4110,2016
-STAT,4110,2,Stat Mthds for Process Control,0.24,0.52,0.03,0.03,0.06,0.0,0.0,0.12,james rieck,STAT-4110,2016
-STAT,8010,1,Statistical Methods I,0.68,0.19,0.13,0.0,0.0,0.0,0.0,0.0,james rieck,STAT-8010,2016
-STAT,8010,2,Statistical Methods I,0.48,0.39,0.03,0.0,0.0,0.0,0.0,0.09,patrick gerard,STAT-8010,2016
-STAT,8010,3,Statistical Methods I,0.57,0.25,0.04,0.0,0.0,0.0,0.0,0.14,jun luo,STAT-8010,2016
-STAT,8040,1,Sampling,0.35,0.41,0.0,0.0,0.0,0.0,0.0,0.24,patrick gerard,STAT-8040,2016
-STAT,8050,1,Design & Anlys of Experiments,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-8050,2016
-STAT,8420,230,Intro to Statistical Methods,0.22,0.5,0.11,0.0,0.06,0.0,0.0,0.11,julia lynn sharp,STAT-8420,2016
-STS,1010,1,Survey of S T S,0.44,0.41,0.09,0.0,0.0,0.0,0.0,0.06,allison ann hinds,STS-1010,2016
-STS,1010,2,Survey of S T S,0.29,0.49,0.09,0.0,0.06,0.0,0.0,0.09,scott brame,STS-1010,2016
-STS,1010,3,Survey of S T S,0.44,0.28,0.19,0.03,0.03,0.0,0.0,0.03,elizabeth stansell,STS-1010,2016
-STS,1010,4,Survey of S T S,0.59,0.34,0.03,0.03,0.0,0.0,0.0,0.0,sarah mae cooper,STS-1010,2016
-STS,1010,5,Survey of S T S,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,philip randall,STS-1010,2016
-STS,1010,6,Survey of S T S,0.74,0.11,0.11,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,STS-1010,2016
-STS,1010,7,Survey of S T S,0.27,0.46,0.11,0.05,0.03,0.0,0.0,0.08,megan no macalystre,STS-1010,2016
-STS,1010,8,Survey of S T S,0.23,0.4,0.1,0.1,0.03,0.0,0.0,0.13,david charles foltz,STS-1010,2016
-THEA,2100,1,Theatre Appreciation,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,richard st. peter,THEA-2100,2016
-THEA,2100,2,Theatre Appreciation,0.87,0.0,0.07,0.0,0.03,0.0,0.0,0.03,kerrie kath seymour,THEA-2100,2016
-THEA,2100,3,Theatre Appreciation,0.76,0.14,0.03,0.03,0.03,0.0,0.0,0.0,kendra lyne johnson,THEA-2100,2016
-THEA,2100,4,Theatre Appreciation,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-2100,2016
-THEA,2100,5,Theatre Appreciation,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,THEA-2100,2016
-THEA,2100,6,Theatre Appreciation,0.63,0.34,0.0,0.0,0.0,0.0,0.0,0.03,jason adkins,THEA-2100,2016
-THEA,2670,1,Stage Makeup,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,shannon ther robert,THEA-2670,2016
-THEA,2790,1,Theatre Practicum,0.79,0.0,0.0,0.0,0.14,0.0,0.0,0.07,matthew leckenbusch,THEA-2790,2016
-THEA,3160,1,Theatre History II,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,richard st. peter,THEA-3160,2016
-THEA,3180,1,Afri-Amer Thea II,0.61,0.23,0.13,0.0,0.03,0.0,0.0,0.0,kendra lyne johnson,THEA-3180,2016
-THEA,4790,1,Acting II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,THEA-4790,2016
-THEA,6870,1,Stage Lighting I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,THEA-6870,2016
-WFB,3010,1,Wildlife Biology Lab,0.46,0.23,0.31,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2016
-WFB,3010,2,Wildlife Biology Lab,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,WFB-3010,2016
-WFB,3130,1,Conservation Biology,0.26,0.38,0.29,0.07,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3130,2016
-WFB,3130,2,Conservation Biology,0.32,0.3,0.26,0.06,0.04,0.0,0.0,0.02,shari lyn rodriguez,WFB-3130,2016
-WFB,3500,1,Princ Fish & Wildlife Biology,0.3,0.43,0.17,0.04,0.04,0.0,0.0,0.04,james davis,WFB-3500,2016
-WFB,3500,2,Princ Fish & Wildlife Biology,0.21,0.41,0.26,0.06,0.03,0.0,0.0,0.03,james davis,WFB-3500,2016
-WFB,4160,1,Fishery Biology,0.21,0.47,0.23,0.04,0.0,0.0,0.0,0.04,yoichiro kanno,WFB-4160,2016
-WFB,4300,1,Wildlife Conservation Policy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,joseph lanham,WFB-4300,2016
-WFB,4620,1,Wetland Wildlife Biology,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,russell barrett,WFB-4620,2016
-WFB,4930,2,Quantitative Ecology,0.37,0.37,0.16,0.02,0.02,0.0,0.0,0.06,david sco jachowski,WFB-4930,2016
-WS,1030,1,Women in Global Perspective,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,WS-1030,2016
-WS,1030,2,Women in Global Perspective,0.61,0.19,0.08,0.0,0.06,0.0,0.0,0.06,saadiqa kumanyika,WS-1030,2016
-WS,3010,1,Intro Women's Studies,0.56,0.31,0.08,0.0,0.06,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2016
-WS,3010,2,Intro Women's Studies,0.41,0.5,0.06,0.0,0.0,0.0,0.0,0.03,elizabeth ros adams,WS-3010,2016
-YDP,3100,400,Youth Developmt and the Family,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,william quinn,YDP-3100,2016
-YDP,3300,1,Designing Effective Youth Prog,0.7,0.17,0.04,0.0,0.09,0.0,0.0,0.0,kellye rembert,YDP-3300,2016
-YDP,3350,1,Youth Activity Leadership,0.57,0.17,0.04,0.09,0.13,0.0,0.0,0.0,ryan joseph gagnon,YDP-3350,2016
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1020,1,Survey of Art & Arch Hist II,0.91,0.07,0.01,0.0,0.0,0.0,0.0,0.01,andrea feeser,
+AAH,2060,1,Art History and Theory II,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,andrea feeser,
+AAH,6320,1,Twentieth Century Art II,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,beth ann lauritis,
+ACCT,2010,1,Financial Accounting Concepts,0.19,0.3,0.32,0.06,0.09,0.0,0.0,0.04,lydia lan schleifer,
+ACCT,2010,2,Financial Accounting Concepts,0.35,0.39,0.14,0.03,0.08,0.0,0.0,0.01,holly rhiannio hawk,
+ACCT,2010,3,Financial Accounting Concepts,0.19,0.24,0.21,0.14,0.1,0.0,0.0,0.12,philip maiberger,
+ACCT,2010,4,Financial Accounting Concepts,0.25,0.24,0.28,0.08,0.06,0.0,0.0,0.08,holly rhiannio hawk,
+ACCT,2010,5,Financial Accounting Concepts,0.3,0.3,0.25,0.05,0.05,0.0,0.0,0.05,lydia lan schleifer,
+ACCT,2010,6,Financial Accounting Concepts,0.26,0.26,0.24,0.05,0.07,0.0,0.0,0.12,lydia lan schleifer,
+ACCT,2010,7,Financial Accounting Concepts,0.11,0.25,0.25,0.07,0.21,0.0,0.0,0.12,tonya dionne smalls,
+ACCT,2010,8,Financial Accounting Concepts,0.35,0.3,0.09,0.07,0.05,0.0,0.0,0.14,mary ann  prater,
+ACCT,2010,9,Financial Accounting Concepts,0.15,0.27,0.31,0.07,0.02,0.0,0.0,0.18,henry anderson,
+ACCT,2010,10,Financial Accounting Concepts,0.27,0.32,0.02,0.07,0.05,0.0,0.0,0.27,mary ann  prater,
+ACCT,2010,11,Financial Accounting Concepts,0.11,0.11,0.32,0.11,0.25,0.0,0.0,0.09,henry anderson,
+ACCT,2010,12,Financial Accounting Concepts,0.14,0.37,0.19,0.11,0.14,0.0,0.0,0.05,tonya dionne smalls,
+ACCT,2010,401,Financial Accounting Concepts,0.14,0.43,0.24,0.08,0.04,0.0,0.0,0.07,jeffrey mcmillan,
+ACCT,2020,1,Managerial Accounting Concepts,0.26,0.34,0.17,0.08,0.06,0.0,0.0,0.09,henry anderson,
+ACCT,2020,2,Managerial Accounting Concepts,0.18,0.39,0.23,0.09,0.02,0.0,0.0,0.09,henry anderson,
+ACCT,2020,3,Managerial Accounting Concepts,0.37,0.24,0.18,0.06,0.08,0.0,0.0,0.06,jace garrett,
+ACCT,2020,4,Managerial Accounting Concepts,0.31,0.31,0.19,0.08,0.05,0.0,0.0,0.06,jace garrett,
+ACCT,2020,5,Managerial Accounting Concepts,0.32,0.29,0.19,0.14,0.0,0.0,0.0,0.07,derek dalton,
+ACCT,2020,401,Managerial Accounting Concepts,0.26,0.21,0.2,0.08,0.1,0.0,0.0,0.16,henry anderson,
+ACCT,3030,1,Cost Accounting,0.22,0.59,0.1,0.0,0.02,0.0,0.0,0.08,robin radtke,
+ACCT,3030,2,Cost Accounting,0.43,0.28,0.17,0.02,0.02,0.0,0.0,0.09,robin radtke,
+ACCT,3030,3,Cost Accounting,0.43,0.33,0.04,0.06,0.02,0.0,0.0,0.12,robin radtke,
+ACCT,3030,5,Cost Accounting,0.15,0.23,0.23,0.08,0.08,0.0,0.0,0.23,tonya dionne smalls,
+ACCT,3110,1,Intermediate Financial Acct I,0.38,0.46,0.08,0.03,0.03,0.0,0.0,0.03,terry daniel knause,
+ACCT,3110,2,Intermediate Financial Acct I,0.06,0.12,0.24,0.15,0.15,0.0,0.0,0.29,brian todd carver,
+ACCT,3110,3,Intermediate Financial Acct I,0.5,0.27,0.14,0.05,0.02,0.0,0.0,0.02,terry daniel knause,
+ACCT,3110,4,Intermediate Financial Acct I,0.28,0.37,0.22,0.02,0.04,0.02,0.0,0.04,terry daniel knause,
+ACCT,3110,5,Intermediate Financial Acct I,0.5,0.25,0.16,0.09,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3120,1,Intermediate Financial Acct II,0.16,0.32,0.26,0.18,0.08,0.0,0.0,0.0,the estate  guffey,
+ACCT,3120,2,Intermediate Financial Acct II,0.11,0.23,0.4,0.14,0.06,0.0,0.0,0.06,the estate  guffey,
+ACCT,3120,3,Intermediate Financial Acct II,0.03,0.18,0.44,0.21,0.13,0.0,0.0,0.03,brian todd carver,
+ACCT,3120,4,Intermediate Financial Acct II,0.03,0.17,0.33,0.23,0.17,0.0,0.0,0.07,brian todd carver,
+ACCT,3120,5,Intermediate Financial Acct II,0.24,0.36,0.31,0.04,0.05,0.0,0.0,0.0,jeremy micha vinson,
+ACCT,3130,1,Intermediate Fin Acct III,0.11,0.4,0.2,0.14,0.03,0.0,0.0,0.11, russell madray,
+ACCT,3130,2,Intermediate Fin Acct III,0.26,0.45,0.21,0.08,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3130,3,Intermediate Fin Acct III,0.38,0.38,0.19,0.03,0.03,0.0,0.0,0.0, russell madray,
+ACCT,3130,4,Intermediate Fin Acct III,0.33,0.36,0.26,0.05,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3220,1,Accounting Information Systems,0.1,0.41,0.29,0.07,0.05,0.0,0.0,0.07,philip maiberger,
+ACCT,3220,2,Accounting Information Systems,0.21,0.48,0.17,0.05,0.0,0.0,0.0,0.1,philip maiberger,
+ACCT,3220,3,Accounting Information Systems,0.14,0.25,0.25,0.07,0.0,0.0,0.0,0.29,philip maiberger,
+ACCT,4040,1,Individual Taxation,0.69,0.16,0.1,0.05,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,2,Individual Taxation,0.71,0.23,0.04,0.02,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.34,0.63,0.03,0.0,0.0,0.0,0.0,0.0,holly rhiannio hawk,
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,holly rhiannio hawk,
+ACCT,4150,1,Auditing,0.26,0.38,0.31,0.05,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,4150,2,Auditing,0.24,0.3,0.3,0.12,0.0,0.0,0.0,0.03,nancy lee harp,
+ACCT,8520,1,Fin Acct Theory/Res,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8520,2,Fin Acct Theory/Res,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8520,3,Fin Acct Theory/Res,0.2,0.63,0.17,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8540,1,Prof Responsibility,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8540,2,Prof Responsibility,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8540,3,Prof Responsibility,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8710,1,Corporate Taxation,0.16,0.76,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,2,Corporate Taxation,0.3,0.65,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,3,Corporate Taxation,0.31,0.67,0.03,0.0,0.0,0.0,0.0,0.0,derek dalton,
+AGED,1000,1,Orientation & Field Experience,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,philip fravel,
+AGED,2030,1,Teaching Agriscience,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,catheri dibenedetto,
+AGED,4160,1,Ethics and Issues,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,thomas dobbins,
+AGED,4250,1,Teaching Ag Mechs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGM,2050,1,Prin of Fabrication,0.12,0.53,0.22,0.08,0.02,0.0,0.0,0.03,hunter massey,
+AGM,2060,1,Machinery Mgt,0.08,0.32,0.41,0.08,0.05,0.0,0.0,0.05,hunter massey,
+AGM,2210,1,Land Measurements,0.17,0.52,0.26,0.0,0.04,0.0,0.0,0.0,charles privette,
+AGM,3030,1,Cal for Mech Ag,0.37,0.42,0.22,0.0,0.0,0.0,0.0,0.0,young han,
+AGM,4020,1,Landscape Drainage and Irrig,0.16,0.49,0.26,0.07,0.02,0.0,0.0,0.0,charles privette,
+AGM,4100,1,Precision Ag Tech,0.24,0.58,0.13,0.02,0.02,0.0,0.0,0.0,hunter massey,
+AGM,4520,1,Mobile Power,0.45,0.29,0.21,0.02,0.02,0.0,0.0,0.0,ali bulent koc,
+AGM,4720,1,Capstone,0.18,0.5,0.3,0.02,0.0,0.0,0.0,0.0,john chastain,
+AGRB,2020,1,Agricultural Economics,0.75,0.14,0.03,0.03,0.05,0.0,0.0,0.0,yuliya val bolotova,
+AGRB,2050,1,Agriculture and Society,0.46,0.34,0.16,0.02,0.0,0.0,0.0,0.02,lisha zhang,
+AGRB,3190,1,Agribusiness Management,0.3,0.3,0.24,0.14,0.02,0.0,0.0,0.0,michael vassalos,
+AGRB,3570,1,Natural Resources Economics,0.31,0.15,0.33,0.13,0.04,0.0,0.0,0.04,david brian willis,
+AGRB,4020,1,Production Economics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,michael vassalos,
+AGRB,4080,1,Quantitative Applied Economics,0.21,0.18,0.42,0.11,0.05,0.0,0.0,0.03,lisha zhang,
+AGRB,4520,1,Agricultural Policy,0.35,0.26,0.28,0.09,0.0,0.0,0.0,0.02,michael vassalos,
+AGRB,4560,1,Prices,0.47,0.38,0.16,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
+AL,3490,400,Principles of Coaching,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,401,Principles of Coaching,0.44,0.16,0.28,0.04,0.08,0.0,0.0,0.0,deborah cadorette,
+AL,3490,402,Principles of Coaching,0.72,0.2,0.04,0.04,0.0,0.0,0.0,0.0,julia wright,
+AL,3490,405,Principles of Coaching,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,edmond fry,
+AL,3500,400,Sci Basis I/Ex Phy,0.24,0.2,0.36,0.08,0.04,0.0,0.0,0.08,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.26,0.35,0.17,0.09,0.04,0.0,0.0,0.09,michael godfrey,
+AL,3520,400,Kinesiology,0.4,0.47,0.07,0.07,0.0,0.0,0.0,0.0,michael godfrey,
+AL,3530,400,Athletic Injuries,0.21,0.25,0.33,0.08,0.08,0.0,0.0,0.04,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.27,0.27,0.27,0.15,0.04,0.0,0.0,0.0,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.29,0.33,0.17,0.13,0.04,0.0,0.0,0.04,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.77,0.09,0.05,0.09,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,Admin/Org of Athletic Programs,0.72,0.12,0.16,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,403,Admin/Org of Athletic Programs,0.39,0.43,0.09,0.04,0.04,0.0,0.0,0.0,john plumblee,
+AL,3620,400,Psychology of Coaching,0.38,0.33,0.21,0.04,0.04,0.0,0.0,0.0,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.27,0.42,0.12,0.12,0.04,0.0,0.0,0.04,natalie anne carter,
+AL,3620,402,Psychology of Coaching,0.2,0.4,0.24,0.04,0.08,0.0,0.0,0.04,natalie anne carter,
+AL,3720,400,Coaching Basketball,0.62,0.15,0.12,0.08,0.0,0.0,0.0,0.04,edmond fry,
+AL,3740,400,Coaching Football,0.71,0.08,0.13,0.04,0.04,0.0,0.0,0.0,edmond fry,
+AL,3760,400,Coaching Strength/Conditioning,0.68,0.12,0.16,0.0,0.0,0.0,0.0,0.04,edmond fry,
+AL,4380,400,Coaching Women,0.52,0.33,0.05,0.1,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,4380,410,Coaching Rugby,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,deborah cadorette,
+AL,8530,400,Legal Iss in Intercoll Athlet,0.79,0.08,0.04,0.0,0.08,0.0,0.0,0.0,michael godfrey,
+ANTH,2010,1,Introduction to Anthropology,0.06,0.17,0.32,0.17,0.1,0.0,0.0,0.17,john coggeshall,
+ANTH,2010,2,Introduction to Anthropology,0.15,0.57,0.19,0.06,0.0,0.0,0.0,0.02,yi wu,
+ANTH,2010,3,Introduction to Anthropology,0.24,0.48,0.2,0.07,0.0,0.0,0.0,0.02,yi wu,
+ANTH,3200,1,North American Indian Cultures,0.13,0.38,0.25,0.0,0.06,0.0,0.0,0.19,john coggeshall,
+ANTH,3310,1,Archaeology,0.33,0.38,0.19,0.05,0.0,0.0,0.0,0.05,melissa vogel,
+ANTH,3510,1,Biological Anthropology,0.21,0.42,0.21,0.05,0.11,0.0,0.0,0.0,lisa rapaport,
+ANTH,3530,1,Forensic Anthropology,0.29,0.38,0.21,0.08,0.0,0.0,0.0,0.04,katherine weisensee,
+ANTH,4040,1,Anthropological Theories,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,john coggeshall,
+ANTH,4510,1,Biol Variation in Human Pop,0.47,0.21,0.16,0.0,0.0,0.0,0.0,0.16,katherine weisensee,
+ANTH,4660,1,Evolution of Human Behav,0.21,0.57,0.07,0.0,0.0,0.0,0.0,0.14,lisa rapaport,
+APEC,8220,1,Public Policy Econ,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,david brian willis,
+ARCH,1510,1,Arch Communication,0.33,0.27,0.07,0.07,0.13,0.0,0.0,0.13,sal hambright-belue,
+ARCH,1510,2,Arch Communication,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,robert silance,
+ARCH,1510,3,Arch Communication,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,1510,4,Arch Communication,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,ladan omidvar,
+ARCH,1510,5,Arch Communication,0.36,0.43,0.07,0.14,0.0,0.0,0.0,0.0,sal hambright-belue,
+ARCH,2520,1,Arch Foundations II,0.38,0.38,0.15,0.08,0.0,0.0,0.0,0.0,david lee,
+ARCH,2520,2,Arch Foundations II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,2520,3,Arch Foundations II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2520,4,Arch Foundations II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,james barker,
+ARCH,2520,5,Arch Foundations II,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,ladan omidvar,
+ARCH,2700,1,Structures I,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,robert john hogan,
+ARCH,2700,2,Structures I,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
+ARCH,3530,1,Studio Genoa,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4010,2,Architectural Portfolio,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,yixiao wang,
+ARCH,4520,1,Synthesis Studio,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,4520,2,Synthesis Studio,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,4520,3,Synthesis Studio,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,4520,4,Synthesis Studio,0.1,0.6,0.3,0.0,0.0,0.0,0.0,0.0,criss mills,
+ARCH,4710,1,Arch Hist of Place,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,james thomas,
+ARCH,4890,1,Internship,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,ashley jennings,
+ARCH,4990,13,Biomimicry and Biomimetics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,
+ARCH,6880,1,Arch Programming,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ARCH,8110,1,Visualization II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,8120,1,Comp Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,8200,1,Bldg Design & Constr,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+ARCH,8420,1,Arch Studio II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,
+ARCH,8420,2,Arch Studio II,0.67,0.0,0.33,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,8520,1,Design Studio IV,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,8520,3,Design Studio IV,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,8610,1,History/Theory II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,8620,1,History/Theory III,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,8740,1,Building Process:TR,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,8740,2,Building Process:TR,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,8820,1,Building Economics,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,8900,1,Directed Studies,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,anjali joseph,
+ARCH,8920,1,Comprehensive Studio,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ARCH,8920,2,Comprehensive Studio,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,8920,3,Comprehensive Studio,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
+ARCH,8920,4,Comprehensive Studio,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8960,1,A+H Studio: Tectonic,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ART,1060,1,Foundation Drawing II,0.6,0.28,0.12,0.0,0.0,0.0,0.0,0.0,carly drew,
+ART,1520,1,Foundations Art II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
+ART,2050,1,Beginning Life Drawing,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,
+ART,2070,1,Beginning Painting,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,mary jane king,
+ART,2090,1,Beginning Sculpture,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary elizabet cooke,
+ART,2100,400,Art Appreciation,0.54,0.32,0.07,0.04,0.0,0.0,0.0,0.04,lydia jane dorsey,
+ART,2100,401,Art Appreciation,0.45,0.24,0.1,0.0,0.0,0.0,0.0,0.21,lydia jane dorsey,
+ART,2100,402,Art Appreciation,0.57,0.36,0.04,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,
+ART,2100,403,Art Appreciation,0.29,0.5,0.14,0.04,0.0,0.0,0.0,0.04,lydia jane dorsey,
+ART,2110,1,Begin Printmaking,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,todd denni anderson,
+ART,2130,1,Begin Photography,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,gregory wi shelnutt,
+ART,2170,1,Beginning Ceramics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,en iwamura,
+ART,2210,1,Beginning New Media,0.8,0.0,0.13,0.0,0.07,0.0,0.0,0.0,christina nguy hung,
+ART,4750,1,Senior Exhibition Internship,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,
+AS,1100,1,Air Force Today II,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,christopher mann,
+AS,2100,2,Dev of Air Power II,0.5,0.2,0.3,0.0,0.0,0.0,0.0,0.0,christopher mann,
+AS,2100,3,Dev of Air Power II,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,
+ASL,1010,1,Am Sign Lang I,0.39,0.22,0.33,0.06,0.0,0.0,0.0,0.0,william alton brant,
+ASL,1010,2,Am Sign Lang I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,2010,1,Am Sign Lang II,0.43,0.36,0.21,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,2020,1,Am Sign Lang II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2020,2,Am Sign Lang II,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,kim ma misener dunn,
+ASL,3050,1,Deaf Studies,0.47,0.21,0.32,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASTR,1010,1,Solar System Astronomy,0.35,0.34,0.11,0.08,0.06,0.0,0.0,0.04,sean brittain,
+ASTR,1020,1,Stellar Astronomy,0.51,0.31,0.1,0.02,0.04,0.0,0.0,0.02,phillip flower,
+ASTR,1020,2,Stellar Astronomy,0.35,0.4,0.14,0.03,0.02,0.0,0.0,0.05,phillip flower,
+ASTR,1020,3,Stellar Astronomy,0.28,0.39,0.22,0.06,0.0,0.0,0.0,0.06,phillip flower,
+ASTR,1030,1,Solar Systm Astr Lab,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,mark leising,
+ASTR,1030,2,Solar Systm Astr Lab,0.69,0.19,0.0,0.04,0.04,0.0,0.0,0.04,mark leising,
+ASTR,1040,1,Stellar Astr Lab,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,mark leising,
+ASTR,1040,2,Stellar Astr Lab,0.43,0.35,0.04,0.04,0.0,0.0,0.0,0.13,mark leising,
+ASTR,1040,3,Stellar Astr Lab,0.74,0.13,0.04,0.0,0.04,0.0,0.0,0.04,mark leising,
+ASTR,1040,5,Stellar Astr Lab,0.23,0.32,0.14,0.14,0.14,0.0,0.0,0.05,mark leising,
+ASTR,1040,6,Stellar Astr Lab,0.0,0.54,0.23,0.08,0.08,0.0,0.0,0.08,mark leising,
+ASTR,3030,1,Galactic Astrophys,0.35,0.41,0.06,0.06,0.0,0.0,0.0,0.12,marco ajello,
+AUE,8160,1,Eng Combustion Emiss,0.74,0.24,0.0,0.0,0.0,0.0,0.0,0.02,robert prucka,
+AUE,8170,3,Alt Energy Sources,0.34,0.61,0.05,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8290,4,Tire Behavior,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8500,6,Stability/Safety Sys,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,beshah ayalew,
+AUE,8550,16,Auto Struct Analysis,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.52,0.33,0.03,0.0,0.09,0.0,0.0,0.03,michael mears,
+AUE,8770,9,Light-Weight Design,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,fadi kama abu-farha,
+AUE,8860,1,Noise Vibration,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,douglas feldmaier,
+AUE,8930,3,Applied Dynamics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8930,4,Mechanics of Composites Struct,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
+AUE,8930,14,Power Electronics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,simona onori,
+AUE,8930,15,Innov & Entrepreneurship,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david leo bodde,
+AVS,2000,1,Beef Cattle Tech,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,nathan long,
+AVS,2010,1,Poultry Techniques,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,2060,1,Swine Techniques,0.63,0.26,0.07,0.0,0.02,0.0,0.0,0.02,richelle lor miller,
+AVS,2090,1,Livestock Exhibition Technique,0.97,0.02,0.02,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3010,1,Anat & Phys Dom Ani,0.67,0.11,0.16,0.04,0.04,0.0,0.0,0.0,tiffany wilmoth,
+AVS,3100,1,Animal Health,0.42,0.35,0.11,0.03,0.02,0.0,0.0,0.08,thomas scott,
+AVS,3150,1,Animal Welfare,0.22,0.22,0.39,0.06,0.06,0.0,0.0,0.06,peter skewes,
+AVS,3700,1,Principles of Animal Nutrition,0.37,0.35,0.18,0.07,0.01,0.0,0.0,0.01,james ro strickland,
+AVS,3750,1,Applied Animal Nutrition,0.24,0.35,0.33,0.07,0.0,0.0,0.0,0.02,gustavo jos lascano,
+AVS,4000,1,AVS Professional Development,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
+AVS,4000,2,AVS Professional Development,0.77,0.15,0.0,0.08,0.0,0.0,0.0,0.0,johanna joh lascano,
+AVS,4060,2,Seminars & Related Topics,0.46,0.39,0.14,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4100,1,Domestic Ani Behav,0.18,0.5,0.26,0.03,0.02,0.0,0.0,0.01,peter skewes,
+AVS,4130,1,Animal Products,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,4140,1,Basic Immunology,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,thomas scott,
+AVS,4170,1,Animal Agribusiness Develpmnt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,4530,1,Animal Reproduction,0.46,0.36,0.12,0.02,0.02,0.0,0.0,0.02,glenn birrenkott,
+AVS,4530,400,Animal Reproduction,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,glenn birrenkott,
+BCHM,3010,1,Molecular Biochem,0.29,0.23,0.32,0.08,0.06,0.0,0.0,0.02,cheryl ingram-smith,
+BCHM,3010,2,Molecular Biochem(HON),0.48,0.29,0.16,0.03,0.0,0.0,0.0,0.03,kerry smith,True
+BCHM,3050,1,Essen Elements Bioch,0.37,0.35,0.1,0.06,0.04,0.0,0.0,0.07,srik chandrasekaran,
+BCHM,3050,2,Essen Elements Bioch,0.39,0.34,0.14,0.05,0.03,0.0,0.0,0.05,srik chandrasekaran,
+BCHM,4320,1,Bioch of Metabolism,0.63,0.15,0.12,0.02,0.02,0.0,0.0,0.05,kimberly paul,
+BCHM,4360,1,Genes to Proteins,0.5,0.33,0.1,0.0,0.05,0.0,0.0,0.02,michael glen sehorn,
+BCHM,4400,1,Bioinformatics,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,liangjiang wang,
+BCHM,4930,1,Senior Seminar,0.55,0.39,0.03,0.0,0.03,0.0,0.0,0.0,james morris,
+BE,2100,1,Intro to Biosystems Engr,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,yi zheng,
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.27,0.42,0.23,0.0,0.04,0.0,0.0,0.04,tom owino,
+BE,4120,1,Be Heat Mass Trans,0.52,0.3,0.04,0.0,0.09,0.0,0.0,0.04,caye marie drapcho,
+BE,4150,1,Instr & Control for Biosys Eng,0.67,0.17,0.08,0.04,0.0,0.0,0.0,0.04,yi zheng,
+BE,4380,1,Bioprocess Engineering Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,terry walker,
+BE,4730,3,Thermodynamics,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,terry walker,
+BIOE,1010,1,Biol for Bioengr,0.51,0.31,0.1,0.02,0.01,0.0,0.0,0.05,vladimir vla reukov,
+BIOE,2010,1,Intro Biomed Engr,0.11,0.72,0.11,0.06,0.0,0.0,0.0,0.0,charles webb,
+BIOE,3020,1,Biomaterials,0.65,0.28,0.01,0.04,0.0,0.0,0.0,0.01,alexey ale vertegel,
+BIOE,3200,1,Biomechanics,0.61,0.26,0.09,0.02,0.0,0.0,0.0,0.02,jiro nagatomi,
+BIOE,3210,1,Biofluid Mechanics,0.47,0.36,0.05,0.05,0.03,0.0,0.0,0.04,sarah harcum,
+BIOE,3700,1,Bioinst & Imaging,0.58,0.4,0.01,0.0,0.0,0.0,0.0,0.0,delphine dean,
+BIOE,4010,1,Bioengineering Design Theory,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
+BIOE,4030,1,Applied Bio E Design,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4200,1,Sports Engineering,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
+BIOE,4230,1,Cardiovascular Engr and Path,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,dan simionescu,
+BIOE,4310,1,Medical Imaging,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,david kwartowitz,
+BIOE,4490,1,Drug Delivery,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,frank alexis,
+BIOE,6350,1,Modeling of Multiphysics Prob,0.46,0.46,0.0,0.0,0.0,0.0,0.0,0.08,guigen zhang,
+BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,martine laberge,
+BIOE,8020,410,Biocompatibility,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
+BIOE,8130,1,Industrial Bioengineering,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michael taylor,
+BIOE,8410,1,Drug Delivery,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,
+BIOE,8500,401,Toolkit - Cell & Molecular Bio,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ann catherine foley,
+BIOL,1040,1,General Biology II,0.27,0.34,0.22,0.1,0.03,0.0,0.0,0.05,nora espinoza,
+BIOL,1040,2,General Biology II,0.44,0.35,0.12,0.06,0.02,0.0,0.0,0.02,william surver,
+BIOL,1040,3,General Biology II,0.15,0.18,0.39,0.16,0.07,0.0,0.0,0.04,salvatore sparace,
+BIOL,1060,1,Gen Biology Lab II,0.09,0.27,0.36,0.09,0.18,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,2,Gen Biology Lab II,0.09,0.36,0.45,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,3,Gen Biology Lab II,0.27,0.27,0.27,0.09,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,4,Gen Biology Lab II,0.1,0.33,0.14,0.29,0.05,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,5,Gen Biology Lab II,0.14,0.19,0.29,0.19,0.1,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,6,Gen Biology Lab II,0.27,0.18,0.36,0.0,0.14,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,7,Gen Biology Lab II,0.05,0.3,0.2,0.2,0.15,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,8,Gen Biology Lab II,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,9,Gen Biology Lab II,0.11,0.37,0.26,0.16,0.11,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,10,Gen Biology Lab II,0.1,0.57,0.19,0.1,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,11,Gen Biology Lab II,0.23,0.55,0.14,0.09,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,12,Gen Biology Lab II,0.18,0.41,0.23,0.09,0.09,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,13,Gen Biology Lab II,0.18,0.32,0.23,0.09,0.09,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,14,Gen Biology Lab II,0.32,0.32,0.09,0.14,0.05,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,15,Gen Biology Lab II,0.09,0.18,0.36,0.18,0.14,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,16,Gen Biology Lab II,0.09,0.36,0.36,0.14,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,17,Gen Biology Lab II,0.13,0.3,0.3,0.09,0.17,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,18,Gen Biology Lab II,0.09,0.09,0.26,0.35,0.17,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,19,Gen Biology Lab II,0.23,0.18,0.45,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,20,Gen Biology Lab II,0.23,0.36,0.18,0.18,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,21,Gen Biology Lab II,0.14,0.23,0.41,0.05,0.18,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,22,Gen Biology Lab II,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,23,Gen Biology Lab II,0.09,0.27,0.36,0.14,0.14,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,24,Gen Biology Lab II,0.0,0.22,0.39,0.17,0.13,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,26,Gen Biology Lab II,0.18,0.09,0.32,0.27,0.09,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,27,Gen Biology Lab II,0.29,0.43,0.24,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,28,Gen Biology Lab II,0.23,0.32,0.18,0.27,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,29,Gen Biology Lab II,0.09,0.55,0.14,0.14,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,30,Gen Biology Lab II,0.05,0.45,0.32,0.05,0.09,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,31,Gen Biology Lab II,0.23,0.14,0.32,0.09,0.18,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,33,Gen Biology Lab II,0.04,0.33,0.25,0.17,0.17,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,34,Gen Biology Lab II,0.0,0.0,0.4,0.3,0.2,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1090,1,Intro to Life Sci,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
+BIOL,1110,1,Principles of Biology II,0.24,0.44,0.24,0.06,0.0,0.0,0.0,0.02,robert kosinski,
+BIOL,1110,2,Principles of Biology II,0.35,0.36,0.15,0.04,0.02,0.0,0.0,0.07,dylan dittrich-reed,
+BIOL,1200,1,Biological Inq Lab,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1200,2,Biological Inq Lab,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06, christine minor,
+BIOL,1200,3,Biological Inq Lab,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06, christine minor,
+BIOL,1200,5,Biological Inq Lab,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0, christine minor,
+BIOL,1200,6,Biological Inq Lab,0.4,0.4,0.07,0.0,0.07,0.0,0.0,0.07, christine minor,
+BIOL,1230,1,Keys to Human Biol,0.32,0.29,0.22,0.09,0.06,0.0,0.0,0.03, christine minor,
+BIOL,2000,2,Biology in the News,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,2000,3,Biology in the News,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
+BIOL,2000,6,Biology in the News,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,simon scott,
+BIOL,2000,7,Biology in the News,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,john michael henson,
+BIOL,2030,1,Human Disease & Soc,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02, christine minor,
+BIOL,2040,1,"Environ, Energy and Society",0.52,0.36,0.06,0.01,0.03,0.0,0.0,0.01,john jenkins hains,
+BIOL,2040,2,"Environ, Energy and Society",0.48,0.35,0.13,0.0,0.05,0.0,0.0,0.0,john jenkins hains,
+BIOL,2110,1,Introduction to Toxicology,0.45,0.48,0.03,0.0,0.0,0.0,0.0,0.03,peter van den hurk,
+BIOL,2230,1,Human Anat and Physiology II,0.32,0.35,0.17,0.08,0.05,0.0,0.0,0.02,john cummings,
+BIOL,2230,2,Human Anat and Physiology II,0.39,0.38,0.12,0.05,0.03,0.0,0.0,0.03,john cummings,
+BIOL,3020,1,Invertebrate Biology,0.11,0.21,0.37,0.18,0.08,0.0,0.0,0.05,juan baeza migueles,
+BIOL,3040,1,Biology of Plants,0.47,0.38,0.08,0.03,0.0,0.0,0.0,0.04,christina wells,
+BIOL,3060,1,Invertebrate Biology Lab,0.16,0.42,0.21,0.05,0.11,0.0,0.0,0.05,juan baeza migueles,
+BIOL,3060,3,Invertebrate Biology Lab,0.11,0.33,0.39,0.11,0.0,0.0,0.0,0.06,juan baeza migueles,
+BIOL,3080,1,Biology of Plants Practicum,0.24,0.47,0.12,0.0,0.06,0.0,0.0,0.12,christina wells,
+BIOL,3080,2,Biology of Plants Practicum,0.35,0.47,0.0,0.06,0.0,0.0,0.0,0.12,christina wells,
+BIOL,3080,3,Biology of Plants Practicum,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,christina wells,
+BIOL,3080,4,Biology of Plants Practicum,0.28,0.39,0.22,0.0,0.06,0.0,0.0,0.06,christina wells,
+BIOL,3130,1,Conservation Biology,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+BIOL,3130,2,Conservation Biology,0.47,0.21,0.16,0.05,0.11,0.0,0.0,0.0,shari lyn rodriguez,
+BIOL,3160,1,Human Physiology,0.35,0.39,0.21,0.03,0.0,0.0,0.0,0.02,tamara mcnutt-scott,
+BIOL,3350,1,Evolutionary Biology,0.37,0.4,0.17,0.02,0.01,0.0,0.0,0.02,michael sears,
+BIOL,3350,2,Evolutionary Biology (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,margaret ptacek,True
+BIOL,3510,1,Biological Anthropology,0.47,0.4,0.07,0.0,0.07,0.0,0.0,0.0,lisa rapaport,
+BIOL,3530,1,Forensic Anthropology,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
+BIOL,4010,1,Plant Physiology,0.09,0.28,0.3,0.21,0.07,0.0,0.0,0.05,douglas bielenberg,
+BIOL,4020,1,Plant Physiology Lab,0.11,0.28,0.33,0.17,0.06,0.0,0.0,0.06,douglas bielenberg,
+BIOL,4020,2,Plant Physiology Lab,0.63,0.13,0.19,0.0,0.06,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4100,1,Limnology,0.58,0.26,0.1,0.03,0.0,0.0,0.0,0.03,john jenkins hains,
+BIOL,4140,1,Basic Immunology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,
+BIOL,4340,1,Biological Chem Lab Techniques,0.0,0.27,0.27,0.27,0.13,0.0,0.0,0.07,salvatore sparace,
+BIOL,4340,2,Biological Chem Lab Techniques,0.13,0.44,0.38,0.0,0.0,0.0,0.0,0.06,salvatore sparace,
+BIOL,4340,3,Biological Chem Lab Techniques,0.0,0.46,0.38,0.15,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,4,Biological Chem Lab Techniques,0.29,0.43,0.07,0.0,0.07,0.0,0.0,0.14,salvatore sparace,
+BIOL,4610,1,Cell Biology,0.31,0.3,0.18,0.12,0.07,0.0,0.0,0.03,lisa bain,
+BIOL,4610,2,Cell Biology (HON),0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,lisa bain,True
+BIOL,4610,3,Cell Biology,0.25,0.3,0.29,0.05,0.03,0.0,0.0,0.07,zhicheng dou,
+BIOL,4620,1,Cell Biology Lab (Lec),0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,2,Cell Biology Lab (Lec),0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,3,Cell Biology Lab (Lec),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,4,Cell Biology Lab (Lec),0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.75,0.06,0.13,0.0,0.06,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,7,Cell Biology Lab (Lec),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,8,Cell Biology Lab (Lec),0.63,0.0,0.06,0.06,0.0,0.0,0.0,0.25,xianzhong yu,
+BIOL,4640,1,Mammalogy,0.48,0.29,0.1,0.1,0.05,0.0,0.0,0.0,john cummings,
+BIOL,4660,1,Evolution of Human Behavior,0.29,0.41,0.12,0.06,0.06,0.0,0.0,0.06,lisa rapaport,
+BIOL,4700,1,Behavioral Ecology,0.26,0.49,0.19,0.04,0.02,0.0,0.0,0.0,michael childress,
+BIOL,4700,2,Behavioral Ecology (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,True
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.62,0.24,0.05,0.05,0.0,0.0,0.0,0.05,michael childress,
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,michael childress,
+BIOL,4710,3,Behavioral Ecology Lab (Lec),0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05,michael childress,
+BIOL,4710,4,Behavioral Ecology Lab (Lec),0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,michael childress,
+BIOL,4930,2,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
+BIOL,4930,4,Senior Seminar,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
+BIOL,4930,5,Senior Seminar,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4930,6,Senior Seminar,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,william baldwin,
+BIOL,4960,1,Biodiversity & Conserv in Asia,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david tonkyn,
+BIOL,8430,1,Underst Genetics & Evol Biol,0.85,0.12,0.01,0.0,0.0,0.0,0.0,0.02,margaret ptacek,
+BIOL,8450,1,Understanding Animal Biology,0.86,0.12,0.01,0.0,0.0,0.0,0.0,0.01,matthew turnbull,
+BIOL,8470,1,Understanding Microbiology,0.63,0.28,0.07,0.0,0.01,0.0,0.0,0.01,harry kurtz,
+BIOL,8480,1,Understanding Scientific Rsrch,0.9,0.0,0.0,0.0,0.02,0.0,0.0,0.07,robert edwa ballard,
+BMOL,4250,1,Biomolecular Engineering,0.45,0.36,0.09,0.09,0.0,0.0,0.0,0.0,mark alan blenner,
+BUS,1010,1,Business Foundations,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,2,Business Foundations,0.22,0.52,0.19,0.04,0.0,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,3,Business Foundations,0.35,0.54,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,4,Business Foundations,0.27,0.54,0.12,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
+BUS,1010,5,Business Foundations,0.39,0.43,0.11,0.0,0.0,0.0,0.0,0.07,william ern tumblin,
+BUS,1010,6,Business Foundations,0.22,0.44,0.19,0.04,0.0,0.0,0.0,0.11,william ern tumblin,
+BUS,1010,7,Business Foundations,0.23,0.46,0.19,0.04,0.04,0.0,0.0,0.04,william ern tumblin,
+BUS,1010,8,Business Foundations,0.28,0.52,0.14,0.03,0.0,0.0,0.0,0.03,william ern tumblin,
+BUS,1010,9,Business Foundations,0.33,0.44,0.19,0.0,0.04,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,10,Business Foundations,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+CE,2010,1,Statics,0.66,0.11,0.18,0.0,0.02,0.0,0.0,0.02,sara khoshnevisan,
+CE,2010,2,Statics,0.19,0.35,0.19,0.03,0.08,0.0,0.0,0.16,melissa sternhagen,
+CE,2010,3,Statics,0.43,0.36,0.16,0.05,0.0,0.0,0.0,0.0,thomas edfo cousins,
+CE,2010,4,Statics,0.16,0.26,0.21,0.13,0.11,0.0,0.0,0.13,melissa sternhagen,
+CE,2010,5,Statics,0.53,0.35,0.05,0.0,0.03,0.0,0.0,0.03,mahmoodreza soltani,
+CE,2010,6,Statics,0.24,0.65,0.07,0.02,0.0,0.0,0.0,0.02, kent nilsson,
+CE,2010,7,Statics,0.27,0.38,0.1,0.06,0.02,0.0,0.0,0.17,thomas edfo cousins,
+CE,2060,1,Structural Mechanics,0.28,0.38,0.26,0.03,0.05,0.0,0.0,0.0,bryant nielson,
+CE,2060,2,Structural Mechanics,0.3,0.35,0.25,0.05,0.02,0.0,0.0,0.04,bryant nielson,
+CE,2080,1,Dynamics,0.12,0.42,0.22,0.02,0.08,0.0,0.0,0.14,melissa sternhagen,
+CE,2080,2,Dynamics,0.14,0.36,0.27,0.09,0.05,0.0,0.0,0.09,melissa sternhagen,
+CE,2080,3,Dynamics,0.28,0.38,0.2,0.08,0.0,0.0,0.0,0.08,thomas edfo cousins,
+CE,2550,1,Geomatics,0.32,0.45,0.14,0.0,0.07,0.0,0.0,0.02,wayne sarasua,
+CE,3010,1,Structural Analysis,0.27,0.27,0.3,0.03,0.09,0.0,0.0,0.03,stephen csernak,
+CE,3110,1,Transportation Engr,0.35,0.35,0.18,0.05,0.04,0.0,0.0,0.03,yongxi huang,
+CE,3210,1,Geotechnical Engineering,0.56,0.28,0.08,0.03,0.05,0.0,0.0,0.0,charng-hsein juang,
+CE,3210,2,Geotechnical Engineering,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,sara khoshnevisan,
+CE,3310,1,Constr Engr & Mgmnt,0.33,0.37,0.24,0.02,0.04,0.0,0.0,0.0,james burati,
+CE,3410,1,Intro to Fluid Mech,0.35,0.35,0.23,0.08,0.0,0.0,0.0,0.0,nigel gregory kaye,
+CE,3410,2,Intro to Fluid Mech,0.36,0.42,0.12,0.0,0.06,0.0,0.0,0.03,nigel gregory kaye,
+CE,3420,1,Hydraulics & Hydro,0.21,0.36,0.29,0.05,0.05,0.0,0.0,0.05,abdul khan,
+CE,3420,2,Hydraulics & Hydro,0.51,0.36,0.1,0.0,0.0,0.0,0.0,0.03,ashok mishra,
+CE,3510,1,Civil Engineering Materials,0.31,0.54,0.1,0.0,0.03,0.0,0.0,0.03,prasada rangaraju,
+CE,3520,1,Econ Eval of Proj,0.38,0.4,0.04,0.11,0.02,0.0,0.0,0.04,james burati,
+CE,3520,2,Econ Eval of Proj,0.58,0.25,0.13,0.03,0.0,0.0,0.0,0.03,bradley putman,
+CE,3530,1,Professional Seminar,0.95,0.03,0.02,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,
+CE,4020,1,Reinfor Con Design,0.5,0.3,0.1,0.04,0.03,0.0,0.0,0.03,brandon ross,
+CE,4080,1,Struct Loads & Sys,0.27,0.35,0.19,0.12,0.04,0.0,0.0,0.04,bryant nielson,
+CE,4110,1,Roadway Geo Design,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,jennifer ogle,
+CE,4120,1,Urban Transport Plan,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CE,4210,1,Geotechnical Design,0.28,0.42,0.23,0.02,0.02,0.0,0.0,0.02,nadara ravichandran,
+CE,4340,1,Const Est Proj Cont,0.73,0.21,0.04,0.0,0.01,0.0,0.0,0.0,kalyan ram piratla,
+CE,4360,1,Sustainable Constr,0.83,0.16,0.02,0.0,0.0,0.0,0.0,0.0,leidy klotz,
+CE,4590,1,Capstone Design Proj,0.48,0.46,0.04,0.03,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4910,1,Non-Destructive Evaluation,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,ami esmaeilpoursaee,
+CE,6080,1,Struct Loads & Sys,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,bryant nielson,
+CE,6340,1,Const Est Proj Cont,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,6360,1,Sustainable Constr,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,leidy klotz,
+CE,6430,1,Water Resources Engr,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,abdul khan,
+CE,6910,1,Non-Destructive Evaluation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,
+CE,8010,1,Finite Ele Analysis,0.35,0.47,0.06,0.0,0.0,0.0,0.0,0.12,nadara ravichandran,
+CE,8280,1,Rep/Rehab of Con Str,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,prasada rangaraju,
+CE,8530,1,Apps in Traffic En,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,mashrur chowdhury,
+CE,8930,1,Selec Topics in CE - Hwy Bridg,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,thomas edfo cousins,
+CE,8930,2,Selec Topics in CE-Risk Assess,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CE,8930,4,Select Topics in CE - Poromech,0.56,0.22,0.0,0.0,0.11,0.0,0.0,0.11,qiushi chen,
+CE,8930,400,Selec Topics in CE-Human Fact,0.71,0.17,0.0,0.0,0.08,0.0,0.0,0.04,kap chalil madathil,
+CH,1010,1,General Chemistry,0.1,0.37,0.25,0.11,0.1,0.0,0.0,0.06,ava kreider-mueller,
+CH,1010,2,General Chemistry,0.23,0.27,0.23,0.15,0.09,0.0,0.0,0.05,ava kreider-mueller,
+CH,1010,3,General Chemistry,0.21,0.31,0.25,0.1,0.1,0.0,0.0,0.04,dennis taylor,
+CH,1010,4,General Chemistry,0.0,0.1,0.13,0.13,0.35,0.0,0.0,0.29,william joh wallace,
+CH,1010,400,General Chemistry,0.17,0.2,0.29,0.2,0.06,0.0,0.0,0.08,stephe schvaneveldt,
+CH,1020,1,General Chemistry,0.32,0.39,0.18,0.05,0.02,0.0,0.0,0.04,tania issa houjeiry,
+CH,1020,2,General Chemistry,0.26,0.42,0.2,0.06,0.02,0.0,0.0,0.04,dennis taylor,
+CH,1020,3,General Chemistry,0.27,0.39,0.23,0.05,0.02,0.0,0.0,0.04,dennis taylor,
+CH,1020,4,General Chemistry,0.02,0.15,0.28,0.17,0.13,0.0,0.0,0.26,william joh wallace,
+CH,1020,5,General Chemistry,0.05,0.35,0.1,0.1,0.3,0.0,0.0,0.1,william joh wallace,
+CH,1020,6,General Chemistry,0.23,0.4,0.22,0.06,0.02,0.0,0.0,0.08,olt geiculescu,
+CH,1020,7,General Chemistry,0.26,0.32,0.25,0.08,0.05,0.0,0.0,0.04,thomas hickman,
+CH,1020,8,General Chemistry,0.14,0.41,0.25,0.08,0.02,0.0,0.0,0.11,elliot ennis,
+CH,1020,9,General Chemistry,0.24,0.46,0.21,0.03,0.03,0.0,0.0,0.03,thomas hickman,
+CH,1020,10,General Chemistry,0.26,0.43,0.21,0.05,0.03,0.0,0.0,0.03,ava kreider-mueller,
+CH,1020,11,General Chemistry,0.16,0.26,0.37,0.0,0.05,0.0,0.0,0.16,christopher wilson,
+CH,1020,13,General Chemistry,0.53,0.37,0.0,0.11,0.0,0.0,0.0,0.0,edward collins,
+CH,1020,50,General Chemistry,0.38,0.19,0.38,0.0,0.0,0.0,0.0,0.05,shiou-jyh hwu,
+CH,1020,51,General Chemistry (HON),0.78,0.11,0.04,0.0,0.0,0.0,0.0,0.07,stephe schvaneveldt,True
+CH,1020,52,General Chemistry (HON),0.8,0.16,0.02,0.0,0.0,0.0,0.0,0.02,stephe schvaneveldt,True
+CH,1050,1,Chemistry in Context I,0.58,0.31,0.05,0.0,0.0,0.0,0.0,0.06,christopher wilson,
+CH,1060,1,Chemistry in Context II,0.42,0.33,0.14,0.08,0.0,0.0,0.0,0.03,olt geiculescu,
+CH,1060,2,Chemistry in Context II,0.38,0.31,0.23,0.08,0.0,0.0,0.0,0.0,olt geiculescu,
+CH,1520,1,Chem Commun I,0.81,0.05,0.05,0.0,0.03,0.0,0.0,0.05,richard marcus,
+CH,2010,1,Survey of Organic Chemistry,0.37,0.34,0.16,0.06,0.05,0.0,0.0,0.02,tania issa houjeiry,
+CH,2020,1,Surv of Organic Chemistry Lab,0.73,0.0,0.07,0.0,0.0,0.0,0.0,0.2,sean 'connor,
+CH,2020,2,Surv of Organic Chemistry Lab,0.5,0.28,0.06,0.0,0.06,0.0,0.0,0.11,sean 'connor,
+CH,2050,1,Intro Inorg Chem,0.44,0.28,0.25,0.0,0.0,0.0,0.0,0.03,william pennington,
+CH,2230,1,Organic Chemistry,0.21,0.32,0.25,0.09,0.05,0.0,0.0,0.07,jacob schroeder,
+CH,2230,2,Organic Chemistry,0.26,0.32,0.2,0.13,0.05,0.0,0.0,0.04,jacob schroeder,
+CH,2230,3,Organic Chemistry,0.13,0.38,0.22,0.13,0.08,0.0,0.0,0.05,jacob schroeder,
+CH,2240,1,Organic Chemistry,0.24,0.4,0.24,0.02,0.05,0.0,0.0,0.04,thomas hickman,
+CH,2240,2,Organic Chemistry,0.34,0.32,0.19,0.09,0.03,0.0,0.0,0.02,elliot ennis,
+CH,2240,3,Organic Chemistry,0.32,0.36,0.25,0.01,0.02,0.0,0.0,0.03,elliot ennis,
+CH,2240,4,Organic Chemistry,0.24,0.36,0.14,0.04,0.1,0.0,0.0,0.13,rhett smith,
+CH,2240,5,Organic Chemistry,0.13,0.23,0.35,0.06,0.03,0.0,0.0,0.19,dev priya arya,
+CH,2270,3,Organic Chem Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,4,Organic Chem Lab,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,5,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,7,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,9,Organic Chem Lab,0.8,0.0,0.07,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,11,Organic Chem Lab,0.81,0.0,0.0,0.0,0.06,0.0,0.0,0.13,sean 'connor,
+CH,2270,12,Organic Chem Lab,0.63,0.31,0.0,0.0,0.06,0.0,0.0,0.0,sean 'connor,
+CH,2270,14,Organic Chem Lab,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,sean 'connor,
+CH,2280,3,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,4,Organic Chem Lab,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2280,6,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2280,11,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,15,Organic Chem Lab,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,sean 'connor,
+CH,2280,16,Organic Chem Lab,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,sean 'connor,
+CH,2280,17,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2280,20,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2280,26,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,
+CH,2280,27,Organic Chem Lab,0.75,0.08,0.0,0.0,0.0,0.0,0.0,0.17,sean 'connor,
+CH,2290,3,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,3310,1,Physical Chemistry,0.47,0.35,0.12,0.0,0.0,0.0,0.0,0.06,arkady kholodenko,
+CH,3320,1,Physical Chemistry,0.31,0.51,0.1,0.04,0.0,0.0,0.0,0.04,steven stuart,
+CH,3320,2,Physical Chemistry,0.39,0.21,0.32,0.05,0.03,0.0,0.0,0.0,jason mcneill,
+CH,3320,3,Physical Chemistry,0.58,0.17,0.13,0.04,0.08,0.0,0.0,0.0,leah bec casabianca,
+CH,3400,5,Physical Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,christopher wilson,
+CH,3600,1,Chemical Biology,0.38,0.36,0.16,0.02,0.02,0.0,0.0,0.07,modi wetzler,
+CH,4110,1,Instrumental Analy,0.26,0.39,0.13,0.09,0.13,0.0,0.0,0.0,george chumanov,
+CH,4120,1,Instr Analysis Lab,0.27,0.45,0.0,0.09,0.18,0.0,0.0,0.0,jeffrey natha anker,
+CH,4130,1,Chemistry of Aqueous Systems,0.43,0.4,0.17,0.0,0.0,0.0,0.0,0.0,cindy lee,
+CH,4250,1,Medicinal Chem,0.33,0.0,0.33,0.0,0.0,0.0,0.0,0.33,dev priya arya,
+CH,4500,1,Chemistry Capstone,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
+CH,6140,1,Bioanalytical Chem,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,carlos garcia perez,
+CH,8050,1,Theor Inorg Chem,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,joseph kolis,
+CH,8180,1,Surface Analysis,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,stephen creager,
+CH,8220,1,Organic Chem II,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,daniel whitehead,
+CH,8340,1,Stat Thermodynamics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,brian dominy,
+CH,8510,1,Grad Student Seminar,0.73,0.13,0.13,0.0,0.0,0.0,0.0,0.0,joseph stu thrasher,
+CHE,1300,1,Chemical Eng Tools,0.16,0.35,0.14,0.11,0.16,0.0,0.0,0.09,christopher norfolk,
+CHE,1300,2,Chemical Eng Tools,0.31,0.18,0.13,0.13,0.16,0.0,0.0,0.08,christopher norfolk,
+CHE,2200,2,Ch E Thermo I,0.18,0.21,0.37,0.06,0.15,0.0,0.0,0.03,joseph scott,
+CHE,2300,1,Fluids/Heat Transfer,0.1,0.33,0.34,0.13,0.07,0.0,0.0,0.03,douglas hirt,
+CHE,2300,2,Fluids/Heat Transfer,0.13,0.24,0.4,0.15,0.04,0.0,0.0,0.05,eric mikel davis,
+CHE,3210,1,Ch E Thermo II,0.13,0.23,0.4,0.18,0.03,0.0,0.0,0.03,sapna sarupria,
+CHE,3300,1,Mass Trans & Seprtn,0.18,0.24,0.35,0.14,0.05,0.0,0.0,0.05,mark thies,
+CHE,3530,1,Proc Dyn & Control,0.24,0.39,0.33,0.02,0.02,0.0,0.0,0.0,mark roberts,
+CHE,4330,1,Process Design II,0.6,0.23,0.17,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,8340,1,CHE Polymer Thermodynamics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark thies,
+CHIN,1010,1,Elementary Chinese,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yanlin wang,
+CHIN,1020,1,Elementary Chinese,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,yanlin wang,
+CHIN,2010,1,Intermediate Chinese,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
+CHIN,4010,1,Pre-Modern Chinese Literature,0.3,0.5,0.15,0.0,0.05,0.0,0.0,0.0,yanming an,
+COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,eddie smith,
+COM,1500,1,Intro to Human Communication,0.81,0.16,0.01,0.0,0.0,0.0,0.0,0.02,eddie smith,
+COM,1500,2,Intro to Human Communication,0.57,0.33,0.05,0.02,0.01,0.0,0.0,0.02,daniel lelan fecher,
+COM,1500,3,Intro to Human Communication,0.82,0.13,0.03,0.0,0.0,0.0,0.0,0.03,eddie smith,
+COM,1500,4,Intro to Human Communication,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,marianne her glaser,
+COM,1500,5,Intro to Human Communication,0.65,0.26,0.04,0.01,0.03,0.0,0.0,0.01,marianne her glaser,
+COM,1500,6,Intro to Human Communication,0.5,0.38,0.05,0.01,0.01,0.0,0.0,0.05,daniel lelan fecher,
+COM,2010,1,Intr to Comm Studies,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,2010,2,Intr to Comm Studies,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,darren linvill,
+COM,2500,1,Public Speaking,0.62,0.24,0.14,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,2,Public Speaking,0.52,0.29,0.1,0.1,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,3,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,2500,4,Public Speaking,0.33,0.38,0.24,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,5,Public Speaking,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,6,Public Speaking,0.48,0.43,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,7,Public Speaking,0.19,0.57,0.14,0.0,0.0,0.0,0.0,0.1,marilyn denise pugh,
+COM,2500,8,Public Speaking,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,
+COM,2500,9,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,10,Public Speaking,0.76,0.05,0.05,0.05,0.1,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,11,Public Speaking,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,12,Public Speaking,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,13,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,14,Public Speaking,0.62,0.19,0.05,0.05,0.0,0.0,0.0,0.1,vanessa anne condon,
+COM,2500,15,Public Speaking,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,16,Public Speaking,0.37,0.32,0.16,0.0,0.05,0.0,0.0,0.11,pauline matthey,
+COM,2500,17,Public Speaking,0.5,0.35,0.05,0.05,0.0,0.0,0.0,0.05,the estate  geddes,
+COM,2500,18,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,19,Public Speaking,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
+COM,2500,20,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,21,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,22,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,23,Public Speaking,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,25,Public Speaking,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
+COM,2500,26,Public Speaking (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,True
+COM,2500,27,Public Speaking (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,True
+COM,2500,29,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,400,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,401,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,402,Public Speaking,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,alexis zachar davis,
+COM,2500,403,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,500,Public Speaking,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
+COM,3010,1,Comm Theory,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,pauline matthey,
+COM,3020,1,Mass Comm Theory,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,karyn jones,
+COM,3050,1,Persuasion,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,karyn jones,
+COM,3060,1,Discourse & Society,0.4,0.44,0.16,0.0,0.0,0.0,0.0,0.0,david travers scott,
+COM,3100,1,Quant Comm Methods,0.64,0.28,0.0,0.0,0.08,0.0,0.0,0.0,john steven spinda,
+COM,3200,1,Bdcst Production,0.67,0.1,0.1,0.05,0.0,0.0,0.0,0.1,wanda johnson,
+COM,3250,1,Survey of Sports Communication,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3250,2,Survey of Sports Communication,0.83,0.08,0.0,0.0,0.04,0.0,0.0,0.04,angela pratt,
+COM,3300,1,Nonverbal Comm,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,joseph mazer,
+COM,3480,1,Interpersonal Comm,0.43,0.43,0.1,0.0,0.05,0.0,0.0,0.0,melinda ra weathers,
+COM,3560,1,Stakeholder Comm,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3610,1,Argue and Debate,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
+COM,3660,2,EC: Brand Comm & Strategy,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,roger beasley,
+COM,3690,1,Political Comm,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,erin michelle ash,
+COM,3690,2,Political Comm,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3720,1,Digital Analytics in Brand Com,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,alicia ni littleton,
+COM,3730,1,Media Management in Brand Comm,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,william reynolds,
+COM,4040,1,Media Comm & Social Identities,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,chenjerai kumanyika,
+COM,4040,2,Media Comm & Social Identities,0.47,0.2,0.27,0.07,0.0,0.0,0.0,0.0,chenjerai kumanyika,
+COM,4260,1,Social Media and Sports Comm,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,john steven spinda,
+COM,4310,1,Legal Communication Trial,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
+COM,4700,1,Comm & Health,0.29,0.65,0.0,0.06,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,4950,1,Senior Capstone,0.9,0.07,0.0,0.0,0.03,0.0,0.0,0.0,erin michelle ash,
+COM,4980,1,Acad & Prof Dev II,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,joseph mazer,
+COM,8020,1,Communication Theory II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,chenjerai kumanyika,
+COM,8110,1,Comm Research Methods II,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+CPSC,1010,1,Computer Science I,0.24,0.32,0.18,0.12,0.09,0.0,0.0,0.06,catherine hochrine,
+CPSC,1010,2,Computer Science I,0.39,0.13,0.18,0.11,0.11,0.0,0.0,0.08,catherine hochrine,
+CPSC,1010,3,Computer Science I,0.33,0.13,0.24,0.13,0.07,0.0,0.0,0.11,yvon feaster,
+CPSC,1020,1,Computer Science II,0.53,0.3,0.06,0.02,0.04,0.0,0.0,0.04,yvon feaster,
+CPSC,1020,2,Computer Science II,0.31,0.48,0.21,0.0,0.0,0.0,0.0,0.0,lanny sitanayah,
+CPSC,1020,3,Computer Science II,0.32,0.32,0.27,0.07,0.02,0.0,0.0,0.0,christopher plaue,
+CPSC,1110,1,Intro to Programming in C,0.54,0.16,0.11,0.03,0.08,0.0,0.0,0.08,catherine hochrine,
+CPSC,1110,2,Intro to Programming in C,0.78,0.07,0.04,0.0,0.04,0.0,0.0,0.07,wanda moses,
+CPSC,1110,3,Intro to Programming in C,0.68,0.14,0.09,0.0,0.05,0.0,0.0,0.05,wanda moses,
+CPSC,2070,1,Discrete Structures,0.14,0.38,0.31,0.1,0.03,0.0,0.0,0.03,sandra hedetniemi,
+CPSC,2070,401,Discrete Structures,0.43,0.3,0.22,0.0,0.01,0.0,0.0,0.04,larry hodges,
+CPSC,2100,1,Progrmng Methodology,0.43,0.23,0.17,0.07,0.0,0.0,0.0,0.1,rose lowe,
+CPSC,2120,1,Algs/Data Structures,0.36,0.28,0.24,0.07,0.04,0.0,0.0,0.01,wayne goddard,
+CPSC,2150,1,Software Dev,0.24,0.25,0.27,0.12,0.07,0.0,0.0,0.05,blair madiso durkee,
+CPSC,2150,2,Software Dev Foundations,0.66,0.26,0.05,0.0,0.02,0.0,0.0,0.02,joseph isaac,
+CPSC,2200,1,Microcomputer Appl,0.42,0.21,0.21,0.11,0.05,0.0,0.0,0.0,renee lambert,
+CPSC,2200,2,Microcomputer Appl,0.45,0.3,0.05,0.1,0.0,0.0,0.0,0.1,renee lambert,
+CPSC,2310,1,Intro Computer Org,0.44,0.26,0.21,0.07,0.02,0.0,0.0,0.0,rose lowe,
+CPSC,2310,2,Intro Computer Org,0.41,0.24,0.12,0.15,0.07,0.0,0.0,0.0,rose lowe,
+CPSC,2910,1,Prof Issues I,0.86,0.07,0.0,0.07,0.0,0.0,0.0,0.0,renee lambert,
+CPSC,2910,2,Prof Issues I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,renee lambert,
+CPSC,2910,3,Prof Issues I,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,renee lambert,
+CPSC,2910,4,Prof Issues I,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,james jones,
+CPSC,3220,1,Intro to Operating Systems,0.18,0.28,0.21,0.07,0.08,0.0,0.0,0.18,jacob sorber,
+CPSC,3300,1,Computer Systems Org,0.2,0.32,0.33,0.09,0.04,0.0,0.0,0.01,mark smotherman,
+CPSC,3500,1,Foundations of Computer Sci,0.15,0.2,0.48,0.03,0.06,0.0,0.0,0.08,ilya mark safro,
+CPSC,3520,1,Programming Systems,0.42,0.32,0.16,0.0,0.04,0.0,0.0,0.06,robert schalkoff,
+CPSC,3600,1,Network Programming,0.07,0.3,0.29,0.06,0.07,0.0,0.0,0.2,sekou lionel remy,
+CPSC,3620,1,Distributed/Cluster Computing,0.15,0.37,0.42,0.0,0.04,0.0,0.0,0.01,amy apon,
+CPSC,3720,1,Software Engineering,0.39,0.28,0.21,0.04,0.02,0.0,0.0,0.07,stephen schaub,
+CPSC,3990,3,Advanced CI: Extreme Orange,0.59,0.24,0.12,0.0,0.0,0.0,0.0,0.06,james martin,
+CPSC,4050,1,Computer Graphics,0.26,0.26,0.22,0.0,0.19,0.0,0.0,0.07,jerry tessendorf,
+CPSC,4140,1,Human and Computer Interaction,0.41,0.34,0.1,0.0,0.07,0.0,0.0,0.07,sabarish venka babu,
+CPSC,4140,2,Human and Computer Interaction,0.14,0.78,0.03,0.0,0.03,0.0,0.0,0.03,kelly caine,
+CPSC,4160,1,2-D Game Engine Construction,0.24,0.34,0.22,0.07,0.1,0.0,0.0,0.02,brian malloy,
+CPSC,4240,1,System Admin and Security,0.11,0.51,0.26,0.09,0.0,0.0,0.0,0.03,james martin,
+CPSC,4620,1,Database Management Systems,0.24,0.6,0.12,0.0,0.04,0.0,0.0,0.0,zijun wang,
+CPSC,4820,1,Selected Topics: Android Dev,0.56,0.25,0.0,0.0,0.0,0.0,0.0,0.19,roy pargas,
+CPSC,4820,2,Special Topics: Data Science,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,
+CPSC,4910,1,Professional Issues II,0.9,0.02,0.05,0.0,0.02,0.0,0.0,0.02,james jones,
+CPSC,6050,1,Computer Graphics,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,robert geist,
+CPSC,6140,1,Human and Computer Interaction,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
+CPSC,6140,2,Human and Computer Interaction,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
+CPSC,6160,1,2-D Game Engine Construction,0.43,0.35,0.09,0.0,0.0,0.0,0.0,0.13,brian malloy,
+CPSC,6240,1,System Admin and Security,0.31,0.44,0.19,0.0,0.0,0.0,0.0,0.06,james martin,
+CPSC,6550,1,Computational Science,0.5,0.19,0.25,0.0,0.0,0.0,0.0,0.06,xizhou feng,
+CPSC,6620,1,Database Management Systems,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,zijun wang,
+CPSC,6820,1,Selected Topics: Android Dev,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,roy pargas,
+CPSC,6820,2,Special Topics: Data Science,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,
+CPSC,8110,1,Character Animation,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,christina sop joerg,
+CPSC,8220,1,Case Study in Operating Sys,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,
+CPSC,8280,1,Theory of Program. Languages,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,murali sitaraman,
+CPSC,8400,1,Design & Anlys of Algorithms,0.19,0.34,0.34,0.0,0.08,0.0,0.0,0.06,brian christop dean,
+CPSC,8620,1,Database Mngmt System Design,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,
+CPSC,8650,1,Data Mining,0.33,0.46,0.17,0.0,0.0,0.0,0.0,0.04,zijun wang,
+CPSC,8750,1,Software Architectur,0.71,0.2,0.06,0.0,0.0,0.0,0.0,0.02,john mcgregor,
+CRP,8020,1,Site Planning,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,clifford dona ellis,
+CRP,8040,1,Land Use Analysis,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,stephen sperry,
+CRP,8050,1,Plning Theory & Hist,0.48,0.38,0.05,0.0,0.1,0.0,0.0,0.0,mickey lauria,
+CRP,8090,1,Current Issues,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,barry nocks,
+CRP,8130,1,Transportation Plan,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,eric morris,
+CRP,8200,1,Negotiation,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
+CRP,8220,1,Urban Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+CRP,8890,3,Sel Top-Geodesign w/ City Eng,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
+CRP,8900,3,Dir Studies in City & Reg Plan,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,clifford dona ellis,
+CRP,8900,8,Dir Studies in City & Reg Plan,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,stephen sperry,
+CSM,1500,1,Constr Prob Solving,0.52,0.35,0.09,0.0,0.0,0.0,0.0,0.04,jason lucas,
+CSM,1500,2,Constr Prob Solving,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,1500,3,Constr Prob Solving,0.48,0.39,0.13,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,2020,1,Structures II,0.32,0.32,0.19,0.16,0.0,0.0,0.0,0.0,shima clarke,
+CSM,2020,2,Structures II,0.31,0.34,0.21,0.14,0.0,0.0,0.0,0.0,shima clarke,
+CSM,2040,1,Cont Documents,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2040,2,Cont Documents,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2050,1,Mats & Methods II,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,2050,2,Mats & Methods II,0.55,0.41,0.03,0.0,0.0,0.0,0.0,0.0,joseph wintz,
+CSM,3050,1,Envir Systems II,0.33,0.42,0.17,0.04,0.0,0.04,0.0,0.0,joseph mich burgett,
+CSM,3050,2,Envir Systems II,0.17,0.63,0.21,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3520,1,Const Scheduling,0.36,0.29,0.18,0.04,0.0,0.14,0.0,0.0,dennis bausman,
+CSM,3520,2,Const Scheduling,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,3530,1,Const Estimating II,0.12,0.69,0.19,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,3530,2,Const Estimating II,0.09,0.73,0.14,0.05,0.0,0.0,0.0,0.0,christine piper,
+CSM,4540,1,Const Capstone,0.43,0.39,0.17,0.0,0.0,0.0,0.0,0.0,james packer smith,
+CSM,4540,2,Const Capstone,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,james packer smith,
+CSM,8620,1,Personnel Mgt & Neg,0.0,0.72,0.28,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CSM,8620,400,Personnel Mgt & Neg,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.65,0.33,0.03,susan whorton,
+CU,1010,1,Univ Success Skills,0.37,0.33,0.1,0.03,0.1,0.0,0.0,0.07,emma reynol reabold,
+CU,1010,2,Univ Success Skills,0.61,0.23,0.03,0.03,0.03,0.0,0.0,0.06,mary mcp von kaenel,
+CU,1010,3,Univ Success Skills,0.43,0.3,0.1,0.07,0.03,0.0,0.0,0.07,cari allyn brooks,
+CU,1010,6,Univ Success Skills,0.32,0.25,0.07,0.04,0.21,0.0,0.0,0.11,ashley crisp,
+CU,1400,1,The Entrepreneurial Mindset,0.46,0.39,0.07,0.0,0.06,0.0,0.0,0.01,john michael hannon,
+CU,1410,1,"Creativity, Innovation & Entr",0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
+CU,1970,1,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.91,0.05,0.05,laurel ann whisler,
+CU,2010,1,Sustainability Leadership,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,jennifer marg goree,
+DANC,1300,1,Tap Dance I,0.75,0.1,0.05,0.0,0.0,0.0,0.0,0.1,cheryl hosler,
+DANC,1400,1,Jazz Dance I,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,cheryl hosler,
+DPA,4010,1,Tech Foundations II,0.09,0.09,0.09,0.27,0.18,0.0,0.0,0.27,donald henry house,
+DPA,4030,1,Vis Foundations II,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,david stewart donar,
+DPA,4030,2,Vis Foundations II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
+ECE,2010,1,Logic and Computing Devices,0.31,0.24,0.17,0.15,0.07,0.0,0.0,0.06,lin zhu,
+ECE,2020,1,Electric Circuits I,0.22,0.26,0.22,0.15,0.09,0.0,0.0,0.06,william harrell,
+ECE,2070,1,Basic Electrical Engineering,0.44,0.3,0.11,0.07,0.04,0.0,0.0,0.03,william th kolodzey,
+ECE,2070,2,Basic Electrical Engineering,0.41,0.37,0.17,0.04,0.0,0.0,0.0,0.01,amir ahmed asif,
+ECE,2070,3,Basic Electrical Engineering,0.17,0.41,0.27,0.03,0.07,0.0,0.0,0.06,hai xiao,
+ECE,2080,2,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,3,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
+ECE,2080,6,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,7,Basic Electrical Engr Lab,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,8,Basic Electrical Engr Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,9,Basic Electrical Engr Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,11,Basic Electrical Engr Lab,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,12,Basic Electrical Engr Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,13,Basic Electrical Engr Lab,0.89,0.0,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,20,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2110,1,Elec Engr Lab I,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,apoorva dee kapadia,
+ECE,2110,2,Elec Engr Lab I,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2220,1,Syst Prog Concept,0.29,0.37,0.14,0.04,0.06,0.0,0.0,0.1,william reid,
+ECE,2230,1,Comp Sys Eng,0.14,0.21,0.29,0.11,0.11,0.0,0.0,0.14,harlan russell,
+ECE,2620,1,Electric Circuits II,0.38,0.32,0.22,0.03,0.02,0.0,0.0,0.03,richard groff,
+ECE,2720,1,Comp Organization,0.26,0.4,0.27,0.03,0.03,0.0,0.0,0.02,william reid,
+ECE,2730,1,Computer Org Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2730,2,Computer Org Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2730,6,Computer Org Lab,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
+ECE,2730,8,Computer Org Lab,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2730,9,Computer Org Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,3,Electrical Engineering Lab III,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,4,Electrical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,5,Electrical Engineering Lab III,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3170,1,Rand Signal Analysis,0.15,0.23,0.36,0.12,0.07,0.0,0.0,0.06,stephen hubbard,
+ECE,3200,1,Electronics I,0.16,0.2,0.25,0.19,0.16,0.0,0.0,0.04,stephen hubbard,
+ECE,3210,1,Electronics II,0.35,0.37,0.12,0.1,0.04,0.0,0.0,0.02,stephen hubbard,
+ECE,3220,1,Intro Operating Sys,0.11,0.26,0.3,0.04,0.0,0.0,0.0,0.3,jacob sorber,
+ECE,3270,1,Dig Comp Design,0.09,0.34,0.25,0.13,0.13,0.0,0.0,0.06,melissa crawl smith,
+ECE,3300,1,Signals & Systems,0.17,0.16,0.31,0.19,0.08,0.0,0.0,0.09,carl baum,
+ECE,3520,1,Programming Systems,0.4,0.44,0.12,0.0,0.0,0.0,0.0,0.04,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.36,0.31,0.19,0.06,0.08,0.0,0.0,0.0,edward collins,
+ECE,3710,1,Microcontr Interface,0.4,0.31,0.1,0.09,0.07,0.0,0.0,0.03,william reid,
+ECE,3720,3,Micro Int Lab,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,5,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,7,Micro Int Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3800,1,Electromagnetics,0.11,0.22,0.4,0.13,0.11,0.0,0.0,0.03,anthony martin,
+ECE,3810,1,Field Waves & Ckts,0.32,0.32,0.3,0.05,0.02,0.0,0.0,0.0,eric gordon johnson,
+ECE,4090,1,Intr to Linear Control Systems,0.63,0.24,0.06,0.02,0.02,0.0,0.0,0.02,apoorva dee kapadia,
+ECE,4190,1,Elec Mach and Drives,0.38,0.27,0.27,0.04,0.0,0.0,0.0,0.04,keith corzine,
+ECE,4200,1,Renewable Energy,0.28,0.23,0.23,0.1,0.03,0.0,0.0,0.13,elham makram,
+ECE,4270,1,Communications Sys,0.38,0.21,0.15,0.13,0.09,0.0,0.0,0.04,madhabi manandhar,
+ECE,4380,1,Computer Commun,0.29,0.27,0.29,0.05,0.05,0.0,0.0,0.05,harlan russell,
+ECE,4400,1,Local Computer Nets,0.22,0.57,0.16,0.0,0.0,0.0,0.0,0.05,kuang-ching wang,
+ECE,4460,1,Antennas,0.58,0.25,0.08,0.08,0.0,0.0,0.0,0.0,anthony martin,
+ECE,4680,1,Embedded Computing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,
+ECE,4950,1,Int Sys Design I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4960,1,Int Sys Design II,0.56,0.3,0.13,0.0,0.0,0.0,0.0,0.01,richard groff,
+ECE,4990,14,Creative Inq-Elec & Comp Engr,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,
+ECE,6320,1,Instrumentation,0.23,0.69,0.08,0.0,0.0,0.0,0.0,0.0,goutam koley,
+ECE,6370,1,Microelectromechanical Systems,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,pingshan wang,
+ECE,6380,1,Computer Commun,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
+ECE,6400,1,Local Computer Nets,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,kuang-ching wang,
+ECE,6680,1,Embedded Computing,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,adam hoover,
+ECE,8400,1,Semicond Devices,0.69,0.25,0.0,0.0,0.06,0.0,0.0,0.0,william harrell,
+ECE,8570,1,Coding Theory,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,
+ECE,8630,1,Pwr Sys Dyna & Stab,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,ramtin hadidi,
+ECE,8720,1,Artificial Neurl Net,0.52,0.38,0.05,0.0,0.0,0.0,0.0,0.05,robert schalkoff,
+ECE,8740,1,Adv Nonlinear Cntrl,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,
+ECE,8790,1,FPGA Design & Applications,0.17,0.17,0.57,0.0,0.04,0.0,0.0,0.04,melissa crawl smith,
+ECE,8910,43,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,0.6,0.0,0.4,yongqiang wang,
+ECE,8930,7,Malware Use and Design,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,richard brooks,
+ECON,2000,1,Economic Concepts,0.14,0.39,0.29,0.11,0.0,0.0,0.0,0.07,jonathan orr ernest,
+ECON,2000,2,Economic Concepts,0.35,0.33,0.23,0.05,0.05,0.0,0.0,0.0,jonathan orr ernest,
+ECON,2000,3,Economic Concepts,0.33,0.41,0.13,0.03,0.08,0.0,0.0,0.03,miren ivankovic,
+ECON,2110,1,Principles of Microeconomics,0.39,0.32,0.21,0.03,0.0,0.03,0.0,0.03,robert dew tollison,
+ECON,2110,2,Principles of Microeconomics,0.15,0.36,0.26,0.1,0.08,0.0,0.0,0.05,charles thomas,
+ECON,2110,3,Principles of Microeconomics,0.18,0.28,0.26,0.18,0.1,0.0,0.0,0.0,steven johnson,
+ECON,2110,4,Principles of Microeconomics,0.31,0.26,0.26,0.05,0.1,0.0,0.0,0.02,amanda caitlin kerr,
+ECON,2110,5,Principles of Microeconomics,0.35,0.35,0.28,0.03,0.0,0.0,0.0,0.0,molly espey,
+ECON,2110,6,Principles of Microeconomics,0.24,0.39,0.25,0.01,0.01,0.0,0.0,0.08,benjamin jo schwall,
+ECON,2110,7,Principles of Microeconomics,0.24,0.33,0.2,0.14,0.04,0.0,0.0,0.04,leah jacq kitashima,
+ECON,2110,8,Principles of Microeconomics,0.21,0.42,0.24,0.06,0.03,0.0,0.0,0.03,alexander fiore,
+ECON,2110,10,Principles of Microeconomics,0.16,0.31,0.35,0.08,0.08,0.0,0.0,0.02,richard alan sessa,
+ECON,2110,11,Principles of Microeconomics,0.14,0.35,0.34,0.14,0.0,0.0,0.0,0.03,michael makowsky,
+ECON,2110,12,Principles of Microeconomics,0.28,0.44,0.26,0.03,0.0,0.0,0.0,0.0,molly espey,
+ECON,2120,1,Principles of Macroeconomics,0.11,0.32,0.37,0.16,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,2,Principles of Macroeconomics,0.18,0.12,0.47,0.18,0.0,0.0,0.0,0.06,scott baier,
+ECON,2120,3,Principles of Macroeconomics,0.2,0.3,0.35,0.05,0.1,0.0,0.0,0.0,scott baier,
+ECON,2120,4,Principles of Macroeconomics,0.26,0.32,0.32,0.05,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,5,Principles of Macroeconomics,0.3,0.35,0.25,0.1,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,6,Principles of Macroeconomics,0.17,0.33,0.39,0.06,0.0,0.0,0.0,0.06,scott baier,
+ECON,2120,7,Principles of Macroeconomics,0.28,0.33,0.22,0.17,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,8,Principles of Macroeconomics,0.21,0.37,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,9,Principles of Macroeconomics,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,10,Principles of Macroeconomics,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,scott baier,
+ECON,2120,11,Principles of Macroeconomics,0.26,0.26,0.42,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,12,Principles of Macroeconomics,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,13,Principles of Macroeconomics,0.37,0.11,0.32,0.05,0.11,0.0,0.0,0.05,scott baier,
+ECON,2120,14,Principles of Macroeconomics,0.26,0.47,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,15,Principles of Macroeconomics,0.43,0.38,0.19,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,16,Principles of Macroeconomics,0.17,0.17,0.67,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,17,Principles of Macroeconomics,0.37,0.37,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,18,Principles of Macroeconomics,0.42,0.26,0.16,0.11,0.0,0.0,0.0,0.05,scott baier,
+ECON,2120,19,Principles of Macroeconomics,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,20,Principles of Macroeconomics,0.25,0.31,0.36,0.07,0.0,0.0,0.0,0.0,peter david lorenz,
+ECON,2120,21,Principles of Macroeconomics,0.61,0.32,0.06,0.0,0.02,0.0,0.0,0.0,mallika garg,
+ECON,2120,22,Principles of Macroeconomics,0.22,0.39,0.27,0.07,0.0,0.0,0.0,0.05,andew swanson,
+ECON,2120,23,Principles of Macroeconomics,0.36,0.39,0.08,0.06,0.08,0.0,0.0,0.03,shan jiang,
+ECON,2120,24,Principles of Macroeconomics,0.2,0.58,0.19,0.03,0.01,0.0,0.0,0.0,scott barkowski,
+ECON,2120,25,Principles of Macroeconomics,0.19,0.56,0.19,0.06,0.0,0.0,0.0,0.0,scott barkowski,
+ECON,2120,26,Principles of Macroeconomics,0.18,0.06,0.15,0.21,0.06,0.0,0.0,0.33,ralph charles allen,
+ECON,2120,27,Principles of Macroeconomics,0.21,0.45,0.27,0.0,0.0,0.0,0.0,0.06,chen wang,
+ECON,3020,1,Money and Banking,0.15,0.36,0.3,0.03,0.0,0.0,0.0,0.15,randall scot cragun,
+ECON,3060,1,Managerial Economics,0.19,0.36,0.17,0.11,0.06,0.0,0.0,0.11,jacob burgdorf,
+ECON,3100,1,International Econ,0.16,0.28,0.19,0.16,0.16,0.0,0.0,0.06,michal jerzmanowski,
+ECON,3140,1,Intermediate Micro,0.17,0.24,0.27,0.15,0.1,0.0,0.0,0.07,robert kennet fleck,
+ECON,3140,2,Intermediate Micro,0.19,0.3,0.35,0.0,0.03,0.0,0.0,0.14,kevin ka kin tsui,
+ECON,3140,3,Intermediate Micro,0.18,0.3,0.25,0.1,0.08,0.0,0.0,0.1,frederick hanssen,
+ECON,3150,1,Intermediate Macro,0.3,0.21,0.21,0.06,0.06,0.0,0.0,0.15,randall scot cragun,
+ECON,3150,2,Intermediate Macro,0.51,0.15,0.18,0.08,0.03,0.0,0.0,0.05,sergey vla mityakov,
+ECON,3190,2,Environmental Econ,0.21,0.43,0.21,0.07,0.04,0.0,0.0,0.04,scott templeton,
+ECON,3400,1,Behavioral Economics,0.51,0.4,0.09,0.0,0.0,0.0,0.0,0.0,daniel wood,
+ECON,3440,1,Property Rights,0.11,0.26,0.3,0.19,0.07,0.0,0.0,0.07,dar litsukova-bokar,
+ECON,3600,1,Public Choice,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,robert dew tollison,
+ECON,4010,1,Labor Mkt Analysis,0.31,0.54,0.12,0.0,0.04,0.0,0.0,0.0,curtis simon,
+ECON,4020,1,Law and Economics,0.23,0.48,0.23,0.0,0.03,0.0,0.0,0.03,thomas wins hazlett,
+ECON,4050,1,Intro to Econometric,0.35,0.31,0.15,0.1,0.08,0.0,0.0,0.02,scott baier,
+ECON,4060,1,Advanced Econometric,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,babur de los santos,
+ECON,4240,1,Organization of Ind,0.42,0.38,0.13,0.04,0.04,0.0,0.0,0.0,matthew lewis,
+ECON,4260,1,Sem Sport Economics,0.52,0.43,0.0,0.0,0.04,0.0,0.0,0.0,raymond sauer,
+ECON,4270,1,Dev American Economy,0.33,0.44,0.15,0.07,0.0,0.0,0.0,0.0,howard ne bodenhorn,
+ECON,4280,1,Cost-Benefit Anlysis,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,william dougan,
+ECON,4290,1,Economics of Energy Markets,0.46,0.35,0.12,0.0,0.04,0.0,0.0,0.04,matthew lewis,
+ECON,4400,1,Game Theory,0.25,0.25,0.42,0.0,0.08,0.0,0.0,0.0,charles thomas,
+ECON,6020,1,Law and Economics,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,thomas wins hazlett,
+ECON,6060,1,Advanced Econometric,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,babur de los santos,
+ECON,6400,1,Game Theory,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,charles thomas,
+ECON,8020,2,Adv Econ Concepts and Applic I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
+ECON,8050,1,Macroeconomic Theory,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,
+ECON,8070,1,Econometrics II,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,chungsang lam,
+ECON,8110,1,Econ of Environment,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,scott templeton,
+ECON,8200,1,Public Finance,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,william dougan,
+ECON,8990,4,History of Econ-Modern Macro,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michel devroey,
+ECON,9010,2,Price Theory,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel wood,
+ECON,9090,1,Time-Series Econ,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
+ED,3970,7,Creative Inquiry in Education,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,david matthew boyer,
+ED,3970,28,Creative Inquiry Education,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,8380,504,Becoming a Reflective Praction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,
+ED,8380,531,Literacy Lessons for Indiv II,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,morgan jones bowie,
+ED,8380,539,Literacy Lessons for Indiv II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,andrea chri overton,
+ED,8390,500,Intro to Linguistics,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,daniel smith,
+ED,8670,500,Practicum in ESOL Instruction,0.69,0.08,0.08,0.0,0.08,0.0,0.0,0.08,margaret mar warner,
+EDC,3900,2,Skills for Stu Leads,0.87,0.0,0.07,0.0,0.0,0.0,0.0,0.07,eric pernotto,
+EDC,3900,4,Skills for Stu Leads,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,eric pernotto,
+EDEC,2200,1,Family/School/Com,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEL,4510,1,Elem Methods in Science Tchg,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
+EDEL,4520,1,Elem Methods Math Teaching,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+EDEL,4870,1,Ele Meth Soc Studies,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
+EDF,3010,1,Principles of American Educat,0.66,0.23,0.09,0.0,0.03,0.0,0.0,0.0,suzanne rosenblith,
+EDF,3010,2,Principles of American Educat,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,nafees mohamma khan,
+EDF,3010,3,Principles of American Educat,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
+EDF,3020,1,Educational Psychology,0.41,0.44,0.09,0.06,0.0,0.0,0.0,0.0,penelope mar vargas,
+EDF,3020,3,Educational Psychology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
+EDF,3020,6,Educational Psychology,0.4,0.46,0.14,0.0,0.0,0.0,0.0,0.0,penelope mar vargas,
+EDF,3340,1,Child Growth and Development,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
+EDF,3340,2,Child Growth and Development,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
+EDF,4800,2,Digital Media & Learning,0.91,0.05,0.05,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,300,Digital Media & Learning,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,david matthew boyer,
+EDF,8080,300,Ed Tests and Measure,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,deborah switzer,
+EDL,7150,502,Sch & Comm Relations,0.86,0.05,0.0,0.0,0.05,0.0,0.0,0.05,frederick buskey,
+EDL,7350,500,Educational Eval,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert knoeppel,
+EDL,7400,502,Curr Plan: Sch Adm,0.71,0.21,0.0,0.0,0.04,0.0,0.0,0.04,elizabeth reynolds,
+EDL,7510,400,El Prin & Spv Ex II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth reynolds,
+EDL,7650,1,Assessment Hi Edu,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,
+EDL,7650,2,Assessment Hi Edu,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,robin phelps-ward,
+EDL,8390,400,Research in Ed L,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,
+EDL,9110,501,Systematic Inq Ed L,0.47,0.4,0.0,0.0,0.0,0.0,0.0,0.13,jane lindle,
+EDLT,4580,1,Early Literacy: Birth-Kindergn,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4620,1,Reading Children's Lit in Elem,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,8100,400,Foundations: Reading & Writing,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,phillip mich wilder,
+EDLT,8150,500,Guided Reading & Writng Scaffo,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,susan kin fullerton,
+EDLT,8270,300,Content Area Rdg/Wtg-MS & HS,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8270,501,Content Area Rdg/Wtg-MS & HS,0.85,0.03,0.0,0.0,0.03,0.0,0.0,0.1,phillip mich wilder,
+EDSA,8190,1,Contemporary College Student,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,michelle boettcher,
+EDSC,4370,1,Technology in Math,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,
+EDSP,3700,2,Intro to Special Education,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,michael wayne riley,
+EDSP,3700,3,Intro to Special Education,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,pamela stecker,
+EDSP,3750,1,Early Intervention Spec Needs,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sara moo mackiewicz,
+EDSP,4910,1,Ed Assess Ind W/Dis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
+EDSP,4950,1,Comm & Collab Sp Ed,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sara moo mackiewicz,
+EES,2020,1,Environ Engr Fundamentals II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
+EES,3100,2,Intro to Nuclear Engineering,0.2,0.27,0.07,0.0,0.07,0.0,0.0,0.4,timothy devol,
+EES,4010,1,Environmental Engr,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.46,0.34,0.09,0.06,0.0,0.0,0.0,0.06,thomas overcamp,
+EES,4750,1,Capstone Design Project,0.69,0.25,0.03,0.0,0.0,0.0,0.0,0.03,david allen ladner,
+EES,4840,2,Solid Waste Mgt,0.35,0.49,0.16,0.0,0.0,0.0,0.0,0.0,thomas overcamp,
+EES,4850,2,Hazard Waste Management,0.16,0.47,0.29,0.05,0.0,0.0,0.0,0.03,mark schlautman,
+EES,6110,1,Rad Detection Mmt,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,timothy devol,
+EES,8030,1,Phy/Chem Ops W/WW T,0.36,0.55,0.0,0.0,0.09,0.0,0.0,0.0,ezra lucas ho cates,
+EES,8040,1,Biochem Ops WW Trt,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,david freedman,
+EES,8090,1,Subsurface Remed Mod,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,ronald falta,
+EES,8120,1,Env Nuclear Engr,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,lin shuller-nickles,
+ELE,3010,1,Intro to Entre,0.05,0.48,0.4,0.05,0.03,0.0,0.0,0.0,ashley will parnell,
+ELE,3010,2,Intro to Entre,0.32,0.61,0.05,0.0,0.0,0.0,0.0,0.02,chad navis,
+ELE,3010,3,Intro to Entre,0.39,0.59,0.02,0.0,0.0,0.0,0.0,0.0,chad navis,
+ELE,4010,1,Exec Lead & Entr II,0.13,0.38,0.35,0.15,0.0,0.0,0.0,0.0,ashley will parnell,
+ENGL,1030,1,Accelerated Composition,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,emily anne boyter,
+ENGL,1030,2,Accelerated Composition,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,kristen joy hixon,
+ENGL,1030,3,Accelerated Composition,0.35,0.59,0.0,0.0,0.0,0.0,0.0,0.06,mary dickens,
+ENGL,1030,4,Accelerated Composition,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,caroline ca swanson,
+ENGL,1030,7,Accelerated Composition,0.75,0.1,0.0,0.0,0.1,0.0,0.0,0.05,kristen joy hixon,
+ENGL,1030,8,Accelerated Composition,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,todd rossi smith,
+ENGL,1030,9,Accelerated Composition,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,mary dickens,
+ENGL,1030,10,Accelerated Composition,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,teneshia head,
+ENGL,1030,11,Accelerated Composition,0.56,0.39,0.0,0.0,0.06,0.0,0.0,0.0,caroline ca swanson,
+ENGL,1030,12,Accelerated Composition,0.75,0.15,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,
+ENGL,1030,13,Accelerated Composition,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,rebecca nico shaver,
+ENGL,1030,14,Accelerated Composition,0.33,0.52,0.1,0.05,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,1030,15,Accelerated Composition,0.45,0.2,0.2,0.1,0.0,0.0,0.0,0.05,andrew mathas,
+ENGL,1030,16,Accelerated Composition,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,charlotte powell,
+ENGL,1030,17,Accelerated Composition,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,karen mary stewart,
+ENGL,1030,18,Accelerated Composition,0.8,0.05,0.05,0.0,0.0,0.0,0.0,0.1,daniel frank,
+ENGL,1030,19,Accelerated Composition,0.8,0.1,0.0,0.05,0.0,0.0,0.0,0.05,brian lee gaines,
+ENGL,1030,20,Accelerated Composition,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,rebecca nico shaver,
+ENGL,1030,21,Accelerated Composition,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,charlotte powell,
+ENGL,1030,22,Accelerated Composition,0.8,0.05,0.1,0.0,0.05,0.0,0.0,0.0,samuel jacks fuller,
+ENGL,1030,23,Accelerated Composition,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,shawn andrew stowe,
+ENGL,1030,24,Accelerated Composition,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,1030,25,Accelerated Composition,0.62,0.15,0.08,0.08,0.0,0.0,0.0,0.08,brian lee gaines,
+ENGL,1030,26,Accelerated Composition,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,1030,30,Accelerated Composition,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,eda ozyesilpinar,
+ENGL,1030,31,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kristen gay,
+ENGL,1030,32,Accelerated Composition,0.76,0.0,0.06,0.06,0.0,0.0,0.0,0.12,katie jo vann,
+ENGL,1030,35,Accelerated Composition,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,jack butts,
+ENGL,1030,36,Accelerated Composition,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,april obrien,
+ENGL,1030,37,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kristen gay,
+ENGL,1030,39,Accelerated Composition,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,joshua wood,
+ENGL,1030,41,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,kellie eliz osborne,
+ENGL,1030,42,Accelerated Composition,0.65,0.25,0.05,0.0,0.0,0.0,0.0,0.05,jennifer moeder,
+ENGL,1030,44,Accelerated Composition,0.73,0.07,0.13,0.0,0.0,0.0,0.0,0.07,eric stephens,
+ENGL,1030,46,Accelerated Composition,0.9,0.0,0.05,0.0,0.05,0.0,0.0,0.0,eric stephens,
+ENGL,1030,51,Accelerated Composition,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,danielle shuff,
+ENGL,1030,53,Accelerated Composition,0.7,0.05,0.05,0.15,0.05,0.0,0.0,0.0,kellie eliz osborne,
+ENGL,1030,54,Accelerated Composition,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,jack butts,
+ENGL,1030,55,Accelerated Composition,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,stephen quigley,
+ENGL,1030,56,Accelerated Composition,0.8,0.0,0.1,0.0,0.05,0.0,0.0,0.05,jennifer moeder,
+ENGL,1030,58,Accelerated Composition,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,daniel frank,
+ENGL,1030,60,Accelerated Composition,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,danielle shuff,
+ENGL,1030,64,Accelerated Composition,0.71,0.14,0.07,0.0,0.07,0.0,0.0,0.0,madison ali johnson,
+ENGL,1030,65,Accelerated Composition,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,stephen quigley,
+ENGL,1030,68,Accelerated Composition,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,70,Accelerated Composition,0.63,0.16,0.05,0.0,0.11,0.0,0.0,0.05,joshua wood,
+ENGL,1030,71,Accelerated Composition,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,1030,72,Accelerated Composition,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,madison ali johnson,
+ENGL,1030,73,Accelerated Composition,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,teneshia head,
+ENGL,1030,502,Accelerated Composition,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,edward collins,
+ENGL,2120,1,World Literature,0.17,0.72,0.06,0.0,0.06,0.0,0.0,0.0,gabriel and hankins,
+ENGL,2120,3,World Literature,0.5,0.21,0.04,0.08,0.0,0.0,0.0,0.17,candace wiley,
+ENGL,2120,6,World Literature,0.46,0.35,0.12,0.0,0.0,0.0,0.0,0.08,candace wiley,
+ENGL,2120,7,World Literature,0.37,0.27,0.23,0.07,0.03,0.0,0.0,0.03,andrew mathas,
+ENGL,2120,9,World Literature,0.34,0.34,0.17,0.03,0.07,0.0,0.0,0.03,andrew mathas,
+ENGL,2120,11,World Literature,0.57,0.29,0.11,0.0,0.04,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,2120,12,World Literature,0.66,0.14,0.21,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,2120,13,World Literature,0.27,0.57,0.17,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2120,14,World Literature,0.17,0.45,0.17,0.07,0.03,0.0,0.0,0.1,meg woosley-goodman,
+ENGL,2120,15,World Literature (HON),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,meg woosley-goodman,True
+ENGL,2120,16,World Literature,0.19,0.48,0.22,0.0,0.07,0.0,0.0,0.04,meg woosley-goodman,
+ENGL,2120,17,World Literature,0.63,0.27,0.03,0.0,0.0,0.0,0.0,0.07,lucian ghita,
+ENGL,2120,18,World Literature,0.59,0.21,0.14,0.0,0.0,0.0,0.0,0.07,lucian ghita,
+ENGL,2120,19,World Literature,0.43,0.39,0.04,0.07,0.0,0.0,0.0,0.07,sarah mae cooper,
+ENGL,2130,1,British Literature,0.7,0.23,0.0,0.0,0.0,0.0,0.0,0.07,jeffrey fallis,
+ENGL,2130,2,British Literature,0.45,0.38,0.1,0.0,0.0,0.0,0.0,0.07,christopher benson,
+ENGL,2130,3,British Literature,0.57,0.33,0.07,0.0,0.03,0.0,0.0,0.0,christopher benson,
+ENGL,2130,4,British Literature,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
+ENGL,2130,5,British Literature,0.76,0.14,0.03,0.03,0.0,0.0,0.0,0.03,stephanie stripling,
+ENGL,2130,6,British Literature,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,jeffrey fallis,
+ENGL,2130,7,British Literature,0.66,0.31,0.0,0.0,0.0,0.0,0.0,0.03,jeffrey fallis,
+ENGL,2130,10,British Literature,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,krist aldebol-hazle,
+ENGL,2130,11,British Literature,0.79,0.11,0.04,0.04,0.0,0.0,0.0,0.04,krist aldebol-hazle,
+ENGL,2130,12,British Literature,0.73,0.23,0.0,0.0,0.0,0.0,0.0,0.03,lucian ghita,
+ENGL,2130,13,British Literature,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2140,1,American Literature,0.53,0.27,0.13,0.0,0.03,0.0,0.0,0.03,john morgenstern,
+ENGL,2140,2,American Literature,0.45,0.24,0.14,0.0,0.14,0.0,0.0,0.03,elizabeth stansell,
+ENGL,2140,3,American Literature,0.12,0.31,0.31,0.04,0.04,0.0,0.0,0.19,david charles foltz,
+ENGL,2140,4,American Literature,0.62,0.31,0.03,0.0,0.0,0.0,0.0,0.03,sherri teres allred,
+ENGL,2140,5,American Literature,0.36,0.39,0.04,0.04,0.0,0.0,0.0,0.18,candace wiley,
+ENGL,2140,6,American Literature,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,candace wiley,
+ENGL,2140,7,American Literature,0.62,0.1,0.21,0.03,0.03,0.0,0.0,0.0,sherri teres allred,
+ENGL,2140,8,American Literature,0.84,0.1,0.0,0.0,0.03,0.0,0.0,0.03,geveryl le robinson,
+ENGL,2140,9,American Literature,0.76,0.17,0.03,0.0,0.0,0.0,0.0,0.03,stephanie stripling,
+ENGL,2140,11,American Literature,0.73,0.17,0.03,0.03,0.03,0.0,0.0,0.0,stephanie stripling,
+ENGL,2140,12,American Literature,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
+ENGL,2140,13,American Literature,0.23,0.42,0.31,0.0,0.0,0.0,0.0,0.04,david charles foltz,
+ENGL,2140,14,American Literature,0.07,0.62,0.17,0.0,0.03,0.0,0.0,0.1,rhondda robi thomas,
+ENGL,2140,15,American Literature,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,april susanne pelt,
+ENGL,2140,17,American Literature,0.47,0.33,0.1,0.0,0.03,0.0,0.0,0.07,william stanton,
+ENGL,2140,18,American Literature,0.57,0.23,0.13,0.0,0.03,0.0,0.0,0.03,william stanton,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.53,0.37,0.07,0.03,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.47,0.27,0.17,0.0,0.03,0.0,0.0,0.07,megan no macalystre,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.47,0.33,0.07,0.13,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.8,0.13,0.0,0.0,0.03,0.0,0.0,0.03,alexander kudera,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,alexander kudera,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.22,0.48,0.11,0.0,0.04,0.0,0.0,0.15,karen kettnich,
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.21,0.43,0.25,0.04,0.04,0.0,0.0,0.04,karen kettnich,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.57,0.3,0.1,0.0,0.03,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,sharon kathl nalley,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.23,0.27,0.27,0.04,0.04,0.0,0.0,0.15,david charles foltz,
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.21,0.34,0.31,0.03,0.0,0.0,0.0,0.1,david charles foltz,
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.8,0.13,0.03,0.0,0.0,0.0,0.0,0.03,sharon kathl nalley,
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.0,0.69,0.31,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.38,0.48,0.07,0.03,0.0,0.0,0.0,0.03,john logan pursley,
+ENGL,3000,1,Professional Develop,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,austin gorman,
+ENGL,3040,2,Business Writing,0.73,0.14,0.05,0.0,0.05,0.0,0.0,0.05,philip randall,
+ENGL,3040,3,Business Writing,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,alexander kudera,
+ENGL,3040,5,Business Writing,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3040,13,Business Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3040,14,Business Writing,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,
+ENGL,3040,16,Business Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
+ENGL,3040,17,Business Writing,0.38,0.52,0.0,0.0,0.0,0.0,0.0,0.1,katalin beck,
+ENGL,3040,18,Business Writing,0.24,0.67,0.1,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3040,19,Business Writing,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,3040,20,Business Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sherri teres allred,
+ENGL,3040,22,Business Writing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,austin gorman,
+ENGL,3040,400,Business Writing,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,3100,1,Crit Writ Lit,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,3100,2,Crit Writ Lit,0.39,0.39,0.22,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,
+ENGL,3100,4,Crit Writ Lit,0.19,0.5,0.19,0.06,0.06,0.0,0.0,0.0,erin marina goss,
+ENGL,3120,1,Advanced Composition,0.42,0.37,0.16,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3120,2,Advanced Composition,0.42,0.32,0.05,0.05,0.16,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,1,Technical Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
+ENGL,3140,2,Technical Writing,0.41,0.5,0.09,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,3,Technical Writing,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,adrian carson,
+ENGL,3140,5,Technical Writing,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,crystal pa stephens,
+ENGL,3140,6,Technical Writing,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,christopher benson,
+ENGL,3140,7,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,3140,9,Technical Writing,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,adrian carson,
+ENGL,3140,10,Technical Writing,0.29,0.57,0.1,0.0,0.05,0.0,0.0,0.0,katalin beck,
+ENGL,3140,12,Technical Writing,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,
+ENGL,3140,13,Technical Writing,0.76,0.1,0.05,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,
+ENGL,3140,15,Technical Writing,0.7,0.15,0.0,0.0,0.05,0.0,0.0,0.1,geveryl le robinson,
+ENGL,3140,16,Technical Writing,0.38,0.52,0.0,0.1,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,17,Technical Writing,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3140,18,Technical Writing,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,19,Technical Writing,0.59,0.23,0.14,0.0,0.0,0.0,0.0,0.05,sharon kathl nalley,
+ENGL,3140,20,Technical Writing,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,24,Technical Writing,0.45,0.4,0.05,0.05,0.05,0.0,0.0,0.0,william pulley,
+ENGL,3140,25,Technical Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sean morey,
+ENGL,3150,1,Scientific Writing & Comm,0.5,0.25,0.1,0.05,0.0,0.0,0.0,0.1,william pulley,
+ENGL,3150,2,Scientific Writing & Comm,0.05,0.7,0.1,0.05,0.0,0.0,0.0,0.1,barbara ramirez,
+ENGL,3150,5,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,18,Scientific Writing & Comm,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew jose osborn,
+ENGL,3150,21,Scientific Writing & Comm,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,john conway,
+ENGL,3150,23,Scientific Writing & Comm,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,john conway,
+ENGL,3320,1,Visual Communication,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,david blakesley,
+ENGL,3370,3,Creative Inquiry: English,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,susanna ashton,
+ENGL,3450,1,Structure of Fiction,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,nicholas chri brown,
+ENGL,3460,1,Structure of Poetry,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,angela naimou,
+ENGL,3570,1,Film,0.16,0.58,0.11,0.0,0.11,0.0,0.0,0.05,amy monaghan,
+ENGL,3570,2,Film,0.26,0.58,0.11,0.0,0.0,0.0,0.0,0.05,amy monaghan,
+ENGL,3800,1,Women Writers,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,meg woosley-goodman,
+ENGL,3960,1,Brit Lit Survey I,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,brian mcgrath,
+ENGL,3970,1,Brit Lit Survey II,0.45,0.35,0.15,0.0,0.0,0.0,0.0,0.05,david sweene coombs,
+ENGL,3980,1,Amer Lit Survey I,0.55,0.32,0.0,0.0,0.14,0.0,0.0,0.0,dominic mastroianni,
+ENGL,3980,2,Amer Lit Survey I,0.33,0.38,0.24,0.0,0.05,0.0,0.0,0.0,susanna ashton,
+ENGL,3990,1,Amer Lit Survey II,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,4110,1,Shakespeare,0.24,0.52,0.14,0.05,0.05,0.0,0.0,0.0,andrew lemons,
+ENGL,4150,1,Restor & 18th Cent,0.0,0.67,0.22,0.0,0.06,0.0,0.0,0.06,lee morrissey,
+ENGL,4200,1,Amer Lit to 1799,0.5,0.39,0.0,0.0,0.06,0.0,0.0,0.06,jonathan beec field,
+ENGL,4310,1,Modern Poetry,0.38,0.46,0.08,0.0,0.08,0.0,0.0,0.0,wayne chapman,
+ENGL,4320,1,Modern Fiction,0.31,0.5,0.06,0.06,0.06,0.0,0.0,0.0,gabriel and hankins,
+ENGL,4350,1,Literary Criticism,0.42,0.42,0.05,0.0,0.05,0.0,0.0,0.05,jonathan beec field,
+ENGL,4420,1,Cultural Studies,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,garry bertholf,
+ENGL,4450,1,Fiction Workshop,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,4460,1,Poetry Workshop,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,4520,1,Great Directors,0.33,0.33,0.27,0.0,0.0,0.0,0.0,0.07,agnieszka skrodzka,
+ENGL,4530,1,Sexuality and Cinema,0.33,0.53,0.07,0.07,0.0,0.0,0.0,0.0,agnieszka skrodzka,
+ENGL,4590,2,Spec Top Lang Criticism Theory,0.39,0.28,0.28,0.0,0.06,0.0,0.0,0.0,lindsay carr thomas,
+ENGL,4630,1,Lit to 1699: Old English,0.71,0.18,0.06,0.06,0.0,0.0,0.0,0.0,andrew lemons,
+ENGL,4640,1,Topics in Literature 1700-1899,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,erin marina goss,
+ENGL,4650,1,Topics in Literature from 1900,0.65,0.18,0.06,0.0,0.06,0.0,0.0,0.06,angela naimou,
+ENGL,4750,1,Writing for Media,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,tharon howard,
+ENGL,4830,1,Af Am Lit 1920-Pres,0.69,0.13,0.06,0.0,0.0,0.0,0.0,0.13,garry bertholf,
+ENGL,4890,1,Topics Write & Publ,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,megan eatman,
+ENGL,4920,1,Modern Rhetoric,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,brian mcgrath,
+ENGL,4960,1,Senior Seminar,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,michael lemahieu,
+ENGL,4960,2,Senior Seminar,0.62,0.15,0.15,0.0,0.0,0.0,0.0,0.08,david sweene coombs,
+ENGL,4960,3,Senior Seminar,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,8120,1,Digital Approaches-Lit/Cul Stu,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,lindsay carr thomas,
+ENGL,8500,1,Methods Prof Comm,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tharon howard,
+ENGR,1020,615,Engineering Discipl & Skills,0.17,0.32,0.17,0.11,0.13,0.0,0.0,0.09,ashley childers,
+ENGR,1020,618,Engineering Discipl & Skills,0.11,0.22,0.35,0.05,0.08,0.0,0.0,0.19,ashley childers,
+ENGR,1060,400,Engr Discipline & Skills II,0.0,0.21,0.35,0.15,0.24,0.0,0.0,0.06,ashley childers,
+ENGR,1060,402,Engr Discipline & Skills II,0.0,0.17,0.38,0.22,0.03,0.0,0.0,0.2,michael giebner,
+ENGR,1060,615,Engr Discipline & Skills II,0.1,0.4,0.3,0.1,0.1,0.0,0.0,0.0,ashley childers,
+ENGR,1060,618,Engr Discipline & Skills II,0.06,0.47,0.24,0.18,0.0,0.0,0.0,0.06,ashley childers,
+ENGR,1060,643,Engr Discipline & Skills II,0.03,0.34,0.23,0.23,0.03,0.0,0.0,0.13,michael giebner,
+ENGR,1060,648,Engr Discipline & Skills II,0.03,0.24,0.42,0.11,0.02,0.0,0.0,0.18,michael giebner,
+ENGR,1070,648,Programming & Prob Solving I,0.0,0.33,0.25,0.17,0.17,0.0,0.0,0.08,michael giebner,
+ENGR,1410,121,Programming & Problem Solving,0.18,0.3,0.3,0.07,0.09,0.0,0.0,0.07,william martin,
+ENGR,1410,122,Programming & Problem Solving,0.31,0.54,0.04,0.06,0.02,0.0,0.0,0.02,william martin,
+ENGR,1410,123,Programming & Problem Solving,0.21,0.48,0.13,0.08,0.02,0.0,0.0,0.08,mariah magagnotti,
+ENGR,1410,124,Programming & Problem Solving,0.11,0.6,0.22,0.0,0.07,0.0,0.0,0.0,sheikh moniruz moni,
+ENGR,1410,125,Programming & Problem Solving,0.13,0.28,0.43,0.09,0.02,0.0,0.0,0.04,roksana mahmud,
+ENGR,1410,126,Programming & Problem Solving,0.15,0.31,0.31,0.15,0.02,0.0,0.0,0.06,matthew kent miller,
+ENGR,1410,127,Programming & Problem Solving,0.04,0.43,0.28,0.11,0.09,0.0,0.0,0.06,andrew isaa neptune,
+ENGR,1410,128,Programming & Problem Solving,0.09,0.21,0.39,0.15,0.09,0.0,0.0,0.06,andrew isaa neptune,
+ENGR,1410,621,Programming & Problem Solving,0.43,0.34,0.11,0.04,0.06,0.0,0.0,0.02,elizabeth stephan,
+ENGR,1410,622,Programming & Problem Solving,0.44,0.4,0.04,0.07,0.04,0.0,0.0,0.0,elizabeth stephan,
+ENGR,1410,623,Programming & Problem Solving,0.33,0.25,0.25,0.02,0.08,0.0,0.0,0.06,srinivasarangan rang,
+ENGR,1410,624,Programming & Problem Solving,0.23,0.27,0.23,0.06,0.13,0.0,0.0,0.08,srinivasarangan rang,
+ENGR,1410,625,Programming & Problem Solving,0.27,0.48,0.19,0.04,0.0,0.0,0.0,0.02,steven brandon,
+ENGR,1410,626,Programming & Problem Solving,0.48,0.27,0.17,0.02,0.04,0.0,0.0,0.02,steven brandon,
+ENGR,1410,627,Programming & Problem Solving,0.09,0.29,0.38,0.13,0.02,0.0,0.0,0.09,jonathan maier,
+ENGR,1410,631,Programming & Problem Solving,0.06,0.17,0.29,0.17,0.11,0.0,0.0,0.2,matthew kent miller,
+ENGR,1410,632,Programming & Problem Solving,0.17,0.38,0.26,0.13,0.0,0.0,0.0,0.06,matthew kent miller,
+ENGR,1410,634,Programming & Problem Solving,0.08,0.41,0.24,0.1,0.02,0.0,0.0,0.14,andrew isaa neptune,
+ENGR,1410,636,Programming & Problem Solving,0.13,0.45,0.21,0.02,0.04,0.0,0.0,0.15,mariah magagnotti,
+ENGR,1410,637,Programming & Problem Solving,0.02,0.28,0.33,0.22,0.09,0.0,0.0,0.07,mariah magagnotti,
+ENGR,1510,501,Engineering Skills,0.27,0.3,0.24,0.12,0.06,0.0,0.0,0.0,john minor,
+ENGR,1510,502,Engineering Skills,0.33,0.3,0.13,0.07,0.17,0.0,0.0,0.0,john minor,
+ENGR,1640,502,Engineering MATLAB Programming,0.3,0.2,0.4,0.0,0.1,0.0,0.0,0.0,jonathan maier,
+ENGR,1900,79,CI: Engr I Punkin Chunkin,0.81,0.0,0.0,0.0,0.13,0.0,0.0,0.06,huijuan zhao,
+ENGR,2080,181,Engr Graphics & Machine Design,0.45,0.3,0.13,0.06,0.04,0.0,0.0,0.02,nighat yasmin,
+ENGR,2080,681,Engr Graphics & Machine Design,0.69,0.18,0.1,0.0,0.02,0.0,0.0,0.02,john minor,
+ENGR,2080,682,Engr Graphics & Machine Design,0.7,0.17,0.09,0.0,0.04,0.0,0.0,0.0,sarah grigg,
+ENGR,2080,683,Engr Graphics & Machine Design,0.56,0.22,0.09,0.04,0.04,0.0,0.0,0.06,sarah grigg,
+ENGR,2080,684,Engr Graphics & Machine Design,0.61,0.24,0.07,0.0,0.06,0.0,0.0,0.02,sarah grigg,
+ENGR,2080,685,Engr Graphics & Machine Design,0.47,0.32,0.15,0.02,0.02,0.0,0.0,0.02,rahul sharan renu,
+ENGR,2080,686,Engr Graphics & Machine Design,0.44,0.33,0.13,0.02,0.06,0.0,0.0,0.02,rahul sharan renu,
+ENGR,2080,687,Engr Graphics & Machine Design,0.53,0.21,0.11,0.09,0.04,0.0,0.0,0.02,anthony pau garland,
+ENGR,2080,688,Engr Graphics & Machine Design,0.45,0.32,0.06,0.02,0.08,0.0,0.0,0.08,anthony pau garland,
+ENGR,2100,601,CAD & Engineering Applications,0.54,0.3,0.06,0.06,0.02,0.0,0.0,0.02,kweku tekyi brown,
+ENGR,2100,602,CAD & Engineering Applications,0.57,0.15,0.11,0.04,0.06,0.0,0.0,0.06,kweku tekyi brown,
+ENGR,2100,603,CAD & Engineering Applications,0.51,0.37,0.04,0.0,0.04,0.0,0.0,0.04,nighat yasmin,
+ENGR,2100,604,CAD & Engineering Applications,0.55,0.33,0.06,0.0,0.04,0.0,0.0,0.02,nighat yasmin,
+ENGR,2200,1,Evaluating Innovations,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,sarah grigg,
+ENR,1020,1,Intro to Envir & Natur Res II,0.52,0.22,0.1,0.08,0.04,0.0,0.0,0.04,russell barrett,
+ENR,3020,1,Nat Res Measurements,0.5,0.27,0.13,0.1,0.0,0.0,0.0,0.0,lawrence gering,
+ENR,3120,1,Env Risks & Society,0.49,0.32,0.14,0.03,0.0,0.0,0.0,0.03,alan johnson,
+ENR,4130,1,Restoration Ecology,0.31,0.59,0.1,0.0,0.0,0.0,0.0,0.0,althea simone hagan,
+ENR,4500,1,Conservation Issues,0.8,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alan johnson,
+ENR,4500,2,Conservation Issues,0.82,0.09,0.05,0.0,0.0,0.0,0.0,0.05,alan johnson,
+ENSP,2000,1,Intro Environ Sci,0.41,0.34,0.24,0.0,0.0,0.0,0.0,0.0,tom owino,
+ENSP,2000,2,Intro Environ Sci,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+ENSP,2000,3,Intro Environ Sci,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENT,2000,1,Six-Legged Science,0.59,0.29,0.05,0.02,0.02,0.0,0.0,0.02,suellen pometto,
+ETOX,8300,1,Mechanistic Toxicology,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,william baldwin,
+FCS,8340,1,Research Methods in FCS II,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,natallia ser sianko,
+FCS,8920,61,Program Evaluation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mark small,
+FDSC,1020,1,Persp Food Nutrition,0.67,0.28,0.04,0.0,0.0,0.0,0.0,0.01,john mcgregor,
+FDSC,2140,1,Fd Resources & Soc,0.56,0.3,0.08,0.02,0.01,0.0,0.0,0.04,paul dawson,
+FDSC,3060,1,Institutional Food Service Mgt,0.62,0.28,0.1,0.0,0.0,0.0,0.0,0.0,angela fraser,
+FDSC,4020,1,Food Chemistry II,0.58,0.33,0.09,0.0,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4030,1,Food Ch & Analysis,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,paul dawson,
+FDSC,4080,1,Food Process Eng,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,felix barron,
+FDSC,4090,1,TQM for Food & Pckg Industries,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+FIN,3040,1,Risk & Insurance,0.2,0.32,0.36,0.12,0.0,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.17,0.39,0.27,0.15,0.0,0.0,0.0,0.02,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.16,0.28,0.33,0.12,0.09,0.0,0.0,0.02,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.16,0.42,0.33,0.05,0.0,0.0,0.0,0.05,kerri mcmillan,
+FIN,3060,1,Corporation Finance,0.14,0.17,0.28,0.17,0.16,0.0,0.0,0.08,william hol johnson,
+FIN,3060,2,Corporation Finance,0.1,0.1,0.14,0.29,0.22,0.0,0.0,0.16,william hol johnson,
+FIN,3060,5,Corporation Finance,0.13,0.16,0.25,0.25,0.11,0.0,0.0,0.1,william hol johnson,
+FIN,3060,400,Corporation Finance,0.16,0.29,0.32,0.16,0.03,0.0,0.0,0.05,jack wolf,
+FIN,3060,401,Corporation Finance,0.15,0.32,0.28,0.15,0.0,0.0,0.0,0.09,jack wolf,
+FIN,3060,402,Corporation Finance,0.13,0.29,0.36,0.11,0.06,0.0,0.0,0.05,jack wolf,
+FIN,3070,1,Prin of Real Estate,0.21,0.38,0.28,0.08,0.05,0.0,0.0,0.0,ramon tolb franklin,
+FIN,3070,2,Prin of Real Estate,0.17,0.31,0.39,0.13,0.0,0.0,0.0,0.0,thomas springer,
+FIN,3080,1,Fin Inst & Mkts,0.24,0.29,0.32,0.1,0.02,0.0,0.0,0.02,daniel thoma greene,
+FIN,3080,2,Fin Inst & Mkts,0.25,0.45,0.23,0.08,0.0,0.0,0.0,0.0,daniel thoma greene,
+FIN,3080,3,Fin Inst & Mkts,0.44,0.28,0.26,0.03,0.0,0.0,0.0,0.0,daniel thoma greene,
+FIN,3110,1,Financial Management I,0.04,0.23,0.38,0.19,0.04,0.0,0.0,0.12,george bra lockhart,
+FIN,3110,2,Financial Management I,0.12,0.28,0.33,0.14,0.07,0.0,0.0,0.07,george bra lockhart,
+FIN,3110,3,Financial Management I,0.06,0.4,0.36,0.02,0.08,0.0,0.0,0.08,ramon tolb franklin,
+FIN,3110,4,Financial Management I,0.17,0.23,0.33,0.04,0.06,0.0,0.0,0.17,george bra lockhart,
+FIN,3120,1,Financial Management II,0.11,0.33,0.31,0.19,0.03,0.0,0.0,0.03,vincent intintoli,
+FIN,3120,2,Financial Management II,0.2,0.34,0.28,0.06,0.06,0.0,0.0,0.06,vincent intintoli,
+FIN,3120,3,Financial Management II,0.24,0.26,0.31,0.16,0.02,0.0,0.0,0.02,angela morgan,
+FIN,4030,1,Spreadsheet Apps in Finance,0.33,0.5,0.08,0.06,0.0,0.0,0.0,0.03,jared daniel smith,
+FIN,4030,2,Spreadsheet Apps in Finance,0.13,0.6,0.17,0.07,0.03,0.0,0.0,0.0,jared daniel smith,
+FIN,4040,1,Financial Modeling,0.1,0.4,0.3,0.0,0.05,0.05,0.0,0.1,jack wolf,
+FIN,4050,1,Portfolio Management & Theory,0.25,0.17,0.29,0.17,0.08,0.0,0.0,0.04,john alexander,
+FIN,4080,1,Mgt of Fin Inst,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4080,2,Mgt of Fin Inst,0.14,0.67,0.1,0.05,0.0,0.0,0.0,0.05,lyudmila chernykh,
+FIN,4090,1,Prof Fin Plan,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william hol johnson,
+FIN,4110,1,Int Fin Mgt,0.34,0.49,0.1,0.05,0.0,0.0,0.0,0.02,tilan tang,
+FIN,4110,2,Int Fin Mgt,0.33,0.46,0.15,0.05,0.0,0.0,0.0,0.0,tilan tang,
+FIN,4150,1,Real Estate Investmt,0.14,0.55,0.18,0.05,0.0,0.0,0.0,0.09,thomas springer,
+FIN,4160,1,Real Estate Val,0.25,0.6,0.1,0.05,0.0,0.0,0.0,0.0,ramon tolb franklin,
+FNR,4700,51,Camera Traps/ Animal Ecology,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,david sco jachowski,
+FNR,4990,1,Natural Resources Seminar,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,greg yarrow,
+FNR,4990,2,Natural Resources Seminar,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,greg yarrow,
+FNR,4990,3,Natural Resources Seminar,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,greg yarrow,
+FOR,1010,1,Intro to Forestry,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,lawrence gering,
+FOR,2060,1,Forestry Ecology,0.31,0.38,0.2,0.06,0.03,0.0,0.0,0.02,donald hagan,
+FOR,3080,1,Remote Sensing in Forestry,0.23,0.46,0.15,0.12,0.04,0.0,0.0,0.0,lawrence gering,
+FOR,4060,1,Forested Watershed Mgmt,0.65,0.29,0.0,0.0,0.02,0.0,0.0,0.04,joanna emily hawley,
+FOR,4080,1,Wood and Paper Products,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,patricia layton,
+FOR,4150,1,Forest Wildlife Managment,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,james davis,
+FOR,4180,1,Forest Resource Valuation,0.23,0.5,0.23,0.04,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4340,1,GIS for Natural Resources,0.51,0.34,0.11,0.0,0.02,0.0,0.0,0.02,robert frit baldwin,
+FOR,4650,1,Silviculture,0.2,0.44,0.24,0.12,0.0,0.0,0.0,0.0,gaofeng wang,
+FOR,8120,1,Fire Ecology and Management,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,gaofeng wang,
+FR,1010,1,Elementary French,0.29,0.53,0.06,0.06,0.0,0.0,0.0,0.06,anne salces  nedeo,
+FR,1020,1,Elementary French,0.09,0.27,0.18,0.18,0.18,0.0,0.0,0.09,anne salces  nedeo,
+FR,1020,2,Elementary French,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,1020,3,Elementary French,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,1,Intermediate French,0.61,0.22,0.11,0.0,0.06,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,2,Intermediate French,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,4,Intermediate French,0.47,0.27,0.13,0.0,0.0,0.0,0.0,0.13,kelly digby peebles,
+FR,2020,1,Intermediate French,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,eric touya,
+FR,2020,2,Intermediate French,0.63,0.26,0.0,0.11,0.0,0.0,0.0,0.0,joseph mai,
+FR,2020,3,Intermediate French,0.71,0.24,0.0,0.06,0.0,0.0,0.0,0.0,joseph mai,
+FR,2020,4,Intermediate French,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,paulin de tholozany,
+FR,3050,1,Int Fr Con & Comp I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
+FR,3160,1,Fr for Intl Trade,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,
+FR,3170,1,Contemp French Civ,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,joseph mai,
+FR,4200,1,French Enlightenment,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
+FR,4760,1,Adv Sem Fr Thought,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,
+GC,1010,1,Orientation to G C,0.41,0.39,0.11,0.02,0.0,0.0,0.0,0.07,carol jones,
+GC,1020,1,Computer Art & CAD Foundations,0.36,0.43,0.16,0.02,0.02,0.0,0.0,0.0,carol jones,
+GC,1030,1,G C I for Pkgsc,0.23,0.54,0.06,0.06,0.06,0.0,0.0,0.06,john jacobs,
+GC,1040,1,Graphic Communications I,0.43,0.51,0.04,0.0,0.0,0.0,0.0,0.01,rebecca suza edlein,
+GC,2070,1,Graphic Communications II,0.53,0.38,0.09,0.0,0.0,0.0,0.0,0.0,patrick gee rose,
+GC,2400,1,Intro to Web Design and Dev,0.56,0.25,0.06,0.0,0.0,0.06,0.0,0.06,erica black walker,
+GC,3400,1,Digital Imaging and eMedia,0.64,0.31,0.05,0.0,0.0,0.0,0.0,0.0,erica black walker,
+GC,3460,1,Ink and Substrates,0.18,0.44,0.29,0.04,0.04,0.0,0.0,0.02,liam henry 'hara,
+GC,4060,1,Package and Specialty Printing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kern cox,
+GC,4400,1,Commercial Printing,0.23,0.49,0.17,0.0,0.03,0.0,0.0,0.09,eric weisenmiller,
+GC,4440,1,Current Dev/Trends in Gr Comm,0.33,0.47,0.14,0.06,0.0,0.0,0.0,0.0,liam henry 'hara,
+GC,4480,1,Plan & Cont Printing Functions,0.6,0.34,0.04,0.02,0.0,0.0,0.0,0.0,john leininger,
+GC,4800,1,Senior Seminar in GC,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,charles edwa tonkin,
+GC,4900,2,G C Selected Topics-Sales,0.62,0.27,0.04,0.0,0.0,0.0,0.0,0.08,john leininger,
+GC,4900,6,G C Selected Topics-The DEN,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,erica black walker,
+GEN,3000,1,Fundamental Genetics,0.23,0.33,0.22,0.11,0.07,0.0,0.0,0.03,kate leanne wi tsai,
+GEN,3000,2,Fundamental Genetics,0.18,0.39,0.24,0.11,0.03,0.0,0.0,0.03,kate leanne wi tsai,
+GEN,3020,1,Molecular & General Genetics,0.33,0.33,0.17,0.04,0.0,0.0,0.0,0.13,meredith tei morris,
+GEN,4100,1,Population & Quant Genetics,0.43,0.38,0.11,0.05,0.03,0.0,0.0,0.0,amy lou lawton rauh,
+GEN,4110,2,Populatn & Quant Genetics Lab,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
+GEN,4400,1,Bioinformatics,0.41,0.35,0.18,0.0,0.0,0.0,0.0,0.06,liangjiang wang,
+GEN,6100,1,Population & Quant Genetics,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
+GEOG,1010,1,Intro to Geography,0.35,0.29,0.29,0.0,0.03,0.0,0.0,0.03,christa smith,
+GEOG,1030,1,World Regional Geol,0.83,0.07,0.03,0.03,0.02,0.0,0.0,0.02,lance forres howard,
+GEOG,1030,2,World Regional Geog,0.4,0.38,0.15,0.08,0.0,0.0,0.0,0.0,william churc terry,
+GEOG,3010,1,Political Geography,0.56,0.28,0.04,0.0,0.04,0.0,0.0,0.08,christa smith,
+GEOL,1010,1,Physical Geology,0.37,0.36,0.17,0.05,0.03,0.0,0.0,0.01,alan coulson,
+GEOL,1010,2,Physical Geology,0.46,0.33,0.12,0.05,0.04,0.0,0.0,0.0,alan coulson,
+GEOL,1030,1,Physical Geol Lab,0.3,0.52,0.13,0.04,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.65,0.13,0.04,0.0,0.09,0.0,0.0,0.09,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.55,0.36,0.05,0.0,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.61,0.3,0.04,0.04,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.58,0.33,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.67,0.21,0.08,0.04,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.75,0.06,0.19,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1120,1,Earth Resources,0.52,0.31,0.15,0.0,0.0,0.0,0.0,0.02,scott brame,
+GEOL,1140,1,Earth Resources Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,2020,1,Earth History,0.25,0.5,0.05,0.1,0.1,0.0,0.0,0.0,alan coulson,
+GEOL,3130,1,Sedimentology & Stratigraphy,0.11,0.44,0.28,0.17,0.0,0.0,0.0,0.0,james castle,
+GEOL,3180,1,Introduction to Geochemistry,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,brian powell,
+GEOL,4210,1,Gis in Geology,0.7,0.26,0.0,0.0,0.0,0.0,0.0,0.04,scott brame,
+GEOL,7900,501,Biogeography & Geology of SC,0.25,0.5,0.13,0.0,0.13,0.0,0.0,0.0,john robert wagner,
+GEOL,8030,1,Geostatistics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,stephen mich moysey,
+GEOL,8160,1,Aquifer Systems,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,lawrence murdoch,
+GER,1010,1,Elementary German,0.32,0.42,0.11,0.05,0.05,0.0,0.0,0.05,oswald harris king,
+GER,1010,2,Elementary German,0.56,0.11,0.11,0.06,0.0,0.0,0.0,0.17,oswald harris king,
+GER,1020,1,Elementary German,0.31,0.31,0.31,0.0,0.0,0.0,0.0,0.08, lee ferrell,
+GER,1020,2,Elementary German,0.21,0.29,0.07,0.0,0.14,0.0,0.0,0.29, lee ferrell,
+GER,2010,1,Intermediate German,0.35,0.53,0.06,0.0,0.0,0.0,0.0,0.06,oswald harris king,
+GER,2020,1,Intermediate German,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,johannes schmidt,
+GER,2020,2,Intermediate German,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,3160,1,Ger for Intl Trade I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0, lee ferrell,
+GER,3610,1,Ger Lit 1832 to Mod,0.55,0.36,0.0,0.0,0.09,0.0,0.0,0.0,johannes schmidt,
+HCC,8810,2,Measurement & Eval,0.57,0.14,0.0,0.0,0.0,0.0,0.0,0.29,bart knijnenburg,
+HCG,9010,1,Adv in Humn Genetics,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,julia eggert,
+HCG,9890,3,Special Topics: Theoretical Fo,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,mary steck,
+HEHD,3990,2,Students Helping Students Peer,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,mary mcp von kaenel,
+HEHD,4000,1,Intro Leadership Theor & Conc,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,william havice,
+HEHD,4200,1,Lead Appli & Exper,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,mary price,
+HEHD,8010,230,Child/Adolescent Dev,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
+HEHD,8040,230,Assessment/Eval,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,
+HEHD,8880,400,Special Topics Youth Dev Ldshp,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,barry garst,
+HIST,1010,1,Hist of the U S,0.27,0.55,0.12,0.0,0.06,0.0,0.0,0.0,james brad jeffries,
+HIST,1240,1,Environmental History Survey,0.04,0.46,0.31,0.05,0.07,0.0,0.0,0.07,james brad jeffries,
+HIST,1720,3,The West and the World I,0.43,0.46,0.06,0.0,0.0,0.0,0.0,0.06,emily wood,
+HIST,1730,1,The West and the World II,0.27,0.38,0.19,0.0,0.08,0.0,0.0,0.08, alan grubb,
+HIST,1730,2,The West and the World II,0.33,0.28,0.25,0.07,0.03,0.0,0.0,0.03,james burns,
+HIST,1730,3,The West and the World II,0.18,0.43,0.2,0.08,0.05,0.0,0.0,0.07,thomas kuehn,
+HIST,2990,1,Historian's Craft,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,michael silvestri,
+HIST,2990,2,Historian's Craft,0.44,0.38,0.06,0.0,0.06,0.0,0.0,0.06,elizabeth carney,
+HIST,3000,1,Hist Colonial Amer,0.62,0.32,0.03,0.0,0.03,0.0,0.0,0.0,lee brady wilson,
+HIST,3010,1,Am Rev & New Nation,0.21,0.27,0.21,0.06,0.15,0.0,0.0,0.09,james brad jeffries,
+HIST,3100,1,History of Religion in the US,0.27,0.53,0.0,0.07,0.07,0.0,0.0,0.07,elizabeth jemison,
+HIST,3110,1,African American Hist to 1877,0.26,0.55,0.1,0.0,0.06,0.0,0.0,0.03,abel bartley,
+HIST,3180,1,American Women,0.26,0.39,0.23,0.1,0.0,0.0,0.0,0.03,meg taylor-shockley,
+HIST,3210,2,History of Science,0.54,0.34,0.03,0.0,0.03,0.0,0.0,0.06,pamela mack,
+HIST,3240,1,Hist of the South II,0.33,0.52,0.09,0.03,0.0,0.0,0.0,0.03,john andrew,
+HIST,3260,1,Hist Am Transport,0.66,0.23,0.03,0.0,0.09,0.0,0.0,0.0, roger grant,
+HIST,3330,1,Hist of Mod Japan,0.21,0.41,0.26,0.03,0.09,0.0,0.0,0.0,edwin moise,
+HIST,3410,1,Modern Mexico,0.57,0.29,0.06,0.0,0.0,0.0,0.0,0.09,rachel anne moore,
+HIST,3510,1,Ancient Near East,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,steven grosby,
+HIST,3730,2,Age of Protestant Reformation,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,thomas kuehn,
+HIST,3810,1,Germany Since 1918,0.16,0.63,0.16,0.0,0.03,0.0,0.0,0.03,michael meng,
+HIST,3890,3,Mitchelville,0.73,0.13,0.07,0.0,0.07,0.0,0.0,0.0,abel bartley,
+HIST,3890,4,Upstate Black Communities,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,abel bartley,
+HIST,3890,5,Churches of Mitchelville,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,
+HIST,3900,1,Modern Military History,0.11,0.43,0.32,0.04,0.07,0.0,0.0,0.04,edwin moise,
+HIST,3920,1,Hist U S Environment,0.16,0.44,0.09,0.09,0.16,0.0,0.0,0.06,pamela mack,
+HIST,3970,1,Modern Middle East,0.42,0.55,0.0,0.03,0.0,0.0,0.0,0.0,amit bein,
+HIST,4000,1,Colonial South Carolina,0.17,0.28,0.39,0.06,0.06,0.0,0.0,0.06,paul chris anderson,
+HIST,4400,1,Studies in Latin American Hist,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
+HIST,4600,2,British India,0.54,0.31,0.0,0.08,0.0,0.0,0.0,0.08,michael silvestri,
+HIST,4870,1,World War II,0.14,0.57,0.17,0.02,0.05,0.0,0.0,0.05,john andrew,
+HIST,4880,1,Middle Eastern Soc & Culture,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
+HIST,4900,2,Domestic Space & History,0.58,0.33,0.0,0.0,0.08,0.0,0.0,0.0,elizabeth carney,
+HIST,4900,3,Capitalism,0.53,0.13,0.2,0.0,0.07,0.0,0.0,0.07,steven marks,
+HIST,4920,1,African American & Sports,0.31,0.46,0.15,0.0,0.0,0.0,0.0,0.08,abel bartley,
+HLTH,2020,1,Introduction to Public Health,0.57,0.29,0.05,0.05,0.0,0.0,0.0,0.05,jeffrey kingree,
+HLTH,2020,2,Introduction to Public Health,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,3,Introduction to Public Health,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,400,Introduction to Public Health,0.53,0.21,0.11,0.05,0.0,0.0,0.0,0.11,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.45,0.27,0.09,0.09,0.0,0.0,0.0,0.09,frederic fraizer,
+HLTH,2030,2,Health Care Sys,0.48,0.31,0.17,0.0,0.0,0.0,0.0,0.03,frederic fraizer,
+HLTH,2030,3,Health Care Sys,0.79,0.09,0.09,0.0,0.0,0.0,0.0,0.03,lee alden crandall,
+HLTH,2030,400,Health Care Sys,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2400,2,Deter of Hlth Behav,0.47,0.43,0.03,0.0,0.03,0.0,0.0,0.03,amelia clinkscales,
+HLTH,2400,400,Deter of Hlth Behav,0.53,0.33,0.07,0.07,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2980,1,Human Hlth & Disease,0.57,0.35,0.02,0.0,0.04,0.0,0.0,0.02,annah kamugiz amani,
+HLTH,2980,2,Human Hlth & Disease,0.66,0.23,0.09,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,3030,1,Public Health Comm,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,debra mitch charles,
+HLTH,3050,1,Body Resp Hlth Beh,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,brian patric graves,
+HLTH,3100,1,Women's Hlth Issues,0.64,0.24,0.09,0.03,0.0,0.0,0.0,0.0,rachel mayo,
+HLTH,3500,1,Med Terminology/Comm,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kari jea strothmann,
+HLTH,3800,1,Epidemiology,0.27,0.57,0.13,0.0,0.03,0.0,0.0,0.0,hugh spitler,
+HLTH,3800,2,Epidemiology,0.45,0.4,0.1,0.03,0.0,0.0,0.0,0.03,deborah alma falta,
+HLTH,3980,1,Hlth Appraisal Sklls,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,kathleen meyer,
+HLTH,3980,2,Hlth Appraisal Sklls,0.71,0.14,0.07,0.07,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4100,1,Maternal Child Hlth,0.66,0.28,0.03,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.45,0.3,0.18,0.03,0.0,0.0,0.0,0.05,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.72,0.26,0.02,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4300,1,Hlth Prom of Aged,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,cheryl jo dye,
+HLTH,4310,1,Public & Environ Hlt,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,4600,1,Health Info Systems,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,4700,400,Global Health,0.58,0.16,0.05,0.0,0.05,0.0,0.0,0.16,annah kamugiz amani,
+HLTH,4780,1,Health Policy Ethics and Law,0.2,0.4,0.35,0.05,0.0,0.0,0.0,0.0,hugh spitler,
+HLTH,4790,1,Fin Mgmt & Hlth Budg,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,lingling zhang,
+HLTH,4800,1,Comm Hlth Promotion,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,joel edwar williams,
+HLTH,4900,1,Res Eval St Pub Hlth,0.59,0.28,0.09,0.03,0.0,0.0,0.0,0.0,khoa dang truong,
+HLTH,4900,2,Res Eval St Pub Hlth,0.44,0.44,0.0,0.06,0.0,0.0,0.0,0.06,khoa dang truong,
+HLTH,4970,4,Creative Inq Hlth - Aspire,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,martha par thompson,
+HLTH,8210,500,Health Research I,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,lee alden crandall,
+HON,2060,1,Intro to Nanotechnology,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,christophe kitchens,
+HON,2060,3,Integrity in Engineering,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,daniel wueste,
+HON,2200,1,Knight of a Different Order,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,emily wood,
+HON,2210,2,"Hamlet, Again",0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+HON,2210,5,Authoring Harry Potter,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,megan no macalystre,
+HORT,1010,1,Horticulture,0.86,0.05,0.04,0.0,0.0,0.0,0.0,0.05,ellen anita vincent,
+HORT,2020,1,Adobe Digital Design,0.75,0.04,0.08,0.0,0.08,0.0,0.0,0.04,janice ann lay,
+HORT,2110,1,Growing Spring Plnts,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,james emerson faust,
+HORT,4040,1,Plant Propagation,0.1,0.38,0.28,0.17,0.03,0.0,0.0,0.03,jeffrey adelberg,
+HORT,4050,1,Plant Propagation Techniq Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
+HORT,4050,2,Plant Propagation Techniq Lab,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,jeffrey adelberg,
+HORT,4270,1,Urban Tree Care,0.23,0.55,0.18,0.0,0.05,0.0,0.0,0.0,robert polomski,
+HORT,4330,1,Turf Weed Management,0.28,0.31,0.34,0.03,0.0,0.0,0.0,0.03,ted whitwell,
+HP,8280,1,Case St in Preservation Engr,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,craig mille bennett,
+HP,8330,1,Cultural and Historical Landsc,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,carter lee hudgins,
+HRD,8490,400,Eval of T&D/Hrd Prog,0.92,0.02,0.0,0.0,0.06,0.0,0.0,0.0,philip mcgee,
+IE,2100,1,Des Analysis Wrk Sys,0.17,0.41,0.2,0.1,0.07,0.0,0.0,0.05,sara lu riggs,
+IE,2800,1,Deterministic Operations Rsrch,0.12,0.41,0.28,0.1,0.03,0.0,0.0,0.05,robert mark curry,
+IE,3010,1,Systems Design I,0.62,0.36,0.02,0.0,0.0,0.0,0.0,0.0,robert james riggs,
+IE,3610,1,Industrial App of Prob/Stat II,0.33,0.37,0.13,0.03,0.13,0.0,0.0,0.0,sandra dun eksioglu,
+IE,3610,2,Industrial App of Prob/Stat II,0.58,0.25,0.12,0.03,0.0,0.0,0.0,0.03,joel greenstein,
+IE,3810,1,Probabilistic Operations Rsrch,0.2,0.31,0.33,0.07,0.09,0.0,0.0,0.0,burak eksioglu,
+IE,3810,2,Probabilistic Operations Rsrch,0.24,0.34,0.19,0.13,0.08,0.0,0.0,0.02,amin khademi,
+IE,3840,1,Engr Econ Analysis,0.55,0.17,0.12,0.04,0.04,0.0,0.0,0.08,brian melloy,
+IE,3860,1,Prod Plan & Cont,0.32,0.36,0.19,0.09,0.02,0.0,0.0,0.03,robert james riggs,
+IE,4020,3,Creative Inq Res,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,anand gramopadhye,
+IE,4620,1,Six Sigma Quality,0.34,0.52,0.14,0.0,0.0,0.0,0.0,0.0,robert james riggs,
+IE,4670,1,System Design II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,
+IE,4910,1,Service Engineering,0.29,0.29,0.18,0.18,0.0,0.0,0.0,0.06,tugce isik,
+IE,4910,3,Invest Human Error Complx Sys,0.4,0.42,0.12,0.03,0.03,0.0,0.0,0.0,sara lu riggs,
+IE,6910,1,Service Engineering,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tugce isik,
+IE,6910,3,Invest Human Error Complx Sys,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,sara lu riggs,
+IE,8010,1,Human-Machine Sys,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joel greenstein,
+IE,8520,1,Prescriptive Analytics,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
+IE,8540,1,SC & Logistics Modeling I,0.73,0.21,0.06,0.0,0.0,0.0,0.0,0.0,william ferrell,
+IE,8580,1,Case Study Supply Chn & Logist,0.83,0.15,0.03,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.92,0.07,0.02,caren kelley-hall,
+INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.93,0.04,0.03,caren kelley-hall,
+INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,uttiyo raychaudhuri,
+ITAL,1010,1,Elementary Italian,0.65,0.06,0.18,0.0,0.06,0.0,0.0,0.06,julia schmidt,
+ITAL,1020,1,Elementary Italian,0.5,0.39,0.0,0.11,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,1020,2,Elementary Italian,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,valentina lombardi,
+ITAL,1020,3,Elementary Italian,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
+ITAL,2020,1,Intermediate Italian,0.61,0.33,0.0,0.06,0.0,0.0,0.0,0.0,valentina lombardi,
+ITAL,2020,2,Intermediate Italian,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,valentina lombardi,
+JAPN,1010,1,Elementary Japanese,0.44,0.11,0.11,0.0,0.17,0.0,0.0,0.17,kazuko shoji,
+JAPN,1010,2,Elementary Japanese,0.38,0.13,0.19,0.06,0.19,0.0,0.0,0.06,kazuko shoji,
+JAPN,1020,1,Elementary Japanese,0.35,0.24,0.06,0.18,0.12,0.0,0.0,0.06,jae allegr takeuchi,
+JAPN,1020,2,Elementary Japanese,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,jae allegr takeuchi,
+JAPN,2010,1,Intermed Japanese,0.2,0.6,0.1,0.0,0.1,0.0,0.0,0.0,kazuko shoji,
+JAPN,2020,1,Intermed Japanese,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,kazuko shoji,
+JAPN,4170,1,Japanese Culture and Society,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jae allegr takeuchi,
+LARC,1160,1,History of Landscape Arch,0.24,0.29,0.3,0.09,0.03,0.0,0.0,0.05,hala fouad nassar,
+LARC,1520,1,Basic Design II,0.65,0.22,0.09,0.0,0.0,0.0,0.0,0.04,paul russell,
+LARC,2520,1,Site Design,0.36,0.36,0.27,0.0,0.0,0.0,0.0,0.0,martin john holland,
+LARC,3620,1,Design Impl II,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,paul russell,
+LARC,4280,1,Comput Aided Design,0.61,0.11,0.18,0.0,0.0,0.0,0.0,0.11,jessica fernandez,
+LAW,3220,1,Legal Env of Bus,0.35,0.37,0.15,0.02,0.07,0.0,0.0,0.04,kenneth toussaint,
+LAW,3220,2,Legal Env of Bus,0.27,0.56,0.16,0.02,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,3,Legal Env of Bus,0.7,0.24,0.07,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,4,Legal Env of Bus,0.38,0.38,0.22,0.0,0.02,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,5,Legal Env of Bus,0.41,0.34,0.18,0.05,0.0,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,6,Legal Env of Bus,0.42,0.38,0.11,0.04,0.0,0.0,0.0,0.04,edward ray claggett,
+LAW,3220,7,Legal Env of Bus,0.57,0.37,0.04,0.02,0.0,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,8,Legal Env of Bus,0.4,0.37,0.21,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,
+LAW,3220,9,Legal Env of Bus,0.41,0.44,0.1,0.03,0.03,0.0,0.0,0.0,kath kisska-schulze,
+LAW,3220,10,Legal Env of Bus,0.28,0.55,0.12,0.03,0.02,0.0,0.0,0.0,john hine,
+LAW,3220,11,Legal Env of Bus,0.21,0.56,0.15,0.03,0.03,0.0,0.0,0.02,john hine,
+LAW,3220,401,Legal Env of Bus,0.14,0.28,0.16,0.16,0.07,0.0,0.0,0.19,virgini ward-vaughn,
+LAW,3220,402,Legal Env of Bus,0.1,0.25,0.23,0.15,0.13,0.0,0.0,0.15,virgini ward-vaughn,
+LAW,3220,403,Legal Env of Bus,0.23,0.28,0.2,0.18,0.1,0.0,0.0,0.03,virgini ward-vaughn,
+LAW,3220,404,Legal Env of Bus,0.22,0.37,0.15,0.17,0.07,0.0,0.0,0.02,virgini ward-vaughn,
+LAW,3220,601,Legal Env of Bus,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LAW,4990,1,Selected Topics: Cyber Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,8500,1,Law for Prof Accts,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LAW,8500,2,Law for Prof Accts,0.18,0.74,0.09,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LAW,8500,3,Law for Prof Accts,0.49,0.43,0.09,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LS,1000,9,Intro to Salsa Dance,0.64,0.09,0.0,0.0,0.27,0.0,0.0,0.0,malik lewis baxter,
+LS,1000,20,Intro to Volleyball,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,kelly lynn ator,
+LS,1000,22,Intermediate Ashtanga Yoga,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
+LS,1000,23,Therapeutic Yoga,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
+LS,1000,24,Therapeutic Yoga,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,
+LS,1000,25,Therapeutic Yoga,0.78,0.09,0.0,0.0,0.0,0.0,0.0,0.13,ranjanbala dil amin,
+LS,1130,1,Wood Carving,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,louwanda jolley,
+LS,1260,1,Group Initiatives,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,christina mar mazer,
+LS,1410,1,Top Rope Climbing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,glenn dav middleton,
+LS,1410,3,Top Rope Climbing,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,glenn dav middleton,
+LS,1450,2,Camping/Backpacking,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,samuel james keith,
+LS,1450,4,Camping/Backpacking,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,samuel james keith,
+LS,1580,2,Archery,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1580,3,Archery,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1580,4,Archery,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,
+LS,1640,1,Whitewater Kayaking,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,robert taylor,
+LS,1850,2,Bowling,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,megan elizabet cato,
+LS,1850,5,Bowling,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.07,katie dudley,
+LS,1850,6,Bowling,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,megan elizabet cato,
+LS,1850,8,Bowling,0.87,0.03,0.0,0.03,0.0,0.0,0.0,0.07,megan elizabet cato,
+LS,1870,1,Frisbee Sports,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,craig goodman,
+LS,1890,1,Tennis,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,jose mezapaniagua,
+LS,1940,1,Racquetball,0.79,0.07,0.0,0.07,0.0,0.0,0.0,0.07,raymond petersen,
+LS,1940,3,Racquetball,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,charlie white,
+LS,1980,1,Golf,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jason jordan,
+LS,1980,3,Golf,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jason jordan,
+LS,1980,6,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,jason jordan,
+LS,2100,1,Learn to Dance,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,matthew lee krabbe,
+LS,2110,2,Introduction to Belly Dance,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,stephanie pack,
+LS,2110,3,Introduction to Belly Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,stephanie pack,
+LS,2180,1,Ballroom Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,
+LS,2200,1,Shag,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,matthew lee krabbe,
+LS,2200,6,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,matthew lee krabbe,
+LS,2200,7,Shag,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,matthew lee krabbe,
+LS,2270,1,Intro to Swing Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,paul hoke,
+LS,2270,2,Intro to Swing Dance,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,paul hoke,
+LS,2270,4,Intro to Swing Dance,0.93,0.0,0.0,0.04,0.0,0.0,0.0,0.04,paul hoke,
+LS,2320,1,Core Training,0.86,0.05,0.05,0.05,0.0,0.0,0.0,0.0,diane moreno,
+LS,2320,2,Core Training,0.79,0.0,0.04,0.04,0.04,0.0,0.0,0.08,diane moreno,
+LS,2320,3,Core Training,0.7,0.1,0.0,0.0,0.0,0.0,0.0,0.2,diane moreno,
+LS,2350,1,Basic Yoga,0.67,0.14,0.05,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,
+LS,2350,2,Basic Yoga,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
+LS,2350,3,Basic Yoga,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2350,4,Basic Yoga,0.75,0.1,0.0,0.1,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2350,5,Basic Yoga,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,renee warren gahan,
+LS,2350,6,Basic Yoga,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jenefer nadenicek,
+LS,2350,7,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,
+LS,2350,8,Basic Yoga,0.87,0.04,0.0,0.0,0.04,0.0,0.0,0.04,jenefer nadenicek,
+LS,2360,2,Power/Ashtanga Yoga,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,silica eliza larkin,
+LS,2380,1,Vinyasa Flow Yoga,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,
+LS,2380,2,Vinyasa Flow Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jenefer nadenicek,
+LS,2420,1,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2420,2,Meditation and Relax,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,renee warren gahan,
+LS,2420,3,Meditation and Relax,0.75,0.08,0.08,0.04,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,4,Meditation and Relax,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,5,Meditation and Relax,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,2420,6,Meditation and Relax,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,2420,8,Meditation and Relax,0.86,0.0,0.09,0.0,0.05,0.0,0.0,0.0,ani reina-nunnelley,
+LS,2420,9,Meditation and Relax,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ani reina-nunnelley,
+LS,2450,1,Pilates,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,melanie ivey job,
+LS,2450,2,Pilates,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,melanie ivey job,
+LS,2460,2,Intermediate Pilates,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
+LS,2510,1,Running & Jogging,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,corey dou brookover,
+LS,2700,1,Sports Officiating,0.71,0.0,0.0,0.0,0.06,0.0,0.0,0.24,christopher war cox,
+LS,3580,1,Advanced Shotgun Skeet,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,charles flint,
+MATH,1010,1,Essen Math for Informed Soc,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,marilyn reba,
+MATH,1010,3,Essen Math for Informed Soc,0.26,0.34,0.11,0.17,0.11,0.0,0.0,0.0,judith cottingham,
+MATH,1010,4,Essen Math for Informed Soc,0.5,0.35,0.12,0.0,0.03,0.0,0.0,0.0,judith cottingham,
+MATH,1010,5,Essen Math for Informed Soc,0.29,0.29,0.24,0.18,0.0,0.0,0.0,0.0,xiyan tan,
+MATH,1010,6,Essen Math for Informed Soc,0.23,0.32,0.32,0.1,0.0,0.0,0.0,0.03,judith cottingham,
+MATH,1020,1,Intro to Mathematical Analysis,0.07,0.31,0.24,0.14,0.24,0.0,0.0,0.0,haodong li,
+MATH,1020,2,Intro to Mathematical Analysis,0.18,0.21,0.26,0.16,0.11,0.0,0.0,0.08,stefani ca mokalled,
+MATH,1020,4,Intro to Mathematical Analysis,0.31,0.19,0.25,0.11,0.11,0.0,0.0,0.03,xiaoyuan liu,
+MATH,1020,6,Intro to Mathematical Analysis,0.18,0.31,0.21,0.1,0.13,0.0,0.0,0.08,tony thanh nguyen,
+MATH,1020,7,Intro to Mathematical Analysis,0.16,0.35,0.11,0.14,0.11,0.0,0.0,0.14,jerry lero phillips,
+MATH,1020,8,Intro to Mathematical Analysis,0.21,0.28,0.23,0.13,0.1,0.0,0.0,0.05,tony thanh nguyen,
+MATH,1020,9,Intro to Mathematical Analysis,0.11,0.34,0.24,0.08,0.24,0.0,0.0,0.0,randy davidson,
+MATH,1020,10,Intro to Mathematical Analysis,0.11,0.16,0.24,0.11,0.35,0.0,0.0,0.03,prab withana gamage,
+MATH,1020,11,Intro to Mathematical Analysis,0.2,0.31,0.11,0.17,0.2,0.0,0.0,0.0,kara ail stasikelis,
+MATH,1020,14,Intro to Mathematical Analysis,0.11,0.4,0.34,0.06,0.09,0.0,0.0,0.0,tony thanh nguyen,
+MATH,1020,15,Intro to Mathematical Analysis,0.21,0.26,0.18,0.13,0.11,0.0,0.0,0.11,randy davidson,
+MATH,1020,16,Intro to Mathematical Analysis,0.21,0.26,0.31,0.13,0.05,0.0,0.0,0.05,abigail bowers,
+MATH,1020,18,Intro to Mathematical Analysis,0.32,0.34,0.22,0.0,0.1,0.0,0.0,0.02,randy davidson,
+MATH,1020,19,Intro to Mathematical Analysis,0.05,0.18,0.32,0.08,0.29,0.0,0.0,0.08,aaro ramirez flores,
+MATH,1020,20,Intro to Mathematical Analysis,0.05,0.24,0.41,0.05,0.17,0.0,0.0,0.07,abigail bowers,
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.61,0.03,jason to hedetniemi,
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.41,0.51,0.08,rebecca lynn knoll,
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.49,0.05,patrick buckingham,
+MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.47,0.41,0.12,charity watson,
+MATH,1060,1,Calculus of One Variable I,0.07,0.07,0.37,0.13,0.27,0.0,0.0,0.1,allen anderso guest,
+MATH,1060,2,Calculus of One Variable I,0.06,0.19,0.38,0.09,0.06,0.0,0.0,0.22,allen anderso guest,
+MATH,1060,3,Calculus of One Variable I,0.17,0.24,0.27,0.05,0.2,0.0,0.0,0.07,marion hanna,
+MATH,1060,4,Calculus of One Variable I,0.05,0.14,0.36,0.12,0.19,0.0,0.0,0.14,beth novick,
+MATH,1060,5,Calculus of One Variable I,0.0,0.15,0.28,0.13,0.28,0.0,0.0,0.15,sanwar ahmad,
+MATH,1060,6,Calculus of One Variable I,0.05,0.2,0.34,0.02,0.27,0.0,0.0,0.12,"koshy chenthittayil,",
+MATH,1060,7,Calculus of One Variable I,0.05,0.18,0.37,0.16,0.18,0.0,0.0,0.05,stefan adam bock,
+MATH,1060,8,Calculus of One Variable I,0.05,0.18,0.13,0.1,0.23,0.0,0.0,0.33,michael gl eldredge,
+MATH,1060,9,Calculus of One Variable I,0.65,0.2,0.15,0.0,0.0,0.0,0.0,0.0,edward collins,
+MATH,1070,1,Differen and Integral Calculus,0.18,0.5,0.21,0.05,0.03,0.0,0.0,0.03,donna simms,
+MATH,1070,2,Differen and Integral Calculus,0.12,0.37,0.39,0.05,0.02,0.0,0.0,0.05,donna simms,
+MATH,1070,3,Differen and Integral Calculus,0.0,0.39,0.55,0.0,0.05,0.0,0.0,0.02,patrick buckingham,
+MATH,1070,5,Differen and Integral Calculus,0.07,0.36,0.29,0.07,0.14,0.0,0.0,0.07,tony thanh nguyen,
+MATH,1080,1,Calculus of One Variable II,0.27,0.23,0.23,0.03,0.1,0.0,0.0,0.13,muhamm mohebujjaman,
+MATH,1080,2,Calculus of One Variable II,0.19,0.21,0.24,0.05,0.21,0.0,0.0,0.1,lee andrew jenkins,
+MATH,1080,3,Calculus of One Variable II,0.13,0.22,0.16,0.07,0.18,0.0,0.0,0.24,sea sather-wagstaff,
+MATH,1080,4,Calculus of One Variable II,0.25,0.41,0.14,0.07,0.07,0.0,0.0,0.07,meredith nicol burr,
+MATH,1080,5,Calculus of One Variable II,0.09,0.36,0.36,0.07,0.07,0.0,0.0,0.05,jonathon leverenz,
+MATH,1080,6,Calculus of One Variable II,0.16,0.36,0.2,0.07,0.05,0.0,0.0,0.16,meredith nicol burr,
+MATH,1080,7,Calculus of One Variable II,0.27,0.33,0.18,0.02,0.04,0.0,0.0,0.16,abdullah al mamun,
+MATH,1080,8,Calculus of One Variable II,0.19,0.25,0.25,0.06,0.08,0.0,0.0,0.17,marilyn reba,
+MATH,1080,9,Calculus of One Variable II,0.36,0.4,0.06,0.02,0.13,0.0,0.0,0.02,ryan grove,
+MATH,1080,10,Calculus of One Variable II,0.16,0.29,0.24,0.02,0.04,0.0,0.0,0.24,jonathon leverenz,
+MATH,1080,11,Calculus of One Variable II,0.09,0.37,0.19,0.12,0.14,0.0,0.0,0.09,fiona may knoll,
+MATH,1080,12,Calculus of One Variable II,0.06,0.25,0.41,0.03,0.22,0.0,0.0,0.03,rui gong,
+MATH,1080,13,Calculus of One Variable II,0.02,0.27,0.24,0.0,0.16,0.0,0.0,0.31,rebecca ramos,
+MATH,1080,14,Calculus of One Variable II,0.22,0.28,0.25,0.08,0.03,0.0,0.0,0.14,honghai xu,
+MATH,1080,15,Calculus of One Variable II,0.1,0.33,0.18,0.05,0.15,0.0,0.0,0.18,shuhan xu,
+MATH,1080,16,Calculus of One Variable II,0.15,0.18,0.24,0.03,0.09,0.0,0.0,0.3,marilyn reba,
+MATH,1150,1,Contemp Math for Elem Teach I,0.53,0.29,0.12,0.06,0.0,0.0,0.0,0.0,charity watson,
+MATH,1160,1,Contemp Math for Elem Teach II,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1160,2,Contemp Math for Elem Teach II,0.56,0.33,0.07,0.0,0.0,0.0,0.0,0.04,allison stoddard,
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,marion hanna,
+MATH,2060,1,Calculus of Several Variables,0.16,0.42,0.1,0.06,0.1,0.0,0.0,0.16,akshay sunil gupte,
+MATH,2060,2,Calculus of Several Variables,0.16,0.4,0.2,0.04,0.12,0.0,0.0,0.08,timothy fra parrott,
+MATH,2060,3,Calculus of Several Variables,0.39,0.22,0.08,0.03,0.17,0.0,0.0,0.11,qijun he,
+MATH,2060,4,Calculus of Several Variables,0.57,0.32,0.08,0.0,0.03,0.0,0.0,0.0,sofya alekseeva,
+MATH,2060,5,Calculus of Several Variables,0.17,0.23,0.34,0.14,0.06,0.0,0.0,0.06,jonathon leverenz,
+MATH,2060,6,Calculus of Several Variables,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,sofya alekseeva,
+MATH,2060,7,Calculus of Several Variables,0.0,0.09,0.06,0.12,0.21,0.0,0.0,0.52,javier ruiz ramirez,
+MATH,2060,8,Calculus of Several Variables,0.46,0.43,0.08,0.0,0.03,0.0,0.0,0.0,sofya alekseeva,
+MATH,2060,9,Calculus of Several Variables,0.42,0.26,0.24,0.0,0.05,0.0,0.0,0.03,mark cawood,
+MATH,2060,10,Calculus of Several Variables,0.11,0.19,0.11,0.07,0.19,0.0,0.0,0.33,dania moham zantout,
+MATH,2070,1,Multivariable Calculus,0.22,0.34,0.22,0.13,0.06,0.0,0.0,0.03,judith irene mcknew,
+MATH,2070,2,Multivariable Calculus,0.34,0.31,0.28,0.0,0.03,0.0,0.0,0.03,jennifer mari hanna,
+MATH,2070,4,Multivariable Calculus,0.39,0.26,0.17,0.09,0.09,0.0,0.0,0.0,thanh thien to,
+MATH,2070,5,Multivariable Calculus,0.44,0.31,0.16,0.03,0.03,0.0,0.0,0.03,jennifer mari hanna,
+MATH,2070,7,Multivariable Calculus,0.22,0.47,0.22,0.03,0.03,0.0,0.0,0.03,tao yang,
+MATH,2070,8,Multivariable Calculus,0.23,0.27,0.13,0.17,0.07,0.0,0.0,0.13,yinggu bao,
+MATH,2070,9,Multivariable Calculus,0.44,0.24,0.24,0.03,0.0,0.0,0.0,0.06,jennifer van dyken,
+MATH,2070,10,Multivariable Calculus,0.36,0.18,0.21,0.12,0.09,0.0,0.0,0.03,jennifer mari hanna,
+MATH,2070,11,Multivariable Calculus,0.07,0.37,0.23,0.1,0.07,0.0,0.0,0.17,tiantian yang,
+MATH,2070,14,Multivariable Calculus,0.16,0.34,0.22,0.06,0.06,0.0,0.0,0.16,allison stoddard,
+MATH,2070,15,Multivariable Calculus,0.16,0.38,0.25,0.13,0.09,0.0,0.0,0.0,trevor scot vilardi,
+MATH,2070,17,Multivariable Calculus,0.38,0.38,0.13,0.0,0.03,0.0,0.0,0.09,garrett dranichak,
+MATH,2070,19,Multivariable Calculus,0.12,0.36,0.12,0.15,0.09,0.0,0.0,0.15,yibo xu,
+MATH,2070,20,Multivariable Calculus,0.27,0.3,0.24,0.09,0.03,0.0,0.0,0.06,liu zhu,
+MATH,2070,22,Multivariable Calculus,0.38,0.32,0.24,0.06,0.0,0.0,0.0,0.0,luke marti giberson,
+MATH,2070,23,Multivariable Calculus,0.21,0.21,0.24,0.12,0.15,0.0,0.0,0.06,emily marie nystrom,
+MATH,2070,25,Multivariable Calculus,0.12,0.39,0.3,0.09,0.06,0.0,0.0,0.03,amy christine grady,
+MATH,2070,26,Multivariable Calculus,0.16,0.19,0.13,0.32,0.1,0.0,0.0,0.1,yijun chen,
+MATH,2080,1,Intro to Ordin Diff Equations,0.35,0.35,0.24,0.0,0.0,0.0,0.0,0.05,james brannan,
+MATH,2080,2,Intro to Ordin Diff Equations,0.09,0.28,0.31,0.06,0.03,0.0,0.0,0.22,terri johnson,
+MATH,2080,4,Intro to Ordin Diff Equations,0.18,0.18,0.3,0.09,0.18,0.0,0.0,0.06,jeong rock yoon,
+MATH,2080,5,Intro to Ordin Diff Equations,0.05,0.23,0.36,0.05,0.14,0.0,0.0,0.18,terri johnson,
+MATH,2080,6,Intro to Ordin Diff Equations,0.22,0.27,0.22,0.05,0.03,0.0,0.0,0.22,shari prevost,
+MATH,2080,7,Intro to Ordin Diff Equations,0.11,0.32,0.11,0.07,0.11,0.0,0.0,0.29,terri johnson,
+MATH,2080,8,Intro to Ordin Diff Equations,0.19,0.3,0.14,0.11,0.05,0.0,0.0,0.22,jeong rock yoon,
+MATH,2080,9,Intro to Ordin Diff Equations,0.32,0.24,0.16,0.0,0.11,0.0,0.0,0.16,shari prevost,
+MATH,2080,10,Intro to Ordin Diff Equations,0.45,0.13,0.24,0.11,0.05,0.0,0.0,0.03,timothy ch teitloff,
+MATH,2080,11,Intro to Ordin Diff Equations,0.32,0.39,0.13,0.05,0.05,0.0,0.0,0.05,nathan jos adelgren,
+MATH,2080,12,Intro to Ordin Diff Equations,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,irina viktorova,
+MATH,2080,13,Intro to Ordin Diff Equations,0.55,0.13,0.05,0.05,0.05,0.0,0.0,0.16,timothy fra parrott,
+MATH,2080,14,Intro to Ordin Diff Equations,0.18,0.45,0.23,0.0,0.08,0.0,0.0,0.08,timothy ch teitloff,
+MATH,2080,15,Intro to Ordin Diff Equations,0.61,0.26,0.11,0.03,0.0,0.0,0.0,0.0,irina viktorova,
+MATH,2080,16,Intro to Ordin Diff Equations,0.66,0.24,0.05,0.0,0.03,0.0,0.0,0.03,irina viktorova,
+MATH,2080,17,Intro to Ordin Diff Equations,0.35,0.35,0.11,0.08,0.0,0.0,0.0,0.11,timothy fra parrott,
+MATH,2080,18,Intro to Ordin Diff Equations,0.31,0.31,0.25,0.06,0.08,0.0,0.0,0.0,timothy ch teitloff,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.88,0.08,0.0,0.03,0.0,0.0,0.0,0.03,james brannan,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.44,0.39,0.14,0.0,0.0,0.0,0.0,0.03,allison stoddard,
+MATH,3020,1,Stat for Science & Engineering,0.24,0.36,0.14,0.07,0.12,0.0,0.0,0.07,ellen hepfe breazel,
+MATH,3020,2,Stat for Science & Engineering,0.33,0.5,0.05,0.05,0.02,0.0,0.0,0.05,ellen hepfe breazel,
+MATH,3020,3,Stat for Science & Engineering,0.26,0.36,0.19,0.07,0.05,0.0,0.0,0.07,ellen hepfe breazel,
+MATH,3020,4,Stat for Science & Engineering,0.44,0.33,0.15,0.0,0.05,0.0,0.0,0.03,yisu jia,
+MATH,3020,5,Stat for Science & Engineering,0.28,0.31,0.18,0.05,0.05,0.0,0.0,0.13,calvin williams,
+MATH,3020,6,Stat for Science & Engineering,0.53,0.16,0.23,0.0,0.05,0.0,0.0,0.02,yanbo xia,
+MATH,3020,7,Stat for Science & Engineering,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.05,brandon gra goodell,
+MATH,3110,1,Linear Algebra,0.48,0.32,0.16,0.0,0.04,0.0,0.0,0.0,james peterson,
+MATH,3110,2,Linear Algebra,0.19,0.28,0.25,0.11,0.08,0.0,0.0,0.08,xuhong gao,
+MATH,3110,3,Linear Algebra,0.32,0.26,0.09,0.06,0.15,0.0,0.0,0.12,xuhong gao,
+MATH,3110,4,Linear Algebra,0.23,0.26,0.17,0.2,0.09,0.0,0.0,0.06,warren adams,
+MATH,3110,5,Linear Algebra,0.36,0.25,0.14,0.08,0.17,0.0,0.0,0.0,brian fralix,
+MATH,3190,1,Introduction to Proof,0.35,0.31,0.08,0.12,0.12,0.0,0.0,0.04,elena sta dimitrova,
+MATH,3190,2,Introduction to Proof,0.38,0.23,0.19,0.0,0.12,0.0,0.0,0.08,elena sta dimitrova,
+MATH,3600,1,Intermediate Math Computing,0.67,0.13,0.0,0.08,0.08,0.0,0.0,0.04,mark cawood,
+MATH,3600,2,Intermediate Math Computing,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,neil calkin,
+MATH,3650,1,Numerical Mthds for Engineers,0.28,0.41,0.22,0.06,0.0,0.0,0.0,0.03,eleanor jenkins,
+MATH,3650,2,Numerical Mthds for Engineers,0.13,0.31,0.31,0.03,0.03,0.0,0.0,0.19,christopher cox,
+MATH,3650,3,Numerical Mthds for Engineers,0.67,0.31,0.03,0.0,0.0,0.0,0.0,0.0,abigail bowers,
+MATH,3650,4,Numerical Mthds for Engineers,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,abigail bowers,
+MATH,4000,1,Theory of Probability,0.15,0.23,0.38,0.04,0.0,0.0,0.0,0.19,julie lassiter,
+MATH,4000,2,Theory of Probability,0.0,0.26,0.21,0.05,0.26,0.0,0.0,0.21,julie lassiter,
+MATH,4030,1,Intro to Statistical Theory,0.41,0.23,0.32,0.0,0.0,0.0,0.0,0.05,xiaoqian sun,
+MATH,4070,1,Regress & Time-Series Analysis,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,4120,1,Algebra I,0.3,0.33,0.1,0.13,0.05,0.0,0.0,0.1,kevin james,
+MATH,4190,1,Discrete Math Structures I,0.4,0.47,0.07,0.03,0.03,0.0,0.0,0.0,beth novick,
+MATH,4310,1,Theory of Interest,0.33,0.08,0.33,0.25,0.0,0.0,0.0,0.0, erwin walker,
+MATH,4340,1,Adv Engineering Mathematics,0.09,0.32,0.18,0.24,0.12,0.0,0.0,0.06,eleanor jenkins,
+MATH,4340,2,Adv Engineering Mathematics,0.19,0.42,0.04,0.15,0.08,0.0,0.0,0.12,hyesuk lee,
+MATH,4400,1,Linear Programming,0.41,0.36,0.09,0.0,0.09,0.0,0.0,0.05,yuyuan ouyang,
+MATH,4410,1,Intro to Stochastic Models,0.33,0.28,0.22,0.0,0.06,0.0,0.0,0.11,brian fralix,
+MATH,4530,1,Advanced Calculus I,0.29,0.29,0.29,0.05,0.05,0.0,0.0,0.05,peter kiessler,
+MATH,4540,1,Advanced Calculus II,0.36,0.32,0.12,0.08,0.04,0.0,0.0,0.08,james peterson,
+MATH,6340,1,Adv Engineering Mathematics,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,vincent ervin,
+MATH,8030,1,Stochastic Processes,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,robert lund,
+MATH,8040,1,Statistical Inference,0.76,0.0,0.12,0.0,0.0,0.0,0.0,0.12,christopher mcmahan,
+MATH,8050,1,Data Analysis,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,yingbo li,
+MATH,8090,1,Time Series Analysis,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
+MATH,8100,1,Mathematical Programming,0.46,0.38,0.08,0.0,0.0,0.0,0.0,0.08,margaret mar wiecek,
+MATH,8130,1,Advanced Linear Programming,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,matthew saltzman,
+MATH,8210,1,Linear Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,shitao liu,
+MATH,8220,1,Measure and Integration,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,mishko mitkovski,
+MATH,8530,1,Matrix Analysis,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,matthew macauley,
+MATH,8540,1,Theory of Graphs,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,wayne goddard,
+MATH,8600,1,Intro to Scientific Computing,0.36,0.57,0.0,0.0,0.0,0.0,0.0,0.07,hyesuk lee,
+MATH,8660,1,Finite Element Method,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,vincent ervin,
+MATH,9860,1,Selected Topics in Geometry,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,
+MBA,8030,1,Stat Analy of Bus Op,0.14,0.54,0.17,0.0,0.03,0.0,0.0,0.11,zachary mo leffakis,
+MBA,8060,1,Operations Mgt,0.09,0.79,0.09,0.0,0.03,0.0,0.0,0.0, sridharan,
+MBA,8070,1,Financial Management,0.66,0.27,0.07,0.0,0.0,0.0,0.0,0.0,melvin stith,
+MBA,8070,2,Financial Management,0.63,0.18,0.13,0.0,0.0,0.0,0.0,0.08,melvin stith,
+MBA,8090,1,Org Beh & Hum Res Mg,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8090,2,Org Beh & Hum Res Mg,0.56,0.42,0.03,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8190,1,Intro to Acc and Fin,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,annieka philo,
+MBA,8190,2,Intro to Acc and Fin,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,
+MBA,8290,1,Marketing Foundation,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MBA,8370,1,Legal Environ of Bus,0.28,0.7,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8430,10,Entrepreneurial Accounting,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,
+MBA,8510,10,Bus Operations & Logistics,0.77,0.19,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,
+MBA,8540,1,Mgrl Accounting,0.63,0.3,0.0,0.0,0.0,0.0,0.0,0.07,james mil kohlmeyer,
+MBA,8540,2,Mgrl Accounting,0.52,0.39,0.07,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,
+MBA,8590,1,Mgr Decision Model,0.48,0.31,0.1,0.0,0.02,0.0,0.0,0.1,mark mcknew,
+MBA,8590,2,Mgr Decision Model,0.57,0.35,0.0,0.0,0.09,0.0,0.0,0.0,sara elizabet yoder,
+MBA,8600,1,Advanced Marketing Strategy,0.38,0.5,0.12,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8610,1,Information Systems,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,varun grover,
+MBA,8610,2,Information Systems,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,kevin mckenzie,
+MBA,8620,1,Managerial Economics,0.43,0.49,0.03,0.0,0.0,0.0,0.0,0.06,ronald earl gregory,
+MBA,8700,1,Strategic Management,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8720,1,Entrepr Finance,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8750,1,Enterprise Develpmnt,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,michael george mino,
+MBA,8990,1,Advanced Leadership,0.87,0.11,0.0,0.0,0.0,0.0,0.0,0.02,gail depriest,
+MBA,8990,3,Service Innovation,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
+MBA,8990,4,Bus. Sport. Enter.,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.04,john michael hannon,
+ME,2000,1,Sophomore Seminar,0.95,0.02,0.01,0.0,0.01,0.0,0.0,0.02,donald beasley,
+ME,2010,1,Statics & Dynamics,0.06,0.16,0.24,0.22,0.24,0.0,0.0,0.07,paul joseph,
+ME,2010,2,Statics & Dynamics,0.13,0.2,0.18,0.13,0.24,0.0,0.0,0.13,lonny thompson,
+ME,2030,1,Founda Th/Fl Syst,0.09,0.28,0.35,0.11,0.05,0.0,0.0,0.11,jay ochterbeck,
+ME,2030,2,Founda Th/Fl Syst,0.16,0.2,0.28,0.11,0.16,0.0,0.0,0.08,john saylor,
+ME,2030,3,Founda Th/Fl Syst,0.38,0.38,0.11,0.02,0.0,0.0,0.0,0.11,donald beasley,
+ME,2040,1,Mechanics of Materials,0.18,0.43,0.26,0.05,0.05,0.0,0.0,0.03,michael porter,
+ME,2040,2,Mechanics of Materials,0.23,0.4,0.26,0.09,0.03,0.0,0.0,0.0,gang li,
+ME,2040,3,Mechanics of Materials,0.17,0.54,0.22,0.02,0.02,0.0,0.0,0.02,garrett pataky,
+ME,2040,302,Mechanics of Materials (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gang li,True
+ME,2220,1,Mechanical Engineering Lab I,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,2,Mechanical Engineering Lab I,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
+ME,2220,3,Mechanical Engineering Lab I,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
+ME,2220,4,Mechanical Engineering Lab I,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,5,Mechanical Engineering Lab I,0.3,0.65,0.05,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,6,Mechanical Engineering Lab I,0.37,0.32,0.21,0.05,0.0,0.0,0.0,0.05,todd schweisinger,
+ME,2220,7,Mechanical Engineering Lab I,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,todd schweisinger,
+ME,2220,8,Mechanical Engineering Lab I,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,9,Mechanical Engineering Lab I,0.25,0.5,0.08,0.0,0.0,0.0,0.0,0.17,todd schweisinger,
+ME,3030,1,Thermodynamics,0.27,0.44,0.22,0.02,0.0,0.0,0.0,0.05,daniel fant,
+ME,3030,2,Thermodynamics,0.13,0.13,0.31,0.15,0.18,0.0,0.0,0.1,richard miller,
+ME,3040,1,Heat Transfer,0.03,0.21,0.49,0.15,0.13,0.0,0.0,0.0,jean-marc delhaye,
+ME,3040,2,Heat Transfer,0.2,0.39,0.32,0.03,0.06,0.0,0.0,0.0,xin zhao,
+ME,3050,1,Model/an Dy Syst,0.18,0.42,0.2,0.05,0.08,0.0,0.0,0.07,phanin tallapragada,
+ME,3050,2,Model/an Dy Syst,0.3,0.26,0.3,0.05,0.06,0.0,0.0,0.03,joshua bostwick,
+ME,3060,1,Fund Machine Design,0.28,0.46,0.19,0.0,0.04,0.0,0.0,0.04,oliver myers,
+ME,3060,2,Fund Machine Design,0.44,0.31,0.21,0.0,0.03,0.0,0.0,0.0,paul jeffrey meyer,
+ME,3070,1,Found of Mechanical Systems,0.27,0.5,0.14,0.02,0.0,0.0,0.0,0.07,lonny thompson,
+ME,3070,2,Found of Mechanical Systems,0.19,0.63,0.14,0.02,0.0,0.0,0.0,0.02,gregory mocko,
+ME,3080,1,Fluid Mechanics,0.05,0.18,0.33,0.2,0.15,0.0,0.0,0.1,jean-marc delhaye,
+ME,3080,2,Fluid Mechanics,0.14,0.3,0.47,0.04,0.04,0.0,0.0,0.02,ethan kung,
+ME,3100,1,Thermo/Heat Transfer,0.28,0.24,0.34,0.03,0.07,0.0,0.0,0.03,xiangchun xuan,
+ME,3120,1,Manuf Processes,0.36,0.45,0.16,0.02,0.0,0.0,0.0,0.01,hong seok choi,
+ME,3330,1,Mechanical Engineering Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,2,Mechanical Engineering Lab II,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,3,Mechanical Engineering Lab II,0.18,0.76,0.0,0.0,0.06,0.0,0.0,0.0,todd schweisinger,
+ME,3330,4,Mechanical Engineering Lab II,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,5,Mechanical Engineering Lab II,0.21,0.57,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,6,Mechanical Engineering Lab II,0.25,0.42,0.17,0.0,0.08,0.0,0.0,0.08,todd schweisinger,
+ME,3330,7,Mechanical Engineering Lab II,0.25,0.56,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,3330,8,Mechanical Engineering Lab II,0.2,0.5,0.2,0.0,0.0,0.0,0.0,0.1,todd schweisinger,
+ME,4010,1,Mech Engr Design,0.49,0.39,0.08,0.03,0.0,0.0,0.0,0.01,cameron turner,
+ME,4020,1,Intern in Engr Des,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,donald beasley,
+ME,4020,3,Intern in Engr Des,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,4,Intern in Engr Des,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
+ME,4020,5,Intern in Engr Des,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4020,7,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,
+ME,4020,8,Intern in Engr Des,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,4020,9,Intern in Engr Des,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,donald beasley,
+ME,4030,1,Control Dynamic Systems,0.18,0.5,0.25,0.03,0.03,0.0,0.0,0.03,suyi li,
+ME,4030,2,Control Dynamic Systems,0.24,0.45,0.31,0.0,0.0,0.0,0.0,0.0,yue wang,
+ME,4170,1,Mechatronic Sys,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4180,1,F E A in M E Design,0.48,0.39,0.09,0.0,0.0,0.0,0.0,0.04,istemi baris ozsoy,
+ME,4220,1,Design Gas Turbines,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,abhijit som,
+ME,4230,1,Intro Aerodynamics,0.34,0.46,0.17,0.0,0.03,0.0,0.0,0.0,richard figliola,
+ME,4260,1,Nuclear Energy,0.44,0.44,0.04,0.04,0.0,0.0,0.0,0.04,richard watkins,
+ME,4300,1,Mech Comp Materials,0.14,0.43,0.38,0.05,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,4440,1,Mechanical Engineering Lab III,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,2,Mechanical Engineering Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,3,Mechanical Engineering Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,4,Mechanical Engineering Lab III,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,5,Mechanical Engineering Lab III,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,7,Mechanical Engineering Lab III,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4930,5,SelectedTopics ME - RapidProto,0.74,0.17,0.09,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4930,11,Selected Topics ME: MicroFab,0.23,0.54,0.15,0.08,0.0,0.0,0.0,0.0,rod martinez-duarte,
+ME,4930,28,Selected Topics ME: HVAC,0.28,0.48,0.12,0.0,0.0,0.0,0.0,0.12,donald willoughby,
+ME,4930,29,Selected Topics ME: Solar E,0.62,0.28,0.07,0.0,0.03,0.0,0.0,0.0,daniel fant,
+ME,6170,1,Mechatronic Sys,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,6300,1,Mech Comp Materials,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,6300,401,Mech Comp Materials,0.44,0.44,0.0,0.0,0.11,0.0,0.0,0.0,huijuan zhao,
+ME,8120,1,Exp Meth Thermal Sci,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
+ME,8190,1,Cp Meth in Therm Sc,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,richard miller,
+ME,8200,1,Mod Cont Engr,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
+ME,8310,1,Convective Ht Trans,0.31,0.19,0.25,0.0,0.25,0.0,0.0,0.0,john saylor,
+ME,8520,1,Adv Finite Ele Ana,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gang li,
+ME,8610,1,Matl Sel Engr Design,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,mica grujicic,
+ME,8730,1,Res Mthds Coll Desgn,0.43,0.43,0.0,0.0,0.14,0.0,0.0,0.0,joshua summers,
+ME,8930,27,Sel Topics in ME - Cont Mech,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
+MGT,2010,1,Principles of Management,0.29,0.38,0.27,0.04,0.01,0.0,0.0,0.01,katherine clark,
+MGT,2010,2,Principles of Management,0.47,0.34,0.14,0.02,0.0,0.0,0.0,0.03,katherine clark,
+MGT,2010,3,Principles of Management,0.4,0.41,0.15,0.01,0.02,0.0,0.0,0.01,katherine clark,
+MGT,2010,4,Principles of Management,0.34,0.39,0.24,0.02,0.0,0.0,0.0,0.01,katherine clark,
+MGT,2010,5,Principles of Management,0.45,0.42,0.12,0.01,0.0,0.0,0.0,0.0,tina robbins,
+MGT,2010,6,Principles of Management,0.46,0.43,0.08,0.01,0.0,0.0,0.0,0.01,tina robbins,
+MGT,2010,7,Principles of Management,0.38,0.39,0.15,0.04,0.01,0.0,0.0,0.02,tina robbins,
+MGT,2010,8,Principles of Management,0.33,0.45,0.16,0.01,0.02,0.0,0.0,0.02,tina robbins,
+MGT,2010,9,Principles of Management (HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
+MGT,2180,1,Management PC Applications,0.45,0.35,0.13,0.01,0.02,0.0,0.0,0.04,ryan toole,
+MGT,2180,2,Management PC Applications,0.49,0.33,0.07,0.03,0.02,0.0,0.0,0.05,ryan toole,
+MGT,2180,3,Management PC Applications,0.56,0.27,0.09,0.02,0.02,0.0,0.0,0.04,ryan toole,
+MGT,2180,4,Management PC Applications,0.42,0.42,0.07,0.04,0.02,0.0,0.0,0.02,ryan toole,
+MGT,2970,1,How to Start a Startup,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23,john michael hannon,
+MGT,2970,2,How to Start a Startup,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,john michael hannon,
+MGT,3070,1,Human Resource Management,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,2,Human Resource Management,0.55,0.43,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,3,Human Resource Management,0.53,0.35,0.13,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,4,Human Resource Management,0.42,0.33,0.09,0.06,0.06,0.0,0.0,0.03,priscilla harrison,
+MGT,3070,6,Human Resource Management,0.15,0.74,0.12,0.0,0.0,0.0,0.0,0.0,kristin dam scott,
+MGT,3100,1,Intermed Business Statistics,0.5,0.29,0.19,0.0,0.0,0.0,0.0,0.02,jerry kermi bilbrey,
+MGT,3100,2,Intermed Business Statistics,0.25,0.3,0.23,0.03,0.18,0.0,0.0,0.03,ezg akpinar ferrand,
+MGT,3100,3,Intermed Business Statistics,0.36,0.23,0.21,0.08,0.08,0.0,0.0,0.05,ezg akpinar ferrand,
+MGT,3100,4,Intermed Business Statistics,0.18,0.28,0.2,0.28,0.05,0.0,0.0,0.03,sara elizabet yoder,
+MGT,3100,5,Intermed Business Statistics,0.8,0.13,0.04,0.02,0.0,0.0,0.0,0.0,shih lun tseng,
+MGT,3100,6,Intermed Business Statistics,0.44,0.37,0.2,0.0,0.0,0.0,0.0,0.0,jerry kermi bilbrey,
+MGT,3100,7,Intermed Business Statistics,0.17,0.34,0.22,0.1,0.1,0.0,0.0,0.07,sara elizabet yoder,
+MGT,3100,8,Intermed Business Statistics,0.18,0.18,0.38,0.05,0.18,0.0,0.0,0.03,sara elizabet yoder,
+MGT,3100,10,Intermed Business Statistics,0.39,0.42,0.13,0.0,0.03,0.0,0.0,0.03,jerry kermi bilbrey,
+MGT,3100,11,Intermed Business Statistics,0.49,0.18,0.11,0.07,0.09,0.0,0.0,0.07,yunsik choi,
+MGT,3100,12,Intermed Business Statistics,0.21,0.28,0.23,0.05,0.08,0.0,0.0,0.15,dan jiang,
+MGT,3120,1,Decision Models for Management,0.29,0.31,0.29,0.07,0.02,0.0,0.0,0.02,mark mcknew,
+MGT,3120,2,Decision Models for Management,0.22,0.28,0.3,0.09,0.09,0.0,0.0,0.02,mark mcknew,
+MGT,3120,3,Decision Models for Management,0.2,0.32,0.3,0.07,0.07,0.0,0.0,0.05,mark mcknew,
+MGT,3150,1,New Venture Creation,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
+MGT,3180,1,Mgt of Info Systems,0.65,0.25,0.05,0.05,0.0,0.0,0.0,0.0,jackie patri london,
+MGT,3180,2,Mgt of Info Systems,0.78,0.2,0.03,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,
+MGT,3180,3,Mgt of Info Systems,0.18,0.5,0.25,0.0,0.02,0.0,0.0,0.05,russell purvis,
+MGT,3180,4,Mgt of Info Systems,0.39,0.39,0.19,0.03,0.0,0.0,0.0,0.0,roopa raman,
+MGT,3900,2,Ops Mgt,0.23,0.23,0.15,0.15,0.18,0.0,0.0,0.08,niratc tungtisanont,
+MGT,3900,3,Ops Mgt,0.05,0.36,0.36,0.08,0.08,0.0,0.0,0.08,zachary mo leffakis,
+MGT,3900,4,Ops Mgt,0.58,0.23,0.18,0.03,0.0,0.0,0.0,0.0,berna quiroga gomez,
+MGT,3900,5,Ops Mgt,0.18,0.38,0.23,0.13,0.08,0.0,0.0,0.03,shouqiang wang,
+MGT,3900,6,Ops Mgt,0.64,0.26,0.1,0.0,0.0,0.0,0.0,0.0,berna quiroga gomez,
+MGT,4000,2,Mgt of Organizational Behavior,0.53,0.38,0.05,0.0,0.05,0.0,0.0,0.0,michael cole,
+MGT,4000,3,Mgt of Organizational Behavior,0.1,0.46,0.36,0.0,0.08,0.0,0.0,0.0,philip roth,
+MGT,4000,4,Mgt of Organizational Behavior,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4020,1,Ops Pln and Ctl,0.06,0.67,0.22,0.0,0.0,0.0,0.0,0.06,zachary mo leffakis,
+MGT,4080,1,Lean Operations,0.29,0.45,0.24,0.0,0.02,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4110,1,Project Management,0.24,0.38,0.29,0.0,0.05,0.0,0.0,0.05,russell purvis,
+MGT,4120,1,Supplier Management,0.18,0.42,0.34,0.05,0.0,0.0,0.0,0.0,shouqiang wang,
+MGT,4150,1,Business Strategy,0.16,0.36,0.4,0.02,0.04,0.0,0.0,0.02,peter gianiodis,
+MGT,4150,2,Business Strategy,0.2,0.56,0.24,0.0,0.0,0.0,0.0,0.0,peter gianiodis,
+MGT,4150,3,Business Strategy,0.36,0.62,0.0,0.0,0.0,0.0,0.0,0.02,john edward hopkins,
+MGT,4150,4,Business Strategy,0.32,0.55,0.13,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,5,Business Strategy,0.48,0.35,0.13,0.02,0.02,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,6,Business Strategy,0.44,0.51,0.04,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4150,7,Business Strategy,0.45,0.52,0.02,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,10,Business Strategy,0.24,0.73,0.02,0.0,0.0,0.0,0.0,0.0,john edward hopkins,
+MGT,4160,1,Special Topics Hr,0.34,0.4,0.26,0.0,0.0,0.0,0.0,0.0,kristin dam scott,
+MGT,4230,1,Intern Bus Mgt,0.08,0.18,0.54,0.05,0.1,0.0,0.0,0.05,wayne stewart,
+MGT,4230,2,Intern Bus Mgt,0.13,0.55,0.3,0.03,0.0,0.0,0.0,0.0,janis miller,
+MGT,4230,3,Intern Bus Mgt,0.14,0.19,0.6,0.05,0.02,0.0,0.0,0.0,wayne stewart,
+MGT,4240,1,Global Supply Chain,0.17,0.58,0.21,0.0,0.04,0.0,0.0,0.0,yann ferrand,
+MGT,4310,1,Emp Rights & Resp,0.31,0.49,0.16,0.02,0.0,0.0,0.0,0.02,leonard jos spooner,
+MGT,4350,1,Pers Interviewing,0.23,0.58,0.13,0.03,0.03,0.0,0.0,0.03,philip roth,
+MGT,4520,1,Business Analysis,0.19,0.43,0.38,0.0,0.0,0.0,0.0,0.0,roopa raman,
+MGT,4550,1,Emerging I T Trends,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MGT,4560,1,Business Info Mgt,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,siyuan li,
+MGT,8120,1,Supply Chain Mgt,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,yann ferrand,
+MICR,3050,1,General Microbiology,0.51,0.34,0.13,0.0,0.0,0.0,0.0,0.01,kristi ja whitehead,
+MICR,3050,2,General Microbiology,0.44,0.37,0.15,0.03,0.01,0.0,0.0,0.01,krista barr rudolph,
+MICR,3050,3,General Microbiology,0.52,0.42,0.02,0.0,0.02,0.0,0.0,0.02,krista barr rudolph,
+MICR,4000,1,Public Health Micro,0.5,0.31,0.09,0.05,0.03,0.0,0.0,0.02,kristi ja whitehead,
+MICR,4020,1,Environmental Micro,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,john michael henson,
+MICR,4070,1,Food and Dairy Micro,0.26,0.46,0.24,0.0,0.0,0.0,0.0,0.04,xiuping jiang,
+MICR,4110,1,Pathogenic Bact,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4120,1,Bacterial Physiology,0.24,0.31,0.22,0.08,0.1,0.0,0.0,0.06,thomas hughes,
+MICR,4130,1,Industrial Micro,0.39,0.37,0.16,0.04,0.01,0.0,0.0,0.03,tzuen-rong je tzeng,
+MICR,4140,1,Basic Immunology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,
+MICR,4170,1,Cancer and Aging,0.87,0.06,0.06,0.0,0.0,0.0,0.0,0.0,yuqing dong,
+MICR,4500,1,Advanced Microbiology I,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4500,2,Advanced Microbiology I,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4500,3,Advanced Microbiology I,0.54,0.15,0.08,0.0,0.08,0.0,0.0,0.15,harry kurtz,
+MICR,4520,1,Advanced Microbiology III,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4930,2,Senior Seminar,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,barbara campbell,
+MKT,3010,1,Prin of Marketing,0.34,0.38,0.17,0.05,0.04,0.0,0.0,0.02,carter wil mcelveen,
+MKT,3010,2,Prin of Marketing,0.26,0.35,0.29,0.05,0.03,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,3,Prin of Marketing,0.21,0.5,0.19,0.03,0.02,0.01,0.0,0.04,james gaubert,
+MKT,3010,4,Prin of Marketing,0.28,0.5,0.19,0.01,0.01,0.0,0.0,0.02,james gaubert,
+MKT,3010,5,Prin of Marketing,0.45,0.38,0.11,0.02,0.04,0.0,0.0,0.0,patricia knowles,
+MKT,3020,1,Consumer Behavior,0.46,0.37,0.12,0.02,0.03,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,2,Consumer Behavior,0.6,0.28,0.09,0.02,0.02,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,3,Consumer Behavior,0.28,0.52,0.13,0.06,0.0,0.0,0.0,0.02, thyroff fitzwater,
+MKT,3020,4,Consumer Behavior,0.35,0.43,0.14,0.05,0.0,0.0,0.0,0.03, thyroff fitzwater,
+MKT,3020,5,Consumer Behavior,0.28,0.48,0.24,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,3210,1,Sports Marketing,0.53,0.39,0.06,0.0,0.02,0.0,0.0,0.0,delancy bennett,
+MKT,3210,2,Sports Marketing,0.5,0.43,0.08,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,
+MKT,3310,1,Marketing Metrics & Analytics,0.26,0.52,0.17,0.04,0.0,0.0,0.0,0.0,peter weathers,
+MKT,3980,1,CI: Sales Experiential,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,
+MKT,4200,1,Professional Selling,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,2,Professional Selling,0.33,0.37,0.17,0.1,0.03,0.0,0.0,0.0,jesse moore,
+MKT,4200,3,Professional Selling,0.84,0.13,0.0,0.0,0.03,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4200,4,Professional Selling,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4230,1,Promotional Strategy,0.44,0.38,0.11,0.02,0.04,0.0,0.0,0.0,patricia knowles,
+MKT,4240,2,Sales Management,0.3,0.66,0.05,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4250,1,Retail Management,0.58,0.38,0.0,0.0,0.02,0.0,0.0,0.02,james gaubert,
+MKT,4270,1,International Mktg,0.2,0.65,0.08,0.03,0.0,0.0,0.0,0.05,thomas poehlman,
+MKT,4270,2,International Mktg,0.23,0.5,0.23,0.02,0.0,0.0,0.0,0.02,roger gomes,
+MKT,4270,3,International Mktg,0.26,0.38,0.33,0.0,0.0,0.0,0.0,0.03,roger gomes,
+MKT,4270,4,International Mktg,0.1,0.49,0.28,0.03,0.08,0.0,0.0,0.03,roger gomes,
+MKT,4270,600,International Mktg,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4280,1,Services Marketing,0.49,0.18,0.23,0.08,0.0,0.0,0.0,0.03,stephen grove,
+MKT,4280,2,Services Marketing,0.28,0.47,0.17,0.08,0.0,0.0,0.0,0.0,stephen grove,
+MKT,4310,1,Marketing Research,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4310,2,Marketing Research,0.25,0.42,0.29,0.0,0.04,0.0,0.0,0.0,william kilbourne,
+MKT,4310,3,Marketing Research,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,4,Marketing Research,0.4,0.48,0.12,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4330,1,Sport Mkt Strategy,0.41,0.48,0.07,0.0,0.0,0.03,0.0,0.0,amanda cooper fine,
+MKT,4430,1,Advertising Strategy,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,albert neil cameron,
+MKT,4450,1,Macromarketing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4500,2,Strategic Mktg Mgt,0.77,0.2,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,
+MKT,4500,3,Strategic Mktg Mgt,0.52,0.41,0.03,0.03,0.0,0.0,0.0,0.0,lura forcum,
+MKT,4500,4,Strategic Mktg Mgt,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,4950,1,Selected Topics: Social Media,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,8620,1,Quant Methods in Mkt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
+MKT,8650,1,Seminar in Mkt Mgmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+ML,1020,1,Leadership Fund II,0.76,0.17,0.0,0.0,0.0,0.0,0.0,0.07,amanda carol kane,
+ML,4020,3,Organizational Leadership II,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,james mullinax,
+MSE,2100,2,Intro to Mat Science,0.16,0.54,0.19,0.02,0.04,0.0,0.0,0.05,kyle brinkman,
+MSE,2100,3,Intro to Mat Science,0.21,0.46,0.16,0.05,0.04,0.0,0.0,0.08,eric skaar,
+MSE,2100,4,Intro to Mat Science,0.4,0.28,0.09,0.09,0.07,0.0,0.0,0.07,olga kuksenok,
+MSE,2100,5,Intro to Mat Science,0.31,0.31,0.27,0.02,0.0,0.0,0.0,0.08,rakhee pani,
+MSE,2410,1,Metrics,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
+MSE,2500,1,Polymer & Fiber Materials I,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,deborah lickfield,
+MSE,2500,2,Polymer & Fiber Materials I,0.36,0.29,0.29,0.0,0.0,0.0,0.0,0.07,deborah lickfield,
+MSE,3260,1,Thermo of Materials,0.15,0.43,0.26,0.08,0.03,0.0,0.0,0.05,gary lickfield,
+MSE,3280,1,Phase Diagrams,0.4,0.37,0.23,0.0,0.0,0.0,0.0,0.0,eric skaar,
+MSE,3610,1,Proc of Metals & Com,0.41,0.36,0.23,0.0,0.0,0.0,0.0,0.0,marian kennedy,
+MSE,4150,1,Polymer Sc Engr,0.33,0.33,0.22,0.07,0.0,0.0,0.0,0.04,igor luzinov,
+MSE,4160,1,Electronic Materials,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
+MSE,4220,1,Mech Behavior of Mat,0.31,0.47,0.17,0.0,0.05,0.0,0.0,0.0,vincent yves blouin,
+MSE,4240,1,Optical Materials,0.28,0.48,0.16,0.08,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,4330,1,Comb Sys & Env Emiss,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,denis brosnan,
+MSE,4560,1,Polymer & Fiber Materials II,0.37,0.41,0.19,0.0,0.0,0.0,0.0,0.04,gary lickfield,
+MSE,4590,2,Color Science Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,philip brown,
+MSE,4910,1,Undergraduate Research,0.59,0.24,0.09,0.03,0.0,0.0,0.0,0.06,marian kennedy,
+MUSC,1110,7,Beginning Class Guitar,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,david stevenson,
+MUSC,1420,1,Music Theory I,0.79,0.07,0.0,0.0,0.07,0.0,0.0,0.07,anthony bernarducci,
+MUSC,1430,1,Aural Skills I,0.86,0.0,0.0,0.0,0.07,0.0,0.0,0.07,anthony bernarducci,
+MUSC,1510,2,Applied Music,0.55,0.0,0.09,0.0,0.09,0.0,0.0,0.27,jonathan edwa doyel,
+MUSC,1800,1,Intro to Music Tech,0.2,0.5,0.1,0.0,0.2,0.0,0.0,0.0,hamilton altstatt,
+MUSC,2100,1,Music in the Western World,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,2100,2,Music in the Western World,0.59,0.22,0.06,0.06,0.0,0.0,0.0,0.06,lisa sain odom,
+MUSC,2100,3,Music in the Western World,0.88,0.06,0.0,0.03,0.03,0.0,0.0,0.0,eric lapin,
+MUSC,2100,4,Music in the Western World,0.65,0.1,0.13,0.06,0.0,0.0,0.0,0.06,linda li-bleuel,
+MUSC,2100,5,Music in the Western World,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,6,Music in the Western World,0.67,0.2,0.07,0.03,0.03,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,7,Music in the Western World,0.48,0.48,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,12,Music in the Western World,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,
+MUSC,2100,13,Music in the Western World,0.84,0.06,0.03,0.0,0.03,0.0,0.0,0.03,linda dzuris,
+MUSC,2100,14,Music in the Western World,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,david conley,
+MUSC,3090,1,Surv of Broadway II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,lisa sain odom,
+MUSC,3110,1,History of American Music,0.78,0.16,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,3170,1,Hist of Country Mus,0.78,0.16,0.0,0.03,0.03,0.0,0.0,0.0,ned hosler,
+MUSC,3180,1,Hist of Audio Tech,0.5,0.21,0.21,0.07,0.0,0.0,0.0,0.0,bruce allen whisler,
+MUSC,3310,1,Pep Band - Men,0.96,0.03,0.0,0.0,0.0,0.0,0.0,0.01,timothy ra hurlburt,
+MUSC,3640,1,Concert Band,0.91,0.01,0.03,0.0,0.0,0.0,0.0,0.04,timothy ra hurlburt,
+MUSC,3690,1,Symphony Orchestra,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,True
+MUSC,3700,1,Clemson University Singers,0.91,0.02,0.05,0.0,0.0,0.0,0.0,0.02,justin durham,
+MUSC,3710,1,Women's Chorus,0.96,0.0,0.02,0.02,0.0,0.0,0.0,0.0,justin durham,
+MUSC,3720,1,Men's Chorus,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,
+MUSC,4160,1,Mus Hist Since 1750,0.39,0.22,0.22,0.06,0.06,0.0,0.0,0.06,linda li-bleuel,
+NPL,3010,2,NPL Stakeholders,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,tracy diane lamb,
+NPL,3030,2,NPL Personnel,0.77,0.09,0.0,0.0,0.09,0.0,0.0,0.05,wendell price,
+NURS,3030,1,Nursing of Adults,0.15,0.75,0.1,0.0,0.0,0.0,0.0,0.0,leslie anne  ravan,
+NURS,3030,400,Nursing of Adults,0.08,0.77,0.12,0.0,0.0,0.0,0.0,0.04,lena marie burgess,
+NURS,3040,1,Pathophysiology,0.29,0.47,0.14,0.04,0.02,0.0,0.0,0.04,catherine si murton,
+NURS,3040,401,Pathophysiology for RN,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
+NURS,3100,1,Health Assessment,0.62,0.36,0.0,0.0,0.0,0.0,0.0,0.02,terry kaye busby,
+NURS,3120,1,Foundations of Nursing,0.38,0.51,0.06,0.0,0.02,0.0,0.0,0.02,angela pye,
+NURS,3190,400,Health Assessment for RNs,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,
+NURS,3190,401,Health Assessment for RNs,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kellie davis-hall,
+NURS,3200,1,Prof in Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3300,1,Research in Nursing,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,shirley mae timmons,
+NURS,3330,1,Health Care Genetics,0.93,0.05,0.0,0.02,0.0,0.0,0.0,0.0,jane marie deluca,
+NURS,3330,400,Health Care Genetics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+NURS,3400,1,Pharmther Nursing,0.28,0.53,0.11,0.04,0.0,0.0,0.0,0.04,catherine si murton,
+NURS,3600,400,Social Determinants in Health,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,roxanne amerson,
+NURS,4010,1,Mental Health Nurs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NURS,4100,1,Lead Mgt Practicum,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,sheri smith webster,
+NURS,4110,1,Nursing of Children,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,
+NURS,4120,1,Nurs Women and Fam,0.68,0.3,0.03,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8010,400,Adv Fam & Comm Nrsng,0.8,0.18,0.02,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
+NURS,8080,400,Nurs Res Stat Analys,0.69,0.28,0.02,0.0,0.02,0.0,0.0,0.0,veronica parker,
+NURS,8190,400,Developing Family,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,paula watt,
+NURS,8200,400,Child & Adol Nursing,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,heide temples,
+NURS,8210,400,Adult Nursing,0.71,0.27,0.0,0.0,0.0,0.0,0.0,0.02,tracy king fasolino,
+NURS,8850,400,Mental Health in Primary Care,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.48,0.32,0.13,0.04,0.02,0.0,0.0,0.02,deborah an hutcheon,
+NUTR,2030,2,Intro Princ of Human Nutrition,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
+NUTR,2040,1,Nutrition Across Life Cycle,0.22,0.53,0.15,0.05,0.03,0.0,0.0,0.02,deborah an hutcheon,
+NUTR,4180,1,Prof Development in Dietetics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,deborah an hutcheon,
+NUTR,4250,1,Medica Nutr Thera II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4260,1,Community Nutrition,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,katherine cason,
+NUTR,4550,1,Nutr Metabolism,0.34,0.26,0.2,0.14,0.06,0.0,0.0,0.0,elliot jesch,
+NUTR,8030,1,Adv Human Nutr,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,vivian haley-zitlin,
+PA,2800,1,Perf Arts Pract II,0.5,0.29,0.07,0.0,0.0,0.0,0.0,0.14,kenneth moore,
+PA,3010,1,Prin of Arts Admin,0.46,0.23,0.31,0.0,0.0,0.0,0.0,0.0,paul buyer,
+PA,4010,1,Capstone Project,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
+PADM,8210,400,Perspectives on Public Admin,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,
+PADM,8290,400,Public Financial Management,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,
+PADM,8410,400,Public Data Analysis,0.27,0.27,0.18,0.0,0.27,0.0,0.0,0.0,ronald chrestman,
+PADM,8430,400,Info Systems for Public Admin,0.5,0.13,0.13,0.0,0.0,0.0,0.0,0.25,mark daniel mellott,
+PADM,8530,400,Homeland Sec/Emergency Mgt Law,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,david leigh cook,
+PADM,8600,400,American Government,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
+PADM,8720,400,Rural Development,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,
+PADM,8780,400,Nonprofit Marketing & Pub Rel,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,debra nelson,
+PES,2020,1,Soils,0.03,0.5,0.36,0.07,0.0,0.0,0.0,0.03,dara michelle park,
+PES,4050,1,Plant Breeding,0.47,0.33,0.07,0.07,0.0,0.0,0.0,0.07,ksenija gasic,
+PES,4220,1,Major World Crops,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,sruthi naraya kutty,
+PES,4460,1,Soil Management,0.23,0.62,0.08,0.0,0.0,0.0,0.0,0.08,dara michelle park,
+PES,4520,1,Soil Fertility and Management,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,haibo liu,
+PES,4900,1,Soil Organisms in Plant Growth,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,"appukuttan suseela,",
+PES,4960,1,BioIntegrated Greenhouse Sys.,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,geoffrey zehnder,
+PHIL,1010,1,Intro to Philosophic Problems,0.57,0.29,0.09,0.03,0.0,0.0,0.0,0.03,david stegall,
+PHIL,1010,2,Intro to Philosophic Problems,0.56,0.24,0.09,0.06,0.0,0.0,0.0,0.06,david stegall,
+PHIL,1010,5,Intro to Philosophic Problems,0.26,0.4,0.2,0.03,0.06,0.0,0.0,0.06,john randall wolfe,
+PHIL,1010,6,Intro to Philosophic Problems,0.34,0.37,0.14,0.0,0.11,0.0,0.0,0.03,john randall wolfe,
+PHIL,1010,7,Intro to Philosophic Problems,0.44,0.41,0.06,0.03,0.0,0.0,0.0,0.06,john randall wolfe,
+PHIL,1020,1,Introduction to Logic,0.81,0.03,0.13,0.0,0.03,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,2,Introduction to Logic,0.58,0.33,0.03,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
+PHIL,1020,3,Introduction to Logic,0.91,0.03,0.0,0.0,0.03,0.0,0.0,0.03,gregory scott moss,
+PHIL,1020,4,Introduction to Logic,0.86,0.09,0.0,0.0,0.03,0.0,0.0,0.03,gregory scott moss,
+PHIL,1020,6,Introduction to Logic,0.45,0.19,0.29,0.06,0.0,0.0,0.0,0.0,stephen satris,
+PHIL,1030,2,Introduction to Ethics,0.17,0.43,0.14,0.11,0.11,0.0,0.0,0.03,malcolm edwa munson,
+PHIL,1030,3,Introduction to Ethics,0.26,0.43,0.29,0.0,0.03,0.0,0.0,0.0,malcolm edwa munson,
+PHIL,1030,5,Introduction to Ethics,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,adam gies,
+PHIL,1030,6,Introduction to Ethics,0.74,0.18,0.03,0.0,0.06,0.0,0.0,0.0,adam gies,
+PHIL,1030,7,Introduction to Ethics,0.41,0.43,0.14,0.03,0.0,0.0,0.0,0.0,ryan lake,
+PHIL,1030,8,Introduction to Ethics,0.41,0.47,0.09,0.03,0.0,0.0,0.0,0.0,ryan lake,
+PHIL,1030,9,Introduction to Ethics,0.47,0.37,0.0,0.0,0.05,0.0,0.0,0.11,ryan lake,
+PHIL,1030,11,Introduction to Ethics,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,jennifer ingle,
+PHIL,1030,12,Introduction to Ethics,0.44,0.41,0.0,0.03,0.0,0.0,0.0,0.12,jennifer ingle,
+PHIL,3030,1,Phil of Religion,0.7,0.23,0.0,0.03,0.0,0.0,0.0,0.03,gregory scott moss,
+PHIL,3150,1,Ancient Philosophy,0.4,0.3,0.13,0.0,0.13,0.0,0.0,0.03,john randall wolfe,
+PHIL,3160,1,Modern Philosophy,0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,michael hal hannen,
+PHIL,3200,1,Soc and Pol Phil,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,david stegall,
+PHIL,3210,1,Crime & Punishment,0.76,0.21,0.0,0.0,0.03,0.0,0.0,0.0,ryan lake,
+PHIL,3260,1,Science and Values,0.53,0.38,0.06,0.0,0.03,0.0,0.0,0.0,andrew garnar,
+PHIL,3260,2,Science and Values,0.53,0.38,0.03,0.0,0.06,0.0,0.0,0.0,andrew garnar,
+PHIL,3430,1,Philosophy of Law,0.7,0.21,0.0,0.0,0.0,0.0,0.0,0.09,david stegall,
+PHIL,3440,1,Business Ethics,0.23,0.69,0.09,0.0,0.0,0.0,0.0,0.0,diane perpich,
+PHIL,3450,1,Environmental Ethics,0.6,0.26,0.06,0.03,0.03,0.0,0.0,0.03,jennifer ingle,
+PHIL,3550,1,Philosophy of Mind & Cog Scien,0.53,0.29,0.0,0.06,0.06,0.0,0.0,0.06,adam gies,
+PHIL,3700,1,Philosophy of War,0.34,0.41,0.13,0.0,0.03,0.0,0.0,0.09,todd may,
+PHIL,4750,1,Philosophy of Film,0.38,0.38,0.06,0.0,0.13,0.06,0.0,0.0,christopher grau,
+PHSC,1170,1,Intro Chem & Earth,0.91,0.08,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics with Calculus I,0.26,0.23,0.26,0.14,0.07,0.0,0.0,0.05,lih-sin the,
+PHYS,1220,2,Physics with Calculus I,0.22,0.35,0.19,0.1,0.06,0.0,0.0,0.08,lih-sin the,
+PHYS,1220,3,Physics with Calculus I,0.27,0.43,0.19,0.06,0.03,0.0,0.0,0.02,lih-sin the,
+PHYS,1220,4,Physics with Calculus I,0.38,0.4,0.14,0.04,0.01,0.0,0.0,0.01,hye jung kang,
+PHYS,1220,5,Physics with Calculus I,0.32,0.37,0.23,0.03,0.03,0.0,0.0,0.02,pooja puneet,
+PHYS,1220,8,Physics With Cal I (HON),0.56,0.26,0.09,0.0,0.0,0.0,0.0,0.09,ramakrishna podila,True
+PHYS,1240,1,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,2,Physics Lab I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,3,Physics Lab I,0.12,0.88,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,4,Physics Lab I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,5,Physics Lab I,0.41,0.47,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
+PHYS,1240,6,Physics Lab I,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,7,Physics Lab I,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,8,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,9,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,10,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,11,Physics Lab I,0.22,0.5,0.0,0.0,0.0,0.0,0.0,0.28,jerry hester,
+PHYS,1240,12,Physics Lab I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,13,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,14,Physics Lab I,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,jerry hester,
+PHYS,1240,15,Physics Lab I,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,16,Physics Lab I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,17,Physics Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,18,Physics Lab I,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,19,Physics Lab I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,20,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,21,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,22,Physics Lab I,0.38,0.44,0.0,0.0,0.0,0.0,0.0,0.19,jerry hester,
+PHYS,1240,23,Physics Lab I,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,jerry hester,
+PHYS,1240,24,Physics Lab I,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,25,Physics Lab I,0.24,0.65,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,26,Physics Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,27,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,29,Physics Lab I,0.22,0.5,0.17,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,30,Physics Lab I,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2000,1,Introductory Physics,0.26,0.49,0.17,0.09,0.0,0.0,0.0,0.0,sean brittain,
+PHYS,2070,1,General Physics I,0.34,0.36,0.16,0.06,0.03,0.0,0.0,0.05,pooja puneet,
+PHYS,2080,1,General Physics II,0.63,0.25,0.07,0.04,0.0,0.0,0.0,0.0,amy liann pope,
+PHYS,2080,2,General Physics II,0.53,0.31,0.08,0.04,0.03,0.0,0.0,0.0,amy liann pope,
+PHYS,2090,1,Gen Phys Lab I,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,2,Gen Phys Lab I,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,jerry hester,
+PHYS,2090,3,Gen Phys Lab I,0.27,0.55,0.14,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,4,Gen Phys Lab I,0.41,0.41,0.05,0.05,0.0,0.0,0.0,0.09,jerry hester,
+PHYS,2090,5,Gen Phys Lab I,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,6,Gen Phys Lab I,0.75,0.21,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,7,Gen Phys Lab I,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,8,Gen Phys Lab I,0.57,0.39,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,9,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,10,Gen Phys Lab I,0.14,0.71,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,1,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,2,Gen Phys Lab II,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,3,Gen Phys Lab II,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,5,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,6,Gen Phys Lab II,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,7,Gen Phys Lab II,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,8,Gen Phys Lab II,0.75,0.21,0.0,0.04,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,9,Gen Phys Lab II,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,10,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,11,Gen Phys Lab II,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,12,Gen Phys Lab II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,13,Gen Phys Lab II,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,14,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,15,Gen Phys Lab II,0.5,0.33,0.08,0.0,0.04,0.0,0.0,0.04,jerry hester,
+PHYS,2100,16,Gen Phys Lab II,0.28,0.61,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,
+PHYS,2100,17,Gen Phys Lab II,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,18,Gen Phys Lab II,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2210,1,Physics with Calculus II,0.28,0.4,0.24,0.04,0.03,0.0,0.0,0.01,jason stratfo brown,
+PHYS,2210,2,Physics with Calculus II,0.33,0.38,0.14,0.11,0.03,0.0,0.0,0.02,jason stratfo brown,
+PHYS,2210,3,Physics with Calculus II,0.36,0.29,0.29,0.0,0.07,0.0,0.0,0.0,murray daw,
+PHYS,2210,5,Physics with Calculus II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,edward collins,
+PHYS,2220,1,Physics with Calculus III,0.36,0.36,0.11,0.0,0.0,0.0,0.0,0.18,jian he,
+PHYS,2230,1,Physics Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,2,Physics Lab II,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,3,Physics Lab II,0.53,0.35,0.0,0.0,0.0,0.0,0.0,0.12,jerry hester,
+PHYS,2230,4,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,5,Physics Lab II,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,6,Physics Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,7,Physics Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,8,Physics Lab II,0.06,0.61,0.17,0.06,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,2230,9,Physics Lab II,0.33,0.4,0.2,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,2230,10,Physics Lab II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,edward collins,
+PHYS,2240,1,Physics Lab III,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,2400,1,Phys of Weather,0.33,0.4,0.18,0.0,0.03,0.0,0.0,0.08,miguel larsen,
+PHYS,3110,1,Methods Theor Phys,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,feng ding,
+PHYS,3220,1,Mechanics II,0.09,0.73,0.09,0.0,0.09,0.0,0.0,0.0,gerald lehmacher,
+PHYS,4650,1,Thermo and Stat Mech,0.33,0.33,0.0,0.08,0.0,0.0,0.0,0.25,jens oberheide,
+PHYS,8150,1,Statistical Therm I,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
+PHYS,8410,1,Electrodynamics I,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+PHYS,9520,1,Quantum Mech II,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,sumanta tewari,
+PKSC,1020,1,Intro to Pkg Sci,0.09,0.31,0.32,0.17,0.03,0.0,0.0,0.07,heather batt,
+PKSC,2010,1,Pkg Perishable Prod,0.12,0.41,0.28,0.09,0.08,0.0,0.0,0.03,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2040,1,Container Systems,0.84,0.15,0.01,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2060,1,Container Sys Lab,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2060,2,Container Sys Lab,0.62,0.14,0.24,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2060,3,Container Sys Lab,0.68,0.18,0.14,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2200,1,Product & Pkg Design,0.67,0.21,0.08,0.04,0.0,0.0,0.0,0.0,william aaro snyder,
+PKSC,3200,1,Pkg Design Theory,0.43,0.52,0.02,0.0,0.0,0.0,0.0,0.02,rupert hurley,
+PKSC,3680,1,Pkg and Society,0.57,0.3,0.11,0.02,0.0,0.0,0.0,0.0,heather batt,
+PKSC,4030,1,Pkg Career Prep,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4200,1,Pkg Design & Dev,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4300,1,Converting Flex Pkg,0.25,0.56,0.08,0.08,0.02,0.0,0.0,0.0,duncan darby,
+PKSC,4400,2,Packaging for Distribution,0.25,0.57,0.1,0.04,0.05,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1,Food & Health Care Pkg Systems,0.7,0.22,0.04,0.04,0.0,0.0,0.0,0.0,kay cooksey,
+PLPA,2130,1,Fungi & Civilization,0.42,0.36,0.06,0.08,0.04,0.0,0.0,0.05,julia loui kerrigan,
+PLPA,8090,1,Analytical Technique,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,tharayil-santhakumar,
+POSC,1010,1,Amer National Govt,0.07,0.36,0.27,0.1,0.11,0.0,0.0,0.07,laura olson,
+POSC,1010,2,Amer National Govt,0.1,0.1,0.3,0.3,0.1,0.0,0.0,0.1,adam warber,
+POSC,1020,1,Intro Intl Relations,0.2,0.45,0.18,0.06,0.09,0.0,0.0,0.02,zeynep taydas,
+POSC,1020,2,Intro Intl Relations,0.11,0.29,0.3,0.11,0.12,0.0,0.0,0.06,zeynep taydas,
+POSC,1020,3,Intro Intl Relations,0.17,0.44,0.22,0.05,0.06,0.0,0.0,0.06,aron geo tannenbaum,
+POSC,1030,1,Intro to Political Theory,0.13,0.47,0.21,0.13,0.03,0.0,0.0,0.03,colin pearce,
+POSC,1030,2,Intro to Political Theory,0.18,0.58,0.13,0.0,0.07,0.0,0.0,0.04,kimberly hurd hale,
+POSC,1040,1,Intro Compar Pol,0.38,0.36,0.15,0.07,0.02,0.0,0.0,0.02,katherine am curtis,
+POSC,1040,2,Intro Compar Pol,0.18,0.48,0.1,0.08,0.04,0.0,0.0,0.12,lydia loui lundgren,
+POSC,1990,1,Intro Pol Sci,0.15,0.39,0.15,0.12,0.09,0.0,0.0,0.09,meredith petersheim,
+POSC,3020,1,State and Loc Gov,0.11,0.62,0.16,0.03,0.05,0.0,0.0,0.03,bruce ransom,
+POSC,3210,1,Public Admin,0.05,0.32,0.5,0.05,0.05,0.0,0.0,0.05,james woodard,
+POSC,3410,1,Quant Meth in Pol Sc,0.25,0.17,0.25,0.17,0.08,0.0,0.0,0.08,steven vince miller,
+POSC,3610,1,Intl Pol in Crisis,0.28,0.48,0.18,0.02,0.0,0.0,0.0,0.04,vladimir matic,
+POSC,3620,1,Intl Organizations,0.1,0.2,0.37,0.07,0.13,0.0,0.0,0.13,zeynep taydas,
+POSC,3630,1,Us Foreign Policy,0.16,0.25,0.27,0.14,0.14,0.0,0.0,0.05,steven vince miller,
+POSC,3710,1,European Politics,0.2,0.39,0.27,0.04,0.04,0.0,0.0,0.06,katherine am curtis,
+POSC,4030,1,United States Congress,0.33,0.41,0.22,0.02,0.0,0.0,0.0,0.02,jeffrey scott peake,
+POSC,4050,1,American Presidency,0.07,0.29,0.36,0.07,0.14,0.0,0.0,0.07,adam warber,
+POSC,4160,1,Int Groups & Soc Mov,0.32,0.42,0.16,0.05,0.0,0.0,0.0,0.05,laura olson,
+POSC,4370,1,Constitut Law: Rights & Libert,0.39,0.47,0.04,0.0,0.04,0.0,0.0,0.06,daniel frost,
+POSC,4490,1,Political Theory of Capitalism,0.49,0.23,0.15,0.05,0.08,0.0,0.0,0.0,brandon turner,
+POSC,4500,1,Contemporary Political Thought,0.52,0.36,0.0,0.0,0.04,0.0,0.0,0.08,daniel frost,
+POSC,4570,1,Political Terrorism,0.69,0.21,0.07,0.0,0.02,0.0,0.0,0.0,aron geo tannenbaum,
+POSC,4660,1,African Politics,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,lydia loui lundgren,
+POSC,4760,1,Middle East Politics,0.5,0.31,0.13,0.0,0.06,0.0,0.0,0.0,vladimir matic,
+POSC,4890,1,WW2: World Conflict Ideology,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,james woodard,
+POST,8430,1,Org Theory & Pub Mgt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,
+PRTM,2200,1,Foundations of PRTM,0.41,0.48,0.03,0.0,0.03,0.0,0.0,0.03,teresa walto tucker,
+PRTM,2200,2,Foundations of PRTM,0.67,0.23,0.0,0.07,0.03,0.0,0.0,0.0,gwynn powell,
+PRTM,2200,3,Foundations of PRTM,0.43,0.37,0.1,0.03,0.03,0.0,0.0,0.03,ryan joseph gagnon,
+PRTM,2200,4,Foundations of PRTM,0.22,0.59,0.15,0.0,0.04,0.0,0.0,0.0,dorothy schmalz,
+PRTM,2200,5,Foundations of PRTM,0.63,0.26,0.07,0.0,0.0,0.0,0.0,0.04,william holland,
+PRTM,2200,6,Foundations of PRTM,0.43,0.43,0.11,0.0,0.04,0.0,0.0,0.0,francis mcguire,
+PRTM,2410,1,Intro to CRSCM,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,
+PRTM,2410,2,Intro to CRSCM,0.56,0.29,0.06,0.0,0.03,0.0,0.0,0.06,jeffrey townsend,
+PRTM,2600,1,Found of Recreational Therapy,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
+PRTM,2650,1,Terminology in RT Practice,0.89,0.06,0.03,0.01,0.01,0.0,0.0,0.0,stephen thoma lewis,
+PRTM,2700,1,Intro Rec Res Mgt,0.4,0.43,0.13,0.0,0.03,0.0,0.0,0.0,lincoln larson,
+PRTM,2980,3,Creative Inquiry in PRTM II,0.52,0.39,0.0,0.0,0.04,0.0,0.0,0.04,francis mcguire,
+PRTM,2980,5,Creative Inquiry in PRTM II,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,lawrence allen,
+PRTM,2980,6,Creative Inquiry in PRTM II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brent hawkins,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.34,0.51,0.06,0.03,0.03,0.0,0.0,0.03,daniel mor anderson,
+PRTM,3070,1,Facility Operations,0.79,0.18,0.0,0.0,0.03,0.0,0.0,0.0,craig goodman,
+PRTM,3210,1,Recreation Admin,0.53,0.22,0.19,0.0,0.03,0.0,0.0,0.03,mariela fernandez,
+PRTM,3250,1,Global Persp in Rec,0.31,0.38,0.25,0.0,0.03,0.0,0.0,0.03,teresa walto tucker,
+PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.77,0.2,0.02,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
+PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.36,0.52,0.09,0.02,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3420,1,Intro to Tourism,0.48,0.15,0.22,0.09,0.02,0.0,0.0,0.04,herbert chancellor,
+PRTM,3420,2,Intro to Tourism,0.91,0.07,0.02,0.0,0.0,0.0,0.0,0.0,maloud shakona,
+PRTM,3440,1,Tourism Markets,0.68,0.15,0.1,0.05,0.03,0.0,0.0,0.0,sheila backman,
+PRTM,3440,2,Tourism Markets,0.86,0.07,0.02,0.02,0.0,0.0,0.0,0.02,sheila backman,
+PRTM,3450,1,Tourism Management,0.52,0.24,0.19,0.0,0.05,0.0,0.0,0.0,garrett stone,
+PRTM,3450,2,Tourism Management,0.52,0.23,0.19,0.03,0.03,0.0,0.0,0.0,lauren duffy,
+PRTM,3460,1,Heritage Tourism,0.25,0.44,0.19,0.1,0.02,0.0,0.0,0.0,gregory phi ramshaw,
+PRTM,3530,1,Foundations of Camp Counseling,0.74,0.11,0.16,0.0,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,3900,4,Independent Study in PRTM,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3910,1,Social Media in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james war sanderson,
+PRTM,3910,2,Intro to GIS for PRTM,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0,david lawrenc white,
+PRTM,4210,1,Rec Fin Resc Mgt,0.2,0.3,0.28,0.15,0.03,0.0,0.0,0.05,lawrence allen,
+PRTM,4260,1,Trends & Issues in Rec Therapy,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,4300,1,World Geog Parks,0.27,0.27,0.27,0.09,0.03,0.0,0.0,0.06,robert baxte powell,
+PRTM,4450,1,Conventions,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,jeffery martin,
+PRTM,4460,2,Community Tourism,0.46,0.27,0.04,0.0,0.04,0.0,0.0,0.19,herbert chancellor,
+PRTM,4510,1,Seminar in CRSCM,0.74,0.03,0.13,0.06,0.03,0.0,0.0,0.0,harrison pinckney,
+PRTM,4540,1,Trends in Sport Mgt,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,brandon harris,
+PRTM,4550,1,Adv Program Planning,0.64,0.18,0.14,0.05,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,4980,10,Creative Inquiry in PRTM IV,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
+PRTM,8030,1,Sem Rec & Park Admin,0.68,0.11,0.11,0.0,0.05,0.0,0.0,0.05,teresa walto tucker,
+PRTM,8080,1,Behavioral Aspects,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,8110,1,Research Methods,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,
+PRTM,8110,2,Research Methods,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,lincoln larson,
+PRTM,8210,1,Alt Funding for PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,8250,1,Populations in PRTM,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,dorothy schmalz,
+PSYC,2010,1,Intro to Psychology,0.34,0.35,0.22,0.03,0.01,0.0,0.0,0.04,mary taylor,
+PSYC,2010,2,Intro to Psychology,0.31,0.35,0.15,0.11,0.05,0.0,0.0,0.02,jo anne jorgensen,
+PSYC,2010,3,Intro to Psychology,0.39,0.28,0.2,0.06,0.07,0.0,0.0,0.0,mary taylor,
+PSYC,2010,4,Intro to Psychology,0.56,0.27,0.08,0.03,0.03,0.0,0.0,0.02,chong hyon pak,
+PSYC,2010,5,Intro to Psychology,0.23,0.31,0.23,0.06,0.09,0.0,0.0,0.08,edwin brainerd,
+PSYC,2010,6,Intro to Psychology (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True
+PSYC,2020,1,Intro Psychology Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jamie fynes,
+PSYC,2020,4,Intro Psychology Lab,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,natalee kri baldwin,
+PSYC,2020,5,Intro Psychology Lab,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,
+PSYC,2020,6,Intro Psychology Lab,0.85,0.08,0.04,0.0,0.04,0.0,0.0,0.0,madison eliza sauls,
+PSYC,3060,1,Human Sexual Beh,0.53,0.22,0.15,0.05,0.03,0.0,0.0,0.01,bruce michael king,
+PSYC,3090,100,Intro Exp Psych,0.33,0.21,0.21,0.12,0.08,0.0,0.0,0.04,richard tyrrell,
+PSYC,3090,200,Intro Exp Psych,0.83,0.07,0.03,0.03,0.0,0.0,0.0,0.03,alice miche brawley,
+PSYC,3090,300,Intro Exp Psych,0.46,0.36,0.04,0.07,0.0,0.0,0.0,0.07,drew michael morris,
+PSYC,3100,100,Advanced Experimental Psych,0.33,0.52,0.05,0.0,0.0,0.0,0.0,0.1,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimental Psych,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,robert campbell,
+PSYC,3100,300,Advanced Experimental Psych,0.45,0.3,0.1,0.0,0.05,0.0,0.0,0.1,thomas britt,
+PSYC,3100,400,Advanced Experimental Psych,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,3100,500,Advanced Experimental Psych,0.37,0.37,0.26,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3100,600,Advanced Experimental Psych,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3240,1,Physiological Psych,0.27,0.23,0.21,0.09,0.07,0.0,0.0,0.13,june pilcher,
+PSYC,3240,2,Physiological Psych,0.47,0.29,0.11,0.05,0.09,0.0,0.0,0.0,claudio cantalupo,
+PSYC,3330,1,Cognitive Psych,0.32,0.21,0.32,0.15,0.0,0.0,0.0,0.0,thomas alley,
+PSYC,3340,2,Cognitive Psych Lab,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,leo gugerty,
+PSYC,3340,3,Cognitive Psych Lab,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,laura whitlock,
+PSYC,3400,1,Lifespan Developmental Psych,0.29,0.54,0.13,0.01,0.01,0.0,0.0,0.01,jennifer bai bisson,
+PSYC,3400,2,Lifespan Developmental Psych,0.47,0.36,0.13,0.01,0.01,0.0,0.0,0.01,jennifer bai bisson,
+PSYC,3520,1,Social Psychology,0.43,0.35,0.16,0.04,0.01,0.0,0.0,0.0,eric mckibben,
+PSYC,3520,2,Social Psychology,0.5,0.3,0.11,0.07,0.0,0.0,0.0,0.01,eric mckibben,
+PSYC,3520,3,Social Psychology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
+PSYC,3640,1,Industrial Psych,0.43,0.4,0.13,0.03,0.0,0.0,0.0,0.01,eric mckibben,
+PSYC,3640,2,Industrial Psych,0.47,0.4,0.08,0.01,0.01,0.0,0.0,0.01,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.34,0.37,0.19,0.06,0.04,0.0,0.0,0.0,kristen su jennings,
+PSYC,3830,1,Abnormal Psychology,0.54,0.31,0.11,0.03,0.0,0.0,0.0,0.01,jo anne jorgensen,
+PSYC,3830,2,Abnormal Psychology,0.45,0.25,0.2,0.04,0.01,0.0,0.0,0.04,jo anne jorgensen,
+PSYC,3830,3,Abnormal Psychology,0.18,0.38,0.26,0.0,0.09,0.0,0.0,0.09,pamela alley,
+PSYC,3830,4,Abnormal Psychology,0.25,0.36,0.22,0.06,0.08,0.0,0.0,0.03,pamela alley,
+PSYC,4080,1,Women and Psychology,0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,
+PSYC,4150,1,Systems and Theories,0.39,0.43,0.13,0.0,0.0,0.0,0.0,0.04,brian day,
+PSYC,4150,2,Systems and Theories,0.25,0.32,0.18,0.07,0.11,0.0,0.0,0.07,edwin brainerd,
+PSYC,4150,3,Systems and Theories,0.33,0.3,0.11,0.07,0.07,0.0,0.0,0.11,edwin brainerd,
+PSYC,4220,1,Perception,0.1,0.38,0.34,0.1,0.03,0.0,0.0,0.03,christopher pagano,
+PSYC,4220,2,Perception,0.32,0.16,0.36,0.16,0.0,0.0,0.0,0.0,claudio cantalupo,
+PSYC,4220,3,Perception,0.16,0.6,0.04,0.16,0.04,0.0,0.0,0.0,claudio cantalupo,
+PSYC,4350,1,Human Factors,0.64,0.2,0.08,0.08,0.0,0.0,0.0,0.0,laura whitlock,
+PSYC,4710,1,Psych of Testing,0.35,0.5,0.04,0.04,0.04,0.0,0.0,0.04,robert ray sinclair,
+PSYC,4800,1,Health Psychology,0.48,0.44,0.08,0.0,0.0,0.0,0.0,0.0,june pilcher,
+PSYC,4820,1,Positive Psychology,0.46,0.29,0.07,0.07,0.04,0.04,0.0,0.04,cynthia pury,
+PSYC,4880,1,Psychotherapy,0.55,0.18,0.05,0.09,0.05,0.05,0.0,0.05,lucinda sorci quick,
+PSYC,4890,1,Teamwork,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,marissa leig porter,
+PSYC,4890,3,Food & Eating,0.46,0.33,0.13,0.04,0.04,0.0,0.0,0.0,thomas alley,
+PSYC,4920,3,Senior Laboratory,0.88,0.04,0.0,0.08,0.0,0.0,0.0,0.0,stephen robertson,
+PSYC,4920,4,Senior Laboratory,0.83,0.0,0.04,0.0,0.08,0.0,0.0,0.04,stephen robertson,
+PSYC,4920,5,Senior Laboratory,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,leah hartman,
+PSYC,4930,100,Pract Clinical Psych,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,heidi marie zinzow,
+PSYC,8110,1,Research Design II,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,patrick rosopa,
+PSYC,8130,1,Research Design III,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,
+PSYC,8140,1,Quantitative Lab,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,
+PSYC,8330,1,Adv Cog Psych,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,leo gugerty,
+PSYC,8370,1,Ergonomics Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,
+PSYC,8610,1,Personnel Psych,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,fred switzer,
+RCID,8030,1,Emp Res Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
+RED,8010,1,Market Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
+RED,8040,1,Resid Practicum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
+RED,8050,1,Commercial Practicum,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+RED,8120,1,Real Estate Technology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+REL,1010,1,Intro to Religion,0.09,0.25,0.41,0.09,0.13,0.0,0.0,0.03,peter cohen,
+REL,1010,2,Intro to Religion,0.12,0.33,0.33,0.12,0.03,0.0,0.0,0.06,peter cohen,
+REL,1010,3,Intro to Religion,0.03,0.52,0.24,0.09,0.12,0.0,0.0,0.0,peter cohen,
+REL,1020,1,World Religions,0.68,0.22,0.11,0.0,0.0,0.0,0.0,0.0,robert stephens,
+REL,1020,2,World Religions,0.5,0.38,0.09,0.03,0.0,0.0,0.0,0.0,robert stephens,
+REL,1020,4,World Religions,0.47,0.41,0.06,0.06,0.0,0.0,0.0,0.0,robert stephens,
+REL,3010,1,Old Testament,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3030,1,The Quran,0.35,0.39,0.13,0.03,0.06,0.0,0.0,0.03,mashal saif,
+REL,3050,1,Constructing Scripture,0.38,0.38,0.07,0.0,0.03,0.07,0.0,0.07,benjamin white,
+REL,3090,1,Religion of the American South,0.24,0.43,0.19,0.0,0.1,0.0,0.0,0.05,elizabeth jemison,
+REL,3100,1,History of Religion in the US,0.47,0.35,0.06,0.0,0.0,0.0,0.0,0.12,elizabeth jemison,
+REL,3120,1,Hinduism,0.7,0.1,0.0,0.03,0.03,0.0,0.0,0.13,robert stephens,
+REL,3140,1,Buddhism in China,0.35,0.29,0.18,0.0,0.18,0.0,0.0,0.0,yanming an,
+REL,3730,2,Age of Protestant Reformation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,thomas kuehn,
+RS,3010,1,Rural Sociology,0.49,0.24,0.12,0.06,0.0,0.0,0.0,0.08,kenneth robinson,
+SOC,2010,1,Intro to Sociology (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,rachael chatterson,True
+SOC,2010,2,Introduction to Sociology,0.48,0.3,0.09,0.09,0.02,0.0,0.0,0.02,rachael chatterson,
+SOC,2010,3,Introduction to Sociology,0.32,0.43,0.18,0.04,0.01,0.0,0.0,0.01,rachael chatterson,
+SOC,2010,4,Introduction to Sociology,0.63,0.23,0.1,0.0,0.02,0.0,0.0,0.02,shannon mcdonough,
+SOC,2010,5,Introduction to Sociology,0.67,0.23,0.08,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,6,Introduction to Sociology,0.66,0.23,0.05,0.04,0.0,0.0,0.0,0.03,shannon mcdonough,
+SOC,2010,7,Introduction to Sociology,0.28,0.4,0.21,0.02,0.02,0.0,0.0,0.06,mary louise barr,
+SOC,2010,8,Introduction to Sociology,0.43,0.43,0.09,0.0,0.02,0.0,0.0,0.04,mary louise barr,
+SOC,2010,9,Introduction to Sociology,0.44,0.38,0.11,0.0,0.02,0.0,0.0,0.04,mary louise barr,
+SOC,2010,10,Introduction to Sociology,0.45,0.36,0.09,0.04,0.06,0.0,0.0,0.0,mary louise barr,
+SOC,2010,11,Introduction to Sociology,0.61,0.24,0.08,0.04,0.0,0.0,0.0,0.02,jennifer le holland,
+SOC,2010,12,Introduction to Sociology,0.39,0.43,0.15,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2050,1,Sociology Lab,0.56,0.14,0.05,0.07,0.16,0.0,0.0,0.02,brenda vander mey,
+SOC,3020,1,Research Methods I,0.19,0.32,0.38,0.11,0.0,0.0,0.0,0.0,andrew whitehead,
+SOC,3040,1,Social Research Methods II,0.37,0.26,0.26,0.05,0.05,0.0,0.0,0.0,ye luo,
+SOC,3110,1,The Family,0.33,0.29,0.25,0.06,0.02,0.0,0.0,0.04,traci ann hefner,
+SOC,3800,1,Intro Social Service,0.57,0.34,0.06,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,3880,1,Criminal Justice,0.19,0.25,0.27,0.21,0.06,0.0,0.0,0.02,margaret tina britz,
+SOC,3890,1,Criminology,0.41,0.26,0.13,0.09,0.0,0.0,0.0,0.11,william white,
+SOC,3910,1,Soc of Deviance,0.39,0.24,0.2,0.05,0.05,0.0,0.0,0.07,william white,
+SOC,3920,1,Juvenile Delinquency,0.28,0.37,0.28,0.0,0.05,0.0,0.0,0.02,william white,
+SOC,3970,1,Substance Abuse,0.56,0.27,0.08,0.02,0.04,0.0,0.0,0.02,shannon mcdonough,
+SOC,4040,1,Soc Theory,0.47,0.22,0.2,0.09,0.0,0.0,0.0,0.02,william wentworth,
+SOC,4320,1,Soc of Religion,0.33,0.33,0.2,0.1,0.03,0.0,0.0,0.0,andrew whitehead,
+SOC,4330,1,Global Social Change,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,william haller,
+SOC,4590,1,The Community,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
+SOC,4600,1,Race & Ethnicity,0.35,0.46,0.15,0.04,0.0,0.0,0.0,0.0,brenda vander mey,
+SOC,4610,1,Sex & Gender,0.24,0.29,0.29,0.05,0.05,0.0,0.0,0.08,rachael chatterson,
+SOC,4840,1,Child Abuse,0.6,0.19,0.17,0.04,0.0,0.0,0.0,0.0,douglas sturkie,
+SOC,4860,4,Creative Inquiry: Sociology,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,margaret tina britz,
+SOC,4860,5,Creative Inquiry in Sociology,0.65,0.12,0.06,0.0,0.18,0.0,0.0,0.0,margaret tina britz,
+SOC,4930,1,Soc of Corrections,0.5,0.29,0.14,0.0,0.07,0.0,0.0,0.0,william white,
+SOC,4940,1,Organized Crimes,0.27,0.17,0.43,0.07,0.0,0.0,0.0,0.07,margaret tina britz,
+SOC,4950,1,Field Experience,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,4970,1,Senior Lab,0.45,0.27,0.09,0.09,0.09,0.0,0.0,0.0,brenda vander mey,
+SOC,4970,2,Senior Lab,0.46,0.31,0.15,0.0,0.08,0.0,0.0,0.0,brenda vander mey,
+SOC,4990,1,Sel Top Seminar in Contemp Soc,0.57,0.29,0.07,0.07,0.0,0.0,0.0,0.0,david williams,
+SPAN,1010,1,Elementary Spanish,0.39,0.28,0.28,0.0,0.0,0.0,0.0,0.06,scott harris,
+SPAN,1010,2,Elementary Spanish,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1020,1,Elementary Spanish,0.35,0.12,0.24,0.18,0.0,0.0,0.0,0.12,roger simpson,
+SPAN,1020,2,Elementary Spanish,0.42,0.26,0.11,0.11,0.0,0.0,0.0,0.11,roger simpson,
+SPAN,1020,3,Elementary Spanish,0.32,0.37,0.21,0.0,0.05,0.0,0.0,0.05,roger simpson,
+SPAN,1020,4,Elementary Spanish,0.5,0.28,0.11,0.0,0.06,0.0,0.0,0.06,roger simpson,
+SPAN,1020,5,Elementary Spanish,0.35,0.29,0.12,0.06,0.12,0.0,0.0,0.06,roger simpson,
+SPAN,1020,6,Elementary Spanish,0.25,0.25,0.13,0.19,0.13,0.0,0.0,0.06,cathy robison,
+SPAN,1020,7,Elementary Spanish,0.32,0.21,0.26,0.0,0.11,0.0,0.0,0.11,cathy robison,
+SPAN,1020,8,Elementary Spanish,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,ana paula  miller,
+SPAN,1020,9,Elementary Spanish,0.39,0.33,0.06,0.06,0.11,0.0,0.0,0.06,ana paula  miller,
+SPAN,1020,10,Elementary Spanish,0.42,0.17,0.33,0.0,0.0,0.0,0.0,0.08,debra oa williamson,
+SPAN,1020,11,Elementary Spanish,0.26,0.26,0.21,0.16,0.0,0.0,0.0,0.11,debra oa williamson,
+SPAN,2010,1,Intermediate Spanish,0.44,0.28,0.17,0.11,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,2,Intermediate Spanish,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,cathy robison,
+SPAN,2010,3,Intermediate Spanish,0.47,0.16,0.26,0.05,0.05,0.0,0.0,0.0,allison ann hinds,
+SPAN,2010,4,Intermediate Spanish,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
+SPAN,2010,5,Intermediate Spanish,0.33,0.53,0.07,0.07,0.0,0.0,0.0,0.0,allison ann hinds,
+SPAN,2010,6,Intermediate Spanish,0.29,0.29,0.19,0.1,0.1,0.0,0.0,0.05,ricardo tremolada,
+SPAN,2010,7,Intermediate Spanish,0.65,0.15,0.05,0.0,0.0,0.0,0.0,0.15,ricardo tremolada,
+SPAN,2010,8,Intermediate Spanish,0.69,0.13,0.13,0.06,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2010,9,Intermediate Spanish,0.64,0.09,0.09,0.0,0.0,0.0,0.0,0.18,ze cruz valderramos,
+SPAN,2010,10,Intermediate Spanish,0.47,0.26,0.11,0.0,0.0,0.0,0.0,0.16,ricardo tremolada,
+SPAN,2010,11,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2010,12,Intermediate Spanish,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,debra oa williamson,
+SPAN,2010,13,Intermediate Spanish,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2010,14,Intermediate Spanish,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2010,15,Intermediate Spanish,0.19,0.63,0.13,0.0,0.0,0.0,0.0,0.06,debra oa williamson,
+SPAN,2020,1,Intermediate Spanish,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,melva margu persico,
+SPAN,2020,2,Intermediate Spanish,0.18,0.47,0.18,0.06,0.06,0.0,0.0,0.06,melva margu persico,
+SPAN,2020,3,Intermediate Spanish,0.5,0.25,0.1,0.1,0.0,0.0,0.0,0.05,juana martin-armas,
+SPAN,2020,4,Intermediate Spanish,0.5,0.22,0.17,0.06,0.06,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,5,Intermediate Spanish,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,6,Intermediate Spanish,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,7,Intermediate Spanish,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,8,Intermediate Spanish,0.22,0.39,0.28,0.06,0.0,0.0,0.0,0.06,heidi montes,
+SPAN,2020,9,Intermediate Spanish,0.41,0.35,0.06,0.12,0.0,0.0,0.0,0.06,heidi montes,
+SPAN,2020,10,Intermediate Spanish,0.5,0.22,0.22,0.06,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,11,Intermediate Spanish,0.45,0.3,0.2,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,12,Intermediate Spanish,0.18,0.5,0.32,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
+SPAN,2020,13,Intermediate Spanish,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,14,Intermediate Spanish,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,19,Intermediate Spanish,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
+SPAN,3020,1,Int Spn Gram & Comp,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,george palacios,
+SPAN,3020,2,Int Spn Gram & Comp,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
+SPAN,3020,3,Int Spn Gram & Comp,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
+SPAN,3040,1,Intro Hisp Lit Forms,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,
+SPAN,3050,1,Int Con Comp Span I,0.31,0.44,0.13,0.06,0.0,0.0,0.0,0.06,raquel anido,
+SPAN,3050,2,Int Con Comp Span I,0.22,0.61,0.06,0.0,0.0,0.0,0.0,0.11,raquel anido,
+SPAN,3050,3,Int Con Comp Span I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,3060,1,Span Comp for Bus,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,3070,1,Hispanic World: Sp,0.29,0.18,0.06,0.06,0.06,0.0,0.0,0.35,juana martin-armas,
+SPAN,3080,1,Hispanic World: La,0.63,0.13,0.13,0.0,0.06,0.0,0.0,0.06,tiffany dawn miller,
+SPAN,3080,2,Hispanic World: La,0.63,0.19,0.13,0.06,0.0,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,3130,1,Span Lit Survey I,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,juana martin-armas,
+SPAN,3140,1,Hispanic Linguistics,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,daniel smith,
+SPAN,3160,1,Span for Intl Trade,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,maureen zamora,
+SPAN,4050,1,Int Trade Film & Lit,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,4060,2,Narrative Fiction,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,filiberto hernandez,
+SPAN,4070,1,Hispanic Film,0.42,0.11,0.11,0.16,0.0,0.0,0.0,0.21,raquel anido,
+SPAN,4150,1,Span for Health Prof,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,4150,35,Span for Health Prof,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+SPAN,4170,1,Prof Communication,0.62,0.15,0.23,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,4180,1,Tech Span Health Man,0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,ricardo tremolada,
+SPAN,4350,35,Contemp Hisp Cult,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+STAT,2220,1,Statistics in Everyday Life,0.35,0.39,0.13,0.06,0.04,0.0,0.0,0.04,ros martinez-dawson,
+STAT,2220,2,Statistics in Everyday Life,0.43,0.31,0.09,0.09,0.02,0.0,0.0,0.06,ros martinez-dawson,
+STAT,2220,3,Statistics in Everyday Life,0.57,0.33,0.07,0.0,0.02,0.0,0.0,0.0,gary fellers,
+STAT,2220,4,Statistics in Everyday Life,0.7,0.2,0.06,0.0,0.02,0.0,0.0,0.02,gary fellers,
+STAT,2220,5,Statistics in Everyday Life,0.61,0.24,0.09,0.02,0.02,0.0,0.0,0.02,gary fellers,
+STAT,2220,6,Statistics in Everyday Life,0.54,0.37,0.07,0.0,0.0,0.0,0.0,0.02,gary fellers,
+STAT,2300,1,Statistical Methods I,0.46,0.26,0.15,0.03,0.1,0.0,0.0,0.0,christy jenki brown,
+STAT,2300,2,Statistical Methods I,0.37,0.27,0.19,0.08,0.08,0.0,0.0,0.03,christy jenki brown,
+STAT,2300,3,Statistical Methods I,0.43,0.28,0.16,0.08,0.05,0.0,0.0,0.01,christy jenki brown,
+STAT,2300,4,Statistical Methods I,0.37,0.35,0.1,0.1,0.04,0.0,0.0,0.04,benjamin sharp,
+STAT,2300,5,Statistical Methods I,0.28,0.35,0.16,0.11,0.08,0.0,0.0,0.03,brook thaye russell,
+STAT,2300,6,Statistical Methods I,0.3,0.41,0.19,0.03,0.08,0.0,0.0,0.0, erwin walker,
+STAT,2300,7,Statistical Methods I,0.13,0.38,0.25,0.14,0.06,0.0,0.0,0.05, erwin walker,
+STAT,2300,8,Statistical Methods I,0.2,0.36,0.21,0.11,0.12,0.0,0.0,0.0, erwin walker,
+STAT,3090,1,Introductory Business Stats,0.02,0.29,0.32,0.17,0.1,0.0,0.0,0.1,elaine ma sotherden,
+STAT,3090,2,Introductory Business Stats,0.18,0.29,0.16,0.16,0.11,0.0,0.0,0.11,james espey,
+STAT,3090,3,Introductory Business Stats,0.24,0.26,0.12,0.06,0.15,0.0,0.0,0.18,paul james cubre,
+STAT,3090,4,Introductory Business Stats,0.1,0.32,0.37,0.1,0.07,0.0,0.0,0.05,james espey,
+STAT,3090,5,Introductory Business Stats,0.14,0.33,0.26,0.0,0.21,0.0,0.0,0.05,paul james cubre,
+STAT,3090,6,Introductory Business Stats,0.26,0.29,0.23,0.11,0.06,0.0,0.0,0.06,audrey nico devries,
+STAT,3090,7,Introductory Business Stats,0.13,0.18,0.23,0.13,0.2,0.0,0.0,0.15,drew jared lipman,
+STAT,3090,8,Introductory Business Stats,0.15,0.51,0.15,0.02,0.12,0.0,0.0,0.05,margaret mar wiecek,
+STAT,3090,9,Introductory Business Stats,0.27,0.41,0.22,0.02,0.07,0.0,0.0,0.0,james espey,
+STAT,3090,10,Introductory Business Stats,0.2,0.37,0.2,0.07,0.1,0.0,0.0,0.07,james espey,
+STAT,3090,11,Introductory Business Stats,0.2,0.23,0.33,0.08,0.15,0.0,0.0,0.03,elaine ma sotherden,
+STAT,3090,12,Introductory Business Stats,0.08,0.38,0.18,0.13,0.2,0.0,0.0,0.05,christopher wilson,
+STAT,3090,13,Introductory Business Stats,0.17,0.29,0.17,0.15,0.12,0.0,0.0,0.1,audrey nico devries,
+STAT,3300,1,Statistical Methods II,0.31,0.42,0.08,0.04,0.08,0.0,0.0,0.08,ros martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,4110,1,Stat Mthds for Process Control,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,
+STAT,4110,2,Stat Mthds for Process Control,0.24,0.52,0.03,0.03,0.06,0.0,0.0,0.12,james rieck,
+STAT,8010,1,Statistical Methods I,0.68,0.19,0.13,0.0,0.0,0.0,0.0,0.0,james rieck,
+STAT,8010,2,Statistical Methods I,0.48,0.39,0.03,0.0,0.0,0.0,0.0,0.09,patrick gerard,
+STAT,8010,3,Statistical Methods I,0.57,0.25,0.04,0.0,0.0,0.0,0.0,0.14,jun luo,
+STAT,8040,1,Sampling,0.35,0.41,0.0,0.0,0.0,0.0,0.0,0.24,patrick gerard,
+STAT,8050,1,Design & Anlys of Experiments,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,8420,230,Intro to Statistical Methods,0.22,0.5,0.11,0.0,0.06,0.0,0.0,0.11,julia lynn sharp,
+STS,1010,1,Survey of S T S,0.44,0.41,0.09,0.0,0.0,0.0,0.0,0.06,allison ann hinds,
+STS,1010,2,Survey of S T S,0.29,0.49,0.09,0.0,0.06,0.0,0.0,0.09,scott brame,
+STS,1010,3,Survey of S T S,0.44,0.28,0.19,0.03,0.03,0.0,0.0,0.03,elizabeth stansell,
+STS,1010,4,Survey of S T S,0.59,0.34,0.03,0.03,0.0,0.0,0.0,0.0,sarah mae cooper,
+STS,1010,5,Survey of S T S,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,philip randall,
+STS,1010,6,Survey of S T S,0.74,0.11,0.11,0.0,0.03,0.0,0.0,0.0,annah kamugiz amani,
+STS,1010,7,Survey of S T S,0.27,0.46,0.11,0.05,0.03,0.0,0.0,0.08,megan no macalystre,
+STS,1010,8,Survey of S T S,0.23,0.4,0.1,0.1,0.03,0.0,0.0,0.13,david charles foltz,
+THEA,2100,1,Theatre Appreciation,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,richard st. peter,
+THEA,2100,2,Theatre Appreciation,0.87,0.0,0.07,0.0,0.03,0.0,0.0,0.03,kerrie kath seymour,
+THEA,2100,3,Theatre Appreciation,0.76,0.14,0.03,0.03,0.03,0.0,0.0,0.0,kendra lyne johnson,
+THEA,2100,4,Theatre Appreciation,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
+THEA,2100,5,Theatre Appreciation,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
+THEA,2100,6,Theatre Appreciation,0.63,0.34,0.0,0.0,0.0,0.0,0.0,0.03,jason adkins,
+THEA,2670,1,Stage Makeup,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,shannon ther robert,
+THEA,2790,1,Theatre Practicum,0.79,0.0,0.0,0.0,0.14,0.0,0.0,0.07,matthew leckenbusch,
+THEA,3160,1,Theatre History II,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,richard st. peter,
+THEA,3180,1,Afri-Amer Thea II,0.61,0.23,0.13,0.0,0.03,0.0,0.0,0.0,kendra lyne johnson,
+THEA,4790,1,Acting II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kerrie kath seymour,
+THEA,6870,1,Stage Lighting I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
+WFB,3010,1,Wildlife Biology Lab,0.46,0.23,0.31,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3010,2,Wildlife Biology Lab,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,shari lyn rodriguez,
+WFB,3130,1,Conservation Biology,0.26,0.38,0.29,0.07,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3130,2,Conservation Biology,0.32,0.3,0.26,0.06,0.04,0.0,0.0,0.02,shari lyn rodriguez,
+WFB,3500,1,Princ Fish & Wildlife Biology,0.3,0.43,0.17,0.04,0.04,0.0,0.0,0.04,james davis,
+WFB,3500,2,Princ Fish & Wildlife Biology,0.21,0.41,0.26,0.06,0.03,0.0,0.0,0.03,james davis,
+WFB,4160,1,Fishery Biology,0.21,0.47,0.23,0.04,0.0,0.0,0.0,0.04,yoichiro kanno,
+WFB,4300,1,Wildlife Conservation Policy,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,joseph lanham,
+WFB,4620,1,Wetland Wildlife Biology,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,russell barrett,
+WFB,4930,2,Quantitative Ecology,0.37,0.37,0.16,0.02,0.02,0.0,0.0,0.06,david sco jachowski,
+WS,1030,1,Women in Global Perspective,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,saadiqa kumanyika,
+WS,1030,2,Women in Global Perspective,0.61,0.19,0.08,0.0,0.06,0.0,0.0,0.06,saadiqa kumanyika,
+WS,3010,1,Intro Women's Studies,0.56,0.31,0.08,0.0,0.06,0.0,0.0,0.0,elizabeth ros adams,
+WS,3010,2,Intro Women's Studies,0.41,0.5,0.06,0.0,0.0,0.0,0.0,0.03,elizabeth ros adams,
+YDP,3100,400,Youth Developmt and the Family,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,william quinn,
+YDP,3300,1,Designing Effective Youth Prog,0.7,0.17,0.04,0.0,0.09,0.0,0.0,0.0,kellye rembert,
+YDP,3350,1,Youth Activity Leadership,0.57,0.17,0.04,0.09,0.13,0.0,0.0,0.0,ryan joseph gagnon,

--- a/bot/cogs/grades_cog/assets/2017_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2017_Fall.csv
@@ -1,2817 +1,2817 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1010,1,Survey of Art & Arch History I,0.4,0.45,0.1,0.0,0.01,0.0,0.0,0.05,beth ann lauritis,
-AAH,1010,2,Surv of Art & Arch I (HON),0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,beth ann lauritis,True
-AAH,2050,1,Art History and Theory I,0.79,0.15,0.0,0.0,0.06,0.0,0.0,0.0,beth ann lauritis,
-AAH,3050,1,Contemporary Art History,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
-ACCT,2010,1,Financial Accounting Concepts,0.18,0.35,0.2,0.12,0.08,0.0,0.0,0.06,emily suza mccorkle,
-ACCT,2010,2,Financial Accounting Concepts,0.21,0.44,0.25,0.04,0.04,0.0,0.0,0.02,emily suza mccorkle,
-ACCT,2010,3,Financial Accounting Concepts,0.3,0.43,0.11,0.04,0.04,0.0,0.0,0.09,lydia lan schleifer,
-ACCT,2010,4,Financial Accounting Concepts,0.28,0.33,0.22,0.09,0.0,0.0,0.0,0.09,emily suza mccorkle,
-ACCT,2010,5,Financial Accounting Concepts,0.34,0.24,0.28,0.08,0.04,0.0,0.0,0.02,annieka philo,
-ACCT,2010,6,Financial Accounting Concepts,0.33,0.31,0.13,0.1,0.04,0.0,0.0,0.08,lydia lan schleifer,
-ACCT,2010,7,Financial Accounting Concepts,0.24,0.37,0.2,0.1,0.08,0.0,0.0,0.0,annieka philo,
-ACCT,2010,8,Financial Accounting Concepts,0.24,0.39,0.12,0.06,0.1,0.0,0.0,0.08,lydia lan schleifer,
-ACCT,2010,9,Financial Accounting Concepts,0.21,0.56,0.13,0.02,0.08,0.0,0.0,0.0,annieka philo,
-ACCT,2010,10,Financial Accounting Concepts,0.36,0.3,0.22,0.02,0.04,0.0,0.0,0.06,annieka philo,
-ACCT,2010,11,Financial Accounting Concepts,0.29,0.43,0.16,0.08,0.02,0.0,0.0,0.02,rebecca pennel trax,
-ACCT,2010,12,Financial Accounting Concepts,0.3,0.26,0.23,0.09,0.06,0.0,0.0,0.06,rebecca pennel trax,
-ACCT,2010,13,Financial Accounting Concepts,0.22,0.35,0.17,0.13,0.09,0.0,0.0,0.04,charles tegen,
-ACCT,2010,14,Financial Accounting Concepts,0.27,0.41,0.18,0.04,0.08,0.0,0.0,0.02,lisa whe birtwistle,
-ACCT,2010,100,Fin Accounting Concepts (HON),0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,lisa whe birtwistle,True
-ACCT,2010,400,Financial Accounting Concepts,0.29,0.34,0.19,0.1,0.05,0.0,0.0,0.02,emily suza mccorkle,
-ACCT,2020,1,Managerial Accounting Concepts,0.36,0.22,0.22,0.02,0.0,0.0,0.0,0.18,henry anderson,
-ACCT,2020,2,Managerial Accounting Concepts,0.36,0.3,0.1,0.0,0.06,0.0,0.0,0.18,henry anderson,
-ACCT,2020,3,Managerial Accounting Concepts,0.28,0.28,0.13,0.02,0.06,0.0,0.0,0.23,henry anderson,
-ACCT,2020,4,Managerial Accounting Concepts,0.29,0.31,0.18,0.07,0.04,0.0,0.0,0.11,phebia davis-culler,
-ACCT,2020,5,Managerial Accounting Concepts,0.28,0.15,0.2,0.22,0.11,0.0,0.0,0.04,phebia davis-culler,
-ACCT,2020,6,Managerial Accounting Concepts,0.21,0.09,0.38,0.09,0.15,0.0,0.0,0.09,phebia davis-culler,
-ACCT,2020,7,Managerial Accounting Concepts,0.09,0.27,0.24,0.11,0.07,0.0,0.0,0.22,brian todd carver,
-ACCT,2020,8,Managerial Accounting Concepts,0.16,0.19,0.23,0.07,0.14,0.0,0.0,0.21,brian todd carver,
-ACCT,2020,400,Managerial Accounting Concepts,0.35,0.24,0.15,0.03,0.04,0.0,0.0,0.19,henry anderson,
-ACCT,3030,1,Cost Accounting,0.32,0.41,0.18,0.0,0.02,0.0,0.0,0.07,robin radtke,
-ACCT,3030,2,Cost Accounting,0.32,0.32,0.26,0.03,0.08,0.0,0.0,0.0,robin radtke,
-ACCT,3030,3,Cost Accounting,0.23,0.34,0.27,0.09,0.0,0.0,0.0,0.07,jace garrett,
-ACCT,3030,4,Cost Accounting,0.2,0.33,0.16,0.13,0.11,0.0,0.0,0.07,jace garrett,
-ACCT,3110,1,Intermediate Financial Acct I,0.33,0.42,0.18,0.02,0.04,0.0,0.0,0.0,amy meliss donnelly,
-ACCT,3110,2,Intermediate Financial Acct I,0.32,0.28,0.28,0.1,0.02,0.0,0.0,0.0,amy meliss donnelly,
-ACCT,3110,3,Intermediate Financial Acct I,0.53,0.24,0.18,0.04,0.0,0.0,0.0,0.0,erin michel hawkins,
-ACCT,3110,4,Intermediate Financial Acct I,0.28,0.33,0.33,0.04,0.02,0.0,0.0,0.0,erin michel hawkins,
-ACCT,3110,400,Intermediate Financial Acct I,0.32,0.32,0.13,0.04,0.08,0.0,0.0,0.11,henry anderson,
-ACCT,3120,1,Intermediate Financial Acct II,0.14,0.5,0.14,0.07,0.0,0.0,0.0,0.14,terry daniel knause,
-ACCT,3120,2,Intermediate Financial Acct II,0.14,0.32,0.41,0.05,0.09,0.0,0.0,0.0,jeremy micha vinson,
-ACCT,3120,3,Intermediate Financial Acct II,0.63,0.16,0.16,0.05,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3120,4,Intermediate Financial Acct II,0.18,0.43,0.3,0.08,0.0,0.0,0.0,0.03,jeremy micha vinson,
-ACCT,3120,5,Intermediate Financial Acct II,0.45,0.33,0.2,0.03,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3120,6,Intermediate Financial Acct II,0.43,0.43,0.1,0.05,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3130,1,Intermediate Fin Acct III,0.22,0.22,0.28,0.08,0.11,0.0,0.0,0.08, russell madray,
-ACCT,3130,2,Intermediate Fin Acct III,0.25,0.39,0.2,0.09,0.02,0.0,0.0,0.05, russell madray,
-ACCT,3130,3,Intermediate Fin Acct III,0.37,0.29,0.2,0.1,0.0,0.0,0.0,0.05, russell madray,
-ACCT,3130,4,Intermediate Fin Acct III,0.33,0.33,0.21,0.05,0.05,0.0,0.0,0.02, russell madray,
-ACCT,3220,1,Accounting Information Systems,0.11,0.42,0.26,0.0,0.05,0.0,0.0,0.16,philip maiberger,
-ACCT,3220,2,Accounting Information Systems,0.06,0.19,0.25,0.31,0.0,0.0,0.0,0.19,philip maiberger,
-ACCT,3220,3,Accounting Information Systems,0.12,0.42,0.28,0.12,0.02,0.0,0.0,0.05,nancy lee harp,
-ACCT,3220,4,Accounting Information Systems,0.17,0.36,0.24,0.07,0.1,0.0,0.0,0.07,nancy lee harp,
-ACCT,4040,1,Individual Taxation,0.33,0.33,0.18,0.08,0.03,0.0,0.0,0.05,derek dalton,
-ACCT,4040,2,Individual Taxation,0.8,0.11,0.06,0.03,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,3,Individual Taxation,0.72,0.21,0.08,0.0,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4080,1,Retire & Estate Plan,0.32,0.42,0.16,0.05,0.0,0.0,0.0,0.05,john hine,
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.16,0.55,0.13,0.13,0.0,0.0,0.0,0.03,sally kathr widener,
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.38,0.41,0.21,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
-ACCT,4150,1,Auditing,0.34,0.39,0.21,0.05,0.0,0.0,0.0,0.0,carl hollingsworth,
-ACCT,4150,2,Auditing,0.19,0.38,0.29,0.1,0.05,0.0,0.0,0.0,carl hollingsworth,
-ACCT,8510,1,Tax Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8510,2,Tax Research,0.26,0.74,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8510,3,Tax Research,0.61,0.37,0.0,0.0,0.0,0.0,0.0,0.02,thomas dickens,
-ACCT,8530,1,Adv Acct Problems,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8530,2,Adv Acct Problems,0.61,0.34,0.02,0.0,0.0,0.0,0.0,0.02,ralph welton,
-ACCT,8530,3,Adv Acct Problems,0.48,0.39,0.06,0.0,0.03,0.0,0.0,0.03,ralph welton,
-ACCT,8550,1,Gov't and Nonprofit Accounting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8550,2,Gov't and Nonprofit Accounting,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,james barnes,
-ACCT,8630,1,Forensics Analysis,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,philip maiberger,
-ACCT,8630,2,Forensics Analysis,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,philip maiberger,
-ACCT,8650,1,Tax & Bus Decisions,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
-ACCT,8720,1,Tax of Flowthroughs,0.34,0.48,0.16,0.0,0.0,0.0,0.0,0.02,thomas dickens,
-AGED,1020,1,Freshman Seminar,0.76,0.12,0.06,0.0,0.0,0.0,0.0,0.06,catheri dibenedetto,
-AGED,2000,1,Agr Appl of Ed Tech,0.67,0.17,0.1,0.0,0.0,0.0,0.0,0.07,kevin layfield,
-AGED,2010,1,Intro to Agric Educ,0.59,0.37,0.0,0.0,0.0,0.0,0.0,0.04,philip fravel,
-AGED,2040,1,App Ag Calculations,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,3030,1,Ag Ed Mech Tech,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGED,4000,1,Supervised Field Experience II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,4010,1,Instr Methods Ag Ed,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,
-AGED,4030,1,Prin Adult/Ext Ed,0.41,0.29,0.18,0.06,0.0,0.0,0.0,0.06,alex byrd,
-AGED,4230,400,Curriculum,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,
-AGED,6030,1,Prin Adult/Ext Ed,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGM,1010,1,Intro Ag Mech & Bus,0.71,0.15,0.08,0.02,0.04,0.0,0.0,0.0,hunter massey,
-AGM,2050,1,Prin of Fabrication,0.3,0.54,0.09,0.02,0.02,0.0,0.0,0.04,hunter massey,
-AGM,2060,1,Machinery Mgt,0.38,0.33,0.19,0.05,0.05,0.0,0.0,0.0,hunter massey,
-AGM,2210,1,Land Measurements,0.26,0.56,0.17,0.01,0.0,0.0,0.0,0.0,charles privette,
-AGM,3010,1,Soil Water Conserv,0.47,0.31,0.18,0.04,0.0,0.0,0.0,0.0,calvin sawyer,
-AGM,4000,1,Seminar in Ag Mech & Business,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,john chastain,
-AGM,4020,1,Irrigation System Design,0.23,0.43,0.27,0.03,0.03,0.0,0.0,0.0,charles privette,
-AGM,4050,1,Env Cont in Anim Str,0.12,0.34,0.46,0.02,0.05,0.0,0.0,0.0,john chastain,
-AGM,4060,1,Mech & Hydraulic Sys,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4520,1,Mobile Power,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4600,1,Electrical Systems,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,young han,
-AGRB,2020,1,Agricultural Economics,0.17,0.27,0.29,0.12,0.1,0.0,0.0,0.06,george apperson,
-AGRB,2020,2,Agricultural Economics,0.12,0.42,0.15,0.18,0.09,0.0,0.0,0.03,george apperson,
-AGRB,2050,1,Agriculture and Society,0.2,0.29,0.45,0.04,0.02,0.0,0.0,0.0,michael vassalos,
-AGRB,3020,1,Economics of Farm Management,0.18,0.28,0.3,0.21,0.01,0.0,0.0,0.02,michael vassalos,
-AGRB,3080,1,Quant Agribusiness Analysis I,0.25,0.33,0.24,0.13,0.04,0.0,0.0,0.01,lisha zhang,
-AGRB,3090,1,Econ of Agricultural Marketing,0.5,0.38,0.08,0.02,0.02,0.0,0.0,0.0,yuliya val bolotova,
-AGRB,3190,1,Agribusiness Management,0.28,0.23,0.18,0.13,0.08,0.0,0.0,0.1,michael vassalos,
-AGRB,3570,1,Natural Resources Economics,0.2,0.18,0.27,0.13,0.09,0.0,0.0,0.13,david brian willis,
-AGRB,4090,1,Commodity Futures Markets,0.16,0.24,0.3,0.19,0.11,0.0,0.0,0.0,george apperson,
-AGRB,4120,1,Reg Econ Devel Theory & Policy,0.57,0.31,0.1,0.0,0.0,0.0,0.0,0.02,lori ann dickes,
-AGRB,4600,1,Agricultural Finance,0.2,0.43,0.33,0.05,0.0,0.0,0.0,0.0,lisha zhang,
-AL,3490,400,Principles of Coaching,0.66,0.21,0.07,0.03,0.0,0.0,0.0,0.03,deborah cadorette,
-AL,3490,401,Principles of Coaching,0.52,0.37,0.07,0.04,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,403,Principles of Coaching,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,3490,404,Principles of Coaching,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,edmond fry,
-AL,3500,400,Sci Basis I/Ex Phy,0.12,0.36,0.2,0.12,0.04,0.0,0.0,0.16,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.29,0.25,0.25,0.13,0.0,0.0,0.0,0.08,michael godfrey,
-AL,3530,400,Athletic Injuries,0.42,0.21,0.29,0.08,0.0,0.0,0.0,0.0,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.11,0.44,0.22,0.11,0.11,0.0,0.0,0.0,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.27,0.27,0.0,0.07,0.0,0.0,0.07,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,henry oates,
-AL,3610,401,Admin/Org of Athletic Programs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,Admin/Org of Athletic Programs,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3620,400,Psychology of Coaching,0.65,0.18,0.06,0.0,0.0,0.0,0.0,0.12,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.41,0.12,0.24,0.18,0.06,0.0,0.0,0.0,natalie anne carter,
-AL,3620,402,Psychology of Coaching,0.29,0.54,0.08,0.04,0.0,0.0,0.0,0.04,natalie anne carter,
-AL,3740,400,Coaching Football,0.78,0.09,0.04,0.0,0.04,0.0,0.0,0.04,edmond fry,
-AL,3760,400,Coaching Strength/Conditioning,0.79,0.13,0.0,0.04,0.04,0.0,0.0,0.0,edmond fry,
-AL,3760,401,Coaching Strength/Conditioning,0.71,0.0,0.21,0.0,0.07,0.0,0.0,0.0,edmond fry,
-AL,4380,402,Coaching the Inner Athlete,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
-AL,4380,403,Media Relations in AL,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,4380,404,Coaching the Inner Athlete,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,4380,408,Officiating in AL,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,8440,400,Surv of Res Mthds in Athletics,0.82,0.06,0.12,0.0,0.0,0.0,0.0,0.0,russell marion,
-AL,8440,401,Surv of Res Mthds in Athletics,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,russell marion,
-AL,8490,401,Athletic Leadership Dev,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,michael godfrey,
-AL,8500,400,Principles Strength and Condit,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8500,401,Principles Strength and Condit,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,michael godfrey,
-AL,8650,400,Mkt and Comm Respon Interc Ath,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,misty soles,
-ANTH,2010,1,Introduction to Anthropology,0.06,0.23,0.28,0.16,0.11,0.0,0.0,0.17,john coggeshall,
-ANTH,2010,2,Introduction to Anthropology,0.0,0.24,0.29,0.24,0.12,0.0,0.0,0.12,john coggeshall,
-ANTH,2010,3,Introduction to Anthropology,0.44,0.37,0.11,0.02,0.02,0.0,0.0,0.04,yi wu,
-ANTH,2010,4,Introduction to Anthropology,0.46,0.2,0.15,0.09,0.06,0.0,0.0,0.04,yi wu,
-ANTH,2010,5,Introduction to Anthropology,0.4,0.37,0.1,0.02,0.03,0.0,0.0,0.08,lisa rapaport,
-ANTH,3010,1,Cultural Anthropology,0.04,0.32,0.44,0.04,0.0,0.0,0.0,0.16,john coggeshall,
-ANTH,3320,1,World Archaeology,0.72,0.11,0.0,0.11,0.06,0.0,0.0,0.0,elizabeth wakefield,
-ANTH,3510,1,Biological Anthropology,0.16,0.21,0.32,0.26,0.05,0.0,0.0,0.0,lisa rapaport,
-ANTH,3530,1,Forensic Anthropology,0.25,0.45,0.3,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
-ANTH,3710,1,Language and Culture,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
-ANTH,4230,1,Women in the Developing World,0.64,0.27,0.0,0.09,0.0,0.0,0.0,0.0,melissa vogel,
-ARCH,1010,1,Intro to Architecture,0.63,0.17,0.07,0.02,0.02,0.0,0.0,0.09,sal hambright-belue,
-ARCH,2040,1,Hist of Modern Arch,0.33,0.51,0.14,0.02,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,2510,1,Arch Foundations I,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,2510,2,Arch Foundations I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,2510,3,Arch Foundations I,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2510,4,Arch Foundations I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,2510,5,Arch Foundations I,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,criss mills,
-ARCH,2700,1,Structures I,0.28,0.59,0.1,0.03,0.0,0.0,0.0,0.0,dustin gra albright,
-ARCH,3500,1,Intro to Urban Contexts,0.29,0.5,0.14,0.07,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,3500,2,Intro to Urban Contexts,0.25,0.17,0.42,0.17,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,3500,3,Intro to Urban Contexts,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,3500,4,Intro to Urban Contexts,0.08,0.42,0.42,0.08,0.0,0.0,0.0,0.0,george schafer,
-ARCH,3500,5,Intro to Urban Contexts,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,3510,2,Studio Clemson,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,
-ARCH,3540,1,Studio Barcelona,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4010,1,Architectural Portfolio,0.62,0.19,0.1,0.0,0.05,0.0,0.0,0.05,clarissa mendez,
-ARCH,4010,2,Architectural Portfolio,0.43,0.24,0.29,0.0,0.0,0.0,0.0,0.05,herminia sil machry,
-ARCH,4010,3,Architectural Portfolio,0.36,0.59,0.0,0.05,0.0,0.0,0.0,0.0,george schafer,
-ARCH,6240,1,Product Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,6850,1,H/Th: Arch+Health,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8100,1,Visualization I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
-ARCH,8210,1,Research Methods,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8410,1,Arch Studio I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,peter laurence,
-ARCH,8410,2,Arch Studio I,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,andreea mihalache,
-ARCH,8510,2,Design Studio III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8510,3,Design Studio III,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,8570,6,Design Studio V,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,8600,1,History/Theory I,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,8720,1,Production & Assemb,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,
-ARCH,8810,1,Pro Practice Survey,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,
-ARCH,8860,1,Health Facilities,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ARCH,8890,1,Mentorship,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,
-ARCH,8970,1,A+H Studio: Hospital,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ART,1050,1,Foundation Drawing I,0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,kathleen ann thum,
-ART,1510,1,Foundations Art I,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,kymberly ann day,
-ART,2070,1,Beginning Painting,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,dustin lee massey,
-ART,2100,400,Art Appreciation,0.57,0.25,0.14,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,
-ART,2100,401,Art Appreciation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lydia jane dorsey,
-ART,2100,402,Art Appreciation,0.68,0.18,0.04,0.0,0.07,0.0,0.0,0.04,lydia jane dorsey,
-ART,2100,403,Art Appreciation,0.32,0.43,0.14,0.0,0.04,0.0,0.0,0.07,lydia jane dorsey,
-ART,2110,1,Begin Printmaking,0.56,0.31,0.06,0.0,0.06,0.0,0.0,0.0,mandy lora ferguson,
-ART,2130,1,Begin Photography,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,amber nic eckersley,
-ART,2210,1,Beginning New Media,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,christina nguy hung,
-ART,8210,1,Visual Narrative,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
-AS,1090,1,Air Force Today I,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,michael allen moore,
-AS,1090,2,Air Force Today I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,1090,3,Air Force Today I,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,michael allen moore,
-AS,2090,2,Dev of Air Power I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brock lusk,
-AS,2090,3,Dev of Air Power I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,3090,2,A F Leadership Mgt I,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,rachelle mar miller,
-AS,4090,1,Nat Sec Policy I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-ASL,1010,1,Am Sign Lang I,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jason hurdich,
-ASL,1010,2,Am Sign Lang I,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,1010,3,Am Sign Lang I,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,william ry clements,
-ASL,1010,5,Am Sign Lang I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,william ry clements,
-ASL,1020,1,Am Sign Lang I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2010,1,Am Sign Lang II,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,2010,2,Am Sign Lang II,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,jason hurdich,
-ASL,2010,3,Am Sign Lang II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william ry clements,
-ASL,2010,4,Am Sign Lang II,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william ry clements,
-ASL,3010,1,Advanced A S L I,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kim ma misener dunn,
-ASTR,1010,1,Solar System Astronomy,0.36,0.41,0.1,0.05,0.05,0.0,0.0,0.02,amber porter,
-ASTR,1010,2,Solar System Astronomy,0.41,0.37,0.13,0.02,0.05,0.0,0.0,0.02,amber porter,
-ASTR,1020,1,Stellar Astronomy,0.24,0.38,0.26,0.05,0.01,0.0,0.0,0.05,marco ajello,
-ASTR,1030,1,Solar Systm Astr Lab,0.64,0.27,0.0,0.0,0.05,0.0,0.0,0.05,amber porter,
-ASTR,1030,2,Solar Systm Astr Lab,0.78,0.09,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,
-ASTR,1030,3,Solar Systm Astr Lab,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,amber porter,
-ASTR,1030,4,Solar Systm Astr Lab,0.67,0.17,0.13,0.0,0.0,0.0,0.0,0.04,amber porter,
-ASTR,1030,5,Solar Systm Astr Lab,0.23,0.64,0.05,0.09,0.0,0.0,0.0,0.0,amber porter,
-ASTR,1030,6,Solar Systm Astr Lab,0.57,0.26,0.13,0.0,0.0,0.0,0.0,0.04,amber porter,
-ASTR,1030,7,Solar Systm Astr Lab,0.5,0.28,0.06,0.06,0.0,0.0,0.0,0.11,amber porter,
-ASTR,1030,8,Solar Systm Astr Lab,0.26,0.53,0.16,0.05,0.0,0.0,0.0,0.0,amber porter,
-ASTR,1030,9,Solar Systm Astr Lab,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,amber porter,
-ASTR,1030,10,Solar Systm Astr Lab,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,amber porter,
-ASTR,1040,1,Stellar Astr Lab,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,amber porter,
-ASTR,1040,2,Stellar Astr Lab,0.52,0.3,0.0,0.0,0.09,0.0,0.0,0.09,amber porter,
-ASTR,1040,4,Stellar Astr Lab,0.41,0.37,0.11,0.04,0.0,0.0,0.0,0.07,amber porter,
-ASTR,8100,1,Astroph I: Radiation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-AUD,1850,1,Intro to Audio Tech,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUD,2800,1,Sound Reinforcement,0.0,0.17,0.75,0.08,0.0,0.0,0.0,0.0,kenneth moore,
-AUE,4010,1,Vehicle Dynamics,0.3,0.5,0.1,0.0,0.1,0.0,0.0,0.0,imtiaz ul haque,
-AUE,4030,1,Automotive Engr Project Tools,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,andrej ivanco,
-AUE,8180,1,"Engine Analysis, Design & Exp",0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8260,1,Vehicle Diagnostics,0.34,0.54,0.11,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8270,5,Auto Cntrl Sys Des,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8280,1,Driveline/Powertrain,0.61,0.26,0.13,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8330,30,Auto Manuf Proc Devl,0.18,0.74,0.08,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8350,100,Auto Electronics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,
-AUE,8670,1,Veh Manuf Proc I,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8810,3,Automotive Systems Overview,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
-AUE,8870,8,Meth Vehicle Testing,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8930,16,Light-Weight Automotive Design,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,david wil schmueser,
-AUE,8930,18,Adv IC Engine Concept,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,8930,19,Autovation II: Tech Enterp Dev,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
-AUE,8930,89,Manufacturing,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,
-AVS,1000,1,Orientation to AVS,0.92,0.05,0.01,0.01,0.0,0.0,0.0,0.01,marie owens bolt,
-AVS,1500,1,Intro Animal Science,0.2,0.4,0.21,0.09,0.06,0.0,0.0,0.03,joseph kei bertrand,
-AVS,1510,1,Intro Ani Sci Lab,0.46,0.46,0.04,0.0,0.0,0.0,0.0,0.04,richelle lor miller,
-AVS,1510,2,Intro Ani Sci Lab,0.68,0.2,0.04,0.0,0.0,0.0,0.0,0.08,richelle lor miller,
-AVS,1510,3,Intro Ani Sci Lab,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,1510,4,Intro Ani Sci Lab,0.77,0.09,0.09,0.0,0.0,0.0,0.0,0.05,chelsea dr sinclair,
-AVS,1510,5,Intro Ani Sci Lab,0.72,0.24,0.0,0.04,0.0,0.0,0.0,0.0,marie owens bolt,
-AVS,1510,6,Intro Ani Sci Lab,0.71,0.21,0.04,0.04,0.0,0.0,0.0,0.0,marie owens bolt,
-AVS,1510,7,Intro Ani Sci Lab,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,chelsea dr sinclair,
-AVS,1510,8,Intro Ani Sci Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
-AVS,2020,1,CAFLS Plus,0.91,0.05,0.0,0.0,0.05,0.0,0.0,0.0,thomas scott,
-AVS,2030,1,Dairy Sci Techniques,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,heather walker dunn,
-AVS,2040,1,Horse Care Techniques,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,2060,1,Swine Techniques,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3010,1,Anat & Phys Dom Ani,0.42,0.34,0.21,0.03,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,3010,400,Anat & Phys Dom Ani,0.27,0.31,0.29,0.12,0.0,0.0,0.0,0.02,glenn birrenkott,
-AVS,3020,1,Livestk Sel Eval I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3100,1,Animal Health,0.52,0.33,0.16,0.0,0.0,0.0,0.0,0.0,celina marc checura,
-AVS,3700,1,Principles of Animal Nutrition,0.68,0.19,0.08,0.03,0.01,0.0,0.0,0.0,james ro strickland,
-AVS,3750,1,Applied Animal Nutrition,0.38,0.38,0.13,0.06,0.0,0.0,0.0,0.06,gustavo jos lascano,
-AVS,3850,1,Equine Behavior and Training,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,chelsea dr sinclair,
-AVS,4000,1,AVS Professional Development,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
-AVS,4000,2,AVS Professional Development,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
-AVS,4060,1,Seminars & Related Topics,0.57,0.37,0.07,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4060,2,Seminars & Related Topics,0.13,0.69,0.19,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4110,1,Animal Growth and Development,0.59,0.21,0.14,0.03,0.03,0.0,0.0,0.0,susan kay duckett,
-AVS,4150,1,Contemporary Issues in AVS,0.3,0.33,0.19,0.05,0.05,0.0,0.0,0.09,peter skewes,
-AVS,4160,1,Equine Exercise Phys,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,4500,1,Sust Livestock Sys,0.36,0.57,0.0,0.0,0.0,0.0,0.0,0.07,matias jose aguerre,
-AVS,4530,1,Animal Reproduction,0.54,0.32,0.11,0.04,0.0,0.0,0.0,0.0,tiffany wilmoth,
-AVS,4650,1,Animal Physiology I,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,celina marc checura,
-AVS,4800,1,Vertebrate Endocrinology,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,6650,1,Animal Physiology I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,celina marc checura,
-BCHM,1030,1,Careers in Bioch/Gen,0.88,0.07,0.0,0.01,0.03,0.0,0.0,0.01,joseph paul thames,
-BCHM,3010,1,Molecular Biochemistry,0.35,0.26,0.13,0.06,0.06,0.0,0.0,0.13,kerry smith,
-BCHM,3050,1,Essen Elements Bioch,0.65,0.23,0.07,0.01,0.01,0.0,0.0,0.03,debra ragland,
-BCHM,3050,2,Essen Elements Bioch,0.43,0.34,0.14,0.02,0.01,0.0,0.0,0.05,debra ragland,
-BCHM,4310,1,Physical Approach to Biochem,0.24,0.43,0.3,0.04,0.0,0.0,0.0,0.0,weiguo cao,
-BCHM,4310,2,Phys App to Bioch (HON),0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True
-BCHM,4330,1,Physical Biochemistry Lab,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,4400,1,Bioinformatics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
-BCHM,4430,1,Mol Basis Disease,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,james morris,
-BCHM,8140,1,Advanced Biochemistry,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,cheryl ingram-smith,
-BE,2120,1,Fundamentals of Biosys Engr,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,caye marie drapcho,
-BE,3200,1,Principles & Prac of Geomatics,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4100,1,Biological Kinetics,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,4210,1,Engr Sys for Soil Water Mgt,0.67,0.27,0.0,0.07,0.0,0.0,0.0,0.0,christophe darnault,
-BE,4280,1,Biochem Engr,0.33,0.33,0.25,0.08,0.0,0.0,0.0,0.0,terry walker,
-BE,4740,1,BE Design Project Managment,0.73,0.15,0.12,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4750,1,BE Capstone Design,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BIOE,2010,1,Intro Biomed Engr,0.25,0.5,0.06,0.0,0.0,0.0,0.0,0.19,charles webb,
-BIOE,2010,2,Intro Biomed Engr,0.46,0.39,0.05,0.01,0.01,0.0,0.0,0.08,charles webb,
-BIOE,3020,1,Biomaterials,0.61,0.27,0.04,0.04,0.04,0.0,0.0,0.02,alexey ale vertegel,
-BIOE,3100,1,Engr Analysis of Physiol Proc,0.55,0.43,0.01,0.0,0.0,0.0,0.0,0.0,brian william booth,
-BIOE,3200,1,Biomechanics,0.74,0.22,0.0,0.01,0.0,0.0,0.0,0.03,jiro nagatomi,
-BIOE,3210,1,Biofluid Mechanics,0.55,0.33,0.09,0.0,0.0,0.0,0.0,0.03,zhi gao,
-BIOE,3700,1,Bioinst & Imaging,0.67,0.24,0.03,0.0,0.0,0.0,0.0,0.06,delphine dean,
-BIOE,4010,1,Bioengineering Design Theory,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,john desjardins,
-BIOE,4010,2,Bioengineering Design Theory,0.95,0.03,0.03,0.0,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4030,1,Applied Bio E Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,
-BIOE,4120,1,Orthopaedic Engr and Pathology,0.5,0.35,0.1,0.0,0.0,0.0,0.0,0.05,melinda harman,
-BIOE,4400,1,Biopharmaceutical Engineering,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,sarah harcum,
-BIOE,4500,3,Biofabrication,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
-BIOE,6120,1,Orthopaedic Engr & Pathology,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,
-BIOE,6400,1,Biopharmaceutical Engineering,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sarah harcum,
-BIOE,8010,1,Bio Materials,0.31,0.59,0.06,0.0,0.0,0.0,0.0,0.03,robert latour,
-BIOE,8020,410,Biocompatibility,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
-BIOE,8140,401,Medical Dev Commercialization,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,david orr,
-BIOE,8160,1,BioE Professional Development,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,martine laberge,
-BIOE,8200,1,Structl Biomechanics,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,hai yao,
-BIOE,8240,1,Cell & Mol Tissue Engineering,0.67,0.0,0.17,0.0,0.0,0.0,0.0,0.17,jeoungsoo lee,
-BIOL,1010,1,Frontiers in Biology I,0.83,0.11,0.05,0.01,0.01,0.0,0.0,0.0,robert edwa ballard,
-BIOL,1010,2,Frontiers in Biology I,0.63,0.22,0.09,0.04,0.02,0.0,0.0,0.0,thomas hughes,
-BIOL,1030,1,General Biology I,0.17,0.27,0.26,0.16,0.06,0.0,0.0,0.09,nora espinoza,
-BIOL,1030,2,General Biology I,0.14,0.31,0.29,0.14,0.07,0.0,0.0,0.06,william baldwin,
-BIOL,1030,3,General Biology I,0.32,0.3,0.2,0.07,0.05,0.0,0.0,0.05,william surver,
-BIOL,1030,4,General Biology I,0.16,0.23,0.33,0.17,0.05,0.0,0.0,0.07,salvatore sparace,
-BIOL,1030,5,General Biology I (HON),0.49,0.36,0.13,0.0,0.0,0.0,0.0,0.03,nora espinoza,True
-BIOL,1050,1,General Biology Lab I,0.13,0.42,0.29,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,2,General Biology Lab I,0.08,0.5,0.33,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,3,General Biology Lab I,0.27,0.32,0.27,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,4,General Biology Lab I,0.0,0.63,0.29,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,5,General Biology Lab I,0.04,0.5,0.46,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,6,General Biology Lab I,0.21,0.54,0.21,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,7,General Biology Lab I,0.0,0.25,0.38,0.08,0.08,0.0,0.0,0.21,tafadzwa kaisa,
-BIOL,1050,8,General Biology Lab I,0.04,0.33,0.42,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,9,General Biology Lab I,0.0,0.15,0.3,0.25,0.1,0.0,0.0,0.2,tafadzwa kaisa,
-BIOL,1050,10,General Biology Lab I,0.04,0.52,0.26,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,11,General Biology Lab I,0.09,0.65,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,12,General Biology Lab I,0.17,0.29,0.38,0.08,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,13,General Biology Lab I,0.08,0.54,0.25,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,14,General Biology Lab I,0.04,0.63,0.29,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,15,General Biology Lab I,0.0,0.67,0.17,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,16,General Biology Lab I,0.04,0.43,0.43,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,17,General Biology Lab I,0.13,0.38,0.33,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,18,General Biology Lab I,0.17,0.42,0.38,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,19,General Biology Lab I,0.23,0.27,0.36,0.09,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,20,General Biology Lab I,0.1,0.35,0.4,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,21,General Biology Lab I,0.0,0.21,0.5,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,22,General Biology Lab I,0.0,0.61,0.3,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,23,General Biology Lab I,0.08,0.29,0.29,0.13,0.13,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,25,General Biology Lab I,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,26,General Biology Lab I,0.25,0.46,0.25,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,27,General Biology Lab I,0.25,0.42,0.25,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,28,General Biology Lab I,0.04,0.5,0.33,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,29,General Biology Lab I,0.0,0.63,0.17,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,30,General Biology Lab I,0.0,0.29,0.29,0.17,0.08,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,31,General Biology Lab I,0.09,0.36,0.41,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,32,General Biology Lab I,0.0,0.39,0.39,0.22,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,33,General Biology Lab I,0.0,0.27,0.4,0.13,0.13,0.0,0.0,0.07,tafadzwa kaisa,
-BIOL,1050,34,General Biology Lab I,0.09,0.57,0.35,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,35,General Biology Lab I,0.13,0.46,0.33,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,36,General Biology Lab I,0.25,0.46,0.17,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,37,General Biology Lab I,0.04,0.38,0.5,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,38,General Biology Lab I,0.13,0.63,0.17,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,39,General Biology Lab I,0.0,0.5,0.42,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,40,General Biology Lab I,0.09,0.65,0.17,0.09,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,41,General Biology Lab I,0.0,0.5,0.42,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,42,General Biology Lab I,0.04,0.43,0.43,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,43,General Biology Lab I,0.09,0.36,0.36,0.09,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,44,General Biology Lab I,0.09,0.52,0.22,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,46,General Biology Lab I,0.04,0.38,0.38,0.13,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1090,1,Intro to Life Sci,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
-BIOL,1100,1,Principles of Biology I,0.47,0.41,0.08,0.01,0.0,0.0,0.0,0.03,dylan dittrich-reed,
-BIOL,1100,2,Principles of Biology I,0.24,0.43,0.23,0.04,0.03,0.0,0.0,0.04,robert kosinski,
-BIOL,1200,1,Biological Inq Lab,0.15,0.6,0.15,0.1,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,2,Biological Inq Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,3,Biological Inq Lab,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,4,Biological Inq Lab,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,
-BIOL,1200,5,Biological Inq Lab,0.25,0.55,0.1,0.05,0.0,0.0,0.0,0.05, christine minor,
-BIOL,1200,6,Biological Inq Lab,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,7,Biological Inq Lab,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,8,Biological Inq Lab,0.21,0.37,0.21,0.0,0.11,0.0,0.0,0.11, christine minor,
-BIOL,1200,9,Biological Inq Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,10,Biological Inq Lab,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,11,Biological Inq Lab,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05, christine minor,
-BIOL,1200,12,Biological Inq Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,13,Biological Inq Lab,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,14,Biological Inq Lab,0.32,0.47,0.16,0.05,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1230,1,Keys to Human Biol,0.16,0.44,0.29,0.1,0.02,0.0,0.0,0.0, christine minor,
-BIOL,1230,2,Keys to Human Biol,0.13,0.49,0.24,0.08,0.01,0.0,0.0,0.04, christine minor,
-BIOL,2040,1,"Environ, Energy and Society",0.4,0.33,0.15,0.05,0.0,0.0,0.0,0.08,john jenkins hains,
-BIOL,2040,2,"Environ, Energy and Society",0.34,0.4,0.17,0.04,0.04,0.0,0.0,0.02,john jenkins hains,
-BIOL,2110,1,Introduction to Toxicology,0.65,0.22,0.13,0.0,0.0,0.0,0.0,0.0,peter van den hurk,
-BIOL,2220,1,Human Anat and Physiology I,0.29,0.31,0.25,0.06,0.05,0.0,0.0,0.04,john cummings,
-BIOL,2220,2,Human Anat and Physiology I,0.22,0.36,0.23,0.05,0.06,0.0,0.0,0.09,john cummings,
-BIOL,3030,1,Vertebrate Biology,0.33,0.3,0.21,0.13,0.01,0.0,0.0,0.02,richard blob,
-BIOL,3030,2,Vertebrate Biology (HON),0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True
-BIOL,3040,1,Biology of Plants,0.53,0.36,0.06,0.02,0.03,0.0,0.0,0.0,christina wells,
-BIOL,3070,1,Vertebrate Biology Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,2,Vertebrate Biology Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,3,Vertebrate Biology Lab,0.25,0.6,0.15,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,4,Vertebrate Biology Lab,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,5,Vertebrate Biology Lab,0.25,0.5,0.15,0.0,0.05,0.0,0.0,0.05,richard blob,
-BIOL,3070,6,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,7,Vertebrate Biology Lab,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,8,Vertebrate Biology Lab,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,richard blob,
-BIOL,3070,9,Vertebrate Biology Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,10,Vertebrate Biology Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,11,Vertebrate Biology Lab,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3080,1,Biology of Plants Practicum,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,2,Biology of Plants Practicum,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,nathan redding,
-BIOL,3080,3,Biology of Plants Practicum,0.35,0.5,0.0,0.1,0.0,0.0,0.0,0.05,nathan redding,
-BIOL,3080,4,Biology of Plants Practicum,0.1,0.65,0.2,0.0,0.0,0.0,0.0,0.05,nathan redding,
-BIOL,3080,5,Biology of Plants Practicum,0.65,0.1,0.25,0.0,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,6,Biology of Plants Practicum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3150,1,Functional Human Anatomy,0.23,0.42,0.19,0.06,0.03,0.0,0.0,0.07,tamara mcnutt-scott,
-BIOL,3200,1,Field Botany,0.25,0.21,0.32,0.07,0.0,0.0,0.0,0.14,robert edwa ballard,
-BIOL,3350,1,Evolutionary Biology,0.41,0.42,0.13,0.02,0.0,0.0,0.0,0.01,michael sears,
-BIOL,3510,1,Biological Anthropology,0.11,0.56,0.11,0.06,0.06,0.0,0.0,0.11,lisa rapaport,
-BIOL,3530,1,Forensic Anthropology,0.29,0.47,0.18,0.0,0.0,0.0,0.0,0.06,katherine weisensee,
-BIOL,4030,1,Intro to Applied Genomics,0.15,0.46,0.08,0.08,0.08,0.0,0.0,0.15,vincent pa richards,
-BIOL,4140,1,Basic Immunology,0.19,0.44,0.31,0.06,0.0,0.0,0.0,0.0,yanzhang wei,
-BIOL,4170,1,Marine Biology,0.93,0.06,0.0,0.0,0.0,0.0,0.0,0.01,charles rice,
-BIOL,4200,1,Neurobiology,0.48,0.45,0.0,0.03,0.0,0.0,0.0,0.03,david feliciano,
-BIOL,4250,1,Introductory Mycology,0.35,0.29,0.26,0.03,0.0,0.0,0.0,0.06,julia loui kerrigan,
-BIOL,4260,2,Mycology Practicum,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,
-BIOL,4340,1,Biological Chem Lab Techniques,0.06,0.38,0.38,0.13,0.06,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,2,Biological Chem Lab Techniques,0.19,0.25,0.19,0.19,0.19,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,4,Biological Chem Lab Techniques,0.21,0.36,0.29,0.14,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4410,1,Ecology,0.58,0.27,0.09,0.05,0.0,0.0,0.0,0.01,john jenkins hains,
-BIOL,4430,1,Freshwater Ecology,0.47,0.33,0.11,0.03,0.0,0.0,0.0,0.06,john jenkins hains,
-BIOL,4440,1,Freshwater Ecology Lab (Lec),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,john jenkins hains,
-BIOL,4450,1,Ecology Laboratory (Lec),0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,john jenkins hains,
-BIOL,4450,3,Ecology Laboratory (Lec),0.5,0.1,0.4,0.0,0.0,0.0,0.0,0.0,john jenkins hains,
-BIOL,4450,4,Ecology Laboratory (Lec),0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,john jenkins hains,
-BIOL,4560,1,Medical and Vet Parasitology,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,wilbur kear milhous,
-BIOL,4610,1,Cell Biology,0.28,0.42,0.19,0.07,0.01,0.0,0.0,0.04,susan carol chapman,
-BIOL,4610,2,Cell Biology (HON),0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True
-BIOL,4620,1,Cell Biology Lab (Lec),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,2,Cell Biology Lab (Lec),0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,4,Cell Biology Lab (Lec),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.92,0.0,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,7,Cell Biology Lab (Lec),0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,8,Cell Biology Lab (Lec),0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
-BIOL,4620,9,Cell Biology Lab (Lec),0.89,0.04,0.0,0.0,0.0,0.0,0.0,0.07,xianzhong yu,
-BIOL,4670,1,Principles of Hematology,0.77,0.13,0.03,0.0,0.0,0.0,0.0,0.06,vincent gallicchio,
-BIOL,4930,1,Sr Sem: Genomics,0.79,0.07,0.0,0.0,0.07,0.0,0.0,0.07,kara elizabe powder,
-BIOL,4930,3,Sr Sem: Advances in Cancer,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
-BIOL,4930,5,Sr Sem: Bioelectricity,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,matthew turnbull,
-BIOL,4930,8,Sr Sem: Evolutionary Medicine,0.71,0.14,0.0,0.07,0.0,0.0,0.0,0.07,samantha ann price,
-BIOL,6030,1,Intro to Applied Genomics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,vincent pa richards,
-BIOL,8400,1,Understanding Biological Inq,0.93,0.05,0.01,0.0,0.01,0.0,0.0,0.01,michael childress,
-BIOL,8420,1,Understand Cellular Processes,0.64,0.31,0.05,0.0,0.01,0.0,0.0,0.0,patricia leota tate,
-BIOL,8440,1,Understanding the Human Body,0.64,0.28,0.04,0.0,0.04,0.0,0.0,0.0,william baldwin,
-BUS,1010,1,Business Foundations,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,2,Business Foundations,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,3,Business Foundations,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,4,Business Foundations,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,christopher mann,
-BUS,1010,5,Business Foundations,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,christopher mann,
-BUS,1010,6,Business Foundations,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,
-BUS,1010,7,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,8,Business Foundations,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
-BUS,1010,9,Business Foundations,0.16,0.21,0.16,0.16,0.11,0.0,0.0,0.21,william ern tumblin,
-BUS,1010,10,Business Foundations,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,11,Business Foundations,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,william ern tumblin,
-BUS,1010,12,Business Foundations,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,christopher mann,
-BUS,1010,13,Business Foundations,0.16,0.79,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,
-BUS,1010,14,Business Foundations,0.42,0.26,0.16,0.05,0.05,0.0,0.0,0.05,christopher mann,
-BUS,1010,15,Business Foundations,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,16,Business Foundations,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,donna mccubbin,
-BUS,1010,17,Business Foundations,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,18,Business Foundations,0.26,0.42,0.11,0.05,0.05,0.0,0.0,0.11,donna mccubbin,
-BUS,1010,19,Business Foundations,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,donna mccubbin,
-BUS,1010,20,Business Foundations,0.39,0.33,0.17,0.0,0.0,0.0,0.0,0.11,donna mccubbin,
-BUS,1010,21,Business Foundations,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,
-BUS,1010,22,Business Foundations,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,christopher mann,
-BUS,1010,23,Business Foundations,0.37,0.42,0.11,0.11,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,24,Business Foundations,0.37,0.37,0.11,0.0,0.0,0.0,0.0,0.16,sandy edge,
-BUS,1010,25,Business Foundations,0.58,0.11,0.21,0.05,0.05,0.0,0.0,0.0,sandy edge,
-BUS,1010,26,Business Foundations,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,27,Business Foundations,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,28,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,29,Business Foundations,0.26,0.28,0.26,0.11,0.02,0.0,0.0,0.07,lance scott young,
-BUS,1010,30,Business Foundations,0.18,0.37,0.35,0.02,0.0,0.0,0.0,0.08,lance scott young,
-BUS,1010,31,Business Foundations,0.42,0.16,0.37,0.0,0.0,0.0,0.0,0.05,lance scott young,
-BUS,1010,33,Business Foundations,0.28,0.32,0.28,0.08,0.04,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,34,Business Foundations,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,35,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,36,Business Foundations,0.26,0.42,0.21,0.0,0.05,0.0,0.0,0.05,christopher mann,
-BUS,1010,37,Business Foundations,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,2990,6,CI: Being a Leader,0.5,0.3,0.1,0.0,0.1,0.0,0.0,0.0,melissa vogel,
-CE,1990,2,Cr Inq in Civil Engineering,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,weichiang pang,
-CE,1990,20,Cr Inq in Civil Engineering,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,bradley putman,
-CE,2010,1,Statics,0.22,0.17,0.26,0.07,0.09,0.0,0.0,0.2,melissa sternhagen,
-CE,2010,2,Statics,0.27,0.3,0.25,0.05,0.07,0.0,0.0,0.07,"mahmoudabadi arani,",
-CE,2010,3,Statics,0.46,0.21,0.13,0.08,0.06,0.0,0.0,0.06,qiushi chen,
-CE,2010,4,Statics,0.18,0.34,0.14,0.11,0.07,0.0,0.0,0.16,melissa sternhagen,
-CE,2010,5,Statics,0.43,0.36,0.16,0.0,0.02,0.0,0.0,0.02,mahmoodreza soltani,
-CE,2010,6,Statics,0.15,0.23,0.15,0.08,0.09,0.0,0.0,0.29,melissa sternhagen,
-CE,2010,8,Statics,0.1,0.37,0.29,0.04,0.08,0.0,0.0,0.12, kent nilsson,
-CE,2060,1,Structural Mechanics,0.41,0.33,0.22,0.02,0.02,0.0,0.0,0.02,mahmoodreza soltani,
-CE,2080,1,Dynamics,0.07,0.29,0.34,0.2,0.05,0.0,0.0,0.05,melissa sternhagen,
-CE,2550,1,Geomatics,0.3,0.45,0.2,0.04,0.01,0.0,0.0,0.0,wayne sarasua,
-CE,3010,1,Structural Analysis,0.35,0.32,0.24,0.08,0.0,0.0,0.0,0.0,stephen csernak,
-CE,3010,2,Structural Analysis,0.42,0.36,0.11,0.06,0.03,0.0,0.0,0.03,thomas edfo cousins,
-CE,3110,1,Transportation Engr,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
-CE,3210,1,Geotechnical Engineering,0.21,0.24,0.33,0.14,0.07,0.0,0.0,0.0,qiushi chen,
-CE,3310,1,Constr Engr & Mgmnt,0.59,0.28,0.09,0.03,0.01,0.0,0.0,0.0,james burati,
-CE,3410,1,Intro to Fluid Mech,0.33,0.4,0.17,0.1,0.0,0.0,0.0,0.0,nigel gregory kaye,
-CE,3410,2,Intro to Fluid Mech,0.17,0.38,0.3,0.02,0.13,0.0,0.0,0.0,abdul khan,
-CE,3420,1,Hydraulics & Hydro,0.5,0.33,0.11,0.07,0.0,0.0,0.0,0.0,ashok mishra,
-CE,3510,1,Civil Engineering Materials,0.24,0.51,0.22,0.0,0.02,0.0,0.0,0.0,ami esmaeilpoursaee,
-CE,3510,2,Civil Engineering Materials,0.45,0.48,0.07,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,
-CE,3520,1,Econ Eval of Proj,0.46,0.26,0.19,0.04,0.0,0.0,0.0,0.06,zoraya rolda rockow,
-CE,4010,1,Matrix Str Analysis,0.0,0.47,0.2,0.2,0.07,0.0,0.0,0.07,bryant nielson,
-CE,4020,1,Reinfor Con Design,0.36,0.39,0.21,0.03,0.0,0.0,0.0,0.0,brandon ross,
-CE,4060,1,Struct Steel Design,0.36,0.44,0.05,0.08,0.03,0.0,0.0,0.05,stephen csernak,
-CE,4100,1,Traffic Engr Oper,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
-CE,4240,1,Earth Slopes & Struc,0.33,0.39,0.2,0.04,0.04,0.0,0.0,0.0,nadara ravichandran,
-CE,4330,1,Const Plan & Sched,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-CE,4390,1,Con Eqpmt Sel & Main,0.32,0.45,0.18,0.0,0.0,0.0,0.0,0.05,james burati,
-CE,4560,1,Pave Design & Constr,0.48,0.44,0.04,0.0,0.0,0.0,0.0,0.04,bradley putman,
-CE,4590,1,Capstone Design Proj,0.51,0.3,0.05,0.14,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4910,1,BIM in Construction Management,0.76,0.14,0.03,0.0,0.07,0.0,0.0,0.0,kalyan ram piratla,
-CE,4910,2,Hydrologic Analysis and Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ashok mishra,
-CE,6010,1,Matrix Str Analysis,0.45,0.41,0.14,0.0,0.0,0.0,0.0,0.0,bryant nielson,
-CE,6100,1,Traffic Engr Oper,0.4,0.2,0.2,0.0,0.0,0.0,0.0,0.2,wayne sarasua,
-CE,6240,1,Earth Slopes & Struc,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,6390,1,Con Eqpmt Sel & Main,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,james burati,
-CE,6560,1,Pavement Des & Const,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,bradley putman,
-CE,8200,1,Geotech Site Charac,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,8260,1,Prop of Concrete,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
-CE,8320,1,Capl Proj Mgmt Fund,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-CE,8580,500,Fund of Risk Engineering Mgt,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,jie zhang,
-CE,8930,2,Bridge Design,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brandon ross,
-CE,8930,4,Data Analytics for Transpo,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CE,8930,5,Civil Infrastructure Systems,0.71,0.0,0.14,0.0,0.0,0.0,0.0,0.14,pamela murray-tuite,
-CH,1010,1,General Chemistry,0.18,0.24,0.27,0.15,0.07,0.0,0.0,0.09,william mcwhorter,
-CH,1010,2,General Chemistry,0.26,0.29,0.23,0.1,0.04,0.0,0.0,0.08,elliot ennis,
-CH,1010,3,General Chemistry,0.16,0.28,0.23,0.15,0.06,0.0,0.0,0.12,william mcwhorter,
-CH,1010,4,General Chemistry,0.24,0.31,0.22,0.11,0.05,0.0,0.0,0.08,dennis taylor,
-CH,1010,5,General Chemistry,0.27,0.29,0.19,0.12,0.05,0.0,0.0,0.08,william mcwhorter,
-CH,1010,6,General Chemistry,0.15,0.38,0.21,0.17,0.04,0.0,0.0,0.05,thomas hickman,
-CH,1010,7,General Chemistry,0.22,0.34,0.25,0.11,0.03,0.0,0.0,0.05,laura lanni,
-CH,1010,8,General Chemistry,0.33,0.37,0.16,0.05,0.03,0.0,0.0,0.05,tania issa houjeiry,
-CH,1010,9,General Chemistry,0.25,0.39,0.21,0.09,0.03,0.0,0.0,0.03,dennis taylor,
-CH,1010,10,General Chemistry,0.33,0.3,0.19,0.06,0.05,0.0,0.0,0.08,tania issa houjeiry,
-CH,1010,11,General Chemistry,0.21,0.24,0.3,0.1,0.07,0.0,0.0,0.08,princess mycia cox,
-CH,1010,12,General Chemistry,0.31,0.33,0.19,0.06,0.03,0.0,0.0,0.08,elliot ennis,
-CH,1010,13,General Chemistry,0.2,0.38,0.26,0.11,0.03,0.0,0.0,0.02,dennis taylor,
-CH,1010,50,General Chemistry,0.26,0.35,0.13,0.16,0.06,0.0,0.0,0.03,shiou-jyh hwu,
-CH,1010,51,General Chemistry (HON),0.69,0.2,0.12,0.0,0.0,0.0,0.0,0.0,william pennington,True
-CH,1010,52,General Chemistry (HON),0.68,0.2,0.1,0.02,0.0,0.0,0.0,0.0,joseph stu thrasher,True
-CH,1010,201,General Chemistry,0.22,0.36,0.28,0.09,0.03,0.0,0.0,0.03,laura lanni,
-CH,1010,202,General Chemistry,0.2,0.43,0.22,0.11,0.02,0.0,0.0,0.03,jacob schroeder,
-CH,1010,203,General Chemistry,0.2,0.39,0.24,0.08,0.03,0.0,0.0,0.05,olt geiculescu,
-CH,1010,204,General Chemistry,0.25,0.43,0.17,0.12,0.02,0.0,0.0,0.01,princess mycia cox,
-CH,1010,501,General Chemistry,0.21,0.39,0.24,0.12,0.0,0.0,0.0,0.03,brian gloor,
-CH,1020,1,General Chemistry,0.37,0.21,0.21,0.11,0.03,0.0,0.0,0.06,stephe schvaneveldt,
-CH,1020,2,General Chemistry,0.21,0.22,0.29,0.15,0.05,0.0,0.0,0.08,stephe schvaneveldt,
-CH,1020,3,General Chemistry,0.31,0.19,0.3,0.09,0.02,0.0,0.0,0.08,stephe schvaneveldt,
-CH,1020,400,General Chemistry,0.1,0.25,0.29,0.15,0.15,0.0,0.0,0.06,stephe schvaneveldt,
-CH,1050,1,Chemistry in Context I,0.37,0.51,0.07,0.02,0.02,0.0,0.0,0.02,olt geiculescu,
-CH,1050,2,Chemistry in Context I,0.33,0.47,0.11,0.04,0.03,0.0,0.0,0.01,olt geiculescu,
-CH,2010,1,Survey of Organic Chemistry,0.2,0.33,0.26,0.11,0.08,0.0,0.0,0.02,thomas hickman,
-CH,2010,2,Survey of Organic Chemistry,0.29,0.45,0.15,0.09,0.0,0.0,0.0,0.02,thomas hickman,
-CH,2020,1,Surv of Organic Chemistry Lab,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2020,2,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2020,4,Surv of Organic Chemistry Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,
-CH,2020,5,Surv of Organic Chemistry Lab,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,james nelso plampin,
-CH,2020,6,Surv of Organic Chemistry Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,
-CH,2020,8,Surv of Organic Chemistry Lab,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
-CH,2020,9,Surv of Organic Chemistry Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2230,1,Organic Chemistry,0.32,0.25,0.14,0.05,0.06,0.0,0.0,0.18,modi wetzler,
-CH,2230,2,Organic Chemistry,0.36,0.3,0.09,0.11,0.04,0.0,0.0,0.11,modi wetzler,
-CH,2230,3,Organic Chemistry,0.34,0.37,0.17,0.04,0.03,0.0,0.0,0.05,tania issa houjeiry,
-CH,2230,4,Organic Chemistry,0.19,0.43,0.17,0.06,0.04,0.0,0.0,0.11,laura lanni,
-CH,2230,5,Organic Chemistry,0.29,0.4,0.15,0.07,0.05,0.0,0.0,0.04,elliot ennis,
-CH,2230,6,Organic Chemistry,0.25,0.36,0.18,0.06,0.04,0.0,0.0,0.12,rhett smith,
-CH,2230,7,Organic Chemistry,0.31,0.31,0.2,0.05,0.03,0.0,0.0,0.1,sourav saha,
-CH,2240,1,Organic Chemistry,0.27,0.31,0.23,0.05,0.13,0.0,0.0,0.01,jacob schroeder,
-CH,2240,2,Organic Chemistry,0.27,0.26,0.26,0.09,0.06,0.0,0.0,0.06,jacob schroeder,
-CH,2270,1,Organic Chem Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
-CH,2270,3,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,4,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,7,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,james nelso plampin,
-CH,2270,8,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,9,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,10,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,
-CH,2270,12,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,13,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,14,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,
-CH,2270,16,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,17,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
-CH,2270,18,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,20,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,21,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,23,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,
-CH,2270,24,Organic Chem Lab,0.73,0.13,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,26,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,27,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,28,Organic Chem Lab,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,james nelso plampin,
-CH,2270,30,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,31,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,james nelso plampin,
-CH,2270,32,Organic Chem Lab,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,33,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2270,34,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,35,Organic Chem Lab,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2270,36,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,
-CH,2270,37,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
-CH,2270,38,Organic Chem Lab,0.56,0.13,0.0,0.0,0.06,0.0,0.0,0.25,james nelso plampin,
-CH,2280,1,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
-CH,2280,2,Organic Chem Lab,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,james nelso plampin,
-CH,2280,3,Organic Chem Lab,0.76,0.06,0.0,0.0,0.0,0.0,0.0,0.18,james nelso plampin,
-CH,2280,4,Organic Chem Lab,0.72,0.0,0.0,0.0,0.0,0.0,0.0,0.28,james nelso plampin,
-CH,2280,5,Organic Chem Lab,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
-CH,2280,6,Organic Chem Lab,0.71,0.0,0.0,0.0,0.06,0.0,0.0,0.24,james nelso plampin,
-CH,2280,7,Organic Chem Lab,0.73,0.07,0.07,0.0,0.13,0.0,0.0,0.0,james nelso plampin,
-CH,2280,9,Organic Chem Lab,0.7,0.0,0.0,0.0,0.0,0.0,0.0,0.3,james nelso plampin,
-CH,3130,1,Quantitative Analys,0.54,0.2,0.22,0.05,0.0,0.0,0.0,0.0,stephen creager,
-CH,3150,1,Quant Analysis Lab,0.64,0.09,0.0,0.0,0.18,0.0,0.0,0.09,carlos garcia perez,
-CH,3150,2,Quant Analysis Lab,0.25,0.58,0.08,0.0,0.0,0.0,0.0,0.08,carlos garcia perez,
-CH,3300,1,Intro to Phys Chem,0.46,0.29,0.14,0.03,0.05,0.0,0.0,0.03,brian dominy,
-CH,3310,1,Physical Chemistry,0.13,0.13,0.33,0.2,0.13,0.0,0.0,0.07,steven stuart,
-CH,3310,2,Physical Chemistry,0.75,0.08,0.08,0.04,0.0,0.0,0.0,0.04,jason mcneill,
-CH,3320,1,Physical Chemistry,0.41,0.35,0.06,0.0,0.0,0.0,0.0,0.18,arkady kholodenko,
-CH,3390,1,Physical Chem Lab,0.2,0.75,0.0,0.0,0.0,0.0,0.0,0.05,princess mycia cox,
-CH,3390,2,Physical Chem Lab,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,princess mycia cox,
-CH,3390,4,Physical Chem Lab,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,5,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3410,1,Introduction to Research,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,stephen creager,
-CH,4010,1,Organometallic Chemistry,0.66,0.3,0.0,0.0,0.0,0.0,0.0,0.04,andrew gre tennyson,
-CH,4020,1,Inorganic Chemistry,0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,joseph kolis,
-CH,8070,1,Chem Trans Elem,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
-CH,8140,1,Analytical Imaging,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,george chumanov,
-CH,8160,1,Separation Science,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,richard marcus,
-CH,8210,1,Organic Chem I,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,ya-ping sun,
-CH,8410,3,N M R Spectroscopy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alek kitaygorodskiy,
-CH,8510,1,Grad Student Seminar,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,joseph stu thrasher,
-CH,8520,1,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,leah bec casabianca,
-CHE,2110,1,Mass and Energy Balances,0.11,0.19,0.31,0.14,0.11,0.0,0.0,0.14,mark roberts,
-CHE,2110,2,Mass and Energy Balances,0.28,0.27,0.33,0.02,0.03,0.0,0.0,0.07,mark roberts,
-CHE,3210,1,Ch E Thermo II,0.13,0.2,0.36,0.27,0.04,0.0,0.0,0.0,sapna sarupria,
-CHE,3300,1,Mass Trans & Seprtn,0.16,0.2,0.4,0.12,0.11,0.0,0.0,0.01,mark thies,
-CHE,4070,1,Unit Op Lab II,0.16,0.72,0.12,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
-CHE,4140,1,Green Engineering,0.48,0.44,0.08,0.0,0.0,0.0,0.0,0.0,christophe kitchens,
-CHE,4310,1,Process Design I,0.25,0.47,0.28,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,4500,1,Chem Reaction Engr,0.19,0.27,0.39,0.14,0.01,0.0,0.0,0.0,rachel getman,
-CHE,6130,1,Polymer Composite Engineering,0.4,0.2,0.4,0.0,0.0,0.0,0.0,0.0,amod ogale,
-CHE,8030,1,Advanced Transport,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,eric mikel davis,
-CHE,8040,1,Ch E Thermodynamics,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,joseph scott,
-CHE,8050,1,Ch E Kinetics,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,mark alan blenner,
-CHIN,2010,1,Intermediate Chinese,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,ling rao,
-CHIN,3050,1,Chin Conv & Comp I,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,yanhua zhang,
-COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,eddie smith,
-COM,1500,1,Intro to Human Communication,0.83,0.15,0.0,0.0,0.01,0.0,0.0,0.02,eddie smith,
-COM,1500,2,Intro to Human Communication,0.69,0.26,0.01,0.01,0.01,0.0,0.0,0.02,daniel lelan fecher,
-COM,1500,3,Intro to Human Communication,0.91,0.07,0.02,0.0,0.01,0.0,0.0,0.0,eddie smith,
-COM,1500,4,Intro to Human Communication,0.77,0.16,0.03,0.0,0.02,0.0,0.0,0.02,marianne her glaser,
-COM,1500,5,Intro to Human Communication,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,marianne her glaser,
-COM,1500,6,Intro to Human Communication,0.81,0.1,0.03,0.0,0.03,0.0,0.0,0.03,marianne her glaser,
-COM,1500,7,Intro to Human Communication,0.43,0.47,0.04,0.03,0.03,0.0,0.0,0.0,daniel lelan fecher,
-COM,2010,1,Intr to Comm Studies,0.69,0.28,0.0,0.03,0.0,0.0,0.0,0.0,darren linvill,
-COM,2010,2,Intr to Comm Studies,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,2020,1,Communication Theory,0.31,0.31,0.31,0.06,0.0,0.0,0.0,0.0,kristen ela okamoto,
-COM,2020,2,Communication Theory,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,kristen ela okamoto,
-COM,2040,1,Critical-Cultural Comm Theory,0.61,0.22,0.11,0.0,0.0,0.0,0.0,0.06,david travers scott,
-COM,2100,1,Quant Comm Research Methods,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,2100,2,Quant Comm Research Methods,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,2110,1,Qual Comm Research Methods,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,angela pratt,
-COM,2500,1,Public Speaking,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,2,Public Speaking,0.35,0.47,0.06,0.06,0.0,0.0,0.0,0.06,sara grumbl crocker,
-COM,2500,3,Public Speaking,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,4,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,5,Public Speaking,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,6,Public Speaking,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,7,Public Speaking,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,
-COM,2500,8,Public Speaking,0.56,0.39,0.0,0.06,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,9,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,10,Public Speaking,0.53,0.26,0.16,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,11,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,
-COM,2500,12,Public Speaking,0.61,0.22,0.06,0.0,0.11,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,13,Public Speaking,0.63,0.21,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,14,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,16,Public Speaking,0.84,0.0,0.11,0.0,0.0,0.0,0.0,0.05,vanessa anne condon,
-COM,2500,17,Public Speaking,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,the estate  geddes,
-COM,2500,18,Public Speaking,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,pauline matthey,
-COM,2500,19,Public Speaking,0.32,0.26,0.32,0.11,0.0,0.0,0.0,0.0,pauline matthey,
-COM,2500,21,Public Speaking,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,katie barn mcelveen,
-COM,2500,23,Public Speaking,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,pauline matthey,
-COM,2500,24,Public Speaking,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,katie barn mcelveen,
-COM,2500,25,Public Speaking (HON),0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True
-COM,2500,26,Public Speaking (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,True
-COM,2500,28,Public Speaking,0.67,0.11,0.11,0.0,0.06,0.0,0.0,0.06,sara grumbl crocker,
-COM,2500,29,Public Speaking,0.68,0.11,0.11,0.0,0.0,0.0,0.0,0.11,sara grumbl crocker,
-COM,2500,30,Public Speaking,0.53,0.21,0.11,0.0,0.05,0.0,0.0,0.11,jumah patrici taweh,
-COM,2500,31,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,32,Public Speaking,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,33,Public Speaking,0.56,0.17,0.17,0.0,0.11,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,34,Public Speaking,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,
-COM,2500,35,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,
-COM,2500,36,Public Speaking,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,amanda elizab moore,
-COM,2500,37,Public Speaking,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,amanda elizab moore,
-COM,2500,39,Public Speaking (HON),0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,lindsey dixon,True
-COM,2500,400,Public Speaking,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,403,Public Speaking,0.89,0.0,0.06,0.0,0.06,0.0,0.0,0.0,alexis zachar davis,
-COM,3220,1,Communication Design,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,
-COM,3240,1,"Communication, Sport & Society",0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,
-COM,3240,2,"Communication, Sport & Society",0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,
-COM,3260,2,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3260,3,Pr in Sports,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,katie barn mcelveen,
-COM,3480,1,Interpersonal Comm,0.64,0.28,0.06,0.03,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,3550,1,Principles of Public Relations,0.65,0.24,0.04,0.02,0.02,0.0,0.0,0.02,meghna tallapragada,
-COM,3570,1,Public Relations Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3570,2,Public Relations Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3660,4,Adv. Strategic Comm,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,mark david land,
-COM,4250,1,Adv Sports Comm,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,bryan denham,
-COM,4260,1,Social Media and Sports Comm,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4260,2,Social Media and Sports Comm,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4300,1,Legal Communication,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
-COM,4710,1,Health Comm in Communities,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,8030,1,Comm Technology Studies Survey,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
-COM,8100,1,Comm Research Methods I,0.25,0.63,0.0,0.0,0.13,0.0,0.0,0.0,gregory kei cranmer,
-CPSC,1010,1,Computer Science I,0.16,0.35,0.13,0.11,0.1,0.0,0.0,0.15,salvatore lamarca,
-CPSC,1010,2,Computer Science I,0.19,0.31,0.21,0.12,0.09,0.0,0.0,0.09,salvatore lamarca,
-CPSC,1020,1,Computer Science II,0.27,0.13,0.17,0.17,0.12,0.0,0.0,0.13,yvon feaster,
-CPSC,1020,2,Computer Science II,0.37,0.29,0.16,0.03,0.11,0.0,0.0,0.05,yvon feaster,
-CPSC,1060,1,Intro to Programming in Java,0.32,0.24,0.12,0.06,0.15,0.0,0.0,0.12,salvatore lamarca,
-CPSC,1070,1,Programming Methodology,0.57,0.18,0.14,0.06,0.02,0.0,0.0,0.04,rose lowe,
-CPSC,1110,1,Intro to Programming in C,0.37,0.27,0.15,0.05,0.07,0.0,0.0,0.08,catherine hochrine,
-CPSC,1110,2,Intro to Programming in C,0.31,0.25,0.1,0.05,0.19,0.0,0.0,0.1,catherine hochrine,
-CPSC,1110,3,Intro to Programming in C,0.48,0.2,0.12,0.08,0.02,0.0,0.0,0.11,john junius porter,
-CPSC,1210,1,Computational Thinking,0.11,0.44,0.11,0.0,0.17,0.0,0.0,0.17,larry hodges,
-CPSC,2070,1,Discrete Structures,0.21,0.28,0.23,0.07,0.11,0.0,0.0,0.1,larry hodges,
-CPSC,2120,1,Algs/Data Structures,0.3,0.23,0.18,0.04,0.09,0.0,0.0,0.16,brian christop dean,
-CPSC,2120,2,Algs/Data Structures,0.25,0.33,0.22,0.05,0.05,0.0,0.0,0.1,wayne goddard,
-CPSC,2150,1,Software Dev Foundations,0.27,0.36,0.25,0.03,0.02,0.0,0.0,0.07,kevin anton plis,
-CPSC,2150,2,Software Dev Foundations,0.27,0.27,0.21,0.02,0.14,0.0,0.0,0.09,kevin anton plis,
-CPSC,2200,1,Microcomputer Appl,0.46,0.39,0.07,0.04,0.04,0.0,0.0,0.0,kevin anton plis,
-CPSC,2200,2,Microcomputer Appl,0.26,0.37,0.19,0.11,0.07,0.0,0.0,0.0,kevin anton plis,
-CPSC,2310,1,Intro Computer Org,0.42,0.43,0.09,0.04,0.02,0.0,0.0,0.0,rose lowe,
-CPSC,2310,2,Intro Computer Org,0.44,0.26,0.22,0.02,0.02,0.0,0.0,0.04,rose lowe,
-CPSC,2810,1,Selected Topics: TA Class,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,christopher plaue,
-CPSC,2910,1,Prof Issues I,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,2,Prof Issues I,0.59,0.24,0.12,0.06,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,3,Prof Issues I,0.47,0.33,0.07,0.0,0.07,0.0,0.0,0.07,catherine hochrine,
-CPSC,2910,4,Prof Issues I,0.61,0.17,0.17,0.0,0.06,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,5,Prof Issues I,0.39,0.39,0.06,0.0,0.11,0.0,0.0,0.06,catherine hochrine,
-CPSC,2920,1,"Computing, Ethics & Society",0.25,0.4,0.25,0.05,0.0,0.0,0.0,0.05,christopher plaue,
-CPSC,3220,1,Intro to Operating Systems,0.12,0.36,0.36,0.12,0.03,0.0,0.0,0.0,mark smotherman,
-CPSC,3220,2,Intro to Operating Systems,0.55,0.4,0.04,0.02,0.0,0.0,0.0,0.0,carl bryan martin,
-CPSC,3220,3,Intro to Operating Systems,0.21,0.42,0.11,0.16,0.11,0.0,0.0,0.0, van den meiracker,
-CPSC,3300,1,Computer Systems Org,0.21,0.34,0.34,0.11,0.0,0.0,0.0,0.0,rong ge,
-CPSC,3500,1,Foundations of Computer Sci,0.15,0.19,0.41,0.07,0.02,0.0,0.0,0.17,ilya mark safro,
-CPSC,3520,1,Programming Systems,0.3,0.48,0.08,0.0,0.03,0.0,0.0,0.1,robert schalkoff,
-CPSC,3600,1,Network Programming,0.28,0.42,0.22,0.02,0.03,0.0,0.0,0.03,feng luo,
-CPSC,3600,2,Network Programming,0.2,0.28,0.35,0.08,0.02,0.0,0.0,0.07,james martin,
-CPSC,3720,1,Software Engineering,0.31,0.36,0.23,0.07,0.0,0.0,0.0,0.03,murali sitaraman,
-CPSC,3720,2,Software Engineering,0.24,0.36,0.4,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,
-CPSC,4050,1,Computer Graphics,0.4,0.28,0.16,0.0,0.08,0.0,0.0,0.08,victor zordan,
-CPSC,4110,1,Virtual Reality Systems,0.38,0.25,0.2,0.08,0.1,0.0,0.0,0.0,sabarish venka babu,
-CPSC,4120,1,Eye Tracking Methodology,0.3,0.49,0.11,0.03,0.03,0.0,0.0,0.05,andrew duchowski,
-CPSC,4160,1,2-D Game Engine Construction,0.64,0.11,0.13,0.0,0.09,0.0,0.0,0.02,brian malloy,
-CPSC,4180,1,Usable Privacy and Security,0.64,0.31,0.03,0.0,0.0,0.0,0.0,0.03,kelly caine,
-CPSC,4200,1,Computer Security Principles,0.68,0.21,0.09,0.0,0.03,0.0,0.0,0.0,hongxin hu,
-CPSC,4300,1,Applied Data Science,0.51,0.28,0.18,0.0,0.03,0.0,0.0,0.0,alexander ch herzog,
-CPSC,4620,1,Database Management Systems,0.06,0.28,0.28,0.0,0.13,0.0,0.0,0.25,pradip srimani,
-CPSC,4770,1,Distributed/Cluster Computing,0.21,0.26,0.16,0.0,0.16,0.0,0.0,0.21,linh bao ngo,
-CPSC,4820,1,Spec Top: Embed Prototyp,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jacob sorber,
-CPSC,4820,2,Spec Topics: Cloud Comp Archit,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,amy apon,
-CPSC,4820,3,Spec Topic: Web Programming,0.51,0.27,0.07,0.02,0.07,0.0,0.0,0.05,craig baker,
-CPSC,4910,1,Professional Issues II,0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
-CPSC,6040,1,Cptr Graphics Image,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,
-CPSC,6040,2,Cptr Graphics Image,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,ioannis karamouzas,
-CPSC,6050,1,Computer Graphics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,victor zordan,
-CPSC,6110,1,Virtual Reality Systems,0.0,0.57,0.29,0.0,0.0,0.0,0.0,0.14,sabarish venka babu,
-CPSC,6120,1,Eye Tracking Methodology,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,andrew duchowski,
-CPSC,6160,3,2-D Game Engine Construction,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,brian malloy,
-CPSC,6300,1,Applied Data Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
-CPSC,6770,1,Distributed/Cluster Computing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,linh bao ngo,
-CPSC,6820,2,Spec Topics: Cloud Comp Archit,0.44,0.38,0.06,0.0,0.0,0.0,0.0,0.13,amy apon,
-CPSC,8170,1,Physically Based Animation,0.64,0.18,0.09,0.0,0.0,0.0,0.0,0.09,jerry tessendorf,
-CPSC,8200,1,Parallel Architechture,0.36,0.36,0.07,0.0,0.07,0.0,0.0,0.14,pradip srimani,
-CPSC,8270,1,Translation of Progr Languages,0.56,0.28,0.13,0.0,0.03,0.0,0.0,0.0,brian malloy,
-CPSC,8480,1,Network Science,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ilya mark safro,
-CPSC,8730,1,"Software Verif, Valid & Measur",0.41,0.54,0.0,0.0,0.0,0.0,0.0,0.05,john mcgregor,
-CPSC,8810,1,Selected Topics: Data Analytic,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CPSC,8810,2,Sel Top: VH/Embod Conver Agent,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,andrew robb,
-CRP,8010,1,Planning Process & Legal Found,0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,caitlin dyckman,
-CRP,8020,1,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
-CRP,8030,2,Quan Analysis for Planners,0.63,0.19,0.06,0.0,0.0,0.0,0.0,0.13,eric morris,
-CRP,8040,1,Intro to GIS for Plan & Policy,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,timothy green,
-CRP,8080,1,Land Use and Compreh Planning,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,clifford dona ellis,
-CRP,8450,1,Water Policy & Law,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,
-CSM,1000,1,Intro to Construct,0.44,0.33,0.11,0.04,0.04,0.0,0.0,0.04,jason lucas,
-CSM,1000,2,Intro to Construct,0.5,0.38,0.04,0.04,0.04,0.0,0.0,0.0,jason lucas,
-CSM,2010,1,Structures I,0.18,0.25,0.32,0.14,0.07,0.0,0.0,0.04,shima clarke,
-CSM,2010,2,Structures I,0.36,0.25,0.21,0.07,0.11,0.0,0.0,0.0,shima clarke,
-CSM,2030,1,Mats & Meth of Const,0.27,0.53,0.13,0.03,0.03,0.0,0.0,0.0,robert seel,
-CSM,2030,2,Mats & Meth of Const,0.23,0.5,0.13,0.0,0.07,0.0,0.0,0.07,robert seel,
-CSM,3040,1,Envir Systems I,0.27,0.43,0.3,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3040,2,Envir Systems I,0.25,0.46,0.13,0.13,0.04,0.0,0.0,0.0,joseph mich burgett,
-CSM,3060,1,Emerging Tech in Construction,0.43,0.43,0.11,0.0,0.0,0.0,0.0,0.04,jason lucas,
-CSM,3060,2,Emerging Tech in Construction,0.52,0.36,0.08,0.0,0.0,0.0,0.0,0.04,jason lucas,
-CSM,3510,1,Const Estimating,0.23,0.35,0.23,0.08,0.12,0.0,0.0,0.0,seyed mousavi rizi,
-CSM,3510,2,Const Estimating,0.36,0.32,0.29,0.0,0.04,0.0,0.0,0.0,seyed mousavi rizi,
-CSM,4110,1,Safety in Bldg Const,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,nicholas corley,
-CSM,4110,2,Safety in Bldg Const,0.61,0.35,0.03,0.0,0.0,0.0,0.0,0.0,nicholas corley,
-CSM,4500,1,Construction Intern,0.84,0.02,0.14,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
-CSM,4530,1,Const Proj Mgmt,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4530,2,Const Proj Mgmt,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4610,1,Const Econ Seminar,0.23,0.47,0.3,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,4610,2,Const Econ Seminar,0.07,0.53,0.33,0.07,0.0,0.0,0.0,0.0,christine piper,
-CSM,8610,1,Construction Control Systems,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8610,400,Construction Control Systems,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8620,1,Personnel Mgt & Neg,0.13,0.5,0.25,0.0,0.13,0.0,0.0,0.0,roger william liska,
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,susan whorton,
-CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,
-CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
-CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
-CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.05,0.01,susan whorton,
-CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,susan whorton,
-CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.79,0.2,0.01,susan whorton,
-CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.17,0.01,susan whorton,
-CU,1000,11,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.78,0.21,0.01,susan whorton,
-CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.24,0.01,susan whorton,
-CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.7,0.29,0.01,susan whorton,
-CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.79,0.21,0.0,susan whorton,
-CU,1000,20,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,
-CU,1000,21,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,susan whorton,
-CU,1010,1,Univ Success Skills,0.46,0.23,0.15,0.0,0.08,0.0,0.0,0.08,bryn zimmerman babb,
-CU,1010,3,Univ Success Skills,0.29,0.24,0.24,0.0,0.12,0.0,0.0,0.12,kirsten noelle dean,
-CU,1010,6,Univ Success Skills,0.43,0.07,0.14,0.07,0.21,0.0,0.0,0.07,cari allyn brooks,
-CU,1010,613,Univ Success Skills,0.5,0.37,0.05,0.03,0.05,0.0,0.0,0.0,elizabeth stephan,
-CU,1010,614,Univ Success Skills,0.34,0.24,0.15,0.12,0.12,0.0,0.0,0.02,mariah magagnotti,
-CU,1010,616,Univ Success Skills,0.58,0.32,0.03,0.0,0.03,0.0,0.0,0.03,matthew kent miller,
-CVT,2260,1,Intro Cardiovas Sono,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,eric walker,
-DANC,1300,1,Tap Dance I,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,cheryl hosler,
-DPA,3070,1,Method 3d Production,0.59,0.17,0.1,0.0,0.03,0.0,0.0,0.1,sarah lydia martin,
-DPA,3070,2,Method 3d Production,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,summer 'nea benton,
-DPA,4000,1,Tech Foundations I,0.09,0.18,0.09,0.0,0.0,0.0,0.0,0.64,andrew duchowski,
-DPA,4020,1,Vis Foundations I,0.69,0.19,0.06,0.0,0.06,0.0,0.0,0.0,erik reed,
-DPA,6830,3,Spec Stud To in DPA: Z-Brush,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,insun kwon,
-DPA,8070,1,3D Modeling and Animation,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-DPA,8150,1,Special Effects Compositing,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,
-ECE,2010,1,Logic and Computing Devices,0.2,0.27,0.26,0.1,0.12,0.0,0.0,0.05,william reid,
-ECE,2010,2,Logic & Comp Device (HON),0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,william reid,True
-ECE,2020,1,Electric Circuits I,0.2,0.37,0.19,0.07,0.06,0.0,0.0,0.1,william harrell,
-ECE,2070,1,Basic Electrical Engineering,0.48,0.3,0.16,0.03,0.01,0.0,0.0,0.02,timothy anglea,
-ECE,2070,2,Basic Electrical Engineering,0.4,0.21,0.23,0.05,0.07,0.0,0.0,0.05,daniel bla cutshall,
-ECE,2070,3,Basic Electrical Engineering,0.47,0.33,0.07,0.04,0.03,0.0,0.0,0.06,william th kolodzey,
-ECE,2080,1,Basic Electrical Engr Lab,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,2,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,3,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,7,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,8,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,9,Basic Electrical Engr Lab,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,10,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,12,Basic Electrical Engr Lab,0.75,0.15,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,14,Basic Electrical Engr Lab,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,
-ECE,2080,15,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,6,Logic Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,apoorva dee kapadia,
-ECE,2090,8,Logic Lab,0.73,0.0,0.09,0.0,0.0,0.0,0.0,0.18,apoorva dee kapadia,
-ECE,2090,12,Logic Lab,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2090,13,Logic Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2110,1,Elec Engr Lab I,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
-ECE,2110,2,Elec Engr Lab I,0.75,0.1,0.0,0.0,0.0,0.0,0.0,0.15,apoorva dee kapadia,
-ECE,2110,3,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2110,4,Elec Engr Lab I,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,apoorva dee kapadia,
-ECE,2110,5,Elec Engr Lab I,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
-ECE,2110,6,Elec Engr Lab I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2110,7,Elec Engr Lab I,0.75,0.0,0.1,0.0,0.1,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2110,8,Elec Engr Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,apoorva dee kapadia,
-ECE,2110,9,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
-ECE,2110,10,Elec Engr Lab I,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2220,1,Syst Prog Concept,0.25,0.25,0.23,0.08,0.0,0.0,0.0,0.19,harlan russell,
-ECE,2230,1,Comp Sys Eng,0.33,0.45,0.08,0.1,0.0,0.0,0.0,0.04,walter ligon,
-ECE,2620,1,Electric Circuits II,0.25,0.27,0.19,0.17,0.04,0.0,0.0,0.08,liang dong,
-ECE,2720,1,Comp Organization,0.18,0.43,0.28,0.08,0.05,0.0,0.0,0.0,william reid,
-ECE,2730,3,Computer Org Lab,0.45,0.18,0.27,0.09,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,1,Electrical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,2,Electrical Engineering Lab III,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,3,Electrical Engineering Lab III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,4,Electrical Engineering Lab III,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,apoorva dee kapadia,
-ECE,3110,7,Electrical Engineering Lab III,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,8,Electrical Engineering Lab III,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,apoorva dee kapadia,
-ECE,3110,9,Electrical Engineering Lab III,0.38,0.5,0.0,0.06,0.06,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3120,2,Electrical Engineering Lab IV,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3170,1,Rand Signal Analysis,0.33,0.43,0.2,0.02,0.0,0.0,0.0,0.03,stephen hubbard,
-ECE,3200,1,Electronics I,0.21,0.23,0.28,0.2,0.08,0.0,0.0,0.01,stephen hubbard,
-ECE,3210,1,Electronics II,0.28,0.55,0.08,0.08,0.03,0.0,0.0,0.0,stephen hubbard,
-ECE,3220,1,Intro Operating Sys,0.13,0.55,0.32,0.0,0.0,0.0,0.0,0.0,mark smotherman,
-ECE,3270,1,Dig Comp Design,0.13,0.35,0.13,0.23,0.03,0.0,0.0,0.13,melissa crawl smith,
-ECE,3300,1,Signals & Systems,0.08,0.3,0.19,0.22,0.09,0.0,0.0,0.12,carl baum,
-ECE,3300,2,Signals & Systems (HON),0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
-ECE,3520,1,Programming Systems,0.65,0.27,0.04,0.0,0.0,0.0,0.0,0.04,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.33,0.36,0.2,0.06,0.05,0.0,0.0,0.0,edward collins,
-ECE,3710,1,Microcontr Interface,0.4,0.3,0.21,0.06,0.02,0.0,0.0,0.01,william reid,
-ECE,3720,1,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,3,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,4,Micro Int Lab,0.58,0.33,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,6,Micro Int Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,7,Micro Int Lab,0.25,0.58,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,9,Micro Int Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3800,1,Electromagnetics,0.23,0.22,0.31,0.05,0.09,0.0,0.0,0.11,jeffrey osterberg,
-ECE,3810,1,Field Waves & Ckts,0.13,0.43,0.26,0.0,0.09,0.0,0.0,0.09,anthony martin,
-ECE,4090,1,Intr to Linear Control Systems,0.56,0.34,0.08,0.0,0.02,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4180,1,Power Syst Analysis,0.23,0.33,0.17,0.03,0.1,0.0,0.0,0.13,ramtin hadidi,
-ECE,4270,1,Communications Sys,0.35,0.44,0.15,0.01,0.03,0.0,0.0,0.01,madhabi manandhar,
-ECE,4420,1,Knowledge Engr,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,robert schalkoff,
-ECE,4490,1,Comp Ntwrk Security,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,richard brooks,
-ECE,4610,1,Fundamentals of Solar Energy,0.45,0.35,0.18,0.0,0.0,0.0,0.0,0.03,rajendra singh,
-ECE,4670,1,Intro to Dig Sig Pro,0.36,0.14,0.36,0.07,0.0,0.0,0.0,0.07,john gowdy,
-ECE,4730,1,Intro Parallel Sys,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,walter ligon,
-ECE,4950,1,Int Sys Design I,0.7,0.29,0.01,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4960,1,Int Sys Design II,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,richard groff,
-ECE,6040,1,Semiconductor Devices,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson doug ryckman,
-ECE,6180,400,Power Syst Analysis,0.4,0.0,0.4,0.0,0.0,0.0,0.0,0.2,ramtin hadidi,
-ECE,6310,1,Intro to Computer Vision,0.48,0.38,0.1,0.0,0.0,0.0,0.0,0.05,adam hoover,
-ECE,6420,1,Knowledge Engr,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert schalkoff,
-ECE,6420,400,Knowledge Engr,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,robert schalkoff,
-ECE,6490,1,Comp Ntwrk Security,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,
-ECE,6490,400,Comp Ntwrk Security,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,richard brooks,
-ECE,6590,1,Int Circ Design,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,
-ECE,6610,1,Fundamentals of Solar Energy,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,rajendra singh,
-ECE,6670,1,Intro to Dig Sig Pro,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john gowdy,
-ECE,6730,1,Intro Parallel Sys,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,walter ligon,
-ECE,8010,1,Analysis of Lin Sys,0.48,0.41,0.04,0.0,0.0,0.0,0.0,0.07,richard groff,
-ECE,8540,1,Analysis of Tracking Systems,0.86,0.1,0.0,0.0,0.03,0.0,0.0,0.0,adam hoover,
-ECON,2000,2,Economic Concepts,0.5,0.33,0.08,0.05,0.05,0.0,0.0,0.0,jonathan orr ernest,
-ECON,2000,4,Economic Concepts,0.46,0.44,0.05,0.03,0.03,0.0,0.0,0.0,miren ivankovic,
-ECON,2000,5,Economic Concepts,0.31,0.23,0.31,0.05,0.08,0.0,0.0,0.03,jonathan orr ernest,
-ECON,2110,1,Principles of Microeconomics,0.21,0.42,0.11,0.16,0.0,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,2,Principles of Microeconomics,0.21,0.26,0.32,0.11,0.05,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,3,Principles of Microeconomics,0.16,0.16,0.47,0.05,0.05,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,4,Principles of Microeconomics,0.0,0.37,0.53,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,5,Principles of Microeconomics,0.11,0.47,0.32,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,6,Principles of Microeconomics,0.11,0.37,0.42,0.05,0.0,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,7,Principles of Microeconomics,0.11,0.26,0.32,0.11,0.16,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,8,Principles of Microeconomics,0.11,0.28,0.44,0.06,0.06,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,9,Principles of Microeconomics,0.16,0.26,0.37,0.05,0.05,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,10,Principles of Microeconomics,0.11,0.28,0.28,0.06,0.11,0.0,0.0,0.17,frederick hanssen,
-ECON,2110,11,Principles of Microeconomics,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,12,Principles of Microeconomics,0.11,0.42,0.26,0.21,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,13,Principles of Microeconomics,0.21,0.32,0.37,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,14,Principles of Microeconomics,0.21,0.21,0.42,0.05,0.0,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,15,Principles of Microeconomics,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,16,Principles of Microeconomics,0.16,0.11,0.47,0.11,0.11,0.0,0.0,0.05,frederick hanssen,
-ECON,2110,17,Principles of Microeconomics,0.11,0.58,0.16,0.05,0.11,0.0,0.0,0.0,frederick hanssen,
-ECON,2110,18,Principles of Microeconomics,0.05,0.32,0.42,0.05,0.05,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,19,Principles of Microeconomics,0.11,0.53,0.11,0.11,0.05,0.0,0.0,0.11,frederick hanssen,
-ECON,2110,20,Principles of Microeconomics,0.16,0.36,0.35,0.13,0.0,0.0,0.0,0.0,benjamin posmanick,
-ECON,2110,21,Principles of Microeconomics,0.33,0.42,0.18,0.06,0.0,0.0,0.0,0.0,michael makowsky,
-ECON,2110,22,Principles of Microeconomics,0.24,0.33,0.26,0.1,0.02,0.0,0.0,0.05,roksan ghanbariamin,
-ECON,2110,23,Principles of Microeconomics,0.26,0.31,0.25,0.11,0.07,0.0,0.0,0.01,sarah louise wilson,
-ECON,2110,24,Principles of Microeconomics,0.2,0.38,0.24,0.12,0.05,0.0,0.0,0.02,kelsey vict roberts,
-ECON,2110,25,Principles of Microeconomics,0.21,0.67,0.1,0.0,0.0,0.0,0.0,0.03,chen wang,
-ECON,2110,26,Principles of Microeconomics,0.22,0.47,0.18,0.07,0.0,0.0,0.0,0.07,benjamin jo schwall,
-ECON,2110,31,Principles of Microeconomics,0.4,0.37,0.17,0.01,0.01,0.0,0.0,0.03,jacob walloga,
-ECON,2110,32,Principles of Microeconomics,0.13,0.44,0.33,0.02,0.02,0.0,0.0,0.06,frederick hanssen,
-ECON,2110,33,Principles of Microeconomics,0.15,0.44,0.22,0.07,0.05,0.0,0.0,0.07,charles thomas,
-ECON,2110,34,Principles of Microecon (HON),0.45,0.45,0.05,0.05,0.0,0.0,0.0,0.0,charles thomas,True
-ECON,2110,35,Principles of Microeconomics,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,chen wang,
-ECON,2110,36,Principles of Microeconomics,0.18,0.48,0.25,0.08,0.0,0.0,0.0,0.03,roksan ghanbariamin,
-ECON,2110,38,Principles of Microeconomics,0.33,0.24,0.26,0.07,0.05,0.0,0.0,0.05,liuna issagholian,
-ECON,2110,40,Principles of Microeconomics,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.03,zhiqi zhao,
-ECON,2110,41,Principles of Microeconomics,0.39,0.34,0.17,0.07,0.02,0.0,0.0,0.0,liuna issagholian,
-ECON,2120,1,Principles of Macroeconomics,0.08,0.14,0.08,0.17,0.11,0.0,0.0,0.42,ralph charles allen,
-ECON,2120,2,Principles of Macroeconomics,0.31,0.51,0.13,0.02,0.02,0.0,0.0,0.0,kyle lance rechard,
-ECON,2120,3,Principles of Macroeconomics,0.15,0.09,0.18,0.15,0.16,0.0,0.0,0.27,ralph charles allen,
-ECON,2120,4,Principles of Macroeconomics,0.26,0.4,0.19,0.05,0.03,0.0,0.0,0.06,elijah neilson,
-ECON,2120,5,Principles of Macroeconomics,0.24,0.41,0.2,0.1,0.0,0.0,0.0,0.05,benjamin ti harbolt,
-ECON,2120,6,Principles of Macroeconomics,0.15,0.35,0.43,0.03,0.05,0.0,0.0,0.0,benjamin ti harbolt,
-ECON,2120,7,Principles of Macroeconomics,0.23,0.43,0.3,0.0,0.0,0.0,0.0,0.05,kyle lance rechard,
-ECON,2120,8,Principles of Macroeconomics,0.87,0.1,0.0,0.02,0.0,0.0,0.0,0.02,jeremy choquette,
-ECON,2120,9,Principles of Macroeconomics,0.35,0.38,0.18,0.08,0.03,0.0,0.0,0.0,narendra regmi,
-ECON,2120,10,Principles of Macroeconomics,0.71,0.07,0.07,0.02,0.07,0.0,0.0,0.05,jeremy choquette,
-ECON,3020,1,Money and Banking,0.08,0.51,0.32,0.0,0.03,0.0,0.0,0.05,smriti bhargava,
-ECON,3060,1,Managerial Economics,0.23,0.28,0.3,0.13,0.05,0.0,0.0,0.03,steven johnson,
-ECON,3100,1,International Econ,0.29,0.29,0.16,0.1,0.09,0.0,0.0,0.09,samuel ar standaert,
-ECON,3140,1,Intermediate Micro,0.25,0.17,0.25,0.1,0.1,0.0,0.0,0.12,patrick warren,
-ECON,3140,2,Intermediate Micro,0.26,0.35,0.24,0.06,0.06,0.0,0.0,0.02,molly espey,
-ECON,3140,3,Intermediate Micro,0.24,0.35,0.22,0.06,0.04,0.0,0.0,0.1,robert kennet fleck,
-ECON,3150,1,Intermediate Macro,0.39,0.25,0.1,0.02,0.08,0.0,0.0,0.16,sergey vla mityakov,
-ECON,3150,2,Intermediate Macro,0.31,0.34,0.24,0.08,0.03,0.0,0.0,0.0,michal jerzmanowski,
-ECON,3190,1,Environmental Econ,0.36,0.33,0.23,0.03,0.03,0.0,0.0,0.03,molly espey,
-ECON,3600,1,Public Choice,0.41,0.24,0.21,0.12,0.03,0.0,0.0,0.0,michael makowsky,
-ECON,4010,1,Labor Mkt Analysis,0.37,0.37,0.22,0.0,0.04,0.0,0.0,0.0,chungsang lam,
-ECON,4020,1,Law and Economics,0.21,0.41,0.31,0.05,0.0,0.0,0.0,0.03,howard ne bodenhorn,
-ECON,4040,1,Comp Econ Systems,0.13,0.38,0.06,0.19,0.19,0.0,0.0,0.06,dar litsukova-bokar,
-ECON,4050,5,Intro to Econometric,0.19,0.23,0.32,0.12,0.11,0.0,0.0,0.04,scott barkowski,
-ECON,4100,1,Economic Development,0.59,0.33,0.0,0.0,0.04,0.0,0.0,0.04,robert tamura,
-ECON,4110,2,Econ of Education,0.3,0.43,0.23,0.0,0.0,0.0,0.0,0.03,peter quarter blair,
-ECON,4120,1,International Micro,0.36,0.39,0.14,0.07,0.04,0.0,0.0,0.0,richard alan sessa,
-ECON,4220,1,Monetary Economics,0.26,0.5,0.12,0.0,0.03,0.0,0.0,0.09,gerald dwyer,
-ECON,4230,1,Economics of Health,0.47,0.18,0.24,0.06,0.0,0.0,0.0,0.06,devon merritt gorry,
-ECON,4250,1,Antitrust Economics,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,raymond sauer,
-ECON,4260,1,Sem Sport Economics,0.47,0.47,0.0,0.05,0.0,0.0,0.0,0.0,raymond sauer,
-ECON,4280,1,Cost-Benefit Anlysis,0.46,0.29,0.11,0.06,0.03,0.0,0.0,0.06,robert kennet fleck,
-ECON,6050,5,Intro to Econometric,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,scott barkowski,
-ECON,6060,1,Advanced Econometric,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,
-ECON,8010,1,Microeconomic Theory,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,william dougan,
-ECON,8040,1,Applied Math Econ,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,curtis simon,
-ECON,8060,1,Econometrics I,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,paul wayne wilson,
-ECON,8080,1,Econometrics III,0.14,0.43,0.21,0.0,0.14,0.0,0.0,0.07,paul wayne wilson,
-ECON,8230,1,Microecon Pub Pol,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,scott templeton,
-ECON,8240,1,Org of Industry,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,8260,1,Econ Theory of Govt Regulation,0.17,0.5,0.0,0.0,0.0,0.0,0.0,0.33,thomas wins hazlett,
-ECON,8550,1,Financial Economics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sergey vla mityakov,
-ED,1050,1,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
-ED,1050,2,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
-ED,1050,5,Educ Orientation,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
-ED,1050,7,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
-ED,8700,300,STEAM Instructional Design,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,
-EDC,3900,1,Skills for Stu Leads,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,
-EDC,3900,2,Skills for Stu Leads,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,eric pernotto,
-EDC,3990,1,Creative Inq in Counselor Ed,0.82,0.06,0.0,0.0,0.0,0.0,0.0,0.12,ken stewart-tillman,
-EDEC,4400,1,Early Childhood Engl Lang Art,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEL,3210,1,Pe for the Elem Tchr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,3210,2,Pe for the Elem Tchr,0.72,0.14,0.14,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4510,1,Elem Methods in Science Tchg,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
-EDEL,4870,1,Ele Meth Soc Studies,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDEL,4870,2,Ele Meth Soc Studies,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDEL,4880,1,Elem Meth La Tchng,0.68,0.23,0.09,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
-EDEL,4880,2,Elem Meth La Tchng,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
-EDF,3010,2,Principles of American Educat,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
-EDF,3020,2,Educational Psychology,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,
-EDF,3080,3,Classroom Assessment,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,
-EDF,3350,1,Adolescent Growth & Develop,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
-EDF,3350,2,Adolescent Growth & Develop,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
-EDF,4800,1,Digital Media & Learning,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,2,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,301,Digital Media & Learning,0.39,0.39,0.06,0.11,0.0,0.0,0.0,0.06,aamena bilal saleh,
-EDF,4800,302,Digital Media & Learning,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,8080,302,Contempor Issues in Assessment,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,heather rog brooker,
-EDF,9270,1,Quant Rsrch & Stats for Ed,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,eliza dar gallagher,
-EDF,9270,400,Quant Rsrch & Stats for Ed,0.62,0.31,0.0,0.0,0.08,0.0,0.0,0.0,jennie lynn farmer,
-EDF,9710,501,Case Study & Ethnographic Mthd,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,daniella hall,
-EDHD,8310,500,Lit Outcomes for Child w disab,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,renee gatlin anders,
-EDL,7300,500,Techniq of Supervision-Pub Sch,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,
-EDL,7400,502,Curr Plan: Sch Adm,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,barbara nesbitt,
-EDL,7500,501,El Prin & Spv Ex I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,
-EDL,7550,500,Sec Prin & Spv Exp I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,
-EDL,8850,401,HRD Learning Leadership,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,angela danie carter,
-EDL,9050,400,Thry/Prac Ed Ldrshp,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,russell marion,
-EDL,9110,400,Systematic Inq Ed L,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,jane lindle,
-EDLT,4590,1,Teaching Reading Grades K-3,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,koti lee hubbard,
-EDLT,4600,1,Teaching Reading Grades 2-6,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4600,3,Teaching Reading Grades 2-6,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4600,6,Teaching Reading Grades 2-6,0.6,0.27,0.07,0.07,0.0,0.0,0.0,0.0,julia kate bentley,
-EDLT,4610,1,Content Area Rdg: Grades 2-6,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,4980,1,Secondary Content Area Reading,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,lorraine an jacques,
-EDLT,4980,3,Secondary Content Area Reading,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,rachelle savitz,
-EDLT,8170,300,Content Area Rdg/Wtg: ECE-ELEM,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,rachelle savitz,
-EDLT,8220,500,Strategies for Teaching ESOL,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDLT,8270,400,Content Area Rdg/Wtg-MS & HS,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,rebecca kaminski,
-EDLT,8400,500,Early Literacy Assessment I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,ellen adkin sanford,
-EDLT,8400,501,Early Literacy Assessment I,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jamie felder white,
-EDLT,8400,503,Early Literacy Assessment I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jaime adele dawson,
-EDLT,8400,504,Early Literacy Assessment I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,
-EDLT,8400,506,Early Literacy Assessment I,0.73,0.0,0.0,0.0,0.09,0.0,0.0,0.18,renee gatlin anders,
-EDLT,8400,507,Early Literacy Assessment I,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,michael moss,
-EDLT,8820,502,Read Recovery Practicum I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary ann fr mcbride,
-EDLT,9140,1,"Lang Dev, Diversity, Discourse",0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDSA,8100,1,Theories & Techn of Counseling,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,
-EDSC,2260,1,Pr Apprch to Sec Alg,0.38,0.38,0.15,0.0,0.0,0.0,0.0,0.08,stacy megan che,
-EDSC,3280,1,Practicum Sec Soc St,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,william da mccorkle,
-EDSC,4260,1,Tchng Sec Math,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,carlos gomez,
-EDSP,3720,1,Char & Instr Individ with LD,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,catherine griffith,
-EDSP,3740,1,Char & Strat Emot/Behav Disord,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,
-EDSP,4920,1,Math Inst Ind W/Dis,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,pamela stecker,
-EDSP,4930,1,Clsrm/Beh Mgmt Sp Ed,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,joseph benedic ryan,
-EDSP,4940,1,Tchg Rdg Mild Dis,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,abigail anne allen,
-EDSP,8220,400,Tchg Math Indv W/Dis,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,pamela stecker,
-EES,2010,1,Environ Engr Fundamentals I,0.28,0.38,0.18,0.08,0.08,0.0,0.0,0.03,david freedman,
-EES,3030,1,Water Treatment Systems,0.63,0.25,0.09,0.03,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3040,1,Wastewater Treatment Systems,0.34,0.41,0.16,0.06,0.03,0.0,0.0,0.0,sudeep popat,
-EES,3050,1,Water/Wastewater Treatment Lab,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3050,2,Water/Wastewater Treatment Lab,0.47,0.4,0.07,0.0,0.0,0.0,0.0,0.07,sudeep popat,
-EES,4010,1,Environmental Engr,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.26,0.52,0.17,0.0,0.04,0.0,0.0,0.0,mark schlautman,
-EES,4100,1,Environ Radiation Protection I,0.22,0.39,0.11,0.11,0.0,0.0,0.0,0.17,nicole eli martinez,
-EES,4300,1,Air Pollution Engineering,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,andrew rich metcalf,
-EES,4800,1,Environmental Risk Assessment,0.23,0.57,0.13,0.0,0.03,0.0,0.0,0.03,nicole eli martinez,
-EES,4840,1,Solid Waste Mgt,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,yi zheng,
-EES,4860,1,Environmental Sustainability,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
-EES,6100,1,Environ Radiation Protection I,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,nicole eli martinez,
-EES,8020,1,Environ Eng Prin,0.71,0.14,0.07,0.0,0.0,0.0,0.0,0.07,david allen ladner,
-EES,8060,1,Design Env Control,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
-EES,8080,1,Groundwater Modeling,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
-EES,8430,1,Environmental Chem,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,brian powell,
-EES,8510,1,Biol Prin Envir Engr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
-EES,8800,1,Env Risk Assessment,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,
-ELE,3010,1,Entrepreneurial Foundations,0.46,0.46,0.03,0.03,0.03,0.0,0.0,0.0,christina kyprianou,
-ELE,3010,2,Entrepreneurial Foundations,0.33,0.65,0.0,0.0,0.0,0.0,0.0,0.03,christina kyprianou,
-ELE,3010,3,Entrepreneurial Foundations,0.18,0.42,0.26,0.03,0.03,0.0,0.0,0.08,ashley will parnell,
-ELE,4010,1,Venture Testing,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,chad navis,
-ELE,4020,1,Venture Creation,0.33,0.58,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
-ELE,4030,1,Venture Growth,0.17,0.26,0.48,0.0,0.09,0.0,0.0,0.0,ashley will parnell,
-ENGL,1030,2,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,
-ENGL,1030,3,Composition and Rhetoric,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,krist aldebol-hazle,
-ENGL,1030,4,Composition and Rhetoric,0.56,0.33,0.0,0.0,0.06,0.0,0.0,0.06,jennie el wakefield,
-ENGL,1030,7,Composition and Rhetoric,0.58,0.16,0.16,0.0,0.0,0.0,0.0,0.11,stephen quigley,
-ENGL,1030,8,Composition and Rhetoric,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,1030,9,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jennie el wakefield,
-ENGL,1030,10,Composition and Rhetoric,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,austin gorman,
-ENGL,1030,11,Composition and Rhetoric,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,austin gorman,
-ENGL,1030,12,Composition and Rhetoric,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,carrie hill,
-ENGL,1030,14,Composition and Rhetoric,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,caroline eliz young,
-ENGL,1030,15,Composition and Rhetoric,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel qui atkinson,
-ENGL,1030,17,Composition and Rhetoric,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,18,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jennie el wakefield,
-ENGL,1030,19,Composition and Rhetoric,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,21,Composition and Rhetoric,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,jennie el wakefield,
-ENGL,1030,22,Composition and Rhetoric,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,abigail maxim,
-ENGL,1030,23,Composition and Rhetoric,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,stephen hundley,
-ENGL,1030,24,Composition and Rhetoric,0.71,0.12,0.18,0.0,0.0,0.0,0.0,0.0,sarah el richardson,
-ENGL,1030,25,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,martha sue karnes,
-ENGL,1030,26,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,
-ENGL,1030,27,Composition and Rhetoric,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,michael davi measel,
-ENGL,1030,29,Composition and Rhetoric,0.61,0.28,0.0,0.06,0.0,0.0,0.0,0.06,caroline eliz young,
-ENGL,1030,30,Composition and Rhetoric,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,remley melis makala,
-ENGL,1030,31,Composition and Rhetoric,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,martha sue karnes,
-ENGL,1030,32,Composition and Rhetoric,0.78,0.11,0.0,0.06,0.0,0.0,0.0,0.06,sarah el richardson,
-ENGL,1030,33,Composition and Rhetoric,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,
-ENGL,1030,34,Composition and Rhetoric,0.5,0.29,0.07,0.0,0.14,0.0,0.0,0.0,carley am robertson,
-ENGL,1030,35,Composition and Rhetoric,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,victoria houser,
-ENGL,1030,37,Composition and Rhetoric,0.67,0.17,0.06,0.06,0.0,0.0,0.0,0.06,michael davi measel,
-ENGL,1030,38,Composition and Rhetoric,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,sarah margar carter,
-ENGL,1030,39,Composition and Rhetoric,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,courtn huff-oelberg,
-ENGL,1030,40,Composition and Rhetoric,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,abigail maxim,
-ENGL,1030,41,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,
-ENGL,1030,42,Composition and Rhetoric,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,michelle lloyd,
-ENGL,1030,43,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gabrielle gr nugent,
-ENGL,1030,44,Composition and Rhetoric,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,gabrielle gr nugent,
-ENGL,1030,45,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,
-ENGL,1030,46,Composition and Rhetoric,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,christopher stuart,
-ENGL,1030,47,Composition and Rhetoric,0.71,0.24,0.0,0.06,0.0,0.0,0.0,0.0,brian lee gaines,
-ENGL,1030,48,Composition and Rhetoric,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,brian lee gaines,
-ENGL,1030,50,Composition and Rhetoric,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,charlotte est lucke,
-ENGL,1030,51,Composition and Rhetoric,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,christopher stuart,
-ENGL,1030,53,Composition and Rhetoric,0.32,0.53,0.0,0.05,0.0,0.0,0.0,0.11,jane elizab kuebler,
-ENGL,1030,55,Composition and Rhetoric,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,courtn huff-oelberg,
-ENGL,1030,57,Composition and Rhetoric,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,shauna chung,
-ENGL,1030,59,Composition and Rhetoric,0.31,0.31,0.23,0.0,0.0,0.0,0.0,0.15,sarah margar carter,
-ENGL,1030,61,Composition and Rhetoric,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,
-ENGL,1030,64,Composition and Rhetoric,0.47,0.24,0.24,0.06,0.0,0.0,0.0,0.0,jennifer forsberg,
-ENGL,1030,65,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,
-ENGL,1030,67,Composition and Rhetoric,0.41,0.41,0.06,0.0,0.12,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,1030,69,Composition and Rhetoric,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,1030,71,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,michael russo,
-ENGL,1030,72,Composition and Rhetoric,0.84,0.0,0.0,0.0,0.11,0.0,0.0,0.05,whitney jorda adams,
-ENGL,1030,73,Composition and Rhetoric,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,carley am robertson,
-ENGL,1030,74,Composition and Rhetoric,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,shauna chung,
-ENGL,1030,75,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen hundley,
-ENGL,1030,76,Composition and Rhetoric,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,carrie hill,
-ENGL,1030,80,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,
-ENGL,1030,81,Composition and Rhetoric,0.72,0.11,0.06,0.06,0.06,0.0,0.0,0.0,charlotte est lucke,
-ENGL,1030,82,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,
-ENGL,1030,83,Composition and Rhetoric,0.47,0.32,0.05,0.11,0.0,0.0,0.0,0.05,jane elizab kuebler,
-ENGL,1030,84,Composition and Rhetoric,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,allison nico harris,
-ENGL,1030,85,Composition and Rhetoric,0.74,0.16,0.0,0.0,0.11,0.0,0.0,0.0,allison nico harris,
-ENGL,1030,86,Composition and Rhetoric,0.67,0.07,0.13,0.0,0.07,0.0,0.0,0.07,stephen quigley,
-ENGL,1030,100,Accelerated Composition (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,michelle smith,True
-ENGL,1030,500,Composition and Rhetoric,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,john conway,
-ENGL,1030,501,Composition and Rhetoric,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,john conway,
-ENGL,2120,1,World Literature,0.16,0.47,0.21,0.11,0.05,0.0,0.0,0.0,lee morrissey,
-ENGL,2120,3,World Literature,0.18,0.43,0.14,0.04,0.0,0.0,0.0,0.21,karen kettnich,
-ENGL,2120,4,World Literature,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2120,5,World Literature,0.3,0.19,0.19,0.11,0.15,0.0,0.0,0.07,andrew mathas,
-ENGL,2120,6,World Literature,0.19,0.59,0.15,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,
-ENGL,2120,7,World Literature,0.59,0.3,0.07,0.0,0.0,0.0,0.0,0.04,allison nico harris,
-ENGL,2120,8,World Literature,0.38,0.35,0.0,0.15,0.08,0.0,0.0,0.04,joshua wood,
-ENGL,2120,9,World Literature,0.37,0.26,0.22,0.07,0.0,0.0,0.0,0.07,katalin beck,
-ENGL,2120,10,World Literature,0.54,0.32,0.07,0.0,0.04,0.0,0.0,0.04,lucian ghita,
-ENGL,2120,11,World Literature,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2120,12,World Literature,0.57,0.39,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
-ENGL,2120,13,World Literature,0.32,0.39,0.14,0.04,0.0,0.0,0.0,0.11,karen kettnich,
-ENGL,2120,14,World Literature,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
-ENGL,2120,15,World Literature,0.54,0.23,0.04,0.04,0.12,0.0,0.0,0.04,chloe mich whitaker,
-ENGL,2120,16,World Literature,0.32,0.43,0.11,0.11,0.0,0.0,0.0,0.04,sarah mae cooper,
-ENGL,2120,17,World Literature,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,allison nico harris,
-ENGL,2120,18,World Literature,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,andrew mathas,
-ENGL,2120,19,World Literature,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,2120,20,World Literature,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,joshua wood,
-ENGL,2130,1,British Literature,0.57,0.32,0.0,0.07,0.04,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,2130,3,British Literature,0.63,0.26,0.0,0.04,0.0,0.0,0.0,0.07,krist aldebol-hazle,
-ENGL,2130,4,British Literature,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,john morgenstern,
-ENGL,2130,5,British Literature,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,2130,7,British Literature,0.37,0.3,0.19,0.04,0.07,0.0,0.0,0.04,megan no macalystre,
-ENGL,2130,9,British Literature,0.3,0.37,0.19,0.04,0.07,0.0,0.0,0.04,megan no macalystre,
-ENGL,2130,10,British Literature,0.43,0.5,0.0,0.04,0.04,0.0,0.0,0.0,christopher benson,
-ENGL,2130,11,British Literature,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,12,British Literature,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,
-ENGL,2130,13,British Literature,0.57,0.18,0.18,0.04,0.0,0.0,0.0,0.04,megan no macalystre,
-ENGL,2140,1,American Literature,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,5,American Literature,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,6,American Literature,0.41,0.44,0.07,0.0,0.0,0.0,0.0,0.07,erin nicholson gale,
-ENGL,2140,7,American Literature,0.39,0.36,0.11,0.07,0.0,0.0,0.0,0.07,elizabeth stansell,
-ENGL,2140,8,American Literature,0.26,0.37,0.15,0.04,0.0,0.0,0.0,0.19,david charles foltz,
-ENGL,2140,9,American Literature,0.63,0.22,0.11,0.0,0.04,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,14,American Literature,0.24,0.48,0.24,0.0,0.0,0.0,0.0,0.04,david charles foltz,
-ENGL,2140,15,American Literature,0.54,0.36,0.07,0.04,0.0,0.0,0.0,0.0,jennifer forsberg,
-ENGL,2140,16,American Literature,0.29,0.54,0.11,0.04,0.04,0.0,0.0,0.0,jennifer forsberg,
-ENGL,2140,17,American Literature,0.36,0.43,0.04,0.04,0.0,0.0,0.0,0.14,david charles foltz,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.5,0.27,0.12,0.0,0.08,0.0,0.0,0.04,sarah mae cooper,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.28,0.44,0.24,0.0,0.04,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.21,0.46,0.29,0.0,0.0,0.0,0.0,0.04,lindsay kath turner,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.18,0.57,0.18,0.0,0.07,0.0,0.0,0.0,lindsay kath turner,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.93,0.0,0.0,0.0,0.07,0.0,0.0,0.0,stephanie stripling,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,daniel scott citro,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.81,0.08,0.0,0.0,0.0,0.0,0.0,0.12,daniel scott citro,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.41,0.33,0.07,0.04,0.15,0.0,0.0,0.0,andrew mathas,
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.33,0.22,0.17,0.06,0.11,0.0,0.0,0.11,chelsea mari clarey,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.46,0.21,0.18,0.11,0.0,0.0,0.0,0.04,andrew mathas,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.26,0.47,0.16,0.11,0.0,0.0,0.0,0.0,chelsea mari clarey,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.28,0.44,0.11,0.06,0.06,0.0,0.0,0.06,chelsea mari clarey,
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.37,0.26,0.16,0.0,0.11,0.0,0.0,0.11,chelsea mari clarey,
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.39,0.29,0.18,0.0,0.11,0.0,0.0,0.04,john logan pursley,
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.45,0.34,0.07,0.07,0.03,0.0,0.0,0.03,john logan pursley,
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.26,0.16,0.32,0.0,0.05,0.0,0.0,0.21,david charles foltz,
-ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.61,0.25,0.0,0.11,0.04,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.46,0.43,0.07,0.04,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,caroline eliz young,
-ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,david charles foltz,
-ENGL,2150,26,Lit in 20th-21st Cent Contexts,0.64,0.25,0.0,0.0,0.04,0.0,0.0,0.07,caroline eliz young,
-ENGL,2150,27,Lit in 20th-21st Cent Contexts,0.0,0.84,0.11,0.0,0.0,0.0,0.0,0.05,amy monaghan,
-ENGL,2150,100,20th - 21st Century Lit (HON),0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
-ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.57,0.07,0.04,0.14,0.0,0.0,0.0,0.18,candace wiley,
-ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.57,0.04,0.04,0.07,0.07,0.0,0.0,0.21,candace wiley,
-ENGL,3040,3,Business Writing,0.68,0.05,0.26,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
-ENGL,3040,4,Business Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3040,5,Business Writing,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,crystal pa stephens,
-ENGL,3040,13,Business Writing,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3040,15,Business Writing,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,philip randall,
-ENGL,3040,16,Business Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,
-ENGL,3040,19,Business Writing,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3040,20,Business Writing,0.58,0.11,0.05,0.0,0.16,0.0,0.0,0.11,geveryl le robinson,
-ENGL,3040,21,Business Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,sean williams,
-ENGL,3040,400,Business Writing,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,steph kartalopoulos,
-ENGL,3040,401,Business Writing,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,steph kartalopoulos,
-ENGL,3100,1,Crit Writ Lit,0.29,0.41,0.12,0.12,0.0,0.0,0.0,0.06,kimberly manganelli,
-ENGL,3100,2,Crit Writ Lit,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,william stockton,
-ENGL,3100,3,Crit Writ Lit,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,
-ENGL,3100,4,Crit Writ Lit,0.39,0.11,0.22,0.0,0.06,0.0,0.0,0.22,william stockton,
-ENGL,3120,1,Advanced Composition,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3120,2,Advanced Composition,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,1,Technical Writing,0.33,0.5,0.06,0.11,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,2,Technical Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,4,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
-ENGL,3140,5,Technical Writing,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,sharon kathl nalley,
-ENGL,3140,6,Technical Writing,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,melissa dugan,
-ENGL,3140,9,Technical Writing,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,10,Technical Writing,0.42,0.47,0.0,0.05,0.0,0.0,0.0,0.05,katalin beck,
-ENGL,3140,11,Technical Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
-ENGL,3140,12,Technical Writing,0.47,0.26,0.05,0.11,0.0,0.0,0.0,0.11,geveryl le robinson,
-ENGL,3140,13,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,3140,16,Technical Writing,0.79,0.0,0.05,0.11,0.0,0.0,0.0,0.05,stephanie stripling,
-ENGL,3140,17,Technical Writing,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,la'cresha ulo green,
-ENGL,3140,19,Technical Writing,0.74,0.05,0.11,0.05,0.05,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,20,Technical Writing,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,22,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,3140,400,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,
-ENGL,3150,1,Scientific Writing & Comm,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,3150,2,Scientific Writing & Comm,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,christopher benson,
-ENGL,3150,3,Scientific Writing & Comm,0.32,0.32,0.16,0.05,0.16,0.0,0.0,0.0,william pulley,
-ENGL,3150,4,Scientific Writing & Comm,0.63,0.21,0.11,0.05,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3150,400,Scientific Writing & Comm,0.65,0.25,0.0,0.0,0.05,0.0,0.0,0.05,philip randall,
-ENGL,3150,401,Sci Writing & Comm,0.56,0.22,0.11,0.0,0.06,0.0,0.0,0.06,philip randall,
-ENGL,3450,1,Structure of Fiction,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,3460,2,Structure of Poetry,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,3480,1,Structure Screenplay,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,nicholas chri brown,
-ENGL,3490,1,Tech/Pop Imagination,0.24,0.53,0.06,0.0,0.0,0.0,0.0,0.18,gabriel and hankins,
-ENGL,3540,1,Lit Middle East & North Africa,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,angela naimou,
-ENGL,3570,1,Film,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3570,2,Film,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3570,3,Film,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,john robert smith,
-ENGL,3850,1,Children's Lit,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,
-ENGL,3860,1,Adolescent Lit,0.32,0.58,0.0,0.05,0.0,0.0,0.0,0.05,sarah mae cooper,
-ENGL,3960,1,Brit Lit Survey I,0.39,0.22,0.17,0.17,0.06,0.0,0.0,0.0,erin marina goss,
-ENGL,3960,2,Brit Lit Survey I,0.26,0.42,0.11,0.16,0.05,0.0,0.0,0.0,erin marina goss,
-ENGL,3960,3,Brit Lit Survey I,0.22,0.33,0.06,0.11,0.11,0.0,0.0,0.17,erin marina goss,
-ENGL,3970,2,Brit Lit Survey II,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
-ENGL,3980,2,Amer Lit Survey I,0.32,0.32,0.21,0.0,0.05,0.0,0.0,0.11,kimberly manganelli,
-ENGL,3990,1,Amer Lit Survey II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,4030,1,The Classics in Translation,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,4110,1,Shakespeare,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,
-ENGL,4110,2,Shakespeare,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,elizabeth rivlin,
-ENGL,4110,3,Shakespeare,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,
-ENGL,4170,1,Victorian Period,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,david sweene coombs,
-ENGL,4190,1,Post Col & World Lit,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
-ENGL,4210,1,Amer Lit 1800-1899,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,dominic mastroianni,
-ENGL,4260,1,Southern Literature,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,michael lemahieu,
-ENGL,4310,1,Modern Poetry,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,steven katz,
-ENGL,4340,1,Environmental Lit,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,matthew hooley,
-ENGL,4350,1,Literary Criticism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,matthew hooley,
-ENGL,4400,1,Literary Theory,0.32,0.42,0.21,0.05,0.0,0.0,0.0,0.0,brian mcgrath,
-ENGL,4420,1,Cultural Studies,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
-ENGL,4450,1,Fiction Workshop,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
-ENGL,4500,1,Film Genres,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0, barton palmer,
-ENGL,4510,1,Film Theory and Criticism,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,john robert smith,
-ENGL,4750,1,Writing for Media,0.33,0.47,0.13,0.0,0.07,0.0,0.0,0.0,jonathan beec field,
-ENGL,4780,1,Digital Literacy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
-ENGL,4890,1,Topics Write & Publ,0.54,0.31,0.0,0.0,0.08,0.0,0.0,0.08,megan eatman,
-ENGL,4920,1,Modern Rhetoric,0.33,0.33,0.27,0.0,0.0,0.0,0.0,0.07,michelle smith,
-ENGL,4960,1,Senior Seminar,0.25,0.42,0.25,0.0,0.0,0.0,0.0,0.08,brian mcgrath,
-ENGL,4960,2,Senior Seminar,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,michelle renee ty,
-ENGL,4960,3,Senior Seminar,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,erin marina goss,
-ENGL,8570,1,Digital Rhetorics,0.78,0.0,0.0,0.0,0.11,0.0,0.0,0.11,tharon howard,
-ENGR,1000,101,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,steven brandon,
-ENGR,1000,102,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,steven brandon,
-ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,steven brandon,
-ENGR,1000,104,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,steven brandon,
-ENGR,1020,116,Engineering Discipl & Skills,0.51,0.39,0.07,0.0,0.0,0.0,0.0,0.02,sarah grigg,
-ENGR,1020,117,Engineering Discipl & Skills,0.46,0.32,0.1,0.02,0.0,0.0,0.0,0.1,sarah grigg,
-ENGR,1020,311,Engineering Discipl & Skills,0.45,0.31,0.14,0.04,0.02,0.0,0.0,0.04,richard watkins,
-ENGR,1020,313,Engineering Discipl & Skills,0.42,0.26,0.09,0.06,0.06,0.0,0.0,0.11,michael giebner,
-ENGR,1020,314,Engineering Discipl & Skills,0.54,0.19,0.12,0.02,0.06,0.0,0.0,0.08,michael giebner,
-ENGR,1020,317,Engineering Discipl & Skills,0.5,0.22,0.12,0.02,0.02,0.0,0.0,0.12,ashley childers,
-ENGR,1020,318,Engineering Discipl & Skills,0.33,0.4,0.17,0.04,0.02,0.0,0.0,0.04,ashley childers,
-ENGR,1020,500,Engineering Discipl & Skills,0.18,0.48,0.21,0.09,0.0,0.0,0.0,0.03,jonathan maier,
-ENGR,1020,611,Engineering Discipl & Skills,0.44,0.3,0.08,0.04,0.08,0.0,0.0,0.06,irene marie ferrara,
-ENGR,1020,612,Engineering Discipl & Skills,0.37,0.4,0.12,0.04,0.0,0.0,0.0,0.08,elizabeth stephan,
-ENGR,1020,613,Engineering Discipl & Skills,0.13,0.55,0.13,0.13,0.05,0.0,0.0,0.0,elizabeth stephan,
-ENGR,1020,614,Engineering Discipl & Skills,0.12,0.34,0.24,0.07,0.07,0.0,0.0,0.15,mariah magagnotti,
-ENGR,1020,615,Engineering Discipl & Skills,0.51,0.24,0.14,0.1,0.02,0.0,0.0,0.0,mariah magagnotti,
-ENGR,1020,616,Engineering Discipl & Skills,0.15,0.44,0.15,0.05,0.05,0.0,0.0,0.15,matthew kent miller,
-ENGR,1020,617,Engineering Discipl & Skills,0.5,0.34,0.12,0.0,0.02,0.0,0.0,0.02,andrew isaa neptune,
-ENGR,1020,618,Engineering Discipl & Skills,0.57,0.28,0.04,0.07,0.02,0.0,0.0,0.02,jonathan maier,
-ENGR,1020,811,Engineering Discipl & Skills,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,
-ENGR,1020,812,Engineering Discipl & Skills,0.4,0.45,0.1,0.0,0.02,0.0,0.0,0.02,mariah magagnotti,
-ENGR,1020,813,Engineering Discipl & Skills,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,andrew isaa neptune,
-ENGR,1020,814,Engineering Discipl & Skills,0.38,0.52,0.07,0.02,0.0,0.0,0.0,0.0,jonathan bro harcum,
-ENGR,1020,815,Engineering Discipl & Skills,0.41,0.37,0.2,0.0,0.02,0.0,0.0,0.0,jonathan bro harcum,
-ENGR,1020,816,Engineering Discipl & Skills,0.54,0.39,0.02,0.0,0.0,0.0,0.0,0.05,andrew isaa neptune,
-ENGR,1020,817,Engineering Discipl & Skills,0.43,0.43,0.1,0.02,0.0,0.0,0.0,0.02,matthew kent miller,
-ENGR,1020,818,Engineering Discipl & Skills,0.48,0.3,0.13,0.05,0.03,0.0,0.0,0.03,matthew kent miller,
-ENGR,1020,831,Engr Discipl & Skills (HON),0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,True
-ENGR,1020,832,Engr Discipl & Skills (HON),0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,True
-ENGR,1060,400,Engr Discipline & Skills II,0.05,0.43,0.24,0.1,0.14,0.0,0.0,0.05,andrew isaa neptune,
-ENGR,1080,400,Programming & Prob Solving II,0.0,0.4,0.5,0.0,0.0,0.0,0.0,0.1,william martin,
-ENGR,1150,500,Engineering Design & Modeling,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john minor,
-ENGR,1410,222,Programming & Problem Solving,0.2,0.27,0.29,0.09,0.02,0.0,0.0,0.13,william martin,
-ENGR,1410,223,Programming & Problem Solving,0.07,0.31,0.36,0.16,0.07,0.0,0.0,0.04,john minor,
-ENGR,1410,226,Programming & Problem Solving,0.13,0.38,0.29,0.07,0.02,0.0,0.0,0.11,steven brandon,
-ENGR,1410,227,Programming & Problem Solving,0.04,0.19,0.4,0.08,0.06,0.0,0.0,0.23,anthony pau garland,
-ENGR,1900,10,CI in Engr I Robotics,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael benj wooten,
-ENGR,1900,78,CI in ENGR Student Design,0.67,0.08,0.0,0.0,0.08,0.0,0.0,0.17,huijuan zhao,
-ENGR,2080,681,Engr Graphics & Machine Design,0.28,0.35,0.09,0.09,0.09,0.0,0.0,0.09,garrison llo broome,
-ENGR,2080,682,Engr Graphics & Machine Design,0.4,0.38,0.19,0.0,0.0,0.0,0.0,0.02,garrison llo broome,
-ENGR,2080,684,Engr Graphics & Machine Design,0.33,0.29,0.24,0.08,0.06,0.0,0.0,0.0,nighat yasmin,
-ENGR,2080,685,Engr Graphics & Machine Design,0.23,0.32,0.2,0.02,0.11,0.0,0.0,0.11,anthony pau garland,
-ENGR,2080,686,Engr Graphics & Machine Design,0.23,0.4,0.19,0.02,0.09,0.0,0.0,0.07,anthony pau garland,
-ENGR,2100,804,CAD & Engineering Applications,0.28,0.44,0.09,0.09,0.02,0.0,0.0,0.07, shams esfandabadi,
-ENGR,2100,805,CAD & Engineering Applications,0.34,0.34,0.11,0.07,0.02,0.0,0.0,0.11,nighat yasmin,
-ENGR,2100,806,CAD & Engineering Applications,0.15,0.4,0.15,0.08,0.1,0.0,0.0,0.13,trent hou dellinger,
-ENGR,2200,115,Evaluating Innovations,0.24,0.57,0.05,0.14,0.0,0.0,0.0,0.0,sarah grigg,
-ENR,1010,1,Intro to Envir & Natur Res I,0.45,0.26,0.15,0.04,0.09,0.0,0.0,0.0,abigail lawson,
-ENR,1010,2,Intro to Envir & Natur Res I,0.43,0.33,0.18,0.05,0.0,0.0,0.0,0.03,abigail lawson,
-ENR,4290,1,Environ Law & Policy,0.32,0.56,0.06,0.0,0.03,0.0,0.0,0.03,alan johnson,
-ENR,4290,2,Environ Law & Policy,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,alan johnson,
-ENSP,2000,1,Intro Environ Sci,0.35,0.35,0.2,0.02,0.04,0.0,0.0,0.04,scott brame,
-ENSP,2000,2,Intro Environ Sci,0.91,0.04,0.04,0.02,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2000,3,Intro Environ Sci,0.88,0.09,0.0,0.02,0.0,0.0,0.0,0.02,minory nammouz,
-ENSP,2000,4,Intro Environ Sci,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-ENSP,2000,5,Intro Environ Sci,0.2,0.48,0.2,0.09,0.02,0.0,0.0,0.02,tom owino,
-ENSP,4000,1,Studies in Environmental Sci,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,margaret thompson,
-ENT,2000,1,Six-Legged Science,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,suellen pometto,
-ENT,2010,1,Insects in Myth & Religion,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,joseph culin,
-ENT,3010,1,Insect Biology and Diversity,0.21,0.21,0.36,0.15,0.03,0.0,0.0,0.03,eric benson,
-ENTR,1010,1,Entrepreneurial Mindset,0.44,0.37,0.08,0.02,0.08,0.0,0.0,0.01,john michael hannon,
-ENTR,2010,2,Select Top in Entrepreneurship,0.64,0.18,0.09,0.0,0.0,0.0,0.0,0.09,john michael hannon,
-ESED,8610,1,Practicum in Engr & Sci Educ,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,karen ann high,
-ETOX,4300,1,Toxicology,0.3,0.1,0.5,0.1,0.0,0.0,0.0,0.0,lisa bain,
-FCS,8300,1,Community Dev: Princ & Pract,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,areli moore peralta,
-FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.72,0.2,0.03,0.03,0.03,0.0,0.0,0.0,aubrey dean coffee,
-FDSC,2160,1,Baking Science,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,
-FDSC,3010,1,Food Regulations,0.77,0.2,0.02,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
-FDSC,4010,1,Food Chemistry I,0.5,0.39,0.1,0.02,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4040,1,Food Prsv & Process,0.44,0.41,0.13,0.02,0.0,0.0,0.0,0.0,anthony lou pometto,
-FDSC,4070,1,Quantity Food Production,0.76,0.12,0.0,0.03,0.09,0.0,0.0,0.0,heather batt,
-FDSC,4170,1,Seminar,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,aubrey dean coffee,
-FDSC,4300,1,Dairy Process & Sant,0.22,0.33,0.39,0.0,0.0,0.0,0.0,0.06,john mcgregor,
-FDSC,4500,11,Creative Inquiry-Food Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,paul dawson,
-FIN,2010,401,Intro to Personal Finance,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,joshua harris,
-FIN,2010,402,Intro to Personal Finance,0.64,0.23,0.06,0.02,0.03,0.0,0.0,0.03,joshua harris,
-FIN,2010,403,Intro to Personal Finance,0.58,0.3,0.07,0.05,0.0,0.0,0.0,0.0,joshua harris,
-FIN,2010,405,Intro to Personal Finance,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,
-FIN,2010,406,Intro to Personal Finance,0.86,0.07,0.02,0.01,0.03,0.0,0.0,0.01,joshua harris,
-FIN,2010,407,Intro to Personal Finance,0.92,0.02,0.02,0.0,0.02,0.0,0.0,0.02,joshua harris,
-FIN,3040,2,Risk & Insurance,0.18,0.38,0.33,0.05,0.08,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.0,0.24,0.35,0.24,0.12,0.0,0.0,0.06,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.26,0.4,0.26,0.06,0.03,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.23,0.26,0.37,0.11,0.0,0.0,0.0,0.03,kerri mcmillan,
-FIN,3050,5,Investment Analysis,0.14,0.19,0.33,0.14,0.08,0.0,0.0,0.11,john alexander,
-FIN,3060,1,Corporation Finance,0.17,0.17,0.25,0.09,0.25,0.0,0.0,0.08,william hol johnson,
-FIN,3060,2,Corporation Finance,0.29,0.12,0.14,0.22,0.16,0.0,0.0,0.08,william hol johnson,
-FIN,3060,3,Corporation Finance,0.34,0.14,0.21,0.16,0.09,0.0,0.0,0.05,william hol johnson,
-FIN,3060,4,Corporation Finance,0.17,0.23,0.19,0.08,0.19,0.0,0.0,0.15,william hol johnson,
-FIN,3060,5,Corporation Finance,0.1,0.23,0.38,0.19,0.04,0.0,0.0,0.06,ramon tolb franklin,
-FIN,3060,6,Corporation Finance,0.12,0.14,0.39,0.18,0.04,0.0,0.0,0.12,ramon tolb franklin,
-FIN,3060,7,Corporation Finance,0.22,0.29,0.29,0.14,0.05,0.0,0.0,0.02,ramon tolb franklin,
-FIN,3060,8,Corporation Finance,0.12,0.16,0.24,0.29,0.08,0.0,0.0,0.1,ramon tolb franklin,
-FIN,3060,9,Corporation Finance,0.28,0.26,0.18,0.22,0.04,0.0,0.0,0.02,melvin stith,
-FIN,3060,10,Corporation Finance,0.22,0.11,0.29,0.31,0.04,0.0,0.0,0.02,melvin stith,
-FIN,3060,401,Corporation Finance,0.17,0.42,0.23,0.07,0.06,0.0,0.0,0.04,jonathan godbey,
-FIN,3070,1,Prin of Real Estate,0.17,0.24,0.37,0.17,0.02,0.0,0.0,0.02,thomas springer,
-FIN,3070,2,Prin of Real Estate,0.24,0.24,0.34,0.12,0.05,0.0,0.0,0.0,thomas springer,
-FIN,3070,3,Prin of Real Estate,0.28,0.42,0.28,0.0,0.03,0.0,0.0,0.0,yannan shen,
-FIN,3080,1,Fin Inst & Mkts,0.21,0.49,0.26,0.03,0.0,0.0,0.0,0.03,lyudmila chernykh,
-FIN,3080,2,Fin Inst & Mkts,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,3080,3,Fin Inst & Mkts,0.38,0.38,0.17,0.05,0.02,0.0,0.0,0.0,daniel thoma greene,
-FIN,3110,1,Financial Management I,0.05,0.18,0.33,0.05,0.18,0.0,0.0,0.21,jack wolf,
-FIN,3110,2,Financial Management I,0.05,0.26,0.35,0.05,0.09,0.0,0.0,0.21,jack wolf,
-FIN,3110,3,Financial Management I,0.26,0.28,0.16,0.07,0.07,0.0,0.0,0.16,george bra lockhart,
-FIN,3110,4,Financial Management I,0.14,0.29,0.36,0.15,0.05,0.0,0.0,0.02,weike xu,
-FIN,3120,1,Financial Management II,0.12,0.35,0.32,0.09,0.06,0.0,0.0,0.06,vincent intintoli,
-FIN,3120,2,Financial Management II,0.16,0.34,0.24,0.21,0.03,0.0,0.0,0.03,vincent intintoli,
-FIN,3120,3,Financial Management II,0.23,0.17,0.43,0.1,0.03,0.0,0.0,0.03,blerina zykaj,
-FIN,3120,4,Financial Management II,0.17,0.36,0.24,0.17,0.02,0.0,0.0,0.05,weike xu,
-FIN,4010,1,Corporate Financial Analysis,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,george bra lockhart,
-FIN,4020,1,Corporate Valuation,0.39,0.39,0.16,0.06,0.0,0.0,0.0,0.0,angela morgan,
-FIN,4020,2,Corporate Valuation,0.24,0.35,0.35,0.0,0.06,0.0,0.0,0.0,angela morgan,
-FIN,4050,1,Portfolio Management & Theory,0.03,0.23,0.43,0.13,0.03,0.0,0.0,0.13,john alexander,
-FIN,4060,1,Derivatives Analysis,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,blerina zykaj,
-FIN,4110,1,Int Fin Mgt,0.22,0.41,0.3,0.05,0.0,0.0,0.0,0.03,luke asher devault,
-FIN,4110,2,Int Fin Mgt,0.18,0.53,0.18,0.0,0.06,0.0,0.0,0.06,luke asher devault,
-FIN,4170,1,Real Estate Finance,0.27,0.47,0.2,0.0,0.07,0.0,0.0,0.0,yannan shen,
-FIN,4980,2,CI in Finance: CFA,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,jack wolf,
-FNR,2040,1,Soil Information Systems,0.71,0.18,0.0,0.11,0.0,0.0,0.0,0.0,elena mikhailova,
-FNR,4700,1,Kennedy Waterfowl CI,0.69,0.0,0.31,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
-FNR,4900,1,Field Training in Natural Res,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,patricia layton,
-FNR,4990,1,Natural Resources Seminar,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,susan talley guynn,
-FOR,2050,1,Dendrology,0.34,0.25,0.22,0.09,0.06,0.0,0.0,0.03,donald hagan,
-FOR,2050,2,Dendrology,0.1,0.39,0.22,0.05,0.1,0.0,0.0,0.15,donald hagan,
-FOR,2050,3,Dendrology,0.36,0.33,0.13,0.05,0.05,0.0,0.0,0.08,donald hagan,
-FOR,2210,1,Forest Biology,0.17,0.3,0.23,0.15,0.08,0.0,0.0,0.07,althea simone hagan,
-FOR,3020,1,Forest Biometrics,0.33,0.4,0.23,0.0,0.0,0.0,0.0,0.03,lawrence gering,
-FOR,3040,1,Forest Resource Economics,0.79,0.15,0.0,0.0,0.0,0.0,0.0,0.05,puskar khanal,
-FOR,4100,1,Harvesting Processes,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,patrick hiesl,
-FOR,4130,1,Integrated Forest Pest Mgt,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,stephen cole,
-FOR,4160,1,Forest Policy and Admin,0.31,0.42,0.21,0.02,0.01,0.0,0.0,0.02,thomas straka,
-FOR,4170,1,Forest Resource Mgt & Regulatn,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,
-FOR,4310,1,Recreation Res Plan in For Mgt,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
-FOR,4340,1,GIS for Natural Resources,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher post,
-FR,1010,1,Elementary French,0.18,0.53,0.06,0.12,0.0,0.0,0.0,0.12,anne salces  nedeo,
-FR,1010,2,Elementary French,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
-FR,1020,1,Elementary French,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,1020,2,Elementary French,0.81,0.0,0.13,0.06,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,1020,3,Elementary French,0.2,0.4,0.1,0.1,0.0,0.0,0.0,0.2,kenneth dav widgren,
-FR,2010,2,Intermediate French,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,kenneth dav widgren,
-FR,2010,3,Intermediate French,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,kenneth dav widgren,
-FR,2010,4,Intermediate French,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
-FR,2020,1,Intermediate French,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2020,2,Intermediate French,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,kelly digby peebles,
-FR,2020,3,Intermediate French,0.33,0.33,0.2,0.07,0.0,0.0,0.0,0.07,kenneth dav widgren,
-FR,2020,4,Intermediate French,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,3000,1,Survey of French Lit,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
-FR,3050,2,Int Fr Con & Comp I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph mai,
-FR,3070,1,French Civilization,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
-FR,4100,1,Francophone Lit,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,True
-GC,1010,1,Orientation to G C,0.68,0.14,0.04,0.02,0.06,0.0,0.0,0.06,john leininger,
-GC,1010,2,Orientation to G C,0.39,0.49,0.0,0.0,0.02,0.0,0.0,0.1,john leininger,
-GC,1020,1,Computer Art & CAD Foundations,0.6,0.29,0.04,0.0,0.02,0.0,0.0,0.04,carol jones,
-GC,1020,2,Computer Art & CAD Foundations,0.52,0.3,0.05,0.05,0.02,0.0,0.0,0.05,carol jones,
-GC,1030,1,G C I for Pkgsc,0.21,0.47,0.32,0.0,0.0,0.0,0.0,0.0,john jacobs,
-GC,1040,1,Graphic Communications I,0.49,0.27,0.14,0.0,0.07,0.0,0.0,0.03,rebecca suza edlein,
-GC,2070,1,Graphic Communications II,0.66,0.22,0.08,0.02,0.0,0.0,0.0,0.02,charles tabor weiss,
-GC,3400,1,Digital Imaging and eMedia,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0,erica black walker,
-GC,3460,1,Ink and Substrates,0.23,0.55,0.19,0.02,0.0,0.0,0.0,0.0,liam henry 'hara,
-GC,3500,1,G C Internship I,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,carol jones,
-GC,4060,1,Package and Specialty Printing,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,kern cox,
-GC,4400,1,Commercial Printing,0.24,0.63,0.05,0.0,0.05,0.0,0.0,0.02,eric weisenmiller,
-GC,4440,1,Current Dev/Trends in Gr Comm,0.67,0.25,0.06,0.0,0.0,0.0,0.0,0.03,samuel ingram,
-GC,4480,1,Plan & Cont Printing Functions,0.89,0.06,0.02,0.0,0.0,0.0,0.0,0.02,nona woolbright,
-GC,4500,1,GC Internship II,0.9,0.0,0.1,0.0,0.0,0.0,0.0,0.0,carol jones,
-GC,4800,1,Senior Seminar in GC,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,
-GC,6060,1,Pkg & Spec Prtg,0.5,0.33,0.0,0.0,0.17,0.0,0.0,0.0,kern cox,
-GEN,1030,1,Careers in Bioch/Gen,0.81,0.09,0.06,0.03,0.01,0.0,0.0,0.0,joseph paul thames,
-GEN,3000,1,Fundamental Genetics,0.31,0.41,0.17,0.06,0.01,0.0,0.0,0.05,kate leanne wi tsai,
-GEN,3000,2,Fundamental Genetics,0.28,0.4,0.19,0.07,0.03,0.0,0.0,0.04,kate leanne wi tsai,
-GEN,3020,1,Molecular & General Genetics,0.3,0.36,0.18,0.07,0.04,0.0,0.0,0.05,lukasz kozubowski,
-GEN,3020,2,Molec & General Genetics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True
-GEN,3020,4,Molecular & General Genetics,0.42,0.36,0.12,0.03,0.06,0.0,0.0,0.0,haiying liang,
-GEN,4200,1,Molecular Genetics & Gene Reg,0.25,0.43,0.23,0.07,0.0,0.0,0.0,0.02,julia frugoli,
-GEN,4200,2,Molecular Genetics & Gen (HON),0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True
-GEN,4210,3,Mol Gen Gene Reg Lab,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
-GEN,4400,1,Bioinformatics,0.62,0.24,0.07,0.05,0.0,0.0,0.0,0.02,frank alexan feltus,
-GEN,4500,1,Comparative Genetics,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,leigh anne clark,
-GEN,4900,1,Epigenetics,0.56,0.25,0.0,0.13,0.0,0.0,0.0,0.06,rajandeep si sekhon,
-GEOG,1010,2,Intro to Geography,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,david doran,
-GEOG,1030,1,World Regional Geography,0.81,0.15,0.02,0.01,0.0,0.0,0.0,0.01,david doran,
-GEOG,1030,2,World Regional Geography,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christa smith,
-GEOG,1030,3,World Regional Geography,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,david doran,
-GEOG,3030,1,Urban Geography,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,christa smith,
-GEOL,1010,1,Physical Geology,0.23,0.29,0.22,0.09,0.09,0.0,0.0,0.09,alan coulson,
-GEOL,1010,2,Physical Geology,0.18,0.32,0.21,0.12,0.07,0.0,0.0,0.1,alan coulson,
-GEOL,1010,3,Physical Geology,0.49,0.33,0.07,0.07,0.0,0.0,0.0,0.04,kelly best lazar,
-GEOL,1010,4,Physical Geology,0.03,0.29,0.26,0.23,0.17,0.0,0.0,0.03,melissa ranhofer,
-GEOL,1030,1,Physical Geol Lab,0.67,0.17,0.08,0.0,0.04,0.0,0.0,0.04,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.26,0.22,0.3,0.09,0.09,0.0,0.0,0.04,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.46,0.33,0.21,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.5,0.21,0.21,0.0,0.04,0.0,0.0,0.04,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.74,0.17,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.75,0.13,0.04,0.0,0.0,0.0,0.0,0.08,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.67,0.25,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,
-GEOL,1030,13,Physical Geol Lab,0.46,0.38,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,2050,1,Mineralogy & Intro Petrology,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,lin shuller-nickles,
-GEOL,2070,1,Min & Intro Pet Lab,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,2700,1,Sustainable Water,0.7,0.15,0.0,0.0,0.0,0.0,0.0,0.15,stephen mich moysey,
-GEOL,2750,1,Field Methods,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,3000,1,Environmental Geology,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,4150,1,Analysis Geological Processes,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
-GEOL,4820,1,Groundwater & Contam Transport,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
-GEOL,7900,500,Biogeography And Geology of SC,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,john robert wagner,
-GEOL,8080,1,Groundwater Modeling,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
-GER,1010,1,Elementary German,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,oswald harris king,
-GER,1010,2,Elementary German,0.24,0.41,0.06,0.12,0.06,0.0,0.0,0.12,oswald harris king,
-GER,1020,1,Elementary German,0.5,0.3,0.0,0.0,0.0,0.0,0.0,0.2,isabel meusen,
-GER,1020,2,Elementary German,0.25,0.42,0.17,0.0,0.08,0.0,0.0,0.08,isabel meusen,
-GER,2010,1,Intermediate German,0.32,0.32,0.26,0.0,0.0,0.0,0.0,0.11, lee ferrell,
-GER,2010,2,Intermediate German,0.33,0.13,0.33,0.07,0.07,0.0,0.0,0.07,gabriela stoicea,
-GER,2020,1,Intermediate German,0.05,0.26,0.37,0.21,0.05,0.0,0.0,0.05,johannes schmidt,
-GER,3400,1,German Culture,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,oswald harris king,
-HCC,8310,1,Fundamentals of Hcc,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,brygg anders ullmer,
-HCC,8330,1,HCC Research Methods,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
-HCC,8810,1,Selected Topic: Measu/Evalu II,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,bart knijnenburg,
-HCG,9040,400,Knowledge Development,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-HIST,1010,1,History of the United States,0.21,0.62,0.09,0.0,0.06,0.0,0.0,0.03,paul chris anderson,
-HIST,1020,1,Hist of the U S,0.35,0.47,0.12,0.06,0.0,0.0,0.0,0.0,john andrew,
-HIST,1020,2,Hist of the U S,0.35,0.57,0.08,0.0,0.0,0.0,0.0,0.0,william camp,
-HIST,1220,1,"Hist, Tech & Society",0.12,0.51,0.19,0.08,0.06,0.0,0.0,0.04,pamela mack,
-HIST,1240,1,Environmental History Survey,0.11,0.5,0.28,0.06,0.06,0.0,0.0,0.0,james brad jeffries,
-HIST,1240,2,Environmental History Survey,0.03,0.5,0.31,0.03,0.06,0.0,0.0,0.06,james brad jeffries,
-HIST,1720,1,The West and the World I,0.36,0.43,0.08,0.02,0.03,0.0,0.0,0.07,caroline dunn clark,
-HIST,1720,2,The West and the World I,0.21,0.47,0.22,0.04,0.04,0.0,0.0,0.02,steven marks,
-HIST,1730,1,The West and the World II,0.26,0.43,0.19,0.01,0.03,0.0,0.0,0.08, alan grubb,
-HIST,1730,2,The West and the World II,0.33,0.39,0.11,0.0,0.06,0.0,0.0,0.11,sandra nic mokalled,
-HIST,2990,2,Historian's Craft,0.75,0.15,0.0,0.05,0.0,0.0,0.0,0.05,rachel anne moore,
-HIST,2990,3,Historian's Craft,0.47,0.42,0.0,0.0,0.0,0.0,0.0,0.11,thomas kuehn,
-HIST,3040,1,Indus & Progr Era,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06, roger grant,
-HIST,3060,1,US: Postwar World 1945-1975,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,william camp,
-HIST,3100,1,History of Religion in the US,0.33,0.22,0.28,0.17,0.0,0.0,0.0,0.0,elizabeth jemison,
-HIST,3120,1,Afr Amer Hist 1877 to Present,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,
-HIST,3170,1,Hist of Nat. Am. Relig/Culture,0.29,0.29,0.07,0.0,0.14,0.0,0.0,0.21,james brad jeffries,
-HIST,3280,1,US Legal History to 1890,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,lee brady wilson,
-HIST,3300,1,Hist of Mod China,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,edwin moise,
-HIST,3390,1,Africa 1875-Present,0.53,0.24,0.12,0.12,0.0,0.0,0.0,0.0,james burns,
-HIST,3410,1,Modern Mexico,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
-HIST,3630,1,Britain Since 1688,0.55,0.38,0.07,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
-HIST,3670,1,Modern Ireland,0.52,0.37,0.04,0.0,0.04,0.0,0.0,0.04,michael silvestri,
-HIST,3730,1,Age of Protestant Reformation,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,thomas kuehn,
-HIST,3750,1,Revolutionary Europe,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0, alan grubb,
-HIST,3900,1,Modern Military History,0.18,0.41,0.29,0.06,0.0,0.0,0.0,0.06,edwin moise,
-HIST,4000,1,Local and Nearby History,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15, roger grant,
-HIST,4510,1,Alexander the Great,0.27,0.53,0.07,0.0,0.0,0.0,0.0,0.13,elizabeth carney,
-HIST,4720,1,Medieval Conquests & Crusades,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,caroline dunn clark,
-HIST,4870,1,World War II,0.03,0.87,0.1,0.0,0.0,0.0,0.0,0.0,john andrew,
-HIST,4900,1,Northern Ireland,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,michael silvestri,
-HIST,4900,3,Disney Parks,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
-HIST,4920,1,The US in the Atomic Age,0.29,0.53,0.0,0.12,0.0,0.0,0.0,0.06,william camp,
-HIST,8000,3,Film and History,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james burns,
-HLTH,2020,1,Introduction to Public Health,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,2,Introduction to Public Health,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,3,Introduction to Public Health,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,4,Introduction to Public Health,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,5,Introduction to Public Health,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,6,Introduction to Public Health,0.6,0.2,0.07,0.0,0.0,0.0,0.0,0.13,becky ann tugman,
-HLTH,2020,400,Introduction to Public Health,0.65,0.2,0.05,0.05,0.05,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2030,2,Health Care Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-HLTH,2400,1,Deter of Hlth Behav,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2400,2,Deter of Hlth Behav,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2600,2,Medical Terminology & Comm,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2980,1,Human Health and Disease,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,2980,2,Human Health and Disease,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,3400,1,Hlth Prom Prog Plan,0.44,0.44,0.12,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,3610,1,Int Health Care Econ,0.5,0.42,0.0,0.04,0.0,0.0,0.0,0.04,khoa dang truong,
-HLTH,3800,1,Epidemiology,0.42,0.32,0.16,0.05,0.0,0.0,0.0,0.05,hugh spitler,
-HLTH,3800,2,Epidemiology,0.74,0.19,0.03,0.0,0.03,0.0,0.0,0.0,hugh spitler,
-HLTH,3800,400,Epidemiology,0.44,0.22,0.22,0.06,0.06,0.0,0.0,0.0,deborah alma falta,
-HLTH,3980,1,Health Appraisal Skills,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,3980,2,Health Appraisal Skills,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4000,4,Public Hlth Social Marketing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,debra mitch charles,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.59,0.29,0.1,0.02,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4400,1,Manag Hlth Serv Org,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,george paul  newby,
-HLTH,4750,1,Hlthcr Oper Mgmt Res,0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,
-HLTH,4900,1,Res Eval St Pub Hlth,0.55,0.26,0.11,0.05,0.0,0.0,0.0,0.03,lingling zhang,
-HLTH,4900,2,Res Eval St Pub Hlth,0.63,0.25,0.06,0.06,0.0,0.0,0.0,0.0,lingling zhang,
-HLTH,8030,1,Theories and Determ of Health,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joel edwar williams,
-HLTH,8120,500,Clinical and Translational Sci,0.5,0.17,0.0,0.0,0.0,0.0,0.0,0.33,ronald gimbel,
-HLTH,8140,500,Health Sys Quality Improvement,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,windsor we sherrill,
-HLTH,8320,1,Quantitative Analy in Hlth II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
-HON,1900,1,Hell in Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True
-HON,1930,2,The Russian Revolution,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,True
-HON,1940,2,Scientific Skepticism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey appling,True
-HON,2020,3,Wisdom of the Moderns,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,colin pearce,True
-HON,2200,3,Europe in the Age of Dictators,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,True
-HON,2210,3,Southern Literature,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,michael lemahieu,True
-HON,2210,4,Imaginary Friends in Fiction,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True
-HON,2220,1,Lit & Science in Modernism,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,True
-HORT,1010,1,Horticulture,0.9,0.05,0.03,0.0,0.0,0.0,0.0,0.02,ellen anita vincent,
-HORT,2020,1,Adobe Digital Design,0.8,0.11,0.0,0.0,0.0,0.0,0.0,0.09,janice ann lay,
-HORT,2100,1,Growing Fall Plants,0.08,0.46,0.33,0.04,0.04,0.0,0.0,0.04,james emerson faust,
-HORT,2120,1,Turfgrass Culture,0.5,0.41,0.08,0.0,0.0,0.0,0.0,0.02,haibo liu,
-HORT,3030,1,Landscape Plants,0.18,0.26,0.24,0.15,0.1,0.0,0.0,0.08,robert polomski,
-HORT,3080,1,Sust Landsc Des Install Maint,0.93,0.02,0.05,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HORT,4120,1,Adv Turfgrass Mgt,0.45,0.27,0.0,0.0,0.09,0.0,0.0,0.18,lambert mccarty,
-HP,8010,1,Preservation Law and Econ,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,william jackso cook,
-HP,8030,1,Building Tech and Pathology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,amalia leifeste,
-HRD,8200,400,Human Perform Improv,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william havice,
-HRD,8200,401,Human Perform Improv,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william havice,
-HRD,8300,400,Concepts of H R D,0.91,0.03,0.06,0.0,0.0,0.0,0.0,0.0,angela danie carter,
-HRD,8600,400,Instruc Mat Devel,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,cynthia sims,
-IE,2100,1,Des Analysis Wrk Sys,0.09,0.47,0.35,0.09,0.01,0.0,0.0,0.0,david neyens,
-IE,2800,1,Deterministic Operations Rsrch,0.13,0.25,0.12,0.17,0.17,0.0,0.0,0.17,robert james riggs,
-IE,3010,1,Systems Design I,0.32,0.47,0.19,0.01,0.0,0.0,0.0,0.01,robert james riggs,
-IE,3600,1,Industrial Apps of Prob/Stat I,0.23,0.23,0.23,0.12,0.14,0.0,0.0,0.05,tugce isik,
-IE,3610,1,Industrial App of Prob/Stat II,0.4,0.25,0.1,0.1,0.05,0.0,0.0,0.1,brian melloy,
-IE,3810,1,Probabilistic Operations Rsrch,0.14,0.34,0.25,0.12,0.09,0.0,0.0,0.07,amin khademi,
-IE,3840,1,Engr Econ Analysis,0.29,0.16,0.2,0.1,0.13,0.0,0.0,0.13,brian melloy,
-IE,3860,1,Prod Plan & Cont,0.31,0.29,0.2,0.13,0.05,0.0,0.0,0.03,robert james riggs,
-IE,4400,1,Decision Support Sys,0.45,0.28,0.16,0.03,0.05,0.0,0.0,0.02,sandra dun eksioglu,
-IE,4400,2,Decision Support Sys,0.29,0.35,0.24,0.06,0.06,0.0,0.0,0.0,sandra dun eksioglu,
-IE,4610,1,Quality Engineering,0.27,0.34,0.2,0.16,0.01,0.0,0.0,0.02,byung rae cho,
-IE,4650,1,Facilities Planning & Design,0.14,0.55,0.27,0.04,0.01,0.0,0.0,0.0,william ferrell,
-IE,4820,1,Systems Modeling,0.44,0.37,0.19,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
-IE,4820,2,Systems Modeling,0.43,0.44,0.12,0.01,0.0,0.0,0.0,0.0,kevin taaffe,
-IE,4910,1,Network Flows for IE Apps,0.29,0.41,0.18,0.12,0.0,0.0,0.0,0.0,burak eksioglu,
-IE,4910,2,Service Engineering,0.21,0.52,0.24,0.03,0.0,0.0,0.0,0.0,tugce isik,
-IE,4910,3,Human Centered Design & Engr,0.31,0.59,0.07,0.0,0.0,0.0,0.0,0.03,laura miche stanley,
-IE,8000,1,Human Factors Eng,0.49,0.47,0.05,0.0,0.0,0.0,0.0,0.0,david neyens,
-IE,8030,1,Engr Optimization and Apps,0.48,0.45,0.05,0.0,0.0,0.0,0.0,0.03,jonathan cole smith,
-IE,8090,1,Model Sys Under Risk,0.43,0.35,0.18,0.0,0.0,0.0,0.0,0.05,burak eksioglu,
-IE,8510,1,Descriptive Analytics,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,mary elizabeth kurz,
-IE,8530,1,Foundations of Quality,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,byung rae cho,
-IE,8550,1,SC & Logistics Modeling II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.84,0.13,0.03,lisa marie robinson,
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,caren kelley-hall,
-IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.48,0.52,0.0,meredith fan wilson,
-ITAL,1010,1,Elementary Italian,0.67,0.2,0.07,0.0,0.07,0.0,0.0,0.0,julia schmidt,
-ITAL,1010,2,Elementary Italian,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,luca barattoni,
-ITAL,1010,3,Elementary Italian,0.38,0.25,0.19,0.0,0.13,0.0,0.0,0.06,julia schmidt,
-ITAL,1010,4,Elementary Italian,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-ITAL,1020,1,Elementary Italian,0.31,0.31,0.06,0.0,0.06,0.0,0.0,0.25,lyudmyla tsykalova,
-ITAL,2010,1,Intermediate Italian,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-JAPN,1010,1,Elementary Japanese,0.28,0.17,0.17,0.11,0.11,0.0,0.0,0.17,saori suto,
-JAPN,1010,2,Elementary Japanese,0.32,0.32,0.11,0.05,0.16,0.0,0.0,0.05,saori suto,
-JAPN,2010,1,Intermed Japanese,0.31,0.31,0.31,0.08,0.0,0.0,0.0,0.0,saori suto,
-JAPN,4010,1,Japanese Lit in Translation,0.47,0.35,0.06,0.12,0.0,0.0,0.0,0.0,kumiko saito,
-JAPN,4060,1,Intro to Japanese Literature,0.67,0.08,0.08,0.17,0.0,0.0,0.0,0.0,kumiko saito,
-JUST,2880,1,The Criminal Justice System,0.4,0.32,0.19,0.09,0.0,0.0,0.0,0.0,margaret tina britz,
-JUST,2890,1,Criminology,0.89,0.06,0.03,0.0,0.0,0.0,0.0,0.03,angelia turner,
-JUST,4680,1,Criminal Evidence,0.4,0.28,0.23,0.09,0.0,0.0,0.0,0.0,margaret tina britz,
-JUST,4910,1,Policing,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david williams,
-LANG,2540,1,Introduction to World Cinemas,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,joseph mai,
-LANG,3710,1,Language and Culture,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,yanhua zhang,
-LARC,1150,1,Intro Landscape Architecture,0.68,0.14,0.11,0.04,0.04,0.0,0.0,0.0,mary padua,
-LARC,1280,1,Technical Graphics,0.18,0.41,0.32,0.09,0.0,0.0,0.0,0.0,cecile martin,
-LARC,1510,1,Basic Design I,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,cecile martin,
-LARC,2510,1,Larch Design Fund,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jessica fernandez,
-LARC,2620,1,Design Impl I,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,pai liu,
-LARC,3510,1,Regional Design,0.41,0.35,0.12,0.0,0.06,0.0,0.0,0.06,matthew neal powers,
-LARC,4540,1,Urban Design Studio,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,paul russell,
-LARC,4620,1,Design Implementation III,0.56,0.25,0.06,0.06,0.0,0.0,0.0,0.06,jessica fernandez,
-LARC,8430,1,Interdisc Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,
-LAW,3220,1,Legal Env of Bus,0.27,0.45,0.29,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,2,Legal Env of Bus,0.33,0.43,0.18,0.02,0.04,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,3,Legal Env of Bus,0.29,0.31,0.33,0.0,0.06,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,4,Legal Env of Bus,0.1,0.44,0.38,0.02,0.06,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,5,Legal Env of Bus,0.05,0.38,0.38,0.1,0.05,0.0,0.0,0.05,kenneth toussaint,
-LAW,3220,6,Legal Env of Bus,0.22,0.39,0.29,0.08,0.0,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,7,Legal Env of Bus,0.31,0.42,0.23,0.02,0.02,0.0,0.0,0.0,kath kisska-schulze,
-LAW,3220,8,Legal Env of Bus,0.39,0.49,0.1,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,
-LAW,3220,9,Legal Env of Bus,0.3,0.4,0.25,0.03,0.0,0.0,0.0,0.03,john hine,
-LAW,3220,10,Legal Env of Bus,0.29,0.41,0.18,0.02,0.0,0.0,0.0,0.1,kath kisska-schulze,
-LAW,3220,400,Legal Env of Bus,0.32,0.47,0.12,0.03,0.03,0.0,0.0,0.03,virgini ward-vaughn,
-LAW,3220,401,Legal Env of Bus,0.33,0.37,0.18,0.02,0.03,0.0,0.0,0.07,virgini ward-vaughn,
-LAW,3220,402,Legal Env of Bus,0.4,0.37,0.12,0.0,0.04,0.0,0.0,0.07,virgini ward-vaughn,
-LAW,3220,403,Legal Env of Bus,0.33,0.43,0.14,0.03,0.03,0.0,0.0,0.03,virgini ward-vaughn,
-LAW,3330,1,Real Estate Law,0.0,0.47,0.33,0.07,0.1,0.0,0.0,0.03,judson jahn,
-LAW,3330,2,Real Estate Law,0.21,0.5,0.21,0.0,0.06,0.0,0.0,0.03,judson jahn,
-LAW,4050,1,Construction Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.9,0.03,0.06, lee ferrell,
-LS,1000,1,Therapeutic Yoga,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,1000,2,Therapeutic Yoga,0.67,0.19,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,
-LS,1000,3,Therapeutic Yoga,0.8,0.05,0.0,0.0,0.0,0.0,0.0,0.15,ranjanbala dil amin,
-LS,1000,4,Intro to Barre,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,lauren eliza george,
-LS,1000,5,Intro to Barre,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lauren eliza george,
-LS,1000,10,Clemson Life,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,kristin anne neff,
-LS,1000,14,Freshman Outdoor,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,emily grace turke,
-LS,1000,28,Stand up Pabbleboarding,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,william holland,
-LS,1410,1,Top Rope Climbing,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,michelle tuday,
-LS,1410,2,Top Rope Climbing,0.73,0.13,0.0,0.0,0.0,0.0,0.0,0.13,michelle tuday,
-LS,1410,4,Top Rope Climbing,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michelle tuday,
-LS,1410,5,Top Rope Climbing,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,michelle tuday,
-LS,1560,2,Riflery,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,hubert cox,
-LS,1560,7,Riflery,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,
-LS,1560,16,Riflery,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,
-LS,1570,1,Shotgun Sports,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,john jeffrey price,
-LS,1570,6,Shotgun Sports,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,william cro mahoney,
-LS,1750,1,Fly Fishing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james micha harvell,
-LS,1850,1,Bowling,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,megan elizabet cato,
-LS,1850,2,Bowling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,alexandra sandoval,
-LS,1850,10,Bowling,0.86,0.0,0.05,0.05,0.0,0.0,0.0,0.05,tyler bennett,
-LS,1940,1,Racquetball,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,
-LS,1960,1,Intro to Billiards,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,broadus fleming,
-LS,1980,4,Golf,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jason jordan,
-LS,1980,5,Golf,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jason jordan,
-LS,1980,9,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,wesley scott womble,
-LS,2200,7,Shag,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,broadus fleming,
-LS,2270,1,Intro to Swing Dance,0.92,0.03,0.0,0.0,0.03,0.0,0.0,0.03,paul hoke,
-LS,2270,2,Intro to Swing Dance,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,
-LS,2270,3,Intro to Swing Dance,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,paul hoke,
-LS,2320,2,Core Training,0.76,0.1,0.05,0.0,0.0,0.0,0.0,0.1,diane moreno,
-LS,2320,3,Core Training,0.78,0.06,0.11,0.0,0.06,0.0,0.0,0.0,diane moreno,
-LS,2320,5,Core Training,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,2350,1,Basic Yoga,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2350,2,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
-LS,2350,3,Basic Yoga,0.86,0.05,0.05,0.05,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2350,4,Basic Yoga,0.81,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
-LS,2350,5,Basic Yoga,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,2350,7,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2350,8,Basic Yoga,0.87,0.09,0.0,0.0,0.04,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2380,4,Vinyasa Flow Yoga,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2420,1,Meditation and Relax,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,2,Meditation and Relax,0.91,0.0,0.04,0.04,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2420,4,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
-LS,2420,5,Meditation and Relax,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2420,6,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,7,Meditation and Relax,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,
-LS,2420,8,Meditation and Relax,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
-LS,2450,1,Pilates,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,melanie ivey job,
-LS,2450,5,Pilates,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,2450,6,Pilates,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,diane moreno,
-LS,2750,8,First Aid/Cpr,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,christopher loomis,
-MATH,1010,1,Essen Math for Informed Soc,0.44,0.39,0.06,0.0,0.06,0.0,0.0,0.06,ebenezer eduafo,
-MATH,1010,2,Essen Math for Informed Soc,0.59,0.29,0.0,0.12,0.0,0.0,0.0,0.0,ebenezer eduafo,
-MATH,1010,3,Essen Math for Informed Soc,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,xiyan tan,
-MATH,1010,4,Essen Math for Informed Soc,0.65,0.12,0.12,0.06,0.0,0.0,0.0,0.06,xiyan tan,
-MATH,1010,5,Essen Math for Informed Soc,0.39,0.39,0.06,0.17,0.0,0.0,0.0,0.0,jun yuan,
-MATH,1010,6,Essen Math for Informed Soc,0.44,0.22,0.22,0.11,0.0,0.0,0.0,0.0,jun yuan,
-MATH,1010,7,Essen Math for Informed Soc,0.61,0.31,0.03,0.03,0.0,0.0,0.0,0.03,marilyn reba,
-MATH,1020,1,Business Calculus I,0.32,0.16,0.21,0.11,0.05,0.0,0.0,0.16,madeleine stville,
-MATH,1020,2,Business Calculus I,0.32,0.37,0.26,0.0,0.05,0.0,0.0,0.0,madeleine stville,
-MATH,1020,3,Business Calculus I,0.26,0.42,0.16,0.05,0.05,0.0,0.0,0.05,morgan elston,
-MATH,1020,4,Business Calculus I,0.16,0.32,0.05,0.21,0.21,0.0,0.0,0.05,morgan elston,
-MATH,1020,5,Business Calculus I,0.21,0.37,0.26,0.11,0.05,0.0,0.0,0.0,michael thoma cowen,
-MATH,1020,6,Business Calculus I,0.47,0.21,0.21,0.05,0.05,0.0,0.0,0.0,michael thoma cowen,
-MATH,1020,7,Business Calculus I,0.17,0.22,0.39,0.06,0.06,0.0,0.0,0.11,aaro ramirez flores,
-MATH,1020,8,Business Calculus I,0.26,0.32,0.26,0.11,0.0,0.0,0.0,0.05,aaro ramirez flores,
-MATH,1020,9,Business Calculus I,0.28,0.28,0.17,0.06,0.11,0.0,0.0,0.11, kamronnaher,
-MATH,1020,10,Business Calculus I,0.21,0.21,0.32,0.16,0.11,0.0,0.0,0.0, kamronnaher,
-MATH,1020,11,Business Calculus I,0.42,0.16,0.16,0.11,0.11,0.0,0.0,0.05,emma cinatl,
-MATH,1020,12,Business Calculus I,0.06,0.5,0.13,0.13,0.13,0.0,0.0,0.06,emma cinatl,
-MATH,1020,13,Business Calculus I,0.37,0.37,0.05,0.11,0.05,0.0,0.0,0.05,zachary david espe,
-MATH,1020,14,Business Calculus I,0.26,0.37,0.16,0.16,0.0,0.0,0.0,0.05,zachary david espe,
-MATH,1020,15,Business Calculus I,0.05,0.16,0.21,0.11,0.32,0.0,0.0,0.16,anna caro bachstein,
-MATH,1020,16,Business Calculus I,0.16,0.32,0.11,0.11,0.21,0.0,0.0,0.11,anna caro bachstein,
-MATH,1020,17,Business Calculus I,0.17,0.22,0.28,0.11,0.11,0.0,0.0,0.11,scott scruggs,
-MATH,1020,18,Business Calculus I,0.5,0.11,0.17,0.11,0.11,0.0,0.0,0.0,aaron moose,
-MATH,1020,19,Business Calculus I,0.16,0.37,0.26,0.0,0.16,0.0,0.0,0.05,rachel bass lanning,
-MATH,1020,20,Business Calculus I,0.26,0.16,0.42,0.11,0.05,0.0,0.0,0.0,john william grant,
-MATH,1020,21,Business Calculus I,0.21,0.42,0.26,0.0,0.11,0.0,0.0,0.0,rachel bass lanning,
-MATH,1020,22,Business Calculus I,0.26,0.26,0.16,0.11,0.05,0.0,0.0,0.16,molly adam honecker,
-MATH,1020,23,Business Calculus I,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,shanshan jia,
-MATH,1020,24,Business Calculus I,0.37,0.21,0.21,0.11,0.05,0.0,0.0,0.05,todd anthony morra,
-MATH,1020,25,Business Calculus I,0.33,0.22,0.28,0.06,0.11,0.0,0.0,0.0,yibo xu,
-MATH,1020,26,Business Calculus I,0.16,0.32,0.32,0.05,0.11,0.0,0.0,0.05,shanshan jia,
-MATH,1020,27,Business Calculus I,0.11,0.32,0.42,0.05,0.05,0.0,0.0,0.05,peter westerbaan,
-MATH,1020,28,Business Calculus I,0.44,0.22,0.28,0.0,0.06,0.0,0.0,0.0,todd anthony morra,
-MATH,1020,29,Business Calculus I,0.17,0.33,0.22,0.06,0.17,0.0,0.0,0.06,yibo xu,
-MATH,1020,30,Business Calculus I,0.42,0.26,0.16,0.05,0.05,0.0,0.0,0.05,kara ail stasikelis,
-MATH,1020,31,Business Calculus I,0.21,0.47,0.0,0.05,0.16,0.0,0.0,0.11,li he,
-MATH,1020,32,Business Calculus I,0.26,0.16,0.37,0.0,0.16,0.0,0.0,0.05,aaron moose,
-MATH,1020,33,Business Calculus I,0.21,0.11,0.42,0.05,0.11,0.0,0.0,0.11,li he,
-MATH,1020,34,Business Calculus I,0.26,0.11,0.21,0.16,0.26,0.0,0.0,0.0,scott scruggs,
-MATH,1020,35,Business Calculus I,0.42,0.22,0.24,0.02,0.04,0.0,0.0,0.04,jennifer ray newton,
-MATH,1020,36,Business Calculus I,0.33,0.27,0.16,0.04,0.09,0.0,0.0,0.11,jennifer ray newton,
-MATH,1020,37,Business Calculus I,0.26,0.26,0.32,0.0,0.16,0.0,0.0,0.0,peter westerbaan,
-MATH,1020,38,Business Calculus I,0.22,0.39,0.33,0.0,0.06,0.0,0.0,0.0,molly adam honecker,
-MATH,1020,39,Business Calculus I,0.45,0.2,0.2,0.07,0.05,0.0,0.0,0.02,jennifer van dyken,
-MATH,1020,40,Business Calculus I,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,randy davidson,
-MATH,1020,41,Business Calculus I,0.29,0.23,0.22,0.06,0.18,0.0,0.0,0.01,randy davidson,
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.57,0.41,0.02,donna simms,
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.62,0.04,stephen peele,
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.47,0.47,0.07,stephen peele,
-MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.5,0.39,0.11,andrew walton green,
-MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.52,0.1,sergey charnyi,
-MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.24,0.64,0.12,stephen garth,
-MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.64,0.33,0.02,stephen peele,
-MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.52,0.02,nicholas ahlstrom,
-MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.45,0.33,0.21,xiaoyuan liu,
-MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.5,0.14,xun dong,
-MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.39,0.52,0.09,stefan adam bock,
-MATH,1040,12,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.34,0.59,0.07,stefan adam bock,
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.44,0.54,0.02,tony thanh nguyen,
-MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.72,0.28,0.0,tony thanh nguyen,
-MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.36,0.05,tony thanh nguyen,
-MATH,1060,1,Calculus of One Variable I,0.17,0.29,0.32,0.07,0.07,0.0,0.0,0.07,thomas clevenger,
-MATH,1060,2,Calculus of One Variable I,0.25,0.23,0.2,0.04,0.17,0.0,0.0,0.11,calvin williams,
-MATH,1060,3,Calculus of One Variable I,0.25,0.32,0.09,0.05,0.14,0.0,0.0,0.16,paul james cubre,
-MATH,1060,4,Calculus of One Variable I,0.35,0.26,0.23,0.0,0.13,0.0,0.0,0.03,huixi li,
-MATH,1060,5,Calculus of One Variable I,0.2,0.27,0.18,0.09,0.04,0.0,0.0,0.22,pye phyo aung,
-MATH,1060,6,Calculus of One Variable I,0.18,0.23,0.3,0.11,0.14,0.0,0.0,0.05,rebecca ramos,
-MATH,1060,8,Calculus of One Variable I,0.25,0.28,0.21,0.05,0.14,0.0,0.0,0.06,judith cottingham,
-MATH,1060,10,Calculus of One Variable I,0.22,0.25,0.2,0.09,0.16,0.0,0.0,0.07,judith cottingham,
-MATH,1060,11,Calculus of One Variable I,0.41,0.28,0.06,0.06,0.13,0.0,0.0,0.06,thowhida akther,
-MATH,1060,14,Calculus of One Variable I,0.12,0.23,0.26,0.14,0.12,0.0,0.0,0.14,paul james cubre,
-MATH,1060,15,Calculus of One Variable I,0.31,0.22,0.17,0.11,0.06,0.0,0.0,0.14,fun choi john chan,
-MATH,1060,16,Calculus of One Variable I,0.25,0.36,0.09,0.05,0.11,0.0,0.0,0.14,pye phyo aung,
-MATH,1060,17,Calculus of One Variable I,0.16,0.24,0.27,0.07,0.16,0.0,0.0,0.11,pye phyo aung,
-MATH,1060,18,Calculus of One Variable I,0.21,0.39,0.33,0.0,0.0,0.0,0.0,0.06,marilyn reba,
-MATH,1060,100,Calc of One Variable I (HON),0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,boshi yang,True
-MATH,1060,201,Calculus of One Variable I,0.25,0.44,0.17,0.04,0.0,0.0,0.0,0.1,james edwar gossell,
-MATH,1060,202,Calculus of One Variable I,0.29,0.4,0.17,0.06,0.02,0.0,0.0,0.06,hiram lopez valdez,
-MATH,1060,203,Calculus of One Variable I,0.37,0.37,0.26,0.0,0.0,0.0,0.0,0.0,alistair bentley,
-MATH,1060,205,Calculus of One Variable I,0.23,0.56,0.1,0.04,0.06,0.0,0.0,0.0,amy christine grady,
-MATH,1060,206,Calculus of One Variable I,0.23,0.46,0.21,0.02,0.04,0.0,0.0,0.04,thomas clevenger,
-MATH,1060,207,Calculus of One Variable I,0.35,0.27,0.13,0.07,0.04,0.0,0.0,0.14,hiram lopez valdez,
-MATH,1070,1,Differen and Integral Calculus,0.0,0.25,0.47,0.13,0.09,0.0,0.0,0.06,donna simms,
-MATH,1080,1,Calculus of One Variable II,0.23,0.13,0.2,0.17,0.13,0.0,0.0,0.13,sanwar ahmad,
-MATH,1080,2,Calculus of One Variable II,0.09,0.23,0.28,0.14,0.12,0.0,0.0,0.14,fei xue,
-MATH,1080,5,Calculus of One Variable II,0.17,0.1,0.15,0.12,0.37,0.0,0.0,0.1,mengying xiao,
-MATH,1080,6,Calculus of One Variable II,0.11,0.21,0.25,0.04,0.14,0.0,0.0,0.25,mark cawood,
-MATH,1080,7,Calculus of One Variable II,0.13,0.23,0.25,0.03,0.23,0.0,0.0,0.15,beth novick,
-MATH,1080,8,Calculus of One Variable II,0.15,0.24,0.15,0.07,0.24,0.0,0.0,0.15,meredith nicol burr,
-MATH,1080,9,Calculus of One Variable II,0.21,0.28,0.14,0.14,0.16,0.0,0.0,0.07,meredith nicol burr,
-MATH,1080,201,Calculus of One Variable II,0.34,0.21,0.26,0.05,0.11,0.0,0.0,0.03,beth novick,
-MATH,1150,1,Contemp Math for Elem Teach I,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,1150,2,Contemp Math for Elem Teach I,0.57,0.27,0.11,0.05,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1160,1,Contemp Math for Elem Teach II,0.41,0.55,0.05,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.0,marion hanna,
-MATH,1990,401,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.04,0.02,marion hanna,
-MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,
-MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,
-MATH,2060,1,Calculus of Several Variables,0.4,0.33,0.22,0.0,0.0,0.0,0.0,0.04,xin liu,
-MATH,2060,2,Calculus of Several Variables,0.31,0.51,0.18,0.0,0.0,0.0,0.0,0.0,peter kiessler,
-MATH,2060,3,Calculus of Several Variables,0.15,0.28,0.28,0.04,0.17,0.0,0.0,0.09,sofya alekseeva,
-MATH,2060,5,Calculus of Several Variables,0.25,0.28,0.19,0.09,0.13,0.0,0.0,0.06,jeong rock yoon,
-MATH,2060,6,Calculus of Several Variables,0.32,0.18,0.11,0.05,0.18,0.0,0.0,0.16,allen anderso guest,
-MATH,2060,7,Calculus of Several Variables,0.22,0.35,0.35,0.07,0.0,0.0,0.0,0.0,sofya alekseeva,
-MATH,2060,9,Calculus of Several Variables,0.09,0.26,0.11,0.09,0.2,0.0,0.0,0.26,timothy fra parrott,
-MATH,2060,10,Calculus of Several Variables,0.2,0.33,0.2,0.02,0.2,0.0,0.0,0.04,allen anderso guest,
-MATH,2060,11,Calculus of Several Variables,0.29,0.47,0.18,0.03,0.0,0.0,0.0,0.03,xin liu,
-MATH,2060,12,Calculus of Several Variables,0.44,0.29,0.15,0.02,0.05,0.0,0.0,0.05,irina viktorova,
-MATH,2060,13,Calculus of Several Variables,0.32,0.39,0.24,0.0,0.0,0.0,0.0,0.05,akshay sunil gupte,
-MATH,2060,14,Calculus of Several Variables,0.49,0.31,0.13,0.02,0.0,0.0,0.0,0.04,martin joha schmoll,
-MATH,2060,15,Calculus of Several Variables,0.22,0.22,0.12,0.2,0.17,0.0,0.0,0.07,julie lassiter,
-MATH,2060,16,Calculus of Several Variables,0.3,0.32,0.11,0.02,0.16,0.0,0.0,0.09,allen anderso guest,
-MATH,2060,17,Calculus of Several Variables,0.05,0.25,0.16,0.2,0.2,0.0,0.0,0.14,julie lassiter,
-MATH,2060,18,Calculus of Several Variables,0.26,0.34,0.21,0.11,0.05,0.0,0.0,0.03,sofya alekseeva,
-MATH,2060,19,Calculus of Several Variables,0.13,0.3,0.19,0.07,0.22,0.0,0.0,0.09,gretchen matthews,
-MATH,2060,20,Calculus of Several Variables,0.33,0.33,0.22,0.04,0.0,0.0,0.0,0.07,martin joha schmoll,
-MATH,2060,21,Calculus of Several Variables,0.28,0.23,0.25,0.1,0.1,0.0,0.0,0.05,shitao liu,
-MATH,2060,22,Calculus of Several Variables,0.16,0.32,0.18,0.11,0.16,0.0,0.0,0.09,gretchen matthews,
-MATH,2060,100,Calc of Several Vars (HON),0.4,0.36,0.12,0.05,0.05,0.0,0.0,0.02,james brown,True
-MATH,2060,201,Calculus of Several Variables,0.11,0.26,0.18,0.05,0.08,0.0,0.0,0.32,timothy fra parrott,
-MATH,2060,202,Calculus of Several Variables,0.14,0.31,0.12,0.05,0.05,0.0,0.0,0.33,timothy fra parrott,
-MATH,2070,1,Business Calculus II,0.28,0.5,0.06,0.17,0.0,0.0,0.0,0.0,thanh thien to,
-MATH,2070,2,Business Calculus II,0.21,0.11,0.32,0.32,0.05,0.0,0.0,0.0,thanh thien to,
-MATH,2070,3,Business Calculus II,0.26,0.32,0.32,0.0,0.0,0.0,0.0,0.11,garrett dranichak,
-MATH,2070,4,Business Calculus II,0.47,0.05,0.16,0.16,0.11,0.0,0.0,0.05,garrett dranichak,
-MATH,2070,7,Business Calculus II,0.28,0.11,0.33,0.11,0.06,0.0,0.0,0.11,yinggu bao,
-MATH,2070,8,Business Calculus II,0.16,0.32,0.21,0.16,0.05,0.0,0.0,0.11,haodong li,
-MATH,2070,9,Business Calculus II,0.17,0.22,0.44,0.06,0.11,0.0,0.0,0.0,haodong li,
-MATH,2070,11,Business Calculus II,0.4,0.31,0.15,0.07,0.05,0.0,0.0,0.02,jennifer ray newton,
-MATH,2070,12,Business Calculus II,0.26,0.26,0.21,0.16,0.0,0.0,0.0,0.11,yinggu bao,
-MATH,2070,13,Business Calculus II,0.33,0.28,0.18,0.05,0.03,0.0,0.0,0.13,jennifer mari hanna,
-MATH,2070,14,Business Calculus II,0.36,0.36,0.14,0.05,0.0,0.0,0.0,0.1,jennifer mari hanna,
-MATH,2070,15,Business Calculus II,0.41,0.32,0.17,0.05,0.02,0.0,0.0,0.02,jennifer mari hanna,
-MATH,2070,16,Business Calculus II,0.34,0.34,0.16,0.09,0.02,0.0,0.0,0.05,sea sather-wagstaff,
-MATH,2070,18,Business Calculus II,0.19,0.21,0.22,0.12,0.1,0.0,0.0,0.16,judith irene mcknew,
-MATH,2080,1,Intro to Ordin Diff Equations,0.16,0.13,0.16,0.19,0.13,0.0,0.0,0.23,terri johnson,
-MATH,2080,2,Intro to Ordin Diff Equations,0.18,0.38,0.18,0.13,0.13,0.0,0.0,0.03,irina viktorova,
-MATH,2080,3,Intro to Ordin Diff Equations,0.07,0.27,0.41,0.12,0.05,0.0,0.0,0.07,irina viktorova,
-MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.13,0.19,0.0,0.22,0.0,0.0,0.25,terri johnson,
-MATH,2080,5,Intro to Ordin Diff Equations,0.13,0.13,0.22,0.06,0.13,0.0,0.0,0.34,terri johnson,
-MATH,2080,6,Intro to Ordin Diff Equations,0.22,0.43,0.16,0.08,0.0,0.0,0.0,0.11,oleg yordanov,
-MATH,2080,7,Intro to Ordin Diff Equations,0.36,0.25,0.19,0.06,0.08,0.0,0.0,0.06,oleg yordanov,
-MATH,2080,8,Intro to Ordin Diff Equations,0.14,0.35,0.26,0.09,0.09,0.0,0.0,0.07,oleg yordanov,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,matthew macauley,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.69,0.17,0.1,0.0,0.03,0.0,0.0,0.0,allison stoddard,
-MATH,2160,2,Geometry for Elem Sch Teachers,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,2500,1,Intro to Mathematical Sciences,0.94,0.03,0.02,0.0,0.0,0.0,0.0,0.02,christopher cox,
-MATH,3020,1,Stat for Science & Engineering,0.32,0.19,0.32,0.11,0.0,0.0,0.0,0.05,derek brown,
-MATH,3020,2,Stat for Science & Engineering,0.2,0.47,0.13,0.0,0.07,0.0,0.0,0.13,haotian feng,
-MATH,3020,3,Stat for Science & Engineering,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,prab withana gamage,
-MATH,3020,4,Stat for Science & Engineering,0.33,0.13,0.33,0.2,0.0,0.0,0.0,0.0,elaine ma sotherden,
-MATH,3020,6,Stat for Science & Engineering,0.17,0.28,0.42,0.0,0.03,0.0,0.0,0.11,calvin williams,
-MATH,3020,8,Stat for Science & Engineering,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,prab withana gamage,
-MATH,3020,9,Stat for Science & Engineering,0.24,0.65,0.12,0.0,0.0,0.0,0.0,0.0,haotian feng,
-MATH,3020,12,Stat for Science & Engineering,0.22,0.28,0.17,0.17,0.11,0.0,0.0,0.06,elaine ma sotherden,
-MATH,3020,14,Stat for Science & Engineering,0.43,0.33,0.13,0.03,0.0,0.0,0.0,0.1,ellen hepfe breazel,
-MATH,3020,15,Stat for Science & Engineering,0.33,0.55,0.08,0.03,0.03,0.0,0.0,0.0,ellen hepfe breazel,
-MATH,3110,1,Linear Algebra,0.34,0.3,0.11,0.05,0.09,0.0,0.0,0.11,xuhong gao,
-MATH,3110,2,Linear Algebra,0.24,0.32,0.17,0.07,0.12,0.0,0.0,0.07,xuhong gao,
-MATH,3110,3,Linear Algebra,0.17,0.26,0.33,0.07,0.07,0.0,0.0,0.11,michael adam burr,
-MATH,3110,4,Linear Algebra,0.22,0.32,0.27,0.15,0.02,0.0,0.0,0.02,hui xue,
-MATH,3110,5,Linear Algebra,0.32,0.29,0.2,0.05,0.12,0.0,0.0,0.02,hui xue,
-MATH,3110,6,Linear Algebra,0.23,0.25,0.18,0.07,0.14,0.0,0.0,0.14,felice manganiello,
-MATH,3110,7,Linear Algebra,0.14,0.28,0.21,0.19,0.05,0.0,0.0,0.14,felice manganiello,
-MATH,3110,8,Linear Algebra,0.62,0.22,0.13,0.0,0.0,0.0,0.0,0.02,benjamin jaye,
-MATH,3110,100,Linear Algebra (HON),0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,neil calkin,True
-MATH,3110,200,Linear Algebra,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,kevin james,
-MATH,3160,1,Prob Solving for Math Teachers,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,3190,1,Introduction to Proof,0.26,0.42,0.16,0.05,0.05,0.0,0.0,0.05,james ba coykendall,
-MATH,3190,2,Introduction to Proof,0.27,0.15,0.27,0.0,0.19,0.0,0.0,0.12,james ba coykendall,
-MATH,3600,1,Intermediate Math Computing,0.7,0.1,0.07,0.03,0.07,0.0,0.0,0.03,mark cawood,
-MATH,3600,2,Intermediate Math Computing,0.81,0.06,0.1,0.0,0.03,0.0,0.0,0.0,mark cawood,
-MATH,3650,1,Numerical Mthds for Engineers,0.22,0.38,0.19,0.11,0.08,0.0,0.0,0.03,vincent ervin,
-MATH,3650,2,Numerical Mthds for Engineers,0.5,0.25,0.22,0.0,0.03,0.0,0.0,0.0,leo rebholz,
-MATH,3650,3,Numerical Mthds for Engineers,0.29,0.6,0.07,0.05,0.0,0.0,0.0,0.0,timo johann heister,
-MATH,3650,4,Numerical Mthds for Engineers,0.14,0.39,0.19,0.06,0.11,0.0,0.0,0.11,eleanor jenkins,
-MATH,4000,1,Theory of Probability,0.44,0.26,0.14,0.05,0.05,0.0,0.0,0.07,xiaoqian sun,
-MATH,4020,1,Stat for Sci & Engineering II,0.5,0.1,0.3,0.0,0.1,0.0,0.0,0.0,calvin williams,
-MATH,4070,1,Regress & Time-Series Analysis,0.36,0.29,0.29,0.0,0.07,0.0,0.0,0.0,colin gallagher,
-MATH,4080,1,Secondary Math Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,carlos gomez,
-MATH,4120,1,Algebra I,0.26,0.31,0.28,0.05,0.08,0.0,0.0,0.03,matthew macauley,
-MATH,4190,1,Discrete Math Structures I,0.7,0.23,0.03,0.0,0.03,0.0,0.0,0.0,beth novick,
-MATH,4190,2,Discrete Math Structures I,0.46,0.36,0.18,0.0,0.0,0.0,0.0,0.0,wayne goddard,
-MATH,4310,1,Theory of Interest,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0, erwin walker,
-MATH,4340,1,Adv Engineering Mathematics,0.25,0.28,0.22,0.09,0.13,0.0,0.0,0.03,hyesuk lee,
-MATH,4340,2,Adv Engineering Mathematics,0.21,0.07,0.14,0.14,0.29,0.0,0.0,0.14,eleanor jenkins,
-MATH,4400,1,Linear Programming,0.42,0.25,0.21,0.04,0.04,0.0,0.0,0.04,boshi yang,
-MATH,4410,1,Intro to Stochastic Models,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,brian fralix,
-MATH,4500,1,Intro to Mathematical Models,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,matthew macauley,
-MATH,4530,1,Advanced Calculus I,0.42,0.28,0.11,0.11,0.06,0.0,0.0,0.03,james peterson,
-MATH,4540,1,Advanced Calculus II,0.17,0.25,0.33,0.17,0.0,0.0,0.0,0.08,james peterson,
-MATH,4630,1,Mathematical Analysis I,0.36,0.18,0.18,0.09,0.18,0.0,0.0,0.0,mishko mitkovski,
-MATH,6340,1,Adv Engineering Mathematics,0.36,0.41,0.14,0.0,0.0,0.0,0.0,0.09,vincent ervin,
-MATH,8000,1,Probability,0.48,0.19,0.11,0.0,0.11,0.0,0.0,0.11,christopher mcmahan,
-MATH,8010,1,General Linear Hypothesis I,0.5,0.42,0.0,0.0,0.08,0.0,0.0,0.0,derek brown,
-MATH,8050,1,Data Analysis,0.68,0.25,0.04,0.0,0.0,0.0,0.0,0.04,ling ma,
-MATH,8070,1,Applied Multivariate Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,8100,1,Mathematical Programming,0.74,0.17,0.0,0.0,0.0,0.0,0.0,0.09,yuyuan ouyang,
-MATH,8140,1,Network Flow Programming,0.36,0.18,0.27,0.0,0.0,0.0,0.0,0.18,herve louis kerivin,
-MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
-MATH,8210,1,Linear Analysis,0.27,0.58,0.0,0.0,0.03,0.0,0.0,0.12,shitao liu,
-MATH,8230,1,Complex Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,
-MATH,8510,1,Abstract Algebra I,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,kevin james,
-MATH,8530,1,Matrix Analysis,0.47,0.11,0.37,0.0,0.0,0.0,0.0,0.05,svetlan poznanovikj,
-MATH,8580,1,Number Theory,0.57,0.14,0.14,0.0,0.14,0.0,0.0,0.0,james brown,
-MATH,8600,1,Intro to Scientific Computing,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,hyesuk lee,
-MATH,8610,1,Advanced Numerical Analysis I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,fei xue,
-MATH,8650,1,Data Structures,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,timo johann heister,
-MATH,8840,1,Statistics for Experimenters,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-MATH,9850,2,Homological Algebra,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,sea sather-wagstaff,
-MBA,8040,20,Busin Data An & Stat Computing,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,
-MBA,8060,1,Operations Mgt,0.16,0.5,0.32,0.0,0.0,0.0,0.0,0.03, sridharan,
-MBA,8070,1,Financial Management,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,george bra lockhart,
-MBA,8070,20,Financial Management,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,george bra lockhart,
-MBA,8090,1,Org Beh & Hum Res Mg,0.43,0.53,0.04,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8090,2,Org Beh & Hum Res Mg,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8180,20,Intro Business Intell & Anlytc,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,heshan sun,
-MBA,8190,1,Intro to Acc and Fin,0.55,0.34,0.1,0.0,0.0,0.0,0.0,0.0,melvin stith,
-MBA,8190,2,Intro to Acc and Fin,0.52,0.36,0.1,0.0,0.02,0.0,0.0,0.0,james mil kohlmeyer,
-MBA,8290,1,Marketing Foundation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MBA,8310,10,Communications and Sales,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,
-MBA,8360,1,Real Estate Principles,0.41,0.48,0.11,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
-MBA,8370,1,Legal Environ of Bus,0.27,0.67,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8370,2,Legal Environ of Bus,0.47,0.47,0.03,0.0,0.0,0.0,0.0,0.03,judson jahn,
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
-MBA,8430,1,Entrepreneurial Accounting,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
-MBA,8450,1,Technology & Innovation Mgt,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,michael george mino,
-MBA,8480,1,Entrpr Mkting & Digital Strat,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,bruce snyder,
-MBA,8480,5,Entrpr Mkting & Digital Strat,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,
-MBA,8490,5,Entrepreneurial Strategy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8510,1,Bus Operations & Logistics,0.24,0.35,0.41,0.0,0.0,0.0,0.0,0.0, sridharan,
-MBA,8540,1,Managerial Accounting,0.4,0.43,0.14,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,
-MBA,8590,1,Mgr Decision Model,0.34,0.26,0.29,0.0,0.0,0.0,0.0,0.11,sara elizabet yoder,
-MBA,8590,2,Mgr Decision Model,0.28,0.51,0.07,0.0,0.02,0.0,0.0,0.12,magda gabriela sava,
-MBA,8600,1,Advanced Marketing Strategy,0.3,0.48,0.23,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8600,2,Advanced Marketing Strategy,0.21,0.64,0.15,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8610,1,Information Systems,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MBA,8620,1,Managerial Economics,0.28,0.56,0.16,0.0,0.0,0.0,0.0,0.0,scott templeton,
-MBA,8620,2,Managerial Economics,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,
-MBA,8620,4,Managerial Economics,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,ronald earl gregory,
-MBA,8650,1,Taxation of Business Decisions,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8700,1,Strategic Management,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,james turner,
-MBA,8700,2,Strategic Management,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,thomas robert uva,
-MBA,8990,2,Creativity,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,kathleen ann kegley,
-MBA,8990,4,Data Analytics & Visualization,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,john frederic tripp,
-ME,2000,1,Sophomore Seminar,0.91,0.05,0.02,0.0,0.01,0.0,0.0,0.01,donald beasley,
-ME,2000,2,Sophomore Seminar,0.78,0.19,0.01,0.0,0.01,0.0,0.0,0.01,donald beasley,
-ME,2010,1,Statics & Dynamics,0.15,0.2,0.2,0.09,0.22,0.0,0.0,0.14,marisa kikendal orr,
-ME,2010,2,Statics & Dynamics,0.09,0.24,0.23,0.14,0.23,0.0,0.0,0.08,paul joseph,
-ME,2010,3,Statics & Dynamics,0.05,0.22,0.19,0.1,0.29,0.0,0.0,0.15,jorge iva rodriguez,
-ME,2030,1,Founda Th/Fl Syst,0.08,0.21,0.21,0.21,0.18,0.0,0.0,0.13,john saylor,
-ME,2030,2,Founda Th/Fl Syst,0.2,0.35,0.2,0.14,0.06,0.0,0.0,0.06,xiangchun xuan,
-ME,2040,1,Mechanics of Materials,0.27,0.45,0.22,0.04,0.02,0.0,0.0,0.0,gang li,
-ME,2040,3,Mechanics of Materials,0.17,0.57,0.19,0.05,0.0,0.0,0.0,0.02,jorge iva rodriguez,
-ME,2220,1,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,2,Mechanical Engineering Lab I,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
-ME,2220,3,Mechanical Engineering Lab I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,5,Mechanical Engineering Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,2220,7,Mechanical Engineering Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,13,Mechanical Engineering Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,15,Mechanical Engineering Lab I,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,17,Mechanical Engineering Lab I,0.31,0.63,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,2220,18,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3030,1,Thermodynamics,0.2,0.3,0.3,0.08,0.04,0.0,0.0,0.08,richard miller,
-ME,3030,2,Thermodynamics,0.26,0.51,0.18,0.0,0.02,0.0,0.0,0.04,yiqiang han,
-ME,3040,1,Heat Transfer,0.05,0.26,0.43,0.12,0.12,0.0,0.0,0.02,jean-marc delhaye,
-ME,3040,2,Heat Transfer,0.19,0.42,0.23,0.07,0.06,0.0,0.0,0.03,xin zhao,
-ME,3050,1,Model/an Dy Syst,0.21,0.17,0.32,0.15,0.06,0.0,0.0,0.09,joshua bostwick,
-ME,3050,2,Model/an Dy Syst,0.22,0.39,0.3,0.04,0.04,0.0,0.0,0.0,ardalan vahidi,
-ME,3060,1,Fund Machine Design,0.13,0.58,0.21,0.0,0.02,0.0,0.0,0.06,oliver myers,
-ME,3060,2,Fund Machine Design,0.24,0.5,0.18,0.02,0.02,0.0,0.0,0.04,paul jeffrey meyer,
-ME,3070,1,Found of Mechanical Systems,0.34,0.39,0.25,0.0,0.02,0.0,0.0,0.0,jorge iva rodriguez,
-ME,3070,2,Found of Mechanical Systems,0.22,0.51,0.17,0.04,0.01,0.0,0.0,0.05,gregory mocko,
-ME,3080,1,Fluid Mechanics,0.34,0.49,0.09,0.06,0.02,0.0,0.0,0.0,yiqiang han,
-ME,3080,2,Fluid Mechanics,0.24,0.51,0.16,0.03,0.05,0.0,0.0,0.0,yiqiang han,
-ME,3080,3,Fluid Mechanics,0.1,0.46,0.39,0.02,0.02,0.0,0.0,0.02,ethan kung,
-ME,3120,1,Manuf Processes,0.35,0.49,0.13,0.02,0.01,0.0,0.0,0.01,rod martinez-duarte,
-ME,3330,1,Mechanical Engineering Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,2,Mechanical Engineering Lab II,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,3,Mechanical Engineering Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,6,Mechanical Engineering Lab II,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,3330,7,Mechanical Engineering Lab II,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
-ME,3330,9,Mechanical Engineering Lab II,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,10,Mechanical Engineering Lab II,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,todd schweisinger,
-ME,4000,1,Senior Seminar,0.96,0.03,0.0,0.0,0.01,0.0,0.0,0.0,richard figliola,
-ME,4010,1,Mech Engr Design,0.87,0.08,0.01,0.02,0.01,0.0,0.0,0.02,cameron turner,
-ME,4020,1,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
-ME,4020,2,Intern in Engr Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,3,Intern in Engr Des,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,4030,1,Control Dynamic Systems,0.32,0.34,0.22,0.04,0.04,0.0,0.0,0.03,suyi li,
-ME,4030,2,Control Dynamic Systems,0.21,0.37,0.33,0.07,0.0,0.0,0.0,0.02,yue wang,
-ME,4210,1,Intro to Comp Flow,0.27,0.46,0.15,0.08,0.04,0.0,0.0,0.0,chenning tong,
-ME,4320,1,Advanced Strength of Materials,0.0,0.87,0.07,0.0,0.07,0.0,0.0,0.0,michael porter,
-ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,2,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,5,Mechanical Engineering Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,6,Mechanical Engineering Lab III,0.18,0.64,0.0,0.0,0.09,0.0,0.0,0.09,john wagner,
-ME,4440,9,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,10,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,18,Mechanical Engineering Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4540,1,Design of Machine Elements,0.53,0.36,0.08,0.0,0.01,0.0,0.0,0.01,paul jeffrey meyer,
-ME,4930,14,Sel.Topics ME - NonLinDy&Chas,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,phanin tallapragada,
-ME,4930,39,Sel.Topics ME - Aero Propul,0.27,0.43,0.27,0.02,0.0,0.0,0.0,0.0,daniel fant,
-ME,4930,139,Sel.Topic ME - Solar Energy,0.44,0.23,0.28,0.0,0.0,0.0,0.0,0.05,daniel fant,
-ME,6210,1,Intro to Comp Flow,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
-ME,6320,1,Advanced Strength of Materials,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,michael porter,
-ME,6540,1,Des Machine Elements,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,
-ME,8010,1,Found of Fluid Mech,0.17,0.44,0.17,0.0,0.11,0.0,0.0,0.11,nicole gise coutris,
-ME,8100,1,Macroscopic Thermo,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,xiangchun xuan,
-ME,8180,1,Intro to Fin Ele Ana,0.58,0.31,0.04,0.0,0.0,0.0,0.0,0.06,lonny thompson,
-ME,8230,1,Control Systems,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,
-ME,8460,1,Inter Dynamics,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,phanin tallapragada,
-ME,8610,1,Matl Sel Engr Design,0.45,0.53,0.0,0.0,0.02,0.0,0.0,0.0,michael porter,
-ME,8610,401,Matl Sel Engr Design,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael porter,
-ME,8700,1,Adv Design Methods,0.29,0.62,0.05,0.0,0.05,0.0,0.0,0.0,joshua summers,
-ME,8710,1,Engr Optimization,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,8710,401,Engr Optimization,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,georges fadel,
-ME,8930,1,Sel. Topics in ME - Scaling,0.3,0.2,0.3,0.0,0.2,0.0,0.0,0.0,jean-marc delhaye,
-ME,8930,4,SelectedTopics in ME - Adv Mfg,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-MGT,2010,1,Principles of Management,0.42,0.43,0.11,0.03,0.01,0.0,0.0,0.0,katherine clark,
-MGT,2010,2,Principles of Management,0.42,0.38,0.16,0.03,0.0,0.0,0.0,0.01,tina robbins,
-MGT,2010,4,Principles of Management (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
-MGT,2010,10,Principles of Management,0.33,0.45,0.23,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
-MGT,2010,11,Principles of Management,0.28,0.33,0.31,0.03,0.03,0.0,0.0,0.03,ashley will parnell,
-MGT,2010,12,Principles of Management,0.16,0.33,0.28,0.09,0.07,0.0,0.0,0.07,ashley will parnell,
-MGT,2180,1,Management PC Applications,0.47,0.37,0.12,0.01,0.01,0.0,0.0,0.02,ryan toole,
-MGT,2180,2,Management PC Applications,0.2,0.47,0.21,0.03,0.04,0.0,0.0,0.03,ryan toole,
-MGT,2970,4,How to Start a Startup,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,john michael hannon,
-MGT,3070,1,Human Resource Management,0.84,0.14,0.0,0.0,0.0,0.0,0.0,0.02,jonathan sanderson,
-MGT,3070,3,Human Resource Management,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,4,Human Resource Management,0.6,0.38,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,5,Human Resource Management,0.43,0.45,0.13,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,6,Human Resource Management,0.53,0.43,0.03,0.03,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,7,Human Resource Management,0.83,0.15,0.0,0.0,0.03,0.0,0.0,0.0,alejandra kennedy,
-MGT,3070,8,Human Resource Management,0.25,0.38,0.13,0.13,0.06,0.0,0.0,0.06,priscilla harrison,
-MGT,3100,1,Intermed Business Statistics,0.38,0.28,0.13,0.1,0.03,0.0,0.0,0.08,min kyung lee,
-MGT,3100,2,Intermed Business Statistics,0.44,0.41,0.05,0.0,0.0,0.0,0.0,0.1,mustafa serk akturk,
-MGT,3100,3,Intermed Business Statistics,0.37,0.23,0.23,0.0,0.02,0.0,0.0,0.14,sukran nil atadeniz,
-MGT,3100,5,Intermed Business Statistics,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.13,mustafa serk akturk,
-MGT,3100,6,Intermed Business Statistics,0.15,0.39,0.36,0.03,0.0,0.0,0.0,0.06,magda gabriela sava,
-MGT,3100,7,Intermed Business Statistics,0.39,0.31,0.19,0.0,0.03,0.0,0.0,0.08,sukran nil atadeniz,
-MGT,3100,8,Intermed Business Statistics,0.42,0.32,0.13,0.05,0.08,0.0,0.0,0.0,min kyung lee,
-MGT,3100,9,Intermed Business Statistics,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,
-MGT,3100,10,Intermed Business Statistics,0.28,0.37,0.21,0.0,0.09,0.0,0.0,0.05,remi charpin,
-MGT,3100,11,Intermed Business Statistics,0.7,0.24,0.0,0.0,0.0,0.0,0.0,0.07,thomas simpson,
-MGT,3120,1,Decision Models for Management,0.12,0.23,0.23,0.19,0.16,0.0,0.0,0.07,sara elizabet yoder,
-MGT,3120,2,Decision Models for Management,0.2,0.16,0.23,0.23,0.1,0.0,0.0,0.07,sara elizabet yoder,
-MGT,3170,1,Logistics Mgmt,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,ahmet colak,
-MGT,3180,1,Mgt of Info Systems,0.28,0.56,0.1,0.03,0.0,0.0,0.0,0.03,marten risius,
-MGT,3180,2,Mgt of Info Systems,0.48,0.35,0.05,0.03,0.0,0.0,0.0,0.1,iaroslava dutchak,
-MGT,3180,3,Mgt of Info Systems,0.35,0.33,0.28,0.0,0.02,0.0,0.0,0.02,tina marie esposito,
-MGT,3180,4,Mgt of Info Systems,0.41,0.41,0.13,0.0,0.02,0.0,0.0,0.02,tina marie esposito,
-MGT,3180,5,Mgt of Info Systems,0.6,0.23,0.12,0.0,0.05,0.0,0.0,0.0,kevin dani matthews,
-MGT,3500,1,Intro to Business Analytics,0.18,0.73,0.09,0.0,0.0,0.0,0.0,0.0,siyuan li,
-MGT,3510,1,Business Analytics & Problems,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,
-MGT,3900,1,Ops Mgt,0.16,0.47,0.32,0.03,0.0,0.0,0.0,0.03,yann ferrand,
-MGT,3900,2,Ops Mgt,0.13,0.23,0.58,0.05,0.0,0.0,0.0,0.03,zachary mo leffakis,
-MGT,3900,3,Ops Mgt,0.11,0.39,0.29,0.03,0.03,0.0,0.0,0.16,berna quiroga gomez,
-MGT,3900,4,Ops Mgt,0.2,0.43,0.28,0.03,0.03,0.0,0.0,0.05,berna quiroga gomez,
-MGT,3900,5,Ops Mgt,0.32,0.24,0.32,0.0,0.03,0.0,0.0,0.08,daniel nielubowicz,
-MGT,3900,6,Ops Mgt,0.36,0.5,0.11,0.0,0.03,0.0,0.0,0.0,maneeshre ajjuguttu,
-MGT,4000,1,Mgt of Organizational Behavior,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,2,Mgt of Organizational Behavior,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,3,Mgt of Organizational Behavior,0.22,0.36,0.31,0.03,0.03,0.0,0.0,0.06,thomas jo zagenczyk,
-MGT,4000,4,Mgt of Organizational Behavior,0.15,0.4,0.35,0.05,0.0,0.0,0.0,0.05,philip roth,
-MGT,4020,1,Ops Pln and Ctl,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4080,1,Lean Operations,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4110,1,Project Management,0.26,0.37,0.33,0.0,0.05,0.0,0.0,0.0,russell purvis,
-MGT,4120,1,Supplier Management,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,ahmet colak,
-MGT,4150,1,Business Strategy,0.18,0.57,0.25,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,3,Business Strategy,0.4,0.53,0.05,0.03,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,4,Business Strategy,0.38,0.55,0.07,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,7,Business Strategy,0.49,0.47,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,8,Business Strategy,0.52,0.41,0.07,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,9,Business Strategy,0.25,0.59,0.11,0.0,0.02,0.0,0.0,0.02,amy elizabet ingram,
-MGT,4160,1,Special Topics Hr,0.36,0.6,0.04,0.0,0.0,0.0,0.0,0.0,kristin dam scott,
-MGT,4230,1,Intern Bus Mgt,0.16,0.16,0.53,0.16,0.0,0.0,0.0,0.0,wayne stewart,
-MGT,4230,2,Intern Bus Mgt,0.18,0.18,0.55,0.0,0.05,0.0,0.0,0.05,wayne stewart,
-MGT,4230,3,Intern Bus Mgt,0.23,0.4,0.3,0.05,0.0,0.0,0.0,0.03,janis miller,
-MGT,4230,4,Intern Bus Mgt,0.11,0.56,0.27,0.02,0.0,0.0,0.0,0.04,janis miller,
-MGT,4240,1,Global Supply Chain,0.21,0.46,0.33,0.0,0.0,0.0,0.0,0.0,yann ferrand,
-MGT,4270,2,Managing Improvement,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MGT,4310,1,Emp Rights & Resp,0.24,0.53,0.15,0.0,0.03,0.0,0.0,0.06,leonard jos spooner,
-MGT,4310,2,Emp Rights & Resp,0.4,0.49,0.11,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,4350,1,Pers Interviewing,0.36,0.36,0.25,0.04,0.0,0.0,0.0,0.0,philip roth,
-MGT,4520,1,Business Analysis,0.15,0.58,0.15,0.04,0.04,0.0,0.0,0.04,marten risius,
-MGT,4540,1,Systems Implement,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,heshan sun,
-MGT,4550,1,Emerging I T Trends,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MGT,4560,1,Business Info Mgt,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,siyuan li,
-MGT,8690,1,Project Mgt,0.41,0.56,0.0,0.0,0.0,0.0,0.0,0.04,russell purvis,
-MICR,2050,1,Introductory Micro,0.55,0.4,0.04,0.01,0.0,0.0,0.0,0.01,john abercrombie,
-MICR,3050,1,General Microbiology,0.38,0.4,0.14,0.05,0.01,0.0,0.0,0.02,krista barr rudolph,
-MICR,3050,2,General Microbiology,0.42,0.41,0.13,0.03,0.01,0.0,0.0,0.01,krista barr rudolph,
-MICR,4010,1,Microbial Diversity & Ecology,0.23,0.51,0.18,0.03,0.03,0.0,0.0,0.03,barbara campbell,
-MICR,4050,1,Adv Microbial Ecol of Humans,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4140,1,Basic Immunology,0.44,0.37,0.1,0.02,0.07,0.0,0.0,0.0,yanzhang wei,
-MICR,4150,1,Microbial Genetics,0.23,0.32,0.26,0.2,0.0,0.0,0.0,0.0,min cao,
-MICR,4160,1,Intro Virology,0.95,0.04,0.0,0.0,0.0,0.0,0.0,0.01,simon scott,
-MICR,4510,1,Advanced Microbiology II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4510,2,Advanced Microbiology II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4510,3,Advanced Microbiology II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MKT,3010,1,Prin of Marketing,0.02,0.43,0.38,0.1,0.05,0.0,0.0,0.02,carter wil mcelveen,
-MKT,3010,2,Prin of Marketing,0.29,0.46,0.18,0.05,0.02,0.0,0.0,0.0,amanda cooper fine,
-MKT,3010,3,Prin of Marketing,0.26,0.45,0.23,0.04,0.01,0.0,0.0,0.0,amanda cooper fine,
-MKT,3010,4,Prin of Marketing,0.27,0.46,0.2,0.04,0.01,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,5,Prin of Marketing,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,3020,1,Consumer Behavior,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,2,Consumer Behavior,0.58,0.4,0.0,0.0,0.0,0.0,0.0,0.02,jennifer di siemens,
-MKT,3020,3,Consumer Behavior,0.34,0.44,0.2,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3020,4,Consumer Behavior,0.51,0.33,0.08,0.06,0.02,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3020,5,Consumer Behavior,0.12,0.64,0.19,0.03,0.0,0.0,0.0,0.02,carter wil mcelveen,
-MKT,3210,1,Sports Marketing,0.74,0.23,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3210,2,Sports Marketing,0.68,0.3,0.0,0.0,0.0,0.0,0.0,0.02,delancy bennett,
-MKT,3310,1,Marketing Metrics & Analytics,0.42,0.56,0.02,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,
-MKT,3310,2,Marketing Metrics & Analytics,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,
-MKT,3980,1,Creative Inquiry in Marketing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james gaubert,
-MKT,4200,2,Professional Selling,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,3,Professional Selling,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4200,4,Professional Selling,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4200,5,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4230,1,Promotional Strategy,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,4240,1,Sales Management,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4260,1,Business-to-Business,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,james gaubert,
-MKT,4270,1,International Mktg,0.58,0.32,0.08,0.0,0.01,0.0,0.0,0.01,roger gomes,
-MKT,4270,2,International Mktg,0.21,0.59,0.13,0.03,0.03,0.0,0.0,0.03,roger gomes,
-MKT,4270,3,International Mktg,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,thomas poehlman,
-MKT,4280,1,Services Marketing,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4280,2,Services Marketing,0.43,0.53,0.05,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4310,1,Marketing Research,0.23,0.5,0.23,0.0,0.0,0.0,0.0,0.04,peter weathers,
-MKT,4310,2,Marketing Research,0.16,0.53,0.21,0.11,0.0,0.0,0.0,0.0,peter weathers,
-MKT,4310,3,Marketing Research,0.35,0.62,0.0,0.0,0.0,0.0,0.0,0.04,scott darren swain,
-MKT,4310,4,Marketing Research,0.35,0.35,0.17,0.0,0.0,0.0,0.0,0.13,william kilbourne,
-MKT,4430,1,Advertising Strategy,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4450,1,Macromarketing,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.19,0.65,0.16,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,2,Strategic Mktg Mgt,0.17,0.45,0.34,0.03,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4950,1,Social Media,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,4950,2,Social Media,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,8610,1,Marketing Research,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
-MKT,8630,1,Buyer Behavior,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
-ML,1010,1,Leadership Fund I,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,clay wilson etterle,
-ML,2010,2,Leadership Development I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,2010,3,Leadership Development I,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,vincent john presto,
-ML,3010,1,Advanced Leadership I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,
-MSE,2100,1,Intro to Mat Science,0.43,0.21,0.15,0.08,0.1,0.0,0.0,0.04,rakhee pani,
-MSE,2100,2,Intro to Mat Science,0.18,0.33,0.29,0.16,0.03,0.0,0.0,0.01,eric skaar,
-MSE,2100,3,Intro to Mat Science,0.27,0.25,0.28,0.08,0.09,0.0,0.0,0.04,fei peng,
-MSE,2100,4,Intro to Mat Science,0.31,0.45,0.14,0.03,0.04,0.0,0.0,0.03,ruslan burtovyy,
-MSE,2100,5,Intro to Mat Science,0.44,0.3,0.11,0.04,0.07,0.0,0.0,0.04,olga kuksenok,
-MSE,3190,1,Materials Proc I,0.34,0.53,0.08,0.03,0.01,0.0,0.0,0.01,olin mefford,
-MSE,3190,2,Materials Proc I,0.14,0.62,0.16,0.08,0.0,0.0,0.0,0.0,olin mefford,
-MSE,3260,1,Thermo of Materials,0.39,0.35,0.2,0.02,0.0,0.0,0.0,0.04,gary lickfield,
-MSE,3260,2,Thermo of Materials,0.25,0.39,0.19,0.08,0.06,0.0,0.0,0.03,gary lickfield,
-MSE,3270,1,Transport Phenomena,0.15,0.47,0.18,0.16,0.03,0.0,0.0,0.02,ulf daniel schiller,
-MSE,3270,2,Transport Phenomena,0.05,0.26,0.31,0.26,0.08,0.0,0.0,0.05,ulf daniel schiller,
-MSE,4020,1,Solid State Material,0.55,0.13,0.26,0.06,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,4070,1,Senior Capstone Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,
-MSE,4130,1,Noncrystalline Materials,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
-MSE,4150,1,Polymer Sc Engr,0.49,0.33,0.01,0.0,0.0,0.0,0.0,0.16,stephen foulger,
-MSE,4150,2,Polymer Sc Engr,0.58,0.28,0.09,0.02,0.02,0.0,0.0,0.0,olin mefford,
-MSE,4320,1,Manuf Proc & Systems,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
-MSE,4580,1,Surf Phen in Ms&E,0.29,0.11,0.21,0.36,0.04,0.0,0.0,0.0,konstantin kornev,
-MSE,4810,1,Undergraduate Research Fundame,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,marian kennedy,
-MSE,4910,1,Undergraduate Research,0.78,0.06,0.06,0.06,0.0,0.0,0.0,0.06,marian kennedy,
-MSE,4910,2,Undergraduate Research,0.59,0.24,0.0,0.06,0.06,0.0,0.0,0.06,marian kennedy,
-MSE,8100,1,Fundamentals of Materials Sci,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,igor luzinov,
-MSE,8270,1,Kin of Phase Tran,0.52,0.38,0.0,0.0,0.05,0.0,0.0,0.05,konstantin kornev,
-MUSC,1420,1,Music Theory I,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,anthony bernarducci,
-MUSC,1430,1,Aural Skills I,0.84,0.0,0.05,0.0,0.11,0.0,0.0,0.0,anthony bernarducci,
-MUSC,2100,2,Music in the Western World,0.56,0.25,0.13,0.0,0.03,0.0,0.0,0.03,lisa sain odom,
-MUSC,2100,3,Music in the Western World,0.41,0.34,0.16,0.09,0.0,0.0,0.0,0.0,alison leigh mero,
-MUSC,2100,4,Music in the Western World,0.56,0.22,0.13,0.0,0.06,0.0,0.0,0.03,linda li-bleuel,
-MUSC,2100,6,Music in the Western World,0.47,0.38,0.09,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
-MUSC,2100,7,Music in the Western World,0.39,0.39,0.1,0.03,0.0,0.0,0.0,0.1,rhea beth jacobus,
-MUSC,2100,8,Music in the Western World,0.53,0.23,0.0,0.0,0.03,0.0,0.0,0.2,rhea beth jacobus,
-MUSC,2100,10,Music in the Western World,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,linda dzuris,
-MUSC,2100,12,Music in the Western World,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,lea kibler,
-MUSC,3110,1,History of American Music,0.61,0.29,0.06,0.03,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,3130,1,Hist of Rock & Roll,0.78,0.16,0.03,0.0,0.03,0.0,0.0,0.0,hamilton altstatt,
-MUSC,3170,1,Hist of Country Mus,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3180,1,Hist of Audio Tech,0.5,0.25,0.19,0.06,0.0,0.0,0.0,0.0,bruce allen whisler,
-MUSC,3610,1,Marching Band,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
-MUSC,3620,1,Symphonic Band,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mark spede,
-MUSC,3690,1,Symphony Orchestra,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,
-MUSC,4150,1,Music Hist to 1750,0.17,0.17,0.33,0.11,0.11,0.0,0.0,0.11,justin durham,
-NPL,3000,1,Nonprofit Leadership,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
-NPL,3000,3,Nonprofit Leadership,0.63,0.2,0.03,0.0,0.0,0.0,0.0,0.13,bonnie west stevens,
-NPL,3000,4,Nonprofit Leadership,0.6,0.23,0.1,0.0,0.03,0.0,0.0,0.03,bonnie west stevens,
-NPL,3000,5,Nonprofit Leadership,0.5,0.23,0.23,0.0,0.05,0.0,0.0,0.0,christina mar mazer,
-NPL,3000,6,Nonprofit Leadership,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
-NPL,3000,7,Nonprofit Leadership,0.63,0.08,0.08,0.08,0.13,0.0,0.0,0.0,christina mar mazer,
-NPL,3040,1,NPL Risk Management,0.72,0.19,0.0,0.0,0.09,0.0,0.0,0.0,daniel mor anderson,
-NURS,1400,1,Comp App Hlth Care,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
-NURS,3030,1,Nursing of Adults,0.3,0.65,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3040,1,Pathophysiology,0.39,0.48,0.1,0.02,0.02,0.0,0.0,0.0,catherine si murton,
-NURS,3040,400,Pathophysiology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
-NURS,3040,401,Pathophysiology,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
-NURS,3050,1,Psychosocial Nursing,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
-NURS,3100,1,Health Assessment,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
-NURS,3100,2,Health Assessment,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
-NURS,3100,400,Health Assessment,0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,jason thrift,
-NURS,3120,1,Foundations of Nursing,0.47,0.52,0.02,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,
-NURS,3120,400,Foundations of Nursing,0.5,0.46,0.0,0.04,0.0,0.0,0.0,0.0,jennifer el bagwell,
-NURS,3190,400,Health Assessment for RNs,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
-NURS,3200,2,Prof in Nurs,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3230,400,Gerontology Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,tawny jenn mcintosh,
-NURS,3300,2,Research in Nursing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,3330,400,Health Care Genetics,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,mary steck,
-NURS,3400,1,Pharmther Nursing,0.32,0.55,0.11,0.0,0.02,0.0,0.0,0.0,catherine si murton,
-NURS,3400,400,Pharmther Nursing,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jenna lyn seawright,
-NURS,3600,400,Social Determinants in Health,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
-NURS,4010,1,Mental Health Nurs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NURS,4030,400,Complex Nursing of Adults,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,
-NURS,4060,400,Issues in Professionalism,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
-NURS,4110,1,Nursing of Children,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
-NURS,4120,1,Nurs Women and Fam,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4140,400,Com Nurs & Hlth Prom,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
-NURS,4250,200,Community Nursing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
-NURS,4980,15,Nursing/Engineering,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,nancy meehan,
-NURS,8050,400,Pharmaco Adv Nurs,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8050,401,Pharmaco Adv Nurs,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8060,400,Advan Assessment for Nursing,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,
-NURS,8090,400,Pathophysiology,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,tracy brock lowe,
-NURS,8190,400,Developing Family,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8200,400,Child & Adol Nursing,0.34,0.55,0.07,0.0,0.03,0.0,0.0,0.0,heide temples,
-NURS,9020,1,DNP Clinical Epidem & Biostats,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,veronica parker,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.81,0.16,0.01,0.0,0.02,0.0,0.0,0.0,bridgit den corbett,
-NUTR,2030,2,Intro Princ of Human Nutrition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,bridgit den corbett,
-NUTR,2050,1,Nutrition for Nursing Prof,0.74,0.25,0.01,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
-NUTR,2160,1,Evidence-Based Nutrition,0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,angela fraser,
-NUTR,4240,1,Medical Nutr Thera I,0.49,0.46,0.06,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4510,1,Human Nutrition & Metabolism I,0.3,0.3,0.19,0.12,0.05,0.0,0.0,0.05,elliot jesch,
-PA,1010,1,Intro to Perf Arts,0.67,0.3,0.04,0.0,0.0,0.0,0.0,0.0,david hartmann,
-PA,2010,2,Career Planning and Prof Devel,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
-PA,2790,1,Perf Arts Pract I,0.36,0.55,0.05,0.0,0.0,0.0,0.0,0.05,kenneth moore,
-PADM,8220,400,Public Policy Process,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,
-PADM,8220,401,Public Policy Process,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,
-PADM,8290,400,Public Financial Management,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,
-PADM,8420,400,GIS for Public Administrators,0.55,0.27,0.0,0.0,0.09,0.0,0.0,0.09,david lawrenc white,
-PADM,8660,400,Nonprofit Fundraising,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,renee salic nichols,
-PADM,8680,400,Local Government Admin,0.22,0.56,0.11,0.0,0.11,0.0,0.0,0.0,alfred bundrick,
-PADM,8720,400,Rural Development,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,
-PAS,3010,1,Pan African Studies,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,abel bartley,
-PDBE,8100,1,Contemporary Issues in EDP,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-PDBE,8150,1,Research Design in EDP,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,mickey lauria,
-PES,1040,1,Introduction to Plant Sciences,0.81,0.17,0.03,0.0,0.0,0.0,0.0,0.0,paula agudelo,
-PES,2020,1,Soils,0.19,0.55,0.19,0.06,0.0,0.0,0.0,0.01,dara michelle park,
-PES,3150,1,Environment and Agriculture,0.38,0.29,0.29,0.0,0.0,0.0,0.0,0.04,"appukuttan suseela,",
-PES,4850,1,Environmental Soil Chemistry,0.44,0.31,0.19,0.0,0.0,0.0,0.0,0.06,haibo liu,
-PHIL,1010,1,Intro to Philosophic Problems,0.44,0.41,0.12,0.0,0.0,0.0,0.0,0.03,david stegall,
-PHIL,1010,2,Intro to Philosophic Problems,0.43,0.26,0.2,0.06,0.03,0.0,0.0,0.03,christopher grau,
-PHIL,1010,3,Intro to Philosophic Problems,0.49,0.31,0.11,0.0,0.0,0.0,0.0,0.09,david stegall,
-PHIL,1010,4,Intro to Philosophic Problems,0.23,0.51,0.14,0.06,0.03,0.0,0.0,0.03,kelly smith,
-PHIL,1010,6,Intro to Philosophic Problems,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,andrew garnar,
-PHIL,1020,1,Introduction to Logic,0.68,0.21,0.12,0.0,0.0,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,2,Introduction to Logic,0.62,0.24,0.03,0.03,0.06,0.0,0.0,0.03,michael hal hannen,
-PHIL,1020,3,Introduction to Logic,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,michael hal hannen,
-PHIL,1020,4,Introduction to Logic,0.61,0.28,0.06,0.06,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1020,7,Introduction to Logic,0.32,0.32,0.29,0.03,0.0,0.0,0.0,0.03,adam gies,
-PHIL,1020,8,Introduction to Logic,0.53,0.25,0.22,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1020,9,Introduction to Logic,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
-PHIL,1020,10,Introduction to Logic,0.26,0.56,0.06,0.03,0.03,0.0,0.0,0.06,christopher wells,
-PHIL,1020,11,Introduction to Logic,0.46,0.29,0.11,0.11,0.0,0.0,0.0,0.03,christopher wells,
-PHIL,1020,12,Introduction to Logic,0.51,0.29,0.09,0.03,0.0,0.0,0.0,0.09,christopher wells,
-PHIL,1020,13,Introduction to Logic,0.72,0.11,0.0,0.11,0.0,0.0,0.0,0.06,christopher wells,
-PHIL,1020,14,Introduction to Logic,0.26,0.26,0.26,0.0,0.03,0.0,0.0,0.18,stephen satris,
-PHIL,1030,1,Introduction to Ethics,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,edyta joanna kuzian,
-PHIL,1030,2,Introduction to Ethics,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,stephen satris,
-PHIL,1030,3,Introduction to Ethics,0.32,0.29,0.32,0.0,0.03,0.0,0.0,0.03,charles starkey,
-PHIL,1030,4,Introduction to Ethics,0.5,0.33,0.06,0.06,0.06,0.0,0.0,0.0,david stegall,
-PHIL,1030,5,Introduction to Ethics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
-PHIL,1030,6,Introduction to Ethics,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
-PHIL,1030,7,Introduction to Ethics,0.38,0.23,0.31,0.0,0.0,0.0,0.0,0.08,edyta joanna kuzian,
-PHIL,1030,8,Introduction to Ethics,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
-PHIL,1030,9,Introduction to Ethics,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
-PHIL,1030,10,Introduction to Ethics,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,david stegall,
-PHIL,3040,1,Moral Philosophy,0.31,0.5,0.06,0.0,0.0,0.0,0.0,0.13,charles starkey,
-PHIL,3150,1,Ancient Philosophy,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,michael hal hannen,
-PHIL,3180,1,20th-Century Philosophy,0.58,0.29,0.03,0.0,0.03,0.0,0.0,0.06,william maker,
-PHIL,3200,1,Soc and Pol Phil,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,david stegall,
-PHIL,3260,1,Science and Values,0.59,0.21,0.06,0.0,0.09,0.0,0.0,0.06,andrew garnar,
-PHIL,3260,2,Science and Values,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,
-PHIL,3430,1,Philosophy of Law,0.21,0.66,0.03,0.03,0.0,0.0,0.0,0.07,brookes colyt brown,
-PHIL,3440,1,Business Ethics,0.24,0.47,0.24,0.0,0.0,0.0,0.0,0.06,brookes colyt brown,
-PHIL,3480,1,Philosophies of Art,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,christopher grau,
-PHIL,3550,1,Philosophy of Mind & Cog Scien,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,4020,1,Topics in Philosophy: Kant,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,kelly smith,
-PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics with Calculus I,0.23,0.33,0.24,0.07,0.06,0.0,0.0,0.07,lih-sin the,
-PHYS,1220,2,Physics with Calculus I,0.29,0.29,0.25,0.09,0.01,0.0,0.0,0.06,lih-sin the,
-PHYS,1220,4,Physics with Calculus I,0.56,0.19,0.06,0.06,0.13,0.0,0.0,0.0,murray daw,
-PHYS,1220,500,Physics with Calculus I,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,elaine parshall,
-PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
-PHYS,1240,2,Physics Lab I,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,3,Physics Lab I,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,4,Physics Lab I,0.56,0.33,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,6,Physics Lab I,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,jerry hester,
-PHYS,1240,7,Physics Lab I,0.28,0.39,0.17,0.11,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,8,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,9,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,10,Physics Lab I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,11,Physics Lab I,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,12,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,14,Physics Lab I,0.25,0.38,0.06,0.06,0.0,0.0,0.0,0.25,jerry hester,
-PHYS,1240,15,Physics Lab I,0.44,0.38,0.13,0.06,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,16,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,17,Physics Lab I,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,1240,18,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,19,Physics Lab I,0.71,0.18,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2070,1,General Physics I,0.13,0.29,0.31,0.14,0.07,0.0,0.0,0.06,amy liann pope,
-PHYS,2070,2,General Physics I,0.27,0.37,0.21,0.06,0.02,0.0,0.0,0.06,amy liann pope,
-PHYS,2070,3,General Physics I,0.36,0.37,0.18,0.06,0.02,0.0,0.0,0.01,amy liann pope,
-PHYS,2080,1,General Physics II,0.49,0.3,0.11,0.06,0.03,0.0,0.0,0.01,sripar bhattacharya,
-PHYS,2090,1,Gen Phys Lab I,0.79,0.04,0.04,0.04,0.04,0.0,0.0,0.04,jerry hester,
-PHYS,2090,2,Gen Phys Lab I,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,3,Gen Phys Lab I,0.33,0.46,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,4,Gen Phys Lab I,0.55,0.23,0.14,0.05,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,5,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,6,Gen Phys Lab I,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,7,Gen Phys Lab I,0.63,0.25,0.04,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,8,Gen Phys Lab I,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,9,Gen Phys Lab I,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,10,Gen Phys Lab I,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,11,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,12,Gen Phys Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,13,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,14,Gen Phys Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,15,Gen Phys Lab I,0.61,0.35,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,16,Gen Phys Lab I,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,17,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,18,Gen Phys Lab I,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,19,Gen Phys Lab I,0.61,0.3,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,20,Gen Phys Lab I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,21,Gen Phys Lab I,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,22,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,23,Gen Phys Lab I,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,24,Gen Phys Lab I,0.52,0.39,0.0,0.0,0.0,0.0,0.0,0.09,jerry hester,
-PHYS,2090,25,Gen Phys Lab I,0.52,0.39,0.0,0.04,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,26,Gen Phys Lab I,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
-PHYS,2090,27,Gen Phys Lab I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,1,Gen Phys Lab II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,2,Gen Phys Lab II,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,3,Gen Phys Lab II,0.65,0.15,0.2,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,4,Gen Phys Lab II,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,6,Gen Phys Lab II,0.52,0.3,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,7,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,8,Gen Phys Lab II,0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,9,Gen Phys Lab II,0.48,0.24,0.24,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2210,1,Physics with Calculus II,0.14,0.54,0.22,0.04,0.04,0.0,0.0,0.03,jason stratfo brown,
-PHYS,2210,2,Physics with Calculus II,0.28,0.52,0.16,0.03,0.0,0.0,0.0,0.01,jason stratfo brown,
-PHYS,2210,3,Physics with Calculus II,0.22,0.55,0.19,0.02,0.0,0.0,0.0,0.01,ramakrishna podila,
-PHYS,2210,4,Physics with Calculus II,0.18,0.56,0.16,0.06,0.04,0.0,0.0,0.0,ramakrishna podila,
-PHYS,2210,7,Physics With Cal II (HON),0.58,0.36,0.06,0.0,0.0,0.0,0.0,0.0,joan marler,True
-PHYS,2220,1,Physics with Calculus III,0.57,0.29,0.0,0.05,0.0,0.0,0.0,0.1,jian he,
-PHYS,2230,3,Physics Lab II,0.72,0.06,0.0,0.0,0.0,0.0,0.0,0.22,jerry hester,
-PHYS,2230,4,Physics Lab II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,6,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,7,Physics Lab II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,11,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,13,Physics Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,17,Physics Lab II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2450,1,Physics of Climate,0.64,0.2,0.05,0.01,0.02,0.0,0.0,0.08,gerald lehmacher,
-PHYS,3120,1,Meth Theor Phys II,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,antony valentini,
-PHYS,3150,1,Intro to Computational Physics,0.5,0.27,0.19,0.0,0.0,0.0,0.0,0.04,emil georgie alexov,
-PHYS,3210,1,Mechanics I,0.29,0.25,0.21,0.04,0.08,0.0,0.0,0.13,joshua alper,
-PHYS,3250,1,Exper Physics I,0.5,0.25,0.15,0.0,0.05,0.0,0.0,0.05,chad sosolik,
-PHYS,4410,1,Electromagnetics I,0.27,0.36,0.14,0.05,0.0,0.0,0.0,0.18,xian lu,
-PHYS,4550,1,Quantum Physics I,0.18,0.64,0.09,0.09,0.0,0.0,0.0,0.0,ramakrishna podila,
-PHYS,8110,1,Meth of Theor Phys I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,feng ding,
-PHYS,8170,1,Molecular Biophysics,0.14,0.71,0.0,0.0,0.14,0.0,0.0,0.0,hugo sanabria,
-PHYS,8210,1,Classical Mech I,0.14,0.57,0.29,0.0,0.0,0.0,0.0,0.0,jens oberheide,
-PHYS,9510,1,Quantum Mech I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
-PKSC,1010,1,Pkgsc Orientation,0.88,0.09,0.02,0.0,0.01,0.0,0.0,0.0,robert truett moore,
-PKSC,1020,1,Intro to Pkg Sci,0.24,0.4,0.26,0.04,0.02,0.0,0.0,0.03,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2040,1,Container Systems,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2060,1,Container Sys Lab,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,4010,1,Packaging Machinery,0.35,0.49,0.14,0.0,0.0,0.0,0.0,0.01,anthony lou pometto,
-PKSC,4040,1,Protective Packaging Prop/Prin,0.34,0.34,0.19,0.05,0.02,0.0,0.0,0.06,gregory batt,
-PKSC,4160,1,Appl Polymers in Pkg,0.13,0.49,0.35,0.03,0.0,0.0,0.0,0.0,tyler stuettgen,
-PKSC,4200,1,Pkg Design & Dev,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4540,1,Prod Pkg Evl Lab,0.13,0.73,0.07,0.07,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4540,2,Prod Pkg Evl Lab,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4540,3,Prod Pkg Evl Lab,0.21,0.57,0.14,0.0,0.0,0.0,0.0,0.07,gregory batt,
-PKSC,4540,4,Prod Pkg Evl Lab,0.25,0.31,0.31,0.0,0.0,0.0,0.0,0.13,gregory batt,
-PKSC,4640,1,Food & Health Care Pkg Systems,0.65,0.25,0.08,0.0,0.03,0.0,0.0,0.0,kay cooksey,
-PKSC,8170,1,Pckg Materials: Sci & Technol,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,duncan darby,
-PLPA,3100,1,Principles of Plant Pathology,0.34,0.38,0.24,0.03,0.0,0.0,0.0,0.0,steven nye jeffers,
-PLPA,6250,1,Introductory Mycology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,
-POSC,1010,1,Amer National Govt,0.15,0.33,0.34,0.13,0.02,0.0,0.0,0.02,joseph earl stewart,
-POSC,1010,2,Amer National Govt,0.21,0.44,0.21,0.06,0.06,0.0,0.0,0.02,jeffrey scott peake,
-POSC,1020,1,Intro Intl Relations,0.4,0.34,0.15,0.06,0.0,0.0,0.0,0.04,brandon mic stewart,
-POSC,1020,2,Intro Intl Relations,0.64,0.22,0.11,0.02,0.02,0.0,0.0,0.0,brandon mic stewart,
-POSC,1020,3,Intro Intl Relations,0.24,0.44,0.11,0.04,0.09,0.0,0.0,0.07,steven vince miller,
-POSC,1020,4,Intro Intl Relations,0.13,0.42,0.27,0.12,0.06,0.0,0.0,0.01,zeynep taydas,
-POSC,1020,5,Intro Intl Relations,0.18,0.41,0.23,0.1,0.05,0.0,0.0,0.04,zeynep taydas,
-POSC,1030,1,Intro to Political Theory,0.37,0.28,0.16,0.07,0.06,0.0,0.0,0.06,brandon turner,
-POSC,1030,2,Intro to Political Theory,0.17,0.61,0.11,0.06,0.0,0.0,0.0,0.06,colin pearce,
-POSC,1030,3,Intro to Political Theory,0.61,0.28,0.0,0.11,0.0,0.0,0.0,0.0,lorianne molinari,
-POSC,1040,1,Intro Compar Pol,0.45,0.35,0.13,0.02,0.04,0.0,0.0,0.02,brandon mic stewart,
-POSC,1040,2,Intro Compar Pol,0.18,0.42,0.16,0.13,0.05,0.0,0.0,0.05,katherine am curtis,
-POSC,1990,1,Intro Pol Sci,0.54,0.26,0.07,0.05,0.04,0.0,0.0,0.04,meredith petersheim,
-POSC,3020,1,State and Loc Gov,0.14,0.42,0.19,0.0,0.05,0.0,0.0,0.21,bruce ransom,
-POSC,3210,1,Public Admin,0.15,0.31,0.46,0.08,0.0,0.0,0.0,0.0,james woodard,
-POSC,3410,1,Quant Meth in Pol Sc,0.28,0.32,0.2,0.08,0.12,0.0,0.0,0.0,jeffrey allen fine,
-POSC,3610,1,International Conflict,0.3,0.19,0.19,0.11,0.09,0.0,0.0,0.13,steven vince miller,
-POSC,3630,1,Us Foreign Policy,0.37,0.54,0.07,0.0,0.0,0.0,0.0,0.02,vladimir matic,
-POSC,3710,1,European Politics,0.29,0.4,0.27,0.0,0.02,0.0,0.0,0.02,vladimir matic,
-POSC,4030,1,United States Congress,0.31,0.31,0.17,0.06,0.17,0.0,0.0,0.0,jeffrey allen fine,
-POSC,4070,1,Religion and Politic,0.16,0.42,0.32,0.06,0.0,0.0,0.0,0.03,laura olson,
-POSC,4210,1,Public Policy,0.19,0.31,0.25,0.06,0.13,0.0,0.0,0.06,adam warber,
-POSC,4360,1,Law Courts Politics,0.88,0.08,0.02,0.0,0.0,0.0,0.0,0.02,joseph earl stewart,
-POSC,4380,1,Constitut Law: Struc of Gov,0.32,0.5,0.12,0.02,0.04,0.0,0.0,0.0,daniel frost,
-POSC,4420,1,Pol Parties & Elect,0.25,0.36,0.23,0.16,0.0,0.0,0.0,0.0,laura olson,
-POSC,4470,1,International Law,0.33,0.3,0.13,0.1,0.08,0.0,0.0,0.08,katherine am curtis,
-POSC,4500,1,Contemporary Political Thought,0.42,0.46,0.04,0.0,0.04,0.0,0.0,0.04,daniel frost,
-POSC,4540,1,Southern Politics,0.11,0.5,0.33,0.0,0.0,0.0,0.0,0.06,james woodard,
-POSC,4550,1,Pol Thght of American Founding,0.29,0.5,0.18,0.0,0.03,0.0,0.0,0.0, bradley thompson,
-POSC,4560,1,Diplomacy,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
-PRTM,1950,2,Pro Golf Management Seminar I,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.92,0.06,0.03,jamie lynn cathey,
-PRTM,2200,10,Foundations of PRTM,0.32,0.42,0.12,0.02,0.03,0.0,0.0,0.08,jamie lynn cathey,
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2260,2,Fnd of Mgt Adm PRTM,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
-PRTM,2260,3,Fnd of Mgt Adm PRTM,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2260,4,Fnd of Mgt Adm PRTM,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2260,5,Fnd of Mgt Adm PRTM,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,garrett stone,
-PRTM,2260,6,Fnd of Mgt Adm PRTM,0.21,0.5,0.21,0.07,0.0,0.0,0.0,0.0,ryan joseph gagnon,
-PRTM,2260,7,Fnd of Mgt Adm PRTM,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,brandon harris,
-PRTM,2260,8,Fnd of Mgt Adm PRTM,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,
-PRTM,2260,9,Fnd of Mgt Adm PRTM,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,katrina latri black,
-PRTM,2270,1,Prov of Leisure Exp,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2270,2,Prov of Leisure Exp,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
-PRTM,2270,3,Prov of Leisure Exp,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2270,4,Prov of Leisure Exp,0.0,0.43,0.21,0.29,0.07,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2270,5,Prov of Leisure Exp,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,garrett stone,
-PRTM,2270,6,Prov of Leisure Exp,0.29,0.21,0.36,0.07,0.07,0.0,0.0,0.0,ryan joseph gagnon,
-PRTM,2270,7,Prov of Leisure Exp,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,brandon harris,
-PRTM,2270,8,Prov of Leisure Exp,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,
-PRTM,2270,9,Prov of Leisure Exp,0.36,0.36,0.21,0.0,0.0,0.0,0.0,0.07,emilie viktor adams,
-PRTM,2290,1,Competency Integration in PRTM,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2290,2,Competency Integration in PRTM,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
-PRTM,2290,3,Competency Integration in PRTM,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2290,4,Competency Integration in PRTM,0.29,0.14,0.43,0.07,0.07,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2290,5,Competency Integration in PRTM,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,garrett stone,
-PRTM,2290,6,Competency Integration in PRTM,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,ryan joseph gagnon,
-PRTM,2290,7,Competency Integration in PRTM,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,brandon harris,
-PRTM,2290,8,Competency Integration in PRTM,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,
-PRTM,2290,9,Competency Integration in PRTM,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,emilie viktor adams,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.63,0.29,0.05,0.03,0.0,0.0,0.0,0.0,katherine an jordan,
-PRTM,3070,2,Facility Operations,0.84,0.09,0.0,0.03,0.03,0.0,0.0,0.0,raymond dunham,
-PRTM,3200,1,Recreation Policy,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,matthew ty brownlee,
-PRTM,3210,1,Recreation Admin,0.26,0.51,0.2,0.0,0.03,0.0,0.0,0.0,gina depper,
-PRTM,3220,1,Facilitation Techniques in RT,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,
-PRTM,3230,1,Prof Prep for RT Practice,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,
-PRTM,3240,1,Assessment & Planning in RT,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3250,1,Global Persp in Rec,0.54,0.35,0.0,0.04,0.0,0.0,0.0,0.08,harrison pinckney,
-PRTM,3300,1,Visit Ser & Interp,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,3420,2,Intro to Tourism,0.52,0.21,0.12,0.06,0.09,0.0,0.0,0.0,herbert chancellor,
-PRTM,3430,1,Spl Asp of Tourist B,0.4,0.51,0.09,0.0,0.0,0.0,0.0,0.0,william norman,
-PRTM,3430,2,Spl Asp of Tourist B,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,'lisha fogle,
-PRTM,3470,1,Sport Tourism,0.47,0.21,0.32,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,
-PRTM,3900,7,Independent Study in PRTM,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3910,1,Social Media in PRTM,0.4,0.52,0.0,0.08,0.0,0.0,0.0,0.0,zeynep gedikoglu,
-PRTM,3910,2,Issues & Trends in Event Mgmt.,0.92,0.0,0.08,0.0,0.0,0.0,0.0,0.0,stephanie per garst,
-PRTM,3920,1,Special Event Management,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,
-PRTM,3920,2,Special Event Management,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,
-PRTM,4030,1,Elem of Rec/Pk Plan,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,gina depper,
-PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,daniel mor anderson,
-PRTM,4210,1,Rec Fin Resc Mgt,0.11,0.26,0.42,0.21,0.0,0.0,0.0,0.0,denise mar anderson,
-PRTM,4220,1,Management of RT Services,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,
-PRTM,4470,1,Perspect Intl Travel,0.82,0.16,0.03,0.0,0.0,0.0,0.0,0.0,lauren duffy,
-PRTM,4510,1,Seminar in CRSCM,0.5,0.33,0.11,0.06,0.0,0.0,0.0,0.0,skye arthur-banning,
-PRTM,4550,1,Adv Program Planning,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,mariela fernandez,
-PRTM,4740,2,Adv Rec Resource Mgt,0.95,0.0,0.0,0.0,0.05,0.0,0.0,0.0,geoffrey koo riungu,
-PRTM,8020,1,Group Proc in Leisure Services,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,
-PRTM,8080,2,Behavioral Aspects,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,8220,2,Strateg Planning in PRTM Orgs,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,thomas john orourke,
-PRTM,8700,1,Foundat & Issues in Rec Therap,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,alysha amber walter,
-PRTM,8710,1,Applied Research in Rec Therap,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
-PSYC,2010,1,Intro to Psychology,0.49,0.31,0.12,0.04,0.0,0.0,0.0,0.04,jo anne jorgensen,
-PSYC,2010,2,Intro to Psychology,0.42,0.35,0.13,0.06,0.01,0.0,0.0,0.03,jo anne jorgensen,
-PSYC,2010,3,Intro to Psychology,0.35,0.32,0.18,0.05,0.04,0.0,0.0,0.06,edwin brainerd,
-PSYC,2010,4,Intro to Psychology,0.57,0.2,0.13,0.04,0.03,0.0,0.0,0.03,chong hyon pak,
-PSYC,2010,5,Intro to Psychology,0.34,0.43,0.17,0.04,0.0,0.0,0.0,0.01,mary taylor,
-PSYC,2010,6,Intro to Psychology (HON),0.63,0.21,0.05,0.05,0.0,0.0,0.0,0.05,robin mari kowalski,True
-PSYC,2020,2,Intro Psychology Lab,0.91,0.0,0.0,0.04,0.0,0.0,0.0,0.04,anton sytine,
-PSYC,2890,1,Fundamentals of Psyc Science,0.39,0.31,0.2,0.05,0.01,0.0,0.0,0.03,cynthia pury,
-PSYC,3060,1,Human Sexual Behavior,0.44,0.28,0.16,0.04,0.06,0.0,0.0,0.02,bruce michael king,
-PSYC,3090,100,Intro Experimental Psychology,0.33,0.28,0.21,0.13,0.03,0.0,0.0,0.03,richard tyrrell,
-PSYC,3090,200,Intro Experimental Psychology,0.45,0.32,0.13,0.06,0.03,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3090,300,Intro Experimental Psychology,0.67,0.2,0.03,0.07,0.0,0.0,0.0,0.03,leah hartman,
-PSYC,3100,100,Advanced Experimental Psych,0.38,0.38,0.19,0.05,0.0,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimental Psych,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert campbell,
-PSYC,3100,300,Advanced Experimental Psych,0.35,0.45,0.05,0.05,0.05,0.0,0.0,0.05,gargi sawhney,
-PSYC,3100,400,Advanced Experimental Psych,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,3100,500,Advanced Experimental Psych,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3240,1,Physiological Psych,0.3,0.35,0.16,0.07,0.06,0.0,0.0,0.06,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.28,0.32,0.26,0.07,0.03,0.0,0.0,0.04,june pilcher,
-PSYC,3310,1,Critical Thinking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,leo gugerty,
-PSYC,3330,1,Cognitive Psych,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,robert campbell,
-PSYC,3330,2,Cognitive Psych,0.39,0.26,0.2,0.09,0.03,0.0,0.0,0.03,kaileigh ange byrne,
-PSYC,3330,3,Cognitive Psych,0.36,0.33,0.23,0.04,0.03,0.0,0.0,0.0,madison eliza sauls,
-PSYC,3340,1,Cognitive Psych Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3340,2,Cognitive Psych Lab,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,leo gugerty,
-PSYC,3400,1,Lifespan Developmental Psych,0.6,0.28,0.09,0.03,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3400,2,Lifespan Developmental Psych,0.21,0.4,0.25,0.07,0.0,0.0,0.0,0.07,pamela alley,
-PSYC,3520,1,Social Psychology,0.41,0.25,0.21,0.06,0.02,0.0,0.0,0.05,eric mckibben,
-PSYC,3640,1,Industrial Psych,0.34,0.49,0.14,0.03,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,3640,2,Industrial Psych,0.26,0.43,0.26,0.03,0.01,0.0,0.0,0.0,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.27,0.31,0.3,0.1,0.01,0.0,0.0,0.0,thomas britt,
-PSYC,3680,2,Organizational Psych,0.3,0.36,0.2,0.06,0.04,0.0,0.0,0.03,dana verhoeven,
-PSYC,3690,1,Leadership in Organiz Settings,0.29,0.33,0.21,0.08,0.02,0.0,0.0,0.06,patrick raymark,
-PSYC,3700,1,Personality,0.31,0.5,0.15,0.01,0.0,0.0,0.0,0.03,eric mckibben,
-PSYC,3700,2,Personality,0.28,0.41,0.23,0.04,0.0,0.0,0.0,0.04,john robert hester,
-PSYC,3830,1,Abnormal Psychology,0.43,0.33,0.12,0.03,0.04,0.0,0.0,0.04,heidi marie zinzow,
-PSYC,3830,2,Abnormal Psychology,0.34,0.55,0.06,0.0,0.02,0.0,0.0,0.02,lucinda sorci quick,
-PSYC,3830,3,Abnormal Psychology,0.29,0.43,0.2,0.06,0.0,0.0,0.0,0.03,pamela alley,
-PSYC,3830,4,Abnormal Psychology,0.16,0.34,0.13,0.16,0.13,0.0,0.0,0.09,pamela alley,
-PSYC,3890,1,Cross-Cultural Psychology,0.62,0.21,0.07,0.0,0.1,0.0,0.0,0.0,ceren gunsoy,
-PSYC,4080,1,Women and Psychology,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,robin mari kowalski,
-PSYC,4150,2,Systems and Theories,0.29,0.41,0.09,0.09,0.12,0.0,0.0,0.0,edwin brainerd,
-PSYC,4150,3,Systems and Theories,0.44,0.24,0.09,0.12,0.03,0.0,0.0,0.09,edwin brainerd,
-PSYC,4220,1,Perception,0.36,0.16,0.2,0.08,0.12,0.0,0.0,0.08,claudio cantalupo,
-PSYC,4220,2,Perception,0.27,0.35,0.31,0.04,0.0,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4220,3,Perception,0.22,0.33,0.19,0.19,0.04,0.0,0.0,0.04,christopher pagano,
-PSYC,4220,4,Perception,0.36,0.28,0.2,0.08,0.0,0.0,0.0,0.08,christopher pagano,
-PSYC,4350,1,Human Factors,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,laura whitlock,
-PSYC,4350,2,Human Factors,0.42,0.42,0.05,0.05,0.05,0.0,0.0,0.0,laura whitlock,
-PSYC,4560,1,Psychophysiology,0.39,0.28,0.28,0.06,0.0,0.0,0.0,0.0,drew michael morris,
-PSYC,4800,1,Health Psychology,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,james mccubbin,
-PSYC,4800,2,Health Psychology,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,
-PSYC,4890,1,Teamwork Dynamics,0.88,0.04,0.04,0.0,0.04,0.0,0.0,0.0,marissa leig porter,
-PSYC,4920,1,Senior Laboratory,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,
-PSYC,4920,2,Senior Laboratory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,
-PSYC,4920,3,Senior Laboratory,0.89,0.04,0.04,0.0,0.04,0.0,0.0,0.0,nastassia ma savage,
-PSYC,4920,5,Senior Laboratory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,drea kevin fekety,
-PSYC,8100,1,Research Design I,0.65,0.27,0.05,0.0,0.0,0.0,0.0,0.03,patrick rosopa,
-PSYC,8620,1,Org Psychology,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,
-PSYC,8730,1,SEM in Applied Psychology,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, dewayne moore,
-RED,8000,1,Real Estate Dvlpment,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-RED,8010,1,Market Analysis,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,thomas andrew fox,
-RED,8040,1,Resid Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-RED,8050,1,Commercial Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-RED,8130,1,Strat in Real Estate,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,
-RED,8170,1,Mixed-Use Development Seminar,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,tor wallace-babcock,
-RED,8890,1,Selected Topics-Adv. Fin. Mod.,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,larry bradle harvey,
-REL,1010,1,Intro to Religion,0.22,0.33,0.22,0.17,0.0,0.0,0.0,0.06,peter cohen,
-REL,1010,2,Intro to Religion,0.34,0.26,0.23,0.06,0.03,0.0,0.0,0.09,peter cohen,
-REL,1010,3,Intro to Religion,0.29,0.51,0.11,0.0,0.0,0.0,0.0,0.09,brett patterson,
-REL,1010,4,Intro to Religion,0.29,0.47,0.0,0.18,0.06,0.0,0.0,0.0,peter cohen,
-REL,1010,5,Intro to Religion,0.17,0.51,0.14,0.03,0.03,0.0,0.0,0.11,brett patterson,
-REL,1020,2,World Religions,0.4,0.43,0.14,0.0,0.0,0.0,0.0,0.03,robert stephens,
-REL,1020,3,World Religions,0.35,0.5,0.12,0.03,0.0,0.0,0.0,0.0,robert stephens,
-REL,1020,4,World Religions,0.2,0.6,0.14,0.03,0.03,0.0,0.0,0.0,robert stephens,
-REL,1020,5,World Religions,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,brett patterson,
-REL,3010,1,Old Testament,0.42,0.48,0.09,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3020,1,New Testament Lit,0.47,0.38,0.03,0.0,0.03,0.0,0.0,0.09,benjamin white,
-REL,3080,1,Religions of the Ancient World,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3100,1,History of Religion in the US,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,elizabeth jemison,
-REL,3150,1,Islam,0.53,0.27,0.07,0.0,0.13,0.0,0.0,0.0,robert stephens,
-REL,4520,1,History of Early Christianity,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,benjamin white,
-RS,3010,1,Rural Sociology,0.53,0.37,0.0,0.05,0.0,0.0,0.0,0.05,kenneth robinson,
-RS,4590,1,The Community,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
-RUSS,1010,1,Elementary Russian,0.5,0.31,0.06,0.06,0.0,0.0,0.0,0.06,stephanie el morris,
-RUSS,1010,2,Elementary Russian,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,stephanie el morris,
-RUSS,3400,1,19th C Russ Culture,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,olga anatol volkova,
-RUSS,3610,1,Russn Lit Since 1910,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,
-SOC,2010,2,Introduction to Sociology,0.94,0.04,0.01,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,
-SOC,2010,3,Introduction to Sociology,0.79,0.18,0.02,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,
-SOC,2010,4,Introduction to Sociology,0.53,0.34,0.13,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,5,Introduction to Sociology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,stacy leanne smith,
-SOC,2010,6,Introduction to Sociology,0.81,0.15,0.02,0.0,0.0,0.0,0.0,0.02,stacy leanne smith,
-SOC,2010,7,Introduction to Sociology,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,stacy leanne smith,
-SOC,2010,8,Introduction to Sociology,0.8,0.12,0.04,0.02,0.0,0.0,0.0,0.02,stacy leanne smith,
-SOC,2010,9,Introduction to Sociology,0.36,0.41,0.16,0.04,0.0,0.0,0.0,0.03,carolyn can coffman,
-SOC,2010,10,Introduction to Sociology,0.53,0.39,0.05,0.01,0.0,0.0,0.0,0.01,carolyn can coffman,
-SOC,2010,11,Introduction to Sociology,0.48,0.41,0.05,0.05,0.02,0.0,0.0,0.0,carolyn can coffman,
-SOC,2010,12,Introduction to Sociology,0.69,0.22,0.06,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,13,Introduction to Sociology,0.71,0.23,0.02,0.01,0.02,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,14,Introduction to Sociology,0.6,0.25,0.08,0.0,0.02,0.0,0.0,0.04,shannon mcdonough,
-SOC,2020,1,Social Problems,0.51,0.4,0.02,0.0,0.02,0.0,0.0,0.04,carolyn can coffman,
-SOC,3020,1,Research Methods I,0.44,0.26,0.23,0.05,0.02,0.0,0.0,0.0,andrew whitehead,
-SOC,3040,1,Social Research Methods II,0.32,0.45,0.14,0.09,0.0,0.0,0.0,0.0,ye luo,
-SOC,3110,1,The Family,0.3,0.53,0.15,0.0,0.02,0.0,0.0,0.0,andrew whitehead,
-SOC,3310,1,Urban Sociology,0.87,0.03,0.05,0.0,0.05,0.0,0.0,0.0,william haller,
-SOC,3910,1,Soc of Deviance,0.34,0.32,0.26,0.06,0.02,0.0,0.0,0.0,shannon mcdonough,
-SOC,3920,1,Juvenile Delinquency,0.76,0.15,0.06,0.0,0.0,0.0,0.0,0.03,angelia turner,
-SOC,3940,1,Sociology of Mental Illness,0.6,0.3,0.06,0.0,0.02,0.0,0.0,0.02,douglas sturkie,
-SOC,4040,1,Soc Theory,0.31,0.26,0.17,0.17,0.03,0.0,0.0,0.06,stacy leanne smith,
-SOC,4140,1,Policy&Social Change,0.54,0.3,0.16,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,4330,1,Global Social Change,0.41,0.41,0.17,0.0,0.0,0.0,0.0,0.0,traci ann hefner,
-SOC,4440,1,Sociology of Educ,0.61,0.26,0.1,0.0,0.03,0.0,0.0,0.0,andrew mannheimer,
-SOC,4590,1,The Community,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
-SOC,4600,1,Race & Ethnicity,0.91,0.07,0.0,0.0,0.02,0.0,0.0,0.0,william haller,
-SOC,4610,1,Sex & Gender,0.43,0.41,0.13,0.0,0.0,0.0,0.0,0.02,traci ann hefner,
-SOC,4970,1,Senior Lab,0.71,0.26,0.0,0.03,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,8030,1,Sur Dsgn App Res Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,
-SPAN,1010,1,Elementary Spanish,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,scott harris,
-SPAN,1010,2,Elementary Spanish,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1010,3,Elementary Spanish,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1020,1,Elementary Spanish,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1020,2,Elementary Spanish,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
-SPAN,1020,3,Elementary Spanish,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
-SPAN,1020,4,Elementary Spanish,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,1020,5,Elementary Spanish,0.67,0.06,0.11,0.06,0.0,0.0,0.0,0.11,danie garcia vieyra,
-SPAN,1020,6,Elementary Spanish,0.24,0.41,0.24,0.06,0.06,0.0,0.0,0.0,cathy robison,
-SPAN,1020,7,Elementary Spanish,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,1020,8,Elementary Spanish,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,1020,10,Elementary Spanish,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,1020,11,Elementary Spanish,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,1020,12,Elementary Spanish,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,1020,13,Elementary Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2010,1,Intermediate Spanish,0.41,0.35,0.18,0.06,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,2,Intermediate Spanish,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,3,Intermediate Spanish,0.47,0.18,0.12,0.12,0.0,0.0,0.0,0.12,melva margu persico,
-SPAN,2010,4,Intermediate Spanish,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,2010,5,Intermediate Spanish,0.81,0.0,0.06,0.0,0.06,0.0,0.0,0.06,danie garcia vieyra,
-SPAN,2010,6,Intermediate Spanish,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,danie garcia vieyra,
-SPAN,2010,7,Intermediate Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,2010,8,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,2010,9,Intermediate Spanish,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,william da holcombe,
-SPAN,2010,10,Intermediate Spanish,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,11,Intermediate Spanish,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
-SPAN,2010,12,Intermediate Spanish,0.68,0.05,0.21,0.05,0.0,0.0,0.0,0.0,al garcia rodriguez,
-SPAN,2010,13,Intermediate Spanish,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,
-SPAN,2010,14,Intermediate Spanish,0.5,0.31,0.13,0.0,0.0,0.0,0.0,0.06,maureen zamora,
-SPAN,2010,15,Intermediate Spanish,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william da holcombe,
-SPAN,2010,16,Intermediate Spanish,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,ellory schmucker,
-SPAN,2010,17,Intermediate Spanish,0.79,0.07,0.0,0.07,0.0,0.0,0.0,0.07,ze cruz valderramos,
-SPAN,2010,19,Intermediate Spanish,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
-SPAN,2020,1,Intermediate Spanish,0.25,0.56,0.13,0.0,0.06,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,2,Intermediate Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,3,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,4,Intermediate Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,5,Intermediate Spanish,0.39,0.44,0.11,0.06,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2020,6,Intermediate Spanish,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,ze cruz valderramos,
-SPAN,2020,7,Intermediate Spanish,0.71,0.06,0.18,0.06,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2020,8,Intermediate Spanish,0.37,0.32,0.21,0.05,0.0,0.0,0.0,0.05,ana paula  miller,
-SPAN,2020,9,Intermediate Spanish,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,10,Intermediate Spanish,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,11,Intermediate Spanish,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,ze cruz valderramos,
-SPAN,2020,12,Intermediate Spanish,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
-SPAN,2020,13,Intermediate Spanish,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,nora arostegu logue,
-SPAN,2020,14,Intermediate Spanish,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
-SPAN,3020,1,Int Spn Gram & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,3020,2,Int Spn Gram & Comp,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,melva margu persico,
-SPAN,3040,1,Intro Hisp Lit Forms,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-SPAN,3050,1,Int Con Comp Span I,0.29,0.29,0.24,0.06,0.0,0.0,0.0,0.12,juana martin-armas,
-SPAN,3050,2,Int Con Comp Span I,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,juana martin-armas,
-SPAN,3050,3,Int Con Comp Span I,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,raquel anido,
-SPAN,3050,4,Int Con Comp Span I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,
-SPAN,3060,1,Span Comp for Bus,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,3070,1,Hispanic World: Sp,0.53,0.37,0.0,0.05,0.05,0.0,0.0,0.0,salvador oropesa,
-SPAN,3070,2,Hispanic World: Sp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,
-SPAN,3080,1,Hispanic World: La,0.19,0.5,0.19,0.06,0.06,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,3110,1,Surv Span-Amer Lit,0.38,0.38,0.08,0.0,0.0,0.0,0.0,0.15,tiffany dawn miller,
-SPAN,3130,2,Span Lit Survey I,0.38,0.38,0.08,0.0,0.08,0.0,0.0,0.08,mon rojas-de-massei,
-SPAN,4030,1,Span Amer Wom Writer,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-STAT,2220,1,Statistics in Everyday Life,0.33,0.37,0.21,0.06,0.02,0.0,0.0,0.01,james espey,
-STAT,2220,2,Statistics in Everyday Life,0.41,0.32,0.17,0.06,0.01,0.0,0.0,0.03,james espey,
-STAT,2220,3,Statistics in Everyday Life,0.34,0.41,0.16,0.06,0.01,0.0,0.0,0.02,james espey,
-STAT,2220,4,Statistics in Everyday Life,0.43,0.31,0.09,0.08,0.06,0.0,0.0,0.03,james espey,
-STAT,2220,5,Statistics in Everyday Life,0.25,0.34,0.27,0.02,0.04,0.0,0.0,0.07,ros martinez-dawson,
-STAT,2220,6,Statistics in Everyday Life,0.42,0.42,0.05,0.0,0.05,0.0,0.0,0.05,jason alexande kurz,
-STAT,2220,7,Statistics in Everyday Life,0.26,0.47,0.16,0.11,0.0,0.0,0.0,0.0,jason alexande kurz,
-STAT,2220,100,Stats in Everyday Life (HON),0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ros martinez-dawson,True
-STAT,2300,1,Statistical Methods I,0.28,0.37,0.18,0.09,0.05,0.0,0.0,0.03,christy jenki brown,
-STAT,2300,2,Statistical Methods I,0.38,0.34,0.13,0.05,0.06,0.0,0.0,0.04,christy jenki brown,
-STAT,2300,3,Statistical Methods I,0.27,0.33,0.21,0.08,0.06,0.0,0.0,0.05, erwin walker,
-STAT,2300,4,Statistical Methods I,0.25,0.45,0.14,0.07,0.05,0.0,0.0,0.04, erwin walker,
-STAT,2300,5,Statistical Methods I,0.24,0.32,0.28,0.05,0.06,0.0,0.0,0.05,william bridges,
-STAT,2300,6,Statistical Methods I,0.18,0.38,0.18,0.09,0.09,0.0,0.0,0.07,william bridges,
-STAT,2300,100,Statistical Methods I (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christy jenki brown,True
-STAT,3090,1,Introductory Business Stats,0.37,0.26,0.26,0.0,0.05,0.0,0.0,0.05,todd fenstermacher,
-STAT,3090,2,Introductory Business Stats,0.22,0.33,0.11,0.17,0.11,0.0,0.0,0.06,todd fenstermacher,
-STAT,3090,3,Introductory Business Stats,0.16,0.37,0.16,0.11,0.21,0.0,0.0,0.0,boyoung hur,
-STAT,3090,4,Introductory Business Stats,0.05,0.32,0.16,0.11,0.32,0.0,0.0,0.05,boyoung hur,
-STAT,3090,5,Introductory Business Stats,0.05,0.26,0.26,0.16,0.21,0.0,0.0,0.05,andrew pangia,
-STAT,3090,6,Introductory Business Stats,0.11,0.33,0.39,0.0,0.11,0.0,0.0,0.06,andrew pangia,
-STAT,3090,7,Introductory Business Stats,0.22,0.33,0.22,0.06,0.17,0.0,0.0,0.0,tiantian yang,
-STAT,3090,8,Introductory Business Stats,0.17,0.28,0.22,0.22,0.11,0.0,0.0,0.0,april thomas,
-STAT,3090,9,Introductory Business Stats,0.11,0.11,0.26,0.11,0.26,0.0,0.0,0.16,feng gao,
-STAT,3090,10,Introductory Business Stats,0.17,0.28,0.33,0.11,0.06,0.0,0.0,0.06,bryce pruitt,
-STAT,3090,11,Introductory Business Stats,0.26,0.16,0.26,0.16,0.16,0.0,0.0,0.0,yisu jia,
-STAT,3090,12,Introductory Business Stats,0.37,0.37,0.16,0.0,0.0,0.0,0.0,0.11,lu sun,
-STAT,3090,13,Introductory Business Stats,0.34,0.3,0.18,0.09,0.06,0.0,0.0,0.03,sharon marie evans,
-STAT,3090,14,Introductory Business Stats,0.5,0.22,0.28,0.0,0.0,0.0,0.0,0.0,kayla doris javier,
-STAT,3090,15,Introductory Business Stats,0.19,0.22,0.34,0.05,0.14,0.0,0.0,0.05,matthew saltzman,
-STAT,3090,16,Introductory Business Stats,0.39,0.28,0.17,0.06,0.11,0.0,0.0,0.0,jiajing niu,
-STAT,3090,18,Introductory Business Stats,0.05,0.58,0.26,0.05,0.05,0.0,0.0,0.0,bryce pruitt,
-STAT,3090,19,Introductory Business Stats,0.16,0.26,0.47,0.0,0.0,0.0,0.0,0.11,rui gong,
-STAT,3090,20,Introductory Business Stats,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,jiajing niu,
-STAT,3090,22,Introductory Business Stats,0.16,0.42,0.16,0.05,0.05,0.0,0.0,0.16,tiantian yang,
-STAT,3090,23,Introductory Business Stats,0.26,0.32,0.11,0.16,0.05,0.0,0.0,0.11,tianhui wei,
-STAT,3090,24,Introductory Business Stats,0.11,0.37,0.26,0.05,0.05,0.0,0.0,0.16,tianhui wei,
-STAT,3090,25,Introductory Business Stats,0.26,0.37,0.16,0.16,0.0,0.0,0.0,0.05,liu zhu,
-STAT,3090,26,Introductory Business Stats,0.26,0.21,0.16,0.16,0.21,0.0,0.0,0.0,april thomas,
-STAT,3090,27,Introductory Business Stats,0.26,0.11,0.16,0.21,0.16,0.0,0.0,0.11,feng gao,
-STAT,3090,28,Introductory Business Stats,0.33,0.56,0.0,0.06,0.0,0.0,0.0,0.06,lu sun,
-STAT,3090,30,Introductory Business Stats,0.53,0.26,0.05,0.11,0.05,0.0,0.0,0.0,liu zhu,
-STAT,3090,31,Introductory Business Stats,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,kayla doris javier,
-STAT,3090,33,Introductory Business Stats,0.28,0.25,0.32,0.05,0.08,0.0,0.0,0.02,sharon marie evans,
-STAT,3090,34,Introductory Business Stats,0.32,0.32,0.16,0.05,0.11,0.0,0.0,0.05,rui gong,
-STAT,3090,35,Introductory Business Stats,0.3,0.21,0.39,0.06,0.0,0.0,0.0,0.03,margaret mar wiecek,
-STAT,3090,36,Introductory Business Stats,0.17,0.24,0.36,0.17,0.0,0.0,0.0,0.07,matthew saltzman,
-STAT,3090,37,Introductory Business Stats,0.26,0.16,0.47,0.0,0.05,0.0,0.0,0.05,yisu jia,
-STAT,3300,1,Statistical Methods II,0.38,0.44,0.06,0.0,0.06,0.0,0.0,0.06,ros martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,ellen hepfe breazel,
-STAT,4110,1,Stat Mthds for Process Control,0.82,0.11,0.05,0.0,0.02,0.0,0.0,0.0,richard stev dubsky,
-STAT,4110,2,Stat Mthds for Process Control,0.85,0.12,0.02,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,
-STAT,4110,3,Stat Mthds for Process Control,0.64,0.27,0.06,0.03,0.0,0.0,0.0,0.0,richard stev dubsky,
-STAT,6020,1,Intro to Statistical Computing,0.33,0.25,0.08,0.0,0.0,0.0,0.0,0.33,ellen hepfe breazel,
-STAT,8010,1,Statistical Methods I,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,james rieck,
-STAT,8010,2,Statistical Methods I,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,patrick gerard,
-STAT,8010,3,Statistical Methods I,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,joseph daniel bible,
-STAT,8010,4,Statistical Methods I,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,
-STAT,8010,5,Statistical Methods I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jun luo,
-STAT,8010,6,Statistical Methods I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,brook thaye russell,
-STAT,8010,7,Statistical Methods I,0.44,0.33,0.17,0.0,0.06,0.0,0.0,0.0,james rieck,
-STAT,8020,1,Statistical Methods II,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,brook thaye russell,
-STAT,8030,1,Regress & Least Squares Anlys,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,jun luo,
-STAT,8170,400,Multivariate Statistics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-STS,1010,1,Survey of S T S,0.68,0.27,0.0,0.0,0.03,0.0,0.0,0.03,kenneth dav widgren,
-STS,1010,2,Survey of S T S,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,scott brame,
-STS,1010,3,Survey of S T S,0.51,0.32,0.03,0.0,0.05,0.0,0.0,0.08,elizabeth stansell,
-STS,1010,5,Survey of S T S,0.47,0.39,0.14,0.0,0.0,0.0,0.0,0.0,philip randall,
-STS,1010,6,Survey of S T S,0.4,0.23,0.17,0.09,0.0,0.0,0.0,0.11,sarah mae cooper,
-STS,1010,7,Survey of S T S,0.5,0.14,0.28,0.0,0.06,0.0,0.0,0.03,megan no macalystre,
-STS,1010,8,Survey of S T S,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,david charles foltz,
-STS,1010,9,Survey of S T S,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-THEA,2100,1,Theatre Appreciation,0.53,0.19,0.16,0.0,0.03,0.0,0.0,0.09,kendra lyne johnson,
-THEA,2100,2,Theatre Appreciation,0.81,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kerrie kath seymour,
-THEA,2100,3,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,
-THEA,2100,4,Theatre Appreciation,0.81,0.13,0.03,0.03,0.0,0.0,0.0,0.0,richard st. peter,
-THEA,2100,5,Theatre Appreciation,0.81,0.13,0.03,0.0,0.0,0.0,0.0,0.03,carol collins,
-THEA,2100,6,Theatre Appreciation,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,
-THEA,2100,7,Theatre Appreciation,0.53,0.28,0.13,0.0,0.0,0.0,0.0,0.06,jason adkins,
-THEA,2670,1,Stage Makeup,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
-THEA,2790,1,Theatre Practicum,0.38,0.25,0.0,0.0,0.06,0.0,0.0,0.31,matthew leckenbusch,
-THEA,2880,1,Intro to Cad,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
-THEA,3150,1,Theatre History I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,richard st. peter,
-THEA,3170,1,African-Amer Thea I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,3470,1,Structure of Drama,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
-THEA,3980,1,Special Topics in Theatre,0.57,0.21,0.14,0.0,0.0,0.0,0.0,0.07,kerrie kath seymour,
-THEA,4870,1,Stage Lighting I,0.33,0.42,0.08,0.0,0.08,0.0,0.0,0.08,anthony penna,
-WFB,3000,1,Wildlife Biology,0.48,0.27,0.17,0.03,0.02,0.0,0.0,0.03,catherine jachowski,
-WFB,3000,2,Wildlife Biology,0.45,0.35,0.14,0.02,0.01,0.0,0.0,0.02,catherine jachowski,
-WFB,3010,2,Wildlife Biology Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,4100,2,Wildlife Management Techniques,0.25,0.54,0.13,0.07,0.0,0.0,0.0,0.02,james davis,
-WFB,4180,1,Fisheries Mgt & Conservation,0.67,0.19,0.11,0.0,0.0,0.0,0.0,0.04,troy mason farmer,
-WFB,4440,1,Wildlife Damage Management,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,james davis,
-WFB,4720,1,Ornithology,0.42,0.25,0.17,0.08,0.0,0.0,0.0,0.08,neil smith,
-WFB,4770,1,Ichthyology,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,brandon kev peoples,
-WFB,4930,2,Plant & Flora ID/Systematics,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,patrick mcmillan,
-WFB,4930,3,Waterfowl Ecology,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
-WFB,8180,2,Waterfowl Ecology & Mgt,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
-WFB,8530,2,Global Change Ecology,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,lydia ri 'halloran,
-WS,1030,1,Women in Global Perspective,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,laura foxworth,
-WS,1030,2,Women in Global Perspective,0.67,0.13,0.1,0.07,0.0,0.0,0.0,0.03,laura foxworth,
-WS,2300,1,Women and Leadership I,0.68,0.16,0.08,0.0,0.04,0.0,0.0,0.04,mary price,
-WS,3010,1,Intro Women's Studies,0.58,0.35,0.03,0.0,0.03,0.0,0.0,0.0,elizabeth ros adams,
-WS,3010,2,Intro Women's Studies,0.48,0.41,0.03,0.0,0.0,0.0,0.0,0.07,elizabeth ros adams,
-YDP,3000,400,Youth Development in Society,0.54,0.33,0.0,0.08,0.04,0.0,0.0,0.0,barry garst,
-YDP,3050,400,Theory/Phil of Youth Dev Work,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,edmond patri bowers,
-YDP,3200,1,Youth Dev in Sport/Phys Activ,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,lauren eli stephens,
-YDP,3300,1,Designing Effective Youth Prog,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,kellye rembert,
-YDP,3350,1,Youth Activity Leadership,0.5,0.17,0.17,0.11,0.06,0.0,0.0,0.0,allison mic avishai,
-YDP,3450,1,Creative Activities for Youth,0.87,0.0,0.09,0.04,0.0,0.0,0.0,0.0,kimberly pe johnson,
-YDP,8000,1,Theories of Youth Development,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
-YDP,8030,1,Creative & Ethical Leadership,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,barry garst,
-YDP,8050,1,Youth Dev in Context of Family,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
-YDP,8060,1,Youth Dev in Global Society,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,ann marie gillard,
-YDP,8060,2,Youth Dev in Global Society,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,ann marie gillard,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1010,1,Survey of Art & Arch History I,0.4,0.45,0.1,0.0,0.01,0.0,0.0,0.05,beth ann lauritis,,AAH-1010,2017
+AAH,1010,2,Surv of Art & Arch I (HON),0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,beth ann lauritis,True,AAH-1010,2017
+AAH,2050,1,Art History and Theory I,0.79,0.15,0.0,0.0,0.06,0.0,0.0,0.0,beth ann lauritis,,AAH-2050,2017
+AAH,3050,1,Contemporary Art History,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,,AAH-3050,2017
+ACCT,2010,1,Financial Accounting Concepts,0.18,0.35,0.2,0.12,0.08,0.0,0.0,0.06,emily suza mccorkle,,ACCT-2010,2017
+ACCT,2010,2,Financial Accounting Concepts,0.21,0.44,0.25,0.04,0.04,0.0,0.0,0.02,emily suza mccorkle,,ACCT-2010,2017
+ACCT,2010,3,Financial Accounting Concepts,0.3,0.43,0.11,0.04,0.04,0.0,0.0,0.09,lydia lan schleifer,,ACCT-2010,2017
+ACCT,2010,4,Financial Accounting Concepts,0.28,0.33,0.22,0.09,0.0,0.0,0.0,0.09,emily suza mccorkle,,ACCT-2010,2017
+ACCT,2010,5,Financial Accounting Concepts,0.34,0.24,0.28,0.08,0.04,0.0,0.0,0.02,annieka philo,,ACCT-2010,2017
+ACCT,2010,6,Financial Accounting Concepts,0.33,0.31,0.13,0.1,0.04,0.0,0.0,0.08,lydia lan schleifer,,ACCT-2010,2017
+ACCT,2010,7,Financial Accounting Concepts,0.24,0.37,0.2,0.1,0.08,0.0,0.0,0.0,annieka philo,,ACCT-2010,2017
+ACCT,2010,8,Financial Accounting Concepts,0.24,0.39,0.12,0.06,0.1,0.0,0.0,0.08,lydia lan schleifer,,ACCT-2010,2017
+ACCT,2010,9,Financial Accounting Concepts,0.21,0.56,0.13,0.02,0.08,0.0,0.0,0.0,annieka philo,,ACCT-2010,2017
+ACCT,2010,10,Financial Accounting Concepts,0.36,0.3,0.22,0.02,0.04,0.0,0.0,0.06,annieka philo,,ACCT-2010,2017
+ACCT,2010,11,Financial Accounting Concepts,0.29,0.43,0.16,0.08,0.02,0.0,0.0,0.02,rebecca pennel trax,,ACCT-2010,2017
+ACCT,2010,12,Financial Accounting Concepts,0.3,0.26,0.23,0.09,0.06,0.0,0.0,0.06,rebecca pennel trax,,ACCT-2010,2017
+ACCT,2010,13,Financial Accounting Concepts,0.22,0.35,0.17,0.13,0.09,0.0,0.0,0.04,charles tegen,,ACCT-2010,2017
+ACCT,2010,14,Financial Accounting Concepts,0.27,0.41,0.18,0.04,0.08,0.0,0.0,0.02,lisa whe birtwistle,,ACCT-2010,2017
+ACCT,2010,100,Fin Accounting Concepts (HON),0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,lisa whe birtwistle,True,ACCT-2010,2017
+ACCT,2010,400,Financial Accounting Concepts,0.29,0.34,0.19,0.1,0.05,0.0,0.0,0.02,emily suza mccorkle,,ACCT-2010,2017
+ACCT,2020,1,Managerial Accounting Concepts,0.36,0.22,0.22,0.02,0.0,0.0,0.0,0.18,henry anderson,,ACCT-2020,2017
+ACCT,2020,2,Managerial Accounting Concepts,0.36,0.3,0.1,0.0,0.06,0.0,0.0,0.18,henry anderson,,ACCT-2020,2017
+ACCT,2020,3,Managerial Accounting Concepts,0.28,0.28,0.13,0.02,0.06,0.0,0.0,0.23,henry anderson,,ACCT-2020,2017
+ACCT,2020,4,Managerial Accounting Concepts,0.29,0.31,0.18,0.07,0.04,0.0,0.0,0.11,phebia davis-culler,,ACCT-2020,2017
+ACCT,2020,5,Managerial Accounting Concepts,0.28,0.15,0.2,0.22,0.11,0.0,0.0,0.04,phebia davis-culler,,ACCT-2020,2017
+ACCT,2020,6,Managerial Accounting Concepts,0.21,0.09,0.38,0.09,0.15,0.0,0.0,0.09,phebia davis-culler,,ACCT-2020,2017
+ACCT,2020,7,Managerial Accounting Concepts,0.09,0.27,0.24,0.11,0.07,0.0,0.0,0.22,brian todd carver,,ACCT-2020,2017
+ACCT,2020,8,Managerial Accounting Concepts,0.16,0.19,0.23,0.07,0.14,0.0,0.0,0.21,brian todd carver,,ACCT-2020,2017
+ACCT,2020,400,Managerial Accounting Concepts,0.35,0.24,0.15,0.03,0.04,0.0,0.0,0.19,henry anderson,,ACCT-2020,2017
+ACCT,3030,1,Cost Accounting,0.32,0.41,0.18,0.0,0.02,0.0,0.0,0.07,robin radtke,,ACCT-3030,2017
+ACCT,3030,2,Cost Accounting,0.32,0.32,0.26,0.03,0.08,0.0,0.0,0.0,robin radtke,,ACCT-3030,2017
+ACCT,3030,3,Cost Accounting,0.23,0.34,0.27,0.09,0.0,0.0,0.0,0.07,jace garrett,,ACCT-3030,2017
+ACCT,3030,4,Cost Accounting,0.2,0.33,0.16,0.13,0.11,0.0,0.0,0.07,jace garrett,,ACCT-3030,2017
+ACCT,3110,1,Intermediate Financial Acct I,0.33,0.42,0.18,0.02,0.04,0.0,0.0,0.0,amy meliss donnelly,,ACCT-3110,2017
+ACCT,3110,2,Intermediate Financial Acct I,0.32,0.28,0.28,0.1,0.02,0.0,0.0,0.0,amy meliss donnelly,,ACCT-3110,2017
+ACCT,3110,3,Intermediate Financial Acct I,0.53,0.24,0.18,0.04,0.0,0.0,0.0,0.0,erin michel hawkins,,ACCT-3110,2017
+ACCT,3110,4,Intermediate Financial Acct I,0.28,0.33,0.33,0.04,0.02,0.0,0.0,0.0,erin michel hawkins,,ACCT-3110,2017
+ACCT,3110,400,Intermediate Financial Acct I,0.32,0.32,0.13,0.04,0.08,0.0,0.0,0.11,henry anderson,,ACCT-3110,2017
+ACCT,3120,1,Intermediate Financial Acct II,0.14,0.5,0.14,0.07,0.0,0.0,0.0,0.14,terry daniel knause,,ACCT-3120,2017
+ACCT,3120,2,Intermediate Financial Acct II,0.14,0.32,0.41,0.05,0.09,0.0,0.0,0.0,jeremy micha vinson,,ACCT-3120,2017
+ACCT,3120,3,Intermediate Financial Acct II,0.63,0.16,0.16,0.05,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3120,2017
+ACCT,3120,4,Intermediate Financial Acct II,0.18,0.43,0.3,0.08,0.0,0.0,0.0,0.03,jeremy micha vinson,,ACCT-3120,2017
+ACCT,3120,5,Intermediate Financial Acct II,0.45,0.33,0.2,0.03,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3120,2017
+ACCT,3120,6,Intermediate Financial Acct II,0.43,0.43,0.1,0.05,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3120,2017
+ACCT,3130,1,Intermediate Fin Acct III,0.22,0.22,0.28,0.08,0.11,0.0,0.0,0.08, russell madray,,ACCT-3130,2017
+ACCT,3130,2,Intermediate Fin Acct III,0.25,0.39,0.2,0.09,0.02,0.0,0.0,0.05, russell madray,,ACCT-3130,2017
+ACCT,3130,3,Intermediate Fin Acct III,0.37,0.29,0.2,0.1,0.0,0.0,0.0,0.05, russell madray,,ACCT-3130,2017
+ACCT,3130,4,Intermediate Fin Acct III,0.33,0.33,0.21,0.05,0.05,0.0,0.0,0.02, russell madray,,ACCT-3130,2017
+ACCT,3220,1,Accounting Information Systems,0.11,0.42,0.26,0.0,0.05,0.0,0.0,0.16,philip maiberger,,ACCT-3220,2017
+ACCT,3220,2,Accounting Information Systems,0.06,0.19,0.25,0.31,0.0,0.0,0.0,0.19,philip maiberger,,ACCT-3220,2017
+ACCT,3220,3,Accounting Information Systems,0.12,0.42,0.28,0.12,0.02,0.0,0.0,0.05,nancy lee harp,,ACCT-3220,2017
+ACCT,3220,4,Accounting Information Systems,0.17,0.36,0.24,0.07,0.1,0.0,0.0,0.07,nancy lee harp,,ACCT-3220,2017
+ACCT,4040,1,Individual Taxation,0.33,0.33,0.18,0.08,0.03,0.0,0.0,0.05,derek dalton,,ACCT-4040,2017
+ACCT,4040,2,Individual Taxation,0.8,0.11,0.06,0.03,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2017
+ACCT,4040,3,Individual Taxation,0.72,0.21,0.08,0.0,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2017
+ACCT,4080,1,Retire & Estate Plan,0.32,0.42,0.16,0.05,0.0,0.0,0.0,0.05,john hine,,ACCT-4080,2017
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.16,0.55,0.13,0.13,0.0,0.0,0.0,0.03,sally kathr widener,,ACCT-4100,2017
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.38,0.41,0.21,0.0,0.0,0.0,0.0,0.0,sally kathr widener,,ACCT-4100,2017
+ACCT,4150,1,Auditing,0.34,0.39,0.21,0.05,0.0,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2017
+ACCT,4150,2,Auditing,0.19,0.38,0.29,0.1,0.05,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2017
+ACCT,8510,1,Tax Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2017
+ACCT,8510,2,Tax Research,0.26,0.74,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2017
+ACCT,8510,3,Tax Research,0.61,0.37,0.0,0.0,0.0,0.0,0.0,0.02,thomas dickens,,ACCT-8510,2017
+ACCT,8530,1,Adv Acct Problems,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8530,2017
+ACCT,8530,2,Adv Acct Problems,0.61,0.34,0.02,0.0,0.0,0.0,0.0,0.02,ralph welton,,ACCT-8530,2017
+ACCT,8530,3,Adv Acct Problems,0.48,0.39,0.06,0.0,0.03,0.0,0.0,0.03,ralph welton,,ACCT-8530,2017
+ACCT,8550,1,Gov't and Nonprofit Accounting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2017
+ACCT,8550,2,Gov't and Nonprofit Accounting,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,james barnes,,ACCT-8550,2017
+ACCT,8630,1,Forensics Analysis,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,philip maiberger,,ACCT-8630,2017
+ACCT,8630,2,Forensics Analysis,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,philip maiberger,,ACCT-8630,2017
+ACCT,8650,1,Tax & Bus Decisions,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,,ACCT-8650,2017
+ACCT,8720,1,Tax of Flowthroughs,0.34,0.48,0.16,0.0,0.0,0.0,0.0,0.02,thomas dickens,,ACCT-8720,2017
+AGED,1020,1,Freshman Seminar,0.76,0.12,0.06,0.0,0.0,0.0,0.0,0.06,catheri dibenedetto,,AGED-1020,2017
+AGED,2000,1,Agr Appl of Ed Tech,0.67,0.17,0.1,0.0,0.0,0.0,0.0,0.07,kevin layfield,,AGED-2000,2017
+AGED,2010,1,Intro to Agric Educ,0.59,0.37,0.0,0.0,0.0,0.0,0.0,0.04,philip fravel,,AGED-2010,2017
+AGED,2040,1,App Ag Calculations,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2040,2017
+AGED,3030,1,Ag Ed Mech Tech,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-3030,2017
+AGED,4000,1,Supervised Field Experience II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-4000,2017
+AGED,4010,1,Instr Methods Ag Ed,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,,AGED-4010,2017
+AGED,4030,1,Prin Adult/Ext Ed,0.41,0.29,0.18,0.06,0.0,0.0,0.0,0.06,alex byrd,,AGED-4030,2017
+AGED,4230,400,Curriculum,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,,AGED-4230,2017
+AGED,6030,1,Prin Adult/Ext Ed,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-6030,2017
+AGM,1010,1,Intro Ag Mech & Bus,0.71,0.15,0.08,0.02,0.04,0.0,0.0,0.0,hunter massey,,AGM-1010,2017
+AGM,2050,1,Prin of Fabrication,0.3,0.54,0.09,0.02,0.02,0.0,0.0,0.04,hunter massey,,AGM-2050,2017
+AGM,2060,1,Machinery Mgt,0.38,0.33,0.19,0.05,0.05,0.0,0.0,0.0,hunter massey,,AGM-2060,2017
+AGM,2210,1,Land Measurements,0.26,0.56,0.17,0.01,0.0,0.0,0.0,0.0,charles privette,,AGM-2210,2017
+AGM,3010,1,Soil Water Conserv,0.47,0.31,0.18,0.04,0.0,0.0,0.0,0.0,calvin sawyer,,AGM-3010,2017
+AGM,4000,1,Seminar in Ag Mech & Business,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,john chastain,,AGM-4000,2017
+AGM,4020,1,Irrigation System Design,0.23,0.43,0.27,0.03,0.03,0.0,0.0,0.0,charles privette,,AGM-4020,2017
+AGM,4050,1,Env Cont in Anim Str,0.12,0.34,0.46,0.02,0.05,0.0,0.0,0.0,john chastain,,AGM-4050,2017
+AGM,4060,1,Mech & Hydraulic Sys,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4060,2017
+AGM,4520,1,Mobile Power,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4520,2017
+AGM,4600,1,Electrical Systems,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,young han,,AGM-4600,2017
+AGRB,2020,1,Agricultural Economics,0.17,0.27,0.29,0.12,0.1,0.0,0.0,0.06,george apperson,,AGRB-2020,2017
+AGRB,2020,2,Agricultural Economics,0.12,0.42,0.15,0.18,0.09,0.0,0.0,0.03,george apperson,,AGRB-2020,2017
+AGRB,2050,1,Agriculture and Society,0.2,0.29,0.45,0.04,0.02,0.0,0.0,0.0,michael vassalos,,AGRB-2050,2017
+AGRB,3020,1,Economics of Farm Management,0.18,0.28,0.3,0.21,0.01,0.0,0.0,0.02,michael vassalos,,AGRB-3020,2017
+AGRB,3080,1,Quant Agribusiness Analysis I,0.25,0.33,0.24,0.13,0.04,0.0,0.0,0.01,lisha zhang,,AGRB-3080,2017
+AGRB,3090,1,Econ of Agricultural Marketing,0.5,0.38,0.08,0.02,0.02,0.0,0.0,0.0,yuliya val bolotova,,AGRB-3090,2017
+AGRB,3190,1,Agribusiness Management,0.28,0.23,0.18,0.13,0.08,0.0,0.0,0.1,michael vassalos,,AGRB-3190,2017
+AGRB,3570,1,Natural Resources Economics,0.2,0.18,0.27,0.13,0.09,0.0,0.0,0.13,david brian willis,,AGRB-3570,2017
+AGRB,4090,1,Commodity Futures Markets,0.16,0.24,0.3,0.19,0.11,0.0,0.0,0.0,george apperson,,AGRB-4090,2017
+AGRB,4120,1,Reg Econ Devel Theory & Policy,0.57,0.31,0.1,0.0,0.0,0.0,0.0,0.02,lori ann dickes,,AGRB-4120,2017
+AGRB,4600,1,Agricultural Finance,0.2,0.43,0.33,0.05,0.0,0.0,0.0,0.0,lisha zhang,,AGRB-4600,2017
+AL,3490,400,Principles of Coaching,0.66,0.21,0.07,0.03,0.0,0.0,0.0,0.03,deborah cadorette,,AL-3490,2017
+AL,3490,401,Principles of Coaching,0.52,0.37,0.07,0.04,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2017
+AL,3490,403,Principles of Coaching,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,clyde keith connor,,AL-3490,2017
+AL,3490,404,Principles of Coaching,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,edmond fry,,AL-3490,2017
+AL,3500,400,Sci Basis I/Ex Phy,0.12,0.36,0.2,0.12,0.04,0.0,0.0,0.16,michael godfrey,,AL-3500,2017
+AL,3500,401,Sci Basis I/Ex Phy,0.29,0.25,0.25,0.13,0.0,0.0,0.0,0.08,michael godfrey,,AL-3500,2017
+AL,3530,400,Athletic Injuries,0.42,0.21,0.29,0.08,0.0,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2017
+AL,3530,401,Athletic Injuries,0.11,0.44,0.22,0.11,0.11,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2017
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.27,0.27,0.0,0.07,0.0,0.0,0.07,clyde keith connor,,AL-3600,2017
+AL,3610,400,Admin/Org of Athletic Programs,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,henry oates,,AL-3610,2017
+AL,3610,401,Admin/Org of Athletic Programs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2017
+AL,3610,402,Admin/Org of Athletic Programs,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2017
+AL,3620,400,Psychology of Coaching,0.65,0.18,0.06,0.0,0.0,0.0,0.0,0.12,natalie anne carter,,AL-3620,2017
+AL,3620,401,Psychology of Coaching,0.41,0.12,0.24,0.18,0.06,0.0,0.0,0.0,natalie anne carter,,AL-3620,2017
+AL,3620,402,Psychology of Coaching,0.29,0.54,0.08,0.04,0.0,0.0,0.0,0.04,natalie anne carter,,AL-3620,2017
+AL,3740,400,Coaching Football,0.78,0.09,0.04,0.0,0.04,0.0,0.0,0.04,edmond fry,,AL-3740,2017
+AL,3760,400,Coaching Strength/Conditioning,0.79,0.13,0.0,0.04,0.04,0.0,0.0,0.0,edmond fry,,AL-3760,2017
+AL,3760,401,Coaching Strength/Conditioning,0.71,0.0,0.21,0.0,0.07,0.0,0.0,0.0,edmond fry,,AL-3760,2017
+AL,4380,402,Coaching the Inner Athlete,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,deborah cadorette,,AL-4380,2017
+AL,4380,403,Media Relations in AL,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-4380,2017
+AL,4380,404,Coaching the Inner Athlete,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-4380,2017
+AL,4380,408,Officiating in AL,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,clyde keith connor,,AL-4380,2017
+AL,8440,400,Surv of Res Mthds in Athletics,0.82,0.06,0.12,0.0,0.0,0.0,0.0,0.0,russell marion,,AL-8440,2017
+AL,8440,401,Surv of Res Mthds in Athletics,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,russell marion,,AL-8440,2017
+AL,8490,401,Athletic Leadership Dev,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,michael godfrey,,AL-8490,2017
+AL,8500,400,Principles Strength and Condit,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8500,2017
+AL,8500,401,Principles Strength and Condit,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,michael godfrey,,AL-8500,2017
+AL,8650,400,Mkt and Comm Respon Interc Ath,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,misty soles,,AL-8650,2017
+ANTH,2010,1,Introduction to Anthropology,0.06,0.23,0.28,0.16,0.11,0.0,0.0,0.17,john coggeshall,,ANTH-2010,2017
+ANTH,2010,2,Introduction to Anthropology,0.0,0.24,0.29,0.24,0.12,0.0,0.0,0.12,john coggeshall,,ANTH-2010,2017
+ANTH,2010,3,Introduction to Anthropology,0.44,0.37,0.11,0.02,0.02,0.0,0.0,0.04,yi wu,,ANTH-2010,2017
+ANTH,2010,4,Introduction to Anthropology,0.46,0.2,0.15,0.09,0.06,0.0,0.0,0.04,yi wu,,ANTH-2010,2017
+ANTH,2010,5,Introduction to Anthropology,0.4,0.37,0.1,0.02,0.03,0.0,0.0,0.08,lisa rapaport,,ANTH-2010,2017
+ANTH,3010,1,Cultural Anthropology,0.04,0.32,0.44,0.04,0.0,0.0,0.0,0.16,john coggeshall,,ANTH-3010,2017
+ANTH,3320,1,World Archaeology,0.72,0.11,0.0,0.11,0.06,0.0,0.0,0.0,elizabeth wakefield,,ANTH-3320,2017
+ANTH,3510,1,Biological Anthropology,0.16,0.21,0.32,0.26,0.05,0.0,0.0,0.0,lisa rapaport,,ANTH-3510,2017
+ANTH,3530,1,Forensic Anthropology,0.25,0.45,0.3,0.0,0.0,0.0,0.0,0.0,katherine weisensee,,ANTH-3530,2017
+ANTH,3710,1,Language and Culture,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,yanhua zhang,,ANTH-3710,2017
+ANTH,4230,1,Women in the Developing World,0.64,0.27,0.0,0.09,0.0,0.0,0.0,0.0,melissa vogel,,ANTH-4230,2017
+ARCH,1010,1,Intro to Architecture,0.63,0.17,0.07,0.02,0.02,0.0,0.0,0.09,sal hambright-belue,,ARCH-1010,2017
+ARCH,2040,1,Hist of Modern Arch,0.33,0.51,0.14,0.02,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-2040,2017
+ARCH,2510,1,Arch Foundations I,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-2510,2017
+ARCH,2510,2,Arch Foundations I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-2510,2017
+ARCH,2510,3,Arch Foundations I,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2510,2017
+ARCH,2510,4,Arch Foundations I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,joseph schott,,ARCH-2510,2017
+ARCH,2510,5,Arch Foundations I,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,criss mills,,ARCH-2510,2017
+ARCH,2700,1,Structures I,0.28,0.59,0.1,0.03,0.0,0.0,0.0,0.0,dustin gra albright,,ARCH-2700,2017
+ARCH,3500,1,Intro to Urban Contexts,0.29,0.5,0.14,0.07,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-3500,2017
+ARCH,3500,2,Intro to Urban Contexts,0.25,0.17,0.42,0.17,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-3500,2017
+ARCH,3500,3,Intro to Urban Contexts,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-3500,2017
+ARCH,3500,4,Intro to Urban Contexts,0.08,0.42,0.42,0.08,0.0,0.0,0.0,0.0,george schafer,,ARCH-3500,2017
+ARCH,3500,5,Intro to Urban Contexts,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-3500,2017
+ARCH,3510,2,Studio Clemson,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,,ARCH-3510,2017
+ARCH,3540,1,Studio Barcelona,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-3540,2017
+ARCH,4010,1,Architectural Portfolio,0.62,0.19,0.1,0.0,0.05,0.0,0.0,0.05,clarissa mendez,,ARCH-4010,2017
+ARCH,4010,2,Architectural Portfolio,0.43,0.24,0.29,0.0,0.0,0.0,0.0,0.05,herminia sil machry,,ARCH-4010,2017
+ARCH,4010,3,Architectural Portfolio,0.36,0.59,0.0,0.05,0.0,0.0,0.0,0.0,george schafer,,ARCH-4010,2017
+ARCH,6240,1,Product Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-6240,2017
+ARCH,6850,1,H/Th: Arch+Health,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-6850,2017
+ARCH,8100,1,Visualization I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,,ARCH-8100,2017
+ARCH,8210,1,Research Methods,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-8210,2017
+ARCH,8410,1,Arch Studio I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,peter laurence,,ARCH-8410,2017
+ARCH,8410,2,Arch Studio I,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,andreea mihalache,,ARCH-8410,2017
+ARCH,8510,2,Design Studio III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8510,2017
+ARCH,8510,3,Design Studio III,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-8510,2017
+ARCH,8570,6,Design Studio V,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-8570,2017
+ARCH,8600,1,History/Theory I,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-8600,2017
+ARCH,8720,1,Production & Assemb,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,,ARCH-8720,2017
+ARCH,8810,1,Pro Practice Survey,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,,ARCH-8810,2017
+ARCH,8860,1,Health Facilities,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8860,2017
+ARCH,8890,1,Mentorship,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,,ARCH-8890,2017
+ARCH,8970,1,A+H Studio: Hospital,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8970,2017
+ART,1050,1,Foundation Drawing I,0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,kathleen ann thum,,ART-1050,2017
+ART,1510,1,Foundations Art I,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,kymberly ann day,,ART-1510,2017
+ART,2070,1,Beginning Painting,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,dustin lee massey,,ART-2070,2017
+ART,2100,400,Art Appreciation,0.57,0.25,0.14,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2017
+ART,2100,401,Art Appreciation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2017
+ART,2100,402,Art Appreciation,0.68,0.18,0.04,0.0,0.07,0.0,0.0,0.04,lydia jane dorsey,,ART-2100,2017
+ART,2100,403,Art Appreciation,0.32,0.43,0.14,0.0,0.04,0.0,0.0,0.07,lydia jane dorsey,,ART-2100,2017
+ART,2110,1,Begin Printmaking,0.56,0.31,0.06,0.0,0.06,0.0,0.0,0.0,mandy lora ferguson,,ART-2110,2017
+ART,2130,1,Begin Photography,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,amber nic eckersley,,ART-2130,2017
+ART,2210,1,Beginning New Media,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,christina nguy hung,,ART-2210,2017
+ART,8210,1,Visual Narrative,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,,ART-8210,2017
+AS,1090,1,Air Force Today I,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,michael allen moore,,AS-1090,2017
+AS,1090,2,Air Force Today I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1090,2017
+AS,1090,3,Air Force Today I,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,michael allen moore,,AS-1090,2017
+AS,2090,2,Dev of Air Power I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brock lusk,,AS-2090,2017
+AS,2090,3,Dev of Air Power I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2090,2017
+AS,3090,2,A F Leadership Mgt I,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,rachelle mar miller,,AS-3090,2017
+AS,4090,1,Nat Sec Policy I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4090,2017
+ASL,1010,1,Am Sign Lang I,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jason hurdich,,ASL-1010,2017
+ASL,1010,2,Am Sign Lang I,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-1010,2017
+ASL,1010,3,Am Sign Lang I,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,william ry clements,,ASL-1010,2017
+ASL,1010,5,Am Sign Lang I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,william ry clements,,ASL-1010,2017
+ASL,1020,1,Am Sign Lang I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-1020,2017
+ASL,2010,1,Am Sign Lang II,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-2010,2017
+ASL,2010,2,Am Sign Lang II,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,jason hurdich,,ASL-2010,2017
+ASL,2010,3,Am Sign Lang II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william ry clements,,ASL-2010,2017
+ASL,2010,4,Am Sign Lang II,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william ry clements,,ASL-2010,2017
+ASL,3010,1,Advanced A S L I,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kim ma misener dunn,,ASL-3010,2017
+ASTR,1010,1,Solar System Astronomy,0.36,0.41,0.1,0.05,0.05,0.0,0.0,0.02,amber porter,,ASTR-1010,2017
+ASTR,1010,2,Solar System Astronomy,0.41,0.37,0.13,0.02,0.05,0.0,0.0,0.02,amber porter,,ASTR-1010,2017
+ASTR,1020,1,Stellar Astronomy,0.24,0.38,0.26,0.05,0.01,0.0,0.0,0.05,marco ajello,,ASTR-1020,2017
+ASTR,1030,1,Solar Systm Astr Lab,0.64,0.27,0.0,0.0,0.05,0.0,0.0,0.05,amber porter,,ASTR-1030,2017
+ASTR,1030,2,Solar Systm Astr Lab,0.78,0.09,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,,ASTR-1030,2017
+ASTR,1030,3,Solar Systm Astr Lab,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,amber porter,,ASTR-1030,2017
+ASTR,1030,4,Solar Systm Astr Lab,0.67,0.17,0.13,0.0,0.0,0.0,0.0,0.04,amber porter,,ASTR-1030,2017
+ASTR,1030,5,Solar Systm Astr Lab,0.23,0.64,0.05,0.09,0.0,0.0,0.0,0.0,amber porter,,ASTR-1030,2017
+ASTR,1030,6,Solar Systm Astr Lab,0.57,0.26,0.13,0.0,0.0,0.0,0.0,0.04,amber porter,,ASTR-1030,2017
+ASTR,1030,7,Solar Systm Astr Lab,0.5,0.28,0.06,0.06,0.0,0.0,0.0,0.11,amber porter,,ASTR-1030,2017
+ASTR,1030,8,Solar Systm Astr Lab,0.26,0.53,0.16,0.05,0.0,0.0,0.0,0.0,amber porter,,ASTR-1030,2017
+ASTR,1030,9,Solar Systm Astr Lab,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,amber porter,,ASTR-1030,2017
+ASTR,1030,10,Solar Systm Astr Lab,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,amber porter,,ASTR-1030,2017
+ASTR,1040,1,Stellar Astr Lab,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,amber porter,,ASTR-1040,2017
+ASTR,1040,2,Stellar Astr Lab,0.52,0.3,0.0,0.0,0.09,0.0,0.0,0.09,amber porter,,ASTR-1040,2017
+ASTR,1040,4,Stellar Astr Lab,0.41,0.37,0.11,0.04,0.0,0.0,0.0,0.07,amber porter,,ASTR-1040,2017
+ASTR,8100,1,Astroph I: Radiation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,,ASTR-8100,2017
+AUD,1850,1,Intro to Audio Tech,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-1850,2017
+AUD,2800,1,Sound Reinforcement,0.0,0.17,0.75,0.08,0.0,0.0,0.0,0.0,kenneth moore,,AUD-2800,2017
+AUE,4010,1,Vehicle Dynamics,0.3,0.5,0.1,0.0,0.1,0.0,0.0,0.0,imtiaz ul haque,,AUE-4010,2017
+AUE,4030,1,Automotive Engr Project Tools,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,andrej ivanco,,AUE-4030,2017
+AUE,8180,1,"Engine Analysis, Design & Exp",0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8180,2017
+AUE,8260,1,Vehicle Diagnostics,0.34,0.54,0.11,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8260,2017
+AUE,8270,5,Auto Cntrl Sys Des,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8270,2017
+AUE,8280,1,Driveline/Powertrain,0.61,0.26,0.13,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8280,2017
+AUE,8330,30,Auto Manuf Proc Devl,0.18,0.74,0.08,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8330,2017
+AUE,8350,100,Auto Electronics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,,AUE-8350,2017
+AUE,8670,1,Veh Manuf Proc I,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8670,2017
+AUE,8810,3,Automotive Systems Overview,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,,AUE-8810,2017
+AUE,8870,8,Meth Vehicle Testing,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8870,2017
+AUE,8930,16,Light-Weight Automotive Design,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,david wil schmueser,,AUE-8930,2017
+AUE,8930,18,Adv IC Engine Concept,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-8930,2017
+AUE,8930,19,Autovation II: Tech Enterp Dev,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,,AUE-8930,2017
+AUE,8930,89,Manufacturing,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,,AUE-8930,2017
+AVS,1000,1,Orientation to AVS,0.92,0.05,0.01,0.01,0.0,0.0,0.0,0.01,marie owens bolt,,AVS-1000,2017
+AVS,1500,1,Intro Animal Science,0.2,0.4,0.21,0.09,0.06,0.0,0.0,0.03,joseph kei bertrand,,AVS-1500,2017
+AVS,1510,1,Intro Ani Sci Lab,0.46,0.46,0.04,0.0,0.0,0.0,0.0,0.04,richelle lor miller,,AVS-1510,2017
+AVS,1510,2,Intro Ani Sci Lab,0.68,0.2,0.04,0.0,0.0,0.0,0.0,0.08,richelle lor miller,,AVS-1510,2017
+AVS,1510,3,Intro Ani Sci Lab,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-1510,2017
+AVS,1510,4,Intro Ani Sci Lab,0.77,0.09,0.09,0.0,0.0,0.0,0.0,0.05,chelsea dr sinclair,,AVS-1510,2017
+AVS,1510,5,Intro Ani Sci Lab,0.72,0.24,0.0,0.04,0.0,0.0,0.0,0.0,marie owens bolt,,AVS-1510,2017
+AVS,1510,6,Intro Ani Sci Lab,0.71,0.21,0.04,0.04,0.0,0.0,0.0,0.0,marie owens bolt,,AVS-1510,2017
+AVS,1510,7,Intro Ani Sci Lab,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,chelsea dr sinclair,,AVS-1510,2017
+AVS,1510,8,Intro Ani Sci Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,marie owens bolt,,AVS-1510,2017
+AVS,2020,1,CAFLS Plus,0.91,0.05,0.0,0.0,0.05,0.0,0.0,0.0,thomas scott,,AVS-2020,2017
+AVS,2030,1,Dairy Sci Techniques,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,heather walker dunn,,AVS-2030,2017
+AVS,2040,1,Horse Care Techniques,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-2040,2017
+AVS,2060,1,Swine Techniques,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-2060,2017
+AVS,3010,1,Anat & Phys Dom Ani,0.42,0.34,0.21,0.03,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2017
+AVS,3010,400,Anat & Phys Dom Ani,0.27,0.31,0.29,0.12,0.0,0.0,0.0,0.02,glenn birrenkott,,AVS-3010,2017
+AVS,3020,1,Livestk Sel Eval I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-3020,2017
+AVS,3100,1,Animal Health,0.52,0.33,0.16,0.0,0.0,0.0,0.0,0.0,celina marc checura,,AVS-3100,2017
+AVS,3700,1,Principles of Animal Nutrition,0.68,0.19,0.08,0.03,0.01,0.0,0.0,0.0,james ro strickland,,AVS-3700,2017
+AVS,3750,1,Applied Animal Nutrition,0.38,0.38,0.13,0.06,0.0,0.0,0.0,0.06,gustavo jos lascano,,AVS-3750,2017
+AVS,3850,1,Equine Behavior and Training,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,chelsea dr sinclair,,AVS-3850,2017
+AVS,4000,1,AVS Professional Development,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,marie owens bolt,,AVS-4000,2017
+AVS,4000,2,AVS Professional Development,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,marie owens bolt,,AVS-4000,2017
+AVS,4060,1,Seminars & Related Topics,0.57,0.37,0.07,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2017
+AVS,4060,2,Seminars & Related Topics,0.13,0.69,0.19,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2017
+AVS,4110,1,Animal Growth and Development,0.59,0.21,0.14,0.03,0.03,0.0,0.0,0.0,susan kay duckett,,AVS-4110,2017
+AVS,4150,1,Contemporary Issues in AVS,0.3,0.33,0.19,0.05,0.05,0.0,0.0,0.09,peter skewes,,AVS-4150,2017
+AVS,4160,1,Equine Exercise Phys,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-4160,2017
+AVS,4500,1,Sust Livestock Sys,0.36,0.57,0.0,0.0,0.0,0.0,0.0,0.07,matias jose aguerre,,AVS-4500,2017
+AVS,4530,1,Animal Reproduction,0.54,0.32,0.11,0.04,0.0,0.0,0.0,0.0,tiffany wilmoth,,AVS-4530,2017
+AVS,4650,1,Animal Physiology I,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,celina marc checura,,AVS-4650,2017
+AVS,4800,1,Vertebrate Endocrinology,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-4800,2017
+AVS,6650,1,Animal Physiology I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,celina marc checura,,AVS-6650,2017
+BCHM,1030,1,Careers in Bioch/Gen,0.88,0.07,0.0,0.01,0.03,0.0,0.0,0.01,joseph paul thames,,BCHM-1030,2017
+BCHM,3010,1,Molecular Biochemistry,0.35,0.26,0.13,0.06,0.06,0.0,0.0,0.13,kerry smith,,BCHM-3010,2017
+BCHM,3050,1,Essen Elements Bioch,0.65,0.23,0.07,0.01,0.01,0.0,0.0,0.03,debra ragland,,BCHM-3050,2017
+BCHM,3050,2,Essen Elements Bioch,0.43,0.34,0.14,0.02,0.01,0.0,0.0,0.05,debra ragland,,BCHM-3050,2017
+BCHM,4310,1,Physical Approach to Biochem,0.24,0.43,0.3,0.04,0.0,0.0,0.0,0.0,weiguo cao,,BCHM-4310,2017
+BCHM,4310,2,Phys App to Bioch (HON),0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True,BCHM-4310,2017
+BCHM,4330,1,Physical Biochemistry Lab,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-4330,2017
+BCHM,4400,1,Bioinformatics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,,BCHM-4400,2017
+BCHM,4430,1,Mol Basis Disease,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,james morris,,BCHM-4430,2017
+BCHM,8140,1,Advanced Biochemistry,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,cheryl ingram-smith,,BCHM-8140,2017
+BE,2120,1,Fundamentals of Biosys Engr,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,caye marie drapcho,,BE-2120,2017
+BE,3200,1,Principles & Prac of Geomatics,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-3200,2017
+BE,4100,1,Biological Kinetics,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4100,2017
+BE,4210,1,Engr Sys for Soil Water Mgt,0.67,0.27,0.0,0.07,0.0,0.0,0.0,0.0,christophe darnault,,BE-4210,2017
+BE,4280,1,Biochem Engr,0.33,0.33,0.25,0.08,0.0,0.0,0.0,0.0,terry walker,,BE-4280,2017
+BE,4740,1,BE Design Project Managment,0.73,0.15,0.12,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-4740,2017
+BE,4750,1,BE Capstone Design,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4750,2017
+BIOE,2010,1,Intro Biomed Engr,0.25,0.5,0.06,0.0,0.0,0.0,0.0,0.19,charles webb,,BIOE-2010,2017
+BIOE,2010,2,Intro Biomed Engr,0.46,0.39,0.05,0.01,0.01,0.0,0.0,0.08,charles webb,,BIOE-2010,2017
+BIOE,3020,1,Biomaterials,0.61,0.27,0.04,0.04,0.04,0.0,0.0,0.02,alexey ale vertegel,,BIOE-3020,2017
+BIOE,3100,1,Engr Analysis of Physiol Proc,0.55,0.43,0.01,0.0,0.0,0.0,0.0,0.0,brian william booth,,BIOE-3100,2017
+BIOE,3200,1,Biomechanics,0.74,0.22,0.0,0.01,0.0,0.0,0.0,0.03,jiro nagatomi,,BIOE-3200,2017
+BIOE,3210,1,Biofluid Mechanics,0.55,0.33,0.09,0.0,0.0,0.0,0.0,0.03,zhi gao,,BIOE-3210,2017
+BIOE,3700,1,Bioinst & Imaging,0.67,0.24,0.03,0.0,0.0,0.0,0.0,0.06,delphine dean,,BIOE-3700,2017
+BIOE,4010,1,Bioengineering Design Theory,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,john desjardins,,BIOE-4010,2017
+BIOE,4010,2,Bioengineering Design Theory,0.95,0.03,0.03,0.0,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4010,2017
+BIOE,4030,1,Applied Bio E Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,,BIOE-4030,2017
+BIOE,4120,1,Orthopaedic Engr and Pathology,0.5,0.35,0.1,0.0,0.0,0.0,0.0,0.05,melinda harman,,BIOE-4120,2017
+BIOE,4400,1,Biopharmaceutical Engineering,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,sarah harcum,,BIOE-4400,2017
+BIOE,4500,3,Biofabrication,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,,BIOE-4500,2017
+BIOE,6120,1,Orthopaedic Engr & Pathology,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,,BIOE-6120,2017
+BIOE,6400,1,Biopharmaceutical Engineering,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sarah harcum,,BIOE-6400,2017
+BIOE,8010,1,Bio Materials,0.31,0.59,0.06,0.0,0.0,0.0,0.0,0.03,robert latour,,BIOE-8010,2017
+BIOE,8020,410,Biocompatibility,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,,BIOE-8020,2017
+BIOE,8140,401,Medical Dev Commercialization,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,david orr,,BIOE-8140,2017
+BIOE,8160,1,BioE Professional Development,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,martine laberge,,BIOE-8160,2017
+BIOE,8200,1,Structl Biomechanics,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,hai yao,,BIOE-8200,2017
+BIOE,8240,1,Cell & Mol Tissue Engineering,0.67,0.0,0.17,0.0,0.0,0.0,0.0,0.17,jeoungsoo lee,,BIOE-8240,2017
+BIOL,1010,1,Frontiers in Biology I,0.83,0.11,0.05,0.01,0.01,0.0,0.0,0.0,robert edwa ballard,,BIOL-1010,2017
+BIOL,1010,2,Frontiers in Biology I,0.63,0.22,0.09,0.04,0.02,0.0,0.0,0.0,thomas hughes,,BIOL-1010,2017
+BIOL,1030,1,General Biology I,0.17,0.27,0.26,0.16,0.06,0.0,0.0,0.09,nora espinoza,,BIOL-1030,2017
+BIOL,1030,2,General Biology I,0.14,0.31,0.29,0.14,0.07,0.0,0.0,0.06,william baldwin,,BIOL-1030,2017
+BIOL,1030,3,General Biology I,0.32,0.3,0.2,0.07,0.05,0.0,0.0,0.05,william surver,,BIOL-1030,2017
+BIOL,1030,4,General Biology I,0.16,0.23,0.33,0.17,0.05,0.0,0.0,0.07,salvatore sparace,,BIOL-1030,2017
+BIOL,1030,5,General Biology I (HON),0.49,0.36,0.13,0.0,0.0,0.0,0.0,0.03,nora espinoza,True,BIOL-1030,2017
+BIOL,1050,1,General Biology Lab I,0.13,0.42,0.29,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,2,General Biology Lab I,0.08,0.5,0.33,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,3,General Biology Lab I,0.27,0.32,0.27,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,4,General Biology Lab I,0.0,0.63,0.29,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,5,General Biology Lab I,0.04,0.5,0.46,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,6,General Biology Lab I,0.21,0.54,0.21,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,7,General Biology Lab I,0.0,0.25,0.38,0.08,0.08,0.0,0.0,0.21,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,8,General Biology Lab I,0.04,0.33,0.42,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,9,General Biology Lab I,0.0,0.15,0.3,0.25,0.1,0.0,0.0,0.2,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,10,General Biology Lab I,0.04,0.52,0.26,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,11,General Biology Lab I,0.09,0.65,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,12,General Biology Lab I,0.17,0.29,0.38,0.08,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,13,General Biology Lab I,0.08,0.54,0.25,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,14,General Biology Lab I,0.04,0.63,0.29,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,15,General Biology Lab I,0.0,0.67,0.17,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,16,General Biology Lab I,0.04,0.43,0.43,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,17,General Biology Lab I,0.13,0.38,0.33,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,18,General Biology Lab I,0.17,0.42,0.38,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,19,General Biology Lab I,0.23,0.27,0.36,0.09,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,20,General Biology Lab I,0.1,0.35,0.4,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,21,General Biology Lab I,0.0,0.21,0.5,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,22,General Biology Lab I,0.0,0.61,0.3,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,23,General Biology Lab I,0.08,0.29,0.29,0.13,0.13,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,25,General Biology Lab I,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,26,General Biology Lab I,0.25,0.46,0.25,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,27,General Biology Lab I,0.25,0.42,0.25,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,28,General Biology Lab I,0.04,0.5,0.33,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,29,General Biology Lab I,0.0,0.63,0.17,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,30,General Biology Lab I,0.0,0.29,0.29,0.17,0.08,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,31,General Biology Lab I,0.09,0.36,0.41,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,32,General Biology Lab I,0.0,0.39,0.39,0.22,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,33,General Biology Lab I,0.0,0.27,0.4,0.13,0.13,0.0,0.0,0.07,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,34,General Biology Lab I,0.09,0.57,0.35,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,35,General Biology Lab I,0.13,0.46,0.33,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,36,General Biology Lab I,0.25,0.46,0.17,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,37,General Biology Lab I,0.04,0.38,0.5,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,38,General Biology Lab I,0.13,0.63,0.17,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,39,General Biology Lab I,0.0,0.5,0.42,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,40,General Biology Lab I,0.09,0.65,0.17,0.09,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,41,General Biology Lab I,0.0,0.5,0.42,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,42,General Biology Lab I,0.04,0.43,0.43,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,43,General Biology Lab I,0.09,0.36,0.36,0.09,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,44,General Biology Lab I,0.09,0.52,0.22,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1050,46,General Biology Lab I,0.04,0.38,0.38,0.13,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2017
+BIOL,1090,1,Intro to Life Sci,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,,BIOL-1090,2017
+BIOL,1100,1,Principles of Biology I,0.47,0.41,0.08,0.01,0.0,0.0,0.0,0.03,dylan dittrich-reed,,BIOL-1100,2017
+BIOL,1100,2,Principles of Biology I,0.24,0.43,0.23,0.04,0.03,0.0,0.0,0.04,robert kosinski,,BIOL-1100,2017
+BIOL,1200,1,Biological Inq Lab,0.15,0.6,0.15,0.1,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,2,Biological Inq Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,3,Biological Inq Lab,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,4,Biological Inq Lab,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,,BIOL-1200,2017
+BIOL,1200,5,Biological Inq Lab,0.25,0.55,0.1,0.05,0.0,0.0,0.0,0.05, christine minor,,BIOL-1200,2017
+BIOL,1200,6,Biological Inq Lab,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,7,Biological Inq Lab,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,8,Biological Inq Lab,0.21,0.37,0.21,0.0,0.11,0.0,0.0,0.11, christine minor,,BIOL-1200,2017
+BIOL,1200,9,Biological Inq Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,10,Biological Inq Lab,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,11,Biological Inq Lab,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05, christine minor,,BIOL-1200,2017
+BIOL,1200,12,Biological Inq Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,13,Biological Inq Lab,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,14,Biological Inq Lab,0.32,0.47,0.16,0.05,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1230,1,Keys to Human Biol,0.16,0.44,0.29,0.1,0.02,0.0,0.0,0.0, christine minor,,BIOL-1230,2017
+BIOL,1230,2,Keys to Human Biol,0.13,0.49,0.24,0.08,0.01,0.0,0.0,0.04, christine minor,,BIOL-1230,2017
+BIOL,2040,1,"Environ, Energy and Society",0.4,0.33,0.15,0.05,0.0,0.0,0.0,0.08,john jenkins hains,,BIOL-2040,2017
+BIOL,2040,2,"Environ, Energy and Society",0.34,0.4,0.17,0.04,0.04,0.0,0.0,0.02,john jenkins hains,,BIOL-2040,2017
+BIOL,2110,1,Introduction to Toxicology,0.65,0.22,0.13,0.0,0.0,0.0,0.0,0.0,peter van den hurk,,BIOL-2110,2017
+BIOL,2220,1,Human Anat and Physiology I,0.29,0.31,0.25,0.06,0.05,0.0,0.0,0.04,john cummings,,BIOL-2220,2017
+BIOL,2220,2,Human Anat and Physiology I,0.22,0.36,0.23,0.05,0.06,0.0,0.0,0.09,john cummings,,BIOL-2220,2017
+BIOL,3030,1,Vertebrate Biology,0.33,0.3,0.21,0.13,0.01,0.0,0.0,0.02,richard blob,,BIOL-3030,2017
+BIOL,3030,2,Vertebrate Biology (HON),0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True,BIOL-3030,2017
+BIOL,3040,1,Biology of Plants,0.53,0.36,0.06,0.02,0.03,0.0,0.0,0.0,christina wells,,BIOL-3040,2017
+BIOL,3070,1,Vertebrate Biology Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2017
+BIOL,3070,2,Vertebrate Biology Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2017
+BIOL,3070,3,Vertebrate Biology Lab,0.25,0.6,0.15,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2017
+BIOL,3070,4,Vertebrate Biology Lab,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2017
+BIOL,3070,5,Vertebrate Biology Lab,0.25,0.5,0.15,0.0,0.05,0.0,0.0,0.05,richard blob,,BIOL-3070,2017
+BIOL,3070,6,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2017
+BIOL,3070,7,Vertebrate Biology Lab,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2017
+BIOL,3070,8,Vertebrate Biology Lab,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,richard blob,,BIOL-3070,2017
+BIOL,3070,9,Vertebrate Biology Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2017
+BIOL,3070,10,Vertebrate Biology Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2017
+BIOL,3070,11,Vertebrate Biology Lab,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2017
+BIOL,3080,1,Biology of Plants Practicum,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2017
+BIOL,3080,2,Biology of Plants Practicum,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,nathan redding,,BIOL-3080,2017
+BIOL,3080,3,Biology of Plants Practicum,0.35,0.5,0.0,0.1,0.0,0.0,0.0,0.05,nathan redding,,BIOL-3080,2017
+BIOL,3080,4,Biology of Plants Practicum,0.1,0.65,0.2,0.0,0.0,0.0,0.0,0.05,nathan redding,,BIOL-3080,2017
+BIOL,3080,5,Biology of Plants Practicum,0.65,0.1,0.25,0.0,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2017
+BIOL,3080,6,Biology of Plants Practicum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2017
+BIOL,3150,1,Functional Human Anatomy,0.23,0.42,0.19,0.06,0.03,0.0,0.0,0.07,tamara mcnutt-scott,,BIOL-3150,2017
+BIOL,3200,1,Field Botany,0.25,0.21,0.32,0.07,0.0,0.0,0.0,0.14,robert edwa ballard,,BIOL-3200,2017
+BIOL,3350,1,Evolutionary Biology,0.41,0.42,0.13,0.02,0.0,0.0,0.0,0.01,michael sears,,BIOL-3350,2017
+BIOL,3510,1,Biological Anthropology,0.11,0.56,0.11,0.06,0.06,0.0,0.0,0.11,lisa rapaport,,BIOL-3510,2017
+BIOL,3530,1,Forensic Anthropology,0.29,0.47,0.18,0.0,0.0,0.0,0.0,0.06,katherine weisensee,,BIOL-3530,2017
+BIOL,4030,1,Intro to Applied Genomics,0.15,0.46,0.08,0.08,0.08,0.0,0.0,0.15,vincent pa richards,,BIOL-4030,2017
+BIOL,4140,1,Basic Immunology,0.19,0.44,0.31,0.06,0.0,0.0,0.0,0.0,yanzhang wei,,BIOL-4140,2017
+BIOL,4170,1,Marine Biology,0.93,0.06,0.0,0.0,0.0,0.0,0.0,0.01,charles rice,,BIOL-4170,2017
+BIOL,4200,1,Neurobiology,0.48,0.45,0.0,0.03,0.0,0.0,0.0,0.03,david feliciano,,BIOL-4200,2017
+BIOL,4250,1,Introductory Mycology,0.35,0.29,0.26,0.03,0.0,0.0,0.0,0.06,julia loui kerrigan,,BIOL-4250,2017
+BIOL,4260,2,Mycology Practicum,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,,BIOL-4260,2017
+BIOL,4340,1,Biological Chem Lab Techniques,0.06,0.38,0.38,0.13,0.06,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2017
+BIOL,4340,2,Biological Chem Lab Techniques,0.19,0.25,0.19,0.19,0.19,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2017
+BIOL,4340,4,Biological Chem Lab Techniques,0.21,0.36,0.29,0.14,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2017
+BIOL,4410,1,Ecology,0.58,0.27,0.09,0.05,0.0,0.0,0.0,0.01,john jenkins hains,,BIOL-4410,2017
+BIOL,4430,1,Freshwater Ecology,0.47,0.33,0.11,0.03,0.0,0.0,0.0,0.06,john jenkins hains,,BIOL-4430,2017
+BIOL,4440,1,Freshwater Ecology Lab (Lec),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,john jenkins hains,,BIOL-4440,2017
+BIOL,4450,1,Ecology Laboratory (Lec),0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,john jenkins hains,,BIOL-4450,2017
+BIOL,4450,3,Ecology Laboratory (Lec),0.5,0.1,0.4,0.0,0.0,0.0,0.0,0.0,john jenkins hains,,BIOL-4450,2017
+BIOL,4450,4,Ecology Laboratory (Lec),0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,john jenkins hains,,BIOL-4450,2017
+BIOL,4560,1,Medical and Vet Parasitology,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,wilbur kear milhous,,BIOL-4560,2017
+BIOL,4610,1,Cell Biology,0.28,0.42,0.19,0.07,0.01,0.0,0.0,0.04,susan carol chapman,,BIOL-4610,2017
+BIOL,4610,2,Cell Biology (HON),0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True,BIOL-4610,2017
+BIOL,4620,1,Cell Biology Lab (Lec),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,2,Cell Biology Lab (Lec),0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,4,Cell Biology Lab (Lec),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,5,Cell Biology Lab (Lec),0.92,0.0,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,6,Cell Biology Lab (Lec),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,7,Cell Biology Lab (Lec),0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,8,Cell Biology Lab (Lec),0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,9,Cell Biology Lab (Lec),0.89,0.04,0.0,0.0,0.0,0.0,0.0,0.07,xianzhong yu,,BIOL-4620,2017
+BIOL,4670,1,Principles of Hematology,0.77,0.13,0.03,0.0,0.0,0.0,0.0,0.06,vincent gallicchio,,BIOL-4670,2017
+BIOL,4930,1,Sr Sem: Genomics,0.79,0.07,0.0,0.0,0.07,0.0,0.0,0.07,kara elizabe powder,,BIOL-4930,2017
+BIOL,4930,3,Sr Sem: Advances in Cancer,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,,BIOL-4930,2017
+BIOL,4930,5,Sr Sem: Bioelectricity,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,matthew turnbull,,BIOL-4930,2017
+BIOL,4930,8,Sr Sem: Evolutionary Medicine,0.71,0.14,0.0,0.07,0.0,0.0,0.0,0.07,samantha ann price,,BIOL-4930,2017
+BIOL,6030,1,Intro to Applied Genomics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,vincent pa richards,,BIOL-6030,2017
+BIOL,8400,1,Understanding Biological Inq,0.93,0.05,0.01,0.0,0.01,0.0,0.0,0.01,michael childress,,BIOL-8400,2017
+BIOL,8420,1,Understand Cellular Processes,0.64,0.31,0.05,0.0,0.01,0.0,0.0,0.0,patricia leota tate,,BIOL-8420,2017
+BIOL,8440,1,Understanding the Human Body,0.64,0.28,0.04,0.0,0.04,0.0,0.0,0.0,william baldwin,,BIOL-8440,2017
+BUS,1010,1,Business Foundations,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,2,Business Foundations,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,3,Business Foundations,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,4,Business Foundations,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,christopher mann,,BUS-1010,2017
+BUS,1010,5,Business Foundations,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,christopher mann,,BUS-1010,2017
+BUS,1010,6,Business Foundations,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,,BUS-1010,2017
+BUS,1010,7,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,8,Business Foundations,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,,BUS-1010,2017
+BUS,1010,9,Business Foundations,0.16,0.21,0.16,0.16,0.11,0.0,0.0,0.21,william ern tumblin,,BUS-1010,2017
+BUS,1010,10,Business Foundations,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,11,Business Foundations,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,william ern tumblin,,BUS-1010,2017
+BUS,1010,12,Business Foundations,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,christopher mann,,BUS-1010,2017
+BUS,1010,13,Business Foundations,0.16,0.79,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,,BUS-1010,2017
+BUS,1010,14,Business Foundations,0.42,0.26,0.16,0.05,0.05,0.0,0.0,0.05,christopher mann,,BUS-1010,2017
+BUS,1010,15,Business Foundations,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2017
+BUS,1010,16,Business Foundations,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,donna mccubbin,,BUS-1010,2017
+BUS,1010,17,Business Foundations,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2017
+BUS,1010,18,Business Foundations,0.26,0.42,0.11,0.05,0.05,0.0,0.0,0.11,donna mccubbin,,BUS-1010,2017
+BUS,1010,19,Business Foundations,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,donna mccubbin,,BUS-1010,2017
+BUS,1010,20,Business Foundations,0.39,0.33,0.17,0.0,0.0,0.0,0.0,0.11,donna mccubbin,,BUS-1010,2017
+BUS,1010,21,Business Foundations,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,,BUS-1010,2017
+BUS,1010,22,Business Foundations,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,christopher mann,,BUS-1010,2017
+BUS,1010,23,Business Foundations,0.37,0.42,0.11,0.11,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2017
+BUS,1010,24,Business Foundations,0.37,0.37,0.11,0.0,0.0,0.0,0.0,0.16,sandy edge,,BUS-1010,2017
+BUS,1010,25,Business Foundations,0.58,0.11,0.21,0.05,0.05,0.0,0.0,0.0,sandy edge,,BUS-1010,2017
+BUS,1010,26,Business Foundations,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2017
+BUS,1010,27,Business Foundations,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2017
+BUS,1010,28,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2017
+BUS,1010,29,Business Foundations,0.26,0.28,0.26,0.11,0.02,0.0,0.0,0.07,lance scott young,,BUS-1010,2017
+BUS,1010,30,Business Foundations,0.18,0.37,0.35,0.02,0.0,0.0,0.0,0.08,lance scott young,,BUS-1010,2017
+BUS,1010,31,Business Foundations,0.42,0.16,0.37,0.0,0.0,0.0,0.0,0.05,lance scott young,,BUS-1010,2017
+BUS,1010,33,Business Foundations,0.28,0.32,0.28,0.08,0.04,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2017
+BUS,1010,34,Business Foundations,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2017
+BUS,1010,35,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,36,Business Foundations,0.26,0.42,0.21,0.0,0.05,0.0,0.0,0.05,christopher mann,,BUS-1010,2017
+BUS,1010,37,Business Foundations,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2017
+BUS,2990,6,CI: Being a Leader,0.5,0.3,0.1,0.0,0.1,0.0,0.0,0.0,melissa vogel,,BUS-2990,2017
+CE,1990,2,Cr Inq in Civil Engineering,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,weichiang pang,,CE-1990,2017
+CE,1990,20,Cr Inq in Civil Engineering,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,bradley putman,,CE-1990,2017
+CE,2010,1,Statics,0.22,0.17,0.26,0.07,0.09,0.0,0.0,0.2,melissa sternhagen,,CE-2010,2017
+CE,2010,2,Statics,0.27,0.3,0.25,0.05,0.07,0.0,0.0,0.07,"mahmoudabadi arani,",,CE-2010,2017
+CE,2010,3,Statics,0.46,0.21,0.13,0.08,0.06,0.0,0.0,0.06,qiushi chen,,CE-2010,2017
+CE,2010,4,Statics,0.18,0.34,0.14,0.11,0.07,0.0,0.0,0.16,melissa sternhagen,,CE-2010,2017
+CE,2010,5,Statics,0.43,0.36,0.16,0.0,0.02,0.0,0.0,0.02,mahmoodreza soltani,,CE-2010,2017
+CE,2010,6,Statics,0.15,0.23,0.15,0.08,0.09,0.0,0.0,0.29,melissa sternhagen,,CE-2010,2017
+CE,2010,8,Statics,0.1,0.37,0.29,0.04,0.08,0.0,0.0,0.12, kent nilsson,,CE-2010,2017
+CE,2060,1,Structural Mechanics,0.41,0.33,0.22,0.02,0.02,0.0,0.0,0.02,mahmoodreza soltani,,CE-2060,2017
+CE,2080,1,Dynamics,0.07,0.29,0.34,0.2,0.05,0.0,0.0,0.05,melissa sternhagen,,CE-2080,2017
+CE,2550,1,Geomatics,0.3,0.45,0.2,0.04,0.01,0.0,0.0,0.0,wayne sarasua,,CE-2550,2017
+CE,3010,1,Structural Analysis,0.35,0.32,0.24,0.08,0.0,0.0,0.0,0.0,stephen csernak,,CE-3010,2017
+CE,3010,2,Structural Analysis,0.42,0.36,0.11,0.06,0.03,0.0,0.0,0.03,thomas edfo cousins,,CE-3010,2017
+CE,3110,1,Transportation Engr,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,jennifer ogle,,CE-3110,2017
+CE,3210,1,Geotechnical Engineering,0.21,0.24,0.33,0.14,0.07,0.0,0.0,0.0,qiushi chen,,CE-3210,2017
+CE,3310,1,Constr Engr & Mgmnt,0.59,0.28,0.09,0.03,0.01,0.0,0.0,0.0,james burati,,CE-3310,2017
+CE,3410,1,Intro to Fluid Mech,0.33,0.4,0.17,0.1,0.0,0.0,0.0,0.0,nigel gregory kaye,,CE-3410,2017
+CE,3410,2,Intro to Fluid Mech,0.17,0.38,0.3,0.02,0.13,0.0,0.0,0.0,abdul khan,,CE-3410,2017
+CE,3420,1,Hydraulics & Hydro,0.5,0.33,0.11,0.07,0.0,0.0,0.0,0.0,ashok mishra,,CE-3420,2017
+CE,3510,1,Civil Engineering Materials,0.24,0.51,0.22,0.0,0.02,0.0,0.0,0.0,ami esmaeilpoursaee,,CE-3510,2017
+CE,3510,2,Civil Engineering Materials,0.45,0.48,0.07,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,,CE-3510,2017
+CE,3520,1,Econ Eval of Proj,0.46,0.26,0.19,0.04,0.0,0.0,0.0,0.06,zoraya rolda rockow,,CE-3520,2017
+CE,4010,1,Matrix Str Analysis,0.0,0.47,0.2,0.2,0.07,0.0,0.0,0.07,bryant nielson,,CE-4010,2017
+CE,4020,1,Reinfor Con Design,0.36,0.39,0.21,0.03,0.0,0.0,0.0,0.0,brandon ross,,CE-4020,2017
+CE,4060,1,Struct Steel Design,0.36,0.44,0.05,0.08,0.03,0.0,0.0,0.05,stephen csernak,,CE-4060,2017
+CE,4100,1,Traffic Engr Oper,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,wayne sarasua,,CE-4100,2017
+CE,4240,1,Earth Slopes & Struc,0.33,0.39,0.2,0.04,0.04,0.0,0.0,0.0,nadara ravichandran,,CE-4240,2017
+CE,4330,1,Const Plan & Sched,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,CE-4330,2017
+CE,4390,1,Con Eqpmt Sel & Main,0.32,0.45,0.18,0.0,0.0,0.0,0.0,0.05,james burati,,CE-4390,2017
+CE,4560,1,Pave Design & Constr,0.48,0.44,0.04,0.0,0.0,0.0,0.0,0.04,bradley putman,,CE-4560,2017
+CE,4590,1,Capstone Design Proj,0.51,0.3,0.05,0.14,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2017
+CE,4910,1,BIM in Construction Management,0.76,0.14,0.03,0.0,0.07,0.0,0.0,0.0,kalyan ram piratla,,CE-4910,2017
+CE,4910,2,Hydrologic Analysis and Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ashok mishra,,CE-4910,2017
+CE,6010,1,Matrix Str Analysis,0.45,0.41,0.14,0.0,0.0,0.0,0.0,0.0,bryant nielson,,CE-6010,2017
+CE,6100,1,Traffic Engr Oper,0.4,0.2,0.2,0.0,0.0,0.0,0.0,0.2,wayne sarasua,,CE-6100,2017
+CE,6240,1,Earth Slopes & Struc,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-6240,2017
+CE,6390,1,Con Eqpmt Sel & Main,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,james burati,,CE-6390,2017
+CE,6560,1,Pavement Des & Const,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,bradley putman,,CE-6560,2017
+CE,8200,1,Geotech Site Charac,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-8200,2017
+CE,8260,1,Prop of Concrete,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,,CE-8260,2017
+CE,8320,1,Capl Proj Mgmt Fund,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,CE-8320,2017
+CE,8580,500,Fund of Risk Engineering Mgt,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,jie zhang,,CE-8580,2017
+CE,8930,2,Bridge Design,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brandon ross,,CE-8930,2017
+CE,8930,4,Data Analytics for Transpo,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-8930,2017
+CE,8930,5,Civil Infrastructure Systems,0.71,0.0,0.14,0.0,0.0,0.0,0.0,0.14,pamela murray-tuite,,CE-8930,2017
+CH,1010,1,General Chemistry,0.18,0.24,0.27,0.15,0.07,0.0,0.0,0.09,william mcwhorter,,CH-1010,2017
+CH,1010,2,General Chemistry,0.26,0.29,0.23,0.1,0.04,0.0,0.0,0.08,elliot ennis,,CH-1010,2017
+CH,1010,3,General Chemistry,0.16,0.28,0.23,0.15,0.06,0.0,0.0,0.12,william mcwhorter,,CH-1010,2017
+CH,1010,4,General Chemistry,0.24,0.31,0.22,0.11,0.05,0.0,0.0,0.08,dennis taylor,,CH-1010,2017
+CH,1010,5,General Chemistry,0.27,0.29,0.19,0.12,0.05,0.0,0.0,0.08,william mcwhorter,,CH-1010,2017
+CH,1010,6,General Chemistry,0.15,0.38,0.21,0.17,0.04,0.0,0.0,0.05,thomas hickman,,CH-1010,2017
+CH,1010,7,General Chemistry,0.22,0.34,0.25,0.11,0.03,0.0,0.0,0.05,laura lanni,,CH-1010,2017
+CH,1010,8,General Chemistry,0.33,0.37,0.16,0.05,0.03,0.0,0.0,0.05,tania issa houjeiry,,CH-1010,2017
+CH,1010,9,General Chemistry,0.25,0.39,0.21,0.09,0.03,0.0,0.0,0.03,dennis taylor,,CH-1010,2017
+CH,1010,10,General Chemistry,0.33,0.3,0.19,0.06,0.05,0.0,0.0,0.08,tania issa houjeiry,,CH-1010,2017
+CH,1010,11,General Chemistry,0.21,0.24,0.3,0.1,0.07,0.0,0.0,0.08,princess mycia cox,,CH-1010,2017
+CH,1010,12,General Chemistry,0.31,0.33,0.19,0.06,0.03,0.0,0.0,0.08,elliot ennis,,CH-1010,2017
+CH,1010,13,General Chemistry,0.2,0.38,0.26,0.11,0.03,0.0,0.0,0.02,dennis taylor,,CH-1010,2017
+CH,1010,50,General Chemistry,0.26,0.35,0.13,0.16,0.06,0.0,0.0,0.03,shiou-jyh hwu,,CH-1010,2017
+CH,1010,51,General Chemistry (HON),0.69,0.2,0.12,0.0,0.0,0.0,0.0,0.0,william pennington,True,CH-1010,2017
+CH,1010,52,General Chemistry (HON),0.68,0.2,0.1,0.02,0.0,0.0,0.0,0.0,joseph stu thrasher,True,CH-1010,2017
+CH,1010,201,General Chemistry,0.22,0.36,0.28,0.09,0.03,0.0,0.0,0.03,laura lanni,,CH-1010,2017
+CH,1010,202,General Chemistry,0.2,0.43,0.22,0.11,0.02,0.0,0.0,0.03,jacob schroeder,,CH-1010,2017
+CH,1010,203,General Chemistry,0.2,0.39,0.24,0.08,0.03,0.0,0.0,0.05,olt geiculescu,,CH-1010,2017
+CH,1010,204,General Chemistry,0.25,0.43,0.17,0.12,0.02,0.0,0.0,0.01,princess mycia cox,,CH-1010,2017
+CH,1010,501,General Chemistry,0.21,0.39,0.24,0.12,0.0,0.0,0.0,0.03,brian gloor,,CH-1010,2017
+CH,1020,1,General Chemistry,0.37,0.21,0.21,0.11,0.03,0.0,0.0,0.06,stephe schvaneveldt,,CH-1020,2017
+CH,1020,2,General Chemistry,0.21,0.22,0.29,0.15,0.05,0.0,0.0,0.08,stephe schvaneveldt,,CH-1020,2017
+CH,1020,3,General Chemistry,0.31,0.19,0.3,0.09,0.02,0.0,0.0,0.08,stephe schvaneveldt,,CH-1020,2017
+CH,1020,400,General Chemistry,0.1,0.25,0.29,0.15,0.15,0.0,0.0,0.06,stephe schvaneveldt,,CH-1020,2017
+CH,1050,1,Chemistry in Context I,0.37,0.51,0.07,0.02,0.02,0.0,0.0,0.02,olt geiculescu,,CH-1050,2017
+CH,1050,2,Chemistry in Context I,0.33,0.47,0.11,0.04,0.03,0.0,0.0,0.01,olt geiculescu,,CH-1050,2017
+CH,2010,1,Survey of Organic Chemistry,0.2,0.33,0.26,0.11,0.08,0.0,0.0,0.02,thomas hickman,,CH-2010,2017
+CH,2010,2,Survey of Organic Chemistry,0.29,0.45,0.15,0.09,0.0,0.0,0.0,0.02,thomas hickman,,CH-2010,2017
+CH,2020,1,Surv of Organic Chemistry Lab,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2020,2017
+CH,2020,2,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2020,2017
+CH,2020,4,Surv of Organic Chemistry Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,,CH-2020,2017
+CH,2020,5,Surv of Organic Chemistry Lab,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,james nelso plampin,,CH-2020,2017
+CH,2020,6,Surv of Organic Chemistry Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,,CH-2020,2017
+CH,2020,8,Surv of Organic Chemistry Lab,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,,CH-2020,2017
+CH,2020,9,Surv of Organic Chemistry Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2020,2017
+CH,2230,1,Organic Chemistry,0.32,0.25,0.14,0.05,0.06,0.0,0.0,0.18,modi wetzler,,CH-2230,2017
+CH,2230,2,Organic Chemistry,0.36,0.3,0.09,0.11,0.04,0.0,0.0,0.11,modi wetzler,,CH-2230,2017
+CH,2230,3,Organic Chemistry,0.34,0.37,0.17,0.04,0.03,0.0,0.0,0.05,tania issa houjeiry,,CH-2230,2017
+CH,2230,4,Organic Chemistry,0.19,0.43,0.17,0.06,0.04,0.0,0.0,0.11,laura lanni,,CH-2230,2017
+CH,2230,5,Organic Chemistry,0.29,0.4,0.15,0.07,0.05,0.0,0.0,0.04,elliot ennis,,CH-2230,2017
+CH,2230,6,Organic Chemistry,0.25,0.36,0.18,0.06,0.04,0.0,0.0,0.12,rhett smith,,CH-2230,2017
+CH,2230,7,Organic Chemistry,0.31,0.31,0.2,0.05,0.03,0.0,0.0,0.1,sourav saha,,CH-2230,2017
+CH,2240,1,Organic Chemistry,0.27,0.31,0.23,0.05,0.13,0.0,0.0,0.01,jacob schroeder,,CH-2240,2017
+CH,2240,2,Organic Chemistry,0.27,0.26,0.26,0.09,0.06,0.0,0.0,0.06,jacob schroeder,,CH-2240,2017
+CH,2270,1,Organic Chem Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,,CH-2270,2017
+CH,2270,3,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,4,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,7,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,james nelso plampin,,CH-2270,2017
+CH,2270,8,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,9,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,10,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,,CH-2270,2017
+CH,2270,12,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,13,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,14,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,,CH-2270,2017
+CH,2270,16,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,17,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,,CH-2270,2017
+CH,2270,18,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,20,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,21,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,23,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,,CH-2270,2017
+CH,2270,24,Organic Chem Lab,0.73,0.13,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,26,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,27,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,28,Organic Chem Lab,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,james nelso plampin,,CH-2270,2017
+CH,2270,30,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,31,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,james nelso plampin,,CH-2270,2017
+CH,2270,32,Organic Chem Lab,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,33,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2270,2017
+CH,2270,34,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,35,Organic Chem Lab,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2270,2017
+CH,2270,36,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,,CH-2270,2017
+CH,2270,37,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,,CH-2270,2017
+CH,2270,38,Organic Chem Lab,0.56,0.13,0.0,0.0,0.06,0.0,0.0,0.25,james nelso plampin,,CH-2270,2017
+CH,2280,1,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,,CH-2280,2017
+CH,2280,2,Organic Chem Lab,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,james nelso plampin,,CH-2280,2017
+CH,2280,3,Organic Chem Lab,0.76,0.06,0.0,0.0,0.0,0.0,0.0,0.18,james nelso plampin,,CH-2280,2017
+CH,2280,4,Organic Chem Lab,0.72,0.0,0.0,0.0,0.0,0.0,0.0,0.28,james nelso plampin,,CH-2280,2017
+CH,2280,5,Organic Chem Lab,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,,CH-2280,2017
+CH,2280,6,Organic Chem Lab,0.71,0.0,0.0,0.0,0.06,0.0,0.0,0.24,james nelso plampin,,CH-2280,2017
+CH,2280,7,Organic Chem Lab,0.73,0.07,0.07,0.0,0.13,0.0,0.0,0.0,james nelso plampin,,CH-2280,2017
+CH,2280,9,Organic Chem Lab,0.7,0.0,0.0,0.0,0.0,0.0,0.0,0.3,james nelso plampin,,CH-2280,2017
+CH,3130,1,Quantitative Analys,0.54,0.2,0.22,0.05,0.0,0.0,0.0,0.0,stephen creager,,CH-3130,2017
+CH,3150,1,Quant Analysis Lab,0.64,0.09,0.0,0.0,0.18,0.0,0.0,0.09,carlos garcia perez,,CH-3150,2017
+CH,3150,2,Quant Analysis Lab,0.25,0.58,0.08,0.0,0.0,0.0,0.0,0.08,carlos garcia perez,,CH-3150,2017
+CH,3300,1,Intro to Phys Chem,0.46,0.29,0.14,0.03,0.05,0.0,0.0,0.03,brian dominy,,CH-3300,2017
+CH,3310,1,Physical Chemistry,0.13,0.13,0.33,0.2,0.13,0.0,0.0,0.07,steven stuart,,CH-3310,2017
+CH,3310,2,Physical Chemistry,0.75,0.08,0.08,0.04,0.0,0.0,0.0,0.04,jason mcneill,,CH-3310,2017
+CH,3320,1,Physical Chemistry,0.41,0.35,0.06,0.0,0.0,0.0,0.0,0.18,arkady kholodenko,,CH-3320,2017
+CH,3390,1,Physical Chem Lab,0.2,0.75,0.0,0.0,0.0,0.0,0.0,0.05,princess mycia cox,,CH-3390,2017
+CH,3390,2,Physical Chem Lab,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,princess mycia cox,,CH-3390,2017
+CH,3390,4,Physical Chem Lab,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2017
+CH,3390,5,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2017
+CH,3410,1,Introduction to Research,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,stephen creager,,CH-3410,2017
+CH,4010,1,Organometallic Chemistry,0.66,0.3,0.0,0.0,0.0,0.0,0.0,0.04,andrew gre tennyson,,CH-4010,2017
+CH,4020,1,Inorganic Chemistry,0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,joseph kolis,,CH-4020,2017
+CH,8070,1,Chem Trans Elem,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,julia brumaghim,,CH-8070,2017
+CH,8140,1,Analytical Imaging,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,george chumanov,,CH-8140,2017
+CH,8160,1,Separation Science,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,richard marcus,,CH-8160,2017
+CH,8210,1,Organic Chem I,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,ya-ping sun,,CH-8210,2017
+CH,8410,3,N M R Spectroscopy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alek kitaygorodskiy,,CH-8410,2017
+CH,8510,1,Grad Student Seminar,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,joseph stu thrasher,,CH-8510,2017
+CH,8520,1,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,leah bec casabianca,,CH-8520,2017
+CHE,2110,1,Mass and Energy Balances,0.11,0.19,0.31,0.14,0.11,0.0,0.0,0.14,mark roberts,,CHE-2110,2017
+CHE,2110,2,Mass and Energy Balances,0.28,0.27,0.33,0.02,0.03,0.0,0.0,0.07,mark roberts,,CHE-2110,2017
+CHE,3210,1,Ch E Thermo II,0.13,0.2,0.36,0.27,0.04,0.0,0.0,0.0,sapna sarupria,,CHE-3210,2017
+CHE,3300,1,Mass Trans & Seprtn,0.16,0.2,0.4,0.12,0.11,0.0,0.0,0.01,mark thies,,CHE-3300,2017
+CHE,4070,1,Unit Op Lab II,0.16,0.72,0.12,0.0,0.0,0.0,0.0,0.0,christopher norfolk,,CHE-4070,2017
+CHE,4140,1,Green Engineering,0.48,0.44,0.08,0.0,0.0,0.0,0.0,0.0,christophe kitchens,,CHE-4140,2017
+CHE,4310,1,Process Design I,0.25,0.47,0.28,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4310,2017
+CHE,4500,1,Chem Reaction Engr,0.19,0.27,0.39,0.14,0.01,0.0,0.0,0.0,rachel getman,,CHE-4500,2017
+CHE,6130,1,Polymer Composite Engineering,0.4,0.2,0.4,0.0,0.0,0.0,0.0,0.0,amod ogale,,CHE-6130,2017
+CHE,8030,1,Advanced Transport,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,eric mikel davis,,CHE-8030,2017
+CHE,8040,1,Ch E Thermodynamics,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,joseph scott,,CHE-8040,2017
+CHE,8050,1,Ch E Kinetics,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,mark alan blenner,,CHE-8050,2017
+CHIN,2010,1,Intermediate Chinese,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,ling rao,,CHIN-2010,2017
+CHIN,3050,1,Chin Conv & Comp I,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,yanhua zhang,,CHIN-3050,2017
+COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,eddie smith,,COM-1010,2017
+COM,1500,1,Intro to Human Communication,0.83,0.15,0.0,0.0,0.01,0.0,0.0,0.02,eddie smith,,COM-1500,2017
+COM,1500,2,Intro to Human Communication,0.69,0.26,0.01,0.01,0.01,0.0,0.0,0.02,daniel lelan fecher,,COM-1500,2017
+COM,1500,3,Intro to Human Communication,0.91,0.07,0.02,0.0,0.01,0.0,0.0,0.0,eddie smith,,COM-1500,2017
+COM,1500,4,Intro to Human Communication,0.77,0.16,0.03,0.0,0.02,0.0,0.0,0.02,marianne her glaser,,COM-1500,2017
+COM,1500,5,Intro to Human Communication,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,marianne her glaser,,COM-1500,2017
+COM,1500,6,Intro to Human Communication,0.81,0.1,0.03,0.0,0.03,0.0,0.0,0.03,marianne her glaser,,COM-1500,2017
+COM,1500,7,Intro to Human Communication,0.43,0.47,0.04,0.03,0.03,0.0,0.0,0.0,daniel lelan fecher,,COM-1500,2017
+COM,2010,1,Intr to Comm Studies,0.69,0.28,0.0,0.03,0.0,0.0,0.0,0.0,darren linvill,,COM-2010,2017
+COM,2010,2,Intr to Comm Studies,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-2010,2017
+COM,2020,1,Communication Theory,0.31,0.31,0.31,0.06,0.0,0.0,0.0,0.0,kristen ela okamoto,,COM-2020,2017
+COM,2020,2,Communication Theory,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,kristen ela okamoto,,COM-2020,2017
+COM,2040,1,Critical-Cultural Comm Theory,0.61,0.22,0.11,0.0,0.0,0.0,0.0,0.06,david travers scott,,COM-2040,2017
+COM,2100,1,Quant Comm Research Methods,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-2100,2017
+COM,2100,2,Quant Comm Research Methods,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-2100,2017
+COM,2110,1,Qual Comm Research Methods,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,angela pratt,,COM-2110,2017
+COM,2500,1,Public Speaking,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2017
+COM,2500,2,Public Speaking,0.35,0.47,0.06,0.06,0.0,0.0,0.0,0.06,sara grumbl crocker,,COM-2500,2017
+COM,2500,3,Public Speaking,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2017
+COM,2500,4,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2017
+COM,2500,5,Public Speaking,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2017
+COM,2500,6,Public Speaking,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2017
+COM,2500,7,Public Speaking,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,,COM-2500,2017
+COM,2500,8,Public Speaking,0.56,0.39,0.0,0.06,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2017
+COM,2500,9,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2017
+COM,2500,10,Public Speaking,0.53,0.26,0.16,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2017
+COM,2500,11,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,,COM-2500,2017
+COM,2500,12,Public Speaking,0.61,0.22,0.06,0.0,0.11,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2017
+COM,2500,13,Public Speaking,0.63,0.21,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2017
+COM,2500,14,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2017
+COM,2500,16,Public Speaking,0.84,0.0,0.11,0.0,0.0,0.0,0.0,0.05,vanessa anne condon,,COM-2500,2017
+COM,2500,17,Public Speaking,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,the estate  geddes,,COM-2500,2017
+COM,2500,18,Public Speaking,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,pauline matthey,,COM-2500,2017
+COM,2500,19,Public Speaking,0.32,0.26,0.32,0.11,0.0,0.0,0.0,0.0,pauline matthey,,COM-2500,2017
+COM,2500,21,Public Speaking,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,katie barn mcelveen,,COM-2500,2017
+COM,2500,23,Public Speaking,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,pauline matthey,,COM-2500,2017
+COM,2500,24,Public Speaking,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,katie barn mcelveen,,COM-2500,2017
+COM,2500,25,Public Speaking (HON),0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True,COM-2500,2017
+COM,2500,26,Public Speaking (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,True,COM-2500,2017
+COM,2500,28,Public Speaking,0.67,0.11,0.11,0.0,0.06,0.0,0.0,0.06,sara grumbl crocker,,COM-2500,2017
+COM,2500,29,Public Speaking,0.68,0.11,0.11,0.0,0.0,0.0,0.0,0.11,sara grumbl crocker,,COM-2500,2017
+COM,2500,30,Public Speaking,0.53,0.21,0.11,0.0,0.05,0.0,0.0,0.11,jumah patrici taweh,,COM-2500,2017
+COM,2500,31,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2017
+COM,2500,32,Public Speaking,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2017
+COM,2500,33,Public Speaking,0.56,0.17,0.17,0.0,0.11,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2017
+COM,2500,34,Public Speaking,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,,COM-2500,2017
+COM,2500,35,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,,COM-2500,2017
+COM,2500,36,Public Speaking,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,amanda elizab moore,,COM-2500,2017
+COM,2500,37,Public Speaking,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,amanda elizab moore,,COM-2500,2017
+COM,2500,39,Public Speaking (HON),0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,lindsey dixon,True,COM-2500,2017
+COM,2500,400,Public Speaking,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2017
+COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2017
+COM,2500,403,Public Speaking,0.89,0.0,0.06,0.0,0.06,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2017
+COM,3220,1,Communication Design,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,,COM-3220,2017
+COM,3240,1,"Communication, Sport & Society",0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,,COM-3240,2017
+COM,3240,2,"Communication, Sport & Society",0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,,COM-3240,2017
+COM,3260,2,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2017
+COM,3260,3,Pr in Sports,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,katie barn mcelveen,,COM-3260,2017
+COM,3480,1,Interpersonal Comm,0.64,0.28,0.06,0.03,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-3480,2017
+COM,3550,1,Principles of Public Relations,0.65,0.24,0.04,0.02,0.02,0.0,0.0,0.02,meghna tallapragada,,COM-3550,2017
+COM,3570,1,Public Relations Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3570,2017
+COM,3570,2,Public Relations Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3570,2017
+COM,3660,4,Adv. Strategic Comm,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,mark david land,,COM-3660,2017
+COM,4250,1,Adv Sports Comm,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,bryan denham,,COM-4250,2017
+COM,4260,1,Social Media and Sports Comm,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4260,2017
+COM,4260,2,Social Media and Sports Comm,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4260,2017
+COM,4300,1,Legal Communication,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,james isaac roberts,,COM-4300,2017
+COM,4710,1,Health Comm in Communities,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4710,2017
+COM,8030,1,Comm Technology Studies Survey,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,,COM-8030,2017
+COM,8100,1,Comm Research Methods I,0.25,0.63,0.0,0.0,0.13,0.0,0.0,0.0,gregory kei cranmer,,COM-8100,2017
+CPSC,1010,1,Computer Science I,0.16,0.35,0.13,0.11,0.1,0.0,0.0,0.15,salvatore lamarca,,CPSC-1010,2017
+CPSC,1010,2,Computer Science I,0.19,0.31,0.21,0.12,0.09,0.0,0.0,0.09,salvatore lamarca,,CPSC-1010,2017
+CPSC,1020,1,Computer Science II,0.27,0.13,0.17,0.17,0.12,0.0,0.0,0.13,yvon feaster,,CPSC-1020,2017
+CPSC,1020,2,Computer Science II,0.37,0.29,0.16,0.03,0.11,0.0,0.0,0.05,yvon feaster,,CPSC-1020,2017
+CPSC,1060,1,Intro to Programming in Java,0.32,0.24,0.12,0.06,0.15,0.0,0.0,0.12,salvatore lamarca,,CPSC-1060,2017
+CPSC,1070,1,Programming Methodology,0.57,0.18,0.14,0.06,0.02,0.0,0.0,0.04,rose lowe,,CPSC-1070,2017
+CPSC,1110,1,Intro to Programming in C,0.37,0.27,0.15,0.05,0.07,0.0,0.0,0.08,catherine hochrine,,CPSC-1110,2017
+CPSC,1110,2,Intro to Programming in C,0.31,0.25,0.1,0.05,0.19,0.0,0.0,0.1,catherine hochrine,,CPSC-1110,2017
+CPSC,1110,3,Intro to Programming in C,0.48,0.2,0.12,0.08,0.02,0.0,0.0,0.11,john junius porter,,CPSC-1110,2017
+CPSC,1210,1,Computational Thinking,0.11,0.44,0.11,0.0,0.17,0.0,0.0,0.17,larry hodges,,CPSC-1210,2017
+CPSC,2070,1,Discrete Structures,0.21,0.28,0.23,0.07,0.11,0.0,0.0,0.1,larry hodges,,CPSC-2070,2017
+CPSC,2120,1,Algs/Data Structures,0.3,0.23,0.18,0.04,0.09,0.0,0.0,0.16,brian christop dean,,CPSC-2120,2017
+CPSC,2120,2,Algs/Data Structures,0.25,0.33,0.22,0.05,0.05,0.0,0.0,0.1,wayne goddard,,CPSC-2120,2017
+CPSC,2150,1,Software Dev Foundations,0.27,0.36,0.25,0.03,0.02,0.0,0.0,0.07,kevin anton plis,,CPSC-2150,2017
+CPSC,2150,2,Software Dev Foundations,0.27,0.27,0.21,0.02,0.14,0.0,0.0,0.09,kevin anton plis,,CPSC-2150,2017
+CPSC,2200,1,Microcomputer Appl,0.46,0.39,0.07,0.04,0.04,0.0,0.0,0.0,kevin anton plis,,CPSC-2200,2017
+CPSC,2200,2,Microcomputer Appl,0.26,0.37,0.19,0.11,0.07,0.0,0.0,0.0,kevin anton plis,,CPSC-2200,2017
+CPSC,2310,1,Intro Computer Org,0.42,0.43,0.09,0.04,0.02,0.0,0.0,0.0,rose lowe,,CPSC-2310,2017
+CPSC,2310,2,Intro Computer Org,0.44,0.26,0.22,0.02,0.02,0.0,0.0,0.04,rose lowe,,CPSC-2310,2017
+CPSC,2810,1,Selected Topics: TA Class,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,christopher plaue,,CPSC-2810,2017
+CPSC,2910,1,Prof Issues I,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2017
+CPSC,2910,2,Prof Issues I,0.59,0.24,0.12,0.06,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2017
+CPSC,2910,3,Prof Issues I,0.47,0.33,0.07,0.0,0.07,0.0,0.0,0.07,catherine hochrine,,CPSC-2910,2017
+CPSC,2910,4,Prof Issues I,0.61,0.17,0.17,0.0,0.06,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2017
+CPSC,2910,5,Prof Issues I,0.39,0.39,0.06,0.0,0.11,0.0,0.0,0.06,catherine hochrine,,CPSC-2910,2017
+CPSC,2920,1,"Computing, Ethics & Society",0.25,0.4,0.25,0.05,0.0,0.0,0.0,0.05,christopher plaue,,CPSC-2920,2017
+CPSC,3220,1,Intro to Operating Systems,0.12,0.36,0.36,0.12,0.03,0.0,0.0,0.0,mark smotherman,,CPSC-3220,2017
+CPSC,3220,2,Intro to Operating Systems,0.55,0.4,0.04,0.02,0.0,0.0,0.0,0.0,carl bryan martin,,CPSC-3220,2017
+CPSC,3220,3,Intro to Operating Systems,0.21,0.42,0.11,0.16,0.11,0.0,0.0,0.0, van den meiracker,,CPSC-3220,2017
+CPSC,3300,1,Computer Systems Org,0.21,0.34,0.34,0.11,0.0,0.0,0.0,0.0,rong ge,,CPSC-3300,2017
+CPSC,3500,1,Foundations of Computer Sci,0.15,0.19,0.41,0.07,0.02,0.0,0.0,0.17,ilya mark safro,,CPSC-3500,2017
+CPSC,3520,1,Programming Systems,0.3,0.48,0.08,0.0,0.03,0.0,0.0,0.1,robert schalkoff,,CPSC-3520,2017
+CPSC,3600,1,Network Programming,0.28,0.42,0.22,0.02,0.03,0.0,0.0,0.03,feng luo,,CPSC-3600,2017
+CPSC,3600,2,Network Programming,0.2,0.28,0.35,0.08,0.02,0.0,0.0,0.07,james martin,,CPSC-3600,2017
+CPSC,3720,1,Software Engineering,0.31,0.36,0.23,0.07,0.0,0.0,0.0,0.03,murali sitaraman,,CPSC-3720,2017
+CPSC,3720,2,Software Engineering,0.24,0.36,0.4,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,,CPSC-3720,2017
+CPSC,4050,1,Computer Graphics,0.4,0.28,0.16,0.0,0.08,0.0,0.0,0.08,victor zordan,,CPSC-4050,2017
+CPSC,4110,1,Virtual Reality Systems,0.38,0.25,0.2,0.08,0.1,0.0,0.0,0.0,sabarish venka babu,,CPSC-4110,2017
+CPSC,4120,1,Eye Tracking Methodology,0.3,0.49,0.11,0.03,0.03,0.0,0.0,0.05,andrew duchowski,,CPSC-4120,2017
+CPSC,4160,1,2-D Game Engine Construction,0.64,0.11,0.13,0.0,0.09,0.0,0.0,0.02,brian malloy,,CPSC-4160,2017
+CPSC,4180,1,Usable Privacy and Security,0.64,0.31,0.03,0.0,0.0,0.0,0.0,0.03,kelly caine,,CPSC-4180,2017
+CPSC,4200,1,Computer Security Principles,0.68,0.21,0.09,0.0,0.03,0.0,0.0,0.0,hongxin hu,,CPSC-4200,2017
+CPSC,4300,1,Applied Data Science,0.51,0.28,0.18,0.0,0.03,0.0,0.0,0.0,alexander ch herzog,,CPSC-4300,2017
+CPSC,4620,1,Database Management Systems,0.06,0.28,0.28,0.0,0.13,0.0,0.0,0.25,pradip srimani,,CPSC-4620,2017
+CPSC,4770,1,Distributed/Cluster Computing,0.21,0.26,0.16,0.0,0.16,0.0,0.0,0.21,linh bao ngo,,CPSC-4770,2017
+CPSC,4820,1,Spec Top: Embed Prototyp,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jacob sorber,,CPSC-4820,2017
+CPSC,4820,2,Spec Topics: Cloud Comp Archit,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,amy apon,,CPSC-4820,2017
+CPSC,4820,3,Spec Topic: Web Programming,0.51,0.27,0.07,0.02,0.07,0.0,0.0,0.05,craig baker,,CPSC-4820,2017
+CPSC,4910,1,Professional Issues II,0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,,CPSC-4910,2017
+CPSC,6040,1,Cptr Graphics Image,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,,CPSC-6040,2017
+CPSC,6040,2,Cptr Graphics Image,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,ioannis karamouzas,,CPSC-6040,2017
+CPSC,6050,1,Computer Graphics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,victor zordan,,CPSC-6050,2017
+CPSC,6110,1,Virtual Reality Systems,0.0,0.57,0.29,0.0,0.0,0.0,0.0,0.14,sabarish venka babu,,CPSC-6110,2017
+CPSC,6120,1,Eye Tracking Methodology,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,andrew duchowski,,CPSC-6120,2017
+CPSC,6160,3,2-D Game Engine Construction,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,brian malloy,,CPSC-6160,2017
+CPSC,6300,1,Applied Data Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,,CPSC-6300,2017
+CPSC,6770,1,Distributed/Cluster Computing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,linh bao ngo,,CPSC-6770,2017
+CPSC,6820,2,Spec Topics: Cloud Comp Archit,0.44,0.38,0.06,0.0,0.0,0.0,0.0,0.13,amy apon,,CPSC-6820,2017
+CPSC,8170,1,Physically Based Animation,0.64,0.18,0.09,0.0,0.0,0.0,0.0,0.09,jerry tessendorf,,CPSC-8170,2017
+CPSC,8200,1,Parallel Architechture,0.36,0.36,0.07,0.0,0.07,0.0,0.0,0.14,pradip srimani,,CPSC-8200,2017
+CPSC,8270,1,Translation of Progr Languages,0.56,0.28,0.13,0.0,0.03,0.0,0.0,0.0,brian malloy,,CPSC-8270,2017
+CPSC,8480,1,Network Science,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ilya mark safro,,CPSC-8480,2017
+CPSC,8730,1,"Software Verif, Valid & Measur",0.41,0.54,0.0,0.0,0.0,0.0,0.0,0.05,john mcgregor,,CPSC-8730,2017
+CPSC,8810,1,Selected Topics: Data Analytic,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CPSC-8810,2017
+CPSC,8810,2,Sel Top: VH/Embod Conver Agent,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,andrew robb,,CPSC-8810,2017
+CRP,8010,1,Planning Process & Legal Found,0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,caitlin dyckman,,CRP-8010,2017
+CRP,8020,1,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,,CRP-8020,2017
+CRP,8030,2,Quan Analysis for Planners,0.63,0.19,0.06,0.0,0.0,0.0,0.0,0.13,eric morris,,CRP-8030,2017
+CRP,8040,1,Intro to GIS for Plan & Policy,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,timothy green,,CRP-8040,2017
+CRP,8080,1,Land Use and Compreh Planning,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,clifford dona ellis,,CRP-8080,2017
+CRP,8450,1,Water Policy & Law,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,,CRP-8450,2017
+CSM,1000,1,Intro to Construct,0.44,0.33,0.11,0.04,0.04,0.0,0.0,0.04,jason lucas,,CSM-1000,2017
+CSM,1000,2,Intro to Construct,0.5,0.38,0.04,0.04,0.04,0.0,0.0,0.0,jason lucas,,CSM-1000,2017
+CSM,2010,1,Structures I,0.18,0.25,0.32,0.14,0.07,0.0,0.0,0.04,shima clarke,,CSM-2010,2017
+CSM,2010,2,Structures I,0.36,0.25,0.21,0.07,0.11,0.0,0.0,0.0,shima clarke,,CSM-2010,2017
+CSM,2030,1,Mats & Meth of Const,0.27,0.53,0.13,0.03,0.03,0.0,0.0,0.0,robert seel,,CSM-2030,2017
+CSM,2030,2,Mats & Meth of Const,0.23,0.5,0.13,0.0,0.07,0.0,0.0,0.07,robert seel,,CSM-2030,2017
+CSM,3040,1,Envir Systems I,0.27,0.43,0.3,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2017
+CSM,3040,2,Envir Systems I,0.25,0.46,0.13,0.13,0.04,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2017
+CSM,3060,1,Emerging Tech in Construction,0.43,0.43,0.11,0.0,0.0,0.0,0.0,0.04,jason lucas,,CSM-3060,2017
+CSM,3060,2,Emerging Tech in Construction,0.52,0.36,0.08,0.0,0.0,0.0,0.0,0.04,jason lucas,,CSM-3060,2017
+CSM,3510,1,Const Estimating,0.23,0.35,0.23,0.08,0.12,0.0,0.0,0.0,seyed mousavi rizi,,CSM-3510,2017
+CSM,3510,2,Const Estimating,0.36,0.32,0.29,0.0,0.04,0.0,0.0,0.0,seyed mousavi rizi,,CSM-3510,2017
+CSM,4110,1,Safety in Bldg Const,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,nicholas corley,,CSM-4110,2017
+CSM,4110,2,Safety in Bldg Const,0.61,0.35,0.03,0.0,0.0,0.0,0.0,0.0,nicholas corley,,CSM-4110,2017
+CSM,4500,1,Construction Intern,0.84,0.02,0.14,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,,CSM-4500,2017
+CSM,4530,1,Const Proj Mgmt,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4530,2017
+CSM,4530,2,Const Proj Mgmt,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4530,2017
+CSM,4610,1,Const Econ Seminar,0.23,0.47,0.3,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-4610,2017
+CSM,4610,2,Const Econ Seminar,0.07,0.53,0.33,0.07,0.0,0.0,0.0,0.0,christine piper,,CSM-4610,2017
+CSM,8610,1,Construction Control Systems,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-8610,2017
+CSM,8610,400,Construction Control Systems,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-8610,2017
+CSM,8620,1,Personnel Mgt & Neg,0.13,0.5,0.25,0.0,0.13,0.0,0.0,0.0,roger william liska,,CSM-8620,2017
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,,CU-1000,2017
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,susan whorton,,CU-1000,2017
+CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,,CU-1000,2017
+CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,,CU-1000,2017
+CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,,CU-1000,2017
+CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.05,0.01,susan whorton,,CU-1000,2017
+CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,susan whorton,,CU-1000,2017
+CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.79,0.2,0.01,susan whorton,,CU-1000,2017
+CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.17,0.01,susan whorton,,CU-1000,2017
+CU,1000,11,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.78,0.21,0.01,susan whorton,,CU-1000,2017
+CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.24,0.01,susan whorton,,CU-1000,2017
+CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.7,0.29,0.01,susan whorton,,CU-1000,2017
+CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.79,0.21,0.0,susan whorton,,CU-1000,2017
+CU,1000,20,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,,CU-1000,2017
+CU,1000,21,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,susan whorton,,CU-1000,2017
+CU,1010,1,Univ Success Skills,0.46,0.23,0.15,0.0,0.08,0.0,0.0,0.08,bryn zimmerman babb,,CU-1010,2017
+CU,1010,3,Univ Success Skills,0.29,0.24,0.24,0.0,0.12,0.0,0.0,0.12,kirsten noelle dean,,CU-1010,2017
+CU,1010,6,Univ Success Skills,0.43,0.07,0.14,0.07,0.21,0.0,0.0,0.07,cari allyn brooks,,CU-1010,2017
+CU,1010,613,Univ Success Skills,0.5,0.37,0.05,0.03,0.05,0.0,0.0,0.0,elizabeth stephan,,CU-1010,2017
+CU,1010,614,Univ Success Skills,0.34,0.24,0.15,0.12,0.12,0.0,0.0,0.02,mariah magagnotti,,CU-1010,2017
+CU,1010,616,Univ Success Skills,0.58,0.32,0.03,0.0,0.03,0.0,0.0,0.03,matthew kent miller,,CU-1010,2017
+CVT,2260,1,Intro Cardiovas Sono,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,eric walker,,CVT-2260,2017
+DANC,1300,1,Tap Dance I,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,cheryl hosler,,DANC-1300,2017
+DPA,3070,1,Method 3d Production,0.59,0.17,0.1,0.0,0.03,0.0,0.0,0.1,sarah lydia martin,,DPA-3070,2017
+DPA,3070,2,Method 3d Production,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,summer 'nea benton,,DPA-3070,2017
+DPA,4000,1,Tech Foundations I,0.09,0.18,0.09,0.0,0.0,0.0,0.0,0.64,andrew duchowski,,DPA-4000,2017
+DPA,4020,1,Vis Foundations I,0.69,0.19,0.06,0.0,0.06,0.0,0.0,0.0,erik reed,,DPA-4020,2017
+DPA,6830,3,Spec Stud To in DPA: Z-Brush,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,insun kwon,,DPA-6830,2017
+DPA,8070,1,3D Modeling and Animation,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,DPA-8070,2017
+DPA,8150,1,Special Effects Compositing,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,,DPA-8150,2017
+ECE,2010,1,Logic and Computing Devices,0.2,0.27,0.26,0.1,0.12,0.0,0.0,0.05,william reid,,ECE-2010,2017
+ECE,2010,2,Logic & Comp Device (HON),0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,william reid,True,ECE-2010,2017
+ECE,2020,1,Electric Circuits I,0.2,0.37,0.19,0.07,0.06,0.0,0.0,0.1,william harrell,,ECE-2020,2017
+ECE,2070,1,Basic Electrical Engineering,0.48,0.3,0.16,0.03,0.01,0.0,0.0,0.02,timothy anglea,,ECE-2070,2017
+ECE,2070,2,Basic Electrical Engineering,0.4,0.21,0.23,0.05,0.07,0.0,0.0,0.05,daniel bla cutshall,,ECE-2070,2017
+ECE,2070,3,Basic Electrical Engineering,0.47,0.33,0.07,0.04,0.03,0.0,0.0,0.06,william th kolodzey,,ECE-2070,2017
+ECE,2080,1,Basic Electrical Engr Lab,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,2,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,3,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,7,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,8,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,9,Basic Electrical Engr Lab,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,10,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,12,Basic Electrical Engr Lab,0.75,0.15,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,14,Basic Electrical Engr Lab,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,15,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2090,6,Logic Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,apoorva dee kapadia,,ECE-2090,2017
+ECE,2090,8,Logic Lab,0.73,0.0,0.09,0.0,0.0,0.0,0.0,0.18,apoorva dee kapadia,,ECE-2090,2017
+ECE,2090,12,Logic Lab,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2090,2017
+ECE,2090,13,Logic Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2017
+ECE,2110,1,Elec Engr Lab I,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,2,Elec Engr Lab I,0.75,0.1,0.0,0.0,0.0,0.0,0.0,0.15,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,3,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,4,Elec Engr Lab I,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,5,Elec Engr Lab I,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,6,Elec Engr Lab I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,7,Elec Engr Lab I,0.75,0.0,0.1,0.0,0.1,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,8,Elec Engr Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,9,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,10,Elec Engr Lab I,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2110,2017
+ECE,2220,1,Syst Prog Concept,0.25,0.25,0.23,0.08,0.0,0.0,0.0,0.19,harlan russell,,ECE-2220,2017
+ECE,2230,1,Comp Sys Eng,0.33,0.45,0.08,0.1,0.0,0.0,0.0,0.04,walter ligon,,ECE-2230,2017
+ECE,2620,1,Electric Circuits II,0.25,0.27,0.19,0.17,0.04,0.0,0.0,0.08,liang dong,,ECE-2620,2017
+ECE,2720,1,Comp Organization,0.18,0.43,0.28,0.08,0.05,0.0,0.0,0.0,william reid,,ECE-2720,2017
+ECE,2730,3,Computer Org Lab,0.45,0.18,0.27,0.09,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2017
+ECE,3110,1,Electrical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2017
+ECE,3110,2,Electrical Engineering Lab III,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2017
+ECE,3110,3,Electrical Engineering Lab III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2017
+ECE,3110,4,Electrical Engineering Lab III,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,apoorva dee kapadia,,ECE-3110,2017
+ECE,3110,7,Electrical Engineering Lab III,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2017
+ECE,3110,8,Electrical Engineering Lab III,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,apoorva dee kapadia,,ECE-3110,2017
+ECE,3110,9,Electrical Engineering Lab III,0.38,0.5,0.0,0.06,0.06,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2017
+ECE,3120,2,Electrical Engineering Lab IV,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3120,2017
+ECE,3170,1,Rand Signal Analysis,0.33,0.43,0.2,0.02,0.0,0.0,0.0,0.03,stephen hubbard,,ECE-3170,2017
+ECE,3200,1,Electronics I,0.21,0.23,0.28,0.2,0.08,0.0,0.0,0.01,stephen hubbard,,ECE-3200,2017
+ECE,3210,1,Electronics II,0.28,0.55,0.08,0.08,0.03,0.0,0.0,0.0,stephen hubbard,,ECE-3210,2017
+ECE,3220,1,Intro Operating Sys,0.13,0.55,0.32,0.0,0.0,0.0,0.0,0.0,mark smotherman,,ECE-3220,2017
+ECE,3270,1,Dig Comp Design,0.13,0.35,0.13,0.23,0.03,0.0,0.0,0.13,melissa crawl smith,,ECE-3270,2017
+ECE,3300,1,Signals & Systems,0.08,0.3,0.19,0.22,0.09,0.0,0.0,0.12,carl baum,,ECE-3300,2017
+ECE,3300,2,Signals & Systems (HON),0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True,ECE-3300,2017
+ECE,3520,1,Programming Systems,0.65,0.27,0.04,0.0,0.0,0.0,0.0,0.04,robert schalkoff,,ECE-3520,2017
+ECE,3600,1,Elect Power Engr,0.33,0.36,0.2,0.06,0.05,0.0,0.0,0.0,edward collins,,ECE-3600,2017
+ECE,3710,1,Microcontr Interface,0.4,0.3,0.21,0.06,0.02,0.0,0.0,0.01,william reid,,ECE-3710,2017
+ECE,3720,1,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,3,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,4,Micro Int Lab,0.58,0.33,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,6,Micro Int Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,7,Micro Int Lab,0.25,0.58,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,9,Micro Int Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3800,1,Electromagnetics,0.23,0.22,0.31,0.05,0.09,0.0,0.0,0.11,jeffrey osterberg,,ECE-3800,2017
+ECE,3810,1,Field Waves & Ckts,0.13,0.43,0.26,0.0,0.09,0.0,0.0,0.09,anthony martin,,ECE-3810,2017
+ECE,4090,1,Intr to Linear Control Systems,0.56,0.34,0.08,0.0,0.02,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4090,2017
+ECE,4180,1,Power Syst Analysis,0.23,0.33,0.17,0.03,0.1,0.0,0.0,0.13,ramtin hadidi,,ECE-4180,2017
+ECE,4270,1,Communications Sys,0.35,0.44,0.15,0.01,0.03,0.0,0.0,0.01,madhabi manandhar,,ECE-4270,2017
+ECE,4420,1,Knowledge Engr,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,robert schalkoff,,ECE-4420,2017
+ECE,4490,1,Comp Ntwrk Security,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,richard brooks,,ECE-4490,2017
+ECE,4610,1,Fundamentals of Solar Energy,0.45,0.35,0.18,0.0,0.0,0.0,0.0,0.03,rajendra singh,,ECE-4610,2017
+ECE,4670,1,Intro to Dig Sig Pro,0.36,0.14,0.36,0.07,0.0,0.0,0.0,0.07,john gowdy,,ECE-4670,2017
+ECE,4730,1,Intro Parallel Sys,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,walter ligon,,ECE-4730,2017
+ECE,4950,1,Int Sys Design I,0.7,0.29,0.01,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4950,2017
+ECE,4960,1,Int Sys Design II,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2017
+ECE,6040,1,Semiconductor Devices,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson doug ryckman,,ECE-6040,2017
+ECE,6180,400,Power Syst Analysis,0.4,0.0,0.4,0.0,0.0,0.0,0.0,0.2,ramtin hadidi,,ECE-6180,2017
+ECE,6310,1,Intro to Computer Vision,0.48,0.38,0.1,0.0,0.0,0.0,0.0,0.05,adam hoover,,ECE-6310,2017
+ECE,6420,1,Knowledge Engr,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert schalkoff,,ECE-6420,2017
+ECE,6420,400,Knowledge Engr,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,robert schalkoff,,ECE-6420,2017
+ECE,6490,1,Comp Ntwrk Security,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,,ECE-6490,2017
+ECE,6490,400,Comp Ntwrk Security,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,richard brooks,,ECE-6490,2017
+ECE,6590,1,Int Circ Design,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,,ECE-6590,2017
+ECE,6610,1,Fundamentals of Solar Energy,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,rajendra singh,,ECE-6610,2017
+ECE,6670,1,Intro to Dig Sig Pro,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john gowdy,,ECE-6670,2017
+ECE,6730,1,Intro Parallel Sys,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,walter ligon,,ECE-6730,2017
+ECE,8010,1,Analysis of Lin Sys,0.48,0.41,0.04,0.0,0.0,0.0,0.0,0.07,richard groff,,ECE-8010,2017
+ECE,8540,1,Analysis of Tracking Systems,0.86,0.1,0.0,0.0,0.03,0.0,0.0,0.0,adam hoover,,ECE-8540,2017
+ECON,2000,2,Economic Concepts,0.5,0.33,0.08,0.05,0.05,0.0,0.0,0.0,jonathan orr ernest,,ECON-2000,2017
+ECON,2000,4,Economic Concepts,0.46,0.44,0.05,0.03,0.03,0.0,0.0,0.0,miren ivankovic,,ECON-2000,2017
+ECON,2000,5,Economic Concepts,0.31,0.23,0.31,0.05,0.08,0.0,0.0,0.03,jonathan orr ernest,,ECON-2000,2017
+ECON,2110,1,Principles of Microeconomics,0.21,0.42,0.11,0.16,0.0,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2017
+ECON,2110,2,Principles of Microeconomics,0.21,0.26,0.32,0.11,0.05,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2017
+ECON,2110,3,Principles of Microeconomics,0.16,0.16,0.47,0.05,0.05,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2017
+ECON,2110,4,Principles of Microeconomics,0.0,0.37,0.53,0.05,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2017
+ECON,2110,5,Principles of Microeconomics,0.11,0.47,0.32,0.05,0.05,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2017
+ECON,2110,6,Principles of Microeconomics,0.11,0.37,0.42,0.05,0.0,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2017
+ECON,2110,7,Principles of Microeconomics,0.11,0.26,0.32,0.11,0.16,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2017
+ECON,2110,8,Principles of Microeconomics,0.11,0.28,0.44,0.06,0.06,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2017
+ECON,2110,9,Principles of Microeconomics,0.16,0.26,0.37,0.05,0.05,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2017
+ECON,2110,10,Principles of Microeconomics,0.11,0.28,0.28,0.06,0.11,0.0,0.0,0.17,frederick hanssen,,ECON-2110,2017
+ECON,2110,11,Principles of Microeconomics,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2017
+ECON,2110,12,Principles of Microeconomics,0.11,0.42,0.26,0.21,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2017
+ECON,2110,13,Principles of Microeconomics,0.21,0.32,0.37,0.11,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2017
+ECON,2110,14,Principles of Microeconomics,0.21,0.21,0.42,0.05,0.0,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2017
+ECON,2110,15,Principles of Microeconomics,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2017
+ECON,2110,16,Principles of Microeconomics,0.16,0.11,0.47,0.11,0.11,0.0,0.0,0.05,frederick hanssen,,ECON-2110,2017
+ECON,2110,17,Principles of Microeconomics,0.11,0.58,0.16,0.05,0.11,0.0,0.0,0.0,frederick hanssen,,ECON-2110,2017
+ECON,2110,18,Principles of Microeconomics,0.05,0.32,0.42,0.05,0.05,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2017
+ECON,2110,19,Principles of Microeconomics,0.11,0.53,0.11,0.11,0.05,0.0,0.0,0.11,frederick hanssen,,ECON-2110,2017
+ECON,2110,20,Principles of Microeconomics,0.16,0.36,0.35,0.13,0.0,0.0,0.0,0.0,benjamin posmanick,,ECON-2110,2017
+ECON,2110,21,Principles of Microeconomics,0.33,0.42,0.18,0.06,0.0,0.0,0.0,0.0,michael makowsky,,ECON-2110,2017
+ECON,2110,22,Principles of Microeconomics,0.24,0.33,0.26,0.1,0.02,0.0,0.0,0.05,roksan ghanbariamin,,ECON-2110,2017
+ECON,2110,23,Principles of Microeconomics,0.26,0.31,0.25,0.11,0.07,0.0,0.0,0.01,sarah louise wilson,,ECON-2110,2017
+ECON,2110,24,Principles of Microeconomics,0.2,0.38,0.24,0.12,0.05,0.0,0.0,0.02,kelsey vict roberts,,ECON-2110,2017
+ECON,2110,25,Principles of Microeconomics,0.21,0.67,0.1,0.0,0.0,0.0,0.0,0.03,chen wang,,ECON-2110,2017
+ECON,2110,26,Principles of Microeconomics,0.22,0.47,0.18,0.07,0.0,0.0,0.0,0.07,benjamin jo schwall,,ECON-2110,2017
+ECON,2110,31,Principles of Microeconomics,0.4,0.37,0.17,0.01,0.01,0.0,0.0,0.03,jacob walloga,,ECON-2110,2017
+ECON,2110,32,Principles of Microeconomics,0.13,0.44,0.33,0.02,0.02,0.0,0.0,0.06,frederick hanssen,,ECON-2110,2017
+ECON,2110,33,Principles of Microeconomics,0.15,0.44,0.22,0.07,0.05,0.0,0.0,0.07,charles thomas,,ECON-2110,2017
+ECON,2110,34,Principles of Microecon (HON),0.45,0.45,0.05,0.05,0.0,0.0,0.0,0.0,charles thomas,True,ECON-2110,2017
+ECON,2110,35,Principles of Microeconomics,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,chen wang,,ECON-2110,2017
+ECON,2110,36,Principles of Microeconomics,0.18,0.48,0.25,0.08,0.0,0.0,0.0,0.03,roksan ghanbariamin,,ECON-2110,2017
+ECON,2110,38,Principles of Microeconomics,0.33,0.24,0.26,0.07,0.05,0.0,0.0,0.05,liuna issagholian,,ECON-2110,2017
+ECON,2110,40,Principles of Microeconomics,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.03,zhiqi zhao,,ECON-2110,2017
+ECON,2110,41,Principles of Microeconomics,0.39,0.34,0.17,0.07,0.02,0.0,0.0,0.0,liuna issagholian,,ECON-2110,2017
+ECON,2120,1,Principles of Macroeconomics,0.08,0.14,0.08,0.17,0.11,0.0,0.0,0.42,ralph charles allen,,ECON-2120,2017
+ECON,2120,2,Principles of Macroeconomics,0.31,0.51,0.13,0.02,0.02,0.0,0.0,0.0,kyle lance rechard,,ECON-2120,2017
+ECON,2120,3,Principles of Macroeconomics,0.15,0.09,0.18,0.15,0.16,0.0,0.0,0.27,ralph charles allen,,ECON-2120,2017
+ECON,2120,4,Principles of Macroeconomics,0.26,0.4,0.19,0.05,0.03,0.0,0.0,0.06,elijah neilson,,ECON-2120,2017
+ECON,2120,5,Principles of Macroeconomics,0.24,0.41,0.2,0.1,0.0,0.0,0.0,0.05,benjamin ti harbolt,,ECON-2120,2017
+ECON,2120,6,Principles of Macroeconomics,0.15,0.35,0.43,0.03,0.05,0.0,0.0,0.0,benjamin ti harbolt,,ECON-2120,2017
+ECON,2120,7,Principles of Macroeconomics,0.23,0.43,0.3,0.0,0.0,0.0,0.0,0.05,kyle lance rechard,,ECON-2120,2017
+ECON,2120,8,Principles of Macroeconomics,0.87,0.1,0.0,0.02,0.0,0.0,0.0,0.02,jeremy choquette,,ECON-2120,2017
+ECON,2120,9,Principles of Macroeconomics,0.35,0.38,0.18,0.08,0.03,0.0,0.0,0.0,narendra regmi,,ECON-2120,2017
+ECON,2120,10,Principles of Macroeconomics,0.71,0.07,0.07,0.02,0.07,0.0,0.0,0.05,jeremy choquette,,ECON-2120,2017
+ECON,3020,1,Money and Banking,0.08,0.51,0.32,0.0,0.03,0.0,0.0,0.05,smriti bhargava,,ECON-3020,2017
+ECON,3060,1,Managerial Economics,0.23,0.28,0.3,0.13,0.05,0.0,0.0,0.03,steven johnson,,ECON-3060,2017
+ECON,3100,1,International Econ,0.29,0.29,0.16,0.1,0.09,0.0,0.0,0.09,samuel ar standaert,,ECON-3100,2017
+ECON,3140,1,Intermediate Micro,0.25,0.17,0.25,0.1,0.1,0.0,0.0,0.12,patrick warren,,ECON-3140,2017
+ECON,3140,2,Intermediate Micro,0.26,0.35,0.24,0.06,0.06,0.0,0.0,0.02,molly espey,,ECON-3140,2017
+ECON,3140,3,Intermediate Micro,0.24,0.35,0.22,0.06,0.04,0.0,0.0,0.1,robert kennet fleck,,ECON-3140,2017
+ECON,3150,1,Intermediate Macro,0.39,0.25,0.1,0.02,0.08,0.0,0.0,0.16,sergey vla mityakov,,ECON-3150,2017
+ECON,3150,2,Intermediate Macro,0.31,0.34,0.24,0.08,0.03,0.0,0.0,0.0,michal jerzmanowski,,ECON-3150,2017
+ECON,3190,1,Environmental Econ,0.36,0.33,0.23,0.03,0.03,0.0,0.0,0.03,molly espey,,ECON-3190,2017
+ECON,3600,1,Public Choice,0.41,0.24,0.21,0.12,0.03,0.0,0.0,0.0,michael makowsky,,ECON-3600,2017
+ECON,4010,1,Labor Mkt Analysis,0.37,0.37,0.22,0.0,0.04,0.0,0.0,0.0,chungsang lam,,ECON-4010,2017
+ECON,4020,1,Law and Economics,0.21,0.41,0.31,0.05,0.0,0.0,0.0,0.03,howard ne bodenhorn,,ECON-4020,2017
+ECON,4040,1,Comp Econ Systems,0.13,0.38,0.06,0.19,0.19,0.0,0.0,0.06,dar litsukova-bokar,,ECON-4040,2017
+ECON,4050,5,Intro to Econometric,0.19,0.23,0.32,0.12,0.11,0.0,0.0,0.04,scott barkowski,,ECON-4050,2017
+ECON,4100,1,Economic Development,0.59,0.33,0.0,0.0,0.04,0.0,0.0,0.04,robert tamura,,ECON-4100,2017
+ECON,4110,2,Econ of Education,0.3,0.43,0.23,0.0,0.0,0.0,0.0,0.03,peter quarter blair,,ECON-4110,2017
+ECON,4120,1,International Micro,0.36,0.39,0.14,0.07,0.04,0.0,0.0,0.0,richard alan sessa,,ECON-4120,2017
+ECON,4220,1,Monetary Economics,0.26,0.5,0.12,0.0,0.03,0.0,0.0,0.09,gerald dwyer,,ECON-4220,2017
+ECON,4230,1,Economics of Health,0.47,0.18,0.24,0.06,0.0,0.0,0.0,0.06,devon merritt gorry,,ECON-4230,2017
+ECON,4250,1,Antitrust Economics,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,raymond sauer,,ECON-4250,2017
+ECON,4260,1,Sem Sport Economics,0.47,0.47,0.0,0.05,0.0,0.0,0.0,0.0,raymond sauer,,ECON-4260,2017
+ECON,4280,1,Cost-Benefit Anlysis,0.46,0.29,0.11,0.06,0.03,0.0,0.0,0.06,robert kennet fleck,,ECON-4280,2017
+ECON,6050,5,Intro to Econometric,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,scott barkowski,,ECON-6050,2017
+ECON,6060,1,Advanced Econometric,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,,ECON-6060,2017
+ECON,8010,1,Microeconomic Theory,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,william dougan,,ECON-8010,2017
+ECON,8040,1,Applied Math Econ,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,curtis simon,,ECON-8040,2017
+ECON,8060,1,Econometrics I,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,paul wayne wilson,,ECON-8060,2017
+ECON,8080,1,Econometrics III,0.14,0.43,0.21,0.0,0.14,0.0,0.0,0.07,paul wayne wilson,,ECON-8080,2017
+ECON,8230,1,Microecon Pub Pol,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,scott templeton,,ECON-8230,2017
+ECON,8240,1,Org of Industry,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew lewis,,ECON-8240,2017
+ECON,8260,1,Econ Theory of Govt Regulation,0.17,0.5,0.0,0.0,0.0,0.0,0.0,0.33,thomas wins hazlett,,ECON-8260,2017
+ECON,8550,1,Financial Economics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sergey vla mityakov,,ECON-8550,2017
+ED,1050,1,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,,ED-1050,2017
+ED,1050,2,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,,ED-1050,2017
+ED,1050,5,Educ Orientation,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,,ED-1050,2017
+ED,1050,7,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,,ED-1050,2017
+ED,8700,300,STEAM Instructional Design,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,,ED-8700,2017
+EDC,3900,1,Skills for Stu Leads,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,,EDC-3900,2017
+EDC,3900,2,Skills for Stu Leads,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,eric pernotto,,EDC-3900,2017
+EDC,3990,1,Creative Inq in Counselor Ed,0.82,0.06,0.0,0.0,0.0,0.0,0.0,0.12,ken stewart-tillman,,EDC-3990,2017
+EDEC,4400,1,Early Childhood Engl Lang Art,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-4400,2017
+EDEL,3210,1,Pe for the Elem Tchr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2017
+EDEL,3210,2,Pe for the Elem Tchr,0.72,0.14,0.14,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2017
+EDEL,4510,1,Elem Methods in Science Tchg,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,,EDEL-4510,2017
+EDEL,4870,1,Ele Meth Soc Studies,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,,EDEL-4870,2017
+EDEL,4870,2,Ele Meth Soc Studies,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,,EDEL-4870,2017
+EDEL,4880,1,Elem Meth La Tchng,0.68,0.23,0.09,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,,EDEL-4880,2017
+EDEL,4880,2,Elem Meth La Tchng,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,,EDEL-4880,2017
+EDF,3010,2,Principles of American Educat,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,,EDF-3010,2017
+EDF,3020,2,Educational Psychology,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,,EDF-3020,2017
+EDF,3080,3,Classroom Assessment,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,,EDF-3080,2017
+EDF,3350,1,Adolescent Growth & Develop,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,,EDF-3350,2017
+EDF,3350,2,Adolescent Growth & Develop,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,,EDF-3350,2017
+EDF,4800,1,Digital Media & Learning,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2017
+EDF,4800,2,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2017
+EDF,4800,301,Digital Media & Learning,0.39,0.39,0.06,0.11,0.0,0.0,0.0,0.06,aamena bilal saleh,,EDF-4800,2017
+EDF,4800,302,Digital Media & Learning,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2017
+EDF,8080,302,Contempor Issues in Assessment,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,heather rog brooker,,EDF-8080,2017
+EDF,9270,1,Quant Rsrch & Stats for Ed,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,eliza dar gallagher,,EDF-9270,2017
+EDF,9270,400,Quant Rsrch & Stats for Ed,0.62,0.31,0.0,0.0,0.08,0.0,0.0,0.0,jennie lynn farmer,,EDF-9270,2017
+EDF,9710,501,Case Study & Ethnographic Mthd,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,daniella hall,,EDF-9710,2017
+EDHD,8310,500,Lit Outcomes for Child w disab,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,renee gatlin anders,,EDHD-8310,2017
+EDL,7300,500,Techniq of Supervision-Pub Sch,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,,EDL-7300,2017
+EDL,7400,502,Curr Plan: Sch Adm,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,barbara nesbitt,,EDL-7400,2017
+EDL,7500,501,El Prin & Spv Ex I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,,EDL-7500,2017
+EDL,7550,500,Sec Prin & Spv Exp I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,,EDL-7550,2017
+EDL,8850,401,HRD Learning Leadership,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,angela danie carter,,EDL-8850,2017
+EDL,9050,400,Thry/Prac Ed Ldrshp,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,russell marion,,EDL-9050,2017
+EDL,9110,400,Systematic Inq Ed L,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,jane lindle,,EDL-9110,2017
+EDLT,4590,1,Teaching Reading Grades K-3,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,koti lee hubbard,,EDLT-4590,2017
+EDLT,4600,1,Teaching Reading Grades 2-6,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4600,2017
+EDLT,4600,3,Teaching Reading Grades 2-6,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4600,2017
+EDLT,4600,6,Teaching Reading Grades 2-6,0.6,0.27,0.07,0.07,0.0,0.0,0.0,0.0,julia kate bentley,,EDLT-4600,2017
+EDLT,4610,1,Content Area Rdg: Grades 2-6,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-4610,2017
+EDLT,4980,1,Secondary Content Area Reading,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,lorraine an jacques,,EDLT-4980,2017
+EDLT,4980,3,Secondary Content Area Reading,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,rachelle savitz,,EDLT-4980,2017
+EDLT,8170,300,Content Area Rdg/Wtg: ECE-ELEM,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,rachelle savitz,,EDLT-8170,2017
+EDLT,8220,500,Strategies for Teaching ESOL,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-8220,2017
+EDLT,8270,400,Content Area Rdg/Wtg-MS & HS,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,rebecca kaminski,,EDLT-8270,2017
+EDLT,8400,500,Early Literacy Assessment I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,ellen adkin sanford,,EDLT-8400,2017
+EDLT,8400,501,Early Literacy Assessment I,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jamie felder white,,EDLT-8400,2017
+EDLT,8400,503,Early Literacy Assessment I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jaime adele dawson,,EDLT-8400,2017
+EDLT,8400,504,Early Literacy Assessment I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,,EDLT-8400,2017
+EDLT,8400,506,Early Literacy Assessment I,0.73,0.0,0.0,0.0,0.09,0.0,0.0,0.18,renee gatlin anders,,EDLT-8400,2017
+EDLT,8400,507,Early Literacy Assessment I,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,michael moss,,EDLT-8400,2017
+EDLT,8820,502,Read Recovery Practicum I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary ann fr mcbride,,EDLT-8820,2017
+EDLT,9140,1,"Lang Dev, Diversity, Discourse",0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-9140,2017
+EDSA,8100,1,Theories & Techn of Counseling,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,,EDSA-8100,2017
+EDSC,2260,1,Pr Apprch to Sec Alg,0.38,0.38,0.15,0.0,0.0,0.0,0.0,0.08,stacy megan che,,EDSC-2260,2017
+EDSC,3280,1,Practicum Sec Soc St,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,william da mccorkle,,EDSC-3280,2017
+EDSC,4260,1,Tchng Sec Math,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,carlos gomez,,EDSC-4260,2017
+EDSP,3720,1,Char & Instr Individ with LD,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,catherine griffith,,EDSP-3720,2017
+EDSP,3740,1,Char & Strat Emot/Behav Disord,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,,EDSP-3740,2017
+EDSP,4920,1,Math Inst Ind W/Dis,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,pamela stecker,,EDSP-4920,2017
+EDSP,4930,1,Clsrm/Beh Mgmt Sp Ed,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,joseph benedic ryan,,EDSP-4930,2017
+EDSP,4940,1,Tchg Rdg Mild Dis,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,abigail anne allen,,EDSP-4940,2017
+EDSP,8220,400,Tchg Math Indv W/Dis,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,pamela stecker,,EDSP-8220,2017
+EES,2010,1,Environ Engr Fundamentals I,0.28,0.38,0.18,0.08,0.08,0.0,0.0,0.03,david freedman,,EES-2010,2017
+EES,3030,1,Water Treatment Systems,0.63,0.25,0.09,0.03,0.0,0.0,0.0,0.0,david allen ladner,,EES-3030,2017
+EES,3040,1,Wastewater Treatment Systems,0.34,0.41,0.16,0.06,0.03,0.0,0.0,0.0,sudeep popat,,EES-3040,2017
+EES,3050,1,Water/Wastewater Treatment Lab,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2017
+EES,3050,2,Water/Wastewater Treatment Lab,0.47,0.4,0.07,0.0,0.0,0.0,0.0,0.07,sudeep popat,,EES-3050,2017
+EES,4010,1,Environmental Engr,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,EES-4010,2017
+EES,4010,2,Environmental Engr,0.26,0.52,0.17,0.0,0.04,0.0,0.0,0.0,mark schlautman,,EES-4010,2017
+EES,4100,1,Environ Radiation Protection I,0.22,0.39,0.11,0.11,0.0,0.0,0.0,0.17,nicole eli martinez,,EES-4100,2017
+EES,4300,1,Air Pollution Engineering,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,andrew rich metcalf,,EES-4300,2017
+EES,4800,1,Environmental Risk Assessment,0.23,0.57,0.13,0.0,0.03,0.0,0.0,0.03,nicole eli martinez,,EES-4800,2017
+EES,4840,1,Solid Waste Mgt,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,yi zheng,,EES-4840,2017
+EES,4860,1,Environmental Sustainability,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,,EES-4860,2017
+EES,6100,1,Environ Radiation Protection I,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,nicole eli martinez,,EES-6100,2017
+EES,8020,1,Environ Eng Prin,0.71,0.14,0.07,0.0,0.0,0.0,0.0,0.07,david allen ladner,,EES-8020,2017
+EES,8060,1,Design Env Control,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,,EES-8060,2017
+EES,8080,1,Groundwater Modeling,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,,EES-8080,2017
+EES,8430,1,Environmental Chem,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,brian powell,,EES-8430,2017
+EES,8510,1,Biol Prin Envir Engr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,,EES-8510,2017
+EES,8800,1,Env Risk Assessment,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,,EES-8800,2017
+ELE,3010,1,Entrepreneurial Foundations,0.46,0.46,0.03,0.03,0.03,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2017
+ELE,3010,2,Entrepreneurial Foundations,0.33,0.65,0.0,0.0,0.0,0.0,0.0,0.03,christina kyprianou,,ELE-3010,2017
+ELE,3010,3,Entrepreneurial Foundations,0.18,0.42,0.26,0.03,0.03,0.0,0.0,0.08,ashley will parnell,,ELE-3010,2017
+ELE,4010,1,Venture Testing,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,chad navis,,ELE-4010,2017
+ELE,4020,1,Venture Creation,0.33,0.58,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,,ELE-4020,2017
+ELE,4030,1,Venture Growth,0.17,0.26,0.48,0.0,0.09,0.0,0.0,0.0,ashley will parnell,,ELE-4030,2017
+ENGL,1030,2,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,,ENGL-1030,2017
+ENGL,1030,3,Composition and Rhetoric,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,krist aldebol-hazle,,ENGL-1030,2017
+ENGL,1030,4,Composition and Rhetoric,0.56,0.33,0.0,0.0,0.06,0.0,0.0,0.06,jennie el wakefield,,ENGL-1030,2017
+ENGL,1030,7,Composition and Rhetoric,0.58,0.16,0.16,0.0,0.0,0.0,0.0,0.11,stephen quigley,,ENGL-1030,2017
+ENGL,1030,8,Composition and Rhetoric,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-1030,2017
+ENGL,1030,9,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jennie el wakefield,,ENGL-1030,2017
+ENGL,1030,10,Composition and Rhetoric,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,austin gorman,,ENGL-1030,2017
+ENGL,1030,11,Composition and Rhetoric,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,austin gorman,,ENGL-1030,2017
+ENGL,1030,12,Composition and Rhetoric,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,carrie hill,,ENGL-1030,2017
+ENGL,1030,14,Composition and Rhetoric,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,caroline eliz young,,ENGL-1030,2017
+ENGL,1030,15,Composition and Rhetoric,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel qui atkinson,,ENGL-1030,2017
+ENGL,1030,17,Composition and Rhetoric,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2017
+ENGL,1030,18,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jennie el wakefield,,ENGL-1030,2017
+ENGL,1030,19,Composition and Rhetoric,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2017
+ENGL,1030,21,Composition and Rhetoric,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,jennie el wakefield,,ENGL-1030,2017
+ENGL,1030,22,Composition and Rhetoric,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,abigail maxim,,ENGL-1030,2017
+ENGL,1030,23,Composition and Rhetoric,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,stephen hundley,,ENGL-1030,2017
+ENGL,1030,24,Composition and Rhetoric,0.71,0.12,0.18,0.0,0.0,0.0,0.0,0.0,sarah el richardson,,ENGL-1030,2017
+ENGL,1030,25,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,martha sue karnes,,ENGL-1030,2017
+ENGL,1030,26,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,,ENGL-1030,2017
+ENGL,1030,27,Composition and Rhetoric,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,michael davi measel,,ENGL-1030,2017
+ENGL,1030,29,Composition and Rhetoric,0.61,0.28,0.0,0.06,0.0,0.0,0.0,0.06,caroline eliz young,,ENGL-1030,2017
+ENGL,1030,30,Composition and Rhetoric,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,remley melis makala,,ENGL-1030,2017
+ENGL,1030,31,Composition and Rhetoric,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,martha sue karnes,,ENGL-1030,2017
+ENGL,1030,32,Composition and Rhetoric,0.78,0.11,0.0,0.06,0.0,0.0,0.0,0.06,sarah el richardson,,ENGL-1030,2017
+ENGL,1030,33,Composition and Rhetoric,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,,ENGL-1030,2017
+ENGL,1030,34,Composition and Rhetoric,0.5,0.29,0.07,0.0,0.14,0.0,0.0,0.0,carley am robertson,,ENGL-1030,2017
+ENGL,1030,35,Composition and Rhetoric,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,victoria houser,,ENGL-1030,2017
+ENGL,1030,37,Composition and Rhetoric,0.67,0.17,0.06,0.06,0.0,0.0,0.0,0.06,michael davi measel,,ENGL-1030,2017
+ENGL,1030,38,Composition and Rhetoric,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,sarah margar carter,,ENGL-1030,2017
+ENGL,1030,39,Composition and Rhetoric,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,courtn huff-oelberg,,ENGL-1030,2017
+ENGL,1030,40,Composition and Rhetoric,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,abigail maxim,,ENGL-1030,2017
+ENGL,1030,41,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,,ENGL-1030,2017
+ENGL,1030,42,Composition and Rhetoric,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,michelle lloyd,,ENGL-1030,2017
+ENGL,1030,43,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gabrielle gr nugent,,ENGL-1030,2017
+ENGL,1030,44,Composition and Rhetoric,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,gabrielle gr nugent,,ENGL-1030,2017
+ENGL,1030,45,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,,ENGL-1030,2017
+ENGL,1030,46,Composition and Rhetoric,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,christopher stuart,,ENGL-1030,2017
+ENGL,1030,47,Composition and Rhetoric,0.71,0.24,0.0,0.06,0.0,0.0,0.0,0.0,brian lee gaines,,ENGL-1030,2017
+ENGL,1030,48,Composition and Rhetoric,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,brian lee gaines,,ENGL-1030,2017
+ENGL,1030,50,Composition and Rhetoric,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,charlotte est lucke,,ENGL-1030,2017
+ENGL,1030,51,Composition and Rhetoric,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,christopher stuart,,ENGL-1030,2017
+ENGL,1030,53,Composition and Rhetoric,0.32,0.53,0.0,0.05,0.0,0.0,0.0,0.11,jane elizab kuebler,,ENGL-1030,2017
+ENGL,1030,55,Composition and Rhetoric,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,courtn huff-oelberg,,ENGL-1030,2017
+ENGL,1030,57,Composition and Rhetoric,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,shauna chung,,ENGL-1030,2017
+ENGL,1030,59,Composition and Rhetoric,0.31,0.31,0.23,0.0,0.0,0.0,0.0,0.15,sarah margar carter,,ENGL-1030,2017
+ENGL,1030,61,Composition and Rhetoric,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,,ENGL-1030,2017
+ENGL,1030,64,Composition and Rhetoric,0.47,0.24,0.24,0.06,0.0,0.0,0.0,0.0,jennifer forsberg,,ENGL-1030,2017
+ENGL,1030,65,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,,ENGL-1030,2017
+ENGL,1030,67,Composition and Rhetoric,0.41,0.41,0.06,0.0,0.12,0.0,0.0,0.0,la'cresha ulo green,,ENGL-1030,2017
+ENGL,1030,69,Composition and Rhetoric,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,,ENGL-1030,2017
+ENGL,1030,71,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,michael russo,,ENGL-1030,2017
+ENGL,1030,72,Composition and Rhetoric,0.84,0.0,0.0,0.0,0.11,0.0,0.0,0.05,whitney jorda adams,,ENGL-1030,2017
+ENGL,1030,73,Composition and Rhetoric,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,carley am robertson,,ENGL-1030,2017
+ENGL,1030,74,Composition and Rhetoric,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,shauna chung,,ENGL-1030,2017
+ENGL,1030,75,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen hundley,,ENGL-1030,2017
+ENGL,1030,76,Composition and Rhetoric,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,carrie hill,,ENGL-1030,2017
+ENGL,1030,80,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,,ENGL-1030,2017
+ENGL,1030,81,Composition and Rhetoric,0.72,0.11,0.06,0.06,0.06,0.0,0.0,0.0,charlotte est lucke,,ENGL-1030,2017
+ENGL,1030,82,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,,ENGL-1030,2017
+ENGL,1030,83,Composition and Rhetoric,0.47,0.32,0.05,0.11,0.0,0.0,0.0,0.05,jane elizab kuebler,,ENGL-1030,2017
+ENGL,1030,84,Composition and Rhetoric,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,allison nico harris,,ENGL-1030,2017
+ENGL,1030,85,Composition and Rhetoric,0.74,0.16,0.0,0.0,0.11,0.0,0.0,0.0,allison nico harris,,ENGL-1030,2017
+ENGL,1030,86,Composition and Rhetoric,0.67,0.07,0.13,0.0,0.07,0.0,0.0,0.07,stephen quigley,,ENGL-1030,2017
+ENGL,1030,100,Accelerated Composition (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,michelle smith,True,ENGL-1030,2017
+ENGL,1030,500,Composition and Rhetoric,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,john conway,,ENGL-1030,2017
+ENGL,1030,501,Composition and Rhetoric,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,john conway,,ENGL-1030,2017
+ENGL,2120,1,World Literature,0.16,0.47,0.21,0.11,0.05,0.0,0.0,0.0,lee morrissey,,ENGL-2120,2017
+ENGL,2120,3,World Literature,0.18,0.43,0.14,0.04,0.0,0.0,0.0,0.21,karen kettnich,,ENGL-2120,2017
+ENGL,2120,4,World Literature,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2120,2017
+ENGL,2120,5,World Literature,0.3,0.19,0.19,0.11,0.15,0.0,0.0,0.07,andrew mathas,,ENGL-2120,2017
+ENGL,2120,6,World Literature,0.19,0.59,0.15,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,,ENGL-2120,2017
+ENGL,2120,7,World Literature,0.59,0.3,0.07,0.0,0.0,0.0,0.0,0.04,allison nico harris,,ENGL-2120,2017
+ENGL,2120,8,World Literature,0.38,0.35,0.0,0.15,0.08,0.0,0.0,0.04,joshua wood,,ENGL-2120,2017
+ENGL,2120,9,World Literature,0.37,0.26,0.22,0.07,0.0,0.0,0.0,0.07,katalin beck,,ENGL-2120,2017
+ENGL,2120,10,World Literature,0.54,0.32,0.07,0.0,0.04,0.0,0.0,0.04,lucian ghita,,ENGL-2120,2017
+ENGL,2120,11,World Literature,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2120,2017
+ENGL,2120,12,World Literature,0.57,0.39,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,,ENGL-2120,2017
+ENGL,2120,13,World Literature,0.32,0.39,0.14,0.04,0.0,0.0,0.0,0.11,karen kettnich,,ENGL-2120,2017
+ENGL,2120,14,World Literature,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,,ENGL-2120,2017
+ENGL,2120,15,World Literature,0.54,0.23,0.04,0.04,0.12,0.0,0.0,0.04,chloe mich whitaker,,ENGL-2120,2017
+ENGL,2120,16,World Literature,0.32,0.43,0.11,0.11,0.0,0.0,0.0,0.04,sarah mae cooper,,ENGL-2120,2017
+ENGL,2120,17,World Literature,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,allison nico harris,,ENGL-2120,2017
+ENGL,2120,18,World Literature,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,andrew mathas,,ENGL-2120,2017
+ENGL,2120,19,World Literature,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,chloe mich whitaker,,ENGL-2120,2017
+ENGL,2120,20,World Literature,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,joshua wood,,ENGL-2120,2017
+ENGL,2130,1,British Literature,0.57,0.32,0.0,0.07,0.04,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-2130,2017
+ENGL,2130,3,British Literature,0.63,0.26,0.0,0.04,0.0,0.0,0.0,0.07,krist aldebol-hazle,,ENGL-2130,2017
+ENGL,2130,4,British Literature,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,john morgenstern,,ENGL-2130,2017
+ENGL,2130,5,British Literature,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-2130,2017
+ENGL,2130,7,British Literature,0.37,0.3,0.19,0.04,0.07,0.0,0.0,0.04,megan no macalystre,,ENGL-2130,2017
+ENGL,2130,9,British Literature,0.3,0.37,0.19,0.04,0.07,0.0,0.0,0.04,megan no macalystre,,ENGL-2130,2017
+ENGL,2130,10,British Literature,0.43,0.5,0.0,0.04,0.04,0.0,0.0,0.0,christopher benson,,ENGL-2130,2017
+ENGL,2130,11,British Literature,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2017
+ENGL,2130,12,British Literature,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,,ENGL-2130,2017
+ENGL,2130,13,British Literature,0.57,0.18,0.18,0.04,0.0,0.0,0.0,0.04,megan no macalystre,,ENGL-2130,2017
+ENGL,2140,1,American Literature,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2017
+ENGL,2140,5,American Literature,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2017
+ENGL,2140,6,American Literature,0.41,0.44,0.07,0.0,0.0,0.0,0.0,0.07,erin nicholson gale,,ENGL-2140,2017
+ENGL,2140,7,American Literature,0.39,0.36,0.11,0.07,0.0,0.0,0.0,0.07,elizabeth stansell,,ENGL-2140,2017
+ENGL,2140,8,American Literature,0.26,0.37,0.15,0.04,0.0,0.0,0.0,0.19,david charles foltz,,ENGL-2140,2017
+ENGL,2140,9,American Literature,0.63,0.22,0.11,0.0,0.04,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2017
+ENGL,2140,14,American Literature,0.24,0.48,0.24,0.0,0.0,0.0,0.0,0.04,david charles foltz,,ENGL-2140,2017
+ENGL,2140,15,American Literature,0.54,0.36,0.07,0.04,0.0,0.0,0.0,0.0,jennifer forsberg,,ENGL-2140,2017
+ENGL,2140,16,American Literature,0.29,0.54,0.11,0.04,0.04,0.0,0.0,0.0,jennifer forsberg,,ENGL-2140,2017
+ENGL,2140,17,American Literature,0.36,0.43,0.04,0.04,0.0,0.0,0.0,0.14,david charles foltz,,ENGL-2140,2017
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.5,0.27,0.12,0.0,0.08,0.0,0.0,0.04,sarah mae cooper,,ENGL-2150,2017
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.28,0.44,0.24,0.0,0.04,0.0,0.0,0.0,sarah mae cooper,,ENGL-2150,2017
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.21,0.46,0.29,0.0,0.0,0.0,0.0,0.04,lindsay kath turner,,ENGL-2150,2017
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.18,0.57,0.18,0.0,0.07,0.0,0.0,0.0,lindsay kath turner,,ENGL-2150,2017
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.93,0.0,0.0,0.0,0.07,0.0,0.0,0.0,stephanie stripling,,ENGL-2150,2017
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,daniel scott citro,,ENGL-2150,2017
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.81,0.08,0.0,0.0,0.0,0.0,0.0,0.12,daniel scott citro,,ENGL-2150,2017
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.41,0.33,0.07,0.04,0.15,0.0,0.0,0.0,andrew mathas,,ENGL-2150,2017
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.33,0.22,0.17,0.06,0.11,0.0,0.0,0.11,chelsea mari clarey,,ENGL-2150,2017
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.46,0.21,0.18,0.11,0.0,0.0,0.0,0.04,andrew mathas,,ENGL-2150,2017
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.26,0.47,0.16,0.11,0.0,0.0,0.0,0.0,chelsea mari clarey,,ENGL-2150,2017
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.28,0.44,0.11,0.06,0.06,0.0,0.0,0.06,chelsea mari clarey,,ENGL-2150,2017
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.37,0.26,0.16,0.0,0.11,0.0,0.0,0.11,chelsea mari clarey,,ENGL-2150,2017
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.39,0.29,0.18,0.0,0.11,0.0,0.0,0.04,john logan pursley,,ENGL-2150,2017
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.45,0.34,0.07,0.07,0.03,0.0,0.0,0.03,john logan pursley,,ENGL-2150,2017
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-2150,2017
+ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2150,2017
+ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2150,2017
+ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.26,0.16,0.32,0.0,0.05,0.0,0.0,0.21,david charles foltz,,ENGL-2150,2017
+ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.61,0.25,0.0,0.11,0.04,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2017
+ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.46,0.43,0.07,0.04,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-2150,2017
+ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,caroline eliz young,,ENGL-2150,2017
+ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,david charles foltz,,ENGL-2150,2017
+ENGL,2150,26,Lit in 20th-21st Cent Contexts,0.64,0.25,0.0,0.0,0.04,0.0,0.0,0.07,caroline eliz young,,ENGL-2150,2017
+ENGL,2150,27,Lit in 20th-21st Cent Contexts,0.0,0.84,0.11,0.0,0.0,0.0,0.0,0.05,amy monaghan,,ENGL-2150,2017
+ENGL,2150,100,20th - 21st Century Lit (HON),0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True,ENGL-2150,2017
+ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.57,0.07,0.04,0.14,0.0,0.0,0.0,0.18,candace wiley,,ENGL-2150,2017
+ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.57,0.04,0.04,0.07,0.07,0.0,0.0,0.21,candace wiley,,ENGL-2150,2017
+ENGL,3040,3,Business Writing,0.68,0.05,0.26,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,,ENGL-3040,2017
+ENGL,3040,4,Business Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3040,2017
+ENGL,3040,5,Business Writing,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,crystal pa stephens,,ENGL-3040,2017
+ENGL,3040,13,Business Writing,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3040,2017
+ENGL,3040,15,Business Writing,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,philip randall,,ENGL-3040,2017
+ENGL,3040,16,Business Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,,ENGL-3040,2017
+ENGL,3040,19,Business Writing,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,crystal pa stephens,,ENGL-3040,2017
+ENGL,3040,20,Business Writing,0.58,0.11,0.05,0.0,0.16,0.0,0.0,0.11,geveryl le robinson,,ENGL-3040,2017
+ENGL,3040,21,Business Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,sean williams,,ENGL-3040,2017
+ENGL,3040,400,Business Writing,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,steph kartalopoulos,,ENGL-3040,2017
+ENGL,3040,401,Business Writing,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,steph kartalopoulos,,ENGL-3040,2017
+ENGL,3100,1,Crit Writ Lit,0.29,0.41,0.12,0.12,0.0,0.0,0.0,0.06,kimberly manganelli,,ENGL-3100,2017
+ENGL,3100,2,Crit Writ Lit,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,william stockton,,ENGL-3100,2017
+ENGL,3100,3,Crit Writ Lit,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,,ENGL-3100,2017
+ENGL,3100,4,Crit Writ Lit,0.39,0.11,0.22,0.0,0.06,0.0,0.0,0.22,william stockton,,ENGL-3100,2017
+ENGL,3120,1,Advanced Composition,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2017
+ENGL,3120,2,Advanced Composition,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2017
+ENGL,3140,1,Technical Writing,0.33,0.5,0.06,0.11,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2017
+ENGL,3140,2,Technical Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2017
+ENGL,3140,4,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,,ENGL-3140,2017
+ENGL,3140,5,Technical Writing,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,sharon kathl nalley,,ENGL-3140,2017
+ENGL,3140,6,Technical Writing,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,melissa dugan,,ENGL-3140,2017
+ENGL,3140,9,Technical Writing,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2017
+ENGL,3140,10,Technical Writing,0.42,0.47,0.0,0.05,0.0,0.0,0.0,0.05,katalin beck,,ENGL-3140,2017
+ENGL,3140,11,Technical Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,,ENGL-3140,2017
+ENGL,3140,12,Technical Writing,0.47,0.26,0.05,0.11,0.0,0.0,0.0,0.11,geveryl le robinson,,ENGL-3140,2017
+ENGL,3140,13,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-3140,2017
+ENGL,3140,16,Technical Writing,0.79,0.0,0.05,0.11,0.0,0.0,0.0,0.05,stephanie stripling,,ENGL-3140,2017
+ENGL,3140,17,Technical Writing,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,la'cresha ulo green,,ENGL-3140,2017
+ENGL,3140,19,Technical Writing,0.74,0.05,0.11,0.05,0.05,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2017
+ENGL,3140,20,Technical Writing,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2017
+ENGL,3140,22,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-3140,2017
+ENGL,3140,400,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,,ENGL-3140,2017
+ENGL,3150,1,Scientific Writing & Comm,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,christopher benson,,ENGL-3150,2017
+ENGL,3150,2,Scientific Writing & Comm,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,christopher benson,,ENGL-3150,2017
+ENGL,3150,3,Scientific Writing & Comm,0.32,0.32,0.16,0.05,0.16,0.0,0.0,0.0,william pulley,,ENGL-3150,2017
+ENGL,3150,4,Scientific Writing & Comm,0.63,0.21,0.11,0.05,0.0,0.0,0.0,0.0,william pulley,,ENGL-3150,2017
+ENGL,3150,400,Scientific Writing & Comm,0.65,0.25,0.0,0.0,0.05,0.0,0.0,0.05,philip randall,,ENGL-3150,2017
+ENGL,3150,401,Sci Writing & Comm,0.56,0.22,0.11,0.0,0.06,0.0,0.0,0.06,philip randall,,ENGL-3150,2017
+ENGL,3450,1,Structure of Fiction,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-3450,2017
+ENGL,3460,2,Structure of Poetry,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-3460,2017
+ENGL,3480,1,Structure Screenplay,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,nicholas chri brown,,ENGL-3480,2017
+ENGL,3490,1,Tech/Pop Imagination,0.24,0.53,0.06,0.0,0.0,0.0,0.0,0.18,gabriel and hankins,,ENGL-3490,2017
+ENGL,3540,1,Lit Middle East & North Africa,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,angela naimou,,ENGL-3540,2017
+ENGL,3570,1,Film,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2017
+ENGL,3570,2,Film,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2017
+ENGL,3570,3,Film,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,john robert smith,,ENGL-3570,2017
+ENGL,3850,1,Children's Lit,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,,ENGL-3850,2017
+ENGL,3860,1,Adolescent Lit,0.32,0.58,0.0,0.05,0.0,0.0,0.0,0.05,sarah mae cooper,,ENGL-3860,2017
+ENGL,3960,1,Brit Lit Survey I,0.39,0.22,0.17,0.17,0.06,0.0,0.0,0.0,erin marina goss,,ENGL-3960,2017
+ENGL,3960,2,Brit Lit Survey I,0.26,0.42,0.11,0.16,0.05,0.0,0.0,0.0,erin marina goss,,ENGL-3960,2017
+ENGL,3960,3,Brit Lit Survey I,0.22,0.33,0.06,0.11,0.11,0.0,0.0,0.17,erin marina goss,,ENGL-3960,2017
+ENGL,3970,2,Brit Lit Survey II,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,david sweene coombs,,ENGL-3970,2017
+ENGL,3980,2,Amer Lit Survey I,0.32,0.32,0.21,0.0,0.05,0.0,0.0,0.11,kimberly manganelli,,ENGL-3980,2017
+ENGL,3990,1,Amer Lit Survey II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-3990,2017
+ENGL,4030,1,The Classics in Translation,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-4030,2017
+ENGL,4110,1,Shakespeare,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,,ENGL-4110,2017
+ENGL,4110,2,Shakespeare,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,elizabeth rivlin,,ENGL-4110,2017
+ENGL,4110,3,Shakespeare,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,,ENGL-4110,2017
+ENGL,4170,1,Victorian Period,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,david sweene coombs,,ENGL-4170,2017
+ENGL,4190,1,Post Col & World Lit,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,,ENGL-4190,2017
+ENGL,4210,1,Amer Lit 1800-1899,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,dominic mastroianni,,ENGL-4210,2017
+ENGL,4260,1,Southern Literature,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,michael lemahieu,,ENGL-4260,2017
+ENGL,4310,1,Modern Poetry,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,steven katz,,ENGL-4310,2017
+ENGL,4340,1,Environmental Lit,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,matthew hooley,,ENGL-4340,2017
+ENGL,4350,1,Literary Criticism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,matthew hooley,,ENGL-4350,2017
+ENGL,4400,1,Literary Theory,0.32,0.42,0.21,0.05,0.0,0.0,0.0,0.0,brian mcgrath,,ENGL-4400,2017
+ENGL,4420,1,Cultural Studies,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,,ENGL-4420,2017
+ENGL,4450,1,Fiction Workshop,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,,ENGL-4450,2017
+ENGL,4500,1,Film Genres,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0, barton palmer,,ENGL-4500,2017
+ENGL,4510,1,Film Theory and Criticism,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,john robert smith,,ENGL-4510,2017
+ENGL,4750,1,Writing for Media,0.33,0.47,0.13,0.0,0.07,0.0,0.0,0.0,jonathan beec field,,ENGL-4750,2017
+ENGL,4780,1,Digital Literacy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,,ENGL-4780,2017
+ENGL,4890,1,Topics Write & Publ,0.54,0.31,0.0,0.0,0.08,0.0,0.0,0.08,megan eatman,,ENGL-4890,2017
+ENGL,4920,1,Modern Rhetoric,0.33,0.33,0.27,0.0,0.0,0.0,0.0,0.07,michelle smith,,ENGL-4920,2017
+ENGL,4960,1,Senior Seminar,0.25,0.42,0.25,0.0,0.0,0.0,0.0,0.08,brian mcgrath,,ENGL-4960,2017
+ENGL,4960,2,Senior Seminar,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,michelle renee ty,,ENGL-4960,2017
+ENGL,4960,3,Senior Seminar,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,erin marina goss,,ENGL-4960,2017
+ENGL,8570,1,Digital Rhetorics,0.78,0.0,0.0,0.0,0.11,0.0,0.0,0.11,tharon howard,,ENGL-8570,2017
+ENGR,1000,101,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,steven brandon,,ENGR-1000,2017
+ENGR,1000,102,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,steven brandon,,ENGR-1000,2017
+ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,steven brandon,,ENGR-1000,2017
+ENGR,1000,104,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,steven brandon,,ENGR-1000,2017
+ENGR,1020,116,Engineering Discipl & Skills,0.51,0.39,0.07,0.0,0.0,0.0,0.0,0.02,sarah grigg,,ENGR-1020,2017
+ENGR,1020,117,Engineering Discipl & Skills,0.46,0.32,0.1,0.02,0.0,0.0,0.0,0.1,sarah grigg,,ENGR-1020,2017
+ENGR,1020,311,Engineering Discipl & Skills,0.45,0.31,0.14,0.04,0.02,0.0,0.0,0.04,richard watkins,,ENGR-1020,2017
+ENGR,1020,313,Engineering Discipl & Skills,0.42,0.26,0.09,0.06,0.06,0.0,0.0,0.11,michael giebner,,ENGR-1020,2017
+ENGR,1020,314,Engineering Discipl & Skills,0.54,0.19,0.12,0.02,0.06,0.0,0.0,0.08,michael giebner,,ENGR-1020,2017
+ENGR,1020,317,Engineering Discipl & Skills,0.5,0.22,0.12,0.02,0.02,0.0,0.0,0.12,ashley childers,,ENGR-1020,2017
+ENGR,1020,318,Engineering Discipl & Skills,0.33,0.4,0.17,0.04,0.02,0.0,0.0,0.04,ashley childers,,ENGR-1020,2017
+ENGR,1020,500,Engineering Discipl & Skills,0.18,0.48,0.21,0.09,0.0,0.0,0.0,0.03,jonathan maier,,ENGR-1020,2017
+ENGR,1020,611,Engineering Discipl & Skills,0.44,0.3,0.08,0.04,0.08,0.0,0.0,0.06,irene marie ferrara,,ENGR-1020,2017
+ENGR,1020,612,Engineering Discipl & Skills,0.37,0.4,0.12,0.04,0.0,0.0,0.0,0.08,elizabeth stephan,,ENGR-1020,2017
+ENGR,1020,613,Engineering Discipl & Skills,0.13,0.55,0.13,0.13,0.05,0.0,0.0,0.0,elizabeth stephan,,ENGR-1020,2017
+ENGR,1020,614,Engineering Discipl & Skills,0.12,0.34,0.24,0.07,0.07,0.0,0.0,0.15,mariah magagnotti,,ENGR-1020,2017
+ENGR,1020,615,Engineering Discipl & Skills,0.51,0.24,0.14,0.1,0.02,0.0,0.0,0.0,mariah magagnotti,,ENGR-1020,2017
+ENGR,1020,616,Engineering Discipl & Skills,0.15,0.44,0.15,0.05,0.05,0.0,0.0,0.15,matthew kent miller,,ENGR-1020,2017
+ENGR,1020,617,Engineering Discipl & Skills,0.5,0.34,0.12,0.0,0.02,0.0,0.0,0.02,andrew isaa neptune,,ENGR-1020,2017
+ENGR,1020,618,Engineering Discipl & Skills,0.57,0.28,0.04,0.07,0.02,0.0,0.0,0.02,jonathan maier,,ENGR-1020,2017
+ENGR,1020,811,Engineering Discipl & Skills,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,,ENGR-1020,2017
+ENGR,1020,812,Engineering Discipl & Skills,0.4,0.45,0.1,0.0,0.02,0.0,0.0,0.02,mariah magagnotti,,ENGR-1020,2017
+ENGR,1020,813,Engineering Discipl & Skills,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,andrew isaa neptune,,ENGR-1020,2017
+ENGR,1020,814,Engineering Discipl & Skills,0.38,0.52,0.07,0.02,0.0,0.0,0.0,0.0,jonathan bro harcum,,ENGR-1020,2017
+ENGR,1020,815,Engineering Discipl & Skills,0.41,0.37,0.2,0.0,0.02,0.0,0.0,0.0,jonathan bro harcum,,ENGR-1020,2017
+ENGR,1020,816,Engineering Discipl & Skills,0.54,0.39,0.02,0.0,0.0,0.0,0.0,0.05,andrew isaa neptune,,ENGR-1020,2017
+ENGR,1020,817,Engineering Discipl & Skills,0.43,0.43,0.1,0.02,0.0,0.0,0.0,0.02,matthew kent miller,,ENGR-1020,2017
+ENGR,1020,818,Engineering Discipl & Skills,0.48,0.3,0.13,0.05,0.03,0.0,0.0,0.03,matthew kent miller,,ENGR-1020,2017
+ENGR,1020,831,Engr Discipl & Skills (HON),0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,True,ENGR-1020,2017
+ENGR,1020,832,Engr Discipl & Skills (HON),0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,True,ENGR-1020,2017
+ENGR,1060,400,Engr Discipline & Skills II,0.05,0.43,0.24,0.1,0.14,0.0,0.0,0.05,andrew isaa neptune,,ENGR-1060,2017
+ENGR,1080,400,Programming & Prob Solving II,0.0,0.4,0.5,0.0,0.0,0.0,0.0,0.1,william martin,,ENGR-1080,2017
+ENGR,1150,500,Engineering Design & Modeling,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john minor,,ENGR-1150,2017
+ENGR,1410,222,Programming & Problem Solving,0.2,0.27,0.29,0.09,0.02,0.0,0.0,0.13,william martin,,ENGR-1410,2017
+ENGR,1410,223,Programming & Problem Solving,0.07,0.31,0.36,0.16,0.07,0.0,0.0,0.04,john minor,,ENGR-1410,2017
+ENGR,1410,226,Programming & Problem Solving,0.13,0.38,0.29,0.07,0.02,0.0,0.0,0.11,steven brandon,,ENGR-1410,2017
+ENGR,1410,227,Programming & Problem Solving,0.04,0.19,0.4,0.08,0.06,0.0,0.0,0.23,anthony pau garland,,ENGR-1410,2017
+ENGR,1900,10,CI in Engr I Robotics,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael benj wooten,,ENGR-1900,2017
+ENGR,1900,78,CI in ENGR Student Design,0.67,0.08,0.0,0.0,0.08,0.0,0.0,0.17,huijuan zhao,,ENGR-1900,2017
+ENGR,2080,681,Engr Graphics & Machine Design,0.28,0.35,0.09,0.09,0.09,0.0,0.0,0.09,garrison llo broome,,ENGR-2080,2017
+ENGR,2080,682,Engr Graphics & Machine Design,0.4,0.38,0.19,0.0,0.0,0.0,0.0,0.02,garrison llo broome,,ENGR-2080,2017
+ENGR,2080,684,Engr Graphics & Machine Design,0.33,0.29,0.24,0.08,0.06,0.0,0.0,0.0,nighat yasmin,,ENGR-2080,2017
+ENGR,2080,685,Engr Graphics & Machine Design,0.23,0.32,0.2,0.02,0.11,0.0,0.0,0.11,anthony pau garland,,ENGR-2080,2017
+ENGR,2080,686,Engr Graphics & Machine Design,0.23,0.4,0.19,0.02,0.09,0.0,0.0,0.07,anthony pau garland,,ENGR-2080,2017
+ENGR,2100,804,CAD & Engineering Applications,0.28,0.44,0.09,0.09,0.02,0.0,0.0,0.07, shams esfandabadi,,ENGR-2100,2017
+ENGR,2100,805,CAD & Engineering Applications,0.34,0.34,0.11,0.07,0.02,0.0,0.0,0.11,nighat yasmin,,ENGR-2100,2017
+ENGR,2100,806,CAD & Engineering Applications,0.15,0.4,0.15,0.08,0.1,0.0,0.0,0.13,trent hou dellinger,,ENGR-2100,2017
+ENGR,2200,115,Evaluating Innovations,0.24,0.57,0.05,0.14,0.0,0.0,0.0,0.0,sarah grigg,,ENGR-2200,2017
+ENR,1010,1,Intro to Envir & Natur Res I,0.45,0.26,0.15,0.04,0.09,0.0,0.0,0.0,abigail lawson,,ENR-1010,2017
+ENR,1010,2,Intro to Envir & Natur Res I,0.43,0.33,0.18,0.05,0.0,0.0,0.0,0.03,abigail lawson,,ENR-1010,2017
+ENR,4290,1,Environ Law & Policy,0.32,0.56,0.06,0.0,0.03,0.0,0.0,0.03,alan johnson,,ENR-4290,2017
+ENR,4290,2,Environ Law & Policy,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,alan johnson,,ENR-4290,2017
+ENSP,2000,1,Intro Environ Sci,0.35,0.35,0.2,0.02,0.04,0.0,0.0,0.04,scott brame,,ENSP-2000,2017
+ENSP,2000,2,Intro Environ Sci,0.91,0.04,0.04,0.02,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2017
+ENSP,2000,3,Intro Environ Sci,0.88,0.09,0.0,0.02,0.0,0.0,0.0,0.02,minory nammouz,,ENSP-2000,2017
+ENSP,2000,4,Intro Environ Sci,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,ENSP-2000,2017
+ENSP,2000,5,Intro Environ Sci,0.2,0.48,0.2,0.09,0.02,0.0,0.0,0.02,tom owino,,ENSP-2000,2017
+ENSP,4000,1,Studies in Environmental Sci,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,margaret thompson,,ENSP-4000,2017
+ENT,2000,1,Six-Legged Science,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,suellen pometto,,ENT-2000,2017
+ENT,2010,1,Insects in Myth & Religion,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,joseph culin,,ENT-2010,2017
+ENT,3010,1,Insect Biology and Diversity,0.21,0.21,0.36,0.15,0.03,0.0,0.0,0.03,eric benson,,ENT-3010,2017
+ENTR,1010,1,Entrepreneurial Mindset,0.44,0.37,0.08,0.02,0.08,0.0,0.0,0.01,john michael hannon,,ENTR-1010,2017
+ENTR,2010,2,Select Top in Entrepreneurship,0.64,0.18,0.09,0.0,0.0,0.0,0.0,0.09,john michael hannon,,ENTR-2010,2017
+ESED,8610,1,Practicum in Engr & Sci Educ,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,karen ann high,,ESED-8610,2017
+ETOX,4300,1,Toxicology,0.3,0.1,0.5,0.1,0.0,0.0,0.0,0.0,lisa bain,,ETOX-4300,2017
+FCS,8300,1,Community Dev: Princ & Pract,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,areli moore peralta,,FCS-8300,2017
+FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.72,0.2,0.03,0.03,0.03,0.0,0.0,0.0,aubrey dean coffee,,FDSC-1010,2017
+FDSC,2160,1,Baking Science,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,,FDSC-2160,2017
+FDSC,3010,1,Food Regulations,0.77,0.2,0.02,0.0,0.0,0.0,0.0,0.0,sara lane cothran,,FDSC-3010,2017
+FDSC,4010,1,Food Chemistry I,0.5,0.39,0.1,0.02,0.0,0.0,0.0,0.0,feng chen,,FDSC-4010,2017
+FDSC,4040,1,Food Prsv & Process,0.44,0.41,0.13,0.02,0.0,0.0,0.0,0.0,anthony lou pometto,,FDSC-4040,2017
+FDSC,4070,1,Quantity Food Production,0.76,0.12,0.0,0.03,0.09,0.0,0.0,0.0,heather batt,,FDSC-4070,2017
+FDSC,4170,1,Seminar,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,aubrey dean coffee,,FDSC-4170,2017
+FDSC,4300,1,Dairy Process & Sant,0.22,0.33,0.39,0.0,0.0,0.0,0.0,0.06,john mcgregor,,FDSC-4300,2017
+FDSC,4500,11,Creative Inquiry-Food Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,paul dawson,,FDSC-4500,2017
+FIN,2010,401,Intro to Personal Finance,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,joshua harris,,FIN-2010,2017
+FIN,2010,402,Intro to Personal Finance,0.64,0.23,0.06,0.02,0.03,0.0,0.0,0.03,joshua harris,,FIN-2010,2017
+FIN,2010,403,Intro to Personal Finance,0.58,0.3,0.07,0.05,0.0,0.0,0.0,0.0,joshua harris,,FIN-2010,2017
+FIN,2010,405,Intro to Personal Finance,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,,FIN-2010,2017
+FIN,2010,406,Intro to Personal Finance,0.86,0.07,0.02,0.01,0.03,0.0,0.0,0.01,joshua harris,,FIN-2010,2017
+FIN,2010,407,Intro to Personal Finance,0.92,0.02,0.02,0.0,0.02,0.0,0.0,0.02,joshua harris,,FIN-2010,2017
+FIN,3040,2,Risk & Insurance,0.18,0.38,0.33,0.05,0.08,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2017
+FIN,3050,1,Investment Analysis,0.0,0.24,0.35,0.24,0.12,0.0,0.0,0.06,kerri mcmillan,,FIN-3050,2017
+FIN,3050,2,Investment Analysis,0.26,0.4,0.26,0.06,0.03,0.0,0.0,0.0,kerri mcmillan,,FIN-3050,2017
+FIN,3050,3,Investment Analysis,0.23,0.26,0.37,0.11,0.0,0.0,0.0,0.03,kerri mcmillan,,FIN-3050,2017
+FIN,3050,5,Investment Analysis,0.14,0.19,0.33,0.14,0.08,0.0,0.0,0.11,john alexander,,FIN-3050,2017
+FIN,3060,1,Corporation Finance,0.17,0.17,0.25,0.09,0.25,0.0,0.0,0.08,william hol johnson,,FIN-3060,2017
+FIN,3060,2,Corporation Finance,0.29,0.12,0.14,0.22,0.16,0.0,0.0,0.08,william hol johnson,,FIN-3060,2017
+FIN,3060,3,Corporation Finance,0.34,0.14,0.21,0.16,0.09,0.0,0.0,0.05,william hol johnson,,FIN-3060,2017
+FIN,3060,4,Corporation Finance,0.17,0.23,0.19,0.08,0.19,0.0,0.0,0.15,william hol johnson,,FIN-3060,2017
+FIN,3060,5,Corporation Finance,0.1,0.23,0.38,0.19,0.04,0.0,0.0,0.06,ramon tolb franklin,,FIN-3060,2017
+FIN,3060,6,Corporation Finance,0.12,0.14,0.39,0.18,0.04,0.0,0.0,0.12,ramon tolb franklin,,FIN-3060,2017
+FIN,3060,7,Corporation Finance,0.22,0.29,0.29,0.14,0.05,0.0,0.0,0.02,ramon tolb franklin,,FIN-3060,2017
+FIN,3060,8,Corporation Finance,0.12,0.16,0.24,0.29,0.08,0.0,0.0,0.1,ramon tolb franklin,,FIN-3060,2017
+FIN,3060,9,Corporation Finance,0.28,0.26,0.18,0.22,0.04,0.0,0.0,0.02,melvin stith,,FIN-3060,2017
+FIN,3060,10,Corporation Finance,0.22,0.11,0.29,0.31,0.04,0.0,0.0,0.02,melvin stith,,FIN-3060,2017
+FIN,3060,401,Corporation Finance,0.17,0.42,0.23,0.07,0.06,0.0,0.0,0.04,jonathan godbey,,FIN-3060,2017
+FIN,3070,1,Prin of Real Estate,0.17,0.24,0.37,0.17,0.02,0.0,0.0,0.02,thomas springer,,FIN-3070,2017
+FIN,3070,2,Prin of Real Estate,0.24,0.24,0.34,0.12,0.05,0.0,0.0,0.0,thomas springer,,FIN-3070,2017
+FIN,3070,3,Prin of Real Estate,0.28,0.42,0.28,0.0,0.03,0.0,0.0,0.0,yannan shen,,FIN-3070,2017
+FIN,3080,1,Fin Inst & Mkts,0.21,0.49,0.26,0.03,0.0,0.0,0.0,0.03,lyudmila chernykh,,FIN-3080,2017
+FIN,3080,2,Fin Inst & Mkts,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-3080,2017
+FIN,3080,3,Fin Inst & Mkts,0.38,0.38,0.17,0.05,0.02,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2017
+FIN,3110,1,Financial Management I,0.05,0.18,0.33,0.05,0.18,0.0,0.0,0.21,jack wolf,,FIN-3110,2017
+FIN,3110,2,Financial Management I,0.05,0.26,0.35,0.05,0.09,0.0,0.0,0.21,jack wolf,,FIN-3110,2017
+FIN,3110,3,Financial Management I,0.26,0.28,0.16,0.07,0.07,0.0,0.0,0.16,george bra lockhart,,FIN-3110,2017
+FIN,3110,4,Financial Management I,0.14,0.29,0.36,0.15,0.05,0.0,0.0,0.02,weike xu,,FIN-3110,2017
+FIN,3120,1,Financial Management II,0.12,0.35,0.32,0.09,0.06,0.0,0.0,0.06,vincent intintoli,,FIN-3120,2017
+FIN,3120,2,Financial Management II,0.16,0.34,0.24,0.21,0.03,0.0,0.0,0.03,vincent intintoli,,FIN-3120,2017
+FIN,3120,3,Financial Management II,0.23,0.17,0.43,0.1,0.03,0.0,0.0,0.03,blerina zykaj,,FIN-3120,2017
+FIN,3120,4,Financial Management II,0.17,0.36,0.24,0.17,0.02,0.0,0.0,0.05,weike xu,,FIN-3120,2017
+FIN,4010,1,Corporate Financial Analysis,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,george bra lockhart,,FIN-4010,2017
+FIN,4020,1,Corporate Valuation,0.39,0.39,0.16,0.06,0.0,0.0,0.0,0.0,angela morgan,,FIN-4020,2017
+FIN,4020,2,Corporate Valuation,0.24,0.35,0.35,0.0,0.06,0.0,0.0,0.0,angela morgan,,FIN-4020,2017
+FIN,4050,1,Portfolio Management & Theory,0.03,0.23,0.43,0.13,0.03,0.0,0.0,0.13,john alexander,,FIN-4050,2017
+FIN,4060,1,Derivatives Analysis,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,blerina zykaj,,FIN-4060,2017
+FIN,4110,1,Int Fin Mgt,0.22,0.41,0.3,0.05,0.0,0.0,0.0,0.03,luke asher devault,,FIN-4110,2017
+FIN,4110,2,Int Fin Mgt,0.18,0.53,0.18,0.0,0.06,0.0,0.0,0.06,luke asher devault,,FIN-4110,2017
+FIN,4170,1,Real Estate Finance,0.27,0.47,0.2,0.0,0.07,0.0,0.0,0.0,yannan shen,,FIN-4170,2017
+FIN,4980,2,CI in Finance: CFA,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,jack wolf,,FIN-4980,2017
+FNR,2040,1,Soil Information Systems,0.71,0.18,0.0,0.11,0.0,0.0,0.0,0.0,elena mikhailova,,FNR-2040,2017
+FNR,4700,1,Kennedy Waterfowl CI,0.69,0.0,0.31,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,,FNR-4700,2017
+FNR,4900,1,Field Training in Natural Res,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,patricia layton,,FNR-4900,2017
+FNR,4990,1,Natural Resources Seminar,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,susan talley guynn,,FNR-4990,2017
+FOR,2050,1,Dendrology,0.34,0.25,0.22,0.09,0.06,0.0,0.0,0.03,donald hagan,,FOR-2050,2017
+FOR,2050,2,Dendrology,0.1,0.39,0.22,0.05,0.1,0.0,0.0,0.15,donald hagan,,FOR-2050,2017
+FOR,2050,3,Dendrology,0.36,0.33,0.13,0.05,0.05,0.0,0.0,0.08,donald hagan,,FOR-2050,2017
+FOR,2210,1,Forest Biology,0.17,0.3,0.23,0.15,0.08,0.0,0.0,0.07,althea simone hagan,,FOR-2210,2017
+FOR,3020,1,Forest Biometrics,0.33,0.4,0.23,0.0,0.0,0.0,0.0,0.03,lawrence gering,,FOR-3020,2017
+FOR,3040,1,Forest Resource Economics,0.79,0.15,0.0,0.0,0.0,0.0,0.0,0.05,puskar khanal,,FOR-3040,2017
+FOR,4100,1,Harvesting Processes,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,patrick hiesl,,FOR-4100,2017
+FOR,4130,1,Integrated Forest Pest Mgt,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,stephen cole,,FOR-4130,2017
+FOR,4160,1,Forest Policy and Admin,0.31,0.42,0.21,0.02,0.01,0.0,0.0,0.02,thomas straka,,FOR-4160,2017
+FOR,4170,1,Forest Resource Mgt & Regulatn,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,,FOR-4170,2017
+FOR,4310,1,Recreation Res Plan in For Mgt,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,robert baxte powell,,FOR-4310,2017
+FOR,4340,1,GIS for Natural Resources,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher post,,FOR-4340,2017
+FR,1010,1,Elementary French,0.18,0.53,0.06,0.12,0.0,0.0,0.0,0.12,anne salces  nedeo,,FR-1010,2017
+FR,1010,2,Elementary French,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,,FR-1010,2017
+FR,1020,1,Elementary French,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2017
+FR,1020,2,Elementary French,0.81,0.0,0.13,0.06,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2017
+FR,1020,3,Elementary French,0.2,0.4,0.1,0.1,0.0,0.0,0.0,0.2,kenneth dav widgren,,FR-1020,2017
+FR,2010,2,Intermediate French,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,kenneth dav widgren,,FR-2010,2017
+FR,2010,3,Intermediate French,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,kenneth dav widgren,,FR-2010,2017
+FR,2010,4,Intermediate French,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,,FR-2010,2017
+FR,2020,1,Intermediate French,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2020,2017
+FR,2020,2,Intermediate French,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,kelly digby peebles,,FR-2020,2017
+FR,2020,3,Intermediate French,0.33,0.33,0.2,0.07,0.0,0.0,0.0,0.07,kenneth dav widgren,,FR-2020,2017
+FR,2020,4,Intermediate French,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2020,2017
+FR,3000,1,Survey of French Lit,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,,FR-3000,2017
+FR,3050,2,Int Fr Con & Comp I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph mai,,FR-3050,2017
+FR,3070,1,French Civilization,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,,FR-3070,2017
+FR,4100,1,Francophone Lit,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,True,FR-4100,2017
+GC,1010,1,Orientation to G C,0.68,0.14,0.04,0.02,0.06,0.0,0.0,0.06,john leininger,,GC-1010,2017
+GC,1010,2,Orientation to G C,0.39,0.49,0.0,0.0,0.02,0.0,0.0,0.1,john leininger,,GC-1010,2017
+GC,1020,1,Computer Art & CAD Foundations,0.6,0.29,0.04,0.0,0.02,0.0,0.0,0.04,carol jones,,GC-1020,2017
+GC,1020,2,Computer Art & CAD Foundations,0.52,0.3,0.05,0.05,0.02,0.0,0.0,0.05,carol jones,,GC-1020,2017
+GC,1030,1,G C I for Pkgsc,0.21,0.47,0.32,0.0,0.0,0.0,0.0,0.0,john jacobs,,GC-1030,2017
+GC,1040,1,Graphic Communications I,0.49,0.27,0.14,0.0,0.07,0.0,0.0,0.03,rebecca suza edlein,,GC-1040,2017
+GC,2070,1,Graphic Communications II,0.66,0.22,0.08,0.02,0.0,0.0,0.0,0.02,charles tabor weiss,,GC-2070,2017
+GC,3400,1,Digital Imaging and eMedia,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0,erica black walker,,GC-3400,2017
+GC,3460,1,Ink and Substrates,0.23,0.55,0.19,0.02,0.0,0.0,0.0,0.0,liam henry 'hara,,GC-3460,2017
+GC,3500,1,G C Internship I,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,carol jones,,GC-3500,2017
+GC,4060,1,Package and Specialty Printing,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,kern cox,,GC-4060,2017
+GC,4400,1,Commercial Printing,0.24,0.63,0.05,0.0,0.05,0.0,0.0,0.02,eric weisenmiller,,GC-4400,2017
+GC,4440,1,Current Dev/Trends in Gr Comm,0.67,0.25,0.06,0.0,0.0,0.0,0.0,0.03,samuel ingram,,GC-4440,2017
+GC,4480,1,Plan & Cont Printing Functions,0.89,0.06,0.02,0.0,0.0,0.0,0.0,0.02,nona woolbright,,GC-4480,2017
+GC,4500,1,GC Internship II,0.9,0.0,0.1,0.0,0.0,0.0,0.0,0.0,carol jones,,GC-4500,2017
+GC,4800,1,Senior Seminar in GC,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,,GC-4800,2017
+GC,6060,1,Pkg & Spec Prtg,0.5,0.33,0.0,0.0,0.17,0.0,0.0,0.0,kern cox,,GC-6060,2017
+GEN,1030,1,Careers in Bioch/Gen,0.81,0.09,0.06,0.03,0.01,0.0,0.0,0.0,joseph paul thames,,GEN-1030,2017
+GEN,3000,1,Fundamental Genetics,0.31,0.41,0.17,0.06,0.01,0.0,0.0,0.05,kate leanne wi tsai,,GEN-3000,2017
+GEN,3000,2,Fundamental Genetics,0.28,0.4,0.19,0.07,0.03,0.0,0.0,0.04,kate leanne wi tsai,,GEN-3000,2017
+GEN,3020,1,Molecular & General Genetics,0.3,0.36,0.18,0.07,0.04,0.0,0.0,0.05,lukasz kozubowski,,GEN-3020,2017
+GEN,3020,2,Molec & General Genetics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True,GEN-3020,2017
+GEN,3020,4,Molecular & General Genetics,0.42,0.36,0.12,0.03,0.06,0.0,0.0,0.0,haiying liang,,GEN-3020,2017
+GEN,4200,1,Molecular Genetics & Gene Reg,0.25,0.43,0.23,0.07,0.0,0.0,0.0,0.02,julia frugoli,,GEN-4200,2017
+GEN,4200,2,Molecular Genetics & Gen (HON),0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True,GEN-4200,2017
+GEN,4210,3,Mol Gen Gene Reg Lab,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,scott michae tanner,,GEN-4210,2017
+GEN,4400,1,Bioinformatics,0.62,0.24,0.07,0.05,0.0,0.0,0.0,0.02,frank alexan feltus,,GEN-4400,2017
+GEN,4500,1,Comparative Genetics,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,leigh anne clark,,GEN-4500,2017
+GEN,4900,1,Epigenetics,0.56,0.25,0.0,0.13,0.0,0.0,0.0,0.06,rajandeep si sekhon,,GEN-4900,2017
+GEOG,1010,2,Intro to Geography,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,david doran,,GEOG-1010,2017
+GEOG,1030,1,World Regional Geography,0.81,0.15,0.02,0.01,0.0,0.0,0.0,0.01,david doran,,GEOG-1030,2017
+GEOG,1030,2,World Regional Geography,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christa smith,,GEOG-1030,2017
+GEOG,1030,3,World Regional Geography,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,david doran,,GEOG-1030,2017
+GEOG,3030,1,Urban Geography,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,christa smith,,GEOG-3030,2017
+GEOL,1010,1,Physical Geology,0.23,0.29,0.22,0.09,0.09,0.0,0.0,0.09,alan coulson,,GEOL-1010,2017
+GEOL,1010,2,Physical Geology,0.18,0.32,0.21,0.12,0.07,0.0,0.0,0.1,alan coulson,,GEOL-1010,2017
+GEOL,1010,3,Physical Geology,0.49,0.33,0.07,0.07,0.0,0.0,0.0,0.04,kelly best lazar,,GEOL-1010,2017
+GEOL,1010,4,Physical Geology,0.03,0.29,0.26,0.23,0.17,0.0,0.0,0.03,melissa ranhofer,,GEOL-1010,2017
+GEOL,1030,1,Physical Geol Lab,0.67,0.17,0.08,0.0,0.04,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,1030,2,Physical Geol Lab,0.26,0.22,0.3,0.09,0.09,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,1030,3,Physical Geol Lab,0.46,0.33,0.21,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,4,Physical Geol Lab,0.5,0.21,0.21,0.0,0.04,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,1030,5,Physical Geol Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,1030,6,Physical Geol Lab,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,8,Physical Geol Lab,0.74,0.17,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,9,Physical Geol Lab,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,10,Physical Geol Lab,0.75,0.13,0.04,0.0,0.0,0.0,0.0,0.08,alan coulson,,GEOL-1030,2017
+GEOL,1030,11,Physical Geol Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,12,Physical Geol Lab,0.67,0.25,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,13,Physical Geol Lab,0.46,0.38,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,2050,1,Mineralogy & Intro Petrology,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,lin shuller-nickles,,GEOL-2050,2017
+GEOL,2070,1,Min & Intro Pet Lab,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-2070,2017
+GEOL,2700,1,Sustainable Water,0.7,0.15,0.0,0.0,0.0,0.0,0.0,0.15,stephen mich moysey,,GEOL-2700,2017
+GEOL,2750,1,Field Methods,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-2750,2017
+GEOL,3000,1,Environmental Geology,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-3000,2017
+GEOL,4150,1,Analysis Geological Processes,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,,GEOL-4150,2017
+GEOL,4820,1,Groundwater & Contam Transport,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,,GEOL-4820,2017
+GEOL,7900,500,Biogeography And Geology of SC,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,john robert wagner,,GEOL-7900,2017
+GEOL,8080,1,Groundwater Modeling,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,,GEOL-8080,2017
+GER,1010,1,Elementary German,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,oswald harris king,,GER-1010,2017
+GER,1010,2,Elementary German,0.24,0.41,0.06,0.12,0.06,0.0,0.0,0.12,oswald harris king,,GER-1010,2017
+GER,1020,1,Elementary German,0.5,0.3,0.0,0.0,0.0,0.0,0.0,0.2,isabel meusen,,GER-1020,2017
+GER,1020,2,Elementary German,0.25,0.42,0.17,0.0,0.08,0.0,0.0,0.08,isabel meusen,,GER-1020,2017
+GER,2010,1,Intermediate German,0.32,0.32,0.26,0.0,0.0,0.0,0.0,0.11, lee ferrell,,GER-2010,2017
+GER,2010,2,Intermediate German,0.33,0.13,0.33,0.07,0.07,0.0,0.0,0.07,gabriela stoicea,,GER-2010,2017
+GER,2020,1,Intermediate German,0.05,0.26,0.37,0.21,0.05,0.0,0.0,0.05,johannes schmidt,,GER-2020,2017
+GER,3400,1,German Culture,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,oswald harris king,,GER-3400,2017
+HCC,8310,1,Fundamentals of Hcc,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,brygg anders ullmer,,HCC-8310,2017
+HCC,8330,1,HCC Research Methods,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,,HCC-8330,2017
+HCC,8810,1,Selected Topic: Measu/Evalu II,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,bart knijnenburg,,HCC-8810,2017
+HCG,9040,400,Knowledge Development,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,HCG-9040,2017
+HIST,1010,1,History of the United States,0.21,0.62,0.09,0.0,0.06,0.0,0.0,0.03,paul chris anderson,,HIST-1010,2017
+HIST,1020,1,Hist of the U S,0.35,0.47,0.12,0.06,0.0,0.0,0.0,0.0,john andrew,,HIST-1020,2017
+HIST,1020,2,Hist of the U S,0.35,0.57,0.08,0.0,0.0,0.0,0.0,0.0,william camp,,HIST-1020,2017
+HIST,1220,1,"Hist, Tech & Society",0.12,0.51,0.19,0.08,0.06,0.0,0.0,0.04,pamela mack,,HIST-1220,2017
+HIST,1240,1,Environmental History Survey,0.11,0.5,0.28,0.06,0.06,0.0,0.0,0.0,james brad jeffries,,HIST-1240,2017
+HIST,1240,2,Environmental History Survey,0.03,0.5,0.31,0.03,0.06,0.0,0.0,0.06,james brad jeffries,,HIST-1240,2017
+HIST,1720,1,The West and the World I,0.36,0.43,0.08,0.02,0.03,0.0,0.0,0.07,caroline dunn clark,,HIST-1720,2017
+HIST,1720,2,The West and the World I,0.21,0.47,0.22,0.04,0.04,0.0,0.0,0.02,steven marks,,HIST-1720,2017
+HIST,1730,1,The West and the World II,0.26,0.43,0.19,0.01,0.03,0.0,0.0,0.08, alan grubb,,HIST-1730,2017
+HIST,1730,2,The West and the World II,0.33,0.39,0.11,0.0,0.06,0.0,0.0,0.11,sandra nic mokalled,,HIST-1730,2017
+HIST,2990,2,Historian's Craft,0.75,0.15,0.0,0.05,0.0,0.0,0.0,0.05,rachel anne moore,,HIST-2990,2017
+HIST,2990,3,Historian's Craft,0.47,0.42,0.0,0.0,0.0,0.0,0.0,0.11,thomas kuehn,,HIST-2990,2017
+HIST,3040,1,Indus & Progr Era,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06, roger grant,,HIST-3040,2017
+HIST,3060,1,US: Postwar World 1945-1975,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,william camp,,HIST-3060,2017
+HIST,3100,1,History of Religion in the US,0.33,0.22,0.28,0.17,0.0,0.0,0.0,0.0,elizabeth jemison,,HIST-3100,2017
+HIST,3120,1,Afr Amer Hist 1877 to Present,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,,HIST-3120,2017
+HIST,3170,1,Hist of Nat. Am. Relig/Culture,0.29,0.29,0.07,0.0,0.14,0.0,0.0,0.21,james brad jeffries,,HIST-3170,2017
+HIST,3280,1,US Legal History to 1890,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,lee brady wilson,,HIST-3280,2017
+HIST,3300,1,Hist of Mod China,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,edwin moise,,HIST-3300,2017
+HIST,3390,1,Africa 1875-Present,0.53,0.24,0.12,0.12,0.0,0.0,0.0,0.0,james burns,,HIST-3390,2017
+HIST,3410,1,Modern Mexico,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,,HIST-3410,2017
+HIST,3630,1,Britain Since 1688,0.55,0.38,0.07,0.0,0.0,0.0,0.0,0.0,stephani barczewski,,HIST-3630,2017
+HIST,3670,1,Modern Ireland,0.52,0.37,0.04,0.0,0.04,0.0,0.0,0.04,michael silvestri,,HIST-3670,2017
+HIST,3730,1,Age of Protestant Reformation,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,thomas kuehn,,HIST-3730,2017
+HIST,3750,1,Revolutionary Europe,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0, alan grubb,,HIST-3750,2017
+HIST,3900,1,Modern Military History,0.18,0.41,0.29,0.06,0.0,0.0,0.0,0.06,edwin moise,,HIST-3900,2017
+HIST,4000,1,Local and Nearby History,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15, roger grant,,HIST-4000,2017
+HIST,4510,1,Alexander the Great,0.27,0.53,0.07,0.0,0.0,0.0,0.0,0.13,elizabeth carney,,HIST-4510,2017
+HIST,4720,1,Medieval Conquests & Crusades,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,caroline dunn clark,,HIST-4720,2017
+HIST,4870,1,World War II,0.03,0.87,0.1,0.0,0.0,0.0,0.0,0.0,john andrew,,HIST-4870,2017
+HIST,4900,1,Northern Ireland,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,michael silvestri,,HIST-4900,2017
+HIST,4900,3,Disney Parks,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,,HIST-4900,2017
+HIST,4920,1,The US in the Atomic Age,0.29,0.53,0.0,0.12,0.0,0.0,0.0,0.06,william camp,,HIST-4920,2017
+HIST,8000,3,Film and History,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james burns,,HIST-8000,2017
+HLTH,2020,1,Introduction to Public Health,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2017
+HLTH,2020,2,Introduction to Public Health,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2017
+HLTH,2020,3,Introduction to Public Health,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2017
+HLTH,2020,4,Introduction to Public Health,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2017
+HLTH,2020,5,Introduction to Public Health,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2017
+HLTH,2020,6,Introduction to Public Health,0.6,0.2,0.07,0.0,0.0,0.0,0.0,0.13,becky ann tugman,,HLTH-2020,2017
+HLTH,2020,400,Introduction to Public Health,0.65,0.2,0.05,0.05,0.05,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2017
+HLTH,2030,1,Health Care Sys,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2017
+HLTH,2030,2,Health Care Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,HLTH-2030,2017
+HLTH,2400,1,Deter of Hlth Behav,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2017
+HLTH,2400,2,Deter of Hlth Behav,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2017
+HLTH,2600,2,Medical Terminology & Comm,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2600,2017
+HLTH,2980,1,Human Health and Disease,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2017
+HLTH,2980,2,Human Health and Disease,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2980,2017
+HLTH,3400,1,Hlth Prom Prog Plan,0.44,0.44,0.12,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-3400,2017
+HLTH,3610,1,Int Health Care Econ,0.5,0.42,0.0,0.04,0.0,0.0,0.0,0.04,khoa dang truong,,HLTH-3610,2017
+HLTH,3800,1,Epidemiology,0.42,0.32,0.16,0.05,0.0,0.0,0.0,0.05,hugh spitler,,HLTH-3800,2017
+HLTH,3800,2,Epidemiology,0.74,0.19,0.03,0.0,0.03,0.0,0.0,0.0,hugh spitler,,HLTH-3800,2017
+HLTH,3800,400,Epidemiology,0.44,0.22,0.22,0.06,0.06,0.0,0.0,0.0,deborah alma falta,,HLTH-3800,2017
+HLTH,3980,1,Health Appraisal Skills,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2017
+HLTH,3980,2,Health Appraisal Skills,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2017
+HLTH,4000,4,Public Hlth Social Marketing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,debra mitch charles,,HLTH-4000,2017
+HLTH,4190,1,Health Sci Internship Prep Sem,0.59,0.29,0.1,0.02,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4190,2017
+HLTH,4200,1,Hlth Science Intern,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2017
+HLTH,4400,1,Manag Hlth Serv Org,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,george paul  newby,,HLTH-4400,2017
+HLTH,4750,1,Hlthcr Oper Mgmt Res,0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,,HLTH-4750,2017
+HLTH,4900,1,Res Eval St Pub Hlth,0.55,0.26,0.11,0.05,0.0,0.0,0.0,0.03,lingling zhang,,HLTH-4900,2017
+HLTH,4900,2,Res Eval St Pub Hlth,0.63,0.25,0.06,0.06,0.0,0.0,0.0,0.0,lingling zhang,,HLTH-4900,2017
+HLTH,8030,1,Theories and Determ of Health,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joel edwar williams,,HLTH-8030,2017
+HLTH,8120,500,Clinical and Translational Sci,0.5,0.17,0.0,0.0,0.0,0.0,0.0,0.33,ronald gimbel,,HLTH-8120,2017
+HLTH,8140,500,Health Sys Quality Improvement,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,windsor we sherrill,,HLTH-8140,2017
+HLTH,8320,1,Quantitative Analy in Hlth II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,,HLTH-8320,2017
+HON,1900,1,Hell in Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True,HON-1900,2017
+HON,1930,2,The Russian Revolution,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,True,HON-1930,2017
+HON,1940,2,Scientific Skepticism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey appling,True,HON-1940,2017
+HON,2020,3,Wisdom of the Moderns,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,colin pearce,True,HON-2020,2017
+HON,2200,3,Europe in the Age of Dictators,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,True,HON-2200,2017
+HON,2210,3,Southern Literature,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,michael lemahieu,True,HON-2210,2017
+HON,2210,4,Imaginary Friends in Fiction,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True,HON-2210,2017
+HON,2220,1,Lit & Science in Modernism,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,True,HON-2220,2017
+HORT,1010,1,Horticulture,0.9,0.05,0.03,0.0,0.0,0.0,0.0,0.02,ellen anita vincent,,HORT-1010,2017
+HORT,2020,1,Adobe Digital Design,0.8,0.11,0.0,0.0,0.0,0.0,0.0,0.09,janice ann lay,,HORT-2020,2017
+HORT,2100,1,Growing Fall Plants,0.08,0.46,0.33,0.04,0.04,0.0,0.0,0.04,james emerson faust,,HORT-2100,2017
+HORT,2120,1,Turfgrass Culture,0.5,0.41,0.08,0.0,0.0,0.0,0.0,0.02,haibo liu,,HORT-2120,2017
+HORT,3030,1,Landscape Plants,0.18,0.26,0.24,0.15,0.1,0.0,0.0,0.08,robert polomski,,HORT-3030,2017
+HORT,3080,1,Sust Landsc Des Install Maint,0.93,0.02,0.05,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-3080,2017
+HORT,4120,1,Adv Turfgrass Mgt,0.45,0.27,0.0,0.0,0.09,0.0,0.0,0.18,lambert mccarty,,HORT-4120,2017
+HP,8010,1,Preservation Law and Econ,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,william jackso cook,,HP-8010,2017
+HP,8030,1,Building Tech and Pathology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,amalia leifeste,,HP-8030,2017
+HRD,8200,400,Human Perform Improv,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william havice,,HRD-8200,2017
+HRD,8200,401,Human Perform Improv,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william havice,,HRD-8200,2017
+HRD,8300,400,Concepts of H R D,0.91,0.03,0.06,0.0,0.0,0.0,0.0,0.0,angela danie carter,,HRD-8300,2017
+HRD,8600,400,Instruc Mat Devel,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,cynthia sims,,HRD-8600,2017
+IE,2100,1,Des Analysis Wrk Sys,0.09,0.47,0.35,0.09,0.01,0.0,0.0,0.0,david neyens,,IE-2100,2017
+IE,2800,1,Deterministic Operations Rsrch,0.13,0.25,0.12,0.17,0.17,0.0,0.0,0.17,robert james riggs,,IE-2800,2017
+IE,3010,1,Systems Design I,0.32,0.47,0.19,0.01,0.0,0.0,0.0,0.01,robert james riggs,,IE-3010,2017
+IE,3600,1,Industrial Apps of Prob/Stat I,0.23,0.23,0.23,0.12,0.14,0.0,0.0,0.05,tugce isik,,IE-3600,2017
+IE,3610,1,Industrial App of Prob/Stat II,0.4,0.25,0.1,0.1,0.05,0.0,0.0,0.1,brian melloy,,IE-3610,2017
+IE,3810,1,Probabilistic Operations Rsrch,0.14,0.34,0.25,0.12,0.09,0.0,0.0,0.07,amin khademi,,IE-3810,2017
+IE,3840,1,Engr Econ Analysis,0.29,0.16,0.2,0.1,0.13,0.0,0.0,0.13,brian melloy,,IE-3840,2017
+IE,3860,1,Prod Plan & Cont,0.31,0.29,0.2,0.13,0.05,0.0,0.0,0.03,robert james riggs,,IE-3860,2017
+IE,4400,1,Decision Support Sys,0.45,0.28,0.16,0.03,0.05,0.0,0.0,0.02,sandra dun eksioglu,,IE-4400,2017
+IE,4400,2,Decision Support Sys,0.29,0.35,0.24,0.06,0.06,0.0,0.0,0.0,sandra dun eksioglu,,IE-4400,2017
+IE,4610,1,Quality Engineering,0.27,0.34,0.2,0.16,0.01,0.0,0.0,0.02,byung rae cho,,IE-4610,2017
+IE,4650,1,Facilities Planning & Design,0.14,0.55,0.27,0.04,0.01,0.0,0.0,0.0,william ferrell,,IE-4650,2017
+IE,4820,1,Systems Modeling,0.44,0.37,0.19,0.0,0.0,0.0,0.0,0.0,kevin taaffe,,IE-4820,2017
+IE,4820,2,Systems Modeling,0.43,0.44,0.12,0.01,0.0,0.0,0.0,0.0,kevin taaffe,,IE-4820,2017
+IE,4910,1,Network Flows for IE Apps,0.29,0.41,0.18,0.12,0.0,0.0,0.0,0.0,burak eksioglu,,IE-4910,2017
+IE,4910,2,Service Engineering,0.21,0.52,0.24,0.03,0.0,0.0,0.0,0.0,tugce isik,,IE-4910,2017
+IE,4910,3,Human Centered Design & Engr,0.31,0.59,0.07,0.0,0.0,0.0,0.0,0.03,laura miche stanley,,IE-4910,2017
+IE,8000,1,Human Factors Eng,0.49,0.47,0.05,0.0,0.0,0.0,0.0,0.0,david neyens,,IE-8000,2017
+IE,8030,1,Engr Optimization and Apps,0.48,0.45,0.05,0.0,0.0,0.0,0.0,0.03,jonathan cole smith,,IE-8030,2017
+IE,8090,1,Model Sys Under Risk,0.43,0.35,0.18,0.0,0.0,0.0,0.0,0.05,burak eksioglu,,IE-8090,2017
+IE,8510,1,Descriptive Analytics,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,mary elizabeth kurz,,IE-8510,2017
+IE,8530,1,Foundations of Quality,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,byung rae cho,,IE-8530,2017
+IE,8550,1,SC & Logistics Modeling II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,,IE-8550,2017
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.84,0.13,0.03,lisa marie robinson,,INT-1510,2017
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,caren kelley-hall,,INT-1530,2017
+IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.48,0.52,0.0,meredith fan wilson,,IS-1010,2017
+ITAL,1010,1,Elementary Italian,0.67,0.2,0.07,0.0,0.07,0.0,0.0,0.0,julia schmidt,,ITAL-1010,2017
+ITAL,1010,2,Elementary Italian,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,luca barattoni,,ITAL-1010,2017
+ITAL,1010,3,Elementary Italian,0.38,0.25,0.19,0.0,0.13,0.0,0.0,0.06,julia schmidt,,ITAL-1010,2017
+ITAL,1010,4,Elementary Italian,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-1010,2017
+ITAL,1020,1,Elementary Italian,0.31,0.31,0.06,0.0,0.06,0.0,0.0,0.25,lyudmyla tsykalova,,ITAL-1020,2017
+ITAL,2010,1,Intermediate Italian,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-2010,2017
+JAPN,1010,1,Elementary Japanese,0.28,0.17,0.17,0.11,0.11,0.0,0.0,0.17,saori suto,,JAPN-1010,2017
+JAPN,1010,2,Elementary Japanese,0.32,0.32,0.11,0.05,0.16,0.0,0.0,0.05,saori suto,,JAPN-1010,2017
+JAPN,2010,1,Intermed Japanese,0.31,0.31,0.31,0.08,0.0,0.0,0.0,0.0,saori suto,,JAPN-2010,2017
+JAPN,4010,1,Japanese Lit in Translation,0.47,0.35,0.06,0.12,0.0,0.0,0.0,0.0,kumiko saito,,JAPN-4010,2017
+JAPN,4060,1,Intro to Japanese Literature,0.67,0.08,0.08,0.17,0.0,0.0,0.0,0.0,kumiko saito,,JAPN-4060,2017
+JUST,2880,1,The Criminal Justice System,0.4,0.32,0.19,0.09,0.0,0.0,0.0,0.0,margaret tina britz,,JUST-2880,2017
+JUST,2890,1,Criminology,0.89,0.06,0.03,0.0,0.0,0.0,0.0,0.03,angelia turner,,JUST-2890,2017
+JUST,4680,1,Criminal Evidence,0.4,0.28,0.23,0.09,0.0,0.0,0.0,0.0,margaret tina britz,,JUST-4680,2017
+JUST,4910,1,Policing,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david williams,,JUST-4910,2017
+LANG,2540,1,Introduction to World Cinemas,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,joseph mai,,LANG-2540,2017
+LANG,3710,1,Language and Culture,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,yanhua zhang,,LANG-3710,2017
+LARC,1150,1,Intro Landscape Architecture,0.68,0.14,0.11,0.04,0.04,0.0,0.0,0.0,mary padua,,LARC-1150,2017
+LARC,1280,1,Technical Graphics,0.18,0.41,0.32,0.09,0.0,0.0,0.0,0.0,cecile martin,,LARC-1280,2017
+LARC,1510,1,Basic Design I,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,cecile martin,,LARC-1510,2017
+LARC,2510,1,Larch Design Fund,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jessica fernandez,,LARC-2510,2017
+LARC,2620,1,Design Impl I,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,pai liu,,LARC-2620,2017
+LARC,3510,1,Regional Design,0.41,0.35,0.12,0.0,0.06,0.0,0.0,0.06,matthew neal powers,,LARC-3510,2017
+LARC,4540,1,Urban Design Studio,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,paul russell,,LARC-4540,2017
+LARC,4620,1,Design Implementation III,0.56,0.25,0.06,0.06,0.0,0.0,0.0,0.06,jessica fernandez,,LARC-4620,2017
+LARC,8430,1,Interdisc Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,,LARC-8430,2017
+LAW,3220,1,Legal Env of Bus,0.27,0.45,0.29,0.0,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2017
+LAW,3220,2,Legal Env of Bus,0.33,0.43,0.18,0.02,0.04,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2017
+LAW,3220,3,Legal Env of Bus,0.29,0.31,0.33,0.0,0.06,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2017
+LAW,3220,4,Legal Env of Bus,0.1,0.44,0.38,0.02,0.06,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2017
+LAW,3220,5,Legal Env of Bus,0.05,0.38,0.38,0.1,0.05,0.0,0.0,0.05,kenneth toussaint,,LAW-3220,2017
+LAW,3220,6,Legal Env of Bus,0.22,0.39,0.29,0.08,0.0,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2017
+LAW,3220,7,Legal Env of Bus,0.31,0.42,0.23,0.02,0.02,0.0,0.0,0.0,kath kisska-schulze,,LAW-3220,2017
+LAW,3220,8,Legal Env of Bus,0.39,0.49,0.1,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,,LAW-3220,2017
+LAW,3220,9,Legal Env of Bus,0.3,0.4,0.25,0.03,0.0,0.0,0.0,0.03,john hine,,LAW-3220,2017
+LAW,3220,10,Legal Env of Bus,0.29,0.41,0.18,0.02,0.0,0.0,0.0,0.1,kath kisska-schulze,,LAW-3220,2017
+LAW,3220,400,Legal Env of Bus,0.32,0.47,0.12,0.03,0.03,0.0,0.0,0.03,virgini ward-vaughn,,LAW-3220,2017
+LAW,3220,401,Legal Env of Bus,0.33,0.37,0.18,0.02,0.03,0.0,0.0,0.07,virgini ward-vaughn,,LAW-3220,2017
+LAW,3220,402,Legal Env of Bus,0.4,0.37,0.12,0.0,0.04,0.0,0.0,0.07,virgini ward-vaughn,,LAW-3220,2017
+LAW,3220,403,Legal Env of Bus,0.33,0.43,0.14,0.03,0.03,0.0,0.0,0.03,virgini ward-vaughn,,LAW-3220,2017
+LAW,3330,1,Real Estate Law,0.0,0.47,0.33,0.07,0.1,0.0,0.0,0.03,judson jahn,,LAW-3330,2017
+LAW,3330,2,Real Estate Law,0.21,0.5,0.21,0.0,0.06,0.0,0.0,0.03,judson jahn,,LAW-3330,2017
+LAW,4050,1,Construction Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-4050,2017
+LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.9,0.03,0.06, lee ferrell,,LIT-1270,2017
+LS,1000,1,Therapeutic Yoga,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-1000,2017
+LS,1000,2,Therapeutic Yoga,0.67,0.19,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,,LS-1000,2017
+LS,1000,3,Therapeutic Yoga,0.8,0.05,0.0,0.0,0.0,0.0,0.0,0.15,ranjanbala dil amin,,LS-1000,2017
+LS,1000,4,Intro to Barre,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,lauren eliza george,,LS-1000,2017
+LS,1000,5,Intro to Barre,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lauren eliza george,,LS-1000,2017
+LS,1000,10,Clemson Life,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,kristin anne neff,,LS-1000,2017
+LS,1000,14,Freshman Outdoor,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,emily grace turke,,LS-1000,2017
+LS,1000,28,Stand up Pabbleboarding,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,william holland,,LS-1000,2017
+LS,1410,1,Top Rope Climbing,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,michelle tuday,,LS-1410,2017
+LS,1410,2,Top Rope Climbing,0.73,0.13,0.0,0.0,0.0,0.0,0.0,0.13,michelle tuday,,LS-1410,2017
+LS,1410,4,Top Rope Climbing,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michelle tuday,,LS-1410,2017
+LS,1410,5,Top Rope Climbing,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,michelle tuday,,LS-1410,2017
+LS,1560,2,Riflery,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,hubert cox,,LS-1560,2017
+LS,1560,7,Riflery,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,,LS-1560,2017
+LS,1560,16,Riflery,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,,LS-1560,2017
+LS,1570,1,Shotgun Sports,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,john jeffrey price,,LS-1570,2017
+LS,1570,6,Shotgun Sports,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,william cro mahoney,,LS-1570,2017
+LS,1750,1,Fly Fishing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james micha harvell,,LS-1750,2017
+LS,1850,1,Bowling,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,megan elizabet cato,,LS-1850,2017
+LS,1850,2,Bowling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,alexandra sandoval,,LS-1850,2017
+LS,1850,10,Bowling,0.86,0.0,0.05,0.05,0.0,0.0,0.0,0.05,tyler bennett,,LS-1850,2017
+LS,1940,1,Racquetball,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,,LS-1940,2017
+LS,1960,1,Intro to Billiards,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,broadus fleming,,LS-1960,2017
+LS,1980,4,Golf,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jason jordan,,LS-1980,2017
+LS,1980,5,Golf,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jason jordan,,LS-1980,2017
+LS,1980,9,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,wesley scott womble,,LS-1980,2017
+LS,2200,7,Shag,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,broadus fleming,,LS-2200,2017
+LS,2270,1,Intro to Swing Dance,0.92,0.03,0.0,0.0,0.03,0.0,0.0,0.03,paul hoke,,LS-2270,2017
+LS,2270,2,Intro to Swing Dance,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,,LS-2270,2017
+LS,2270,3,Intro to Swing Dance,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,paul hoke,,LS-2270,2017
+LS,2320,2,Core Training,0.76,0.1,0.05,0.0,0.0,0.0,0.0,0.1,diane moreno,,LS-2320,2017
+LS,2320,3,Core Training,0.78,0.06,0.11,0.0,0.06,0.0,0.0,0.0,diane moreno,,LS-2320,2017
+LS,2320,5,Core Training,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-2320,2017
+LS,2350,1,Basic Yoga,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2350,2017
+LS,2350,2,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,,LS-2350,2017
+LS,2350,3,Basic Yoga,0.86,0.05,0.05,0.05,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2017
+LS,2350,4,Basic Yoga,0.81,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,,LS-2350,2017
+LS,2350,5,Basic Yoga,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-2350,2017
+LS,2350,7,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,,LS-2350,2017
+LS,2350,8,Basic Yoga,0.87,0.09,0.0,0.0,0.04,0.0,0.0,0.0,kayla lee wardlaw,,LS-2350,2017
+LS,2380,4,Vinyasa Flow Yoga,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,,LS-2380,2017
+LS,2420,1,Meditation and Relax,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2017
+LS,2420,2,Meditation and Relax,0.91,0.0,0.04,0.04,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2420,2017
+LS,2420,4,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,,LS-2420,2017
+LS,2420,5,Meditation and Relax,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2420,2017
+LS,2420,6,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2017
+LS,2420,7,Meditation and Relax,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,,LS-2420,2017
+LS,2420,8,Meditation and Relax,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,,LS-2420,2017
+LS,2450,1,Pilates,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,melanie ivey job,,LS-2450,2017
+LS,2450,5,Pilates,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-2450,2017
+LS,2450,6,Pilates,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,diane moreno,,LS-2450,2017
+LS,2750,8,First Aid/Cpr,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,christopher loomis,,LS-2750,2017
+MATH,1010,1,Essen Math for Informed Soc,0.44,0.39,0.06,0.0,0.06,0.0,0.0,0.06,ebenezer eduafo,,MATH-1010,2017
+MATH,1010,2,Essen Math for Informed Soc,0.59,0.29,0.0,0.12,0.0,0.0,0.0,0.0,ebenezer eduafo,,MATH-1010,2017
+MATH,1010,3,Essen Math for Informed Soc,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,xiyan tan,,MATH-1010,2017
+MATH,1010,4,Essen Math for Informed Soc,0.65,0.12,0.12,0.06,0.0,0.0,0.0,0.06,xiyan tan,,MATH-1010,2017
+MATH,1010,5,Essen Math for Informed Soc,0.39,0.39,0.06,0.17,0.0,0.0,0.0,0.0,jun yuan,,MATH-1010,2017
+MATH,1010,6,Essen Math for Informed Soc,0.44,0.22,0.22,0.11,0.0,0.0,0.0,0.0,jun yuan,,MATH-1010,2017
+MATH,1010,7,Essen Math for Informed Soc,0.61,0.31,0.03,0.03,0.0,0.0,0.0,0.03,marilyn reba,,MATH-1010,2017
+MATH,1020,1,Business Calculus I,0.32,0.16,0.21,0.11,0.05,0.0,0.0,0.16,madeleine stville,,MATH-1020,2017
+MATH,1020,2,Business Calculus I,0.32,0.37,0.26,0.0,0.05,0.0,0.0,0.0,madeleine stville,,MATH-1020,2017
+MATH,1020,3,Business Calculus I,0.26,0.42,0.16,0.05,0.05,0.0,0.0,0.05,morgan elston,,MATH-1020,2017
+MATH,1020,4,Business Calculus I,0.16,0.32,0.05,0.21,0.21,0.0,0.0,0.05,morgan elston,,MATH-1020,2017
+MATH,1020,5,Business Calculus I,0.21,0.37,0.26,0.11,0.05,0.0,0.0,0.0,michael thoma cowen,,MATH-1020,2017
+MATH,1020,6,Business Calculus I,0.47,0.21,0.21,0.05,0.05,0.0,0.0,0.0,michael thoma cowen,,MATH-1020,2017
+MATH,1020,7,Business Calculus I,0.17,0.22,0.39,0.06,0.06,0.0,0.0,0.11,aaro ramirez flores,,MATH-1020,2017
+MATH,1020,8,Business Calculus I,0.26,0.32,0.26,0.11,0.0,0.0,0.0,0.05,aaro ramirez flores,,MATH-1020,2017
+MATH,1020,9,Business Calculus I,0.28,0.28,0.17,0.06,0.11,0.0,0.0,0.11, kamronnaher,,MATH-1020,2017
+MATH,1020,10,Business Calculus I,0.21,0.21,0.32,0.16,0.11,0.0,0.0,0.0, kamronnaher,,MATH-1020,2017
+MATH,1020,11,Business Calculus I,0.42,0.16,0.16,0.11,0.11,0.0,0.0,0.05,emma cinatl,,MATH-1020,2017
+MATH,1020,12,Business Calculus I,0.06,0.5,0.13,0.13,0.13,0.0,0.0,0.06,emma cinatl,,MATH-1020,2017
+MATH,1020,13,Business Calculus I,0.37,0.37,0.05,0.11,0.05,0.0,0.0,0.05,zachary david espe,,MATH-1020,2017
+MATH,1020,14,Business Calculus I,0.26,0.37,0.16,0.16,0.0,0.0,0.0,0.05,zachary david espe,,MATH-1020,2017
+MATH,1020,15,Business Calculus I,0.05,0.16,0.21,0.11,0.32,0.0,0.0,0.16,anna caro bachstein,,MATH-1020,2017
+MATH,1020,16,Business Calculus I,0.16,0.32,0.11,0.11,0.21,0.0,0.0,0.11,anna caro bachstein,,MATH-1020,2017
+MATH,1020,17,Business Calculus I,0.17,0.22,0.28,0.11,0.11,0.0,0.0,0.11,scott scruggs,,MATH-1020,2017
+MATH,1020,18,Business Calculus I,0.5,0.11,0.17,0.11,0.11,0.0,0.0,0.0,aaron moose,,MATH-1020,2017
+MATH,1020,19,Business Calculus I,0.16,0.37,0.26,0.0,0.16,0.0,0.0,0.05,rachel bass lanning,,MATH-1020,2017
+MATH,1020,20,Business Calculus I,0.26,0.16,0.42,0.11,0.05,0.0,0.0,0.0,john william grant,,MATH-1020,2017
+MATH,1020,21,Business Calculus I,0.21,0.42,0.26,0.0,0.11,0.0,0.0,0.0,rachel bass lanning,,MATH-1020,2017
+MATH,1020,22,Business Calculus I,0.26,0.26,0.16,0.11,0.05,0.0,0.0,0.16,molly adam honecker,,MATH-1020,2017
+MATH,1020,23,Business Calculus I,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,shanshan jia,,MATH-1020,2017
+MATH,1020,24,Business Calculus I,0.37,0.21,0.21,0.11,0.05,0.0,0.0,0.05,todd anthony morra,,MATH-1020,2017
+MATH,1020,25,Business Calculus I,0.33,0.22,0.28,0.06,0.11,0.0,0.0,0.0,yibo xu,,MATH-1020,2017
+MATH,1020,26,Business Calculus I,0.16,0.32,0.32,0.05,0.11,0.0,0.0,0.05,shanshan jia,,MATH-1020,2017
+MATH,1020,27,Business Calculus I,0.11,0.32,0.42,0.05,0.05,0.0,0.0,0.05,peter westerbaan,,MATH-1020,2017
+MATH,1020,28,Business Calculus I,0.44,0.22,0.28,0.0,0.06,0.0,0.0,0.0,todd anthony morra,,MATH-1020,2017
+MATH,1020,29,Business Calculus I,0.17,0.33,0.22,0.06,0.17,0.0,0.0,0.06,yibo xu,,MATH-1020,2017
+MATH,1020,30,Business Calculus I,0.42,0.26,0.16,0.05,0.05,0.0,0.0,0.05,kara ail stasikelis,,MATH-1020,2017
+MATH,1020,31,Business Calculus I,0.21,0.47,0.0,0.05,0.16,0.0,0.0,0.11,li he,,MATH-1020,2017
+MATH,1020,32,Business Calculus I,0.26,0.16,0.37,0.0,0.16,0.0,0.0,0.05,aaron moose,,MATH-1020,2017
+MATH,1020,33,Business Calculus I,0.21,0.11,0.42,0.05,0.11,0.0,0.0,0.11,li he,,MATH-1020,2017
+MATH,1020,34,Business Calculus I,0.26,0.11,0.21,0.16,0.26,0.0,0.0,0.0,scott scruggs,,MATH-1020,2017
+MATH,1020,35,Business Calculus I,0.42,0.22,0.24,0.02,0.04,0.0,0.0,0.04,jennifer ray newton,,MATH-1020,2017
+MATH,1020,36,Business Calculus I,0.33,0.27,0.16,0.04,0.09,0.0,0.0,0.11,jennifer ray newton,,MATH-1020,2017
+MATH,1020,37,Business Calculus I,0.26,0.26,0.32,0.0,0.16,0.0,0.0,0.0,peter westerbaan,,MATH-1020,2017
+MATH,1020,38,Business Calculus I,0.22,0.39,0.33,0.0,0.06,0.0,0.0,0.0,molly adam honecker,,MATH-1020,2017
+MATH,1020,39,Business Calculus I,0.45,0.2,0.2,0.07,0.05,0.0,0.0,0.02,jennifer van dyken,,MATH-1020,2017
+MATH,1020,40,Business Calculus I,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,randy davidson,,MATH-1020,2017
+MATH,1020,41,Business Calculus I,0.29,0.23,0.22,0.06,0.18,0.0,0.0,0.01,randy davidson,,MATH-1020,2017
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.57,0.41,0.02,donna simms,,MATH-1040,2017
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.62,0.04,stephen peele,,MATH-1040,2017
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.47,0.47,0.07,stephen peele,,MATH-1040,2017
+MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.5,0.39,0.11,andrew walton green,,MATH-1040,2017
+MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.52,0.1,sergey charnyi,,MATH-1040,2017
+MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.24,0.64,0.12,stephen garth,,MATH-1040,2017
+MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.64,0.33,0.02,stephen peele,,MATH-1040,2017
+MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.52,0.02,nicholas ahlstrom,,MATH-1040,2017
+MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.45,0.33,0.21,xiaoyuan liu,,MATH-1040,2017
+MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.5,0.14,xun dong,,MATH-1040,2017
+MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.39,0.52,0.09,stefan adam bock,,MATH-1040,2017
+MATH,1040,12,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.34,0.59,0.07,stefan adam bock,,MATH-1040,2017
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.44,0.54,0.02,tony thanh nguyen,,MATH-1050,2017
+MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.72,0.28,0.0,tony thanh nguyen,,MATH-1050,2017
+MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.36,0.05,tony thanh nguyen,,MATH-1050,2017
+MATH,1060,1,Calculus of One Variable I,0.17,0.29,0.32,0.07,0.07,0.0,0.0,0.07,thomas clevenger,,MATH-1060,2017
+MATH,1060,2,Calculus of One Variable I,0.25,0.23,0.2,0.04,0.17,0.0,0.0,0.11,calvin williams,,MATH-1060,2017
+MATH,1060,3,Calculus of One Variable I,0.25,0.32,0.09,0.05,0.14,0.0,0.0,0.16,paul james cubre,,MATH-1060,2017
+MATH,1060,4,Calculus of One Variable I,0.35,0.26,0.23,0.0,0.13,0.0,0.0,0.03,huixi li,,MATH-1060,2017
+MATH,1060,5,Calculus of One Variable I,0.2,0.27,0.18,0.09,0.04,0.0,0.0,0.22,pye phyo aung,,MATH-1060,2017
+MATH,1060,6,Calculus of One Variable I,0.18,0.23,0.3,0.11,0.14,0.0,0.0,0.05,rebecca ramos,,MATH-1060,2017
+MATH,1060,8,Calculus of One Variable I,0.25,0.28,0.21,0.05,0.14,0.0,0.0,0.06,judith cottingham,,MATH-1060,2017
+MATH,1060,10,Calculus of One Variable I,0.22,0.25,0.2,0.09,0.16,0.0,0.0,0.07,judith cottingham,,MATH-1060,2017
+MATH,1060,11,Calculus of One Variable I,0.41,0.28,0.06,0.06,0.13,0.0,0.0,0.06,thowhida akther,,MATH-1060,2017
+MATH,1060,14,Calculus of One Variable I,0.12,0.23,0.26,0.14,0.12,0.0,0.0,0.14,paul james cubre,,MATH-1060,2017
+MATH,1060,15,Calculus of One Variable I,0.31,0.22,0.17,0.11,0.06,0.0,0.0,0.14,fun choi john chan,,MATH-1060,2017
+MATH,1060,16,Calculus of One Variable I,0.25,0.36,0.09,0.05,0.11,0.0,0.0,0.14,pye phyo aung,,MATH-1060,2017
+MATH,1060,17,Calculus of One Variable I,0.16,0.24,0.27,0.07,0.16,0.0,0.0,0.11,pye phyo aung,,MATH-1060,2017
+MATH,1060,18,Calculus of One Variable I,0.21,0.39,0.33,0.0,0.0,0.0,0.0,0.06,marilyn reba,,MATH-1060,2017
+MATH,1060,100,Calc of One Variable I (HON),0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,boshi yang,True,MATH-1060,2017
+MATH,1060,201,Calculus of One Variable I,0.25,0.44,0.17,0.04,0.0,0.0,0.0,0.1,james edwar gossell,,MATH-1060,2017
+MATH,1060,202,Calculus of One Variable I,0.29,0.4,0.17,0.06,0.02,0.0,0.0,0.06,hiram lopez valdez,,MATH-1060,2017
+MATH,1060,203,Calculus of One Variable I,0.37,0.37,0.26,0.0,0.0,0.0,0.0,0.0,alistair bentley,,MATH-1060,2017
+MATH,1060,205,Calculus of One Variable I,0.23,0.56,0.1,0.04,0.06,0.0,0.0,0.0,amy christine grady,,MATH-1060,2017
+MATH,1060,206,Calculus of One Variable I,0.23,0.46,0.21,0.02,0.04,0.0,0.0,0.04,thomas clevenger,,MATH-1060,2017
+MATH,1060,207,Calculus of One Variable I,0.35,0.27,0.13,0.07,0.04,0.0,0.0,0.14,hiram lopez valdez,,MATH-1060,2017
+MATH,1070,1,Differen and Integral Calculus,0.0,0.25,0.47,0.13,0.09,0.0,0.0,0.06,donna simms,,MATH-1070,2017
+MATH,1080,1,Calculus of One Variable II,0.23,0.13,0.2,0.17,0.13,0.0,0.0,0.13,sanwar ahmad,,MATH-1080,2017
+MATH,1080,2,Calculus of One Variable II,0.09,0.23,0.28,0.14,0.12,0.0,0.0,0.14,fei xue,,MATH-1080,2017
+MATH,1080,5,Calculus of One Variable II,0.17,0.1,0.15,0.12,0.37,0.0,0.0,0.1,mengying xiao,,MATH-1080,2017
+MATH,1080,6,Calculus of One Variable II,0.11,0.21,0.25,0.04,0.14,0.0,0.0,0.25,mark cawood,,MATH-1080,2017
+MATH,1080,7,Calculus of One Variable II,0.13,0.23,0.25,0.03,0.23,0.0,0.0,0.15,beth novick,,MATH-1080,2017
+MATH,1080,8,Calculus of One Variable II,0.15,0.24,0.15,0.07,0.24,0.0,0.0,0.15,meredith nicol burr,,MATH-1080,2017
+MATH,1080,9,Calculus of One Variable II,0.21,0.28,0.14,0.14,0.16,0.0,0.0,0.07,meredith nicol burr,,MATH-1080,2017
+MATH,1080,201,Calculus of One Variable II,0.34,0.21,0.26,0.05,0.11,0.0,0.0,0.03,beth novick,,MATH-1080,2017
+MATH,1150,1,Contemp Math for Elem Teach I,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-1150,2017
+MATH,1150,2,Contemp Math for Elem Teach I,0.57,0.27,0.11,0.05,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1150,2017
+MATH,1160,1,Contemp Math for Elem Teach II,0.41,0.55,0.05,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1160,2017
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.0,marion hanna,,MATH-1990,2017
+MATH,1990,401,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.04,0.02,marion hanna,,MATH-1990,2017
+MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,,MATH-1990,2017
+MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,,MATH-1990,2017
+MATH,2060,1,Calculus of Several Variables,0.4,0.33,0.22,0.0,0.0,0.0,0.0,0.04,xin liu,,MATH-2060,2017
+MATH,2060,2,Calculus of Several Variables,0.31,0.51,0.18,0.0,0.0,0.0,0.0,0.0,peter kiessler,,MATH-2060,2017
+MATH,2060,3,Calculus of Several Variables,0.15,0.28,0.28,0.04,0.17,0.0,0.0,0.09,sofya alekseeva,,MATH-2060,2017
+MATH,2060,5,Calculus of Several Variables,0.25,0.28,0.19,0.09,0.13,0.0,0.0,0.06,jeong rock yoon,,MATH-2060,2017
+MATH,2060,6,Calculus of Several Variables,0.32,0.18,0.11,0.05,0.18,0.0,0.0,0.16,allen anderso guest,,MATH-2060,2017
+MATH,2060,7,Calculus of Several Variables,0.22,0.35,0.35,0.07,0.0,0.0,0.0,0.0,sofya alekseeva,,MATH-2060,2017
+MATH,2060,9,Calculus of Several Variables,0.09,0.26,0.11,0.09,0.2,0.0,0.0,0.26,timothy fra parrott,,MATH-2060,2017
+MATH,2060,10,Calculus of Several Variables,0.2,0.33,0.2,0.02,0.2,0.0,0.0,0.04,allen anderso guest,,MATH-2060,2017
+MATH,2060,11,Calculus of Several Variables,0.29,0.47,0.18,0.03,0.0,0.0,0.0,0.03,xin liu,,MATH-2060,2017
+MATH,2060,12,Calculus of Several Variables,0.44,0.29,0.15,0.02,0.05,0.0,0.0,0.05,irina viktorova,,MATH-2060,2017
+MATH,2060,13,Calculus of Several Variables,0.32,0.39,0.24,0.0,0.0,0.0,0.0,0.05,akshay sunil gupte,,MATH-2060,2017
+MATH,2060,14,Calculus of Several Variables,0.49,0.31,0.13,0.02,0.0,0.0,0.0,0.04,martin joha schmoll,,MATH-2060,2017
+MATH,2060,15,Calculus of Several Variables,0.22,0.22,0.12,0.2,0.17,0.0,0.0,0.07,julie lassiter,,MATH-2060,2017
+MATH,2060,16,Calculus of Several Variables,0.3,0.32,0.11,0.02,0.16,0.0,0.0,0.09,allen anderso guest,,MATH-2060,2017
+MATH,2060,17,Calculus of Several Variables,0.05,0.25,0.16,0.2,0.2,0.0,0.0,0.14,julie lassiter,,MATH-2060,2017
+MATH,2060,18,Calculus of Several Variables,0.26,0.34,0.21,0.11,0.05,0.0,0.0,0.03,sofya alekseeva,,MATH-2060,2017
+MATH,2060,19,Calculus of Several Variables,0.13,0.3,0.19,0.07,0.22,0.0,0.0,0.09,gretchen matthews,,MATH-2060,2017
+MATH,2060,20,Calculus of Several Variables,0.33,0.33,0.22,0.04,0.0,0.0,0.0,0.07,martin joha schmoll,,MATH-2060,2017
+MATH,2060,21,Calculus of Several Variables,0.28,0.23,0.25,0.1,0.1,0.0,0.0,0.05,shitao liu,,MATH-2060,2017
+MATH,2060,22,Calculus of Several Variables,0.16,0.32,0.18,0.11,0.16,0.0,0.0,0.09,gretchen matthews,,MATH-2060,2017
+MATH,2060,100,Calc of Several Vars (HON),0.4,0.36,0.12,0.05,0.05,0.0,0.0,0.02,james brown,True,MATH-2060,2017
+MATH,2060,201,Calculus of Several Variables,0.11,0.26,0.18,0.05,0.08,0.0,0.0,0.32,timothy fra parrott,,MATH-2060,2017
+MATH,2060,202,Calculus of Several Variables,0.14,0.31,0.12,0.05,0.05,0.0,0.0,0.33,timothy fra parrott,,MATH-2060,2017
+MATH,2070,1,Business Calculus II,0.28,0.5,0.06,0.17,0.0,0.0,0.0,0.0,thanh thien to,,MATH-2070,2017
+MATH,2070,2,Business Calculus II,0.21,0.11,0.32,0.32,0.05,0.0,0.0,0.0,thanh thien to,,MATH-2070,2017
+MATH,2070,3,Business Calculus II,0.26,0.32,0.32,0.0,0.0,0.0,0.0,0.11,garrett dranichak,,MATH-2070,2017
+MATH,2070,4,Business Calculus II,0.47,0.05,0.16,0.16,0.11,0.0,0.0,0.05,garrett dranichak,,MATH-2070,2017
+MATH,2070,7,Business Calculus II,0.28,0.11,0.33,0.11,0.06,0.0,0.0,0.11,yinggu bao,,MATH-2070,2017
+MATH,2070,8,Business Calculus II,0.16,0.32,0.21,0.16,0.05,0.0,0.0,0.11,haodong li,,MATH-2070,2017
+MATH,2070,9,Business Calculus II,0.17,0.22,0.44,0.06,0.11,0.0,0.0,0.0,haodong li,,MATH-2070,2017
+MATH,2070,11,Business Calculus II,0.4,0.31,0.15,0.07,0.05,0.0,0.0,0.02,jennifer ray newton,,MATH-2070,2017
+MATH,2070,12,Business Calculus II,0.26,0.26,0.21,0.16,0.0,0.0,0.0,0.11,yinggu bao,,MATH-2070,2017
+MATH,2070,13,Business Calculus II,0.33,0.28,0.18,0.05,0.03,0.0,0.0,0.13,jennifer mari hanna,,MATH-2070,2017
+MATH,2070,14,Business Calculus II,0.36,0.36,0.14,0.05,0.0,0.0,0.0,0.1,jennifer mari hanna,,MATH-2070,2017
+MATH,2070,15,Business Calculus II,0.41,0.32,0.17,0.05,0.02,0.0,0.0,0.02,jennifer mari hanna,,MATH-2070,2017
+MATH,2070,16,Business Calculus II,0.34,0.34,0.16,0.09,0.02,0.0,0.0,0.05,sea sather-wagstaff,,MATH-2070,2017
+MATH,2070,18,Business Calculus II,0.19,0.21,0.22,0.12,0.1,0.0,0.0,0.16,judith irene mcknew,,MATH-2070,2017
+MATH,2080,1,Intro to Ordin Diff Equations,0.16,0.13,0.16,0.19,0.13,0.0,0.0,0.23,terri johnson,,MATH-2080,2017
+MATH,2080,2,Intro to Ordin Diff Equations,0.18,0.38,0.18,0.13,0.13,0.0,0.0,0.03,irina viktorova,,MATH-2080,2017
+MATH,2080,3,Intro to Ordin Diff Equations,0.07,0.27,0.41,0.12,0.05,0.0,0.0,0.07,irina viktorova,,MATH-2080,2017
+MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.13,0.19,0.0,0.22,0.0,0.0,0.25,terri johnson,,MATH-2080,2017
+MATH,2080,5,Intro to Ordin Diff Equations,0.13,0.13,0.22,0.06,0.13,0.0,0.0,0.34,terri johnson,,MATH-2080,2017
+MATH,2080,6,Intro to Ordin Diff Equations,0.22,0.43,0.16,0.08,0.0,0.0,0.0,0.11,oleg yordanov,,MATH-2080,2017
+MATH,2080,7,Intro to Ordin Diff Equations,0.36,0.25,0.19,0.06,0.08,0.0,0.0,0.06,oleg yordanov,,MATH-2080,2017
+MATH,2080,8,Intro to Ordin Diff Equations,0.14,0.35,0.26,0.09,0.09,0.0,0.0,0.07,oleg yordanov,,MATH-2080,2017
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,matthew macauley,True,MATH-2080,2017
+MATH,2160,1,Geometry for Elem Sch Teachers,0.69,0.17,0.1,0.0,0.03,0.0,0.0,0.0,allison stoddard,,MATH-2160,2017
+MATH,2160,2,Geometry for Elem Sch Teachers,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-2160,2017
+MATH,2500,1,Intro to Mathematical Sciences,0.94,0.03,0.02,0.0,0.0,0.0,0.0,0.02,christopher cox,,MATH-2500,2017
+MATH,3020,1,Stat for Science & Engineering,0.32,0.19,0.32,0.11,0.0,0.0,0.0,0.05,derek brown,,MATH-3020,2017
+MATH,3020,2,Stat for Science & Engineering,0.2,0.47,0.13,0.0,0.07,0.0,0.0,0.13,haotian feng,,MATH-3020,2017
+MATH,3020,3,Stat for Science & Engineering,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,prab withana gamage,,MATH-3020,2017
+MATH,3020,4,Stat for Science & Engineering,0.33,0.13,0.33,0.2,0.0,0.0,0.0,0.0,elaine ma sotherden,,MATH-3020,2017
+MATH,3020,6,Stat for Science & Engineering,0.17,0.28,0.42,0.0,0.03,0.0,0.0,0.11,calvin williams,,MATH-3020,2017
+MATH,3020,8,Stat for Science & Engineering,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,prab withana gamage,,MATH-3020,2017
+MATH,3020,9,Stat for Science & Engineering,0.24,0.65,0.12,0.0,0.0,0.0,0.0,0.0,haotian feng,,MATH-3020,2017
+MATH,3020,12,Stat for Science & Engineering,0.22,0.28,0.17,0.17,0.11,0.0,0.0,0.06,elaine ma sotherden,,MATH-3020,2017
+MATH,3020,14,Stat for Science & Engineering,0.43,0.33,0.13,0.03,0.0,0.0,0.0,0.1,ellen hepfe breazel,,MATH-3020,2017
+MATH,3020,15,Stat for Science & Engineering,0.33,0.55,0.08,0.03,0.03,0.0,0.0,0.0,ellen hepfe breazel,,MATH-3020,2017
+MATH,3110,1,Linear Algebra,0.34,0.3,0.11,0.05,0.09,0.0,0.0,0.11,xuhong gao,,MATH-3110,2017
+MATH,3110,2,Linear Algebra,0.24,0.32,0.17,0.07,0.12,0.0,0.0,0.07,xuhong gao,,MATH-3110,2017
+MATH,3110,3,Linear Algebra,0.17,0.26,0.33,0.07,0.07,0.0,0.0,0.11,michael adam burr,,MATH-3110,2017
+MATH,3110,4,Linear Algebra,0.22,0.32,0.27,0.15,0.02,0.0,0.0,0.02,hui xue,,MATH-3110,2017
+MATH,3110,5,Linear Algebra,0.32,0.29,0.2,0.05,0.12,0.0,0.0,0.02,hui xue,,MATH-3110,2017
+MATH,3110,6,Linear Algebra,0.23,0.25,0.18,0.07,0.14,0.0,0.0,0.14,felice manganiello,,MATH-3110,2017
+MATH,3110,7,Linear Algebra,0.14,0.28,0.21,0.19,0.05,0.0,0.0,0.14,felice manganiello,,MATH-3110,2017
+MATH,3110,8,Linear Algebra,0.62,0.22,0.13,0.0,0.0,0.0,0.0,0.02,benjamin jaye,,MATH-3110,2017
+MATH,3110,100,Linear Algebra (HON),0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,neil calkin,True,MATH-3110,2017
+MATH,3110,200,Linear Algebra,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,kevin james,,MATH-3110,2017
+MATH,3160,1,Prob Solving for Math Teachers,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-3160,2017
+MATH,3190,1,Introduction to Proof,0.26,0.42,0.16,0.05,0.05,0.0,0.0,0.05,james ba coykendall,,MATH-3190,2017
+MATH,3190,2,Introduction to Proof,0.27,0.15,0.27,0.0,0.19,0.0,0.0,0.12,james ba coykendall,,MATH-3190,2017
+MATH,3600,1,Intermediate Math Computing,0.7,0.1,0.07,0.03,0.07,0.0,0.0,0.03,mark cawood,,MATH-3600,2017
+MATH,3600,2,Intermediate Math Computing,0.81,0.06,0.1,0.0,0.03,0.0,0.0,0.0,mark cawood,,MATH-3600,2017
+MATH,3650,1,Numerical Mthds for Engineers,0.22,0.38,0.19,0.11,0.08,0.0,0.0,0.03,vincent ervin,,MATH-3650,2017
+MATH,3650,2,Numerical Mthds for Engineers,0.5,0.25,0.22,0.0,0.03,0.0,0.0,0.0,leo rebholz,,MATH-3650,2017
+MATH,3650,3,Numerical Mthds for Engineers,0.29,0.6,0.07,0.05,0.0,0.0,0.0,0.0,timo johann heister,,MATH-3650,2017
+MATH,3650,4,Numerical Mthds for Engineers,0.14,0.39,0.19,0.06,0.11,0.0,0.0,0.11,eleanor jenkins,,MATH-3650,2017
+MATH,4000,1,Theory of Probability,0.44,0.26,0.14,0.05,0.05,0.0,0.0,0.07,xiaoqian sun,,MATH-4000,2017
+MATH,4020,1,Stat for Sci & Engineering II,0.5,0.1,0.3,0.0,0.1,0.0,0.0,0.0,calvin williams,,MATH-4020,2017
+MATH,4070,1,Regress & Time-Series Analysis,0.36,0.29,0.29,0.0,0.07,0.0,0.0,0.0,colin gallagher,,MATH-4070,2017
+MATH,4080,1,Secondary Math Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,carlos gomez,,MATH-4080,2017
+MATH,4120,1,Algebra I,0.26,0.31,0.28,0.05,0.08,0.0,0.0,0.03,matthew macauley,,MATH-4120,2017
+MATH,4190,1,Discrete Math Structures I,0.7,0.23,0.03,0.0,0.03,0.0,0.0,0.0,beth novick,,MATH-4190,2017
+MATH,4190,2,Discrete Math Structures I,0.46,0.36,0.18,0.0,0.0,0.0,0.0,0.0,wayne goddard,,MATH-4190,2017
+MATH,4310,1,Theory of Interest,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0, erwin walker,,MATH-4310,2017
+MATH,4340,1,Adv Engineering Mathematics,0.25,0.28,0.22,0.09,0.13,0.0,0.0,0.03,hyesuk lee,,MATH-4340,2017
+MATH,4340,2,Adv Engineering Mathematics,0.21,0.07,0.14,0.14,0.29,0.0,0.0,0.14,eleanor jenkins,,MATH-4340,2017
+MATH,4400,1,Linear Programming,0.42,0.25,0.21,0.04,0.04,0.0,0.0,0.04,boshi yang,,MATH-4400,2017
+MATH,4410,1,Intro to Stochastic Models,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,brian fralix,,MATH-4410,2017
+MATH,4500,1,Intro to Mathematical Models,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,matthew macauley,,MATH-4500,2017
+MATH,4530,1,Advanced Calculus I,0.42,0.28,0.11,0.11,0.06,0.0,0.0,0.03,james peterson,,MATH-4530,2017
+MATH,4540,1,Advanced Calculus II,0.17,0.25,0.33,0.17,0.0,0.0,0.0,0.08,james peterson,,MATH-4540,2017
+MATH,4630,1,Mathematical Analysis I,0.36,0.18,0.18,0.09,0.18,0.0,0.0,0.0,mishko mitkovski,,MATH-4630,2017
+MATH,6340,1,Adv Engineering Mathematics,0.36,0.41,0.14,0.0,0.0,0.0,0.0,0.09,vincent ervin,,MATH-6340,2017
+MATH,8000,1,Probability,0.48,0.19,0.11,0.0,0.11,0.0,0.0,0.11,christopher mcmahan,,MATH-8000,2017
+MATH,8010,1,General Linear Hypothesis I,0.5,0.42,0.0,0.0,0.08,0.0,0.0,0.0,derek brown,,MATH-8010,2017
+MATH,8050,1,Data Analysis,0.68,0.25,0.04,0.0,0.0,0.0,0.0,0.04,ling ma,,MATH-8050,2017
+MATH,8070,1,Applied Multivariate Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-8070,2017
+MATH,8100,1,Mathematical Programming,0.74,0.17,0.0,0.0,0.0,0.0,0.0,0.09,yuyuan ouyang,,MATH-8100,2017
+MATH,8140,1,Network Flow Programming,0.36,0.18,0.27,0.0,0.0,0.0,0.0,0.18,herve louis kerivin,,MATH-8140,2017
+MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,,MATH-8170,2017
+MATH,8210,1,Linear Analysis,0.27,0.58,0.0,0.0,0.03,0.0,0.0,0.12,shitao liu,,MATH-8210,2017
+MATH,8230,1,Complex Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,,MATH-8230,2017
+MATH,8510,1,Abstract Algebra I,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,kevin james,,MATH-8510,2017
+MATH,8530,1,Matrix Analysis,0.47,0.11,0.37,0.0,0.0,0.0,0.0,0.05,svetlan poznanovikj,,MATH-8530,2017
+MATH,8580,1,Number Theory,0.57,0.14,0.14,0.0,0.14,0.0,0.0,0.0,james brown,,MATH-8580,2017
+MATH,8600,1,Intro to Scientific Computing,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,hyesuk lee,,MATH-8600,2017
+MATH,8610,1,Advanced Numerical Analysis I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,fei xue,,MATH-8610,2017
+MATH,8650,1,Data Structures,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,timo johann heister,,MATH-8650,2017
+MATH,8840,1,Statistics for Experimenters,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,,MATH-8840,2017
+MATH,9850,2,Homological Algebra,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,sea sather-wagstaff,,MATH-9850,2017
+MBA,8040,20,Busin Data An & Stat Computing,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,,MBA-8040,2017
+MBA,8060,1,Operations Mgt,0.16,0.5,0.32,0.0,0.0,0.0,0.0,0.03, sridharan,,MBA-8060,2017
+MBA,8070,1,Financial Management,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,george bra lockhart,,MBA-8070,2017
+MBA,8070,20,Financial Management,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,george bra lockhart,,MBA-8070,2017
+MBA,8090,1,Org Beh & Hum Res Mg,0.43,0.53,0.04,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2017
+MBA,8090,2,Org Beh & Hum Res Mg,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2017
+MBA,8180,20,Intro Business Intell & Anlytc,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,heshan sun,,MBA-8180,2017
+MBA,8190,1,Intro to Acc and Fin,0.55,0.34,0.1,0.0,0.0,0.0,0.0,0.0,melvin stith,,MBA-8190,2017
+MBA,8190,2,Intro to Acc and Fin,0.52,0.36,0.1,0.0,0.02,0.0,0.0,0.0,james mil kohlmeyer,,MBA-8190,2017
+MBA,8290,1,Marketing Foundation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MBA-8290,2017
+MBA,8310,10,Communications and Sales,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,,MBA-8310,2017
+MBA,8360,1,Real Estate Principles,0.41,0.48,0.11,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,,MBA-8360,2017
+MBA,8370,1,Legal Environ of Bus,0.27,0.67,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2017
+MBA,8370,2,Legal Environ of Bus,0.47,0.47,0.03,0.0,0.0,0.0,0.0,0.03,judson jahn,,MBA-8370,2017
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,prashant prabhu,,MBA-8400,2017
+MBA,8430,1,Entrepreneurial Accounting,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,sally kathr widener,,MBA-8430,2017
+MBA,8450,1,Technology & Innovation Mgt,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,michael george mino,,MBA-8450,2017
+MBA,8480,1,Entrpr Mkting & Digital Strat,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,bruce snyder,,MBA-8480,2017
+MBA,8480,5,Entrpr Mkting & Digital Strat,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,,MBA-8480,2017
+MBA,8490,5,Entrepreneurial Strategy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8490,2017
+MBA,8510,1,Bus Operations & Logistics,0.24,0.35,0.41,0.0,0.0,0.0,0.0,0.0, sridharan,,MBA-8510,2017
+MBA,8540,1,Managerial Accounting,0.4,0.43,0.14,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,,MBA-8540,2017
+MBA,8590,1,Mgr Decision Model,0.34,0.26,0.29,0.0,0.0,0.0,0.0,0.11,sara elizabet yoder,,MBA-8590,2017
+MBA,8590,2,Mgr Decision Model,0.28,0.51,0.07,0.0,0.02,0.0,0.0,0.12,magda gabriela sava,,MBA-8590,2017
+MBA,8600,1,Advanced Marketing Strategy,0.3,0.48,0.23,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2017
+MBA,8600,2,Advanced Marketing Strategy,0.21,0.64,0.15,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2017
+MBA,8610,1,Information Systems,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MBA-8610,2017
+MBA,8620,1,Managerial Economics,0.28,0.56,0.16,0.0,0.0,0.0,0.0,0.0,scott templeton,,MBA-8620,2017
+MBA,8620,2,Managerial Economics,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,,MBA-8620,2017
+MBA,8620,4,Managerial Economics,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,ronald earl gregory,,MBA-8620,2017
+MBA,8650,1,Taxation of Business Decisions,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8650,2017
+MBA,8700,1,Strategic Management,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,james turner,,MBA-8700,2017
+MBA,8700,2,Strategic Management,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,thomas robert uva,,MBA-8700,2017
+MBA,8990,2,Creativity,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,kathleen ann kegley,,MBA-8990,2017
+MBA,8990,4,Data Analytics & Visualization,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,john frederic tripp,,MBA-8990,2017
+ME,2000,1,Sophomore Seminar,0.91,0.05,0.02,0.0,0.01,0.0,0.0,0.01,donald beasley,,ME-2000,2017
+ME,2000,2,Sophomore Seminar,0.78,0.19,0.01,0.0,0.01,0.0,0.0,0.01,donald beasley,,ME-2000,2017
+ME,2010,1,Statics & Dynamics,0.15,0.2,0.2,0.09,0.22,0.0,0.0,0.14,marisa kikendal orr,,ME-2010,2017
+ME,2010,2,Statics & Dynamics,0.09,0.24,0.23,0.14,0.23,0.0,0.0,0.08,paul joseph,,ME-2010,2017
+ME,2010,3,Statics & Dynamics,0.05,0.22,0.19,0.1,0.29,0.0,0.0,0.15,jorge iva rodriguez,,ME-2010,2017
+ME,2030,1,Founda Th/Fl Syst,0.08,0.21,0.21,0.21,0.18,0.0,0.0,0.13,john saylor,,ME-2030,2017
+ME,2030,2,Founda Th/Fl Syst,0.2,0.35,0.2,0.14,0.06,0.0,0.0,0.06,xiangchun xuan,,ME-2030,2017
+ME,2040,1,Mechanics of Materials,0.27,0.45,0.22,0.04,0.02,0.0,0.0,0.0,gang li,,ME-2040,2017
+ME,2040,3,Mechanics of Materials,0.17,0.57,0.19,0.05,0.0,0.0,0.0,0.02,jorge iva rodriguez,,ME-2040,2017
+ME,2220,1,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,2,Mechanical Engineering Lab I,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,,ME-2220,2017
+ME,2220,3,Mechanical Engineering Lab I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,5,Mechanical Engineering Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-2220,2017
+ME,2220,7,Mechanical Engineering Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,13,Mechanical Engineering Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,15,Mechanical Engineering Lab I,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,17,Mechanical Engineering Lab I,0.31,0.63,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-2220,2017
+ME,2220,18,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,3030,1,Thermodynamics,0.2,0.3,0.3,0.08,0.04,0.0,0.0,0.08,richard miller,,ME-3030,2017
+ME,3030,2,Thermodynamics,0.26,0.51,0.18,0.0,0.02,0.0,0.0,0.04,yiqiang han,,ME-3030,2017
+ME,3040,1,Heat Transfer,0.05,0.26,0.43,0.12,0.12,0.0,0.0,0.02,jean-marc delhaye,,ME-3040,2017
+ME,3040,2,Heat Transfer,0.19,0.42,0.23,0.07,0.06,0.0,0.0,0.03,xin zhao,,ME-3040,2017
+ME,3050,1,Model/an Dy Syst,0.21,0.17,0.32,0.15,0.06,0.0,0.0,0.09,joshua bostwick,,ME-3050,2017
+ME,3050,2,Model/an Dy Syst,0.22,0.39,0.3,0.04,0.04,0.0,0.0,0.0,ardalan vahidi,,ME-3050,2017
+ME,3060,1,Fund Machine Design,0.13,0.58,0.21,0.0,0.02,0.0,0.0,0.06,oliver myers,,ME-3060,2017
+ME,3060,2,Fund Machine Design,0.24,0.5,0.18,0.02,0.02,0.0,0.0,0.04,paul jeffrey meyer,,ME-3060,2017
+ME,3070,1,Found of Mechanical Systems,0.34,0.39,0.25,0.0,0.02,0.0,0.0,0.0,jorge iva rodriguez,,ME-3070,2017
+ME,3070,2,Found of Mechanical Systems,0.22,0.51,0.17,0.04,0.01,0.0,0.0,0.05,gregory mocko,,ME-3070,2017
+ME,3080,1,Fluid Mechanics,0.34,0.49,0.09,0.06,0.02,0.0,0.0,0.0,yiqiang han,,ME-3080,2017
+ME,3080,2,Fluid Mechanics,0.24,0.51,0.16,0.03,0.05,0.0,0.0,0.0,yiqiang han,,ME-3080,2017
+ME,3080,3,Fluid Mechanics,0.1,0.46,0.39,0.02,0.02,0.0,0.0,0.02,ethan kung,,ME-3080,2017
+ME,3120,1,Manuf Processes,0.35,0.49,0.13,0.02,0.01,0.0,0.0,0.01,rod martinez-duarte,,ME-3120,2017
+ME,3330,1,Mechanical Engineering Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,3330,2,Mechanical Engineering Lab II,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,3330,3,Mechanical Engineering Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,3330,6,Mechanical Engineering Lab II,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-3330,2017
+ME,3330,7,Mechanical Engineering Lab II,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,,ME-3330,2017
+ME,3330,9,Mechanical Engineering Lab II,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,3330,10,Mechanical Engineering Lab II,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,todd schweisinger,,ME-3330,2017
+ME,4000,1,Senior Seminar,0.96,0.03,0.0,0.0,0.01,0.0,0.0,0.0,richard figliola,,ME-4000,2017
+ME,4010,1,Mech Engr Design,0.87,0.08,0.01,0.02,0.01,0.0,0.0,0.02,cameron turner,,ME-4010,2017
+ME,4020,1,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,,ME-4020,2017
+ME,4020,2,Intern in Engr Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2017
+ME,4020,3,Intern in Engr Des,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-4020,2017
+ME,4030,1,Control Dynamic Systems,0.32,0.34,0.22,0.04,0.04,0.0,0.0,0.03,suyi li,,ME-4030,2017
+ME,4030,2,Control Dynamic Systems,0.21,0.37,0.33,0.07,0.0,0.0,0.0,0.02,yue wang,,ME-4030,2017
+ME,4210,1,Intro to Comp Flow,0.27,0.46,0.15,0.08,0.04,0.0,0.0,0.0,chenning tong,,ME-4210,2017
+ME,4320,1,Advanced Strength of Materials,0.0,0.87,0.07,0.0,0.07,0.0,0.0,0.0,michael porter,,ME-4320,2017
+ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2017
+ME,4440,2,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2017
+ME,4440,5,Mechanical Engineering Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2017
+ME,4440,6,Mechanical Engineering Lab III,0.18,0.64,0.0,0.0,0.09,0.0,0.0,0.09,john wagner,,ME-4440,2017
+ME,4440,9,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2017
+ME,4440,10,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2017
+ME,4440,18,Mechanical Engineering Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2017
+ME,4540,1,Design of Machine Elements,0.53,0.36,0.08,0.0,0.01,0.0,0.0,0.01,paul jeffrey meyer,,ME-4540,2017
+ME,4930,14,Sel.Topics ME - NonLinDy&Chas,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,phanin tallapragada,,ME-4930,2017
+ME,4930,39,Sel.Topics ME - Aero Propul,0.27,0.43,0.27,0.02,0.0,0.0,0.0,0.0,daniel fant,,ME-4930,2017
+ME,4930,139,Sel.Topic ME - Solar Energy,0.44,0.23,0.28,0.0,0.0,0.0,0.0,0.05,daniel fant,,ME-4930,2017
+ME,6210,1,Intro to Comp Flow,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,,ME-6210,2017
+ME,6320,1,Advanced Strength of Materials,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,michael porter,,ME-6320,2017
+ME,6540,1,Des Machine Elements,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,,ME-6540,2017
+ME,8010,1,Found of Fluid Mech,0.17,0.44,0.17,0.0,0.11,0.0,0.0,0.11,nicole gise coutris,,ME-8010,2017
+ME,8100,1,Macroscopic Thermo,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,xiangchun xuan,,ME-8100,2017
+ME,8180,1,Intro to Fin Ele Ana,0.58,0.31,0.04,0.0,0.0,0.0,0.0,0.06,lonny thompson,,ME-8180,2017
+ME,8230,1,Control Systems,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,,ME-8230,2017
+ME,8460,1,Inter Dynamics,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,phanin tallapragada,,ME-8460,2017
+ME,8610,1,Matl Sel Engr Design,0.45,0.53,0.0,0.0,0.02,0.0,0.0,0.0,michael porter,,ME-8610,2017
+ME,8610,401,Matl Sel Engr Design,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael porter,,ME-8610,2017
+ME,8700,1,Adv Design Methods,0.29,0.62,0.05,0.0,0.05,0.0,0.0,0.0,joshua summers,,ME-8700,2017
+ME,8710,1,Engr Optimization,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-8710,2017
+ME,8710,401,Engr Optimization,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,georges fadel,,ME-8710,2017
+ME,8930,1,Sel. Topics in ME - Scaling,0.3,0.2,0.3,0.0,0.2,0.0,0.0,0.0,jean-marc delhaye,,ME-8930,2017
+ME,8930,4,SelectedTopics in ME - Adv Mfg,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-8930,2017
+MGT,2010,1,Principles of Management,0.42,0.43,0.11,0.03,0.01,0.0,0.0,0.0,katherine clark,,MGT-2010,2017
+MGT,2010,2,Principles of Management,0.42,0.38,0.16,0.03,0.0,0.0,0.0,0.01,tina robbins,,MGT-2010,2017
+MGT,2010,4,Principles of Management (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True,MGT-2010,2017
+MGT,2010,10,Principles of Management,0.33,0.45,0.23,0.0,0.0,0.0,0.0,0.0,ashley will parnell,,MGT-2010,2017
+MGT,2010,11,Principles of Management,0.28,0.33,0.31,0.03,0.03,0.0,0.0,0.03,ashley will parnell,,MGT-2010,2017
+MGT,2010,12,Principles of Management,0.16,0.33,0.28,0.09,0.07,0.0,0.0,0.07,ashley will parnell,,MGT-2010,2017
+MGT,2180,1,Management PC Applications,0.47,0.37,0.12,0.01,0.01,0.0,0.0,0.02,ryan toole,,MGT-2180,2017
+MGT,2180,2,Management PC Applications,0.2,0.47,0.21,0.03,0.04,0.0,0.0,0.03,ryan toole,,MGT-2180,2017
+MGT,2970,4,How to Start a Startup,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,john michael hannon,,MGT-2970,2017
+MGT,3070,1,Human Resource Management,0.84,0.14,0.0,0.0,0.0,0.0,0.0,0.02,jonathan sanderson,,MGT-3070,2017
+MGT,3070,3,Human Resource Management,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2017
+MGT,3070,4,Human Resource Management,0.6,0.38,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2017
+MGT,3070,5,Human Resource Management,0.43,0.45,0.13,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2017
+MGT,3070,6,Human Resource Management,0.53,0.43,0.03,0.03,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2017
+MGT,3070,7,Human Resource Management,0.83,0.15,0.0,0.0,0.03,0.0,0.0,0.0,alejandra kennedy,,MGT-3070,2017
+MGT,3070,8,Human Resource Management,0.25,0.38,0.13,0.13,0.06,0.0,0.0,0.06,priscilla harrison,,MGT-3070,2017
+MGT,3100,1,Intermed Business Statistics,0.38,0.28,0.13,0.1,0.03,0.0,0.0,0.08,min kyung lee,,MGT-3100,2017
+MGT,3100,2,Intermed Business Statistics,0.44,0.41,0.05,0.0,0.0,0.0,0.0,0.1,mustafa serk akturk,,MGT-3100,2017
+MGT,3100,3,Intermed Business Statistics,0.37,0.23,0.23,0.0,0.02,0.0,0.0,0.14,sukran nil atadeniz,,MGT-3100,2017
+MGT,3100,5,Intermed Business Statistics,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.13,mustafa serk akturk,,MGT-3100,2017
+MGT,3100,6,Intermed Business Statistics,0.15,0.39,0.36,0.03,0.0,0.0,0.0,0.06,magda gabriela sava,,MGT-3100,2017
+MGT,3100,7,Intermed Business Statistics,0.39,0.31,0.19,0.0,0.03,0.0,0.0,0.08,sukran nil atadeniz,,MGT-3100,2017
+MGT,3100,8,Intermed Business Statistics,0.42,0.32,0.13,0.05,0.08,0.0,0.0,0.0,min kyung lee,,MGT-3100,2017
+MGT,3100,9,Intermed Business Statistics,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,,MGT-3100,2017
+MGT,3100,10,Intermed Business Statistics,0.28,0.37,0.21,0.0,0.09,0.0,0.0,0.05,remi charpin,,MGT-3100,2017
+MGT,3100,11,Intermed Business Statistics,0.7,0.24,0.0,0.0,0.0,0.0,0.0,0.07,thomas simpson,,MGT-3100,2017
+MGT,3120,1,Decision Models for Management,0.12,0.23,0.23,0.19,0.16,0.0,0.0,0.07,sara elizabet yoder,,MGT-3120,2017
+MGT,3120,2,Decision Models for Management,0.2,0.16,0.23,0.23,0.1,0.0,0.0,0.07,sara elizabet yoder,,MGT-3120,2017
+MGT,3170,1,Logistics Mgmt,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,ahmet colak,,MGT-3170,2017
+MGT,3180,1,Mgt of Info Systems,0.28,0.56,0.1,0.03,0.0,0.0,0.0,0.03,marten risius,,MGT-3180,2017
+MGT,3180,2,Mgt of Info Systems,0.48,0.35,0.05,0.03,0.0,0.0,0.0,0.1,iaroslava dutchak,,MGT-3180,2017
+MGT,3180,3,Mgt of Info Systems,0.35,0.33,0.28,0.0,0.02,0.0,0.0,0.02,tina marie esposito,,MGT-3180,2017
+MGT,3180,4,Mgt of Info Systems,0.41,0.41,0.13,0.0,0.02,0.0,0.0,0.02,tina marie esposito,,MGT-3180,2017
+MGT,3180,5,Mgt of Info Systems,0.6,0.23,0.12,0.0,0.05,0.0,0.0,0.0,kevin dani matthews,,MGT-3180,2017
+MGT,3500,1,Intro to Business Analytics,0.18,0.73,0.09,0.0,0.0,0.0,0.0,0.0,siyuan li,,MGT-3500,2017
+MGT,3510,1,Business Analytics & Problems,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,,MGT-3510,2017
+MGT,3900,1,Ops Mgt,0.16,0.47,0.32,0.03,0.0,0.0,0.0,0.03,yann ferrand,,MGT-3900,2017
+MGT,3900,2,Ops Mgt,0.13,0.23,0.58,0.05,0.0,0.0,0.0,0.03,zachary mo leffakis,,MGT-3900,2017
+MGT,3900,3,Ops Mgt,0.11,0.39,0.29,0.03,0.03,0.0,0.0,0.16,berna quiroga gomez,,MGT-3900,2017
+MGT,3900,4,Ops Mgt,0.2,0.43,0.28,0.03,0.03,0.0,0.0,0.05,berna quiroga gomez,,MGT-3900,2017
+MGT,3900,5,Ops Mgt,0.32,0.24,0.32,0.0,0.03,0.0,0.0,0.08,daniel nielubowicz,,MGT-3900,2017
+MGT,3900,6,Ops Mgt,0.36,0.5,0.11,0.0,0.03,0.0,0.0,0.0,maneeshre ajjuguttu,,MGT-3900,2017
+MGT,4000,1,Mgt of Organizational Behavior,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2017
+MGT,4000,2,Mgt of Organizational Behavior,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2017
+MGT,4000,3,Mgt of Organizational Behavior,0.22,0.36,0.31,0.03,0.03,0.0,0.0,0.06,thomas jo zagenczyk,,MGT-4000,2017
+MGT,4000,4,Mgt of Organizational Behavior,0.15,0.4,0.35,0.05,0.0,0.0,0.0,0.05,philip roth,,MGT-4000,2017
+MGT,4020,1,Ops Pln and Ctl,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4020,2017
+MGT,4080,1,Lean Operations,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4080,2017
+MGT,4110,1,Project Management,0.26,0.37,0.33,0.0,0.05,0.0,0.0,0.0,russell purvis,,MGT-4110,2017
+MGT,4120,1,Supplier Management,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,ahmet colak,,MGT-4120,2017
+MGT,4150,1,Business Strategy,0.18,0.57,0.25,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2017
+MGT,4150,3,Business Strategy,0.4,0.53,0.05,0.03,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2017
+MGT,4150,4,Business Strategy,0.38,0.55,0.07,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2017
+MGT,4150,7,Business Strategy,0.49,0.47,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2017
+MGT,4150,8,Business Strategy,0.52,0.41,0.07,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2017
+MGT,4150,9,Business Strategy,0.25,0.59,0.11,0.0,0.02,0.0,0.0,0.02,amy elizabet ingram,,MGT-4150,2017
+MGT,4160,1,Special Topics Hr,0.36,0.6,0.04,0.0,0.0,0.0,0.0,0.0,kristin dam scott,,MGT-4160,2017
+MGT,4230,1,Intern Bus Mgt,0.16,0.16,0.53,0.16,0.0,0.0,0.0,0.0,wayne stewart,,MGT-4230,2017
+MGT,4230,2,Intern Bus Mgt,0.18,0.18,0.55,0.0,0.05,0.0,0.0,0.05,wayne stewart,,MGT-4230,2017
+MGT,4230,3,Intern Bus Mgt,0.23,0.4,0.3,0.05,0.0,0.0,0.0,0.03,janis miller,,MGT-4230,2017
+MGT,4230,4,Intern Bus Mgt,0.11,0.56,0.27,0.02,0.0,0.0,0.0,0.04,janis miller,,MGT-4230,2017
+MGT,4240,1,Global Supply Chain,0.21,0.46,0.33,0.0,0.0,0.0,0.0,0.0,yann ferrand,,MGT-4240,2017
+MGT,4270,2,Managing Improvement,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MGT-4270,2017
+MGT,4310,1,Emp Rights & Resp,0.24,0.53,0.15,0.0,0.03,0.0,0.0,0.06,leonard jos spooner,,MGT-4310,2017
+MGT,4310,2,Emp Rights & Resp,0.4,0.49,0.11,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-4310,2017
+MGT,4350,1,Pers Interviewing,0.36,0.36,0.25,0.04,0.0,0.0,0.0,0.0,philip roth,,MGT-4350,2017
+MGT,4520,1,Business Analysis,0.15,0.58,0.15,0.04,0.04,0.0,0.0,0.04,marten risius,,MGT-4520,2017
+MGT,4540,1,Systems Implement,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,heshan sun,,MGT-4540,2017
+MGT,4550,1,Emerging I T Trends,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MGT-4550,2017
+MGT,4560,1,Business Info Mgt,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,siyuan li,,MGT-4560,2017
+MGT,8690,1,Project Mgt,0.41,0.56,0.0,0.0,0.0,0.0,0.0,0.04,russell purvis,,MGT-8690,2017
+MICR,2050,1,Introductory Micro,0.55,0.4,0.04,0.01,0.0,0.0,0.0,0.01,john abercrombie,,MICR-2050,2017
+MICR,3050,1,General Microbiology,0.38,0.4,0.14,0.05,0.01,0.0,0.0,0.02,krista barr rudolph,,MICR-3050,2017
+MICR,3050,2,General Microbiology,0.42,0.41,0.13,0.03,0.01,0.0,0.0,0.01,krista barr rudolph,,MICR-3050,2017
+MICR,4010,1,Microbial Diversity & Ecology,0.23,0.51,0.18,0.03,0.03,0.0,0.0,0.03,barbara campbell,,MICR-4010,2017
+MICR,4050,1,Adv Microbial Ecol of Humans,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4050,2017
+MICR,4140,1,Basic Immunology,0.44,0.37,0.1,0.02,0.07,0.0,0.0,0.0,yanzhang wei,,MICR-4140,2017
+MICR,4150,1,Microbial Genetics,0.23,0.32,0.26,0.2,0.0,0.0,0.0,0.0,min cao,,MICR-4150,2017
+MICR,4160,1,Intro Virology,0.95,0.04,0.0,0.0,0.0,0.0,0.0,0.01,simon scott,,MICR-4160,2017
+MICR,4510,1,Advanced Microbiology II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4510,2017
+MICR,4510,2,Advanced Microbiology II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4510,2017
+MICR,4510,3,Advanced Microbiology II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4510,2017
+MKT,3010,1,Prin of Marketing,0.02,0.43,0.38,0.1,0.05,0.0,0.0,0.02,carter wil mcelveen,,MKT-3010,2017
+MKT,3010,2,Prin of Marketing,0.29,0.46,0.18,0.05,0.02,0.0,0.0,0.0,amanda cooper fine,,MKT-3010,2017
+MKT,3010,3,Prin of Marketing,0.26,0.45,0.23,0.04,0.01,0.0,0.0,0.0,amanda cooper fine,,MKT-3010,2017
+MKT,3010,4,Prin of Marketing,0.27,0.46,0.2,0.04,0.01,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2017
+MKT,3010,5,Prin of Marketing,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,patricia knowles,,MKT-3010,2017
+MKT,3020,1,Consumer Behavior,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2017
+MKT,3020,2,Consumer Behavior,0.58,0.4,0.0,0.0,0.0,0.0,0.0,0.02,jennifer di siemens,,MKT-3020,2017
+MKT,3020,3,Consumer Behavior,0.34,0.44,0.2,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2017
+MKT,3020,4,Consumer Behavior,0.51,0.33,0.08,0.06,0.02,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2017
+MKT,3020,5,Consumer Behavior,0.12,0.64,0.19,0.03,0.0,0.0,0.0,0.02,carter wil mcelveen,,MKT-3020,2017
+MKT,3210,1,Sports Marketing,0.74,0.23,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2017
+MKT,3210,2,Sports Marketing,0.68,0.3,0.0,0.0,0.0,0.0,0.0,0.02,delancy bennett,,MKT-3210,2017
+MKT,3310,1,Marketing Metrics & Analytics,0.42,0.56,0.02,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,,MKT-3310,2017
+MKT,3310,2,Marketing Metrics & Analytics,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,,MKT-3310,2017
+MKT,3980,1,Creative Inquiry in Marketing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james gaubert,,MKT-3980,2017
+MKT,4200,2,Professional Selling,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2017
+MKT,4200,3,Professional Selling,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2017
+MKT,4200,4,Professional Selling,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4200,2017
+MKT,4200,5,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4200,2017
+MKT,4230,1,Promotional Strategy,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,patricia knowles,,MKT-4230,2017
+MKT,4240,1,Sales Management,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4240,2017
+MKT,4260,1,Business-to-Business,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,james gaubert,,MKT-4260,2017
+MKT,4270,1,International Mktg,0.58,0.32,0.08,0.0,0.01,0.0,0.0,0.01,roger gomes,,MKT-4270,2017
+MKT,4270,2,International Mktg,0.21,0.59,0.13,0.03,0.03,0.0,0.0,0.03,roger gomes,,MKT-4270,2017
+MKT,4270,3,International Mktg,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,thomas poehlman,,MKT-4270,2017
+MKT,4280,1,Services Marketing,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4280,2017
+MKT,4280,2,Services Marketing,0.43,0.53,0.05,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4280,2017
+MKT,4310,1,Marketing Research,0.23,0.5,0.23,0.0,0.0,0.0,0.0,0.04,peter weathers,,MKT-4310,2017
+MKT,4310,2,Marketing Research,0.16,0.53,0.21,0.11,0.0,0.0,0.0,0.0,peter weathers,,MKT-4310,2017
+MKT,4310,3,Marketing Research,0.35,0.62,0.0,0.0,0.0,0.0,0.0,0.04,scott darren swain,,MKT-4310,2017
+MKT,4310,4,Marketing Research,0.35,0.35,0.17,0.0,0.0,0.0,0.0,0.13,william kilbourne,,MKT-4310,2017
+MKT,4430,1,Advertising Strategy,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4430,2017
+MKT,4450,1,Macromarketing,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,,MKT-4450,2017
+MKT,4500,1,Strategic Mktg Mgt,0.19,0.65,0.16,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2017
+MKT,4500,2,Strategic Mktg Mgt,0.17,0.45,0.34,0.03,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2017
+MKT,4950,1,Social Media,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-4950,2017
+MKT,4950,2,Social Media,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-4950,2017
+MKT,8610,1,Marketing Research,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,,MKT-8610,2017
+MKT,8630,1,Buyer Behavior,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-8630,2017
+ML,1010,1,Leadership Fund I,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,clay wilson etterle,,ML-1010,2017
+ML,2010,2,Leadership Development I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2010,2017
+ML,2010,3,Leadership Development I,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,vincent john presto,,ML-2010,2017
+ML,3010,1,Advanced Leadership I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,,ML-3010,2017
+MSE,2100,1,Intro to Mat Science,0.43,0.21,0.15,0.08,0.1,0.0,0.0,0.04,rakhee pani,,MSE-2100,2017
+MSE,2100,2,Intro to Mat Science,0.18,0.33,0.29,0.16,0.03,0.0,0.0,0.01,eric skaar,,MSE-2100,2017
+MSE,2100,3,Intro to Mat Science,0.27,0.25,0.28,0.08,0.09,0.0,0.0,0.04,fei peng,,MSE-2100,2017
+MSE,2100,4,Intro to Mat Science,0.31,0.45,0.14,0.03,0.04,0.0,0.0,0.03,ruslan burtovyy,,MSE-2100,2017
+MSE,2100,5,Intro to Mat Science,0.44,0.3,0.11,0.04,0.07,0.0,0.0,0.04,olga kuksenok,,MSE-2100,2017
+MSE,3190,1,Materials Proc I,0.34,0.53,0.08,0.03,0.01,0.0,0.0,0.01,olin mefford,,MSE-3190,2017
+MSE,3190,2,Materials Proc I,0.14,0.62,0.16,0.08,0.0,0.0,0.0,0.0,olin mefford,,MSE-3190,2017
+MSE,3260,1,Thermo of Materials,0.39,0.35,0.2,0.02,0.0,0.0,0.0,0.04,gary lickfield,,MSE-3260,2017
+MSE,3260,2,Thermo of Materials,0.25,0.39,0.19,0.08,0.06,0.0,0.0,0.03,gary lickfield,,MSE-3260,2017
+MSE,3270,1,Transport Phenomena,0.15,0.47,0.18,0.16,0.03,0.0,0.0,0.02,ulf daniel schiller,,MSE-3270,2017
+MSE,3270,2,Transport Phenomena,0.05,0.26,0.31,0.26,0.08,0.0,0.0,0.05,ulf daniel schiller,,MSE-3270,2017
+MSE,4020,1,Solid State Material,0.55,0.13,0.26,0.06,0.0,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-4020,2017
+MSE,4070,1,Senior Capstone Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,,MSE-4070,2017
+MSE,4130,1,Noncrystalline Materials,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,,MSE-4130,2017
+MSE,4150,1,Polymer Sc Engr,0.49,0.33,0.01,0.0,0.0,0.0,0.0,0.16,stephen foulger,,MSE-4150,2017
+MSE,4150,2,Polymer Sc Engr,0.58,0.28,0.09,0.02,0.02,0.0,0.0,0.0,olin mefford,,MSE-4150,2017
+MSE,4320,1,Manuf Proc & Systems,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,,MSE-4320,2017
+MSE,4580,1,Surf Phen in Ms&E,0.29,0.11,0.21,0.36,0.04,0.0,0.0,0.0,konstantin kornev,,MSE-4580,2017
+MSE,4810,1,Undergraduate Research Fundame,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,marian kennedy,,MSE-4810,2017
+MSE,4910,1,Undergraduate Research,0.78,0.06,0.06,0.06,0.0,0.0,0.0,0.06,marian kennedy,,MSE-4910,2017
+MSE,4910,2,Undergraduate Research,0.59,0.24,0.0,0.06,0.06,0.0,0.0,0.06,marian kennedy,,MSE-4910,2017
+MSE,8100,1,Fundamentals of Materials Sci,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,igor luzinov,,MSE-8100,2017
+MSE,8270,1,Kin of Phase Tran,0.52,0.38,0.0,0.0,0.05,0.0,0.0,0.05,konstantin kornev,,MSE-8270,2017
+MUSC,1420,1,Music Theory I,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,anthony bernarducci,,MUSC-1420,2017
+MUSC,1430,1,Aural Skills I,0.84,0.0,0.05,0.0,0.11,0.0,0.0,0.0,anthony bernarducci,,MUSC-1430,2017
+MUSC,2100,2,Music in the Western World,0.56,0.25,0.13,0.0,0.03,0.0,0.0,0.03,lisa sain odom,,MUSC-2100,2017
+MUSC,2100,3,Music in the Western World,0.41,0.34,0.16,0.09,0.0,0.0,0.0,0.0,alison leigh mero,,MUSC-2100,2017
+MUSC,2100,4,Music in the Western World,0.56,0.22,0.13,0.0,0.06,0.0,0.0,0.03,linda li-bleuel,,MUSC-2100,2017
+MUSC,2100,6,Music in the Western World,0.47,0.38,0.09,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,,MUSC-2100,2017
+MUSC,2100,7,Music in the Western World,0.39,0.39,0.1,0.03,0.0,0.0,0.0,0.1,rhea beth jacobus,,MUSC-2100,2017
+MUSC,2100,8,Music in the Western World,0.53,0.23,0.0,0.0,0.03,0.0,0.0,0.2,rhea beth jacobus,,MUSC-2100,2017
+MUSC,2100,10,Music in the Western World,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,linda dzuris,,MUSC-2100,2017
+MUSC,2100,12,Music in the Western World,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,lea kibler,,MUSC-2100,2017
+MUSC,3110,1,History of American Music,0.61,0.29,0.06,0.03,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3110,2017
+MUSC,3120,1,History of Jazz,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-3120,2017
+MUSC,3130,1,Hist of Rock & Roll,0.78,0.16,0.03,0.0,0.03,0.0,0.0,0.0,hamilton altstatt,,MUSC-3130,2017
+MUSC,3170,1,Hist of Country Mus,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3170,2017
+MUSC,3180,1,Hist of Audio Tech,0.5,0.25,0.19,0.06,0.0,0.0,0.0,0.0,bruce allen whisler,,MUSC-3180,2017
+MUSC,3610,1,Marching Band,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,,MUSC-3610,2017
+MUSC,3620,1,Symphonic Band,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mark spede,,MUSC-3620,2017
+MUSC,3690,1,Symphony Orchestra,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,,MUSC-3690,2017
+MUSC,4150,1,Music Hist to 1750,0.17,0.17,0.33,0.11,0.11,0.0,0.0,0.11,justin durham,,MUSC-4150,2017
+NPL,3000,1,Nonprofit Leadership,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2017
+NPL,3000,3,Nonprofit Leadership,0.63,0.2,0.03,0.0,0.0,0.0,0.0,0.13,bonnie west stevens,,NPL-3000,2017
+NPL,3000,4,Nonprofit Leadership,0.6,0.23,0.1,0.0,0.03,0.0,0.0,0.03,bonnie west stevens,,NPL-3000,2017
+NPL,3000,5,Nonprofit Leadership,0.5,0.23,0.23,0.0,0.05,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2017
+NPL,3000,6,Nonprofit Leadership,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2017
+NPL,3000,7,Nonprofit Leadership,0.63,0.08,0.08,0.08,0.13,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2017
+NPL,3040,1,NPL Risk Management,0.72,0.19,0.0,0.0,0.09,0.0,0.0,0.0,daniel mor anderson,,NPL-3040,2017
+NURS,1400,1,Comp App Hlth Care,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,,NURS-1400,2017
+NURS,3030,1,Nursing of Adults,0.3,0.65,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2017
+NURS,3040,1,Pathophysiology,0.39,0.48,0.1,0.02,0.02,0.0,0.0,0.0,catherine si murton,,NURS-3040,2017
+NURS,3040,400,Pathophysiology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,,NURS-3040,2017
+NURS,3040,401,Pathophysiology,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,,NURS-3040,2017
+NURS,3050,1,Psychosocial Nursing,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,,NURS-3050,2017
+NURS,3100,1,Health Assessment,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,,NURS-3100,2017
+NURS,3100,2,Health Assessment,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,,NURS-3100,2017
+NURS,3100,400,Health Assessment,0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,jason thrift,,NURS-3100,2017
+NURS,3120,1,Foundations of Nursing,0.47,0.52,0.02,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,,NURS-3120,2017
+NURS,3120,400,Foundations of Nursing,0.5,0.46,0.0,0.04,0.0,0.0,0.0,0.0,jennifer el bagwell,,NURS-3120,2017
+NURS,3190,400,Health Assessment for RNs,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,,NURS-3190,2017
+NURS,3200,2,Prof in Nurs,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3200,2017
+NURS,3230,400,Gerontology Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,tawny jenn mcintosh,,NURS-3230,2017
+NURS,3300,2,Research in Nursing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-3300,2017
+NURS,3330,400,Health Care Genetics,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,mary steck,,NURS-3330,2017
+NURS,3400,1,Pharmther Nursing,0.32,0.55,0.11,0.0,0.02,0.0,0.0,0.0,catherine si murton,,NURS-3400,2017
+NURS,3400,400,Pharmther Nursing,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jenna lyn seawright,,NURS-3400,2017
+NURS,3600,400,Social Determinants in Health,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,,NURS-3600,2017
+NURS,4010,1,Mental Health Nurs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-4010,2017
+NURS,4030,400,Complex Nursing of Adults,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,,NURS-4030,2017
+NURS,4060,400,Issues in Professionalism,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,,NURS-4060,2017
+NURS,4110,1,Nursing of Children,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,,NURS-4110,2017
+NURS,4120,1,Nurs Women and Fam,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2017
+NURS,4140,400,Com Nurs & Hlth Prom,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,,NURS-4140,2017
+NURS,4250,200,Community Nursing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,,NURS-4250,2017
+NURS,4980,15,Nursing/Engineering,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,nancy meehan,,NURS-4980,2017
+NURS,8050,400,Pharmaco Adv Nurs,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8050,2017
+NURS,8050,401,Pharmaco Adv Nurs,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8050,2017
+NURS,8060,400,Advan Assessment for Nursing,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,,NURS-8060,2017
+NURS,8090,400,Pathophysiology,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,tracy brock lowe,,NURS-8090,2017
+NURS,8190,400,Developing Family,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-8190,2017
+NURS,8200,400,Child & Adol Nursing,0.34,0.55,0.07,0.0,0.03,0.0,0.0,0.0,heide temples,,NURS-8200,2017
+NURS,9020,1,DNP Clinical Epidem & Biostats,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,veronica parker,,NURS-9020,2017
+NUTR,2030,1,Intro Princ of Human Nutrition,0.81,0.16,0.01,0.0,0.02,0.0,0.0,0.0,bridgit den corbett,,NUTR-2030,2017
+NUTR,2030,2,Intro Princ of Human Nutrition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,bridgit den corbett,,NUTR-2030,2017
+NUTR,2050,1,Nutrition for Nursing Prof,0.74,0.25,0.01,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,,NUTR-2050,2017
+NUTR,2160,1,Evidence-Based Nutrition,0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,angela fraser,,NUTR-2160,2017
+NUTR,4240,1,Medical Nutr Thera I,0.49,0.46,0.06,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4240,2017
+NUTR,4510,1,Human Nutrition & Metabolism I,0.3,0.3,0.19,0.12,0.05,0.0,0.0,0.05,elliot jesch,,NUTR-4510,2017
+PA,1010,1,Intro to Perf Arts,0.67,0.3,0.04,0.0,0.0,0.0,0.0,0.0,david hartmann,,PA-1010,2017
+PA,2010,2,Career Planning and Prof Devel,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,,PA-2010,2017
+PA,2790,1,Perf Arts Pract I,0.36,0.55,0.05,0.0,0.0,0.0,0.0,0.05,kenneth moore,,PA-2790,2017
+PADM,8220,400,Public Policy Process,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,,PADM-8220,2017
+PADM,8220,401,Public Policy Process,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,,PADM-8220,2017
+PADM,8290,400,Public Financial Management,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,,PADM-8290,2017
+PADM,8420,400,GIS for Public Administrators,0.55,0.27,0.0,0.0,0.09,0.0,0.0,0.09,david lawrenc white,,PADM-8420,2017
+PADM,8660,400,Nonprofit Fundraising,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,renee salic nichols,,PADM-8660,2017
+PADM,8680,400,Local Government Admin,0.22,0.56,0.11,0.0,0.11,0.0,0.0,0.0,alfred bundrick,,PADM-8680,2017
+PADM,8720,400,Rural Development,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,,PADM-8720,2017
+PAS,3010,1,Pan African Studies,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,abel bartley,,PAS-3010,2017
+PDBE,8100,1,Contemporary Issues in EDP,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,PDBE-8100,2017
+PDBE,8150,1,Research Design in EDP,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,mickey lauria,,PDBE-8150,2017
+PES,1040,1,Introduction to Plant Sciences,0.81,0.17,0.03,0.0,0.0,0.0,0.0,0.0,paula agudelo,,PES-1040,2017
+PES,2020,1,Soils,0.19,0.55,0.19,0.06,0.0,0.0,0.0,0.01,dara michelle park,,PES-2020,2017
+PES,3150,1,Environment and Agriculture,0.38,0.29,0.29,0.0,0.0,0.0,0.0,0.04,"appukuttan suseela,",,PES-3150,2017
+PES,4850,1,Environmental Soil Chemistry,0.44,0.31,0.19,0.0,0.0,0.0,0.0,0.06,haibo liu,,PES-4850,2017
+PHIL,1010,1,Intro to Philosophic Problems,0.44,0.41,0.12,0.0,0.0,0.0,0.0,0.03,david stegall,,PHIL-1010,2017
+PHIL,1010,2,Intro to Philosophic Problems,0.43,0.26,0.2,0.06,0.03,0.0,0.0,0.03,christopher grau,,PHIL-1010,2017
+PHIL,1010,3,Intro to Philosophic Problems,0.49,0.31,0.11,0.0,0.0,0.0,0.0,0.09,david stegall,,PHIL-1010,2017
+PHIL,1010,4,Intro to Philosophic Problems,0.23,0.51,0.14,0.06,0.03,0.0,0.0,0.03,kelly smith,,PHIL-1010,2017
+PHIL,1010,6,Intro to Philosophic Problems,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,andrew garnar,,PHIL-1010,2017
+PHIL,1020,1,Introduction to Logic,0.68,0.21,0.12,0.0,0.0,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2017
+PHIL,1020,2,Introduction to Logic,0.62,0.24,0.03,0.03,0.06,0.0,0.0,0.03,michael hal hannen,,PHIL-1020,2017
+PHIL,1020,3,Introduction to Logic,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,michael hal hannen,,PHIL-1020,2017
+PHIL,1020,4,Introduction to Logic,0.61,0.28,0.06,0.06,0.0,0.0,0.0,0.0,adam gies,,PHIL-1020,2017
+PHIL,1020,7,Introduction to Logic,0.32,0.32,0.29,0.03,0.0,0.0,0.0,0.03,adam gies,,PHIL-1020,2017
+PHIL,1020,8,Introduction to Logic,0.53,0.25,0.22,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-1020,2017
+PHIL,1020,9,Introduction to Logic,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,,PHIL-1020,2017
+PHIL,1020,10,Introduction to Logic,0.26,0.56,0.06,0.03,0.03,0.0,0.0,0.06,christopher wells,,PHIL-1020,2017
+PHIL,1020,11,Introduction to Logic,0.46,0.29,0.11,0.11,0.0,0.0,0.0,0.03,christopher wells,,PHIL-1020,2017
+PHIL,1020,12,Introduction to Logic,0.51,0.29,0.09,0.03,0.0,0.0,0.0,0.09,christopher wells,,PHIL-1020,2017
+PHIL,1020,13,Introduction to Logic,0.72,0.11,0.0,0.11,0.0,0.0,0.0,0.06,christopher wells,,PHIL-1020,2017
+PHIL,1020,14,Introduction to Logic,0.26,0.26,0.26,0.0,0.03,0.0,0.0,0.18,stephen satris,,PHIL-1020,2017
+PHIL,1030,1,Introduction to Ethics,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,edyta joanna kuzian,,PHIL-1030,2017
+PHIL,1030,2,Introduction to Ethics,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,stephen satris,,PHIL-1030,2017
+PHIL,1030,3,Introduction to Ethics,0.32,0.29,0.32,0.0,0.03,0.0,0.0,0.03,charles starkey,,PHIL-1030,2017
+PHIL,1030,4,Introduction to Ethics,0.5,0.33,0.06,0.06,0.06,0.0,0.0,0.0,david stegall,,PHIL-1030,2017
+PHIL,1030,5,Introduction to Ethics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,,PHIL-1030,2017
+PHIL,1030,6,Introduction to Ethics,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,,PHIL-1030,2017
+PHIL,1030,7,Introduction to Ethics,0.38,0.23,0.31,0.0,0.0,0.0,0.0,0.08,edyta joanna kuzian,,PHIL-1030,2017
+PHIL,1030,8,Introduction to Ethics,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,,PHIL-1030,2017
+PHIL,1030,9,Introduction to Ethics,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,john randall wolfe,,PHIL-1030,2017
+PHIL,1030,10,Introduction to Ethics,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,david stegall,,PHIL-1030,2017
+PHIL,3040,1,Moral Philosophy,0.31,0.5,0.06,0.0,0.0,0.0,0.0,0.13,charles starkey,,PHIL-3040,2017
+PHIL,3150,1,Ancient Philosophy,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,michael hal hannen,,PHIL-3150,2017
+PHIL,3180,1,20th-Century Philosophy,0.58,0.29,0.03,0.0,0.03,0.0,0.0,0.06,william maker,,PHIL-3180,2017
+PHIL,3200,1,Soc and Pol Phil,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,david stegall,,PHIL-3200,2017
+PHIL,3260,1,Science and Values,0.59,0.21,0.06,0.0,0.09,0.0,0.0,0.06,andrew garnar,,PHIL-3260,2017
+PHIL,3260,2,Science and Values,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2017
+PHIL,3430,1,Philosophy of Law,0.21,0.66,0.03,0.03,0.0,0.0,0.0,0.07,brookes colyt brown,,PHIL-3430,2017
+PHIL,3440,1,Business Ethics,0.24,0.47,0.24,0.0,0.0,0.0,0.0,0.06,brookes colyt brown,,PHIL-3440,2017
+PHIL,3480,1,Philosophies of Art,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,christopher grau,,PHIL-3480,2017
+PHIL,3550,1,Philosophy of Mind & Cog Scien,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-3550,2017
+PHIL,4020,1,Topics in Philosophy: Kant,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,kelly smith,,PHIL-4020,2017
+PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1180,2017
+PHYS,1220,1,Physics with Calculus I,0.23,0.33,0.24,0.07,0.06,0.0,0.0,0.07,lih-sin the,,PHYS-1220,2017
+PHYS,1220,2,Physics with Calculus I,0.29,0.29,0.25,0.09,0.01,0.0,0.0,0.06,lih-sin the,,PHYS-1220,2017
+PHYS,1220,4,Physics with Calculus I,0.56,0.19,0.06,0.06,0.13,0.0,0.0,0.0,murray daw,,PHYS-1220,2017
+PHYS,1220,500,Physics with Calculus I,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,elaine parshall,,PHYS-1220,2017
+PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,,PHYS-1240,2017
+PHYS,1240,2,Physics Lab I,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,3,Physics Lab I,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2017
+PHYS,1240,4,Physics Lab I,0.56,0.33,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,6,Physics Lab I,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,7,Physics Lab I,0.28,0.39,0.17,0.11,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,8,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,9,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,10,Physics Lab I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,11,Physics Lab I,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,12,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,14,Physics Lab I,0.25,0.38,0.06,0.06,0.0,0.0,0.0,0.25,jerry hester,,PHYS-1240,2017
+PHYS,1240,15,Physics Lab I,0.44,0.38,0.13,0.06,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,16,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,17,Physics Lab I,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-1240,2017
+PHYS,1240,18,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,19,Physics Lab I,0.71,0.18,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,2070,1,General Physics I,0.13,0.29,0.31,0.14,0.07,0.0,0.0,0.06,amy liann pope,,PHYS-2070,2017
+PHYS,2070,2,General Physics I,0.27,0.37,0.21,0.06,0.02,0.0,0.0,0.06,amy liann pope,,PHYS-2070,2017
+PHYS,2070,3,General Physics I,0.36,0.37,0.18,0.06,0.02,0.0,0.0,0.01,amy liann pope,,PHYS-2070,2017
+PHYS,2080,1,General Physics II,0.49,0.3,0.11,0.06,0.03,0.0,0.0,0.01,sripar bhattacharya,,PHYS-2080,2017
+PHYS,2090,1,Gen Phys Lab I,0.79,0.04,0.04,0.04,0.04,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,2,Gen Phys Lab I,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2017
+PHYS,2090,3,Gen Phys Lab I,0.33,0.46,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,4,Gen Phys Lab I,0.55,0.23,0.14,0.05,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2017
+PHYS,2090,5,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,6,Gen Phys Lab I,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,7,Gen Phys Lab I,0.63,0.25,0.04,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2017
+PHYS,2090,8,Gen Phys Lab I,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2017
+PHYS,2090,9,Gen Phys Lab I,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,10,Gen Phys Lab I,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,11,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,12,Gen Phys Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,13,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,14,Gen Phys Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,15,Gen Phys Lab I,0.61,0.35,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,16,Gen Phys Lab I,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,17,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,18,Gen Phys Lab I,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,19,Gen Phys Lab I,0.61,0.3,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,20,Gen Phys Lab I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,21,Gen Phys Lab I,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,22,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2017
+PHYS,2090,23,Gen Phys Lab I,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,24,Gen Phys Lab I,0.52,0.39,0.0,0.0,0.0,0.0,0.0,0.09,jerry hester,,PHYS-2090,2017
+PHYS,2090,25,Gen Phys Lab I,0.52,0.39,0.0,0.04,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,26,Gen Phys Lab I,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,,PHYS-2090,2017
+PHYS,2090,27,Gen Phys Lab I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2100,1,Gen Phys Lab II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,2,Gen Phys Lab II,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,3,Gen Phys Lab II,0.65,0.15,0.2,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,4,Gen Phys Lab II,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,6,Gen Phys Lab II,0.52,0.3,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,7,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,8,Gen Phys Lab II,0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,9,Gen Phys Lab II,0.48,0.24,0.24,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2100,2017
+PHYS,2210,1,Physics with Calculus II,0.14,0.54,0.22,0.04,0.04,0.0,0.0,0.03,jason stratfo brown,,PHYS-2210,2017
+PHYS,2210,2,Physics with Calculus II,0.28,0.52,0.16,0.03,0.0,0.0,0.0,0.01,jason stratfo brown,,PHYS-2210,2017
+PHYS,2210,3,Physics with Calculus II,0.22,0.55,0.19,0.02,0.0,0.0,0.0,0.01,ramakrishna podila,,PHYS-2210,2017
+PHYS,2210,4,Physics with Calculus II,0.18,0.56,0.16,0.06,0.04,0.0,0.0,0.0,ramakrishna podila,,PHYS-2210,2017
+PHYS,2210,7,Physics With Cal II (HON),0.58,0.36,0.06,0.0,0.0,0.0,0.0,0.0,joan marler,True,PHYS-2210,2017
+PHYS,2220,1,Physics with Calculus III,0.57,0.29,0.0,0.05,0.0,0.0,0.0,0.1,jian he,,PHYS-2220,2017
+PHYS,2230,3,Physics Lab II,0.72,0.06,0.0,0.0,0.0,0.0,0.0,0.22,jerry hester,,PHYS-2230,2017
+PHYS,2230,4,Physics Lab II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2017
+PHYS,2230,6,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2017
+PHYS,2230,7,Physics Lab II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2017
+PHYS,2230,11,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2017
+PHYS,2230,13,Physics Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2017
+PHYS,2230,17,Physics Lab II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2017
+PHYS,2450,1,Physics of Climate,0.64,0.2,0.05,0.01,0.02,0.0,0.0,0.08,gerald lehmacher,,PHYS-2450,2017
+PHYS,3120,1,Meth Theor Phys II,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,antony valentini,,PHYS-3120,2017
+PHYS,3150,1,Intro to Computational Physics,0.5,0.27,0.19,0.0,0.0,0.0,0.0,0.04,emil georgie alexov,,PHYS-3150,2017
+PHYS,3210,1,Mechanics I,0.29,0.25,0.21,0.04,0.08,0.0,0.0,0.13,joshua alper,,PHYS-3210,2017
+PHYS,3250,1,Exper Physics I,0.5,0.25,0.15,0.0,0.05,0.0,0.0,0.05,chad sosolik,,PHYS-3250,2017
+PHYS,4410,1,Electromagnetics I,0.27,0.36,0.14,0.05,0.0,0.0,0.0,0.18,xian lu,,PHYS-4410,2017
+PHYS,4550,1,Quantum Physics I,0.18,0.64,0.09,0.09,0.0,0.0,0.0,0.0,ramakrishna podila,,PHYS-4550,2017
+PHYS,8110,1,Meth of Theor Phys I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,feng ding,,PHYS-8110,2017
+PHYS,8170,1,Molecular Biophysics,0.14,0.71,0.0,0.0,0.14,0.0,0.0,0.0,hugo sanabria,,PHYS-8170,2017
+PHYS,8210,1,Classical Mech I,0.14,0.57,0.29,0.0,0.0,0.0,0.0,0.0,jens oberheide,,PHYS-8210,2017
+PHYS,9510,1,Quantum Mech I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,,PHYS-9510,2017
+PKSC,1010,1,Pkgsc Orientation,0.88,0.09,0.02,0.0,0.01,0.0,0.0,0.0,robert truett moore,,PKSC-1010,2017
+PKSC,1020,1,Intro to Pkg Sci,0.24,0.4,0.26,0.04,0.02,0.0,0.0,0.03,heather batt,,PKSC-1020,2017
+PKSC,2020,1,Packaging Mtl & Mfg,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2020,2017
+PKSC,2040,1,Container Systems,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2040,2017
+PKSC,2060,1,Container Sys Lab,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2060,2017
+PKSC,4010,1,Packaging Machinery,0.35,0.49,0.14,0.0,0.0,0.0,0.0,0.01,anthony lou pometto,,PKSC-4010,2017
+PKSC,4040,1,Protective Packaging Prop/Prin,0.34,0.34,0.19,0.05,0.02,0.0,0.0,0.06,gregory batt,,PKSC-4040,2017
+PKSC,4160,1,Appl Polymers in Pkg,0.13,0.49,0.35,0.03,0.0,0.0,0.0,0.0,tyler stuettgen,,PKSC-4160,2017
+PKSC,4200,1,Pkg Design & Dev,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2017
+PKSC,4540,1,Prod Pkg Evl Lab,0.13,0.73,0.07,0.07,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2017
+PKSC,4540,2,Prod Pkg Evl Lab,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2017
+PKSC,4540,3,Prod Pkg Evl Lab,0.21,0.57,0.14,0.0,0.0,0.0,0.0,0.07,gregory batt,,PKSC-4540,2017
+PKSC,4540,4,Prod Pkg Evl Lab,0.25,0.31,0.31,0.0,0.0,0.0,0.0,0.13,gregory batt,,PKSC-4540,2017
+PKSC,4640,1,Food & Health Care Pkg Systems,0.65,0.25,0.08,0.0,0.03,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2017
+PKSC,8170,1,Pckg Materials: Sci & Technol,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,duncan darby,,PKSC-8170,2017
+PLPA,3100,1,Principles of Plant Pathology,0.34,0.38,0.24,0.03,0.0,0.0,0.0,0.0,steven nye jeffers,,PLPA-3100,2017
+PLPA,6250,1,Introductory Mycology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,,PLPA-6250,2017
+POSC,1010,1,Amer National Govt,0.15,0.33,0.34,0.13,0.02,0.0,0.0,0.02,joseph earl stewart,,POSC-1010,2017
+POSC,1010,2,Amer National Govt,0.21,0.44,0.21,0.06,0.06,0.0,0.0,0.02,jeffrey scott peake,,POSC-1010,2017
+POSC,1020,1,Intro Intl Relations,0.4,0.34,0.15,0.06,0.0,0.0,0.0,0.04,brandon mic stewart,,POSC-1020,2017
+POSC,1020,2,Intro Intl Relations,0.64,0.22,0.11,0.02,0.02,0.0,0.0,0.0,brandon mic stewart,,POSC-1020,2017
+POSC,1020,3,Intro Intl Relations,0.24,0.44,0.11,0.04,0.09,0.0,0.0,0.07,steven vince miller,,POSC-1020,2017
+POSC,1020,4,Intro Intl Relations,0.13,0.42,0.27,0.12,0.06,0.0,0.0,0.01,zeynep taydas,,POSC-1020,2017
+POSC,1020,5,Intro Intl Relations,0.18,0.41,0.23,0.1,0.05,0.0,0.0,0.04,zeynep taydas,,POSC-1020,2017
+POSC,1030,1,Intro to Political Theory,0.37,0.28,0.16,0.07,0.06,0.0,0.0,0.06,brandon turner,,POSC-1030,2017
+POSC,1030,2,Intro to Political Theory,0.17,0.61,0.11,0.06,0.0,0.0,0.0,0.06,colin pearce,,POSC-1030,2017
+POSC,1030,3,Intro to Political Theory,0.61,0.28,0.0,0.11,0.0,0.0,0.0,0.0,lorianne molinari,,POSC-1030,2017
+POSC,1040,1,Intro Compar Pol,0.45,0.35,0.13,0.02,0.04,0.0,0.0,0.02,brandon mic stewart,,POSC-1040,2017
+POSC,1040,2,Intro Compar Pol,0.18,0.42,0.16,0.13,0.05,0.0,0.0,0.05,katherine am curtis,,POSC-1040,2017
+POSC,1990,1,Intro Pol Sci,0.54,0.26,0.07,0.05,0.04,0.0,0.0,0.04,meredith petersheim,,POSC-1990,2017
+POSC,3020,1,State and Loc Gov,0.14,0.42,0.19,0.0,0.05,0.0,0.0,0.21,bruce ransom,,POSC-3020,2017
+POSC,3210,1,Public Admin,0.15,0.31,0.46,0.08,0.0,0.0,0.0,0.0,james woodard,,POSC-3210,2017
+POSC,3410,1,Quant Meth in Pol Sc,0.28,0.32,0.2,0.08,0.12,0.0,0.0,0.0,jeffrey allen fine,,POSC-3410,2017
+POSC,3610,1,International Conflict,0.3,0.19,0.19,0.11,0.09,0.0,0.0,0.13,steven vince miller,,POSC-3610,2017
+POSC,3630,1,Us Foreign Policy,0.37,0.54,0.07,0.0,0.0,0.0,0.0,0.02,vladimir matic,,POSC-3630,2017
+POSC,3710,1,European Politics,0.29,0.4,0.27,0.0,0.02,0.0,0.0,0.02,vladimir matic,,POSC-3710,2017
+POSC,4030,1,United States Congress,0.31,0.31,0.17,0.06,0.17,0.0,0.0,0.0,jeffrey allen fine,,POSC-4030,2017
+POSC,4070,1,Religion and Politic,0.16,0.42,0.32,0.06,0.0,0.0,0.0,0.03,laura olson,,POSC-4070,2017
+POSC,4210,1,Public Policy,0.19,0.31,0.25,0.06,0.13,0.0,0.0,0.06,adam warber,,POSC-4210,2017
+POSC,4360,1,Law Courts Politics,0.88,0.08,0.02,0.0,0.0,0.0,0.0,0.02,joseph earl stewart,,POSC-4360,2017
+POSC,4380,1,Constitut Law: Struc of Gov,0.32,0.5,0.12,0.02,0.04,0.0,0.0,0.0,daniel frost,,POSC-4380,2017
+POSC,4420,1,Pol Parties & Elect,0.25,0.36,0.23,0.16,0.0,0.0,0.0,0.0,laura olson,,POSC-4420,2017
+POSC,4470,1,International Law,0.33,0.3,0.13,0.1,0.08,0.0,0.0,0.08,katherine am curtis,,POSC-4470,2017
+POSC,4500,1,Contemporary Political Thought,0.42,0.46,0.04,0.0,0.04,0.0,0.0,0.04,daniel frost,,POSC-4500,2017
+POSC,4540,1,Southern Politics,0.11,0.5,0.33,0.0,0.0,0.0,0.0,0.06,james woodard,,POSC-4540,2017
+POSC,4550,1,Pol Thght of American Founding,0.29,0.5,0.18,0.0,0.03,0.0,0.0,0.0, bradley thompson,,POSC-4550,2017
+POSC,4560,1,Diplomacy,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,,POSC-4560,2017
+PRTM,1950,2,Pro Golf Management Seminar I,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-1950,2017
+PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.92,0.06,0.03,jamie lynn cathey,,PRTM-2070,2017
+PRTM,2200,10,Foundations of PRTM,0.32,0.42,0.12,0.02,0.03,0.0,0.0,0.08,jamie lynn cathey,,PRTM-2200,2017
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2260,2017
+PRTM,2260,2,Fnd of Mgt Adm PRTM,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,,PRTM-2260,2017
+PRTM,2260,3,Fnd of Mgt Adm PRTM,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2260,2017
+PRTM,2260,4,Fnd of Mgt Adm PRTM,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2260,2017
+PRTM,2260,5,Fnd of Mgt Adm PRTM,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,garrett stone,,PRTM-2260,2017
+PRTM,2260,6,Fnd of Mgt Adm PRTM,0.21,0.5,0.21,0.07,0.0,0.0,0.0,0.0,ryan joseph gagnon,,PRTM-2260,2017
+PRTM,2260,7,Fnd of Mgt Adm PRTM,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,brandon harris,,PRTM-2260,2017
+PRTM,2260,8,Fnd of Mgt Adm PRTM,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,,PRTM-2260,2017
+PRTM,2260,9,Fnd of Mgt Adm PRTM,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,katrina latri black,,PRTM-2260,2017
+PRTM,2270,1,Prov of Leisure Exp,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2270,2017
+PRTM,2270,2,Prov of Leisure Exp,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,,PRTM-2270,2017
+PRTM,2270,3,Prov of Leisure Exp,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2270,2017
+PRTM,2270,4,Prov of Leisure Exp,0.0,0.43,0.21,0.29,0.07,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2270,2017
+PRTM,2270,5,Prov of Leisure Exp,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,garrett stone,,PRTM-2270,2017
+PRTM,2270,6,Prov of Leisure Exp,0.29,0.21,0.36,0.07,0.07,0.0,0.0,0.0,ryan joseph gagnon,,PRTM-2270,2017
+PRTM,2270,7,Prov of Leisure Exp,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,brandon harris,,PRTM-2270,2017
+PRTM,2270,8,Prov of Leisure Exp,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,,PRTM-2270,2017
+PRTM,2270,9,Prov of Leisure Exp,0.36,0.36,0.21,0.0,0.0,0.0,0.0,0.07,emilie viktor adams,,PRTM-2270,2017
+PRTM,2290,1,Competency Integration in PRTM,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2290,2017
+PRTM,2290,2,Competency Integration in PRTM,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,,PRTM-2290,2017
+PRTM,2290,3,Competency Integration in PRTM,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2290,2017
+PRTM,2290,4,Competency Integration in PRTM,0.29,0.14,0.43,0.07,0.07,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2290,2017
+PRTM,2290,5,Competency Integration in PRTM,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,garrett stone,,PRTM-2290,2017
+PRTM,2290,6,Competency Integration in PRTM,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,ryan joseph gagnon,,PRTM-2290,2017
+PRTM,2290,7,Competency Integration in PRTM,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,brandon harris,,PRTM-2290,2017
+PRTM,2290,8,Competency Integration in PRTM,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,,PRTM-2290,2017
+PRTM,2290,9,Competency Integration in PRTM,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,emilie viktor adams,,PRTM-2290,2017
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.63,0.29,0.05,0.03,0.0,0.0,0.0,0.0,katherine an jordan,,PRTM-3050,2017
+PRTM,3070,2,Facility Operations,0.84,0.09,0.0,0.03,0.03,0.0,0.0,0.0,raymond dunham,,PRTM-3070,2017
+PRTM,3200,1,Recreation Policy,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,matthew ty brownlee,,PRTM-3200,2017
+PRTM,3210,1,Recreation Admin,0.26,0.51,0.2,0.0,0.03,0.0,0.0,0.0,gina depper,,PRTM-3210,2017
+PRTM,3220,1,Facilitation Techniques in RT,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,,PRTM-3220,2017
+PRTM,3230,1,Prof Prep for RT Practice,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,,PRTM-3230,2017
+PRTM,3240,1,Assessment & Planning in RT,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3240,2017
+PRTM,3250,1,Global Persp in Rec,0.54,0.35,0.0,0.04,0.0,0.0,0.0,0.08,harrison pinckney,,PRTM-3250,2017
+PRTM,3300,1,Visit Ser & Interp,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-3300,2017
+PRTM,3420,2,Intro to Tourism,0.52,0.21,0.12,0.06,0.09,0.0,0.0,0.0,herbert chancellor,,PRTM-3420,2017
+PRTM,3430,1,Spl Asp of Tourist B,0.4,0.51,0.09,0.0,0.0,0.0,0.0,0.0,william norman,,PRTM-3430,2017
+PRTM,3430,2,Spl Asp of Tourist B,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,'lisha fogle,,PRTM-3430,2017
+PRTM,3470,1,Sport Tourism,0.47,0.21,0.32,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,,PRTM-3470,2017
+PRTM,3900,7,Independent Study in PRTM,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3900,2017
+PRTM,3910,1,Social Media in PRTM,0.4,0.52,0.0,0.08,0.0,0.0,0.0,0.0,zeynep gedikoglu,,PRTM-3910,2017
+PRTM,3910,2,Issues & Trends in Event Mgmt.,0.92,0.0,0.08,0.0,0.0,0.0,0.0,0.0,stephanie per garst,,PRTM-3910,2017
+PRTM,3920,1,Special Event Management,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,,PRTM-3920,2017
+PRTM,3920,2,Special Event Management,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,,PRTM-3920,2017
+PRTM,4030,1,Elem of Rec/Pk Plan,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,gina depper,,PRTM-4030,2017
+PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,daniel mor anderson,,PRTM-4040,2017
+PRTM,4210,1,Rec Fin Resc Mgt,0.11,0.26,0.42,0.21,0.0,0.0,0.0,0.0,denise mar anderson,,PRTM-4210,2017
+PRTM,4220,1,Management of RT Services,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,,PRTM-4220,2017
+PRTM,4470,1,Perspect Intl Travel,0.82,0.16,0.03,0.0,0.0,0.0,0.0,0.0,lauren duffy,,PRTM-4470,2017
+PRTM,4510,1,Seminar in CRSCM,0.5,0.33,0.11,0.06,0.0,0.0,0.0,0.0,skye arthur-banning,,PRTM-4510,2017
+PRTM,4550,1,Adv Program Planning,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,mariela fernandez,,PRTM-4550,2017
+PRTM,4740,2,Adv Rec Resource Mgt,0.95,0.0,0.0,0.0,0.05,0.0,0.0,0.0,geoffrey koo riungu,,PRTM-4740,2017
+PRTM,8020,1,Group Proc in Leisure Services,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,,PRTM-8020,2017
+PRTM,8080,2,Behavioral Aspects,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-8080,2017
+PRTM,8220,2,Strateg Planning in PRTM Orgs,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,thomas john orourke,,PRTM-8220,2017
+PRTM,8700,1,Foundat & Issues in Rec Therap,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,alysha amber walter,,PRTM-8700,2017
+PRTM,8710,1,Applied Research in Rec Therap,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,,PRTM-8710,2017
+PSYC,2010,1,Intro to Psychology,0.49,0.31,0.12,0.04,0.0,0.0,0.0,0.04,jo anne jorgensen,,PSYC-2010,2017
+PSYC,2010,2,Intro to Psychology,0.42,0.35,0.13,0.06,0.01,0.0,0.0,0.03,jo anne jorgensen,,PSYC-2010,2017
+PSYC,2010,3,Intro to Psychology,0.35,0.32,0.18,0.05,0.04,0.0,0.0,0.06,edwin brainerd,,PSYC-2010,2017
+PSYC,2010,4,Intro to Psychology,0.57,0.2,0.13,0.04,0.03,0.0,0.0,0.03,chong hyon pak,,PSYC-2010,2017
+PSYC,2010,5,Intro to Psychology,0.34,0.43,0.17,0.04,0.0,0.0,0.0,0.01,mary taylor,,PSYC-2010,2017
+PSYC,2010,6,Intro to Psychology (HON),0.63,0.21,0.05,0.05,0.0,0.0,0.0,0.05,robin mari kowalski,True,PSYC-2010,2017
+PSYC,2020,2,Intro Psychology Lab,0.91,0.0,0.0,0.04,0.0,0.0,0.0,0.04,anton sytine,,PSYC-2020,2017
+PSYC,2890,1,Fundamentals of Psyc Science,0.39,0.31,0.2,0.05,0.01,0.0,0.0,0.03,cynthia pury,,PSYC-2890,2017
+PSYC,3060,1,Human Sexual Behavior,0.44,0.28,0.16,0.04,0.06,0.0,0.0,0.02,bruce michael king,,PSYC-3060,2017
+PSYC,3090,100,Intro Experimental Psychology,0.33,0.28,0.21,0.13,0.03,0.0,0.0,0.03,richard tyrrell,,PSYC-3090,2017
+PSYC,3090,200,Intro Experimental Psychology,0.45,0.32,0.13,0.06,0.03,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3090,2017
+PSYC,3090,300,Intro Experimental Psychology,0.67,0.2,0.03,0.07,0.0,0.0,0.0,0.03,leah hartman,,PSYC-3090,2017
+PSYC,3100,100,Advanced Experimental Psych,0.38,0.38,0.19,0.05,0.0,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3100,2017
+PSYC,3100,200,Advanced Experimental Psych,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert campbell,,PSYC-3100,2017
+PSYC,3100,300,Advanced Experimental Psych,0.35,0.45,0.05,0.05,0.05,0.0,0.0,0.05,gargi sawhney,,PSYC-3100,2017
+PSYC,3100,400,Advanced Experimental Psych,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2017
+PSYC,3100,500,Advanced Experimental Psych,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2017
+PSYC,3240,1,Physiological Psych,0.3,0.35,0.16,0.07,0.06,0.0,0.0,0.06,claudio cantalupo,,PSYC-3240,2017
+PSYC,3240,2,Physiological Psych,0.28,0.32,0.26,0.07,0.03,0.0,0.0,0.04,june pilcher,,PSYC-3240,2017
+PSYC,3310,1,Critical Thinking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,leo gugerty,,PSYC-3310,2017
+PSYC,3330,1,Cognitive Psych,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,robert campbell,,PSYC-3330,2017
+PSYC,3330,2,Cognitive Psych,0.39,0.26,0.2,0.09,0.03,0.0,0.0,0.03,kaileigh ange byrne,,PSYC-3330,2017
+PSYC,3330,3,Cognitive Psych,0.36,0.33,0.23,0.04,0.03,0.0,0.0,0.0,madison eliza sauls,,PSYC-3330,2017
+PSYC,3340,1,Cognitive Psych Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3340,2017
+PSYC,3340,2,Cognitive Psych Lab,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,leo gugerty,,PSYC-3340,2017
+PSYC,3400,1,Lifespan Developmental Psych,0.6,0.28,0.09,0.03,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3400,2017
+PSYC,3400,2,Lifespan Developmental Psych,0.21,0.4,0.25,0.07,0.0,0.0,0.0,0.07,pamela alley,,PSYC-3400,2017
+PSYC,3520,1,Social Psychology,0.41,0.25,0.21,0.06,0.02,0.0,0.0,0.05,eric mckibben,,PSYC-3520,2017
+PSYC,3640,1,Industrial Psych,0.34,0.49,0.14,0.03,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-3640,2017
+PSYC,3640,2,Industrial Psych,0.26,0.43,0.26,0.03,0.01,0.0,0.0,0.0,eric mckibben,,PSYC-3640,2017
+PSYC,3680,1,Organizational Psych,0.27,0.31,0.3,0.1,0.01,0.0,0.0,0.0,thomas britt,,PSYC-3680,2017
+PSYC,3680,2,Organizational Psych,0.3,0.36,0.2,0.06,0.04,0.0,0.0,0.03,dana verhoeven,,PSYC-3680,2017
+PSYC,3690,1,Leadership in Organiz Settings,0.29,0.33,0.21,0.08,0.02,0.0,0.0,0.06,patrick raymark,,PSYC-3690,2017
+PSYC,3700,1,Personality,0.31,0.5,0.15,0.01,0.0,0.0,0.0,0.03,eric mckibben,,PSYC-3700,2017
+PSYC,3700,2,Personality,0.28,0.41,0.23,0.04,0.0,0.0,0.0,0.04,john robert hester,,PSYC-3700,2017
+PSYC,3830,1,Abnormal Psychology,0.43,0.33,0.12,0.03,0.04,0.0,0.0,0.04,heidi marie zinzow,,PSYC-3830,2017
+PSYC,3830,2,Abnormal Psychology,0.34,0.55,0.06,0.0,0.02,0.0,0.0,0.02,lucinda sorci quick,,PSYC-3830,2017
+PSYC,3830,3,Abnormal Psychology,0.29,0.43,0.2,0.06,0.0,0.0,0.0,0.03,pamela alley,,PSYC-3830,2017
+PSYC,3830,4,Abnormal Psychology,0.16,0.34,0.13,0.16,0.13,0.0,0.0,0.09,pamela alley,,PSYC-3830,2017
+PSYC,3890,1,Cross-Cultural Psychology,0.62,0.21,0.07,0.0,0.1,0.0,0.0,0.0,ceren gunsoy,,PSYC-3890,2017
+PSYC,4080,1,Women and Psychology,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,robin mari kowalski,,PSYC-4080,2017
+PSYC,4150,2,Systems and Theories,0.29,0.41,0.09,0.09,0.12,0.0,0.0,0.0,edwin brainerd,,PSYC-4150,2017
+PSYC,4150,3,Systems and Theories,0.44,0.24,0.09,0.12,0.03,0.0,0.0,0.09,edwin brainerd,,PSYC-4150,2017
+PSYC,4220,1,Perception,0.36,0.16,0.2,0.08,0.12,0.0,0.0,0.08,claudio cantalupo,,PSYC-4220,2017
+PSYC,4220,2,Perception,0.27,0.35,0.31,0.04,0.0,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2017
+PSYC,4220,3,Perception,0.22,0.33,0.19,0.19,0.04,0.0,0.0,0.04,christopher pagano,,PSYC-4220,2017
+PSYC,4220,4,Perception,0.36,0.28,0.2,0.08,0.0,0.0,0.0,0.08,christopher pagano,,PSYC-4220,2017
+PSYC,4350,1,Human Factors,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,laura whitlock,,PSYC-4350,2017
+PSYC,4350,2,Human Factors,0.42,0.42,0.05,0.05,0.05,0.0,0.0,0.0,laura whitlock,,PSYC-4350,2017
+PSYC,4560,1,Psychophysiology,0.39,0.28,0.28,0.06,0.0,0.0,0.0,0.0,drew michael morris,,PSYC-4560,2017
+PSYC,4800,1,Health Psychology,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2017
+PSYC,4800,2,Health Psychology,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2017
+PSYC,4890,1,Teamwork Dynamics,0.88,0.04,0.04,0.0,0.04,0.0,0.0,0.0,marissa leig porter,,PSYC-4890,2017
+PSYC,4920,1,Senior Laboratory,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,,PSYC-4920,2017
+PSYC,4920,2,Senior Laboratory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,,PSYC-4920,2017
+PSYC,4920,3,Senior Laboratory,0.89,0.04,0.04,0.0,0.04,0.0,0.0,0.0,nastassia ma savage,,PSYC-4920,2017
+PSYC,4920,5,Senior Laboratory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,drea kevin fekety,,PSYC-4920,2017
+PSYC,8100,1,Research Design I,0.65,0.27,0.05,0.0,0.0,0.0,0.0,0.03,patrick rosopa,,PSYC-8100,2017
+PSYC,8620,1,Org Psychology,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,,PSYC-8620,2017
+PSYC,8730,1,SEM in Applied Psychology,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, dewayne moore,,PSYC-8730,2017
+RED,8000,1,Real Estate Dvlpment,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8000,2017
+RED,8010,1,Market Analysis,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,thomas andrew fox,,RED-8010,2017
+RED,8040,1,Resid Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8040,2017
+RED,8050,1,Commercial Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8050,2017
+RED,8130,1,Strat in Real Estate,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,,RED-8130,2017
+RED,8170,1,Mixed-Use Development Seminar,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,tor wallace-babcock,,RED-8170,2017
+RED,8890,1,Selected Topics-Adv. Fin. Mod.,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,larry bradle harvey,,RED-8890,2017
+REL,1010,1,Intro to Religion,0.22,0.33,0.22,0.17,0.0,0.0,0.0,0.06,peter cohen,,REL-1010,2017
+REL,1010,2,Intro to Religion,0.34,0.26,0.23,0.06,0.03,0.0,0.0,0.09,peter cohen,,REL-1010,2017
+REL,1010,3,Intro to Religion,0.29,0.51,0.11,0.0,0.0,0.0,0.0,0.09,brett patterson,,REL-1010,2017
+REL,1010,4,Intro to Religion,0.29,0.47,0.0,0.18,0.06,0.0,0.0,0.0,peter cohen,,REL-1010,2017
+REL,1010,5,Intro to Religion,0.17,0.51,0.14,0.03,0.03,0.0,0.0,0.11,brett patterson,,REL-1010,2017
+REL,1020,2,World Religions,0.4,0.43,0.14,0.0,0.0,0.0,0.0,0.03,robert stephens,,REL-1020,2017
+REL,1020,3,World Religions,0.35,0.5,0.12,0.03,0.0,0.0,0.0,0.0,robert stephens,,REL-1020,2017
+REL,1020,4,World Religions,0.2,0.6,0.14,0.03,0.03,0.0,0.0,0.0,robert stephens,,REL-1020,2017
+REL,1020,5,World Religions,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,brett patterson,,REL-1020,2017
+REL,3010,1,Old Testament,0.42,0.48,0.09,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3010,2017
+REL,3020,1,New Testament Lit,0.47,0.38,0.03,0.0,0.03,0.0,0.0,0.09,benjamin white,,REL-3020,2017
+REL,3080,1,Religions of the Ancient World,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3080,2017
+REL,3100,1,History of Religion in the US,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,elizabeth jemison,,REL-3100,2017
+REL,3150,1,Islam,0.53,0.27,0.07,0.0,0.13,0.0,0.0,0.0,robert stephens,,REL-3150,2017
+REL,4520,1,History of Early Christianity,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,benjamin white,,REL-4520,2017
+RS,3010,1,Rural Sociology,0.53,0.37,0.0,0.05,0.0,0.0,0.0,0.05,kenneth robinson,,RS-3010,2017
+RS,4590,1,The Community,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,,RS-4590,2017
+RUSS,1010,1,Elementary Russian,0.5,0.31,0.06,0.06,0.0,0.0,0.0,0.06,stephanie el morris,,RUSS-1010,2017
+RUSS,1010,2,Elementary Russian,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,stephanie el morris,,RUSS-1010,2017
+RUSS,3400,1,19th C Russ Culture,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,olga anatol volkova,,RUSS-3400,2017
+RUSS,3610,1,Russn Lit Since 1910,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,,RUSS-3610,2017
+SOC,2010,2,Introduction to Sociology,0.94,0.04,0.01,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,,SOC-2010,2017
+SOC,2010,3,Introduction to Sociology,0.79,0.18,0.02,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,,SOC-2010,2017
+SOC,2010,4,Introduction to Sociology,0.53,0.34,0.13,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2017
+SOC,2010,5,Introduction to Sociology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,stacy leanne smith,,SOC-2010,2017
+SOC,2010,6,Introduction to Sociology,0.81,0.15,0.02,0.0,0.0,0.0,0.0,0.02,stacy leanne smith,,SOC-2010,2017
+SOC,2010,7,Introduction to Sociology,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,stacy leanne smith,,SOC-2010,2017
+SOC,2010,8,Introduction to Sociology,0.8,0.12,0.04,0.02,0.0,0.0,0.0,0.02,stacy leanne smith,,SOC-2010,2017
+SOC,2010,9,Introduction to Sociology,0.36,0.41,0.16,0.04,0.0,0.0,0.0,0.03,carolyn can coffman,,SOC-2010,2017
+SOC,2010,10,Introduction to Sociology,0.53,0.39,0.05,0.01,0.0,0.0,0.0,0.01,carolyn can coffman,,SOC-2010,2017
+SOC,2010,11,Introduction to Sociology,0.48,0.41,0.05,0.05,0.02,0.0,0.0,0.0,carolyn can coffman,,SOC-2010,2017
+SOC,2010,12,Introduction to Sociology,0.69,0.22,0.06,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2017
+SOC,2010,13,Introduction to Sociology,0.71,0.23,0.02,0.01,0.02,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2017
+SOC,2010,14,Introduction to Sociology,0.6,0.25,0.08,0.0,0.02,0.0,0.0,0.04,shannon mcdonough,,SOC-2010,2017
+SOC,2020,1,Social Problems,0.51,0.4,0.02,0.0,0.02,0.0,0.0,0.04,carolyn can coffman,,SOC-2020,2017
+SOC,3020,1,Research Methods I,0.44,0.26,0.23,0.05,0.02,0.0,0.0,0.0,andrew whitehead,,SOC-3020,2017
+SOC,3040,1,Social Research Methods II,0.32,0.45,0.14,0.09,0.0,0.0,0.0,0.0,ye luo,,SOC-3040,2017
+SOC,3110,1,The Family,0.3,0.53,0.15,0.0,0.02,0.0,0.0,0.0,andrew whitehead,,SOC-3110,2017
+SOC,3310,1,Urban Sociology,0.87,0.03,0.05,0.0,0.05,0.0,0.0,0.0,william haller,,SOC-3310,2017
+SOC,3910,1,Soc of Deviance,0.34,0.32,0.26,0.06,0.02,0.0,0.0,0.0,shannon mcdonough,,SOC-3910,2017
+SOC,3920,1,Juvenile Delinquency,0.76,0.15,0.06,0.0,0.0,0.0,0.0,0.03,angelia turner,,SOC-3920,2017
+SOC,3940,1,Sociology of Mental Illness,0.6,0.3,0.06,0.0,0.02,0.0,0.0,0.02,douglas sturkie,,SOC-3940,2017
+SOC,4040,1,Soc Theory,0.31,0.26,0.17,0.17,0.03,0.0,0.0,0.06,stacy leanne smith,,SOC-4040,2017
+SOC,4140,1,Policy&Social Change,0.54,0.3,0.16,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-4140,2017
+SOC,4330,1,Global Social Change,0.41,0.41,0.17,0.0,0.0,0.0,0.0,0.0,traci ann hefner,,SOC-4330,2017
+SOC,4440,1,Sociology of Educ,0.61,0.26,0.1,0.0,0.03,0.0,0.0,0.0,andrew mannheimer,,SOC-4440,2017
+SOC,4590,1,The Community,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,kenneth robinson,,SOC-4590,2017
+SOC,4600,1,Race & Ethnicity,0.91,0.07,0.0,0.0,0.02,0.0,0.0,0.0,william haller,,SOC-4600,2017
+SOC,4610,1,Sex & Gender,0.43,0.41,0.13,0.0,0.0,0.0,0.0,0.02,traci ann hefner,,SOC-4610,2017
+SOC,4970,1,Senior Lab,0.71,0.26,0.0,0.03,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-4970,2017
+SOC,8030,1,Sur Dsgn App Res Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,,SOC-8030,2017
+SPAN,1010,1,Elementary Spanish,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,scott harris,,SPAN-1010,2017
+SPAN,1010,2,Elementary Spanish,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2017
+SPAN,1010,3,Elementary Spanish,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2017
+SPAN,1020,1,Elementary Spanish,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1020,2017
+SPAN,1020,2,Elementary Spanish,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,,SPAN-1020,2017
+SPAN,1020,3,Elementary Spanish,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,,SPAN-1020,2017
+SPAN,1020,4,Elementary Spanish,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,danie garcia vieyra,,SPAN-1020,2017
+SPAN,1020,5,Elementary Spanish,0.67,0.06,0.11,0.06,0.0,0.0,0.0,0.11,danie garcia vieyra,,SPAN-1020,2017
+SPAN,1020,6,Elementary Spanish,0.24,0.41,0.24,0.06,0.06,0.0,0.0,0.0,cathy robison,,SPAN-1020,2017
+SPAN,1020,7,Elementary Spanish,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,cathy robison,,SPAN-1020,2017
+SPAN,1020,8,Elementary Spanish,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-1020,2017
+SPAN,1020,10,Elementary Spanish,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-1020,2017
+SPAN,1020,11,Elementary Spanish,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-1020,2017
+SPAN,1020,12,Elementary Spanish,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-1020,2017
+SPAN,1020,13,Elementary Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-1020,2017
+SPAN,2010,1,Intermediate Spanish,0.41,0.35,0.18,0.06,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2017
+SPAN,2010,2,Intermediate Spanish,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2017
+SPAN,2010,3,Intermediate Spanish,0.47,0.18,0.12,0.12,0.0,0.0,0.0,0.12,melva margu persico,,SPAN-2010,2017
+SPAN,2010,4,Intermediate Spanish,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-2010,2017
+SPAN,2010,5,Intermediate Spanish,0.81,0.0,0.06,0.0,0.06,0.0,0.0,0.06,danie garcia vieyra,,SPAN-2010,2017
+SPAN,2010,6,Intermediate Spanish,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,danie garcia vieyra,,SPAN-2010,2017
+SPAN,2010,7,Intermediate Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-2010,2017
+SPAN,2010,8,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-2010,2017
+SPAN,2010,9,Intermediate Spanish,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,william da holcombe,,SPAN-2010,2017
+SPAN,2010,10,Intermediate Spanish,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2017
+SPAN,2010,11,Intermediate Spanish,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,,SPAN-2010,2017
+SPAN,2010,12,Intermediate Spanish,0.68,0.05,0.21,0.05,0.0,0.0,0.0,0.0,al garcia rodriguez,,SPAN-2010,2017
+SPAN,2010,13,Intermediate Spanish,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,,SPAN-2010,2017
+SPAN,2010,14,Intermediate Spanish,0.5,0.31,0.13,0.0,0.0,0.0,0.0,0.06,maureen zamora,,SPAN-2010,2017
+SPAN,2010,15,Intermediate Spanish,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william da holcombe,,SPAN-2010,2017
+SPAN,2010,16,Intermediate Spanish,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,ellory schmucker,,SPAN-2010,2017
+SPAN,2010,17,Intermediate Spanish,0.79,0.07,0.0,0.07,0.0,0.0,0.0,0.07,ze cruz valderramos,,SPAN-2010,2017
+SPAN,2010,19,Intermediate Spanish,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,,SPAN-2010,2017
+SPAN,2020,1,Intermediate Spanish,0.25,0.56,0.13,0.0,0.06,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2017
+SPAN,2020,2,Intermediate Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2017
+SPAN,2020,3,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2017
+SPAN,2020,4,Intermediate Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2017
+SPAN,2020,5,Intermediate Spanish,0.39,0.44,0.11,0.06,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2020,2017
+SPAN,2020,6,Intermediate Spanish,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,ze cruz valderramos,,SPAN-2020,2017
+SPAN,2020,7,Intermediate Spanish,0.71,0.06,0.18,0.06,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2020,2017
+SPAN,2020,8,Intermediate Spanish,0.37,0.32,0.21,0.05,0.0,0.0,0.0,0.05,ana paula  miller,,SPAN-2020,2017
+SPAN,2020,9,Intermediate Spanish,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2017
+SPAN,2020,10,Intermediate Spanish,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2017
+SPAN,2020,11,Intermediate Spanish,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,ze cruz valderramos,,SPAN-2020,2017
+SPAN,2020,12,Intermediate Spanish,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,,SPAN-2020,2017
+SPAN,2020,13,Intermediate Spanish,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,nora arostegu logue,,SPAN-2020,2017
+SPAN,2020,14,Intermediate Spanish,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,,SPAN-2020,2017
+SPAN,3020,1,Int Spn Gram & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-3020,2017
+SPAN,3020,2,Int Spn Gram & Comp,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,melva margu persico,,SPAN-3020,2017
+SPAN,3040,1,Intro Hisp Lit Forms,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-3040,2017
+SPAN,3050,1,Int Con Comp Span I,0.29,0.29,0.24,0.06,0.0,0.0,0.0,0.12,juana martin-armas,,SPAN-3050,2017
+SPAN,3050,2,Int Con Comp Span I,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,juana martin-armas,,SPAN-3050,2017
+SPAN,3050,3,Int Con Comp Span I,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,raquel anido,,SPAN-3050,2017
+SPAN,3050,4,Int Con Comp Span I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,,SPAN-3050,2017
+SPAN,3060,1,Span Comp for Bus,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-3060,2017
+SPAN,3070,1,Hispanic World: Sp,0.53,0.37,0.0,0.05,0.05,0.0,0.0,0.0,salvador oropesa,,SPAN-3070,2017
+SPAN,3070,2,Hispanic World: Sp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,,SPAN-3070,2017
+SPAN,3080,1,Hispanic World: La,0.19,0.5,0.19,0.06,0.06,0.0,0.0,0.0,tiffany dawn miller,,SPAN-3080,2017
+SPAN,3110,1,Surv Span-Amer Lit,0.38,0.38,0.08,0.0,0.0,0.0,0.0,0.15,tiffany dawn miller,,SPAN-3110,2017
+SPAN,3130,2,Span Lit Survey I,0.38,0.38,0.08,0.0,0.08,0.0,0.0,0.08,mon rojas-de-massei,,SPAN-3130,2017
+SPAN,4030,1,Span Amer Wom Writer,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-4030,2017
+STAT,2220,1,Statistics in Everyday Life,0.33,0.37,0.21,0.06,0.02,0.0,0.0,0.01,james espey,,STAT-2220,2017
+STAT,2220,2,Statistics in Everyday Life,0.41,0.32,0.17,0.06,0.01,0.0,0.0,0.03,james espey,,STAT-2220,2017
+STAT,2220,3,Statistics in Everyday Life,0.34,0.41,0.16,0.06,0.01,0.0,0.0,0.02,james espey,,STAT-2220,2017
+STAT,2220,4,Statistics in Everyday Life,0.43,0.31,0.09,0.08,0.06,0.0,0.0,0.03,james espey,,STAT-2220,2017
+STAT,2220,5,Statistics in Everyday Life,0.25,0.34,0.27,0.02,0.04,0.0,0.0,0.07,ros martinez-dawson,,STAT-2220,2017
+STAT,2220,6,Statistics in Everyday Life,0.42,0.42,0.05,0.0,0.05,0.0,0.0,0.05,jason alexande kurz,,STAT-2220,2017
+STAT,2220,7,Statistics in Everyday Life,0.26,0.47,0.16,0.11,0.0,0.0,0.0,0.0,jason alexande kurz,,STAT-2220,2017
+STAT,2220,100,Stats in Everyday Life (HON),0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ros martinez-dawson,True,STAT-2220,2017
+STAT,2300,1,Statistical Methods I,0.28,0.37,0.18,0.09,0.05,0.0,0.0,0.03,christy jenki brown,,STAT-2300,2017
+STAT,2300,2,Statistical Methods I,0.38,0.34,0.13,0.05,0.06,0.0,0.0,0.04,christy jenki brown,,STAT-2300,2017
+STAT,2300,3,Statistical Methods I,0.27,0.33,0.21,0.08,0.06,0.0,0.0,0.05, erwin walker,,STAT-2300,2017
+STAT,2300,4,Statistical Methods I,0.25,0.45,0.14,0.07,0.05,0.0,0.0,0.04, erwin walker,,STAT-2300,2017
+STAT,2300,5,Statistical Methods I,0.24,0.32,0.28,0.05,0.06,0.0,0.0,0.05,william bridges,,STAT-2300,2017
+STAT,2300,6,Statistical Methods I,0.18,0.38,0.18,0.09,0.09,0.0,0.0,0.07,william bridges,,STAT-2300,2017
+STAT,2300,100,Statistical Methods I (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christy jenki brown,True,STAT-2300,2017
+STAT,3090,1,Introductory Business Stats,0.37,0.26,0.26,0.0,0.05,0.0,0.0,0.05,todd fenstermacher,,STAT-3090,2017
+STAT,3090,2,Introductory Business Stats,0.22,0.33,0.11,0.17,0.11,0.0,0.0,0.06,todd fenstermacher,,STAT-3090,2017
+STAT,3090,3,Introductory Business Stats,0.16,0.37,0.16,0.11,0.21,0.0,0.0,0.0,boyoung hur,,STAT-3090,2017
+STAT,3090,4,Introductory Business Stats,0.05,0.32,0.16,0.11,0.32,0.0,0.0,0.05,boyoung hur,,STAT-3090,2017
+STAT,3090,5,Introductory Business Stats,0.05,0.26,0.26,0.16,0.21,0.0,0.0,0.05,andrew pangia,,STAT-3090,2017
+STAT,3090,6,Introductory Business Stats,0.11,0.33,0.39,0.0,0.11,0.0,0.0,0.06,andrew pangia,,STAT-3090,2017
+STAT,3090,7,Introductory Business Stats,0.22,0.33,0.22,0.06,0.17,0.0,0.0,0.0,tiantian yang,,STAT-3090,2017
+STAT,3090,8,Introductory Business Stats,0.17,0.28,0.22,0.22,0.11,0.0,0.0,0.0,april thomas,,STAT-3090,2017
+STAT,3090,9,Introductory Business Stats,0.11,0.11,0.26,0.11,0.26,0.0,0.0,0.16,feng gao,,STAT-3090,2017
+STAT,3090,10,Introductory Business Stats,0.17,0.28,0.33,0.11,0.06,0.0,0.0,0.06,bryce pruitt,,STAT-3090,2017
+STAT,3090,11,Introductory Business Stats,0.26,0.16,0.26,0.16,0.16,0.0,0.0,0.0,yisu jia,,STAT-3090,2017
+STAT,3090,12,Introductory Business Stats,0.37,0.37,0.16,0.0,0.0,0.0,0.0,0.11,lu sun,,STAT-3090,2017
+STAT,3090,13,Introductory Business Stats,0.34,0.3,0.18,0.09,0.06,0.0,0.0,0.03,sharon marie evans,,STAT-3090,2017
+STAT,3090,14,Introductory Business Stats,0.5,0.22,0.28,0.0,0.0,0.0,0.0,0.0,kayla doris javier,,STAT-3090,2017
+STAT,3090,15,Introductory Business Stats,0.19,0.22,0.34,0.05,0.14,0.0,0.0,0.05,matthew saltzman,,STAT-3090,2017
+STAT,3090,16,Introductory Business Stats,0.39,0.28,0.17,0.06,0.11,0.0,0.0,0.0,jiajing niu,,STAT-3090,2017
+STAT,3090,18,Introductory Business Stats,0.05,0.58,0.26,0.05,0.05,0.0,0.0,0.0,bryce pruitt,,STAT-3090,2017
+STAT,3090,19,Introductory Business Stats,0.16,0.26,0.47,0.0,0.0,0.0,0.0,0.11,rui gong,,STAT-3090,2017
+STAT,3090,20,Introductory Business Stats,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,jiajing niu,,STAT-3090,2017
+STAT,3090,22,Introductory Business Stats,0.16,0.42,0.16,0.05,0.05,0.0,0.0,0.16,tiantian yang,,STAT-3090,2017
+STAT,3090,23,Introductory Business Stats,0.26,0.32,0.11,0.16,0.05,0.0,0.0,0.11,tianhui wei,,STAT-3090,2017
+STAT,3090,24,Introductory Business Stats,0.11,0.37,0.26,0.05,0.05,0.0,0.0,0.16,tianhui wei,,STAT-3090,2017
+STAT,3090,25,Introductory Business Stats,0.26,0.37,0.16,0.16,0.0,0.0,0.0,0.05,liu zhu,,STAT-3090,2017
+STAT,3090,26,Introductory Business Stats,0.26,0.21,0.16,0.16,0.21,0.0,0.0,0.0,april thomas,,STAT-3090,2017
+STAT,3090,27,Introductory Business Stats,0.26,0.11,0.16,0.21,0.16,0.0,0.0,0.11,feng gao,,STAT-3090,2017
+STAT,3090,28,Introductory Business Stats,0.33,0.56,0.0,0.06,0.0,0.0,0.0,0.06,lu sun,,STAT-3090,2017
+STAT,3090,30,Introductory Business Stats,0.53,0.26,0.05,0.11,0.05,0.0,0.0,0.0,liu zhu,,STAT-3090,2017
+STAT,3090,31,Introductory Business Stats,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,kayla doris javier,,STAT-3090,2017
+STAT,3090,33,Introductory Business Stats,0.28,0.25,0.32,0.05,0.08,0.0,0.0,0.02,sharon marie evans,,STAT-3090,2017
+STAT,3090,34,Introductory Business Stats,0.32,0.32,0.16,0.05,0.11,0.0,0.0,0.05,rui gong,,STAT-3090,2017
+STAT,3090,35,Introductory Business Stats,0.3,0.21,0.39,0.06,0.0,0.0,0.0,0.03,margaret mar wiecek,,STAT-3090,2017
+STAT,3090,36,Introductory Business Stats,0.17,0.24,0.36,0.17,0.0,0.0,0.0,0.07,matthew saltzman,,STAT-3090,2017
+STAT,3090,37,Introductory Business Stats,0.26,0.16,0.47,0.0,0.05,0.0,0.0,0.05,yisu jia,,STAT-3090,2017
+STAT,3300,1,Statistical Methods II,0.38,0.44,0.06,0.0,0.06,0.0,0.0,0.06,ros martinez-dawson,,STAT-3300,2017
+STAT,4020,1,Intro to Statistical Computing,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,ellen hepfe breazel,,STAT-4020,2017
+STAT,4110,1,Stat Mthds for Process Control,0.82,0.11,0.05,0.0,0.02,0.0,0.0,0.0,richard stev dubsky,,STAT-4110,2017
+STAT,4110,2,Stat Mthds for Process Control,0.85,0.12,0.02,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,,STAT-4110,2017
+STAT,4110,3,Stat Mthds for Process Control,0.64,0.27,0.06,0.03,0.0,0.0,0.0,0.0,richard stev dubsky,,STAT-4110,2017
+STAT,6020,1,Intro to Statistical Computing,0.33,0.25,0.08,0.0,0.0,0.0,0.0,0.33,ellen hepfe breazel,,STAT-6020,2017
+STAT,8010,1,Statistical Methods I,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,james rieck,,STAT-8010,2017
+STAT,8010,2,Statistical Methods I,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,patrick gerard,,STAT-8010,2017
+STAT,8010,3,Statistical Methods I,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,joseph daniel bible,,STAT-8010,2017
+STAT,8010,4,Statistical Methods I,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,,STAT-8010,2017
+STAT,8010,5,Statistical Methods I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jun luo,,STAT-8010,2017
+STAT,8010,6,Statistical Methods I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,brook thaye russell,,STAT-8010,2017
+STAT,8010,7,Statistical Methods I,0.44,0.33,0.17,0.0,0.06,0.0,0.0,0.0,james rieck,,STAT-8010,2017
+STAT,8020,1,Statistical Methods II,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,brook thaye russell,,STAT-8020,2017
+STAT,8030,1,Regress & Least Squares Anlys,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,jun luo,,STAT-8030,2017
+STAT,8170,400,Multivariate Statistics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,,STAT-8170,2017
+STS,1010,1,Survey of S T S,0.68,0.27,0.0,0.0,0.03,0.0,0.0,0.03,kenneth dav widgren,,STS-1010,2017
+STS,1010,2,Survey of S T S,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,scott brame,,STS-1010,2017
+STS,1010,3,Survey of S T S,0.51,0.32,0.03,0.0,0.05,0.0,0.0,0.08,elizabeth stansell,,STS-1010,2017
+STS,1010,5,Survey of S T S,0.47,0.39,0.14,0.0,0.0,0.0,0.0,0.0,philip randall,,STS-1010,2017
+STS,1010,6,Survey of S T S,0.4,0.23,0.17,0.09,0.0,0.0,0.0,0.11,sarah mae cooper,,STS-1010,2017
+STS,1010,7,Survey of S T S,0.5,0.14,0.28,0.0,0.06,0.0,0.0,0.03,megan no macalystre,,STS-1010,2017
+STS,1010,8,Survey of S T S,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,david charles foltz,,STS-1010,2017
+STS,1010,9,Survey of S T S,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,melissa dugan,,STS-1010,2017
+THEA,2100,1,Theatre Appreciation,0.53,0.19,0.16,0.0,0.03,0.0,0.0,0.09,kendra lyne johnson,,THEA-2100,2017
+THEA,2100,2,Theatre Appreciation,0.81,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kerrie kath seymour,,THEA-2100,2017
+THEA,2100,3,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,,THEA-2100,2017
+THEA,2100,4,Theatre Appreciation,0.81,0.13,0.03,0.03,0.0,0.0,0.0,0.0,richard st. peter,,THEA-2100,2017
+THEA,2100,5,Theatre Appreciation,0.81,0.13,0.03,0.0,0.0,0.0,0.0,0.03,carol collins,,THEA-2100,2017
+THEA,2100,6,Theatre Appreciation,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,,THEA-2100,2017
+THEA,2100,7,Theatre Appreciation,0.53,0.28,0.13,0.0,0.0,0.0,0.0,0.06,jason adkins,,THEA-2100,2017
+THEA,2670,1,Stage Makeup,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,,THEA-2670,2017
+THEA,2790,1,Theatre Practicum,0.38,0.25,0.0,0.0,0.06,0.0,0.0,0.31,matthew leckenbusch,,THEA-2790,2017
+THEA,2880,1,Intro to Cad,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,,THEA-2880,2017
+THEA,3150,1,Theatre History I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,richard st. peter,,THEA-3150,2017
+THEA,3170,1,African-Amer Thea I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-3170,2017
+THEA,3470,1,Structure of Drama,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-3470,2017
+THEA,3980,1,Special Topics in Theatre,0.57,0.21,0.14,0.0,0.0,0.0,0.0,0.07,kerrie kath seymour,,THEA-3980,2017
+THEA,4870,1,Stage Lighting I,0.33,0.42,0.08,0.0,0.08,0.0,0.0,0.08,anthony penna,,THEA-4870,2017
+WFB,3000,1,Wildlife Biology,0.48,0.27,0.17,0.03,0.02,0.0,0.0,0.03,catherine jachowski,,WFB-3000,2017
+WFB,3000,2,Wildlife Biology,0.45,0.35,0.14,0.02,0.01,0.0,0.0,0.02,catherine jachowski,,WFB-3000,2017
+WFB,3010,2,Wildlife Biology Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2017
+WFB,4100,2,Wildlife Management Techniques,0.25,0.54,0.13,0.07,0.0,0.0,0.0,0.02,james davis,,WFB-4100,2017
+WFB,4180,1,Fisheries Mgt & Conservation,0.67,0.19,0.11,0.0,0.0,0.0,0.0,0.04,troy mason farmer,,WFB-4180,2017
+WFB,4440,1,Wildlife Damage Management,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,james davis,,WFB-4440,2017
+WFB,4720,1,Ornithology,0.42,0.25,0.17,0.08,0.0,0.0,0.0,0.08,neil smith,,WFB-4720,2017
+WFB,4770,1,Ichthyology,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,brandon kev peoples,,WFB-4770,2017
+WFB,4930,2,Plant & Flora ID/Systematics,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,patrick mcmillan,,WFB-4930,2017
+WFB,4930,3,Waterfowl Ecology,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,,WFB-4930,2017
+WFB,8180,2,Waterfowl Ecology & Mgt,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,,WFB-8180,2017
+WFB,8530,2,Global Change Ecology,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,lydia ri 'halloran,,WFB-8530,2017
+WS,1030,1,Women in Global Perspective,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,laura foxworth,,WS-1030,2017
+WS,1030,2,Women in Global Perspective,0.67,0.13,0.1,0.07,0.0,0.0,0.0,0.03,laura foxworth,,WS-1030,2017
+WS,2300,1,Women and Leadership I,0.68,0.16,0.08,0.0,0.04,0.0,0.0,0.04,mary price,,WS-2300,2017
+WS,3010,1,Intro Women's Studies,0.58,0.35,0.03,0.0,0.03,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2017
+WS,3010,2,Intro Women's Studies,0.48,0.41,0.03,0.0,0.0,0.0,0.0,0.07,elizabeth ros adams,,WS-3010,2017
+YDP,3000,400,Youth Development in Society,0.54,0.33,0.0,0.08,0.04,0.0,0.0,0.0,barry garst,,YDP-3000,2017
+YDP,3050,400,Theory/Phil of Youth Dev Work,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,edmond patri bowers,,YDP-3050,2017
+YDP,3200,1,Youth Dev in Sport/Phys Activ,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,lauren eli stephens,,YDP-3200,2017
+YDP,3300,1,Designing Effective Youth Prog,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,kellye rembert,,YDP-3300,2017
+YDP,3350,1,Youth Activity Leadership,0.5,0.17,0.17,0.11,0.06,0.0,0.0,0.0,allison mic avishai,,YDP-3350,2017
+YDP,3450,1,Creative Activities for Youth,0.87,0.0,0.09,0.04,0.0,0.0,0.0,0.0,kimberly pe johnson,,YDP-3450,2017
+YDP,8000,1,Theories of Youth Development,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,,YDP-8000,2017
+YDP,8030,1,Creative & Ethical Leadership,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,barry garst,,YDP-8030,2017
+YDP,8050,1,Youth Dev in Context of Family,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,,YDP-8050,2017
+YDP,8060,1,Youth Dev in Global Society,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,ann marie gillard,,YDP-8060,2017
+YDP,8060,2,Youth Dev in Global Society,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,ann marie gillard,,YDP-8060,2017

--- a/bot/cogs/grades_cog/assets/2017_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2017_Fall.csv
@@ -1,2817 +1,2817 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1010,1,Survey of Art & Arch History I,0.4,0.45,0.1,0.0,0.01,0.0,0.0,0.05,beth ann lauritis,AAH-1010,2017
-AAH,1010,2,Surv of Art & Arch I (HON),0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,beth ann lauritis,AAH-1010,2017
-AAH,2050,1,Art History and Theory I,0.79,0.15,0.0,0.0,0.06,0.0,0.0,0.0,beth ann lauritis,AAH-2050,2017
-AAH,3050,1,Contemporary Art History,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,AAH-3050,2017
-ACCT,2010,1,Financial Accounting Concepts,0.18,0.35,0.2,0.12,0.08,0.0,0.0,0.06,emily suza mccorkle,ACCT-2010,2017
-ACCT,2010,2,Financial Accounting Concepts,0.21,0.44,0.25,0.04,0.04,0.0,0.0,0.02,emily suza mccorkle,ACCT-2010,2017
-ACCT,2010,3,Financial Accounting Concepts,0.3,0.43,0.11,0.04,0.04,0.0,0.0,0.09,lydia lan schleifer,ACCT-2010,2017
-ACCT,2010,4,Financial Accounting Concepts,0.28,0.33,0.22,0.09,0.0,0.0,0.0,0.09,emily suza mccorkle,ACCT-2010,2017
-ACCT,2010,5,Financial Accounting Concepts,0.34,0.24,0.28,0.08,0.04,0.0,0.0,0.02,annieka philo,ACCT-2010,2017
-ACCT,2010,6,Financial Accounting Concepts,0.33,0.31,0.13,0.1,0.04,0.0,0.0,0.08,lydia lan schleifer,ACCT-2010,2017
-ACCT,2010,7,Financial Accounting Concepts,0.24,0.37,0.2,0.1,0.08,0.0,0.0,0.0,annieka philo,ACCT-2010,2017
-ACCT,2010,8,Financial Accounting Concepts,0.24,0.39,0.12,0.06,0.1,0.0,0.0,0.08,lydia lan schleifer,ACCT-2010,2017
-ACCT,2010,9,Financial Accounting Concepts,0.21,0.56,0.13,0.02,0.08,0.0,0.0,0.0,annieka philo,ACCT-2010,2017
-ACCT,2010,10,Financial Accounting Concepts,0.36,0.3,0.22,0.02,0.04,0.0,0.0,0.06,annieka philo,ACCT-2010,2017
-ACCT,2010,11,Financial Accounting Concepts,0.29,0.43,0.16,0.08,0.02,0.0,0.0,0.02,rebecca pennel trax,ACCT-2010,2017
-ACCT,2010,12,Financial Accounting Concepts,0.3,0.26,0.23,0.09,0.06,0.0,0.0,0.06,rebecca pennel trax,ACCT-2010,2017
-ACCT,2010,13,Financial Accounting Concepts,0.22,0.35,0.17,0.13,0.09,0.0,0.0,0.04,charles tegen,ACCT-2010,2017
-ACCT,2010,14,Financial Accounting Concepts,0.27,0.41,0.18,0.04,0.08,0.0,0.0,0.02,lisa whe birtwistle,ACCT-2010,2017
-ACCT,2010,100,Fin Accounting Concepts (HON),0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,lisa whe birtwistle,ACCT-2010,2017
-ACCT,2010,400,Financial Accounting Concepts,0.29,0.34,0.19,0.1,0.05,0.0,0.0,0.02,emily suza mccorkle,ACCT-2010,2017
-ACCT,2020,1,Managerial Accounting Concepts,0.36,0.22,0.22,0.02,0.0,0.0,0.0,0.18,henry anderson,ACCT-2020,2017
-ACCT,2020,2,Managerial Accounting Concepts,0.36,0.3,0.1,0.0,0.06,0.0,0.0,0.18,henry anderson,ACCT-2020,2017
-ACCT,2020,3,Managerial Accounting Concepts,0.28,0.28,0.13,0.02,0.06,0.0,0.0,0.23,henry anderson,ACCT-2020,2017
-ACCT,2020,4,Managerial Accounting Concepts,0.29,0.31,0.18,0.07,0.04,0.0,0.0,0.11,phebia davis-culler,ACCT-2020,2017
-ACCT,2020,5,Managerial Accounting Concepts,0.28,0.15,0.2,0.22,0.11,0.0,0.0,0.04,phebia davis-culler,ACCT-2020,2017
-ACCT,2020,6,Managerial Accounting Concepts,0.21,0.09,0.38,0.09,0.15,0.0,0.0,0.09,phebia davis-culler,ACCT-2020,2017
-ACCT,2020,7,Managerial Accounting Concepts,0.09,0.27,0.24,0.11,0.07,0.0,0.0,0.22,brian todd carver,ACCT-2020,2017
-ACCT,2020,8,Managerial Accounting Concepts,0.16,0.19,0.23,0.07,0.14,0.0,0.0,0.21,brian todd carver,ACCT-2020,2017
-ACCT,2020,400,Managerial Accounting Concepts,0.35,0.24,0.15,0.03,0.04,0.0,0.0,0.19,henry anderson,ACCT-2020,2017
-ACCT,3030,1,Cost Accounting,0.32,0.41,0.18,0.0,0.02,0.0,0.0,0.07,robin radtke,ACCT-3030,2017
-ACCT,3030,2,Cost Accounting,0.32,0.32,0.26,0.03,0.08,0.0,0.0,0.0,robin radtke,ACCT-3030,2017
-ACCT,3030,3,Cost Accounting,0.23,0.34,0.27,0.09,0.0,0.0,0.0,0.07,jace garrett,ACCT-3030,2017
-ACCT,3030,4,Cost Accounting,0.2,0.33,0.16,0.13,0.11,0.0,0.0,0.07,jace garrett,ACCT-3030,2017
-ACCT,3110,1,Intermediate Financial Acct I,0.33,0.42,0.18,0.02,0.04,0.0,0.0,0.0,amy meliss donnelly,ACCT-3110,2017
-ACCT,3110,2,Intermediate Financial Acct I,0.32,0.28,0.28,0.1,0.02,0.0,0.0,0.0,amy meliss donnelly,ACCT-3110,2017
-ACCT,3110,3,Intermediate Financial Acct I,0.53,0.24,0.18,0.04,0.0,0.0,0.0,0.0,erin michel hawkins,ACCT-3110,2017
-ACCT,3110,4,Intermediate Financial Acct I,0.28,0.33,0.33,0.04,0.02,0.0,0.0,0.0,erin michel hawkins,ACCT-3110,2017
-ACCT,3110,400,Intermediate Financial Acct I,0.32,0.32,0.13,0.04,0.08,0.0,0.0,0.11,henry anderson,ACCT-3110,2017
-ACCT,3120,1,Intermediate Financial Acct II,0.14,0.5,0.14,0.07,0.0,0.0,0.0,0.14,terry daniel knause,ACCT-3120,2017
-ACCT,3120,2,Intermediate Financial Acct II,0.14,0.32,0.41,0.05,0.09,0.0,0.0,0.0,jeremy micha vinson,ACCT-3120,2017
-ACCT,3120,3,Intermediate Financial Acct II,0.63,0.16,0.16,0.05,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2017
-ACCT,3120,4,Intermediate Financial Acct II,0.18,0.43,0.3,0.08,0.0,0.0,0.0,0.03,jeremy micha vinson,ACCT-3120,2017
-ACCT,3120,5,Intermediate Financial Acct II,0.45,0.33,0.2,0.03,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2017
-ACCT,3120,6,Intermediate Financial Acct II,0.43,0.43,0.1,0.05,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2017
-ACCT,3130,1,Intermediate Fin Acct III,0.22,0.22,0.28,0.08,0.11,0.0,0.0,0.08, russell madray,ACCT-3130,2017
-ACCT,3130,2,Intermediate Fin Acct III,0.25,0.39,0.2,0.09,0.02,0.0,0.0,0.05, russell madray,ACCT-3130,2017
-ACCT,3130,3,Intermediate Fin Acct III,0.37,0.29,0.2,0.1,0.0,0.0,0.0,0.05, russell madray,ACCT-3130,2017
-ACCT,3130,4,Intermediate Fin Acct III,0.33,0.33,0.21,0.05,0.05,0.0,0.0,0.02, russell madray,ACCT-3130,2017
-ACCT,3220,1,Accounting Information Systems,0.11,0.42,0.26,0.0,0.05,0.0,0.0,0.16,philip maiberger,ACCT-3220,2017
-ACCT,3220,2,Accounting Information Systems,0.06,0.19,0.25,0.31,0.0,0.0,0.0,0.19,philip maiberger,ACCT-3220,2017
-ACCT,3220,3,Accounting Information Systems,0.12,0.42,0.28,0.12,0.02,0.0,0.0,0.05,nancy lee harp,ACCT-3220,2017
-ACCT,3220,4,Accounting Information Systems,0.17,0.36,0.24,0.07,0.1,0.0,0.0,0.07,nancy lee harp,ACCT-3220,2017
-ACCT,4040,1,Individual Taxation,0.33,0.33,0.18,0.08,0.03,0.0,0.0,0.05,derek dalton,ACCT-4040,2017
-ACCT,4040,2,Individual Taxation,0.8,0.11,0.06,0.03,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2017
-ACCT,4040,3,Individual Taxation,0.72,0.21,0.08,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2017
-ACCT,4080,1,Retire & Estate Plan,0.32,0.42,0.16,0.05,0.0,0.0,0.0,0.05,john hine,ACCT-4080,2017
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.16,0.55,0.13,0.13,0.0,0.0,0.0,0.03,sally kathr widener,ACCT-4100,2017
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.38,0.41,0.21,0.0,0.0,0.0,0.0,0.0,sally kathr widener,ACCT-4100,2017
-ACCT,4150,1,Auditing,0.34,0.39,0.21,0.05,0.0,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2017
-ACCT,4150,2,Auditing,0.19,0.38,0.29,0.1,0.05,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2017
-ACCT,8510,1,Tax Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2017
-ACCT,8510,2,Tax Research,0.26,0.74,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2017
-ACCT,8510,3,Tax Research,0.61,0.37,0.0,0.0,0.0,0.0,0.0,0.02,thomas dickens,ACCT-8510,2017
-ACCT,8530,1,Adv Acct Problems,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8530,2017
-ACCT,8530,2,Adv Acct Problems,0.61,0.34,0.02,0.0,0.0,0.0,0.0,0.02,ralph welton,ACCT-8530,2017
-ACCT,8530,3,Adv Acct Problems,0.48,0.39,0.06,0.0,0.03,0.0,0.0,0.03,ralph welton,ACCT-8530,2017
-ACCT,8550,1,Gov't and Nonprofit Accounting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2017
-ACCT,8550,2,Gov't and Nonprofit Accounting,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,james barnes,ACCT-8550,2017
-ACCT,8630,1,Forensics Analysis,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,philip maiberger,ACCT-8630,2017
-ACCT,8630,2,Forensics Analysis,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,philip maiberger,ACCT-8630,2017
-ACCT,8650,1,Tax & Bus Decisions,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,ACCT-8650,2017
-ACCT,8720,1,Tax of Flowthroughs,0.34,0.48,0.16,0.0,0.0,0.0,0.0,0.02,thomas dickens,ACCT-8720,2017
-AGED,1020,1,Freshman Seminar,0.76,0.12,0.06,0.0,0.0,0.0,0.0,0.06,catheri dibenedetto,AGED-1020,2017
-AGED,2000,1,Agr Appl of Ed Tech,0.67,0.17,0.1,0.0,0.0,0.0,0.0,0.07,kevin layfield,AGED-2000,2017
-AGED,2010,1,Intro to Agric Educ,0.59,0.37,0.0,0.0,0.0,0.0,0.0,0.04,philip fravel,AGED-2010,2017
-AGED,2040,1,App Ag Calculations,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2040,2017
-AGED,3030,1,Ag Ed Mech Tech,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-3030,2017
-AGED,4000,1,Supervised Field Experience II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-4000,2017
-AGED,4010,1,Instr Methods Ag Ed,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,AGED-4010,2017
-AGED,4030,1,Prin Adult/Ext Ed,0.41,0.29,0.18,0.06,0.0,0.0,0.0,0.06,alex byrd,AGED-4030,2017
-AGED,4230,400,Curriculum,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,AGED-4230,2017
-AGED,6030,1,Prin Adult/Ext Ed,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-6030,2017
-AGM,1010,1,Intro Ag Mech & Bus,0.71,0.15,0.08,0.02,0.04,0.0,0.0,0.0,hunter massey,AGM-1010,2017
-AGM,2050,1,Prin of Fabrication,0.3,0.54,0.09,0.02,0.02,0.0,0.0,0.04,hunter massey,AGM-2050,2017
-AGM,2060,1,Machinery Mgt,0.38,0.33,0.19,0.05,0.05,0.0,0.0,0.0,hunter massey,AGM-2060,2017
-AGM,2210,1,Land Measurements,0.26,0.56,0.17,0.01,0.0,0.0,0.0,0.0,charles privette,AGM-2210,2017
-AGM,3010,1,Soil Water Conserv,0.47,0.31,0.18,0.04,0.0,0.0,0.0,0.0,calvin sawyer,AGM-3010,2017
-AGM,4000,1,Seminar in Ag Mech & Business,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,john chastain,AGM-4000,2017
-AGM,4020,1,Irrigation System Design,0.23,0.43,0.27,0.03,0.03,0.0,0.0,0.0,charles privette,AGM-4020,2017
-AGM,4050,1,Env Cont in Anim Str,0.12,0.34,0.46,0.02,0.05,0.0,0.0,0.0,john chastain,AGM-4050,2017
-AGM,4060,1,Mech & Hydraulic Sys,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4060,2017
-AGM,4520,1,Mobile Power,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4520,2017
-AGM,4600,1,Electrical Systems,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,young han,AGM-4600,2017
-AGRB,2020,1,Agricultural Economics,0.17,0.27,0.29,0.12,0.1,0.0,0.0,0.06,george apperson,AGRB-2020,2017
-AGRB,2020,2,Agricultural Economics,0.12,0.42,0.15,0.18,0.09,0.0,0.0,0.03,george apperson,AGRB-2020,2017
-AGRB,2050,1,Agriculture and Society,0.2,0.29,0.45,0.04,0.02,0.0,0.0,0.0,michael vassalos,AGRB-2050,2017
-AGRB,3020,1,Economics of Farm Management,0.18,0.28,0.3,0.21,0.01,0.0,0.0,0.02,michael vassalos,AGRB-3020,2017
-AGRB,3080,1,Quant Agribusiness Analysis I,0.25,0.33,0.24,0.13,0.04,0.0,0.0,0.01,lisha zhang,AGRB-3080,2017
-AGRB,3090,1,Econ of Agricultural Marketing,0.5,0.38,0.08,0.02,0.02,0.0,0.0,0.0,yuliya val bolotova,AGRB-3090,2017
-AGRB,3190,1,Agribusiness Management,0.28,0.23,0.18,0.13,0.08,0.0,0.0,0.1,michael vassalos,AGRB-3190,2017
-AGRB,3570,1,Natural Resources Economics,0.2,0.18,0.27,0.13,0.09,0.0,0.0,0.13,david brian willis,AGRB-3570,2017
-AGRB,4090,1,Commodity Futures Markets,0.16,0.24,0.3,0.19,0.11,0.0,0.0,0.0,george apperson,AGRB-4090,2017
-AGRB,4120,1,Reg Econ Devel Theory & Policy,0.57,0.31,0.1,0.0,0.0,0.0,0.0,0.02,lori ann dickes,AGRB-4120,2017
-AGRB,4600,1,Agricultural Finance,0.2,0.43,0.33,0.05,0.0,0.0,0.0,0.0,lisha zhang,AGRB-4600,2017
-AL,3490,400,Principles of Coaching,0.66,0.21,0.07,0.03,0.0,0.0,0.0,0.03,deborah cadorette,AL-3490,2017
-AL,3490,401,Principles of Coaching,0.52,0.37,0.07,0.04,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2017
-AL,3490,403,Principles of Coaching,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,clyde keith connor,AL-3490,2017
-AL,3490,404,Principles of Coaching,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,edmond fry,AL-3490,2017
-AL,3500,400,Sci Basis I/Ex Phy,0.12,0.36,0.2,0.12,0.04,0.0,0.0,0.16,michael godfrey,AL-3500,2017
-AL,3500,401,Sci Basis I/Ex Phy,0.29,0.25,0.25,0.13,0.0,0.0,0.0,0.08,michael godfrey,AL-3500,2017
-AL,3530,400,Athletic Injuries,0.42,0.21,0.29,0.08,0.0,0.0,0.0,0.0,isaac sean colbert,AL-3530,2017
-AL,3530,401,Athletic Injuries,0.11,0.44,0.22,0.11,0.11,0.0,0.0,0.0,isaac sean colbert,AL-3530,2017
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.27,0.27,0.0,0.07,0.0,0.0,0.07,clyde keith connor,AL-3600,2017
-AL,3610,400,Admin/Org of Athletic Programs,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,henry oates,AL-3610,2017
-AL,3610,401,Admin/Org of Athletic Programs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2017
-AL,3610,402,Admin/Org of Athletic Programs,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2017
-AL,3620,400,Psychology of Coaching,0.65,0.18,0.06,0.0,0.0,0.0,0.0,0.12,natalie anne carter,AL-3620,2017
-AL,3620,401,Psychology of Coaching,0.41,0.12,0.24,0.18,0.06,0.0,0.0,0.0,natalie anne carter,AL-3620,2017
-AL,3620,402,Psychology of Coaching,0.29,0.54,0.08,0.04,0.0,0.0,0.0,0.04,natalie anne carter,AL-3620,2017
-AL,3740,400,Coaching Football,0.78,0.09,0.04,0.0,0.04,0.0,0.0,0.04,edmond fry,AL-3740,2017
-AL,3760,400,Coaching Strength/Conditioning,0.79,0.13,0.0,0.04,0.04,0.0,0.0,0.0,edmond fry,AL-3760,2017
-AL,3760,401,Coaching Strength/Conditioning,0.71,0.0,0.21,0.0,0.07,0.0,0.0,0.0,edmond fry,AL-3760,2017
-AL,4380,402,Coaching the Inner Athlete,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,deborah cadorette,AL-4380,2017
-AL,4380,403,Media Relations in AL,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,AL-4380,2017
-AL,4380,404,Coaching the Inner Athlete,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-4380,2017
-AL,4380,408,Officiating in AL,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,clyde keith connor,AL-4380,2017
-AL,8440,400,Surv of Res Mthds in Athletics,0.82,0.06,0.12,0.0,0.0,0.0,0.0,0.0,russell marion,AL-8440,2017
-AL,8440,401,Surv of Res Mthds in Athletics,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,russell marion,AL-8440,2017
-AL,8490,401,Athletic Leadership Dev,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,michael godfrey,AL-8490,2017
-AL,8500,400,Principles Strength and Condit,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8500,2017
-AL,8500,401,Principles Strength and Condit,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,michael godfrey,AL-8500,2017
-AL,8650,400,Mkt and Comm Respon Interc Ath,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,misty soles,AL-8650,2017
-ANTH,2010,1,Introduction to Anthropology,0.06,0.23,0.28,0.16,0.11,0.0,0.0,0.17,john coggeshall,ANTH-2010,2017
-ANTH,2010,2,Introduction to Anthropology,0.0,0.24,0.29,0.24,0.12,0.0,0.0,0.12,john coggeshall,ANTH-2010,2017
-ANTH,2010,3,Introduction to Anthropology,0.44,0.37,0.11,0.02,0.02,0.0,0.0,0.04,yi wu,ANTH-2010,2017
-ANTH,2010,4,Introduction to Anthropology,0.46,0.2,0.15,0.09,0.06,0.0,0.0,0.04,yi wu,ANTH-2010,2017
-ANTH,2010,5,Introduction to Anthropology,0.4,0.37,0.1,0.02,0.03,0.0,0.0,0.08,lisa rapaport,ANTH-2010,2017
-ANTH,3010,1,Cultural Anthropology,0.04,0.32,0.44,0.04,0.0,0.0,0.0,0.16,john coggeshall,ANTH-3010,2017
-ANTH,3320,1,World Archaeology,0.72,0.11,0.0,0.11,0.06,0.0,0.0,0.0,elizabeth wakefield,ANTH-3320,2017
-ANTH,3510,1,Biological Anthropology,0.16,0.21,0.32,0.26,0.05,0.0,0.0,0.0,lisa rapaport,ANTH-3510,2017
-ANTH,3530,1,Forensic Anthropology,0.25,0.45,0.3,0.0,0.0,0.0,0.0,0.0,katherine weisensee,ANTH-3530,2017
-ANTH,3710,1,Language and Culture,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,yanhua zhang,ANTH-3710,2017
-ANTH,4230,1,Women in the Developing World,0.64,0.27,0.0,0.09,0.0,0.0,0.0,0.0,melissa vogel,ANTH-4230,2017
-ARCH,1010,1,Intro to Architecture,0.63,0.17,0.07,0.02,0.02,0.0,0.0,0.09,sal hambright-belue,ARCH-1010,2017
-ARCH,2040,1,Hist of Modern Arch,0.33,0.51,0.14,0.02,0.0,0.0,0.0,0.0,robert bruhns,ARCH-2040,2017
-ARCH,2510,1,Arch Foundations I,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-2510,2017
-ARCH,2510,2,Arch Foundations I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-2510,2017
-ARCH,2510,3,Arch Foundations I,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2510,2017
-ARCH,2510,4,Arch Foundations I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,joseph schott,ARCH-2510,2017
-ARCH,2510,5,Arch Foundations I,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,criss mills,ARCH-2510,2017
-ARCH,2700,1,Structures I,0.28,0.59,0.1,0.03,0.0,0.0,0.0,0.0,dustin gra albright,ARCH-2700,2017
-ARCH,3500,1,Intro to Urban Contexts,0.29,0.5,0.14,0.07,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-3500,2017
-ARCH,3500,2,Intro to Urban Contexts,0.25,0.17,0.42,0.17,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-3500,2017
-ARCH,3500,3,Intro to Urban Contexts,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-3500,2017
-ARCH,3500,4,Intro to Urban Contexts,0.08,0.42,0.42,0.08,0.0,0.0,0.0,0.0,george schafer,ARCH-3500,2017
-ARCH,3500,5,Intro to Urban Contexts,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-3500,2017
-ARCH,3510,2,Studio Clemson,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,ARCH-3510,2017
-ARCH,3540,1,Studio Barcelona,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-3540,2017
-ARCH,4010,1,Architectural Portfolio,0.62,0.19,0.1,0.0,0.05,0.0,0.0,0.05,clarissa mendez,ARCH-4010,2017
-ARCH,4010,2,Architectural Portfolio,0.43,0.24,0.29,0.0,0.0,0.0,0.0,0.05,herminia sil machry,ARCH-4010,2017
-ARCH,4010,3,Architectural Portfolio,0.36,0.59,0.0,0.05,0.0,0.0,0.0,0.0,george schafer,ARCH-4010,2017
-ARCH,6240,1,Product Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-6240,2017
-ARCH,6850,1,H/Th: Arch+Health,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-6850,2017
-ARCH,8100,1,Visualization I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,ARCH-8100,2017
-ARCH,8210,1,Research Methods,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-8210,2017
-ARCH,8410,1,Arch Studio I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,peter laurence,ARCH-8410,2017
-ARCH,8410,2,Arch Studio I,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,andreea mihalache,ARCH-8410,2017
-ARCH,8510,2,Design Studio III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8510,2017
-ARCH,8510,3,Design Studio III,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-8510,2017
-ARCH,8570,6,Design Studio V,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-8570,2017
-ARCH,8600,1,History/Theory I,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-8600,2017
-ARCH,8720,1,Production & Assemb,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,ARCH-8720,2017
-ARCH,8810,1,Pro Practice Survey,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,ARCH-8810,2017
-ARCH,8860,1,Health Facilities,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8860,2017
-ARCH,8890,1,Mentorship,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,ARCH-8890,2017
-ARCH,8970,1,A+H Studio: Hospital,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8970,2017
-ART,1050,1,Foundation Drawing I,0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,kathleen ann thum,ART-1050,2017
-ART,1510,1,Foundations Art I,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,kymberly ann day,ART-1510,2017
-ART,2070,1,Beginning Painting,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,dustin lee massey,ART-2070,2017
-ART,2100,400,Art Appreciation,0.57,0.25,0.14,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2017
-ART,2100,401,Art Appreciation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2017
-ART,2100,402,Art Appreciation,0.68,0.18,0.04,0.0,0.07,0.0,0.0,0.04,lydia jane dorsey,ART-2100,2017
-ART,2100,403,Art Appreciation,0.32,0.43,0.14,0.0,0.04,0.0,0.0,0.07,lydia jane dorsey,ART-2100,2017
-ART,2110,1,Begin Printmaking,0.56,0.31,0.06,0.0,0.06,0.0,0.0,0.0,mandy lora ferguson,ART-2110,2017
-ART,2130,1,Begin Photography,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,amber nic eckersley,ART-2130,2017
-ART,2210,1,Beginning New Media,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,christina nguy hung,ART-2210,2017
-ART,8210,1,Visual Narrative,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,ART-8210,2017
-AS,1090,1,Air Force Today I,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,michael allen moore,AS-1090,2017
-AS,1090,2,Air Force Today I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1090,2017
-AS,1090,3,Air Force Today I,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,michael allen moore,AS-1090,2017
-AS,2090,2,Dev of Air Power I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brock lusk,AS-2090,2017
-AS,2090,3,Dev of Air Power I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2090,2017
-AS,3090,2,A F Leadership Mgt I,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,rachelle mar miller,AS-3090,2017
-AS,4090,1,Nat Sec Policy I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4090,2017
-ASL,1010,1,Am Sign Lang I,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jason hurdich,ASL-1010,2017
-ASL,1010,2,Am Sign Lang I,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-1010,2017
-ASL,1010,3,Am Sign Lang I,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,william ry clements,ASL-1010,2017
-ASL,1010,5,Am Sign Lang I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,william ry clements,ASL-1010,2017
-ASL,1020,1,Am Sign Lang I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-1020,2017
-ASL,2010,1,Am Sign Lang II,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-2010,2017
-ASL,2010,2,Am Sign Lang II,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,jason hurdich,ASL-2010,2017
-ASL,2010,3,Am Sign Lang II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william ry clements,ASL-2010,2017
-ASL,2010,4,Am Sign Lang II,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william ry clements,ASL-2010,2017
-ASL,3010,1,Advanced A S L I,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kim ma misener dunn,ASL-3010,2017
-ASTR,1010,1,Solar System Astronomy,0.36,0.41,0.1,0.05,0.05,0.0,0.0,0.02,amber porter,ASTR-1010,2017
-ASTR,1010,2,Solar System Astronomy,0.41,0.37,0.13,0.02,0.05,0.0,0.0,0.02,amber porter,ASTR-1010,2017
-ASTR,1020,1,Stellar Astronomy,0.24,0.38,0.26,0.05,0.01,0.0,0.0,0.05,marco ajello,ASTR-1020,2017
-ASTR,1030,1,Solar Systm Astr Lab,0.64,0.27,0.0,0.0,0.05,0.0,0.0,0.05,amber porter,ASTR-1030,2017
-ASTR,1030,2,Solar Systm Astr Lab,0.78,0.09,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,ASTR-1030,2017
-ASTR,1030,3,Solar Systm Astr Lab,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,amber porter,ASTR-1030,2017
-ASTR,1030,4,Solar Systm Astr Lab,0.67,0.17,0.13,0.0,0.0,0.0,0.0,0.04,amber porter,ASTR-1030,2017
-ASTR,1030,5,Solar Systm Astr Lab,0.23,0.64,0.05,0.09,0.0,0.0,0.0,0.0,amber porter,ASTR-1030,2017
-ASTR,1030,6,Solar Systm Astr Lab,0.57,0.26,0.13,0.0,0.0,0.0,0.0,0.04,amber porter,ASTR-1030,2017
-ASTR,1030,7,Solar Systm Astr Lab,0.5,0.28,0.06,0.06,0.0,0.0,0.0,0.11,amber porter,ASTR-1030,2017
-ASTR,1030,8,Solar Systm Astr Lab,0.26,0.53,0.16,0.05,0.0,0.0,0.0,0.0,amber porter,ASTR-1030,2017
-ASTR,1030,9,Solar Systm Astr Lab,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,amber porter,ASTR-1030,2017
-ASTR,1030,10,Solar Systm Astr Lab,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,amber porter,ASTR-1030,2017
-ASTR,1040,1,Stellar Astr Lab,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,amber porter,ASTR-1040,2017
-ASTR,1040,2,Stellar Astr Lab,0.52,0.3,0.0,0.0,0.09,0.0,0.0,0.09,amber porter,ASTR-1040,2017
-ASTR,1040,4,Stellar Astr Lab,0.41,0.37,0.11,0.04,0.0,0.0,0.0,0.07,amber porter,ASTR-1040,2017
-ASTR,8100,1,Astroph I: Radiation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,ASTR-8100,2017
-AUD,1850,1,Intro to Audio Tech,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-1850,2017
-AUD,2800,1,Sound Reinforcement,0.0,0.17,0.75,0.08,0.0,0.0,0.0,0.0,kenneth moore,AUD-2800,2017
-AUE,4010,1,Vehicle Dynamics,0.3,0.5,0.1,0.0,0.1,0.0,0.0,0.0,imtiaz ul haque,AUE-4010,2017
-AUE,4030,1,Automotive Engr Project Tools,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,andrej ivanco,AUE-4030,2017
-AUE,8180,1,"Engine Analysis, Design & Exp",0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8180,2017
-AUE,8260,1,Vehicle Diagnostics,0.34,0.54,0.11,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8260,2017
-AUE,8270,5,Auto Cntrl Sys Des,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8270,2017
-AUE,8280,1,Driveline/Powertrain,0.61,0.26,0.13,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8280,2017
-AUE,8330,30,Auto Manuf Proc Devl,0.18,0.74,0.08,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8330,2017
-AUE,8350,100,Auto Electronics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,AUE-8350,2017
-AUE,8670,1,Veh Manuf Proc I,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8670,2017
-AUE,8810,3,Automotive Systems Overview,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,AUE-8810,2017
-AUE,8870,8,Meth Vehicle Testing,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8870,2017
-AUE,8930,16,Light-Weight Automotive Design,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,david wil schmueser,AUE-8930,2017
-AUE,8930,18,Adv IC Engine Concept,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-8930,2017
-AUE,8930,19,Autovation II: Tech Enterp Dev,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,AUE-8930,2017
-AUE,8930,89,Manufacturing,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,AUE-8930,2017
-AVS,1000,1,Orientation to AVS,0.92,0.05,0.01,0.01,0.0,0.0,0.0,0.01,marie owens bolt,AVS-1000,2017
-AVS,1500,1,Intro Animal Science,0.2,0.4,0.21,0.09,0.06,0.0,0.0,0.03,joseph kei bertrand,AVS-1500,2017
-AVS,1510,1,Intro Ani Sci Lab,0.46,0.46,0.04,0.0,0.0,0.0,0.0,0.04,richelle lor miller,AVS-1510,2017
-AVS,1510,2,Intro Ani Sci Lab,0.68,0.2,0.04,0.0,0.0,0.0,0.0,0.08,richelle lor miller,AVS-1510,2017
-AVS,1510,3,Intro Ani Sci Lab,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-1510,2017
-AVS,1510,4,Intro Ani Sci Lab,0.77,0.09,0.09,0.0,0.0,0.0,0.0,0.05,chelsea dr sinclair,AVS-1510,2017
-AVS,1510,5,Intro Ani Sci Lab,0.72,0.24,0.0,0.04,0.0,0.0,0.0,0.0,marie owens bolt,AVS-1510,2017
-AVS,1510,6,Intro Ani Sci Lab,0.71,0.21,0.04,0.04,0.0,0.0,0.0,0.0,marie owens bolt,AVS-1510,2017
-AVS,1510,7,Intro Ani Sci Lab,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,chelsea dr sinclair,AVS-1510,2017
-AVS,1510,8,Intro Ani Sci Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,marie owens bolt,AVS-1510,2017
-AVS,2020,1,CAFLS Plus,0.91,0.05,0.0,0.0,0.05,0.0,0.0,0.0,thomas scott,AVS-2020,2017
-AVS,2030,1,Dairy Sci Techniques,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,heather walker dunn,AVS-2030,2017
-AVS,2040,1,Horse Care Techniques,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-2040,2017
-AVS,2060,1,Swine Techniques,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-2060,2017
-AVS,3010,1,Anat & Phys Dom Ani,0.42,0.34,0.21,0.03,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2017
-AVS,3010,400,Anat & Phys Dom Ani,0.27,0.31,0.29,0.12,0.0,0.0,0.0,0.02,glenn birrenkott,AVS-3010,2017
-AVS,3020,1,Livestk Sel Eval I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-3020,2017
-AVS,3100,1,Animal Health,0.52,0.33,0.16,0.0,0.0,0.0,0.0,0.0,celina marc checura,AVS-3100,2017
-AVS,3700,1,Principles of Animal Nutrition,0.68,0.19,0.08,0.03,0.01,0.0,0.0,0.0,james ro strickland,AVS-3700,2017
-AVS,3750,1,Applied Animal Nutrition,0.38,0.38,0.13,0.06,0.0,0.0,0.0,0.06,gustavo jos lascano,AVS-3750,2017
-AVS,3850,1,Equine Behavior and Training,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,chelsea dr sinclair,AVS-3850,2017
-AVS,4000,1,AVS Professional Development,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,marie owens bolt,AVS-4000,2017
-AVS,4000,2,AVS Professional Development,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,marie owens bolt,AVS-4000,2017
-AVS,4060,1,Seminars & Related Topics,0.57,0.37,0.07,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2017
-AVS,4060,2,Seminars & Related Topics,0.13,0.69,0.19,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2017
-AVS,4110,1,Animal Growth and Development,0.59,0.21,0.14,0.03,0.03,0.0,0.0,0.0,susan kay duckett,AVS-4110,2017
-AVS,4150,1,Contemporary Issues in AVS,0.3,0.33,0.19,0.05,0.05,0.0,0.0,0.09,peter skewes,AVS-4150,2017
-AVS,4160,1,Equine Exercise Phys,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-4160,2017
-AVS,4500,1,Sust Livestock Sys,0.36,0.57,0.0,0.0,0.0,0.0,0.0,0.07,matias jose aguerre,AVS-4500,2017
-AVS,4530,1,Animal Reproduction,0.54,0.32,0.11,0.04,0.0,0.0,0.0,0.0,tiffany wilmoth,AVS-4530,2017
-AVS,4650,1,Animal Physiology I,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,celina marc checura,AVS-4650,2017
-AVS,4800,1,Vertebrate Endocrinology,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,heather walker dunn,AVS-4800,2017
-AVS,6650,1,Animal Physiology I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,celina marc checura,AVS-6650,2017
-BCHM,1030,1,Careers in Bioch/Gen,0.88,0.07,0.0,0.01,0.03,0.0,0.0,0.01,joseph paul thames,BCHM-1030,2017
-BCHM,3010,1,Molecular Biochemistry,0.35,0.26,0.13,0.06,0.06,0.0,0.0,0.13,kerry smith,BCHM-3010,2017
-BCHM,3050,1,Essen Elements Bioch,0.65,0.23,0.07,0.01,0.01,0.0,0.0,0.03,debra ragland,BCHM-3050,2017
-BCHM,3050,2,Essen Elements Bioch,0.43,0.34,0.14,0.02,0.01,0.0,0.0,0.05,debra ragland,BCHM-3050,2017
-BCHM,4310,1,Physical Approach to Biochem,0.24,0.43,0.3,0.04,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4310,2017
-BCHM,4310,2,Phys App to Bioch (HON),0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4310,2017
-BCHM,4330,1,Physical Biochemistry Lab,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-4330,2017
-BCHM,4400,1,Bioinformatics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,BCHM-4400,2017
-BCHM,4430,1,Mol Basis Disease,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,james morris,BCHM-4430,2017
-BCHM,8140,1,Advanced Biochemistry,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,cheryl ingram-smith,BCHM-8140,2017
-BE,2120,1,Fundamentals of Biosys Engr,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,caye marie drapcho,BE-2120,2017
-BE,3200,1,Principles & Prac of Geomatics,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,tom owino,BE-3200,2017
-BE,4100,1,Biological Kinetics,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4100,2017
-BE,4210,1,Engr Sys for Soil Water Mgt,0.67,0.27,0.0,0.07,0.0,0.0,0.0,0.0,christophe darnault,BE-4210,2017
-BE,4280,1,Biochem Engr,0.33,0.33,0.25,0.08,0.0,0.0,0.0,0.0,terry walker,BE-4280,2017
-BE,4740,1,BE Design Project Managment,0.73,0.15,0.12,0.0,0.0,0.0,0.0,0.0,tom owino,BE-4740,2017
-BE,4750,1,BE Capstone Design,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4750,2017
-BIOE,2010,1,Intro Biomed Engr,0.25,0.5,0.06,0.0,0.0,0.0,0.0,0.19,charles webb,BIOE-2010,2017
-BIOE,2010,2,Intro Biomed Engr,0.46,0.39,0.05,0.01,0.01,0.0,0.0,0.08,charles webb,BIOE-2010,2017
-BIOE,3020,1,Biomaterials,0.61,0.27,0.04,0.04,0.04,0.0,0.0,0.02,alexey ale vertegel,BIOE-3020,2017
-BIOE,3100,1,Engr Analysis of Physiol Proc,0.55,0.43,0.01,0.0,0.0,0.0,0.0,0.0,brian william booth,BIOE-3100,2017
-BIOE,3200,1,Biomechanics,0.74,0.22,0.0,0.01,0.0,0.0,0.0,0.03,jiro nagatomi,BIOE-3200,2017
-BIOE,3210,1,Biofluid Mechanics,0.55,0.33,0.09,0.0,0.0,0.0,0.0,0.03,zhi gao,BIOE-3210,2017
-BIOE,3700,1,Bioinst & Imaging,0.67,0.24,0.03,0.0,0.0,0.0,0.0,0.06,delphine dean,BIOE-3700,2017
-BIOE,4010,1,Bioengineering Design Theory,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,john desjardins,BIOE-4010,2017
-BIOE,4010,2,Bioengineering Design Theory,0.95,0.03,0.03,0.0,0.0,0.0,0.0,0.0,john desjardins,BIOE-4010,2017
-BIOE,4030,1,Applied Bio E Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,BIOE-4030,2017
-BIOE,4120,1,Orthopaedic Engr and Pathology,0.5,0.35,0.1,0.0,0.0,0.0,0.0,0.05,melinda harman,BIOE-4120,2017
-BIOE,4400,1,Biopharmaceutical Engineering,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,sarah harcum,BIOE-4400,2017
-BIOE,4500,3,Biofabrication,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,BIOE-4500,2017
-BIOE,6120,1,Orthopaedic Engr & Pathology,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,BIOE-6120,2017
-BIOE,6400,1,Biopharmaceutical Engineering,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sarah harcum,BIOE-6400,2017
-BIOE,8010,1,Bio Materials,0.31,0.59,0.06,0.0,0.0,0.0,0.0,0.03,robert latour,BIOE-8010,2017
-BIOE,8020,410,Biocompatibility,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,BIOE-8020,2017
-BIOE,8140,401,Medical Dev Commercialization,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,david orr,BIOE-8140,2017
-BIOE,8160,1,BioE Professional Development,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,martine laberge,BIOE-8160,2017
-BIOE,8200,1,Structl Biomechanics,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,hai yao,BIOE-8200,2017
-BIOE,8240,1,Cell & Mol Tissue Engineering,0.67,0.0,0.17,0.0,0.0,0.0,0.0,0.17,jeoungsoo lee,BIOE-8240,2017
-BIOL,1010,1,Frontiers in Biology I,0.83,0.11,0.05,0.01,0.01,0.0,0.0,0.0,robert edwa ballard,BIOL-1010,2017
-BIOL,1010,2,Frontiers in Biology I,0.63,0.22,0.09,0.04,0.02,0.0,0.0,0.0,thomas hughes,BIOL-1010,2017
-BIOL,1030,1,General Biology I,0.17,0.27,0.26,0.16,0.06,0.0,0.0,0.09,nora espinoza,BIOL-1030,2017
-BIOL,1030,2,General Biology I,0.14,0.31,0.29,0.14,0.07,0.0,0.0,0.06,william baldwin,BIOL-1030,2017
-BIOL,1030,3,General Biology I,0.32,0.3,0.2,0.07,0.05,0.0,0.0,0.05,william surver,BIOL-1030,2017
-BIOL,1030,4,General Biology I,0.16,0.23,0.33,0.17,0.05,0.0,0.0,0.07,salvatore sparace,BIOL-1030,2017
-BIOL,1030,5,General Biology I (HON),0.49,0.36,0.13,0.0,0.0,0.0,0.0,0.03,nora espinoza,BIOL-1030,2017
-BIOL,1050,1,General Biology Lab I,0.13,0.42,0.29,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,2,General Biology Lab I,0.08,0.5,0.33,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,3,General Biology Lab I,0.27,0.32,0.27,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,4,General Biology Lab I,0.0,0.63,0.29,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,5,General Biology Lab I,0.04,0.5,0.46,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,6,General Biology Lab I,0.21,0.54,0.21,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,7,General Biology Lab I,0.0,0.25,0.38,0.08,0.08,0.0,0.0,0.21,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,8,General Biology Lab I,0.04,0.33,0.42,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,9,General Biology Lab I,0.0,0.15,0.3,0.25,0.1,0.0,0.0,0.2,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,10,General Biology Lab I,0.04,0.52,0.26,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,11,General Biology Lab I,0.09,0.65,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,12,General Biology Lab I,0.17,0.29,0.38,0.08,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,13,General Biology Lab I,0.08,0.54,0.25,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,14,General Biology Lab I,0.04,0.63,0.29,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,15,General Biology Lab I,0.0,0.67,0.17,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,16,General Biology Lab I,0.04,0.43,0.43,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,17,General Biology Lab I,0.13,0.38,0.33,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,18,General Biology Lab I,0.17,0.42,0.38,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,19,General Biology Lab I,0.23,0.27,0.36,0.09,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,20,General Biology Lab I,0.1,0.35,0.4,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,21,General Biology Lab I,0.0,0.21,0.5,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,22,General Biology Lab I,0.0,0.61,0.3,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,23,General Biology Lab I,0.08,0.29,0.29,0.13,0.13,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,25,General Biology Lab I,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,26,General Biology Lab I,0.25,0.46,0.25,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,27,General Biology Lab I,0.25,0.42,0.25,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,28,General Biology Lab I,0.04,0.5,0.33,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,29,General Biology Lab I,0.0,0.63,0.17,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,30,General Biology Lab I,0.0,0.29,0.29,0.17,0.08,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,31,General Biology Lab I,0.09,0.36,0.41,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,32,General Biology Lab I,0.0,0.39,0.39,0.22,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,33,General Biology Lab I,0.0,0.27,0.4,0.13,0.13,0.0,0.0,0.07,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,34,General Biology Lab I,0.09,0.57,0.35,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,35,General Biology Lab I,0.13,0.46,0.33,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,36,General Biology Lab I,0.25,0.46,0.17,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,37,General Biology Lab I,0.04,0.38,0.5,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,38,General Biology Lab I,0.13,0.63,0.17,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,39,General Biology Lab I,0.0,0.5,0.42,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,40,General Biology Lab I,0.09,0.65,0.17,0.09,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,41,General Biology Lab I,0.0,0.5,0.42,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,42,General Biology Lab I,0.04,0.43,0.43,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,43,General Biology Lab I,0.09,0.36,0.36,0.09,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,44,General Biology Lab I,0.09,0.52,0.22,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1050,46,General Biology Lab I,0.04,0.38,0.38,0.13,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2017
-BIOL,1090,1,Intro to Life Sci,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,BIOL-1090,2017
-BIOL,1100,1,Principles of Biology I,0.47,0.41,0.08,0.01,0.0,0.0,0.0,0.03,dylan dittrich-reed,BIOL-1100,2017
-BIOL,1100,2,Principles of Biology I,0.24,0.43,0.23,0.04,0.03,0.0,0.0,0.04,robert kosinski,BIOL-1100,2017
-BIOL,1200,1,Biological Inq Lab,0.15,0.6,0.15,0.1,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,2,Biological Inq Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,3,Biological Inq Lab,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,4,Biological Inq Lab,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,BIOL-1200,2017
-BIOL,1200,5,Biological Inq Lab,0.25,0.55,0.1,0.05,0.0,0.0,0.0,0.05, christine minor,BIOL-1200,2017
-BIOL,1200,6,Biological Inq Lab,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,7,Biological Inq Lab,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,8,Biological Inq Lab,0.21,0.37,0.21,0.0,0.11,0.0,0.0,0.11, christine minor,BIOL-1200,2017
-BIOL,1200,9,Biological Inq Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,10,Biological Inq Lab,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,11,Biological Inq Lab,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05, christine minor,BIOL-1200,2017
-BIOL,1200,12,Biological Inq Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,13,Biological Inq Lab,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,14,Biological Inq Lab,0.32,0.47,0.16,0.05,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1230,1,Keys to Human Biol,0.16,0.44,0.29,0.1,0.02,0.0,0.0,0.0, christine minor,BIOL-1230,2017
-BIOL,1230,2,Keys to Human Biol,0.13,0.49,0.24,0.08,0.01,0.0,0.0,0.04, christine minor,BIOL-1230,2017
-BIOL,2040,1,"Environ, Energy and Society",0.4,0.33,0.15,0.05,0.0,0.0,0.0,0.08,john jenkins hains,BIOL-2040,2017
-BIOL,2040,2,"Environ, Energy and Society",0.34,0.4,0.17,0.04,0.04,0.0,0.0,0.02,john jenkins hains,BIOL-2040,2017
-BIOL,2110,1,Introduction to Toxicology,0.65,0.22,0.13,0.0,0.0,0.0,0.0,0.0,peter van den hurk,BIOL-2110,2017
-BIOL,2220,1,Human Anat and Physiology I,0.29,0.31,0.25,0.06,0.05,0.0,0.0,0.04,john cummings,BIOL-2220,2017
-BIOL,2220,2,Human Anat and Physiology I,0.22,0.36,0.23,0.05,0.06,0.0,0.0,0.09,john cummings,BIOL-2220,2017
-BIOL,3030,1,Vertebrate Biology,0.33,0.3,0.21,0.13,0.01,0.0,0.0,0.02,richard blob,BIOL-3030,2017
-BIOL,3030,2,Vertebrate Biology (HON),0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3030,2017
-BIOL,3040,1,Biology of Plants,0.53,0.36,0.06,0.02,0.03,0.0,0.0,0.0,christina wells,BIOL-3040,2017
-BIOL,3070,1,Vertebrate Biology Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2017
-BIOL,3070,2,Vertebrate Biology Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2017
-BIOL,3070,3,Vertebrate Biology Lab,0.25,0.6,0.15,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2017
-BIOL,3070,4,Vertebrate Biology Lab,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2017
-BIOL,3070,5,Vertebrate Biology Lab,0.25,0.5,0.15,0.0,0.05,0.0,0.0,0.05,richard blob,BIOL-3070,2017
-BIOL,3070,6,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2017
-BIOL,3070,7,Vertebrate Biology Lab,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2017
-BIOL,3070,8,Vertebrate Biology Lab,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,richard blob,BIOL-3070,2017
-BIOL,3070,9,Vertebrate Biology Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2017
-BIOL,3070,10,Vertebrate Biology Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2017
-BIOL,3070,11,Vertebrate Biology Lab,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2017
-BIOL,3080,1,Biology of Plants Practicum,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2017
-BIOL,3080,2,Biology of Plants Practicum,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,nathan redding,BIOL-3080,2017
-BIOL,3080,3,Biology of Plants Practicum,0.35,0.5,0.0,0.1,0.0,0.0,0.0,0.05,nathan redding,BIOL-3080,2017
-BIOL,3080,4,Biology of Plants Practicum,0.1,0.65,0.2,0.0,0.0,0.0,0.0,0.05,nathan redding,BIOL-3080,2017
-BIOL,3080,5,Biology of Plants Practicum,0.65,0.1,0.25,0.0,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2017
-BIOL,3080,6,Biology of Plants Practicum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2017
-BIOL,3150,1,Functional Human Anatomy,0.23,0.42,0.19,0.06,0.03,0.0,0.0,0.07,tamara mcnutt-scott,BIOL-3150,2017
-BIOL,3200,1,Field Botany,0.25,0.21,0.32,0.07,0.0,0.0,0.0,0.14,robert edwa ballard,BIOL-3200,2017
-BIOL,3350,1,Evolutionary Biology,0.41,0.42,0.13,0.02,0.0,0.0,0.0,0.01,michael sears,BIOL-3350,2017
-BIOL,3510,1,Biological Anthropology,0.11,0.56,0.11,0.06,0.06,0.0,0.0,0.11,lisa rapaport,BIOL-3510,2017
-BIOL,3530,1,Forensic Anthropology,0.29,0.47,0.18,0.0,0.0,0.0,0.0,0.06,katherine weisensee,BIOL-3530,2017
-BIOL,4030,1,Intro to Applied Genomics,0.15,0.46,0.08,0.08,0.08,0.0,0.0,0.15,vincent pa richards,BIOL-4030,2017
-BIOL,4140,1,Basic Immunology,0.19,0.44,0.31,0.06,0.0,0.0,0.0,0.0,yanzhang wei,BIOL-4140,2017
-BIOL,4170,1,Marine Biology,0.93,0.06,0.0,0.0,0.0,0.0,0.0,0.01,charles rice,BIOL-4170,2017
-BIOL,4200,1,Neurobiology,0.48,0.45,0.0,0.03,0.0,0.0,0.0,0.03,david feliciano,BIOL-4200,2017
-BIOL,4250,1,Introductory Mycology,0.35,0.29,0.26,0.03,0.0,0.0,0.0,0.06,julia loui kerrigan,BIOL-4250,2017
-BIOL,4260,2,Mycology Practicum,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,BIOL-4260,2017
-BIOL,4340,1,Biological Chem Lab Techniques,0.06,0.38,0.38,0.13,0.06,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2017
-BIOL,4340,2,Biological Chem Lab Techniques,0.19,0.25,0.19,0.19,0.19,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2017
-BIOL,4340,4,Biological Chem Lab Techniques,0.21,0.36,0.29,0.14,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2017
-BIOL,4410,1,Ecology,0.58,0.27,0.09,0.05,0.0,0.0,0.0,0.01,john jenkins hains,BIOL-4410,2017
-BIOL,4430,1,Freshwater Ecology,0.47,0.33,0.11,0.03,0.0,0.0,0.0,0.06,john jenkins hains,BIOL-4430,2017
-BIOL,4440,1,Freshwater Ecology Lab (Lec),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,john jenkins hains,BIOL-4440,2017
-BIOL,4450,1,Ecology Laboratory (Lec),0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,john jenkins hains,BIOL-4450,2017
-BIOL,4450,3,Ecology Laboratory (Lec),0.5,0.1,0.4,0.0,0.0,0.0,0.0,0.0,john jenkins hains,BIOL-4450,2017
-BIOL,4450,4,Ecology Laboratory (Lec),0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,john jenkins hains,BIOL-4450,2017
-BIOL,4560,1,Medical and Vet Parasitology,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,wilbur kear milhous,BIOL-4560,2017
-BIOL,4610,1,Cell Biology,0.28,0.42,0.19,0.07,0.01,0.0,0.0,0.04,susan carol chapman,BIOL-4610,2017
-BIOL,4610,2,Cell Biology (HON),0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,susan carol chapman,BIOL-4610,2017
-BIOL,4620,1,Cell Biology Lab (Lec),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,2,Cell Biology Lab (Lec),0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,4,Cell Biology Lab (Lec),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,5,Cell Biology Lab (Lec),0.92,0.0,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,6,Cell Biology Lab (Lec),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,7,Cell Biology Lab (Lec),0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,8,Cell Biology Lab (Lec),0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,BIOL-4620,2017
-BIOL,4620,9,Cell Biology Lab (Lec),0.89,0.04,0.0,0.0,0.0,0.0,0.0,0.07,xianzhong yu,BIOL-4620,2017
-BIOL,4670,1,Principles of Hematology,0.77,0.13,0.03,0.0,0.0,0.0,0.0,0.06,vincent gallicchio,BIOL-4670,2017
-BIOL,4930,1,Sr Sem: Genomics,0.79,0.07,0.0,0.0,0.07,0.0,0.0,0.07,kara elizabe powder,BIOL-4930,2017
-BIOL,4930,3,Sr Sem: Advances in Cancer,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,BIOL-4930,2017
-BIOL,4930,5,Sr Sem: Bioelectricity,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,matthew turnbull,BIOL-4930,2017
-BIOL,4930,8,Sr Sem: Evolutionary Medicine,0.71,0.14,0.0,0.07,0.0,0.0,0.0,0.07,samantha ann price,BIOL-4930,2017
-BIOL,6030,1,Intro to Applied Genomics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,vincent pa richards,BIOL-6030,2017
-BIOL,8400,1,Understanding Biological Inq,0.93,0.05,0.01,0.0,0.01,0.0,0.0,0.01,michael childress,BIOL-8400,2017
-BIOL,8420,1,Understand Cellular Processes,0.64,0.31,0.05,0.0,0.01,0.0,0.0,0.0,patricia leota tate,BIOL-8420,2017
-BIOL,8440,1,Understanding the Human Body,0.64,0.28,0.04,0.0,0.04,0.0,0.0,0.0,william baldwin,BIOL-8440,2017
-BUS,1010,1,Business Foundations,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,2,Business Foundations,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,3,Business Foundations,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,4,Business Foundations,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,christopher mann,BUS-1010,2017
-BUS,1010,5,Business Foundations,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,christopher mann,BUS-1010,2017
-BUS,1010,6,Business Foundations,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,BUS-1010,2017
-BUS,1010,7,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,8,Business Foundations,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,BUS-1010,2017
-BUS,1010,9,Business Foundations,0.16,0.21,0.16,0.16,0.11,0.0,0.0,0.21,william ern tumblin,BUS-1010,2017
-BUS,1010,10,Business Foundations,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,11,Business Foundations,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,william ern tumblin,BUS-1010,2017
-BUS,1010,12,Business Foundations,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,christopher mann,BUS-1010,2017
-BUS,1010,13,Business Foundations,0.16,0.79,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,BUS-1010,2017
-BUS,1010,14,Business Foundations,0.42,0.26,0.16,0.05,0.05,0.0,0.0,0.05,christopher mann,BUS-1010,2017
-BUS,1010,15,Business Foundations,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2017
-BUS,1010,16,Business Foundations,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,donna mccubbin,BUS-1010,2017
-BUS,1010,17,Business Foundations,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,donna mccubbin,BUS-1010,2017
-BUS,1010,18,Business Foundations,0.26,0.42,0.11,0.05,0.05,0.0,0.0,0.11,donna mccubbin,BUS-1010,2017
-BUS,1010,19,Business Foundations,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,donna mccubbin,BUS-1010,2017
-BUS,1010,20,Business Foundations,0.39,0.33,0.17,0.0,0.0,0.0,0.0,0.11,donna mccubbin,BUS-1010,2017
-BUS,1010,21,Business Foundations,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,BUS-1010,2017
-BUS,1010,22,Business Foundations,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,christopher mann,BUS-1010,2017
-BUS,1010,23,Business Foundations,0.37,0.42,0.11,0.11,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2017
-BUS,1010,24,Business Foundations,0.37,0.37,0.11,0.0,0.0,0.0,0.0,0.16,sandy edge,BUS-1010,2017
-BUS,1010,25,Business Foundations,0.58,0.11,0.21,0.05,0.05,0.0,0.0,0.0,sandy edge,BUS-1010,2017
-BUS,1010,26,Business Foundations,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2017
-BUS,1010,27,Business Foundations,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2017
-BUS,1010,28,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2017
-BUS,1010,29,Business Foundations,0.26,0.28,0.26,0.11,0.02,0.0,0.0,0.07,lance scott young,BUS-1010,2017
-BUS,1010,30,Business Foundations,0.18,0.37,0.35,0.02,0.0,0.0,0.0,0.08,lance scott young,BUS-1010,2017
-BUS,1010,31,Business Foundations,0.42,0.16,0.37,0.0,0.0,0.0,0.0,0.05,lance scott young,BUS-1010,2017
-BUS,1010,33,Business Foundations,0.28,0.32,0.28,0.08,0.04,0.0,0.0,0.0,donna mccubbin,BUS-1010,2017
-BUS,1010,34,Business Foundations,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2017
-BUS,1010,35,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,36,Business Foundations,0.26,0.42,0.21,0.0,0.05,0.0,0.0,0.05,christopher mann,BUS-1010,2017
-BUS,1010,37,Business Foundations,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2017
-BUS,2990,6,CI: Being a Leader,0.5,0.3,0.1,0.0,0.1,0.0,0.0,0.0,melissa vogel,BUS-2990,2017
-CE,1990,2,Cr Inq in Civil Engineering,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,weichiang pang,CE-1990,2017
-CE,1990,20,Cr Inq in Civil Engineering,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,bradley putman,CE-1990,2017
-CE,2010,1,Statics,0.22,0.17,0.26,0.07,0.09,0.0,0.0,0.2,melissa sternhagen,CE-2010,2017
-CE,2010,2,Statics,0.27,0.3,0.25,0.05,0.07,0.0,0.0,0.07,"mahmoudabadi arani,",CE-2010,2017
-CE,2010,3,Statics,0.46,0.21,0.13,0.08,0.06,0.0,0.0,0.06,qiushi chen,CE-2010,2017
-CE,2010,4,Statics,0.18,0.34,0.14,0.11,0.07,0.0,0.0,0.16,melissa sternhagen,CE-2010,2017
-CE,2010,5,Statics,0.43,0.36,0.16,0.0,0.02,0.0,0.0,0.02,mahmoodreza soltani,CE-2010,2017
-CE,2010,6,Statics,0.15,0.23,0.15,0.08,0.09,0.0,0.0,0.29,melissa sternhagen,CE-2010,2017
-CE,2010,8,Statics,0.1,0.37,0.29,0.04,0.08,0.0,0.0,0.12, kent nilsson,CE-2010,2017
-CE,2060,1,Structural Mechanics,0.41,0.33,0.22,0.02,0.02,0.0,0.0,0.02,mahmoodreza soltani,CE-2060,2017
-CE,2080,1,Dynamics,0.07,0.29,0.34,0.2,0.05,0.0,0.0,0.05,melissa sternhagen,CE-2080,2017
-CE,2550,1,Geomatics,0.3,0.45,0.2,0.04,0.01,0.0,0.0,0.0,wayne sarasua,CE-2550,2017
-CE,3010,1,Structural Analysis,0.35,0.32,0.24,0.08,0.0,0.0,0.0,0.0,stephen csernak,CE-3010,2017
-CE,3010,2,Structural Analysis,0.42,0.36,0.11,0.06,0.03,0.0,0.0,0.03,thomas edfo cousins,CE-3010,2017
-CE,3110,1,Transportation Engr,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,jennifer ogle,CE-3110,2017
-CE,3210,1,Geotechnical Engineering,0.21,0.24,0.33,0.14,0.07,0.0,0.0,0.0,qiushi chen,CE-3210,2017
-CE,3310,1,Constr Engr & Mgmnt,0.59,0.28,0.09,0.03,0.01,0.0,0.0,0.0,james burati,CE-3310,2017
-CE,3410,1,Intro to Fluid Mech,0.33,0.4,0.17,0.1,0.0,0.0,0.0,0.0,nigel gregory kaye,CE-3410,2017
-CE,3410,2,Intro to Fluid Mech,0.17,0.38,0.3,0.02,0.13,0.0,0.0,0.0,abdul khan,CE-3410,2017
-CE,3420,1,Hydraulics & Hydro,0.5,0.33,0.11,0.07,0.0,0.0,0.0,0.0,ashok mishra,CE-3420,2017
-CE,3510,1,Civil Engineering Materials,0.24,0.51,0.22,0.0,0.02,0.0,0.0,0.0,ami esmaeilpoursaee,CE-3510,2017
-CE,3510,2,Civil Engineering Materials,0.45,0.48,0.07,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,CE-3510,2017
-CE,3520,1,Econ Eval of Proj,0.46,0.26,0.19,0.04,0.0,0.0,0.0,0.06,zoraya rolda rockow,CE-3520,2017
-CE,4010,1,Matrix Str Analysis,0.0,0.47,0.2,0.2,0.07,0.0,0.0,0.07,bryant nielson,CE-4010,2017
-CE,4020,1,Reinfor Con Design,0.36,0.39,0.21,0.03,0.0,0.0,0.0,0.0,brandon ross,CE-4020,2017
-CE,4060,1,Struct Steel Design,0.36,0.44,0.05,0.08,0.03,0.0,0.0,0.05,stephen csernak,CE-4060,2017
-CE,4100,1,Traffic Engr Oper,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,wayne sarasua,CE-4100,2017
-CE,4240,1,Earth Slopes & Struc,0.33,0.39,0.2,0.04,0.04,0.0,0.0,0.0,nadara ravichandran,CE-4240,2017
-CE,4330,1,Const Plan & Sched,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,CE-4330,2017
-CE,4390,1,Con Eqpmt Sel & Main,0.32,0.45,0.18,0.0,0.0,0.0,0.0,0.05,james burati,CE-4390,2017
-CE,4560,1,Pave Design & Constr,0.48,0.44,0.04,0.0,0.0,0.0,0.0,0.04,bradley putman,CE-4560,2017
-CE,4590,1,Capstone Design Proj,0.51,0.3,0.05,0.14,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2017
-CE,4910,1,BIM in Construction Management,0.76,0.14,0.03,0.0,0.07,0.0,0.0,0.0,kalyan ram piratla,CE-4910,2017
-CE,4910,2,Hydrologic Analysis and Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ashok mishra,CE-4910,2017
-CE,6010,1,Matrix Str Analysis,0.45,0.41,0.14,0.0,0.0,0.0,0.0,0.0,bryant nielson,CE-6010,2017
-CE,6100,1,Traffic Engr Oper,0.4,0.2,0.2,0.0,0.0,0.0,0.0,0.2,wayne sarasua,CE-6100,2017
-CE,6240,1,Earth Slopes & Struc,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,CE-6240,2017
-CE,6390,1,Con Eqpmt Sel & Main,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,james burati,CE-6390,2017
-CE,6560,1,Pavement Des & Const,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,bradley putman,CE-6560,2017
-CE,8200,1,Geotech Site Charac,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-8200,2017
-CE,8260,1,Prop of Concrete,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,CE-8260,2017
-CE,8320,1,Capl Proj Mgmt Fund,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,CE-8320,2017
-CE,8580,500,Fund of Risk Engineering Mgt,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,jie zhang,CE-8580,2017
-CE,8930,2,Bridge Design,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brandon ross,CE-8930,2017
-CE,8930,4,Data Analytics for Transpo,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-8930,2017
-CE,8930,5,Civil Infrastructure Systems,0.71,0.0,0.14,0.0,0.0,0.0,0.0,0.14,pamela murray-tuite,CE-8930,2017
-CH,1010,1,General Chemistry,0.18,0.24,0.27,0.15,0.07,0.0,0.0,0.09,william mcwhorter,CH-1010,2017
-CH,1010,2,General Chemistry,0.26,0.29,0.23,0.1,0.04,0.0,0.0,0.08,elliot ennis,CH-1010,2017
-CH,1010,3,General Chemistry,0.16,0.28,0.23,0.15,0.06,0.0,0.0,0.12,william mcwhorter,CH-1010,2017
-CH,1010,4,General Chemistry,0.24,0.31,0.22,0.11,0.05,0.0,0.0,0.08,dennis taylor,CH-1010,2017
-CH,1010,5,General Chemistry,0.27,0.29,0.19,0.12,0.05,0.0,0.0,0.08,william mcwhorter,CH-1010,2017
-CH,1010,6,General Chemistry,0.15,0.38,0.21,0.17,0.04,0.0,0.0,0.05,thomas hickman,CH-1010,2017
-CH,1010,7,General Chemistry,0.22,0.34,0.25,0.11,0.03,0.0,0.0,0.05,laura lanni,CH-1010,2017
-CH,1010,8,General Chemistry,0.33,0.37,0.16,0.05,0.03,0.0,0.0,0.05,tania issa houjeiry,CH-1010,2017
-CH,1010,9,General Chemistry,0.25,0.39,0.21,0.09,0.03,0.0,0.0,0.03,dennis taylor,CH-1010,2017
-CH,1010,10,General Chemistry,0.33,0.3,0.19,0.06,0.05,0.0,0.0,0.08,tania issa houjeiry,CH-1010,2017
-CH,1010,11,General Chemistry,0.21,0.24,0.3,0.1,0.07,0.0,0.0,0.08,princess mycia cox,CH-1010,2017
-CH,1010,12,General Chemistry,0.31,0.33,0.19,0.06,0.03,0.0,0.0,0.08,elliot ennis,CH-1010,2017
-CH,1010,13,General Chemistry,0.2,0.38,0.26,0.11,0.03,0.0,0.0,0.02,dennis taylor,CH-1010,2017
-CH,1010,50,General Chemistry,0.26,0.35,0.13,0.16,0.06,0.0,0.0,0.03,shiou-jyh hwu,CH-1010,2017
-CH,1010,51,General Chemistry (HON),0.69,0.2,0.12,0.0,0.0,0.0,0.0,0.0,william pennington,CH-1010,2017
-CH,1010,52,General Chemistry (HON),0.68,0.2,0.1,0.02,0.0,0.0,0.0,0.0,joseph stu thrasher,CH-1010,2017
-CH,1010,201,General Chemistry,0.22,0.36,0.28,0.09,0.03,0.0,0.0,0.03,laura lanni,CH-1010,2017
-CH,1010,202,General Chemistry,0.2,0.43,0.22,0.11,0.02,0.0,0.0,0.03,jacob schroeder,CH-1010,2017
-CH,1010,203,General Chemistry,0.2,0.39,0.24,0.08,0.03,0.0,0.0,0.05,olt geiculescu,CH-1010,2017
-CH,1010,204,General Chemistry,0.25,0.43,0.17,0.12,0.02,0.0,0.0,0.01,princess mycia cox,CH-1010,2017
-CH,1010,501,General Chemistry,0.21,0.39,0.24,0.12,0.0,0.0,0.0,0.03,brian gloor,CH-1010,2017
-CH,1020,1,General Chemistry,0.37,0.21,0.21,0.11,0.03,0.0,0.0,0.06,stephe schvaneveldt,CH-1020,2017
-CH,1020,2,General Chemistry,0.21,0.22,0.29,0.15,0.05,0.0,0.0,0.08,stephe schvaneveldt,CH-1020,2017
-CH,1020,3,General Chemistry,0.31,0.19,0.3,0.09,0.02,0.0,0.0,0.08,stephe schvaneveldt,CH-1020,2017
-CH,1020,400,General Chemistry,0.1,0.25,0.29,0.15,0.15,0.0,0.0,0.06,stephe schvaneveldt,CH-1020,2017
-CH,1050,1,Chemistry in Context I,0.37,0.51,0.07,0.02,0.02,0.0,0.0,0.02,olt geiculescu,CH-1050,2017
-CH,1050,2,Chemistry in Context I,0.33,0.47,0.11,0.04,0.03,0.0,0.0,0.01,olt geiculescu,CH-1050,2017
-CH,2010,1,Survey of Organic Chemistry,0.2,0.33,0.26,0.11,0.08,0.0,0.0,0.02,thomas hickman,CH-2010,2017
-CH,2010,2,Survey of Organic Chemistry,0.29,0.45,0.15,0.09,0.0,0.0,0.0,0.02,thomas hickman,CH-2010,2017
-CH,2020,1,Surv of Organic Chemistry Lab,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2020,2017
-CH,2020,2,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2020,2017
-CH,2020,4,Surv of Organic Chemistry Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,CH-2020,2017
-CH,2020,5,Surv of Organic Chemistry Lab,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,james nelso plampin,CH-2020,2017
-CH,2020,6,Surv of Organic Chemistry Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,CH-2020,2017
-CH,2020,8,Surv of Organic Chemistry Lab,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,CH-2020,2017
-CH,2020,9,Surv of Organic Chemistry Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2020,2017
-CH,2230,1,Organic Chemistry,0.32,0.25,0.14,0.05,0.06,0.0,0.0,0.18,modi wetzler,CH-2230,2017
-CH,2230,2,Organic Chemistry,0.36,0.3,0.09,0.11,0.04,0.0,0.0,0.11,modi wetzler,CH-2230,2017
-CH,2230,3,Organic Chemistry,0.34,0.37,0.17,0.04,0.03,0.0,0.0,0.05,tania issa houjeiry,CH-2230,2017
-CH,2230,4,Organic Chemistry,0.19,0.43,0.17,0.06,0.04,0.0,0.0,0.11,laura lanni,CH-2230,2017
-CH,2230,5,Organic Chemistry,0.29,0.4,0.15,0.07,0.05,0.0,0.0,0.04,elliot ennis,CH-2230,2017
-CH,2230,6,Organic Chemistry,0.25,0.36,0.18,0.06,0.04,0.0,0.0,0.12,rhett smith,CH-2230,2017
-CH,2230,7,Organic Chemistry,0.31,0.31,0.2,0.05,0.03,0.0,0.0,0.1,sourav saha,CH-2230,2017
-CH,2240,1,Organic Chemistry,0.27,0.31,0.23,0.05,0.13,0.0,0.0,0.01,jacob schroeder,CH-2240,2017
-CH,2240,2,Organic Chemistry,0.27,0.26,0.26,0.09,0.06,0.0,0.0,0.06,jacob schroeder,CH-2240,2017
-CH,2270,1,Organic Chem Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,CH-2270,2017
-CH,2270,3,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,4,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,7,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,james nelso plampin,CH-2270,2017
-CH,2270,8,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,9,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,10,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,CH-2270,2017
-CH,2270,12,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,13,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,14,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,CH-2270,2017
-CH,2270,16,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,17,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,CH-2270,2017
-CH,2270,18,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,20,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,21,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,23,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,CH-2270,2017
-CH,2270,24,Organic Chem Lab,0.73,0.13,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,26,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,27,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,28,Organic Chem Lab,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,james nelso plampin,CH-2270,2017
-CH,2270,30,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,31,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,james nelso plampin,CH-2270,2017
-CH,2270,32,Organic Chem Lab,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,33,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2270,2017
-CH,2270,34,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,35,Organic Chem Lab,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2270,2017
-CH,2270,36,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,CH-2270,2017
-CH,2270,37,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,CH-2270,2017
-CH,2270,38,Organic Chem Lab,0.56,0.13,0.0,0.0,0.06,0.0,0.0,0.25,james nelso plampin,CH-2270,2017
-CH,2280,1,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,CH-2280,2017
-CH,2280,2,Organic Chem Lab,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,james nelso plampin,CH-2280,2017
-CH,2280,3,Organic Chem Lab,0.76,0.06,0.0,0.0,0.0,0.0,0.0,0.18,james nelso plampin,CH-2280,2017
-CH,2280,4,Organic Chem Lab,0.72,0.0,0.0,0.0,0.0,0.0,0.0,0.28,james nelso plampin,CH-2280,2017
-CH,2280,5,Organic Chem Lab,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,CH-2280,2017
-CH,2280,6,Organic Chem Lab,0.71,0.0,0.0,0.0,0.06,0.0,0.0,0.24,james nelso plampin,CH-2280,2017
-CH,2280,7,Organic Chem Lab,0.73,0.07,0.07,0.0,0.13,0.0,0.0,0.0,james nelso plampin,CH-2280,2017
-CH,2280,9,Organic Chem Lab,0.7,0.0,0.0,0.0,0.0,0.0,0.0,0.3,james nelso plampin,CH-2280,2017
-CH,3130,1,Quantitative Analys,0.54,0.2,0.22,0.05,0.0,0.0,0.0,0.0,stephen creager,CH-3130,2017
-CH,3150,1,Quant Analysis Lab,0.64,0.09,0.0,0.0,0.18,0.0,0.0,0.09,carlos garcia perez,CH-3150,2017
-CH,3150,2,Quant Analysis Lab,0.25,0.58,0.08,0.0,0.0,0.0,0.0,0.08,carlos garcia perez,CH-3150,2017
-CH,3300,1,Intro to Phys Chem,0.46,0.29,0.14,0.03,0.05,0.0,0.0,0.03,brian dominy,CH-3300,2017
-CH,3310,1,Physical Chemistry,0.13,0.13,0.33,0.2,0.13,0.0,0.0,0.07,steven stuart,CH-3310,2017
-CH,3310,2,Physical Chemistry,0.75,0.08,0.08,0.04,0.0,0.0,0.0,0.04,jason mcneill,CH-3310,2017
-CH,3320,1,Physical Chemistry,0.41,0.35,0.06,0.0,0.0,0.0,0.0,0.18,arkady kholodenko,CH-3320,2017
-CH,3390,1,Physical Chem Lab,0.2,0.75,0.0,0.0,0.0,0.0,0.0,0.05,princess mycia cox,CH-3390,2017
-CH,3390,2,Physical Chem Lab,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,princess mycia cox,CH-3390,2017
-CH,3390,4,Physical Chem Lab,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2017
-CH,3390,5,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2017
-CH,3410,1,Introduction to Research,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,stephen creager,CH-3410,2017
-CH,4010,1,Organometallic Chemistry,0.66,0.3,0.0,0.0,0.0,0.0,0.0,0.04,andrew gre tennyson,CH-4010,2017
-CH,4020,1,Inorganic Chemistry,0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,joseph kolis,CH-4020,2017
-CH,8070,1,Chem Trans Elem,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,julia brumaghim,CH-8070,2017
-CH,8140,1,Analytical Imaging,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,george chumanov,CH-8140,2017
-CH,8160,1,Separation Science,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,richard marcus,CH-8160,2017
-CH,8210,1,Organic Chem I,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,ya-ping sun,CH-8210,2017
-CH,8410,3,N M R Spectroscopy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alek kitaygorodskiy,CH-8410,2017
-CH,8510,1,Grad Student Seminar,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,joseph stu thrasher,CH-8510,2017
-CH,8520,1,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,leah bec casabianca,CH-8520,2017
-CHE,2110,1,Mass and Energy Balances,0.11,0.19,0.31,0.14,0.11,0.0,0.0,0.14,mark roberts,CHE-2110,2017
-CHE,2110,2,Mass and Energy Balances,0.28,0.27,0.33,0.02,0.03,0.0,0.0,0.07,mark roberts,CHE-2110,2017
-CHE,3210,1,Ch E Thermo II,0.13,0.2,0.36,0.27,0.04,0.0,0.0,0.0,sapna sarupria,CHE-3210,2017
-CHE,3300,1,Mass Trans & Seprtn,0.16,0.2,0.4,0.12,0.11,0.0,0.0,0.01,mark thies,CHE-3300,2017
-CHE,4070,1,Unit Op Lab II,0.16,0.72,0.12,0.0,0.0,0.0,0.0,0.0,christopher norfolk,CHE-4070,2017
-CHE,4140,1,Green Engineering,0.48,0.44,0.08,0.0,0.0,0.0,0.0,0.0,christophe kitchens,CHE-4140,2017
-CHE,4310,1,Process Design I,0.25,0.47,0.28,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4310,2017
-CHE,4500,1,Chem Reaction Engr,0.19,0.27,0.39,0.14,0.01,0.0,0.0,0.0,rachel getman,CHE-4500,2017
-CHE,6130,1,Polymer Composite Engineering,0.4,0.2,0.4,0.0,0.0,0.0,0.0,0.0,amod ogale,CHE-6130,2017
-CHE,8030,1,Advanced Transport,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,eric mikel davis,CHE-8030,2017
-CHE,8040,1,Ch E Thermodynamics,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,joseph scott,CHE-8040,2017
-CHE,8050,1,Ch E Kinetics,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,mark alan blenner,CHE-8050,2017
-CHIN,2010,1,Intermediate Chinese,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,ling rao,CHIN-2010,2017
-CHIN,3050,1,Chin Conv & Comp I,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,yanhua zhang,CHIN-3050,2017
-COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,eddie smith,COM-1010,2017
-COM,1500,1,Intro to Human Communication,0.83,0.15,0.0,0.0,0.01,0.0,0.0,0.02,eddie smith,COM-1500,2017
-COM,1500,2,Intro to Human Communication,0.69,0.26,0.01,0.01,0.01,0.0,0.0,0.02,daniel lelan fecher,COM-1500,2017
-COM,1500,3,Intro to Human Communication,0.91,0.07,0.02,0.0,0.01,0.0,0.0,0.0,eddie smith,COM-1500,2017
-COM,1500,4,Intro to Human Communication,0.77,0.16,0.03,0.0,0.02,0.0,0.0,0.02,marianne her glaser,COM-1500,2017
-COM,1500,5,Intro to Human Communication,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,marianne her glaser,COM-1500,2017
-COM,1500,6,Intro to Human Communication,0.81,0.1,0.03,0.0,0.03,0.0,0.0,0.03,marianne her glaser,COM-1500,2017
-COM,1500,7,Intro to Human Communication,0.43,0.47,0.04,0.03,0.03,0.0,0.0,0.0,daniel lelan fecher,COM-1500,2017
-COM,2010,1,Intr to Comm Studies,0.69,0.28,0.0,0.03,0.0,0.0,0.0,0.0,darren linvill,COM-2010,2017
-COM,2010,2,Intr to Comm Studies,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-2010,2017
-COM,2020,1,Communication Theory,0.31,0.31,0.31,0.06,0.0,0.0,0.0,0.0,kristen ela okamoto,COM-2020,2017
-COM,2020,2,Communication Theory,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,kristen ela okamoto,COM-2020,2017
-COM,2040,1,Critical-Cultural Comm Theory,0.61,0.22,0.11,0.0,0.0,0.0,0.0,0.06,david travers scott,COM-2040,2017
-COM,2100,1,Quant Comm Research Methods,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-2100,2017
-COM,2100,2,Quant Comm Research Methods,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-2100,2017
-COM,2110,1,Qual Comm Research Methods,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,angela pratt,COM-2110,2017
-COM,2500,1,Public Speaking,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2017
-COM,2500,2,Public Speaking,0.35,0.47,0.06,0.06,0.0,0.0,0.0,0.06,sara grumbl crocker,COM-2500,2017
-COM,2500,3,Public Speaking,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2017
-COM,2500,4,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2017
-COM,2500,5,Public Speaking,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2017
-COM,2500,6,Public Speaking,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2017
-COM,2500,7,Public Speaking,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,COM-2500,2017
-COM,2500,8,Public Speaking,0.56,0.39,0.0,0.06,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2017
-COM,2500,9,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2017
-COM,2500,10,Public Speaking,0.53,0.26,0.16,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2017
-COM,2500,11,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,COM-2500,2017
-COM,2500,12,Public Speaking,0.61,0.22,0.06,0.0,0.11,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2017
-COM,2500,13,Public Speaking,0.63,0.21,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,COM-2500,2017
-COM,2500,14,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2017
-COM,2500,16,Public Speaking,0.84,0.0,0.11,0.0,0.0,0.0,0.0,0.05,vanessa anne condon,COM-2500,2017
-COM,2500,17,Public Speaking,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,the estate  geddes,COM-2500,2017
-COM,2500,18,Public Speaking,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2017
-COM,2500,19,Public Speaking,0.32,0.26,0.32,0.11,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2017
-COM,2500,21,Public Speaking,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,katie barn mcelveen,COM-2500,2017
-COM,2500,23,Public Speaking,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,pauline matthey,COM-2500,2017
-COM,2500,24,Public Speaking,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,katie barn mcelveen,COM-2500,2017
-COM,2500,25,Public Speaking (HON),0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-2500,2017
-COM,2500,26,Public Speaking (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,COM-2500,2017
-COM,2500,28,Public Speaking,0.67,0.11,0.11,0.0,0.06,0.0,0.0,0.06,sara grumbl crocker,COM-2500,2017
-COM,2500,29,Public Speaking,0.68,0.11,0.11,0.0,0.0,0.0,0.0,0.11,sara grumbl crocker,COM-2500,2017
-COM,2500,30,Public Speaking,0.53,0.21,0.11,0.0,0.05,0.0,0.0,0.11,jumah patrici taweh,COM-2500,2017
-COM,2500,31,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2017
-COM,2500,32,Public Speaking,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2017
-COM,2500,33,Public Speaking,0.56,0.17,0.17,0.0,0.11,0.0,0.0,0.0,vanessa anne condon,COM-2500,2017
-COM,2500,34,Public Speaking,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,COM-2500,2017
-COM,2500,35,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,COM-2500,2017
-COM,2500,36,Public Speaking,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,amanda elizab moore,COM-2500,2017
-COM,2500,37,Public Speaking,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,amanda elizab moore,COM-2500,2017
-COM,2500,39,Public Speaking (HON),0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,lindsey dixon,COM-2500,2017
-COM,2500,400,Public Speaking,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2017
-COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2017
-COM,2500,403,Public Speaking,0.89,0.0,0.06,0.0,0.06,0.0,0.0,0.0,alexis zachar davis,COM-2500,2017
-COM,3220,1,Communication Design,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,COM-3220,2017
-COM,3240,1,"Communication, Sport & Society",0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,COM-3240,2017
-COM,3240,2,"Communication, Sport & Society",0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,COM-3240,2017
-COM,3260,2,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2017
-COM,3260,3,Pr in Sports,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,katie barn mcelveen,COM-3260,2017
-COM,3480,1,Interpersonal Comm,0.64,0.28,0.06,0.03,0.0,0.0,0.0,0.0,stephanie pangborn,COM-3480,2017
-COM,3550,1,Principles of Public Relations,0.65,0.24,0.04,0.02,0.02,0.0,0.0,0.02,meghna tallapragada,COM-3550,2017
-COM,3570,1,Public Relations Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3570,2017
-COM,3570,2,Public Relations Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3570,2017
-COM,3660,4,Adv. Strategic Comm,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,mark david land,COM-3660,2017
-COM,4250,1,Adv Sports Comm,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,bryan denham,COM-4250,2017
-COM,4260,1,Social Media and Sports Comm,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4260,2017
-COM,4260,2,Social Media and Sports Comm,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4260,2017
-COM,4300,1,Legal Communication,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,james isaac roberts,COM-4300,2017
-COM,4710,1,Health Comm in Communities,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4710,2017
-COM,8030,1,Comm Technology Studies Survey,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,COM-8030,2017
-COM,8100,1,Comm Research Methods I,0.25,0.63,0.0,0.0,0.13,0.0,0.0,0.0,gregory kei cranmer,COM-8100,2017
-CPSC,1010,1,Computer Science I,0.16,0.35,0.13,0.11,0.1,0.0,0.0,0.15,salvatore lamarca,CPSC-1010,2017
-CPSC,1010,2,Computer Science I,0.19,0.31,0.21,0.12,0.09,0.0,0.0,0.09,salvatore lamarca,CPSC-1010,2017
-CPSC,1020,1,Computer Science II,0.27,0.13,0.17,0.17,0.12,0.0,0.0,0.13,yvon feaster,CPSC-1020,2017
-CPSC,1020,2,Computer Science II,0.37,0.29,0.16,0.03,0.11,0.0,0.0,0.05,yvon feaster,CPSC-1020,2017
-CPSC,1060,1,Intro to Programming in Java,0.32,0.24,0.12,0.06,0.15,0.0,0.0,0.12,salvatore lamarca,CPSC-1060,2017
-CPSC,1070,1,Programming Methodology,0.57,0.18,0.14,0.06,0.02,0.0,0.0,0.04,rose lowe,CPSC-1070,2017
-CPSC,1110,1,Intro to Programming in C,0.37,0.27,0.15,0.05,0.07,0.0,0.0,0.08,catherine hochrine,CPSC-1110,2017
-CPSC,1110,2,Intro to Programming in C,0.31,0.25,0.1,0.05,0.19,0.0,0.0,0.1,catherine hochrine,CPSC-1110,2017
-CPSC,1110,3,Intro to Programming in C,0.48,0.2,0.12,0.08,0.02,0.0,0.0,0.11,john junius porter,CPSC-1110,2017
-CPSC,1210,1,Computational Thinking,0.11,0.44,0.11,0.0,0.17,0.0,0.0,0.17,larry hodges,CPSC-1210,2017
-CPSC,2070,1,Discrete Structures,0.21,0.28,0.23,0.07,0.11,0.0,0.0,0.1,larry hodges,CPSC-2070,2017
-CPSC,2120,1,Algs/Data Structures,0.3,0.23,0.18,0.04,0.09,0.0,0.0,0.16,brian christop dean,CPSC-2120,2017
-CPSC,2120,2,Algs/Data Structures,0.25,0.33,0.22,0.05,0.05,0.0,0.0,0.1,wayne goddard,CPSC-2120,2017
-CPSC,2150,1,Software Dev Foundations,0.27,0.36,0.25,0.03,0.02,0.0,0.0,0.07,kevin anton plis,CPSC-2150,2017
-CPSC,2150,2,Software Dev Foundations,0.27,0.27,0.21,0.02,0.14,0.0,0.0,0.09,kevin anton plis,CPSC-2150,2017
-CPSC,2200,1,Microcomputer Appl,0.46,0.39,0.07,0.04,0.04,0.0,0.0,0.0,kevin anton plis,CPSC-2200,2017
-CPSC,2200,2,Microcomputer Appl,0.26,0.37,0.19,0.11,0.07,0.0,0.0,0.0,kevin anton plis,CPSC-2200,2017
-CPSC,2310,1,Intro Computer Org,0.42,0.43,0.09,0.04,0.02,0.0,0.0,0.0,rose lowe,CPSC-2310,2017
-CPSC,2310,2,Intro Computer Org,0.44,0.26,0.22,0.02,0.02,0.0,0.0,0.04,rose lowe,CPSC-2310,2017
-CPSC,2810,1,Selected Topics: TA Class,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,christopher plaue,CPSC-2810,2017
-CPSC,2910,1,Prof Issues I,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2017
-CPSC,2910,2,Prof Issues I,0.59,0.24,0.12,0.06,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2017
-CPSC,2910,3,Prof Issues I,0.47,0.33,0.07,0.0,0.07,0.0,0.0,0.07,catherine hochrine,CPSC-2910,2017
-CPSC,2910,4,Prof Issues I,0.61,0.17,0.17,0.0,0.06,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2017
-CPSC,2910,5,Prof Issues I,0.39,0.39,0.06,0.0,0.11,0.0,0.0,0.06,catherine hochrine,CPSC-2910,2017
-CPSC,2920,1,"Computing, Ethics & Society",0.25,0.4,0.25,0.05,0.0,0.0,0.0,0.05,christopher plaue,CPSC-2920,2017
-CPSC,3220,1,Intro to Operating Systems,0.12,0.36,0.36,0.12,0.03,0.0,0.0,0.0,mark smotherman,CPSC-3220,2017
-CPSC,3220,2,Intro to Operating Systems,0.55,0.4,0.04,0.02,0.0,0.0,0.0,0.0,carl bryan martin,CPSC-3220,2017
-CPSC,3220,3,Intro to Operating Systems,0.21,0.42,0.11,0.16,0.11,0.0,0.0,0.0, van den meiracker,CPSC-3220,2017
-CPSC,3300,1,Computer Systems Org,0.21,0.34,0.34,0.11,0.0,0.0,0.0,0.0,rong ge,CPSC-3300,2017
-CPSC,3500,1,Foundations of Computer Sci,0.15,0.19,0.41,0.07,0.02,0.0,0.0,0.17,ilya mark safro,CPSC-3500,2017
-CPSC,3520,1,Programming Systems,0.3,0.48,0.08,0.0,0.03,0.0,0.0,0.1,robert schalkoff,CPSC-3520,2017
-CPSC,3600,1,Network Programming,0.28,0.42,0.22,0.02,0.03,0.0,0.0,0.03,feng luo,CPSC-3600,2017
-CPSC,3600,2,Network Programming,0.2,0.28,0.35,0.08,0.02,0.0,0.0,0.07,james martin,CPSC-3600,2017
-CPSC,3720,1,Software Engineering,0.31,0.36,0.23,0.07,0.0,0.0,0.0,0.03,murali sitaraman,CPSC-3720,2017
-CPSC,3720,2,Software Engineering,0.24,0.36,0.4,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,CPSC-3720,2017
-CPSC,4050,1,Computer Graphics,0.4,0.28,0.16,0.0,0.08,0.0,0.0,0.08,victor zordan,CPSC-4050,2017
-CPSC,4110,1,Virtual Reality Systems,0.38,0.25,0.2,0.08,0.1,0.0,0.0,0.0,sabarish venka babu,CPSC-4110,2017
-CPSC,4120,1,Eye Tracking Methodology,0.3,0.49,0.11,0.03,0.03,0.0,0.0,0.05,andrew duchowski,CPSC-4120,2017
-CPSC,4160,1,2-D Game Engine Construction,0.64,0.11,0.13,0.0,0.09,0.0,0.0,0.02,brian malloy,CPSC-4160,2017
-CPSC,4180,1,Usable Privacy and Security,0.64,0.31,0.03,0.0,0.0,0.0,0.0,0.03,kelly caine,CPSC-4180,2017
-CPSC,4200,1,Computer Security Principles,0.68,0.21,0.09,0.0,0.03,0.0,0.0,0.0,hongxin hu,CPSC-4200,2017
-CPSC,4300,1,Applied Data Science,0.51,0.28,0.18,0.0,0.03,0.0,0.0,0.0,alexander ch herzog,CPSC-4300,2017
-CPSC,4620,1,Database Management Systems,0.06,0.28,0.28,0.0,0.13,0.0,0.0,0.25,pradip srimani,CPSC-4620,2017
-CPSC,4770,1,Distributed/Cluster Computing,0.21,0.26,0.16,0.0,0.16,0.0,0.0,0.21,linh bao ngo,CPSC-4770,2017
-CPSC,4820,1,Spec Top: Embed Prototyp,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jacob sorber,CPSC-4820,2017
-CPSC,4820,2,Spec Topics: Cloud Comp Archit,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,amy apon,CPSC-4820,2017
-CPSC,4820,3,Spec Topic: Web Programming,0.51,0.27,0.07,0.02,0.07,0.0,0.0,0.05,craig baker,CPSC-4820,2017
-CPSC,4910,1,Professional Issues II,0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,CPSC-4910,2017
-CPSC,6040,1,Cptr Graphics Image,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,CPSC-6040,2017
-CPSC,6040,2,Cptr Graphics Image,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,ioannis karamouzas,CPSC-6040,2017
-CPSC,6050,1,Computer Graphics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,victor zordan,CPSC-6050,2017
-CPSC,6110,1,Virtual Reality Systems,0.0,0.57,0.29,0.0,0.0,0.0,0.0,0.14,sabarish venka babu,CPSC-6110,2017
-CPSC,6120,1,Eye Tracking Methodology,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,andrew duchowski,CPSC-6120,2017
-CPSC,6160,3,2-D Game Engine Construction,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,brian malloy,CPSC-6160,2017
-CPSC,6300,1,Applied Data Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,CPSC-6300,2017
-CPSC,6770,1,Distributed/Cluster Computing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,linh bao ngo,CPSC-6770,2017
-CPSC,6820,2,Spec Topics: Cloud Comp Archit,0.44,0.38,0.06,0.0,0.0,0.0,0.0,0.13,amy apon,CPSC-6820,2017
-CPSC,8170,1,Physically Based Animation,0.64,0.18,0.09,0.0,0.0,0.0,0.0,0.09,jerry tessendorf,CPSC-8170,2017
-CPSC,8200,1,Parallel Architechture,0.36,0.36,0.07,0.0,0.07,0.0,0.0,0.14,pradip srimani,CPSC-8200,2017
-CPSC,8270,1,Translation of Progr Languages,0.56,0.28,0.13,0.0,0.03,0.0,0.0,0.0,brian malloy,CPSC-8270,2017
-CPSC,8480,1,Network Science,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ilya mark safro,CPSC-8480,2017
-CPSC,8730,1,"Software Verif, Valid & Measur",0.41,0.54,0.0,0.0,0.0,0.0,0.0,0.05,john mcgregor,CPSC-8730,2017
-CPSC,8810,1,Selected Topics: Data Analytic,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CPSC-8810,2017
-CPSC,8810,2,Sel Top: VH/Embod Conver Agent,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,andrew robb,CPSC-8810,2017
-CRP,8010,1,Planning Process & Legal Found,0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,caitlin dyckman,CRP-8010,2017
-CRP,8020,1,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,CRP-8020,2017
-CRP,8030,2,Quan Analysis for Planners,0.63,0.19,0.06,0.0,0.0,0.0,0.0,0.13,eric morris,CRP-8030,2017
-CRP,8040,1,Intro to GIS for Plan & Policy,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,timothy green,CRP-8040,2017
-CRP,8080,1,Land Use and Compreh Planning,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,clifford dona ellis,CRP-8080,2017
-CRP,8450,1,Water Policy & Law,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,CRP-8450,2017
-CSM,1000,1,Intro to Construct,0.44,0.33,0.11,0.04,0.04,0.0,0.0,0.04,jason lucas,CSM-1000,2017
-CSM,1000,2,Intro to Construct,0.5,0.38,0.04,0.04,0.04,0.0,0.0,0.0,jason lucas,CSM-1000,2017
-CSM,2010,1,Structures I,0.18,0.25,0.32,0.14,0.07,0.0,0.0,0.04,shima clarke,CSM-2010,2017
-CSM,2010,2,Structures I,0.36,0.25,0.21,0.07,0.11,0.0,0.0,0.0,shima clarke,CSM-2010,2017
-CSM,2030,1,Mats & Meth of Const,0.27,0.53,0.13,0.03,0.03,0.0,0.0,0.0,robert seel,CSM-2030,2017
-CSM,2030,2,Mats & Meth of Const,0.23,0.5,0.13,0.0,0.07,0.0,0.0,0.07,robert seel,CSM-2030,2017
-CSM,3040,1,Envir Systems I,0.27,0.43,0.3,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2017
-CSM,3040,2,Envir Systems I,0.25,0.46,0.13,0.13,0.04,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2017
-CSM,3060,1,Emerging Tech in Construction,0.43,0.43,0.11,0.0,0.0,0.0,0.0,0.04,jason lucas,CSM-3060,2017
-CSM,3060,2,Emerging Tech in Construction,0.52,0.36,0.08,0.0,0.0,0.0,0.0,0.04,jason lucas,CSM-3060,2017
-CSM,3510,1,Const Estimating,0.23,0.35,0.23,0.08,0.12,0.0,0.0,0.0,seyed mousavi rizi,CSM-3510,2017
-CSM,3510,2,Const Estimating,0.36,0.32,0.29,0.0,0.04,0.0,0.0,0.0,seyed mousavi rizi,CSM-3510,2017
-CSM,4110,1,Safety in Bldg Const,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,nicholas corley,CSM-4110,2017
-CSM,4110,2,Safety in Bldg Const,0.61,0.35,0.03,0.0,0.0,0.0,0.0,0.0,nicholas corley,CSM-4110,2017
-CSM,4500,1,Construction Intern,0.84,0.02,0.14,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,CSM-4500,2017
-CSM,4530,1,Const Proj Mgmt,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4530,2017
-CSM,4530,2,Const Proj Mgmt,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4530,2017
-CSM,4610,1,Const Econ Seminar,0.23,0.47,0.3,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-4610,2017
-CSM,4610,2,Const Econ Seminar,0.07,0.53,0.33,0.07,0.0,0.0,0.0,0.0,christine piper,CSM-4610,2017
-CSM,8610,1,Construction Control Systems,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-8610,2017
-CSM,8610,400,Construction Control Systems,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-8610,2017
-CSM,8620,1,Personnel Mgt & Neg,0.13,0.5,0.25,0.0,0.13,0.0,0.0,0.0,roger william liska,CSM-8620,2017
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,CU-1000,2017
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,susan whorton,CU-1000,2017
-CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,CU-1000,2017
-CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,CU-1000,2017
-CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,CU-1000,2017
-CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.05,0.01,susan whorton,CU-1000,2017
-CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,susan whorton,CU-1000,2017
-CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.79,0.2,0.01,susan whorton,CU-1000,2017
-CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.17,0.01,susan whorton,CU-1000,2017
-CU,1000,11,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.78,0.21,0.01,susan whorton,CU-1000,2017
-CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.24,0.01,susan whorton,CU-1000,2017
-CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.7,0.29,0.01,susan whorton,CU-1000,2017
-CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.79,0.21,0.0,susan whorton,CU-1000,2017
-CU,1000,20,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,CU-1000,2017
-CU,1000,21,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,susan whorton,CU-1000,2017
-CU,1010,1,Univ Success Skills,0.46,0.23,0.15,0.0,0.08,0.0,0.0,0.08,bryn zimmerman babb,CU-1010,2017
-CU,1010,3,Univ Success Skills,0.29,0.24,0.24,0.0,0.12,0.0,0.0,0.12,kirsten noelle dean,CU-1010,2017
-CU,1010,6,Univ Success Skills,0.43,0.07,0.14,0.07,0.21,0.0,0.0,0.07,cari allyn brooks,CU-1010,2017
-CU,1010,613,Univ Success Skills,0.5,0.37,0.05,0.03,0.05,0.0,0.0,0.0,elizabeth stephan,CU-1010,2017
-CU,1010,614,Univ Success Skills,0.34,0.24,0.15,0.12,0.12,0.0,0.0,0.02,mariah magagnotti,CU-1010,2017
-CU,1010,616,Univ Success Skills,0.58,0.32,0.03,0.0,0.03,0.0,0.0,0.03,matthew kent miller,CU-1010,2017
-CVT,2260,1,Intro Cardiovas Sono,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,eric walker,CVT-2260,2017
-DANC,1300,1,Tap Dance I,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,cheryl hosler,DANC-1300,2017
-DPA,3070,1,Method 3d Production,0.59,0.17,0.1,0.0,0.03,0.0,0.0,0.1,sarah lydia martin,DPA-3070,2017
-DPA,3070,2,Method 3d Production,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,summer 'nea benton,DPA-3070,2017
-DPA,4000,1,Tech Foundations I,0.09,0.18,0.09,0.0,0.0,0.0,0.0,0.64,andrew duchowski,DPA-4000,2017
-DPA,4020,1,Vis Foundations I,0.69,0.19,0.06,0.0,0.06,0.0,0.0,0.0,erik reed,DPA-4020,2017
-DPA,6830,3,Spec Stud To in DPA: Z-Brush,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,insun kwon,DPA-6830,2017
-DPA,8070,1,3D Modeling and Animation,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,DPA-8070,2017
-DPA,8150,1,Special Effects Compositing,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,DPA-8150,2017
-ECE,2010,1,Logic and Computing Devices,0.2,0.27,0.26,0.1,0.12,0.0,0.0,0.05,william reid,ECE-2010,2017
-ECE,2010,2,Logic & Comp Device (HON),0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,william reid,ECE-2010,2017
-ECE,2020,1,Electric Circuits I,0.2,0.37,0.19,0.07,0.06,0.0,0.0,0.1,william harrell,ECE-2020,2017
-ECE,2070,1,Basic Electrical Engineering,0.48,0.3,0.16,0.03,0.01,0.0,0.0,0.02,timothy anglea,ECE-2070,2017
-ECE,2070,2,Basic Electrical Engineering,0.4,0.21,0.23,0.05,0.07,0.0,0.0,0.05,daniel bla cutshall,ECE-2070,2017
-ECE,2070,3,Basic Electrical Engineering,0.47,0.33,0.07,0.04,0.03,0.0,0.0,0.06,william th kolodzey,ECE-2070,2017
-ECE,2080,1,Basic Electrical Engr Lab,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,2,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,3,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,7,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,8,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,9,Basic Electrical Engr Lab,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,10,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,12,Basic Electrical Engr Lab,0.75,0.15,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,14,Basic Electrical Engr Lab,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,15,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2090,6,Logic Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,apoorva dee kapadia,ECE-2090,2017
-ECE,2090,8,Logic Lab,0.73,0.0,0.09,0.0,0.0,0.0,0.0,0.18,apoorva dee kapadia,ECE-2090,2017
-ECE,2090,12,Logic Lab,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva dee kapadia,ECE-2090,2017
-ECE,2090,13,Logic Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2017
-ECE,2110,1,Elec Engr Lab I,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,2,Elec Engr Lab I,0.75,0.1,0.0,0.0,0.0,0.0,0.0,0.15,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,3,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,4,Elec Engr Lab I,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,5,Elec Engr Lab I,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,6,Elec Engr Lab I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,7,Elec Engr Lab I,0.75,0.0,0.1,0.0,0.1,0.0,0.0,0.05,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,8,Elec Engr Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,9,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,10,Elec Engr Lab I,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,apoorva dee kapadia,ECE-2110,2017
-ECE,2220,1,Syst Prog Concept,0.25,0.25,0.23,0.08,0.0,0.0,0.0,0.19,harlan russell,ECE-2220,2017
-ECE,2230,1,Comp Sys Eng,0.33,0.45,0.08,0.1,0.0,0.0,0.0,0.04,walter ligon,ECE-2230,2017
-ECE,2620,1,Electric Circuits II,0.25,0.27,0.19,0.17,0.04,0.0,0.0,0.08,liang dong,ECE-2620,2017
-ECE,2720,1,Comp Organization,0.18,0.43,0.28,0.08,0.05,0.0,0.0,0.0,william reid,ECE-2720,2017
-ECE,2730,3,Computer Org Lab,0.45,0.18,0.27,0.09,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2017
-ECE,3110,1,Electrical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2017
-ECE,3110,2,Electrical Engineering Lab III,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2017
-ECE,3110,3,Electrical Engineering Lab III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2017
-ECE,3110,4,Electrical Engineering Lab III,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,apoorva dee kapadia,ECE-3110,2017
-ECE,3110,7,Electrical Engineering Lab III,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2017
-ECE,3110,8,Electrical Engineering Lab III,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,apoorva dee kapadia,ECE-3110,2017
-ECE,3110,9,Electrical Engineering Lab III,0.38,0.5,0.0,0.06,0.06,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2017
-ECE,3120,2,Electrical Engineering Lab IV,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3120,2017
-ECE,3170,1,Rand Signal Analysis,0.33,0.43,0.2,0.02,0.0,0.0,0.0,0.03,stephen hubbard,ECE-3170,2017
-ECE,3200,1,Electronics I,0.21,0.23,0.28,0.2,0.08,0.0,0.0,0.01,stephen hubbard,ECE-3200,2017
-ECE,3210,1,Electronics II,0.28,0.55,0.08,0.08,0.03,0.0,0.0,0.0,stephen hubbard,ECE-3210,2017
-ECE,3220,1,Intro Operating Sys,0.13,0.55,0.32,0.0,0.0,0.0,0.0,0.0,mark smotherman,ECE-3220,2017
-ECE,3270,1,Dig Comp Design,0.13,0.35,0.13,0.23,0.03,0.0,0.0,0.13,melissa crawl smith,ECE-3270,2017
-ECE,3300,1,Signals & Systems,0.08,0.3,0.19,0.22,0.09,0.0,0.0,0.12,carl baum,ECE-3300,2017
-ECE,3300,2,Signals & Systems (HON),0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,ECE-3300,2017
-ECE,3520,1,Programming Systems,0.65,0.27,0.04,0.0,0.0,0.0,0.0,0.04,robert schalkoff,ECE-3520,2017
-ECE,3600,1,Elect Power Engr,0.33,0.36,0.2,0.06,0.05,0.0,0.0,0.0,edward collins,ECE-3600,2017
-ECE,3710,1,Microcontr Interface,0.4,0.3,0.21,0.06,0.02,0.0,0.0,0.01,william reid,ECE-3710,2017
-ECE,3720,1,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,3,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,4,Micro Int Lab,0.58,0.33,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,6,Micro Int Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,7,Micro Int Lab,0.25,0.58,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,9,Micro Int Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3800,1,Electromagnetics,0.23,0.22,0.31,0.05,0.09,0.0,0.0,0.11,jeffrey osterberg,ECE-3800,2017
-ECE,3810,1,Field Waves & Ckts,0.13,0.43,0.26,0.0,0.09,0.0,0.0,0.09,anthony martin,ECE-3810,2017
-ECE,4090,1,Intr to Linear Control Systems,0.56,0.34,0.08,0.0,0.02,0.0,0.0,0.0,apoorva dee kapadia,ECE-4090,2017
-ECE,4180,1,Power Syst Analysis,0.23,0.33,0.17,0.03,0.1,0.0,0.0,0.13,ramtin hadidi,ECE-4180,2017
-ECE,4270,1,Communications Sys,0.35,0.44,0.15,0.01,0.03,0.0,0.0,0.01,madhabi manandhar,ECE-4270,2017
-ECE,4420,1,Knowledge Engr,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,robert schalkoff,ECE-4420,2017
-ECE,4490,1,Comp Ntwrk Security,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,richard brooks,ECE-4490,2017
-ECE,4610,1,Fundamentals of Solar Energy,0.45,0.35,0.18,0.0,0.0,0.0,0.0,0.03,rajendra singh,ECE-4610,2017
-ECE,4670,1,Intro to Dig Sig Pro,0.36,0.14,0.36,0.07,0.0,0.0,0.0,0.07,john gowdy,ECE-4670,2017
-ECE,4730,1,Intro Parallel Sys,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,walter ligon,ECE-4730,2017
-ECE,4950,1,Int Sys Design I,0.7,0.29,0.01,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-4950,2017
-ECE,4960,1,Int Sys Design II,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2017
-ECE,6040,1,Semiconductor Devices,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson doug ryckman,ECE-6040,2017
-ECE,6180,400,Power Syst Analysis,0.4,0.0,0.4,0.0,0.0,0.0,0.0,0.2,ramtin hadidi,ECE-6180,2017
-ECE,6310,1,Intro to Computer Vision,0.48,0.38,0.1,0.0,0.0,0.0,0.0,0.05,adam hoover,ECE-6310,2017
-ECE,6420,1,Knowledge Engr,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert schalkoff,ECE-6420,2017
-ECE,6420,400,Knowledge Engr,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,robert schalkoff,ECE-6420,2017
-ECE,6490,1,Comp Ntwrk Security,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,ECE-6490,2017
-ECE,6490,400,Comp Ntwrk Security,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,richard brooks,ECE-6490,2017
-ECE,6590,1,Int Circ Design,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,ECE-6590,2017
-ECE,6610,1,Fundamentals of Solar Energy,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,rajendra singh,ECE-6610,2017
-ECE,6670,1,Intro to Dig Sig Pro,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john gowdy,ECE-6670,2017
-ECE,6730,1,Intro Parallel Sys,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,walter ligon,ECE-6730,2017
-ECE,8010,1,Analysis of Lin Sys,0.48,0.41,0.04,0.0,0.0,0.0,0.0,0.07,richard groff,ECE-8010,2017
-ECE,8540,1,Analysis of Tracking Systems,0.86,0.1,0.0,0.0,0.03,0.0,0.0,0.0,adam hoover,ECE-8540,2017
-ECON,2000,2,Economic Concepts,0.5,0.33,0.08,0.05,0.05,0.0,0.0,0.0,jonathan orr ernest,ECON-2000,2017
-ECON,2000,4,Economic Concepts,0.46,0.44,0.05,0.03,0.03,0.0,0.0,0.0,miren ivankovic,ECON-2000,2017
-ECON,2000,5,Economic Concepts,0.31,0.23,0.31,0.05,0.08,0.0,0.0,0.03,jonathan orr ernest,ECON-2000,2017
-ECON,2110,1,Principles of Microeconomics,0.21,0.42,0.11,0.16,0.0,0.0,0.0,0.11,frederick hanssen,ECON-2110,2017
-ECON,2110,2,Principles of Microeconomics,0.21,0.26,0.32,0.11,0.05,0.0,0.0,0.05,frederick hanssen,ECON-2110,2017
-ECON,2110,3,Principles of Microeconomics,0.16,0.16,0.47,0.05,0.05,0.0,0.0,0.11,frederick hanssen,ECON-2110,2017
-ECON,2110,4,Principles of Microeconomics,0.0,0.37,0.53,0.05,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2017
-ECON,2110,5,Principles of Microeconomics,0.11,0.47,0.32,0.05,0.05,0.0,0.0,0.0,frederick hanssen,ECON-2110,2017
-ECON,2110,6,Principles of Microeconomics,0.11,0.37,0.42,0.05,0.0,0.0,0.0,0.05,frederick hanssen,ECON-2110,2017
-ECON,2110,7,Principles of Microeconomics,0.11,0.26,0.32,0.11,0.16,0.0,0.0,0.05,frederick hanssen,ECON-2110,2017
-ECON,2110,8,Principles of Microeconomics,0.11,0.28,0.44,0.06,0.06,0.0,0.0,0.06,frederick hanssen,ECON-2110,2017
-ECON,2110,9,Principles of Microeconomics,0.16,0.26,0.37,0.05,0.05,0.0,0.0,0.11,frederick hanssen,ECON-2110,2017
-ECON,2110,10,Principles of Microeconomics,0.11,0.28,0.28,0.06,0.11,0.0,0.0,0.17,frederick hanssen,ECON-2110,2017
-ECON,2110,11,Principles of Microeconomics,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2017
-ECON,2110,12,Principles of Microeconomics,0.11,0.42,0.26,0.21,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2017
-ECON,2110,13,Principles of Microeconomics,0.21,0.32,0.37,0.11,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2017
-ECON,2110,14,Principles of Microeconomics,0.21,0.21,0.42,0.05,0.0,0.0,0.0,0.11,frederick hanssen,ECON-2110,2017
-ECON,2110,15,Principles of Microeconomics,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,frederick hanssen,ECON-2110,2017
-ECON,2110,16,Principles of Microeconomics,0.16,0.11,0.47,0.11,0.11,0.0,0.0,0.05,frederick hanssen,ECON-2110,2017
-ECON,2110,17,Principles of Microeconomics,0.11,0.58,0.16,0.05,0.11,0.0,0.0,0.0,frederick hanssen,ECON-2110,2017
-ECON,2110,18,Principles of Microeconomics,0.05,0.32,0.42,0.05,0.05,0.0,0.0,0.11,frederick hanssen,ECON-2110,2017
-ECON,2110,19,Principles of Microeconomics,0.11,0.53,0.11,0.11,0.05,0.0,0.0,0.11,frederick hanssen,ECON-2110,2017
-ECON,2110,20,Principles of Microeconomics,0.16,0.36,0.35,0.13,0.0,0.0,0.0,0.0,benjamin posmanick,ECON-2110,2017
-ECON,2110,21,Principles of Microeconomics,0.33,0.42,0.18,0.06,0.0,0.0,0.0,0.0,michael makowsky,ECON-2110,2017
-ECON,2110,22,Principles of Microeconomics,0.24,0.33,0.26,0.1,0.02,0.0,0.0,0.05,roksan ghanbariamin,ECON-2110,2017
-ECON,2110,23,Principles of Microeconomics,0.26,0.31,0.25,0.11,0.07,0.0,0.0,0.01,sarah louise wilson,ECON-2110,2017
-ECON,2110,24,Principles of Microeconomics,0.2,0.38,0.24,0.12,0.05,0.0,0.0,0.02,kelsey vict roberts,ECON-2110,2017
-ECON,2110,25,Principles of Microeconomics,0.21,0.67,0.1,0.0,0.0,0.0,0.0,0.03,chen wang,ECON-2110,2017
-ECON,2110,26,Principles of Microeconomics,0.22,0.47,0.18,0.07,0.0,0.0,0.0,0.07,benjamin jo schwall,ECON-2110,2017
-ECON,2110,31,Principles of Microeconomics,0.4,0.37,0.17,0.01,0.01,0.0,0.0,0.03,jacob walloga,ECON-2110,2017
-ECON,2110,32,Principles of Microeconomics,0.13,0.44,0.33,0.02,0.02,0.0,0.0,0.06,frederick hanssen,ECON-2110,2017
-ECON,2110,33,Principles of Microeconomics,0.15,0.44,0.22,0.07,0.05,0.0,0.0,0.07,charles thomas,ECON-2110,2017
-ECON,2110,34,Principles of Microecon (HON),0.45,0.45,0.05,0.05,0.0,0.0,0.0,0.0,charles thomas,ECON-2110,2017
-ECON,2110,35,Principles of Microeconomics,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,chen wang,ECON-2110,2017
-ECON,2110,36,Principles of Microeconomics,0.18,0.48,0.25,0.08,0.0,0.0,0.0,0.03,roksan ghanbariamin,ECON-2110,2017
-ECON,2110,38,Principles of Microeconomics,0.33,0.24,0.26,0.07,0.05,0.0,0.0,0.05,liuna issagholian,ECON-2110,2017
-ECON,2110,40,Principles of Microeconomics,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.03,zhiqi zhao,ECON-2110,2017
-ECON,2110,41,Principles of Microeconomics,0.39,0.34,0.17,0.07,0.02,0.0,0.0,0.0,liuna issagholian,ECON-2110,2017
-ECON,2120,1,Principles of Macroeconomics,0.08,0.14,0.08,0.17,0.11,0.0,0.0,0.42,ralph charles allen,ECON-2120,2017
-ECON,2120,2,Principles of Macroeconomics,0.31,0.51,0.13,0.02,0.02,0.0,0.0,0.0,kyle lance rechard,ECON-2120,2017
-ECON,2120,3,Principles of Macroeconomics,0.15,0.09,0.18,0.15,0.16,0.0,0.0,0.27,ralph charles allen,ECON-2120,2017
-ECON,2120,4,Principles of Macroeconomics,0.26,0.4,0.19,0.05,0.03,0.0,0.0,0.06,elijah neilson,ECON-2120,2017
-ECON,2120,5,Principles of Macroeconomics,0.24,0.41,0.2,0.1,0.0,0.0,0.0,0.05,benjamin ti harbolt,ECON-2120,2017
-ECON,2120,6,Principles of Macroeconomics,0.15,0.35,0.43,0.03,0.05,0.0,0.0,0.0,benjamin ti harbolt,ECON-2120,2017
-ECON,2120,7,Principles of Macroeconomics,0.23,0.43,0.3,0.0,0.0,0.0,0.0,0.05,kyle lance rechard,ECON-2120,2017
-ECON,2120,8,Principles of Macroeconomics,0.87,0.1,0.0,0.02,0.0,0.0,0.0,0.02,jeremy choquette,ECON-2120,2017
-ECON,2120,9,Principles of Macroeconomics,0.35,0.38,0.18,0.08,0.03,0.0,0.0,0.0,narendra regmi,ECON-2120,2017
-ECON,2120,10,Principles of Macroeconomics,0.71,0.07,0.07,0.02,0.07,0.0,0.0,0.05,jeremy choquette,ECON-2120,2017
-ECON,3020,1,Money and Banking,0.08,0.51,0.32,0.0,0.03,0.0,0.0,0.05,smriti bhargava,ECON-3020,2017
-ECON,3060,1,Managerial Economics,0.23,0.28,0.3,0.13,0.05,0.0,0.0,0.03,steven johnson,ECON-3060,2017
-ECON,3100,1,International Econ,0.29,0.29,0.16,0.1,0.09,0.0,0.0,0.09,samuel ar standaert,ECON-3100,2017
-ECON,3140,1,Intermediate Micro,0.25,0.17,0.25,0.1,0.1,0.0,0.0,0.12,patrick warren,ECON-3140,2017
-ECON,3140,2,Intermediate Micro,0.26,0.35,0.24,0.06,0.06,0.0,0.0,0.02,molly espey,ECON-3140,2017
-ECON,3140,3,Intermediate Micro,0.24,0.35,0.22,0.06,0.04,0.0,0.0,0.1,robert kennet fleck,ECON-3140,2017
-ECON,3150,1,Intermediate Macro,0.39,0.25,0.1,0.02,0.08,0.0,0.0,0.16,sergey vla mityakov,ECON-3150,2017
-ECON,3150,2,Intermediate Macro,0.31,0.34,0.24,0.08,0.03,0.0,0.0,0.0,michal jerzmanowski,ECON-3150,2017
-ECON,3190,1,Environmental Econ,0.36,0.33,0.23,0.03,0.03,0.0,0.0,0.03,molly espey,ECON-3190,2017
-ECON,3600,1,Public Choice,0.41,0.24,0.21,0.12,0.03,0.0,0.0,0.0,michael makowsky,ECON-3600,2017
-ECON,4010,1,Labor Mkt Analysis,0.37,0.37,0.22,0.0,0.04,0.0,0.0,0.0,chungsang lam,ECON-4010,2017
-ECON,4020,1,Law and Economics,0.21,0.41,0.31,0.05,0.0,0.0,0.0,0.03,howard ne bodenhorn,ECON-4020,2017
-ECON,4040,1,Comp Econ Systems,0.13,0.38,0.06,0.19,0.19,0.0,0.0,0.06,dar litsukova-bokar,ECON-4040,2017
-ECON,4050,5,Intro to Econometric,0.19,0.23,0.32,0.12,0.11,0.0,0.0,0.04,scott barkowski,ECON-4050,2017
-ECON,4100,1,Economic Development,0.59,0.33,0.0,0.0,0.04,0.0,0.0,0.04,robert tamura,ECON-4100,2017
-ECON,4110,2,Econ of Education,0.3,0.43,0.23,0.0,0.0,0.0,0.0,0.03,peter quarter blair,ECON-4110,2017
-ECON,4120,1,International Micro,0.36,0.39,0.14,0.07,0.04,0.0,0.0,0.0,richard alan sessa,ECON-4120,2017
-ECON,4220,1,Monetary Economics,0.26,0.5,0.12,0.0,0.03,0.0,0.0,0.09,gerald dwyer,ECON-4220,2017
-ECON,4230,1,Economics of Health,0.47,0.18,0.24,0.06,0.0,0.0,0.0,0.06,devon merritt gorry,ECON-4230,2017
-ECON,4250,1,Antitrust Economics,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,raymond sauer,ECON-4250,2017
-ECON,4260,1,Sem Sport Economics,0.47,0.47,0.0,0.05,0.0,0.0,0.0,0.0,raymond sauer,ECON-4260,2017
-ECON,4280,1,Cost-Benefit Anlysis,0.46,0.29,0.11,0.06,0.03,0.0,0.0,0.06,robert kennet fleck,ECON-4280,2017
-ECON,6050,5,Intro to Econometric,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,scott barkowski,ECON-6050,2017
-ECON,6060,1,Advanced Econometric,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,ECON-6060,2017
-ECON,8010,1,Microeconomic Theory,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,william dougan,ECON-8010,2017
-ECON,8040,1,Applied Math Econ,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,curtis simon,ECON-8040,2017
-ECON,8060,1,Econometrics I,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,paul wayne wilson,ECON-8060,2017
-ECON,8080,1,Econometrics III,0.14,0.43,0.21,0.0,0.14,0.0,0.0,0.07,paul wayne wilson,ECON-8080,2017
-ECON,8230,1,Microecon Pub Pol,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,scott templeton,ECON-8230,2017
-ECON,8240,1,Org of Industry,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew lewis,ECON-8240,2017
-ECON,8260,1,Econ Theory of Govt Regulation,0.17,0.5,0.0,0.0,0.0,0.0,0.0,0.33,thomas wins hazlett,ECON-8260,2017
-ECON,8550,1,Financial Economics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sergey vla mityakov,ECON-8550,2017
-ED,1050,1,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,ED-1050,2017
-ED,1050,2,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,ED-1050,2017
-ED,1050,5,Educ Orientation,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,ED-1050,2017
-ED,1050,7,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,ED-1050,2017
-ED,8700,300,STEAM Instructional Design,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,ED-8700,2017
-EDC,3900,1,Skills for Stu Leads,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,EDC-3900,2017
-EDC,3900,2,Skills for Stu Leads,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,eric pernotto,EDC-3900,2017
-EDC,3990,1,Creative Inq in Counselor Ed,0.82,0.06,0.0,0.0,0.0,0.0,0.0,0.12,ken stewart-tillman,EDC-3990,2017
-EDEC,4400,1,Early Childhood Engl Lang Art,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-4400,2017
-EDEL,3210,1,Pe for the Elem Tchr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2017
-EDEL,3210,2,Pe for the Elem Tchr,0.72,0.14,0.14,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2017
-EDEL,4510,1,Elem Methods in Science Tchg,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,EDEL-4510,2017
-EDEL,4870,1,Ele Meth Soc Studies,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,EDEL-4870,2017
-EDEL,4870,2,Ele Meth Soc Studies,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,EDEL-4870,2017
-EDEL,4880,1,Elem Meth La Tchng,0.68,0.23,0.09,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,EDEL-4880,2017
-EDEL,4880,2,Elem Meth La Tchng,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,EDEL-4880,2017
-EDF,3010,2,Principles of American Educat,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,EDF-3010,2017
-EDF,3020,2,Educational Psychology,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,EDF-3020,2017
-EDF,3080,3,Classroom Assessment,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,EDF-3080,2017
-EDF,3350,1,Adolescent Growth & Develop,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,EDF-3350,2017
-EDF,3350,2,Adolescent Growth & Develop,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,EDF-3350,2017
-EDF,4800,1,Digital Media & Learning,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2017
-EDF,4800,2,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2017
-EDF,4800,301,Digital Media & Learning,0.39,0.39,0.06,0.11,0.0,0.0,0.0,0.06,aamena bilal saleh,EDF-4800,2017
-EDF,4800,302,Digital Media & Learning,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2017
-EDF,8080,302,Contempor Issues in Assessment,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,heather rog brooker,EDF-8080,2017
-EDF,9270,1,Quant Rsrch & Stats for Ed,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,eliza dar gallagher,EDF-9270,2017
-EDF,9270,400,Quant Rsrch & Stats for Ed,0.62,0.31,0.0,0.0,0.08,0.0,0.0,0.0,jennie lynn farmer,EDF-9270,2017
-EDF,9710,501,Case Study & Ethnographic Mthd,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,daniella hall,EDF-9710,2017
-EDHD,8310,500,Lit Outcomes for Child w disab,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,renee gatlin anders,EDHD-8310,2017
-EDL,7300,500,Techniq of Supervision-Pub Sch,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,EDL-7300,2017
-EDL,7400,502,Curr Plan: Sch Adm,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,barbara nesbitt,EDL-7400,2017
-EDL,7500,501,El Prin & Spv Ex I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,EDL-7500,2017
-EDL,7550,500,Sec Prin & Spv Exp I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,EDL-7550,2017
-EDL,8850,401,HRD Learning Leadership,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,angela danie carter,EDL-8850,2017
-EDL,9050,400,Thry/Prac Ed Ldrshp,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,russell marion,EDL-9050,2017
-EDL,9110,400,Systematic Inq Ed L,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,jane lindle,EDL-9110,2017
-EDLT,4590,1,Teaching Reading Grades K-3,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,koti lee hubbard,EDLT-4590,2017
-EDLT,4600,1,Teaching Reading Grades 2-6,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4600,2017
-EDLT,4600,3,Teaching Reading Grades 2-6,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4600,2017
-EDLT,4600,6,Teaching Reading Grades 2-6,0.6,0.27,0.07,0.07,0.0,0.0,0.0,0.0,julia kate bentley,EDLT-4600,2017
-EDLT,4610,1,Content Area Rdg: Grades 2-6,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-4610,2017
-EDLT,4980,1,Secondary Content Area Reading,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,lorraine an jacques,EDLT-4980,2017
-EDLT,4980,3,Secondary Content Area Reading,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,rachelle savitz,EDLT-4980,2017
-EDLT,8170,300,Content Area Rdg/Wtg: ECE-ELEM,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,rachelle savitz,EDLT-8170,2017
-EDLT,8220,500,Strategies for Teaching ESOL,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-8220,2017
-EDLT,8270,400,Content Area Rdg/Wtg-MS & HS,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,rebecca kaminski,EDLT-8270,2017
-EDLT,8400,500,Early Literacy Assessment I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,ellen adkin sanford,EDLT-8400,2017
-EDLT,8400,501,Early Literacy Assessment I,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jamie felder white,EDLT-8400,2017
-EDLT,8400,503,Early Literacy Assessment I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jaime adele dawson,EDLT-8400,2017
-EDLT,8400,504,Early Literacy Assessment I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,EDLT-8400,2017
-EDLT,8400,506,Early Literacy Assessment I,0.73,0.0,0.0,0.0,0.09,0.0,0.0,0.18,renee gatlin anders,EDLT-8400,2017
-EDLT,8400,507,Early Literacy Assessment I,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,michael moss,EDLT-8400,2017
-EDLT,8820,502,Read Recovery Practicum I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary ann fr mcbride,EDLT-8820,2017
-EDLT,9140,1,"Lang Dev, Diversity, Discourse",0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-9140,2017
-EDSA,8100,1,Theories & Techn of Counseling,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,EDSA-8100,2017
-EDSC,2260,1,Pr Apprch to Sec Alg,0.38,0.38,0.15,0.0,0.0,0.0,0.0,0.08,stacy megan che,EDSC-2260,2017
-EDSC,3280,1,Practicum Sec Soc St,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,william da mccorkle,EDSC-3280,2017
-EDSC,4260,1,Tchng Sec Math,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,carlos gomez,EDSC-4260,2017
-EDSP,3720,1,Char & Instr Individ with LD,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,catherine griffith,EDSP-3720,2017
-EDSP,3740,1,Char & Strat Emot/Behav Disord,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,EDSP-3740,2017
-EDSP,4920,1,Math Inst Ind W/Dis,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,pamela stecker,EDSP-4920,2017
-EDSP,4930,1,Clsrm/Beh Mgmt Sp Ed,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,joseph benedic ryan,EDSP-4930,2017
-EDSP,4940,1,Tchg Rdg Mild Dis,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,abigail anne allen,EDSP-4940,2017
-EDSP,8220,400,Tchg Math Indv W/Dis,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,pamela stecker,EDSP-8220,2017
-EES,2010,1,Environ Engr Fundamentals I,0.28,0.38,0.18,0.08,0.08,0.0,0.0,0.03,david freedman,EES-2010,2017
-EES,3030,1,Water Treatment Systems,0.63,0.25,0.09,0.03,0.0,0.0,0.0,0.0,david allen ladner,EES-3030,2017
-EES,3040,1,Wastewater Treatment Systems,0.34,0.41,0.16,0.06,0.03,0.0,0.0,0.0,sudeep popat,EES-3040,2017
-EES,3050,1,Water/Wastewater Treatment Lab,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2017
-EES,3050,2,Water/Wastewater Treatment Lab,0.47,0.4,0.07,0.0,0.0,0.0,0.0,0.07,sudeep popat,EES-3050,2017
-EES,4010,1,Environmental Engr,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,EES-4010,2017
-EES,4010,2,Environmental Engr,0.26,0.52,0.17,0.0,0.04,0.0,0.0,0.0,mark schlautman,EES-4010,2017
-EES,4100,1,Environ Radiation Protection I,0.22,0.39,0.11,0.11,0.0,0.0,0.0,0.17,nicole eli martinez,EES-4100,2017
-EES,4300,1,Air Pollution Engineering,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,andrew rich metcalf,EES-4300,2017
-EES,4800,1,Environmental Risk Assessment,0.23,0.57,0.13,0.0,0.03,0.0,0.0,0.03,nicole eli martinez,EES-4800,2017
-EES,4840,1,Solid Waste Mgt,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,yi zheng,EES-4840,2017
-EES,4860,1,Environmental Sustainability,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,EES-4860,2017
-EES,6100,1,Environ Radiation Protection I,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,nicole eli martinez,EES-6100,2017
-EES,8020,1,Environ Eng Prin,0.71,0.14,0.07,0.0,0.0,0.0,0.0,0.07,david allen ladner,EES-8020,2017
-EES,8060,1,Design Env Control,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,EES-8060,2017
-EES,8080,1,Groundwater Modeling,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,EES-8080,2017
-EES,8430,1,Environmental Chem,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,brian powell,EES-8430,2017
-EES,8510,1,Biol Prin Envir Engr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,EES-8510,2017
-EES,8800,1,Env Risk Assessment,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,EES-8800,2017
-ELE,3010,1,Entrepreneurial Foundations,0.46,0.46,0.03,0.03,0.03,0.0,0.0,0.0,christina kyprianou,ELE-3010,2017
-ELE,3010,2,Entrepreneurial Foundations,0.33,0.65,0.0,0.0,0.0,0.0,0.0,0.03,christina kyprianou,ELE-3010,2017
-ELE,3010,3,Entrepreneurial Foundations,0.18,0.42,0.26,0.03,0.03,0.0,0.0,0.08,ashley will parnell,ELE-3010,2017
-ELE,4010,1,Venture Testing,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,chad navis,ELE-4010,2017
-ELE,4020,1,Venture Creation,0.33,0.58,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,ELE-4020,2017
-ELE,4030,1,Venture Growth,0.17,0.26,0.48,0.0,0.09,0.0,0.0,0.0,ashley will parnell,ELE-4030,2017
-ENGL,1030,2,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,ENGL-1030,2017
-ENGL,1030,3,Composition and Rhetoric,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,krist aldebol-hazle,ENGL-1030,2017
-ENGL,1030,4,Composition and Rhetoric,0.56,0.33,0.0,0.0,0.06,0.0,0.0,0.06,jennie el wakefield,ENGL-1030,2017
-ENGL,1030,7,Composition and Rhetoric,0.58,0.16,0.16,0.0,0.0,0.0,0.0,0.11,stephen quigley,ENGL-1030,2017
-ENGL,1030,8,Composition and Rhetoric,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,ENGL-1030,2017
-ENGL,1030,9,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jennie el wakefield,ENGL-1030,2017
-ENGL,1030,10,Composition and Rhetoric,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,austin gorman,ENGL-1030,2017
-ENGL,1030,11,Composition and Rhetoric,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,austin gorman,ENGL-1030,2017
-ENGL,1030,12,Composition and Rhetoric,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,carrie hill,ENGL-1030,2017
-ENGL,1030,14,Composition and Rhetoric,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,caroline eliz young,ENGL-1030,2017
-ENGL,1030,15,Composition and Rhetoric,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel qui atkinson,ENGL-1030,2017
-ENGL,1030,17,Composition and Rhetoric,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2017
-ENGL,1030,18,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jennie el wakefield,ENGL-1030,2017
-ENGL,1030,19,Composition and Rhetoric,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2017
-ENGL,1030,21,Composition and Rhetoric,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,jennie el wakefield,ENGL-1030,2017
-ENGL,1030,22,Composition and Rhetoric,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,abigail maxim,ENGL-1030,2017
-ENGL,1030,23,Composition and Rhetoric,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,stephen hundley,ENGL-1030,2017
-ENGL,1030,24,Composition and Rhetoric,0.71,0.12,0.18,0.0,0.0,0.0,0.0,0.0,sarah el richardson,ENGL-1030,2017
-ENGL,1030,25,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,martha sue karnes,ENGL-1030,2017
-ENGL,1030,26,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,ENGL-1030,2017
-ENGL,1030,27,Composition and Rhetoric,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,michael davi measel,ENGL-1030,2017
-ENGL,1030,29,Composition and Rhetoric,0.61,0.28,0.0,0.06,0.0,0.0,0.0,0.06,caroline eliz young,ENGL-1030,2017
-ENGL,1030,30,Composition and Rhetoric,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,remley melis makala,ENGL-1030,2017
-ENGL,1030,31,Composition and Rhetoric,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,martha sue karnes,ENGL-1030,2017
-ENGL,1030,32,Composition and Rhetoric,0.78,0.11,0.0,0.06,0.0,0.0,0.0,0.06,sarah el richardson,ENGL-1030,2017
-ENGL,1030,33,Composition and Rhetoric,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,ENGL-1030,2017
-ENGL,1030,34,Composition and Rhetoric,0.5,0.29,0.07,0.0,0.14,0.0,0.0,0.0,carley am robertson,ENGL-1030,2017
-ENGL,1030,35,Composition and Rhetoric,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,victoria houser,ENGL-1030,2017
-ENGL,1030,37,Composition and Rhetoric,0.67,0.17,0.06,0.06,0.0,0.0,0.0,0.06,michael davi measel,ENGL-1030,2017
-ENGL,1030,38,Composition and Rhetoric,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,sarah margar carter,ENGL-1030,2017
-ENGL,1030,39,Composition and Rhetoric,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,courtn huff-oelberg,ENGL-1030,2017
-ENGL,1030,40,Composition and Rhetoric,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,abigail maxim,ENGL-1030,2017
-ENGL,1030,41,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,ENGL-1030,2017
-ENGL,1030,42,Composition and Rhetoric,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,michelle lloyd,ENGL-1030,2017
-ENGL,1030,43,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gabrielle gr nugent,ENGL-1030,2017
-ENGL,1030,44,Composition and Rhetoric,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,gabrielle gr nugent,ENGL-1030,2017
-ENGL,1030,45,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,ENGL-1030,2017
-ENGL,1030,46,Composition and Rhetoric,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,christopher stuart,ENGL-1030,2017
-ENGL,1030,47,Composition and Rhetoric,0.71,0.24,0.0,0.06,0.0,0.0,0.0,0.0,brian lee gaines,ENGL-1030,2017
-ENGL,1030,48,Composition and Rhetoric,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,brian lee gaines,ENGL-1030,2017
-ENGL,1030,50,Composition and Rhetoric,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,charlotte est lucke,ENGL-1030,2017
-ENGL,1030,51,Composition and Rhetoric,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,christopher stuart,ENGL-1030,2017
-ENGL,1030,53,Composition and Rhetoric,0.32,0.53,0.0,0.05,0.0,0.0,0.0,0.11,jane elizab kuebler,ENGL-1030,2017
-ENGL,1030,55,Composition and Rhetoric,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,courtn huff-oelberg,ENGL-1030,2017
-ENGL,1030,57,Composition and Rhetoric,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,shauna chung,ENGL-1030,2017
-ENGL,1030,59,Composition and Rhetoric,0.31,0.31,0.23,0.0,0.0,0.0,0.0,0.15,sarah margar carter,ENGL-1030,2017
-ENGL,1030,61,Composition and Rhetoric,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,ENGL-1030,2017
-ENGL,1030,64,Composition and Rhetoric,0.47,0.24,0.24,0.06,0.0,0.0,0.0,0.0,jennifer forsberg,ENGL-1030,2017
-ENGL,1030,65,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,ENGL-1030,2017
-ENGL,1030,67,Composition and Rhetoric,0.41,0.41,0.06,0.0,0.12,0.0,0.0,0.0,la'cresha ulo green,ENGL-1030,2017
-ENGL,1030,69,Composition and Rhetoric,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,ENGL-1030,2017
-ENGL,1030,71,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,michael russo,ENGL-1030,2017
-ENGL,1030,72,Composition and Rhetoric,0.84,0.0,0.0,0.0,0.11,0.0,0.0,0.05,whitney jorda adams,ENGL-1030,2017
-ENGL,1030,73,Composition and Rhetoric,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,carley am robertson,ENGL-1030,2017
-ENGL,1030,74,Composition and Rhetoric,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,shauna chung,ENGL-1030,2017
-ENGL,1030,75,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen hundley,ENGL-1030,2017
-ENGL,1030,76,Composition and Rhetoric,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,carrie hill,ENGL-1030,2017
-ENGL,1030,80,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,ENGL-1030,2017
-ENGL,1030,81,Composition and Rhetoric,0.72,0.11,0.06,0.06,0.06,0.0,0.0,0.0,charlotte est lucke,ENGL-1030,2017
-ENGL,1030,82,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,ENGL-1030,2017
-ENGL,1030,83,Composition and Rhetoric,0.47,0.32,0.05,0.11,0.0,0.0,0.0,0.05,jane elizab kuebler,ENGL-1030,2017
-ENGL,1030,84,Composition and Rhetoric,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,allison nico harris,ENGL-1030,2017
-ENGL,1030,85,Composition and Rhetoric,0.74,0.16,0.0,0.0,0.11,0.0,0.0,0.0,allison nico harris,ENGL-1030,2017
-ENGL,1030,86,Composition and Rhetoric,0.67,0.07,0.13,0.0,0.07,0.0,0.0,0.07,stephen quigley,ENGL-1030,2017
-ENGL,1030,100,Accelerated Composition (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,michelle smith,ENGL-1030,2017
-ENGL,1030,500,Composition and Rhetoric,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,john conway,ENGL-1030,2017
-ENGL,1030,501,Composition and Rhetoric,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,john conway,ENGL-1030,2017
-ENGL,2120,1,World Literature,0.16,0.47,0.21,0.11,0.05,0.0,0.0,0.0,lee morrissey,ENGL-2120,2017
-ENGL,2120,3,World Literature,0.18,0.43,0.14,0.04,0.0,0.0,0.0,0.21,karen kettnich,ENGL-2120,2017
-ENGL,2120,4,World Literature,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2120,2017
-ENGL,2120,5,World Literature,0.3,0.19,0.19,0.11,0.15,0.0,0.0,0.07,andrew mathas,ENGL-2120,2017
-ENGL,2120,6,World Literature,0.19,0.59,0.15,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,ENGL-2120,2017
-ENGL,2120,7,World Literature,0.59,0.3,0.07,0.0,0.0,0.0,0.0,0.04,allison nico harris,ENGL-2120,2017
-ENGL,2120,8,World Literature,0.38,0.35,0.0,0.15,0.08,0.0,0.0,0.04,joshua wood,ENGL-2120,2017
-ENGL,2120,9,World Literature,0.37,0.26,0.22,0.07,0.0,0.0,0.0,0.07,katalin beck,ENGL-2120,2017
-ENGL,2120,10,World Literature,0.54,0.32,0.07,0.0,0.04,0.0,0.0,0.04,lucian ghita,ENGL-2120,2017
-ENGL,2120,11,World Literature,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2120,2017
-ENGL,2120,12,World Literature,0.57,0.39,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,ENGL-2120,2017
-ENGL,2120,13,World Literature,0.32,0.39,0.14,0.04,0.0,0.0,0.0,0.11,karen kettnich,ENGL-2120,2017
-ENGL,2120,14,World Literature,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,ENGL-2120,2017
-ENGL,2120,15,World Literature,0.54,0.23,0.04,0.04,0.12,0.0,0.0,0.04,chloe mich whitaker,ENGL-2120,2017
-ENGL,2120,16,World Literature,0.32,0.43,0.11,0.11,0.0,0.0,0.0,0.04,sarah mae cooper,ENGL-2120,2017
-ENGL,2120,17,World Literature,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,allison nico harris,ENGL-2120,2017
-ENGL,2120,18,World Literature,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,andrew mathas,ENGL-2120,2017
-ENGL,2120,19,World Literature,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,chloe mich whitaker,ENGL-2120,2017
-ENGL,2120,20,World Literature,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,joshua wood,ENGL-2120,2017
-ENGL,2130,1,British Literature,0.57,0.32,0.0,0.07,0.04,0.0,0.0,0.0,krist aldebol-hazle,ENGL-2130,2017
-ENGL,2130,3,British Literature,0.63,0.26,0.0,0.04,0.0,0.0,0.0,0.07,krist aldebol-hazle,ENGL-2130,2017
-ENGL,2130,4,British Literature,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,john morgenstern,ENGL-2130,2017
-ENGL,2130,5,British Literature,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-2130,2017
-ENGL,2130,7,British Literature,0.37,0.3,0.19,0.04,0.07,0.0,0.0,0.04,megan no macalystre,ENGL-2130,2017
-ENGL,2130,9,British Literature,0.3,0.37,0.19,0.04,0.07,0.0,0.0,0.04,megan no macalystre,ENGL-2130,2017
-ENGL,2130,10,British Literature,0.43,0.5,0.0,0.04,0.04,0.0,0.0,0.0,christopher benson,ENGL-2130,2017
-ENGL,2130,11,British Literature,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2017
-ENGL,2130,12,British Literature,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,ENGL-2130,2017
-ENGL,2130,13,British Literature,0.57,0.18,0.18,0.04,0.0,0.0,0.0,0.04,megan no macalystre,ENGL-2130,2017
-ENGL,2140,1,American Literature,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2017
-ENGL,2140,5,American Literature,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2017
-ENGL,2140,6,American Literature,0.41,0.44,0.07,0.0,0.0,0.0,0.0,0.07,erin nicholson gale,ENGL-2140,2017
-ENGL,2140,7,American Literature,0.39,0.36,0.11,0.07,0.0,0.0,0.0,0.07,elizabeth stansell,ENGL-2140,2017
-ENGL,2140,8,American Literature,0.26,0.37,0.15,0.04,0.0,0.0,0.0,0.19,david charles foltz,ENGL-2140,2017
-ENGL,2140,9,American Literature,0.63,0.22,0.11,0.0,0.04,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2017
-ENGL,2140,14,American Literature,0.24,0.48,0.24,0.0,0.0,0.0,0.0,0.04,david charles foltz,ENGL-2140,2017
-ENGL,2140,15,American Literature,0.54,0.36,0.07,0.04,0.0,0.0,0.0,0.0,jennifer forsberg,ENGL-2140,2017
-ENGL,2140,16,American Literature,0.29,0.54,0.11,0.04,0.04,0.0,0.0,0.0,jennifer forsberg,ENGL-2140,2017
-ENGL,2140,17,American Literature,0.36,0.43,0.04,0.04,0.0,0.0,0.0,0.14,david charles foltz,ENGL-2140,2017
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.5,0.27,0.12,0.0,0.08,0.0,0.0,0.04,sarah mae cooper,ENGL-2150,2017
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.28,0.44,0.24,0.0,0.04,0.0,0.0,0.0,sarah mae cooper,ENGL-2150,2017
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.21,0.46,0.29,0.0,0.0,0.0,0.0,0.04,lindsay kath turner,ENGL-2150,2017
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.18,0.57,0.18,0.0,0.07,0.0,0.0,0.0,lindsay kath turner,ENGL-2150,2017
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.93,0.0,0.0,0.0,0.07,0.0,0.0,0.0,stephanie stripling,ENGL-2150,2017
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,daniel scott citro,ENGL-2150,2017
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.81,0.08,0.0,0.0,0.0,0.0,0.0,0.12,daniel scott citro,ENGL-2150,2017
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.41,0.33,0.07,0.04,0.15,0.0,0.0,0.0,andrew mathas,ENGL-2150,2017
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.33,0.22,0.17,0.06,0.11,0.0,0.0,0.11,chelsea mari clarey,ENGL-2150,2017
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.46,0.21,0.18,0.11,0.0,0.0,0.0,0.04,andrew mathas,ENGL-2150,2017
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.26,0.47,0.16,0.11,0.0,0.0,0.0,0.0,chelsea mari clarey,ENGL-2150,2017
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.28,0.44,0.11,0.06,0.06,0.0,0.0,0.06,chelsea mari clarey,ENGL-2150,2017
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.37,0.26,0.16,0.0,0.11,0.0,0.0,0.11,chelsea mari clarey,ENGL-2150,2017
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.39,0.29,0.18,0.0,0.11,0.0,0.0,0.04,john logan pursley,ENGL-2150,2017
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.45,0.34,0.07,0.07,0.03,0.0,0.0,0.03,john logan pursley,ENGL-2150,2017
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-2150,2017
-ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2150,2017
-ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2150,2017
-ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.26,0.16,0.32,0.0,0.05,0.0,0.0,0.21,david charles foltz,ENGL-2150,2017
-ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.61,0.25,0.0,0.11,0.04,0.0,0.0,0.0,john logan pursley,ENGL-2150,2017
-ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.46,0.43,0.07,0.04,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-2150,2017
-ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,caroline eliz young,ENGL-2150,2017
-ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,david charles foltz,ENGL-2150,2017
-ENGL,2150,26,Lit in 20th-21st Cent Contexts,0.64,0.25,0.0,0.0,0.04,0.0,0.0,0.07,caroline eliz young,ENGL-2150,2017
-ENGL,2150,27,Lit in 20th-21st Cent Contexts,0.0,0.84,0.11,0.0,0.0,0.0,0.0,0.05,amy monaghan,ENGL-2150,2017
-ENGL,2150,100,20th - 21st Century Lit (HON),0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-2150,2017
-ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.57,0.07,0.04,0.14,0.0,0.0,0.0,0.18,candace wiley,ENGL-2150,2017
-ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.57,0.04,0.04,0.07,0.07,0.0,0.0,0.21,candace wiley,ENGL-2150,2017
-ENGL,3040,3,Business Writing,0.68,0.05,0.26,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,ENGL-3040,2017
-ENGL,3040,4,Business Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3040,2017
-ENGL,3040,5,Business Writing,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,crystal pa stephens,ENGL-3040,2017
-ENGL,3040,13,Business Writing,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3040,2017
-ENGL,3040,15,Business Writing,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,philip randall,ENGL-3040,2017
-ENGL,3040,16,Business Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,ENGL-3040,2017
-ENGL,3040,19,Business Writing,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,crystal pa stephens,ENGL-3040,2017
-ENGL,3040,20,Business Writing,0.58,0.11,0.05,0.0,0.16,0.0,0.0,0.11,geveryl le robinson,ENGL-3040,2017
-ENGL,3040,21,Business Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,sean williams,ENGL-3040,2017
-ENGL,3040,400,Business Writing,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,steph kartalopoulos,ENGL-3040,2017
-ENGL,3040,401,Business Writing,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,steph kartalopoulos,ENGL-3040,2017
-ENGL,3100,1,Crit Writ Lit,0.29,0.41,0.12,0.12,0.0,0.0,0.0,0.06,kimberly manganelli,ENGL-3100,2017
-ENGL,3100,2,Crit Writ Lit,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,william stockton,ENGL-3100,2017
-ENGL,3100,3,Crit Writ Lit,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,ENGL-3100,2017
-ENGL,3100,4,Crit Writ Lit,0.39,0.11,0.22,0.0,0.06,0.0,0.0,0.22,william stockton,ENGL-3100,2017
-ENGL,3120,1,Advanced Composition,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2017
-ENGL,3120,2,Advanced Composition,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2017
-ENGL,3140,1,Technical Writing,0.33,0.5,0.06,0.11,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2017
-ENGL,3140,2,Technical Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2017
-ENGL,3140,4,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,ENGL-3140,2017
-ENGL,3140,5,Technical Writing,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,sharon kathl nalley,ENGL-3140,2017
-ENGL,3140,6,Technical Writing,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,melissa dugan,ENGL-3140,2017
-ENGL,3140,9,Technical Writing,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2017
-ENGL,3140,10,Technical Writing,0.42,0.47,0.0,0.05,0.0,0.0,0.0,0.05,katalin beck,ENGL-3140,2017
-ENGL,3140,11,Technical Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,ENGL-3140,2017
-ENGL,3140,12,Technical Writing,0.47,0.26,0.05,0.11,0.0,0.0,0.0,0.11,geveryl le robinson,ENGL-3140,2017
-ENGL,3140,13,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-3140,2017
-ENGL,3140,16,Technical Writing,0.79,0.0,0.05,0.11,0.0,0.0,0.0,0.05,stephanie stripling,ENGL-3140,2017
-ENGL,3140,17,Technical Writing,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,la'cresha ulo green,ENGL-3140,2017
-ENGL,3140,19,Technical Writing,0.74,0.05,0.11,0.05,0.05,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2017
-ENGL,3140,20,Technical Writing,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2017
-ENGL,3140,22,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-3140,2017
-ENGL,3140,400,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,ENGL-3140,2017
-ENGL,3150,1,Scientific Writing & Comm,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,christopher benson,ENGL-3150,2017
-ENGL,3150,2,Scientific Writing & Comm,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,christopher benson,ENGL-3150,2017
-ENGL,3150,3,Scientific Writing & Comm,0.32,0.32,0.16,0.05,0.16,0.0,0.0,0.0,william pulley,ENGL-3150,2017
-ENGL,3150,4,Scientific Writing & Comm,0.63,0.21,0.11,0.05,0.0,0.0,0.0,0.0,william pulley,ENGL-3150,2017
-ENGL,3150,400,Scientific Writing & Comm,0.65,0.25,0.0,0.0,0.05,0.0,0.0,0.05,philip randall,ENGL-3150,2017
-ENGL,3150,401,Sci Writing & Comm,0.56,0.22,0.11,0.0,0.06,0.0,0.0,0.06,philip randall,ENGL-3150,2017
-ENGL,3450,1,Structure of Fiction,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-3450,2017
-ENGL,3460,2,Structure of Poetry,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-3460,2017
-ENGL,3480,1,Structure Screenplay,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,nicholas chri brown,ENGL-3480,2017
-ENGL,3490,1,Tech/Pop Imagination,0.24,0.53,0.06,0.0,0.0,0.0,0.0,0.18,gabriel and hankins,ENGL-3490,2017
-ENGL,3540,1,Lit Middle East & North Africa,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,angela naimou,ENGL-3540,2017
-ENGL,3570,1,Film,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2017
-ENGL,3570,2,Film,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2017
-ENGL,3570,3,Film,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,john robert smith,ENGL-3570,2017
-ENGL,3850,1,Children's Lit,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,ENGL-3850,2017
-ENGL,3860,1,Adolescent Lit,0.32,0.58,0.0,0.05,0.0,0.0,0.0,0.05,sarah mae cooper,ENGL-3860,2017
-ENGL,3960,1,Brit Lit Survey I,0.39,0.22,0.17,0.17,0.06,0.0,0.0,0.0,erin marina goss,ENGL-3960,2017
-ENGL,3960,2,Brit Lit Survey I,0.26,0.42,0.11,0.16,0.05,0.0,0.0,0.0,erin marina goss,ENGL-3960,2017
-ENGL,3960,3,Brit Lit Survey I,0.22,0.33,0.06,0.11,0.11,0.0,0.0,0.17,erin marina goss,ENGL-3960,2017
-ENGL,3970,2,Brit Lit Survey II,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,david sweene coombs,ENGL-3970,2017
-ENGL,3980,2,Amer Lit Survey I,0.32,0.32,0.21,0.0,0.05,0.0,0.0,0.11,kimberly manganelli,ENGL-3980,2017
-ENGL,3990,1,Amer Lit Survey II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-3990,2017
-ENGL,4030,1,The Classics in Translation,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-4030,2017
-ENGL,4110,1,Shakespeare,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,ENGL-4110,2017
-ENGL,4110,2,Shakespeare,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,elizabeth rivlin,ENGL-4110,2017
-ENGL,4110,3,Shakespeare,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,ENGL-4110,2017
-ENGL,4170,1,Victorian Period,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,david sweene coombs,ENGL-4170,2017
-ENGL,4190,1,Post Col & World Lit,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,ENGL-4190,2017
-ENGL,4210,1,Amer Lit 1800-1899,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,dominic mastroianni,ENGL-4210,2017
-ENGL,4260,1,Southern Literature,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,michael lemahieu,ENGL-4260,2017
-ENGL,4310,1,Modern Poetry,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,steven katz,ENGL-4310,2017
-ENGL,4340,1,Environmental Lit,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,matthew hooley,ENGL-4340,2017
-ENGL,4350,1,Literary Criticism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,matthew hooley,ENGL-4350,2017
-ENGL,4400,1,Literary Theory,0.32,0.42,0.21,0.05,0.0,0.0,0.0,0.0,brian mcgrath,ENGL-4400,2017
-ENGL,4420,1,Cultural Studies,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,ENGL-4420,2017
-ENGL,4450,1,Fiction Workshop,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,ENGL-4450,2017
-ENGL,4500,1,Film Genres,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0, barton palmer,ENGL-4500,2017
-ENGL,4510,1,Film Theory and Criticism,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,john robert smith,ENGL-4510,2017
-ENGL,4750,1,Writing for Media,0.33,0.47,0.13,0.0,0.07,0.0,0.0,0.0,jonathan beec field,ENGL-4750,2017
-ENGL,4780,1,Digital Literacy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,ENGL-4780,2017
-ENGL,4890,1,Topics Write & Publ,0.54,0.31,0.0,0.0,0.08,0.0,0.0,0.08,megan eatman,ENGL-4890,2017
-ENGL,4920,1,Modern Rhetoric,0.33,0.33,0.27,0.0,0.0,0.0,0.0,0.07,michelle smith,ENGL-4920,2017
-ENGL,4960,1,Senior Seminar,0.25,0.42,0.25,0.0,0.0,0.0,0.0,0.08,brian mcgrath,ENGL-4960,2017
-ENGL,4960,2,Senior Seminar,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,michelle renee ty,ENGL-4960,2017
-ENGL,4960,3,Senior Seminar,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,erin marina goss,ENGL-4960,2017
-ENGL,8570,1,Digital Rhetorics,0.78,0.0,0.0,0.0,0.11,0.0,0.0,0.11,tharon howard,ENGL-8570,2017
-ENGR,1000,101,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,steven brandon,ENGR-1000,2017
-ENGR,1000,102,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,steven brandon,ENGR-1000,2017
-ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,steven brandon,ENGR-1000,2017
-ENGR,1000,104,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,steven brandon,ENGR-1000,2017
-ENGR,1020,116,Engineering Discipl & Skills,0.51,0.39,0.07,0.0,0.0,0.0,0.0,0.02,sarah grigg,ENGR-1020,2017
-ENGR,1020,117,Engineering Discipl & Skills,0.46,0.32,0.1,0.02,0.0,0.0,0.0,0.1,sarah grigg,ENGR-1020,2017
-ENGR,1020,311,Engineering Discipl & Skills,0.45,0.31,0.14,0.04,0.02,0.0,0.0,0.04,richard watkins,ENGR-1020,2017
-ENGR,1020,313,Engineering Discipl & Skills,0.42,0.26,0.09,0.06,0.06,0.0,0.0,0.11,michael giebner,ENGR-1020,2017
-ENGR,1020,314,Engineering Discipl & Skills,0.54,0.19,0.12,0.02,0.06,0.0,0.0,0.08,michael giebner,ENGR-1020,2017
-ENGR,1020,317,Engineering Discipl & Skills,0.5,0.22,0.12,0.02,0.02,0.0,0.0,0.12,ashley childers,ENGR-1020,2017
-ENGR,1020,318,Engineering Discipl & Skills,0.33,0.4,0.17,0.04,0.02,0.0,0.0,0.04,ashley childers,ENGR-1020,2017
-ENGR,1020,500,Engineering Discipl & Skills,0.18,0.48,0.21,0.09,0.0,0.0,0.0,0.03,jonathan maier,ENGR-1020,2017
-ENGR,1020,611,Engineering Discipl & Skills,0.44,0.3,0.08,0.04,0.08,0.0,0.0,0.06,irene marie ferrara,ENGR-1020,2017
-ENGR,1020,612,Engineering Discipl & Skills,0.37,0.4,0.12,0.04,0.0,0.0,0.0,0.08,elizabeth stephan,ENGR-1020,2017
-ENGR,1020,613,Engineering Discipl & Skills,0.13,0.55,0.13,0.13,0.05,0.0,0.0,0.0,elizabeth stephan,ENGR-1020,2017
-ENGR,1020,614,Engineering Discipl & Skills,0.12,0.34,0.24,0.07,0.07,0.0,0.0,0.15,mariah magagnotti,ENGR-1020,2017
-ENGR,1020,615,Engineering Discipl & Skills,0.51,0.24,0.14,0.1,0.02,0.0,0.0,0.0,mariah magagnotti,ENGR-1020,2017
-ENGR,1020,616,Engineering Discipl & Skills,0.15,0.44,0.15,0.05,0.05,0.0,0.0,0.15,matthew kent miller,ENGR-1020,2017
-ENGR,1020,617,Engineering Discipl & Skills,0.5,0.34,0.12,0.0,0.02,0.0,0.0,0.02,andrew isaa neptune,ENGR-1020,2017
-ENGR,1020,618,Engineering Discipl & Skills,0.57,0.28,0.04,0.07,0.02,0.0,0.0,0.02,jonathan maier,ENGR-1020,2017
-ENGR,1020,811,Engineering Discipl & Skills,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,ENGR-1020,2017
-ENGR,1020,812,Engineering Discipl & Skills,0.4,0.45,0.1,0.0,0.02,0.0,0.0,0.02,mariah magagnotti,ENGR-1020,2017
-ENGR,1020,813,Engineering Discipl & Skills,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,andrew isaa neptune,ENGR-1020,2017
-ENGR,1020,814,Engineering Discipl & Skills,0.38,0.52,0.07,0.02,0.0,0.0,0.0,0.0,jonathan bro harcum,ENGR-1020,2017
-ENGR,1020,815,Engineering Discipl & Skills,0.41,0.37,0.2,0.0,0.02,0.0,0.0,0.0,jonathan bro harcum,ENGR-1020,2017
-ENGR,1020,816,Engineering Discipl & Skills,0.54,0.39,0.02,0.0,0.0,0.0,0.0,0.05,andrew isaa neptune,ENGR-1020,2017
-ENGR,1020,817,Engineering Discipl & Skills,0.43,0.43,0.1,0.02,0.0,0.0,0.0,0.02,matthew kent miller,ENGR-1020,2017
-ENGR,1020,818,Engineering Discipl & Skills,0.48,0.3,0.13,0.05,0.03,0.0,0.0,0.03,matthew kent miller,ENGR-1020,2017
-ENGR,1020,831,Engr Discipl & Skills (HON),0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,ENGR-1020,2017
-ENGR,1020,832,Engr Discipl & Skills (HON),0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,ENGR-1020,2017
-ENGR,1060,400,Engr Discipline & Skills II,0.05,0.43,0.24,0.1,0.14,0.0,0.0,0.05,andrew isaa neptune,ENGR-1060,2017
-ENGR,1080,400,Programming & Prob Solving II,0.0,0.4,0.5,0.0,0.0,0.0,0.0,0.1,william martin,ENGR-1080,2017
-ENGR,1150,500,Engineering Design & Modeling,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1150,2017
-ENGR,1410,222,Programming & Problem Solving,0.2,0.27,0.29,0.09,0.02,0.0,0.0,0.13,william martin,ENGR-1410,2017
-ENGR,1410,223,Programming & Problem Solving,0.07,0.31,0.36,0.16,0.07,0.0,0.0,0.04,john minor,ENGR-1410,2017
-ENGR,1410,226,Programming & Problem Solving,0.13,0.38,0.29,0.07,0.02,0.0,0.0,0.11,steven brandon,ENGR-1410,2017
-ENGR,1410,227,Programming & Problem Solving,0.04,0.19,0.4,0.08,0.06,0.0,0.0,0.23,anthony pau garland,ENGR-1410,2017
-ENGR,1900,10,CI in Engr I Robotics,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael benj wooten,ENGR-1900,2017
-ENGR,1900,78,CI in ENGR Student Design,0.67,0.08,0.0,0.0,0.08,0.0,0.0,0.17,huijuan zhao,ENGR-1900,2017
-ENGR,2080,681,Engr Graphics & Machine Design,0.28,0.35,0.09,0.09,0.09,0.0,0.0,0.09,garrison llo broome,ENGR-2080,2017
-ENGR,2080,682,Engr Graphics & Machine Design,0.4,0.38,0.19,0.0,0.0,0.0,0.0,0.02,garrison llo broome,ENGR-2080,2017
-ENGR,2080,684,Engr Graphics & Machine Design,0.33,0.29,0.24,0.08,0.06,0.0,0.0,0.0,nighat yasmin,ENGR-2080,2017
-ENGR,2080,685,Engr Graphics & Machine Design,0.23,0.32,0.2,0.02,0.11,0.0,0.0,0.11,anthony pau garland,ENGR-2080,2017
-ENGR,2080,686,Engr Graphics & Machine Design,0.23,0.4,0.19,0.02,0.09,0.0,0.0,0.07,anthony pau garland,ENGR-2080,2017
-ENGR,2100,804,CAD & Engineering Applications,0.28,0.44,0.09,0.09,0.02,0.0,0.0,0.07, shams esfandabadi,ENGR-2100,2017
-ENGR,2100,805,CAD & Engineering Applications,0.34,0.34,0.11,0.07,0.02,0.0,0.0,0.11,nighat yasmin,ENGR-2100,2017
-ENGR,2100,806,CAD & Engineering Applications,0.15,0.4,0.15,0.08,0.1,0.0,0.0,0.13,trent hou dellinger,ENGR-2100,2017
-ENGR,2200,115,Evaluating Innovations,0.24,0.57,0.05,0.14,0.0,0.0,0.0,0.0,sarah grigg,ENGR-2200,2017
-ENR,1010,1,Intro to Envir & Natur Res I,0.45,0.26,0.15,0.04,0.09,0.0,0.0,0.0,abigail lawson,ENR-1010,2017
-ENR,1010,2,Intro to Envir & Natur Res I,0.43,0.33,0.18,0.05,0.0,0.0,0.0,0.03,abigail lawson,ENR-1010,2017
-ENR,4290,1,Environ Law & Policy,0.32,0.56,0.06,0.0,0.03,0.0,0.0,0.03,alan johnson,ENR-4290,2017
-ENR,4290,2,Environ Law & Policy,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,alan johnson,ENR-4290,2017
-ENSP,2000,1,Intro Environ Sci,0.35,0.35,0.2,0.02,0.04,0.0,0.0,0.04,scott brame,ENSP-2000,2017
-ENSP,2000,2,Intro Environ Sci,0.91,0.04,0.04,0.02,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2017
-ENSP,2000,3,Intro Environ Sci,0.88,0.09,0.0,0.02,0.0,0.0,0.0,0.02,minory nammouz,ENSP-2000,2017
-ENSP,2000,4,Intro Environ Sci,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,ENSP-2000,2017
-ENSP,2000,5,Intro Environ Sci,0.2,0.48,0.2,0.09,0.02,0.0,0.0,0.02,tom owino,ENSP-2000,2017
-ENSP,4000,1,Studies in Environmental Sci,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,margaret thompson,ENSP-4000,2017
-ENT,2000,1,Six-Legged Science,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,suellen pometto,ENT-2000,2017
-ENT,2010,1,Insects in Myth & Religion,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,joseph culin,ENT-2010,2017
-ENT,3010,1,Insect Biology and Diversity,0.21,0.21,0.36,0.15,0.03,0.0,0.0,0.03,eric benson,ENT-3010,2017
-ENTR,1010,1,Entrepreneurial Mindset,0.44,0.37,0.08,0.02,0.08,0.0,0.0,0.01,john michael hannon,ENTR-1010,2017
-ENTR,2010,2,Select Top in Entrepreneurship,0.64,0.18,0.09,0.0,0.0,0.0,0.0,0.09,john michael hannon,ENTR-2010,2017
-ESED,8610,1,Practicum in Engr & Sci Educ,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,karen ann high,ESED-8610,2017
-ETOX,4300,1,Toxicology,0.3,0.1,0.5,0.1,0.0,0.0,0.0,0.0,lisa bain,ETOX-4300,2017
-FCS,8300,1,Community Dev: Princ & Pract,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,areli moore peralta,FCS-8300,2017
-FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.72,0.2,0.03,0.03,0.03,0.0,0.0,0.0,aubrey dean coffee,FDSC-1010,2017
-FDSC,2160,1,Baking Science,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,FDSC-2160,2017
-FDSC,3010,1,Food Regulations,0.77,0.2,0.02,0.0,0.0,0.0,0.0,0.0,sara lane cothran,FDSC-3010,2017
-FDSC,4010,1,Food Chemistry I,0.5,0.39,0.1,0.02,0.0,0.0,0.0,0.0,feng chen,FDSC-4010,2017
-FDSC,4040,1,Food Prsv & Process,0.44,0.41,0.13,0.02,0.0,0.0,0.0,0.0,anthony lou pometto,FDSC-4040,2017
-FDSC,4070,1,Quantity Food Production,0.76,0.12,0.0,0.03,0.09,0.0,0.0,0.0,heather batt,FDSC-4070,2017
-FDSC,4170,1,Seminar,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,aubrey dean coffee,FDSC-4170,2017
-FDSC,4300,1,Dairy Process & Sant,0.22,0.33,0.39,0.0,0.0,0.0,0.0,0.06,john mcgregor,FDSC-4300,2017
-FDSC,4500,11,Creative Inquiry-Food Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,paul dawson,FDSC-4500,2017
-FIN,2010,401,Intro to Personal Finance,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,joshua harris,FIN-2010,2017
-FIN,2010,402,Intro to Personal Finance,0.64,0.23,0.06,0.02,0.03,0.0,0.0,0.03,joshua harris,FIN-2010,2017
-FIN,2010,403,Intro to Personal Finance,0.58,0.3,0.07,0.05,0.0,0.0,0.0,0.0,joshua harris,FIN-2010,2017
-FIN,2010,405,Intro to Personal Finance,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,FIN-2010,2017
-FIN,2010,406,Intro to Personal Finance,0.86,0.07,0.02,0.01,0.03,0.0,0.0,0.01,joshua harris,FIN-2010,2017
-FIN,2010,407,Intro to Personal Finance,0.92,0.02,0.02,0.0,0.02,0.0,0.0,0.02,joshua harris,FIN-2010,2017
-FIN,3040,2,Risk & Insurance,0.18,0.38,0.33,0.05,0.08,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2017
-FIN,3050,1,Investment Analysis,0.0,0.24,0.35,0.24,0.12,0.0,0.0,0.06,kerri mcmillan,FIN-3050,2017
-FIN,3050,2,Investment Analysis,0.26,0.4,0.26,0.06,0.03,0.0,0.0,0.0,kerri mcmillan,FIN-3050,2017
-FIN,3050,3,Investment Analysis,0.23,0.26,0.37,0.11,0.0,0.0,0.0,0.03,kerri mcmillan,FIN-3050,2017
-FIN,3050,5,Investment Analysis,0.14,0.19,0.33,0.14,0.08,0.0,0.0,0.11,john alexander,FIN-3050,2017
-FIN,3060,1,Corporation Finance,0.17,0.17,0.25,0.09,0.25,0.0,0.0,0.08,william hol johnson,FIN-3060,2017
-FIN,3060,2,Corporation Finance,0.29,0.12,0.14,0.22,0.16,0.0,0.0,0.08,william hol johnson,FIN-3060,2017
-FIN,3060,3,Corporation Finance,0.34,0.14,0.21,0.16,0.09,0.0,0.0,0.05,william hol johnson,FIN-3060,2017
-FIN,3060,4,Corporation Finance,0.17,0.23,0.19,0.08,0.19,0.0,0.0,0.15,william hol johnson,FIN-3060,2017
-FIN,3060,5,Corporation Finance,0.1,0.23,0.38,0.19,0.04,0.0,0.0,0.06,ramon tolb franklin,FIN-3060,2017
-FIN,3060,6,Corporation Finance,0.12,0.14,0.39,0.18,0.04,0.0,0.0,0.12,ramon tolb franklin,FIN-3060,2017
-FIN,3060,7,Corporation Finance,0.22,0.29,0.29,0.14,0.05,0.0,0.0,0.02,ramon tolb franklin,FIN-3060,2017
-FIN,3060,8,Corporation Finance,0.12,0.16,0.24,0.29,0.08,0.0,0.0,0.1,ramon tolb franklin,FIN-3060,2017
-FIN,3060,9,Corporation Finance,0.28,0.26,0.18,0.22,0.04,0.0,0.0,0.02,melvin stith,FIN-3060,2017
-FIN,3060,10,Corporation Finance,0.22,0.11,0.29,0.31,0.04,0.0,0.0,0.02,melvin stith,FIN-3060,2017
-FIN,3060,401,Corporation Finance,0.17,0.42,0.23,0.07,0.06,0.0,0.0,0.04,jonathan godbey,FIN-3060,2017
-FIN,3070,1,Prin of Real Estate,0.17,0.24,0.37,0.17,0.02,0.0,0.0,0.02,thomas springer,FIN-3070,2017
-FIN,3070,2,Prin of Real Estate,0.24,0.24,0.34,0.12,0.05,0.0,0.0,0.0,thomas springer,FIN-3070,2017
-FIN,3070,3,Prin of Real Estate,0.28,0.42,0.28,0.0,0.03,0.0,0.0,0.0,yannan shen,FIN-3070,2017
-FIN,3080,1,Fin Inst & Mkts,0.21,0.49,0.26,0.03,0.0,0.0,0.0,0.03,lyudmila chernykh,FIN-3080,2017
-FIN,3080,2,Fin Inst & Mkts,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-3080,2017
-FIN,3080,3,Fin Inst & Mkts,0.38,0.38,0.17,0.05,0.02,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2017
-FIN,3110,1,Financial Management I,0.05,0.18,0.33,0.05,0.18,0.0,0.0,0.21,jack wolf,FIN-3110,2017
-FIN,3110,2,Financial Management I,0.05,0.26,0.35,0.05,0.09,0.0,0.0,0.21,jack wolf,FIN-3110,2017
-FIN,3110,3,Financial Management I,0.26,0.28,0.16,0.07,0.07,0.0,0.0,0.16,george bra lockhart,FIN-3110,2017
-FIN,3110,4,Financial Management I,0.14,0.29,0.36,0.15,0.05,0.0,0.0,0.02,weike xu,FIN-3110,2017
-FIN,3120,1,Financial Management II,0.12,0.35,0.32,0.09,0.06,0.0,0.0,0.06,vincent intintoli,FIN-3120,2017
-FIN,3120,2,Financial Management II,0.16,0.34,0.24,0.21,0.03,0.0,0.0,0.03,vincent intintoli,FIN-3120,2017
-FIN,3120,3,Financial Management II,0.23,0.17,0.43,0.1,0.03,0.0,0.0,0.03,blerina zykaj,FIN-3120,2017
-FIN,3120,4,Financial Management II,0.17,0.36,0.24,0.17,0.02,0.0,0.0,0.05,weike xu,FIN-3120,2017
-FIN,4010,1,Corporate Financial Analysis,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,george bra lockhart,FIN-4010,2017
-FIN,4020,1,Corporate Valuation,0.39,0.39,0.16,0.06,0.0,0.0,0.0,0.0,angela morgan,FIN-4020,2017
-FIN,4020,2,Corporate Valuation,0.24,0.35,0.35,0.0,0.06,0.0,0.0,0.0,angela morgan,FIN-4020,2017
-FIN,4050,1,Portfolio Management & Theory,0.03,0.23,0.43,0.13,0.03,0.0,0.0,0.13,john alexander,FIN-4050,2017
-FIN,4060,1,Derivatives Analysis,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,blerina zykaj,FIN-4060,2017
-FIN,4110,1,Int Fin Mgt,0.22,0.41,0.3,0.05,0.0,0.0,0.0,0.03,luke asher devault,FIN-4110,2017
-FIN,4110,2,Int Fin Mgt,0.18,0.53,0.18,0.0,0.06,0.0,0.0,0.06,luke asher devault,FIN-4110,2017
-FIN,4170,1,Real Estate Finance,0.27,0.47,0.2,0.0,0.07,0.0,0.0,0.0,yannan shen,FIN-4170,2017
-FIN,4980,2,CI in Finance: CFA,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,jack wolf,FIN-4980,2017
-FNR,2040,1,Soil Information Systems,0.71,0.18,0.0,0.11,0.0,0.0,0.0,0.0,elena mikhailova,FNR-2040,2017
-FNR,4700,1,Kennedy Waterfowl CI,0.69,0.0,0.31,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,FNR-4700,2017
-FNR,4900,1,Field Training in Natural Res,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,patricia layton,FNR-4900,2017
-FNR,4990,1,Natural Resources Seminar,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,susan talley guynn,FNR-4990,2017
-FOR,2050,1,Dendrology,0.34,0.25,0.22,0.09,0.06,0.0,0.0,0.03,donald hagan,FOR-2050,2017
-FOR,2050,2,Dendrology,0.1,0.39,0.22,0.05,0.1,0.0,0.0,0.15,donald hagan,FOR-2050,2017
-FOR,2050,3,Dendrology,0.36,0.33,0.13,0.05,0.05,0.0,0.0,0.08,donald hagan,FOR-2050,2017
-FOR,2210,1,Forest Biology,0.17,0.3,0.23,0.15,0.08,0.0,0.0,0.07,althea simone hagan,FOR-2210,2017
-FOR,3020,1,Forest Biometrics,0.33,0.4,0.23,0.0,0.0,0.0,0.0,0.03,lawrence gering,FOR-3020,2017
-FOR,3040,1,Forest Resource Economics,0.79,0.15,0.0,0.0,0.0,0.0,0.0,0.05,puskar khanal,FOR-3040,2017
-FOR,4100,1,Harvesting Processes,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,patrick hiesl,FOR-4100,2017
-FOR,4130,1,Integrated Forest Pest Mgt,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,stephen cole,FOR-4130,2017
-FOR,4160,1,Forest Policy and Admin,0.31,0.42,0.21,0.02,0.01,0.0,0.0,0.02,thomas straka,FOR-4160,2017
-FOR,4170,1,Forest Resource Mgt & Regulatn,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,FOR-4170,2017
-FOR,4310,1,Recreation Res Plan in For Mgt,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,robert baxte powell,FOR-4310,2017
-FOR,4340,1,GIS for Natural Resources,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher post,FOR-4340,2017
-FR,1010,1,Elementary French,0.18,0.53,0.06,0.12,0.0,0.0,0.0,0.12,anne salces  nedeo,FR-1010,2017
-FR,1010,2,Elementary French,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,FR-1010,2017
-FR,1020,1,Elementary French,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2017
-FR,1020,2,Elementary French,0.81,0.0,0.13,0.06,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2017
-FR,1020,3,Elementary French,0.2,0.4,0.1,0.1,0.0,0.0,0.0,0.2,kenneth dav widgren,FR-1020,2017
-FR,2010,2,Intermediate French,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,kenneth dav widgren,FR-2010,2017
-FR,2010,3,Intermediate French,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,kenneth dav widgren,FR-2010,2017
-FR,2010,4,Intermediate French,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,FR-2010,2017
-FR,2020,1,Intermediate French,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2020,2017
-FR,2020,2,Intermediate French,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,kelly digby peebles,FR-2020,2017
-FR,2020,3,Intermediate French,0.33,0.33,0.2,0.07,0.0,0.0,0.0,0.07,kenneth dav widgren,FR-2020,2017
-FR,2020,4,Intermediate French,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,amy lyn grif sawyer,FR-2020,2017
-FR,3000,1,Survey of French Lit,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,FR-3000,2017
-FR,3050,2,Int Fr Con & Comp I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph mai,FR-3050,2017
-FR,3070,1,French Civilization,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,FR-3070,2017
-FR,4100,1,Francophone Lit,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,FR-4100,2017
-GC,1010,1,Orientation to G C,0.68,0.14,0.04,0.02,0.06,0.0,0.0,0.06,john leininger,GC-1010,2017
-GC,1010,2,Orientation to G C,0.39,0.49,0.0,0.0,0.02,0.0,0.0,0.1,john leininger,GC-1010,2017
-GC,1020,1,Computer Art & CAD Foundations,0.6,0.29,0.04,0.0,0.02,0.0,0.0,0.04,carol jones,GC-1020,2017
-GC,1020,2,Computer Art & CAD Foundations,0.52,0.3,0.05,0.05,0.02,0.0,0.0,0.05,carol jones,GC-1020,2017
-GC,1030,1,G C I for Pkgsc,0.21,0.47,0.32,0.0,0.0,0.0,0.0,0.0,john jacobs,GC-1030,2017
-GC,1040,1,Graphic Communications I,0.49,0.27,0.14,0.0,0.07,0.0,0.0,0.03,rebecca suza edlein,GC-1040,2017
-GC,2070,1,Graphic Communications II,0.66,0.22,0.08,0.02,0.0,0.0,0.0,0.02,charles tabor weiss,GC-2070,2017
-GC,3400,1,Digital Imaging and eMedia,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0,erica black walker,GC-3400,2017
-GC,3460,1,Ink and Substrates,0.23,0.55,0.19,0.02,0.0,0.0,0.0,0.0,liam henry 'hara,GC-3460,2017
-GC,3500,1,G C Internship I,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,carol jones,GC-3500,2017
-GC,4060,1,Package and Specialty Printing,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,kern cox,GC-4060,2017
-GC,4400,1,Commercial Printing,0.24,0.63,0.05,0.0,0.05,0.0,0.0,0.02,eric weisenmiller,GC-4400,2017
-GC,4440,1,Current Dev/Trends in Gr Comm,0.67,0.25,0.06,0.0,0.0,0.0,0.0,0.03,samuel ingram,GC-4440,2017
-GC,4480,1,Plan & Cont Printing Functions,0.89,0.06,0.02,0.0,0.0,0.0,0.0,0.02,nona woolbright,GC-4480,2017
-GC,4500,1,GC Internship II,0.9,0.0,0.1,0.0,0.0,0.0,0.0,0.0,carol jones,GC-4500,2017
-GC,4800,1,Senior Seminar in GC,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,GC-4800,2017
-GC,6060,1,Pkg & Spec Prtg,0.5,0.33,0.0,0.0,0.17,0.0,0.0,0.0,kern cox,GC-6060,2017
-GEN,1030,1,Careers in Bioch/Gen,0.81,0.09,0.06,0.03,0.01,0.0,0.0,0.0,joseph paul thames,GEN-1030,2017
-GEN,3000,1,Fundamental Genetics,0.31,0.41,0.17,0.06,0.01,0.0,0.0,0.05,kate leanne wi tsai,GEN-3000,2017
-GEN,3000,2,Fundamental Genetics,0.28,0.4,0.19,0.07,0.03,0.0,0.0,0.04,kate leanne wi tsai,GEN-3000,2017
-GEN,3020,1,Molecular & General Genetics,0.3,0.36,0.18,0.07,0.04,0.0,0.0,0.05,lukasz kozubowski,GEN-3020,2017
-GEN,3020,2,Molec & General Genetics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,GEN-3020,2017
-GEN,3020,4,Molecular & General Genetics,0.42,0.36,0.12,0.03,0.06,0.0,0.0,0.0,haiying liang,GEN-3020,2017
-GEN,4200,1,Molecular Genetics & Gene Reg,0.25,0.43,0.23,0.07,0.0,0.0,0.0,0.02,julia frugoli,GEN-4200,2017
-GEN,4200,2,Molecular Genetics & Gen (HON),0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,GEN-4200,2017
-GEN,4210,3,Mol Gen Gene Reg Lab,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,scott michae tanner,GEN-4210,2017
-GEN,4400,1,Bioinformatics,0.62,0.24,0.07,0.05,0.0,0.0,0.0,0.02,frank alexan feltus,GEN-4400,2017
-GEN,4500,1,Comparative Genetics,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,leigh anne clark,GEN-4500,2017
-GEN,4900,1,Epigenetics,0.56,0.25,0.0,0.13,0.0,0.0,0.0,0.06,rajandeep si sekhon,GEN-4900,2017
-GEOG,1010,2,Intro to Geography,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,david doran,GEOG-1010,2017
-GEOG,1030,1,World Regional Geography,0.81,0.15,0.02,0.01,0.0,0.0,0.0,0.01,david doran,GEOG-1030,2017
-GEOG,1030,2,World Regional Geography,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christa smith,GEOG-1030,2017
-GEOG,1030,3,World Regional Geography,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,david doran,GEOG-1030,2017
-GEOG,3030,1,Urban Geography,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,christa smith,GEOG-3030,2017
-GEOL,1010,1,Physical Geology,0.23,0.29,0.22,0.09,0.09,0.0,0.0,0.09,alan coulson,GEOL-1010,2017
-GEOL,1010,2,Physical Geology,0.18,0.32,0.21,0.12,0.07,0.0,0.0,0.1,alan coulson,GEOL-1010,2017
-GEOL,1010,3,Physical Geology,0.49,0.33,0.07,0.07,0.0,0.0,0.0,0.04,kelly best lazar,GEOL-1010,2017
-GEOL,1010,4,Physical Geology,0.03,0.29,0.26,0.23,0.17,0.0,0.0,0.03,melissa ranhofer,GEOL-1010,2017
-GEOL,1030,1,Physical Geol Lab,0.67,0.17,0.08,0.0,0.04,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,1030,2,Physical Geol Lab,0.26,0.22,0.3,0.09,0.09,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,1030,3,Physical Geol Lab,0.46,0.33,0.21,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,4,Physical Geol Lab,0.5,0.21,0.21,0.0,0.04,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,1030,5,Physical Geol Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,1030,6,Physical Geol Lab,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,8,Physical Geol Lab,0.74,0.17,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,9,Physical Geol Lab,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,10,Physical Geol Lab,0.75,0.13,0.04,0.0,0.0,0.0,0.0,0.08,alan coulson,GEOL-1030,2017
-GEOL,1030,11,Physical Geol Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,12,Physical Geol Lab,0.67,0.25,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,13,Physical Geol Lab,0.46,0.38,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,2050,1,Mineralogy & Intro Petrology,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,lin shuller-nickles,GEOL-2050,2017
-GEOL,2070,1,Min & Intro Pet Lab,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-2070,2017
-GEOL,2700,1,Sustainable Water,0.7,0.15,0.0,0.0,0.0,0.0,0.0,0.15,stephen mich moysey,GEOL-2700,2017
-GEOL,2750,1,Field Methods,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-2750,2017
-GEOL,3000,1,Environmental Geology,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-3000,2017
-GEOL,4150,1,Analysis Geological Processes,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,GEOL-4150,2017
-GEOL,4820,1,Groundwater & Contam Transport,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,GEOL-4820,2017
-GEOL,7900,500,Biogeography And Geology of SC,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,john robert wagner,GEOL-7900,2017
-GEOL,8080,1,Groundwater Modeling,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,GEOL-8080,2017
-GER,1010,1,Elementary German,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,oswald harris king,GER-1010,2017
-GER,1010,2,Elementary German,0.24,0.41,0.06,0.12,0.06,0.0,0.0,0.12,oswald harris king,GER-1010,2017
-GER,1020,1,Elementary German,0.5,0.3,0.0,0.0,0.0,0.0,0.0,0.2,isabel meusen,GER-1020,2017
-GER,1020,2,Elementary German,0.25,0.42,0.17,0.0,0.08,0.0,0.0,0.08,isabel meusen,GER-1020,2017
-GER,2010,1,Intermediate German,0.32,0.32,0.26,0.0,0.0,0.0,0.0,0.11, lee ferrell,GER-2010,2017
-GER,2010,2,Intermediate German,0.33,0.13,0.33,0.07,0.07,0.0,0.0,0.07,gabriela stoicea,GER-2010,2017
-GER,2020,1,Intermediate German,0.05,0.26,0.37,0.21,0.05,0.0,0.0,0.05,johannes schmidt,GER-2020,2017
-GER,3400,1,German Culture,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,oswald harris king,GER-3400,2017
-HCC,8310,1,Fundamentals of Hcc,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,brygg anders ullmer,HCC-8310,2017
-HCC,8330,1,HCC Research Methods,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,HCC-8330,2017
-HCC,8810,1,Selected Topic: Measu/Evalu II,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,bart knijnenburg,HCC-8810,2017
-HCG,9040,400,Knowledge Development,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,HCG-9040,2017
-HIST,1010,1,History of the United States,0.21,0.62,0.09,0.0,0.06,0.0,0.0,0.03,paul chris anderson,HIST-1010,2017
-HIST,1020,1,Hist of the U S,0.35,0.47,0.12,0.06,0.0,0.0,0.0,0.0,john andrew,HIST-1020,2017
-HIST,1020,2,Hist of the U S,0.35,0.57,0.08,0.0,0.0,0.0,0.0,0.0,william camp,HIST-1020,2017
-HIST,1220,1,"Hist, Tech & Society",0.12,0.51,0.19,0.08,0.06,0.0,0.0,0.04,pamela mack,HIST-1220,2017
-HIST,1240,1,Environmental History Survey,0.11,0.5,0.28,0.06,0.06,0.0,0.0,0.0,james brad jeffries,HIST-1240,2017
-HIST,1240,2,Environmental History Survey,0.03,0.5,0.31,0.03,0.06,0.0,0.0,0.06,james brad jeffries,HIST-1240,2017
-HIST,1720,1,The West and the World I,0.36,0.43,0.08,0.02,0.03,0.0,0.0,0.07,caroline dunn clark,HIST-1720,2017
-HIST,1720,2,The West and the World I,0.21,0.47,0.22,0.04,0.04,0.0,0.0,0.02,steven marks,HIST-1720,2017
-HIST,1730,1,The West and the World II,0.26,0.43,0.19,0.01,0.03,0.0,0.0,0.08, alan grubb,HIST-1730,2017
-HIST,1730,2,The West and the World II,0.33,0.39,0.11,0.0,0.06,0.0,0.0,0.11,sandra nic mokalled,HIST-1730,2017
-HIST,2990,2,Historian's Craft,0.75,0.15,0.0,0.05,0.0,0.0,0.0,0.05,rachel anne moore,HIST-2990,2017
-HIST,2990,3,Historian's Craft,0.47,0.42,0.0,0.0,0.0,0.0,0.0,0.11,thomas kuehn,HIST-2990,2017
-HIST,3040,1,Indus & Progr Era,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06, roger grant,HIST-3040,2017
-HIST,3060,1,US: Postwar World 1945-1975,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,william camp,HIST-3060,2017
-HIST,3100,1,History of Religion in the US,0.33,0.22,0.28,0.17,0.0,0.0,0.0,0.0,elizabeth jemison,HIST-3100,2017
-HIST,3120,1,Afr Amer Hist 1877 to Present,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,HIST-3120,2017
-HIST,3170,1,Hist of Nat. Am. Relig/Culture,0.29,0.29,0.07,0.0,0.14,0.0,0.0,0.21,james brad jeffries,HIST-3170,2017
-HIST,3280,1,US Legal History to 1890,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,lee brady wilson,HIST-3280,2017
-HIST,3300,1,Hist of Mod China,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,edwin moise,HIST-3300,2017
-HIST,3390,1,Africa 1875-Present,0.53,0.24,0.12,0.12,0.0,0.0,0.0,0.0,james burns,HIST-3390,2017
-HIST,3410,1,Modern Mexico,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,HIST-3410,2017
-HIST,3630,1,Britain Since 1688,0.55,0.38,0.07,0.0,0.0,0.0,0.0,0.0,stephani barczewski,HIST-3630,2017
-HIST,3670,1,Modern Ireland,0.52,0.37,0.04,0.0,0.04,0.0,0.0,0.04,michael silvestri,HIST-3670,2017
-HIST,3730,1,Age of Protestant Reformation,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,thomas kuehn,HIST-3730,2017
-HIST,3750,1,Revolutionary Europe,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0, alan grubb,HIST-3750,2017
-HIST,3900,1,Modern Military History,0.18,0.41,0.29,0.06,0.0,0.0,0.0,0.06,edwin moise,HIST-3900,2017
-HIST,4000,1,Local and Nearby History,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15, roger grant,HIST-4000,2017
-HIST,4510,1,Alexander the Great,0.27,0.53,0.07,0.0,0.0,0.0,0.0,0.13,elizabeth carney,HIST-4510,2017
-HIST,4720,1,Medieval Conquests & Crusades,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,caroline dunn clark,HIST-4720,2017
-HIST,4870,1,World War II,0.03,0.87,0.1,0.0,0.0,0.0,0.0,0.0,john andrew,HIST-4870,2017
-HIST,4900,1,Northern Ireland,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,michael silvestri,HIST-4900,2017
-HIST,4900,3,Disney Parks,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,HIST-4900,2017
-HIST,4920,1,The US in the Atomic Age,0.29,0.53,0.0,0.12,0.0,0.0,0.0,0.06,william camp,HIST-4920,2017
-HIST,8000,3,Film and History,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james burns,HIST-8000,2017
-HLTH,2020,1,Introduction to Public Health,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2017
-HLTH,2020,2,Introduction to Public Health,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2017
-HLTH,2020,3,Introduction to Public Health,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2017
-HLTH,2020,4,Introduction to Public Health,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2017
-HLTH,2020,5,Introduction to Public Health,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2017
-HLTH,2020,6,Introduction to Public Health,0.6,0.2,0.07,0.0,0.0,0.0,0.0,0.13,becky ann tugman,HLTH-2020,2017
-HLTH,2020,400,Introduction to Public Health,0.65,0.2,0.05,0.05,0.05,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2017
-HLTH,2030,1,Health Care Sys,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2017
-HLTH,2030,2,Health Care Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,HLTH-2030,2017
-HLTH,2400,1,Deter of Hlth Behav,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2017
-HLTH,2400,2,Deter of Hlth Behav,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2017
-HLTH,2600,2,Medical Terminology & Comm,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2600,2017
-HLTH,2980,1,Human Health and Disease,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2017
-HLTH,2980,2,Human Health and Disease,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2980,2017
-HLTH,3400,1,Hlth Prom Prog Plan,0.44,0.44,0.12,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-3400,2017
-HLTH,3610,1,Int Health Care Econ,0.5,0.42,0.0,0.04,0.0,0.0,0.0,0.04,khoa dang truong,HLTH-3610,2017
-HLTH,3800,1,Epidemiology,0.42,0.32,0.16,0.05,0.0,0.0,0.0,0.05,hugh spitler,HLTH-3800,2017
-HLTH,3800,2,Epidemiology,0.74,0.19,0.03,0.0,0.03,0.0,0.0,0.0,hugh spitler,HLTH-3800,2017
-HLTH,3800,400,Epidemiology,0.44,0.22,0.22,0.06,0.06,0.0,0.0,0.0,deborah alma falta,HLTH-3800,2017
-HLTH,3980,1,Health Appraisal Skills,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2017
-HLTH,3980,2,Health Appraisal Skills,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2017
-HLTH,4000,4,Public Hlth Social Marketing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,debra mitch charles,HLTH-4000,2017
-HLTH,4190,1,Health Sci Internship Prep Sem,0.59,0.29,0.1,0.02,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4190,2017
-HLTH,4200,1,Hlth Science Intern,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2017
-HLTH,4400,1,Manag Hlth Serv Org,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,george paul  newby,HLTH-4400,2017
-HLTH,4750,1,Hlthcr Oper Mgmt Res,0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,HLTH-4750,2017
-HLTH,4900,1,Res Eval St Pub Hlth,0.55,0.26,0.11,0.05,0.0,0.0,0.0,0.03,lingling zhang,HLTH-4900,2017
-HLTH,4900,2,Res Eval St Pub Hlth,0.63,0.25,0.06,0.06,0.0,0.0,0.0,0.0,lingling zhang,HLTH-4900,2017
-HLTH,8030,1,Theories and Determ of Health,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joel edwar williams,HLTH-8030,2017
-HLTH,8120,500,Clinical and Translational Sci,0.5,0.17,0.0,0.0,0.0,0.0,0.0,0.33,ronald gimbel,HLTH-8120,2017
-HLTH,8140,500,Health Sys Quality Improvement,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,windsor we sherrill,HLTH-8140,2017
-HLTH,8320,1,Quantitative Analy in Hlth II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,HLTH-8320,2017
-HON,1900,1,Hell in Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,HON-1900,2017
-HON,1930,2,The Russian Revolution,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,HON-1930,2017
-HON,1940,2,Scientific Skepticism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey appling,HON-1940,2017
-HON,2020,3,Wisdom of the Moderns,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,colin pearce,HON-2020,2017
-HON,2200,3,Europe in the Age of Dictators,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,HON-2200,2017
-HON,2210,3,Southern Literature,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,michael lemahieu,HON-2210,2017
-HON,2210,4,Imaginary Friends in Fiction,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,april susanne pelt,HON-2210,2017
-HON,2220,1,Lit & Science in Modernism,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,HON-2220,2017
-HORT,1010,1,Horticulture,0.9,0.05,0.03,0.0,0.0,0.0,0.0,0.02,ellen anita vincent,HORT-1010,2017
-HORT,2020,1,Adobe Digital Design,0.8,0.11,0.0,0.0,0.0,0.0,0.0,0.09,janice ann lay,HORT-2020,2017
-HORT,2100,1,Growing Fall Plants,0.08,0.46,0.33,0.04,0.04,0.0,0.0,0.04,james emerson faust,HORT-2100,2017
-HORT,2120,1,Turfgrass Culture,0.5,0.41,0.08,0.0,0.0,0.0,0.0,0.02,haibo liu,HORT-2120,2017
-HORT,3030,1,Landscape Plants,0.18,0.26,0.24,0.15,0.1,0.0,0.0,0.08,robert polomski,HORT-3030,2017
-HORT,3080,1,Sust Landsc Des Install Maint,0.93,0.02,0.05,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-3080,2017
-HORT,4120,1,Adv Turfgrass Mgt,0.45,0.27,0.0,0.0,0.09,0.0,0.0,0.18,lambert mccarty,HORT-4120,2017
-HP,8010,1,Preservation Law and Econ,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,william jackso cook,HP-8010,2017
-HP,8030,1,Building Tech and Pathology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,amalia leifeste,HP-8030,2017
-HRD,8200,400,Human Perform Improv,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william havice,HRD-8200,2017
-HRD,8200,401,Human Perform Improv,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william havice,HRD-8200,2017
-HRD,8300,400,Concepts of H R D,0.91,0.03,0.06,0.0,0.0,0.0,0.0,0.0,angela danie carter,HRD-8300,2017
-HRD,8600,400,Instruc Mat Devel,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,cynthia sims,HRD-8600,2017
-IE,2100,1,Des Analysis Wrk Sys,0.09,0.47,0.35,0.09,0.01,0.0,0.0,0.0,david neyens,IE-2100,2017
-IE,2800,1,Deterministic Operations Rsrch,0.13,0.25,0.12,0.17,0.17,0.0,0.0,0.17,robert james riggs,IE-2800,2017
-IE,3010,1,Systems Design I,0.32,0.47,0.19,0.01,0.0,0.0,0.0,0.01,robert james riggs,IE-3010,2017
-IE,3600,1,Industrial Apps of Prob/Stat I,0.23,0.23,0.23,0.12,0.14,0.0,0.0,0.05,tugce isik,IE-3600,2017
-IE,3610,1,Industrial App of Prob/Stat II,0.4,0.25,0.1,0.1,0.05,0.0,0.0,0.1,brian melloy,IE-3610,2017
-IE,3810,1,Probabilistic Operations Rsrch,0.14,0.34,0.25,0.12,0.09,0.0,0.0,0.07,amin khademi,IE-3810,2017
-IE,3840,1,Engr Econ Analysis,0.29,0.16,0.2,0.1,0.13,0.0,0.0,0.13,brian melloy,IE-3840,2017
-IE,3860,1,Prod Plan & Cont,0.31,0.29,0.2,0.13,0.05,0.0,0.0,0.03,robert james riggs,IE-3860,2017
-IE,4400,1,Decision Support Sys,0.45,0.28,0.16,0.03,0.05,0.0,0.0,0.02,sandra dun eksioglu,IE-4400,2017
-IE,4400,2,Decision Support Sys,0.29,0.35,0.24,0.06,0.06,0.0,0.0,0.0,sandra dun eksioglu,IE-4400,2017
-IE,4610,1,Quality Engineering,0.27,0.34,0.2,0.16,0.01,0.0,0.0,0.02,byung rae cho,IE-4610,2017
-IE,4650,1,Facilities Planning & Design,0.14,0.55,0.27,0.04,0.01,0.0,0.0,0.0,william ferrell,IE-4650,2017
-IE,4820,1,Systems Modeling,0.44,0.37,0.19,0.0,0.0,0.0,0.0,0.0,kevin taaffe,IE-4820,2017
-IE,4820,2,Systems Modeling,0.43,0.44,0.12,0.01,0.0,0.0,0.0,0.0,kevin taaffe,IE-4820,2017
-IE,4910,1,Network Flows for IE Apps,0.29,0.41,0.18,0.12,0.0,0.0,0.0,0.0,burak eksioglu,IE-4910,2017
-IE,4910,2,Service Engineering,0.21,0.52,0.24,0.03,0.0,0.0,0.0,0.0,tugce isik,IE-4910,2017
-IE,4910,3,Human Centered Design & Engr,0.31,0.59,0.07,0.0,0.0,0.0,0.0,0.03,laura miche stanley,IE-4910,2017
-IE,8000,1,Human Factors Eng,0.49,0.47,0.05,0.0,0.0,0.0,0.0,0.0,david neyens,IE-8000,2017
-IE,8030,1,Engr Optimization and Apps,0.48,0.45,0.05,0.0,0.0,0.0,0.0,0.03,jonathan cole smith,IE-8030,2017
-IE,8090,1,Model Sys Under Risk,0.43,0.35,0.18,0.0,0.0,0.0,0.0,0.05,burak eksioglu,IE-8090,2017
-IE,8510,1,Descriptive Analytics,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,mary elizabeth kurz,IE-8510,2017
-IE,8530,1,Foundations of Quality,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,byung rae cho,IE-8530,2017
-IE,8550,1,SC & Logistics Modeling II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,IE-8550,2017
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.84,0.13,0.03,lisa marie robinson,INT-1510,2017
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,caren kelley-hall,INT-1530,2017
-IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.48,0.52,0.0,meredith fan wilson,IS-1010,2017
-ITAL,1010,1,Elementary Italian,0.67,0.2,0.07,0.0,0.07,0.0,0.0,0.0,julia schmidt,ITAL-1010,2017
-ITAL,1010,2,Elementary Italian,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,luca barattoni,ITAL-1010,2017
-ITAL,1010,3,Elementary Italian,0.38,0.25,0.19,0.0,0.13,0.0,0.0,0.06,julia schmidt,ITAL-1010,2017
-ITAL,1010,4,Elementary Italian,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-1010,2017
-ITAL,1020,1,Elementary Italian,0.31,0.31,0.06,0.0,0.06,0.0,0.0,0.25,lyudmyla tsykalova,ITAL-1020,2017
-ITAL,2010,1,Intermediate Italian,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-2010,2017
-JAPN,1010,1,Elementary Japanese,0.28,0.17,0.17,0.11,0.11,0.0,0.0,0.17,saori suto,JAPN-1010,2017
-JAPN,1010,2,Elementary Japanese,0.32,0.32,0.11,0.05,0.16,0.0,0.0,0.05,saori suto,JAPN-1010,2017
-JAPN,2010,1,Intermed Japanese,0.31,0.31,0.31,0.08,0.0,0.0,0.0,0.0,saori suto,JAPN-2010,2017
-JAPN,4010,1,Japanese Lit in Translation,0.47,0.35,0.06,0.12,0.0,0.0,0.0,0.0,kumiko saito,JAPN-4010,2017
-JAPN,4060,1,Intro to Japanese Literature,0.67,0.08,0.08,0.17,0.0,0.0,0.0,0.0,kumiko saito,JAPN-4060,2017
-JUST,2880,1,The Criminal Justice System,0.4,0.32,0.19,0.09,0.0,0.0,0.0,0.0,margaret tina britz,JUST-2880,2017
-JUST,2890,1,Criminology,0.89,0.06,0.03,0.0,0.0,0.0,0.0,0.03,angelia turner,JUST-2890,2017
-JUST,4680,1,Criminal Evidence,0.4,0.28,0.23,0.09,0.0,0.0,0.0,0.0,margaret tina britz,JUST-4680,2017
-JUST,4910,1,Policing,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david williams,JUST-4910,2017
-LANG,2540,1,Introduction to World Cinemas,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,joseph mai,LANG-2540,2017
-LANG,3710,1,Language and Culture,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,yanhua zhang,LANG-3710,2017
-LARC,1150,1,Intro Landscape Architecture,0.68,0.14,0.11,0.04,0.04,0.0,0.0,0.0,mary padua,LARC-1150,2017
-LARC,1280,1,Technical Graphics,0.18,0.41,0.32,0.09,0.0,0.0,0.0,0.0,cecile martin,LARC-1280,2017
-LARC,1510,1,Basic Design I,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,cecile martin,LARC-1510,2017
-LARC,2510,1,Larch Design Fund,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jessica fernandez,LARC-2510,2017
-LARC,2620,1,Design Impl I,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,pai liu,LARC-2620,2017
-LARC,3510,1,Regional Design,0.41,0.35,0.12,0.0,0.06,0.0,0.0,0.06,matthew neal powers,LARC-3510,2017
-LARC,4540,1,Urban Design Studio,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,paul russell,LARC-4540,2017
-LARC,4620,1,Design Implementation III,0.56,0.25,0.06,0.06,0.0,0.0,0.0,0.06,jessica fernandez,LARC-4620,2017
-LARC,8430,1,Interdisc Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,LARC-8430,2017
-LAW,3220,1,Legal Env of Bus,0.27,0.45,0.29,0.0,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2017
-LAW,3220,2,Legal Env of Bus,0.33,0.43,0.18,0.02,0.04,0.0,0.0,0.0,edward ray claggett,LAW-3220,2017
-LAW,3220,3,Legal Env of Bus,0.29,0.31,0.33,0.0,0.06,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2017
-LAW,3220,4,Legal Env of Bus,0.1,0.44,0.38,0.02,0.06,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2017
-LAW,3220,5,Legal Env of Bus,0.05,0.38,0.38,0.1,0.05,0.0,0.0,0.05,kenneth toussaint,LAW-3220,2017
-LAW,3220,6,Legal Env of Bus,0.22,0.39,0.29,0.08,0.0,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2017
-LAW,3220,7,Legal Env of Bus,0.31,0.42,0.23,0.02,0.02,0.0,0.0,0.0,kath kisska-schulze,LAW-3220,2017
-LAW,3220,8,Legal Env of Bus,0.39,0.49,0.1,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,LAW-3220,2017
-LAW,3220,9,Legal Env of Bus,0.3,0.4,0.25,0.03,0.0,0.0,0.0,0.03,john hine,LAW-3220,2017
-LAW,3220,10,Legal Env of Bus,0.29,0.41,0.18,0.02,0.0,0.0,0.0,0.1,kath kisska-schulze,LAW-3220,2017
-LAW,3220,400,Legal Env of Bus,0.32,0.47,0.12,0.03,0.03,0.0,0.0,0.03,virgini ward-vaughn,LAW-3220,2017
-LAW,3220,401,Legal Env of Bus,0.33,0.37,0.18,0.02,0.03,0.0,0.0,0.07,virgini ward-vaughn,LAW-3220,2017
-LAW,3220,402,Legal Env of Bus,0.4,0.37,0.12,0.0,0.04,0.0,0.0,0.07,virgini ward-vaughn,LAW-3220,2017
-LAW,3220,403,Legal Env of Bus,0.33,0.43,0.14,0.03,0.03,0.0,0.0,0.03,virgini ward-vaughn,LAW-3220,2017
-LAW,3330,1,Real Estate Law,0.0,0.47,0.33,0.07,0.1,0.0,0.0,0.03,judson jahn,LAW-3330,2017
-LAW,3330,2,Real Estate Law,0.21,0.5,0.21,0.0,0.06,0.0,0.0,0.03,judson jahn,LAW-3330,2017
-LAW,4050,1,Construction Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-4050,2017
-LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.9,0.03,0.06, lee ferrell,LIT-1270,2017
-LS,1000,1,Therapeutic Yoga,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-1000,2017
-LS,1000,2,Therapeutic Yoga,0.67,0.19,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,LS-1000,2017
-LS,1000,3,Therapeutic Yoga,0.8,0.05,0.0,0.0,0.0,0.0,0.0,0.15,ranjanbala dil amin,LS-1000,2017
-LS,1000,4,Intro to Barre,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,lauren eliza george,LS-1000,2017
-LS,1000,5,Intro to Barre,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lauren eliza george,LS-1000,2017
-LS,1000,10,Clemson Life,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,kristin anne neff,LS-1000,2017
-LS,1000,14,Freshman Outdoor,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,emily grace turke,LS-1000,2017
-LS,1000,28,Stand up Pabbleboarding,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,william holland,LS-1000,2017
-LS,1410,1,Top Rope Climbing,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,michelle tuday,LS-1410,2017
-LS,1410,2,Top Rope Climbing,0.73,0.13,0.0,0.0,0.0,0.0,0.0,0.13,michelle tuday,LS-1410,2017
-LS,1410,4,Top Rope Climbing,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michelle tuday,LS-1410,2017
-LS,1410,5,Top Rope Climbing,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,michelle tuday,LS-1410,2017
-LS,1560,2,Riflery,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,hubert cox,LS-1560,2017
-LS,1560,7,Riflery,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,LS-1560,2017
-LS,1560,16,Riflery,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,LS-1560,2017
-LS,1570,1,Shotgun Sports,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,john jeffrey price,LS-1570,2017
-LS,1570,6,Shotgun Sports,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,william cro mahoney,LS-1570,2017
-LS,1750,1,Fly Fishing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james micha harvell,LS-1750,2017
-LS,1850,1,Bowling,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,megan elizabet cato,LS-1850,2017
-LS,1850,2,Bowling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,alexandra sandoval,LS-1850,2017
-LS,1850,10,Bowling,0.86,0.0,0.05,0.05,0.0,0.0,0.0,0.05,tyler bennett,LS-1850,2017
-LS,1940,1,Racquetball,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,LS-1940,2017
-LS,1960,1,Intro to Billiards,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,broadus fleming,LS-1960,2017
-LS,1980,4,Golf,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jason jordan,LS-1980,2017
-LS,1980,5,Golf,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jason jordan,LS-1980,2017
-LS,1980,9,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,wesley scott womble,LS-1980,2017
-LS,2200,7,Shag,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,broadus fleming,LS-2200,2017
-LS,2270,1,Intro to Swing Dance,0.92,0.03,0.0,0.0,0.03,0.0,0.0,0.03,paul hoke,LS-2270,2017
-LS,2270,2,Intro to Swing Dance,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,LS-2270,2017
-LS,2270,3,Intro to Swing Dance,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,paul hoke,LS-2270,2017
-LS,2320,2,Core Training,0.76,0.1,0.05,0.0,0.0,0.0,0.0,0.1,diane moreno,LS-2320,2017
-LS,2320,3,Core Training,0.78,0.06,0.11,0.0,0.06,0.0,0.0,0.0,diane moreno,LS-2320,2017
-LS,2320,5,Core Training,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-2320,2017
-LS,2350,1,Basic Yoga,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,LS-2350,2017
-LS,2350,2,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,LS-2350,2017
-LS,2350,3,Basic Yoga,0.86,0.05,0.05,0.05,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2017
-LS,2350,4,Basic Yoga,0.81,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,LS-2350,2017
-LS,2350,5,Basic Yoga,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-2350,2017
-LS,2350,7,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,LS-2350,2017
-LS,2350,8,Basic Yoga,0.87,0.09,0.0,0.0,0.04,0.0,0.0,0.0,kayla lee wardlaw,LS-2350,2017
-LS,2380,4,Vinyasa Flow Yoga,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,LS-2380,2017
-LS,2420,1,Meditation and Relax,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2017
-LS,2420,2,Meditation and Relax,0.91,0.0,0.04,0.04,0.0,0.0,0.0,0.0,renee warren gahan,LS-2420,2017
-LS,2420,4,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,LS-2420,2017
-LS,2420,5,Meditation and Relax,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2420,2017
-LS,2420,6,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2017
-LS,2420,7,Meditation and Relax,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,LS-2420,2017
-LS,2420,8,Meditation and Relax,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,LS-2420,2017
-LS,2450,1,Pilates,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,melanie ivey job,LS-2450,2017
-LS,2450,5,Pilates,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-2450,2017
-LS,2450,6,Pilates,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,diane moreno,LS-2450,2017
-LS,2750,8,First Aid/Cpr,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,christopher loomis,LS-2750,2017
-MATH,1010,1,Essen Math for Informed Soc,0.44,0.39,0.06,0.0,0.06,0.0,0.0,0.06,ebenezer eduafo,MATH-1010,2017
-MATH,1010,2,Essen Math for Informed Soc,0.59,0.29,0.0,0.12,0.0,0.0,0.0,0.0,ebenezer eduafo,MATH-1010,2017
-MATH,1010,3,Essen Math for Informed Soc,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,xiyan tan,MATH-1010,2017
-MATH,1010,4,Essen Math for Informed Soc,0.65,0.12,0.12,0.06,0.0,0.0,0.0,0.06,xiyan tan,MATH-1010,2017
-MATH,1010,5,Essen Math for Informed Soc,0.39,0.39,0.06,0.17,0.0,0.0,0.0,0.0,jun yuan,MATH-1010,2017
-MATH,1010,6,Essen Math for Informed Soc,0.44,0.22,0.22,0.11,0.0,0.0,0.0,0.0,jun yuan,MATH-1010,2017
-MATH,1010,7,Essen Math for Informed Soc,0.61,0.31,0.03,0.03,0.0,0.0,0.0,0.03,marilyn reba,MATH-1010,2017
-MATH,1020,1,Business Calculus I,0.32,0.16,0.21,0.11,0.05,0.0,0.0,0.16,madeleine stville,MATH-1020,2017
-MATH,1020,2,Business Calculus I,0.32,0.37,0.26,0.0,0.05,0.0,0.0,0.0,madeleine stville,MATH-1020,2017
-MATH,1020,3,Business Calculus I,0.26,0.42,0.16,0.05,0.05,0.0,0.0,0.05,morgan elston,MATH-1020,2017
-MATH,1020,4,Business Calculus I,0.16,0.32,0.05,0.21,0.21,0.0,0.0,0.05,morgan elston,MATH-1020,2017
-MATH,1020,5,Business Calculus I,0.21,0.37,0.26,0.11,0.05,0.0,0.0,0.0,michael thoma cowen,MATH-1020,2017
-MATH,1020,6,Business Calculus I,0.47,0.21,0.21,0.05,0.05,0.0,0.0,0.0,michael thoma cowen,MATH-1020,2017
-MATH,1020,7,Business Calculus I,0.17,0.22,0.39,0.06,0.06,0.0,0.0,0.11,aaro ramirez flores,MATH-1020,2017
-MATH,1020,8,Business Calculus I,0.26,0.32,0.26,0.11,0.0,0.0,0.0,0.05,aaro ramirez flores,MATH-1020,2017
-MATH,1020,9,Business Calculus I,0.28,0.28,0.17,0.06,0.11,0.0,0.0,0.11, kamronnaher,MATH-1020,2017
-MATH,1020,10,Business Calculus I,0.21,0.21,0.32,0.16,0.11,0.0,0.0,0.0, kamronnaher,MATH-1020,2017
-MATH,1020,11,Business Calculus I,0.42,0.16,0.16,0.11,0.11,0.0,0.0,0.05,emma cinatl,MATH-1020,2017
-MATH,1020,12,Business Calculus I,0.06,0.5,0.13,0.13,0.13,0.0,0.0,0.06,emma cinatl,MATH-1020,2017
-MATH,1020,13,Business Calculus I,0.37,0.37,0.05,0.11,0.05,0.0,0.0,0.05,zachary david espe,MATH-1020,2017
-MATH,1020,14,Business Calculus I,0.26,0.37,0.16,0.16,0.0,0.0,0.0,0.05,zachary david espe,MATH-1020,2017
-MATH,1020,15,Business Calculus I,0.05,0.16,0.21,0.11,0.32,0.0,0.0,0.16,anna caro bachstein,MATH-1020,2017
-MATH,1020,16,Business Calculus I,0.16,0.32,0.11,0.11,0.21,0.0,0.0,0.11,anna caro bachstein,MATH-1020,2017
-MATH,1020,17,Business Calculus I,0.17,0.22,0.28,0.11,0.11,0.0,0.0,0.11,scott scruggs,MATH-1020,2017
-MATH,1020,18,Business Calculus I,0.5,0.11,0.17,0.11,0.11,0.0,0.0,0.0,aaron moose,MATH-1020,2017
-MATH,1020,19,Business Calculus I,0.16,0.37,0.26,0.0,0.16,0.0,0.0,0.05,rachel bass lanning,MATH-1020,2017
-MATH,1020,20,Business Calculus I,0.26,0.16,0.42,0.11,0.05,0.0,0.0,0.0,john william grant,MATH-1020,2017
-MATH,1020,21,Business Calculus I,0.21,0.42,0.26,0.0,0.11,0.0,0.0,0.0,rachel bass lanning,MATH-1020,2017
-MATH,1020,22,Business Calculus I,0.26,0.26,0.16,0.11,0.05,0.0,0.0,0.16,molly adam honecker,MATH-1020,2017
-MATH,1020,23,Business Calculus I,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,shanshan jia,MATH-1020,2017
-MATH,1020,24,Business Calculus I,0.37,0.21,0.21,0.11,0.05,0.0,0.0,0.05,todd anthony morra,MATH-1020,2017
-MATH,1020,25,Business Calculus I,0.33,0.22,0.28,0.06,0.11,0.0,0.0,0.0,yibo xu,MATH-1020,2017
-MATH,1020,26,Business Calculus I,0.16,0.32,0.32,0.05,0.11,0.0,0.0,0.05,shanshan jia,MATH-1020,2017
-MATH,1020,27,Business Calculus I,0.11,0.32,0.42,0.05,0.05,0.0,0.0,0.05,peter westerbaan,MATH-1020,2017
-MATH,1020,28,Business Calculus I,0.44,0.22,0.28,0.0,0.06,0.0,0.0,0.0,todd anthony morra,MATH-1020,2017
-MATH,1020,29,Business Calculus I,0.17,0.33,0.22,0.06,0.17,0.0,0.0,0.06,yibo xu,MATH-1020,2017
-MATH,1020,30,Business Calculus I,0.42,0.26,0.16,0.05,0.05,0.0,0.0,0.05,kara ail stasikelis,MATH-1020,2017
-MATH,1020,31,Business Calculus I,0.21,0.47,0.0,0.05,0.16,0.0,0.0,0.11,li he,MATH-1020,2017
-MATH,1020,32,Business Calculus I,0.26,0.16,0.37,0.0,0.16,0.0,0.0,0.05,aaron moose,MATH-1020,2017
-MATH,1020,33,Business Calculus I,0.21,0.11,0.42,0.05,0.11,0.0,0.0,0.11,li he,MATH-1020,2017
-MATH,1020,34,Business Calculus I,0.26,0.11,0.21,0.16,0.26,0.0,0.0,0.0,scott scruggs,MATH-1020,2017
-MATH,1020,35,Business Calculus I,0.42,0.22,0.24,0.02,0.04,0.0,0.0,0.04,jennifer ray newton,MATH-1020,2017
-MATH,1020,36,Business Calculus I,0.33,0.27,0.16,0.04,0.09,0.0,0.0,0.11,jennifer ray newton,MATH-1020,2017
-MATH,1020,37,Business Calculus I,0.26,0.26,0.32,0.0,0.16,0.0,0.0,0.0,peter westerbaan,MATH-1020,2017
-MATH,1020,38,Business Calculus I,0.22,0.39,0.33,0.0,0.06,0.0,0.0,0.0,molly adam honecker,MATH-1020,2017
-MATH,1020,39,Business Calculus I,0.45,0.2,0.2,0.07,0.05,0.0,0.0,0.02,jennifer van dyken,MATH-1020,2017
-MATH,1020,40,Business Calculus I,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,randy davidson,MATH-1020,2017
-MATH,1020,41,Business Calculus I,0.29,0.23,0.22,0.06,0.18,0.0,0.0,0.01,randy davidson,MATH-1020,2017
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.57,0.41,0.02,donna simms,MATH-1040,2017
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.62,0.04,stephen peele,MATH-1040,2017
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.47,0.47,0.07,stephen peele,MATH-1040,2017
-MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.5,0.39,0.11,andrew walton green,MATH-1040,2017
-MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.52,0.1,sergey charnyi,MATH-1040,2017
-MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.24,0.64,0.12,stephen garth,MATH-1040,2017
-MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.64,0.33,0.02,stephen peele,MATH-1040,2017
-MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.52,0.02,nicholas ahlstrom,MATH-1040,2017
-MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.45,0.33,0.21,xiaoyuan liu,MATH-1040,2017
-MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.5,0.14,xun dong,MATH-1040,2017
-MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.39,0.52,0.09,stefan adam bock,MATH-1040,2017
-MATH,1040,12,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.34,0.59,0.07,stefan adam bock,MATH-1040,2017
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.44,0.54,0.02,tony thanh nguyen,MATH-1050,2017
-MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.72,0.28,0.0,tony thanh nguyen,MATH-1050,2017
-MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.36,0.05,tony thanh nguyen,MATH-1050,2017
-MATH,1060,1,Calculus of One Variable I,0.17,0.29,0.32,0.07,0.07,0.0,0.0,0.07,thomas clevenger,MATH-1060,2017
-MATH,1060,2,Calculus of One Variable I,0.25,0.23,0.2,0.04,0.17,0.0,0.0,0.11,calvin williams,MATH-1060,2017
-MATH,1060,3,Calculus of One Variable I,0.25,0.32,0.09,0.05,0.14,0.0,0.0,0.16,paul james cubre,MATH-1060,2017
-MATH,1060,4,Calculus of One Variable I,0.35,0.26,0.23,0.0,0.13,0.0,0.0,0.03,huixi li,MATH-1060,2017
-MATH,1060,5,Calculus of One Variable I,0.2,0.27,0.18,0.09,0.04,0.0,0.0,0.22,pye phyo aung,MATH-1060,2017
-MATH,1060,6,Calculus of One Variable I,0.18,0.23,0.3,0.11,0.14,0.0,0.0,0.05,rebecca ramos,MATH-1060,2017
-MATH,1060,8,Calculus of One Variable I,0.25,0.28,0.21,0.05,0.14,0.0,0.0,0.06,judith cottingham,MATH-1060,2017
-MATH,1060,10,Calculus of One Variable I,0.22,0.25,0.2,0.09,0.16,0.0,0.0,0.07,judith cottingham,MATH-1060,2017
-MATH,1060,11,Calculus of One Variable I,0.41,0.28,0.06,0.06,0.13,0.0,0.0,0.06,thowhida akther,MATH-1060,2017
-MATH,1060,14,Calculus of One Variable I,0.12,0.23,0.26,0.14,0.12,0.0,0.0,0.14,paul james cubre,MATH-1060,2017
-MATH,1060,15,Calculus of One Variable I,0.31,0.22,0.17,0.11,0.06,0.0,0.0,0.14,fun choi john chan,MATH-1060,2017
-MATH,1060,16,Calculus of One Variable I,0.25,0.36,0.09,0.05,0.11,0.0,0.0,0.14,pye phyo aung,MATH-1060,2017
-MATH,1060,17,Calculus of One Variable I,0.16,0.24,0.27,0.07,0.16,0.0,0.0,0.11,pye phyo aung,MATH-1060,2017
-MATH,1060,18,Calculus of One Variable I,0.21,0.39,0.33,0.0,0.0,0.0,0.0,0.06,marilyn reba,MATH-1060,2017
-MATH,1060,100,Calc of One Variable I (HON),0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,boshi yang,MATH-1060,2017
-MATH,1060,201,Calculus of One Variable I,0.25,0.44,0.17,0.04,0.0,0.0,0.0,0.1,james edwar gossell,MATH-1060,2017
-MATH,1060,202,Calculus of One Variable I,0.29,0.4,0.17,0.06,0.02,0.0,0.0,0.06,hiram lopez valdez,MATH-1060,2017
-MATH,1060,203,Calculus of One Variable I,0.37,0.37,0.26,0.0,0.0,0.0,0.0,0.0,alistair bentley,MATH-1060,2017
-MATH,1060,205,Calculus of One Variable I,0.23,0.56,0.1,0.04,0.06,0.0,0.0,0.0,amy christine grady,MATH-1060,2017
-MATH,1060,206,Calculus of One Variable I,0.23,0.46,0.21,0.02,0.04,0.0,0.0,0.04,thomas clevenger,MATH-1060,2017
-MATH,1060,207,Calculus of One Variable I,0.35,0.27,0.13,0.07,0.04,0.0,0.0,0.14,hiram lopez valdez,MATH-1060,2017
-MATH,1070,1,Differen and Integral Calculus,0.0,0.25,0.47,0.13,0.09,0.0,0.0,0.06,donna simms,MATH-1070,2017
-MATH,1080,1,Calculus of One Variable II,0.23,0.13,0.2,0.17,0.13,0.0,0.0,0.13,sanwar ahmad,MATH-1080,2017
-MATH,1080,2,Calculus of One Variable II,0.09,0.23,0.28,0.14,0.12,0.0,0.0,0.14,fei xue,MATH-1080,2017
-MATH,1080,5,Calculus of One Variable II,0.17,0.1,0.15,0.12,0.37,0.0,0.0,0.1,mengying xiao,MATH-1080,2017
-MATH,1080,6,Calculus of One Variable II,0.11,0.21,0.25,0.04,0.14,0.0,0.0,0.25,mark cawood,MATH-1080,2017
-MATH,1080,7,Calculus of One Variable II,0.13,0.23,0.25,0.03,0.23,0.0,0.0,0.15,beth novick,MATH-1080,2017
-MATH,1080,8,Calculus of One Variable II,0.15,0.24,0.15,0.07,0.24,0.0,0.0,0.15,meredith nicol burr,MATH-1080,2017
-MATH,1080,9,Calculus of One Variable II,0.21,0.28,0.14,0.14,0.16,0.0,0.0,0.07,meredith nicol burr,MATH-1080,2017
-MATH,1080,201,Calculus of One Variable II,0.34,0.21,0.26,0.05,0.11,0.0,0.0,0.03,beth novick,MATH-1080,2017
-MATH,1150,1,Contemp Math for Elem Teach I,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-1150,2017
-MATH,1150,2,Contemp Math for Elem Teach I,0.57,0.27,0.11,0.05,0.0,0.0,0.0,0.0,allison stoddard,MATH-1150,2017
-MATH,1160,1,Contemp Math for Elem Teach II,0.41,0.55,0.05,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1160,2017
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.0,marion hanna,MATH-1990,2017
-MATH,1990,401,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.04,0.02,marion hanna,MATH-1990,2017
-MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,MATH-1990,2017
-MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,MATH-1990,2017
-MATH,2060,1,Calculus of Several Variables,0.4,0.33,0.22,0.0,0.0,0.0,0.0,0.04,xin liu,MATH-2060,2017
-MATH,2060,2,Calculus of Several Variables,0.31,0.51,0.18,0.0,0.0,0.0,0.0,0.0,peter kiessler,MATH-2060,2017
-MATH,2060,3,Calculus of Several Variables,0.15,0.28,0.28,0.04,0.17,0.0,0.0,0.09,sofya alekseeva,MATH-2060,2017
-MATH,2060,5,Calculus of Several Variables,0.25,0.28,0.19,0.09,0.13,0.0,0.0,0.06,jeong rock yoon,MATH-2060,2017
-MATH,2060,6,Calculus of Several Variables,0.32,0.18,0.11,0.05,0.18,0.0,0.0,0.16,allen anderso guest,MATH-2060,2017
-MATH,2060,7,Calculus of Several Variables,0.22,0.35,0.35,0.07,0.0,0.0,0.0,0.0,sofya alekseeva,MATH-2060,2017
-MATH,2060,9,Calculus of Several Variables,0.09,0.26,0.11,0.09,0.2,0.0,0.0,0.26,timothy fra parrott,MATH-2060,2017
-MATH,2060,10,Calculus of Several Variables,0.2,0.33,0.2,0.02,0.2,0.0,0.0,0.04,allen anderso guest,MATH-2060,2017
-MATH,2060,11,Calculus of Several Variables,0.29,0.47,0.18,0.03,0.0,0.0,0.0,0.03,xin liu,MATH-2060,2017
-MATH,2060,12,Calculus of Several Variables,0.44,0.29,0.15,0.02,0.05,0.0,0.0,0.05,irina viktorova,MATH-2060,2017
-MATH,2060,13,Calculus of Several Variables,0.32,0.39,0.24,0.0,0.0,0.0,0.0,0.05,akshay sunil gupte,MATH-2060,2017
-MATH,2060,14,Calculus of Several Variables,0.49,0.31,0.13,0.02,0.0,0.0,0.0,0.04,martin joha schmoll,MATH-2060,2017
-MATH,2060,15,Calculus of Several Variables,0.22,0.22,0.12,0.2,0.17,0.0,0.0,0.07,julie lassiter,MATH-2060,2017
-MATH,2060,16,Calculus of Several Variables,0.3,0.32,0.11,0.02,0.16,0.0,0.0,0.09,allen anderso guest,MATH-2060,2017
-MATH,2060,17,Calculus of Several Variables,0.05,0.25,0.16,0.2,0.2,0.0,0.0,0.14,julie lassiter,MATH-2060,2017
-MATH,2060,18,Calculus of Several Variables,0.26,0.34,0.21,0.11,0.05,0.0,0.0,0.03,sofya alekseeva,MATH-2060,2017
-MATH,2060,19,Calculus of Several Variables,0.13,0.3,0.19,0.07,0.22,0.0,0.0,0.09,gretchen matthews,MATH-2060,2017
-MATH,2060,20,Calculus of Several Variables,0.33,0.33,0.22,0.04,0.0,0.0,0.0,0.07,martin joha schmoll,MATH-2060,2017
-MATH,2060,21,Calculus of Several Variables,0.28,0.23,0.25,0.1,0.1,0.0,0.0,0.05,shitao liu,MATH-2060,2017
-MATH,2060,22,Calculus of Several Variables,0.16,0.32,0.18,0.11,0.16,0.0,0.0,0.09,gretchen matthews,MATH-2060,2017
-MATH,2060,100,Calc of Several Vars (HON),0.4,0.36,0.12,0.05,0.05,0.0,0.0,0.02,james brown,MATH-2060,2017
-MATH,2060,201,Calculus of Several Variables,0.11,0.26,0.18,0.05,0.08,0.0,0.0,0.32,timothy fra parrott,MATH-2060,2017
-MATH,2060,202,Calculus of Several Variables,0.14,0.31,0.12,0.05,0.05,0.0,0.0,0.33,timothy fra parrott,MATH-2060,2017
-MATH,2070,1,Business Calculus II,0.28,0.5,0.06,0.17,0.0,0.0,0.0,0.0,thanh thien to,MATH-2070,2017
-MATH,2070,2,Business Calculus II,0.21,0.11,0.32,0.32,0.05,0.0,0.0,0.0,thanh thien to,MATH-2070,2017
-MATH,2070,3,Business Calculus II,0.26,0.32,0.32,0.0,0.0,0.0,0.0,0.11,garrett dranichak,MATH-2070,2017
-MATH,2070,4,Business Calculus II,0.47,0.05,0.16,0.16,0.11,0.0,0.0,0.05,garrett dranichak,MATH-2070,2017
-MATH,2070,7,Business Calculus II,0.28,0.11,0.33,0.11,0.06,0.0,0.0,0.11,yinggu bao,MATH-2070,2017
-MATH,2070,8,Business Calculus II,0.16,0.32,0.21,0.16,0.05,0.0,0.0,0.11,haodong li,MATH-2070,2017
-MATH,2070,9,Business Calculus II,0.17,0.22,0.44,0.06,0.11,0.0,0.0,0.0,haodong li,MATH-2070,2017
-MATH,2070,11,Business Calculus II,0.4,0.31,0.15,0.07,0.05,0.0,0.0,0.02,jennifer ray newton,MATH-2070,2017
-MATH,2070,12,Business Calculus II,0.26,0.26,0.21,0.16,0.0,0.0,0.0,0.11,yinggu bao,MATH-2070,2017
-MATH,2070,13,Business Calculus II,0.33,0.28,0.18,0.05,0.03,0.0,0.0,0.13,jennifer mari hanna,MATH-2070,2017
-MATH,2070,14,Business Calculus II,0.36,0.36,0.14,0.05,0.0,0.0,0.0,0.1,jennifer mari hanna,MATH-2070,2017
-MATH,2070,15,Business Calculus II,0.41,0.32,0.17,0.05,0.02,0.0,0.0,0.02,jennifer mari hanna,MATH-2070,2017
-MATH,2070,16,Business Calculus II,0.34,0.34,0.16,0.09,0.02,0.0,0.0,0.05,sea sather-wagstaff,MATH-2070,2017
-MATH,2070,18,Business Calculus II,0.19,0.21,0.22,0.12,0.1,0.0,0.0,0.16,judith irene mcknew,MATH-2070,2017
-MATH,2080,1,Intro to Ordin Diff Equations,0.16,0.13,0.16,0.19,0.13,0.0,0.0,0.23,terri johnson,MATH-2080,2017
-MATH,2080,2,Intro to Ordin Diff Equations,0.18,0.38,0.18,0.13,0.13,0.0,0.0,0.03,irina viktorova,MATH-2080,2017
-MATH,2080,3,Intro to Ordin Diff Equations,0.07,0.27,0.41,0.12,0.05,0.0,0.0,0.07,irina viktorova,MATH-2080,2017
-MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.13,0.19,0.0,0.22,0.0,0.0,0.25,terri johnson,MATH-2080,2017
-MATH,2080,5,Intro to Ordin Diff Equations,0.13,0.13,0.22,0.06,0.13,0.0,0.0,0.34,terri johnson,MATH-2080,2017
-MATH,2080,6,Intro to Ordin Diff Equations,0.22,0.43,0.16,0.08,0.0,0.0,0.0,0.11,oleg yordanov,MATH-2080,2017
-MATH,2080,7,Intro to Ordin Diff Equations,0.36,0.25,0.19,0.06,0.08,0.0,0.0,0.06,oleg yordanov,MATH-2080,2017
-MATH,2080,8,Intro to Ordin Diff Equations,0.14,0.35,0.26,0.09,0.09,0.0,0.0,0.07,oleg yordanov,MATH-2080,2017
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,matthew macauley,MATH-2080,2017
-MATH,2160,1,Geometry for Elem Sch Teachers,0.69,0.17,0.1,0.0,0.03,0.0,0.0,0.0,allison stoddard,MATH-2160,2017
-MATH,2160,2,Geometry for Elem Sch Teachers,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-2160,2017
-MATH,2500,1,Intro to Mathematical Sciences,0.94,0.03,0.02,0.0,0.0,0.0,0.0,0.02,christopher cox,MATH-2500,2017
-MATH,3020,1,Stat for Science & Engineering,0.32,0.19,0.32,0.11,0.0,0.0,0.0,0.05,derek brown,MATH-3020,2017
-MATH,3020,2,Stat for Science & Engineering,0.2,0.47,0.13,0.0,0.07,0.0,0.0,0.13,haotian feng,MATH-3020,2017
-MATH,3020,3,Stat for Science & Engineering,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,prab withana gamage,MATH-3020,2017
-MATH,3020,4,Stat for Science & Engineering,0.33,0.13,0.33,0.2,0.0,0.0,0.0,0.0,elaine ma sotherden,MATH-3020,2017
-MATH,3020,6,Stat for Science & Engineering,0.17,0.28,0.42,0.0,0.03,0.0,0.0,0.11,calvin williams,MATH-3020,2017
-MATH,3020,8,Stat for Science & Engineering,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,prab withana gamage,MATH-3020,2017
-MATH,3020,9,Stat for Science & Engineering,0.24,0.65,0.12,0.0,0.0,0.0,0.0,0.0,haotian feng,MATH-3020,2017
-MATH,3020,12,Stat for Science & Engineering,0.22,0.28,0.17,0.17,0.11,0.0,0.0,0.06,elaine ma sotherden,MATH-3020,2017
-MATH,3020,14,Stat for Science & Engineering,0.43,0.33,0.13,0.03,0.0,0.0,0.0,0.1,ellen hepfe breazel,MATH-3020,2017
-MATH,3020,15,Stat for Science & Engineering,0.33,0.55,0.08,0.03,0.03,0.0,0.0,0.0,ellen hepfe breazel,MATH-3020,2017
-MATH,3110,1,Linear Algebra,0.34,0.3,0.11,0.05,0.09,0.0,0.0,0.11,xuhong gao,MATH-3110,2017
-MATH,3110,2,Linear Algebra,0.24,0.32,0.17,0.07,0.12,0.0,0.0,0.07,xuhong gao,MATH-3110,2017
-MATH,3110,3,Linear Algebra,0.17,0.26,0.33,0.07,0.07,0.0,0.0,0.11,michael adam burr,MATH-3110,2017
-MATH,3110,4,Linear Algebra,0.22,0.32,0.27,0.15,0.02,0.0,0.0,0.02,hui xue,MATH-3110,2017
-MATH,3110,5,Linear Algebra,0.32,0.29,0.2,0.05,0.12,0.0,0.0,0.02,hui xue,MATH-3110,2017
-MATH,3110,6,Linear Algebra,0.23,0.25,0.18,0.07,0.14,0.0,0.0,0.14,felice manganiello,MATH-3110,2017
-MATH,3110,7,Linear Algebra,0.14,0.28,0.21,0.19,0.05,0.0,0.0,0.14,felice manganiello,MATH-3110,2017
-MATH,3110,8,Linear Algebra,0.62,0.22,0.13,0.0,0.0,0.0,0.0,0.02,benjamin jaye,MATH-3110,2017
-MATH,3110,100,Linear Algebra (HON),0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,neil calkin,MATH-3110,2017
-MATH,3110,200,Linear Algebra,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,kevin james,MATH-3110,2017
-MATH,3160,1,Prob Solving for Math Teachers,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-3160,2017
-MATH,3190,1,Introduction to Proof,0.26,0.42,0.16,0.05,0.05,0.0,0.0,0.05,james ba coykendall,MATH-3190,2017
-MATH,3190,2,Introduction to Proof,0.27,0.15,0.27,0.0,0.19,0.0,0.0,0.12,james ba coykendall,MATH-3190,2017
-MATH,3600,1,Intermediate Math Computing,0.7,0.1,0.07,0.03,0.07,0.0,0.0,0.03,mark cawood,MATH-3600,2017
-MATH,3600,2,Intermediate Math Computing,0.81,0.06,0.1,0.0,0.03,0.0,0.0,0.0,mark cawood,MATH-3600,2017
-MATH,3650,1,Numerical Mthds for Engineers,0.22,0.38,0.19,0.11,0.08,0.0,0.0,0.03,vincent ervin,MATH-3650,2017
-MATH,3650,2,Numerical Mthds for Engineers,0.5,0.25,0.22,0.0,0.03,0.0,0.0,0.0,leo rebholz,MATH-3650,2017
-MATH,3650,3,Numerical Mthds for Engineers,0.29,0.6,0.07,0.05,0.0,0.0,0.0,0.0,timo johann heister,MATH-3650,2017
-MATH,3650,4,Numerical Mthds for Engineers,0.14,0.39,0.19,0.06,0.11,0.0,0.0,0.11,eleanor jenkins,MATH-3650,2017
-MATH,4000,1,Theory of Probability,0.44,0.26,0.14,0.05,0.05,0.0,0.0,0.07,xiaoqian sun,MATH-4000,2017
-MATH,4020,1,Stat for Sci & Engineering II,0.5,0.1,0.3,0.0,0.1,0.0,0.0,0.0,calvin williams,MATH-4020,2017
-MATH,4070,1,Regress & Time-Series Analysis,0.36,0.29,0.29,0.0,0.07,0.0,0.0,0.0,colin gallagher,MATH-4070,2017
-MATH,4080,1,Secondary Math Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,carlos gomez,MATH-4080,2017
-MATH,4120,1,Algebra I,0.26,0.31,0.28,0.05,0.08,0.0,0.0,0.03,matthew macauley,MATH-4120,2017
-MATH,4190,1,Discrete Math Structures I,0.7,0.23,0.03,0.0,0.03,0.0,0.0,0.0,beth novick,MATH-4190,2017
-MATH,4190,2,Discrete Math Structures I,0.46,0.36,0.18,0.0,0.0,0.0,0.0,0.0,wayne goddard,MATH-4190,2017
-MATH,4310,1,Theory of Interest,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0, erwin walker,MATH-4310,2017
-MATH,4340,1,Adv Engineering Mathematics,0.25,0.28,0.22,0.09,0.13,0.0,0.0,0.03,hyesuk lee,MATH-4340,2017
-MATH,4340,2,Adv Engineering Mathematics,0.21,0.07,0.14,0.14,0.29,0.0,0.0,0.14,eleanor jenkins,MATH-4340,2017
-MATH,4400,1,Linear Programming,0.42,0.25,0.21,0.04,0.04,0.0,0.0,0.04,boshi yang,MATH-4400,2017
-MATH,4410,1,Intro to Stochastic Models,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,brian fralix,MATH-4410,2017
-MATH,4500,1,Intro to Mathematical Models,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,matthew macauley,MATH-4500,2017
-MATH,4530,1,Advanced Calculus I,0.42,0.28,0.11,0.11,0.06,0.0,0.0,0.03,james peterson,MATH-4530,2017
-MATH,4540,1,Advanced Calculus II,0.17,0.25,0.33,0.17,0.0,0.0,0.0,0.08,james peterson,MATH-4540,2017
-MATH,4630,1,Mathematical Analysis I,0.36,0.18,0.18,0.09,0.18,0.0,0.0,0.0,mishko mitkovski,MATH-4630,2017
-MATH,6340,1,Adv Engineering Mathematics,0.36,0.41,0.14,0.0,0.0,0.0,0.0,0.09,vincent ervin,MATH-6340,2017
-MATH,8000,1,Probability,0.48,0.19,0.11,0.0,0.11,0.0,0.0,0.11,christopher mcmahan,MATH-8000,2017
-MATH,8010,1,General Linear Hypothesis I,0.5,0.42,0.0,0.0,0.08,0.0,0.0,0.0,derek brown,MATH-8010,2017
-MATH,8050,1,Data Analysis,0.68,0.25,0.04,0.0,0.0,0.0,0.0,0.04,ling ma,MATH-8050,2017
-MATH,8070,1,Applied Multivariate Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-8070,2017
-MATH,8100,1,Mathematical Programming,0.74,0.17,0.0,0.0,0.0,0.0,0.0,0.09,yuyuan ouyang,MATH-8100,2017
-MATH,8140,1,Network Flow Programming,0.36,0.18,0.27,0.0,0.0,0.0,0.0,0.18,herve louis kerivin,MATH-8140,2017
-MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,MATH-8170,2017
-MATH,8210,1,Linear Analysis,0.27,0.58,0.0,0.0,0.03,0.0,0.0,0.12,shitao liu,MATH-8210,2017
-MATH,8230,1,Complex Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,MATH-8230,2017
-MATH,8510,1,Abstract Algebra I,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,kevin james,MATH-8510,2017
-MATH,8530,1,Matrix Analysis,0.47,0.11,0.37,0.0,0.0,0.0,0.0,0.05,svetlan poznanovikj,MATH-8530,2017
-MATH,8580,1,Number Theory,0.57,0.14,0.14,0.0,0.14,0.0,0.0,0.0,james brown,MATH-8580,2017
-MATH,8600,1,Intro to Scientific Computing,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,hyesuk lee,MATH-8600,2017
-MATH,8610,1,Advanced Numerical Analysis I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,fei xue,MATH-8610,2017
-MATH,8650,1,Data Structures,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,timo johann heister,MATH-8650,2017
-MATH,8840,1,Statistics for Experimenters,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,MATH-8840,2017
-MATH,9850,2,Homological Algebra,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,sea sather-wagstaff,MATH-9850,2017
-MBA,8040,20,Busin Data An & Stat Computing,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,MBA-8040,2017
-MBA,8060,1,Operations Mgt,0.16,0.5,0.32,0.0,0.0,0.0,0.0,0.03, sridharan,MBA-8060,2017
-MBA,8070,1,Financial Management,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,george bra lockhart,MBA-8070,2017
-MBA,8070,20,Financial Management,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,george bra lockhart,MBA-8070,2017
-MBA,8090,1,Org Beh & Hum Res Mg,0.43,0.53,0.04,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2017
-MBA,8090,2,Org Beh & Hum Res Mg,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2017
-MBA,8180,20,Intro Business Intell & Anlytc,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,heshan sun,MBA-8180,2017
-MBA,8190,1,Intro to Acc and Fin,0.55,0.34,0.1,0.0,0.0,0.0,0.0,0.0,melvin stith,MBA-8190,2017
-MBA,8190,2,Intro to Acc and Fin,0.52,0.36,0.1,0.0,0.02,0.0,0.0,0.0,james mil kohlmeyer,MBA-8190,2017
-MBA,8290,1,Marketing Foundation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MBA-8290,2017
-MBA,8310,10,Communications and Sales,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,MBA-8310,2017
-MBA,8360,1,Real Estate Principles,0.41,0.48,0.11,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,MBA-8360,2017
-MBA,8370,1,Legal Environ of Bus,0.27,0.67,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2017
-MBA,8370,2,Legal Environ of Bus,0.47,0.47,0.03,0.0,0.0,0.0,0.0,0.03,judson jahn,MBA-8370,2017
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,prashant prabhu,MBA-8400,2017
-MBA,8430,1,Entrepreneurial Accounting,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,sally kathr widener,MBA-8430,2017
-MBA,8450,1,Technology & Innovation Mgt,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,michael george mino,MBA-8450,2017
-MBA,8480,1,Entrpr Mkting & Digital Strat,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,bruce snyder,MBA-8480,2017
-MBA,8480,5,Entrpr Mkting & Digital Strat,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,MBA-8480,2017
-MBA,8490,5,Entrepreneurial Strategy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8490,2017
-MBA,8510,1,Bus Operations & Logistics,0.24,0.35,0.41,0.0,0.0,0.0,0.0,0.0, sridharan,MBA-8510,2017
-MBA,8540,1,Managerial Accounting,0.4,0.43,0.14,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,MBA-8540,2017
-MBA,8590,1,Mgr Decision Model,0.34,0.26,0.29,0.0,0.0,0.0,0.0,0.11,sara elizabet yoder,MBA-8590,2017
-MBA,8590,2,Mgr Decision Model,0.28,0.51,0.07,0.0,0.02,0.0,0.0,0.12,magda gabriela sava,MBA-8590,2017
-MBA,8600,1,Advanced Marketing Strategy,0.3,0.48,0.23,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2017
-MBA,8600,2,Advanced Marketing Strategy,0.21,0.64,0.15,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2017
-MBA,8610,1,Information Systems,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,MBA-8610,2017
-MBA,8620,1,Managerial Economics,0.28,0.56,0.16,0.0,0.0,0.0,0.0,0.0,scott templeton,MBA-8620,2017
-MBA,8620,2,Managerial Economics,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,MBA-8620,2017
-MBA,8620,4,Managerial Economics,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,ronald earl gregory,MBA-8620,2017
-MBA,8650,1,Taxation of Business Decisions,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8650,2017
-MBA,8700,1,Strategic Management,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,james turner,MBA-8700,2017
-MBA,8700,2,Strategic Management,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,thomas robert uva,MBA-8700,2017
-MBA,8990,2,Creativity,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,kathleen ann kegley,MBA-8990,2017
-MBA,8990,4,Data Analytics & Visualization,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,john frederic tripp,MBA-8990,2017
-ME,2000,1,Sophomore Seminar,0.91,0.05,0.02,0.0,0.01,0.0,0.0,0.01,donald beasley,ME-2000,2017
-ME,2000,2,Sophomore Seminar,0.78,0.19,0.01,0.0,0.01,0.0,0.0,0.01,donald beasley,ME-2000,2017
-ME,2010,1,Statics & Dynamics,0.15,0.2,0.2,0.09,0.22,0.0,0.0,0.14,marisa kikendal orr,ME-2010,2017
-ME,2010,2,Statics & Dynamics,0.09,0.24,0.23,0.14,0.23,0.0,0.0,0.08,paul joseph,ME-2010,2017
-ME,2010,3,Statics & Dynamics,0.05,0.22,0.19,0.1,0.29,0.0,0.0,0.15,jorge iva rodriguez,ME-2010,2017
-ME,2030,1,Founda Th/Fl Syst,0.08,0.21,0.21,0.21,0.18,0.0,0.0,0.13,john saylor,ME-2030,2017
-ME,2030,2,Founda Th/Fl Syst,0.2,0.35,0.2,0.14,0.06,0.0,0.0,0.06,xiangchun xuan,ME-2030,2017
-ME,2040,1,Mechanics of Materials,0.27,0.45,0.22,0.04,0.02,0.0,0.0,0.0,gang li,ME-2040,2017
-ME,2040,3,Mechanics of Materials,0.17,0.57,0.19,0.05,0.0,0.0,0.0,0.02,jorge iva rodriguez,ME-2040,2017
-ME,2220,1,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,2,Mechanical Engineering Lab I,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,ME-2220,2017
-ME,2220,3,Mechanical Engineering Lab I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,5,Mechanical Engineering Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-2220,2017
-ME,2220,7,Mechanical Engineering Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,13,Mechanical Engineering Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,15,Mechanical Engineering Lab I,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,17,Mechanical Engineering Lab I,0.31,0.63,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-2220,2017
-ME,2220,18,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,3030,1,Thermodynamics,0.2,0.3,0.3,0.08,0.04,0.0,0.0,0.08,richard miller,ME-3030,2017
-ME,3030,2,Thermodynamics,0.26,0.51,0.18,0.0,0.02,0.0,0.0,0.04,yiqiang han,ME-3030,2017
-ME,3040,1,Heat Transfer,0.05,0.26,0.43,0.12,0.12,0.0,0.0,0.02,jean-marc delhaye,ME-3040,2017
-ME,3040,2,Heat Transfer,0.19,0.42,0.23,0.07,0.06,0.0,0.0,0.03,xin zhao,ME-3040,2017
-ME,3050,1,Model/an Dy Syst,0.21,0.17,0.32,0.15,0.06,0.0,0.0,0.09,joshua bostwick,ME-3050,2017
-ME,3050,2,Model/an Dy Syst,0.22,0.39,0.3,0.04,0.04,0.0,0.0,0.0,ardalan vahidi,ME-3050,2017
-ME,3060,1,Fund Machine Design,0.13,0.58,0.21,0.0,0.02,0.0,0.0,0.06,oliver myers,ME-3060,2017
-ME,3060,2,Fund Machine Design,0.24,0.5,0.18,0.02,0.02,0.0,0.0,0.04,paul jeffrey meyer,ME-3060,2017
-ME,3070,1,Found of Mechanical Systems,0.34,0.39,0.25,0.0,0.02,0.0,0.0,0.0,jorge iva rodriguez,ME-3070,2017
-ME,3070,2,Found of Mechanical Systems,0.22,0.51,0.17,0.04,0.01,0.0,0.0,0.05,gregory mocko,ME-3070,2017
-ME,3080,1,Fluid Mechanics,0.34,0.49,0.09,0.06,0.02,0.0,0.0,0.0,yiqiang han,ME-3080,2017
-ME,3080,2,Fluid Mechanics,0.24,0.51,0.16,0.03,0.05,0.0,0.0,0.0,yiqiang han,ME-3080,2017
-ME,3080,3,Fluid Mechanics,0.1,0.46,0.39,0.02,0.02,0.0,0.0,0.02,ethan kung,ME-3080,2017
-ME,3120,1,Manuf Processes,0.35,0.49,0.13,0.02,0.01,0.0,0.0,0.01,rod martinez-duarte,ME-3120,2017
-ME,3330,1,Mechanical Engineering Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,3330,2,Mechanical Engineering Lab II,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,3330,3,Mechanical Engineering Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,3330,6,Mechanical Engineering Lab II,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-3330,2017
-ME,3330,7,Mechanical Engineering Lab II,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,ME-3330,2017
-ME,3330,9,Mechanical Engineering Lab II,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,3330,10,Mechanical Engineering Lab II,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,todd schweisinger,ME-3330,2017
-ME,4000,1,Senior Seminar,0.96,0.03,0.0,0.0,0.01,0.0,0.0,0.0,richard figliola,ME-4000,2017
-ME,4010,1,Mech Engr Design,0.87,0.08,0.01,0.02,0.01,0.0,0.0,0.02,cameron turner,ME-4010,2017
-ME,4020,1,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,ME-4020,2017
-ME,4020,2,Intern in Engr Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2017
-ME,4020,3,Intern in Engr Des,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-4020,2017
-ME,4030,1,Control Dynamic Systems,0.32,0.34,0.22,0.04,0.04,0.0,0.0,0.03,suyi li,ME-4030,2017
-ME,4030,2,Control Dynamic Systems,0.21,0.37,0.33,0.07,0.0,0.0,0.0,0.02,yue wang,ME-4030,2017
-ME,4210,1,Intro to Comp Flow,0.27,0.46,0.15,0.08,0.04,0.0,0.0,0.0,chenning tong,ME-4210,2017
-ME,4320,1,Advanced Strength of Materials,0.0,0.87,0.07,0.0,0.07,0.0,0.0,0.0,michael porter,ME-4320,2017
-ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2017
-ME,4440,2,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2017
-ME,4440,5,Mechanical Engineering Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2017
-ME,4440,6,Mechanical Engineering Lab III,0.18,0.64,0.0,0.0,0.09,0.0,0.0,0.09,john wagner,ME-4440,2017
-ME,4440,9,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2017
-ME,4440,10,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2017
-ME,4440,18,Mechanical Engineering Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2017
-ME,4540,1,Design of Machine Elements,0.53,0.36,0.08,0.0,0.01,0.0,0.0,0.01,paul jeffrey meyer,ME-4540,2017
-ME,4930,14,Sel.Topics ME - NonLinDy&Chas,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,phanin tallapragada,ME-4930,2017
-ME,4930,39,Sel.Topics ME - Aero Propul,0.27,0.43,0.27,0.02,0.0,0.0,0.0,0.0,daniel fant,ME-4930,2017
-ME,4930,139,Sel.Topic ME - Solar Energy,0.44,0.23,0.28,0.0,0.0,0.0,0.0,0.05,daniel fant,ME-4930,2017
-ME,6210,1,Intro to Comp Flow,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,ME-6210,2017
-ME,6320,1,Advanced Strength of Materials,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,michael porter,ME-6320,2017
-ME,6540,1,Des Machine Elements,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,ME-6540,2017
-ME,8010,1,Found of Fluid Mech,0.17,0.44,0.17,0.0,0.11,0.0,0.0,0.11,nicole gise coutris,ME-8010,2017
-ME,8100,1,Macroscopic Thermo,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,xiangchun xuan,ME-8100,2017
-ME,8180,1,Intro to Fin Ele Ana,0.58,0.31,0.04,0.0,0.0,0.0,0.0,0.06,lonny thompson,ME-8180,2017
-ME,8230,1,Control Systems,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,ME-8230,2017
-ME,8460,1,Inter Dynamics,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,phanin tallapragada,ME-8460,2017
-ME,8610,1,Matl Sel Engr Design,0.45,0.53,0.0,0.0,0.02,0.0,0.0,0.0,michael porter,ME-8610,2017
-ME,8610,401,Matl Sel Engr Design,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael porter,ME-8610,2017
-ME,8700,1,Adv Design Methods,0.29,0.62,0.05,0.0,0.05,0.0,0.0,0.0,joshua summers,ME-8700,2017
-ME,8710,1,Engr Optimization,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-8710,2017
-ME,8710,401,Engr Optimization,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,georges fadel,ME-8710,2017
-ME,8930,1,Sel. Topics in ME - Scaling,0.3,0.2,0.3,0.0,0.2,0.0,0.0,0.0,jean-marc delhaye,ME-8930,2017
-ME,8930,4,SelectedTopics in ME - Adv Mfg,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-8930,2017
-MGT,2010,1,Principles of Management,0.42,0.43,0.11,0.03,0.01,0.0,0.0,0.0,katherine clark,MGT-2010,2017
-MGT,2010,2,Principles of Management,0.42,0.38,0.16,0.03,0.0,0.0,0.0,0.01,tina robbins,MGT-2010,2017
-MGT,2010,4,Principles of Management (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,MGT-2010,2017
-MGT,2010,10,Principles of Management,0.33,0.45,0.23,0.0,0.0,0.0,0.0,0.0,ashley will parnell,MGT-2010,2017
-MGT,2010,11,Principles of Management,0.28,0.33,0.31,0.03,0.03,0.0,0.0,0.03,ashley will parnell,MGT-2010,2017
-MGT,2010,12,Principles of Management,0.16,0.33,0.28,0.09,0.07,0.0,0.0,0.07,ashley will parnell,MGT-2010,2017
-MGT,2180,1,Management PC Applications,0.47,0.37,0.12,0.01,0.01,0.0,0.0,0.02,ryan toole,MGT-2180,2017
-MGT,2180,2,Management PC Applications,0.2,0.47,0.21,0.03,0.04,0.0,0.0,0.03,ryan toole,MGT-2180,2017
-MGT,2970,4,How to Start a Startup,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,john michael hannon,MGT-2970,2017
-MGT,3070,1,Human Resource Management,0.84,0.14,0.0,0.0,0.0,0.0,0.0,0.02,jonathan sanderson,MGT-3070,2017
-MGT,3070,3,Human Resource Management,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2017
-MGT,3070,4,Human Resource Management,0.6,0.38,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2017
-MGT,3070,5,Human Resource Management,0.43,0.45,0.13,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2017
-MGT,3070,6,Human Resource Management,0.53,0.43,0.03,0.03,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2017
-MGT,3070,7,Human Resource Management,0.83,0.15,0.0,0.0,0.03,0.0,0.0,0.0,alejandra kennedy,MGT-3070,2017
-MGT,3070,8,Human Resource Management,0.25,0.38,0.13,0.13,0.06,0.0,0.0,0.06,priscilla harrison,MGT-3070,2017
-MGT,3100,1,Intermed Business Statistics,0.38,0.28,0.13,0.1,0.03,0.0,0.0,0.08,min kyung lee,MGT-3100,2017
-MGT,3100,2,Intermed Business Statistics,0.44,0.41,0.05,0.0,0.0,0.0,0.0,0.1,mustafa serk akturk,MGT-3100,2017
-MGT,3100,3,Intermed Business Statistics,0.37,0.23,0.23,0.0,0.02,0.0,0.0,0.14,sukran nil atadeniz,MGT-3100,2017
-MGT,3100,5,Intermed Business Statistics,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.13,mustafa serk akturk,MGT-3100,2017
-MGT,3100,6,Intermed Business Statistics,0.15,0.39,0.36,0.03,0.0,0.0,0.0,0.06,magda gabriela sava,MGT-3100,2017
-MGT,3100,7,Intermed Business Statistics,0.39,0.31,0.19,0.0,0.03,0.0,0.0,0.08,sukran nil atadeniz,MGT-3100,2017
-MGT,3100,8,Intermed Business Statistics,0.42,0.32,0.13,0.05,0.08,0.0,0.0,0.0,min kyung lee,MGT-3100,2017
-MGT,3100,9,Intermed Business Statistics,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,MGT-3100,2017
-MGT,3100,10,Intermed Business Statistics,0.28,0.37,0.21,0.0,0.09,0.0,0.0,0.05,remi charpin,MGT-3100,2017
-MGT,3100,11,Intermed Business Statistics,0.7,0.24,0.0,0.0,0.0,0.0,0.0,0.07,thomas simpson,MGT-3100,2017
-MGT,3120,1,Decision Models for Management,0.12,0.23,0.23,0.19,0.16,0.0,0.0,0.07,sara elizabet yoder,MGT-3120,2017
-MGT,3120,2,Decision Models for Management,0.2,0.16,0.23,0.23,0.1,0.0,0.0,0.07,sara elizabet yoder,MGT-3120,2017
-MGT,3170,1,Logistics Mgmt,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,ahmet colak,MGT-3170,2017
-MGT,3180,1,Mgt of Info Systems,0.28,0.56,0.1,0.03,0.0,0.0,0.0,0.03,marten risius,MGT-3180,2017
-MGT,3180,2,Mgt of Info Systems,0.48,0.35,0.05,0.03,0.0,0.0,0.0,0.1,iaroslava dutchak,MGT-3180,2017
-MGT,3180,3,Mgt of Info Systems,0.35,0.33,0.28,0.0,0.02,0.0,0.0,0.02,tina marie esposito,MGT-3180,2017
-MGT,3180,4,Mgt of Info Systems,0.41,0.41,0.13,0.0,0.02,0.0,0.0,0.02,tina marie esposito,MGT-3180,2017
-MGT,3180,5,Mgt of Info Systems,0.6,0.23,0.12,0.0,0.05,0.0,0.0,0.0,kevin dani matthews,MGT-3180,2017
-MGT,3500,1,Intro to Business Analytics,0.18,0.73,0.09,0.0,0.0,0.0,0.0,0.0,siyuan li,MGT-3500,2017
-MGT,3510,1,Business Analytics & Problems,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,MGT-3510,2017
-MGT,3900,1,Ops Mgt,0.16,0.47,0.32,0.03,0.0,0.0,0.0,0.03,yann ferrand,MGT-3900,2017
-MGT,3900,2,Ops Mgt,0.13,0.23,0.58,0.05,0.0,0.0,0.0,0.03,zachary mo leffakis,MGT-3900,2017
-MGT,3900,3,Ops Mgt,0.11,0.39,0.29,0.03,0.03,0.0,0.0,0.16,berna quiroga gomez,MGT-3900,2017
-MGT,3900,4,Ops Mgt,0.2,0.43,0.28,0.03,0.03,0.0,0.0,0.05,berna quiroga gomez,MGT-3900,2017
-MGT,3900,5,Ops Mgt,0.32,0.24,0.32,0.0,0.03,0.0,0.0,0.08,daniel nielubowicz,MGT-3900,2017
-MGT,3900,6,Ops Mgt,0.36,0.5,0.11,0.0,0.03,0.0,0.0,0.0,maneeshre ajjuguttu,MGT-3900,2017
-MGT,4000,1,Mgt of Organizational Behavior,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2017
-MGT,4000,2,Mgt of Organizational Behavior,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2017
-MGT,4000,3,Mgt of Organizational Behavior,0.22,0.36,0.31,0.03,0.03,0.0,0.0,0.06,thomas jo zagenczyk,MGT-4000,2017
-MGT,4000,4,Mgt of Organizational Behavior,0.15,0.4,0.35,0.05,0.0,0.0,0.0,0.05,philip roth,MGT-4000,2017
-MGT,4020,1,Ops Pln and Ctl,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4020,2017
-MGT,4080,1,Lean Operations,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4080,2017
-MGT,4110,1,Project Management,0.26,0.37,0.33,0.0,0.05,0.0,0.0,0.0,russell purvis,MGT-4110,2017
-MGT,4120,1,Supplier Management,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,ahmet colak,MGT-4120,2017
-MGT,4150,1,Business Strategy,0.18,0.57,0.25,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2017
-MGT,4150,3,Business Strategy,0.4,0.53,0.05,0.03,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2017
-MGT,4150,4,Business Strategy,0.38,0.55,0.07,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2017
-MGT,4150,7,Business Strategy,0.49,0.47,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2017
-MGT,4150,8,Business Strategy,0.52,0.41,0.07,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2017
-MGT,4150,9,Business Strategy,0.25,0.59,0.11,0.0,0.02,0.0,0.0,0.02,amy elizabet ingram,MGT-4150,2017
-MGT,4160,1,Special Topics Hr,0.36,0.6,0.04,0.0,0.0,0.0,0.0,0.0,kristin dam scott,MGT-4160,2017
-MGT,4230,1,Intern Bus Mgt,0.16,0.16,0.53,0.16,0.0,0.0,0.0,0.0,wayne stewart,MGT-4230,2017
-MGT,4230,2,Intern Bus Mgt,0.18,0.18,0.55,0.0,0.05,0.0,0.0,0.05,wayne stewart,MGT-4230,2017
-MGT,4230,3,Intern Bus Mgt,0.23,0.4,0.3,0.05,0.0,0.0,0.0,0.03,janis miller,MGT-4230,2017
-MGT,4230,4,Intern Bus Mgt,0.11,0.56,0.27,0.02,0.0,0.0,0.0,0.04,janis miller,MGT-4230,2017
-MGT,4240,1,Global Supply Chain,0.21,0.46,0.33,0.0,0.0,0.0,0.0,0.0,yann ferrand,MGT-4240,2017
-MGT,4270,2,Managing Improvement,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MGT-4270,2017
-MGT,4310,1,Emp Rights & Resp,0.24,0.53,0.15,0.0,0.03,0.0,0.0,0.06,leonard jos spooner,MGT-4310,2017
-MGT,4310,2,Emp Rights & Resp,0.4,0.49,0.11,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-4310,2017
-MGT,4350,1,Pers Interviewing,0.36,0.36,0.25,0.04,0.0,0.0,0.0,0.0,philip roth,MGT-4350,2017
-MGT,4520,1,Business Analysis,0.15,0.58,0.15,0.04,0.04,0.0,0.0,0.04,marten risius,MGT-4520,2017
-MGT,4540,1,Systems Implement,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,heshan sun,MGT-4540,2017
-MGT,4550,1,Emerging I T Trends,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,MGT-4550,2017
-MGT,4560,1,Business Info Mgt,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,siyuan li,MGT-4560,2017
-MGT,8690,1,Project Mgt,0.41,0.56,0.0,0.0,0.0,0.0,0.0,0.04,russell purvis,MGT-8690,2017
-MICR,2050,1,Introductory Micro,0.55,0.4,0.04,0.01,0.0,0.0,0.0,0.01,john abercrombie,MICR-2050,2017
-MICR,3050,1,General Microbiology,0.38,0.4,0.14,0.05,0.01,0.0,0.0,0.02,krista barr rudolph,MICR-3050,2017
-MICR,3050,2,General Microbiology,0.42,0.41,0.13,0.03,0.01,0.0,0.0,0.01,krista barr rudolph,MICR-3050,2017
-MICR,4010,1,Microbial Diversity & Ecology,0.23,0.51,0.18,0.03,0.03,0.0,0.0,0.03,barbara campbell,MICR-4010,2017
-MICR,4050,1,Adv Microbial Ecol of Humans,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4050,2017
-MICR,4140,1,Basic Immunology,0.44,0.37,0.1,0.02,0.07,0.0,0.0,0.0,yanzhang wei,MICR-4140,2017
-MICR,4150,1,Microbial Genetics,0.23,0.32,0.26,0.2,0.0,0.0,0.0,0.0,min cao,MICR-4150,2017
-MICR,4160,1,Intro Virology,0.95,0.04,0.0,0.0,0.0,0.0,0.0,0.01,simon scott,MICR-4160,2017
-MICR,4510,1,Advanced Microbiology II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4510,2017
-MICR,4510,2,Advanced Microbiology II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4510,2017
-MICR,4510,3,Advanced Microbiology II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4510,2017
-MKT,3010,1,Prin of Marketing,0.02,0.43,0.38,0.1,0.05,0.0,0.0,0.02,carter wil mcelveen,MKT-3010,2017
-MKT,3010,2,Prin of Marketing,0.29,0.46,0.18,0.05,0.02,0.0,0.0,0.0,amanda cooper fine,MKT-3010,2017
-MKT,3010,3,Prin of Marketing,0.26,0.45,0.23,0.04,0.01,0.0,0.0,0.0,amanda cooper fine,MKT-3010,2017
-MKT,3010,4,Prin of Marketing,0.27,0.46,0.2,0.04,0.01,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2017
-MKT,3010,5,Prin of Marketing,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,patricia knowles,MKT-3010,2017
-MKT,3020,1,Consumer Behavior,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2017
-MKT,3020,2,Consumer Behavior,0.58,0.4,0.0,0.0,0.0,0.0,0.0,0.02,jennifer di siemens,MKT-3020,2017
-MKT,3020,3,Consumer Behavior,0.34,0.44,0.2,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2017
-MKT,3020,4,Consumer Behavior,0.51,0.33,0.08,0.06,0.02,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2017
-MKT,3020,5,Consumer Behavior,0.12,0.64,0.19,0.03,0.0,0.0,0.0,0.02,carter wil mcelveen,MKT-3020,2017
-MKT,3210,1,Sports Marketing,0.74,0.23,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2017
-MKT,3210,2,Sports Marketing,0.68,0.3,0.0,0.0,0.0,0.0,0.0,0.02,delancy bennett,MKT-3210,2017
-MKT,3310,1,Marketing Metrics & Analytics,0.42,0.56,0.02,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,MKT-3310,2017
-MKT,3310,2,Marketing Metrics & Analytics,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,MKT-3310,2017
-MKT,3980,1,Creative Inquiry in Marketing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james gaubert,MKT-3980,2017
-MKT,4200,2,Professional Selling,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2017
-MKT,4200,3,Professional Selling,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2017
-MKT,4200,4,Professional Selling,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4200,2017
-MKT,4200,5,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4200,2017
-MKT,4230,1,Promotional Strategy,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,patricia knowles,MKT-4230,2017
-MKT,4240,1,Sales Management,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4240,2017
-MKT,4260,1,Business-to-Business,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,james gaubert,MKT-4260,2017
-MKT,4270,1,International Mktg,0.58,0.32,0.08,0.0,0.01,0.0,0.0,0.01,roger gomes,MKT-4270,2017
-MKT,4270,2,International Mktg,0.21,0.59,0.13,0.03,0.03,0.0,0.0,0.03,roger gomes,MKT-4270,2017
-MKT,4270,3,International Mktg,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,thomas poehlman,MKT-4270,2017
-MKT,4280,1,Services Marketing,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4280,2017
-MKT,4280,2,Services Marketing,0.43,0.53,0.05,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4280,2017
-MKT,4310,1,Marketing Research,0.23,0.5,0.23,0.0,0.0,0.0,0.0,0.04,peter weathers,MKT-4310,2017
-MKT,4310,2,Marketing Research,0.16,0.53,0.21,0.11,0.0,0.0,0.0,0.0,peter weathers,MKT-4310,2017
-MKT,4310,3,Marketing Research,0.35,0.62,0.0,0.0,0.0,0.0,0.0,0.04,scott darren swain,MKT-4310,2017
-MKT,4310,4,Marketing Research,0.35,0.35,0.17,0.0,0.0,0.0,0.0,0.13,william kilbourne,MKT-4310,2017
-MKT,4430,1,Advertising Strategy,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4430,2017
-MKT,4450,1,Macromarketing,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,MKT-4450,2017
-MKT,4500,1,Strategic Mktg Mgt,0.19,0.65,0.16,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2017
-MKT,4500,2,Strategic Mktg Mgt,0.17,0.45,0.34,0.03,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2017
-MKT,4950,1,Social Media,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-4950,2017
-MKT,4950,2,Social Media,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-4950,2017
-MKT,8610,1,Marketing Research,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,MKT-8610,2017
-MKT,8630,1,Buyer Behavior,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,thomas poehlman,MKT-8630,2017
-ML,1010,1,Leadership Fund I,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,clay wilson etterle,ML-1010,2017
-ML,2010,2,Leadership Development I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2010,2017
-ML,2010,3,Leadership Development I,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,vincent john presto,ML-2010,2017
-ML,3010,1,Advanced Leadership I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,ML-3010,2017
-MSE,2100,1,Intro to Mat Science,0.43,0.21,0.15,0.08,0.1,0.0,0.0,0.04,rakhee pani,MSE-2100,2017
-MSE,2100,2,Intro to Mat Science,0.18,0.33,0.29,0.16,0.03,0.0,0.0,0.01,eric skaar,MSE-2100,2017
-MSE,2100,3,Intro to Mat Science,0.27,0.25,0.28,0.08,0.09,0.0,0.0,0.04,fei peng,MSE-2100,2017
-MSE,2100,4,Intro to Mat Science,0.31,0.45,0.14,0.03,0.04,0.0,0.0,0.03,ruslan burtovyy,MSE-2100,2017
-MSE,2100,5,Intro to Mat Science,0.44,0.3,0.11,0.04,0.07,0.0,0.0,0.04,olga kuksenok,MSE-2100,2017
-MSE,3190,1,Materials Proc I,0.34,0.53,0.08,0.03,0.01,0.0,0.0,0.01,olin mefford,MSE-3190,2017
-MSE,3190,2,Materials Proc I,0.14,0.62,0.16,0.08,0.0,0.0,0.0,0.0,olin mefford,MSE-3190,2017
-MSE,3260,1,Thermo of Materials,0.39,0.35,0.2,0.02,0.0,0.0,0.0,0.04,gary lickfield,MSE-3260,2017
-MSE,3260,2,Thermo of Materials,0.25,0.39,0.19,0.08,0.06,0.0,0.0,0.03,gary lickfield,MSE-3260,2017
-MSE,3270,1,Transport Phenomena,0.15,0.47,0.18,0.16,0.03,0.0,0.0,0.02,ulf daniel schiller,MSE-3270,2017
-MSE,3270,2,Transport Phenomena,0.05,0.26,0.31,0.26,0.08,0.0,0.0,0.05,ulf daniel schiller,MSE-3270,2017
-MSE,4020,1,Solid State Material,0.55,0.13,0.26,0.06,0.0,0.0,0.0,0.0,luiz gust jacobsohn,MSE-4020,2017
-MSE,4070,1,Senior Capstone Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,MSE-4070,2017
-MSE,4130,1,Noncrystalline Materials,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,MSE-4130,2017
-MSE,4150,1,Polymer Sc Engr,0.49,0.33,0.01,0.0,0.0,0.0,0.0,0.16,stephen foulger,MSE-4150,2017
-MSE,4150,2,Polymer Sc Engr,0.58,0.28,0.09,0.02,0.02,0.0,0.0,0.0,olin mefford,MSE-4150,2017
-MSE,4320,1,Manuf Proc & Systems,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,MSE-4320,2017
-MSE,4580,1,Surf Phen in Ms&E,0.29,0.11,0.21,0.36,0.04,0.0,0.0,0.0,konstantin kornev,MSE-4580,2017
-MSE,4810,1,Undergraduate Research Fundame,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,marian kennedy,MSE-4810,2017
-MSE,4910,1,Undergraduate Research,0.78,0.06,0.06,0.06,0.0,0.0,0.0,0.06,marian kennedy,MSE-4910,2017
-MSE,4910,2,Undergraduate Research,0.59,0.24,0.0,0.06,0.06,0.0,0.0,0.06,marian kennedy,MSE-4910,2017
-MSE,8100,1,Fundamentals of Materials Sci,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,igor luzinov,MSE-8100,2017
-MSE,8270,1,Kin of Phase Tran,0.52,0.38,0.0,0.0,0.05,0.0,0.0,0.05,konstantin kornev,MSE-8270,2017
-MUSC,1420,1,Music Theory I,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,anthony bernarducci,MUSC-1420,2017
-MUSC,1430,1,Aural Skills I,0.84,0.0,0.05,0.0,0.11,0.0,0.0,0.0,anthony bernarducci,MUSC-1430,2017
-MUSC,2100,2,Music in the Western World,0.56,0.25,0.13,0.0,0.03,0.0,0.0,0.03,lisa sain odom,MUSC-2100,2017
-MUSC,2100,3,Music in the Western World,0.41,0.34,0.16,0.09,0.0,0.0,0.0,0.0,alison leigh mero,MUSC-2100,2017
-MUSC,2100,4,Music in the Western World,0.56,0.22,0.13,0.0,0.06,0.0,0.0,0.03,linda li-bleuel,MUSC-2100,2017
-MUSC,2100,6,Music in the Western World,0.47,0.38,0.09,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,MUSC-2100,2017
-MUSC,2100,7,Music in the Western World,0.39,0.39,0.1,0.03,0.0,0.0,0.0,0.1,rhea beth jacobus,MUSC-2100,2017
-MUSC,2100,8,Music in the Western World,0.53,0.23,0.0,0.0,0.03,0.0,0.0,0.2,rhea beth jacobus,MUSC-2100,2017
-MUSC,2100,10,Music in the Western World,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,linda dzuris,MUSC-2100,2017
-MUSC,2100,12,Music in the Western World,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,lea kibler,MUSC-2100,2017
-MUSC,3110,1,History of American Music,0.61,0.29,0.06,0.03,0.0,0.0,0.0,0.0,ned hosler,MUSC-3110,2017
-MUSC,3120,1,History of Jazz,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-3120,2017
-MUSC,3130,1,Hist of Rock & Roll,0.78,0.16,0.03,0.0,0.03,0.0,0.0,0.0,hamilton altstatt,MUSC-3130,2017
-MUSC,3170,1,Hist of Country Mus,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3170,2017
-MUSC,3180,1,Hist of Audio Tech,0.5,0.25,0.19,0.06,0.0,0.0,0.0,0.0,bruce allen whisler,MUSC-3180,2017
-MUSC,3610,1,Marching Band,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,MUSC-3610,2017
-MUSC,3620,1,Symphonic Band,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mark spede,MUSC-3620,2017
-MUSC,3690,1,Symphony Orchestra,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,MUSC-3690,2017
-MUSC,4150,1,Music Hist to 1750,0.17,0.17,0.33,0.11,0.11,0.0,0.0,0.11,justin durham,MUSC-4150,2017
-NPL,3000,1,Nonprofit Leadership,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,NPL-3000,2017
-NPL,3000,3,Nonprofit Leadership,0.63,0.2,0.03,0.0,0.0,0.0,0.0,0.13,bonnie west stevens,NPL-3000,2017
-NPL,3000,4,Nonprofit Leadership,0.6,0.23,0.1,0.0,0.03,0.0,0.0,0.03,bonnie west stevens,NPL-3000,2017
-NPL,3000,5,Nonprofit Leadership,0.5,0.23,0.23,0.0,0.05,0.0,0.0,0.0,christina mar mazer,NPL-3000,2017
-NPL,3000,6,Nonprofit Leadership,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,christina mar mazer,NPL-3000,2017
-NPL,3000,7,Nonprofit Leadership,0.63,0.08,0.08,0.08,0.13,0.0,0.0,0.0,christina mar mazer,NPL-3000,2017
-NPL,3040,1,NPL Risk Management,0.72,0.19,0.0,0.0,0.09,0.0,0.0,0.0,daniel mor anderson,NPL-3040,2017
-NURS,1400,1,Comp App Hlth Care,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,NURS-1400,2017
-NURS,3030,1,Nursing of Adults,0.3,0.65,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2017
-NURS,3040,1,Pathophysiology,0.39,0.48,0.1,0.02,0.02,0.0,0.0,0.0,catherine si murton,NURS-3040,2017
-NURS,3040,400,Pathophysiology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,NURS-3040,2017
-NURS,3040,401,Pathophysiology,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,NURS-3040,2017
-NURS,3050,1,Psychosocial Nursing,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,NURS-3050,2017
-NURS,3100,1,Health Assessment,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,NURS-3100,2017
-NURS,3100,2,Health Assessment,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,NURS-3100,2017
-NURS,3100,400,Health Assessment,0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,jason thrift,NURS-3100,2017
-NURS,3120,1,Foundations of Nursing,0.47,0.52,0.02,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,NURS-3120,2017
-NURS,3120,400,Foundations of Nursing,0.5,0.46,0.0,0.04,0.0,0.0,0.0,0.0,jennifer el bagwell,NURS-3120,2017
-NURS,3190,400,Health Assessment for RNs,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,NURS-3190,2017
-NURS,3200,2,Prof in Nurs,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3200,2017
-NURS,3230,400,Gerontology Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,tawny jenn mcintosh,NURS-3230,2017
-NURS,3300,2,Research in Nursing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-3300,2017
-NURS,3330,400,Health Care Genetics,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,mary steck,NURS-3330,2017
-NURS,3400,1,Pharmther Nursing,0.32,0.55,0.11,0.0,0.02,0.0,0.0,0.0,catherine si murton,NURS-3400,2017
-NURS,3400,400,Pharmther Nursing,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jenna lyn seawright,NURS-3400,2017
-NURS,3600,400,Social Determinants in Health,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,NURS-3600,2017
-NURS,4010,1,Mental Health Nurs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-4010,2017
-NURS,4030,400,Complex Nursing of Adults,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,NURS-4030,2017
-NURS,4060,400,Issues in Professionalism,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,NURS-4060,2017
-NURS,4110,1,Nursing of Children,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,NURS-4110,2017
-NURS,4120,1,Nurs Women and Fam,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2017
-NURS,4140,400,Com Nurs & Hlth Prom,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,NURS-4140,2017
-NURS,4250,200,Community Nursing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,NURS-4250,2017
-NURS,4980,15,Nursing/Engineering,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,nancy meehan,NURS-4980,2017
-NURS,8050,400,Pharmaco Adv Nurs,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8050,2017
-NURS,8050,401,Pharmaco Adv Nurs,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8050,2017
-NURS,8060,400,Advan Assessment for Nursing,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,NURS-8060,2017
-NURS,8090,400,Pathophysiology,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,tracy brock lowe,NURS-8090,2017
-NURS,8190,400,Developing Family,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-8190,2017
-NURS,8200,400,Child & Adol Nursing,0.34,0.55,0.07,0.0,0.03,0.0,0.0,0.0,heide temples,NURS-8200,2017
-NURS,9020,1,DNP Clinical Epidem & Biostats,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,veronica parker,NURS-9020,2017
-NUTR,2030,1,Intro Princ of Human Nutrition,0.81,0.16,0.01,0.0,0.02,0.0,0.0,0.0,bridgit den corbett,NUTR-2030,2017
-NUTR,2030,2,Intro Princ of Human Nutrition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,bridgit den corbett,NUTR-2030,2017
-NUTR,2050,1,Nutrition for Nursing Prof,0.74,0.25,0.01,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,NUTR-2050,2017
-NUTR,2160,1,Evidence-Based Nutrition,0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,angela fraser,NUTR-2160,2017
-NUTR,4240,1,Medical Nutr Thera I,0.49,0.46,0.06,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4240,2017
-NUTR,4510,1,Human Nutrition & Metabolism I,0.3,0.3,0.19,0.12,0.05,0.0,0.0,0.05,elliot jesch,NUTR-4510,2017
-PA,1010,1,Intro to Perf Arts,0.67,0.3,0.04,0.0,0.0,0.0,0.0,0.0,david hartmann,PA-1010,2017
-PA,2010,2,Career Planning and Prof Devel,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,PA-2010,2017
-PA,2790,1,Perf Arts Pract I,0.36,0.55,0.05,0.0,0.0,0.0,0.0,0.05,kenneth moore,PA-2790,2017
-PADM,8220,400,Public Policy Process,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,PADM-8220,2017
-PADM,8220,401,Public Policy Process,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,PADM-8220,2017
-PADM,8290,400,Public Financial Management,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,PADM-8290,2017
-PADM,8420,400,GIS for Public Administrators,0.55,0.27,0.0,0.0,0.09,0.0,0.0,0.09,david lawrenc white,PADM-8420,2017
-PADM,8660,400,Nonprofit Fundraising,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,renee salic nichols,PADM-8660,2017
-PADM,8680,400,Local Government Admin,0.22,0.56,0.11,0.0,0.11,0.0,0.0,0.0,alfred bundrick,PADM-8680,2017
-PADM,8720,400,Rural Development,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,PADM-8720,2017
-PAS,3010,1,Pan African Studies,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,abel bartley,PAS-3010,2017
-PDBE,8100,1,Contemporary Issues in EDP,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,thomas will schurch,PDBE-8100,2017
-PDBE,8150,1,Research Design in EDP,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,mickey lauria,PDBE-8150,2017
-PES,1040,1,Introduction to Plant Sciences,0.81,0.17,0.03,0.0,0.0,0.0,0.0,0.0,paula agudelo,PES-1040,2017
-PES,2020,1,Soils,0.19,0.55,0.19,0.06,0.0,0.0,0.0,0.01,dara michelle park,PES-2020,2017
-PES,3150,1,Environment and Agriculture,0.38,0.29,0.29,0.0,0.0,0.0,0.0,0.04,"appukuttan suseela,",PES-3150,2017
-PES,4850,1,Environmental Soil Chemistry,0.44,0.31,0.19,0.0,0.0,0.0,0.0,0.06,haibo liu,PES-4850,2017
-PHIL,1010,1,Intro to Philosophic Problems,0.44,0.41,0.12,0.0,0.0,0.0,0.0,0.03,david stegall,PHIL-1010,2017
-PHIL,1010,2,Intro to Philosophic Problems,0.43,0.26,0.2,0.06,0.03,0.0,0.0,0.03,christopher grau,PHIL-1010,2017
-PHIL,1010,3,Intro to Philosophic Problems,0.49,0.31,0.11,0.0,0.0,0.0,0.0,0.09,david stegall,PHIL-1010,2017
-PHIL,1010,4,Intro to Philosophic Problems,0.23,0.51,0.14,0.06,0.03,0.0,0.0,0.03,kelly smith,PHIL-1010,2017
-PHIL,1010,6,Intro to Philosophic Problems,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,andrew garnar,PHIL-1010,2017
-PHIL,1020,1,Introduction to Logic,0.68,0.21,0.12,0.0,0.0,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2017
-PHIL,1020,2,Introduction to Logic,0.62,0.24,0.03,0.03,0.06,0.0,0.0,0.03,michael hal hannen,PHIL-1020,2017
-PHIL,1020,3,Introduction to Logic,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,michael hal hannen,PHIL-1020,2017
-PHIL,1020,4,Introduction to Logic,0.61,0.28,0.06,0.06,0.0,0.0,0.0,0.0,adam gies,PHIL-1020,2017
-PHIL,1020,7,Introduction to Logic,0.32,0.32,0.29,0.03,0.0,0.0,0.0,0.03,adam gies,PHIL-1020,2017
-PHIL,1020,8,Introduction to Logic,0.53,0.25,0.22,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-1020,2017
-PHIL,1020,9,Introduction to Logic,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,PHIL-1020,2017
-PHIL,1020,10,Introduction to Logic,0.26,0.56,0.06,0.03,0.03,0.0,0.0,0.06,christopher wells,PHIL-1020,2017
-PHIL,1020,11,Introduction to Logic,0.46,0.29,0.11,0.11,0.0,0.0,0.0,0.03,christopher wells,PHIL-1020,2017
-PHIL,1020,12,Introduction to Logic,0.51,0.29,0.09,0.03,0.0,0.0,0.0,0.09,christopher wells,PHIL-1020,2017
-PHIL,1020,13,Introduction to Logic,0.72,0.11,0.0,0.11,0.0,0.0,0.0,0.06,christopher wells,PHIL-1020,2017
-PHIL,1020,14,Introduction to Logic,0.26,0.26,0.26,0.0,0.03,0.0,0.0,0.18,stephen satris,PHIL-1020,2017
-PHIL,1030,1,Introduction to Ethics,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,edyta joanna kuzian,PHIL-1030,2017
-PHIL,1030,2,Introduction to Ethics,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,stephen satris,PHIL-1030,2017
-PHIL,1030,3,Introduction to Ethics,0.32,0.29,0.32,0.0,0.03,0.0,0.0,0.03,charles starkey,PHIL-1030,2017
-PHIL,1030,4,Introduction to Ethics,0.5,0.33,0.06,0.06,0.06,0.0,0.0,0.0,david stegall,PHIL-1030,2017
-PHIL,1030,5,Introduction to Ethics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,PHIL-1030,2017
-PHIL,1030,6,Introduction to Ethics,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,PHIL-1030,2017
-PHIL,1030,7,Introduction to Ethics,0.38,0.23,0.31,0.0,0.0,0.0,0.0,0.08,edyta joanna kuzian,PHIL-1030,2017
-PHIL,1030,8,Introduction to Ethics,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,PHIL-1030,2017
-PHIL,1030,9,Introduction to Ethics,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,john randall wolfe,PHIL-1030,2017
-PHIL,1030,10,Introduction to Ethics,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,david stegall,PHIL-1030,2017
-PHIL,3040,1,Moral Philosophy,0.31,0.5,0.06,0.0,0.0,0.0,0.0,0.13,charles starkey,PHIL-3040,2017
-PHIL,3150,1,Ancient Philosophy,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,michael hal hannen,PHIL-3150,2017
-PHIL,3180,1,20th-Century Philosophy,0.58,0.29,0.03,0.0,0.03,0.0,0.0,0.06,william maker,PHIL-3180,2017
-PHIL,3200,1,Soc and Pol Phil,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,david stegall,PHIL-3200,2017
-PHIL,3260,1,Science and Values,0.59,0.21,0.06,0.0,0.09,0.0,0.0,0.06,andrew garnar,PHIL-3260,2017
-PHIL,3260,2,Science and Values,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,PHIL-3260,2017
-PHIL,3430,1,Philosophy of Law,0.21,0.66,0.03,0.03,0.0,0.0,0.0,0.07,brookes colyt brown,PHIL-3430,2017
-PHIL,3440,1,Business Ethics,0.24,0.47,0.24,0.0,0.0,0.0,0.0,0.06,brookes colyt brown,PHIL-3440,2017
-PHIL,3480,1,Philosophies of Art,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,christopher grau,PHIL-3480,2017
-PHIL,3550,1,Philosophy of Mind & Cog Scien,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-3550,2017
-PHIL,4020,1,Topics in Philosophy: Kant,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,kelly smith,PHIL-4020,2017
-PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1180,2017
-PHYS,1220,1,Physics with Calculus I,0.23,0.33,0.24,0.07,0.06,0.0,0.0,0.07,lih-sin the,PHYS-1220,2017
-PHYS,1220,2,Physics with Calculus I,0.29,0.29,0.25,0.09,0.01,0.0,0.0,0.06,lih-sin the,PHYS-1220,2017
-PHYS,1220,4,Physics with Calculus I,0.56,0.19,0.06,0.06,0.13,0.0,0.0,0.0,murray daw,PHYS-1220,2017
-PHYS,1220,500,Physics with Calculus I,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,elaine parshall,PHYS-1220,2017
-PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,PHYS-1240,2017
-PHYS,1240,2,Physics Lab I,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,3,Physics Lab I,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2017
-PHYS,1240,4,Physics Lab I,0.56,0.33,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,6,Physics Lab I,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,7,Physics Lab I,0.28,0.39,0.17,0.11,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,8,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,9,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,10,Physics Lab I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,11,Physics Lab I,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,12,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,14,Physics Lab I,0.25,0.38,0.06,0.06,0.0,0.0,0.0,0.25,jerry hester,PHYS-1240,2017
-PHYS,1240,15,Physics Lab I,0.44,0.38,0.13,0.06,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,16,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,17,Physics Lab I,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-1240,2017
-PHYS,1240,18,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,19,Physics Lab I,0.71,0.18,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,2070,1,General Physics I,0.13,0.29,0.31,0.14,0.07,0.0,0.0,0.06,amy liann pope,PHYS-2070,2017
-PHYS,2070,2,General Physics I,0.27,0.37,0.21,0.06,0.02,0.0,0.0,0.06,amy liann pope,PHYS-2070,2017
-PHYS,2070,3,General Physics I,0.36,0.37,0.18,0.06,0.02,0.0,0.0,0.01,amy liann pope,PHYS-2070,2017
-PHYS,2080,1,General Physics II,0.49,0.3,0.11,0.06,0.03,0.0,0.0,0.01,sripar bhattacharya,PHYS-2080,2017
-PHYS,2090,1,Gen Phys Lab I,0.79,0.04,0.04,0.04,0.04,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,2,Gen Phys Lab I,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2017
-PHYS,2090,3,Gen Phys Lab I,0.33,0.46,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,4,Gen Phys Lab I,0.55,0.23,0.14,0.05,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2017
-PHYS,2090,5,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,6,Gen Phys Lab I,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,7,Gen Phys Lab I,0.63,0.25,0.04,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2017
-PHYS,2090,8,Gen Phys Lab I,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2017
-PHYS,2090,9,Gen Phys Lab I,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,10,Gen Phys Lab I,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,11,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,12,Gen Phys Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,13,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,14,Gen Phys Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,15,Gen Phys Lab I,0.61,0.35,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,16,Gen Phys Lab I,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,17,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,18,Gen Phys Lab I,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,19,Gen Phys Lab I,0.61,0.3,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,20,Gen Phys Lab I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,21,Gen Phys Lab I,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,22,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2017
-PHYS,2090,23,Gen Phys Lab I,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,24,Gen Phys Lab I,0.52,0.39,0.0,0.0,0.0,0.0,0.0,0.09,jerry hester,PHYS-2090,2017
-PHYS,2090,25,Gen Phys Lab I,0.52,0.39,0.0,0.04,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,26,Gen Phys Lab I,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,PHYS-2090,2017
-PHYS,2090,27,Gen Phys Lab I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2100,1,Gen Phys Lab II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,2,Gen Phys Lab II,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,3,Gen Phys Lab II,0.65,0.15,0.2,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,4,Gen Phys Lab II,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,6,Gen Phys Lab II,0.52,0.3,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,7,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,8,Gen Phys Lab II,0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,9,Gen Phys Lab II,0.48,0.24,0.24,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2100,2017
-PHYS,2210,1,Physics with Calculus II,0.14,0.54,0.22,0.04,0.04,0.0,0.0,0.03,jason stratfo brown,PHYS-2210,2017
-PHYS,2210,2,Physics with Calculus II,0.28,0.52,0.16,0.03,0.0,0.0,0.0,0.01,jason stratfo brown,PHYS-2210,2017
-PHYS,2210,3,Physics with Calculus II,0.22,0.55,0.19,0.02,0.0,0.0,0.0,0.01,ramakrishna podila,PHYS-2210,2017
-PHYS,2210,4,Physics with Calculus II,0.18,0.56,0.16,0.06,0.04,0.0,0.0,0.0,ramakrishna podila,PHYS-2210,2017
-PHYS,2210,7,Physics With Cal II (HON),0.58,0.36,0.06,0.0,0.0,0.0,0.0,0.0,joan marler,PHYS-2210,2017
-PHYS,2220,1,Physics with Calculus III,0.57,0.29,0.0,0.05,0.0,0.0,0.0,0.1,jian he,PHYS-2220,2017
-PHYS,2230,3,Physics Lab II,0.72,0.06,0.0,0.0,0.0,0.0,0.0,0.22,jerry hester,PHYS-2230,2017
-PHYS,2230,4,Physics Lab II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2017
-PHYS,2230,6,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2017
-PHYS,2230,7,Physics Lab II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2017
-PHYS,2230,11,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2017
-PHYS,2230,13,Physics Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2017
-PHYS,2230,17,Physics Lab II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2017
-PHYS,2450,1,Physics of Climate,0.64,0.2,0.05,0.01,0.02,0.0,0.0,0.08,gerald lehmacher,PHYS-2450,2017
-PHYS,3120,1,Meth Theor Phys II,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,antony valentini,PHYS-3120,2017
-PHYS,3150,1,Intro to Computational Physics,0.5,0.27,0.19,0.0,0.0,0.0,0.0,0.04,emil georgie alexov,PHYS-3150,2017
-PHYS,3210,1,Mechanics I,0.29,0.25,0.21,0.04,0.08,0.0,0.0,0.13,joshua alper,PHYS-3210,2017
-PHYS,3250,1,Exper Physics I,0.5,0.25,0.15,0.0,0.05,0.0,0.0,0.05,chad sosolik,PHYS-3250,2017
-PHYS,4410,1,Electromagnetics I,0.27,0.36,0.14,0.05,0.0,0.0,0.0,0.18,xian lu,PHYS-4410,2017
-PHYS,4550,1,Quantum Physics I,0.18,0.64,0.09,0.09,0.0,0.0,0.0,0.0,ramakrishna podila,PHYS-4550,2017
-PHYS,8110,1,Meth of Theor Phys I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,feng ding,PHYS-8110,2017
-PHYS,8170,1,Molecular Biophysics,0.14,0.71,0.0,0.0,0.14,0.0,0.0,0.0,hugo sanabria,PHYS-8170,2017
-PHYS,8210,1,Classical Mech I,0.14,0.57,0.29,0.0,0.0,0.0,0.0,0.0,jens oberheide,PHYS-8210,2017
-PHYS,9510,1,Quantum Mech I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,PHYS-9510,2017
-PKSC,1010,1,Pkgsc Orientation,0.88,0.09,0.02,0.0,0.01,0.0,0.0,0.0,robert truett moore,PKSC-1010,2017
-PKSC,1020,1,Intro to Pkg Sci,0.24,0.4,0.26,0.04,0.02,0.0,0.0,0.03,heather batt,PKSC-1020,2017
-PKSC,2020,1,Packaging Mtl & Mfg,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2020,2017
-PKSC,2040,1,Container Systems,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2040,2017
-PKSC,2060,1,Container Sys Lab,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2060,2017
-PKSC,4010,1,Packaging Machinery,0.35,0.49,0.14,0.0,0.0,0.0,0.0,0.01,anthony lou pometto,PKSC-4010,2017
-PKSC,4040,1,Protective Packaging Prop/Prin,0.34,0.34,0.19,0.05,0.02,0.0,0.0,0.06,gregory batt,PKSC-4040,2017
-PKSC,4160,1,Appl Polymers in Pkg,0.13,0.49,0.35,0.03,0.0,0.0,0.0,0.0,tyler stuettgen,PKSC-4160,2017
-PKSC,4200,1,Pkg Design & Dev,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2017
-PKSC,4540,1,Prod Pkg Evl Lab,0.13,0.73,0.07,0.07,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2017
-PKSC,4540,2,Prod Pkg Evl Lab,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2017
-PKSC,4540,3,Prod Pkg Evl Lab,0.21,0.57,0.14,0.0,0.0,0.0,0.0,0.07,gregory batt,PKSC-4540,2017
-PKSC,4540,4,Prod Pkg Evl Lab,0.25,0.31,0.31,0.0,0.0,0.0,0.0,0.13,gregory batt,PKSC-4540,2017
-PKSC,4640,1,Food & Health Care Pkg Systems,0.65,0.25,0.08,0.0,0.03,0.0,0.0,0.0,kay cooksey,PKSC-4640,2017
-PKSC,8170,1,Pckg Materials: Sci & Technol,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,duncan darby,PKSC-8170,2017
-PLPA,3100,1,Principles of Plant Pathology,0.34,0.38,0.24,0.03,0.0,0.0,0.0,0.0,steven nye jeffers,PLPA-3100,2017
-PLPA,6250,1,Introductory Mycology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,PLPA-6250,2017
-POSC,1010,1,Amer National Govt,0.15,0.33,0.34,0.13,0.02,0.0,0.0,0.02,joseph earl stewart,POSC-1010,2017
-POSC,1010,2,Amer National Govt,0.21,0.44,0.21,0.06,0.06,0.0,0.0,0.02,jeffrey scott peake,POSC-1010,2017
-POSC,1020,1,Intro Intl Relations,0.4,0.34,0.15,0.06,0.0,0.0,0.0,0.04,brandon mic stewart,POSC-1020,2017
-POSC,1020,2,Intro Intl Relations,0.64,0.22,0.11,0.02,0.02,0.0,0.0,0.0,brandon mic stewart,POSC-1020,2017
-POSC,1020,3,Intro Intl Relations,0.24,0.44,0.11,0.04,0.09,0.0,0.0,0.07,steven vince miller,POSC-1020,2017
-POSC,1020,4,Intro Intl Relations,0.13,0.42,0.27,0.12,0.06,0.0,0.0,0.01,zeynep taydas,POSC-1020,2017
-POSC,1020,5,Intro Intl Relations,0.18,0.41,0.23,0.1,0.05,0.0,0.0,0.04,zeynep taydas,POSC-1020,2017
-POSC,1030,1,Intro to Political Theory,0.37,0.28,0.16,0.07,0.06,0.0,0.0,0.06,brandon turner,POSC-1030,2017
-POSC,1030,2,Intro to Political Theory,0.17,0.61,0.11,0.06,0.0,0.0,0.0,0.06,colin pearce,POSC-1030,2017
-POSC,1030,3,Intro to Political Theory,0.61,0.28,0.0,0.11,0.0,0.0,0.0,0.0,lorianne molinari,POSC-1030,2017
-POSC,1040,1,Intro Compar Pol,0.45,0.35,0.13,0.02,0.04,0.0,0.0,0.02,brandon mic stewart,POSC-1040,2017
-POSC,1040,2,Intro Compar Pol,0.18,0.42,0.16,0.13,0.05,0.0,0.0,0.05,katherine am curtis,POSC-1040,2017
-POSC,1990,1,Intro Pol Sci,0.54,0.26,0.07,0.05,0.04,0.0,0.0,0.04,meredith petersheim,POSC-1990,2017
-POSC,3020,1,State and Loc Gov,0.14,0.42,0.19,0.0,0.05,0.0,0.0,0.21,bruce ransom,POSC-3020,2017
-POSC,3210,1,Public Admin,0.15,0.31,0.46,0.08,0.0,0.0,0.0,0.0,james woodard,POSC-3210,2017
-POSC,3410,1,Quant Meth in Pol Sc,0.28,0.32,0.2,0.08,0.12,0.0,0.0,0.0,jeffrey allen fine,POSC-3410,2017
-POSC,3610,1,International Conflict,0.3,0.19,0.19,0.11,0.09,0.0,0.0,0.13,steven vince miller,POSC-3610,2017
-POSC,3630,1,Us Foreign Policy,0.37,0.54,0.07,0.0,0.0,0.0,0.0,0.02,vladimir matic,POSC-3630,2017
-POSC,3710,1,European Politics,0.29,0.4,0.27,0.0,0.02,0.0,0.0,0.02,vladimir matic,POSC-3710,2017
-POSC,4030,1,United States Congress,0.31,0.31,0.17,0.06,0.17,0.0,0.0,0.0,jeffrey allen fine,POSC-4030,2017
-POSC,4070,1,Religion and Politic,0.16,0.42,0.32,0.06,0.0,0.0,0.0,0.03,laura olson,POSC-4070,2017
-POSC,4210,1,Public Policy,0.19,0.31,0.25,0.06,0.13,0.0,0.0,0.06,adam warber,POSC-4210,2017
-POSC,4360,1,Law Courts Politics,0.88,0.08,0.02,0.0,0.0,0.0,0.0,0.02,joseph earl stewart,POSC-4360,2017
-POSC,4380,1,Constitut Law: Struc of Gov,0.32,0.5,0.12,0.02,0.04,0.0,0.0,0.0,daniel frost,POSC-4380,2017
-POSC,4420,1,Pol Parties & Elect,0.25,0.36,0.23,0.16,0.0,0.0,0.0,0.0,laura olson,POSC-4420,2017
-POSC,4470,1,International Law,0.33,0.3,0.13,0.1,0.08,0.0,0.0,0.08,katherine am curtis,POSC-4470,2017
-POSC,4500,1,Contemporary Political Thought,0.42,0.46,0.04,0.0,0.04,0.0,0.0,0.04,daniel frost,POSC-4500,2017
-POSC,4540,1,Southern Politics,0.11,0.5,0.33,0.0,0.0,0.0,0.0,0.06,james woodard,POSC-4540,2017
-POSC,4550,1,Pol Thght of American Founding,0.29,0.5,0.18,0.0,0.03,0.0,0.0,0.0, bradley thompson,POSC-4550,2017
-POSC,4560,1,Diplomacy,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,POSC-4560,2017
-PRTM,1950,2,Pro Golf Management Seminar I,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-1950,2017
-PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.92,0.06,0.03,jamie lynn cathey,PRTM-2070,2017
-PRTM,2200,10,Foundations of PRTM,0.32,0.42,0.12,0.02,0.03,0.0,0.0,0.08,jamie lynn cathey,PRTM-2200,2017
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2260,2017
-PRTM,2260,2,Fnd of Mgt Adm PRTM,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,PRTM-2260,2017
-PRTM,2260,3,Fnd of Mgt Adm PRTM,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2260,2017
-PRTM,2260,4,Fnd of Mgt Adm PRTM,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2260,2017
-PRTM,2260,5,Fnd of Mgt Adm PRTM,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,garrett stone,PRTM-2260,2017
-PRTM,2260,6,Fnd of Mgt Adm PRTM,0.21,0.5,0.21,0.07,0.0,0.0,0.0,0.0,ryan joseph gagnon,PRTM-2260,2017
-PRTM,2260,7,Fnd of Mgt Adm PRTM,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,brandon harris,PRTM-2260,2017
-PRTM,2260,8,Fnd of Mgt Adm PRTM,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,PRTM-2260,2017
-PRTM,2260,9,Fnd of Mgt Adm PRTM,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,katrina latri black,PRTM-2260,2017
-PRTM,2270,1,Prov of Leisure Exp,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2270,2017
-PRTM,2270,2,Prov of Leisure Exp,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,PRTM-2270,2017
-PRTM,2270,3,Prov of Leisure Exp,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2270,2017
-PRTM,2270,4,Prov of Leisure Exp,0.0,0.43,0.21,0.29,0.07,0.0,0.0,0.0,jamie lynn cathey,PRTM-2270,2017
-PRTM,2270,5,Prov of Leisure Exp,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,garrett stone,PRTM-2270,2017
-PRTM,2270,6,Prov of Leisure Exp,0.29,0.21,0.36,0.07,0.07,0.0,0.0,0.0,ryan joseph gagnon,PRTM-2270,2017
-PRTM,2270,7,Prov of Leisure Exp,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,brandon harris,PRTM-2270,2017
-PRTM,2270,8,Prov of Leisure Exp,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,PRTM-2270,2017
-PRTM,2270,9,Prov of Leisure Exp,0.36,0.36,0.21,0.0,0.0,0.0,0.0,0.07,emilie viktor adams,PRTM-2270,2017
-PRTM,2290,1,Competency Integration in PRTM,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2290,2017
-PRTM,2290,2,Competency Integration in PRTM,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,PRTM-2290,2017
-PRTM,2290,3,Competency Integration in PRTM,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2290,2017
-PRTM,2290,4,Competency Integration in PRTM,0.29,0.14,0.43,0.07,0.07,0.0,0.0,0.0,jamie lynn cathey,PRTM-2290,2017
-PRTM,2290,5,Competency Integration in PRTM,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,garrett stone,PRTM-2290,2017
-PRTM,2290,6,Competency Integration in PRTM,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,ryan joseph gagnon,PRTM-2290,2017
-PRTM,2290,7,Competency Integration in PRTM,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,brandon harris,PRTM-2290,2017
-PRTM,2290,8,Competency Integration in PRTM,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,PRTM-2290,2017
-PRTM,2290,9,Competency Integration in PRTM,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,emilie viktor adams,PRTM-2290,2017
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.63,0.29,0.05,0.03,0.0,0.0,0.0,0.0,katherine an jordan,PRTM-3050,2017
-PRTM,3070,2,Facility Operations,0.84,0.09,0.0,0.03,0.03,0.0,0.0,0.0,raymond dunham,PRTM-3070,2017
-PRTM,3200,1,Recreation Policy,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,matthew ty brownlee,PRTM-3200,2017
-PRTM,3210,1,Recreation Admin,0.26,0.51,0.2,0.0,0.03,0.0,0.0,0.0,gina depper,PRTM-3210,2017
-PRTM,3220,1,Facilitation Techniques in RT,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,PRTM-3220,2017
-PRTM,3230,1,Prof Prep for RT Practice,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,PRTM-3230,2017
-PRTM,3240,1,Assessment & Planning in RT,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3240,2017
-PRTM,3250,1,Global Persp in Rec,0.54,0.35,0.0,0.04,0.0,0.0,0.0,0.08,harrison pinckney,PRTM-3250,2017
-PRTM,3300,1,Visit Ser & Interp,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-3300,2017
-PRTM,3420,2,Intro to Tourism,0.52,0.21,0.12,0.06,0.09,0.0,0.0,0.0,herbert chancellor,PRTM-3420,2017
-PRTM,3430,1,Spl Asp of Tourist B,0.4,0.51,0.09,0.0,0.0,0.0,0.0,0.0,william norman,PRTM-3430,2017
-PRTM,3430,2,Spl Asp of Tourist B,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,'lisha fogle,PRTM-3430,2017
-PRTM,3470,1,Sport Tourism,0.47,0.21,0.32,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,PRTM-3470,2017
-PRTM,3900,7,Independent Study in PRTM,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3900,2017
-PRTM,3910,1,Social Media in PRTM,0.4,0.52,0.0,0.08,0.0,0.0,0.0,0.0,zeynep gedikoglu,PRTM-3910,2017
-PRTM,3910,2,Issues & Trends in Event Mgmt.,0.92,0.0,0.08,0.0,0.0,0.0,0.0,0.0,stephanie per garst,PRTM-3910,2017
-PRTM,3920,1,Special Event Management,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,PRTM-3920,2017
-PRTM,3920,2,Special Event Management,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,PRTM-3920,2017
-PRTM,4030,1,Elem of Rec/Pk Plan,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,gina depper,PRTM-4030,2017
-PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,daniel mor anderson,PRTM-4040,2017
-PRTM,4210,1,Rec Fin Resc Mgt,0.11,0.26,0.42,0.21,0.0,0.0,0.0,0.0,denise mar anderson,PRTM-4210,2017
-PRTM,4220,1,Management of RT Services,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,PRTM-4220,2017
-PRTM,4470,1,Perspect Intl Travel,0.82,0.16,0.03,0.0,0.0,0.0,0.0,0.0,lauren duffy,PRTM-4470,2017
-PRTM,4510,1,Seminar in CRSCM,0.5,0.33,0.11,0.06,0.0,0.0,0.0,0.0,skye arthur-banning,PRTM-4510,2017
-PRTM,4550,1,Adv Program Planning,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,mariela fernandez,PRTM-4550,2017
-PRTM,4740,2,Adv Rec Resource Mgt,0.95,0.0,0.0,0.0,0.05,0.0,0.0,0.0,geoffrey koo riungu,PRTM-4740,2017
-PRTM,8020,1,Group Proc in Leisure Services,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,PRTM-8020,2017
-PRTM,8080,2,Behavioral Aspects,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-8080,2017
-PRTM,8220,2,Strateg Planning in PRTM Orgs,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,thomas john orourke,PRTM-8220,2017
-PRTM,8700,1,Foundat & Issues in Rec Therap,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,alysha amber walter,PRTM-8700,2017
-PRTM,8710,1,Applied Research in Rec Therap,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,PRTM-8710,2017
-PSYC,2010,1,Intro to Psychology,0.49,0.31,0.12,0.04,0.0,0.0,0.0,0.04,jo anne jorgensen,PSYC-2010,2017
-PSYC,2010,2,Intro to Psychology,0.42,0.35,0.13,0.06,0.01,0.0,0.0,0.03,jo anne jorgensen,PSYC-2010,2017
-PSYC,2010,3,Intro to Psychology,0.35,0.32,0.18,0.05,0.04,0.0,0.0,0.06,edwin brainerd,PSYC-2010,2017
-PSYC,2010,4,Intro to Psychology,0.57,0.2,0.13,0.04,0.03,0.0,0.0,0.03,chong hyon pak,PSYC-2010,2017
-PSYC,2010,5,Intro to Psychology,0.34,0.43,0.17,0.04,0.0,0.0,0.0,0.01,mary taylor,PSYC-2010,2017
-PSYC,2010,6,Intro to Psychology (HON),0.63,0.21,0.05,0.05,0.0,0.0,0.0,0.05,robin mari kowalski,PSYC-2010,2017
-PSYC,2020,2,Intro Psychology Lab,0.91,0.0,0.0,0.04,0.0,0.0,0.0,0.04,anton sytine,PSYC-2020,2017
-PSYC,2890,1,Fundamentals of Psyc Science,0.39,0.31,0.2,0.05,0.01,0.0,0.0,0.03,cynthia pury,PSYC-2890,2017
-PSYC,3060,1,Human Sexual Behavior,0.44,0.28,0.16,0.04,0.06,0.0,0.0,0.02,bruce michael king,PSYC-3060,2017
-PSYC,3090,100,Intro Experimental Psychology,0.33,0.28,0.21,0.13,0.03,0.0,0.0,0.03,richard tyrrell,PSYC-3090,2017
-PSYC,3090,200,Intro Experimental Psychology,0.45,0.32,0.13,0.06,0.03,0.0,0.0,0.0,jennifer bai bisson,PSYC-3090,2017
-PSYC,3090,300,Intro Experimental Psychology,0.67,0.2,0.03,0.07,0.0,0.0,0.0,0.03,leah hartman,PSYC-3090,2017
-PSYC,3100,100,Advanced Experimental Psych,0.38,0.38,0.19,0.05,0.0,0.0,0.0,0.0,jennifer bai bisson,PSYC-3100,2017
-PSYC,3100,200,Advanced Experimental Psych,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert campbell,PSYC-3100,2017
-PSYC,3100,300,Advanced Experimental Psych,0.35,0.45,0.05,0.05,0.05,0.0,0.0,0.05,gargi sawhney,PSYC-3100,2017
-PSYC,3100,400,Advanced Experimental Psych,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2017
-PSYC,3100,500,Advanced Experimental Psych,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2017
-PSYC,3240,1,Physiological Psych,0.3,0.35,0.16,0.07,0.06,0.0,0.0,0.06,claudio cantalupo,PSYC-3240,2017
-PSYC,3240,2,Physiological Psych,0.28,0.32,0.26,0.07,0.03,0.0,0.0,0.04,june pilcher,PSYC-3240,2017
-PSYC,3310,1,Critical Thinking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,leo gugerty,PSYC-3310,2017
-PSYC,3330,1,Cognitive Psych,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,robert campbell,PSYC-3330,2017
-PSYC,3330,2,Cognitive Psych,0.39,0.26,0.2,0.09,0.03,0.0,0.0,0.03,kaileigh ange byrne,PSYC-3330,2017
-PSYC,3330,3,Cognitive Psych,0.36,0.33,0.23,0.04,0.03,0.0,0.0,0.0,madison eliza sauls,PSYC-3330,2017
-PSYC,3340,1,Cognitive Psych Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3340,2017
-PSYC,3340,2,Cognitive Psych Lab,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,leo gugerty,PSYC-3340,2017
-PSYC,3400,1,Lifespan Developmental Psych,0.6,0.28,0.09,0.03,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3400,2017
-PSYC,3400,2,Lifespan Developmental Psych,0.21,0.4,0.25,0.07,0.0,0.0,0.0,0.07,pamela alley,PSYC-3400,2017
-PSYC,3520,1,Social Psychology,0.41,0.25,0.21,0.06,0.02,0.0,0.0,0.05,eric mckibben,PSYC-3520,2017
-PSYC,3640,1,Industrial Psych,0.34,0.49,0.14,0.03,0.0,0.0,0.0,0.0,eric mckibben,PSYC-3640,2017
-PSYC,3640,2,Industrial Psych,0.26,0.43,0.26,0.03,0.01,0.0,0.0,0.0,eric mckibben,PSYC-3640,2017
-PSYC,3680,1,Organizational Psych,0.27,0.31,0.3,0.1,0.01,0.0,0.0,0.0,thomas britt,PSYC-3680,2017
-PSYC,3680,2,Organizational Psych,0.3,0.36,0.2,0.06,0.04,0.0,0.0,0.03,dana verhoeven,PSYC-3680,2017
-PSYC,3690,1,Leadership in Organiz Settings,0.29,0.33,0.21,0.08,0.02,0.0,0.0,0.06,patrick raymark,PSYC-3690,2017
-PSYC,3700,1,Personality,0.31,0.5,0.15,0.01,0.0,0.0,0.0,0.03,eric mckibben,PSYC-3700,2017
-PSYC,3700,2,Personality,0.28,0.41,0.23,0.04,0.0,0.0,0.0,0.04,john robert hester,PSYC-3700,2017
-PSYC,3830,1,Abnormal Psychology,0.43,0.33,0.12,0.03,0.04,0.0,0.0,0.04,heidi marie zinzow,PSYC-3830,2017
-PSYC,3830,2,Abnormal Psychology,0.34,0.55,0.06,0.0,0.02,0.0,0.0,0.02,lucinda sorci quick,PSYC-3830,2017
-PSYC,3830,3,Abnormal Psychology,0.29,0.43,0.2,0.06,0.0,0.0,0.0,0.03,pamela alley,PSYC-3830,2017
-PSYC,3830,4,Abnormal Psychology,0.16,0.34,0.13,0.16,0.13,0.0,0.0,0.09,pamela alley,PSYC-3830,2017
-PSYC,3890,1,Cross-Cultural Psychology,0.62,0.21,0.07,0.0,0.1,0.0,0.0,0.0,ceren gunsoy,PSYC-3890,2017
-PSYC,4080,1,Women and Psychology,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,robin mari kowalski,PSYC-4080,2017
-PSYC,4150,2,Systems and Theories,0.29,0.41,0.09,0.09,0.12,0.0,0.0,0.0,edwin brainerd,PSYC-4150,2017
-PSYC,4150,3,Systems and Theories,0.44,0.24,0.09,0.12,0.03,0.0,0.0,0.09,edwin brainerd,PSYC-4150,2017
-PSYC,4220,1,Perception,0.36,0.16,0.2,0.08,0.12,0.0,0.0,0.08,claudio cantalupo,PSYC-4220,2017
-PSYC,4220,2,Perception,0.27,0.35,0.31,0.04,0.0,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2017
-PSYC,4220,3,Perception,0.22,0.33,0.19,0.19,0.04,0.0,0.0,0.04,christopher pagano,PSYC-4220,2017
-PSYC,4220,4,Perception,0.36,0.28,0.2,0.08,0.0,0.0,0.0,0.08,christopher pagano,PSYC-4220,2017
-PSYC,4350,1,Human Factors,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,laura whitlock,PSYC-4350,2017
-PSYC,4350,2,Human Factors,0.42,0.42,0.05,0.05,0.05,0.0,0.0,0.0,laura whitlock,PSYC-4350,2017
-PSYC,4560,1,Psychophysiology,0.39,0.28,0.28,0.06,0.0,0.0,0.0,0.0,drew michael morris,PSYC-4560,2017
-PSYC,4800,1,Health Psychology,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,james mccubbin,PSYC-4800,2017
-PSYC,4800,2,Health Psychology,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,PSYC-4800,2017
-PSYC,4890,1,Teamwork Dynamics,0.88,0.04,0.04,0.0,0.04,0.0,0.0,0.0,marissa leig porter,PSYC-4890,2017
-PSYC,4920,1,Senior Laboratory,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,PSYC-4920,2017
-PSYC,4920,2,Senior Laboratory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,PSYC-4920,2017
-PSYC,4920,3,Senior Laboratory,0.89,0.04,0.04,0.0,0.04,0.0,0.0,0.0,nastassia ma savage,PSYC-4920,2017
-PSYC,4920,5,Senior Laboratory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,drea kevin fekety,PSYC-4920,2017
-PSYC,8100,1,Research Design I,0.65,0.27,0.05,0.0,0.0,0.0,0.0,0.03,patrick rosopa,PSYC-8100,2017
-PSYC,8620,1,Org Psychology,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,PSYC-8620,2017
-PSYC,8730,1,SEM in Applied Psychology,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, dewayne moore,PSYC-8730,2017
-RED,8000,1,Real Estate Dvlpment,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8000,2017
-RED,8010,1,Market Analysis,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,thomas andrew fox,RED-8010,2017
-RED,8040,1,Resid Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8040,2017
-RED,8050,1,Commercial Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8050,2017
-RED,8130,1,Strat in Real Estate,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,RED-8130,2017
-RED,8170,1,Mixed-Use Development Seminar,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,tor wallace-babcock,RED-8170,2017
-RED,8890,1,Selected Topics-Adv. Fin. Mod.,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,larry bradle harvey,RED-8890,2017
-REL,1010,1,Intro to Religion,0.22,0.33,0.22,0.17,0.0,0.0,0.0,0.06,peter cohen,REL-1010,2017
-REL,1010,2,Intro to Religion,0.34,0.26,0.23,0.06,0.03,0.0,0.0,0.09,peter cohen,REL-1010,2017
-REL,1010,3,Intro to Religion,0.29,0.51,0.11,0.0,0.0,0.0,0.0,0.09,brett patterson,REL-1010,2017
-REL,1010,4,Intro to Religion,0.29,0.47,0.0,0.18,0.06,0.0,0.0,0.0,peter cohen,REL-1010,2017
-REL,1010,5,Intro to Religion,0.17,0.51,0.14,0.03,0.03,0.0,0.0,0.11,brett patterson,REL-1010,2017
-REL,1020,2,World Religions,0.4,0.43,0.14,0.0,0.0,0.0,0.0,0.03,robert stephens,REL-1020,2017
-REL,1020,3,World Religions,0.35,0.5,0.12,0.03,0.0,0.0,0.0,0.0,robert stephens,REL-1020,2017
-REL,1020,4,World Religions,0.2,0.6,0.14,0.03,0.03,0.0,0.0,0.0,robert stephens,REL-1020,2017
-REL,1020,5,World Religions,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,brett patterson,REL-1020,2017
-REL,3010,1,Old Testament,0.42,0.48,0.09,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3010,2017
-REL,3020,1,New Testament Lit,0.47,0.38,0.03,0.0,0.03,0.0,0.0,0.09,benjamin white,REL-3020,2017
-REL,3080,1,Religions of the Ancient World,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3080,2017
-REL,3100,1,History of Religion in the US,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,elizabeth jemison,REL-3100,2017
-REL,3150,1,Islam,0.53,0.27,0.07,0.0,0.13,0.0,0.0,0.0,robert stephens,REL-3150,2017
-REL,4520,1,History of Early Christianity,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,benjamin white,REL-4520,2017
-RS,3010,1,Rural Sociology,0.53,0.37,0.0,0.05,0.0,0.0,0.0,0.05,kenneth robinson,RS-3010,2017
-RS,4590,1,The Community,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,RS-4590,2017
-RUSS,1010,1,Elementary Russian,0.5,0.31,0.06,0.06,0.0,0.0,0.0,0.06,stephanie el morris,RUSS-1010,2017
-RUSS,1010,2,Elementary Russian,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,stephanie el morris,RUSS-1010,2017
-RUSS,3400,1,19th C Russ Culture,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,olga anatol volkova,RUSS-3400,2017
-RUSS,3610,1,Russn Lit Since 1910,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,RUSS-3610,2017
-SOC,2010,2,Introduction to Sociology,0.94,0.04,0.01,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,SOC-2010,2017
-SOC,2010,3,Introduction to Sociology,0.79,0.18,0.02,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,SOC-2010,2017
-SOC,2010,4,Introduction to Sociology,0.53,0.34,0.13,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-2010,2017
-SOC,2010,5,Introduction to Sociology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,stacy leanne smith,SOC-2010,2017
-SOC,2010,6,Introduction to Sociology,0.81,0.15,0.02,0.0,0.0,0.0,0.0,0.02,stacy leanne smith,SOC-2010,2017
-SOC,2010,7,Introduction to Sociology,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,stacy leanne smith,SOC-2010,2017
-SOC,2010,8,Introduction to Sociology,0.8,0.12,0.04,0.02,0.0,0.0,0.0,0.02,stacy leanne smith,SOC-2010,2017
-SOC,2010,9,Introduction to Sociology,0.36,0.41,0.16,0.04,0.0,0.0,0.0,0.03,carolyn can coffman,SOC-2010,2017
-SOC,2010,10,Introduction to Sociology,0.53,0.39,0.05,0.01,0.0,0.0,0.0,0.01,carolyn can coffman,SOC-2010,2017
-SOC,2010,11,Introduction to Sociology,0.48,0.41,0.05,0.05,0.02,0.0,0.0,0.0,carolyn can coffman,SOC-2010,2017
-SOC,2010,12,Introduction to Sociology,0.69,0.22,0.06,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2017
-SOC,2010,13,Introduction to Sociology,0.71,0.23,0.02,0.01,0.02,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2017
-SOC,2010,14,Introduction to Sociology,0.6,0.25,0.08,0.0,0.02,0.0,0.0,0.04,shannon mcdonough,SOC-2010,2017
-SOC,2020,1,Social Problems,0.51,0.4,0.02,0.0,0.02,0.0,0.0,0.04,carolyn can coffman,SOC-2020,2017
-SOC,3020,1,Research Methods I,0.44,0.26,0.23,0.05,0.02,0.0,0.0,0.0,andrew whitehead,SOC-3020,2017
-SOC,3040,1,Social Research Methods II,0.32,0.45,0.14,0.09,0.0,0.0,0.0,0.0,ye luo,SOC-3040,2017
-SOC,3110,1,The Family,0.3,0.53,0.15,0.0,0.02,0.0,0.0,0.0,andrew whitehead,SOC-3110,2017
-SOC,3310,1,Urban Sociology,0.87,0.03,0.05,0.0,0.05,0.0,0.0,0.0,william haller,SOC-3310,2017
-SOC,3910,1,Soc of Deviance,0.34,0.32,0.26,0.06,0.02,0.0,0.0,0.0,shannon mcdonough,SOC-3910,2017
-SOC,3920,1,Juvenile Delinquency,0.76,0.15,0.06,0.0,0.0,0.0,0.0,0.03,angelia turner,SOC-3920,2017
-SOC,3940,1,Sociology of Mental Illness,0.6,0.3,0.06,0.0,0.02,0.0,0.0,0.02,douglas sturkie,SOC-3940,2017
-SOC,4040,1,Soc Theory,0.31,0.26,0.17,0.17,0.03,0.0,0.0,0.06,stacy leanne smith,SOC-4040,2017
-SOC,4140,1,Policy&Social Change,0.54,0.3,0.16,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-4140,2017
-SOC,4330,1,Global Social Change,0.41,0.41,0.17,0.0,0.0,0.0,0.0,0.0,traci ann hefner,SOC-4330,2017
-SOC,4440,1,Sociology of Educ,0.61,0.26,0.1,0.0,0.03,0.0,0.0,0.0,andrew mannheimer,SOC-4440,2017
-SOC,4590,1,The Community,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,kenneth robinson,SOC-4590,2017
-SOC,4600,1,Race & Ethnicity,0.91,0.07,0.0,0.0,0.02,0.0,0.0,0.0,william haller,SOC-4600,2017
-SOC,4610,1,Sex & Gender,0.43,0.41,0.13,0.0,0.0,0.0,0.0,0.02,traci ann hefner,SOC-4610,2017
-SOC,4970,1,Senior Lab,0.71,0.26,0.0,0.03,0.0,0.0,0.0,0.0,jennifer le holland,SOC-4970,2017
-SOC,8030,1,Sur Dsgn App Res Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,SOC-8030,2017
-SPAN,1010,1,Elementary Spanish,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,scott harris,SPAN-1010,2017
-SPAN,1010,2,Elementary Spanish,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2017
-SPAN,1010,3,Elementary Spanish,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2017
-SPAN,1020,1,Elementary Spanish,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1020,2017
-SPAN,1020,2,Elementary Spanish,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,SPAN-1020,2017
-SPAN,1020,3,Elementary Spanish,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,SPAN-1020,2017
-SPAN,1020,4,Elementary Spanish,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,danie garcia vieyra,SPAN-1020,2017
-SPAN,1020,5,Elementary Spanish,0.67,0.06,0.11,0.06,0.0,0.0,0.0,0.11,danie garcia vieyra,SPAN-1020,2017
-SPAN,1020,6,Elementary Spanish,0.24,0.41,0.24,0.06,0.06,0.0,0.0,0.0,cathy robison,SPAN-1020,2017
-SPAN,1020,7,Elementary Spanish,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,cathy robison,SPAN-1020,2017
-SPAN,1020,8,Elementary Spanish,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-1020,2017
-SPAN,1020,10,Elementary Spanish,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-1020,2017
-SPAN,1020,11,Elementary Spanish,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-1020,2017
-SPAN,1020,12,Elementary Spanish,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-1020,2017
-SPAN,1020,13,Elementary Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-1020,2017
-SPAN,2010,1,Intermediate Spanish,0.41,0.35,0.18,0.06,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2017
-SPAN,2010,2,Intermediate Spanish,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2017
-SPAN,2010,3,Intermediate Spanish,0.47,0.18,0.12,0.12,0.0,0.0,0.0,0.12,melva margu persico,SPAN-2010,2017
-SPAN,2010,4,Intermediate Spanish,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,melva margu persico,SPAN-2010,2017
-SPAN,2010,5,Intermediate Spanish,0.81,0.0,0.06,0.0,0.06,0.0,0.0,0.06,danie garcia vieyra,SPAN-2010,2017
-SPAN,2010,6,Intermediate Spanish,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,danie garcia vieyra,SPAN-2010,2017
-SPAN,2010,7,Intermediate Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-2010,2017
-SPAN,2010,8,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-2010,2017
-SPAN,2010,9,Intermediate Spanish,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,william da holcombe,SPAN-2010,2017
-SPAN,2010,10,Intermediate Spanish,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2017
-SPAN,2010,11,Intermediate Spanish,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,SPAN-2010,2017
-SPAN,2010,12,Intermediate Spanish,0.68,0.05,0.21,0.05,0.0,0.0,0.0,0.0,al garcia rodriguez,SPAN-2010,2017
-SPAN,2010,13,Intermediate Spanish,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,SPAN-2010,2017
-SPAN,2010,14,Intermediate Spanish,0.5,0.31,0.13,0.0,0.0,0.0,0.0,0.06,maureen zamora,SPAN-2010,2017
-SPAN,2010,15,Intermediate Spanish,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william da holcombe,SPAN-2010,2017
-SPAN,2010,16,Intermediate Spanish,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,ellory schmucker,SPAN-2010,2017
-SPAN,2010,17,Intermediate Spanish,0.79,0.07,0.0,0.07,0.0,0.0,0.0,0.07,ze cruz valderramos,SPAN-2010,2017
-SPAN,2010,19,Intermediate Spanish,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,SPAN-2010,2017
-SPAN,2020,1,Intermediate Spanish,0.25,0.56,0.13,0.0,0.06,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2017
-SPAN,2020,2,Intermediate Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2017
-SPAN,2020,3,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2017
-SPAN,2020,4,Intermediate Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2017
-SPAN,2020,5,Intermediate Spanish,0.39,0.44,0.11,0.06,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2020,2017
-SPAN,2020,6,Intermediate Spanish,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,ze cruz valderramos,SPAN-2020,2017
-SPAN,2020,7,Intermediate Spanish,0.71,0.06,0.18,0.06,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2020,2017
-SPAN,2020,8,Intermediate Spanish,0.37,0.32,0.21,0.05,0.0,0.0,0.0,0.05,ana paula  miller,SPAN-2020,2017
-SPAN,2020,9,Intermediate Spanish,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2017
-SPAN,2020,10,Intermediate Spanish,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2017
-SPAN,2020,11,Intermediate Spanish,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,ze cruz valderramos,SPAN-2020,2017
-SPAN,2020,12,Intermediate Spanish,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,SPAN-2020,2017
-SPAN,2020,13,Intermediate Spanish,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,nora arostegu logue,SPAN-2020,2017
-SPAN,2020,14,Intermediate Spanish,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,SPAN-2020,2017
-SPAN,3020,1,Int Spn Gram & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,SPAN-3020,2017
-SPAN,3020,2,Int Spn Gram & Comp,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,melva margu persico,SPAN-3020,2017
-SPAN,3040,1,Intro Hisp Lit Forms,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-3040,2017
-SPAN,3050,1,Int Con Comp Span I,0.29,0.29,0.24,0.06,0.0,0.0,0.0,0.12,juana martin-armas,SPAN-3050,2017
-SPAN,3050,2,Int Con Comp Span I,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,juana martin-armas,SPAN-3050,2017
-SPAN,3050,3,Int Con Comp Span I,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,raquel anido,SPAN-3050,2017
-SPAN,3050,4,Int Con Comp Span I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,SPAN-3050,2017
-SPAN,3060,1,Span Comp for Bus,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-3060,2017
-SPAN,3070,1,Hispanic World: Sp,0.53,0.37,0.0,0.05,0.05,0.0,0.0,0.0,salvador oropesa,SPAN-3070,2017
-SPAN,3070,2,Hispanic World: Sp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,SPAN-3070,2017
-SPAN,3080,1,Hispanic World: La,0.19,0.5,0.19,0.06,0.06,0.0,0.0,0.0,tiffany dawn miller,SPAN-3080,2017
-SPAN,3110,1,Surv Span-Amer Lit,0.38,0.38,0.08,0.0,0.0,0.0,0.0,0.15,tiffany dawn miller,SPAN-3110,2017
-SPAN,3130,2,Span Lit Survey I,0.38,0.38,0.08,0.0,0.08,0.0,0.0,0.08,mon rojas-de-massei,SPAN-3130,2017
-SPAN,4030,1,Span Amer Wom Writer,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-4030,2017
-STAT,2220,1,Statistics in Everyday Life,0.33,0.37,0.21,0.06,0.02,0.0,0.0,0.01,james espey,STAT-2220,2017
-STAT,2220,2,Statistics in Everyday Life,0.41,0.32,0.17,0.06,0.01,0.0,0.0,0.03,james espey,STAT-2220,2017
-STAT,2220,3,Statistics in Everyday Life,0.34,0.41,0.16,0.06,0.01,0.0,0.0,0.02,james espey,STAT-2220,2017
-STAT,2220,4,Statistics in Everyday Life,0.43,0.31,0.09,0.08,0.06,0.0,0.0,0.03,james espey,STAT-2220,2017
-STAT,2220,5,Statistics in Everyday Life,0.25,0.34,0.27,0.02,0.04,0.0,0.0,0.07,ros martinez-dawson,STAT-2220,2017
-STAT,2220,6,Statistics in Everyday Life,0.42,0.42,0.05,0.0,0.05,0.0,0.0,0.05,jason alexande kurz,STAT-2220,2017
-STAT,2220,7,Statistics in Everyday Life,0.26,0.47,0.16,0.11,0.0,0.0,0.0,0.0,jason alexande kurz,STAT-2220,2017
-STAT,2220,100,Stats in Everyday Life (HON),0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ros martinez-dawson,STAT-2220,2017
-STAT,2300,1,Statistical Methods I,0.28,0.37,0.18,0.09,0.05,0.0,0.0,0.03,christy jenki brown,STAT-2300,2017
-STAT,2300,2,Statistical Methods I,0.38,0.34,0.13,0.05,0.06,0.0,0.0,0.04,christy jenki brown,STAT-2300,2017
-STAT,2300,3,Statistical Methods I,0.27,0.33,0.21,0.08,0.06,0.0,0.0,0.05, erwin walker,STAT-2300,2017
-STAT,2300,4,Statistical Methods I,0.25,0.45,0.14,0.07,0.05,0.0,0.0,0.04, erwin walker,STAT-2300,2017
-STAT,2300,5,Statistical Methods I,0.24,0.32,0.28,0.05,0.06,0.0,0.0,0.05,william bridges,STAT-2300,2017
-STAT,2300,6,Statistical Methods I,0.18,0.38,0.18,0.09,0.09,0.0,0.0,0.07,william bridges,STAT-2300,2017
-STAT,2300,100,Statistical Methods I (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christy jenki brown,STAT-2300,2017
-STAT,3090,1,Introductory Business Stats,0.37,0.26,0.26,0.0,0.05,0.0,0.0,0.05,todd fenstermacher,STAT-3090,2017
-STAT,3090,2,Introductory Business Stats,0.22,0.33,0.11,0.17,0.11,0.0,0.0,0.06,todd fenstermacher,STAT-3090,2017
-STAT,3090,3,Introductory Business Stats,0.16,0.37,0.16,0.11,0.21,0.0,0.0,0.0,boyoung hur,STAT-3090,2017
-STAT,3090,4,Introductory Business Stats,0.05,0.32,0.16,0.11,0.32,0.0,0.0,0.05,boyoung hur,STAT-3090,2017
-STAT,3090,5,Introductory Business Stats,0.05,0.26,0.26,0.16,0.21,0.0,0.0,0.05,andrew pangia,STAT-3090,2017
-STAT,3090,6,Introductory Business Stats,0.11,0.33,0.39,0.0,0.11,0.0,0.0,0.06,andrew pangia,STAT-3090,2017
-STAT,3090,7,Introductory Business Stats,0.22,0.33,0.22,0.06,0.17,0.0,0.0,0.0,tiantian yang,STAT-3090,2017
-STAT,3090,8,Introductory Business Stats,0.17,0.28,0.22,0.22,0.11,0.0,0.0,0.0,april thomas,STAT-3090,2017
-STAT,3090,9,Introductory Business Stats,0.11,0.11,0.26,0.11,0.26,0.0,0.0,0.16,feng gao,STAT-3090,2017
-STAT,3090,10,Introductory Business Stats,0.17,0.28,0.33,0.11,0.06,0.0,0.0,0.06,bryce pruitt,STAT-3090,2017
-STAT,3090,11,Introductory Business Stats,0.26,0.16,0.26,0.16,0.16,0.0,0.0,0.0,yisu jia,STAT-3090,2017
-STAT,3090,12,Introductory Business Stats,0.37,0.37,0.16,0.0,0.0,0.0,0.0,0.11,lu sun,STAT-3090,2017
-STAT,3090,13,Introductory Business Stats,0.34,0.3,0.18,0.09,0.06,0.0,0.0,0.03,sharon marie evans,STAT-3090,2017
-STAT,3090,14,Introductory Business Stats,0.5,0.22,0.28,0.0,0.0,0.0,0.0,0.0,kayla doris javier,STAT-3090,2017
-STAT,3090,15,Introductory Business Stats,0.19,0.22,0.34,0.05,0.14,0.0,0.0,0.05,matthew saltzman,STAT-3090,2017
-STAT,3090,16,Introductory Business Stats,0.39,0.28,0.17,0.06,0.11,0.0,0.0,0.0,jiajing niu,STAT-3090,2017
-STAT,3090,18,Introductory Business Stats,0.05,0.58,0.26,0.05,0.05,0.0,0.0,0.0,bryce pruitt,STAT-3090,2017
-STAT,3090,19,Introductory Business Stats,0.16,0.26,0.47,0.0,0.0,0.0,0.0,0.11,rui gong,STAT-3090,2017
-STAT,3090,20,Introductory Business Stats,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,jiajing niu,STAT-3090,2017
-STAT,3090,22,Introductory Business Stats,0.16,0.42,0.16,0.05,0.05,0.0,0.0,0.16,tiantian yang,STAT-3090,2017
-STAT,3090,23,Introductory Business Stats,0.26,0.32,0.11,0.16,0.05,0.0,0.0,0.11,tianhui wei,STAT-3090,2017
-STAT,3090,24,Introductory Business Stats,0.11,0.37,0.26,0.05,0.05,0.0,0.0,0.16,tianhui wei,STAT-3090,2017
-STAT,3090,25,Introductory Business Stats,0.26,0.37,0.16,0.16,0.0,0.0,0.0,0.05,liu zhu,STAT-3090,2017
-STAT,3090,26,Introductory Business Stats,0.26,0.21,0.16,0.16,0.21,0.0,0.0,0.0,april thomas,STAT-3090,2017
-STAT,3090,27,Introductory Business Stats,0.26,0.11,0.16,0.21,0.16,0.0,0.0,0.11,feng gao,STAT-3090,2017
-STAT,3090,28,Introductory Business Stats,0.33,0.56,0.0,0.06,0.0,0.0,0.0,0.06,lu sun,STAT-3090,2017
-STAT,3090,30,Introductory Business Stats,0.53,0.26,0.05,0.11,0.05,0.0,0.0,0.0,liu zhu,STAT-3090,2017
-STAT,3090,31,Introductory Business Stats,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,kayla doris javier,STAT-3090,2017
-STAT,3090,33,Introductory Business Stats,0.28,0.25,0.32,0.05,0.08,0.0,0.0,0.02,sharon marie evans,STAT-3090,2017
-STAT,3090,34,Introductory Business Stats,0.32,0.32,0.16,0.05,0.11,0.0,0.0,0.05,rui gong,STAT-3090,2017
-STAT,3090,35,Introductory Business Stats,0.3,0.21,0.39,0.06,0.0,0.0,0.0,0.03,margaret mar wiecek,STAT-3090,2017
-STAT,3090,36,Introductory Business Stats,0.17,0.24,0.36,0.17,0.0,0.0,0.0,0.07,matthew saltzman,STAT-3090,2017
-STAT,3090,37,Introductory Business Stats,0.26,0.16,0.47,0.0,0.05,0.0,0.0,0.05,yisu jia,STAT-3090,2017
-STAT,3300,1,Statistical Methods II,0.38,0.44,0.06,0.0,0.06,0.0,0.0,0.06,ros martinez-dawson,STAT-3300,2017
-STAT,4020,1,Intro to Statistical Computing,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,ellen hepfe breazel,STAT-4020,2017
-STAT,4110,1,Stat Mthds for Process Control,0.82,0.11,0.05,0.0,0.02,0.0,0.0,0.0,richard stev dubsky,STAT-4110,2017
-STAT,4110,2,Stat Mthds for Process Control,0.85,0.12,0.02,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,STAT-4110,2017
-STAT,4110,3,Stat Mthds for Process Control,0.64,0.27,0.06,0.03,0.0,0.0,0.0,0.0,richard stev dubsky,STAT-4110,2017
-STAT,6020,1,Intro to Statistical Computing,0.33,0.25,0.08,0.0,0.0,0.0,0.0,0.33,ellen hepfe breazel,STAT-6020,2017
-STAT,8010,1,Statistical Methods I,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,james rieck,STAT-8010,2017
-STAT,8010,2,Statistical Methods I,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,patrick gerard,STAT-8010,2017
-STAT,8010,3,Statistical Methods I,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,joseph daniel bible,STAT-8010,2017
-STAT,8010,4,Statistical Methods I,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,STAT-8010,2017
-STAT,8010,5,Statistical Methods I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jun luo,STAT-8010,2017
-STAT,8010,6,Statistical Methods I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,brook thaye russell,STAT-8010,2017
-STAT,8010,7,Statistical Methods I,0.44,0.33,0.17,0.0,0.06,0.0,0.0,0.0,james rieck,STAT-8010,2017
-STAT,8020,1,Statistical Methods II,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,brook thaye russell,STAT-8020,2017
-STAT,8030,1,Regress & Least Squares Anlys,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,jun luo,STAT-8030,2017
-STAT,8170,400,Multivariate Statistics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,STAT-8170,2017
-STS,1010,1,Survey of S T S,0.68,0.27,0.0,0.0,0.03,0.0,0.0,0.03,kenneth dav widgren,STS-1010,2017
-STS,1010,2,Survey of S T S,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,scott brame,STS-1010,2017
-STS,1010,3,Survey of S T S,0.51,0.32,0.03,0.0,0.05,0.0,0.0,0.08,elizabeth stansell,STS-1010,2017
-STS,1010,5,Survey of S T S,0.47,0.39,0.14,0.0,0.0,0.0,0.0,0.0,philip randall,STS-1010,2017
-STS,1010,6,Survey of S T S,0.4,0.23,0.17,0.09,0.0,0.0,0.0,0.11,sarah mae cooper,STS-1010,2017
-STS,1010,7,Survey of S T S,0.5,0.14,0.28,0.0,0.06,0.0,0.0,0.03,megan no macalystre,STS-1010,2017
-STS,1010,8,Survey of S T S,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,david charles foltz,STS-1010,2017
-STS,1010,9,Survey of S T S,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,melissa dugan,STS-1010,2017
-THEA,2100,1,Theatre Appreciation,0.53,0.19,0.16,0.0,0.03,0.0,0.0,0.09,kendra lyne johnson,THEA-2100,2017
-THEA,2100,2,Theatre Appreciation,0.81,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kerrie kath seymour,THEA-2100,2017
-THEA,2100,3,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,THEA-2100,2017
-THEA,2100,4,Theatre Appreciation,0.81,0.13,0.03,0.03,0.0,0.0,0.0,0.0,richard st. peter,THEA-2100,2017
-THEA,2100,5,Theatre Appreciation,0.81,0.13,0.03,0.0,0.0,0.0,0.0,0.03,carol collins,THEA-2100,2017
-THEA,2100,6,Theatre Appreciation,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,THEA-2100,2017
-THEA,2100,7,Theatre Appreciation,0.53,0.28,0.13,0.0,0.0,0.0,0.0,0.06,jason adkins,THEA-2100,2017
-THEA,2670,1,Stage Makeup,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,THEA-2670,2017
-THEA,2790,1,Theatre Practicum,0.38,0.25,0.0,0.0,0.06,0.0,0.0,0.31,matthew leckenbusch,THEA-2790,2017
-THEA,2880,1,Intro to Cad,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,THEA-2880,2017
-THEA,3150,1,Theatre History I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,richard st. peter,THEA-3150,2017
-THEA,3170,1,African-Amer Thea I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-3170,2017
-THEA,3470,1,Structure of Drama,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-3470,2017
-THEA,3980,1,Special Topics in Theatre,0.57,0.21,0.14,0.0,0.0,0.0,0.0,0.07,kerrie kath seymour,THEA-3980,2017
-THEA,4870,1,Stage Lighting I,0.33,0.42,0.08,0.0,0.08,0.0,0.0,0.08,anthony penna,THEA-4870,2017
-WFB,3000,1,Wildlife Biology,0.48,0.27,0.17,0.03,0.02,0.0,0.0,0.03,catherine jachowski,WFB-3000,2017
-WFB,3000,2,Wildlife Biology,0.45,0.35,0.14,0.02,0.01,0.0,0.0,0.02,catherine jachowski,WFB-3000,2017
-WFB,3010,2,Wildlife Biology Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2017
-WFB,4100,2,Wildlife Management Techniques,0.25,0.54,0.13,0.07,0.0,0.0,0.0,0.02,james davis,WFB-4100,2017
-WFB,4180,1,Fisheries Mgt & Conservation,0.67,0.19,0.11,0.0,0.0,0.0,0.0,0.04,troy mason farmer,WFB-4180,2017
-WFB,4440,1,Wildlife Damage Management,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,james davis,WFB-4440,2017
-WFB,4720,1,Ornithology,0.42,0.25,0.17,0.08,0.0,0.0,0.0,0.08,neil smith,WFB-4720,2017
-WFB,4770,1,Ichthyology,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,brandon kev peoples,WFB-4770,2017
-WFB,4930,2,Plant & Flora ID/Systematics,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,patrick mcmillan,WFB-4930,2017
-WFB,4930,3,Waterfowl Ecology,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,WFB-4930,2017
-WFB,8180,2,Waterfowl Ecology & Mgt,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,WFB-8180,2017
-WFB,8530,2,Global Change Ecology,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,lydia ri 'halloran,WFB-8530,2017
-WS,1030,1,Women in Global Perspective,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,laura foxworth,WS-1030,2017
-WS,1030,2,Women in Global Perspective,0.67,0.13,0.1,0.07,0.0,0.0,0.0,0.03,laura foxworth,WS-1030,2017
-WS,2300,1,Women and Leadership I,0.68,0.16,0.08,0.0,0.04,0.0,0.0,0.04,mary price,WS-2300,2017
-WS,3010,1,Intro Women's Studies,0.58,0.35,0.03,0.0,0.03,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2017
-WS,3010,2,Intro Women's Studies,0.48,0.41,0.03,0.0,0.0,0.0,0.0,0.07,elizabeth ros adams,WS-3010,2017
-YDP,3000,400,Youth Development in Society,0.54,0.33,0.0,0.08,0.04,0.0,0.0,0.0,barry garst,YDP-3000,2017
-YDP,3050,400,Theory/Phil of Youth Dev Work,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,edmond patri bowers,YDP-3050,2017
-YDP,3200,1,Youth Dev in Sport/Phys Activ,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,lauren eli stephens,YDP-3200,2017
-YDP,3300,1,Designing Effective Youth Prog,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,kellye rembert,YDP-3300,2017
-YDP,3350,1,Youth Activity Leadership,0.5,0.17,0.17,0.11,0.06,0.0,0.0,0.0,allison mic avishai,YDP-3350,2017
-YDP,3450,1,Creative Activities for Youth,0.87,0.0,0.09,0.04,0.0,0.0,0.0,0.0,kimberly pe johnson,YDP-3450,2017
-YDP,8000,1,Theories of Youth Development,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,YDP-8000,2017
-YDP,8030,1,Creative & Ethical Leadership,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,barry garst,YDP-8030,2017
-YDP,8050,1,Youth Dev in Context of Family,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,YDP-8050,2017
-YDP,8060,1,Youth Dev in Global Society,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,ann marie gillard,YDP-8060,2017
-YDP,8060,2,Youth Dev in Global Society,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,ann marie gillard,YDP-8060,2017
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1010,1,Survey of Art & Arch History I,0.4,0.45,0.1,0.0,0.01,0.0,0.0,0.05,beth ann lauritis,
+AAH,1010,2,Surv of Art & Arch I (HON),0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,beth ann lauritis,True
+AAH,2050,1,Art History and Theory I,0.79,0.15,0.0,0.0,0.06,0.0,0.0,0.0,beth ann lauritis,
+AAH,3050,1,Contemporary Art History,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
+ACCT,2010,1,Financial Accounting Concepts,0.18,0.35,0.2,0.12,0.08,0.0,0.0,0.06,emily suza mccorkle,
+ACCT,2010,2,Financial Accounting Concepts,0.21,0.44,0.25,0.04,0.04,0.0,0.0,0.02,emily suza mccorkle,
+ACCT,2010,3,Financial Accounting Concepts,0.3,0.43,0.11,0.04,0.04,0.0,0.0,0.09,lydia lan schleifer,
+ACCT,2010,4,Financial Accounting Concepts,0.28,0.33,0.22,0.09,0.0,0.0,0.0,0.09,emily suza mccorkle,
+ACCT,2010,5,Financial Accounting Concepts,0.34,0.24,0.28,0.08,0.04,0.0,0.0,0.02,annieka philo,
+ACCT,2010,6,Financial Accounting Concepts,0.33,0.31,0.13,0.1,0.04,0.0,0.0,0.08,lydia lan schleifer,
+ACCT,2010,7,Financial Accounting Concepts,0.24,0.37,0.2,0.1,0.08,0.0,0.0,0.0,annieka philo,
+ACCT,2010,8,Financial Accounting Concepts,0.24,0.39,0.12,0.06,0.1,0.0,0.0,0.08,lydia lan schleifer,
+ACCT,2010,9,Financial Accounting Concepts,0.21,0.56,0.13,0.02,0.08,0.0,0.0,0.0,annieka philo,
+ACCT,2010,10,Financial Accounting Concepts,0.36,0.3,0.22,0.02,0.04,0.0,0.0,0.06,annieka philo,
+ACCT,2010,11,Financial Accounting Concepts,0.29,0.43,0.16,0.08,0.02,0.0,0.0,0.02,rebecca pennel trax,
+ACCT,2010,12,Financial Accounting Concepts,0.3,0.26,0.23,0.09,0.06,0.0,0.0,0.06,rebecca pennel trax,
+ACCT,2010,13,Financial Accounting Concepts,0.22,0.35,0.17,0.13,0.09,0.0,0.0,0.04,charles tegen,
+ACCT,2010,14,Financial Accounting Concepts,0.27,0.41,0.18,0.04,0.08,0.0,0.0,0.02,lisa whe birtwistle,
+ACCT,2010,100,Fin Accounting Concepts (HON),0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,lisa whe birtwistle,True
+ACCT,2010,400,Financial Accounting Concepts,0.29,0.34,0.19,0.1,0.05,0.0,0.0,0.02,emily suza mccorkle,
+ACCT,2020,1,Managerial Accounting Concepts,0.36,0.22,0.22,0.02,0.0,0.0,0.0,0.18,henry anderson,
+ACCT,2020,2,Managerial Accounting Concepts,0.36,0.3,0.1,0.0,0.06,0.0,0.0,0.18,henry anderson,
+ACCT,2020,3,Managerial Accounting Concepts,0.28,0.28,0.13,0.02,0.06,0.0,0.0,0.23,henry anderson,
+ACCT,2020,4,Managerial Accounting Concepts,0.29,0.31,0.18,0.07,0.04,0.0,0.0,0.11,phebia davis-culler,
+ACCT,2020,5,Managerial Accounting Concepts,0.28,0.15,0.2,0.22,0.11,0.0,0.0,0.04,phebia davis-culler,
+ACCT,2020,6,Managerial Accounting Concepts,0.21,0.09,0.38,0.09,0.15,0.0,0.0,0.09,phebia davis-culler,
+ACCT,2020,7,Managerial Accounting Concepts,0.09,0.27,0.24,0.11,0.07,0.0,0.0,0.22,brian todd carver,
+ACCT,2020,8,Managerial Accounting Concepts,0.16,0.19,0.23,0.07,0.14,0.0,0.0,0.21,brian todd carver,
+ACCT,2020,400,Managerial Accounting Concepts,0.35,0.24,0.15,0.03,0.04,0.0,0.0,0.19,henry anderson,
+ACCT,3030,1,Cost Accounting,0.32,0.41,0.18,0.0,0.02,0.0,0.0,0.07,robin radtke,
+ACCT,3030,2,Cost Accounting,0.32,0.32,0.26,0.03,0.08,0.0,0.0,0.0,robin radtke,
+ACCT,3030,3,Cost Accounting,0.23,0.34,0.27,0.09,0.0,0.0,0.0,0.07,jace garrett,
+ACCT,3030,4,Cost Accounting,0.2,0.33,0.16,0.13,0.11,0.0,0.0,0.07,jace garrett,
+ACCT,3110,1,Intermediate Financial Acct I,0.33,0.42,0.18,0.02,0.04,0.0,0.0,0.0,amy meliss donnelly,
+ACCT,3110,2,Intermediate Financial Acct I,0.32,0.28,0.28,0.1,0.02,0.0,0.0,0.0,amy meliss donnelly,
+ACCT,3110,3,Intermediate Financial Acct I,0.53,0.24,0.18,0.04,0.0,0.0,0.0,0.0,erin michel hawkins,
+ACCT,3110,4,Intermediate Financial Acct I,0.28,0.33,0.33,0.04,0.02,0.0,0.0,0.0,erin michel hawkins,
+ACCT,3110,400,Intermediate Financial Acct I,0.32,0.32,0.13,0.04,0.08,0.0,0.0,0.11,henry anderson,
+ACCT,3120,1,Intermediate Financial Acct II,0.14,0.5,0.14,0.07,0.0,0.0,0.0,0.14,terry daniel knause,
+ACCT,3120,2,Intermediate Financial Acct II,0.14,0.32,0.41,0.05,0.09,0.0,0.0,0.0,jeremy micha vinson,
+ACCT,3120,3,Intermediate Financial Acct II,0.63,0.16,0.16,0.05,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3120,4,Intermediate Financial Acct II,0.18,0.43,0.3,0.08,0.0,0.0,0.0,0.03,jeremy micha vinson,
+ACCT,3120,5,Intermediate Financial Acct II,0.45,0.33,0.2,0.03,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3120,6,Intermediate Financial Acct II,0.43,0.43,0.1,0.05,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3130,1,Intermediate Fin Acct III,0.22,0.22,0.28,0.08,0.11,0.0,0.0,0.08, russell madray,
+ACCT,3130,2,Intermediate Fin Acct III,0.25,0.39,0.2,0.09,0.02,0.0,0.0,0.05, russell madray,
+ACCT,3130,3,Intermediate Fin Acct III,0.37,0.29,0.2,0.1,0.0,0.0,0.0,0.05, russell madray,
+ACCT,3130,4,Intermediate Fin Acct III,0.33,0.33,0.21,0.05,0.05,0.0,0.0,0.02, russell madray,
+ACCT,3220,1,Accounting Information Systems,0.11,0.42,0.26,0.0,0.05,0.0,0.0,0.16,philip maiberger,
+ACCT,3220,2,Accounting Information Systems,0.06,0.19,0.25,0.31,0.0,0.0,0.0,0.19,philip maiberger,
+ACCT,3220,3,Accounting Information Systems,0.12,0.42,0.28,0.12,0.02,0.0,0.0,0.05,nancy lee harp,
+ACCT,3220,4,Accounting Information Systems,0.17,0.36,0.24,0.07,0.1,0.0,0.0,0.07,nancy lee harp,
+ACCT,4040,1,Individual Taxation,0.33,0.33,0.18,0.08,0.03,0.0,0.0,0.05,derek dalton,
+ACCT,4040,2,Individual Taxation,0.8,0.11,0.06,0.03,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,3,Individual Taxation,0.72,0.21,0.08,0.0,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4080,1,Retire & Estate Plan,0.32,0.42,0.16,0.05,0.0,0.0,0.0,0.05,john hine,
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.16,0.55,0.13,0.13,0.0,0.0,0.0,0.03,sally kathr widener,
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.38,0.41,0.21,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
+ACCT,4150,1,Auditing,0.34,0.39,0.21,0.05,0.0,0.0,0.0,0.0,carl hollingsworth,
+ACCT,4150,2,Auditing,0.19,0.38,0.29,0.1,0.05,0.0,0.0,0.0,carl hollingsworth,
+ACCT,8510,1,Tax Research,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8510,2,Tax Research,0.26,0.74,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8510,3,Tax Research,0.61,0.37,0.0,0.0,0.0,0.0,0.0,0.02,thomas dickens,
+ACCT,8530,1,Adv Acct Problems,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8530,2,Adv Acct Problems,0.61,0.34,0.02,0.0,0.0,0.0,0.0,0.02,ralph welton,
+ACCT,8530,3,Adv Acct Problems,0.48,0.39,0.06,0.0,0.03,0.0,0.0,0.03,ralph welton,
+ACCT,8550,1,Gov't and Nonprofit Accounting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8550,2,Gov't and Nonprofit Accounting,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,james barnes,
+ACCT,8630,1,Forensics Analysis,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,philip maiberger,
+ACCT,8630,2,Forensics Analysis,0.38,0.59,0.03,0.0,0.0,0.0,0.0,0.0,philip maiberger,
+ACCT,8650,1,Tax & Bus Decisions,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
+ACCT,8720,1,Tax of Flowthroughs,0.34,0.48,0.16,0.0,0.0,0.0,0.0,0.02,thomas dickens,
+AGED,1020,1,Freshman Seminar,0.76,0.12,0.06,0.0,0.0,0.0,0.0,0.06,catheri dibenedetto,
+AGED,2000,1,Agr Appl of Ed Tech,0.67,0.17,0.1,0.0,0.0,0.0,0.0,0.07,kevin layfield,
+AGED,2010,1,Intro to Agric Educ,0.59,0.37,0.0,0.0,0.0,0.0,0.0,0.04,philip fravel,
+AGED,2040,1,App Ag Calculations,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,3030,1,Ag Ed Mech Tech,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGED,4000,1,Supervised Field Experience II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,4010,1,Instr Methods Ag Ed,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,
+AGED,4030,1,Prin Adult/Ext Ed,0.41,0.29,0.18,0.06,0.0,0.0,0.0,0.06,alex byrd,
+AGED,4230,400,Curriculum,0.17,0.5,0.33,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,
+AGED,6030,1,Prin Adult/Ext Ed,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGM,1010,1,Intro Ag Mech & Bus,0.71,0.15,0.08,0.02,0.04,0.0,0.0,0.0,hunter massey,
+AGM,2050,1,Prin of Fabrication,0.3,0.54,0.09,0.02,0.02,0.0,0.0,0.04,hunter massey,
+AGM,2060,1,Machinery Mgt,0.38,0.33,0.19,0.05,0.05,0.0,0.0,0.0,hunter massey,
+AGM,2210,1,Land Measurements,0.26,0.56,0.17,0.01,0.0,0.0,0.0,0.0,charles privette,
+AGM,3010,1,Soil Water Conserv,0.47,0.31,0.18,0.04,0.0,0.0,0.0,0.0,calvin sawyer,
+AGM,4000,1,Seminar in Ag Mech & Business,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,john chastain,
+AGM,4020,1,Irrigation System Design,0.23,0.43,0.27,0.03,0.03,0.0,0.0,0.0,charles privette,
+AGM,4050,1,Env Cont in Anim Str,0.12,0.34,0.46,0.02,0.05,0.0,0.0,0.0,john chastain,
+AGM,4060,1,Mech & Hydraulic Sys,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4520,1,Mobile Power,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4600,1,Electrical Systems,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,young han,
+AGRB,2020,1,Agricultural Economics,0.17,0.27,0.29,0.12,0.1,0.0,0.0,0.06,george apperson,
+AGRB,2020,2,Agricultural Economics,0.12,0.42,0.15,0.18,0.09,0.0,0.0,0.03,george apperson,
+AGRB,2050,1,Agriculture and Society,0.2,0.29,0.45,0.04,0.02,0.0,0.0,0.0,michael vassalos,
+AGRB,3020,1,Economics of Farm Management,0.18,0.28,0.3,0.21,0.01,0.0,0.0,0.02,michael vassalos,
+AGRB,3080,1,Quant Agribusiness Analysis I,0.25,0.33,0.24,0.13,0.04,0.0,0.0,0.01,lisha zhang,
+AGRB,3090,1,Econ of Agricultural Marketing,0.5,0.38,0.08,0.02,0.02,0.0,0.0,0.0,yuliya val bolotova,
+AGRB,3190,1,Agribusiness Management,0.28,0.23,0.18,0.13,0.08,0.0,0.0,0.1,michael vassalos,
+AGRB,3570,1,Natural Resources Economics,0.2,0.18,0.27,0.13,0.09,0.0,0.0,0.13,david brian willis,
+AGRB,4090,1,Commodity Futures Markets,0.16,0.24,0.3,0.19,0.11,0.0,0.0,0.0,george apperson,
+AGRB,4120,1,Reg Econ Devel Theory & Policy,0.57,0.31,0.1,0.0,0.0,0.0,0.0,0.02,lori ann dickes,
+AGRB,4600,1,Agricultural Finance,0.2,0.43,0.33,0.05,0.0,0.0,0.0,0.0,lisha zhang,
+AL,3490,400,Principles of Coaching,0.66,0.21,0.07,0.03,0.0,0.0,0.0,0.03,deborah cadorette,
+AL,3490,401,Principles of Coaching,0.52,0.37,0.07,0.04,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,403,Principles of Coaching,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,3490,404,Principles of Coaching,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,edmond fry,
+AL,3500,400,Sci Basis I/Ex Phy,0.12,0.36,0.2,0.12,0.04,0.0,0.0,0.16,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.29,0.25,0.25,0.13,0.0,0.0,0.0,0.08,michael godfrey,
+AL,3530,400,Athletic Injuries,0.42,0.21,0.29,0.08,0.0,0.0,0.0,0.0,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.11,0.44,0.22,0.11,0.11,0.0,0.0,0.0,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.27,0.27,0.0,0.07,0.0,0.0,0.07,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,henry oates,
+AL,3610,401,Admin/Org of Athletic Programs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,Admin/Org of Athletic Programs,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3620,400,Psychology of Coaching,0.65,0.18,0.06,0.0,0.0,0.0,0.0,0.12,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.41,0.12,0.24,0.18,0.06,0.0,0.0,0.0,natalie anne carter,
+AL,3620,402,Psychology of Coaching,0.29,0.54,0.08,0.04,0.0,0.0,0.0,0.04,natalie anne carter,
+AL,3740,400,Coaching Football,0.78,0.09,0.04,0.0,0.04,0.0,0.0,0.04,edmond fry,
+AL,3760,400,Coaching Strength/Conditioning,0.79,0.13,0.0,0.04,0.04,0.0,0.0,0.0,edmond fry,
+AL,3760,401,Coaching Strength/Conditioning,0.71,0.0,0.21,0.0,0.07,0.0,0.0,0.0,edmond fry,
+AL,4380,402,Coaching the Inner Athlete,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
+AL,4380,403,Media Relations in AL,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,4380,404,Coaching the Inner Athlete,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,4380,408,Officiating in AL,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,8440,400,Surv of Res Mthds in Athletics,0.82,0.06,0.12,0.0,0.0,0.0,0.0,0.0,russell marion,
+AL,8440,401,Surv of Res Mthds in Athletics,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,russell marion,
+AL,8490,401,Athletic Leadership Dev,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,michael godfrey,
+AL,8500,400,Principles Strength and Condit,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8500,401,Principles Strength and Condit,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,michael godfrey,
+AL,8650,400,Mkt and Comm Respon Interc Ath,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,misty soles,
+ANTH,2010,1,Introduction to Anthropology,0.06,0.23,0.28,0.16,0.11,0.0,0.0,0.17,john coggeshall,
+ANTH,2010,2,Introduction to Anthropology,0.0,0.24,0.29,0.24,0.12,0.0,0.0,0.12,john coggeshall,
+ANTH,2010,3,Introduction to Anthropology,0.44,0.37,0.11,0.02,0.02,0.0,0.0,0.04,yi wu,
+ANTH,2010,4,Introduction to Anthropology,0.46,0.2,0.15,0.09,0.06,0.0,0.0,0.04,yi wu,
+ANTH,2010,5,Introduction to Anthropology,0.4,0.37,0.1,0.02,0.03,0.0,0.0,0.08,lisa rapaport,
+ANTH,3010,1,Cultural Anthropology,0.04,0.32,0.44,0.04,0.0,0.0,0.0,0.16,john coggeshall,
+ANTH,3320,1,World Archaeology,0.72,0.11,0.0,0.11,0.06,0.0,0.0,0.0,elizabeth wakefield,
+ANTH,3510,1,Biological Anthropology,0.16,0.21,0.32,0.26,0.05,0.0,0.0,0.0,lisa rapaport,
+ANTH,3530,1,Forensic Anthropology,0.25,0.45,0.3,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
+ANTH,3710,1,Language and Culture,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,yanhua zhang,
+ANTH,4230,1,Women in the Developing World,0.64,0.27,0.0,0.09,0.0,0.0,0.0,0.0,melissa vogel,
+ARCH,1010,1,Intro to Architecture,0.63,0.17,0.07,0.02,0.02,0.0,0.0,0.09,sal hambright-belue,
+ARCH,2040,1,Hist of Modern Arch,0.33,0.51,0.14,0.02,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,2510,1,Arch Foundations I,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,2510,2,Arch Foundations I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,2510,3,Arch Foundations I,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2510,4,Arch Foundations I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,2510,5,Arch Foundations I,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,criss mills,
+ARCH,2700,1,Structures I,0.28,0.59,0.1,0.03,0.0,0.0,0.0,0.0,dustin gra albright,
+ARCH,3500,1,Intro to Urban Contexts,0.29,0.5,0.14,0.07,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,3500,2,Intro to Urban Contexts,0.25,0.17,0.42,0.17,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,3500,3,Intro to Urban Contexts,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,3500,4,Intro to Urban Contexts,0.08,0.42,0.42,0.08,0.0,0.0,0.0,0.0,george schafer,
+ARCH,3500,5,Intro to Urban Contexts,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,3510,2,Studio Clemson,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,
+ARCH,3540,1,Studio Barcelona,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4010,1,Architectural Portfolio,0.62,0.19,0.1,0.0,0.05,0.0,0.0,0.05,clarissa mendez,
+ARCH,4010,2,Architectural Portfolio,0.43,0.24,0.29,0.0,0.0,0.0,0.0,0.05,herminia sil machry,
+ARCH,4010,3,Architectural Portfolio,0.36,0.59,0.0,0.05,0.0,0.0,0.0,0.0,george schafer,
+ARCH,6240,1,Product Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,6850,1,H/Th: Arch+Health,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8100,1,Visualization I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
+ARCH,8210,1,Research Methods,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8410,1,Arch Studio I,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,peter laurence,
+ARCH,8410,2,Arch Studio I,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,andreea mihalache,
+ARCH,8510,2,Design Studio III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8510,3,Design Studio III,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,8570,6,Design Studio V,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,8600,1,History/Theory I,0.17,0.75,0.08,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,8720,1,Production & Assemb,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,
+ARCH,8810,1,Pro Practice Survey,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,katherin schwennsen,
+ARCH,8860,1,Health Facilities,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ARCH,8890,1,Mentorship,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley jennings,
+ARCH,8970,1,A+H Studio: Hospital,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ART,1050,1,Foundation Drawing I,0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,kathleen ann thum,
+ART,1510,1,Foundations Art I,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,kymberly ann day,
+ART,2070,1,Beginning Painting,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,dustin lee massey,
+ART,2100,400,Art Appreciation,0.57,0.25,0.14,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,
+ART,2100,401,Art Appreciation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lydia jane dorsey,
+ART,2100,402,Art Appreciation,0.68,0.18,0.04,0.0,0.07,0.0,0.0,0.04,lydia jane dorsey,
+ART,2100,403,Art Appreciation,0.32,0.43,0.14,0.0,0.04,0.0,0.0,0.07,lydia jane dorsey,
+ART,2110,1,Begin Printmaking,0.56,0.31,0.06,0.0,0.06,0.0,0.0,0.0,mandy lora ferguson,
+ART,2130,1,Begin Photography,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,amber nic eckersley,
+ART,2210,1,Beginning New Media,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,christina nguy hung,
+ART,8210,1,Visual Narrative,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david stewart donar,
+AS,1090,1,Air Force Today I,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,michael allen moore,
+AS,1090,2,Air Force Today I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,1090,3,Air Force Today I,0.37,0.58,0.0,0.0,0.0,0.0,0.0,0.05,michael allen moore,
+AS,2090,2,Dev of Air Power I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,brock lusk,
+AS,2090,3,Dev of Air Power I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,3090,2,A F Leadership Mgt I,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,rachelle mar miller,
+AS,4090,1,Nat Sec Policy I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+ASL,1010,1,Am Sign Lang I,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jason hurdich,
+ASL,1010,2,Am Sign Lang I,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,1010,3,Am Sign Lang I,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,william ry clements,
+ASL,1010,5,Am Sign Lang I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,william ry clements,
+ASL,1020,1,Am Sign Lang I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2010,1,Am Sign Lang II,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,2010,2,Am Sign Lang II,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,jason hurdich,
+ASL,2010,3,Am Sign Lang II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william ry clements,
+ASL,2010,4,Am Sign Lang II,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william ry clements,
+ASL,3010,1,Advanced A S L I,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kim ma misener dunn,
+ASTR,1010,1,Solar System Astronomy,0.36,0.41,0.1,0.05,0.05,0.0,0.0,0.02,amber porter,
+ASTR,1010,2,Solar System Astronomy,0.41,0.37,0.13,0.02,0.05,0.0,0.0,0.02,amber porter,
+ASTR,1020,1,Stellar Astronomy,0.24,0.38,0.26,0.05,0.01,0.0,0.0,0.05,marco ajello,
+ASTR,1030,1,Solar Systm Astr Lab,0.64,0.27,0.0,0.0,0.05,0.0,0.0,0.05,amber porter,
+ASTR,1030,2,Solar Systm Astr Lab,0.78,0.09,0.04,0.04,0.0,0.0,0.0,0.04,amber porter,
+ASTR,1030,3,Solar Systm Astr Lab,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,amber porter,
+ASTR,1030,4,Solar Systm Astr Lab,0.67,0.17,0.13,0.0,0.0,0.0,0.0,0.04,amber porter,
+ASTR,1030,5,Solar Systm Astr Lab,0.23,0.64,0.05,0.09,0.0,0.0,0.0,0.0,amber porter,
+ASTR,1030,6,Solar Systm Astr Lab,0.57,0.26,0.13,0.0,0.0,0.0,0.0,0.04,amber porter,
+ASTR,1030,7,Solar Systm Astr Lab,0.5,0.28,0.06,0.06,0.0,0.0,0.0,0.11,amber porter,
+ASTR,1030,8,Solar Systm Astr Lab,0.26,0.53,0.16,0.05,0.0,0.0,0.0,0.0,amber porter,
+ASTR,1030,9,Solar Systm Astr Lab,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,amber porter,
+ASTR,1030,10,Solar Systm Astr Lab,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,amber porter,
+ASTR,1040,1,Stellar Astr Lab,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,amber porter,
+ASTR,1040,2,Stellar Astr Lab,0.52,0.3,0.0,0.0,0.09,0.0,0.0,0.09,amber porter,
+ASTR,1040,4,Stellar Astr Lab,0.41,0.37,0.11,0.04,0.0,0.0,0.0,0.07,amber porter,
+ASTR,8100,1,Astroph I: Radiation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+AUD,1850,1,Intro to Audio Tech,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUD,2800,1,Sound Reinforcement,0.0,0.17,0.75,0.08,0.0,0.0,0.0,0.0,kenneth moore,
+AUE,4010,1,Vehicle Dynamics,0.3,0.5,0.1,0.0,0.1,0.0,0.0,0.0,imtiaz ul haque,
+AUE,4030,1,Automotive Engr Project Tools,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,andrej ivanco,
+AUE,8180,1,"Engine Analysis, Design & Exp",0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8260,1,Vehicle Diagnostics,0.34,0.54,0.11,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8270,5,Auto Cntrl Sys Des,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8280,1,Driveline/Powertrain,0.61,0.26,0.13,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8330,30,Auto Manuf Proc Devl,0.18,0.74,0.08,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8350,100,Auto Electronics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,
+AUE,8670,1,Veh Manuf Proc I,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8810,3,Automotive Systems Overview,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
+AUE,8870,8,Meth Vehicle Testing,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8930,16,Light-Weight Automotive Design,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,david wil schmueser,
+AUE,8930,18,Adv IC Engine Concept,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,8930,19,Autovation II: Tech Enterp Dev,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
+AUE,8930,89,Manufacturing,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,
+AVS,1000,1,Orientation to AVS,0.92,0.05,0.01,0.01,0.0,0.0,0.0,0.01,marie owens bolt,
+AVS,1500,1,Intro Animal Science,0.2,0.4,0.21,0.09,0.06,0.0,0.0,0.03,joseph kei bertrand,
+AVS,1510,1,Intro Ani Sci Lab,0.46,0.46,0.04,0.0,0.0,0.0,0.0,0.04,richelle lor miller,
+AVS,1510,2,Intro Ani Sci Lab,0.68,0.2,0.04,0.0,0.0,0.0,0.0,0.08,richelle lor miller,
+AVS,1510,3,Intro Ani Sci Lab,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,1510,4,Intro Ani Sci Lab,0.77,0.09,0.09,0.0,0.0,0.0,0.0,0.05,chelsea dr sinclair,
+AVS,1510,5,Intro Ani Sci Lab,0.72,0.24,0.0,0.04,0.0,0.0,0.0,0.0,marie owens bolt,
+AVS,1510,6,Intro Ani Sci Lab,0.71,0.21,0.04,0.04,0.0,0.0,0.0,0.0,marie owens bolt,
+AVS,1510,7,Intro Ani Sci Lab,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,chelsea dr sinclair,
+AVS,1510,8,Intro Ani Sci Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
+AVS,2020,1,CAFLS Plus,0.91,0.05,0.0,0.0,0.05,0.0,0.0,0.0,thomas scott,
+AVS,2030,1,Dairy Sci Techniques,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,heather walker dunn,
+AVS,2040,1,Horse Care Techniques,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,2060,1,Swine Techniques,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3010,1,Anat & Phys Dom Ani,0.42,0.34,0.21,0.03,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,3010,400,Anat & Phys Dom Ani,0.27,0.31,0.29,0.12,0.0,0.0,0.0,0.02,glenn birrenkott,
+AVS,3020,1,Livestk Sel Eval I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3100,1,Animal Health,0.52,0.33,0.16,0.0,0.0,0.0,0.0,0.0,celina marc checura,
+AVS,3700,1,Principles of Animal Nutrition,0.68,0.19,0.08,0.03,0.01,0.0,0.0,0.0,james ro strickland,
+AVS,3750,1,Applied Animal Nutrition,0.38,0.38,0.13,0.06,0.0,0.0,0.0,0.06,gustavo jos lascano,
+AVS,3850,1,Equine Behavior and Training,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,chelsea dr sinclair,
+AVS,4000,1,AVS Professional Development,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
+AVS,4000,2,AVS Professional Development,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
+AVS,4060,1,Seminars & Related Topics,0.57,0.37,0.07,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4060,2,Seminars & Related Topics,0.13,0.69,0.19,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4110,1,Animal Growth and Development,0.59,0.21,0.14,0.03,0.03,0.0,0.0,0.0,susan kay duckett,
+AVS,4150,1,Contemporary Issues in AVS,0.3,0.33,0.19,0.05,0.05,0.0,0.0,0.09,peter skewes,
+AVS,4160,1,Equine Exercise Phys,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,4500,1,Sust Livestock Sys,0.36,0.57,0.0,0.0,0.0,0.0,0.0,0.07,matias jose aguerre,
+AVS,4530,1,Animal Reproduction,0.54,0.32,0.11,0.04,0.0,0.0,0.0,0.0,tiffany wilmoth,
+AVS,4650,1,Animal Physiology I,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,celina marc checura,
+AVS,4800,1,Vertebrate Endocrinology,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,6650,1,Animal Physiology I,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,celina marc checura,
+BCHM,1030,1,Careers in Bioch/Gen,0.88,0.07,0.0,0.01,0.03,0.0,0.0,0.01,joseph paul thames,
+BCHM,3010,1,Molecular Biochemistry,0.35,0.26,0.13,0.06,0.06,0.0,0.0,0.13,kerry smith,
+BCHM,3050,1,Essen Elements Bioch,0.65,0.23,0.07,0.01,0.01,0.0,0.0,0.03,debra ragland,
+BCHM,3050,2,Essen Elements Bioch,0.43,0.34,0.14,0.02,0.01,0.0,0.0,0.05,debra ragland,
+BCHM,4310,1,Physical Approach to Biochem,0.24,0.43,0.3,0.04,0.0,0.0,0.0,0.0,weiguo cao,
+BCHM,4310,2,Phys App to Bioch (HON),0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,weiguo cao,True
+BCHM,4330,1,Physical Biochemistry Lab,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,4400,1,Bioinformatics,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,frank alexan feltus,
+BCHM,4430,1,Mol Basis Disease,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,james morris,
+BCHM,8140,1,Advanced Biochemistry,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,cheryl ingram-smith,
+BE,2120,1,Fundamentals of Biosys Engr,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,caye marie drapcho,
+BE,3200,1,Principles & Prac of Geomatics,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4100,1,Biological Kinetics,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,4210,1,Engr Sys for Soil Water Mgt,0.67,0.27,0.0,0.07,0.0,0.0,0.0,0.0,christophe darnault,
+BE,4280,1,Biochem Engr,0.33,0.33,0.25,0.08,0.0,0.0,0.0,0.0,terry walker,
+BE,4740,1,BE Design Project Managment,0.73,0.15,0.12,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4750,1,BE Capstone Design,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BIOE,2010,1,Intro Biomed Engr,0.25,0.5,0.06,0.0,0.0,0.0,0.0,0.19,charles webb,
+BIOE,2010,2,Intro Biomed Engr,0.46,0.39,0.05,0.01,0.01,0.0,0.0,0.08,charles webb,
+BIOE,3020,1,Biomaterials,0.61,0.27,0.04,0.04,0.04,0.0,0.0,0.02,alexey ale vertegel,
+BIOE,3100,1,Engr Analysis of Physiol Proc,0.55,0.43,0.01,0.0,0.0,0.0,0.0,0.0,brian william booth,
+BIOE,3200,1,Biomechanics,0.74,0.22,0.0,0.01,0.0,0.0,0.0,0.03,jiro nagatomi,
+BIOE,3210,1,Biofluid Mechanics,0.55,0.33,0.09,0.0,0.0,0.0,0.0,0.03,zhi gao,
+BIOE,3700,1,Bioinst & Imaging,0.67,0.24,0.03,0.0,0.0,0.0,0.0,0.06,delphine dean,
+BIOE,4010,1,Bioengineering Design Theory,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,john desjardins,
+BIOE,4010,2,Bioengineering Design Theory,0.95,0.03,0.03,0.0,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4030,1,Applied Bio E Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,
+BIOE,4120,1,Orthopaedic Engr and Pathology,0.5,0.35,0.1,0.0,0.0,0.0,0.0,0.05,melinda harman,
+BIOE,4400,1,Biopharmaceutical Engineering,0.45,0.45,0.05,0.0,0.0,0.0,0.0,0.05,sarah harcum,
+BIOE,4500,3,Biofabrication,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
+BIOE,6120,1,Orthopaedic Engr & Pathology,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,
+BIOE,6400,1,Biopharmaceutical Engineering,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sarah harcum,
+BIOE,8010,1,Bio Materials,0.31,0.59,0.06,0.0,0.0,0.0,0.0,0.03,robert latour,
+BIOE,8020,410,Biocompatibility,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
+BIOE,8140,401,Medical Dev Commercialization,0.91,0.0,0.0,0.0,0.04,0.0,0.0,0.04,david orr,
+BIOE,8160,1,BioE Professional Development,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,martine laberge,
+BIOE,8200,1,Structl Biomechanics,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,hai yao,
+BIOE,8240,1,Cell & Mol Tissue Engineering,0.67,0.0,0.17,0.0,0.0,0.0,0.0,0.17,jeoungsoo lee,
+BIOL,1010,1,Frontiers in Biology I,0.83,0.11,0.05,0.01,0.01,0.0,0.0,0.0,robert edwa ballard,
+BIOL,1010,2,Frontiers in Biology I,0.63,0.22,0.09,0.04,0.02,0.0,0.0,0.0,thomas hughes,
+BIOL,1030,1,General Biology I,0.17,0.27,0.26,0.16,0.06,0.0,0.0,0.09,nora espinoza,
+BIOL,1030,2,General Biology I,0.14,0.31,0.29,0.14,0.07,0.0,0.0,0.06,william baldwin,
+BIOL,1030,3,General Biology I,0.32,0.3,0.2,0.07,0.05,0.0,0.0,0.05,william surver,
+BIOL,1030,4,General Biology I,0.16,0.23,0.33,0.17,0.05,0.0,0.0,0.07,salvatore sparace,
+BIOL,1030,5,General Biology I (HON),0.49,0.36,0.13,0.0,0.0,0.0,0.0,0.03,nora espinoza,True
+BIOL,1050,1,General Biology Lab I,0.13,0.42,0.29,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,2,General Biology Lab I,0.08,0.5,0.33,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,3,General Biology Lab I,0.27,0.32,0.27,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,4,General Biology Lab I,0.0,0.63,0.29,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,5,General Biology Lab I,0.04,0.5,0.46,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,6,General Biology Lab I,0.21,0.54,0.21,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,7,General Biology Lab I,0.0,0.25,0.38,0.08,0.08,0.0,0.0,0.21,tafadzwa kaisa,
+BIOL,1050,8,General Biology Lab I,0.04,0.33,0.42,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,9,General Biology Lab I,0.0,0.15,0.3,0.25,0.1,0.0,0.0,0.2,tafadzwa kaisa,
+BIOL,1050,10,General Biology Lab I,0.04,0.52,0.26,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,11,General Biology Lab I,0.09,0.65,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,12,General Biology Lab I,0.17,0.29,0.38,0.08,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,13,General Biology Lab I,0.08,0.54,0.25,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,14,General Biology Lab I,0.04,0.63,0.29,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,15,General Biology Lab I,0.0,0.67,0.17,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,16,General Biology Lab I,0.04,0.43,0.43,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,17,General Biology Lab I,0.13,0.38,0.33,0.13,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,18,General Biology Lab I,0.17,0.42,0.38,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,19,General Biology Lab I,0.23,0.27,0.36,0.09,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,20,General Biology Lab I,0.1,0.35,0.4,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,21,General Biology Lab I,0.0,0.21,0.5,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,22,General Biology Lab I,0.0,0.61,0.3,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,23,General Biology Lab I,0.08,0.29,0.29,0.13,0.13,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,25,General Biology Lab I,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,26,General Biology Lab I,0.25,0.46,0.25,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,27,General Biology Lab I,0.25,0.42,0.25,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,28,General Biology Lab I,0.04,0.5,0.33,0.04,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,29,General Biology Lab I,0.0,0.63,0.17,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,30,General Biology Lab I,0.0,0.29,0.29,0.17,0.08,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,31,General Biology Lab I,0.09,0.36,0.41,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,32,General Biology Lab I,0.0,0.39,0.39,0.22,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,33,General Biology Lab I,0.0,0.27,0.4,0.13,0.13,0.0,0.0,0.07,tafadzwa kaisa,
+BIOL,1050,34,General Biology Lab I,0.09,0.57,0.35,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,35,General Biology Lab I,0.13,0.46,0.33,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,36,General Biology Lab I,0.25,0.46,0.17,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,37,General Biology Lab I,0.04,0.38,0.5,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,38,General Biology Lab I,0.13,0.63,0.17,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,39,General Biology Lab I,0.0,0.5,0.42,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,40,General Biology Lab I,0.09,0.65,0.17,0.09,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,41,General Biology Lab I,0.0,0.5,0.42,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,42,General Biology Lab I,0.04,0.43,0.43,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,43,General Biology Lab I,0.09,0.36,0.36,0.09,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,44,General Biology Lab I,0.09,0.52,0.22,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,46,General Biology Lab I,0.04,0.38,0.38,0.13,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1090,1,Intro to Life Sci,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,
+BIOL,1100,1,Principles of Biology I,0.47,0.41,0.08,0.01,0.0,0.0,0.0,0.03,dylan dittrich-reed,
+BIOL,1100,2,Principles of Biology I,0.24,0.43,0.23,0.04,0.03,0.0,0.0,0.04,robert kosinski,
+BIOL,1200,1,Biological Inq Lab,0.15,0.6,0.15,0.1,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,2,Biological Inq Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,3,Biological Inq Lab,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,4,Biological Inq Lab,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05, christine minor,
+BIOL,1200,5,Biological Inq Lab,0.25,0.55,0.1,0.05,0.0,0.0,0.0,0.05, christine minor,
+BIOL,1200,6,Biological Inq Lab,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,7,Biological Inq Lab,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,8,Biological Inq Lab,0.21,0.37,0.21,0.0,0.11,0.0,0.0,0.11, christine minor,
+BIOL,1200,9,Biological Inq Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,10,Biological Inq Lab,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,11,Biological Inq Lab,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05, christine minor,
+BIOL,1200,12,Biological Inq Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,13,Biological Inq Lab,0.4,0.5,0.05,0.05,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,14,Biological Inq Lab,0.32,0.47,0.16,0.05,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1230,1,Keys to Human Biol,0.16,0.44,0.29,0.1,0.02,0.0,0.0,0.0, christine minor,
+BIOL,1230,2,Keys to Human Biol,0.13,0.49,0.24,0.08,0.01,0.0,0.0,0.04, christine minor,
+BIOL,2040,1,"Environ, Energy and Society",0.4,0.33,0.15,0.05,0.0,0.0,0.0,0.08,john jenkins hains,
+BIOL,2040,2,"Environ, Energy and Society",0.34,0.4,0.17,0.04,0.04,0.0,0.0,0.02,john jenkins hains,
+BIOL,2110,1,Introduction to Toxicology,0.65,0.22,0.13,0.0,0.0,0.0,0.0,0.0,peter van den hurk,
+BIOL,2220,1,Human Anat and Physiology I,0.29,0.31,0.25,0.06,0.05,0.0,0.0,0.04,john cummings,
+BIOL,2220,2,Human Anat and Physiology I,0.22,0.36,0.23,0.05,0.06,0.0,0.0,0.09,john cummings,
+BIOL,3030,1,Vertebrate Biology,0.33,0.3,0.21,0.13,0.01,0.0,0.0,0.02,richard blob,
+BIOL,3030,2,Vertebrate Biology (HON),0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,True
+BIOL,3040,1,Biology of Plants,0.53,0.36,0.06,0.02,0.03,0.0,0.0,0.0,christina wells,
+BIOL,3070,1,Vertebrate Biology Lab,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,2,Vertebrate Biology Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,3,Vertebrate Biology Lab,0.25,0.6,0.15,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,4,Vertebrate Biology Lab,0.42,0.47,0.05,0.05,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,5,Vertebrate Biology Lab,0.25,0.5,0.15,0.0,0.05,0.0,0.0,0.05,richard blob,
+BIOL,3070,6,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,7,Vertebrate Biology Lab,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,8,Vertebrate Biology Lab,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,richard blob,
+BIOL,3070,9,Vertebrate Biology Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,10,Vertebrate Biology Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,11,Vertebrate Biology Lab,0.5,0.39,0.06,0.06,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3080,1,Biology of Plants Practicum,0.4,0.35,0.2,0.05,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,2,Biology of Plants Practicum,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,nathan redding,
+BIOL,3080,3,Biology of Plants Practicum,0.35,0.5,0.0,0.1,0.0,0.0,0.0,0.05,nathan redding,
+BIOL,3080,4,Biology of Plants Practicum,0.1,0.65,0.2,0.0,0.0,0.0,0.0,0.05,nathan redding,
+BIOL,3080,5,Biology of Plants Practicum,0.65,0.1,0.25,0.0,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,6,Biology of Plants Practicum,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3150,1,Functional Human Anatomy,0.23,0.42,0.19,0.06,0.03,0.0,0.0,0.07,tamara mcnutt-scott,
+BIOL,3200,1,Field Botany,0.25,0.21,0.32,0.07,0.0,0.0,0.0,0.14,robert edwa ballard,
+BIOL,3350,1,Evolutionary Biology,0.41,0.42,0.13,0.02,0.0,0.0,0.0,0.01,michael sears,
+BIOL,3510,1,Biological Anthropology,0.11,0.56,0.11,0.06,0.06,0.0,0.0,0.11,lisa rapaport,
+BIOL,3530,1,Forensic Anthropology,0.29,0.47,0.18,0.0,0.0,0.0,0.0,0.06,katherine weisensee,
+BIOL,4030,1,Intro to Applied Genomics,0.15,0.46,0.08,0.08,0.08,0.0,0.0,0.15,vincent pa richards,
+BIOL,4140,1,Basic Immunology,0.19,0.44,0.31,0.06,0.0,0.0,0.0,0.0,yanzhang wei,
+BIOL,4170,1,Marine Biology,0.93,0.06,0.0,0.0,0.0,0.0,0.0,0.01,charles rice,
+BIOL,4200,1,Neurobiology,0.48,0.45,0.0,0.03,0.0,0.0,0.0,0.03,david feliciano,
+BIOL,4250,1,Introductory Mycology,0.35,0.29,0.26,0.03,0.0,0.0,0.0,0.06,julia loui kerrigan,
+BIOL,4260,2,Mycology Practicum,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,
+BIOL,4340,1,Biological Chem Lab Techniques,0.06,0.38,0.38,0.13,0.06,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,2,Biological Chem Lab Techniques,0.19,0.25,0.19,0.19,0.19,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,4,Biological Chem Lab Techniques,0.21,0.36,0.29,0.14,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4410,1,Ecology,0.58,0.27,0.09,0.05,0.0,0.0,0.0,0.01,john jenkins hains,
+BIOL,4430,1,Freshwater Ecology,0.47,0.33,0.11,0.03,0.0,0.0,0.0,0.06,john jenkins hains,
+BIOL,4440,1,Freshwater Ecology Lab (Lec),0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,john jenkins hains,
+BIOL,4450,1,Ecology Laboratory (Lec),0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,john jenkins hains,
+BIOL,4450,3,Ecology Laboratory (Lec),0.5,0.1,0.4,0.0,0.0,0.0,0.0,0.0,john jenkins hains,
+BIOL,4450,4,Ecology Laboratory (Lec),0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,john jenkins hains,
+BIOL,4560,1,Medical and Vet Parasitology,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,wilbur kear milhous,
+BIOL,4610,1,Cell Biology,0.28,0.42,0.19,0.07,0.01,0.0,0.0,0.04,susan carol chapman,
+BIOL,4610,2,Cell Biology (HON),0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,susan carol chapman,True
+BIOL,4620,1,Cell Biology Lab (Lec),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,2,Cell Biology Lab (Lec),0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,4,Cell Biology Lab (Lec),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.92,0.0,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,7,Cell Biology Lab (Lec),0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,8,Cell Biology Lab (Lec),0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
+BIOL,4620,9,Cell Biology Lab (Lec),0.89,0.04,0.0,0.0,0.0,0.0,0.0,0.07,xianzhong yu,
+BIOL,4670,1,Principles of Hematology,0.77,0.13,0.03,0.0,0.0,0.0,0.0,0.06,vincent gallicchio,
+BIOL,4930,1,Sr Sem: Genomics,0.79,0.07,0.0,0.0,0.07,0.0,0.0,0.07,kara elizabe powder,
+BIOL,4930,3,Sr Sem: Advances in Cancer,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
+BIOL,4930,5,Sr Sem: Bioelectricity,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,matthew turnbull,
+BIOL,4930,8,Sr Sem: Evolutionary Medicine,0.71,0.14,0.0,0.07,0.0,0.0,0.0,0.07,samantha ann price,
+BIOL,6030,1,Intro to Applied Genomics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,vincent pa richards,
+BIOL,8400,1,Understanding Biological Inq,0.93,0.05,0.01,0.0,0.01,0.0,0.0,0.01,michael childress,
+BIOL,8420,1,Understand Cellular Processes,0.64,0.31,0.05,0.0,0.01,0.0,0.0,0.0,patricia leota tate,
+BIOL,8440,1,Understanding the Human Body,0.64,0.28,0.04,0.0,0.04,0.0,0.0,0.0,william baldwin,
+BUS,1010,1,Business Foundations,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,2,Business Foundations,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,3,Business Foundations,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,4,Business Foundations,0.47,0.37,0.05,0.0,0.0,0.0,0.0,0.11,christopher mann,
+BUS,1010,5,Business Foundations,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,christopher mann,
+BUS,1010,6,Business Foundations,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,
+BUS,1010,7,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,8,Business Foundations,0.32,0.47,0.16,0.0,0.0,0.0,0.0,0.05,william ern tumblin,
+BUS,1010,9,Business Foundations,0.16,0.21,0.16,0.16,0.11,0.0,0.0,0.21,william ern tumblin,
+BUS,1010,10,Business Foundations,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,11,Business Foundations,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,william ern tumblin,
+BUS,1010,12,Business Foundations,0.21,0.37,0.37,0.0,0.05,0.0,0.0,0.0,christopher mann,
+BUS,1010,13,Business Foundations,0.16,0.79,0.05,0.0,0.0,0.0,0.0,0.0,christopher mann,
+BUS,1010,14,Business Foundations,0.42,0.26,0.16,0.05,0.05,0.0,0.0,0.05,christopher mann,
+BUS,1010,15,Business Foundations,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,16,Business Foundations,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,donna mccubbin,
+BUS,1010,17,Business Foundations,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,18,Business Foundations,0.26,0.42,0.11,0.05,0.05,0.0,0.0,0.11,donna mccubbin,
+BUS,1010,19,Business Foundations,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,donna mccubbin,
+BUS,1010,20,Business Foundations,0.39,0.33,0.17,0.0,0.0,0.0,0.0,0.11,donna mccubbin,
+BUS,1010,21,Business Foundations,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,christopher mann,
+BUS,1010,22,Business Foundations,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,christopher mann,
+BUS,1010,23,Business Foundations,0.37,0.42,0.11,0.11,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,24,Business Foundations,0.37,0.37,0.11,0.0,0.0,0.0,0.0,0.16,sandy edge,
+BUS,1010,25,Business Foundations,0.58,0.11,0.21,0.05,0.05,0.0,0.0,0.0,sandy edge,
+BUS,1010,26,Business Foundations,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,27,Business Foundations,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,28,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,29,Business Foundations,0.26,0.28,0.26,0.11,0.02,0.0,0.0,0.07,lance scott young,
+BUS,1010,30,Business Foundations,0.18,0.37,0.35,0.02,0.0,0.0,0.0,0.08,lance scott young,
+BUS,1010,31,Business Foundations,0.42,0.16,0.37,0.0,0.0,0.0,0.0,0.05,lance scott young,
+BUS,1010,33,Business Foundations,0.28,0.32,0.28,0.08,0.04,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,34,Business Foundations,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,35,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,36,Business Foundations,0.26,0.42,0.21,0.0,0.05,0.0,0.0,0.05,christopher mann,
+BUS,1010,37,Business Foundations,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,2990,6,CI: Being a Leader,0.5,0.3,0.1,0.0,0.1,0.0,0.0,0.0,melissa vogel,
+CE,1990,2,Cr Inq in Civil Engineering,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,weichiang pang,
+CE,1990,20,Cr Inq in Civil Engineering,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,bradley putman,
+CE,2010,1,Statics,0.22,0.17,0.26,0.07,0.09,0.0,0.0,0.2,melissa sternhagen,
+CE,2010,2,Statics,0.27,0.3,0.25,0.05,0.07,0.0,0.0,0.07,"mahmoudabadi arani,",
+CE,2010,3,Statics,0.46,0.21,0.13,0.08,0.06,0.0,0.0,0.06,qiushi chen,
+CE,2010,4,Statics,0.18,0.34,0.14,0.11,0.07,0.0,0.0,0.16,melissa sternhagen,
+CE,2010,5,Statics,0.43,0.36,0.16,0.0,0.02,0.0,0.0,0.02,mahmoodreza soltani,
+CE,2010,6,Statics,0.15,0.23,0.15,0.08,0.09,0.0,0.0,0.29,melissa sternhagen,
+CE,2010,8,Statics,0.1,0.37,0.29,0.04,0.08,0.0,0.0,0.12, kent nilsson,
+CE,2060,1,Structural Mechanics,0.41,0.33,0.22,0.02,0.02,0.0,0.0,0.02,mahmoodreza soltani,
+CE,2080,1,Dynamics,0.07,0.29,0.34,0.2,0.05,0.0,0.0,0.05,melissa sternhagen,
+CE,2550,1,Geomatics,0.3,0.45,0.2,0.04,0.01,0.0,0.0,0.0,wayne sarasua,
+CE,3010,1,Structural Analysis,0.35,0.32,0.24,0.08,0.0,0.0,0.0,0.0,stephen csernak,
+CE,3010,2,Structural Analysis,0.42,0.36,0.11,0.06,0.03,0.0,0.0,0.03,thomas edfo cousins,
+CE,3110,1,Transportation Engr,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
+CE,3210,1,Geotechnical Engineering,0.21,0.24,0.33,0.14,0.07,0.0,0.0,0.0,qiushi chen,
+CE,3310,1,Constr Engr & Mgmnt,0.59,0.28,0.09,0.03,0.01,0.0,0.0,0.0,james burati,
+CE,3410,1,Intro to Fluid Mech,0.33,0.4,0.17,0.1,0.0,0.0,0.0,0.0,nigel gregory kaye,
+CE,3410,2,Intro to Fluid Mech,0.17,0.38,0.3,0.02,0.13,0.0,0.0,0.0,abdul khan,
+CE,3420,1,Hydraulics & Hydro,0.5,0.33,0.11,0.07,0.0,0.0,0.0,0.0,ashok mishra,
+CE,3510,1,Civil Engineering Materials,0.24,0.51,0.22,0.0,0.02,0.0,0.0,0.0,ami esmaeilpoursaee,
+CE,3510,2,Civil Engineering Materials,0.45,0.48,0.07,0.0,0.0,0.0,0.0,0.0,ami esmaeilpoursaee,
+CE,3520,1,Econ Eval of Proj,0.46,0.26,0.19,0.04,0.0,0.0,0.0,0.06,zoraya rolda rockow,
+CE,4010,1,Matrix Str Analysis,0.0,0.47,0.2,0.2,0.07,0.0,0.0,0.07,bryant nielson,
+CE,4020,1,Reinfor Con Design,0.36,0.39,0.21,0.03,0.0,0.0,0.0,0.0,brandon ross,
+CE,4060,1,Struct Steel Design,0.36,0.44,0.05,0.08,0.03,0.0,0.0,0.05,stephen csernak,
+CE,4100,1,Traffic Engr Oper,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
+CE,4240,1,Earth Slopes & Struc,0.33,0.39,0.2,0.04,0.04,0.0,0.0,0.0,nadara ravichandran,
+CE,4330,1,Const Plan & Sched,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+CE,4390,1,Con Eqpmt Sel & Main,0.32,0.45,0.18,0.0,0.0,0.0,0.0,0.05,james burati,
+CE,4560,1,Pave Design & Constr,0.48,0.44,0.04,0.0,0.0,0.0,0.0,0.04,bradley putman,
+CE,4590,1,Capstone Design Proj,0.51,0.3,0.05,0.14,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4910,1,BIM in Construction Management,0.76,0.14,0.03,0.0,0.07,0.0,0.0,0.0,kalyan ram piratla,
+CE,4910,2,Hydrologic Analysis and Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ashok mishra,
+CE,6010,1,Matrix Str Analysis,0.45,0.41,0.14,0.0,0.0,0.0,0.0,0.0,bryant nielson,
+CE,6100,1,Traffic Engr Oper,0.4,0.2,0.2,0.0,0.0,0.0,0.0,0.2,wayne sarasua,
+CE,6240,1,Earth Slopes & Struc,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,6390,1,Con Eqpmt Sel & Main,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,james burati,
+CE,6560,1,Pavement Des & Const,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,bradley putman,
+CE,8200,1,Geotech Site Charac,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,8260,1,Prop of Concrete,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
+CE,8320,1,Capl Proj Mgmt Fund,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+CE,8580,500,Fund of Risk Engineering Mgt,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,jie zhang,
+CE,8930,2,Bridge Design,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brandon ross,
+CE,8930,4,Data Analytics for Transpo,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CE,8930,5,Civil Infrastructure Systems,0.71,0.0,0.14,0.0,0.0,0.0,0.0,0.14,pamela murray-tuite,
+CH,1010,1,General Chemistry,0.18,0.24,0.27,0.15,0.07,0.0,0.0,0.09,william mcwhorter,
+CH,1010,2,General Chemistry,0.26,0.29,0.23,0.1,0.04,0.0,0.0,0.08,elliot ennis,
+CH,1010,3,General Chemistry,0.16,0.28,0.23,0.15,0.06,0.0,0.0,0.12,william mcwhorter,
+CH,1010,4,General Chemistry,0.24,0.31,0.22,0.11,0.05,0.0,0.0,0.08,dennis taylor,
+CH,1010,5,General Chemistry,0.27,0.29,0.19,0.12,0.05,0.0,0.0,0.08,william mcwhorter,
+CH,1010,6,General Chemistry,0.15,0.38,0.21,0.17,0.04,0.0,0.0,0.05,thomas hickman,
+CH,1010,7,General Chemistry,0.22,0.34,0.25,0.11,0.03,0.0,0.0,0.05,laura lanni,
+CH,1010,8,General Chemistry,0.33,0.37,0.16,0.05,0.03,0.0,0.0,0.05,tania issa houjeiry,
+CH,1010,9,General Chemistry,0.25,0.39,0.21,0.09,0.03,0.0,0.0,0.03,dennis taylor,
+CH,1010,10,General Chemistry,0.33,0.3,0.19,0.06,0.05,0.0,0.0,0.08,tania issa houjeiry,
+CH,1010,11,General Chemistry,0.21,0.24,0.3,0.1,0.07,0.0,0.0,0.08,princess mycia cox,
+CH,1010,12,General Chemistry,0.31,0.33,0.19,0.06,0.03,0.0,0.0,0.08,elliot ennis,
+CH,1010,13,General Chemistry,0.2,0.38,0.26,0.11,0.03,0.0,0.0,0.02,dennis taylor,
+CH,1010,50,General Chemistry,0.26,0.35,0.13,0.16,0.06,0.0,0.0,0.03,shiou-jyh hwu,
+CH,1010,51,General Chemistry (HON),0.69,0.2,0.12,0.0,0.0,0.0,0.0,0.0,william pennington,True
+CH,1010,52,General Chemistry (HON),0.68,0.2,0.1,0.02,0.0,0.0,0.0,0.0,joseph stu thrasher,True
+CH,1010,201,General Chemistry,0.22,0.36,0.28,0.09,0.03,0.0,0.0,0.03,laura lanni,
+CH,1010,202,General Chemistry,0.2,0.43,0.22,0.11,0.02,0.0,0.0,0.03,jacob schroeder,
+CH,1010,203,General Chemistry,0.2,0.39,0.24,0.08,0.03,0.0,0.0,0.05,olt geiculescu,
+CH,1010,204,General Chemistry,0.25,0.43,0.17,0.12,0.02,0.0,0.0,0.01,princess mycia cox,
+CH,1010,501,General Chemistry,0.21,0.39,0.24,0.12,0.0,0.0,0.0,0.03,brian gloor,
+CH,1020,1,General Chemistry,0.37,0.21,0.21,0.11,0.03,0.0,0.0,0.06,stephe schvaneveldt,
+CH,1020,2,General Chemistry,0.21,0.22,0.29,0.15,0.05,0.0,0.0,0.08,stephe schvaneveldt,
+CH,1020,3,General Chemistry,0.31,0.19,0.3,0.09,0.02,0.0,0.0,0.08,stephe schvaneveldt,
+CH,1020,400,General Chemistry,0.1,0.25,0.29,0.15,0.15,0.0,0.0,0.06,stephe schvaneveldt,
+CH,1050,1,Chemistry in Context I,0.37,0.51,0.07,0.02,0.02,0.0,0.0,0.02,olt geiculescu,
+CH,1050,2,Chemistry in Context I,0.33,0.47,0.11,0.04,0.03,0.0,0.0,0.01,olt geiculescu,
+CH,2010,1,Survey of Organic Chemistry,0.2,0.33,0.26,0.11,0.08,0.0,0.0,0.02,thomas hickman,
+CH,2010,2,Survey of Organic Chemistry,0.29,0.45,0.15,0.09,0.0,0.0,0.0,0.02,thomas hickman,
+CH,2020,1,Surv of Organic Chemistry Lab,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2020,2,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2020,4,Surv of Organic Chemistry Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,
+CH,2020,5,Surv of Organic Chemistry Lab,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,james nelso plampin,
+CH,2020,6,Surv of Organic Chemistry Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,
+CH,2020,8,Surv of Organic Chemistry Lab,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
+CH,2020,9,Surv of Organic Chemistry Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2230,1,Organic Chemistry,0.32,0.25,0.14,0.05,0.06,0.0,0.0,0.18,modi wetzler,
+CH,2230,2,Organic Chemistry,0.36,0.3,0.09,0.11,0.04,0.0,0.0,0.11,modi wetzler,
+CH,2230,3,Organic Chemistry,0.34,0.37,0.17,0.04,0.03,0.0,0.0,0.05,tania issa houjeiry,
+CH,2230,4,Organic Chemistry,0.19,0.43,0.17,0.06,0.04,0.0,0.0,0.11,laura lanni,
+CH,2230,5,Organic Chemistry,0.29,0.4,0.15,0.07,0.05,0.0,0.0,0.04,elliot ennis,
+CH,2230,6,Organic Chemistry,0.25,0.36,0.18,0.06,0.04,0.0,0.0,0.12,rhett smith,
+CH,2230,7,Organic Chemistry,0.31,0.31,0.2,0.05,0.03,0.0,0.0,0.1,sourav saha,
+CH,2240,1,Organic Chemistry,0.27,0.31,0.23,0.05,0.13,0.0,0.0,0.01,jacob schroeder,
+CH,2240,2,Organic Chemistry,0.27,0.26,0.26,0.09,0.06,0.0,0.0,0.06,jacob schroeder,
+CH,2270,1,Organic Chem Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
+CH,2270,3,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,4,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,7,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,james nelso plampin,
+CH,2270,8,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,9,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,10,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,
+CH,2270,12,Organic Chem Lab,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,13,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,14,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nelso plampin,
+CH,2270,16,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,17,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
+CH,2270,18,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,20,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,21,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,23,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,
+CH,2270,24,Organic Chem Lab,0.73,0.13,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,26,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,27,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,28,Organic Chem Lab,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,james nelso plampin,
+CH,2270,30,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,31,Organic Chem Lab,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,james nelso plampin,
+CH,2270,32,Organic Chem Lab,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,33,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2270,34,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,35,Organic Chem Lab,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2270,36,Organic Chem Lab,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,james nelso plampin,
+CH,2270,37,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
+CH,2270,38,Organic Chem Lab,0.56,0.13,0.0,0.0,0.06,0.0,0.0,0.25,james nelso plampin,
+CH,2280,1,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelso plampin,
+CH,2280,2,Organic Chem Lab,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,james nelso plampin,
+CH,2280,3,Organic Chem Lab,0.76,0.06,0.0,0.0,0.0,0.0,0.0,0.18,james nelso plampin,
+CH,2280,4,Organic Chem Lab,0.72,0.0,0.0,0.0,0.0,0.0,0.0,0.28,james nelso plampin,
+CH,2280,5,Organic Chem Lab,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,james nelso plampin,
+CH,2280,6,Organic Chem Lab,0.71,0.0,0.0,0.0,0.06,0.0,0.0,0.24,james nelso plampin,
+CH,2280,7,Organic Chem Lab,0.73,0.07,0.07,0.0,0.13,0.0,0.0,0.0,james nelso plampin,
+CH,2280,9,Organic Chem Lab,0.7,0.0,0.0,0.0,0.0,0.0,0.0,0.3,james nelso plampin,
+CH,3130,1,Quantitative Analys,0.54,0.2,0.22,0.05,0.0,0.0,0.0,0.0,stephen creager,
+CH,3150,1,Quant Analysis Lab,0.64,0.09,0.0,0.0,0.18,0.0,0.0,0.09,carlos garcia perez,
+CH,3150,2,Quant Analysis Lab,0.25,0.58,0.08,0.0,0.0,0.0,0.0,0.08,carlos garcia perez,
+CH,3300,1,Intro to Phys Chem,0.46,0.29,0.14,0.03,0.05,0.0,0.0,0.03,brian dominy,
+CH,3310,1,Physical Chemistry,0.13,0.13,0.33,0.2,0.13,0.0,0.0,0.07,steven stuart,
+CH,3310,2,Physical Chemistry,0.75,0.08,0.08,0.04,0.0,0.0,0.0,0.04,jason mcneill,
+CH,3320,1,Physical Chemistry,0.41,0.35,0.06,0.0,0.0,0.0,0.0,0.18,arkady kholodenko,
+CH,3390,1,Physical Chem Lab,0.2,0.75,0.0,0.0,0.0,0.0,0.0,0.05,princess mycia cox,
+CH,3390,2,Physical Chem Lab,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,princess mycia cox,
+CH,3390,4,Physical Chem Lab,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,5,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3410,1,Introduction to Research,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,stephen creager,
+CH,4010,1,Organometallic Chemistry,0.66,0.3,0.0,0.0,0.0,0.0,0.0,0.04,andrew gre tennyson,
+CH,4020,1,Inorganic Chemistry,0.63,0.26,0.05,0.05,0.0,0.0,0.0,0.0,joseph kolis,
+CH,8070,1,Chem Trans Elem,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
+CH,8140,1,Analytical Imaging,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,george chumanov,
+CH,8160,1,Separation Science,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,richard marcus,
+CH,8210,1,Organic Chem I,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,ya-ping sun,
+CH,8410,3,N M R Spectroscopy,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alek kitaygorodskiy,
+CH,8510,1,Grad Student Seminar,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,joseph stu thrasher,
+CH,8520,1,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,leah bec casabianca,
+CHE,2110,1,Mass and Energy Balances,0.11,0.19,0.31,0.14,0.11,0.0,0.0,0.14,mark roberts,
+CHE,2110,2,Mass and Energy Balances,0.28,0.27,0.33,0.02,0.03,0.0,0.0,0.07,mark roberts,
+CHE,3210,1,Ch E Thermo II,0.13,0.2,0.36,0.27,0.04,0.0,0.0,0.0,sapna sarupria,
+CHE,3300,1,Mass Trans & Seprtn,0.16,0.2,0.4,0.12,0.11,0.0,0.0,0.01,mark thies,
+CHE,4070,1,Unit Op Lab II,0.16,0.72,0.12,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
+CHE,4140,1,Green Engineering,0.48,0.44,0.08,0.0,0.0,0.0,0.0,0.0,christophe kitchens,
+CHE,4310,1,Process Design I,0.25,0.47,0.28,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,4500,1,Chem Reaction Engr,0.19,0.27,0.39,0.14,0.01,0.0,0.0,0.0,rachel getman,
+CHE,6130,1,Polymer Composite Engineering,0.4,0.2,0.4,0.0,0.0,0.0,0.0,0.0,amod ogale,
+CHE,8030,1,Advanced Transport,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,eric mikel davis,
+CHE,8040,1,Ch E Thermodynamics,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,joseph scott,
+CHE,8050,1,Ch E Kinetics,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,mark alan blenner,
+CHIN,2010,1,Intermediate Chinese,0.56,0.25,0.19,0.0,0.0,0.0,0.0,0.0,ling rao,
+CHIN,3050,1,Chin Conv & Comp I,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,yanhua zhang,
+COM,1010,3,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,eddie smith,
+COM,1500,1,Intro to Human Communication,0.83,0.15,0.0,0.0,0.01,0.0,0.0,0.02,eddie smith,
+COM,1500,2,Intro to Human Communication,0.69,0.26,0.01,0.01,0.01,0.0,0.0,0.02,daniel lelan fecher,
+COM,1500,3,Intro to Human Communication,0.91,0.07,0.02,0.0,0.01,0.0,0.0,0.0,eddie smith,
+COM,1500,4,Intro to Human Communication,0.77,0.16,0.03,0.0,0.02,0.0,0.0,0.02,marianne her glaser,
+COM,1500,5,Intro to Human Communication,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,marianne her glaser,
+COM,1500,6,Intro to Human Communication,0.81,0.1,0.03,0.0,0.03,0.0,0.0,0.03,marianne her glaser,
+COM,1500,7,Intro to Human Communication,0.43,0.47,0.04,0.03,0.03,0.0,0.0,0.0,daniel lelan fecher,
+COM,2010,1,Intr to Comm Studies,0.69,0.28,0.0,0.03,0.0,0.0,0.0,0.0,darren linvill,
+COM,2010,2,Intr to Comm Studies,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,2020,1,Communication Theory,0.31,0.31,0.31,0.06,0.0,0.0,0.0,0.0,kristen ela okamoto,
+COM,2020,2,Communication Theory,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,kristen ela okamoto,
+COM,2040,1,Critical-Cultural Comm Theory,0.61,0.22,0.11,0.0,0.0,0.0,0.0,0.06,david travers scott,
+COM,2100,1,Quant Comm Research Methods,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,2100,2,Quant Comm Research Methods,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,2110,1,Qual Comm Research Methods,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,angela pratt,
+COM,2500,1,Public Speaking,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,2,Public Speaking,0.35,0.47,0.06,0.06,0.0,0.0,0.0,0.06,sara grumbl crocker,
+COM,2500,3,Public Speaking,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,4,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,5,Public Speaking,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,6,Public Speaking,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,7,Public Speaking,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christ davis,
+COM,2500,8,Public Speaking,0.56,0.39,0.0,0.06,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,9,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,10,Public Speaking,0.53,0.26,0.16,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,11,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,
+COM,2500,12,Public Speaking,0.61,0.22,0.06,0.0,0.11,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,13,Public Speaking,0.63,0.21,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,14,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,16,Public Speaking,0.84,0.0,0.11,0.0,0.0,0.0,0.0,0.05,vanessa anne condon,
+COM,2500,17,Public Speaking,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,the estate  geddes,
+COM,2500,18,Public Speaking,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,pauline matthey,
+COM,2500,19,Public Speaking,0.32,0.26,0.32,0.11,0.0,0.0,0.0,0.0,pauline matthey,
+COM,2500,21,Public Speaking,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,katie barn mcelveen,
+COM,2500,23,Public Speaking,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,pauline matthey,
+COM,2500,24,Public Speaking,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,katie barn mcelveen,
+COM,2500,25,Public Speaking (HON),0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True
+COM,2500,26,Public Speaking (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jumah patrici taweh,True
+COM,2500,28,Public Speaking,0.67,0.11,0.11,0.0,0.06,0.0,0.0,0.06,sara grumbl crocker,
+COM,2500,29,Public Speaking,0.68,0.11,0.11,0.0,0.0,0.0,0.0,0.11,sara grumbl crocker,
+COM,2500,30,Public Speaking,0.53,0.21,0.11,0.0,0.05,0.0,0.0,0.11,jumah patrici taweh,
+COM,2500,31,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,32,Public Speaking,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,33,Public Speaking,0.56,0.17,0.17,0.0,0.11,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,34,Public Speaking,0.53,0.32,0.16,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,
+COM,2500,35,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,
+COM,2500,36,Public Speaking,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,amanda elizab moore,
+COM,2500,37,Public Speaking,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,amanda elizab moore,
+COM,2500,39,Public Speaking (HON),0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,lindsey dixon,True
+COM,2500,400,Public Speaking,0.83,0.06,0.06,0.06,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,403,Public Speaking,0.89,0.0,0.06,0.0,0.06,0.0,0.0,0.0,alexis zachar davis,
+COM,3220,1,Communication Design,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,lori marlise pindar,
+COM,3240,1,"Communication, Sport & Society",0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,
+COM,3240,2,"Communication, Sport & Society",0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,gregory kei cranmer,
+COM,3260,2,Pr in Sports,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3260,3,Pr in Sports,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,katie barn mcelveen,
+COM,3480,1,Interpersonal Comm,0.64,0.28,0.06,0.03,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,3550,1,Principles of Public Relations,0.65,0.24,0.04,0.02,0.02,0.0,0.0,0.02,meghna tallapragada,
+COM,3570,1,Public Relations Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3570,2,Public Relations Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3660,4,Adv. Strategic Comm,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,mark david land,
+COM,4250,1,Adv Sports Comm,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,bryan denham,
+COM,4260,1,Social Media and Sports Comm,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4260,2,Social Media and Sports Comm,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4300,1,Legal Communication,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
+COM,4710,1,Health Comm in Communities,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,8030,1,Comm Technology Studies Survey,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
+COM,8100,1,Comm Research Methods I,0.25,0.63,0.0,0.0,0.13,0.0,0.0,0.0,gregory kei cranmer,
+CPSC,1010,1,Computer Science I,0.16,0.35,0.13,0.11,0.1,0.0,0.0,0.15,salvatore lamarca,
+CPSC,1010,2,Computer Science I,0.19,0.31,0.21,0.12,0.09,0.0,0.0,0.09,salvatore lamarca,
+CPSC,1020,1,Computer Science II,0.27,0.13,0.17,0.17,0.12,0.0,0.0,0.13,yvon feaster,
+CPSC,1020,2,Computer Science II,0.37,0.29,0.16,0.03,0.11,0.0,0.0,0.05,yvon feaster,
+CPSC,1060,1,Intro to Programming in Java,0.32,0.24,0.12,0.06,0.15,0.0,0.0,0.12,salvatore lamarca,
+CPSC,1070,1,Programming Methodology,0.57,0.18,0.14,0.06,0.02,0.0,0.0,0.04,rose lowe,
+CPSC,1110,1,Intro to Programming in C,0.37,0.27,0.15,0.05,0.07,0.0,0.0,0.08,catherine hochrine,
+CPSC,1110,2,Intro to Programming in C,0.31,0.25,0.1,0.05,0.19,0.0,0.0,0.1,catherine hochrine,
+CPSC,1110,3,Intro to Programming in C,0.48,0.2,0.12,0.08,0.02,0.0,0.0,0.11,john junius porter,
+CPSC,1210,1,Computational Thinking,0.11,0.44,0.11,0.0,0.17,0.0,0.0,0.17,larry hodges,
+CPSC,2070,1,Discrete Structures,0.21,0.28,0.23,0.07,0.11,0.0,0.0,0.1,larry hodges,
+CPSC,2120,1,Algs/Data Structures,0.3,0.23,0.18,0.04,0.09,0.0,0.0,0.16,brian christop dean,
+CPSC,2120,2,Algs/Data Structures,0.25,0.33,0.22,0.05,0.05,0.0,0.0,0.1,wayne goddard,
+CPSC,2150,1,Software Dev Foundations,0.27,0.36,0.25,0.03,0.02,0.0,0.0,0.07,kevin anton plis,
+CPSC,2150,2,Software Dev Foundations,0.27,0.27,0.21,0.02,0.14,0.0,0.0,0.09,kevin anton plis,
+CPSC,2200,1,Microcomputer Appl,0.46,0.39,0.07,0.04,0.04,0.0,0.0,0.0,kevin anton plis,
+CPSC,2200,2,Microcomputer Appl,0.26,0.37,0.19,0.11,0.07,0.0,0.0,0.0,kevin anton plis,
+CPSC,2310,1,Intro Computer Org,0.42,0.43,0.09,0.04,0.02,0.0,0.0,0.0,rose lowe,
+CPSC,2310,2,Intro Computer Org,0.44,0.26,0.22,0.02,0.02,0.0,0.0,0.04,rose lowe,
+CPSC,2810,1,Selected Topics: TA Class,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,christopher plaue,
+CPSC,2910,1,Prof Issues I,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,2,Prof Issues I,0.59,0.24,0.12,0.06,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,3,Prof Issues I,0.47,0.33,0.07,0.0,0.07,0.0,0.0,0.07,catherine hochrine,
+CPSC,2910,4,Prof Issues I,0.61,0.17,0.17,0.0,0.06,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,5,Prof Issues I,0.39,0.39,0.06,0.0,0.11,0.0,0.0,0.06,catherine hochrine,
+CPSC,2920,1,"Computing, Ethics & Society",0.25,0.4,0.25,0.05,0.0,0.0,0.0,0.05,christopher plaue,
+CPSC,3220,1,Intro to Operating Systems,0.12,0.36,0.36,0.12,0.03,0.0,0.0,0.0,mark smotherman,
+CPSC,3220,2,Intro to Operating Systems,0.55,0.4,0.04,0.02,0.0,0.0,0.0,0.0,carl bryan martin,
+CPSC,3220,3,Intro to Operating Systems,0.21,0.42,0.11,0.16,0.11,0.0,0.0,0.0, van den meiracker,
+CPSC,3300,1,Computer Systems Org,0.21,0.34,0.34,0.11,0.0,0.0,0.0,0.0,rong ge,
+CPSC,3500,1,Foundations of Computer Sci,0.15,0.19,0.41,0.07,0.02,0.0,0.0,0.17,ilya mark safro,
+CPSC,3520,1,Programming Systems,0.3,0.48,0.08,0.0,0.03,0.0,0.0,0.1,robert schalkoff,
+CPSC,3600,1,Network Programming,0.28,0.42,0.22,0.02,0.03,0.0,0.0,0.03,feng luo,
+CPSC,3600,2,Network Programming,0.2,0.28,0.35,0.08,0.02,0.0,0.0,0.07,james martin,
+CPSC,3720,1,Software Engineering,0.31,0.36,0.23,0.07,0.0,0.0,0.0,0.03,murali sitaraman,
+CPSC,3720,2,Software Engineering,0.24,0.36,0.4,0.0,0.0,0.0,0.0,0.0,eileen ther kraemer,
+CPSC,4050,1,Computer Graphics,0.4,0.28,0.16,0.0,0.08,0.0,0.0,0.08,victor zordan,
+CPSC,4110,1,Virtual Reality Systems,0.38,0.25,0.2,0.08,0.1,0.0,0.0,0.0,sabarish venka babu,
+CPSC,4120,1,Eye Tracking Methodology,0.3,0.49,0.11,0.03,0.03,0.0,0.0,0.05,andrew duchowski,
+CPSC,4160,1,2-D Game Engine Construction,0.64,0.11,0.13,0.0,0.09,0.0,0.0,0.02,brian malloy,
+CPSC,4180,1,Usable Privacy and Security,0.64,0.31,0.03,0.0,0.0,0.0,0.0,0.03,kelly caine,
+CPSC,4200,1,Computer Security Principles,0.68,0.21,0.09,0.0,0.03,0.0,0.0,0.0,hongxin hu,
+CPSC,4300,1,Applied Data Science,0.51,0.28,0.18,0.0,0.03,0.0,0.0,0.0,alexander ch herzog,
+CPSC,4620,1,Database Management Systems,0.06,0.28,0.28,0.0,0.13,0.0,0.0,0.25,pradip srimani,
+CPSC,4770,1,Distributed/Cluster Computing,0.21,0.26,0.16,0.0,0.16,0.0,0.0,0.21,linh bao ngo,
+CPSC,4820,1,Spec Top: Embed Prototyp,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jacob sorber,
+CPSC,4820,2,Spec Topics: Cloud Comp Archit,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,amy apon,
+CPSC,4820,3,Spec Topic: Web Programming,0.51,0.27,0.07,0.02,0.07,0.0,0.0,0.05,craig baker,
+CPSC,4910,1,Professional Issues II,0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
+CPSC,6040,1,Cptr Graphics Image,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,
+CPSC,6040,2,Cptr Graphics Image,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,ioannis karamouzas,
+CPSC,6050,1,Computer Graphics,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,victor zordan,
+CPSC,6110,1,Virtual Reality Systems,0.0,0.57,0.29,0.0,0.0,0.0,0.0,0.14,sabarish venka babu,
+CPSC,6120,1,Eye Tracking Methodology,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,andrew duchowski,
+CPSC,6160,3,2-D Game Engine Construction,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,brian malloy,
+CPSC,6300,1,Applied Data Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
+CPSC,6770,1,Distributed/Cluster Computing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,linh bao ngo,
+CPSC,6820,2,Spec Topics: Cloud Comp Archit,0.44,0.38,0.06,0.0,0.0,0.0,0.0,0.13,amy apon,
+CPSC,8170,1,Physically Based Animation,0.64,0.18,0.09,0.0,0.0,0.0,0.0,0.09,jerry tessendorf,
+CPSC,8200,1,Parallel Architechture,0.36,0.36,0.07,0.0,0.07,0.0,0.0,0.14,pradip srimani,
+CPSC,8270,1,Translation of Progr Languages,0.56,0.28,0.13,0.0,0.03,0.0,0.0,0.0,brian malloy,
+CPSC,8480,1,Network Science,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,ilya mark safro,
+CPSC,8730,1,"Software Verif, Valid & Measur",0.41,0.54,0.0,0.0,0.0,0.0,0.0,0.05,john mcgregor,
+CPSC,8810,1,Selected Topics: Data Analytic,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CPSC,8810,2,Sel Top: VH/Embod Conver Agent,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,andrew robb,
+CRP,8010,1,Planning Process & Legal Found,0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,caitlin dyckman,
+CRP,8020,1,Site Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,clifford dona ellis,
+CRP,8030,2,Quan Analysis for Planners,0.63,0.19,0.06,0.0,0.0,0.0,0.0,0.13,eric morris,
+CRP,8040,1,Intro to GIS for Plan & Policy,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,timothy green,
+CRP,8080,1,Land Use and Compreh Planning,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,clifford dona ellis,
+CRP,8450,1,Water Policy & Law,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,
+CSM,1000,1,Intro to Construct,0.44,0.33,0.11,0.04,0.04,0.0,0.0,0.04,jason lucas,
+CSM,1000,2,Intro to Construct,0.5,0.38,0.04,0.04,0.04,0.0,0.0,0.0,jason lucas,
+CSM,2010,1,Structures I,0.18,0.25,0.32,0.14,0.07,0.0,0.0,0.04,shima clarke,
+CSM,2010,2,Structures I,0.36,0.25,0.21,0.07,0.11,0.0,0.0,0.0,shima clarke,
+CSM,2030,1,Mats & Meth of Const,0.27,0.53,0.13,0.03,0.03,0.0,0.0,0.0,robert seel,
+CSM,2030,2,Mats & Meth of Const,0.23,0.5,0.13,0.0,0.07,0.0,0.0,0.07,robert seel,
+CSM,3040,1,Envir Systems I,0.27,0.43,0.3,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3040,2,Envir Systems I,0.25,0.46,0.13,0.13,0.04,0.0,0.0,0.0,joseph mich burgett,
+CSM,3060,1,Emerging Tech in Construction,0.43,0.43,0.11,0.0,0.0,0.0,0.0,0.04,jason lucas,
+CSM,3060,2,Emerging Tech in Construction,0.52,0.36,0.08,0.0,0.0,0.0,0.0,0.04,jason lucas,
+CSM,3510,1,Const Estimating,0.23,0.35,0.23,0.08,0.12,0.0,0.0,0.0,seyed mousavi rizi,
+CSM,3510,2,Const Estimating,0.36,0.32,0.29,0.0,0.04,0.0,0.0,0.0,seyed mousavi rizi,
+CSM,4110,1,Safety in Bldg Const,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,nicholas corley,
+CSM,4110,2,Safety in Bldg Const,0.61,0.35,0.03,0.0,0.0,0.0,0.0,0.0,nicholas corley,
+CSM,4500,1,Construction Intern,0.84,0.02,0.14,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
+CSM,4530,1,Const Proj Mgmt,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4530,2,Const Proj Mgmt,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4610,1,Const Econ Seminar,0.23,0.47,0.3,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,4610,2,Const Econ Seminar,0.07,0.53,0.33,0.07,0.0,0.0,0.0,0.0,christine piper,
+CSM,8610,1,Construction Control Systems,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8610,400,Construction Control Systems,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8620,1,Personnel Mgt & Neg,0.13,0.5,0.25,0.0,0.13,0.0,0.0,0.0,roger william liska,
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,susan whorton,
+CU,1000,3,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,
+CU,1000,4,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
+CU,1000,5,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,susan whorton,
+CU,1000,6,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.93,0.05,0.01,susan whorton,
+CU,1000,7,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,susan whorton,
+CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.79,0.2,0.01,susan whorton,
+CU,1000,10,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.17,0.01,susan whorton,
+CU,1000,11,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.78,0.21,0.01,susan whorton,
+CU,1000,12,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.75,0.24,0.01,susan whorton,
+CU,1000,13,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.7,0.29,0.01,susan whorton,
+CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.79,0.21,0.0,susan whorton,
+CU,1000,20,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,susan whorton,
+CU,1000,21,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,susan whorton,
+CU,1010,1,Univ Success Skills,0.46,0.23,0.15,0.0,0.08,0.0,0.0,0.08,bryn zimmerman babb,
+CU,1010,3,Univ Success Skills,0.29,0.24,0.24,0.0,0.12,0.0,0.0,0.12,kirsten noelle dean,
+CU,1010,6,Univ Success Skills,0.43,0.07,0.14,0.07,0.21,0.0,0.0,0.07,cari allyn brooks,
+CU,1010,613,Univ Success Skills,0.5,0.37,0.05,0.03,0.05,0.0,0.0,0.0,elizabeth stephan,
+CU,1010,614,Univ Success Skills,0.34,0.24,0.15,0.12,0.12,0.0,0.0,0.02,mariah magagnotti,
+CU,1010,616,Univ Success Skills,0.58,0.32,0.03,0.0,0.03,0.0,0.0,0.03,matthew kent miller,
+CVT,2260,1,Intro Cardiovas Sono,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,eric walker,
+DANC,1300,1,Tap Dance I,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,cheryl hosler,
+DPA,3070,1,Method 3d Production,0.59,0.17,0.1,0.0,0.03,0.0,0.0,0.1,sarah lydia martin,
+DPA,3070,2,Method 3d Production,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,summer 'nea benton,
+DPA,4000,1,Tech Foundations I,0.09,0.18,0.09,0.0,0.0,0.0,0.0,0.64,andrew duchowski,
+DPA,4020,1,Vis Foundations I,0.69,0.19,0.06,0.0,0.06,0.0,0.0,0.0,erik reed,
+DPA,6830,3,Spec Stud To in DPA: Z-Brush,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,insun kwon,
+DPA,8070,1,3D Modeling and Animation,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+DPA,8150,1,Special Effects Compositing,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,
+ECE,2010,1,Logic and Computing Devices,0.2,0.27,0.26,0.1,0.12,0.0,0.0,0.05,william reid,
+ECE,2010,2,Logic & Comp Device (HON),0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,william reid,True
+ECE,2020,1,Electric Circuits I,0.2,0.37,0.19,0.07,0.06,0.0,0.0,0.1,william harrell,
+ECE,2070,1,Basic Electrical Engineering,0.48,0.3,0.16,0.03,0.01,0.0,0.0,0.02,timothy anglea,
+ECE,2070,2,Basic Electrical Engineering,0.4,0.21,0.23,0.05,0.07,0.0,0.0,0.05,daniel bla cutshall,
+ECE,2070,3,Basic Electrical Engineering,0.47,0.33,0.07,0.04,0.03,0.0,0.0,0.06,william th kolodzey,
+ECE,2080,1,Basic Electrical Engr Lab,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,2,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,3,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,7,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,8,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,9,Basic Electrical Engr Lab,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,10,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,12,Basic Electrical Engr Lab,0.75,0.15,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,14,Basic Electrical Engr Lab,0.83,0.0,0.06,0.0,0.0,0.0,0.0,0.11,apoorva dee kapadia,
+ECE,2080,15,Basic Electrical Engr Lab,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,6,Logic Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,apoorva dee kapadia,
+ECE,2090,8,Logic Lab,0.73,0.0,0.09,0.0,0.0,0.0,0.0,0.18,apoorva dee kapadia,
+ECE,2090,12,Logic Lab,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2090,13,Logic Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2110,1,Elec Engr Lab I,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
+ECE,2110,2,Elec Engr Lab I,0.75,0.1,0.0,0.0,0.0,0.0,0.0,0.15,apoorva dee kapadia,
+ECE,2110,3,Elec Engr Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2110,4,Elec Engr Lab I,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,apoorva dee kapadia,
+ECE,2110,5,Elec Engr Lab I,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
+ECE,2110,6,Elec Engr Lab I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2110,7,Elec Engr Lab I,0.75,0.0,0.1,0.0,0.1,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2110,8,Elec Engr Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,apoorva dee kapadia,
+ECE,2110,9,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
+ECE,2110,10,Elec Engr Lab I,0.64,0.27,0.0,0.0,0.09,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2220,1,Syst Prog Concept,0.25,0.25,0.23,0.08,0.0,0.0,0.0,0.19,harlan russell,
+ECE,2230,1,Comp Sys Eng,0.33,0.45,0.08,0.1,0.0,0.0,0.0,0.04,walter ligon,
+ECE,2620,1,Electric Circuits II,0.25,0.27,0.19,0.17,0.04,0.0,0.0,0.08,liang dong,
+ECE,2720,1,Comp Organization,0.18,0.43,0.28,0.08,0.05,0.0,0.0,0.0,william reid,
+ECE,2730,3,Computer Org Lab,0.45,0.18,0.27,0.09,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,1,Electrical Engineering Lab III,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,2,Electrical Engineering Lab III,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,3,Electrical Engineering Lab III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,4,Electrical Engineering Lab III,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,apoorva dee kapadia,
+ECE,3110,7,Electrical Engineering Lab III,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,8,Electrical Engineering Lab III,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,apoorva dee kapadia,
+ECE,3110,9,Electrical Engineering Lab III,0.38,0.5,0.0,0.06,0.06,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3120,2,Electrical Engineering Lab IV,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3170,1,Rand Signal Analysis,0.33,0.43,0.2,0.02,0.0,0.0,0.0,0.03,stephen hubbard,
+ECE,3200,1,Electronics I,0.21,0.23,0.28,0.2,0.08,0.0,0.0,0.01,stephen hubbard,
+ECE,3210,1,Electronics II,0.28,0.55,0.08,0.08,0.03,0.0,0.0,0.0,stephen hubbard,
+ECE,3220,1,Intro Operating Sys,0.13,0.55,0.32,0.0,0.0,0.0,0.0,0.0,mark smotherman,
+ECE,3270,1,Dig Comp Design,0.13,0.35,0.13,0.23,0.03,0.0,0.0,0.13,melissa crawl smith,
+ECE,3300,1,Signals & Systems,0.08,0.3,0.19,0.22,0.09,0.0,0.0,0.12,carl baum,
+ECE,3300,2,Signals & Systems (HON),0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
+ECE,3520,1,Programming Systems,0.65,0.27,0.04,0.0,0.0,0.0,0.0,0.04,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.33,0.36,0.2,0.06,0.05,0.0,0.0,0.0,edward collins,
+ECE,3710,1,Microcontr Interface,0.4,0.3,0.21,0.06,0.02,0.0,0.0,0.01,william reid,
+ECE,3720,1,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,3,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,4,Micro Int Lab,0.58,0.33,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,6,Micro Int Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,7,Micro Int Lab,0.25,0.58,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,9,Micro Int Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3800,1,Electromagnetics,0.23,0.22,0.31,0.05,0.09,0.0,0.0,0.11,jeffrey osterberg,
+ECE,3810,1,Field Waves & Ckts,0.13,0.43,0.26,0.0,0.09,0.0,0.0,0.09,anthony martin,
+ECE,4090,1,Intr to Linear Control Systems,0.56,0.34,0.08,0.0,0.02,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4180,1,Power Syst Analysis,0.23,0.33,0.17,0.03,0.1,0.0,0.0,0.13,ramtin hadidi,
+ECE,4270,1,Communications Sys,0.35,0.44,0.15,0.01,0.03,0.0,0.0,0.01,madhabi manandhar,
+ECE,4420,1,Knowledge Engr,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,robert schalkoff,
+ECE,4490,1,Comp Ntwrk Security,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,richard brooks,
+ECE,4610,1,Fundamentals of Solar Energy,0.45,0.35,0.18,0.0,0.0,0.0,0.0,0.03,rajendra singh,
+ECE,4670,1,Intro to Dig Sig Pro,0.36,0.14,0.36,0.07,0.0,0.0,0.0,0.07,john gowdy,
+ECE,4730,1,Intro Parallel Sys,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,walter ligon,
+ECE,4950,1,Int Sys Design I,0.7,0.29,0.01,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4960,1,Int Sys Design II,0.47,0.43,0.1,0.0,0.0,0.0,0.0,0.0,richard groff,
+ECE,6040,1,Semiconductor Devices,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson doug ryckman,
+ECE,6180,400,Power Syst Analysis,0.4,0.0,0.4,0.0,0.0,0.0,0.0,0.2,ramtin hadidi,
+ECE,6310,1,Intro to Computer Vision,0.48,0.38,0.1,0.0,0.0,0.0,0.0,0.05,adam hoover,
+ECE,6420,1,Knowledge Engr,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert schalkoff,
+ECE,6420,400,Knowledge Engr,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,robert schalkoff,
+ECE,6490,1,Comp Ntwrk Security,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,
+ECE,6490,400,Comp Ntwrk Security,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,richard brooks,
+ECE,6590,1,Int Circ Design,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,
+ECE,6610,1,Fundamentals of Solar Energy,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,rajendra singh,
+ECE,6670,1,Intro to Dig Sig Pro,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john gowdy,
+ECE,6730,1,Intro Parallel Sys,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,walter ligon,
+ECE,8010,1,Analysis of Lin Sys,0.48,0.41,0.04,0.0,0.0,0.0,0.0,0.07,richard groff,
+ECE,8540,1,Analysis of Tracking Systems,0.86,0.1,0.0,0.0,0.03,0.0,0.0,0.0,adam hoover,
+ECON,2000,2,Economic Concepts,0.5,0.33,0.08,0.05,0.05,0.0,0.0,0.0,jonathan orr ernest,
+ECON,2000,4,Economic Concepts,0.46,0.44,0.05,0.03,0.03,0.0,0.0,0.0,miren ivankovic,
+ECON,2000,5,Economic Concepts,0.31,0.23,0.31,0.05,0.08,0.0,0.0,0.03,jonathan orr ernest,
+ECON,2110,1,Principles of Microeconomics,0.21,0.42,0.11,0.16,0.0,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,2,Principles of Microeconomics,0.21,0.26,0.32,0.11,0.05,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,3,Principles of Microeconomics,0.16,0.16,0.47,0.05,0.05,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,4,Principles of Microeconomics,0.0,0.37,0.53,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,5,Principles of Microeconomics,0.11,0.47,0.32,0.05,0.05,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,6,Principles of Microeconomics,0.11,0.37,0.42,0.05,0.0,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,7,Principles of Microeconomics,0.11,0.26,0.32,0.11,0.16,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,8,Principles of Microeconomics,0.11,0.28,0.44,0.06,0.06,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,9,Principles of Microeconomics,0.16,0.26,0.37,0.05,0.05,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,10,Principles of Microeconomics,0.11,0.28,0.28,0.06,0.11,0.0,0.0,0.17,frederick hanssen,
+ECON,2110,11,Principles of Microeconomics,0.16,0.63,0.21,0.0,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,12,Principles of Microeconomics,0.11,0.42,0.26,0.21,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,13,Principles of Microeconomics,0.21,0.32,0.37,0.11,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,14,Principles of Microeconomics,0.21,0.21,0.42,0.05,0.0,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,15,Principles of Microeconomics,0.16,0.58,0.21,0.05,0.0,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,16,Principles of Microeconomics,0.16,0.11,0.47,0.11,0.11,0.0,0.0,0.05,frederick hanssen,
+ECON,2110,17,Principles of Microeconomics,0.11,0.58,0.16,0.05,0.11,0.0,0.0,0.0,frederick hanssen,
+ECON,2110,18,Principles of Microeconomics,0.05,0.32,0.42,0.05,0.05,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,19,Principles of Microeconomics,0.11,0.53,0.11,0.11,0.05,0.0,0.0,0.11,frederick hanssen,
+ECON,2110,20,Principles of Microeconomics,0.16,0.36,0.35,0.13,0.0,0.0,0.0,0.0,benjamin posmanick,
+ECON,2110,21,Principles of Microeconomics,0.33,0.42,0.18,0.06,0.0,0.0,0.0,0.0,michael makowsky,
+ECON,2110,22,Principles of Microeconomics,0.24,0.33,0.26,0.1,0.02,0.0,0.0,0.05,roksan ghanbariamin,
+ECON,2110,23,Principles of Microeconomics,0.26,0.31,0.25,0.11,0.07,0.0,0.0,0.01,sarah louise wilson,
+ECON,2110,24,Principles of Microeconomics,0.2,0.38,0.24,0.12,0.05,0.0,0.0,0.02,kelsey vict roberts,
+ECON,2110,25,Principles of Microeconomics,0.21,0.67,0.1,0.0,0.0,0.0,0.0,0.03,chen wang,
+ECON,2110,26,Principles of Microeconomics,0.22,0.47,0.18,0.07,0.0,0.0,0.0,0.07,benjamin jo schwall,
+ECON,2110,31,Principles of Microeconomics,0.4,0.37,0.17,0.01,0.01,0.0,0.0,0.03,jacob walloga,
+ECON,2110,32,Principles of Microeconomics,0.13,0.44,0.33,0.02,0.02,0.0,0.0,0.06,frederick hanssen,
+ECON,2110,33,Principles of Microeconomics,0.15,0.44,0.22,0.07,0.05,0.0,0.0,0.07,charles thomas,
+ECON,2110,34,Principles of Microecon (HON),0.45,0.45,0.05,0.05,0.0,0.0,0.0,0.0,charles thomas,True
+ECON,2110,35,Principles of Microeconomics,0.25,0.65,0.1,0.0,0.0,0.0,0.0,0.0,chen wang,
+ECON,2110,36,Principles of Microeconomics,0.18,0.48,0.25,0.08,0.0,0.0,0.0,0.03,roksan ghanbariamin,
+ECON,2110,38,Principles of Microeconomics,0.33,0.24,0.26,0.07,0.05,0.0,0.0,0.05,liuna issagholian,
+ECON,2110,40,Principles of Microeconomics,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.03,zhiqi zhao,
+ECON,2110,41,Principles of Microeconomics,0.39,0.34,0.17,0.07,0.02,0.0,0.0,0.0,liuna issagholian,
+ECON,2120,1,Principles of Macroeconomics,0.08,0.14,0.08,0.17,0.11,0.0,0.0,0.42,ralph charles allen,
+ECON,2120,2,Principles of Macroeconomics,0.31,0.51,0.13,0.02,0.02,0.0,0.0,0.0,kyle lance rechard,
+ECON,2120,3,Principles of Macroeconomics,0.15,0.09,0.18,0.15,0.16,0.0,0.0,0.27,ralph charles allen,
+ECON,2120,4,Principles of Macroeconomics,0.26,0.4,0.19,0.05,0.03,0.0,0.0,0.06,elijah neilson,
+ECON,2120,5,Principles of Macroeconomics,0.24,0.41,0.2,0.1,0.0,0.0,0.0,0.05,benjamin ti harbolt,
+ECON,2120,6,Principles of Macroeconomics,0.15,0.35,0.43,0.03,0.05,0.0,0.0,0.0,benjamin ti harbolt,
+ECON,2120,7,Principles of Macroeconomics,0.23,0.43,0.3,0.0,0.0,0.0,0.0,0.05,kyle lance rechard,
+ECON,2120,8,Principles of Macroeconomics,0.87,0.1,0.0,0.02,0.0,0.0,0.0,0.02,jeremy choquette,
+ECON,2120,9,Principles of Macroeconomics,0.35,0.38,0.18,0.08,0.03,0.0,0.0,0.0,narendra regmi,
+ECON,2120,10,Principles of Macroeconomics,0.71,0.07,0.07,0.02,0.07,0.0,0.0,0.05,jeremy choquette,
+ECON,3020,1,Money and Banking,0.08,0.51,0.32,0.0,0.03,0.0,0.0,0.05,smriti bhargava,
+ECON,3060,1,Managerial Economics,0.23,0.28,0.3,0.13,0.05,0.0,0.0,0.03,steven johnson,
+ECON,3100,1,International Econ,0.29,0.29,0.16,0.1,0.09,0.0,0.0,0.09,samuel ar standaert,
+ECON,3140,1,Intermediate Micro,0.25,0.17,0.25,0.1,0.1,0.0,0.0,0.12,patrick warren,
+ECON,3140,2,Intermediate Micro,0.26,0.35,0.24,0.06,0.06,0.0,0.0,0.02,molly espey,
+ECON,3140,3,Intermediate Micro,0.24,0.35,0.22,0.06,0.04,0.0,0.0,0.1,robert kennet fleck,
+ECON,3150,1,Intermediate Macro,0.39,0.25,0.1,0.02,0.08,0.0,0.0,0.16,sergey vla mityakov,
+ECON,3150,2,Intermediate Macro,0.31,0.34,0.24,0.08,0.03,0.0,0.0,0.0,michal jerzmanowski,
+ECON,3190,1,Environmental Econ,0.36,0.33,0.23,0.03,0.03,0.0,0.0,0.03,molly espey,
+ECON,3600,1,Public Choice,0.41,0.24,0.21,0.12,0.03,0.0,0.0,0.0,michael makowsky,
+ECON,4010,1,Labor Mkt Analysis,0.37,0.37,0.22,0.0,0.04,0.0,0.0,0.0,chungsang lam,
+ECON,4020,1,Law and Economics,0.21,0.41,0.31,0.05,0.0,0.0,0.0,0.03,howard ne bodenhorn,
+ECON,4040,1,Comp Econ Systems,0.13,0.38,0.06,0.19,0.19,0.0,0.0,0.06,dar litsukova-bokar,
+ECON,4050,5,Intro to Econometric,0.19,0.23,0.32,0.12,0.11,0.0,0.0,0.04,scott barkowski,
+ECON,4100,1,Economic Development,0.59,0.33,0.0,0.0,0.04,0.0,0.0,0.04,robert tamura,
+ECON,4110,2,Econ of Education,0.3,0.43,0.23,0.0,0.0,0.0,0.0,0.03,peter quarter blair,
+ECON,4120,1,International Micro,0.36,0.39,0.14,0.07,0.04,0.0,0.0,0.0,richard alan sessa,
+ECON,4220,1,Monetary Economics,0.26,0.5,0.12,0.0,0.03,0.0,0.0,0.09,gerald dwyer,
+ECON,4230,1,Economics of Health,0.47,0.18,0.24,0.06,0.0,0.0,0.0,0.06,devon merritt gorry,
+ECON,4250,1,Antitrust Economics,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,raymond sauer,
+ECON,4260,1,Sem Sport Economics,0.47,0.47,0.0,0.05,0.0,0.0,0.0,0.0,raymond sauer,
+ECON,4280,1,Cost-Benefit Anlysis,0.46,0.29,0.11,0.06,0.03,0.0,0.0,0.06,robert kennet fleck,
+ECON,6050,5,Intro to Econometric,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,scott barkowski,
+ECON,6060,1,Advanced Econometric,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,babur de los santos,
+ECON,8010,1,Microeconomic Theory,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,william dougan,
+ECON,8040,1,Applied Math Econ,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,curtis simon,
+ECON,8060,1,Econometrics I,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,paul wayne wilson,
+ECON,8080,1,Econometrics III,0.14,0.43,0.21,0.0,0.14,0.0,0.0,0.07,paul wayne wilson,
+ECON,8230,1,Microecon Pub Pol,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,scott templeton,
+ECON,8240,1,Org of Industry,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,8260,1,Econ Theory of Govt Regulation,0.17,0.5,0.0,0.0,0.0,0.0,0.0,0.33,thomas wins hazlett,
+ECON,8550,1,Financial Economics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,sergey vla mityakov,
+ED,1050,1,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
+ED,1050,2,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
+ED,1050,5,Educ Orientation,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
+ED,1050,7,Educ Orientation,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
+ED,8700,300,STEAM Instructional Design,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,cassie fay quigley,
+EDC,3900,1,Skills for Stu Leads,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,
+EDC,3900,2,Skills for Stu Leads,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,eric pernotto,
+EDC,3990,1,Creative Inq in Counselor Ed,0.82,0.06,0.0,0.0,0.0,0.0,0.0,0.12,ken stewart-tillman,
+EDEC,4400,1,Early Childhood Engl Lang Art,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEL,3210,1,Pe for the Elem Tchr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,3210,2,Pe for the Elem Tchr,0.72,0.14,0.14,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4510,1,Elem Methods in Science Tchg,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
+EDEL,4870,1,Ele Meth Soc Studies,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDEL,4870,2,Ele Meth Soc Studies,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDEL,4880,1,Elem Meth La Tchng,0.68,0.23,0.09,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
+EDEL,4880,2,Elem Meth La Tchng,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
+EDF,3010,2,Principles of American Educat,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohamma khan,
+EDF,3020,2,Educational Psychology,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,meihua qian,
+EDF,3080,3,Classroom Assessment,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah switzer,
+EDF,3350,1,Adolescent Growth & Develop,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
+EDF,3350,2,Adolescent Growth & Develop,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
+EDF,4800,1,Digital Media & Learning,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,2,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,301,Digital Media & Learning,0.39,0.39,0.06,0.11,0.0,0.0,0.0,0.06,aamena bilal saleh,
+EDF,4800,302,Digital Media & Learning,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,8080,302,Contempor Issues in Assessment,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,heather rog brooker,
+EDF,9270,1,Quant Rsrch & Stats for Ed,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,eliza dar gallagher,
+EDF,9270,400,Quant Rsrch & Stats for Ed,0.62,0.31,0.0,0.0,0.08,0.0,0.0,0.0,jennie lynn farmer,
+EDF,9710,501,Case Study & Ethnographic Mthd,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,daniella hall,
+EDHD,8310,500,Lit Outcomes for Child w disab,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,renee gatlin anders,
+EDL,7300,500,Techniq of Supervision-Pub Sch,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,hans william klar,
+EDL,7400,502,Curr Plan: Sch Adm,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,barbara nesbitt,
+EDL,7500,501,El Prin & Spv Ex I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,
+EDL,7550,500,Sec Prin & Spv Exp I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,
+EDL,8850,401,HRD Learning Leadership,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,angela danie carter,
+EDL,9050,400,Thry/Prac Ed Ldrshp,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,russell marion,
+EDL,9110,400,Systematic Inq Ed L,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,jane lindle,
+EDLT,4590,1,Teaching Reading Grades K-3,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,koti lee hubbard,
+EDLT,4600,1,Teaching Reading Grades 2-6,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4600,3,Teaching Reading Grades 2-6,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4600,6,Teaching Reading Grades 2-6,0.6,0.27,0.07,0.07,0.0,0.0,0.0,0.0,julia kate bentley,
+EDLT,4610,1,Content Area Rdg: Grades 2-6,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,4980,1,Secondary Content Area Reading,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,lorraine an jacques,
+EDLT,4980,3,Secondary Content Area Reading,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,rachelle savitz,
+EDLT,8170,300,Content Area Rdg/Wtg: ECE-ELEM,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,rachelle savitz,
+EDLT,8220,500,Strategies for Teaching ESOL,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDLT,8270,400,Content Area Rdg/Wtg-MS & HS,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,rebecca kaminski,
+EDLT,8400,500,Early Literacy Assessment I,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,ellen adkin sanford,
+EDLT,8400,501,Early Literacy Assessment I,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,jamie felder white,
+EDLT,8400,503,Early Literacy Assessment I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jaime adele dawson,
+EDLT,8400,504,Early Literacy Assessment I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,
+EDLT,8400,506,Early Literacy Assessment I,0.73,0.0,0.0,0.0,0.09,0.0,0.0,0.18,renee gatlin anders,
+EDLT,8400,507,Early Literacy Assessment I,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,michael moss,
+EDLT,8820,502,Read Recovery Practicum I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary ann fr mcbride,
+EDLT,9140,1,"Lang Dev, Diversity, Discourse",0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDSA,8100,1,Theories & Techn of Counseling,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,
+EDSC,2260,1,Pr Apprch to Sec Alg,0.38,0.38,0.15,0.0,0.0,0.0,0.0,0.08,stacy megan che,
+EDSC,3280,1,Practicum Sec Soc St,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,william da mccorkle,
+EDSC,4260,1,Tchng Sec Math,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,carlos gomez,
+EDSP,3720,1,Char & Instr Individ with LD,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,catherine griffith,
+EDSP,3740,1,Char & Strat Emot/Behav Disord,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,
+EDSP,4920,1,Math Inst Ind W/Dis,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,pamela stecker,
+EDSP,4930,1,Clsrm/Beh Mgmt Sp Ed,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,joseph benedic ryan,
+EDSP,4940,1,Tchg Rdg Mild Dis,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,abigail anne allen,
+EDSP,8220,400,Tchg Math Indv W/Dis,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,pamela stecker,
+EES,2010,1,Environ Engr Fundamentals I,0.28,0.38,0.18,0.08,0.08,0.0,0.0,0.03,david freedman,
+EES,3030,1,Water Treatment Systems,0.63,0.25,0.09,0.03,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3040,1,Wastewater Treatment Systems,0.34,0.41,0.16,0.06,0.03,0.0,0.0,0.0,sudeep popat,
+EES,3050,1,Water/Wastewater Treatment Lab,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3050,2,Water/Wastewater Treatment Lab,0.47,0.4,0.07,0.0,0.0,0.0,0.0,0.07,sudeep popat,
+EES,4010,1,Environmental Engr,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.26,0.52,0.17,0.0,0.04,0.0,0.0,0.0,mark schlautman,
+EES,4100,1,Environ Radiation Protection I,0.22,0.39,0.11,0.11,0.0,0.0,0.0,0.17,nicole eli martinez,
+EES,4300,1,Air Pollution Engineering,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,andrew rich metcalf,
+EES,4800,1,Environmental Risk Assessment,0.23,0.57,0.13,0.0,0.03,0.0,0.0,0.03,nicole eli martinez,
+EES,4840,1,Solid Waste Mgt,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,yi zheng,
+EES,4860,1,Environmental Sustainability,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
+EES,6100,1,Environ Radiation Protection I,0.29,0.57,0.0,0.0,0.0,0.0,0.0,0.14,nicole eli martinez,
+EES,8020,1,Environ Eng Prin,0.71,0.14,0.07,0.0,0.0,0.0,0.0,0.07,david allen ladner,
+EES,8060,1,Design Env Control,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
+EES,8080,1,Groundwater Modeling,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
+EES,8430,1,Environmental Chem,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,brian powell,
+EES,8510,1,Biol Prin Envir Engr,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
+EES,8800,1,Env Risk Assessment,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,
+ELE,3010,1,Entrepreneurial Foundations,0.46,0.46,0.03,0.03,0.03,0.0,0.0,0.0,christina kyprianou,
+ELE,3010,2,Entrepreneurial Foundations,0.33,0.65,0.0,0.0,0.0,0.0,0.0,0.03,christina kyprianou,
+ELE,3010,3,Entrepreneurial Foundations,0.18,0.42,0.26,0.03,0.03,0.0,0.0,0.08,ashley will parnell,
+ELE,4010,1,Venture Testing,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,chad navis,
+ELE,4020,1,Venture Creation,0.33,0.58,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
+ELE,4030,1,Venture Growth,0.17,0.26,0.48,0.0,0.09,0.0,0.0,0.0,ashley will parnell,
+ENGL,1030,2,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,
+ENGL,1030,3,Composition and Rhetoric,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,krist aldebol-hazle,
+ENGL,1030,4,Composition and Rhetoric,0.56,0.33,0.0,0.0,0.06,0.0,0.0,0.06,jennie el wakefield,
+ENGL,1030,7,Composition and Rhetoric,0.58,0.16,0.16,0.0,0.0,0.0,0.0,0.11,stephen quigley,
+ENGL,1030,8,Composition and Rhetoric,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,1030,9,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jennie el wakefield,
+ENGL,1030,10,Composition and Rhetoric,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,austin gorman,
+ENGL,1030,11,Composition and Rhetoric,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,austin gorman,
+ENGL,1030,12,Composition and Rhetoric,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,carrie hill,
+ENGL,1030,14,Composition and Rhetoric,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,caroline eliz young,
+ENGL,1030,15,Composition and Rhetoric,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel qui atkinson,
+ENGL,1030,17,Composition and Rhetoric,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,18,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jennie el wakefield,
+ENGL,1030,19,Composition and Rhetoric,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,21,Composition and Rhetoric,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,jennie el wakefield,
+ENGL,1030,22,Composition and Rhetoric,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,abigail maxim,
+ENGL,1030,23,Composition and Rhetoric,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,stephen hundley,
+ENGL,1030,24,Composition and Rhetoric,0.71,0.12,0.18,0.0,0.0,0.0,0.0,0.0,sarah el richardson,
+ENGL,1030,25,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,martha sue karnes,
+ENGL,1030,26,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,
+ENGL,1030,27,Composition and Rhetoric,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,michael davi measel,
+ENGL,1030,29,Composition and Rhetoric,0.61,0.28,0.0,0.06,0.0,0.0,0.0,0.06,caroline eliz young,
+ENGL,1030,30,Composition and Rhetoric,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,remley melis makala,
+ENGL,1030,31,Composition and Rhetoric,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,martha sue karnes,
+ENGL,1030,32,Composition and Rhetoric,0.78,0.11,0.0,0.06,0.0,0.0,0.0,0.06,sarah el richardson,
+ENGL,1030,33,Composition and Rhetoric,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,
+ENGL,1030,34,Composition and Rhetoric,0.5,0.29,0.07,0.0,0.14,0.0,0.0,0.0,carley am robertson,
+ENGL,1030,35,Composition and Rhetoric,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,victoria houser,
+ENGL,1030,37,Composition and Rhetoric,0.67,0.17,0.06,0.06,0.0,0.0,0.0,0.06,michael davi measel,
+ENGL,1030,38,Composition and Rhetoric,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,sarah margar carter,
+ENGL,1030,39,Composition and Rhetoric,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,courtn huff-oelberg,
+ENGL,1030,40,Composition and Rhetoric,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,abigail maxim,
+ENGL,1030,41,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,
+ENGL,1030,42,Composition and Rhetoric,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,michelle lloyd,
+ENGL,1030,43,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gabrielle gr nugent,
+ENGL,1030,44,Composition and Rhetoric,0.79,0.11,0.05,0.0,0.05,0.0,0.0,0.0,gabrielle gr nugent,
+ENGL,1030,45,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,
+ENGL,1030,46,Composition and Rhetoric,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,christopher stuart,
+ENGL,1030,47,Composition and Rhetoric,0.71,0.24,0.0,0.06,0.0,0.0,0.0,0.0,brian lee gaines,
+ENGL,1030,48,Composition and Rhetoric,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,brian lee gaines,
+ENGL,1030,50,Composition and Rhetoric,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,charlotte est lucke,
+ENGL,1030,51,Composition and Rhetoric,0.58,0.26,0.05,0.0,0.05,0.0,0.0,0.05,christopher stuart,
+ENGL,1030,53,Composition and Rhetoric,0.32,0.53,0.0,0.05,0.0,0.0,0.0,0.11,jane elizab kuebler,
+ENGL,1030,55,Composition and Rhetoric,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,courtn huff-oelberg,
+ENGL,1030,57,Composition and Rhetoric,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,shauna chung,
+ENGL,1030,59,Composition and Rhetoric,0.31,0.31,0.23,0.0,0.0,0.0,0.0,0.15,sarah margar carter,
+ENGL,1030,61,Composition and Rhetoric,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,
+ENGL,1030,64,Composition and Rhetoric,0.47,0.24,0.24,0.06,0.0,0.0,0.0,0.0,jennifer forsberg,
+ENGL,1030,65,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,
+ENGL,1030,67,Composition and Rhetoric,0.41,0.41,0.06,0.0,0.12,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,1030,69,Composition and Rhetoric,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,1030,71,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,michael russo,
+ENGL,1030,72,Composition and Rhetoric,0.84,0.0,0.0,0.0,0.11,0.0,0.0,0.05,whitney jorda adams,
+ENGL,1030,73,Composition and Rhetoric,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,carley am robertson,
+ENGL,1030,74,Composition and Rhetoric,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,shauna chung,
+ENGL,1030,75,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,stephen hundley,
+ENGL,1030,76,Composition and Rhetoric,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,carrie hill,
+ENGL,1030,80,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,
+ENGL,1030,81,Composition and Rhetoric,0.72,0.11,0.06,0.06,0.06,0.0,0.0,0.0,charlotte est lucke,
+ENGL,1030,82,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,
+ENGL,1030,83,Composition and Rhetoric,0.47,0.32,0.05,0.11,0.0,0.0,0.0,0.05,jane elizab kuebler,
+ENGL,1030,84,Composition and Rhetoric,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,allison nico harris,
+ENGL,1030,85,Composition and Rhetoric,0.74,0.16,0.0,0.0,0.11,0.0,0.0,0.0,allison nico harris,
+ENGL,1030,86,Composition and Rhetoric,0.67,0.07,0.13,0.0,0.07,0.0,0.0,0.07,stephen quigley,
+ENGL,1030,100,Accelerated Composition (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,michelle smith,True
+ENGL,1030,500,Composition and Rhetoric,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,john conway,
+ENGL,1030,501,Composition and Rhetoric,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,john conway,
+ENGL,2120,1,World Literature,0.16,0.47,0.21,0.11,0.05,0.0,0.0,0.0,lee morrissey,
+ENGL,2120,3,World Literature,0.18,0.43,0.14,0.04,0.0,0.0,0.0,0.21,karen kettnich,
+ENGL,2120,4,World Literature,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2120,5,World Literature,0.3,0.19,0.19,0.11,0.15,0.0,0.0,0.07,andrew mathas,
+ENGL,2120,6,World Literature,0.19,0.59,0.15,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,
+ENGL,2120,7,World Literature,0.59,0.3,0.07,0.0,0.0,0.0,0.0,0.04,allison nico harris,
+ENGL,2120,8,World Literature,0.38,0.35,0.0,0.15,0.08,0.0,0.0,0.04,joshua wood,
+ENGL,2120,9,World Literature,0.37,0.26,0.22,0.07,0.0,0.0,0.0,0.07,katalin beck,
+ENGL,2120,10,World Literature,0.54,0.32,0.07,0.0,0.04,0.0,0.0,0.04,lucian ghita,
+ENGL,2120,11,World Literature,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2120,12,World Literature,0.57,0.39,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
+ENGL,2120,13,World Literature,0.32,0.39,0.14,0.04,0.0,0.0,0.0,0.11,karen kettnich,
+ENGL,2120,14,World Literature,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
+ENGL,2120,15,World Literature,0.54,0.23,0.04,0.04,0.12,0.0,0.0,0.04,chloe mich whitaker,
+ENGL,2120,16,World Literature,0.32,0.43,0.11,0.11,0.0,0.0,0.0,0.04,sarah mae cooper,
+ENGL,2120,17,World Literature,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,allison nico harris,
+ENGL,2120,18,World Literature,0.64,0.21,0.0,0.0,0.07,0.0,0.0,0.07,andrew mathas,
+ENGL,2120,19,World Literature,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,2120,20,World Literature,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,joshua wood,
+ENGL,2130,1,British Literature,0.57,0.32,0.0,0.07,0.04,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,2130,3,British Literature,0.63,0.26,0.0,0.04,0.0,0.0,0.0,0.07,krist aldebol-hazle,
+ENGL,2130,4,British Literature,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,john morgenstern,
+ENGL,2130,5,British Literature,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,2130,7,British Literature,0.37,0.3,0.19,0.04,0.07,0.0,0.0,0.04,megan no macalystre,
+ENGL,2130,9,British Literature,0.3,0.37,0.19,0.04,0.07,0.0,0.0,0.04,megan no macalystre,
+ENGL,2130,10,British Literature,0.43,0.5,0.0,0.04,0.04,0.0,0.0,0.0,christopher benson,
+ENGL,2130,11,British Literature,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,12,British Literature,0.68,0.29,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,
+ENGL,2130,13,British Literature,0.57,0.18,0.18,0.04,0.0,0.0,0.0,0.04,megan no macalystre,
+ENGL,2140,1,American Literature,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,5,American Literature,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,6,American Literature,0.41,0.44,0.07,0.0,0.0,0.0,0.0,0.07,erin nicholson gale,
+ENGL,2140,7,American Literature,0.39,0.36,0.11,0.07,0.0,0.0,0.0,0.07,elizabeth stansell,
+ENGL,2140,8,American Literature,0.26,0.37,0.15,0.04,0.0,0.0,0.0,0.19,david charles foltz,
+ENGL,2140,9,American Literature,0.63,0.22,0.11,0.0,0.04,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,14,American Literature,0.24,0.48,0.24,0.0,0.0,0.0,0.0,0.04,david charles foltz,
+ENGL,2140,15,American Literature,0.54,0.36,0.07,0.04,0.0,0.0,0.0,0.0,jennifer forsberg,
+ENGL,2140,16,American Literature,0.29,0.54,0.11,0.04,0.04,0.0,0.0,0.0,jennifer forsberg,
+ENGL,2140,17,American Literature,0.36,0.43,0.04,0.04,0.0,0.0,0.0,0.14,david charles foltz,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.5,0.27,0.12,0.0,0.08,0.0,0.0,0.04,sarah mae cooper,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.28,0.44,0.24,0.0,0.04,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.21,0.46,0.29,0.0,0.0,0.0,0.0,0.04,lindsay kath turner,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.18,0.57,0.18,0.0,0.07,0.0,0.0,0.0,lindsay kath turner,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.93,0.0,0.0,0.0,0.07,0.0,0.0,0.0,stephanie stripling,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.5,0.43,0.0,0.0,0.0,0.0,0.0,0.07,daniel scott citro,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.81,0.08,0.0,0.0,0.0,0.0,0.0,0.12,daniel scott citro,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.41,0.33,0.07,0.04,0.15,0.0,0.0,0.0,andrew mathas,
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.33,0.22,0.17,0.06,0.11,0.0,0.0,0.11,chelsea mari clarey,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.46,0.21,0.18,0.11,0.0,0.0,0.0,0.04,andrew mathas,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.26,0.47,0.16,0.11,0.0,0.0,0.0,0.0,chelsea mari clarey,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.28,0.44,0.11,0.06,0.06,0.0,0.0,0.06,chelsea mari clarey,
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.37,0.26,0.16,0.0,0.11,0.0,0.0,0.11,chelsea mari clarey,
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.39,0.29,0.18,0.0,0.11,0.0,0.0,0.04,john logan pursley,
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.45,0.34,0.07,0.07,0.03,0.0,0.0,0.03,john logan pursley,
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.26,0.16,0.32,0.0,0.05,0.0,0.0,0.21,david charles foltz,
+ENGL,2150,22,Lit in 20th-21st Cent Contexts,0.61,0.25,0.0,0.11,0.04,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.46,0.43,0.07,0.04,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,caroline eliz young,
+ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,david charles foltz,
+ENGL,2150,26,Lit in 20th-21st Cent Contexts,0.64,0.25,0.0,0.0,0.04,0.0,0.0,0.07,caroline eliz young,
+ENGL,2150,27,Lit in 20th-21st Cent Contexts,0.0,0.84,0.11,0.0,0.0,0.0,0.0,0.05,amy monaghan,
+ENGL,2150,100,20th - 21st Century Lit (HON),0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
+ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.57,0.07,0.04,0.14,0.0,0.0,0.0,0.18,candace wiley,
+ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.57,0.04,0.04,0.07,0.07,0.0,0.0,0.21,candace wiley,
+ENGL,3040,3,Business Writing,0.68,0.05,0.26,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
+ENGL,3040,4,Business Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3040,5,Business Writing,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,crystal pa stephens,
+ENGL,3040,13,Business Writing,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3040,15,Business Writing,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,philip randall,
+ENGL,3040,16,Business Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,
+ENGL,3040,19,Business Writing,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3040,20,Business Writing,0.58,0.11,0.05,0.0,0.16,0.0,0.0,0.11,geveryl le robinson,
+ENGL,3040,21,Business Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,sean williams,
+ENGL,3040,400,Business Writing,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,steph kartalopoulos,
+ENGL,3040,401,Business Writing,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,steph kartalopoulos,
+ENGL,3100,1,Crit Writ Lit,0.29,0.41,0.12,0.12,0.0,0.0,0.0,0.06,kimberly manganelli,
+ENGL,3100,2,Crit Writ Lit,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,william stockton,
+ENGL,3100,3,Crit Writ Lit,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,
+ENGL,3100,4,Crit Writ Lit,0.39,0.11,0.22,0.0,0.06,0.0,0.0,0.22,william stockton,
+ENGL,3120,1,Advanced Composition,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3120,2,Advanced Composition,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,1,Technical Writing,0.33,0.5,0.06,0.11,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,2,Technical Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,4,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,samuel jacks fuller,
+ENGL,3140,5,Technical Writing,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,sharon kathl nalley,
+ENGL,3140,6,Technical Writing,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,melissa dugan,
+ENGL,3140,9,Technical Writing,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,10,Technical Writing,0.42,0.47,0.0,0.05,0.0,0.0,0.0,0.05,katalin beck,
+ENGL,3140,11,Technical Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,geveryl le robinson,
+ENGL,3140,12,Technical Writing,0.47,0.26,0.05,0.11,0.0,0.0,0.0,0.11,geveryl le robinson,
+ENGL,3140,13,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,3140,16,Technical Writing,0.79,0.0,0.05,0.11,0.0,0.0,0.0,0.05,stephanie stripling,
+ENGL,3140,17,Technical Writing,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,la'cresha ulo green,
+ENGL,3140,19,Technical Writing,0.74,0.05,0.11,0.05,0.05,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,20,Technical Writing,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,22,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,3140,400,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,
+ENGL,3150,1,Scientific Writing & Comm,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,3150,2,Scientific Writing & Comm,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,christopher benson,
+ENGL,3150,3,Scientific Writing & Comm,0.32,0.32,0.16,0.05,0.16,0.0,0.0,0.0,william pulley,
+ENGL,3150,4,Scientific Writing & Comm,0.63,0.21,0.11,0.05,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3150,400,Scientific Writing & Comm,0.65,0.25,0.0,0.0,0.05,0.0,0.0,0.05,philip randall,
+ENGL,3150,401,Sci Writing & Comm,0.56,0.22,0.11,0.0,0.06,0.0,0.0,0.06,philip randall,
+ENGL,3450,1,Structure of Fiction,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,3460,2,Structure of Poetry,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,3480,1,Structure Screenplay,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,nicholas chri brown,
+ENGL,3490,1,Tech/Pop Imagination,0.24,0.53,0.06,0.0,0.0,0.0,0.0,0.18,gabriel and hankins,
+ENGL,3540,1,Lit Middle East & North Africa,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,angela naimou,
+ENGL,3570,1,Film,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3570,2,Film,0.11,0.78,0.11,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3570,3,Film,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,john robert smith,
+ENGL,3850,1,Children's Lit,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,megan no macalystre,
+ENGL,3860,1,Adolescent Lit,0.32,0.58,0.0,0.05,0.0,0.0,0.0,0.05,sarah mae cooper,
+ENGL,3960,1,Brit Lit Survey I,0.39,0.22,0.17,0.17,0.06,0.0,0.0,0.0,erin marina goss,
+ENGL,3960,2,Brit Lit Survey I,0.26,0.42,0.11,0.16,0.05,0.0,0.0,0.0,erin marina goss,
+ENGL,3960,3,Brit Lit Survey I,0.22,0.33,0.06,0.11,0.11,0.0,0.0,0.17,erin marina goss,
+ENGL,3970,2,Brit Lit Survey II,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,david sweene coombs,
+ENGL,3980,2,Amer Lit Survey I,0.32,0.32,0.21,0.0,0.05,0.0,0.0,0.11,kimberly manganelli,
+ENGL,3990,1,Amer Lit Survey II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,4030,1,The Classics in Translation,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,4110,1,Shakespeare,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,elizabeth rivlin,
+ENGL,4110,2,Shakespeare,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,elizabeth rivlin,
+ENGL,4110,3,Shakespeare,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,
+ENGL,4170,1,Victorian Period,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,david sweene coombs,
+ENGL,4190,1,Post Col & World Lit,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
+ENGL,4210,1,Amer Lit 1800-1899,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,dominic mastroianni,
+ENGL,4260,1,Southern Literature,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,michael lemahieu,
+ENGL,4310,1,Modern Poetry,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,steven katz,
+ENGL,4340,1,Environmental Lit,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,matthew hooley,
+ENGL,4350,1,Literary Criticism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,matthew hooley,
+ENGL,4400,1,Literary Theory,0.32,0.42,0.21,0.05,0.0,0.0,0.0,0.0,brian mcgrath,
+ENGL,4420,1,Cultural Studies,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
+ENGL,4450,1,Fiction Workshop,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
+ENGL,4500,1,Film Genres,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0, barton palmer,
+ENGL,4510,1,Film Theory and Criticism,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,john robert smith,
+ENGL,4750,1,Writing for Media,0.33,0.47,0.13,0.0,0.07,0.0,0.0,0.0,jonathan beec field,
+ENGL,4780,1,Digital Literacy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
+ENGL,4890,1,Topics Write & Publ,0.54,0.31,0.0,0.0,0.08,0.0,0.0,0.08,megan eatman,
+ENGL,4920,1,Modern Rhetoric,0.33,0.33,0.27,0.0,0.0,0.0,0.0,0.07,michelle smith,
+ENGL,4960,1,Senior Seminar,0.25,0.42,0.25,0.0,0.0,0.0,0.0,0.08,brian mcgrath,
+ENGL,4960,2,Senior Seminar,0.46,0.38,0.08,0.0,0.08,0.0,0.0,0.0,michelle renee ty,
+ENGL,4960,3,Senior Seminar,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,erin marina goss,
+ENGL,8570,1,Digital Rhetorics,0.78,0.0,0.0,0.0,0.11,0.0,0.0,0.11,tharon howard,
+ENGR,1000,101,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.03,0.0,steven brandon,
+ENGR,1000,102,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,steven brandon,
+ENGR,1000,103,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,steven brandon,
+ENGR,1000,104,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,steven brandon,
+ENGR,1020,116,Engineering Discipl & Skills,0.51,0.39,0.07,0.0,0.0,0.0,0.0,0.02,sarah grigg,
+ENGR,1020,117,Engineering Discipl & Skills,0.46,0.32,0.1,0.02,0.0,0.0,0.0,0.1,sarah grigg,
+ENGR,1020,311,Engineering Discipl & Skills,0.45,0.31,0.14,0.04,0.02,0.0,0.0,0.04,richard watkins,
+ENGR,1020,313,Engineering Discipl & Skills,0.42,0.26,0.09,0.06,0.06,0.0,0.0,0.11,michael giebner,
+ENGR,1020,314,Engineering Discipl & Skills,0.54,0.19,0.12,0.02,0.06,0.0,0.0,0.08,michael giebner,
+ENGR,1020,317,Engineering Discipl & Skills,0.5,0.22,0.12,0.02,0.02,0.0,0.0,0.12,ashley childers,
+ENGR,1020,318,Engineering Discipl & Skills,0.33,0.4,0.17,0.04,0.02,0.0,0.0,0.04,ashley childers,
+ENGR,1020,500,Engineering Discipl & Skills,0.18,0.48,0.21,0.09,0.0,0.0,0.0,0.03,jonathan maier,
+ENGR,1020,611,Engineering Discipl & Skills,0.44,0.3,0.08,0.04,0.08,0.0,0.0,0.06,irene marie ferrara,
+ENGR,1020,612,Engineering Discipl & Skills,0.37,0.4,0.12,0.04,0.0,0.0,0.0,0.08,elizabeth stephan,
+ENGR,1020,613,Engineering Discipl & Skills,0.13,0.55,0.13,0.13,0.05,0.0,0.0,0.0,elizabeth stephan,
+ENGR,1020,614,Engineering Discipl & Skills,0.12,0.34,0.24,0.07,0.07,0.0,0.0,0.15,mariah magagnotti,
+ENGR,1020,615,Engineering Discipl & Skills,0.51,0.24,0.14,0.1,0.02,0.0,0.0,0.0,mariah magagnotti,
+ENGR,1020,616,Engineering Discipl & Skills,0.15,0.44,0.15,0.05,0.05,0.0,0.0,0.15,matthew kent miller,
+ENGR,1020,617,Engineering Discipl & Skills,0.5,0.34,0.12,0.0,0.02,0.0,0.0,0.02,andrew isaa neptune,
+ENGR,1020,618,Engineering Discipl & Skills,0.57,0.28,0.04,0.07,0.02,0.0,0.0,0.02,jonathan maier,
+ENGR,1020,811,Engineering Discipl & Skills,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,
+ENGR,1020,812,Engineering Discipl & Skills,0.4,0.45,0.1,0.0,0.02,0.0,0.0,0.02,mariah magagnotti,
+ENGR,1020,813,Engineering Discipl & Skills,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,andrew isaa neptune,
+ENGR,1020,814,Engineering Discipl & Skills,0.38,0.52,0.07,0.02,0.0,0.0,0.0,0.0,jonathan bro harcum,
+ENGR,1020,815,Engineering Discipl & Skills,0.41,0.37,0.2,0.0,0.02,0.0,0.0,0.0,jonathan bro harcum,
+ENGR,1020,816,Engineering Discipl & Skills,0.54,0.39,0.02,0.0,0.0,0.0,0.0,0.05,andrew isaa neptune,
+ENGR,1020,817,Engineering Discipl & Skills,0.43,0.43,0.1,0.02,0.0,0.0,0.0,0.02,matthew kent miller,
+ENGR,1020,818,Engineering Discipl & Skills,0.48,0.3,0.13,0.05,0.03,0.0,0.0,0.03,matthew kent miller,
+ENGR,1020,831,Engr Discipl & Skills (HON),0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,True
+ENGR,1020,832,Engr Discipl & Skills (HON),0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,True
+ENGR,1060,400,Engr Discipline & Skills II,0.05,0.43,0.24,0.1,0.14,0.0,0.0,0.05,andrew isaa neptune,
+ENGR,1080,400,Programming & Prob Solving II,0.0,0.4,0.5,0.0,0.0,0.0,0.0,0.1,william martin,
+ENGR,1150,500,Engineering Design & Modeling,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john minor,
+ENGR,1410,222,Programming & Problem Solving,0.2,0.27,0.29,0.09,0.02,0.0,0.0,0.13,william martin,
+ENGR,1410,223,Programming & Problem Solving,0.07,0.31,0.36,0.16,0.07,0.0,0.0,0.04,john minor,
+ENGR,1410,226,Programming & Problem Solving,0.13,0.38,0.29,0.07,0.02,0.0,0.0,0.11,steven brandon,
+ENGR,1410,227,Programming & Problem Solving,0.04,0.19,0.4,0.08,0.06,0.0,0.0,0.23,anthony pau garland,
+ENGR,1900,10,CI in Engr I Robotics,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael benj wooten,
+ENGR,1900,78,CI in ENGR Student Design,0.67,0.08,0.0,0.0,0.08,0.0,0.0,0.17,huijuan zhao,
+ENGR,2080,681,Engr Graphics & Machine Design,0.28,0.35,0.09,0.09,0.09,0.0,0.0,0.09,garrison llo broome,
+ENGR,2080,682,Engr Graphics & Machine Design,0.4,0.38,0.19,0.0,0.0,0.0,0.0,0.02,garrison llo broome,
+ENGR,2080,684,Engr Graphics & Machine Design,0.33,0.29,0.24,0.08,0.06,0.0,0.0,0.0,nighat yasmin,
+ENGR,2080,685,Engr Graphics & Machine Design,0.23,0.32,0.2,0.02,0.11,0.0,0.0,0.11,anthony pau garland,
+ENGR,2080,686,Engr Graphics & Machine Design,0.23,0.4,0.19,0.02,0.09,0.0,0.0,0.07,anthony pau garland,
+ENGR,2100,804,CAD & Engineering Applications,0.28,0.44,0.09,0.09,0.02,0.0,0.0,0.07, shams esfandabadi,
+ENGR,2100,805,CAD & Engineering Applications,0.34,0.34,0.11,0.07,0.02,0.0,0.0,0.11,nighat yasmin,
+ENGR,2100,806,CAD & Engineering Applications,0.15,0.4,0.15,0.08,0.1,0.0,0.0,0.13,trent hou dellinger,
+ENGR,2200,115,Evaluating Innovations,0.24,0.57,0.05,0.14,0.0,0.0,0.0,0.0,sarah grigg,
+ENR,1010,1,Intro to Envir & Natur Res I,0.45,0.26,0.15,0.04,0.09,0.0,0.0,0.0,abigail lawson,
+ENR,1010,2,Intro to Envir & Natur Res I,0.43,0.33,0.18,0.05,0.0,0.0,0.0,0.03,abigail lawson,
+ENR,4290,1,Environ Law & Policy,0.32,0.56,0.06,0.0,0.03,0.0,0.0,0.03,alan johnson,
+ENR,4290,2,Environ Law & Policy,0.56,0.38,0.03,0.03,0.0,0.0,0.0,0.0,alan johnson,
+ENSP,2000,1,Intro Environ Sci,0.35,0.35,0.2,0.02,0.04,0.0,0.0,0.04,scott brame,
+ENSP,2000,2,Intro Environ Sci,0.91,0.04,0.04,0.02,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2000,3,Intro Environ Sci,0.88,0.09,0.0,0.02,0.0,0.0,0.0,0.02,minory nammouz,
+ENSP,2000,4,Intro Environ Sci,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+ENSP,2000,5,Intro Environ Sci,0.2,0.48,0.2,0.09,0.02,0.0,0.0,0.02,tom owino,
+ENSP,4000,1,Studies in Environmental Sci,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,margaret thompson,
+ENT,2000,1,Six-Legged Science,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,suellen pometto,
+ENT,2010,1,Insects in Myth & Religion,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,joseph culin,
+ENT,3010,1,Insect Biology and Diversity,0.21,0.21,0.36,0.15,0.03,0.0,0.0,0.03,eric benson,
+ENTR,1010,1,Entrepreneurial Mindset,0.44,0.37,0.08,0.02,0.08,0.0,0.0,0.01,john michael hannon,
+ENTR,2010,2,Select Top in Entrepreneurship,0.64,0.18,0.09,0.0,0.0,0.0,0.0,0.09,john michael hannon,
+ESED,8610,1,Practicum in Engr & Sci Educ,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,karen ann high,
+ETOX,4300,1,Toxicology,0.3,0.1,0.5,0.1,0.0,0.0,0.0,0.0,lisa bain,
+FCS,8300,1,Community Dev: Princ & Pract,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,areli moore peralta,
+FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.72,0.2,0.03,0.03,0.03,0.0,0.0,0.0,aubrey dean coffee,
+FDSC,2160,1,Baking Science,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,
+FDSC,3010,1,Food Regulations,0.77,0.2,0.02,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
+FDSC,4010,1,Food Chemistry I,0.5,0.39,0.1,0.02,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4040,1,Food Prsv & Process,0.44,0.41,0.13,0.02,0.0,0.0,0.0,0.0,anthony lou pometto,
+FDSC,4070,1,Quantity Food Production,0.76,0.12,0.0,0.03,0.09,0.0,0.0,0.0,heather batt,
+FDSC,4170,1,Seminar,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,aubrey dean coffee,
+FDSC,4300,1,Dairy Process & Sant,0.22,0.33,0.39,0.0,0.0,0.0,0.0,0.06,john mcgregor,
+FDSC,4500,11,Creative Inquiry-Food Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,paul dawson,
+FIN,2010,401,Intro to Personal Finance,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,joshua harris,
+FIN,2010,402,Intro to Personal Finance,0.64,0.23,0.06,0.02,0.03,0.0,0.0,0.03,joshua harris,
+FIN,2010,403,Intro to Personal Finance,0.58,0.3,0.07,0.05,0.0,0.0,0.0,0.0,joshua harris,
+FIN,2010,405,Intro to Personal Finance,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,
+FIN,2010,406,Intro to Personal Finance,0.86,0.07,0.02,0.01,0.03,0.0,0.0,0.01,joshua harris,
+FIN,2010,407,Intro to Personal Finance,0.92,0.02,0.02,0.0,0.02,0.0,0.0,0.02,joshua harris,
+FIN,3040,2,Risk & Insurance,0.18,0.38,0.33,0.05,0.08,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.0,0.24,0.35,0.24,0.12,0.0,0.0,0.06,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.26,0.4,0.26,0.06,0.03,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.23,0.26,0.37,0.11,0.0,0.0,0.0,0.03,kerri mcmillan,
+FIN,3050,5,Investment Analysis,0.14,0.19,0.33,0.14,0.08,0.0,0.0,0.11,john alexander,
+FIN,3060,1,Corporation Finance,0.17,0.17,0.25,0.09,0.25,0.0,0.0,0.08,william hol johnson,
+FIN,3060,2,Corporation Finance,0.29,0.12,0.14,0.22,0.16,0.0,0.0,0.08,william hol johnson,
+FIN,3060,3,Corporation Finance,0.34,0.14,0.21,0.16,0.09,0.0,0.0,0.05,william hol johnson,
+FIN,3060,4,Corporation Finance,0.17,0.23,0.19,0.08,0.19,0.0,0.0,0.15,william hol johnson,
+FIN,3060,5,Corporation Finance,0.1,0.23,0.38,0.19,0.04,0.0,0.0,0.06,ramon tolb franklin,
+FIN,3060,6,Corporation Finance,0.12,0.14,0.39,0.18,0.04,0.0,0.0,0.12,ramon tolb franklin,
+FIN,3060,7,Corporation Finance,0.22,0.29,0.29,0.14,0.05,0.0,0.0,0.02,ramon tolb franklin,
+FIN,3060,8,Corporation Finance,0.12,0.16,0.24,0.29,0.08,0.0,0.0,0.1,ramon tolb franklin,
+FIN,3060,9,Corporation Finance,0.28,0.26,0.18,0.22,0.04,0.0,0.0,0.02,melvin stith,
+FIN,3060,10,Corporation Finance,0.22,0.11,0.29,0.31,0.04,0.0,0.0,0.02,melvin stith,
+FIN,3060,401,Corporation Finance,0.17,0.42,0.23,0.07,0.06,0.0,0.0,0.04,jonathan godbey,
+FIN,3070,1,Prin of Real Estate,0.17,0.24,0.37,0.17,0.02,0.0,0.0,0.02,thomas springer,
+FIN,3070,2,Prin of Real Estate,0.24,0.24,0.34,0.12,0.05,0.0,0.0,0.0,thomas springer,
+FIN,3070,3,Prin of Real Estate,0.28,0.42,0.28,0.0,0.03,0.0,0.0,0.0,yannan shen,
+FIN,3080,1,Fin Inst & Mkts,0.21,0.49,0.26,0.03,0.0,0.0,0.0,0.03,lyudmila chernykh,
+FIN,3080,2,Fin Inst & Mkts,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,3080,3,Fin Inst & Mkts,0.38,0.38,0.17,0.05,0.02,0.0,0.0,0.0,daniel thoma greene,
+FIN,3110,1,Financial Management I,0.05,0.18,0.33,0.05,0.18,0.0,0.0,0.21,jack wolf,
+FIN,3110,2,Financial Management I,0.05,0.26,0.35,0.05,0.09,0.0,0.0,0.21,jack wolf,
+FIN,3110,3,Financial Management I,0.26,0.28,0.16,0.07,0.07,0.0,0.0,0.16,george bra lockhart,
+FIN,3110,4,Financial Management I,0.14,0.29,0.36,0.15,0.05,0.0,0.0,0.02,weike xu,
+FIN,3120,1,Financial Management II,0.12,0.35,0.32,0.09,0.06,0.0,0.0,0.06,vincent intintoli,
+FIN,3120,2,Financial Management II,0.16,0.34,0.24,0.21,0.03,0.0,0.0,0.03,vincent intintoli,
+FIN,3120,3,Financial Management II,0.23,0.17,0.43,0.1,0.03,0.0,0.0,0.03,blerina zykaj,
+FIN,3120,4,Financial Management II,0.17,0.36,0.24,0.17,0.02,0.0,0.0,0.05,weike xu,
+FIN,4010,1,Corporate Financial Analysis,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,george bra lockhart,
+FIN,4020,1,Corporate Valuation,0.39,0.39,0.16,0.06,0.0,0.0,0.0,0.0,angela morgan,
+FIN,4020,2,Corporate Valuation,0.24,0.35,0.35,0.0,0.06,0.0,0.0,0.0,angela morgan,
+FIN,4050,1,Portfolio Management & Theory,0.03,0.23,0.43,0.13,0.03,0.0,0.0,0.13,john alexander,
+FIN,4060,1,Derivatives Analysis,0.25,0.4,0.35,0.0,0.0,0.0,0.0,0.0,blerina zykaj,
+FIN,4110,1,Int Fin Mgt,0.22,0.41,0.3,0.05,0.0,0.0,0.0,0.03,luke asher devault,
+FIN,4110,2,Int Fin Mgt,0.18,0.53,0.18,0.0,0.06,0.0,0.0,0.06,luke asher devault,
+FIN,4170,1,Real Estate Finance,0.27,0.47,0.2,0.0,0.07,0.0,0.0,0.0,yannan shen,
+FIN,4980,2,CI in Finance: CFA,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,jack wolf,
+FNR,2040,1,Soil Information Systems,0.71,0.18,0.0,0.11,0.0,0.0,0.0,0.0,elena mikhailova,
+FNR,4700,1,Kennedy Waterfowl CI,0.69,0.0,0.31,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
+FNR,4900,1,Field Training in Natural Res,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,patricia layton,
+FNR,4990,1,Natural Resources Seminar,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,susan talley guynn,
+FOR,2050,1,Dendrology,0.34,0.25,0.22,0.09,0.06,0.0,0.0,0.03,donald hagan,
+FOR,2050,2,Dendrology,0.1,0.39,0.22,0.05,0.1,0.0,0.0,0.15,donald hagan,
+FOR,2050,3,Dendrology,0.36,0.33,0.13,0.05,0.05,0.0,0.0,0.08,donald hagan,
+FOR,2210,1,Forest Biology,0.17,0.3,0.23,0.15,0.08,0.0,0.0,0.07,althea simone hagan,
+FOR,3020,1,Forest Biometrics,0.33,0.4,0.23,0.0,0.0,0.0,0.0,0.03,lawrence gering,
+FOR,3040,1,Forest Resource Economics,0.79,0.15,0.0,0.0,0.0,0.0,0.0,0.05,puskar khanal,
+FOR,4100,1,Harvesting Processes,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,patrick hiesl,
+FOR,4130,1,Integrated Forest Pest Mgt,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,stephen cole,
+FOR,4160,1,Forest Policy and Admin,0.31,0.42,0.21,0.02,0.01,0.0,0.0,0.02,thomas straka,
+FOR,4170,1,Forest Resource Mgt & Regulatn,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,
+FOR,4310,1,Recreation Res Plan in For Mgt,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,robert baxte powell,
+FOR,4340,1,GIS for Natural Resources,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher post,
+FR,1010,1,Elementary French,0.18,0.53,0.06,0.12,0.0,0.0,0.0,0.12,anne salces  nedeo,
+FR,1010,2,Elementary French,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
+FR,1020,1,Elementary French,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,1020,2,Elementary French,0.81,0.0,0.13,0.06,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,1020,3,Elementary French,0.2,0.4,0.1,0.1,0.0,0.0,0.0,0.2,kenneth dav widgren,
+FR,2010,2,Intermediate French,0.21,0.47,0.26,0.0,0.0,0.0,0.0,0.05,kenneth dav widgren,
+FR,2010,3,Intermediate French,0.16,0.58,0.21,0.0,0.05,0.0,0.0,0.0,kenneth dav widgren,
+FR,2010,4,Intermediate French,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
+FR,2020,1,Intermediate French,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2020,2,Intermediate French,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,kelly digby peebles,
+FR,2020,3,Intermediate French,0.33,0.33,0.2,0.07,0.0,0.0,0.0,0.07,kenneth dav widgren,
+FR,2020,4,Intermediate French,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,3000,1,Survey of French Lit,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
+FR,3050,2,Int Fr Con & Comp I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph mai,
+FR,3070,1,French Civilization,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
+FR,4100,1,Francophone Lit,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,True
+GC,1010,1,Orientation to G C,0.68,0.14,0.04,0.02,0.06,0.0,0.0,0.06,john leininger,
+GC,1010,2,Orientation to G C,0.39,0.49,0.0,0.0,0.02,0.0,0.0,0.1,john leininger,
+GC,1020,1,Computer Art & CAD Foundations,0.6,0.29,0.04,0.0,0.02,0.0,0.0,0.04,carol jones,
+GC,1020,2,Computer Art & CAD Foundations,0.52,0.3,0.05,0.05,0.02,0.0,0.0,0.05,carol jones,
+GC,1030,1,G C I for Pkgsc,0.21,0.47,0.32,0.0,0.0,0.0,0.0,0.0,john jacobs,
+GC,1040,1,Graphic Communications I,0.49,0.27,0.14,0.0,0.07,0.0,0.0,0.03,rebecca suza edlein,
+GC,2070,1,Graphic Communications II,0.66,0.22,0.08,0.02,0.0,0.0,0.0,0.02,charles tabor weiss,
+GC,3400,1,Digital Imaging and eMedia,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0,erica black walker,
+GC,3460,1,Ink and Substrates,0.23,0.55,0.19,0.02,0.0,0.0,0.0,0.0,liam henry 'hara,
+GC,3500,1,G C Internship I,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,carol jones,
+GC,4060,1,Package and Specialty Printing,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,kern cox,
+GC,4400,1,Commercial Printing,0.24,0.63,0.05,0.0,0.05,0.0,0.0,0.02,eric weisenmiller,
+GC,4440,1,Current Dev/Trends in Gr Comm,0.67,0.25,0.06,0.0,0.0,0.0,0.0,0.03,samuel ingram,
+GC,4480,1,Plan & Cont Printing Functions,0.89,0.06,0.02,0.0,0.0,0.0,0.0,0.02,nona woolbright,
+GC,4500,1,GC Internship II,0.9,0.0,0.1,0.0,0.0,0.0,0.0,0.0,carol jones,
+GC,4800,1,Senior Seminar in GC,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,
+GC,6060,1,Pkg & Spec Prtg,0.5,0.33,0.0,0.0,0.17,0.0,0.0,0.0,kern cox,
+GEN,1030,1,Careers in Bioch/Gen,0.81,0.09,0.06,0.03,0.01,0.0,0.0,0.0,joseph paul thames,
+GEN,3000,1,Fundamental Genetics,0.31,0.41,0.17,0.06,0.01,0.0,0.0,0.05,kate leanne wi tsai,
+GEN,3000,2,Fundamental Genetics,0.28,0.4,0.19,0.07,0.03,0.0,0.0,0.04,kate leanne wi tsai,
+GEN,3020,1,Molecular & General Genetics,0.3,0.36,0.18,0.07,0.04,0.0,0.0,0.05,lukasz kozubowski,
+GEN,3020,2,Molec & General Genetics (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True
+GEN,3020,4,Molecular & General Genetics,0.42,0.36,0.12,0.03,0.06,0.0,0.0,0.0,haiying liang,
+GEN,4200,1,Molecular Genetics & Gene Reg,0.25,0.43,0.23,0.07,0.0,0.0,0.0,0.02,julia frugoli,
+GEN,4200,2,Molecular Genetics & Gen (HON),0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,True
+GEN,4210,3,Mol Gen Gene Reg Lab,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
+GEN,4400,1,Bioinformatics,0.62,0.24,0.07,0.05,0.0,0.0,0.0,0.02,frank alexan feltus,
+GEN,4500,1,Comparative Genetics,0.37,0.32,0.26,0.0,0.0,0.0,0.0,0.05,leigh anne clark,
+GEN,4900,1,Epigenetics,0.56,0.25,0.0,0.13,0.0,0.0,0.0,0.06,rajandeep si sekhon,
+GEOG,1010,2,Intro to Geography,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,david doran,
+GEOG,1030,1,World Regional Geography,0.81,0.15,0.02,0.01,0.0,0.0,0.0,0.01,david doran,
+GEOG,1030,2,World Regional Geography,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christa smith,
+GEOG,1030,3,World Regional Geography,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,david doran,
+GEOG,3030,1,Urban Geography,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,christa smith,
+GEOL,1010,1,Physical Geology,0.23,0.29,0.22,0.09,0.09,0.0,0.0,0.09,alan coulson,
+GEOL,1010,2,Physical Geology,0.18,0.32,0.21,0.12,0.07,0.0,0.0,0.1,alan coulson,
+GEOL,1010,3,Physical Geology,0.49,0.33,0.07,0.07,0.0,0.0,0.0,0.04,kelly best lazar,
+GEOL,1010,4,Physical Geology,0.03,0.29,0.26,0.23,0.17,0.0,0.0,0.03,melissa ranhofer,
+GEOL,1030,1,Physical Geol Lab,0.67,0.17,0.08,0.0,0.04,0.0,0.0,0.04,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.26,0.22,0.3,0.09,0.09,0.0,0.0,0.04,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.46,0.33,0.21,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.5,0.21,0.21,0.0,0.04,0.0,0.0,0.04,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.74,0.17,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.75,0.13,0.04,0.0,0.0,0.0,0.0,0.08,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.67,0.25,0.04,0.0,0.04,0.0,0.0,0.0,alan coulson,
+GEOL,1030,13,Physical Geol Lab,0.46,0.38,0.13,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,2050,1,Mineralogy & Intro Petrology,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,lin shuller-nickles,
+GEOL,2070,1,Min & Intro Pet Lab,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,2700,1,Sustainable Water,0.7,0.15,0.0,0.0,0.0,0.0,0.0,0.15,stephen mich moysey,
+GEOL,2750,1,Field Methods,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,3000,1,Environmental Geology,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,4150,1,Analysis Geological Processes,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
+GEOL,4820,1,Groundwater & Contam Transport,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
+GEOL,7900,500,Biogeography And Geology of SC,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,john robert wagner,
+GEOL,8080,1,Groundwater Modeling,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
+GER,1010,1,Elementary German,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,oswald harris king,
+GER,1010,2,Elementary German,0.24,0.41,0.06,0.12,0.06,0.0,0.0,0.12,oswald harris king,
+GER,1020,1,Elementary German,0.5,0.3,0.0,0.0,0.0,0.0,0.0,0.2,isabel meusen,
+GER,1020,2,Elementary German,0.25,0.42,0.17,0.0,0.08,0.0,0.0,0.08,isabel meusen,
+GER,2010,1,Intermediate German,0.32,0.32,0.26,0.0,0.0,0.0,0.0,0.11, lee ferrell,
+GER,2010,2,Intermediate German,0.33,0.13,0.33,0.07,0.07,0.0,0.0,0.07,gabriela stoicea,
+GER,2020,1,Intermediate German,0.05,0.26,0.37,0.21,0.05,0.0,0.0,0.05,johannes schmidt,
+GER,3400,1,German Culture,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,oswald harris king,
+HCC,8310,1,Fundamentals of Hcc,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,brygg anders ullmer,
+HCC,8330,1,HCC Research Methods,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kelly caine,
+HCC,8810,1,Selected Topic: Measu/Evalu II,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,bart knijnenburg,
+HCG,9040,400,Knowledge Development,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+HIST,1010,1,History of the United States,0.21,0.62,0.09,0.0,0.06,0.0,0.0,0.03,paul chris anderson,
+HIST,1020,1,Hist of the U S,0.35,0.47,0.12,0.06,0.0,0.0,0.0,0.0,john andrew,
+HIST,1020,2,Hist of the U S,0.35,0.57,0.08,0.0,0.0,0.0,0.0,0.0,william camp,
+HIST,1220,1,"Hist, Tech & Society",0.12,0.51,0.19,0.08,0.06,0.0,0.0,0.04,pamela mack,
+HIST,1240,1,Environmental History Survey,0.11,0.5,0.28,0.06,0.06,0.0,0.0,0.0,james brad jeffries,
+HIST,1240,2,Environmental History Survey,0.03,0.5,0.31,0.03,0.06,0.0,0.0,0.06,james brad jeffries,
+HIST,1720,1,The West and the World I,0.36,0.43,0.08,0.02,0.03,0.0,0.0,0.07,caroline dunn clark,
+HIST,1720,2,The West and the World I,0.21,0.47,0.22,0.04,0.04,0.0,0.0,0.02,steven marks,
+HIST,1730,1,The West and the World II,0.26,0.43,0.19,0.01,0.03,0.0,0.0,0.08, alan grubb,
+HIST,1730,2,The West and the World II,0.33,0.39,0.11,0.0,0.06,0.0,0.0,0.11,sandra nic mokalled,
+HIST,2990,2,Historian's Craft,0.75,0.15,0.0,0.05,0.0,0.0,0.0,0.05,rachel anne moore,
+HIST,2990,3,Historian's Craft,0.47,0.42,0.0,0.0,0.0,0.0,0.0,0.11,thomas kuehn,
+HIST,3040,1,Indus & Progr Era,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06, roger grant,
+HIST,3060,1,US: Postwar World 1945-1975,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,william camp,
+HIST,3100,1,History of Religion in the US,0.33,0.22,0.28,0.17,0.0,0.0,0.0,0.0,elizabeth jemison,
+HIST,3120,1,Afr Amer Hist 1877 to Present,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,
+HIST,3170,1,Hist of Nat. Am. Relig/Culture,0.29,0.29,0.07,0.0,0.14,0.0,0.0,0.21,james brad jeffries,
+HIST,3280,1,US Legal History to 1890,0.7,0.27,0.0,0.0,0.0,0.0,0.0,0.03,lee brady wilson,
+HIST,3300,1,Hist of Mod China,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,edwin moise,
+HIST,3390,1,Africa 1875-Present,0.53,0.24,0.12,0.12,0.0,0.0,0.0,0.0,james burns,
+HIST,3410,1,Modern Mexico,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
+HIST,3630,1,Britain Since 1688,0.55,0.38,0.07,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
+HIST,3670,1,Modern Ireland,0.52,0.37,0.04,0.0,0.04,0.0,0.0,0.04,michael silvestri,
+HIST,3730,1,Age of Protestant Reformation,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,thomas kuehn,
+HIST,3750,1,Revolutionary Europe,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0, alan grubb,
+HIST,3900,1,Modern Military History,0.18,0.41,0.29,0.06,0.0,0.0,0.0,0.06,edwin moise,
+HIST,4000,1,Local and Nearby History,0.77,0.08,0.0,0.0,0.0,0.0,0.0,0.15, roger grant,
+HIST,4510,1,Alexander the Great,0.27,0.53,0.07,0.0,0.0,0.0,0.0,0.13,elizabeth carney,
+HIST,4720,1,Medieval Conquests & Crusades,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,caroline dunn clark,
+HIST,4870,1,World War II,0.03,0.87,0.1,0.0,0.0,0.0,0.0,0.0,john andrew,
+HIST,4900,1,Northern Ireland,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,michael silvestri,
+HIST,4900,3,Disney Parks,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
+HIST,4920,1,The US in the Atomic Age,0.29,0.53,0.0,0.12,0.0,0.0,0.0,0.06,william camp,
+HIST,8000,3,Film and History,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,james burns,
+HLTH,2020,1,Introduction to Public Health,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,2,Introduction to Public Health,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,3,Introduction to Public Health,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,4,Introduction to Public Health,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,5,Introduction to Public Health,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,6,Introduction to Public Health,0.6,0.2,0.07,0.0,0.0,0.0,0.0,0.13,becky ann tugman,
+HLTH,2020,400,Introduction to Public Health,0.65,0.2,0.05,0.05,0.05,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2030,2,Health Care Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+HLTH,2400,1,Deter of Hlth Behav,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2400,2,Deter of Hlth Behav,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2600,2,Medical Terminology & Comm,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2980,1,Human Health and Disease,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,2980,2,Human Health and Disease,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,3400,1,Hlth Prom Prog Plan,0.44,0.44,0.12,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,3610,1,Int Health Care Econ,0.5,0.42,0.0,0.04,0.0,0.0,0.0,0.04,khoa dang truong,
+HLTH,3800,1,Epidemiology,0.42,0.32,0.16,0.05,0.0,0.0,0.0,0.05,hugh spitler,
+HLTH,3800,2,Epidemiology,0.74,0.19,0.03,0.0,0.03,0.0,0.0,0.0,hugh spitler,
+HLTH,3800,400,Epidemiology,0.44,0.22,0.22,0.06,0.06,0.0,0.0,0.0,deborah alma falta,
+HLTH,3980,1,Health Appraisal Skills,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,3980,2,Health Appraisal Skills,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4000,4,Public Hlth Social Marketing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,debra mitch charles,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.59,0.29,0.1,0.02,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4400,1,Manag Hlth Serv Org,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,george paul  newby,
+HLTH,4750,1,Hlthcr Oper Mgmt Res,0.63,0.29,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,
+HLTH,4900,1,Res Eval St Pub Hlth,0.55,0.26,0.11,0.05,0.0,0.0,0.0,0.03,lingling zhang,
+HLTH,4900,2,Res Eval St Pub Hlth,0.63,0.25,0.06,0.06,0.0,0.0,0.0,0.0,lingling zhang,
+HLTH,8030,1,Theories and Determ of Health,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joel edwar williams,
+HLTH,8120,500,Clinical and Translational Sci,0.5,0.17,0.0,0.0,0.0,0.0,0.0,0.33,ronald gimbel,
+HLTH,8140,500,Health Sys Quality Improvement,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,windsor we sherrill,
+HLTH,8320,1,Quantitative Analy in Hlth II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
+HON,1900,1,Hell in Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,True
+HON,1930,2,The Russian Revolution,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,True
+HON,1940,2,Scientific Skepticism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey appling,True
+HON,2020,3,Wisdom of the Moderns,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,colin pearce,True
+HON,2200,3,Europe in the Age of Dictators,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,True
+HON,2210,3,Southern Literature,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,michael lemahieu,True
+HON,2210,4,Imaginary Friends in Fiction,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True
+HON,2220,1,Lit & Science in Modernism,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,gabriela stoicea,True
+HORT,1010,1,Horticulture,0.9,0.05,0.03,0.0,0.0,0.0,0.0,0.02,ellen anita vincent,
+HORT,2020,1,Adobe Digital Design,0.8,0.11,0.0,0.0,0.0,0.0,0.0,0.09,janice ann lay,
+HORT,2100,1,Growing Fall Plants,0.08,0.46,0.33,0.04,0.04,0.0,0.0,0.04,james emerson faust,
+HORT,2120,1,Turfgrass Culture,0.5,0.41,0.08,0.0,0.0,0.0,0.0,0.02,haibo liu,
+HORT,3030,1,Landscape Plants,0.18,0.26,0.24,0.15,0.1,0.0,0.0,0.08,robert polomski,
+HORT,3080,1,Sust Landsc Des Install Maint,0.93,0.02,0.05,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HORT,4120,1,Adv Turfgrass Mgt,0.45,0.27,0.0,0.0,0.09,0.0,0.0,0.18,lambert mccarty,
+HP,8010,1,Preservation Law and Econ,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,william jackso cook,
+HP,8030,1,Building Tech and Pathology,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,amalia leifeste,
+HRD,8200,400,Human Perform Improv,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,william havice,
+HRD,8200,401,Human Perform Improv,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william havice,
+HRD,8300,400,Concepts of H R D,0.91,0.03,0.06,0.0,0.0,0.0,0.0,0.0,angela danie carter,
+HRD,8600,400,Instruc Mat Devel,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,cynthia sims,
+IE,2100,1,Des Analysis Wrk Sys,0.09,0.47,0.35,0.09,0.01,0.0,0.0,0.0,david neyens,
+IE,2800,1,Deterministic Operations Rsrch,0.13,0.25,0.12,0.17,0.17,0.0,0.0,0.17,robert james riggs,
+IE,3010,1,Systems Design I,0.32,0.47,0.19,0.01,0.0,0.0,0.0,0.01,robert james riggs,
+IE,3600,1,Industrial Apps of Prob/Stat I,0.23,0.23,0.23,0.12,0.14,0.0,0.0,0.05,tugce isik,
+IE,3610,1,Industrial App of Prob/Stat II,0.4,0.25,0.1,0.1,0.05,0.0,0.0,0.1,brian melloy,
+IE,3810,1,Probabilistic Operations Rsrch,0.14,0.34,0.25,0.12,0.09,0.0,0.0,0.07,amin khademi,
+IE,3840,1,Engr Econ Analysis,0.29,0.16,0.2,0.1,0.13,0.0,0.0,0.13,brian melloy,
+IE,3860,1,Prod Plan & Cont,0.31,0.29,0.2,0.13,0.05,0.0,0.0,0.03,robert james riggs,
+IE,4400,1,Decision Support Sys,0.45,0.28,0.16,0.03,0.05,0.0,0.0,0.02,sandra dun eksioglu,
+IE,4400,2,Decision Support Sys,0.29,0.35,0.24,0.06,0.06,0.0,0.0,0.0,sandra dun eksioglu,
+IE,4610,1,Quality Engineering,0.27,0.34,0.2,0.16,0.01,0.0,0.0,0.02,byung rae cho,
+IE,4650,1,Facilities Planning & Design,0.14,0.55,0.27,0.04,0.01,0.0,0.0,0.0,william ferrell,
+IE,4820,1,Systems Modeling,0.44,0.37,0.19,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
+IE,4820,2,Systems Modeling,0.43,0.44,0.12,0.01,0.0,0.0,0.0,0.0,kevin taaffe,
+IE,4910,1,Network Flows for IE Apps,0.29,0.41,0.18,0.12,0.0,0.0,0.0,0.0,burak eksioglu,
+IE,4910,2,Service Engineering,0.21,0.52,0.24,0.03,0.0,0.0,0.0,0.0,tugce isik,
+IE,4910,3,Human Centered Design & Engr,0.31,0.59,0.07,0.0,0.0,0.0,0.0,0.03,laura miche stanley,
+IE,8000,1,Human Factors Eng,0.49,0.47,0.05,0.0,0.0,0.0,0.0,0.0,david neyens,
+IE,8030,1,Engr Optimization and Apps,0.48,0.45,0.05,0.0,0.0,0.0,0.0,0.03,jonathan cole smith,
+IE,8090,1,Model Sys Under Risk,0.43,0.35,0.18,0.0,0.0,0.0,0.0,0.05,burak eksioglu,
+IE,8510,1,Descriptive Analytics,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,mary elizabeth kurz,
+IE,8530,1,Foundations of Quality,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,byung rae cho,
+IE,8550,1,SC & Logistics Modeling II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.84,0.13,0.03,lisa marie robinson,
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,caren kelley-hall,
+IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.48,0.52,0.0,meredith fan wilson,
+ITAL,1010,1,Elementary Italian,0.67,0.2,0.07,0.0,0.07,0.0,0.0,0.0,julia schmidt,
+ITAL,1010,2,Elementary Italian,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,luca barattoni,
+ITAL,1010,3,Elementary Italian,0.38,0.25,0.19,0.0,0.13,0.0,0.0,0.06,julia schmidt,
+ITAL,1010,4,Elementary Italian,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+ITAL,1020,1,Elementary Italian,0.31,0.31,0.06,0.0,0.06,0.0,0.0,0.25,lyudmyla tsykalova,
+ITAL,2010,1,Intermediate Italian,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+JAPN,1010,1,Elementary Japanese,0.28,0.17,0.17,0.11,0.11,0.0,0.0,0.17,saori suto,
+JAPN,1010,2,Elementary Japanese,0.32,0.32,0.11,0.05,0.16,0.0,0.0,0.05,saori suto,
+JAPN,2010,1,Intermed Japanese,0.31,0.31,0.31,0.08,0.0,0.0,0.0,0.0,saori suto,
+JAPN,4010,1,Japanese Lit in Translation,0.47,0.35,0.06,0.12,0.0,0.0,0.0,0.0,kumiko saito,
+JAPN,4060,1,Intro to Japanese Literature,0.67,0.08,0.08,0.17,0.0,0.0,0.0,0.0,kumiko saito,
+JUST,2880,1,The Criminal Justice System,0.4,0.32,0.19,0.09,0.0,0.0,0.0,0.0,margaret tina britz,
+JUST,2890,1,Criminology,0.89,0.06,0.03,0.0,0.0,0.0,0.0,0.03,angelia turner,
+JUST,4680,1,Criminal Evidence,0.4,0.28,0.23,0.09,0.0,0.0,0.0,0.0,margaret tina britz,
+JUST,4910,1,Policing,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,david williams,
+LANG,2540,1,Introduction to World Cinemas,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,joseph mai,
+LANG,3710,1,Language and Culture,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,yanhua zhang,
+LARC,1150,1,Intro Landscape Architecture,0.68,0.14,0.11,0.04,0.04,0.0,0.0,0.0,mary padua,
+LARC,1280,1,Technical Graphics,0.18,0.41,0.32,0.09,0.0,0.0,0.0,0.0,cecile martin,
+LARC,1510,1,Basic Design I,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,cecile martin,
+LARC,2510,1,Larch Design Fund,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jessica fernandez,
+LARC,2620,1,Design Impl I,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,pai liu,
+LARC,3510,1,Regional Design,0.41,0.35,0.12,0.0,0.06,0.0,0.0,0.06,matthew neal powers,
+LARC,4540,1,Urban Design Studio,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,paul russell,
+LARC,4620,1,Design Implementation III,0.56,0.25,0.06,0.06,0.0,0.0,0.0,0.06,jessica fernandez,
+LARC,8430,1,Interdisc Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,
+LAW,3220,1,Legal Env of Bus,0.27,0.45,0.29,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,2,Legal Env of Bus,0.33,0.43,0.18,0.02,0.04,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,3,Legal Env of Bus,0.29,0.31,0.33,0.0,0.06,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,4,Legal Env of Bus,0.1,0.44,0.38,0.02,0.06,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,5,Legal Env of Bus,0.05,0.38,0.38,0.1,0.05,0.0,0.0,0.05,kenneth toussaint,
+LAW,3220,6,Legal Env of Bus,0.22,0.39,0.29,0.08,0.0,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,7,Legal Env of Bus,0.31,0.42,0.23,0.02,0.02,0.0,0.0,0.0,kath kisska-schulze,
+LAW,3220,8,Legal Env of Bus,0.39,0.49,0.1,0.02,0.0,0.0,0.0,0.0,kath kisska-schulze,
+LAW,3220,9,Legal Env of Bus,0.3,0.4,0.25,0.03,0.0,0.0,0.0,0.03,john hine,
+LAW,3220,10,Legal Env of Bus,0.29,0.41,0.18,0.02,0.0,0.0,0.0,0.1,kath kisska-schulze,
+LAW,3220,400,Legal Env of Bus,0.32,0.47,0.12,0.03,0.03,0.0,0.0,0.03,virgini ward-vaughn,
+LAW,3220,401,Legal Env of Bus,0.33,0.37,0.18,0.02,0.03,0.0,0.0,0.07,virgini ward-vaughn,
+LAW,3220,402,Legal Env of Bus,0.4,0.37,0.12,0.0,0.04,0.0,0.0,0.07,virgini ward-vaughn,
+LAW,3220,403,Legal Env of Bus,0.33,0.43,0.14,0.03,0.03,0.0,0.0,0.03,virgini ward-vaughn,
+LAW,3330,1,Real Estate Law,0.0,0.47,0.33,0.07,0.1,0.0,0.0,0.03,judson jahn,
+LAW,3330,2,Real Estate Law,0.21,0.5,0.21,0.0,0.06,0.0,0.0,0.03,judson jahn,
+LAW,4050,1,Construction Law,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.9,0.03,0.06, lee ferrell,
+LS,1000,1,Therapeutic Yoga,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,1000,2,Therapeutic Yoga,0.67,0.19,0.0,0.0,0.0,0.0,0.0,0.14,ranjanbala dil amin,
+LS,1000,3,Therapeutic Yoga,0.8,0.05,0.0,0.0,0.0,0.0,0.0,0.15,ranjanbala dil amin,
+LS,1000,4,Intro to Barre,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,lauren eliza george,
+LS,1000,5,Intro to Barre,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lauren eliza george,
+LS,1000,10,Clemson Life,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,kristin anne neff,
+LS,1000,14,Freshman Outdoor,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,emily grace turke,
+LS,1000,28,Stand up Pabbleboarding,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,william holland,
+LS,1410,1,Top Rope Climbing,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,michelle tuday,
+LS,1410,2,Top Rope Climbing,0.73,0.13,0.0,0.0,0.0,0.0,0.0,0.13,michelle tuday,
+LS,1410,4,Top Rope Climbing,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michelle tuday,
+LS,1410,5,Top Rope Climbing,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,michelle tuday,
+LS,1560,2,Riflery,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,hubert cox,
+LS,1560,7,Riflery,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,
+LS,1560,16,Riflery,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,
+LS,1570,1,Shotgun Sports,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,john jeffrey price,
+LS,1570,6,Shotgun Sports,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,william cro mahoney,
+LS,1750,1,Fly Fishing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james micha harvell,
+LS,1850,1,Bowling,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,megan elizabet cato,
+LS,1850,2,Bowling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,alexandra sandoval,
+LS,1850,10,Bowling,0.86,0.0,0.05,0.05,0.0,0.0,0.0,0.05,tyler bennett,
+LS,1940,1,Racquetball,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,raymond petersen,
+LS,1960,1,Intro to Billiards,0.69,0.0,0.0,0.0,0.0,0.0,0.0,0.31,broadus fleming,
+LS,1980,4,Golf,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,jason jordan,
+LS,1980,5,Golf,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jason jordan,
+LS,1980,9,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,wesley scott womble,
+LS,2200,7,Shag,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,broadus fleming,
+LS,2270,1,Intro to Swing Dance,0.92,0.03,0.0,0.0,0.03,0.0,0.0,0.03,paul hoke,
+LS,2270,2,Intro to Swing Dance,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,paul hoke,
+LS,2270,3,Intro to Swing Dance,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,paul hoke,
+LS,2320,2,Core Training,0.76,0.1,0.05,0.0,0.0,0.0,0.0,0.1,diane moreno,
+LS,2320,3,Core Training,0.78,0.06,0.11,0.0,0.06,0.0,0.0,0.0,diane moreno,
+LS,2320,5,Core Training,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,2350,1,Basic Yoga,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2350,2,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
+LS,2350,3,Basic Yoga,0.86,0.05,0.05,0.05,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2350,4,Basic Yoga,0.81,0.1,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dil amin,
+LS,2350,5,Basic Yoga,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,2350,7,Basic Yoga,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2350,8,Basic Yoga,0.87,0.09,0.0,0.0,0.04,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2380,4,Vinyasa Flow Yoga,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2420,1,Meditation and Relax,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,2,Meditation and Relax,0.91,0.0,0.04,0.04,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2420,4,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dil amin,
+LS,2420,5,Meditation and Relax,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2420,6,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,7,Meditation and Relax,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dil amin,
+LS,2420,8,Meditation and Relax,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
+LS,2450,1,Pilates,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,melanie ivey job,
+LS,2450,5,Pilates,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,2450,6,Pilates,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,diane moreno,
+LS,2750,8,First Aid/Cpr,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,christopher loomis,
+MATH,1010,1,Essen Math for Informed Soc,0.44,0.39,0.06,0.0,0.06,0.0,0.0,0.06,ebenezer eduafo,
+MATH,1010,2,Essen Math for Informed Soc,0.59,0.29,0.0,0.12,0.0,0.0,0.0,0.0,ebenezer eduafo,
+MATH,1010,3,Essen Math for Informed Soc,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,xiyan tan,
+MATH,1010,4,Essen Math for Informed Soc,0.65,0.12,0.12,0.06,0.0,0.0,0.0,0.06,xiyan tan,
+MATH,1010,5,Essen Math for Informed Soc,0.39,0.39,0.06,0.17,0.0,0.0,0.0,0.0,jun yuan,
+MATH,1010,6,Essen Math for Informed Soc,0.44,0.22,0.22,0.11,0.0,0.0,0.0,0.0,jun yuan,
+MATH,1010,7,Essen Math for Informed Soc,0.61,0.31,0.03,0.03,0.0,0.0,0.0,0.03,marilyn reba,
+MATH,1020,1,Business Calculus I,0.32,0.16,0.21,0.11,0.05,0.0,0.0,0.16,madeleine stville,
+MATH,1020,2,Business Calculus I,0.32,0.37,0.26,0.0,0.05,0.0,0.0,0.0,madeleine stville,
+MATH,1020,3,Business Calculus I,0.26,0.42,0.16,0.05,0.05,0.0,0.0,0.05,morgan elston,
+MATH,1020,4,Business Calculus I,0.16,0.32,0.05,0.21,0.21,0.0,0.0,0.05,morgan elston,
+MATH,1020,5,Business Calculus I,0.21,0.37,0.26,0.11,0.05,0.0,0.0,0.0,michael thoma cowen,
+MATH,1020,6,Business Calculus I,0.47,0.21,0.21,0.05,0.05,0.0,0.0,0.0,michael thoma cowen,
+MATH,1020,7,Business Calculus I,0.17,0.22,0.39,0.06,0.06,0.0,0.0,0.11,aaro ramirez flores,
+MATH,1020,8,Business Calculus I,0.26,0.32,0.26,0.11,0.0,0.0,0.0,0.05,aaro ramirez flores,
+MATH,1020,9,Business Calculus I,0.28,0.28,0.17,0.06,0.11,0.0,0.0,0.11, kamronnaher,
+MATH,1020,10,Business Calculus I,0.21,0.21,0.32,0.16,0.11,0.0,0.0,0.0, kamronnaher,
+MATH,1020,11,Business Calculus I,0.42,0.16,0.16,0.11,0.11,0.0,0.0,0.05,emma cinatl,
+MATH,1020,12,Business Calculus I,0.06,0.5,0.13,0.13,0.13,0.0,0.0,0.06,emma cinatl,
+MATH,1020,13,Business Calculus I,0.37,0.37,0.05,0.11,0.05,0.0,0.0,0.05,zachary david espe,
+MATH,1020,14,Business Calculus I,0.26,0.37,0.16,0.16,0.0,0.0,0.0,0.05,zachary david espe,
+MATH,1020,15,Business Calculus I,0.05,0.16,0.21,0.11,0.32,0.0,0.0,0.16,anna caro bachstein,
+MATH,1020,16,Business Calculus I,0.16,0.32,0.11,0.11,0.21,0.0,0.0,0.11,anna caro bachstein,
+MATH,1020,17,Business Calculus I,0.17,0.22,0.28,0.11,0.11,0.0,0.0,0.11,scott scruggs,
+MATH,1020,18,Business Calculus I,0.5,0.11,0.17,0.11,0.11,0.0,0.0,0.0,aaron moose,
+MATH,1020,19,Business Calculus I,0.16,0.37,0.26,0.0,0.16,0.0,0.0,0.05,rachel bass lanning,
+MATH,1020,20,Business Calculus I,0.26,0.16,0.42,0.11,0.05,0.0,0.0,0.0,john william grant,
+MATH,1020,21,Business Calculus I,0.21,0.42,0.26,0.0,0.11,0.0,0.0,0.0,rachel bass lanning,
+MATH,1020,22,Business Calculus I,0.26,0.26,0.16,0.11,0.05,0.0,0.0,0.16,molly adam honecker,
+MATH,1020,23,Business Calculus I,0.39,0.39,0.11,0.0,0.06,0.0,0.0,0.06,shanshan jia,
+MATH,1020,24,Business Calculus I,0.37,0.21,0.21,0.11,0.05,0.0,0.0,0.05,todd anthony morra,
+MATH,1020,25,Business Calculus I,0.33,0.22,0.28,0.06,0.11,0.0,0.0,0.0,yibo xu,
+MATH,1020,26,Business Calculus I,0.16,0.32,0.32,0.05,0.11,0.0,0.0,0.05,shanshan jia,
+MATH,1020,27,Business Calculus I,0.11,0.32,0.42,0.05,0.05,0.0,0.0,0.05,peter westerbaan,
+MATH,1020,28,Business Calculus I,0.44,0.22,0.28,0.0,0.06,0.0,0.0,0.0,todd anthony morra,
+MATH,1020,29,Business Calculus I,0.17,0.33,0.22,0.06,0.17,0.0,0.0,0.06,yibo xu,
+MATH,1020,30,Business Calculus I,0.42,0.26,0.16,0.05,0.05,0.0,0.0,0.05,kara ail stasikelis,
+MATH,1020,31,Business Calculus I,0.21,0.47,0.0,0.05,0.16,0.0,0.0,0.11,li he,
+MATH,1020,32,Business Calculus I,0.26,0.16,0.37,0.0,0.16,0.0,0.0,0.05,aaron moose,
+MATH,1020,33,Business Calculus I,0.21,0.11,0.42,0.05,0.11,0.0,0.0,0.11,li he,
+MATH,1020,34,Business Calculus I,0.26,0.11,0.21,0.16,0.26,0.0,0.0,0.0,scott scruggs,
+MATH,1020,35,Business Calculus I,0.42,0.22,0.24,0.02,0.04,0.0,0.0,0.04,jennifer ray newton,
+MATH,1020,36,Business Calculus I,0.33,0.27,0.16,0.04,0.09,0.0,0.0,0.11,jennifer ray newton,
+MATH,1020,37,Business Calculus I,0.26,0.26,0.32,0.0,0.16,0.0,0.0,0.0,peter westerbaan,
+MATH,1020,38,Business Calculus I,0.22,0.39,0.33,0.0,0.06,0.0,0.0,0.0,molly adam honecker,
+MATH,1020,39,Business Calculus I,0.45,0.2,0.2,0.07,0.05,0.0,0.0,0.02,jennifer van dyken,
+MATH,1020,40,Business Calculus I,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,randy davidson,
+MATH,1020,41,Business Calculus I,0.29,0.23,0.22,0.06,0.18,0.0,0.0,0.01,randy davidson,
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.57,0.41,0.02,donna simms,
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.62,0.04,stephen peele,
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.47,0.47,0.07,stephen peele,
+MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.5,0.39,0.11,andrew walton green,
+MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.52,0.1,sergey charnyi,
+MATH,1040,6,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.24,0.64,0.12,stephen garth,
+MATH,1040,7,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.64,0.33,0.02,stephen peele,
+MATH,1040,8,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.46,0.52,0.02,nicholas ahlstrom,
+MATH,1040,9,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.45,0.33,0.21,xiaoyuan liu,
+MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.5,0.14,xun dong,
+MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.39,0.52,0.09,stefan adam bock,
+MATH,1040,12,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.34,0.59,0.07,stefan adam bock,
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.44,0.54,0.02,tony thanh nguyen,
+MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.72,0.28,0.0,tony thanh nguyen,
+MATH,1050,403,Precalculus,0.0,0.0,0.0,0.0,0.0,0.59,0.36,0.05,tony thanh nguyen,
+MATH,1060,1,Calculus of One Variable I,0.17,0.29,0.32,0.07,0.07,0.0,0.0,0.07,thomas clevenger,
+MATH,1060,2,Calculus of One Variable I,0.25,0.23,0.2,0.04,0.17,0.0,0.0,0.11,calvin williams,
+MATH,1060,3,Calculus of One Variable I,0.25,0.32,0.09,0.05,0.14,0.0,0.0,0.16,paul james cubre,
+MATH,1060,4,Calculus of One Variable I,0.35,0.26,0.23,0.0,0.13,0.0,0.0,0.03,huixi li,
+MATH,1060,5,Calculus of One Variable I,0.2,0.27,0.18,0.09,0.04,0.0,0.0,0.22,pye phyo aung,
+MATH,1060,6,Calculus of One Variable I,0.18,0.23,0.3,0.11,0.14,0.0,0.0,0.05,rebecca ramos,
+MATH,1060,8,Calculus of One Variable I,0.25,0.28,0.21,0.05,0.14,0.0,0.0,0.06,judith cottingham,
+MATH,1060,10,Calculus of One Variable I,0.22,0.25,0.2,0.09,0.16,0.0,0.0,0.07,judith cottingham,
+MATH,1060,11,Calculus of One Variable I,0.41,0.28,0.06,0.06,0.13,0.0,0.0,0.06,thowhida akther,
+MATH,1060,14,Calculus of One Variable I,0.12,0.23,0.26,0.14,0.12,0.0,0.0,0.14,paul james cubre,
+MATH,1060,15,Calculus of One Variable I,0.31,0.22,0.17,0.11,0.06,0.0,0.0,0.14,fun choi john chan,
+MATH,1060,16,Calculus of One Variable I,0.25,0.36,0.09,0.05,0.11,0.0,0.0,0.14,pye phyo aung,
+MATH,1060,17,Calculus of One Variable I,0.16,0.24,0.27,0.07,0.16,0.0,0.0,0.11,pye phyo aung,
+MATH,1060,18,Calculus of One Variable I,0.21,0.39,0.33,0.0,0.0,0.0,0.0,0.06,marilyn reba,
+MATH,1060,100,Calc of One Variable I (HON),0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,boshi yang,True
+MATH,1060,201,Calculus of One Variable I,0.25,0.44,0.17,0.04,0.0,0.0,0.0,0.1,james edwar gossell,
+MATH,1060,202,Calculus of One Variable I,0.29,0.4,0.17,0.06,0.02,0.0,0.0,0.06,hiram lopez valdez,
+MATH,1060,203,Calculus of One Variable I,0.37,0.37,0.26,0.0,0.0,0.0,0.0,0.0,alistair bentley,
+MATH,1060,205,Calculus of One Variable I,0.23,0.56,0.1,0.04,0.06,0.0,0.0,0.0,amy christine grady,
+MATH,1060,206,Calculus of One Variable I,0.23,0.46,0.21,0.02,0.04,0.0,0.0,0.04,thomas clevenger,
+MATH,1060,207,Calculus of One Variable I,0.35,0.27,0.13,0.07,0.04,0.0,0.0,0.14,hiram lopez valdez,
+MATH,1070,1,Differen and Integral Calculus,0.0,0.25,0.47,0.13,0.09,0.0,0.0,0.06,donna simms,
+MATH,1080,1,Calculus of One Variable II,0.23,0.13,0.2,0.17,0.13,0.0,0.0,0.13,sanwar ahmad,
+MATH,1080,2,Calculus of One Variable II,0.09,0.23,0.28,0.14,0.12,0.0,0.0,0.14,fei xue,
+MATH,1080,5,Calculus of One Variable II,0.17,0.1,0.15,0.12,0.37,0.0,0.0,0.1,mengying xiao,
+MATH,1080,6,Calculus of One Variable II,0.11,0.21,0.25,0.04,0.14,0.0,0.0,0.25,mark cawood,
+MATH,1080,7,Calculus of One Variable II,0.13,0.23,0.25,0.03,0.23,0.0,0.0,0.15,beth novick,
+MATH,1080,8,Calculus of One Variable II,0.15,0.24,0.15,0.07,0.24,0.0,0.0,0.15,meredith nicol burr,
+MATH,1080,9,Calculus of One Variable II,0.21,0.28,0.14,0.14,0.16,0.0,0.0,0.07,meredith nicol burr,
+MATH,1080,201,Calculus of One Variable II,0.34,0.21,0.26,0.05,0.11,0.0,0.0,0.03,beth novick,
+MATH,1150,1,Contemp Math for Elem Teach I,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,1150,2,Contemp Math for Elem Teach I,0.57,0.27,0.11,0.05,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1160,1,Contemp Math for Elem Teach II,0.41,0.55,0.05,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.91,0.09,0.0,marion hanna,
+MATH,1990,401,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.94,0.04,0.02,marion hanna,
+MATH,1990,402,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,
+MATH,1990,403,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,marion hanna,
+MATH,2060,1,Calculus of Several Variables,0.4,0.33,0.22,0.0,0.0,0.0,0.0,0.04,xin liu,
+MATH,2060,2,Calculus of Several Variables,0.31,0.51,0.18,0.0,0.0,0.0,0.0,0.0,peter kiessler,
+MATH,2060,3,Calculus of Several Variables,0.15,0.28,0.28,0.04,0.17,0.0,0.0,0.09,sofya alekseeva,
+MATH,2060,5,Calculus of Several Variables,0.25,0.28,0.19,0.09,0.13,0.0,0.0,0.06,jeong rock yoon,
+MATH,2060,6,Calculus of Several Variables,0.32,0.18,0.11,0.05,0.18,0.0,0.0,0.16,allen anderso guest,
+MATH,2060,7,Calculus of Several Variables,0.22,0.35,0.35,0.07,0.0,0.0,0.0,0.0,sofya alekseeva,
+MATH,2060,9,Calculus of Several Variables,0.09,0.26,0.11,0.09,0.2,0.0,0.0,0.26,timothy fra parrott,
+MATH,2060,10,Calculus of Several Variables,0.2,0.33,0.2,0.02,0.2,0.0,0.0,0.04,allen anderso guest,
+MATH,2060,11,Calculus of Several Variables,0.29,0.47,0.18,0.03,0.0,0.0,0.0,0.03,xin liu,
+MATH,2060,12,Calculus of Several Variables,0.44,0.29,0.15,0.02,0.05,0.0,0.0,0.05,irina viktorova,
+MATH,2060,13,Calculus of Several Variables,0.32,0.39,0.24,0.0,0.0,0.0,0.0,0.05,akshay sunil gupte,
+MATH,2060,14,Calculus of Several Variables,0.49,0.31,0.13,0.02,0.0,0.0,0.0,0.04,martin joha schmoll,
+MATH,2060,15,Calculus of Several Variables,0.22,0.22,0.12,0.2,0.17,0.0,0.0,0.07,julie lassiter,
+MATH,2060,16,Calculus of Several Variables,0.3,0.32,0.11,0.02,0.16,0.0,0.0,0.09,allen anderso guest,
+MATH,2060,17,Calculus of Several Variables,0.05,0.25,0.16,0.2,0.2,0.0,0.0,0.14,julie lassiter,
+MATH,2060,18,Calculus of Several Variables,0.26,0.34,0.21,0.11,0.05,0.0,0.0,0.03,sofya alekseeva,
+MATH,2060,19,Calculus of Several Variables,0.13,0.3,0.19,0.07,0.22,0.0,0.0,0.09,gretchen matthews,
+MATH,2060,20,Calculus of Several Variables,0.33,0.33,0.22,0.04,0.0,0.0,0.0,0.07,martin joha schmoll,
+MATH,2060,21,Calculus of Several Variables,0.28,0.23,0.25,0.1,0.1,0.0,0.0,0.05,shitao liu,
+MATH,2060,22,Calculus of Several Variables,0.16,0.32,0.18,0.11,0.16,0.0,0.0,0.09,gretchen matthews,
+MATH,2060,100,Calc of Several Vars (HON),0.4,0.36,0.12,0.05,0.05,0.0,0.0,0.02,james brown,True
+MATH,2060,201,Calculus of Several Variables,0.11,0.26,0.18,0.05,0.08,0.0,0.0,0.32,timothy fra parrott,
+MATH,2060,202,Calculus of Several Variables,0.14,0.31,0.12,0.05,0.05,0.0,0.0,0.33,timothy fra parrott,
+MATH,2070,1,Business Calculus II,0.28,0.5,0.06,0.17,0.0,0.0,0.0,0.0,thanh thien to,
+MATH,2070,2,Business Calculus II,0.21,0.11,0.32,0.32,0.05,0.0,0.0,0.0,thanh thien to,
+MATH,2070,3,Business Calculus II,0.26,0.32,0.32,0.0,0.0,0.0,0.0,0.11,garrett dranichak,
+MATH,2070,4,Business Calculus II,0.47,0.05,0.16,0.16,0.11,0.0,0.0,0.05,garrett dranichak,
+MATH,2070,7,Business Calculus II,0.28,0.11,0.33,0.11,0.06,0.0,0.0,0.11,yinggu bao,
+MATH,2070,8,Business Calculus II,0.16,0.32,0.21,0.16,0.05,0.0,0.0,0.11,haodong li,
+MATH,2070,9,Business Calculus II,0.17,0.22,0.44,0.06,0.11,0.0,0.0,0.0,haodong li,
+MATH,2070,11,Business Calculus II,0.4,0.31,0.15,0.07,0.05,0.0,0.0,0.02,jennifer ray newton,
+MATH,2070,12,Business Calculus II,0.26,0.26,0.21,0.16,0.0,0.0,0.0,0.11,yinggu bao,
+MATH,2070,13,Business Calculus II,0.33,0.28,0.18,0.05,0.03,0.0,0.0,0.13,jennifer mari hanna,
+MATH,2070,14,Business Calculus II,0.36,0.36,0.14,0.05,0.0,0.0,0.0,0.1,jennifer mari hanna,
+MATH,2070,15,Business Calculus II,0.41,0.32,0.17,0.05,0.02,0.0,0.0,0.02,jennifer mari hanna,
+MATH,2070,16,Business Calculus II,0.34,0.34,0.16,0.09,0.02,0.0,0.0,0.05,sea sather-wagstaff,
+MATH,2070,18,Business Calculus II,0.19,0.21,0.22,0.12,0.1,0.0,0.0,0.16,judith irene mcknew,
+MATH,2080,1,Intro to Ordin Diff Equations,0.16,0.13,0.16,0.19,0.13,0.0,0.0,0.23,terri johnson,
+MATH,2080,2,Intro to Ordin Diff Equations,0.18,0.38,0.18,0.13,0.13,0.0,0.0,0.03,irina viktorova,
+MATH,2080,3,Intro to Ordin Diff Equations,0.07,0.27,0.41,0.12,0.05,0.0,0.0,0.07,irina viktorova,
+MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.13,0.19,0.0,0.22,0.0,0.0,0.25,terri johnson,
+MATH,2080,5,Intro to Ordin Diff Equations,0.13,0.13,0.22,0.06,0.13,0.0,0.0,0.34,terri johnson,
+MATH,2080,6,Intro to Ordin Diff Equations,0.22,0.43,0.16,0.08,0.0,0.0,0.0,0.11,oleg yordanov,
+MATH,2080,7,Intro to Ordin Diff Equations,0.36,0.25,0.19,0.06,0.08,0.0,0.0,0.06,oleg yordanov,
+MATH,2080,8,Intro to Ordin Diff Equations,0.14,0.35,0.26,0.09,0.09,0.0,0.0,0.07,oleg yordanov,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,matthew macauley,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.69,0.17,0.1,0.0,0.03,0.0,0.0,0.0,allison stoddard,
+MATH,2160,2,Geometry for Elem Sch Teachers,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,2500,1,Intro to Mathematical Sciences,0.94,0.03,0.02,0.0,0.0,0.0,0.0,0.02,christopher cox,
+MATH,3020,1,Stat for Science & Engineering,0.32,0.19,0.32,0.11,0.0,0.0,0.0,0.05,derek brown,
+MATH,3020,2,Stat for Science & Engineering,0.2,0.47,0.13,0.0,0.07,0.0,0.0,0.13,haotian feng,
+MATH,3020,3,Stat for Science & Engineering,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,prab withana gamage,
+MATH,3020,4,Stat for Science & Engineering,0.33,0.13,0.33,0.2,0.0,0.0,0.0,0.0,elaine ma sotherden,
+MATH,3020,6,Stat for Science & Engineering,0.17,0.28,0.42,0.0,0.03,0.0,0.0,0.11,calvin williams,
+MATH,3020,8,Stat for Science & Engineering,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,prab withana gamage,
+MATH,3020,9,Stat for Science & Engineering,0.24,0.65,0.12,0.0,0.0,0.0,0.0,0.0,haotian feng,
+MATH,3020,12,Stat for Science & Engineering,0.22,0.28,0.17,0.17,0.11,0.0,0.0,0.06,elaine ma sotherden,
+MATH,3020,14,Stat for Science & Engineering,0.43,0.33,0.13,0.03,0.0,0.0,0.0,0.1,ellen hepfe breazel,
+MATH,3020,15,Stat for Science & Engineering,0.33,0.55,0.08,0.03,0.03,0.0,0.0,0.0,ellen hepfe breazel,
+MATH,3110,1,Linear Algebra,0.34,0.3,0.11,0.05,0.09,0.0,0.0,0.11,xuhong gao,
+MATH,3110,2,Linear Algebra,0.24,0.32,0.17,0.07,0.12,0.0,0.0,0.07,xuhong gao,
+MATH,3110,3,Linear Algebra,0.17,0.26,0.33,0.07,0.07,0.0,0.0,0.11,michael adam burr,
+MATH,3110,4,Linear Algebra,0.22,0.32,0.27,0.15,0.02,0.0,0.0,0.02,hui xue,
+MATH,3110,5,Linear Algebra,0.32,0.29,0.2,0.05,0.12,0.0,0.0,0.02,hui xue,
+MATH,3110,6,Linear Algebra,0.23,0.25,0.18,0.07,0.14,0.0,0.0,0.14,felice manganiello,
+MATH,3110,7,Linear Algebra,0.14,0.28,0.21,0.19,0.05,0.0,0.0,0.14,felice manganiello,
+MATH,3110,8,Linear Algebra,0.62,0.22,0.13,0.0,0.0,0.0,0.0,0.02,benjamin jaye,
+MATH,3110,100,Linear Algebra (HON),0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,neil calkin,True
+MATH,3110,200,Linear Algebra,0.62,0.23,0.0,0.0,0.08,0.0,0.0,0.08,kevin james,
+MATH,3160,1,Prob Solving for Math Teachers,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,3190,1,Introduction to Proof,0.26,0.42,0.16,0.05,0.05,0.0,0.0,0.05,james ba coykendall,
+MATH,3190,2,Introduction to Proof,0.27,0.15,0.27,0.0,0.19,0.0,0.0,0.12,james ba coykendall,
+MATH,3600,1,Intermediate Math Computing,0.7,0.1,0.07,0.03,0.07,0.0,0.0,0.03,mark cawood,
+MATH,3600,2,Intermediate Math Computing,0.81,0.06,0.1,0.0,0.03,0.0,0.0,0.0,mark cawood,
+MATH,3650,1,Numerical Mthds for Engineers,0.22,0.38,0.19,0.11,0.08,0.0,0.0,0.03,vincent ervin,
+MATH,3650,2,Numerical Mthds for Engineers,0.5,0.25,0.22,0.0,0.03,0.0,0.0,0.0,leo rebholz,
+MATH,3650,3,Numerical Mthds for Engineers,0.29,0.6,0.07,0.05,0.0,0.0,0.0,0.0,timo johann heister,
+MATH,3650,4,Numerical Mthds for Engineers,0.14,0.39,0.19,0.06,0.11,0.0,0.0,0.11,eleanor jenkins,
+MATH,4000,1,Theory of Probability,0.44,0.26,0.14,0.05,0.05,0.0,0.0,0.07,xiaoqian sun,
+MATH,4020,1,Stat for Sci & Engineering II,0.5,0.1,0.3,0.0,0.1,0.0,0.0,0.0,calvin williams,
+MATH,4070,1,Regress & Time-Series Analysis,0.36,0.29,0.29,0.0,0.07,0.0,0.0,0.0,colin gallagher,
+MATH,4080,1,Secondary Math Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,carlos gomez,
+MATH,4120,1,Algebra I,0.26,0.31,0.28,0.05,0.08,0.0,0.0,0.03,matthew macauley,
+MATH,4190,1,Discrete Math Structures I,0.7,0.23,0.03,0.0,0.03,0.0,0.0,0.0,beth novick,
+MATH,4190,2,Discrete Math Structures I,0.46,0.36,0.18,0.0,0.0,0.0,0.0,0.0,wayne goddard,
+MATH,4310,1,Theory of Interest,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0, erwin walker,
+MATH,4340,1,Adv Engineering Mathematics,0.25,0.28,0.22,0.09,0.13,0.0,0.0,0.03,hyesuk lee,
+MATH,4340,2,Adv Engineering Mathematics,0.21,0.07,0.14,0.14,0.29,0.0,0.0,0.14,eleanor jenkins,
+MATH,4400,1,Linear Programming,0.42,0.25,0.21,0.04,0.04,0.0,0.0,0.04,boshi yang,
+MATH,4410,1,Intro to Stochastic Models,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,brian fralix,
+MATH,4500,1,Intro to Mathematical Models,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,matthew macauley,
+MATH,4530,1,Advanced Calculus I,0.42,0.28,0.11,0.11,0.06,0.0,0.0,0.03,james peterson,
+MATH,4540,1,Advanced Calculus II,0.17,0.25,0.33,0.17,0.0,0.0,0.0,0.08,james peterson,
+MATH,4630,1,Mathematical Analysis I,0.36,0.18,0.18,0.09,0.18,0.0,0.0,0.0,mishko mitkovski,
+MATH,6340,1,Adv Engineering Mathematics,0.36,0.41,0.14,0.0,0.0,0.0,0.0,0.09,vincent ervin,
+MATH,8000,1,Probability,0.48,0.19,0.11,0.0,0.11,0.0,0.0,0.11,christopher mcmahan,
+MATH,8010,1,General Linear Hypothesis I,0.5,0.42,0.0,0.0,0.08,0.0,0.0,0.0,derek brown,
+MATH,8050,1,Data Analysis,0.68,0.25,0.04,0.0,0.0,0.0,0.0,0.04,ling ma,
+MATH,8070,1,Applied Multivariate Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,8100,1,Mathematical Programming,0.74,0.17,0.0,0.0,0.0,0.0,0.0,0.09,yuyuan ouyang,
+MATH,8140,1,Network Flow Programming,0.36,0.18,0.27,0.0,0.0,0.0,0.0,0.18,herve louis kerivin,
+MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
+MATH,8210,1,Linear Analysis,0.27,0.58,0.0,0.0,0.03,0.0,0.0,0.12,shitao liu,
+MATH,8230,1,Complex Analysis,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,jeong rock yoon,
+MATH,8510,1,Abstract Algebra I,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,kevin james,
+MATH,8530,1,Matrix Analysis,0.47,0.11,0.37,0.0,0.0,0.0,0.0,0.05,svetlan poznanovikj,
+MATH,8580,1,Number Theory,0.57,0.14,0.14,0.0,0.14,0.0,0.0,0.0,james brown,
+MATH,8600,1,Intro to Scientific Computing,0.47,0.47,0.0,0.0,0.05,0.0,0.0,0.0,hyesuk lee,
+MATH,8610,1,Advanced Numerical Analysis I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,fei xue,
+MATH,8650,1,Data Structures,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,timo johann heister,
+MATH,8840,1,Statistics for Experimenters,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+MATH,9850,2,Homological Algebra,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,sea sather-wagstaff,
+MBA,8040,20,Busin Data An & Stat Computing,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,
+MBA,8060,1,Operations Mgt,0.16,0.5,0.32,0.0,0.0,0.0,0.0,0.03, sridharan,
+MBA,8070,1,Financial Management,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,george bra lockhart,
+MBA,8070,20,Financial Management,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,george bra lockhart,
+MBA,8090,1,Org Beh & Hum Res Mg,0.43,0.53,0.04,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8090,2,Org Beh & Hum Res Mg,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8180,20,Intro Business Intell & Anlytc,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,heshan sun,
+MBA,8190,1,Intro to Acc and Fin,0.55,0.34,0.1,0.0,0.0,0.0,0.0,0.0,melvin stith,
+MBA,8190,2,Intro to Acc and Fin,0.52,0.36,0.1,0.0,0.02,0.0,0.0,0.0,james mil kohlmeyer,
+MBA,8290,1,Marketing Foundation,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MBA,8310,10,Communications and Sales,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,
+MBA,8360,1,Real Estate Principles,0.41,0.48,0.11,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
+MBA,8370,1,Legal Environ of Bus,0.27,0.67,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8370,2,Legal Environ of Bus,0.47,0.47,0.03,0.0,0.0,0.0,0.0,0.03,judson jahn,
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
+MBA,8430,1,Entrepreneurial Accounting,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,sally kathr widener,
+MBA,8450,1,Technology & Innovation Mgt,0.68,0.28,0.0,0.0,0.0,0.0,0.0,0.04,michael george mino,
+MBA,8480,1,Entrpr Mkting & Digital Strat,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,bruce snyder,
+MBA,8480,5,Entrpr Mkting & Digital Strat,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,
+MBA,8490,5,Entrepreneurial Strategy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8510,1,Bus Operations & Logistics,0.24,0.35,0.41,0.0,0.0,0.0,0.0,0.0, sridharan,
+MBA,8540,1,Managerial Accounting,0.4,0.43,0.14,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,
+MBA,8590,1,Mgr Decision Model,0.34,0.26,0.29,0.0,0.0,0.0,0.0,0.11,sara elizabet yoder,
+MBA,8590,2,Mgr Decision Model,0.28,0.51,0.07,0.0,0.02,0.0,0.0,0.12,magda gabriela sava,
+MBA,8600,1,Advanced Marketing Strategy,0.3,0.48,0.23,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8600,2,Advanced Marketing Strategy,0.21,0.64,0.15,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8610,1,Information Systems,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MBA,8620,1,Managerial Economics,0.28,0.56,0.16,0.0,0.0,0.0,0.0,0.0,scott templeton,
+MBA,8620,2,Managerial Economics,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,ronald earl gregory,
+MBA,8620,4,Managerial Economics,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,ronald earl gregory,
+MBA,8650,1,Taxation of Business Decisions,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8700,1,Strategic Management,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,james turner,
+MBA,8700,2,Strategic Management,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,thomas robert uva,
+MBA,8990,2,Creativity,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,kathleen ann kegley,
+MBA,8990,4,Data Analytics & Visualization,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,john frederic tripp,
+ME,2000,1,Sophomore Seminar,0.91,0.05,0.02,0.0,0.01,0.0,0.0,0.01,donald beasley,
+ME,2000,2,Sophomore Seminar,0.78,0.19,0.01,0.0,0.01,0.0,0.0,0.01,donald beasley,
+ME,2010,1,Statics & Dynamics,0.15,0.2,0.2,0.09,0.22,0.0,0.0,0.14,marisa kikendal orr,
+ME,2010,2,Statics & Dynamics,0.09,0.24,0.23,0.14,0.23,0.0,0.0,0.08,paul joseph,
+ME,2010,3,Statics & Dynamics,0.05,0.22,0.19,0.1,0.29,0.0,0.0,0.15,jorge iva rodriguez,
+ME,2030,1,Founda Th/Fl Syst,0.08,0.21,0.21,0.21,0.18,0.0,0.0,0.13,john saylor,
+ME,2030,2,Founda Th/Fl Syst,0.2,0.35,0.2,0.14,0.06,0.0,0.0,0.06,xiangchun xuan,
+ME,2040,1,Mechanics of Materials,0.27,0.45,0.22,0.04,0.02,0.0,0.0,0.0,gang li,
+ME,2040,3,Mechanics of Materials,0.17,0.57,0.19,0.05,0.0,0.0,0.0,0.02,jorge iva rodriguez,
+ME,2220,1,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,2,Mechanical Engineering Lab I,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
+ME,2220,3,Mechanical Engineering Lab I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,5,Mechanical Engineering Lab I,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,2220,7,Mechanical Engineering Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,13,Mechanical Engineering Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,15,Mechanical Engineering Lab I,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,17,Mechanical Engineering Lab I,0.31,0.63,0.0,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,2220,18,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3030,1,Thermodynamics,0.2,0.3,0.3,0.08,0.04,0.0,0.0,0.08,richard miller,
+ME,3030,2,Thermodynamics,0.26,0.51,0.18,0.0,0.02,0.0,0.0,0.04,yiqiang han,
+ME,3040,1,Heat Transfer,0.05,0.26,0.43,0.12,0.12,0.0,0.0,0.02,jean-marc delhaye,
+ME,3040,2,Heat Transfer,0.19,0.42,0.23,0.07,0.06,0.0,0.0,0.03,xin zhao,
+ME,3050,1,Model/an Dy Syst,0.21,0.17,0.32,0.15,0.06,0.0,0.0,0.09,joshua bostwick,
+ME,3050,2,Model/an Dy Syst,0.22,0.39,0.3,0.04,0.04,0.0,0.0,0.0,ardalan vahidi,
+ME,3060,1,Fund Machine Design,0.13,0.58,0.21,0.0,0.02,0.0,0.0,0.06,oliver myers,
+ME,3060,2,Fund Machine Design,0.24,0.5,0.18,0.02,0.02,0.0,0.0,0.04,paul jeffrey meyer,
+ME,3070,1,Found of Mechanical Systems,0.34,0.39,0.25,0.0,0.02,0.0,0.0,0.0,jorge iva rodriguez,
+ME,3070,2,Found of Mechanical Systems,0.22,0.51,0.17,0.04,0.01,0.0,0.0,0.05,gregory mocko,
+ME,3080,1,Fluid Mechanics,0.34,0.49,0.09,0.06,0.02,0.0,0.0,0.0,yiqiang han,
+ME,3080,2,Fluid Mechanics,0.24,0.51,0.16,0.03,0.05,0.0,0.0,0.0,yiqiang han,
+ME,3080,3,Fluid Mechanics,0.1,0.46,0.39,0.02,0.02,0.0,0.0,0.02,ethan kung,
+ME,3120,1,Manuf Processes,0.35,0.49,0.13,0.02,0.01,0.0,0.0,0.01,rod martinez-duarte,
+ME,3330,1,Mechanical Engineering Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,2,Mechanical Engineering Lab II,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,3,Mechanical Engineering Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,6,Mechanical Engineering Lab II,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,3330,7,Mechanical Engineering Lab II,0.43,0.5,0.0,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
+ME,3330,9,Mechanical Engineering Lab II,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,10,Mechanical Engineering Lab II,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,todd schweisinger,
+ME,4000,1,Senior Seminar,0.96,0.03,0.0,0.0,0.01,0.0,0.0,0.0,richard figliola,
+ME,4010,1,Mech Engr Design,0.87,0.08,0.01,0.02,0.01,0.0,0.0,0.02,cameron turner,
+ME,4020,1,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,nicole gise coutris,
+ME,4020,2,Intern in Engr Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,3,Intern in Engr Des,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,4030,1,Control Dynamic Systems,0.32,0.34,0.22,0.04,0.04,0.0,0.0,0.03,suyi li,
+ME,4030,2,Control Dynamic Systems,0.21,0.37,0.33,0.07,0.0,0.0,0.0,0.02,yue wang,
+ME,4210,1,Intro to Comp Flow,0.27,0.46,0.15,0.08,0.04,0.0,0.0,0.0,chenning tong,
+ME,4320,1,Advanced Strength of Materials,0.0,0.87,0.07,0.0,0.07,0.0,0.0,0.0,michael porter,
+ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,2,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,5,Mechanical Engineering Lab III,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,6,Mechanical Engineering Lab III,0.18,0.64,0.0,0.0,0.09,0.0,0.0,0.09,john wagner,
+ME,4440,9,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,10,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,18,Mechanical Engineering Lab III,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4540,1,Design of Machine Elements,0.53,0.36,0.08,0.0,0.01,0.0,0.0,0.01,paul jeffrey meyer,
+ME,4930,14,Sel.Topics ME - NonLinDy&Chas,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,phanin tallapragada,
+ME,4930,39,Sel.Topics ME - Aero Propul,0.27,0.43,0.27,0.02,0.0,0.0,0.0,0.0,daniel fant,
+ME,4930,139,Sel.Topic ME - Solar Energy,0.44,0.23,0.28,0.0,0.0,0.0,0.0,0.05,daniel fant,
+ME,6210,1,Intro to Comp Flow,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
+ME,6320,1,Advanced Strength of Materials,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,michael porter,
+ME,6540,1,Des Machine Elements,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,paul jeffrey meyer,
+ME,8010,1,Found of Fluid Mech,0.17,0.44,0.17,0.0,0.11,0.0,0.0,0.11,nicole gise coutris,
+ME,8100,1,Macroscopic Thermo,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,xiangchun xuan,
+ME,8180,1,Intro to Fin Ele Ana,0.58,0.31,0.04,0.0,0.0,0.0,0.0,0.06,lonny thompson,
+ME,8230,1,Control Systems,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,
+ME,8460,1,Inter Dynamics,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,phanin tallapragada,
+ME,8610,1,Matl Sel Engr Design,0.45,0.53,0.0,0.0,0.02,0.0,0.0,0.0,michael porter,
+ME,8610,401,Matl Sel Engr Design,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael porter,
+ME,8700,1,Adv Design Methods,0.29,0.62,0.05,0.0,0.05,0.0,0.0,0.0,joshua summers,
+ME,8710,1,Engr Optimization,0.64,0.32,0.05,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,8710,401,Engr Optimization,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,georges fadel,
+ME,8930,1,Sel. Topics in ME - Scaling,0.3,0.2,0.3,0.0,0.2,0.0,0.0,0.0,jean-marc delhaye,
+ME,8930,4,SelectedTopics in ME - Adv Mfg,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+MGT,2010,1,Principles of Management,0.42,0.43,0.11,0.03,0.01,0.0,0.0,0.0,katherine clark,
+MGT,2010,2,Principles of Management,0.42,0.38,0.16,0.03,0.0,0.0,0.0,0.01,tina robbins,
+MGT,2010,4,Principles of Management (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tina robbins,True
+MGT,2010,10,Principles of Management,0.33,0.45,0.23,0.0,0.0,0.0,0.0,0.0,ashley will parnell,
+MGT,2010,11,Principles of Management,0.28,0.33,0.31,0.03,0.03,0.0,0.0,0.03,ashley will parnell,
+MGT,2010,12,Principles of Management,0.16,0.33,0.28,0.09,0.07,0.0,0.0,0.07,ashley will parnell,
+MGT,2180,1,Management PC Applications,0.47,0.37,0.12,0.01,0.01,0.0,0.0,0.02,ryan toole,
+MGT,2180,2,Management PC Applications,0.2,0.47,0.21,0.03,0.04,0.0,0.0,0.03,ryan toole,
+MGT,2970,4,How to Start a Startup,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,john michael hannon,
+MGT,3070,1,Human Resource Management,0.84,0.14,0.0,0.0,0.0,0.0,0.0,0.02,jonathan sanderson,
+MGT,3070,3,Human Resource Management,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,4,Human Resource Management,0.6,0.38,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,5,Human Resource Management,0.43,0.45,0.13,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,6,Human Resource Management,0.53,0.43,0.03,0.03,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,7,Human Resource Management,0.83,0.15,0.0,0.0,0.03,0.0,0.0,0.0,alejandra kennedy,
+MGT,3070,8,Human Resource Management,0.25,0.38,0.13,0.13,0.06,0.0,0.0,0.06,priscilla harrison,
+MGT,3100,1,Intermed Business Statistics,0.38,0.28,0.13,0.1,0.03,0.0,0.0,0.08,min kyung lee,
+MGT,3100,2,Intermed Business Statistics,0.44,0.41,0.05,0.0,0.0,0.0,0.0,0.1,mustafa serk akturk,
+MGT,3100,3,Intermed Business Statistics,0.37,0.23,0.23,0.0,0.02,0.0,0.0,0.14,sukran nil atadeniz,
+MGT,3100,5,Intermed Business Statistics,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.13,mustafa serk akturk,
+MGT,3100,6,Intermed Business Statistics,0.15,0.39,0.36,0.03,0.0,0.0,0.0,0.06,magda gabriela sava,
+MGT,3100,7,Intermed Business Statistics,0.39,0.31,0.19,0.0,0.03,0.0,0.0,0.08,sukran nil atadeniz,
+MGT,3100,8,Intermed Business Statistics,0.42,0.32,0.13,0.05,0.08,0.0,0.0,0.0,min kyung lee,
+MGT,3100,9,Intermed Business Statistics,0.64,0.31,0.06,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,
+MGT,3100,10,Intermed Business Statistics,0.28,0.37,0.21,0.0,0.09,0.0,0.0,0.05,remi charpin,
+MGT,3100,11,Intermed Business Statistics,0.7,0.24,0.0,0.0,0.0,0.0,0.0,0.07,thomas simpson,
+MGT,3120,1,Decision Models for Management,0.12,0.23,0.23,0.19,0.16,0.0,0.0,0.07,sara elizabet yoder,
+MGT,3120,2,Decision Models for Management,0.2,0.16,0.23,0.23,0.1,0.0,0.0,0.07,sara elizabet yoder,
+MGT,3170,1,Logistics Mgmt,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,ahmet colak,
+MGT,3180,1,Mgt of Info Systems,0.28,0.56,0.1,0.03,0.0,0.0,0.0,0.03,marten risius,
+MGT,3180,2,Mgt of Info Systems,0.48,0.35,0.05,0.03,0.0,0.0,0.0,0.1,iaroslava dutchak,
+MGT,3180,3,Mgt of Info Systems,0.35,0.33,0.28,0.0,0.02,0.0,0.0,0.02,tina marie esposito,
+MGT,3180,4,Mgt of Info Systems,0.41,0.41,0.13,0.0,0.02,0.0,0.0,0.02,tina marie esposito,
+MGT,3180,5,Mgt of Info Systems,0.6,0.23,0.12,0.0,0.05,0.0,0.0,0.0,kevin dani matthews,
+MGT,3500,1,Intro to Business Analytics,0.18,0.73,0.09,0.0,0.0,0.0,0.0,0.0,siyuan li,
+MGT,3510,1,Business Analytics & Problems,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,
+MGT,3900,1,Ops Mgt,0.16,0.47,0.32,0.03,0.0,0.0,0.0,0.03,yann ferrand,
+MGT,3900,2,Ops Mgt,0.13,0.23,0.58,0.05,0.0,0.0,0.0,0.03,zachary mo leffakis,
+MGT,3900,3,Ops Mgt,0.11,0.39,0.29,0.03,0.03,0.0,0.0,0.16,berna quiroga gomez,
+MGT,3900,4,Ops Mgt,0.2,0.43,0.28,0.03,0.03,0.0,0.0,0.05,berna quiroga gomez,
+MGT,3900,5,Ops Mgt,0.32,0.24,0.32,0.0,0.03,0.0,0.0,0.08,daniel nielubowicz,
+MGT,3900,6,Ops Mgt,0.36,0.5,0.11,0.0,0.03,0.0,0.0,0.0,maneeshre ajjuguttu,
+MGT,4000,1,Mgt of Organizational Behavior,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,2,Mgt of Organizational Behavior,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,3,Mgt of Organizational Behavior,0.22,0.36,0.31,0.03,0.03,0.0,0.0,0.06,thomas jo zagenczyk,
+MGT,4000,4,Mgt of Organizational Behavior,0.15,0.4,0.35,0.05,0.0,0.0,0.0,0.05,philip roth,
+MGT,4020,1,Ops Pln and Ctl,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4080,1,Lean Operations,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4110,1,Project Management,0.26,0.37,0.33,0.0,0.05,0.0,0.0,0.0,russell purvis,
+MGT,4120,1,Supplier Management,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,ahmet colak,
+MGT,4150,1,Business Strategy,0.18,0.57,0.25,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,3,Business Strategy,0.4,0.53,0.05,0.03,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,4,Business Strategy,0.38,0.55,0.07,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,7,Business Strategy,0.49,0.47,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,8,Business Strategy,0.52,0.41,0.07,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,9,Business Strategy,0.25,0.59,0.11,0.0,0.02,0.0,0.0,0.02,amy elizabet ingram,
+MGT,4160,1,Special Topics Hr,0.36,0.6,0.04,0.0,0.0,0.0,0.0,0.0,kristin dam scott,
+MGT,4230,1,Intern Bus Mgt,0.16,0.16,0.53,0.16,0.0,0.0,0.0,0.0,wayne stewart,
+MGT,4230,2,Intern Bus Mgt,0.18,0.18,0.55,0.0,0.05,0.0,0.0,0.05,wayne stewart,
+MGT,4230,3,Intern Bus Mgt,0.23,0.4,0.3,0.05,0.0,0.0,0.0,0.03,janis miller,
+MGT,4230,4,Intern Bus Mgt,0.11,0.56,0.27,0.02,0.0,0.0,0.0,0.04,janis miller,
+MGT,4240,1,Global Supply Chain,0.21,0.46,0.33,0.0,0.0,0.0,0.0,0.0,yann ferrand,
+MGT,4270,2,Managing Improvement,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MGT,4310,1,Emp Rights & Resp,0.24,0.53,0.15,0.0,0.03,0.0,0.0,0.06,leonard jos spooner,
+MGT,4310,2,Emp Rights & Resp,0.4,0.49,0.11,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,4350,1,Pers Interviewing,0.36,0.36,0.25,0.04,0.0,0.0,0.0,0.0,philip roth,
+MGT,4520,1,Business Analysis,0.15,0.58,0.15,0.04,0.04,0.0,0.0,0.04,marten risius,
+MGT,4540,1,Systems Implement,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,heshan sun,
+MGT,4550,1,Emerging I T Trends,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MGT,4560,1,Business Info Mgt,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,siyuan li,
+MGT,8690,1,Project Mgt,0.41,0.56,0.0,0.0,0.0,0.0,0.0,0.04,russell purvis,
+MICR,2050,1,Introductory Micro,0.55,0.4,0.04,0.01,0.0,0.0,0.0,0.01,john abercrombie,
+MICR,3050,1,General Microbiology,0.38,0.4,0.14,0.05,0.01,0.0,0.0,0.02,krista barr rudolph,
+MICR,3050,2,General Microbiology,0.42,0.41,0.13,0.03,0.01,0.0,0.0,0.01,krista barr rudolph,
+MICR,4010,1,Microbial Diversity & Ecology,0.23,0.51,0.18,0.03,0.03,0.0,0.0,0.03,barbara campbell,
+MICR,4050,1,Adv Microbial Ecol of Humans,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4140,1,Basic Immunology,0.44,0.37,0.1,0.02,0.07,0.0,0.0,0.0,yanzhang wei,
+MICR,4150,1,Microbial Genetics,0.23,0.32,0.26,0.2,0.0,0.0,0.0,0.0,min cao,
+MICR,4160,1,Intro Virology,0.95,0.04,0.0,0.0,0.0,0.0,0.0,0.01,simon scott,
+MICR,4510,1,Advanced Microbiology II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4510,2,Advanced Microbiology II,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4510,3,Advanced Microbiology II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MKT,3010,1,Prin of Marketing,0.02,0.43,0.38,0.1,0.05,0.0,0.0,0.02,carter wil mcelveen,
+MKT,3010,2,Prin of Marketing,0.29,0.46,0.18,0.05,0.02,0.0,0.0,0.0,amanda cooper fine,
+MKT,3010,3,Prin of Marketing,0.26,0.45,0.23,0.04,0.01,0.0,0.0,0.0,amanda cooper fine,
+MKT,3010,4,Prin of Marketing,0.27,0.46,0.2,0.04,0.01,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,5,Prin of Marketing,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,3020,1,Consumer Behavior,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,2,Consumer Behavior,0.58,0.4,0.0,0.0,0.0,0.0,0.0,0.02,jennifer di siemens,
+MKT,3020,3,Consumer Behavior,0.34,0.44,0.2,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3020,4,Consumer Behavior,0.51,0.33,0.08,0.06,0.02,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3020,5,Consumer Behavior,0.12,0.64,0.19,0.03,0.0,0.0,0.0,0.02,carter wil mcelveen,
+MKT,3210,1,Sports Marketing,0.74,0.23,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3210,2,Sports Marketing,0.68,0.3,0.0,0.0,0.0,0.0,0.0,0.02,delancy bennett,
+MKT,3310,1,Marketing Metrics & Analytics,0.42,0.56,0.02,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,
+MKT,3310,2,Marketing Metrics & Analytics,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,
+MKT,3980,1,Creative Inquiry in Marketing,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james gaubert,
+MKT,4200,2,Professional Selling,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,3,Professional Selling,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4200,4,Professional Selling,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4200,5,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4230,1,Promotional Strategy,0.53,0.39,0.08,0.0,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,4240,1,Sales Management,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4260,1,Business-to-Business,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,james gaubert,
+MKT,4270,1,International Mktg,0.58,0.32,0.08,0.0,0.01,0.0,0.0,0.01,roger gomes,
+MKT,4270,2,International Mktg,0.21,0.59,0.13,0.03,0.03,0.0,0.0,0.03,roger gomes,
+MKT,4270,3,International Mktg,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,thomas poehlman,
+MKT,4280,1,Services Marketing,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4280,2,Services Marketing,0.43,0.53,0.05,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4310,1,Marketing Research,0.23,0.5,0.23,0.0,0.0,0.0,0.0,0.04,peter weathers,
+MKT,4310,2,Marketing Research,0.16,0.53,0.21,0.11,0.0,0.0,0.0,0.0,peter weathers,
+MKT,4310,3,Marketing Research,0.35,0.62,0.0,0.0,0.0,0.0,0.0,0.04,scott darren swain,
+MKT,4310,4,Marketing Research,0.35,0.35,0.17,0.0,0.0,0.0,0.0,0.13,william kilbourne,
+MKT,4430,1,Advertising Strategy,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4450,1,Macromarketing,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.19,0.65,0.16,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,2,Strategic Mktg Mgt,0.17,0.45,0.34,0.03,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4950,1,Social Media,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,4950,2,Social Media,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,8610,1,Marketing Research,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,william kilbourne,
+MKT,8630,1,Buyer Behavior,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
+ML,1010,1,Leadership Fund I,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,clay wilson etterle,
+ML,2010,2,Leadership Development I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,2010,3,Leadership Development I,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,vincent john presto,
+ML,3010,1,Advanced Leadership I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,
+MSE,2100,1,Intro to Mat Science,0.43,0.21,0.15,0.08,0.1,0.0,0.0,0.04,rakhee pani,
+MSE,2100,2,Intro to Mat Science,0.18,0.33,0.29,0.16,0.03,0.0,0.0,0.01,eric skaar,
+MSE,2100,3,Intro to Mat Science,0.27,0.25,0.28,0.08,0.09,0.0,0.0,0.04,fei peng,
+MSE,2100,4,Intro to Mat Science,0.31,0.45,0.14,0.03,0.04,0.0,0.0,0.03,ruslan burtovyy,
+MSE,2100,5,Intro to Mat Science,0.44,0.3,0.11,0.04,0.07,0.0,0.0,0.04,olga kuksenok,
+MSE,3190,1,Materials Proc I,0.34,0.53,0.08,0.03,0.01,0.0,0.0,0.01,olin mefford,
+MSE,3190,2,Materials Proc I,0.14,0.62,0.16,0.08,0.0,0.0,0.0,0.0,olin mefford,
+MSE,3260,1,Thermo of Materials,0.39,0.35,0.2,0.02,0.0,0.0,0.0,0.04,gary lickfield,
+MSE,3260,2,Thermo of Materials,0.25,0.39,0.19,0.08,0.06,0.0,0.0,0.03,gary lickfield,
+MSE,3270,1,Transport Phenomena,0.15,0.47,0.18,0.16,0.03,0.0,0.0,0.02,ulf daniel schiller,
+MSE,3270,2,Transport Phenomena,0.05,0.26,0.31,0.26,0.08,0.0,0.0,0.05,ulf daniel schiller,
+MSE,4020,1,Solid State Material,0.55,0.13,0.26,0.06,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,4070,1,Senior Capstone Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,
+MSE,4130,1,Noncrystalline Materials,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
+MSE,4150,1,Polymer Sc Engr,0.49,0.33,0.01,0.0,0.0,0.0,0.0,0.16,stephen foulger,
+MSE,4150,2,Polymer Sc Engr,0.58,0.28,0.09,0.02,0.02,0.0,0.0,0.0,olin mefford,
+MSE,4320,1,Manuf Proc & Systems,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
+MSE,4580,1,Surf Phen in Ms&E,0.29,0.11,0.21,0.36,0.04,0.0,0.0,0.0,konstantin kornev,
+MSE,4810,1,Undergraduate Research Fundame,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,marian kennedy,
+MSE,4910,1,Undergraduate Research,0.78,0.06,0.06,0.06,0.0,0.0,0.0,0.06,marian kennedy,
+MSE,4910,2,Undergraduate Research,0.59,0.24,0.0,0.06,0.06,0.0,0.0,0.06,marian kennedy,
+MSE,8100,1,Fundamentals of Materials Sci,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,igor luzinov,
+MSE,8270,1,Kin of Phase Tran,0.52,0.38,0.0,0.0,0.05,0.0,0.0,0.05,konstantin kornev,
+MUSC,1420,1,Music Theory I,0.84,0.05,0.0,0.0,0.11,0.0,0.0,0.0,anthony bernarducci,
+MUSC,1430,1,Aural Skills I,0.84,0.0,0.05,0.0,0.11,0.0,0.0,0.0,anthony bernarducci,
+MUSC,2100,2,Music in the Western World,0.56,0.25,0.13,0.0,0.03,0.0,0.0,0.03,lisa sain odom,
+MUSC,2100,3,Music in the Western World,0.41,0.34,0.16,0.09,0.0,0.0,0.0,0.0,alison leigh mero,
+MUSC,2100,4,Music in the Western World,0.56,0.22,0.13,0.0,0.06,0.0,0.0,0.03,linda li-bleuel,
+MUSC,2100,6,Music in the Western World,0.47,0.38,0.09,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
+MUSC,2100,7,Music in the Western World,0.39,0.39,0.1,0.03,0.0,0.0,0.0,0.1,rhea beth jacobus,
+MUSC,2100,8,Music in the Western World,0.53,0.23,0.0,0.0,0.03,0.0,0.0,0.2,rhea beth jacobus,
+MUSC,2100,10,Music in the Western World,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,linda dzuris,
+MUSC,2100,12,Music in the Western World,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,lea kibler,
+MUSC,3110,1,History of American Music,0.61,0.29,0.06,0.03,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,3130,1,Hist of Rock & Roll,0.78,0.16,0.03,0.0,0.03,0.0,0.0,0.0,hamilton altstatt,
+MUSC,3170,1,Hist of Country Mus,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3180,1,Hist of Audio Tech,0.5,0.25,0.19,0.06,0.0,0.0,0.0,0.0,bruce allen whisler,
+MUSC,3610,1,Marching Band,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
+MUSC,3620,1,Symphonic Band,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mark spede,
+MUSC,3690,1,Symphony Orchestra,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,
+MUSC,4150,1,Music Hist to 1750,0.17,0.17,0.33,0.11,0.11,0.0,0.0,0.11,justin durham,
+NPL,3000,1,Nonprofit Leadership,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
+NPL,3000,3,Nonprofit Leadership,0.63,0.2,0.03,0.0,0.0,0.0,0.0,0.13,bonnie west stevens,
+NPL,3000,4,Nonprofit Leadership,0.6,0.23,0.1,0.0,0.03,0.0,0.0,0.03,bonnie west stevens,
+NPL,3000,5,Nonprofit Leadership,0.5,0.23,0.23,0.0,0.05,0.0,0.0,0.0,christina mar mazer,
+NPL,3000,6,Nonprofit Leadership,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
+NPL,3000,7,Nonprofit Leadership,0.63,0.08,0.08,0.08,0.13,0.0,0.0,0.0,christina mar mazer,
+NPL,3040,1,NPL Risk Management,0.72,0.19,0.0,0.0,0.09,0.0,0.0,0.0,daniel mor anderson,
+NURS,1400,1,Comp App Hlth Care,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
+NURS,3030,1,Nursing of Adults,0.3,0.65,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3040,1,Pathophysiology,0.39,0.48,0.1,0.02,0.02,0.0,0.0,0.0,catherine si murton,
+NURS,3040,400,Pathophysiology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
+NURS,3040,401,Pathophysiology,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
+NURS,3050,1,Psychosocial Nursing,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
+NURS,3100,1,Health Assessment,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
+NURS,3100,2,Health Assessment,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
+NURS,3100,400,Health Assessment,0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,jason thrift,
+NURS,3120,1,Foundations of Nursing,0.47,0.52,0.02,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,
+NURS,3120,400,Foundations of Nursing,0.5,0.46,0.0,0.04,0.0,0.0,0.0,0.0,jennifer el bagwell,
+NURS,3190,400,Health Assessment for RNs,0.79,0.07,0.14,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
+NURS,3200,2,Prof in Nurs,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3230,400,Gerontology Nurs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,tawny jenn mcintosh,
+NURS,3300,2,Research in Nursing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,3330,400,Health Care Genetics,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,mary steck,
+NURS,3400,1,Pharmther Nursing,0.32,0.55,0.11,0.0,0.02,0.0,0.0,0.0,catherine si murton,
+NURS,3400,400,Pharmther Nursing,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jenna lyn seawright,
+NURS,3600,400,Social Determinants in Health,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
+NURS,4010,1,Mental Health Nurs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NURS,4030,400,Complex Nursing of Adults,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,
+NURS,4060,400,Issues in Professionalism,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
+NURS,4110,1,Nursing of Children,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
+NURS,4120,1,Nurs Women and Fam,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4140,400,Com Nurs & Hlth Prom,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
+NURS,4250,200,Community Nursing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
+NURS,4980,15,Nursing/Engineering,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,nancy meehan,
+NURS,8050,400,Pharmaco Adv Nurs,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8050,401,Pharmaco Adv Nurs,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8060,400,Advan Assessment for Nursing,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,
+NURS,8090,400,Pathophysiology,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,tracy brock lowe,
+NURS,8190,400,Developing Family,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8200,400,Child & Adol Nursing,0.34,0.55,0.07,0.0,0.03,0.0,0.0,0.0,heide temples,
+NURS,9020,1,DNP Clinical Epidem & Biostats,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,veronica parker,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.81,0.16,0.01,0.0,0.02,0.0,0.0,0.0,bridgit den corbett,
+NUTR,2030,2,Intro Princ of Human Nutrition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,bridgit den corbett,
+NUTR,2050,1,Nutrition for Nursing Prof,0.74,0.25,0.01,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
+NUTR,2160,1,Evidence-Based Nutrition,0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,angela fraser,
+NUTR,4240,1,Medical Nutr Thera I,0.49,0.46,0.06,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4510,1,Human Nutrition & Metabolism I,0.3,0.3,0.19,0.12,0.05,0.0,0.0,0.05,elliot jesch,
+PA,1010,1,Intro to Perf Arts,0.67,0.3,0.04,0.0,0.0,0.0,0.0,0.0,david hartmann,
+PA,2010,2,Career Planning and Prof Devel,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
+PA,2790,1,Perf Arts Pract I,0.36,0.55,0.05,0.0,0.0,0.0,0.0,0.05,kenneth moore,
+PADM,8220,400,Public Policy Process,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,
+PADM,8220,401,Public Policy Process,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,
+PADM,8290,400,Public Financial Management,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,
+PADM,8420,400,GIS for Public Administrators,0.55,0.27,0.0,0.0,0.09,0.0,0.0,0.09,david lawrenc white,
+PADM,8660,400,Nonprofit Fundraising,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,renee salic nichols,
+PADM,8680,400,Local Government Admin,0.22,0.56,0.11,0.0,0.11,0.0,0.0,0.0,alfred bundrick,
+PADM,8720,400,Rural Development,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lori ann dickes,
+PAS,3010,1,Pan African Studies,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,abel bartley,
+PDBE,8100,1,Contemporary Issues in EDP,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+PDBE,8150,1,Research Design in EDP,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,mickey lauria,
+PES,1040,1,Introduction to Plant Sciences,0.81,0.17,0.03,0.0,0.0,0.0,0.0,0.0,paula agudelo,
+PES,2020,1,Soils,0.19,0.55,0.19,0.06,0.0,0.0,0.0,0.01,dara michelle park,
+PES,3150,1,Environment and Agriculture,0.38,0.29,0.29,0.0,0.0,0.0,0.0,0.04,"appukuttan suseela,",
+PES,4850,1,Environmental Soil Chemistry,0.44,0.31,0.19,0.0,0.0,0.0,0.0,0.06,haibo liu,
+PHIL,1010,1,Intro to Philosophic Problems,0.44,0.41,0.12,0.0,0.0,0.0,0.0,0.03,david stegall,
+PHIL,1010,2,Intro to Philosophic Problems,0.43,0.26,0.2,0.06,0.03,0.0,0.0,0.03,christopher grau,
+PHIL,1010,3,Intro to Philosophic Problems,0.49,0.31,0.11,0.0,0.0,0.0,0.0,0.09,david stegall,
+PHIL,1010,4,Intro to Philosophic Problems,0.23,0.51,0.14,0.06,0.03,0.0,0.0,0.03,kelly smith,
+PHIL,1010,6,Intro to Philosophic Problems,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,andrew garnar,
+PHIL,1020,1,Introduction to Logic,0.68,0.21,0.12,0.0,0.0,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,2,Introduction to Logic,0.62,0.24,0.03,0.03,0.06,0.0,0.0,0.03,michael hal hannen,
+PHIL,1020,3,Introduction to Logic,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,michael hal hannen,
+PHIL,1020,4,Introduction to Logic,0.61,0.28,0.06,0.06,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1020,7,Introduction to Logic,0.32,0.32,0.29,0.03,0.0,0.0,0.0,0.03,adam gies,
+PHIL,1020,8,Introduction to Logic,0.53,0.25,0.22,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1020,9,Introduction to Logic,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
+PHIL,1020,10,Introduction to Logic,0.26,0.56,0.06,0.03,0.03,0.0,0.0,0.06,christopher wells,
+PHIL,1020,11,Introduction to Logic,0.46,0.29,0.11,0.11,0.0,0.0,0.0,0.03,christopher wells,
+PHIL,1020,12,Introduction to Logic,0.51,0.29,0.09,0.03,0.0,0.0,0.0,0.09,christopher wells,
+PHIL,1020,13,Introduction to Logic,0.72,0.11,0.0,0.11,0.0,0.0,0.0,0.06,christopher wells,
+PHIL,1020,14,Introduction to Logic,0.26,0.26,0.26,0.0,0.03,0.0,0.0,0.18,stephen satris,
+PHIL,1030,1,Introduction to Ethics,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,edyta joanna kuzian,
+PHIL,1030,2,Introduction to Ethics,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,stephen satris,
+PHIL,1030,3,Introduction to Ethics,0.32,0.29,0.32,0.0,0.03,0.0,0.0,0.03,charles starkey,
+PHIL,1030,4,Introduction to Ethics,0.5,0.33,0.06,0.06,0.06,0.0,0.0,0.0,david stegall,
+PHIL,1030,5,Introduction to Ethics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
+PHIL,1030,6,Introduction to Ethics,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
+PHIL,1030,7,Introduction to Ethics,0.38,0.23,0.31,0.0,0.0,0.0,0.0,0.08,edyta joanna kuzian,
+PHIL,1030,8,Introduction to Ethics,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
+PHIL,1030,9,Introduction to Ethics,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
+PHIL,1030,10,Introduction to Ethics,0.74,0.11,0.11,0.0,0.0,0.0,0.0,0.05,david stegall,
+PHIL,3040,1,Moral Philosophy,0.31,0.5,0.06,0.0,0.0,0.0,0.0,0.13,charles starkey,
+PHIL,3150,1,Ancient Philosophy,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,michael hal hannen,
+PHIL,3180,1,20th-Century Philosophy,0.58,0.29,0.03,0.0,0.03,0.0,0.0,0.06,william maker,
+PHIL,3200,1,Soc and Pol Phil,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,david stegall,
+PHIL,3260,1,Science and Values,0.59,0.21,0.06,0.0,0.09,0.0,0.0,0.06,andrew garnar,
+PHIL,3260,2,Science and Values,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,
+PHIL,3430,1,Philosophy of Law,0.21,0.66,0.03,0.03,0.0,0.0,0.0,0.07,brookes colyt brown,
+PHIL,3440,1,Business Ethics,0.24,0.47,0.24,0.0,0.0,0.0,0.0,0.06,brookes colyt brown,
+PHIL,3480,1,Philosophies of Art,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,christopher grau,
+PHIL,3550,1,Philosophy of Mind & Cog Scien,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,4020,1,Topics in Philosophy: Kant,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,kelly smith,
+PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.88,0.1,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics with Calculus I,0.23,0.33,0.24,0.07,0.06,0.0,0.0,0.07,lih-sin the,
+PHYS,1220,2,Physics with Calculus I,0.29,0.29,0.25,0.09,0.01,0.0,0.0,0.06,lih-sin the,
+PHYS,1220,4,Physics with Calculus I,0.56,0.19,0.06,0.06,0.13,0.0,0.0,0.0,murray daw,
+PHYS,1220,500,Physics with Calculus I,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,elaine parshall,
+PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,jerry hester,
+PHYS,1240,2,Physics Lab I,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,3,Physics Lab I,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,4,Physics Lab I,0.56,0.33,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,6,Physics Lab I,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,jerry hester,
+PHYS,1240,7,Physics Lab I,0.28,0.39,0.17,0.11,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,8,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,9,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,10,Physics Lab I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,11,Physics Lab I,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,12,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,14,Physics Lab I,0.25,0.38,0.06,0.06,0.0,0.0,0.0,0.25,jerry hester,
+PHYS,1240,15,Physics Lab I,0.44,0.38,0.13,0.06,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,16,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,17,Physics Lab I,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,1240,18,Physics Lab I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,19,Physics Lab I,0.71,0.18,0.0,0.06,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2070,1,General Physics I,0.13,0.29,0.31,0.14,0.07,0.0,0.0,0.06,amy liann pope,
+PHYS,2070,2,General Physics I,0.27,0.37,0.21,0.06,0.02,0.0,0.0,0.06,amy liann pope,
+PHYS,2070,3,General Physics I,0.36,0.37,0.18,0.06,0.02,0.0,0.0,0.01,amy liann pope,
+PHYS,2080,1,General Physics II,0.49,0.3,0.11,0.06,0.03,0.0,0.0,0.01,sripar bhattacharya,
+PHYS,2090,1,Gen Phys Lab I,0.79,0.04,0.04,0.04,0.04,0.0,0.0,0.04,jerry hester,
+PHYS,2090,2,Gen Phys Lab I,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,3,Gen Phys Lab I,0.33,0.46,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,4,Gen Phys Lab I,0.55,0.23,0.14,0.05,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,5,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,6,Gen Phys Lab I,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,7,Gen Phys Lab I,0.63,0.25,0.04,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,8,Gen Phys Lab I,0.45,0.5,0.0,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,9,Gen Phys Lab I,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,10,Gen Phys Lab I,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,11,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,12,Gen Phys Lab I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,13,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,14,Gen Phys Lab I,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,15,Gen Phys Lab I,0.61,0.35,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,16,Gen Phys Lab I,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,17,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,18,Gen Phys Lab I,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,19,Gen Phys Lab I,0.61,0.3,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,20,Gen Phys Lab I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,21,Gen Phys Lab I,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,22,Gen Phys Lab I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,23,Gen Phys Lab I,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,24,Gen Phys Lab I,0.52,0.39,0.0,0.0,0.0,0.0,0.0,0.09,jerry hester,
+PHYS,2090,25,Gen Phys Lab I,0.52,0.39,0.0,0.04,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,26,Gen Phys Lab I,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,jerry hester,
+PHYS,2090,27,Gen Phys Lab I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,1,Gen Phys Lab II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,2,Gen Phys Lab II,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,3,Gen Phys Lab II,0.65,0.15,0.2,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,4,Gen Phys Lab II,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,6,Gen Phys Lab II,0.52,0.3,0.17,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,7,Gen Phys Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,8,Gen Phys Lab II,0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,9,Gen Phys Lab II,0.48,0.24,0.24,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2210,1,Physics with Calculus II,0.14,0.54,0.22,0.04,0.04,0.0,0.0,0.03,jason stratfo brown,
+PHYS,2210,2,Physics with Calculus II,0.28,0.52,0.16,0.03,0.0,0.0,0.0,0.01,jason stratfo brown,
+PHYS,2210,3,Physics with Calculus II,0.22,0.55,0.19,0.02,0.0,0.0,0.0,0.01,ramakrishna podila,
+PHYS,2210,4,Physics with Calculus II,0.18,0.56,0.16,0.06,0.04,0.0,0.0,0.0,ramakrishna podila,
+PHYS,2210,7,Physics With Cal II (HON),0.58,0.36,0.06,0.0,0.0,0.0,0.0,0.0,joan marler,True
+PHYS,2220,1,Physics with Calculus III,0.57,0.29,0.0,0.05,0.0,0.0,0.0,0.1,jian he,
+PHYS,2230,3,Physics Lab II,0.72,0.06,0.0,0.0,0.0,0.0,0.0,0.22,jerry hester,
+PHYS,2230,4,Physics Lab II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,6,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,7,Physics Lab II,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,11,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,13,Physics Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,17,Physics Lab II,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2450,1,Physics of Climate,0.64,0.2,0.05,0.01,0.02,0.0,0.0,0.08,gerald lehmacher,
+PHYS,3120,1,Meth Theor Phys II,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,antony valentini,
+PHYS,3150,1,Intro to Computational Physics,0.5,0.27,0.19,0.0,0.0,0.0,0.0,0.04,emil georgie alexov,
+PHYS,3210,1,Mechanics I,0.29,0.25,0.21,0.04,0.08,0.0,0.0,0.13,joshua alper,
+PHYS,3250,1,Exper Physics I,0.5,0.25,0.15,0.0,0.05,0.0,0.0,0.05,chad sosolik,
+PHYS,4410,1,Electromagnetics I,0.27,0.36,0.14,0.05,0.0,0.0,0.0,0.18,xian lu,
+PHYS,4550,1,Quantum Physics I,0.18,0.64,0.09,0.09,0.0,0.0,0.0,0.0,ramakrishna podila,
+PHYS,8110,1,Meth of Theor Phys I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,feng ding,
+PHYS,8170,1,Molecular Biophysics,0.14,0.71,0.0,0.0,0.14,0.0,0.0,0.0,hugo sanabria,
+PHYS,8210,1,Classical Mech I,0.14,0.57,0.29,0.0,0.0,0.0,0.0,0.0,jens oberheide,
+PHYS,9510,1,Quantum Mech I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
+PKSC,1010,1,Pkgsc Orientation,0.88,0.09,0.02,0.0,0.01,0.0,0.0,0.0,robert truett moore,
+PKSC,1020,1,Intro to Pkg Sci,0.24,0.4,0.26,0.04,0.02,0.0,0.0,0.03,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2040,1,Container Systems,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2060,1,Container Sys Lab,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,4010,1,Packaging Machinery,0.35,0.49,0.14,0.0,0.0,0.0,0.0,0.01,anthony lou pometto,
+PKSC,4040,1,Protective Packaging Prop/Prin,0.34,0.34,0.19,0.05,0.02,0.0,0.0,0.06,gregory batt,
+PKSC,4160,1,Appl Polymers in Pkg,0.13,0.49,0.35,0.03,0.0,0.0,0.0,0.0,tyler stuettgen,
+PKSC,4200,1,Pkg Design & Dev,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4540,1,Prod Pkg Evl Lab,0.13,0.73,0.07,0.07,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4540,2,Prod Pkg Evl Lab,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4540,3,Prod Pkg Evl Lab,0.21,0.57,0.14,0.0,0.0,0.0,0.0,0.07,gregory batt,
+PKSC,4540,4,Prod Pkg Evl Lab,0.25,0.31,0.31,0.0,0.0,0.0,0.0,0.13,gregory batt,
+PKSC,4640,1,Food & Health Care Pkg Systems,0.65,0.25,0.08,0.0,0.03,0.0,0.0,0.0,kay cooksey,
+PKSC,8170,1,Pckg Materials: Sci & Technol,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,duncan darby,
+PLPA,3100,1,Principles of Plant Pathology,0.34,0.38,0.24,0.03,0.0,0.0,0.0,0.0,steven nye jeffers,
+PLPA,6250,1,Introductory Mycology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,julia loui kerrigan,
+POSC,1010,1,Amer National Govt,0.15,0.33,0.34,0.13,0.02,0.0,0.0,0.02,joseph earl stewart,
+POSC,1010,2,Amer National Govt,0.21,0.44,0.21,0.06,0.06,0.0,0.0,0.02,jeffrey scott peake,
+POSC,1020,1,Intro Intl Relations,0.4,0.34,0.15,0.06,0.0,0.0,0.0,0.04,brandon mic stewart,
+POSC,1020,2,Intro Intl Relations,0.64,0.22,0.11,0.02,0.02,0.0,0.0,0.0,brandon mic stewart,
+POSC,1020,3,Intro Intl Relations,0.24,0.44,0.11,0.04,0.09,0.0,0.0,0.07,steven vince miller,
+POSC,1020,4,Intro Intl Relations,0.13,0.42,0.27,0.12,0.06,0.0,0.0,0.01,zeynep taydas,
+POSC,1020,5,Intro Intl Relations,0.18,0.41,0.23,0.1,0.05,0.0,0.0,0.04,zeynep taydas,
+POSC,1030,1,Intro to Political Theory,0.37,0.28,0.16,0.07,0.06,0.0,0.0,0.06,brandon turner,
+POSC,1030,2,Intro to Political Theory,0.17,0.61,0.11,0.06,0.0,0.0,0.0,0.06,colin pearce,
+POSC,1030,3,Intro to Political Theory,0.61,0.28,0.0,0.11,0.0,0.0,0.0,0.0,lorianne molinari,
+POSC,1040,1,Intro Compar Pol,0.45,0.35,0.13,0.02,0.04,0.0,0.0,0.02,brandon mic stewart,
+POSC,1040,2,Intro Compar Pol,0.18,0.42,0.16,0.13,0.05,0.0,0.0,0.05,katherine am curtis,
+POSC,1990,1,Intro Pol Sci,0.54,0.26,0.07,0.05,0.04,0.0,0.0,0.04,meredith petersheim,
+POSC,3020,1,State and Loc Gov,0.14,0.42,0.19,0.0,0.05,0.0,0.0,0.21,bruce ransom,
+POSC,3210,1,Public Admin,0.15,0.31,0.46,0.08,0.0,0.0,0.0,0.0,james woodard,
+POSC,3410,1,Quant Meth in Pol Sc,0.28,0.32,0.2,0.08,0.12,0.0,0.0,0.0,jeffrey allen fine,
+POSC,3610,1,International Conflict,0.3,0.19,0.19,0.11,0.09,0.0,0.0,0.13,steven vince miller,
+POSC,3630,1,Us Foreign Policy,0.37,0.54,0.07,0.0,0.0,0.0,0.0,0.02,vladimir matic,
+POSC,3710,1,European Politics,0.29,0.4,0.27,0.0,0.02,0.0,0.0,0.02,vladimir matic,
+POSC,4030,1,United States Congress,0.31,0.31,0.17,0.06,0.17,0.0,0.0,0.0,jeffrey allen fine,
+POSC,4070,1,Religion and Politic,0.16,0.42,0.32,0.06,0.0,0.0,0.0,0.03,laura olson,
+POSC,4210,1,Public Policy,0.19,0.31,0.25,0.06,0.13,0.0,0.0,0.06,adam warber,
+POSC,4360,1,Law Courts Politics,0.88,0.08,0.02,0.0,0.0,0.0,0.0,0.02,joseph earl stewart,
+POSC,4380,1,Constitut Law: Struc of Gov,0.32,0.5,0.12,0.02,0.04,0.0,0.0,0.0,daniel frost,
+POSC,4420,1,Pol Parties & Elect,0.25,0.36,0.23,0.16,0.0,0.0,0.0,0.0,laura olson,
+POSC,4470,1,International Law,0.33,0.3,0.13,0.1,0.08,0.0,0.0,0.08,katherine am curtis,
+POSC,4500,1,Contemporary Political Thought,0.42,0.46,0.04,0.0,0.04,0.0,0.0,0.04,daniel frost,
+POSC,4540,1,Southern Politics,0.11,0.5,0.33,0.0,0.0,0.0,0.0,0.06,james woodard,
+POSC,4550,1,Pol Thght of American Founding,0.29,0.5,0.18,0.0,0.03,0.0,0.0,0.0, bradley thompson,
+POSC,4560,1,Diplomacy,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
+PRTM,1950,2,Pro Golf Management Seminar I,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.92,0.06,0.03,jamie lynn cathey,
+PRTM,2200,10,Foundations of PRTM,0.32,0.42,0.12,0.02,0.03,0.0,0.0,0.08,jamie lynn cathey,
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2260,2,Fnd of Mgt Adm PRTM,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
+PRTM,2260,3,Fnd of Mgt Adm PRTM,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2260,4,Fnd of Mgt Adm PRTM,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2260,5,Fnd of Mgt Adm PRTM,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,garrett stone,
+PRTM,2260,6,Fnd of Mgt Adm PRTM,0.21,0.5,0.21,0.07,0.0,0.0,0.0,0.0,ryan joseph gagnon,
+PRTM,2260,7,Fnd of Mgt Adm PRTM,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,brandon harris,
+PRTM,2260,8,Fnd of Mgt Adm PRTM,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,
+PRTM,2260,9,Fnd of Mgt Adm PRTM,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,katrina latri black,
+PRTM,2270,1,Prov of Leisure Exp,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2270,2,Prov of Leisure Exp,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
+PRTM,2270,3,Prov of Leisure Exp,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2270,4,Prov of Leisure Exp,0.0,0.43,0.21,0.29,0.07,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2270,5,Prov of Leisure Exp,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,garrett stone,
+PRTM,2270,6,Prov of Leisure Exp,0.29,0.21,0.36,0.07,0.07,0.0,0.0,0.0,ryan joseph gagnon,
+PRTM,2270,7,Prov of Leisure Exp,0.54,0.23,0.23,0.0,0.0,0.0,0.0,0.0,brandon harris,
+PRTM,2270,8,Prov of Leisure Exp,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,
+PRTM,2270,9,Prov of Leisure Exp,0.36,0.36,0.21,0.0,0.0,0.0,0.0,0.07,emilie viktor adams,
+PRTM,2290,1,Competency Integration in PRTM,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2290,2,Competency Integration in PRTM,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
+PRTM,2290,3,Competency Integration in PRTM,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2290,4,Competency Integration in PRTM,0.29,0.14,0.43,0.07,0.07,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2290,5,Competency Integration in PRTM,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,garrett stone,
+PRTM,2290,6,Competency Integration in PRTM,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,ryan joseph gagnon,
+PRTM,2290,7,Competency Integration in PRTM,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,brandon harris,
+PRTM,2290,8,Competency Integration in PRTM,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,katie dudley,
+PRTM,2290,9,Competency Integration in PRTM,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,emilie viktor adams,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.63,0.29,0.05,0.03,0.0,0.0,0.0,0.0,katherine an jordan,
+PRTM,3070,2,Facility Operations,0.84,0.09,0.0,0.03,0.03,0.0,0.0,0.0,raymond dunham,
+PRTM,3200,1,Recreation Policy,0.64,0.21,0.07,0.0,0.07,0.0,0.0,0.0,matthew ty brownlee,
+PRTM,3210,1,Recreation Admin,0.26,0.51,0.2,0.0,0.03,0.0,0.0,0.0,gina depper,
+PRTM,3220,1,Facilitation Techniques in RT,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,
+PRTM,3230,1,Prof Prep for RT Practice,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0,stephen thoma lewis,
+PRTM,3240,1,Assessment & Planning in RT,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3250,1,Global Persp in Rec,0.54,0.35,0.0,0.04,0.0,0.0,0.0,0.08,harrison pinckney,
+PRTM,3300,1,Visit Ser & Interp,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,3420,2,Intro to Tourism,0.52,0.21,0.12,0.06,0.09,0.0,0.0,0.0,herbert chancellor,
+PRTM,3430,1,Spl Asp of Tourist B,0.4,0.51,0.09,0.0,0.0,0.0,0.0,0.0,william norman,
+PRTM,3430,2,Spl Asp of Tourist B,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,'lisha fogle,
+PRTM,3470,1,Sport Tourism,0.47,0.21,0.32,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,
+PRTM,3900,7,Independent Study in PRTM,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3910,1,Social Media in PRTM,0.4,0.52,0.0,0.08,0.0,0.0,0.0,0.0,zeynep gedikoglu,
+PRTM,3910,2,Issues & Trends in Event Mgmt.,0.92,0.0,0.08,0.0,0.0,0.0,0.0,0.0,stephanie per garst,
+PRTM,3920,1,Special Event Management,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,
+PRTM,3920,2,Special Event Management,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,
+PRTM,4030,1,Elem of Rec/Pk Plan,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,gina depper,
+PRTM,4040,1,Field Training I,0.0,0.0,0.0,0.0,0.0,0.94,0.06,0.0,daniel mor anderson,
+PRTM,4210,1,Rec Fin Resc Mgt,0.11,0.26,0.42,0.21,0.0,0.0,0.0,0.0,denise mar anderson,
+PRTM,4220,1,Management of RT Services,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,
+PRTM,4470,1,Perspect Intl Travel,0.82,0.16,0.03,0.0,0.0,0.0,0.0,0.0,lauren duffy,
+PRTM,4510,1,Seminar in CRSCM,0.5,0.33,0.11,0.06,0.0,0.0,0.0,0.0,skye arthur-banning,
+PRTM,4550,1,Adv Program Planning,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,mariela fernandez,
+PRTM,4740,2,Adv Rec Resource Mgt,0.95,0.0,0.0,0.0,0.05,0.0,0.0,0.0,geoffrey koo riungu,
+PRTM,8020,1,Group Proc in Leisure Services,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,skye arthur-banning,
+PRTM,8080,2,Behavioral Aspects,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,8220,2,Strateg Planning in PRTM Orgs,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,thomas john orourke,
+PRTM,8700,1,Foundat & Issues in Rec Therap,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,alysha amber walter,
+PRTM,8710,1,Applied Research in Rec Therap,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
+PSYC,2010,1,Intro to Psychology,0.49,0.31,0.12,0.04,0.0,0.0,0.0,0.04,jo anne jorgensen,
+PSYC,2010,2,Intro to Psychology,0.42,0.35,0.13,0.06,0.01,0.0,0.0,0.03,jo anne jorgensen,
+PSYC,2010,3,Intro to Psychology,0.35,0.32,0.18,0.05,0.04,0.0,0.0,0.06,edwin brainerd,
+PSYC,2010,4,Intro to Psychology,0.57,0.2,0.13,0.04,0.03,0.0,0.0,0.03,chong hyon pak,
+PSYC,2010,5,Intro to Psychology,0.34,0.43,0.17,0.04,0.0,0.0,0.0,0.01,mary taylor,
+PSYC,2010,6,Intro to Psychology (HON),0.63,0.21,0.05,0.05,0.0,0.0,0.0,0.05,robin mari kowalski,True
+PSYC,2020,2,Intro Psychology Lab,0.91,0.0,0.0,0.04,0.0,0.0,0.0,0.04,anton sytine,
+PSYC,2890,1,Fundamentals of Psyc Science,0.39,0.31,0.2,0.05,0.01,0.0,0.0,0.03,cynthia pury,
+PSYC,3060,1,Human Sexual Behavior,0.44,0.28,0.16,0.04,0.06,0.0,0.0,0.02,bruce michael king,
+PSYC,3090,100,Intro Experimental Psychology,0.33,0.28,0.21,0.13,0.03,0.0,0.0,0.03,richard tyrrell,
+PSYC,3090,200,Intro Experimental Psychology,0.45,0.32,0.13,0.06,0.03,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3090,300,Intro Experimental Psychology,0.67,0.2,0.03,0.07,0.0,0.0,0.0,0.03,leah hartman,
+PSYC,3100,100,Advanced Experimental Psych,0.38,0.38,0.19,0.05,0.0,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimental Psych,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert campbell,
+PSYC,3100,300,Advanced Experimental Psych,0.35,0.45,0.05,0.05,0.05,0.0,0.0,0.05,gargi sawhney,
+PSYC,3100,400,Advanced Experimental Psych,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,3100,500,Advanced Experimental Psych,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3240,1,Physiological Psych,0.3,0.35,0.16,0.07,0.06,0.0,0.0,0.06,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.28,0.32,0.26,0.07,0.03,0.0,0.0,0.04,june pilcher,
+PSYC,3310,1,Critical Thinking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,leo gugerty,
+PSYC,3330,1,Cognitive Psych,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,robert campbell,
+PSYC,3330,2,Cognitive Psych,0.39,0.26,0.2,0.09,0.03,0.0,0.0,0.03,kaileigh ange byrne,
+PSYC,3330,3,Cognitive Psych,0.36,0.33,0.23,0.04,0.03,0.0,0.0,0.0,madison eliza sauls,
+PSYC,3340,1,Cognitive Psych Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3340,2,Cognitive Psych Lab,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,leo gugerty,
+PSYC,3400,1,Lifespan Developmental Psych,0.6,0.28,0.09,0.03,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3400,2,Lifespan Developmental Psych,0.21,0.4,0.25,0.07,0.0,0.0,0.0,0.07,pamela alley,
+PSYC,3520,1,Social Psychology,0.41,0.25,0.21,0.06,0.02,0.0,0.0,0.05,eric mckibben,
+PSYC,3640,1,Industrial Psych,0.34,0.49,0.14,0.03,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,3640,2,Industrial Psych,0.26,0.43,0.26,0.03,0.01,0.0,0.0,0.0,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.27,0.31,0.3,0.1,0.01,0.0,0.0,0.0,thomas britt,
+PSYC,3680,2,Organizational Psych,0.3,0.36,0.2,0.06,0.04,0.0,0.0,0.03,dana verhoeven,
+PSYC,3690,1,Leadership in Organiz Settings,0.29,0.33,0.21,0.08,0.02,0.0,0.0,0.06,patrick raymark,
+PSYC,3700,1,Personality,0.31,0.5,0.15,0.01,0.0,0.0,0.0,0.03,eric mckibben,
+PSYC,3700,2,Personality,0.28,0.41,0.23,0.04,0.0,0.0,0.0,0.04,john robert hester,
+PSYC,3830,1,Abnormal Psychology,0.43,0.33,0.12,0.03,0.04,0.0,0.0,0.04,heidi marie zinzow,
+PSYC,3830,2,Abnormal Psychology,0.34,0.55,0.06,0.0,0.02,0.0,0.0,0.02,lucinda sorci quick,
+PSYC,3830,3,Abnormal Psychology,0.29,0.43,0.2,0.06,0.0,0.0,0.0,0.03,pamela alley,
+PSYC,3830,4,Abnormal Psychology,0.16,0.34,0.13,0.16,0.13,0.0,0.0,0.09,pamela alley,
+PSYC,3890,1,Cross-Cultural Psychology,0.62,0.21,0.07,0.0,0.1,0.0,0.0,0.0,ceren gunsoy,
+PSYC,4080,1,Women and Psychology,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,robin mari kowalski,
+PSYC,4150,2,Systems and Theories,0.29,0.41,0.09,0.09,0.12,0.0,0.0,0.0,edwin brainerd,
+PSYC,4150,3,Systems and Theories,0.44,0.24,0.09,0.12,0.03,0.0,0.0,0.09,edwin brainerd,
+PSYC,4220,1,Perception,0.36,0.16,0.2,0.08,0.12,0.0,0.0,0.08,claudio cantalupo,
+PSYC,4220,2,Perception,0.27,0.35,0.31,0.04,0.0,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4220,3,Perception,0.22,0.33,0.19,0.19,0.04,0.0,0.0,0.04,christopher pagano,
+PSYC,4220,4,Perception,0.36,0.28,0.2,0.08,0.0,0.0,0.0,0.08,christopher pagano,
+PSYC,4350,1,Human Factors,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,laura whitlock,
+PSYC,4350,2,Human Factors,0.42,0.42,0.05,0.05,0.05,0.0,0.0,0.0,laura whitlock,
+PSYC,4560,1,Psychophysiology,0.39,0.28,0.28,0.06,0.0,0.0,0.0,0.0,drew michael morris,
+PSYC,4800,1,Health Psychology,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,james mccubbin,
+PSYC,4800,2,Health Psychology,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,
+PSYC,4890,1,Teamwork Dynamics,0.88,0.04,0.04,0.0,0.04,0.0,0.0,0.0,marissa leig porter,
+PSYC,4920,1,Senior Laboratory,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,
+PSYC,4920,2,Senior Laboratory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,
+PSYC,4920,3,Senior Laboratory,0.89,0.04,0.04,0.0,0.04,0.0,0.0,0.0,nastassia ma savage,
+PSYC,4920,5,Senior Laboratory,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,drea kevin fekety,
+PSYC,8100,1,Research Design I,0.65,0.27,0.05,0.0,0.0,0.0,0.0,0.03,patrick rosopa,
+PSYC,8620,1,Org Psychology,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,robert ray sinclair,
+PSYC,8730,1,SEM in Applied Psychology,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, dewayne moore,
+RED,8000,1,Real Estate Dvlpment,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+RED,8010,1,Market Analysis,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,thomas andrew fox,
+RED,8040,1,Resid Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+RED,8050,1,Commercial Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+RED,8130,1,Strat in Real Estate,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,phillip rive hughes,
+RED,8170,1,Mixed-Use Development Seminar,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,tor wallace-babcock,
+RED,8890,1,Selected Topics-Adv. Fin. Mod.,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,larry bradle harvey,
+REL,1010,1,Intro to Religion,0.22,0.33,0.22,0.17,0.0,0.0,0.0,0.06,peter cohen,
+REL,1010,2,Intro to Religion,0.34,0.26,0.23,0.06,0.03,0.0,0.0,0.09,peter cohen,
+REL,1010,3,Intro to Religion,0.29,0.51,0.11,0.0,0.0,0.0,0.0,0.09,brett patterson,
+REL,1010,4,Intro to Religion,0.29,0.47,0.0,0.18,0.06,0.0,0.0,0.0,peter cohen,
+REL,1010,5,Intro to Religion,0.17,0.51,0.14,0.03,0.03,0.0,0.0,0.11,brett patterson,
+REL,1020,2,World Religions,0.4,0.43,0.14,0.0,0.0,0.0,0.0,0.03,robert stephens,
+REL,1020,3,World Religions,0.35,0.5,0.12,0.03,0.0,0.0,0.0,0.0,robert stephens,
+REL,1020,4,World Religions,0.2,0.6,0.14,0.03,0.03,0.0,0.0,0.0,robert stephens,
+REL,1020,5,World Religions,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,brett patterson,
+REL,3010,1,Old Testament,0.42,0.48,0.09,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3020,1,New Testament Lit,0.47,0.38,0.03,0.0,0.03,0.0,0.0,0.09,benjamin white,
+REL,3080,1,Religions of the Ancient World,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3100,1,History of Religion in the US,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,elizabeth jemison,
+REL,3150,1,Islam,0.53,0.27,0.07,0.0,0.13,0.0,0.0,0.0,robert stephens,
+REL,4520,1,History of Early Christianity,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,benjamin white,
+RS,3010,1,Rural Sociology,0.53,0.37,0.0,0.05,0.0,0.0,0.0,0.05,kenneth robinson,
+RS,4590,1,The Community,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
+RUSS,1010,1,Elementary Russian,0.5,0.31,0.06,0.06,0.0,0.0,0.0,0.06,stephanie el morris,
+RUSS,1010,2,Elementary Russian,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,stephanie el morris,
+RUSS,3400,1,19th C Russ Culture,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,olga anatol volkova,
+RUSS,3610,1,Russn Lit Since 1910,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,
+SOC,2010,2,Introduction to Sociology,0.94,0.04,0.01,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,
+SOC,2010,3,Introduction to Sociology,0.79,0.18,0.02,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,
+SOC,2010,4,Introduction to Sociology,0.53,0.34,0.13,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,5,Introduction to Sociology,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,stacy leanne smith,
+SOC,2010,6,Introduction to Sociology,0.81,0.15,0.02,0.0,0.0,0.0,0.0,0.02,stacy leanne smith,
+SOC,2010,7,Introduction to Sociology,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,stacy leanne smith,
+SOC,2010,8,Introduction to Sociology,0.8,0.12,0.04,0.02,0.0,0.0,0.0,0.02,stacy leanne smith,
+SOC,2010,9,Introduction to Sociology,0.36,0.41,0.16,0.04,0.0,0.0,0.0,0.03,carolyn can coffman,
+SOC,2010,10,Introduction to Sociology,0.53,0.39,0.05,0.01,0.0,0.0,0.0,0.01,carolyn can coffman,
+SOC,2010,11,Introduction to Sociology,0.48,0.41,0.05,0.05,0.02,0.0,0.0,0.0,carolyn can coffman,
+SOC,2010,12,Introduction to Sociology,0.69,0.22,0.06,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,13,Introduction to Sociology,0.71,0.23,0.02,0.01,0.02,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,14,Introduction to Sociology,0.6,0.25,0.08,0.0,0.02,0.0,0.0,0.04,shannon mcdonough,
+SOC,2020,1,Social Problems,0.51,0.4,0.02,0.0,0.02,0.0,0.0,0.04,carolyn can coffman,
+SOC,3020,1,Research Methods I,0.44,0.26,0.23,0.05,0.02,0.0,0.0,0.0,andrew whitehead,
+SOC,3040,1,Social Research Methods II,0.32,0.45,0.14,0.09,0.0,0.0,0.0,0.0,ye luo,
+SOC,3110,1,The Family,0.3,0.53,0.15,0.0,0.02,0.0,0.0,0.0,andrew whitehead,
+SOC,3310,1,Urban Sociology,0.87,0.03,0.05,0.0,0.05,0.0,0.0,0.0,william haller,
+SOC,3910,1,Soc of Deviance,0.34,0.32,0.26,0.06,0.02,0.0,0.0,0.0,shannon mcdonough,
+SOC,3920,1,Juvenile Delinquency,0.76,0.15,0.06,0.0,0.0,0.0,0.0,0.03,angelia turner,
+SOC,3940,1,Sociology of Mental Illness,0.6,0.3,0.06,0.0,0.02,0.0,0.0,0.02,douglas sturkie,
+SOC,4040,1,Soc Theory,0.31,0.26,0.17,0.17,0.03,0.0,0.0,0.06,stacy leanne smith,
+SOC,4140,1,Policy&Social Change,0.54,0.3,0.16,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,4330,1,Global Social Change,0.41,0.41,0.17,0.0,0.0,0.0,0.0,0.0,traci ann hefner,
+SOC,4440,1,Sociology of Educ,0.61,0.26,0.1,0.0,0.03,0.0,0.0,0.0,andrew mannheimer,
+SOC,4590,1,The Community,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
+SOC,4600,1,Race & Ethnicity,0.91,0.07,0.0,0.0,0.02,0.0,0.0,0.0,william haller,
+SOC,4610,1,Sex & Gender,0.43,0.41,0.13,0.0,0.0,0.0,0.0,0.02,traci ann hefner,
+SOC,4970,1,Senior Lab,0.71,0.26,0.0,0.03,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,8030,1,Sur Dsgn App Res Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ye luo,
+SPAN,1010,1,Elementary Spanish,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,scott harris,
+SPAN,1010,2,Elementary Spanish,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1010,3,Elementary Spanish,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1020,1,Elementary Spanish,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1020,2,Elementary Spanish,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
+SPAN,1020,3,Elementary Spanish,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
+SPAN,1020,4,Elementary Spanish,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,1020,5,Elementary Spanish,0.67,0.06,0.11,0.06,0.0,0.0,0.0,0.11,danie garcia vieyra,
+SPAN,1020,6,Elementary Spanish,0.24,0.41,0.24,0.06,0.06,0.0,0.0,0.0,cathy robison,
+SPAN,1020,7,Elementary Spanish,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,1020,8,Elementary Spanish,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,1020,10,Elementary Spanish,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,1020,11,Elementary Spanish,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,1020,12,Elementary Spanish,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,1020,13,Elementary Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2010,1,Intermediate Spanish,0.41,0.35,0.18,0.06,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,2,Intermediate Spanish,0.11,0.58,0.32,0.0,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,3,Intermediate Spanish,0.47,0.18,0.12,0.12,0.0,0.0,0.0,0.12,melva margu persico,
+SPAN,2010,4,Intermediate Spanish,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,2010,5,Intermediate Spanish,0.81,0.0,0.06,0.0,0.06,0.0,0.0,0.06,danie garcia vieyra,
+SPAN,2010,6,Intermediate Spanish,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,danie garcia vieyra,
+SPAN,2010,7,Intermediate Spanish,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,2010,8,Intermediate Spanish,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,2010,9,Intermediate Spanish,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,william da holcombe,
+SPAN,2010,10,Intermediate Spanish,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,11,Intermediate Spanish,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
+SPAN,2010,12,Intermediate Spanish,0.68,0.05,0.21,0.05,0.0,0.0,0.0,0.0,al garcia rodriguez,
+SPAN,2010,13,Intermediate Spanish,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,maureen zamora,
+SPAN,2010,14,Intermediate Spanish,0.5,0.31,0.13,0.0,0.0,0.0,0.0,0.06,maureen zamora,
+SPAN,2010,15,Intermediate Spanish,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william da holcombe,
+SPAN,2010,16,Intermediate Spanish,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,ellory schmucker,
+SPAN,2010,17,Intermediate Spanish,0.79,0.07,0.0,0.07,0.0,0.0,0.0,0.07,ze cruz valderramos,
+SPAN,2010,19,Intermediate Spanish,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
+SPAN,2020,1,Intermediate Spanish,0.25,0.56,0.13,0.0,0.06,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,2,Intermediate Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,3,Intermediate Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,4,Intermediate Spanish,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,5,Intermediate Spanish,0.39,0.44,0.11,0.06,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2020,6,Intermediate Spanish,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,ze cruz valderramos,
+SPAN,2020,7,Intermediate Spanish,0.71,0.06,0.18,0.06,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2020,8,Intermediate Spanish,0.37,0.32,0.21,0.05,0.0,0.0,0.0,0.05,ana paula  miller,
+SPAN,2020,9,Intermediate Spanish,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,10,Intermediate Spanish,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,11,Intermediate Spanish,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,ze cruz valderramos,
+SPAN,2020,12,Intermediate Spanish,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
+SPAN,2020,13,Intermediate Spanish,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,nora arostegu logue,
+SPAN,2020,14,Intermediate Spanish,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
+SPAN,3020,1,Int Spn Gram & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,3020,2,Int Spn Gram & Comp,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,melva margu persico,
+SPAN,3040,1,Intro Hisp Lit Forms,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+SPAN,3050,1,Int Con Comp Span I,0.29,0.29,0.24,0.06,0.0,0.0,0.0,0.12,juana martin-armas,
+SPAN,3050,2,Int Con Comp Span I,0.32,0.47,0.05,0.0,0.0,0.0,0.0,0.16,juana martin-armas,
+SPAN,3050,3,Int Con Comp Span I,0.47,0.37,0.05,0.0,0.05,0.0,0.0,0.05,raquel anido,
+SPAN,3050,4,Int Con Comp Span I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,
+SPAN,3060,1,Span Comp for Bus,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,3070,1,Hispanic World: Sp,0.53,0.37,0.0,0.05,0.05,0.0,0.0,0.0,salvador oropesa,
+SPAN,3070,2,Hispanic World: Sp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,
+SPAN,3080,1,Hispanic World: La,0.19,0.5,0.19,0.06,0.06,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,3110,1,Surv Span-Amer Lit,0.38,0.38,0.08,0.0,0.0,0.0,0.0,0.15,tiffany dawn miller,
+SPAN,3130,2,Span Lit Survey I,0.38,0.38,0.08,0.0,0.08,0.0,0.0,0.08,mon rojas-de-massei,
+SPAN,4030,1,Span Amer Wom Writer,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+STAT,2220,1,Statistics in Everyday Life,0.33,0.37,0.21,0.06,0.02,0.0,0.0,0.01,james espey,
+STAT,2220,2,Statistics in Everyday Life,0.41,0.32,0.17,0.06,0.01,0.0,0.0,0.03,james espey,
+STAT,2220,3,Statistics in Everyday Life,0.34,0.41,0.16,0.06,0.01,0.0,0.0,0.02,james espey,
+STAT,2220,4,Statistics in Everyday Life,0.43,0.31,0.09,0.08,0.06,0.0,0.0,0.03,james espey,
+STAT,2220,5,Statistics in Everyday Life,0.25,0.34,0.27,0.02,0.04,0.0,0.0,0.07,ros martinez-dawson,
+STAT,2220,6,Statistics in Everyday Life,0.42,0.42,0.05,0.0,0.05,0.0,0.0,0.05,jason alexande kurz,
+STAT,2220,7,Statistics in Everyday Life,0.26,0.47,0.16,0.11,0.0,0.0,0.0,0.0,jason alexande kurz,
+STAT,2220,100,Stats in Everyday Life (HON),0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ros martinez-dawson,True
+STAT,2300,1,Statistical Methods I,0.28,0.37,0.18,0.09,0.05,0.0,0.0,0.03,christy jenki brown,
+STAT,2300,2,Statistical Methods I,0.38,0.34,0.13,0.05,0.06,0.0,0.0,0.04,christy jenki brown,
+STAT,2300,3,Statistical Methods I,0.27,0.33,0.21,0.08,0.06,0.0,0.0,0.05, erwin walker,
+STAT,2300,4,Statistical Methods I,0.25,0.45,0.14,0.07,0.05,0.0,0.0,0.04, erwin walker,
+STAT,2300,5,Statistical Methods I,0.24,0.32,0.28,0.05,0.06,0.0,0.0,0.05,william bridges,
+STAT,2300,6,Statistical Methods I,0.18,0.38,0.18,0.09,0.09,0.0,0.0,0.07,william bridges,
+STAT,2300,100,Statistical Methods I (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christy jenki brown,True
+STAT,3090,1,Introductory Business Stats,0.37,0.26,0.26,0.0,0.05,0.0,0.0,0.05,todd fenstermacher,
+STAT,3090,2,Introductory Business Stats,0.22,0.33,0.11,0.17,0.11,0.0,0.0,0.06,todd fenstermacher,
+STAT,3090,3,Introductory Business Stats,0.16,0.37,0.16,0.11,0.21,0.0,0.0,0.0,boyoung hur,
+STAT,3090,4,Introductory Business Stats,0.05,0.32,0.16,0.11,0.32,0.0,0.0,0.05,boyoung hur,
+STAT,3090,5,Introductory Business Stats,0.05,0.26,0.26,0.16,0.21,0.0,0.0,0.05,andrew pangia,
+STAT,3090,6,Introductory Business Stats,0.11,0.33,0.39,0.0,0.11,0.0,0.0,0.06,andrew pangia,
+STAT,3090,7,Introductory Business Stats,0.22,0.33,0.22,0.06,0.17,0.0,0.0,0.0,tiantian yang,
+STAT,3090,8,Introductory Business Stats,0.17,0.28,0.22,0.22,0.11,0.0,0.0,0.0,april thomas,
+STAT,3090,9,Introductory Business Stats,0.11,0.11,0.26,0.11,0.26,0.0,0.0,0.16,feng gao,
+STAT,3090,10,Introductory Business Stats,0.17,0.28,0.33,0.11,0.06,0.0,0.0,0.06,bryce pruitt,
+STAT,3090,11,Introductory Business Stats,0.26,0.16,0.26,0.16,0.16,0.0,0.0,0.0,yisu jia,
+STAT,3090,12,Introductory Business Stats,0.37,0.37,0.16,0.0,0.0,0.0,0.0,0.11,lu sun,
+STAT,3090,13,Introductory Business Stats,0.34,0.3,0.18,0.09,0.06,0.0,0.0,0.03,sharon marie evans,
+STAT,3090,14,Introductory Business Stats,0.5,0.22,0.28,0.0,0.0,0.0,0.0,0.0,kayla doris javier,
+STAT,3090,15,Introductory Business Stats,0.19,0.22,0.34,0.05,0.14,0.0,0.0,0.05,matthew saltzman,
+STAT,3090,16,Introductory Business Stats,0.39,0.28,0.17,0.06,0.11,0.0,0.0,0.0,jiajing niu,
+STAT,3090,18,Introductory Business Stats,0.05,0.58,0.26,0.05,0.05,0.0,0.0,0.0,bryce pruitt,
+STAT,3090,19,Introductory Business Stats,0.16,0.26,0.47,0.0,0.0,0.0,0.0,0.11,rui gong,
+STAT,3090,20,Introductory Business Stats,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,jiajing niu,
+STAT,3090,22,Introductory Business Stats,0.16,0.42,0.16,0.05,0.05,0.0,0.0,0.16,tiantian yang,
+STAT,3090,23,Introductory Business Stats,0.26,0.32,0.11,0.16,0.05,0.0,0.0,0.11,tianhui wei,
+STAT,3090,24,Introductory Business Stats,0.11,0.37,0.26,0.05,0.05,0.0,0.0,0.16,tianhui wei,
+STAT,3090,25,Introductory Business Stats,0.26,0.37,0.16,0.16,0.0,0.0,0.0,0.05,liu zhu,
+STAT,3090,26,Introductory Business Stats,0.26,0.21,0.16,0.16,0.21,0.0,0.0,0.0,april thomas,
+STAT,3090,27,Introductory Business Stats,0.26,0.11,0.16,0.21,0.16,0.0,0.0,0.11,feng gao,
+STAT,3090,28,Introductory Business Stats,0.33,0.56,0.0,0.06,0.0,0.0,0.0,0.06,lu sun,
+STAT,3090,30,Introductory Business Stats,0.53,0.26,0.05,0.11,0.05,0.0,0.0,0.0,liu zhu,
+STAT,3090,31,Introductory Business Stats,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,kayla doris javier,
+STAT,3090,33,Introductory Business Stats,0.28,0.25,0.32,0.05,0.08,0.0,0.0,0.02,sharon marie evans,
+STAT,3090,34,Introductory Business Stats,0.32,0.32,0.16,0.05,0.11,0.0,0.0,0.05,rui gong,
+STAT,3090,35,Introductory Business Stats,0.3,0.21,0.39,0.06,0.0,0.0,0.0,0.03,margaret mar wiecek,
+STAT,3090,36,Introductory Business Stats,0.17,0.24,0.36,0.17,0.0,0.0,0.0,0.07,matthew saltzman,
+STAT,3090,37,Introductory Business Stats,0.26,0.16,0.47,0.0,0.05,0.0,0.0,0.05,yisu jia,
+STAT,3300,1,Statistical Methods II,0.38,0.44,0.06,0.0,0.06,0.0,0.0,0.06,ros martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,ellen hepfe breazel,
+STAT,4110,1,Stat Mthds for Process Control,0.82,0.11,0.05,0.0,0.02,0.0,0.0,0.0,richard stev dubsky,
+STAT,4110,2,Stat Mthds for Process Control,0.85,0.12,0.02,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,
+STAT,4110,3,Stat Mthds for Process Control,0.64,0.27,0.06,0.03,0.0,0.0,0.0,0.0,richard stev dubsky,
+STAT,6020,1,Intro to Statistical Computing,0.33,0.25,0.08,0.0,0.0,0.0,0.0,0.33,ellen hepfe breazel,
+STAT,8010,1,Statistical Methods I,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,james rieck,
+STAT,8010,2,Statistical Methods I,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,patrick gerard,
+STAT,8010,3,Statistical Methods I,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,joseph daniel bible,
+STAT,8010,4,Statistical Methods I,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,
+STAT,8010,5,Statistical Methods I,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,jun luo,
+STAT,8010,6,Statistical Methods I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,brook thaye russell,
+STAT,8010,7,Statistical Methods I,0.44,0.33,0.17,0.0,0.06,0.0,0.0,0.0,james rieck,
+STAT,8020,1,Statistical Methods II,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,brook thaye russell,
+STAT,8030,1,Regress & Least Squares Anlys,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,jun luo,
+STAT,8170,400,Multivariate Statistics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+STS,1010,1,Survey of S T S,0.68,0.27,0.0,0.0,0.03,0.0,0.0,0.03,kenneth dav widgren,
+STS,1010,2,Survey of S T S,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,scott brame,
+STS,1010,3,Survey of S T S,0.51,0.32,0.03,0.0,0.05,0.0,0.0,0.08,elizabeth stansell,
+STS,1010,5,Survey of S T S,0.47,0.39,0.14,0.0,0.0,0.0,0.0,0.0,philip randall,
+STS,1010,6,Survey of S T S,0.4,0.23,0.17,0.09,0.0,0.0,0.0,0.11,sarah mae cooper,
+STS,1010,7,Survey of S T S,0.5,0.14,0.28,0.0,0.06,0.0,0.0,0.03,megan no macalystre,
+STS,1010,8,Survey of S T S,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,david charles foltz,
+STS,1010,9,Survey of S T S,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+THEA,2100,1,Theatre Appreciation,0.53,0.19,0.16,0.0,0.03,0.0,0.0,0.09,kendra lyne johnson,
+THEA,2100,2,Theatre Appreciation,0.81,0.09,0.0,0.0,0.09,0.0,0.0,0.0,kerrie kath seymour,
+THEA,2100,3,Theatre Appreciation,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,shannon ther robert,
+THEA,2100,4,Theatre Appreciation,0.81,0.13,0.03,0.03,0.0,0.0,0.0,0.0,richard st. peter,
+THEA,2100,5,Theatre Appreciation,0.81,0.13,0.03,0.0,0.0,0.0,0.0,0.03,carol collins,
+THEA,2100,6,Theatre Appreciation,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,
+THEA,2100,7,Theatre Appreciation,0.53,0.28,0.13,0.0,0.0,0.0,0.0,0.06,jason adkins,
+THEA,2670,1,Stage Makeup,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
+THEA,2790,1,Theatre Practicum,0.38,0.25,0.0,0.0,0.06,0.0,0.0,0.31,matthew leckenbusch,
+THEA,2880,1,Intro to Cad,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anthony penna,
+THEA,3150,1,Theatre History I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,richard st. peter,
+THEA,3170,1,African-Amer Thea I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,3470,1,Structure of Drama,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
+THEA,3980,1,Special Topics in Theatre,0.57,0.21,0.14,0.0,0.0,0.0,0.0,0.07,kerrie kath seymour,
+THEA,4870,1,Stage Lighting I,0.33,0.42,0.08,0.0,0.08,0.0,0.0,0.08,anthony penna,
+WFB,3000,1,Wildlife Biology,0.48,0.27,0.17,0.03,0.02,0.0,0.0,0.03,catherine jachowski,
+WFB,3000,2,Wildlife Biology,0.45,0.35,0.14,0.02,0.01,0.0,0.0,0.02,catherine jachowski,
+WFB,3010,2,Wildlife Biology Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,4100,2,Wildlife Management Techniques,0.25,0.54,0.13,0.07,0.0,0.0,0.0,0.02,james davis,
+WFB,4180,1,Fisheries Mgt & Conservation,0.67,0.19,0.11,0.0,0.0,0.0,0.0,0.04,troy mason farmer,
+WFB,4440,1,Wildlife Damage Management,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,james davis,
+WFB,4720,1,Ornithology,0.42,0.25,0.17,0.08,0.0,0.0,0.0,0.08,neil smith,
+WFB,4770,1,Ichthyology,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,brandon kev peoples,
+WFB,4930,2,Plant & Flora ID/Systematics,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,patrick mcmillan,
+WFB,4930,3,Waterfowl Ecology,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
+WFB,8180,2,Waterfowl Ecology & Mgt,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,richard ma kaminski,
+WFB,8530,2,Global Change Ecology,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,lydia ri 'halloran,
+WS,1030,1,Women in Global Perspective,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,laura foxworth,
+WS,1030,2,Women in Global Perspective,0.67,0.13,0.1,0.07,0.0,0.0,0.0,0.03,laura foxworth,
+WS,2300,1,Women and Leadership I,0.68,0.16,0.08,0.0,0.04,0.0,0.0,0.04,mary price,
+WS,3010,1,Intro Women's Studies,0.58,0.35,0.03,0.0,0.03,0.0,0.0,0.0,elizabeth ros adams,
+WS,3010,2,Intro Women's Studies,0.48,0.41,0.03,0.0,0.0,0.0,0.0,0.07,elizabeth ros adams,
+YDP,3000,400,Youth Development in Society,0.54,0.33,0.0,0.08,0.04,0.0,0.0,0.0,barry garst,
+YDP,3050,400,Theory/Phil of Youth Dev Work,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,edmond patri bowers,
+YDP,3200,1,Youth Dev in Sport/Phys Activ,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,lauren eli stephens,
+YDP,3300,1,Designing Effective Youth Prog,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,kellye rembert,
+YDP,3350,1,Youth Activity Leadership,0.5,0.17,0.17,0.11,0.06,0.0,0.0,0.0,allison mic avishai,
+YDP,3450,1,Creative Activities for Youth,0.87,0.0,0.09,0.04,0.0,0.0,0.0,0.0,kimberly pe johnson,
+YDP,8000,1,Theories of Youth Development,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
+YDP,8030,1,Creative & Ethical Leadership,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,barry garst,
+YDP,8050,1,Youth Dev in Context of Family,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
+YDP,8060,1,Youth Dev in Global Society,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,ann marie gillard,
+YDP,8060,2,Youth Dev in Global Society,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,ann marie gillard,

--- a/bot/cogs/grades_cog/assets/2017_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2017_Spring.csv
@@ -1,2496 +1,2496 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1020,1,Survey of Art & Arch Hist II,0.41,0.41,0.13,0.02,0.01,0.0,0.0,0.03,andrea feeser,AAH-1020,2017
-AAH,2060,1,Art History and Theory II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,AAH-2060,2017
-ACCT,2010,1,Financial Accounting Concepts,0.42,0.2,0.13,0.05,0.12,0.0,0.0,0.08,lydia lan schleifer,ACCT-2010,2017
-ACCT,2010,2,Financial Accounting Concepts,0.4,0.25,0.22,0.05,0.07,0.0,0.0,0.02,annieka philo,ACCT-2010,2017
-ACCT,2010,3,Financial Accounting Concepts,0.2,0.41,0.2,0.14,0.0,0.0,0.0,0.06,philip maiberger,ACCT-2010,2017
-ACCT,2010,4,Financial Accounting Concepts,0.35,0.22,0.27,0.07,0.1,0.0,0.0,0.0,annieka philo,ACCT-2010,2017
-ACCT,2010,5,Financial Accounting Concepts,0.38,0.2,0.15,0.07,0.08,0.0,0.0,0.12,lydia lan schleifer,ACCT-2010,2017
-ACCT,2010,6,Financial Accounting Concepts,0.45,0.25,0.08,0.05,0.08,0.0,0.0,0.08,lydia lan schleifer,ACCT-2010,2017
-ACCT,2010,7,Financial Accounting Concepts,0.27,0.13,0.23,0.07,0.13,0.0,0.0,0.18,mary ann  prater,ACCT-2010,2017
-ACCT,2010,8,Financial Accounting Concepts,0.41,0.24,0.21,0.1,0.02,0.0,0.0,0.02,annieka philo,ACCT-2010,2017
-ACCT,2010,9,Financial Accounting Concepts,0.11,0.29,0.2,0.09,0.09,0.0,0.0,0.23,mary ann  prater,ACCT-2010,2017
-ACCT,2010,10,Financial Accounting Concepts,0.59,0.29,0.05,0.02,0.02,0.0,0.0,0.03,charles tegen,ACCT-2010,2017
-ACCT,2010,101,Fin Acct Concepts (HON),0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,mary ann  prater,ACCT-2010,2017
-ACCT,2010,401,Financial Accounting Concepts,0.28,0.45,0.14,0.03,0.06,0.0,0.0,0.03,jeffrey mcmillan,ACCT-2010,2017
-ACCT,2010,402,Financial Accounting Concepts,0.21,0.5,0.13,0.05,0.09,0.0,0.0,0.02,jeffrey mcmillan,ACCT-2010,2017
-ACCT,2020,1,Managerial Accounting Concepts,0.09,0.37,0.3,0.09,0.04,0.0,0.0,0.11,henry anderson,ACCT-2020,2017
-ACCT,2020,2,Managerial Accounting Concepts,0.11,0.33,0.29,0.03,0.07,0.0,0.0,0.17,henry anderson,ACCT-2020,2017
-ACCT,2020,3,Managerial Accounting Concepts,0.25,0.23,0.3,0.08,0.03,0.0,0.0,0.13,henry anderson,ACCT-2020,2017
-ACCT,2020,4,Managerial Accounting Concepts,0.15,0.32,0.29,0.06,0.1,0.0,0.0,0.08,emily suza mccorkle,ACCT-2020,2017
-ACCT,2020,5,Managerial Accounting Concepts,0.46,0.34,0.13,0.04,0.01,0.0,0.0,0.01,emily suza mccorkle,ACCT-2020,2017
-ACCT,2020,401,Managerial Accounting Concepts,0.11,0.32,0.16,0.1,0.08,0.0,0.0,0.23,henry anderson,ACCT-2020,2017
-ACCT,3030,1,Cost Accounting,0.4,0.29,0.2,0.02,0.04,0.0,0.0,0.04,jace garrett,ACCT-3030,2017
-ACCT,3030,2,Cost Accounting,0.2,0.39,0.31,0.04,0.0,0.0,0.0,0.06,jace garrett,ACCT-3030,2017
-ACCT,3030,3,Cost Accounting,0.24,0.32,0.24,0.04,0.06,0.0,0.0,0.1,rebecca pennel trax,ACCT-3030,2017
-ACCT,3030,4,Cost Accounting,0.18,0.29,0.29,0.04,0.07,0.0,0.0,0.14,rebecca pennel trax,ACCT-3030,2017
-ACCT,3110,1,Intermediate Financial Acct I,0.22,0.29,0.24,0.09,0.09,0.0,0.0,0.07,terry daniel knause,ACCT-3110,2017
-ACCT,3110,2,Intermediate Financial Acct I,0.3,0.34,0.18,0.08,0.04,0.0,0.0,0.06,terry daniel knause,ACCT-3110,2017
-ACCT,3110,3,Intermediate Financial Acct I,0.34,0.42,0.14,0.08,0.0,0.0,0.0,0.02,terry daniel knause,ACCT-3110,2017
-ACCT,3110,4,Intermediate Financial Acct I,0.2,0.36,0.24,0.1,0.04,0.0,0.0,0.06,terry daniel knause,ACCT-3110,2017
-ACCT,3110,401,Intermediate Financial Acct I,0.16,0.22,0.22,0.09,0.13,0.0,0.0,0.19,henry anderson,ACCT-3110,2017
-ACCT,3120,1,Intermediate Financial Acct II,0.09,0.34,0.39,0.09,0.07,0.0,0.0,0.02,the estate  guffey,ACCT-3120,2017
-ACCT,3120,2,Intermediate Financial Acct II,0.27,0.24,0.35,0.05,0.03,0.0,0.0,0.05,the estate  guffey,ACCT-3120,2017
-ACCT,3120,3,Intermediate Financial Acct II,0.07,0.3,0.34,0.09,0.14,0.0,0.0,0.07,brian todd carver,ACCT-3120,2017
-ACCT,3120,4,Intermediate Financial Acct II,0.07,0.27,0.4,0.2,0.0,0.0,0.0,0.07,brian todd carver,ACCT-3120,2017
-ACCT,3120,5,Intermediate Financial Acct II,0.23,0.42,0.19,0.07,0.0,0.0,0.0,0.09,jeremy micha vinson,ACCT-3120,2017
-ACCT,3130,1,Intermediate Fin Acct III,0.15,0.35,0.45,0.0,0.05,0.0,0.0,0.0, russell madray,ACCT-3130,2017
-ACCT,3130,2,Intermediate Fin Acct III,0.35,0.38,0.25,0.02,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2017
-ACCT,3130,3,Intermediate Fin Acct III,0.26,0.54,0.18,0.0,0.03,0.0,0.0,0.0, russell madray,ACCT-3130,2017
-ACCT,3130,4,Intermediate Fin Acct III,0.32,0.46,0.22,0.0,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2017
-ACCT,3220,1,Accounting Information Systems,0.27,0.36,0.21,0.03,0.03,0.0,0.0,0.09,philip maiberger,ACCT-3220,2017
-ACCT,3220,2,Accounting Information Systems,0.38,0.35,0.09,0.03,0.0,0.0,0.0,0.15,philip maiberger,ACCT-3220,2017
-ACCT,3220,3,Accounting Information Systems,0.19,0.34,0.34,0.03,0.0,0.0,0.0,0.09,philip maiberger,ACCT-3220,2017
-ACCT,4040,1,Individual Taxation,0.61,0.2,0.18,0.0,0.02,0.0,0.0,0.0,sarah martin,ACCT-4040,2017
-ACCT,4040,2,Individual Taxation,0.61,0.18,0.14,0.05,0.02,0.0,0.0,0.0,sarah martin,ACCT-4040,2017
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.23,0.67,0.1,0.0,0.0,0.0,0.0,0.0,robin radtke,ACCT-4100,2017
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.15,0.49,0.31,0.03,0.03,0.0,0.0,0.0,robin radtke,ACCT-4100,2017
-ACCT,4150,1,Auditing,0.24,0.43,0.29,0.01,0.01,0.0,0.0,0.01,carl hollingsworth,ACCT-4150,2017
-ACCT,8520,1,Fin Acct Theory/Res,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8520,2017
-ACCT,8520,2,Fin Acct Theory/Res,0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,ralph welton,ACCT-8520,2017
-ACCT,8540,1,Prof Responsibility,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2017
-ACCT,8540,2,Prof Responsibility,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2017
-ACCT,8540,3,Prof Responsibility,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2017
-ACCT,8620,1,Financial Auditing,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,ACCT-8620,2017
-ACCT,8620,2,Financial Auditing,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,ACCT-8620,2017
-ACCT,8710,1,Corporate Taxation,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2017
-ACCT,8710,2,Corporate Taxation,0.2,0.68,0.13,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2017
-ACCT,8710,3,Corporate Taxation,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2017
-ACCT,8730,1,Intl/Spec Tax Topic,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,ACCT-8730,2017
-ACCT,8740,1,Tax Aspects of Finan Planning,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,ACCT-8740,2017
-AGED,1000,1,Orientation & Field Experience,0.67,0.26,0.0,0.04,0.0,0.0,0.0,0.04,philip fravel,AGED-1000,2017
-AGED,2030,1,Teaching Agriscience,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,AGED-2030,2017
-AGED,4150,1,Leadership of Vol,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,kevin layfield,AGED-4150,2017
-AGED,4160,1,Ethics and Issues,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,AGED-4160,2017
-AGM,2050,1,Prin of Fabrication,0.27,0.38,0.25,0.05,0.04,0.0,0.0,0.02,hunter massey,AGM-2050,2017
-AGM,2060,1,Machinery Mgt,0.28,0.43,0.18,0.05,0.05,0.0,0.0,0.03,hunter massey,AGM-2060,2017
-AGM,2200,1,Calc for Mechanized Agricult,0.36,0.51,0.08,0.03,0.0,0.0,0.0,0.02,young han,AGM-2200,2017
-AGM,2210,1,Land Measurements,0.33,0.26,0.3,0.06,0.04,0.0,0.0,0.02,charles privette,AGM-2210,2017
-AGM,4020,1,Irrigation System Design,0.38,0.4,0.2,0.03,0.0,0.0,0.0,0.0,charles privette,AGM-4020,2017
-AGM,4100,1,Precision Ag Tech,0.61,0.2,0.13,0.04,0.02,0.0,0.0,0.0,hunter massey,AGM-4100,2017
-AGM,4520,1,Mobile Power,0.56,0.37,0.07,0.0,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4520,2017
-AGM,4720,1,Capstone,0.5,0.35,0.15,0.0,0.0,0.0,0.0,0.0,john chastain,AGM-4720,2017
-AGM,4730,2,Selected Topics,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,young han,AGM-4730,2017
-AGRB,2020,1,Agricultural Economics,0.16,0.34,0.23,0.1,0.13,0.0,0.0,0.03,george apperson,AGRB-2020,2017
-AGRB,2020,2,Agricultural Economics,0.34,0.32,0.32,0.0,0.0,0.0,0.0,0.03,george apperson,AGRB-2020,2017
-AGRB,2050,1,Agriculture and Society,0.28,0.33,0.2,0.13,0.06,0.0,0.0,0.0,george apperson,AGRB-2050,2017
-AGRB,3190,1,Agribusiness Management,0.4,0.26,0.19,0.14,0.0,0.0,0.0,0.01,michael vassalos,AGRB-3190,2017
-AGRB,3570,1,Natural Resources Economics,0.21,0.31,0.29,0.1,0.04,0.0,0.0,0.04,david brian willis,AGRB-3570,2017
-AGRB,4020,1,Production Economics,0.59,0.3,0.07,0.0,0.0,0.0,0.0,0.04,michael vassalos,AGRB-4020,2017
-AGRB,4080,1,Quant Agribusiness Analysis II,0.24,0.48,0.24,0.03,0.0,0.0,0.0,0.0,lisha zhang,AGRB-4080,2017
-AGRB,4520,1,Agricultural Policy,0.17,0.48,0.25,0.06,0.0,0.0,0.0,0.04,michael vassalos,AGRB-4520,2017
-AGRB,4560,1,Prices,0.41,0.31,0.28,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,AGRB-4560,2017
-AGRB,4570,1,"Natural Res Use, Tech & Policy",0.25,0.42,0.17,0.0,0.0,0.0,0.0,0.17,david brian willis,AGRB-4570,2017
-AL,3490,400,Principles of Coaching,0.81,0.08,0.04,0.04,0.0,0.0,0.0,0.04,deborah cadorette,AL-3490,2017
-AL,3490,401,Principles of Coaching,0.76,0.2,0.0,0.0,0.0,0.0,0.0,0.04,deborah cadorette,AL-3490,2017
-AL,3490,402,Principles of Coaching,0.71,0.17,0.08,0.0,0.04,0.0,0.0,0.0,julia wright,AL-3490,2017
-AL,3490,403,Principles of Coaching,0.6,0.2,0.08,0.08,0.04,0.0,0.0,0.0,clyde keith connor,AL-3490,2017
-AL,3490,404,Principles of Coaching,0.89,0.0,0.0,0.07,0.04,0.0,0.0,0.0,edmond fry,AL-3490,2017
-AL,3490,405,Principles of Coaching,0.78,0.11,0.07,0.0,0.04,0.0,0.0,0.0,deborah cadorette,AL-3490,2017
-AL,3500,400,Sci Basis I/Ex Phy,0.19,0.07,0.52,0.19,0.0,0.0,0.0,0.04,michael godfrey,AL-3500,2017
-AL,3500,401,Sci Basis I/Ex Phy,0.17,0.3,0.39,0.04,0.0,0.0,0.0,0.09,michael godfrey,AL-3500,2017
-AL,3530,400,Athletic Injuries,0.26,0.26,0.37,0.07,0.04,0.0,0.0,0.0,isaac sean colbert,AL-3530,2017
-AL,3530,401,Athletic Injuries,0.32,0.4,0.12,0.12,0.0,0.0,0.0,0.04,isaac sean colbert,AL-3530,2017
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.57,0.19,0.14,0.1,0.0,0.0,0.0,0.0,clyde keith connor,AL-3600,2017
-AL,3610,400,Admin/Org of Athletic Programs,0.64,0.24,0.08,0.0,0.04,0.0,0.0,0.0,henry oates,AL-3610,2017
-AL,3610,401,Admin/Org of Athletic Programs,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2017
-AL,3610,402,Admin/Org of Athletic Programs,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2017
-AL,3620,400,Psychology of Coaching,0.32,0.4,0.16,0.08,0.0,0.0,0.0,0.04,natalie anne carter,AL-3620,2017
-AL,3620,401,Psychology of Coaching,0.46,0.25,0.21,0.0,0.08,0.0,0.0,0.0,natalie anne carter,AL-3620,2017
-AL,3620,402,Psychology of Coaching,0.48,0.22,0.13,0.13,0.04,0.0,0.0,0.0,natalie anne carter,AL-3620,2017
-AL,3720,400,Coaching Basketball,0.72,0.12,0.08,0.0,0.08,0.0,0.0,0.0,edmond fry,AL-3720,2017
-AL,3740,400,Coaching Football,0.76,0.08,0.04,0.0,0.04,0.0,0.0,0.08,edmond fry,AL-3740,2017
-AL,3750,400,Coaching Soccer,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,deborah cadorette,AL-3750,2017
-AL,3760,400,Coaching Strength/Conditioning,0.58,0.27,0.08,0.04,0.0,0.0,0.0,0.04,edmond fry,AL-3760,2017
-AL,4380,400,Coaching Women,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,AL-4380,2017
-AL,4380,402,Officiating in Athletic Leader,0.64,0.16,0.16,0.0,0.04,0.0,0.0,0.0,clyde keith connor,AL-4380,2017
-AL,4380,403,Coaching Inner Athlete,0.74,0.11,0.07,0.0,0.04,0.0,0.0,0.04,deborah cadorette,AL-4380,2017
-AL,4380,404,CPR/AED for Athletic Coaches,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,julia wright,AL-4380,2017
-AL,4380,405,CPR/AED for Athletic Coaches,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,AL-4380,2017
-AL,8530,400,Legal Iss in Intercoll Athlet,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,AL-8530,2017
-AL,8530,401,Legal Iss in Intercoll Athlet,0.78,0.0,0.0,0.0,0.22,0.0,0.0,0.0,misty soles,AL-8530,2017
-AL,8630,400,Socio Dynam in Intercol Athlet,0.69,0.19,0.0,0.0,0.13,0.0,0.0,0.0,michael godfrey,AL-8630,2017
-AL,8640,400,Ethical Iss in Collegiate Athl,0.64,0.32,0.0,0.0,0.0,0.0,0.0,0.04,michael godfrey,AL-8640,2017
-AL,8640,401,Ethical Iss in Collegiate Athl,0.6,0.25,0.0,0.0,0.15,0.0,0.0,0.0,michael godfrey,AL-8640,2017
-AL,8700,400,Intercoll Athletics Finance,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,misty soles,AL-8700,2017
-ANTH,2010,1,Introduction to Anthropology,0.66,0.21,0.07,0.02,0.02,0.0,0.0,0.01,melissa vogel,ANTH-2010,2017
-ANTH,2010,2,Introduction to Anthropology,0.67,0.25,0.06,0.0,0.02,0.0,0.0,0.0,yi wu,ANTH-2010,2017
-ANTH,2010,3,Introduction to Anthropology,0.36,0.38,0.1,0.02,0.02,0.0,0.0,0.12,lisa rapaport,ANTH-2010,2017
-ANTH,2050,1,Professional Development,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,katherine weisensee,ANTH-2050,2017
-ANTH,3200,1,North American Indian Cultures,0.21,0.36,0.14,0.14,0.0,0.0,0.0,0.14,john coggeshall,ANTH-3200,2017
-ANTH,3310,1,Archaeology,0.37,0.33,0.26,0.04,0.0,0.0,0.0,0.0,melissa vogel,ANTH-3310,2017
-ANTH,3510,1,Biological Anthropology,0.4,0.4,0.1,0.05,0.0,0.0,0.0,0.05,katherine weisensee,ANTH-3510,2017
-ANTH,4040,1,Anthropological Theories,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,john coggeshall,ANTH-4040,2017
-ANTH,4990,1,Special Topics,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,yi wu,ANTH-4990,2017
-ARCH,1510,1,Arch Communication,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,ARCH-1510,2017
-ARCH,1510,2,Arch Communication,0.38,0.5,0.06,0.0,0.06,0.0,0.0,0.0,robert silance,ARCH-1510,2017
-ARCH,1510,3,Arch Communication,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,clarissa mendez,ARCH-1510,2017
-ARCH,1510,4,Arch Communication,0.2,0.6,0.07,0.07,0.0,0.0,0.0,0.07,berrin terim,ARCH-1510,2017
-ARCH,1510,5,Arch Communication,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-1510,2017
-ARCH,1510,6,Arch Communication,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,maryam hamidpour,ARCH-1510,2017
-ARCH,2520,1,Arch Foundations II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-2520,2017
-ARCH,2520,2,Arch Foundations II,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,james barker,ARCH-2520,2017
-ARCH,2520,3,Arch Foundations II,0.33,0.42,0.17,0.08,0.0,0.0,0.0,0.0,david lee,ARCH-2520,2017
-ARCH,2520,4,Arch Foundations II,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2520,2017
-ARCH,2520,5,Arch Foundations II,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,ARCH-2520,2017
-ARCH,2700,2,Structures I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,ARCH-2700,2017
-ARCH,2710,1,Structures II,0.66,0.21,0.07,0.03,0.03,0.0,0.0,0.0,mahmoodreza soltani,ARCH-2710,2017
-ARCH,3530,1,Studio Genoa,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,ARCH-3530,2017
-ARCH,4120,1,History Research,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,ARCH-4120,2017
-ARCH,4120,2,History Research,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-4120,2017
-ARCH,4140,2,Design Seminar,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-4140,2017
-ARCH,4160,1,Field Studies,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,ARCH-4160,2017
-ARCH,4160,2,Field Studies,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-4160,2017
-ARCH,4520,1,Synthesis Studio,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-4520,2017
-ARCH,4520,2,Synthesis Studio,0.44,0.22,0.22,0.0,0.0,0.0,0.0,0.11,julie poe wilkerson,ARCH-4520,2017
-ARCH,4520,3,Synthesis Studio,0.11,0.56,0.33,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-4520,2017
-ARCH,4520,4,Synthesis Studio,0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4520,2017
-ARCH,4710,1,Arch Hist of Place,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,james thomas,ARCH-4710,2017
-ARCH,4890,1,Internship,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,ashley jennings,ARCH-4890,2017
-ARCH,6160,2,Field Studies,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,miguel roldan,ARCH-6160,2017
-ARCH,6880,1,Arch Programming,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-6880,2017
-ARCH,8110,1,Visualization II,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,ARCH-8110,2017
-ARCH,8320,1,Community 1:1,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,ARCH-8320,2017
-ARCH,8420,1,Arch Studio II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,ARCH-8420,2017
-ARCH,8420,2,Arch Studio II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,ARCH-8420,2017
-ARCH,8520,6,Design Studio IV,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,miguel roldan,ARCH-8520,2017
-ARCH,8520,8,Design Studio IV,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-8520,2017
-ARCH,8520,9,Design Studio IV,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-8520,2017
-ARCH,8610,1,History/Theory II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8610,2017
-ARCH,8620,1,History/Theory III,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,ARCH-8620,2017
-ARCH,8650,1,Topics in Health Policy,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,anjali joseph,ARCH-8650,2017
-ARCH,8710,1,Structures II,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,dustin gra albright,ARCH-8710,2017
-ARCH,8730,2,Environmental Sys,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,ARCH-8730,2017
-ARCH,8740,1,Building Process:TR,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-8740,2017
-ARCH,8820,1,Building Economics,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-8820,2017
-ARCH,8920,1,Comprehensive Studio,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8920,2017
-ARCH,8920,2,Comprehensive Studio,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-8920,2017
-ARCH,8920,3,Comprehensive Studio,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,ARCH-8920,2017
-ARCH,8920,4,Comprehensive Studio,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-8920,2017
-ARCH,8960,1,A+H Studio: Tectonic,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-8960,2017
-ART,1060,1,Foundation Drawing II,0.7,0.17,0.0,0.04,0.09,0.0,0.0,0.0,carly drew,ART-1060,2017
-ART,1520,1,Foundations Art II,0.76,0.2,0.0,0.04,0.0,0.0,0.0,0.0,joseph ric manson ,ART-1520,2017
-ART,2050,1,Beginning Life Drawing,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,ART-2050,2017
-ART,2070,1,Beginning Painting,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,todd mcdonald,ART-2070,2017
-ART,2100,400,Art Appreciation,0.35,0.48,0.09,0.09,0.0,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2017
-ART,2100,401,Art Appreciation,0.55,0.24,0.1,0.0,0.0,0.0,0.0,0.1,lydia jane dorsey,ART-2100,2017
-ART,2100,402,Art Appreciation,0.46,0.29,0.18,0.0,0.04,0.0,0.0,0.04,lydia jane dorsey,ART-2100,2017
-ART,2100,403,Art Appreciation,0.24,0.59,0.14,0.0,0.0,0.0,0.0,0.03,lydia jane dorsey,ART-2100,2017
-ART,2130,1,Begin Photography,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amber nic eckersley,ART-2130,2017
-ART,8060,1,Visual Arts Sem II,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,gregory wi shelnutt,ART-8060,2017
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1100,2017
-AS,1100,2,Air Force Today II,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1100,2017
-AS,1100,3,Air Force Today II,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1100,2017
-AS,2100,2,Dev of Air Power II,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,christopher mann,AS-2100,2017
-AS,2100,3,Dev of Air Power II,0.8,0.13,0.0,0.07,0.0,0.0,0.0,0.0,christopher mann,AS-2100,2017
-ASL,1010,1,Am Sign Lang I,0.26,0.37,0.32,0.05,0.0,0.0,0.0,0.0,william alton brant,ASL-1010,2017
-ASL,1010,2,Am Sign Lang I,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,william alton brant,ASL-1010,2017
-ASL,1010,3,Am Sign Lang I,0.58,0.37,0.0,0.05,0.0,0.0,0.0,0.0,michael alb barrett,ASL-1010,2017
-ASL,1020,1,Am Sign Lang I,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-1020,2017
-ASL,1020,2,Am Sign Lang I,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,kim ma misener dunn,ASL-1020,2017
-ASL,1020,3,Am Sign Lang I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-1020,2017
-ASL,2010,1,Am Sign Lang II,0.31,0.23,0.38,0.0,0.0,0.0,0.0,0.08,michael alb barrett,ASL-2010,2017
-ASL,2020,1,Am Sign Lang II,0.26,0.16,0.42,0.11,0.05,0.0,0.0,0.0,michael alb barrett,ASL-2020,2017
-ASL,2020,2,Am Sign Lang II,0.64,0.09,0.09,0.09,0.0,0.0,0.0,0.09,michael alb barrett,ASL-2020,2017
-ASL,3020,1,Advanced Asl II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-3020,2017
-ASL,4600,1,Deaf Literature,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-4600,2017
-ASTR,1010,1,Solar System Astronomy,0.25,0.35,0.16,0.1,0.07,0.0,0.0,0.08,lih-sin the,ASTR-1010,2017
-ASTR,1020,1,Stellar Astronomy,0.27,0.26,0.11,0.05,0.16,0.0,0.0,0.15,amber porter,ASTR-1020,2017
-ASTR,1020,2,Stellar Astronomy,0.24,0.38,0.17,0.09,0.04,0.0,0.0,0.07,amber porter,ASTR-1020,2017
-ASTR,1030,1,Solar Systm Astr Lab,0.35,0.35,0.08,0.04,0.19,0.0,0.0,0.0,amber porter,ASTR-1030,2017
-ASTR,1030,2,Solar Systm Astr Lab,0.38,0.35,0.12,0.04,0.0,0.0,0.0,0.12,amber porter,ASTR-1030,2017
-ASTR,1030,3,Solar Systm Astr Lab,0.38,0.29,0.24,0.05,0.0,0.0,0.0,0.05,amber porter,ASTR-1030,2017
-ASTR,1040,1,Stellar Astr Lab,0.64,0.18,0.14,0.0,0.0,0.0,0.0,0.05,amber porter,ASTR-1040,2017
-ASTR,1040,2,Stellar Astr Lab,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,amber porter,ASTR-1040,2017
-ASTR,1040,3,Stellar Astr Lab,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,amber porter,ASTR-1040,2017
-ASTR,1040,5,Stellar Astr Lab,0.55,0.2,0.05,0.0,0.05,0.0,0.0,0.15,amber porter,ASTR-1040,2017
-AUD,2850,1,Acoustics of Music,0.2,0.5,0.2,0.1,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-2850,2017
-AUE,8160,1,Eng Combustion Emiss,0.75,0.23,0.03,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8160,2017
-AUE,8170,3,Alt Energy Sources,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,simona onori,AUE-8170,2017
-AUE,8500,6,Stability/Safety Sys,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8500,2017
-AUE,8550,16,Auto Struct Analysis,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,david wil schmueser,AUE-8550,2017
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.49,0.46,0.05,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8690,2017
-AUE,8770,9,Light-Weight Design,0.52,0.39,0.06,0.0,0.03,0.0,0.0,0.0,fadi kama abu-farha,AUE-8770,2017
-AUE,8860,1,Noise Vibration,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,douglas feldmaier,AUE-8860,2017
-AUE,8900,102,Automotive Engineering Project,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8900,2017
-AUE,8930,3,Applied Dynamics,0.37,0.47,0.11,0.0,0.05,0.0,0.0,0.0,imtiaz ul haque,AUE-8930,2017
-AUE,8930,4,Mechanics of Composites Struct,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,srikanth pilla,AUE-8930,2017
-AUE,8930,401,Autonomous Driving Techn,0.67,0.31,0.03,0.0,0.0,0.0,0.0,0.0,yunyi jia,AUE-8930,2017
-AUE,8930,402,Sustainability & LCE,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,AUE-8930,2017
-AVS,2000,1,Beef Cattle Tech,0.62,0.27,0.08,0.0,0.04,0.0,0.0,0.0,nathan long,AVS-2000,2017
-AVS,2020,1,CAFLS Plus,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,thomas scott,AVS-2020,2017
-AVS,2060,1,Swine Techniques,0.8,0.13,0.0,0.0,0.03,0.0,0.0,0.05,richelle lor miller,AVS-2060,2017
-AVS,3010,1,Anat & Phys Dom Ani,0.44,0.32,0.13,0.05,0.03,0.0,0.0,0.03,tiffany wilmoth,AVS-3010,2017
-AVS,3100,1,Animal Health,0.54,0.2,0.1,0.03,0.06,0.0,0.0,0.07,thomas scott,AVS-3100,2017
-AVS,3150,1,Animal Welfare,0.46,0.21,0.33,0.0,0.0,0.0,0.0,0.0,peter skewes,AVS-3150,2017
-AVS,3700,1,Principles of Animal Nutrition,0.49,0.24,0.16,0.08,0.02,0.0,0.0,0.0,james ro strickland,AVS-3700,2017
-AVS,3750,1,Applied Animal Nutrition,0.29,0.33,0.19,0.15,0.0,0.0,0.0,0.04,gustavo jos lascano,AVS-3750,2017
-AVS,4000,1,AVS Professional Development,0.73,0.2,0.08,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,AVS-4000,2017
-AVS,4000,2,AVS Professional Development,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,AVS-4000,2017
-AVS,4010,1,Beef Production,0.1,0.6,0.2,0.1,0.0,0.0,0.0,0.0,nathan long,AVS-4010,2017
-AVS,4060,1,Seminars & Related Topics,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2017
-AVS,4060,2,Seminars & Related Topics,0.33,0.47,0.13,0.07,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2017
-AVS,4100,1,Domestic Ani Behav,0.31,0.46,0.17,0.03,0.01,0.0,0.0,0.02,peter skewes,AVS-4100,2017
-AVS,4120,1,Advanced Equine Management,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-4120,2017
-AVS,4130,1,Animal Products,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-4130,2017
-AVS,4140,1,Basic Immunology,0.74,0.11,0.11,0.0,0.04,0.0,0.0,0.0,thomas scott,AVS-4140,2017
-AVS,4220,6,Special Problems,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,susan kay duckett,AVS-4220,2017
-AVS,4530,1,Animal Reproduction,0.46,0.24,0.27,0.0,0.02,0.0,0.0,0.0,glenn birrenkott,AVS-4530,2017
-AVS,4530,400,Animal Reproduction,0.57,0.21,0.14,0.07,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-4530,2017
-BCHM,3010,1,Molecular Biochem,0.1,0.37,0.23,0.12,0.07,0.0,0.0,0.1,meredith tei morris,BCHM-3010,2017
-BCHM,3010,2,Molecular Biochem(HON),0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,cheryl ingram-smith,BCHM-3010,2017
-BCHM,3050,1,Essen Elements Bioch,0.29,0.38,0.2,0.07,0.01,0.0,0.0,0.03,srik chandrasekaran,BCHM-3050,2017
-BCHM,3050,2,Essen Elements Bioch,0.4,0.32,0.2,0.06,0.0,0.0,0.0,0.02,srik chandrasekaran,BCHM-3050,2017
-BCHM,4320,1,Bioch of Metabolism,0.78,0.13,0.08,0.02,0.0,0.0,0.0,0.0,kimberly paul,BCHM-4320,2017
-BCHM,4340,3,Biochemistry of Metabolism Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kimberly paul,BCHM-4340,2017
-BCHM,4340,4,Biochemistry of Metabolism Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,kimberly paul,BCHM-4340,2017
-BCHM,4360,1,Genes to Proteins,0.8,0.17,0.02,0.0,0.02,0.0,0.0,0.0,michael glen sehorn,BCHM-4360,2017
-BCHM,4400,1,Bioinformatics,0.45,0.35,0.15,0.0,0.05,0.0,0.0,0.0,liangjiang wang,BCHM-4400,2017
-BCHM,4900,21,EPIC Ambassadors,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,meredith tei morris,BCHM-4900,2017
-BCHM,8050,1,Issues in Research,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,BCHM-8050,2017
-BE,2100,1,Intro to Biosystems Engr,0.71,0.14,0.0,0.07,0.07,0.0,0.0,0.0,yi zheng,BE-2100,2017
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.63,0.21,0.13,0.0,0.0,0.0,0.0,0.04,tom owino,BE-3220,2017
-BE,4120,1,Be Heat Mass Trans,0.38,0.38,0.08,0.13,0.0,0.0,0.0,0.04,caye marie drapcho,BE-4120,2017
-BE,4150,1,Instr & Control for Biosys Eng,0.67,0.1,0.1,0.1,0.0,0.0,0.0,0.05,yi zheng,BE-4150,2017
-BE,4240,2,Ecological Engineering,0.71,0.21,0.05,0.0,0.0,0.0,0.0,0.02,christophe darnault,BE-4240,2017
-BE,4380,1,Bioprocess Engineering Design,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4380,2017
-BE,4730,3,Thermodynamics,0.26,0.53,0.11,0.0,0.11,0.0,0.0,0.0,terry walker,BE-4730,2017
-BIOE,1010,1,Biol for Bioengr,0.58,0.34,0.04,0.0,0.0,0.0,0.0,0.05,vladimir vla reukov,BIOE-1010,2017
-BIOE,2000,1,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,martine laberge,BIOE-2000,2017
-BIOE,2010,1,Intro Biomed Engr,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,charles webb,BIOE-2010,2017
-BIOE,3020,1,Biomaterials,0.67,0.29,0.03,0.0,0.0,0.0,0.0,0.01,alexey ale vertegel,BIOE-3020,2017
-BIOE,3200,1,Biomechanics,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,BIOE-3200,2017
-BIOE,3210,1,Biofluid Mechanics,0.6,0.19,0.15,0.04,0.0,0.0,0.0,0.02,sarah harcum,BIOE-3210,2017
-BIOE,3700,1,Bioinst & Imaging,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,delphine dean,BIOE-3700,2017
-BIOE,4030,1,Applied Bio E Design,0.75,0.24,0.01,0.0,0.0,0.0,0.0,0.0,john desjardins,BIOE-4030,2017
-BIOE,4200,1,Sports Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,BIOE-4200,2017
-BIOE,4230,1,Cardiovascular Engr and Path,0.54,0.44,0.02,0.0,0.0,0.0,0.0,0.0,dan simionescu,BIOE-4230,2017
-BIOE,4490,1,Drug Delivery,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,frank alexis,BIOE-4490,2017
-BIOE,6230,1,Cardiovascular Engr and Path,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.03,dan simionescu,BIOE-6230,2017
-BIOE,6350,1,Modeling of Multiphysics Prob,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,guigen zhang,BIOE-6350,2017
-BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,martine laberge,BIOE-8000,2017
-BIOE,8410,1,Drug Delivery,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,BIOE-8410,2017
-BIOE,8500,3,Reg & Clin Affairs-Med Devices,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,jeremy mercuri,BIOE-8500,2017
-BIOE,8610,1,Biomed Eng Product Translation,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,BIOE-8610,2017
-BIOL,1040,1,General Biology II,0.13,0.27,0.28,0.16,0.1,0.0,0.0,0.06,nora espinoza,BIOL-1040,2017
-BIOL,1040,2,General Biology II,0.45,0.32,0.16,0.04,0.02,0.0,0.0,0.01,william surver,BIOL-1040,2017
-BIOL,1040,3,General Biology II,0.13,0.22,0.38,0.13,0.09,0.0,0.0,0.05,salvatore sparace,BIOL-1040,2017
-BIOL,1040,4,General Biology II (HON),0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,BIOL-1040,2017
-BIOL,1060,1,Gen Biology Lab II,0.22,0.52,0.17,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,2,Gen Biology Lab II,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,3,Gen Biology Lab II,0.13,0.58,0.08,0.04,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,4,Gen Biology Lab II,0.08,0.58,0.29,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,5,Gen Biology Lab II,0.14,0.23,0.41,0.14,0.09,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,7,Gen Biology Lab II,0.14,0.5,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,8,Gen Biology Lab II,0.23,0.45,0.18,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,9,Gen Biology Lab II,0.27,0.27,0.32,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,10,Gen Biology Lab II,0.18,0.32,0.36,0.05,0.09,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,11,Gen Biology Lab II,0.08,0.58,0.29,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,12,Gen Biology Lab II,0.17,0.57,0.26,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,13,Gen Biology Lab II,0.17,0.54,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,14,Gen Biology Lab II,0.14,0.57,0.24,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,15,Gen Biology Lab II,0.1,0.71,0.14,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,16,Gen Biology Lab II,0.04,0.71,0.17,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,17,Gen Biology Lab II,0.13,0.42,0.25,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,18,Gen Biology Lab II,0.05,0.55,0.35,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,19,Gen Biology Lab II,0.0,0.4,0.45,0.05,0.0,0.0,0.0,0.1,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,20,Gen Biology Lab II,0.29,0.43,0.19,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,21,Gen Biology Lab II,0.18,0.5,0.23,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,22,Gen Biology Lab II,0.19,0.48,0.19,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,24,Gen Biology Lab II,0.05,0.6,0.3,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,25,Gen Biology Lab II,0.08,0.58,0.25,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,26,Gen Biology Lab II,0.53,0.21,0.21,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,27,Gen Biology Lab II,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,28,Gen Biology Lab II,0.32,0.5,0.05,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,29,Gen Biology Lab II,0.09,0.45,0.36,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,30,Gen Biology Lab II,0.15,0.55,0.2,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,31,Gen Biology Lab II,0.08,0.46,0.33,0.04,0.08,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,32,Gen Biology Lab II,0.23,0.45,0.27,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,35,Gen Biology Lab II,0.05,0.48,0.33,0.05,0.1,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1060,36,Gen Biology Lab II,0.0,0.19,0.63,0.06,0.0,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1060,2017
-BIOL,1110,1,Principles of Biology II,0.24,0.48,0.19,0.03,0.05,0.0,0.0,0.01,dylan dittrich-reed,BIOL-1110,2017
-BIOL,1110,3,Principles of Biology II,0.4,0.37,0.14,0.03,0.03,0.0,0.0,0.02,robert kosinski,BIOL-1110,2017
-BIOL,1110,4,Prin of Biol II  (HON),0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,robert kosinski,BIOL-1110,2017
-BIOL,1200,1,Biological Inq Lab,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,2,Biological Inq Lab,0.39,0.28,0.33,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,3,Biological Inq Lab,0.6,0.27,0.07,0.0,0.0,0.0,0.0,0.07, christine minor,BIOL-1200,2017
-BIOL,1200,4,Biological Inq Lab,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,5,Biological Inq Lab,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1200,6,Biological Inq Lab,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1200,2017
-BIOL,1230,1,Keys to Human Biol,0.3,0.34,0.19,0.12,0.03,0.0,0.0,0.02, christine minor,BIOL-1230,2017
-BIOL,2000,1,Biology in the News,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-2000,2017
-BIOL,2000,4,Biology in the News,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,vincent pa richards,BIOL-2000,2017
-BIOL,2030,1,Human Disease & Soc,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-2030,2017
-BIOL,2040,1,"Environ, Energy and Society",0.34,0.4,0.09,0.08,0.0,0.0,0.0,0.09,john jenkins hains,BIOL-2040,2017
-BIOL,2040,2,"Environ, Energy and Society",0.18,0.56,0.16,0.09,0.0,0.0,0.0,0.02,john jenkins hains,BIOL-2040,2017
-BIOL,2230,1,Human Anat and Physiology II,0.41,0.34,0.11,0.09,0.02,0.0,0.0,0.02,john cummings,BIOL-2230,2017
-BIOL,2230,2,Human Anat and Physiology II,0.5,0.29,0.14,0.05,0.01,0.0,0.0,0.01,john cummings,BIOL-2230,2017
-BIOL,3020,1,Invertebrate Biology,0.13,0.28,0.39,0.11,0.09,0.0,0.0,0.0,juan baeza migueles,BIOL-3020,2017
-BIOL,3040,1,Biology of Plants,0.15,0.3,0.26,0.23,0.04,0.0,0.0,0.01,robert edwa ballard,BIOL-3040,2017
-BIOL,3060,2,Invertebrate Biology Lab,0.29,0.33,0.25,0.0,0.08,0.0,0.0,0.04,juan baeza migueles,BIOL-3060,2017
-BIOL,3060,4,Invertebrate Biology Lab,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,juan baeza migueles,BIOL-3060,2017
-BIOL,3080,1,Biology of Plants Practicum,0.22,0.33,0.28,0.11,0.0,0.0,0.0,0.06,nathan redding,BIOL-3080,2017
-BIOL,3080,2,Biology of Plants Practicum,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2017
-BIOL,3080,3,Biology of Plants Practicum,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2017
-BIOL,3080,4,Biology of Plants Practicum,0.76,0.12,0.0,0.0,0.12,0.0,0.0,0.0,nathan redding,BIOL-3080,2017
-BIOL,3160,1,Human Physiology,0.35,0.51,0.11,0.02,0.01,0.0,0.0,0.01,tamara mcnutt-scott,BIOL-3160,2017
-BIOL,3350,1,Evolutionary Biology,0.45,0.33,0.14,0.07,0.0,0.0,0.0,0.01,michael sears,BIOL-3350,2017
-BIOL,3510,1,Biological Anthropology,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,katherine weisensee,BIOL-3510,2017
-BIOL,4010,1,Plant Physiology,0.22,0.24,0.33,0.15,0.02,0.0,0.0,0.05,douglas bielenberg,BIOL-4010,2017
-BIOL,4020,1,Plant Physiology Lab,0.55,0.35,0.05,0.05,0.0,0.0,0.0,0.0,douglas bielenberg,BIOL-4020,2017
-BIOL,4020,2,Plant Physiology Lab,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,BIOL-4020,2017
-BIOL,4080,1,Comparative Vertebrate Morph,0.29,0.5,0.13,0.04,0.0,0.0,0.0,0.04,christopher mayerl,BIOL-4080,2017
-BIOL,4090,1,Comp Vertebrate Morph Lab,0.5,0.21,0.21,0.04,0.0,0.0,0.0,0.04,richard blob,BIOL-4090,2017
-BIOL,4100,1,Limnology,0.24,0.52,0.14,0.02,0.0,0.0,0.0,0.07,john jenkins hains,BIOL-4100,2017
-BIOL,4140,1,Basic Immunology,0.83,0.1,0.0,0.0,0.0,0.0,0.0,0.07,charles rice,BIOL-4140,2017
-BIOL,4340,1,Biological Chem Lab Techniques,0.06,0.13,0.31,0.44,0.06,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2017
-BIOL,4340,2,Biological Chem Lab Techniques,0.14,0.29,0.36,0.21,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2017
-BIOL,4340,3,Biological Chem Lab Techniques,0.19,0.56,0.06,0.13,0.0,0.0,0.0,0.06,salvatore sparace,BIOL-4340,2017
-BIOL,4340,4,Biological Chem Lab Techniques,0.13,0.33,0.27,0.27,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2017
-BIOL,4610,1,Cell Biology,0.35,0.26,0.26,0.09,0.0,0.0,0.0,0.03,zhicheng dou,BIOL-4610,2017
-BIOL,4610,2,Cell Biology (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,zhicheng dou,BIOL-4610,2017
-BIOL,4610,3,Cell Biology,0.29,0.33,0.26,0.07,0.04,0.0,0.0,0.01,lisa bain,BIOL-4610,2017
-BIOL,4610,4,Cell Biology (HON),0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,lisa bain,BIOL-4610,2017
-BIOL,4620,1,Cell Biology Lab (Lec),0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,2,Cell Biology Lab (Lec),0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,BIOL-4620,2017
-BIOL,4620,4,Cell Biology Lab (Lec),0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,5,Cell Biology Lab (Lec),0.87,0.04,0.09,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,6,Cell Biology Lab (Lec),0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4620,8,Cell Biology Lab (Lec),0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2017
-BIOL,4670,1,Principles of Hematology,0.73,0.18,0.05,0.02,0.0,0.0,0.0,0.02,vincent gallicchio,BIOL-4670,2017
-BIOL,4700,1,Behavioral Ecology,0.34,0.46,0.16,0.02,0.0,0.0,0.0,0.01,michael childress,BIOL-4700,2017
-BIOL,4700,2,Behavioral Ecology (HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,BIOL-4700,2017
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,michael childress,BIOL-4710,2017
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,BIOL-4710,2017
-BIOL,4710,4,Behavioral Ecology Lab (Lec),0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,michael childress,BIOL-4710,2017
-BIOL,4780,1,Exercise Physiology,0.4,0.4,0.17,0.0,0.0,0.0,0.0,0.02,john cummings,BIOL-4780,2017
-BIOL,4800,1,Vertebrate Endocrinology,0.31,0.25,0.19,0.13,0.0,0.0,0.0,0.13,william baldwin,BIOL-4800,2017
-BIOL,4930,2,Sr Sem: Adv Cancer Research,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,BIOL-4930,2017
-BIOL,4930,5,Sr Sem: Nervous Systems,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,david feliciano,BIOL-4930,2017
-BIOL,4930,7,Sr Sem: Conservation Biology,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david tonkyn,BIOL-4930,2017
-BIOL,4940,4,CI: Popular Science Journalism,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4940,2017
-BIOL,8430,1,Underst Genetics & Evol Biol,0.64,0.33,0.02,0.0,0.02,0.0,0.0,0.0,margaret ptacek,BIOL-8430,2017
-BIOL,8450,1,Understanding Animal Biology,0.93,0.03,0.01,0.0,0.02,0.0,0.0,0.0,matthew turnbull,BIOL-8450,2017
-BIOL,8470,1,Understanding Microbiology,0.58,0.34,0.04,0.0,0.02,0.0,0.0,0.02,harry kurtz,BIOL-8470,2017
-BIOL,8480,1,Understanding Scientific Rsrch,0.93,0.0,0.0,0.0,0.02,0.0,0.0,0.05,robert edwa ballard,BIOL-8480,2017
-BIOL,8710,1,Current Topics in Biology,0.67,0.0,0.0,0.0,0.17,0.0,0.0,0.17,robert edwa ballard,BIOL-8710,2017
-BMOL,4250,1,Biomolecular Engineering,0.26,0.3,0.22,0.09,0.07,0.0,0.0,0.07,mark alan blenner,BMOL-4250,2017
-BUS,1010,1,Business Foundations,0.33,0.52,0.11,0.0,0.04,0.0,0.0,0.0,donna mccubbin,BUS-1010,2017
-BUS,1010,2,Business Foundations,0.39,0.39,0.14,0.0,0.04,0.0,0.0,0.04,donna mccubbin,BUS-1010,2017
-BUS,1010,3,Business Foundations,0.35,0.58,0.08,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2017
-BUS,1010,4,Business Foundations,0.19,0.38,0.35,0.04,0.0,0.0,0.0,0.04,william ern tumblin,BUS-1010,2017
-BUS,1010,5,Business Foundations,0.26,0.37,0.3,0.04,0.04,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,6,Business Foundations,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,7,Business Foundations,0.19,0.63,0.19,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2017
-BUS,1010,8,Business Foundations,0.35,0.26,0.3,0.0,0.04,0.0,0.0,0.04,donna mccubbin,BUS-1010,2017
-BUS,1010,9,Business Foundations,0.25,0.44,0.19,0.0,0.13,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,10,Business Foundations,0.16,0.48,0.2,0.08,0.08,0.0,0.0,0.0,william ern tumblin,BUS-1010,2017
-BUS,1010,16,Business Foundations,0.14,0.41,0.1,0.17,0.0,0.0,0.0,0.17,james mullinax,BUS-1010,2017
-BUS,1010,17,Business Foundations,0.24,0.34,0.34,0.07,0.0,0.0,0.0,0.0,james mullinax,BUS-1010,2017
-BUS,2990,3,CI:  Being a Leader,0.75,0.19,0.0,0.06,0.0,0.0,0.0,0.0,christopher mann,BUS-2990,2017
-CE,2010,1,Statics,0.59,0.24,0.09,0.02,0.03,0.0,0.0,0.03,sara khoshnevisan,CE-2010,2017
-CE,2010,2,Statics,0.12,0.31,0.4,0.0,0.1,0.0,0.0,0.07,melissa sternhagen,CE-2010,2017
-CE,2010,3,Statics,0.63,0.23,0.08,0.03,0.0,0.0,0.0,0.03,brandon ross,CE-2010,2017
-CE,2010,4,Statics,0.12,0.24,0.12,0.2,0.28,0.0,0.0,0.04,melissa sternhagen,CE-2010,2017
-CE,2010,5,Statics,0.36,0.36,0.18,0.06,0.03,0.0,0.0,0.0,william albe ashman,CE-2010,2017
-CE,2010,6,Statics,0.5,0.22,0.22,0.04,0.02,0.0,0.0,0.0, kent nilsson,CE-2010,2017
-CE,2010,7,Statics (HON),0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,brandon ross,CE-2010,2017
-CE,2060,1,Structural Mechanics,0.31,0.51,0.18,0.0,0.0,0.0,0.0,0.0,bryant nielson,CE-2060,2017
-CE,2060,2,Structural Mechanics,0.54,0.38,0.06,0.0,0.02,0.0,0.0,0.0,mahmoodreza soltani,CE-2060,2017
-CE,2080,1,Dynamics,0.17,0.3,0.42,0.07,0.02,0.0,0.0,0.03,melissa sternhagen,CE-2080,2017
-CE,2080,2,Dynamics,0.18,0.37,0.26,0.08,0.08,0.0,0.0,0.03,melissa sternhagen,CE-2080,2017
-CE,2550,1,Geomatics,0.29,0.44,0.2,0.03,0.03,0.0,0.0,0.0, shams esfandabadi,CE-2550,2017
-CE,3010,1,Structural Analysis,0.34,0.26,0.2,0.09,0.06,0.0,0.0,0.06,stephen csernak,CE-3010,2017
-CE,3110,1,Transportation Engr,0.3,0.43,0.21,0.05,0.0,0.0,0.0,0.02,wayne sarasua,CE-3110,2017
-CE,3210,1,Geotechnical Engineering,0.58,0.3,0.09,0.0,0.0,0.0,0.0,0.02,charng-hsein juang,CE-3210,2017
-CE,3210,2,Geotechnical Engineering,0.57,0.37,0.07,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,CE-3210,2017
-CE,3310,1,Constr Engr & Mgmnt,0.36,0.43,0.18,0.0,0.0,0.0,0.0,0.02,james burati,CE-3310,2017
-CE,3410,1,Intro to Fluid Mech,0.26,0.44,0.21,0.06,0.0,0.0,0.0,0.03,md nasimu chowdhury,CE-3410,2017
-CE,3420,1,Hydraulics & Hydro,0.37,0.27,0.2,0.03,0.0,0.0,0.0,0.13,abdul khan,CE-3420,2017
-CE,3420,2,Hydraulics & Hydro,0.6,0.38,0.03,0.0,0.0,0.0,0.0,0.0,ashok mishra,CE-3420,2017
-CE,3510,1,Civil Engineering Materials,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,CE-3510,2017
-CE,3520,2,Econ Eval of Proj,0.51,0.39,0.08,0.0,0.0,0.0,0.0,0.02,bradley putman,CE-3520,2017
-CE,3530,1,Professional Seminar,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-3530,2017
-CE,4020,1,Reinfor Con Design,0.44,0.31,0.22,0.01,0.0,0.0,0.0,0.01,brandon ross,CE-4020,2017
-CE,4070,1,Wood Design,0.52,0.33,0.1,0.0,0.0,0.0,0.0,0.05,weichiang pang,CE-4070,2017
-CE,4080,1,Struct Loads & Sys,0.08,0.38,0.25,0.17,0.0,0.0,0.0,0.13,bryant nielson,CE-4080,2017
-CE,4110,1,Roadway Geo Design,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ogle,CE-4110,2017
-CE,4120,1,Urban Transport Plan,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,CE-4120,2017
-CE,4210,1,Geotechnical Design,0.37,0.26,0.29,0.05,0.03,0.0,0.0,0.0,nadara ravichandran,CE-4210,2017
-CE,4340,1,Const Est Proj Cont,0.57,0.37,0.04,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4340,2017
-CE,4350,1,Infra Proj Planning,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,CE-4350,2017
-CE,4470,1,Stormwater Managemnt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john philli raiford,CE-4470,2017
-CE,4590,1,Capstone Design Proj,0.46,0.49,0.05,0.0,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2017
-CE,6070,1,Wood Design,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-6070,2017
-CE,6080,1,Struct Loads & Sys,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,bryant nielson,CE-6080,2017
-CE,6210,1,Geotechnical Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,CE-6210,2017
-CE,6350,1,Infra Proj Planning,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,CE-6350,2017
-CE,6470,1,Stormwater Managemnt,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john philli raiford,CE-6470,2017
-CE,8020,1,Adv R/C Design,0.48,0.32,0.12,0.0,0.0,0.0,0.0,0.08,thomas edfo cousins,CE-8020,2017
-CE,8060,1,Dyn Analys of Struc,0.42,0.38,0.12,0.0,0.0,0.0,0.0,0.08,bryant nielson,CE-8060,2017
-CE,8250,1,Geotech Equake Engr,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,CE-8250,2017
-CE,8260,1,Prop of Concrete,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,CE-8260,2017
-CE,8460,1,Flow in Open Chnls,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,abdul khan,CE-8460,2017
-CE,8530,1,Apps in Traffic En,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-8530,2017
-CE,8580,501,Fund of Risk Engineering Mgt,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,jie zhang,CE-8580,2017
-CH,1010,1,General Chemistry,0.06,0.2,0.32,0.11,0.2,0.0,0.0,0.12,princess mycia cox,CH-1010,2017
-CH,1010,2,General Chemistry,0.02,0.26,0.27,0.16,0.22,0.0,0.0,0.07,princess mycia cox,CH-1010,2017
-CH,1010,3,General Chemistry,0.28,0.24,0.28,0.07,0.07,0.0,0.0,0.06,dennis taylor,CH-1010,2017
-CH,1010,4,General Chemistry,0.05,0.24,0.28,0.13,0.17,0.0,0.0,0.14,joseph stu thrasher,CH-1010,2017
-CH,1010,400,General Chemistry,0.19,0.23,0.25,0.15,0.07,0.0,0.0,0.12,stephe schvaneveldt,CH-1010,2017
-CH,1020,1,General Chemistry,0.07,0.43,0.28,0.08,0.0,0.0,0.0,0.13,william mcwhorter,CH-1020,2017
-CH,1020,2,General Chemistry,0.31,0.44,0.19,0.03,0.02,0.0,0.0,0.01,thomas hickman,CH-1020,2017
-CH,1020,3,General Chemistry,0.39,0.37,0.12,0.08,0.01,0.0,0.0,0.03,dennis taylor,CH-1020,2017
-CH,1020,4,General Chemistry,0.35,0.4,0.14,0.04,0.0,0.0,0.0,0.06,dennis taylor,CH-1020,2017
-CH,1020,5,General Chemistry,0.1,0.34,0.33,0.17,0.01,0.0,0.0,0.04,william mcwhorter,CH-1020,2017
-CH,1020,6,General Chemistry,0.09,0.35,0.37,0.07,0.02,0.0,0.0,0.09,william mcwhorter,CH-1020,2017
-CH,1020,7,General Chemistry,0.12,0.37,0.35,0.04,0.02,0.0,0.0,0.1,olt geiculescu,CH-1020,2017
-CH,1020,8,General Chemistry,0.26,0.41,0.25,0.04,0.04,0.0,0.0,0.02,thomas hickman,CH-1020,2017
-CH,1020,9,General Chemistry,0.25,0.47,0.2,0.05,0.01,0.0,0.0,0.02,elliot ennis,CH-1020,2017
-CH,1020,10,General Chemistry,0.27,0.41,0.21,0.04,0.03,0.0,0.0,0.03,laura lanni,CH-1020,2017
-CH,1020,11,General Chemistry,0.23,0.39,0.31,0.04,0.02,0.0,0.0,0.01,laura lanni,CH-1020,2017
-CH,1020,50,General Chemistry,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,shiou-jyh hwu,CH-1020,2017
-CH,1020,51,General Chemistry (HON),0.88,0.09,0.02,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,CH-1020,2017
-CH,1020,52,General Chemistry (HON),0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,CH-1020,2017
-CH,1020,500,General Chemistry,0.29,0.32,0.29,0.1,0.0,0.0,0.0,0.0,brian gloor,CH-1020,2017
-CH,1050,1,Chemistry in Context I,0.32,0.47,0.06,0.06,0.02,0.0,0.0,0.06,olt geiculescu,CH-1050,2017
-CH,1050,2,Chemistry in Context I,0.32,0.48,0.11,0.0,0.02,0.0,0.0,0.07,olt geiculescu,CH-1050,2017
-CH,1060,1,Chemistry in Context II,0.47,0.38,0.15,0.0,0.0,0.0,0.0,0.0,thomas hickman,CH-1060,2017
-CH,1520,1,Chemistry Communication,0.84,0.0,0.11,0.0,0.05,0.0,0.0,0.0,richard marcus,CH-1520,2017
-CH,2010,1,Survey of Organic Chemistry,0.44,0.37,0.07,0.08,0.04,0.0,0.0,0.01,tania issa houjeiry,CH-2010,2017
-CH,2020,1,Surv of Organic Chemistry Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2020,2017
-CH,2020,2,Surv of Organic Chemistry Lab,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,CH-2020,2017
-CH,2050,1,Intro Inorg Chem,0.43,0.43,0.11,0.0,0.03,0.0,0.0,0.0,william pennington,CH-2050,2017
-CH,2230,1,Organic Chemistry,0.19,0.3,0.25,0.15,0.09,0.0,0.0,0.02,jacob schroeder,CH-2230,2017
-CH,2230,2,Organic Chemistry,0.34,0.3,0.21,0.08,0.04,0.0,0.0,0.02,jacob schroeder,CH-2230,2017
-CH,2230,3,Organic Chemistry,0.29,0.18,0.24,0.1,0.09,0.0,0.0,0.1,sourav saha,CH-2230,2017
-CH,2240,1,Organic Chemistry,0.33,0.33,0.19,0.07,0.02,0.0,0.0,0.06,elliot ennis,CH-2240,2017
-CH,2240,2,Organic Chemistry,0.21,0.29,0.21,0.07,0.03,0.0,0.0,0.18,laura lanni,CH-2240,2017
-CH,2240,3,Organic Chemistry,0.3,0.38,0.17,0.1,0.0,0.0,0.0,0.05,elliot ennis,CH-2240,2017
-CH,2240,4,Organic Chemistry,0.29,0.31,0.2,0.07,0.04,0.0,0.0,0.09,rhett smith,CH-2240,2017
-CH,2240,5,Organic Chemistry,0.35,0.43,0.18,0.01,0.01,0.0,0.0,0.02,jacob schroeder,CH-2240,2017
-CH,2270,3,Organic Chem Lab,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2017
-CH,2270,6,Organic Chem Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2017
-CH,2270,7,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2017
-CH,2270,8,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2017
-CH,2270,9,Organic Chem Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2017
-CH,2270,10,Organic Chem Lab,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2017
-CH,2270,11,Organic Chem Lab,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,CH-2270,2017
-CH,2270,12,Organic Chem Lab,0.81,0.06,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,CH-2270,2017
-CH,2270,13,Organic Chem Lab,0.59,0.12,0.18,0.0,0.0,0.0,0.0,0.12,sean 'connor,CH-2270,2017
-CH,2270,14,Organic Chem Lab,0.79,0.0,0.07,0.0,0.0,0.0,0.0,0.14,sean 'connor,CH-2270,2017
-CH,2270,15,Organic Chem Lab,0.67,0.2,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2270,2017
-CH,2280,1,Organic Chem Lab,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,CH-2280,2017
-CH,2280,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2280,2017
-CH,2280,6,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2280,2017
-CH,2280,10,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,CH-2280,2017
-CH,2280,12,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,CH-2280,2017
-CH,2280,19,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2280,2017
-CH,2280,21,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,CH-2280,2017
-CH,3310,1,Physical Chemistry,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,arkady kholodenko,CH-3310,2017
-CH,3320,1,Physical Chemistry,0.29,0.46,0.15,0.06,0.02,0.0,0.0,0.02,steven stuart,CH-3320,2017
-CH,3320,2,Physical Chemistry,0.68,0.2,0.04,0.04,0.0,0.0,0.0,0.04,jason mcneill,CH-3320,2017
-CH,3320,3,Physical Chemistry,0.29,0.33,0.24,0.0,0.14,0.0,0.0,0.0,leah bec casabianca,CH-3320,2017
-CH,3400,2,Physical Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2017
-CH,3400,3,Physical Chem Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2017
-CH,3400,5,Physical Chem Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2017
-CH,3600,1,Chemical Biology,0.58,0.28,0.11,0.0,0.02,0.0,0.0,0.0,modi wetzler,CH-3600,2017
-CH,4040,1,Bioinorganic Chem,0.38,0.25,0.19,0.06,0.0,0.0,0.0,0.13,julia brumaghim,CH-4040,2017
-CH,4110,1,Instrumental Analy,0.33,0.33,0.0,0.25,0.08,0.0,0.0,0.0,george chumanov,CH-4110,2017
-CH,4120,1,Instr Analysis Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey natha anker,CH-4120,2017
-CH,4130,1,Chemistry of Aqueous Systems,0.51,0.31,0.11,0.0,0.0,0.0,0.0,0.06,cindy lee,CH-4130,2017
-CH,4250,1,Medicinal Chem,0.38,0.23,0.08,0.0,0.08,0.0,0.0,0.23,dev priya arya,CH-4250,2017
-CH,4500,1,Chemistry Capstone,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,CH-4500,2017
-CH,8130,1,Electrochem Sci,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,stephen creager,CH-8130,2017
-CH,8510,1,Grad Student Seminar,0.77,0.2,0.0,0.0,0.03,0.0,0.0,0.0,joseph stu thrasher,CH-8510,2017
-CHE,1300,1,Intro to Chemical Engineering,0.15,0.28,0.26,0.13,0.11,0.0,0.0,0.07,christopher norfolk,CHE-1300,2017
-CHE,1300,2,Intro to Chemical Engineering,0.14,0.24,0.24,0.1,0.1,0.0,0.0,0.2,christopher norfolk,CHE-1300,2017
-CHE,2200,1,Ch E Thermo I,0.21,0.38,0.25,0.09,0.06,0.0,0.0,0.01,joseph scott,CHE-2200,2017
-CHE,2300,1,Fluids/Heat Transfer,0.08,0.18,0.5,0.08,0.13,0.0,0.0,0.03,eric mikel davis,CHE-2300,2017
-CHE,2300,2,Fluids/Heat Transfer,0.12,0.34,0.29,0.12,0.1,0.0,0.0,0.03,eric mikel davis,CHE-2300,2017
-CHE,3070,1,Unit Ops Lab I,0.24,0.53,0.19,0.0,0.0,0.0,0.0,0.03,mark thies,CHE-3070,2017
-CHE,3190,1,Engr Materials,0.17,0.35,0.33,0.08,0.0,0.0,0.0,0.07,christopher norfolk,CHE-3190,2017
-CHE,3530,2,Proc Dyn & Control,0.31,0.51,0.17,0.01,0.0,0.0,0.0,0.0,mark roberts,CHE-3530,2017
-CHE,4330,1,Process Design II,0.59,0.4,0.01,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4330,2017
-CHIN,1020,1,Elementary Chinese,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,ling rao,CHIN-1020,2017
-CHIN,2020,1,Intermediate Chinese,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ling rao,CHIN-2020,2017
-CHIN,4010,1,Pre-Modern Chinese Literature,0.21,0.42,0.26,0.11,0.0,0.0,0.0,0.0,yanming an,CHIN-4010,2017
-COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,eddie smith,COM-1010,2017
-COM,1500,1,Intro to Human Communication,0.8,0.13,0.02,0.02,0.03,0.0,0.0,0.0,eddie smith,COM-1500,2017
-COM,1500,2,Intro to Human Communication,0.6,0.29,0.08,0.01,0.01,0.0,0.0,0.01,daniel lelan fecher,COM-1500,2017
-COM,1500,3,Intro to Human Communication,0.86,0.09,0.03,0.0,0.01,0.0,0.0,0.01,eddie smith,COM-1500,2017
-COM,1500,4,Intro to Human Communication,0.62,0.31,0.04,0.02,0.0,0.0,0.0,0.01,marianne her glaser,COM-1500,2017
-COM,1500,5,Intro to Human Communication,0.69,0.25,0.06,0.01,0.0,0.0,0.0,0.0,marianne her glaser,COM-1500,2017
-COM,1500,6,Intro to Human Communication,0.41,0.47,0.09,0.03,0.0,0.0,0.0,0.0,daniel lelan fecher,COM-1500,2017
-COM,2010,1,Intr to Comm Studies,0.6,0.3,0.07,0.0,0.0,0.0,0.0,0.03,darren linvill,COM-2010,2017
-COM,2010,2,Intr to Comm Studies,0.47,0.4,0.07,0.03,0.0,0.0,0.0,0.03,darren linvill,COM-2010,2017
-COM,2500,1,Public Speaking,0.33,0.43,0.1,0.1,0.05,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2017
-COM,2500,2,Public Speaking,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,brandon boatwright,COM-2500,2017
-COM,2500,3,Public Speaking,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2017
-COM,2500,4,Public Speaking,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2017
-COM,2500,5,Public Speaking,0.29,0.62,0.1,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2017
-COM,2500,6,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2017
-COM,2500,7,Public Speaking,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,COM-2500,2017
-COM,2500,8,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2017
-COM,2500,10,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2017
-COM,2500,11,Public Speaking,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,COM-2500,2017
-COM,2500,12,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2017
-COM,2500,13,Public Speaking,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2017
-COM,2500,14,Public Speaking,0.52,0.33,0.0,0.0,0.1,0.0,0.0,0.05,jumah patrici taweh,COM-2500,2017
-COM,2500,15,Public Speaking,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2017
-COM,2500,16,Public Speaking,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2017
-COM,2500,17,Public Speaking,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,the estate  geddes,COM-2500,2017
-COM,2500,18,Public Speaking,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,COM-2500,2017
-COM,2500,19,Public Speaking,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2017
-COM,2500,21,Public Speaking,0.67,0.24,0.0,0.05,0.0,0.0,0.0,0.05,sara grumbl crocker,COM-2500,2017
-COM,2500,22,Public Speaking,0.52,0.33,0.0,0.0,0.05,0.0,0.0,0.1,jumah patrici taweh,COM-2500,2017
-COM,2500,24,Public Speaking,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2017
-COM,2500,25,Public Speaking,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,COM-2500,2017
-COM,2500,27,Public Speaking (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,COM-2500,2017
-COM,2500,29,Public Speaking,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,COM-2500,2017
-COM,2500,30,Public Speaking,0.32,0.64,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2017
-COM,2500,31,Public Speaking,0.1,0.57,0.14,0.05,0.1,0.0,0.0,0.05,pauline matthey,COM-2500,2017
-COM,2500,32,Public Speaking,0.25,0.2,0.25,0.1,0.1,0.0,0.0,0.1,pauline matthey,COM-2500,2017
-COM,2500,400,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexis zachar davis,COM-2500,2017
-COM,2500,401,Public Speaking,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,alexis zachar davis,COM-2500,2017
-COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2017
-COM,2500,403,Public Speaking,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2017
-COM,2500,500,Public Speaking,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2017
-COM,2500,501,Public Speaking,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2017
-COM,3010,1,Comm Theory,0.24,0.62,0.0,0.1,0.0,0.0,0.0,0.05,gregory kei cranmer,COM-3010,2017
-COM,3020,1,Mass Comm Theory,0.58,0.13,0.29,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3020,2017
-COM,3020,2,Mass Comm Theory,0.43,0.35,0.22,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3020,2017
-COM,3060,1,Crit-Cultural Rsrch Methods,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,COM-3060,2017
-COM,3110,1,Qual Comm Methods,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,chenjerai kumanyika,COM-3110,2017
-COM,3250,1,Survey of Sports Communication,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-3250,2017
-COM,3250,2,Survey of Sports Communication,0.8,0.08,0.08,0.0,0.04,0.0,0.0,0.0,john steven spinda,COM-3250,2017
-COM,3550,1,Principles of Public Relations,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3550,2017
-COM,3550,2,Principles of Public Relations,0.79,0.17,0.0,0.0,0.04,0.0,0.0,0.0,andrew stephen pyle,COM-3550,2017
-COM,3560,1,Crisis Communication,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3560,2017
-COM,3610,1,Argue and Debate,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,lindsey dixon,COM-3610,2017
-COM,3660,1,Video COMM w/ Adobe CC,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,michael rodgers,COM-3660,2017
-COM,3700,1,Survey of Brand Communications,0.93,0.0,0.03,0.0,0.0,0.0,0.0,0.03,lisa willi papenfus,COM-3700,2017
-COM,3720,1,Digital Analytics in Brand Com,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,alicia ni littleton,COM-3720,2017
-COM,3730,1,Media Management in Brand Comm,0.77,0.19,0.0,0.04,0.0,0.0,0.0,0.0,william reynolds,COM-3730,2017
-COM,3740,1,Brand Comm and Media Strategy,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,roger beasley,COM-3740,2017
-COM,4040,1,Media Comm & Social Identities,0.18,0.53,0.0,0.06,0.12,0.0,0.0,0.12,chenjerai kumanyika,COM-4040,2017
-COM,4040,2,Media Comm & Social Identities,0.43,0.48,0.0,0.1,0.0,0.0,0.0,0.0,chenjerai kumanyika,COM-4040,2017
-COM,4270,1,Comm in Sports Organizations,0.68,0.24,0.04,0.0,0.0,0.0,0.0,0.04,angela pratt,COM-4270,2017
-COM,4270,2,Comm in Sports Organizations,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-4270,2017
-COM,4280,1,Interpers/Family Comm & Sport,0.43,0.48,0.04,0.0,0.0,0.0,0.0,0.04,gregory kei cranmer,COM-4280,2017
-COM,4280,2,Interpers/Family Comm & Sport,0.4,0.56,0.0,0.0,0.0,0.0,0.0,0.04,gregory kei cranmer,COM-4280,2017
-COM,4700,1,Comm & Health,0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4700,2017
-COM,4950,1,Senior Capstone,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-4950,2017
-COM,4950,2,Senior Capstone,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-4950,2017
-COM,4980,1,Acad & Prof Dev II,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.04,joseph mazer,COM-4980,2017
-COM,8110,1,Comm Research Methods II,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-8110,2017
-COOP,1010,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey frank neal,COOP-1010,2017
-CPSC,1010,1,Computer Science I,0.23,0.24,0.18,0.08,0.12,0.0,0.0,0.15,salvatore lamarca,CPSC-1010,2017
-CPSC,1010,2,Computer Science I,0.26,0.24,0.18,0.05,0.11,0.0,0.0,0.16,lanny sitanayah,CPSC-1010,2017
-CPSC,1020,1,Computer Science II,0.4,0.29,0.14,0.1,0.05,0.0,0.0,0.02,yvon feaster,CPSC-1020,2017
-CPSC,1020,2,Computer Science II,0.49,0.2,0.11,0.11,0.08,0.0,0.0,0.02,yvon feaster,CPSC-1020,2017
-CPSC,1070,1,Programming Methodology,0.42,0.29,0.16,0.0,0.03,0.0,0.0,0.1,rose lowe,CPSC-1070,2017
-CPSC,1110,1,Intro to Programming in C,0.25,0.37,0.2,0.04,0.02,0.0,0.0,0.12,catherine hochrine,CPSC-1110,2017
-CPSC,1110,2,Intro to Programming in C,0.33,0.38,0.1,0.04,0.04,0.0,0.0,0.12,catherine hochrine,CPSC-1110,2017
-CPSC,2070,1,Discrete Structures,0.26,0.26,0.18,0.09,0.15,0.0,0.0,0.06,sandra hedetniemi,CPSC-2070,2017
-CPSC,2070,2,Discrete Structures,0.3,0.25,0.23,0.15,0.02,0.0,0.0,0.07,larry hodges,CPSC-2070,2017
-CPSC,2120,1,Algs/Data Structures,0.11,0.31,0.25,0.17,0.09,0.0,0.0,0.06,salvatore lamarca,CPSC-2120,2017
-CPSC,2120,2,Algs/Data Structures,0.26,0.32,0.23,0.05,0.06,0.0,0.0,0.08,salvatore lamarca,CPSC-2120,2017
-CPSC,2150,1,Software Dev Foundations,0.27,0.33,0.24,0.05,0.06,0.0,0.0,0.05,kevin anton plis,CPSC-2150,2017
-CPSC,2150,2,Software Dev Foundations,0.26,0.34,0.18,0.05,0.07,0.0,0.0,0.1,murali sitaraman,CPSC-2150,2017
-CPSC,2200,1,Microcomputer Appl,0.7,0.17,0.09,0.0,0.0,0.0,0.0,0.04,lanny sitanayah,CPSC-2200,2017
-CPSC,2310,1,Intro Computer Org,0.3,0.34,0.2,0.02,0.04,0.0,0.0,0.1,rose lowe,CPSC-2310,2017
-CPSC,2310,2,Intro Computer Org,0.29,0.22,0.31,0.1,0.06,0.0,0.0,0.02,rose lowe,CPSC-2310,2017
-CPSC,2910,1,Prof Issues I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2017
-CPSC,2910,2,Prof Issues I,0.65,0.2,0.15,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2017
-CPSC,2910,3,Prof Issues I,0.42,0.26,0.32,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2017
-CPSC,2910,4,Prof Issues I,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2017
-CPSC,2910,5,Prof Issues I,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2017
-CPSC,3220,1,Intro to Operating Systems,0.25,0.19,0.09,0.06,0.13,0.0,0.0,0.28,jacob sorber,CPSC-3220,2017
-CPSC,3220,2,Intro to Operating Systems,0.18,0.24,0.29,0.11,0.11,0.0,0.0,0.07,mark smotherman,CPSC-3220,2017
-CPSC,3300,1,Computer Systems Org,0.24,0.15,0.31,0.22,0.05,0.0,0.0,0.03,mark smotherman,CPSC-3300,2017
-CPSC,3500,1,Foundations of Computer Sci,0.24,0.37,0.34,0.02,0.01,0.0,0.0,0.01,wayne goddard,CPSC-3500,2017
-CPSC,3520,1,Programming Systems,0.37,0.4,0.09,0.0,0.09,0.0,0.0,0.06,robert schalkoff,CPSC-3520,2017
-CPSC,3600,1,Network Programming,0.29,0.29,0.14,0.11,0.03,0.0,0.0,0.14,feng luo,CPSC-3600,2017
-CPSC,3600,2,Network Programming,0.44,0.22,0.27,0.02,0.05,0.0,0.0,0.0,lanny sitanayah,CPSC-3600,2017
-CPSC,3620,1,Distributed/Cluster Computing,0.19,0.4,0.3,0.03,0.02,0.0,0.0,0.06,linh bao ngo,CPSC-3620,2017
-CPSC,3720,1,Software Engineering,0.37,0.39,0.16,0.08,0.0,0.0,0.0,0.0,kevin anton plis,CPSC-3720,2017
-CPSC,3720,2,Software Engineering,0.24,0.33,0.33,0.04,0.06,0.0,0.0,0.0,kevin anton plis,CPSC-3720,2017
-CPSC,3990,1,Advanced CI: Extreme Orange,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james martin,CPSC-3990,2017
-CPSC,4050,1,Computer Graphics,0.31,0.38,0.19,0.06,0.0,0.0,0.0,0.06,robert geist,CPSC-4050,2017
-CPSC,4110,1,Virtual Reality Systems,0.56,0.24,0.15,0.03,0.03,0.0,0.0,0.0,andrew robb,CPSC-4110,2017
-CPSC,4140,1,Human and Computer Interaction,0.16,0.42,0.32,0.0,0.11,0.0,0.0,0.0,sabarish venka babu,CPSC-4140,2017
-CPSC,4140,2,Human and Computer Interaction,0.61,0.3,0.0,0.0,0.04,0.0,0.0,0.04,sabarish venka babu,CPSC-4140,2017
-CPSC,4140,3,Human and Computer Interaction,0.35,0.35,0.17,0.0,0.04,0.0,0.0,0.09,christopher plaue,CPSC-4140,2017
-CPSC,4160,1,2-D Game Engine Construction,0.43,0.28,0.13,0.06,0.02,0.0,0.0,0.08,brian malloy,CPSC-4160,2017
-CPSC,4240,1,System Admin and Security,0.15,0.61,0.24,0.0,0.0,0.0,0.0,0.0,james martin,CPSC-4240,2017
-CPSC,4620,1,Database Management Systems,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,zijun wang,CPSC-4620,2017
-CPSC,4820,1,Selected Topics: Android Dev,0.75,0.06,0.13,0.06,0.0,0.0,0.0,0.0,roy pargas,CPSC-4820,2017
-CPSC,4820,2,Special Topics: Dig Sulpt,0.25,0.67,0.0,0.0,0.0,0.0,0.0,0.08,insun kwon,CPSC-4820,2017
-CPSC,4820,3,Special Topics: Data Science,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,CPSC-4820,2017
-CPSC,4820,4,Special Topic: Cloud Comp Arch,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,amy apon,CPSC-4820,2017
-CPSC,4820,5,Special Topics: Tang and Embod,0.35,0.3,0.2,0.0,0.1,0.0,0.0,0.05,brygg anders ullmer,CPSC-4820,2017
-CPSC,4910,1,Professional Issues II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,CPSC-4910,2017
-CPSC,6050,1,Computer Graphics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,CPSC-6050,2017
-CPSC,6110,1,Virtual Reality Systems,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,andrew robb,CPSC-6110,2017
-CPSC,6140,1,Human and Computer Interaction,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,CPSC-6140,2017
-CPSC,6140,2,Human and Computer Interaction,0.7,0.17,0.09,0.0,0.0,0.0,0.0,0.04,sabarish venka babu,CPSC-6140,2017
-CPSC,6160,1,2-D Game Engine Construction,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian malloy,CPSC-6160,2017
-CPSC,6620,1,Database Management Systems,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,zijun wang,CPSC-6620,2017
-CPSC,6810,3,Selected Topic: Program Team,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,brian christop dean,CPSC-6810,2017
-CPSC,6820,3,Special Topics: Data Science,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,CPSC-6820,2017
-CPSC,6820,4,Special Topic: Cloud Comp Arch,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,amy apon,CPSC-6820,2017
-CPSC,8050,1,Adv Comp Graphics,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,CPSC-8050,2017
-CPSC,8110,1,Technical Character Animation,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,christina sop joerg,CPSC-8110,2017
-CPSC,8220,1,Case Study in Operating Sys,0.55,0.35,0.0,0.0,0.0,0.0,0.0,0.1,robert geist,CPSC-8220,2017
-CPSC,8400,1,Design & Anlys of Algorithms,0.18,0.32,0.26,0.0,0.08,0.0,0.0,0.16,brian christop dean,CPSC-8400,2017
-CPSC,8470,1,Intro to Information Retrieval,0.66,0.17,0.14,0.0,0.0,0.0,0.0,0.03,feng luo,CPSC-8470,2017
-CPSC,8570,1,Network Technologies Security,0.43,0.53,0.0,0.0,0.0,0.0,0.0,0.04,hongxin hu,CPSC-8570,2017
-CPSC,8630,1,Multimedia Sys/Apps,0.31,0.46,0.15,0.0,0.0,0.0,0.0,0.08,zijun wang,CPSC-8630,2017
-CPSC,8650,1,Data Mining,0.34,0.45,0.17,0.0,0.02,0.0,0.0,0.02,zijun wang,CPSC-8650,2017
-CPSC,8750,1,Software Architectur,0.44,0.41,0.07,0.0,0.0,0.0,0.0,0.07,john mcgregor,CPSC-8750,2017
-CPSC,8810,5,Selected Topics: Eff Comput,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,rong ge,CPSC-8810,2017
-CRP,8020,1,Site Planning,0.73,0.23,0.0,0.0,0.04,0.0,0.0,0.0,clifford dona ellis,CRP-8020,2017
-CRP,8040,1,Land Use Analysis,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,CRP-8040,2017
-CRP,8050,1,Plning Theory & Hist,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,mickey lauria,CRP-8050,2017
-CRP,8090,1,Current Issues,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,CRP-8090,2017
-CRP,8200,1,Negotiation,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,CRP-8200,2017
-CRP,8220,1,Urban Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,CRP-8220,2017
-CRP,8410,1,Env Planning,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,CRP-8410,2017
-CRP,8730,1,Econ Dev Planning,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,timothy green,CRP-8730,2017
-CSM,1500,1,Constr Prob Solving,0.41,0.33,0.19,0.04,0.04,0.0,0.0,0.0,jason lucas,CSM-1500,2017
-CSM,1500,2,Constr Prob Solving,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-1500,2017
-CSM,2020,1,Structures II,0.28,0.48,0.2,0.0,0.0,0.0,0.0,0.04,shima clarke,CSM-2020,2017
-CSM,2020,2,Structures II,0.16,0.32,0.47,0.0,0.05,0.0,0.0,0.0,shima clarke,CSM-2020,2017
-CSM,2040,1,Cont Documents,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-2040,2017
-CSM,2040,2,Cont Documents,0.52,0.3,0.13,0.0,0.04,0.0,0.0,0.0,joseph mich burgett,CSM-2040,2017
-CSM,2050,1,Mats & Methods II,0.2,0.52,0.28,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-2050,2017
-CSM,2050,2,Mats & Methods II,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,raymond schneider,CSM-2050,2017
-CSM,3050,1,Envir Systems II,0.18,0.61,0.18,0.0,0.03,0.0,0.0,0.0,joseph mich burgett,CSM-3050,2017
-CSM,3050,2,Envir Systems II,0.29,0.43,0.21,0.07,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3050,2017
-CSM,3520,1,Const Scheduling,0.13,0.5,0.28,0.06,0.03,0.0,0.0,0.0,christine piper,CSM-3520,2017
-CSM,3520,2,Const Scheduling,0.28,0.34,0.34,0.03,0.0,0.0,0.0,0.0,christine piper,CSM-3520,2017
-CSM,3530,1,Const Estimating II,0.26,0.45,0.16,0.13,0.0,0.0,0.0,0.0,seyed mousavi rizi,CSM-3530,2017
-CSM,3530,2,Const Estimating II,0.22,0.47,0.28,0.0,0.03,0.0,0.0,0.0,seyed mousavi rizi,CSM-3530,2017
-CSM,4540,1,Const Capstone,0.35,0.62,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4540,2017
-CSM,4540,2,Const Capstone,0.12,0.8,0.08,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4540,2017
-CSM,8520,1,Const Mgmt Research,0.0,0.4,0.6,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-8520,2017
-CSM,8520,400,Const Mgmt Research,0.2,0.2,0.6,0.0,0.0,0.0,0.0,0.0,roger william liska,CSM-8520,2017
-CSM,8650,1,Project Management,0.15,0.69,0.08,0.0,0.08,0.0,0.0,0.0,christine piper,CSM-8650,2017
-CSM,8660,1,Role in Development,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8660,2017
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.03,susan whorton,CU-1000,2017
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.0,susan whorton,CU-1000,2017
-CU,1010,1,Univ Success Skills,0.25,0.25,0.25,0.05,0.05,0.0,0.0,0.15,matthew james kirk,CU-1010,2017
-CU,1010,2,Univ Success Skills,0.41,0.14,0.05,0.09,0.14,0.0,0.0,0.18,joseph paul thames,CU-1010,2017
-CU,1010,3,Univ Success Skills,0.53,0.21,0.05,0.11,0.0,0.0,0.0,0.11,jessica gale owens,CU-1010,2017
-CU,1010,4,Univ Success Skills,0.39,0.28,0.17,0.17,0.0,0.0,0.0,0.0,cari allyn brooks,CU-1010,2017
-CU,1010,5,Univ Success Skills,0.53,0.21,0.11,0.05,0.0,0.0,0.0,0.11,bryn zimmerman babb,CU-1010,2017
-CU,1100,100,Introduction to Tutoring,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,ashley crisp,CU-1100,2017
-CU,1970,2,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,robert austi massey,CU-1970,2017
-CU,2010,1,Sustainability Leadership,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,CU-2010,2017
-DPA,3070,1,Method 3d Production,0.86,0.04,0.0,0.0,0.04,0.0,0.0,0.07,summer 'nea benton,DPA-3070,2017
-DPA,4030,1,Vis Foundations II,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,erik reed,DPA-4030,2017
-DPA,8080,2,Artistic Character Animation,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,david stewart donar,DPA-8080,2017
-DPA,8090,1,Rendering and Shading,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,eric patterson,DPA-8090,2017
-DPA,8090,2,Rendering and Shading,0.0,0.4,0.0,0.0,0.0,0.0,0.0,0.6,eric patterson,DPA-8090,2017
-ECE,1010,400,Robots in Business & Society,0.45,0.35,0.1,0.03,0.03,0.0,0.0,0.03,ian walker,ECE-1010,2017
-ECE,2010,1,Logic and Computing Devices,0.21,0.23,0.25,0.22,0.05,0.0,0.0,0.04,lin zhu,ECE-2010,2017
-ECE,2020,1,Electric Circuits I,0.27,0.27,0.29,0.06,0.1,0.0,0.0,0.01,william harrell,ECE-2020,2017
-ECE,2070,1,Basic Electrical Engineering,0.48,0.32,0.08,0.07,0.02,0.0,0.0,0.03,timothy anglea,ECE-2070,2017
-ECE,2070,2,Basic Electrical Engineering,0.55,0.29,0.1,0.03,0.0,0.0,0.0,0.03,william th kolodzey,ECE-2070,2017
-ECE,2070,3,Basic Electrical Engineering,0.25,0.28,0.34,0.03,0.06,0.0,0.0,0.03,daniel bla cutshall,ECE-2070,2017
-ECE,2080,1,Basic Electrical Engr Lab,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,2,Basic Electrical Engr Lab,0.25,0.45,0.15,0.1,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,4,Basic Electrical Engr Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,5,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,6,Basic Electrical Engr Lab,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,9,Basic Electrical Engr Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,10,Basic Electrical Engr Lab,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,11,Basic Electrical Engr Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2080,15,Basic Electrical Engr Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2017
-ECE,2090,1,Logic Lab,0.58,0.25,0.08,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2017
-ECE,2090,2,Logic Lab,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2017
-ECE,2090,3,Logic Lab,0.58,0.17,0.17,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-2090,2017
-ECE,2090,4,Logic Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2090,2017
-ECE,2110,2,Elec Engr Lab I,0.4,0.13,0.07,0.2,0.07,0.0,0.0,0.13,apoorva dee kapadia,ECE-2110,2017
-ECE,2110,4,Elec Engr Lab I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2110,2017
-ECE,2120,1,Electrical Engineering Lab II,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-2120,2017
-ECE,2220,1,Syst Prog Concept,0.22,0.33,0.19,0.08,0.06,0.0,0.0,0.12,william reid,ECE-2220,2017
-ECE,2230,1,Comp Sys Eng,0.28,0.59,0.06,0.03,0.0,0.0,0.0,0.03,walter ligon,ECE-2230,2017
-ECE,2620,1,Electric Circuits II,0.46,0.38,0.11,0.01,0.03,0.0,0.0,0.02,richard groff,ECE-2620,2017
-ECE,2720,1,Comp Organization,0.3,0.4,0.18,0.08,0.04,0.0,0.0,0.01,william reid,ECE-2720,2017
-ECE,2730,1,Computer Org Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2017
-ECE,2730,2,Computer Org Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2017
-ECE,2730,3,Computer Org Lab,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2017
-ECE,2730,4,Computer Org Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2017
-ECE,3170,1,Rand Signal Analysis,0.24,0.27,0.25,0.13,0.05,0.0,0.0,0.06,stephen hubbard,ECE-3170,2017
-ECE,3200,1,Electronics I,0.18,0.27,0.27,0.14,0.13,0.0,0.0,0.01,stephen hubbard,ECE-3200,2017
-ECE,3210,1,Electronics II,0.32,0.34,0.21,0.1,0.03,0.0,0.0,0.0,stephen hubbard,ECE-3210,2017
-ECE,3220,1,Intro Operating Sys,0.23,0.33,0.13,0.03,0.07,0.0,0.0,0.2,jacob sorber,ECE-3220,2017
-ECE,3270,1,Dig Comp Design,0.2,0.3,0.13,0.17,0.1,0.0,0.0,0.1,melissa crawl smith,ECE-3270,2017
-ECE,3300,1,Signals & Systems,0.2,0.22,0.25,0.16,0.03,0.0,0.0,0.14,carl baum,ECE-3300,2017
-ECE,3520,1,Programming Systems,0.46,0.27,0.15,0.0,0.04,0.0,0.0,0.08,robert schalkoff,ECE-3520,2017
-ECE,3600,1,Elect Power Engr,0.42,0.31,0.15,0.0,0.0,0.0,0.0,0.12,edward collins,ECE-3600,2017
-ECE,3710,1,Microcontr Interface,0.33,0.4,0.21,0.04,0.0,0.0,0.0,0.02,william reid,ECE-3710,2017
-ECE,3720,1,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,2,Micro Int Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,3,Micro Int Lab,0.58,0.25,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,4,Micro Int Lab,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,5,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,6,Micro Int Lab,0.4,0.1,0.3,0.0,0.2,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3720,7,Micro Int Lab,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2017
-ECE,3800,1,Electromagnetics,0.39,0.32,0.05,0.1,0.07,0.0,0.0,0.07,anthony martin,ECE-3800,2017
-ECE,3810,1,Field Waves & Ckts,0.37,0.38,0.19,0.02,0.0,0.0,0.0,0.05,eric gordon johnson,ECE-3810,2017
-ECE,4090,1,Intr to Linear Control Systems,0.49,0.38,0.0,0.05,0.05,0.0,0.0,0.03,apoorva dee kapadia,ECE-4090,2017
-ECE,4190,1,Elec Mach and Drives,0.17,0.48,0.17,0.14,0.0,0.0,0.0,0.03,thomas salem,ECE-4190,2017
-ECE,4270,1,Communications Sys,0.39,0.31,0.22,0.03,0.06,0.0,0.0,0.0,madhabi manandhar,ECE-4270,2017
-ECE,4320,1,Instrumentation,0.3,0.2,0.4,0.0,0.1,0.0,0.0,0.0,goutam koley,ECE-4320,2017
-ECE,4380,1,Computer Commun,0.31,0.25,0.22,0.06,0.06,0.0,0.0,0.11,harlan russell,ECE-4380,2017
-ECE,4400,1,Local Computer Nets,0.48,0.35,0.16,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,ECE-4400,2017
-ECE,4680,1,Embedded Computing,0.55,0.3,0.05,0.0,0.0,0.0,0.0,0.1,adam hoover,ECE-4680,2017
-ECE,4930,2,Smart Grid,0.24,0.66,0.07,0.0,0.0,0.0,0.0,0.03,gan venayagamoorthy,ECE-4930,2017
-ECE,4950,1,Int Sys Design I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-4950,2017
-ECE,4960,1,Int Sys Design II,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2017
-ECE,6190,1,Elec Mach and Drives,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,thomas salem,ECE-6190,2017
-ECE,6380,1,Computer Commun,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,harlan russell,ECE-6380,2017
-ECE,6460,1,Antennas,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,anthony martin,ECE-6460,2017
-ECE,6930,1,VLSI Design Automation,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,yingjie lao,ECE-6930,2017
-ECE,8160,1,Elec Power Distr Sys Engr,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,elham makram,ECE-8160,2017
-ECE,8260,1,Solar Cells,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,ECE-8260,2017
-ECE,8400,1,Semicond Devices,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,ECE-8400,2017
-ECE,8440,1,Digital Signal Proc,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,eric patterson,ECE-8440,2017
-ECE,8560,1,Pattern Recognition,0.58,0.36,0.0,0.0,0.0,0.0,0.0,0.06,robert schalkoff,ECE-8560,2017
-ECE,8740,1,Adv Nonlinear Cntrl,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,yongqiang wang,ECE-8740,2017
-ECE,8780,1,High-Perform Computing w GPUs,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,ECE-8780,2017
-ECE,8930,10,Distributed Denial of Service,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,ECE-8930,2017
-ECON,2000,1,Economic Concepts,0.28,0.4,0.23,0.1,0.0,0.0,0.0,0.0,jonathan orr ernest,ECON-2000,2017
-ECON,2000,2,Economic Concepts,0.51,0.23,0.13,0.05,0.05,0.0,0.0,0.03,jonathan orr ernest,ECON-2000,2017
-ECON,2000,3,Economic Concepts,0.31,0.38,0.15,0.03,0.13,0.0,0.0,0.0,miren ivankovic,ECON-2000,2017
-ECON,2110,1,Principles of Microeconomics,0.21,0.28,0.26,0.1,0.13,0.0,0.0,0.03,amanda caitlin kerr,ECON-2110,2017
-ECON,2110,2,Principles of Microeconomics,0.3,0.53,0.08,0.05,0.03,0.0,0.0,0.03,molly espey,ECON-2110,2017
-ECON,2110,3,Principles of Microeconomics,0.14,0.24,0.23,0.29,0.08,0.0,0.0,0.03,liuna issagholian,ECON-2110,2017
-ECON,2110,4,Principles of Microeconomics,0.38,0.38,0.13,0.13,0.0,0.0,0.0,0.0,maria droganova,ECON-2110,2017
-ECON,2110,5,Principles of Microeconomics,0.38,0.33,0.15,0.05,0.05,0.0,0.0,0.05,roksan ghanbariamin,ECON-2110,2017
-ECON,2110,6,Principles of Microeconomics,0.18,0.21,0.31,0.09,0.15,0.0,0.0,0.06,bradley keith hobbs,ECON-2110,2017
-ECON,2110,7,Principles of Microeconomics,0.16,0.24,0.26,0.16,0.13,0.0,0.0,0.06,bradley keith hobbs,ECON-2110,2017
-ECON,2110,8,Principles of Microeconomics,0.18,0.43,0.2,0.12,0.06,0.0,0.0,0.01,kelsey vict roberts,ECON-2110,2017
-ECON,2110,10,Principles of Microeconomics,0.51,0.14,0.14,0.08,0.08,0.0,0.0,0.04,steven johnson,ECON-2110,2017
-ECON,2110,11,Principles of Microeconomics,0.34,0.35,0.14,0.1,0.03,0.0,0.0,0.04,leah jacq kitashima,ECON-2110,2017
-ECON,2110,12,Principles of Microeconomics,0.3,0.55,0.08,0.05,0.0,0.0,0.0,0.03,benjamin jo schwall,ECON-2110,2017
-ECON,2120,1,Principles of Macroeconomics,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,scott baier,ECON-2120,2017
-ECON,2120,2,Principles of Macroeconomics,0.26,0.37,0.21,0.16,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,3,Principles of Macroeconomics,0.3,0.35,0.3,0.0,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,4,Principles of Macroeconomics,0.21,0.58,0.11,0.0,0.11,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,5,Principles of Macroeconomics,0.35,0.2,0.45,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,6,Principles of Macroeconomics,0.16,0.47,0.21,0.16,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,7,Principles of Macroeconomics,0.21,0.37,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,8,Principles of Macroeconomics,0.16,0.47,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,9,Principles of Macroeconomics,0.2,0.45,0.3,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,10,Principles of Macroeconomics,0.11,0.53,0.32,0.0,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,11,Principles of Macroeconomics,0.16,0.32,0.47,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,12,Principles of Macroeconomics,0.17,0.33,0.33,0.0,0.17,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,13,Principles of Macroeconomics,0.47,0.41,0.0,0.0,0.06,0.0,0.0,0.06,scott baier,ECON-2120,2017
-ECON,2120,14,Principles of Macroeconomics,0.35,0.47,0.06,0.06,0.06,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,15,Principles of Macroeconomics,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,16,Principles of Macroeconomics,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,17,Principles of Macroeconomics,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,18,Principles of Macroeconomics,0.16,0.58,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,19,Principles of Macroeconomics,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,2120,20,Principles of Macroeconomics,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,peter david lorenz,ECON-2120,2017
-ECON,2120,21,Principles of Macroeconomics,0.6,0.37,0.01,0.01,0.0,0.0,0.0,0.0,huili li,ECON-2120,2017
-ECON,2120,22,Principles of Macroeconomics,0.27,0.56,0.17,0.0,0.0,0.0,0.0,0.0,ce castellon chicas,ECON-2120,2017
-ECON,2120,23,Principles of Macroeconomics,0.3,0.48,0.18,0.0,0.0,0.0,0.0,0.05,jordan adamson,ECON-2120,2017
-ECON,2120,24,Principles of Macroeconomics,0.1,0.23,0.16,0.19,0.12,0.0,0.0,0.19,ralph charles allen,ECON-2120,2017
-ECON,2120,25,Principles of Macroeconomics,0.19,0.19,0.11,0.22,0.04,0.0,0.0,0.26,ralph charles allen,ECON-2120,2017
-ECON,2120,26,Principles of Macroeconomics,0.28,0.42,0.22,0.08,0.0,0.0,0.0,0.0,scott barkowski,ECON-2120,2017
-ECON,2120,27,Principles of Macroeconomics,0.4,0.5,0.08,0.03,0.0,0.0,0.0,0.0,peter david lorenz,ECON-2120,2017
-ECON,2120,28,Principles of Macroecon (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2017
-ECON,3020,1,Money and Banking,0.33,0.38,0.2,0.1,0.0,0.0,0.0,0.0,smriti bhargava,ECON-3020,2017
-ECON,3060,1,Managerial Economics,0.25,0.23,0.25,0.15,0.07,0.0,0.0,0.05,timothy jay bacon,ECON-3060,2017
-ECON,3100,1,International Econ,0.24,0.4,0.32,0.03,0.02,0.0,0.0,0.0,richard alan sessa,ECON-3100,2017
-ECON,3140,1,Intermediate Micro,0.43,0.28,0.23,0.0,0.03,0.0,0.0,0.05,molly espey,ECON-3140,2017
-ECON,3140,2,Intermediate Micro,0.32,0.29,0.11,0.13,0.05,0.0,0.0,0.11,patrick warren,ECON-3140,2017
-ECON,3140,3,Intermediate Micro,0.23,0.21,0.46,0.03,0.08,0.0,0.0,0.0,molly espey,ECON-3140,2017
-ECON,3150,1,Intermediate Macro,0.26,0.36,0.22,0.12,0.03,0.0,0.0,0.01,michal jerzmanowski,ECON-3150,2017
-ECON,3150,2,Intermediate Macro,0.26,0.26,0.29,0.0,0.08,0.0,0.0,0.11,sergey vla mityakov,ECON-3150,2017
-ECON,3440,1,Property Rights,0.19,0.19,0.26,0.11,0.15,0.0,0.0,0.11,dar litsukova-bokar,ECON-3440,2017
-ECON,3500,1,Moral & Ethical Econ,0.15,0.27,0.3,0.06,0.15,0.0,0.0,0.06,bradley keith hobbs,ECON-3500,2017
-ECON,3600,1,Public Choice,0.36,0.23,0.26,0.05,0.05,0.0,0.0,0.05,michael makowsky,ECON-3600,2017
-ECON,4010,1,Labor Mkt Analysis,0.23,0.42,0.23,0.0,0.08,0.0,0.0,0.04,curtis simon,ECON-4010,2017
-ECON,4020,1,Law and Economics,0.2,0.47,0.23,0.07,0.03,0.0,0.0,0.0,thomas wins hazlett,ECON-4020,2017
-ECON,4050,1,Intro to Econometric,0.28,0.28,0.23,0.12,0.07,0.0,0.0,0.02,scott barkowski,ECON-4050,2017
-ECON,4200,1,Pub Sector Econ,0.2,0.3,0.33,0.05,0.08,0.0,0.0,0.05,william dougan,ECON-4200,2017
-ECON,4240,1,Organization of Ind,0.53,0.23,0.2,0.03,0.0,0.0,0.0,0.0,matthew lewis,ECON-4240,2017
-ECON,4260,1,Sem Sport Economics,0.6,0.32,0.0,0.0,0.0,0.0,0.0,0.08,raymond sauer,ECON-4260,2017
-ECON,4270,1,Dev American Economy,0.22,0.5,0.19,0.06,0.03,0.0,0.0,0.0,howard ne bodenhorn,ECON-4270,2017
-ECON,4290,1,Economics of Energy Markets,0.37,0.5,0.13,0.0,0.0,0.0,0.0,0.0,matthew lewis,ECON-4290,2017
-ECON,4400,1,Game Theory,0.23,0.46,0.27,0.0,0.04,0.0,0.0,0.0,charles thomas,ECON-4400,2017
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.11,0.42,0.32,0.11,0.0,0.0,0.0,0.05,scott templeton,ECON-4570,2017
-ECON,6400,1,Game Theory,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,charles thomas,ECON-6400,2017
-ECON,8020,2,Adv Econ Concepts and Applic I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,ECON-8020,2017
-ECON,8050,1,Macroeconomic Theory,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,ECON-8050,2017
-ECON,8070,1,Econometrics II,0.38,0.48,0.1,0.0,0.0,0.0,0.0,0.05,chungsang lam,ECON-8070,2017
-ECON,8110,1,Econ of Environment,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,ECON-8110,2017
-ECON,8200,1,Public Finance,0.44,0.33,0.0,0.0,0.0,0.0,0.0,0.22,william dougan,ECON-8200,2017
-ECON,9000,2,Empirical Public Choice,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,ECON-9000,2017
-ED,1050,1,Educ Orientation,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,william da mccorkle,ED-1050,2017
-ED,1050,2,Educ Orientation,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,william da mccorkle,ED-1050,2017
-EDC,3900,2,Skills for Stu Leads,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2017
-EDC,3900,3,Skills for Stu Leads,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2017
-EDC,3900,4,Skills for Stu Leads,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2017
-EDC,3900,5,Skills for Stu Leads,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2017
-EDC,3900,6,Skills for Stu Leads,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2017
-EDEC,2200,1,Family/School/Com,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,EDEC-2200,2017
-EDEC,8100,500,Adv Ece Found & Meth,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-8100,2017
-EDEL,3210,1,Pe for the Elem Tchr,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2017
-EDEL,4510,1,Elem Methods in Science Tchg,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,EDEL-4510,2017
-EDEL,4520,1,Elem Methods Math Teaching,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,EDEL-4520,2017
-EDEL,4520,2,Elem Methods Math Teaching,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,EDEL-4520,2017
-EDEL,4870,1,Ele Meth Soc Studies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,dwane valera,EDEL-4870,2017
-EDF,3010,1,Principles of American Educat,0.86,0.09,0.06,0.0,0.0,0.0,0.0,0.0,william da mccorkle,EDF-3010,2017
-EDF,3020,1,Educational Psychology,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,EDF-3020,2017
-EDF,3020,2,Educational Psychology,0.83,0.13,0.05,0.0,0.0,0.0,0.0,0.0,heather rog brooker,EDF-3020,2017
-EDF,3020,3,Educational Psychology,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0,stephen chou,EDF-3020,2017
-EDF,3340,1,Child Growth and Development,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,EDF-3340,2017
-EDF,3340,3,Child Growth and Development,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,EDF-3340,2017
-EDF,3350,1,Adolescent Growth & Develop,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,heather rog brooker,EDF-3350,2017
-EDF,4800,3,Digital Media & Learning,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,juan li,EDF-4800,2017
-EDF,4800,300,Digital Media & Learning,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2017
-EDF,8080,300,Ed Tests and Measure,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,heather rog brooker,EDF-8080,2017
-EDF,9700,1,Democratic Education,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,EDF-9700,2017
-EDF,9770,400,Multi Regress Ed Research,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jennie lynn farmer,EDF-9770,2017
-EDF,9790,1,Qualitative Research in Educ,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,melinda spearman,EDF-9790,2017
-EDHD,3110,1,CI- Research in DM & Learning,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,david matthew boyer,EDHD-3110,2017
-EDL,7150,500,Sch & Comm Relations,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,frederick buskey,EDL-7150,2017
-EDL,7300,502,Techniq of Supervision-Pub Sch,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,hans william klar,EDL-7300,2017
-EDL,7400,511,Curr Plan: Sch Adm,0.88,0.0,0.06,0.0,0.06,0.0,0.0,0.0,barbara nesbitt,EDL-7400,2017
-EDL,7510,500,El Prin & Spv Ex II,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,frederick buskey,EDL-7510,2017
-EDL,7650,1,Assessment Hi Edu,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,kristin walker,EDL-7650,2017
-EDL,7650,2,Assessment Hi Edu,0.17,0.72,0.11,0.0,0.0,0.0,0.0,0.0,kristin walker,EDL-7650,2017
-EDL,8500,501,Practicum: District,0.38,0.0,0.08,0.0,0.54,0.0,0.0,0.0,elizabeth reynolds,EDL-8500,2017
-EDL,8850,512,STEM - School Admin,0.57,0.0,0.0,0.0,0.43,0.0,0.0,0.0,william havice,EDL-8850,2017
-EDL,9110,400,Systematic Inq Ed L,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,EDL-9110,2017
-EDL,9750,2,College Teaching,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,pamela havice,EDL-9750,2017
-EDLT,4580,1,Early Literacy: Birth-Kindergn,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4580,2017
-EDLT,4620,1,Reading Children's Lit in Elem,0.59,0.27,0.09,0.05,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4620,2017
-EDLT,8270,300,Content Area Rdg/Wtg-MS & HS,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8270,2017
-EDLT,8410,501,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,EDLT-8410,2017
-EDLT,8410,502,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,EDLT-8410,2017
-EDLT,8410,505,Early Literacy Inst Strategies,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephanie amb pitts,EDLT-8410,2017
-EDLT,8810,506,Reading Recovery Teacher II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,EDLT-8810,2017
-EDLT,8830,506,Read Recovery Practicum II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,EDLT-8830,2017
-EDSC,4370,1,Technology in Math,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,EDSC-4370,2017
-EDSC,4480,1,Teach Intern Sec Soc,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,marshall alan darby,EDSC-4480,2017
-EDSP,3700,2,Intro to Special Education,0.81,0.17,0.03,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,EDSP-3700,2017
-EDSP,3700,4,Intro to Special Education,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,catherine griffith,EDSP-3700,2017
-EDSP,4910,1,Ed Assess Ind W/Dis,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,EDSP-4910,2017
-EES,2020,1,Environ Engr Fundamentals II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,EES-2020,2017
-EES,4010,1,Environmental Engr,0.49,0.51,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,EES-4010,2017
-EES,4010,2,Environmental Engr,0.36,0.21,0.25,0.0,0.07,0.0,0.0,0.11,ezra lucas ho cates,EES-4010,2017
-EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-4750,2017
-EES,4840,2,Solid Waste Mgt,0.58,0.35,0.04,0.0,0.04,0.0,0.0,0.0,thomas overcamp,EES-4840,2017
-EES,4850,2,Hazard Waste Management,0.22,0.52,0.26,0.0,0.0,0.0,0.0,0.0,mark schlautman,EES-4850,2017
-EES,4860,6,Environmental Sustainability,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,michael anthon dale,EES-4860,2017
-EES,8030,1,Phy/Chem Ops W/WW T,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,ezra lucas ho cates,EES-8030,2017
-EES,8040,1,Biochem Ops WW Trt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,EES-8040,2017
-EES,8090,1,Subsurface Remed Mod,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,ronald falta,EES-8090,2017
-ELE,3010,1,Intro to Entre,0.44,0.51,0.03,0.0,0.0,0.0,0.0,0.03,christina kyprianou,ELE-3010,2017
-ELE,3010,2,Intro to Entre,0.41,0.51,0.08,0.0,0.0,0.0,0.0,0.0,christina kyprianou,ELE-3010,2017
-ELE,3010,3,Intro to Entre,0.24,0.36,0.38,0.0,0.02,0.0,0.0,0.0,ashley will parnell,ELE-3010,2017
-ELE,3140,1,New Venture Creat I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,chad navis,ELE-3140,2017
-ELE,3140,2,New Venture Creat I,0.57,0.3,0.14,0.0,0.0,0.0,0.0,0.0,chad navis,ELE-3140,2017
-ELE,4010,1,Exec Lead & Entr II,0.24,0.33,0.38,0.02,0.0,0.0,0.0,0.02,ashley will parnell,ELE-4010,2017
-ENGL,1030,1,Accelerated Composition,0.62,0.24,0.05,0.0,0.05,0.0,0.0,0.05,chloe helene cahill,ENGL-1030,2017
-ENGL,1030,2,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,ENGL-1030,2017
-ENGL,1030,3,Accelerated Composition,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,sharif youssef,ENGL-1030,2017
-ENGL,1030,4,Accelerated Composition,0.7,0.05,0.05,0.05,0.0,0.0,0.0,0.15,melissa dugan,ENGL-1030,2017
-ENGL,1030,7,Accelerated Composition,0.71,0.05,0.14,0.0,0.1,0.0,0.0,0.0,charlotte est lucke,ENGL-1030,2017
-ENGL,1030,8,Accelerated Composition,0.81,0.1,0.0,0.05,0.05,0.0,0.0,0.0,melissa dugan,ENGL-1030,2017
-ENGL,1030,9,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,katie jo vann,ENGL-1030,2017
-ENGL,1030,10,Accelerated Composition,0.57,0.29,0.05,0.0,0.0,0.0,0.0,0.1,krist aldebol-hazle,ENGL-1030,2017
-ENGL,1030,11,Accelerated Composition,0.76,0.19,0.0,0.0,0.05,0.0,0.0,0.0,robert brissey,ENGL-1030,2017
-ENGL,1030,12,Accelerated Composition,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,robert brissey,ENGL-1030,2017
-ENGL,1030,13,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,kala parker,ENGL-1030,2017
-ENGL,1030,15,Accelerated Composition,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,katie jo vann,ENGL-1030,2017
-ENGL,1030,16,Accelerated Composition,0.59,0.24,0.0,0.0,0.06,0.0,0.0,0.12,kala parker,ENGL-1030,2017
-ENGL,1030,18,Accelerated Composition,0.81,0.05,0.0,0.0,0.0,0.0,0.0,0.14,katie jo vann,ENGL-1030,2017
-ENGL,1030,19,Accelerated Composition,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,samuel david martin,ENGL-1030,2017
-ENGL,1030,20,Accelerated Composition,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,samuel david martin,ENGL-1030,2017
-ENGL,1030,21,Accelerated Composition,0.76,0.14,0.05,0.0,0.05,0.0,0.0,0.0,brian lee gaines,ENGL-1030,2017
-ENGL,1030,22,Accelerated Composition,0.62,0.24,0.1,0.0,0.05,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2017
-ENGL,1030,23,Accelerated Composition,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,charlotte est lucke,ENGL-1030,2017
-ENGL,1030,24,Accelerated Composition,0.65,0.12,0.12,0.06,0.06,0.0,0.0,0.0,brian lee gaines,ENGL-1030,2017
-ENGL,1030,25,Accelerated Composition,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,michael davi measel,ENGL-1030,2017
-ENGL,1030,26,Accelerated Composition,0.31,0.38,0.0,0.0,0.19,0.0,0.0,0.13,la'cresha ulo green,ENGL-1030,2017
-ENGL,1030,27,Accelerated Composition,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2017
-ENGL,1030,28,Accelerated Composition,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,michael davi measel,ENGL-1030,2017
-ENGL,1030,30,Accelerated Composition,0.69,0.06,0.06,0.13,0.0,0.0,0.0,0.06,michael russo,ENGL-1030,2017
-ENGL,1030,31,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,laurie pfister epps,ENGL-1030,2017
-ENGL,1030,37,Accelerated Composition,0.76,0.05,0.1,0.0,0.0,0.0,0.0,0.1,christopher stuart,ENGL-1030,2017
-ENGL,1030,39,Accelerated Composition,0.81,0.1,0.0,0.0,0.0,0.0,0.0,0.1,michael russo,ENGL-1030,2017
-ENGL,1030,40,Accelerated Composition,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,austin gorman,ENGL-1030,2017
-ENGL,1030,41,Accelerated Composition,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,christopher stuart,ENGL-1030,2017
-ENGL,1030,44,Accelerated Composition,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,erica mich marquard,ENGL-1030,2017
-ENGL,1030,48,Accelerated Composition,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,matthew scot duncan,ENGL-1030,2017
-ENGL,1030,49,Accelerated Composition,0.33,0.44,0.0,0.0,0.11,0.0,0.0,0.11,matthew scot duncan,ENGL-1030,2017
-ENGL,1030,51,Accelerated Composition,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,stephen quigley,ENGL-1030,2017
-ENGL,1030,52,Accelerated Composition,0.76,0.14,0.0,0.0,0.1,0.0,0.0,0.0,stephen quigley,ENGL-1030,2017
-ENGL,1030,55,Accelerated Composition,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,daniel frank,ENGL-1030,2017
-ENGL,1030,57,Accelerated Composition,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,krist aldebol-hazle,ENGL-1030,2017
-ENGL,1030,58,Accelerated Composition,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,chloe helene cahill,ENGL-1030,2017
-ENGL,1030,60,Accelerated Composition,0.62,0.29,0.0,0.0,0.05,0.0,0.0,0.05,jennifer forsberg,ENGL-1030,2017
-ENGL,1030,62,Accelerated Composition,0.85,0.05,0.05,0.05,0.0,0.0,0.0,0.0,jennifer forsberg,ENGL-1030,2017
-ENGL,1030,63,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,christa kettlewell,ENGL-1030,2017
-ENGL,1030,65,Accelerated Composition,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,christa kettlewell,ENGL-1030,2017
-ENGL,1030,67,Accelerated Composition,0.14,0.71,0.05,0.0,0.0,0.0,0.0,0.1,renesha moniq poole,ENGL-1030,2017
-ENGL,1030,68,Accelerated Composition,0.06,0.78,0.06,0.06,0.0,0.0,0.0,0.06,renesha moniq poole,ENGL-1030,2017
-ENGL,1030,69,Accelerated Composition,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,dia quaglia beltran,ENGL-1030,2017
-ENGL,1030,70,Accelerated Composition,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,parker elizabe king,ENGL-1030,2017
-ENGL,1030,71,Accelerated Composition,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,yvonne kao,ENGL-1030,2017
-ENGL,1030,72,Accelerated Composition,0.71,0.12,0.06,0.06,0.0,0.0,0.0,0.06,yvonne kao,ENGL-1030,2017
-ENGL,1030,555,Accelerated Composition,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,ENGL-1030,2017
-ENGL,2020,555,The Major Forms of Literature,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,ENGL-2020,2017
-ENGL,2120,1,World Literature,0.34,0.34,0.14,0.07,0.03,0.0,0.0,0.07,andrew mathas,ENGL-2120,2017
-ENGL,2120,2,World Literature,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.03,daniel scott citro,ENGL-2120,2017
-ENGL,2120,3,World Literature,0.28,0.34,0.21,0.03,0.07,0.0,0.0,0.07,karen kettnich,ENGL-2120,2017
-ENGL,2120,4,World Literature,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,walter edgar hunter,ENGL-2120,2017
-ENGL,2120,5,World Literature,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,stephanie stripling,ENGL-2120,2017
-ENGL,2120,6,World Literature,0.28,0.45,0.17,0.03,0.07,0.0,0.0,0.0,karen kettnich,ENGL-2120,2017
-ENGL,2120,7,World Literature,0.76,0.17,0.03,0.03,0.0,0.0,0.0,0.0,stephanie stripling,ENGL-2120,2017
-ENGL,2120,11,World Literature,0.48,0.21,0.24,0.03,0.0,0.0,0.0,0.03,chloe mich whitaker,ENGL-2120,2017
-ENGL,2120,12,World Literature,0.41,0.41,0.07,0.07,0.0,0.0,0.0,0.03,chloe mich whitaker,ENGL-2120,2017
-ENGL,2120,13,World Literature,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.03,daniel scott citro,ENGL-2120,2017
-ENGL,2120,14,World Literature,0.38,0.48,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2120,2017
-ENGL,2120,16,World Literature,0.2,0.63,0.1,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,ENGL-2120,2017
-ENGL,2120,17,World Literature,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,april susanne pelt,ENGL-2120,2017
-ENGL,2120,18,World Literature,0.45,0.39,0.13,0.03,0.0,0.0,0.0,0.0,olga anatol volkova,ENGL-2120,2017
-ENGL,2120,19,World Literature,0.43,0.33,0.17,0.03,0.03,0.0,0.0,0.0,karen kettnich,ENGL-2120,2017
-ENGL,2120,20,World Literature,0.37,0.33,0.1,0.07,0.03,0.0,0.0,0.1,katalin beck,ENGL-2120,2017
-ENGL,2130,1,British Literature,0.76,0.21,0.03,0.0,0.0,0.0,0.0,0.0,benjamin hudson,ENGL-2130,2017
-ENGL,2130,2,British Literature,0.57,0.3,0.1,0.0,0.03,0.0,0.0,0.0,christopher benson,ENGL-2130,2017
-ENGL,2130,3,British Literature,0.77,0.2,0.0,0.0,0.0,0.0,0.0,0.03,christopher benson,ENGL-2130,2017
-ENGL,2130,4,British Literature,0.86,0.07,0.03,0.0,0.03,0.0,0.0,0.0,stephanie stripling,ENGL-2130,2017
-ENGL,2130,6,British Literature,0.61,0.32,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-2130,2017
-ENGL,2130,7,British Literature,0.8,0.13,0.03,0.0,0.0,0.0,0.0,0.03,benjamin hudson,ENGL-2130,2017
-ENGL,2130,10,British Literature,0.63,0.27,0.0,0.03,0.07,0.0,0.0,0.0,krist aldebol-hazle,ENGL-2130,2017
-ENGL,2130,12,British Literature,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2017
-ENGL,2130,13,British Literature,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,lucian ghita,ENGL-2130,2017
-ENGL,2130,14,British Literature,0.77,0.17,0.0,0.0,0.0,0.0,0.0,0.07,lucian ghita,ENGL-2130,2017
-ENGL,2140,1,American Literature,0.7,0.13,0.13,0.0,0.03,0.0,0.0,0.0,jennifer forsberg,ENGL-2140,2017
-ENGL,2140,2,American Literature,0.43,0.29,0.07,0.04,0.04,0.0,0.0,0.14,jennifer forsberg,ENGL-2140,2017
-ENGL,2140,3,American Literature,0.72,0.21,0.03,0.03,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2140,2017
-ENGL,2140,4,American Literature,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2017
-ENGL,2140,5,American Literature,0.29,0.43,0.11,0.07,0.0,0.0,0.0,0.11,david charles foltz,ENGL-2140,2017
-ENGL,2140,6,American Literature,0.19,0.38,0.23,0.04,0.04,0.0,0.0,0.12,david charles foltz,ENGL-2140,2017
-ENGL,2140,7,American Literature,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2017
-ENGL,2140,8,American Literature,0.15,0.41,0.19,0.0,0.11,0.0,0.0,0.15,david charles foltz,ENGL-2140,2017
-ENGL,2140,12,American Literature,0.11,0.37,0.15,0.07,0.19,0.0,0.0,0.11,david charles foltz,ENGL-2140,2017
-ENGL,2140,13,American Literature,0.78,0.15,0.0,0.0,0.0,0.0,0.0,0.07,candace wiley,ENGL-2140,2017
-ENGL,2140,14,American Literature,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2017
-ENGL,2140,15,American Literature,0.8,0.13,0.0,0.03,0.03,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2017
-ENGL,2140,16,American Literature,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2140,2017
-ENGL,2140,17,American Literature,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,adrian carson,ENGL-2140,2017
-ENGL,2140,18,American Literature,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,adrian carson,ENGL-2140,2017
-ENGL,2140,19,American Literature,0.72,0.03,0.0,0.0,0.1,0.0,0.0,0.14,candace wiley,ENGL-2140,2017
-ENGL,2140,20,American Literature,0.77,0.12,0.0,0.0,0.0,0.0,0.0,0.12,candace wiley,ENGL-2140,2017
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.48,0.32,0.13,0.03,0.0,0.0,0.0,0.03,john logan pursley,ENGL-2150,2017
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.33,0.37,0.1,0.1,0.07,0.0,0.0,0.03,megan no macalystre,ENGL-2150,2017
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.52,0.34,0.07,0.03,0.03,0.0,0.0,0.0,megan no macalystre,ENGL-2150,2017
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.47,0.3,0.03,0.0,0.1,0.0,0.0,0.1,andrew mathas,ENGL-2150,2017
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.67,0.23,0.03,0.0,0.07,0.0,0.0,0.0,megan no macalystre,ENGL-2150,2017
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.5,0.33,0.03,0.03,0.07,0.0,0.0,0.03,andrew mathas,ENGL-2150,2017
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.43,0.37,0.13,0.07,0.0,0.0,0.0,0.0,andrew mathas,ENGL-2150,2017
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.33,0.07,0.0,0.07,0.0,0.0,0.0,john logan pursley,ENGL-2150,2017
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,mari elena ramler,ENGL-2150,2017
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.3,0.57,0.07,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,ENGL-2150,2017
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,ENGL-2150,2017
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,benjamin hudson,ENGL-2150,2017
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.8,0.1,0.03,0.0,0.03,0.0,0.0,0.03,benjamin hudson,ENGL-2150,2017
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,sharif youssef,ENGL-2150,2017
-ENGL,3010,1,Great Books of Western World,0.12,0.65,0.18,0.0,0.0,0.0,0.0,0.06,colin pearce,ENGL-3010,2017
-ENGL,3040,2,Business Writing,0.81,0.1,0.05,0.05,0.0,0.0,0.0,0.0,philip randall,ENGL-3040,2017
-ENGL,3040,3,Business Writing,0.6,0.2,0.1,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,ENGL-3040,2017
-ENGL,3040,4,Business Writing,0.64,0.14,0.09,0.0,0.0,0.0,0.0,0.14,geveryl le robinson,ENGL-3040,2017
-ENGL,3040,5,Business Writing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3040,2017
-ENGL,3040,13,Business Writing,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,katalin beck,ENGL-3040,2017
-ENGL,3040,14,Business Writing,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,philip randall,ENGL-3040,2017
-ENGL,3040,16,Business Writing,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,emily anne boyter,ENGL-3040,2017
-ENGL,3040,17,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharif youssef,ENGL-3040,2017
-ENGL,3040,18,Business Writing,0.75,0.0,0.15,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,ENGL-3040,2017
-ENGL,3040,19,Business Writing,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3040,2017
-ENGL,3040,22,Business Writing,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,sharif youssef,ENGL-3040,2017
-ENGL,3040,400,Business Writing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,ENGL-3040,2017
-ENGL,3040,401,Business Writing,0.71,0.14,0.05,0.0,0.05,0.0,0.0,0.05,hayley ren zertuche,ENGL-3040,2017
-ENGL,3040,402,Business Writing,0.71,0.19,0.0,0.0,0.05,0.0,0.0,0.05,hayley ren zertuche,ENGL-3040,2017
-ENGL,3040,403,Business Writing,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,hayley ren zertuche,ENGL-3040,2017
-ENGL,3040,404,Business Writing,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,steph kartalopoulos,ENGL-3040,2017
-ENGL,3040,405,Business Writing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,ENGL-3040,2017
-ENGL,3040,406,Business Writing,0.6,0.3,0.0,0.05,0.0,0.0,0.0,0.05,steph kartalopoulos,ENGL-3040,2017
-ENGL,3040,407,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,ENGL-3040,2017
-ENGL,3100,1,Crit Writ Lit,0.38,0.48,0.1,0.0,0.05,0.0,0.0,0.0,david sweene coombs,ENGL-3100,2017
-ENGL,3100,2,Crit Writ Lit,0.19,0.33,0.14,0.1,0.14,0.0,0.0,0.1,william stockton,ENGL-3100,2017
-ENGL,3100,4,Crit Writ Lit,0.29,0.48,0.14,0.0,0.0,0.0,0.0,0.1,david sweene coombs,ENGL-3100,2017
-ENGL,3120,1,Advanced Composition,0.57,0.19,0.1,0.0,0.1,0.0,0.0,0.05,elizabeth stansell,ENGL-3120,2017
-ENGL,3120,2,Advanced Composition,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2017
-ENGL,3140,1,Technical Writing,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2017
-ENGL,3140,2,Technical Writing,0.74,0.22,0.0,0.0,0.04,0.0,0.0,0.0,nathan riggs,ENGL-3140,2017
-ENGL,3140,3,Technical Writing,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3140,2017
-ENGL,3140,4,Technical Writing,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,eric stephens,ENGL-3140,2017
-ENGL,3140,5,Technical Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2017
-ENGL,3140,6,Technical Writing,0.67,0.24,0.0,0.1,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2017
-ENGL,3140,7,Technical Writing,0.81,0.05,0.05,0.0,0.05,0.0,0.0,0.05,eric stephens,ENGL-3140,2017
-ENGL,3140,9,Technical Writing,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2017
-ENGL,3140,10,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,ENGL-3140,2017
-ENGL,3140,11,Technical Writing,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,la'cresha ulo green,ENGL-3140,2017
-ENGL,3140,12,Technical Writing,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,ENGL-3140,2017
-ENGL,3140,13,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,ENGL-3140,2017
-ENGL,3140,14,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-3140,2017
-ENGL,3140,15,Technical Writing,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,joshua wood,ENGL-3140,2017
-ENGL,3140,16,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,joshua wood,ENGL-3140,2017
-ENGL,3140,18,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3140,2017
-ENGL,3140,19,Technical Writing,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3140,2017
-ENGL,3140,25,Technical Writing,0.8,0.15,0.0,0.05,0.0,0.0,0.0,0.0,crystal pa stephens,ENGL-3140,2017
-ENGL,3150,1,Scientific Writing & Comm,0.47,0.26,0.16,0.05,0.0,0.0,0.0,0.05,william pulley,ENGL-3150,2017
-ENGL,3150,2,Scientific Writing & Comm,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3150,2017
-ENGL,3150,5,Scientific Writing & Comm,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,ENGL-3150,2017
-ENGL,3150,18,Scientific Writing & Comm,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,christopher benson,ENGL-3150,2017
-ENGL,3320,1,Visual Communication,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,sean williams,ENGL-3320,2017
-ENGL,3330,1,Writing News Media,0.47,0.33,0.07,0.0,0.13,0.0,0.0,0.0,geveryl le robinson,ENGL-3330,2017
-ENGL,3450,1,Structure of Fiction,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,ENGL-3450,2017
-ENGL,3460,1,Structure of Poetry,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,candace wiley,ENGL-3460,2017
-ENGL,3480,1,Structure Screenplay,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,ENGL-3480,2017
-ENGL,3540,1,Lit Middle East & North Africa,0.53,0.29,0.0,0.0,0.06,0.0,0.0,0.12,angela naimou,ENGL-3540,2017
-ENGL,3570,1,Film,0.05,0.7,0.15,0.0,0.05,0.0,0.0,0.05,amy monaghan,ENGL-3570,2017
-ENGL,3570,2,Film,0.06,0.61,0.17,0.0,0.11,0.0,0.0,0.06,amy monaghan,ENGL-3570,2017
-ENGL,3570,3,Film,0.05,0.79,0.11,0.0,0.05,0.0,0.0,0.0,amy monaghan,ENGL-3570,2017
-ENGL,3850,1,Children's Lit,0.74,0.11,0.0,0.05,0.05,0.0,0.0,0.05,megan no macalystre,ENGL-3850,2017
-ENGL,3970,1,Brit Lit Survey II,0.56,0.22,0.17,0.0,0.0,0.0,0.0,0.06,john morgenstern,ENGL-3970,2017
-ENGL,3980,1,Amer Lit Survey I,0.2,0.53,0.2,0.0,0.07,0.0,0.0,0.0,rhondda robi thomas,ENGL-3980,2017
-ENGL,3980,2,Amer Lit Survey I,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,susanna ashton,ENGL-3980,2017
-ENGL,3990,1,Amer Lit Survey II,0.68,0.11,0.16,0.0,0.0,0.0,0.0,0.05,walter edgar hunter,ENGL-3990,2017
-ENGL,3990,2,Amer Lit Survey II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-3990,2017
-ENGL,4070,1,Medieval Period,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,ENGL-4070,2017
-ENGL,4110,1,Shakespeare,0.48,0.29,0.0,0.0,0.14,0.0,0.0,0.1,elizabeth rivlin,ENGL-4110,2017
-ENGL,4110,2,Shakespeare,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,andrew lemons,ENGL-4110,2017
-ENGL,4110,3,Shakespeare,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-4110,2017
-ENGL,4190,1,Post Col & World Lit,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,ENGL-4190,2017
-ENGL,4200,1,Amer Lit to 1799,0.5,0.3,0.0,0.0,0.1,0.0,0.0,0.1,jonathan beec field,ENGL-4200,2017
-ENGL,4250,1,American Novel,0.39,0.22,0.17,0.06,0.06,0.0,0.0,0.11,susanna ashton,ENGL-4250,2017
-ENGL,4320,1,Modern Fiction,0.39,0.44,0.06,0.0,0.06,0.0,0.0,0.06,gabriel and hankins,ENGL-4320,2017
-ENGL,4360,1,Feminist Literary Criticism,0.59,0.29,0.0,0.0,0.06,0.0,0.0,0.06,michelle renee ty,ENGL-4360,2017
-ENGL,4400,1,Literary Theory,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,michelle renee ty,ENGL-4400,2017
-ENGL,4420,1,Cultural Studies,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,gabriel and hankins,ENGL-4420,2017
-ENGL,4450,1,Fiction Workshop,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-4450,2017
-ENGL,4580,1,Adaptations of World Classics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-4580,2017
-ENGL,4650,1,Topics in Literature from 1900,0.67,0.11,0.06,0.0,0.11,0.0,0.0,0.06,garry bertholf,ENGL-4650,2017
-ENGL,4750,1,Writing for Media,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,jonathan beec field,ENGL-4750,2017
-ENGL,4780,1,Digital Literacy,0.76,0.06,0.06,0.0,0.06,0.0,0.0,0.06,megan eatman,ENGL-4780,2017
-ENGL,4890,1,Topics Write & Publ,0.78,0.06,0.0,0.0,0.06,0.0,0.0,0.11,jan rune holmevik,ENGL-4890,2017
-ENGL,4920,1,Modern Rhetoric,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,megan eatman,ENGL-4920,2017
-ENGL,4960,1,Senior Seminar,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,rhondda robi thomas,ENGL-4960,2017
-ENGL,4960,2,Senior Seminar,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,angela naimou,ENGL-4960,2017
-ENGL,4960,3,Senior Seminar,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-4960,2017
-ENGL,4960,4,Senior Seminar,0.42,0.25,0.25,0.0,0.0,0.0,0.0,0.08,william stockton,ENGL-4960,2017
-ENGR,1020,312,Engineering Discipl & Skills,0.07,0.22,0.3,0.15,0.07,0.0,0.0,0.19,bradley putman,ENGR-1020,2017
-ENGR,1020,317,Engineering Discipl & Skills,0.19,0.41,0.19,0.06,0.07,0.0,0.0,0.09,ashley childers,ENGR-1020,2017
-ENGR,1020,318,Engineering Discipl & Skills,0.06,0.44,0.31,0.06,0.11,0.0,0.0,0.02,ashley childers,ENGR-1020,2017
-ENGR,1060,242,Engr Discipline & Skills II,0.03,0.1,0.37,0.3,0.13,0.0,0.0,0.07,sarah grigg,ENGR-1060,2017
-ENGR,1060,312,Engr Discipline & Skills II,0.0,0.4,0.6,0.0,0.0,0.0,0.0,0.0,bradley putman,ENGR-1060,2017
-ENGR,1410,122,Programming & Problem Solving,0.31,0.38,0.27,0.02,0.0,0.0,0.0,0.02,matthew kent miller,ENGR-1410,2017
-ENGR,1410,321,Programming & Problem Solving,0.02,0.3,0.41,0.15,0.02,0.0,0.0,0.09,michael giebner,ENGR-1410,2017
-ENGR,1410,323,Programming & Problem Solving,0.22,0.46,0.22,0.09,0.0,0.0,0.0,0.02,mariah magagnotti,ENGR-1410,2017
-ENGR,1410,324,Programming & Problem Solving,0.22,0.37,0.3,0.09,0.0,0.0,0.0,0.02,irene marie ferrara,ENGR-1410,2017
-ENGR,1410,325,Programming & Problem Solving,0.33,0.33,0.2,0.09,0.02,0.0,0.0,0.04,steven brandon,ENGR-1410,2017
-ENGR,1410,326,Programming & Problem Solving,0.27,0.38,0.22,0.02,0.0,0.0,0.0,0.11,steven brandon,ENGR-1410,2017
-ENGR,1410,621,Programming & Problem Solving,0.25,0.3,0.25,0.08,0.03,0.0,0.0,0.1,william martin,ENGR-1410,2017
-ENGR,1410,622,Programming & Problem Solving,0.34,0.4,0.09,0.11,0.02,0.0,0.0,0.04,william martin,ENGR-1410,2017
-ENGR,1410,623,Programming & Problem Solving,0.43,0.49,0.09,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,ENGR-1410,2017
-ENGR,1410,624,Programming & Problem Solving,0.16,0.45,0.3,0.05,0.02,0.0,0.0,0.02,andrew isaa neptune,ENGR-1410,2017
-ENGR,1410,625,Programming & Problem Solving,0.15,0.59,0.13,0.04,0.0,0.0,0.0,0.09,matthew kent miller,ENGR-1410,2017
-ENGR,1410,626,Programming & Problem Solving,0.14,0.36,0.32,0.11,0.0,0.0,0.0,0.07,matthew kent miller,ENGR-1410,2017
-ENGR,1410,627,Programming & Problem Solving,0.21,0.55,0.17,0.02,0.02,0.0,0.0,0.02,sarah grigg,ENGR-1410,2017
-ENGR,1410,628,Programming & Problem Solving,0.09,0.56,0.24,0.09,0.0,0.0,0.0,0.03,sarah grigg,ENGR-1410,2017
-ENGR,1410,821,Programming & Problem Solving,0.13,0.39,0.19,0.16,0.03,0.0,0.0,0.1,andrew isaa neptune,ENGR-1410,2017
-ENGR,1410,822,Programming & Problem Solving,0.33,0.33,0.26,0.04,0.0,0.0,0.0,0.04,andrew isaa neptune,ENGR-1410,2017
-ENGR,1410,823,Program & Prob Solving (HON),0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,john minor,ENGR-1410,2017
-ENGR,1410,824,Program & Prob Solving (HON),0.44,0.53,0.03,0.0,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1410,2017
-ENGR,1410,825,Programming & Problem Solving,0.16,0.38,0.31,0.09,0.0,0.0,0.0,0.07,mariah magagnotti,ENGR-1410,2017
-ENGR,1410,826,Programming & Problem Solving,0.11,0.37,0.41,0.02,0.02,0.0,0.0,0.07,mariah magagnotti,ENGR-1410,2017
-ENGR,1410,827,Programming & Problem Solving,0.13,0.6,0.27,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,ENGR-1410,2017
-ENGR,1410,828,Programming & Problem Solving,0.15,0.35,0.24,0.24,0.0,0.0,0.0,0.03,irene marie ferrara,ENGR-1410,2017
-ENGR,1640,500,Engineering MATLAB Programming,0.14,0.43,0.29,0.14,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1640,2017
-ENGR,1640,501,Engineering MATLAB Programming,0.05,0.35,0.25,0.2,0.15,0.0,0.0,0.0,jonathan maier,ENGR-1640,2017
-ENGR,2080,382,Engr Graphics & Machine Design,0.68,0.26,0.0,0.04,0.0,0.0,0.0,0.02,john minor,ENGR-2080,2017
-ENGR,2080,384,Engr Graphics & Machine Design,0.61,0.21,0.04,0.02,0.09,0.0,0.0,0.04,anthony pau garland,ENGR-2080,2017
-ENGR,2080,385,Engr Graphics & Machine Design,0.49,0.19,0.14,0.04,0.07,0.0,0.0,0.07,anthony pau garland,ENGR-2080,2017
-ENGR,2080,686,Engr Graphics & Machine Design,0.55,0.23,0.13,0.02,0.04,0.0,0.0,0.04,garrison llo broome,ENGR-2080,2017
-ENGR,2080,881,Engr Graphics & Machine Design,0.47,0.33,0.09,0.03,0.07,0.0,0.0,0.02,amaninder sing gill,ENGR-2080,2017
-ENGR,2080,882,Engr Graphics & Machine Design,0.63,0.28,0.05,0.02,0.02,0.0,0.0,0.0,amaninder sing gill,ENGR-2080,2017
-ENGR,2080,884,Engr Graphics & Machine Design,0.66,0.23,0.05,0.0,0.04,0.0,0.0,0.02,nighat yasmin,ENGR-2080,2017
-ENGR,2080,885,Engr Graphics & Machine Design,0.61,0.29,0.05,0.02,0.04,0.0,0.0,0.0,sarah rowlinson,ENGR-2080,2017
-ENGR,2080,886,Engr Graphics & Machine Design,0.5,0.29,0.11,0.04,0.05,0.0,0.0,0.02,sarah rowlinson,ENGR-2080,2017
-ENGR,2100,601,CAD & Engineering Applications,0.67,0.19,0.13,0.0,0.02,0.0,0.0,0.0,nighat yasmin,ENGR-2100,2017
-ENGR,2100,602,CAD & Engineering Applications,0.56,0.25,0.13,0.0,0.02,0.0,0.0,0.04,nighat yasmin,ENGR-2100,2017
-ENGR,2100,604,CAD & Engineering Applications,0.56,0.32,0.08,0.0,0.02,0.0,0.0,0.02,trent hou dellinger,ENGR-2100,2017
-ENGR,2100,605,CAD & Engineering Applications,0.65,0.29,0.04,0.0,0.02,0.0,0.0,0.0, shams esfandabadi,ENGR-2100,2017
-ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.15,0.06,0.02,0.02,0.0,0.0,0.04,russell barrett,ENR-1020,2017
-ENR,3020,1,Nat Res Measurements,0.68,0.24,0.05,0.03,0.0,0.0,0.0,0.0,lawrence gering,ENR-3020,2017
-ENR,4130,2,Restoration Ecology,0.17,0.47,0.19,0.14,0.03,0.0,0.0,0.0,althea simone hagan,ENR-4130,2017
-ENR,4500,1,Conservation Issues,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,ENR-4500,2017
-ENR,4500,2,Conservation Issues,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,ENR-4500,2017
-ENSP,2000,1,Intro Environ Sci,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,tom owino,ENSP-2000,2017
-ENSP,2000,2,Intro Environ Sci,0.72,0.23,0.02,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,ENSP-2000,2017
-ENSP,2000,3,Intro Environ Sci,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2017
-ENSP,2010,1,Environm Sci for Educ Majors,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2010,2017
-ENT,2000,1,Six-Legged Science,0.49,0.33,0.14,0.0,0.0,0.0,0.0,0.05,suellen pometto,ENT-2000,2017
-ENT,2010,1,Animated Insects,0.92,0.05,0.03,0.0,0.0,0.0,0.0,0.0,joseph culin,ENT-2010,2017
-ENTR,1010,1,Entrepreneurial Mindset,0.5,0.28,0.06,0.05,0.08,0.0,0.0,0.04,john michael hannon,ENTR-1010,2017
-ENTR,1040,1,Technology Entrepreneurship,0.55,0.31,0.03,0.0,0.1,0.0,0.0,0.0,john michael hannon,ENTR-1040,2017
-ESED,8210,1,Teaching Undergraduate Science,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,jennifer van dyken,ESED-8210,2017
-ETOX,6370,1,Ecotoxicology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,peter van den hurk,ETOX-6370,2017
-FCS,8110,1,Hum Dev & Fam Life,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,susan limber,FCS-8110,2017
-FCS,8340,1,Research Methods in FCS II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,FCS-8340,2017
-FDSC,1020,1,Persp Food Nutrition,0.94,0.0,0.0,0.03,0.0,0.0,0.0,0.03,john mcgregor,FDSC-1020,2017
-FDSC,2140,1,Fd Resources & Soc,0.49,0.36,0.08,0.04,0.0,0.0,0.0,0.04,paul dawson,FDSC-2140,2017
-FDSC,2150,1,Culinary Fundamental,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,aubrey dean coffee,FDSC-2150,2017
-FDSC,3040,1,Eval Dairy Products,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john mcgregor,FDSC-3040,2017
-FDSC,3060,1,Institutional Food Service Mgt,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,FDSC-3060,2017
-FDSC,4020,1,Food Chemistry II,0.46,0.48,0.04,0.0,0.0,0.0,0.0,0.02,feng chen,FDSC-4020,2017
-FDSC,4030,1,Food Ch & Analysis,0.7,0.19,0.09,0.02,0.0,0.0,0.0,0.0,paul dawson,FDSC-4030,2017
-FDSC,4080,1,Food Process Eng,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,felix barron,FDSC-4080,2017
-FDSC,4090,1,TQM for Food & Pckg Industries,0.54,0.32,0.1,0.02,0.0,0.0,0.0,0.02,john mcgregor,FDSC-4090,2017
-FIN,2010,401,Intro to Personal Finance,0.68,0.18,0.04,0.04,0.0,0.0,0.0,0.07,joshua harris,FIN-2010,2017
-FIN,2010,402,Intro to Personal Finance,0.69,0.21,0.0,0.07,0.0,0.0,0.0,0.03,joshua harris,FIN-2010,2017
-FIN,2010,403,Intro to Personal Finance,0.27,0.62,0.08,0.0,0.0,0.0,0.0,0.04,joshua harris,FIN-2010,2017
-FIN,2010,404,Intro to Personal Finance,0.69,0.18,0.02,0.02,0.02,0.0,0.0,0.07,joshua harris,FIN-2010,2017
-FIN,2010,405,Intro to Personal Finance,0.64,0.17,0.03,0.06,0.11,0.0,0.0,0.0,joshua harris,FIN-2010,2017
-FIN,2010,406,Intro to Personal Finance,0.73,0.08,0.12,0.0,0.08,0.0,0.0,0.0,joshua harris,FIN-2010,2017
-FIN,3040,1,Risk & Insurance,0.28,0.17,0.44,0.0,0.06,0.0,0.0,0.06,kerri mcmillan,FIN-3040,2017
-FIN,3050,1,Investment Analysis,0.18,0.34,0.26,0.13,0.05,0.0,0.0,0.03,kerri mcmillan,FIN-3050,2017
-FIN,3050,2,Investment Analysis,0.13,0.32,0.39,0.08,0.03,0.0,0.0,0.05,kerri mcmillan,FIN-3050,2017
-FIN,3050,3,Investment Analysis,0.3,0.33,0.25,0.08,0.03,0.0,0.0,0.03,kerri mcmillan,FIN-3050,2017
-FIN,3060,1,Corporation Finance,0.25,0.15,0.18,0.2,0.2,0.0,0.0,0.03,william hol johnson,FIN-3060,2017
-FIN,3060,2,Corporation Finance,0.39,0.16,0.13,0.16,0.03,0.0,0.0,0.13,william hol johnson,FIN-3060,2017
-FIN,3060,3,Corporation Finance,0.31,0.13,0.17,0.22,0.06,0.0,0.0,0.11,william hol johnson,FIN-3060,2017
-FIN,3060,4,Corporation Finance,0.08,0.25,0.34,0.17,0.08,0.0,0.0,0.08,ramon tolb franklin,FIN-3060,2017
-FIN,3060,5,Corporation Finance,0.14,0.17,0.41,0.14,0.08,0.0,0.0,0.05,ramon tolb franklin,FIN-3060,2017
-FIN,3060,6,Corporation Finance,0.25,0.25,0.38,0.05,0.0,0.0,0.0,0.06,ramon tolb franklin,FIN-3060,2017
-FIN,3060,8,Corporation Finance,0.19,0.41,0.26,0.11,0.04,0.0,0.0,0.0,minxing sun,FIN-3060,2017
-FIN,3070,1,Prin of Real Estate,0.28,0.44,0.21,0.03,0.03,0.0,0.0,0.03,yannan shen,FIN-3070,2017
-FIN,3070,2,Prin of Real Estate,0.26,0.45,0.24,0.0,0.03,0.0,0.0,0.03,yannan shen,FIN-3070,2017
-FIN,3070,3,Prin of Real Estate,0.16,0.39,0.45,0.0,0.0,0.0,0.0,0.0,thomas springer,FIN-3070,2017
-FIN,3080,1,Fin Inst & Mkts,0.14,0.51,0.29,0.06,0.0,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2017
-FIN,3080,2,Fin Inst & Mkts,0.23,0.43,0.25,0.1,0.0,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2017
-FIN,3080,3,Fin Inst & Mkts,0.33,0.31,0.31,0.05,0.0,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2017
-FIN,3110,1,Financial Management I,0.12,0.31,0.21,0.17,0.05,0.0,0.0,0.14,george bra lockhart,FIN-3110,2017
-FIN,3110,2,Financial Management I,0.11,0.38,0.19,0.08,0.11,0.0,0.0,0.14,george bra lockhart,FIN-3110,2017
-FIN,3110,3,Financial Management I,0.12,0.32,0.15,0.24,0.05,0.0,0.0,0.12,george bra lockhart,FIN-3110,2017
-FIN,3110,4,Financial Management I,0.12,0.19,0.26,0.1,0.1,0.0,0.0,0.24,john alexander,FIN-3110,2017
-FIN,3120,1,Financial Management II,0.16,0.2,0.24,0.16,0.04,0.0,0.0,0.2,blerina zykaj,FIN-3120,2017
-FIN,3120,2,Financial Management II,0.31,0.19,0.39,0.0,0.0,0.0,0.0,0.11,blerina zykaj,FIN-3120,2017
-FIN,3120,3,Financial Management II,0.26,0.34,0.26,0.14,0.0,0.0,0.0,0.0,weike xu,FIN-3120,2017
-FIN,3120,4,Financial Management II,0.18,0.45,0.18,0.06,0.0,0.0,0.0,0.12,weike xu,FIN-3120,2017
-FIN,4030,1,Spreadsheet Apps in Finance,0.17,0.47,0.31,0.06,0.0,0.0,0.0,0.0,vincent intintoli,FIN-4030,2017
-FIN,4030,2,Spreadsheet Apps in Finance,0.25,0.36,0.25,0.06,0.06,0.0,0.0,0.03,vincent intintoli,FIN-4030,2017
-FIN,4040,2,Financial Modeling,0.13,0.39,0.43,0.04,0.0,0.0,0.0,0.0,jack wolf,FIN-4040,2017
-FIN,4050,1,Portfolio Management & Theory,0.1,0.28,0.45,0.17,0.0,0.0,0.0,0.0,john alexander,FIN-4050,2017
-FIN,4080,1,Mgt of Fin Inst,0.21,0.71,0.07,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2017
-FIN,4080,2,Mgt of Fin Inst,0.18,0.68,0.09,0.05,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2017
-FIN,4110,1,Int Fin Mgt,0.25,0.38,0.35,0.03,0.0,0.0,0.0,0.0,luke asher devault,FIN-4110,2017
-FIN,4110,2,Int Fin Mgt,0.19,0.53,0.25,0.0,0.0,0.0,0.0,0.03,luke asher devault,FIN-4110,2017
-FIN,4150,1,Real Estate Investmt,0.18,0.36,0.41,0.05,0.0,0.0,0.0,0.0,thomas springer,FIN-4150,2017
-FIN,4160,1,Real Estate Val,0.26,0.61,0.09,0.0,0.0,0.0,0.0,0.04,ramon tolb franklin,FIN-4160,2017
-FNR,4700,10,Kennedy Wtrfowl & Wetland Intn,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,richard ma kaminski,FNR-4700,2017
-FNR,4990,1,Natural Resources Seminar,0.78,0.06,0.06,0.0,0.06,0.0,0.0,0.06,susan talley guynn,FNR-4990,2017
-FNR,4990,3,Natural Resources Seminar,0.68,0.09,0.05,0.14,0.05,0.0,0.0,0.0,susan talley guynn,FNR-4990,2017
-FOR,1010,1,Intro to Forestry,0.79,0.1,0.0,0.05,0.0,0.0,0.0,0.05,lawrence gering,FOR-1010,2017
-FOR,2060,1,Forestry Ecology,0.26,0.4,0.18,0.07,0.04,0.0,0.0,0.06,donald hagan,FOR-2060,2017
-FOR,3080,1,Remote Sensing in Forestry,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,lawrence gering,FOR-3080,2017
-FOR,4060,1,Forested Watershed Mgmt,0.97,0.01,0.01,0.0,0.0,0.0,0.0,0.0,thomas adam coates,FOR-4060,2017
-FOR,4080,1,Wood and Paper Products,0.48,0.45,0.03,0.03,0.0,0.0,0.0,0.0,patricia layton,FOR-4080,2017
-FOR,4150,1,Forest Wildlife Managment,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,james davis,FOR-4150,2017
-FOR,4180,1,Forest Resource Valuation,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,thomas straka,FOR-4180,2017
-FOR,4340,1,GIS for Natural Resources,0.48,0.41,0.09,0.02,0.0,0.0,0.0,0.0,robert frit baldwin,FOR-4340,2017
-FOR,4650,1,Silviculture,0.27,0.47,0.2,0.07,0.0,0.0,0.0,0.0,gaofeng wang,FOR-4650,2017
-FR,1010,1,Elementary French,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1010,2017
-FR,1010,2,Elementary French,0.39,0.39,0.06,0.06,0.06,0.0,0.0,0.06,kenneth dav widgren,FR-1010,2017
-FR,1020,2,Elementary French,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,FR-1020,2017
-FR,1020,3,Elementary French,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2017
-FR,2010,2,Intermediate French,0.42,0.17,0.25,0.0,0.0,0.0,0.0,0.17,anne salces  nedeo,FR-2010,2017
-FR,2010,3,Intermediate French,0.8,0.05,0.1,0.0,0.0,0.0,0.0,0.05,kelly digby peebles,FR-2010,2017
-FR,2010,4,Intermediate French,0.25,0.38,0.19,0.0,0.06,0.0,0.0,0.13,erin shevau stigers,FR-2010,2017
-FR,2020,1,Intermediate French,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,erin shevau stigers,FR-2020,2017
-FR,2020,4,Intermediate French,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,FR-2020,2017
-FR,3050,1,Int Fr Con & Comp I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,FR-3050,2017
-FR,3170,1,Contemp French Civ,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,eric touya,FR-3170,2017
-GC,1010,1,Orientation to G C,0.84,0.04,0.02,0.0,0.02,0.0,0.0,0.07,kern cox,GC-1010,2017
-GC,1020,1,Computer Art & CAD Foundations,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,carol jones,GC-1020,2017
-GC,1030,1,G C I for Pkgsc,0.28,0.53,0.13,0.0,0.08,0.0,0.0,0.0,john jacobs,GC-1030,2017
-GC,1040,1,Graphic Communications I,0.54,0.39,0.01,0.01,0.03,0.0,0.0,0.01,rebecca suza edlein,GC-1040,2017
-GC,2070,1,Graphic Communications II,0.63,0.26,0.04,0.0,0.04,0.0,0.0,0.04,charles tabor weiss,GC-2070,2017
-GC,3400,1,Digital Imaging and eMedia,0.36,0.47,0.14,0.0,0.03,0.0,0.0,0.0,erica black walker,GC-3400,2017
-GC,3460,1,Ink and Substrates,0.32,0.53,0.12,0.02,0.02,0.0,0.0,0.0,michelle suki  fox,GC-3460,2017
-GC,4060,1,Package and Specialty Printing,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,kern cox,GC-4060,2017
-GC,4400,1,Commercial Printing,0.3,0.53,0.1,0.0,0.07,0.0,0.0,0.0,eric weisenmiller,GC-4400,2017
-GC,4440,1,Current Dev/Trends in Gr Comm,0.65,0.23,0.13,0.0,0.0,0.0,0.0,0.0,samuel ingram,GC-4440,2017
-GC,4480,1,Plan & Cont Printing Functions,0.41,0.5,0.09,0.0,0.0,0.0,0.0,0.0,john leininger,GC-4480,2017
-GC,4800,1,Senior Seminar in GC,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,GC-4800,2017
-GC,4900,2,G C Selected Topics-Sales,0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,john leininger,GC-4900,2017
-GC,4900,5,GC Selected Topics-Concept Pkg,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,john jacobs,GC-4900,2017
-GEN,3000,1,Fundamental Genetics,0.28,0.4,0.25,0.03,0.0,0.0,0.0,0.05,kate leanne wi tsai,GEN-3000,2017
-GEN,3000,2,Fundamental Genetics,0.24,0.37,0.2,0.1,0.02,0.0,0.0,0.07,kate leanne wi tsai,GEN-3000,2017
-GEN,3020,1,Molecular & General Genetics,0.39,0.24,0.22,0.02,0.05,0.0,0.0,0.07,lukasz kozubowski,GEN-3020,2017
-GEN,4100,1,Population & Quant Genetics,0.44,0.26,0.23,0.05,0.03,0.0,0.0,0.0,amy lou lawton rauh,GEN-4100,2017
-GEN,4110,1,Population & Quant Gen Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,GEN-4110,2017
-GEN,4400,1,Bioinformatics,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,liangjiang wang,GEN-4400,2017
-GEN,4700,1,Human Genetics,0.45,0.27,0.22,0.0,0.0,0.0,0.0,0.06,leigh anne clark,GEN-4700,2017
-GEN,6700,1,Human Genetics,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,leigh anne clark,GEN-6700,2017
-GEOG,1010,1,Intro to Geography,0.18,0.32,0.24,0.21,0.06,0.0,0.0,0.0,christa smith,GEOG-1010,2017
-GEOG,1030,1,World Regional Geography,0.91,0.05,0.01,0.02,0.01,0.0,0.0,0.02,lance forres howard,GEOG-1030,2017
-GEOG,1030,2,World Regional Geography,0.52,0.3,0.09,0.0,0.03,0.0,0.0,0.06,william churc terry,GEOG-1030,2017
-GEOG,4400,1,Geog of Hist Preserv,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,christa smith,GEOG-4400,2017
-GEOL,1010,1,Physical Geology,0.39,0.27,0.21,0.04,0.08,0.0,0.0,0.02,alan coulson,GEOL-1010,2017
-GEOL,1010,2,Physical Geology,0.43,0.29,0.17,0.06,0.02,0.0,0.0,0.02,alan coulson,GEOL-1010,2017
-GEOL,1030,1,Physical Geol Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,1030,2,Physical Geol Lab,0.33,0.42,0.21,0.04,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,3,Physical Geol Lab,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,4,Physical Geol Lab,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,1030,5,Physical Geol Lab,0.58,0.29,0.04,0.08,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,6,Physical Geol Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,7,Physical Geol Lab,0.42,0.38,0.13,0.04,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,1030,8,Physical Geol Lab,0.63,0.25,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2017
-GEOL,1030,9,Physical Geol Lab,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,10,Physical Geol Lab,0.75,0.08,0.04,0.0,0.04,0.0,0.0,0.08,alan coulson,GEOL-1030,2017
-GEOL,1030,11,Physical Geol Lab,0.87,0.09,0.0,0.0,0.04,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1030,12,Physical Geol Lab,0.37,0.32,0.26,0.0,0.05,0.0,0.0,0.0,alan coulson,GEOL-1030,2017
-GEOL,1120,1,Earth Resources,0.46,0.37,0.14,0.02,0.0,0.0,0.0,0.02,scott brame,GEOL-1120,2017
-GEOL,1140,1,Earth Resources Lab,0.54,0.29,0.09,0.09,0.0,0.0,0.0,0.0,scott brame,GEOL-1140,2017
-GEOL,2020,1,Earth History,0.05,0.37,0.26,0.16,0.05,0.0,0.0,0.11,alan coulson,GEOL-2020,2017
-GEOL,4050,1,Surficial Geology,0.41,0.18,0.35,0.06,0.0,0.0,0.0,0.0,james castle,GEOL-4050,2017
-GEOL,4210,1,Gis in Geology,0.63,0.22,0.15,0.0,0.0,0.0,0.0,0.0,scott brame,GEOL-4210,2017
-GEOL,4920,1,Resrch Synthesis II,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-4920,2017
-GEOL,7900,501,Biogeography & Geology of SC,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,GEOL-7900,2017
-GEOL,8090,1,Subsurface Remed Mod,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,GEOL-8090,2017
-GER,1010,1,Elementary German,0.19,0.25,0.25,0.06,0.06,0.0,0.0,0.19, lee ferrell,GER-1010,2017
-GER,1010,2,Elementary German,0.35,0.24,0.06,0.06,0.0,0.0,0.0,0.29, lee ferrell,GER-1010,2017
-GER,1020,1,Elementary German,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05,oswald harris king,GER-1020,2017
-GER,1020,2,Elementary German,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-1020,2017
-GER,2010,1,Intermediate German,0.05,0.42,0.37,0.0,0.0,0.0,0.0,0.16, lee ferrell,GER-2010,2017
-GER,2020,1,Intermediate German,0.31,0.31,0.15,0.23,0.0,0.0,0.0,0.0,gabriela stoicea,GER-2020,2017
-GER,2020,2,Intermediate German,0.36,0.29,0.14,0.07,0.14,0.0,0.0,0.0, lee ferrell,GER-2020,2017
-GER,3060,1,German Short Story,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-3060,2017
-HCC,8810,1,Measurement & Eval,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,bart knijnenburg,HCC-8810,2017
-HCG,9090,1,Lab Methods in Healthcare Gen,0.0,0.0,0.0,0.0,0.0,0.67,0.0,0.33,patricia leota tate,HCG-9090,2017
-HCG,9890,400,Sel Topics-Dev Research Propos,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,julia eggert,HCG-9890,2017
-HIST,1240,1,Environmental History Survey,0.17,0.47,0.21,0.03,0.06,0.0,0.0,0.05,james brad jeffries,HIST-1240,2017
-HIST,1720,3,The West and the World I,0.15,0.39,0.37,0.07,0.0,0.0,0.0,0.02,caroline dunn clark,HIST-1720,2017
-HIST,1730,1,The West and the World II,0.16,0.41,0.2,0.05,0.15,0.0,0.0,0.04, alan grubb,HIST-1730,2017
-HIST,1730,2,The West and the World II,0.23,0.44,0.2,0.02,0.04,0.0,0.0,0.07,subah dayal,HIST-1730,2017
-HIST,1730,3,The West and the World II,0.21,0.52,0.18,0.03,0.01,0.0,0.0,0.05,steven marks,HIST-1730,2017
-HIST,2990,1,Historian's Craft,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,michael silvestri,HIST-2990,2017
-HIST,2990,2,Historian's Craft,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carney,HIST-2990,2017
-HIST,3000,1,History of Colonial America,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,lee brady wilson,HIST-3000,2017
-HIST,3080,1,US: Reagan/Clinton 1975-Pres,0.23,0.5,0.23,0.03,0.0,0.0,0.0,0.0,meg taylor-shockley,HIST-3080,2017
-HIST,3100,1,History of Religion in the US,0.24,0.35,0.24,0.06,0.06,0.0,0.0,0.06,elizabeth jemison,HIST-3100,2017
-HIST,3110,1,African American Hist to 1877,0.42,0.28,0.16,0.02,0.07,0.0,0.0,0.05,abel bartley,HIST-3110,2017
-HIST,3170,1,Hist of Nat. Am. Relig/Culture,0.25,0.4,0.15,0.05,0.1,0.0,0.0,0.05,james brad jeffries,HIST-3170,2017
-HIST,3210,1,History of Science,0.26,0.58,0.1,0.0,0.03,0.0,0.0,0.03,pamela mack,HIST-3210,2017
-HIST,3240,1,Hist of the South II,0.33,0.55,0.03,0.0,0.0,0.0,0.0,0.09,john andrew,HIST-3240,2017
-HIST,3260,1,Hist Am Transport,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0, roger grant,HIST-3260,2017
-HIST,3330,1,Hist of Mod Japan,0.24,0.39,0.24,0.03,0.08,0.0,0.0,0.03,edwin moise,HIST-3330,2017
-HIST,3390,1,Africa 1875-Present,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,james burns,HIST-3390,2017
-HIST,3420,1,South Am Since 1800,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,HIST-3420,2017
-HIST,3520,1,Pharaonic Egypt,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carney,HIST-3520,2017
-HIST,3900,1,Modern Military History,0.23,0.33,0.27,0.07,0.03,0.0,0.0,0.07,edwin moise,HIST-3900,2017
-HIST,3970,1,Modern Middle East,0.38,0.45,0.17,0.0,0.0,0.0,0.0,0.0,amit bein,HIST-3970,2017
-HIST,4170,1,History and Tourism,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,meg taylor-shockley,HIST-4170,2017
-HIST,4700,1,History of Florence,0.32,0.42,0.11,0.0,0.0,0.0,0.0,0.16,thomas kuehn,HIST-4700,2017
-HIST,4880,1,Middle Eastern Society&Culture,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,HIST-4880,2017
-HIST,4900,1,Food & Pre-Industrial World,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,HIST-4900,2017
-HIST,4900,2,Brexit Euro Union Memory WWars,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,stephani barczewski,HIST-4900,2017
-HIST,4940,2,Slavery & Freedom ATL World,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lee brady wilson,HIST-4940,2017
-HIST,4960,1,European Legal History,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,thomas kuehn,HIST-4960,2017
-HIST,8810,1,Historiography,0.6,0.0,0.0,0.0,0.2,0.0,0.0,0.2,stephani barczewski,HIST-8810,2017
-HLTH,2020,1,Introduction to Public Health,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2017
-HLTH,2020,2,Introduction to Public Health,0.7,0.28,0.03,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2017
-HLTH,2020,400,Introduction to Public Health,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,ralph stewart welsh,HLTH-2020,2017
-HLTH,2030,1,Health Care Sys,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,frederic fraizer,HLTH-2030,2017
-HLTH,2030,2,Health Care Sys,0.52,0.36,0.12,0.0,0.0,0.0,0.0,0.0,frederic fraizer,HLTH-2030,2017
-HLTH,2030,3,Health Care Sys,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,lee alden crandall,HLTH-2030,2017
-HLTH,2030,400,Health Care Sys,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2030,2017
-HLTH,2400,1,Deter of Hlth Behav,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2017
-HLTH,2400,2,Deter of Hlth Behav,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.05,amelia clinkscales,HLTH-2400,2017
-HLTH,2600,1,Medical Terminology & Comm,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,karen edwards,HLTH-2600,2017
-HLTH,2980,1,Human Hlth & Disease,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2017
-HLTH,2980,2,Human Hlth & Disease,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2017
-HLTH,3030,1,Public Health Comm,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,HLTH-3030,2017
-HLTH,3050,1,Body Resp Hlth Beh,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,brian patric graves,HLTH-3050,2017
-HLTH,3800,1,Epidemiology,0.38,0.42,0.17,0.04,0.0,0.0,0.0,0.0,hugh spitler,HLTH-3800,2017
-HLTH,3800,2,Epidemiology,0.6,0.24,0.04,0.04,0.04,0.0,0.0,0.04,deborah alma falta,HLTH-3800,2017
-HLTH,3980,2,Health Appraisal Skills,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2017
-HLTH,4000,2,Drug Epi & Opiate Epidemic,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,HLTH-4000,2017
-HLTH,4000,3,Public Hlth Social Marketing,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,debra mitch charles,HLTH-4000,2017
-HLTH,4190,1,Health Sci Internship Prep Sem,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4190,2017
-HLTH,4200,1,Hlth Science Intern,0.83,0.15,0.0,0.02,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2017
-HLTH,4310,1,Public & Environ Hlt,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-4310,2017
-HLTH,4600,1,Health Info Systems,0.57,0.29,0.07,0.0,0.07,0.0,0.0,0.0,deborah alma falta,HLTH-4600,2017
-HLTH,4700,1,Global Health,0.71,0.18,0.07,0.0,0.04,0.0,0.0,0.0,rachel mayo,HLTH-4700,2017
-HLTH,4780,1,Health Policy Ethics and Law,0.39,0.26,0.17,0.09,0.04,0.0,0.0,0.04,hugh spitler,HLTH-4780,2017
-HLTH,4790,1,Fin Mgmt & Hlth Budg,0.63,0.17,0.17,0.0,0.04,0.0,0.0,0.0,lingling zhang,HLTH-4790,2017
-HLTH,4800,1,Comm Hlth Promotion,0.54,0.41,0.0,0.0,0.02,0.0,0.0,0.02,sarah griffin,HLTH-4800,2017
-HLTH,4900,1,Res Eval St Pub Hlth,0.76,0.16,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,HLTH-4900,2017
-HLTH,4900,2,Res Eval St Pub Hlth,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,jeffrey kingree,HLTH-4900,2017
-HLTH,4900,3,Res Eval St Pub Hlth,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-4900,2017
-HLTH,8110,1,Health Care Delivery Systems,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,HLTH-8110,2017
-HLTH,8130,400,Population Health and Research,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,HLTH-8130,2017
-HLTH,8130,500,Population Health and Research,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,HLTH-8130,2017
-HLTH,8210,500,Health Research I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,joel edwar williams,HLTH-8210,2017
-HLTH,8310,1,Quantitative Analy in Hlth I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,HLTH-8310,2017
-HON,2060,1,Intro to Nanotechnology,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,HON-2060,2017
-HON,2200,4,The Empire World,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,michael silvestri,HON-2200,2017
-HON,2210,2,Russian Film History,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,HON-2210,2017
-HON,2210,4,Soderbergh's Cinema,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,HON-2210,2017
-HON,2220,2,Holocaust and Eichmann Trial,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,HON-2220,2017
-HORT,2020,1,Adobe Digital Design,0.86,0.09,0.0,0.03,0.0,0.0,0.0,0.03,janice ann lay,HORT-2020,2017
-HORT,2110,1,Growing Spring Plnts,0.35,0.4,0.2,0.0,0.0,0.0,0.0,0.05,james emerson faust,HORT-2110,2017
-HORT,4040,1,Plant Propagation,0.13,0.45,0.24,0.11,0.03,0.0,0.0,0.05,jeffrey adelberg,HORT-4040,2017
-HORT,4050,2,Plant Propagation Techniq Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey adelberg,HORT-4050,2017
-HORT,4200,1,Applied Turf Physiol,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,HORT-4200,2017
-HORT,4270,1,Urban Tree Care,0.04,0.31,0.31,0.27,0.0,0.0,0.0,0.08,robert polomski,HORT-4270,2017
-HORT,4330,1,Turf Weed Management,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,ted whitwell,HORT-4330,2017
-HORT,4560,1,Vegetable Crops,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,HORT-4560,2017
-HORT,6040,1,Plant Propagation,0.29,0.43,0.0,0.0,0.29,0.0,0.0,0.0,jeffrey adelberg,HORT-6040,2017
-HP,8280,1,Case St in Preservation Engr,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,craig mille bennett,HP-8280,2017
-HP,8920,200,Special Topics in Hist Preserv,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0,richard gra gilmore,HP-8920,2017
-HRD,8250,400,Org Perf Improvement,0.87,0.08,0.05,0.0,0.0,0.0,0.0,0.0,philip mcgee,HRD-8250,2017
-HRD,8470,400,Instru System Design,0.74,0.05,0.05,0.0,0.11,0.0,0.0,0.05,eileen newmark,HRD-8470,2017
-HRD,8800,400,Research Concepts,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,cynthia sims,HRD-8800,2017
-IE,2000,1,Soph Seminar in I E,0.51,0.15,0.12,0.2,0.0,0.0,0.0,0.02,brian melloy,IE-2000,2017
-IE,2100,1,Des Analysis Wrk Sys,0.16,0.36,0.24,0.09,0.04,0.0,0.0,0.1,sara lu riggs,IE-2100,2017
-IE,2800,1,Deterministic Operations Rsrch,0.08,0.23,0.25,0.22,0.18,0.0,0.0,0.05,amin khademi,IE-2800,2017
-IE,3010,1,Systems Design I,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,joel greenstein,IE-3010,2017
-IE,3600,1,Industrial Apps of Prob/Stat I,0.47,0.26,0.16,0.05,0.05,0.0,0.0,0.0,mary elizabeth kurz,IE-3600,2017
-IE,3610,1,Industrial App of Prob/Stat II,0.26,0.35,0.28,0.06,0.03,0.0,0.0,0.01,sandra dun eksioglu,IE-3610,2017
-IE,3810,1,Probabilistic Operations Rsrch,0.14,0.37,0.32,0.12,0.05,0.0,0.0,0.0,burak eksioglu,IE-3810,2017
-IE,3840,1,Engr Econ Analysis,0.42,0.22,0.1,0.02,0.07,0.0,0.0,0.17,brian melloy,IE-3840,2017
-IE,3860,1,Prod Plan & Cont,0.56,0.27,0.11,0.02,0.01,0.0,0.0,0.02,jonathan lowe,IE-3860,2017
-IE,4300,1,Human Fact Engr in Healthcare,0.69,0.29,0.02,0.0,0.0,0.0,0.0,0.0,david neyens,IE-4300,2017
-IE,4400,1,Decision Support Sys,0.3,0.35,0.18,0.12,0.04,0.0,0.0,0.01,sandra dun eksioglu,IE-4400,2017
-IE,4610,1,Quality Engineering,0.22,0.22,0.15,0.27,0.07,0.0,0.0,0.07,robert james riggs,IE-4610,2017
-IE,4620,1,Six Sigma Quality,0.17,0.37,0.36,0.08,0.0,0.0,0.0,0.03,robert james riggs,IE-4620,2017
-IE,4650,1,Facilities Planning & Design,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,nadeepa wickramage,IE-4650,2017
-IE,4670,1,System Design II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-4670,2017
-IE,4670,2,System Design II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-4670,2017
-IE,4820,1,Systems Modeling,0.41,0.31,0.09,0.13,0.03,0.0,0.0,0.03,tugce isik,IE-4820,2017
-IE,4880,1,Human Factors Eng,0.34,0.51,0.14,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,IE-4880,2017
-IE,6620,1,Six Sigma Quality,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,IE-6620,2017
-IE,6820,1,Systems Modeling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tugce isik,IE-6820,2017
-IE,6840,1,Applied Engineering Economics`,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nadeepa wickramage,IE-6840,2017
-IE,8020,1,Human Comp Sys,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,joel greenstein,IE-8020,2017
-IE,8050,1,Found Qual Engr,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,byung rae cho,IE-8050,2017
-IE,8520,1,Prescriptive Analytics,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,jonathan cole smith,IE-8520,2017
-IE,8540,1,SC & Logistics Modeling I,0.65,0.26,0.0,0.0,0.09,0.0,0.0,0.0,william ferrell,IE-8540,2017
-IE,8580,1,Case Study Supply Chn & Logist,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-8580,2017
-IE,8870,1,Model Logist Behav Simulation,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,IE-8870,2017
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.06,0.03,caren kelley-hall,INT-1510,2017
-INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.89,0.09,0.03,caren kelley-hall,INT-1520,2017
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.02,caren kelley-hall,INT-1530,2017
-INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.89,0.09,0.02,caren kelley-hall,INT-1540,2017
-INT,2010,1,Off-Campus Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,katherine el horner,INT-2010,2017
-INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.89,0.11,0.0,caren kelley-hall,INT-2510,2017
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,uttiyo raychaudhuri,IS-1010,2017
-IS,1010,2,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,uttiyo raychaudhuri,IS-1010,2017
-ITAL,1010,1,Elementary Italian,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,lyudmyla tsykalova,ITAL-1010,2017
-ITAL,1010,2,Elementary Italian,0.42,0.26,0.11,0.05,0.05,0.0,0.0,0.11,julia schmidt,ITAL-1010,2017
-ITAL,1020,2,Elementary Italian,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-1020,2017
-ITAL,2020,1,Intermediate Italian,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,ITAL-2020,2017
-JAPN,1010,1,Elementary Japanese,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,saori suto,JAPN-1010,2017
-JAPN,1010,2,Elementary Japanese,0.2,0.4,0.2,0.0,0.07,0.0,0.0,0.13,saori suto,JAPN-1010,2017
-JAPN,1020,1,Elementary Japanese,0.16,0.16,0.32,0.0,0.11,0.0,0.0,0.26,toshiko joerger,JAPN-1020,2017
-JAPN,2020,1,Intermed Japanese,0.47,0.13,0.33,0.07,0.0,0.0,0.0,0.0,saori suto,JAPN-2020,2017
-JAPN,4170,1,Japanese Culture and Society,0.53,0.21,0.0,0.21,0.05,0.0,0.0,0.0,jae allegr takeuchi,JAPN-4170,2017
-JUST,2880,1,The Criminal Justice System,0.39,0.22,0.35,0.04,0.0,0.0,0.0,0.0,margaret tina britz,JUST-2880,2017
-JUST,2890,1,Criminology,0.3,0.35,0.15,0.0,0.15,0.0,0.0,0.05,william white,JUST-2890,2017
-JUST,4910,1,Policing,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,william white,JUST-4910,2017
-JUST,4930,1,Corrections,0.39,0.43,0.07,0.04,0.0,0.0,0.0,0.07,william white,JUST-4930,2017
-JUST,4940,1,Organized Crime,0.28,0.48,0.24,0.0,0.0,0.0,0.0,0.0,margaret tina britz,JUST-4940,2017
-LANG,2540,1,Introduction to World Cinemas,0.67,0.24,0.0,0.0,0.05,0.0,0.0,0.05,raquel anido,LANG-2540,2017
-LARC,1160,1,History of Landscape Arch,0.3,0.47,0.16,0.01,0.01,0.0,0.0,0.05,hala fouad nassar,LARC-1160,2017
-LARC,1160,2,History of Landscape Arch,0.69,0.19,0.08,0.04,0.0,0.0,0.0,0.0,martin john holland,LARC-1160,2017
-LARC,1520,1,Basic Design II,0.46,0.42,0.08,0.04,0.0,0.0,0.0,0.0,paul russell,LARC-1520,2017
-LARC,2550,1,Community Design Studio,0.78,0.0,0.17,0.0,0.06,0.0,0.0,0.0,martin john holland,LARC-2550,2017
-LARC,3620,1,Design Impl II,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,paul russell,LARC-3620,2017
-LARC,4280,1,Computer-Aided Design,0.85,0.04,0.12,0.0,0.0,0.0,0.0,0.0,yang song,LARC-4280,2017
-LARC,6810,1,Professional Practice,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,david lycke,LARC-6810,2017
-LAW,3220,1,Legal Env of Bus,0.14,0.51,0.29,0.04,0.02,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2017
-LAW,3220,2,Legal Env of Bus,0.47,0.36,0.11,0.07,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2017
-LAW,3220,3,Legal Env of Bus,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2017
-LAW,3220,4,Legal Env of Bus,0.4,0.42,0.16,0.02,0.0,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2017
-LAW,3220,5,Legal Env of Bus,0.27,0.2,0.36,0.16,0.02,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2017
-LAW,3220,6,Legal Env of Bus,0.31,0.47,0.16,0.04,0.02,0.0,0.0,0.0,edward ray claggett,LAW-3220,2017
-LAW,3220,7,Legal Env of Bus,0.09,0.55,0.32,0.02,0.02,0.0,0.0,0.0,judson jahn,LAW-3220,2017
-LAW,3220,8,Legal Env of Bus,0.22,0.38,0.27,0.09,0.04,0.0,0.0,0.0,kenneth toussaint,LAW-3220,2017
-LAW,3220,9,Legal Env of Bus,0.49,0.36,0.13,0.0,0.0,0.0,0.0,0.02,kath kisska-schulze,LAW-3220,2017
-LAW,3220,10,Legal Env of Bus,0.33,0.38,0.27,0.02,0.0,0.0,0.0,0.0,john hine,LAW-3220,2017
-LAW,3220,11,Legal Env of Bus,0.16,0.42,0.27,0.09,0.02,0.0,0.0,0.04,john hine,LAW-3220,2017
-LAW,3220,401,Legal Env of Bus,0.27,0.31,0.23,0.06,0.06,0.0,0.0,0.06,virgini ward-vaughn,LAW-3220,2017
-LAW,3220,402,Legal Env of Bus,0.21,0.46,0.13,0.08,0.06,0.0,0.0,0.06,virgini ward-vaughn,LAW-3220,2017
-LAW,3220,403,Legal Env of Bus,0.19,0.43,0.17,0.04,0.11,0.0,0.0,0.06,virgini ward-vaughn,LAW-3220,2017
-LAW,3220,404,Legal Env of Bus,0.13,0.33,0.27,0.07,0.07,0.0,0.0,0.13,virgini ward-vaughn,LAW-3220,2017
-LAW,3330,1,Real Estate Law,0.18,0.51,0.22,0.02,0.0,0.0,0.0,0.07,judson jahn,LAW-3330,2017
-LAW,8480,1,Law Real Estate Prof,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james ivey warren,LAW-8480,2017
-LIB,2990,1,Creative Inq - The Libraries,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert wilmott,LIB-2990,2017
-LIH,4000,35,Internship Abroad,0.0,0.0,0.0,0.0,0.0,0.79,0.21,0.0,juana martin-armas,LIH-4000,2017
-LS,1000,2,Fitness Leadership,0.82,0.0,0.0,0.09,0.0,0.0,0.0,0.09,patricia figueroa,LS-1000,2017
-LS,1000,9,Intro to Salsa Dance,0.85,0.05,0.0,0.05,0.0,0.0,0.0,0.05,malik lewis baxter,LS-1000,2017
-LS,1000,10,Intro to Salsa Dance,0.9,0.0,0.1,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,LS-1000,2017
-LS,1000,11,Shotgun II,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,edward licus prater,LS-1000,2017
-LS,1000,12,Intermediate Rock Climbing,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,corey newe winstead,LS-1000,2017
-LS,1000,17,A.C.E. Personal Trainer Prep,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,corey dou brookover,LS-1000,2017
-LS,1000,20,Intro to Volleyball,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,kelly lynn ator,LS-1000,2017
-LS,1000,23,Therapeutic Yoga,0.75,0.05,0.05,0.0,0.05,0.0,0.0,0.1,ranjanbala dil amin,LS-1000,2017
-LS,1000,24,Therapeutic Yoga,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,ranjanbala dil amin,LS-1000,2017
-LS,1000,25,Therapeutic Yoga,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-1000,2017
-LS,1000,26,Therapeutic Yoga,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,LS-1000,2017
-LS,1000,27,Beg. Non-Competitive Karate,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,june pilcher,LS-1000,2017
-LS,1410,1,Top Rope Climbing,0.79,0.07,0.0,0.0,0.14,0.0,0.0,0.0,michelle tuday,LS-1410,2017
-LS,1410,3,Top Rope Climbing,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,michelle tuday,LS-1410,2017
-LS,1410,5,Top Rope Climbing,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,michelle tuday,LS-1410,2017
-LS,1410,6,Top Rope Climbing,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,michelle tuday,LS-1410,2017
-LS,1410,8,Top Rope Climbing,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,corey newe winstead,LS-1410,2017
-LS,1450,5,Camping/Backpacking,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,sarah wilcer,LS-1450,2017
-LS,1560,16,Riflery,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,LS-1560,2017
-LS,1560,19,Riflery,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,dominic cirocco,LS-1560,2017
-LS,1570,9,Shotgun Sports,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james gill,LS-1570,2017
-LS,1580,5,Archery,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,herbert strickland,LS-1580,2017
-LS,1640,2,Whitewater Kayaking,0.5,0.2,0.0,0.0,0.0,0.0,0.0,0.3,robert taylor,LS-1640,2017
-LS,1850,2,Bowling,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,adam perr middleton,LS-1850,2017
-LS,1850,4,Bowling,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kathryn ly mitchell,LS-1850,2017
-LS,1850,7,Bowling,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,megan elizabet cato,LS-1850,2017
-LS,1850,8,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,adam perr middleton,LS-1850,2017
-LS,1850,9,Bowling,0.82,0.04,0.0,0.04,0.0,0.0,0.0,0.11,megan elizabet cato,LS-1850,2017
-LS,1940,2,Racquetball,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,raymond petersen,LS-1940,2017
-LS,1940,3,Racquetball,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,charlie white,LS-1940,2017
-LS,1980,9,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,wesley scott womble,LS-1980,2017
-LS,2200,3,Shag,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,broadus fleming,LS-2200,2017
-LS,2200,7,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,matthew lee krabbe,LS-2200,2017
-LS,2270,1,Intro to Swing Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,paul hoke,LS-2270,2017
-LS,2320,1,Core Training,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,LS-2320,2017
-LS,2320,2,Core Training,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,LS-2320,2017
-LS,2320,3,Core Training,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-2320,2017
-LS,2350,1,Basic Yoga,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,silica eliza larkin,LS-2350,2017
-LS,2350,3,Basic Yoga,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,LS-2350,2017
-LS,2350,4,Basic Yoga,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2017
-LS,2350,5,Basic Yoga,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,renee warren gahan,LS-2350,2017
-LS,2350,6,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,LS-2350,2017
-LS,2350,7,Basic Yoga,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,kayla lee wardlaw,LS-2350,2017
-LS,2380,1,Vinyasa Flow Yoga,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,LS-2380,2017
-LS,2380,3,Vinyasa Flow Yoga,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,LS-2380,2017
-LS,2420,1,Meditation and Relax,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2017
-LS,2420,3,Meditation and Relax,0.7,0.13,0.04,0.04,0.0,0.0,0.0,0.09,renee warren gahan,LS-2420,2017
-LS,2420,4,Meditation and Relax,0.76,0.14,0.05,0.0,0.0,0.0,0.0,0.05,renee warren gahan,LS-2420,2017
-LS,2420,5,Meditation and Relax,0.91,0.0,0.0,0.04,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-2420,2017
-LS,2420,8,Meditation and Relax,0.84,0.08,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-2420,2017
-LS,2450,2,Pilates,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,LS-2450,2017
-LS,2450,4,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-2450,2017
-LS,2450,6,Pilates,0.83,0.09,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,LS-2450,2017
-LS,2460,1,Intermediate Pilates,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,melanie ivey job,LS-2460,2017
-LS,2700,1,Sports Officiating,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,christopher war cox,LS-2700,2017
-LS,2750,7,First Aid/Cpr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,christopher loomis,LS-2750,2017
-LS,2750,8,First Aid/Cpr,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,christopher loomis,LS-2750,2017
-LS,2780,3,Wilderness First Aid,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,emily grace turke,LS-2780,2017
-LS,2910,1,Outdoor Leadership,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,emily grace turke,LS-2910,2017
-LS,3580,1,Advanced Shotgun Skeet,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,james gill,LS-3580,2017
-MATH,1010,1,Essen Math for Informed Soc,0.32,0.48,0.12,0.04,0.0,0.0,0.0,0.04,marilyn reba,MATH-1010,2017
-MATH,1010,2,Essen Math for Informed Soc,0.53,0.26,0.18,0.0,0.0,0.0,0.0,0.03,marilyn reba,MATH-1010,2017
-MATH,1010,3,Essen Math for Informed Soc,0.58,0.14,0.14,0.03,0.08,0.0,0.0,0.03,marilyn reba,MATH-1010,2017
-MATH,1010,4,Essen Math for Informed Soc,0.53,0.31,0.13,0.0,0.0,0.0,0.0,0.03,marilyn reba,MATH-1010,2017
-MATH,1020,1,Business Calculus I,0.09,0.27,0.34,0.05,0.2,0.0,0.0,0.05,tony thanh nguyen,MATH-1020,2017
-MATH,1020,2,Business Calculus I,0.21,0.13,0.21,0.13,0.19,0.0,0.0,0.13,michael thoma cowen,MATH-1020,2017
-MATH,1020,3,Business Calculus I,0.2,0.28,0.22,0.07,0.11,0.0,0.0,0.13,tony thanh nguyen,MATH-1020,2017
-MATH,1020,4,Business Calculus I,0.17,0.21,0.21,0.12,0.17,0.0,0.0,0.12,todd fenstermacher,MATH-1020,2017
-MATH,1020,5,Business Calculus I,0.09,0.18,0.4,0.13,0.18,0.0,0.0,0.02,stephen garth,MATH-1020,2017
-MATH,1020,6,Business Calculus I,0.15,0.35,0.24,0.07,0.11,0.0,0.0,0.09,randy davidson,MATH-1020,2017
-MATH,1020,7,Business Calculus I,0.17,0.29,0.27,0.07,0.07,0.0,0.0,0.12,marion hanna,MATH-1020,2017
-MATH,1020,8,Business Calculus I,0.14,0.28,0.33,0.07,0.16,0.0,0.0,0.02,randy davidson,MATH-1020,2017
-MATH,1020,9,Business Calculus I,0.21,0.5,0.12,0.1,0.07,0.0,0.0,0.0,marion hanna,MATH-1020,2017
-MATH,1020,10,Business Calculus I,0.17,0.32,0.29,0.1,0.1,0.0,0.0,0.02,peter westerbaan,MATH-1020,2017
-MATH,1020,11,Business Calculus I,0.21,0.37,0.26,0.02,0.09,0.0,0.0,0.05,john william grant,MATH-1020,2017
-MATH,1020,12,Business Calculus I,0.11,0.45,0.23,0.0,0.09,0.0,0.0,0.11,randy davidson,MATH-1020,2017
-MATH,1020,13,Business Calculus I,0.05,0.17,0.26,0.19,0.21,0.0,0.0,0.12,javier ruiz ramirez,MATH-1020,2017
-MATH,1020,16,Business Calculus I,0.11,0.13,0.36,0.16,0.13,0.0,0.0,0.11,bryce pruitt,MATH-1020,2017
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.44,0.54,0.03,stefan adam bock,MATH-1040,2017
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.56,0.12,nicholas ahlstrom,MATH-1040,2017
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.58,0.33,0.09,charity watson,MATH-1040,2017
-MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.71,0.2,0.09,charity watson,MATH-1050,2017
-MATH,1060,1,Calculus of One Variable I,0.0,0.16,0.32,0.14,0.27,0.0,0.0,0.11,judith cottingham,MATH-1060,2017
-MATH,1060,2,Calculus of One Variable I,0.02,0.33,0.2,0.16,0.22,0.0,0.0,0.07,judith cottingham,MATH-1060,2017
-MATH,1060,3,Calculus of One Variable I,0.06,0.13,0.24,0.15,0.25,0.0,0.0,0.18,allen anderso guest,MATH-1060,2017
-MATH,1060,5,Calculus of One Variable I,0.1,0.19,0.23,0.09,0.26,0.0,0.0,0.14,allen anderso guest,MATH-1060,2017
-MATH,1060,7,Calculus of One Variable I,0.08,0.17,0.11,0.08,0.44,0.0,0.0,0.11,thowhida akther,MATH-1060,2017
-MATH,1060,500,Calculus of One Variable I,0.59,0.21,0.21,0.0,0.0,0.0,0.0,0.0,laura dostert,MATH-1060,2017
-MATH,1070,1,Differen and Integral Calculus,0.14,0.34,0.34,0.07,0.07,0.0,0.0,0.03,donna simms,MATH-1070,2017
-MATH,1070,2,Differen and Integral Calculus,0.24,0.44,0.32,0.0,0.0,0.0,0.0,0.0,donna simms,MATH-1070,2017
-MATH,1070,3,Differen and Integral Calculus,0.07,0.37,0.37,0.05,0.07,0.0,0.0,0.07,chase norman joyner,MATH-1070,2017
-MATH,1070,5,Differen and Integral Calculus,0.08,0.23,0.33,0.23,0.03,0.0,0.0,0.1,stefan adam bock,MATH-1070,2017
-MATH,1070,7,Differen and Integral Calculus,0.03,0.28,0.34,0.28,0.03,0.0,0.0,0.03,rebecca ramos,MATH-1070,2017
-MATH,1080,1,Calculus of One Variable II,0.13,0.31,0.31,0.09,0.13,0.0,0.0,0.03,beth novick,MATH-1080,2017
-MATH,1080,4,Calculus of One Variable II,0.15,0.41,0.1,0.08,0.13,0.0,0.0,0.13,sergey charnyi,MATH-1080,2017
-MATH,1080,5,Calculus of One Variable II,0.19,0.35,0.19,0.07,0.14,0.0,0.0,0.07,mengying xiao,MATH-1080,2017
-MATH,1080,7,Calculus of One Variable II,0.2,0.24,0.2,0.09,0.16,0.0,0.0,0.11,fun choi john chan,MATH-1080,2017
-MATH,1080,8,Calculus of One Variable II,0.18,0.34,0.2,0.14,0.09,0.0,0.0,0.05,honghai xu,MATH-1080,2017
-MATH,1080,10,Calculus of One Variable II,0.24,0.41,0.2,0.04,0.04,0.0,0.0,0.07,garrett dranichak,MATH-1080,2017
-MATH,1080,11,Calculus of One Variable II,0.16,0.38,0.24,0.11,0.04,0.0,0.0,0.07,honghai xu,MATH-1080,2017
-MATH,1080,12,Calculus of One Variable II,0.13,0.29,0.24,0.07,0.09,0.0,0.0,0.18,rui gong,MATH-1080,2017
-MATH,1080,13,Calculus of One Variable II,0.14,0.32,0.25,0.11,0.11,0.0,0.0,0.07,alistair bentley,MATH-1080,2017
-MATH,1080,16,Calculus of One Variable II,0.13,0.3,0.22,0.11,0.13,0.0,0.0,0.11,camille zerfas,MATH-1080,2017
-MATH,1080,100,Calc of One Variable II (HON),0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,beth novick,MATH-1080,2017
-MATH,1080,203,Calc of One Variable II (RiSE),0.2,0.28,0.33,0.13,0.0,0.0,0.0,0.07,kara ail stasikelis,MATH-1080,2017
-MATH,1080,203,Calc of One Variable II,0.2,0.28,0.33,0.13,0.0,0.0,0.0,0.07,kara ail stasikelis,MATH-1080,2017
-MATH,1080,206,Calc of One Variable II (RiSE),0.21,0.21,0.31,0.05,0.15,0.0,0.0,0.08,honghai xu,MATH-1080,2017
-MATH,1080,206,Calc of One Variable II,0.21,0.21,0.31,0.05,0.15,0.0,0.0,0.08,honghai xu,MATH-1080,2017
-MATH,1080,209,Calc of One Variable II,0.2,0.32,0.17,0.12,0.07,0.0,0.0,0.12,jonathon leverenz,MATH-1080,2017
-MATH,1080,209,Calc of One Variable II (RiSE),0.2,0.32,0.17,0.12,0.07,0.0,0.0,0.12,jonathon leverenz,MATH-1080,2017
-MATH,1080,214,Calc of One Variable II (RiSE),0.28,0.22,0.35,0.02,0.11,0.0,0.0,0.02,lauren pai mcintyre,MATH-1080,2017
-MATH,1080,214,Calc of One Variable II,0.28,0.22,0.35,0.02,0.11,0.0,0.0,0.02,lauren pai mcintyre,MATH-1080,2017
-MATH,1080,217,Calc of One Variable II,0.28,0.35,0.15,0.11,0.02,0.0,0.0,0.09,audrey nico devries,MATH-1080,2017
-MATH,1080,218,Calc of One Variable II,0.24,0.37,0.2,0.09,0.09,0.0,0.0,0.02,ryan grove,MATH-1080,2017
-MATH,1150,1,Contemp Math for Elem Teach I,0.5,0.27,0.19,0.0,0.04,0.0,0.0,0.0,charity watson,MATH-1150,2017
-MATH,1160,1,Contemp Math for Elem Teach II,0.74,0.2,0.06,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1160,2017
-MATH,1160,2,Contemp Math for Elem Teach II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,MATH-1160,2017
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.84,0.12,0.04,marion hanna,MATH-1990,2017
-MATH,2060,1,Calculus of Several Variables,0.23,0.4,0.14,0.11,0.09,0.0,0.0,0.03,hiram lopez valdez,MATH-2060,2017
-MATH,2060,2,Calculus of Several Variables,0.15,0.32,0.09,0.06,0.18,0.0,0.0,0.21,timothy fra parrott,MATH-2060,2017
-MATH,2060,3,Calculus of Several Variables,0.32,0.36,0.19,0.04,0.06,0.0,0.0,0.02,hiram lopez valdez,MATH-2060,2017
-MATH,2060,4,Calculus of Several Variables,0.46,0.38,0.05,0.08,0.03,0.0,0.0,0.0,muhamm mohebujjaman,MATH-2060,2017
-MATH,2060,5,Calculus of Several Variables,0.11,0.21,0.25,0.18,0.11,0.0,0.0,0.14,timothy fra parrott,MATH-2060,2017
-MATH,2060,6,Calculus of Several Variables,0.08,0.56,0.19,0.0,0.11,0.0,0.0,0.06,sofya alekseeva,MATH-2060,2017
-MATH,2060,7,Calculus of Several Variables,0.19,0.5,0.19,0.06,0.03,0.0,0.0,0.03,sofya alekseeva,MATH-2060,2017
-MATH,2060,8,Calculus of Several Variables,0.44,0.33,0.1,0.04,0.04,0.0,0.0,0.04,martin joha schmoll,MATH-2060,2017
-MATH,2060,9,Calculus of Several Variables,0.13,0.45,0.24,0.08,0.05,0.0,0.0,0.05,sofya alekseeva,MATH-2060,2017
-MATH,2060,10,Calculus of Several Variables,0.0,0.21,0.16,0.11,0.37,0.0,0.0,0.16,jonathon leverenz,MATH-2060,2017
-MATH,2060,500,Calculus of Several Variables,0.4,0.27,0.27,0.07,0.0,0.0,0.0,0.0,brian gloor,MATH-2060,2017
-MATH,2070,1,Business Calculus II,0.28,0.38,0.2,0.13,0.0,0.0,0.0,0.03,jennifer mari hanna,MATH-2070,2017
-MATH,2070,2,Business Calculus II,0.3,0.45,0.2,0.0,0.03,0.0,0.0,0.03,tony thanh nguyen,MATH-2070,2017
-MATH,2070,3,Business Calculus II,0.23,0.33,0.18,0.15,0.03,0.0,0.0,0.1,thanh thien to,MATH-2070,2017
-MATH,2070,4,Business Calculus II,0.53,0.28,0.13,0.08,0.0,0.0,0.0,0.0,jennifer mari hanna,MATH-2070,2017
-MATH,2070,5,Business Calculus II,0.28,0.38,0.2,0.1,0.05,0.0,0.0,0.0,allison stoddard,MATH-2070,2017
-MATH,2070,6,Business Calculus II,0.33,0.25,0.23,0.08,0.13,0.0,0.0,0.0,tony thanh nguyen,MATH-2070,2017
-MATH,2070,7,Business Calculus II,0.65,0.15,0.13,0.05,0.0,0.0,0.0,0.03,jennifer mari hanna,MATH-2070,2017
-MATH,2070,8,Business Calculus II,0.29,0.24,0.21,0.1,0.1,0.0,0.0,0.07,judith irene mcknew,MATH-2070,2017
-MATH,2070,9,Business Calculus II,0.23,0.36,0.13,0.08,0.05,0.0,0.0,0.15,judith irene mcknew,MATH-2070,2017
-MATH,2070,10,Business Calculus II,0.2,0.39,0.24,0.1,0.05,0.0,0.0,0.02,daniel kuzbary,MATH-2070,2017
-MATH,2070,11,Business Calculus II,0.31,0.36,0.1,0.08,0.1,0.0,0.0,0.05,jing li,MATH-2070,2017
-MATH,2070,12,Business Calculus II,0.38,0.28,0.15,0.05,0.08,0.0,0.0,0.05,neil calkin,MATH-2070,2017
-MATH,2070,13,Business Calculus II,0.35,0.35,0.18,0.03,0.08,0.0,0.0,0.03,haodong li,MATH-2070,2017
-MATH,2070,14,Business Calculus II,0.23,0.36,0.36,0.0,0.0,0.0,0.0,0.05,shanshan jia,MATH-2070,2017
-MATH,2070,15,Business Calculus II,0.25,0.35,0.23,0.05,0.0,0.0,0.0,0.13,aaro ramirez flores,MATH-2070,2017
-MATH,2070,16,Business Calculus II,0.4,0.35,0.08,0.08,0.08,0.0,0.0,0.03,stephen peele,MATH-2070,2017
-MATH,2080,1,Intro to Ordin Diff Equations,0.09,0.3,0.17,0.13,0.04,0.0,0.0,0.26,terri johnson,MATH-2080,2017
-MATH,2080,2,Intro to Ordin Diff Equations,0.37,0.49,0.09,0.0,0.06,0.0,0.0,0.0,oleg yordanov,MATH-2080,2017
-MATH,2080,4,Intro to Ordin Diff Equations,0.08,0.05,0.26,0.03,0.24,0.0,0.0,0.34,terri johnson,MATH-2080,2017
-MATH,2080,5,Intro to Ordin Diff Equations,0.53,0.21,0.21,0.03,0.0,0.0,0.0,0.03,timothy ch teitloff,MATH-2080,2017
-MATH,2080,6,Intro to Ordin Diff Equations,0.47,0.37,0.05,0.05,0.0,0.0,0.0,0.07,oleg yordanov,MATH-2080,2017
-MATH,2080,7,Intro to Ordin Diff Equations,0.06,0.15,0.21,0.06,0.15,0.0,0.0,0.38,terri johnson,MATH-2080,2017
-MATH,2080,8,Intro to Ordin Diff Equations,0.26,0.26,0.09,0.18,0.15,0.0,0.0,0.06,julie lassiter,MATH-2080,2017
-MATH,2080,9,Intro to Ordin Diff Equations,0.62,0.1,0.23,0.0,0.0,0.0,0.0,0.05,timothy ch teitloff,MATH-2080,2017
-MATH,2080,10,Intro to Ordin Diff Equations,0.33,0.36,0.13,0.08,0.1,0.0,0.0,0.0,irina viktorova,MATH-2080,2017
-MATH,2080,11,Intro to Ordin Diff Equations,0.25,0.19,0.16,0.19,0.16,0.0,0.0,0.06,julie lassiter,MATH-2080,2017
-MATH,2080,12,Intro to Ordin Diff Equations,0.36,0.27,0.21,0.06,0.0,0.0,0.0,0.09,shari prevost,MATH-2080,2017
-MATH,2080,13,Intro to Ordin Diff Equations,0.28,0.35,0.2,0.08,0.08,0.0,0.0,0.03,irina viktorova,MATH-2080,2017
-MATH,2080,14,Intro to Ordin Diff Equations,0.24,0.29,0.24,0.0,0.08,0.0,0.0,0.16,jonathon leverenz,MATH-2080,2017
-MATH,2080,15,Intro to Ordin Diff Equations,0.19,0.36,0.17,0.03,0.14,0.0,0.0,0.11,shari prevost,MATH-2080,2017
-MATH,2080,16,Intro to Ordin Diff Equations,0.38,0.2,0.29,0.09,0.0,0.0,0.0,0.04,irina viktorova,MATH-2080,2017
-MATH,2080,17,Intro to Ordin Diff Equations,0.19,0.25,0.28,0.09,0.06,0.0,0.0,0.13,jeong rock yoon,MATH-2080,2017
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.62,0.31,0.04,0.0,0.04,0.0,0.0,0.0,brian fralix,MATH-2080,2017
-MATH,2160,1,Geometry for Elem Sch Teachers,0.6,0.25,0.1,0.05,0.0,0.0,0.0,0.0,allison stoddard,MATH-2160,2017
-MATH,3020,1,Stat for Science & Engineering,0.33,0.4,0.14,0.05,0.05,0.0,0.0,0.02,william bridges,MATH-3020,2017
-MATH,3020,2,Stat for Science & Engineering,0.66,0.29,0.03,0.0,0.0,0.0,0.0,0.03,xiyan tan,MATH-3020,2017
-MATH,3020,3,Stat for Science & Engineering,0.54,0.18,0.18,0.03,0.08,0.0,0.0,0.0,yisu jia,MATH-3020,2017
-MATH,3020,4,Stat for Science & Engineering,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,brandon gra goodell,MATH-3020,2017
-MATH,3020,5,Stat for Science & Engineering,0.5,0.31,0.12,0.02,0.05,0.0,0.0,0.0,"koshy chenthittayil,",MATH-3020,2017
-MATH,3020,6,Stat for Science & Engineering,0.35,0.32,0.11,0.11,0.05,0.0,0.0,0.05,prab withana gamage,MATH-3020,2017
-MATH,3020,7,Stat for Science & Engineering,0.4,0.33,0.12,0.07,0.07,0.0,0.0,0.0,yinggu bao,MATH-3020,2017
-MATH,3020,8,Stat for Science & Engineering,0.25,0.42,0.22,0.06,0.03,0.0,0.0,0.03,ellen hepfe breazel,MATH-3020,2017
-MATH,3020,9,Stat for Science & Engineering,0.3,0.33,0.12,0.0,0.09,0.0,0.0,0.15,paul james cubre,MATH-3020,2017
-MATH,3080,1,College Geometry,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,carlos gomez,MATH-3080,2017
-MATH,3110,1,Linear Algebra,0.45,0.18,0.24,0.08,0.03,0.0,0.0,0.03,amy christine grady,MATH-3110,2017
-MATH,3110,2,Linear Algebra,0.15,0.38,0.15,0.18,0.05,0.0,0.0,0.08,amy christine grady,MATH-3110,2017
-MATH,3110,3,Linear Algebra,0.21,0.3,0.12,0.09,0.12,0.0,0.0,0.15,xuhong gao,MATH-3110,2017
-MATH,3110,4,Linear Algebra,0.3,0.5,0.1,0.05,0.05,0.0,0.0,0.0,hui xue,MATH-3110,2017
-MATH,3110,5,Linear Algebra,0.11,0.46,0.17,0.06,0.14,0.0,0.0,0.06,michael adam burr,MATH-3110,2017
-MATH,3110,6,Linear Algebra,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,wayne goddard,MATH-3110,2017
-MATH,3110,7,Linear Algebra,0.24,0.24,0.21,0.09,0.06,0.0,0.0,0.15,neil calkin,MATH-3110,2017
-MATH,3110,200,Linear Algebra,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,beth novick,MATH-3110,2017
-MATH,3150,1,Adv Top in Math for Elem Teach,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,MATH-3150,2017
-MATH,3190,1,Introduction to Proof,0.1,0.29,0.19,0.1,0.0,0.0,0.0,0.33,james ba coykendall,MATH-3190,2017
-MATH,3190,2,Introduction to Proof,0.18,0.36,0.32,0.05,0.05,0.0,0.0,0.05,james ba coykendall,MATH-3190,2017
-MATH,3600,1,Intermediate Math Computing,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,mark cawood,MATH-3600,2017
-MATH,3600,2,Intermediate Math Computing,0.67,0.17,0.0,0.06,0.06,0.0,0.0,0.06,mark cawood,MATH-3600,2017
-MATH,3650,1,Numerical Mthds for Engineers,0.2,0.26,0.17,0.14,0.14,0.0,0.0,0.09,fei xue,MATH-3650,2017
-MATH,3650,2,Numerical Mthds for Engineers,0.33,0.21,0.29,0.08,0.04,0.0,0.0,0.04,fei xue,MATH-3650,2017
-MATH,3650,3,Numerical Mthds for Engineers,0.53,0.29,0.06,0.0,0.06,0.0,0.0,0.06,timo johann heister,MATH-3650,2017
-MATH,3650,4,Numerical Mthds for Engineers,0.35,0.19,0.15,0.08,0.04,0.0,0.0,0.19,christopher cox,MATH-3650,2017
-MATH,4000,1,Theory of Probability,0.28,0.31,0.18,0.1,0.08,0.0,0.0,0.05,ling ma,MATH-4000,2017
-MATH,4030,1,Intro to Statistical Theory,0.36,0.45,0.14,0.05,0.0,0.0,0.0,0.0,xiaoqian sun,MATH-4030,2017
-MATH,4060,1,Sampling Theory and Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,MATH-4060,2017
-MATH,4070,1,Regress & Time-Series Analysis,0.45,0.24,0.21,0.03,0.0,0.0,0.0,0.07,colin gallagher,MATH-4070,2017
-MATH,4100,1,Number Theory,0.5,0.1,0.2,0.1,0.0,0.0,0.0,0.1,hui xue,MATH-4100,2017
-MATH,4120,1,Algebra I,0.08,0.11,0.39,0.08,0.06,0.0,0.0,0.28,sea sather-wagstaff,MATH-4120,2017
-MATH,4190,1,Discrete Math Structures I,0.57,0.25,0.09,0.02,0.05,0.0,0.0,0.02,beth novick,MATH-4190,2017
-MATH,4310,1,Theory of Interest,0.44,0.39,0.11,0.0,0.06,0.0,0.0,0.0, erwin walker,MATH-4310,2017
-MATH,4320,1,Actuarial Science Seminar II,0.6,0.07,0.27,0.0,0.0,0.0,0.0,0.07, erwin walker,MATH-4320,2017
-MATH,4340,1,Adv Engineering Mathematics,0.15,0.15,0.38,0.12,0.15,0.0,0.0,0.04,vincent ervin,MATH-4340,2017
-MATH,4340,2,Adv Engineering Mathematics,0.06,0.16,0.38,0.13,0.09,0.0,0.0,0.19,eleanor jenkins,MATH-4340,2017
-MATH,4400,1,Linear Programming,0.31,0.27,0.19,0.15,0.0,0.0,0.0,0.08,boshi yang,MATH-4400,2017
-MATH,4410,1,Intro to Stochastic Models,0.41,0.24,0.35,0.0,0.0,0.0,0.0,0.0,peter kiessler,MATH-4410,2017
-MATH,4530,1,Advanced Calculus I,0.32,0.05,0.21,0.16,0.11,0.0,0.0,0.16,james peterson,MATH-4530,2017
-MATH,4540,1,Advanced Calculus II,0.25,0.32,0.21,0.14,0.04,0.0,0.0,0.04,james peterson,MATH-4540,2017
-MATH,4600,1,Intro to Numerical Analysis I,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,eleanor jenkins,MATH-4600,2017
-MATH,6340,1,Adv Engineering Mathematics,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,vincent ervin,MATH-6340,2017
-MATH,8030,1,Stochastic Processes,0.55,0.36,0.0,0.0,0.05,0.0,0.0,0.05,xin liu,MATH-8030,2017
-MATH,8040,1,Statistical Inference,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,christopher mcmahan,MATH-8040,2017
-MATH,8050,1,Data Analysis,0.42,0.47,0.0,0.0,0.0,0.0,0.0,0.11,calvin williams,MATH-8050,2017
-MATH,8090,1,Time Series Analysis,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-8090,2017
-MATH,8100,1,Mathematical Programming,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,MATH-8100,2017
-MATH,8130,1,Advanced Linear Programming,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,MATH-8130,2017
-MATH,8210,1,Linear Analysis,0.33,0.56,0.0,0.0,0.11,0.0,0.0,0.0,taufiquar rahm khan,MATH-8210,2017
-MATH,8220,1,Measure and Integration,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,martin joha schmoll,MATH-8220,2017
-MATH,8260,1,Partial Differential Equations,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,qingshan chen,MATH-8260,2017
-MATH,8530,1,Matrix Analysis,0.48,0.4,0.04,0.0,0.0,0.0,0.0,0.08,matthew macauley,MATH-8530,2017
-MATH,8600,1,Intro to Scientific Computing,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,qingshan chen,MATH-8600,2017
-MATH,8660,1,Finite Element Method,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,vincent ervin,MATH-8660,2017
-MATH,9000,2,Prof Devel in Math Sciences,0.0,0.0,0.0,0.0,0.0,0.91,0.04,0.04,meredith nicol burr,MATH-9000,2017
-MBA,8030,1,Stat Analy of Bus Op,0.3,0.35,0.16,0.0,0.16,0.0,0.0,0.02,janis miller,MBA-8030,2017
-MBA,8060,1,Operations Mgt,0.58,0.33,0.04,0.0,0.02,0.0,0.0,0.02, sridharan,MBA-8060,2017
-MBA,8060,20,Operations Mgt,0.69,0.15,0.12,0.0,0.04,0.0,0.0,0.0, sridharan,MBA-8060,2017
-MBA,8070,1,Financial Management,0.56,0.3,0.14,0.0,0.0,0.0,0.0,0.0,melvin stith,MBA-8070,2017
-MBA,8070,2,Financial Management,0.44,0.39,0.12,0.0,0.0,0.0,0.0,0.05,melvin stith,MBA-8070,2017
-MBA,8090,1,Org Beh & Hum Res Mg,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.02,kristin dam scott,MBA-8090,2017
-MBA,8090,2,Org Beh & Hum Res Mg,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,kristin dam scott,MBA-8090,2017
-MBA,8190,1,Intro to Acc and Fin,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,MBA-8190,2017
-MBA,8190,2,Intro to Acc and Fin,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,annieka philo,MBA-8190,2017
-MBA,8290,1,Marketing Foundation,0.68,0.23,0.04,0.0,0.0,0.0,0.0,0.04,gary hunter,MBA-8290,2017
-MBA,8330,1,Real Estate Investmt,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,MBA-8330,2017
-MBA,8370,1,Legal Environ of Bus,0.48,0.53,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2017
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,MBA-8400,2017
-MBA,8430,10,Entrepreneurial Accounting,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,MBA-8430,2017
-MBA,8450,1,Technology & Innovation Mgt,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8450,2017
-MBA,8470,1,New Venture Creation,0.64,0.27,0.05,0.0,0.05,0.0,0.0,0.0,elizabeth er powell,MBA-8470,2017
-MBA,8510,10,Bus Operations & Logistics,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,james liddle,MBA-8510,2017
-MBA,8540,1,Mgrl Accounting,0.39,0.57,0.05,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,MBA-8540,2017
-MBA,8540,2,Mgrl Accounting,0.56,0.4,0.02,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,MBA-8540,2017
-MBA,8540,3,Mgrl Accounting,0.26,0.43,0.22,0.0,0.0,0.0,0.0,0.09,james mil kohlmeyer,MBA-8540,2017
-MBA,8590,1,Mgr Decision Model,0.37,0.3,0.21,0.0,0.05,0.0,0.0,0.07,magda gabriela sava,MBA-8590,2017
-MBA,8590,2,Mgr Decision Model,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,sara elizabet yoder,MBA-8590,2017
-MBA,8600,1,Advanced Marketing Strategy,0.22,0.61,0.17,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2017
-MBA,8610,1,Information Systems,0.28,0.7,0.03,0.0,0.0,0.0,0.0,0.0,varun grover,MBA-8610,2017
-MBA,8610,2,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,MBA-8610,2017
-MBA,8620,1,Managerial Economics,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,MBA-8620,2017
-MBA,8720,1,Entrepr Finance,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,MBA-8720,2017
-MBA,8720,2,Entrepr Finance,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8720,2017
-MBA,8740,1,Managing Cont Impvmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MBA-8740,2017
-MBA,8750,1,Enterprise Develpmnt,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8750,2017
-MBA,8990,1,Advanced Leadership,0.95,0.0,0.02,0.0,0.0,0.0,0.0,0.02,gail depriest,MBA-8990,2017
-MBA,8990,3,Service Innovation,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,aleda marie roth,MBA-8990,2017
-MBA,8990,4,Bus. Sport. Enter.,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,MBA-8990,2017
-MBA,8990,20,Analytics & Application,0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,heshan sun,MBA-8990,2017
-ME,2000,1,Sophomore Seminar,0.92,0.05,0.0,0.0,0.01,0.0,0.0,0.02,donald beasley,ME-2000,2017
-ME,2010,1,Statics & Dynamics,0.06,0.26,0.25,0.14,0.17,0.0,0.0,0.13,marisa kikendal orr,ME-2010,2017
-ME,2010,2,Statics & Dynamics,0.06,0.29,0.17,0.13,0.23,0.0,0.0,0.12,paul joseph,ME-2010,2017
-ME,2030,1,Founda Th/Fl Syst,0.16,0.31,0.27,0.16,0.05,0.0,0.0,0.05,jay ochterbeck,ME-2030,2017
-ME,2030,2,Founda Th/Fl Syst,0.07,0.2,0.4,0.21,0.05,0.0,0.0,0.06,john saylor,ME-2030,2017
-ME,2040,1,Mechanics of Materials,0.36,0.53,0.03,0.02,0.05,0.0,0.0,0.02,jorge iva rodriguez,ME-2040,2017
-ME,2040,2,Mechanics of Materials,0.12,0.49,0.37,0.02,0.0,0.0,0.0,0.0,gang li,ME-2040,2017
-ME,2040,3,Mechanics of Materials,0.33,0.47,0.18,0.0,0.02,0.0,0.0,0.0,garrett pataky,ME-2040,2017
-ME,2040,302,Mechanics of Materials (HON),0.55,0.36,0.0,0.09,0.0,0.0,0.0,0.0,gang li,ME-2040,2017
-ME,2220,2,Mechanical Engineering Lab I,0.53,0.33,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,ME-2220,2017
-ME,2220,3,Mechanical Engineering Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,5,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,6,Mechanical Engineering Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,7,Mechanical Engineering Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,8,Mechanical Engineering Lab I,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,9,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,10,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,13,Mechanical Engineering Lab I,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,2220,14,Mechanical Engineering Lab I,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,todd schweisinger,ME-2220,2017
-ME,2220,15,Mechanical Engineering Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-2220,2017
-ME,3030,1,Thermodynamics,0.23,0.55,0.15,0.05,0.0,0.0,0.0,0.03,yiqiang han,ME-3030,2017
-ME,3030,2,Thermodynamics,0.17,0.6,0.17,0.02,0.0,0.0,0.0,0.05,yiqiang han,ME-3030,2017
-ME,3040,1,Heat Transfer,0.08,0.37,0.34,0.05,0.06,0.0,0.0,0.1,jean-marc delhaye,ME-3040,2017
-ME,3040,2,Heat Transfer,0.19,0.32,0.4,0.04,0.04,0.0,0.0,0.01,jean-marc delhaye,ME-3040,2017
-ME,3050,1,Model/an Dy Syst,0.2,0.47,0.2,0.0,0.08,0.0,0.0,0.05,phanin tallapragada,ME-3050,2017
-ME,3050,2,Model/an Dy Syst,0.21,0.5,0.21,0.07,0.01,0.0,0.0,0.0,joshua bostwick,ME-3050,2017
-ME,3060,1,Fund Machine Design,0.54,0.37,0.06,0.0,0.0,0.0,0.0,0.04,oliver myers,ME-3060,2017
-ME,3060,2,Fund Machine Design,0.34,0.44,0.17,0.02,0.01,0.0,0.0,0.01,paul jeffrey meyer,ME-3060,2017
-ME,3070,1,Found of Mechanical Systems,0.6,0.24,0.09,0.0,0.05,0.0,0.0,0.02,jorge iva rodriguez,ME-3070,2017
-ME,3070,2,Found of Mechanical Systems,0.19,0.56,0.22,0.04,0.0,0.0,0.0,0.0,gregory mocko,ME-3070,2017
-ME,3080,1,Fluid Mechanics,0.13,0.58,0.24,0.04,0.0,0.0,0.0,0.0,daniel fant,ME-3080,2017
-ME,3080,2,Fluid Mechanics,0.23,0.38,0.27,0.08,0.02,0.0,0.0,0.02,xiangchun xuan,ME-3080,2017
-ME,3100,1,Thermo/Heat Transfer,0.39,0.39,0.13,0.0,0.0,0.0,0.0,0.09,yiqiang han,ME-3100,2017
-ME,3120,1,Manuf Processes,0.19,0.47,0.3,0.03,0.01,0.0,0.0,0.01,hong seok choi,ME-3120,2017
-ME,3330,1,Mechanical Engineering Lab II,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,3330,2,Mechanical Engineering Lab II,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-3330,2017
-ME,3330,3,Mechanical Engineering Lab II,0.25,0.63,0.06,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-3330,2017
-ME,3330,4,Mechanical Engineering Lab II,0.29,0.5,0.07,0.0,0.14,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,3330,5,Mechanical Engineering Lab II,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,3330,6,Mechanical Engineering Lab II,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,ME-3330,2017
-ME,3330,7,Mechanical Engineering Lab II,0.31,0.5,0.19,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,3330,8,Mechanical Engineering Lab II,0.27,0.47,0.2,0.0,0.07,0.0,0.0,0.0,todd schweisinger,ME-3330,2017
-ME,4000,1,Senior Seminar,0.84,0.12,0.01,0.03,0.0,0.0,0.0,0.0,donald beasley,ME-4000,2017
-ME,4010,1,Mech Engr Design,0.54,0.34,0.1,0.0,0.02,0.0,0.0,0.0,cameron turner,ME-4010,2017
-ME,4020,2,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,ME-4020,2017
-ME,4020,3,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lonny thompson,ME-4020,2017
-ME,4020,4,Intern in Engr Des,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-4020,2017
-ME,4020,5,Intern in Engr Des,0.4,0.27,0.33,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2017
-ME,4020,6,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,ME-4020,2017
-ME,4020,7,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-4020,2017
-ME,4020,9,Intern in Engr Des,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,ME-4020,2017
-ME,4030,1,Control Dynamic Systems,0.31,0.23,0.29,0.14,0.03,0.0,0.0,0.0,suyi li,ME-4030,2017
-ME,4030,2,Control Dynamic Systems,0.35,0.53,0.1,0.03,0.0,0.0,0.0,0.0,yue wang,ME-4030,2017
-ME,4170,1,Mechatronic Sys,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4170,2017
-ME,4180,1,F E A in M E Design,0.24,0.48,0.2,0.08,0.0,0.0,0.0,0.0,gang li,ME-4180,2017
-ME,4220,1,Design Gas Turbines,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,abhijit som,ME-4220,2017
-ME,4260,1,Nuclear Energy,0.36,0.36,0.29,0.0,0.0,0.0,0.0,0.0,richard watkins,ME-4260,2017
-ME,4300,1,Mech Comp Materials,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,huijuan zhao,ME-4300,2017
-ME,4440,1,Mechanical Engineering Lab III,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2017
-ME,4440,2,Mechanical Engineering Lab III,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2017
-ME,4440,3,Mechanical Engineering Lab III,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2017
-ME,4440,4,Mechanical Engineering Lab III,0.08,0.83,0.08,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2017
-ME,4440,5,Mechanical Engineering Lab III,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2017
-ME,4440,7,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2017
-ME,4930,5,Sel.Topics in ME - Rapid Proto,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4930,2017
-ME,4930,34,Selected Topics ME (Cardio),0.15,0.62,0.15,0.0,0.0,0.0,0.0,0.08,ethan kung,ME-4930,2017
-ME,4930,36,Sel. Topics in ME (BioDesgin),0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,michael porter,ME-4930,2017
-ME,4930,39,Sel Topics ME (Solar Energy),0.4,0.46,0.06,0.0,0.0,0.0,0.0,0.09,daniel fant,ME-4930,2017
-ME,6300,1,Mech Comp Materials,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,ME-6300,2017
-ME,6320,1,Adv Strength of Matl,0.14,0.71,0.14,0.0,0.0,0.0,0.0,0.0,michael porter,ME-6320,2017
-ME,8120,1,Exp Meth Thermal Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,ME-8120,2017
-ME,8190,1,Cp Meth in Therm Sc,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,ME-8190,2017
-ME,8200,1,Mod Cont Engr,0.47,0.36,0.14,0.0,0.0,0.0,0.0,0.03,ardalan vahidi,ME-8200,2017
-ME,8200,401,Mod Cont Engr,0.23,0.54,0.15,0.0,0.08,0.0,0.0,0.0,ardalan vahidi,ME-8200,2017
-ME,8310,1,Convective Ht Trans,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,xin zhao,ME-8310,2017
-ME,8370,1,Theory of Elast I,0.26,0.48,0.22,0.0,0.04,0.0,0.0,0.0,nicole gise coutris,ME-8370,2017
-MGT,2010,1,Principles of Management,0.39,0.37,0.17,0.03,0.03,0.0,0.0,0.01,katherine clark,MGT-2010,2017
-MGT,2010,2,Principles of Management,0.45,0.34,0.14,0.03,0.03,0.0,0.0,0.03,katherine clark,MGT-2010,2017
-MGT,2010,3,Principles of Management,0.38,0.31,0.19,0.06,0.03,0.0,0.0,0.03,katherine clark,MGT-2010,2017
-MGT,2010,5,Principles of Management,0.44,0.37,0.15,0.02,0.01,0.0,0.0,0.0,tina robbins,MGT-2010,2017
-MGT,2010,6,Principles of Management,0.36,0.46,0.16,0.0,0.0,0.0,0.0,0.01,tina robbins,MGT-2010,2017
-MGT,2010,7,Principles of Management,0.41,0.41,0.15,0.0,0.0,0.0,0.0,0.03,tina robbins,MGT-2010,2017
-MGT,2010,8,Principles of Management,0.43,0.44,0.06,0.03,0.03,0.0,0.0,0.01,tina robbins,MGT-2010,2017
-MGT,2010,10,Principles of Management,0.3,0.35,0.26,0.07,0.02,0.0,0.0,0.0,ashley will parnell,MGT-2010,2017
-MGT,2010,11,Principles of Management,0.28,0.44,0.21,0.05,0.0,0.0,0.0,0.03,ashley will parnell,MGT-2010,2017
-MGT,2180,1,Management PC Applications,0.52,0.28,0.11,0.04,0.05,0.0,0.0,0.01,ryan toole,MGT-2180,2017
-MGT,2180,2,Management PC Applications,0.51,0.36,0.06,0.02,0.02,0.0,0.0,0.02,ryan toole,MGT-2180,2017
-MGT,2180,3,Management PC Applications,0.58,0.29,0.08,0.0,0.02,0.0,0.0,0.03,ryan toole,MGT-2180,2017
-MGT,2180,4,Management PC Applications,0.48,0.34,0.11,0.02,0.02,0.0,0.0,0.04,ryan toole,MGT-2180,2017
-MGT,2970,1,How to Start a Startup,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,john michael hannon,MGT-2970,2017
-MGT,2970,2,How to Start a Startup,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,john michael hannon,MGT-2970,2017
-MGT,2970,4,How to Start a Startup,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,MGT-2970,2017
-MGT,2970,5,CI in Management (Film Study),0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,john michael hannon,MGT-2970,2017
-MGT,3070,1,Human Resource Management,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2017
-MGT,3070,2,Human Resource Management,0.68,0.25,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2017
-MGT,3070,3,Human Resource Management,0.65,0.28,0.05,0.0,0.03,0.0,0.0,0.0,michael cole,MGT-3070,2017
-MGT,3070,4,Human Resource Management,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2017
-MGT,3070,6,Human Resource Management,0.41,0.51,0.05,0.0,0.0,0.0,0.0,0.03,leonard jos spooner,MGT-3070,2017
-MGT,3100,1,Intermed Business Statistics,0.14,0.19,0.2,0.12,0.15,0.0,0.0,0.2,sara elizabet yoder,MGT-3100,2017
-MGT,3100,2,Intermed Business Statistics,0.1,0.24,0.26,0.06,0.16,0.0,0.0,0.18,sara elizabet yoder,MGT-3100,2017
-MGT,3100,3,Intermed Business Statistics,0.5,0.32,0.11,0.05,0.0,0.0,0.0,0.03,wenxi pu,MGT-3100,2017
-MGT,3100,4,Intermed Business Statistics,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,MGT-3100,2017
-MGT,3100,5,Intermed Business Statistics,0.44,0.28,0.18,0.1,0.0,0.0,0.0,0.0,daniel nielubowicz,MGT-3100,2017
-MGT,3100,6,Intermed Business Statistics,0.19,0.28,0.22,0.0,0.11,0.0,0.0,0.19,magda gabriela sava,MGT-3100,2017
-MGT,3100,7,Intermed Business Statistics,0.52,0.27,0.18,0.02,0.0,0.0,0.0,0.0,dan jiang,MGT-3100,2017
-MGT,3120,1,Decision Models for Management,0.45,0.32,0.19,0.0,0.03,0.0,0.0,0.01,mark mcknew,MGT-3120,2017
-MGT,3120,2,Decision Models for Management,0.51,0.25,0.12,0.06,0.03,0.0,0.0,0.03,mark mcknew,MGT-3120,2017
-MGT,3150,1,New Venture Creation,0.38,0.55,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,MGT-3150,2017
-MGT,3180,1,Mgt of Info Systems,0.53,0.43,0.05,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,MGT-3180,2017
-MGT,3180,2,Mgt of Info Systems,0.77,0.16,0.07,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,MGT-3180,2017
-MGT,3180,3,Mgt of Info Systems,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,heshan sun,MGT-3180,2017
-MGT,3180,4,Mgt of Info Systems,0.3,0.6,0.08,0.0,0.03,0.0,0.0,0.0,roopa raman,MGT-3180,2017
-MGT,3500,1,Intro to Business Analytics,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,siyuan li,MGT-3500,2017
-MGT,3900,1,Ops Mgt,0.46,0.15,0.15,0.1,0.05,0.0,0.0,0.08,berna quiroga gomez,MGT-3900,2017
-MGT,3900,2,Ops Mgt,0.13,0.23,0.51,0.1,0.0,0.0,0.0,0.03,niratc tungtisanont,MGT-3900,2017
-MGT,3900,3,Ops Mgt,0.15,0.48,0.25,0.13,0.0,0.0,0.0,0.0,remi charpin,MGT-3900,2017
-MGT,3900,4,Ops Mgt,0.09,0.57,0.28,0.02,0.04,0.0,0.0,0.0,zachary mo leffakis,MGT-3900,2017
-MGT,3900,5,Ops Mgt,0.2,0.1,0.43,0.13,0.08,0.0,0.0,0.08,berna quiroga gomez,MGT-3900,2017
-MGT,4000,2,Mgt of Organizational Behavior,0.73,0.25,0.0,0.0,0.0,0.0,0.0,0.03,michael cole,MGT-4000,2017
-MGT,4000,3,Mgt of Organizational Behavior,0.43,0.28,0.28,0.0,0.03,0.0,0.0,0.0,philip roth,MGT-4000,2017
-MGT,4000,4,Mgt of Organizational Behavior,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2017
-MGT,4020,1,Ops Pln and Ctl,0.05,0.45,0.41,0.05,0.05,0.0,0.0,0.0,zachary mo leffakis,MGT-4020,2017
-MGT,4080,1,Lean Operations,0.32,0.45,0.18,0.0,0.05,0.0,0.0,0.0,zachary mo leffakis,MGT-4080,2017
-MGT,4110,1,Project Management,0.38,0.45,0.1,0.0,0.05,0.0,0.0,0.03,russell purvis,MGT-4110,2017
-MGT,4120,1,Supplier Management,0.13,0.51,0.36,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4120,2017
-MGT,4150,1,Business Strategy,0.43,0.58,0.0,0.0,0.0,0.0,0.0,0.0,dane patric blevins,MGT-4150,2017
-MGT,4150,2,Business Strategy,0.53,0.45,0.03,0.0,0.0,0.0,0.0,0.0,dane patric blevins,MGT-4150,2017
-MGT,4150,3,Business Strategy,0.26,0.57,0.14,0.0,0.0,0.0,0.0,0.02,zeki simsek,MGT-4150,2017
-MGT,4150,4,Business Strategy,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2017
-MGT,4150,5,Business Strategy,0.32,0.29,0.32,0.05,0.02,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2017
-MGT,4150,6,Business Strategy,0.41,0.48,0.09,0.0,0.02,0.0,0.0,0.0,james liddle,MGT-4150,2017
-MGT,4150,7,Business Strategy,0.46,0.52,0.02,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2017
-MGT,4150,8,Business Strategy,0.5,0.48,0.02,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2017
-MGT,4160,1,Special Topics Hr,0.4,0.45,0.1,0.0,0.03,0.0,0.0,0.03,kristin dam scott,MGT-4160,2017
-MGT,4230,1,Intern Bus Mgt,0.35,0.5,0.08,0.05,0.0,0.0,0.0,0.03,janis miller,MGT-4230,2017
-MGT,4230,2,Intern Bus Mgt,0.36,0.38,0.24,0.02,0.0,0.0,0.0,0.0,james liddle,MGT-4230,2017
-MGT,4230,3,Intern Bus Mgt,0.18,0.23,0.48,0.03,0.03,0.0,0.0,0.08,wayne stewart,MGT-4230,2017
-MGT,4230,4,Intern Bus Mgt,0.1,0.36,0.38,0.0,0.08,0.0,0.0,0.08,wayne stewart,MGT-4230,2017
-MGT,4240,1,Global Supply Chain,0.19,0.58,0.19,0.0,0.0,0.0,0.0,0.03,yann ferrand,MGT-4240,2017
-MGT,4310,1,Emp Rights & Resp,0.35,0.56,0.09,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-4310,2017
-MGT,4350,1,Pers Interviewing,0.25,0.43,0.25,0.03,0.05,0.0,0.0,0.0,philip roth,MGT-4350,2017
-MGT,4520,1,Business Analysis,0.15,0.56,0.23,0.03,0.0,0.0,0.0,0.03,roopa raman,MGT-4520,2017
-MGT,4550,1,Emerging I T Trends,0.41,0.49,0.1,0.0,0.0,0.0,0.0,0.0,jason thatcher,MGT-4550,2017
-MGT,4560,1,Business Info Mgt,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,siyuan li,MGT-4560,2017
-MGT,8120,1,Supply Chain Mgt,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,yann ferrand,MGT-8120,2017
-MICR,3050,1,General Microbiology,0.41,0.41,0.15,0.01,0.01,0.0,0.0,0.01,krista barr rudolph,MICR-3050,2017
-MICR,3050,2,General Microbiology,0.34,0.34,0.23,0.05,0.01,0.0,0.0,0.03,kristi ja whitehead,MICR-3050,2017
-MICR,3050,3,General Microbiology,0.7,0.24,0.07,0.0,0.0,0.0,0.0,0.0,krista barr rudolph,MICR-3050,2017
-MICR,4000,1,Public Health Micro,0.52,0.27,0.16,0.03,0.02,0.0,0.0,0.01,kristi ja whitehead,MICR-4000,2017
-MICR,4000,2,Public Health Micro (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4000,2017
-MICR,4030,1,Marine Microbiology,0.29,0.5,0.17,0.0,0.0,0.0,0.0,0.04,john michael henson,MICR-4030,2017
-MICR,4070,1,Food and Dairy Micro,0.26,0.47,0.21,0.03,0.01,0.0,0.0,0.01,xiuping jiang,MICR-4070,2017
-MICR,4110,1,Pathogenic Bact,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4110,2017
-MICR,4120,1,Bacterial Physiology,0.23,0.31,0.19,0.17,0.07,0.0,0.0,0.03,thomas hughes,MICR-4120,2017
-MICR,4130,1,Industrial Micro,0.64,0.34,0.01,0.01,0.0,0.0,0.0,0.0,tzuen-rong je tzeng,MICR-4130,2017
-MICR,4140,1,Basic Immunology,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,charles rice,MICR-4140,2017
-MICR,4170,1,Cancer and Aging,0.87,0.11,0.02,0.0,0.0,0.0,0.0,0.0,yuqing dong,MICR-4170,2017
-MICR,4500,1,Advanced Microbiology I,0.42,0.42,0.08,0.04,0.04,0.0,0.0,0.0,harry kurtz,MICR-4500,2017
-MICR,4500,2,Advanced Microbiology I,0.42,0.33,0.13,0.08,0.0,0.0,0.0,0.04,harry kurtz,MICR-4500,2017
-MICR,4500,3,Advanced Microbiology I,0.06,0.63,0.31,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2017
-MICR,4520,1,Advanced Microbiology III,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4520,2017
-MICR,4520,2,Advanced Microbiology III,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.04,harry kurtz,MICR-4520,2017
-MKT,3010,1,Prin of Marketing,0.3,0.39,0.2,0.09,0.01,0.0,0.0,0.01,carter wil mcelveen,MKT-3010,2017
-MKT,3010,2,Prin of Marketing,0.18,0.42,0.27,0.06,0.04,0.0,0.0,0.03,carter wil mcelveen,MKT-3010,2017
-MKT,3010,3,Prin of Marketing,0.27,0.36,0.25,0.09,0.01,0.0,0.0,0.01,amanda cooper fine,MKT-3010,2017
-MKT,3010,4,Prin of Marketing,0.24,0.4,0.25,0.06,0.04,0.0,0.0,0.01,amanda cooper fine,MKT-3010,2017
-MKT,3010,5,Prin of Marketing,0.73,0.18,0.06,0.0,0.02,0.0,0.0,0.02,patricia knowles,MKT-3010,2017
-MKT,3020,1,Consumer Behavior,0.44,0.36,0.14,0.04,0.02,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2017
-MKT,3020,2,Consumer Behavior,0.33,0.37,0.24,0.04,0.02,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2017
-MKT,3020,3,Consumer Behavior,0.38,0.48,0.12,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2017
-MKT,3020,4,Consumer Behavior,0.32,0.44,0.16,0.08,0.0,0.0,0.0,0.0, thyroff fitzwater,MKT-3020,2017
-MKT,3020,5,Consumer Behavior,0.28,0.56,0.14,0.02,0.0,0.0,0.0,0.0,james gaubert,MKT-3020,2017
-MKT,3210,1,Sports Marketing,0.6,0.37,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2017
-MKT,3210,2,Sports Marketing,0.51,0.43,0.02,0.0,0.0,0.0,0.0,0.04,delancy bennett,MKT-3210,2017
-MKT,3310,1,Marketing Metrics & Analytics,0.81,0.14,0.03,0.0,0.0,0.0,0.0,0.03,oriana rache aragon,MKT-3310,2017
-MKT,3310,2,Marketing Metrics & Analytics,0.9,0.08,0.0,0.03,0.0,0.0,0.0,0.0,oriana rache aragon,MKT-3310,2017
-MKT,3980,1,CI: Sales Experiential,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.01,carter wil mcelveen,MKT-3980,2017
-MKT,4200,1,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2017
-MKT,4200,2,Professional Selling,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2017
-MKT,4200,3,Professional Selling,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,MKT-4200,2017
-MKT,4200,4,Professional Selling,0.72,0.2,0.04,0.0,0.04,0.0,0.0,0.0,gary hunter,MKT-4200,2017
-MKT,4200,5,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2017
-MKT,4230,1,Promotional Strategy,0.35,0.44,0.18,0.03,0.0,0.0,0.0,0.0,patricia knowles,MKT-4230,2017
-MKT,4240,1,Sales Management,0.38,0.6,0.03,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4240,2017
-MKT,4270,1,International Mktg,0.28,0.5,0.13,0.08,0.0,0.0,0.0,0.03,thomas poehlman,MKT-4270,2017
-MKT,4270,2,International Mktg,0.23,0.48,0.2,0.03,0.0,0.0,0.0,0.08,roger gomes,MKT-4270,2017
-MKT,4270,3,International Mktg,0.59,0.33,0.07,0.02,0.0,0.0,0.0,0.0,roger gomes,MKT-4270,2017
-MKT,4280,1,Services Marketing,0.58,0.24,0.16,0.0,0.0,0.0,0.0,0.02,james gaubert,MKT-4280,2017
-MKT,4280,2,Services Marketing,0.68,0.29,0.02,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4280,2017
-MKT,4310,1,Marketing Research,0.25,0.25,0.32,0.14,0.04,0.0,0.0,0.0,peter weathers,MKT-4310,2017
-MKT,4310,2,Marketing Research,0.26,0.45,0.23,0.0,0.0,0.0,0.0,0.06,william kilbourne,MKT-4310,2017
-MKT,4310,3,Marketing Research,0.3,0.59,0.11,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2017
-MKT,4310,4,Marketing Research,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2017
-MKT,4330,1,Sport Mkt Strategy,0.47,0.44,0.06,0.0,0.0,0.0,0.0,0.03,amanda cooper fine,MKT-4330,2017
-MKT,4450,1,Macromarketing,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,william kilbourne,MKT-4450,2017
-MKT,4500,1,Strategic Mktg Mgt,0.22,0.56,0.19,0.0,0.03,0.0,0.0,0.0,christopher hopkins,MKT-4500,2017
-MKT,4500,2,Strategic Mktg Mgt,0.29,0.68,0.03,0.0,0.0,0.0,0.0,0.0,christopher hopkins,MKT-4500,2017
-MKT,4500,3,Strategic Mktg Mgt,0.73,0.24,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,MKT-4500,2017
-MKT,4500,4,Strategic Mktg Mgt,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-4500,2017
-MKT,8620,1,Quant Methods in Mkt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,MKT-8620,2017
-MKT,8650,1,Seminar in Mkt Mgmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,MKT-8650,2017
-MKT,8660,1,International Marketing,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,thomas poehlman,MKT-8660,2017
-ML,1020,1,Leadership Fund II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,clay wilson etterle,ML-1020,2017
-ML,1020,2,Leadership Fund II,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,amanda carol kane,ML-1020,2017
-ML,2020,1,Leadership Development II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,shane allen werst,ML-2020,2017
-ML,2020,2,Leadership Development II,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,shane allen werst,ML-2020,2017
-ML,3020,1,Advanced Leadership II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,ML-3020,2017
-ML,3020,2,Advanced Leadership II,0.88,0.04,0.0,0.04,0.0,0.0,0.0,0.04,william cod cleland,ML-3020,2017
-MSE,2100,1,Intro to Mat Science,0.47,0.2,0.16,0.06,0.06,0.0,0.0,0.05,rakhee pani,MSE-2100,2017
-MSE,2100,2,Intro to Mat Science,0.3,0.46,0.12,0.0,0.03,0.0,0.0,0.09,eric skaar,MSE-2100,2017
-MSE,2100,3,Intro to Mat Science,0.23,0.2,0.23,0.13,0.08,0.0,0.0,0.14,fei peng,MSE-2100,2017
-MSE,2100,4,Intro to Mat Science,0.41,0.34,0.17,0.06,0.02,0.0,0.0,0.0,olga kuksenok,MSE-2100,2017
-MSE,2410,1,Metrics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,MSE-2410,2017
-MSE,2410,2,Metrics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,MSE-2410,2017
-MSE,2500,1,Polymer & Fiber Materials I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,MSE-2500,2017
-MSE,3260,1,Thermo of Materials,0.33,0.26,0.26,0.04,0.09,0.0,0.0,0.02,gary lickfield,MSE-3260,2017
-MSE,3270,1,Transport Phenomena,0.23,0.4,0.13,0.13,0.07,0.0,0.0,0.03,ulf daniel schiller,MSE-3270,2017
-MSE,3280,1,Phase Diagrams,0.5,0.11,0.25,0.0,0.0,0.0,0.0,0.14,eric skaar,MSE-3280,2017
-MSE,3420,1,Struct/Property,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,rajendra kum bordia,MSE-3420,2017
-MSE,3420,2,Struct/Property,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,rajendra kum bordia,MSE-3420,2017
-MSE,3610,1,Proc of Metals & Composites,0.3,0.49,0.08,0.05,0.0,0.0,0.0,0.08,marian kennedy,MSE-3610,2017
-MSE,4150,1,Polymer Sc Engr,0.48,0.23,0.2,0.05,0.03,0.0,0.0,0.03,igor luzinov,MSE-4150,2017
-MSE,4160,1,Electronic Materials,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,MSE-4160,2017
-MSE,4220,1,Mech Behavior of Mat,0.26,0.5,0.15,0.02,0.0,0.0,0.0,0.07,vincent yves blouin,MSE-4220,2017
-MSE,4240,1,Optical Materials,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,MSE-4240,2017
-MSE,4330,1,Comb Sys & Env Emiss,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,MSE-4330,2017
-MSE,4560,1,Polymer & Fiber Materials II,0.32,0.39,0.21,0.04,0.0,0.0,0.0,0.04,gary lickfield,MSE-4560,2017
-MSE,4810,1,Undergraduate Research Fundame,0.81,0.13,0.03,0.03,0.0,0.0,0.0,0.0,marian kennedy,MSE-4810,2017
-MSE,4910,1,Undergraduate Research,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,marian kennedy,MSE-4910,2017
-MSE,4910,2,Undergraduate Research,0.62,0.15,0.08,0.0,0.08,0.0,0.0,0.08,marian kennedy,MSE-4910,2017
-MSE,8010,1,Grad Sem in Materials Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,olga kuksenok,MSE-8010,2017
-MSE,8250,1,Solid State Mtl Sci,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,stephen foulger,MSE-8250,2017
-MSE,8520,1,Polymer Science II,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,igor luzinov,MSE-8520,2017
-MUSC,1420,1,Music Theory I,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,anthony bernarducci,MUSC-1420,2017
-MUSC,1440,1,Music Theory II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,MUSC-1440,2017
-MUSC,1450,1,Aural Skills II,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,andrew levin,MUSC-1450,2017
-MUSC,1510,2,Applied Music,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,jonathan edwa doyel,MUSC-1510,2017
-MUSC,2100,1,Music in the Western World,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-2100,2017
-MUSC,2100,2,Music in the Western World,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,lisa sain odom,MUSC-2100,2017
-MUSC,2100,3,Music in the Western World,0.69,0.19,0.09,0.0,0.0,0.0,0.0,0.03,linda li-bleuel,MUSC-2100,2017
-MUSC,2100,4,Music in the Western World,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2017
-MUSC,2100,5,Music in the Western World,0.44,0.44,0.09,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,MUSC-2100,2017
-MUSC,2100,6,Music in the Western World,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2017
-MUSC,2100,8,Music in the Western World,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,monty craig,MUSC-2100,2017
-MUSC,2100,9,Music in the Western World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,lea kibler,MUSC-2100,2017
-MUSC,3110,1,History of American Music,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3110,2017
-MUSC,3120,1,History of Jazz,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-3120,2017
-MUSC,3170,1,Hist of Country Mus,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3170,2017
-MUSC,3180,1,Hist of Audio Tech,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,bruce allen whisler,MUSC-3180,2017
-MUSC,3640,1,Concert Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,timothy ra hurlburt,MUSC-3640,2017
-MUSC,3690,1,Symphony Orchestra,0.94,0.02,0.0,0.0,0.02,0.0,0.0,0.02,andrew levin,MUSC-3690,2017
-MUSC,4160,1,Mus Hist Since 1750,0.52,0.11,0.04,0.22,0.07,0.0,0.0,0.04,linda li-bleuel,MUSC-4160,2017
-MUSC,4300,1,Conducting,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,mark spede,MUSC-4300,2017
-NPL,3000,1,Nonprofit Leadership,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,NPL-3000,2017
-NPL,3000,2,Nonprofit Leadership,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,bonnie west stevens,NPL-3000,2017
-NPL,3010,2,NPL Stakeholders,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,christina mar mazer,NPL-3010,2017
-NPL,3030,2,NPL Personnel,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,wendell price,NPL-3030,2017
-NURS,1400,1,Comp App Hlth Care,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,NURS-1400,2017
-NURS,3030,1,Nursing of Adults,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2017
-NURS,3030,400,Nursing of Adults,0.14,0.68,0.18,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2017
-NURS,3040,1,Pathophysiology,0.39,0.49,0.06,0.04,0.02,0.0,0.0,0.0,catherine si murton,NURS-3040,2017
-NURS,3040,401,Pathophysiology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,NURS-3040,2017
-NURS,3050,1,Psychosocial Nursing,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,barbara jean warner,NURS-3050,2017
-NURS,3050,400,Psychosocial Nursing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,NURS-3050,2017
-NURS,3100,1,Health Assessment,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,NURS-3100,2017
-NURS,3120,1,Foundations of Nursing,0.34,0.55,0.09,0.02,0.0,0.0,0.0,0.0,angela pye,NURS-3120,2017
-NURS,3190,400,Health Assessment for RNs,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,jennifer geter rice,NURS-3190,2017
-NURS,3330,400,Health Care Genetics,0.87,0.07,0.0,0.07,0.0,0.0,0.0,0.0,mary steck,NURS-3330,2017
-NURS,3330,401,Health Care Genetics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,NURS-3330,2017
-NURS,3400,1,Pharmther Nursing,0.35,0.46,0.1,0.06,0.02,0.0,0.0,0.0,catherine si murton,NURS-3400,2017
-NURS,4010,1,Mental Health Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-4010,2017
-NURS,4030,1,Complex Nursing of Adults,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,NURS-4030,2017
-NURS,4110,1,Nursing of Children,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,NURS-4110,2017
-NURS,4120,1,Nurs Women and Fam,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2017
-NURS,8010,400,Adv Fam & Comm Nrsng,0.89,0.08,0.0,0.0,0.0,0.0,0.0,0.03,shirley mae timmons,NURS-8010,2017
-NURS,8010,401,Adv Fam & Comm Nrsng,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,NURS-8010,2017
-NURS,8080,400,Nurs Res Stat Analys,0.64,0.22,0.08,0.0,0.06,0.0,0.0,0.0,veronica parker,NURS-8080,2017
-NURS,8190,400,Developing Family,0.43,0.07,0.0,0.0,0.47,0.0,0.0,0.03,lisa miller,NURS-8190,2017
-NURS,8200,400,Child & Adol Nursing,0.14,0.23,0.0,0.0,0.59,0.0,0.0,0.05,heide temples,NURS-8200,2017
-NURS,8210,400,Adult Nursing,0.47,0.17,0.0,0.0,0.37,0.0,0.0,0.0,tracy king fasolino,NURS-8210,2017
-NURS,8210,401,Adult Nursing,0.41,0.41,0.0,0.0,0.14,0.0,0.0,0.03,tracy king fasolino,NURS-8210,2017
-NURS,8230,400,NP Clinical Practicum,0.96,0.0,0.0,0.0,0.04,0.0,0.0,0.0,rosanne pruitt,NURS-8230,2017
-NURS,8840,400,Adult Mental Health,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,lindsey reb garrard,NURS-8840,2017
-NURS,8850,400,Mental Health in Primary Care,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-8850,2017
-NUTR,2030,1,Intro Princ of Human Nutrition,0.34,0.49,0.09,0.03,0.02,0.0,0.0,0.03,elizabeth durrance,NUTR-2030,2017
-NUTR,2030,2,Intro Princ of Human Nutrition,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,NUTR-2030,2017
-NUTR,2040,1,Nutrition Across Life Cycle,0.5,0.4,0.07,0.02,0.02,0.0,0.0,0.0,elizabeth durrance,NUTR-2040,2017
-NUTR,4180,1,Prof Development in Dietetics,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4180,2017
-NUTR,4250,1,Medica Nutr Thera II,0.45,0.42,0.13,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4250,2017
-NUTR,4260,1,Community Nutrition,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,margaret condrasky,NUTR-4260,2017
-NUTR,4550,1,Human Nutr & Metabolism II,0.54,0.29,0.11,0.03,0.03,0.0,0.0,0.0,elliot jesch,NUTR-4550,2017
-PA,2790,1,Perf Arts Pract I,0.6,0.2,0.0,0.2,0.0,0.0,0.0,0.0,kenneth moore,PA-2790,2017
-PA,2800,1,Perf Arts Pract II,0.5,0.06,0.0,0.13,0.19,0.0,0.0,0.13,kenneth moore,PA-2800,2017
-PADM,8220,400,Public Policy Process,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,PADM-8220,2017
-PADM,8270,400,Public Personnel Admin,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,lawrence nichols,PADM-8270,2017
-PADM,8290,400,Public Financial Management,0.57,0.29,0.0,0.0,0.07,0.0,0.0,0.07,robert frager,PADM-8290,2017
-PADM,8410,400,Public Data Analysis,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,ronald chrestman,PADM-8410,2017
-PADM,8410,401,Public Data Analysis,0.78,0.0,0.11,0.0,0.11,0.0,0.0,0.0,ronald chrestman,PADM-8410,2017
-PADM,8410,402,Public Data Analysis,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,PADM-8410,2017
-PADM,8450,400,Grant Writing for Public Admin,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,katheri kransteuber,PADM-8450,2017
-PADM,8520,400,Emergency Mgt Planning & Prep,0.73,0.13,0.0,0.0,0.13,0.0,0.0,0.0,amanda nico ritsema,PADM-8520,2017
-PADM,8540,400,Cybersecurity,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,david leigh cook,PADM-8540,2017
-PADM,8680,400,Local Government Admin,0.36,0.45,0.0,0.0,0.18,0.0,0.0,0.0,alfred bundrick,PADM-8680,2017
-PADM,8780,402,Local Govt. Budgeting & Financ,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,kevin yokim,PADM-8780,2017
-PADM,8780,405,Regional Econ Devlpmnt Policy,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,lori ann dickes,PADM-8780,2017
-PAS,3010,1,Pan African Studies,0.74,0.17,0.0,0.0,0.04,0.0,0.0,0.04,garry bertholf,PAS-3010,2017
-PES,2020,1,Soils,0.3,0.33,0.35,0.0,0.02,0.0,0.0,0.0,dara michelle park,PES-2020,2017
-PES,4230,1,Field Crops - Forages,0.12,0.19,0.54,0.08,0.04,0.0,0.0,0.04,matias jose aguerre,PES-4230,2017
-PES,4330,1,Landscape & Turf Weed Mgt,0.07,0.71,0.14,0.0,0.07,0.0,0.0,0.0,ted whitwell,PES-4330,2017
-PES,4450,1,Regulatory Issues & Policies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,PES-4450,2017
-PES,4520,1,Soil Fertility and Management,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,PES-4520,2017
-PES,4900,1,Soil Organisms in Plant Growth,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,"appukuttan suseela,",PES-4900,2017
-PES,6900,1,Soil Organisms in Plant Growth,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,"appukuttan suseela,",PES-6900,2017
-PES,8010,1,Crop Physiology and Nutrition,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,sruthi naraya kutty,PES-8010,2017
-PHIL,1010,1,Intro to Philosophic Problems,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,david stegall,PHIL-1010,2017
-PHIL,1010,2,Intro to Philosophic Problems,0.6,0.17,0.11,0.03,0.09,0.0,0.0,0.0,david stegall,PHIL-1010,2017
-PHIL,1010,3,Intro to Philosophic Problems,0.21,0.55,0.15,0.0,0.03,0.0,0.0,0.06,kelly smith,PHIL-1010,2017
-PHIL,1010,5,Intro to Philosophic Problems,0.26,0.47,0.16,0.0,0.05,0.0,0.0,0.05,john randall wolfe,PHIL-1010,2017
-PHIL,1010,6,Intro to Philosophic Problems,0.54,0.23,0.14,0.0,0.06,0.0,0.0,0.03,john randall wolfe,PHIL-1010,2017
-PHIL,1010,7,Intro to Philosophic Problems,0.52,0.36,0.06,0.0,0.03,0.0,0.0,0.03,john randall wolfe,PHIL-1010,2017
-PHIL,1020,1,Introduction to Logic,0.75,0.11,0.08,0.0,0.03,0.0,0.0,0.03,michael hal hannen,PHIL-1020,2017
-PHIL,1020,2,Introduction to Logic,0.77,0.14,0.06,0.03,0.0,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2017
-PHIL,1020,3,Introduction to Logic,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,michael hal hannen,PHIL-1020,2017
-PHIL,1020,4,Introduction to Logic,0.59,0.26,0.12,0.03,0.0,0.0,0.0,0.0,adam gies,PHIL-1020,2017
-PHIL,1020,5,Introduction to Logic,0.71,0.18,0.03,0.0,0.03,0.0,0.0,0.06,adam gies,PHIL-1020,2017
-PHIL,1020,6,Introduction to Logic,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-1020,2017
-PHIL,1030,2,Introduction to Ethics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,PHIL-1030,2017
-PHIL,1030,3,Introduction to Ethics,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,william maker,PHIL-1030,2017
-PHIL,1030,5,Introduction to Ethics,0.5,0.32,0.09,0.03,0.03,0.0,0.0,0.03,edyta joanna kuzian,PHIL-1030,2017
-PHIL,1030,6,Introduction to Ethics,0.51,0.4,0.03,0.0,0.0,0.0,0.0,0.06,john jung park,PHIL-1030,2017
-PHIL,1030,7,Introduction to Ethics,0.46,0.43,0.09,0.03,0.0,0.0,0.0,0.0,john jung park,PHIL-1030,2017
-PHIL,1030,8,Introduction to Ethics,0.31,0.46,0.12,0.04,0.04,0.0,0.0,0.04,charles starkey,PHIL-1030,2017
-PHIL,1030,9,Introduction to Ethics,0.54,0.31,0.09,0.06,0.0,0.0,0.0,0.0,edyta joanna kuzian,PHIL-1030,2017
-PHIL,1030,10,Introduction to Ethics,0.54,0.31,0.11,0.0,0.03,0.0,0.0,0.0,john jung park,PHIL-1030,2017
-PHIL,3040,1,Moral Philosophy,0.31,0.15,0.23,0.23,0.0,0.0,0.0,0.08,john jung park,PHIL-3040,2017
-PHIL,3050,2,Existentialism,0.84,0.09,0.0,0.0,0.06,0.0,0.0,0.0,david stegall,PHIL-3050,2017
-PHIL,3150,1,Ancient Philosophy,0.32,0.26,0.21,0.05,0.05,0.0,0.0,0.11,jennifer ingle,PHIL-3150,2017
-PHIL,3160,1,Modern Philosophy,0.47,0.41,0.06,0.0,0.03,0.0,0.0,0.03,michael hal hannen,PHIL-3160,2017
-PHIL,3170,1,19th-Century Philosophy,0.19,0.31,0.31,0.06,0.06,0.0,0.0,0.06,william maker,PHIL-3170,2017
-PHIL,3180,1,20th-Century Philosophy,0.59,0.33,0.07,0.0,0.0,0.0,0.0,0.0,john randall wolfe,PHIL-3180,2017
-PHIL,3210,1,Crime & Punishment,0.34,0.48,0.14,0.0,0.03,0.0,0.0,0.0,daniel wueste,PHIL-3210,2017
-PHIL,3250,2,Phil of Science,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-3250,2017
-PHIL,3260,1,Science and Values,0.47,0.47,0.0,0.0,0.06,0.0,0.0,0.0,andrew garnar,PHIL-3260,2017
-PHIL,3260,2,Science and Values,0.41,0.38,0.0,0.0,0.03,0.0,0.0,0.18,andrew garnar,PHIL-3260,2017
-PHIL,3260,3,Science and Values,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,PHIL-3260,2017
-PHIL,3280,1,Technology of Bodies,0.54,0.31,0.08,0.04,0.0,0.0,0.0,0.04,edyta joanna kuzian,PHIL-3280,2017
-PHIL,3450,1,Environmental Ethics,0.51,0.29,0.09,0.06,0.03,0.0,0.0,0.03,jennifer ingle,PHIL-3450,2017
-PHIL,3450,2,Environmental Ethics,0.51,0.34,0.11,0.0,0.03,0.0,0.0,0.0,jennifer ingle,PHIL-3450,2017
-PHIL,3490,2,Gender and Sexuality,0.52,0.43,0.05,0.0,0.0,0.0,0.0,0.0,diane perpich,PHIL-3490,2017
-PHIL,4010,1,Studies in the Hist of Phil,0.71,0.06,0.0,0.0,0.12,0.0,0.0,0.12,david stegall,PHIL-4010,2017
-PHIL,4750,1,Philosophy of Film,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,christopher grau,PHIL-4750,2017
-PHSC,1170,1,Intro Chem & Earth,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1170,2017
-PHYS,1220,1,Physics with Calculus I,0.18,0.47,0.22,0.07,0.05,0.0,0.0,0.01,amy liann pope,PHYS-1220,2017
-PHYS,1220,2,Physics with Calculus I,0.19,0.46,0.23,0.03,0.02,0.0,0.0,0.07,lih-sin the,PHYS-1220,2017
-PHYS,1220,3,Physics with Calculus I,0.14,0.49,0.29,0.04,0.01,0.0,0.0,0.02,apparao rao,PHYS-1220,2017
-PHYS,1220,4,Physics with Calculus I,0.22,0.49,0.22,0.02,0.01,0.0,0.0,0.03,jason stratfo brown,PHYS-1220,2017
-PHYS,1220,5,Physics with Calculus I,0.27,0.51,0.15,0.04,0.01,0.0,0.0,0.02,pooja puneet,PHYS-1220,2017
-PHYS,1220,8,Physics With Cal I (HON),0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,hugo sanabria,PHYS-1220,2017
-PHYS,1240,1,Physics Lab I,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2017
-PHYS,1240,2,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,3,Physics Lab I,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,4,Physics Lab I,0.28,0.61,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,5,Physics Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,6,Physics Lab I,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,7,Physics Lab I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-1240,2017
-PHYS,1240,8,Physics Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,9,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,10,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,11,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,12,Physics Lab I,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,13,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,15,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,16,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,17,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,19,Physics Lab I,0.24,0.59,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,20,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,21,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,22,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,24,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,25,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,26,Physics Lab I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,27,Physics Lab I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-1240,2017
-PHYS,1240,29,Physics Lab I,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,1240,30,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-1240,2017
-PHYS,2000,1,Introductory Physics,0.49,0.4,0.04,0.03,0.04,0.0,0.0,0.0,sean brittain,PHYS-2000,2017
-PHYS,2070,1,General Physics I,0.38,0.4,0.14,0.03,0.02,0.0,0.0,0.03,amy liann pope,PHYS-2070,2017
-PHYS,2080,1,General Physics II,0.51,0.33,0.1,0.03,0.02,0.0,0.0,0.0,pooja puneet,PHYS-2080,2017
-PHYS,2080,2,General Physics II,0.65,0.28,0.05,0.0,0.01,0.0,0.0,0.0,pooja puneet,PHYS-2080,2017
-PHYS,2090,1,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,2,Gen Phys Lab I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,3,Gen Phys Lab I,0.17,0.74,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,4,Gen Phys Lab I,0.31,0.44,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,PHYS-2090,2017
-PHYS,2090,5,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2090,6,Gen Phys Lab I,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,7,Gen Phys Lab I,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,jerry hester,PHYS-2090,2017
-PHYS,2090,9,Gen Phys Lab I,0.52,0.35,0.0,0.0,0.09,0.0,0.0,0.04,jerry hester,PHYS-2090,2017
-PHYS,2090,10,Gen Phys Lab I,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2090,2017
-PHYS,2100,1,Gen Phys Lab II,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,2,Gen Phys Lab II,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2017
-PHYS,2100,3,Gen Phys Lab II,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,4,Gen Phys Lab II,0.46,0.33,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,5,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,6,Gen Phys Lab II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,7,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,10,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,11,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,12,Gen Phys Lab II,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2017
-PHYS,2100,13,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,14,Gen Phys Lab II,0.75,0.13,0.08,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2017
-PHYS,2100,15,Gen Phys Lab II,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2017
-PHYS,2100,16,Gen Phys Lab II,0.57,0.39,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2100,17,Gen Phys Lab II,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,PHYS-2100,2017
-PHYS,2100,18,Gen Phys Lab II,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2100,2017
-PHYS,2210,1,Physics with Calculus II,0.28,0.34,0.27,0.06,0.03,0.0,0.0,0.02,jason stratfo brown,PHYS-2210,2017
-PHYS,2210,2,Physics with Calculus II,0.24,0.41,0.23,0.03,0.06,0.0,0.0,0.02,jason stratfo brown,PHYS-2210,2017
-PHYS,2210,500,Physics With Calculus II,0.2,0.4,0.33,0.07,0.0,0.0,0.0,0.0,elaine parshall,PHYS-2210,2017
-PHYS,2220,1,Physics with Calculus III,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,jian he,PHYS-2220,2017
-PHYS,2230,1,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2017
-PHYS,2230,2,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,PHYS-2230,2017
-PHYS,2230,5,Physics Lab II,0.36,0.36,0.18,0.0,0.09,0.0,0.0,0.0,jerry hester,PHYS-2230,2017
-PHYS,2230,6,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2017
-PHYS,2230,7,Physics Lab II,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,PHYS-2230,2017
-PHYS,2230,8,Physics Lab II,0.83,0.06,0.0,0.11,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2017
-PHYS,2230,9,Physics Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2230,2017
-PHYS,2230,500,Physics Lab II,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,elaine parshall,PHYS-2230,2017
-PHYS,2240,1,Physics Lab III,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,PHYS-2240,2017
-PHYS,2400,1,Phys of Weather,0.35,0.41,0.11,0.02,0.0,0.0,0.0,0.11,miguel larsen,PHYS-2400,2017
-PHYS,3110,1,Methods Theor Phys,0.31,0.46,0.08,0.0,0.04,0.0,0.0,0.12,antony valentini,PHYS-3110,2017
-PHYS,3220,1,Mechanics II,0.18,0.45,0.18,0.0,0.09,0.0,0.0,0.09,joshua alper,PHYS-3220,2017
-PHYS,3260,1,Exper Physics II,0.6,0.2,0.12,0.0,0.04,0.0,0.0,0.04,chad sosolik,PHYS-3260,2017
-PHYS,4650,1,Thermo and Stat Mech,0.46,0.15,0.31,0.0,0.0,0.0,0.0,0.08,feng ding,PHYS-4650,2017
-PHYS,6560,1,Quantum Physics II,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,ramakrishna podila,PHYS-6560,2017
-PHYS,8150,1,Statistical Therm I,0.11,0.67,0.11,0.0,0.0,0.0,0.0,0.11,jens oberheide,PHYS-8150,2017
-PHYS,8410,1,Electrodynamics I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,dieter hartmann,PHYS-8410,2017
-PHYS,9520,1,Quantum Mech II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,domnita marinescu,PHYS-9520,2017
-PKSC,1020,1,Intro to Pkg Sci,0.31,0.44,0.16,0.06,0.01,0.0,0.0,0.02,heather batt,PKSC-1020,2017
-PKSC,2010,1,Pkg Perishable Prod,0.15,0.34,0.24,0.08,0.1,0.0,0.0,0.1,heather batt,PKSC-2010,2017
-PKSC,2020,1,Packaging Mtl & Mfg,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,PKSC-2020,2017
-PKSC,2040,1,Container Systems,0.93,0.02,0.03,0.0,0.02,0.0,0.0,0.0,robert truett moore,PKSC-2040,2017
-PKSC,2060,1,Container Sys Lab,0.57,0.33,0.05,0.05,0.0,0.0,0.0,0.0,tyler stuettgen,PKSC-2060,2017
-PKSC,2060,2,Container Sys Lab,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,PKSC-2060,2017
-PKSC,2060,3,Container Sys Lab,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,tyler stuettgen,PKSC-2060,2017
-PKSC,2200,1,Product & Pkg Design,0.83,0.1,0.02,0.0,0.02,0.0,0.0,0.02,william aaro snyder,PKSC-2200,2017
-PKSC,3200,1,Pkg Design Theory,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,rupert hurley,PKSC-3200,2017
-PKSC,3680,1,Pkg and Society,0.31,0.38,0.17,0.03,0.03,0.0,0.0,0.07,heather batt,PKSC-3680,2017
-PKSC,4030,1,Pkg Career Prep,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2017
-PKSC,4200,1,Pkg Design & Dev,0.71,0.17,0.11,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2017
-PKSC,4240,400,Structural Pkg Design Online,0.6,0.1,0.0,0.0,0.2,0.0,0.0,0.1,rupert hurley,PKSC-4240,2017
-PKSC,4300,1,Converting Flex Pkg,0.16,0.62,0.13,0.03,0.04,0.0,0.0,0.01,duncan darby,PKSC-4300,2017
-PKSC,4400,1,Packaging for Distribution,0.17,0.46,0.22,0.04,0.11,0.0,0.0,0.0,gregory batt,PKSC-4400,2017
-PKSC,4640,1,Food & Health Care Pkg Systems,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2017
-PKSC,8220,400,3D Parametric Design,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,rupert hurley,PKSC-8220,2017
-PLPA,2130,1,Fungi & Civilization,0.37,0.37,0.17,0.06,0.02,0.0,0.0,0.01,julia loui kerrigan,PLPA-2130,2017
-PLPA,4060,1,Diseases/Insects Turfgrasses,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,samuel martin,PLPA-4060,2017
-PLPA,8090,1,Analytical Technique,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,PLPA-8090,2017
-POSC,1010,2,Amer National Govt,0.08,0.36,0.12,0.16,0.24,0.0,0.0,0.04,adam warber,POSC-1010,2017
-POSC,1010,3,Amer National Govt,0.05,0.33,0.33,0.1,0.0,0.0,0.0,0.2,james woodard,POSC-1010,2017
-POSC,1020,1,Intro Intl Relations,0.26,0.42,0.22,0.04,0.02,0.0,0.0,0.04,tara elizabet trask,POSC-1020,2017
-POSC,1020,2,Intro Intl Relations,0.16,0.29,0.3,0.13,0.04,0.0,0.0,0.07,aron geo tannenbaum,POSC-1020,2017
-POSC,1020,3,Intro Intl Relations,0.1,0.45,0.27,0.09,0.03,0.0,0.0,0.05,zeynep taydas,POSC-1020,2017
-POSC,1020,5,Intro Intl Relations,0.23,0.31,0.27,0.08,0.04,0.0,0.0,0.08,joshua douglas king,POSC-1020,2017
-POSC,1030,1,Intro to Political Theory,0.24,0.33,0.2,0.09,0.13,0.0,0.0,0.01,brandon turner,POSC-1030,2017
-POSC,1030,2,Intro to Political Theory,0.23,0.65,0.08,0.0,0.0,0.0,0.0,0.04,colin pearce,POSC-1030,2017
-POSC,1040,1,Intro Compar Pol,0.29,0.31,0.16,0.02,0.11,0.0,0.0,0.11,katherine am curtis,POSC-1040,2017
-POSC,1040,2,Intro Compar Pol,0.48,0.26,0.09,0.09,0.04,0.0,0.0,0.04,tara elizabet trask,POSC-1040,2017
-POSC,1990,1,Intro Pol Sci,0.48,0.25,0.12,0.06,0.04,0.0,0.0,0.06,meredith petersheim,POSC-1990,2017
-POSC,3020,1,State and Loc Gov,0.17,0.52,0.17,0.0,0.02,0.0,0.0,0.12,bruce ransom,POSC-3020,2017
-POSC,3210,1,Public Admin,0.13,0.35,0.43,0.0,0.04,0.0,0.0,0.04,james woodard,POSC-3210,2017
-POSC,3610,1,Intl Pol in Crisis,0.25,0.25,0.1,0.05,0.18,0.0,0.0,0.18,steven vince miller,POSC-3610,2017
-POSC,3630,1,Us Foreign Policy,0.38,0.27,0.19,0.04,0.12,0.0,0.0,0.0,jeffrey scott peake,POSC-3630,2017
-POSC,3710,1,European Politics,0.51,0.29,0.1,0.04,0.04,0.0,0.0,0.02,vladimir matic,POSC-3710,2017
-POSC,3750,1,European Integration,0.37,0.19,0.26,0.07,0.07,0.0,0.0,0.04,katherine am curtis,POSC-3750,2017
-POSC,3810,1,African Amer Politic,0.33,0.47,0.2,0.0,0.0,0.0,0.0,0.0,bruce ransom,POSC-3810,2017
-POSC,4050,1,American Presidency,0.08,0.21,0.37,0.11,0.21,0.0,0.0,0.03,adam warber,POSC-4050,2017
-POSC,4160,1,Int Groups & Soc Mov,0.29,0.38,0.2,0.07,0.04,0.0,0.0,0.02,laura olson,POSC-4160,2017
-POSC,4360,1,Law Courts Politics,0.36,0.36,0.2,0.0,0.04,0.0,0.0,0.04,joseph earl stewart,POSC-4360,2017
-POSC,4360,2,Law Courts Politics,0.32,0.5,0.06,0.06,0.03,0.0,0.0,0.03,joseph earl stewart,POSC-4360,2017
-POSC,4370,1,Constitut Law: Rights & Libert,0.24,0.53,0.14,0.02,0.04,0.0,0.0,0.02,daniel frost,POSC-4370,2017
-POSC,4500,1,Contemporary Political Thought,0.36,0.44,0.2,0.0,0.0,0.0,0.0,0.0,daniel frost,POSC-4500,2017
-POSC,4530,1,American Political Thought,0.25,0.45,0.18,0.05,0.05,0.0,0.0,0.03, bradley thompson,POSC-4530,2017
-POSC,4710,1,Russian Politics,0.38,0.33,0.15,0.0,0.05,0.0,0.0,0.08,aron geo tannenbaum,POSC-4710,2017
-POSC,4760,1,Middle East Politics,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,vladimir matic,POSC-4760,2017
-POSC,4890,1,Voting Rights Law Politics Pol,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,POSC-4890,2017
-PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,jamie lynn cathey,PRTM-2070,2017
-PRTM,2200,1,Foundations of PRTM,0.32,0.52,0.1,0.06,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2200,2017
-PRTM,2200,2,Foundations of PRTM,0.67,0.13,0.13,0.0,0.03,0.0,0.0,0.03,gwynn powell,PRTM-2200,2017
-PRTM,2200,3,Foundations of PRTM,0.36,0.43,0.11,0.04,0.07,0.0,0.0,0.0,katherine an jordan,PRTM-2200,2017
-PRTM,2200,4,Foundations of PRTM,0.58,0.26,0.03,0.06,0.06,0.0,0.0,0.0,ryan joseph gagnon,PRTM-2200,2017
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2260,2017
-PRTM,2270,1,Prov of Leisure Exp,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2270,2017
-PRTM,2290,1,Competency Integration in PRTM,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2290,2017
-PRTM,2410,1,Intro to CRSCM,0.62,0.24,0.05,0.0,0.07,0.0,0.0,0.02,harrison pinckney,PRTM-2410,2017
-PRTM,2600,1,Found of Recreational Therapy,0.53,0.36,0.08,0.01,0.01,0.0,0.0,0.01,anna-mar chancellor,PRTM-2600,2017
-PRTM,2650,1,Terminology in RT Practice,0.88,0.09,0.0,0.03,0.0,0.0,0.0,0.0,stephen thoma lewis,PRTM-2650,2017
-PRTM,2700,1,Intro Rec Res Mgt,0.54,0.39,0.0,0.0,0.07,0.0,0.0,0.0,elizabeth baldwin,PRTM-2700,2017
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.21,0.48,0.27,0.03,0.0,0.0,0.0,0.0,daniel mor anderson,PRTM-3050,2017
-PRTM,3070,1,Facility Operations,0.64,0.18,0.09,0.09,0.0,0.0,0.0,0.0,raymond dunham,PRTM-3070,2017
-PRTM,3210,1,Recreation Admin,0.67,0.27,0.03,0.0,0.03,0.0,0.0,0.0,mariela fernandez,PRTM-3210,2017
-PRTM,3250,1,Global Persp in Rec,0.42,0.39,0.06,0.0,0.12,0.0,0.0,0.0,skye arthur-banning,PRTM-3250,2017
-PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.89,0.1,0.02,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,PRTM-3260,2017
-PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3270,2017
-PRTM,3280,2,Preceptorship in Recr Therapy,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,stephen thoma lewis,PRTM-3280,2017
-PRTM,3420,1,Intro to Tourism,0.73,0.24,0.0,0.0,0.02,0.0,0.0,0.0,li-hsin chen,PRTM-3420,2017
-PRTM,3420,2,Intro to Tourism,0.73,0.23,0.02,0.0,0.02,0.0,0.0,0.0,garrett stone,PRTM-3420,2017
-PRTM,3440,1,Tourism Markets,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,PRTM-3440,2017
-PRTM,3440,2,Tourism Markets,0.75,0.23,0.03,0.0,0.0,0.0,0.0,0.0,zeynep gedikoglu,PRTM-3440,2017
-PRTM,3450,1,Tourism Management,0.48,0.29,0.19,0.0,0.03,0.0,0.0,0.0,william norman,PRTM-3450,2017
-PRTM,3450,2,Tourism Management,0.41,0.47,0.13,0.0,0.0,0.0,0.0,0.0,william norman,PRTM-3450,2017
-PRTM,3460,1,Heritage Tourism,0.33,0.37,0.23,0.07,0.0,0.0,0.0,0.0,gregory phi ramshaw,PRTM-3460,2017
-PRTM,3460,2,Heritage Tourism,0.21,0.55,0.14,0.0,0.07,0.0,0.0,0.03,gregory phi ramshaw,PRTM-3460,2017
-PRTM,3530,2,Foundations of Camp Counseling,0.8,0.0,0.0,0.0,0.13,0.0,0.0,0.07,gwynn powell,PRTM-3530,2017
-PRTM,3830,1,Golf Shop Operations,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3830,2017
-PRTM,3900,3,Independent Study in PRTM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3900,2017
-PRTM,3910,1,Mgmt Admin Outdr Rec Programs,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,robert baxte powell,PRTM-3910,2017
-PRTM,3910,9,Intro to GIS for PRTM,0.27,0.64,0.0,0.0,0.09,0.0,0.0,0.0,david lawrenc white,PRTM-3910,2017
-PRTM,4210,1,Rec Fin Resc Mgt,0.5,0.38,0.1,0.0,0.03,0.0,0.0,0.0,jamie lynn cathey,PRTM-4210,2017
-PRTM,4260,1,Trends & Issues in Rec Therapy,0.62,0.29,0.07,0.0,0.0,0.0,0.0,0.02,brent hawkins,PRTM-4260,2017
-PRTM,4300,1,World Geog Parks,0.22,0.54,0.22,0.0,0.03,0.0,0.0,0.0,robert baxte powell,PRTM-4300,2017
-PRTM,4310,1,Mthds of Envir Interpretation,0.67,0.08,0.25,0.0,0.0,0.0,0.0,0.0,robert bixler,PRTM-4310,2017
-PRTM,4460,2,Community Tourism,0.67,0.2,0.1,0.03,0.0,0.0,0.0,0.0,lauren duffy,PRTM-4460,2017
-PRTM,4460,3,Community Tourism,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,lauren duffy,PRTM-4460,2017
-PRTM,4510,1,Seminar in CRSCM,0.59,0.25,0.09,0.03,0.0,0.0,0.0,0.03,jamie lynn cathey,PRTM-4510,2017
-PRTM,4550,1,Adv Program Planning,0.59,0.23,0.14,0.0,0.05,0.0,0.0,0.0,jamie lynn cathey,PRTM-4550,2017
-PRTM,4980,7,Tanzania,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,skye arthur-banning,PRTM-4980,2017
-PRTM,8030,1,Sem Rec & Park Admin,0.65,0.25,0.05,0.0,0.05,0.0,0.0,0.0,teresa walto tucker,PRTM-8030,2017
-PRTM,8110,2,Research Methods,0.35,0.53,0.09,0.0,0.03,0.0,0.0,0.0,dorothy schmalz,PRTM-8110,2017
-PRTM,8110,3,Research Methods,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,PRTM-8110,2017
-PRTM,8250,1,Populations in PRTM,0.5,0.33,0.0,0.0,0.17,0.0,0.0,0.0,dorothy schmalz,PRTM-8250,2017
-PRTM,8500,2,Sustainable Tourism,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,kenneth backman,PRTM-8500,2017
-PRTM,8720,1,Adv Facilitation Techniq in RT,0.6,0.0,0.2,0.0,0.0,0.0,0.0,0.2,jasmine nu townsend,PRTM-8720,2017
-PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.7,0.0,0.0,0.0,0.2,0.0,0.0,0.1,stephen thoma lewis,PRTM-8730,2017
-PRTM,9000,4,Politics of Science,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,gary edward machlis,PRTM-9000,2017
-PRTM,9110,1,Professional Issues,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,gwynn powell,PRTM-9110,2017
-PSYC,2010,1,Intro to Psychology,0.43,0.28,0.16,0.07,0.04,0.0,0.0,0.02,jo anne jorgensen,PSYC-2010,2017
-PSYC,2010,2,Intro to Psychology,0.2,0.28,0.23,0.13,0.08,0.0,0.0,0.08,edwin brainerd,PSYC-2010,2017
-PSYC,2010,3,Intro to Psychology,0.22,0.36,0.3,0.04,0.01,0.0,0.0,0.06,thomas britt,PSYC-2010,2017
-PSYC,2010,4,Intro to Psychology,0.44,0.34,0.16,0.03,0.01,0.0,0.0,0.01,fred switzer,PSYC-2010,2017
-PSYC,2010,5,Intro to Psychology,0.36,0.3,0.16,0.12,0.03,0.0,0.0,0.03,mary taylor,PSYC-2010,2017
-PSYC,2010,6,Intro to Psychology,0.36,0.36,0.19,0.1,0.0,0.0,0.0,0.0,mary taylor,PSYC-2010,2017
-PSYC,2010,7,Intro to Psychology (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,PSYC-2010,2017
-PSYC,2020,3,Intro Psychology Lab,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,madison eliza sauls,PSYC-2020,2017
-PSYC,2020,4,Intro Psychology Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,PSYC-2020,2017
-PSYC,2020,5,Intro Psychology Lab,0.86,0.04,0.04,0.0,0.04,0.0,0.0,0.04,nastassia ma savage,PSYC-2020,2017
-PSYC,2020,6,Intro Psychology Lab,0.81,0.07,0.04,0.04,0.0,0.0,0.0,0.04,nastassia ma savage,PSYC-2020,2017
-PSYC,3060,1,Human Sexual Beh,0.55,0.23,0.12,0.05,0.04,0.0,0.0,0.01,bruce michael king,PSYC-3060,2017
-PSYC,3090,100,Intro Exp Psych,0.25,0.37,0.17,0.08,0.08,0.0,0.0,0.04,richard tyrrell,PSYC-3090,2017
-PSYC,3090,200,Intro Exp Psych,0.48,0.27,0.15,0.03,0.06,0.0,0.0,0.0,jennifer bai bisson,PSYC-3090,2017
-PSYC,3090,300,Intro Exp Psych,0.55,0.26,0.1,0.03,0.06,0.0,0.0,0.0,stephen robertson,PSYC-3090,2017
-PSYC,3100,100,Advanced Experimental Psych,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,jennifer bai bisson,PSYC-3100,2017
-PSYC,3100,200,Advanced Experimental Psych,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,robert campbell,PSYC-3100,2017
-PSYC,3100,300,Advanced Experimental Psych,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,cynthia pury,PSYC-3100,2017
-PSYC,3100,400,Advanced Experimental Psych,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2017
-PSYC,3100,500,Advanced Experimental Psych,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3100,2017
-PSYC,3100,600,Advanced Experimental Psych,0.43,0.52,0.0,0.0,0.05,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2017
-PSYC,3240,1,Physiological Psych,0.48,0.23,0.14,0.07,0.07,0.0,0.0,0.0,claudio cantalupo,PSYC-3240,2017
-PSYC,3240,2,Physiological Psych,0.24,0.39,0.25,0.06,0.03,0.0,0.0,0.03,june pilcher,PSYC-3240,2017
-PSYC,3330,1,Cognitive Psych,0.45,0.26,0.2,0.03,0.06,0.0,0.0,0.0,robert campbell,PSYC-3330,2017
-PSYC,3330,2,Cognitive Psych,0.46,0.38,0.13,0.03,0.0,0.0,0.0,0.01,leah hartman,PSYC-3330,2017
-PSYC,3340,1,Cognitive Psych Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,PSYC-3340,2017
-PSYC,3340,2,Cognitive Psych Lab,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,tiffany cooper,PSYC-3340,2017
-PSYC,3400,1,Lifespan Developmental Psych,0.64,0.24,0.08,0.02,0.02,0.0,0.0,0.0,sarah mae sanborn,PSYC-3400,2017
-PSYC,3400,2,Lifespan Developmental Psych,0.21,0.34,0.2,0.1,0.03,0.0,0.0,0.11,pamela alley,PSYC-3400,2017
-PSYC,3520,1,Social Psychology,0.64,0.26,0.06,0.01,0.01,0.0,0.0,0.01,eric mckibben,PSYC-3520,2017
-PSYC,3520,2,Social Psychology,0.36,0.39,0.2,0.03,0.0,0.0,0.0,0.03,eric mckibben,PSYC-3520,2017
-PSYC,3640,1,Industrial Psych,0.19,0.41,0.26,0.04,0.03,0.0,0.0,0.06,eric mckibben,PSYC-3640,2017
-PSYC,3640,2,Industrial Psych,0.33,0.4,0.24,0.01,0.01,0.0,0.0,0.0,eric mckibben,PSYC-3640,2017
-PSYC,3680,1,Organizational Psych,0.16,0.49,0.26,0.04,0.04,0.0,0.0,0.01,gargi sawhney,PSYC-3680,2017
-PSYC,3830,1,Abnormal Psychology,0.48,0.34,0.09,0.05,0.04,0.0,0.0,0.0,jo anne jorgensen,PSYC-3830,2017
-PSYC,3830,2,Abnormal Psychology,0.48,0.28,0.17,0.06,0.0,0.0,0.0,0.01,jo anne jorgensen,PSYC-3830,2017
-PSYC,3830,3,Abnormal Psychology,0.23,0.34,0.26,0.11,0.03,0.0,0.0,0.03,pamela alley,PSYC-3830,2017
-PSYC,3830,4,Abnormal Psychology,0.34,0.26,0.11,0.09,0.11,0.0,0.0,0.09,pamela alley,PSYC-3830,2017
-PSYC,4080,1,Women and Psychology,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-4080,2017
-PSYC,4080,2,Women and Psychology,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,robin mari kowalski,PSYC-4080,2017
-PSYC,4150,1,Systems and Theories,0.23,0.37,0.2,0.03,0.09,0.0,0.0,0.09,edwin brainerd,PSYC-4150,2017
-PSYC,4150,2,Systems and Theories,0.34,0.2,0.26,0.14,0.06,0.0,0.0,0.0,edwin brainerd,PSYC-4150,2017
-PSYC,4150,3,Systems and Theories,0.37,0.37,0.16,0.03,0.03,0.0,0.0,0.05,brian day,PSYC-4150,2017
-PSYC,4150,3,Systems and Theories,0.37,0.37,0.16,0.03,0.03,0.0,0.0,0.05,brian day,PSYC-4150,2017
-PSYC,4220,1,Perception,0.41,0.3,0.11,0.11,0.04,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2017
-PSYC,4220,2,Perception,0.54,0.15,0.23,0.0,0.04,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2017
-PSYC,4220,3,Perception,0.24,0.28,0.24,0.16,0.08,0.0,0.0,0.0,christopher pagano,PSYC-4220,2017
-PSYC,4350,1,Human Factors,0.52,0.16,0.32,0.0,0.0,0.0,0.0,0.0,laura whitlock,PSYC-4350,2017
-PSYC,4560,1,Psychophysiology,0.36,0.2,0.24,0.08,0.08,0.0,0.0,0.04,drew michael morris,PSYC-4560,2017
-PSYC,4560,1,Psychophysiology,0.36,0.2,0.24,0.08,0.08,0.0,0.0,0.04,drew michael morris,PSYC-4560,2017
-PSYC,4710,1,Psych of Testing,0.52,0.29,0.1,0.05,0.0,0.0,0.0,0.05,robert ray sinclair,PSYC-4710,2017
-PSYC,4800,1,Health Psychology,0.41,0.52,0.04,0.0,0.0,0.0,0.0,0.04,james mccubbin,PSYC-4800,2017
-PSYC,4800,2,Health Psychology,0.32,0.52,0.12,0.0,0.0,0.0,0.0,0.04,james mccubbin,PSYC-4800,2017
-PSYC,4880,1,Psychotherapy,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,lucinda sorci quick,PSYC-4880,2017
-PSYC,4890,1,21st Cen Teamwork,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,marissa leig porter,PSYC-4890,2017
-PSYC,4920,4,Senior Laboratory,0.89,0.04,0.0,0.04,0.04,0.0,0.0,0.0,miranda pelkey,PSYC-4920,2017
-PSYC,4920,5,Senior Laboratory,0.77,0.09,0.05,0.0,0.0,0.0,0.0,0.09,dana verhoeven,PSYC-4920,2017
-PSYC,4980,291,CI Suicide Prevention,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,heidi marie zinzow,PSYC-4980,2017
-PSYC,8130,1,Research Design III,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05, dewayne moore,PSYC-8130,2017
-PSYC,8140,1,Quantitative Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,PSYC-8140,2017
-PSYC,8680,1,Leadership in Orgs,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,patrick raymark,PSYC-8680,2017
-PSYC,8710,1,Psych Tests,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,mary taylor,PSYC-8710,2017
-PSYC,8710,1,Psych Tests,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,mary taylor,PSYC-8710,2017
-RCID,8030,1,Emp Res Methods,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,RCID-8030,2017
-RED,8030,1,Pub-Priv Partnership,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,RED-8030,2017
-RED,8040,1,Resid Practicum,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,RED-8040,2017
-RED,8890,2,Selected Topics-Ad. Fin. Mod.,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,larry bradle harvey,RED-8890,2017
-REL,1010,1,Intro to Religion,0.32,0.53,0.05,0.05,0.05,0.0,0.0,0.0,steven grosby,REL-1010,2017
-REL,1010,2,Intro to Religion,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,robert stephens,REL-1010,2017
-REL,1010,3,Intro to Religion,0.66,0.23,0.03,0.0,0.03,0.0,0.0,0.06,robert stephens,REL-1010,2017
-REL,1010,4,Intro to Religion,0.38,0.47,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,REL-1010,2017
-REL,1020,1,World Religions,0.2,0.29,0.31,0.09,0.09,0.0,0.0,0.03,peter cohen,REL-1020,2017
-REL,1020,2,World Religions,0.2,0.29,0.26,0.17,0.09,0.0,0.0,0.0,peter cohen,REL-1020,2017
-REL,1020,4,World Religions,0.35,0.29,0.18,0.12,0.03,0.0,0.0,0.03,peter cohen,REL-1020,2017
-REL,1020,7,World Religions,0.34,0.5,0.13,0.0,0.0,0.0,0.0,0.03,brett patterson,REL-1020,2017
-REL,3000,2,Studying Religion,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth jemison,REL-3000,2017
-REL,3010,1,Old Testament,0.43,0.51,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3010,2017
-REL,3020,1,New Testament Lit,0.42,0.42,0.06,0.03,0.03,0.0,0.0,0.03,benjamin white,REL-3020,2017
-REL,3030,1,The Quran,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,mashal saif,REL-3030,2017
-REL,3100,1,History of Religion in the US,0.28,0.44,0.22,0.0,0.0,0.0,0.0,0.06,elizabeth jemison,REL-3100,2017
-REL,3120,1,Hinduism,0.15,0.62,0.0,0.0,0.0,0.0,0.0,0.23,robert stephens,REL-3120,2017
-REL,3170,1,Hist of Nat. Am. Relig/Culture,0.33,0.42,0.17,0.08,0.0,0.0,0.0,0.0,james brad jeffries,REL-3170,2017
-RS,3010,1,Rural Sociology,0.41,0.48,0.03,0.03,0.03,0.0,0.0,0.0,kenneth robinson,RS-3010,2017
-RUSS,1020,1,Elementary Russian,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,RUSS-1020,2017
-RUSS,3610,1,Russn Lit Since 1910,0.56,0.33,0.06,0.0,0.06,0.0,0.0,0.0,olga anatol volkova,RUSS-3610,2017
-SAP,8020,1,Study Abroad Hybrid Grad,0.0,0.0,0.0,0.0,0.0,0.75,0.0,0.25,uttiyo raychaudhuri,SAP-8020,2017
-SOC,2010,2,Introduction to Sociology,0.85,0.06,0.04,0.04,0.0,0.0,0.0,0.0,andrew mannheimer,SOC-2010,2017
-SOC,2010,3,Introduction to Sociology,0.79,0.15,0.04,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,SOC-2010,2017
-SOC,2010,4,Introduction to Sociology,0.69,0.16,0.12,0.0,0.02,0.0,0.0,0.0,jennifer le holland,SOC-2010,2017
-SOC,2010,5,Introduction to Sociology,0.27,0.52,0.13,0.0,0.0,0.0,0.0,0.08,carolyn can coffman,SOC-2010,2017
-SOC,2010,6,Introduction to Sociology,0.68,0.25,0.05,0.0,0.0,0.0,0.0,0.01,shannon mcdonough,SOC-2010,2017
-SOC,2010,7,Introduction to Sociology,0.76,0.18,0.02,0.0,0.0,0.0,0.0,0.04,shannon mcdonough,SOC-2010,2017
-SOC,2010,8,Introduction to Sociology,0.64,0.24,0.1,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2017
-SOC,2010,9,Introduction to Sociology,0.21,0.64,0.11,0.04,0.0,0.0,0.0,0.0,mary louise barr,SOC-2010,2017
-SOC,2010,10,Introduction to Sociology,0.37,0.41,0.18,0.0,0.0,0.0,0.0,0.04,mary louise barr,SOC-2010,2017
-SOC,2010,11,Introduction to Sociology,0.17,0.5,0.15,0.1,0.04,0.0,0.0,0.04,mary louise barr,SOC-2010,2017
-SOC,2010,12,Introduction to Sociology,0.28,0.43,0.15,0.06,0.02,0.0,0.0,0.06,mary louise barr,SOC-2010,2017
-SOC,2020,1,Social Problems,0.17,0.61,0.12,0.02,0.07,0.0,0.0,0.0,carolyn can coffman,SOC-2020,2017
-SOC,2020,2,Social Problems,0.33,0.46,0.13,0.09,0.0,0.0,0.0,0.0,carolyn can coffman,SOC-2020,2017
-SOC,2050,1,Sociology Lab,0.55,0.23,0.03,0.0,0.16,0.0,0.0,0.03,brenda vander mey,SOC-2050,2017
-SOC,3020,1,Research Methods I,0.3,0.48,0.17,0.04,0.0,0.0,0.0,0.0,andrew whitehead,SOC-3020,2017
-SOC,3040,1,Social Research Methods II,0.14,0.18,0.55,0.14,0.0,0.0,0.0,0.0,ye luo,SOC-3040,2017
-SOC,3100,1,Marriage & Intimacy,0.26,0.39,0.13,0.04,0.11,0.0,0.0,0.07,carolyn can coffman,SOC-3100,2017
-SOC,3600,1,Class & Poverty,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william wentworth,SOC-3600,2017
-SOC,3600,2,Class & Poverty,0.81,0.14,0.0,0.03,0.03,0.0,0.0,0.0,william wentworth,SOC-3600,2017
-SOC,3800,1,Intro Social Service,0.58,0.24,0.16,0.02,0.0,0.0,0.0,0.0,jennifer le holland,SOC-3800,2017
-SOC,3910,1,Soc of Deviance,0.32,0.36,0.13,0.04,0.06,0.0,0.0,0.09,william white,SOC-3910,2017
-SOC,3940,1,Sociology of Mental Illness,0.6,0.28,0.04,0.02,0.04,0.0,0.0,0.02,marissa el yingling,SOC-3940,2017
-SOC,3970,1,Substance Abuse,0.53,0.35,0.1,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,SOC-3970,2017
-SOC,4030,1,"Technol, Environment & Society",0.14,0.32,0.23,0.14,0.05,0.0,0.0,0.14, catherine mobley,SOC-4030,2017
-SOC,4040,1,Soc Theory,0.51,0.34,0.09,0.03,0.0,0.0,0.0,0.03,william wentworth,SOC-4040,2017
-SOC,4320,1,Soc of Religion,0.19,0.38,0.44,0.0,0.0,0.0,0.0,0.0,andrew whitehead,SOC-4320,2017
-SOC,4330,1,Global Social Change,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,william haller,SOC-4330,2017
-SOC,4600,1,Race & Ethnicity,0.52,0.3,0.11,0.0,0.0,0.0,0.0,0.07,brenda vander mey,SOC-4600,2017
-SOC,4610,1,Sex & Gender,0.36,0.48,0.07,0.05,0.02,0.0,0.0,0.02,traci ann hefner,SOC-4610,2017
-SOC,4800,1,Medical Sociology,0.53,0.24,0.12,0.0,0.06,0.0,0.0,0.06,carolyn can coffman,SOC-4800,2017
-SOC,4840,1,Child Abuse,0.56,0.3,0.07,0.0,0.05,0.0,0.0,0.02,marissa el yingling,SOC-4840,2017
-SOC,4860,2,Creative Inquiry: Sociology,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,margaret tina britz,SOC-4860,2017
-SOC,4860,3,Creative Inquiry in Sociology,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,margaret tina britz,SOC-4860,2017
-SOC,4950,1,Field Experience,0.85,0.0,0.15,0.0,0.0,0.0,0.0,0.0, catherine mobley,SOC-4950,2017
-SOC,4970,1,Senior Lab,0.25,0.25,0.4,0.05,0.05,0.0,0.0,0.0,brenda vander mey,SOC-4970,2017
-SOC,4970,2,Senior Lab,0.28,0.22,0.28,0.06,0.17,0.0,0.0,0.0,brenda vander mey,SOC-4970,2017
-SOC,4990,1,Sel Top Seminar in Contemp Soc,0.63,0.25,0.06,0.0,0.06,0.0,0.0,0.0,andrew mannheimer,SOC-4990,2017
-SPAN,1010,1,Elementary Spanish,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2017
-SPAN,1010,2,Elementary Spanish,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,scott harris,SPAN-1010,2017
-SPAN,1020,2,Elementary Spanish,0.44,0.28,0.17,0.06,0.0,0.0,0.0,0.06,al garcia rodriguez,SPAN-1020,2017
-SPAN,1020,3,Elementary Spanish,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,al garcia rodriguez,SPAN-1020,2017
-SPAN,1020,4,Elementary Spanish,0.58,0.32,0.0,0.05,0.0,0.0,0.0,0.05,al garcia rodriguez,SPAN-1020,2017
-SPAN,1020,5,Elementary Spanish,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,al garcia rodriguez,SPAN-1020,2017
-SPAN,1020,6,Elementary Spanish,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,cathy robison,SPAN-1020,2017
-SPAN,1020,7,Elementary Spanish,0.29,0.53,0.12,0.0,0.06,0.0,0.0,0.0,cathy robison,SPAN-1020,2017
-SPAN,1020,8,Elementary Spanish,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,debra oa williamson,SPAN-1020,2017
-SPAN,1020,9,Elementary Spanish,0.47,0.29,0.24,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-1020,2017
-SPAN,1020,10,Elementary Spanish,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-1020,2017
-SPAN,1020,11,Elementary Spanish,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-1020,2017
-SPAN,2010,1,Intermediate Spanish,0.32,0.47,0.11,0.05,0.0,0.0,0.0,0.05,cathy robison,SPAN-2010,2017
-SPAN,2010,2,Intermediate Spanish,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,cathy robison,SPAN-2010,2017
-SPAN,2010,3,Intermediate Spanish,0.41,0.41,0.0,0.0,0.0,0.0,0.0,0.18,allison ann hinds,SPAN-2010,2017
-SPAN,2010,4,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,SPAN-2010,2017
-SPAN,2010,5,Intermediate Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,allison ann hinds,SPAN-2010,2017
-SPAN,2010,6,Intermediate Spanish,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-2010,2017
-SPAN,2010,7,Intermediate Spanish,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-2010,2017
-SPAN,2010,8,Intermediate Spanish,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-2010,2017
-SPAN,2010,9,Intermediate Spanish,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,heidi montes,SPAN-2010,2017
-SPAN,2010,10,Intermediate Spanish,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,SPAN-2010,2017
-SPAN,2010,11,Intermediate Spanish,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,SPAN-2010,2017
-SPAN,2010,13,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,SPAN-2010,2017
-SPAN,2010,14,Intermediate Spanish,0.43,0.29,0.14,0.0,0.0,0.0,0.0,0.14,melva margu persico,SPAN-2010,2017
-SPAN,2010,15,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,SPAN-2010,2017
-SPAN,2010,16,Intermediate Spanish,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-2010,2017
-SPAN,2020,1,Intermediate Spanish,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-2020,2017
-SPAN,2020,2,Intermediate Spanish,0.61,0.22,0.0,0.0,0.11,0.0,0.0,0.06,danie garcia vieyra,SPAN-2020,2017
-SPAN,2020,3,Intermediate Spanish,0.57,0.29,0.05,0.05,0.0,0.0,0.0,0.05,danie garcia vieyra,SPAN-2020,2017
-SPAN,2020,4,Intermediate Spanish,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2017
-SPAN,2020,5,Intermediate Spanish,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2017
-SPAN,2020,6,Intermediate Spanish,0.76,0.1,0.05,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,SPAN-2020,2017
-SPAN,2020,7,Intermediate Spanish,0.35,0.41,0.12,0.06,0.06,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2017
-SPAN,2020,8,Intermediate Spanish,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2017
-SPAN,2020,9,Intermediate Spanish,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2017
-SPAN,2020,10,Intermediate Spanish,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2017
-SPAN,2020,11,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2017
-SPAN,2020,12,Intermediate Spanish,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2017
-SPAN,2020,13,Intermediate Spanish,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,heidi montes,SPAN-2020,2017
-SPAN,2020,14,Intermediate Spanish,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,heidi montes,SPAN-2020,2017
-SPAN,2020,15,Intermediate Spanish,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,SPAN-2020,2017
-SPAN,3020,1,Int Spn Gram & Comp,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,george palacios,SPAN-3020,2017
-SPAN,3020,2,Int Spn Gram & Comp,0.3,0.5,0.15,0.0,0.05,0.0,0.0,0.0,melva margu persico,SPAN-3020,2017
-SPAN,3020,3,Int Spn Gram & Comp,0.11,0.84,0.0,0.0,0.05,0.0,0.0,0.0,melva margu persico,SPAN-3020,2017
-SPAN,3040,1,Intro Hisp Lit Forms,0.78,0.09,0.09,0.0,0.0,0.0,0.0,0.04,george palacios,SPAN-3040,2017
-SPAN,3050,1,Int Con Comp Span I,0.28,0.44,0.17,0.0,0.0,0.0,0.0,0.11,melva margu persico,SPAN-3050,2017
-SPAN,3050,2,Int Con Comp Span I,0.5,0.35,0.05,0.0,0.05,0.0,0.0,0.05,juana martin-armas,SPAN-3050,2017
-SPAN,3050,3,Int Con Comp Span I,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,juana martin-armas,SPAN-3050,2017
-SPAN,3060,1,Span Comp for Bus,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,maureen zamora,SPAN-3060,2017
-SPAN,3070,1,Hispanic World: Sp,0.26,0.37,0.21,0.0,0.11,0.0,0.0,0.05,juana martin-armas,SPAN-3070,2017
-SPAN,3080,1,Hispanic World: La,0.33,0.44,0.22,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,SPAN-3080,2017
-SPAN,3080,2,Hispanic World: La,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,tiffany dawn miller,SPAN-3080,2017
-SPAN,3130,1,Span Lit Survey I,0.4,0.2,0.2,0.0,0.1,0.0,0.0,0.1,mon rojas-de-massei,SPAN-3130,2017
-SPAN,3130,35,Span Lit Survey I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-3130,2017
-SPAN,3140,1,Hispanic Linguistics,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,daniel smith,SPAN-3140,2017
-SPAN,3160,1,Span for Intl Trade,0.76,0.06,0.12,0.0,0.0,0.0,0.0,0.06,maureen zamora,SPAN-3160,2017
-SPAN,4010,1,New Spanish Fiction,0.75,0.0,0.13,0.0,0.06,0.0,0.0,0.06,salvador oropesa,SPAN-4010,2017
-SPAN,4060,1,Narrative Fiction,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,mon rojas-de-massei,SPAN-4060,2017
-SPAN,4070,1,Hispanic Film,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,raquel anido,SPAN-4070,2017
-SPAN,4150,1,Span for Health Prof,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,areli moore peralta,SPAN-4150,2017
-SPAN,4170,1,Prof Communication,0.53,0.33,0.0,0.0,0.0,0.0,0.0,0.13,maureen zamora,SPAN-4170,2017
-SPAN,4180,35,Tech Span Health Man,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-4180,2017
-STAT,2220,1,Statistics in Everyday Life,0.3,0.36,0.25,0.08,0.02,0.0,0.0,0.0,james espey,STAT-2220,2017
-STAT,2220,2,Statistics in Everyday Life,0.4,0.34,0.09,0.11,0.04,0.0,0.0,0.02,james espey,STAT-2220,2017
-STAT,2220,3,Statistics in Everyday Life,0.32,0.4,0.11,0.13,0.02,0.0,0.0,0.02,james espey,STAT-2220,2017
-STAT,2220,4,Statistics in Everyday Life,0.3,0.28,0.3,0.07,0.02,0.0,0.0,0.04,james espey,STAT-2220,2017
-STAT,2220,5,Statistics in Everyday Life,0.32,0.36,0.17,0.04,0.11,0.0,0.0,0.0,ros martinez-dawson,STAT-2220,2017
-STAT,2220,6,Statistics in Everyday Life,0.33,0.41,0.22,0.02,0.0,0.0,0.0,0.02,ros martinez-dawson,STAT-2220,2017
-STAT,2220,7,Statistics in Everyday Life,0.33,0.3,0.26,0.09,0.02,0.0,0.0,0.0,andrew walton green,STAT-2220,2017
-STAT,2300,1,Statistical Methods I,0.29,0.35,0.15,0.12,0.04,0.0,0.0,0.05,christy jenki brown,STAT-2300,2017
-STAT,2300,2,Statistical Methods I,0.36,0.25,0.22,0.12,0.05,0.0,0.0,0.01,christy jenki brown,STAT-2300,2017
-STAT,2300,3,Statistical Methods I,0.4,0.32,0.14,0.08,0.02,0.0,0.0,0.04,christy jenki brown,STAT-2300,2017
-STAT,2300,4,Statistical Methods I,0.29,0.29,0.2,0.1,0.1,0.0,0.0,0.03,april thomas,STAT-2300,2017
-STAT,2300,5,Statistical Methods I,0.24,0.42,0.16,0.1,0.05,0.0,0.0,0.04, erwin walker,STAT-2300,2017
-STAT,2300,6,Statistical Methods I,0.21,0.39,0.22,0.1,0.06,0.0,0.0,0.03, erwin walker,STAT-2300,2017
-STAT,2300,7,Statistical Methods I,0.12,0.23,0.27,0.2,0.12,0.0,0.0,0.05,tao yang,STAT-2300,2017
-STAT,3090,1,Introductory Business Stats,0.05,0.33,0.24,0.19,0.17,0.0,0.0,0.02,boyoung hur,STAT-3090,2017
-STAT,3090,2,Introductory Business Stats,0.16,0.3,0.23,0.09,0.12,0.0,0.0,0.09,elaine ma sotherden,STAT-3090,2017
-STAT,3090,3,Introductory Business Stats,0.14,0.51,0.19,0.07,0.07,0.0,0.0,0.02,sharon marie evans,STAT-3090,2017
-STAT,3090,4,Introductory Business Stats,0.19,0.33,0.21,0.17,0.07,0.0,0.0,0.02,sharon marie evans,STAT-3090,2017
-STAT,3090,5,Introductory Business Stats,0.28,0.42,0.16,0.07,0.07,0.0,0.0,0.0,sharon marie evans,STAT-3090,2017
-STAT,3090,6,Introductory Business Stats,0.24,0.39,0.24,0.0,0.07,0.0,0.0,0.05, morales hernandez,STAT-3090,2017
-STAT,3090,7,Introductory Business Stats,0.17,0.39,0.34,0.07,0.02,0.0,0.0,0.0,jason alexande kurz,STAT-3090,2017
-STAT,3090,8,Introductory Business Stats,0.11,0.43,0.31,0.03,0.09,0.0,0.0,0.03,li he,STAT-3090,2017
-STAT,3090,9,Introductory Business Stats,0.15,0.12,0.3,0.15,0.18,0.0,0.0,0.09,mengcong ren,STAT-3090,2017
-STAT,3090,10,Introductory Business Stats,0.31,0.4,0.17,0.09,0.03,0.0,0.0,0.0,dilhani marasinghe,STAT-3090,2017
-STAT,3090,11,Introductory Business Stats,0.11,0.28,0.17,0.15,0.22,0.0,0.0,0.07,sanjog arv kulkarni,STAT-3090,2017
-STAT,3090,12,Introductory Business Stats,0.18,0.44,0.23,0.08,0.05,0.0,0.0,0.03,yijun chen,STAT-3090,2017
-STAT,3090,13,Introductory Business Stats,0.24,0.31,0.26,0.02,0.12,0.0,0.0,0.05,kayla doris javier,STAT-3090,2017
-STAT,3090,14,Introductory Business Stats,0.16,0.36,0.25,0.02,0.18,0.0,0.0,0.02,andrew pangia,STAT-3090,2017
-STAT,3300,1,Statistical Methods II,0.25,0.33,0.29,0.04,0.04,0.0,0.0,0.04,ros martinez-dawson,STAT-3300,2017
-STAT,4020,1,Intro to Statistical Computing,0.5,0.19,0.06,0.06,0.06,0.0,0.0,0.13,ellen hepfe breazel,STAT-4020,2017
-STAT,4110,1,Stat Mthds for Process Control,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,STAT-4110,2017
-STAT,4110,2,Stat Mthds for Process Control,0.5,0.28,0.11,0.0,0.11,0.0,0.0,0.0,james rieck,STAT-4110,2017
-STAT,6020,1,Intro to Statistical Computing,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,ellen hepfe breazel,STAT-6020,2017
-STAT,8010,1,Statistical Methods I,0.5,0.3,0.07,0.0,0.07,0.0,0.0,0.07,brook thaye russell,STAT-8010,2017
-STAT,8010,2,Statistical Methods I,0.38,0.28,0.18,0.0,0.1,0.0,0.0,0.08,james rieck,STAT-8010,2017
-STAT,8010,3,Statistical Methods I,0.64,0.24,0.06,0.0,0.03,0.0,0.0,0.03,jun luo,STAT-8010,2017
-STAT,8040,1,Sampling,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,STAT-8040,2017
-STAT,8050,1,Design & Anlys of Experiments,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-8050,2017
-STS,1010,2,Survey of S T S,0.3,0.55,0.09,0.03,0.0,0.0,0.0,0.03,scott brame,STS-1010,2017
-STS,1010,3,Survey of S T S,0.5,0.39,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,STS-1010,2017
-STS,1010,4,Survey of S T S,0.67,0.28,0.03,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,STS-1010,2017
-STS,1010,5,Survey of S T S,0.65,0.32,0.03,0.0,0.0,0.0,0.0,0.0,philip randall,STS-1010,2017
-STS,1010,6,Survey of S T S,0.36,0.47,0.03,0.0,0.0,0.0,0.0,0.14,sarah mae cooper,STS-1010,2017
-STS,1010,7,Survey of S T S,0.46,0.23,0.17,0.03,0.06,0.0,0.0,0.06,megan no macalystre,STS-1010,2017
-STS,1010,8,Survey of S T S,0.28,0.24,0.24,0.07,0.03,0.0,0.0,0.14,david charles foltz,STS-1010,2017
-THEA,2100,1,Theatre Appreciation,0.58,0.29,0.1,0.0,0.0,0.0,0.0,0.03,kendra lyne johnson,THEA-2100,2017
-THEA,2100,2,Theatre Appreciation,0.72,0.22,0.0,0.03,0.03,0.0,0.0,0.0,kendra lyne johnson,THEA-2100,2017
-THEA,2100,3,Theatre Appreciation,0.81,0.16,0.0,0.03,0.0,0.0,0.0,0.0,kerrie kath seymour,THEA-2100,2017
-THEA,2100,4,Theatre Appreciation,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-2100,2017
-THEA,2100,6,Theatre Appreciation,0.34,0.5,0.09,0.03,0.0,0.0,0.0,0.03,jason adkins,THEA-2100,2017
-THEA,2100,7,Theatre Appreciation,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,richard st. peter,THEA-2100,2017
-THEA,2100,9,Theatre Appreciation,0.91,0.03,0.0,0.0,0.0,0.0,0.0,0.06,richard st. peter,THEA-2100,2017
-THEA,2770,1,Prod Studies in Thea,0.72,0.17,0.03,0.0,0.03,0.0,0.0,0.03,david hartmann,THEA-2770,2017
-THEA,2790,1,Theatre Practicum,0.67,0.25,0.0,0.0,0.08,0.0,0.0,0.0,matthew leckenbusch,THEA-2790,2017
-THEA,3180,1,Afri-Amer Thea II,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,kendra lyne johnson,THEA-3180,2017
-THEA,3740,1,Movement for Actors,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,kerrie kath seymour,THEA-3740,2017
-THEA,4720,1,Improvisation,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-4720,2017
-WFB,3010,1,Wildlife Biology Lab,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2017
-WFB,3010,2,Wildlife Biology Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2017
-WFB,3130,1,Conservation Biology,0.46,0.29,0.14,0.05,0.04,0.0,0.0,0.01,shari lyn rodriguez,WFB-3130,2017
-WFB,3130,2,Conservation Biology,0.35,0.2,0.35,0.02,0.06,0.0,0.0,0.02,shari lyn rodriguez,WFB-3130,2017
-WFB,3500,1,Princ Fish & Wildlife Biology,0.38,0.42,0.13,0.0,0.0,0.0,0.0,0.07,james davis,WFB-3500,2017
-WFB,3500,2,Princ Fish & Wildlife Biology,0.3,0.35,0.22,0.09,0.02,0.0,0.0,0.02,james davis,WFB-3500,2017
-WFB,4160,1,Fishery Biology,0.19,0.5,0.24,0.05,0.02,0.0,0.0,0.0,kasey celen pregler,WFB-4160,2017
-WFB,4620,1,Wetland Wildlife Biology,0.55,0.4,0.03,0.01,0.0,0.0,0.0,0.0,russell barrett,WFB-4620,2017
-WFB,4930,2,Quantitative Ecology,0.46,0.3,0.16,0.0,0.03,0.0,0.0,0.05,david sco jachowski,WFB-4930,2017
-WFB,4930,3,Human Dim of Fisheries & Wildl,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-4930,2017
-WS,1030,1,Women in Global Perspective,0.68,0.24,0.04,0.0,0.0,0.0,0.0,0.04,laura foxworth,WS-1030,2017
-WS,1030,2,Women in Global Perspective,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,laura foxworth,WS-1030,2017
-WS,3010,1,Intro Women's Studies,0.54,0.33,0.04,0.04,0.0,0.0,0.0,0.04,elizabeth ros adams,WS-3010,2017
-WS,3010,2,Intro Women's Studies,0.46,0.38,0.13,0.0,0.04,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2017
-WS,3490,1,Gender and Sexuality,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,diane perpich,WS-3490,2017
-YDP,3100,1,Youth Developmt and the Family,0.83,0.09,0.0,0.04,0.04,0.0,0.0,0.0,william quinn,YDP-3100,2017
-YDP,3100,2,Youth Developmt and the Family,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,YDP-3100,2017
-YDP,3150,1,Community & Youth Dev Systems,0.55,0.27,0.09,0.0,0.09,0.0,0.0,0.0,toby kirkland,YDP-3150,2017
-YDP,3250,1,Working with Diverse Youth,0.7,0.1,0.15,0.0,0.0,0.0,0.0,0.05,kimberly pe johnson,YDP-3250,2017
-YDP,8010,1,Child/Adolescent Dev,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,edmond patri bowers,YDP-8010,2017
-YDP,8040,1,Assess & Eval of Youth Program,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,barry garst,YDP-8040,2017
-YDP,8880,1,Special Topics Youth Dev Ldshp,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,barry garst,YDP-8880,2017
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1020,1,Survey of Art & Arch Hist II,0.41,0.41,0.13,0.02,0.01,0.0,0.0,0.03,andrea feeser,
+AAH,2060,1,Art History and Theory II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
+ACCT,2010,1,Financial Accounting Concepts,0.42,0.2,0.13,0.05,0.12,0.0,0.0,0.08,lydia lan schleifer,
+ACCT,2010,2,Financial Accounting Concepts,0.4,0.25,0.22,0.05,0.07,0.0,0.0,0.02,annieka philo,
+ACCT,2010,3,Financial Accounting Concepts,0.2,0.41,0.2,0.14,0.0,0.0,0.0,0.06,philip maiberger,
+ACCT,2010,4,Financial Accounting Concepts,0.35,0.22,0.27,0.07,0.1,0.0,0.0,0.0,annieka philo,
+ACCT,2010,5,Financial Accounting Concepts,0.38,0.2,0.15,0.07,0.08,0.0,0.0,0.12,lydia lan schleifer,
+ACCT,2010,6,Financial Accounting Concepts,0.45,0.25,0.08,0.05,0.08,0.0,0.0,0.08,lydia lan schleifer,
+ACCT,2010,7,Financial Accounting Concepts,0.27,0.13,0.23,0.07,0.13,0.0,0.0,0.18,mary ann  prater,
+ACCT,2010,8,Financial Accounting Concepts,0.41,0.24,0.21,0.1,0.02,0.0,0.0,0.02,annieka philo,
+ACCT,2010,9,Financial Accounting Concepts,0.11,0.29,0.2,0.09,0.09,0.0,0.0,0.23,mary ann  prater,
+ACCT,2010,10,Financial Accounting Concepts,0.59,0.29,0.05,0.02,0.02,0.0,0.0,0.03,charles tegen,
+ACCT,2010,101,Fin Acct Concepts (HON),0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,mary ann  prater,True
+ACCT,2010,401,Financial Accounting Concepts,0.28,0.45,0.14,0.03,0.06,0.0,0.0,0.03,jeffrey mcmillan,
+ACCT,2010,402,Financial Accounting Concepts,0.21,0.5,0.13,0.05,0.09,0.0,0.0,0.02,jeffrey mcmillan,
+ACCT,2020,1,Managerial Accounting Concepts,0.09,0.37,0.3,0.09,0.04,0.0,0.0,0.11,henry anderson,
+ACCT,2020,2,Managerial Accounting Concepts,0.11,0.33,0.29,0.03,0.07,0.0,0.0,0.17,henry anderson,
+ACCT,2020,3,Managerial Accounting Concepts,0.25,0.23,0.3,0.08,0.03,0.0,0.0,0.13,henry anderson,
+ACCT,2020,4,Managerial Accounting Concepts,0.15,0.32,0.29,0.06,0.1,0.0,0.0,0.08,emily suza mccorkle,
+ACCT,2020,5,Managerial Accounting Concepts,0.46,0.34,0.13,0.04,0.01,0.0,0.0,0.01,emily suza mccorkle,
+ACCT,2020,401,Managerial Accounting Concepts,0.11,0.32,0.16,0.1,0.08,0.0,0.0,0.23,henry anderson,
+ACCT,3030,1,Cost Accounting,0.4,0.29,0.2,0.02,0.04,0.0,0.0,0.04,jace garrett,
+ACCT,3030,2,Cost Accounting,0.2,0.39,0.31,0.04,0.0,0.0,0.0,0.06,jace garrett,
+ACCT,3030,3,Cost Accounting,0.24,0.32,0.24,0.04,0.06,0.0,0.0,0.1,rebecca pennel trax,
+ACCT,3030,4,Cost Accounting,0.18,0.29,0.29,0.04,0.07,0.0,0.0,0.14,rebecca pennel trax,
+ACCT,3110,1,Intermediate Financial Acct I,0.22,0.29,0.24,0.09,0.09,0.0,0.0,0.07,terry daniel knause,
+ACCT,3110,2,Intermediate Financial Acct I,0.3,0.34,0.18,0.08,0.04,0.0,0.0,0.06,terry daniel knause,
+ACCT,3110,3,Intermediate Financial Acct I,0.34,0.42,0.14,0.08,0.0,0.0,0.0,0.02,terry daniel knause,
+ACCT,3110,4,Intermediate Financial Acct I,0.2,0.36,0.24,0.1,0.04,0.0,0.0,0.06,terry daniel knause,
+ACCT,3110,401,Intermediate Financial Acct I,0.16,0.22,0.22,0.09,0.13,0.0,0.0,0.19,henry anderson,
+ACCT,3120,1,Intermediate Financial Acct II,0.09,0.34,0.39,0.09,0.07,0.0,0.0,0.02,the estate  guffey,
+ACCT,3120,2,Intermediate Financial Acct II,0.27,0.24,0.35,0.05,0.03,0.0,0.0,0.05,the estate  guffey,
+ACCT,3120,3,Intermediate Financial Acct II,0.07,0.3,0.34,0.09,0.14,0.0,0.0,0.07,brian todd carver,
+ACCT,3120,4,Intermediate Financial Acct II,0.07,0.27,0.4,0.2,0.0,0.0,0.0,0.07,brian todd carver,
+ACCT,3120,5,Intermediate Financial Acct II,0.23,0.42,0.19,0.07,0.0,0.0,0.0,0.09,jeremy micha vinson,
+ACCT,3130,1,Intermediate Fin Acct III,0.15,0.35,0.45,0.0,0.05,0.0,0.0,0.0, russell madray,
+ACCT,3130,2,Intermediate Fin Acct III,0.35,0.38,0.25,0.02,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3130,3,Intermediate Fin Acct III,0.26,0.54,0.18,0.0,0.03,0.0,0.0,0.0, russell madray,
+ACCT,3130,4,Intermediate Fin Acct III,0.32,0.46,0.22,0.0,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3220,1,Accounting Information Systems,0.27,0.36,0.21,0.03,0.03,0.0,0.0,0.09,philip maiberger,
+ACCT,3220,2,Accounting Information Systems,0.38,0.35,0.09,0.03,0.0,0.0,0.0,0.15,philip maiberger,
+ACCT,3220,3,Accounting Information Systems,0.19,0.34,0.34,0.03,0.0,0.0,0.0,0.09,philip maiberger,
+ACCT,4040,1,Individual Taxation,0.61,0.2,0.18,0.0,0.02,0.0,0.0,0.0,sarah martin,
+ACCT,4040,2,Individual Taxation,0.61,0.18,0.14,0.05,0.02,0.0,0.0,0.0,sarah martin,
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.23,0.67,0.1,0.0,0.0,0.0,0.0,0.0,robin radtke,
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.15,0.49,0.31,0.03,0.03,0.0,0.0,0.0,robin radtke,
+ACCT,4150,1,Auditing,0.24,0.43,0.29,0.01,0.01,0.0,0.0,0.01,carl hollingsworth,
+ACCT,8520,1,Fin Acct Theory/Res,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8520,2,Fin Acct Theory/Res,0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,ralph welton,
+ACCT,8540,1,Prof Responsibility,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8540,2,Prof Responsibility,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8540,3,Prof Responsibility,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8620,1,Financial Auditing,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,
+ACCT,8620,2,Financial Auditing,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,
+ACCT,8710,1,Corporate Taxation,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,2,Corporate Taxation,0.2,0.68,0.13,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,3,Corporate Taxation,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8730,1,Intl/Spec Tax Topic,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,
+ACCT,8740,1,Tax Aspects of Finan Planning,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,
+AGED,1000,1,Orientation & Field Experience,0.67,0.26,0.0,0.04,0.0,0.0,0.0,0.04,philip fravel,
+AGED,2030,1,Teaching Agriscience,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,
+AGED,4150,1,Leadership of Vol,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,kevin layfield,
+AGED,4160,1,Ethics and Issues,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,
+AGM,2050,1,Prin of Fabrication,0.27,0.38,0.25,0.05,0.04,0.0,0.0,0.02,hunter massey,
+AGM,2060,1,Machinery Mgt,0.28,0.43,0.18,0.05,0.05,0.0,0.0,0.03,hunter massey,
+AGM,2200,1,Calc for Mechanized Agricult,0.36,0.51,0.08,0.03,0.0,0.0,0.0,0.02,young han,
+AGM,2210,1,Land Measurements,0.33,0.26,0.3,0.06,0.04,0.0,0.0,0.02,charles privette,
+AGM,4020,1,Irrigation System Design,0.38,0.4,0.2,0.03,0.0,0.0,0.0,0.0,charles privette,
+AGM,4100,1,Precision Ag Tech,0.61,0.2,0.13,0.04,0.02,0.0,0.0,0.0,hunter massey,
+AGM,4520,1,Mobile Power,0.56,0.37,0.07,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4720,1,Capstone,0.5,0.35,0.15,0.0,0.0,0.0,0.0,0.0,john chastain,
+AGM,4730,2,Selected Topics,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,young han,
+AGRB,2020,1,Agricultural Economics,0.16,0.34,0.23,0.1,0.13,0.0,0.0,0.03,george apperson,
+AGRB,2020,2,Agricultural Economics,0.34,0.32,0.32,0.0,0.0,0.0,0.0,0.03,george apperson,
+AGRB,2050,1,Agriculture and Society,0.28,0.33,0.2,0.13,0.06,0.0,0.0,0.0,george apperson,
+AGRB,3190,1,Agribusiness Management,0.4,0.26,0.19,0.14,0.0,0.0,0.0,0.01,michael vassalos,
+AGRB,3570,1,Natural Resources Economics,0.21,0.31,0.29,0.1,0.04,0.0,0.0,0.04,david brian willis,
+AGRB,4020,1,Production Economics,0.59,0.3,0.07,0.0,0.0,0.0,0.0,0.04,michael vassalos,
+AGRB,4080,1,Quant Agribusiness Analysis II,0.24,0.48,0.24,0.03,0.0,0.0,0.0,0.0,lisha zhang,
+AGRB,4520,1,Agricultural Policy,0.17,0.48,0.25,0.06,0.0,0.0,0.0,0.04,michael vassalos,
+AGRB,4560,1,Prices,0.41,0.31,0.28,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
+AGRB,4570,1,"Natural Res Use, Tech & Policy",0.25,0.42,0.17,0.0,0.0,0.0,0.0,0.17,david brian willis,
+AL,3490,400,Principles of Coaching,0.81,0.08,0.04,0.04,0.0,0.0,0.0,0.04,deborah cadorette,
+AL,3490,401,Principles of Coaching,0.76,0.2,0.0,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
+AL,3490,402,Principles of Coaching,0.71,0.17,0.08,0.0,0.04,0.0,0.0,0.0,julia wright,
+AL,3490,403,Principles of Coaching,0.6,0.2,0.08,0.08,0.04,0.0,0.0,0.0,clyde keith connor,
+AL,3490,404,Principles of Coaching,0.89,0.0,0.0,0.07,0.04,0.0,0.0,0.0,edmond fry,
+AL,3490,405,Principles of Coaching,0.78,0.11,0.07,0.0,0.04,0.0,0.0,0.0,deborah cadorette,
+AL,3500,400,Sci Basis I/Ex Phy,0.19,0.07,0.52,0.19,0.0,0.0,0.0,0.04,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.17,0.3,0.39,0.04,0.0,0.0,0.0,0.09,michael godfrey,
+AL,3530,400,Athletic Injuries,0.26,0.26,0.37,0.07,0.04,0.0,0.0,0.0,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.32,0.4,0.12,0.12,0.0,0.0,0.0,0.04,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.57,0.19,0.14,0.1,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.64,0.24,0.08,0.0,0.04,0.0,0.0,0.0,henry oates,
+AL,3610,401,Admin/Org of Athletic Programs,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,Admin/Org of Athletic Programs,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3620,400,Psychology of Coaching,0.32,0.4,0.16,0.08,0.0,0.0,0.0,0.04,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.46,0.25,0.21,0.0,0.08,0.0,0.0,0.0,natalie anne carter,
+AL,3620,402,Psychology of Coaching,0.48,0.22,0.13,0.13,0.04,0.0,0.0,0.0,natalie anne carter,
+AL,3720,400,Coaching Basketball,0.72,0.12,0.08,0.0,0.08,0.0,0.0,0.0,edmond fry,
+AL,3740,400,Coaching Football,0.76,0.08,0.04,0.0,0.04,0.0,0.0,0.08,edmond fry,
+AL,3750,400,Coaching Soccer,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,deborah cadorette,
+AL,3760,400,Coaching Strength/Conditioning,0.58,0.27,0.08,0.04,0.0,0.0,0.0,0.04,edmond fry,
+AL,4380,400,Coaching Women,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,4380,402,Officiating in Athletic Leader,0.64,0.16,0.16,0.0,0.04,0.0,0.0,0.0,clyde keith connor,
+AL,4380,403,Coaching Inner Athlete,0.74,0.11,0.07,0.0,0.04,0.0,0.0,0.04,deborah cadorette,
+AL,4380,404,CPR/AED for Athletic Coaches,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,julia wright,
+AL,4380,405,CPR/AED for Athletic Coaches,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,
+AL,8530,400,Legal Iss in Intercoll Athlet,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,8530,401,Legal Iss in Intercoll Athlet,0.78,0.0,0.0,0.0,0.22,0.0,0.0,0.0,misty soles,
+AL,8630,400,Socio Dynam in Intercol Athlet,0.69,0.19,0.0,0.0,0.13,0.0,0.0,0.0,michael godfrey,
+AL,8640,400,Ethical Iss in Collegiate Athl,0.64,0.32,0.0,0.0,0.0,0.0,0.0,0.04,michael godfrey,
+AL,8640,401,Ethical Iss in Collegiate Athl,0.6,0.25,0.0,0.0,0.15,0.0,0.0,0.0,michael godfrey,
+AL,8700,400,Intercoll Athletics Finance,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,misty soles,
+ANTH,2010,1,Introduction to Anthropology,0.66,0.21,0.07,0.02,0.02,0.0,0.0,0.01,melissa vogel,
+ANTH,2010,2,Introduction to Anthropology,0.67,0.25,0.06,0.0,0.02,0.0,0.0,0.0,yi wu,
+ANTH,2010,3,Introduction to Anthropology,0.36,0.38,0.1,0.02,0.02,0.0,0.0,0.12,lisa rapaport,
+ANTH,2050,1,Professional Development,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
+ANTH,3200,1,North American Indian Cultures,0.21,0.36,0.14,0.14,0.0,0.0,0.0,0.14,john coggeshall,
+ANTH,3310,1,Archaeology,0.37,0.33,0.26,0.04,0.0,0.0,0.0,0.0,melissa vogel,
+ANTH,3510,1,Biological Anthropology,0.4,0.4,0.1,0.05,0.0,0.0,0.0,0.05,katherine weisensee,
+ANTH,4040,1,Anthropological Theories,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,john coggeshall,
+ANTH,4990,1,Special Topics,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,yi wu,
+ARCH,1510,1,Arch Communication,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,
+ARCH,1510,2,Arch Communication,0.38,0.5,0.06,0.0,0.06,0.0,0.0,0.0,robert silance,
+ARCH,1510,3,Arch Communication,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,clarissa mendez,
+ARCH,1510,4,Arch Communication,0.2,0.6,0.07,0.07,0.0,0.0,0.0,0.07,berrin terim,
+ARCH,1510,5,Arch Communication,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,1510,6,Arch Communication,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,maryam hamidpour,
+ARCH,2520,1,Arch Foundations II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,2520,2,Arch Foundations II,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,james barker,
+ARCH,2520,3,Arch Foundations II,0.33,0.42,0.17,0.08,0.0,0.0,0.0,0.0,david lee,
+ARCH,2520,4,Arch Foundations II,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2520,5,Arch Foundations II,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,
+ARCH,2700,2,Structures I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,
+ARCH,2710,1,Structures II,0.66,0.21,0.07,0.03,0.03,0.0,0.0,0.0,mahmoodreza soltani,
+ARCH,3530,1,Studio Genoa,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,4120,1,History Research,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,4120,2,History Research,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4140,2,Design Seminar,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4160,1,Field Studies,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,4160,2,Field Studies,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4520,1,Synthesis Studio,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,4520,2,Synthesis Studio,0.44,0.22,0.22,0.0,0.0,0.0,0.0,0.11,julie poe wilkerson,
+ARCH,4520,3,Synthesis Studio,0.11,0.56,0.33,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,4520,4,Synthesis Studio,0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4710,1,Arch Hist of Place,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,james thomas,
+ARCH,4890,1,Internship,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,ashley jennings,
+ARCH,6160,2,Field Studies,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,miguel roldan,
+ARCH,6880,1,Arch Programming,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ARCH,8110,1,Visualization II,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,
+ARCH,8320,1,Community 1:1,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,
+ARCH,8420,1,Arch Studio II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,
+ARCH,8420,2,Arch Studio II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
+ARCH,8520,6,Design Studio IV,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,miguel roldan,
+ARCH,8520,8,Design Studio IV,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,8520,9,Design Studio IV,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,8610,1,History/Theory II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8620,1,History/Theory III,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
+ARCH,8650,1,Topics in Health Policy,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,anjali joseph,
+ARCH,8710,1,Structures II,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,dustin gra albright,
+ARCH,8730,2,Environmental Sys,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
+ARCH,8740,1,Building Process:TR,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,8820,1,Building Economics,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,8920,1,Comprehensive Studio,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ARCH,8920,2,Comprehensive Studio,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,8920,3,Comprehensive Studio,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
+ARCH,8920,4,Comprehensive Studio,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,8960,1,A+H Studio: Tectonic,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ART,1060,1,Foundation Drawing II,0.7,0.17,0.0,0.04,0.09,0.0,0.0,0.0,carly drew,
+ART,1520,1,Foundations Art II,0.76,0.2,0.0,0.04,0.0,0.0,0.0,0.0,joseph ric manson ,
+ART,2050,1,Beginning Life Drawing,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,
+ART,2070,1,Beginning Painting,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,todd mcdonald,
+ART,2100,400,Art Appreciation,0.35,0.48,0.09,0.09,0.0,0.0,0.0,0.0,lydia jane dorsey,
+ART,2100,401,Art Appreciation,0.55,0.24,0.1,0.0,0.0,0.0,0.0,0.1,lydia jane dorsey,
+ART,2100,402,Art Appreciation,0.46,0.29,0.18,0.0,0.04,0.0,0.0,0.04,lydia jane dorsey,
+ART,2100,403,Art Appreciation,0.24,0.59,0.14,0.0,0.0,0.0,0.0,0.03,lydia jane dorsey,
+ART,2130,1,Begin Photography,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amber nic eckersley,
+ART,8060,1,Visual Arts Sem II,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,gregory wi shelnutt,
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,1100,2,Air Force Today II,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,1100,3,Air Force Today II,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,2100,2,Dev of Air Power II,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,christopher mann,
+AS,2100,3,Dev of Air Power II,0.8,0.13,0.0,0.07,0.0,0.0,0.0,0.0,christopher mann,
+ASL,1010,1,Am Sign Lang I,0.26,0.37,0.32,0.05,0.0,0.0,0.0,0.0,william alton brant,
+ASL,1010,2,Am Sign Lang I,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,william alton brant,
+ASL,1010,3,Am Sign Lang I,0.58,0.37,0.0,0.05,0.0,0.0,0.0,0.0,michael alb barrett,
+ASL,1020,1,Am Sign Lang I,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,1020,2,Am Sign Lang I,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,kim ma misener dunn,
+ASL,1020,3,Am Sign Lang I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2010,1,Am Sign Lang II,0.31,0.23,0.38,0.0,0.0,0.0,0.0,0.08,michael alb barrett,
+ASL,2020,1,Am Sign Lang II,0.26,0.16,0.42,0.11,0.05,0.0,0.0,0.0,michael alb barrett,
+ASL,2020,2,Am Sign Lang II,0.64,0.09,0.09,0.09,0.0,0.0,0.0,0.09,michael alb barrett,
+ASL,3020,1,Advanced Asl II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,4600,1,Deaf Literature,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASTR,1010,1,Solar System Astronomy,0.25,0.35,0.16,0.1,0.07,0.0,0.0,0.08,lih-sin the,
+ASTR,1020,1,Stellar Astronomy,0.27,0.26,0.11,0.05,0.16,0.0,0.0,0.15,amber porter,
+ASTR,1020,2,Stellar Astronomy,0.24,0.38,0.17,0.09,0.04,0.0,0.0,0.07,amber porter,
+ASTR,1030,1,Solar Systm Astr Lab,0.35,0.35,0.08,0.04,0.19,0.0,0.0,0.0,amber porter,
+ASTR,1030,2,Solar Systm Astr Lab,0.38,0.35,0.12,0.04,0.0,0.0,0.0,0.12,amber porter,
+ASTR,1030,3,Solar Systm Astr Lab,0.38,0.29,0.24,0.05,0.0,0.0,0.0,0.05,amber porter,
+ASTR,1040,1,Stellar Astr Lab,0.64,0.18,0.14,0.0,0.0,0.0,0.0,0.05,amber porter,
+ASTR,1040,2,Stellar Astr Lab,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,amber porter,
+ASTR,1040,3,Stellar Astr Lab,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,amber porter,
+ASTR,1040,5,Stellar Astr Lab,0.55,0.2,0.05,0.0,0.05,0.0,0.0,0.15,amber porter,
+AUD,2850,1,Acoustics of Music,0.2,0.5,0.2,0.1,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUE,8160,1,Eng Combustion Emiss,0.75,0.23,0.03,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8170,3,Alt Energy Sources,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,simona onori,
+AUE,8500,6,Stability/Safety Sys,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8550,16,Auto Struct Analysis,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.49,0.46,0.05,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8770,9,Light-Weight Design,0.52,0.39,0.06,0.0,0.03,0.0,0.0,0.0,fadi kama abu-farha,
+AUE,8860,1,Noise Vibration,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,douglas feldmaier,
+AUE,8900,102,Automotive Engineering Project,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8930,3,Applied Dynamics,0.37,0.47,0.11,0.0,0.05,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8930,4,Mechanics of Composites Struct,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
+AUE,8930,401,Autonomous Driving Techn,0.67,0.31,0.03,0.0,0.0,0.0,0.0,0.0,yunyi jia,
+AUE,8930,402,Sustainability & LCE,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
+AVS,2000,1,Beef Cattle Tech,0.62,0.27,0.08,0.0,0.04,0.0,0.0,0.0,nathan long,
+AVS,2020,1,CAFLS Plus,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,thomas scott,
+AVS,2060,1,Swine Techniques,0.8,0.13,0.0,0.0,0.03,0.0,0.0,0.05,richelle lor miller,
+AVS,3010,1,Anat & Phys Dom Ani,0.44,0.32,0.13,0.05,0.03,0.0,0.0,0.03,tiffany wilmoth,
+AVS,3100,1,Animal Health,0.54,0.2,0.1,0.03,0.06,0.0,0.0,0.07,thomas scott,
+AVS,3150,1,Animal Welfare,0.46,0.21,0.33,0.0,0.0,0.0,0.0,0.0,peter skewes,
+AVS,3700,1,Principles of Animal Nutrition,0.49,0.24,0.16,0.08,0.02,0.0,0.0,0.0,james ro strickland,
+AVS,3750,1,Applied Animal Nutrition,0.29,0.33,0.19,0.15,0.0,0.0,0.0,0.04,gustavo jos lascano,
+AVS,4000,1,AVS Professional Development,0.73,0.2,0.08,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
+AVS,4000,2,AVS Professional Development,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
+AVS,4010,1,Beef Production,0.1,0.6,0.2,0.1,0.0,0.0,0.0,0.0,nathan long,
+AVS,4060,1,Seminars & Related Topics,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4060,2,Seminars & Related Topics,0.33,0.47,0.13,0.07,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4100,1,Domestic Ani Behav,0.31,0.46,0.17,0.03,0.01,0.0,0.0,0.02,peter skewes,
+AVS,4120,1,Advanced Equine Management,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,4130,1,Animal Products,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,4140,1,Basic Immunology,0.74,0.11,0.11,0.0,0.04,0.0,0.0,0.0,thomas scott,
+AVS,4220,6,Special Problems,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,susan kay duckett,
+AVS,4530,1,Animal Reproduction,0.46,0.24,0.27,0.0,0.02,0.0,0.0,0.0,glenn birrenkott,
+AVS,4530,400,Animal Reproduction,0.57,0.21,0.14,0.07,0.0,0.0,0.0,0.0,glenn birrenkott,
+BCHM,3010,1,Molecular Biochem,0.1,0.37,0.23,0.12,0.07,0.0,0.0,0.1,meredith tei morris,
+BCHM,3010,2,Molecular Biochem(HON),0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,cheryl ingram-smith,True
+BCHM,3050,1,Essen Elements Bioch,0.29,0.38,0.2,0.07,0.01,0.0,0.0,0.03,srik chandrasekaran,
+BCHM,3050,2,Essen Elements Bioch,0.4,0.32,0.2,0.06,0.0,0.0,0.0,0.02,srik chandrasekaran,
+BCHM,4320,1,Bioch of Metabolism,0.78,0.13,0.08,0.02,0.0,0.0,0.0,0.0,kimberly paul,
+BCHM,4340,3,Biochemistry of Metabolism Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kimberly paul,
+BCHM,4340,4,Biochemistry of Metabolism Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,kimberly paul,
+BCHM,4360,1,Genes to Proteins,0.8,0.17,0.02,0.0,0.02,0.0,0.0,0.0,michael glen sehorn,
+BCHM,4400,1,Bioinformatics,0.45,0.35,0.15,0.0,0.05,0.0,0.0,0.0,liangjiang wang,
+BCHM,4900,21,EPIC Ambassadors,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,meredith tei morris,
+BCHM,8050,1,Issues in Research,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,
+BE,2100,1,Intro to Biosystems Engr,0.71,0.14,0.0,0.07,0.07,0.0,0.0,0.0,yi zheng,
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.63,0.21,0.13,0.0,0.0,0.0,0.0,0.04,tom owino,
+BE,4120,1,Be Heat Mass Trans,0.38,0.38,0.08,0.13,0.0,0.0,0.0,0.04,caye marie drapcho,
+BE,4150,1,Instr & Control for Biosys Eng,0.67,0.1,0.1,0.1,0.0,0.0,0.0,0.05,yi zheng,
+BE,4240,2,Ecological Engineering,0.71,0.21,0.05,0.0,0.0,0.0,0.0,0.02,christophe darnault,
+BE,4380,1,Bioprocess Engineering Design,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,terry walker,
+BE,4730,3,Thermodynamics,0.26,0.53,0.11,0.0,0.11,0.0,0.0,0.0,terry walker,
+BIOE,1010,1,Biol for Bioengr,0.58,0.34,0.04,0.0,0.0,0.0,0.0,0.05,vladimir vla reukov,
+BIOE,2000,1,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,martine laberge,
+BIOE,2010,1,Intro Biomed Engr,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,charles webb,
+BIOE,3020,1,Biomaterials,0.67,0.29,0.03,0.0,0.0,0.0,0.0,0.01,alexey ale vertegel,
+BIOE,3200,1,Biomechanics,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,
+BIOE,3210,1,Biofluid Mechanics,0.6,0.19,0.15,0.04,0.0,0.0,0.0,0.02,sarah harcum,
+BIOE,3700,1,Bioinst & Imaging,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,delphine dean,
+BIOE,4030,1,Applied Bio E Design,0.75,0.24,0.01,0.0,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4200,1,Sports Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
+BIOE,4230,1,Cardiovascular Engr and Path,0.54,0.44,0.02,0.0,0.0,0.0,0.0,0.0,dan simionescu,
+BIOE,4490,1,Drug Delivery,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,frank alexis,
+BIOE,6230,1,Cardiovascular Engr and Path,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.03,dan simionescu,
+BIOE,6350,1,Modeling of Multiphysics Prob,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,guigen zhang,
+BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,martine laberge,
+BIOE,8410,1,Drug Delivery,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,
+BIOE,8500,3,Reg & Clin Affairs-Med Devices,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,jeremy mercuri,
+BIOE,8610,1,Biomed Eng Product Translation,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
+BIOL,1040,1,General Biology II,0.13,0.27,0.28,0.16,0.1,0.0,0.0,0.06,nora espinoza,
+BIOL,1040,2,General Biology II,0.45,0.32,0.16,0.04,0.02,0.0,0.0,0.01,william surver,
+BIOL,1040,3,General Biology II,0.13,0.22,0.38,0.13,0.09,0.0,0.0,0.05,salvatore sparace,
+BIOL,1040,4,General Biology II (HON),0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
+BIOL,1060,1,Gen Biology Lab II,0.22,0.52,0.17,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,2,Gen Biology Lab II,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,3,Gen Biology Lab II,0.13,0.58,0.08,0.04,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1060,4,Gen Biology Lab II,0.08,0.58,0.29,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,5,Gen Biology Lab II,0.14,0.23,0.41,0.14,0.09,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,7,Gen Biology Lab II,0.14,0.5,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,8,Gen Biology Lab II,0.23,0.45,0.18,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,9,Gen Biology Lab II,0.27,0.27,0.32,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,10,Gen Biology Lab II,0.18,0.32,0.36,0.05,0.09,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,11,Gen Biology Lab II,0.08,0.58,0.29,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,12,Gen Biology Lab II,0.17,0.57,0.26,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,13,Gen Biology Lab II,0.17,0.54,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,14,Gen Biology Lab II,0.14,0.57,0.24,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,15,Gen Biology Lab II,0.1,0.71,0.14,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,16,Gen Biology Lab II,0.04,0.71,0.17,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,17,Gen Biology Lab II,0.13,0.42,0.25,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1060,18,Gen Biology Lab II,0.05,0.55,0.35,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,19,Gen Biology Lab II,0.0,0.4,0.45,0.05,0.0,0.0,0.0,0.1,tafadzwa kaisa,
+BIOL,1060,20,Gen Biology Lab II,0.29,0.43,0.19,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,21,Gen Biology Lab II,0.18,0.5,0.23,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,22,Gen Biology Lab II,0.19,0.48,0.19,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,24,Gen Biology Lab II,0.05,0.6,0.3,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,25,Gen Biology Lab II,0.08,0.58,0.25,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,26,Gen Biology Lab II,0.53,0.21,0.21,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,27,Gen Biology Lab II,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,28,Gen Biology Lab II,0.32,0.5,0.05,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,29,Gen Biology Lab II,0.09,0.45,0.36,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,30,Gen Biology Lab II,0.15,0.55,0.2,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,31,Gen Biology Lab II,0.08,0.46,0.33,0.04,0.08,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,32,Gen Biology Lab II,0.23,0.45,0.27,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,35,Gen Biology Lab II,0.05,0.48,0.33,0.05,0.1,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,36,Gen Biology Lab II,0.0,0.19,0.63,0.06,0.0,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1110,1,Principles of Biology II,0.24,0.48,0.19,0.03,0.05,0.0,0.0,0.01,dylan dittrich-reed,
+BIOL,1110,3,Principles of Biology II,0.4,0.37,0.14,0.03,0.03,0.0,0.0,0.02,robert kosinski,
+BIOL,1110,4,Prin of Biol II  (HON),0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,robert kosinski,True
+BIOL,1200,1,Biological Inq Lab,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,2,Biological Inq Lab,0.39,0.28,0.33,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,3,Biological Inq Lab,0.6,0.27,0.07,0.0,0.0,0.0,0.0,0.07, christine minor,
+BIOL,1200,4,Biological Inq Lab,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,5,Biological Inq Lab,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1200,6,Biological Inq Lab,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,1230,1,Keys to Human Biol,0.3,0.34,0.19,0.12,0.03,0.0,0.0,0.02, christine minor,
+BIOL,2000,1,Biology in the News,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,2000,4,Biology in the News,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,vincent pa richards,
+BIOL,2030,1,Human Disease & Soc,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0, christine minor,
+BIOL,2040,1,"Environ, Energy and Society",0.34,0.4,0.09,0.08,0.0,0.0,0.0,0.09,john jenkins hains,
+BIOL,2040,2,"Environ, Energy and Society",0.18,0.56,0.16,0.09,0.0,0.0,0.0,0.02,john jenkins hains,
+BIOL,2230,1,Human Anat and Physiology II,0.41,0.34,0.11,0.09,0.02,0.0,0.0,0.02,john cummings,
+BIOL,2230,2,Human Anat and Physiology II,0.5,0.29,0.14,0.05,0.01,0.0,0.0,0.01,john cummings,
+BIOL,3020,1,Invertebrate Biology,0.13,0.28,0.39,0.11,0.09,0.0,0.0,0.0,juan baeza migueles,
+BIOL,3040,1,Biology of Plants,0.15,0.3,0.26,0.23,0.04,0.0,0.0,0.01,robert edwa ballard,
+BIOL,3060,2,Invertebrate Biology Lab,0.29,0.33,0.25,0.0,0.08,0.0,0.0,0.04,juan baeza migueles,
+BIOL,3060,4,Invertebrate Biology Lab,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,juan baeza migueles,
+BIOL,3080,1,Biology of Plants Practicum,0.22,0.33,0.28,0.11,0.0,0.0,0.0,0.06,nathan redding,
+BIOL,3080,2,Biology of Plants Practicum,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,3,Biology of Plants Practicum,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,4,Biology of Plants Practicum,0.76,0.12,0.0,0.0,0.12,0.0,0.0,0.0,nathan redding,
+BIOL,3160,1,Human Physiology,0.35,0.51,0.11,0.02,0.01,0.0,0.0,0.01,tamara mcnutt-scott,
+BIOL,3350,1,Evolutionary Biology,0.45,0.33,0.14,0.07,0.0,0.0,0.0,0.01,michael sears,
+BIOL,3510,1,Biological Anthropology,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
+BIOL,4010,1,Plant Physiology,0.22,0.24,0.33,0.15,0.02,0.0,0.0,0.05,douglas bielenberg,
+BIOL,4020,1,Plant Physiology Lab,0.55,0.35,0.05,0.05,0.0,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4020,2,Plant Physiology Lab,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4080,1,Comparative Vertebrate Morph,0.29,0.5,0.13,0.04,0.0,0.0,0.0,0.04,christopher mayerl,
+BIOL,4090,1,Comp Vertebrate Morph Lab,0.5,0.21,0.21,0.04,0.0,0.0,0.0,0.04,richard blob,
+BIOL,4100,1,Limnology,0.24,0.52,0.14,0.02,0.0,0.0,0.0,0.07,john jenkins hains,
+BIOL,4140,1,Basic Immunology,0.83,0.1,0.0,0.0,0.0,0.0,0.0,0.07,charles rice,
+BIOL,4340,1,Biological Chem Lab Techniques,0.06,0.13,0.31,0.44,0.06,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,2,Biological Chem Lab Techniques,0.14,0.29,0.36,0.21,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4340,3,Biological Chem Lab Techniques,0.19,0.56,0.06,0.13,0.0,0.0,0.0,0.06,salvatore sparace,
+BIOL,4340,4,Biological Chem Lab Techniques,0.13,0.33,0.27,0.27,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4610,1,Cell Biology,0.35,0.26,0.26,0.09,0.0,0.0,0.0,0.03,zhicheng dou,
+BIOL,4610,2,Cell Biology (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,zhicheng dou,True
+BIOL,4610,3,Cell Biology,0.29,0.33,0.26,0.07,0.04,0.0,0.0,0.01,lisa bain,
+BIOL,4610,4,Cell Biology (HON),0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,lisa bain,True
+BIOL,4620,1,Cell Biology Lab (Lec),0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,2,Cell Biology Lab (Lec),0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
+BIOL,4620,4,Cell Biology Lab (Lec),0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.87,0.04,0.09,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,8,Cell Biology Lab (Lec),0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4670,1,Principles of Hematology,0.73,0.18,0.05,0.02,0.0,0.0,0.0,0.02,vincent gallicchio,
+BIOL,4700,1,Behavioral Ecology,0.34,0.46,0.16,0.02,0.0,0.0,0.0,0.01,michael childress,
+BIOL,4700,2,Behavioral Ecology (HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,True
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,michael childress,
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,
+BIOL,4710,4,Behavioral Ecology Lab (Lec),0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,michael childress,
+BIOL,4780,1,Exercise Physiology,0.4,0.4,0.17,0.0,0.0,0.0,0.0,0.02,john cummings,
+BIOL,4800,1,Vertebrate Endocrinology,0.31,0.25,0.19,0.13,0.0,0.0,0.0,0.13,william baldwin,
+BIOL,4930,2,Sr Sem: Adv Cancer Research,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
+BIOL,4930,5,Sr Sem: Nervous Systems,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,david feliciano,
+BIOL,4930,7,Sr Sem: Conservation Biology,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david tonkyn,
+BIOL,4940,4,CI: Popular Science Journalism,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
+BIOL,8430,1,Underst Genetics & Evol Biol,0.64,0.33,0.02,0.0,0.02,0.0,0.0,0.0,margaret ptacek,
+BIOL,8450,1,Understanding Animal Biology,0.93,0.03,0.01,0.0,0.02,0.0,0.0,0.0,matthew turnbull,
+BIOL,8470,1,Understanding Microbiology,0.58,0.34,0.04,0.0,0.02,0.0,0.0,0.02,harry kurtz,
+BIOL,8480,1,Understanding Scientific Rsrch,0.93,0.0,0.0,0.0,0.02,0.0,0.0,0.05,robert edwa ballard,
+BIOL,8710,1,Current Topics in Biology,0.67,0.0,0.0,0.0,0.17,0.0,0.0,0.17,robert edwa ballard,
+BMOL,4250,1,Biomolecular Engineering,0.26,0.3,0.22,0.09,0.07,0.0,0.0,0.07,mark alan blenner,
+BUS,1010,1,Business Foundations,0.33,0.52,0.11,0.0,0.04,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,2,Business Foundations,0.39,0.39,0.14,0.0,0.04,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,3,Business Foundations,0.35,0.58,0.08,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,4,Business Foundations,0.19,0.38,0.35,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
+BUS,1010,5,Business Foundations,0.26,0.37,0.3,0.04,0.04,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,6,Business Foundations,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,7,Business Foundations,0.19,0.63,0.19,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,8,Business Foundations,0.35,0.26,0.3,0.0,0.04,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,9,Business Foundations,0.25,0.44,0.19,0.0,0.13,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,10,Business Foundations,0.16,0.48,0.2,0.08,0.08,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,16,Business Foundations,0.14,0.41,0.1,0.17,0.0,0.0,0.0,0.17,james mullinax,
+BUS,1010,17,Business Foundations,0.24,0.34,0.34,0.07,0.0,0.0,0.0,0.0,james mullinax,
+BUS,2990,3,CI:  Being a Leader,0.75,0.19,0.0,0.06,0.0,0.0,0.0,0.0,christopher mann,
+CE,2010,1,Statics,0.59,0.24,0.09,0.02,0.03,0.0,0.0,0.03,sara khoshnevisan,
+CE,2010,2,Statics,0.12,0.31,0.4,0.0,0.1,0.0,0.0,0.07,melissa sternhagen,
+CE,2010,3,Statics,0.63,0.23,0.08,0.03,0.0,0.0,0.0,0.03,brandon ross,
+CE,2010,4,Statics,0.12,0.24,0.12,0.2,0.28,0.0,0.0,0.04,melissa sternhagen,
+CE,2010,5,Statics,0.36,0.36,0.18,0.06,0.03,0.0,0.0,0.0,william albe ashman,
+CE,2010,6,Statics,0.5,0.22,0.22,0.04,0.02,0.0,0.0,0.0, kent nilsson,
+CE,2010,7,Statics (HON),0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,brandon ross,True
+CE,2060,1,Structural Mechanics,0.31,0.51,0.18,0.0,0.0,0.0,0.0,0.0,bryant nielson,
+CE,2060,2,Structural Mechanics,0.54,0.38,0.06,0.0,0.02,0.0,0.0,0.0,mahmoodreza soltani,
+CE,2080,1,Dynamics,0.17,0.3,0.42,0.07,0.02,0.0,0.0,0.03,melissa sternhagen,
+CE,2080,2,Dynamics,0.18,0.37,0.26,0.08,0.08,0.0,0.0,0.03,melissa sternhagen,
+CE,2550,1,Geomatics,0.29,0.44,0.2,0.03,0.03,0.0,0.0,0.0, shams esfandabadi,
+CE,3010,1,Structural Analysis,0.34,0.26,0.2,0.09,0.06,0.0,0.0,0.06,stephen csernak,
+CE,3110,1,Transportation Engr,0.3,0.43,0.21,0.05,0.0,0.0,0.0,0.02,wayne sarasua,
+CE,3210,1,Geotechnical Engineering,0.58,0.3,0.09,0.0,0.0,0.0,0.0,0.02,charng-hsein juang,
+CE,3210,2,Geotechnical Engineering,0.57,0.37,0.07,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
+CE,3310,1,Constr Engr & Mgmnt,0.36,0.43,0.18,0.0,0.0,0.0,0.0,0.02,james burati,
+CE,3410,1,Intro to Fluid Mech,0.26,0.44,0.21,0.06,0.0,0.0,0.0,0.03,md nasimu chowdhury,
+CE,3420,1,Hydraulics & Hydro,0.37,0.27,0.2,0.03,0.0,0.0,0.0,0.13,abdul khan,
+CE,3420,2,Hydraulics & Hydro,0.6,0.38,0.03,0.0,0.0,0.0,0.0,0.0,ashok mishra,
+CE,3510,1,Civil Engineering Materials,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
+CE,3520,2,Econ Eval of Proj,0.51,0.39,0.08,0.0,0.0,0.0,0.0,0.02,bradley putman,
+CE,3530,1,Professional Seminar,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,4020,1,Reinfor Con Design,0.44,0.31,0.22,0.01,0.0,0.0,0.0,0.01,brandon ross,
+CE,4070,1,Wood Design,0.52,0.33,0.1,0.0,0.0,0.0,0.0,0.05,weichiang pang,
+CE,4080,1,Struct Loads & Sys,0.08,0.38,0.25,0.17,0.0,0.0,0.0,0.13,bryant nielson,
+CE,4110,1,Roadway Geo Design,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
+CE,4120,1,Urban Transport Plan,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
+CE,4210,1,Geotechnical Design,0.37,0.26,0.29,0.05,0.03,0.0,0.0,0.0,nadara ravichandran,
+CE,4340,1,Const Est Proj Cont,0.57,0.37,0.04,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,4350,1,Infra Proj Planning,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+CE,4470,1,Stormwater Managemnt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john philli raiford,
+CE,4590,1,Capstone Design Proj,0.46,0.49,0.05,0.0,0.0,0.0,0.0,0.0,stephen csernak,
+CE,6070,1,Wood Design,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CE,6080,1,Struct Loads & Sys,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,bryant nielson,
+CE,6210,1,Geotechnical Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
+CE,6350,1,Infra Proj Planning,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+CE,6470,1,Stormwater Managemnt,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john philli raiford,
+CE,8020,1,Adv R/C Design,0.48,0.32,0.12,0.0,0.0,0.0,0.0,0.08,thomas edfo cousins,
+CE,8060,1,Dyn Analys of Struc,0.42,0.38,0.12,0.0,0.0,0.0,0.0,0.08,bryant nielson,
+CE,8250,1,Geotech Equake Engr,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
+CE,8260,1,Prop of Concrete,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
+CE,8460,1,Flow in Open Chnls,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,abdul khan,
+CE,8530,1,Apps in Traffic En,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CE,8580,501,Fund of Risk Engineering Mgt,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,jie zhang,
+CH,1010,1,General Chemistry,0.06,0.2,0.32,0.11,0.2,0.0,0.0,0.12,princess mycia cox,
+CH,1010,2,General Chemistry,0.02,0.26,0.27,0.16,0.22,0.0,0.0,0.07,princess mycia cox,
+CH,1010,3,General Chemistry,0.28,0.24,0.28,0.07,0.07,0.0,0.0,0.06,dennis taylor,
+CH,1010,4,General Chemistry,0.05,0.24,0.28,0.13,0.17,0.0,0.0,0.14,joseph stu thrasher,
+CH,1010,400,General Chemistry,0.19,0.23,0.25,0.15,0.07,0.0,0.0,0.12,stephe schvaneveldt,
+CH,1020,1,General Chemistry,0.07,0.43,0.28,0.08,0.0,0.0,0.0,0.13,william mcwhorter,
+CH,1020,2,General Chemistry,0.31,0.44,0.19,0.03,0.02,0.0,0.0,0.01,thomas hickman,
+CH,1020,3,General Chemistry,0.39,0.37,0.12,0.08,0.01,0.0,0.0,0.03,dennis taylor,
+CH,1020,4,General Chemistry,0.35,0.4,0.14,0.04,0.0,0.0,0.0,0.06,dennis taylor,
+CH,1020,5,General Chemistry,0.1,0.34,0.33,0.17,0.01,0.0,0.0,0.04,william mcwhorter,
+CH,1020,6,General Chemistry,0.09,0.35,0.37,0.07,0.02,0.0,0.0,0.09,william mcwhorter,
+CH,1020,7,General Chemistry,0.12,0.37,0.35,0.04,0.02,0.0,0.0,0.1,olt geiculescu,
+CH,1020,8,General Chemistry,0.26,0.41,0.25,0.04,0.04,0.0,0.0,0.02,thomas hickman,
+CH,1020,9,General Chemistry,0.25,0.47,0.2,0.05,0.01,0.0,0.0,0.02,elliot ennis,
+CH,1020,10,General Chemistry,0.27,0.41,0.21,0.04,0.03,0.0,0.0,0.03,laura lanni,
+CH,1020,11,General Chemistry,0.23,0.39,0.31,0.04,0.02,0.0,0.0,0.01,laura lanni,
+CH,1020,50,General Chemistry,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,shiou-jyh hwu,
+CH,1020,51,General Chemistry (HON),0.88,0.09,0.02,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
+CH,1020,52,General Chemistry (HON),0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
+CH,1020,500,General Chemistry,0.29,0.32,0.29,0.1,0.0,0.0,0.0,0.0,brian gloor,
+CH,1050,1,Chemistry in Context I,0.32,0.47,0.06,0.06,0.02,0.0,0.0,0.06,olt geiculescu,
+CH,1050,2,Chemistry in Context I,0.32,0.48,0.11,0.0,0.02,0.0,0.0,0.07,olt geiculescu,
+CH,1060,1,Chemistry in Context II,0.47,0.38,0.15,0.0,0.0,0.0,0.0,0.0,thomas hickman,
+CH,1520,1,Chemistry Communication,0.84,0.0,0.11,0.0,0.05,0.0,0.0,0.0,richard marcus,
+CH,2010,1,Survey of Organic Chemistry,0.44,0.37,0.07,0.08,0.04,0.0,0.0,0.01,tania issa houjeiry,
+CH,2020,1,Surv of Organic Chemistry Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2020,2,Surv of Organic Chemistry Lab,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2050,1,Intro Inorg Chem,0.43,0.43,0.11,0.0,0.03,0.0,0.0,0.0,william pennington,
+CH,2230,1,Organic Chemistry,0.19,0.3,0.25,0.15,0.09,0.0,0.0,0.02,jacob schroeder,
+CH,2230,2,Organic Chemistry,0.34,0.3,0.21,0.08,0.04,0.0,0.0,0.02,jacob schroeder,
+CH,2230,3,Organic Chemistry,0.29,0.18,0.24,0.1,0.09,0.0,0.0,0.1,sourav saha,
+CH,2240,1,Organic Chemistry,0.33,0.33,0.19,0.07,0.02,0.0,0.0,0.06,elliot ennis,
+CH,2240,2,Organic Chemistry,0.21,0.29,0.21,0.07,0.03,0.0,0.0,0.18,laura lanni,
+CH,2240,3,Organic Chemistry,0.3,0.38,0.17,0.1,0.0,0.0,0.0,0.05,elliot ennis,
+CH,2240,4,Organic Chemistry,0.29,0.31,0.2,0.07,0.04,0.0,0.0,0.09,rhett smith,
+CH,2240,5,Organic Chemistry,0.35,0.43,0.18,0.01,0.01,0.0,0.0,0.02,jacob schroeder,
+CH,2270,3,Organic Chem Lab,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,6,Organic Chem Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,7,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,8,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,9,Organic Chem Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,10,Organic Chem Lab,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2270,11,Organic Chem Lab,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2270,12,Organic Chem Lab,0.81,0.06,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,
+CH,2270,13,Organic Chem Lab,0.59,0.12,0.18,0.0,0.0,0.0,0.0,0.12,sean 'connor,
+CH,2270,14,Organic Chem Lab,0.79,0.0,0.07,0.0,0.0,0.0,0.0,0.14,sean 'connor,
+CH,2270,15,Organic Chem Lab,0.67,0.2,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,1,Organic Chem Lab,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,
+CH,2280,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,6,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,10,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
+CH,2280,12,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,
+CH,2280,19,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,2280,21,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
+CH,3310,1,Physical Chemistry,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,arkady kholodenko,
+CH,3320,1,Physical Chemistry,0.29,0.46,0.15,0.06,0.02,0.0,0.0,0.02,steven stuart,
+CH,3320,2,Physical Chemistry,0.68,0.2,0.04,0.04,0.0,0.0,0.0,0.04,jason mcneill,
+CH,3320,3,Physical Chemistry,0.29,0.33,0.24,0.0,0.14,0.0,0.0,0.0,leah bec casabianca,
+CH,3400,2,Physical Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3400,3,Physical Chem Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3400,5,Physical Chem Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3600,1,Chemical Biology,0.58,0.28,0.11,0.0,0.02,0.0,0.0,0.0,modi wetzler,
+CH,4040,1,Bioinorganic Chem,0.38,0.25,0.19,0.06,0.0,0.0,0.0,0.13,julia brumaghim,
+CH,4110,1,Instrumental Analy,0.33,0.33,0.0,0.25,0.08,0.0,0.0,0.0,george chumanov,
+CH,4120,1,Instr Analysis Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey natha anker,
+CH,4130,1,Chemistry of Aqueous Systems,0.51,0.31,0.11,0.0,0.0,0.0,0.0,0.06,cindy lee,
+CH,4250,1,Medicinal Chem,0.38,0.23,0.08,0.0,0.08,0.0,0.0,0.23,dev priya arya,
+CH,4500,1,Chemistry Capstone,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
+CH,8130,1,Electrochem Sci,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,stephen creager,
+CH,8510,1,Grad Student Seminar,0.77,0.2,0.0,0.0,0.03,0.0,0.0,0.0,joseph stu thrasher,
+CHE,1300,1,Intro to Chemical Engineering,0.15,0.28,0.26,0.13,0.11,0.0,0.0,0.07,christopher norfolk,
+CHE,1300,2,Intro to Chemical Engineering,0.14,0.24,0.24,0.1,0.1,0.0,0.0,0.2,christopher norfolk,
+CHE,2200,1,Ch E Thermo I,0.21,0.38,0.25,0.09,0.06,0.0,0.0,0.01,joseph scott,
+CHE,2300,1,Fluids/Heat Transfer,0.08,0.18,0.5,0.08,0.13,0.0,0.0,0.03,eric mikel davis,
+CHE,2300,2,Fluids/Heat Transfer,0.12,0.34,0.29,0.12,0.1,0.0,0.0,0.03,eric mikel davis,
+CHE,3070,1,Unit Ops Lab I,0.24,0.53,0.19,0.0,0.0,0.0,0.0,0.03,mark thies,
+CHE,3190,1,Engr Materials,0.17,0.35,0.33,0.08,0.0,0.0,0.0,0.07,christopher norfolk,
+CHE,3530,2,Proc Dyn & Control,0.31,0.51,0.17,0.01,0.0,0.0,0.0,0.0,mark roberts,
+CHE,4330,1,Process Design II,0.59,0.4,0.01,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHIN,1020,1,Elementary Chinese,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,ling rao,
+CHIN,2020,1,Intermediate Chinese,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ling rao,
+CHIN,4010,1,Pre-Modern Chinese Literature,0.21,0.42,0.26,0.11,0.0,0.0,0.0,0.0,yanming an,
+COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,eddie smith,
+COM,1500,1,Intro to Human Communication,0.8,0.13,0.02,0.02,0.03,0.0,0.0,0.0,eddie smith,
+COM,1500,2,Intro to Human Communication,0.6,0.29,0.08,0.01,0.01,0.0,0.0,0.01,daniel lelan fecher,
+COM,1500,3,Intro to Human Communication,0.86,0.09,0.03,0.0,0.01,0.0,0.0,0.01,eddie smith,
+COM,1500,4,Intro to Human Communication,0.62,0.31,0.04,0.02,0.0,0.0,0.0,0.01,marianne her glaser,
+COM,1500,5,Intro to Human Communication,0.69,0.25,0.06,0.01,0.0,0.0,0.0,0.0,marianne her glaser,
+COM,1500,6,Intro to Human Communication,0.41,0.47,0.09,0.03,0.0,0.0,0.0,0.0,daniel lelan fecher,
+COM,2010,1,Intr to Comm Studies,0.6,0.3,0.07,0.0,0.0,0.0,0.0,0.03,darren linvill,
+COM,2010,2,Intr to Comm Studies,0.47,0.4,0.07,0.03,0.0,0.0,0.0,0.03,darren linvill,
+COM,2500,1,Public Speaking,0.33,0.43,0.1,0.1,0.05,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,2,Public Speaking,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,brandon boatwright,
+COM,2500,3,Public Speaking,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,4,Public Speaking,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,5,Public Speaking,0.29,0.62,0.1,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,6,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,7,Public Speaking,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,8,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,10,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,11,Public Speaking,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
+COM,2500,12,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,13,Public Speaking,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,14,Public Speaking,0.52,0.33,0.0,0.0,0.1,0.0,0.0,0.05,jumah patrici taweh,
+COM,2500,15,Public Speaking,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,16,Public Speaking,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,17,Public Speaking,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,the estate  geddes,
+COM,2500,18,Public Speaking,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
+COM,2500,19,Public Speaking,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,21,Public Speaking,0.67,0.24,0.0,0.05,0.0,0.0,0.0,0.05,sara grumbl crocker,
+COM,2500,22,Public Speaking,0.52,0.33,0.0,0.0,0.05,0.0,0.0,0.1,jumah patrici taweh,
+COM,2500,24,Public Speaking,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,25,Public Speaking,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
+COM,2500,27,Public Speaking (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,True
+COM,2500,29,Public Speaking,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,30,Public Speaking,0.32,0.64,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,31,Public Speaking,0.1,0.57,0.14,0.05,0.1,0.0,0.0,0.05,pauline matthey,
+COM,2500,32,Public Speaking,0.25,0.2,0.25,0.1,0.1,0.0,0.0,0.1,pauline matthey,
+COM,2500,400,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,401,Public Speaking,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,alexis zachar davis,
+COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,403,Public Speaking,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,500,Public Speaking,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,501,Public Speaking,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
+COM,3010,1,Comm Theory,0.24,0.62,0.0,0.1,0.0,0.0,0.0,0.05,gregory kei cranmer,
+COM,3020,1,Mass Comm Theory,0.58,0.13,0.29,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3020,2,Mass Comm Theory,0.43,0.35,0.22,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3060,1,Crit-Cultural Rsrch Methods,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
+COM,3110,1,Qual Comm Methods,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,chenjerai kumanyika,
+COM,3250,1,Survey of Sports Communication,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,3250,2,Survey of Sports Communication,0.8,0.08,0.08,0.0,0.04,0.0,0.0,0.0,john steven spinda,
+COM,3550,1,Principles of Public Relations,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3550,2,Principles of Public Relations,0.79,0.17,0.0,0.0,0.04,0.0,0.0,0.0,andrew stephen pyle,
+COM,3560,1,Crisis Communication,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3610,1,Argue and Debate,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,lindsey dixon,
+COM,3660,1,Video COMM w/ Adobe CC,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,michael rodgers,
+COM,3700,1,Survey of Brand Communications,0.93,0.0,0.03,0.0,0.0,0.0,0.0,0.03,lisa willi papenfus,
+COM,3720,1,Digital Analytics in Brand Com,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,alicia ni littleton,
+COM,3730,1,Media Management in Brand Comm,0.77,0.19,0.0,0.04,0.0,0.0,0.0,0.0,william reynolds,
+COM,3740,1,Brand Comm and Media Strategy,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,roger beasley,
+COM,4040,1,Media Comm & Social Identities,0.18,0.53,0.0,0.06,0.12,0.0,0.0,0.12,chenjerai kumanyika,
+COM,4040,2,Media Comm & Social Identities,0.43,0.48,0.0,0.1,0.0,0.0,0.0,0.0,chenjerai kumanyika,
+COM,4270,1,Comm in Sports Organizations,0.68,0.24,0.04,0.0,0.0,0.0,0.0,0.04,angela pratt,
+COM,4270,2,Comm in Sports Organizations,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,4280,1,Interpers/Family Comm & Sport,0.43,0.48,0.04,0.0,0.0,0.0,0.0,0.04,gregory kei cranmer,
+COM,4280,2,Interpers/Family Comm & Sport,0.4,0.56,0.0,0.0,0.0,0.0,0.0,0.04,gregory kei cranmer,
+COM,4700,1,Comm & Health,0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,4950,1,Senior Capstone,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,4950,2,Senior Capstone,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,4980,1,Acad & Prof Dev II,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.04,joseph mazer,
+COM,8110,1,Comm Research Methods II,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COOP,1010,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey frank neal,
+CPSC,1010,1,Computer Science I,0.23,0.24,0.18,0.08,0.12,0.0,0.0,0.15,salvatore lamarca,
+CPSC,1010,2,Computer Science I,0.26,0.24,0.18,0.05,0.11,0.0,0.0,0.16,lanny sitanayah,
+CPSC,1020,1,Computer Science II,0.4,0.29,0.14,0.1,0.05,0.0,0.0,0.02,yvon feaster,
+CPSC,1020,2,Computer Science II,0.49,0.2,0.11,0.11,0.08,0.0,0.0,0.02,yvon feaster,
+CPSC,1070,1,Programming Methodology,0.42,0.29,0.16,0.0,0.03,0.0,0.0,0.1,rose lowe,
+CPSC,1110,1,Intro to Programming in C,0.25,0.37,0.2,0.04,0.02,0.0,0.0,0.12,catherine hochrine,
+CPSC,1110,2,Intro to Programming in C,0.33,0.38,0.1,0.04,0.04,0.0,0.0,0.12,catherine hochrine,
+CPSC,2070,1,Discrete Structures,0.26,0.26,0.18,0.09,0.15,0.0,0.0,0.06,sandra hedetniemi,
+CPSC,2070,2,Discrete Structures,0.3,0.25,0.23,0.15,0.02,0.0,0.0,0.07,larry hodges,
+CPSC,2120,1,Algs/Data Structures,0.11,0.31,0.25,0.17,0.09,0.0,0.0,0.06,salvatore lamarca,
+CPSC,2120,2,Algs/Data Structures,0.26,0.32,0.23,0.05,0.06,0.0,0.0,0.08,salvatore lamarca,
+CPSC,2150,1,Software Dev Foundations,0.27,0.33,0.24,0.05,0.06,0.0,0.0,0.05,kevin anton plis,
+CPSC,2150,2,Software Dev Foundations,0.26,0.34,0.18,0.05,0.07,0.0,0.0,0.1,murali sitaraman,
+CPSC,2200,1,Microcomputer Appl,0.7,0.17,0.09,0.0,0.0,0.0,0.0,0.04,lanny sitanayah,
+CPSC,2310,1,Intro Computer Org,0.3,0.34,0.2,0.02,0.04,0.0,0.0,0.1,rose lowe,
+CPSC,2310,2,Intro Computer Org,0.29,0.22,0.31,0.1,0.06,0.0,0.0,0.02,rose lowe,
+CPSC,2910,1,Prof Issues I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,2,Prof Issues I,0.65,0.2,0.15,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,3,Prof Issues I,0.42,0.26,0.32,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,4,Prof Issues I,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,5,Prof Issues I,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,3220,1,Intro to Operating Systems,0.25,0.19,0.09,0.06,0.13,0.0,0.0,0.28,jacob sorber,
+CPSC,3220,2,Intro to Operating Systems,0.18,0.24,0.29,0.11,0.11,0.0,0.0,0.07,mark smotherman,
+CPSC,3300,1,Computer Systems Org,0.24,0.15,0.31,0.22,0.05,0.0,0.0,0.03,mark smotherman,
+CPSC,3500,1,Foundations of Computer Sci,0.24,0.37,0.34,0.02,0.01,0.0,0.0,0.01,wayne goddard,
+CPSC,3520,1,Programming Systems,0.37,0.4,0.09,0.0,0.09,0.0,0.0,0.06,robert schalkoff,
+CPSC,3600,1,Network Programming,0.29,0.29,0.14,0.11,0.03,0.0,0.0,0.14,feng luo,
+CPSC,3600,2,Network Programming,0.44,0.22,0.27,0.02,0.05,0.0,0.0,0.0,lanny sitanayah,
+CPSC,3620,1,Distributed/Cluster Computing,0.19,0.4,0.3,0.03,0.02,0.0,0.0,0.06,linh bao ngo,
+CPSC,3720,1,Software Engineering,0.37,0.39,0.16,0.08,0.0,0.0,0.0,0.0,kevin anton plis,
+CPSC,3720,2,Software Engineering,0.24,0.33,0.33,0.04,0.06,0.0,0.0,0.0,kevin anton plis,
+CPSC,3990,1,Advanced CI: Extreme Orange,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james martin,
+CPSC,4050,1,Computer Graphics,0.31,0.38,0.19,0.06,0.0,0.0,0.0,0.06,robert geist,
+CPSC,4110,1,Virtual Reality Systems,0.56,0.24,0.15,0.03,0.03,0.0,0.0,0.0,andrew robb,
+CPSC,4140,1,Human and Computer Interaction,0.16,0.42,0.32,0.0,0.11,0.0,0.0,0.0,sabarish venka babu,
+CPSC,4140,2,Human and Computer Interaction,0.61,0.3,0.0,0.0,0.04,0.0,0.0,0.04,sabarish venka babu,
+CPSC,4140,3,Human and Computer Interaction,0.35,0.35,0.17,0.0,0.04,0.0,0.0,0.09,christopher plaue,
+CPSC,4160,1,2-D Game Engine Construction,0.43,0.28,0.13,0.06,0.02,0.0,0.0,0.08,brian malloy,
+CPSC,4240,1,System Admin and Security,0.15,0.61,0.24,0.0,0.0,0.0,0.0,0.0,james martin,
+CPSC,4620,1,Database Management Systems,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,zijun wang,
+CPSC,4820,1,Selected Topics: Android Dev,0.75,0.06,0.13,0.06,0.0,0.0,0.0,0.0,roy pargas,
+CPSC,4820,2,Special Topics: Dig Sulpt,0.25,0.67,0.0,0.0,0.0,0.0,0.0,0.08,insun kwon,
+CPSC,4820,3,Special Topics: Data Science,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
+CPSC,4820,4,Special Topic: Cloud Comp Arch,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,amy apon,
+CPSC,4820,5,Special Topics: Tang and Embod,0.35,0.3,0.2,0.0,0.1,0.0,0.0,0.05,brygg anders ullmer,
+CPSC,4910,1,Professional Issues II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
+CPSC,6050,1,Computer Graphics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,
+CPSC,6110,1,Virtual Reality Systems,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,andrew robb,
+CPSC,6140,1,Human and Computer Interaction,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
+CPSC,6140,2,Human and Computer Interaction,0.7,0.17,0.09,0.0,0.0,0.0,0.0,0.04,sabarish venka babu,
+CPSC,6160,1,2-D Game Engine Construction,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian malloy,
+CPSC,6620,1,Database Management Systems,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,zijun wang,
+CPSC,6810,3,Selected Topic: Program Team,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,brian christop dean,
+CPSC,6820,3,Special Topics: Data Science,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
+CPSC,6820,4,Special Topic: Cloud Comp Arch,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,amy apon,
+CPSC,8050,1,Adv Comp Graphics,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,
+CPSC,8110,1,Technical Character Animation,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,christina sop joerg,
+CPSC,8220,1,Case Study in Operating Sys,0.55,0.35,0.0,0.0,0.0,0.0,0.0,0.1,robert geist,
+CPSC,8400,1,Design & Anlys of Algorithms,0.18,0.32,0.26,0.0,0.08,0.0,0.0,0.16,brian christop dean,
+CPSC,8470,1,Intro to Information Retrieval,0.66,0.17,0.14,0.0,0.0,0.0,0.0,0.03,feng luo,
+CPSC,8570,1,Network Technologies Security,0.43,0.53,0.0,0.0,0.0,0.0,0.0,0.04,hongxin hu,
+CPSC,8630,1,Multimedia Sys/Apps,0.31,0.46,0.15,0.0,0.0,0.0,0.0,0.08,zijun wang,
+CPSC,8650,1,Data Mining,0.34,0.45,0.17,0.0,0.02,0.0,0.0,0.02,zijun wang,
+CPSC,8750,1,Software Architectur,0.44,0.41,0.07,0.0,0.0,0.0,0.0,0.07,john mcgregor,
+CPSC,8810,5,Selected Topics: Eff Comput,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,rong ge,
+CRP,8020,1,Site Planning,0.73,0.23,0.0,0.0,0.04,0.0,0.0,0.0,clifford dona ellis,
+CRP,8040,1,Land Use Analysis,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
+CRP,8050,1,Plning Theory & Hist,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,mickey lauria,
+CRP,8090,1,Current Issues,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
+CRP,8200,1,Negotiation,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
+CRP,8220,1,Urban Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+CRP,8410,1,Env Planning,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,
+CRP,8730,1,Econ Dev Planning,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,timothy green,
+CSM,1500,1,Constr Prob Solving,0.41,0.33,0.19,0.04,0.04,0.0,0.0,0.0,jason lucas,
+CSM,1500,2,Constr Prob Solving,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,2020,1,Structures II,0.28,0.48,0.2,0.0,0.0,0.0,0.0,0.04,shima clarke,
+CSM,2020,2,Structures II,0.16,0.32,0.47,0.0,0.05,0.0,0.0,0.0,shima clarke,
+CSM,2040,1,Cont Documents,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,2040,2,Cont Documents,0.52,0.3,0.13,0.0,0.04,0.0,0.0,0.0,joseph mich burgett,
+CSM,2050,1,Mats & Methods II,0.2,0.52,0.28,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,2050,2,Mats & Methods II,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,raymond schneider,
+CSM,3050,1,Envir Systems II,0.18,0.61,0.18,0.0,0.03,0.0,0.0,0.0,joseph mich burgett,
+CSM,3050,2,Envir Systems II,0.29,0.43,0.21,0.07,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3520,1,Const Scheduling,0.13,0.5,0.28,0.06,0.03,0.0,0.0,0.0,christine piper,
+CSM,3520,2,Const Scheduling,0.28,0.34,0.34,0.03,0.0,0.0,0.0,0.0,christine piper,
+CSM,3530,1,Const Estimating II,0.26,0.45,0.16,0.13,0.0,0.0,0.0,0.0,seyed mousavi rizi,
+CSM,3530,2,Const Estimating II,0.22,0.47,0.28,0.0,0.03,0.0,0.0,0.0,seyed mousavi rizi,
+CSM,4540,1,Const Capstone,0.35,0.62,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4540,2,Const Capstone,0.12,0.8,0.08,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8520,1,Const Mgmt Research,0.0,0.4,0.6,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CSM,8520,400,Const Mgmt Research,0.2,0.2,0.6,0.0,0.0,0.0,0.0,0.0,roger william liska,
+CSM,8650,1,Project Management,0.15,0.69,0.08,0.0,0.08,0.0,0.0,0.0,christine piper,
+CSM,8660,1,Role in Development,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.03,susan whorton,
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.0,susan whorton,
+CU,1010,1,Univ Success Skills,0.25,0.25,0.25,0.05,0.05,0.0,0.0,0.15,matthew james kirk,
+CU,1010,2,Univ Success Skills,0.41,0.14,0.05,0.09,0.14,0.0,0.0,0.18,joseph paul thames,
+CU,1010,3,Univ Success Skills,0.53,0.21,0.05,0.11,0.0,0.0,0.0,0.11,jessica gale owens,
+CU,1010,4,Univ Success Skills,0.39,0.28,0.17,0.17,0.0,0.0,0.0,0.0,cari allyn brooks,
+CU,1010,5,Univ Success Skills,0.53,0.21,0.11,0.05,0.0,0.0,0.0,0.11,bryn zimmerman babb,
+CU,1100,100,Introduction to Tutoring,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,ashley crisp,
+CU,1970,2,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,robert austi massey,
+CU,2010,1,Sustainability Leadership,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,
+DPA,3070,1,Method 3d Production,0.86,0.04,0.0,0.0,0.04,0.0,0.0,0.07,summer 'nea benton,
+DPA,4030,1,Vis Foundations II,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,erik reed,
+DPA,8080,2,Artistic Character Animation,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,david stewart donar,
+DPA,8090,1,Rendering and Shading,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,eric patterson,
+DPA,8090,2,Rendering and Shading,0.0,0.4,0.0,0.0,0.0,0.0,0.0,0.6,eric patterson,
+ECE,1010,400,Robots in Business & Society,0.45,0.35,0.1,0.03,0.03,0.0,0.0,0.03,ian walker,
+ECE,2010,1,Logic and Computing Devices,0.21,0.23,0.25,0.22,0.05,0.0,0.0,0.04,lin zhu,
+ECE,2020,1,Electric Circuits I,0.27,0.27,0.29,0.06,0.1,0.0,0.0,0.01,william harrell,
+ECE,2070,1,Basic Electrical Engineering,0.48,0.32,0.08,0.07,0.02,0.0,0.0,0.03,timothy anglea,
+ECE,2070,2,Basic Electrical Engineering,0.55,0.29,0.1,0.03,0.0,0.0,0.0,0.03,william th kolodzey,
+ECE,2070,3,Basic Electrical Engineering,0.25,0.28,0.34,0.03,0.06,0.0,0.0,0.03,daniel bla cutshall,
+ECE,2080,1,Basic Electrical Engr Lab,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,2,Basic Electrical Engr Lab,0.25,0.45,0.15,0.1,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,4,Basic Electrical Engr Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,5,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,6,Basic Electrical Engr Lab,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,9,Basic Electrical Engr Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,10,Basic Electrical Engr Lab,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,11,Basic Electrical Engr Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,15,Basic Electrical Engr Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,1,Logic Lab,0.58,0.25,0.08,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,2,Logic Lab,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2090,3,Logic Lab,0.58,0.17,0.17,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2090,4,Logic Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2110,2,Elec Engr Lab I,0.4,0.13,0.07,0.2,0.07,0.0,0.0,0.13,apoorva dee kapadia,
+ECE,2110,4,Elec Engr Lab I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2120,1,Electrical Engineering Lab II,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2220,1,Syst Prog Concept,0.22,0.33,0.19,0.08,0.06,0.0,0.0,0.12,william reid,
+ECE,2230,1,Comp Sys Eng,0.28,0.59,0.06,0.03,0.0,0.0,0.0,0.03,walter ligon,
+ECE,2620,1,Electric Circuits II,0.46,0.38,0.11,0.01,0.03,0.0,0.0,0.02,richard groff,
+ECE,2720,1,Comp Organization,0.3,0.4,0.18,0.08,0.04,0.0,0.0,0.01,william reid,
+ECE,2730,1,Computer Org Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2730,2,Computer Org Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2730,3,Computer Org Lab,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2730,4,Computer Org Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3170,1,Rand Signal Analysis,0.24,0.27,0.25,0.13,0.05,0.0,0.0,0.06,stephen hubbard,
+ECE,3200,1,Electronics I,0.18,0.27,0.27,0.14,0.13,0.0,0.0,0.01,stephen hubbard,
+ECE,3210,1,Electronics II,0.32,0.34,0.21,0.1,0.03,0.0,0.0,0.0,stephen hubbard,
+ECE,3220,1,Intro Operating Sys,0.23,0.33,0.13,0.03,0.07,0.0,0.0,0.2,jacob sorber,
+ECE,3270,1,Dig Comp Design,0.2,0.3,0.13,0.17,0.1,0.0,0.0,0.1,melissa crawl smith,
+ECE,3300,1,Signals & Systems,0.2,0.22,0.25,0.16,0.03,0.0,0.0,0.14,carl baum,
+ECE,3520,1,Programming Systems,0.46,0.27,0.15,0.0,0.04,0.0,0.0,0.08,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.42,0.31,0.15,0.0,0.0,0.0,0.0,0.12,edward collins,
+ECE,3710,1,Microcontr Interface,0.33,0.4,0.21,0.04,0.0,0.0,0.0,0.02,william reid,
+ECE,3720,1,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,3720,2,Micro Int Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,3,Micro Int Lab,0.58,0.25,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,4,Micro Int Lab,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,5,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,3720,6,Micro Int Lab,0.4,0.1,0.3,0.0,0.2,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,7,Micro Int Lab,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3800,1,Electromagnetics,0.39,0.32,0.05,0.1,0.07,0.0,0.0,0.07,anthony martin,
+ECE,3810,1,Field Waves & Ckts,0.37,0.38,0.19,0.02,0.0,0.0,0.0,0.05,eric gordon johnson,
+ECE,4090,1,Intr to Linear Control Systems,0.49,0.38,0.0,0.05,0.05,0.0,0.0,0.03,apoorva dee kapadia,
+ECE,4190,1,Elec Mach and Drives,0.17,0.48,0.17,0.14,0.0,0.0,0.0,0.03,thomas salem,
+ECE,4270,1,Communications Sys,0.39,0.31,0.22,0.03,0.06,0.0,0.0,0.0,madhabi manandhar,
+ECE,4320,1,Instrumentation,0.3,0.2,0.4,0.0,0.1,0.0,0.0,0.0,goutam koley,
+ECE,4380,1,Computer Commun,0.31,0.25,0.22,0.06,0.06,0.0,0.0,0.11,harlan russell,
+ECE,4400,1,Local Computer Nets,0.48,0.35,0.16,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,
+ECE,4680,1,Embedded Computing,0.55,0.3,0.05,0.0,0.0,0.0,0.0,0.1,adam hoover,
+ECE,4930,2,Smart Grid,0.24,0.66,0.07,0.0,0.0,0.0,0.0,0.03,gan venayagamoorthy,
+ECE,4950,1,Int Sys Design I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4960,1,Int Sys Design II,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,richard groff,
+ECE,6190,1,Elec Mach and Drives,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,thomas salem,
+ECE,6380,1,Computer Commun,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,harlan russell,
+ECE,6460,1,Antennas,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,anthony martin,
+ECE,6930,1,VLSI Design Automation,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,yingjie lao,
+ECE,8160,1,Elec Power Distr Sys Engr,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,elham makram,
+ECE,8260,1,Solar Cells,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,
+ECE,8400,1,Semicond Devices,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,
+ECE,8440,1,Digital Signal Proc,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,eric patterson,
+ECE,8560,1,Pattern Recognition,0.58,0.36,0.0,0.0,0.0,0.0,0.0,0.06,robert schalkoff,
+ECE,8740,1,Adv Nonlinear Cntrl,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,yongqiang wang,
+ECE,8780,1,High-Perform Computing w GPUs,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,
+ECE,8930,10,Distributed Denial of Service,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,
+ECON,2000,1,Economic Concepts,0.28,0.4,0.23,0.1,0.0,0.0,0.0,0.0,jonathan orr ernest,
+ECON,2000,2,Economic Concepts,0.51,0.23,0.13,0.05,0.05,0.0,0.0,0.03,jonathan orr ernest,
+ECON,2000,3,Economic Concepts,0.31,0.38,0.15,0.03,0.13,0.0,0.0,0.0,miren ivankovic,
+ECON,2110,1,Principles of Microeconomics,0.21,0.28,0.26,0.1,0.13,0.0,0.0,0.03,amanda caitlin kerr,
+ECON,2110,2,Principles of Microeconomics,0.3,0.53,0.08,0.05,0.03,0.0,0.0,0.03,molly espey,
+ECON,2110,3,Principles of Microeconomics,0.14,0.24,0.23,0.29,0.08,0.0,0.0,0.03,liuna issagholian,
+ECON,2110,4,Principles of Microeconomics,0.38,0.38,0.13,0.13,0.0,0.0,0.0,0.0,maria droganova,
+ECON,2110,5,Principles of Microeconomics,0.38,0.33,0.15,0.05,0.05,0.0,0.0,0.05,roksan ghanbariamin,
+ECON,2110,6,Principles of Microeconomics,0.18,0.21,0.31,0.09,0.15,0.0,0.0,0.06,bradley keith hobbs,
+ECON,2110,7,Principles of Microeconomics,0.16,0.24,0.26,0.16,0.13,0.0,0.0,0.06,bradley keith hobbs,
+ECON,2110,8,Principles of Microeconomics,0.18,0.43,0.2,0.12,0.06,0.0,0.0,0.01,kelsey vict roberts,
+ECON,2110,10,Principles of Microeconomics,0.51,0.14,0.14,0.08,0.08,0.0,0.0,0.04,steven johnson,
+ECON,2110,11,Principles of Microeconomics,0.34,0.35,0.14,0.1,0.03,0.0,0.0,0.04,leah jacq kitashima,
+ECON,2110,12,Principles of Microeconomics,0.3,0.55,0.08,0.05,0.0,0.0,0.0,0.03,benjamin jo schwall,
+ECON,2120,1,Principles of Macroeconomics,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,scott baier,
+ECON,2120,2,Principles of Macroeconomics,0.26,0.37,0.21,0.16,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,3,Principles of Macroeconomics,0.3,0.35,0.3,0.0,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,4,Principles of Macroeconomics,0.21,0.58,0.11,0.0,0.11,0.0,0.0,0.0,scott baier,
+ECON,2120,5,Principles of Macroeconomics,0.35,0.2,0.45,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,6,Principles of Macroeconomics,0.16,0.47,0.21,0.16,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,7,Principles of Macroeconomics,0.21,0.37,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,8,Principles of Macroeconomics,0.16,0.47,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,9,Principles of Macroeconomics,0.2,0.45,0.3,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,10,Principles of Macroeconomics,0.11,0.53,0.32,0.0,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,11,Principles of Macroeconomics,0.16,0.32,0.47,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,12,Principles of Macroeconomics,0.17,0.33,0.33,0.0,0.17,0.0,0.0,0.0,scott baier,
+ECON,2120,13,Principles of Macroeconomics,0.47,0.41,0.0,0.0,0.06,0.0,0.0,0.06,scott baier,
+ECON,2120,14,Principles of Macroeconomics,0.35,0.47,0.06,0.06,0.06,0.0,0.0,0.0,scott baier,
+ECON,2120,15,Principles of Macroeconomics,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,16,Principles of Macroeconomics,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,17,Principles of Macroeconomics,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,18,Principles of Macroeconomics,0.16,0.58,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,19,Principles of Macroeconomics,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,20,Principles of Macroeconomics,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,peter david lorenz,
+ECON,2120,21,Principles of Macroeconomics,0.6,0.37,0.01,0.01,0.0,0.0,0.0,0.0,huili li,
+ECON,2120,22,Principles of Macroeconomics,0.27,0.56,0.17,0.0,0.0,0.0,0.0,0.0,ce castellon chicas,
+ECON,2120,23,Principles of Macroeconomics,0.3,0.48,0.18,0.0,0.0,0.0,0.0,0.05,jordan adamson,
+ECON,2120,24,Principles of Macroeconomics,0.1,0.23,0.16,0.19,0.12,0.0,0.0,0.19,ralph charles allen,
+ECON,2120,25,Principles of Macroeconomics,0.19,0.19,0.11,0.22,0.04,0.0,0.0,0.26,ralph charles allen,
+ECON,2120,26,Principles of Macroeconomics,0.28,0.42,0.22,0.08,0.0,0.0,0.0,0.0,scott barkowski,
+ECON,2120,27,Principles of Macroeconomics,0.4,0.5,0.08,0.03,0.0,0.0,0.0,0.0,peter david lorenz,
+ECON,2120,28,Principles of Macroecon (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,True
+ECON,3020,1,Money and Banking,0.33,0.38,0.2,0.1,0.0,0.0,0.0,0.0,smriti bhargava,
+ECON,3060,1,Managerial Economics,0.25,0.23,0.25,0.15,0.07,0.0,0.0,0.05,timothy jay bacon,
+ECON,3100,1,International Econ,0.24,0.4,0.32,0.03,0.02,0.0,0.0,0.0,richard alan sessa,
+ECON,3140,1,Intermediate Micro,0.43,0.28,0.23,0.0,0.03,0.0,0.0,0.05,molly espey,
+ECON,3140,2,Intermediate Micro,0.32,0.29,0.11,0.13,0.05,0.0,0.0,0.11,patrick warren,
+ECON,3140,3,Intermediate Micro,0.23,0.21,0.46,0.03,0.08,0.0,0.0,0.0,molly espey,
+ECON,3150,1,Intermediate Macro,0.26,0.36,0.22,0.12,0.03,0.0,0.0,0.01,michal jerzmanowski,
+ECON,3150,2,Intermediate Macro,0.26,0.26,0.29,0.0,0.08,0.0,0.0,0.11,sergey vla mityakov,
+ECON,3440,1,Property Rights,0.19,0.19,0.26,0.11,0.15,0.0,0.0,0.11,dar litsukova-bokar,
+ECON,3500,1,Moral & Ethical Econ,0.15,0.27,0.3,0.06,0.15,0.0,0.0,0.06,bradley keith hobbs,
+ECON,3600,1,Public Choice,0.36,0.23,0.26,0.05,0.05,0.0,0.0,0.05,michael makowsky,
+ECON,4010,1,Labor Mkt Analysis,0.23,0.42,0.23,0.0,0.08,0.0,0.0,0.04,curtis simon,
+ECON,4020,1,Law and Economics,0.2,0.47,0.23,0.07,0.03,0.0,0.0,0.0,thomas wins hazlett,
+ECON,4050,1,Intro to Econometric,0.28,0.28,0.23,0.12,0.07,0.0,0.0,0.02,scott barkowski,
+ECON,4200,1,Pub Sector Econ,0.2,0.3,0.33,0.05,0.08,0.0,0.0,0.05,william dougan,
+ECON,4240,1,Organization of Ind,0.53,0.23,0.2,0.03,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,4260,1,Sem Sport Economics,0.6,0.32,0.0,0.0,0.0,0.0,0.0,0.08,raymond sauer,
+ECON,4270,1,Dev American Economy,0.22,0.5,0.19,0.06,0.03,0.0,0.0,0.0,howard ne bodenhorn,
+ECON,4290,1,Economics of Energy Markets,0.37,0.5,0.13,0.0,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,4400,1,Game Theory,0.23,0.46,0.27,0.0,0.04,0.0,0.0,0.0,charles thomas,
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.11,0.42,0.32,0.11,0.0,0.0,0.0,0.05,scott templeton,
+ECON,6400,1,Game Theory,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,charles thomas,
+ECON,8020,2,Adv Econ Concepts and Applic I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
+ECON,8050,1,Macroeconomic Theory,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,
+ECON,8070,1,Econometrics II,0.38,0.48,0.1,0.0,0.0,0.0,0.0,0.05,chungsang lam,
+ECON,8110,1,Econ of Environment,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,
+ECON,8200,1,Public Finance,0.44,0.33,0.0,0.0,0.0,0.0,0.0,0.22,william dougan,
+ECON,9000,2,Empirical Public Choice,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
+ED,1050,1,Educ Orientation,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,william da mccorkle,
+ED,1050,2,Educ Orientation,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,william da mccorkle,
+EDC,3900,2,Skills for Stu Leads,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,3,Skills for Stu Leads,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,4,Skills for Stu Leads,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,5,Skills for Stu Leads,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,6,Skills for Stu Leads,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDEC,2200,1,Family/School/Com,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
+EDEC,8100,500,Adv Ece Found & Meth,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEL,3210,1,Pe for the Elem Tchr,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4510,1,Elem Methods in Science Tchg,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
+EDEL,4520,1,Elem Methods Math Teaching,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+EDEL,4520,2,Elem Methods Math Teaching,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+EDEL,4870,1,Ele Meth Soc Studies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,dwane valera,
+EDF,3010,1,Principles of American Educat,0.86,0.09,0.06,0.0,0.0,0.0,0.0,0.0,william da mccorkle,
+EDF,3020,1,Educational Psychology,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
+EDF,3020,2,Educational Psychology,0.83,0.13,0.05,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
+EDF,3020,3,Educational Psychology,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0,stephen chou,
+EDF,3340,1,Child Growth and Development,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
+EDF,3340,3,Child Growth and Development,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
+EDF,3350,1,Adolescent Growth & Develop,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
+EDF,4800,3,Digital Media & Learning,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,juan li,
+EDF,4800,300,Digital Media & Learning,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,8080,300,Ed Tests and Measure,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,heather rog brooker,
+EDF,9700,1,Democratic Education,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,
+EDF,9770,400,Multi Regress Ed Research,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jennie lynn farmer,
+EDF,9790,1,Qualitative Research in Educ,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDHD,3110,1,CI- Research in DM & Learning,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,david matthew boyer,
+EDL,7150,500,Sch & Comm Relations,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,frederick buskey,
+EDL,7300,502,Techniq of Supervision-Pub Sch,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,hans william klar,
+EDL,7400,511,Curr Plan: Sch Adm,0.88,0.0,0.06,0.0,0.06,0.0,0.0,0.0,barbara nesbitt,
+EDL,7510,500,El Prin & Spv Ex II,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,frederick buskey,
+EDL,7650,1,Assessment Hi Edu,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,kristin walker,
+EDL,7650,2,Assessment Hi Edu,0.17,0.72,0.11,0.0,0.0,0.0,0.0,0.0,kristin walker,
+EDL,8500,501,Practicum: District,0.38,0.0,0.08,0.0,0.54,0.0,0.0,0.0,elizabeth reynolds,
+EDL,8850,512,STEM - School Admin,0.57,0.0,0.0,0.0,0.43,0.0,0.0,0.0,william havice,
+EDL,9110,400,Systematic Inq Ed L,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,
+EDL,9750,2,College Teaching,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,pamela havice,
+EDLT,4580,1,Early Literacy: Birth-Kindergn,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4620,1,Reading Children's Lit in Elem,0.59,0.27,0.09,0.05,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,8270,300,Content Area Rdg/Wtg-MS & HS,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8410,501,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
+EDLT,8410,502,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,
+EDLT,8410,505,Early Literacy Inst Strategies,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephanie amb pitts,
+EDLT,8810,506,Reading Recovery Teacher II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,
+EDLT,8830,506,Read Recovery Practicum II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,
+EDSC,4370,1,Technology in Math,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,
+EDSC,4480,1,Teach Intern Sec Soc,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,marshall alan darby,
+EDSP,3700,2,Intro to Special Education,0.81,0.17,0.03,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,
+EDSP,3700,4,Intro to Special Education,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,catherine griffith,
+EDSP,4910,1,Ed Assess Ind W/Dis,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
+EES,2020,1,Environ Engr Fundamentals II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
+EES,4010,1,Environmental Engr,0.49,0.51,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.36,0.21,0.25,0.0,0.07,0.0,0.0,0.11,ezra lucas ho cates,
+EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,4840,2,Solid Waste Mgt,0.58,0.35,0.04,0.0,0.04,0.0,0.0,0.0,thomas overcamp,
+EES,4850,2,Hazard Waste Management,0.22,0.52,0.26,0.0,0.0,0.0,0.0,0.0,mark schlautman,
+EES,4860,6,Environmental Sustainability,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
+EES,8030,1,Phy/Chem Ops W/WW T,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,ezra lucas ho cates,
+EES,8040,1,Biochem Ops WW Trt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,
+EES,8090,1,Subsurface Remed Mod,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,ronald falta,
+ELE,3010,1,Intro to Entre,0.44,0.51,0.03,0.0,0.0,0.0,0.0,0.03,christina kyprianou,
+ELE,3010,2,Intro to Entre,0.41,0.51,0.08,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
+ELE,3010,3,Intro to Entre,0.24,0.36,0.38,0.0,0.02,0.0,0.0,0.0,ashley will parnell,
+ELE,3140,1,New Venture Creat I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,chad navis,
+ELE,3140,2,New Venture Creat I,0.57,0.3,0.14,0.0,0.0,0.0,0.0,0.0,chad navis,
+ELE,4010,1,Exec Lead & Entr II,0.24,0.33,0.38,0.02,0.0,0.0,0.0,0.02,ashley will parnell,
+ENGL,1030,1,Accelerated Composition,0.62,0.24,0.05,0.0,0.05,0.0,0.0,0.05,chloe helene cahill,
+ENGL,1030,2,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,1030,3,Accelerated Composition,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,sharif youssef,
+ENGL,1030,4,Accelerated Composition,0.7,0.05,0.05,0.05,0.0,0.0,0.0,0.15,melissa dugan,
+ENGL,1030,7,Accelerated Composition,0.71,0.05,0.14,0.0,0.1,0.0,0.0,0.0,charlotte est lucke,
+ENGL,1030,8,Accelerated Composition,0.81,0.1,0.0,0.05,0.05,0.0,0.0,0.0,melissa dugan,
+ENGL,1030,9,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,katie jo vann,
+ENGL,1030,10,Accelerated Composition,0.57,0.29,0.05,0.0,0.0,0.0,0.0,0.1,krist aldebol-hazle,
+ENGL,1030,11,Accelerated Composition,0.76,0.19,0.0,0.0,0.05,0.0,0.0,0.0,robert brissey,
+ENGL,1030,12,Accelerated Composition,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,robert brissey,
+ENGL,1030,13,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,kala parker,
+ENGL,1030,15,Accelerated Composition,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,katie jo vann,
+ENGL,1030,16,Accelerated Composition,0.59,0.24,0.0,0.0,0.06,0.0,0.0,0.12,kala parker,
+ENGL,1030,18,Accelerated Composition,0.81,0.05,0.0,0.0,0.0,0.0,0.0,0.14,katie jo vann,
+ENGL,1030,19,Accelerated Composition,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,samuel david martin,
+ENGL,1030,20,Accelerated Composition,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,samuel david martin,
+ENGL,1030,21,Accelerated Composition,0.76,0.14,0.05,0.0,0.05,0.0,0.0,0.0,brian lee gaines,
+ENGL,1030,22,Accelerated Composition,0.62,0.24,0.1,0.0,0.05,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,23,Accelerated Composition,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,charlotte est lucke,
+ENGL,1030,24,Accelerated Composition,0.65,0.12,0.12,0.06,0.06,0.0,0.0,0.0,brian lee gaines,
+ENGL,1030,25,Accelerated Composition,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,michael davi measel,
+ENGL,1030,26,Accelerated Composition,0.31,0.38,0.0,0.0,0.19,0.0,0.0,0.13,la'cresha ulo green,
+ENGL,1030,27,Accelerated Composition,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,28,Accelerated Composition,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,michael davi measel,
+ENGL,1030,30,Accelerated Composition,0.69,0.06,0.06,0.13,0.0,0.0,0.0,0.06,michael russo,
+ENGL,1030,31,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,laurie pfister epps,
+ENGL,1030,37,Accelerated Composition,0.76,0.05,0.1,0.0,0.0,0.0,0.0,0.1,christopher stuart,
+ENGL,1030,39,Accelerated Composition,0.81,0.1,0.0,0.0,0.0,0.0,0.0,0.1,michael russo,
+ENGL,1030,40,Accelerated Composition,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,austin gorman,
+ENGL,1030,41,Accelerated Composition,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,christopher stuart,
+ENGL,1030,44,Accelerated Composition,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,erica mich marquard,
+ENGL,1030,48,Accelerated Composition,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,matthew scot duncan,
+ENGL,1030,49,Accelerated Composition,0.33,0.44,0.0,0.0,0.11,0.0,0.0,0.11,matthew scot duncan,
+ENGL,1030,51,Accelerated Composition,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,stephen quigley,
+ENGL,1030,52,Accelerated Composition,0.76,0.14,0.0,0.0,0.1,0.0,0.0,0.0,stephen quigley,
+ENGL,1030,55,Accelerated Composition,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,daniel frank,
+ENGL,1030,57,Accelerated Composition,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,krist aldebol-hazle,
+ENGL,1030,58,Accelerated Composition,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,chloe helene cahill,
+ENGL,1030,60,Accelerated Composition,0.62,0.29,0.0,0.0,0.05,0.0,0.0,0.05,jennifer forsberg,
+ENGL,1030,62,Accelerated Composition,0.85,0.05,0.05,0.05,0.0,0.0,0.0,0.0,jennifer forsberg,
+ENGL,1030,63,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,christa kettlewell,
+ENGL,1030,65,Accelerated Composition,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,christa kettlewell,
+ENGL,1030,67,Accelerated Composition,0.14,0.71,0.05,0.0,0.0,0.0,0.0,0.1,renesha moniq poole,
+ENGL,1030,68,Accelerated Composition,0.06,0.78,0.06,0.06,0.0,0.0,0.0,0.06,renesha moniq poole,
+ENGL,1030,69,Accelerated Composition,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,dia quaglia beltran,
+ENGL,1030,70,Accelerated Composition,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,parker elizabe king,
+ENGL,1030,71,Accelerated Composition,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,yvonne kao,
+ENGL,1030,72,Accelerated Composition,0.71,0.12,0.06,0.06,0.0,0.0,0.0,0.06,yvonne kao,
+ENGL,1030,555,Accelerated Composition,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,
+ENGL,2020,555,The Major Forms of Literature,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,
+ENGL,2120,1,World Literature,0.34,0.34,0.14,0.07,0.03,0.0,0.0,0.07,andrew mathas,
+ENGL,2120,2,World Literature,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.03,daniel scott citro,
+ENGL,2120,3,World Literature,0.28,0.34,0.21,0.03,0.07,0.0,0.0,0.07,karen kettnich,
+ENGL,2120,4,World Literature,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,walter edgar hunter,
+ENGL,2120,5,World Literature,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,stephanie stripling,
+ENGL,2120,6,World Literature,0.28,0.45,0.17,0.03,0.07,0.0,0.0,0.0,karen kettnich,
+ENGL,2120,7,World Literature,0.76,0.17,0.03,0.03,0.0,0.0,0.0,0.0,stephanie stripling,
+ENGL,2120,11,World Literature,0.48,0.21,0.24,0.03,0.0,0.0,0.0,0.03,chloe mich whitaker,
+ENGL,2120,12,World Literature,0.41,0.41,0.07,0.07,0.0,0.0,0.0,0.03,chloe mich whitaker,
+ENGL,2120,13,World Literature,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.03,daniel scott citro,
+ENGL,2120,14,World Literature,0.38,0.48,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2120,16,World Literature,0.2,0.63,0.1,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,
+ENGL,2120,17,World Literature,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,april susanne pelt,
+ENGL,2120,18,World Literature,0.45,0.39,0.13,0.03,0.0,0.0,0.0,0.0,olga anatol volkova,
+ENGL,2120,19,World Literature,0.43,0.33,0.17,0.03,0.03,0.0,0.0,0.0,karen kettnich,
+ENGL,2120,20,World Literature,0.37,0.33,0.1,0.07,0.03,0.0,0.0,0.1,katalin beck,
+ENGL,2130,1,British Literature,0.76,0.21,0.03,0.0,0.0,0.0,0.0,0.0,benjamin hudson,
+ENGL,2130,2,British Literature,0.57,0.3,0.1,0.0,0.03,0.0,0.0,0.0,christopher benson,
+ENGL,2130,3,British Literature,0.77,0.2,0.0,0.0,0.0,0.0,0.0,0.03,christopher benson,
+ENGL,2130,4,British Literature,0.86,0.07,0.03,0.0,0.03,0.0,0.0,0.0,stephanie stripling,
+ENGL,2130,6,British Literature,0.61,0.32,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,2130,7,British Literature,0.8,0.13,0.03,0.0,0.0,0.0,0.0,0.03,benjamin hudson,
+ENGL,2130,10,British Literature,0.63,0.27,0.0,0.03,0.07,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,2130,12,British Literature,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,13,British Literature,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,lucian ghita,
+ENGL,2130,14,British Literature,0.77,0.17,0.0,0.0,0.0,0.0,0.0,0.07,lucian ghita,
+ENGL,2140,1,American Literature,0.7,0.13,0.13,0.0,0.03,0.0,0.0,0.0,jennifer forsberg,
+ENGL,2140,2,American Literature,0.43,0.29,0.07,0.04,0.04,0.0,0.0,0.14,jennifer forsberg,
+ENGL,2140,3,American Literature,0.72,0.21,0.03,0.03,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2140,4,American Literature,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,5,American Literature,0.29,0.43,0.11,0.07,0.0,0.0,0.0,0.11,david charles foltz,
+ENGL,2140,6,American Literature,0.19,0.38,0.23,0.04,0.04,0.0,0.0,0.12,david charles foltz,
+ENGL,2140,7,American Literature,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,8,American Literature,0.15,0.41,0.19,0.0,0.11,0.0,0.0,0.15,david charles foltz,
+ENGL,2140,12,American Literature,0.11,0.37,0.15,0.07,0.19,0.0,0.0,0.11,david charles foltz,
+ENGL,2140,13,American Literature,0.78,0.15,0.0,0.0,0.0,0.0,0.0,0.07,candace wiley,
+ENGL,2140,14,American Literature,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,15,American Literature,0.8,0.13,0.0,0.03,0.03,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,16,American Literature,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2140,17,American Literature,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,adrian carson,
+ENGL,2140,18,American Literature,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,adrian carson,
+ENGL,2140,19,American Literature,0.72,0.03,0.0,0.0,0.1,0.0,0.0,0.14,candace wiley,
+ENGL,2140,20,American Literature,0.77,0.12,0.0,0.0,0.0,0.0,0.0,0.12,candace wiley,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.48,0.32,0.13,0.03,0.0,0.0,0.0,0.03,john logan pursley,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.33,0.37,0.1,0.1,0.07,0.0,0.0,0.03,megan no macalystre,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.52,0.34,0.07,0.03,0.03,0.0,0.0,0.0,megan no macalystre,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.47,0.3,0.03,0.0,0.1,0.0,0.0,0.1,andrew mathas,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.67,0.23,0.03,0.0,0.07,0.0,0.0,0.0,megan no macalystre,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.5,0.33,0.03,0.03,0.07,0.0,0.0,0.03,andrew mathas,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.43,0.37,0.13,0.07,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.33,0.07,0.0,0.07,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,mari elena ramler,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.3,0.57,0.07,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,benjamin hudson,
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.8,0.1,0.03,0.0,0.03,0.0,0.0,0.03,benjamin hudson,
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,sharif youssef,
+ENGL,3010,1,Great Books of Western World,0.12,0.65,0.18,0.0,0.0,0.0,0.0,0.06,colin pearce,
+ENGL,3040,2,Business Writing,0.81,0.1,0.05,0.05,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3040,3,Business Writing,0.6,0.2,0.1,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,
+ENGL,3040,4,Business Writing,0.64,0.14,0.09,0.0,0.0,0.0,0.0,0.14,geveryl le robinson,
+ENGL,3040,5,Business Writing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3040,13,Business Writing,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,katalin beck,
+ENGL,3040,14,Business Writing,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,philip randall,
+ENGL,3040,16,Business Writing,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,emily anne boyter,
+ENGL,3040,17,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharif youssef,
+ENGL,3040,18,Business Writing,0.75,0.0,0.15,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,
+ENGL,3040,19,Business Writing,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3040,22,Business Writing,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,sharif youssef,
+ENGL,3040,400,Business Writing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,
+ENGL,3040,401,Business Writing,0.71,0.14,0.05,0.0,0.05,0.0,0.0,0.05,hayley ren zertuche,
+ENGL,3040,402,Business Writing,0.71,0.19,0.0,0.0,0.05,0.0,0.0,0.05,hayley ren zertuche,
+ENGL,3040,403,Business Writing,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,hayley ren zertuche,
+ENGL,3040,404,Business Writing,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,steph kartalopoulos,
+ENGL,3040,405,Business Writing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,
+ENGL,3040,406,Business Writing,0.6,0.3,0.0,0.05,0.0,0.0,0.0,0.05,steph kartalopoulos,
+ENGL,3040,407,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,
+ENGL,3100,1,Crit Writ Lit,0.38,0.48,0.1,0.0,0.05,0.0,0.0,0.0,david sweene coombs,
+ENGL,3100,2,Crit Writ Lit,0.19,0.33,0.14,0.1,0.14,0.0,0.0,0.1,william stockton,
+ENGL,3100,4,Crit Writ Lit,0.29,0.48,0.14,0.0,0.0,0.0,0.0,0.1,david sweene coombs,
+ENGL,3120,1,Advanced Composition,0.57,0.19,0.1,0.0,0.1,0.0,0.0,0.05,elizabeth stansell,
+ENGL,3120,2,Advanced Composition,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3140,1,Technical Writing,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,2,Technical Writing,0.74,0.22,0.0,0.0,0.04,0.0,0.0,0.0,nathan riggs,
+ENGL,3140,3,Technical Writing,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3140,4,Technical Writing,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,eric stephens,
+ENGL,3140,5,Technical Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,6,Technical Writing,0.67,0.24,0.0,0.1,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,7,Technical Writing,0.81,0.05,0.05,0.0,0.05,0.0,0.0,0.05,eric stephens,
+ENGL,3140,9,Technical Writing,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,10,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
+ENGL,3140,11,Technical Writing,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,3140,12,Technical Writing,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,3140,13,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
+ENGL,3140,14,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,3140,15,Technical Writing,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,joshua wood,
+ENGL,3140,16,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,joshua wood,
+ENGL,3140,18,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3140,19,Technical Writing,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3140,25,Technical Writing,0.8,0.15,0.0,0.05,0.0,0.0,0.0,0.0,crystal pa stephens,
+ENGL,3150,1,Scientific Writing & Comm,0.47,0.26,0.16,0.05,0.0,0.0,0.0,0.05,william pulley,
+ENGL,3150,2,Scientific Writing & Comm,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3150,5,Scientific Writing & Comm,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,
+ENGL,3150,18,Scientific Writing & Comm,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,christopher benson,
+ENGL,3320,1,Visual Communication,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,sean williams,
+ENGL,3330,1,Writing News Media,0.47,0.33,0.07,0.0,0.13,0.0,0.0,0.0,geveryl le robinson,
+ENGL,3450,1,Structure of Fiction,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
+ENGL,3460,1,Structure of Poetry,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,candace wiley,
+ENGL,3480,1,Structure Screenplay,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
+ENGL,3540,1,Lit Middle East & North Africa,0.53,0.29,0.0,0.0,0.06,0.0,0.0,0.12,angela naimou,
+ENGL,3570,1,Film,0.05,0.7,0.15,0.0,0.05,0.0,0.0,0.05,amy monaghan,
+ENGL,3570,2,Film,0.06,0.61,0.17,0.0,0.11,0.0,0.0,0.06,amy monaghan,
+ENGL,3570,3,Film,0.05,0.79,0.11,0.0,0.05,0.0,0.0,0.0,amy monaghan,
+ENGL,3850,1,Children's Lit,0.74,0.11,0.0,0.05,0.05,0.0,0.0,0.05,megan no macalystre,
+ENGL,3970,1,Brit Lit Survey II,0.56,0.22,0.17,0.0,0.0,0.0,0.0,0.06,john morgenstern,
+ENGL,3980,1,Amer Lit Survey I,0.2,0.53,0.2,0.0,0.07,0.0,0.0,0.0,rhondda robi thomas,
+ENGL,3980,2,Amer Lit Survey I,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,susanna ashton,
+ENGL,3990,1,Amer Lit Survey II,0.68,0.11,0.16,0.0,0.0,0.0,0.0,0.05,walter edgar hunter,
+ENGL,3990,2,Amer Lit Survey II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,4070,1,Medieval Period,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,
+ENGL,4110,1,Shakespeare,0.48,0.29,0.0,0.0,0.14,0.0,0.0,0.1,elizabeth rivlin,
+ENGL,4110,2,Shakespeare,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,andrew lemons,
+ENGL,4110,3,Shakespeare,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4190,1,Post Col & World Lit,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
+ENGL,4200,1,Amer Lit to 1799,0.5,0.3,0.0,0.0,0.1,0.0,0.0,0.1,jonathan beec field,
+ENGL,4250,1,American Novel,0.39,0.22,0.17,0.06,0.06,0.0,0.0,0.11,susanna ashton,
+ENGL,4320,1,Modern Fiction,0.39,0.44,0.06,0.0,0.06,0.0,0.0,0.06,gabriel and hankins,
+ENGL,4360,1,Feminist Literary Criticism,0.59,0.29,0.0,0.0,0.06,0.0,0.0,0.06,michelle renee ty,
+ENGL,4400,1,Literary Theory,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,michelle renee ty,
+ENGL,4420,1,Cultural Studies,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,gabriel and hankins,
+ENGL,4450,1,Fiction Workshop,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,4580,1,Adaptations of World Classics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,4650,1,Topics in Literature from 1900,0.67,0.11,0.06,0.0,0.11,0.0,0.0,0.06,garry bertholf,
+ENGL,4750,1,Writing for Media,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,jonathan beec field,
+ENGL,4780,1,Digital Literacy,0.76,0.06,0.06,0.0,0.06,0.0,0.0,0.06,megan eatman,
+ENGL,4890,1,Topics Write & Publ,0.78,0.06,0.0,0.0,0.06,0.0,0.0,0.11,jan rune holmevik,
+ENGL,4920,1,Modern Rhetoric,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,megan eatman,
+ENGL,4960,1,Senior Seminar,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,rhondda robi thomas,
+ENGL,4960,2,Senior Seminar,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,angela naimou,
+ENGL,4960,3,Senior Seminar,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,4960,4,Senior Seminar,0.42,0.25,0.25,0.0,0.0,0.0,0.0,0.08,william stockton,
+ENGR,1020,312,Engineering Discipl & Skills,0.07,0.22,0.3,0.15,0.07,0.0,0.0,0.19,bradley putman,
+ENGR,1020,317,Engineering Discipl & Skills,0.19,0.41,0.19,0.06,0.07,0.0,0.0,0.09,ashley childers,
+ENGR,1020,318,Engineering Discipl & Skills,0.06,0.44,0.31,0.06,0.11,0.0,0.0,0.02,ashley childers,
+ENGR,1060,242,Engr Discipline & Skills II,0.03,0.1,0.37,0.3,0.13,0.0,0.0,0.07,sarah grigg,
+ENGR,1060,312,Engr Discipline & Skills II,0.0,0.4,0.6,0.0,0.0,0.0,0.0,0.0,bradley putman,
+ENGR,1410,122,Programming & Problem Solving,0.31,0.38,0.27,0.02,0.0,0.0,0.0,0.02,matthew kent miller,
+ENGR,1410,321,Programming & Problem Solving,0.02,0.3,0.41,0.15,0.02,0.0,0.0,0.09,michael giebner,
+ENGR,1410,323,Programming & Problem Solving,0.22,0.46,0.22,0.09,0.0,0.0,0.0,0.02,mariah magagnotti,
+ENGR,1410,324,Programming & Problem Solving,0.22,0.37,0.3,0.09,0.0,0.0,0.0,0.02,irene marie ferrara,
+ENGR,1410,325,Programming & Problem Solving,0.33,0.33,0.2,0.09,0.02,0.0,0.0,0.04,steven brandon,
+ENGR,1410,326,Programming & Problem Solving,0.27,0.38,0.22,0.02,0.0,0.0,0.0,0.11,steven brandon,
+ENGR,1410,621,Programming & Problem Solving,0.25,0.3,0.25,0.08,0.03,0.0,0.0,0.1,william martin,
+ENGR,1410,622,Programming & Problem Solving,0.34,0.4,0.09,0.11,0.02,0.0,0.0,0.04,william martin,
+ENGR,1410,623,Programming & Problem Solving,0.43,0.49,0.09,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,
+ENGR,1410,624,Programming & Problem Solving,0.16,0.45,0.3,0.05,0.02,0.0,0.0,0.02,andrew isaa neptune,
+ENGR,1410,625,Programming & Problem Solving,0.15,0.59,0.13,0.04,0.0,0.0,0.0,0.09,matthew kent miller,
+ENGR,1410,626,Programming & Problem Solving,0.14,0.36,0.32,0.11,0.0,0.0,0.0,0.07,matthew kent miller,
+ENGR,1410,627,Programming & Problem Solving,0.21,0.55,0.17,0.02,0.02,0.0,0.0,0.02,sarah grigg,
+ENGR,1410,628,Programming & Problem Solving,0.09,0.56,0.24,0.09,0.0,0.0,0.0,0.03,sarah grigg,
+ENGR,1410,821,Programming & Problem Solving,0.13,0.39,0.19,0.16,0.03,0.0,0.0,0.1,andrew isaa neptune,
+ENGR,1410,822,Programming & Problem Solving,0.33,0.33,0.26,0.04,0.0,0.0,0.0,0.04,andrew isaa neptune,
+ENGR,1410,823,Program & Prob Solving (HON),0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,john minor,True
+ENGR,1410,824,Program & Prob Solving (HON),0.44,0.53,0.03,0.0,0.0,0.0,0.0,0.0,jonathan maier,True
+ENGR,1410,825,Programming & Problem Solving,0.16,0.38,0.31,0.09,0.0,0.0,0.0,0.07,mariah magagnotti,
+ENGR,1410,826,Programming & Problem Solving,0.11,0.37,0.41,0.02,0.02,0.0,0.0,0.07,mariah magagnotti,
+ENGR,1410,827,Programming & Problem Solving,0.13,0.6,0.27,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,
+ENGR,1410,828,Programming & Problem Solving,0.15,0.35,0.24,0.24,0.0,0.0,0.0,0.03,irene marie ferrara,
+ENGR,1640,500,Engineering MATLAB Programming,0.14,0.43,0.29,0.14,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,1640,501,Engineering MATLAB Programming,0.05,0.35,0.25,0.2,0.15,0.0,0.0,0.0,jonathan maier,
+ENGR,2080,382,Engr Graphics & Machine Design,0.68,0.26,0.0,0.04,0.0,0.0,0.0,0.02,john minor,
+ENGR,2080,384,Engr Graphics & Machine Design,0.61,0.21,0.04,0.02,0.09,0.0,0.0,0.04,anthony pau garland,
+ENGR,2080,385,Engr Graphics & Machine Design,0.49,0.19,0.14,0.04,0.07,0.0,0.0,0.07,anthony pau garland,
+ENGR,2080,686,Engr Graphics & Machine Design,0.55,0.23,0.13,0.02,0.04,0.0,0.0,0.04,garrison llo broome,
+ENGR,2080,881,Engr Graphics & Machine Design,0.47,0.33,0.09,0.03,0.07,0.0,0.0,0.02,amaninder sing gill,
+ENGR,2080,882,Engr Graphics & Machine Design,0.63,0.28,0.05,0.02,0.02,0.0,0.0,0.0,amaninder sing gill,
+ENGR,2080,884,Engr Graphics & Machine Design,0.66,0.23,0.05,0.0,0.04,0.0,0.0,0.02,nighat yasmin,
+ENGR,2080,885,Engr Graphics & Machine Design,0.61,0.29,0.05,0.02,0.04,0.0,0.0,0.0,sarah rowlinson,
+ENGR,2080,886,Engr Graphics & Machine Design,0.5,0.29,0.11,0.04,0.05,0.0,0.0,0.02,sarah rowlinson,
+ENGR,2100,601,CAD & Engineering Applications,0.67,0.19,0.13,0.0,0.02,0.0,0.0,0.0,nighat yasmin,
+ENGR,2100,602,CAD & Engineering Applications,0.56,0.25,0.13,0.0,0.02,0.0,0.0,0.04,nighat yasmin,
+ENGR,2100,604,CAD & Engineering Applications,0.56,0.32,0.08,0.0,0.02,0.0,0.0,0.02,trent hou dellinger,
+ENGR,2100,605,CAD & Engineering Applications,0.65,0.29,0.04,0.0,0.02,0.0,0.0,0.0, shams esfandabadi,
+ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.15,0.06,0.02,0.02,0.0,0.0,0.04,russell barrett,
+ENR,3020,1,Nat Res Measurements,0.68,0.24,0.05,0.03,0.0,0.0,0.0,0.0,lawrence gering,
+ENR,4130,2,Restoration Ecology,0.17,0.47,0.19,0.14,0.03,0.0,0.0,0.0,althea simone hagan,
+ENR,4500,1,Conservation Issues,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
+ENR,4500,2,Conservation Issues,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
+ENSP,2000,1,Intro Environ Sci,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,tom owino,
+ENSP,2000,2,Intro Environ Sci,0.72,0.23,0.02,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,
+ENSP,2000,3,Intro Environ Sci,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2010,1,Environm Sci for Educ Majors,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENT,2000,1,Six-Legged Science,0.49,0.33,0.14,0.0,0.0,0.0,0.0,0.05,suellen pometto,
+ENT,2010,1,Animated Insects,0.92,0.05,0.03,0.0,0.0,0.0,0.0,0.0,joseph culin,
+ENTR,1010,1,Entrepreneurial Mindset,0.5,0.28,0.06,0.05,0.08,0.0,0.0,0.04,john michael hannon,
+ENTR,1040,1,Technology Entrepreneurship,0.55,0.31,0.03,0.0,0.1,0.0,0.0,0.0,john michael hannon,
+ESED,8210,1,Teaching Undergraduate Science,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,jennifer van dyken,
+ETOX,6370,1,Ecotoxicology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,peter van den hurk,
+FCS,8110,1,Hum Dev & Fam Life,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,susan limber,
+FCS,8340,1,Research Methods in FCS II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,
+FDSC,1020,1,Persp Food Nutrition,0.94,0.0,0.0,0.03,0.0,0.0,0.0,0.03,john mcgregor,
+FDSC,2140,1,Fd Resources & Soc,0.49,0.36,0.08,0.04,0.0,0.0,0.0,0.04,paul dawson,
+FDSC,2150,1,Culinary Fundamental,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,aubrey dean coffee,
+FDSC,3040,1,Eval Dairy Products,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john mcgregor,
+FDSC,3060,1,Institutional Food Service Mgt,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,
+FDSC,4020,1,Food Chemistry II,0.46,0.48,0.04,0.0,0.0,0.0,0.0,0.02,feng chen,
+FDSC,4030,1,Food Ch & Analysis,0.7,0.19,0.09,0.02,0.0,0.0,0.0,0.0,paul dawson,
+FDSC,4080,1,Food Process Eng,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,felix barron,
+FDSC,4090,1,TQM for Food & Pckg Industries,0.54,0.32,0.1,0.02,0.0,0.0,0.0,0.02,john mcgregor,
+FIN,2010,401,Intro to Personal Finance,0.68,0.18,0.04,0.04,0.0,0.0,0.0,0.07,joshua harris,
+FIN,2010,402,Intro to Personal Finance,0.69,0.21,0.0,0.07,0.0,0.0,0.0,0.03,joshua harris,
+FIN,2010,403,Intro to Personal Finance,0.27,0.62,0.08,0.0,0.0,0.0,0.0,0.04,joshua harris,
+FIN,2010,404,Intro to Personal Finance,0.69,0.18,0.02,0.02,0.02,0.0,0.0,0.07,joshua harris,
+FIN,2010,405,Intro to Personal Finance,0.64,0.17,0.03,0.06,0.11,0.0,0.0,0.0,joshua harris,
+FIN,2010,406,Intro to Personal Finance,0.73,0.08,0.12,0.0,0.08,0.0,0.0,0.0,joshua harris,
+FIN,3040,1,Risk & Insurance,0.28,0.17,0.44,0.0,0.06,0.0,0.0,0.06,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.18,0.34,0.26,0.13,0.05,0.0,0.0,0.03,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.13,0.32,0.39,0.08,0.03,0.0,0.0,0.05,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.3,0.33,0.25,0.08,0.03,0.0,0.0,0.03,kerri mcmillan,
+FIN,3060,1,Corporation Finance,0.25,0.15,0.18,0.2,0.2,0.0,0.0,0.03,william hol johnson,
+FIN,3060,2,Corporation Finance,0.39,0.16,0.13,0.16,0.03,0.0,0.0,0.13,william hol johnson,
+FIN,3060,3,Corporation Finance,0.31,0.13,0.17,0.22,0.06,0.0,0.0,0.11,william hol johnson,
+FIN,3060,4,Corporation Finance,0.08,0.25,0.34,0.17,0.08,0.0,0.0,0.08,ramon tolb franklin,
+FIN,3060,5,Corporation Finance,0.14,0.17,0.41,0.14,0.08,0.0,0.0,0.05,ramon tolb franklin,
+FIN,3060,6,Corporation Finance,0.25,0.25,0.38,0.05,0.0,0.0,0.0,0.06,ramon tolb franklin,
+FIN,3060,8,Corporation Finance,0.19,0.41,0.26,0.11,0.04,0.0,0.0,0.0,minxing sun,
+FIN,3070,1,Prin of Real Estate,0.28,0.44,0.21,0.03,0.03,0.0,0.0,0.03,yannan shen,
+FIN,3070,2,Prin of Real Estate,0.26,0.45,0.24,0.0,0.03,0.0,0.0,0.03,yannan shen,
+FIN,3070,3,Prin of Real Estate,0.16,0.39,0.45,0.0,0.0,0.0,0.0,0.0,thomas springer,
+FIN,3080,1,Fin Inst & Mkts,0.14,0.51,0.29,0.06,0.0,0.0,0.0,0.0,daniel thoma greene,
+FIN,3080,2,Fin Inst & Mkts,0.23,0.43,0.25,0.1,0.0,0.0,0.0,0.0,daniel thoma greene,
+FIN,3080,3,Fin Inst & Mkts,0.33,0.31,0.31,0.05,0.0,0.0,0.0,0.0,daniel thoma greene,
+FIN,3110,1,Financial Management I,0.12,0.31,0.21,0.17,0.05,0.0,0.0,0.14,george bra lockhart,
+FIN,3110,2,Financial Management I,0.11,0.38,0.19,0.08,0.11,0.0,0.0,0.14,george bra lockhart,
+FIN,3110,3,Financial Management I,0.12,0.32,0.15,0.24,0.05,0.0,0.0,0.12,george bra lockhart,
+FIN,3110,4,Financial Management I,0.12,0.19,0.26,0.1,0.1,0.0,0.0,0.24,john alexander,
+FIN,3120,1,Financial Management II,0.16,0.2,0.24,0.16,0.04,0.0,0.0,0.2,blerina zykaj,
+FIN,3120,2,Financial Management II,0.31,0.19,0.39,0.0,0.0,0.0,0.0,0.11,blerina zykaj,
+FIN,3120,3,Financial Management II,0.26,0.34,0.26,0.14,0.0,0.0,0.0,0.0,weike xu,
+FIN,3120,4,Financial Management II,0.18,0.45,0.18,0.06,0.0,0.0,0.0,0.12,weike xu,
+FIN,4030,1,Spreadsheet Apps in Finance,0.17,0.47,0.31,0.06,0.0,0.0,0.0,0.0,vincent intintoli,
+FIN,4030,2,Spreadsheet Apps in Finance,0.25,0.36,0.25,0.06,0.06,0.0,0.0,0.03,vincent intintoli,
+FIN,4040,2,Financial Modeling,0.13,0.39,0.43,0.04,0.0,0.0,0.0,0.0,jack wolf,
+FIN,4050,1,Portfolio Management & Theory,0.1,0.28,0.45,0.17,0.0,0.0,0.0,0.0,john alexander,
+FIN,4080,1,Mgt of Fin Inst,0.21,0.71,0.07,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4080,2,Mgt of Fin Inst,0.18,0.68,0.09,0.05,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4110,1,Int Fin Mgt,0.25,0.38,0.35,0.03,0.0,0.0,0.0,0.0,luke asher devault,
+FIN,4110,2,Int Fin Mgt,0.19,0.53,0.25,0.0,0.0,0.0,0.0,0.03,luke asher devault,
+FIN,4150,1,Real Estate Investmt,0.18,0.36,0.41,0.05,0.0,0.0,0.0,0.0,thomas springer,
+FIN,4160,1,Real Estate Val,0.26,0.61,0.09,0.0,0.0,0.0,0.0,0.04,ramon tolb franklin,
+FNR,4700,10,Kennedy Wtrfowl & Wetland Intn,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,richard ma kaminski,
+FNR,4990,1,Natural Resources Seminar,0.78,0.06,0.06,0.0,0.06,0.0,0.0,0.06,susan talley guynn,
+FNR,4990,3,Natural Resources Seminar,0.68,0.09,0.05,0.14,0.05,0.0,0.0,0.0,susan talley guynn,
+FOR,1010,1,Intro to Forestry,0.79,0.1,0.0,0.05,0.0,0.0,0.0,0.05,lawrence gering,
+FOR,2060,1,Forestry Ecology,0.26,0.4,0.18,0.07,0.04,0.0,0.0,0.06,donald hagan,
+FOR,3080,1,Remote Sensing in Forestry,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,lawrence gering,
+FOR,4060,1,Forested Watershed Mgmt,0.97,0.01,0.01,0.0,0.0,0.0,0.0,0.0,thomas adam coates,
+FOR,4080,1,Wood and Paper Products,0.48,0.45,0.03,0.03,0.0,0.0,0.0,0.0,patricia layton,
+FOR,4150,1,Forest Wildlife Managment,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,james davis,
+FOR,4180,1,Forest Resource Valuation,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4340,1,GIS for Natural Resources,0.48,0.41,0.09,0.02,0.0,0.0,0.0,0.0,robert frit baldwin,
+FOR,4650,1,Silviculture,0.27,0.47,0.2,0.07,0.0,0.0,0.0,0.0,gaofeng wang,
+FR,1010,1,Elementary French,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,1010,2,Elementary French,0.39,0.39,0.06,0.06,0.06,0.0,0.0,0.06,kenneth dav widgren,
+FR,1020,2,Elementary French,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,
+FR,1020,3,Elementary French,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,2,Intermediate French,0.42,0.17,0.25,0.0,0.0,0.0,0.0,0.17,anne salces  nedeo,
+FR,2010,3,Intermediate French,0.8,0.05,0.1,0.0,0.0,0.0,0.0,0.05,kelly digby peebles,
+FR,2010,4,Intermediate French,0.25,0.38,0.19,0.0,0.06,0.0,0.0,0.13,erin shevau stigers,
+FR,2020,1,Intermediate French,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,erin shevau stigers,
+FR,2020,4,Intermediate French,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
+FR,3050,1,Int Fr Con & Comp I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
+FR,3170,1,Contemp French Civ,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,eric touya,
+GC,1010,1,Orientation to G C,0.84,0.04,0.02,0.0,0.02,0.0,0.0,0.07,kern cox,
+GC,1020,1,Computer Art & CAD Foundations,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,carol jones,
+GC,1030,1,G C I for Pkgsc,0.28,0.53,0.13,0.0,0.08,0.0,0.0,0.0,john jacobs,
+GC,1040,1,Graphic Communications I,0.54,0.39,0.01,0.01,0.03,0.0,0.0,0.01,rebecca suza edlein,
+GC,2070,1,Graphic Communications II,0.63,0.26,0.04,0.0,0.04,0.0,0.0,0.04,charles tabor weiss,
+GC,3400,1,Digital Imaging and eMedia,0.36,0.47,0.14,0.0,0.03,0.0,0.0,0.0,erica black walker,
+GC,3460,1,Ink and Substrates,0.32,0.53,0.12,0.02,0.02,0.0,0.0,0.0,michelle suki  fox,
+GC,4060,1,Package and Specialty Printing,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,kern cox,
+GC,4400,1,Commercial Printing,0.3,0.53,0.1,0.0,0.07,0.0,0.0,0.0,eric weisenmiller,
+GC,4440,1,Current Dev/Trends in Gr Comm,0.65,0.23,0.13,0.0,0.0,0.0,0.0,0.0,samuel ingram,
+GC,4480,1,Plan & Cont Printing Functions,0.41,0.5,0.09,0.0,0.0,0.0,0.0,0.0,john leininger,
+GC,4800,1,Senior Seminar in GC,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,
+GC,4900,2,G C Selected Topics-Sales,0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,john leininger,
+GC,4900,5,GC Selected Topics-Concept Pkg,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,john jacobs,
+GEN,3000,1,Fundamental Genetics,0.28,0.4,0.25,0.03,0.0,0.0,0.0,0.05,kate leanne wi tsai,
+GEN,3000,2,Fundamental Genetics,0.24,0.37,0.2,0.1,0.02,0.0,0.0,0.07,kate leanne wi tsai,
+GEN,3020,1,Molecular & General Genetics,0.39,0.24,0.22,0.02,0.05,0.0,0.0,0.07,lukasz kozubowski,
+GEN,4100,1,Population & Quant Genetics,0.44,0.26,0.23,0.05,0.03,0.0,0.0,0.0,amy lou lawton rauh,
+GEN,4110,1,Population & Quant Gen Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
+GEN,4400,1,Bioinformatics,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,liangjiang wang,
+GEN,4700,1,Human Genetics,0.45,0.27,0.22,0.0,0.0,0.0,0.0,0.06,leigh anne clark,
+GEN,6700,1,Human Genetics,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,leigh anne clark,
+GEOG,1010,1,Intro to Geography,0.18,0.32,0.24,0.21,0.06,0.0,0.0,0.0,christa smith,
+GEOG,1030,1,World Regional Geography,0.91,0.05,0.01,0.02,0.01,0.0,0.0,0.02,lance forres howard,
+GEOG,1030,2,World Regional Geography,0.52,0.3,0.09,0.0,0.03,0.0,0.0,0.06,william churc terry,
+GEOG,4400,1,Geog of Hist Preserv,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,christa smith,
+GEOL,1010,1,Physical Geology,0.39,0.27,0.21,0.04,0.08,0.0,0.0,0.02,alan coulson,
+GEOL,1010,2,Physical Geology,0.43,0.29,0.17,0.06,0.02,0.0,0.0,0.02,alan coulson,
+GEOL,1030,1,Physical Geol Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.33,0.42,0.21,0.04,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.58,0.29,0.04,0.08,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.42,0.38,0.13,0.04,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.63,0.25,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.75,0.08,0.04,0.0,0.04,0.0,0.0,0.08,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.87,0.09,0.0,0.0,0.04,0.0,0.0,0.0,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.37,0.32,0.26,0.0,0.05,0.0,0.0,0.0,alan coulson,
+GEOL,1120,1,Earth Resources,0.46,0.37,0.14,0.02,0.0,0.0,0.0,0.02,scott brame,
+GEOL,1140,1,Earth Resources Lab,0.54,0.29,0.09,0.09,0.0,0.0,0.0,0.0,scott brame,
+GEOL,2020,1,Earth History,0.05,0.37,0.26,0.16,0.05,0.0,0.0,0.11,alan coulson,
+GEOL,4050,1,Surficial Geology,0.41,0.18,0.35,0.06,0.0,0.0,0.0,0.0,james castle,
+GEOL,4210,1,Gis in Geology,0.63,0.22,0.15,0.0,0.0,0.0,0.0,0.0,scott brame,
+GEOL,4920,1,Resrch Synthesis II,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,7900,501,Biogeography & Geology of SC,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
+GEOL,8090,1,Subsurface Remed Mod,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
+GER,1010,1,Elementary German,0.19,0.25,0.25,0.06,0.06,0.0,0.0,0.19, lee ferrell,
+GER,1010,2,Elementary German,0.35,0.24,0.06,0.06,0.0,0.0,0.0,0.29, lee ferrell,
+GER,1020,1,Elementary German,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05,oswald harris king,
+GER,1020,2,Elementary German,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,2010,1,Intermediate German,0.05,0.42,0.37,0.0,0.0,0.0,0.0,0.16, lee ferrell,
+GER,2020,1,Intermediate German,0.31,0.31,0.15,0.23,0.0,0.0,0.0,0.0,gabriela stoicea,
+GER,2020,2,Intermediate German,0.36,0.29,0.14,0.07,0.14,0.0,0.0,0.0, lee ferrell,
+GER,3060,1,German Short Story,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+HCC,8810,1,Measurement & Eval,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,bart knijnenburg,
+HCG,9090,1,Lab Methods in Healthcare Gen,0.0,0.0,0.0,0.0,0.0,0.67,0.0,0.33,patricia leota tate,
+HCG,9890,400,Sel Topics-Dev Research Propos,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,julia eggert,
+HIST,1240,1,Environmental History Survey,0.17,0.47,0.21,0.03,0.06,0.0,0.0,0.05,james brad jeffries,
+HIST,1720,3,The West and the World I,0.15,0.39,0.37,0.07,0.0,0.0,0.0,0.02,caroline dunn clark,
+HIST,1730,1,The West and the World II,0.16,0.41,0.2,0.05,0.15,0.0,0.0,0.04, alan grubb,
+HIST,1730,2,The West and the World II,0.23,0.44,0.2,0.02,0.04,0.0,0.0,0.07,subah dayal,
+HIST,1730,3,The West and the World II,0.21,0.52,0.18,0.03,0.01,0.0,0.0,0.05,steven marks,
+HIST,2990,1,Historian's Craft,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,michael silvestri,
+HIST,2990,2,Historian's Craft,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carney,
+HIST,3000,1,History of Colonial America,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,lee brady wilson,
+HIST,3080,1,US: Reagan/Clinton 1975-Pres,0.23,0.5,0.23,0.03,0.0,0.0,0.0,0.0,meg taylor-shockley,
+HIST,3100,1,History of Religion in the US,0.24,0.35,0.24,0.06,0.06,0.0,0.0,0.06,elizabeth jemison,
+HIST,3110,1,African American Hist to 1877,0.42,0.28,0.16,0.02,0.07,0.0,0.0,0.05,abel bartley,
+HIST,3170,1,Hist of Nat. Am. Relig/Culture,0.25,0.4,0.15,0.05,0.1,0.0,0.0,0.05,james brad jeffries,
+HIST,3210,1,History of Science,0.26,0.58,0.1,0.0,0.03,0.0,0.0,0.03,pamela mack,
+HIST,3240,1,Hist of the South II,0.33,0.55,0.03,0.0,0.0,0.0,0.0,0.09,john andrew,
+HIST,3260,1,Hist Am Transport,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0, roger grant,
+HIST,3330,1,Hist of Mod Japan,0.24,0.39,0.24,0.03,0.08,0.0,0.0,0.03,edwin moise,
+HIST,3390,1,Africa 1875-Present,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,james burns,
+HIST,3420,1,South Am Since 1800,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
+HIST,3520,1,Pharaonic Egypt,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carney,
+HIST,3900,1,Modern Military History,0.23,0.33,0.27,0.07,0.03,0.0,0.0,0.07,edwin moise,
+HIST,3970,1,Modern Middle East,0.38,0.45,0.17,0.0,0.0,0.0,0.0,0.0,amit bein,
+HIST,4170,1,History and Tourism,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,meg taylor-shockley,
+HIST,4700,1,History of Florence,0.32,0.42,0.11,0.0,0.0,0.0,0.0,0.16,thomas kuehn,
+HIST,4880,1,Middle Eastern Society&Culture,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
+HIST,4900,1,Food & Pre-Industrial World,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,
+HIST,4900,2,Brexit Euro Union Memory WWars,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,stephani barczewski,
+HIST,4940,2,Slavery & Freedom ATL World,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
+HIST,4960,1,European Legal History,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,thomas kuehn,
+HIST,8810,1,Historiography,0.6,0.0,0.0,0.0,0.2,0.0,0.0,0.2,stephani barczewski,
+HLTH,2020,1,Introduction to Public Health,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,2,Introduction to Public Health,0.7,0.28,0.03,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,400,Introduction to Public Health,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,frederic fraizer,
+HLTH,2030,2,Health Care Sys,0.52,0.36,0.12,0.0,0.0,0.0,0.0,0.0,frederic fraizer,
+HLTH,2030,3,Health Care Sys,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+HLTH,2030,400,Health Care Sys,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2400,1,Deter of Hlth Behav,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2400,2,Deter of Hlth Behav,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.05,amelia clinkscales,
+HLTH,2600,1,Medical Terminology & Comm,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,karen edwards,
+HLTH,2980,1,Human Hlth & Disease,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,2980,2,Human Hlth & Disease,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,3030,1,Public Health Comm,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
+HLTH,3050,1,Body Resp Hlth Beh,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,brian patric graves,
+HLTH,3800,1,Epidemiology,0.38,0.42,0.17,0.04,0.0,0.0,0.0,0.0,hugh spitler,
+HLTH,3800,2,Epidemiology,0.6,0.24,0.04,0.04,0.04,0.0,0.0,0.04,deborah alma falta,
+HLTH,3980,2,Health Appraisal Skills,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4000,2,Drug Epi & Opiate Epidemic,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+HLTH,4000,3,Public Hlth Social Marketing,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,debra mitch charles,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.83,0.15,0.0,0.02,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4310,1,Public & Environ Hlt,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,4600,1,Health Info Systems,0.57,0.29,0.07,0.0,0.07,0.0,0.0,0.0,deborah alma falta,
+HLTH,4700,1,Global Health,0.71,0.18,0.07,0.0,0.04,0.0,0.0,0.0,rachel mayo,
+HLTH,4780,1,Health Policy Ethics and Law,0.39,0.26,0.17,0.09,0.04,0.0,0.0,0.04,hugh spitler,
+HLTH,4790,1,Fin Mgmt & Hlth Budg,0.63,0.17,0.17,0.0,0.04,0.0,0.0,0.0,lingling zhang,
+HLTH,4800,1,Comm Hlth Promotion,0.54,0.41,0.0,0.0,0.02,0.0,0.0,0.02,sarah griffin,
+HLTH,4900,1,Res Eval St Pub Hlth,0.76,0.16,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,
+HLTH,4900,2,Res Eval St Pub Hlth,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,jeffrey kingree,
+HLTH,4900,3,Res Eval St Pub Hlth,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,8110,1,Health Care Delivery Systems,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
+HLTH,8130,400,Population Health and Research,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,
+HLTH,8130,500,Population Health and Research,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,
+HLTH,8210,500,Health Research I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,joel edwar williams,
+HLTH,8310,1,Quantitative Analy in Hlth I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,
+HON,2060,1,Intro to Nanotechnology,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,
+HON,2200,4,The Empire World,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,michael silvestri,
+HON,2210,2,Russian Film History,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,
+HON,2210,4,Soderbergh's Cinema,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+HON,2220,2,Holocaust and Eichmann Trial,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,
+HORT,2020,1,Adobe Digital Design,0.86,0.09,0.0,0.03,0.0,0.0,0.0,0.03,janice ann lay,
+HORT,2110,1,Growing Spring Plnts,0.35,0.4,0.2,0.0,0.0,0.0,0.0,0.05,james emerson faust,
+HORT,4040,1,Plant Propagation,0.13,0.45,0.24,0.11,0.03,0.0,0.0,0.05,jeffrey adelberg,
+HORT,4050,2,Plant Propagation Techniq Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey adelberg,
+HORT,4200,1,Applied Turf Physiol,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
+HORT,4270,1,Urban Tree Care,0.04,0.31,0.31,0.27,0.0,0.0,0.0,0.08,robert polomski,
+HORT,4330,1,Turf Weed Management,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,ted whitwell,
+HORT,4560,1,Vegetable Crops,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,
+HORT,6040,1,Plant Propagation,0.29,0.43,0.0,0.0,0.29,0.0,0.0,0.0,jeffrey adelberg,
+HP,8280,1,Case St in Preservation Engr,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,craig mille bennett,
+HP,8920,200,Special Topics in Hist Preserv,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0,richard gra gilmore,
+HRD,8250,400,Org Perf Improvement,0.87,0.08,0.05,0.0,0.0,0.0,0.0,0.0,philip mcgee,
+HRD,8470,400,Instru System Design,0.74,0.05,0.05,0.0,0.11,0.0,0.0,0.05,eileen newmark,
+HRD,8800,400,Research Concepts,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,cynthia sims,
+IE,2000,1,Soph Seminar in I E,0.51,0.15,0.12,0.2,0.0,0.0,0.0,0.02,brian melloy,
+IE,2100,1,Des Analysis Wrk Sys,0.16,0.36,0.24,0.09,0.04,0.0,0.0,0.1,sara lu riggs,
+IE,2800,1,Deterministic Operations Rsrch,0.08,0.23,0.25,0.22,0.18,0.0,0.0,0.05,amin khademi,
+IE,3010,1,Systems Design I,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,joel greenstein,
+IE,3600,1,Industrial Apps of Prob/Stat I,0.47,0.26,0.16,0.05,0.05,0.0,0.0,0.0,mary elizabeth kurz,
+IE,3610,1,Industrial App of Prob/Stat II,0.26,0.35,0.28,0.06,0.03,0.0,0.0,0.01,sandra dun eksioglu,
+IE,3810,1,Probabilistic Operations Rsrch,0.14,0.37,0.32,0.12,0.05,0.0,0.0,0.0,burak eksioglu,
+IE,3840,1,Engr Econ Analysis,0.42,0.22,0.1,0.02,0.07,0.0,0.0,0.17,brian melloy,
+IE,3860,1,Prod Plan & Cont,0.56,0.27,0.11,0.02,0.01,0.0,0.0,0.02,jonathan lowe,
+IE,4300,1,Human Fact Engr in Healthcare,0.69,0.29,0.02,0.0,0.0,0.0,0.0,0.0,david neyens,
+IE,4400,1,Decision Support Sys,0.3,0.35,0.18,0.12,0.04,0.0,0.0,0.01,sandra dun eksioglu,
+IE,4610,1,Quality Engineering,0.22,0.22,0.15,0.27,0.07,0.0,0.0,0.07,robert james riggs,
+IE,4620,1,Six Sigma Quality,0.17,0.37,0.36,0.08,0.0,0.0,0.0,0.03,robert james riggs,
+IE,4650,1,Facilities Planning & Design,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,nadeepa wickramage,
+IE,4670,1,System Design II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+IE,4670,2,System Design II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+IE,4820,1,Systems Modeling,0.41,0.31,0.09,0.13,0.03,0.0,0.0,0.03,tugce isik,
+IE,4880,1,Human Factors Eng,0.34,0.51,0.14,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,
+IE,6620,1,Six Sigma Quality,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
+IE,6820,1,Systems Modeling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tugce isik,
+IE,6840,1,Applied Engineering Economics`,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nadeepa wickramage,
+IE,8020,1,Human Comp Sys,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,joel greenstein,
+IE,8050,1,Found Qual Engr,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,byung rae cho,
+IE,8520,1,Prescriptive Analytics,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,jonathan cole smith,
+IE,8540,1,SC & Logistics Modeling I,0.65,0.26,0.0,0.0,0.09,0.0,0.0,0.0,william ferrell,
+IE,8580,1,Case Study Supply Chn & Logist,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+IE,8870,1,Model Logist Behav Simulation,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.06,0.03,caren kelley-hall,
+INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.89,0.09,0.03,caren kelley-hall,
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.02,caren kelley-hall,
+INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.89,0.09,0.02,caren kelley-hall,
+INT,2010,1,Off-Campus Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,katherine el horner,
+INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.89,0.11,0.0,caren kelley-hall,
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,uttiyo raychaudhuri,
+IS,1010,2,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,uttiyo raychaudhuri,
+ITAL,1010,1,Elementary Italian,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,lyudmyla tsykalova,
+ITAL,1010,2,Elementary Italian,0.42,0.26,0.11,0.05,0.05,0.0,0.0,0.11,julia schmidt,
+ITAL,1020,2,Elementary Italian,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+ITAL,2020,1,Intermediate Italian,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
+JAPN,1010,1,Elementary Japanese,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,saori suto,
+JAPN,1010,2,Elementary Japanese,0.2,0.4,0.2,0.0,0.07,0.0,0.0,0.13,saori suto,
+JAPN,1020,1,Elementary Japanese,0.16,0.16,0.32,0.0,0.11,0.0,0.0,0.26,toshiko joerger,
+JAPN,2020,1,Intermed Japanese,0.47,0.13,0.33,0.07,0.0,0.0,0.0,0.0,saori suto,
+JAPN,4170,1,Japanese Culture and Society,0.53,0.21,0.0,0.21,0.05,0.0,0.0,0.0,jae allegr takeuchi,
+JUST,2880,1,The Criminal Justice System,0.39,0.22,0.35,0.04,0.0,0.0,0.0,0.0,margaret tina britz,
+JUST,2890,1,Criminology,0.3,0.35,0.15,0.0,0.15,0.0,0.0,0.05,william white,
+JUST,4910,1,Policing,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,william white,
+JUST,4930,1,Corrections,0.39,0.43,0.07,0.04,0.0,0.0,0.0,0.07,william white,
+JUST,4940,1,Organized Crime,0.28,0.48,0.24,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
+LANG,2540,1,Introduction to World Cinemas,0.67,0.24,0.0,0.0,0.05,0.0,0.0,0.05,raquel anido,
+LARC,1160,1,History of Landscape Arch,0.3,0.47,0.16,0.01,0.01,0.0,0.0,0.05,hala fouad nassar,
+LARC,1160,2,History of Landscape Arch,0.69,0.19,0.08,0.04,0.0,0.0,0.0,0.0,martin john holland,
+LARC,1520,1,Basic Design II,0.46,0.42,0.08,0.04,0.0,0.0,0.0,0.0,paul russell,
+LARC,2550,1,Community Design Studio,0.78,0.0,0.17,0.0,0.06,0.0,0.0,0.0,martin john holland,
+LARC,3620,1,Design Impl II,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,paul russell,
+LARC,4280,1,Computer-Aided Design,0.85,0.04,0.12,0.0,0.0,0.0,0.0,0.0,yang song,
+LARC,6810,1,Professional Practice,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,david lycke,
+LAW,3220,1,Legal Env of Bus,0.14,0.51,0.29,0.04,0.02,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,2,Legal Env of Bus,0.47,0.36,0.11,0.07,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,3,Legal Env of Bus,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,4,Legal Env of Bus,0.4,0.42,0.16,0.02,0.0,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,5,Legal Env of Bus,0.27,0.2,0.36,0.16,0.02,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,6,Legal Env of Bus,0.31,0.47,0.16,0.04,0.02,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,7,Legal Env of Bus,0.09,0.55,0.32,0.02,0.02,0.0,0.0,0.0,judson jahn,
+LAW,3220,8,Legal Env of Bus,0.22,0.38,0.27,0.09,0.04,0.0,0.0,0.0,kenneth toussaint,
+LAW,3220,9,Legal Env of Bus,0.49,0.36,0.13,0.0,0.0,0.0,0.0,0.02,kath kisska-schulze,
+LAW,3220,10,Legal Env of Bus,0.33,0.38,0.27,0.02,0.0,0.0,0.0,0.0,john hine,
+LAW,3220,11,Legal Env of Bus,0.16,0.42,0.27,0.09,0.02,0.0,0.0,0.04,john hine,
+LAW,3220,401,Legal Env of Bus,0.27,0.31,0.23,0.06,0.06,0.0,0.0,0.06,virgini ward-vaughn,
+LAW,3220,402,Legal Env of Bus,0.21,0.46,0.13,0.08,0.06,0.0,0.0,0.06,virgini ward-vaughn,
+LAW,3220,403,Legal Env of Bus,0.19,0.43,0.17,0.04,0.11,0.0,0.0,0.06,virgini ward-vaughn,
+LAW,3220,404,Legal Env of Bus,0.13,0.33,0.27,0.07,0.07,0.0,0.0,0.13,virgini ward-vaughn,
+LAW,3330,1,Real Estate Law,0.18,0.51,0.22,0.02,0.0,0.0,0.0,0.07,judson jahn,
+LAW,8480,1,Law Real Estate Prof,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james ivey warren,
+LIB,2990,1,Creative Inq - The Libraries,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert wilmott,
+LIH,4000,35,Internship Abroad,0.0,0.0,0.0,0.0,0.0,0.79,0.21,0.0,juana martin-armas,
+LS,1000,2,Fitness Leadership,0.82,0.0,0.0,0.09,0.0,0.0,0.0,0.09,patricia figueroa,
+LS,1000,9,Intro to Salsa Dance,0.85,0.05,0.0,0.05,0.0,0.0,0.0,0.05,malik lewis baxter,
+LS,1000,10,Intro to Salsa Dance,0.9,0.0,0.1,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,
+LS,1000,11,Shotgun II,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,edward licus prater,
+LS,1000,12,Intermediate Rock Climbing,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,corey newe winstead,
+LS,1000,17,A.C.E. Personal Trainer Prep,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,corey dou brookover,
+LS,1000,20,Intro to Volleyball,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,kelly lynn ator,
+LS,1000,23,Therapeutic Yoga,0.75,0.05,0.05,0.0,0.05,0.0,0.0,0.1,ranjanbala dil amin,
+LS,1000,24,Therapeutic Yoga,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,ranjanbala dil amin,
+LS,1000,25,Therapeutic Yoga,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,1000,26,Therapeutic Yoga,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
+LS,1000,27,Beg. Non-Competitive Karate,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,june pilcher,
+LS,1410,1,Top Rope Climbing,0.79,0.07,0.0,0.0,0.14,0.0,0.0,0.0,michelle tuday,
+LS,1410,3,Top Rope Climbing,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,michelle tuday,
+LS,1410,5,Top Rope Climbing,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,michelle tuday,
+LS,1410,6,Top Rope Climbing,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,michelle tuday,
+LS,1410,8,Top Rope Climbing,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,corey newe winstead,
+LS,1450,5,Camping/Backpacking,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,sarah wilcer,
+LS,1560,16,Riflery,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,
+LS,1560,19,Riflery,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,dominic cirocco,
+LS,1570,9,Shotgun Sports,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james gill,
+LS,1580,5,Archery,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,herbert strickland,
+LS,1640,2,Whitewater Kayaking,0.5,0.2,0.0,0.0,0.0,0.0,0.0,0.3,robert taylor,
+LS,1850,2,Bowling,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,adam perr middleton,
+LS,1850,4,Bowling,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kathryn ly mitchell,
+LS,1850,7,Bowling,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,megan elizabet cato,
+LS,1850,8,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,adam perr middleton,
+LS,1850,9,Bowling,0.82,0.04,0.0,0.04,0.0,0.0,0.0,0.11,megan elizabet cato,
+LS,1940,2,Racquetball,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,raymond petersen,
+LS,1940,3,Racquetball,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,charlie white,
+LS,1980,9,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,wesley scott womble,
+LS,2200,3,Shag,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,broadus fleming,
+LS,2200,7,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,matthew lee krabbe,
+LS,2270,1,Intro to Swing Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,paul hoke,
+LS,2320,1,Core Training,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,
+LS,2320,2,Core Training,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
+LS,2320,3,Core Training,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,2350,1,Basic Yoga,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,silica eliza larkin,
+LS,2350,3,Basic Yoga,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2350,4,Basic Yoga,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2350,5,Basic Yoga,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,renee warren gahan,
+LS,2350,6,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,
+LS,2350,7,Basic Yoga,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,kayla lee wardlaw,
+LS,2380,1,Vinyasa Flow Yoga,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,
+LS,2380,3,Vinyasa Flow Yoga,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2420,1,Meditation and Relax,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,3,Meditation and Relax,0.7,0.13,0.04,0.04,0.0,0.0,0.0,0.09,renee warren gahan,
+LS,2420,4,Meditation and Relax,0.76,0.14,0.05,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2420,5,Meditation and Relax,0.91,0.0,0.0,0.04,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,2420,8,Meditation and Relax,0.84,0.08,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,2450,2,Pilates,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
+LS,2450,4,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,2450,6,Pilates,0.83,0.09,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
+LS,2460,1,Intermediate Pilates,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,melanie ivey job,
+LS,2700,1,Sports Officiating,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,christopher war cox,
+LS,2750,7,First Aid/Cpr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,christopher loomis,
+LS,2750,8,First Aid/Cpr,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,christopher loomis,
+LS,2780,3,Wilderness First Aid,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,emily grace turke,
+LS,2910,1,Outdoor Leadership,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,emily grace turke,
+LS,3580,1,Advanced Shotgun Skeet,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,james gill,
+MATH,1010,1,Essen Math for Informed Soc,0.32,0.48,0.12,0.04,0.0,0.0,0.0,0.04,marilyn reba,
+MATH,1010,2,Essen Math for Informed Soc,0.53,0.26,0.18,0.0,0.0,0.0,0.0,0.03,marilyn reba,
+MATH,1010,3,Essen Math for Informed Soc,0.58,0.14,0.14,0.03,0.08,0.0,0.0,0.03,marilyn reba,
+MATH,1010,4,Essen Math for Informed Soc,0.53,0.31,0.13,0.0,0.0,0.0,0.0,0.03,marilyn reba,
+MATH,1020,1,Business Calculus I,0.09,0.27,0.34,0.05,0.2,0.0,0.0,0.05,tony thanh nguyen,
+MATH,1020,2,Business Calculus I,0.21,0.13,0.21,0.13,0.19,0.0,0.0,0.13,michael thoma cowen,
+MATH,1020,3,Business Calculus I,0.2,0.28,0.22,0.07,0.11,0.0,0.0,0.13,tony thanh nguyen,
+MATH,1020,4,Business Calculus I,0.17,0.21,0.21,0.12,0.17,0.0,0.0,0.12,todd fenstermacher,
+MATH,1020,5,Business Calculus I,0.09,0.18,0.4,0.13,0.18,0.0,0.0,0.02,stephen garth,
+MATH,1020,6,Business Calculus I,0.15,0.35,0.24,0.07,0.11,0.0,0.0,0.09,randy davidson,
+MATH,1020,7,Business Calculus I,0.17,0.29,0.27,0.07,0.07,0.0,0.0,0.12,marion hanna,
+MATH,1020,8,Business Calculus I,0.14,0.28,0.33,0.07,0.16,0.0,0.0,0.02,randy davidson,
+MATH,1020,9,Business Calculus I,0.21,0.5,0.12,0.1,0.07,0.0,0.0,0.0,marion hanna,
+MATH,1020,10,Business Calculus I,0.17,0.32,0.29,0.1,0.1,0.0,0.0,0.02,peter westerbaan,
+MATH,1020,11,Business Calculus I,0.21,0.37,0.26,0.02,0.09,0.0,0.0,0.05,john william grant,
+MATH,1020,12,Business Calculus I,0.11,0.45,0.23,0.0,0.09,0.0,0.0,0.11,randy davidson,
+MATH,1020,13,Business Calculus I,0.05,0.17,0.26,0.19,0.21,0.0,0.0,0.12,javier ruiz ramirez,
+MATH,1020,16,Business Calculus I,0.11,0.13,0.36,0.16,0.13,0.0,0.0,0.11,bryce pruitt,
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.44,0.54,0.03,stefan adam bock,
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.56,0.12,nicholas ahlstrom,
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.58,0.33,0.09,charity watson,
+MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.71,0.2,0.09,charity watson,
+MATH,1060,1,Calculus of One Variable I,0.0,0.16,0.32,0.14,0.27,0.0,0.0,0.11,judith cottingham,
+MATH,1060,2,Calculus of One Variable I,0.02,0.33,0.2,0.16,0.22,0.0,0.0,0.07,judith cottingham,
+MATH,1060,3,Calculus of One Variable I,0.06,0.13,0.24,0.15,0.25,0.0,0.0,0.18,allen anderso guest,
+MATH,1060,5,Calculus of One Variable I,0.1,0.19,0.23,0.09,0.26,0.0,0.0,0.14,allen anderso guest,
+MATH,1060,7,Calculus of One Variable I,0.08,0.17,0.11,0.08,0.44,0.0,0.0,0.11,thowhida akther,
+MATH,1060,500,Calculus of One Variable I,0.59,0.21,0.21,0.0,0.0,0.0,0.0,0.0,laura dostert,
+MATH,1070,1,Differen and Integral Calculus,0.14,0.34,0.34,0.07,0.07,0.0,0.0,0.03,donna simms,
+MATH,1070,2,Differen and Integral Calculus,0.24,0.44,0.32,0.0,0.0,0.0,0.0,0.0,donna simms,
+MATH,1070,3,Differen and Integral Calculus,0.07,0.37,0.37,0.05,0.07,0.0,0.0,0.07,chase norman joyner,
+MATH,1070,5,Differen and Integral Calculus,0.08,0.23,0.33,0.23,0.03,0.0,0.0,0.1,stefan adam bock,
+MATH,1070,7,Differen and Integral Calculus,0.03,0.28,0.34,0.28,0.03,0.0,0.0,0.03,rebecca ramos,
+MATH,1080,1,Calculus of One Variable II,0.13,0.31,0.31,0.09,0.13,0.0,0.0,0.03,beth novick,
+MATH,1080,4,Calculus of One Variable II,0.15,0.41,0.1,0.08,0.13,0.0,0.0,0.13,sergey charnyi,
+MATH,1080,5,Calculus of One Variable II,0.19,0.35,0.19,0.07,0.14,0.0,0.0,0.07,mengying xiao,
+MATH,1080,7,Calculus of One Variable II,0.2,0.24,0.2,0.09,0.16,0.0,0.0,0.11,fun choi john chan,
+MATH,1080,8,Calculus of One Variable II,0.18,0.34,0.2,0.14,0.09,0.0,0.0,0.05,honghai xu,
+MATH,1080,10,Calculus of One Variable II,0.24,0.41,0.2,0.04,0.04,0.0,0.0,0.07,garrett dranichak,
+MATH,1080,11,Calculus of One Variable II,0.16,0.38,0.24,0.11,0.04,0.0,0.0,0.07,honghai xu,
+MATH,1080,12,Calculus of One Variable II,0.13,0.29,0.24,0.07,0.09,0.0,0.0,0.18,rui gong,
+MATH,1080,13,Calculus of One Variable II,0.14,0.32,0.25,0.11,0.11,0.0,0.0,0.07,alistair bentley,
+MATH,1080,16,Calculus of One Variable II,0.13,0.3,0.22,0.11,0.13,0.0,0.0,0.11,camille zerfas,
+MATH,1080,100,Calc of One Variable II (HON),0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,beth novick,True
+MATH,1080,203,Calc of One Variable II (RiSE),0.2,0.28,0.33,0.13,0.0,0.0,0.0,0.07,kara ail stasikelis,
+MATH,1080,203,Calc of One Variable II,0.2,0.28,0.33,0.13,0.0,0.0,0.0,0.07,kara ail stasikelis,
+MATH,1080,206,Calc of One Variable II (RiSE),0.21,0.21,0.31,0.05,0.15,0.0,0.0,0.08,honghai xu,
+MATH,1080,206,Calc of One Variable II,0.21,0.21,0.31,0.05,0.15,0.0,0.0,0.08,honghai xu,
+MATH,1080,209,Calc of One Variable II,0.2,0.32,0.17,0.12,0.07,0.0,0.0,0.12,jonathon leverenz,
+MATH,1080,209,Calc of One Variable II (RiSE),0.2,0.32,0.17,0.12,0.07,0.0,0.0,0.12,jonathon leverenz,
+MATH,1080,214,Calc of One Variable II (RiSE),0.28,0.22,0.35,0.02,0.11,0.0,0.0,0.02,lauren pai mcintyre,
+MATH,1080,214,Calc of One Variable II,0.28,0.22,0.35,0.02,0.11,0.0,0.0,0.02,lauren pai mcintyre,
+MATH,1080,217,Calc of One Variable II,0.28,0.35,0.15,0.11,0.02,0.0,0.0,0.09,audrey nico devries,
+MATH,1080,218,Calc of One Variable II,0.24,0.37,0.2,0.09,0.09,0.0,0.0,0.02,ryan grove,
+MATH,1150,1,Contemp Math for Elem Teach I,0.5,0.27,0.19,0.0,0.04,0.0,0.0,0.0,charity watson,
+MATH,1160,1,Contemp Math for Elem Teach II,0.74,0.2,0.06,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1160,2,Contemp Math for Elem Teach II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.84,0.12,0.04,marion hanna,
+MATH,2060,1,Calculus of Several Variables,0.23,0.4,0.14,0.11,0.09,0.0,0.0,0.03,hiram lopez valdez,
+MATH,2060,2,Calculus of Several Variables,0.15,0.32,0.09,0.06,0.18,0.0,0.0,0.21,timothy fra parrott,
+MATH,2060,3,Calculus of Several Variables,0.32,0.36,0.19,0.04,0.06,0.0,0.0,0.02,hiram lopez valdez,
+MATH,2060,4,Calculus of Several Variables,0.46,0.38,0.05,0.08,0.03,0.0,0.0,0.0,muhamm mohebujjaman,
+MATH,2060,5,Calculus of Several Variables,0.11,0.21,0.25,0.18,0.11,0.0,0.0,0.14,timothy fra parrott,
+MATH,2060,6,Calculus of Several Variables,0.08,0.56,0.19,0.0,0.11,0.0,0.0,0.06,sofya alekseeva,
+MATH,2060,7,Calculus of Several Variables,0.19,0.5,0.19,0.06,0.03,0.0,0.0,0.03,sofya alekseeva,
+MATH,2060,8,Calculus of Several Variables,0.44,0.33,0.1,0.04,0.04,0.0,0.0,0.04,martin joha schmoll,
+MATH,2060,9,Calculus of Several Variables,0.13,0.45,0.24,0.08,0.05,0.0,0.0,0.05,sofya alekseeva,
+MATH,2060,10,Calculus of Several Variables,0.0,0.21,0.16,0.11,0.37,0.0,0.0,0.16,jonathon leverenz,
+MATH,2060,500,Calculus of Several Variables,0.4,0.27,0.27,0.07,0.0,0.0,0.0,0.0,brian gloor,
+MATH,2070,1,Business Calculus II,0.28,0.38,0.2,0.13,0.0,0.0,0.0,0.03,jennifer mari hanna,
+MATH,2070,2,Business Calculus II,0.3,0.45,0.2,0.0,0.03,0.0,0.0,0.03,tony thanh nguyen,
+MATH,2070,3,Business Calculus II,0.23,0.33,0.18,0.15,0.03,0.0,0.0,0.1,thanh thien to,
+MATH,2070,4,Business Calculus II,0.53,0.28,0.13,0.08,0.0,0.0,0.0,0.0,jennifer mari hanna,
+MATH,2070,5,Business Calculus II,0.28,0.38,0.2,0.1,0.05,0.0,0.0,0.0,allison stoddard,
+MATH,2070,6,Business Calculus II,0.33,0.25,0.23,0.08,0.13,0.0,0.0,0.0,tony thanh nguyen,
+MATH,2070,7,Business Calculus II,0.65,0.15,0.13,0.05,0.0,0.0,0.0,0.03,jennifer mari hanna,
+MATH,2070,8,Business Calculus II,0.29,0.24,0.21,0.1,0.1,0.0,0.0,0.07,judith irene mcknew,
+MATH,2070,9,Business Calculus II,0.23,0.36,0.13,0.08,0.05,0.0,0.0,0.15,judith irene mcknew,
+MATH,2070,10,Business Calculus II,0.2,0.39,0.24,0.1,0.05,0.0,0.0,0.02,daniel kuzbary,
+MATH,2070,11,Business Calculus II,0.31,0.36,0.1,0.08,0.1,0.0,0.0,0.05,jing li,
+MATH,2070,12,Business Calculus II,0.38,0.28,0.15,0.05,0.08,0.0,0.0,0.05,neil calkin,
+MATH,2070,13,Business Calculus II,0.35,0.35,0.18,0.03,0.08,0.0,0.0,0.03,haodong li,
+MATH,2070,14,Business Calculus II,0.23,0.36,0.36,0.0,0.0,0.0,0.0,0.05,shanshan jia,
+MATH,2070,15,Business Calculus II,0.25,0.35,0.23,0.05,0.0,0.0,0.0,0.13,aaro ramirez flores,
+MATH,2070,16,Business Calculus II,0.4,0.35,0.08,0.08,0.08,0.0,0.0,0.03,stephen peele,
+MATH,2080,1,Intro to Ordin Diff Equations,0.09,0.3,0.17,0.13,0.04,0.0,0.0,0.26,terri johnson,
+MATH,2080,2,Intro to Ordin Diff Equations,0.37,0.49,0.09,0.0,0.06,0.0,0.0,0.0,oleg yordanov,
+MATH,2080,4,Intro to Ordin Diff Equations,0.08,0.05,0.26,0.03,0.24,0.0,0.0,0.34,terri johnson,
+MATH,2080,5,Intro to Ordin Diff Equations,0.53,0.21,0.21,0.03,0.0,0.0,0.0,0.03,timothy ch teitloff,
+MATH,2080,6,Intro to Ordin Diff Equations,0.47,0.37,0.05,0.05,0.0,0.0,0.0,0.07,oleg yordanov,
+MATH,2080,7,Intro to Ordin Diff Equations,0.06,0.15,0.21,0.06,0.15,0.0,0.0,0.38,terri johnson,
+MATH,2080,8,Intro to Ordin Diff Equations,0.26,0.26,0.09,0.18,0.15,0.0,0.0,0.06,julie lassiter,
+MATH,2080,9,Intro to Ordin Diff Equations,0.62,0.1,0.23,0.0,0.0,0.0,0.0,0.05,timothy ch teitloff,
+MATH,2080,10,Intro to Ordin Diff Equations,0.33,0.36,0.13,0.08,0.1,0.0,0.0,0.0,irina viktorova,
+MATH,2080,11,Intro to Ordin Diff Equations,0.25,0.19,0.16,0.19,0.16,0.0,0.0,0.06,julie lassiter,
+MATH,2080,12,Intro to Ordin Diff Equations,0.36,0.27,0.21,0.06,0.0,0.0,0.0,0.09,shari prevost,
+MATH,2080,13,Intro to Ordin Diff Equations,0.28,0.35,0.2,0.08,0.08,0.0,0.0,0.03,irina viktorova,
+MATH,2080,14,Intro to Ordin Diff Equations,0.24,0.29,0.24,0.0,0.08,0.0,0.0,0.16,jonathon leverenz,
+MATH,2080,15,Intro to Ordin Diff Equations,0.19,0.36,0.17,0.03,0.14,0.0,0.0,0.11,shari prevost,
+MATH,2080,16,Intro to Ordin Diff Equations,0.38,0.2,0.29,0.09,0.0,0.0,0.0,0.04,irina viktorova,
+MATH,2080,17,Intro to Ordin Diff Equations,0.19,0.25,0.28,0.09,0.06,0.0,0.0,0.13,jeong rock yoon,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.62,0.31,0.04,0.0,0.04,0.0,0.0,0.0,brian fralix,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.6,0.25,0.1,0.05,0.0,0.0,0.0,0.0,allison stoddard,
+MATH,3020,1,Stat for Science & Engineering,0.33,0.4,0.14,0.05,0.05,0.0,0.0,0.02,william bridges,
+MATH,3020,2,Stat for Science & Engineering,0.66,0.29,0.03,0.0,0.0,0.0,0.0,0.03,xiyan tan,
+MATH,3020,3,Stat for Science & Engineering,0.54,0.18,0.18,0.03,0.08,0.0,0.0,0.0,yisu jia,
+MATH,3020,4,Stat for Science & Engineering,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,brandon gra goodell,
+MATH,3020,5,Stat for Science & Engineering,0.5,0.31,0.12,0.02,0.05,0.0,0.0,0.0,"koshy chenthittayil,",
+MATH,3020,6,Stat for Science & Engineering,0.35,0.32,0.11,0.11,0.05,0.0,0.0,0.05,prab withana gamage,
+MATH,3020,7,Stat for Science & Engineering,0.4,0.33,0.12,0.07,0.07,0.0,0.0,0.0,yinggu bao,
+MATH,3020,8,Stat for Science & Engineering,0.25,0.42,0.22,0.06,0.03,0.0,0.0,0.03,ellen hepfe breazel,
+MATH,3020,9,Stat for Science & Engineering,0.3,0.33,0.12,0.0,0.09,0.0,0.0,0.15,paul james cubre,
+MATH,3080,1,College Geometry,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,carlos gomez,
+MATH,3110,1,Linear Algebra,0.45,0.18,0.24,0.08,0.03,0.0,0.0,0.03,amy christine grady,
+MATH,3110,2,Linear Algebra,0.15,0.38,0.15,0.18,0.05,0.0,0.0,0.08,amy christine grady,
+MATH,3110,3,Linear Algebra,0.21,0.3,0.12,0.09,0.12,0.0,0.0,0.15,xuhong gao,
+MATH,3110,4,Linear Algebra,0.3,0.5,0.1,0.05,0.05,0.0,0.0,0.0,hui xue,
+MATH,3110,5,Linear Algebra,0.11,0.46,0.17,0.06,0.14,0.0,0.0,0.06,michael adam burr,
+MATH,3110,6,Linear Algebra,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,wayne goddard,
+MATH,3110,7,Linear Algebra,0.24,0.24,0.21,0.09,0.06,0.0,0.0,0.15,neil calkin,
+MATH,3110,200,Linear Algebra,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,beth novick,
+MATH,3150,1,Adv Top in Math for Elem Teach,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
+MATH,3190,1,Introduction to Proof,0.1,0.29,0.19,0.1,0.0,0.0,0.0,0.33,james ba coykendall,
+MATH,3190,2,Introduction to Proof,0.18,0.36,0.32,0.05,0.05,0.0,0.0,0.05,james ba coykendall,
+MATH,3600,1,Intermediate Math Computing,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,mark cawood,
+MATH,3600,2,Intermediate Math Computing,0.67,0.17,0.0,0.06,0.06,0.0,0.0,0.06,mark cawood,
+MATH,3650,1,Numerical Mthds for Engineers,0.2,0.26,0.17,0.14,0.14,0.0,0.0,0.09,fei xue,
+MATH,3650,2,Numerical Mthds for Engineers,0.33,0.21,0.29,0.08,0.04,0.0,0.0,0.04,fei xue,
+MATH,3650,3,Numerical Mthds for Engineers,0.53,0.29,0.06,0.0,0.06,0.0,0.0,0.06,timo johann heister,
+MATH,3650,4,Numerical Mthds for Engineers,0.35,0.19,0.15,0.08,0.04,0.0,0.0,0.19,christopher cox,
+MATH,4000,1,Theory of Probability,0.28,0.31,0.18,0.1,0.08,0.0,0.0,0.05,ling ma,
+MATH,4030,1,Intro to Statistical Theory,0.36,0.45,0.14,0.05,0.0,0.0,0.0,0.0,xiaoqian sun,
+MATH,4060,1,Sampling Theory and Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+MATH,4070,1,Regress & Time-Series Analysis,0.45,0.24,0.21,0.03,0.0,0.0,0.0,0.07,colin gallagher,
+MATH,4100,1,Number Theory,0.5,0.1,0.2,0.1,0.0,0.0,0.0,0.1,hui xue,
+MATH,4120,1,Algebra I,0.08,0.11,0.39,0.08,0.06,0.0,0.0,0.28,sea sather-wagstaff,
+MATH,4190,1,Discrete Math Structures I,0.57,0.25,0.09,0.02,0.05,0.0,0.0,0.02,beth novick,
+MATH,4310,1,Theory of Interest,0.44,0.39,0.11,0.0,0.06,0.0,0.0,0.0, erwin walker,
+MATH,4320,1,Actuarial Science Seminar II,0.6,0.07,0.27,0.0,0.0,0.0,0.0,0.07, erwin walker,
+MATH,4340,1,Adv Engineering Mathematics,0.15,0.15,0.38,0.12,0.15,0.0,0.0,0.04,vincent ervin,
+MATH,4340,2,Adv Engineering Mathematics,0.06,0.16,0.38,0.13,0.09,0.0,0.0,0.19,eleanor jenkins,
+MATH,4400,1,Linear Programming,0.31,0.27,0.19,0.15,0.0,0.0,0.0,0.08,boshi yang,
+MATH,4410,1,Intro to Stochastic Models,0.41,0.24,0.35,0.0,0.0,0.0,0.0,0.0,peter kiessler,
+MATH,4530,1,Advanced Calculus I,0.32,0.05,0.21,0.16,0.11,0.0,0.0,0.16,james peterson,
+MATH,4540,1,Advanced Calculus II,0.25,0.32,0.21,0.14,0.04,0.0,0.0,0.04,james peterson,
+MATH,4600,1,Intro to Numerical Analysis I,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,eleanor jenkins,
+MATH,6340,1,Adv Engineering Mathematics,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,vincent ervin,
+MATH,8030,1,Stochastic Processes,0.55,0.36,0.0,0.0,0.05,0.0,0.0,0.05,xin liu,
+MATH,8040,1,Statistical Inference,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,christopher mcmahan,
+MATH,8050,1,Data Analysis,0.42,0.47,0.0,0.0,0.0,0.0,0.0,0.11,calvin williams,
+MATH,8090,1,Time Series Analysis,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,8100,1,Mathematical Programming,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
+MATH,8130,1,Advanced Linear Programming,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
+MATH,8210,1,Linear Analysis,0.33,0.56,0.0,0.0,0.11,0.0,0.0,0.0,taufiquar rahm khan,
+MATH,8220,1,Measure and Integration,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,martin joha schmoll,
+MATH,8260,1,Partial Differential Equations,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,qingshan chen,
+MATH,8530,1,Matrix Analysis,0.48,0.4,0.04,0.0,0.0,0.0,0.0,0.08,matthew macauley,
+MATH,8600,1,Intro to Scientific Computing,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,qingshan chen,
+MATH,8660,1,Finite Element Method,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,vincent ervin,
+MATH,9000,2,Prof Devel in Math Sciences,0.0,0.0,0.0,0.0,0.0,0.91,0.04,0.04,meredith nicol burr,
+MBA,8030,1,Stat Analy of Bus Op,0.3,0.35,0.16,0.0,0.16,0.0,0.0,0.02,janis miller,
+MBA,8060,1,Operations Mgt,0.58,0.33,0.04,0.0,0.02,0.0,0.0,0.02, sridharan,
+MBA,8060,20,Operations Mgt,0.69,0.15,0.12,0.0,0.04,0.0,0.0,0.0, sridharan,
+MBA,8070,1,Financial Management,0.56,0.3,0.14,0.0,0.0,0.0,0.0,0.0,melvin stith,
+MBA,8070,2,Financial Management,0.44,0.39,0.12,0.0,0.0,0.0,0.0,0.05,melvin stith,
+MBA,8090,1,Org Beh & Hum Res Mg,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.02,kristin dam scott,
+MBA,8090,2,Org Beh & Hum Res Mg,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,kristin dam scott,
+MBA,8190,1,Intro to Acc and Fin,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,
+MBA,8190,2,Intro to Acc and Fin,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,annieka philo,
+MBA,8290,1,Marketing Foundation,0.68,0.23,0.04,0.0,0.0,0.0,0.0,0.04,gary hunter,
+MBA,8330,1,Real Estate Investmt,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,
+MBA,8370,1,Legal Environ of Bus,0.48,0.53,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
+MBA,8430,10,Entrepreneurial Accounting,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,
+MBA,8450,1,Technology & Innovation Mgt,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8470,1,New Venture Creation,0.64,0.27,0.05,0.0,0.05,0.0,0.0,0.0,elizabeth er powell,
+MBA,8510,10,Bus Operations & Logistics,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,james liddle,
+MBA,8540,1,Mgrl Accounting,0.39,0.57,0.05,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,
+MBA,8540,2,Mgrl Accounting,0.56,0.4,0.02,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,
+MBA,8540,3,Mgrl Accounting,0.26,0.43,0.22,0.0,0.0,0.0,0.0,0.09,james mil kohlmeyer,
+MBA,8590,1,Mgr Decision Model,0.37,0.3,0.21,0.0,0.05,0.0,0.0,0.07,magda gabriela sava,
+MBA,8590,2,Mgr Decision Model,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,sara elizabet yoder,
+MBA,8600,1,Advanced Marketing Strategy,0.22,0.61,0.17,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8610,1,Information Systems,0.28,0.7,0.03,0.0,0.0,0.0,0.0,0.0,varun grover,
+MBA,8610,2,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MBA,8620,1,Managerial Economics,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,
+MBA,8720,1,Entrepr Finance,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,
+MBA,8720,2,Entrepr Finance,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8740,1,Managing Cont Impvmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MBA,8750,1,Enterprise Develpmnt,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8990,1,Advanced Leadership,0.95,0.0,0.02,0.0,0.0,0.0,0.0,0.02,gail depriest,
+MBA,8990,3,Service Innovation,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
+MBA,8990,4,Bus. Sport. Enter.,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
+MBA,8990,20,Analytics & Application,0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,heshan sun,
+ME,2000,1,Sophomore Seminar,0.92,0.05,0.0,0.0,0.01,0.0,0.0,0.02,donald beasley,
+ME,2010,1,Statics & Dynamics,0.06,0.26,0.25,0.14,0.17,0.0,0.0,0.13,marisa kikendal orr,
+ME,2010,2,Statics & Dynamics,0.06,0.29,0.17,0.13,0.23,0.0,0.0,0.12,paul joseph,
+ME,2030,1,Founda Th/Fl Syst,0.16,0.31,0.27,0.16,0.05,0.0,0.0,0.05,jay ochterbeck,
+ME,2030,2,Founda Th/Fl Syst,0.07,0.2,0.4,0.21,0.05,0.0,0.0,0.06,john saylor,
+ME,2040,1,Mechanics of Materials,0.36,0.53,0.03,0.02,0.05,0.0,0.0,0.02,jorge iva rodriguez,
+ME,2040,2,Mechanics of Materials,0.12,0.49,0.37,0.02,0.0,0.0,0.0,0.0,gang li,
+ME,2040,3,Mechanics of Materials,0.33,0.47,0.18,0.0,0.02,0.0,0.0,0.0,garrett pataky,
+ME,2040,302,Mechanics of Materials (HON),0.55,0.36,0.0,0.09,0.0,0.0,0.0,0.0,gang li,True
+ME,2220,2,Mechanical Engineering Lab I,0.53,0.33,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
+ME,2220,3,Mechanical Engineering Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,5,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,6,Mechanical Engineering Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,7,Mechanical Engineering Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,8,Mechanical Engineering Lab I,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,9,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,10,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,13,Mechanical Engineering Lab I,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,2220,14,Mechanical Engineering Lab I,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,todd schweisinger,
+ME,2220,15,Mechanical Engineering Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3030,1,Thermodynamics,0.23,0.55,0.15,0.05,0.0,0.0,0.0,0.03,yiqiang han,
+ME,3030,2,Thermodynamics,0.17,0.6,0.17,0.02,0.0,0.0,0.0,0.05,yiqiang han,
+ME,3040,1,Heat Transfer,0.08,0.37,0.34,0.05,0.06,0.0,0.0,0.1,jean-marc delhaye,
+ME,3040,2,Heat Transfer,0.19,0.32,0.4,0.04,0.04,0.0,0.0,0.01,jean-marc delhaye,
+ME,3050,1,Model/an Dy Syst,0.2,0.47,0.2,0.0,0.08,0.0,0.0,0.05,phanin tallapragada,
+ME,3050,2,Model/an Dy Syst,0.21,0.5,0.21,0.07,0.01,0.0,0.0,0.0,joshua bostwick,
+ME,3060,1,Fund Machine Design,0.54,0.37,0.06,0.0,0.0,0.0,0.0,0.04,oliver myers,
+ME,3060,2,Fund Machine Design,0.34,0.44,0.17,0.02,0.01,0.0,0.0,0.01,paul jeffrey meyer,
+ME,3070,1,Found of Mechanical Systems,0.6,0.24,0.09,0.0,0.05,0.0,0.0,0.02,jorge iva rodriguez,
+ME,3070,2,Found of Mechanical Systems,0.19,0.56,0.22,0.04,0.0,0.0,0.0,0.0,gregory mocko,
+ME,3080,1,Fluid Mechanics,0.13,0.58,0.24,0.04,0.0,0.0,0.0,0.0,daniel fant,
+ME,3080,2,Fluid Mechanics,0.23,0.38,0.27,0.08,0.02,0.0,0.0,0.02,xiangchun xuan,
+ME,3100,1,Thermo/Heat Transfer,0.39,0.39,0.13,0.0,0.0,0.0,0.0,0.09,yiqiang han,
+ME,3120,1,Manuf Processes,0.19,0.47,0.3,0.03,0.01,0.0,0.0,0.01,hong seok choi,
+ME,3330,1,Mechanical Engineering Lab II,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,2,Mechanical Engineering Lab II,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,3330,3,Mechanical Engineering Lab II,0.25,0.63,0.06,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,3330,4,Mechanical Engineering Lab II,0.29,0.5,0.07,0.0,0.14,0.0,0.0,0.0,todd schweisinger,
+ME,3330,5,Mechanical Engineering Lab II,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,6,Mechanical Engineering Lab II,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,3330,7,Mechanical Engineering Lab II,0.31,0.5,0.19,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,3330,8,Mechanical Engineering Lab II,0.27,0.47,0.2,0.0,0.07,0.0,0.0,0.0,todd schweisinger,
+ME,4000,1,Senior Seminar,0.84,0.12,0.01,0.03,0.0,0.0,0.0,0.0,donald beasley,
+ME,4010,1,Mech Engr Design,0.54,0.34,0.1,0.0,0.02,0.0,0.0,0.0,cameron turner,
+ME,4020,2,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
+ME,4020,3,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lonny thompson,
+ME,4020,4,Intern in Engr Des,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,4020,5,Intern in Engr Des,0.4,0.27,0.33,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,6,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
+ME,4020,7,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+ME,4020,9,Intern in Engr Des,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,
+ME,4030,1,Control Dynamic Systems,0.31,0.23,0.29,0.14,0.03,0.0,0.0,0.0,suyi li,
+ME,4030,2,Control Dynamic Systems,0.35,0.53,0.1,0.03,0.0,0.0,0.0,0.0,yue wang,
+ME,4170,1,Mechatronic Sys,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4180,1,F E A in M E Design,0.24,0.48,0.2,0.08,0.0,0.0,0.0,0.0,gang li,
+ME,4220,1,Design Gas Turbines,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,abhijit som,
+ME,4260,1,Nuclear Energy,0.36,0.36,0.29,0.0,0.0,0.0,0.0,0.0,richard watkins,
+ME,4300,1,Mech Comp Materials,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,4440,1,Mechanical Engineering Lab III,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4440,2,Mechanical Engineering Lab III,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4440,3,Mechanical Engineering Lab III,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4440,4,Mechanical Engineering Lab III,0.08,0.83,0.08,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4440,5,Mechanical Engineering Lab III,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4440,7,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4930,5,Sel.Topics in ME - Rapid Proto,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4930,34,Selected Topics ME (Cardio),0.15,0.62,0.15,0.0,0.0,0.0,0.0,0.08,ethan kung,
+ME,4930,36,Sel. Topics in ME (BioDesgin),0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,michael porter,
+ME,4930,39,Sel Topics ME (Solar Energy),0.4,0.46,0.06,0.0,0.0,0.0,0.0,0.09,daniel fant,
+ME,6300,1,Mech Comp Materials,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,6320,1,Adv Strength of Matl,0.14,0.71,0.14,0.0,0.0,0.0,0.0,0.0,michael porter,
+ME,8120,1,Exp Meth Thermal Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
+ME,8190,1,Cp Meth in Therm Sc,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,
+ME,8200,1,Mod Cont Engr,0.47,0.36,0.14,0.0,0.0,0.0,0.0,0.03,ardalan vahidi,
+ME,8200,401,Mod Cont Engr,0.23,0.54,0.15,0.0,0.08,0.0,0.0,0.0,ardalan vahidi,
+ME,8310,1,Convective Ht Trans,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,xin zhao,
+ME,8370,1,Theory of Elast I,0.26,0.48,0.22,0.0,0.04,0.0,0.0,0.0,nicole gise coutris,
+MGT,2010,1,Principles of Management,0.39,0.37,0.17,0.03,0.03,0.0,0.0,0.01,katherine clark,
+MGT,2010,2,Principles of Management,0.45,0.34,0.14,0.03,0.03,0.0,0.0,0.03,katherine clark,
+MGT,2010,3,Principles of Management,0.38,0.31,0.19,0.06,0.03,0.0,0.0,0.03,katherine clark,
+MGT,2010,5,Principles of Management,0.44,0.37,0.15,0.02,0.01,0.0,0.0,0.0,tina robbins,
+MGT,2010,6,Principles of Management,0.36,0.46,0.16,0.0,0.0,0.0,0.0,0.01,tina robbins,
+MGT,2010,7,Principles of Management,0.41,0.41,0.15,0.0,0.0,0.0,0.0,0.03,tina robbins,
+MGT,2010,8,Principles of Management,0.43,0.44,0.06,0.03,0.03,0.0,0.0,0.01,tina robbins,
+MGT,2010,10,Principles of Management,0.3,0.35,0.26,0.07,0.02,0.0,0.0,0.0,ashley will parnell,
+MGT,2010,11,Principles of Management,0.28,0.44,0.21,0.05,0.0,0.0,0.0,0.03,ashley will parnell,
+MGT,2180,1,Management PC Applications,0.52,0.28,0.11,0.04,0.05,0.0,0.0,0.01,ryan toole,
+MGT,2180,2,Management PC Applications,0.51,0.36,0.06,0.02,0.02,0.0,0.0,0.02,ryan toole,
+MGT,2180,3,Management PC Applications,0.58,0.29,0.08,0.0,0.02,0.0,0.0,0.03,ryan toole,
+MGT,2180,4,Management PC Applications,0.48,0.34,0.11,0.02,0.02,0.0,0.0,0.04,ryan toole,
+MGT,2970,1,How to Start a Startup,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,john michael hannon,
+MGT,2970,2,How to Start a Startup,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,john michael hannon,
+MGT,2970,4,How to Start a Startup,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
+MGT,2970,5,CI in Management (Film Study),0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,john michael hannon,
+MGT,3070,1,Human Resource Management,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,2,Human Resource Management,0.68,0.25,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,3,Human Resource Management,0.65,0.28,0.05,0.0,0.03,0.0,0.0,0.0,michael cole,
+MGT,3070,4,Human Resource Management,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,6,Human Resource Management,0.41,0.51,0.05,0.0,0.0,0.0,0.0,0.03,leonard jos spooner,
+MGT,3100,1,Intermed Business Statistics,0.14,0.19,0.2,0.12,0.15,0.0,0.0,0.2,sara elizabet yoder,
+MGT,3100,2,Intermed Business Statistics,0.1,0.24,0.26,0.06,0.16,0.0,0.0,0.18,sara elizabet yoder,
+MGT,3100,3,Intermed Business Statistics,0.5,0.32,0.11,0.05,0.0,0.0,0.0,0.03,wenxi pu,
+MGT,3100,4,Intermed Business Statistics,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MGT,3100,5,Intermed Business Statistics,0.44,0.28,0.18,0.1,0.0,0.0,0.0,0.0,daniel nielubowicz,
+MGT,3100,6,Intermed Business Statistics,0.19,0.28,0.22,0.0,0.11,0.0,0.0,0.19,magda gabriela sava,
+MGT,3100,7,Intermed Business Statistics,0.52,0.27,0.18,0.02,0.0,0.0,0.0,0.0,dan jiang,
+MGT,3120,1,Decision Models for Management,0.45,0.32,0.19,0.0,0.03,0.0,0.0,0.01,mark mcknew,
+MGT,3120,2,Decision Models for Management,0.51,0.25,0.12,0.06,0.03,0.0,0.0,0.03,mark mcknew,
+MGT,3150,1,New Venture Creation,0.38,0.55,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
+MGT,3180,1,Mgt of Info Systems,0.53,0.43,0.05,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,
+MGT,3180,2,Mgt of Info Systems,0.77,0.16,0.07,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,
+MGT,3180,3,Mgt of Info Systems,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,heshan sun,
+MGT,3180,4,Mgt of Info Systems,0.3,0.6,0.08,0.0,0.03,0.0,0.0,0.0,roopa raman,
+MGT,3500,1,Intro to Business Analytics,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,siyuan li,
+MGT,3900,1,Ops Mgt,0.46,0.15,0.15,0.1,0.05,0.0,0.0,0.08,berna quiroga gomez,
+MGT,3900,2,Ops Mgt,0.13,0.23,0.51,0.1,0.0,0.0,0.0,0.03,niratc tungtisanont,
+MGT,3900,3,Ops Mgt,0.15,0.48,0.25,0.13,0.0,0.0,0.0,0.0,remi charpin,
+MGT,3900,4,Ops Mgt,0.09,0.57,0.28,0.02,0.04,0.0,0.0,0.0,zachary mo leffakis,
+MGT,3900,5,Ops Mgt,0.2,0.1,0.43,0.13,0.08,0.0,0.0,0.08,berna quiroga gomez,
+MGT,4000,2,Mgt of Organizational Behavior,0.73,0.25,0.0,0.0,0.0,0.0,0.0,0.03,michael cole,
+MGT,4000,3,Mgt of Organizational Behavior,0.43,0.28,0.28,0.0,0.03,0.0,0.0,0.0,philip roth,
+MGT,4000,4,Mgt of Organizational Behavior,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4020,1,Ops Pln and Ctl,0.05,0.45,0.41,0.05,0.05,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4080,1,Lean Operations,0.32,0.45,0.18,0.0,0.05,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4110,1,Project Management,0.38,0.45,0.1,0.0,0.05,0.0,0.0,0.03,russell purvis,
+MGT,4120,1,Supplier Management,0.13,0.51,0.36,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,1,Business Strategy,0.43,0.58,0.0,0.0,0.0,0.0,0.0,0.0,dane patric blevins,
+MGT,4150,2,Business Strategy,0.53,0.45,0.03,0.0,0.0,0.0,0.0,0.0,dane patric blevins,
+MGT,4150,3,Business Strategy,0.26,0.57,0.14,0.0,0.0,0.0,0.0,0.02,zeki simsek,
+MGT,4150,4,Business Strategy,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,5,Business Strategy,0.32,0.29,0.32,0.05,0.02,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,6,Business Strategy,0.41,0.48,0.09,0.0,0.02,0.0,0.0,0.0,james liddle,
+MGT,4150,7,Business Strategy,0.46,0.52,0.02,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,8,Business Strategy,0.5,0.48,0.02,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4160,1,Special Topics Hr,0.4,0.45,0.1,0.0,0.03,0.0,0.0,0.03,kristin dam scott,
+MGT,4230,1,Intern Bus Mgt,0.35,0.5,0.08,0.05,0.0,0.0,0.0,0.03,janis miller,
+MGT,4230,2,Intern Bus Mgt,0.36,0.38,0.24,0.02,0.0,0.0,0.0,0.0,james liddle,
+MGT,4230,3,Intern Bus Mgt,0.18,0.23,0.48,0.03,0.03,0.0,0.0,0.08,wayne stewart,
+MGT,4230,4,Intern Bus Mgt,0.1,0.36,0.38,0.0,0.08,0.0,0.0,0.08,wayne stewart,
+MGT,4240,1,Global Supply Chain,0.19,0.58,0.19,0.0,0.0,0.0,0.0,0.03,yann ferrand,
+MGT,4310,1,Emp Rights & Resp,0.35,0.56,0.09,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,4350,1,Pers Interviewing,0.25,0.43,0.25,0.03,0.05,0.0,0.0,0.0,philip roth,
+MGT,4520,1,Business Analysis,0.15,0.56,0.23,0.03,0.0,0.0,0.0,0.03,roopa raman,
+MGT,4550,1,Emerging I T Trends,0.41,0.49,0.1,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MGT,4560,1,Business Info Mgt,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,siyuan li,
+MGT,8120,1,Supply Chain Mgt,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,yann ferrand,
+MICR,3050,1,General Microbiology,0.41,0.41,0.15,0.01,0.01,0.0,0.0,0.01,krista barr rudolph,
+MICR,3050,2,General Microbiology,0.34,0.34,0.23,0.05,0.01,0.0,0.0,0.03,kristi ja whitehead,
+MICR,3050,3,General Microbiology,0.7,0.24,0.07,0.0,0.0,0.0,0.0,0.0,krista barr rudolph,
+MICR,4000,1,Public Health Micro,0.52,0.27,0.16,0.03,0.02,0.0,0.0,0.01,kristi ja whitehead,
+MICR,4000,2,Public Health Micro (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,True
+MICR,4030,1,Marine Microbiology,0.29,0.5,0.17,0.0,0.0,0.0,0.0,0.04,john michael henson,
+MICR,4070,1,Food and Dairy Micro,0.26,0.47,0.21,0.03,0.01,0.0,0.0,0.01,xiuping jiang,
+MICR,4110,1,Pathogenic Bact,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4120,1,Bacterial Physiology,0.23,0.31,0.19,0.17,0.07,0.0,0.0,0.03,thomas hughes,
+MICR,4130,1,Industrial Micro,0.64,0.34,0.01,0.01,0.0,0.0,0.0,0.0,tzuen-rong je tzeng,
+MICR,4140,1,Basic Immunology,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,charles rice,
+MICR,4170,1,Cancer and Aging,0.87,0.11,0.02,0.0,0.0,0.0,0.0,0.0,yuqing dong,
+MICR,4500,1,Advanced Microbiology I,0.42,0.42,0.08,0.04,0.04,0.0,0.0,0.0,harry kurtz,
+MICR,4500,2,Advanced Microbiology I,0.42,0.33,0.13,0.08,0.0,0.0,0.0,0.04,harry kurtz,
+MICR,4500,3,Advanced Microbiology I,0.06,0.63,0.31,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4520,1,Advanced Microbiology III,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4520,2,Advanced Microbiology III,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.04,harry kurtz,
+MKT,3010,1,Prin of Marketing,0.3,0.39,0.2,0.09,0.01,0.0,0.0,0.01,carter wil mcelveen,
+MKT,3010,2,Prin of Marketing,0.18,0.42,0.27,0.06,0.04,0.0,0.0,0.03,carter wil mcelveen,
+MKT,3010,3,Prin of Marketing,0.27,0.36,0.25,0.09,0.01,0.0,0.0,0.01,amanda cooper fine,
+MKT,3010,4,Prin of Marketing,0.24,0.4,0.25,0.06,0.04,0.0,0.0,0.01,amanda cooper fine,
+MKT,3010,5,Prin of Marketing,0.73,0.18,0.06,0.0,0.02,0.0,0.0,0.02,patricia knowles,
+MKT,3020,1,Consumer Behavior,0.44,0.36,0.14,0.04,0.02,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,2,Consumer Behavior,0.33,0.37,0.24,0.04,0.02,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,3,Consumer Behavior,0.38,0.48,0.12,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3020,4,Consumer Behavior,0.32,0.44,0.16,0.08,0.0,0.0,0.0,0.0, thyroff fitzwater,
+MKT,3020,5,Consumer Behavior,0.28,0.56,0.14,0.02,0.0,0.0,0.0,0.0,james gaubert,
+MKT,3210,1,Sports Marketing,0.6,0.37,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3210,2,Sports Marketing,0.51,0.43,0.02,0.0,0.0,0.0,0.0,0.04,delancy bennett,
+MKT,3310,1,Marketing Metrics & Analytics,0.81,0.14,0.03,0.0,0.0,0.0,0.0,0.03,oriana rache aragon,
+MKT,3310,2,Marketing Metrics & Analytics,0.9,0.08,0.0,0.03,0.0,0.0,0.0,0.0,oriana rache aragon,
+MKT,3980,1,CI: Sales Experiential,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.01,carter wil mcelveen,
+MKT,4200,1,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,2,Professional Selling,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,3,Professional Selling,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4200,4,Professional Selling,0.72,0.2,0.04,0.0,0.04,0.0,0.0,0.0,gary hunter,
+MKT,4200,5,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4230,1,Promotional Strategy,0.35,0.44,0.18,0.03,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,4240,1,Sales Management,0.38,0.6,0.03,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4270,1,International Mktg,0.28,0.5,0.13,0.08,0.0,0.0,0.0,0.03,thomas poehlman,
+MKT,4270,2,International Mktg,0.23,0.48,0.2,0.03,0.0,0.0,0.0,0.08,roger gomes,
+MKT,4270,3,International Mktg,0.59,0.33,0.07,0.02,0.0,0.0,0.0,0.0,roger gomes,
+MKT,4280,1,Services Marketing,0.58,0.24,0.16,0.0,0.0,0.0,0.0,0.02,james gaubert,
+MKT,4280,2,Services Marketing,0.68,0.29,0.02,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4310,1,Marketing Research,0.25,0.25,0.32,0.14,0.04,0.0,0.0,0.0,peter weathers,
+MKT,4310,2,Marketing Research,0.26,0.45,0.23,0.0,0.0,0.0,0.0,0.06,william kilbourne,
+MKT,4310,3,Marketing Research,0.3,0.59,0.11,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,4,Marketing Research,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4330,1,Sport Mkt Strategy,0.47,0.44,0.06,0.0,0.0,0.0,0.0,0.03,amanda cooper fine,
+MKT,4450,1,Macromarketing,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,william kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.22,0.56,0.19,0.0,0.03,0.0,0.0,0.0,christopher hopkins,
+MKT,4500,2,Strategic Mktg Mgt,0.29,0.68,0.03,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
+MKT,4500,3,Strategic Mktg Mgt,0.73,0.24,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,
+MKT,4500,4,Strategic Mktg Mgt,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,8620,1,Quant Methods in Mkt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
+MKT,8650,1,Seminar in Mkt Mgmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MKT,8660,1,International Marketing,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,thomas poehlman,
+ML,1020,1,Leadership Fund II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,clay wilson etterle,
+ML,1020,2,Leadership Fund II,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,amanda carol kane,
+ML,2020,1,Leadership Development II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,shane allen werst,
+ML,2020,2,Leadership Development II,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,shane allen werst,
+ML,3020,1,Advanced Leadership II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,
+ML,3020,2,Advanced Leadership II,0.88,0.04,0.0,0.04,0.0,0.0,0.0,0.04,william cod cleland,
+MSE,2100,1,Intro to Mat Science,0.47,0.2,0.16,0.06,0.06,0.0,0.0,0.05,rakhee pani,
+MSE,2100,2,Intro to Mat Science,0.3,0.46,0.12,0.0,0.03,0.0,0.0,0.09,eric skaar,
+MSE,2100,3,Intro to Mat Science,0.23,0.2,0.23,0.13,0.08,0.0,0.0,0.14,fei peng,
+MSE,2100,4,Intro to Mat Science,0.41,0.34,0.17,0.06,0.02,0.0,0.0,0.0,olga kuksenok,
+MSE,2410,1,Metrics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
+MSE,2410,2,Metrics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
+MSE,2500,1,Polymer & Fiber Materials I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,
+MSE,3260,1,Thermo of Materials,0.33,0.26,0.26,0.04,0.09,0.0,0.0,0.02,gary lickfield,
+MSE,3270,1,Transport Phenomena,0.23,0.4,0.13,0.13,0.07,0.0,0.0,0.03,ulf daniel schiller,
+MSE,3280,1,Phase Diagrams,0.5,0.11,0.25,0.0,0.0,0.0,0.0,0.14,eric skaar,
+MSE,3420,1,Struct/Property,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,rajendra kum bordia,
+MSE,3420,2,Struct/Property,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,rajendra kum bordia,
+MSE,3610,1,Proc of Metals & Composites,0.3,0.49,0.08,0.05,0.0,0.0,0.0,0.08,marian kennedy,
+MSE,4150,1,Polymer Sc Engr,0.48,0.23,0.2,0.05,0.03,0.0,0.0,0.03,igor luzinov,
+MSE,4160,1,Electronic Materials,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
+MSE,4220,1,Mech Behavior of Mat,0.26,0.5,0.15,0.02,0.0,0.0,0.0,0.07,vincent yves blouin,
+MSE,4240,1,Optical Materials,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,4330,1,Comb Sys & Env Emiss,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
+MSE,4560,1,Polymer & Fiber Materials II,0.32,0.39,0.21,0.04,0.0,0.0,0.0,0.04,gary lickfield,
+MSE,4810,1,Undergraduate Research Fundame,0.81,0.13,0.03,0.03,0.0,0.0,0.0,0.0,marian kennedy,
+MSE,4910,1,Undergraduate Research,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,marian kennedy,
+MSE,4910,2,Undergraduate Research,0.62,0.15,0.08,0.0,0.08,0.0,0.0,0.08,marian kennedy,
+MSE,8010,1,Grad Sem in Materials Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,olga kuksenok,
+MSE,8250,1,Solid State Mtl Sci,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,stephen foulger,
+MSE,8520,1,Polymer Science II,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,igor luzinov,
+MUSC,1420,1,Music Theory I,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,anthony bernarducci,
+MUSC,1440,1,Music Theory II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,
+MUSC,1450,1,Aural Skills II,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,andrew levin,
+MUSC,1510,2,Applied Music,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,jonathan edwa doyel,
+MUSC,2100,1,Music in the Western World,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,2100,2,Music in the Western World,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
+MUSC,2100,3,Music in the Western World,0.69,0.19,0.09,0.0,0.0,0.0,0.0,0.03,linda li-bleuel,
+MUSC,2100,4,Music in the Western World,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,5,Music in the Western World,0.44,0.44,0.09,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
+MUSC,2100,6,Music in the Western World,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,8,Music in the Western World,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,monty craig,
+MUSC,2100,9,Music in the Western World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,lea kibler,
+MUSC,3110,1,History of American Music,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,3170,1,Hist of Country Mus,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3180,1,Hist of Audio Tech,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,bruce allen whisler,
+MUSC,3640,1,Concert Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,timothy ra hurlburt,
+MUSC,3690,1,Symphony Orchestra,0.94,0.02,0.0,0.0,0.02,0.0,0.0,0.02,andrew levin,
+MUSC,4160,1,Mus Hist Since 1750,0.52,0.11,0.04,0.22,0.07,0.0,0.0,0.04,linda li-bleuel,
+MUSC,4300,1,Conducting,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,mark spede,
+NPL,3000,1,Nonprofit Leadership,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
+NPL,3000,2,Nonprofit Leadership,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,bonnie west stevens,
+NPL,3010,2,NPL Stakeholders,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
+NPL,3030,2,NPL Personnel,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,wendell price,
+NURS,1400,1,Comp App Hlth Care,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
+NURS,3030,1,Nursing of Adults,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3030,400,Nursing of Adults,0.14,0.68,0.18,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3040,1,Pathophysiology,0.39,0.49,0.06,0.04,0.02,0.0,0.0,0.0,catherine si murton,
+NURS,3040,401,Pathophysiology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
+NURS,3050,1,Psychosocial Nursing,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,barbara jean warner,
+NURS,3050,400,Psychosocial Nursing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
+NURS,3100,1,Health Assessment,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
+NURS,3120,1,Foundations of Nursing,0.34,0.55,0.09,0.02,0.0,0.0,0.0,0.0,angela pye,
+NURS,3190,400,Health Assessment for RNs,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,jennifer geter rice,
+NURS,3330,400,Health Care Genetics,0.87,0.07,0.0,0.07,0.0,0.0,0.0,0.0,mary steck,
+NURS,3330,401,Health Care Genetics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+NURS,3400,1,Pharmther Nursing,0.35,0.46,0.1,0.06,0.02,0.0,0.0,0.0,catherine si murton,
+NURS,4010,1,Mental Health Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NURS,4030,1,Complex Nursing of Adults,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
+NURS,4110,1,Nursing of Children,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,
+NURS,4120,1,Nurs Women and Fam,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8010,400,Adv Fam & Comm Nrsng,0.89,0.08,0.0,0.0,0.0,0.0,0.0,0.03,shirley mae timmons,
+NURS,8010,401,Adv Fam & Comm Nrsng,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
+NURS,8080,400,Nurs Res Stat Analys,0.64,0.22,0.08,0.0,0.06,0.0,0.0,0.0,veronica parker,
+NURS,8190,400,Developing Family,0.43,0.07,0.0,0.0,0.47,0.0,0.0,0.03,lisa miller,
+NURS,8200,400,Child & Adol Nursing,0.14,0.23,0.0,0.0,0.59,0.0,0.0,0.05,heide temples,
+NURS,8210,400,Adult Nursing,0.47,0.17,0.0,0.0,0.37,0.0,0.0,0.0,tracy king fasolino,
+NURS,8210,401,Adult Nursing,0.41,0.41,0.0,0.0,0.14,0.0,0.0,0.03,tracy king fasolino,
+NURS,8230,400,NP Clinical Practicum,0.96,0.0,0.0,0.0,0.04,0.0,0.0,0.0,rosanne pruitt,
+NURS,8840,400,Adult Mental Health,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,lindsey reb garrard,
+NURS,8850,400,Mental Health in Primary Care,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.34,0.49,0.09,0.03,0.02,0.0,0.0,0.03,elizabeth durrance,
+NUTR,2030,2,Intro Princ of Human Nutrition,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
+NUTR,2040,1,Nutrition Across Life Cycle,0.5,0.4,0.07,0.02,0.02,0.0,0.0,0.0,elizabeth durrance,
+NUTR,4180,1,Prof Development in Dietetics,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4250,1,Medica Nutr Thera II,0.45,0.42,0.13,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4260,1,Community Nutrition,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,margaret condrasky,
+NUTR,4550,1,Human Nutr & Metabolism II,0.54,0.29,0.11,0.03,0.03,0.0,0.0,0.0,elliot jesch,
+PA,2790,1,Perf Arts Pract I,0.6,0.2,0.0,0.2,0.0,0.0,0.0,0.0,kenneth moore,
+PA,2800,1,Perf Arts Pract II,0.5,0.06,0.0,0.13,0.19,0.0,0.0,0.13,kenneth moore,
+PADM,8220,400,Public Policy Process,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,
+PADM,8270,400,Public Personnel Admin,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,lawrence nichols,
+PADM,8290,400,Public Financial Management,0.57,0.29,0.0,0.0,0.07,0.0,0.0,0.07,robert frager,
+PADM,8410,400,Public Data Analysis,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
+PADM,8410,401,Public Data Analysis,0.78,0.0,0.11,0.0,0.11,0.0,0.0,0.0,ronald chrestman,
+PADM,8410,402,Public Data Analysis,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
+PADM,8450,400,Grant Writing for Public Admin,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,katheri kransteuber,
+PADM,8520,400,Emergency Mgt Planning & Prep,0.73,0.13,0.0,0.0,0.13,0.0,0.0,0.0,amanda nico ritsema,
+PADM,8540,400,Cybersecurity,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,david leigh cook,
+PADM,8680,400,Local Government Admin,0.36,0.45,0.0,0.0,0.18,0.0,0.0,0.0,alfred bundrick,
+PADM,8780,402,Local Govt. Budgeting & Financ,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,kevin yokim,
+PADM,8780,405,Regional Econ Devlpmnt Policy,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,lori ann dickes,
+PAS,3010,1,Pan African Studies,0.74,0.17,0.0,0.0,0.04,0.0,0.0,0.04,garry bertholf,
+PES,2020,1,Soils,0.3,0.33,0.35,0.0,0.02,0.0,0.0,0.0,dara michelle park,
+PES,4230,1,Field Crops - Forages,0.12,0.19,0.54,0.08,0.04,0.0,0.0,0.04,matias jose aguerre,
+PES,4330,1,Landscape & Turf Weed Mgt,0.07,0.71,0.14,0.0,0.07,0.0,0.0,0.0,ted whitwell,
+PES,4450,1,Regulatory Issues & Policies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,
+PES,4520,1,Soil Fertility and Management,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
+PES,4900,1,Soil Organisms in Plant Growth,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,"appukuttan suseela,",
+PES,6900,1,Soil Organisms in Plant Growth,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,"appukuttan suseela,",
+PES,8010,1,Crop Physiology and Nutrition,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,sruthi naraya kutty,
+PHIL,1010,1,Intro to Philosophic Problems,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,david stegall,
+PHIL,1010,2,Intro to Philosophic Problems,0.6,0.17,0.11,0.03,0.09,0.0,0.0,0.0,david stegall,
+PHIL,1010,3,Intro to Philosophic Problems,0.21,0.55,0.15,0.0,0.03,0.0,0.0,0.06,kelly smith,
+PHIL,1010,5,Intro to Philosophic Problems,0.26,0.47,0.16,0.0,0.05,0.0,0.0,0.05,john randall wolfe,
+PHIL,1010,6,Intro to Philosophic Problems,0.54,0.23,0.14,0.0,0.06,0.0,0.0,0.03,john randall wolfe,
+PHIL,1010,7,Intro to Philosophic Problems,0.52,0.36,0.06,0.0,0.03,0.0,0.0,0.03,john randall wolfe,
+PHIL,1020,1,Introduction to Logic,0.75,0.11,0.08,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
+PHIL,1020,2,Introduction to Logic,0.77,0.14,0.06,0.03,0.0,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,3,Introduction to Logic,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,michael hal hannen,
+PHIL,1020,4,Introduction to Logic,0.59,0.26,0.12,0.03,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1020,5,Introduction to Logic,0.71,0.18,0.03,0.0,0.03,0.0,0.0,0.06,adam gies,
+PHIL,1020,6,Introduction to Logic,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1030,2,Introduction to Ethics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,
+PHIL,1030,3,Introduction to Ethics,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,william maker,
+PHIL,1030,5,Introduction to Ethics,0.5,0.32,0.09,0.03,0.03,0.0,0.0,0.03,edyta joanna kuzian,
+PHIL,1030,6,Introduction to Ethics,0.51,0.4,0.03,0.0,0.0,0.0,0.0,0.06,john jung park,
+PHIL,1030,7,Introduction to Ethics,0.46,0.43,0.09,0.03,0.0,0.0,0.0,0.0,john jung park,
+PHIL,1030,8,Introduction to Ethics,0.31,0.46,0.12,0.04,0.04,0.0,0.0,0.04,charles starkey,
+PHIL,1030,9,Introduction to Ethics,0.54,0.31,0.09,0.06,0.0,0.0,0.0,0.0,edyta joanna kuzian,
+PHIL,1030,10,Introduction to Ethics,0.54,0.31,0.11,0.0,0.03,0.0,0.0,0.0,john jung park,
+PHIL,3040,1,Moral Philosophy,0.31,0.15,0.23,0.23,0.0,0.0,0.0,0.08,john jung park,
+PHIL,3050,2,Existentialism,0.84,0.09,0.0,0.0,0.06,0.0,0.0,0.0,david stegall,
+PHIL,3150,1,Ancient Philosophy,0.32,0.26,0.21,0.05,0.05,0.0,0.0,0.11,jennifer ingle,
+PHIL,3160,1,Modern Philosophy,0.47,0.41,0.06,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
+PHIL,3170,1,19th-Century Philosophy,0.19,0.31,0.31,0.06,0.06,0.0,0.0,0.06,william maker,
+PHIL,3180,1,20th-Century Philosophy,0.59,0.33,0.07,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
+PHIL,3210,1,Crime & Punishment,0.34,0.48,0.14,0.0,0.03,0.0,0.0,0.0,daniel wueste,
+PHIL,3250,2,Phil of Science,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,3260,1,Science and Values,0.47,0.47,0.0,0.0,0.06,0.0,0.0,0.0,andrew garnar,
+PHIL,3260,2,Science and Values,0.41,0.38,0.0,0.0,0.03,0.0,0.0,0.18,andrew garnar,
+PHIL,3260,3,Science and Values,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,
+PHIL,3280,1,Technology of Bodies,0.54,0.31,0.08,0.04,0.0,0.0,0.0,0.04,edyta joanna kuzian,
+PHIL,3450,1,Environmental Ethics,0.51,0.29,0.09,0.06,0.03,0.0,0.0,0.03,jennifer ingle,
+PHIL,3450,2,Environmental Ethics,0.51,0.34,0.11,0.0,0.03,0.0,0.0,0.0,jennifer ingle,
+PHIL,3490,2,Gender and Sexuality,0.52,0.43,0.05,0.0,0.0,0.0,0.0,0.0,diane perpich,
+PHIL,4010,1,Studies in the Hist of Phil,0.71,0.06,0.0,0.0,0.12,0.0,0.0,0.12,david stegall,
+PHIL,4750,1,Philosophy of Film,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,christopher grau,
+PHSC,1170,1,Intro Chem & Earth,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics with Calculus I,0.18,0.47,0.22,0.07,0.05,0.0,0.0,0.01,amy liann pope,
+PHYS,1220,2,Physics with Calculus I,0.19,0.46,0.23,0.03,0.02,0.0,0.0,0.07,lih-sin the,
+PHYS,1220,3,Physics with Calculus I,0.14,0.49,0.29,0.04,0.01,0.0,0.0,0.02,apparao rao,
+PHYS,1220,4,Physics with Calculus I,0.22,0.49,0.22,0.02,0.01,0.0,0.0,0.03,jason stratfo brown,
+PHYS,1220,5,Physics with Calculus I,0.27,0.51,0.15,0.04,0.01,0.0,0.0,0.02,pooja puneet,
+PHYS,1220,8,Physics With Cal I (HON),0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True
+PHYS,1240,1,Physics Lab I,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,2,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,3,Physics Lab I,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,4,Physics Lab I,0.28,0.61,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,
+PHYS,1240,5,Physics Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,6,Physics Lab I,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,7,Physics Lab I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,1240,8,Physics Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,9,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,10,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,11,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,12,Physics Lab I,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,13,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,15,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,16,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,17,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,19,Physics Lab I,0.24,0.59,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,20,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,21,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,22,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,24,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,25,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,26,Physics Lab I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,27,Physics Lab I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,1240,29,Physics Lab I,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,1240,30,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2000,1,Introductory Physics,0.49,0.4,0.04,0.03,0.04,0.0,0.0,0.0,sean brittain,
+PHYS,2070,1,General Physics I,0.38,0.4,0.14,0.03,0.02,0.0,0.0,0.03,amy liann pope,
+PHYS,2080,1,General Physics II,0.51,0.33,0.1,0.03,0.02,0.0,0.0,0.0,pooja puneet,
+PHYS,2080,2,General Physics II,0.65,0.28,0.05,0.0,0.01,0.0,0.0,0.0,pooja puneet,
+PHYS,2090,1,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,2,Gen Phys Lab I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,3,Gen Phys Lab I,0.17,0.74,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,4,Gen Phys Lab I,0.31,0.44,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,
+PHYS,2090,5,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2090,6,Gen Phys Lab I,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2090,7,Gen Phys Lab I,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,jerry hester,
+PHYS,2090,9,Gen Phys Lab I,0.52,0.35,0.0,0.0,0.09,0.0,0.0,0.04,jerry hester,
+PHYS,2090,10,Gen Phys Lab I,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,1,Gen Phys Lab II,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,2,Gen Phys Lab II,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,3,Gen Phys Lab II,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,4,Gen Phys Lab II,0.46,0.33,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,5,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,6,Gen Phys Lab II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,7,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,10,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,11,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,12,Gen Phys Lab II,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,13,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2100,14,Gen Phys Lab II,0.75,0.13,0.08,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,15,Gen Phys Lab II,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,16,Gen Phys Lab II,0.57,0.39,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,
+PHYS,2100,17,Gen Phys Lab II,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
+PHYS,2100,18,Gen Phys Lab II,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2210,1,Physics with Calculus II,0.28,0.34,0.27,0.06,0.03,0.0,0.0,0.02,jason stratfo brown,
+PHYS,2210,2,Physics with Calculus II,0.24,0.41,0.23,0.03,0.06,0.0,0.0,0.02,jason stratfo brown,
+PHYS,2210,500,Physics With Calculus II,0.2,0.4,0.33,0.07,0.0,0.0,0.0,0.0,elaine parshall,
+PHYS,2220,1,Physics with Calculus III,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,jian he,
+PHYS,2230,1,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,2,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
+PHYS,2230,5,Physics Lab II,0.36,0.36,0.18,0.0,0.09,0.0,0.0,0.0,jerry hester,
+PHYS,2230,6,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,7,Physics Lab II,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
+PHYS,2230,8,Physics Lab II,0.83,0.06,0.0,0.11,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,9,Physics Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2230,500,Physics Lab II,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,elaine parshall,
+PHYS,2240,1,Physics Lab III,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
+PHYS,2400,1,Phys of Weather,0.35,0.41,0.11,0.02,0.0,0.0,0.0,0.11,miguel larsen,
+PHYS,3110,1,Methods Theor Phys,0.31,0.46,0.08,0.0,0.04,0.0,0.0,0.12,antony valentini,
+PHYS,3220,1,Mechanics II,0.18,0.45,0.18,0.0,0.09,0.0,0.0,0.09,joshua alper,
+PHYS,3260,1,Exper Physics II,0.6,0.2,0.12,0.0,0.04,0.0,0.0,0.04,chad sosolik,
+PHYS,4650,1,Thermo and Stat Mech,0.46,0.15,0.31,0.0,0.0,0.0,0.0,0.08,feng ding,
+PHYS,6560,1,Quantum Physics II,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,ramakrishna podila,
+PHYS,8150,1,Statistical Therm I,0.11,0.67,0.11,0.0,0.0,0.0,0.0,0.11,jens oberheide,
+PHYS,8410,1,Electrodynamics I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
+PHYS,9520,1,Quantum Mech II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
+PKSC,1020,1,Intro to Pkg Sci,0.31,0.44,0.16,0.06,0.01,0.0,0.0,0.02,heather batt,
+PKSC,2010,1,Pkg Perishable Prod,0.15,0.34,0.24,0.08,0.1,0.0,0.0,0.1,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,
+PKSC,2040,1,Container Systems,0.93,0.02,0.03,0.0,0.02,0.0,0.0,0.0,robert truett moore,
+PKSC,2060,1,Container Sys Lab,0.57,0.33,0.05,0.05,0.0,0.0,0.0,0.0,tyler stuettgen,
+PKSC,2060,2,Container Sys Lab,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,
+PKSC,2060,3,Container Sys Lab,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,tyler stuettgen,
+PKSC,2200,1,Product & Pkg Design,0.83,0.1,0.02,0.0,0.02,0.0,0.0,0.02,william aaro snyder,
+PKSC,3200,1,Pkg Design Theory,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,rupert hurley,
+PKSC,3680,1,Pkg and Society,0.31,0.38,0.17,0.03,0.03,0.0,0.0,0.07,heather batt,
+PKSC,4030,1,Pkg Career Prep,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4200,1,Pkg Design & Dev,0.71,0.17,0.11,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4240,400,Structural Pkg Design Online,0.6,0.1,0.0,0.0,0.2,0.0,0.0,0.1,rupert hurley,
+PKSC,4300,1,Converting Flex Pkg,0.16,0.62,0.13,0.03,0.04,0.0,0.0,0.01,duncan darby,
+PKSC,4400,1,Packaging for Distribution,0.17,0.46,0.22,0.04,0.11,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1,Food & Health Care Pkg Systems,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kay cooksey,
+PKSC,8220,400,3D Parametric Design,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,rupert hurley,
+PLPA,2130,1,Fungi & Civilization,0.37,0.37,0.17,0.06,0.02,0.0,0.0,0.01,julia loui kerrigan,
+PLPA,4060,1,Diseases/Insects Turfgrasses,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,samuel martin,
+PLPA,8090,1,Analytical Technique,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,
+POSC,1010,2,Amer National Govt,0.08,0.36,0.12,0.16,0.24,0.0,0.0,0.04,adam warber,
+POSC,1010,3,Amer National Govt,0.05,0.33,0.33,0.1,0.0,0.0,0.0,0.2,james woodard,
+POSC,1020,1,Intro Intl Relations,0.26,0.42,0.22,0.04,0.02,0.0,0.0,0.04,tara elizabet trask,
+POSC,1020,2,Intro Intl Relations,0.16,0.29,0.3,0.13,0.04,0.0,0.0,0.07,aron geo tannenbaum,
+POSC,1020,3,Intro Intl Relations,0.1,0.45,0.27,0.09,0.03,0.0,0.0,0.05,zeynep taydas,
+POSC,1020,5,Intro Intl Relations,0.23,0.31,0.27,0.08,0.04,0.0,0.0,0.08,joshua douglas king,
+POSC,1030,1,Intro to Political Theory,0.24,0.33,0.2,0.09,0.13,0.0,0.0,0.01,brandon turner,
+POSC,1030,2,Intro to Political Theory,0.23,0.65,0.08,0.0,0.0,0.0,0.0,0.04,colin pearce,
+POSC,1040,1,Intro Compar Pol,0.29,0.31,0.16,0.02,0.11,0.0,0.0,0.11,katherine am curtis,
+POSC,1040,2,Intro Compar Pol,0.48,0.26,0.09,0.09,0.04,0.0,0.0,0.04,tara elizabet trask,
+POSC,1990,1,Intro Pol Sci,0.48,0.25,0.12,0.06,0.04,0.0,0.0,0.06,meredith petersheim,
+POSC,3020,1,State and Loc Gov,0.17,0.52,0.17,0.0,0.02,0.0,0.0,0.12,bruce ransom,
+POSC,3210,1,Public Admin,0.13,0.35,0.43,0.0,0.04,0.0,0.0,0.04,james woodard,
+POSC,3610,1,Intl Pol in Crisis,0.25,0.25,0.1,0.05,0.18,0.0,0.0,0.18,steven vince miller,
+POSC,3630,1,Us Foreign Policy,0.38,0.27,0.19,0.04,0.12,0.0,0.0,0.0,jeffrey scott peake,
+POSC,3710,1,European Politics,0.51,0.29,0.1,0.04,0.04,0.0,0.0,0.02,vladimir matic,
+POSC,3750,1,European Integration,0.37,0.19,0.26,0.07,0.07,0.0,0.0,0.04,katherine am curtis,
+POSC,3810,1,African Amer Politic,0.33,0.47,0.2,0.0,0.0,0.0,0.0,0.0,bruce ransom,
+POSC,4050,1,American Presidency,0.08,0.21,0.37,0.11,0.21,0.0,0.0,0.03,adam warber,
+POSC,4160,1,Int Groups & Soc Mov,0.29,0.38,0.2,0.07,0.04,0.0,0.0,0.02,laura olson,
+POSC,4360,1,Law Courts Politics,0.36,0.36,0.2,0.0,0.04,0.0,0.0,0.04,joseph earl stewart,
+POSC,4360,2,Law Courts Politics,0.32,0.5,0.06,0.06,0.03,0.0,0.0,0.03,joseph earl stewart,
+POSC,4370,1,Constitut Law: Rights & Libert,0.24,0.53,0.14,0.02,0.04,0.0,0.0,0.02,daniel frost,
+POSC,4500,1,Contemporary Political Thought,0.36,0.44,0.2,0.0,0.0,0.0,0.0,0.0,daniel frost,
+POSC,4530,1,American Political Thought,0.25,0.45,0.18,0.05,0.05,0.0,0.0,0.03, bradley thompson,
+POSC,4710,1,Russian Politics,0.38,0.33,0.15,0.0,0.05,0.0,0.0,0.08,aron geo tannenbaum,
+POSC,4760,1,Middle East Politics,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,vladimir matic,
+POSC,4890,1,Voting Rights Law Politics Pol,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
+PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,jamie lynn cathey,
+PRTM,2200,1,Foundations of PRTM,0.32,0.52,0.1,0.06,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2200,2,Foundations of PRTM,0.67,0.13,0.13,0.0,0.03,0.0,0.0,0.03,gwynn powell,
+PRTM,2200,3,Foundations of PRTM,0.36,0.43,0.11,0.04,0.07,0.0,0.0,0.0,katherine an jordan,
+PRTM,2200,4,Foundations of PRTM,0.58,0.26,0.03,0.06,0.06,0.0,0.0,0.0,ryan joseph gagnon,
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2270,1,Prov of Leisure Exp,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2290,1,Competency Integration in PRTM,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2410,1,Intro to CRSCM,0.62,0.24,0.05,0.0,0.07,0.0,0.0,0.02,harrison pinckney,
+PRTM,2600,1,Found of Recreational Therapy,0.53,0.36,0.08,0.01,0.01,0.0,0.0,0.01,anna-mar chancellor,
+PRTM,2650,1,Terminology in RT Practice,0.88,0.09,0.0,0.03,0.0,0.0,0.0,0.0,stephen thoma lewis,
+PRTM,2700,1,Intro Rec Res Mgt,0.54,0.39,0.0,0.0,0.07,0.0,0.0,0.0,elizabeth baldwin,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.21,0.48,0.27,0.03,0.0,0.0,0.0,0.0,daniel mor anderson,
+PRTM,3070,1,Facility Operations,0.64,0.18,0.09,0.09,0.0,0.0,0.0,0.0,raymond dunham,
+PRTM,3210,1,Recreation Admin,0.67,0.27,0.03,0.0,0.03,0.0,0.0,0.0,mariela fernandez,
+PRTM,3250,1,Global Persp in Rec,0.42,0.39,0.06,0.0,0.12,0.0,0.0,0.0,skye arthur-banning,
+PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.89,0.1,0.02,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
+PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3280,2,Preceptorship in Recr Therapy,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,stephen thoma lewis,
+PRTM,3420,1,Intro to Tourism,0.73,0.24,0.0,0.0,0.02,0.0,0.0,0.0,li-hsin chen,
+PRTM,3420,2,Intro to Tourism,0.73,0.23,0.02,0.0,0.02,0.0,0.0,0.0,garrett stone,
+PRTM,3440,1,Tourism Markets,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,
+PRTM,3440,2,Tourism Markets,0.75,0.23,0.03,0.0,0.0,0.0,0.0,0.0,zeynep gedikoglu,
+PRTM,3450,1,Tourism Management,0.48,0.29,0.19,0.0,0.03,0.0,0.0,0.0,william norman,
+PRTM,3450,2,Tourism Management,0.41,0.47,0.13,0.0,0.0,0.0,0.0,0.0,william norman,
+PRTM,3460,1,Heritage Tourism,0.33,0.37,0.23,0.07,0.0,0.0,0.0,0.0,gregory phi ramshaw,
+PRTM,3460,2,Heritage Tourism,0.21,0.55,0.14,0.0,0.07,0.0,0.0,0.03,gregory phi ramshaw,
+PRTM,3530,2,Foundations of Camp Counseling,0.8,0.0,0.0,0.0,0.13,0.0,0.0,0.07,gwynn powell,
+PRTM,3830,1,Golf Shop Operations,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3900,3,Independent Study in PRTM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3910,1,Mgmt Admin Outdr Rec Programs,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,robert baxte powell,
+PRTM,3910,9,Intro to GIS for PRTM,0.27,0.64,0.0,0.0,0.09,0.0,0.0,0.0,david lawrenc white,
+PRTM,4210,1,Rec Fin Resc Mgt,0.5,0.38,0.1,0.0,0.03,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,4260,1,Trends & Issues in Rec Therapy,0.62,0.29,0.07,0.0,0.0,0.0,0.0,0.02,brent hawkins,
+PRTM,4300,1,World Geog Parks,0.22,0.54,0.22,0.0,0.03,0.0,0.0,0.0,robert baxte powell,
+PRTM,4310,1,Mthds of Envir Interpretation,0.67,0.08,0.25,0.0,0.0,0.0,0.0,0.0,robert bixler,
+PRTM,4460,2,Community Tourism,0.67,0.2,0.1,0.03,0.0,0.0,0.0,0.0,lauren duffy,
+PRTM,4460,3,Community Tourism,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,lauren duffy,
+PRTM,4510,1,Seminar in CRSCM,0.59,0.25,0.09,0.03,0.0,0.0,0.0,0.03,jamie lynn cathey,
+PRTM,4550,1,Adv Program Planning,0.59,0.23,0.14,0.0,0.05,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,4980,7,Tanzania,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,skye arthur-banning,
+PRTM,8030,1,Sem Rec & Park Admin,0.65,0.25,0.05,0.0,0.05,0.0,0.0,0.0,teresa walto tucker,
+PRTM,8110,2,Research Methods,0.35,0.53,0.09,0.0,0.03,0.0,0.0,0.0,dorothy schmalz,
+PRTM,8110,3,Research Methods,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,
+PRTM,8250,1,Populations in PRTM,0.5,0.33,0.0,0.0,0.17,0.0,0.0,0.0,dorothy schmalz,
+PRTM,8500,2,Sustainable Tourism,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,kenneth backman,
+PRTM,8720,1,Adv Facilitation Techniq in RT,0.6,0.0,0.2,0.0,0.0,0.0,0.0,0.2,jasmine nu townsend,
+PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.7,0.0,0.0,0.0,0.2,0.0,0.0,0.1,stephen thoma lewis,
+PRTM,9000,4,Politics of Science,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,gary edward machlis,
+PRTM,9110,1,Professional Issues,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,gwynn powell,
+PSYC,2010,1,Intro to Psychology,0.43,0.28,0.16,0.07,0.04,0.0,0.0,0.02,jo anne jorgensen,
+PSYC,2010,2,Intro to Psychology,0.2,0.28,0.23,0.13,0.08,0.0,0.0,0.08,edwin brainerd,
+PSYC,2010,3,Intro to Psychology,0.22,0.36,0.3,0.04,0.01,0.0,0.0,0.06,thomas britt,
+PSYC,2010,4,Intro to Psychology,0.44,0.34,0.16,0.03,0.01,0.0,0.0,0.01,fred switzer,
+PSYC,2010,5,Intro to Psychology,0.36,0.3,0.16,0.12,0.03,0.0,0.0,0.03,mary taylor,
+PSYC,2010,6,Intro to Psychology,0.36,0.36,0.19,0.1,0.0,0.0,0.0,0.0,mary taylor,
+PSYC,2010,7,Intro to Psychology (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
+PSYC,2020,3,Intro Psychology Lab,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,madison eliza sauls,
+PSYC,2020,4,Intro Psychology Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,
+PSYC,2020,5,Intro Psychology Lab,0.86,0.04,0.04,0.0,0.04,0.0,0.0,0.04,nastassia ma savage,
+PSYC,2020,6,Intro Psychology Lab,0.81,0.07,0.04,0.04,0.0,0.0,0.0,0.04,nastassia ma savage,
+PSYC,3060,1,Human Sexual Beh,0.55,0.23,0.12,0.05,0.04,0.0,0.0,0.01,bruce michael king,
+PSYC,3090,100,Intro Exp Psych,0.25,0.37,0.17,0.08,0.08,0.0,0.0,0.04,richard tyrrell,
+PSYC,3090,200,Intro Exp Psych,0.48,0.27,0.15,0.03,0.06,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3090,300,Intro Exp Psych,0.55,0.26,0.1,0.03,0.06,0.0,0.0,0.0,stephen robertson,
+PSYC,3100,100,Advanced Experimental Psych,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimental Psych,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,robert campbell,
+PSYC,3100,300,Advanced Experimental Psych,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,cynthia pury,
+PSYC,3100,400,Advanced Experimental Psych,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,3100,500,Advanced Experimental Psych,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3100,600,Advanced Experimental Psych,0.43,0.52,0.0,0.0,0.05,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3240,1,Physiological Psych,0.48,0.23,0.14,0.07,0.07,0.0,0.0,0.0,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.24,0.39,0.25,0.06,0.03,0.0,0.0,0.03,june pilcher,
+PSYC,3330,1,Cognitive Psych,0.45,0.26,0.2,0.03,0.06,0.0,0.0,0.0,robert campbell,
+PSYC,3330,2,Cognitive Psych,0.46,0.38,0.13,0.03,0.0,0.0,0.0,0.01,leah hartman,
+PSYC,3340,1,Cognitive Psych Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,
+PSYC,3340,2,Cognitive Psych Lab,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,tiffany cooper,
+PSYC,3400,1,Lifespan Developmental Psych,0.64,0.24,0.08,0.02,0.02,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3400,2,Lifespan Developmental Psych,0.21,0.34,0.2,0.1,0.03,0.0,0.0,0.11,pamela alley,
+PSYC,3520,1,Social Psychology,0.64,0.26,0.06,0.01,0.01,0.0,0.0,0.01,eric mckibben,
+PSYC,3520,2,Social Psychology,0.36,0.39,0.2,0.03,0.0,0.0,0.0,0.03,eric mckibben,
+PSYC,3640,1,Industrial Psych,0.19,0.41,0.26,0.04,0.03,0.0,0.0,0.06,eric mckibben,
+PSYC,3640,2,Industrial Psych,0.33,0.4,0.24,0.01,0.01,0.0,0.0,0.0,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.16,0.49,0.26,0.04,0.04,0.0,0.0,0.01,gargi sawhney,
+PSYC,3830,1,Abnormal Psychology,0.48,0.34,0.09,0.05,0.04,0.0,0.0,0.0,jo anne jorgensen,
+PSYC,3830,2,Abnormal Psychology,0.48,0.28,0.17,0.06,0.0,0.0,0.0,0.01,jo anne jorgensen,
+PSYC,3830,3,Abnormal Psychology,0.23,0.34,0.26,0.11,0.03,0.0,0.0,0.03,pamela alley,
+PSYC,3830,4,Abnormal Psychology,0.34,0.26,0.11,0.09,0.11,0.0,0.0,0.09,pamela alley,
+PSYC,4080,1,Women and Psychology,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,
+PSYC,4080,2,Women and Psychology,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,robin mari kowalski,
+PSYC,4150,1,Systems and Theories,0.23,0.37,0.2,0.03,0.09,0.0,0.0,0.09,edwin brainerd,
+PSYC,4150,2,Systems and Theories,0.34,0.2,0.26,0.14,0.06,0.0,0.0,0.0,edwin brainerd,
+PSYC,4150,3,Systems and Theories,0.37,0.37,0.16,0.03,0.03,0.0,0.0,0.05,brian day,
+PSYC,4150,3,Systems and Theories,0.37,0.37,0.16,0.03,0.03,0.0,0.0,0.05,brian day,
+PSYC,4220,1,Perception,0.41,0.3,0.11,0.11,0.04,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4220,2,Perception,0.54,0.15,0.23,0.0,0.04,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4220,3,Perception,0.24,0.28,0.24,0.16,0.08,0.0,0.0,0.0,christopher pagano,
+PSYC,4350,1,Human Factors,0.52,0.16,0.32,0.0,0.0,0.0,0.0,0.0,laura whitlock,
+PSYC,4560,1,Psychophysiology,0.36,0.2,0.24,0.08,0.08,0.0,0.0,0.04,drew michael morris,
+PSYC,4560,1,Psychophysiology,0.36,0.2,0.24,0.08,0.08,0.0,0.0,0.04,drew michael morris,
+PSYC,4710,1,Psych of Testing,0.52,0.29,0.1,0.05,0.0,0.0,0.0,0.05,robert ray sinclair,
+PSYC,4800,1,Health Psychology,0.41,0.52,0.04,0.0,0.0,0.0,0.0,0.04,james mccubbin,
+PSYC,4800,2,Health Psychology,0.32,0.52,0.12,0.0,0.0,0.0,0.0,0.04,james mccubbin,
+PSYC,4880,1,Psychotherapy,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,lucinda sorci quick,
+PSYC,4890,1,21st Cen Teamwork,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,marissa leig porter,
+PSYC,4920,4,Senior Laboratory,0.89,0.04,0.0,0.04,0.04,0.0,0.0,0.0,miranda pelkey,
+PSYC,4920,5,Senior Laboratory,0.77,0.09,0.05,0.0,0.0,0.0,0.0,0.09,dana verhoeven,
+PSYC,4980,291,CI Suicide Prevention,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,heidi marie zinzow,
+PSYC,8130,1,Research Design III,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05, dewayne moore,
+PSYC,8140,1,Quantitative Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,
+PSYC,8680,1,Leadership in Orgs,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,patrick raymark,
+PSYC,8710,1,Psych Tests,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,mary taylor,
+PSYC,8710,1,Psych Tests,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,mary taylor,
+RCID,8030,1,Emp Res Methods,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
+RED,8030,1,Pub-Priv Partnership,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
+RED,8040,1,Resid Practicum,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
+RED,8890,2,Selected Topics-Ad. Fin. Mod.,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,larry bradle harvey,
+REL,1010,1,Intro to Religion,0.32,0.53,0.05,0.05,0.05,0.0,0.0,0.0,steven grosby,
+REL,1010,2,Intro to Religion,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,robert stephens,
+REL,1010,3,Intro to Religion,0.66,0.23,0.03,0.0,0.03,0.0,0.0,0.06,robert stephens,
+REL,1010,4,Intro to Religion,0.38,0.47,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,
+REL,1020,1,World Religions,0.2,0.29,0.31,0.09,0.09,0.0,0.0,0.03,peter cohen,
+REL,1020,2,World Religions,0.2,0.29,0.26,0.17,0.09,0.0,0.0,0.0,peter cohen,
+REL,1020,4,World Religions,0.35,0.29,0.18,0.12,0.03,0.0,0.0,0.03,peter cohen,
+REL,1020,7,World Religions,0.34,0.5,0.13,0.0,0.0,0.0,0.0,0.03,brett patterson,
+REL,3000,2,Studying Religion,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth jemison,
+REL,3010,1,Old Testament,0.43,0.51,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3020,1,New Testament Lit,0.42,0.42,0.06,0.03,0.03,0.0,0.0,0.03,benjamin white,
+REL,3030,1,The Quran,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,mashal saif,
+REL,3100,1,History of Religion in the US,0.28,0.44,0.22,0.0,0.0,0.0,0.0,0.06,elizabeth jemison,
+REL,3120,1,Hinduism,0.15,0.62,0.0,0.0,0.0,0.0,0.0,0.23,robert stephens,
+REL,3170,1,Hist of Nat. Am. Relig/Culture,0.33,0.42,0.17,0.08,0.0,0.0,0.0,0.0,james brad jeffries,
+RS,3010,1,Rural Sociology,0.41,0.48,0.03,0.03,0.03,0.0,0.0,0.0,kenneth robinson,
+RUSS,1020,1,Elementary Russian,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,
+RUSS,3610,1,Russn Lit Since 1910,0.56,0.33,0.06,0.0,0.06,0.0,0.0,0.0,olga anatol volkova,
+SAP,8020,1,Study Abroad Hybrid Grad,0.0,0.0,0.0,0.0,0.0,0.75,0.0,0.25,uttiyo raychaudhuri,
+SOC,2010,2,Introduction to Sociology,0.85,0.06,0.04,0.04,0.0,0.0,0.0,0.0,andrew mannheimer,
+SOC,2010,3,Introduction to Sociology,0.79,0.15,0.04,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,
+SOC,2010,4,Introduction to Sociology,0.69,0.16,0.12,0.0,0.02,0.0,0.0,0.0,jennifer le holland,
+SOC,2010,5,Introduction to Sociology,0.27,0.52,0.13,0.0,0.0,0.0,0.0,0.08,carolyn can coffman,
+SOC,2010,6,Introduction to Sociology,0.68,0.25,0.05,0.0,0.0,0.0,0.0,0.01,shannon mcdonough,
+SOC,2010,7,Introduction to Sociology,0.76,0.18,0.02,0.0,0.0,0.0,0.0,0.04,shannon mcdonough,
+SOC,2010,8,Introduction to Sociology,0.64,0.24,0.1,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,9,Introduction to Sociology,0.21,0.64,0.11,0.04,0.0,0.0,0.0,0.0,mary louise barr,
+SOC,2010,10,Introduction to Sociology,0.37,0.41,0.18,0.0,0.0,0.0,0.0,0.04,mary louise barr,
+SOC,2010,11,Introduction to Sociology,0.17,0.5,0.15,0.1,0.04,0.0,0.0,0.04,mary louise barr,
+SOC,2010,12,Introduction to Sociology,0.28,0.43,0.15,0.06,0.02,0.0,0.0,0.06,mary louise barr,
+SOC,2020,1,Social Problems,0.17,0.61,0.12,0.02,0.07,0.0,0.0,0.0,carolyn can coffman,
+SOC,2020,2,Social Problems,0.33,0.46,0.13,0.09,0.0,0.0,0.0,0.0,carolyn can coffman,
+SOC,2050,1,Sociology Lab,0.55,0.23,0.03,0.0,0.16,0.0,0.0,0.03,brenda vander mey,
+SOC,3020,1,Research Methods I,0.3,0.48,0.17,0.04,0.0,0.0,0.0,0.0,andrew whitehead,
+SOC,3040,1,Social Research Methods II,0.14,0.18,0.55,0.14,0.0,0.0,0.0,0.0,ye luo,
+SOC,3100,1,Marriage & Intimacy,0.26,0.39,0.13,0.04,0.11,0.0,0.0,0.07,carolyn can coffman,
+SOC,3600,1,Class & Poverty,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william wentworth,
+SOC,3600,2,Class & Poverty,0.81,0.14,0.0,0.03,0.03,0.0,0.0,0.0,william wentworth,
+SOC,3800,1,Intro Social Service,0.58,0.24,0.16,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,3910,1,Soc of Deviance,0.32,0.36,0.13,0.04,0.06,0.0,0.0,0.09,william white,
+SOC,3940,1,Sociology of Mental Illness,0.6,0.28,0.04,0.02,0.04,0.0,0.0,0.02,marissa el yingling,
+SOC,3970,1,Substance Abuse,0.53,0.35,0.1,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,
+SOC,4030,1,"Technol, Environment & Society",0.14,0.32,0.23,0.14,0.05,0.0,0.0,0.14, catherine mobley,
+SOC,4040,1,Soc Theory,0.51,0.34,0.09,0.03,0.0,0.0,0.0,0.03,william wentworth,
+SOC,4320,1,Soc of Religion,0.19,0.38,0.44,0.0,0.0,0.0,0.0,0.0,andrew whitehead,
+SOC,4330,1,Global Social Change,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,william haller,
+SOC,4600,1,Race & Ethnicity,0.52,0.3,0.11,0.0,0.0,0.0,0.0,0.07,brenda vander mey,
+SOC,4610,1,Sex & Gender,0.36,0.48,0.07,0.05,0.02,0.0,0.0,0.02,traci ann hefner,
+SOC,4800,1,Medical Sociology,0.53,0.24,0.12,0.0,0.06,0.0,0.0,0.06,carolyn can coffman,
+SOC,4840,1,Child Abuse,0.56,0.3,0.07,0.0,0.05,0.0,0.0,0.02,marissa el yingling,
+SOC,4860,2,Creative Inquiry: Sociology,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,margaret tina britz,
+SOC,4860,3,Creative Inquiry in Sociology,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
+SOC,4950,1,Field Experience,0.85,0.0,0.15,0.0,0.0,0.0,0.0,0.0, catherine mobley,
+SOC,4970,1,Senior Lab,0.25,0.25,0.4,0.05,0.05,0.0,0.0,0.0,brenda vander mey,
+SOC,4970,2,Senior Lab,0.28,0.22,0.28,0.06,0.17,0.0,0.0,0.0,brenda vander mey,
+SOC,4990,1,Sel Top Seminar in Contemp Soc,0.63,0.25,0.06,0.0,0.06,0.0,0.0,0.0,andrew mannheimer,
+SPAN,1010,1,Elementary Spanish,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1010,2,Elementary Spanish,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,scott harris,
+SPAN,1020,2,Elementary Spanish,0.44,0.28,0.17,0.06,0.0,0.0,0.0,0.06,al garcia rodriguez,
+SPAN,1020,3,Elementary Spanish,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,al garcia rodriguez,
+SPAN,1020,4,Elementary Spanish,0.58,0.32,0.0,0.05,0.0,0.0,0.0,0.05,al garcia rodriguez,
+SPAN,1020,5,Elementary Spanish,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,al garcia rodriguez,
+SPAN,1020,6,Elementary Spanish,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,1020,7,Elementary Spanish,0.29,0.53,0.12,0.0,0.06,0.0,0.0,0.0,cathy robison,
+SPAN,1020,8,Elementary Spanish,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,debra oa williamson,
+SPAN,1020,9,Elementary Spanish,0.47,0.29,0.24,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,1020,10,Elementary Spanish,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,1020,11,Elementary Spanish,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2010,1,Intermediate Spanish,0.32,0.47,0.11,0.05,0.0,0.0,0.0,0.05,cathy robison,
+SPAN,2010,2,Intermediate Spanish,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,cathy robison,
+SPAN,2010,3,Intermediate Spanish,0.41,0.41,0.0,0.0,0.0,0.0,0.0,0.18,allison ann hinds,
+SPAN,2010,4,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
+SPAN,2010,5,Intermediate Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
+SPAN,2010,6,Intermediate Spanish,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,2010,7,Intermediate Spanish,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,2010,8,Intermediate Spanish,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2010,9,Intermediate Spanish,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2010,10,Intermediate Spanish,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,
+SPAN,2010,11,Intermediate Spanish,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,
+SPAN,2010,13,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
+SPAN,2010,14,Intermediate Spanish,0.43,0.29,0.14,0.0,0.0,0.0,0.0,0.14,melva margu persico,
+SPAN,2010,15,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,
+SPAN,2010,16,Intermediate Spanish,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,2020,1,Intermediate Spanish,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,2020,2,Intermediate Spanish,0.61,0.22,0.0,0.0,0.11,0.0,0.0,0.06,danie garcia vieyra,
+SPAN,2020,3,Intermediate Spanish,0.57,0.29,0.05,0.05,0.0,0.0,0.0,0.05,danie garcia vieyra,
+SPAN,2020,4,Intermediate Spanish,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,5,Intermediate Spanish,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,6,Intermediate Spanish,0.76,0.1,0.05,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,
+SPAN,2020,7,Intermediate Spanish,0.35,0.41,0.12,0.06,0.06,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,8,Intermediate Spanish,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,9,Intermediate Spanish,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,10,Intermediate Spanish,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,11,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,12,Intermediate Spanish,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,13,Intermediate Spanish,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,heidi montes,
+SPAN,2020,14,Intermediate Spanish,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,heidi montes,
+SPAN,2020,15,Intermediate Spanish,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
+SPAN,3020,1,Int Spn Gram & Comp,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,george palacios,
+SPAN,3020,2,Int Spn Gram & Comp,0.3,0.5,0.15,0.0,0.05,0.0,0.0,0.0,melva margu persico,
+SPAN,3020,3,Int Spn Gram & Comp,0.11,0.84,0.0,0.0,0.05,0.0,0.0,0.0,melva margu persico,
+SPAN,3040,1,Intro Hisp Lit Forms,0.78,0.09,0.09,0.0,0.0,0.0,0.0,0.04,george palacios,
+SPAN,3050,1,Int Con Comp Span I,0.28,0.44,0.17,0.0,0.0,0.0,0.0,0.11,melva margu persico,
+SPAN,3050,2,Int Con Comp Span I,0.5,0.35,0.05,0.0,0.05,0.0,0.0,0.05,juana martin-armas,
+SPAN,3050,3,Int Con Comp Span I,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,juana martin-armas,
+SPAN,3060,1,Span Comp for Bus,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,maureen zamora,
+SPAN,3070,1,Hispanic World: Sp,0.26,0.37,0.21,0.0,0.11,0.0,0.0,0.05,juana martin-armas,
+SPAN,3080,1,Hispanic World: La,0.33,0.44,0.22,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,3080,2,Hispanic World: La,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,tiffany dawn miller,
+SPAN,3130,1,Span Lit Survey I,0.4,0.2,0.2,0.0,0.1,0.0,0.0,0.1,mon rojas-de-massei,
+SPAN,3130,35,Span Lit Survey I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+SPAN,3140,1,Hispanic Linguistics,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,daniel smith,
+SPAN,3160,1,Span for Intl Trade,0.76,0.06,0.12,0.0,0.0,0.0,0.0,0.06,maureen zamora,
+SPAN,4010,1,New Spanish Fiction,0.75,0.0,0.13,0.0,0.06,0.0,0.0,0.06,salvador oropesa,
+SPAN,4060,1,Narrative Fiction,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,mon rojas-de-massei,
+SPAN,4070,1,Hispanic Film,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,raquel anido,
+SPAN,4150,1,Span for Health Prof,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,areli moore peralta,
+SPAN,4170,1,Prof Communication,0.53,0.33,0.0,0.0,0.0,0.0,0.0,0.13,maureen zamora,
+SPAN,4180,35,Tech Span Health Man,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+STAT,2220,1,Statistics in Everyday Life,0.3,0.36,0.25,0.08,0.02,0.0,0.0,0.0,james espey,
+STAT,2220,2,Statistics in Everyday Life,0.4,0.34,0.09,0.11,0.04,0.0,0.0,0.02,james espey,
+STAT,2220,3,Statistics in Everyday Life,0.32,0.4,0.11,0.13,0.02,0.0,0.0,0.02,james espey,
+STAT,2220,4,Statistics in Everyday Life,0.3,0.28,0.3,0.07,0.02,0.0,0.0,0.04,james espey,
+STAT,2220,5,Statistics in Everyday Life,0.32,0.36,0.17,0.04,0.11,0.0,0.0,0.0,ros martinez-dawson,
+STAT,2220,6,Statistics in Everyday Life,0.33,0.41,0.22,0.02,0.0,0.0,0.0,0.02,ros martinez-dawson,
+STAT,2220,7,Statistics in Everyday Life,0.33,0.3,0.26,0.09,0.02,0.0,0.0,0.0,andrew walton green,
+STAT,2300,1,Statistical Methods I,0.29,0.35,0.15,0.12,0.04,0.0,0.0,0.05,christy jenki brown,
+STAT,2300,2,Statistical Methods I,0.36,0.25,0.22,0.12,0.05,0.0,0.0,0.01,christy jenki brown,
+STAT,2300,3,Statistical Methods I,0.4,0.32,0.14,0.08,0.02,0.0,0.0,0.04,christy jenki brown,
+STAT,2300,4,Statistical Methods I,0.29,0.29,0.2,0.1,0.1,0.0,0.0,0.03,april thomas,
+STAT,2300,5,Statistical Methods I,0.24,0.42,0.16,0.1,0.05,0.0,0.0,0.04, erwin walker,
+STAT,2300,6,Statistical Methods I,0.21,0.39,0.22,0.1,0.06,0.0,0.0,0.03, erwin walker,
+STAT,2300,7,Statistical Methods I,0.12,0.23,0.27,0.2,0.12,0.0,0.0,0.05,tao yang,
+STAT,3090,1,Introductory Business Stats,0.05,0.33,0.24,0.19,0.17,0.0,0.0,0.02,boyoung hur,
+STAT,3090,2,Introductory Business Stats,0.16,0.3,0.23,0.09,0.12,0.0,0.0,0.09,elaine ma sotherden,
+STAT,3090,3,Introductory Business Stats,0.14,0.51,0.19,0.07,0.07,0.0,0.0,0.02,sharon marie evans,
+STAT,3090,4,Introductory Business Stats,0.19,0.33,0.21,0.17,0.07,0.0,0.0,0.02,sharon marie evans,
+STAT,3090,5,Introductory Business Stats,0.28,0.42,0.16,0.07,0.07,0.0,0.0,0.0,sharon marie evans,
+STAT,3090,6,Introductory Business Stats,0.24,0.39,0.24,0.0,0.07,0.0,0.0,0.05, morales hernandez,
+STAT,3090,7,Introductory Business Stats,0.17,0.39,0.34,0.07,0.02,0.0,0.0,0.0,jason alexande kurz,
+STAT,3090,8,Introductory Business Stats,0.11,0.43,0.31,0.03,0.09,0.0,0.0,0.03,li he,
+STAT,3090,9,Introductory Business Stats,0.15,0.12,0.3,0.15,0.18,0.0,0.0,0.09,mengcong ren,
+STAT,3090,10,Introductory Business Stats,0.31,0.4,0.17,0.09,0.03,0.0,0.0,0.0,dilhani marasinghe,
+STAT,3090,11,Introductory Business Stats,0.11,0.28,0.17,0.15,0.22,0.0,0.0,0.07,sanjog arv kulkarni,
+STAT,3090,12,Introductory Business Stats,0.18,0.44,0.23,0.08,0.05,0.0,0.0,0.03,yijun chen,
+STAT,3090,13,Introductory Business Stats,0.24,0.31,0.26,0.02,0.12,0.0,0.0,0.05,kayla doris javier,
+STAT,3090,14,Introductory Business Stats,0.16,0.36,0.25,0.02,0.18,0.0,0.0,0.02,andrew pangia,
+STAT,3300,1,Statistical Methods II,0.25,0.33,0.29,0.04,0.04,0.0,0.0,0.04,ros martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.5,0.19,0.06,0.06,0.06,0.0,0.0,0.13,ellen hepfe breazel,
+STAT,4110,1,Stat Mthds for Process Control,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,
+STAT,4110,2,Stat Mthds for Process Control,0.5,0.28,0.11,0.0,0.11,0.0,0.0,0.0,james rieck,
+STAT,6020,1,Intro to Statistical Computing,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,ellen hepfe breazel,
+STAT,8010,1,Statistical Methods I,0.5,0.3,0.07,0.0,0.07,0.0,0.0,0.07,brook thaye russell,
+STAT,8010,2,Statistical Methods I,0.38,0.28,0.18,0.0,0.1,0.0,0.0,0.08,james rieck,
+STAT,8010,3,Statistical Methods I,0.64,0.24,0.06,0.0,0.03,0.0,0.0,0.03,jun luo,
+STAT,8040,1,Sampling,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+STAT,8050,1,Design & Anlys of Experiments,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STS,1010,2,Survey of S T S,0.3,0.55,0.09,0.03,0.0,0.0,0.0,0.03,scott brame,
+STS,1010,3,Survey of S T S,0.5,0.39,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,
+STS,1010,4,Survey of S T S,0.67,0.28,0.03,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,
+STS,1010,5,Survey of S T S,0.65,0.32,0.03,0.0,0.0,0.0,0.0,0.0,philip randall,
+STS,1010,6,Survey of S T S,0.36,0.47,0.03,0.0,0.0,0.0,0.0,0.14,sarah mae cooper,
+STS,1010,7,Survey of S T S,0.46,0.23,0.17,0.03,0.06,0.0,0.0,0.06,megan no macalystre,
+STS,1010,8,Survey of S T S,0.28,0.24,0.24,0.07,0.03,0.0,0.0,0.14,david charles foltz,
+THEA,2100,1,Theatre Appreciation,0.58,0.29,0.1,0.0,0.0,0.0,0.0,0.03,kendra lyne johnson,
+THEA,2100,2,Theatre Appreciation,0.72,0.22,0.0,0.03,0.03,0.0,0.0,0.0,kendra lyne johnson,
+THEA,2100,3,Theatre Appreciation,0.81,0.16,0.0,0.03,0.0,0.0,0.0,0.0,kerrie kath seymour,
+THEA,2100,4,Theatre Appreciation,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,carol collins,
+THEA,2100,6,Theatre Appreciation,0.34,0.5,0.09,0.03,0.0,0.0,0.0,0.03,jason adkins,
+THEA,2100,7,Theatre Appreciation,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,richard st. peter,
+THEA,2100,9,Theatre Appreciation,0.91,0.03,0.0,0.0,0.0,0.0,0.0,0.06,richard st. peter,
+THEA,2770,1,Prod Studies in Thea,0.72,0.17,0.03,0.0,0.03,0.0,0.0,0.03,david hartmann,
+THEA,2790,1,Theatre Practicum,0.67,0.25,0.0,0.0,0.08,0.0,0.0,0.0,matthew leckenbusch,
+THEA,3180,1,Afri-Amer Thea II,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,kendra lyne johnson,
+THEA,3740,1,Movement for Actors,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,kerrie kath seymour,
+THEA,4720,1,Improvisation,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,
+WFB,3010,1,Wildlife Biology Lab,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3010,2,Wildlife Biology Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3130,1,Conservation Biology,0.46,0.29,0.14,0.05,0.04,0.0,0.0,0.01,shari lyn rodriguez,
+WFB,3130,2,Conservation Biology,0.35,0.2,0.35,0.02,0.06,0.0,0.0,0.02,shari lyn rodriguez,
+WFB,3500,1,Princ Fish & Wildlife Biology,0.38,0.42,0.13,0.0,0.0,0.0,0.0,0.07,james davis,
+WFB,3500,2,Princ Fish & Wildlife Biology,0.3,0.35,0.22,0.09,0.02,0.0,0.0,0.02,james davis,
+WFB,4160,1,Fishery Biology,0.19,0.5,0.24,0.05,0.02,0.0,0.0,0.0,kasey celen pregler,
+WFB,4620,1,Wetland Wildlife Biology,0.55,0.4,0.03,0.01,0.0,0.0,0.0,0.0,russell barrett,
+WFB,4930,2,Quantitative Ecology,0.46,0.3,0.16,0.0,0.03,0.0,0.0,0.05,david sco jachowski,
+WFB,4930,3,Human Dim of Fisheries & Wildl,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WS,1030,1,Women in Global Perspective,0.68,0.24,0.04,0.0,0.0,0.0,0.0,0.04,laura foxworth,
+WS,1030,2,Women in Global Perspective,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,laura foxworth,
+WS,3010,1,Intro Women's Studies,0.54,0.33,0.04,0.04,0.0,0.0,0.0,0.04,elizabeth ros adams,
+WS,3010,2,Intro Women's Studies,0.46,0.38,0.13,0.0,0.04,0.0,0.0,0.0,elizabeth ros adams,
+WS,3490,1,Gender and Sexuality,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,diane perpich,
+YDP,3100,1,Youth Developmt and the Family,0.83,0.09,0.0,0.04,0.04,0.0,0.0,0.0,william quinn,
+YDP,3100,2,Youth Developmt and the Family,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
+YDP,3150,1,Community & Youth Dev Systems,0.55,0.27,0.09,0.0,0.09,0.0,0.0,0.0,toby kirkland,
+YDP,3250,1,Working with Diverse Youth,0.7,0.1,0.15,0.0,0.0,0.0,0.0,0.05,kimberly pe johnson,
+YDP,8010,1,Child/Adolescent Dev,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,edmond patri bowers,
+YDP,8040,1,Assess & Eval of Youth Program,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,barry garst,
+YDP,8880,1,Special Topics Youth Dev Ldshp,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,barry garst,

--- a/bot/cogs/grades_cog/assets/2017_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2017_Spring.csv
@@ -1,2496 +1,2496 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1020,1,Survey of Art & Arch Hist II,0.41,0.41,0.13,0.02,0.01,0.0,0.0,0.03,andrea feeser,
-AAH,2060,1,Art History and Theory II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
-ACCT,2010,1,Financial Accounting Concepts,0.42,0.2,0.13,0.05,0.12,0.0,0.0,0.08,lydia lan schleifer,
-ACCT,2010,2,Financial Accounting Concepts,0.4,0.25,0.22,0.05,0.07,0.0,0.0,0.02,annieka philo,
-ACCT,2010,3,Financial Accounting Concepts,0.2,0.41,0.2,0.14,0.0,0.0,0.0,0.06,philip maiberger,
-ACCT,2010,4,Financial Accounting Concepts,0.35,0.22,0.27,0.07,0.1,0.0,0.0,0.0,annieka philo,
-ACCT,2010,5,Financial Accounting Concepts,0.38,0.2,0.15,0.07,0.08,0.0,0.0,0.12,lydia lan schleifer,
-ACCT,2010,6,Financial Accounting Concepts,0.45,0.25,0.08,0.05,0.08,0.0,0.0,0.08,lydia lan schleifer,
-ACCT,2010,7,Financial Accounting Concepts,0.27,0.13,0.23,0.07,0.13,0.0,0.0,0.18,mary ann  prater,
-ACCT,2010,8,Financial Accounting Concepts,0.41,0.24,0.21,0.1,0.02,0.0,0.0,0.02,annieka philo,
-ACCT,2010,9,Financial Accounting Concepts,0.11,0.29,0.2,0.09,0.09,0.0,0.0,0.23,mary ann  prater,
-ACCT,2010,10,Financial Accounting Concepts,0.59,0.29,0.05,0.02,0.02,0.0,0.0,0.03,charles tegen,
-ACCT,2010,101,Fin Acct Concepts (HON),0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,mary ann  prater,True
-ACCT,2010,401,Financial Accounting Concepts,0.28,0.45,0.14,0.03,0.06,0.0,0.0,0.03,jeffrey mcmillan,
-ACCT,2010,402,Financial Accounting Concepts,0.21,0.5,0.13,0.05,0.09,0.0,0.0,0.02,jeffrey mcmillan,
-ACCT,2020,1,Managerial Accounting Concepts,0.09,0.37,0.3,0.09,0.04,0.0,0.0,0.11,henry anderson,
-ACCT,2020,2,Managerial Accounting Concepts,0.11,0.33,0.29,0.03,0.07,0.0,0.0,0.17,henry anderson,
-ACCT,2020,3,Managerial Accounting Concepts,0.25,0.23,0.3,0.08,0.03,0.0,0.0,0.13,henry anderson,
-ACCT,2020,4,Managerial Accounting Concepts,0.15,0.32,0.29,0.06,0.1,0.0,0.0,0.08,emily suza mccorkle,
-ACCT,2020,5,Managerial Accounting Concepts,0.46,0.34,0.13,0.04,0.01,0.0,0.0,0.01,emily suza mccorkle,
-ACCT,2020,401,Managerial Accounting Concepts,0.11,0.32,0.16,0.1,0.08,0.0,0.0,0.23,henry anderson,
-ACCT,3030,1,Cost Accounting,0.4,0.29,0.2,0.02,0.04,0.0,0.0,0.04,jace garrett,
-ACCT,3030,2,Cost Accounting,0.2,0.39,0.31,0.04,0.0,0.0,0.0,0.06,jace garrett,
-ACCT,3030,3,Cost Accounting,0.24,0.32,0.24,0.04,0.06,0.0,0.0,0.1,rebecca pennel trax,
-ACCT,3030,4,Cost Accounting,0.18,0.29,0.29,0.04,0.07,0.0,0.0,0.14,rebecca pennel trax,
-ACCT,3110,1,Intermediate Financial Acct I,0.22,0.29,0.24,0.09,0.09,0.0,0.0,0.07,terry daniel knause,
-ACCT,3110,2,Intermediate Financial Acct I,0.3,0.34,0.18,0.08,0.04,0.0,0.0,0.06,terry daniel knause,
-ACCT,3110,3,Intermediate Financial Acct I,0.34,0.42,0.14,0.08,0.0,0.0,0.0,0.02,terry daniel knause,
-ACCT,3110,4,Intermediate Financial Acct I,0.2,0.36,0.24,0.1,0.04,0.0,0.0,0.06,terry daniel knause,
-ACCT,3110,401,Intermediate Financial Acct I,0.16,0.22,0.22,0.09,0.13,0.0,0.0,0.19,henry anderson,
-ACCT,3120,1,Intermediate Financial Acct II,0.09,0.34,0.39,0.09,0.07,0.0,0.0,0.02,the estate  guffey,
-ACCT,3120,2,Intermediate Financial Acct II,0.27,0.24,0.35,0.05,0.03,0.0,0.0,0.05,the estate  guffey,
-ACCT,3120,3,Intermediate Financial Acct II,0.07,0.3,0.34,0.09,0.14,0.0,0.0,0.07,brian todd carver,
-ACCT,3120,4,Intermediate Financial Acct II,0.07,0.27,0.4,0.2,0.0,0.0,0.0,0.07,brian todd carver,
-ACCT,3120,5,Intermediate Financial Acct II,0.23,0.42,0.19,0.07,0.0,0.0,0.0,0.09,jeremy micha vinson,
-ACCT,3130,1,Intermediate Fin Acct III,0.15,0.35,0.45,0.0,0.05,0.0,0.0,0.0, russell madray,
-ACCT,3130,2,Intermediate Fin Acct III,0.35,0.38,0.25,0.02,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3130,3,Intermediate Fin Acct III,0.26,0.54,0.18,0.0,0.03,0.0,0.0,0.0, russell madray,
-ACCT,3130,4,Intermediate Fin Acct III,0.32,0.46,0.22,0.0,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3220,1,Accounting Information Systems,0.27,0.36,0.21,0.03,0.03,0.0,0.0,0.09,philip maiberger,
-ACCT,3220,2,Accounting Information Systems,0.38,0.35,0.09,0.03,0.0,0.0,0.0,0.15,philip maiberger,
-ACCT,3220,3,Accounting Information Systems,0.19,0.34,0.34,0.03,0.0,0.0,0.0,0.09,philip maiberger,
-ACCT,4040,1,Individual Taxation,0.61,0.2,0.18,0.0,0.02,0.0,0.0,0.0,sarah martin,
-ACCT,4040,2,Individual Taxation,0.61,0.18,0.14,0.05,0.02,0.0,0.0,0.0,sarah martin,
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.23,0.67,0.1,0.0,0.0,0.0,0.0,0.0,robin radtke,
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.15,0.49,0.31,0.03,0.03,0.0,0.0,0.0,robin radtke,
-ACCT,4150,1,Auditing,0.24,0.43,0.29,0.01,0.01,0.0,0.0,0.01,carl hollingsworth,
-ACCT,8520,1,Fin Acct Theory/Res,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8520,2,Fin Acct Theory/Res,0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,ralph welton,
-ACCT,8540,1,Prof Responsibility,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8540,2,Prof Responsibility,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8540,3,Prof Responsibility,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8620,1,Financial Auditing,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,
-ACCT,8620,2,Financial Auditing,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,
-ACCT,8710,1,Corporate Taxation,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,2,Corporate Taxation,0.2,0.68,0.13,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,3,Corporate Taxation,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8730,1,Intl/Spec Tax Topic,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,
-ACCT,8740,1,Tax Aspects of Finan Planning,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,
-AGED,1000,1,Orientation & Field Experience,0.67,0.26,0.0,0.04,0.0,0.0,0.0,0.04,philip fravel,
-AGED,2030,1,Teaching Agriscience,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,
-AGED,4150,1,Leadership of Vol,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,kevin layfield,
-AGED,4160,1,Ethics and Issues,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,
-AGM,2050,1,Prin of Fabrication,0.27,0.38,0.25,0.05,0.04,0.0,0.0,0.02,hunter massey,
-AGM,2060,1,Machinery Mgt,0.28,0.43,0.18,0.05,0.05,0.0,0.0,0.03,hunter massey,
-AGM,2200,1,Calc for Mechanized Agricult,0.36,0.51,0.08,0.03,0.0,0.0,0.0,0.02,young han,
-AGM,2210,1,Land Measurements,0.33,0.26,0.3,0.06,0.04,0.0,0.0,0.02,charles privette,
-AGM,4020,1,Irrigation System Design,0.38,0.4,0.2,0.03,0.0,0.0,0.0,0.0,charles privette,
-AGM,4100,1,Precision Ag Tech,0.61,0.2,0.13,0.04,0.02,0.0,0.0,0.0,hunter massey,
-AGM,4520,1,Mobile Power,0.56,0.37,0.07,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4720,1,Capstone,0.5,0.35,0.15,0.0,0.0,0.0,0.0,0.0,john chastain,
-AGM,4730,2,Selected Topics,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,young han,
-AGRB,2020,1,Agricultural Economics,0.16,0.34,0.23,0.1,0.13,0.0,0.0,0.03,george apperson,
-AGRB,2020,2,Agricultural Economics,0.34,0.32,0.32,0.0,0.0,0.0,0.0,0.03,george apperson,
-AGRB,2050,1,Agriculture and Society,0.28,0.33,0.2,0.13,0.06,0.0,0.0,0.0,george apperson,
-AGRB,3190,1,Agribusiness Management,0.4,0.26,0.19,0.14,0.0,0.0,0.0,0.01,michael vassalos,
-AGRB,3570,1,Natural Resources Economics,0.21,0.31,0.29,0.1,0.04,0.0,0.0,0.04,david brian willis,
-AGRB,4020,1,Production Economics,0.59,0.3,0.07,0.0,0.0,0.0,0.0,0.04,michael vassalos,
-AGRB,4080,1,Quant Agribusiness Analysis II,0.24,0.48,0.24,0.03,0.0,0.0,0.0,0.0,lisha zhang,
-AGRB,4520,1,Agricultural Policy,0.17,0.48,0.25,0.06,0.0,0.0,0.0,0.04,michael vassalos,
-AGRB,4560,1,Prices,0.41,0.31,0.28,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,
-AGRB,4570,1,"Natural Res Use, Tech & Policy",0.25,0.42,0.17,0.0,0.0,0.0,0.0,0.17,david brian willis,
-AL,3490,400,Principles of Coaching,0.81,0.08,0.04,0.04,0.0,0.0,0.0,0.04,deborah cadorette,
-AL,3490,401,Principles of Coaching,0.76,0.2,0.0,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
-AL,3490,402,Principles of Coaching,0.71,0.17,0.08,0.0,0.04,0.0,0.0,0.0,julia wright,
-AL,3490,403,Principles of Coaching,0.6,0.2,0.08,0.08,0.04,0.0,0.0,0.0,clyde keith connor,
-AL,3490,404,Principles of Coaching,0.89,0.0,0.0,0.07,0.04,0.0,0.0,0.0,edmond fry,
-AL,3490,405,Principles of Coaching,0.78,0.11,0.07,0.0,0.04,0.0,0.0,0.0,deborah cadorette,
-AL,3500,400,Sci Basis I/Ex Phy,0.19,0.07,0.52,0.19,0.0,0.0,0.0,0.04,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.17,0.3,0.39,0.04,0.0,0.0,0.0,0.09,michael godfrey,
-AL,3530,400,Athletic Injuries,0.26,0.26,0.37,0.07,0.04,0.0,0.0,0.0,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.32,0.4,0.12,0.12,0.0,0.0,0.0,0.04,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.57,0.19,0.14,0.1,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.64,0.24,0.08,0.0,0.04,0.0,0.0,0.0,henry oates,
-AL,3610,401,Admin/Org of Athletic Programs,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,Admin/Org of Athletic Programs,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3620,400,Psychology of Coaching,0.32,0.4,0.16,0.08,0.0,0.0,0.0,0.04,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.46,0.25,0.21,0.0,0.08,0.0,0.0,0.0,natalie anne carter,
-AL,3620,402,Psychology of Coaching,0.48,0.22,0.13,0.13,0.04,0.0,0.0,0.0,natalie anne carter,
-AL,3720,400,Coaching Basketball,0.72,0.12,0.08,0.0,0.08,0.0,0.0,0.0,edmond fry,
-AL,3740,400,Coaching Football,0.76,0.08,0.04,0.0,0.04,0.0,0.0,0.08,edmond fry,
-AL,3750,400,Coaching Soccer,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,deborah cadorette,
-AL,3760,400,Coaching Strength/Conditioning,0.58,0.27,0.08,0.04,0.0,0.0,0.0,0.04,edmond fry,
-AL,4380,400,Coaching Women,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,4380,402,Officiating in Athletic Leader,0.64,0.16,0.16,0.0,0.04,0.0,0.0,0.0,clyde keith connor,
-AL,4380,403,Coaching Inner Athlete,0.74,0.11,0.07,0.0,0.04,0.0,0.0,0.04,deborah cadorette,
-AL,4380,404,CPR/AED for Athletic Coaches,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,julia wright,
-AL,4380,405,CPR/AED for Athletic Coaches,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,
-AL,8530,400,Legal Iss in Intercoll Athlet,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,8530,401,Legal Iss in Intercoll Athlet,0.78,0.0,0.0,0.0,0.22,0.0,0.0,0.0,misty soles,
-AL,8630,400,Socio Dynam in Intercol Athlet,0.69,0.19,0.0,0.0,0.13,0.0,0.0,0.0,michael godfrey,
-AL,8640,400,Ethical Iss in Collegiate Athl,0.64,0.32,0.0,0.0,0.0,0.0,0.0,0.04,michael godfrey,
-AL,8640,401,Ethical Iss in Collegiate Athl,0.6,0.25,0.0,0.0,0.15,0.0,0.0,0.0,michael godfrey,
-AL,8700,400,Intercoll Athletics Finance,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,misty soles,
-ANTH,2010,1,Introduction to Anthropology,0.66,0.21,0.07,0.02,0.02,0.0,0.0,0.01,melissa vogel,
-ANTH,2010,2,Introduction to Anthropology,0.67,0.25,0.06,0.0,0.02,0.0,0.0,0.0,yi wu,
-ANTH,2010,3,Introduction to Anthropology,0.36,0.38,0.1,0.02,0.02,0.0,0.0,0.12,lisa rapaport,
-ANTH,2050,1,Professional Development,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
-ANTH,3200,1,North American Indian Cultures,0.21,0.36,0.14,0.14,0.0,0.0,0.0,0.14,john coggeshall,
-ANTH,3310,1,Archaeology,0.37,0.33,0.26,0.04,0.0,0.0,0.0,0.0,melissa vogel,
-ANTH,3510,1,Biological Anthropology,0.4,0.4,0.1,0.05,0.0,0.0,0.0,0.05,katherine weisensee,
-ANTH,4040,1,Anthropological Theories,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,john coggeshall,
-ANTH,4990,1,Special Topics,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,yi wu,
-ARCH,1510,1,Arch Communication,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,
-ARCH,1510,2,Arch Communication,0.38,0.5,0.06,0.0,0.06,0.0,0.0,0.0,robert silance,
-ARCH,1510,3,Arch Communication,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,clarissa mendez,
-ARCH,1510,4,Arch Communication,0.2,0.6,0.07,0.07,0.0,0.0,0.0,0.07,berrin terim,
-ARCH,1510,5,Arch Communication,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,1510,6,Arch Communication,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,maryam hamidpour,
-ARCH,2520,1,Arch Foundations II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,2520,2,Arch Foundations II,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,james barker,
-ARCH,2520,3,Arch Foundations II,0.33,0.42,0.17,0.08,0.0,0.0,0.0,0.0,david lee,
-ARCH,2520,4,Arch Foundations II,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2520,5,Arch Foundations II,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,
-ARCH,2700,2,Structures I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,
-ARCH,2710,1,Structures II,0.66,0.21,0.07,0.03,0.03,0.0,0.0,0.0,mahmoodreza soltani,
-ARCH,3530,1,Studio Genoa,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,4120,1,History Research,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,4120,2,History Research,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4140,2,Design Seminar,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4160,1,Field Studies,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,4160,2,Field Studies,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4520,1,Synthesis Studio,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,4520,2,Synthesis Studio,0.44,0.22,0.22,0.0,0.0,0.0,0.0,0.11,julie poe wilkerson,
-ARCH,4520,3,Synthesis Studio,0.11,0.56,0.33,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,4520,4,Synthesis Studio,0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4710,1,Arch Hist of Place,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,james thomas,
-ARCH,4890,1,Internship,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,ashley jennings,
-ARCH,6160,2,Field Studies,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,miguel roldan,
-ARCH,6880,1,Arch Programming,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ARCH,8110,1,Visualization II,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,
-ARCH,8320,1,Community 1:1,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,
-ARCH,8420,1,Arch Studio II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,
-ARCH,8420,2,Arch Studio II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
-ARCH,8520,6,Design Studio IV,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,miguel roldan,
-ARCH,8520,8,Design Studio IV,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,8520,9,Design Studio IV,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,8610,1,History/Theory II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8620,1,History/Theory III,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
-ARCH,8650,1,Topics in Health Policy,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,anjali joseph,
-ARCH,8710,1,Structures II,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,dustin gra albright,
-ARCH,8730,2,Environmental Sys,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
-ARCH,8740,1,Building Process:TR,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,8820,1,Building Economics,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,8920,1,Comprehensive Studio,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ARCH,8920,2,Comprehensive Studio,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,8920,3,Comprehensive Studio,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,
-ARCH,8920,4,Comprehensive Studio,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,8960,1,A+H Studio: Tectonic,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ART,1060,1,Foundation Drawing II,0.7,0.17,0.0,0.04,0.09,0.0,0.0,0.0,carly drew,
-ART,1520,1,Foundations Art II,0.76,0.2,0.0,0.04,0.0,0.0,0.0,0.0,joseph ric manson ,
-ART,2050,1,Beginning Life Drawing,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,
-ART,2070,1,Beginning Painting,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,todd mcdonald,
-ART,2100,400,Art Appreciation,0.35,0.48,0.09,0.09,0.0,0.0,0.0,0.0,lydia jane dorsey,
-ART,2100,401,Art Appreciation,0.55,0.24,0.1,0.0,0.0,0.0,0.0,0.1,lydia jane dorsey,
-ART,2100,402,Art Appreciation,0.46,0.29,0.18,0.0,0.04,0.0,0.0,0.04,lydia jane dorsey,
-ART,2100,403,Art Appreciation,0.24,0.59,0.14,0.0,0.0,0.0,0.0,0.03,lydia jane dorsey,
-ART,2130,1,Begin Photography,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amber nic eckersley,
-ART,8060,1,Visual Arts Sem II,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,gregory wi shelnutt,
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,1100,2,Air Force Today II,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,1100,3,Air Force Today II,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,2100,2,Dev of Air Power II,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,christopher mann,
-AS,2100,3,Dev of Air Power II,0.8,0.13,0.0,0.07,0.0,0.0,0.0,0.0,christopher mann,
-ASL,1010,1,Am Sign Lang I,0.26,0.37,0.32,0.05,0.0,0.0,0.0,0.0,william alton brant,
-ASL,1010,2,Am Sign Lang I,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,william alton brant,
-ASL,1010,3,Am Sign Lang I,0.58,0.37,0.0,0.05,0.0,0.0,0.0,0.0,michael alb barrett,
-ASL,1020,1,Am Sign Lang I,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,1020,2,Am Sign Lang I,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,kim ma misener dunn,
-ASL,1020,3,Am Sign Lang I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2010,1,Am Sign Lang II,0.31,0.23,0.38,0.0,0.0,0.0,0.0,0.08,michael alb barrett,
-ASL,2020,1,Am Sign Lang II,0.26,0.16,0.42,0.11,0.05,0.0,0.0,0.0,michael alb barrett,
-ASL,2020,2,Am Sign Lang II,0.64,0.09,0.09,0.09,0.0,0.0,0.0,0.09,michael alb barrett,
-ASL,3020,1,Advanced Asl II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,4600,1,Deaf Literature,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASTR,1010,1,Solar System Astronomy,0.25,0.35,0.16,0.1,0.07,0.0,0.0,0.08,lih-sin the,
-ASTR,1020,1,Stellar Astronomy,0.27,0.26,0.11,0.05,0.16,0.0,0.0,0.15,amber porter,
-ASTR,1020,2,Stellar Astronomy,0.24,0.38,0.17,0.09,0.04,0.0,0.0,0.07,amber porter,
-ASTR,1030,1,Solar Systm Astr Lab,0.35,0.35,0.08,0.04,0.19,0.0,0.0,0.0,amber porter,
-ASTR,1030,2,Solar Systm Astr Lab,0.38,0.35,0.12,0.04,0.0,0.0,0.0,0.12,amber porter,
-ASTR,1030,3,Solar Systm Astr Lab,0.38,0.29,0.24,0.05,0.0,0.0,0.0,0.05,amber porter,
-ASTR,1040,1,Stellar Astr Lab,0.64,0.18,0.14,0.0,0.0,0.0,0.0,0.05,amber porter,
-ASTR,1040,2,Stellar Astr Lab,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,amber porter,
-ASTR,1040,3,Stellar Astr Lab,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,amber porter,
-ASTR,1040,5,Stellar Astr Lab,0.55,0.2,0.05,0.0,0.05,0.0,0.0,0.15,amber porter,
-AUD,2850,1,Acoustics of Music,0.2,0.5,0.2,0.1,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUE,8160,1,Eng Combustion Emiss,0.75,0.23,0.03,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8170,3,Alt Energy Sources,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,simona onori,
-AUE,8500,6,Stability/Safety Sys,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8550,16,Auto Struct Analysis,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.49,0.46,0.05,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8770,9,Light-Weight Design,0.52,0.39,0.06,0.0,0.03,0.0,0.0,0.0,fadi kama abu-farha,
-AUE,8860,1,Noise Vibration,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,douglas feldmaier,
-AUE,8900,102,Automotive Engineering Project,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8930,3,Applied Dynamics,0.37,0.47,0.11,0.0,0.05,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8930,4,Mechanics of Composites Struct,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
-AUE,8930,401,Autonomous Driving Techn,0.67,0.31,0.03,0.0,0.0,0.0,0.0,0.0,yunyi jia,
-AUE,8930,402,Sustainability & LCE,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,
-AVS,2000,1,Beef Cattle Tech,0.62,0.27,0.08,0.0,0.04,0.0,0.0,0.0,nathan long,
-AVS,2020,1,CAFLS Plus,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,thomas scott,
-AVS,2060,1,Swine Techniques,0.8,0.13,0.0,0.0,0.03,0.0,0.0,0.05,richelle lor miller,
-AVS,3010,1,Anat & Phys Dom Ani,0.44,0.32,0.13,0.05,0.03,0.0,0.0,0.03,tiffany wilmoth,
-AVS,3100,1,Animal Health,0.54,0.2,0.1,0.03,0.06,0.0,0.0,0.07,thomas scott,
-AVS,3150,1,Animal Welfare,0.46,0.21,0.33,0.0,0.0,0.0,0.0,0.0,peter skewes,
-AVS,3700,1,Principles of Animal Nutrition,0.49,0.24,0.16,0.08,0.02,0.0,0.0,0.0,james ro strickland,
-AVS,3750,1,Applied Animal Nutrition,0.29,0.33,0.19,0.15,0.0,0.0,0.0,0.04,gustavo jos lascano,
-AVS,4000,1,AVS Professional Development,0.73,0.2,0.08,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
-AVS,4000,2,AVS Professional Development,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,
-AVS,4010,1,Beef Production,0.1,0.6,0.2,0.1,0.0,0.0,0.0,0.0,nathan long,
-AVS,4060,1,Seminars & Related Topics,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4060,2,Seminars & Related Topics,0.33,0.47,0.13,0.07,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4100,1,Domestic Ani Behav,0.31,0.46,0.17,0.03,0.01,0.0,0.0,0.02,peter skewes,
-AVS,4120,1,Advanced Equine Management,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,4130,1,Animal Products,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,4140,1,Basic Immunology,0.74,0.11,0.11,0.0,0.04,0.0,0.0,0.0,thomas scott,
-AVS,4220,6,Special Problems,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,susan kay duckett,
-AVS,4530,1,Animal Reproduction,0.46,0.24,0.27,0.0,0.02,0.0,0.0,0.0,glenn birrenkott,
-AVS,4530,400,Animal Reproduction,0.57,0.21,0.14,0.07,0.0,0.0,0.0,0.0,glenn birrenkott,
-BCHM,3010,1,Molecular Biochem,0.1,0.37,0.23,0.12,0.07,0.0,0.0,0.1,meredith tei morris,
-BCHM,3010,2,Molecular Biochem(HON),0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,cheryl ingram-smith,True
-BCHM,3050,1,Essen Elements Bioch,0.29,0.38,0.2,0.07,0.01,0.0,0.0,0.03,srik chandrasekaran,
-BCHM,3050,2,Essen Elements Bioch,0.4,0.32,0.2,0.06,0.0,0.0,0.0,0.02,srik chandrasekaran,
-BCHM,4320,1,Bioch of Metabolism,0.78,0.13,0.08,0.02,0.0,0.0,0.0,0.0,kimberly paul,
-BCHM,4340,3,Biochemistry of Metabolism Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kimberly paul,
-BCHM,4340,4,Biochemistry of Metabolism Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,kimberly paul,
-BCHM,4360,1,Genes to Proteins,0.8,0.17,0.02,0.0,0.02,0.0,0.0,0.0,michael glen sehorn,
-BCHM,4400,1,Bioinformatics,0.45,0.35,0.15,0.0,0.05,0.0,0.0,0.0,liangjiang wang,
-BCHM,4900,21,EPIC Ambassadors,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,meredith tei morris,
-BCHM,8050,1,Issues in Research,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,
-BE,2100,1,Intro to Biosystems Engr,0.71,0.14,0.0,0.07,0.07,0.0,0.0,0.0,yi zheng,
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.63,0.21,0.13,0.0,0.0,0.0,0.0,0.04,tom owino,
-BE,4120,1,Be Heat Mass Trans,0.38,0.38,0.08,0.13,0.0,0.0,0.0,0.04,caye marie drapcho,
-BE,4150,1,Instr & Control for Biosys Eng,0.67,0.1,0.1,0.1,0.0,0.0,0.0,0.05,yi zheng,
-BE,4240,2,Ecological Engineering,0.71,0.21,0.05,0.0,0.0,0.0,0.0,0.02,christophe darnault,
-BE,4380,1,Bioprocess Engineering Design,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,terry walker,
-BE,4730,3,Thermodynamics,0.26,0.53,0.11,0.0,0.11,0.0,0.0,0.0,terry walker,
-BIOE,1010,1,Biol for Bioengr,0.58,0.34,0.04,0.0,0.0,0.0,0.0,0.05,vladimir vla reukov,
-BIOE,2000,1,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,martine laberge,
-BIOE,2010,1,Intro Biomed Engr,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,charles webb,
-BIOE,3020,1,Biomaterials,0.67,0.29,0.03,0.0,0.0,0.0,0.0,0.01,alexey ale vertegel,
-BIOE,3200,1,Biomechanics,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,
-BIOE,3210,1,Biofluid Mechanics,0.6,0.19,0.15,0.04,0.0,0.0,0.0,0.02,sarah harcum,
-BIOE,3700,1,Bioinst & Imaging,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,delphine dean,
-BIOE,4030,1,Applied Bio E Design,0.75,0.24,0.01,0.0,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4200,1,Sports Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
-BIOE,4230,1,Cardiovascular Engr and Path,0.54,0.44,0.02,0.0,0.0,0.0,0.0,0.0,dan simionescu,
-BIOE,4490,1,Drug Delivery,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,frank alexis,
-BIOE,6230,1,Cardiovascular Engr and Path,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.03,dan simionescu,
-BIOE,6350,1,Modeling of Multiphysics Prob,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,guigen zhang,
-BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,martine laberge,
-BIOE,8410,1,Drug Delivery,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,
-BIOE,8500,3,Reg & Clin Affairs-Med Devices,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,jeremy mercuri,
-BIOE,8610,1,Biomed Eng Product Translation,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,
-BIOL,1040,1,General Biology II,0.13,0.27,0.28,0.16,0.1,0.0,0.0,0.06,nora espinoza,
-BIOL,1040,2,General Biology II,0.45,0.32,0.16,0.04,0.02,0.0,0.0,0.01,william surver,
-BIOL,1040,3,General Biology II,0.13,0.22,0.38,0.13,0.09,0.0,0.0,0.05,salvatore sparace,
-BIOL,1040,4,General Biology II (HON),0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
-BIOL,1060,1,Gen Biology Lab II,0.22,0.52,0.17,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,2,Gen Biology Lab II,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,3,Gen Biology Lab II,0.13,0.58,0.08,0.04,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1060,4,Gen Biology Lab II,0.08,0.58,0.29,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,5,Gen Biology Lab II,0.14,0.23,0.41,0.14,0.09,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,7,Gen Biology Lab II,0.14,0.5,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,8,Gen Biology Lab II,0.23,0.45,0.18,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,9,Gen Biology Lab II,0.27,0.27,0.32,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,10,Gen Biology Lab II,0.18,0.32,0.36,0.05,0.09,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,11,Gen Biology Lab II,0.08,0.58,0.29,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,12,Gen Biology Lab II,0.17,0.57,0.26,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,13,Gen Biology Lab II,0.17,0.54,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,14,Gen Biology Lab II,0.14,0.57,0.24,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,15,Gen Biology Lab II,0.1,0.71,0.14,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,16,Gen Biology Lab II,0.04,0.71,0.17,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,17,Gen Biology Lab II,0.13,0.42,0.25,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1060,18,Gen Biology Lab II,0.05,0.55,0.35,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,19,Gen Biology Lab II,0.0,0.4,0.45,0.05,0.0,0.0,0.0,0.1,tafadzwa kaisa,
-BIOL,1060,20,Gen Biology Lab II,0.29,0.43,0.19,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,21,Gen Biology Lab II,0.18,0.5,0.23,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,22,Gen Biology Lab II,0.19,0.48,0.19,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,24,Gen Biology Lab II,0.05,0.6,0.3,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,25,Gen Biology Lab II,0.08,0.58,0.25,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,26,Gen Biology Lab II,0.53,0.21,0.21,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,27,Gen Biology Lab II,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,28,Gen Biology Lab II,0.32,0.5,0.05,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,29,Gen Biology Lab II,0.09,0.45,0.36,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,30,Gen Biology Lab II,0.15,0.55,0.2,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,31,Gen Biology Lab II,0.08,0.46,0.33,0.04,0.08,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,32,Gen Biology Lab II,0.23,0.45,0.27,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,35,Gen Biology Lab II,0.05,0.48,0.33,0.05,0.1,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,36,Gen Biology Lab II,0.0,0.19,0.63,0.06,0.0,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1110,1,Principles of Biology II,0.24,0.48,0.19,0.03,0.05,0.0,0.0,0.01,dylan dittrich-reed,
-BIOL,1110,3,Principles of Biology II,0.4,0.37,0.14,0.03,0.03,0.0,0.0,0.02,robert kosinski,
-BIOL,1110,4,Prin of Biol II  (HON),0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,robert kosinski,True
-BIOL,1200,1,Biological Inq Lab,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,2,Biological Inq Lab,0.39,0.28,0.33,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,3,Biological Inq Lab,0.6,0.27,0.07,0.0,0.0,0.0,0.0,0.07, christine minor,
-BIOL,1200,4,Biological Inq Lab,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,5,Biological Inq Lab,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1200,6,Biological Inq Lab,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,1230,1,Keys to Human Biol,0.3,0.34,0.19,0.12,0.03,0.0,0.0,0.02, christine minor,
-BIOL,2000,1,Biology in the News,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,2000,4,Biology in the News,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,vincent pa richards,
-BIOL,2030,1,Human Disease & Soc,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0, christine minor,
-BIOL,2040,1,"Environ, Energy and Society",0.34,0.4,0.09,0.08,0.0,0.0,0.0,0.09,john jenkins hains,
-BIOL,2040,2,"Environ, Energy and Society",0.18,0.56,0.16,0.09,0.0,0.0,0.0,0.02,john jenkins hains,
-BIOL,2230,1,Human Anat and Physiology II,0.41,0.34,0.11,0.09,0.02,0.0,0.0,0.02,john cummings,
-BIOL,2230,2,Human Anat and Physiology II,0.5,0.29,0.14,0.05,0.01,0.0,0.0,0.01,john cummings,
-BIOL,3020,1,Invertebrate Biology,0.13,0.28,0.39,0.11,0.09,0.0,0.0,0.0,juan baeza migueles,
-BIOL,3040,1,Biology of Plants,0.15,0.3,0.26,0.23,0.04,0.0,0.0,0.01,robert edwa ballard,
-BIOL,3060,2,Invertebrate Biology Lab,0.29,0.33,0.25,0.0,0.08,0.0,0.0,0.04,juan baeza migueles,
-BIOL,3060,4,Invertebrate Biology Lab,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,juan baeza migueles,
-BIOL,3080,1,Biology of Plants Practicum,0.22,0.33,0.28,0.11,0.0,0.0,0.0,0.06,nathan redding,
-BIOL,3080,2,Biology of Plants Practicum,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,3,Biology of Plants Practicum,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,4,Biology of Plants Practicum,0.76,0.12,0.0,0.0,0.12,0.0,0.0,0.0,nathan redding,
-BIOL,3160,1,Human Physiology,0.35,0.51,0.11,0.02,0.01,0.0,0.0,0.01,tamara mcnutt-scott,
-BIOL,3350,1,Evolutionary Biology,0.45,0.33,0.14,0.07,0.0,0.0,0.0,0.01,michael sears,
-BIOL,3510,1,Biological Anthropology,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,katherine weisensee,
-BIOL,4010,1,Plant Physiology,0.22,0.24,0.33,0.15,0.02,0.0,0.0,0.05,douglas bielenberg,
-BIOL,4020,1,Plant Physiology Lab,0.55,0.35,0.05,0.05,0.0,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4020,2,Plant Physiology Lab,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4080,1,Comparative Vertebrate Morph,0.29,0.5,0.13,0.04,0.0,0.0,0.0,0.04,christopher mayerl,
-BIOL,4090,1,Comp Vertebrate Morph Lab,0.5,0.21,0.21,0.04,0.0,0.0,0.0,0.04,richard blob,
-BIOL,4100,1,Limnology,0.24,0.52,0.14,0.02,0.0,0.0,0.0,0.07,john jenkins hains,
-BIOL,4140,1,Basic Immunology,0.83,0.1,0.0,0.0,0.0,0.0,0.0,0.07,charles rice,
-BIOL,4340,1,Biological Chem Lab Techniques,0.06,0.13,0.31,0.44,0.06,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,2,Biological Chem Lab Techniques,0.14,0.29,0.36,0.21,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4340,3,Biological Chem Lab Techniques,0.19,0.56,0.06,0.13,0.0,0.0,0.0,0.06,salvatore sparace,
-BIOL,4340,4,Biological Chem Lab Techniques,0.13,0.33,0.27,0.27,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4610,1,Cell Biology,0.35,0.26,0.26,0.09,0.0,0.0,0.0,0.03,zhicheng dou,
-BIOL,4610,2,Cell Biology (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,zhicheng dou,True
-BIOL,4610,3,Cell Biology,0.29,0.33,0.26,0.07,0.04,0.0,0.0,0.01,lisa bain,
-BIOL,4610,4,Cell Biology (HON),0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,lisa bain,True
-BIOL,4620,1,Cell Biology Lab (Lec),0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,2,Cell Biology Lab (Lec),0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
-BIOL,4620,4,Cell Biology Lab (Lec),0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.87,0.04,0.09,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,8,Cell Biology Lab (Lec),0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4670,1,Principles of Hematology,0.73,0.18,0.05,0.02,0.0,0.0,0.0,0.02,vincent gallicchio,
-BIOL,4700,1,Behavioral Ecology,0.34,0.46,0.16,0.02,0.0,0.0,0.0,0.01,michael childress,
-BIOL,4700,2,Behavioral Ecology (HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,True
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,michael childress,
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,
-BIOL,4710,4,Behavioral Ecology Lab (Lec),0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,michael childress,
-BIOL,4780,1,Exercise Physiology,0.4,0.4,0.17,0.0,0.0,0.0,0.0,0.02,john cummings,
-BIOL,4800,1,Vertebrate Endocrinology,0.31,0.25,0.19,0.13,0.0,0.0,0.0,0.13,william baldwin,
-BIOL,4930,2,Sr Sem: Adv Cancer Research,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
-BIOL,4930,5,Sr Sem: Nervous Systems,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,david feliciano,
-BIOL,4930,7,Sr Sem: Conservation Biology,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david tonkyn,
-BIOL,4940,4,CI: Popular Science Journalism,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
-BIOL,8430,1,Underst Genetics & Evol Biol,0.64,0.33,0.02,0.0,0.02,0.0,0.0,0.0,margaret ptacek,
-BIOL,8450,1,Understanding Animal Biology,0.93,0.03,0.01,0.0,0.02,0.0,0.0,0.0,matthew turnbull,
-BIOL,8470,1,Understanding Microbiology,0.58,0.34,0.04,0.0,0.02,0.0,0.0,0.02,harry kurtz,
-BIOL,8480,1,Understanding Scientific Rsrch,0.93,0.0,0.0,0.0,0.02,0.0,0.0,0.05,robert edwa ballard,
-BIOL,8710,1,Current Topics in Biology,0.67,0.0,0.0,0.0,0.17,0.0,0.0,0.17,robert edwa ballard,
-BMOL,4250,1,Biomolecular Engineering,0.26,0.3,0.22,0.09,0.07,0.0,0.0,0.07,mark alan blenner,
-BUS,1010,1,Business Foundations,0.33,0.52,0.11,0.0,0.04,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,2,Business Foundations,0.39,0.39,0.14,0.0,0.04,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,3,Business Foundations,0.35,0.58,0.08,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,4,Business Foundations,0.19,0.38,0.35,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
-BUS,1010,5,Business Foundations,0.26,0.37,0.3,0.04,0.04,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,6,Business Foundations,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,7,Business Foundations,0.19,0.63,0.19,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,8,Business Foundations,0.35,0.26,0.3,0.0,0.04,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,9,Business Foundations,0.25,0.44,0.19,0.0,0.13,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,10,Business Foundations,0.16,0.48,0.2,0.08,0.08,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,16,Business Foundations,0.14,0.41,0.1,0.17,0.0,0.0,0.0,0.17,james mullinax,
-BUS,1010,17,Business Foundations,0.24,0.34,0.34,0.07,0.0,0.0,0.0,0.0,james mullinax,
-BUS,2990,3,CI:  Being a Leader,0.75,0.19,0.0,0.06,0.0,0.0,0.0,0.0,christopher mann,
-CE,2010,1,Statics,0.59,0.24,0.09,0.02,0.03,0.0,0.0,0.03,sara khoshnevisan,
-CE,2010,2,Statics,0.12,0.31,0.4,0.0,0.1,0.0,0.0,0.07,melissa sternhagen,
-CE,2010,3,Statics,0.63,0.23,0.08,0.03,0.0,0.0,0.0,0.03,brandon ross,
-CE,2010,4,Statics,0.12,0.24,0.12,0.2,0.28,0.0,0.0,0.04,melissa sternhagen,
-CE,2010,5,Statics,0.36,0.36,0.18,0.06,0.03,0.0,0.0,0.0,william albe ashman,
-CE,2010,6,Statics,0.5,0.22,0.22,0.04,0.02,0.0,0.0,0.0, kent nilsson,
-CE,2010,7,Statics (HON),0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,brandon ross,True
-CE,2060,1,Structural Mechanics,0.31,0.51,0.18,0.0,0.0,0.0,0.0,0.0,bryant nielson,
-CE,2060,2,Structural Mechanics,0.54,0.38,0.06,0.0,0.02,0.0,0.0,0.0,mahmoodreza soltani,
-CE,2080,1,Dynamics,0.17,0.3,0.42,0.07,0.02,0.0,0.0,0.03,melissa sternhagen,
-CE,2080,2,Dynamics,0.18,0.37,0.26,0.08,0.08,0.0,0.0,0.03,melissa sternhagen,
-CE,2550,1,Geomatics,0.29,0.44,0.2,0.03,0.03,0.0,0.0,0.0, shams esfandabadi,
-CE,3010,1,Structural Analysis,0.34,0.26,0.2,0.09,0.06,0.0,0.0,0.06,stephen csernak,
-CE,3110,1,Transportation Engr,0.3,0.43,0.21,0.05,0.0,0.0,0.0,0.02,wayne sarasua,
-CE,3210,1,Geotechnical Engineering,0.58,0.3,0.09,0.0,0.0,0.0,0.0,0.02,charng-hsein juang,
-CE,3210,2,Geotechnical Engineering,0.57,0.37,0.07,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
-CE,3310,1,Constr Engr & Mgmnt,0.36,0.43,0.18,0.0,0.0,0.0,0.0,0.02,james burati,
-CE,3410,1,Intro to Fluid Mech,0.26,0.44,0.21,0.06,0.0,0.0,0.0,0.03,md nasimu chowdhury,
-CE,3420,1,Hydraulics & Hydro,0.37,0.27,0.2,0.03,0.0,0.0,0.0,0.13,abdul khan,
-CE,3420,2,Hydraulics & Hydro,0.6,0.38,0.03,0.0,0.0,0.0,0.0,0.0,ashok mishra,
-CE,3510,1,Civil Engineering Materials,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
-CE,3520,2,Econ Eval of Proj,0.51,0.39,0.08,0.0,0.0,0.0,0.0,0.02,bradley putman,
-CE,3530,1,Professional Seminar,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,4020,1,Reinfor Con Design,0.44,0.31,0.22,0.01,0.0,0.0,0.0,0.01,brandon ross,
-CE,4070,1,Wood Design,0.52,0.33,0.1,0.0,0.0,0.0,0.0,0.05,weichiang pang,
-CE,4080,1,Struct Loads & Sys,0.08,0.38,0.25,0.17,0.0,0.0,0.0,0.13,bryant nielson,
-CE,4110,1,Roadway Geo Design,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
-CE,4120,1,Urban Transport Plan,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
-CE,4210,1,Geotechnical Design,0.37,0.26,0.29,0.05,0.03,0.0,0.0,0.0,nadara ravichandran,
-CE,4340,1,Const Est Proj Cont,0.57,0.37,0.04,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,4350,1,Infra Proj Planning,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-CE,4470,1,Stormwater Managemnt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john philli raiford,
-CE,4590,1,Capstone Design Proj,0.46,0.49,0.05,0.0,0.0,0.0,0.0,0.0,stephen csernak,
-CE,6070,1,Wood Design,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CE,6080,1,Struct Loads & Sys,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,bryant nielson,
-CE,6210,1,Geotechnical Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,
-CE,6350,1,Infra Proj Planning,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-CE,6470,1,Stormwater Managemnt,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john philli raiford,
-CE,8020,1,Adv R/C Design,0.48,0.32,0.12,0.0,0.0,0.0,0.0,0.08,thomas edfo cousins,
-CE,8060,1,Dyn Analys of Struc,0.42,0.38,0.12,0.0,0.0,0.0,0.0,0.08,bryant nielson,
-CE,8250,1,Geotech Equake Engr,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,
-CE,8260,1,Prop of Concrete,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
-CE,8460,1,Flow in Open Chnls,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,abdul khan,
-CE,8530,1,Apps in Traffic En,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CE,8580,501,Fund of Risk Engineering Mgt,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,jie zhang,
-CH,1010,1,General Chemistry,0.06,0.2,0.32,0.11,0.2,0.0,0.0,0.12,princess mycia cox,
-CH,1010,2,General Chemistry,0.02,0.26,0.27,0.16,0.22,0.0,0.0,0.07,princess mycia cox,
-CH,1010,3,General Chemistry,0.28,0.24,0.28,0.07,0.07,0.0,0.0,0.06,dennis taylor,
-CH,1010,4,General Chemistry,0.05,0.24,0.28,0.13,0.17,0.0,0.0,0.14,joseph stu thrasher,
-CH,1010,400,General Chemistry,0.19,0.23,0.25,0.15,0.07,0.0,0.0,0.12,stephe schvaneveldt,
-CH,1020,1,General Chemistry,0.07,0.43,0.28,0.08,0.0,0.0,0.0,0.13,william mcwhorter,
-CH,1020,2,General Chemistry,0.31,0.44,0.19,0.03,0.02,0.0,0.0,0.01,thomas hickman,
-CH,1020,3,General Chemistry,0.39,0.37,0.12,0.08,0.01,0.0,0.0,0.03,dennis taylor,
-CH,1020,4,General Chemistry,0.35,0.4,0.14,0.04,0.0,0.0,0.0,0.06,dennis taylor,
-CH,1020,5,General Chemistry,0.1,0.34,0.33,0.17,0.01,0.0,0.0,0.04,william mcwhorter,
-CH,1020,6,General Chemistry,0.09,0.35,0.37,0.07,0.02,0.0,0.0,0.09,william mcwhorter,
-CH,1020,7,General Chemistry,0.12,0.37,0.35,0.04,0.02,0.0,0.0,0.1,olt geiculescu,
-CH,1020,8,General Chemistry,0.26,0.41,0.25,0.04,0.04,0.0,0.0,0.02,thomas hickman,
-CH,1020,9,General Chemistry,0.25,0.47,0.2,0.05,0.01,0.0,0.0,0.02,elliot ennis,
-CH,1020,10,General Chemistry,0.27,0.41,0.21,0.04,0.03,0.0,0.0,0.03,laura lanni,
-CH,1020,11,General Chemistry,0.23,0.39,0.31,0.04,0.02,0.0,0.0,0.01,laura lanni,
-CH,1020,50,General Chemistry,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,shiou-jyh hwu,
-CH,1020,51,General Chemistry (HON),0.88,0.09,0.02,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
-CH,1020,52,General Chemistry (HON),0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
-CH,1020,500,General Chemistry,0.29,0.32,0.29,0.1,0.0,0.0,0.0,0.0,brian gloor,
-CH,1050,1,Chemistry in Context I,0.32,0.47,0.06,0.06,0.02,0.0,0.0,0.06,olt geiculescu,
-CH,1050,2,Chemistry in Context I,0.32,0.48,0.11,0.0,0.02,0.0,0.0,0.07,olt geiculescu,
-CH,1060,1,Chemistry in Context II,0.47,0.38,0.15,0.0,0.0,0.0,0.0,0.0,thomas hickman,
-CH,1520,1,Chemistry Communication,0.84,0.0,0.11,0.0,0.05,0.0,0.0,0.0,richard marcus,
-CH,2010,1,Survey of Organic Chemistry,0.44,0.37,0.07,0.08,0.04,0.0,0.0,0.01,tania issa houjeiry,
-CH,2020,1,Surv of Organic Chemistry Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2020,2,Surv of Organic Chemistry Lab,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2050,1,Intro Inorg Chem,0.43,0.43,0.11,0.0,0.03,0.0,0.0,0.0,william pennington,
-CH,2230,1,Organic Chemistry,0.19,0.3,0.25,0.15,0.09,0.0,0.0,0.02,jacob schroeder,
-CH,2230,2,Organic Chemistry,0.34,0.3,0.21,0.08,0.04,0.0,0.0,0.02,jacob schroeder,
-CH,2230,3,Organic Chemistry,0.29,0.18,0.24,0.1,0.09,0.0,0.0,0.1,sourav saha,
-CH,2240,1,Organic Chemistry,0.33,0.33,0.19,0.07,0.02,0.0,0.0,0.06,elliot ennis,
-CH,2240,2,Organic Chemistry,0.21,0.29,0.21,0.07,0.03,0.0,0.0,0.18,laura lanni,
-CH,2240,3,Organic Chemistry,0.3,0.38,0.17,0.1,0.0,0.0,0.0,0.05,elliot ennis,
-CH,2240,4,Organic Chemistry,0.29,0.31,0.2,0.07,0.04,0.0,0.0,0.09,rhett smith,
-CH,2240,5,Organic Chemistry,0.35,0.43,0.18,0.01,0.01,0.0,0.0,0.02,jacob schroeder,
-CH,2270,3,Organic Chem Lab,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,6,Organic Chem Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,7,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,8,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,9,Organic Chem Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,10,Organic Chem Lab,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2270,11,Organic Chem Lab,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2270,12,Organic Chem Lab,0.81,0.06,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,
-CH,2270,13,Organic Chem Lab,0.59,0.12,0.18,0.0,0.0,0.0,0.0,0.12,sean 'connor,
-CH,2270,14,Organic Chem Lab,0.79,0.0,0.07,0.0,0.0,0.0,0.0,0.14,sean 'connor,
-CH,2270,15,Organic Chem Lab,0.67,0.2,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,1,Organic Chem Lab,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,
-CH,2280,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,6,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,10,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,
-CH,2280,12,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,
-CH,2280,19,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,2280,21,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,
-CH,3310,1,Physical Chemistry,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,arkady kholodenko,
-CH,3320,1,Physical Chemistry,0.29,0.46,0.15,0.06,0.02,0.0,0.0,0.02,steven stuart,
-CH,3320,2,Physical Chemistry,0.68,0.2,0.04,0.04,0.0,0.0,0.0,0.04,jason mcneill,
-CH,3320,3,Physical Chemistry,0.29,0.33,0.24,0.0,0.14,0.0,0.0,0.0,leah bec casabianca,
-CH,3400,2,Physical Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3400,3,Physical Chem Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3400,5,Physical Chem Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3600,1,Chemical Biology,0.58,0.28,0.11,0.0,0.02,0.0,0.0,0.0,modi wetzler,
-CH,4040,1,Bioinorganic Chem,0.38,0.25,0.19,0.06,0.0,0.0,0.0,0.13,julia brumaghim,
-CH,4110,1,Instrumental Analy,0.33,0.33,0.0,0.25,0.08,0.0,0.0,0.0,george chumanov,
-CH,4120,1,Instr Analysis Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey natha anker,
-CH,4130,1,Chemistry of Aqueous Systems,0.51,0.31,0.11,0.0,0.0,0.0,0.0,0.06,cindy lee,
-CH,4250,1,Medicinal Chem,0.38,0.23,0.08,0.0,0.08,0.0,0.0,0.23,dev priya arya,
-CH,4500,1,Chemistry Capstone,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
-CH,8130,1,Electrochem Sci,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,stephen creager,
-CH,8510,1,Grad Student Seminar,0.77,0.2,0.0,0.0,0.03,0.0,0.0,0.0,joseph stu thrasher,
-CHE,1300,1,Intro to Chemical Engineering,0.15,0.28,0.26,0.13,0.11,0.0,0.0,0.07,christopher norfolk,
-CHE,1300,2,Intro to Chemical Engineering,0.14,0.24,0.24,0.1,0.1,0.0,0.0,0.2,christopher norfolk,
-CHE,2200,1,Ch E Thermo I,0.21,0.38,0.25,0.09,0.06,0.0,0.0,0.01,joseph scott,
-CHE,2300,1,Fluids/Heat Transfer,0.08,0.18,0.5,0.08,0.13,0.0,0.0,0.03,eric mikel davis,
-CHE,2300,2,Fluids/Heat Transfer,0.12,0.34,0.29,0.12,0.1,0.0,0.0,0.03,eric mikel davis,
-CHE,3070,1,Unit Ops Lab I,0.24,0.53,0.19,0.0,0.0,0.0,0.0,0.03,mark thies,
-CHE,3190,1,Engr Materials,0.17,0.35,0.33,0.08,0.0,0.0,0.0,0.07,christopher norfolk,
-CHE,3530,2,Proc Dyn & Control,0.31,0.51,0.17,0.01,0.0,0.0,0.0,0.0,mark roberts,
-CHE,4330,1,Process Design II,0.59,0.4,0.01,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHIN,1020,1,Elementary Chinese,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,ling rao,
-CHIN,2020,1,Intermediate Chinese,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ling rao,
-CHIN,4010,1,Pre-Modern Chinese Literature,0.21,0.42,0.26,0.11,0.0,0.0,0.0,0.0,yanming an,
-COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,eddie smith,
-COM,1500,1,Intro to Human Communication,0.8,0.13,0.02,0.02,0.03,0.0,0.0,0.0,eddie smith,
-COM,1500,2,Intro to Human Communication,0.6,0.29,0.08,0.01,0.01,0.0,0.0,0.01,daniel lelan fecher,
-COM,1500,3,Intro to Human Communication,0.86,0.09,0.03,0.0,0.01,0.0,0.0,0.01,eddie smith,
-COM,1500,4,Intro to Human Communication,0.62,0.31,0.04,0.02,0.0,0.0,0.0,0.01,marianne her glaser,
-COM,1500,5,Intro to Human Communication,0.69,0.25,0.06,0.01,0.0,0.0,0.0,0.0,marianne her glaser,
-COM,1500,6,Intro to Human Communication,0.41,0.47,0.09,0.03,0.0,0.0,0.0,0.0,daniel lelan fecher,
-COM,2010,1,Intr to Comm Studies,0.6,0.3,0.07,0.0,0.0,0.0,0.0,0.03,darren linvill,
-COM,2010,2,Intr to Comm Studies,0.47,0.4,0.07,0.03,0.0,0.0,0.0,0.03,darren linvill,
-COM,2500,1,Public Speaking,0.33,0.43,0.1,0.1,0.05,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,2,Public Speaking,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,brandon boatwright,
-COM,2500,3,Public Speaking,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,4,Public Speaking,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,5,Public Speaking,0.29,0.62,0.1,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,6,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,7,Public Speaking,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,8,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,10,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,11,Public Speaking,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
-COM,2500,12,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,13,Public Speaking,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,14,Public Speaking,0.52,0.33,0.0,0.0,0.1,0.0,0.0,0.05,jumah patrici taweh,
-COM,2500,15,Public Speaking,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,16,Public Speaking,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,17,Public Speaking,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,the estate  geddes,
-COM,2500,18,Public Speaking,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,
-COM,2500,19,Public Speaking,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,21,Public Speaking,0.67,0.24,0.0,0.05,0.0,0.0,0.0,0.05,sara grumbl crocker,
-COM,2500,22,Public Speaking,0.52,0.33,0.0,0.0,0.05,0.0,0.0,0.1,jumah patrici taweh,
-COM,2500,24,Public Speaking,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,25,Public Speaking,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,
-COM,2500,27,Public Speaking (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,True
-COM,2500,29,Public Speaking,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,30,Public Speaking,0.32,0.64,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,31,Public Speaking,0.1,0.57,0.14,0.05,0.1,0.0,0.0,0.05,pauline matthey,
-COM,2500,32,Public Speaking,0.25,0.2,0.25,0.1,0.1,0.0,0.0,0.1,pauline matthey,
-COM,2500,400,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,401,Public Speaking,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,alexis zachar davis,
-COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,403,Public Speaking,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,500,Public Speaking,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,501,Public Speaking,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
-COM,3010,1,Comm Theory,0.24,0.62,0.0,0.1,0.0,0.0,0.0,0.05,gregory kei cranmer,
-COM,3020,1,Mass Comm Theory,0.58,0.13,0.29,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3020,2,Mass Comm Theory,0.43,0.35,0.22,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3060,1,Crit-Cultural Rsrch Methods,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,
-COM,3110,1,Qual Comm Methods,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,chenjerai kumanyika,
-COM,3250,1,Survey of Sports Communication,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,3250,2,Survey of Sports Communication,0.8,0.08,0.08,0.0,0.04,0.0,0.0,0.0,john steven spinda,
-COM,3550,1,Principles of Public Relations,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3550,2,Principles of Public Relations,0.79,0.17,0.0,0.0,0.04,0.0,0.0,0.0,andrew stephen pyle,
-COM,3560,1,Crisis Communication,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3610,1,Argue and Debate,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,lindsey dixon,
-COM,3660,1,Video COMM w/ Adobe CC,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,michael rodgers,
-COM,3700,1,Survey of Brand Communications,0.93,0.0,0.03,0.0,0.0,0.0,0.0,0.03,lisa willi papenfus,
-COM,3720,1,Digital Analytics in Brand Com,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,alicia ni littleton,
-COM,3730,1,Media Management in Brand Comm,0.77,0.19,0.0,0.04,0.0,0.0,0.0,0.0,william reynolds,
-COM,3740,1,Brand Comm and Media Strategy,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,roger beasley,
-COM,4040,1,Media Comm & Social Identities,0.18,0.53,0.0,0.06,0.12,0.0,0.0,0.12,chenjerai kumanyika,
-COM,4040,2,Media Comm & Social Identities,0.43,0.48,0.0,0.1,0.0,0.0,0.0,0.0,chenjerai kumanyika,
-COM,4270,1,Comm in Sports Organizations,0.68,0.24,0.04,0.0,0.0,0.0,0.0,0.04,angela pratt,
-COM,4270,2,Comm in Sports Organizations,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,4280,1,Interpers/Family Comm & Sport,0.43,0.48,0.04,0.0,0.0,0.0,0.0,0.04,gregory kei cranmer,
-COM,4280,2,Interpers/Family Comm & Sport,0.4,0.56,0.0,0.0,0.0,0.0,0.0,0.04,gregory kei cranmer,
-COM,4700,1,Comm & Health,0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,4950,1,Senior Capstone,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,4950,2,Senior Capstone,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,4980,1,Acad & Prof Dev II,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.04,joseph mazer,
-COM,8110,1,Comm Research Methods II,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COOP,1010,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey frank neal,
-CPSC,1010,1,Computer Science I,0.23,0.24,0.18,0.08,0.12,0.0,0.0,0.15,salvatore lamarca,
-CPSC,1010,2,Computer Science I,0.26,0.24,0.18,0.05,0.11,0.0,0.0,0.16,lanny sitanayah,
-CPSC,1020,1,Computer Science II,0.4,0.29,0.14,0.1,0.05,0.0,0.0,0.02,yvon feaster,
-CPSC,1020,2,Computer Science II,0.49,0.2,0.11,0.11,0.08,0.0,0.0,0.02,yvon feaster,
-CPSC,1070,1,Programming Methodology,0.42,0.29,0.16,0.0,0.03,0.0,0.0,0.1,rose lowe,
-CPSC,1110,1,Intro to Programming in C,0.25,0.37,0.2,0.04,0.02,0.0,0.0,0.12,catherine hochrine,
-CPSC,1110,2,Intro to Programming in C,0.33,0.38,0.1,0.04,0.04,0.0,0.0,0.12,catherine hochrine,
-CPSC,2070,1,Discrete Structures,0.26,0.26,0.18,0.09,0.15,0.0,0.0,0.06,sandra hedetniemi,
-CPSC,2070,2,Discrete Structures,0.3,0.25,0.23,0.15,0.02,0.0,0.0,0.07,larry hodges,
-CPSC,2120,1,Algs/Data Structures,0.11,0.31,0.25,0.17,0.09,0.0,0.0,0.06,salvatore lamarca,
-CPSC,2120,2,Algs/Data Structures,0.26,0.32,0.23,0.05,0.06,0.0,0.0,0.08,salvatore lamarca,
-CPSC,2150,1,Software Dev Foundations,0.27,0.33,0.24,0.05,0.06,0.0,0.0,0.05,kevin anton plis,
-CPSC,2150,2,Software Dev Foundations,0.26,0.34,0.18,0.05,0.07,0.0,0.0,0.1,murali sitaraman,
-CPSC,2200,1,Microcomputer Appl,0.7,0.17,0.09,0.0,0.0,0.0,0.0,0.04,lanny sitanayah,
-CPSC,2310,1,Intro Computer Org,0.3,0.34,0.2,0.02,0.04,0.0,0.0,0.1,rose lowe,
-CPSC,2310,2,Intro Computer Org,0.29,0.22,0.31,0.1,0.06,0.0,0.0,0.02,rose lowe,
-CPSC,2910,1,Prof Issues I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,2,Prof Issues I,0.65,0.2,0.15,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,3,Prof Issues I,0.42,0.26,0.32,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,4,Prof Issues I,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,5,Prof Issues I,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,3220,1,Intro to Operating Systems,0.25,0.19,0.09,0.06,0.13,0.0,0.0,0.28,jacob sorber,
-CPSC,3220,2,Intro to Operating Systems,0.18,0.24,0.29,0.11,0.11,0.0,0.0,0.07,mark smotherman,
-CPSC,3300,1,Computer Systems Org,0.24,0.15,0.31,0.22,0.05,0.0,0.0,0.03,mark smotherman,
-CPSC,3500,1,Foundations of Computer Sci,0.24,0.37,0.34,0.02,0.01,0.0,0.0,0.01,wayne goddard,
-CPSC,3520,1,Programming Systems,0.37,0.4,0.09,0.0,0.09,0.0,0.0,0.06,robert schalkoff,
-CPSC,3600,1,Network Programming,0.29,0.29,0.14,0.11,0.03,0.0,0.0,0.14,feng luo,
-CPSC,3600,2,Network Programming,0.44,0.22,0.27,0.02,0.05,0.0,0.0,0.0,lanny sitanayah,
-CPSC,3620,1,Distributed/Cluster Computing,0.19,0.4,0.3,0.03,0.02,0.0,0.0,0.06,linh bao ngo,
-CPSC,3720,1,Software Engineering,0.37,0.39,0.16,0.08,0.0,0.0,0.0,0.0,kevin anton plis,
-CPSC,3720,2,Software Engineering,0.24,0.33,0.33,0.04,0.06,0.0,0.0,0.0,kevin anton plis,
-CPSC,3990,1,Advanced CI: Extreme Orange,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james martin,
-CPSC,4050,1,Computer Graphics,0.31,0.38,0.19,0.06,0.0,0.0,0.0,0.06,robert geist,
-CPSC,4110,1,Virtual Reality Systems,0.56,0.24,0.15,0.03,0.03,0.0,0.0,0.0,andrew robb,
-CPSC,4140,1,Human and Computer Interaction,0.16,0.42,0.32,0.0,0.11,0.0,0.0,0.0,sabarish venka babu,
-CPSC,4140,2,Human and Computer Interaction,0.61,0.3,0.0,0.0,0.04,0.0,0.0,0.04,sabarish venka babu,
-CPSC,4140,3,Human and Computer Interaction,0.35,0.35,0.17,0.0,0.04,0.0,0.0,0.09,christopher plaue,
-CPSC,4160,1,2-D Game Engine Construction,0.43,0.28,0.13,0.06,0.02,0.0,0.0,0.08,brian malloy,
-CPSC,4240,1,System Admin and Security,0.15,0.61,0.24,0.0,0.0,0.0,0.0,0.0,james martin,
-CPSC,4620,1,Database Management Systems,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,zijun wang,
-CPSC,4820,1,Selected Topics: Android Dev,0.75,0.06,0.13,0.06,0.0,0.0,0.0,0.0,roy pargas,
-CPSC,4820,2,Special Topics: Dig Sulpt,0.25,0.67,0.0,0.0,0.0,0.0,0.0,0.08,insun kwon,
-CPSC,4820,3,Special Topics: Data Science,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
-CPSC,4820,4,Special Topic: Cloud Comp Arch,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,amy apon,
-CPSC,4820,5,Special Topics: Tang and Embod,0.35,0.3,0.2,0.0,0.1,0.0,0.0,0.05,brygg anders ullmer,
-CPSC,4910,1,Professional Issues II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
-CPSC,6050,1,Computer Graphics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,
-CPSC,6110,1,Virtual Reality Systems,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,andrew robb,
-CPSC,6140,1,Human and Computer Interaction,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,
-CPSC,6140,2,Human and Computer Interaction,0.7,0.17,0.09,0.0,0.0,0.0,0.0,0.04,sabarish venka babu,
-CPSC,6160,1,2-D Game Engine Construction,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian malloy,
-CPSC,6620,1,Database Management Systems,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,zijun wang,
-CPSC,6810,3,Selected Topic: Program Team,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,brian christop dean,
-CPSC,6820,3,Special Topics: Data Science,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
-CPSC,6820,4,Special Topic: Cloud Comp Arch,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,amy apon,
-CPSC,8050,1,Adv Comp Graphics,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,
-CPSC,8110,1,Technical Character Animation,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,christina sop joerg,
-CPSC,8220,1,Case Study in Operating Sys,0.55,0.35,0.0,0.0,0.0,0.0,0.0,0.1,robert geist,
-CPSC,8400,1,Design & Anlys of Algorithms,0.18,0.32,0.26,0.0,0.08,0.0,0.0,0.16,brian christop dean,
-CPSC,8470,1,Intro to Information Retrieval,0.66,0.17,0.14,0.0,0.0,0.0,0.0,0.03,feng luo,
-CPSC,8570,1,Network Technologies Security,0.43,0.53,0.0,0.0,0.0,0.0,0.0,0.04,hongxin hu,
-CPSC,8630,1,Multimedia Sys/Apps,0.31,0.46,0.15,0.0,0.0,0.0,0.0,0.08,zijun wang,
-CPSC,8650,1,Data Mining,0.34,0.45,0.17,0.0,0.02,0.0,0.0,0.02,zijun wang,
-CPSC,8750,1,Software Architectur,0.44,0.41,0.07,0.0,0.0,0.0,0.0,0.07,john mcgregor,
-CPSC,8810,5,Selected Topics: Eff Comput,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,rong ge,
-CRP,8020,1,Site Planning,0.73,0.23,0.0,0.0,0.04,0.0,0.0,0.0,clifford dona ellis,
-CRP,8040,1,Land Use Analysis,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,
-CRP,8050,1,Plning Theory & Hist,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,mickey lauria,
-CRP,8090,1,Current Issues,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
-CRP,8200,1,Negotiation,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
-CRP,8220,1,Urban Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-CRP,8410,1,Env Planning,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,
-CRP,8730,1,Econ Dev Planning,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,timothy green,
-CSM,1500,1,Constr Prob Solving,0.41,0.33,0.19,0.04,0.04,0.0,0.0,0.0,jason lucas,
-CSM,1500,2,Constr Prob Solving,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,2020,1,Structures II,0.28,0.48,0.2,0.0,0.0,0.0,0.0,0.04,shima clarke,
-CSM,2020,2,Structures II,0.16,0.32,0.47,0.0,0.05,0.0,0.0,0.0,shima clarke,
-CSM,2040,1,Cont Documents,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,2040,2,Cont Documents,0.52,0.3,0.13,0.0,0.04,0.0,0.0,0.0,joseph mich burgett,
-CSM,2050,1,Mats & Methods II,0.2,0.52,0.28,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,2050,2,Mats & Methods II,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,raymond schneider,
-CSM,3050,1,Envir Systems II,0.18,0.61,0.18,0.0,0.03,0.0,0.0,0.0,joseph mich burgett,
-CSM,3050,2,Envir Systems II,0.29,0.43,0.21,0.07,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3520,1,Const Scheduling,0.13,0.5,0.28,0.06,0.03,0.0,0.0,0.0,christine piper,
-CSM,3520,2,Const Scheduling,0.28,0.34,0.34,0.03,0.0,0.0,0.0,0.0,christine piper,
-CSM,3530,1,Const Estimating II,0.26,0.45,0.16,0.13,0.0,0.0,0.0,0.0,seyed mousavi rizi,
-CSM,3530,2,Const Estimating II,0.22,0.47,0.28,0.0,0.03,0.0,0.0,0.0,seyed mousavi rizi,
-CSM,4540,1,Const Capstone,0.35,0.62,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4540,2,Const Capstone,0.12,0.8,0.08,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8520,1,Const Mgmt Research,0.0,0.4,0.6,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CSM,8520,400,Const Mgmt Research,0.2,0.2,0.6,0.0,0.0,0.0,0.0,0.0,roger william liska,
-CSM,8650,1,Project Management,0.15,0.69,0.08,0.0,0.08,0.0,0.0,0.0,christine piper,
-CSM,8660,1,Role in Development,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.03,susan whorton,
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.0,susan whorton,
-CU,1010,1,Univ Success Skills,0.25,0.25,0.25,0.05,0.05,0.0,0.0,0.15,matthew james kirk,
-CU,1010,2,Univ Success Skills,0.41,0.14,0.05,0.09,0.14,0.0,0.0,0.18,joseph paul thames,
-CU,1010,3,Univ Success Skills,0.53,0.21,0.05,0.11,0.0,0.0,0.0,0.11,jessica gale owens,
-CU,1010,4,Univ Success Skills,0.39,0.28,0.17,0.17,0.0,0.0,0.0,0.0,cari allyn brooks,
-CU,1010,5,Univ Success Skills,0.53,0.21,0.11,0.05,0.0,0.0,0.0,0.11,bryn zimmerman babb,
-CU,1100,100,Introduction to Tutoring,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,ashley crisp,
-CU,1970,2,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,robert austi massey,
-CU,2010,1,Sustainability Leadership,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,
-DPA,3070,1,Method 3d Production,0.86,0.04,0.0,0.0,0.04,0.0,0.0,0.07,summer 'nea benton,
-DPA,4030,1,Vis Foundations II,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,erik reed,
-DPA,8080,2,Artistic Character Animation,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,david stewart donar,
-DPA,8090,1,Rendering and Shading,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,eric patterson,
-DPA,8090,2,Rendering and Shading,0.0,0.4,0.0,0.0,0.0,0.0,0.0,0.6,eric patterson,
-ECE,1010,400,Robots in Business & Society,0.45,0.35,0.1,0.03,0.03,0.0,0.0,0.03,ian walker,
-ECE,2010,1,Logic and Computing Devices,0.21,0.23,0.25,0.22,0.05,0.0,0.0,0.04,lin zhu,
-ECE,2020,1,Electric Circuits I,0.27,0.27,0.29,0.06,0.1,0.0,0.0,0.01,william harrell,
-ECE,2070,1,Basic Electrical Engineering,0.48,0.32,0.08,0.07,0.02,0.0,0.0,0.03,timothy anglea,
-ECE,2070,2,Basic Electrical Engineering,0.55,0.29,0.1,0.03,0.0,0.0,0.0,0.03,william th kolodzey,
-ECE,2070,3,Basic Electrical Engineering,0.25,0.28,0.34,0.03,0.06,0.0,0.0,0.03,daniel bla cutshall,
-ECE,2080,1,Basic Electrical Engr Lab,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,2,Basic Electrical Engr Lab,0.25,0.45,0.15,0.1,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,4,Basic Electrical Engr Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,5,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,6,Basic Electrical Engr Lab,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,9,Basic Electrical Engr Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,10,Basic Electrical Engr Lab,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,11,Basic Electrical Engr Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,15,Basic Electrical Engr Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,1,Logic Lab,0.58,0.25,0.08,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,2,Logic Lab,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2090,3,Logic Lab,0.58,0.17,0.17,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2090,4,Logic Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2110,2,Elec Engr Lab I,0.4,0.13,0.07,0.2,0.07,0.0,0.0,0.13,apoorva dee kapadia,
-ECE,2110,4,Elec Engr Lab I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2120,1,Electrical Engineering Lab II,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2220,1,Syst Prog Concept,0.22,0.33,0.19,0.08,0.06,0.0,0.0,0.12,william reid,
-ECE,2230,1,Comp Sys Eng,0.28,0.59,0.06,0.03,0.0,0.0,0.0,0.03,walter ligon,
-ECE,2620,1,Electric Circuits II,0.46,0.38,0.11,0.01,0.03,0.0,0.0,0.02,richard groff,
-ECE,2720,1,Comp Organization,0.3,0.4,0.18,0.08,0.04,0.0,0.0,0.01,william reid,
-ECE,2730,1,Computer Org Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2730,2,Computer Org Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2730,3,Computer Org Lab,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2730,4,Computer Org Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3170,1,Rand Signal Analysis,0.24,0.27,0.25,0.13,0.05,0.0,0.0,0.06,stephen hubbard,
-ECE,3200,1,Electronics I,0.18,0.27,0.27,0.14,0.13,0.0,0.0,0.01,stephen hubbard,
-ECE,3210,1,Electronics II,0.32,0.34,0.21,0.1,0.03,0.0,0.0,0.0,stephen hubbard,
-ECE,3220,1,Intro Operating Sys,0.23,0.33,0.13,0.03,0.07,0.0,0.0,0.2,jacob sorber,
-ECE,3270,1,Dig Comp Design,0.2,0.3,0.13,0.17,0.1,0.0,0.0,0.1,melissa crawl smith,
-ECE,3300,1,Signals & Systems,0.2,0.22,0.25,0.16,0.03,0.0,0.0,0.14,carl baum,
-ECE,3520,1,Programming Systems,0.46,0.27,0.15,0.0,0.04,0.0,0.0,0.08,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.42,0.31,0.15,0.0,0.0,0.0,0.0,0.12,edward collins,
-ECE,3710,1,Microcontr Interface,0.33,0.4,0.21,0.04,0.0,0.0,0.0,0.02,william reid,
-ECE,3720,1,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,3720,2,Micro Int Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,3,Micro Int Lab,0.58,0.25,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,4,Micro Int Lab,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,5,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,3720,6,Micro Int Lab,0.4,0.1,0.3,0.0,0.2,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,7,Micro Int Lab,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3800,1,Electromagnetics,0.39,0.32,0.05,0.1,0.07,0.0,0.0,0.07,anthony martin,
-ECE,3810,1,Field Waves & Ckts,0.37,0.38,0.19,0.02,0.0,0.0,0.0,0.05,eric gordon johnson,
-ECE,4090,1,Intr to Linear Control Systems,0.49,0.38,0.0,0.05,0.05,0.0,0.0,0.03,apoorva dee kapadia,
-ECE,4190,1,Elec Mach and Drives,0.17,0.48,0.17,0.14,0.0,0.0,0.0,0.03,thomas salem,
-ECE,4270,1,Communications Sys,0.39,0.31,0.22,0.03,0.06,0.0,0.0,0.0,madhabi manandhar,
-ECE,4320,1,Instrumentation,0.3,0.2,0.4,0.0,0.1,0.0,0.0,0.0,goutam koley,
-ECE,4380,1,Computer Commun,0.31,0.25,0.22,0.06,0.06,0.0,0.0,0.11,harlan russell,
-ECE,4400,1,Local Computer Nets,0.48,0.35,0.16,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,
-ECE,4680,1,Embedded Computing,0.55,0.3,0.05,0.0,0.0,0.0,0.0,0.1,adam hoover,
-ECE,4930,2,Smart Grid,0.24,0.66,0.07,0.0,0.0,0.0,0.0,0.03,gan venayagamoorthy,
-ECE,4950,1,Int Sys Design I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4960,1,Int Sys Design II,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,richard groff,
-ECE,6190,1,Elec Mach and Drives,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,thomas salem,
-ECE,6380,1,Computer Commun,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,harlan russell,
-ECE,6460,1,Antennas,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,anthony martin,
-ECE,6930,1,VLSI Design Automation,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,yingjie lao,
-ECE,8160,1,Elec Power Distr Sys Engr,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,elham makram,
-ECE,8260,1,Solar Cells,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,
-ECE,8400,1,Semicond Devices,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,
-ECE,8440,1,Digital Signal Proc,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,eric patterson,
-ECE,8560,1,Pattern Recognition,0.58,0.36,0.0,0.0,0.0,0.0,0.0,0.06,robert schalkoff,
-ECE,8740,1,Adv Nonlinear Cntrl,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,yongqiang wang,
-ECE,8780,1,High-Perform Computing w GPUs,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,
-ECE,8930,10,Distributed Denial of Service,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,
-ECON,2000,1,Economic Concepts,0.28,0.4,0.23,0.1,0.0,0.0,0.0,0.0,jonathan orr ernest,
-ECON,2000,2,Economic Concepts,0.51,0.23,0.13,0.05,0.05,0.0,0.0,0.03,jonathan orr ernest,
-ECON,2000,3,Economic Concepts,0.31,0.38,0.15,0.03,0.13,0.0,0.0,0.0,miren ivankovic,
-ECON,2110,1,Principles of Microeconomics,0.21,0.28,0.26,0.1,0.13,0.0,0.0,0.03,amanda caitlin kerr,
-ECON,2110,2,Principles of Microeconomics,0.3,0.53,0.08,0.05,0.03,0.0,0.0,0.03,molly espey,
-ECON,2110,3,Principles of Microeconomics,0.14,0.24,0.23,0.29,0.08,0.0,0.0,0.03,liuna issagholian,
-ECON,2110,4,Principles of Microeconomics,0.38,0.38,0.13,0.13,0.0,0.0,0.0,0.0,maria droganova,
-ECON,2110,5,Principles of Microeconomics,0.38,0.33,0.15,0.05,0.05,0.0,0.0,0.05,roksan ghanbariamin,
-ECON,2110,6,Principles of Microeconomics,0.18,0.21,0.31,0.09,0.15,0.0,0.0,0.06,bradley keith hobbs,
-ECON,2110,7,Principles of Microeconomics,0.16,0.24,0.26,0.16,0.13,0.0,0.0,0.06,bradley keith hobbs,
-ECON,2110,8,Principles of Microeconomics,0.18,0.43,0.2,0.12,0.06,0.0,0.0,0.01,kelsey vict roberts,
-ECON,2110,10,Principles of Microeconomics,0.51,0.14,0.14,0.08,0.08,0.0,0.0,0.04,steven johnson,
-ECON,2110,11,Principles of Microeconomics,0.34,0.35,0.14,0.1,0.03,0.0,0.0,0.04,leah jacq kitashima,
-ECON,2110,12,Principles of Microeconomics,0.3,0.55,0.08,0.05,0.0,0.0,0.0,0.03,benjamin jo schwall,
-ECON,2120,1,Principles of Macroeconomics,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,scott baier,
-ECON,2120,2,Principles of Macroeconomics,0.26,0.37,0.21,0.16,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,3,Principles of Macroeconomics,0.3,0.35,0.3,0.0,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,4,Principles of Macroeconomics,0.21,0.58,0.11,0.0,0.11,0.0,0.0,0.0,scott baier,
-ECON,2120,5,Principles of Macroeconomics,0.35,0.2,0.45,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,6,Principles of Macroeconomics,0.16,0.47,0.21,0.16,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,7,Principles of Macroeconomics,0.21,0.37,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,8,Principles of Macroeconomics,0.16,0.47,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,9,Principles of Macroeconomics,0.2,0.45,0.3,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,10,Principles of Macroeconomics,0.11,0.53,0.32,0.0,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,11,Principles of Macroeconomics,0.16,0.32,0.47,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,12,Principles of Macroeconomics,0.17,0.33,0.33,0.0,0.17,0.0,0.0,0.0,scott baier,
-ECON,2120,13,Principles of Macroeconomics,0.47,0.41,0.0,0.0,0.06,0.0,0.0,0.06,scott baier,
-ECON,2120,14,Principles of Macroeconomics,0.35,0.47,0.06,0.06,0.06,0.0,0.0,0.0,scott baier,
-ECON,2120,15,Principles of Macroeconomics,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,16,Principles of Macroeconomics,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,17,Principles of Macroeconomics,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,18,Principles of Macroeconomics,0.16,0.58,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,19,Principles of Macroeconomics,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,20,Principles of Macroeconomics,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,peter david lorenz,
-ECON,2120,21,Principles of Macroeconomics,0.6,0.37,0.01,0.01,0.0,0.0,0.0,0.0,huili li,
-ECON,2120,22,Principles of Macroeconomics,0.27,0.56,0.17,0.0,0.0,0.0,0.0,0.0,ce castellon chicas,
-ECON,2120,23,Principles of Macroeconomics,0.3,0.48,0.18,0.0,0.0,0.0,0.0,0.05,jordan adamson,
-ECON,2120,24,Principles of Macroeconomics,0.1,0.23,0.16,0.19,0.12,0.0,0.0,0.19,ralph charles allen,
-ECON,2120,25,Principles of Macroeconomics,0.19,0.19,0.11,0.22,0.04,0.0,0.0,0.26,ralph charles allen,
-ECON,2120,26,Principles of Macroeconomics,0.28,0.42,0.22,0.08,0.0,0.0,0.0,0.0,scott barkowski,
-ECON,2120,27,Principles of Macroeconomics,0.4,0.5,0.08,0.03,0.0,0.0,0.0,0.0,peter david lorenz,
-ECON,2120,28,Principles of Macroecon (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,True
-ECON,3020,1,Money and Banking,0.33,0.38,0.2,0.1,0.0,0.0,0.0,0.0,smriti bhargava,
-ECON,3060,1,Managerial Economics,0.25,0.23,0.25,0.15,0.07,0.0,0.0,0.05,timothy jay bacon,
-ECON,3100,1,International Econ,0.24,0.4,0.32,0.03,0.02,0.0,0.0,0.0,richard alan sessa,
-ECON,3140,1,Intermediate Micro,0.43,0.28,0.23,0.0,0.03,0.0,0.0,0.05,molly espey,
-ECON,3140,2,Intermediate Micro,0.32,0.29,0.11,0.13,0.05,0.0,0.0,0.11,patrick warren,
-ECON,3140,3,Intermediate Micro,0.23,0.21,0.46,0.03,0.08,0.0,0.0,0.0,molly espey,
-ECON,3150,1,Intermediate Macro,0.26,0.36,0.22,0.12,0.03,0.0,0.0,0.01,michal jerzmanowski,
-ECON,3150,2,Intermediate Macro,0.26,0.26,0.29,0.0,0.08,0.0,0.0,0.11,sergey vla mityakov,
-ECON,3440,1,Property Rights,0.19,0.19,0.26,0.11,0.15,0.0,0.0,0.11,dar litsukova-bokar,
-ECON,3500,1,Moral & Ethical Econ,0.15,0.27,0.3,0.06,0.15,0.0,0.0,0.06,bradley keith hobbs,
-ECON,3600,1,Public Choice,0.36,0.23,0.26,0.05,0.05,0.0,0.0,0.05,michael makowsky,
-ECON,4010,1,Labor Mkt Analysis,0.23,0.42,0.23,0.0,0.08,0.0,0.0,0.04,curtis simon,
-ECON,4020,1,Law and Economics,0.2,0.47,0.23,0.07,0.03,0.0,0.0,0.0,thomas wins hazlett,
-ECON,4050,1,Intro to Econometric,0.28,0.28,0.23,0.12,0.07,0.0,0.0,0.02,scott barkowski,
-ECON,4200,1,Pub Sector Econ,0.2,0.3,0.33,0.05,0.08,0.0,0.0,0.05,william dougan,
-ECON,4240,1,Organization of Ind,0.53,0.23,0.2,0.03,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,4260,1,Sem Sport Economics,0.6,0.32,0.0,0.0,0.0,0.0,0.0,0.08,raymond sauer,
-ECON,4270,1,Dev American Economy,0.22,0.5,0.19,0.06,0.03,0.0,0.0,0.0,howard ne bodenhorn,
-ECON,4290,1,Economics of Energy Markets,0.37,0.5,0.13,0.0,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,4400,1,Game Theory,0.23,0.46,0.27,0.0,0.04,0.0,0.0,0.0,charles thomas,
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.11,0.42,0.32,0.11,0.0,0.0,0.0,0.05,scott templeton,
-ECON,6400,1,Game Theory,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,charles thomas,
-ECON,8020,2,Adv Econ Concepts and Applic I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
-ECON,8050,1,Macroeconomic Theory,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,
-ECON,8070,1,Econometrics II,0.38,0.48,0.1,0.0,0.0,0.0,0.0,0.05,chungsang lam,
-ECON,8110,1,Econ of Environment,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,
-ECON,8200,1,Public Finance,0.44,0.33,0.0,0.0,0.0,0.0,0.0,0.22,william dougan,
-ECON,9000,2,Empirical Public Choice,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
-ED,1050,1,Educ Orientation,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,william da mccorkle,
-ED,1050,2,Educ Orientation,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,william da mccorkle,
-EDC,3900,2,Skills for Stu Leads,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,3,Skills for Stu Leads,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,4,Skills for Stu Leads,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,5,Skills for Stu Leads,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,6,Skills for Stu Leads,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDEC,2200,1,Family/School/Com,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
-EDEC,8100,500,Adv Ece Found & Meth,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEL,3210,1,Pe for the Elem Tchr,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4510,1,Elem Methods in Science Tchg,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,
-EDEL,4520,1,Elem Methods Math Teaching,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-EDEL,4520,2,Elem Methods Math Teaching,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-EDEL,4870,1,Ele Meth Soc Studies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,dwane valera,
-EDF,3010,1,Principles of American Educat,0.86,0.09,0.06,0.0,0.0,0.0,0.0,0.0,william da mccorkle,
-EDF,3020,1,Educational Psychology,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
-EDF,3020,2,Educational Psychology,0.83,0.13,0.05,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
-EDF,3020,3,Educational Psychology,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0,stephen chou,
-EDF,3340,1,Child Growth and Development,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
-EDF,3340,3,Child Growth and Development,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,
-EDF,3350,1,Adolescent Growth & Develop,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
-EDF,4800,3,Digital Media & Learning,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,juan li,
-EDF,4800,300,Digital Media & Learning,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,8080,300,Ed Tests and Measure,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,heather rog brooker,
-EDF,9700,1,Democratic Education,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,
-EDF,9770,400,Multi Regress Ed Research,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jennie lynn farmer,
-EDF,9790,1,Qualitative Research in Educ,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDHD,3110,1,CI- Research in DM & Learning,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,david matthew boyer,
-EDL,7150,500,Sch & Comm Relations,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,frederick buskey,
-EDL,7300,502,Techniq of Supervision-Pub Sch,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,hans william klar,
-EDL,7400,511,Curr Plan: Sch Adm,0.88,0.0,0.06,0.0,0.06,0.0,0.0,0.0,barbara nesbitt,
-EDL,7510,500,El Prin & Spv Ex II,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,frederick buskey,
-EDL,7650,1,Assessment Hi Edu,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,kristin walker,
-EDL,7650,2,Assessment Hi Edu,0.17,0.72,0.11,0.0,0.0,0.0,0.0,0.0,kristin walker,
-EDL,8500,501,Practicum: District,0.38,0.0,0.08,0.0,0.54,0.0,0.0,0.0,elizabeth reynolds,
-EDL,8850,512,STEM - School Admin,0.57,0.0,0.0,0.0,0.43,0.0,0.0,0.0,william havice,
-EDL,9110,400,Systematic Inq Ed L,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,
-EDL,9750,2,College Teaching,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,pamela havice,
-EDLT,4580,1,Early Literacy: Birth-Kindergn,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4620,1,Reading Children's Lit in Elem,0.59,0.27,0.09,0.05,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,8270,300,Content Area Rdg/Wtg-MS & HS,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8410,501,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
-EDLT,8410,502,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,
-EDLT,8410,505,Early Literacy Inst Strategies,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephanie amb pitts,
-EDLT,8810,506,Reading Recovery Teacher II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,
-EDLT,8830,506,Read Recovery Practicum II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,
-EDSC,4370,1,Technology in Math,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,
-EDSC,4480,1,Teach Intern Sec Soc,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,marshall alan darby,
-EDSP,3700,2,Intro to Special Education,0.81,0.17,0.03,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,
-EDSP,3700,4,Intro to Special Education,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,catherine griffith,
-EDSP,4910,1,Ed Assess Ind W/Dis,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
-EES,2020,1,Environ Engr Fundamentals II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
-EES,4010,1,Environmental Engr,0.49,0.51,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.36,0.21,0.25,0.0,0.07,0.0,0.0,0.11,ezra lucas ho cates,
-EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,4840,2,Solid Waste Mgt,0.58,0.35,0.04,0.0,0.04,0.0,0.0,0.0,thomas overcamp,
-EES,4850,2,Hazard Waste Management,0.22,0.52,0.26,0.0,0.0,0.0,0.0,0.0,mark schlautman,
-EES,4860,6,Environmental Sustainability,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
-EES,8030,1,Phy/Chem Ops W/WW T,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,ezra lucas ho cates,
-EES,8040,1,Biochem Ops WW Trt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,
-EES,8090,1,Subsurface Remed Mod,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,ronald falta,
-ELE,3010,1,Intro to Entre,0.44,0.51,0.03,0.0,0.0,0.0,0.0,0.03,christina kyprianou,
-ELE,3010,2,Intro to Entre,0.41,0.51,0.08,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
-ELE,3010,3,Intro to Entre,0.24,0.36,0.38,0.0,0.02,0.0,0.0,0.0,ashley will parnell,
-ELE,3140,1,New Venture Creat I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,chad navis,
-ELE,3140,2,New Venture Creat I,0.57,0.3,0.14,0.0,0.0,0.0,0.0,0.0,chad navis,
-ELE,4010,1,Exec Lead & Entr II,0.24,0.33,0.38,0.02,0.0,0.0,0.0,0.02,ashley will parnell,
-ENGL,1030,1,Accelerated Composition,0.62,0.24,0.05,0.0,0.05,0.0,0.0,0.05,chloe helene cahill,
-ENGL,1030,2,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,1030,3,Accelerated Composition,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,sharif youssef,
-ENGL,1030,4,Accelerated Composition,0.7,0.05,0.05,0.05,0.0,0.0,0.0,0.15,melissa dugan,
-ENGL,1030,7,Accelerated Composition,0.71,0.05,0.14,0.0,0.1,0.0,0.0,0.0,charlotte est lucke,
-ENGL,1030,8,Accelerated Composition,0.81,0.1,0.0,0.05,0.05,0.0,0.0,0.0,melissa dugan,
-ENGL,1030,9,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,katie jo vann,
-ENGL,1030,10,Accelerated Composition,0.57,0.29,0.05,0.0,0.0,0.0,0.0,0.1,krist aldebol-hazle,
-ENGL,1030,11,Accelerated Composition,0.76,0.19,0.0,0.0,0.05,0.0,0.0,0.0,robert brissey,
-ENGL,1030,12,Accelerated Composition,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,robert brissey,
-ENGL,1030,13,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,kala parker,
-ENGL,1030,15,Accelerated Composition,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,katie jo vann,
-ENGL,1030,16,Accelerated Composition,0.59,0.24,0.0,0.0,0.06,0.0,0.0,0.12,kala parker,
-ENGL,1030,18,Accelerated Composition,0.81,0.05,0.0,0.0,0.0,0.0,0.0,0.14,katie jo vann,
-ENGL,1030,19,Accelerated Composition,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,samuel david martin,
-ENGL,1030,20,Accelerated Composition,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,samuel david martin,
-ENGL,1030,21,Accelerated Composition,0.76,0.14,0.05,0.0,0.05,0.0,0.0,0.0,brian lee gaines,
-ENGL,1030,22,Accelerated Composition,0.62,0.24,0.1,0.0,0.05,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,23,Accelerated Composition,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,charlotte est lucke,
-ENGL,1030,24,Accelerated Composition,0.65,0.12,0.12,0.06,0.06,0.0,0.0,0.0,brian lee gaines,
-ENGL,1030,25,Accelerated Composition,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,michael davi measel,
-ENGL,1030,26,Accelerated Composition,0.31,0.38,0.0,0.0,0.19,0.0,0.0,0.13,la'cresha ulo green,
-ENGL,1030,27,Accelerated Composition,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,28,Accelerated Composition,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,michael davi measel,
-ENGL,1030,30,Accelerated Composition,0.69,0.06,0.06,0.13,0.0,0.0,0.0,0.06,michael russo,
-ENGL,1030,31,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,laurie pfister epps,
-ENGL,1030,37,Accelerated Composition,0.76,0.05,0.1,0.0,0.0,0.0,0.0,0.1,christopher stuart,
-ENGL,1030,39,Accelerated Composition,0.81,0.1,0.0,0.0,0.0,0.0,0.0,0.1,michael russo,
-ENGL,1030,40,Accelerated Composition,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,austin gorman,
-ENGL,1030,41,Accelerated Composition,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,christopher stuart,
-ENGL,1030,44,Accelerated Composition,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,erica mich marquard,
-ENGL,1030,48,Accelerated Composition,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,matthew scot duncan,
-ENGL,1030,49,Accelerated Composition,0.33,0.44,0.0,0.0,0.11,0.0,0.0,0.11,matthew scot duncan,
-ENGL,1030,51,Accelerated Composition,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,stephen quigley,
-ENGL,1030,52,Accelerated Composition,0.76,0.14,0.0,0.0,0.1,0.0,0.0,0.0,stephen quigley,
-ENGL,1030,55,Accelerated Composition,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,daniel frank,
-ENGL,1030,57,Accelerated Composition,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,krist aldebol-hazle,
-ENGL,1030,58,Accelerated Composition,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,chloe helene cahill,
-ENGL,1030,60,Accelerated Composition,0.62,0.29,0.0,0.0,0.05,0.0,0.0,0.05,jennifer forsberg,
-ENGL,1030,62,Accelerated Composition,0.85,0.05,0.05,0.05,0.0,0.0,0.0,0.0,jennifer forsberg,
-ENGL,1030,63,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,christa kettlewell,
-ENGL,1030,65,Accelerated Composition,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,christa kettlewell,
-ENGL,1030,67,Accelerated Composition,0.14,0.71,0.05,0.0,0.0,0.0,0.0,0.1,renesha moniq poole,
-ENGL,1030,68,Accelerated Composition,0.06,0.78,0.06,0.06,0.0,0.0,0.0,0.06,renesha moniq poole,
-ENGL,1030,69,Accelerated Composition,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,dia quaglia beltran,
-ENGL,1030,70,Accelerated Composition,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,parker elizabe king,
-ENGL,1030,71,Accelerated Composition,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,yvonne kao,
-ENGL,1030,72,Accelerated Composition,0.71,0.12,0.06,0.06,0.0,0.0,0.0,0.06,yvonne kao,
-ENGL,1030,555,Accelerated Composition,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,
-ENGL,2020,555,The Major Forms of Literature,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,
-ENGL,2120,1,World Literature,0.34,0.34,0.14,0.07,0.03,0.0,0.0,0.07,andrew mathas,
-ENGL,2120,2,World Literature,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.03,daniel scott citro,
-ENGL,2120,3,World Literature,0.28,0.34,0.21,0.03,0.07,0.0,0.0,0.07,karen kettnich,
-ENGL,2120,4,World Literature,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,walter edgar hunter,
-ENGL,2120,5,World Literature,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,stephanie stripling,
-ENGL,2120,6,World Literature,0.28,0.45,0.17,0.03,0.07,0.0,0.0,0.0,karen kettnich,
-ENGL,2120,7,World Literature,0.76,0.17,0.03,0.03,0.0,0.0,0.0,0.0,stephanie stripling,
-ENGL,2120,11,World Literature,0.48,0.21,0.24,0.03,0.0,0.0,0.0,0.03,chloe mich whitaker,
-ENGL,2120,12,World Literature,0.41,0.41,0.07,0.07,0.0,0.0,0.0,0.03,chloe mich whitaker,
-ENGL,2120,13,World Literature,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.03,daniel scott citro,
-ENGL,2120,14,World Literature,0.38,0.48,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2120,16,World Literature,0.2,0.63,0.1,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,
-ENGL,2120,17,World Literature,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,april susanne pelt,
-ENGL,2120,18,World Literature,0.45,0.39,0.13,0.03,0.0,0.0,0.0,0.0,olga anatol volkova,
-ENGL,2120,19,World Literature,0.43,0.33,0.17,0.03,0.03,0.0,0.0,0.0,karen kettnich,
-ENGL,2120,20,World Literature,0.37,0.33,0.1,0.07,0.03,0.0,0.0,0.1,katalin beck,
-ENGL,2130,1,British Literature,0.76,0.21,0.03,0.0,0.0,0.0,0.0,0.0,benjamin hudson,
-ENGL,2130,2,British Literature,0.57,0.3,0.1,0.0,0.03,0.0,0.0,0.0,christopher benson,
-ENGL,2130,3,British Literature,0.77,0.2,0.0,0.0,0.0,0.0,0.0,0.03,christopher benson,
-ENGL,2130,4,British Literature,0.86,0.07,0.03,0.0,0.03,0.0,0.0,0.0,stephanie stripling,
-ENGL,2130,6,British Literature,0.61,0.32,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,2130,7,British Literature,0.8,0.13,0.03,0.0,0.0,0.0,0.0,0.03,benjamin hudson,
-ENGL,2130,10,British Literature,0.63,0.27,0.0,0.03,0.07,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,2130,12,British Literature,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,13,British Literature,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,lucian ghita,
-ENGL,2130,14,British Literature,0.77,0.17,0.0,0.0,0.0,0.0,0.0,0.07,lucian ghita,
-ENGL,2140,1,American Literature,0.7,0.13,0.13,0.0,0.03,0.0,0.0,0.0,jennifer forsberg,
-ENGL,2140,2,American Literature,0.43,0.29,0.07,0.04,0.04,0.0,0.0,0.14,jennifer forsberg,
-ENGL,2140,3,American Literature,0.72,0.21,0.03,0.03,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2140,4,American Literature,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,5,American Literature,0.29,0.43,0.11,0.07,0.0,0.0,0.0,0.11,david charles foltz,
-ENGL,2140,6,American Literature,0.19,0.38,0.23,0.04,0.04,0.0,0.0,0.12,david charles foltz,
-ENGL,2140,7,American Literature,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,8,American Literature,0.15,0.41,0.19,0.0,0.11,0.0,0.0,0.15,david charles foltz,
-ENGL,2140,12,American Literature,0.11,0.37,0.15,0.07,0.19,0.0,0.0,0.11,david charles foltz,
-ENGL,2140,13,American Literature,0.78,0.15,0.0,0.0,0.0,0.0,0.0,0.07,candace wiley,
-ENGL,2140,14,American Literature,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,15,American Literature,0.8,0.13,0.0,0.03,0.03,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,16,American Literature,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2140,17,American Literature,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,adrian carson,
-ENGL,2140,18,American Literature,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,adrian carson,
-ENGL,2140,19,American Literature,0.72,0.03,0.0,0.0,0.1,0.0,0.0,0.14,candace wiley,
-ENGL,2140,20,American Literature,0.77,0.12,0.0,0.0,0.0,0.0,0.0,0.12,candace wiley,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.48,0.32,0.13,0.03,0.0,0.0,0.0,0.03,john logan pursley,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.33,0.37,0.1,0.1,0.07,0.0,0.0,0.03,megan no macalystre,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.52,0.34,0.07,0.03,0.03,0.0,0.0,0.0,megan no macalystre,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.47,0.3,0.03,0.0,0.1,0.0,0.0,0.1,andrew mathas,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.67,0.23,0.03,0.0,0.07,0.0,0.0,0.0,megan no macalystre,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.5,0.33,0.03,0.03,0.07,0.0,0.0,0.03,andrew mathas,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.43,0.37,0.13,0.07,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.33,0.07,0.0,0.07,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,mari elena ramler,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.3,0.57,0.07,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,benjamin hudson,
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.8,0.1,0.03,0.0,0.03,0.0,0.0,0.03,benjamin hudson,
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,sharif youssef,
-ENGL,3010,1,Great Books of Western World,0.12,0.65,0.18,0.0,0.0,0.0,0.0,0.06,colin pearce,
-ENGL,3040,2,Business Writing,0.81,0.1,0.05,0.05,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3040,3,Business Writing,0.6,0.2,0.1,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,
-ENGL,3040,4,Business Writing,0.64,0.14,0.09,0.0,0.0,0.0,0.0,0.14,geveryl le robinson,
-ENGL,3040,5,Business Writing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3040,13,Business Writing,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,katalin beck,
-ENGL,3040,14,Business Writing,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,philip randall,
-ENGL,3040,16,Business Writing,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,emily anne boyter,
-ENGL,3040,17,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharif youssef,
-ENGL,3040,18,Business Writing,0.75,0.0,0.15,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,
-ENGL,3040,19,Business Writing,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3040,22,Business Writing,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,sharif youssef,
-ENGL,3040,400,Business Writing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,
-ENGL,3040,401,Business Writing,0.71,0.14,0.05,0.0,0.05,0.0,0.0,0.05,hayley ren zertuche,
-ENGL,3040,402,Business Writing,0.71,0.19,0.0,0.0,0.05,0.0,0.0,0.05,hayley ren zertuche,
-ENGL,3040,403,Business Writing,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,hayley ren zertuche,
-ENGL,3040,404,Business Writing,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,steph kartalopoulos,
-ENGL,3040,405,Business Writing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,
-ENGL,3040,406,Business Writing,0.6,0.3,0.0,0.05,0.0,0.0,0.0,0.05,steph kartalopoulos,
-ENGL,3040,407,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,
-ENGL,3100,1,Crit Writ Lit,0.38,0.48,0.1,0.0,0.05,0.0,0.0,0.0,david sweene coombs,
-ENGL,3100,2,Crit Writ Lit,0.19,0.33,0.14,0.1,0.14,0.0,0.0,0.1,william stockton,
-ENGL,3100,4,Crit Writ Lit,0.29,0.48,0.14,0.0,0.0,0.0,0.0,0.1,david sweene coombs,
-ENGL,3120,1,Advanced Composition,0.57,0.19,0.1,0.0,0.1,0.0,0.0,0.05,elizabeth stansell,
-ENGL,3120,2,Advanced Composition,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3140,1,Technical Writing,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,2,Technical Writing,0.74,0.22,0.0,0.0,0.04,0.0,0.0,0.0,nathan riggs,
-ENGL,3140,3,Technical Writing,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3140,4,Technical Writing,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,eric stephens,
-ENGL,3140,5,Technical Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,6,Technical Writing,0.67,0.24,0.0,0.1,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,7,Technical Writing,0.81,0.05,0.05,0.0,0.05,0.0,0.0,0.05,eric stephens,
-ENGL,3140,9,Technical Writing,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,10,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
-ENGL,3140,11,Technical Writing,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,3140,12,Technical Writing,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,3140,13,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,
-ENGL,3140,14,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,3140,15,Technical Writing,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,joshua wood,
-ENGL,3140,16,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,joshua wood,
-ENGL,3140,18,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3140,19,Technical Writing,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3140,25,Technical Writing,0.8,0.15,0.0,0.05,0.0,0.0,0.0,0.0,crystal pa stephens,
-ENGL,3150,1,Scientific Writing & Comm,0.47,0.26,0.16,0.05,0.0,0.0,0.0,0.05,william pulley,
-ENGL,3150,2,Scientific Writing & Comm,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3150,5,Scientific Writing & Comm,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,
-ENGL,3150,18,Scientific Writing & Comm,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,christopher benson,
-ENGL,3320,1,Visual Communication,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,sean williams,
-ENGL,3330,1,Writing News Media,0.47,0.33,0.07,0.0,0.13,0.0,0.0,0.0,geveryl le robinson,
-ENGL,3450,1,Structure of Fiction,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
-ENGL,3460,1,Structure of Poetry,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,candace wiley,
-ENGL,3480,1,Structure Screenplay,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
-ENGL,3540,1,Lit Middle East & North Africa,0.53,0.29,0.0,0.0,0.06,0.0,0.0,0.12,angela naimou,
-ENGL,3570,1,Film,0.05,0.7,0.15,0.0,0.05,0.0,0.0,0.05,amy monaghan,
-ENGL,3570,2,Film,0.06,0.61,0.17,0.0,0.11,0.0,0.0,0.06,amy monaghan,
-ENGL,3570,3,Film,0.05,0.79,0.11,0.0,0.05,0.0,0.0,0.0,amy monaghan,
-ENGL,3850,1,Children's Lit,0.74,0.11,0.0,0.05,0.05,0.0,0.0,0.05,megan no macalystre,
-ENGL,3970,1,Brit Lit Survey II,0.56,0.22,0.17,0.0,0.0,0.0,0.0,0.06,john morgenstern,
-ENGL,3980,1,Amer Lit Survey I,0.2,0.53,0.2,0.0,0.07,0.0,0.0,0.0,rhondda robi thomas,
-ENGL,3980,2,Amer Lit Survey I,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,susanna ashton,
-ENGL,3990,1,Amer Lit Survey II,0.68,0.11,0.16,0.0,0.0,0.0,0.0,0.05,walter edgar hunter,
-ENGL,3990,2,Amer Lit Survey II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,4070,1,Medieval Period,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,
-ENGL,4110,1,Shakespeare,0.48,0.29,0.0,0.0,0.14,0.0,0.0,0.1,elizabeth rivlin,
-ENGL,4110,2,Shakespeare,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,andrew lemons,
-ENGL,4110,3,Shakespeare,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4190,1,Post Col & World Lit,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,
-ENGL,4200,1,Amer Lit to 1799,0.5,0.3,0.0,0.0,0.1,0.0,0.0,0.1,jonathan beec field,
-ENGL,4250,1,American Novel,0.39,0.22,0.17,0.06,0.06,0.0,0.0,0.11,susanna ashton,
-ENGL,4320,1,Modern Fiction,0.39,0.44,0.06,0.0,0.06,0.0,0.0,0.06,gabriel and hankins,
-ENGL,4360,1,Feminist Literary Criticism,0.59,0.29,0.0,0.0,0.06,0.0,0.0,0.06,michelle renee ty,
-ENGL,4400,1,Literary Theory,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,michelle renee ty,
-ENGL,4420,1,Cultural Studies,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,gabriel and hankins,
-ENGL,4450,1,Fiction Workshop,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,4580,1,Adaptations of World Classics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,4650,1,Topics in Literature from 1900,0.67,0.11,0.06,0.0,0.11,0.0,0.0,0.06,garry bertholf,
-ENGL,4750,1,Writing for Media,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,jonathan beec field,
-ENGL,4780,1,Digital Literacy,0.76,0.06,0.06,0.0,0.06,0.0,0.0,0.06,megan eatman,
-ENGL,4890,1,Topics Write & Publ,0.78,0.06,0.0,0.0,0.06,0.0,0.0,0.11,jan rune holmevik,
-ENGL,4920,1,Modern Rhetoric,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,megan eatman,
-ENGL,4960,1,Senior Seminar,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,rhondda robi thomas,
-ENGL,4960,2,Senior Seminar,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,angela naimou,
-ENGL,4960,3,Senior Seminar,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,4960,4,Senior Seminar,0.42,0.25,0.25,0.0,0.0,0.0,0.0,0.08,william stockton,
-ENGR,1020,312,Engineering Discipl & Skills,0.07,0.22,0.3,0.15,0.07,0.0,0.0,0.19,bradley putman,
-ENGR,1020,317,Engineering Discipl & Skills,0.19,0.41,0.19,0.06,0.07,0.0,0.0,0.09,ashley childers,
-ENGR,1020,318,Engineering Discipl & Skills,0.06,0.44,0.31,0.06,0.11,0.0,0.0,0.02,ashley childers,
-ENGR,1060,242,Engr Discipline & Skills II,0.03,0.1,0.37,0.3,0.13,0.0,0.0,0.07,sarah grigg,
-ENGR,1060,312,Engr Discipline & Skills II,0.0,0.4,0.6,0.0,0.0,0.0,0.0,0.0,bradley putman,
-ENGR,1410,122,Programming & Problem Solving,0.31,0.38,0.27,0.02,0.0,0.0,0.0,0.02,matthew kent miller,
-ENGR,1410,321,Programming & Problem Solving,0.02,0.3,0.41,0.15,0.02,0.0,0.0,0.09,michael giebner,
-ENGR,1410,323,Programming & Problem Solving,0.22,0.46,0.22,0.09,0.0,0.0,0.0,0.02,mariah magagnotti,
-ENGR,1410,324,Programming & Problem Solving,0.22,0.37,0.3,0.09,0.0,0.0,0.0,0.02,irene marie ferrara,
-ENGR,1410,325,Programming & Problem Solving,0.33,0.33,0.2,0.09,0.02,0.0,0.0,0.04,steven brandon,
-ENGR,1410,326,Programming & Problem Solving,0.27,0.38,0.22,0.02,0.0,0.0,0.0,0.11,steven brandon,
-ENGR,1410,621,Programming & Problem Solving,0.25,0.3,0.25,0.08,0.03,0.0,0.0,0.1,william martin,
-ENGR,1410,622,Programming & Problem Solving,0.34,0.4,0.09,0.11,0.02,0.0,0.0,0.04,william martin,
-ENGR,1410,623,Programming & Problem Solving,0.43,0.49,0.09,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,
-ENGR,1410,624,Programming & Problem Solving,0.16,0.45,0.3,0.05,0.02,0.0,0.0,0.02,andrew isaa neptune,
-ENGR,1410,625,Programming & Problem Solving,0.15,0.59,0.13,0.04,0.0,0.0,0.0,0.09,matthew kent miller,
-ENGR,1410,626,Programming & Problem Solving,0.14,0.36,0.32,0.11,0.0,0.0,0.0,0.07,matthew kent miller,
-ENGR,1410,627,Programming & Problem Solving,0.21,0.55,0.17,0.02,0.02,0.0,0.0,0.02,sarah grigg,
-ENGR,1410,628,Programming & Problem Solving,0.09,0.56,0.24,0.09,0.0,0.0,0.0,0.03,sarah grigg,
-ENGR,1410,821,Programming & Problem Solving,0.13,0.39,0.19,0.16,0.03,0.0,0.0,0.1,andrew isaa neptune,
-ENGR,1410,822,Programming & Problem Solving,0.33,0.33,0.26,0.04,0.0,0.0,0.0,0.04,andrew isaa neptune,
-ENGR,1410,823,Program & Prob Solving (HON),0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,john minor,True
-ENGR,1410,824,Program & Prob Solving (HON),0.44,0.53,0.03,0.0,0.0,0.0,0.0,0.0,jonathan maier,True
-ENGR,1410,825,Programming & Problem Solving,0.16,0.38,0.31,0.09,0.0,0.0,0.0,0.07,mariah magagnotti,
-ENGR,1410,826,Programming & Problem Solving,0.11,0.37,0.41,0.02,0.02,0.0,0.0,0.07,mariah magagnotti,
-ENGR,1410,827,Programming & Problem Solving,0.13,0.6,0.27,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,
-ENGR,1410,828,Programming & Problem Solving,0.15,0.35,0.24,0.24,0.0,0.0,0.0,0.03,irene marie ferrara,
-ENGR,1640,500,Engineering MATLAB Programming,0.14,0.43,0.29,0.14,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,1640,501,Engineering MATLAB Programming,0.05,0.35,0.25,0.2,0.15,0.0,0.0,0.0,jonathan maier,
-ENGR,2080,382,Engr Graphics & Machine Design,0.68,0.26,0.0,0.04,0.0,0.0,0.0,0.02,john minor,
-ENGR,2080,384,Engr Graphics & Machine Design,0.61,0.21,0.04,0.02,0.09,0.0,0.0,0.04,anthony pau garland,
-ENGR,2080,385,Engr Graphics & Machine Design,0.49,0.19,0.14,0.04,0.07,0.0,0.0,0.07,anthony pau garland,
-ENGR,2080,686,Engr Graphics & Machine Design,0.55,0.23,0.13,0.02,0.04,0.0,0.0,0.04,garrison llo broome,
-ENGR,2080,881,Engr Graphics & Machine Design,0.47,0.33,0.09,0.03,0.07,0.0,0.0,0.02,amaninder sing gill,
-ENGR,2080,882,Engr Graphics & Machine Design,0.63,0.28,0.05,0.02,0.02,0.0,0.0,0.0,amaninder sing gill,
-ENGR,2080,884,Engr Graphics & Machine Design,0.66,0.23,0.05,0.0,0.04,0.0,0.0,0.02,nighat yasmin,
-ENGR,2080,885,Engr Graphics & Machine Design,0.61,0.29,0.05,0.02,0.04,0.0,0.0,0.0,sarah rowlinson,
-ENGR,2080,886,Engr Graphics & Machine Design,0.5,0.29,0.11,0.04,0.05,0.0,0.0,0.02,sarah rowlinson,
-ENGR,2100,601,CAD & Engineering Applications,0.67,0.19,0.13,0.0,0.02,0.0,0.0,0.0,nighat yasmin,
-ENGR,2100,602,CAD & Engineering Applications,0.56,0.25,0.13,0.0,0.02,0.0,0.0,0.04,nighat yasmin,
-ENGR,2100,604,CAD & Engineering Applications,0.56,0.32,0.08,0.0,0.02,0.0,0.0,0.02,trent hou dellinger,
-ENGR,2100,605,CAD & Engineering Applications,0.65,0.29,0.04,0.0,0.02,0.0,0.0,0.0, shams esfandabadi,
-ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.15,0.06,0.02,0.02,0.0,0.0,0.04,russell barrett,
-ENR,3020,1,Nat Res Measurements,0.68,0.24,0.05,0.03,0.0,0.0,0.0,0.0,lawrence gering,
-ENR,4130,2,Restoration Ecology,0.17,0.47,0.19,0.14,0.03,0.0,0.0,0.0,althea simone hagan,
-ENR,4500,1,Conservation Issues,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
-ENR,4500,2,Conservation Issues,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
-ENSP,2000,1,Intro Environ Sci,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,tom owino,
-ENSP,2000,2,Intro Environ Sci,0.72,0.23,0.02,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,
-ENSP,2000,3,Intro Environ Sci,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2010,1,Environm Sci for Educ Majors,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENT,2000,1,Six-Legged Science,0.49,0.33,0.14,0.0,0.0,0.0,0.0,0.05,suellen pometto,
-ENT,2010,1,Animated Insects,0.92,0.05,0.03,0.0,0.0,0.0,0.0,0.0,joseph culin,
-ENTR,1010,1,Entrepreneurial Mindset,0.5,0.28,0.06,0.05,0.08,0.0,0.0,0.04,john michael hannon,
-ENTR,1040,1,Technology Entrepreneurship,0.55,0.31,0.03,0.0,0.1,0.0,0.0,0.0,john michael hannon,
-ESED,8210,1,Teaching Undergraduate Science,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,jennifer van dyken,
-ETOX,6370,1,Ecotoxicology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,peter van den hurk,
-FCS,8110,1,Hum Dev & Fam Life,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,susan limber,
-FCS,8340,1,Research Methods in FCS II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,
-FDSC,1020,1,Persp Food Nutrition,0.94,0.0,0.0,0.03,0.0,0.0,0.0,0.03,john mcgregor,
-FDSC,2140,1,Fd Resources & Soc,0.49,0.36,0.08,0.04,0.0,0.0,0.0,0.04,paul dawson,
-FDSC,2150,1,Culinary Fundamental,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,aubrey dean coffee,
-FDSC,3040,1,Eval Dairy Products,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john mcgregor,
-FDSC,3060,1,Institutional Food Service Mgt,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,
-FDSC,4020,1,Food Chemistry II,0.46,0.48,0.04,0.0,0.0,0.0,0.0,0.02,feng chen,
-FDSC,4030,1,Food Ch & Analysis,0.7,0.19,0.09,0.02,0.0,0.0,0.0,0.0,paul dawson,
-FDSC,4080,1,Food Process Eng,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,felix barron,
-FDSC,4090,1,TQM for Food & Pckg Industries,0.54,0.32,0.1,0.02,0.0,0.0,0.0,0.02,john mcgregor,
-FIN,2010,401,Intro to Personal Finance,0.68,0.18,0.04,0.04,0.0,0.0,0.0,0.07,joshua harris,
-FIN,2010,402,Intro to Personal Finance,0.69,0.21,0.0,0.07,0.0,0.0,0.0,0.03,joshua harris,
-FIN,2010,403,Intro to Personal Finance,0.27,0.62,0.08,0.0,0.0,0.0,0.0,0.04,joshua harris,
-FIN,2010,404,Intro to Personal Finance,0.69,0.18,0.02,0.02,0.02,0.0,0.0,0.07,joshua harris,
-FIN,2010,405,Intro to Personal Finance,0.64,0.17,0.03,0.06,0.11,0.0,0.0,0.0,joshua harris,
-FIN,2010,406,Intro to Personal Finance,0.73,0.08,0.12,0.0,0.08,0.0,0.0,0.0,joshua harris,
-FIN,3040,1,Risk & Insurance,0.28,0.17,0.44,0.0,0.06,0.0,0.0,0.06,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.18,0.34,0.26,0.13,0.05,0.0,0.0,0.03,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.13,0.32,0.39,0.08,0.03,0.0,0.0,0.05,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.3,0.33,0.25,0.08,0.03,0.0,0.0,0.03,kerri mcmillan,
-FIN,3060,1,Corporation Finance,0.25,0.15,0.18,0.2,0.2,0.0,0.0,0.03,william hol johnson,
-FIN,3060,2,Corporation Finance,0.39,0.16,0.13,0.16,0.03,0.0,0.0,0.13,william hol johnson,
-FIN,3060,3,Corporation Finance,0.31,0.13,0.17,0.22,0.06,0.0,0.0,0.11,william hol johnson,
-FIN,3060,4,Corporation Finance,0.08,0.25,0.34,0.17,0.08,0.0,0.0,0.08,ramon tolb franklin,
-FIN,3060,5,Corporation Finance,0.14,0.17,0.41,0.14,0.08,0.0,0.0,0.05,ramon tolb franklin,
-FIN,3060,6,Corporation Finance,0.25,0.25,0.38,0.05,0.0,0.0,0.0,0.06,ramon tolb franklin,
-FIN,3060,8,Corporation Finance,0.19,0.41,0.26,0.11,0.04,0.0,0.0,0.0,minxing sun,
-FIN,3070,1,Prin of Real Estate,0.28,0.44,0.21,0.03,0.03,0.0,0.0,0.03,yannan shen,
-FIN,3070,2,Prin of Real Estate,0.26,0.45,0.24,0.0,0.03,0.0,0.0,0.03,yannan shen,
-FIN,3070,3,Prin of Real Estate,0.16,0.39,0.45,0.0,0.0,0.0,0.0,0.0,thomas springer,
-FIN,3080,1,Fin Inst & Mkts,0.14,0.51,0.29,0.06,0.0,0.0,0.0,0.0,daniel thoma greene,
-FIN,3080,2,Fin Inst & Mkts,0.23,0.43,0.25,0.1,0.0,0.0,0.0,0.0,daniel thoma greene,
-FIN,3080,3,Fin Inst & Mkts,0.33,0.31,0.31,0.05,0.0,0.0,0.0,0.0,daniel thoma greene,
-FIN,3110,1,Financial Management I,0.12,0.31,0.21,0.17,0.05,0.0,0.0,0.14,george bra lockhart,
-FIN,3110,2,Financial Management I,0.11,0.38,0.19,0.08,0.11,0.0,0.0,0.14,george bra lockhart,
-FIN,3110,3,Financial Management I,0.12,0.32,0.15,0.24,0.05,0.0,0.0,0.12,george bra lockhart,
-FIN,3110,4,Financial Management I,0.12,0.19,0.26,0.1,0.1,0.0,0.0,0.24,john alexander,
-FIN,3120,1,Financial Management II,0.16,0.2,0.24,0.16,0.04,0.0,0.0,0.2,blerina zykaj,
-FIN,3120,2,Financial Management II,0.31,0.19,0.39,0.0,0.0,0.0,0.0,0.11,blerina zykaj,
-FIN,3120,3,Financial Management II,0.26,0.34,0.26,0.14,0.0,0.0,0.0,0.0,weike xu,
-FIN,3120,4,Financial Management II,0.18,0.45,0.18,0.06,0.0,0.0,0.0,0.12,weike xu,
-FIN,4030,1,Spreadsheet Apps in Finance,0.17,0.47,0.31,0.06,0.0,0.0,0.0,0.0,vincent intintoli,
-FIN,4030,2,Spreadsheet Apps in Finance,0.25,0.36,0.25,0.06,0.06,0.0,0.0,0.03,vincent intintoli,
-FIN,4040,2,Financial Modeling,0.13,0.39,0.43,0.04,0.0,0.0,0.0,0.0,jack wolf,
-FIN,4050,1,Portfolio Management & Theory,0.1,0.28,0.45,0.17,0.0,0.0,0.0,0.0,john alexander,
-FIN,4080,1,Mgt of Fin Inst,0.21,0.71,0.07,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4080,2,Mgt of Fin Inst,0.18,0.68,0.09,0.05,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4110,1,Int Fin Mgt,0.25,0.38,0.35,0.03,0.0,0.0,0.0,0.0,luke asher devault,
-FIN,4110,2,Int Fin Mgt,0.19,0.53,0.25,0.0,0.0,0.0,0.0,0.03,luke asher devault,
-FIN,4150,1,Real Estate Investmt,0.18,0.36,0.41,0.05,0.0,0.0,0.0,0.0,thomas springer,
-FIN,4160,1,Real Estate Val,0.26,0.61,0.09,0.0,0.0,0.0,0.0,0.04,ramon tolb franklin,
-FNR,4700,10,Kennedy Wtrfowl & Wetland Intn,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,richard ma kaminski,
-FNR,4990,1,Natural Resources Seminar,0.78,0.06,0.06,0.0,0.06,0.0,0.0,0.06,susan talley guynn,
-FNR,4990,3,Natural Resources Seminar,0.68,0.09,0.05,0.14,0.05,0.0,0.0,0.0,susan talley guynn,
-FOR,1010,1,Intro to Forestry,0.79,0.1,0.0,0.05,0.0,0.0,0.0,0.05,lawrence gering,
-FOR,2060,1,Forestry Ecology,0.26,0.4,0.18,0.07,0.04,0.0,0.0,0.06,donald hagan,
-FOR,3080,1,Remote Sensing in Forestry,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,lawrence gering,
-FOR,4060,1,Forested Watershed Mgmt,0.97,0.01,0.01,0.0,0.0,0.0,0.0,0.0,thomas adam coates,
-FOR,4080,1,Wood and Paper Products,0.48,0.45,0.03,0.03,0.0,0.0,0.0,0.0,patricia layton,
-FOR,4150,1,Forest Wildlife Managment,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,james davis,
-FOR,4180,1,Forest Resource Valuation,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4340,1,GIS for Natural Resources,0.48,0.41,0.09,0.02,0.0,0.0,0.0,0.0,robert frit baldwin,
-FOR,4650,1,Silviculture,0.27,0.47,0.2,0.07,0.0,0.0,0.0,0.0,gaofeng wang,
-FR,1010,1,Elementary French,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,1010,2,Elementary French,0.39,0.39,0.06,0.06,0.06,0.0,0.0,0.06,kenneth dav widgren,
-FR,1020,2,Elementary French,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,
-FR,1020,3,Elementary French,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,2,Intermediate French,0.42,0.17,0.25,0.0,0.0,0.0,0.0,0.17,anne salces  nedeo,
-FR,2010,3,Intermediate French,0.8,0.05,0.1,0.0,0.0,0.0,0.0,0.05,kelly digby peebles,
-FR,2010,4,Intermediate French,0.25,0.38,0.19,0.0,0.06,0.0,0.0,0.13,erin shevau stigers,
-FR,2020,1,Intermediate French,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,erin shevau stigers,
-FR,2020,4,Intermediate French,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,
-FR,3050,1,Int Fr Con & Comp I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,
-FR,3170,1,Contemp French Civ,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,eric touya,
-GC,1010,1,Orientation to G C,0.84,0.04,0.02,0.0,0.02,0.0,0.0,0.07,kern cox,
-GC,1020,1,Computer Art & CAD Foundations,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,carol jones,
-GC,1030,1,G C I for Pkgsc,0.28,0.53,0.13,0.0,0.08,0.0,0.0,0.0,john jacobs,
-GC,1040,1,Graphic Communications I,0.54,0.39,0.01,0.01,0.03,0.0,0.0,0.01,rebecca suza edlein,
-GC,2070,1,Graphic Communications II,0.63,0.26,0.04,0.0,0.04,0.0,0.0,0.04,charles tabor weiss,
-GC,3400,1,Digital Imaging and eMedia,0.36,0.47,0.14,0.0,0.03,0.0,0.0,0.0,erica black walker,
-GC,3460,1,Ink and Substrates,0.32,0.53,0.12,0.02,0.02,0.0,0.0,0.0,michelle suki  fox,
-GC,4060,1,Package and Specialty Printing,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,kern cox,
-GC,4400,1,Commercial Printing,0.3,0.53,0.1,0.0,0.07,0.0,0.0,0.0,eric weisenmiller,
-GC,4440,1,Current Dev/Trends in Gr Comm,0.65,0.23,0.13,0.0,0.0,0.0,0.0,0.0,samuel ingram,
-GC,4480,1,Plan & Cont Printing Functions,0.41,0.5,0.09,0.0,0.0,0.0,0.0,0.0,john leininger,
-GC,4800,1,Senior Seminar in GC,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,
-GC,4900,2,G C Selected Topics-Sales,0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,john leininger,
-GC,4900,5,GC Selected Topics-Concept Pkg,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,john jacobs,
-GEN,3000,1,Fundamental Genetics,0.28,0.4,0.25,0.03,0.0,0.0,0.0,0.05,kate leanne wi tsai,
-GEN,3000,2,Fundamental Genetics,0.24,0.37,0.2,0.1,0.02,0.0,0.0,0.07,kate leanne wi tsai,
-GEN,3020,1,Molecular & General Genetics,0.39,0.24,0.22,0.02,0.05,0.0,0.0,0.07,lukasz kozubowski,
-GEN,4100,1,Population & Quant Genetics,0.44,0.26,0.23,0.05,0.03,0.0,0.0,0.0,amy lou lawton rauh,
-GEN,4110,1,Population & Quant Gen Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,
-GEN,4400,1,Bioinformatics,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,liangjiang wang,
-GEN,4700,1,Human Genetics,0.45,0.27,0.22,0.0,0.0,0.0,0.0,0.06,leigh anne clark,
-GEN,6700,1,Human Genetics,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,leigh anne clark,
-GEOG,1010,1,Intro to Geography,0.18,0.32,0.24,0.21,0.06,0.0,0.0,0.0,christa smith,
-GEOG,1030,1,World Regional Geography,0.91,0.05,0.01,0.02,0.01,0.0,0.0,0.02,lance forres howard,
-GEOG,1030,2,World Regional Geography,0.52,0.3,0.09,0.0,0.03,0.0,0.0,0.06,william churc terry,
-GEOG,4400,1,Geog of Hist Preserv,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,christa smith,
-GEOL,1010,1,Physical Geology,0.39,0.27,0.21,0.04,0.08,0.0,0.0,0.02,alan coulson,
-GEOL,1010,2,Physical Geology,0.43,0.29,0.17,0.06,0.02,0.0,0.0,0.02,alan coulson,
-GEOL,1030,1,Physical Geol Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.33,0.42,0.21,0.04,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.58,0.29,0.04,0.08,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.42,0.38,0.13,0.04,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.63,0.25,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.75,0.08,0.04,0.0,0.04,0.0,0.0,0.08,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.87,0.09,0.0,0.0,0.04,0.0,0.0,0.0,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.37,0.32,0.26,0.0,0.05,0.0,0.0,0.0,alan coulson,
-GEOL,1120,1,Earth Resources,0.46,0.37,0.14,0.02,0.0,0.0,0.0,0.02,scott brame,
-GEOL,1140,1,Earth Resources Lab,0.54,0.29,0.09,0.09,0.0,0.0,0.0,0.0,scott brame,
-GEOL,2020,1,Earth History,0.05,0.37,0.26,0.16,0.05,0.0,0.0,0.11,alan coulson,
-GEOL,4050,1,Surficial Geology,0.41,0.18,0.35,0.06,0.0,0.0,0.0,0.0,james castle,
-GEOL,4210,1,Gis in Geology,0.63,0.22,0.15,0.0,0.0,0.0,0.0,0.0,scott brame,
-GEOL,4920,1,Resrch Synthesis II,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,7900,501,Biogeography & Geology of SC,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
-GEOL,8090,1,Subsurface Remed Mod,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,
-GER,1010,1,Elementary German,0.19,0.25,0.25,0.06,0.06,0.0,0.0,0.19, lee ferrell,
-GER,1010,2,Elementary German,0.35,0.24,0.06,0.06,0.0,0.0,0.0,0.29, lee ferrell,
-GER,1020,1,Elementary German,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05,oswald harris king,
-GER,1020,2,Elementary German,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,2010,1,Intermediate German,0.05,0.42,0.37,0.0,0.0,0.0,0.0,0.16, lee ferrell,
-GER,2020,1,Intermediate German,0.31,0.31,0.15,0.23,0.0,0.0,0.0,0.0,gabriela stoicea,
-GER,2020,2,Intermediate German,0.36,0.29,0.14,0.07,0.14,0.0,0.0,0.0, lee ferrell,
-GER,3060,1,German Short Story,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-HCC,8810,1,Measurement & Eval,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,bart knijnenburg,
-HCG,9090,1,Lab Methods in Healthcare Gen,0.0,0.0,0.0,0.0,0.0,0.67,0.0,0.33,patricia leota tate,
-HCG,9890,400,Sel Topics-Dev Research Propos,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,julia eggert,
-HIST,1240,1,Environmental History Survey,0.17,0.47,0.21,0.03,0.06,0.0,0.0,0.05,james brad jeffries,
-HIST,1720,3,The West and the World I,0.15,0.39,0.37,0.07,0.0,0.0,0.0,0.02,caroline dunn clark,
-HIST,1730,1,The West and the World II,0.16,0.41,0.2,0.05,0.15,0.0,0.0,0.04, alan grubb,
-HIST,1730,2,The West and the World II,0.23,0.44,0.2,0.02,0.04,0.0,0.0,0.07,subah dayal,
-HIST,1730,3,The West and the World II,0.21,0.52,0.18,0.03,0.01,0.0,0.0,0.05,steven marks,
-HIST,2990,1,Historian's Craft,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,michael silvestri,
-HIST,2990,2,Historian's Craft,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carney,
-HIST,3000,1,History of Colonial America,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,lee brady wilson,
-HIST,3080,1,US: Reagan/Clinton 1975-Pres,0.23,0.5,0.23,0.03,0.0,0.0,0.0,0.0,meg taylor-shockley,
-HIST,3100,1,History of Religion in the US,0.24,0.35,0.24,0.06,0.06,0.0,0.0,0.06,elizabeth jemison,
-HIST,3110,1,African American Hist to 1877,0.42,0.28,0.16,0.02,0.07,0.0,0.0,0.05,abel bartley,
-HIST,3170,1,Hist of Nat. Am. Relig/Culture,0.25,0.4,0.15,0.05,0.1,0.0,0.0,0.05,james brad jeffries,
-HIST,3210,1,History of Science,0.26,0.58,0.1,0.0,0.03,0.0,0.0,0.03,pamela mack,
-HIST,3240,1,Hist of the South II,0.33,0.55,0.03,0.0,0.0,0.0,0.0,0.09,john andrew,
-HIST,3260,1,Hist Am Transport,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0, roger grant,
-HIST,3330,1,Hist of Mod Japan,0.24,0.39,0.24,0.03,0.08,0.0,0.0,0.03,edwin moise,
-HIST,3390,1,Africa 1875-Present,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,james burns,
-HIST,3420,1,South Am Since 1800,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
-HIST,3520,1,Pharaonic Egypt,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carney,
-HIST,3900,1,Modern Military History,0.23,0.33,0.27,0.07,0.03,0.0,0.0,0.07,edwin moise,
-HIST,3970,1,Modern Middle East,0.38,0.45,0.17,0.0,0.0,0.0,0.0,0.0,amit bein,
-HIST,4170,1,History and Tourism,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,meg taylor-shockley,
-HIST,4700,1,History of Florence,0.32,0.42,0.11,0.0,0.0,0.0,0.0,0.16,thomas kuehn,
-HIST,4880,1,Middle Eastern Society&Culture,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
-HIST,4900,1,Food & Pre-Industrial World,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,
-HIST,4900,2,Brexit Euro Union Memory WWars,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,stephani barczewski,
-HIST,4940,2,Slavery & Freedom ATL World,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
-HIST,4960,1,European Legal History,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,thomas kuehn,
-HIST,8810,1,Historiography,0.6,0.0,0.0,0.0,0.2,0.0,0.0,0.2,stephani barczewski,
-HLTH,2020,1,Introduction to Public Health,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,2,Introduction to Public Health,0.7,0.28,0.03,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,400,Introduction to Public Health,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,frederic fraizer,
-HLTH,2030,2,Health Care Sys,0.52,0.36,0.12,0.0,0.0,0.0,0.0,0.0,frederic fraizer,
-HLTH,2030,3,Health Care Sys,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-HLTH,2030,400,Health Care Sys,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2400,1,Deter of Hlth Behav,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2400,2,Deter of Hlth Behav,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.05,amelia clinkscales,
-HLTH,2600,1,Medical Terminology & Comm,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,karen edwards,
-HLTH,2980,1,Human Hlth & Disease,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,2980,2,Human Hlth & Disease,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,3030,1,Public Health Comm,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
-HLTH,3050,1,Body Resp Hlth Beh,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,brian patric graves,
-HLTH,3800,1,Epidemiology,0.38,0.42,0.17,0.04,0.0,0.0,0.0,0.0,hugh spitler,
-HLTH,3800,2,Epidemiology,0.6,0.24,0.04,0.04,0.04,0.0,0.0,0.04,deborah alma falta,
-HLTH,3980,2,Health Appraisal Skills,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4000,2,Drug Epi & Opiate Epidemic,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-HLTH,4000,3,Public Hlth Social Marketing,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,debra mitch charles,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.83,0.15,0.0,0.02,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4310,1,Public & Environ Hlt,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,4600,1,Health Info Systems,0.57,0.29,0.07,0.0,0.07,0.0,0.0,0.0,deborah alma falta,
-HLTH,4700,1,Global Health,0.71,0.18,0.07,0.0,0.04,0.0,0.0,0.0,rachel mayo,
-HLTH,4780,1,Health Policy Ethics and Law,0.39,0.26,0.17,0.09,0.04,0.0,0.0,0.04,hugh spitler,
-HLTH,4790,1,Fin Mgmt & Hlth Budg,0.63,0.17,0.17,0.0,0.04,0.0,0.0,0.0,lingling zhang,
-HLTH,4800,1,Comm Hlth Promotion,0.54,0.41,0.0,0.0,0.02,0.0,0.0,0.02,sarah griffin,
-HLTH,4900,1,Res Eval St Pub Hlth,0.76,0.16,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,
-HLTH,4900,2,Res Eval St Pub Hlth,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,jeffrey kingree,
-HLTH,4900,3,Res Eval St Pub Hlth,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,8110,1,Health Care Delivery Systems,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
-HLTH,8130,400,Population Health and Research,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,
-HLTH,8130,500,Population Health and Research,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,
-HLTH,8210,500,Health Research I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,joel edwar williams,
-HLTH,8310,1,Quantitative Analy in Hlth I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,
-HON,2060,1,Intro to Nanotechnology,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,
-HON,2200,4,The Empire World,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,michael silvestri,
-HON,2210,2,Russian Film History,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,
-HON,2210,4,Soderbergh's Cinema,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-HON,2220,2,Holocaust and Eichmann Trial,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,
-HORT,2020,1,Adobe Digital Design,0.86,0.09,0.0,0.03,0.0,0.0,0.0,0.03,janice ann lay,
-HORT,2110,1,Growing Spring Plnts,0.35,0.4,0.2,0.0,0.0,0.0,0.0,0.05,james emerson faust,
-HORT,4040,1,Plant Propagation,0.13,0.45,0.24,0.11,0.03,0.0,0.0,0.05,jeffrey adelberg,
-HORT,4050,2,Plant Propagation Techniq Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey adelberg,
-HORT,4200,1,Applied Turf Physiol,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
-HORT,4270,1,Urban Tree Care,0.04,0.31,0.31,0.27,0.0,0.0,0.0,0.08,robert polomski,
-HORT,4330,1,Turf Weed Management,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,ted whitwell,
-HORT,4560,1,Vegetable Crops,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,
-HORT,6040,1,Plant Propagation,0.29,0.43,0.0,0.0,0.29,0.0,0.0,0.0,jeffrey adelberg,
-HP,8280,1,Case St in Preservation Engr,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,craig mille bennett,
-HP,8920,200,Special Topics in Hist Preserv,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0,richard gra gilmore,
-HRD,8250,400,Org Perf Improvement,0.87,0.08,0.05,0.0,0.0,0.0,0.0,0.0,philip mcgee,
-HRD,8470,400,Instru System Design,0.74,0.05,0.05,0.0,0.11,0.0,0.0,0.05,eileen newmark,
-HRD,8800,400,Research Concepts,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,cynthia sims,
-IE,2000,1,Soph Seminar in I E,0.51,0.15,0.12,0.2,0.0,0.0,0.0,0.02,brian melloy,
-IE,2100,1,Des Analysis Wrk Sys,0.16,0.36,0.24,0.09,0.04,0.0,0.0,0.1,sara lu riggs,
-IE,2800,1,Deterministic Operations Rsrch,0.08,0.23,0.25,0.22,0.18,0.0,0.0,0.05,amin khademi,
-IE,3010,1,Systems Design I,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,joel greenstein,
-IE,3600,1,Industrial Apps of Prob/Stat I,0.47,0.26,0.16,0.05,0.05,0.0,0.0,0.0,mary elizabeth kurz,
-IE,3610,1,Industrial App of Prob/Stat II,0.26,0.35,0.28,0.06,0.03,0.0,0.0,0.01,sandra dun eksioglu,
-IE,3810,1,Probabilistic Operations Rsrch,0.14,0.37,0.32,0.12,0.05,0.0,0.0,0.0,burak eksioglu,
-IE,3840,1,Engr Econ Analysis,0.42,0.22,0.1,0.02,0.07,0.0,0.0,0.17,brian melloy,
-IE,3860,1,Prod Plan & Cont,0.56,0.27,0.11,0.02,0.01,0.0,0.0,0.02,jonathan lowe,
-IE,4300,1,Human Fact Engr in Healthcare,0.69,0.29,0.02,0.0,0.0,0.0,0.0,0.0,david neyens,
-IE,4400,1,Decision Support Sys,0.3,0.35,0.18,0.12,0.04,0.0,0.0,0.01,sandra dun eksioglu,
-IE,4610,1,Quality Engineering,0.22,0.22,0.15,0.27,0.07,0.0,0.0,0.07,robert james riggs,
-IE,4620,1,Six Sigma Quality,0.17,0.37,0.36,0.08,0.0,0.0,0.0,0.03,robert james riggs,
-IE,4650,1,Facilities Planning & Design,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,nadeepa wickramage,
-IE,4670,1,System Design II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-IE,4670,2,System Design II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-IE,4820,1,Systems Modeling,0.41,0.31,0.09,0.13,0.03,0.0,0.0,0.03,tugce isik,
-IE,4880,1,Human Factors Eng,0.34,0.51,0.14,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,
-IE,6620,1,Six Sigma Quality,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
-IE,6820,1,Systems Modeling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tugce isik,
-IE,6840,1,Applied Engineering Economics`,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nadeepa wickramage,
-IE,8020,1,Human Comp Sys,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,joel greenstein,
-IE,8050,1,Found Qual Engr,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,byung rae cho,
-IE,8520,1,Prescriptive Analytics,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,jonathan cole smith,
-IE,8540,1,SC & Logistics Modeling I,0.65,0.26,0.0,0.0,0.09,0.0,0.0,0.0,william ferrell,
-IE,8580,1,Case Study Supply Chn & Logist,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-IE,8870,1,Model Logist Behav Simulation,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.06,0.03,caren kelley-hall,
-INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.89,0.09,0.03,caren kelley-hall,
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.02,caren kelley-hall,
-INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.89,0.09,0.02,caren kelley-hall,
-INT,2010,1,Off-Campus Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,katherine el horner,
-INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.89,0.11,0.0,caren kelley-hall,
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,uttiyo raychaudhuri,
-IS,1010,2,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,uttiyo raychaudhuri,
-ITAL,1010,1,Elementary Italian,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,lyudmyla tsykalova,
-ITAL,1010,2,Elementary Italian,0.42,0.26,0.11,0.05,0.05,0.0,0.0,0.11,julia schmidt,
-ITAL,1020,2,Elementary Italian,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-ITAL,2020,1,Intermediate Italian,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
-JAPN,1010,1,Elementary Japanese,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,saori suto,
-JAPN,1010,2,Elementary Japanese,0.2,0.4,0.2,0.0,0.07,0.0,0.0,0.13,saori suto,
-JAPN,1020,1,Elementary Japanese,0.16,0.16,0.32,0.0,0.11,0.0,0.0,0.26,toshiko joerger,
-JAPN,2020,1,Intermed Japanese,0.47,0.13,0.33,0.07,0.0,0.0,0.0,0.0,saori suto,
-JAPN,4170,1,Japanese Culture and Society,0.53,0.21,0.0,0.21,0.05,0.0,0.0,0.0,jae allegr takeuchi,
-JUST,2880,1,The Criminal Justice System,0.39,0.22,0.35,0.04,0.0,0.0,0.0,0.0,margaret tina britz,
-JUST,2890,1,Criminology,0.3,0.35,0.15,0.0,0.15,0.0,0.0,0.05,william white,
-JUST,4910,1,Policing,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,william white,
-JUST,4930,1,Corrections,0.39,0.43,0.07,0.04,0.0,0.0,0.0,0.07,william white,
-JUST,4940,1,Organized Crime,0.28,0.48,0.24,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
-LANG,2540,1,Introduction to World Cinemas,0.67,0.24,0.0,0.0,0.05,0.0,0.0,0.05,raquel anido,
-LARC,1160,1,History of Landscape Arch,0.3,0.47,0.16,0.01,0.01,0.0,0.0,0.05,hala fouad nassar,
-LARC,1160,2,History of Landscape Arch,0.69,0.19,0.08,0.04,0.0,0.0,0.0,0.0,martin john holland,
-LARC,1520,1,Basic Design II,0.46,0.42,0.08,0.04,0.0,0.0,0.0,0.0,paul russell,
-LARC,2550,1,Community Design Studio,0.78,0.0,0.17,0.0,0.06,0.0,0.0,0.0,martin john holland,
-LARC,3620,1,Design Impl II,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,paul russell,
-LARC,4280,1,Computer-Aided Design,0.85,0.04,0.12,0.0,0.0,0.0,0.0,0.0,yang song,
-LARC,6810,1,Professional Practice,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,david lycke,
-LAW,3220,1,Legal Env of Bus,0.14,0.51,0.29,0.04,0.02,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,2,Legal Env of Bus,0.47,0.36,0.11,0.07,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,3,Legal Env of Bus,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,4,Legal Env of Bus,0.4,0.42,0.16,0.02,0.0,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,5,Legal Env of Bus,0.27,0.2,0.36,0.16,0.02,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,6,Legal Env of Bus,0.31,0.47,0.16,0.04,0.02,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,7,Legal Env of Bus,0.09,0.55,0.32,0.02,0.02,0.0,0.0,0.0,judson jahn,
-LAW,3220,8,Legal Env of Bus,0.22,0.38,0.27,0.09,0.04,0.0,0.0,0.0,kenneth toussaint,
-LAW,3220,9,Legal Env of Bus,0.49,0.36,0.13,0.0,0.0,0.0,0.0,0.02,kath kisska-schulze,
-LAW,3220,10,Legal Env of Bus,0.33,0.38,0.27,0.02,0.0,0.0,0.0,0.0,john hine,
-LAW,3220,11,Legal Env of Bus,0.16,0.42,0.27,0.09,0.02,0.0,0.0,0.04,john hine,
-LAW,3220,401,Legal Env of Bus,0.27,0.31,0.23,0.06,0.06,0.0,0.0,0.06,virgini ward-vaughn,
-LAW,3220,402,Legal Env of Bus,0.21,0.46,0.13,0.08,0.06,0.0,0.0,0.06,virgini ward-vaughn,
-LAW,3220,403,Legal Env of Bus,0.19,0.43,0.17,0.04,0.11,0.0,0.0,0.06,virgini ward-vaughn,
-LAW,3220,404,Legal Env of Bus,0.13,0.33,0.27,0.07,0.07,0.0,0.0,0.13,virgini ward-vaughn,
-LAW,3330,1,Real Estate Law,0.18,0.51,0.22,0.02,0.0,0.0,0.0,0.07,judson jahn,
-LAW,8480,1,Law Real Estate Prof,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james ivey warren,
-LIB,2990,1,Creative Inq - The Libraries,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert wilmott,
-LIH,4000,35,Internship Abroad,0.0,0.0,0.0,0.0,0.0,0.79,0.21,0.0,juana martin-armas,
-LS,1000,2,Fitness Leadership,0.82,0.0,0.0,0.09,0.0,0.0,0.0,0.09,patricia figueroa,
-LS,1000,9,Intro to Salsa Dance,0.85,0.05,0.0,0.05,0.0,0.0,0.0,0.05,malik lewis baxter,
-LS,1000,10,Intro to Salsa Dance,0.9,0.0,0.1,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,
-LS,1000,11,Shotgun II,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,edward licus prater,
-LS,1000,12,Intermediate Rock Climbing,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,corey newe winstead,
-LS,1000,17,A.C.E. Personal Trainer Prep,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,corey dou brookover,
-LS,1000,20,Intro to Volleyball,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,kelly lynn ator,
-LS,1000,23,Therapeutic Yoga,0.75,0.05,0.05,0.0,0.05,0.0,0.0,0.1,ranjanbala dil amin,
-LS,1000,24,Therapeutic Yoga,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,ranjanbala dil amin,
-LS,1000,25,Therapeutic Yoga,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,1000,26,Therapeutic Yoga,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
-LS,1000,27,Beg. Non-Competitive Karate,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,june pilcher,
-LS,1410,1,Top Rope Climbing,0.79,0.07,0.0,0.0,0.14,0.0,0.0,0.0,michelle tuday,
-LS,1410,3,Top Rope Climbing,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,michelle tuday,
-LS,1410,5,Top Rope Climbing,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,michelle tuday,
-LS,1410,6,Top Rope Climbing,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,michelle tuday,
-LS,1410,8,Top Rope Climbing,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,corey newe winstead,
-LS,1450,5,Camping/Backpacking,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,sarah wilcer,
-LS,1560,16,Riflery,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,
-LS,1560,19,Riflery,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,dominic cirocco,
-LS,1570,9,Shotgun Sports,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james gill,
-LS,1580,5,Archery,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,herbert strickland,
-LS,1640,2,Whitewater Kayaking,0.5,0.2,0.0,0.0,0.0,0.0,0.0,0.3,robert taylor,
-LS,1850,2,Bowling,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,adam perr middleton,
-LS,1850,4,Bowling,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kathryn ly mitchell,
-LS,1850,7,Bowling,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,megan elizabet cato,
-LS,1850,8,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,adam perr middleton,
-LS,1850,9,Bowling,0.82,0.04,0.0,0.04,0.0,0.0,0.0,0.11,megan elizabet cato,
-LS,1940,2,Racquetball,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,raymond petersen,
-LS,1940,3,Racquetball,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,charlie white,
-LS,1980,9,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,wesley scott womble,
-LS,2200,3,Shag,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,broadus fleming,
-LS,2200,7,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,matthew lee krabbe,
-LS,2270,1,Intro to Swing Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,paul hoke,
-LS,2320,1,Core Training,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,
-LS,2320,2,Core Training,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
-LS,2320,3,Core Training,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,2350,1,Basic Yoga,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,silica eliza larkin,
-LS,2350,3,Basic Yoga,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2350,4,Basic Yoga,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2350,5,Basic Yoga,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,renee warren gahan,
-LS,2350,6,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,
-LS,2350,7,Basic Yoga,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,kayla lee wardlaw,
-LS,2380,1,Vinyasa Flow Yoga,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,
-LS,2380,3,Vinyasa Flow Yoga,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2420,1,Meditation and Relax,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,3,Meditation and Relax,0.7,0.13,0.04,0.04,0.0,0.0,0.0,0.09,renee warren gahan,
-LS,2420,4,Meditation and Relax,0.76,0.14,0.05,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2420,5,Meditation and Relax,0.91,0.0,0.0,0.04,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,2420,8,Meditation and Relax,0.84,0.08,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,2450,2,Pilates,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
-LS,2450,4,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,2450,6,Pilates,0.83,0.09,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
-LS,2460,1,Intermediate Pilates,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,melanie ivey job,
-LS,2700,1,Sports Officiating,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,christopher war cox,
-LS,2750,7,First Aid/Cpr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,christopher loomis,
-LS,2750,8,First Aid/Cpr,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,christopher loomis,
-LS,2780,3,Wilderness First Aid,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,emily grace turke,
-LS,2910,1,Outdoor Leadership,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,emily grace turke,
-LS,3580,1,Advanced Shotgun Skeet,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,james gill,
-MATH,1010,1,Essen Math for Informed Soc,0.32,0.48,0.12,0.04,0.0,0.0,0.0,0.04,marilyn reba,
-MATH,1010,2,Essen Math for Informed Soc,0.53,0.26,0.18,0.0,0.0,0.0,0.0,0.03,marilyn reba,
-MATH,1010,3,Essen Math for Informed Soc,0.58,0.14,0.14,0.03,0.08,0.0,0.0,0.03,marilyn reba,
-MATH,1010,4,Essen Math for Informed Soc,0.53,0.31,0.13,0.0,0.0,0.0,0.0,0.03,marilyn reba,
-MATH,1020,1,Business Calculus I,0.09,0.27,0.34,0.05,0.2,0.0,0.0,0.05,tony thanh nguyen,
-MATH,1020,2,Business Calculus I,0.21,0.13,0.21,0.13,0.19,0.0,0.0,0.13,michael thoma cowen,
-MATH,1020,3,Business Calculus I,0.2,0.28,0.22,0.07,0.11,0.0,0.0,0.13,tony thanh nguyen,
-MATH,1020,4,Business Calculus I,0.17,0.21,0.21,0.12,0.17,0.0,0.0,0.12,todd fenstermacher,
-MATH,1020,5,Business Calculus I,0.09,0.18,0.4,0.13,0.18,0.0,0.0,0.02,stephen garth,
-MATH,1020,6,Business Calculus I,0.15,0.35,0.24,0.07,0.11,0.0,0.0,0.09,randy davidson,
-MATH,1020,7,Business Calculus I,0.17,0.29,0.27,0.07,0.07,0.0,0.0,0.12,marion hanna,
-MATH,1020,8,Business Calculus I,0.14,0.28,0.33,0.07,0.16,0.0,0.0,0.02,randy davidson,
-MATH,1020,9,Business Calculus I,0.21,0.5,0.12,0.1,0.07,0.0,0.0,0.0,marion hanna,
-MATH,1020,10,Business Calculus I,0.17,0.32,0.29,0.1,0.1,0.0,0.0,0.02,peter westerbaan,
-MATH,1020,11,Business Calculus I,0.21,0.37,0.26,0.02,0.09,0.0,0.0,0.05,john william grant,
-MATH,1020,12,Business Calculus I,0.11,0.45,0.23,0.0,0.09,0.0,0.0,0.11,randy davidson,
-MATH,1020,13,Business Calculus I,0.05,0.17,0.26,0.19,0.21,0.0,0.0,0.12,javier ruiz ramirez,
-MATH,1020,16,Business Calculus I,0.11,0.13,0.36,0.16,0.13,0.0,0.0,0.11,bryce pruitt,
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.44,0.54,0.03,stefan adam bock,
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.56,0.12,nicholas ahlstrom,
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.58,0.33,0.09,charity watson,
-MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.71,0.2,0.09,charity watson,
-MATH,1060,1,Calculus of One Variable I,0.0,0.16,0.32,0.14,0.27,0.0,0.0,0.11,judith cottingham,
-MATH,1060,2,Calculus of One Variable I,0.02,0.33,0.2,0.16,0.22,0.0,0.0,0.07,judith cottingham,
-MATH,1060,3,Calculus of One Variable I,0.06,0.13,0.24,0.15,0.25,0.0,0.0,0.18,allen anderso guest,
-MATH,1060,5,Calculus of One Variable I,0.1,0.19,0.23,0.09,0.26,0.0,0.0,0.14,allen anderso guest,
-MATH,1060,7,Calculus of One Variable I,0.08,0.17,0.11,0.08,0.44,0.0,0.0,0.11,thowhida akther,
-MATH,1060,500,Calculus of One Variable I,0.59,0.21,0.21,0.0,0.0,0.0,0.0,0.0,laura dostert,
-MATH,1070,1,Differen and Integral Calculus,0.14,0.34,0.34,0.07,0.07,0.0,0.0,0.03,donna simms,
-MATH,1070,2,Differen and Integral Calculus,0.24,0.44,0.32,0.0,0.0,0.0,0.0,0.0,donna simms,
-MATH,1070,3,Differen and Integral Calculus,0.07,0.37,0.37,0.05,0.07,0.0,0.0,0.07,chase norman joyner,
-MATH,1070,5,Differen and Integral Calculus,0.08,0.23,0.33,0.23,0.03,0.0,0.0,0.1,stefan adam bock,
-MATH,1070,7,Differen and Integral Calculus,0.03,0.28,0.34,0.28,0.03,0.0,0.0,0.03,rebecca ramos,
-MATH,1080,1,Calculus of One Variable II,0.13,0.31,0.31,0.09,0.13,0.0,0.0,0.03,beth novick,
-MATH,1080,4,Calculus of One Variable II,0.15,0.41,0.1,0.08,0.13,0.0,0.0,0.13,sergey charnyi,
-MATH,1080,5,Calculus of One Variable II,0.19,0.35,0.19,0.07,0.14,0.0,0.0,0.07,mengying xiao,
-MATH,1080,7,Calculus of One Variable II,0.2,0.24,0.2,0.09,0.16,0.0,0.0,0.11,fun choi john chan,
-MATH,1080,8,Calculus of One Variable II,0.18,0.34,0.2,0.14,0.09,0.0,0.0,0.05,honghai xu,
-MATH,1080,10,Calculus of One Variable II,0.24,0.41,0.2,0.04,0.04,0.0,0.0,0.07,garrett dranichak,
-MATH,1080,11,Calculus of One Variable II,0.16,0.38,0.24,0.11,0.04,0.0,0.0,0.07,honghai xu,
-MATH,1080,12,Calculus of One Variable II,0.13,0.29,0.24,0.07,0.09,0.0,0.0,0.18,rui gong,
-MATH,1080,13,Calculus of One Variable II,0.14,0.32,0.25,0.11,0.11,0.0,0.0,0.07,alistair bentley,
-MATH,1080,16,Calculus of One Variable II,0.13,0.3,0.22,0.11,0.13,0.0,0.0,0.11,camille zerfas,
-MATH,1080,100,Calc of One Variable II (HON),0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,beth novick,True
-MATH,1080,203,Calc of One Variable II (RiSE),0.2,0.28,0.33,0.13,0.0,0.0,0.0,0.07,kara ail stasikelis,
-MATH,1080,203,Calc of One Variable II,0.2,0.28,0.33,0.13,0.0,0.0,0.0,0.07,kara ail stasikelis,
-MATH,1080,206,Calc of One Variable II (RiSE),0.21,0.21,0.31,0.05,0.15,0.0,0.0,0.08,honghai xu,
-MATH,1080,206,Calc of One Variable II,0.21,0.21,0.31,0.05,0.15,0.0,0.0,0.08,honghai xu,
-MATH,1080,209,Calc of One Variable II,0.2,0.32,0.17,0.12,0.07,0.0,0.0,0.12,jonathon leverenz,
-MATH,1080,209,Calc of One Variable II (RiSE),0.2,0.32,0.17,0.12,0.07,0.0,0.0,0.12,jonathon leverenz,
-MATH,1080,214,Calc of One Variable II (RiSE),0.28,0.22,0.35,0.02,0.11,0.0,0.0,0.02,lauren pai mcintyre,
-MATH,1080,214,Calc of One Variable II,0.28,0.22,0.35,0.02,0.11,0.0,0.0,0.02,lauren pai mcintyre,
-MATH,1080,217,Calc of One Variable II,0.28,0.35,0.15,0.11,0.02,0.0,0.0,0.09,audrey nico devries,
-MATH,1080,218,Calc of One Variable II,0.24,0.37,0.2,0.09,0.09,0.0,0.0,0.02,ryan grove,
-MATH,1150,1,Contemp Math for Elem Teach I,0.5,0.27,0.19,0.0,0.04,0.0,0.0,0.0,charity watson,
-MATH,1160,1,Contemp Math for Elem Teach II,0.74,0.2,0.06,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1160,2,Contemp Math for Elem Teach II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.84,0.12,0.04,marion hanna,
-MATH,2060,1,Calculus of Several Variables,0.23,0.4,0.14,0.11,0.09,0.0,0.0,0.03,hiram lopez valdez,
-MATH,2060,2,Calculus of Several Variables,0.15,0.32,0.09,0.06,0.18,0.0,0.0,0.21,timothy fra parrott,
-MATH,2060,3,Calculus of Several Variables,0.32,0.36,0.19,0.04,0.06,0.0,0.0,0.02,hiram lopez valdez,
-MATH,2060,4,Calculus of Several Variables,0.46,0.38,0.05,0.08,0.03,0.0,0.0,0.0,muhamm mohebujjaman,
-MATH,2060,5,Calculus of Several Variables,0.11,0.21,0.25,0.18,0.11,0.0,0.0,0.14,timothy fra parrott,
-MATH,2060,6,Calculus of Several Variables,0.08,0.56,0.19,0.0,0.11,0.0,0.0,0.06,sofya alekseeva,
-MATH,2060,7,Calculus of Several Variables,0.19,0.5,0.19,0.06,0.03,0.0,0.0,0.03,sofya alekseeva,
-MATH,2060,8,Calculus of Several Variables,0.44,0.33,0.1,0.04,0.04,0.0,0.0,0.04,martin joha schmoll,
-MATH,2060,9,Calculus of Several Variables,0.13,0.45,0.24,0.08,0.05,0.0,0.0,0.05,sofya alekseeva,
-MATH,2060,10,Calculus of Several Variables,0.0,0.21,0.16,0.11,0.37,0.0,0.0,0.16,jonathon leverenz,
-MATH,2060,500,Calculus of Several Variables,0.4,0.27,0.27,0.07,0.0,0.0,0.0,0.0,brian gloor,
-MATH,2070,1,Business Calculus II,0.28,0.38,0.2,0.13,0.0,0.0,0.0,0.03,jennifer mari hanna,
-MATH,2070,2,Business Calculus II,0.3,0.45,0.2,0.0,0.03,0.0,0.0,0.03,tony thanh nguyen,
-MATH,2070,3,Business Calculus II,0.23,0.33,0.18,0.15,0.03,0.0,0.0,0.1,thanh thien to,
-MATH,2070,4,Business Calculus II,0.53,0.28,0.13,0.08,0.0,0.0,0.0,0.0,jennifer mari hanna,
-MATH,2070,5,Business Calculus II,0.28,0.38,0.2,0.1,0.05,0.0,0.0,0.0,allison stoddard,
-MATH,2070,6,Business Calculus II,0.33,0.25,0.23,0.08,0.13,0.0,0.0,0.0,tony thanh nguyen,
-MATH,2070,7,Business Calculus II,0.65,0.15,0.13,0.05,0.0,0.0,0.0,0.03,jennifer mari hanna,
-MATH,2070,8,Business Calculus II,0.29,0.24,0.21,0.1,0.1,0.0,0.0,0.07,judith irene mcknew,
-MATH,2070,9,Business Calculus II,0.23,0.36,0.13,0.08,0.05,0.0,0.0,0.15,judith irene mcknew,
-MATH,2070,10,Business Calculus II,0.2,0.39,0.24,0.1,0.05,0.0,0.0,0.02,daniel kuzbary,
-MATH,2070,11,Business Calculus II,0.31,0.36,0.1,0.08,0.1,0.0,0.0,0.05,jing li,
-MATH,2070,12,Business Calculus II,0.38,0.28,0.15,0.05,0.08,0.0,0.0,0.05,neil calkin,
-MATH,2070,13,Business Calculus II,0.35,0.35,0.18,0.03,0.08,0.0,0.0,0.03,haodong li,
-MATH,2070,14,Business Calculus II,0.23,0.36,0.36,0.0,0.0,0.0,0.0,0.05,shanshan jia,
-MATH,2070,15,Business Calculus II,0.25,0.35,0.23,0.05,0.0,0.0,0.0,0.13,aaro ramirez flores,
-MATH,2070,16,Business Calculus II,0.4,0.35,0.08,0.08,0.08,0.0,0.0,0.03,stephen peele,
-MATH,2080,1,Intro to Ordin Diff Equations,0.09,0.3,0.17,0.13,0.04,0.0,0.0,0.26,terri johnson,
-MATH,2080,2,Intro to Ordin Diff Equations,0.37,0.49,0.09,0.0,0.06,0.0,0.0,0.0,oleg yordanov,
-MATH,2080,4,Intro to Ordin Diff Equations,0.08,0.05,0.26,0.03,0.24,0.0,0.0,0.34,terri johnson,
-MATH,2080,5,Intro to Ordin Diff Equations,0.53,0.21,0.21,0.03,0.0,0.0,0.0,0.03,timothy ch teitloff,
-MATH,2080,6,Intro to Ordin Diff Equations,0.47,0.37,0.05,0.05,0.0,0.0,0.0,0.07,oleg yordanov,
-MATH,2080,7,Intro to Ordin Diff Equations,0.06,0.15,0.21,0.06,0.15,0.0,0.0,0.38,terri johnson,
-MATH,2080,8,Intro to Ordin Diff Equations,0.26,0.26,0.09,0.18,0.15,0.0,0.0,0.06,julie lassiter,
-MATH,2080,9,Intro to Ordin Diff Equations,0.62,0.1,0.23,0.0,0.0,0.0,0.0,0.05,timothy ch teitloff,
-MATH,2080,10,Intro to Ordin Diff Equations,0.33,0.36,0.13,0.08,0.1,0.0,0.0,0.0,irina viktorova,
-MATH,2080,11,Intro to Ordin Diff Equations,0.25,0.19,0.16,0.19,0.16,0.0,0.0,0.06,julie lassiter,
-MATH,2080,12,Intro to Ordin Diff Equations,0.36,0.27,0.21,0.06,0.0,0.0,0.0,0.09,shari prevost,
-MATH,2080,13,Intro to Ordin Diff Equations,0.28,0.35,0.2,0.08,0.08,0.0,0.0,0.03,irina viktorova,
-MATH,2080,14,Intro to Ordin Diff Equations,0.24,0.29,0.24,0.0,0.08,0.0,0.0,0.16,jonathon leverenz,
-MATH,2080,15,Intro to Ordin Diff Equations,0.19,0.36,0.17,0.03,0.14,0.0,0.0,0.11,shari prevost,
-MATH,2080,16,Intro to Ordin Diff Equations,0.38,0.2,0.29,0.09,0.0,0.0,0.0,0.04,irina viktorova,
-MATH,2080,17,Intro to Ordin Diff Equations,0.19,0.25,0.28,0.09,0.06,0.0,0.0,0.13,jeong rock yoon,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.62,0.31,0.04,0.0,0.04,0.0,0.0,0.0,brian fralix,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.6,0.25,0.1,0.05,0.0,0.0,0.0,0.0,allison stoddard,
-MATH,3020,1,Stat for Science & Engineering,0.33,0.4,0.14,0.05,0.05,0.0,0.0,0.02,william bridges,
-MATH,3020,2,Stat for Science & Engineering,0.66,0.29,0.03,0.0,0.0,0.0,0.0,0.03,xiyan tan,
-MATH,3020,3,Stat for Science & Engineering,0.54,0.18,0.18,0.03,0.08,0.0,0.0,0.0,yisu jia,
-MATH,3020,4,Stat for Science & Engineering,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,brandon gra goodell,
-MATH,3020,5,Stat for Science & Engineering,0.5,0.31,0.12,0.02,0.05,0.0,0.0,0.0,"koshy chenthittayil,",
-MATH,3020,6,Stat for Science & Engineering,0.35,0.32,0.11,0.11,0.05,0.0,0.0,0.05,prab withana gamage,
-MATH,3020,7,Stat for Science & Engineering,0.4,0.33,0.12,0.07,0.07,0.0,0.0,0.0,yinggu bao,
-MATH,3020,8,Stat for Science & Engineering,0.25,0.42,0.22,0.06,0.03,0.0,0.0,0.03,ellen hepfe breazel,
-MATH,3020,9,Stat for Science & Engineering,0.3,0.33,0.12,0.0,0.09,0.0,0.0,0.15,paul james cubre,
-MATH,3080,1,College Geometry,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,carlos gomez,
-MATH,3110,1,Linear Algebra,0.45,0.18,0.24,0.08,0.03,0.0,0.0,0.03,amy christine grady,
-MATH,3110,2,Linear Algebra,0.15,0.38,0.15,0.18,0.05,0.0,0.0,0.08,amy christine grady,
-MATH,3110,3,Linear Algebra,0.21,0.3,0.12,0.09,0.12,0.0,0.0,0.15,xuhong gao,
-MATH,3110,4,Linear Algebra,0.3,0.5,0.1,0.05,0.05,0.0,0.0,0.0,hui xue,
-MATH,3110,5,Linear Algebra,0.11,0.46,0.17,0.06,0.14,0.0,0.0,0.06,michael adam burr,
-MATH,3110,6,Linear Algebra,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,wayne goddard,
-MATH,3110,7,Linear Algebra,0.24,0.24,0.21,0.09,0.06,0.0,0.0,0.15,neil calkin,
-MATH,3110,200,Linear Algebra,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,beth novick,
-MATH,3150,1,Adv Top in Math for Elem Teach,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,
-MATH,3190,1,Introduction to Proof,0.1,0.29,0.19,0.1,0.0,0.0,0.0,0.33,james ba coykendall,
-MATH,3190,2,Introduction to Proof,0.18,0.36,0.32,0.05,0.05,0.0,0.0,0.05,james ba coykendall,
-MATH,3600,1,Intermediate Math Computing,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,mark cawood,
-MATH,3600,2,Intermediate Math Computing,0.67,0.17,0.0,0.06,0.06,0.0,0.0,0.06,mark cawood,
-MATH,3650,1,Numerical Mthds for Engineers,0.2,0.26,0.17,0.14,0.14,0.0,0.0,0.09,fei xue,
-MATH,3650,2,Numerical Mthds for Engineers,0.33,0.21,0.29,0.08,0.04,0.0,0.0,0.04,fei xue,
-MATH,3650,3,Numerical Mthds for Engineers,0.53,0.29,0.06,0.0,0.06,0.0,0.0,0.06,timo johann heister,
-MATH,3650,4,Numerical Mthds for Engineers,0.35,0.19,0.15,0.08,0.04,0.0,0.0,0.19,christopher cox,
-MATH,4000,1,Theory of Probability,0.28,0.31,0.18,0.1,0.08,0.0,0.0,0.05,ling ma,
-MATH,4030,1,Intro to Statistical Theory,0.36,0.45,0.14,0.05,0.0,0.0,0.0,0.0,xiaoqian sun,
-MATH,4060,1,Sampling Theory and Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-MATH,4070,1,Regress & Time-Series Analysis,0.45,0.24,0.21,0.03,0.0,0.0,0.0,0.07,colin gallagher,
-MATH,4100,1,Number Theory,0.5,0.1,0.2,0.1,0.0,0.0,0.0,0.1,hui xue,
-MATH,4120,1,Algebra I,0.08,0.11,0.39,0.08,0.06,0.0,0.0,0.28,sea sather-wagstaff,
-MATH,4190,1,Discrete Math Structures I,0.57,0.25,0.09,0.02,0.05,0.0,0.0,0.02,beth novick,
-MATH,4310,1,Theory of Interest,0.44,0.39,0.11,0.0,0.06,0.0,0.0,0.0, erwin walker,
-MATH,4320,1,Actuarial Science Seminar II,0.6,0.07,0.27,0.0,0.0,0.0,0.0,0.07, erwin walker,
-MATH,4340,1,Adv Engineering Mathematics,0.15,0.15,0.38,0.12,0.15,0.0,0.0,0.04,vincent ervin,
-MATH,4340,2,Adv Engineering Mathematics,0.06,0.16,0.38,0.13,0.09,0.0,0.0,0.19,eleanor jenkins,
-MATH,4400,1,Linear Programming,0.31,0.27,0.19,0.15,0.0,0.0,0.0,0.08,boshi yang,
-MATH,4410,1,Intro to Stochastic Models,0.41,0.24,0.35,0.0,0.0,0.0,0.0,0.0,peter kiessler,
-MATH,4530,1,Advanced Calculus I,0.32,0.05,0.21,0.16,0.11,0.0,0.0,0.16,james peterson,
-MATH,4540,1,Advanced Calculus II,0.25,0.32,0.21,0.14,0.04,0.0,0.0,0.04,james peterson,
-MATH,4600,1,Intro to Numerical Analysis I,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,eleanor jenkins,
-MATH,6340,1,Adv Engineering Mathematics,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,vincent ervin,
-MATH,8030,1,Stochastic Processes,0.55,0.36,0.0,0.0,0.05,0.0,0.0,0.05,xin liu,
-MATH,8040,1,Statistical Inference,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,christopher mcmahan,
-MATH,8050,1,Data Analysis,0.42,0.47,0.0,0.0,0.0,0.0,0.0,0.11,calvin williams,
-MATH,8090,1,Time Series Analysis,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,8100,1,Mathematical Programming,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
-MATH,8130,1,Advanced Linear Programming,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
-MATH,8210,1,Linear Analysis,0.33,0.56,0.0,0.0,0.11,0.0,0.0,0.0,taufiquar rahm khan,
-MATH,8220,1,Measure and Integration,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,martin joha schmoll,
-MATH,8260,1,Partial Differential Equations,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,qingshan chen,
-MATH,8530,1,Matrix Analysis,0.48,0.4,0.04,0.0,0.0,0.0,0.0,0.08,matthew macauley,
-MATH,8600,1,Intro to Scientific Computing,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,qingshan chen,
-MATH,8660,1,Finite Element Method,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,vincent ervin,
-MATH,9000,2,Prof Devel in Math Sciences,0.0,0.0,0.0,0.0,0.0,0.91,0.04,0.04,meredith nicol burr,
-MBA,8030,1,Stat Analy of Bus Op,0.3,0.35,0.16,0.0,0.16,0.0,0.0,0.02,janis miller,
-MBA,8060,1,Operations Mgt,0.58,0.33,0.04,0.0,0.02,0.0,0.0,0.02, sridharan,
-MBA,8060,20,Operations Mgt,0.69,0.15,0.12,0.0,0.04,0.0,0.0,0.0, sridharan,
-MBA,8070,1,Financial Management,0.56,0.3,0.14,0.0,0.0,0.0,0.0,0.0,melvin stith,
-MBA,8070,2,Financial Management,0.44,0.39,0.12,0.0,0.0,0.0,0.0,0.05,melvin stith,
-MBA,8090,1,Org Beh & Hum Res Mg,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.02,kristin dam scott,
-MBA,8090,2,Org Beh & Hum Res Mg,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,kristin dam scott,
-MBA,8190,1,Intro to Acc and Fin,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,
-MBA,8190,2,Intro to Acc and Fin,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,annieka philo,
-MBA,8290,1,Marketing Foundation,0.68,0.23,0.04,0.0,0.0,0.0,0.0,0.04,gary hunter,
-MBA,8330,1,Real Estate Investmt,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,
-MBA,8370,1,Legal Environ of Bus,0.48,0.53,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
-MBA,8430,10,Entrepreneurial Accounting,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,
-MBA,8450,1,Technology & Innovation Mgt,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8470,1,New Venture Creation,0.64,0.27,0.05,0.0,0.05,0.0,0.0,0.0,elizabeth er powell,
-MBA,8510,10,Bus Operations & Logistics,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,james liddle,
-MBA,8540,1,Mgrl Accounting,0.39,0.57,0.05,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,
-MBA,8540,2,Mgrl Accounting,0.56,0.4,0.02,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,
-MBA,8540,3,Mgrl Accounting,0.26,0.43,0.22,0.0,0.0,0.0,0.0,0.09,james mil kohlmeyer,
-MBA,8590,1,Mgr Decision Model,0.37,0.3,0.21,0.0,0.05,0.0,0.0,0.07,magda gabriela sava,
-MBA,8590,2,Mgr Decision Model,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,sara elizabet yoder,
-MBA,8600,1,Advanced Marketing Strategy,0.22,0.61,0.17,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8610,1,Information Systems,0.28,0.7,0.03,0.0,0.0,0.0,0.0,0.0,varun grover,
-MBA,8610,2,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MBA,8620,1,Managerial Economics,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,
-MBA,8720,1,Entrepr Finance,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,
-MBA,8720,2,Entrepr Finance,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8740,1,Managing Cont Impvmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MBA,8750,1,Enterprise Develpmnt,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8990,1,Advanced Leadership,0.95,0.0,0.02,0.0,0.0,0.0,0.0,0.02,gail depriest,
-MBA,8990,3,Service Innovation,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
-MBA,8990,4,Bus. Sport. Enter.,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
-MBA,8990,20,Analytics & Application,0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,heshan sun,
-ME,2000,1,Sophomore Seminar,0.92,0.05,0.0,0.0,0.01,0.0,0.0,0.02,donald beasley,
-ME,2010,1,Statics & Dynamics,0.06,0.26,0.25,0.14,0.17,0.0,0.0,0.13,marisa kikendal orr,
-ME,2010,2,Statics & Dynamics,0.06,0.29,0.17,0.13,0.23,0.0,0.0,0.12,paul joseph,
-ME,2030,1,Founda Th/Fl Syst,0.16,0.31,0.27,0.16,0.05,0.0,0.0,0.05,jay ochterbeck,
-ME,2030,2,Founda Th/Fl Syst,0.07,0.2,0.4,0.21,0.05,0.0,0.0,0.06,john saylor,
-ME,2040,1,Mechanics of Materials,0.36,0.53,0.03,0.02,0.05,0.0,0.0,0.02,jorge iva rodriguez,
-ME,2040,2,Mechanics of Materials,0.12,0.49,0.37,0.02,0.0,0.0,0.0,0.0,gang li,
-ME,2040,3,Mechanics of Materials,0.33,0.47,0.18,0.0,0.02,0.0,0.0,0.0,garrett pataky,
-ME,2040,302,Mechanics of Materials (HON),0.55,0.36,0.0,0.09,0.0,0.0,0.0,0.0,gang li,True
-ME,2220,2,Mechanical Engineering Lab I,0.53,0.33,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,
-ME,2220,3,Mechanical Engineering Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,5,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,6,Mechanical Engineering Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,7,Mechanical Engineering Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,8,Mechanical Engineering Lab I,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,9,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,10,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,13,Mechanical Engineering Lab I,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,2220,14,Mechanical Engineering Lab I,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,todd schweisinger,
-ME,2220,15,Mechanical Engineering Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3030,1,Thermodynamics,0.23,0.55,0.15,0.05,0.0,0.0,0.0,0.03,yiqiang han,
-ME,3030,2,Thermodynamics,0.17,0.6,0.17,0.02,0.0,0.0,0.0,0.05,yiqiang han,
-ME,3040,1,Heat Transfer,0.08,0.37,0.34,0.05,0.06,0.0,0.0,0.1,jean-marc delhaye,
-ME,3040,2,Heat Transfer,0.19,0.32,0.4,0.04,0.04,0.0,0.0,0.01,jean-marc delhaye,
-ME,3050,1,Model/an Dy Syst,0.2,0.47,0.2,0.0,0.08,0.0,0.0,0.05,phanin tallapragada,
-ME,3050,2,Model/an Dy Syst,0.21,0.5,0.21,0.07,0.01,0.0,0.0,0.0,joshua bostwick,
-ME,3060,1,Fund Machine Design,0.54,0.37,0.06,0.0,0.0,0.0,0.0,0.04,oliver myers,
-ME,3060,2,Fund Machine Design,0.34,0.44,0.17,0.02,0.01,0.0,0.0,0.01,paul jeffrey meyer,
-ME,3070,1,Found of Mechanical Systems,0.6,0.24,0.09,0.0,0.05,0.0,0.0,0.02,jorge iva rodriguez,
-ME,3070,2,Found of Mechanical Systems,0.19,0.56,0.22,0.04,0.0,0.0,0.0,0.0,gregory mocko,
-ME,3080,1,Fluid Mechanics,0.13,0.58,0.24,0.04,0.0,0.0,0.0,0.0,daniel fant,
-ME,3080,2,Fluid Mechanics,0.23,0.38,0.27,0.08,0.02,0.0,0.0,0.02,xiangchun xuan,
-ME,3100,1,Thermo/Heat Transfer,0.39,0.39,0.13,0.0,0.0,0.0,0.0,0.09,yiqiang han,
-ME,3120,1,Manuf Processes,0.19,0.47,0.3,0.03,0.01,0.0,0.0,0.01,hong seok choi,
-ME,3330,1,Mechanical Engineering Lab II,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,2,Mechanical Engineering Lab II,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,3330,3,Mechanical Engineering Lab II,0.25,0.63,0.06,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,3330,4,Mechanical Engineering Lab II,0.29,0.5,0.07,0.0,0.14,0.0,0.0,0.0,todd schweisinger,
-ME,3330,5,Mechanical Engineering Lab II,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,6,Mechanical Engineering Lab II,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,3330,7,Mechanical Engineering Lab II,0.31,0.5,0.19,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,3330,8,Mechanical Engineering Lab II,0.27,0.47,0.2,0.0,0.07,0.0,0.0,0.0,todd schweisinger,
-ME,4000,1,Senior Seminar,0.84,0.12,0.01,0.03,0.0,0.0,0.0,0.0,donald beasley,
-ME,4010,1,Mech Engr Design,0.54,0.34,0.1,0.0,0.02,0.0,0.0,0.0,cameron turner,
-ME,4020,2,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
-ME,4020,3,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lonny thompson,
-ME,4020,4,Intern in Engr Des,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,4020,5,Intern in Engr Des,0.4,0.27,0.33,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,6,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,
-ME,4020,7,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-ME,4020,9,Intern in Engr Des,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,
-ME,4030,1,Control Dynamic Systems,0.31,0.23,0.29,0.14,0.03,0.0,0.0,0.0,suyi li,
-ME,4030,2,Control Dynamic Systems,0.35,0.53,0.1,0.03,0.0,0.0,0.0,0.0,yue wang,
-ME,4170,1,Mechatronic Sys,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4180,1,F E A in M E Design,0.24,0.48,0.2,0.08,0.0,0.0,0.0,0.0,gang li,
-ME,4220,1,Design Gas Turbines,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,abhijit som,
-ME,4260,1,Nuclear Energy,0.36,0.36,0.29,0.0,0.0,0.0,0.0,0.0,richard watkins,
-ME,4300,1,Mech Comp Materials,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,4440,1,Mechanical Engineering Lab III,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4440,2,Mechanical Engineering Lab III,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4440,3,Mechanical Engineering Lab III,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4440,4,Mechanical Engineering Lab III,0.08,0.83,0.08,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4440,5,Mechanical Engineering Lab III,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4440,7,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4930,5,Sel.Topics in ME - Rapid Proto,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4930,34,Selected Topics ME (Cardio),0.15,0.62,0.15,0.0,0.0,0.0,0.0,0.08,ethan kung,
-ME,4930,36,Sel. Topics in ME (BioDesgin),0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,michael porter,
-ME,4930,39,Sel Topics ME (Solar Energy),0.4,0.46,0.06,0.0,0.0,0.0,0.0,0.09,daniel fant,
-ME,6300,1,Mech Comp Materials,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,6320,1,Adv Strength of Matl,0.14,0.71,0.14,0.0,0.0,0.0,0.0,0.0,michael porter,
-ME,8120,1,Exp Meth Thermal Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,
-ME,8190,1,Cp Meth in Therm Sc,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,
-ME,8200,1,Mod Cont Engr,0.47,0.36,0.14,0.0,0.0,0.0,0.0,0.03,ardalan vahidi,
-ME,8200,401,Mod Cont Engr,0.23,0.54,0.15,0.0,0.08,0.0,0.0,0.0,ardalan vahidi,
-ME,8310,1,Convective Ht Trans,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,xin zhao,
-ME,8370,1,Theory of Elast I,0.26,0.48,0.22,0.0,0.04,0.0,0.0,0.0,nicole gise coutris,
-MGT,2010,1,Principles of Management,0.39,0.37,0.17,0.03,0.03,0.0,0.0,0.01,katherine clark,
-MGT,2010,2,Principles of Management,0.45,0.34,0.14,0.03,0.03,0.0,0.0,0.03,katherine clark,
-MGT,2010,3,Principles of Management,0.38,0.31,0.19,0.06,0.03,0.0,0.0,0.03,katherine clark,
-MGT,2010,5,Principles of Management,0.44,0.37,0.15,0.02,0.01,0.0,0.0,0.0,tina robbins,
-MGT,2010,6,Principles of Management,0.36,0.46,0.16,0.0,0.0,0.0,0.0,0.01,tina robbins,
-MGT,2010,7,Principles of Management,0.41,0.41,0.15,0.0,0.0,0.0,0.0,0.03,tina robbins,
-MGT,2010,8,Principles of Management,0.43,0.44,0.06,0.03,0.03,0.0,0.0,0.01,tina robbins,
-MGT,2010,10,Principles of Management,0.3,0.35,0.26,0.07,0.02,0.0,0.0,0.0,ashley will parnell,
-MGT,2010,11,Principles of Management,0.28,0.44,0.21,0.05,0.0,0.0,0.0,0.03,ashley will parnell,
-MGT,2180,1,Management PC Applications,0.52,0.28,0.11,0.04,0.05,0.0,0.0,0.01,ryan toole,
-MGT,2180,2,Management PC Applications,0.51,0.36,0.06,0.02,0.02,0.0,0.0,0.02,ryan toole,
-MGT,2180,3,Management PC Applications,0.58,0.29,0.08,0.0,0.02,0.0,0.0,0.03,ryan toole,
-MGT,2180,4,Management PC Applications,0.48,0.34,0.11,0.02,0.02,0.0,0.0,0.04,ryan toole,
-MGT,2970,1,How to Start a Startup,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,john michael hannon,
-MGT,2970,2,How to Start a Startup,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,john michael hannon,
-MGT,2970,4,How to Start a Startup,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
-MGT,2970,5,CI in Management (Film Study),0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,john michael hannon,
-MGT,3070,1,Human Resource Management,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,2,Human Resource Management,0.68,0.25,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,3,Human Resource Management,0.65,0.28,0.05,0.0,0.03,0.0,0.0,0.0,michael cole,
-MGT,3070,4,Human Resource Management,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,6,Human Resource Management,0.41,0.51,0.05,0.0,0.0,0.0,0.0,0.03,leonard jos spooner,
-MGT,3100,1,Intermed Business Statistics,0.14,0.19,0.2,0.12,0.15,0.0,0.0,0.2,sara elizabet yoder,
-MGT,3100,2,Intermed Business Statistics,0.1,0.24,0.26,0.06,0.16,0.0,0.0,0.18,sara elizabet yoder,
-MGT,3100,3,Intermed Business Statistics,0.5,0.32,0.11,0.05,0.0,0.0,0.0,0.03,wenxi pu,
-MGT,3100,4,Intermed Business Statistics,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MGT,3100,5,Intermed Business Statistics,0.44,0.28,0.18,0.1,0.0,0.0,0.0,0.0,daniel nielubowicz,
-MGT,3100,6,Intermed Business Statistics,0.19,0.28,0.22,0.0,0.11,0.0,0.0,0.19,magda gabriela sava,
-MGT,3100,7,Intermed Business Statistics,0.52,0.27,0.18,0.02,0.0,0.0,0.0,0.0,dan jiang,
-MGT,3120,1,Decision Models for Management,0.45,0.32,0.19,0.0,0.03,0.0,0.0,0.01,mark mcknew,
-MGT,3120,2,Decision Models for Management,0.51,0.25,0.12,0.06,0.03,0.0,0.0,0.03,mark mcknew,
-MGT,3150,1,New Venture Creation,0.38,0.55,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,
-MGT,3180,1,Mgt of Info Systems,0.53,0.43,0.05,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,
-MGT,3180,2,Mgt of Info Systems,0.77,0.16,0.07,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,
-MGT,3180,3,Mgt of Info Systems,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,heshan sun,
-MGT,3180,4,Mgt of Info Systems,0.3,0.6,0.08,0.0,0.03,0.0,0.0,0.0,roopa raman,
-MGT,3500,1,Intro to Business Analytics,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,siyuan li,
-MGT,3900,1,Ops Mgt,0.46,0.15,0.15,0.1,0.05,0.0,0.0,0.08,berna quiroga gomez,
-MGT,3900,2,Ops Mgt,0.13,0.23,0.51,0.1,0.0,0.0,0.0,0.03,niratc tungtisanont,
-MGT,3900,3,Ops Mgt,0.15,0.48,0.25,0.13,0.0,0.0,0.0,0.0,remi charpin,
-MGT,3900,4,Ops Mgt,0.09,0.57,0.28,0.02,0.04,0.0,0.0,0.0,zachary mo leffakis,
-MGT,3900,5,Ops Mgt,0.2,0.1,0.43,0.13,0.08,0.0,0.0,0.08,berna quiroga gomez,
-MGT,4000,2,Mgt of Organizational Behavior,0.73,0.25,0.0,0.0,0.0,0.0,0.0,0.03,michael cole,
-MGT,4000,3,Mgt of Organizational Behavior,0.43,0.28,0.28,0.0,0.03,0.0,0.0,0.0,philip roth,
-MGT,4000,4,Mgt of Organizational Behavior,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4020,1,Ops Pln and Ctl,0.05,0.45,0.41,0.05,0.05,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4080,1,Lean Operations,0.32,0.45,0.18,0.0,0.05,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4110,1,Project Management,0.38,0.45,0.1,0.0,0.05,0.0,0.0,0.03,russell purvis,
-MGT,4120,1,Supplier Management,0.13,0.51,0.36,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,1,Business Strategy,0.43,0.58,0.0,0.0,0.0,0.0,0.0,0.0,dane patric blevins,
-MGT,4150,2,Business Strategy,0.53,0.45,0.03,0.0,0.0,0.0,0.0,0.0,dane patric blevins,
-MGT,4150,3,Business Strategy,0.26,0.57,0.14,0.0,0.0,0.0,0.0,0.02,zeki simsek,
-MGT,4150,4,Business Strategy,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,5,Business Strategy,0.32,0.29,0.32,0.05,0.02,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,6,Business Strategy,0.41,0.48,0.09,0.0,0.02,0.0,0.0,0.0,james liddle,
-MGT,4150,7,Business Strategy,0.46,0.52,0.02,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,8,Business Strategy,0.5,0.48,0.02,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4160,1,Special Topics Hr,0.4,0.45,0.1,0.0,0.03,0.0,0.0,0.03,kristin dam scott,
-MGT,4230,1,Intern Bus Mgt,0.35,0.5,0.08,0.05,0.0,0.0,0.0,0.03,janis miller,
-MGT,4230,2,Intern Bus Mgt,0.36,0.38,0.24,0.02,0.0,0.0,0.0,0.0,james liddle,
-MGT,4230,3,Intern Bus Mgt,0.18,0.23,0.48,0.03,0.03,0.0,0.0,0.08,wayne stewart,
-MGT,4230,4,Intern Bus Mgt,0.1,0.36,0.38,0.0,0.08,0.0,0.0,0.08,wayne stewart,
-MGT,4240,1,Global Supply Chain,0.19,0.58,0.19,0.0,0.0,0.0,0.0,0.03,yann ferrand,
-MGT,4310,1,Emp Rights & Resp,0.35,0.56,0.09,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,4350,1,Pers Interviewing,0.25,0.43,0.25,0.03,0.05,0.0,0.0,0.0,philip roth,
-MGT,4520,1,Business Analysis,0.15,0.56,0.23,0.03,0.0,0.0,0.0,0.03,roopa raman,
-MGT,4550,1,Emerging I T Trends,0.41,0.49,0.1,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MGT,4560,1,Business Info Mgt,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,siyuan li,
-MGT,8120,1,Supply Chain Mgt,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,yann ferrand,
-MICR,3050,1,General Microbiology,0.41,0.41,0.15,0.01,0.01,0.0,0.0,0.01,krista barr rudolph,
-MICR,3050,2,General Microbiology,0.34,0.34,0.23,0.05,0.01,0.0,0.0,0.03,kristi ja whitehead,
-MICR,3050,3,General Microbiology,0.7,0.24,0.07,0.0,0.0,0.0,0.0,0.0,krista barr rudolph,
-MICR,4000,1,Public Health Micro,0.52,0.27,0.16,0.03,0.02,0.0,0.0,0.01,kristi ja whitehead,
-MICR,4000,2,Public Health Micro (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,True
-MICR,4030,1,Marine Microbiology,0.29,0.5,0.17,0.0,0.0,0.0,0.0,0.04,john michael henson,
-MICR,4070,1,Food and Dairy Micro,0.26,0.47,0.21,0.03,0.01,0.0,0.0,0.01,xiuping jiang,
-MICR,4110,1,Pathogenic Bact,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4120,1,Bacterial Physiology,0.23,0.31,0.19,0.17,0.07,0.0,0.0,0.03,thomas hughes,
-MICR,4130,1,Industrial Micro,0.64,0.34,0.01,0.01,0.0,0.0,0.0,0.0,tzuen-rong je tzeng,
-MICR,4140,1,Basic Immunology,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,charles rice,
-MICR,4170,1,Cancer and Aging,0.87,0.11,0.02,0.0,0.0,0.0,0.0,0.0,yuqing dong,
-MICR,4500,1,Advanced Microbiology I,0.42,0.42,0.08,0.04,0.04,0.0,0.0,0.0,harry kurtz,
-MICR,4500,2,Advanced Microbiology I,0.42,0.33,0.13,0.08,0.0,0.0,0.0,0.04,harry kurtz,
-MICR,4500,3,Advanced Microbiology I,0.06,0.63,0.31,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4520,1,Advanced Microbiology III,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4520,2,Advanced Microbiology III,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.04,harry kurtz,
-MKT,3010,1,Prin of Marketing,0.3,0.39,0.2,0.09,0.01,0.0,0.0,0.01,carter wil mcelveen,
-MKT,3010,2,Prin of Marketing,0.18,0.42,0.27,0.06,0.04,0.0,0.0,0.03,carter wil mcelveen,
-MKT,3010,3,Prin of Marketing,0.27,0.36,0.25,0.09,0.01,0.0,0.0,0.01,amanda cooper fine,
-MKT,3010,4,Prin of Marketing,0.24,0.4,0.25,0.06,0.04,0.0,0.0,0.01,amanda cooper fine,
-MKT,3010,5,Prin of Marketing,0.73,0.18,0.06,0.0,0.02,0.0,0.0,0.02,patricia knowles,
-MKT,3020,1,Consumer Behavior,0.44,0.36,0.14,0.04,0.02,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,2,Consumer Behavior,0.33,0.37,0.24,0.04,0.02,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,3,Consumer Behavior,0.38,0.48,0.12,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3020,4,Consumer Behavior,0.32,0.44,0.16,0.08,0.0,0.0,0.0,0.0, thyroff fitzwater,
-MKT,3020,5,Consumer Behavior,0.28,0.56,0.14,0.02,0.0,0.0,0.0,0.0,james gaubert,
-MKT,3210,1,Sports Marketing,0.6,0.37,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3210,2,Sports Marketing,0.51,0.43,0.02,0.0,0.0,0.0,0.0,0.04,delancy bennett,
-MKT,3310,1,Marketing Metrics & Analytics,0.81,0.14,0.03,0.0,0.0,0.0,0.0,0.03,oriana rache aragon,
-MKT,3310,2,Marketing Metrics & Analytics,0.9,0.08,0.0,0.03,0.0,0.0,0.0,0.0,oriana rache aragon,
-MKT,3980,1,CI: Sales Experiential,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.01,carter wil mcelveen,
-MKT,4200,1,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,2,Professional Selling,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,3,Professional Selling,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4200,4,Professional Selling,0.72,0.2,0.04,0.0,0.04,0.0,0.0,0.0,gary hunter,
-MKT,4200,5,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4230,1,Promotional Strategy,0.35,0.44,0.18,0.03,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,4240,1,Sales Management,0.38,0.6,0.03,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4270,1,International Mktg,0.28,0.5,0.13,0.08,0.0,0.0,0.0,0.03,thomas poehlman,
-MKT,4270,2,International Mktg,0.23,0.48,0.2,0.03,0.0,0.0,0.0,0.08,roger gomes,
-MKT,4270,3,International Mktg,0.59,0.33,0.07,0.02,0.0,0.0,0.0,0.0,roger gomes,
-MKT,4280,1,Services Marketing,0.58,0.24,0.16,0.0,0.0,0.0,0.0,0.02,james gaubert,
-MKT,4280,2,Services Marketing,0.68,0.29,0.02,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4310,1,Marketing Research,0.25,0.25,0.32,0.14,0.04,0.0,0.0,0.0,peter weathers,
-MKT,4310,2,Marketing Research,0.26,0.45,0.23,0.0,0.0,0.0,0.0,0.06,william kilbourne,
-MKT,4310,3,Marketing Research,0.3,0.59,0.11,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,4,Marketing Research,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4330,1,Sport Mkt Strategy,0.47,0.44,0.06,0.0,0.0,0.0,0.0,0.03,amanda cooper fine,
-MKT,4450,1,Macromarketing,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,william kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.22,0.56,0.19,0.0,0.03,0.0,0.0,0.0,christopher hopkins,
-MKT,4500,2,Strategic Mktg Mgt,0.29,0.68,0.03,0.0,0.0,0.0,0.0,0.0,christopher hopkins,
-MKT,4500,3,Strategic Mktg Mgt,0.73,0.24,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,
-MKT,4500,4,Strategic Mktg Mgt,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,8620,1,Quant Methods in Mkt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
-MKT,8650,1,Seminar in Mkt Mgmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MKT,8660,1,International Marketing,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,thomas poehlman,
-ML,1020,1,Leadership Fund II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,clay wilson etterle,
-ML,1020,2,Leadership Fund II,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,amanda carol kane,
-ML,2020,1,Leadership Development II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,shane allen werst,
-ML,2020,2,Leadership Development II,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,shane allen werst,
-ML,3020,1,Advanced Leadership II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,
-ML,3020,2,Advanced Leadership II,0.88,0.04,0.0,0.04,0.0,0.0,0.0,0.04,william cod cleland,
-MSE,2100,1,Intro to Mat Science,0.47,0.2,0.16,0.06,0.06,0.0,0.0,0.05,rakhee pani,
-MSE,2100,2,Intro to Mat Science,0.3,0.46,0.12,0.0,0.03,0.0,0.0,0.09,eric skaar,
-MSE,2100,3,Intro to Mat Science,0.23,0.2,0.23,0.13,0.08,0.0,0.0,0.14,fei peng,
-MSE,2100,4,Intro to Mat Science,0.41,0.34,0.17,0.06,0.02,0.0,0.0,0.0,olga kuksenok,
-MSE,2410,1,Metrics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
-MSE,2410,2,Metrics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
-MSE,2500,1,Polymer & Fiber Materials I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,
-MSE,3260,1,Thermo of Materials,0.33,0.26,0.26,0.04,0.09,0.0,0.0,0.02,gary lickfield,
-MSE,3270,1,Transport Phenomena,0.23,0.4,0.13,0.13,0.07,0.0,0.0,0.03,ulf daniel schiller,
-MSE,3280,1,Phase Diagrams,0.5,0.11,0.25,0.0,0.0,0.0,0.0,0.14,eric skaar,
-MSE,3420,1,Struct/Property,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,rajendra kum bordia,
-MSE,3420,2,Struct/Property,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,rajendra kum bordia,
-MSE,3610,1,Proc of Metals & Composites,0.3,0.49,0.08,0.05,0.0,0.0,0.0,0.08,marian kennedy,
-MSE,4150,1,Polymer Sc Engr,0.48,0.23,0.2,0.05,0.03,0.0,0.0,0.03,igor luzinov,
-MSE,4160,1,Electronic Materials,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,
-MSE,4220,1,Mech Behavior of Mat,0.26,0.5,0.15,0.02,0.0,0.0,0.0,0.07,vincent yves blouin,
-MSE,4240,1,Optical Materials,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,4330,1,Comb Sys & Env Emiss,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
-MSE,4560,1,Polymer & Fiber Materials II,0.32,0.39,0.21,0.04,0.0,0.0,0.0,0.04,gary lickfield,
-MSE,4810,1,Undergraduate Research Fundame,0.81,0.13,0.03,0.03,0.0,0.0,0.0,0.0,marian kennedy,
-MSE,4910,1,Undergraduate Research,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,marian kennedy,
-MSE,4910,2,Undergraduate Research,0.62,0.15,0.08,0.0,0.08,0.0,0.0,0.08,marian kennedy,
-MSE,8010,1,Grad Sem in Materials Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,olga kuksenok,
-MSE,8250,1,Solid State Mtl Sci,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,stephen foulger,
-MSE,8520,1,Polymer Science II,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,igor luzinov,
-MUSC,1420,1,Music Theory I,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,anthony bernarducci,
-MUSC,1440,1,Music Theory II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,
-MUSC,1450,1,Aural Skills II,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,andrew levin,
-MUSC,1510,2,Applied Music,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,jonathan edwa doyel,
-MUSC,2100,1,Music in the Western World,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,2100,2,Music in the Western World,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
-MUSC,2100,3,Music in the Western World,0.69,0.19,0.09,0.0,0.0,0.0,0.0,0.03,linda li-bleuel,
-MUSC,2100,4,Music in the Western World,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,5,Music in the Western World,0.44,0.44,0.09,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,
-MUSC,2100,6,Music in the Western World,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,8,Music in the Western World,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,monty craig,
-MUSC,2100,9,Music in the Western World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,lea kibler,
-MUSC,3110,1,History of American Music,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,3170,1,Hist of Country Mus,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3180,1,Hist of Audio Tech,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,bruce allen whisler,
-MUSC,3640,1,Concert Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,timothy ra hurlburt,
-MUSC,3690,1,Symphony Orchestra,0.94,0.02,0.0,0.0,0.02,0.0,0.0,0.02,andrew levin,
-MUSC,4160,1,Mus Hist Since 1750,0.52,0.11,0.04,0.22,0.07,0.0,0.0,0.04,linda li-bleuel,
-MUSC,4300,1,Conducting,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,mark spede,
-NPL,3000,1,Nonprofit Leadership,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
-NPL,3000,2,Nonprofit Leadership,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,bonnie west stevens,
-NPL,3010,2,NPL Stakeholders,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
-NPL,3030,2,NPL Personnel,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,wendell price,
-NURS,1400,1,Comp App Hlth Care,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
-NURS,3030,1,Nursing of Adults,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3030,400,Nursing of Adults,0.14,0.68,0.18,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3040,1,Pathophysiology,0.39,0.49,0.06,0.04,0.02,0.0,0.0,0.0,catherine si murton,
-NURS,3040,401,Pathophysiology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,
-NURS,3050,1,Psychosocial Nursing,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,barbara jean warner,
-NURS,3050,400,Psychosocial Nursing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
-NURS,3100,1,Health Assessment,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
-NURS,3120,1,Foundations of Nursing,0.34,0.55,0.09,0.02,0.0,0.0,0.0,0.0,angela pye,
-NURS,3190,400,Health Assessment for RNs,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,jennifer geter rice,
-NURS,3330,400,Health Care Genetics,0.87,0.07,0.0,0.07,0.0,0.0,0.0,0.0,mary steck,
-NURS,3330,401,Health Care Genetics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-NURS,3400,1,Pharmther Nursing,0.35,0.46,0.1,0.06,0.02,0.0,0.0,0.0,catherine si murton,
-NURS,4010,1,Mental Health Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NURS,4030,1,Complex Nursing of Adults,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,
-NURS,4110,1,Nursing of Children,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,
-NURS,4120,1,Nurs Women and Fam,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8010,400,Adv Fam & Comm Nrsng,0.89,0.08,0.0,0.0,0.0,0.0,0.0,0.03,shirley mae timmons,
-NURS,8010,401,Adv Fam & Comm Nrsng,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
-NURS,8080,400,Nurs Res Stat Analys,0.64,0.22,0.08,0.0,0.06,0.0,0.0,0.0,veronica parker,
-NURS,8190,400,Developing Family,0.43,0.07,0.0,0.0,0.47,0.0,0.0,0.03,lisa miller,
-NURS,8200,400,Child & Adol Nursing,0.14,0.23,0.0,0.0,0.59,0.0,0.0,0.05,heide temples,
-NURS,8210,400,Adult Nursing,0.47,0.17,0.0,0.0,0.37,0.0,0.0,0.0,tracy king fasolino,
-NURS,8210,401,Adult Nursing,0.41,0.41,0.0,0.0,0.14,0.0,0.0,0.03,tracy king fasolino,
-NURS,8230,400,NP Clinical Practicum,0.96,0.0,0.0,0.0,0.04,0.0,0.0,0.0,rosanne pruitt,
-NURS,8840,400,Adult Mental Health,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,lindsey reb garrard,
-NURS,8850,400,Mental Health in Primary Care,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.34,0.49,0.09,0.03,0.02,0.0,0.0,0.03,elizabeth durrance,
-NUTR,2030,2,Intro Princ of Human Nutrition,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
-NUTR,2040,1,Nutrition Across Life Cycle,0.5,0.4,0.07,0.02,0.02,0.0,0.0,0.0,elizabeth durrance,
-NUTR,4180,1,Prof Development in Dietetics,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4250,1,Medica Nutr Thera II,0.45,0.42,0.13,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4260,1,Community Nutrition,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,margaret condrasky,
-NUTR,4550,1,Human Nutr & Metabolism II,0.54,0.29,0.11,0.03,0.03,0.0,0.0,0.0,elliot jesch,
-PA,2790,1,Perf Arts Pract I,0.6,0.2,0.0,0.2,0.0,0.0,0.0,0.0,kenneth moore,
-PA,2800,1,Perf Arts Pract II,0.5,0.06,0.0,0.13,0.19,0.0,0.0,0.13,kenneth moore,
-PADM,8220,400,Public Policy Process,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,
-PADM,8270,400,Public Personnel Admin,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,lawrence nichols,
-PADM,8290,400,Public Financial Management,0.57,0.29,0.0,0.0,0.07,0.0,0.0,0.07,robert frager,
-PADM,8410,400,Public Data Analysis,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
-PADM,8410,401,Public Data Analysis,0.78,0.0,0.11,0.0,0.11,0.0,0.0,0.0,ronald chrestman,
-PADM,8410,402,Public Data Analysis,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
-PADM,8450,400,Grant Writing for Public Admin,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,katheri kransteuber,
-PADM,8520,400,Emergency Mgt Planning & Prep,0.73,0.13,0.0,0.0,0.13,0.0,0.0,0.0,amanda nico ritsema,
-PADM,8540,400,Cybersecurity,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,david leigh cook,
-PADM,8680,400,Local Government Admin,0.36,0.45,0.0,0.0,0.18,0.0,0.0,0.0,alfred bundrick,
-PADM,8780,402,Local Govt. Budgeting & Financ,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,kevin yokim,
-PADM,8780,405,Regional Econ Devlpmnt Policy,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,lori ann dickes,
-PAS,3010,1,Pan African Studies,0.74,0.17,0.0,0.0,0.04,0.0,0.0,0.04,garry bertholf,
-PES,2020,1,Soils,0.3,0.33,0.35,0.0,0.02,0.0,0.0,0.0,dara michelle park,
-PES,4230,1,Field Crops - Forages,0.12,0.19,0.54,0.08,0.04,0.0,0.0,0.04,matias jose aguerre,
-PES,4330,1,Landscape & Turf Weed Mgt,0.07,0.71,0.14,0.0,0.07,0.0,0.0,0.0,ted whitwell,
-PES,4450,1,Regulatory Issues & Policies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,
-PES,4520,1,Soil Fertility and Management,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
-PES,4900,1,Soil Organisms in Plant Growth,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,"appukuttan suseela,",
-PES,6900,1,Soil Organisms in Plant Growth,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,"appukuttan suseela,",
-PES,8010,1,Crop Physiology and Nutrition,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,sruthi naraya kutty,
-PHIL,1010,1,Intro to Philosophic Problems,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,david stegall,
-PHIL,1010,2,Intro to Philosophic Problems,0.6,0.17,0.11,0.03,0.09,0.0,0.0,0.0,david stegall,
-PHIL,1010,3,Intro to Philosophic Problems,0.21,0.55,0.15,0.0,0.03,0.0,0.0,0.06,kelly smith,
-PHIL,1010,5,Intro to Philosophic Problems,0.26,0.47,0.16,0.0,0.05,0.0,0.0,0.05,john randall wolfe,
-PHIL,1010,6,Intro to Philosophic Problems,0.54,0.23,0.14,0.0,0.06,0.0,0.0,0.03,john randall wolfe,
-PHIL,1010,7,Intro to Philosophic Problems,0.52,0.36,0.06,0.0,0.03,0.0,0.0,0.03,john randall wolfe,
-PHIL,1020,1,Introduction to Logic,0.75,0.11,0.08,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
-PHIL,1020,2,Introduction to Logic,0.77,0.14,0.06,0.03,0.0,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,3,Introduction to Logic,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,michael hal hannen,
-PHIL,1020,4,Introduction to Logic,0.59,0.26,0.12,0.03,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1020,5,Introduction to Logic,0.71,0.18,0.03,0.0,0.03,0.0,0.0,0.06,adam gies,
-PHIL,1020,6,Introduction to Logic,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1030,2,Introduction to Ethics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,
-PHIL,1030,3,Introduction to Ethics,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,william maker,
-PHIL,1030,5,Introduction to Ethics,0.5,0.32,0.09,0.03,0.03,0.0,0.0,0.03,edyta joanna kuzian,
-PHIL,1030,6,Introduction to Ethics,0.51,0.4,0.03,0.0,0.0,0.0,0.0,0.06,john jung park,
-PHIL,1030,7,Introduction to Ethics,0.46,0.43,0.09,0.03,0.0,0.0,0.0,0.0,john jung park,
-PHIL,1030,8,Introduction to Ethics,0.31,0.46,0.12,0.04,0.04,0.0,0.0,0.04,charles starkey,
-PHIL,1030,9,Introduction to Ethics,0.54,0.31,0.09,0.06,0.0,0.0,0.0,0.0,edyta joanna kuzian,
-PHIL,1030,10,Introduction to Ethics,0.54,0.31,0.11,0.0,0.03,0.0,0.0,0.0,john jung park,
-PHIL,3040,1,Moral Philosophy,0.31,0.15,0.23,0.23,0.0,0.0,0.0,0.08,john jung park,
-PHIL,3050,2,Existentialism,0.84,0.09,0.0,0.0,0.06,0.0,0.0,0.0,david stegall,
-PHIL,3150,1,Ancient Philosophy,0.32,0.26,0.21,0.05,0.05,0.0,0.0,0.11,jennifer ingle,
-PHIL,3160,1,Modern Philosophy,0.47,0.41,0.06,0.0,0.03,0.0,0.0,0.03,michael hal hannen,
-PHIL,3170,1,19th-Century Philosophy,0.19,0.31,0.31,0.06,0.06,0.0,0.0,0.06,william maker,
-PHIL,3180,1,20th-Century Philosophy,0.59,0.33,0.07,0.0,0.0,0.0,0.0,0.0,john randall wolfe,
-PHIL,3210,1,Crime & Punishment,0.34,0.48,0.14,0.0,0.03,0.0,0.0,0.0,daniel wueste,
-PHIL,3250,2,Phil of Science,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,3260,1,Science and Values,0.47,0.47,0.0,0.0,0.06,0.0,0.0,0.0,andrew garnar,
-PHIL,3260,2,Science and Values,0.41,0.38,0.0,0.0,0.03,0.0,0.0,0.18,andrew garnar,
-PHIL,3260,3,Science and Values,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,
-PHIL,3280,1,Technology of Bodies,0.54,0.31,0.08,0.04,0.0,0.0,0.0,0.04,edyta joanna kuzian,
-PHIL,3450,1,Environmental Ethics,0.51,0.29,0.09,0.06,0.03,0.0,0.0,0.03,jennifer ingle,
-PHIL,3450,2,Environmental Ethics,0.51,0.34,0.11,0.0,0.03,0.0,0.0,0.0,jennifer ingle,
-PHIL,3490,2,Gender and Sexuality,0.52,0.43,0.05,0.0,0.0,0.0,0.0,0.0,diane perpich,
-PHIL,4010,1,Studies in the Hist of Phil,0.71,0.06,0.0,0.0,0.12,0.0,0.0,0.12,david stegall,
-PHIL,4750,1,Philosophy of Film,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,christopher grau,
-PHSC,1170,1,Intro Chem & Earth,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics with Calculus I,0.18,0.47,0.22,0.07,0.05,0.0,0.0,0.01,amy liann pope,
-PHYS,1220,2,Physics with Calculus I,0.19,0.46,0.23,0.03,0.02,0.0,0.0,0.07,lih-sin the,
-PHYS,1220,3,Physics with Calculus I,0.14,0.49,0.29,0.04,0.01,0.0,0.0,0.02,apparao rao,
-PHYS,1220,4,Physics with Calculus I,0.22,0.49,0.22,0.02,0.01,0.0,0.0,0.03,jason stratfo brown,
-PHYS,1220,5,Physics with Calculus I,0.27,0.51,0.15,0.04,0.01,0.0,0.0,0.02,pooja puneet,
-PHYS,1220,8,Physics With Cal I (HON),0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True
-PHYS,1240,1,Physics Lab I,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,2,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,3,Physics Lab I,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,4,Physics Lab I,0.28,0.61,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,
-PHYS,1240,5,Physics Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,6,Physics Lab I,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,7,Physics Lab I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,1240,8,Physics Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,9,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,10,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,11,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,12,Physics Lab I,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,13,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,15,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,16,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,17,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,19,Physics Lab I,0.24,0.59,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,20,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,21,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,22,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,24,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,25,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,26,Physics Lab I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,27,Physics Lab I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,1240,29,Physics Lab I,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,1240,30,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2000,1,Introductory Physics,0.49,0.4,0.04,0.03,0.04,0.0,0.0,0.0,sean brittain,
-PHYS,2070,1,General Physics I,0.38,0.4,0.14,0.03,0.02,0.0,0.0,0.03,amy liann pope,
-PHYS,2080,1,General Physics II,0.51,0.33,0.1,0.03,0.02,0.0,0.0,0.0,pooja puneet,
-PHYS,2080,2,General Physics II,0.65,0.28,0.05,0.0,0.01,0.0,0.0,0.0,pooja puneet,
-PHYS,2090,1,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,2,Gen Phys Lab I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,3,Gen Phys Lab I,0.17,0.74,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,4,Gen Phys Lab I,0.31,0.44,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,
-PHYS,2090,5,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2090,6,Gen Phys Lab I,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2090,7,Gen Phys Lab I,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,jerry hester,
-PHYS,2090,9,Gen Phys Lab I,0.52,0.35,0.0,0.0,0.09,0.0,0.0,0.04,jerry hester,
-PHYS,2090,10,Gen Phys Lab I,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,1,Gen Phys Lab II,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,2,Gen Phys Lab II,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,3,Gen Phys Lab II,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,4,Gen Phys Lab II,0.46,0.33,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,5,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,6,Gen Phys Lab II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,7,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,10,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,11,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,12,Gen Phys Lab II,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,13,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2100,14,Gen Phys Lab II,0.75,0.13,0.08,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,15,Gen Phys Lab II,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,16,Gen Phys Lab II,0.57,0.39,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,
-PHYS,2100,17,Gen Phys Lab II,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,
-PHYS,2100,18,Gen Phys Lab II,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2210,1,Physics with Calculus II,0.28,0.34,0.27,0.06,0.03,0.0,0.0,0.02,jason stratfo brown,
-PHYS,2210,2,Physics with Calculus II,0.24,0.41,0.23,0.03,0.06,0.0,0.0,0.02,jason stratfo brown,
-PHYS,2210,500,Physics With Calculus II,0.2,0.4,0.33,0.07,0.0,0.0,0.0,0.0,elaine parshall,
-PHYS,2220,1,Physics with Calculus III,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,jian he,
-PHYS,2230,1,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,2,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,
-PHYS,2230,5,Physics Lab II,0.36,0.36,0.18,0.0,0.09,0.0,0.0,0.0,jerry hester,
-PHYS,2230,6,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,7,Physics Lab II,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,
-PHYS,2230,8,Physics Lab II,0.83,0.06,0.0,0.11,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,9,Physics Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2230,500,Physics Lab II,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,elaine parshall,
-PHYS,2240,1,Physics Lab III,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,
-PHYS,2400,1,Phys of Weather,0.35,0.41,0.11,0.02,0.0,0.0,0.0,0.11,miguel larsen,
-PHYS,3110,1,Methods Theor Phys,0.31,0.46,0.08,0.0,0.04,0.0,0.0,0.12,antony valentini,
-PHYS,3220,1,Mechanics II,0.18,0.45,0.18,0.0,0.09,0.0,0.0,0.09,joshua alper,
-PHYS,3260,1,Exper Physics II,0.6,0.2,0.12,0.0,0.04,0.0,0.0,0.04,chad sosolik,
-PHYS,4650,1,Thermo and Stat Mech,0.46,0.15,0.31,0.0,0.0,0.0,0.0,0.08,feng ding,
-PHYS,6560,1,Quantum Physics II,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,ramakrishna podila,
-PHYS,8150,1,Statistical Therm I,0.11,0.67,0.11,0.0,0.0,0.0,0.0,0.11,jens oberheide,
-PHYS,8410,1,Electrodynamics I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
-PHYS,9520,1,Quantum Mech II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,domnita marinescu,
-PKSC,1020,1,Intro to Pkg Sci,0.31,0.44,0.16,0.06,0.01,0.0,0.0,0.02,heather batt,
-PKSC,2010,1,Pkg Perishable Prod,0.15,0.34,0.24,0.08,0.1,0.0,0.0,0.1,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,
-PKSC,2040,1,Container Systems,0.93,0.02,0.03,0.0,0.02,0.0,0.0,0.0,robert truett moore,
-PKSC,2060,1,Container Sys Lab,0.57,0.33,0.05,0.05,0.0,0.0,0.0,0.0,tyler stuettgen,
-PKSC,2060,2,Container Sys Lab,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,
-PKSC,2060,3,Container Sys Lab,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,tyler stuettgen,
-PKSC,2200,1,Product & Pkg Design,0.83,0.1,0.02,0.0,0.02,0.0,0.0,0.02,william aaro snyder,
-PKSC,3200,1,Pkg Design Theory,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,rupert hurley,
-PKSC,3680,1,Pkg and Society,0.31,0.38,0.17,0.03,0.03,0.0,0.0,0.07,heather batt,
-PKSC,4030,1,Pkg Career Prep,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4200,1,Pkg Design & Dev,0.71,0.17,0.11,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4240,400,Structural Pkg Design Online,0.6,0.1,0.0,0.0,0.2,0.0,0.0,0.1,rupert hurley,
-PKSC,4300,1,Converting Flex Pkg,0.16,0.62,0.13,0.03,0.04,0.0,0.0,0.01,duncan darby,
-PKSC,4400,1,Packaging for Distribution,0.17,0.46,0.22,0.04,0.11,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1,Food & Health Care Pkg Systems,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kay cooksey,
-PKSC,8220,400,3D Parametric Design,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,rupert hurley,
-PLPA,2130,1,Fungi & Civilization,0.37,0.37,0.17,0.06,0.02,0.0,0.0,0.01,julia loui kerrigan,
-PLPA,4060,1,Diseases/Insects Turfgrasses,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,samuel martin,
-PLPA,8090,1,Analytical Technique,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,
-POSC,1010,2,Amer National Govt,0.08,0.36,0.12,0.16,0.24,0.0,0.0,0.04,adam warber,
-POSC,1010,3,Amer National Govt,0.05,0.33,0.33,0.1,0.0,0.0,0.0,0.2,james woodard,
-POSC,1020,1,Intro Intl Relations,0.26,0.42,0.22,0.04,0.02,0.0,0.0,0.04,tara elizabet trask,
-POSC,1020,2,Intro Intl Relations,0.16,0.29,0.3,0.13,0.04,0.0,0.0,0.07,aron geo tannenbaum,
-POSC,1020,3,Intro Intl Relations,0.1,0.45,0.27,0.09,0.03,0.0,0.0,0.05,zeynep taydas,
-POSC,1020,5,Intro Intl Relations,0.23,0.31,0.27,0.08,0.04,0.0,0.0,0.08,joshua douglas king,
-POSC,1030,1,Intro to Political Theory,0.24,0.33,0.2,0.09,0.13,0.0,0.0,0.01,brandon turner,
-POSC,1030,2,Intro to Political Theory,0.23,0.65,0.08,0.0,0.0,0.0,0.0,0.04,colin pearce,
-POSC,1040,1,Intro Compar Pol,0.29,0.31,0.16,0.02,0.11,0.0,0.0,0.11,katherine am curtis,
-POSC,1040,2,Intro Compar Pol,0.48,0.26,0.09,0.09,0.04,0.0,0.0,0.04,tara elizabet trask,
-POSC,1990,1,Intro Pol Sci,0.48,0.25,0.12,0.06,0.04,0.0,0.0,0.06,meredith petersheim,
-POSC,3020,1,State and Loc Gov,0.17,0.52,0.17,0.0,0.02,0.0,0.0,0.12,bruce ransom,
-POSC,3210,1,Public Admin,0.13,0.35,0.43,0.0,0.04,0.0,0.0,0.04,james woodard,
-POSC,3610,1,Intl Pol in Crisis,0.25,0.25,0.1,0.05,0.18,0.0,0.0,0.18,steven vince miller,
-POSC,3630,1,Us Foreign Policy,0.38,0.27,0.19,0.04,0.12,0.0,0.0,0.0,jeffrey scott peake,
-POSC,3710,1,European Politics,0.51,0.29,0.1,0.04,0.04,0.0,0.0,0.02,vladimir matic,
-POSC,3750,1,European Integration,0.37,0.19,0.26,0.07,0.07,0.0,0.0,0.04,katherine am curtis,
-POSC,3810,1,African Amer Politic,0.33,0.47,0.2,0.0,0.0,0.0,0.0,0.0,bruce ransom,
-POSC,4050,1,American Presidency,0.08,0.21,0.37,0.11,0.21,0.0,0.0,0.03,adam warber,
-POSC,4160,1,Int Groups & Soc Mov,0.29,0.38,0.2,0.07,0.04,0.0,0.0,0.02,laura olson,
-POSC,4360,1,Law Courts Politics,0.36,0.36,0.2,0.0,0.04,0.0,0.0,0.04,joseph earl stewart,
-POSC,4360,2,Law Courts Politics,0.32,0.5,0.06,0.06,0.03,0.0,0.0,0.03,joseph earl stewart,
-POSC,4370,1,Constitut Law: Rights & Libert,0.24,0.53,0.14,0.02,0.04,0.0,0.0,0.02,daniel frost,
-POSC,4500,1,Contemporary Political Thought,0.36,0.44,0.2,0.0,0.0,0.0,0.0,0.0,daniel frost,
-POSC,4530,1,American Political Thought,0.25,0.45,0.18,0.05,0.05,0.0,0.0,0.03, bradley thompson,
-POSC,4710,1,Russian Politics,0.38,0.33,0.15,0.0,0.05,0.0,0.0,0.08,aron geo tannenbaum,
-POSC,4760,1,Middle East Politics,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,vladimir matic,
-POSC,4890,1,Voting Rights Law Politics Pol,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
-PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,jamie lynn cathey,
-PRTM,2200,1,Foundations of PRTM,0.32,0.52,0.1,0.06,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2200,2,Foundations of PRTM,0.67,0.13,0.13,0.0,0.03,0.0,0.0,0.03,gwynn powell,
-PRTM,2200,3,Foundations of PRTM,0.36,0.43,0.11,0.04,0.07,0.0,0.0,0.0,katherine an jordan,
-PRTM,2200,4,Foundations of PRTM,0.58,0.26,0.03,0.06,0.06,0.0,0.0,0.0,ryan joseph gagnon,
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2270,1,Prov of Leisure Exp,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2290,1,Competency Integration in PRTM,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2410,1,Intro to CRSCM,0.62,0.24,0.05,0.0,0.07,0.0,0.0,0.02,harrison pinckney,
-PRTM,2600,1,Found of Recreational Therapy,0.53,0.36,0.08,0.01,0.01,0.0,0.0,0.01,anna-mar chancellor,
-PRTM,2650,1,Terminology in RT Practice,0.88,0.09,0.0,0.03,0.0,0.0,0.0,0.0,stephen thoma lewis,
-PRTM,2700,1,Intro Rec Res Mgt,0.54,0.39,0.0,0.0,0.07,0.0,0.0,0.0,elizabeth baldwin,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.21,0.48,0.27,0.03,0.0,0.0,0.0,0.0,daniel mor anderson,
-PRTM,3070,1,Facility Operations,0.64,0.18,0.09,0.09,0.0,0.0,0.0,0.0,raymond dunham,
-PRTM,3210,1,Recreation Admin,0.67,0.27,0.03,0.0,0.03,0.0,0.0,0.0,mariela fernandez,
-PRTM,3250,1,Global Persp in Rec,0.42,0.39,0.06,0.0,0.12,0.0,0.0,0.0,skye arthur-banning,
-PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.89,0.1,0.02,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
-PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3280,2,Preceptorship in Recr Therapy,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,stephen thoma lewis,
-PRTM,3420,1,Intro to Tourism,0.73,0.24,0.0,0.0,0.02,0.0,0.0,0.0,li-hsin chen,
-PRTM,3420,2,Intro to Tourism,0.73,0.23,0.02,0.0,0.02,0.0,0.0,0.0,garrett stone,
-PRTM,3440,1,Tourism Markets,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,
-PRTM,3440,2,Tourism Markets,0.75,0.23,0.03,0.0,0.0,0.0,0.0,0.0,zeynep gedikoglu,
-PRTM,3450,1,Tourism Management,0.48,0.29,0.19,0.0,0.03,0.0,0.0,0.0,william norman,
-PRTM,3450,2,Tourism Management,0.41,0.47,0.13,0.0,0.0,0.0,0.0,0.0,william norman,
-PRTM,3460,1,Heritage Tourism,0.33,0.37,0.23,0.07,0.0,0.0,0.0,0.0,gregory phi ramshaw,
-PRTM,3460,2,Heritage Tourism,0.21,0.55,0.14,0.0,0.07,0.0,0.0,0.03,gregory phi ramshaw,
-PRTM,3530,2,Foundations of Camp Counseling,0.8,0.0,0.0,0.0,0.13,0.0,0.0,0.07,gwynn powell,
-PRTM,3830,1,Golf Shop Operations,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3900,3,Independent Study in PRTM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3910,1,Mgmt Admin Outdr Rec Programs,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,robert baxte powell,
-PRTM,3910,9,Intro to GIS for PRTM,0.27,0.64,0.0,0.0,0.09,0.0,0.0,0.0,david lawrenc white,
-PRTM,4210,1,Rec Fin Resc Mgt,0.5,0.38,0.1,0.0,0.03,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,4260,1,Trends & Issues in Rec Therapy,0.62,0.29,0.07,0.0,0.0,0.0,0.0,0.02,brent hawkins,
-PRTM,4300,1,World Geog Parks,0.22,0.54,0.22,0.0,0.03,0.0,0.0,0.0,robert baxte powell,
-PRTM,4310,1,Mthds of Envir Interpretation,0.67,0.08,0.25,0.0,0.0,0.0,0.0,0.0,robert bixler,
-PRTM,4460,2,Community Tourism,0.67,0.2,0.1,0.03,0.0,0.0,0.0,0.0,lauren duffy,
-PRTM,4460,3,Community Tourism,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,lauren duffy,
-PRTM,4510,1,Seminar in CRSCM,0.59,0.25,0.09,0.03,0.0,0.0,0.0,0.03,jamie lynn cathey,
-PRTM,4550,1,Adv Program Planning,0.59,0.23,0.14,0.0,0.05,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,4980,7,Tanzania,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,skye arthur-banning,
-PRTM,8030,1,Sem Rec & Park Admin,0.65,0.25,0.05,0.0,0.05,0.0,0.0,0.0,teresa walto tucker,
-PRTM,8110,2,Research Methods,0.35,0.53,0.09,0.0,0.03,0.0,0.0,0.0,dorothy schmalz,
-PRTM,8110,3,Research Methods,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,
-PRTM,8250,1,Populations in PRTM,0.5,0.33,0.0,0.0,0.17,0.0,0.0,0.0,dorothy schmalz,
-PRTM,8500,2,Sustainable Tourism,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,kenneth backman,
-PRTM,8720,1,Adv Facilitation Techniq in RT,0.6,0.0,0.2,0.0,0.0,0.0,0.0,0.2,jasmine nu townsend,
-PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.7,0.0,0.0,0.0,0.2,0.0,0.0,0.1,stephen thoma lewis,
-PRTM,9000,4,Politics of Science,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,gary edward machlis,
-PRTM,9110,1,Professional Issues,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,gwynn powell,
-PSYC,2010,1,Intro to Psychology,0.43,0.28,0.16,0.07,0.04,0.0,0.0,0.02,jo anne jorgensen,
-PSYC,2010,2,Intro to Psychology,0.2,0.28,0.23,0.13,0.08,0.0,0.0,0.08,edwin brainerd,
-PSYC,2010,3,Intro to Psychology,0.22,0.36,0.3,0.04,0.01,0.0,0.0,0.06,thomas britt,
-PSYC,2010,4,Intro to Psychology,0.44,0.34,0.16,0.03,0.01,0.0,0.0,0.01,fred switzer,
-PSYC,2010,5,Intro to Psychology,0.36,0.3,0.16,0.12,0.03,0.0,0.0,0.03,mary taylor,
-PSYC,2010,6,Intro to Psychology,0.36,0.36,0.19,0.1,0.0,0.0,0.0,0.0,mary taylor,
-PSYC,2010,7,Intro to Psychology (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
-PSYC,2020,3,Intro Psychology Lab,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,madison eliza sauls,
-PSYC,2020,4,Intro Psychology Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,
-PSYC,2020,5,Intro Psychology Lab,0.86,0.04,0.04,0.0,0.04,0.0,0.0,0.04,nastassia ma savage,
-PSYC,2020,6,Intro Psychology Lab,0.81,0.07,0.04,0.04,0.0,0.0,0.0,0.04,nastassia ma savage,
-PSYC,3060,1,Human Sexual Beh,0.55,0.23,0.12,0.05,0.04,0.0,0.0,0.01,bruce michael king,
-PSYC,3090,100,Intro Exp Psych,0.25,0.37,0.17,0.08,0.08,0.0,0.0,0.04,richard tyrrell,
-PSYC,3090,200,Intro Exp Psych,0.48,0.27,0.15,0.03,0.06,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3090,300,Intro Exp Psych,0.55,0.26,0.1,0.03,0.06,0.0,0.0,0.0,stephen robertson,
-PSYC,3100,100,Advanced Experimental Psych,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimental Psych,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,robert campbell,
-PSYC,3100,300,Advanced Experimental Psych,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,cynthia pury,
-PSYC,3100,400,Advanced Experimental Psych,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,3100,500,Advanced Experimental Psych,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3100,600,Advanced Experimental Psych,0.43,0.52,0.0,0.0,0.05,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3240,1,Physiological Psych,0.48,0.23,0.14,0.07,0.07,0.0,0.0,0.0,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.24,0.39,0.25,0.06,0.03,0.0,0.0,0.03,june pilcher,
-PSYC,3330,1,Cognitive Psych,0.45,0.26,0.2,0.03,0.06,0.0,0.0,0.0,robert campbell,
-PSYC,3330,2,Cognitive Psych,0.46,0.38,0.13,0.03,0.0,0.0,0.0,0.01,leah hartman,
-PSYC,3340,1,Cognitive Psych Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,
-PSYC,3340,2,Cognitive Psych Lab,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,tiffany cooper,
-PSYC,3400,1,Lifespan Developmental Psych,0.64,0.24,0.08,0.02,0.02,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3400,2,Lifespan Developmental Psych,0.21,0.34,0.2,0.1,0.03,0.0,0.0,0.11,pamela alley,
-PSYC,3520,1,Social Psychology,0.64,0.26,0.06,0.01,0.01,0.0,0.0,0.01,eric mckibben,
-PSYC,3520,2,Social Psychology,0.36,0.39,0.2,0.03,0.0,0.0,0.0,0.03,eric mckibben,
-PSYC,3640,1,Industrial Psych,0.19,0.41,0.26,0.04,0.03,0.0,0.0,0.06,eric mckibben,
-PSYC,3640,2,Industrial Psych,0.33,0.4,0.24,0.01,0.01,0.0,0.0,0.0,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.16,0.49,0.26,0.04,0.04,0.0,0.0,0.01,gargi sawhney,
-PSYC,3830,1,Abnormal Psychology,0.48,0.34,0.09,0.05,0.04,0.0,0.0,0.0,jo anne jorgensen,
-PSYC,3830,2,Abnormal Psychology,0.48,0.28,0.17,0.06,0.0,0.0,0.0,0.01,jo anne jorgensen,
-PSYC,3830,3,Abnormal Psychology,0.23,0.34,0.26,0.11,0.03,0.0,0.0,0.03,pamela alley,
-PSYC,3830,4,Abnormal Psychology,0.34,0.26,0.11,0.09,0.11,0.0,0.0,0.09,pamela alley,
-PSYC,4080,1,Women and Psychology,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,
-PSYC,4080,2,Women and Psychology,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,robin mari kowalski,
-PSYC,4150,1,Systems and Theories,0.23,0.37,0.2,0.03,0.09,0.0,0.0,0.09,edwin brainerd,
-PSYC,4150,2,Systems and Theories,0.34,0.2,0.26,0.14,0.06,0.0,0.0,0.0,edwin brainerd,
-PSYC,4150,3,Systems and Theories,0.37,0.37,0.16,0.03,0.03,0.0,0.0,0.05,brian day,
-PSYC,4150,3,Systems and Theories,0.37,0.37,0.16,0.03,0.03,0.0,0.0,0.05,brian day,
-PSYC,4220,1,Perception,0.41,0.3,0.11,0.11,0.04,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4220,2,Perception,0.54,0.15,0.23,0.0,0.04,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4220,3,Perception,0.24,0.28,0.24,0.16,0.08,0.0,0.0,0.0,christopher pagano,
-PSYC,4350,1,Human Factors,0.52,0.16,0.32,0.0,0.0,0.0,0.0,0.0,laura whitlock,
-PSYC,4560,1,Psychophysiology,0.36,0.2,0.24,0.08,0.08,0.0,0.0,0.04,drew michael morris,
-PSYC,4560,1,Psychophysiology,0.36,0.2,0.24,0.08,0.08,0.0,0.0,0.04,drew michael morris,
-PSYC,4710,1,Psych of Testing,0.52,0.29,0.1,0.05,0.0,0.0,0.0,0.05,robert ray sinclair,
-PSYC,4800,1,Health Psychology,0.41,0.52,0.04,0.0,0.0,0.0,0.0,0.04,james mccubbin,
-PSYC,4800,2,Health Psychology,0.32,0.52,0.12,0.0,0.0,0.0,0.0,0.04,james mccubbin,
-PSYC,4880,1,Psychotherapy,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,lucinda sorci quick,
-PSYC,4890,1,21st Cen Teamwork,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,marissa leig porter,
-PSYC,4920,4,Senior Laboratory,0.89,0.04,0.0,0.04,0.04,0.0,0.0,0.0,miranda pelkey,
-PSYC,4920,5,Senior Laboratory,0.77,0.09,0.05,0.0,0.0,0.0,0.0,0.09,dana verhoeven,
-PSYC,4980,291,CI Suicide Prevention,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,heidi marie zinzow,
-PSYC,8130,1,Research Design III,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05, dewayne moore,
-PSYC,8140,1,Quantitative Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,
-PSYC,8680,1,Leadership in Orgs,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,patrick raymark,
-PSYC,8710,1,Psych Tests,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,mary taylor,
-PSYC,8710,1,Psych Tests,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,mary taylor,
-RCID,8030,1,Emp Res Methods,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
-RED,8030,1,Pub-Priv Partnership,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,
-RED,8040,1,Resid Practicum,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,
-RED,8890,2,Selected Topics-Ad. Fin. Mod.,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,larry bradle harvey,
-REL,1010,1,Intro to Religion,0.32,0.53,0.05,0.05,0.05,0.0,0.0,0.0,steven grosby,
-REL,1010,2,Intro to Religion,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,robert stephens,
-REL,1010,3,Intro to Religion,0.66,0.23,0.03,0.0,0.03,0.0,0.0,0.06,robert stephens,
-REL,1010,4,Intro to Religion,0.38,0.47,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,
-REL,1020,1,World Religions,0.2,0.29,0.31,0.09,0.09,0.0,0.0,0.03,peter cohen,
-REL,1020,2,World Religions,0.2,0.29,0.26,0.17,0.09,0.0,0.0,0.0,peter cohen,
-REL,1020,4,World Religions,0.35,0.29,0.18,0.12,0.03,0.0,0.0,0.03,peter cohen,
-REL,1020,7,World Religions,0.34,0.5,0.13,0.0,0.0,0.0,0.0,0.03,brett patterson,
-REL,3000,2,Studying Religion,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth jemison,
-REL,3010,1,Old Testament,0.43,0.51,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3020,1,New Testament Lit,0.42,0.42,0.06,0.03,0.03,0.0,0.0,0.03,benjamin white,
-REL,3030,1,The Quran,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,mashal saif,
-REL,3100,1,History of Religion in the US,0.28,0.44,0.22,0.0,0.0,0.0,0.0,0.06,elizabeth jemison,
-REL,3120,1,Hinduism,0.15,0.62,0.0,0.0,0.0,0.0,0.0,0.23,robert stephens,
-REL,3170,1,Hist of Nat. Am. Relig/Culture,0.33,0.42,0.17,0.08,0.0,0.0,0.0,0.0,james brad jeffries,
-RS,3010,1,Rural Sociology,0.41,0.48,0.03,0.03,0.03,0.0,0.0,0.0,kenneth robinson,
-RUSS,1020,1,Elementary Russian,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,
-RUSS,3610,1,Russn Lit Since 1910,0.56,0.33,0.06,0.0,0.06,0.0,0.0,0.0,olga anatol volkova,
-SAP,8020,1,Study Abroad Hybrid Grad,0.0,0.0,0.0,0.0,0.0,0.75,0.0,0.25,uttiyo raychaudhuri,
-SOC,2010,2,Introduction to Sociology,0.85,0.06,0.04,0.04,0.0,0.0,0.0,0.0,andrew mannheimer,
-SOC,2010,3,Introduction to Sociology,0.79,0.15,0.04,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,
-SOC,2010,4,Introduction to Sociology,0.69,0.16,0.12,0.0,0.02,0.0,0.0,0.0,jennifer le holland,
-SOC,2010,5,Introduction to Sociology,0.27,0.52,0.13,0.0,0.0,0.0,0.0,0.08,carolyn can coffman,
-SOC,2010,6,Introduction to Sociology,0.68,0.25,0.05,0.0,0.0,0.0,0.0,0.01,shannon mcdonough,
-SOC,2010,7,Introduction to Sociology,0.76,0.18,0.02,0.0,0.0,0.0,0.0,0.04,shannon mcdonough,
-SOC,2010,8,Introduction to Sociology,0.64,0.24,0.1,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,9,Introduction to Sociology,0.21,0.64,0.11,0.04,0.0,0.0,0.0,0.0,mary louise barr,
-SOC,2010,10,Introduction to Sociology,0.37,0.41,0.18,0.0,0.0,0.0,0.0,0.04,mary louise barr,
-SOC,2010,11,Introduction to Sociology,0.17,0.5,0.15,0.1,0.04,0.0,0.0,0.04,mary louise barr,
-SOC,2010,12,Introduction to Sociology,0.28,0.43,0.15,0.06,0.02,0.0,0.0,0.06,mary louise barr,
-SOC,2020,1,Social Problems,0.17,0.61,0.12,0.02,0.07,0.0,0.0,0.0,carolyn can coffman,
-SOC,2020,2,Social Problems,0.33,0.46,0.13,0.09,0.0,0.0,0.0,0.0,carolyn can coffman,
-SOC,2050,1,Sociology Lab,0.55,0.23,0.03,0.0,0.16,0.0,0.0,0.03,brenda vander mey,
-SOC,3020,1,Research Methods I,0.3,0.48,0.17,0.04,0.0,0.0,0.0,0.0,andrew whitehead,
-SOC,3040,1,Social Research Methods II,0.14,0.18,0.55,0.14,0.0,0.0,0.0,0.0,ye luo,
-SOC,3100,1,Marriage & Intimacy,0.26,0.39,0.13,0.04,0.11,0.0,0.0,0.07,carolyn can coffman,
-SOC,3600,1,Class & Poverty,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william wentworth,
-SOC,3600,2,Class & Poverty,0.81,0.14,0.0,0.03,0.03,0.0,0.0,0.0,william wentworth,
-SOC,3800,1,Intro Social Service,0.58,0.24,0.16,0.02,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,3910,1,Soc of Deviance,0.32,0.36,0.13,0.04,0.06,0.0,0.0,0.09,william white,
-SOC,3940,1,Sociology of Mental Illness,0.6,0.28,0.04,0.02,0.04,0.0,0.0,0.02,marissa el yingling,
-SOC,3970,1,Substance Abuse,0.53,0.35,0.1,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,
-SOC,4030,1,"Technol, Environment & Society",0.14,0.32,0.23,0.14,0.05,0.0,0.0,0.14, catherine mobley,
-SOC,4040,1,Soc Theory,0.51,0.34,0.09,0.03,0.0,0.0,0.0,0.03,william wentworth,
-SOC,4320,1,Soc of Religion,0.19,0.38,0.44,0.0,0.0,0.0,0.0,0.0,andrew whitehead,
-SOC,4330,1,Global Social Change,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,william haller,
-SOC,4600,1,Race & Ethnicity,0.52,0.3,0.11,0.0,0.0,0.0,0.0,0.07,brenda vander mey,
-SOC,4610,1,Sex & Gender,0.36,0.48,0.07,0.05,0.02,0.0,0.0,0.02,traci ann hefner,
-SOC,4800,1,Medical Sociology,0.53,0.24,0.12,0.0,0.06,0.0,0.0,0.06,carolyn can coffman,
-SOC,4840,1,Child Abuse,0.56,0.3,0.07,0.0,0.05,0.0,0.0,0.02,marissa el yingling,
-SOC,4860,2,Creative Inquiry: Sociology,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,margaret tina britz,
-SOC,4860,3,Creative Inquiry in Sociology,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
-SOC,4950,1,Field Experience,0.85,0.0,0.15,0.0,0.0,0.0,0.0,0.0, catherine mobley,
-SOC,4970,1,Senior Lab,0.25,0.25,0.4,0.05,0.05,0.0,0.0,0.0,brenda vander mey,
-SOC,4970,2,Senior Lab,0.28,0.22,0.28,0.06,0.17,0.0,0.0,0.0,brenda vander mey,
-SOC,4990,1,Sel Top Seminar in Contemp Soc,0.63,0.25,0.06,0.0,0.06,0.0,0.0,0.0,andrew mannheimer,
-SPAN,1010,1,Elementary Spanish,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1010,2,Elementary Spanish,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,scott harris,
-SPAN,1020,2,Elementary Spanish,0.44,0.28,0.17,0.06,0.0,0.0,0.0,0.06,al garcia rodriguez,
-SPAN,1020,3,Elementary Spanish,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,al garcia rodriguez,
-SPAN,1020,4,Elementary Spanish,0.58,0.32,0.0,0.05,0.0,0.0,0.0,0.05,al garcia rodriguez,
-SPAN,1020,5,Elementary Spanish,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,al garcia rodriguez,
-SPAN,1020,6,Elementary Spanish,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,1020,7,Elementary Spanish,0.29,0.53,0.12,0.0,0.06,0.0,0.0,0.0,cathy robison,
-SPAN,1020,8,Elementary Spanish,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,debra oa williamson,
-SPAN,1020,9,Elementary Spanish,0.47,0.29,0.24,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,1020,10,Elementary Spanish,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,1020,11,Elementary Spanish,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2010,1,Intermediate Spanish,0.32,0.47,0.11,0.05,0.0,0.0,0.0,0.05,cathy robison,
-SPAN,2010,2,Intermediate Spanish,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,cathy robison,
-SPAN,2010,3,Intermediate Spanish,0.41,0.41,0.0,0.0,0.0,0.0,0.0,0.18,allison ann hinds,
-SPAN,2010,4,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
-SPAN,2010,5,Intermediate Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
-SPAN,2010,6,Intermediate Spanish,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,2010,7,Intermediate Spanish,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,2010,8,Intermediate Spanish,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2010,9,Intermediate Spanish,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2010,10,Intermediate Spanish,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,
-SPAN,2010,11,Intermediate Spanish,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,
-SPAN,2010,13,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
-SPAN,2010,14,Intermediate Spanish,0.43,0.29,0.14,0.0,0.0,0.0,0.0,0.14,melva margu persico,
-SPAN,2010,15,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,
-SPAN,2010,16,Intermediate Spanish,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,2020,1,Intermediate Spanish,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,2020,2,Intermediate Spanish,0.61,0.22,0.0,0.0,0.11,0.0,0.0,0.06,danie garcia vieyra,
-SPAN,2020,3,Intermediate Spanish,0.57,0.29,0.05,0.05,0.0,0.0,0.0,0.05,danie garcia vieyra,
-SPAN,2020,4,Intermediate Spanish,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,5,Intermediate Spanish,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,6,Intermediate Spanish,0.76,0.1,0.05,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,
-SPAN,2020,7,Intermediate Spanish,0.35,0.41,0.12,0.06,0.06,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,8,Intermediate Spanish,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,9,Intermediate Spanish,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,10,Intermediate Spanish,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,11,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,12,Intermediate Spanish,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,13,Intermediate Spanish,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,heidi montes,
-SPAN,2020,14,Intermediate Spanish,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,heidi montes,
-SPAN,2020,15,Intermediate Spanish,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,
-SPAN,3020,1,Int Spn Gram & Comp,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,george palacios,
-SPAN,3020,2,Int Spn Gram & Comp,0.3,0.5,0.15,0.0,0.05,0.0,0.0,0.0,melva margu persico,
-SPAN,3020,3,Int Spn Gram & Comp,0.11,0.84,0.0,0.0,0.05,0.0,0.0,0.0,melva margu persico,
-SPAN,3040,1,Intro Hisp Lit Forms,0.78,0.09,0.09,0.0,0.0,0.0,0.0,0.04,george palacios,
-SPAN,3050,1,Int Con Comp Span I,0.28,0.44,0.17,0.0,0.0,0.0,0.0,0.11,melva margu persico,
-SPAN,3050,2,Int Con Comp Span I,0.5,0.35,0.05,0.0,0.05,0.0,0.0,0.05,juana martin-armas,
-SPAN,3050,3,Int Con Comp Span I,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,juana martin-armas,
-SPAN,3060,1,Span Comp for Bus,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,maureen zamora,
-SPAN,3070,1,Hispanic World: Sp,0.26,0.37,0.21,0.0,0.11,0.0,0.0,0.05,juana martin-armas,
-SPAN,3080,1,Hispanic World: La,0.33,0.44,0.22,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,3080,2,Hispanic World: La,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,tiffany dawn miller,
-SPAN,3130,1,Span Lit Survey I,0.4,0.2,0.2,0.0,0.1,0.0,0.0,0.1,mon rojas-de-massei,
-SPAN,3130,35,Span Lit Survey I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-SPAN,3140,1,Hispanic Linguistics,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,daniel smith,
-SPAN,3160,1,Span for Intl Trade,0.76,0.06,0.12,0.0,0.0,0.0,0.0,0.06,maureen zamora,
-SPAN,4010,1,New Spanish Fiction,0.75,0.0,0.13,0.0,0.06,0.0,0.0,0.06,salvador oropesa,
-SPAN,4060,1,Narrative Fiction,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,mon rojas-de-massei,
-SPAN,4070,1,Hispanic Film,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,raquel anido,
-SPAN,4150,1,Span for Health Prof,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,areli moore peralta,
-SPAN,4170,1,Prof Communication,0.53,0.33,0.0,0.0,0.0,0.0,0.0,0.13,maureen zamora,
-SPAN,4180,35,Tech Span Health Man,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-STAT,2220,1,Statistics in Everyday Life,0.3,0.36,0.25,0.08,0.02,0.0,0.0,0.0,james espey,
-STAT,2220,2,Statistics in Everyday Life,0.4,0.34,0.09,0.11,0.04,0.0,0.0,0.02,james espey,
-STAT,2220,3,Statistics in Everyday Life,0.32,0.4,0.11,0.13,0.02,0.0,0.0,0.02,james espey,
-STAT,2220,4,Statistics in Everyday Life,0.3,0.28,0.3,0.07,0.02,0.0,0.0,0.04,james espey,
-STAT,2220,5,Statistics in Everyday Life,0.32,0.36,0.17,0.04,0.11,0.0,0.0,0.0,ros martinez-dawson,
-STAT,2220,6,Statistics in Everyday Life,0.33,0.41,0.22,0.02,0.0,0.0,0.0,0.02,ros martinez-dawson,
-STAT,2220,7,Statistics in Everyday Life,0.33,0.3,0.26,0.09,0.02,0.0,0.0,0.0,andrew walton green,
-STAT,2300,1,Statistical Methods I,0.29,0.35,0.15,0.12,0.04,0.0,0.0,0.05,christy jenki brown,
-STAT,2300,2,Statistical Methods I,0.36,0.25,0.22,0.12,0.05,0.0,0.0,0.01,christy jenki brown,
-STAT,2300,3,Statistical Methods I,0.4,0.32,0.14,0.08,0.02,0.0,0.0,0.04,christy jenki brown,
-STAT,2300,4,Statistical Methods I,0.29,0.29,0.2,0.1,0.1,0.0,0.0,0.03,april thomas,
-STAT,2300,5,Statistical Methods I,0.24,0.42,0.16,0.1,0.05,0.0,0.0,0.04, erwin walker,
-STAT,2300,6,Statistical Methods I,0.21,0.39,0.22,0.1,0.06,0.0,0.0,0.03, erwin walker,
-STAT,2300,7,Statistical Methods I,0.12,0.23,0.27,0.2,0.12,0.0,0.0,0.05,tao yang,
-STAT,3090,1,Introductory Business Stats,0.05,0.33,0.24,0.19,0.17,0.0,0.0,0.02,boyoung hur,
-STAT,3090,2,Introductory Business Stats,0.16,0.3,0.23,0.09,0.12,0.0,0.0,0.09,elaine ma sotherden,
-STAT,3090,3,Introductory Business Stats,0.14,0.51,0.19,0.07,0.07,0.0,0.0,0.02,sharon marie evans,
-STAT,3090,4,Introductory Business Stats,0.19,0.33,0.21,0.17,0.07,0.0,0.0,0.02,sharon marie evans,
-STAT,3090,5,Introductory Business Stats,0.28,0.42,0.16,0.07,0.07,0.0,0.0,0.0,sharon marie evans,
-STAT,3090,6,Introductory Business Stats,0.24,0.39,0.24,0.0,0.07,0.0,0.0,0.05, morales hernandez,
-STAT,3090,7,Introductory Business Stats,0.17,0.39,0.34,0.07,0.02,0.0,0.0,0.0,jason alexande kurz,
-STAT,3090,8,Introductory Business Stats,0.11,0.43,0.31,0.03,0.09,0.0,0.0,0.03,li he,
-STAT,3090,9,Introductory Business Stats,0.15,0.12,0.3,0.15,0.18,0.0,0.0,0.09,mengcong ren,
-STAT,3090,10,Introductory Business Stats,0.31,0.4,0.17,0.09,0.03,0.0,0.0,0.0,dilhani marasinghe,
-STAT,3090,11,Introductory Business Stats,0.11,0.28,0.17,0.15,0.22,0.0,0.0,0.07,sanjog arv kulkarni,
-STAT,3090,12,Introductory Business Stats,0.18,0.44,0.23,0.08,0.05,0.0,0.0,0.03,yijun chen,
-STAT,3090,13,Introductory Business Stats,0.24,0.31,0.26,0.02,0.12,0.0,0.0,0.05,kayla doris javier,
-STAT,3090,14,Introductory Business Stats,0.16,0.36,0.25,0.02,0.18,0.0,0.0,0.02,andrew pangia,
-STAT,3300,1,Statistical Methods II,0.25,0.33,0.29,0.04,0.04,0.0,0.0,0.04,ros martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.5,0.19,0.06,0.06,0.06,0.0,0.0,0.13,ellen hepfe breazel,
-STAT,4110,1,Stat Mthds for Process Control,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,
-STAT,4110,2,Stat Mthds for Process Control,0.5,0.28,0.11,0.0,0.11,0.0,0.0,0.0,james rieck,
-STAT,6020,1,Intro to Statistical Computing,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,ellen hepfe breazel,
-STAT,8010,1,Statistical Methods I,0.5,0.3,0.07,0.0,0.07,0.0,0.0,0.07,brook thaye russell,
-STAT,8010,2,Statistical Methods I,0.38,0.28,0.18,0.0,0.1,0.0,0.0,0.08,james rieck,
-STAT,8010,3,Statistical Methods I,0.64,0.24,0.06,0.0,0.03,0.0,0.0,0.03,jun luo,
-STAT,8040,1,Sampling,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-STAT,8050,1,Design & Anlys of Experiments,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STS,1010,2,Survey of S T S,0.3,0.55,0.09,0.03,0.0,0.0,0.0,0.03,scott brame,
-STS,1010,3,Survey of S T S,0.5,0.39,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,
-STS,1010,4,Survey of S T S,0.67,0.28,0.03,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,
-STS,1010,5,Survey of S T S,0.65,0.32,0.03,0.0,0.0,0.0,0.0,0.0,philip randall,
-STS,1010,6,Survey of S T S,0.36,0.47,0.03,0.0,0.0,0.0,0.0,0.14,sarah mae cooper,
-STS,1010,7,Survey of S T S,0.46,0.23,0.17,0.03,0.06,0.0,0.0,0.06,megan no macalystre,
-STS,1010,8,Survey of S T S,0.28,0.24,0.24,0.07,0.03,0.0,0.0,0.14,david charles foltz,
-THEA,2100,1,Theatre Appreciation,0.58,0.29,0.1,0.0,0.0,0.0,0.0,0.03,kendra lyne johnson,
-THEA,2100,2,Theatre Appreciation,0.72,0.22,0.0,0.03,0.03,0.0,0.0,0.0,kendra lyne johnson,
-THEA,2100,3,Theatre Appreciation,0.81,0.16,0.0,0.03,0.0,0.0,0.0,0.0,kerrie kath seymour,
-THEA,2100,4,Theatre Appreciation,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,carol collins,
-THEA,2100,6,Theatre Appreciation,0.34,0.5,0.09,0.03,0.0,0.0,0.0,0.03,jason adkins,
-THEA,2100,7,Theatre Appreciation,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,richard st. peter,
-THEA,2100,9,Theatre Appreciation,0.91,0.03,0.0,0.0,0.0,0.0,0.0,0.06,richard st. peter,
-THEA,2770,1,Prod Studies in Thea,0.72,0.17,0.03,0.0,0.03,0.0,0.0,0.03,david hartmann,
-THEA,2790,1,Theatre Practicum,0.67,0.25,0.0,0.0,0.08,0.0,0.0,0.0,matthew leckenbusch,
-THEA,3180,1,Afri-Amer Thea II,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,kendra lyne johnson,
-THEA,3740,1,Movement for Actors,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,kerrie kath seymour,
-THEA,4720,1,Improvisation,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,
-WFB,3010,1,Wildlife Biology Lab,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3010,2,Wildlife Biology Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3130,1,Conservation Biology,0.46,0.29,0.14,0.05,0.04,0.0,0.0,0.01,shari lyn rodriguez,
-WFB,3130,2,Conservation Biology,0.35,0.2,0.35,0.02,0.06,0.0,0.0,0.02,shari lyn rodriguez,
-WFB,3500,1,Princ Fish & Wildlife Biology,0.38,0.42,0.13,0.0,0.0,0.0,0.0,0.07,james davis,
-WFB,3500,2,Princ Fish & Wildlife Biology,0.3,0.35,0.22,0.09,0.02,0.0,0.0,0.02,james davis,
-WFB,4160,1,Fishery Biology,0.19,0.5,0.24,0.05,0.02,0.0,0.0,0.0,kasey celen pregler,
-WFB,4620,1,Wetland Wildlife Biology,0.55,0.4,0.03,0.01,0.0,0.0,0.0,0.0,russell barrett,
-WFB,4930,2,Quantitative Ecology,0.46,0.3,0.16,0.0,0.03,0.0,0.0,0.05,david sco jachowski,
-WFB,4930,3,Human Dim of Fisheries & Wildl,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WS,1030,1,Women in Global Perspective,0.68,0.24,0.04,0.0,0.0,0.0,0.0,0.04,laura foxworth,
-WS,1030,2,Women in Global Perspective,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,laura foxworth,
-WS,3010,1,Intro Women's Studies,0.54,0.33,0.04,0.04,0.0,0.0,0.0,0.04,elizabeth ros adams,
-WS,3010,2,Intro Women's Studies,0.46,0.38,0.13,0.0,0.04,0.0,0.0,0.0,elizabeth ros adams,
-WS,3490,1,Gender and Sexuality,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,diane perpich,
-YDP,3100,1,Youth Developmt and the Family,0.83,0.09,0.0,0.04,0.04,0.0,0.0,0.0,william quinn,
-YDP,3100,2,Youth Developmt and the Family,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
-YDP,3150,1,Community & Youth Dev Systems,0.55,0.27,0.09,0.0,0.09,0.0,0.0,0.0,toby kirkland,
-YDP,3250,1,Working with Diverse Youth,0.7,0.1,0.15,0.0,0.0,0.0,0.0,0.05,kimberly pe johnson,
-YDP,8010,1,Child/Adolescent Dev,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,edmond patri bowers,
-YDP,8040,1,Assess & Eval of Youth Program,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,barry garst,
-YDP,8880,1,Special Topics Youth Dev Ldshp,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,barry garst,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1020,1,Survey of Art & Arch Hist II,0.41,0.41,0.13,0.02,0.01,0.0,0.0,0.03,andrea feeser,,AAH-1020,2017
+AAH,2060,1,Art History and Theory II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,,AAH-2060,2017
+ACCT,2010,1,Financial Accounting Concepts,0.42,0.2,0.13,0.05,0.12,0.0,0.0,0.08,lydia lan schleifer,,ACCT-2010,2017
+ACCT,2010,2,Financial Accounting Concepts,0.4,0.25,0.22,0.05,0.07,0.0,0.0,0.02,annieka philo,,ACCT-2010,2017
+ACCT,2010,3,Financial Accounting Concepts,0.2,0.41,0.2,0.14,0.0,0.0,0.0,0.06,philip maiberger,,ACCT-2010,2017
+ACCT,2010,4,Financial Accounting Concepts,0.35,0.22,0.27,0.07,0.1,0.0,0.0,0.0,annieka philo,,ACCT-2010,2017
+ACCT,2010,5,Financial Accounting Concepts,0.38,0.2,0.15,0.07,0.08,0.0,0.0,0.12,lydia lan schleifer,,ACCT-2010,2017
+ACCT,2010,6,Financial Accounting Concepts,0.45,0.25,0.08,0.05,0.08,0.0,0.0,0.08,lydia lan schleifer,,ACCT-2010,2017
+ACCT,2010,7,Financial Accounting Concepts,0.27,0.13,0.23,0.07,0.13,0.0,0.0,0.18,mary ann  prater,,ACCT-2010,2017
+ACCT,2010,8,Financial Accounting Concepts,0.41,0.24,0.21,0.1,0.02,0.0,0.0,0.02,annieka philo,,ACCT-2010,2017
+ACCT,2010,9,Financial Accounting Concepts,0.11,0.29,0.2,0.09,0.09,0.0,0.0,0.23,mary ann  prater,,ACCT-2010,2017
+ACCT,2010,10,Financial Accounting Concepts,0.59,0.29,0.05,0.02,0.02,0.0,0.0,0.03,charles tegen,,ACCT-2010,2017
+ACCT,2010,101,Fin Acct Concepts (HON),0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,mary ann  prater,True,ACCT-2010,2017
+ACCT,2010,401,Financial Accounting Concepts,0.28,0.45,0.14,0.03,0.06,0.0,0.0,0.03,jeffrey mcmillan,,ACCT-2010,2017
+ACCT,2010,402,Financial Accounting Concepts,0.21,0.5,0.13,0.05,0.09,0.0,0.0,0.02,jeffrey mcmillan,,ACCT-2010,2017
+ACCT,2020,1,Managerial Accounting Concepts,0.09,0.37,0.3,0.09,0.04,0.0,0.0,0.11,henry anderson,,ACCT-2020,2017
+ACCT,2020,2,Managerial Accounting Concepts,0.11,0.33,0.29,0.03,0.07,0.0,0.0,0.17,henry anderson,,ACCT-2020,2017
+ACCT,2020,3,Managerial Accounting Concepts,0.25,0.23,0.3,0.08,0.03,0.0,0.0,0.13,henry anderson,,ACCT-2020,2017
+ACCT,2020,4,Managerial Accounting Concepts,0.15,0.32,0.29,0.06,0.1,0.0,0.0,0.08,emily suza mccorkle,,ACCT-2020,2017
+ACCT,2020,5,Managerial Accounting Concepts,0.46,0.34,0.13,0.04,0.01,0.0,0.0,0.01,emily suza mccorkle,,ACCT-2020,2017
+ACCT,2020,401,Managerial Accounting Concepts,0.11,0.32,0.16,0.1,0.08,0.0,0.0,0.23,henry anderson,,ACCT-2020,2017
+ACCT,3030,1,Cost Accounting,0.4,0.29,0.2,0.02,0.04,0.0,0.0,0.04,jace garrett,,ACCT-3030,2017
+ACCT,3030,2,Cost Accounting,0.2,0.39,0.31,0.04,0.0,0.0,0.0,0.06,jace garrett,,ACCT-3030,2017
+ACCT,3030,3,Cost Accounting,0.24,0.32,0.24,0.04,0.06,0.0,0.0,0.1,rebecca pennel trax,,ACCT-3030,2017
+ACCT,3030,4,Cost Accounting,0.18,0.29,0.29,0.04,0.07,0.0,0.0,0.14,rebecca pennel trax,,ACCT-3030,2017
+ACCT,3110,1,Intermediate Financial Acct I,0.22,0.29,0.24,0.09,0.09,0.0,0.0,0.07,terry daniel knause,,ACCT-3110,2017
+ACCT,3110,2,Intermediate Financial Acct I,0.3,0.34,0.18,0.08,0.04,0.0,0.0,0.06,terry daniel knause,,ACCT-3110,2017
+ACCT,3110,3,Intermediate Financial Acct I,0.34,0.42,0.14,0.08,0.0,0.0,0.0,0.02,terry daniel knause,,ACCT-3110,2017
+ACCT,3110,4,Intermediate Financial Acct I,0.2,0.36,0.24,0.1,0.04,0.0,0.0,0.06,terry daniel knause,,ACCT-3110,2017
+ACCT,3110,401,Intermediate Financial Acct I,0.16,0.22,0.22,0.09,0.13,0.0,0.0,0.19,henry anderson,,ACCT-3110,2017
+ACCT,3120,1,Intermediate Financial Acct II,0.09,0.34,0.39,0.09,0.07,0.0,0.0,0.02,the estate  guffey,,ACCT-3120,2017
+ACCT,3120,2,Intermediate Financial Acct II,0.27,0.24,0.35,0.05,0.03,0.0,0.0,0.05,the estate  guffey,,ACCT-3120,2017
+ACCT,3120,3,Intermediate Financial Acct II,0.07,0.3,0.34,0.09,0.14,0.0,0.0,0.07,brian todd carver,,ACCT-3120,2017
+ACCT,3120,4,Intermediate Financial Acct II,0.07,0.27,0.4,0.2,0.0,0.0,0.0,0.07,brian todd carver,,ACCT-3120,2017
+ACCT,3120,5,Intermediate Financial Acct II,0.23,0.42,0.19,0.07,0.0,0.0,0.0,0.09,jeremy micha vinson,,ACCT-3120,2017
+ACCT,3130,1,Intermediate Fin Acct III,0.15,0.35,0.45,0.0,0.05,0.0,0.0,0.0, russell madray,,ACCT-3130,2017
+ACCT,3130,2,Intermediate Fin Acct III,0.35,0.38,0.25,0.02,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2017
+ACCT,3130,3,Intermediate Fin Acct III,0.26,0.54,0.18,0.0,0.03,0.0,0.0,0.0, russell madray,,ACCT-3130,2017
+ACCT,3130,4,Intermediate Fin Acct III,0.32,0.46,0.22,0.0,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2017
+ACCT,3220,1,Accounting Information Systems,0.27,0.36,0.21,0.03,0.03,0.0,0.0,0.09,philip maiberger,,ACCT-3220,2017
+ACCT,3220,2,Accounting Information Systems,0.38,0.35,0.09,0.03,0.0,0.0,0.0,0.15,philip maiberger,,ACCT-3220,2017
+ACCT,3220,3,Accounting Information Systems,0.19,0.34,0.34,0.03,0.0,0.0,0.0,0.09,philip maiberger,,ACCT-3220,2017
+ACCT,4040,1,Individual Taxation,0.61,0.2,0.18,0.0,0.02,0.0,0.0,0.0,sarah martin,,ACCT-4040,2017
+ACCT,4040,2,Individual Taxation,0.61,0.18,0.14,0.05,0.02,0.0,0.0,0.0,sarah martin,,ACCT-4040,2017
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.23,0.67,0.1,0.0,0.0,0.0,0.0,0.0,robin radtke,,ACCT-4100,2017
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.15,0.49,0.31,0.03,0.03,0.0,0.0,0.0,robin radtke,,ACCT-4100,2017
+ACCT,4150,1,Auditing,0.24,0.43,0.29,0.01,0.01,0.0,0.0,0.01,carl hollingsworth,,ACCT-4150,2017
+ACCT,8520,1,Fin Acct Theory/Res,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8520,2017
+ACCT,8520,2,Fin Acct Theory/Res,0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,ralph welton,,ACCT-8520,2017
+ACCT,8540,1,Prof Responsibility,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2017
+ACCT,8540,2,Prof Responsibility,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2017
+ACCT,8540,3,Prof Responsibility,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2017
+ACCT,8620,1,Financial Auditing,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,,ACCT-8620,2017
+ACCT,8620,2,Financial Auditing,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,carl hollingsworth,,ACCT-8620,2017
+ACCT,8710,1,Corporate Taxation,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2017
+ACCT,8710,2,Corporate Taxation,0.2,0.68,0.13,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2017
+ACCT,8710,3,Corporate Taxation,0.24,0.59,0.18,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2017
+ACCT,8730,1,Intl/Spec Tax Topic,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,,ACCT-8730,2017
+ACCT,8740,1,Tax Aspects of Finan Planning,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,judson jahn,,ACCT-8740,2017
+AGED,1000,1,Orientation & Field Experience,0.67,0.26,0.0,0.04,0.0,0.0,0.0,0.04,philip fravel,,AGED-1000,2017
+AGED,2030,1,Teaching Agriscience,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,catheri dibenedetto,,AGED-2030,2017
+AGED,4150,1,Leadership of Vol,0.83,0.08,0.04,0.0,0.0,0.0,0.0,0.04,kevin layfield,,AGED-4150,2017
+AGED,4160,1,Ethics and Issues,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,,AGED-4160,2017
+AGM,2050,1,Prin of Fabrication,0.27,0.38,0.25,0.05,0.04,0.0,0.0,0.02,hunter massey,,AGM-2050,2017
+AGM,2060,1,Machinery Mgt,0.28,0.43,0.18,0.05,0.05,0.0,0.0,0.03,hunter massey,,AGM-2060,2017
+AGM,2200,1,Calc for Mechanized Agricult,0.36,0.51,0.08,0.03,0.0,0.0,0.0,0.02,young han,,AGM-2200,2017
+AGM,2210,1,Land Measurements,0.33,0.26,0.3,0.06,0.04,0.0,0.0,0.02,charles privette,,AGM-2210,2017
+AGM,4020,1,Irrigation System Design,0.38,0.4,0.2,0.03,0.0,0.0,0.0,0.0,charles privette,,AGM-4020,2017
+AGM,4100,1,Precision Ag Tech,0.61,0.2,0.13,0.04,0.02,0.0,0.0,0.0,hunter massey,,AGM-4100,2017
+AGM,4520,1,Mobile Power,0.56,0.37,0.07,0.0,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4520,2017
+AGM,4720,1,Capstone,0.5,0.35,0.15,0.0,0.0,0.0,0.0,0.0,john chastain,,AGM-4720,2017
+AGM,4730,2,Selected Topics,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,young han,,AGM-4730,2017
+AGRB,2020,1,Agricultural Economics,0.16,0.34,0.23,0.1,0.13,0.0,0.0,0.03,george apperson,,AGRB-2020,2017
+AGRB,2020,2,Agricultural Economics,0.34,0.32,0.32,0.0,0.0,0.0,0.0,0.03,george apperson,,AGRB-2020,2017
+AGRB,2050,1,Agriculture and Society,0.28,0.33,0.2,0.13,0.06,0.0,0.0,0.0,george apperson,,AGRB-2050,2017
+AGRB,3190,1,Agribusiness Management,0.4,0.26,0.19,0.14,0.0,0.0,0.0,0.01,michael vassalos,,AGRB-3190,2017
+AGRB,3570,1,Natural Resources Economics,0.21,0.31,0.29,0.1,0.04,0.0,0.0,0.04,david brian willis,,AGRB-3570,2017
+AGRB,4020,1,Production Economics,0.59,0.3,0.07,0.0,0.0,0.0,0.0,0.04,michael vassalos,,AGRB-4020,2017
+AGRB,4080,1,Quant Agribusiness Analysis II,0.24,0.48,0.24,0.03,0.0,0.0,0.0,0.0,lisha zhang,,AGRB-4080,2017
+AGRB,4520,1,Agricultural Policy,0.17,0.48,0.25,0.06,0.0,0.0,0.0,0.04,michael vassalos,,AGRB-4520,2017
+AGRB,4560,1,Prices,0.41,0.31,0.28,0.0,0.0,0.0,0.0,0.0,yuliya val bolotova,,AGRB-4560,2017
+AGRB,4570,1,"Natural Res Use, Tech & Policy",0.25,0.42,0.17,0.0,0.0,0.0,0.0,0.17,david brian willis,,AGRB-4570,2017
+AL,3490,400,Principles of Coaching,0.81,0.08,0.04,0.04,0.0,0.0,0.0,0.04,deborah cadorette,,AL-3490,2017
+AL,3490,401,Principles of Coaching,0.76,0.2,0.0,0.0,0.0,0.0,0.0,0.04,deborah cadorette,,AL-3490,2017
+AL,3490,402,Principles of Coaching,0.71,0.17,0.08,0.0,0.04,0.0,0.0,0.0,julia wright,,AL-3490,2017
+AL,3490,403,Principles of Coaching,0.6,0.2,0.08,0.08,0.04,0.0,0.0,0.0,clyde keith connor,,AL-3490,2017
+AL,3490,404,Principles of Coaching,0.89,0.0,0.0,0.07,0.04,0.0,0.0,0.0,edmond fry,,AL-3490,2017
+AL,3490,405,Principles of Coaching,0.78,0.11,0.07,0.0,0.04,0.0,0.0,0.0,deborah cadorette,,AL-3490,2017
+AL,3500,400,Sci Basis I/Ex Phy,0.19,0.07,0.52,0.19,0.0,0.0,0.0,0.04,michael godfrey,,AL-3500,2017
+AL,3500,401,Sci Basis I/Ex Phy,0.17,0.3,0.39,0.04,0.0,0.0,0.0,0.09,michael godfrey,,AL-3500,2017
+AL,3530,400,Athletic Injuries,0.26,0.26,0.37,0.07,0.04,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2017
+AL,3530,401,Athletic Injuries,0.32,0.4,0.12,0.12,0.0,0.0,0.0,0.04,isaac sean colbert,,AL-3530,2017
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.57,0.19,0.14,0.1,0.0,0.0,0.0,0.0,clyde keith connor,,AL-3600,2017
+AL,3610,400,Admin/Org of Athletic Programs,0.64,0.24,0.08,0.0,0.04,0.0,0.0,0.0,henry oates,,AL-3610,2017
+AL,3610,401,Admin/Org of Athletic Programs,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2017
+AL,3610,402,Admin/Org of Athletic Programs,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2017
+AL,3620,400,Psychology of Coaching,0.32,0.4,0.16,0.08,0.0,0.0,0.0,0.04,natalie anne carter,,AL-3620,2017
+AL,3620,401,Psychology of Coaching,0.46,0.25,0.21,0.0,0.08,0.0,0.0,0.0,natalie anne carter,,AL-3620,2017
+AL,3620,402,Psychology of Coaching,0.48,0.22,0.13,0.13,0.04,0.0,0.0,0.0,natalie anne carter,,AL-3620,2017
+AL,3720,400,Coaching Basketball,0.72,0.12,0.08,0.0,0.08,0.0,0.0,0.0,edmond fry,,AL-3720,2017
+AL,3740,400,Coaching Football,0.76,0.08,0.04,0.0,0.04,0.0,0.0,0.08,edmond fry,,AL-3740,2017
+AL,3750,400,Coaching Soccer,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,deborah cadorette,,AL-3750,2017
+AL,3760,400,Coaching Strength/Conditioning,0.58,0.27,0.08,0.04,0.0,0.0,0.0,0.04,edmond fry,,AL-3760,2017
+AL,4380,400,Coaching Women,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-4380,2017
+AL,4380,402,Officiating in Athletic Leader,0.64,0.16,0.16,0.0,0.04,0.0,0.0,0.0,clyde keith connor,,AL-4380,2017
+AL,4380,403,Coaching Inner Athlete,0.74,0.11,0.07,0.0,0.04,0.0,0.0,0.04,deborah cadorette,,AL-4380,2017
+AL,4380,404,CPR/AED for Athletic Coaches,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,julia wright,,AL-4380,2017
+AL,4380,405,CPR/AED for Athletic Coaches,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,julia wright,,AL-4380,2017
+AL,8530,400,Legal Iss in Intercoll Athlet,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-8530,2017
+AL,8530,401,Legal Iss in Intercoll Athlet,0.78,0.0,0.0,0.0,0.22,0.0,0.0,0.0,misty soles,,AL-8530,2017
+AL,8630,400,Socio Dynam in Intercol Athlet,0.69,0.19,0.0,0.0,0.13,0.0,0.0,0.0,michael godfrey,,AL-8630,2017
+AL,8640,400,Ethical Iss in Collegiate Athl,0.64,0.32,0.0,0.0,0.0,0.0,0.0,0.04,michael godfrey,,AL-8640,2017
+AL,8640,401,Ethical Iss in Collegiate Athl,0.6,0.25,0.0,0.0,0.15,0.0,0.0,0.0,michael godfrey,,AL-8640,2017
+AL,8700,400,Intercoll Athletics Finance,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,misty soles,,AL-8700,2017
+ANTH,2010,1,Introduction to Anthropology,0.66,0.21,0.07,0.02,0.02,0.0,0.0,0.01,melissa vogel,,ANTH-2010,2017
+ANTH,2010,2,Introduction to Anthropology,0.67,0.25,0.06,0.0,0.02,0.0,0.0,0.0,yi wu,,ANTH-2010,2017
+ANTH,2010,3,Introduction to Anthropology,0.36,0.38,0.1,0.02,0.02,0.0,0.0,0.12,lisa rapaport,,ANTH-2010,2017
+ANTH,2050,1,Professional Development,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,katherine weisensee,,ANTH-2050,2017
+ANTH,3200,1,North American Indian Cultures,0.21,0.36,0.14,0.14,0.0,0.0,0.0,0.14,john coggeshall,,ANTH-3200,2017
+ANTH,3310,1,Archaeology,0.37,0.33,0.26,0.04,0.0,0.0,0.0,0.0,melissa vogel,,ANTH-3310,2017
+ANTH,3510,1,Biological Anthropology,0.4,0.4,0.1,0.05,0.0,0.0,0.0,0.05,katherine weisensee,,ANTH-3510,2017
+ANTH,4040,1,Anthropological Theories,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,john coggeshall,,ANTH-4040,2017
+ANTH,4990,1,Special Topics,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,yi wu,,ANTH-4990,2017
+ARCH,1510,1,Arch Communication,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,,ARCH-1510,2017
+ARCH,1510,2,Arch Communication,0.38,0.5,0.06,0.0,0.06,0.0,0.0,0.0,robert silance,,ARCH-1510,2017
+ARCH,1510,3,Arch Communication,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,clarissa mendez,,ARCH-1510,2017
+ARCH,1510,4,Arch Communication,0.2,0.6,0.07,0.07,0.0,0.0,0.0,0.07,berrin terim,,ARCH-1510,2017
+ARCH,1510,5,Arch Communication,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-1510,2017
+ARCH,1510,6,Arch Communication,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,maryam hamidpour,,ARCH-1510,2017
+ARCH,2520,1,Arch Foundations II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-2520,2017
+ARCH,2520,2,Arch Foundations II,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,james barker,,ARCH-2520,2017
+ARCH,2520,3,Arch Foundations II,0.33,0.42,0.17,0.08,0.0,0.0,0.0,0.0,david lee,,ARCH-2520,2017
+ARCH,2520,4,Arch Foundations II,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2520,2017
+ARCH,2520,5,Arch Foundations II,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,,ARCH-2520,2017
+ARCH,2700,2,Structures I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,michael carl kleiss,,ARCH-2700,2017
+ARCH,2710,1,Structures II,0.66,0.21,0.07,0.03,0.03,0.0,0.0,0.0,mahmoodreza soltani,,ARCH-2710,2017
+ARCH,3530,1,Studio Genoa,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,,ARCH-3530,2017
+ARCH,4120,1,History Research,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,,ARCH-4120,2017
+ARCH,4120,2,History Research,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-4120,2017
+ARCH,4140,2,Design Seminar,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-4140,2017
+ARCH,4160,1,Field Studies,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,,ARCH-4160,2017
+ARCH,4160,2,Field Studies,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-4160,2017
+ARCH,4520,1,Synthesis Studio,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-4520,2017
+ARCH,4520,2,Synthesis Studio,0.44,0.22,0.22,0.0,0.0,0.0,0.0,0.11,julie poe wilkerson,,ARCH-4520,2017
+ARCH,4520,3,Synthesis Studio,0.11,0.56,0.33,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-4520,2017
+ARCH,4520,4,Synthesis Studio,0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4520,2017
+ARCH,4710,1,Arch Hist of Place,0.22,0.78,0.0,0.0,0.0,0.0,0.0,0.0,james thomas,,ARCH-4710,2017
+ARCH,4890,1,Internship,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,ashley jennings,,ARCH-4890,2017
+ARCH,6160,2,Field Studies,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,miguel roldan,,ARCH-6160,2017
+ARCH,6880,1,Arch Programming,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-6880,2017
+ARCH,8110,1,Visualization II,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,,ARCH-8110,2017
+ARCH,8320,1,Community 1:1,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,,ARCH-8320,2017
+ARCH,8420,1,Arch Studio II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,peter laurence,,ARCH-8420,2017
+ARCH,8420,2,Arch Studio II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,,ARCH-8420,2017
+ARCH,8520,6,Design Studio IV,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,miguel roldan,,ARCH-8520,2017
+ARCH,8520,8,Design Studio IV,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-8520,2017
+ARCH,8520,9,Design Studio IV,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-8520,2017
+ARCH,8610,1,History/Theory II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8610,2017
+ARCH,8620,1,History/Theory III,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,,ARCH-8620,2017
+ARCH,8650,1,Topics in Health Policy,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,anjali joseph,,ARCH-8650,2017
+ARCH,8710,1,Structures II,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,dustin gra albright,,ARCH-8710,2017
+ARCH,8730,2,Environmental Sys,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,,ARCH-8730,2017
+ARCH,8740,1,Building Process:TR,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-8740,2017
+ARCH,8820,1,Building Economics,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-8820,2017
+ARCH,8920,1,Comprehensive Studio,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8920,2017
+ARCH,8920,2,Comprehensive Studio,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-8920,2017
+ARCH,8920,3,Comprehensive Studio,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,dustin gra albright,,ARCH-8920,2017
+ARCH,8920,4,Comprehensive Studio,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-8920,2017
+ARCH,8960,1,A+H Studio: Tectonic,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-8960,2017
+ART,1060,1,Foundation Drawing II,0.7,0.17,0.0,0.04,0.09,0.0,0.0,0.0,carly drew,,ART-1060,2017
+ART,1520,1,Foundations Art II,0.76,0.2,0.0,0.04,0.0,0.0,0.0,0.0,joseph ric manson ,,ART-1520,2017
+ART,2050,1,Beginning Life Drawing,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,,ART-2050,2017
+ART,2070,1,Beginning Painting,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,todd mcdonald,,ART-2070,2017
+ART,2100,400,Art Appreciation,0.35,0.48,0.09,0.09,0.0,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2017
+ART,2100,401,Art Appreciation,0.55,0.24,0.1,0.0,0.0,0.0,0.0,0.1,lydia jane dorsey,,ART-2100,2017
+ART,2100,402,Art Appreciation,0.46,0.29,0.18,0.0,0.04,0.0,0.0,0.04,lydia jane dorsey,,ART-2100,2017
+ART,2100,403,Art Appreciation,0.24,0.59,0.14,0.0,0.0,0.0,0.0,0.03,lydia jane dorsey,,ART-2100,2017
+ART,2130,1,Begin Photography,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,amber nic eckersley,,ART-2130,2017
+ART,8060,1,Visual Arts Sem II,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,gregory wi shelnutt,,ART-8060,2017
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1100,2017
+AS,1100,2,Air Force Today II,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1100,2017
+AS,1100,3,Air Force Today II,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1100,2017
+AS,2100,2,Dev of Air Power II,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,christopher mann,,AS-2100,2017
+AS,2100,3,Dev of Air Power II,0.8,0.13,0.0,0.07,0.0,0.0,0.0,0.0,christopher mann,,AS-2100,2017
+ASL,1010,1,Am Sign Lang I,0.26,0.37,0.32,0.05,0.0,0.0,0.0,0.0,william alton brant,,ASL-1010,2017
+ASL,1010,2,Am Sign Lang I,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,william alton brant,,ASL-1010,2017
+ASL,1010,3,Am Sign Lang I,0.58,0.37,0.0,0.05,0.0,0.0,0.0,0.0,michael alb barrett,,ASL-1010,2017
+ASL,1020,1,Am Sign Lang I,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-1020,2017
+ASL,1020,2,Am Sign Lang I,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,kim ma misener dunn,,ASL-1020,2017
+ASL,1020,3,Am Sign Lang I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-1020,2017
+ASL,2010,1,Am Sign Lang II,0.31,0.23,0.38,0.0,0.0,0.0,0.0,0.08,michael alb barrett,,ASL-2010,2017
+ASL,2020,1,Am Sign Lang II,0.26,0.16,0.42,0.11,0.05,0.0,0.0,0.0,michael alb barrett,,ASL-2020,2017
+ASL,2020,2,Am Sign Lang II,0.64,0.09,0.09,0.09,0.0,0.0,0.0,0.09,michael alb barrett,,ASL-2020,2017
+ASL,3020,1,Advanced Asl II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-3020,2017
+ASL,4600,1,Deaf Literature,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-4600,2017
+ASTR,1010,1,Solar System Astronomy,0.25,0.35,0.16,0.1,0.07,0.0,0.0,0.08,lih-sin the,,ASTR-1010,2017
+ASTR,1020,1,Stellar Astronomy,0.27,0.26,0.11,0.05,0.16,0.0,0.0,0.15,amber porter,,ASTR-1020,2017
+ASTR,1020,2,Stellar Astronomy,0.24,0.38,0.17,0.09,0.04,0.0,0.0,0.07,amber porter,,ASTR-1020,2017
+ASTR,1030,1,Solar Systm Astr Lab,0.35,0.35,0.08,0.04,0.19,0.0,0.0,0.0,amber porter,,ASTR-1030,2017
+ASTR,1030,2,Solar Systm Astr Lab,0.38,0.35,0.12,0.04,0.0,0.0,0.0,0.12,amber porter,,ASTR-1030,2017
+ASTR,1030,3,Solar Systm Astr Lab,0.38,0.29,0.24,0.05,0.0,0.0,0.0,0.05,amber porter,,ASTR-1030,2017
+ASTR,1040,1,Stellar Astr Lab,0.64,0.18,0.14,0.0,0.0,0.0,0.0,0.05,amber porter,,ASTR-1040,2017
+ASTR,1040,2,Stellar Astr Lab,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,amber porter,,ASTR-1040,2017
+ASTR,1040,3,Stellar Astr Lab,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,amber porter,,ASTR-1040,2017
+ASTR,1040,5,Stellar Astr Lab,0.55,0.2,0.05,0.0,0.05,0.0,0.0,0.15,amber porter,,ASTR-1040,2017
+AUD,2850,1,Acoustics of Music,0.2,0.5,0.2,0.1,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-2850,2017
+AUE,8160,1,Eng Combustion Emiss,0.75,0.23,0.03,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8160,2017
+AUE,8170,3,Alt Energy Sources,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,simona onori,,AUE-8170,2017
+AUE,8500,6,Stability/Safety Sys,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8500,2017
+AUE,8550,16,Auto Struct Analysis,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,david wil schmueser,,AUE-8550,2017
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.49,0.46,0.05,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8690,2017
+AUE,8770,9,Light-Weight Design,0.52,0.39,0.06,0.0,0.03,0.0,0.0,0.0,fadi kama abu-farha,,AUE-8770,2017
+AUE,8860,1,Noise Vibration,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,douglas feldmaier,,AUE-8860,2017
+AUE,8900,102,Automotive Engineering Project,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8900,2017
+AUE,8930,3,Applied Dynamics,0.37,0.47,0.11,0.0,0.05,0.0,0.0,0.0,imtiaz ul haque,,AUE-8930,2017
+AUE,8930,4,Mechanics of Composites Struct,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,srikanth pilla,,AUE-8930,2017
+AUE,8930,401,Autonomous Driving Techn,0.67,0.31,0.03,0.0,0.0,0.0,0.0,0.0,yunyi jia,,AUE-8930,2017
+AUE,8930,402,Sustainability & LCE,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,srikanth pilla,,AUE-8930,2017
+AVS,2000,1,Beef Cattle Tech,0.62,0.27,0.08,0.0,0.04,0.0,0.0,0.0,nathan long,,AVS-2000,2017
+AVS,2020,1,CAFLS Plus,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,thomas scott,,AVS-2020,2017
+AVS,2060,1,Swine Techniques,0.8,0.13,0.0,0.0,0.03,0.0,0.0,0.05,richelle lor miller,,AVS-2060,2017
+AVS,3010,1,Anat & Phys Dom Ani,0.44,0.32,0.13,0.05,0.03,0.0,0.0,0.03,tiffany wilmoth,,AVS-3010,2017
+AVS,3100,1,Animal Health,0.54,0.2,0.1,0.03,0.06,0.0,0.0,0.07,thomas scott,,AVS-3100,2017
+AVS,3150,1,Animal Welfare,0.46,0.21,0.33,0.0,0.0,0.0,0.0,0.0,peter skewes,,AVS-3150,2017
+AVS,3700,1,Principles of Animal Nutrition,0.49,0.24,0.16,0.08,0.02,0.0,0.0,0.0,james ro strickland,,AVS-3700,2017
+AVS,3750,1,Applied Animal Nutrition,0.29,0.33,0.19,0.15,0.0,0.0,0.0,0.04,gustavo jos lascano,,AVS-3750,2017
+AVS,4000,1,AVS Professional Development,0.73,0.2,0.08,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,,AVS-4000,2017
+AVS,4000,2,AVS Professional Development,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,johanna joh lascano,,AVS-4000,2017
+AVS,4010,1,Beef Production,0.1,0.6,0.2,0.1,0.0,0.0,0.0,0.0,nathan long,,AVS-4010,2017
+AVS,4060,1,Seminars & Related Topics,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2017
+AVS,4060,2,Seminars & Related Topics,0.33,0.47,0.13,0.07,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2017
+AVS,4100,1,Domestic Ani Behav,0.31,0.46,0.17,0.03,0.01,0.0,0.0,0.02,peter skewes,,AVS-4100,2017
+AVS,4120,1,Advanced Equine Management,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-4120,2017
+AVS,4130,1,Animal Products,0.64,0.3,0.06,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-4130,2017
+AVS,4140,1,Basic Immunology,0.74,0.11,0.11,0.0,0.04,0.0,0.0,0.0,thomas scott,,AVS-4140,2017
+AVS,4220,6,Special Problems,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,susan kay duckett,,AVS-4220,2017
+AVS,4530,1,Animal Reproduction,0.46,0.24,0.27,0.0,0.02,0.0,0.0,0.0,glenn birrenkott,,AVS-4530,2017
+AVS,4530,400,Animal Reproduction,0.57,0.21,0.14,0.07,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-4530,2017
+BCHM,3010,1,Molecular Biochem,0.1,0.37,0.23,0.12,0.07,0.0,0.0,0.1,meredith tei morris,,BCHM-3010,2017
+BCHM,3010,2,Molecular Biochem(HON),0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,cheryl ingram-smith,True,BCHM-3010,2017
+BCHM,3050,1,Essen Elements Bioch,0.29,0.38,0.2,0.07,0.01,0.0,0.0,0.03,srik chandrasekaran,,BCHM-3050,2017
+BCHM,3050,2,Essen Elements Bioch,0.4,0.32,0.2,0.06,0.0,0.0,0.0,0.02,srik chandrasekaran,,BCHM-3050,2017
+BCHM,4320,1,Bioch of Metabolism,0.78,0.13,0.08,0.02,0.0,0.0,0.0,0.0,kimberly paul,,BCHM-4320,2017
+BCHM,4340,3,Biochemistry of Metabolism Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kimberly paul,,BCHM-4340,2017
+BCHM,4340,4,Biochemistry of Metabolism Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,kimberly paul,,BCHM-4340,2017
+BCHM,4360,1,Genes to Proteins,0.8,0.17,0.02,0.0,0.02,0.0,0.0,0.0,michael glen sehorn,,BCHM-4360,2017
+BCHM,4400,1,Bioinformatics,0.45,0.35,0.15,0.0,0.05,0.0,0.0,0.0,liangjiang wang,,BCHM-4400,2017
+BCHM,4900,21,EPIC Ambassadors,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,meredith tei morris,,BCHM-4900,2017
+BCHM,8050,1,Issues in Research,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,julia frugoli,,BCHM-8050,2017
+BE,2100,1,Intro to Biosystems Engr,0.71,0.14,0.0,0.07,0.07,0.0,0.0,0.0,yi zheng,,BE-2100,2017
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.63,0.21,0.13,0.0,0.0,0.0,0.0,0.04,tom owino,,BE-3220,2017
+BE,4120,1,Be Heat Mass Trans,0.38,0.38,0.08,0.13,0.0,0.0,0.0,0.04,caye marie drapcho,,BE-4120,2017
+BE,4150,1,Instr & Control for Biosys Eng,0.67,0.1,0.1,0.1,0.0,0.0,0.0,0.05,yi zheng,,BE-4150,2017
+BE,4240,2,Ecological Engineering,0.71,0.21,0.05,0.0,0.0,0.0,0.0,0.02,christophe darnault,,BE-4240,2017
+BE,4380,1,Bioprocess Engineering Design,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4380,2017
+BE,4730,3,Thermodynamics,0.26,0.53,0.11,0.0,0.11,0.0,0.0,0.0,terry walker,,BE-4730,2017
+BIOE,1010,1,Biol for Bioengr,0.58,0.34,0.04,0.0,0.0,0.0,0.0,0.05,vladimir vla reukov,,BIOE-1010,2017
+BIOE,2000,1,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,martine laberge,,BIOE-2000,2017
+BIOE,2010,1,Intro Biomed Engr,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,charles webb,,BIOE-2010,2017
+BIOE,3020,1,Biomaterials,0.67,0.29,0.03,0.0,0.0,0.0,0.0,0.01,alexey ale vertegel,,BIOE-3020,2017
+BIOE,3200,1,Biomechanics,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,,BIOE-3200,2017
+BIOE,3210,1,Biofluid Mechanics,0.6,0.19,0.15,0.04,0.0,0.0,0.0,0.02,sarah harcum,,BIOE-3210,2017
+BIOE,3700,1,Bioinst & Imaging,0.9,0.08,0.02,0.0,0.0,0.0,0.0,0.0,delphine dean,,BIOE-3700,2017
+BIOE,4030,1,Applied Bio E Design,0.75,0.24,0.01,0.0,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4030,2017
+BIOE,4200,1,Sports Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,,BIOE-4200,2017
+BIOE,4230,1,Cardiovascular Engr and Path,0.54,0.44,0.02,0.0,0.0,0.0,0.0,0.0,dan simionescu,,BIOE-4230,2017
+BIOE,4490,1,Drug Delivery,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,frank alexis,,BIOE-4490,2017
+BIOE,6230,1,Cardiovascular Engr and Path,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.03,dan simionescu,,BIOE-6230,2017
+BIOE,6350,1,Modeling of Multiphysics Prob,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,guigen zhang,,BIOE-6350,2017
+BIOE,8000,1,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,martine laberge,,BIOE-8000,2017
+BIOE,8410,1,Drug Delivery,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,,BIOE-8410,2017
+BIOE,8500,3,Reg & Clin Affairs-Med Devices,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,jeremy mercuri,,BIOE-8500,2017
+BIOE,8610,1,Biomed Eng Product Translation,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jeremy mercuri,,BIOE-8610,2017
+BIOL,1040,1,General Biology II,0.13,0.27,0.28,0.16,0.1,0.0,0.0,0.06,nora espinoza,,BIOL-1040,2017
+BIOL,1040,2,General Biology II,0.45,0.32,0.16,0.04,0.02,0.0,0.0,0.01,william surver,,BIOL-1040,2017
+BIOL,1040,3,General Biology II,0.13,0.22,0.38,0.13,0.09,0.0,0.0,0.05,salvatore sparace,,BIOL-1040,2017
+BIOL,1040,4,General Biology II (HON),0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True,BIOL-1040,2017
+BIOL,1060,1,Gen Biology Lab II,0.22,0.52,0.17,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,2,Gen Biology Lab II,0.32,0.5,0.18,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,3,Gen Biology Lab II,0.13,0.58,0.08,0.04,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,4,Gen Biology Lab II,0.08,0.58,0.29,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,5,Gen Biology Lab II,0.14,0.23,0.41,0.14,0.09,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,7,Gen Biology Lab II,0.14,0.5,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,8,Gen Biology Lab II,0.23,0.45,0.18,0.0,0.05,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,9,Gen Biology Lab II,0.27,0.27,0.32,0.09,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,10,Gen Biology Lab II,0.18,0.32,0.36,0.05,0.09,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,11,Gen Biology Lab II,0.08,0.58,0.29,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,12,Gen Biology Lab II,0.17,0.57,0.26,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,13,Gen Biology Lab II,0.17,0.54,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,14,Gen Biology Lab II,0.14,0.57,0.24,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,15,Gen Biology Lab II,0.1,0.71,0.14,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,16,Gen Biology Lab II,0.04,0.71,0.17,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,17,Gen Biology Lab II,0.13,0.42,0.25,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,18,Gen Biology Lab II,0.05,0.55,0.35,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,19,Gen Biology Lab II,0.0,0.4,0.45,0.05,0.0,0.0,0.0,0.1,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,20,Gen Biology Lab II,0.29,0.43,0.19,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,21,Gen Biology Lab II,0.18,0.5,0.23,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,22,Gen Biology Lab II,0.19,0.48,0.19,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,24,Gen Biology Lab II,0.05,0.6,0.3,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,25,Gen Biology Lab II,0.08,0.58,0.25,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,26,Gen Biology Lab II,0.53,0.21,0.21,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,27,Gen Biology Lab II,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,28,Gen Biology Lab II,0.32,0.5,0.05,0.05,0.05,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,29,Gen Biology Lab II,0.09,0.45,0.36,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,30,Gen Biology Lab II,0.15,0.55,0.2,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,31,Gen Biology Lab II,0.08,0.46,0.33,0.04,0.08,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,32,Gen Biology Lab II,0.23,0.45,0.27,0.0,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,35,Gen Biology Lab II,0.05,0.48,0.33,0.05,0.1,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1060,36,Gen Biology Lab II,0.0,0.19,0.63,0.06,0.0,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1060,2017
+BIOL,1110,1,Principles of Biology II,0.24,0.48,0.19,0.03,0.05,0.0,0.0,0.01,dylan dittrich-reed,,BIOL-1110,2017
+BIOL,1110,3,Principles of Biology II,0.4,0.37,0.14,0.03,0.03,0.0,0.0,0.02,robert kosinski,,BIOL-1110,2017
+BIOL,1110,4,Prin of Biol II  (HON),0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,robert kosinski,True,BIOL-1110,2017
+BIOL,1200,1,Biological Inq Lab,0.24,0.71,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,2,Biological Inq Lab,0.39,0.28,0.33,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,3,Biological Inq Lab,0.6,0.27,0.07,0.0,0.0,0.0,0.0,0.07, christine minor,,BIOL-1200,2017
+BIOL,1200,4,Biological Inq Lab,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,5,Biological Inq Lab,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1200,6,Biological Inq Lab,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-1200,2017
+BIOL,1230,1,Keys to Human Biol,0.3,0.34,0.19,0.12,0.03,0.0,0.0,0.02, christine minor,,BIOL-1230,2017
+BIOL,2000,1,Biology in the News,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-2000,2017
+BIOL,2000,4,Biology in the News,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,vincent pa richards,,BIOL-2000,2017
+BIOL,2030,1,Human Disease & Soc,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0, christine minor,,BIOL-2030,2017
+BIOL,2040,1,"Environ, Energy and Society",0.34,0.4,0.09,0.08,0.0,0.0,0.0,0.09,john jenkins hains,,BIOL-2040,2017
+BIOL,2040,2,"Environ, Energy and Society",0.18,0.56,0.16,0.09,0.0,0.0,0.0,0.02,john jenkins hains,,BIOL-2040,2017
+BIOL,2230,1,Human Anat and Physiology II,0.41,0.34,0.11,0.09,0.02,0.0,0.0,0.02,john cummings,,BIOL-2230,2017
+BIOL,2230,2,Human Anat and Physiology II,0.5,0.29,0.14,0.05,0.01,0.0,0.0,0.01,john cummings,,BIOL-2230,2017
+BIOL,3020,1,Invertebrate Biology,0.13,0.28,0.39,0.11,0.09,0.0,0.0,0.0,juan baeza migueles,,BIOL-3020,2017
+BIOL,3040,1,Biology of Plants,0.15,0.3,0.26,0.23,0.04,0.0,0.0,0.01,robert edwa ballard,,BIOL-3040,2017
+BIOL,3060,2,Invertebrate Biology Lab,0.29,0.33,0.25,0.0,0.08,0.0,0.0,0.04,juan baeza migueles,,BIOL-3060,2017
+BIOL,3060,4,Invertebrate Biology Lab,0.3,0.48,0.22,0.0,0.0,0.0,0.0,0.0,juan baeza migueles,,BIOL-3060,2017
+BIOL,3080,1,Biology of Plants Practicum,0.22,0.33,0.28,0.11,0.0,0.0,0.0,0.06,nathan redding,,BIOL-3080,2017
+BIOL,3080,2,Biology of Plants Practicum,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2017
+BIOL,3080,3,Biology of Plants Practicum,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2017
+BIOL,3080,4,Biology of Plants Practicum,0.76,0.12,0.0,0.0,0.12,0.0,0.0,0.0,nathan redding,,BIOL-3080,2017
+BIOL,3160,1,Human Physiology,0.35,0.51,0.11,0.02,0.01,0.0,0.0,0.01,tamara mcnutt-scott,,BIOL-3160,2017
+BIOL,3350,1,Evolutionary Biology,0.45,0.33,0.14,0.07,0.0,0.0,0.0,0.01,michael sears,,BIOL-3350,2017
+BIOL,3510,1,Biological Anthropology,0.33,0.39,0.28,0.0,0.0,0.0,0.0,0.0,katherine weisensee,,BIOL-3510,2017
+BIOL,4010,1,Plant Physiology,0.22,0.24,0.33,0.15,0.02,0.0,0.0,0.05,douglas bielenberg,,BIOL-4010,2017
+BIOL,4020,1,Plant Physiology Lab,0.55,0.35,0.05,0.05,0.0,0.0,0.0,0.0,douglas bielenberg,,BIOL-4020,2017
+BIOL,4020,2,Plant Physiology Lab,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,,BIOL-4020,2017
+BIOL,4080,1,Comparative Vertebrate Morph,0.29,0.5,0.13,0.04,0.0,0.0,0.0,0.04,christopher mayerl,,BIOL-4080,2017
+BIOL,4090,1,Comp Vertebrate Morph Lab,0.5,0.21,0.21,0.04,0.0,0.0,0.0,0.04,richard blob,,BIOL-4090,2017
+BIOL,4100,1,Limnology,0.24,0.52,0.14,0.02,0.0,0.0,0.0,0.07,john jenkins hains,,BIOL-4100,2017
+BIOL,4140,1,Basic Immunology,0.83,0.1,0.0,0.0,0.0,0.0,0.0,0.07,charles rice,,BIOL-4140,2017
+BIOL,4340,1,Biological Chem Lab Techniques,0.06,0.13,0.31,0.44,0.06,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2017
+BIOL,4340,2,Biological Chem Lab Techniques,0.14,0.29,0.36,0.21,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2017
+BIOL,4340,3,Biological Chem Lab Techniques,0.19,0.56,0.06,0.13,0.0,0.0,0.0,0.06,salvatore sparace,,BIOL-4340,2017
+BIOL,4340,4,Biological Chem Lab Techniques,0.13,0.33,0.27,0.27,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2017
+BIOL,4610,1,Cell Biology,0.35,0.26,0.26,0.09,0.0,0.0,0.0,0.03,zhicheng dou,,BIOL-4610,2017
+BIOL,4610,2,Cell Biology (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,zhicheng dou,True,BIOL-4610,2017
+BIOL,4610,3,Cell Biology,0.29,0.33,0.26,0.07,0.04,0.0,0.0,0.01,lisa bain,,BIOL-4610,2017
+BIOL,4610,4,Cell Biology (HON),0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,lisa bain,True,BIOL-4610,2017
+BIOL,4620,1,Cell Biology Lab (Lec),0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,2,Cell Biology Lab (Lec),0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,4,Cell Biology Lab (Lec),0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,5,Cell Biology Lab (Lec),0.87,0.04,0.09,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,6,Cell Biology Lab (Lec),0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4620,8,Cell Biology Lab (Lec),0.52,0.39,0.09,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2017
+BIOL,4670,1,Principles of Hematology,0.73,0.18,0.05,0.02,0.0,0.0,0.0,0.02,vincent gallicchio,,BIOL-4670,2017
+BIOL,4700,1,Behavioral Ecology,0.34,0.46,0.16,0.02,0.0,0.0,0.0,0.01,michael childress,,BIOL-4700,2017
+BIOL,4700,2,Behavioral Ecology (HON),0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,True,BIOL-4700,2017
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,michael childress,,BIOL-4710,2017
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,,BIOL-4710,2017
+BIOL,4710,4,Behavioral Ecology Lab (Lec),0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,michael childress,,BIOL-4710,2017
+BIOL,4780,1,Exercise Physiology,0.4,0.4,0.17,0.0,0.0,0.0,0.0,0.02,john cummings,,BIOL-4780,2017
+BIOL,4800,1,Vertebrate Endocrinology,0.31,0.25,0.19,0.13,0.0,0.0,0.0,0.13,william baldwin,,BIOL-4800,2017
+BIOL,4930,2,Sr Sem: Adv Cancer Research,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,,BIOL-4930,2017
+BIOL,4930,5,Sr Sem: Nervous Systems,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,david feliciano,,BIOL-4930,2017
+BIOL,4930,7,Sr Sem: Conservation Biology,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david tonkyn,,BIOL-4930,2017
+BIOL,4940,4,CI: Popular Science Journalism,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,,BIOL-4940,2017
+BIOL,8430,1,Underst Genetics & Evol Biol,0.64,0.33,0.02,0.0,0.02,0.0,0.0,0.0,margaret ptacek,,BIOL-8430,2017
+BIOL,8450,1,Understanding Animal Biology,0.93,0.03,0.01,0.0,0.02,0.0,0.0,0.0,matthew turnbull,,BIOL-8450,2017
+BIOL,8470,1,Understanding Microbiology,0.58,0.34,0.04,0.0,0.02,0.0,0.0,0.02,harry kurtz,,BIOL-8470,2017
+BIOL,8480,1,Understanding Scientific Rsrch,0.93,0.0,0.0,0.0,0.02,0.0,0.0,0.05,robert edwa ballard,,BIOL-8480,2017
+BIOL,8710,1,Current Topics in Biology,0.67,0.0,0.0,0.0,0.17,0.0,0.0,0.17,robert edwa ballard,,BIOL-8710,2017
+BMOL,4250,1,Biomolecular Engineering,0.26,0.3,0.22,0.09,0.07,0.0,0.0,0.07,mark alan blenner,,BMOL-4250,2017
+BUS,1010,1,Business Foundations,0.33,0.52,0.11,0.0,0.04,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2017
+BUS,1010,2,Business Foundations,0.39,0.39,0.14,0.0,0.04,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2017
+BUS,1010,3,Business Foundations,0.35,0.58,0.08,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2017
+BUS,1010,4,Business Foundations,0.19,0.38,0.35,0.04,0.0,0.0,0.0,0.04,william ern tumblin,,BUS-1010,2017
+BUS,1010,5,Business Foundations,0.26,0.37,0.3,0.04,0.04,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,6,Business Foundations,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,7,Business Foundations,0.19,0.63,0.19,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2017
+BUS,1010,8,Business Foundations,0.35,0.26,0.3,0.0,0.04,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2017
+BUS,1010,9,Business Foundations,0.25,0.44,0.19,0.0,0.13,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,10,Business Foundations,0.16,0.48,0.2,0.08,0.08,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2017
+BUS,1010,16,Business Foundations,0.14,0.41,0.1,0.17,0.0,0.0,0.0,0.17,james mullinax,,BUS-1010,2017
+BUS,1010,17,Business Foundations,0.24,0.34,0.34,0.07,0.0,0.0,0.0,0.0,james mullinax,,BUS-1010,2017
+BUS,2990,3,CI:  Being a Leader,0.75,0.19,0.0,0.06,0.0,0.0,0.0,0.0,christopher mann,,BUS-2990,2017
+CE,2010,1,Statics,0.59,0.24,0.09,0.02,0.03,0.0,0.0,0.03,sara khoshnevisan,,CE-2010,2017
+CE,2010,2,Statics,0.12,0.31,0.4,0.0,0.1,0.0,0.0,0.07,melissa sternhagen,,CE-2010,2017
+CE,2010,3,Statics,0.63,0.23,0.08,0.03,0.0,0.0,0.0,0.03,brandon ross,,CE-2010,2017
+CE,2010,4,Statics,0.12,0.24,0.12,0.2,0.28,0.0,0.0,0.04,melissa sternhagen,,CE-2010,2017
+CE,2010,5,Statics,0.36,0.36,0.18,0.06,0.03,0.0,0.0,0.0,william albe ashman,,CE-2010,2017
+CE,2010,6,Statics,0.5,0.22,0.22,0.04,0.02,0.0,0.0,0.0, kent nilsson,,CE-2010,2017
+CE,2010,7,Statics (HON),0.82,0.09,0.0,0.09,0.0,0.0,0.0,0.0,brandon ross,True,CE-2010,2017
+CE,2060,1,Structural Mechanics,0.31,0.51,0.18,0.0,0.0,0.0,0.0,0.0,bryant nielson,,CE-2060,2017
+CE,2060,2,Structural Mechanics,0.54,0.38,0.06,0.0,0.02,0.0,0.0,0.0,mahmoodreza soltani,,CE-2060,2017
+CE,2080,1,Dynamics,0.17,0.3,0.42,0.07,0.02,0.0,0.0,0.03,melissa sternhagen,,CE-2080,2017
+CE,2080,2,Dynamics,0.18,0.37,0.26,0.08,0.08,0.0,0.0,0.03,melissa sternhagen,,CE-2080,2017
+CE,2550,1,Geomatics,0.29,0.44,0.2,0.03,0.03,0.0,0.0,0.0, shams esfandabadi,,CE-2550,2017
+CE,3010,1,Structural Analysis,0.34,0.26,0.2,0.09,0.06,0.0,0.0,0.06,stephen csernak,,CE-3010,2017
+CE,3110,1,Transportation Engr,0.3,0.43,0.21,0.05,0.0,0.0,0.0,0.02,wayne sarasua,,CE-3110,2017
+CE,3210,1,Geotechnical Engineering,0.58,0.3,0.09,0.0,0.0,0.0,0.0,0.02,charng-hsein juang,,CE-3210,2017
+CE,3210,2,Geotechnical Engineering,0.57,0.37,0.07,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,,CE-3210,2017
+CE,3310,1,Constr Engr & Mgmnt,0.36,0.43,0.18,0.0,0.0,0.0,0.0,0.02,james burati,,CE-3310,2017
+CE,3410,1,Intro to Fluid Mech,0.26,0.44,0.21,0.06,0.0,0.0,0.0,0.03,md nasimu chowdhury,,CE-3410,2017
+CE,3420,1,Hydraulics & Hydro,0.37,0.27,0.2,0.03,0.0,0.0,0.0,0.13,abdul khan,,CE-3420,2017
+CE,3420,2,Hydraulics & Hydro,0.6,0.38,0.03,0.0,0.0,0.0,0.0,0.0,ashok mishra,,CE-3420,2017
+CE,3510,1,Civil Engineering Materials,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,,CE-3510,2017
+CE,3520,2,Econ Eval of Proj,0.51,0.39,0.08,0.0,0.0,0.0,0.0,0.02,bradley putman,,CE-3520,2017
+CE,3530,1,Professional Seminar,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-3530,2017
+CE,4020,1,Reinfor Con Design,0.44,0.31,0.22,0.01,0.0,0.0,0.0,0.01,brandon ross,,CE-4020,2017
+CE,4070,1,Wood Design,0.52,0.33,0.1,0.0,0.0,0.0,0.0,0.05,weichiang pang,,CE-4070,2017
+CE,4080,1,Struct Loads & Sys,0.08,0.38,0.25,0.17,0.0,0.0,0.0,0.13,bryant nielson,,CE-4080,2017
+CE,4110,1,Roadway Geo Design,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ogle,,CE-4110,2017
+CE,4120,1,Urban Transport Plan,0.24,0.76,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,,CE-4120,2017
+CE,4210,1,Geotechnical Design,0.37,0.26,0.29,0.05,0.03,0.0,0.0,0.0,nadara ravichandran,,CE-4210,2017
+CE,4340,1,Const Est Proj Cont,0.57,0.37,0.04,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4340,2017
+CE,4350,1,Infra Proj Planning,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,CE-4350,2017
+CE,4470,1,Stormwater Managemnt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john philli raiford,,CE-4470,2017
+CE,4590,1,Capstone Design Proj,0.46,0.49,0.05,0.0,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2017
+CE,6070,1,Wood Design,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-6070,2017
+CE,6080,1,Struct Loads & Sys,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,bryant nielson,,CE-6080,2017
+CE,6210,1,Geotechnical Design,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,nadara ravichandran,,CE-6210,2017
+CE,6350,1,Infra Proj Planning,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,CE-6350,2017
+CE,6470,1,Stormwater Managemnt,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john philli raiford,,CE-6470,2017
+CE,8020,1,Adv R/C Design,0.48,0.32,0.12,0.0,0.0,0.0,0.0,0.08,thomas edfo cousins,,CE-8020,2017
+CE,8060,1,Dyn Analys of Struc,0.42,0.38,0.12,0.0,0.0,0.0,0.0,0.08,bryant nielson,,CE-8060,2017
+CE,8250,1,Geotech Equake Engr,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald andrus,,CE-8250,2017
+CE,8260,1,Prop of Concrete,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,,CE-8260,2017
+CE,8460,1,Flow in Open Chnls,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,abdul khan,,CE-8460,2017
+CE,8530,1,Apps in Traffic En,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-8530,2017
+CE,8580,501,Fund of Risk Engineering Mgt,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,jie zhang,,CE-8580,2017
+CH,1010,1,General Chemistry,0.06,0.2,0.32,0.11,0.2,0.0,0.0,0.12,princess mycia cox,,CH-1010,2017
+CH,1010,2,General Chemistry,0.02,0.26,0.27,0.16,0.22,0.0,0.0,0.07,princess mycia cox,,CH-1010,2017
+CH,1010,3,General Chemistry,0.28,0.24,0.28,0.07,0.07,0.0,0.0,0.06,dennis taylor,,CH-1010,2017
+CH,1010,4,General Chemistry,0.05,0.24,0.28,0.13,0.17,0.0,0.0,0.14,joseph stu thrasher,,CH-1010,2017
+CH,1010,400,General Chemistry,0.19,0.23,0.25,0.15,0.07,0.0,0.0,0.12,stephe schvaneveldt,,CH-1010,2017
+CH,1020,1,General Chemistry,0.07,0.43,0.28,0.08,0.0,0.0,0.0,0.13,william mcwhorter,,CH-1020,2017
+CH,1020,2,General Chemistry,0.31,0.44,0.19,0.03,0.02,0.0,0.0,0.01,thomas hickman,,CH-1020,2017
+CH,1020,3,General Chemistry,0.39,0.37,0.12,0.08,0.01,0.0,0.0,0.03,dennis taylor,,CH-1020,2017
+CH,1020,4,General Chemistry,0.35,0.4,0.14,0.04,0.0,0.0,0.0,0.06,dennis taylor,,CH-1020,2017
+CH,1020,5,General Chemistry,0.1,0.34,0.33,0.17,0.01,0.0,0.0,0.04,william mcwhorter,,CH-1020,2017
+CH,1020,6,General Chemistry,0.09,0.35,0.37,0.07,0.02,0.0,0.0,0.09,william mcwhorter,,CH-1020,2017
+CH,1020,7,General Chemistry,0.12,0.37,0.35,0.04,0.02,0.0,0.0,0.1,olt geiculescu,,CH-1020,2017
+CH,1020,8,General Chemistry,0.26,0.41,0.25,0.04,0.04,0.0,0.0,0.02,thomas hickman,,CH-1020,2017
+CH,1020,9,General Chemistry,0.25,0.47,0.2,0.05,0.01,0.0,0.0,0.02,elliot ennis,,CH-1020,2017
+CH,1020,10,General Chemistry,0.27,0.41,0.21,0.04,0.03,0.0,0.0,0.03,laura lanni,,CH-1020,2017
+CH,1020,11,General Chemistry,0.23,0.39,0.31,0.04,0.02,0.0,0.0,0.01,laura lanni,,CH-1020,2017
+CH,1020,50,General Chemistry,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,shiou-jyh hwu,,CH-1020,2017
+CH,1020,51,General Chemistry (HON),0.88,0.09,0.02,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True,CH-1020,2017
+CH,1020,52,General Chemistry (HON),0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True,CH-1020,2017
+CH,1020,500,General Chemistry,0.29,0.32,0.29,0.1,0.0,0.0,0.0,0.0,brian gloor,,CH-1020,2017
+CH,1050,1,Chemistry in Context I,0.32,0.47,0.06,0.06,0.02,0.0,0.0,0.06,olt geiculescu,,CH-1050,2017
+CH,1050,2,Chemistry in Context I,0.32,0.48,0.11,0.0,0.02,0.0,0.0,0.07,olt geiculescu,,CH-1050,2017
+CH,1060,1,Chemistry in Context II,0.47,0.38,0.15,0.0,0.0,0.0,0.0,0.0,thomas hickman,,CH-1060,2017
+CH,1520,1,Chemistry Communication,0.84,0.0,0.11,0.0,0.05,0.0,0.0,0.0,richard marcus,,CH-1520,2017
+CH,2010,1,Survey of Organic Chemistry,0.44,0.37,0.07,0.08,0.04,0.0,0.0,0.01,tania issa houjeiry,,CH-2010,2017
+CH,2020,1,Surv of Organic Chemistry Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2020,2017
+CH,2020,2,Surv of Organic Chemistry Lab,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,,CH-2020,2017
+CH,2050,1,Intro Inorg Chem,0.43,0.43,0.11,0.0,0.03,0.0,0.0,0.0,william pennington,,CH-2050,2017
+CH,2230,1,Organic Chemistry,0.19,0.3,0.25,0.15,0.09,0.0,0.0,0.02,jacob schroeder,,CH-2230,2017
+CH,2230,2,Organic Chemistry,0.34,0.3,0.21,0.08,0.04,0.0,0.0,0.02,jacob schroeder,,CH-2230,2017
+CH,2230,3,Organic Chemistry,0.29,0.18,0.24,0.1,0.09,0.0,0.0,0.1,sourav saha,,CH-2230,2017
+CH,2240,1,Organic Chemistry,0.33,0.33,0.19,0.07,0.02,0.0,0.0,0.06,elliot ennis,,CH-2240,2017
+CH,2240,2,Organic Chemistry,0.21,0.29,0.21,0.07,0.03,0.0,0.0,0.18,laura lanni,,CH-2240,2017
+CH,2240,3,Organic Chemistry,0.3,0.38,0.17,0.1,0.0,0.0,0.0,0.05,elliot ennis,,CH-2240,2017
+CH,2240,4,Organic Chemistry,0.29,0.31,0.2,0.07,0.04,0.0,0.0,0.09,rhett smith,,CH-2240,2017
+CH,2240,5,Organic Chemistry,0.35,0.43,0.18,0.01,0.01,0.0,0.0,0.02,jacob schroeder,,CH-2240,2017
+CH,2270,3,Organic Chem Lab,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2017
+CH,2270,6,Organic Chem Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2017
+CH,2270,7,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2017
+CH,2270,8,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2017
+CH,2270,9,Organic Chem Lab,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2017
+CH,2270,10,Organic Chem Lab,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2017
+CH,2270,11,Organic Chem Lab,0.89,0.0,0.0,0.06,0.0,0.0,0.0,0.06,sean 'connor,,CH-2270,2017
+CH,2270,12,Organic Chem Lab,0.81,0.06,0.06,0.06,0.0,0.0,0.0,0.0,sean 'connor,,CH-2270,2017
+CH,2270,13,Organic Chem Lab,0.59,0.12,0.18,0.0,0.0,0.0,0.0,0.12,sean 'connor,,CH-2270,2017
+CH,2270,14,Organic Chem Lab,0.79,0.0,0.07,0.0,0.0,0.0,0.0,0.14,sean 'connor,,CH-2270,2017
+CH,2270,15,Organic Chem Lab,0.67,0.2,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2270,2017
+CH,2280,1,Organic Chem Lab,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,sean 'connor,,CH-2280,2017
+CH,2280,5,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2280,2017
+CH,2280,6,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2280,2017
+CH,2280,10,Organic Chem Lab,0.81,0.06,0.0,0.0,0.0,0.0,0.0,0.13,sean 'connor,,CH-2280,2017
+CH,2280,12,Organic Chem Lab,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,sean 'connor,,CH-2280,2017
+CH,2280,19,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2280,2017
+CH,2280,21,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,sean 'connor,,CH-2280,2017
+CH,3310,1,Physical Chemistry,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,arkady kholodenko,,CH-3310,2017
+CH,3320,1,Physical Chemistry,0.29,0.46,0.15,0.06,0.02,0.0,0.0,0.02,steven stuart,,CH-3320,2017
+CH,3320,2,Physical Chemistry,0.68,0.2,0.04,0.04,0.0,0.0,0.0,0.04,jason mcneill,,CH-3320,2017
+CH,3320,3,Physical Chemistry,0.29,0.33,0.24,0.0,0.14,0.0,0.0,0.0,leah bec casabianca,,CH-3320,2017
+CH,3400,2,Physical Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2017
+CH,3400,3,Physical Chem Lab,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2017
+CH,3400,5,Physical Chem Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2017
+CH,3600,1,Chemical Biology,0.58,0.28,0.11,0.0,0.02,0.0,0.0,0.0,modi wetzler,,CH-3600,2017
+CH,4040,1,Bioinorganic Chem,0.38,0.25,0.19,0.06,0.0,0.0,0.0,0.13,julia brumaghim,,CH-4040,2017
+CH,4110,1,Instrumental Analy,0.33,0.33,0.0,0.25,0.08,0.0,0.0,0.0,george chumanov,,CH-4110,2017
+CH,4120,1,Instr Analysis Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey natha anker,,CH-4120,2017
+CH,4130,1,Chemistry of Aqueous Systems,0.51,0.31,0.11,0.0,0.0,0.0,0.0,0.06,cindy lee,,CH-4130,2017
+CH,4250,1,Medicinal Chem,0.38,0.23,0.08,0.0,0.08,0.0,0.0,0.23,dev priya arya,,CH-4250,2017
+CH,4500,1,Chemistry Capstone,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,,CH-4500,2017
+CH,8130,1,Electrochem Sci,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,stephen creager,,CH-8130,2017
+CH,8510,1,Grad Student Seminar,0.77,0.2,0.0,0.0,0.03,0.0,0.0,0.0,joseph stu thrasher,,CH-8510,2017
+CHE,1300,1,Intro to Chemical Engineering,0.15,0.28,0.26,0.13,0.11,0.0,0.0,0.07,christopher norfolk,,CHE-1300,2017
+CHE,1300,2,Intro to Chemical Engineering,0.14,0.24,0.24,0.1,0.1,0.0,0.0,0.2,christopher norfolk,,CHE-1300,2017
+CHE,2200,1,Ch E Thermo I,0.21,0.38,0.25,0.09,0.06,0.0,0.0,0.01,joseph scott,,CHE-2200,2017
+CHE,2300,1,Fluids/Heat Transfer,0.08,0.18,0.5,0.08,0.13,0.0,0.0,0.03,eric mikel davis,,CHE-2300,2017
+CHE,2300,2,Fluids/Heat Transfer,0.12,0.34,0.29,0.12,0.1,0.0,0.0,0.03,eric mikel davis,,CHE-2300,2017
+CHE,3070,1,Unit Ops Lab I,0.24,0.53,0.19,0.0,0.0,0.0,0.0,0.03,mark thies,,CHE-3070,2017
+CHE,3190,1,Engr Materials,0.17,0.35,0.33,0.08,0.0,0.0,0.0,0.07,christopher norfolk,,CHE-3190,2017
+CHE,3530,2,Proc Dyn & Control,0.31,0.51,0.17,0.01,0.0,0.0,0.0,0.0,mark roberts,,CHE-3530,2017
+CHE,4330,1,Process Design II,0.59,0.4,0.01,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4330,2017
+CHIN,1020,1,Elementary Chinese,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,ling rao,,CHIN-1020,2017
+CHIN,2020,1,Intermediate Chinese,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ling rao,,CHIN-2020,2017
+CHIN,4010,1,Pre-Modern Chinese Literature,0.21,0.42,0.26,0.11,0.0,0.0,0.0,0.0,yanming an,,CHIN-4010,2017
+COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,eddie smith,,COM-1010,2017
+COM,1500,1,Intro to Human Communication,0.8,0.13,0.02,0.02,0.03,0.0,0.0,0.0,eddie smith,,COM-1500,2017
+COM,1500,2,Intro to Human Communication,0.6,0.29,0.08,0.01,0.01,0.0,0.0,0.01,daniel lelan fecher,,COM-1500,2017
+COM,1500,3,Intro to Human Communication,0.86,0.09,0.03,0.0,0.01,0.0,0.0,0.01,eddie smith,,COM-1500,2017
+COM,1500,4,Intro to Human Communication,0.62,0.31,0.04,0.02,0.0,0.0,0.0,0.01,marianne her glaser,,COM-1500,2017
+COM,1500,5,Intro to Human Communication,0.69,0.25,0.06,0.01,0.0,0.0,0.0,0.0,marianne her glaser,,COM-1500,2017
+COM,1500,6,Intro to Human Communication,0.41,0.47,0.09,0.03,0.0,0.0,0.0,0.0,daniel lelan fecher,,COM-1500,2017
+COM,2010,1,Intr to Comm Studies,0.6,0.3,0.07,0.0,0.0,0.0,0.0,0.03,darren linvill,,COM-2010,2017
+COM,2010,2,Intr to Comm Studies,0.47,0.4,0.07,0.03,0.0,0.0,0.0,0.03,darren linvill,,COM-2010,2017
+COM,2500,1,Public Speaking,0.33,0.43,0.1,0.1,0.05,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2017
+COM,2500,2,Public Speaking,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,brandon boatwright,,COM-2500,2017
+COM,2500,3,Public Speaking,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2017
+COM,2500,4,Public Speaking,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2017
+COM,2500,5,Public Speaking,0.29,0.62,0.1,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2017
+COM,2500,6,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2017
+COM,2500,7,Public Speaking,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2017
+COM,2500,8,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2017
+COM,2500,10,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2017
+COM,2500,11,Public Speaking,0.71,0.24,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,,COM-2500,2017
+COM,2500,12,Public Speaking,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2017
+COM,2500,13,Public Speaking,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2017
+COM,2500,14,Public Speaking,0.52,0.33,0.0,0.0,0.1,0.0,0.0,0.05,jumah patrici taweh,,COM-2500,2017
+COM,2500,15,Public Speaking,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2017
+COM,2500,16,Public Speaking,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2017
+COM,2500,17,Public Speaking,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,the estate  geddes,,COM-2500,2017
+COM,2500,18,Public Speaking,0.86,0.1,0.0,0.0,0.05,0.0,0.0,0.0,caitlin baker,,COM-2500,2017
+COM,2500,19,Public Speaking,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2017
+COM,2500,21,Public Speaking,0.67,0.24,0.0,0.05,0.0,0.0,0.0,0.05,sara grumbl crocker,,COM-2500,2017
+COM,2500,22,Public Speaking,0.52,0.33,0.0,0.0,0.05,0.0,0.0,0.1,jumah patrici taweh,,COM-2500,2017
+COM,2500,24,Public Speaking,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2017
+COM,2500,25,Public Speaking,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,katharin schoonover,,COM-2500,2017
+COM,2500,27,Public Speaking (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,True,COM-2500,2017
+COM,2500,29,Public Speaking,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2017
+COM,2500,30,Public Speaking,0.32,0.64,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2017
+COM,2500,31,Public Speaking,0.1,0.57,0.14,0.05,0.1,0.0,0.0,0.05,pauline matthey,,COM-2500,2017
+COM,2500,32,Public Speaking,0.25,0.2,0.25,0.1,0.1,0.0,0.0,0.1,pauline matthey,,COM-2500,2017
+COM,2500,400,Public Speaking,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2017
+COM,2500,401,Public Speaking,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,alexis zachar davis,,COM-2500,2017
+COM,2500,402,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2017
+COM,2500,403,Public Speaking,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2017
+COM,2500,500,Public Speaking,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2017
+COM,2500,501,Public Speaking,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2017
+COM,3010,1,Comm Theory,0.24,0.62,0.0,0.1,0.0,0.0,0.0,0.05,gregory kei cranmer,,COM-3010,2017
+COM,3020,1,Mass Comm Theory,0.58,0.13,0.29,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3020,2017
+COM,3020,2,Mass Comm Theory,0.43,0.35,0.22,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3020,2017
+COM,3060,1,Crit-Cultural Rsrch Methods,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,brandon boatwright,,COM-3060,2017
+COM,3110,1,Qual Comm Methods,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,chenjerai kumanyika,,COM-3110,2017
+COM,3250,1,Survey of Sports Communication,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-3250,2017
+COM,3250,2,Survey of Sports Communication,0.8,0.08,0.08,0.0,0.04,0.0,0.0,0.0,john steven spinda,,COM-3250,2017
+COM,3550,1,Principles of Public Relations,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3550,2017
+COM,3550,2,Principles of Public Relations,0.79,0.17,0.0,0.0,0.04,0.0,0.0,0.0,andrew stephen pyle,,COM-3550,2017
+COM,3560,1,Crisis Communication,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3560,2017
+COM,3610,1,Argue and Debate,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,lindsey dixon,,COM-3610,2017
+COM,3660,1,Video COMM w/ Adobe CC,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,michael rodgers,,COM-3660,2017
+COM,3700,1,Survey of Brand Communications,0.93,0.0,0.03,0.0,0.0,0.0,0.0,0.03,lisa willi papenfus,,COM-3700,2017
+COM,3720,1,Digital Analytics in Brand Com,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,alicia ni littleton,,COM-3720,2017
+COM,3730,1,Media Management in Brand Comm,0.77,0.19,0.0,0.04,0.0,0.0,0.0,0.0,william reynolds,,COM-3730,2017
+COM,3740,1,Brand Comm and Media Strategy,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,roger beasley,,COM-3740,2017
+COM,4040,1,Media Comm & Social Identities,0.18,0.53,0.0,0.06,0.12,0.0,0.0,0.12,chenjerai kumanyika,,COM-4040,2017
+COM,4040,2,Media Comm & Social Identities,0.43,0.48,0.0,0.1,0.0,0.0,0.0,0.0,chenjerai kumanyika,,COM-4040,2017
+COM,4270,1,Comm in Sports Organizations,0.68,0.24,0.04,0.0,0.0,0.0,0.0,0.04,angela pratt,,COM-4270,2017
+COM,4270,2,Comm in Sports Organizations,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-4270,2017
+COM,4280,1,Interpers/Family Comm & Sport,0.43,0.48,0.04,0.0,0.0,0.0,0.0,0.04,gregory kei cranmer,,COM-4280,2017
+COM,4280,2,Interpers/Family Comm & Sport,0.4,0.56,0.0,0.0,0.0,0.0,0.0,0.04,gregory kei cranmer,,COM-4280,2017
+COM,4700,1,Comm & Health,0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4700,2017
+COM,4950,1,Senior Capstone,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-4950,2017
+COM,4950,2,Senior Capstone,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-4950,2017
+COM,4980,1,Acad & Prof Dev II,0.0,0.0,0.0,0.0,0.0,0.95,0.02,0.04,joseph mazer,,COM-4980,2017
+COM,8110,1,Comm Research Methods II,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-8110,2017
+COOP,1010,1,Co-Op Education,0.0,0.0,0.0,0.0,0.0,0.98,0.02,0.0,jeffrey frank neal,,COOP-1010,2017
+CPSC,1010,1,Computer Science I,0.23,0.24,0.18,0.08,0.12,0.0,0.0,0.15,salvatore lamarca,,CPSC-1010,2017
+CPSC,1010,2,Computer Science I,0.26,0.24,0.18,0.05,0.11,0.0,0.0,0.16,lanny sitanayah,,CPSC-1010,2017
+CPSC,1020,1,Computer Science II,0.4,0.29,0.14,0.1,0.05,0.0,0.0,0.02,yvon feaster,,CPSC-1020,2017
+CPSC,1020,2,Computer Science II,0.49,0.2,0.11,0.11,0.08,0.0,0.0,0.02,yvon feaster,,CPSC-1020,2017
+CPSC,1070,1,Programming Methodology,0.42,0.29,0.16,0.0,0.03,0.0,0.0,0.1,rose lowe,,CPSC-1070,2017
+CPSC,1110,1,Intro to Programming in C,0.25,0.37,0.2,0.04,0.02,0.0,0.0,0.12,catherine hochrine,,CPSC-1110,2017
+CPSC,1110,2,Intro to Programming in C,0.33,0.38,0.1,0.04,0.04,0.0,0.0,0.12,catherine hochrine,,CPSC-1110,2017
+CPSC,2070,1,Discrete Structures,0.26,0.26,0.18,0.09,0.15,0.0,0.0,0.06,sandra hedetniemi,,CPSC-2070,2017
+CPSC,2070,2,Discrete Structures,0.3,0.25,0.23,0.15,0.02,0.0,0.0,0.07,larry hodges,,CPSC-2070,2017
+CPSC,2120,1,Algs/Data Structures,0.11,0.31,0.25,0.17,0.09,0.0,0.0,0.06,salvatore lamarca,,CPSC-2120,2017
+CPSC,2120,2,Algs/Data Structures,0.26,0.32,0.23,0.05,0.06,0.0,0.0,0.08,salvatore lamarca,,CPSC-2120,2017
+CPSC,2150,1,Software Dev Foundations,0.27,0.33,0.24,0.05,0.06,0.0,0.0,0.05,kevin anton plis,,CPSC-2150,2017
+CPSC,2150,2,Software Dev Foundations,0.26,0.34,0.18,0.05,0.07,0.0,0.0,0.1,murali sitaraman,,CPSC-2150,2017
+CPSC,2200,1,Microcomputer Appl,0.7,0.17,0.09,0.0,0.0,0.0,0.0,0.04,lanny sitanayah,,CPSC-2200,2017
+CPSC,2310,1,Intro Computer Org,0.3,0.34,0.2,0.02,0.04,0.0,0.0,0.1,rose lowe,,CPSC-2310,2017
+CPSC,2310,2,Intro Computer Org,0.29,0.22,0.31,0.1,0.06,0.0,0.0,0.02,rose lowe,,CPSC-2310,2017
+CPSC,2910,1,Prof Issues I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2017
+CPSC,2910,2,Prof Issues I,0.65,0.2,0.15,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2017
+CPSC,2910,3,Prof Issues I,0.42,0.26,0.32,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2017
+CPSC,2910,4,Prof Issues I,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2017
+CPSC,2910,5,Prof Issues I,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2017
+CPSC,3220,1,Intro to Operating Systems,0.25,0.19,0.09,0.06,0.13,0.0,0.0,0.28,jacob sorber,,CPSC-3220,2017
+CPSC,3220,2,Intro to Operating Systems,0.18,0.24,0.29,0.11,0.11,0.0,0.0,0.07,mark smotherman,,CPSC-3220,2017
+CPSC,3300,1,Computer Systems Org,0.24,0.15,0.31,0.22,0.05,0.0,0.0,0.03,mark smotherman,,CPSC-3300,2017
+CPSC,3500,1,Foundations of Computer Sci,0.24,0.37,0.34,0.02,0.01,0.0,0.0,0.01,wayne goddard,,CPSC-3500,2017
+CPSC,3520,1,Programming Systems,0.37,0.4,0.09,0.0,0.09,0.0,0.0,0.06,robert schalkoff,,CPSC-3520,2017
+CPSC,3600,1,Network Programming,0.29,0.29,0.14,0.11,0.03,0.0,0.0,0.14,feng luo,,CPSC-3600,2017
+CPSC,3600,2,Network Programming,0.44,0.22,0.27,0.02,0.05,0.0,0.0,0.0,lanny sitanayah,,CPSC-3600,2017
+CPSC,3620,1,Distributed/Cluster Computing,0.19,0.4,0.3,0.03,0.02,0.0,0.0,0.06,linh bao ngo,,CPSC-3620,2017
+CPSC,3720,1,Software Engineering,0.37,0.39,0.16,0.08,0.0,0.0,0.0,0.0,kevin anton plis,,CPSC-3720,2017
+CPSC,3720,2,Software Engineering,0.24,0.33,0.33,0.04,0.06,0.0,0.0,0.0,kevin anton plis,,CPSC-3720,2017
+CPSC,3990,1,Advanced CI: Extreme Orange,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james martin,,CPSC-3990,2017
+CPSC,4050,1,Computer Graphics,0.31,0.38,0.19,0.06,0.0,0.0,0.0,0.06,robert geist,,CPSC-4050,2017
+CPSC,4110,1,Virtual Reality Systems,0.56,0.24,0.15,0.03,0.03,0.0,0.0,0.0,andrew robb,,CPSC-4110,2017
+CPSC,4140,1,Human and Computer Interaction,0.16,0.42,0.32,0.0,0.11,0.0,0.0,0.0,sabarish venka babu,,CPSC-4140,2017
+CPSC,4140,2,Human and Computer Interaction,0.61,0.3,0.0,0.0,0.04,0.0,0.0,0.04,sabarish venka babu,,CPSC-4140,2017
+CPSC,4140,3,Human and Computer Interaction,0.35,0.35,0.17,0.0,0.04,0.0,0.0,0.09,christopher plaue,,CPSC-4140,2017
+CPSC,4160,1,2-D Game Engine Construction,0.43,0.28,0.13,0.06,0.02,0.0,0.0,0.08,brian malloy,,CPSC-4160,2017
+CPSC,4240,1,System Admin and Security,0.15,0.61,0.24,0.0,0.0,0.0,0.0,0.0,james martin,,CPSC-4240,2017
+CPSC,4620,1,Database Management Systems,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,zijun wang,,CPSC-4620,2017
+CPSC,4820,1,Selected Topics: Android Dev,0.75,0.06,0.13,0.06,0.0,0.0,0.0,0.0,roy pargas,,CPSC-4820,2017
+CPSC,4820,2,Special Topics: Dig Sulpt,0.25,0.67,0.0,0.0,0.0,0.0,0.0,0.08,insun kwon,,CPSC-4820,2017
+CPSC,4820,3,Special Topics: Data Science,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,,CPSC-4820,2017
+CPSC,4820,4,Special Topic: Cloud Comp Arch,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,amy apon,,CPSC-4820,2017
+CPSC,4820,5,Special Topics: Tang and Embod,0.35,0.3,0.2,0.0,0.1,0.0,0.0,0.05,brygg anders ullmer,,CPSC-4820,2017
+CPSC,4910,1,Professional Issues II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,,CPSC-4910,2017
+CPSC,6050,1,Computer Graphics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert geist,,CPSC-6050,2017
+CPSC,6110,1,Virtual Reality Systems,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,andrew robb,,CPSC-6110,2017
+CPSC,6140,1,Human and Computer Interaction,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venka babu,,CPSC-6140,2017
+CPSC,6140,2,Human and Computer Interaction,0.7,0.17,0.09,0.0,0.0,0.0,0.0,0.04,sabarish venka babu,,CPSC-6140,2017
+CPSC,6160,1,2-D Game Engine Construction,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,brian malloy,,CPSC-6160,2017
+CPSC,6620,1,Database Management Systems,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,zijun wang,,CPSC-6620,2017
+CPSC,6810,3,Selected Topic: Program Team,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,brian christop dean,,CPSC-6810,2017
+CPSC,6820,3,Special Topics: Data Science,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,,CPSC-6820,2017
+CPSC,6820,4,Special Topic: Cloud Comp Arch,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,amy apon,,CPSC-6820,2017
+CPSC,8050,1,Adv Comp Graphics,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,,CPSC-8050,2017
+CPSC,8110,1,Technical Character Animation,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,christina sop joerg,,CPSC-8110,2017
+CPSC,8220,1,Case Study in Operating Sys,0.55,0.35,0.0,0.0,0.0,0.0,0.0,0.1,robert geist,,CPSC-8220,2017
+CPSC,8400,1,Design & Anlys of Algorithms,0.18,0.32,0.26,0.0,0.08,0.0,0.0,0.16,brian christop dean,,CPSC-8400,2017
+CPSC,8470,1,Intro to Information Retrieval,0.66,0.17,0.14,0.0,0.0,0.0,0.0,0.03,feng luo,,CPSC-8470,2017
+CPSC,8570,1,Network Technologies Security,0.43,0.53,0.0,0.0,0.0,0.0,0.0,0.04,hongxin hu,,CPSC-8570,2017
+CPSC,8630,1,Multimedia Sys/Apps,0.31,0.46,0.15,0.0,0.0,0.0,0.0,0.08,zijun wang,,CPSC-8630,2017
+CPSC,8650,1,Data Mining,0.34,0.45,0.17,0.0,0.02,0.0,0.0,0.02,zijun wang,,CPSC-8650,2017
+CPSC,8750,1,Software Architectur,0.44,0.41,0.07,0.0,0.0,0.0,0.0,0.07,john mcgregor,,CPSC-8750,2017
+CPSC,8810,5,Selected Topics: Eff Comput,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,rong ge,,CPSC-8810,2017
+CRP,8020,1,Site Planning,0.73,0.23,0.0,0.0,0.04,0.0,0.0,0.0,clifford dona ellis,,CRP-8020,2017
+CRP,8040,1,Land Use Analysis,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephen sperry,,CRP-8040,2017
+CRP,8050,1,Plning Theory & Hist,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,mickey lauria,,CRP-8050,2017
+CRP,8090,1,Current Issues,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,,CRP-8090,2017
+CRP,8200,1,Negotiation,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,,CRP-8200,2017
+CRP,8220,1,Urban Design,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,CRP-8220,2017
+CRP,8410,1,Env Planning,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,caitlin dyckman,,CRP-8410,2017
+CRP,8730,1,Econ Dev Planning,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,timothy green,,CRP-8730,2017
+CSM,1500,1,Constr Prob Solving,0.41,0.33,0.19,0.04,0.04,0.0,0.0,0.0,jason lucas,,CSM-1500,2017
+CSM,1500,2,Constr Prob Solving,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-1500,2017
+CSM,2020,1,Structures II,0.28,0.48,0.2,0.0,0.0,0.0,0.0,0.04,shima clarke,,CSM-2020,2017
+CSM,2020,2,Structures II,0.16,0.32,0.47,0.0,0.05,0.0,0.0,0.0,shima clarke,,CSM-2020,2017
+CSM,2040,1,Cont Documents,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-2040,2017
+CSM,2040,2,Cont Documents,0.52,0.3,0.13,0.0,0.04,0.0,0.0,0.0,joseph mich burgett,,CSM-2040,2017
+CSM,2050,1,Mats & Methods II,0.2,0.52,0.28,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-2050,2017
+CSM,2050,2,Mats & Methods II,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,raymond schneider,,CSM-2050,2017
+CSM,3050,1,Envir Systems II,0.18,0.61,0.18,0.0,0.03,0.0,0.0,0.0,joseph mich burgett,,CSM-3050,2017
+CSM,3050,2,Envir Systems II,0.29,0.43,0.21,0.07,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3050,2017
+CSM,3520,1,Const Scheduling,0.13,0.5,0.28,0.06,0.03,0.0,0.0,0.0,christine piper,,CSM-3520,2017
+CSM,3520,2,Const Scheduling,0.28,0.34,0.34,0.03,0.0,0.0,0.0,0.0,christine piper,,CSM-3520,2017
+CSM,3530,1,Const Estimating II,0.26,0.45,0.16,0.13,0.0,0.0,0.0,0.0,seyed mousavi rizi,,CSM-3530,2017
+CSM,3530,2,Const Estimating II,0.22,0.47,0.28,0.0,0.03,0.0,0.0,0.0,seyed mousavi rizi,,CSM-3530,2017
+CSM,4540,1,Const Capstone,0.35,0.62,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4540,2017
+CSM,4540,2,Const Capstone,0.12,0.8,0.08,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4540,2017
+CSM,8520,1,Const Mgmt Research,0.0,0.4,0.6,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-8520,2017
+CSM,8520,400,Const Mgmt Research,0.2,0.2,0.6,0.0,0.0,0.0,0.0,0.0,roger william liska,,CSM-8520,2017
+CSM,8650,1,Project Management,0.15,0.69,0.08,0.0,0.08,0.0,0.0,0.0,christine piper,,CSM-8650,2017
+CSM,8660,1,Role in Development,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8660,2017
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.03,susan whorton,,CU-1000,2017
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.77,0.23,0.0,susan whorton,,CU-1000,2017
+CU,1010,1,Univ Success Skills,0.25,0.25,0.25,0.05,0.05,0.0,0.0,0.15,matthew james kirk,,CU-1010,2017
+CU,1010,2,Univ Success Skills,0.41,0.14,0.05,0.09,0.14,0.0,0.0,0.18,joseph paul thames,,CU-1010,2017
+CU,1010,3,Univ Success Skills,0.53,0.21,0.05,0.11,0.0,0.0,0.0,0.11,jessica gale owens,,CU-1010,2017
+CU,1010,4,Univ Success Skills,0.39,0.28,0.17,0.17,0.0,0.0,0.0,0.0,cari allyn brooks,,CU-1010,2017
+CU,1010,5,Univ Success Skills,0.53,0.21,0.11,0.05,0.0,0.0,0.0,0.11,bryn zimmerman babb,,CU-1010,2017
+CU,1100,100,Introduction to Tutoring,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,ashley crisp,,CU-1100,2017
+CU,1970,2,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,robert austi massey,,CU-1970,2017
+CU,2010,1,Sustainability Leadership,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,,CU-2010,2017
+DPA,3070,1,Method 3d Production,0.86,0.04,0.0,0.0,0.04,0.0,0.0,0.07,summer 'nea benton,,DPA-3070,2017
+DPA,4030,1,Vis Foundations II,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,erik reed,,DPA-4030,2017
+DPA,8080,2,Artistic Character Animation,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,david stewart donar,,DPA-8080,2017
+DPA,8090,1,Rendering and Shading,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,eric patterson,,DPA-8090,2017
+DPA,8090,2,Rendering and Shading,0.0,0.4,0.0,0.0,0.0,0.0,0.0,0.6,eric patterson,,DPA-8090,2017
+ECE,1010,400,Robots in Business & Society,0.45,0.35,0.1,0.03,0.03,0.0,0.0,0.03,ian walker,,ECE-1010,2017
+ECE,2010,1,Logic and Computing Devices,0.21,0.23,0.25,0.22,0.05,0.0,0.0,0.04,lin zhu,,ECE-2010,2017
+ECE,2020,1,Electric Circuits I,0.27,0.27,0.29,0.06,0.1,0.0,0.0,0.01,william harrell,,ECE-2020,2017
+ECE,2070,1,Basic Electrical Engineering,0.48,0.32,0.08,0.07,0.02,0.0,0.0,0.03,timothy anglea,,ECE-2070,2017
+ECE,2070,2,Basic Electrical Engineering,0.55,0.29,0.1,0.03,0.0,0.0,0.0,0.03,william th kolodzey,,ECE-2070,2017
+ECE,2070,3,Basic Electrical Engineering,0.25,0.28,0.34,0.03,0.06,0.0,0.0,0.03,daniel bla cutshall,,ECE-2070,2017
+ECE,2080,1,Basic Electrical Engr Lab,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,2,Basic Electrical Engr Lab,0.25,0.45,0.15,0.1,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,4,Basic Electrical Engr Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,5,Basic Electrical Engr Lab,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,6,Basic Electrical Engr Lab,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,9,Basic Electrical Engr Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,10,Basic Electrical Engr Lab,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,11,Basic Electrical Engr Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2080,15,Basic Electrical Engr Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2017
+ECE,2090,1,Logic Lab,0.58,0.25,0.08,0.08,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2017
+ECE,2090,2,Logic Lab,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2017
+ECE,2090,3,Logic Lab,0.58,0.17,0.17,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2090,2017
+ECE,2090,4,Logic Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2090,2017
+ECE,2110,2,Elec Engr Lab I,0.4,0.13,0.07,0.2,0.07,0.0,0.0,0.13,apoorva dee kapadia,,ECE-2110,2017
+ECE,2110,4,Elec Engr Lab I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2110,2017
+ECE,2120,1,Electrical Engineering Lab II,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2120,2017
+ECE,2220,1,Syst Prog Concept,0.22,0.33,0.19,0.08,0.06,0.0,0.0,0.12,william reid,,ECE-2220,2017
+ECE,2230,1,Comp Sys Eng,0.28,0.59,0.06,0.03,0.0,0.0,0.0,0.03,walter ligon,,ECE-2230,2017
+ECE,2620,1,Electric Circuits II,0.46,0.38,0.11,0.01,0.03,0.0,0.0,0.02,richard groff,,ECE-2620,2017
+ECE,2720,1,Comp Organization,0.3,0.4,0.18,0.08,0.04,0.0,0.0,0.01,william reid,,ECE-2720,2017
+ECE,2730,1,Computer Org Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2017
+ECE,2730,2,Computer Org Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2017
+ECE,2730,3,Computer Org Lab,0.31,0.63,0.06,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2017
+ECE,2730,4,Computer Org Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2017
+ECE,3170,1,Rand Signal Analysis,0.24,0.27,0.25,0.13,0.05,0.0,0.0,0.06,stephen hubbard,,ECE-3170,2017
+ECE,3200,1,Electronics I,0.18,0.27,0.27,0.14,0.13,0.0,0.0,0.01,stephen hubbard,,ECE-3200,2017
+ECE,3210,1,Electronics II,0.32,0.34,0.21,0.1,0.03,0.0,0.0,0.0,stephen hubbard,,ECE-3210,2017
+ECE,3220,1,Intro Operating Sys,0.23,0.33,0.13,0.03,0.07,0.0,0.0,0.2,jacob sorber,,ECE-3220,2017
+ECE,3270,1,Dig Comp Design,0.2,0.3,0.13,0.17,0.1,0.0,0.0,0.1,melissa crawl smith,,ECE-3270,2017
+ECE,3300,1,Signals & Systems,0.2,0.22,0.25,0.16,0.03,0.0,0.0,0.14,carl baum,,ECE-3300,2017
+ECE,3520,1,Programming Systems,0.46,0.27,0.15,0.0,0.04,0.0,0.0,0.08,robert schalkoff,,ECE-3520,2017
+ECE,3600,1,Elect Power Engr,0.42,0.31,0.15,0.0,0.0,0.0,0.0,0.12,edward collins,,ECE-3600,2017
+ECE,3710,1,Microcontr Interface,0.33,0.4,0.21,0.04,0.0,0.0,0.0,0.02,william reid,,ECE-3710,2017
+ECE,3720,1,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,2,Micro Int Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,3,Micro Int Lab,0.58,0.25,0.08,0.0,0.08,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,4,Micro Int Lab,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,5,Micro Int Lab,0.67,0.17,0.08,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,6,Micro Int Lab,0.4,0.1,0.3,0.0,0.2,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3720,7,Micro Int Lab,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2017
+ECE,3800,1,Electromagnetics,0.39,0.32,0.05,0.1,0.07,0.0,0.0,0.07,anthony martin,,ECE-3800,2017
+ECE,3810,1,Field Waves & Ckts,0.37,0.38,0.19,0.02,0.0,0.0,0.0,0.05,eric gordon johnson,,ECE-3810,2017
+ECE,4090,1,Intr to Linear Control Systems,0.49,0.38,0.0,0.05,0.05,0.0,0.0,0.03,apoorva dee kapadia,,ECE-4090,2017
+ECE,4190,1,Elec Mach and Drives,0.17,0.48,0.17,0.14,0.0,0.0,0.0,0.03,thomas salem,,ECE-4190,2017
+ECE,4270,1,Communications Sys,0.39,0.31,0.22,0.03,0.06,0.0,0.0,0.0,madhabi manandhar,,ECE-4270,2017
+ECE,4320,1,Instrumentation,0.3,0.2,0.4,0.0,0.1,0.0,0.0,0.0,goutam koley,,ECE-4320,2017
+ECE,4380,1,Computer Commun,0.31,0.25,0.22,0.06,0.06,0.0,0.0,0.11,harlan russell,,ECE-4380,2017
+ECE,4400,1,Local Computer Nets,0.48,0.35,0.16,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,,ECE-4400,2017
+ECE,4680,1,Embedded Computing,0.55,0.3,0.05,0.0,0.0,0.0,0.0,0.1,adam hoover,,ECE-4680,2017
+ECE,4930,2,Smart Grid,0.24,0.66,0.07,0.0,0.0,0.0,0.0,0.03,gan venayagamoorthy,,ECE-4930,2017
+ECE,4950,1,Int Sys Design I,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4950,2017
+ECE,4960,1,Int Sys Design II,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2017
+ECE,6190,1,Elec Mach and Drives,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,thomas salem,,ECE-6190,2017
+ECE,6380,1,Computer Commun,0.42,0.42,0.08,0.0,0.0,0.0,0.0,0.08,harlan russell,,ECE-6380,2017
+ECE,6460,1,Antennas,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,anthony martin,,ECE-6460,2017
+ECE,6930,1,VLSI Design Automation,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,yingjie lao,,ECE-6930,2017
+ECE,8160,1,Elec Power Distr Sys Engr,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,elham makram,,ECE-8160,2017
+ECE,8260,1,Solar Cells,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,,ECE-8260,2017
+ECE,8400,1,Semicond Devices,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,william harrell,,ECE-8400,2017
+ECE,8440,1,Digital Signal Proc,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,eric patterson,,ECE-8440,2017
+ECE,8560,1,Pattern Recognition,0.58,0.36,0.0,0.0,0.0,0.0,0.0,0.06,robert schalkoff,,ECE-8560,2017
+ECE,8740,1,Adv Nonlinear Cntrl,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.06,yongqiang wang,,ECE-8740,2017
+ECE,8780,1,High-Perform Computing w GPUs,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,,ECE-8780,2017
+ECE,8930,10,Distributed Denial of Service,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,,ECE-8930,2017
+ECON,2000,1,Economic Concepts,0.28,0.4,0.23,0.1,0.0,0.0,0.0,0.0,jonathan orr ernest,,ECON-2000,2017
+ECON,2000,2,Economic Concepts,0.51,0.23,0.13,0.05,0.05,0.0,0.0,0.03,jonathan orr ernest,,ECON-2000,2017
+ECON,2000,3,Economic Concepts,0.31,0.38,0.15,0.03,0.13,0.0,0.0,0.0,miren ivankovic,,ECON-2000,2017
+ECON,2110,1,Principles of Microeconomics,0.21,0.28,0.26,0.1,0.13,0.0,0.0,0.03,amanda caitlin kerr,,ECON-2110,2017
+ECON,2110,2,Principles of Microeconomics,0.3,0.53,0.08,0.05,0.03,0.0,0.0,0.03,molly espey,,ECON-2110,2017
+ECON,2110,3,Principles of Microeconomics,0.14,0.24,0.23,0.29,0.08,0.0,0.0,0.03,liuna issagholian,,ECON-2110,2017
+ECON,2110,4,Principles of Microeconomics,0.38,0.38,0.13,0.13,0.0,0.0,0.0,0.0,maria droganova,,ECON-2110,2017
+ECON,2110,5,Principles of Microeconomics,0.38,0.33,0.15,0.05,0.05,0.0,0.0,0.05,roksan ghanbariamin,,ECON-2110,2017
+ECON,2110,6,Principles of Microeconomics,0.18,0.21,0.31,0.09,0.15,0.0,0.0,0.06,bradley keith hobbs,,ECON-2110,2017
+ECON,2110,7,Principles of Microeconomics,0.16,0.24,0.26,0.16,0.13,0.0,0.0,0.06,bradley keith hobbs,,ECON-2110,2017
+ECON,2110,8,Principles of Microeconomics,0.18,0.43,0.2,0.12,0.06,0.0,0.0,0.01,kelsey vict roberts,,ECON-2110,2017
+ECON,2110,10,Principles of Microeconomics,0.51,0.14,0.14,0.08,0.08,0.0,0.0,0.04,steven johnson,,ECON-2110,2017
+ECON,2110,11,Principles of Microeconomics,0.34,0.35,0.14,0.1,0.03,0.0,0.0,0.04,leah jacq kitashima,,ECON-2110,2017
+ECON,2110,12,Principles of Microeconomics,0.3,0.55,0.08,0.05,0.0,0.0,0.0,0.03,benjamin jo schwall,,ECON-2110,2017
+ECON,2120,1,Principles of Macroeconomics,0.16,0.42,0.37,0.0,0.0,0.0,0.0,0.05,scott baier,,ECON-2120,2017
+ECON,2120,2,Principles of Macroeconomics,0.26,0.37,0.21,0.16,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,3,Principles of Macroeconomics,0.3,0.35,0.3,0.0,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,4,Principles of Macroeconomics,0.21,0.58,0.11,0.0,0.11,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,5,Principles of Macroeconomics,0.35,0.2,0.45,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,6,Principles of Macroeconomics,0.16,0.47,0.21,0.16,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,7,Principles of Macroeconomics,0.21,0.37,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,8,Principles of Macroeconomics,0.16,0.47,0.37,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,9,Principles of Macroeconomics,0.2,0.45,0.3,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,10,Principles of Macroeconomics,0.11,0.53,0.32,0.0,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,11,Principles of Macroeconomics,0.16,0.32,0.47,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,12,Principles of Macroeconomics,0.17,0.33,0.33,0.0,0.17,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,13,Principles of Macroeconomics,0.47,0.41,0.0,0.0,0.06,0.0,0.0,0.06,scott baier,,ECON-2120,2017
+ECON,2120,14,Principles of Macroeconomics,0.35,0.47,0.06,0.06,0.06,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,15,Principles of Macroeconomics,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,16,Principles of Macroeconomics,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,17,Principles of Macroeconomics,0.32,0.53,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,18,Principles of Macroeconomics,0.16,0.58,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,19,Principles of Macroeconomics,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2017
+ECON,2120,20,Principles of Macroeconomics,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,peter david lorenz,,ECON-2120,2017
+ECON,2120,21,Principles of Macroeconomics,0.6,0.37,0.01,0.01,0.0,0.0,0.0,0.0,huili li,,ECON-2120,2017
+ECON,2120,22,Principles of Macroeconomics,0.27,0.56,0.17,0.0,0.0,0.0,0.0,0.0,ce castellon chicas,,ECON-2120,2017
+ECON,2120,23,Principles of Macroeconomics,0.3,0.48,0.18,0.0,0.0,0.0,0.0,0.05,jordan adamson,,ECON-2120,2017
+ECON,2120,24,Principles of Macroeconomics,0.1,0.23,0.16,0.19,0.12,0.0,0.0,0.19,ralph charles allen,,ECON-2120,2017
+ECON,2120,25,Principles of Macroeconomics,0.19,0.19,0.11,0.22,0.04,0.0,0.0,0.26,ralph charles allen,,ECON-2120,2017
+ECON,2120,26,Principles of Macroeconomics,0.28,0.42,0.22,0.08,0.0,0.0,0.0,0.0,scott barkowski,,ECON-2120,2017
+ECON,2120,27,Principles of Macroeconomics,0.4,0.5,0.08,0.03,0.0,0.0,0.0,0.0,peter david lorenz,,ECON-2120,2017
+ECON,2120,28,Principles of Macroecon (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott baier,True,ECON-2120,2017
+ECON,3020,1,Money and Banking,0.33,0.38,0.2,0.1,0.0,0.0,0.0,0.0,smriti bhargava,,ECON-3020,2017
+ECON,3060,1,Managerial Economics,0.25,0.23,0.25,0.15,0.07,0.0,0.0,0.05,timothy jay bacon,,ECON-3060,2017
+ECON,3100,1,International Econ,0.24,0.4,0.32,0.03,0.02,0.0,0.0,0.0,richard alan sessa,,ECON-3100,2017
+ECON,3140,1,Intermediate Micro,0.43,0.28,0.23,0.0,0.03,0.0,0.0,0.05,molly espey,,ECON-3140,2017
+ECON,3140,2,Intermediate Micro,0.32,0.29,0.11,0.13,0.05,0.0,0.0,0.11,patrick warren,,ECON-3140,2017
+ECON,3140,3,Intermediate Micro,0.23,0.21,0.46,0.03,0.08,0.0,0.0,0.0,molly espey,,ECON-3140,2017
+ECON,3150,1,Intermediate Macro,0.26,0.36,0.22,0.12,0.03,0.0,0.0,0.01,michal jerzmanowski,,ECON-3150,2017
+ECON,3150,2,Intermediate Macro,0.26,0.26,0.29,0.0,0.08,0.0,0.0,0.11,sergey vla mityakov,,ECON-3150,2017
+ECON,3440,1,Property Rights,0.19,0.19,0.26,0.11,0.15,0.0,0.0,0.11,dar litsukova-bokar,,ECON-3440,2017
+ECON,3500,1,Moral & Ethical Econ,0.15,0.27,0.3,0.06,0.15,0.0,0.0,0.06,bradley keith hobbs,,ECON-3500,2017
+ECON,3600,1,Public Choice,0.36,0.23,0.26,0.05,0.05,0.0,0.0,0.05,michael makowsky,,ECON-3600,2017
+ECON,4010,1,Labor Mkt Analysis,0.23,0.42,0.23,0.0,0.08,0.0,0.0,0.04,curtis simon,,ECON-4010,2017
+ECON,4020,1,Law and Economics,0.2,0.47,0.23,0.07,0.03,0.0,0.0,0.0,thomas wins hazlett,,ECON-4020,2017
+ECON,4050,1,Intro to Econometric,0.28,0.28,0.23,0.12,0.07,0.0,0.0,0.02,scott barkowski,,ECON-4050,2017
+ECON,4200,1,Pub Sector Econ,0.2,0.3,0.33,0.05,0.08,0.0,0.0,0.05,william dougan,,ECON-4200,2017
+ECON,4240,1,Organization of Ind,0.53,0.23,0.2,0.03,0.0,0.0,0.0,0.0,matthew lewis,,ECON-4240,2017
+ECON,4260,1,Sem Sport Economics,0.6,0.32,0.0,0.0,0.0,0.0,0.0,0.08,raymond sauer,,ECON-4260,2017
+ECON,4270,1,Dev American Economy,0.22,0.5,0.19,0.06,0.03,0.0,0.0,0.0,howard ne bodenhorn,,ECON-4270,2017
+ECON,4290,1,Economics of Energy Markets,0.37,0.5,0.13,0.0,0.0,0.0,0.0,0.0,matthew lewis,,ECON-4290,2017
+ECON,4400,1,Game Theory,0.23,0.46,0.27,0.0,0.04,0.0,0.0,0.0,charles thomas,,ECON-4400,2017
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.11,0.42,0.32,0.11,0.0,0.0,0.0,0.05,scott templeton,,ECON-4570,2017
+ECON,6400,1,Game Theory,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,charles thomas,,ECON-6400,2017
+ECON,8020,2,Adv Econ Concepts and Applic I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,,ECON-8020,2017
+ECON,8050,1,Macroeconomic Theory,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,michal jerzmanowski,,ECON-8050,2017
+ECON,8070,1,Econometrics II,0.38,0.48,0.1,0.0,0.0,0.0,0.0,0.05,chungsang lam,,ECON-8070,2017
+ECON,8110,1,Econ of Environment,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,,ECON-8110,2017
+ECON,8200,1,Public Finance,0.44,0.33,0.0,0.0,0.0,0.0,0.0,0.22,william dougan,,ECON-8200,2017
+ECON,9000,2,Empirical Public Choice,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,,ECON-9000,2017
+ED,1050,1,Educ Orientation,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,william da mccorkle,,ED-1050,2017
+ED,1050,2,Educ Orientation,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,william da mccorkle,,ED-1050,2017
+EDC,3900,2,Skills for Stu Leads,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2017
+EDC,3900,3,Skills for Stu Leads,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2017
+EDC,3900,4,Skills for Stu Leads,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2017
+EDC,3900,5,Skills for Stu Leads,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2017
+EDC,3900,6,Skills for Stu Leads,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2017
+EDEC,2200,1,Family/School/Com,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,,EDEC-2200,2017
+EDEC,8100,500,Adv Ece Found & Meth,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-8100,2017
+EDEL,3210,1,Pe for the Elem Tchr,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2017
+EDEL,4510,1,Elem Methods in Science Tchg,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,cynthia chri deaton,,EDEL-4510,2017
+EDEL,4520,1,Elem Methods Math Teaching,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,EDEL-4520,2017
+EDEL,4520,2,Elem Methods Math Teaching,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,EDEL-4520,2017
+EDEL,4870,1,Ele Meth Soc Studies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,dwane valera,,EDEL-4870,2017
+EDF,3010,1,Principles of American Educat,0.86,0.09,0.06,0.0,0.0,0.0,0.0,0.0,william da mccorkle,,EDF-3010,2017
+EDF,3020,1,Educational Psychology,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,heather rog brooker,,EDF-3020,2017
+EDF,3020,2,Educational Psychology,0.83,0.13,0.05,0.0,0.0,0.0,0.0,0.0,heather rog brooker,,EDF-3020,2017
+EDF,3020,3,Educational Psychology,0.96,0.0,0.04,0.0,0.0,0.0,0.0,0.0,stephen chou,,EDF-3020,2017
+EDF,3340,1,Child Growth and Development,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,,EDF-3340,2017
+EDF,3340,3,Child Growth and Development,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoo jamil,,EDF-3340,2017
+EDF,3350,1,Adolescent Growth & Develop,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,heather rog brooker,,EDF-3350,2017
+EDF,4800,3,Digital Media & Learning,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,juan li,,EDF-4800,2017
+EDF,4800,300,Digital Media & Learning,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2017
+EDF,8080,300,Ed Tests and Measure,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,heather rog brooker,,EDF-8080,2017
+EDF,9700,1,Democratic Education,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,,EDF-9700,2017
+EDF,9770,400,Multi Regress Ed Research,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jennie lynn farmer,,EDF-9770,2017
+EDF,9790,1,Qualitative Research in Educ,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,melinda spearman,,EDF-9790,2017
+EDHD,3110,1,CI- Research in DM & Learning,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,david matthew boyer,,EDHD-3110,2017
+EDL,7150,500,Sch & Comm Relations,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,frederick buskey,,EDL-7150,2017
+EDL,7300,502,Techniq of Supervision-Pub Sch,0.85,0.0,0.0,0.0,0.15,0.0,0.0,0.0,hans william klar,,EDL-7300,2017
+EDL,7400,511,Curr Plan: Sch Adm,0.88,0.0,0.06,0.0,0.06,0.0,0.0,0.0,barbara nesbitt,,EDL-7400,2017
+EDL,7510,500,El Prin & Spv Ex II,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,frederick buskey,,EDL-7510,2017
+EDL,7650,1,Assessment Hi Edu,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,kristin walker,,EDL-7650,2017
+EDL,7650,2,Assessment Hi Edu,0.17,0.72,0.11,0.0,0.0,0.0,0.0,0.0,kristin walker,,EDL-7650,2017
+EDL,8500,501,Practicum: District,0.38,0.0,0.08,0.0,0.54,0.0,0.0,0.0,elizabeth reynolds,,EDL-8500,2017
+EDL,8850,512,STEM - School Admin,0.57,0.0,0.0,0.0,0.43,0.0,0.0,0.0,william havice,,EDL-8850,2017
+EDL,9110,400,Systematic Inq Ed L,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jane lindle,,EDL-9110,2017
+EDL,9750,2,College Teaching,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,pamela havice,,EDL-9750,2017
+EDLT,4580,1,Early Literacy: Birth-Kindergn,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4580,2017
+EDLT,4620,1,Reading Children's Lit in Elem,0.59,0.27,0.09,0.05,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4620,2017
+EDLT,8270,300,Content Area Rdg/Wtg-MS & HS,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8270,2017
+EDLT,8410,501,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,,EDLT-8410,2017
+EDLT,8410,502,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,,EDLT-8410,2017
+EDLT,8410,505,Early Literacy Inst Strategies,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephanie amb pitts,,EDLT-8410,2017
+EDLT,8810,506,Reading Recovery Teacher II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,,EDLT-8810,2017
+EDLT,8830,506,Read Recovery Practicum II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele dawson,,EDLT-8830,2017
+EDSC,4370,1,Technology in Math,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,,EDSC-4370,2017
+EDSC,4480,1,Teach Intern Sec Soc,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,marshall alan darby,,EDSC-4480,2017
+EDSP,3700,2,Intro to Special Education,0.81,0.17,0.03,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,,EDSP-3700,2017
+EDSP,3700,4,Intro to Special Education,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,catherine griffith,,EDSP-3700,2017
+EDSP,4910,1,Ed Assess Ind W/Dis,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,,EDSP-4910,2017
+EES,2020,1,Environ Engr Fundamentals II,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,,EES-2020,2017
+EES,4010,1,Environmental Engr,0.49,0.51,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,EES-4010,2017
+EES,4010,2,Environmental Engr,0.36,0.21,0.25,0.0,0.07,0.0,0.0,0.11,ezra lucas ho cates,,EES-4010,2017
+EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-4750,2017
+EES,4840,2,Solid Waste Mgt,0.58,0.35,0.04,0.0,0.04,0.0,0.0,0.0,thomas overcamp,,EES-4840,2017
+EES,4850,2,Hazard Waste Management,0.22,0.52,0.26,0.0,0.0,0.0,0.0,0.0,mark schlautman,,EES-4850,2017
+EES,4860,6,Environmental Sustainability,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,michael anthon dale,,EES-4860,2017
+EES,8030,1,Phy/Chem Ops W/WW T,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,ezra lucas ho cates,,EES-8030,2017
+EES,8040,1,Biochem Ops WW Trt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,david freedman,,EES-8040,2017
+EES,8090,1,Subsurface Remed Mod,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,ronald falta,,EES-8090,2017
+ELE,3010,1,Intro to Entre,0.44,0.51,0.03,0.0,0.0,0.0,0.0,0.03,christina kyprianou,,ELE-3010,2017
+ELE,3010,2,Intro to Entre,0.41,0.51,0.08,0.0,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2017
+ELE,3010,3,Intro to Entre,0.24,0.36,0.38,0.0,0.02,0.0,0.0,0.0,ashley will parnell,,ELE-3010,2017
+ELE,3140,1,New Venture Creat I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,chad navis,,ELE-3140,2017
+ELE,3140,2,New Venture Creat I,0.57,0.3,0.14,0.0,0.0,0.0,0.0,0.0,chad navis,,ELE-3140,2017
+ELE,4010,1,Exec Lead & Entr II,0.24,0.33,0.38,0.02,0.0,0.0,0.0,0.02,ashley will parnell,,ELE-4010,2017
+ENGL,1030,1,Accelerated Composition,0.62,0.24,0.05,0.0,0.05,0.0,0.0,0.05,chloe helene cahill,,ENGL-1030,2017
+ENGL,1030,2,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,,ENGL-1030,2017
+ENGL,1030,3,Accelerated Composition,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,sharif youssef,,ENGL-1030,2017
+ENGL,1030,4,Accelerated Composition,0.7,0.05,0.05,0.05,0.0,0.0,0.0,0.15,melissa dugan,,ENGL-1030,2017
+ENGL,1030,7,Accelerated Composition,0.71,0.05,0.14,0.0,0.1,0.0,0.0,0.0,charlotte est lucke,,ENGL-1030,2017
+ENGL,1030,8,Accelerated Composition,0.81,0.1,0.0,0.05,0.05,0.0,0.0,0.0,melissa dugan,,ENGL-1030,2017
+ENGL,1030,9,Accelerated Composition,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,katie jo vann,,ENGL-1030,2017
+ENGL,1030,10,Accelerated Composition,0.57,0.29,0.05,0.0,0.0,0.0,0.0,0.1,krist aldebol-hazle,,ENGL-1030,2017
+ENGL,1030,11,Accelerated Composition,0.76,0.19,0.0,0.0,0.05,0.0,0.0,0.0,robert brissey,,ENGL-1030,2017
+ENGL,1030,12,Accelerated Composition,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,robert brissey,,ENGL-1030,2017
+ENGL,1030,13,Accelerated Composition,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,kala parker,,ENGL-1030,2017
+ENGL,1030,15,Accelerated Composition,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,katie jo vann,,ENGL-1030,2017
+ENGL,1030,16,Accelerated Composition,0.59,0.24,0.0,0.0,0.06,0.0,0.0,0.12,kala parker,,ENGL-1030,2017
+ENGL,1030,18,Accelerated Composition,0.81,0.05,0.0,0.0,0.0,0.0,0.0,0.14,katie jo vann,,ENGL-1030,2017
+ENGL,1030,19,Accelerated Composition,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,samuel david martin,,ENGL-1030,2017
+ENGL,1030,20,Accelerated Composition,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,samuel david martin,,ENGL-1030,2017
+ENGL,1030,21,Accelerated Composition,0.76,0.14,0.05,0.0,0.05,0.0,0.0,0.0,brian lee gaines,,ENGL-1030,2017
+ENGL,1030,22,Accelerated Composition,0.62,0.24,0.1,0.0,0.05,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2017
+ENGL,1030,23,Accelerated Composition,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,charlotte est lucke,,ENGL-1030,2017
+ENGL,1030,24,Accelerated Composition,0.65,0.12,0.12,0.06,0.06,0.0,0.0,0.0,brian lee gaines,,ENGL-1030,2017
+ENGL,1030,25,Accelerated Composition,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,michael davi measel,,ENGL-1030,2017
+ENGL,1030,26,Accelerated Composition,0.31,0.38,0.0,0.0,0.19,0.0,0.0,0.13,la'cresha ulo green,,ENGL-1030,2017
+ENGL,1030,27,Accelerated Composition,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2017
+ENGL,1030,28,Accelerated Composition,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,michael davi measel,,ENGL-1030,2017
+ENGL,1030,30,Accelerated Composition,0.69,0.06,0.06,0.13,0.0,0.0,0.0,0.06,michael russo,,ENGL-1030,2017
+ENGL,1030,31,Accelerated Composition,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,laurie pfister epps,,ENGL-1030,2017
+ENGL,1030,37,Accelerated Composition,0.76,0.05,0.1,0.0,0.0,0.0,0.0,0.1,christopher stuart,,ENGL-1030,2017
+ENGL,1030,39,Accelerated Composition,0.81,0.1,0.0,0.0,0.0,0.0,0.0,0.1,michael russo,,ENGL-1030,2017
+ENGL,1030,40,Accelerated Composition,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,austin gorman,,ENGL-1030,2017
+ENGL,1030,41,Accelerated Composition,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,christopher stuart,,ENGL-1030,2017
+ENGL,1030,44,Accelerated Composition,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,erica mich marquard,,ENGL-1030,2017
+ENGL,1030,48,Accelerated Composition,0.22,0.56,0.17,0.0,0.0,0.0,0.0,0.06,matthew scot duncan,,ENGL-1030,2017
+ENGL,1030,49,Accelerated Composition,0.33,0.44,0.0,0.0,0.11,0.0,0.0,0.11,matthew scot duncan,,ENGL-1030,2017
+ENGL,1030,51,Accelerated Composition,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,stephen quigley,,ENGL-1030,2017
+ENGL,1030,52,Accelerated Composition,0.76,0.14,0.0,0.0,0.1,0.0,0.0,0.0,stephen quigley,,ENGL-1030,2017
+ENGL,1030,55,Accelerated Composition,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,daniel frank,,ENGL-1030,2017
+ENGL,1030,57,Accelerated Composition,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,krist aldebol-hazle,,ENGL-1030,2017
+ENGL,1030,58,Accelerated Composition,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,chloe helene cahill,,ENGL-1030,2017
+ENGL,1030,60,Accelerated Composition,0.62,0.29,0.0,0.0,0.05,0.0,0.0,0.05,jennifer forsberg,,ENGL-1030,2017
+ENGL,1030,62,Accelerated Composition,0.85,0.05,0.05,0.05,0.0,0.0,0.0,0.0,jennifer forsberg,,ENGL-1030,2017
+ENGL,1030,63,Accelerated Composition,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,christa kettlewell,,ENGL-1030,2017
+ENGL,1030,65,Accelerated Composition,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,christa kettlewell,,ENGL-1030,2017
+ENGL,1030,67,Accelerated Composition,0.14,0.71,0.05,0.0,0.0,0.0,0.0,0.1,renesha moniq poole,,ENGL-1030,2017
+ENGL,1030,68,Accelerated Composition,0.06,0.78,0.06,0.06,0.0,0.0,0.0,0.06,renesha moniq poole,,ENGL-1030,2017
+ENGL,1030,69,Accelerated Composition,0.85,0.0,0.08,0.0,0.08,0.0,0.0,0.0,dia quaglia beltran,,ENGL-1030,2017
+ENGL,1030,70,Accelerated Composition,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,parker elizabe king,,ENGL-1030,2017
+ENGL,1030,71,Accelerated Composition,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,yvonne kao,,ENGL-1030,2017
+ENGL,1030,72,Accelerated Composition,0.71,0.12,0.06,0.06,0.0,0.0,0.0,0.06,yvonne kao,,ENGL-1030,2017
+ENGL,1030,555,Accelerated Composition,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,,ENGL-1030,2017
+ENGL,2020,555,The Major Forms of Literature,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,,ENGL-2020,2017
+ENGL,2120,1,World Literature,0.34,0.34,0.14,0.07,0.03,0.0,0.0,0.07,andrew mathas,,ENGL-2120,2017
+ENGL,2120,2,World Literature,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.03,daniel scott citro,,ENGL-2120,2017
+ENGL,2120,3,World Literature,0.28,0.34,0.21,0.03,0.07,0.0,0.0,0.07,karen kettnich,,ENGL-2120,2017
+ENGL,2120,4,World Literature,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,walter edgar hunter,,ENGL-2120,2017
+ENGL,2120,5,World Literature,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,stephanie stripling,,ENGL-2120,2017
+ENGL,2120,6,World Literature,0.28,0.45,0.17,0.03,0.07,0.0,0.0,0.0,karen kettnich,,ENGL-2120,2017
+ENGL,2120,7,World Literature,0.76,0.17,0.03,0.03,0.0,0.0,0.0,0.0,stephanie stripling,,ENGL-2120,2017
+ENGL,2120,11,World Literature,0.48,0.21,0.24,0.03,0.0,0.0,0.0,0.03,chloe mich whitaker,,ENGL-2120,2017
+ENGL,2120,12,World Literature,0.41,0.41,0.07,0.07,0.0,0.0,0.0,0.03,chloe mich whitaker,,ENGL-2120,2017
+ENGL,2120,13,World Literature,0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.03,daniel scott citro,,ENGL-2120,2017
+ENGL,2120,14,World Literature,0.38,0.48,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2120,2017
+ENGL,2120,16,World Literature,0.2,0.63,0.1,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,,ENGL-2120,2017
+ENGL,2120,17,World Literature,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,april susanne pelt,,ENGL-2120,2017
+ENGL,2120,18,World Literature,0.45,0.39,0.13,0.03,0.0,0.0,0.0,0.0,olga anatol volkova,,ENGL-2120,2017
+ENGL,2120,19,World Literature,0.43,0.33,0.17,0.03,0.03,0.0,0.0,0.0,karen kettnich,,ENGL-2120,2017
+ENGL,2120,20,World Literature,0.37,0.33,0.1,0.07,0.03,0.0,0.0,0.1,katalin beck,,ENGL-2120,2017
+ENGL,2130,1,British Literature,0.76,0.21,0.03,0.0,0.0,0.0,0.0,0.0,benjamin hudson,,ENGL-2130,2017
+ENGL,2130,2,British Literature,0.57,0.3,0.1,0.0,0.03,0.0,0.0,0.0,christopher benson,,ENGL-2130,2017
+ENGL,2130,3,British Literature,0.77,0.2,0.0,0.0,0.0,0.0,0.0,0.03,christopher benson,,ENGL-2130,2017
+ENGL,2130,4,British Literature,0.86,0.07,0.03,0.0,0.03,0.0,0.0,0.0,stephanie stripling,,ENGL-2130,2017
+ENGL,2130,6,British Literature,0.61,0.32,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-2130,2017
+ENGL,2130,7,British Literature,0.8,0.13,0.03,0.0,0.0,0.0,0.0,0.03,benjamin hudson,,ENGL-2130,2017
+ENGL,2130,10,British Literature,0.63,0.27,0.0,0.03,0.07,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-2130,2017
+ENGL,2130,12,British Literature,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2017
+ENGL,2130,13,British Literature,0.67,0.27,0.03,0.0,0.0,0.0,0.0,0.03,lucian ghita,,ENGL-2130,2017
+ENGL,2130,14,British Literature,0.77,0.17,0.0,0.0,0.0,0.0,0.0,0.07,lucian ghita,,ENGL-2130,2017
+ENGL,2140,1,American Literature,0.7,0.13,0.13,0.0,0.03,0.0,0.0,0.0,jennifer forsberg,,ENGL-2140,2017
+ENGL,2140,2,American Literature,0.43,0.29,0.07,0.04,0.04,0.0,0.0,0.14,jennifer forsberg,,ENGL-2140,2017
+ENGL,2140,3,American Literature,0.72,0.21,0.03,0.03,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2140,2017
+ENGL,2140,4,American Literature,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2017
+ENGL,2140,5,American Literature,0.29,0.43,0.11,0.07,0.0,0.0,0.0,0.11,david charles foltz,,ENGL-2140,2017
+ENGL,2140,6,American Literature,0.19,0.38,0.23,0.04,0.04,0.0,0.0,0.12,david charles foltz,,ENGL-2140,2017
+ENGL,2140,7,American Literature,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2017
+ENGL,2140,8,American Literature,0.15,0.41,0.19,0.0,0.11,0.0,0.0,0.15,david charles foltz,,ENGL-2140,2017
+ENGL,2140,12,American Literature,0.11,0.37,0.15,0.07,0.19,0.0,0.0,0.11,david charles foltz,,ENGL-2140,2017
+ENGL,2140,13,American Literature,0.78,0.15,0.0,0.0,0.0,0.0,0.0,0.07,candace wiley,,ENGL-2140,2017
+ENGL,2140,14,American Literature,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2017
+ENGL,2140,15,American Literature,0.8,0.13,0.0,0.03,0.03,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2017
+ENGL,2140,16,American Literature,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2140,2017
+ENGL,2140,17,American Literature,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,adrian carson,,ENGL-2140,2017
+ENGL,2140,18,American Literature,0.87,0.1,0.0,0.0,0.0,0.0,0.0,0.03,adrian carson,,ENGL-2140,2017
+ENGL,2140,19,American Literature,0.72,0.03,0.0,0.0,0.1,0.0,0.0,0.14,candace wiley,,ENGL-2140,2017
+ENGL,2140,20,American Literature,0.77,0.12,0.0,0.0,0.0,0.0,0.0,0.12,candace wiley,,ENGL-2140,2017
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.48,0.32,0.13,0.03,0.0,0.0,0.0,0.03,john logan pursley,,ENGL-2150,2017
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.33,0.37,0.1,0.1,0.07,0.0,0.0,0.03,megan no macalystre,,ENGL-2150,2017
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.52,0.34,0.07,0.03,0.03,0.0,0.0,0.0,megan no macalystre,,ENGL-2150,2017
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.47,0.3,0.03,0.0,0.1,0.0,0.0,0.1,andrew mathas,,ENGL-2150,2017
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.67,0.23,0.03,0.0,0.07,0.0,0.0,0.0,megan no macalystre,,ENGL-2150,2017
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.5,0.33,0.03,0.03,0.07,0.0,0.0,0.03,andrew mathas,,ENGL-2150,2017
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.43,0.37,0.13,0.07,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-2150,2017
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.33,0.07,0.0,0.07,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2017
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,mari elena ramler,,ENGL-2150,2017
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.3,0.57,0.07,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,,ENGL-2150,2017
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,sarah mae cooper,,ENGL-2150,2017
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,benjamin hudson,,ENGL-2150,2017
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.8,0.1,0.03,0.0,0.03,0.0,0.0,0.03,benjamin hudson,,ENGL-2150,2017
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,sharif youssef,,ENGL-2150,2017
+ENGL,3010,1,Great Books of Western World,0.12,0.65,0.18,0.0,0.0,0.0,0.0,0.06,colin pearce,,ENGL-3010,2017
+ENGL,3040,2,Business Writing,0.81,0.1,0.05,0.05,0.0,0.0,0.0,0.0,philip randall,,ENGL-3040,2017
+ENGL,3040,3,Business Writing,0.6,0.2,0.1,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,,ENGL-3040,2017
+ENGL,3040,4,Business Writing,0.64,0.14,0.09,0.0,0.0,0.0,0.0,0.14,geveryl le robinson,,ENGL-3040,2017
+ENGL,3040,5,Business Writing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3040,2017
+ENGL,3040,13,Business Writing,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,katalin beck,,ENGL-3040,2017
+ENGL,3040,14,Business Writing,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,philip randall,,ENGL-3040,2017
+ENGL,3040,16,Business Writing,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,emily anne boyter,,ENGL-3040,2017
+ENGL,3040,17,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharif youssef,,ENGL-3040,2017
+ENGL,3040,18,Business Writing,0.75,0.0,0.15,0.0,0.05,0.0,0.0,0.05,geveryl le robinson,,ENGL-3040,2017
+ENGL,3040,19,Business Writing,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3040,2017
+ENGL,3040,22,Business Writing,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,sharif youssef,,ENGL-3040,2017
+ENGL,3040,400,Business Writing,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,hayley ren zertuche,,ENGL-3040,2017
+ENGL,3040,401,Business Writing,0.71,0.14,0.05,0.0,0.05,0.0,0.0,0.05,hayley ren zertuche,,ENGL-3040,2017
+ENGL,3040,402,Business Writing,0.71,0.19,0.0,0.0,0.05,0.0,0.0,0.05,hayley ren zertuche,,ENGL-3040,2017
+ENGL,3040,403,Business Writing,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,hayley ren zertuche,,ENGL-3040,2017
+ENGL,3040,404,Business Writing,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,steph kartalopoulos,,ENGL-3040,2017
+ENGL,3040,405,Business Writing,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,,ENGL-3040,2017
+ENGL,3040,406,Business Writing,0.6,0.3,0.0,0.05,0.0,0.0,0.0,0.05,steph kartalopoulos,,ENGL-3040,2017
+ENGL,3040,407,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,steph kartalopoulos,,ENGL-3040,2017
+ENGL,3100,1,Crit Writ Lit,0.38,0.48,0.1,0.0,0.05,0.0,0.0,0.0,david sweene coombs,,ENGL-3100,2017
+ENGL,3100,2,Crit Writ Lit,0.19,0.33,0.14,0.1,0.14,0.0,0.0,0.1,william stockton,,ENGL-3100,2017
+ENGL,3100,4,Crit Writ Lit,0.29,0.48,0.14,0.0,0.0,0.0,0.0,0.1,david sweene coombs,,ENGL-3100,2017
+ENGL,3120,1,Advanced Composition,0.57,0.19,0.1,0.0,0.1,0.0,0.0,0.05,elizabeth stansell,,ENGL-3120,2017
+ENGL,3120,2,Advanced Composition,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2017
+ENGL,3140,1,Technical Writing,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2017
+ENGL,3140,2,Technical Writing,0.74,0.22,0.0,0.0,0.04,0.0,0.0,0.0,nathan riggs,,ENGL-3140,2017
+ENGL,3140,3,Technical Writing,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3140,2017
+ENGL,3140,4,Technical Writing,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,eric stephens,,ENGL-3140,2017
+ENGL,3140,5,Technical Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2017
+ENGL,3140,6,Technical Writing,0.67,0.24,0.0,0.1,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2017
+ENGL,3140,7,Technical Writing,0.81,0.05,0.05,0.0,0.05,0.0,0.0,0.05,eric stephens,,ENGL-3140,2017
+ENGL,3140,9,Technical Writing,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2017
+ENGL,3140,10,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,,ENGL-3140,2017
+ENGL,3140,11,Technical Writing,0.86,0.05,0.05,0.0,0.05,0.0,0.0,0.0,la'cresha ulo green,,ENGL-3140,2017
+ENGL,3140,12,Technical Writing,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,,ENGL-3140,2017
+ENGL,3140,13,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nathan riggs,,ENGL-3140,2017
+ENGL,3140,14,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-3140,2017
+ENGL,3140,15,Technical Writing,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,joshua wood,,ENGL-3140,2017
+ENGL,3140,16,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,joshua wood,,ENGL-3140,2017
+ENGL,3140,18,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3140,2017
+ENGL,3140,19,Technical Writing,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3140,2017
+ENGL,3140,25,Technical Writing,0.8,0.15,0.0,0.05,0.0,0.0,0.0,0.0,crystal pa stephens,,ENGL-3140,2017
+ENGL,3150,1,Scientific Writing & Comm,0.47,0.26,0.16,0.05,0.0,0.0,0.0,0.05,william pulley,,ENGL-3150,2017
+ENGL,3150,2,Scientific Writing & Comm,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3150,2017
+ENGL,3150,5,Scientific Writing & Comm,0.81,0.14,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,,ENGL-3150,2017
+ENGL,3150,18,Scientific Writing & Comm,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,christopher benson,,ENGL-3150,2017
+ENGL,3320,1,Visual Communication,0.68,0.16,0.11,0.0,0.0,0.0,0.0,0.05,sean williams,,ENGL-3320,2017
+ENGL,3330,1,Writing News Media,0.47,0.33,0.07,0.0,0.13,0.0,0.0,0.0,geveryl le robinson,,ENGL-3330,2017
+ENGL,3450,1,Structure of Fiction,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,,ENGL-3450,2017
+ENGL,3460,1,Structure of Poetry,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,candace wiley,,ENGL-3460,2017
+ENGL,3480,1,Structure Screenplay,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,,ENGL-3480,2017
+ENGL,3540,1,Lit Middle East & North Africa,0.53,0.29,0.0,0.0,0.06,0.0,0.0,0.12,angela naimou,,ENGL-3540,2017
+ENGL,3570,1,Film,0.05,0.7,0.15,0.0,0.05,0.0,0.0,0.05,amy monaghan,,ENGL-3570,2017
+ENGL,3570,2,Film,0.06,0.61,0.17,0.0,0.11,0.0,0.0,0.06,amy monaghan,,ENGL-3570,2017
+ENGL,3570,3,Film,0.05,0.79,0.11,0.0,0.05,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2017
+ENGL,3850,1,Children's Lit,0.74,0.11,0.0,0.05,0.05,0.0,0.0,0.05,megan no macalystre,,ENGL-3850,2017
+ENGL,3970,1,Brit Lit Survey II,0.56,0.22,0.17,0.0,0.0,0.0,0.0,0.06,john morgenstern,,ENGL-3970,2017
+ENGL,3980,1,Amer Lit Survey I,0.2,0.53,0.2,0.0,0.07,0.0,0.0,0.0,rhondda robi thomas,,ENGL-3980,2017
+ENGL,3980,2,Amer Lit Survey I,0.28,0.56,0.11,0.0,0.0,0.0,0.0,0.06,susanna ashton,,ENGL-3980,2017
+ENGL,3990,1,Amer Lit Survey II,0.68,0.11,0.16,0.0,0.0,0.0,0.0,0.05,walter edgar hunter,,ENGL-3990,2017
+ENGL,3990,2,Amer Lit Survey II,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-3990,2017
+ENGL,4070,1,Medieval Period,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,,ENGL-4070,2017
+ENGL,4110,1,Shakespeare,0.48,0.29,0.0,0.0,0.14,0.0,0.0,0.1,elizabeth rivlin,,ENGL-4110,2017
+ENGL,4110,2,Shakespeare,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,andrew lemons,,ENGL-4110,2017
+ENGL,4110,3,Shakespeare,0.33,0.52,0.14,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4110,2017
+ENGL,4190,1,Post Col & World Lit,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,cameron fa bushnell,,ENGL-4190,2017
+ENGL,4200,1,Amer Lit to 1799,0.5,0.3,0.0,0.0,0.1,0.0,0.0,0.1,jonathan beec field,,ENGL-4200,2017
+ENGL,4250,1,American Novel,0.39,0.22,0.17,0.06,0.06,0.0,0.0,0.11,susanna ashton,,ENGL-4250,2017
+ENGL,4320,1,Modern Fiction,0.39,0.44,0.06,0.0,0.06,0.0,0.0,0.06,gabriel and hankins,,ENGL-4320,2017
+ENGL,4360,1,Feminist Literary Criticism,0.59,0.29,0.0,0.0,0.06,0.0,0.0,0.06,michelle renee ty,,ENGL-4360,2017
+ENGL,4400,1,Literary Theory,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,michelle renee ty,,ENGL-4400,2017
+ENGL,4420,1,Cultural Studies,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,gabriel and hankins,,ENGL-4420,2017
+ENGL,4450,1,Fiction Workshop,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-4450,2017
+ENGL,4580,1,Adaptations of World Classics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-4580,2017
+ENGL,4650,1,Topics in Literature from 1900,0.67,0.11,0.06,0.0,0.11,0.0,0.0,0.06,garry bertholf,,ENGL-4650,2017
+ENGL,4750,1,Writing for Media,0.6,0.33,0.0,0.0,0.07,0.0,0.0,0.0,jonathan beec field,,ENGL-4750,2017
+ENGL,4780,1,Digital Literacy,0.76,0.06,0.06,0.0,0.06,0.0,0.0,0.06,megan eatman,,ENGL-4780,2017
+ENGL,4890,1,Topics Write & Publ,0.78,0.06,0.0,0.0,0.06,0.0,0.0,0.11,jan rune holmevik,,ENGL-4890,2017
+ENGL,4920,1,Modern Rhetoric,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,megan eatman,,ENGL-4920,2017
+ENGL,4960,1,Senior Seminar,0.17,0.67,0.08,0.08,0.0,0.0,0.0,0.0,rhondda robi thomas,,ENGL-4960,2017
+ENGL,4960,2,Senior Seminar,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,angela naimou,,ENGL-4960,2017
+ENGL,4960,3,Senior Seminar,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-4960,2017
+ENGL,4960,4,Senior Seminar,0.42,0.25,0.25,0.0,0.0,0.0,0.0,0.08,william stockton,,ENGL-4960,2017
+ENGR,1020,312,Engineering Discipl & Skills,0.07,0.22,0.3,0.15,0.07,0.0,0.0,0.19,bradley putman,,ENGR-1020,2017
+ENGR,1020,317,Engineering Discipl & Skills,0.19,0.41,0.19,0.06,0.07,0.0,0.0,0.09,ashley childers,,ENGR-1020,2017
+ENGR,1020,318,Engineering Discipl & Skills,0.06,0.44,0.31,0.06,0.11,0.0,0.0,0.02,ashley childers,,ENGR-1020,2017
+ENGR,1060,242,Engr Discipline & Skills II,0.03,0.1,0.37,0.3,0.13,0.0,0.0,0.07,sarah grigg,,ENGR-1060,2017
+ENGR,1060,312,Engr Discipline & Skills II,0.0,0.4,0.6,0.0,0.0,0.0,0.0,0.0,bradley putman,,ENGR-1060,2017
+ENGR,1410,122,Programming & Problem Solving,0.31,0.38,0.27,0.02,0.0,0.0,0.0,0.02,matthew kent miller,,ENGR-1410,2017
+ENGR,1410,321,Programming & Problem Solving,0.02,0.3,0.41,0.15,0.02,0.0,0.0,0.09,michael giebner,,ENGR-1410,2017
+ENGR,1410,323,Programming & Problem Solving,0.22,0.46,0.22,0.09,0.0,0.0,0.0,0.02,mariah magagnotti,,ENGR-1410,2017
+ENGR,1410,324,Programming & Problem Solving,0.22,0.37,0.3,0.09,0.0,0.0,0.0,0.02,irene marie ferrara,,ENGR-1410,2017
+ENGR,1410,325,Programming & Problem Solving,0.33,0.33,0.2,0.09,0.02,0.0,0.0,0.04,steven brandon,,ENGR-1410,2017
+ENGR,1410,326,Programming & Problem Solving,0.27,0.38,0.22,0.02,0.0,0.0,0.0,0.11,steven brandon,,ENGR-1410,2017
+ENGR,1410,621,Programming & Problem Solving,0.25,0.3,0.25,0.08,0.03,0.0,0.0,0.1,william martin,,ENGR-1410,2017
+ENGR,1410,622,Programming & Problem Solving,0.34,0.4,0.09,0.11,0.02,0.0,0.0,0.04,william martin,,ENGR-1410,2017
+ENGR,1410,623,Programming & Problem Solving,0.43,0.49,0.09,0.0,0.0,0.0,0.0,0.0,elizabeth stephan,,ENGR-1410,2017
+ENGR,1410,624,Programming & Problem Solving,0.16,0.45,0.3,0.05,0.02,0.0,0.0,0.02,andrew isaa neptune,,ENGR-1410,2017
+ENGR,1410,625,Programming & Problem Solving,0.15,0.59,0.13,0.04,0.0,0.0,0.0,0.09,matthew kent miller,,ENGR-1410,2017
+ENGR,1410,626,Programming & Problem Solving,0.14,0.36,0.32,0.11,0.0,0.0,0.0,0.07,matthew kent miller,,ENGR-1410,2017
+ENGR,1410,627,Programming & Problem Solving,0.21,0.55,0.17,0.02,0.02,0.0,0.0,0.02,sarah grigg,,ENGR-1410,2017
+ENGR,1410,628,Programming & Problem Solving,0.09,0.56,0.24,0.09,0.0,0.0,0.0,0.03,sarah grigg,,ENGR-1410,2017
+ENGR,1410,821,Programming & Problem Solving,0.13,0.39,0.19,0.16,0.03,0.0,0.0,0.1,andrew isaa neptune,,ENGR-1410,2017
+ENGR,1410,822,Programming & Problem Solving,0.33,0.33,0.26,0.04,0.0,0.0,0.0,0.04,andrew isaa neptune,,ENGR-1410,2017
+ENGR,1410,823,Program & Prob Solving (HON),0.47,0.45,0.08,0.0,0.0,0.0,0.0,0.0,john minor,True,ENGR-1410,2017
+ENGR,1410,824,Program & Prob Solving (HON),0.44,0.53,0.03,0.0,0.0,0.0,0.0,0.0,jonathan maier,True,ENGR-1410,2017
+ENGR,1410,825,Programming & Problem Solving,0.16,0.38,0.31,0.09,0.0,0.0,0.0,0.07,mariah magagnotti,,ENGR-1410,2017
+ENGR,1410,826,Programming & Problem Solving,0.11,0.37,0.41,0.02,0.02,0.0,0.0,0.07,mariah magagnotti,,ENGR-1410,2017
+ENGR,1410,827,Programming & Problem Solving,0.13,0.6,0.27,0.0,0.0,0.0,0.0,0.0,irene marie ferrara,,ENGR-1410,2017
+ENGR,1410,828,Programming & Problem Solving,0.15,0.35,0.24,0.24,0.0,0.0,0.0,0.03,irene marie ferrara,,ENGR-1410,2017
+ENGR,1640,500,Engineering MATLAB Programming,0.14,0.43,0.29,0.14,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1640,2017
+ENGR,1640,501,Engineering MATLAB Programming,0.05,0.35,0.25,0.2,0.15,0.0,0.0,0.0,jonathan maier,,ENGR-1640,2017
+ENGR,2080,382,Engr Graphics & Machine Design,0.68,0.26,0.0,0.04,0.0,0.0,0.0,0.02,john minor,,ENGR-2080,2017
+ENGR,2080,384,Engr Graphics & Machine Design,0.61,0.21,0.04,0.02,0.09,0.0,0.0,0.04,anthony pau garland,,ENGR-2080,2017
+ENGR,2080,385,Engr Graphics & Machine Design,0.49,0.19,0.14,0.04,0.07,0.0,0.0,0.07,anthony pau garland,,ENGR-2080,2017
+ENGR,2080,686,Engr Graphics & Machine Design,0.55,0.23,0.13,0.02,0.04,0.0,0.0,0.04,garrison llo broome,,ENGR-2080,2017
+ENGR,2080,881,Engr Graphics & Machine Design,0.47,0.33,0.09,0.03,0.07,0.0,0.0,0.02,amaninder sing gill,,ENGR-2080,2017
+ENGR,2080,882,Engr Graphics & Machine Design,0.63,0.28,0.05,0.02,0.02,0.0,0.0,0.0,amaninder sing gill,,ENGR-2080,2017
+ENGR,2080,884,Engr Graphics & Machine Design,0.66,0.23,0.05,0.0,0.04,0.0,0.0,0.02,nighat yasmin,,ENGR-2080,2017
+ENGR,2080,885,Engr Graphics & Machine Design,0.61,0.29,0.05,0.02,0.04,0.0,0.0,0.0,sarah rowlinson,,ENGR-2080,2017
+ENGR,2080,886,Engr Graphics & Machine Design,0.5,0.29,0.11,0.04,0.05,0.0,0.0,0.02,sarah rowlinson,,ENGR-2080,2017
+ENGR,2100,601,CAD & Engineering Applications,0.67,0.19,0.13,0.0,0.02,0.0,0.0,0.0,nighat yasmin,,ENGR-2100,2017
+ENGR,2100,602,CAD & Engineering Applications,0.56,0.25,0.13,0.0,0.02,0.0,0.0,0.04,nighat yasmin,,ENGR-2100,2017
+ENGR,2100,604,CAD & Engineering Applications,0.56,0.32,0.08,0.0,0.02,0.0,0.0,0.02,trent hou dellinger,,ENGR-2100,2017
+ENGR,2100,605,CAD & Engineering Applications,0.65,0.29,0.04,0.0,0.02,0.0,0.0,0.0, shams esfandabadi,,ENGR-2100,2017
+ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.15,0.06,0.02,0.02,0.0,0.0,0.04,russell barrett,,ENR-1020,2017
+ENR,3020,1,Nat Res Measurements,0.68,0.24,0.05,0.03,0.0,0.0,0.0,0.0,lawrence gering,,ENR-3020,2017
+ENR,4130,2,Restoration Ecology,0.17,0.47,0.19,0.14,0.03,0.0,0.0,0.0,althea simone hagan,,ENR-4130,2017
+ENR,4500,1,Conservation Issues,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,,ENR-4500,2017
+ENR,4500,2,Conservation Issues,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,,ENR-4500,2017
+ENSP,2000,1,Intro Environ Sci,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,tom owino,,ENSP-2000,2017
+ENSP,2000,2,Intro Environ Sci,0.72,0.23,0.02,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,,ENSP-2000,2017
+ENSP,2000,3,Intro Environ Sci,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2017
+ENSP,2010,1,Environm Sci for Educ Majors,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2010,2017
+ENT,2000,1,Six-Legged Science,0.49,0.33,0.14,0.0,0.0,0.0,0.0,0.05,suellen pometto,,ENT-2000,2017
+ENT,2010,1,Animated Insects,0.92,0.05,0.03,0.0,0.0,0.0,0.0,0.0,joseph culin,,ENT-2010,2017
+ENTR,1010,1,Entrepreneurial Mindset,0.5,0.28,0.06,0.05,0.08,0.0,0.0,0.04,john michael hannon,,ENTR-1010,2017
+ENTR,1040,1,Technology Entrepreneurship,0.55,0.31,0.03,0.0,0.1,0.0,0.0,0.0,john michael hannon,,ENTR-1040,2017
+ESED,8210,1,Teaching Undergraduate Science,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,jennifer van dyken,,ESED-8210,2017
+ETOX,6370,1,Ecotoxicology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,peter van den hurk,,ETOX-6370,2017
+FCS,8110,1,Hum Dev & Fam Life,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,susan limber,,FCS-8110,2017
+FCS,8340,1,Research Methods in FCS II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james mcdonell,,FCS-8340,2017
+FDSC,1020,1,Persp Food Nutrition,0.94,0.0,0.0,0.03,0.0,0.0,0.0,0.03,john mcgregor,,FDSC-1020,2017
+FDSC,2140,1,Fd Resources & Soc,0.49,0.36,0.08,0.04,0.0,0.0,0.0,0.04,paul dawson,,FDSC-2140,2017
+FDSC,2150,1,Culinary Fundamental,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,aubrey dean coffee,,FDSC-2150,2017
+FDSC,3040,1,Eval Dairy Products,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john mcgregor,,FDSC-3040,2017
+FDSC,3060,1,Institutional Food Service Mgt,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,,FDSC-3060,2017
+FDSC,4020,1,Food Chemistry II,0.46,0.48,0.04,0.0,0.0,0.0,0.0,0.02,feng chen,,FDSC-4020,2017
+FDSC,4030,1,Food Ch & Analysis,0.7,0.19,0.09,0.02,0.0,0.0,0.0,0.0,paul dawson,,FDSC-4030,2017
+FDSC,4080,1,Food Process Eng,0.65,0.26,0.09,0.0,0.0,0.0,0.0,0.0,felix barron,,FDSC-4080,2017
+FDSC,4090,1,TQM for Food & Pckg Industries,0.54,0.32,0.1,0.02,0.0,0.0,0.0,0.02,john mcgregor,,FDSC-4090,2017
+FIN,2010,401,Intro to Personal Finance,0.68,0.18,0.04,0.04,0.0,0.0,0.0,0.07,joshua harris,,FIN-2010,2017
+FIN,2010,402,Intro to Personal Finance,0.69,0.21,0.0,0.07,0.0,0.0,0.0,0.03,joshua harris,,FIN-2010,2017
+FIN,2010,403,Intro to Personal Finance,0.27,0.62,0.08,0.0,0.0,0.0,0.0,0.04,joshua harris,,FIN-2010,2017
+FIN,2010,404,Intro to Personal Finance,0.69,0.18,0.02,0.02,0.02,0.0,0.0,0.07,joshua harris,,FIN-2010,2017
+FIN,2010,405,Intro to Personal Finance,0.64,0.17,0.03,0.06,0.11,0.0,0.0,0.0,joshua harris,,FIN-2010,2017
+FIN,2010,406,Intro to Personal Finance,0.73,0.08,0.12,0.0,0.08,0.0,0.0,0.0,joshua harris,,FIN-2010,2017
+FIN,3040,1,Risk & Insurance,0.28,0.17,0.44,0.0,0.06,0.0,0.0,0.06,kerri mcmillan,,FIN-3040,2017
+FIN,3050,1,Investment Analysis,0.18,0.34,0.26,0.13,0.05,0.0,0.0,0.03,kerri mcmillan,,FIN-3050,2017
+FIN,3050,2,Investment Analysis,0.13,0.32,0.39,0.08,0.03,0.0,0.0,0.05,kerri mcmillan,,FIN-3050,2017
+FIN,3050,3,Investment Analysis,0.3,0.33,0.25,0.08,0.03,0.0,0.0,0.03,kerri mcmillan,,FIN-3050,2017
+FIN,3060,1,Corporation Finance,0.25,0.15,0.18,0.2,0.2,0.0,0.0,0.03,william hol johnson,,FIN-3060,2017
+FIN,3060,2,Corporation Finance,0.39,0.16,0.13,0.16,0.03,0.0,0.0,0.13,william hol johnson,,FIN-3060,2017
+FIN,3060,3,Corporation Finance,0.31,0.13,0.17,0.22,0.06,0.0,0.0,0.11,william hol johnson,,FIN-3060,2017
+FIN,3060,4,Corporation Finance,0.08,0.25,0.34,0.17,0.08,0.0,0.0,0.08,ramon tolb franklin,,FIN-3060,2017
+FIN,3060,5,Corporation Finance,0.14,0.17,0.41,0.14,0.08,0.0,0.0,0.05,ramon tolb franklin,,FIN-3060,2017
+FIN,3060,6,Corporation Finance,0.25,0.25,0.38,0.05,0.0,0.0,0.0,0.06,ramon tolb franklin,,FIN-3060,2017
+FIN,3060,8,Corporation Finance,0.19,0.41,0.26,0.11,0.04,0.0,0.0,0.0,minxing sun,,FIN-3060,2017
+FIN,3070,1,Prin of Real Estate,0.28,0.44,0.21,0.03,0.03,0.0,0.0,0.03,yannan shen,,FIN-3070,2017
+FIN,3070,2,Prin of Real Estate,0.26,0.45,0.24,0.0,0.03,0.0,0.0,0.03,yannan shen,,FIN-3070,2017
+FIN,3070,3,Prin of Real Estate,0.16,0.39,0.45,0.0,0.0,0.0,0.0,0.0,thomas springer,,FIN-3070,2017
+FIN,3080,1,Fin Inst & Mkts,0.14,0.51,0.29,0.06,0.0,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2017
+FIN,3080,2,Fin Inst & Mkts,0.23,0.43,0.25,0.1,0.0,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2017
+FIN,3080,3,Fin Inst & Mkts,0.33,0.31,0.31,0.05,0.0,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2017
+FIN,3110,1,Financial Management I,0.12,0.31,0.21,0.17,0.05,0.0,0.0,0.14,george bra lockhart,,FIN-3110,2017
+FIN,3110,2,Financial Management I,0.11,0.38,0.19,0.08,0.11,0.0,0.0,0.14,george bra lockhart,,FIN-3110,2017
+FIN,3110,3,Financial Management I,0.12,0.32,0.15,0.24,0.05,0.0,0.0,0.12,george bra lockhart,,FIN-3110,2017
+FIN,3110,4,Financial Management I,0.12,0.19,0.26,0.1,0.1,0.0,0.0,0.24,john alexander,,FIN-3110,2017
+FIN,3120,1,Financial Management II,0.16,0.2,0.24,0.16,0.04,0.0,0.0,0.2,blerina zykaj,,FIN-3120,2017
+FIN,3120,2,Financial Management II,0.31,0.19,0.39,0.0,0.0,0.0,0.0,0.11,blerina zykaj,,FIN-3120,2017
+FIN,3120,3,Financial Management II,0.26,0.34,0.26,0.14,0.0,0.0,0.0,0.0,weike xu,,FIN-3120,2017
+FIN,3120,4,Financial Management II,0.18,0.45,0.18,0.06,0.0,0.0,0.0,0.12,weike xu,,FIN-3120,2017
+FIN,4030,1,Spreadsheet Apps in Finance,0.17,0.47,0.31,0.06,0.0,0.0,0.0,0.0,vincent intintoli,,FIN-4030,2017
+FIN,4030,2,Spreadsheet Apps in Finance,0.25,0.36,0.25,0.06,0.06,0.0,0.0,0.03,vincent intintoli,,FIN-4030,2017
+FIN,4040,2,Financial Modeling,0.13,0.39,0.43,0.04,0.0,0.0,0.0,0.0,jack wolf,,FIN-4040,2017
+FIN,4050,1,Portfolio Management & Theory,0.1,0.28,0.45,0.17,0.0,0.0,0.0,0.0,john alexander,,FIN-4050,2017
+FIN,4080,1,Mgt of Fin Inst,0.21,0.71,0.07,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2017
+FIN,4080,2,Mgt of Fin Inst,0.18,0.68,0.09,0.05,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2017
+FIN,4110,1,Int Fin Mgt,0.25,0.38,0.35,0.03,0.0,0.0,0.0,0.0,luke asher devault,,FIN-4110,2017
+FIN,4110,2,Int Fin Mgt,0.19,0.53,0.25,0.0,0.0,0.0,0.0,0.03,luke asher devault,,FIN-4110,2017
+FIN,4150,1,Real Estate Investmt,0.18,0.36,0.41,0.05,0.0,0.0,0.0,0.0,thomas springer,,FIN-4150,2017
+FIN,4160,1,Real Estate Val,0.26,0.61,0.09,0.0,0.0,0.0,0.0,0.04,ramon tolb franklin,,FIN-4160,2017
+FNR,4700,10,Kennedy Wtrfowl & Wetland Intn,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,richard ma kaminski,,FNR-4700,2017
+FNR,4990,1,Natural Resources Seminar,0.78,0.06,0.06,0.0,0.06,0.0,0.0,0.06,susan talley guynn,,FNR-4990,2017
+FNR,4990,3,Natural Resources Seminar,0.68,0.09,0.05,0.14,0.05,0.0,0.0,0.0,susan talley guynn,,FNR-4990,2017
+FOR,1010,1,Intro to Forestry,0.79,0.1,0.0,0.05,0.0,0.0,0.0,0.05,lawrence gering,,FOR-1010,2017
+FOR,2060,1,Forestry Ecology,0.26,0.4,0.18,0.07,0.04,0.0,0.0,0.06,donald hagan,,FOR-2060,2017
+FOR,3080,1,Remote Sensing in Forestry,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,lawrence gering,,FOR-3080,2017
+FOR,4060,1,Forested Watershed Mgmt,0.97,0.01,0.01,0.0,0.0,0.0,0.0,0.0,thomas adam coates,,FOR-4060,2017
+FOR,4080,1,Wood and Paper Products,0.48,0.45,0.03,0.03,0.0,0.0,0.0,0.0,patricia layton,,FOR-4080,2017
+FOR,4150,1,Forest Wildlife Managment,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,james davis,,FOR-4150,2017
+FOR,4180,1,Forest Resource Valuation,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,thomas straka,,FOR-4180,2017
+FOR,4340,1,GIS for Natural Resources,0.48,0.41,0.09,0.02,0.0,0.0,0.0,0.0,robert frit baldwin,,FOR-4340,2017
+FOR,4650,1,Silviculture,0.27,0.47,0.2,0.07,0.0,0.0,0.0,0.0,gaofeng wang,,FOR-4650,2017
+FR,1010,1,Elementary French,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1010,2017
+FR,1010,2,Elementary French,0.39,0.39,0.06,0.06,0.06,0.0,0.0,0.06,kenneth dav widgren,,FR-1010,2017
+FR,1020,2,Elementary French,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,amy lyn grif sawyer,,FR-1020,2017
+FR,1020,3,Elementary French,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2017
+FR,2010,2,Intermediate French,0.42,0.17,0.25,0.0,0.0,0.0,0.0,0.17,anne salces  nedeo,,FR-2010,2017
+FR,2010,3,Intermediate French,0.8,0.05,0.1,0.0,0.0,0.0,0.0,0.05,kelly digby peebles,,FR-2010,2017
+FR,2010,4,Intermediate French,0.25,0.38,0.19,0.0,0.06,0.0,0.0,0.13,erin shevau stigers,,FR-2010,2017
+FR,2020,1,Intermediate French,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,erin shevau stigers,,FR-2020,2017
+FR,2020,4,Intermediate French,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,paulin de tholozany,,FR-2020,2017
+FR,3050,1,Int Fr Con & Comp I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,anne salces  nedeo,,FR-3050,2017
+FR,3170,1,Contemp French Civ,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-3170,2017
+GC,1010,1,Orientation to G C,0.84,0.04,0.02,0.0,0.02,0.0,0.0,0.07,kern cox,,GC-1010,2017
+GC,1020,1,Computer Art & CAD Foundations,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,carol jones,,GC-1020,2017
+GC,1030,1,G C I for Pkgsc,0.28,0.53,0.13,0.0,0.08,0.0,0.0,0.0,john jacobs,,GC-1030,2017
+GC,1040,1,Graphic Communications I,0.54,0.39,0.01,0.01,0.03,0.0,0.0,0.01,rebecca suza edlein,,GC-1040,2017
+GC,2070,1,Graphic Communications II,0.63,0.26,0.04,0.0,0.04,0.0,0.0,0.04,charles tabor weiss,,GC-2070,2017
+GC,3400,1,Digital Imaging and eMedia,0.36,0.47,0.14,0.0,0.03,0.0,0.0,0.0,erica black walker,,GC-3400,2017
+GC,3460,1,Ink and Substrates,0.32,0.53,0.12,0.02,0.02,0.0,0.0,0.0,michelle suki  fox,,GC-3460,2017
+GC,4060,1,Package and Specialty Printing,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,kern cox,,GC-4060,2017
+GC,4400,1,Commercial Printing,0.3,0.53,0.1,0.0,0.07,0.0,0.0,0.0,eric weisenmiller,,GC-4400,2017
+GC,4440,1,Current Dev/Trends in Gr Comm,0.65,0.23,0.13,0.0,0.0,0.0,0.0,0.0,samuel ingram,,GC-4440,2017
+GC,4480,1,Plan & Cont Printing Functions,0.41,0.5,0.09,0.0,0.0,0.0,0.0,0.0,john leininger,,GC-4480,2017
+GC,4800,1,Senior Seminar in GC,0.71,0.2,0.09,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,,GC-4800,2017
+GC,4900,2,G C Selected Topics-Sales,0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,john leininger,,GC-4900,2017
+GC,4900,5,GC Selected Topics-Concept Pkg,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,john jacobs,,GC-4900,2017
+GEN,3000,1,Fundamental Genetics,0.28,0.4,0.25,0.03,0.0,0.0,0.0,0.05,kate leanne wi tsai,,GEN-3000,2017
+GEN,3000,2,Fundamental Genetics,0.24,0.37,0.2,0.1,0.02,0.0,0.0,0.07,kate leanne wi tsai,,GEN-3000,2017
+GEN,3020,1,Molecular & General Genetics,0.39,0.24,0.22,0.02,0.05,0.0,0.0,0.07,lukasz kozubowski,,GEN-3020,2017
+GEN,4100,1,Population & Quant Genetics,0.44,0.26,0.23,0.05,0.03,0.0,0.0,0.0,amy lou lawton rauh,,GEN-4100,2017
+GEN,4110,1,Population & Quant Gen Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amy lou lawton rauh,,GEN-4110,2017
+GEN,4400,1,Bioinformatics,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,liangjiang wang,,GEN-4400,2017
+GEN,4700,1,Human Genetics,0.45,0.27,0.22,0.0,0.0,0.0,0.0,0.06,leigh anne clark,,GEN-4700,2017
+GEN,6700,1,Human Genetics,0.17,0.67,0.0,0.0,0.0,0.0,0.0,0.17,leigh anne clark,,GEN-6700,2017
+GEOG,1010,1,Intro to Geography,0.18,0.32,0.24,0.21,0.06,0.0,0.0,0.0,christa smith,,GEOG-1010,2017
+GEOG,1030,1,World Regional Geography,0.91,0.05,0.01,0.02,0.01,0.0,0.0,0.02,lance forres howard,,GEOG-1030,2017
+GEOG,1030,2,World Regional Geography,0.52,0.3,0.09,0.0,0.03,0.0,0.0,0.06,william churc terry,,GEOG-1030,2017
+GEOG,4400,1,Geog of Hist Preserv,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,christa smith,,GEOG-4400,2017
+GEOL,1010,1,Physical Geology,0.39,0.27,0.21,0.04,0.08,0.0,0.0,0.02,alan coulson,,GEOL-1010,2017
+GEOL,1010,2,Physical Geology,0.43,0.29,0.17,0.06,0.02,0.0,0.0,0.02,alan coulson,,GEOL-1010,2017
+GEOL,1030,1,Physical Geol Lab,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,1030,2,Physical Geol Lab,0.33,0.42,0.21,0.04,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,3,Physical Geol Lab,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,4,Physical Geol Lab,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,1030,5,Physical Geol Lab,0.58,0.29,0.04,0.08,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,6,Physical Geol Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,7,Physical Geol Lab,0.42,0.38,0.13,0.04,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,1030,8,Physical Geol Lab,0.63,0.25,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2017
+GEOL,1030,9,Physical Geol Lab,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,10,Physical Geol Lab,0.75,0.08,0.04,0.0,0.04,0.0,0.0,0.08,alan coulson,,GEOL-1030,2017
+GEOL,1030,11,Physical Geol Lab,0.87,0.09,0.0,0.0,0.04,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1030,12,Physical Geol Lab,0.37,0.32,0.26,0.0,0.05,0.0,0.0,0.0,alan coulson,,GEOL-1030,2017
+GEOL,1120,1,Earth Resources,0.46,0.37,0.14,0.02,0.0,0.0,0.0,0.02,scott brame,,GEOL-1120,2017
+GEOL,1140,1,Earth Resources Lab,0.54,0.29,0.09,0.09,0.0,0.0,0.0,0.0,scott brame,,GEOL-1140,2017
+GEOL,2020,1,Earth History,0.05,0.37,0.26,0.16,0.05,0.0,0.0,0.11,alan coulson,,GEOL-2020,2017
+GEOL,4050,1,Surficial Geology,0.41,0.18,0.35,0.06,0.0,0.0,0.0,0.0,james castle,,GEOL-4050,2017
+GEOL,4210,1,Gis in Geology,0.63,0.22,0.15,0.0,0.0,0.0,0.0,0.0,scott brame,,GEOL-4210,2017
+GEOL,4920,1,Resrch Synthesis II,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-4920,2017
+GEOL,7900,501,Biogeography & Geology of SC,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,,GEOL-7900,2017
+GEOL,8090,1,Subsurface Remed Mod,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,ronald falta,,GEOL-8090,2017
+GER,1010,1,Elementary German,0.19,0.25,0.25,0.06,0.06,0.0,0.0,0.19, lee ferrell,,GER-1010,2017
+GER,1010,2,Elementary German,0.35,0.24,0.06,0.06,0.0,0.0,0.0,0.29, lee ferrell,,GER-1010,2017
+GER,1020,1,Elementary German,0.35,0.5,0.1,0.0,0.0,0.0,0.0,0.05,oswald harris king,,GER-1020,2017
+GER,1020,2,Elementary German,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-1020,2017
+GER,2010,1,Intermediate German,0.05,0.42,0.37,0.0,0.0,0.0,0.0,0.16, lee ferrell,,GER-2010,2017
+GER,2020,1,Intermediate German,0.31,0.31,0.15,0.23,0.0,0.0,0.0,0.0,gabriela stoicea,,GER-2020,2017
+GER,2020,2,Intermediate German,0.36,0.29,0.14,0.07,0.14,0.0,0.0,0.0, lee ferrell,,GER-2020,2017
+GER,3060,1,German Short Story,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-3060,2017
+HCC,8810,1,Measurement & Eval,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,bart knijnenburg,,HCC-8810,2017
+HCG,9090,1,Lab Methods in Healthcare Gen,0.0,0.0,0.0,0.0,0.0,0.67,0.0,0.33,patricia leota tate,,HCG-9090,2017
+HCG,9890,400,Sel Topics-Dev Research Propos,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,julia eggert,,HCG-9890,2017
+HIST,1240,1,Environmental History Survey,0.17,0.47,0.21,0.03,0.06,0.0,0.0,0.05,james brad jeffries,,HIST-1240,2017
+HIST,1720,3,The West and the World I,0.15,0.39,0.37,0.07,0.0,0.0,0.0,0.02,caroline dunn clark,,HIST-1720,2017
+HIST,1730,1,The West and the World II,0.16,0.41,0.2,0.05,0.15,0.0,0.0,0.04, alan grubb,,HIST-1730,2017
+HIST,1730,2,The West and the World II,0.23,0.44,0.2,0.02,0.04,0.0,0.0,0.07,subah dayal,,HIST-1730,2017
+HIST,1730,3,The West and the World II,0.21,0.52,0.18,0.03,0.01,0.0,0.0,0.05,steven marks,,HIST-1730,2017
+HIST,2990,1,Historian's Craft,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,michael silvestri,,HIST-2990,2017
+HIST,2990,2,Historian's Craft,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carney,,HIST-2990,2017
+HIST,3000,1,History of Colonial America,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,lee brady wilson,,HIST-3000,2017
+HIST,3080,1,US: Reagan/Clinton 1975-Pres,0.23,0.5,0.23,0.03,0.0,0.0,0.0,0.0,meg taylor-shockley,,HIST-3080,2017
+HIST,3100,1,History of Religion in the US,0.24,0.35,0.24,0.06,0.06,0.0,0.0,0.06,elizabeth jemison,,HIST-3100,2017
+HIST,3110,1,African American Hist to 1877,0.42,0.28,0.16,0.02,0.07,0.0,0.0,0.05,abel bartley,,HIST-3110,2017
+HIST,3170,1,Hist of Nat. Am. Relig/Culture,0.25,0.4,0.15,0.05,0.1,0.0,0.0,0.05,james brad jeffries,,HIST-3170,2017
+HIST,3210,1,History of Science,0.26,0.58,0.1,0.0,0.03,0.0,0.0,0.03,pamela mack,,HIST-3210,2017
+HIST,3240,1,Hist of the South II,0.33,0.55,0.03,0.0,0.0,0.0,0.0,0.09,john andrew,,HIST-3240,2017
+HIST,3260,1,Hist Am Transport,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0, roger grant,,HIST-3260,2017
+HIST,3330,1,Hist of Mod Japan,0.24,0.39,0.24,0.03,0.08,0.0,0.0,0.03,edwin moise,,HIST-3330,2017
+HIST,3390,1,Africa 1875-Present,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,james burns,,HIST-3390,2017
+HIST,3420,1,South Am Since 1800,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,,HIST-3420,2017
+HIST,3520,1,Pharaonic Egypt,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carney,,HIST-3520,2017
+HIST,3900,1,Modern Military History,0.23,0.33,0.27,0.07,0.03,0.0,0.0,0.07,edwin moise,,HIST-3900,2017
+HIST,3970,1,Modern Middle East,0.38,0.45,0.17,0.0,0.0,0.0,0.0,0.0,amit bein,,HIST-3970,2017
+HIST,4170,1,History and Tourism,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,meg taylor-shockley,,HIST-4170,2017
+HIST,4700,1,History of Florence,0.32,0.42,0.11,0.0,0.0,0.0,0.0,0.16,thomas kuehn,,HIST-4700,2017
+HIST,4880,1,Middle Eastern Society&Culture,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,,HIST-4880,2017
+HIST,4900,1,Food & Pre-Industrial World,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,,HIST-4900,2017
+HIST,4900,2,Brexit Euro Union Memory WWars,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,stephani barczewski,,HIST-4900,2017
+HIST,4940,2,Slavery & Freedom ATL World,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lee brady wilson,,HIST-4940,2017
+HIST,4960,1,European Legal History,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,thomas kuehn,,HIST-4960,2017
+HIST,8810,1,Historiography,0.6,0.0,0.0,0.0,0.2,0.0,0.0,0.2,stephani barczewski,,HIST-8810,2017
+HLTH,2020,1,Introduction to Public Health,0.65,0.3,0.0,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2017
+HLTH,2020,2,Introduction to Public Health,0.7,0.28,0.03,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2017
+HLTH,2020,400,Introduction to Public Health,0.47,0.41,0.06,0.0,0.0,0.0,0.0,0.06,ralph stewart welsh,,HLTH-2020,2017
+HLTH,2030,1,Health Care Sys,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,frederic fraizer,,HLTH-2030,2017
+HLTH,2030,2,Health Care Sys,0.52,0.36,0.12,0.0,0.0,0.0,0.0,0.0,frederic fraizer,,HLTH-2030,2017
+HLTH,2030,3,Health Care Sys,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,HLTH-2030,2017
+HLTH,2030,400,Health Care Sys,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2030,2017
+HLTH,2400,1,Deter of Hlth Behav,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2017
+HLTH,2400,2,Deter of Hlth Behav,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.05,amelia clinkscales,,HLTH-2400,2017
+HLTH,2600,1,Medical Terminology & Comm,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,karen edwards,,HLTH-2600,2017
+HLTH,2980,1,Human Hlth & Disease,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2017
+HLTH,2980,2,Human Hlth & Disease,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2017
+HLTH,3030,1,Public Health Comm,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,,HLTH-3030,2017
+HLTH,3050,1,Body Resp Hlth Beh,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,brian patric graves,,HLTH-3050,2017
+HLTH,3800,1,Epidemiology,0.38,0.42,0.17,0.04,0.0,0.0,0.0,0.0,hugh spitler,,HLTH-3800,2017
+HLTH,3800,2,Epidemiology,0.6,0.24,0.04,0.04,0.04,0.0,0.0,0.04,deborah alma falta,,HLTH-3800,2017
+HLTH,3980,2,Health Appraisal Skills,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2017
+HLTH,4000,2,Drug Epi & Opiate Epidemic,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,HLTH-4000,2017
+HLTH,4000,3,Public Hlth Social Marketing,0.75,0.13,0.06,0.0,0.0,0.0,0.0,0.06,debra mitch charles,,HLTH-4000,2017
+HLTH,4190,1,Health Sci Internship Prep Sem,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4190,2017
+HLTH,4200,1,Hlth Science Intern,0.83,0.15,0.0,0.02,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2017
+HLTH,4310,1,Public & Environ Hlt,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-4310,2017
+HLTH,4600,1,Health Info Systems,0.57,0.29,0.07,0.0,0.07,0.0,0.0,0.0,deborah alma falta,,HLTH-4600,2017
+HLTH,4700,1,Global Health,0.71,0.18,0.07,0.0,0.04,0.0,0.0,0.0,rachel mayo,,HLTH-4700,2017
+HLTH,4780,1,Health Policy Ethics and Law,0.39,0.26,0.17,0.09,0.04,0.0,0.0,0.04,hugh spitler,,HLTH-4780,2017
+HLTH,4790,1,Fin Mgmt & Hlth Budg,0.63,0.17,0.17,0.0,0.04,0.0,0.0,0.0,lingling zhang,,HLTH-4790,2017
+HLTH,4800,1,Comm Hlth Promotion,0.54,0.41,0.0,0.0,0.02,0.0,0.0,0.02,sarah griffin,,HLTH-4800,2017
+HLTH,4900,1,Res Eval St Pub Hlth,0.76,0.16,0.04,0.04,0.0,0.0,0.0,0.0,lu shi,,HLTH-4900,2017
+HLTH,4900,2,Res Eval St Pub Hlth,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,jeffrey kingree,,HLTH-4900,2017
+HLTH,4900,3,Res Eval St Pub Hlth,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-4900,2017
+HLTH,8110,1,Health Care Delivery Systems,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,,HLTH-8110,2017
+HLTH,8130,400,Population Health and Research,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,,HLTH-8130,2017
+HLTH,8130,500,Population Health and Research,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,cheryl jo dye,,HLTH-8130,2017
+HLTH,8210,500,Health Research I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,joel edwar williams,,HLTH-8210,2017
+HLTH,8310,1,Quantitative Analy in Hlth I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,,HLTH-8310,2017
+HON,2060,1,Intro to Nanotechnology,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,,HON-2060,2017
+HON,2200,4,The Empire World,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,michael silvestri,,HON-2200,2017
+HON,2210,2,Russian Film History,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,,HON-2210,2017
+HON,2210,4,Soderbergh's Cinema,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,,HON-2210,2017
+HON,2220,2,Holocaust and Eichmann Trial,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,,HON-2220,2017
+HORT,2020,1,Adobe Digital Design,0.86,0.09,0.0,0.03,0.0,0.0,0.0,0.03,janice ann lay,,HORT-2020,2017
+HORT,2110,1,Growing Spring Plnts,0.35,0.4,0.2,0.0,0.0,0.0,0.0,0.05,james emerson faust,,HORT-2110,2017
+HORT,4040,1,Plant Propagation,0.13,0.45,0.24,0.11,0.03,0.0,0.0,0.05,jeffrey adelberg,,HORT-4040,2017
+HORT,4050,2,Plant Propagation Techniq Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,jeffrey adelberg,,HORT-4050,2017
+HORT,4200,1,Applied Turf Physiol,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,,HORT-4200,2017
+HORT,4270,1,Urban Tree Care,0.04,0.31,0.31,0.27,0.0,0.0,0.0,0.08,robert polomski,,HORT-4270,2017
+HORT,4330,1,Turf Weed Management,0.2,0.64,0.16,0.0,0.0,0.0,0.0,0.0,ted whitwell,,HORT-4330,2017
+HORT,4560,1,Vegetable Crops,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,,HORT-4560,2017
+HORT,6040,1,Plant Propagation,0.29,0.43,0.0,0.0,0.29,0.0,0.0,0.0,jeffrey adelberg,,HORT-6040,2017
+HP,8280,1,Case St in Preservation Engr,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,craig mille bennett,,HP-8280,2017
+HP,8920,200,Special Topics in Hist Preserv,0.33,0.5,0.0,0.0,0.17,0.0,0.0,0.0,richard gra gilmore,,HP-8920,2017
+HRD,8250,400,Org Perf Improvement,0.87,0.08,0.05,0.0,0.0,0.0,0.0,0.0,philip mcgee,,HRD-8250,2017
+HRD,8470,400,Instru System Design,0.74,0.05,0.05,0.0,0.11,0.0,0.0,0.05,eileen newmark,,HRD-8470,2017
+HRD,8800,400,Research Concepts,0.83,0.06,0.0,0.0,0.06,0.0,0.0,0.06,cynthia sims,,HRD-8800,2017
+IE,2000,1,Soph Seminar in I E,0.51,0.15,0.12,0.2,0.0,0.0,0.0,0.02,brian melloy,,IE-2000,2017
+IE,2100,1,Des Analysis Wrk Sys,0.16,0.36,0.24,0.09,0.04,0.0,0.0,0.1,sara lu riggs,,IE-2100,2017
+IE,2800,1,Deterministic Operations Rsrch,0.08,0.23,0.25,0.22,0.18,0.0,0.0,0.05,amin khademi,,IE-2800,2017
+IE,3010,1,Systems Design I,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,joel greenstein,,IE-3010,2017
+IE,3600,1,Industrial Apps of Prob/Stat I,0.47,0.26,0.16,0.05,0.05,0.0,0.0,0.0,mary elizabeth kurz,,IE-3600,2017
+IE,3610,1,Industrial App of Prob/Stat II,0.26,0.35,0.28,0.06,0.03,0.0,0.0,0.01,sandra dun eksioglu,,IE-3610,2017
+IE,3810,1,Probabilistic Operations Rsrch,0.14,0.37,0.32,0.12,0.05,0.0,0.0,0.0,burak eksioglu,,IE-3810,2017
+IE,3840,1,Engr Econ Analysis,0.42,0.22,0.1,0.02,0.07,0.0,0.0,0.17,brian melloy,,IE-3840,2017
+IE,3860,1,Prod Plan & Cont,0.56,0.27,0.11,0.02,0.01,0.0,0.0,0.02,jonathan lowe,,IE-3860,2017
+IE,4300,1,Human Fact Engr in Healthcare,0.69,0.29,0.02,0.0,0.0,0.0,0.0,0.0,david neyens,,IE-4300,2017
+IE,4400,1,Decision Support Sys,0.3,0.35,0.18,0.12,0.04,0.0,0.0,0.01,sandra dun eksioglu,,IE-4400,2017
+IE,4610,1,Quality Engineering,0.22,0.22,0.15,0.27,0.07,0.0,0.0,0.07,robert james riggs,,IE-4610,2017
+IE,4620,1,Six Sigma Quality,0.17,0.37,0.36,0.08,0.0,0.0,0.0,0.03,robert james riggs,,IE-4620,2017
+IE,4650,1,Facilities Planning & Design,0.64,0.25,0.11,0.0,0.0,0.0,0.0,0.0,nadeepa wickramage,,IE-4650,2017
+IE,4670,1,System Design II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-4670,2017
+IE,4670,2,System Design II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-4670,2017
+IE,4820,1,Systems Modeling,0.41,0.31,0.09,0.13,0.03,0.0,0.0,0.03,tugce isik,,IE-4820,2017
+IE,4880,1,Human Factors Eng,0.34,0.51,0.14,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,,IE-4880,2017
+IE,6620,1,Six Sigma Quality,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,,IE-6620,2017
+IE,6820,1,Systems Modeling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,tugce isik,,IE-6820,2017
+IE,6840,1,Applied Engineering Economics`,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nadeepa wickramage,,IE-6840,2017
+IE,8020,1,Human Comp Sys,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,joel greenstein,,IE-8020,2017
+IE,8050,1,Found Qual Engr,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,byung rae cho,,IE-8050,2017
+IE,8520,1,Prescriptive Analytics,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,jonathan cole smith,,IE-8520,2017
+IE,8540,1,SC & Logistics Modeling I,0.65,0.26,0.0,0.0,0.09,0.0,0.0,0.0,william ferrell,,IE-8540,2017
+IE,8580,1,Case Study Supply Chn & Logist,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-8580,2017
+IE,8870,1,Model Logist Behav Simulation,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kevin taaffe,,IE-8870,2017
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.06,0.03,caren kelley-hall,,INT-1510,2017
+INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.89,0.09,0.03,caren kelley-hall,,INT-1520,2017
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.82,0.16,0.02,caren kelley-hall,,INT-1530,2017
+INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.89,0.09,0.02,caren kelley-hall,,INT-1540,2017
+INT,2010,1,Off-Campus Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,katherine el horner,,INT-2010,2017
+INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.89,0.11,0.0,caren kelley-hall,,INT-2510,2017
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,uttiyo raychaudhuri,,IS-1010,2017
+IS,1010,2,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.92,0.08,0.0,uttiyo raychaudhuri,,IS-1010,2017
+ITAL,1010,1,Elementary Italian,0.54,0.38,0.0,0.0,0.0,0.0,0.0,0.08,lyudmyla tsykalova,,ITAL-1010,2017
+ITAL,1010,2,Elementary Italian,0.42,0.26,0.11,0.05,0.05,0.0,0.0,0.11,julia schmidt,,ITAL-1010,2017
+ITAL,1020,2,Elementary Italian,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-1020,2017
+ITAL,2020,1,Intermediate Italian,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,,ITAL-2020,2017
+JAPN,1010,1,Elementary Japanese,0.44,0.33,0.17,0.0,0.0,0.0,0.0,0.06,saori suto,,JAPN-1010,2017
+JAPN,1010,2,Elementary Japanese,0.2,0.4,0.2,0.0,0.07,0.0,0.0,0.13,saori suto,,JAPN-1010,2017
+JAPN,1020,1,Elementary Japanese,0.16,0.16,0.32,0.0,0.11,0.0,0.0,0.26,toshiko joerger,,JAPN-1020,2017
+JAPN,2020,1,Intermed Japanese,0.47,0.13,0.33,0.07,0.0,0.0,0.0,0.0,saori suto,,JAPN-2020,2017
+JAPN,4170,1,Japanese Culture and Society,0.53,0.21,0.0,0.21,0.05,0.0,0.0,0.0,jae allegr takeuchi,,JAPN-4170,2017
+JUST,2880,1,The Criminal Justice System,0.39,0.22,0.35,0.04,0.0,0.0,0.0,0.0,margaret tina britz,,JUST-2880,2017
+JUST,2890,1,Criminology,0.3,0.35,0.15,0.0,0.15,0.0,0.0,0.05,william white,,JUST-2890,2017
+JUST,4910,1,Policing,0.5,0.3,0.1,0.1,0.0,0.0,0.0,0.0,william white,,JUST-4910,2017
+JUST,4930,1,Corrections,0.39,0.43,0.07,0.04,0.0,0.0,0.0,0.07,william white,,JUST-4930,2017
+JUST,4940,1,Organized Crime,0.28,0.48,0.24,0.0,0.0,0.0,0.0,0.0,margaret tina britz,,JUST-4940,2017
+LANG,2540,1,Introduction to World Cinemas,0.67,0.24,0.0,0.0,0.05,0.0,0.0,0.05,raquel anido,,LANG-2540,2017
+LARC,1160,1,History of Landscape Arch,0.3,0.47,0.16,0.01,0.01,0.0,0.0,0.05,hala fouad nassar,,LARC-1160,2017
+LARC,1160,2,History of Landscape Arch,0.69,0.19,0.08,0.04,0.0,0.0,0.0,0.0,martin john holland,,LARC-1160,2017
+LARC,1520,1,Basic Design II,0.46,0.42,0.08,0.04,0.0,0.0,0.0,0.0,paul russell,,LARC-1520,2017
+LARC,2550,1,Community Design Studio,0.78,0.0,0.17,0.0,0.06,0.0,0.0,0.0,martin john holland,,LARC-2550,2017
+LARC,3620,1,Design Impl II,0.41,0.41,0.06,0.06,0.06,0.0,0.0,0.0,paul russell,,LARC-3620,2017
+LARC,4280,1,Computer-Aided Design,0.85,0.04,0.12,0.0,0.0,0.0,0.0,0.0,yang song,,LARC-4280,2017
+LARC,6810,1,Professional Practice,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,david lycke,,LARC-6810,2017
+LAW,3220,1,Legal Env of Bus,0.14,0.51,0.29,0.04,0.02,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2017
+LAW,3220,2,Legal Env of Bus,0.47,0.36,0.11,0.07,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2017
+LAW,3220,3,Legal Env of Bus,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2017
+LAW,3220,4,Legal Env of Bus,0.4,0.42,0.16,0.02,0.0,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2017
+LAW,3220,5,Legal Env of Bus,0.27,0.2,0.36,0.16,0.02,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2017
+LAW,3220,6,Legal Env of Bus,0.31,0.47,0.16,0.04,0.02,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2017
+LAW,3220,7,Legal Env of Bus,0.09,0.55,0.32,0.02,0.02,0.0,0.0,0.0,judson jahn,,LAW-3220,2017
+LAW,3220,8,Legal Env of Bus,0.22,0.38,0.27,0.09,0.04,0.0,0.0,0.0,kenneth toussaint,,LAW-3220,2017
+LAW,3220,9,Legal Env of Bus,0.49,0.36,0.13,0.0,0.0,0.0,0.0,0.02,kath kisska-schulze,,LAW-3220,2017
+LAW,3220,10,Legal Env of Bus,0.33,0.38,0.27,0.02,0.0,0.0,0.0,0.0,john hine,,LAW-3220,2017
+LAW,3220,11,Legal Env of Bus,0.16,0.42,0.27,0.09,0.02,0.0,0.0,0.04,john hine,,LAW-3220,2017
+LAW,3220,401,Legal Env of Bus,0.27,0.31,0.23,0.06,0.06,0.0,0.0,0.06,virgini ward-vaughn,,LAW-3220,2017
+LAW,3220,402,Legal Env of Bus,0.21,0.46,0.13,0.08,0.06,0.0,0.0,0.06,virgini ward-vaughn,,LAW-3220,2017
+LAW,3220,403,Legal Env of Bus,0.19,0.43,0.17,0.04,0.11,0.0,0.0,0.06,virgini ward-vaughn,,LAW-3220,2017
+LAW,3220,404,Legal Env of Bus,0.13,0.33,0.27,0.07,0.07,0.0,0.0,0.13,virgini ward-vaughn,,LAW-3220,2017
+LAW,3330,1,Real Estate Law,0.18,0.51,0.22,0.02,0.0,0.0,0.0,0.07,judson jahn,,LAW-3330,2017
+LAW,8480,1,Law Real Estate Prof,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james ivey warren,,LAW-8480,2017
+LIB,2990,1,Creative Inq - The Libraries,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert wilmott,,LIB-2990,2017
+LIH,4000,35,Internship Abroad,0.0,0.0,0.0,0.0,0.0,0.79,0.21,0.0,juana martin-armas,,LIH-4000,2017
+LS,1000,2,Fitness Leadership,0.82,0.0,0.0,0.09,0.0,0.0,0.0,0.09,patricia figueroa,,LS-1000,2017
+LS,1000,9,Intro to Salsa Dance,0.85,0.05,0.0,0.05,0.0,0.0,0.0,0.05,malik lewis baxter,,LS-1000,2017
+LS,1000,10,Intro to Salsa Dance,0.9,0.0,0.1,0.0,0.0,0.0,0.0,0.0,malik lewis baxter,,LS-1000,2017
+LS,1000,11,Shotgun II,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,edward licus prater,,LS-1000,2017
+LS,1000,12,Intermediate Rock Climbing,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,corey newe winstead,,LS-1000,2017
+LS,1000,17,A.C.E. Personal Trainer Prep,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,corey dou brookover,,LS-1000,2017
+LS,1000,20,Intro to Volleyball,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,kelly lynn ator,,LS-1000,2017
+LS,1000,23,Therapeutic Yoga,0.75,0.05,0.05,0.0,0.05,0.0,0.0,0.1,ranjanbala dil amin,,LS-1000,2017
+LS,1000,24,Therapeutic Yoga,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,ranjanbala dil amin,,LS-1000,2017
+LS,1000,25,Therapeutic Yoga,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-1000,2017
+LS,1000,26,Therapeutic Yoga,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,,LS-1000,2017
+LS,1000,27,Beg. Non-Competitive Karate,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,june pilcher,,LS-1000,2017
+LS,1410,1,Top Rope Climbing,0.79,0.07,0.0,0.0,0.14,0.0,0.0,0.0,michelle tuday,,LS-1410,2017
+LS,1410,3,Top Rope Climbing,0.85,0.08,0.0,0.0,0.08,0.0,0.0,0.0,michelle tuday,,LS-1410,2017
+LS,1410,5,Top Rope Climbing,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,michelle tuday,,LS-1410,2017
+LS,1410,6,Top Rope Climbing,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,michelle tuday,,LS-1410,2017
+LS,1410,8,Top Rope Climbing,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,corey newe winstead,,LS-1410,2017
+LS,1450,5,Camping/Backpacking,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,sarah wilcer,,LS-1450,2017
+LS,1560,16,Riflery,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dominic cirocco,,LS-1560,2017
+LS,1560,19,Riflery,0.36,0.45,0.0,0.0,0.09,0.0,0.0,0.09,dominic cirocco,,LS-1560,2017
+LS,1570,9,Shotgun Sports,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,james gill,,LS-1570,2017
+LS,1580,5,Archery,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,herbert strickland,,LS-1580,2017
+LS,1640,2,Whitewater Kayaking,0.5,0.2,0.0,0.0,0.0,0.0,0.0,0.3,robert taylor,,LS-1640,2017
+LS,1850,2,Bowling,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,adam perr middleton,,LS-1850,2017
+LS,1850,4,Bowling,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kathryn ly mitchell,,LS-1850,2017
+LS,1850,7,Bowling,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,megan elizabet cato,,LS-1850,2017
+LS,1850,8,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,adam perr middleton,,LS-1850,2017
+LS,1850,9,Bowling,0.82,0.04,0.0,0.04,0.0,0.0,0.0,0.11,megan elizabet cato,,LS-1850,2017
+LS,1940,2,Racquetball,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,raymond petersen,,LS-1940,2017
+LS,1940,3,Racquetball,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,charlie white,,LS-1940,2017
+LS,1980,9,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,wesley scott womble,,LS-1980,2017
+LS,2200,3,Shag,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,broadus fleming,,LS-2200,2017
+LS,2200,7,Shag,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,matthew lee krabbe,,LS-2200,2017
+LS,2270,1,Intro to Swing Dance,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,paul hoke,,LS-2270,2017
+LS,2320,1,Core Training,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,,LS-2320,2017
+LS,2320,2,Core Training,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,,LS-2320,2017
+LS,2320,3,Core Training,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-2320,2017
+LS,2350,1,Basic Yoga,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,silica eliza larkin,,LS-2350,2017
+LS,2350,3,Basic Yoga,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2350,2017
+LS,2350,4,Basic Yoga,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2017
+LS,2350,5,Basic Yoga,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,renee warren gahan,,LS-2350,2017
+LS,2350,6,Basic Yoga,0.91,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,,LS-2350,2017
+LS,2350,7,Basic Yoga,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,kayla lee wardlaw,,LS-2350,2017
+LS,2380,1,Vinyasa Flow Yoga,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nicole eli martinez,,LS-2380,2017
+LS,2380,3,Vinyasa Flow Yoga,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,,LS-2380,2017
+LS,2420,1,Meditation and Relax,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2017
+LS,2420,3,Meditation and Relax,0.7,0.13,0.04,0.04,0.0,0.0,0.0,0.09,renee warren gahan,,LS-2420,2017
+LS,2420,4,Meditation and Relax,0.76,0.14,0.05,0.0,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2420,2017
+LS,2420,5,Meditation and Relax,0.91,0.0,0.0,0.04,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-2420,2017
+LS,2420,8,Meditation and Relax,0.84,0.08,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-2420,2017
+LS,2450,2,Pilates,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,,LS-2450,2017
+LS,2450,4,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-2450,2017
+LS,2450,6,Pilates,0.83,0.09,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,,LS-2450,2017
+LS,2460,1,Intermediate Pilates,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,melanie ivey job,,LS-2460,2017
+LS,2700,1,Sports Officiating,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,christopher war cox,,LS-2700,2017
+LS,2750,7,First Aid/Cpr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,christopher loomis,,LS-2750,2017
+LS,2750,8,First Aid/Cpr,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,christopher loomis,,LS-2750,2017
+LS,2780,3,Wilderness First Aid,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,emily grace turke,,LS-2780,2017
+LS,2910,1,Outdoor Leadership,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,emily grace turke,,LS-2910,2017
+LS,3580,1,Advanced Shotgun Skeet,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,james gill,,LS-3580,2017
+MATH,1010,1,Essen Math for Informed Soc,0.32,0.48,0.12,0.04,0.0,0.0,0.0,0.04,marilyn reba,,MATH-1010,2017
+MATH,1010,2,Essen Math for Informed Soc,0.53,0.26,0.18,0.0,0.0,0.0,0.0,0.03,marilyn reba,,MATH-1010,2017
+MATH,1010,3,Essen Math for Informed Soc,0.58,0.14,0.14,0.03,0.08,0.0,0.0,0.03,marilyn reba,,MATH-1010,2017
+MATH,1010,4,Essen Math for Informed Soc,0.53,0.31,0.13,0.0,0.0,0.0,0.0,0.03,marilyn reba,,MATH-1010,2017
+MATH,1020,1,Business Calculus I,0.09,0.27,0.34,0.05,0.2,0.0,0.0,0.05,tony thanh nguyen,,MATH-1020,2017
+MATH,1020,2,Business Calculus I,0.21,0.13,0.21,0.13,0.19,0.0,0.0,0.13,michael thoma cowen,,MATH-1020,2017
+MATH,1020,3,Business Calculus I,0.2,0.28,0.22,0.07,0.11,0.0,0.0,0.13,tony thanh nguyen,,MATH-1020,2017
+MATH,1020,4,Business Calculus I,0.17,0.21,0.21,0.12,0.17,0.0,0.0,0.12,todd fenstermacher,,MATH-1020,2017
+MATH,1020,5,Business Calculus I,0.09,0.18,0.4,0.13,0.18,0.0,0.0,0.02,stephen garth,,MATH-1020,2017
+MATH,1020,6,Business Calculus I,0.15,0.35,0.24,0.07,0.11,0.0,0.0,0.09,randy davidson,,MATH-1020,2017
+MATH,1020,7,Business Calculus I,0.17,0.29,0.27,0.07,0.07,0.0,0.0,0.12,marion hanna,,MATH-1020,2017
+MATH,1020,8,Business Calculus I,0.14,0.28,0.33,0.07,0.16,0.0,0.0,0.02,randy davidson,,MATH-1020,2017
+MATH,1020,9,Business Calculus I,0.21,0.5,0.12,0.1,0.07,0.0,0.0,0.0,marion hanna,,MATH-1020,2017
+MATH,1020,10,Business Calculus I,0.17,0.32,0.29,0.1,0.1,0.0,0.0,0.02,peter westerbaan,,MATH-1020,2017
+MATH,1020,11,Business Calculus I,0.21,0.37,0.26,0.02,0.09,0.0,0.0,0.05,john william grant,,MATH-1020,2017
+MATH,1020,12,Business Calculus I,0.11,0.45,0.23,0.0,0.09,0.0,0.0,0.11,randy davidson,,MATH-1020,2017
+MATH,1020,13,Business Calculus I,0.05,0.17,0.26,0.19,0.21,0.0,0.0,0.12,javier ruiz ramirez,,MATH-1020,2017
+MATH,1020,16,Business Calculus I,0.11,0.13,0.36,0.16,0.13,0.0,0.0,0.11,bryce pruitt,,MATH-1020,2017
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.44,0.54,0.03,stefan adam bock,,MATH-1040,2017
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.56,0.12,nicholas ahlstrom,,MATH-1040,2017
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.58,0.33,0.09,charity watson,,MATH-1040,2017
+MATH,1050,400,Precalculus,0.0,0.0,0.0,0.0,0.0,0.71,0.2,0.09,charity watson,,MATH-1050,2017
+MATH,1060,1,Calculus of One Variable I,0.0,0.16,0.32,0.14,0.27,0.0,0.0,0.11,judith cottingham,,MATH-1060,2017
+MATH,1060,2,Calculus of One Variable I,0.02,0.33,0.2,0.16,0.22,0.0,0.0,0.07,judith cottingham,,MATH-1060,2017
+MATH,1060,3,Calculus of One Variable I,0.06,0.13,0.24,0.15,0.25,0.0,0.0,0.18,allen anderso guest,,MATH-1060,2017
+MATH,1060,5,Calculus of One Variable I,0.1,0.19,0.23,0.09,0.26,0.0,0.0,0.14,allen anderso guest,,MATH-1060,2017
+MATH,1060,7,Calculus of One Variable I,0.08,0.17,0.11,0.08,0.44,0.0,0.0,0.11,thowhida akther,,MATH-1060,2017
+MATH,1060,500,Calculus of One Variable I,0.59,0.21,0.21,0.0,0.0,0.0,0.0,0.0,laura dostert,,MATH-1060,2017
+MATH,1070,1,Differen and Integral Calculus,0.14,0.34,0.34,0.07,0.07,0.0,0.0,0.03,donna simms,,MATH-1070,2017
+MATH,1070,2,Differen and Integral Calculus,0.24,0.44,0.32,0.0,0.0,0.0,0.0,0.0,donna simms,,MATH-1070,2017
+MATH,1070,3,Differen and Integral Calculus,0.07,0.37,0.37,0.05,0.07,0.0,0.0,0.07,chase norman joyner,,MATH-1070,2017
+MATH,1070,5,Differen and Integral Calculus,0.08,0.23,0.33,0.23,0.03,0.0,0.0,0.1,stefan adam bock,,MATH-1070,2017
+MATH,1070,7,Differen and Integral Calculus,0.03,0.28,0.34,0.28,0.03,0.0,0.0,0.03,rebecca ramos,,MATH-1070,2017
+MATH,1080,1,Calculus of One Variable II,0.13,0.31,0.31,0.09,0.13,0.0,0.0,0.03,beth novick,,MATH-1080,2017
+MATH,1080,4,Calculus of One Variable II,0.15,0.41,0.1,0.08,0.13,0.0,0.0,0.13,sergey charnyi,,MATH-1080,2017
+MATH,1080,5,Calculus of One Variable II,0.19,0.35,0.19,0.07,0.14,0.0,0.0,0.07,mengying xiao,,MATH-1080,2017
+MATH,1080,7,Calculus of One Variable II,0.2,0.24,0.2,0.09,0.16,0.0,0.0,0.11,fun choi john chan,,MATH-1080,2017
+MATH,1080,8,Calculus of One Variable II,0.18,0.34,0.2,0.14,0.09,0.0,0.0,0.05,honghai xu,,MATH-1080,2017
+MATH,1080,10,Calculus of One Variable II,0.24,0.41,0.2,0.04,0.04,0.0,0.0,0.07,garrett dranichak,,MATH-1080,2017
+MATH,1080,11,Calculus of One Variable II,0.16,0.38,0.24,0.11,0.04,0.0,0.0,0.07,honghai xu,,MATH-1080,2017
+MATH,1080,12,Calculus of One Variable II,0.13,0.29,0.24,0.07,0.09,0.0,0.0,0.18,rui gong,,MATH-1080,2017
+MATH,1080,13,Calculus of One Variable II,0.14,0.32,0.25,0.11,0.11,0.0,0.0,0.07,alistair bentley,,MATH-1080,2017
+MATH,1080,16,Calculus of One Variable II,0.13,0.3,0.22,0.11,0.13,0.0,0.0,0.11,camille zerfas,,MATH-1080,2017
+MATH,1080,100,Calc of One Variable II (HON),0.64,0.18,0.0,0.0,0.0,0.0,0.0,0.18,beth novick,True,MATH-1080,2017
+MATH,1080,203,Calc of One Variable II (RiSE),0.2,0.28,0.33,0.13,0.0,0.0,0.0,0.07,kara ail stasikelis,,MATH-1080,2017
+MATH,1080,203,Calc of One Variable II,0.2,0.28,0.33,0.13,0.0,0.0,0.0,0.07,kara ail stasikelis,,MATH-1080,2017
+MATH,1080,206,Calc of One Variable II (RiSE),0.21,0.21,0.31,0.05,0.15,0.0,0.0,0.08,honghai xu,,MATH-1080,2017
+MATH,1080,206,Calc of One Variable II,0.21,0.21,0.31,0.05,0.15,0.0,0.0,0.08,honghai xu,,MATH-1080,2017
+MATH,1080,209,Calc of One Variable II,0.2,0.32,0.17,0.12,0.07,0.0,0.0,0.12,jonathon leverenz,,MATH-1080,2017
+MATH,1080,209,Calc of One Variable II (RiSE),0.2,0.32,0.17,0.12,0.07,0.0,0.0,0.12,jonathon leverenz,,MATH-1080,2017
+MATH,1080,214,Calc of One Variable II (RiSE),0.28,0.22,0.35,0.02,0.11,0.0,0.0,0.02,lauren pai mcintyre,,MATH-1080,2017
+MATH,1080,214,Calc of One Variable II,0.28,0.22,0.35,0.02,0.11,0.0,0.0,0.02,lauren pai mcintyre,,MATH-1080,2017
+MATH,1080,217,Calc of One Variable II,0.28,0.35,0.15,0.11,0.02,0.0,0.0,0.09,audrey nico devries,,MATH-1080,2017
+MATH,1080,218,Calc of One Variable II,0.24,0.37,0.2,0.09,0.09,0.0,0.0,0.02,ryan grove,,MATH-1080,2017
+MATH,1150,1,Contemp Math for Elem Teach I,0.5,0.27,0.19,0.0,0.04,0.0,0.0,0.0,charity watson,,MATH-1150,2017
+MATH,1160,1,Contemp Math for Elem Teach II,0.74,0.2,0.06,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1160,2017
+MATH,1160,2,Contemp Math for Elem Teach II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,allison stoddard,,MATH-1160,2017
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.84,0.12,0.04,marion hanna,,MATH-1990,2017
+MATH,2060,1,Calculus of Several Variables,0.23,0.4,0.14,0.11,0.09,0.0,0.0,0.03,hiram lopez valdez,,MATH-2060,2017
+MATH,2060,2,Calculus of Several Variables,0.15,0.32,0.09,0.06,0.18,0.0,0.0,0.21,timothy fra parrott,,MATH-2060,2017
+MATH,2060,3,Calculus of Several Variables,0.32,0.36,0.19,0.04,0.06,0.0,0.0,0.02,hiram lopez valdez,,MATH-2060,2017
+MATH,2060,4,Calculus of Several Variables,0.46,0.38,0.05,0.08,0.03,0.0,0.0,0.0,muhamm mohebujjaman,,MATH-2060,2017
+MATH,2060,5,Calculus of Several Variables,0.11,0.21,0.25,0.18,0.11,0.0,0.0,0.14,timothy fra parrott,,MATH-2060,2017
+MATH,2060,6,Calculus of Several Variables,0.08,0.56,0.19,0.0,0.11,0.0,0.0,0.06,sofya alekseeva,,MATH-2060,2017
+MATH,2060,7,Calculus of Several Variables,0.19,0.5,0.19,0.06,0.03,0.0,0.0,0.03,sofya alekseeva,,MATH-2060,2017
+MATH,2060,8,Calculus of Several Variables,0.44,0.33,0.1,0.04,0.04,0.0,0.0,0.04,martin joha schmoll,,MATH-2060,2017
+MATH,2060,9,Calculus of Several Variables,0.13,0.45,0.24,0.08,0.05,0.0,0.0,0.05,sofya alekseeva,,MATH-2060,2017
+MATH,2060,10,Calculus of Several Variables,0.0,0.21,0.16,0.11,0.37,0.0,0.0,0.16,jonathon leverenz,,MATH-2060,2017
+MATH,2060,500,Calculus of Several Variables,0.4,0.27,0.27,0.07,0.0,0.0,0.0,0.0,brian gloor,,MATH-2060,2017
+MATH,2070,1,Business Calculus II,0.28,0.38,0.2,0.13,0.0,0.0,0.0,0.03,jennifer mari hanna,,MATH-2070,2017
+MATH,2070,2,Business Calculus II,0.3,0.45,0.2,0.0,0.03,0.0,0.0,0.03,tony thanh nguyen,,MATH-2070,2017
+MATH,2070,3,Business Calculus II,0.23,0.33,0.18,0.15,0.03,0.0,0.0,0.1,thanh thien to,,MATH-2070,2017
+MATH,2070,4,Business Calculus II,0.53,0.28,0.13,0.08,0.0,0.0,0.0,0.0,jennifer mari hanna,,MATH-2070,2017
+MATH,2070,5,Business Calculus II,0.28,0.38,0.2,0.1,0.05,0.0,0.0,0.0,allison stoddard,,MATH-2070,2017
+MATH,2070,6,Business Calculus II,0.33,0.25,0.23,0.08,0.13,0.0,0.0,0.0,tony thanh nguyen,,MATH-2070,2017
+MATH,2070,7,Business Calculus II,0.65,0.15,0.13,0.05,0.0,0.0,0.0,0.03,jennifer mari hanna,,MATH-2070,2017
+MATH,2070,8,Business Calculus II,0.29,0.24,0.21,0.1,0.1,0.0,0.0,0.07,judith irene mcknew,,MATH-2070,2017
+MATH,2070,9,Business Calculus II,0.23,0.36,0.13,0.08,0.05,0.0,0.0,0.15,judith irene mcknew,,MATH-2070,2017
+MATH,2070,10,Business Calculus II,0.2,0.39,0.24,0.1,0.05,0.0,0.0,0.02,daniel kuzbary,,MATH-2070,2017
+MATH,2070,11,Business Calculus II,0.31,0.36,0.1,0.08,0.1,0.0,0.0,0.05,jing li,,MATH-2070,2017
+MATH,2070,12,Business Calculus II,0.38,0.28,0.15,0.05,0.08,0.0,0.0,0.05,neil calkin,,MATH-2070,2017
+MATH,2070,13,Business Calculus II,0.35,0.35,0.18,0.03,0.08,0.0,0.0,0.03,haodong li,,MATH-2070,2017
+MATH,2070,14,Business Calculus II,0.23,0.36,0.36,0.0,0.0,0.0,0.0,0.05,shanshan jia,,MATH-2070,2017
+MATH,2070,15,Business Calculus II,0.25,0.35,0.23,0.05,0.0,0.0,0.0,0.13,aaro ramirez flores,,MATH-2070,2017
+MATH,2070,16,Business Calculus II,0.4,0.35,0.08,0.08,0.08,0.0,0.0,0.03,stephen peele,,MATH-2070,2017
+MATH,2080,1,Intro to Ordin Diff Equations,0.09,0.3,0.17,0.13,0.04,0.0,0.0,0.26,terri johnson,,MATH-2080,2017
+MATH,2080,2,Intro to Ordin Diff Equations,0.37,0.49,0.09,0.0,0.06,0.0,0.0,0.0,oleg yordanov,,MATH-2080,2017
+MATH,2080,4,Intro to Ordin Diff Equations,0.08,0.05,0.26,0.03,0.24,0.0,0.0,0.34,terri johnson,,MATH-2080,2017
+MATH,2080,5,Intro to Ordin Diff Equations,0.53,0.21,0.21,0.03,0.0,0.0,0.0,0.03,timothy ch teitloff,,MATH-2080,2017
+MATH,2080,6,Intro to Ordin Diff Equations,0.47,0.37,0.05,0.05,0.0,0.0,0.0,0.07,oleg yordanov,,MATH-2080,2017
+MATH,2080,7,Intro to Ordin Diff Equations,0.06,0.15,0.21,0.06,0.15,0.0,0.0,0.38,terri johnson,,MATH-2080,2017
+MATH,2080,8,Intro to Ordin Diff Equations,0.26,0.26,0.09,0.18,0.15,0.0,0.0,0.06,julie lassiter,,MATH-2080,2017
+MATH,2080,9,Intro to Ordin Diff Equations,0.62,0.1,0.23,0.0,0.0,0.0,0.0,0.05,timothy ch teitloff,,MATH-2080,2017
+MATH,2080,10,Intro to Ordin Diff Equations,0.33,0.36,0.13,0.08,0.1,0.0,0.0,0.0,irina viktorova,,MATH-2080,2017
+MATH,2080,11,Intro to Ordin Diff Equations,0.25,0.19,0.16,0.19,0.16,0.0,0.0,0.06,julie lassiter,,MATH-2080,2017
+MATH,2080,12,Intro to Ordin Diff Equations,0.36,0.27,0.21,0.06,0.0,0.0,0.0,0.09,shari prevost,,MATH-2080,2017
+MATH,2080,13,Intro to Ordin Diff Equations,0.28,0.35,0.2,0.08,0.08,0.0,0.0,0.03,irina viktorova,,MATH-2080,2017
+MATH,2080,14,Intro to Ordin Diff Equations,0.24,0.29,0.24,0.0,0.08,0.0,0.0,0.16,jonathon leverenz,,MATH-2080,2017
+MATH,2080,15,Intro to Ordin Diff Equations,0.19,0.36,0.17,0.03,0.14,0.0,0.0,0.11,shari prevost,,MATH-2080,2017
+MATH,2080,16,Intro to Ordin Diff Equations,0.38,0.2,0.29,0.09,0.0,0.0,0.0,0.04,irina viktorova,,MATH-2080,2017
+MATH,2080,17,Intro to Ordin Diff Equations,0.19,0.25,0.28,0.09,0.06,0.0,0.0,0.13,jeong rock yoon,,MATH-2080,2017
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.62,0.31,0.04,0.0,0.04,0.0,0.0,0.0,brian fralix,True,MATH-2080,2017
+MATH,2160,1,Geometry for Elem Sch Teachers,0.6,0.25,0.1,0.05,0.0,0.0,0.0,0.0,allison stoddard,,MATH-2160,2017
+MATH,3020,1,Stat for Science & Engineering,0.33,0.4,0.14,0.05,0.05,0.0,0.0,0.02,william bridges,,MATH-3020,2017
+MATH,3020,2,Stat for Science & Engineering,0.66,0.29,0.03,0.0,0.0,0.0,0.0,0.03,xiyan tan,,MATH-3020,2017
+MATH,3020,3,Stat for Science & Engineering,0.54,0.18,0.18,0.03,0.08,0.0,0.0,0.0,yisu jia,,MATH-3020,2017
+MATH,3020,4,Stat for Science & Engineering,0.84,0.05,0.0,0.0,0.0,0.0,0.0,0.11,brandon gra goodell,,MATH-3020,2017
+MATH,3020,5,Stat for Science & Engineering,0.5,0.31,0.12,0.02,0.05,0.0,0.0,0.0,"koshy chenthittayil,",,MATH-3020,2017
+MATH,3020,6,Stat for Science & Engineering,0.35,0.32,0.11,0.11,0.05,0.0,0.0,0.05,prab withana gamage,,MATH-3020,2017
+MATH,3020,7,Stat for Science & Engineering,0.4,0.33,0.12,0.07,0.07,0.0,0.0,0.0,yinggu bao,,MATH-3020,2017
+MATH,3020,8,Stat for Science & Engineering,0.25,0.42,0.22,0.06,0.03,0.0,0.0,0.03,ellen hepfe breazel,,MATH-3020,2017
+MATH,3020,9,Stat for Science & Engineering,0.3,0.33,0.12,0.0,0.09,0.0,0.0,0.15,paul james cubre,,MATH-3020,2017
+MATH,3080,1,College Geometry,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,carlos gomez,,MATH-3080,2017
+MATH,3110,1,Linear Algebra,0.45,0.18,0.24,0.08,0.03,0.0,0.0,0.03,amy christine grady,,MATH-3110,2017
+MATH,3110,2,Linear Algebra,0.15,0.38,0.15,0.18,0.05,0.0,0.0,0.08,amy christine grady,,MATH-3110,2017
+MATH,3110,3,Linear Algebra,0.21,0.3,0.12,0.09,0.12,0.0,0.0,0.15,xuhong gao,,MATH-3110,2017
+MATH,3110,4,Linear Algebra,0.3,0.5,0.1,0.05,0.05,0.0,0.0,0.0,hui xue,,MATH-3110,2017
+MATH,3110,5,Linear Algebra,0.11,0.46,0.17,0.06,0.14,0.0,0.0,0.06,michael adam burr,,MATH-3110,2017
+MATH,3110,6,Linear Algebra,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,wayne goddard,,MATH-3110,2017
+MATH,3110,7,Linear Algebra,0.24,0.24,0.21,0.09,0.06,0.0,0.0,0.15,neil calkin,,MATH-3110,2017
+MATH,3110,200,Linear Algebra,0.4,0.33,0.07,0.07,0.07,0.0,0.0,0.07,beth novick,,MATH-3110,2017
+MATH,3150,1,Adv Top in Math for Elem Teach,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,andrew mic tyminski,,MATH-3150,2017
+MATH,3190,1,Introduction to Proof,0.1,0.29,0.19,0.1,0.0,0.0,0.0,0.33,james ba coykendall,,MATH-3190,2017
+MATH,3190,2,Introduction to Proof,0.18,0.36,0.32,0.05,0.05,0.0,0.0,0.05,james ba coykendall,,MATH-3190,2017
+MATH,3600,1,Intermediate Math Computing,0.78,0.06,0.06,0.0,0.11,0.0,0.0,0.0,mark cawood,,MATH-3600,2017
+MATH,3600,2,Intermediate Math Computing,0.67,0.17,0.0,0.06,0.06,0.0,0.0,0.06,mark cawood,,MATH-3600,2017
+MATH,3650,1,Numerical Mthds for Engineers,0.2,0.26,0.17,0.14,0.14,0.0,0.0,0.09,fei xue,,MATH-3650,2017
+MATH,3650,2,Numerical Mthds for Engineers,0.33,0.21,0.29,0.08,0.04,0.0,0.0,0.04,fei xue,,MATH-3650,2017
+MATH,3650,3,Numerical Mthds for Engineers,0.53,0.29,0.06,0.0,0.06,0.0,0.0,0.06,timo johann heister,,MATH-3650,2017
+MATH,3650,4,Numerical Mthds for Engineers,0.35,0.19,0.15,0.08,0.04,0.0,0.0,0.19,christopher cox,,MATH-3650,2017
+MATH,4000,1,Theory of Probability,0.28,0.31,0.18,0.1,0.08,0.0,0.0,0.05,ling ma,,MATH-4000,2017
+MATH,4030,1,Intro to Statistical Theory,0.36,0.45,0.14,0.05,0.0,0.0,0.0,0.0,xiaoqian sun,,MATH-4030,2017
+MATH,4060,1,Sampling Theory and Methods,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,,MATH-4060,2017
+MATH,4070,1,Regress & Time-Series Analysis,0.45,0.24,0.21,0.03,0.0,0.0,0.0,0.07,colin gallagher,,MATH-4070,2017
+MATH,4100,1,Number Theory,0.5,0.1,0.2,0.1,0.0,0.0,0.0,0.1,hui xue,,MATH-4100,2017
+MATH,4120,1,Algebra I,0.08,0.11,0.39,0.08,0.06,0.0,0.0,0.28,sea sather-wagstaff,,MATH-4120,2017
+MATH,4190,1,Discrete Math Structures I,0.57,0.25,0.09,0.02,0.05,0.0,0.0,0.02,beth novick,,MATH-4190,2017
+MATH,4310,1,Theory of Interest,0.44,0.39,0.11,0.0,0.06,0.0,0.0,0.0, erwin walker,,MATH-4310,2017
+MATH,4320,1,Actuarial Science Seminar II,0.6,0.07,0.27,0.0,0.0,0.0,0.0,0.07, erwin walker,,MATH-4320,2017
+MATH,4340,1,Adv Engineering Mathematics,0.15,0.15,0.38,0.12,0.15,0.0,0.0,0.04,vincent ervin,,MATH-4340,2017
+MATH,4340,2,Adv Engineering Mathematics,0.06,0.16,0.38,0.13,0.09,0.0,0.0,0.19,eleanor jenkins,,MATH-4340,2017
+MATH,4400,1,Linear Programming,0.31,0.27,0.19,0.15,0.0,0.0,0.0,0.08,boshi yang,,MATH-4400,2017
+MATH,4410,1,Intro to Stochastic Models,0.41,0.24,0.35,0.0,0.0,0.0,0.0,0.0,peter kiessler,,MATH-4410,2017
+MATH,4530,1,Advanced Calculus I,0.32,0.05,0.21,0.16,0.11,0.0,0.0,0.16,james peterson,,MATH-4530,2017
+MATH,4540,1,Advanced Calculus II,0.25,0.32,0.21,0.14,0.04,0.0,0.0,0.04,james peterson,,MATH-4540,2017
+MATH,4600,1,Intro to Numerical Analysis I,0.1,0.4,0.2,0.1,0.0,0.0,0.0,0.2,eleanor jenkins,,MATH-4600,2017
+MATH,6340,1,Adv Engineering Mathematics,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,vincent ervin,,MATH-6340,2017
+MATH,8030,1,Stochastic Processes,0.55,0.36,0.0,0.0,0.05,0.0,0.0,0.05,xin liu,,MATH-8030,2017
+MATH,8040,1,Statistical Inference,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,christopher mcmahan,,MATH-8040,2017
+MATH,8050,1,Data Analysis,0.42,0.47,0.0,0.0,0.0,0.0,0.0,0.11,calvin williams,,MATH-8050,2017
+MATH,8090,1,Time Series Analysis,0.56,0.22,0.22,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-8090,2017
+MATH,8100,1,Mathematical Programming,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,,MATH-8100,2017
+MATH,8130,1,Advanced Linear Programming,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,,MATH-8130,2017
+MATH,8210,1,Linear Analysis,0.33,0.56,0.0,0.0,0.11,0.0,0.0,0.0,taufiquar rahm khan,,MATH-8210,2017
+MATH,8220,1,Measure and Integration,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,martin joha schmoll,,MATH-8220,2017
+MATH,8260,1,Partial Differential Equations,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,qingshan chen,,MATH-8260,2017
+MATH,8530,1,Matrix Analysis,0.48,0.4,0.04,0.0,0.0,0.0,0.0,0.08,matthew macauley,,MATH-8530,2017
+MATH,8600,1,Intro to Scientific Computing,0.45,0.35,0.1,0.0,0.0,0.0,0.0,0.1,qingshan chen,,MATH-8600,2017
+MATH,8660,1,Finite Element Method,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,vincent ervin,,MATH-8660,2017
+MATH,9000,2,Prof Devel in Math Sciences,0.0,0.0,0.0,0.0,0.0,0.91,0.04,0.04,meredith nicol burr,,MATH-9000,2017
+MBA,8030,1,Stat Analy of Bus Op,0.3,0.35,0.16,0.0,0.16,0.0,0.0,0.02,janis miller,,MBA-8030,2017
+MBA,8060,1,Operations Mgt,0.58,0.33,0.04,0.0,0.02,0.0,0.0,0.02, sridharan,,MBA-8060,2017
+MBA,8060,20,Operations Mgt,0.69,0.15,0.12,0.0,0.04,0.0,0.0,0.0, sridharan,,MBA-8060,2017
+MBA,8070,1,Financial Management,0.56,0.3,0.14,0.0,0.0,0.0,0.0,0.0,melvin stith,,MBA-8070,2017
+MBA,8070,2,Financial Management,0.44,0.39,0.12,0.0,0.0,0.0,0.0,0.05,melvin stith,,MBA-8070,2017
+MBA,8090,1,Org Beh & Hum Res Mg,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.02,kristin dam scott,,MBA-8090,2017
+MBA,8090,2,Org Beh & Hum Res Mg,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,kristin dam scott,,MBA-8090,2017
+MBA,8190,1,Intro to Acc and Fin,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,,MBA-8190,2017
+MBA,8190,2,Intro to Acc and Fin,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,annieka philo,,MBA-8190,2017
+MBA,8290,1,Marketing Foundation,0.68,0.23,0.04,0.0,0.0,0.0,0.0,0.04,gary hunter,,MBA-8290,2017
+MBA,8330,1,Real Estate Investmt,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,,MBA-8330,2017
+MBA,8370,1,Legal Environ of Bus,0.48,0.53,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2017
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,,MBA-8400,2017
+MBA,8430,10,Entrepreneurial Accounting,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,,MBA-8430,2017
+MBA,8450,1,Technology & Innovation Mgt,0.23,0.77,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8450,2017
+MBA,8470,1,New Venture Creation,0.64,0.27,0.05,0.0,0.05,0.0,0.0,0.0,elizabeth er powell,,MBA-8470,2017
+MBA,8510,10,Bus Operations & Logistics,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,james liddle,,MBA-8510,2017
+MBA,8540,1,Mgrl Accounting,0.39,0.57,0.05,0.0,0.0,0.0,0.0,0.0,james mil kohlmeyer,,MBA-8540,2017
+MBA,8540,2,Mgrl Accounting,0.56,0.4,0.02,0.0,0.0,0.0,0.0,0.02,james mil kohlmeyer,,MBA-8540,2017
+MBA,8540,3,Mgrl Accounting,0.26,0.43,0.22,0.0,0.0,0.0,0.0,0.09,james mil kohlmeyer,,MBA-8540,2017
+MBA,8590,1,Mgr Decision Model,0.37,0.3,0.21,0.0,0.05,0.0,0.0,0.07,magda gabriela sava,,MBA-8590,2017
+MBA,8590,2,Mgr Decision Model,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,sara elizabet yoder,,MBA-8590,2017
+MBA,8600,1,Advanced Marketing Strategy,0.22,0.61,0.17,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2017
+MBA,8610,1,Information Systems,0.28,0.7,0.03,0.0,0.0,0.0,0.0,0.0,varun grover,,MBA-8610,2017
+MBA,8610,2,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MBA-8610,2017
+MBA,8620,1,Managerial Economics,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,,MBA-8620,2017
+MBA,8720,1,Entrepr Finance,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,raymond dunbar,,MBA-8720,2017
+MBA,8720,2,Entrepr Finance,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8720,2017
+MBA,8740,1,Managing Cont Impvmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MBA-8740,2017
+MBA,8750,1,Enterprise Develpmnt,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8750,2017
+MBA,8990,1,Advanced Leadership,0.95,0.0,0.02,0.0,0.0,0.0,0.0,0.02,gail depriest,,MBA-8990,2017
+MBA,8990,3,Service Innovation,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,aleda marie roth,,MBA-8990,2017
+MBA,8990,4,Bus. Sport. Enter.,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,,MBA-8990,2017
+MBA,8990,20,Analytics & Application,0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,heshan sun,,MBA-8990,2017
+ME,2000,1,Sophomore Seminar,0.92,0.05,0.0,0.0,0.01,0.0,0.0,0.02,donald beasley,,ME-2000,2017
+ME,2010,1,Statics & Dynamics,0.06,0.26,0.25,0.14,0.17,0.0,0.0,0.13,marisa kikendal orr,,ME-2010,2017
+ME,2010,2,Statics & Dynamics,0.06,0.29,0.17,0.13,0.23,0.0,0.0,0.12,paul joseph,,ME-2010,2017
+ME,2030,1,Founda Th/Fl Syst,0.16,0.31,0.27,0.16,0.05,0.0,0.0,0.05,jay ochterbeck,,ME-2030,2017
+ME,2030,2,Founda Th/Fl Syst,0.07,0.2,0.4,0.21,0.05,0.0,0.0,0.06,john saylor,,ME-2030,2017
+ME,2040,1,Mechanics of Materials,0.36,0.53,0.03,0.02,0.05,0.0,0.0,0.02,jorge iva rodriguez,,ME-2040,2017
+ME,2040,2,Mechanics of Materials,0.12,0.49,0.37,0.02,0.0,0.0,0.0,0.0,gang li,,ME-2040,2017
+ME,2040,3,Mechanics of Materials,0.33,0.47,0.18,0.0,0.02,0.0,0.0,0.0,garrett pataky,,ME-2040,2017
+ME,2040,302,Mechanics of Materials (HON),0.55,0.36,0.0,0.09,0.0,0.0,0.0,0.0,gang li,True,ME-2040,2017
+ME,2220,2,Mechanical Engineering Lab I,0.53,0.33,0.07,0.0,0.0,0.0,0.0,0.07,todd schweisinger,,ME-2220,2017
+ME,2220,3,Mechanical Engineering Lab I,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,5,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,6,Mechanical Engineering Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,7,Mechanical Engineering Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,8,Mechanical Engineering Lab I,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,9,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,10,Mechanical Engineering Lab I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,13,Mechanical Engineering Lab I,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,2220,14,Mechanical Engineering Lab I,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,todd schweisinger,,ME-2220,2017
+ME,2220,15,Mechanical Engineering Lab I,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-2220,2017
+ME,3030,1,Thermodynamics,0.23,0.55,0.15,0.05,0.0,0.0,0.0,0.03,yiqiang han,,ME-3030,2017
+ME,3030,2,Thermodynamics,0.17,0.6,0.17,0.02,0.0,0.0,0.0,0.05,yiqiang han,,ME-3030,2017
+ME,3040,1,Heat Transfer,0.08,0.37,0.34,0.05,0.06,0.0,0.0,0.1,jean-marc delhaye,,ME-3040,2017
+ME,3040,2,Heat Transfer,0.19,0.32,0.4,0.04,0.04,0.0,0.0,0.01,jean-marc delhaye,,ME-3040,2017
+ME,3050,1,Model/an Dy Syst,0.2,0.47,0.2,0.0,0.08,0.0,0.0,0.05,phanin tallapragada,,ME-3050,2017
+ME,3050,2,Model/an Dy Syst,0.21,0.5,0.21,0.07,0.01,0.0,0.0,0.0,joshua bostwick,,ME-3050,2017
+ME,3060,1,Fund Machine Design,0.54,0.37,0.06,0.0,0.0,0.0,0.0,0.04,oliver myers,,ME-3060,2017
+ME,3060,2,Fund Machine Design,0.34,0.44,0.17,0.02,0.01,0.0,0.0,0.01,paul jeffrey meyer,,ME-3060,2017
+ME,3070,1,Found of Mechanical Systems,0.6,0.24,0.09,0.0,0.05,0.0,0.0,0.02,jorge iva rodriguez,,ME-3070,2017
+ME,3070,2,Found of Mechanical Systems,0.19,0.56,0.22,0.04,0.0,0.0,0.0,0.0,gregory mocko,,ME-3070,2017
+ME,3080,1,Fluid Mechanics,0.13,0.58,0.24,0.04,0.0,0.0,0.0,0.0,daniel fant,,ME-3080,2017
+ME,3080,2,Fluid Mechanics,0.23,0.38,0.27,0.08,0.02,0.0,0.0,0.02,xiangchun xuan,,ME-3080,2017
+ME,3100,1,Thermo/Heat Transfer,0.39,0.39,0.13,0.0,0.0,0.0,0.0,0.09,yiqiang han,,ME-3100,2017
+ME,3120,1,Manuf Processes,0.19,0.47,0.3,0.03,0.01,0.0,0.0,0.01,hong seok choi,,ME-3120,2017
+ME,3330,1,Mechanical Engineering Lab II,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,3330,2,Mechanical Engineering Lab II,0.25,0.5,0.19,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-3330,2017
+ME,3330,3,Mechanical Engineering Lab II,0.25,0.63,0.06,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-3330,2017
+ME,3330,4,Mechanical Engineering Lab II,0.29,0.5,0.07,0.0,0.14,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,3330,5,Mechanical Engineering Lab II,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,3330,6,Mechanical Engineering Lab II,0.31,0.5,0.13,0.0,0.0,0.0,0.0,0.06,todd schweisinger,,ME-3330,2017
+ME,3330,7,Mechanical Engineering Lab II,0.31,0.5,0.19,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,3330,8,Mechanical Engineering Lab II,0.27,0.47,0.2,0.0,0.07,0.0,0.0,0.0,todd schweisinger,,ME-3330,2017
+ME,4000,1,Senior Seminar,0.84,0.12,0.01,0.03,0.0,0.0,0.0,0.0,donald beasley,,ME-4000,2017
+ME,4010,1,Mech Engr Design,0.54,0.34,0.1,0.0,0.02,0.0,0.0,0.0,cameron turner,,ME-4010,2017
+ME,4020,2,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,,ME-4020,2017
+ME,4020,3,Intern in Engr Des,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lonny thompson,,ME-4020,2017
+ME,4020,4,Intern in Engr Des,0.53,0.27,0.2,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-4020,2017
+ME,4020,5,Intern in Engr Des,0.4,0.27,0.33,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2017
+ME,4020,6,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jean-marc delhaye,,ME-4020,2017
+ME,4020,7,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-4020,2017
+ME,4020,9,Intern in Engr Des,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,,ME-4020,2017
+ME,4030,1,Control Dynamic Systems,0.31,0.23,0.29,0.14,0.03,0.0,0.0,0.0,suyi li,,ME-4030,2017
+ME,4030,2,Control Dynamic Systems,0.35,0.53,0.1,0.03,0.0,0.0,0.0,0.0,yue wang,,ME-4030,2017
+ME,4170,1,Mechatronic Sys,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4170,2017
+ME,4180,1,F E A in M E Design,0.24,0.48,0.2,0.08,0.0,0.0,0.0,0.0,gang li,,ME-4180,2017
+ME,4220,1,Design Gas Turbines,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,abhijit som,,ME-4220,2017
+ME,4260,1,Nuclear Energy,0.36,0.36,0.29,0.0,0.0,0.0,0.0,0.0,richard watkins,,ME-4260,2017
+ME,4300,1,Mech Comp Materials,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,huijuan zhao,,ME-4300,2017
+ME,4440,1,Mechanical Engineering Lab III,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2017
+ME,4440,2,Mechanical Engineering Lab III,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2017
+ME,4440,3,Mechanical Engineering Lab III,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2017
+ME,4440,4,Mechanical Engineering Lab III,0.08,0.83,0.08,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2017
+ME,4440,5,Mechanical Engineering Lab III,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2017
+ME,4440,7,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2017
+ME,4930,5,Sel.Topics in ME - Rapid Proto,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4930,2017
+ME,4930,34,Selected Topics ME (Cardio),0.15,0.62,0.15,0.0,0.0,0.0,0.0,0.08,ethan kung,,ME-4930,2017
+ME,4930,36,Sel. Topics in ME (BioDesgin),0.48,0.48,0.05,0.0,0.0,0.0,0.0,0.0,michael porter,,ME-4930,2017
+ME,4930,39,Sel Topics ME (Solar Energy),0.4,0.46,0.06,0.0,0.0,0.0,0.0,0.09,daniel fant,,ME-4930,2017
+ME,6300,1,Mech Comp Materials,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,,ME-6300,2017
+ME,6320,1,Adv Strength of Matl,0.14,0.71,0.14,0.0,0.0,0.0,0.0,0.0,michael porter,,ME-6320,2017
+ME,8120,1,Exp Meth Thermal Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chenning tong,,ME-8120,2017
+ME,8190,1,Cp Meth in Therm Sc,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,richard miller,,ME-8190,2017
+ME,8200,1,Mod Cont Engr,0.47,0.36,0.14,0.0,0.0,0.0,0.0,0.03,ardalan vahidi,,ME-8200,2017
+ME,8200,401,Mod Cont Engr,0.23,0.54,0.15,0.0,0.08,0.0,0.0,0.0,ardalan vahidi,,ME-8200,2017
+ME,8310,1,Convective Ht Trans,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,xin zhao,,ME-8310,2017
+ME,8370,1,Theory of Elast I,0.26,0.48,0.22,0.0,0.04,0.0,0.0,0.0,nicole gise coutris,,ME-8370,2017
+MGT,2010,1,Principles of Management,0.39,0.37,0.17,0.03,0.03,0.0,0.0,0.01,katherine clark,,MGT-2010,2017
+MGT,2010,2,Principles of Management,0.45,0.34,0.14,0.03,0.03,0.0,0.0,0.03,katherine clark,,MGT-2010,2017
+MGT,2010,3,Principles of Management,0.38,0.31,0.19,0.06,0.03,0.0,0.0,0.03,katherine clark,,MGT-2010,2017
+MGT,2010,5,Principles of Management,0.44,0.37,0.15,0.02,0.01,0.0,0.0,0.0,tina robbins,,MGT-2010,2017
+MGT,2010,6,Principles of Management,0.36,0.46,0.16,0.0,0.0,0.0,0.0,0.01,tina robbins,,MGT-2010,2017
+MGT,2010,7,Principles of Management,0.41,0.41,0.15,0.0,0.0,0.0,0.0,0.03,tina robbins,,MGT-2010,2017
+MGT,2010,8,Principles of Management,0.43,0.44,0.06,0.03,0.03,0.0,0.0,0.01,tina robbins,,MGT-2010,2017
+MGT,2010,10,Principles of Management,0.3,0.35,0.26,0.07,0.02,0.0,0.0,0.0,ashley will parnell,,MGT-2010,2017
+MGT,2010,11,Principles of Management,0.28,0.44,0.21,0.05,0.0,0.0,0.0,0.03,ashley will parnell,,MGT-2010,2017
+MGT,2180,1,Management PC Applications,0.52,0.28,0.11,0.04,0.05,0.0,0.0,0.01,ryan toole,,MGT-2180,2017
+MGT,2180,2,Management PC Applications,0.51,0.36,0.06,0.02,0.02,0.0,0.0,0.02,ryan toole,,MGT-2180,2017
+MGT,2180,3,Management PC Applications,0.58,0.29,0.08,0.0,0.02,0.0,0.0,0.03,ryan toole,,MGT-2180,2017
+MGT,2180,4,Management PC Applications,0.48,0.34,0.11,0.02,0.02,0.0,0.0,0.04,ryan toole,,MGT-2180,2017
+MGT,2970,1,How to Start a Startup,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,john michael hannon,,MGT-2970,2017
+MGT,2970,2,How to Start a Startup,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,john michael hannon,,MGT-2970,2017
+MGT,2970,4,How to Start a Startup,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,,MGT-2970,2017
+MGT,2970,5,CI in Management (Film Study),0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,john michael hannon,,MGT-2970,2017
+MGT,3070,1,Human Resource Management,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2017
+MGT,3070,2,Human Resource Management,0.68,0.25,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2017
+MGT,3070,3,Human Resource Management,0.65,0.28,0.05,0.0,0.03,0.0,0.0,0.0,michael cole,,MGT-3070,2017
+MGT,3070,4,Human Resource Management,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2017
+MGT,3070,6,Human Resource Management,0.41,0.51,0.05,0.0,0.0,0.0,0.0,0.03,leonard jos spooner,,MGT-3070,2017
+MGT,3100,1,Intermed Business Statistics,0.14,0.19,0.2,0.12,0.15,0.0,0.0,0.2,sara elizabet yoder,,MGT-3100,2017
+MGT,3100,2,Intermed Business Statistics,0.1,0.24,0.26,0.06,0.16,0.0,0.0,0.18,sara elizabet yoder,,MGT-3100,2017
+MGT,3100,3,Intermed Business Statistics,0.5,0.32,0.11,0.05,0.0,0.0,0.0,0.03,wenxi pu,,MGT-3100,2017
+MGT,3100,4,Intermed Business Statistics,0.77,0.21,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MGT-3100,2017
+MGT,3100,5,Intermed Business Statistics,0.44,0.28,0.18,0.1,0.0,0.0,0.0,0.0,daniel nielubowicz,,MGT-3100,2017
+MGT,3100,6,Intermed Business Statistics,0.19,0.28,0.22,0.0,0.11,0.0,0.0,0.19,magda gabriela sava,,MGT-3100,2017
+MGT,3100,7,Intermed Business Statistics,0.52,0.27,0.18,0.02,0.0,0.0,0.0,0.0,dan jiang,,MGT-3100,2017
+MGT,3120,1,Decision Models for Management,0.45,0.32,0.19,0.0,0.03,0.0,0.0,0.01,mark mcknew,,MGT-3120,2017
+MGT,3120,2,Decision Models for Management,0.51,0.25,0.12,0.06,0.03,0.0,0.0,0.03,mark mcknew,,MGT-3120,2017
+MGT,3150,1,New Venture Creation,0.38,0.55,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth er powell,,MGT-3150,2017
+MGT,3180,1,Mgt of Info Systems,0.53,0.43,0.05,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,,MGT-3180,2017
+MGT,3180,2,Mgt of Info Systems,0.77,0.16,0.07,0.0,0.0,0.0,0.0,0.0,kevin dani matthews,,MGT-3180,2017
+MGT,3180,3,Mgt of Info Systems,0.19,0.75,0.06,0.0,0.0,0.0,0.0,0.0,heshan sun,,MGT-3180,2017
+MGT,3180,4,Mgt of Info Systems,0.3,0.6,0.08,0.0,0.03,0.0,0.0,0.0,roopa raman,,MGT-3180,2017
+MGT,3500,1,Intro to Business Analytics,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,siyuan li,,MGT-3500,2017
+MGT,3900,1,Ops Mgt,0.46,0.15,0.15,0.1,0.05,0.0,0.0,0.08,berna quiroga gomez,,MGT-3900,2017
+MGT,3900,2,Ops Mgt,0.13,0.23,0.51,0.1,0.0,0.0,0.0,0.03,niratc tungtisanont,,MGT-3900,2017
+MGT,3900,3,Ops Mgt,0.15,0.48,0.25,0.13,0.0,0.0,0.0,0.0,remi charpin,,MGT-3900,2017
+MGT,3900,4,Ops Mgt,0.09,0.57,0.28,0.02,0.04,0.0,0.0,0.0,zachary mo leffakis,,MGT-3900,2017
+MGT,3900,5,Ops Mgt,0.2,0.1,0.43,0.13,0.08,0.0,0.0,0.08,berna quiroga gomez,,MGT-3900,2017
+MGT,4000,2,Mgt of Organizational Behavior,0.73,0.25,0.0,0.0,0.0,0.0,0.0,0.03,michael cole,,MGT-4000,2017
+MGT,4000,3,Mgt of Organizational Behavior,0.43,0.28,0.28,0.0,0.03,0.0,0.0,0.0,philip roth,,MGT-4000,2017
+MGT,4000,4,Mgt of Organizational Behavior,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2017
+MGT,4020,1,Ops Pln and Ctl,0.05,0.45,0.41,0.05,0.05,0.0,0.0,0.0,zachary mo leffakis,,MGT-4020,2017
+MGT,4080,1,Lean Operations,0.32,0.45,0.18,0.0,0.05,0.0,0.0,0.0,zachary mo leffakis,,MGT-4080,2017
+MGT,4110,1,Project Management,0.38,0.45,0.1,0.0,0.05,0.0,0.0,0.03,russell purvis,,MGT-4110,2017
+MGT,4120,1,Supplier Management,0.13,0.51,0.36,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4120,2017
+MGT,4150,1,Business Strategy,0.43,0.58,0.0,0.0,0.0,0.0,0.0,0.0,dane patric blevins,,MGT-4150,2017
+MGT,4150,2,Business Strategy,0.53,0.45,0.03,0.0,0.0,0.0,0.0,0.0,dane patric blevins,,MGT-4150,2017
+MGT,4150,3,Business Strategy,0.26,0.57,0.14,0.0,0.0,0.0,0.0,0.02,zeki simsek,,MGT-4150,2017
+MGT,4150,4,Business Strategy,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2017
+MGT,4150,5,Business Strategy,0.32,0.29,0.32,0.05,0.02,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2017
+MGT,4150,6,Business Strategy,0.41,0.48,0.09,0.0,0.02,0.0,0.0,0.0,james liddle,,MGT-4150,2017
+MGT,4150,7,Business Strategy,0.46,0.52,0.02,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2017
+MGT,4150,8,Business Strategy,0.5,0.48,0.02,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2017
+MGT,4160,1,Special Topics Hr,0.4,0.45,0.1,0.0,0.03,0.0,0.0,0.03,kristin dam scott,,MGT-4160,2017
+MGT,4230,1,Intern Bus Mgt,0.35,0.5,0.08,0.05,0.0,0.0,0.0,0.03,janis miller,,MGT-4230,2017
+MGT,4230,2,Intern Bus Mgt,0.36,0.38,0.24,0.02,0.0,0.0,0.0,0.0,james liddle,,MGT-4230,2017
+MGT,4230,3,Intern Bus Mgt,0.18,0.23,0.48,0.03,0.03,0.0,0.0,0.08,wayne stewart,,MGT-4230,2017
+MGT,4230,4,Intern Bus Mgt,0.1,0.36,0.38,0.0,0.08,0.0,0.0,0.08,wayne stewart,,MGT-4230,2017
+MGT,4240,1,Global Supply Chain,0.19,0.58,0.19,0.0,0.0,0.0,0.0,0.03,yann ferrand,,MGT-4240,2017
+MGT,4310,1,Emp Rights & Resp,0.35,0.56,0.09,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-4310,2017
+MGT,4350,1,Pers Interviewing,0.25,0.43,0.25,0.03,0.05,0.0,0.0,0.0,philip roth,,MGT-4350,2017
+MGT,4520,1,Business Analysis,0.15,0.56,0.23,0.03,0.0,0.0,0.0,0.03,roopa raman,,MGT-4520,2017
+MGT,4550,1,Emerging I T Trends,0.41,0.49,0.1,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MGT-4550,2017
+MGT,4560,1,Business Info Mgt,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,siyuan li,,MGT-4560,2017
+MGT,8120,1,Supply Chain Mgt,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,yann ferrand,,MGT-8120,2017
+MICR,3050,1,General Microbiology,0.41,0.41,0.15,0.01,0.01,0.0,0.0,0.01,krista barr rudolph,,MICR-3050,2017
+MICR,3050,2,General Microbiology,0.34,0.34,0.23,0.05,0.01,0.0,0.0,0.03,kristi ja whitehead,,MICR-3050,2017
+MICR,3050,3,General Microbiology,0.7,0.24,0.07,0.0,0.0,0.0,0.0,0.0,krista barr rudolph,,MICR-3050,2017
+MICR,4000,1,Public Health Micro,0.52,0.27,0.16,0.03,0.02,0.0,0.0,0.01,kristi ja whitehead,,MICR-4000,2017
+MICR,4000,2,Public Health Micro (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,True,MICR-4000,2017
+MICR,4030,1,Marine Microbiology,0.29,0.5,0.17,0.0,0.0,0.0,0.0,0.04,john michael henson,,MICR-4030,2017
+MICR,4070,1,Food and Dairy Micro,0.26,0.47,0.21,0.03,0.01,0.0,0.0,0.01,xiuping jiang,,MICR-4070,2017
+MICR,4110,1,Pathogenic Bact,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4110,2017
+MICR,4120,1,Bacterial Physiology,0.23,0.31,0.19,0.17,0.07,0.0,0.0,0.03,thomas hughes,,MICR-4120,2017
+MICR,4130,1,Industrial Micro,0.64,0.34,0.01,0.01,0.0,0.0,0.0,0.0,tzuen-rong je tzeng,,MICR-4130,2017
+MICR,4140,1,Basic Immunology,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,charles rice,,MICR-4140,2017
+MICR,4170,1,Cancer and Aging,0.87,0.11,0.02,0.0,0.0,0.0,0.0,0.0,yuqing dong,,MICR-4170,2017
+MICR,4500,1,Advanced Microbiology I,0.42,0.42,0.08,0.04,0.04,0.0,0.0,0.0,harry kurtz,,MICR-4500,2017
+MICR,4500,2,Advanced Microbiology I,0.42,0.33,0.13,0.08,0.0,0.0,0.0,0.04,harry kurtz,,MICR-4500,2017
+MICR,4500,3,Advanced Microbiology I,0.06,0.63,0.31,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2017
+MICR,4520,1,Advanced Microbiology III,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4520,2017
+MICR,4520,2,Advanced Microbiology III,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.04,harry kurtz,,MICR-4520,2017
+MKT,3010,1,Prin of Marketing,0.3,0.39,0.2,0.09,0.01,0.0,0.0,0.01,carter wil mcelveen,,MKT-3010,2017
+MKT,3010,2,Prin of Marketing,0.18,0.42,0.27,0.06,0.04,0.0,0.0,0.03,carter wil mcelveen,,MKT-3010,2017
+MKT,3010,3,Prin of Marketing,0.27,0.36,0.25,0.09,0.01,0.0,0.0,0.01,amanda cooper fine,,MKT-3010,2017
+MKT,3010,4,Prin of Marketing,0.24,0.4,0.25,0.06,0.04,0.0,0.0,0.01,amanda cooper fine,,MKT-3010,2017
+MKT,3010,5,Prin of Marketing,0.73,0.18,0.06,0.0,0.02,0.0,0.0,0.02,patricia knowles,,MKT-3010,2017
+MKT,3020,1,Consumer Behavior,0.44,0.36,0.14,0.04,0.02,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2017
+MKT,3020,2,Consumer Behavior,0.33,0.37,0.24,0.04,0.02,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2017
+MKT,3020,3,Consumer Behavior,0.38,0.48,0.12,0.02,0.0,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2017
+MKT,3020,4,Consumer Behavior,0.32,0.44,0.16,0.08,0.0,0.0,0.0,0.0, thyroff fitzwater,,MKT-3020,2017
+MKT,3020,5,Consumer Behavior,0.28,0.56,0.14,0.02,0.0,0.0,0.0,0.0,james gaubert,,MKT-3020,2017
+MKT,3210,1,Sports Marketing,0.6,0.37,0.02,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2017
+MKT,3210,2,Sports Marketing,0.51,0.43,0.02,0.0,0.0,0.0,0.0,0.04,delancy bennett,,MKT-3210,2017
+MKT,3310,1,Marketing Metrics & Analytics,0.81,0.14,0.03,0.0,0.0,0.0,0.0,0.03,oriana rache aragon,,MKT-3310,2017
+MKT,3310,2,Marketing Metrics & Analytics,0.9,0.08,0.0,0.03,0.0,0.0,0.0,0.0,oriana rache aragon,,MKT-3310,2017
+MKT,3980,1,CI: Sales Experiential,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.01,carter wil mcelveen,,MKT-3980,2017
+MKT,4200,1,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2017
+MKT,4200,2,Professional Selling,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2017
+MKT,4200,3,Professional Selling,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,,MKT-4200,2017
+MKT,4200,4,Professional Selling,0.72,0.2,0.04,0.0,0.04,0.0,0.0,0.0,gary hunter,,MKT-4200,2017
+MKT,4200,5,Professional Selling,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2017
+MKT,4230,1,Promotional Strategy,0.35,0.44,0.18,0.03,0.0,0.0,0.0,0.0,patricia knowles,,MKT-4230,2017
+MKT,4240,1,Sales Management,0.38,0.6,0.03,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4240,2017
+MKT,4270,1,International Mktg,0.28,0.5,0.13,0.08,0.0,0.0,0.0,0.03,thomas poehlman,,MKT-4270,2017
+MKT,4270,2,International Mktg,0.23,0.48,0.2,0.03,0.0,0.0,0.0,0.08,roger gomes,,MKT-4270,2017
+MKT,4270,3,International Mktg,0.59,0.33,0.07,0.02,0.0,0.0,0.0,0.0,roger gomes,,MKT-4270,2017
+MKT,4280,1,Services Marketing,0.58,0.24,0.16,0.0,0.0,0.0,0.0,0.02,james gaubert,,MKT-4280,2017
+MKT,4280,2,Services Marketing,0.68,0.29,0.02,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4280,2017
+MKT,4310,1,Marketing Research,0.25,0.25,0.32,0.14,0.04,0.0,0.0,0.0,peter weathers,,MKT-4310,2017
+MKT,4310,2,Marketing Research,0.26,0.45,0.23,0.0,0.0,0.0,0.0,0.06,william kilbourne,,MKT-4310,2017
+MKT,4310,3,Marketing Research,0.3,0.59,0.11,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2017
+MKT,4310,4,Marketing Research,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2017
+MKT,4330,1,Sport Mkt Strategy,0.47,0.44,0.06,0.0,0.0,0.0,0.0,0.03,amanda cooper fine,,MKT-4330,2017
+MKT,4450,1,Macromarketing,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,william kilbourne,,MKT-4450,2017
+MKT,4500,1,Strategic Mktg Mgt,0.22,0.56,0.19,0.0,0.03,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2017
+MKT,4500,2,Strategic Mktg Mgt,0.29,0.68,0.03,0.0,0.0,0.0,0.0,0.0,christopher hopkins,,MKT-4500,2017
+MKT,4500,3,Strategic Mktg Mgt,0.73,0.24,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,,MKT-4500,2017
+MKT,4500,4,Strategic Mktg Mgt,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-4500,2017
+MKT,8620,1,Quant Methods in Mkt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,,MKT-8620,2017
+MKT,8650,1,Seminar in Mkt Mgmt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MKT-8650,2017
+MKT,8660,1,International Marketing,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,thomas poehlman,,MKT-8660,2017
+ML,1020,1,Leadership Fund II,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,clay wilson etterle,,ML-1020,2017
+ML,1020,2,Leadership Fund II,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,amanda carol kane,,ML-1020,2017
+ML,2020,1,Leadership Development II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,shane allen werst,,ML-2020,2017
+ML,2020,2,Leadership Development II,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,shane allen werst,,ML-2020,2017
+ML,3020,1,Advanced Leadership II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,,ML-3020,2017
+ML,3020,2,Advanced Leadership II,0.88,0.04,0.0,0.04,0.0,0.0,0.0,0.04,william cod cleland,,ML-3020,2017
+MSE,2100,1,Intro to Mat Science,0.47,0.2,0.16,0.06,0.06,0.0,0.0,0.05,rakhee pani,,MSE-2100,2017
+MSE,2100,2,Intro to Mat Science,0.3,0.46,0.12,0.0,0.03,0.0,0.0,0.09,eric skaar,,MSE-2100,2017
+MSE,2100,3,Intro to Mat Science,0.23,0.2,0.23,0.13,0.08,0.0,0.0,0.14,fei peng,,MSE-2100,2017
+MSE,2100,4,Intro to Mat Science,0.41,0.34,0.17,0.06,0.02,0.0,0.0,0.0,olga kuksenok,,MSE-2100,2017
+MSE,2410,1,Metrics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,,MSE-2410,2017
+MSE,2410,2,Metrics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,,MSE-2410,2017
+MSE,2500,1,Polymer & Fiber Materials I,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,deborah lickfield,,MSE-2500,2017
+MSE,3260,1,Thermo of Materials,0.33,0.26,0.26,0.04,0.09,0.0,0.0,0.02,gary lickfield,,MSE-3260,2017
+MSE,3270,1,Transport Phenomena,0.23,0.4,0.13,0.13,0.07,0.0,0.0,0.03,ulf daniel schiller,,MSE-3270,2017
+MSE,3280,1,Phase Diagrams,0.5,0.11,0.25,0.0,0.0,0.0,0.0,0.14,eric skaar,,MSE-3280,2017
+MSE,3420,1,Struct/Property,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,rajendra kum bordia,,MSE-3420,2017
+MSE,3420,2,Struct/Property,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,rajendra kum bordia,,MSE-3420,2017
+MSE,3610,1,Proc of Metals & Composites,0.3,0.49,0.08,0.05,0.0,0.0,0.0,0.08,marian kennedy,,MSE-3610,2017
+MSE,4150,1,Polymer Sc Engr,0.48,0.23,0.2,0.05,0.03,0.0,0.0,0.03,igor luzinov,,MSE-4150,2017
+MSE,4160,1,Electronic Materials,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,kyle brinkman,,MSE-4160,2017
+MSE,4220,1,Mech Behavior of Mat,0.26,0.5,0.15,0.02,0.0,0.0,0.0,0.07,vincent yves blouin,,MSE-4220,2017
+MSE,4240,1,Optical Materials,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-4240,2017
+MSE,4330,1,Comb Sys & Env Emiss,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,,MSE-4330,2017
+MSE,4560,1,Polymer & Fiber Materials II,0.32,0.39,0.21,0.04,0.0,0.0,0.0,0.04,gary lickfield,,MSE-4560,2017
+MSE,4810,1,Undergraduate Research Fundame,0.81,0.13,0.03,0.03,0.0,0.0,0.0,0.0,marian kennedy,,MSE-4810,2017
+MSE,4910,1,Undergraduate Research,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,marian kennedy,,MSE-4910,2017
+MSE,4910,2,Undergraduate Research,0.62,0.15,0.08,0.0,0.08,0.0,0.0,0.08,marian kennedy,,MSE-4910,2017
+MSE,8010,1,Grad Sem in Materials Research,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,olga kuksenok,,MSE-8010,2017
+MSE,8250,1,Solid State Mtl Sci,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,stephen foulger,,MSE-8250,2017
+MSE,8520,1,Polymer Science II,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,igor luzinov,,MSE-8520,2017
+MUSC,1420,1,Music Theory I,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,anthony bernarducci,,MUSC-1420,2017
+MUSC,1440,1,Music Theory II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,andrew levin,,MUSC-1440,2017
+MUSC,1450,1,Aural Skills II,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,andrew levin,,MUSC-1450,2017
+MUSC,1510,2,Applied Music,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,jonathan edwa doyel,,MUSC-1510,2017
+MUSC,2100,1,Music in the Western World,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-2100,2017
+MUSC,2100,2,Music in the Western World,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,lisa sain odom,,MUSC-2100,2017
+MUSC,2100,3,Music in the Western World,0.69,0.19,0.09,0.0,0.0,0.0,0.0,0.03,linda li-bleuel,,MUSC-2100,2017
+MUSC,2100,4,Music in the Western World,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2017
+MUSC,2100,5,Music in the Western World,0.44,0.44,0.09,0.0,0.0,0.0,0.0,0.03,rhea beth jacobus,,MUSC-2100,2017
+MUSC,2100,6,Music in the Western World,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2017
+MUSC,2100,8,Music in the Western World,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,monty craig,,MUSC-2100,2017
+MUSC,2100,9,Music in the Western World,0.69,0.25,0.03,0.03,0.0,0.0,0.0,0.0,lea kibler,,MUSC-2100,2017
+MUSC,3110,1,History of American Music,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3110,2017
+MUSC,3120,1,History of Jazz,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-3120,2017
+MUSC,3170,1,Hist of Country Mus,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3170,2017
+MUSC,3180,1,Hist of Audio Tech,0.59,0.29,0.06,0.0,0.06,0.0,0.0,0.0,bruce allen whisler,,MUSC-3180,2017
+MUSC,3640,1,Concert Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,timothy ra hurlburt,,MUSC-3640,2017
+MUSC,3690,1,Symphony Orchestra,0.94,0.02,0.0,0.0,0.02,0.0,0.0,0.02,andrew levin,,MUSC-3690,2017
+MUSC,4160,1,Mus Hist Since 1750,0.52,0.11,0.04,0.22,0.07,0.0,0.0,0.04,linda li-bleuel,,MUSC-4160,2017
+MUSC,4300,1,Conducting,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,mark spede,,MUSC-4300,2017
+NPL,3000,1,Nonprofit Leadership,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2017
+NPL,3000,2,Nonprofit Leadership,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,bonnie west stevens,,NPL-3000,2017
+NPL,3010,2,NPL Stakeholders,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,christina mar mazer,,NPL-3010,2017
+NPL,3030,2,NPL Personnel,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,wendell price,,NPL-3030,2017
+NURS,1400,1,Comp App Hlth Care,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,,NURS-1400,2017
+NURS,3030,1,Nursing of Adults,0.22,0.72,0.06,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2017
+NURS,3030,400,Nursing of Adults,0.14,0.68,0.18,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2017
+NURS,3040,1,Pathophysiology,0.39,0.49,0.06,0.04,0.02,0.0,0.0,0.0,catherine si murton,,NURS-3040,2017
+NURS,3040,401,Pathophysiology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth ca hassen,,NURS-3040,2017
+NURS,3050,1,Psychosocial Nursing,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,barbara jean warner,,NURS-3050,2017
+NURS,3050,400,Psychosocial Nursing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,,NURS-3050,2017
+NURS,3100,1,Health Assessment,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,,NURS-3100,2017
+NURS,3120,1,Foundations of Nursing,0.34,0.55,0.09,0.02,0.0,0.0,0.0,0.0,angela pye,,NURS-3120,2017
+NURS,3190,400,Health Assessment for RNs,0.89,0.06,0.0,0.06,0.0,0.0,0.0,0.0,jennifer geter rice,,NURS-3190,2017
+NURS,3330,400,Health Care Genetics,0.87,0.07,0.0,0.07,0.0,0.0,0.0,0.0,mary steck,,NURS-3330,2017
+NURS,3330,401,Health Care Genetics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,NURS-3330,2017
+NURS,3400,1,Pharmther Nursing,0.35,0.46,0.1,0.06,0.02,0.0,0.0,0.0,catherine si murton,,NURS-3400,2017
+NURS,4010,1,Mental Health Nurs,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-4010,2017
+NURS,4030,1,Complex Nursing of Adults,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,john josep whitcomb,,NURS-4030,2017
+NURS,4110,1,Nursing of Children,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,,NURS-4110,2017
+NURS,4120,1,Nurs Women and Fam,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2017
+NURS,8010,400,Adv Fam & Comm Nrsng,0.89,0.08,0.0,0.0,0.0,0.0,0.0,0.03,shirley mae timmons,,NURS-8010,2017
+NURS,8010,401,Adv Fam & Comm Nrsng,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,,NURS-8010,2017
+NURS,8080,400,Nurs Res Stat Analys,0.64,0.22,0.08,0.0,0.06,0.0,0.0,0.0,veronica parker,,NURS-8080,2017
+NURS,8190,400,Developing Family,0.43,0.07,0.0,0.0,0.47,0.0,0.0,0.03,lisa miller,,NURS-8190,2017
+NURS,8200,400,Child & Adol Nursing,0.14,0.23,0.0,0.0,0.59,0.0,0.0,0.05,heide temples,,NURS-8200,2017
+NURS,8210,400,Adult Nursing,0.47,0.17,0.0,0.0,0.37,0.0,0.0,0.0,tracy king fasolino,,NURS-8210,2017
+NURS,8210,401,Adult Nursing,0.41,0.41,0.0,0.0,0.14,0.0,0.0,0.03,tracy king fasolino,,NURS-8210,2017
+NURS,8230,400,NP Clinical Practicum,0.96,0.0,0.0,0.0,0.04,0.0,0.0,0.0,rosanne pruitt,,NURS-8230,2017
+NURS,8840,400,Adult Mental Health,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,lindsey reb garrard,,NURS-8840,2017
+NURS,8850,400,Mental Health in Primary Care,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-8850,2017
+NUTR,2030,1,Intro Princ of Human Nutrition,0.34,0.49,0.09,0.03,0.02,0.0,0.0,0.03,elizabeth durrance,,NUTR-2030,2017
+NUTR,2030,2,Intro Princ of Human Nutrition,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,,NUTR-2030,2017
+NUTR,2040,1,Nutrition Across Life Cycle,0.5,0.4,0.07,0.02,0.02,0.0,0.0,0.0,elizabeth durrance,,NUTR-2040,2017
+NUTR,4180,1,Prof Development in Dietetics,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4180,2017
+NUTR,4250,1,Medica Nutr Thera II,0.45,0.42,0.13,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4250,2017
+NUTR,4260,1,Community Nutrition,0.75,0.22,0.03,0.0,0.0,0.0,0.0,0.0,margaret condrasky,,NUTR-4260,2017
+NUTR,4550,1,Human Nutr & Metabolism II,0.54,0.29,0.11,0.03,0.03,0.0,0.0,0.0,elliot jesch,,NUTR-4550,2017
+PA,2790,1,Perf Arts Pract I,0.6,0.2,0.0,0.2,0.0,0.0,0.0,0.0,kenneth moore,,PA-2790,2017
+PA,2800,1,Perf Arts Pract II,0.5,0.06,0.0,0.13,0.19,0.0,0.0,0.13,kenneth moore,,PA-2800,2017
+PADM,8220,400,Public Policy Process,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ek yazykova mellott,,PADM-8220,2017
+PADM,8270,400,Public Personnel Admin,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,lawrence nichols,,PADM-8270,2017
+PADM,8290,400,Public Financial Management,0.57,0.29,0.0,0.0,0.07,0.0,0.0,0.07,robert frager,,PADM-8290,2017
+PADM,8410,400,Public Data Analysis,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,ronald chrestman,,PADM-8410,2017
+PADM,8410,401,Public Data Analysis,0.78,0.0,0.11,0.0,0.11,0.0,0.0,0.0,ronald chrestman,,PADM-8410,2017
+PADM,8410,402,Public Data Analysis,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,,PADM-8410,2017
+PADM,8450,400,Grant Writing for Public Admin,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,katheri kransteuber,,PADM-8450,2017
+PADM,8520,400,Emergency Mgt Planning & Prep,0.73,0.13,0.0,0.0,0.13,0.0,0.0,0.0,amanda nico ritsema,,PADM-8520,2017
+PADM,8540,400,Cybersecurity,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,david leigh cook,,PADM-8540,2017
+PADM,8680,400,Local Government Admin,0.36,0.45,0.0,0.0,0.18,0.0,0.0,0.0,alfred bundrick,,PADM-8680,2017
+PADM,8780,402,Local Govt. Budgeting & Financ,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,kevin yokim,,PADM-8780,2017
+PADM,8780,405,Regional Econ Devlpmnt Policy,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,lori ann dickes,,PADM-8780,2017
+PAS,3010,1,Pan African Studies,0.74,0.17,0.0,0.0,0.04,0.0,0.0,0.04,garry bertholf,,PAS-3010,2017
+PES,2020,1,Soils,0.3,0.33,0.35,0.0,0.02,0.0,0.0,0.0,dara michelle park,,PES-2020,2017
+PES,4230,1,Field Crops - Forages,0.12,0.19,0.54,0.08,0.04,0.0,0.0,0.04,matias jose aguerre,,PES-4230,2017
+PES,4330,1,Landscape & Turf Weed Mgt,0.07,0.71,0.14,0.0,0.07,0.0,0.0,0.0,ted whitwell,,PES-4330,2017
+PES,4450,1,Regulatory Issues & Policies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,,PES-4450,2017
+PES,4520,1,Soil Fertility and Management,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,,PES-4520,2017
+PES,4900,1,Soil Organisms in Plant Growth,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,"appukuttan suseela,",,PES-4900,2017
+PES,6900,1,Soil Organisms in Plant Growth,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,"appukuttan suseela,",,PES-6900,2017
+PES,8010,1,Crop Physiology and Nutrition,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,sruthi naraya kutty,,PES-8010,2017
+PHIL,1010,1,Intro to Philosophic Problems,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,david stegall,,PHIL-1010,2017
+PHIL,1010,2,Intro to Philosophic Problems,0.6,0.17,0.11,0.03,0.09,0.0,0.0,0.0,david stegall,,PHIL-1010,2017
+PHIL,1010,3,Intro to Philosophic Problems,0.21,0.55,0.15,0.0,0.03,0.0,0.0,0.06,kelly smith,,PHIL-1010,2017
+PHIL,1010,5,Intro to Philosophic Problems,0.26,0.47,0.16,0.0,0.05,0.0,0.0,0.05,john randall wolfe,,PHIL-1010,2017
+PHIL,1010,6,Intro to Philosophic Problems,0.54,0.23,0.14,0.0,0.06,0.0,0.0,0.03,john randall wolfe,,PHIL-1010,2017
+PHIL,1010,7,Intro to Philosophic Problems,0.52,0.36,0.06,0.0,0.03,0.0,0.0,0.03,john randall wolfe,,PHIL-1010,2017
+PHIL,1020,1,Introduction to Logic,0.75,0.11,0.08,0.0,0.03,0.0,0.0,0.03,michael hal hannen,,PHIL-1020,2017
+PHIL,1020,2,Introduction to Logic,0.77,0.14,0.06,0.03,0.0,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2017
+PHIL,1020,3,Introduction to Logic,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,michael hal hannen,,PHIL-1020,2017
+PHIL,1020,4,Introduction to Logic,0.59,0.26,0.12,0.03,0.0,0.0,0.0,0.0,adam gies,,PHIL-1020,2017
+PHIL,1020,5,Introduction to Logic,0.71,0.18,0.03,0.0,0.03,0.0,0.0,0.06,adam gies,,PHIL-1020,2017
+PHIL,1020,6,Introduction to Logic,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-1020,2017
+PHIL,1030,2,Introduction to Ethics,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stephen satris,,PHIL-1030,2017
+PHIL,1030,3,Introduction to Ethics,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,william maker,,PHIL-1030,2017
+PHIL,1030,5,Introduction to Ethics,0.5,0.32,0.09,0.03,0.03,0.0,0.0,0.03,edyta joanna kuzian,,PHIL-1030,2017
+PHIL,1030,6,Introduction to Ethics,0.51,0.4,0.03,0.0,0.0,0.0,0.0,0.06,john jung park,,PHIL-1030,2017
+PHIL,1030,7,Introduction to Ethics,0.46,0.43,0.09,0.03,0.0,0.0,0.0,0.0,john jung park,,PHIL-1030,2017
+PHIL,1030,8,Introduction to Ethics,0.31,0.46,0.12,0.04,0.04,0.0,0.0,0.04,charles starkey,,PHIL-1030,2017
+PHIL,1030,9,Introduction to Ethics,0.54,0.31,0.09,0.06,0.0,0.0,0.0,0.0,edyta joanna kuzian,,PHIL-1030,2017
+PHIL,1030,10,Introduction to Ethics,0.54,0.31,0.11,0.0,0.03,0.0,0.0,0.0,john jung park,,PHIL-1030,2017
+PHIL,3040,1,Moral Philosophy,0.31,0.15,0.23,0.23,0.0,0.0,0.0,0.08,john jung park,,PHIL-3040,2017
+PHIL,3050,2,Existentialism,0.84,0.09,0.0,0.0,0.06,0.0,0.0,0.0,david stegall,,PHIL-3050,2017
+PHIL,3150,1,Ancient Philosophy,0.32,0.26,0.21,0.05,0.05,0.0,0.0,0.11,jennifer ingle,,PHIL-3150,2017
+PHIL,3160,1,Modern Philosophy,0.47,0.41,0.06,0.0,0.03,0.0,0.0,0.03,michael hal hannen,,PHIL-3160,2017
+PHIL,3170,1,19th-Century Philosophy,0.19,0.31,0.31,0.06,0.06,0.0,0.0,0.06,william maker,,PHIL-3170,2017
+PHIL,3180,1,20th-Century Philosophy,0.59,0.33,0.07,0.0,0.0,0.0,0.0,0.0,john randall wolfe,,PHIL-3180,2017
+PHIL,3210,1,Crime & Punishment,0.34,0.48,0.14,0.0,0.03,0.0,0.0,0.0,daniel wueste,,PHIL-3210,2017
+PHIL,3250,2,Phil of Science,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-3250,2017
+PHIL,3260,1,Science and Values,0.47,0.47,0.0,0.0,0.06,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2017
+PHIL,3260,2,Science and Values,0.41,0.38,0.0,0.0,0.03,0.0,0.0,0.18,andrew garnar,,PHIL-3260,2017
+PHIL,3260,3,Science and Values,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2017
+PHIL,3280,1,Technology of Bodies,0.54,0.31,0.08,0.04,0.0,0.0,0.0,0.04,edyta joanna kuzian,,PHIL-3280,2017
+PHIL,3450,1,Environmental Ethics,0.51,0.29,0.09,0.06,0.03,0.0,0.0,0.03,jennifer ingle,,PHIL-3450,2017
+PHIL,3450,2,Environmental Ethics,0.51,0.34,0.11,0.0,0.03,0.0,0.0,0.0,jennifer ingle,,PHIL-3450,2017
+PHIL,3490,2,Gender and Sexuality,0.52,0.43,0.05,0.0,0.0,0.0,0.0,0.0,diane perpich,,PHIL-3490,2017
+PHIL,4010,1,Studies in the Hist of Phil,0.71,0.06,0.0,0.0,0.12,0.0,0.0,0.12,david stegall,,PHIL-4010,2017
+PHIL,4750,1,Philosophy of Film,0.38,0.46,0.08,0.08,0.0,0.0,0.0,0.0,christopher grau,,PHIL-4750,2017
+PHSC,1170,1,Intro Chem & Earth,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1170,2017
+PHYS,1220,1,Physics with Calculus I,0.18,0.47,0.22,0.07,0.05,0.0,0.0,0.01,amy liann pope,,PHYS-1220,2017
+PHYS,1220,2,Physics with Calculus I,0.19,0.46,0.23,0.03,0.02,0.0,0.0,0.07,lih-sin the,,PHYS-1220,2017
+PHYS,1220,3,Physics with Calculus I,0.14,0.49,0.29,0.04,0.01,0.0,0.0,0.02,apparao rao,,PHYS-1220,2017
+PHYS,1220,4,Physics with Calculus I,0.22,0.49,0.22,0.02,0.01,0.0,0.0,0.03,jason stratfo brown,,PHYS-1220,2017
+PHYS,1220,5,Physics with Calculus I,0.27,0.51,0.15,0.04,0.01,0.0,0.0,0.02,pooja puneet,,PHYS-1220,2017
+PHYS,1220,8,Physics With Cal I (HON),0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True,PHYS-1220,2017
+PHYS,1240,1,Physics Lab I,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2017
+PHYS,1240,2,Physics Lab I,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,3,Physics Lab I,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,4,Physics Lab I,0.28,0.61,0.0,0.0,0.06,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,5,Physics Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,6,Physics Lab I,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,7,Physics Lab I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-1240,2017
+PHYS,1240,8,Physics Lab I,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,9,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,10,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,11,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,12,Physics Lab I,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,13,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,15,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,16,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,17,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,19,Physics Lab I,0.24,0.59,0.12,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,20,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,21,Physics Lab I,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,22,Physics Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,24,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,25,Physics Lab I,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,26,Physics Lab I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,27,Physics Lab I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-1240,2017
+PHYS,1240,29,Physics Lab I,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,1240,30,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-1240,2017
+PHYS,2000,1,Introductory Physics,0.49,0.4,0.04,0.03,0.04,0.0,0.0,0.0,sean brittain,,PHYS-2000,2017
+PHYS,2070,1,General Physics I,0.38,0.4,0.14,0.03,0.02,0.0,0.0,0.03,amy liann pope,,PHYS-2070,2017
+PHYS,2080,1,General Physics II,0.51,0.33,0.1,0.03,0.02,0.0,0.0,0.0,pooja puneet,,PHYS-2080,2017
+PHYS,2080,2,General Physics II,0.65,0.28,0.05,0.0,0.01,0.0,0.0,0.0,pooja puneet,,PHYS-2080,2017
+PHYS,2090,1,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,2,Gen Phys Lab I,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,3,Gen Phys Lab I,0.17,0.74,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,4,Gen Phys Lab I,0.31,0.44,0.13,0.0,0.0,0.0,0.0,0.13,jerry hester,,PHYS-2090,2017
+PHYS,2090,5,Gen Phys Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2090,6,Gen Phys Lab I,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,7,Gen Phys Lab I,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,jerry hester,,PHYS-2090,2017
+PHYS,2090,9,Gen Phys Lab I,0.52,0.35,0.0,0.0,0.09,0.0,0.0,0.04,jerry hester,,PHYS-2090,2017
+PHYS,2090,10,Gen Phys Lab I,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2090,2017
+PHYS,2100,1,Gen Phys Lab II,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,2,Gen Phys Lab II,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2017
+PHYS,2100,3,Gen Phys Lab II,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,4,Gen Phys Lab II,0.46,0.33,0.21,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,5,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,6,Gen Phys Lab II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,7,Gen Phys Lab II,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,10,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,11,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,12,Gen Phys Lab II,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2017
+PHYS,2100,13,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,14,Gen Phys Lab II,0.75,0.13,0.08,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2017
+PHYS,2100,15,Gen Phys Lab II,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2017
+PHYS,2100,16,Gen Phys Lab II,0.57,0.39,0.0,0.0,0.04,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2100,17,Gen Phys Lab II,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.04,jerry hester,,PHYS-2100,2017
+PHYS,2100,18,Gen Phys Lab II,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2100,2017
+PHYS,2210,1,Physics with Calculus II,0.28,0.34,0.27,0.06,0.03,0.0,0.0,0.02,jason stratfo brown,,PHYS-2210,2017
+PHYS,2210,2,Physics with Calculus II,0.24,0.41,0.23,0.03,0.06,0.0,0.0,0.02,jason stratfo brown,,PHYS-2210,2017
+PHYS,2210,500,Physics With Calculus II,0.2,0.4,0.33,0.07,0.0,0.0,0.0,0.0,elaine parshall,,PHYS-2210,2017
+PHYS,2220,1,Physics with Calculus III,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,jian he,,PHYS-2220,2017
+PHYS,2230,1,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2017
+PHYS,2230,2,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,jerry hester,,PHYS-2230,2017
+PHYS,2230,5,Physics Lab II,0.36,0.36,0.18,0.0,0.09,0.0,0.0,0.0,jerry hester,,PHYS-2230,2017
+PHYS,2230,6,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2017
+PHYS,2230,7,Physics Lab II,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,jerry hester,,PHYS-2230,2017
+PHYS,2230,8,Physics Lab II,0.83,0.06,0.0,0.11,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2017
+PHYS,2230,9,Physics Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2230,2017
+PHYS,2230,500,Physics Lab II,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,elaine parshall,,PHYS-2230,2017
+PHYS,2240,1,Physics Lab III,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,jerry hester,,PHYS-2240,2017
+PHYS,2400,1,Phys of Weather,0.35,0.41,0.11,0.02,0.0,0.0,0.0,0.11,miguel larsen,,PHYS-2400,2017
+PHYS,3110,1,Methods Theor Phys,0.31,0.46,0.08,0.0,0.04,0.0,0.0,0.12,antony valentini,,PHYS-3110,2017
+PHYS,3220,1,Mechanics II,0.18,0.45,0.18,0.0,0.09,0.0,0.0,0.09,joshua alper,,PHYS-3220,2017
+PHYS,3260,1,Exper Physics II,0.6,0.2,0.12,0.0,0.04,0.0,0.0,0.04,chad sosolik,,PHYS-3260,2017
+PHYS,4650,1,Thermo and Stat Mech,0.46,0.15,0.31,0.0,0.0,0.0,0.0,0.08,feng ding,,PHYS-4650,2017
+PHYS,6560,1,Quantum Physics II,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,ramakrishna podila,,PHYS-6560,2017
+PHYS,8150,1,Statistical Therm I,0.11,0.67,0.11,0.0,0.0,0.0,0.0,0.11,jens oberheide,,PHYS-8150,2017
+PHYS,8410,1,Electrodynamics I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,dieter hartmann,,PHYS-8410,2017
+PHYS,9520,1,Quantum Mech II,0.13,0.63,0.25,0.0,0.0,0.0,0.0,0.0,domnita marinescu,,PHYS-9520,2017
+PKSC,1020,1,Intro to Pkg Sci,0.31,0.44,0.16,0.06,0.01,0.0,0.0,0.02,heather batt,,PKSC-1020,2017
+PKSC,2010,1,Pkg Perishable Prod,0.15,0.34,0.24,0.08,0.1,0.0,0.0,0.1,heather batt,,PKSC-2010,2017
+PKSC,2020,1,Packaging Mtl & Mfg,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert truett moore,,PKSC-2020,2017
+PKSC,2040,1,Container Systems,0.93,0.02,0.03,0.0,0.02,0.0,0.0,0.0,robert truett moore,,PKSC-2040,2017
+PKSC,2060,1,Container Sys Lab,0.57,0.33,0.05,0.05,0.0,0.0,0.0,0.0,tyler stuettgen,,PKSC-2060,2017
+PKSC,2060,2,Container Sys Lab,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,,PKSC-2060,2017
+PKSC,2060,3,Container Sys Lab,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,tyler stuettgen,,PKSC-2060,2017
+PKSC,2200,1,Product & Pkg Design,0.83,0.1,0.02,0.0,0.02,0.0,0.0,0.02,william aaro snyder,,PKSC-2200,2017
+PKSC,3200,1,Pkg Design Theory,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,rupert hurley,,PKSC-3200,2017
+PKSC,3680,1,Pkg and Society,0.31,0.38,0.17,0.03,0.03,0.0,0.0,0.07,heather batt,,PKSC-3680,2017
+PKSC,4030,1,Pkg Career Prep,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2017
+PKSC,4200,1,Pkg Design & Dev,0.71,0.17,0.11,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2017
+PKSC,4240,400,Structural Pkg Design Online,0.6,0.1,0.0,0.0,0.2,0.0,0.0,0.1,rupert hurley,,PKSC-4240,2017
+PKSC,4300,1,Converting Flex Pkg,0.16,0.62,0.13,0.03,0.04,0.0,0.0,0.01,duncan darby,,PKSC-4300,2017
+PKSC,4400,1,Packaging for Distribution,0.17,0.46,0.22,0.04,0.11,0.0,0.0,0.0,gregory batt,,PKSC-4400,2017
+PKSC,4640,1,Food & Health Care Pkg Systems,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2017
+PKSC,8220,400,3D Parametric Design,0.83,0.08,0.0,0.0,0.08,0.0,0.0,0.0,rupert hurley,,PKSC-8220,2017
+PLPA,2130,1,Fungi & Civilization,0.37,0.37,0.17,0.06,0.02,0.0,0.0,0.01,julia loui kerrigan,,PLPA-2130,2017
+PLPA,4060,1,Diseases/Insects Turfgrasses,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,samuel martin,,PLPA-4060,2017
+PLPA,8090,1,Analytical Technique,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,,PLPA-8090,2017
+POSC,1010,2,Amer National Govt,0.08,0.36,0.12,0.16,0.24,0.0,0.0,0.04,adam warber,,POSC-1010,2017
+POSC,1010,3,Amer National Govt,0.05,0.33,0.33,0.1,0.0,0.0,0.0,0.2,james woodard,,POSC-1010,2017
+POSC,1020,1,Intro Intl Relations,0.26,0.42,0.22,0.04,0.02,0.0,0.0,0.04,tara elizabet trask,,POSC-1020,2017
+POSC,1020,2,Intro Intl Relations,0.16,0.29,0.3,0.13,0.04,0.0,0.0,0.07,aron geo tannenbaum,,POSC-1020,2017
+POSC,1020,3,Intro Intl Relations,0.1,0.45,0.27,0.09,0.03,0.0,0.0,0.05,zeynep taydas,,POSC-1020,2017
+POSC,1020,5,Intro Intl Relations,0.23,0.31,0.27,0.08,0.04,0.0,0.0,0.08,joshua douglas king,,POSC-1020,2017
+POSC,1030,1,Intro to Political Theory,0.24,0.33,0.2,0.09,0.13,0.0,0.0,0.01,brandon turner,,POSC-1030,2017
+POSC,1030,2,Intro to Political Theory,0.23,0.65,0.08,0.0,0.0,0.0,0.0,0.04,colin pearce,,POSC-1030,2017
+POSC,1040,1,Intro Compar Pol,0.29,0.31,0.16,0.02,0.11,0.0,0.0,0.11,katherine am curtis,,POSC-1040,2017
+POSC,1040,2,Intro Compar Pol,0.48,0.26,0.09,0.09,0.04,0.0,0.0,0.04,tara elizabet trask,,POSC-1040,2017
+POSC,1990,1,Intro Pol Sci,0.48,0.25,0.12,0.06,0.04,0.0,0.0,0.06,meredith petersheim,,POSC-1990,2017
+POSC,3020,1,State and Loc Gov,0.17,0.52,0.17,0.0,0.02,0.0,0.0,0.12,bruce ransom,,POSC-3020,2017
+POSC,3210,1,Public Admin,0.13,0.35,0.43,0.0,0.04,0.0,0.0,0.04,james woodard,,POSC-3210,2017
+POSC,3610,1,Intl Pol in Crisis,0.25,0.25,0.1,0.05,0.18,0.0,0.0,0.18,steven vince miller,,POSC-3610,2017
+POSC,3630,1,Us Foreign Policy,0.38,0.27,0.19,0.04,0.12,0.0,0.0,0.0,jeffrey scott peake,,POSC-3630,2017
+POSC,3710,1,European Politics,0.51,0.29,0.1,0.04,0.04,0.0,0.0,0.02,vladimir matic,,POSC-3710,2017
+POSC,3750,1,European Integration,0.37,0.19,0.26,0.07,0.07,0.0,0.0,0.04,katherine am curtis,,POSC-3750,2017
+POSC,3810,1,African Amer Politic,0.33,0.47,0.2,0.0,0.0,0.0,0.0,0.0,bruce ransom,,POSC-3810,2017
+POSC,4050,1,American Presidency,0.08,0.21,0.37,0.11,0.21,0.0,0.0,0.03,adam warber,,POSC-4050,2017
+POSC,4160,1,Int Groups & Soc Mov,0.29,0.38,0.2,0.07,0.04,0.0,0.0,0.02,laura olson,,POSC-4160,2017
+POSC,4360,1,Law Courts Politics,0.36,0.36,0.2,0.0,0.04,0.0,0.0,0.04,joseph earl stewart,,POSC-4360,2017
+POSC,4360,2,Law Courts Politics,0.32,0.5,0.06,0.06,0.03,0.0,0.0,0.03,joseph earl stewart,,POSC-4360,2017
+POSC,4370,1,Constitut Law: Rights & Libert,0.24,0.53,0.14,0.02,0.04,0.0,0.0,0.02,daniel frost,,POSC-4370,2017
+POSC,4500,1,Contemporary Political Thought,0.36,0.44,0.2,0.0,0.0,0.0,0.0,0.0,daniel frost,,POSC-4500,2017
+POSC,4530,1,American Political Thought,0.25,0.45,0.18,0.05,0.05,0.0,0.0,0.03, bradley thompson,,POSC-4530,2017
+POSC,4710,1,Russian Politics,0.38,0.33,0.15,0.0,0.05,0.0,0.0,0.08,aron geo tannenbaum,,POSC-4710,2017
+POSC,4760,1,Middle East Politics,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,vladimir matic,,POSC-4760,2017
+POSC,4890,1,Voting Rights Law Politics Pol,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,,POSC-4890,2017
+PRTM,2070,1,Practicum II,0.0,0.0,0.0,0.0,0.0,0.93,0.07,0.0,jamie lynn cathey,,PRTM-2070,2017
+PRTM,2200,1,Foundations of PRTM,0.32,0.52,0.1,0.06,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2200,2017
+PRTM,2200,2,Foundations of PRTM,0.67,0.13,0.13,0.0,0.03,0.0,0.0,0.03,gwynn powell,,PRTM-2200,2017
+PRTM,2200,3,Foundations of PRTM,0.36,0.43,0.11,0.04,0.07,0.0,0.0,0.0,katherine an jordan,,PRTM-2200,2017
+PRTM,2200,4,Foundations of PRTM,0.58,0.26,0.03,0.06,0.06,0.0,0.0,0.0,ryan joseph gagnon,,PRTM-2200,2017
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2260,2017
+PRTM,2270,1,Prov of Leisure Exp,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2270,2017
+PRTM,2290,1,Competency Integration in PRTM,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2290,2017
+PRTM,2410,1,Intro to CRSCM,0.62,0.24,0.05,0.0,0.07,0.0,0.0,0.02,harrison pinckney,,PRTM-2410,2017
+PRTM,2600,1,Found of Recreational Therapy,0.53,0.36,0.08,0.01,0.01,0.0,0.0,0.01,anna-mar chancellor,,PRTM-2600,2017
+PRTM,2650,1,Terminology in RT Practice,0.88,0.09,0.0,0.03,0.0,0.0,0.0,0.0,stephen thoma lewis,,PRTM-2650,2017
+PRTM,2700,1,Intro Rec Res Mgt,0.54,0.39,0.0,0.0,0.07,0.0,0.0,0.0,elizabeth baldwin,,PRTM-2700,2017
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.21,0.48,0.27,0.03,0.0,0.0,0.0,0.0,daniel mor anderson,,PRTM-3050,2017
+PRTM,3070,1,Facility Operations,0.64,0.18,0.09,0.09,0.0,0.0,0.0,0.0,raymond dunham,,PRTM-3070,2017
+PRTM,3210,1,Recreation Admin,0.67,0.27,0.03,0.0,0.03,0.0,0.0,0.0,mariela fernandez,,PRTM-3210,2017
+PRTM,3250,1,Global Persp in Rec,0.42,0.39,0.06,0.0,0.12,0.0,0.0,0.0,skye arthur-banning,,PRTM-3250,2017
+PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.89,0.1,0.02,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,,PRTM-3260,2017
+PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.73,0.19,0.08,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3270,2017
+PRTM,3280,2,Preceptorship in Recr Therapy,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,stephen thoma lewis,,PRTM-3280,2017
+PRTM,3420,1,Intro to Tourism,0.73,0.24,0.0,0.0,0.02,0.0,0.0,0.0,li-hsin chen,,PRTM-3420,2017
+PRTM,3420,2,Intro to Tourism,0.73,0.23,0.02,0.0,0.02,0.0,0.0,0.0,garrett stone,,PRTM-3420,2017
+PRTM,3440,1,Tourism Markets,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,,PRTM-3440,2017
+PRTM,3440,2,Tourism Markets,0.75,0.23,0.03,0.0,0.0,0.0,0.0,0.0,zeynep gedikoglu,,PRTM-3440,2017
+PRTM,3450,1,Tourism Management,0.48,0.29,0.19,0.0,0.03,0.0,0.0,0.0,william norman,,PRTM-3450,2017
+PRTM,3450,2,Tourism Management,0.41,0.47,0.13,0.0,0.0,0.0,0.0,0.0,william norman,,PRTM-3450,2017
+PRTM,3460,1,Heritage Tourism,0.33,0.37,0.23,0.07,0.0,0.0,0.0,0.0,gregory phi ramshaw,,PRTM-3460,2017
+PRTM,3460,2,Heritage Tourism,0.21,0.55,0.14,0.0,0.07,0.0,0.0,0.03,gregory phi ramshaw,,PRTM-3460,2017
+PRTM,3530,2,Foundations of Camp Counseling,0.8,0.0,0.0,0.0,0.13,0.0,0.0,0.07,gwynn powell,,PRTM-3530,2017
+PRTM,3830,1,Golf Shop Operations,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3830,2017
+PRTM,3900,3,Independent Study in PRTM,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3900,2017
+PRTM,3910,1,Mgmt Admin Outdr Rec Programs,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,robert baxte powell,,PRTM-3910,2017
+PRTM,3910,9,Intro to GIS for PRTM,0.27,0.64,0.0,0.0,0.09,0.0,0.0,0.0,david lawrenc white,,PRTM-3910,2017
+PRTM,4210,1,Rec Fin Resc Mgt,0.5,0.38,0.1,0.0,0.03,0.0,0.0,0.0,jamie lynn cathey,,PRTM-4210,2017
+PRTM,4260,1,Trends & Issues in Rec Therapy,0.62,0.29,0.07,0.0,0.0,0.0,0.0,0.02,brent hawkins,,PRTM-4260,2017
+PRTM,4300,1,World Geog Parks,0.22,0.54,0.22,0.0,0.03,0.0,0.0,0.0,robert baxte powell,,PRTM-4300,2017
+PRTM,4310,1,Mthds of Envir Interpretation,0.67,0.08,0.25,0.0,0.0,0.0,0.0,0.0,robert bixler,,PRTM-4310,2017
+PRTM,4460,2,Community Tourism,0.67,0.2,0.1,0.03,0.0,0.0,0.0,0.0,lauren duffy,,PRTM-4460,2017
+PRTM,4460,3,Community Tourism,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,lauren duffy,,PRTM-4460,2017
+PRTM,4510,1,Seminar in CRSCM,0.59,0.25,0.09,0.03,0.0,0.0,0.0,0.03,jamie lynn cathey,,PRTM-4510,2017
+PRTM,4550,1,Adv Program Planning,0.59,0.23,0.14,0.0,0.05,0.0,0.0,0.0,jamie lynn cathey,,PRTM-4550,2017
+PRTM,4980,7,Tanzania,0.86,0.0,0.0,0.0,0.14,0.0,0.0,0.0,skye arthur-banning,,PRTM-4980,2017
+PRTM,8030,1,Sem Rec & Park Admin,0.65,0.25,0.05,0.0,0.05,0.0,0.0,0.0,teresa walto tucker,,PRTM-8030,2017
+PRTM,8110,2,Research Methods,0.35,0.53,0.09,0.0,0.03,0.0,0.0,0.0,dorothy schmalz,,PRTM-8110,2017
+PRTM,8110,3,Research Methods,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charl hallo,,PRTM-8110,2017
+PRTM,8250,1,Populations in PRTM,0.5,0.33,0.0,0.0,0.17,0.0,0.0,0.0,dorothy schmalz,,PRTM-8250,2017
+PRTM,8500,2,Sustainable Tourism,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,kenneth backman,,PRTM-8500,2017
+PRTM,8720,1,Adv Facilitation Techniq in RT,0.6,0.0,0.2,0.0,0.0,0.0,0.0,0.2,jasmine nu townsend,,PRTM-8720,2017
+PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.7,0.0,0.0,0.0,0.2,0.0,0.0,0.1,stephen thoma lewis,,PRTM-8730,2017
+PRTM,9000,4,Politics of Science,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,gary edward machlis,,PRTM-9000,2017
+PRTM,9110,1,Professional Issues,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,gwynn powell,,PRTM-9110,2017
+PSYC,2010,1,Intro to Psychology,0.43,0.28,0.16,0.07,0.04,0.0,0.0,0.02,jo anne jorgensen,,PSYC-2010,2017
+PSYC,2010,2,Intro to Psychology,0.2,0.28,0.23,0.13,0.08,0.0,0.0,0.08,edwin brainerd,,PSYC-2010,2017
+PSYC,2010,3,Intro to Psychology,0.22,0.36,0.3,0.04,0.01,0.0,0.0,0.06,thomas britt,,PSYC-2010,2017
+PSYC,2010,4,Intro to Psychology,0.44,0.34,0.16,0.03,0.01,0.0,0.0,0.01,fred switzer,,PSYC-2010,2017
+PSYC,2010,5,Intro to Psychology,0.36,0.3,0.16,0.12,0.03,0.0,0.0,0.03,mary taylor,,PSYC-2010,2017
+PSYC,2010,6,Intro to Psychology,0.36,0.36,0.19,0.1,0.0,0.0,0.0,0.0,mary taylor,,PSYC-2010,2017
+PSYC,2010,7,Intro to Psychology (HON),0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True,PSYC-2010,2017
+PSYC,2020,3,Intro Psychology Lab,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,madison eliza sauls,,PSYC-2020,2017
+PSYC,2020,4,Intro Psychology Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,madison eliza sauls,,PSYC-2020,2017
+PSYC,2020,5,Intro Psychology Lab,0.86,0.04,0.04,0.0,0.04,0.0,0.0,0.04,nastassia ma savage,,PSYC-2020,2017
+PSYC,2020,6,Intro Psychology Lab,0.81,0.07,0.04,0.04,0.0,0.0,0.0,0.04,nastassia ma savage,,PSYC-2020,2017
+PSYC,3060,1,Human Sexual Beh,0.55,0.23,0.12,0.05,0.04,0.0,0.0,0.01,bruce michael king,,PSYC-3060,2017
+PSYC,3090,100,Intro Exp Psych,0.25,0.37,0.17,0.08,0.08,0.0,0.0,0.04,richard tyrrell,,PSYC-3090,2017
+PSYC,3090,200,Intro Exp Psych,0.48,0.27,0.15,0.03,0.06,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3090,2017
+PSYC,3090,300,Intro Exp Psych,0.55,0.26,0.1,0.03,0.06,0.0,0.0,0.0,stephen robertson,,PSYC-3090,2017
+PSYC,3100,100,Advanced Experimental Psych,0.47,0.32,0.11,0.05,0.05,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3100,2017
+PSYC,3100,200,Advanced Experimental Psych,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,robert campbell,,PSYC-3100,2017
+PSYC,3100,300,Advanced Experimental Psych,0.39,0.44,0.11,0.0,0.0,0.0,0.0,0.06,cynthia pury,,PSYC-3100,2017
+PSYC,3100,400,Advanced Experimental Psych,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2017
+PSYC,3100,500,Advanced Experimental Psych,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3100,2017
+PSYC,3100,600,Advanced Experimental Psych,0.43,0.52,0.0,0.0,0.05,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2017
+PSYC,3240,1,Physiological Psych,0.48,0.23,0.14,0.07,0.07,0.0,0.0,0.0,claudio cantalupo,,PSYC-3240,2017
+PSYC,3240,2,Physiological Psych,0.24,0.39,0.25,0.06,0.03,0.0,0.0,0.03,june pilcher,,PSYC-3240,2017
+PSYC,3330,1,Cognitive Psych,0.45,0.26,0.2,0.03,0.06,0.0,0.0,0.0,robert campbell,,PSYC-3330,2017
+PSYC,3330,2,Cognitive Psych,0.46,0.38,0.13,0.03,0.0,0.0,0.0,0.01,leah hartman,,PSYC-3330,2017
+PSYC,3340,1,Cognitive Psych Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany cooper,,PSYC-3340,2017
+PSYC,3340,2,Cognitive Psych Lab,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,tiffany cooper,,PSYC-3340,2017
+PSYC,3400,1,Lifespan Developmental Psych,0.64,0.24,0.08,0.02,0.02,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3400,2017
+PSYC,3400,2,Lifespan Developmental Psych,0.21,0.34,0.2,0.1,0.03,0.0,0.0,0.11,pamela alley,,PSYC-3400,2017
+PSYC,3520,1,Social Psychology,0.64,0.26,0.06,0.01,0.01,0.0,0.0,0.01,eric mckibben,,PSYC-3520,2017
+PSYC,3520,2,Social Psychology,0.36,0.39,0.2,0.03,0.0,0.0,0.0,0.03,eric mckibben,,PSYC-3520,2017
+PSYC,3640,1,Industrial Psych,0.19,0.41,0.26,0.04,0.03,0.0,0.0,0.06,eric mckibben,,PSYC-3640,2017
+PSYC,3640,2,Industrial Psych,0.33,0.4,0.24,0.01,0.01,0.0,0.0,0.0,eric mckibben,,PSYC-3640,2017
+PSYC,3680,1,Organizational Psych,0.16,0.49,0.26,0.04,0.04,0.0,0.0,0.01,gargi sawhney,,PSYC-3680,2017
+PSYC,3830,1,Abnormal Psychology,0.48,0.34,0.09,0.05,0.04,0.0,0.0,0.0,jo anne jorgensen,,PSYC-3830,2017
+PSYC,3830,2,Abnormal Psychology,0.48,0.28,0.17,0.06,0.0,0.0,0.0,0.01,jo anne jorgensen,,PSYC-3830,2017
+PSYC,3830,3,Abnormal Psychology,0.23,0.34,0.26,0.11,0.03,0.0,0.0,0.03,pamela alley,,PSYC-3830,2017
+PSYC,3830,4,Abnormal Psychology,0.34,0.26,0.11,0.09,0.11,0.0,0.0,0.09,pamela alley,,PSYC-3830,2017
+PSYC,4080,1,Women and Psychology,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,,PSYC-4080,2017
+PSYC,4080,2,Women and Psychology,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,robin mari kowalski,,PSYC-4080,2017
+PSYC,4150,1,Systems and Theories,0.23,0.37,0.2,0.03,0.09,0.0,0.0,0.09,edwin brainerd,,PSYC-4150,2017
+PSYC,4150,2,Systems and Theories,0.34,0.2,0.26,0.14,0.06,0.0,0.0,0.0,edwin brainerd,,PSYC-4150,2017
+PSYC,4150,3,Systems and Theories,0.37,0.37,0.16,0.03,0.03,0.0,0.0,0.05,brian day,,PSYC-4150,2017
+PSYC,4150,3,Systems and Theories,0.37,0.37,0.16,0.03,0.03,0.0,0.0,0.05,brian day,,PSYC-4150,2017
+PSYC,4220,1,Perception,0.41,0.3,0.11,0.11,0.04,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2017
+PSYC,4220,2,Perception,0.54,0.15,0.23,0.0,0.04,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2017
+PSYC,4220,3,Perception,0.24,0.28,0.24,0.16,0.08,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2017
+PSYC,4350,1,Human Factors,0.52,0.16,0.32,0.0,0.0,0.0,0.0,0.0,laura whitlock,,PSYC-4350,2017
+PSYC,4560,1,Psychophysiology,0.36,0.2,0.24,0.08,0.08,0.0,0.0,0.04,drew michael morris,,PSYC-4560,2017
+PSYC,4560,1,Psychophysiology,0.36,0.2,0.24,0.08,0.08,0.0,0.0,0.04,drew michael morris,,PSYC-4560,2017
+PSYC,4710,1,Psych of Testing,0.52,0.29,0.1,0.05,0.0,0.0,0.0,0.05,robert ray sinclair,,PSYC-4710,2017
+PSYC,4800,1,Health Psychology,0.41,0.52,0.04,0.0,0.0,0.0,0.0,0.04,james mccubbin,,PSYC-4800,2017
+PSYC,4800,2,Health Psychology,0.32,0.52,0.12,0.0,0.0,0.0,0.0,0.04,james mccubbin,,PSYC-4800,2017
+PSYC,4880,1,Psychotherapy,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,lucinda sorci quick,,PSYC-4880,2017
+PSYC,4890,1,21st Cen Teamwork,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,marissa leig porter,,PSYC-4890,2017
+PSYC,4920,4,Senior Laboratory,0.89,0.04,0.0,0.04,0.04,0.0,0.0,0.0,miranda pelkey,,PSYC-4920,2017
+PSYC,4920,5,Senior Laboratory,0.77,0.09,0.05,0.0,0.0,0.0,0.0,0.09,dana verhoeven,,PSYC-4920,2017
+PSYC,4980,291,CI Suicide Prevention,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,heidi marie zinzow,,PSYC-4980,2017
+PSYC,8130,1,Research Design III,0.71,0.19,0.05,0.0,0.0,0.0,0.0,0.05, dewayne moore,,PSYC-8130,2017
+PSYC,8140,1,Quantitative Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05, dewayne moore,,PSYC-8140,2017
+PSYC,8680,1,Leadership in Orgs,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,patrick raymark,,PSYC-8680,2017
+PSYC,8710,1,Psych Tests,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,mary taylor,,PSYC-8710,2017
+PSYC,8710,1,Psych Tests,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,mary taylor,,PSYC-8710,2017
+RCID,8030,1,Emp Res Methods,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,,RCID-8030,2017
+RED,8030,1,Pub-Priv Partnership,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,john terrenc farris,,RED-8030,2017
+RED,8040,1,Resid Practicum,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey randolph,,RED-8040,2017
+RED,8890,2,Selected Topics-Ad. Fin. Mod.,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,larry bradle harvey,,RED-8890,2017
+REL,1010,1,Intro to Religion,0.32,0.53,0.05,0.05,0.05,0.0,0.0,0.0,steven grosby,,REL-1010,2017
+REL,1010,2,Intro to Religion,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,robert stephens,,REL-1010,2017
+REL,1010,3,Intro to Religion,0.66,0.23,0.03,0.0,0.03,0.0,0.0,0.06,robert stephens,,REL-1010,2017
+REL,1010,4,Intro to Religion,0.38,0.47,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,,REL-1010,2017
+REL,1020,1,World Religions,0.2,0.29,0.31,0.09,0.09,0.0,0.0,0.03,peter cohen,,REL-1020,2017
+REL,1020,2,World Religions,0.2,0.29,0.26,0.17,0.09,0.0,0.0,0.0,peter cohen,,REL-1020,2017
+REL,1020,4,World Religions,0.35,0.29,0.18,0.12,0.03,0.0,0.0,0.03,peter cohen,,REL-1020,2017
+REL,1020,7,World Religions,0.34,0.5,0.13,0.0,0.0,0.0,0.0,0.03,brett patterson,,REL-1020,2017
+REL,3000,2,Studying Religion,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth jemison,,REL-3000,2017
+REL,3010,1,Old Testament,0.43,0.51,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3010,2017
+REL,3020,1,New Testament Lit,0.42,0.42,0.06,0.03,0.03,0.0,0.0,0.03,benjamin white,,REL-3020,2017
+REL,3030,1,The Quran,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,mashal saif,,REL-3030,2017
+REL,3100,1,History of Religion in the US,0.28,0.44,0.22,0.0,0.0,0.0,0.0,0.06,elizabeth jemison,,REL-3100,2017
+REL,3120,1,Hinduism,0.15,0.62,0.0,0.0,0.0,0.0,0.0,0.23,robert stephens,,REL-3120,2017
+REL,3170,1,Hist of Nat. Am. Relig/Culture,0.33,0.42,0.17,0.08,0.0,0.0,0.0,0.0,james brad jeffries,,REL-3170,2017
+RS,3010,1,Rural Sociology,0.41,0.48,0.03,0.03,0.03,0.0,0.0,0.0,kenneth robinson,,RS-3010,2017
+RUSS,1020,1,Elementary Russian,0.4,0.47,0.13,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,,RUSS-1020,2017
+RUSS,3610,1,Russn Lit Since 1910,0.56,0.33,0.06,0.0,0.06,0.0,0.0,0.0,olga anatol volkova,,RUSS-3610,2017
+SAP,8020,1,Study Abroad Hybrid Grad,0.0,0.0,0.0,0.0,0.0,0.75,0.0,0.25,uttiyo raychaudhuri,,SAP-8020,2017
+SOC,2010,2,Introduction to Sociology,0.85,0.06,0.04,0.04,0.0,0.0,0.0,0.0,andrew mannheimer,,SOC-2010,2017
+SOC,2010,3,Introduction to Sociology,0.79,0.15,0.04,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,,SOC-2010,2017
+SOC,2010,4,Introduction to Sociology,0.69,0.16,0.12,0.0,0.02,0.0,0.0,0.0,jennifer le holland,,SOC-2010,2017
+SOC,2010,5,Introduction to Sociology,0.27,0.52,0.13,0.0,0.0,0.0,0.0,0.08,carolyn can coffman,,SOC-2010,2017
+SOC,2010,6,Introduction to Sociology,0.68,0.25,0.05,0.0,0.0,0.0,0.0,0.01,shannon mcdonough,,SOC-2010,2017
+SOC,2010,7,Introduction to Sociology,0.76,0.18,0.02,0.0,0.0,0.0,0.0,0.04,shannon mcdonough,,SOC-2010,2017
+SOC,2010,8,Introduction to Sociology,0.64,0.24,0.1,0.02,0.0,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2017
+SOC,2010,9,Introduction to Sociology,0.21,0.64,0.11,0.04,0.0,0.0,0.0,0.0,mary louise barr,,SOC-2010,2017
+SOC,2010,10,Introduction to Sociology,0.37,0.41,0.18,0.0,0.0,0.0,0.0,0.04,mary louise barr,,SOC-2010,2017
+SOC,2010,11,Introduction to Sociology,0.17,0.5,0.15,0.1,0.04,0.0,0.0,0.04,mary louise barr,,SOC-2010,2017
+SOC,2010,12,Introduction to Sociology,0.28,0.43,0.15,0.06,0.02,0.0,0.0,0.06,mary louise barr,,SOC-2010,2017
+SOC,2020,1,Social Problems,0.17,0.61,0.12,0.02,0.07,0.0,0.0,0.0,carolyn can coffman,,SOC-2020,2017
+SOC,2020,2,Social Problems,0.33,0.46,0.13,0.09,0.0,0.0,0.0,0.0,carolyn can coffman,,SOC-2020,2017
+SOC,2050,1,Sociology Lab,0.55,0.23,0.03,0.0,0.16,0.0,0.0,0.03,brenda vander mey,,SOC-2050,2017
+SOC,3020,1,Research Methods I,0.3,0.48,0.17,0.04,0.0,0.0,0.0,0.0,andrew whitehead,,SOC-3020,2017
+SOC,3040,1,Social Research Methods II,0.14,0.18,0.55,0.14,0.0,0.0,0.0,0.0,ye luo,,SOC-3040,2017
+SOC,3100,1,Marriage & Intimacy,0.26,0.39,0.13,0.04,0.11,0.0,0.0,0.07,carolyn can coffman,,SOC-3100,2017
+SOC,3600,1,Class & Poverty,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william wentworth,,SOC-3600,2017
+SOC,3600,2,Class & Poverty,0.81,0.14,0.0,0.03,0.03,0.0,0.0,0.0,william wentworth,,SOC-3600,2017
+SOC,3800,1,Intro Social Service,0.58,0.24,0.16,0.02,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-3800,2017
+SOC,3910,1,Soc of Deviance,0.32,0.36,0.13,0.04,0.06,0.0,0.0,0.09,william white,,SOC-3910,2017
+SOC,3940,1,Sociology of Mental Illness,0.6,0.28,0.04,0.02,0.04,0.0,0.0,0.02,marissa el yingling,,SOC-3940,2017
+SOC,3970,1,Substance Abuse,0.53,0.35,0.1,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,,SOC-3970,2017
+SOC,4030,1,"Technol, Environment & Society",0.14,0.32,0.23,0.14,0.05,0.0,0.0,0.14, catherine mobley,,SOC-4030,2017
+SOC,4040,1,Soc Theory,0.51,0.34,0.09,0.03,0.0,0.0,0.0,0.03,william wentworth,,SOC-4040,2017
+SOC,4320,1,Soc of Religion,0.19,0.38,0.44,0.0,0.0,0.0,0.0,0.0,andrew whitehead,,SOC-4320,2017
+SOC,4330,1,Global Social Change,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,william haller,,SOC-4330,2017
+SOC,4600,1,Race & Ethnicity,0.52,0.3,0.11,0.0,0.0,0.0,0.0,0.07,brenda vander mey,,SOC-4600,2017
+SOC,4610,1,Sex & Gender,0.36,0.48,0.07,0.05,0.02,0.0,0.0,0.02,traci ann hefner,,SOC-4610,2017
+SOC,4800,1,Medical Sociology,0.53,0.24,0.12,0.0,0.06,0.0,0.0,0.06,carolyn can coffman,,SOC-4800,2017
+SOC,4840,1,Child Abuse,0.56,0.3,0.07,0.0,0.05,0.0,0.0,0.02,marissa el yingling,,SOC-4840,2017
+SOC,4860,2,Creative Inquiry: Sociology,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,margaret tina britz,,SOC-4860,2017
+SOC,4860,3,Creative Inquiry in Sociology,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,margaret tina britz,,SOC-4860,2017
+SOC,4950,1,Field Experience,0.85,0.0,0.15,0.0,0.0,0.0,0.0,0.0, catherine mobley,,SOC-4950,2017
+SOC,4970,1,Senior Lab,0.25,0.25,0.4,0.05,0.05,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2017
+SOC,4970,2,Senior Lab,0.28,0.22,0.28,0.06,0.17,0.0,0.0,0.0,brenda vander mey,,SOC-4970,2017
+SOC,4990,1,Sel Top Seminar in Contemp Soc,0.63,0.25,0.06,0.0,0.06,0.0,0.0,0.0,andrew mannheimer,,SOC-4990,2017
+SPAN,1010,1,Elementary Spanish,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2017
+SPAN,1010,2,Elementary Spanish,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,scott harris,,SPAN-1010,2017
+SPAN,1020,2,Elementary Spanish,0.44,0.28,0.17,0.06,0.0,0.0,0.0,0.06,al garcia rodriguez,,SPAN-1020,2017
+SPAN,1020,3,Elementary Spanish,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,al garcia rodriguez,,SPAN-1020,2017
+SPAN,1020,4,Elementary Spanish,0.58,0.32,0.0,0.05,0.0,0.0,0.0,0.05,al garcia rodriguez,,SPAN-1020,2017
+SPAN,1020,5,Elementary Spanish,0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,al garcia rodriguez,,SPAN-1020,2017
+SPAN,1020,6,Elementary Spanish,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,cathy robison,,SPAN-1020,2017
+SPAN,1020,7,Elementary Spanish,0.29,0.53,0.12,0.0,0.06,0.0,0.0,0.0,cathy robison,,SPAN-1020,2017
+SPAN,1020,8,Elementary Spanish,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,debra oa williamson,,SPAN-1020,2017
+SPAN,1020,9,Elementary Spanish,0.47,0.29,0.24,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-1020,2017
+SPAN,1020,10,Elementary Spanish,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-1020,2017
+SPAN,1020,11,Elementary Spanish,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-1020,2017
+SPAN,2010,1,Intermediate Spanish,0.32,0.47,0.11,0.05,0.0,0.0,0.0,0.05,cathy robison,,SPAN-2010,2017
+SPAN,2010,2,Intermediate Spanish,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,cathy robison,,SPAN-2010,2017
+SPAN,2010,3,Intermediate Spanish,0.41,0.41,0.0,0.0,0.0,0.0,0.0,0.18,allison ann hinds,,SPAN-2010,2017
+SPAN,2010,4,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,,SPAN-2010,2017
+SPAN,2010,5,Intermediate Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,allison ann hinds,,SPAN-2010,2017
+SPAN,2010,6,Intermediate Spanish,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-2010,2017
+SPAN,2010,7,Intermediate Spanish,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-2010,2017
+SPAN,2010,8,Intermediate Spanish,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2010,2017
+SPAN,2010,9,Intermediate Spanish,0.42,0.42,0.11,0.05,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2010,2017
+SPAN,2010,10,Intermediate Spanish,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,,SPAN-2010,2017
+SPAN,2010,11,Intermediate Spanish,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,,SPAN-2010,2017
+SPAN,2010,13,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,,SPAN-2010,2017
+SPAN,2010,14,Intermediate Spanish,0.43,0.29,0.14,0.0,0.0,0.0,0.0,0.14,melva margu persico,,SPAN-2010,2017
+SPAN,2010,15,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0, buitrago gonzalez,,SPAN-2010,2017
+SPAN,2010,16,Intermediate Spanish,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-2010,2017
+SPAN,2020,1,Intermediate Spanish,0.75,0.15,0.1,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-2020,2017
+SPAN,2020,2,Intermediate Spanish,0.61,0.22,0.0,0.0,0.11,0.0,0.0,0.06,danie garcia vieyra,,SPAN-2020,2017
+SPAN,2020,3,Intermediate Spanish,0.57,0.29,0.05,0.05,0.0,0.0,0.0,0.05,danie garcia vieyra,,SPAN-2020,2017
+SPAN,2020,4,Intermediate Spanish,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2017
+SPAN,2020,5,Intermediate Spanish,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2017
+SPAN,2020,6,Intermediate Spanish,0.76,0.1,0.05,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,,SPAN-2020,2017
+SPAN,2020,7,Intermediate Spanish,0.35,0.41,0.12,0.06,0.06,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2017
+SPAN,2020,8,Intermediate Spanish,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2017
+SPAN,2020,9,Intermediate Spanish,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2017
+SPAN,2020,10,Intermediate Spanish,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2017
+SPAN,2020,11,Intermediate Spanish,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2017
+SPAN,2020,12,Intermediate Spanish,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2017
+SPAN,2020,13,Intermediate Spanish,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,heidi montes,,SPAN-2020,2017
+SPAN,2020,14,Intermediate Spanish,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,heidi montes,,SPAN-2020,2017
+SPAN,2020,15,Intermediate Spanish,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,nora arostegu logue,,SPAN-2020,2017
+SPAN,3020,1,Int Spn Gram & Comp,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,george palacios,,SPAN-3020,2017
+SPAN,3020,2,Int Spn Gram & Comp,0.3,0.5,0.15,0.0,0.05,0.0,0.0,0.0,melva margu persico,,SPAN-3020,2017
+SPAN,3020,3,Int Spn Gram & Comp,0.11,0.84,0.0,0.0,0.05,0.0,0.0,0.0,melva margu persico,,SPAN-3020,2017
+SPAN,3040,1,Intro Hisp Lit Forms,0.78,0.09,0.09,0.0,0.0,0.0,0.0,0.04,george palacios,,SPAN-3040,2017
+SPAN,3050,1,Int Con Comp Span I,0.28,0.44,0.17,0.0,0.0,0.0,0.0,0.11,melva margu persico,,SPAN-3050,2017
+SPAN,3050,2,Int Con Comp Span I,0.5,0.35,0.05,0.0,0.05,0.0,0.0,0.05,juana martin-armas,,SPAN-3050,2017
+SPAN,3050,3,Int Con Comp Span I,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,juana martin-armas,,SPAN-3050,2017
+SPAN,3060,1,Span Comp for Bus,0.6,0.25,0.05,0.0,0.05,0.0,0.0,0.05,maureen zamora,,SPAN-3060,2017
+SPAN,3070,1,Hispanic World: Sp,0.26,0.37,0.21,0.0,0.11,0.0,0.0,0.05,juana martin-armas,,SPAN-3070,2017
+SPAN,3080,1,Hispanic World: La,0.33,0.44,0.22,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,,SPAN-3080,2017
+SPAN,3080,2,Hispanic World: La,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,tiffany dawn miller,,SPAN-3080,2017
+SPAN,3130,1,Span Lit Survey I,0.4,0.2,0.2,0.0,0.1,0.0,0.0,0.1,mon rojas-de-massei,,SPAN-3130,2017
+SPAN,3130,35,Span Lit Survey I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-3130,2017
+SPAN,3140,1,Hispanic Linguistics,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,daniel smith,,SPAN-3140,2017
+SPAN,3160,1,Span for Intl Trade,0.76,0.06,0.12,0.0,0.0,0.0,0.0,0.06,maureen zamora,,SPAN-3160,2017
+SPAN,4010,1,New Spanish Fiction,0.75,0.0,0.13,0.0,0.06,0.0,0.0,0.06,salvador oropesa,,SPAN-4010,2017
+SPAN,4060,1,Narrative Fiction,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,mon rojas-de-massei,,SPAN-4060,2017
+SPAN,4070,1,Hispanic Film,0.33,0.5,0.11,0.0,0.0,0.0,0.0,0.06,raquel anido,,SPAN-4070,2017
+SPAN,4150,1,Span for Health Prof,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,areli moore peralta,,SPAN-4150,2017
+SPAN,4170,1,Prof Communication,0.53,0.33,0.0,0.0,0.0,0.0,0.0,0.13,maureen zamora,,SPAN-4170,2017
+SPAN,4180,35,Tech Span Health Man,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-4180,2017
+STAT,2220,1,Statistics in Everyday Life,0.3,0.36,0.25,0.08,0.02,0.0,0.0,0.0,james espey,,STAT-2220,2017
+STAT,2220,2,Statistics in Everyday Life,0.4,0.34,0.09,0.11,0.04,0.0,0.0,0.02,james espey,,STAT-2220,2017
+STAT,2220,3,Statistics in Everyday Life,0.32,0.4,0.11,0.13,0.02,0.0,0.0,0.02,james espey,,STAT-2220,2017
+STAT,2220,4,Statistics in Everyday Life,0.3,0.28,0.3,0.07,0.02,0.0,0.0,0.04,james espey,,STAT-2220,2017
+STAT,2220,5,Statistics in Everyday Life,0.32,0.36,0.17,0.04,0.11,0.0,0.0,0.0,ros martinez-dawson,,STAT-2220,2017
+STAT,2220,6,Statistics in Everyday Life,0.33,0.41,0.22,0.02,0.0,0.0,0.0,0.02,ros martinez-dawson,,STAT-2220,2017
+STAT,2220,7,Statistics in Everyday Life,0.33,0.3,0.26,0.09,0.02,0.0,0.0,0.0,andrew walton green,,STAT-2220,2017
+STAT,2300,1,Statistical Methods I,0.29,0.35,0.15,0.12,0.04,0.0,0.0,0.05,christy jenki brown,,STAT-2300,2017
+STAT,2300,2,Statistical Methods I,0.36,0.25,0.22,0.12,0.05,0.0,0.0,0.01,christy jenki brown,,STAT-2300,2017
+STAT,2300,3,Statistical Methods I,0.4,0.32,0.14,0.08,0.02,0.0,0.0,0.04,christy jenki brown,,STAT-2300,2017
+STAT,2300,4,Statistical Methods I,0.29,0.29,0.2,0.1,0.1,0.0,0.0,0.03,april thomas,,STAT-2300,2017
+STAT,2300,5,Statistical Methods I,0.24,0.42,0.16,0.1,0.05,0.0,0.0,0.04, erwin walker,,STAT-2300,2017
+STAT,2300,6,Statistical Methods I,0.21,0.39,0.22,0.1,0.06,0.0,0.0,0.03, erwin walker,,STAT-2300,2017
+STAT,2300,7,Statistical Methods I,0.12,0.23,0.27,0.2,0.12,0.0,0.0,0.05,tao yang,,STAT-2300,2017
+STAT,3090,1,Introductory Business Stats,0.05,0.33,0.24,0.19,0.17,0.0,0.0,0.02,boyoung hur,,STAT-3090,2017
+STAT,3090,2,Introductory Business Stats,0.16,0.3,0.23,0.09,0.12,0.0,0.0,0.09,elaine ma sotherden,,STAT-3090,2017
+STAT,3090,3,Introductory Business Stats,0.14,0.51,0.19,0.07,0.07,0.0,0.0,0.02,sharon marie evans,,STAT-3090,2017
+STAT,3090,4,Introductory Business Stats,0.19,0.33,0.21,0.17,0.07,0.0,0.0,0.02,sharon marie evans,,STAT-3090,2017
+STAT,3090,5,Introductory Business Stats,0.28,0.42,0.16,0.07,0.07,0.0,0.0,0.0,sharon marie evans,,STAT-3090,2017
+STAT,3090,6,Introductory Business Stats,0.24,0.39,0.24,0.0,0.07,0.0,0.0,0.05, morales hernandez,,STAT-3090,2017
+STAT,3090,7,Introductory Business Stats,0.17,0.39,0.34,0.07,0.02,0.0,0.0,0.0,jason alexande kurz,,STAT-3090,2017
+STAT,3090,8,Introductory Business Stats,0.11,0.43,0.31,0.03,0.09,0.0,0.0,0.03,li he,,STAT-3090,2017
+STAT,3090,9,Introductory Business Stats,0.15,0.12,0.3,0.15,0.18,0.0,0.0,0.09,mengcong ren,,STAT-3090,2017
+STAT,3090,10,Introductory Business Stats,0.31,0.4,0.17,0.09,0.03,0.0,0.0,0.0,dilhani marasinghe,,STAT-3090,2017
+STAT,3090,11,Introductory Business Stats,0.11,0.28,0.17,0.15,0.22,0.0,0.0,0.07,sanjog arv kulkarni,,STAT-3090,2017
+STAT,3090,12,Introductory Business Stats,0.18,0.44,0.23,0.08,0.05,0.0,0.0,0.03,yijun chen,,STAT-3090,2017
+STAT,3090,13,Introductory Business Stats,0.24,0.31,0.26,0.02,0.12,0.0,0.0,0.05,kayla doris javier,,STAT-3090,2017
+STAT,3090,14,Introductory Business Stats,0.16,0.36,0.25,0.02,0.18,0.0,0.0,0.02,andrew pangia,,STAT-3090,2017
+STAT,3300,1,Statistical Methods II,0.25,0.33,0.29,0.04,0.04,0.0,0.0,0.04,ros martinez-dawson,,STAT-3300,2017
+STAT,4020,1,Intro to Statistical Computing,0.5,0.19,0.06,0.06,0.06,0.0,0.0,0.13,ellen hepfe breazel,,STAT-4020,2017
+STAT,4110,1,Stat Mthds for Process Control,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lawrence wad grimes,,STAT-4110,2017
+STAT,4110,2,Stat Mthds for Process Control,0.5,0.28,0.11,0.0,0.11,0.0,0.0,0.0,james rieck,,STAT-4110,2017
+STAT,6020,1,Intro to Statistical Computing,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,ellen hepfe breazel,,STAT-6020,2017
+STAT,8010,1,Statistical Methods I,0.5,0.3,0.07,0.0,0.07,0.0,0.0,0.07,brook thaye russell,,STAT-8010,2017
+STAT,8010,2,Statistical Methods I,0.38,0.28,0.18,0.0,0.1,0.0,0.0,0.08,james rieck,,STAT-8010,2017
+STAT,8010,3,Statistical Methods I,0.64,0.24,0.06,0.0,0.03,0.0,0.0,0.03,jun luo,,STAT-8010,2017
+STAT,8040,1,Sampling,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,,STAT-8040,2017
+STAT,8050,1,Design & Anlys of Experiments,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-8050,2017
+STS,1010,2,Survey of S T S,0.3,0.55,0.09,0.03,0.0,0.0,0.0,0.03,scott brame,,STS-1010,2017
+STS,1010,3,Survey of S T S,0.5,0.39,0.08,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,,STS-1010,2017
+STS,1010,4,Survey of S T S,0.67,0.28,0.03,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,,STS-1010,2017
+STS,1010,5,Survey of S T S,0.65,0.32,0.03,0.0,0.0,0.0,0.0,0.0,philip randall,,STS-1010,2017
+STS,1010,6,Survey of S T S,0.36,0.47,0.03,0.0,0.0,0.0,0.0,0.14,sarah mae cooper,,STS-1010,2017
+STS,1010,7,Survey of S T S,0.46,0.23,0.17,0.03,0.06,0.0,0.0,0.06,megan no macalystre,,STS-1010,2017
+STS,1010,8,Survey of S T S,0.28,0.24,0.24,0.07,0.03,0.0,0.0,0.14,david charles foltz,,STS-1010,2017
+THEA,2100,1,Theatre Appreciation,0.58,0.29,0.1,0.0,0.0,0.0,0.0,0.03,kendra lyne johnson,,THEA-2100,2017
+THEA,2100,2,Theatre Appreciation,0.72,0.22,0.0,0.03,0.03,0.0,0.0,0.0,kendra lyne johnson,,THEA-2100,2017
+THEA,2100,3,Theatre Appreciation,0.81,0.16,0.0,0.03,0.0,0.0,0.0,0.0,kerrie kath seymour,,THEA-2100,2017
+THEA,2100,4,Theatre Appreciation,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-2100,2017
+THEA,2100,6,Theatre Appreciation,0.34,0.5,0.09,0.03,0.0,0.0,0.0,0.03,jason adkins,,THEA-2100,2017
+THEA,2100,7,Theatre Appreciation,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,richard st. peter,,THEA-2100,2017
+THEA,2100,9,Theatre Appreciation,0.91,0.03,0.0,0.0,0.0,0.0,0.0,0.06,richard st. peter,,THEA-2100,2017
+THEA,2770,1,Prod Studies in Thea,0.72,0.17,0.03,0.0,0.03,0.0,0.0,0.03,david hartmann,,THEA-2770,2017
+THEA,2790,1,Theatre Practicum,0.67,0.25,0.0,0.0,0.08,0.0,0.0,0.0,matthew leckenbusch,,THEA-2790,2017
+THEA,3180,1,Afri-Amer Thea II,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,kendra lyne johnson,,THEA-3180,2017
+THEA,3740,1,Movement for Actors,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,kerrie kath seymour,,THEA-3740,2017
+THEA,4720,1,Improvisation,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-4720,2017
+WFB,3010,1,Wildlife Biology Lab,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2017
+WFB,3010,2,Wildlife Biology Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2017
+WFB,3130,1,Conservation Biology,0.46,0.29,0.14,0.05,0.04,0.0,0.0,0.01,shari lyn rodriguez,,WFB-3130,2017
+WFB,3130,2,Conservation Biology,0.35,0.2,0.35,0.02,0.06,0.0,0.0,0.02,shari lyn rodriguez,,WFB-3130,2017
+WFB,3500,1,Princ Fish & Wildlife Biology,0.38,0.42,0.13,0.0,0.0,0.0,0.0,0.07,james davis,,WFB-3500,2017
+WFB,3500,2,Princ Fish & Wildlife Biology,0.3,0.35,0.22,0.09,0.02,0.0,0.0,0.02,james davis,,WFB-3500,2017
+WFB,4160,1,Fishery Biology,0.19,0.5,0.24,0.05,0.02,0.0,0.0,0.0,kasey celen pregler,,WFB-4160,2017
+WFB,4620,1,Wetland Wildlife Biology,0.55,0.4,0.03,0.01,0.0,0.0,0.0,0.0,russell barrett,,WFB-4620,2017
+WFB,4930,2,Quantitative Ecology,0.46,0.3,0.16,0.0,0.03,0.0,0.0,0.05,david sco jachowski,,WFB-4930,2017
+WFB,4930,3,Human Dim of Fisheries & Wildl,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-4930,2017
+WS,1030,1,Women in Global Perspective,0.68,0.24,0.04,0.0,0.0,0.0,0.0,0.04,laura foxworth,,WS-1030,2017
+WS,1030,2,Women in Global Perspective,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,laura foxworth,,WS-1030,2017
+WS,3010,1,Intro Women's Studies,0.54,0.33,0.04,0.04,0.0,0.0,0.0,0.04,elizabeth ros adams,,WS-3010,2017
+WS,3010,2,Intro Women's Studies,0.46,0.38,0.13,0.0,0.04,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2017
+WS,3490,1,Gender and Sexuality,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,diane perpich,,WS-3490,2017
+YDP,3100,1,Youth Developmt and the Family,0.83,0.09,0.0,0.04,0.04,0.0,0.0,0.0,william quinn,,YDP-3100,2017
+YDP,3100,2,Youth Developmt and the Family,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,,YDP-3100,2017
+YDP,3150,1,Community & Youth Dev Systems,0.55,0.27,0.09,0.0,0.09,0.0,0.0,0.0,toby kirkland,,YDP-3150,2017
+YDP,3250,1,Working with Diverse Youth,0.7,0.1,0.15,0.0,0.0,0.0,0.0,0.05,kimberly pe johnson,,YDP-3250,2017
+YDP,8010,1,Child/Adolescent Dev,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,edmond patri bowers,,YDP-8010,2017
+YDP,8040,1,Assess & Eval of Youth Program,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,barry garst,,YDP-8040,2017
+YDP,8880,1,Special Topics Youth Dev Ldshp,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,barry garst,,YDP-8880,2017

--- a/bot/cogs/grades_cog/assets/2018_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2018_Fall.csv
@@ -1,2544 +1,2544 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1010,1,Survey of Art & Arch History I,0.42,0.45,0.11,0.01,0.01,0.0,0.0,0.0,beth ann lauritis,
-AAH,2050,1,Art History and Theory I,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,beth ann lauritis,
-AAH,3050,1,Contemporary Art History,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
-ACCT,2010,1,Financial Accounting Concepts,0.09,0.36,0.27,0.02,0.09,0.0,0.0,0.18,lydia lanc schleifer,
-ACCT,2010,2,Financial Accounting Concepts,0.28,0.23,0.23,0.13,0.04,0.0,0.0,0.09,emily suzan mccorkle,
-ACCT,2010,3,Financial Accounting Concepts,0.33,0.48,0.13,0.08,0.0,0.0,0.0,0.0,emily suzan mccorkle,
-ACCT,2010,4,Financial Accounting Concepts,0.36,0.28,0.21,0.04,0.09,0.0,0.0,0.02,annieka philo,
-ACCT,2010,5,Financial Accounting Concepts,0.33,0.23,0.19,0.02,0.13,0.0,0.0,0.1,lydia lanc schleifer,
-ACCT,2010,6,Financial Accounting Concepts,0.24,0.26,0.29,0.07,0.1,0.0,0.0,0.05,annieka philo,
-ACCT,2010,7,Financial Accounting Concepts,0.17,0.4,0.19,0.07,0.05,0.0,0.0,0.12,emily suzan mccorkle,
-ACCT,2010,8,Financial Accounting Concepts,0.21,0.35,0.19,0.1,0.04,0.0,0.0,0.1,lydia lanc schleifer,
-ACCT,2010,9,Financial Accounting Concepts,0.26,0.41,0.21,0.08,0.0,0.0,0.0,0.05,annieka philo,
-ACCT,2010,10,Financial Accounting Concepts,0.3,0.25,0.23,0.05,0.18,0.0,0.0,0.0,emily suzan mccorkle,
-ACCT,2010,11,Financial Accounting Concepts,0.16,0.42,0.16,0.05,0.11,0.0,0.0,0.11,charles tegen,
-ACCT,2010,12,Financial Accounting Concepts,0.26,0.24,0.29,0.08,0.03,0.0,0.0,0.11,philip maiberger,
-ACCT,2010,13,Financial Accounting Concepts,0.23,0.28,0.36,0.05,0.05,0.0,0.0,0.03,lisa whea birtwistle,
-ACCT,2010,14,Financial Accounting Concepts,0.37,0.37,0.17,0.07,0.0,0.0,0.0,0.02,lisa whea birtwistle,
-ACCT,2010,100,Fin Accounting Concepts (HON),0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,lisa whea birtwistle,True
-ACCT,2010,400,Financial Accounting Concepts,0.19,0.43,0.16,0.09,0.07,0.0,0.0,0.06,jeffrey mcmillan,
-ACCT,2020,1,Managerial Accounting Concepts,0.14,0.2,0.37,0.03,0.09,0.0,0.0,0.17,henry anderson,
-ACCT,2020,2,Managerial Accounting Concepts,0.25,0.45,0.14,0.05,0.02,0.0,0.0,0.09,henry anderson,
-ACCT,2020,3,Managerial Accounting Concepts,0.36,0.24,0.18,0.0,0.09,0.0,0.0,0.13,henry anderson,
-ACCT,2020,4,Managerial Accounting Concepts,0.19,0.35,0.16,0.22,0.0,0.0,0.0,0.08,brian todd carver,
-ACCT,2020,5,Managerial Accounting Concepts,0.24,0.22,0.2,0.07,0.18,0.0,0.0,0.09,brian todd carver,
-ACCT,2020,6,Managerial Accounting Concepts,0.11,0.3,0.27,0.09,0.02,0.0,0.0,0.2,brian todd carver,
-ACCT,2020,7,Managerial Accounting Concepts,0.25,0.29,0.33,0.04,0.02,0.0,0.0,0.06,phebian davis-culler,
-ACCT,2020,400,Managerial Accounting Concepts,0.25,0.36,0.2,0.09,0.04,0.0,0.0,0.06,henry anderson,
-ACCT,3030,3,Cost Accounting,0.45,0.37,0.08,0.0,0.08,0.0,0.0,0.02,phebian davis-culler,
-ACCT,3030,4,Cost Accounting,0.21,0.28,0.3,0.12,0.07,0.0,0.0,0.02,phebian davis-culler,
-ACCT,3110,1,Intermediate Financial Acct I,0.1,0.33,0.25,0.17,0.08,0.0,0.0,0.06,erin michell hawkins,
-ACCT,3110,2,Intermediate Financial Acct I,0.16,0.29,0.24,0.13,0.11,0.0,0.0,0.07,erin michell hawkins,
-ACCT,3110,3,Intermediate Financial Acct I,0.14,0.44,0.23,0.12,0.02,0.0,0.0,0.05,amy melissa donnelly,
-ACCT,3110,4,Intermediate Financial Acct I,0.09,0.55,0.21,0.06,0.02,0.0,0.0,0.06,amy melissa donnelly,
-ACCT,3110,400,Intermediate Financial Acct I,0.21,0.35,0.13,0.04,0.08,0.0,0.0,0.19,henry anderson,
-ACCT,3120,1,Intermediate Financial Acct II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3120,2,Intermediate Financial Acct II,0.1,0.34,0.37,0.07,0.1,0.0,0.0,0.02,jeremy michae vinson,
-ACCT,3120,3,Intermediate Financial Acct II,0.38,0.41,0.21,0.0,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3120,4,Intermediate Financial Acct II,0.35,0.35,0.25,0.03,0.0,0.0,0.0,0.03,jeremy michae vinson,
-ACCT,3120,5,Intermediate Financial Acct II,0.26,0.42,0.26,0.0,0.0,0.0,0.0,0.05,terry daniel knause,
-ACCT,3120,6,Intermediate Financial Acct II,0.33,0.49,0.18,0.0,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3130,1,Intermediate Fin Acct III,0.1,0.31,0.38,0.17,0.05,0.0,0.0,0.0, russell madray,
-ACCT,3130,2,Intermediate Fin Acct III,0.09,0.45,0.33,0.06,0.03,0.0,0.0,0.03, russell madray,
-ACCT,3130,3,Intermediate Fin Acct III,0.27,0.37,0.2,0.1,0.05,0.0,0.0,0.02, russell madray,
-ACCT,3130,4,Intermediate Fin Acct III,0.27,0.27,0.39,0.05,0.02,0.0,0.0,0.0, russell madray,
-ACCT,3220,1,Accounting Information Systems,0.36,0.27,0.25,0.05,0.02,0.0,0.0,0.05,philip maiberger,
-ACCT,3220,2,Accounting Information Systems,0.18,0.34,0.24,0.11,0.05,0.0,0.0,0.08,philip maiberger,
-ACCT,3220,3,Accounting Information Systems,0.16,0.26,0.34,0.11,0.03,0.0,0.0,0.11,philip maiberger,
-ACCT,4040,1,Individual Taxation,0.5,0.29,0.12,0.06,0.03,0.0,0.0,0.0,lisa whea birtwistle,
-ACCT,4040,2,Individual Taxation,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,3,Individual Taxation,0.57,0.26,0.09,0.06,0.03,0.0,0.0,0.0,sarah martin,
-ACCT,4080,1,Retire & Estate Plan,0.37,0.52,0.07,0.0,0.0,0.0,0.0,0.04,john hine,
-ACCT,4100,3,Reporting and Mgmt Control Sys,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,robin radtke,
-ACCT,4150,1,Auditing,0.2,0.5,0.25,0.05,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,4150,2,Auditing,0.26,0.58,0.11,0.05,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,8510,1,Tax Research,0.07,0.93,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8510,2,Tax Research,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8510,3,Tax Research,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8530,1,Adv Acct Problems,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,ralph edward welton,
-ACCT,8530,2,Adv Acct Problems,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8530,3,Adv Acct Problems,0.72,0.25,0.0,0.0,0.0,0.0,0.0,0.03,suzanne pearse,
-ACCT,8550,1,Gov't and Nonprofit Accounting,0.86,0.11,0.03,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8550,2,Gov't and Nonprofit Accounting,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8550,3,Gov't and Nonprofit Accounting,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8650,1,Tax & Bus Decisions,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
-ACCT,8720,1,Tax of Flowthroughs,0.32,0.27,0.38,0.0,0.0,0.0,0.0,0.03,thomas dickens,
-AGED,1020,1,Freshman Seminar,0.8,0.07,0.07,0.07,0.0,0.0,0.0,0.0,catherin dibenedetto,
-AGED,2000,1,Agr Appl of Ed Tech,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,
-AGED,2010,1,Intro to Agric Educ,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,2040,1,App Ag Calculations,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,3030,1,Ag Ed Mech Tech,0.4,0.33,0.2,0.07,0.0,0.0,0.0,0.0,alex byrd,
-AGED,4030,1,Prin Adult/Ext Ed,0.79,0.07,0.07,0.0,0.07,0.0,0.0,0.0,alex byrd,
-AGM,1010,1,Intro Ag Mech & Bus,0.62,0.28,0.03,0.03,0.05,0.0,0.0,0.0,hunter massey,
-AGM,2050,1,Prin of Fabrication,0.26,0.48,0.17,0.05,0.05,0.0,0.0,0.0,hunter massey,
-AGM,2060,1,Machinery Mgt,0.33,0.33,0.2,0.07,0.07,0.0,0.0,0.0,hunter massey,
-AGM,2210,1,Land Measurements,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,charles privette,
-AGM,3010,1,Soil Water Conserv,0.45,0.29,0.2,0.04,0.03,0.0,0.0,0.0,calvin sawyer,
-AGM,4000,1,Seminar in Ag Mech & Business,0.04,0.22,0.4,0.24,0.1,0.0,0.0,0.0,john chastain,
-AGM,4020,1,Irrigation System Design,0.12,0.41,0.35,0.06,0.06,0.0,0.0,0.0,charles privette,
-AGM,4050,1,Env Cont in Anim Str,0.11,0.31,0.44,0.13,0.0,0.0,0.0,0.0,john chastain,
-AGM,4060,1,Mech & Hydraulic Sys,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4520,1,Mobile Power,0.37,0.48,0.11,0.04,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4600,1,Electrical Systems,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,young jo han,
-AGRB,2020,1,Agricultural Economics,0.2,0.29,0.24,0.18,0.05,0.0,0.0,0.04,george apperson,
-AGRB,2050,1,Agriculture and Society,0.15,0.22,0.3,0.25,0.03,0.0,0.0,0.04,michael vassalos,
-AGRB,3020,1,Economics of Farm Management,0.11,0.28,0.27,0.27,0.06,0.0,0.0,0.0,michael vassalos,
-AGRB,3080,1,Quant Agribusiness Analysis I,0.27,0.37,0.2,0.1,0.02,0.0,0.0,0.04,lisha zhang,
-AGRB,3090,1,Econ of Agricultural Marketing,0.59,0.33,0.04,0.0,0.03,0.0,0.0,0.01,yuliya vale bolotova,
-AGRB,3570,1,Natural Resources Economics,0.27,0.23,0.27,0.07,0.07,0.0,0.0,0.09,david brian willis,
-AGRB,4090,1,Commodity Futures Markets,0.13,0.26,0.29,0.21,0.11,0.0,0.0,0.0,george apperson,
-AGRB,4120,1,Reg Econ Devel Theory & Policy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ronald lamie,
-AGRB,4520,1,Agricultural Policy,0.24,0.33,0.24,0.15,0.03,0.0,0.0,0.0,michael vassalos,
-AGRB,4600,1,Agricultural Finance,0.36,0.26,0.26,0.13,0.0,0.0,0.0,0.0,lisha zhang,
-AL,3440,400,Athletics and Women,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,3490,400,Principles of Coaching,0.61,0.29,0.07,0.04,0.0,0.0,0.0,0.0,deborah jo cadorette,
-AL,3490,401,Principles of Coaching,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,
-AL,3490,402,Principles of Coaching,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,john plumblee,
-AL,3490,403,Principles of Coaching,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,john plumblee,
-AL,3490,404,Principles of Coaching,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,3490,407,Principles of Coaching,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,nicholas phi whitrow,
-AL,3490,408,Principles of Coaching,0.56,0.24,0.04,0.04,0.12,0.0,0.0,0.0,nicholas phi whitrow,
-AL,3490,409,Principles of Coaching,0.76,0.12,0.0,0.0,0.12,0.0,0.0,0.0,nicholas phi whitrow,
-AL,3500,400,Sci Basis I/Ex Phy,0.21,0.38,0.21,0.13,0.0,0.0,0.0,0.08,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.3,0.35,0.26,0.09,0.0,0.0,0.0,0.0,michael godfrey,
-AL,3510,400,Nat'l Coach Cert Prep for AL,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,
-AL,3530,400,Athletic Injuries,0.14,0.39,0.32,0.11,0.04,0.0,0.0,0.0,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.28,0.36,0.16,0.08,0.08,0.0,0.0,0.04,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.58,0.21,0.17,0.0,0.0,0.0,0.0,0.04,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3620,400,Psychology of Coaching,0.38,0.12,0.35,0.12,0.04,0.0,0.0,0.0,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.64,0.28,0.04,0.04,0.0,0.0,0.0,0.0,natalie anne carter,
-AL,3620,402,Psychology of Coaching,0.44,0.28,0.16,0.08,0.0,0.0,0.0,0.04,natalie anne carter,
-AL,3740,400,Coaching Football,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,edmond fry,
-AL,3740,401,Coaching Football,0.61,0.09,0.0,0.04,0.04,0.0,0.0,0.22,edmond fry,
-AL,3760,400,Coaching Strength/Conditioning,0.72,0.21,0.0,0.0,0.07,0.0,0.0,0.0,edmond fry,
-AL,3760,401,Coaching Strength/Conditioning,0.81,0.04,0.04,0.0,0.11,0.0,0.0,0.0,edmond fry,
-AL,4380,402,Current Iss in HS Athletics,0.71,0.21,0.0,0.04,0.0,0.0,0.0,0.04,deborah jo cadorette,
-AL,4380,403,Media Relations in AL,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,4380,408,Officiating in AL,0.57,0.22,0.17,0.04,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,8380,400,Sp Topics in Intercoll Athlet,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,elliott charles,
-AL,8440,400,Surv of Res Mthds in Athletics,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristin kelly frady,
-AL,8440,401,Surv of Res Mthds in Athletics,0.71,0.07,0.14,0.0,0.07,0.0,0.0,0.0,kristin kelly frady,
-AL,8500,400,Principles Strength and Condit,0.74,0.19,0.07,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8650,401,Mkt and Comm Respon Interc Ath,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,misty soles,
-ANTH,2010,1,Introduction to Anthropology,0.44,0.24,0.18,0.04,0.04,0.0,0.0,0.04,yi wu,
-ANTH,2010,2,Introduction to Anthropology,0.35,0.33,0.2,0.05,0.02,0.0,0.0,0.05,yi wu,
-ANTH,2010,3,Introduction to Anthropology,0.4,0.49,0.1,0.0,0.0,0.0,0.0,0.01,david markus,
-ANTH,2010,4,Introduction to Anthropology,0.3,0.63,0.05,0.0,0.01,0.0,0.0,0.0,david markus,
-ANTH,2010,5,Introduction to Anthropology,0.36,0.56,0.01,0.03,0.04,0.0,0.0,0.0,david markus,
-ANTH,3320,1,World Archaeology,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,david markus,
-ANTH,3510,1,Biological Anthropology,0.37,0.42,0.11,0.05,0.05,0.0,0.0,0.0,lisa rapaport,
-ANTH,3530,1,Forensic Anthropology,0.24,0.65,0.0,0.12,0.0,0.0,0.0,0.0,katherine weisensee,
-ANTH,4660,1,Evolution of Human Behav,0.4,0.3,0.1,0.2,0.0,0.0,0.0,0.0,lisa rapaport,
-ANTH,4960,2,Anth CI: Entrepreneurs in BSHS,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,janie shonta johnson,
-ARCH,1010,1,Introduction to Architecture,0.63,0.19,0.04,0.01,0.04,0.0,0.0,0.08,sall hambright-belue,
-ARCH,2040,1,Hist of Modern Arch,0.55,0.32,0.12,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,2510,1,Arch Foundations I,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,2510,2,Arch Foundations I,0.14,0.5,0.29,0.0,0.0,0.0,0.0,0.07,robert silance,
-ARCH,2510,3,Arch Foundations I,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,dustin grah albright,
-ARCH,2510,4,Arch Foundations I,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,2510,5,Arch Foundations I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,2510,6,Arch Foundations I,0.54,0.31,0.08,0.08,0.0,0.0,0.0,0.0,timothy sutherland,
-ARCH,2700,1,Structures I,0.52,0.42,0.06,0.0,0.0,0.0,0.0,0.0,dustin grah albright,
-ARCH,3500,1,Intro to Urban Contexts,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,
-ARCH,3500,2,Intro to Urban Contexts,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,3500,3,Intro to Urban Contexts,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,3500,4,Intro to Urban Contexts,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,3500,5,Intro to Urban Contexts,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,3510,3,Studio Clemson,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,michael carlo kleiss,
-ARCH,3510,4,Studio Clemson,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,
-ARCH,3540,1,Studio Barcelona,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4010,1,Architectural Portfolio,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,4010,2,Architectural Portfolio,0.25,0.58,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4010,4,Architectural Portfolio,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,pai liu,
-ARCH,4140,2,Design Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,6990,9,Freehand Drawing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,
-ARCH,8100,1,Visualization I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
-ARCH,8210,1,Research Methods,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8360,1,Managing Integr Proj Delivery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,sall hambright-belue,
-ARCH,8510,1,Design Studio III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-sop heine,
-ARCH,8510,2,Design Studio III,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,santa cruz da franco da,
-ARCH,8510,3,Design Studio III,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,
-ARCH,8600,1,History/Theory I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,8720,1,Production & Assemb,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,
-ARCH,8810,1,Pro Practice Survey,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,katherine schwennsen,
-ARCH,8950,1,A+H Studio: Projects,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ART,1050,1,Foundation Drawing I,0.18,0.18,0.55,0.09,0.0,0.0,0.0,0.0,denise elizabe ayers,
-ART,2070,1,Beginning Painting,0.35,0.18,0.29,0.0,0.0,0.0,0.0,0.18,dustin lee massey,
-ART,2090,1,Beginning Sculpture,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0, joseph rich manson rich,
-ART,2100,5,Art Appreciation,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,angel roche estrella,
-ART,2100,400,Art Appreciation,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0, joseph rich manson rich,
-ART,2110,1,Begin Printmaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mandy lorai ferguson,
-ART,2130,1,Begin Photography,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,amanda denise musick,
-ART,2170,1,Beginning Ceramics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,
-ART,2210,1,Beginning New Media,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,christina nguye hung,
-ART,3050,1,Intermediate Drawing,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,annamarie williams,
-AS,1090,1,Air Force Today I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,1090,2,Air Force Today I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,1090,3,Air Force Today I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,2090,1,Dev of Air Power I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,2090,2,Dev of Air Power I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,2090,3,Dev of Air Power I,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,4090,1,Nat Sec Policy I,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,4090,2,Nat Sec Policy I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-ASL,1010,2,Am Sign Lang I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,
-ASL,1010,3,Am Sign Lang I,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
-ASL,1010,5,Am Sign Lang I,0.79,0.11,0.0,0.05,0.05,0.0,0.0,0.0,dunn kim mar misener mar,
-ASL,1010,6,Am Sign Lang I,0.58,0.21,0.05,0.0,0.11,0.0,0.0,0.05,jason hurdich,
-ASL,1020,1,Am Sign Lang I,0.41,0.24,0.29,0.0,0.0,0.0,0.0,0.06,jason hurdich,
-ASL,1020,2,Am Sign Lang I,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,2010,1,Am Sign Lang II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,
-ASL,2010,3,Am Sign Lang II,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
-ASL,2010,4,Am Sign Lang II,0.87,0.07,0.0,0.07,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
-ASL,2020,1,Am Sign Lang II,0.21,0.43,0.14,0.21,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,3010,1,Advanced A S L I,0.65,0.18,0.18,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
-ASL,3050,1,Deaf Studies,0.83,0.0,0.0,0.06,0.11,0.0,0.0,0.0,jason hurdich,
-ASL,3490,1,Adv App in Asl,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,
-ASTR,1010,1,Solar System Astronomy,0.24,0.32,0.31,0.06,0.03,0.0,0.0,0.05,mate adamkovics,
-ASTR,1020,1,Stellar Astronomy,0.38,0.28,0.15,0.08,0.05,0.0,0.0,0.06,mark leising,
-ASTR,1030,1,Solar Systm Astr Lab,0.74,0.13,0.09,0.0,0.0,0.0,0.0,0.04,mark leising,
-ASTR,1030,2,Solar Systm Astr Lab,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1030,4,Solar Systm Astr Lab,0.4,0.35,0.05,0.0,0.05,0.0,0.0,0.15,mark leising,
-ASTR,1030,6,Solar Systm Astr Lab,0.62,0.23,0.04,0.04,0.04,0.0,0.0,0.04,mark leising,
-ASTR,1030,7,Solar Systm Astr Lab,0.82,0.09,0.05,0.0,0.0,0.0,0.0,0.05,mark leising,
-ASTR,1030,8,Solar Systm Astr Lab,0.54,0.38,0.04,0.04,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1030,9,Solar Systm Astr Lab,0.72,0.06,0.06,0.0,0.17,0.0,0.0,0.0,mark leising,
-ASTR,1030,10,Solar Systm Astr Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1040,1,Stellar Astr Lab,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,mark leising,
-ASTR,1040,2,Stellar Astr Lab,0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1040,4,Stellar Astr Lab,0.43,0.48,0.0,0.0,0.04,0.0,0.0,0.04,mark leising,
-ASTR,3020,1,Stellar Astrophysics,0.35,0.41,0.0,0.0,0.06,0.0,0.0,0.18,marco ajello,
-ASTR,8300,1,Astroph III:Galactic,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-AUD,1850,1,Intro to Audio Tech,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUE,6010,1,Vehicle Dynamics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8040,699,Autovation for Entrepreneurs,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
-AUE,8180,1,"Engine Analysis, Design & Exp",0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8190,100,Adv Int Combustion Engine Conc,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,8280,1,Driveline/Powertrain,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8330,30,Auto Manuf Proc Devl,0.18,0.75,0.0,0.0,0.0,0.0,0.0,0.07,michael mears,
-AUE,8350,100,Auto Electronics,0.63,0.32,0.01,0.0,0.0,0.0,0.0,0.03,yunyi jia,
-AUE,8800,2,Vehicle Project Mngt,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,dee ann wood kivett wood,
-AUE,8810,3,Automotive Systems Overview,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,christiaan paredis,
-AUE,8870,8,Meth Vehicle Testing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,
-AVS,1000,1,Orientation to AVS,0.87,0.1,0.01,0.0,0.01,0.0,0.0,0.01,marie owens bolt,
-AVS,1500,1,Intro Animal Science,0.26,0.3,0.21,0.12,0.08,0.0,0.0,0.03,joseph keit bertrand,
-AVS,1500,2,Intro Animal Science,0.33,0.17,0.29,0.1,0.1,0.0,0.0,0.02,joseph keit bertrand,
-AVS,1510,1,Intro Ani Sci Lab,0.48,0.4,0.12,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
-AVS,1510,2,Intro Ani Sci Lab,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
-AVS,1510,3,Intro Ani Sci Lab,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
-AVS,1510,4,Intro Ani Sci Lab,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,alissa moritz,
-AVS,1510,5,Intro Ani Sci Lab,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
-AVS,1510,6,Intro Ani Sci Lab,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
-AVS,1510,7,Intro Ani Sci Lab,0.43,0.43,0.1,0.05,0.0,0.0,0.0,0.0,maslyn ann greene,
-AVS,1510,8,Intro Ani Sci Lab,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
-AVS,2040,1,Horse Care Techniques,0.7,0.22,0.05,0.03,0.0,0.0,0.0,0.0,kristine lang vernon,
-AVS,2060,1,Swine Techniques,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
-AVS,3010,1,Anat & Phys Dom Ani,0.54,0.22,0.23,0.01,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,3010,400,Anat & Phys Dom Ani,0.4,0.35,0.18,0.07,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,3020,1,Livestk Sel Eval I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
-AVS,3100,1,Animal Health,0.62,0.24,0.12,0.0,0.0,0.0,0.0,0.03,celina marce checura,
-AVS,3700,1,Principles of Animal Nutrition,0.49,0.22,0.21,0.06,0.01,0.0,0.0,0.01,zheng zhou,
-AVS,3750,1,Applied Animal Nutrition,0.23,0.39,0.29,0.06,0.0,0.0,0.0,0.03,gustavo jose lascano,
-AVS,4000,2,AVS Professional Development,0.85,0.0,0.08,0.0,0.0,0.0,0.0,0.08,marie owens bolt,
-AVS,4110,1,Animal Growth and Development,0.49,0.34,0.1,0.05,0.02,0.0,0.0,0.0,susan kay duckett,
-AVS,4140,1,Basic Immunology,0.4,0.4,0.0,0.1,0.0,0.0,0.0,0.1,farzana ferdous,
-AVS,4150,1,Contemporary Issues in AVS,0.82,0.14,0.03,0.02,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,4160,1,Equine Exercise Phys,0.5,0.45,0.0,0.05,0.0,0.0,0.0,0.0,kristine lang vernon,
-AVS,4500,1,Sustain Livestock Product Sys,0.09,0.64,0.18,0.09,0.0,0.0,0.0,0.0,matias jose aguerre,
-AVS,4530,1,Animal Reproduction,0.61,0.32,0.05,0.0,0.02,0.0,0.0,0.0,tiffany wilmoth,
-AVS,4670,1,Animal Physiology II,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,celina marce checura,
-AVS,4800,1,Vertebrate Endocrinology,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,8200,1,Graduate Seminar,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,
-BCHM,1030,1,Careers in Bioch/Gen,0.88,0.03,0.06,0.0,0.01,0.0,0.0,0.02,alison ni starr-moss,
-BCHM,3010,1,Molecular Biochemistry,0.4,0.29,0.18,0.04,0.07,0.0,0.0,0.02,kerry smith,
-BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3040,2,Molecular Biology Laboratory,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3040,3,Molecular Biology Laboratory,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3040,4,Molecular Biology Laboratory,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,geoffrey ford,
-BCHM,3040,5,Molecular Biology Laboratory,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3050,1,Essen Elements Bioch,0.25,0.34,0.25,0.08,0.05,0.0,0.0,0.04,debra ragland,
-BCHM,3050,2,Essen Elements Bioch,0.39,0.4,0.13,0.04,0.01,0.0,0.0,0.04,debra ragland,
-BCHM,4310,1,Physical Approach to Biochem,0.28,0.4,0.25,0.02,0.02,0.0,0.0,0.04,weiguo cao,
-BCHM,4330,2,Physical Biochemistry Lab,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,geoffrey ford,
-BCHM,4330,4,Physical Biochemistry Lab,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,geoffrey ford,
-BCHM,4400,1,Bioinformatics,0.68,0.26,0.0,0.0,0.03,0.0,0.0,0.03,frank alexand feltus,
-BCHM,4430,1,Molecular Basis of Disease,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,james morris,
-BCHM,8900,1,Euk Path Journal Club,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,kerry smith,
-BE,2120,1,Fundamentals of Biosys Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,3200,1,Principles & Prac of Geomatics,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4100,1,Biological Kinetics,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,4280,1,Biochem Engr,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,terry walker,
-BE,4750,1,BE Capstone Design,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,
-BIOE,1010,1,Biol for Bioengr,0.47,0.2,0.27,0.0,0.07,0.0,0.0,0.0,vladimir vlad reukov,
-BIOE,2010,1,Intro Biomed Engr,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,charles webb,
-BIOE,2010,2,Intro Biomed Engr,0.27,0.42,0.18,0.04,0.01,0.0,0.0,0.08,charles webb,
-BIOE,3020,1,Biomaterials,0.75,0.17,0.06,0.0,0.0,0.0,0.0,0.02,alexey alex vertegel,
-BIOE,3100,1,Engr Analysis of Physiol Proc,0.78,0.2,0.0,0.01,0.0,0.0,0.0,0.0,brian william booth,
-BIOE,3200,1,Biomechanics,0.55,0.34,0.09,0.02,0.0,0.0,0.0,0.0,jiro nagatomi,
-BIOE,3210,1,Biofluid Mechanics,0.65,0.16,0.16,0.0,0.03,0.0,0.0,0.0,zhi gao,
-BIOE,3470,1,Transport Processes in Bioengr,0.44,0.35,0.14,0.03,0.01,0.0,0.0,0.03,renee nicole cottle,
-BIOE,3700,1,Bioinst & Imaging,0.58,0.32,0.05,0.01,0.01,0.0,0.0,0.03,delphine dean,
-BIOE,4120,1,Orthopaedic Engr and Pathology,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,melinda harman,
-BIOE,4400,1,Biopharmaceutical Engineering,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,sarah harcum,
-BIOE,4480,1,Tissue Engineering,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,angela ant alexander,
-BIOE,6120,1,Orthopaedic Engr & Pathology,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,
-BIOE,6350,1,Modeling of Multiphysics Prob,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,
-BIOE,8010,1,Bio Materials,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,robert latour,
-BIOE,8020,864,Biocompatibility,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
-BIOE,8140,843,Medical Dev Commercialization,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hobey tam,
-BIOE,8700,1,Bioinstrumentation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,tong ye,
-BIOL,1010,1,Frontiers in Biology I,0.8,0.1,0.08,0.01,0.01,0.0,0.0,0.0,robert edwar ballard,
-BIOL,1010,2,Frontiers in Biology I,0.84,0.09,0.05,0.0,0.01,0.0,0.0,0.01,michael childress,
-BIOL,1030,1,General Biology I,0.2,0.25,0.28,0.11,0.07,0.0,0.0,0.1,nora espinoza,
-BIOL,1030,2,General Biology I,0.22,0.39,0.25,0.07,0.02,0.0,0.0,0.04,william baldwin,
-BIOL,1030,3,General Biology I,0.3,0.31,0.24,0.1,0.02,0.0,0.0,0.03,wen chen,
-BIOL,1030,4,General Biology I,0.16,0.29,0.31,0.09,0.05,0.0,0.0,0.1,salvatore sparace,
-BIOL,1030,5,General Biology I (HON),0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
-BIOL,1050,1,General Biology Lab I,0.17,0.48,0.22,0.04,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,2,General Biology Lab I,0.35,0.39,0.09,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,3,General Biology Lab I,0.22,0.39,0.26,0.09,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,4,General Biology Lab I,0.17,0.54,0.08,0.04,0.0,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,5,General Biology Lab I,0.18,0.47,0.24,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1050,6,General Biology Lab I,0.33,0.48,0.05,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,7,General Biology Lab I,0.21,0.5,0.13,0.04,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,8,General Biology Lab I,0.17,0.5,0.25,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,9,General Biology Lab I,0.18,0.5,0.27,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,10,General Biology Lab I,0.14,0.41,0.18,0.14,0.0,0.0,0.0,0.14,tafadzwa kaisa,
-BIOL,1050,11,General Biology Lab I,0.29,0.33,0.29,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,12,General Biology Lab I,0.27,0.36,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,13,General Biology Lab I,0.17,0.63,0.13,0.0,0.08,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,14,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,15,General Biology Lab I,0.29,0.38,0.25,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,16,General Biology Lab I,0.17,0.67,0.08,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,17,General Biology Lab I,0.38,0.38,0.17,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,18,General Biology Lab I,0.33,0.38,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,19,General Biology Lab I,0.18,0.59,0.23,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,20,General Biology Lab I,0.35,0.43,0.17,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,21,General Biology Lab I,0.21,0.63,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,22,General Biology Lab I,0.16,0.42,0.16,0.11,0.11,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,23,General Biology Lab I,0.28,0.22,0.28,0.22,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,24,General Biology Lab I,0.05,0.73,0.14,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,25,General Biology Lab I,0.22,0.57,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,26,General Biology Lab I,0.05,0.45,0.27,0.18,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,28,General Biology Lab I,0.21,0.58,0.13,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,29,General Biology Lab I,0.29,0.54,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,31,General Biology Lab I,0.33,0.5,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,32,General Biology Lab I,0.21,0.42,0.25,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,33,General Biology Lab I,0.5,0.33,0.08,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,34,General Biology Lab I,0.24,0.52,0.14,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,35,General Biology Lab I,0.36,0.55,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,37,General Biology Lab I,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,38,General Biology Lab I,0.33,0.42,0.21,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,39,General Biology Lab I,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,40,General Biology Lab I,0.33,0.54,0.08,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,41,General Biology Lab I,0.21,0.5,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,42,General Biology Lab I,0.29,0.58,0.08,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,43,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,44,General Biology Lab I,0.21,0.54,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,45,General Biology Lab I,0.33,0.54,0.08,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,46,General Biology Lab I,0.24,0.52,0.14,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,47,General Biology Lab I,0.25,0.6,0.1,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,48,General Biology Lab I,0.33,0.57,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1090,1,Intro to Life Sci,0.83,0.13,0.03,0.01,0.0,0.0,0.0,0.0,renea chris hardwick,
-BIOL,1100,1,Principles of Biology I,0.36,0.35,0.17,0.05,0.03,0.0,0.0,0.03,renea chris hardwick,
-BIOL,1100,2,Principles of Biology I (HON),0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,renea chris hardwick,True
-BIOL,1100,3,Principles of Biology I,0.27,0.49,0.16,0.04,0.02,0.0,0.0,0.03, christine minor m,
-BIOL,1100,4,Principles of Biology I (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,True
-BIOL,2000,2,Biology in the News,0.67,0.11,0.17,0.0,0.0,0.0,0.0,0.06,dylan dittrich-reed,
-BIOL,2000,3,Biology in the News,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,
-BIOL,2000,4,Biology in the News,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,
-BIOL,2110,1,Introduction to Toxicology,0.72,0.24,0.0,0.03,0.0,0.0,0.0,0.0,den hurk peter van peter,
-BIOL,2220,1,Human Anat and Physiology I,0.26,0.3,0.23,0.09,0.07,0.0,0.0,0.04,john cummings,
-BIOL,2220,2,Human Anat and Physiology I,0.25,0.37,0.2,0.09,0.07,0.0,0.0,0.02,john cummings,
-BIOL,3030,1,Vertebrate Biology,0.35,0.25,0.19,0.15,0.03,0.0,0.0,0.04,richard blob,
-BIOL,3030,2,Vertebrate Biology (HON),0.79,0.17,0.03,0.0,0.0,0.0,0.0,0.0,richard blob,True
-BIOL,3040,1,Biology of Plants,0.38,0.35,0.19,0.04,0.01,0.0,0.0,0.03,christina wells,
-BIOL,3070,1,Vertebrate Biology Lab,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,2,Vertebrate Biology Lab,0.63,0.16,0.21,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,3,Vertebrate Biology Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,4,Vertebrate Biology Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,5,Vertebrate Biology Lab,0.45,0.4,0.0,0.0,0.0,0.0,0.0,0.15,richard blob,
-BIOL,3070,6,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,7,Vertebrate Biology Lab,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,8,Vertebrate Biology Lab,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,9,Vertebrate Biology Lab,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,
-BIOL,3070,10,Vertebrate Biology Lab,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,11,Vertebrate Biology Lab,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,12,Vertebrate Biology Lab,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,13,Vertebrate Biology Lab,0.3,0.5,0.05,0.05,0.0,0.0,0.0,0.1,richard blob,
-BIOL,3080,1,Biology of Plants Practicum,0.5,0.35,0.05,0.1,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,2,Biology of Plants Practicum,0.25,0.25,0.35,0.15,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,3,Biology of Plants Practicum,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,nathan redding,
-BIOL,3080,4,Biology of Plants Practicum,0.33,0.39,0.17,0.11,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,5,Biology of Plants Practicum,0.32,0.37,0.32,0.0,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,6,Biology of Plants Practicum,0.26,0.26,0.26,0.11,0.0,0.0,0.0,0.11,nathan redding,
-BIOL,3150,1,Functional Human Anatomy,0.19,0.41,0.25,0.07,0.02,0.0,0.0,0.05,tamara mcnutt-scott,
-BIOL,3200,1,Field Botany,0.16,0.28,0.25,0.09,0.06,0.0,0.0,0.16,robert edwar ballard,
-BIOL,3350,1,Evolutionary Biology,0.29,0.38,0.21,0.04,0.05,0.0,0.0,0.02,samantha ann price,
-BIOL,3510,1,Biological Anthropology,0.53,0.41,0.0,0.06,0.0,0.0,0.0,0.0,lisa rapaport,
-BIOL,3530,1,Forensic Anthropology,0.35,0.5,0.1,0.05,0.0,0.0,0.0,0.0,katherine weisensee,
-BIOL,4140,1,Basic Immunology,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,yanzhang wei,
-BIOL,4200,1,Neurobiology,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4250,1,Introductory Mycology,0.34,0.41,0.19,0.05,0.02,0.0,0.0,0.0,julia louis kerrigan,
-BIOL,4260,1,Mycology Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,julia louis kerrigan,
-BIOL,4260,2,Mycology Practicum,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,julia louis kerrigan,
-BIOL,4400,1,Developmental Animal Biology,0.38,0.28,0.25,0.06,0.01,0.0,0.0,0.01,kara elizabet powder,
-BIOL,4430,2,Freshwater Ecology,0.19,0.48,0.19,0.03,0.03,0.0,0.0,0.06,john jenkins hains,
-BIOL,4560,1,Medical and Vet Parasitology,0.67,0.25,0.06,0.0,0.0,0.0,0.0,0.03,wilbur kears milhous,
-BIOL,4610,1,Cell Biology,0.28,0.45,0.2,0.05,0.0,0.0,0.0,0.02,susan caroli chapman,
-BIOL,4610,2,Cell Biology (HON),0.65,0.26,0.06,0.03,0.0,0.0,0.0,0.0,susan caroli chapman,True
-BIOL,4620,1,Cell Biology Lab (Lec),0.64,0.32,0.0,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,2,Cell Biology Lab (Lec),0.67,0.3,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,3,Cell Biology Lab (Lec),0.64,0.29,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,4,Cell Biology Lab (Lec),0.61,0.29,0.04,0.07,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.7,0.22,0.0,0.04,0.04,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.52,0.37,0.0,0.0,0.0,0.0,0.0,0.11,xianzhong yu,
-BIOL,4670,1,Principles of Hematology,0.8,0.11,0.0,0.03,0.0,0.0,0.0,0.06,vincent gallicchio,
-BIOL,4930,5,Sr Sem: Symbiosis,0.8,0.07,0.13,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
-BIOL,8120,1,Seminar,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,michael sears,
-BIOL,8200,1,Community Ecology,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,saara dewalt,
-BIOL,8400,1,Understanding Biological Inq,0.88,0.01,0.02,0.0,0.04,0.0,0.0,0.06,michael childress,
-BIOL,8420,1,Understand Cellular Processes,0.67,0.24,0.08,0.0,0.02,0.0,0.0,0.0,patricia leota tate,
-BIOL,8440,1,Understanding the Human Body,0.65,0.27,0.07,0.0,0.0,0.0,0.0,0.01,william baldwin,
-BIOL,8710,2,MCDB Grad Core,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,lisa bain,
-BUS,1010,1,Business Foundations,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,william erne tumblin,
-BUS,1010,2,Business Foundations,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,william erne tumblin,
-BUS,1010,3,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william erne tumblin,
-BUS,1010,4,Business Foundations,0.35,0.53,0.06,0.0,0.06,0.0,0.0,0.0,mary ann  prater m,
-BUS,1010,5,Business Foundations,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,mary ann  prater m,
-BUS,1010,6,Business Foundations,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,mary ann  prater m,
-BUS,1010,7,Business Foundations,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,william erne tumblin,
-BUS,1010,8,Business Foundations,0.11,0.39,0.28,0.11,0.11,0.0,0.0,0.0,william erne tumblin,
-BUS,1010,9,Business Foundations,0.22,0.44,0.11,0.17,0.0,0.0,0.0,0.06,william erne tumblin,
-BUS,1010,10,Business Foundations,0.42,0.37,0.11,0.0,0.05,0.0,0.0,0.05,william erne tumblin,
-BUS,1010,11,Business Foundations,0.32,0.42,0.11,0.0,0.11,0.0,0.0,0.05,william erne tumblin,
-BUS,1010,15,Business Foundations,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,16,Business Foundations,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,17,Business Foundations,0.36,0.5,0.0,0.0,0.07,0.0,0.0,0.07,donna mccubbin,
-BUS,1010,18,Business Foundations,0.11,0.5,0.28,0.06,0.06,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,19,Business Foundations,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,donna mccubbin,
-BUS,1010,20,Business Foundations,0.21,0.47,0.21,0.0,0.11,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,23,Business Foundations,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,24,Business Foundations,0.42,0.32,0.16,0.0,0.05,0.0,0.0,0.05,sandy edge,
-BUS,1010,25,Business Foundations,0.39,0.44,0.06,0.06,0.0,0.0,0.0,0.06,sandy edge,
-BUS,1010,26,Business Foundations,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,iulio edward barr de barr,
-BUS,1010,27,Business Foundations,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,iulio edward barr de barr,
-BUS,1010,28,Business Foundations,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,iulio edward barr de barr,
-BUS,1010,29,Business Foundations,0.15,0.32,0.21,0.09,0.11,0.0,0.0,0.13,mary ann  prater m,
-BUS,1010,30,Business Foundations,0.11,0.59,0.26,0.02,0.02,0.0,0.0,0.0,mary ann  prater m,
-BUS,1010,31,Business Foundations,0.29,0.53,0.06,0.06,0.0,0.0,0.0,0.06,mary ann  prater m,
-BUS,1010,33,Business Foundations,0.2,0.47,0.1,0.07,0.03,0.0,0.0,0.13,donna mccubbin,
-BUS,1010,34,Business Foundations,0.37,0.32,0.32,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,35,Business Foundations,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,william erne tumblin,
-BUS,1010,37,Business Foundations,0.44,0.31,0.19,0.06,0.0,0.0,0.0,0.0,donna mccubbin,
-CE,1990,20,Cr Inq in Civil Engineering,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,bradley putman,
-CE,2010,1,Statics,0.34,0.26,0.18,0.04,0.15,0.0,0.0,0.03,qiushi chen,
-CE,2010,2,Statics,0.1,0.4,0.26,0.02,0.02,0.0,0.0,0.19,melissa sternhagen,
-CE,2010,3,Statics,0.18,0.48,0.2,0.07,0.02,0.0,0.0,0.05,md nasimul chowdhury,
-CE,2010,4,Statics,0.11,0.3,0.21,0.12,0.09,0.0,0.0,0.17,melissa sternhagen,
-CE,2010,5,Statics,0.24,0.27,0.22,0.07,0.07,0.0,0.0,0.12,qiushi chen,
-CE,2010,6,Statics,0.1,0.15,0.2,0.15,0.15,0.0,0.0,0.25,melissa sternhagen,
-CE,2010,7,Statics (HON),0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,melissa sternhagen,True
-CE,2010,8,Statics,0.09,0.34,0.36,0.07,0.02,0.0,0.0,0.11,md nasimul chowdhury,
-CE,2060,1,Structural Mechanics,0.07,0.25,0.4,0.17,0.07,0.0,0.0,0.05,melissa sternhagen,
-CE,2080,1,Dynamics,0.11,0.44,0.37,0.06,0.03,0.0,0.0,0.0,md nasimul chowdhury,
-CE,2550,1,Geomatics,0.3,0.34,0.3,0.01,0.03,0.0,0.0,0.01,wayne sarasua,
-CE,3010,1,Structural Analysis,0.34,0.29,0.26,0.03,0.09,0.0,0.0,0.0,stephen csernak,
-CE,3010,2,Structural Analysis,0.35,0.4,0.23,0.03,0.0,0.0,0.0,0.0,brandon ross,
-CE,3110,1,Transportation Engr,0.47,0.45,0.05,0.0,0.03,0.0,0.0,0.0,jennifer ogle,
-CE,3210,1,Geotechnical Engineering,0.38,0.45,0.13,0.05,0.0,0.0,0.0,0.0,shweta shrestha,
-CE,3310,1,Constr Engr & Mgmnt,0.44,0.41,0.09,0.05,0.0,0.0,0.0,0.0,james burati,
-CE,3410,1,Intro to Fluid Mech,0.36,0.52,0.11,0.02,0.0,0.0,0.0,0.0,nigel gregory kaye,
-CE,3410,2,Intro to Fluid Mech,0.28,0.36,0.22,0.04,0.08,0.0,0.0,0.02,abdul khan,
-CE,3420,1,Hydraulics & Hydro,0.47,0.38,0.05,0.02,0.04,0.0,0.0,0.04,ashok mishra,
-CE,3510,1,Civil Engineering Materials,0.48,0.44,0.06,0.02,0.0,0.0,0.0,0.0,amir esmaeilpoursaee,
-CE,3510,2,Civil Engineering Materials,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0,amir esmaeilpoursaee,
-CE,3520,1,Econ Eval of Proj,0.4,0.38,0.13,0.02,0.04,0.0,0.0,0.04,zoraya roldan rockow,
-CE,4020,1,Reinfor Con Design,0.28,0.51,0.15,0.02,0.02,0.0,0.0,0.02,brandon ross,
-CE,4060,1,Struct Steel Design,0.38,0.35,0.24,0.03,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4100,1,Traffic Engr Oper,0.27,0.32,0.23,0.05,0.05,0.0,0.0,0.09,wayne sarasua,
-CE,4240,1,Earth Slopes & Struc,0.35,0.48,0.13,0.05,0.0,0.0,0.0,0.0,nadaraj ravichandran,
-CE,4390,1,Con Eqpmt Sel & Main,0.49,0.38,0.11,0.03,0.0,0.0,0.0,0.0,james burati,
-CE,4470,1,Stormwater Managemnt,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,earl hayter,
-CE,4560,1,Pave Design & Constr,0.47,0.41,0.09,0.0,0.0,0.0,0.0,0.03,bradley putman,
-CE,4590,1,Capstone Design Proj,0.46,0.38,0.11,0.03,0.0,0.0,0.0,0.03,stephen csernak,
-CE,4820,1,Groundwater & Contam Transport,0.3,0.3,0.1,0.0,0.0,0.0,0.0,0.3,lawrence murdoch,
-CE,4910,1,BIM in Construction Management,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,6100,1,Traffic Engr Oper,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
-CE,6240,1,Earth Slopes & Struc,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,nadaraj ravichandran,
-CE,6390,1,Con Eqpmt Sel & Main,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james burati,
-CE,8020,1,Adv R/C Design,0.38,0.31,0.23,0.0,0.0,0.0,0.0,0.08,thomas edfor cousins,
-CE,8220,1,Foundation Engr,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,nadaraj ravichandran,
-CE,8260,1,Prop of Concrete,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,prasada ra rangaraju,
-CE,8460,1,Flow in Open Chnls,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,abdul khan,
-CE,8480,500,Risk Analyt in Supply Chains,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott jennings mason,
-CE,8540,1,Travl Demnd Forecast,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,pamela murray-tuite,
-CE,8930,3,Risk Assessment,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CES,1900,101,CI - LEAD Forward I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,steve richar sanders,
-CES,1900,500,CI - PEER/WISE Exp Seminar,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jordon antho gilmore,
-CH,1010,1,General Chemistry,0.23,0.31,0.22,0.11,0.1,0.0,0.0,0.04,william we mcwhorter,
-CH,1010,2,General Chemistry,0.23,0.34,0.23,0.1,0.03,0.0,0.0,0.06,laura lanni,
-CH,1010,3,General Chemistry,0.13,0.36,0.35,0.05,0.06,0.0,0.0,0.06,olt geiculescu,
-CH,1010,4,General Chemistry,0.19,0.33,0.19,0.12,0.1,0.0,0.0,0.07,william we mcwhorter,
-CH,1010,5,General Chemistry,0.28,0.32,0.19,0.12,0.06,0.0,0.0,0.03,steven lo pellizzeri,
-CH,1010,6,General Chemistry,0.2,0.32,0.3,0.07,0.07,0.0,0.0,0.04,elliot ennis,
-CH,1010,7,General Chemistry,0.26,0.32,0.22,0.13,0.06,0.0,0.0,0.02,jacob schroeder,
-CH,1010,8,General Chemistry,0.33,0.28,0.23,0.07,0.04,0.0,0.0,0.05,princess mycia cox,
-CH,1010,9,General Chemistry,0.2,0.29,0.29,0.11,0.08,0.0,0.0,0.04,dennis taylor,
-CH,1010,10,General Chemistry,0.3,0.27,0.21,0.07,0.12,0.0,0.0,0.03,thomas hickman,
-CH,1010,11,General Chemistry,0.28,0.34,0.21,0.1,0.03,0.0,0.0,0.03,steven lo pellizzeri,
-CH,1010,12,General Chemistry,0.27,0.35,0.24,0.06,0.04,0.0,0.0,0.03,elliot ennis,
-CH,1010,13,General Chemistry,0.19,0.27,0.26,0.18,0.05,0.0,0.0,0.05,dennis taylor,
-CH,1010,50,General Chemistry,0.58,0.29,0.06,0.06,0.0,0.0,0.0,0.0,tania issa houjeiry,
-CH,1010,51,General Chemistry (HON),0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,True
-CH,1010,52,General Chemistry (HON),0.71,0.23,0.06,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True
-CH,1010,201,General Chemistry,0.21,0.44,0.25,0.06,0.04,0.0,0.0,0.01,laura lanni,
-CH,1010,202,General Chemistry,0.29,0.44,0.19,0.04,0.02,0.0,0.0,0.03,tania issa houjeiry,
-CH,1010,203,General Chemistry,0.19,0.45,0.22,0.06,0.03,0.0,0.0,0.05,william we mcwhorter,
-CH,1010,204,General Chemistry,0.31,0.34,0.24,0.09,0.01,0.0,0.0,0.02,princess mycia cox,
-CH,1020,1,General Chemistry,0.33,0.23,0.22,0.12,0.05,0.0,0.0,0.05,stephen schvaneveldt,
-CH,1020,2,General Chemistry,0.33,0.27,0.19,0.14,0.04,0.0,0.0,0.02,stephen schvaneveldt,
-CH,1020,3,General Chemistry,0.29,0.29,0.22,0.09,0.02,0.0,0.0,0.08,stephen schvaneveldt,
-CH,1020,400,General Chemistry,0.09,0.21,0.23,0.26,0.11,0.0,0.0,0.11,stephen schvaneveldt,
-CH,1050,1,Chemistry in Context I,0.19,0.46,0.29,0.03,0.02,0.0,0.0,0.01,elliot ennis,
-CH,1050,2,Chemistry in Context I,0.16,0.57,0.15,0.05,0.01,0.0,0.0,0.06,elliot ennis,
-CH,2010,1,Survey of Organic Chemistry,0.3,0.37,0.09,0.06,0.13,0.0,0.0,0.05,thomas hickman,
-CH,2010,2,Survey of Organic Chemistry,0.46,0.32,0.15,0.08,0.0,0.0,0.0,0.0,thomas hickman,
-CH,2020,2,Surv of Organic Chemistry Lab,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,
-CH,2020,3,Surv of Organic Chemistry Lab,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,james nelson plampin,
-CH,2020,9,Surv of Organic Chemistry Lab,0.82,0.0,0.05,0.0,0.09,0.0,0.0,0.05,james nelson plampin,
-CH,2230,1,Organic Chemistry,0.08,0.2,0.25,0.14,0.2,0.0,0.0,0.13,modi wetzler,
-CH,2230,2,Organic Chemistry,0.18,0.26,0.24,0.17,0.06,0.0,0.0,0.1,modi wetzler,
-CH,2230,3,Organic Chemistry,0.43,0.25,0.15,0.08,0.03,0.0,0.0,0.06,tania issa houjeiry,
-CH,2230,4,Organic Chemistry,0.35,0.27,0.18,0.09,0.04,0.0,0.0,0.07,laura lanni,
-CH,2230,5,Organic Chemistry,0.55,0.26,0.13,0.03,0.02,0.0,0.0,0.03,rhett smith,
-CH,2230,6,Organic Chemistry,0.26,0.23,0.12,0.15,0.15,0.0,0.0,0.09,rhett smith,
-CH,2230,7,Organic Chemistry,0.21,0.24,0.23,0.08,0.1,0.0,0.0,0.16,sourav saha,
-CH,2240,1,Organic Chemistry,0.22,0.32,0.24,0.13,0.09,0.0,0.0,0.01,jacob schroeder,
-CH,2240,2,Organic Chemistry,0.33,0.29,0.2,0.09,0.06,0.0,0.0,0.03,jacob schroeder,
-CH,2270,1,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2270,2,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,5,Organic Chem Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,
-CH,2270,6,Organic Chem Lab,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,7,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,
-CH,2270,8,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,
-CH,2270,13,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,
-CH,2270,15,Organic Chem Lab,0.78,0.11,0.0,0.06,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2270,17,Organic Chem Lab,0.47,0.26,0.0,0.05,0.0,0.0,0.0,0.21,james nelson plampin,
-CH,2270,18,Organic Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
-CH,2270,19,Organic Chem Lab,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,20,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,22,Organic Chem Lab,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2270,23,Organic Chem Lab,0.84,0.05,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,
-CH,2270,24,Organic Chem Lab,0.67,0.11,0.11,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,25,Organic Chem Lab,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,
-CH,2270,26,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,
-CH,2270,27,Organic Chem Lab,0.84,0.0,0.0,0.0,0.05,0.0,0.0,0.11,james nelson plampin,
-CH,2270,28,Organic Chem Lab,0.78,0.06,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,
-CH,2270,29,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,30,Organic Chem Lab,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,
-CH,2270,31,Organic Chem Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,
-CH,2270,32,Organic Chem Lab,0.69,0.06,0.0,0.0,0.0,0.0,0.0,0.25,james nelson plampin,
-CH,2270,33,Organic Chem Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,
-CH,2270,35,Organic Chem Lab,0.63,0.06,0.13,0.0,0.06,0.0,0.0,0.13,james nelson plampin,
-CH,2270,36,Organic Chem Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,james nelson plampin,
-CH,2270,37,Organic Chem Lab,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,
-CH,2270,39,Organic Chem Lab,0.73,0.08,0.0,0.0,0.0,0.0,0.0,0.19,james nelson plampin,
-CH,2270,40,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,
-CH,2280,1,Organic Chem Lab,0.84,0.05,0.0,0.05,0.0,0.0,0.0,0.05,james nelson plampin,
-CH,2280,2,Organic Chem Lab,0.82,0.05,0.0,0.05,0.05,0.0,0.0,0.05,james nelson plampin,
-CH,2280,4,Organic Chem Lab,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,james nelson plampin,
-CH,2280,6,Organic Chem Lab,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,james nelson plampin,
-CH,2280,8,Organic Chem Lab,0.88,0.04,0.0,0.0,0.04,0.0,0.0,0.04,james nelson plampin,
-CH,2280,9,Organic Chem Lab,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,james nelson plampin,
-CH,3130,1,Quantitative Analys,0.37,0.23,0.27,0.07,0.03,0.0,0.0,0.03,olt geiculescu,
-CH,3150,1,Quant Analysis Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,perez carlos garcia,
-CH,3150,2,Quant Analysis Lab,0.45,0.18,0.18,0.0,0.18,0.0,0.0,0.0,perez carlos garcia,
-CH,3300,1,Intro to Phys Chem,0.45,0.39,0.09,0.03,0.0,0.0,0.0,0.03,brian dominy,
-CH,3310,1,Physical Chemistry,0.35,0.31,0.23,0.08,0.04,0.0,0.0,0.0,steven stuart,
-CH,3320,1,Physical Chemistry,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,arkady kholodenko,
-CH,3390,1,Physical Chem Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,2,Physical Chem Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,3,Physical Chem Lab,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,princess mycia cox,
-CH,3390,5,Physical Chem Lab,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3410,1,Introduction to Research,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,stephen creager,
-CH,4010,1,Organometallic Chemistry,0.74,0.23,0.0,0.0,0.0,0.0,0.0,0.03,andrew greg tennyson,
-CH,4020,1,Inorganic Chemistry,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,joseph kolis,
-CH,6020,1,Inorganic Chemistry,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph kolis,
-CH,8070,1,Chem Trans Elem,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,julia brumaghim,
-CH,8090,1,Chem App/X-Ray Cryst,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,
-CH,8210,1,Organic Chem I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ya-ping sun,
-CH,8300,1,Fund Phys Chem,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,
-CH,8510,3,Grad Student Seminar,0.83,0.15,0.0,0.0,0.0,0.0,0.0,0.03,joseph stua thrasher,
-CHE,2110,1,Mass and Energy Balances,0.32,0.29,0.35,0.03,0.0,0.0,0.0,0.0,karen ann high,
-CHE,2110,2,Mass and Energy Balances,0.22,0.25,0.31,0.11,0.07,0.0,0.0,0.04,mark roberts,
-CHE,3210,1,Ch E Thermo II,0.14,0.21,0.3,0.24,0.1,0.0,0.0,0.02,sapna sarupria,
-CHE,3300,1,Mass Trans & Seprtn,0.23,0.16,0.3,0.2,0.11,0.0,0.0,0.0,mark thies,
-CHE,4070,1,Unit Op Lab II,0.18,0.53,0.29,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
-CHE,4310,1,Process Design I,0.31,0.57,0.11,0.01,0.0,0.0,0.0,0.0,david bruce,
-CHE,4500,1,Chem Reaction Engr,0.4,0.41,0.17,0.02,0.0,0.0,0.0,0.0,rachel getman,
-CHE,8030,1,Advanced Transport,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,eric mikel davis,
-CHE,8040,1,Ch E Thermodynamics,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,joseph scott,
-CHE,8050,1,Ch E Kinetics,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,mark alan blenner,
-CHE,8450,4,Systems Biology & Pharmacology,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,marc russ birtwistle,
-CHIN,1010,2,Elementary Chinese,0.27,0.33,0.2,0.0,0.0,0.0,0.0,0.2,ling rao,
-CHIN,2010,1,Intermediate Chinese,0.55,0.27,0.0,0.09,0.0,0.0,0.0,0.09,ling rao,
-CHIN,4010,1,Pre-Modern Chinese Literature,0.33,0.38,0.13,0.03,0.05,0.0,0.0,0.1,yanming an,
-COM,1500,1,Intro to Human Communication,0.72,0.24,0.01,0.0,0.01,0.0,0.0,0.01,daniel leland fecher,
-COM,1500,2,Intro to Human Communication,0.64,0.26,0.05,0.01,0.02,0.0,0.0,0.03,daniel leland fecher,
-COM,1500,3,Intro to Human Communication,0.75,0.21,0.02,0.01,0.01,0.0,0.0,0.01,daniel leland fecher,
-COM,1500,4,Intro to Human Communication,0.64,0.24,0.06,0.02,0.03,0.0,0.0,0.01,marianne herr glaser,
-COM,1500,5,Intro to Human Communication,0.65,0.26,0.04,0.02,0.0,0.0,0.0,0.02,marianne herr glaser,
-COM,1500,6,Intro to Human Communication,0.53,0.33,0.09,0.0,0.04,0.0,0.0,0.01,marianne herr glaser,
-COM,1500,7,Intro to Human Communication,0.55,0.44,0.01,0.0,0.0,0.0,0.0,0.0,daniel leland fecher,
-COM,2010,1,Intr to Comm Studies,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,
-COM,2010,2,Intr to Comm Studies,0.67,0.27,0.03,0.03,0.0,0.0,0.0,0.0,john steven  spinda w,
-COM,2030,1,Mass Communication Theory,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,2110,1,Qual Comm Research Methods,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,2110,2,Qual Comm Research Methods,0.58,0.21,0.16,0.05,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,2500,1,Public Speaking,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,3,Public Speaking,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,caitlin baker,
-COM,2500,5,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,6,Public Speaking,0.47,0.37,0.0,0.11,0.0,0.0,0.0,0.05,vanessa anne condon,
-COM,2500,7,Public Speaking,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,sara grumble crocker,
-COM,2500,8,Public Speaking,0.53,0.26,0.05,0.05,0.05,0.0,0.0,0.05,sara grumble crocker,
-COM,2500,9,Public Speaking,0.44,0.28,0.06,0.06,0.06,0.0,0.0,0.11,sara grumble crocker,
-COM,2500,10,Public Speaking,0.56,0.11,0.28,0.0,0.06,0.0,0.0,0.0,sara grumble crocker,
-COM,2500,11,Public Speaking,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,alyssa christi davis,
-COM,2500,12,Public Speaking,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,alyssa christi davis,
-COM,2500,13,Public Speaking,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christi davis,
-COM,2500,14,Public Speaking,0.78,0.06,0.06,0.0,0.0,0.0,0.0,0.11,pauline matthey,
-COM,2500,15,Public Speaking,0.63,0.16,0.0,0.05,0.0,0.0,0.0,0.16,pauline matthey,
-COM,2500,16,Public Speaking,0.59,0.35,0.0,0.0,0.06,0.0,0.0,0.0,pauline matthey,
-COM,2500,17,Public Speaking,0.35,0.41,0.06,0.0,0.12,0.0,0.0,0.06,pauline matthey,
-COM,2500,18,Public Speaking,0.47,0.42,0.0,0.05,0.0,0.0,0.0,0.05,rachelle lei beckner,
-COM,2500,19,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,
-COM,2500,20,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,
-COM,2500,29,Public Speaking,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jumah patricia taweh,
-COM,2500,30,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,
-COM,2500,400,Public Speaking,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,alexis zachary davis,
-COM,2500,401,Public Speaking,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
-COM,2500,403,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
-COM,3080,1,Public Comm & Pop Culture,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3080,2,Public Comm & Pop Culture,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3080,3,Public Comm & Pop Culture,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
-COM,3240,1,"Communication, Sport & Society",0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
-COM,3240,2,"Communication, Sport & Society",0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
-COM,3250,1,Survey of Sports Communication,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
-COM,3260,1,Pr in Sports,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3260,3,Pr in Sports,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,
-COM,3270,1,Sports Media Criticism,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
-COM,3550,1,Principles of Public Relations,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,meghnaa tallapragada,
-COM,3560,1,Crisis Communication,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,andrew stephen pyle,
-COM,3570,1,Public Relations Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3640,1,Organizational Comm,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,kristen elai okamoto,
-COM,3660,2,EC: Survey of Brand Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lisa willif papenfus,
-COM,3660,4,EC: Digital Analytics & Brand,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,alicia nic littleton,
-COM,3690,1,Political Comm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,4250,1,Adv Sports Comm,0.54,0.38,0.0,0.0,0.08,0.0,0.0,0.0,bryan denham,
-COM,4300,1,Legal Communication,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,james isaac roberts,
-COM,4720,1,Comm in Health Organizations,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kristen elai okamoto,
-CPSC,1010,3,Computer Science I,0.24,0.17,0.24,0.1,0.1,0.0,0.0,0.15,christopher plaue,
-CPSC,1020,1,Computer Science II,0.28,0.18,0.14,0.1,0.18,0.0,0.0,0.12,yvon feaster,
-CPSC,1020,2,Computer Science II,0.16,0.26,0.28,0.1,0.12,0.0,0.0,0.08,yvon feaster,
-CPSC,1070,1,Programming Methodology,0.45,0.19,0.15,0.06,0.07,0.0,0.0,0.07,catherine hochrine,
-CPSC,1110,1,Intro to Programming in C,0.28,0.18,0.26,0.08,0.18,0.0,0.0,0.02,catherine hochrine,
-CPSC,1110,2,Intro to Programming in C,0.37,0.35,0.06,0.08,0.14,0.0,0.0,0.0,nicolas benja widman,
-CPSC,1110,3,Intro to Programming in C,0.46,0.24,0.13,0.04,0.07,0.0,0.0,0.07,nicolas benja widman,
-CPSC,1110,4,Intro to Programming in C,0.25,0.23,0.23,0.11,0.07,0.0,0.0,0.11,james martin,
-CPSC,2120,1,Algs/Data Structures,0.26,0.32,0.2,0.06,0.08,0.0,0.0,0.08,brian christoph dean,
-CPSC,2150,1,Software Dev Foundations,0.27,0.31,0.19,0.03,0.07,0.0,0.0,0.14,kevin anton plis,
-CPSC,2150,2,Software Dev Foundations,0.32,0.31,0.15,0.07,0.08,0.0,0.0,0.07,kevin anton plis,
-CPSC,2200,1,Microcomputer Appl,0.46,0.31,0.23,0.0,0.0,0.0,0.0,0.0,kevin anton plis,
-CPSC,2200,2,Microcomputer Appl,0.22,0.3,0.19,0.15,0.11,0.0,0.0,0.04,kevin anton plis,
-CPSC,2310,1,Intro Computer Org,0.58,0.24,0.1,0.02,0.04,0.0,0.0,0.02,nicolas benja widman,
-CPSC,2310,2,Intro Computer Org,0.49,0.22,0.16,0.03,0.08,0.0,0.0,0.03,nicolas benja widman,
-CPSC,2810,1,Selected Topics: TA Class,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher plaue,
-CPSC,2810,2,Selected Topics: Cybersecurity,0.76,0.08,0.0,0.0,0.0,0.0,0.0,0.16,yvon feaster,
-CPSC,2910,1,Prof Issues I,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,2,Prof Issues I,0.6,0.25,0.0,0.05,0.0,0.0,0.0,0.1,catherine hochrine,
-CPSC,2910,3,Prof Issues I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,4,Prof Issues I,0.6,0.25,0.0,0.05,0.05,0.0,0.0,0.05,catherine hochrine,
-CPSC,2910,5,Prof Issues I,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,catherine hochrine,
-CPSC,2920,1,"Computing, Ethics & Society",0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,julian lang brinkley,
-CPSC,3120,1,Design Analysis of Algorithms,0.07,0.1,0.14,0.14,0.17,0.0,0.0,0.38,pradip srimani,
-CPSC,3220,1,Intro to Operating Systems,0.62,0.31,0.03,0.0,0.03,0.0,0.0,0.0,brygg anders ullmer,
-CPSC,3220,3,Intro to Operating Systems,0.19,0.33,0.29,0.0,0.1,0.0,0.0,0.1,pradip srimani,
-CPSC,3300,1,Computer Systems Org,0.25,0.25,0.4,0.04,0.03,0.0,0.0,0.03,mark smotherman,
-CPSC,3500,1,Foundations of Computer Sci,0.28,0.13,0.45,0.04,0.0,0.0,0.0,0.09,ilya mark safro,
-CPSC,3520,1,Programming Systems,0.39,0.29,0.22,0.0,0.02,0.0,0.0,0.08,robert schalkoff,
-CPSC,3600,1,Network Programming,0.44,0.29,0.15,0.0,0.08,0.0,0.0,0.03,andrew robb,
-CPSC,3600,2,Network Programming,0.67,0.21,0.07,0.04,0.0,0.0,0.0,0.02,andrew robb,
-CPSC,3720,1,Software Engineering,0.27,0.38,0.24,0.05,0.0,0.0,0.0,0.05,eileen there kraemer,
-CPSC,3720,2,Software Engineering,0.21,0.42,0.25,0.06,0.0,0.0,0.0,0.06,murali sitaraman,
-CPSC,4040,1,Cmptr Graphics Image,0.29,0.24,0.24,0.0,0.12,0.0,0.0,0.12,ioannis karamouzas,
-CPSC,4050,1,Computer Graphics,0.24,0.18,0.12,0.12,0.24,0.0,0.0,0.12,andrew duchowski,
-CPSC,4110,1,Virtual Reality Systems,0.27,0.41,0.22,0.05,0.0,0.0,0.0,0.05,sabarish venkat babu,
-CPSC,4120,1,Eye Tracking Methodology,0.22,0.61,0.04,0.0,0.04,0.0,0.0,0.09,andrew duchowski,
-CPSC,4140,1,Human and Computer Interaction,0.21,0.56,0.21,0.03,0.0,0.0,0.0,0.0,nathaniel mcneese,
-CPSC,4160,1,2-D Game Engine Construction,0.54,0.23,0.06,0.02,0.08,0.0,0.0,0.06,brian malloy,
-CPSC,4200,1,Computer Security Principles,0.61,0.26,0.08,0.0,0.03,0.0,0.0,0.03,yvon feaster,
-CPSC,4200,2,Computer Security Principles,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,
-CPSC,4300,1,Applied Data Science,0.25,0.5,0.08,0.17,0.0,0.0,0.0,0.0,alexander chr herzog,
-CPSC,4440,1,Cloud Computing Architecture,0.32,0.45,0.18,0.0,0.0,0.0,0.0,0.05,amy apon,
-CPSC,4620,1,Database Management Systems,0.09,0.22,0.22,0.09,0.13,0.0,0.0,0.26,pradip srimani,
-CPSC,4820,1,Special Topic: Web Programming,0.56,0.1,0.22,0.06,0.06,0.0,0.0,0.0,craig baker,
-CPSC,4820,4,Spe Topic: HPC Fault Tolerance,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,jon cameron calhoun,
-CPSC,6040,1,Cptr Graphics Image,0.5,0.07,0.14,0.0,0.0,0.0,0.0,0.29,ioannis karamouzas,
-CPSC,6110,1,Virtual Reality Systems,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,sabarish venkat babu,
-CPSC,6140,1,Human and Computer Interaction,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel mcneese,
-CPSC,6160,1,2-D Game Engine Construction,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,brian malloy,
-CPSC,6300,1,Applied Data Science,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,
-CPSC,6440,1,Cloud Computing Architecture,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,amy apon,
-CPSC,6620,1,Database Management Systems,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,pradip srimani,
-CPSC,6780,1,Gen Purpose Computation on GPU,0.4,0.4,0.0,0.0,0.2,0.0,0.0,0.0,shuangshuang jin,
-CPSC,8170,1,Physically Based Animation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,donald henry house,
-CPSC,8200,1,Parallel Architechture,0.5,0.3,0.1,0.0,0.1,0.0,0.0,0.0,rong ge,
-CPSC,8270,1,Translation of Progr Languages,0.74,0.13,0.1,0.0,0.0,0.0,0.0,0.03,brian malloy,
-CPSC,8380,1,Adv Data Structures,0.3,0.2,0.1,0.0,0.1,0.0,0.0,0.3,sandra hedetniemi,
-CPSC,8480,1,Network Science,0.31,0.31,0.34,0.0,0.0,0.0,0.0,0.03,ilya mark safro,
-CPSC,8550,1,Embedded Network Sys,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jacob sorber,
-CPSC,8580,1,Security in Emerging Systems,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,hongxin hu,
-CPSC,8810,1,Selected Topics: Intro to BDSI,0.67,0.0,0.0,0.0,0.17,0.0,0.0,0.17,brian christoph dean,
-CRP,8020,1,Site Planning & Infrastructure,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,
-CSM,1000,1,Intro to Construct,0.92,0.07,0.0,0.0,0.0,0.0,0.0,0.02,nathaniel jackson,
-CSM,2010,1,Structures I,0.36,0.21,0.24,0.07,0.02,0.0,0.0,0.1,shima clarke,
-CSM,2020,1,Structures II,0.24,0.18,0.41,0.12,0.0,0.0,0.0,0.06, kent nilsson,
-CSM,2040,1,Cont Documents,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,robert dawson coffey,
-CSM,3040,1,Envir Systems I,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,
-CSM,3040,2,Envir Systems I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,
-CSM,3060,1,Emerging Tech in Construction,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,3060,2,Emerging Tech in Construction,0.17,0.59,0.21,0.03,0.0,0.0,0.0,0.0,jason lucas,
-CSM,3510,1,Construction Estimating,0.29,0.32,0.32,0.06,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,
-CSM,3510,2,Construction Estimating,0.35,0.48,0.1,0.06,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,
-CSM,4500,1,Construction Intern,0.4,0.36,0.25,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
-CSM,4530,1,Const Proj Mgmt,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4530,2,Const Proj Mgmt,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8630,400,Adv Plan/Sched,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,craig townsend,
-CSM,8650,1,Project Management,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,dennis bausman,
-CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,16,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,19,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,24,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,26,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,27,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,28,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,
-CU,1010,1,Univ Success Skills,0.33,0.17,0.28,0.06,0.11,0.0,0.0,0.06,bryn zimmermann babb,
-CU,1010,6,Univ Success Skills,0.21,0.16,0.21,0.16,0.11,0.0,0.0,0.16,valerie kay oonk,
-CU,1010,7,Univ Success Skills,0.41,0.24,0.18,0.0,0.12,0.0,0.0,0.06,bryn zimmermann babb,
-CU,1010,600,Univ Success Skills,0.38,0.42,0.08,0.0,0.13,0.0,0.0,0.0,elizabeth an stephan,
-CU,1010,601,Univ Success Skills,0.5,0.21,0.13,0.04,0.0,0.0,0.0,0.13,bridget trogden,
-CU,1010,602,Univ Success Skills,0.46,0.29,0.17,0.0,0.04,0.0,0.0,0.04,laurel ann  whisler c,
-CU,1010,603,Univ Success Skills,0.55,0.25,0.2,0.0,0.0,0.0,0.0,0.0,abigail stephan,
-DPA,3070,1,Method 3d Production,0.45,0.41,0.1,0.0,0.03,0.0,0.0,0.0,tommy van bui,
-DPA,4000,1,Tech Foundations I,0.24,0.24,0.12,0.0,0.06,0.0,0.0,0.35,jessica baron,
-DPA,4020,1,Vis Foundations I,0.27,0.55,0.0,0.0,0.0,0.0,0.0,0.18,anthony summey,
-DPA,4020,2,Vis Foundations I,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,anthony summey,
-DPA,6000,1,Tech Foundations I,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,victor zordan,
-DPA,8070,843,3D Modeling and Animation,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,matias volonte,
-DPA,8090,1,Rendering and Shading,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,
-ECE,2010,1,Logic and Computing Device,0.12,0.27,0.26,0.16,0.15,0.0,0.0,0.04,william reid,
-ECE,2010,1,Logic and Computing Devices,0.12,0.27,0.26,0.16,0.15,0.0,0.0,0.04,william reid,
-ECE,2010,2,Logic & Comp Device (HON),0.8,0.0,0.1,0.0,0.0,0.0,0.0,0.1,william reid,True
-ECE,2020,1,Electric Circuits I,0.34,0.23,0.19,0.07,0.1,0.0,0.0,0.06,william harrell,
-ECE,2070,1,Basic Electrical Engineering,0.42,0.38,0.14,0.03,0.01,0.0,0.0,0.03,william tho kolodzey,
-ECE,2070,2,Basic Electrical Engineering,0.38,0.36,0.14,0.02,0.07,0.0,0.0,0.02,fatemeh tooryan,
-ECE,2070,3,Basic Electrical Engineering,0.57,0.31,0.07,0.0,0.01,0.0,0.0,0.03,timothy anglea,
-ECE,2080,1,Basic Electrical Engr Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,
-ECE,2080,3,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2080,6,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2080,7,Basic Electrical Engr Lab,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2080,8,Basic Electrical Engr Lab,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,
-ECE,2080,10,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,
-ECE,2080,12,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,
-ECE,2080,14,Basic Electrical Engr Lab,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2090,3,Logic Lab,0.75,0.0,0.0,0.08,0.08,0.0,0.0,0.08,apoorva deep kapadia,
-ECE,2090,7,Logic Lab,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva deep kapadia,
-ECE,2090,8,Logic Lab,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deep kapadia,
-ECE,2090,13,Logic Lab,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,apoorva deep kapadia,
-ECE,2090,14,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva deep kapadia,
-ECE,2110,1,Elec Engr Lab I,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,
-ECE,2110,2,Elec Engr Lab I,0.44,0.19,0.13,0.13,0.06,0.0,0.0,0.06,apoorva deep kapadia,
-ECE,2110,3,Elec Engr Lab I,0.45,0.25,0.1,0.1,0.05,0.0,0.0,0.05,apoorva deep kapadia,
-ECE,2110,5,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,apoorva deep kapadia,
-ECE,2110,6,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,
-ECE,2110,10,Elec Engr Lab I,0.7,0.1,0.0,0.0,0.0,0.0,0.0,0.2,apoorva deep kapadia,
-ECE,2120,1,Electrical Engineering Lab II,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,apoorva deep kapadia,
-ECE,2120,4,Electrical Engineering Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2220,1,Syst Prog Concept,0.18,0.2,0.05,0.0,0.23,0.0,0.0,0.34,lu yu,
-ECE,2230,1,Comp Sys Eng,0.36,0.16,0.27,0.11,0.04,0.0,0.0,0.07,harlan russell,
-ECE,2620,1,Electric Circuits II,0.2,0.26,0.34,0.04,0.08,0.0,0.0,0.08,liang dong,
-ECE,2720,1,Comp Organization,0.06,0.18,0.35,0.24,0.14,0.0,0.0,0.02,william reid,
-ECE,3110,1,Electrical Engineering Lab III,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3110,2,Electrical Engineering Lab III,0.75,0.13,0.0,0.06,0.0,0.0,0.0,0.06,apoorva deep kapadia,
-ECE,3110,3,Electrical Engineering Lab III,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,
-ECE,3110,7,Electrical Engineering Lab III,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3110,8,Electrical Engineering Lab III,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva deep kapadia,
-ECE,3120,1,Electrical Engineering Lab IV,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3120,2,Electrical Engineering Lab IV,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3170,1,Rand Signal Analysis,0.23,0.3,0.26,0.1,0.07,0.0,0.0,0.03,stephen hubbard,
-ECE,3200,1,Electronics I,0.24,0.26,0.22,0.15,0.1,0.0,0.0,0.03,stephen hubbard,
-ECE,3200,2,Electronics I (HON),0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,stephen hubbard,True
-ECE,3210,1,Electronics II,0.45,0.3,0.15,0.08,0.03,0.0,0.0,0.0,stephen hubbard,
-ECE,3270,1,Dig Comp Design,0.12,0.2,0.24,0.16,0.08,0.0,0.0,0.2,melissa crawle smith,
-ECE,3300,1,Signals & Systems,0.15,0.25,0.27,0.14,0.08,0.0,0.0,0.1,carl baum,
-ECE,3300,2,Signals & Systems (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
-ECE,3520,1,Programming Systems,0.36,0.59,0.05,0.0,0.0,0.0,0.0,0.0,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.49,0.23,0.13,0.09,0.02,0.0,0.0,0.04,edward collins,
-ECE,3710,1,Microcontr Interface,0.47,0.26,0.14,0.1,0.02,0.0,0.0,0.0,william reid,
-ECE,3720,3,Micro Int Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3720,4,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3720,6,Micro Int Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3720,7,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3720,9,Micro Int Lab,0.5,0.25,0.0,0.0,0.25,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3720,11,Micro Int Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3800,1,Electromagnetics,0.27,0.27,0.18,0.13,0.11,0.0,0.0,0.04,anthony martin,
-ECE,3810,1,Field Waves & Ckts,0.41,0.44,0.13,0.0,0.03,0.0,0.0,0.0,hai xiao,
-ECE,4090,1,Intr to Linear Control Systems,0.63,0.33,0.03,0.01,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,4180,1,Power Syst Analysis,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,ramtin hadidi,
-ECE,4270,1,Communications Sys,0.33,0.47,0.16,0.0,0.0,0.0,0.0,0.05,lu yu,
-ECE,4310,1,Intro to Computer Vision,0.64,0.28,0.03,0.03,0.03,0.0,0.0,0.0,adam hoover,
-ECE,4420,1,Knowledge Engr,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,robert schalkoff,
-ECE,4490,1,Comp Ntwrk Security,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,richard brooks,
-ECE,4610,1,Fundamentals of Solar Energy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,
-ECE,4670,1,Intro to Dig Sig Pro,0.24,0.18,0.47,0.0,0.0,0.0,0.0,0.12,john gowdy,
-ECE,4730,1,Intro Parallel Sys,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,walter ligon,
-ECE,4950,1,Int Sys Design I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,4960,1,Int Sys Design II,0.64,0.27,0.07,0.02,0.0,0.0,0.0,0.0,richard groff,
-ECE,6040,1,Semiconductor Devices,0.57,0.14,0.29,0.0,0.0,0.0,0.0,0.0,judson dougl ryckman,
-ECE,6180,1,Power Syst Analysis,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ramtin hadidi,
-ECE,6310,1,Intro to Computer Vision,0.6,0.15,0.1,0.0,0.0,0.0,0.0,0.15,adam hoover,
-ECE,6490,1,Comp Ntwrk Security,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,richard brooks,
-ECE,6590,1,Int Circ Design,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,
-ECE,6670,1,Intro to Dig Sig Pro,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,john gowdy,
-ECE,8010,1,Analysis of Lin Sys,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,richard groff,
-ECE,8010,843,Analysis of Lin Sys,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,richard groff,
-ECON,2000,2,Economic Concepts,0.31,0.26,0.23,0.13,0.03,0.0,0.0,0.05,shubhashrita basu,
-ECON,2000,4,Economic Concepts,0.38,0.43,0.1,0.0,0.08,0.0,0.0,0.03,miren ivankovic,
-ECON,2000,5,Economic Concepts,0.32,0.34,0.26,0.03,0.05,0.0,0.0,0.0,shubhashrita basu,
-ECON,2110,1,Principles of Microeconomics,0.21,0.26,0.32,0.11,0.05,0.0,0.0,0.05,frederick an hanssen,
-ECON,2110,2,Principles of Microeconomics,0.21,0.32,0.26,0.0,0.11,0.0,0.0,0.11,frederick an hanssen,
-ECON,2110,3,Principles of Microeconomics,0.05,0.32,0.47,0.11,0.0,0.0,0.0,0.05,frederick an hanssen,
-ECON,2110,4,Principles of Microeconomics,0.21,0.42,0.26,0.0,0.05,0.0,0.0,0.05,frederick an hanssen,
-ECON,2110,5,Principles of Microeconomics,0.28,0.22,0.28,0.17,0.06,0.0,0.0,0.0,frederick an hanssen,
-ECON,2110,6,Principles of Microeconomics,0.16,0.37,0.26,0.05,0.11,0.0,0.0,0.05,frederick an hanssen,
-ECON,2110,7,Principles of Microeconomics,0.0,0.5,0.33,0.0,0.06,0.0,0.0,0.11,frederick an hanssen,
-ECON,2110,8,Principles of Microeconomics,0.22,0.28,0.28,0.11,0.06,0.0,0.0,0.06,frederick an hanssen,
-ECON,2110,9,Principles of Microeconomics,0.17,0.39,0.33,0.0,0.0,0.0,0.0,0.11,frederick an hanssen,
-ECON,2110,10,Principles of Microeconomics,0.28,0.28,0.28,0.06,0.06,0.0,0.0,0.06,frederick an hanssen,
-ECON,2110,11,Principles of Microeconomics,0.11,0.42,0.21,0.11,0.0,0.0,0.0,0.16,frederick an hanssen,
-ECON,2110,12,Principles of Microeconomics,0.11,0.26,0.32,0.16,0.05,0.0,0.0,0.11,frederick an hanssen,
-ECON,2110,13,Principles of Microeconomics,0.05,0.58,0.26,0.05,0.05,0.0,0.0,0.0,frederick an hanssen,
-ECON,2110,14,Principles of Microeconomics,0.16,0.53,0.16,0.11,0.05,0.0,0.0,0.0,frederick an hanssen,
-ECON,2110,15,Principles of Microeconomics,0.0,0.33,0.56,0.06,0.06,0.0,0.0,0.0,frederick an hanssen,
-ECON,2110,16,Principles of Microeconomics,0.15,0.4,0.25,0.1,0.1,0.0,0.0,0.0,frederick an hanssen,
-ECON,2110,17,Principles of Microeconomics,0.11,0.21,0.42,0.16,0.05,0.0,0.0,0.05,frederick an hanssen,
-ECON,2110,18,Principles of Microeconomics,0.05,0.53,0.05,0.16,0.16,0.0,0.0,0.05,frederick an hanssen,
-ECON,2110,19,Principles of Microeconomics,0.05,0.42,0.11,0.26,0.05,0.0,0.0,0.11,frederick an hanssen,
-ECON,2110,20,Principles of Microeconomics,0.31,0.32,0.22,0.09,0.04,0.0,0.0,0.01,benjamin posmanick,
-ECON,2110,21,Principles of Microeconomics,0.28,0.46,0.21,0.03,0.0,0.0,0.0,0.03,michael makowsky,
-ECON,2110,23,Principles of Microeconomics,0.2,0.29,0.28,0.08,0.1,0.0,0.0,0.04,roksana ghanbariamin,
-ECON,2110,24,Principles of Microeconomics,0.24,0.34,0.3,0.08,0.02,0.0,0.0,0.03,kelsey victo roberts,
-ECON,2110,25,Principles of Microeconomics,0.28,0.56,0.13,0.0,0.03,0.0,0.0,0.0,chen wang,
-ECON,2110,26,Principles of Microeconomics,0.28,0.28,0.26,0.13,0.02,0.0,0.0,0.02,sarah louise wilson,
-ECON,2110,31,Principles of Microeconomics,0.33,0.29,0.26,0.04,0.08,0.0,0.0,0.0,jonathan orry ernest,
-ECON,2110,32,Principles of Microeconomics,0.28,0.52,0.13,0.02,0.04,0.0,0.0,0.0,jacob walloga,
-ECON,2110,33,Principles of Microeconomics,0.33,0.44,0.13,0.0,0.08,0.0,0.0,0.03,liuna issagholian,
-ECON,2110,34,Principles of Microecon (HON),0.45,0.32,0.18,0.05,0.0,0.0,0.0,0.0,charles thomas,True
-ECON,2110,35,Principles of Microeconomics,0.25,0.55,0.2,0.0,0.0,0.0,0.0,0.0,chen wang,
-ECON,2110,36,Principles of Microeconomics,0.28,0.4,0.18,0.08,0.06,0.0,0.0,0.0,roksana ghanbariamin,
-ECON,2110,40,Principles of Microeconomics,0.25,0.36,0.21,0.04,0.14,0.0,0.0,0.0,liuna issagholian,
-ECON,2110,41,Principles of Microeconomics,0.48,0.38,0.1,0.02,0.0,0.0,0.0,0.02,jonathan orry ernest,
-ECON,2120,1,Principles of Macroeconomics,0.3,0.41,0.2,0.04,0.03,0.0,0.0,0.03,elijah neilson,
-ECON,2120,2,Principles of Macroeconomics,0.23,0.36,0.32,0.0,0.04,0.0,0.0,0.04,kenneth whaley,
-ECON,2120,3,Principles of Macroeconomics,0.25,0.43,0.25,0.02,0.0,0.0,0.0,0.05,elijah neilson,
-ECON,2120,4,Principles of Macroeconomics,0.25,0.36,0.28,0.06,0.06,0.0,0.0,0.0,wing yin chung,
-ECON,2120,5,Principles of Macroeconomics,0.29,0.39,0.26,0.03,0.0,0.0,0.0,0.03,narendra regmi,
-ECON,2120,6,Principles of Macroeconomics,0.45,0.33,0.13,0.08,0.0,0.0,0.0,0.03,kenneth whaley,
-ECON,2120,7,Principles of Macroeconomics,0.51,0.18,0.18,0.08,0.05,0.0,0.0,0.0,narendra regmi,
-ECON,2120,8,Principles of Macroeconomics,0.67,0.21,0.02,0.0,0.05,0.0,0.0,0.05,tyler francis,
-ECON,2120,9,Principles of Macroeconomics,0.88,0.07,0.05,0.0,0.0,0.0,0.0,0.0,tyler francis,
-ECON,2120,10,Principles of Macroeconomics,0.23,0.36,0.31,0.03,0.05,0.0,0.0,0.03,kyle lance rechard,
-ECON,3020,1,Money and Banking,0.18,0.31,0.33,0.1,0.0,0.0,0.0,0.08,smriti bhargava,
-ECON,3060,1,Managerial Economics,0.2,0.25,0.25,0.18,0.08,0.0,0.0,0.05,steven johnson,
-ECON,3100,1,International Econ,0.19,0.54,0.17,0.06,0.03,0.0,0.0,0.01,scott baier,
-ECON,3140,1,Intermediate Micro,0.28,0.15,0.18,0.08,0.15,0.0,0.0,0.15,patrick warren,
-ECON,3140,2,Intermediate Micro,0.17,0.57,0.15,0.07,0.0,0.0,0.0,0.05,molly espey,
-ECON,3140,3,Intermediate Micro,0.27,0.31,0.2,0.08,0.06,0.0,0.0,0.08,robert kenneth fleck,
-ECON,3140,5,Intermediate Micro,0.26,0.22,0.22,0.15,0.07,0.0,0.0,0.07,yichen christy zhou,
-ECON,3150,1,Intermediate Macro,0.86,0.05,0.02,0.0,0.02,0.0,0.0,0.05,jeremy choquette,
-ECON,3150,2,Intermediate Macro,0.39,0.24,0.17,0.1,0.05,0.0,0.0,0.05,michal jerzmanowski,
-ECON,3190,1,Environmental Econ,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,molly espey,
-ECON,3600,1,Public Choice,0.37,0.29,0.21,0.08,0.0,0.0,0.0,0.05,michael makowsky,
-ECON,4010,1,Labor Mkt Analysis,0.5,0.25,0.08,0.0,0.08,0.0,0.0,0.08,chungsang lam,
-ECON,4020,1,Law and Economics,0.23,0.5,0.15,0.05,0.03,0.0,0.0,0.05,howard nel bodenhorn,
-ECON,4040,1,Comp Econ Systems,0.33,0.07,0.2,0.07,0.13,0.0,0.0,0.2,dari litsukova-bokar,
-ECON,4050,5,Intro to Econometric,0.25,0.23,0.35,0.08,0.06,0.0,0.0,0.04,scott barkowski,
-ECON,4100,1,Economic Development,0.72,0.14,0.03,0.0,0.03,0.0,0.0,0.07,robert tamura,
-ECON,4120,1,International Micro,0.35,0.26,0.17,0.0,0.0,0.0,0.0,0.22,scott baier,
-ECON,4130,1,International Macro,0.45,0.36,0.0,0.0,0.09,0.0,0.0,0.09,michal jerzmanowski,
-ECON,4230,1,Economics of Health,0.51,0.34,0.11,0.0,0.0,0.0,0.0,0.03,devon merritt gorry,
-ECON,4240,1,Organization of Ind,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,4240,2,Organization of Ind,0.72,0.1,0.1,0.03,0.0,0.0,0.0,0.03,matthew lewis,
-ECON,4250,1,Antitrust Economics,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.12,raymond sauer,
-ECON,4260,1,Sem Sport Economics,0.63,0.3,0.0,0.0,0.0,0.0,0.0,0.07,raymond sauer,
-ECON,4280,1,Cost-Benefit Anlysis,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,robert kenneth fleck,
-ECON,4980,3,Econ of Entertainment Industry,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,frederick an hanssen,
-ECON,4980,4,Sel Topic - Why Business?,0.44,0.33,0.19,0.04,0.0,0.0,0.0,0.0,bradley keith hobbs,
-ECON,4980,5,Sel Topics-Cryptocurrency,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,gerald dwyer,
-ECON,6050,5,Intro to Econometric,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott barkowski,
-ECON,8010,1,Microeconomic Theory,0.5,0.13,0.38,0.0,0.0,0.0,0.0,0.0,william dougan,
-ECON,8040,1,Applied Math Econ,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
-ECON,8060,1,Econometrics I,0.13,0.38,0.38,0.0,0.13,0.0,0.0,0.0,paul wayne wilson,
-ECON,8080,1,Econometrics III,0.17,0.5,0.17,0.0,0.17,0.0,0.0,0.0,paul wayne wilson,
-ECON,8230,1,Microecon Pub Pol,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,
-ECON,8990,3,Industrial Organization Theory,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,charles thomas,
-ECON,8990,5,Sel Topics - Macro Theory II,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,christopher as gorry,
-ED,1050,1,Educ Orientation,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,jennifer michel hein,
-ED,1050,3,Educ Orientation,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,
-ED,1050,7,Educ Orientation,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,
-ED,1050,8,Educ Orientation,0.84,0.08,0.0,0.0,0.0,0.0,0.0,0.08,amaris joseph tejada,
-ED,1970,1,CI-CONNECTIONS Stud Developmnt,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,2,CI-CONNECTIONS Stud Developmnt,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,3,CI-CONNECTIONS Stud Developmnt,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,4,CI-CONNECTIONS Stud Developmnt,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,5,CI-CONNECTIONS Stud Developmnt,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,6,CI-CONNECTIONS Stud Developmnt,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,deonte brown,
-ED,3010,1,Principles of American Educat,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohammad khan,
-ED,8750,321,Elements of Instructional Effe,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,susan ridg nunamaker,
-ED,9540,1,Curriculum Theory,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDC,3900,2,Skills for Student Leaders,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,5,Skills for Student Leaders,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-EDC,3990,1,Creative Inq in Counselor Ed,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,jacob frankovich,
-EDEC,3000,1,Found Early Chld Ed,0.91,0.0,0.0,0.03,0.03,0.0,0.0,0.03,jill chandle shelnut,
-EDEC,3010,1,Early Childhood Practicum I,0.89,0.0,0.0,0.04,0.04,0.0,0.0,0.04,jennifer schumpert,
-EDEC,4300,1,Early Childhd Math,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sandra mamman linder,
-EDEC,4400,1,Early Childhood Engl Lang Art,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEC,8100,312,Adv Ece Found & Meth,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,sandra mamman linder,
-EDEL,3210,1,Pe for the Elem Tchr,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,3210,2,Pe for the Elem Tchr,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4870,2,Ele Meth Soc Studies,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,melinda spearman,
-EDEL,4880,2,Elem Language Arts Teaching,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,jacquelynn malloy,
-EDF,3020,2,Educational Psychology,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,meihua qian,
-EDF,3340,1,Child Growth and Development,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoob jamil,
-EDF,3340,3,Child Growth and Development,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,faiza marghoob jamil,
-EDF,3350,1,Adolescent Growth & Develop,0.41,0.27,0.18,0.05,0.0,0.0,0.0,0.09,david barrett,
-EDF,4800,2,Digital Media & Learning,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,anne mcmahan grant,
-EDF,8080,312,Contempor Issues in Assessment,0.8,0.12,0.04,0.0,0.0,0.0,0.0,0.04,eliza darg gallagher,
-EDF,8710,400,Cultural Diversity in Educatio,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,reginald wilkerson,
-EDF,9020,1,Learning Sciences Seminar II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
-EDF,9270,401,Quant Rsrch & Stats for Ed,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,russell aubre marion,
-EDHD,3110,1,CI- Research in DM & Learning,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.07,david matthew boyer,
-EDL,7150,503,Sch & Comm Relations,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,
-EDL,7400,500,Curr Plan: Sch Adm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,daniella hall,
-EDL,7400,501,Curr Plan: Sch Adm,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,daniella hall,
-EDL,9110,400,Systematic Inq Ed L,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,jane lindle,
-EDL,9770,1,Div Issues in Hi Ed,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robin je phelps-ward,
-EDLT,4610,1,Content Area Read/Writing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,4800,1,Found in Adolescent Literacy,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,phillip micha wilder,
-EDLT,4800,2,Found in Adolescent Literacy,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,phillip micha wilder,
-EDLT,8150,500,Guided Reading & Guided Writng,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,susan king fullerton,
-EDLT,8170,300,Content Area Rdg/Wtg: ECE-ELEM,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8170,500,Content Area Rdg/Wtg: ECE-ELEM,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8220,500,Strategies for Teaching ESOL,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDLT,8240,300,Practicum in ESOL,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,rebecca kaminski,
-EDLT,8400,501,Early Literacy Assessment I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,
-EDLT,8400,502,Early Literacy Assessment I,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,antoinett dibellonia,
-EDLT,8400,506,Early Literacy Assessment I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jo anne solesbee,
-EDLT,8800,505,Reading Recovery Teacher I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,
-EDSC,2260,1,Pr Apprch to Sec Alg,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,stacy megan che,
-EDSP,3700,1,Intro to Special Education,0.74,0.18,0.06,0.03,0.0,0.0,0.0,0.0,friggita johnson,
-EDSP,3720,1,Char & Instr Individ with LD,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,
-EDSP,4920,1,Math Inst Ind W/Dis,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,pamela stecker,
-EDSP,4930,1,Clsrm/Beh Mgmt Sp Ed,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,joseph benedict ryan,
-EDSP,4940,1,Tchg Rdg Mild Dis,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
-EDSP,4960,1,Sp Ed Field Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,wendell kent parker,
-EDSP,4970,1,Sec Meth Ind W/Dis,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,wendell kent parker,
-EDSP,8120,400,Learning Disabilities Prac Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,catherine griffith,
-EDSP,8220,400,Tchg Math Indv W/Dis,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,pamela stecker,
-EDSP,8530,1,Legal/Pol Issu Sp Ed,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
-EES,2010,1,Environ Engr Fundamentals I,0.31,0.33,0.14,0.0,0.11,0.0,0.0,0.11,david freedman,
-EES,3030,1,Water Treatment Systems,0.41,0.38,0.14,0.03,0.03,0.0,0.0,0.0,david allen ladner,
-EES,3040,1,Wastewater Treatment Systems,0.31,0.45,0.17,0.07,0.0,0.0,0.0,0.0,sudeep popat,
-EES,3050,1,Water/Wastewater Treatment Lab,0.38,0.38,0.19,0.06,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3050,2,Water/Wastewater Treatment Lab,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,sudeep popat,
-EES,4010,1,Environmental Engr,0.82,0.16,0.03,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.27,0.53,0.13,0.03,0.03,0.0,0.0,0.0,mark schlautman,
-EES,4090,1,Intro to Nuc Engr & Radiol Sci,0.18,0.53,0.12,0.12,0.0,0.0,0.0,0.06,timothy devol,
-EES,4300,1,Air Pollution Engineering,0.44,0.31,0.14,0.0,0.03,0.0,0.0,0.08,andrew richa metcalf,
-EES,4800,1,Environmental Risk Assessment,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,nicole eliz martinez,
-EES,4840,1,Solid Waste Mgt,0.35,0.46,0.08,0.08,0.04,0.0,0.0,0.0,ezra lucas hoy cates hoy,
-EES,4860,1,Environmental Sustainability,0.78,0.15,0.04,0.0,0.0,0.0,0.0,0.04,michael anthony dale,
-EES,8020,1,Environ Eng Prin,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,8430,1,Environmental Chem,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,
-EES,8510,1,Biol Prin Envir Engr,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,kevin thoma finneran,
-EES,8800,1,Env Risk Assessment,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,
-ELE,3010,1,Entrepreneurial Foundations,0.19,0.37,0.37,0.01,0.0,0.0,0.0,0.04,ashley willi parnell,
-ELE,3010,2,Entrepreneurial Foundations,0.12,0.34,0.36,0.12,0.0,0.0,0.0,0.06,ashley willi parnell,
-ELE,3020,1,Entrepreneurial Resource Acqu,0.36,0.44,0.17,0.0,0.0,0.0,0.0,0.03,karl bruce kelly,
-ELE,3020,2,Entrepreneurial Resource Acqu,0.26,0.71,0.03,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,
-ELE,4020,1,Venture Creation,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,
-ELE,4990,1,Venture Consulting,0.49,0.46,0.05,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
-ELE,4990,2,Venture Counsulting,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
-ENGL,1030,1,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,allen swords,
-ENGL,1030,2,Composition and Rhetoric,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,1030,3,Composition and Rhetoric,0.26,0.26,0.26,0.05,0.05,0.0,0.0,0.11,chelsea marie clarey,
-ENGL,1030,4,Composition and Rhetoric,0.75,0.06,0.0,0.13,0.0,0.0,0.0,0.06,stephanie stripling,
-ENGL,1030,6,Composition and Rhetoric,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,
-ENGL,1030,8,Composition and Rhetoric,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,chelsea marie clarey,
-ENGL,1030,10,Composition and Rhetoric,0.42,0.32,0.16,0.11,0.0,0.0,0.0,0.0,allison nicol harris,
-ENGL,1030,11,Composition and Rhetoric,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
-ENGL,1030,13,Composition and Rhetoric,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,julia brownlee koets,
-ENGL,1030,18,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
-ENGL,1030,19,Composition and Rhetoric,0.74,0.11,0.11,0.05,0.0,0.0,0.0,0.0,stephanie stripling,
-ENGL,1030,23,Composition and Rhetoric,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,charissa fryberger,
-ENGL,1030,24,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,charissa fryberger,
-ENGL,1030,27,Composition and Rhetoric,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,naomi marie white,
-ENGL,1030,29,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,eric reid hamilton,
-ENGL,1030,32,Composition and Rhetoric,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,blake elizabe bowens,
-ENGL,1030,33,Composition and Rhetoric,0.47,0.32,0.11,0.0,0.05,0.0,0.0,0.05,geveryl lee robinson,
-ENGL,1030,34,Composition and Rhetoric,0.42,0.26,0.16,0.05,0.11,0.0,0.0,0.0,geveryl lee robinson,
-ENGL,1030,35,Composition and Rhetoric,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,blake elizabe bowens,
-ENGL,1030,37,Composition and Rhetoric,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,naomi marie white,
-ENGL,1030,38,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,
-ENGL,1030,39,Composition and Rhetoric,0.58,0.26,0.05,0.0,0.0,0.0,0.0,0.11,julie edewaard,
-ENGL,1030,40,Composition and Rhetoric,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,julie edewaard,
-ENGL,1030,41,Composition and Rhetoric,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,myers addison enlow,
-ENGL,1030,42,Composition and Rhetoric,0.63,0.16,0.11,0.0,0.11,0.0,0.0,0.0,myers addison enlow,
-ENGL,1030,43,Composition and Rhetoric,0.63,0.16,0.11,0.0,0.05,0.0,0.0,0.05,jennie eli wakefield,
-ENGL,1030,44,Composition and Rhetoric,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,caroline eliza young,
-ENGL,1030,45,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,
-ENGL,1030,46,Composition and Rhetoric,0.68,0.21,0.0,0.11,0.0,0.0,0.0,0.0,jennie eli wakefield,
-ENGL,1030,47,Composition and Rhetoric,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,chloe miche whitaker,
-ENGL,1030,48,Composition and Rhetoric,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,chloe miche whitaker,
-ENGL,1030,51,Composition and Rhetoric,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,victoria houser,
-ENGL,1030,52,Composition and Rhetoric,0.68,0.05,0.16,0.05,0.05,0.0,0.0,0.0,victoria houser,
-ENGL,1030,53,Composition and Rhetoric,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,michelle lloyd,
-ENGL,1030,55,Composition and Rhetoric,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,michelle lloyd,
-ENGL,1030,61,Composition and Rhetoric,0.53,0.26,0.16,0.05,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,1030,71,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,shauna chung,
-ENGL,1030,73,Composition and Rhetoric,0.21,0.68,0.0,0.0,0.0,0.0,0.0,0.11,la'cresha ulon green,
-ENGL,1030,74,Composition and Rhetoric,0.22,0.44,0.11,0.06,0.0,0.0,0.0,0.17,la'cresha ulon green,
-ENGL,1030,75,Composition and Rhetoric,0.39,0.33,0.06,0.0,0.0,0.0,0.0,0.22,kristian wilson,
-ENGL,1030,76,Composition and Rhetoric,0.32,0.32,0.05,0.05,0.0,0.0,0.0,0.26,kristian wilson,
-ENGL,1030,82,Composition and Rhetoric,0.22,0.5,0.17,0.0,0.06,0.0,0.0,0.06,andrew mathas,
-ENGL,1030,83,Composition and Rhetoric,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,
-ENGL,2120,3,World Literature,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathle nalley,
-ENGL,2120,5,World Literature,0.11,0.58,0.21,0.05,0.05,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2120,6,World Literature,0.17,0.5,0.22,0.06,0.0,0.0,0.0,0.06,david charles foltz,
-ENGL,2120,7,World Literature,0.22,0.39,0.11,0.11,0.0,0.0,0.0,0.17,david charles foltz,
-ENGL,2120,9,World Literature,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,hannah pittma godwin,
-ENGL,2120,10,World Literature,0.47,0.26,0.21,0.0,0.0,0.0,0.0,0.05,hannah pittma godwin,
-ENGL,2120,11,World Literature,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,hannah pittma godwin,
-ENGL,2120,12,World Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathle nalley,
-ENGL,2120,13,World Literature,0.42,0.26,0.11,0.11,0.0,0.0,0.0,0.11,heather pri williams,
-ENGL,2120,15,World Literature,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,chloe miche whitaker,
-ENGL,2120,19,World Literature,0.37,0.37,0.21,0.0,0.0,0.0,0.0,0.05,chloe miche whitaker,
-ENGL,2120,20,World Literature,0.47,0.21,0.16,0.0,0.11,0.0,0.0,0.05,hannah pittma godwin,
-ENGL,2120,21,World Literature,0.33,0.17,0.33,0.0,0.08,0.0,0.0,0.08,gabriel ande hankins,
-ENGL,2120,400,World Literature,0.19,0.48,0.19,0.04,0.04,0.0,0.0,0.07,sarah mae cooper,
-ENGL,2120,401,World Literature,0.18,0.47,0.18,0.06,0.06,0.0,0.0,0.06,sarah mae cooper,
-ENGL,2120,402,World Literature,0.73,0.15,0.08,0.0,0.04,0.0,0.0,0.0,heather pri williams,
-ENGL,2120,403,World Literature,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.04,keri ja crist-wagner,
-ENGL,2130,3,British Literature,0.37,0.21,0.21,0.05,0.11,0.0,0.0,0.05,megan noe macalystre,
-ENGL,2130,4,British Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john morgenstern,
-ENGL,2130,5,British Literature,0.63,0.16,0.16,0.0,0.0,0.0,0.0,0.05,lucian ghita,
-ENGL,2130,6,British Literature,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,kriste aldebol-hazle,
-ENGL,2130,7,British Literature,0.37,0.37,0.05,0.05,0.0,0.0,0.0,0.16,megan noe macalystre,
-ENGL,2130,9,British Literature,0.32,0.42,0.16,0.05,0.05,0.0,0.0,0.0,megan noe macalystre,
-ENGL,2130,10,British Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,11,British Literature,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,christopher benson,
-ENGL,2130,12,British Literature,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,13,British Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,400,British Literature,0.37,0.48,0.07,0.0,0.04,0.0,0.0,0.04,daniel scott citro,
-ENGL,2130,401,British Literature,0.39,0.43,0.11,0.04,0.0,0.0,0.0,0.04,daniel scott citro,
-ENGL,2130,402,British Literature,0.48,0.24,0.2,0.0,0.04,0.0,0.0,0.04,kriste aldebol-hazle,
-ENGL,2140,1,American Literature,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,5,American Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,6,American Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
-ENGL,2140,7,American Literature,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
-ENGL,2140,8,American Literature,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john robert smith,
-ENGL,2140,14,American Literature,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,17,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,400,American Literature,0.84,0.12,0.0,0.04,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,allen swords,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.26,0.42,0.11,0.05,0.05,0.0,0.0,0.11,john logan pursley,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.47,0.37,0.05,0.11,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,sharon kathle nalley,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.42,0.32,0.05,0.11,0.0,0.0,0.0,0.11,andrew mathas,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.47,0.35,0.06,0.0,0.12,0.0,0.0,0.0,andrew mathas,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,david charles foltz,
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.16,0.21,0.05,0.05,0.0,0.0,0.0,elizabeth stansell,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.84,0.0,0.05,0.05,0.05,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,remley meliss makala,
-ENGL,2150,18,Lit in 20th-21st Cent Contexts,0.37,0.37,0.11,0.0,0.11,0.0,0.0,0.05,chelsea marie clarey,
-ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.47,0.32,0.11,0.0,0.05,0.0,0.0,0.05,david charles foltz,
-ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.44,0.39,0.06,0.0,0.0,0.0,0.0,0.11,david charles foltz,
-ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
-ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.37,0.42,0.11,0.05,0.0,0.0,0.0,0.05,chelsea marie clarey,
-ENGL,2150,26,Lit in 20th-21st Cent Contexts,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,daniel scott citro,
-ENGL,2150,27,Lit in 20th-21st Cent Contexts,0.72,0.11,0.11,0.06,0.0,0.0,0.0,0.0,remley meliss makala,
-ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.42,0.19,0.19,0.0,0.04,0.0,0.0,0.15,candace wiley,
-ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.37,0.11,0.15,0.15,0.07,0.0,0.0,0.15,candace wiley,
-ENGL,2150,402,Lit in 20th-21st Cent Contexts,0.56,0.26,0.15,0.04,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,2150,403,Lit in 20th-21st Cent Contexts,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
-ENGL,3010,1,Great Books of Western World,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,dominic mastroianni,
-ENGL,3040,1,Business Writing,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,
-ENGL,3040,3,Business Writing,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulon green,
-ENGL,3040,4,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulon green,
-ENGL,3040,5,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
-ENGL,3040,12,Business Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,heather pri williams,
-ENGL,3040,15,Business Writing,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,katalin beck,
-ENGL,3040,16,Business Writing,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3040,19,Business Writing,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
-ENGL,3040,20,Business Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
-ENGL,3040,400,Business Writing,0.85,0.05,0.1,0.0,0.0,0.0,0.0,0.0,kriste aldebol-hazle,
-ENGL,3040,401,Business Writing,0.78,0.0,0.17,0.06,0.0,0.0,0.0,0.0,kriste aldebol-hazle,
-ENGL,3040,402,Business Writing,0.47,0.37,0.05,0.0,0.11,0.0,0.0,0.0,sean williams,
-ENGL,3100,1,Crit Writ Lit,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth rivlin,
-ENGL,3100,2,Crit Writ Lit,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,cameron fae bushnell,
-ENGL,3100,3,Crit Writ Lit,0.58,0.21,0.11,0.0,0.0,0.0,0.0,0.11,kimberly manganelli,
-ENGL,3100,4,Crit Writ Lit,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,
-ENGL,3120,1,Advanced Composition,0.82,0.0,0.12,0.0,0.06,0.0,0.0,0.0,christopher stuart,
-ENGL,3120,2,Advanced Composition,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,christopher stuart,
-ENGL,3120,3,Advanced Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,
-ENGL,3140,1,Technical Writing,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,william pulley,
-ENGL,3140,2,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,4,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,
-ENGL,3140,6,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,beltran dian quaglia,
-ENGL,3140,8,Technical Writing,0.79,0.05,0.05,0.05,0.0,0.0,0.0,0.05,brian lee gaines,
-ENGL,3140,11,Technical Writing,0.5,0.33,0.06,0.06,0.0,0.0,0.0,0.06,geveryl lee robinson,
-ENGL,3140,12,Technical Writing,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,geveryl lee robinson,
-ENGL,3140,13,Technical Writing,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,april obrien,
-ENGL,3140,14,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,april obrien,
-ENGL,3140,16,Technical Writing,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,22,Technical Writing,0.74,0.11,0.0,0.0,0.05,0.0,0.0,0.11,michael david measel,
-ENGL,3140,100,Technical Writing (HONORS),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,True
-ENGL,3150,1,Scientific Writing & Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,3150,2,Scientific Writing & Comm,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,3150,3,Scientific Writing & Comm,0.53,0.24,0.06,0.06,0.0,0.0,0.0,0.12,william pulley,
-ENGL,3150,4,Scientific Writing & Comm,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,william pulley,
-ENGL,3150,400,Scientific Writing & Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,401,Scientific Writing & Comm,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,402,Scientific Writing & Comm,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,403,Scientific Writing & Comm,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,405,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3450,1,Intr Creative Writing: Fiction,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nicholas chris brown,
-ENGL,3460,2,Intr Creative Writing: Poetry,0.61,0.22,0.06,0.06,0.0,0.0,0.0,0.06,sharon kathle nalley,
-ENGL,3480,1,Intr Creat Writ: Screenwriting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,
-ENGL,3480,2,Intr Creat Writ: Screenwriting,0.67,0.17,0.0,0.0,0.06,0.0,0.0,0.11,julia brownlee koets,
-ENGL,3570,1,Film,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,
-ENGL,3800,1,Women Writers,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,remley meliss makala,
-ENGL,3850,1,Children's Lit,0.6,0.27,0.0,0.0,0.13,0.0,0.0,0.0,megan noe macalystre,
-ENGL,3860,1,Adolescent Lit,0.12,0.65,0.24,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,3970,2,Brit Lit Survey II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,
-ENGL,3980,2,Amer Lit Survey I,0.26,0.63,0.05,0.0,0.0,0.0,0.0,0.05,susanna ashton,
-ENGL,4010,1,Grammar Survey,0.68,0.11,0.11,0.05,0.05,0.0,0.0,0.0,william stockton,
-ENGL,4080,1,Chaucer,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,andrew lemons,
-ENGL,4180,1,English Novel,0.09,0.64,0.18,0.0,0.0,0.0,0.0,0.09,lee morrissey,
-ENGL,4200,1,Amer Lit to 1799,0.4,0.4,0.0,0.0,0.07,0.0,0.0,0.13,jonathan beech field,
-ENGL,4210,1,Amer Lit 1800-1899,0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,dominic mastroianni,
-ENGL,4280,1,Contemporary Literature,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,matthew hooley,
-ENGL,4310,1,Modern Poetry,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,4360,1,Feminist Literary Criticism,0.47,0.29,0.12,0.06,0.0,0.0,0.0,0.06,erin marina goss,
-ENGL,4400,1,Literary Theory,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,maria selene bose,
-ENGL,4420,1,Cultural Studies,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,maria selene bose,
-ENGL,4430,1,Theories of World Literature,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,andrew lemons,
-ENGL,4440,1,Renaissance Literature,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4450,1,Fiction Workshop,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,4480,1,Screenwriting Wkshop,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,nicholas chris brown,
-ENGL,4510,1,Film Theory and Criticism,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,john robert smith,
-ENGL,4510,2,Film Theory and Criticism,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,john robert smith,
-ENGL,4520,1,Great Directors,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,olga anatoly volkova,
-ENGL,4560,1,Holocaust Lit/Arts,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,steven katz,
-ENGL,4600,1,Writing Technologies,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,tharon howard,
-ENGL,4780,1,Digital Literacy,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,tharon howard,
-ENGL,4920,1,Modern Rhetoric,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,megan eatman,
-ENGL,4960,1,Senior Seminar,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jonathan beech field,
-ENGL,4960,2,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,4960,3,Senior Seminar,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,erin marina goss,
-ENGL,8520,1,Rhetorical Theories & Practice,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,megan eatman,
-ENGR,1020,112,Engineering Discipl & Skills,0.13,0.63,0.15,0.03,0.0,0.0,0.0,0.08,sarah grigg,
-ENGR,1020,113,Engineering Discipl & Skills,0.18,0.63,0.18,0.0,0.0,0.0,0.0,0.03,sarah grigg,
-ENGR,1020,116,Engineering Discipl & Skills,0.4,0.38,0.15,0.0,0.0,0.0,0.0,0.08,michael giebner,
-ENGR,1020,211,Engineering Discipl & Skills,0.38,0.4,0.05,0.05,0.05,0.0,0.0,0.07,ashley childers,
-ENGR,1020,218,Engineering Discipl & Skills,0.21,0.47,0.21,0.05,0.03,0.0,0.0,0.03,michael giebner,
-ENGR,1020,311,Engineering Discipl & Skills,0.24,0.43,0.21,0.02,0.05,0.0,0.0,0.05,john minor,
-ENGR,1020,312,Engineering Discipl & Skills,0.33,0.36,0.21,0.02,0.02,0.0,0.0,0.05,john minor,
-ENGR,1020,314,Engineering Discipl & Skills,0.51,0.17,0.17,0.07,0.0,0.0,0.0,0.07,ashley childers,
-ENGR,1020,315,Engr Discipl & Skills (HON),0.76,0.21,0.0,0.0,0.0,0.0,0.0,0.03,richard watkins,True
-ENGR,1020,316,Engineering Discipl & Skills,0.33,0.38,0.14,0.02,0.02,0.0,0.0,0.1,steven brandon,
-ENGR,1020,611,Engineering Discipl & Skills,0.37,0.37,0.12,0.07,0.02,0.0,0.0,0.05,irene marie ferrara,
-ENGR,1020,612,Engineering Discipl & Skills,0.63,0.2,0.12,0.02,0.02,0.0,0.0,0.0,irene marie ferrara,
-ENGR,1020,613,Engineering Discipl & Skills,0.12,0.33,0.3,0.12,0.03,0.0,0.0,0.09,elizabeth an stephan,
-ENGR,1020,614,Engineering Discipl & Skills,0.09,0.19,0.13,0.25,0.06,0.0,0.0,0.28,matthew kent miller,
-ENGR,1020,615,Engineering Discipl & Skills,0.31,0.36,0.21,0.07,0.0,0.0,0.0,0.05,anthony paul garland,
-ENGR,1020,616,Engineering Discipl & Skills,0.04,0.48,0.3,0.07,0.04,0.0,0.0,0.07,andrew isaac neptune,
-ENGR,1020,617,Engineering Discipl & Skills,0.34,0.32,0.21,0.0,0.0,0.0,0.0,0.13,anthony paul garland,
-ENGR,1020,618,Engineering Discipl & Skills,0.12,0.39,0.27,0.05,0.02,0.0,0.0,0.15,anthony paul garland,
-ENGR,1020,811,Engineering Discipl & Skills,0.45,0.38,0.15,0.03,0.0,0.0,0.0,0.0,jonathan broo harcum,
-ENGR,1020,812,Engineering Discipl & Skills,0.29,0.49,0.15,0.05,0.0,0.0,0.0,0.02,elizabeth an stephan,
-ENGR,1020,813,Engineering Discipl & Skills,0.3,0.43,0.18,0.08,0.0,0.0,0.0,0.03,andrew isaac neptune,
-ENGR,1020,814,Engineering Discipl & Skills,0.55,0.3,0.08,0.03,0.0,0.0,0.0,0.05,jonathan broo harcum,
-ENGR,1020,815,Engineering Discipl & Skills,0.4,0.5,0.05,0.0,0.05,0.0,0.0,0.0,jonathan broo harcum,
-ENGR,1020,816,Engineering Discipl & Skills,0.43,0.38,0.13,0.03,0.0,0.0,0.0,0.05,matthew kent miller,
-ENGR,1020,817,Engineering Discipl & Skills,0.23,0.5,0.15,0.08,0.0,0.0,0.0,0.05,matthew kent miller,
-ENGR,1020,818,Engineering Discipl & Skills,0.41,0.38,0.05,0.14,0.03,0.0,0.0,0.0,andrew isaac neptune,
-ENGR,1020,831,Engr Discipl & Skills (HON),0.69,0.29,0.0,0.0,0.0,0.0,0.0,0.03,jonathan maier,True
-ENGR,1020,832,Engr Discipl & Skills (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jonathan maier,True
-ENGR,1060,400,Engr Discipline & Skills II,0.0,0.44,0.19,0.19,0.19,0.0,0.0,0.0,mariah so magagnotti,
-ENGR,1060,401,Engr Discipline & Skills II,0.17,0.17,0.17,0.17,0.33,0.0,0.0,0.0,mariah so magagnotti,
-ENGR,1410,222,Programming & Problem Solving,0.05,0.26,0.32,0.11,0.16,0.0,0.0,0.11,mariah so magagnotti,
-ENGR,1410,223,Programming & Problem Solving,0.05,0.16,0.51,0.11,0.03,0.0,0.0,0.14,william martin,
-ENGR,1410,226,Programming & Problem Solving,0.13,0.21,0.39,0.11,0.11,0.0,0.0,0.05,mariah so magagnotti,
-ENGR,1410,227,Programming & Problem Solving,0.14,0.36,0.31,0.14,0.03,0.0,0.0,0.03,william martin,
-ENGR,2080,681,Engr Graphics & Machine Design,0.42,0.33,0.11,0.0,0.08,0.0,0.0,0.06,nighat yasmin,
-ENGR,2080,682,Engr Graphics & Machine Design,0.32,0.3,0.22,0.11,0.05,0.0,0.0,0.0,nighat yasmin,
-ENGR,2080,683,Engr Graphics & Machine Design,0.44,0.33,0.13,0.0,0.1,0.0,0.0,0.0,kyle walker,
-ENGR,2080,684,Engr Graphics & Machine Design,0.37,0.39,0.13,0.0,0.0,0.0,0.0,0.11,kyle walker,
-ENGR,2080,685,Engr Graphics & Machine Design,0.5,0.16,0.16,0.03,0.03,0.0,0.0,0.13,samuel coeyman,
-ENGR,2080,686,Engr Graphics & Machine Design,0.35,0.32,0.21,0.06,0.06,0.0,0.0,0.0,samuel coeyman,
-ENGR,2100,804,CAD & Engineering Applications,0.44,0.18,0.1,0.1,0.1,0.0,0.0,0.08,afshin famili,
-ENGR,2100,805,CAD & Engineering Applications,0.45,0.33,0.1,0.03,0.05,0.0,0.0,0.05,nighat yasmin,
-ENGR,2100,806,CAD & Engineering Applications,0.55,0.26,0.03,0.05,0.0,0.0,0.0,0.11,afshin famili,
-ENGR,2200,115,Evaluating Innovations,0.1,0.65,0.23,0.03,0.0,0.0,0.0,0.0,sarah grigg,
-ENR,1010,2,Intro to Envir & Natur Res I,0.82,0.11,0.02,0.0,0.0,0.0,0.0,0.05,emily catheri oakman,
-ENR,1010,3,Intro to Envir & Natur Res I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,emily catheri oakman,
-ENR,4290,1,Environ Law & Policy,0.24,0.38,0.27,0.03,0.03,0.0,0.0,0.05,alan johnson,
-ENR,4290,2,Environ Law & Policy,0.36,0.45,0.11,0.0,0.0,0.0,0.0,0.07,alan johnson,
-ENSP,2000,1,Intro Environ Sci,0.33,0.47,0.19,0.0,0.02,0.0,0.0,0.0,scott brame,
-ENSP,2000,2,Intro Environ Sci,0.69,0.28,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2000,3,Intro Environ Sci,0.57,0.39,0.02,0.0,0.0,0.0,0.0,0.02,minory nammouz,
-ENSP,2000,4,Intro Environ Sci,0.56,0.4,0.02,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,
-ENSP,2000,5,Intro Environ Sci,0.39,0.39,0.13,0.02,0.0,0.0,0.0,0.07,tom owino,
-ENSP,4000,1,Studies in Environmental Sci,0.53,0.35,0.0,0.06,0.0,0.0,0.0,0.06,margaret lo thompson,
-ENT,2000,1,Six-Legged Science,0.53,0.4,0.05,0.0,0.0,0.0,0.0,0.03,suellen pometto,
-ENT,3010,1,Insect Biology and Diversity,0.33,0.33,0.27,0.07,0.0,0.0,0.0,0.0,eric benson,
-ENTR,1010,3,Entrepreneurial Mindset,0.69,0.23,0.05,0.01,0.01,0.0,0.0,0.01,john michael hannon,
-ENTR,1090,6,Creative Inq-Entrepreneurship,0.61,0.3,0.0,0.0,0.0,0.0,0.0,0.09,john michael hannon,
-ENTR,2010,4,Sports Entrepreneurship,0.63,0.27,0.03,0.0,0.03,0.0,0.0,0.03,john michael hannon,
-ETOX,4300,1,Toxicology,0.54,0.23,0.15,0.08,0.0,0.0,0.0,0.0,lisa bain,
-FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.88,0.05,0.02,0.02,0.01,0.0,0.0,0.02,sara lane cothran,
-FDSC,3010,1,Food Regulations,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
-FDSC,4010,1,Food Chemistry I,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4040,1,Food Prsv & Process,0.53,0.21,0.21,0.02,0.02,0.0,0.0,0.0,anthony loui pometto,
-FDSC,4070,1,Quantity Food Production,0.84,0.1,0.03,0.0,0.03,0.0,0.0,0.0,bridgit deni corbett,
-FDSC,4300,1,Dairy Process & Sant,0.52,0.24,0.1,0.14,0.0,0.0,0.0,0.0,john mcgregor,
-FDSC,8120,1,Microbial Food Syst,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,xiuping jiang,
-FDSC,8210,1,Selected Topics,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,julie kath northcutt,
-FIN,2010,401,Intro to Personal Finance,0.95,0.04,0.01,0.0,0.0,0.0,0.0,0.0,joshua harris,
-FIN,2010,402,Intro to Personal Finance,0.89,0.08,0.01,0.0,0.0,0.0,0.0,0.02,joshua harris,
-FIN,2010,403,Intro to Personal Finance,0.9,0.07,0.01,0.0,0.01,0.0,0.0,0.01,joshua harris,
-FIN,2010,404,Intro to Personal Finance,0.78,0.09,0.02,0.02,0.06,0.0,0.0,0.02,joshua harris,
-FIN,2010,406,Intro to Personal Finance,0.79,0.15,0.0,0.02,0.02,0.0,0.0,0.02,joshua harris,
-FIN,2010,407,Intro to Personal Finance,0.81,0.1,0.0,0.1,0.0,0.0,0.0,0.0,joshua harris,
-FIN,3040,1,Risk & Insurance,0.28,0.3,0.23,0.15,0.0,0.0,0.0,0.05,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.07,0.29,0.32,0.05,0.17,0.0,0.0,0.1,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.08,0.5,0.32,0.03,0.08,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.21,0.36,0.28,0.05,0.03,0.0,0.0,0.08,kerri mcmillan,
-FIN,3050,4,Investment Analysis,0.14,0.25,0.19,0.17,0.14,0.0,0.0,0.11,john alexander,
-FIN,3060,5,Corporation Finance,0.09,0.45,0.3,0.11,0.02,0.0,0.0,0.04,ramon tolbe franklin,
-FIN,3060,6,Corporation Finance,0.09,0.27,0.34,0.14,0.09,0.0,0.0,0.07,ramon tolbe franklin,
-FIN,3060,7,Corporation Finance,0.15,0.26,0.26,0.15,0.0,0.0,0.0,0.17,ramon tolbe franklin,
-FIN,3060,8,Corporation Finance,0.24,0.41,0.25,0.08,0.0,0.0,0.0,0.02,melvin stith,
-FIN,3060,9,Corporation Finance,0.29,0.39,0.2,0.1,0.02,0.0,0.0,0.0,melvin stith,
-FIN,3060,401,Corporation Finance,0.49,0.23,0.23,0.02,0.0,0.0,0.0,0.04,joshua harris,
-FIN,3060,402,Corporation Finance,0.37,0.42,0.12,0.04,0.02,0.0,0.0,0.04,joshua harris,
-FIN,3070,1,Prin of Real Estate,0.1,0.22,0.39,0.17,0.1,0.0,0.0,0.02,thomas springer,
-FIN,3070,2,Prin of Real Estate,0.18,0.32,0.23,0.2,0.0,0.0,0.0,0.07,thomas springer,
-FIN,3070,3,Prin of Real Estate,0.26,0.42,0.29,0.03,0.0,0.0,0.0,0.0,yannan shen,
-FIN,3080,3,Fin Inst & Mkts,0.23,0.33,0.36,0.08,0.0,0.0,0.0,0.0,daniel thomas greene,
-FIN,3080,401,Fin Inst & Mkts,0.21,0.32,0.36,0.09,0.0,0.0,0.0,0.02,daniel thomas greene,
-FIN,3110,1,Financial Management I,0.12,0.24,0.31,0.12,0.05,0.0,0.0,0.17,jack wolf,
-FIN,3110,2,Financial Management I,0.12,0.3,0.4,0.12,0.05,0.0,0.0,0.02,jack wolf,
-FIN,3110,3,Financial Management I,0.28,0.28,0.28,0.13,0.05,0.0,0.0,0.0,jack wolf,
-FIN,3110,5,Financial Management I,0.16,0.34,0.36,0.11,0.02,0.0,0.0,0.02,weike xu,
-FIN,3110,6,Financial Management I,0.16,0.43,0.3,0.07,0.04,0.0,0.0,0.0,weike xu,
-FIN,3120,1,Financial Management II,0.17,0.3,0.37,0.1,0.0,0.0,0.0,0.07,vincent ja intintoli,
-FIN,3120,2,Financial Management II,0.05,0.31,0.36,0.1,0.14,0.0,0.0,0.05,vincent ja intintoli,
-FIN,3120,3,Financial Management II,0.24,0.27,0.15,0.07,0.05,0.0,0.0,0.22,blerina zykaj,
-FIN,3120,4,Financial Management II,0.21,0.39,0.21,0.05,0.04,0.0,0.0,0.09,weike xu,
-FIN,3120,101,Financial Mgt II (HON),0.7,0.2,0.0,0.1,0.0,0.0,0.0,0.0,vincent ja intintoli,True
-FIN,4010,1,Corporate Financial Analysis,0.33,0.4,0.17,0.02,0.02,0.0,0.0,0.05,george bran lockhart,
-FIN,4020,1,Corporate Valuation,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,angela morgan,
-FIN,4050,1,Portfolio Management & Theory,0.14,0.17,0.44,0.14,0.06,0.0,0.0,0.06,john alexander,
-FIN,4060,1,Derivatives Analysis,0.34,0.31,0.17,0.07,0.07,0.0,0.0,0.03,blerina zykaj,
-FIN,4110,1,Int Fin Mgt,0.21,0.46,0.28,0.05,0.0,0.0,0.0,0.0,luke asher devault,
-FIN,4110,2,Int Fin Mgt,0.22,0.53,0.22,0.03,0.0,0.0,0.0,0.0,luke asher devault,
-FIN,4170,1,Real Estate Finance,0.24,0.38,0.24,0.1,0.05,0.0,0.0,0.0,yannan shen,
-FNR,2040,1,Soil Information Systems,0.84,0.1,0.03,0.0,0.02,0.0,0.0,0.02,elena mikhailova,
-FNR,4990,1,Natural Resources Seminar,0.76,0.21,0.03,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
-FOR,2050,1,Dendrology,0.24,0.35,0.05,0.22,0.08,0.0,0.0,0.05,donald hagan,
-FOR,2050,2,Dendrology,0.27,0.37,0.16,0.08,0.02,0.0,0.0,0.1,donald hagan,
-FOR,2050,3,Dendrology,0.37,0.16,0.11,0.11,0.21,0.0,0.0,0.05,donald hagan,
-FOR,2210,1,Forest Biology,0.75,0.12,0.1,0.01,0.0,0.0,0.0,0.02,emily catheri oakman,
-FOR,3020,1,Forest Biometrics,0.24,0.44,0.16,0.16,0.0,0.0,0.0,0.0,lawrence gering,
-FOR,3040,1,Forest Resource Economics,0.46,0.46,0.07,0.0,0.0,0.0,0.0,0.0,puskar khanal,
-FOR,4100,1,Harvesting Processes,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,patrick hiesl,
-FOR,4160,1,Forest Policy and Admin,0.44,0.3,0.22,0.02,0.0,0.0,0.0,0.01,thomas straka,
-FOR,4170,1,Forest Resource Mgt & Regulatn,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.0,puskar khanal,
-FOR,4310,1,Recreation Res Plan in For Mgt,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,robert baxter powell,
-FOR,4340,1,GIS for Natural Resources,0.79,0.19,0.02,0.0,0.0,0.0,0.0,0.0,christopher post,
-FR,1010,1,Elementary French,0.33,0.33,0.17,0.06,0.0,0.0,0.0,0.11, nedeo anne salces anne,
-FR,1010,2,Elementary French,0.31,0.44,0.19,0.0,0.06,0.0,0.0,0.0, nedeo anne salces anne,
-FR,1010,3,Elementary French,0.13,0.38,0.38,0.06,0.06,0.0,0.0,0.0, nedeo anne salces anne,
-FR,1020,1,Elementary French,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
-FR,1020,2,Elementary French,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,amy lyn griff sawyer griff,
-FR,2010,2,Intermediate French,0.28,0.56,0.06,0.0,0.06,0.0,0.0,0.06,kenneth davi widgren,
-FR,2010,3,Intermediate French,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,kenneth davi widgren,
-FR,2010,4,Intermediate French,0.33,0.5,0.06,0.06,0.0,0.0,0.0,0.06,tholozany pauline de,
-FR,2020,1,Intermediate French,0.89,0.0,0.05,0.0,0.0,0.0,0.0,0.05,amy lyn griff sawyer griff,
-FR,2020,2,Intermediate French,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,
-FR,2020,3,Intermediate French,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,eric touya,
-FR,2020,4,Intermediate French,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
-FR,2020,5,Intermediate French,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,kenneth davi widgren,
-FR,3000,1,Survey of French Lit,0.39,0.5,0.0,0.0,0.06,0.0,0.0,0.06,tholozany pauline de,
-FR,3050,1,Int Fr Con & Comp I,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,kenneth davi widgren,
-FR,4120,1,Fr & Francoph Cinema,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,joseph mai,
-FR,4160,1,Fr for Intl Trade II,0.43,0.36,0.14,0.0,0.0,0.0,0.0,0.07,eric touya,
-GC,1020,1,Computer Art & CAD Foundations,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,carol jones,
-GC,1020,2,Computer Art & CAD Foundations,0.5,0.42,0.0,0.0,0.06,0.0,0.0,0.02,carol jones,
-GC,1030,1,G C I for Pkgsc,0.29,0.67,0.05,0.0,0.0,0.0,0.0,0.0,john jacobs,
-GC,1040,1,Graphic Communications I,0.67,0.23,0.05,0.02,0.02,0.0,0.0,0.02,michelle suki bo fox bo,
-GC,2070,1,Graphic Communications II,0.6,0.29,0.02,0.0,0.04,0.0,0.0,0.04,charles tabor weiss,
-GC,3400,1,Digital Imaging and eMedia,0.29,0.48,0.17,0.0,0.04,0.0,0.0,0.02,erica black walker,
-GC,3460,1,Ink and Substrates,0.25,0.36,0.34,0.0,0.05,0.0,0.0,0.0,liam henry 'hara,
-GC,4060,1,Package and Specialty Printing,0.67,0.29,0.02,0.0,0.02,0.0,0.0,0.0,kern cox,
-GC,4400,1,Commercial Printing,0.28,0.59,0.1,0.0,0.03,0.0,0.0,0.0,eric weisenmiller,
-GC,4440,1,Current Dev/Trends in Gr Comm,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,
-GC,4800,1,Senior Seminar in GC,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,charles edwar tonkin,
-GC,4900,1,Media & Film in Dig Age,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,erica black walker,
-GC,4900,3,Digital Media Design,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erica black walker,
-GC,4900,6,GC-UX & Web Design,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erica black walker,
-GC,4900,230,G C Selected Topics-GC Sales,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,
-GEN,1030,1,Careers in Bioch/Gen,0.88,0.07,0.0,0.01,0.03,0.0,0.0,0.01,alison ni starr-moss,
-GEN,3000,1,Fundamental Genetics,0.29,0.33,0.26,0.03,0.01,0.0,0.0,0.09,kate leanne wil tsai wil,
-GEN,3000,2,Fundamental Genetics,0.26,0.34,0.25,0.1,0.02,0.0,0.0,0.04,kate leanne wil tsai wil,
-GEN,3020,1,Molecular & General Genetics,0.57,0.35,0.05,0.01,0.0,0.0,0.0,0.02,jennifer may mason,
-GEN,3020,2,Molec & General Genetics (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True
-GEN,3040,1,Molecular Biology Laboratory,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,scott michael tanner,
-GEN,3040,2,Molecular Biology Laboratory,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,3040,3,Molecular Biology Laboratory,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,3040,4,Molecular Biology Laboratory,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,4100,1,Population & Quant Genetics,0.38,0.44,0.1,0.04,0.02,0.0,0.0,0.02,scott michael tanner,
-GEN,4100,2,Population & Quant Gen (HON),0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,scott michael tanner,True
-GEN,4110,1,Population & Quant Gen Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,4110,2,Population & Quant Gen Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,4110,3,Population & Quant Gen Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,4110,4,Population & Quant Gen Lab,0.79,0.0,0.07,0.0,0.07,0.0,0.0,0.07,scott michael tanner,
-GEN,4400,1,Bioinformatics,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,frank alexand feltus,
-GEN,4500,1,Comparative Genetics,0.25,0.45,0.25,0.0,0.03,0.0,0.0,0.03,leigh anne clark,
-GEN,4900,1,Epigenetics,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,rajandeep sin sekhon,
-GEN,8140,1,Advanced Genetics,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,miriam kristi konkel,
-GEOG,1030,1,World Regional Geography,0.33,0.42,0.15,0.02,0.02,0.0,0.0,0.06,william church terry,
-GEOG,3010,1,Political Geography,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,christa smith,
-GEOG,4010,1,Studies in Geography,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william church terry,
-GEOL,1010,1,Physical Geology,0.22,0.3,0.18,0.11,0.09,0.0,0.0,0.1,alan coulson,
-GEOL,1010,2,Physical Geology,0.24,0.33,0.25,0.05,0.06,0.0,0.0,0.06,alan coulson,
-GEOL,1010,4,Physical Geology,0.49,0.29,0.16,0.0,0.02,0.0,0.0,0.04,mary katherin fidler,
-GEOL,1030,1,Physical Geol Lab,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.42,0.46,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.38,0.46,0.17,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.57,0.26,0.04,0.04,0.0,0.0,0.0,0.09,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.32,0.5,0.09,0.05,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.54,0.13,0.0,0.04,0.17,0.0,0.0,0.13,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.58,0.29,0.04,0.0,0.04,0.0,0.0,0.04,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,13,Physical Geol Lab,0.22,0.48,0.22,0.04,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1120,1,Earth Resources,0.27,0.32,0.23,0.09,0.05,0.0,0.0,0.03,mary katherin fidler,
-GEOL,1140,1,Earth Resources Lab,0.58,0.2,0.13,0.02,0.02,0.0,0.0,0.04,mary katherin fidler,
-GEOL,2050,1,Mineralogy & Intro Petrology,0.4,0.33,0.13,0.07,0.0,0.0,0.0,0.07,lind shuller-nickles,
-GEOL,2070,1,Min & Intro Pet Lab,0.33,0.13,0.27,0.13,0.07,0.0,0.0,0.07,mary katherin fidler,
-GEOL,2750,1,Field Methods,0.7,0.0,0.0,0.0,0.0,0.0,0.0,0.3,scott brame,
-GEOL,3000,1,Environmental Geology,0.05,0.49,0.31,0.1,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,3020,1,Structural Geology,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,alexander tho pullen,
-GEOL,4030,1,Invertebrate Paleontology,0.1,0.7,0.0,0.0,0.0,0.0,0.0,0.2,neil smith,
-GEOL,4150,1,Analysis Geological Processes,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,lawrence murdoch,
-GEOL,4910,1,Research Synthesis I,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,alan coulson,
-GEOL,6820,1,Groundwater & Contam Transport,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
-GEOL,7900,501,Biogeography And Geology of SC,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
-GER,1010,2,Elementary German,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-GER,1010,3,Elementary German,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,oswald harris king,
-GER,1020,1,Elementary German,0.07,0.33,0.2,0.13,0.07,0.0,0.0,0.2, lee ferrell,
-GER,2010,1,Intermediate German,0.25,0.19,0.38,0.13,0.06,0.0,0.0,0.0,johannes schmidt,
-GER,2010,2,Intermediate German,0.08,0.31,0.38,0.23,0.0,0.0,0.0,0.0,johannes schmidt,
-GER,2020,1,Intermediate German,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,gabriela stoicea,
-GER,2020,2,Intermediate German,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,oswald harris king,
-GER,3050,1,Ger Conv & Comp,0.57,0.21,0.21,0.0,0.0,0.0,0.0,0.0, lee ferrell,
-GER,3400,1,German Culture,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,
-HIST,1010,1,History of the United States,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
-HIST,1010,2,History of the United States,0.21,0.47,0.18,0.09,0.06,0.0,0.0,0.0,john andrew,
-HIST,1020,1,History of the United States,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,maribel morey,
-HIST,1220,1,"Hist, Tech & Society",0.36,0.49,0.06,0.05,0.02,0.0,0.0,0.03,pamela mack,
-HIST,1240,1,Environmental History Survey,0.3,0.3,0.23,0.03,0.03,0.0,0.0,0.1,james bradf jeffries,
-HIST,1240,2,Environmental History Survey,0.23,0.37,0.23,0.13,0.03,0.0,0.0,0.0,james bradf jeffries,
-HIST,1720,1,The West and the World I,0.22,0.34,0.26,0.05,0.06,0.0,0.0,0.07,caroline dunn clark,
-HIST,1720,2,The West and the World I,0.29,0.47,0.15,0.07,0.02,0.0,0.0,0.01,steven marks,
-HIST,1730,1,The West and the World II,0.19,0.43,0.19,0.05,0.08,0.0,0.0,0.06,michael meng,
-HIST,1730,2,The West and the World II,0.44,0.3,0.15,0.04,0.0,0.0,0.0,0.07, alan grubb,
-HIST,2990,1,Historian's Craft,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,thomas kuehn,
-HIST,2990,3,Historian's Craft,0.59,0.24,0.06,0.06,0.06,0.0,0.0,0.0,michael silvestri,
-HIST,3010,1,Am Rev & New Nation,0.26,0.53,0.11,0.0,0.11,0.0,0.0,0.0,james bradf jeffries,
-HIST,3030,1,Civil War & Recon,0.16,0.79,0.0,0.0,0.0,0.0,0.0,0.05,paul christ anderson,
-HIST,3040,1,Indus & Progr Era,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0, roger grant,
-HIST,3120,1,Afr Amer Hist 1877 to Present,0.21,0.63,0.11,0.0,0.0,0.0,0.0,0.05,abel bartley,
-HIST,3240,1,Hist of the South II,0.36,0.4,0.12,0.04,0.04,0.0,0.0,0.04,john andrew,
-HIST,3280,1,US Legal History to 1890,0.7,0.27,0.03,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
-HIST,3330,1,Hist of Mod Japan,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,edwin moise,
-HIST,3380,1,Africa to 1875,0.38,0.25,0.21,0.13,0.0,0.0,0.0,0.04,james burns,
-HIST,3410,1,Modern Mexico,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,rachel anne moore,
-HIST,3630,1,Britain Since 1688,0.5,0.38,0.04,0.0,0.0,0.0,0.0,0.08,stephanie barczewski,
-HIST,3700,1,Medieval History,0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,
-HIST,3970,1,Modern Middle East,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
-HIST,4400,1,Studies in Latin American Hist,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
-HIST,4710,1,The Great War,0.57,0.14,0.14,0.0,0.07,0.0,0.0,0.07, alan grubb,
-HIST,4900,2,Weimar Germany,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,michael meng,
-HIST,4900,3,Dictatorship&ViolenceIW Europe,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,amit bein,
-HIST,4920,1,Iraq War,0.2,0.2,0.47,0.07,0.0,0.0,0.0,0.07,edwin moise,
-HIST,4960,1,European Law,0.2,0.4,0.3,0.0,0.0,0.0,0.0,0.1,thomas kuehn,
-HLTH,2020,1,Introduction to Public Health,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,2,Introduction to Public Health,0.56,0.33,0.1,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,3,Introduction to Public Health,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2020,4,Introduction to Public Health,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,becky ann tugman,
-HLTH,2020,5,Introduction to Public Health,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2020,400,Introduction to Public Health,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,401,Introduction to Public Health,0.53,0.26,0.11,0.0,0.0,0.0,0.0,0.11,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-HLTH,2030,2,Health Care Sys,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-HLTH,2030,3,Health Care Sys,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,tanya lee staton,
-HLTH,2400,1,Deter of Hlth Behav,0.45,0.42,0.12,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2400,2,Deter of Hlth Behav,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
-HLTH,2400,400,Deter of Hlth Behav,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2600,1,Medical Terminology & Comm,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,karen edwards,
-HLTH,2600,2,Medical Terminology & Comm,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,karen edwards,
-HLTH,2600,400,Medical Terminology & Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2980,1,Human Health and Disease,0.75,0.16,0.09,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,2980,2,Human Health and Disease,0.54,0.31,0.11,0.03,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2980,3,Human Health and Disease,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,3400,1,Hlth Prom Prog Plan,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,3610,1,Int Health Care Econ,0.67,0.23,0.03,0.0,0.0,0.0,0.0,0.07,khoa dang truong,
-HLTH,3800,1,Epidemiology,0.64,0.27,0.06,0.0,0.0,0.0,0.0,0.03,deborah alma falta,
-HLTH,3800,2,Epidemiology,0.42,0.39,0.15,0.0,0.0,0.0,0.0,0.03,deborah alma falta,
-HLTH,3800,400,Epidemiology,0.37,0.37,0.21,0.0,0.05,0.0,0.0,0.0,deborah alma falta,
-HLTH,3980,1,Health Appraisal Skills,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,3980,2,Health Appraisal Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4100,1,Maternal Child Hlth,0.54,0.43,0.04,0.0,0.0,0.0,0.0,0.0,karyn jones,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.79,0.1,0.1,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4400,1,Manag Hlth Serv Org,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,
-HLTH,4700,1,Global Health,0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,micky rogers ward,
-HLTH,4750,1,Hlthcr Oper Mgmt Res,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,lu shi,
-HLTH,4900,1,Res Eval St Pub Hlth,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,karen kemper,
-HLTH,4900,2,Res Eval St Pub Hlth,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,4970,4,Aspire to Be Well - CI,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,chloe carolin greene,
-HLTH,4970,5,Alcohol & Other Drugs-CI,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,crystal burne fulmer,
-HLTH,8030,1,Theories and Determ of Health,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,joel edward williams,
-HLTH,8410,1,Foundations of Eval in Health,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,
-HON,1940,1,Bioinspired,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,charles beard,True
-HON,2020,1,Who Decides What's Cool?,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,True
-HON,2020,2,World of Ideas,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True
-HON,2050,1,Architecture: Ideas & Practice,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burl brown,True
-HON,2060,3,Puzzles and Paradoxes,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,marilyn reba,True
-HON,2210,1,Frankenstein at 200,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,remley meliss makala,True
-HORT,1010,1,Horticulture,0.86,0.09,0.01,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,
-HORT,2020,1,Adobe Digital Design,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,janice ann lay,
-HORT,2020,2,Hydroponics,0.17,0.28,0.19,0.17,0.06,0.0,0.0,0.15,james emerson faust,
-HORT,2120,1,Turfgrass Culture,0.56,0.38,0.05,0.0,0.0,0.0,0.0,0.0,haibo liu,
-HORT,2130,2,Turf Culture Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
-HORT,3030,1,Landscape Plants,0.09,0.22,0.35,0.16,0.15,0.0,0.0,0.03,robert polomski,
-HORT,3080,1,Sust Landsc Des Install Maint,0.9,0.08,0.0,0.0,0.03,0.0,0.0,0.0,ellen anita vincent,
-HORT,4120,1,Adv Turfgrass Mgt,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,lambert mccarty,
-HP,8070,400,American Architecture,0.6,0.1,0.0,0.0,0.0,0.0,0.0,0.3,carter lee hudgins,
-HP,8080,400,Hist and Theory of Hist Pres,0.56,0.11,0.0,0.0,0.0,0.0,0.0,0.33,carter lee hudgins,
-HP,8090,400,Historical Research Methods,0.5,0.13,0.0,0.0,0.0,0.0,0.0,0.38,katherine pemberton,
-HP,8190,1,"Investig, Docum, Conservation",0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,amalia leifeste,
-HRD,8200,401,Human Perform Improv,0.77,0.14,0.0,0.0,0.0,0.0,0.0,0.09,angela daniel carter,
-HRD,8450,400,Needs Assess Ed/Ind,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,angela daniel carter,
-HRD,8600,400,Instruc Mat Devel,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,cynthia sims,
-IE,2100,1,Des Analysis Wrk Sys,0.49,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jeffery messer,
-IE,3010,1,Systems Design I,0.35,0.49,0.14,0.01,0.0,0.0,0.0,0.01,robert james riggs,
-IE,3600,1,Industrial Apps of Prob/Stat I,0.23,0.25,0.23,0.14,0.08,0.0,0.0,0.06,tugce isik,
-IE,3610,1,Industrial App of Prob/Stat II,0.31,0.41,0.1,0.1,0.04,0.0,0.0,0.04,david neyens,
-IE,3800,1,Deterministic Operations Rsrch,0.17,0.42,0.2,0.05,0.15,0.0,0.0,0.01,joshua tayl margolis,
-IE,3810,1,Probabilistic Operations Rsrch,0.6,0.29,0.07,0.01,0.0,0.0,0.0,0.02,burak eksioglu,
-IE,3840,1,Engr Econ Analysis,0.4,0.2,0.09,0.06,0.05,0.0,0.0,0.19,brian melloy,
-IE,3860,1,Production Planning & Control,0.84,0.12,0.02,0.02,0.0,0.0,0.0,0.0,xiaoxia li,
-IE,4400,1,Decision Support Sys,0.53,0.3,0.06,0.01,0.05,0.0,0.0,0.05,scott jennings mason,
-IE,4460,1,Model & Analysis Mfg Systems,0.37,0.47,0.14,0.0,0.0,0.0,0.0,0.02,robert james riggs,
-IE,4510,1,Investigating Human Error,0.36,0.26,0.28,0.04,0.0,0.0,0.0,0.06,sara lu riggs,
-IE,4530,1,Network Flows for IE Apps,0.36,0.36,0.09,0.0,0.09,0.0,0.0,0.09,burak eksioglu,
-IE,4610,1,Quality Engineering,0.29,0.32,0.27,0.07,0.02,0.0,0.0,0.02,byung rae cho,
-IE,4650,1,Facilities Planning & Design,0.23,0.47,0.18,0.06,0.02,0.0,0.0,0.03,william ferrell,
-IE,4670,1,System Design II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,
-IE,4810,1,App of Prob Models in Ind Engr,0.36,0.27,0.27,0.0,0.0,0.0,0.0,0.09,brian melloy,
-IE,4820,1,Systems Modeling,0.46,0.28,0.18,0.03,0.0,0.0,0.0,0.05,kevin taaffe,
-IE,4820,2,Systems Modeling,0.2,0.44,0.24,0.1,0.02,0.0,0.0,0.0,kevin taaffe,
-IE,4910,3,Human Centered Design & Engr,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,laura michel stanley,
-IE,6460,1,Model & Analysis Mfg Systems,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
-IE,8000,1,Human Factors Eng,0.15,0.63,0.22,0.0,0.0,0.0,0.0,0.0,david neyens,
-IE,8030,1,Engr Optimization and Apps,0.68,0.26,0.05,0.0,0.01,0.0,0.0,0.0,sandra duni eksioglu,
-IE,8040,1,Mfg Sys Plan & Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,
-IE,8530,1,Foundations of Quality,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,byung rae cho,
-IE,8550,1,SC & Logistics Modeling II,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
-IE,8930,1,Markov Decision Processes,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amin khademi,
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,lisa marie robinson,
-IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,james dougla bennett,
-ITAL,1010,2,Elementary Italian,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,luca barattoni,
-ITAL,1010,3,Elementary Italian,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,julia schmidt,
-ITAL,1010,4,Elementary Italian,0.23,0.46,0.15,0.0,0.08,0.0,0.0,0.08,julia schmidt,
-ITAL,2010,1,Intermediate Italian,0.5,0.11,0.22,0.11,0.0,0.0,0.0,0.06,julia schmidt,
-JAPN,1010,1,Elementary Japanese,0.53,0.26,0.05,0.05,0.0,0.0,0.0,0.11,saori suto,
-JAPN,1010,2,Elementary Japanese,0.47,0.16,0.21,0.05,0.0,0.0,0.0,0.11,saori suto,
-JAPN,1010,3,Elementary Japanese,0.5,0.33,0.08,0.0,0.08,0.0,0.0,0.0,satomi saito,
-JAPN,1020,1,Elementary Japanese,0.38,0.31,0.08,0.15,0.0,0.0,0.0,0.08,satomi saito,
-JAPN,2010,1,Intermed Japanese,0.46,0.08,0.31,0.08,0.0,0.0,0.0,0.08,saori suto,
-JAPN,3050,1,Japanese Conversation & Comp,0.57,0.14,0.07,0.07,0.14,0.0,0.0,0.0,jae allegra takeuchi,
-JAPN,4010,1,Japanese Lit in Translation,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,kumiko saito,
-JUST,2880,1,The Criminal Justice System,0.5,0.22,0.16,0.04,0.08,0.0,0.0,0.0,margaret tina britz,
-JUST,4680,1,Criminal Evidence,0.44,0.35,0.09,0.07,0.02,0.0,0.0,0.02,margaret tina britz,
-JUST,4860,1,Creative Inquiry in CJ,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
-LANG,3000,1,Intro Linguistics,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,daniel smith,
-LANG,4540,1,Sel Top in International Film,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,satomi saito,
-LARC,1150,1,Intro Landscape Architecture,0.77,0.14,0.05,0.0,0.0,0.0,0.0,0.05,mary padua,
-LARC,1280,1,Technical Graphics,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
-LARC,1510,1,Basic Design I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
-LARC,2510,2,Larch Design Fund,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,
-LARC,2620,1,Design Implementation I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,robert hewitt,
-LARC,4530,1,Key Issues in Landscape Arch,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,mary padua,
-LARC,4620,1,Design Implementation III,0.18,0.59,0.09,0.14,0.0,0.0,0.0,0.0,mary padua,
-LAW,3220,1,Legal Env of Bus,0.21,0.38,0.31,0.06,0.02,0.0,0.0,0.02,john hine,
-LAW,3220,4,Legal Env of Bus,0.17,0.37,0.35,0.07,0.02,0.0,0.0,0.02,kenneth sc toussaint,
-LAW,3220,5,Legal Env of Bus,0.23,0.35,0.31,0.1,0.0,0.0,0.0,0.0,kenneth sc toussaint,
-LAW,3220,6,Legal Env of Bus,0.37,0.41,0.18,0.02,0.02,0.0,0.0,0.0,kathr kisska-schulze,
-LAW,3220,7,Legal Env of Bus,0.37,0.49,0.08,0.04,0.02,0.0,0.0,0.0,kathr kisska-schulze,
-LAW,3220,8,Legal Env of Bus,0.31,0.48,0.1,0.06,0.04,0.0,0.0,0.0,kathr kisska-schulze,
-LAW,3220,9,Legal Env of Bus,0.3,0.51,0.19,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,10,Legal Env of Bus,0.3,0.33,0.26,0.04,0.02,0.0,0.0,0.04,edward ray claggett,
-LAW,3220,11,Legal Env of Bus,0.42,0.48,0.1,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,400,Legal Env of Bus,0.37,0.35,0.19,0.02,0.0,0.0,0.0,0.06,virginia ward-vaughn,
-LAW,3220,401,Legal Env of Bus,0.31,0.44,0.15,0.05,0.02,0.0,0.0,0.05,virginia ward-vaughn,
-LAW,3220,402,Legal Env of Bus,0.33,0.44,0.14,0.05,0.0,0.0,0.0,0.03,virginia ward-vaughn,
-LAW,3220,403,Legal Env of Bus,0.3,0.4,0.18,0.07,0.0,0.0,0.0,0.05,virginia ward-vaughn,
-LAW,3330,1,Real Estate Law,0.0,0.42,0.32,0.16,0.11,0.0,0.0,0.0,kenneth sc toussaint,
-LAW,3330,2,Real Estate Law,0.17,0.49,0.2,0.11,0.03,0.0,0.0,0.0,kenneth sc toussaint,
-LAW,4050,1,Construction Law,0.9,0.08,0.0,0.0,0.0,0.0,0.0,0.03,frances edwards,
-LS,1000,1,Therapeutic Yoga,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dili amin,
-LS,1000,2,Therapeutic Yoga,0.77,0.14,0.05,0.0,0.0,0.0,0.0,0.05,ranjanbala dili amin,
-LS,1000,3,Therapeutic Yoga,0.82,0.09,0.0,0.0,0.05,0.0,0.0,0.05,renee warren gahan,
-LS,1000,8,Intro to Volleyball,0.79,0.07,0.07,0.07,0.0,0.0,0.0,0.0,kelly lynn ator,
-LS,1000,12,Introduction to Salsa,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,malik lewis  baxter c,
-LS,1000,13,Introduction to Salsa Dance,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,malik lewis  baxter c,
-LS,1570,2,Shotgun Sports,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,bonnie duke gill,
-LS,1570,3,Shotgun Sports,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,edward licus prater,
-LS,1580,3,Archery,0.55,0.27,0.0,0.0,0.0,0.0,0.0,0.18,herbert strickland,
-LS,1850,1,Bowling,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,madison neel workman,
-LS,1850,2,Bowling,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,
-LS,1850,3,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,kimberly coury,
-LS,1850,4,Bowling,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,alexandra sandoval,
-LS,1850,5,Bowling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,alexandra sandoval,
-LS,1870,2,Frisbee Sports,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,steven simoneaux,
-LS,1980,9,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,wesley scott womble,
-LS,2270,2,Intro to Swing Dance,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,paul hoke,
-LS,2320,2,Core Training,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,
-LS,2320,3,Core Training,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,2320,4,Core Training,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,diane moreno,
-LS,2320,5,Core Training,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
-LS,2350,1,Basic Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2350,7,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,
-LS,2350,8,Basic Yoga,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2360,1,Power/Ashtanga Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,silica elizab larkin,
-LS,2360,2,Power/Ashtanga Yoga,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,silica elizab larkin,
-LS,2380,2,Vinyasa Flow Yoga,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,nicole eliz martinez,
-LS,2420,1,Meditation and Relax,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2420,2,Meditation and Relax,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,renee warren gahan,
-LS,2420,5,Meditation and Relax,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dili amin,
-LS,2420,6,Meditation and Relax,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dili amin,
-LS,2420,7,Meditation and Relax,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2420,9,Meditation and Relax,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,kayla lee wardlaw,
-LS,2450,1,Pilates,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,melanie ivey job,
-LS,2450,4,Pilates,0.77,0.05,0.0,0.0,0.14,0.0,0.0,0.05,diane moreno,
-LS,2450,8,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
-LS,2750,10,First Aid/Cpr,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,christopher loomis,
-MATH,1010,1,Essen Math for Informed Soc,0.33,0.33,0.27,0.07,0.0,0.0,0.0,0.0,bryce pruitt,
-MATH,1010,2,Essen Math for Informed Soc,0.22,0.33,0.17,0.22,0.0,0.0,0.0,0.06,seth selken,
-MATH,1010,3,Essen Math for Informed Soc,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,seth selken,
-MATH,1010,4,Essen Math for Informed Soc,0.47,0.13,0.2,0.13,0.0,0.0,0.0,0.07,alexander joyce,
-MATH,1010,5,Essen Math for Informed Soc,0.47,0.35,0.06,0.06,0.06,0.0,0.0,0.0,bryce pruitt,
-MATH,1010,6,Essen Math for Informed Soc,0.39,0.39,0.17,0.0,0.06,0.0,0.0,0.0,alexander joyce,
-MATH,1010,7,Essen Math for Informed Soc,0.44,0.18,0.21,0.09,0.09,0.0,0.0,0.0,marilyn reba,
-MATH,1010,8,Essen Math for Informed Soc,0.44,0.31,0.19,0.0,0.0,0.0,0.0,0.06,seth selken,
-MATH,1010,9,Essen Math for Informed Soc,0.64,0.09,0.18,0.09,0.0,0.0,0.0,0.0,alexander joyce,
-MATH,1020,1,Business Calculus I,0.24,0.24,0.18,0.24,0.12,0.0,0.0,0.0,hannah grace rollins,
-MATH,1020,2,Business Calculus I,0.05,0.42,0.26,0.11,0.11,0.0,0.0,0.05,hannah grace rollins,
-MATH,1020,3,Business Calculus I,0.11,0.39,0.17,0.17,0.06,0.0,0.0,0.11,morgan elston,
-MATH,1020,4,Business Calculus I,0.06,0.39,0.28,0.28,0.0,0.0,0.0,0.0,morgan elston,
-MATH,1020,5,Business Calculus I,0.17,0.28,0.22,0.17,0.11,0.0,0.0,0.06,zachary ray johnston,
-MATH,1020,6,Business Calculus I,0.11,0.37,0.21,0.16,0.05,0.0,0.0,0.11,zachary ray johnston,
-MATH,1020,7,Business Calculus I,0.22,0.11,0.33,0.17,0.0,0.0,0.0,0.17,michael thomas cowen,
-MATH,1020,8,Business Calculus I,0.11,0.33,0.5,0.0,0.0,0.0,0.0,0.06,michael thomas cowen,
-MATH,1020,11,Business Calculus I,0.22,0.22,0.22,0.06,0.11,0.0,0.0,0.17,andrew pangia,
-MATH,1020,12,Business Calculus I,0.0,0.35,0.29,0.18,0.12,0.0,0.0,0.06,andrew gray pitman,
-MATH,1020,15,Business Calculus I,0.28,0.17,0.22,0.22,0.06,0.0,0.0,0.06,hemanta kunwar,
-MATH,1020,16,Business Calculus I,0.11,0.33,0.5,0.06,0.0,0.0,0.0,0.0,andrew gray pitman,
-MATH,1020,18,Business Calculus I,0.29,0.24,0.35,0.06,0.0,0.0,0.0,0.06,ebenezer eduafo,
-MATH,1020,19,Business Calculus I,0.28,0.39,0.11,0.06,0.11,0.0,0.0,0.06,andrew pangia,
-MATH,1020,20,Business Calculus I,0.12,0.29,0.12,0.18,0.24,0.0,0.0,0.06,michael gle eldredge,
-MATH,1020,21,Business Calculus I,0.22,0.22,0.33,0.06,0.17,0.0,0.0,0.0,hassan kiyadeh hami,
-MATH,1020,22,Business Calculus I,0.39,0.22,0.11,0.11,0.11,0.0,0.0,0.06,zachary david espe,
-MATH,1020,23,Business Calculus I,0.32,0.37,0.2,0.02,0.02,0.0,0.0,0.07,tony thanh nguyen,
-MATH,1020,24,Business Calculus I,0.39,0.28,0.17,0.11,0.0,0.0,0.0,0.06,zachary david espe,
-MATH,1020,25,Business Calculus I,0.24,0.47,0.12,0.06,0.06,0.0,0.0,0.06,nicholas john porter,
-MATH,1020,26,Business Calculus I,0.22,0.17,0.28,0.11,0.11,0.0,0.0,0.11,hemanta kunwar,
-MATH,1020,27,Business Calculus I,0.39,0.17,0.11,0.28,0.0,0.0,0.0,0.06,cameron arnold,
-MATH,1020,28,Business Calculus I,0.26,0.26,0.26,0.11,0.05,0.0,0.0,0.05,nicholas john porter,
-MATH,1020,29,Business Calculus I,0.25,0.2,0.28,0.05,0.13,0.0,0.0,0.1,marion hanna,
-MATH,1020,30,Business Calculus I,0.37,0.21,0.21,0.16,0.05,0.0,0.0,0.0,cameron arnold,
-MATH,1020,31,Business Calculus I,0.33,0.22,0.17,0.11,0.11,0.0,0.0,0.06,hassan kiyadeh hami,
-MATH,1020,33,Business Calculus I,0.17,0.17,0.28,0.11,0.17,0.0,0.0,0.11,michael gle eldredge,
-MATH,1020,34,Business Calculus I,0.24,0.34,0.22,0.1,0.07,0.0,0.0,0.02,marion hanna,
-MATH,1020,35,Business Calculus I,0.06,0.44,0.06,0.11,0.28,0.0,0.0,0.06,ebenezer eduafo,
-MATH,1020,38,Business Calculus I,0.29,0.29,0.21,0.14,0.02,0.0,0.0,0.05,tony thanh nguyen,
-MATH,1020,39,Business Calculus I,0.36,0.19,0.29,0.1,0.02,0.0,0.0,0.05,dyken jennifer  van e,
-MATH,1020,40,Business Calculus I,0.39,0.27,0.19,0.09,0.03,0.0,0.0,0.02,jennifer marie hanna,
-MATH,1020,41,Business Calculus I,0.47,0.23,0.18,0.08,0.01,0.0,0.0,0.03,jennifer marie hanna,
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.87,0.0,0.13,donna simms,
-MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.79,0.0,0.21,kristina gorsline,
-MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.68,0.0,0.32,aaron moose,
-MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,stephen peele,
-MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.8,0.0,0.2,emma cinatl,
-MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.87,0.0,0.13,tony thanh nguyen,
-MATH,1060,1,Calculus of One Variable I,0.21,0.19,0.21,0.07,0.17,0.0,0.0,0.14,timothy fran parrott,
-MATH,1060,2,Calculus of One Variable I,0.29,0.12,0.29,0.1,0.17,0.0,0.0,0.05,timothy fran parrott,
-MATH,1060,3,Calculus of One Variable I,0.23,0.2,0.25,0.07,0.16,0.0,0.0,0.09,timothy fran parrott,
-MATH,1060,4,Calculus of One Variable I,0.09,0.32,0.18,0.14,0.18,0.0,0.0,0.09,sofya alekseeva,
-MATH,1060,5,Calculus of One Variable I,0.19,0.16,0.19,0.26,0.09,0.0,0.0,0.12,sofya alekseeva,
-MATH,1060,6,Calculus of One Variable I,0.12,0.33,0.21,0.09,0.14,0.0,0.0,0.12,sofya alekseeva,
-MATH,1060,8,Calculus of One Variable I,0.36,0.25,0.14,0.06,0.09,0.0,0.0,0.1,judith el cottingham,
-MATH,1060,10,Calculus of One Variable I,0.24,0.27,0.23,0.05,0.14,0.0,0.0,0.07,judith el cottingham,
-MATH,1060,12,Calculus of One Variable I,0.32,0.27,0.16,0.07,0.16,0.0,0.0,0.02,hugh geller,
-MATH,1060,14,Calculus of One Variable I,0.13,0.28,0.16,0.03,0.22,0.0,0.0,0.19,valdez hiram lopez,
-MATH,1060,15,Calculus of One Variable I,0.27,0.16,0.25,0.16,0.11,0.0,0.0,0.05,blake antho splitter,
-MATH,1060,16,Calculus of One Variable I,0.33,0.19,0.23,0.07,0.09,0.0,0.0,0.09,stephen peele,
-MATH,1060,17,Calculus of One Variable I,0.15,0.24,0.12,0.15,0.22,0.0,0.0,0.12,valdez hiram lopez,
-MATH,1060,18,Calculus of One Variable I,0.17,0.37,0.14,0.09,0.09,0.0,0.0,0.14,marilyn reba,
-MATH,1060,19,Calculus of One Variable I,0.28,0.3,0.14,0.05,0.16,0.0,0.0,0.07,jason alexander kurz,
-MATH,1060,201,Calculus of One Variable I,0.44,0.33,0.12,0.05,0.05,0.0,0.0,0.02,camille zerfas,
-MATH,1060,202,Calculus of One Variable I,0.33,0.36,0.1,0.05,0.12,0.0,0.0,0.05,andrew walton green,
-MATH,1060,203,Calculus of One Variable I,0.31,0.31,0.23,0.03,0.06,0.0,0.0,0.06,charles lanning,
-MATH,1060,204,Calculus of One Variable I,0.31,0.31,0.22,0.02,0.09,0.0,0.0,0.04,scott scruggs,
-MATH,1060,205,Calculus of One Variable I,0.37,0.29,0.2,0.04,0.06,0.0,0.0,0.04,james edward gossell,
-MATH,1060,206,Calculus of One Variable I,0.2,0.24,0.37,0.0,0.17,0.0,0.0,0.02,catherine mar kenyon,
-MATH,1060,207,Calculus of One Variable I,0.24,0.33,0.12,0.07,0.14,0.0,0.0,0.1,rachel bass lanning,
-MATH,1060,208,Calculus of One Variable I,0.39,0.39,0.12,0.05,0.05,0.0,0.0,0.0,todd fenstermacher,
-MATH,1060,300,Calculus of One Variable I,0.32,0.16,0.29,0.16,0.03,0.0,0.0,0.03,matthew macauley,
-MATH,1070,1,Differen and Integral Calculus,0.08,0.35,0.38,0.08,0.12,0.0,0.0,0.0,donna simms,
-MATH,1080,1,Calculus of One Variable II,0.13,0.17,0.2,0.09,0.27,0.0,0.0,0.14,benjamin chris wiles,
-MATH,1080,2,Calculus of One Variable II,0.23,0.25,0.25,0.14,0.11,0.0,0.0,0.02,timothy cha teitloff,
-MATH,1080,3,Calculus of One Variable II,0.1,0.26,0.26,0.05,0.18,0.0,0.0,0.15,beth novick,
-MATH,1080,4,Calculus of One Variable II,0.14,0.23,0.25,0.09,0.2,0.0,0.0,0.09,timothy cha teitloff,
-MATH,1080,5,Calculus of One Variable II,0.28,0.23,0.3,0.02,0.12,0.0,0.0,0.05,timothy cha teitloff,
-MATH,1080,6,Calculus of One Variable II,0.27,0.22,0.2,0.07,0.1,0.0,0.0,0.15,meredith nicole burr,
-MATH,1080,7,Calculus of One Variable II,0.21,0.28,0.21,0.1,0.1,0.0,0.0,0.1,meredith nicole burr,
-MATH,1080,201,Calculus of One Variable II,0.34,0.14,0.23,0.09,0.11,0.0,0.0,0.09,fun choi john chan john,
-MATH,1150,1,Contemp Math for Elem Teach I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew mich tyminski,
-MATH,1150,2,Contemp Math for Elem Teach I,0.5,0.33,0.1,0.05,0.0,0.0,0.0,0.02,eliza darg gallagher,
-MATH,1160,1,Contemp Math for Elem Teach II,0.6,0.27,0.0,0.0,0.07,0.0,0.0,0.07,nicole alain sinwell,
-MATH,2060,1,Calculus of Several Variables,0.23,0.3,0.29,0.09,0.06,0.0,0.0,0.03,irina viktorova,
-MATH,2060,4,Calculus of Several Variables,0.18,0.2,0.22,0.18,0.13,0.0,0.0,0.1,oleg yordanov,
-MATH,2060,7,Calculus of Several Variables,0.3,0.36,0.17,0.04,0.1,0.0,0.0,0.02,irina viktorova,
-MATH,2060,10,Calculus of Several Variables,0.24,0.17,0.12,0.26,0.12,0.0,0.0,0.1,terri johnson,
-MATH,2060,11,Calculus of Several Variables,0.38,0.43,0.05,0.04,0.06,0.0,0.0,0.04,allen anderson guest,
-MATH,2060,12,Calculus of Several Variables,0.43,0.31,0.14,0.03,0.05,0.0,0.0,0.04,allen anderson guest,
-MATH,2060,14,Calculus of Several Variables,0.32,0.45,0.17,0.03,0.03,0.0,0.0,0.01,oleg yordanov,
-MATH,2060,15,Calculus of Several Variables,0.4,0.33,0.24,0.0,0.02,0.0,0.0,0.0,akshay sunil gupte,
-MATH,2060,19,Calculus of Several Variables,0.14,0.14,0.14,0.28,0.16,0.0,0.0,0.14,terri johnson,
-MATH,2060,20,Calculus of Several Variables,0.17,0.19,0.11,0.25,0.08,0.0,0.0,0.19,terri johnson,
-MATH,2060,100,Calc of Several Vars (HON),0.69,0.27,0.02,0.0,0.0,0.0,0.0,0.02,peter kiessler,True
-MATH,2060,201,Calculus of Several Variables,0.5,0.36,0.07,0.0,0.07,0.0,0.0,0.0,sanwar ahmad,
-MATH,2060,202,Calculus of Several Variables,0.24,0.31,0.22,0.02,0.04,0.0,0.0,0.16,martin johan schmoll,
-MATH,2070,1,Business Calculus II,0.12,0.35,0.12,0.06,0.35,0.0,0.0,0.0,haodong li,
-MATH,2070,2,Business Calculus II,0.0,0.44,0.39,0.06,0.11,0.0,0.0,0.0,haodong li,
-MATH,2070,3,Business Calculus II,0.0,0.33,0.17,0.22,0.11,0.0,0.0,0.17,thanh thien to,
-MATH,2070,4,Business Calculus II,0.11,0.33,0.22,0.22,0.11,0.0,0.0,0.0,todd anthony morra,
-MATH,2070,5,Business Calculus II,0.06,0.13,0.25,0.31,0.19,0.0,0.0,0.06,todd anthony morra,
-MATH,2070,6,Business Calculus II,0.27,0.07,0.33,0.13,0.07,0.0,0.0,0.13,ville madeleine  st e,
-MATH,2070,7,Business Calculus II,0.12,0.29,0.35,0.12,0.12,0.0,0.0,0.0,xiaoyuan liu,
-MATH,2070,8,Business Calculus II,0.17,0.39,0.28,0.06,0.06,0.0,0.0,0.06,xiaoyuan liu,
-MATH,2070,11,Business Calculus II,0.31,0.32,0.22,0.09,0.06,0.0,0.0,0.0,jennifer ray newton,
-MATH,2070,13,Business Calculus II,0.29,0.29,0.07,0.29,0.0,0.0,0.0,0.07,thanh thien to,
-MATH,2070,14,Business Calculus II,0.06,0.24,0.41,0.18,0.06,0.0,0.0,0.06,anna carol bachstein,
-MATH,2070,15,Business Calculus II,0.17,0.28,0.11,0.33,0.0,0.0,0.0,0.11,anna carol bachstein,
-MATH,2070,17,Business Calculus II,0.22,0.39,0.22,0.0,0.06,0.0,0.0,0.11,ville madeleine  st e,
-MATH,2070,18,Business Calculus II,0.33,0.18,0.28,0.14,0.05,0.0,0.0,0.02,jennifer ray newton,
-MATH,2070,19,Business Calculus II,0.18,0.24,0.18,0.12,0.12,0.0,0.0,0.18,thanh thien to,
-MATH,2070,20,Business Calculus II,0.0,0.21,0.07,0.14,0.36,0.0,0.0,0.21,todd anthony morra,
-MATH,2080,3,Intro to Ordin Diff Equations,0.13,0.28,0.41,0.05,0.07,0.0,0.0,0.07,pye phyo aung,
-MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.3,0.26,0.08,0.09,0.0,0.0,0.05,pye phyo aung,
-MATH,2080,5,Intro to Ordin Diff Equations,0.2,0.03,0.23,0.1,0.3,0.0,0.0,0.13,julie lassiter,
-MATH,2080,6,Intro to Ordin Diff Equations,0.14,0.23,0.26,0.14,0.14,0.0,0.0,0.09,julie lassiter,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.7,0.13,0.17,0.0,0.0,0.0,0.0,0.0,jeong rock yoon rock,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.39,0.39,0.17,0.02,0.02,0.0,0.0,0.0,allison kes stoddard,
-MATH,2160,2,Geometry for Elem Sch Teachers,0.7,0.2,0.0,0.05,0.0,0.0,0.0,0.05,allison kes stoddard,
-MATH,2500,1,Intro to Mathematical Sciences,0.95,0.04,0.01,0.0,0.0,0.0,0.0,0.0,mark cawood,
-MATH,3020,1,Stat for Science & Engineering,0.36,0.3,0.19,0.02,0.06,0.0,0.0,0.06,ellen hepfer breazel,
-MATH,3020,2,Stat for Science & Engineering,0.36,0.34,0.23,0.02,0.0,0.0,0.0,0.04,ellen hepfer breazel,
-MATH,3020,4,Stat for Science & Engineering,0.61,0.27,0.11,0.0,0.0,0.0,0.0,0.0,xin liu,
-MATH,3020,5,Stat for Science & Engineering,0.38,0.4,0.07,0.07,0.07,0.0,0.0,0.02,xiaoqian sun,
-MATH,3020,6,Stat for Science & Engineering,0.53,0.24,0.06,0.06,0.06,0.0,0.0,0.06, kamronnaher,
-MATH,3020,7,Stat for Science & Engineering,0.29,0.24,0.29,0.06,0.06,0.0,0.0,0.06, kamronnaher,
-MATH,3020,9,Stat for Science & Engineering,0.61,0.22,0.06,0.0,0.11,0.0,0.0,0.0,merenchig jayasekara,
-MATH,3020,10,Stat for Science & Engineering,0.29,0.29,0.14,0.0,0.14,0.0,0.0,0.14,merenchig jayasekara,
-MATH,3110,3,Linear Algebra,0.36,0.43,0.17,0.02,0.0,0.0,0.0,0.02,wayne goddard,
-MATH,3110,4,Linear Algebra,0.24,0.31,0.26,0.07,0.12,0.0,0.0,0.0,hui xue,
-MATH,3110,5,Linear Algebra,0.21,0.21,0.19,0.12,0.16,0.0,0.0,0.12,felice manganiello,
-MATH,3110,6,Linear Algebra,0.27,0.3,0.14,0.09,0.05,0.0,0.0,0.16,felice manganiello,
-MATH,3110,7,Linear Algebra,0.23,0.31,0.1,0.05,0.03,0.0,0.0,0.28,xuhong gao,
-MATH,3110,8,Linear Algebra,0.45,0.24,0.08,0.0,0.11,0.0,0.0,0.13,xuhong gao,
-MATH,3110,9,Linear Algebra,0.22,0.33,0.28,0.03,0.11,0.0,0.0,0.03,vincent ervin,
-MATH,3110,100,Linear Algebra (HON),0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,beth novick,True
-MATH,3110,200,Linear Algebra,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,beth novick,
-MATH,3190,1,Introduction to Proof,0.28,0.12,0.24,0.16,0.12,0.0,0.0,0.08,elena stan dimitrova,
-MATH,3190,2,Introduction to Proof,0.44,0.2,0.16,0.04,0.08,0.0,0.0,0.08,elena stan dimitrova,
-MATH,3600,2,Intermediate Math Computing,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,mark cawood,
-MATH,3650,1,Numerical Mthds for Engineers,0.14,0.42,0.32,0.04,0.04,0.0,0.0,0.04,eleanor jenkins,
-MATH,3650,2,Numerical Mthds for Engineers,0.23,0.23,0.4,0.09,0.02,0.0,0.0,0.02,hyesuk lee,
-MATH,3650,3,Numerical Mthds for Engineers,0.26,0.33,0.24,0.05,0.07,0.0,0.0,0.05,hyesuk lee,
-MATH,4000,1,Theory of Probability,0.3,0.22,0.3,0.04,0.0,0.0,0.0,0.15,brian fralix,
-MATH,4000,2,Theory of Probability,0.29,0.26,0.29,0.06,0.09,0.0,0.0,0.03,derek brown,
-MATH,4020,1,Stat for Sci & Engineering II,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,colin gallagher,
-MATH,4070,1,Regress & Time-Series Analysis,0.47,0.4,0.0,0.0,0.0,0.0,0.0,0.13,colin gallagher,
-MATH,4120,2,Algebra I,0.24,0.52,0.2,0.04,0.0,0.0,0.0,0.0,hui xue,
-MATH,4190,1,Discrete Math Structures I,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,wayne goddard,
-MATH,4190,2,Discrete Math Structures I,0.48,0.3,0.07,0.0,0.11,0.0,0.0,0.04,beth novick,
-MATH,4340,1,Adv Engineering Mathematics,0.4,0.15,0.15,0.0,0.05,0.0,0.0,0.25,eleanor jenkins,
-MATH,4340,2,Adv Engineering Mathematics,0.33,0.33,0.11,0.11,0.06,0.0,0.0,0.06,qingshan chen,
-MATH,4350,1,Complex Variables,0.67,0.08,0.08,0.08,0.0,0.0,0.0,0.08,shitao liu,
-MATH,4400,1,Linear Programming,0.57,0.13,0.09,0.09,0.04,0.0,0.0,0.09,yuyuan ouyang,
-MATH,4530,1,Advanced Calculus I,0.48,0.22,0.19,0.0,0.07,0.0,0.0,0.04,james peterson,
-MATH,4540,1,Advanced Calculus II,0.46,0.08,0.46,0.0,0.0,0.0,0.0,0.0,james peterson,
-MATH,4560,1,Topology,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,james bar coykendall,
-MATH,4630,1,Mathematical Analysis I,0.54,0.23,0.08,0.0,0.0,0.0,0.0,0.15,benjamin jaye,
-MATH,4910,2,Mathematics of Option Pricing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,mark cawood,
-MATH,6000,1,Theory of Probability,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,brian fralix,
-MATH,6340,1,Adv Engineering Mathematics,0.43,0.37,0.1,0.0,0.07,0.0,0.0,0.03,vincent ervin,
-MATH,8000,1,Probability,0.53,0.2,0.07,0.0,0.0,0.0,0.0,0.2,robert lund,
-MATH,8010,1,General Linear Hypothesis I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,derek brown,
-MATH,8050,1,Data Analysis,0.44,0.22,0.11,0.0,0.11,0.0,0.0,0.11,xiaoqian sun,
-MATH,8100,1,Mathematical Programming,0.5,0.32,0.18,0.0,0.0,0.0,0.0,0.0,boshi yang,
-MATH,8100,2,Mathematical Programming,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,yuyuan ouyang,
-MATH,8140,1,Network Flow Programming,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
-MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
-MATH,8210,1,Linear Analysis,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,benjamin jaye,
-MATH,8250,1,Intro to Dynamical Syst Theory,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,martin johan schmoll,
-MATH,8530,1,Matrix Analysis,0.44,0.25,0.19,0.0,0.06,0.0,0.0,0.06,sean sather-wagstaff,
-MATH,8600,1,Intro to Scientific Computing,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,fei xue,
-MATH,8610,1,Advanced Numerical Analysis I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,qingshan chen,
-MATH,8650,1,Data Structures,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,matthew saltzman,
-MATH,8820,1,Intro to Bayesian Statistics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,
-MBA,8030,1,Stat Analy of Bus Op,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett wood,
-MBA,8030,2,Stat Analy of Bus Op,0.51,0.46,0.0,0.0,0.03,0.0,0.0,0.0,william ed kilbourne,
-MBA,8040,20,Busin Data An & Stat Computing,0.62,0.35,0.0,0.0,0.0,0.0,0.0,0.03,william ed kilbourne,
-MBA,8060,1,Operations Mgt,0.24,0.56,0.2,0.0,0.0,0.0,0.0,0.0, sridharan,
-MBA,8060,2,Operations Mgt,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,george kennet morgan,
-MBA,8070,1,Financial Management,0.67,0.28,0.03,0.0,0.0,0.0,0.0,0.03,george bran lockhart,
-MBA,8070,2,Financial Management,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,george bran lockhart,
-MBA,8090,1,Org Beh & Hum Res Mg,0.43,0.55,0.02,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,
-MBA,8090,2,Org Beh & Hum Res Mg,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,thomas jos zagenczyk,
-MBA,8180,20,Intro Business Intell & Anlytc,0.79,0.15,0.03,0.0,0.0,0.0,0.0,0.03,heshan sun,
-MBA,8190,1,Intro to Acc and Fin,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,
-MBA,8190,2,Intro to Acc and Fin,0.45,0.37,0.03,0.0,0.05,0.0,0.0,0.11,jeffrey mcmillan,
-MBA,8290,1,Marketing Foundation,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MBA,8310,10,Communications and Sales,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,
-MBA,8370,1,Legal Environ of Bus,0.42,0.45,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8370,2,Legal Environ of Bus,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
-MBA,8430,1,Entrepreneurial Accounting,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,annieka philo,
-MBA,8440,1,Entrepreneurial Law,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8450,1,Technology & Innovation Mgt,0.72,0.2,0.04,0.0,0.0,0.0,0.0,0.04,michael george mino,
-MBA,8480,5,Entrpr Mkting & Digital Strat,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,bruce snyder,
-MBA,8490,5,Entrepreneurial Strategy,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,matthew charle klein,
-MBA,8510,1,Bus Operations & Logistics,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0, sridharan,
-MBA,8540,1,Managerial Accounting,0.35,0.58,0.05,0.0,0.0,0.0,0.0,0.03,emily suzan mccorkle,
-MBA,8590,1,Mgr Decision Model,0.23,0.27,0.15,0.0,0.27,0.0,0.0,0.08,sara elizabeth yoder,
-MBA,8590,2,Mgr Decision Model,0.45,0.37,0.18,0.0,0.0,0.0,0.0,0.0,magda gabriela sava,
-MBA,8590,3,Mgr Decision Model,0.08,0.54,0.31,0.0,0.08,0.0,0.0,0.0,magda gabriela sava,
-MBA,8600,1,Advanced Marketing Strategy,0.35,0.38,0.25,0.0,0.0,0.0,0.0,0.03,michael dorsch,
-MBA,8600,2,Advanced Marketing Strategy,0.21,0.56,0.23,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8610,2,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,kevin mckenzie,
-MBA,8620,1,Managerial Economics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,
-MBA,8620,2,Managerial Economics,0.62,0.34,0.0,0.0,0.0,0.0,0.0,0.03,ronald earle gregory,
-MBA,8620,4,Managerial Economics,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,
-MBA,8650,1,Taxation of Business Decisions,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8660,21,"Data, Storage, Business Decis",0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
-MBA,8700,1,Strategic Management,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,james turner,
-MBA,8990,2,Creativity,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,
-ME,2000,1,Sophomore Seminar,0.87,0.04,0.02,0.01,0.01,0.0,0.0,0.05,todd al schweisinger,
-ME,2000,2,Sophomore Seminar,0.83,0.07,0.04,0.02,0.0,0.0,0.0,0.05,todd al schweisinger,
-ME,2010,1,Statics & Dynamics,0.12,0.2,0.29,0.08,0.19,0.0,0.0,0.11,marisa kikendall orr,
-ME,2010,2,Statics & Dynamics,0.11,0.23,0.25,0.07,0.27,0.0,0.0,0.06,paul joseph,
-ME,2010,4,Statics & Dynamics,0.04,0.17,0.23,0.13,0.29,0.0,0.0,0.13,lonny thompson,
-ME,2030,1,Founda Th/Fl Syst,0.0,0.08,0.42,0.17,0.1,0.0,0.0,0.23,john saylor,
-ME,2220,2,Mechanical Engineering Lab I,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,
-ME,2220,3,Mechanical Engineering Lab I,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,5,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,6,Mechanical Engineering Lab I,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,7,Mechanical Engineering Lab I,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,todd al schweisinger,
-ME,2220,8,Mechanical Engineering Lab I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,13,Mechanical Engineering Lab I,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,15,Mechanical Engineering Lab I,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,
-ME,2220,16,Mechanical Engineering Lab I,0.25,0.42,0.25,0.0,0.08,0.0,0.0,0.0,todd al schweisinger,
-ME,3030,1,Thermodynamics,0.3,0.45,0.16,0.02,0.06,0.0,0.0,0.01,yiqiang han,
-ME,3030,2,Thermodynamics,0.3,0.37,0.22,0.08,0.0,0.0,0.0,0.03,yiqiang han,
-ME,3050,1,Model/an Dy Syst,0.19,0.26,0.4,0.05,0.07,0.0,0.0,0.02,joshua bostwick,
-ME,3050,2,Model/an Dy Syst,0.31,0.31,0.2,0.11,0.04,0.0,0.0,0.02,ardalan vahidi,
-ME,3060,1,Fund Machine Design,0.3,0.55,0.09,0.0,0.0,0.0,0.0,0.06,oliver myers,
-ME,3060,2,Fund Machine Design,0.24,0.52,0.22,0.02,0.0,0.0,0.0,0.0,james allen righter,
-ME,3070,1,Found of Mechanical Systems,0.23,0.49,0.2,0.04,0.03,0.0,0.0,0.01,jorge ivan rodriguez,
-ME,3070,2,Found of Mechanical Systems,0.43,0.38,0.14,0.02,0.0,0.0,0.0,0.03,jorge ivan rodriguez,
-ME,3080,1,Fluid Mechanics,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,
-ME,3080,2,Fluid Mechanics,0.28,0.3,0.3,0.04,0.04,0.0,0.0,0.02,yiqiang han,
-ME,3080,3,Fluid Mechanics,0.06,0.44,0.41,0.05,0.03,0.0,0.0,0.01,ethan kung,
-ME,3120,1,Manuf Processes,0.83,0.15,0.01,0.0,0.01,0.0,0.0,0.0,rodr martinez-duarte,
-ME,3330,1,Mechanical Engineering Lab II,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,
-ME,3330,2,Mechanical Engineering Lab II,0.25,0.44,0.25,0.06,0.0,0.0,0.0,0.0,james allen righter,
-ME,3330,3,Mechanical Engineering Lab II,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,
-ME,3330,6,Mechanical Engineering Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,
-ME,3330,7,Mechanical Engineering Lab II,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,james allen righter,
-ME,3330,8,Mechanical Engineering Lab II,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,james allen righter,
-ME,3330,9,Mechanical Engineering Lab II,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,james allen righter,
-ME,3330,10,Mechanical Engineering Lab II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,james allen righter,
-ME,4010,1,Mech Engr Design,0.3,0.59,0.08,0.0,0.0,0.0,0.0,0.03,joshua summers,
-ME,4010,2,Mech Engr Design,0.29,0.59,0.11,0.0,0.02,0.0,0.0,0.0,joshua summers,
-ME,4010,3,Mech Engr Design,0.26,0.59,0.1,0.02,0.03,0.0,0.0,0.0,joshua summers,
-ME,4020,1,Intern in Engr Des,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,cameron turner,
-ME,4020,3,Intern in Engr Des,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,4,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lonny thompson,
-ME,4030,2,Control Dynamic Systems,0.34,0.36,0.26,0.01,0.01,0.0,0.0,0.01,suyi li,
-ME,4210,1,Intro to Comp Flow,0.33,0.43,0.19,0.05,0.0,0.0,0.0,0.0,chenning tong,
-ME,4290,1,Ther Env Control,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,
-ME,4400,1,Matls for Aggr Envir,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,garrett pataky,
-ME,4440,6,Mechanical Engineering Lab III,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4540,1,Design of Machine Elements,0.24,0.62,0.1,0.0,0.05,0.0,0.0,0.0,hong seok choi,
-ME,4930,14,Sel.Topics ME - NonLinDy&Chas,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,
-ME,4930,39,Sel.Topics ME - Aero Propul,0.47,0.45,0.09,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,6540,1,Des Machine Elements,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-ME,6540,843,Des Machine Elements,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-ME,6930,14,Sel.Topics ME - NonLinDy&Chas,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,
-ME,8010,1,Found of Fluid Mech,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,richard figliola,
-ME,8100,1,Macroscopic Thermo,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,
-ME,8180,1,Intro to Fin Ele Ana,0.44,0.49,0.05,0.0,0.0,0.0,0.0,0.02,gang li,
-ME,8230,1,Control Systems,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,
-ME,8360,1,Fracture Mech,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,8460,1,Inter Dynamics,0.56,0.11,0.33,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,
-ME,8710,1,Engr Optimization,0.47,0.35,0.06,0.0,0.06,0.0,0.0,0.06,georges fadel,
-ME,8930,9,Sel Topics - Continuum Mech.,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,gang li,
-ME,8930,27,SelTopics ME - OptimalControls,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
-ME,8930,37,SelTopics ME - Laser Based Mfg,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,xin zhao,
-MGT,2010,1,Principles of Management,0.38,0.43,0.17,0.02,0.01,0.0,0.0,0.0,katherine clark,
-MGT,2010,2,Principles of Management,0.56,0.34,0.08,0.01,0.01,0.0,0.0,0.01,tina robbins,
-MGT,2010,8,Principles of Management,0.33,0.45,0.23,0.0,0.0,0.0,0.0,0.0,christopher mann,
-MGT,2010,9,Principles of Management,0.3,0.5,0.15,0.03,0.03,0.0,0.0,0.0,christopher mann,
-MGT,2010,10,Principles of Management,0.25,0.39,0.34,0.0,0.0,0.0,0.0,0.02,ashley willi parnell,
-MGT,2010,11,Principles of Management,0.16,0.32,0.32,0.11,0.02,0.0,0.0,0.07,ashley willi parnell,
-MGT,2180,1,Management PC Applications,0.47,0.38,0.08,0.03,0.02,0.0,0.0,0.02,ryan toole,
-MGT,2180,2,Management PC Applications,0.2,0.56,0.16,0.08,0.0,0.0,0.0,0.0,ryan toole,
-MGT,3070,1,Human Resource Management,0.38,0.48,0.15,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
-MGT,3070,3,Human Resource Management,0.45,0.45,0.08,0.0,0.03,0.0,0.0,0.0,kristin dama scott dama,
-MGT,3070,4,Human Resource Management,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,5,Human Resource Management,0.33,0.46,0.21,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
-MGT,3070,6,Human Resource Management,0.6,0.33,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,7,Human Resource Management,0.28,0.55,0.15,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,
-MGT,3070,8,Human Resource Management,0.42,0.33,0.15,0.06,0.0,0.0,0.0,0.03,priscilla harrison,
-MGT,3100,1,Intermed Business Statistics,0.07,0.39,0.34,0.08,0.03,0.0,0.0,0.08,janis miller,
-MGT,3100,2,Intermed Business Statistics,0.37,0.4,0.2,0.03,0.0,0.0,0.0,0.0,mustafa serka akturk,
-MGT,3100,3,Intermed Business Statistics,0.35,0.3,0.13,0.05,0.08,0.0,0.0,0.1,daniel nielubowicz,
-MGT,3100,5,Intermed Business Statistics,0.3,0.38,0.23,0.0,0.03,0.0,0.0,0.08,mustafa serka akturk,
-MGT,3100,6,Intermed Business Statistics,0.2,0.46,0.2,0.02,0.07,0.0,0.0,0.07,magda gabriela sava,
-MGT,3100,7,Intermed Business Statistics,0.36,0.19,0.17,0.06,0.17,0.0,0.0,0.06,daniel nielubowicz,
-MGT,3100,8,Intermed Business Statistics,0.31,0.24,0.21,0.05,0.07,0.0,0.0,0.12,iaroslava vo dutchak,
-MGT,3100,9,Intermed Business Statistics,0.69,0.24,0.05,0.0,0.02,0.0,0.0,0.0,maneeshred ajjuguttu,
-MGT,3100,10,Intermed Business Statistics,0.56,0.25,0.13,0.03,0.0,0.0,0.0,0.03,jeromy blake snider,
-MGT,3100,12,Intermed Business Statistics,0.3,0.19,0.24,0.08,0.08,0.0,0.0,0.11,daniel allan detoma,
-MGT,3120,1,Decision Models for Management,0.22,0.21,0.27,0.08,0.08,0.0,0.0,0.14,sara elizabeth yoder,
-MGT,3120,2,Decision Models for Management,0.19,0.31,0.34,0.02,0.1,0.0,0.0,0.05,sara elizabeth yoder,
-MGT,3120,4,Decision Models for Management,0.29,0.37,0.26,0.0,0.05,0.0,0.0,0.03,james turner,
-MGT,3180,1,Mgt of Info Systems,0.86,0.09,0.02,0.02,0.0,0.0,0.0,0.0,shih lun tseng,
-MGT,3180,2,Mgt of Info Systems,0.28,0.33,0.3,0.05,0.0,0.0,0.0,0.05,marten risius,
-MGT,3180,3,Mgt of Info Systems,0.87,0.12,0.02,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,
-MGT,3180,4,Mgt of Info Systems,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,daniel aaron pienta,
-MGT,3180,5,Mgt of Info Systems,0.4,0.35,0.23,0.0,0.0,0.0,0.0,0.03,wenxi pu,
-MGT,3900,1,Operations Management,0.15,0.5,0.28,0.05,0.03,0.0,0.0,0.0,yann ferrand,
-MGT,3900,2,Operations Management,0.08,0.5,0.38,0.03,0.0,0.0,0.0,0.03,zachary mor leffakis,
-MGT,3900,4,Operations Management,0.12,0.33,0.26,0.08,0.06,0.0,0.0,0.15, sridharan,
-MGT,4000,1,Mgt of Organizational Behavior,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,2,Mgt of Organizational Behavior,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,3,Mgt of Organizational Behavior,0.25,0.35,0.38,0.0,0.0,0.0,0.0,0.03,thomas jos zagenczyk,
-MGT,4000,4,Mgt of Organizational Behavior,0.15,0.46,0.28,0.03,0.0,0.0,0.0,0.08,philip roth,
-MGT,4020,1,Ops Pln and Ctl,0.06,0.33,0.56,0.06,0.0,0.0,0.0,0.0,zachary mor leffakis,
-MGT,4080,1,Lean Operations,0.14,0.5,0.27,0.05,0.05,0.0,0.0,0.0,zachary mor leffakis,
-MGT,4110,1,Project Management,0.23,0.6,0.13,0.0,0.0,0.0,0.0,0.05,russell purvis,
-MGT,4120,1,Supplier Management,0.42,0.53,0.03,0.0,0.03,0.0,0.0,0.0,ahmet colak,
-MGT,4150,1,Business Strategy,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,2,Business Strategy,0.16,0.44,0.33,0.02,0.0,0.0,0.0,0.04,james liddle,
-MGT,4150,3,Business Strategy,0.12,0.64,0.21,0.02,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,4,Business Strategy,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
-MGT,4150,6,Business Strategy,0.11,0.37,0.45,0.05,0.0,0.0,0.0,0.03,james liddle,
-MGT,4150,9,Business Strategy,0.36,0.52,0.11,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
-MGT,4160,1,Special Topics Hr,0.34,0.42,0.18,0.05,0.0,0.0,0.0,0.0,kristin dama scott dama,
-MGT,4230,1,Intern Bus Mgt,0.07,0.33,0.55,0.0,0.02,0.0,0.0,0.02,wayne stewart,
-MGT,4230,2,Intern Bus Mgt,0.2,0.15,0.57,0.07,0.02,0.0,0.0,0.0,wayne stewart,
-MGT,4230,3,Intern Bus Mgt,0.05,0.53,0.38,0.03,0.0,0.0,0.0,0.03,janis miller,
-MGT,4230,4,Intern Bus Mgt,0.09,0.59,0.25,0.07,0.0,0.0,0.0,0.0,janis miller,
-MGT,4240,1,Global Supply Chain,0.32,0.44,0.24,0.0,0.0,0.0,0.0,0.0,yann ferrand,
-MGT,4270,2,Managing Improvement,0.25,0.35,0.35,0.0,0.05,0.0,0.0,0.0,lawrence fredendall,
-MGT,4310,1,Emp Rights & Resp,0.44,0.49,0.08,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
-MGT,4350,1,Pers Interviewing,0.34,0.39,0.16,0.11,0.0,0.0,0.0,0.0,philip roth,
-MGT,4520,1,Business Analysis,0.21,0.36,0.27,0.03,0.03,0.0,0.0,0.09,marten risius,
-MGT,8690,1,Project Mgt,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
-MICR,2050,1,Introductory Micro,0.38,0.43,0.19,0.01,0.0,0.0,0.0,0.0,john abercrombie,
-MICR,3050,1,General Microbiology,0.29,0.42,0.24,0.03,0.01,0.0,0.0,0.02,krista barri rudolph,
-MICR,3050,2,General Microbiology,0.52,0.37,0.09,0.02,0.0,0.0,0.0,0.0,krista barri rudolph,
-MICR,4010,1,Microbial Diversity & Ecology,0.19,0.34,0.33,0.08,0.02,0.0,0.0,0.05,barbara campbell,
-MICR,4050,1,Adv Microbial Ecol of Humans,0.5,0.26,0.16,0.09,0.0,0.0,0.0,0.0,kristi jam whitehead,
-MICR,4140,1,Basic Immunology,0.46,0.28,0.15,0.09,0.0,0.0,0.0,0.02,yanzhang wei,
-MICR,4150,1,Microbial Genetics,0.2,0.49,0.22,0.09,0.0,0.0,0.0,0.0,min cao,
-MICR,4160,1,Intro Virology,0.69,0.2,0.09,0.0,0.01,0.0,0.0,0.01,kristi jam whitehead,
-MICR,4510,1,Advanced Microbiology II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4510,2,Advanced Microbiology II,0.45,0.5,0.0,0.0,0.05,0.0,0.0,0.0,harry kurtz,
-MICR,4510,3,Advanced Microbiology II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4560,1,Medical and Vet Parasitology,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kears milhous,
-MICR,4940,11,CI: Microbes All Around Us,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,kristi jam whitehead,
-MKT,3010,1,Principles of Marketing,0.19,0.4,0.27,0.1,0.02,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,2,Principles of Marketing,0.32,0.34,0.21,0.09,0.02,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,3,Principles of Marketing,0.33,0.33,0.26,0.05,0.02,0.0,0.0,0.01,amanda cooper fine,
-MKT,3010,4,Principles of Marketing,0.27,0.41,0.24,0.05,0.03,0.0,0.0,0.0,carter will mcelveen,
-MKT,3010,5,Principles of Marketing,0.36,0.34,0.22,0.06,0.02,0.0,0.0,0.01,carter will mcelveen,
-MKT,3010,7,Principles of Marketing,0.27,0.41,0.23,0.01,0.01,0.0,0.0,0.07,james gaubert,
-MKT,3020,1,Consumer Behavior,0.37,0.46,0.15,0.02,0.0,0.0,0.0,0.0,jennifer dia siemens,
-MKT,3020,2,Consumer Behavior,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,jennifer dia siemens,
-MKT,3020,3,Consumer Behavior,0.51,0.38,0.09,0.0,0.0,0.0,0.0,0.02,anastasia el thyroff,
-MKT,3020,4,Consumer Behavior,0.37,0.51,0.12,0.0,0.0,0.0,0.0,0.0,anastasia el thyroff,
-MKT,3020,5,Consumer Behavior,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,3210,1,Sports Marketing,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,
-MKT,3210,2,Sports Marketing,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,
-MKT,3220,1,Social Media Marketing,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,3220,2,Social Media Marketing,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,3220,3,Social Media Marketing,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,michele melto cauley,
-MKT,3220,4,Social Media Marketing,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michele melto cauley,
-MKT,3310,1,Marketing Metrics & Analytics,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,oriana rachel aragon,
-MKT,3310,2,Marketing Metrics & Analytics,0.67,0.28,0.03,0.0,0.03,0.0,0.0,0.0,oriana rachel aragon,
-MKT,3310,3,Marketing Metrics & Analytics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,3310,4,Marketing Metrics & Analytics,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4200,1,Professional Selling,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,2,Professional Selling,0.71,0.23,0.06,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4200,3,Professional Selling,0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4200,5,Professional Selling,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,carter will mcelveen,
-MKT,4230,1,Promotional Strategy,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,4230,2,Promotional Strategy,0.77,0.16,0.03,0.03,0.0,0.0,0.0,0.0,michele melto cauley,
-MKT,4230,3,Promotional Strategy,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,michele melto cauley,
-MKT,4240,1,Sales Management,0.32,0.62,0.06,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4270,1,International Marketing,0.51,0.46,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4270,2,International Marketing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4270,3,International Marketing,0.26,0.6,0.12,0.0,0.0,0.0,0.0,0.02,thomas poehlman,
-MKT,4270,4,International Marketing,0.58,0.3,0.1,0.01,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,4280,1,Services Marketing,0.38,0.49,0.14,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4280,2,Services Marketing,0.41,0.46,0.14,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4310,3,Marketing Research,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,4,Marketing Research,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4450,1,Macromarketing,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,
-MKT,4500,3,Strategic Mktg Mgt,0.25,0.5,0.21,0.04,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,8610,1,Marketing Research,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,
-MKT,8630,1,Buyer Behavior,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
-ML,2010,1,Leadership Development I,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,2010,2,Leadership Development I,0.76,0.12,0.0,0.06,0.06,0.0,0.0,0.0,vincent john presto,
-ML,2010,3,Leadership Development I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,3010,1,Advanced Leadership I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william cody cleland,
-ML,3010,2,Advanced Leadership I,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,william cody cleland,
-MSE,2100,1,Intro to Materials Science,0.34,0.27,0.16,0.12,0.04,0.0,0.0,0.07,rakhee pani,
-MSE,2100,2,Intro to Materials Science,0.07,0.29,0.37,0.13,0.06,0.0,0.0,0.07,kai he,
-MSE,2100,3,Intro to Materials Science,0.24,0.37,0.25,0.06,0.04,0.0,0.0,0.04,kyle brinkman,
-MSE,2100,4,Intro to Materials Science,0.27,0.33,0.23,0.09,0.04,0.0,0.0,0.04,marian kennedy,
-MSE,2100,5,Introduction to Materials Sci,0.41,0.29,0.09,0.18,0.0,0.0,0.0,0.03,olga kuksenok,
-MSE,3010,4,Materials Synthesis & Fabr Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
-MSE,3190,1,Materials Proc I,0.35,0.55,0.09,0.0,0.0,0.0,0.0,0.01,rajendra kuma bordia,
-MSE,3190,2,Materials Proc I,0.2,0.47,0.2,0.13,0.0,0.0,0.0,0.0,rajendra kuma bordia,
-MSE,3260,1,Thermo of Materials,0.23,0.37,0.26,0.09,0.03,0.0,0.0,0.03,fei peng,
-MSE,3260,2,Thermo of Materials,0.18,0.47,0.18,0.13,0.0,0.0,0.0,0.03,fei peng,
-MSE,3270,1,Transport Phenomena,0.38,0.23,0.23,0.08,0.08,0.0,0.0,0.0,ulf daniel schiller,
-MSE,4020,1,Solid State Material,0.45,0.14,0.3,0.07,0.02,0.0,0.0,0.02,luiz gusta jacobsohn,
-MSE,4130,1,Noncrystalline Materials,0.54,0.38,0.0,0.04,0.04,0.0,0.0,0.0,jianhua tong,
-MSE,4150,1,Polymer Sc Engr,0.42,0.33,0.18,0.06,0.0,0.0,0.0,0.0,igor luzinov,
-MSE,4150,2,Polymer Sc Engr,0.5,0.19,0.24,0.02,0.02,0.0,0.0,0.04,rakhee pani,
-MSE,4320,1,Manuf Proc & Systems,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
-MSE,4580,1,Surf Phen in Ms&E,0.25,0.17,0.33,0.08,0.13,0.0,0.0,0.04,konstantin ge kornev,
-MSE,4610,1,Polymer & Fiber Materials III,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,philip brown,
-MSE,4810,1,Undergraduate Research Fundame,0.64,0.22,0.11,0.02,0.0,0.0,0.0,0.0,marian kennedy,
-MSE,4910,1,Undergraduate Research,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kuma bordia,
-MSE,8100,1,Fundamentals of Materials Sci,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,igor luzinov,
-MSE,8260,1,Phase Equil Mat Sys,0.43,0.5,0.0,0.0,0.07,0.0,0.0,0.0,stephen foulger,
-MSE,8270,1,Kin of Phase Tran,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,konstantin ge kornev,
-MUSC,1420,1,Music Theory I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david conley,
-MUSC,1430,1,Aural Skills I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david conley,
-MUSC,1510,2,Applied Music,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,jonathan edwar doyel,
-MUSC,2100,2,Music in the Western World,0.53,0.41,0.03,0.0,0.0,0.0,0.0,0.03,lisa sain odom,
-MUSC,2100,4,Music in the Western World,0.58,0.1,0.13,0.06,0.0,0.0,0.0,0.13,linda li-bleuel,
-MUSC,2100,6,Music in the Western World,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,7,Music in the Western World,0.33,0.47,0.17,0.0,0.03,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,8,Music in the Western World,0.44,0.48,0.04,0.0,0.0,0.0,0.0,0.04,rhea beth jacobus,
-MUSC,2100,12,Music in the Western World,0.72,0.19,0.0,0.0,0.03,0.0,0.0,0.06,lea kibler,
-MUSC,3110,1,History of American Music,0.65,0.26,0.03,0.03,0.03,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.75,0.18,0.04,0.04,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,3170,1,Hist of Country Mus,0.72,0.19,0.0,0.03,0.03,0.0,0.0,0.03,ned hosler,
-MUSC,3180,1,Hist of Audio Tech,0.42,0.37,0.11,0.05,0.05,0.0,0.0,0.0,bruce allen whisler,
-MUSC,3610,1,Marching Band,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
-MUSC,3980,1,Special Topics,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,hamilton altstatt,
-MUSC,4150,1,Music Hist to 1750,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,linda dzuris,
-NPL,3000,1,Nonprofit Leadership,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,christina mari mazer,
-NPL,3000,2,Nonprofit Leadership,0.33,0.61,0.0,0.0,0.06,0.0,0.0,0.0,bonnie westb stevens,
-NPL,3000,3,Nonprofit Leadership,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,christina mari mazer,
-NPL,3000,4,Nonprofit Leadership,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,corey doug brookover,
-NPL,3000,5,Nonprofit Leadership,0.55,0.2,0.2,0.0,0.05,0.0,0.0,0.0,corey doug brookover,
-NPL,3000,6,Nonprofit Leadership,0.45,0.45,0.05,0.0,0.05,0.0,0.0,0.0,corey doug brookover,
-NPL,3000,7,Nonprofit Leadership,0.3,0.5,0.05,0.05,0.0,0.0,0.0,0.1,bonnie westb stevens,
-NPL,3000,8,Nonprofit Leadership,0.58,0.29,0.08,0.0,0.04,0.0,0.0,0.0,christina mari mazer,
-NPL,3000,9,Nonprofit Leadership,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,christina mari mazer,
-NPL,3010,1,NPL Stakeholders,0.5,0.33,0.06,0.0,0.11,0.0,0.0,0.0,christina mari mazer,
-NPL,3020,1,NPL Fundraising,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,robert brookover,
-NPL,3030,1,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,corey doug brookover,
-NPL,3040,1,NPL Risk Management,0.7,0.1,0.0,0.15,0.05,0.0,0.0,0.0,daniel morg anderson,
-NPL,3050,2,Strat Social Media for NP Org,0.44,0.22,0.19,0.0,0.11,0.0,0.0,0.04,amanda elizabe moore,
-NURS,3030,1,Nursing of Adults,0.42,0.56,0.02,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3040,1,Pathophysiology,0.45,0.35,0.15,0.02,0.03,0.0,0.0,0.0,catherine sik murton,
-NURS,3040,2,Pathophysiology,0.36,0.55,0.05,0.04,0.0,0.0,0.0,0.0,amy boggs garrison,
-NURS,3040,400,Pathophysiology,0.44,0.52,0.0,0.04,0.0,0.0,0.0,0.0,amy boggs garrison,
-NURS,3040,401,Pathophysiology,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,elizabeth cam hassen,
-NURS,3050,1,Psychosocial Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
-NURS,3100,400,Health Assessment,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,
-NURS,3120,1,Foundations of Nursing,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,
-NURS,3120,2,Foundations of Nursing,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,
-NURS,3120,400,Foundations of Nursing,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,
-NURS,3200,1,Prof in Nurs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3300,1,Research in Nursing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,3330,400,Health Care Genetics,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,
-NURS,3400,1,Pharmther Nursing,0.45,0.35,0.12,0.05,0.03,0.0,0.0,0.0,catherine sik murton,
-NURS,3400,2,Pharmther Nursing,0.39,0.46,0.11,0.04,0.0,0.0,0.0,0.0,jenna lynn seawright,
-NURS,3400,400,Pharmther Nursing,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jenna lynn seawright,
-NURS,3600,400,Social Determinants in Health,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
-NURS,4010,1,Mental Health Nurs,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,
-NURS,4060,400,Issues in Professionalism,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
-NURS,4110,1,Nursing of Children,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
-NURS,4120,1,Nurs Women and Fam,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4250,400,Community Nursing,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,tiffany leah stewart,
-NURS,4980,17,Neonatal Abstinence Syndrome,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,heide temples,
-NURS,8040,400,Dev Nurs Knowledge,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,stephanie clar davis,
-NURS,8050,400,Pharmaco Adv Nurs,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8050,401,Pharmaco Adv Nurs,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8060,400,Advan Assessment for Nursing,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,jennifer geter rice,
-NURS,8090,400,Pathophysiology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
-NURS,8180,400,Develop Family in Primary Care,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8190,400,Developing Family,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8200,400,Child & Adol Nursing,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,heide temples,
-NURS,9010,1,"DNP Role, Theory & Philosophy",0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,jean ellen zavertnik,
-NURS,9020,1,DNP Clinical Epidem & Biostats,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,veronica parker,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.86,0.09,0.0,0.01,0.03,0.0,0.0,0.0,bridgit deni corbett,
-NUTR,2030,2,Intro Princ of Human Nutrition,0.67,0.25,0.05,0.0,0.0,0.0,0.0,0.02,bridgit deni corbett,
-NUTR,2050,400,Nutrition for Nursing Prof,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
-NUTR,2160,1,Evidence-Based Nutrition,0.88,0.06,0.05,0.0,0.01,0.0,0.0,0.0,angela fraser,
-NUTR,3020,1,Nutrition Assessment,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,elliot jesch,
-NUTR,4240,1,Medical Nutr Thera I,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4510,1,Human Nutrition & Metabolism I,0.31,0.26,0.17,0.17,0.03,0.0,0.0,0.06,elliot jesch,
-PA,1010,1,Intro to Perf Arts,0.72,0.2,0.0,0.0,0.08,0.0,0.0,0.0,david hartmann,
-PA,2790,1,Perf Arts Pract I,0.47,0.41,0.0,0.0,0.0,0.0,0.0,0.12,kenneth moore,
-PADM,8210,400,Perspectives on Public Admin,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,thomas walker,
-PADM,8210,401,Perspectives on Public Admin,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,thomas walker,
-PADM,8420,400,GIS for Public Administrators,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,david lawrence white,
-PADM,8450,400,Grant Writing for Public Admin,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,katherin kransteuber,
-PADM,8530,400,Homeland Sec/Emergency Mgt Law,0.64,0.09,0.0,0.0,0.09,0.0,0.0,0.18,david leigh cook,
-PADM,8600,400,American Government,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
-PADM,8670,401,State Government Admin,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
-PADM,8710,401,Sustainability Practices Appli,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,david morgan young,
-PAS,3010,1,Intro to Pan African Studies,0.27,0.47,0.15,0.02,0.04,0.0,0.0,0.05,abel bartley,
-PES,1040,1,Introduction to Plant Sciences,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,
-PES,2020,1,Soils,0.14,0.49,0.27,0.08,0.02,0.0,0.0,0.0,dara michelle park,
-PES,3150,1,Environment and Agriculture,0.3,0.3,0.3,0.0,0.0,0.0,0.0,0.1,suseela appukuttan,
-PHIL,1010,1,Intro to Philosophic Problems,0.38,0.53,0.09,0.0,0.0,0.0,0.0,0.0,kelly smith,
-PHIL,1010,2,Intro to Philosophic Problems,0.42,0.32,0.11,0.05,0.11,0.0,0.0,0.0,kelly smith,
-PHIL,1010,3,Intro to Philosophic Problems,0.37,0.32,0.11,0.05,0.11,0.0,0.0,0.05,christopher grau,
-PHIL,1010,5,Intro to Philosophic Problems,0.56,0.32,0.06,0.0,0.03,0.0,0.0,0.03,david stegall,
-PHIL,1010,6,Intro to Philosophic Problems,0.38,0.35,0.03,0.09,0.03,0.0,0.0,0.12,david stegall,
-PHIL,1020,5,Introduction to Logic,0.29,0.37,0.03,0.17,0.03,0.0,0.0,0.11,david stegall,
-PHIL,1020,6,Introduction to Logic,0.39,0.36,0.09,0.0,0.03,0.0,0.0,0.12,david stegall,
-PHIL,1020,7,Introduction to Logic,0.47,0.32,0.18,0.03,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1020,8,Introduction to Logic,0.41,0.29,0.12,0.18,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1020,9,Introduction to Logic,0.56,0.22,0.11,0.0,0.06,0.0,0.0,0.06,adam gies,
-PHIL,1020,10,Introduction to Logic,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,adam gies,
-PHIL,1030,1,Introduction to Ethics,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,stephen satris,
-PHIL,1030,2,Introduction to Ethics,0.49,0.31,0.09,0.09,0.03,0.0,0.0,0.0,stephen satris,
-PHIL,1030,4,Introduction to Ethics,0.59,0.19,0.09,0.0,0.06,0.0,0.0,0.06,edyta joanna kuzian,
-PHIL,1030,5,Introduction to Ethics,0.48,0.3,0.15,0.0,0.0,0.0,0.0,0.06,edyta joanna kuzian,
-PHIL,1030,6,Introduction to Ethics,0.65,0.26,0.06,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,
-PHIL,3040,1,Moral Philosophy,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,todd may,
-PHIL,3150,1,Ancient Philosophy,0.39,0.26,0.23,0.03,0.03,0.0,0.0,0.06,stephen satris,
-PHIL,3210,1,Crime & Punishment,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,daniel wueste,
-PHIL,3430,1,Philosophy of Law,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,brookes colyto brown,
-PHIL,3440,1,Business Ethics,0.08,0.69,0.08,0.0,0.08,0.0,0.0,0.08,brookes colyto brown,
-PHIL,3480,1,Philosophies of Art,0.67,0.22,0.0,0.06,0.0,0.0,0.0,0.06,christopher grau,
-PHIL,3490,1,Gender and Sexuality,0.65,0.12,0.18,0.0,0.0,0.0,0.0,0.06,diane perpich,
-PHIL,4020,1,Recovery in Ethics,0.2,0.7,0.0,0.0,0.1,0.0,0.0,0.0,daniel wueste,
-PHIL,4220,1,Anarchism,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,todd may,
-PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.66,0.32,0.0,0.0,0.0,0.0,0.0,0.02,minory nammouz,
-PHYS,1220,1,Physics with Calculus I,0.31,0.25,0.22,0.11,0.06,0.0,0.0,0.05,lih-sin the,
-PHYS,1220,2,Physics with Calculus I,0.26,0.38,0.2,0.1,0.02,0.0,0.0,0.04,lih-sin the,
-PHYS,1220,7,Physics with Calculus I (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,hugo sanabria,True
-PHYS,1240,1,Physics Lab I,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,2,Physics Lab I,0.17,0.67,0.11,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,3,Physics Lab I,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,4,Physics Lab I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,5,Physics Lab I,0.28,0.39,0.28,0.0,0.06,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,6,Physics Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,7,Physics Lab I,0.17,0.56,0.17,0.11,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,8,Physics Lab I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,9,Physics Lab I,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,10,Physics Lab I,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,11,Physics Lab I,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,12,Physics Lab I,0.46,0.31,0.08,0.0,0.0,0.0,0.0,0.15,daniel ross thompson,
-PHYS,1240,14,Physics Lab I,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,
-PHYS,1240,15,Physics Lab I,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,16,Physics Lab I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,17,Physics Lab I,0.69,0.08,0.08,0.0,0.0,0.0,0.0,0.15,daniel ross thompson,
-PHYS,1240,18,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,19,Physics Lab I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,daniel ross thompson,
-PHYS,1240,20,Physics Lab I,0.72,0.17,0.0,0.0,0.11,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2070,1,General Physics I,0.35,0.31,0.18,0.05,0.06,0.0,0.0,0.05,amy liann pope,
-PHYS,2070,2,General Physics I,0.41,0.33,0.16,0.04,0.03,0.0,0.0,0.03,amy liann pope,
-PHYS,2070,3,General Physics I,0.44,0.31,0.14,0.05,0.02,0.0,0.0,0.05,amy liann pope,
-PHYS,2070,4,General Physics I,0.11,0.33,0.3,0.07,0.07,0.0,0.0,0.11,amy liann pope,
-PHYS,2080,1,General Physics II,0.44,0.4,0.09,0.02,0.02,0.0,0.0,0.02,pooja puneet,
-PHYS,2090,1,Gen Phys Lab I,0.43,0.43,0.09,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,2,Gen Phys Lab I,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,3,Gen Phys Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,4,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,5,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,6,Gen Phys Lab I,0.21,0.42,0.29,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,
-PHYS,2090,7,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,8,Gen Phys Lab I,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,9,Gen Phys Lab I,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,
-PHYS,2090,10,Gen Phys Lab I,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,11,Gen Phys Lab I,0.5,0.42,0.04,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,12,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,13,Gen Phys Lab I,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,14,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,15,Gen Phys Lab I,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,16,Gen Phys Lab I,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,17,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,18,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,19,Gen Phys Lab I,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,20,Gen Phys Lab I,0.61,0.35,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,21,Gen Phys Lab I,0.17,0.74,0.0,0.04,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,22,Gen Phys Lab I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,
-PHYS,2090,23,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,24,Gen Phys Lab I,0.42,0.46,0.08,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,25,Gen Phys Lab I,0.13,0.83,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,26,Gen Phys Lab I,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,27,Gen Phys Lab I,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,1,Gen Phys Lab II,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,2,Gen Phys Lab II,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2100,3,Gen Phys Lab II,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,4,Gen Phys Lab II,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,6,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,7,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,8,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,9,Gen Phys Lab II,0.96,0.0,0.0,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2210,1,Physics with Calculus II,0.28,0.4,0.23,0.04,0.04,0.0,0.0,0.01,jason stratfor brown,
-PHYS,2210,2,Physics with Calculus II,0.18,0.45,0.28,0.06,0.02,0.0,0.0,0.01,jason stratfor brown,
-PHYS,2210,3,Physics with Calculus II,0.34,0.44,0.15,0.02,0.03,0.0,0.0,0.01,jason stratfor brown,
-PHYS,2210,4,Physics with Calculus II,0.13,0.5,0.26,0.05,0.05,0.0,0.0,0.01,jason stratfor brown,
-PHYS,2210,8,Physics with Calculus II (HON),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True
-PHYS,2220,1,Physics with Calculus III,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,jian he,
-PHYS,2230,1,Physics Lab II,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,2,Physics Lab II,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,3,Physics Lab II,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,4,Physics Lab II,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,5,Physics Lab II,0.29,0.53,0.06,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,
-PHYS,2230,6,Physics Lab II,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,7,Physics Lab II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,9,Physics Lab II,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,10,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,11,Physics Lab II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,12,Physics Lab II,0.18,0.76,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,13,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,14,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,17,Physics Lab II,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,
-PHYS,2450,1,Physics of Climate,0.51,0.3,0.09,0.01,0.02,0.0,0.0,0.07,gerald lehmacher,
-PHYS,3000,1,Intro to Research,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,
-PHYS,3120,1,Meth Theor Phys II,0.5,0.2,0.3,0.0,0.0,0.0,0.0,0.0,lih-sin the,
-PHYS,3150,1,Intro to Computational Physics,0.64,0.14,0.07,0.0,0.0,0.0,0.0,0.14,emil georgiev alexov,
-PHYS,3210,1,Mechanics I,0.23,0.42,0.19,0.04,0.0,0.0,0.0,0.12,stephen rol kaeppler,
-PHYS,4410,1,Electromagnetics I,0.33,0.28,0.28,0.06,0.0,0.0,0.0,0.06,xian lu,
-PHYS,4550,1,Quantum Physics I,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,sumanta tewari,
-PHYS,8110,1,Meth of Theor Phys I,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,feng ding,
-PHYS,8210,1,Classical Mech I,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
-PHYS,8750,2,Intro to Research Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,
-PHYS,9510,1,Quantum Mech I,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,domnita ca marinescu,
-PKSC,1010,1,Pkgsc Orientation,0.27,0.53,0.18,0.0,0.0,0.0,0.0,0.01,marcondes pat guerra,
-PKSC,1020,1,Intro to Pkg Sci,0.08,0.32,0.3,0.21,0.05,0.0,0.0,0.04,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.29,0.46,0.19,0.06,0.0,0.0,0.0,0.0,marcondes pat guerra,
-PKSC,2040,1,Container Systems,0.28,0.53,0.13,0.03,0.03,0.0,0.0,0.0,marcondes pat guerra,
-PKSC,3200,1,Pkg Design Theory,0.83,0.04,0.09,0.0,0.0,0.0,0.0,0.04,rupert hurley,
-PKSC,4010,1,Packaging Machinery,0.36,0.54,0.05,0.03,0.0,0.0,0.0,0.03,anthony loui pometto,
-PKSC,4030,1,Pkg Career Prep,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4040,1,Protective Packaging Prop/Prin,0.4,0.36,0.16,0.0,0.06,0.0,0.0,0.03,gregory batt,
-PKSC,4160,1,Appl Polymers in Pkg,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,duncan darby,
-PKSC,4200,1,Pkg Design & Dev,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4540,1,Prod Pkg Evl Lab,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4540,2,Prod Pkg Evl Lab,0.25,0.56,0.06,0.0,0.06,0.0,0.0,0.06,gregory batt,
-PKSC,4540,3,Prod Pkg Evl Lab,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4540,4,Prod Pkg Evl Lab,0.56,0.25,0.06,0.13,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1,Food & Health Care Pkg Systems,0.6,0.3,0.09,0.0,0.0,0.0,0.0,0.0,kay cooksey,
-PKSC,4990,7,CI-Packaging  Sci Seminar,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,rupert hurley,
-PLPA,3100,1,Principles of Plant Pathology,0.14,0.46,0.39,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,
-PLPA,4250,1,Introductory Mycology,0.33,0.25,0.08,0.25,0.08,0.0,0.0,0.0,julia louis kerrigan,
-POSC,1010,1,Amer National Govt,0.21,0.44,0.25,0.07,0.0,0.0,0.0,0.04,joseph earl stewart,
-POSC,1010,2,Amer National Govt,0.54,0.22,0.2,0.02,0.0,0.0,0.0,0.02,jeffrey allen fine,
-POSC,1020,1,Intro Intl Relations,0.36,0.36,0.15,0.07,0.02,0.0,0.0,0.04,steven vincen miller,
-POSC,1020,2,Intro Intl Relations,0.19,0.38,0.27,0.05,0.03,0.0,0.0,0.08,zeynep taydas,
-POSC,1020,3,Intro Intl Relations,0.17,0.37,0.27,0.06,0.08,0.0,0.0,0.05,zeynep taydas,
-POSC,1040,1,Intro Compar Pol,0.17,0.43,0.26,0.0,0.0,0.0,0.0,0.13,xiaobo hu,
-POSC,1040,2,Intro Compar Pol,0.29,0.45,0.17,0.05,0.05,0.0,0.0,0.0,katherine amb curtis,
-POSC,1990,1,Intro Pol Sci,0.6,0.22,0.07,0.04,0.05,0.0,0.0,0.02,meredith- petersheim,
-POSC,3020,1,State and Loc Gov,0.31,0.49,0.09,0.0,0.09,0.0,0.0,0.02,bruce ransom,
-POSC,3610,1,International Conflict,0.39,0.22,0.16,0.0,0.12,0.0,0.0,0.1,steven vincen miller,
-POSC,3630,1,Us Foreign Policy,0.3,0.51,0.11,0.04,0.02,0.0,0.0,0.02,vladimir matic,
-POSC,3710,1,European Politics,0.41,0.44,0.1,0.0,0.05,0.0,0.0,0.0,vladimir matic,
-POSC,4030,1,United States Congress,0.26,0.47,0.17,0.04,0.02,0.0,0.0,0.04,jeffrey scott peake,
-POSC,4210,1,Public Policy,0.12,0.35,0.24,0.06,0.18,0.0,0.0,0.06,adam warber,
-POSC,4230,1,Urban Politics,0.5,0.28,0.06,0.0,0.06,0.0,0.0,0.11,bruce ransom,
-POSC,4360,1,Law Courts Politics,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,joseph earl stewart,
-POSC,4470,1,International Law,0.4,0.23,0.13,0.13,0.0,0.0,0.0,0.1,katherine amb curtis,
-POSC,4490,1,Political Theory of Capitalism,0.27,0.55,0.09,0.03,0.06,0.0,0.0,0.0,colin denby pearce,
-POSC,4550,1,Pol Thght of American Founding,0.38,0.34,0.23,0.0,0.04,0.0,0.0,0.0, bradley thompson,
-POSC,4560,1,Diplomacy,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,vladimir matic,
-POSC,4760,1,Middle East Politics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
-PRTM,2200,10,Foundations of PRTM,0.35,0.43,0.16,0.02,0.02,0.0,0.0,0.02,jamie lynn cathey,
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2260,2,Fnd of Mgt Adm PRTM,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth de baldwin,
-PRTM,2260,3,Fnd of Mgt Adm PRTM,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2260,4,Fnd of Mgt Adm PRTM,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2260,5,Fnd of Mgt Adm PRTM,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,2260,6,Fnd of Mgt Adm PRTM,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,katrina latric black,
-PRTM,2260,7,Fnd of Mgt Adm PRTM,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,katie dudley,
-PRTM,2260,8,Fnd of Mgt Adm PRTM,0.69,0.15,0.0,0.08,0.08,0.0,0.0,0.0,lauren eliz stephens,
-PRTM,2270,1,Prov of Leisure Exp,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2270,2,Prov of Leisure Exp,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth de baldwin,
-PRTM,2270,3,Prov of Leisure Exp,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2270,4,Prov of Leisure Exp,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2270,5,Prov of Leisure Exp,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,2270,6,Prov of Leisure Exp,0.13,0.69,0.06,0.13,0.0,0.0,0.0,0.0,katrina latric black,
-PRTM,2270,7,Prov of Leisure Exp,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,katie dudley,
-PRTM,2270,8,Prov of Leisure Exp,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,lauren eliz stephens,
-PRTM,2290,1,Competency Integration in PRTM,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2290,2,Competency Integration in PRTM,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,elizabeth de baldwin,
-PRTM,2290,3,Competency Integration in PRTM,0.33,0.47,0.13,0.07,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,2290,4,Competency Integration in PRTM,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2290,5,Competency Integration in PRTM,0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,2290,6,Competency Integration in PRTM,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,katrina latric black,
-PRTM,2290,7,Competency Integration in PRTM,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,katie dudley,
-PRTM,2290,8,Competency Integration in PRTM,0.77,0.08,0.0,0.08,0.08,0.0,0.0,0.0,lauren eliz stephens,
-PRTM,2950,1,Pro Golf Management Seminar II,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.52,0.17,0.28,0.0,0.0,0.0,0.0,0.03,daniel morg anderson,
-PRTM,3070,2,Facility Operations,0.85,0.09,0.06,0.0,0.0,0.0,0.0,0.0,raymond dunham,
-PRTM,3200,1,Recreation Policy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,matthew tyl brownlee,
-PRTM,3220,1,Facilitation Techniques in RT,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,
-PRTM,3230,1,Prof Prep for RT Practice,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,
-PRTM,3240,1,Assessment & Planning in RT,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3300,1,Visit Ser & Interp,0.64,0.14,0.21,0.0,0.0,0.0,0.0,0.0,michael pa blacketer,
-PRTM,3430,1,Spl Asp of Tourist B,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,'lisha fogle,
-PRTM,3470,1,Sport Tourism,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,gregory phil ramshaw,
-PRTM,3520,1,Camp Org and Admin,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,lisa kay-powle olsen,
-PRTM,3600,1,Recreation & Amateur Sport Mgt,0.26,0.61,0.09,0.0,0.0,0.0,0.0,0.04,skye arthur-banning,
-PRTM,3900,8,PGA GM Player Development,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3920,1,Special Event Management,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,
-PRTM,3920,2,Special Event Management,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,
-PRTM,3950,1,PGM Seminar III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,4030,1,Elem of Rec/Pk Plan,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,robert baxter powell,
-PRTM,4210,1,Rec Fin Resc Mgt,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,ryan joseph gagnon,
-PRTM,4220,1,Management of RT Services,0.49,0.49,0.03,0.0,0.0,0.0,0.0,0.0,brandi crowe,
-PRTM,4450,1,Conventions,0.82,0.09,0.06,0.0,0.0,0.0,0.0,0.03,stephanie perl garst,
-PRTM,4470,1,Perspect Intl Travel,0.93,0.0,0.04,0.0,0.04,0.0,0.0,0.0,sheila backman,
-PRTM,4510,1,Seminar in CRSCM,0.83,0.09,0.04,0.04,0.0,0.0,0.0,0.0,harrison pa pinckney,
-PRTM,4550,1,Adv Program Planning,0.62,0.23,0.08,0.04,0.04,0.0,0.0,0.0,harrison pa pinckney,
-PRTM,4740,2,Adv Rec Resource Mgt,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,matthew tyl brownlee,
-PRTM,4830,1,Golf Club Mgt & Ops,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,4950,1,Pro Golf Management Seminar IV,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,9000,7,Online Comp Exam,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,jeffrey charle hallo,
-PSYC,2010,1,Intro to Psychology,0.52,0.23,0.21,0.0,0.03,0.0,0.0,0.02,chong hyon pak,
-PSYC,2010,2,Intro to Psychology,0.27,0.31,0.26,0.08,0.02,0.0,0.0,0.05,edwin brainerd,
-PSYC,2010,3,Intro to Psychology,0.33,0.37,0.16,0.08,0.01,0.0,0.0,0.05,jo anne jorgensen,
-PSYC,2010,4,Intro to Psychology,0.34,0.39,0.14,0.07,0.0,0.0,0.0,0.06,mary taylor,
-PSYC,2010,5,Intro to Psychology (HON),0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,True
-PSYC,2890,1,Fundamentals of Psyc Science,0.56,0.34,0.06,0.03,0.01,0.0,0.0,0.01,peggy tyler,
-PSYC,3060,1,Human Sexual Behavior,0.51,0.22,0.13,0.06,0.07,0.0,0.0,0.01,bruce michael king,
-PSYC,3090,100,Intro Experimental Psychology,0.33,0.39,0.21,0.03,0.02,0.0,0.0,0.02,jennifer bail bisson,
-PSYC,3090,200,Intro Experimental Psychology,0.47,0.18,0.19,0.05,0.09,0.0,0.0,0.01,patrick rosopa,
-PSYC,3100,100,Advanced Experimental Psych,0.3,0.35,0.25,0.05,0.0,0.0,0.0,0.05,eric mckibben,
-PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,thomas britt,
-PSYC,3100,300,Advanced Experimental Psych,0.35,0.41,0.06,0.0,0.06,0.0,0.0,0.12,robert campbell,
-PSYC,3100,400,Advanced Experimental Psych,0.43,0.43,0.05,0.05,0.0,0.0,0.0,0.05,fred switzer,
-PSYC,3100,500,Advanced Experimental Psych,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,3100,600,Advanced Experimental Psych,0.35,0.57,0.09,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3240,1,Physiological Psych,0.35,0.29,0.17,0.06,0.07,0.0,0.0,0.06,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.43,0.26,0.17,0.1,0.01,0.0,0.0,0.01,claudio cantalupo,
-PSYC,3310,1,Critical Thinking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3330,1,Cognitive Psych,0.47,0.31,0.1,0.03,0.03,0.0,0.0,0.06,robert campbell,
-PSYC,3330,2,Cognitive Psych,0.65,0.26,0.07,0.01,0.0,0.0,0.0,0.0,kaileigh angel byrne,
-PSYC,3330,3,Cognitive Psych,0.57,0.26,0.08,0.02,0.05,0.0,0.0,0.03,kaileigh angel byrne,
-PSYC,3340,2,Cognitive Psych Lab,0.64,0.29,0.0,0.07,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3340,3,Cognitive Psych Lab,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,kathryn lucaites,
-PSYC,3340,4,Cognitive Psych Lab,0.54,0.31,0.0,0.15,0.0,0.0,0.0,0.0,kathryn lucaites,
-PSYC,3400,1,Lifespan Developmental Psych,0.68,0.22,0.08,0.01,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3400,2,Lifespan Developmental Psych,0.38,0.44,0.13,0.01,0.0,0.0,0.0,0.04,jennifer bail bisson,
-PSYC,3400,3,Lifespan Developmental Psych,0.25,0.3,0.22,0.09,0.1,0.0,0.0,0.04,pamela alley,
-PSYC,3520,1,Social Psychology,0.4,0.28,0.25,0.07,0.0,0.0,0.0,0.0,jo anne jorgensen,
-PSYC,3640,1,Industrial Psych,0.54,0.3,0.08,0.05,0.0,0.0,0.0,0.03,anton sytine,
-PSYC,3640,2,Industrial Psych,0.29,0.37,0.26,0.04,0.0,0.0,0.0,0.03,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.25,0.3,0.22,0.08,0.05,0.0,0.0,0.1,eric mckibben,
-PSYC,3680,2,Organizational Psych,0.59,0.27,0.09,0.01,0.03,0.0,0.0,0.01,zachary klinefelter,
-PSYC,3700,1,Personality,0.49,0.34,0.14,0.01,0.0,0.0,0.0,0.01,john robert hester,
-PSYC,3830,1,Abnormal Psychology,0.41,0.34,0.18,0.03,0.03,0.0,0.0,0.01,jo anne jorgensen,
-PSYC,3830,2,Abnormal Psychology,0.22,0.26,0.26,0.07,0.15,0.0,0.0,0.04,pamela alley,
-PSYC,3830,3,Abnormal Psychology,0.26,0.34,0.17,0.06,0.14,0.0,0.0,0.03,pamela alley,
-PSYC,3890,1,Group/Team Dynamics,0.9,0.07,0.0,0.01,0.01,0.0,0.0,0.0,marissa leigh porter,
-PSYC,3890,2,Psychology and Culture,0.6,0.21,0.12,0.05,0.02,0.0,0.0,0.0,ceren gunsoy,
-PSYC,4080,1,Women and Psychology,0.58,0.17,0.04,0.0,0.04,0.0,0.0,0.17,robin marie kowalski,
-PSYC,4150,1,Systems and Theories,0.29,0.46,0.17,0.09,0.0,0.0,0.0,0.0,edwin brainerd,
-PSYC,4150,2,Systems and Theories,0.34,0.41,0.16,0.03,0.03,0.0,0.0,0.03,edwin brainerd,
-PSYC,4150,3,Systems and Theories,0.8,0.11,0.03,0.0,0.03,0.0,0.0,0.03,michael shreeves,
-PSYC,4220,1,Perception,0.29,0.42,0.17,0.0,0.0,0.0,0.0,0.13,claudio cantalupo,
-PSYC,4220,2,Perception,0.33,0.15,0.33,0.19,0.0,0.0,0.0,0.0,christopher pagano,
-PSYC,4220,3,Perception,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,christopher pagano,
-PSYC,4220,4,Perception,0.72,0.16,0.08,0.0,0.04,0.0,0.0,0.0,darlene edewaard,
-PSYC,4350,1,Human Factors,0.58,0.23,0.12,0.04,0.0,0.0,0.0,0.04,laura whitlock,
-PSYC,4350,2,Human Factors,0.68,0.2,0.12,0.0,0.0,0.0,0.0,0.0,laura whitlock,
-PSYC,4710,1,Psych of Testing,0.46,0.31,0.15,0.08,0.0,0.0,0.0,0.0,zhuo chen,
-PSYC,4800,1,Health Psychology,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,james mccubbin,
-PSYC,4800,2,Health Psychology,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,james mccubbin,
-PSYC,4820,1,Positive Psychology,0.52,0.3,0.04,0.0,0.0,0.0,0.0,0.13,cynthia pury s,
-PSYC,4880,1,Psychotherapy,0.31,0.31,0.08,0.0,0.15,0.0,0.0,0.15,lucinda sorcie quick,
-PSYC,4890,1,21st Century Teams,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,marissa leigh porter,
-PSYC,4920,1,Senior Laboratory,0.64,0.18,0.09,0.0,0.05,0.0,0.0,0.05,chloe wilson,
-PSYC,4920,2,Senior Laboratory,0.77,0.09,0.05,0.0,0.09,0.0,0.0,0.0,chloe wilson,
-PSYC,4920,3,Senior Laboratory,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,chloe wilson,
-PSYC,4920,4,Senior Laboratory,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,tiffany cooper,
-PSYC,8100,1,Research Design I,0.73,0.19,0.0,0.0,0.03,0.0,0.0,0.05, dewayne moore,
-PSYC,8520,1,Social Psychology,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,ceren gunsoy,
-RED,8000,1,Real Estate Dvlpment,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,robert crei benedict,
-RED,8130,1,Strat in Real Estate,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,phillip river hughes,
-REL,1010,1,Intro to Religion,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,peter cohen,
-REL,1010,2,Intro to Religion,0.28,0.22,0.17,0.17,0.11,0.0,0.0,0.06,peter cohen,
-REL,1010,3,Intro to Religion,0.18,0.38,0.15,0.09,0.09,0.0,0.0,0.12,peter cohen,
-REL,1010,4,Intro to Religion,0.59,0.32,0.06,0.0,0.0,0.0,0.0,0.03,richard ale amesbury,
-REL,1020,2,World Religions,0.3,0.39,0.21,0.0,0.0,0.0,0.0,0.09,robert stephens,
-REL,1020,3,World Religions,0.31,0.46,0.11,0.06,0.03,0.0,0.0,0.03,robert stephens,
-REL,1020,4,World Religions,0.41,0.32,0.21,0.0,0.03,0.0,0.0,0.03,robert stephens,
-REL,3010,1,Old Testament,0.59,0.34,0.03,0.03,0.0,0.0,0.0,0.0,steven grosby,
-REL,3060,1,Judaism,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3090,1,Religion of the American South,0.6,0.13,0.13,0.0,0.07,0.0,0.0,0.07,elizabeth jemison,
-REL,3110,1,African American Rel,0.41,0.35,0.12,0.0,0.06,0.0,0.0,0.06,elizabeth jemison,
-REL,3130,1,Buddhism,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,robert stephens,
-REL,3150,1,Islam,0.53,0.2,0.13,0.07,0.0,0.0,0.0,0.07,mashal saif,
-REL,3200,1,"Jesus in History, Faith & Film",0.47,0.47,0.0,0.0,0.03,0.0,0.0,0.03,benjamin white,
-REL,4010,1,Stud Biblical Literature & Rel,0.5,0.21,0.07,0.07,0.0,0.0,0.0,0.14,benjamin white,
-RUSS,1010,1,Elementary Russian,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,stephanie ely morris,
-RUSS,1010,2,Elementary Russian,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,stephanie ely morris,
-RUSS,2010,1,Intermediate Russ,0.29,0.36,0.21,0.0,0.07,0.0,0.0,0.07,olga anatoly volkova,
-RUSS,3400,1,19th C Russ Culture,0.54,0.33,0.04,0.0,0.0,0.0,0.0,0.08,olga anatoly volkova,
-RUSS,3600,1,Russian Lit to 1910,0.58,0.25,0.13,0.0,0.0,0.0,0.0,0.04,olga anatoly volkova,
-SOC,2010,2,Introduction to Sociology,0.89,0.09,0.01,0.0,0.0,0.0,0.0,0.02,andrew he mannheimer,
-SOC,2010,3,Introduction to Sociology,0.49,0.36,0.09,0.01,0.02,0.0,0.0,0.02,carolyn cand coffman,
-SOC,2010,4,Introduction to Sociology,0.5,0.35,0.11,0.04,0.0,0.0,0.0,0.01,shannon mcdonough,
-SOC,2010,5,Introduction to Sociology,0.56,0.27,0.13,0.03,0.01,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,7,Introduction to Sociology,0.46,0.36,0.14,0.02,0.0,0.0,0.0,0.02,jennifer lea holland,
-SOC,2040,1,Prof Dev for Sociology Majors,0.41,0.32,0.15,0.05,0.05,0.0,0.0,0.02, catherine mobley,
-SOC,3040,1,Social Research Methods II,0.32,0.29,0.14,0.21,0.0,0.0,0.0,0.04,ye luo,
-SOC,3110,1,The Family,0.37,0.51,0.08,0.02,0.02,0.0,0.0,0.0,andrew whitehead,
-SOC,3400,1,Sport and Society,0.36,0.33,0.24,0.04,0.0,0.0,0.0,0.02,andrew whitehead,
-SOC,3940,1,Sociology of Mental Illness,0.78,0.2,0.0,0.02,0.0,0.0,0.0,0.0,james rosenberger,
-SOC,3970,1,Substance Abuse,0.55,0.34,0.11,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,
-SOC,4040,1,Soc Theory,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,william haller,
-SOC,4060,1,Qual Rsrch Methods for Soc Sci,0.55,0.18,0.0,0.09,0.0,0.0,0.0,0.18,melissa vogel,
-SOC,4140,1,Policy&Social Change,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,jennifer lea holland,
-SOC,4600,1,Race & Ethnicity,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew he mannheimer,
-SOC,4610,1,Sex & Gender,0.53,0.2,0.18,0.0,0.02,0.0,0.0,0.07,carolyn cand coffman,
-SOC,4800,1,Medical Sociology,0.82,0.06,0.03,0.0,0.09,0.0,0.0,0.0,carolyn cand coffman,
-SOC,6060,1,Qual Rsrch Methods for Soc Sci,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,
-SPAN,1010,1,Elementary Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,
-SPAN,1010,2,Elementary Spanish,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,rosa maca pillcurima,
-SPAN,1010,3,Elementary Spanish,0.63,0.16,0.05,0.11,0.05,0.0,0.0,0.0,rosa maca pillcurima,
-SPAN,1020,1,Elementary Spanish,0.72,0.11,0.06,0.0,0.11,0.0,0.0,0.0,rosa maca pillcurima,
-SPAN,1020,2,Elementary Spanish,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
-SPAN,1020,3,Elementary Spanish,0.47,0.26,0.21,0.05,0.0,0.0,0.0,0.0,valderramos zen cruz,
-SPAN,1020,4,Elementary Spanish,0.71,0.12,0.06,0.06,0.06,0.0,0.0,0.0,vieyra daniel garcia,
-SPAN,1020,5,Elementary Spanish,0.63,0.32,0.0,0.05,0.0,0.0,0.0,0.0,vieyra daniel garcia,
-SPAN,1020,6,Elementary Spanish,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,riquelme maria judez,
-SPAN,1020,7,Elementary Spanish,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,
-SPAN,1020,8,Elementary Spanish,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,vieyra daniel garcia,
-SPAN,1020,10,Elementary Spanish,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,debra oak williamson,
-SPAN,1020,11,Elementary Spanish,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,debra oak williamson,
-SPAN,1020,12,Elementary Spanish,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,adrienne elizab fama,
-SPAN,1020,13,Elementary Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,
-SPAN,2010,1,Intermediate Spanish,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,riquelme maria judez,
-SPAN,2010,2,Intermediate Spanish,0.61,0.0,0.28,0.0,0.11,0.0,0.0,0.0,valderramos zen cruz,
-SPAN,2010,3,Intermediate Spanish,0.5,0.33,0.06,0.0,0.06,0.0,0.0,0.06,melva margue persico,
-SPAN,2010,4,Intermediate Spanish,0.19,0.75,0.0,0.0,0.0,0.0,0.0,0.06,melva margue persico,
-SPAN,2010,7,Intermediate Spanish,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,debra oak williamson,
-SPAN,2010,8,Intermediate Spanish,0.5,0.25,0.17,0.08,0.0,0.0,0.0,0.0,debra oak williamson,
-SPAN,2010,9,Intermediate Spanish,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,
-SPAN,2010,10,Intermediate Spanish,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,ellory schmucker,
-SPAN,2010,11,Intermediate Spanish,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
-SPAN,2010,12,Intermediate Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
-SPAN,2010,16,Intermediate Spanish,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,17,Intermediate Spanish,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,
-SPAN,2020,1,Intermediate Spanish,0.21,0.58,0.16,0.0,0.05,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,2,Intermediate Spanish,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,
-SPAN,2020,3,Intermediate Spanish,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,
-SPAN,2020,4,Intermediate Spanish,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,
-SPAN,2020,5,Intermediate Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2020,7,Intermediate Spanish,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2020,8,Intermediate Spanish,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,
-SPAN,2020,9,Intermediate Spanish,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,ana paula  miller e,
-SPAN,2020,10,Intermediate Spanish,0.47,0.26,0.21,0.0,0.0,0.0,0.0,0.05,valderramos zen cruz,
-SPAN,2020,11,Intermediate Spanish,0.24,0.65,0.06,0.0,0.06,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,12,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,valderramos zen cruz,
-SPAN,2020,13,Intermediate Spanish,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,valderramos zen cruz,
-SPAN,2020,14,Intermediate Spanish,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,3010,1,Spanish Comp for Health Prof,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,3020,1,Intermed Span Grammar & Comp,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,melva margue persico,
-SPAN,3020,2,Intermed Span Grammar & Comp,0.32,0.53,0.05,0.0,0.05,0.0,0.0,0.05,melva margue persico,
-SPAN,3020,3,Intermed Span Grammar & Comp,0.53,0.26,0.16,0.0,0.0,0.0,0.0,0.05,daniel smith,
-SPAN,3050,1,Intermed Span Convers/Comp I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,moni rojas-de-massei,
-SPAN,3050,2,Intermed Span Convers/Comp I,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,moni rojas-de-massei,
-SPAN,3050,3,Intermed Span Convers/Comp I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,juana martin-armas,
-SPAN,3050,4,Intermed Span Convers/Comp I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,graciela tissera,
-SPAN,3050,6,Intermed Span Convers/Comp I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,vieyra daniel garcia,
-SPAN,3050,7,Intermed Span Convers/Comp I,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,vieyra daniel garcia,
-SPAN,3070,1,The Hispanic World: Spain,0.44,0.28,0.11,0.06,0.11,0.0,0.0,0.0,raquel anido,
-SPAN,3080,1,The Hispanic World: Latin Amer,0.44,0.28,0.06,0.0,0.17,0.0,0.0,0.06,tiffany dawn miller,
-SPAN,3080,2,The Hispanic World: Latin Amer,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,tiffany dawn miller,
-SPAN,3130,2,Span Lit Survey I,0.25,0.38,0.13,0.0,0.19,0.0,0.0,0.06,moni rojas-de-massei,
-SPAN,3180,1,Spanish Through Culture,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,george palacios,
-SPAN,4010,1,New Spanish Fiction,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,salvador oropesa,
-SPAN,4060,2,Narrative Fiction,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
-SPAN,4070,1,Hispanic Film,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,
-SPAN,4150,1,Spanish for Health Prof,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,riquelme maria judez,
-STAT,2220,1,Statistics in Everyday Life,0.45,0.26,0.19,0.09,0.01,0.0,0.0,0.0,james espey,
-STAT,2220,2,Statistics in Everyday Life,0.48,0.26,0.17,0.04,0.01,0.0,0.0,0.03,james espey,
-STAT,2220,3,Statistics in Everyday Life,0.49,0.29,0.11,0.07,0.01,0.0,0.0,0.03,james espey,
-STAT,2220,4,Statistics in Everyday Life,0.38,0.33,0.15,0.08,0.02,0.0,0.0,0.03,james espey,
-STAT,2220,5,Statistics in Everyday Life,0.4,0.26,0.18,0.08,0.05,0.0,0.0,0.04,rose martinez-dawson,
-STAT,2220,6,Statistics in Everyday Life,0.31,0.23,0.28,0.07,0.06,0.0,0.0,0.05,rose martinez-dawson,
-STAT,2300,1,Statistical Methods I,0.23,0.29,0.27,0.09,0.08,0.0,0.0,0.02,christy jenkin brown,
-STAT,2300,2,Statistical Methods I,0.33,0.42,0.17,0.04,0.03,0.0,0.0,0.02,christy jenkin brown,
-STAT,2300,3,Statistical Methods I,0.32,0.35,0.11,0.14,0.04,0.0,0.0,0.04,sharon marie evans,
-STAT,2300,4,Statistical Methods I,0.29,0.37,0.13,0.08,0.09,0.0,0.0,0.05,sharon marie evans,
-STAT,2300,5,Statistical Methods I,0.18,0.29,0.17,0.15,0.15,0.0,0.0,0.06, erwin walker,
-STAT,2300,6,Statistical Methods I,0.13,0.35,0.22,0.08,0.12,0.0,0.0,0.11, erwin walker,
-STAT,2300,100,Statistical Methods I (HON),0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,christy jenkin brown,True
-STAT,3090,1,Introductory Business Stats,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,margaret emma brooks,
-STAT,3090,2,Introductory Business Stats,0.26,0.37,0.21,0.05,0.05,0.0,0.0,0.05,margaret emma brooks,
-STAT,3090,3,Introductory Business Stats,0.37,0.32,0.16,0.11,0.05,0.0,0.0,0.0,boyoung hur,
-STAT,3090,4,Introductory Business Stats,0.26,0.26,0.21,0.26,0.0,0.0,0.0,0.0,boyoung hur,
-STAT,3090,5,Introductory Business Stats,0.28,0.33,0.22,0.17,0.0,0.0,0.0,0.0,tiantian yang,
-STAT,3090,6,Introductory Business Stats,0.18,0.12,0.06,0.18,0.35,0.0,0.0,0.12,rui gong,
-STAT,3090,7,Introductory Business Stats,0.26,0.37,0.21,0.11,0.05,0.0,0.0,0.0,yiren ding,
-STAT,3090,8,Introductory Business Stats,0.12,0.35,0.35,0.12,0.06,0.0,0.0,0.0,yiren ding,
-STAT,3090,9,Introductory Business Stats,0.47,0.26,0.16,0.11,0.0,0.0,0.0,0.0,brandon lumsden,
-STAT,3090,10,Introductory Business Stats,0.29,0.18,0.35,0.06,0.06,0.0,0.0,0.06,jiajing niu,
-STAT,3090,11,Introductory Business Stats,0.26,0.37,0.16,0.05,0.11,0.0,0.0,0.05,anna marie vagnozzi,
-STAT,3090,12,Introductory Business Stats,0.21,0.21,0.26,0.0,0.16,0.0,0.0,0.16,john charl nicholson,
-STAT,3090,13,Introductory Business Stats,0.3,0.26,0.2,0.12,0.09,0.0,0.0,0.03,april thomas,
-STAT,3090,14,Introductory Business Stats,0.37,0.32,0.11,0.05,0.16,0.0,0.0,0.0,kayla doris javier,
-STAT,3090,15,Introductory Business Stats,0.32,0.39,0.11,0.08,0.09,0.0,0.0,0.01,april thomas,
-STAT,3090,16,Introductory Business Stats,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,yidan guo,
-STAT,3090,17,Introductory Business Stats,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,john charl nicholson,
-STAT,3090,18,Introductory Business Stats,0.22,0.33,0.28,0.11,0.06,0.0,0.0,0.0,feng gao,
-STAT,3090,19,Introductory Business Stats,0.42,0.32,0.11,0.05,0.11,0.0,0.0,0.0,kayla doris javier,
-STAT,3090,20,Introductory Business Stats,0.16,0.37,0.26,0.05,0.11,0.0,0.0,0.05,yidan guo,
-STAT,3090,21,Introductory Business Stats,0.18,0.41,0.24,0.0,0.12,0.0,0.0,0.06,minghua cui,
-STAT,3090,22,Introductory Business Stats,0.21,0.26,0.21,0.16,0.11,0.0,0.0,0.05,rui gong,
-STAT,3090,23,Introductory Business Stats,0.47,0.24,0.24,0.06,0.0,0.0,0.0,0.0,tiantian yang,
-STAT,3090,24,Introductory Business Stats,0.21,0.47,0.26,0.05,0.0,0.0,0.0,0.0,xueheng shi,
-STAT,3090,25,Introductory Business Stats,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,norman michae snyder,
-STAT,3090,26,Introductory Business Stats,0.37,0.37,0.16,0.0,0.11,0.0,0.0,0.0,anna marie vagnozzi,
-STAT,3090,27,Introductory Business Stats,0.32,0.37,0.16,0.11,0.05,0.0,0.0,0.0,sean walk ingimarson,
-STAT,3090,28,Introductory Business Stats,0.11,0.39,0.28,0.06,0.11,0.0,0.0,0.06,xueheng shi,
-STAT,3090,29,Introductory Business Stats,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,jiajing niu,
-STAT,3090,30,Introductory Business Stats,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,norman michae snyder,
-STAT,3090,31,Introductory Business Stats,0.53,0.21,0.21,0.05,0.0,0.0,0.0,0.0,brandon lumsden,
-STAT,3090,32,Introductory Business Stats,0.28,0.22,0.33,0.0,0.17,0.0,0.0,0.0,minghua cui,
-STAT,3090,33,Introductory Business Stats,0.2,0.42,0.27,0.04,0.07,0.0,0.0,0.0,margaret mari wiecek,
-STAT,3090,34,Introductory Business Stats,0.53,0.21,0.21,0.05,0.0,0.0,0.0,0.0,alan robert hahn,
-STAT,3090,35,Introductory Business Stats,0.16,0.47,0.32,0.05,0.0,0.0,0.0,0.0,alan robert hahn,
-STAT,3090,36,Introductory Business Stats,0.21,0.47,0.16,0.05,0.11,0.0,0.0,0.0,feng gao,
-STAT,3090,37,Introductory Business Stats,0.18,0.29,0.12,0.12,0.24,0.0,0.0,0.06,sean walk ingimarson,
-STAT,3300,1,Statistical Methods II,0.44,0.17,0.11,0.17,0.06,0.0,0.0,0.06,rose martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.32,0.44,0.16,0.04,0.04,0.0,0.0,0.0,ellen hepfer breazel,
-STAT,4110,1,Stat Mthds for Process Control,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,richard steve dubsky,
-STAT,4110,3,Stat Mthds for Process Control,0.56,0.28,0.11,0.0,0.03,0.0,0.0,0.03,william bridges,
-STAT,6020,1,Intro to Statistical Computing,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,
-STAT,8010,3,Statistical Methods I,0.36,0.41,0.05,0.0,0.05,0.0,0.0,0.14,jun luo,
-STAT,8010,4,Statistical Methods I,0.27,0.09,0.32,0.0,0.05,0.0,0.0,0.27,jun luo,
-STAT,8010,5,Statistical Methods I,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,joseph daniel bible,
-STAT,8010,7,Statistical Methods I,0.62,0.29,0.0,0.0,0.0,0.0,0.0,0.1,brook thayer russell,
-STAT,8020,1,Statistical Methods II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-STAT,8030,1,Regress & Least Squares Anlys,0.57,0.39,0.0,0.0,0.04,0.0,0.0,0.0,brook thayer russell,
-STS,1010,1,Survey Sci & Techn in Society,0.49,0.49,0.03,0.0,0.0,0.0,0.0,0.0,kenneth davi widgren,
-STS,1010,2,Survey Sci & Techn in Society,0.43,0.37,0.14,0.03,0.0,0.0,0.0,0.03,scott brame,
-STS,1010,3,Survey Sci & Techn in Society,0.49,0.37,0.11,0.0,0.0,0.0,0.0,0.03,elizabeth stansell,
-STS,1010,4,Survey Sci & Techn in Society,0.19,0.5,0.28,0.03,0.0,0.0,0.0,0.0,sarah mae cooper,
-STS,1010,5,Survey Sci & Techn in Society,0.54,0.29,0.09,0.03,0.03,0.0,0.0,0.03,philip randall,
-STS,1010,6,Survey Sci & Techn in Society,0.79,0.06,0.06,0.0,0.03,0.0,0.0,0.06,christine cla murphy,
-STS,1010,7,Survey Sci & Techn in Society,0.31,0.44,0.14,0.03,0.06,0.0,0.0,0.03,megan noe macalystre,
-STS,1010,8,Survey Sci & Techn in Society,0.34,0.4,0.09,0.0,0.03,0.0,0.0,0.14,david charles foltz,
-STS,1010,9,Survey Sci & Techn in Society,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-THEA,2100,1,Theatre Appreciation,0.66,0.19,0.06,0.03,0.03,0.0,0.0,0.03,kendra lynet johnson,
-THEA,2100,2,Theatre Appreciation,0.84,0.06,0.0,0.03,0.03,0.0,0.0,0.03,kerrie kathl seymour,
-THEA,2100,3,Theatre Appreciation,0.63,0.25,0.06,0.03,0.03,0.0,0.0,0.0,david hartmann,
-THEA,2100,4,Theatre Appreciation,0.9,0.06,0.0,0.0,0.0,0.0,0.0,0.03,anthony penna,
-THEA,2100,5,Theatre Appreciation,0.81,0.09,0.03,0.03,0.0,0.0,0.0,0.03,carol collins,
-THEA,2100,6,Theatre Appreciation,0.53,0.25,0.09,0.13,0.0,0.0,0.0,0.0,jason adkins,
-THEA,2100,7,Theatre Appreciation,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,jason adkins,
-THEA,2780,1,Acting I,0.73,0.09,0.09,0.09,0.0,0.0,0.0,0.0,kerrie kathl seymour,
-THEA,3170,1,African-Amer Thea I,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,kendra lynet johnson,
-THEA,4290,1,Dramatic Literature I,0.5,0.0,0.1,0.1,0.3,0.0,0.0,0.0,jason adkins,
-WFB,4100,2,Wildlife Management Techniques,0.29,0.48,0.18,0.02,0.02,0.0,0.0,0.02,james davis,
-WFB,4180,2,Fisheries Mgt & Conservation,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,troy mason farmer,
-WFB,4440,1,Wildlife Damage Management,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
-WFB,4720,1,Ornithology,0.18,0.55,0.18,0.09,0.0,0.0,0.0,0.0,john cummings,
-WFB,4770,1,Ichthyology,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,brandon kevi peoples,
-WFB,4800,1,Waterfowl Ecology & Management,0.61,0.22,0.11,0.03,0.0,0.0,0.0,0.03,richard mar kaminski,
-WFB,4930,2,Plant & Flora ID/Systematics,0.7,0.18,0.06,0.01,0.0,0.0,0.0,0.04,patrick mcmillan,
-WFB,6620,1,Wetland Wildlife Biology,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,russell barrett,
-WFB,6800,1,Waterfowl Ecology & Management,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,richard mar kaminski,
-WFB,8530,2,Global Chg Eco,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,lydia rie 'halloran,
-WS,1030,1,Women in Global Perspective,0.6,0.17,0.17,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,
-WS,2300,1,Women and Leadership I,0.55,0.27,0.09,0.05,0.0,0.0,0.0,0.05,mary price,
-WS,3010,1,Intro Women's Studies,0.43,0.43,0.03,0.07,0.0,0.0,0.0,0.03,elizabeth rose adams,
-WS,3010,2,Intro Women's Studies,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth rose adams,
-WS,3490,1,Gender and Sexuality,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,diane perpich,
-YDP,3000,400,Youth Development in Society,0.56,0.36,0.04,0.0,0.04,0.0,0.0,0.0,barry garst,
-YDP,3050,400,Theory/Phil of Youth Dev Work,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,edmond patric bowers,
-YDP,3300,1,Designing Effective Youth Prog,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
-YDP,3450,1,Creative Activities for Youth,0.9,0.03,0.07,0.0,0.0,0.0,0.0,0.0,kimberly pea johnson,
-YDP,8000,1,Theories of Youth Development,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,edmond patric bowers,
-YDP,8030,1,Creative & Ethical Leadership,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,barry garst,
-YDP,8050,1,Youth Dev in Context of Family,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
-YDP,8060,2,Youth Dev in Global Society,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ann marie gillard,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1010,1,Survey of Art & Arch History I,0.42,0.45,0.11,0.01,0.01,0.0,0.0,0.0,beth ann lauritis,,AAH-1010,2018
+AAH,2050,1,Art History and Theory I,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,beth ann lauritis,,AAH-2050,2018
+AAH,3050,1,Contemporary Art History,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,,AAH-3050,2018
+ACCT,2010,1,Financial Accounting Concepts,0.09,0.36,0.27,0.02,0.09,0.0,0.0,0.18,lydia lanc schleifer,,ACCT-2010,2018
+ACCT,2010,2,Financial Accounting Concepts,0.28,0.23,0.23,0.13,0.04,0.0,0.0,0.09,emily suzan mccorkle,,ACCT-2010,2018
+ACCT,2010,3,Financial Accounting Concepts,0.33,0.48,0.13,0.08,0.0,0.0,0.0,0.0,emily suzan mccorkle,,ACCT-2010,2018
+ACCT,2010,4,Financial Accounting Concepts,0.36,0.28,0.21,0.04,0.09,0.0,0.0,0.02,annieka philo,,ACCT-2010,2018
+ACCT,2010,5,Financial Accounting Concepts,0.33,0.23,0.19,0.02,0.13,0.0,0.0,0.1,lydia lanc schleifer,,ACCT-2010,2018
+ACCT,2010,6,Financial Accounting Concepts,0.24,0.26,0.29,0.07,0.1,0.0,0.0,0.05,annieka philo,,ACCT-2010,2018
+ACCT,2010,7,Financial Accounting Concepts,0.17,0.4,0.19,0.07,0.05,0.0,0.0,0.12,emily suzan mccorkle,,ACCT-2010,2018
+ACCT,2010,8,Financial Accounting Concepts,0.21,0.35,0.19,0.1,0.04,0.0,0.0,0.1,lydia lanc schleifer,,ACCT-2010,2018
+ACCT,2010,9,Financial Accounting Concepts,0.26,0.41,0.21,0.08,0.0,0.0,0.0,0.05,annieka philo,,ACCT-2010,2018
+ACCT,2010,10,Financial Accounting Concepts,0.3,0.25,0.23,0.05,0.18,0.0,0.0,0.0,emily suzan mccorkle,,ACCT-2010,2018
+ACCT,2010,11,Financial Accounting Concepts,0.16,0.42,0.16,0.05,0.11,0.0,0.0,0.11,charles tegen,,ACCT-2010,2018
+ACCT,2010,12,Financial Accounting Concepts,0.26,0.24,0.29,0.08,0.03,0.0,0.0,0.11,philip maiberger,,ACCT-2010,2018
+ACCT,2010,13,Financial Accounting Concepts,0.23,0.28,0.36,0.05,0.05,0.0,0.0,0.03,lisa whea birtwistle,,ACCT-2010,2018
+ACCT,2010,14,Financial Accounting Concepts,0.37,0.37,0.17,0.07,0.0,0.0,0.0,0.02,lisa whea birtwistle,,ACCT-2010,2018
+ACCT,2010,100,Fin Accounting Concepts (HON),0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,lisa whea birtwistle,True,ACCT-2010,2018
+ACCT,2010,400,Financial Accounting Concepts,0.19,0.43,0.16,0.09,0.07,0.0,0.0,0.06,jeffrey mcmillan,,ACCT-2010,2018
+ACCT,2020,1,Managerial Accounting Concepts,0.14,0.2,0.37,0.03,0.09,0.0,0.0,0.17,henry anderson,,ACCT-2020,2018
+ACCT,2020,2,Managerial Accounting Concepts,0.25,0.45,0.14,0.05,0.02,0.0,0.0,0.09,henry anderson,,ACCT-2020,2018
+ACCT,2020,3,Managerial Accounting Concepts,0.36,0.24,0.18,0.0,0.09,0.0,0.0,0.13,henry anderson,,ACCT-2020,2018
+ACCT,2020,4,Managerial Accounting Concepts,0.19,0.35,0.16,0.22,0.0,0.0,0.0,0.08,brian todd carver,,ACCT-2020,2018
+ACCT,2020,5,Managerial Accounting Concepts,0.24,0.22,0.2,0.07,0.18,0.0,0.0,0.09,brian todd carver,,ACCT-2020,2018
+ACCT,2020,6,Managerial Accounting Concepts,0.11,0.3,0.27,0.09,0.02,0.0,0.0,0.2,brian todd carver,,ACCT-2020,2018
+ACCT,2020,7,Managerial Accounting Concepts,0.25,0.29,0.33,0.04,0.02,0.0,0.0,0.06,phebian davis-culler,,ACCT-2020,2018
+ACCT,2020,400,Managerial Accounting Concepts,0.25,0.36,0.2,0.09,0.04,0.0,0.0,0.06,henry anderson,,ACCT-2020,2018
+ACCT,3030,3,Cost Accounting,0.45,0.37,0.08,0.0,0.08,0.0,0.0,0.02,phebian davis-culler,,ACCT-3030,2018
+ACCT,3030,4,Cost Accounting,0.21,0.28,0.3,0.12,0.07,0.0,0.0,0.02,phebian davis-culler,,ACCT-3030,2018
+ACCT,3110,1,Intermediate Financial Acct I,0.1,0.33,0.25,0.17,0.08,0.0,0.0,0.06,erin michell hawkins,,ACCT-3110,2018
+ACCT,3110,2,Intermediate Financial Acct I,0.16,0.29,0.24,0.13,0.11,0.0,0.0,0.07,erin michell hawkins,,ACCT-3110,2018
+ACCT,3110,3,Intermediate Financial Acct I,0.14,0.44,0.23,0.12,0.02,0.0,0.0,0.05,amy melissa donnelly,,ACCT-3110,2018
+ACCT,3110,4,Intermediate Financial Acct I,0.09,0.55,0.21,0.06,0.02,0.0,0.0,0.06,amy melissa donnelly,,ACCT-3110,2018
+ACCT,3110,400,Intermediate Financial Acct I,0.21,0.35,0.13,0.04,0.08,0.0,0.0,0.19,henry anderson,,ACCT-3110,2018
+ACCT,3120,1,Intermediate Financial Acct II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3120,2018
+ACCT,3120,2,Intermediate Financial Acct II,0.1,0.34,0.37,0.07,0.1,0.0,0.0,0.02,jeremy michae vinson,,ACCT-3120,2018
+ACCT,3120,3,Intermediate Financial Acct II,0.38,0.41,0.21,0.0,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3120,2018
+ACCT,3120,4,Intermediate Financial Acct II,0.35,0.35,0.25,0.03,0.0,0.0,0.0,0.03,jeremy michae vinson,,ACCT-3120,2018
+ACCT,3120,5,Intermediate Financial Acct II,0.26,0.42,0.26,0.0,0.0,0.0,0.0,0.05,terry daniel knause,,ACCT-3120,2018
+ACCT,3120,6,Intermediate Financial Acct II,0.33,0.49,0.18,0.0,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3120,2018
+ACCT,3130,1,Intermediate Fin Acct III,0.1,0.31,0.38,0.17,0.05,0.0,0.0,0.0, russell madray,,ACCT-3130,2018
+ACCT,3130,2,Intermediate Fin Acct III,0.09,0.45,0.33,0.06,0.03,0.0,0.0,0.03, russell madray,,ACCT-3130,2018
+ACCT,3130,3,Intermediate Fin Acct III,0.27,0.37,0.2,0.1,0.05,0.0,0.0,0.02, russell madray,,ACCT-3130,2018
+ACCT,3130,4,Intermediate Fin Acct III,0.27,0.27,0.39,0.05,0.02,0.0,0.0,0.0, russell madray,,ACCT-3130,2018
+ACCT,3220,1,Accounting Information Systems,0.36,0.27,0.25,0.05,0.02,0.0,0.0,0.05,philip maiberger,,ACCT-3220,2018
+ACCT,3220,2,Accounting Information Systems,0.18,0.34,0.24,0.11,0.05,0.0,0.0,0.08,philip maiberger,,ACCT-3220,2018
+ACCT,3220,3,Accounting Information Systems,0.16,0.26,0.34,0.11,0.03,0.0,0.0,0.11,philip maiberger,,ACCT-3220,2018
+ACCT,4040,1,Individual Taxation,0.5,0.29,0.12,0.06,0.03,0.0,0.0,0.0,lisa whea birtwistle,,ACCT-4040,2018
+ACCT,4040,2,Individual Taxation,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2018
+ACCT,4040,3,Individual Taxation,0.57,0.26,0.09,0.06,0.03,0.0,0.0,0.0,sarah martin,,ACCT-4040,2018
+ACCT,4080,1,Retire & Estate Plan,0.37,0.52,0.07,0.0,0.0,0.0,0.0,0.04,john hine,,ACCT-4080,2018
+ACCT,4100,3,Reporting and Mgmt Control Sys,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,robin radtke,,ACCT-4100,2018
+ACCT,4150,1,Auditing,0.2,0.5,0.25,0.05,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-4150,2018
+ACCT,4150,2,Auditing,0.26,0.58,0.11,0.05,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-4150,2018
+ACCT,8510,1,Tax Research,0.07,0.93,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2018
+ACCT,8510,2,Tax Research,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2018
+ACCT,8510,3,Tax Research,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2018
+ACCT,8530,1,Adv Acct Problems,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,ralph edward welton,,ACCT-8530,2018
+ACCT,8530,2,Adv Acct Problems,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8530,2018
+ACCT,8530,3,Adv Acct Problems,0.72,0.25,0.0,0.0,0.0,0.0,0.0,0.03,suzanne pearse,,ACCT-8530,2018
+ACCT,8550,1,Gov't and Nonprofit Accounting,0.86,0.11,0.03,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2018
+ACCT,8550,2,Gov't and Nonprofit Accounting,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2018
+ACCT,8550,3,Gov't and Nonprofit Accounting,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2018
+ACCT,8650,1,Tax & Bus Decisions,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,,ACCT-8650,2018
+ACCT,8720,1,Tax of Flowthroughs,0.32,0.27,0.38,0.0,0.0,0.0,0.0,0.03,thomas dickens,,ACCT-8720,2018
+AGED,1020,1,Freshman Seminar,0.8,0.07,0.07,0.07,0.0,0.0,0.0,0.0,catherin dibenedetto,,AGED-1020,2018
+AGED,2000,1,Agr Appl of Ed Tech,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,,AGED-2000,2018
+AGED,2010,1,Intro to Agric Educ,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2010,2018
+AGED,2040,1,App Ag Calculations,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2040,2018
+AGED,3030,1,Ag Ed Mech Tech,0.4,0.33,0.2,0.07,0.0,0.0,0.0,0.0,alex byrd,,AGED-3030,2018
+AGED,4030,1,Prin Adult/Ext Ed,0.79,0.07,0.07,0.0,0.07,0.0,0.0,0.0,alex byrd,,AGED-4030,2018
+AGM,1010,1,Intro Ag Mech & Bus,0.62,0.28,0.03,0.03,0.05,0.0,0.0,0.0,hunter massey,,AGM-1010,2018
+AGM,2050,1,Prin of Fabrication,0.26,0.48,0.17,0.05,0.05,0.0,0.0,0.0,hunter massey,,AGM-2050,2018
+AGM,2060,1,Machinery Mgt,0.33,0.33,0.2,0.07,0.07,0.0,0.0,0.0,hunter massey,,AGM-2060,2018
+AGM,2210,1,Land Measurements,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,charles privette,,AGM-2210,2018
+AGM,3010,1,Soil Water Conserv,0.45,0.29,0.2,0.04,0.03,0.0,0.0,0.0,calvin sawyer,,AGM-3010,2018
+AGM,4000,1,Seminar in Ag Mech & Business,0.04,0.22,0.4,0.24,0.1,0.0,0.0,0.0,john chastain,,AGM-4000,2018
+AGM,4020,1,Irrigation System Design,0.12,0.41,0.35,0.06,0.06,0.0,0.0,0.0,charles privette,,AGM-4020,2018
+AGM,4050,1,Env Cont in Anim Str,0.11,0.31,0.44,0.13,0.0,0.0,0.0,0.0,john chastain,,AGM-4050,2018
+AGM,4060,1,Mech & Hydraulic Sys,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4060,2018
+AGM,4520,1,Mobile Power,0.37,0.48,0.11,0.04,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4520,2018
+AGM,4600,1,Electrical Systems,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,young jo han,,AGM-4600,2018
+AGRB,2020,1,Agricultural Economics,0.2,0.29,0.24,0.18,0.05,0.0,0.0,0.04,george apperson,,AGRB-2020,2018
+AGRB,2050,1,Agriculture and Society,0.15,0.22,0.3,0.25,0.03,0.0,0.0,0.04,michael vassalos,,AGRB-2050,2018
+AGRB,3020,1,Economics of Farm Management,0.11,0.28,0.27,0.27,0.06,0.0,0.0,0.0,michael vassalos,,AGRB-3020,2018
+AGRB,3080,1,Quant Agribusiness Analysis I,0.27,0.37,0.2,0.1,0.02,0.0,0.0,0.04,lisha zhang,,AGRB-3080,2018
+AGRB,3090,1,Econ of Agricultural Marketing,0.59,0.33,0.04,0.0,0.03,0.0,0.0,0.01,yuliya vale bolotova,,AGRB-3090,2018
+AGRB,3570,1,Natural Resources Economics,0.27,0.23,0.27,0.07,0.07,0.0,0.0,0.09,david brian willis,,AGRB-3570,2018
+AGRB,4090,1,Commodity Futures Markets,0.13,0.26,0.29,0.21,0.11,0.0,0.0,0.0,george apperson,,AGRB-4090,2018
+AGRB,4120,1,Reg Econ Devel Theory & Policy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ronald lamie,,AGRB-4120,2018
+AGRB,4520,1,Agricultural Policy,0.24,0.33,0.24,0.15,0.03,0.0,0.0,0.0,michael vassalos,,AGRB-4520,2018
+AGRB,4600,1,Agricultural Finance,0.36,0.26,0.26,0.13,0.0,0.0,0.0,0.0,lisha zhang,,AGRB-4600,2018
+AL,3440,400,Athletics and Women,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-3440,2018
+AL,3490,400,Principles of Coaching,0.61,0.29,0.07,0.04,0.0,0.0,0.0,0.0,deborah jo cadorette,,AL-3490,2018
+AL,3490,401,Principles of Coaching,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,,AL-3490,2018
+AL,3490,402,Principles of Coaching,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,john plumblee,,AL-3490,2018
+AL,3490,403,Principles of Coaching,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,john plumblee,,AL-3490,2018
+AL,3490,404,Principles of Coaching,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,clyde keith connor,,AL-3490,2018
+AL,3490,407,Principles of Coaching,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,nicholas phi whitrow,,AL-3490,2018
+AL,3490,408,Principles of Coaching,0.56,0.24,0.04,0.04,0.12,0.0,0.0,0.0,nicholas phi whitrow,,AL-3490,2018
+AL,3490,409,Principles of Coaching,0.76,0.12,0.0,0.0,0.12,0.0,0.0,0.0,nicholas phi whitrow,,AL-3490,2018
+AL,3500,400,Sci Basis I/Ex Phy,0.21,0.38,0.21,0.13,0.0,0.0,0.0,0.08,michael godfrey,,AL-3500,2018
+AL,3500,401,Sci Basis I/Ex Phy,0.3,0.35,0.26,0.09,0.0,0.0,0.0,0.0,michael godfrey,,AL-3500,2018
+AL,3510,400,Nat'l Coach Cert Prep for AL,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,,AL-3510,2018
+AL,3530,400,Athletic Injuries,0.14,0.39,0.32,0.11,0.04,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2018
+AL,3530,401,Athletic Injuries,0.28,0.36,0.16,0.08,0.08,0.0,0.0,0.04,isaac sean colbert,,AL-3530,2018
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.58,0.21,0.17,0.0,0.0,0.0,0.0,0.04,clyde keith connor,,AL-3600,2018
+AL,3610,400,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2018
+AL,3620,400,Psychology of Coaching,0.38,0.12,0.35,0.12,0.04,0.0,0.0,0.0,natalie anne carter,,AL-3620,2018
+AL,3620,401,Psychology of Coaching,0.64,0.28,0.04,0.04,0.0,0.0,0.0,0.0,natalie anne carter,,AL-3620,2018
+AL,3620,402,Psychology of Coaching,0.44,0.28,0.16,0.08,0.0,0.0,0.0,0.04,natalie anne carter,,AL-3620,2018
+AL,3740,400,Coaching Football,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,edmond fry,,AL-3740,2018
+AL,3740,401,Coaching Football,0.61,0.09,0.0,0.04,0.04,0.0,0.0,0.22,edmond fry,,AL-3740,2018
+AL,3760,400,Coaching Strength/Conditioning,0.72,0.21,0.0,0.0,0.07,0.0,0.0,0.0,edmond fry,,AL-3760,2018
+AL,3760,401,Coaching Strength/Conditioning,0.81,0.04,0.04,0.0,0.11,0.0,0.0,0.0,edmond fry,,AL-3760,2018
+AL,4380,402,Current Iss in HS Athletics,0.71,0.21,0.0,0.04,0.0,0.0,0.0,0.04,deborah jo cadorette,,AL-4380,2018
+AL,4380,403,Media Relations in AL,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-4380,2018
+AL,4380,408,Officiating in AL,0.57,0.22,0.17,0.04,0.0,0.0,0.0,0.0,clyde keith connor,,AL-4380,2018
+AL,8380,400,Sp Topics in Intercoll Athlet,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,elliott charles,,AL-8380,2018
+AL,8440,400,Surv of Res Mthds in Athletics,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristin kelly frady,,AL-8440,2018
+AL,8440,401,Surv of Res Mthds in Athletics,0.71,0.07,0.14,0.0,0.07,0.0,0.0,0.0,kristin kelly frady,,AL-8440,2018
+AL,8500,400,Principles Strength and Condit,0.74,0.19,0.07,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8500,2018
+AL,8650,401,Mkt and Comm Respon Interc Ath,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-8650,2018
+ANTH,2010,1,Introduction to Anthropology,0.44,0.24,0.18,0.04,0.04,0.0,0.0,0.04,yi wu,,ANTH-2010,2018
+ANTH,2010,2,Introduction to Anthropology,0.35,0.33,0.2,0.05,0.02,0.0,0.0,0.05,yi wu,,ANTH-2010,2018
+ANTH,2010,3,Introduction to Anthropology,0.4,0.49,0.1,0.0,0.0,0.0,0.0,0.01,david markus,,ANTH-2010,2018
+ANTH,2010,4,Introduction to Anthropology,0.3,0.63,0.05,0.0,0.01,0.0,0.0,0.0,david markus,,ANTH-2010,2018
+ANTH,2010,5,Introduction to Anthropology,0.36,0.56,0.01,0.03,0.04,0.0,0.0,0.0,david markus,,ANTH-2010,2018
+ANTH,3320,1,World Archaeology,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,david markus,,ANTH-3320,2018
+ANTH,3510,1,Biological Anthropology,0.37,0.42,0.11,0.05,0.05,0.0,0.0,0.0,lisa rapaport,,ANTH-3510,2018
+ANTH,3530,1,Forensic Anthropology,0.24,0.65,0.0,0.12,0.0,0.0,0.0,0.0,katherine weisensee,,ANTH-3530,2018
+ANTH,4660,1,Evolution of Human Behav,0.4,0.3,0.1,0.2,0.0,0.0,0.0,0.0,lisa rapaport,,ANTH-4660,2018
+ANTH,4960,2,Anth CI: Entrepreneurs in BSHS,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,janie shonta johnson,,ANTH-4960,2018
+ARCH,1010,1,Introduction to Architecture,0.63,0.19,0.04,0.01,0.04,0.0,0.0,0.08,sall hambright-belue,,ARCH-1010,2018
+ARCH,2040,1,Hist of Modern Arch,0.55,0.32,0.12,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-2040,2018
+ARCH,2510,1,Arch Foundations I,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-2510,2018
+ARCH,2510,2,Arch Foundations I,0.14,0.5,0.29,0.0,0.0,0.0,0.0,0.07,robert silance,,ARCH-2510,2018
+ARCH,2510,3,Arch Foundations I,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,dustin grah albright,,ARCH-2510,2018
+ARCH,2510,4,Arch Foundations I,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-2510,2018
+ARCH,2510,5,Arch Foundations I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-2510,2018
+ARCH,2510,6,Arch Foundations I,0.54,0.31,0.08,0.08,0.0,0.0,0.0,0.0,timothy sutherland,,ARCH-2510,2018
+ARCH,2700,1,Structures I,0.52,0.42,0.06,0.0,0.0,0.0,0.0,0.0,dustin grah albright,,ARCH-2700,2018
+ARCH,3500,1,Intro to Urban Contexts,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,,ARCH-3500,2018
+ARCH,3500,2,Intro to Urban Contexts,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-3500,2018
+ARCH,3500,3,Intro to Urban Contexts,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-3500,2018
+ARCH,3500,4,Intro to Urban Contexts,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-3500,2018
+ARCH,3500,5,Intro to Urban Contexts,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-3500,2018
+ARCH,3510,3,Studio Clemson,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,michael carlo kleiss,,ARCH-3510,2018
+ARCH,3510,4,Studio Clemson,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,,ARCH-3510,2018
+ARCH,3540,1,Studio Barcelona,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-3540,2018
+ARCH,4010,1,Architectural Portfolio,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-4010,2018
+ARCH,4010,2,Architectural Portfolio,0.25,0.58,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4010,2018
+ARCH,4010,4,Architectural Portfolio,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,pai liu,,ARCH-4010,2018
+ARCH,4140,2,Design Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-4140,2018
+ARCH,6990,9,Freehand Drawing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,,ARCH-6990,2018
+ARCH,8100,1,Visualization I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,,ARCH-8100,2018
+ARCH,8210,1,Research Methods,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-8210,2018
+ARCH,8360,1,Managing Integr Proj Delivery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,sall hambright-belue,,ARCH-8360,2018
+ARCH,8510,1,Design Studio III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-sop heine,,ARCH-8510,2018
+ARCH,8510,2,Design Studio III,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,santa cruz da franco da,,ARCH-8510,2018
+ARCH,8510,3,Design Studio III,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,,ARCH-8510,2018
+ARCH,8600,1,History/Theory I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-8600,2018
+ARCH,8720,1,Production & Assemb,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,,ARCH-8720,2018
+ARCH,8810,1,Pro Practice Survey,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,katherine schwennsen,,ARCH-8810,2018
+ARCH,8950,1,A+H Studio: Projects,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8950,2018
+ART,1050,1,Foundation Drawing I,0.18,0.18,0.55,0.09,0.0,0.0,0.0,0.0,denise elizabe ayers,,ART-1050,2018
+ART,2070,1,Beginning Painting,0.35,0.18,0.29,0.0,0.0,0.0,0.0,0.18,dustin lee massey,,ART-2070,2018
+ART,2090,1,Beginning Sculpture,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0, joseph rich manson rich,,ART-2090,2018
+ART,2100,5,Art Appreciation,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,angel roche estrella,,ART-2100,2018
+ART,2100,400,Art Appreciation,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0, joseph rich manson rich,,ART-2100,2018
+ART,2110,1,Begin Printmaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mandy lorai ferguson,,ART-2110,2018
+ART,2130,1,Begin Photography,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,amanda denise musick,,ART-2130,2018
+ART,2170,1,Beginning Ceramics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,,ART-2170,2018
+ART,2210,1,Beginning New Media,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,christina nguye hung,,ART-2210,2018
+ART,3050,1,Intermediate Drawing,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,annamarie williams,,ART-3050,2018
+AS,1090,1,Air Force Today I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1090,2018
+AS,1090,2,Air Force Today I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1090,2018
+AS,1090,3,Air Force Today I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1090,2018
+AS,2090,1,Dev of Air Power I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2090,2018
+AS,2090,2,Dev of Air Power I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2090,2018
+AS,2090,3,Dev of Air Power I,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2090,2018
+AS,4090,1,Nat Sec Policy I,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4090,2018
+AS,4090,2,Nat Sec Policy I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4090,2018
+ASL,1010,2,Am Sign Lang I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,,ASL-1010,2018
+ASL,1010,3,Am Sign Lang I,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,,ASL-1010,2018
+ASL,1010,5,Am Sign Lang I,0.79,0.11,0.0,0.05,0.05,0.0,0.0,0.0,dunn kim mar misener mar,,ASL-1010,2018
+ASL,1010,6,Am Sign Lang I,0.58,0.21,0.05,0.0,0.11,0.0,0.0,0.05,jason hurdich,,ASL-1010,2018
+ASL,1020,1,Am Sign Lang I,0.41,0.24,0.29,0.0,0.0,0.0,0.0,0.06,jason hurdich,,ASL-1020,2018
+ASL,1020,2,Am Sign Lang I,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,jason hurdich,,ASL-1020,2018
+ASL,2010,1,Am Sign Lang II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,,ASL-2010,2018
+ASL,2010,3,Am Sign Lang II,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,,ASL-2010,2018
+ASL,2010,4,Am Sign Lang II,0.87,0.07,0.0,0.07,0.0,0.0,0.0,0.0,dunn kim mar misener mar,,ASL-2010,2018
+ASL,2020,1,Am Sign Lang II,0.21,0.43,0.14,0.21,0.0,0.0,0.0,0.0,jason hurdich,,ASL-2020,2018
+ASL,3010,1,Advanced A S L I,0.65,0.18,0.18,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,,ASL-3010,2018
+ASL,3050,1,Deaf Studies,0.83,0.0,0.0,0.06,0.11,0.0,0.0,0.0,jason hurdich,,ASL-3050,2018
+ASL,3490,1,Adv App in Asl,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,,ASL-3490,2018
+ASTR,1010,1,Solar System Astronomy,0.24,0.32,0.31,0.06,0.03,0.0,0.0,0.05,mate adamkovics,,ASTR-1010,2018
+ASTR,1020,1,Stellar Astronomy,0.38,0.28,0.15,0.08,0.05,0.0,0.0,0.06,mark leising,,ASTR-1020,2018
+ASTR,1030,1,Solar Systm Astr Lab,0.74,0.13,0.09,0.0,0.0,0.0,0.0,0.04,mark leising,,ASTR-1030,2018
+ASTR,1030,2,Solar Systm Astr Lab,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,,ASTR-1030,2018
+ASTR,1030,4,Solar Systm Astr Lab,0.4,0.35,0.05,0.0,0.05,0.0,0.0,0.15,mark leising,,ASTR-1030,2018
+ASTR,1030,6,Solar Systm Astr Lab,0.62,0.23,0.04,0.04,0.04,0.0,0.0,0.04,mark leising,,ASTR-1030,2018
+ASTR,1030,7,Solar Systm Astr Lab,0.82,0.09,0.05,0.0,0.0,0.0,0.0,0.05,mark leising,,ASTR-1030,2018
+ASTR,1030,8,Solar Systm Astr Lab,0.54,0.38,0.04,0.04,0.0,0.0,0.0,0.0,mark leising,,ASTR-1030,2018
+ASTR,1030,9,Solar Systm Astr Lab,0.72,0.06,0.06,0.0,0.17,0.0,0.0,0.0,mark leising,,ASTR-1030,2018
+ASTR,1030,10,Solar Systm Astr Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,mark leising,,ASTR-1030,2018
+ASTR,1040,1,Stellar Astr Lab,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,mark leising,,ASTR-1040,2018
+ASTR,1040,2,Stellar Astr Lab,0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,mark leising,,ASTR-1040,2018
+ASTR,1040,4,Stellar Astr Lab,0.43,0.48,0.0,0.0,0.04,0.0,0.0,0.04,mark leising,,ASTR-1040,2018
+ASTR,3020,1,Stellar Astrophysics,0.35,0.41,0.0,0.0,0.06,0.0,0.0,0.18,marco ajello,,ASTR-3020,2018
+ASTR,8300,1,Astroph III:Galactic,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,,ASTR-8300,2018
+AUD,1850,1,Intro to Audio Tech,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-1850,2018
+AUE,6010,1,Vehicle Dynamics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,,AUE-6010,2018
+AUE,8040,699,Autovation for Entrepreneurs,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,,AUE-8040,2018
+AUE,8180,1,"Engine Analysis, Design & Exp",0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8180,2018
+AUE,8190,100,Adv Int Combustion Engine Conc,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-8190,2018
+AUE,8280,1,Driveline/Powertrain,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8280,2018
+AUE,8330,30,Auto Manuf Proc Devl,0.18,0.75,0.0,0.0,0.0,0.0,0.0,0.07,michael mears,,AUE-8330,2018
+AUE,8350,100,Auto Electronics,0.63,0.32,0.01,0.0,0.0,0.0,0.0,0.03,yunyi jia,,AUE-8350,2018
+AUE,8800,2,Vehicle Project Mngt,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,dee ann wood kivett wood,,AUE-8800,2018
+AUE,8810,3,Automotive Systems Overview,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,christiaan paredis,,AUE-8810,2018
+AUE,8870,8,Meth Vehicle Testing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,,AUE-8870,2018
+AVS,1000,1,Orientation to AVS,0.87,0.1,0.01,0.0,0.01,0.0,0.0,0.01,marie owens bolt,,AVS-1000,2018
+AVS,1500,1,Intro Animal Science,0.26,0.3,0.21,0.12,0.08,0.0,0.0,0.03,joseph keit bertrand,,AVS-1500,2018
+AVS,1500,2,Intro Animal Science,0.33,0.17,0.29,0.1,0.1,0.0,0.0,0.02,joseph keit bertrand,,AVS-1500,2018
+AVS,1510,1,Intro Ani Sci Lab,0.48,0.4,0.12,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,,AVS-1510,2018
+AVS,1510,2,Intro Ani Sci Lab,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,,AVS-1510,2018
+AVS,1510,3,Intro Ani Sci Lab,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,,AVS-1510,2018
+AVS,1510,4,Intro Ani Sci Lab,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,alissa moritz,,AVS-1510,2018
+AVS,1510,5,Intro Ani Sci Lab,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,,AVS-1510,2018
+AVS,1510,6,Intro Ani Sci Lab,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,,AVS-1510,2018
+AVS,1510,7,Intro Ani Sci Lab,0.43,0.43,0.1,0.05,0.0,0.0,0.0,0.0,maslyn ann greene,,AVS-1510,2018
+AVS,1510,8,Intro Ani Sci Lab,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,,AVS-1510,2018
+AVS,2040,1,Horse Care Techniques,0.7,0.22,0.05,0.03,0.0,0.0,0.0,0.0,kristine lang vernon,,AVS-2040,2018
+AVS,2060,1,Swine Techniques,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,,AVS-2060,2018
+AVS,3010,1,Anat & Phys Dom Ani,0.54,0.22,0.23,0.01,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2018
+AVS,3010,400,Anat & Phys Dom Ani,0.4,0.35,0.18,0.07,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2018
+AVS,3020,1,Livestk Sel Eval I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,,AVS-3020,2018
+AVS,3100,1,Animal Health,0.62,0.24,0.12,0.0,0.0,0.0,0.0,0.03,celina marce checura,,AVS-3100,2018
+AVS,3700,1,Principles of Animal Nutrition,0.49,0.22,0.21,0.06,0.01,0.0,0.0,0.01,zheng zhou,,AVS-3700,2018
+AVS,3750,1,Applied Animal Nutrition,0.23,0.39,0.29,0.06,0.0,0.0,0.0,0.03,gustavo jose lascano,,AVS-3750,2018
+AVS,4000,2,AVS Professional Development,0.85,0.0,0.08,0.0,0.0,0.0,0.0,0.08,marie owens bolt,,AVS-4000,2018
+AVS,4110,1,Animal Growth and Development,0.49,0.34,0.1,0.05,0.02,0.0,0.0,0.0,susan kay duckett,,AVS-4110,2018
+AVS,4140,1,Basic Immunology,0.4,0.4,0.0,0.1,0.0,0.0,0.0,0.1,farzana ferdous,,AVS-4140,2018
+AVS,4150,1,Contemporary Issues in AVS,0.82,0.14,0.03,0.02,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-4150,2018
+AVS,4160,1,Equine Exercise Phys,0.5,0.45,0.0,0.05,0.0,0.0,0.0,0.0,kristine lang vernon,,AVS-4160,2018
+AVS,4500,1,Sustain Livestock Product Sys,0.09,0.64,0.18,0.09,0.0,0.0,0.0,0.0,matias jose aguerre,,AVS-4500,2018
+AVS,4530,1,Animal Reproduction,0.61,0.32,0.05,0.0,0.02,0.0,0.0,0.0,tiffany wilmoth,,AVS-4530,2018
+AVS,4670,1,Animal Physiology II,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,celina marce checura,,AVS-4670,2018
+AVS,4800,1,Vertebrate Endocrinology,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-4800,2018
+AVS,8200,1,Graduate Seminar,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,,AVS-8200,2018
+BCHM,1030,1,Careers in Bioch/Gen,0.88,0.03,0.06,0.0,0.01,0.0,0.0,0.02,alison ni starr-moss,,BCHM-1030,2018
+BCHM,3010,1,Molecular Biochemistry,0.4,0.29,0.18,0.04,0.07,0.0,0.0,0.02,kerry smith,,BCHM-3010,2018
+BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2018
+BCHM,3040,2,Molecular Biology Laboratory,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2018
+BCHM,3040,3,Molecular Biology Laboratory,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2018
+BCHM,3040,4,Molecular Biology Laboratory,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2018
+BCHM,3040,5,Molecular Biology Laboratory,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2018
+BCHM,3050,1,Essen Elements Bioch,0.25,0.34,0.25,0.08,0.05,0.0,0.0,0.04,debra ragland,,BCHM-3050,2018
+BCHM,3050,2,Essen Elements Bioch,0.39,0.4,0.13,0.04,0.01,0.0,0.0,0.04,debra ragland,,BCHM-3050,2018
+BCHM,4310,1,Physical Approach to Biochem,0.28,0.4,0.25,0.02,0.02,0.0,0.0,0.04,weiguo cao,,BCHM-4310,2018
+BCHM,4330,2,Physical Biochemistry Lab,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,geoffrey ford,,BCHM-4330,2018
+BCHM,4330,4,Physical Biochemistry Lab,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,geoffrey ford,,BCHM-4330,2018
+BCHM,4400,1,Bioinformatics,0.68,0.26,0.0,0.0,0.03,0.0,0.0,0.03,frank alexand feltus,,BCHM-4400,2018
+BCHM,4430,1,Molecular Basis of Disease,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,james morris,,BCHM-4430,2018
+BCHM,8900,1,Euk Path Journal Club,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,kerry smith,,BCHM-8900,2018
+BE,2120,1,Fundamentals of Biosys Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-2120,2018
+BE,3200,1,Principles & Prac of Geomatics,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-3200,2018
+BE,4100,1,Biological Kinetics,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4100,2018
+BE,4280,1,Biochem Engr,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4280,2018
+BE,4750,1,BE Capstone Design,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,,BE-4750,2018
+BIOE,1010,1,Biol for Bioengr,0.47,0.2,0.27,0.0,0.07,0.0,0.0,0.0,vladimir vlad reukov,,BIOE-1010,2018
+BIOE,2010,1,Intro Biomed Engr,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,charles webb,,BIOE-2010,2018
+BIOE,2010,2,Intro Biomed Engr,0.27,0.42,0.18,0.04,0.01,0.0,0.0,0.08,charles webb,,BIOE-2010,2018
+BIOE,3020,1,Biomaterials,0.75,0.17,0.06,0.0,0.0,0.0,0.0,0.02,alexey alex vertegel,,BIOE-3020,2018
+BIOE,3100,1,Engr Analysis of Physiol Proc,0.78,0.2,0.0,0.01,0.0,0.0,0.0,0.0,brian william booth,,BIOE-3100,2018
+BIOE,3200,1,Biomechanics,0.55,0.34,0.09,0.02,0.0,0.0,0.0,0.0,jiro nagatomi,,BIOE-3200,2018
+BIOE,3210,1,Biofluid Mechanics,0.65,0.16,0.16,0.0,0.03,0.0,0.0,0.0,zhi gao,,BIOE-3210,2018
+BIOE,3470,1,Transport Processes in Bioengr,0.44,0.35,0.14,0.03,0.01,0.0,0.0,0.03,renee nicole cottle,,BIOE-3470,2018
+BIOE,3700,1,Bioinst & Imaging,0.58,0.32,0.05,0.01,0.01,0.0,0.0,0.03,delphine dean,,BIOE-3700,2018
+BIOE,4120,1,Orthopaedic Engr and Pathology,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,melinda harman,,BIOE-4120,2018
+BIOE,4400,1,Biopharmaceutical Engineering,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,sarah harcum,,BIOE-4400,2018
+BIOE,4480,1,Tissue Engineering,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,angela ant alexander,,BIOE-4480,2018
+BIOE,6120,1,Orthopaedic Engr & Pathology,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,,BIOE-6120,2018
+BIOE,6350,1,Modeling of Multiphysics Prob,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,,BIOE-6350,2018
+BIOE,8010,1,Bio Materials,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,robert latour,,BIOE-8010,2018
+BIOE,8020,864,Biocompatibility,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,,BIOE-8020,2018
+BIOE,8140,843,Medical Dev Commercialization,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hobey tam,,BIOE-8140,2018
+BIOE,8700,1,Bioinstrumentation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,tong ye,,BIOE-8700,2018
+BIOL,1010,1,Frontiers in Biology I,0.8,0.1,0.08,0.01,0.01,0.0,0.0,0.0,robert edwar ballard,,BIOL-1010,2018
+BIOL,1010,2,Frontiers in Biology I,0.84,0.09,0.05,0.0,0.01,0.0,0.0,0.01,michael childress,,BIOL-1010,2018
+BIOL,1030,1,General Biology I,0.2,0.25,0.28,0.11,0.07,0.0,0.0,0.1,nora espinoza,,BIOL-1030,2018
+BIOL,1030,2,General Biology I,0.22,0.39,0.25,0.07,0.02,0.0,0.0,0.04,william baldwin,,BIOL-1030,2018
+BIOL,1030,3,General Biology I,0.3,0.31,0.24,0.1,0.02,0.0,0.0,0.03,wen chen,,BIOL-1030,2018
+BIOL,1030,4,General Biology I,0.16,0.29,0.31,0.09,0.05,0.0,0.0,0.1,salvatore sparace,,BIOL-1030,2018
+BIOL,1030,5,General Biology I (HON),0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,nora espinoza,True,BIOL-1030,2018
+BIOL,1050,1,General Biology Lab I,0.17,0.48,0.22,0.04,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,2,General Biology Lab I,0.35,0.39,0.09,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,3,General Biology Lab I,0.22,0.39,0.26,0.09,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,4,General Biology Lab I,0.17,0.54,0.08,0.04,0.0,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,5,General Biology Lab I,0.18,0.47,0.24,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,6,General Biology Lab I,0.33,0.48,0.05,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,7,General Biology Lab I,0.21,0.5,0.13,0.04,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,8,General Biology Lab I,0.17,0.5,0.25,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,9,General Biology Lab I,0.18,0.5,0.27,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,10,General Biology Lab I,0.14,0.41,0.18,0.14,0.0,0.0,0.0,0.14,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,11,General Biology Lab I,0.29,0.33,0.29,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,12,General Biology Lab I,0.27,0.36,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,13,General Biology Lab I,0.17,0.63,0.13,0.0,0.08,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,14,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,15,General Biology Lab I,0.29,0.38,0.25,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,16,General Biology Lab I,0.17,0.67,0.08,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,17,General Biology Lab I,0.38,0.38,0.17,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,18,General Biology Lab I,0.33,0.38,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,19,General Biology Lab I,0.18,0.59,0.23,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,20,General Biology Lab I,0.35,0.43,0.17,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,21,General Biology Lab I,0.21,0.63,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,22,General Biology Lab I,0.16,0.42,0.16,0.11,0.11,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,23,General Biology Lab I,0.28,0.22,0.28,0.22,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,24,General Biology Lab I,0.05,0.73,0.14,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,25,General Biology Lab I,0.22,0.57,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,26,General Biology Lab I,0.05,0.45,0.27,0.18,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,28,General Biology Lab I,0.21,0.58,0.13,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,29,General Biology Lab I,0.29,0.54,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,31,General Biology Lab I,0.33,0.5,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,32,General Biology Lab I,0.21,0.42,0.25,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,33,General Biology Lab I,0.5,0.33,0.08,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,34,General Biology Lab I,0.24,0.52,0.14,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,35,General Biology Lab I,0.36,0.55,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,37,General Biology Lab I,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,38,General Biology Lab I,0.33,0.42,0.21,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,39,General Biology Lab I,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,40,General Biology Lab I,0.33,0.54,0.08,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,41,General Biology Lab I,0.21,0.5,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,42,General Biology Lab I,0.29,0.58,0.08,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,43,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,44,General Biology Lab I,0.21,0.54,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,45,General Biology Lab I,0.33,0.54,0.08,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,46,General Biology Lab I,0.24,0.52,0.14,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,47,General Biology Lab I,0.25,0.6,0.1,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1050,48,General Biology Lab I,0.33,0.57,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2018
+BIOL,1090,1,Intro to Life Sci,0.83,0.13,0.03,0.01,0.0,0.0,0.0,0.0,renea chris hardwick,,BIOL-1090,2018
+BIOL,1100,1,Principles of Biology I,0.36,0.35,0.17,0.05,0.03,0.0,0.0,0.03,renea chris hardwick,,BIOL-1100,2018
+BIOL,1100,2,Principles of Biology I (HON),0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,renea chris hardwick,True,BIOL-1100,2018
+BIOL,1100,3,Principles of Biology I,0.27,0.49,0.16,0.04,0.02,0.0,0.0,0.03, christine minor m,,BIOL-1100,2018
+BIOL,1100,4,Principles of Biology I (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,True,BIOL-1100,2018
+BIOL,2000,2,Biology in the News,0.67,0.11,0.17,0.0,0.0,0.0,0.0,0.06,dylan dittrich-reed,,BIOL-2000,2018
+BIOL,2000,3,Biology in the News,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,,BIOL-2000,2018
+BIOL,2000,4,Biology in the News,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,,BIOL-2000,2018
+BIOL,2110,1,Introduction to Toxicology,0.72,0.24,0.0,0.03,0.0,0.0,0.0,0.0,den hurk peter van peter,,BIOL-2110,2018
+BIOL,2220,1,Human Anat and Physiology I,0.26,0.3,0.23,0.09,0.07,0.0,0.0,0.04,john cummings,,BIOL-2220,2018
+BIOL,2220,2,Human Anat and Physiology I,0.25,0.37,0.2,0.09,0.07,0.0,0.0,0.02,john cummings,,BIOL-2220,2018
+BIOL,3030,1,Vertebrate Biology,0.35,0.25,0.19,0.15,0.03,0.0,0.0,0.04,richard blob,,BIOL-3030,2018
+BIOL,3030,2,Vertebrate Biology (HON),0.79,0.17,0.03,0.0,0.0,0.0,0.0,0.0,richard blob,True,BIOL-3030,2018
+BIOL,3040,1,Biology of Plants,0.38,0.35,0.19,0.04,0.01,0.0,0.0,0.03,christina wells,,BIOL-3040,2018
+BIOL,3070,1,Vertebrate Biology Lab,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,2,Vertebrate Biology Lab,0.63,0.16,0.21,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,3,Vertebrate Biology Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,4,Vertebrate Biology Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,5,Vertebrate Biology Lab,0.45,0.4,0.0,0.0,0.0,0.0,0.0,0.15,richard blob,,BIOL-3070,2018
+BIOL,3070,6,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,7,Vertebrate Biology Lab,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,8,Vertebrate Biology Lab,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,9,Vertebrate Biology Lab,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,,BIOL-3070,2018
+BIOL,3070,10,Vertebrate Biology Lab,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,11,Vertebrate Biology Lab,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,12,Vertebrate Biology Lab,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2018
+BIOL,3070,13,Vertebrate Biology Lab,0.3,0.5,0.05,0.05,0.0,0.0,0.0,0.1,richard blob,,BIOL-3070,2018
+BIOL,3080,1,Biology of Plants Practicum,0.5,0.35,0.05,0.1,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2018
+BIOL,3080,2,Biology of Plants Practicum,0.25,0.25,0.35,0.15,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2018
+BIOL,3080,3,Biology of Plants Practicum,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,nathan redding,,BIOL-3080,2018
+BIOL,3080,4,Biology of Plants Practicum,0.33,0.39,0.17,0.11,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2018
+BIOL,3080,5,Biology of Plants Practicum,0.32,0.37,0.32,0.0,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2018
+BIOL,3080,6,Biology of Plants Practicum,0.26,0.26,0.26,0.11,0.0,0.0,0.0,0.11,nathan redding,,BIOL-3080,2018
+BIOL,3150,1,Functional Human Anatomy,0.19,0.41,0.25,0.07,0.02,0.0,0.0,0.05,tamara mcnutt-scott,,BIOL-3150,2018
+BIOL,3200,1,Field Botany,0.16,0.28,0.25,0.09,0.06,0.0,0.0,0.16,robert edwar ballard,,BIOL-3200,2018
+BIOL,3350,1,Evolutionary Biology,0.29,0.38,0.21,0.04,0.05,0.0,0.0,0.02,samantha ann price,,BIOL-3350,2018
+BIOL,3510,1,Biological Anthropology,0.53,0.41,0.0,0.06,0.0,0.0,0.0,0.0,lisa rapaport,,BIOL-3510,2018
+BIOL,3530,1,Forensic Anthropology,0.35,0.5,0.1,0.05,0.0,0.0,0.0,0.0,katherine weisensee,,BIOL-3530,2018
+BIOL,4140,1,Basic Immunology,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,yanzhang wei,,BIOL-4140,2018
+BIOL,4200,1,Neurobiology,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4200,2018
+BIOL,4250,1,Introductory Mycology,0.34,0.41,0.19,0.05,0.02,0.0,0.0,0.0,julia louis kerrigan,,BIOL-4250,2018
+BIOL,4260,1,Mycology Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,julia louis kerrigan,,BIOL-4260,2018
+BIOL,4260,2,Mycology Practicum,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,julia louis kerrigan,,BIOL-4260,2018
+BIOL,4400,1,Developmental Animal Biology,0.38,0.28,0.25,0.06,0.01,0.0,0.0,0.01,kara elizabet powder,,BIOL-4400,2018
+BIOL,4430,2,Freshwater Ecology,0.19,0.48,0.19,0.03,0.03,0.0,0.0,0.06,john jenkins hains,,BIOL-4430,2018
+BIOL,4560,1,Medical and Vet Parasitology,0.67,0.25,0.06,0.0,0.0,0.0,0.0,0.03,wilbur kears milhous,,BIOL-4560,2018
+BIOL,4610,1,Cell Biology,0.28,0.45,0.2,0.05,0.0,0.0,0.0,0.02,susan caroli chapman,,BIOL-4610,2018
+BIOL,4610,2,Cell Biology (HON),0.65,0.26,0.06,0.03,0.0,0.0,0.0,0.0,susan caroli chapman,True,BIOL-4610,2018
+BIOL,4620,1,Cell Biology Lab (Lec),0.64,0.32,0.0,0.04,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,2,Cell Biology Lab (Lec),0.67,0.3,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,3,Cell Biology Lab (Lec),0.64,0.29,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,4,Cell Biology Lab (Lec),0.61,0.29,0.04,0.07,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,5,Cell Biology Lab (Lec),0.7,0.22,0.0,0.04,0.04,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,6,Cell Biology Lab (Lec),0.52,0.37,0.0,0.0,0.0,0.0,0.0,0.11,xianzhong yu,,BIOL-4620,2018
+BIOL,4670,1,Principles of Hematology,0.8,0.11,0.0,0.03,0.0,0.0,0.0,0.06,vincent gallicchio,,BIOL-4670,2018
+BIOL,4930,5,Sr Sem: Symbiosis,0.8,0.07,0.13,0.0,0.0,0.0,0.0,0.0,matthew turnbull,,BIOL-4930,2018
+BIOL,8120,1,Seminar,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,michael sears,,BIOL-8120,2018
+BIOL,8200,1,Community Ecology,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,saara dewalt,,BIOL-8200,2018
+BIOL,8400,1,Understanding Biological Inq,0.88,0.01,0.02,0.0,0.04,0.0,0.0,0.06,michael childress,,BIOL-8400,2018
+BIOL,8420,1,Understand Cellular Processes,0.67,0.24,0.08,0.0,0.02,0.0,0.0,0.0,patricia leota tate,,BIOL-8420,2018
+BIOL,8440,1,Understanding the Human Body,0.65,0.27,0.07,0.0,0.0,0.0,0.0,0.01,william baldwin,,BIOL-8440,2018
+BIOL,8710,2,MCDB Grad Core,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,lisa bain,,BIOL-8710,2018
+BUS,1010,1,Business Foundations,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,william erne tumblin,,BUS-1010,2018
+BUS,1010,2,Business Foundations,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,william erne tumblin,,BUS-1010,2018
+BUS,1010,3,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william erne tumblin,,BUS-1010,2018
+BUS,1010,4,Business Foundations,0.35,0.53,0.06,0.0,0.06,0.0,0.0,0.0,mary ann  prater m,,BUS-1010,2018
+BUS,1010,5,Business Foundations,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,mary ann  prater m,,BUS-1010,2018
+BUS,1010,6,Business Foundations,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,mary ann  prater m,,BUS-1010,2018
+BUS,1010,7,Business Foundations,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,william erne tumblin,,BUS-1010,2018
+BUS,1010,8,Business Foundations,0.11,0.39,0.28,0.11,0.11,0.0,0.0,0.0,william erne tumblin,,BUS-1010,2018
+BUS,1010,9,Business Foundations,0.22,0.44,0.11,0.17,0.0,0.0,0.0,0.06,william erne tumblin,,BUS-1010,2018
+BUS,1010,10,Business Foundations,0.42,0.37,0.11,0.0,0.05,0.0,0.0,0.05,william erne tumblin,,BUS-1010,2018
+BUS,1010,11,Business Foundations,0.32,0.42,0.11,0.0,0.11,0.0,0.0,0.05,william erne tumblin,,BUS-1010,2018
+BUS,1010,15,Business Foundations,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2018
+BUS,1010,16,Business Foundations,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2018
+BUS,1010,17,Business Foundations,0.36,0.5,0.0,0.0,0.07,0.0,0.0,0.07,donna mccubbin,,BUS-1010,2018
+BUS,1010,18,Business Foundations,0.11,0.5,0.28,0.06,0.06,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2018
+BUS,1010,19,Business Foundations,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,donna mccubbin,,BUS-1010,2018
+BUS,1010,20,Business Foundations,0.21,0.47,0.21,0.0,0.11,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2018
+BUS,1010,23,Business Foundations,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2018
+BUS,1010,24,Business Foundations,0.42,0.32,0.16,0.0,0.05,0.0,0.0,0.05,sandy edge,,BUS-1010,2018
+BUS,1010,25,Business Foundations,0.39,0.44,0.06,0.06,0.0,0.0,0.0,0.06,sandy edge,,BUS-1010,2018
+BUS,1010,26,Business Foundations,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,iulio edward barr de barr,,BUS-1010,2018
+BUS,1010,27,Business Foundations,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,iulio edward barr de barr,,BUS-1010,2018
+BUS,1010,28,Business Foundations,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,iulio edward barr de barr,,BUS-1010,2018
+BUS,1010,29,Business Foundations,0.15,0.32,0.21,0.09,0.11,0.0,0.0,0.13,mary ann  prater m,,BUS-1010,2018
+BUS,1010,30,Business Foundations,0.11,0.59,0.26,0.02,0.02,0.0,0.0,0.0,mary ann  prater m,,BUS-1010,2018
+BUS,1010,31,Business Foundations,0.29,0.53,0.06,0.06,0.0,0.0,0.0,0.06,mary ann  prater m,,BUS-1010,2018
+BUS,1010,33,Business Foundations,0.2,0.47,0.1,0.07,0.03,0.0,0.0,0.13,donna mccubbin,,BUS-1010,2018
+BUS,1010,34,Business Foundations,0.37,0.32,0.32,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2018
+BUS,1010,35,Business Foundations,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,william erne tumblin,,BUS-1010,2018
+BUS,1010,37,Business Foundations,0.44,0.31,0.19,0.06,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2018
+CE,1990,20,Cr Inq in Civil Engineering,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,bradley putman,,CE-1990,2018
+CE,2010,1,Statics,0.34,0.26,0.18,0.04,0.15,0.0,0.0,0.03,qiushi chen,,CE-2010,2018
+CE,2010,2,Statics,0.1,0.4,0.26,0.02,0.02,0.0,0.0,0.19,melissa sternhagen,,CE-2010,2018
+CE,2010,3,Statics,0.18,0.48,0.2,0.07,0.02,0.0,0.0,0.05,md nasimul chowdhury,,CE-2010,2018
+CE,2010,4,Statics,0.11,0.3,0.21,0.12,0.09,0.0,0.0,0.17,melissa sternhagen,,CE-2010,2018
+CE,2010,5,Statics,0.24,0.27,0.22,0.07,0.07,0.0,0.0,0.12,qiushi chen,,CE-2010,2018
+CE,2010,6,Statics,0.1,0.15,0.2,0.15,0.15,0.0,0.0,0.25,melissa sternhagen,,CE-2010,2018
+CE,2010,7,Statics (HON),0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,melissa sternhagen,True,CE-2010,2018
+CE,2010,8,Statics,0.09,0.34,0.36,0.07,0.02,0.0,0.0,0.11,md nasimul chowdhury,,CE-2010,2018
+CE,2060,1,Structural Mechanics,0.07,0.25,0.4,0.17,0.07,0.0,0.0,0.05,melissa sternhagen,,CE-2060,2018
+CE,2080,1,Dynamics,0.11,0.44,0.37,0.06,0.03,0.0,0.0,0.0,md nasimul chowdhury,,CE-2080,2018
+CE,2550,1,Geomatics,0.3,0.34,0.3,0.01,0.03,0.0,0.0,0.01,wayne sarasua,,CE-2550,2018
+CE,3010,1,Structural Analysis,0.34,0.29,0.26,0.03,0.09,0.0,0.0,0.0,stephen csernak,,CE-3010,2018
+CE,3010,2,Structural Analysis,0.35,0.4,0.23,0.03,0.0,0.0,0.0,0.0,brandon ross,,CE-3010,2018
+CE,3110,1,Transportation Engr,0.47,0.45,0.05,0.0,0.03,0.0,0.0,0.0,jennifer ogle,,CE-3110,2018
+CE,3210,1,Geotechnical Engineering,0.38,0.45,0.13,0.05,0.0,0.0,0.0,0.0,shweta shrestha,,CE-3210,2018
+CE,3310,1,Constr Engr & Mgmnt,0.44,0.41,0.09,0.05,0.0,0.0,0.0,0.0,james burati,,CE-3310,2018
+CE,3410,1,Intro to Fluid Mech,0.36,0.52,0.11,0.02,0.0,0.0,0.0,0.0,nigel gregory kaye,,CE-3410,2018
+CE,3410,2,Intro to Fluid Mech,0.28,0.36,0.22,0.04,0.08,0.0,0.0,0.02,abdul khan,,CE-3410,2018
+CE,3420,1,Hydraulics & Hydro,0.47,0.38,0.05,0.02,0.04,0.0,0.0,0.04,ashok mishra,,CE-3420,2018
+CE,3510,1,Civil Engineering Materials,0.48,0.44,0.06,0.02,0.0,0.0,0.0,0.0,amir esmaeilpoursaee,,CE-3510,2018
+CE,3510,2,Civil Engineering Materials,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0,amir esmaeilpoursaee,,CE-3510,2018
+CE,3520,1,Econ Eval of Proj,0.4,0.38,0.13,0.02,0.04,0.0,0.0,0.04,zoraya roldan rockow,,CE-3520,2018
+CE,4020,1,Reinfor Con Design,0.28,0.51,0.15,0.02,0.02,0.0,0.0,0.02,brandon ross,,CE-4020,2018
+CE,4060,1,Struct Steel Design,0.38,0.35,0.24,0.03,0.0,0.0,0.0,0.0,stephen csernak,,CE-4060,2018
+CE,4100,1,Traffic Engr Oper,0.27,0.32,0.23,0.05,0.05,0.0,0.0,0.09,wayne sarasua,,CE-4100,2018
+CE,4240,1,Earth Slopes & Struc,0.35,0.48,0.13,0.05,0.0,0.0,0.0,0.0,nadaraj ravichandran,,CE-4240,2018
+CE,4390,1,Con Eqpmt Sel & Main,0.49,0.38,0.11,0.03,0.0,0.0,0.0,0.0,james burati,,CE-4390,2018
+CE,4470,1,Stormwater Managemnt,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,earl hayter,,CE-4470,2018
+CE,4560,1,Pave Design & Constr,0.47,0.41,0.09,0.0,0.0,0.0,0.0,0.03,bradley putman,,CE-4560,2018
+CE,4590,1,Capstone Design Proj,0.46,0.38,0.11,0.03,0.0,0.0,0.0,0.03,stephen csernak,,CE-4590,2018
+CE,4820,1,Groundwater & Contam Transport,0.3,0.3,0.1,0.0,0.0,0.0,0.0,0.3,lawrence murdoch,,CE-4820,2018
+CE,4910,1,BIM in Construction Management,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4910,2018
+CE,6100,1,Traffic Engr Oper,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,wayne sarasua,,CE-6100,2018
+CE,6240,1,Earth Slopes & Struc,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,nadaraj ravichandran,,CE-6240,2018
+CE,6390,1,Con Eqpmt Sel & Main,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james burati,,CE-6390,2018
+CE,8020,1,Adv R/C Design,0.38,0.31,0.23,0.0,0.0,0.0,0.0,0.08,thomas edfor cousins,,CE-8020,2018
+CE,8220,1,Foundation Engr,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,nadaraj ravichandran,,CE-8220,2018
+CE,8260,1,Prop of Concrete,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,prasada ra rangaraju,,CE-8260,2018
+CE,8460,1,Flow in Open Chnls,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,abdul khan,,CE-8460,2018
+CE,8480,500,Risk Analyt in Supply Chains,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott jennings mason,,CE-8480,2018
+CE,8540,1,Travl Demnd Forecast,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,pamela murray-tuite,,CE-8540,2018
+CE,8930,3,Risk Assessment,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-8930,2018
+CES,1900,101,CI - LEAD Forward I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,steve richar sanders,,CES-1900,2018
+CES,1900,500,CI - PEER/WISE Exp Seminar,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jordon antho gilmore,,CES-1900,2018
+CH,1010,1,General Chemistry,0.23,0.31,0.22,0.11,0.1,0.0,0.0,0.04,william we mcwhorter,,CH-1010,2018
+CH,1010,2,General Chemistry,0.23,0.34,0.23,0.1,0.03,0.0,0.0,0.06,laura lanni,,CH-1010,2018
+CH,1010,3,General Chemistry,0.13,0.36,0.35,0.05,0.06,0.0,0.0,0.06,olt geiculescu,,CH-1010,2018
+CH,1010,4,General Chemistry,0.19,0.33,0.19,0.12,0.1,0.0,0.0,0.07,william we mcwhorter,,CH-1010,2018
+CH,1010,5,General Chemistry,0.28,0.32,0.19,0.12,0.06,0.0,0.0,0.03,steven lo pellizzeri,,CH-1010,2018
+CH,1010,6,General Chemistry,0.2,0.32,0.3,0.07,0.07,0.0,0.0,0.04,elliot ennis,,CH-1010,2018
+CH,1010,7,General Chemistry,0.26,0.32,0.22,0.13,0.06,0.0,0.0,0.02,jacob schroeder,,CH-1010,2018
+CH,1010,8,General Chemistry,0.33,0.28,0.23,0.07,0.04,0.0,0.0,0.05,princess mycia cox,,CH-1010,2018
+CH,1010,9,General Chemistry,0.2,0.29,0.29,0.11,0.08,0.0,0.0,0.04,dennis taylor,,CH-1010,2018
+CH,1010,10,General Chemistry,0.3,0.27,0.21,0.07,0.12,0.0,0.0,0.03,thomas hickman,,CH-1010,2018
+CH,1010,11,General Chemistry,0.28,0.34,0.21,0.1,0.03,0.0,0.0,0.03,steven lo pellizzeri,,CH-1010,2018
+CH,1010,12,General Chemistry,0.27,0.35,0.24,0.06,0.04,0.0,0.0,0.03,elliot ennis,,CH-1010,2018
+CH,1010,13,General Chemistry,0.19,0.27,0.26,0.18,0.05,0.0,0.0,0.05,dennis taylor,,CH-1010,2018
+CH,1010,50,General Chemistry,0.58,0.29,0.06,0.06,0.0,0.0,0.0,0.0,tania issa houjeiry,,CH-1010,2018
+CH,1010,51,General Chemistry (HON),0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,True,CH-1010,2018
+CH,1010,52,General Chemistry (HON),0.71,0.23,0.06,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True,CH-1010,2018
+CH,1010,201,General Chemistry,0.21,0.44,0.25,0.06,0.04,0.0,0.0,0.01,laura lanni,,CH-1010,2018
+CH,1010,202,General Chemistry,0.29,0.44,0.19,0.04,0.02,0.0,0.0,0.03,tania issa houjeiry,,CH-1010,2018
+CH,1010,203,General Chemistry,0.19,0.45,0.22,0.06,0.03,0.0,0.0,0.05,william we mcwhorter,,CH-1010,2018
+CH,1010,204,General Chemistry,0.31,0.34,0.24,0.09,0.01,0.0,0.0,0.02,princess mycia cox,,CH-1010,2018
+CH,1020,1,General Chemistry,0.33,0.23,0.22,0.12,0.05,0.0,0.0,0.05,stephen schvaneveldt,,CH-1020,2018
+CH,1020,2,General Chemistry,0.33,0.27,0.19,0.14,0.04,0.0,0.0,0.02,stephen schvaneveldt,,CH-1020,2018
+CH,1020,3,General Chemistry,0.29,0.29,0.22,0.09,0.02,0.0,0.0,0.08,stephen schvaneveldt,,CH-1020,2018
+CH,1020,400,General Chemistry,0.09,0.21,0.23,0.26,0.11,0.0,0.0,0.11,stephen schvaneveldt,,CH-1020,2018
+CH,1050,1,Chemistry in Context I,0.19,0.46,0.29,0.03,0.02,0.0,0.0,0.01,elliot ennis,,CH-1050,2018
+CH,1050,2,Chemistry in Context I,0.16,0.57,0.15,0.05,0.01,0.0,0.0,0.06,elliot ennis,,CH-1050,2018
+CH,2010,1,Survey of Organic Chemistry,0.3,0.37,0.09,0.06,0.13,0.0,0.0,0.05,thomas hickman,,CH-2010,2018
+CH,2010,2,Survey of Organic Chemistry,0.46,0.32,0.15,0.08,0.0,0.0,0.0,0.0,thomas hickman,,CH-2010,2018
+CH,2020,2,Surv of Organic Chemistry Lab,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,,CH-2020,2018
+CH,2020,3,Surv of Organic Chemistry Lab,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,james nelson plampin,,CH-2020,2018
+CH,2020,9,Surv of Organic Chemistry Lab,0.82,0.0,0.05,0.0,0.09,0.0,0.0,0.05,james nelson plampin,,CH-2020,2018
+CH,2230,1,Organic Chemistry,0.08,0.2,0.25,0.14,0.2,0.0,0.0,0.13,modi wetzler,,CH-2230,2018
+CH,2230,2,Organic Chemistry,0.18,0.26,0.24,0.17,0.06,0.0,0.0,0.1,modi wetzler,,CH-2230,2018
+CH,2230,3,Organic Chemistry,0.43,0.25,0.15,0.08,0.03,0.0,0.0,0.06,tania issa houjeiry,,CH-2230,2018
+CH,2230,4,Organic Chemistry,0.35,0.27,0.18,0.09,0.04,0.0,0.0,0.07,laura lanni,,CH-2230,2018
+CH,2230,5,Organic Chemistry,0.55,0.26,0.13,0.03,0.02,0.0,0.0,0.03,rhett smith,,CH-2230,2018
+CH,2230,6,Organic Chemistry,0.26,0.23,0.12,0.15,0.15,0.0,0.0,0.09,rhett smith,,CH-2230,2018
+CH,2230,7,Organic Chemistry,0.21,0.24,0.23,0.08,0.1,0.0,0.0,0.16,sourav saha,,CH-2230,2018
+CH,2240,1,Organic Chemistry,0.22,0.32,0.24,0.13,0.09,0.0,0.0,0.01,jacob schroeder,,CH-2240,2018
+CH,2240,2,Organic Chemistry,0.33,0.29,0.2,0.09,0.06,0.0,0.0,0.03,jacob schroeder,,CH-2240,2018
+CH,2270,1,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2270,2018
+CH,2270,2,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2018
+CH,2270,5,Organic Chem Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,,CH-2270,2018
+CH,2270,6,Organic Chem Lab,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2018
+CH,2270,7,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,,CH-2270,2018
+CH,2270,8,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,,CH-2270,2018
+CH,2270,13,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,,CH-2270,2018
+CH,2270,15,Organic Chem Lab,0.78,0.11,0.0,0.06,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2270,2018
+CH,2270,17,Organic Chem Lab,0.47,0.26,0.0,0.05,0.0,0.0,0.0,0.21,james nelson plampin,,CH-2270,2018
+CH,2270,18,Organic Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,,CH-2270,2018
+CH,2270,19,Organic Chem Lab,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2018
+CH,2270,20,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2018
+CH,2270,22,Organic Chem Lab,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2270,2018
+CH,2270,23,Organic Chem Lab,0.84,0.05,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,,CH-2270,2018
+CH,2270,24,Organic Chem Lab,0.67,0.11,0.11,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2018
+CH,2270,25,Organic Chem Lab,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,,CH-2270,2018
+CH,2270,26,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,,CH-2270,2018
+CH,2270,27,Organic Chem Lab,0.84,0.0,0.0,0.0,0.05,0.0,0.0,0.11,james nelson plampin,,CH-2270,2018
+CH,2270,28,Organic Chem Lab,0.78,0.06,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,,CH-2270,2018
+CH,2270,29,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2018
+CH,2270,30,Organic Chem Lab,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,,CH-2270,2018
+CH,2270,31,Organic Chem Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,,CH-2270,2018
+CH,2270,32,Organic Chem Lab,0.69,0.06,0.0,0.0,0.0,0.0,0.0,0.25,james nelson plampin,,CH-2270,2018
+CH,2270,33,Organic Chem Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,,CH-2270,2018
+CH,2270,35,Organic Chem Lab,0.63,0.06,0.13,0.0,0.06,0.0,0.0,0.13,james nelson plampin,,CH-2270,2018
+CH,2270,36,Organic Chem Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,james nelson plampin,,CH-2270,2018
+CH,2270,37,Organic Chem Lab,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,,CH-2270,2018
+CH,2270,39,Organic Chem Lab,0.73,0.08,0.0,0.0,0.0,0.0,0.0,0.19,james nelson plampin,,CH-2270,2018
+CH,2270,40,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,,CH-2270,2018
+CH,2280,1,Organic Chem Lab,0.84,0.05,0.0,0.05,0.0,0.0,0.0,0.05,james nelson plampin,,CH-2280,2018
+CH,2280,2,Organic Chem Lab,0.82,0.05,0.0,0.05,0.05,0.0,0.0,0.05,james nelson plampin,,CH-2280,2018
+CH,2280,4,Organic Chem Lab,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,james nelson plampin,,CH-2280,2018
+CH,2280,6,Organic Chem Lab,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,james nelson plampin,,CH-2280,2018
+CH,2280,8,Organic Chem Lab,0.88,0.04,0.0,0.0,0.04,0.0,0.0,0.04,james nelson plampin,,CH-2280,2018
+CH,2280,9,Organic Chem Lab,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,james nelson plampin,,CH-2280,2018
+CH,3130,1,Quantitative Analys,0.37,0.23,0.27,0.07,0.03,0.0,0.0,0.03,olt geiculescu,,CH-3130,2018
+CH,3150,1,Quant Analysis Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,perez carlos garcia,,CH-3150,2018
+CH,3150,2,Quant Analysis Lab,0.45,0.18,0.18,0.0,0.18,0.0,0.0,0.0,perez carlos garcia,,CH-3150,2018
+CH,3300,1,Intro to Phys Chem,0.45,0.39,0.09,0.03,0.0,0.0,0.0,0.03,brian dominy,,CH-3300,2018
+CH,3310,1,Physical Chemistry,0.35,0.31,0.23,0.08,0.04,0.0,0.0,0.0,steven stuart,,CH-3310,2018
+CH,3320,1,Physical Chemistry,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,arkady kholodenko,,CH-3320,2018
+CH,3390,1,Physical Chem Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2018
+CH,3390,2,Physical Chem Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2018
+CH,3390,3,Physical Chem Lab,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,princess mycia cox,,CH-3390,2018
+CH,3390,5,Physical Chem Lab,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2018
+CH,3410,1,Introduction to Research,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,stephen creager,,CH-3410,2018
+CH,4010,1,Organometallic Chemistry,0.74,0.23,0.0,0.0,0.0,0.0,0.0,0.03,andrew greg tennyson,,CH-4010,2018
+CH,4020,1,Inorganic Chemistry,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,joseph kolis,,CH-4020,2018
+CH,6020,1,Inorganic Chemistry,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph kolis,,CH-6020,2018
+CH,8070,1,Chem Trans Elem,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,julia brumaghim,,CH-8070,2018
+CH,8090,1,Chem App/X-Ray Cryst,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,,CH-8090,2018
+CH,8210,1,Organic Chem I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ya-ping sun,,CH-8210,2018
+CH,8300,1,Fund Phys Chem,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,,CH-8300,2018
+CH,8510,3,Grad Student Seminar,0.83,0.15,0.0,0.0,0.0,0.0,0.0,0.03,joseph stua thrasher,,CH-8510,2018
+CHE,2110,1,Mass and Energy Balances,0.32,0.29,0.35,0.03,0.0,0.0,0.0,0.0,karen ann high,,CHE-2110,2018
+CHE,2110,2,Mass and Energy Balances,0.22,0.25,0.31,0.11,0.07,0.0,0.0,0.04,mark roberts,,CHE-2110,2018
+CHE,3210,1,Ch E Thermo II,0.14,0.21,0.3,0.24,0.1,0.0,0.0,0.02,sapna sarupria,,CHE-3210,2018
+CHE,3300,1,Mass Trans & Seprtn,0.23,0.16,0.3,0.2,0.11,0.0,0.0,0.0,mark thies,,CHE-3300,2018
+CHE,4070,1,Unit Op Lab II,0.18,0.53,0.29,0.0,0.0,0.0,0.0,0.0,christopher norfolk,,CHE-4070,2018
+CHE,4310,1,Process Design I,0.31,0.57,0.11,0.01,0.0,0.0,0.0,0.0,david bruce,,CHE-4310,2018
+CHE,4500,1,Chem Reaction Engr,0.4,0.41,0.17,0.02,0.0,0.0,0.0,0.0,rachel getman,,CHE-4500,2018
+CHE,8030,1,Advanced Transport,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,eric mikel davis,,CHE-8030,2018
+CHE,8040,1,Ch E Thermodynamics,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,joseph scott,,CHE-8040,2018
+CHE,8050,1,Ch E Kinetics,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,mark alan blenner,,CHE-8050,2018
+CHE,8450,4,Systems Biology & Pharmacology,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,marc russ birtwistle,,CHE-8450,2018
+CHIN,1010,2,Elementary Chinese,0.27,0.33,0.2,0.0,0.0,0.0,0.0,0.2,ling rao,,CHIN-1010,2018
+CHIN,2010,1,Intermediate Chinese,0.55,0.27,0.0,0.09,0.0,0.0,0.0,0.09,ling rao,,CHIN-2010,2018
+CHIN,4010,1,Pre-Modern Chinese Literature,0.33,0.38,0.13,0.03,0.05,0.0,0.0,0.1,yanming an,,CHIN-4010,2018
+COM,1500,1,Intro to Human Communication,0.72,0.24,0.01,0.0,0.01,0.0,0.0,0.01,daniel leland fecher,,COM-1500,2018
+COM,1500,2,Intro to Human Communication,0.64,0.26,0.05,0.01,0.02,0.0,0.0,0.03,daniel leland fecher,,COM-1500,2018
+COM,1500,3,Intro to Human Communication,0.75,0.21,0.02,0.01,0.01,0.0,0.0,0.01,daniel leland fecher,,COM-1500,2018
+COM,1500,4,Intro to Human Communication,0.64,0.24,0.06,0.02,0.03,0.0,0.0,0.01,marianne herr glaser,,COM-1500,2018
+COM,1500,5,Intro to Human Communication,0.65,0.26,0.04,0.02,0.0,0.0,0.0,0.02,marianne herr glaser,,COM-1500,2018
+COM,1500,6,Intro to Human Communication,0.53,0.33,0.09,0.0,0.04,0.0,0.0,0.01,marianne herr glaser,,COM-1500,2018
+COM,1500,7,Intro to Human Communication,0.55,0.44,0.01,0.0,0.0,0.0,0.0,0.0,daniel leland fecher,,COM-1500,2018
+COM,2010,1,Intr to Comm Studies,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,,COM-2010,2018
+COM,2010,2,Intr to Comm Studies,0.67,0.27,0.03,0.03,0.0,0.0,0.0,0.0,john steven  spinda w,,COM-2010,2018
+COM,2030,1,Mass Communication Theory,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-2030,2018
+COM,2110,1,Qual Comm Research Methods,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-2110,2018
+COM,2110,2,Qual Comm Research Methods,0.58,0.21,0.16,0.05,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-2110,2018
+COM,2500,1,Public Speaking,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2018
+COM,2500,3,Public Speaking,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,caitlin baker,,COM-2500,2018
+COM,2500,5,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2018
+COM,2500,6,Public Speaking,0.47,0.37,0.0,0.11,0.0,0.0,0.0,0.05,vanessa anne condon,,COM-2500,2018
+COM,2500,7,Public Speaking,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,sara grumble crocker,,COM-2500,2018
+COM,2500,8,Public Speaking,0.53,0.26,0.05,0.05,0.05,0.0,0.0,0.05,sara grumble crocker,,COM-2500,2018
+COM,2500,9,Public Speaking,0.44,0.28,0.06,0.06,0.06,0.0,0.0,0.11,sara grumble crocker,,COM-2500,2018
+COM,2500,10,Public Speaking,0.56,0.11,0.28,0.0,0.06,0.0,0.0,0.0,sara grumble crocker,,COM-2500,2018
+COM,2500,11,Public Speaking,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,alyssa christi davis,,COM-2500,2018
+COM,2500,12,Public Speaking,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,alyssa christi davis,,COM-2500,2018
+COM,2500,13,Public Speaking,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christi davis,,COM-2500,2018
+COM,2500,14,Public Speaking,0.78,0.06,0.06,0.0,0.0,0.0,0.0,0.11,pauline matthey,,COM-2500,2018
+COM,2500,15,Public Speaking,0.63,0.16,0.0,0.05,0.0,0.0,0.0,0.16,pauline matthey,,COM-2500,2018
+COM,2500,16,Public Speaking,0.59,0.35,0.0,0.0,0.06,0.0,0.0,0.0,pauline matthey,,COM-2500,2018
+COM,2500,17,Public Speaking,0.35,0.41,0.06,0.0,0.12,0.0,0.0,0.06,pauline matthey,,COM-2500,2018
+COM,2500,18,Public Speaking,0.47,0.42,0.0,0.05,0.0,0.0,0.0,0.05,rachelle lei beckner,,COM-2500,2018
+COM,2500,19,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,,COM-2500,2018
+COM,2500,20,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,,COM-2500,2018
+COM,2500,29,Public Speaking,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jumah patricia taweh,,COM-2500,2018
+COM,2500,30,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,,COM-2500,2018
+COM,2500,400,Public Speaking,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,alexis zachary davis,,COM-2500,2018
+COM,2500,401,Public Speaking,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,,COM-2500,2018
+COM,2500,403,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,,COM-2500,2018
+COM,3080,1,Public Comm & Pop Culture,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3080,2018
+COM,3080,2,Public Comm & Pop Culture,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3080,2018
+COM,3080,3,Public Comm & Pop Culture,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,,COM-3080,2018
+COM,3240,1,"Communication, Sport & Society",0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,,COM-3240,2018
+COM,3240,2,"Communication, Sport & Society",0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,,COM-3240,2018
+COM,3250,1,Survey of Sports Communication,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,,COM-3250,2018
+COM,3260,1,Pr in Sports,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2018
+COM,3260,3,Pr in Sports,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,,COM-3260,2018
+COM,3270,1,Sports Media Criticism,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,,COM-3270,2018
+COM,3550,1,Principles of Public Relations,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,meghnaa tallapragada,,COM-3550,2018
+COM,3560,1,Crisis Communication,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,andrew stephen pyle,,COM-3560,2018
+COM,3570,1,Public Relations Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3570,2018
+COM,3640,1,Organizational Comm,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,kristen elai okamoto,,COM-3640,2018
+COM,3660,2,EC: Survey of Brand Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lisa willif papenfus,,COM-3660,2018
+COM,3660,4,EC: Digital Analytics & Brand,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,alicia nic littleton,,COM-3660,2018
+COM,3690,1,Political Comm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-3690,2018
+COM,4250,1,Adv Sports Comm,0.54,0.38,0.0,0.0,0.08,0.0,0.0,0.0,bryan denham,,COM-4250,2018
+COM,4300,1,Legal Communication,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,james isaac roberts,,COM-4300,2018
+COM,4720,1,Comm in Health Organizations,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kristen elai okamoto,,COM-4720,2018
+CPSC,1010,3,Computer Science I,0.24,0.17,0.24,0.1,0.1,0.0,0.0,0.15,christopher plaue,,CPSC-1010,2018
+CPSC,1020,1,Computer Science II,0.28,0.18,0.14,0.1,0.18,0.0,0.0,0.12,yvon feaster,,CPSC-1020,2018
+CPSC,1020,2,Computer Science II,0.16,0.26,0.28,0.1,0.12,0.0,0.0,0.08,yvon feaster,,CPSC-1020,2018
+CPSC,1070,1,Programming Methodology,0.45,0.19,0.15,0.06,0.07,0.0,0.0,0.07,catherine hochrine,,CPSC-1070,2018
+CPSC,1110,1,Intro to Programming in C,0.28,0.18,0.26,0.08,0.18,0.0,0.0,0.02,catherine hochrine,,CPSC-1110,2018
+CPSC,1110,2,Intro to Programming in C,0.37,0.35,0.06,0.08,0.14,0.0,0.0,0.0,nicolas benja widman,,CPSC-1110,2018
+CPSC,1110,3,Intro to Programming in C,0.46,0.24,0.13,0.04,0.07,0.0,0.0,0.07,nicolas benja widman,,CPSC-1110,2018
+CPSC,1110,4,Intro to Programming in C,0.25,0.23,0.23,0.11,0.07,0.0,0.0,0.11,james martin,,CPSC-1110,2018
+CPSC,2120,1,Algs/Data Structures,0.26,0.32,0.2,0.06,0.08,0.0,0.0,0.08,brian christoph dean,,CPSC-2120,2018
+CPSC,2150,1,Software Dev Foundations,0.27,0.31,0.19,0.03,0.07,0.0,0.0,0.14,kevin anton plis,,CPSC-2150,2018
+CPSC,2150,2,Software Dev Foundations,0.32,0.31,0.15,0.07,0.08,0.0,0.0,0.07,kevin anton plis,,CPSC-2150,2018
+CPSC,2200,1,Microcomputer Appl,0.46,0.31,0.23,0.0,0.0,0.0,0.0,0.0,kevin anton plis,,CPSC-2200,2018
+CPSC,2200,2,Microcomputer Appl,0.22,0.3,0.19,0.15,0.11,0.0,0.0,0.04,kevin anton plis,,CPSC-2200,2018
+CPSC,2310,1,Intro Computer Org,0.58,0.24,0.1,0.02,0.04,0.0,0.0,0.02,nicolas benja widman,,CPSC-2310,2018
+CPSC,2310,2,Intro Computer Org,0.49,0.22,0.16,0.03,0.08,0.0,0.0,0.03,nicolas benja widman,,CPSC-2310,2018
+CPSC,2810,1,Selected Topics: TA Class,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher plaue,,CPSC-2810,2018
+CPSC,2810,2,Selected Topics: Cybersecurity,0.76,0.08,0.0,0.0,0.0,0.0,0.0,0.16,yvon feaster,,CPSC-2810,2018
+CPSC,2910,1,Prof Issues I,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2018
+CPSC,2910,2,Prof Issues I,0.6,0.25,0.0,0.05,0.0,0.0,0.0,0.1,catherine hochrine,,CPSC-2910,2018
+CPSC,2910,3,Prof Issues I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2018
+CPSC,2910,4,Prof Issues I,0.6,0.25,0.0,0.05,0.05,0.0,0.0,0.05,catherine hochrine,,CPSC-2910,2018
+CPSC,2910,5,Prof Issues I,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,catherine hochrine,,CPSC-2910,2018
+CPSC,2920,1,"Computing, Ethics & Society",0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,julian lang brinkley,,CPSC-2920,2018
+CPSC,3120,1,Design Analysis of Algorithms,0.07,0.1,0.14,0.14,0.17,0.0,0.0,0.38,pradip srimani,,CPSC-3120,2018
+CPSC,3220,1,Intro to Operating Systems,0.62,0.31,0.03,0.0,0.03,0.0,0.0,0.0,brygg anders ullmer,,CPSC-3220,2018
+CPSC,3220,3,Intro to Operating Systems,0.19,0.33,0.29,0.0,0.1,0.0,0.0,0.1,pradip srimani,,CPSC-3220,2018
+CPSC,3300,1,Computer Systems Org,0.25,0.25,0.4,0.04,0.03,0.0,0.0,0.03,mark smotherman,,CPSC-3300,2018
+CPSC,3500,1,Foundations of Computer Sci,0.28,0.13,0.45,0.04,0.0,0.0,0.0,0.09,ilya mark safro,,CPSC-3500,2018
+CPSC,3520,1,Programming Systems,0.39,0.29,0.22,0.0,0.02,0.0,0.0,0.08,robert schalkoff,,CPSC-3520,2018
+CPSC,3600,1,Network Programming,0.44,0.29,0.15,0.0,0.08,0.0,0.0,0.03,andrew robb,,CPSC-3600,2018
+CPSC,3600,2,Network Programming,0.67,0.21,0.07,0.04,0.0,0.0,0.0,0.02,andrew robb,,CPSC-3600,2018
+CPSC,3720,1,Software Engineering,0.27,0.38,0.24,0.05,0.0,0.0,0.0,0.05,eileen there kraemer,,CPSC-3720,2018
+CPSC,3720,2,Software Engineering,0.21,0.42,0.25,0.06,0.0,0.0,0.0,0.06,murali sitaraman,,CPSC-3720,2018
+CPSC,4040,1,Cmptr Graphics Image,0.29,0.24,0.24,0.0,0.12,0.0,0.0,0.12,ioannis karamouzas,,CPSC-4040,2018
+CPSC,4050,1,Computer Graphics,0.24,0.18,0.12,0.12,0.24,0.0,0.0,0.12,andrew duchowski,,CPSC-4050,2018
+CPSC,4110,1,Virtual Reality Systems,0.27,0.41,0.22,0.05,0.0,0.0,0.0,0.05,sabarish venkat babu,,CPSC-4110,2018
+CPSC,4120,1,Eye Tracking Methodology,0.22,0.61,0.04,0.0,0.04,0.0,0.0,0.09,andrew duchowski,,CPSC-4120,2018
+CPSC,4140,1,Human and Computer Interaction,0.21,0.56,0.21,0.03,0.0,0.0,0.0,0.0,nathaniel mcneese,,CPSC-4140,2018
+CPSC,4160,1,2-D Game Engine Construction,0.54,0.23,0.06,0.02,0.08,0.0,0.0,0.06,brian malloy,,CPSC-4160,2018
+CPSC,4200,1,Computer Security Principles,0.61,0.26,0.08,0.0,0.03,0.0,0.0,0.03,yvon feaster,,CPSC-4200,2018
+CPSC,4200,2,Computer Security Principles,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,,CPSC-4200,2018
+CPSC,4300,1,Applied Data Science,0.25,0.5,0.08,0.17,0.0,0.0,0.0,0.0,alexander chr herzog,,CPSC-4300,2018
+CPSC,4440,1,Cloud Computing Architecture,0.32,0.45,0.18,0.0,0.0,0.0,0.0,0.05,amy apon,,CPSC-4440,2018
+CPSC,4620,1,Database Management Systems,0.09,0.22,0.22,0.09,0.13,0.0,0.0,0.26,pradip srimani,,CPSC-4620,2018
+CPSC,4820,1,Special Topic: Web Programming,0.56,0.1,0.22,0.06,0.06,0.0,0.0,0.0,craig baker,,CPSC-4820,2018
+CPSC,4820,4,Spe Topic: HPC Fault Tolerance,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,jon cameron calhoun,,CPSC-4820,2018
+CPSC,6040,1,Cptr Graphics Image,0.5,0.07,0.14,0.0,0.0,0.0,0.0,0.29,ioannis karamouzas,,CPSC-6040,2018
+CPSC,6110,1,Virtual Reality Systems,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,sabarish venkat babu,,CPSC-6110,2018
+CPSC,6140,1,Human and Computer Interaction,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel mcneese,,CPSC-6140,2018
+CPSC,6160,1,2-D Game Engine Construction,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,brian malloy,,CPSC-6160,2018
+CPSC,6300,1,Applied Data Science,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,,CPSC-6300,2018
+CPSC,6440,1,Cloud Computing Architecture,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,amy apon,,CPSC-6440,2018
+CPSC,6620,1,Database Management Systems,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,pradip srimani,,CPSC-6620,2018
+CPSC,6780,1,Gen Purpose Computation on GPU,0.4,0.4,0.0,0.0,0.2,0.0,0.0,0.0,shuangshuang jin,,CPSC-6780,2018
+CPSC,8170,1,Physically Based Animation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,donald henry house,,CPSC-8170,2018
+CPSC,8200,1,Parallel Architechture,0.5,0.3,0.1,0.0,0.1,0.0,0.0,0.0,rong ge,,CPSC-8200,2018
+CPSC,8270,1,Translation of Progr Languages,0.74,0.13,0.1,0.0,0.0,0.0,0.0,0.03,brian malloy,,CPSC-8270,2018
+CPSC,8380,1,Adv Data Structures,0.3,0.2,0.1,0.0,0.1,0.0,0.0,0.3,sandra hedetniemi,,CPSC-8380,2018
+CPSC,8480,1,Network Science,0.31,0.31,0.34,0.0,0.0,0.0,0.0,0.03,ilya mark safro,,CPSC-8480,2018
+CPSC,8550,1,Embedded Network Sys,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jacob sorber,,CPSC-8550,2018
+CPSC,8580,1,Security in Emerging Systems,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,hongxin hu,,CPSC-8580,2018
+CPSC,8810,1,Selected Topics: Intro to BDSI,0.67,0.0,0.0,0.0,0.17,0.0,0.0,0.17,brian christoph dean,,CPSC-8810,2018
+CRP,8020,1,Site Planning & Infrastructure,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,,CRP-8020,2018
+CSM,1000,1,Intro to Construct,0.92,0.07,0.0,0.0,0.0,0.0,0.0,0.02,nathaniel jackson,,CSM-1000,2018
+CSM,2010,1,Structures I,0.36,0.21,0.24,0.07,0.02,0.0,0.0,0.1,shima clarke,,CSM-2010,2018
+CSM,2020,1,Structures II,0.24,0.18,0.41,0.12,0.0,0.0,0.0,0.06, kent nilsson,,CSM-2020,2018
+CSM,2040,1,Cont Documents,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,robert dawson coffey,,CSM-2040,2018
+CSM,3040,1,Envir Systems I,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,,CSM-3040,2018
+CSM,3040,2,Envir Systems I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,,CSM-3040,2018
+CSM,3060,1,Emerging Tech in Construction,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-3060,2018
+CSM,3060,2,Emerging Tech in Construction,0.17,0.59,0.21,0.03,0.0,0.0,0.0,0.0,jason lucas,,CSM-3060,2018
+CSM,3510,1,Construction Estimating,0.29,0.32,0.32,0.06,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,,CSM-3510,2018
+CSM,3510,2,Construction Estimating,0.35,0.48,0.1,0.06,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,,CSM-3510,2018
+CSM,4500,1,Construction Intern,0.4,0.36,0.25,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,,CSM-4500,2018
+CSM,4530,1,Const Proj Mgmt,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4530,2018
+CSM,4530,2,Const Proj Mgmt,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4530,2018
+CSM,8630,400,Adv Plan/Sched,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,craig townsend,,CSM-8630,2018
+CSM,8650,1,Project Management,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,dennis bausman,,CSM-8650,2018
+CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2018
+CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2018
+CU,1000,16,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2018
+CU,1000,19,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2018
+CU,1000,24,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2018
+CU,1000,26,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2018
+CU,1000,27,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2018
+CU,1000,28,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,,CU-1000,2018
+CU,1010,1,Univ Success Skills,0.33,0.17,0.28,0.06,0.11,0.0,0.0,0.06,bryn zimmermann babb,,CU-1010,2018
+CU,1010,6,Univ Success Skills,0.21,0.16,0.21,0.16,0.11,0.0,0.0,0.16,valerie kay oonk,,CU-1010,2018
+CU,1010,7,Univ Success Skills,0.41,0.24,0.18,0.0,0.12,0.0,0.0,0.06,bryn zimmermann babb,,CU-1010,2018
+CU,1010,600,Univ Success Skills,0.38,0.42,0.08,0.0,0.13,0.0,0.0,0.0,elizabeth an stephan,,CU-1010,2018
+CU,1010,601,Univ Success Skills,0.5,0.21,0.13,0.04,0.0,0.0,0.0,0.13,bridget trogden,,CU-1010,2018
+CU,1010,602,Univ Success Skills,0.46,0.29,0.17,0.0,0.04,0.0,0.0,0.04,laurel ann  whisler c,,CU-1010,2018
+CU,1010,603,Univ Success Skills,0.55,0.25,0.2,0.0,0.0,0.0,0.0,0.0,abigail stephan,,CU-1010,2018
+DPA,3070,1,Method 3d Production,0.45,0.41,0.1,0.0,0.03,0.0,0.0,0.0,tommy van bui,,DPA-3070,2018
+DPA,4000,1,Tech Foundations I,0.24,0.24,0.12,0.0,0.06,0.0,0.0,0.35,jessica baron,,DPA-4000,2018
+DPA,4020,1,Vis Foundations I,0.27,0.55,0.0,0.0,0.0,0.0,0.0,0.18,anthony summey,,DPA-4020,2018
+DPA,4020,2,Vis Foundations I,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,anthony summey,,DPA-4020,2018
+DPA,6000,1,Tech Foundations I,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,victor zordan,,DPA-6000,2018
+DPA,8070,843,3D Modeling and Animation,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,matias volonte,,DPA-8070,2018
+DPA,8090,1,Rendering and Shading,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,,DPA-8090,2018
+ECE,2010,1,Logic and Computing Device,0.12,0.27,0.26,0.16,0.15,0.0,0.0,0.04,william reid,,ECE-2010,2018
+ECE,2010,1,Logic and Computing Devices,0.12,0.27,0.26,0.16,0.15,0.0,0.0,0.04,william reid,,ECE-2010,2018
+ECE,2010,2,Logic & Comp Device (HON),0.8,0.0,0.1,0.0,0.0,0.0,0.0,0.1,william reid,True,ECE-2010,2018
+ECE,2020,1,Electric Circuits I,0.34,0.23,0.19,0.07,0.1,0.0,0.0,0.06,william harrell,,ECE-2020,2018
+ECE,2070,1,Basic Electrical Engineering,0.42,0.38,0.14,0.03,0.01,0.0,0.0,0.03,william tho kolodzey,,ECE-2070,2018
+ECE,2070,2,Basic Electrical Engineering,0.38,0.36,0.14,0.02,0.07,0.0,0.0,0.02,fatemeh tooryan,,ECE-2070,2018
+ECE,2070,3,Basic Electrical Engineering,0.57,0.31,0.07,0.0,0.01,0.0,0.0,0.03,timothy anglea,,ECE-2070,2018
+ECE,2080,1,Basic Electrical Engr Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,3,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,6,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,7,Basic Electrical Engr Lab,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,8,Basic Electrical Engr Lab,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,10,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,12,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,14,Basic Electrical Engr Lab,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2080,2018
+ECE,2090,3,Logic Lab,0.75,0.0,0.0,0.08,0.08,0.0,0.0,0.08,apoorva deep kapadia,,ECE-2090,2018
+ECE,2090,7,Logic Lab,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva deep kapadia,,ECE-2090,2018
+ECE,2090,8,Logic Lab,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deep kapadia,,ECE-2090,2018
+ECE,2090,13,Logic Lab,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,apoorva deep kapadia,,ECE-2090,2018
+ECE,2090,14,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva deep kapadia,,ECE-2090,2018
+ECE,2110,1,Elec Engr Lab I,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,,ECE-2110,2018
+ECE,2110,2,Elec Engr Lab I,0.44,0.19,0.13,0.13,0.06,0.0,0.0,0.06,apoorva deep kapadia,,ECE-2110,2018
+ECE,2110,3,Elec Engr Lab I,0.45,0.25,0.1,0.1,0.05,0.0,0.0,0.05,apoorva deep kapadia,,ECE-2110,2018
+ECE,2110,5,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,apoorva deep kapadia,,ECE-2110,2018
+ECE,2110,6,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,,ECE-2110,2018
+ECE,2110,10,Elec Engr Lab I,0.7,0.1,0.0,0.0,0.0,0.0,0.0,0.2,apoorva deep kapadia,,ECE-2110,2018
+ECE,2120,1,Electrical Engineering Lab II,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,apoorva deep kapadia,,ECE-2120,2018
+ECE,2120,4,Electrical Engineering Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2120,2018
+ECE,2220,1,Syst Prog Concept,0.18,0.2,0.05,0.0,0.23,0.0,0.0,0.34,lu yu,,ECE-2220,2018
+ECE,2230,1,Comp Sys Eng,0.36,0.16,0.27,0.11,0.04,0.0,0.0,0.07,harlan russell,,ECE-2230,2018
+ECE,2620,1,Electric Circuits II,0.2,0.26,0.34,0.04,0.08,0.0,0.0,0.08,liang dong,,ECE-2620,2018
+ECE,2720,1,Comp Organization,0.06,0.18,0.35,0.24,0.14,0.0,0.0,0.02,william reid,,ECE-2720,2018
+ECE,3110,1,Electrical Engineering Lab III,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3110,2018
+ECE,3110,2,Electrical Engineering Lab III,0.75,0.13,0.0,0.06,0.0,0.0,0.0,0.06,apoorva deep kapadia,,ECE-3110,2018
+ECE,3110,3,Electrical Engineering Lab III,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,,ECE-3110,2018
+ECE,3110,7,Electrical Engineering Lab III,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3110,2018
+ECE,3110,8,Electrical Engineering Lab III,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva deep kapadia,,ECE-3110,2018
+ECE,3120,1,Electrical Engineering Lab IV,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3120,2018
+ECE,3120,2,Electrical Engineering Lab IV,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3120,2018
+ECE,3170,1,Rand Signal Analysis,0.23,0.3,0.26,0.1,0.07,0.0,0.0,0.03,stephen hubbard,,ECE-3170,2018
+ECE,3200,1,Electronics I,0.24,0.26,0.22,0.15,0.1,0.0,0.0,0.03,stephen hubbard,,ECE-3200,2018
+ECE,3200,2,Electronics I (HON),0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,stephen hubbard,True,ECE-3200,2018
+ECE,3210,1,Electronics II,0.45,0.3,0.15,0.08,0.03,0.0,0.0,0.0,stephen hubbard,,ECE-3210,2018
+ECE,3270,1,Dig Comp Design,0.12,0.2,0.24,0.16,0.08,0.0,0.0,0.2,melissa crawle smith,,ECE-3270,2018
+ECE,3300,1,Signals & Systems,0.15,0.25,0.27,0.14,0.08,0.0,0.0,0.1,carl baum,,ECE-3300,2018
+ECE,3300,2,Signals & Systems (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True,ECE-3300,2018
+ECE,3520,1,Programming Systems,0.36,0.59,0.05,0.0,0.0,0.0,0.0,0.0,robert schalkoff,,ECE-3520,2018
+ECE,3600,1,Elect Power Engr,0.49,0.23,0.13,0.09,0.02,0.0,0.0,0.04,edward collins,,ECE-3600,2018
+ECE,3710,1,Microcontr Interface,0.47,0.26,0.14,0.1,0.02,0.0,0.0,0.0,william reid,,ECE-3710,2018
+ECE,3720,3,Micro Int Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3720,4,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3720,6,Micro Int Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3720,7,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3720,9,Micro Int Lab,0.5,0.25,0.0,0.0,0.25,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3720,11,Micro Int Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3800,1,Electromagnetics,0.27,0.27,0.18,0.13,0.11,0.0,0.0,0.04,anthony martin,,ECE-3800,2018
+ECE,3810,1,Field Waves & Ckts,0.41,0.44,0.13,0.0,0.03,0.0,0.0,0.0,hai xiao,,ECE-3810,2018
+ECE,4090,1,Intr to Linear Control Systems,0.63,0.33,0.03,0.01,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-4090,2018
+ECE,4180,1,Power Syst Analysis,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,ramtin hadidi,,ECE-4180,2018
+ECE,4270,1,Communications Sys,0.33,0.47,0.16,0.0,0.0,0.0,0.0,0.05,lu yu,,ECE-4270,2018
+ECE,4310,1,Intro to Computer Vision,0.64,0.28,0.03,0.03,0.03,0.0,0.0,0.0,adam hoover,,ECE-4310,2018
+ECE,4420,1,Knowledge Engr,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,robert schalkoff,,ECE-4420,2018
+ECE,4490,1,Comp Ntwrk Security,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,richard brooks,,ECE-4490,2018
+ECE,4610,1,Fundamentals of Solar Energy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,,ECE-4610,2018
+ECE,4670,1,Intro to Dig Sig Pro,0.24,0.18,0.47,0.0,0.0,0.0,0.0,0.12,john gowdy,,ECE-4670,2018
+ECE,4730,1,Intro Parallel Sys,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,walter ligon,,ECE-4730,2018
+ECE,4950,1,Int Sys Design I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-4950,2018
+ECE,4960,1,Int Sys Design II,0.64,0.27,0.07,0.02,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2018
+ECE,6040,1,Semiconductor Devices,0.57,0.14,0.29,0.0,0.0,0.0,0.0,0.0,judson dougl ryckman,,ECE-6040,2018
+ECE,6180,1,Power Syst Analysis,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ramtin hadidi,,ECE-6180,2018
+ECE,6310,1,Intro to Computer Vision,0.6,0.15,0.1,0.0,0.0,0.0,0.0,0.15,adam hoover,,ECE-6310,2018
+ECE,6490,1,Comp Ntwrk Security,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,richard brooks,,ECE-6490,2018
+ECE,6590,1,Int Circ Design,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,,ECE-6590,2018
+ECE,6670,1,Intro to Dig Sig Pro,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,john gowdy,,ECE-6670,2018
+ECE,8010,1,Analysis of Lin Sys,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,richard groff,,ECE-8010,2018
+ECE,8010,843,Analysis of Lin Sys,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,richard groff,,ECE-8010,2018
+ECON,2000,2,Economic Concepts,0.31,0.26,0.23,0.13,0.03,0.0,0.0,0.05,shubhashrita basu,,ECON-2000,2018
+ECON,2000,4,Economic Concepts,0.38,0.43,0.1,0.0,0.08,0.0,0.0,0.03,miren ivankovic,,ECON-2000,2018
+ECON,2000,5,Economic Concepts,0.32,0.34,0.26,0.03,0.05,0.0,0.0,0.0,shubhashrita basu,,ECON-2000,2018
+ECON,2110,1,Principles of Microeconomics,0.21,0.26,0.32,0.11,0.05,0.0,0.0,0.05,frederick an hanssen,,ECON-2110,2018
+ECON,2110,2,Principles of Microeconomics,0.21,0.32,0.26,0.0,0.11,0.0,0.0,0.11,frederick an hanssen,,ECON-2110,2018
+ECON,2110,3,Principles of Microeconomics,0.05,0.32,0.47,0.11,0.0,0.0,0.0,0.05,frederick an hanssen,,ECON-2110,2018
+ECON,2110,4,Principles of Microeconomics,0.21,0.42,0.26,0.0,0.05,0.0,0.0,0.05,frederick an hanssen,,ECON-2110,2018
+ECON,2110,5,Principles of Microeconomics,0.28,0.22,0.28,0.17,0.06,0.0,0.0,0.0,frederick an hanssen,,ECON-2110,2018
+ECON,2110,6,Principles of Microeconomics,0.16,0.37,0.26,0.05,0.11,0.0,0.0,0.05,frederick an hanssen,,ECON-2110,2018
+ECON,2110,7,Principles of Microeconomics,0.0,0.5,0.33,0.0,0.06,0.0,0.0,0.11,frederick an hanssen,,ECON-2110,2018
+ECON,2110,8,Principles of Microeconomics,0.22,0.28,0.28,0.11,0.06,0.0,0.0,0.06,frederick an hanssen,,ECON-2110,2018
+ECON,2110,9,Principles of Microeconomics,0.17,0.39,0.33,0.0,0.0,0.0,0.0,0.11,frederick an hanssen,,ECON-2110,2018
+ECON,2110,10,Principles of Microeconomics,0.28,0.28,0.28,0.06,0.06,0.0,0.0,0.06,frederick an hanssen,,ECON-2110,2018
+ECON,2110,11,Principles of Microeconomics,0.11,0.42,0.21,0.11,0.0,0.0,0.0,0.16,frederick an hanssen,,ECON-2110,2018
+ECON,2110,12,Principles of Microeconomics,0.11,0.26,0.32,0.16,0.05,0.0,0.0,0.11,frederick an hanssen,,ECON-2110,2018
+ECON,2110,13,Principles of Microeconomics,0.05,0.58,0.26,0.05,0.05,0.0,0.0,0.0,frederick an hanssen,,ECON-2110,2018
+ECON,2110,14,Principles of Microeconomics,0.16,0.53,0.16,0.11,0.05,0.0,0.0,0.0,frederick an hanssen,,ECON-2110,2018
+ECON,2110,15,Principles of Microeconomics,0.0,0.33,0.56,0.06,0.06,0.0,0.0,0.0,frederick an hanssen,,ECON-2110,2018
+ECON,2110,16,Principles of Microeconomics,0.15,0.4,0.25,0.1,0.1,0.0,0.0,0.0,frederick an hanssen,,ECON-2110,2018
+ECON,2110,17,Principles of Microeconomics,0.11,0.21,0.42,0.16,0.05,0.0,0.0,0.05,frederick an hanssen,,ECON-2110,2018
+ECON,2110,18,Principles of Microeconomics,0.05,0.53,0.05,0.16,0.16,0.0,0.0,0.05,frederick an hanssen,,ECON-2110,2018
+ECON,2110,19,Principles of Microeconomics,0.05,0.42,0.11,0.26,0.05,0.0,0.0,0.11,frederick an hanssen,,ECON-2110,2018
+ECON,2110,20,Principles of Microeconomics,0.31,0.32,0.22,0.09,0.04,0.0,0.0,0.01,benjamin posmanick,,ECON-2110,2018
+ECON,2110,21,Principles of Microeconomics,0.28,0.46,0.21,0.03,0.0,0.0,0.0,0.03,michael makowsky,,ECON-2110,2018
+ECON,2110,23,Principles of Microeconomics,0.2,0.29,0.28,0.08,0.1,0.0,0.0,0.04,roksana ghanbariamin,,ECON-2110,2018
+ECON,2110,24,Principles of Microeconomics,0.24,0.34,0.3,0.08,0.02,0.0,0.0,0.03,kelsey victo roberts,,ECON-2110,2018
+ECON,2110,25,Principles of Microeconomics,0.28,0.56,0.13,0.0,0.03,0.0,0.0,0.0,chen wang,,ECON-2110,2018
+ECON,2110,26,Principles of Microeconomics,0.28,0.28,0.26,0.13,0.02,0.0,0.0,0.02,sarah louise wilson,,ECON-2110,2018
+ECON,2110,31,Principles of Microeconomics,0.33,0.29,0.26,0.04,0.08,0.0,0.0,0.0,jonathan orry ernest,,ECON-2110,2018
+ECON,2110,32,Principles of Microeconomics,0.28,0.52,0.13,0.02,0.04,0.0,0.0,0.0,jacob walloga,,ECON-2110,2018
+ECON,2110,33,Principles of Microeconomics,0.33,0.44,0.13,0.0,0.08,0.0,0.0,0.03,liuna issagholian,,ECON-2110,2018
+ECON,2110,34,Principles of Microecon (HON),0.45,0.32,0.18,0.05,0.0,0.0,0.0,0.0,charles thomas,True,ECON-2110,2018
+ECON,2110,35,Principles of Microeconomics,0.25,0.55,0.2,0.0,0.0,0.0,0.0,0.0,chen wang,,ECON-2110,2018
+ECON,2110,36,Principles of Microeconomics,0.28,0.4,0.18,0.08,0.06,0.0,0.0,0.0,roksana ghanbariamin,,ECON-2110,2018
+ECON,2110,40,Principles of Microeconomics,0.25,0.36,0.21,0.04,0.14,0.0,0.0,0.0,liuna issagholian,,ECON-2110,2018
+ECON,2110,41,Principles of Microeconomics,0.48,0.38,0.1,0.02,0.0,0.0,0.0,0.02,jonathan orry ernest,,ECON-2110,2018
+ECON,2120,1,Principles of Macroeconomics,0.3,0.41,0.2,0.04,0.03,0.0,0.0,0.03,elijah neilson,,ECON-2120,2018
+ECON,2120,2,Principles of Macroeconomics,0.23,0.36,0.32,0.0,0.04,0.0,0.0,0.04,kenneth whaley,,ECON-2120,2018
+ECON,2120,3,Principles of Macroeconomics,0.25,0.43,0.25,0.02,0.0,0.0,0.0,0.05,elijah neilson,,ECON-2120,2018
+ECON,2120,4,Principles of Macroeconomics,0.25,0.36,0.28,0.06,0.06,0.0,0.0,0.0,wing yin chung,,ECON-2120,2018
+ECON,2120,5,Principles of Macroeconomics,0.29,0.39,0.26,0.03,0.0,0.0,0.0,0.03,narendra regmi,,ECON-2120,2018
+ECON,2120,6,Principles of Macroeconomics,0.45,0.33,0.13,0.08,0.0,0.0,0.0,0.03,kenneth whaley,,ECON-2120,2018
+ECON,2120,7,Principles of Macroeconomics,0.51,0.18,0.18,0.08,0.05,0.0,0.0,0.0,narendra regmi,,ECON-2120,2018
+ECON,2120,8,Principles of Macroeconomics,0.67,0.21,0.02,0.0,0.05,0.0,0.0,0.05,tyler francis,,ECON-2120,2018
+ECON,2120,9,Principles of Macroeconomics,0.88,0.07,0.05,0.0,0.0,0.0,0.0,0.0,tyler francis,,ECON-2120,2018
+ECON,2120,10,Principles of Macroeconomics,0.23,0.36,0.31,0.03,0.05,0.0,0.0,0.03,kyle lance rechard,,ECON-2120,2018
+ECON,3020,1,Money and Banking,0.18,0.31,0.33,0.1,0.0,0.0,0.0,0.08,smriti bhargava,,ECON-3020,2018
+ECON,3060,1,Managerial Economics,0.2,0.25,0.25,0.18,0.08,0.0,0.0,0.05,steven johnson,,ECON-3060,2018
+ECON,3100,1,International Econ,0.19,0.54,0.17,0.06,0.03,0.0,0.0,0.01,scott baier,,ECON-3100,2018
+ECON,3140,1,Intermediate Micro,0.28,0.15,0.18,0.08,0.15,0.0,0.0,0.15,patrick warren,,ECON-3140,2018
+ECON,3140,2,Intermediate Micro,0.17,0.57,0.15,0.07,0.0,0.0,0.0,0.05,molly espey,,ECON-3140,2018
+ECON,3140,3,Intermediate Micro,0.27,0.31,0.2,0.08,0.06,0.0,0.0,0.08,robert kenneth fleck,,ECON-3140,2018
+ECON,3140,5,Intermediate Micro,0.26,0.22,0.22,0.15,0.07,0.0,0.0,0.07,yichen christy zhou,,ECON-3140,2018
+ECON,3150,1,Intermediate Macro,0.86,0.05,0.02,0.0,0.02,0.0,0.0,0.05,jeremy choquette,,ECON-3150,2018
+ECON,3150,2,Intermediate Macro,0.39,0.24,0.17,0.1,0.05,0.0,0.0,0.05,michal jerzmanowski,,ECON-3150,2018
+ECON,3190,1,Environmental Econ,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,molly espey,,ECON-3190,2018
+ECON,3600,1,Public Choice,0.37,0.29,0.21,0.08,0.0,0.0,0.0,0.05,michael makowsky,,ECON-3600,2018
+ECON,4010,1,Labor Mkt Analysis,0.5,0.25,0.08,0.0,0.08,0.0,0.0,0.08,chungsang lam,,ECON-4010,2018
+ECON,4020,1,Law and Economics,0.23,0.5,0.15,0.05,0.03,0.0,0.0,0.05,howard nel bodenhorn,,ECON-4020,2018
+ECON,4040,1,Comp Econ Systems,0.33,0.07,0.2,0.07,0.13,0.0,0.0,0.2,dari litsukova-bokar,,ECON-4040,2018
+ECON,4050,5,Intro to Econometric,0.25,0.23,0.35,0.08,0.06,0.0,0.0,0.04,scott barkowski,,ECON-4050,2018
+ECON,4100,1,Economic Development,0.72,0.14,0.03,0.0,0.03,0.0,0.0,0.07,robert tamura,,ECON-4100,2018
+ECON,4120,1,International Micro,0.35,0.26,0.17,0.0,0.0,0.0,0.0,0.22,scott baier,,ECON-4120,2018
+ECON,4130,1,International Macro,0.45,0.36,0.0,0.0,0.09,0.0,0.0,0.09,michal jerzmanowski,,ECON-4130,2018
+ECON,4230,1,Economics of Health,0.51,0.34,0.11,0.0,0.0,0.0,0.0,0.03,devon merritt gorry,,ECON-4230,2018
+ECON,4240,1,Organization of Ind,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,matthew lewis,,ECON-4240,2018
+ECON,4240,2,Organization of Ind,0.72,0.1,0.1,0.03,0.0,0.0,0.0,0.03,matthew lewis,,ECON-4240,2018
+ECON,4250,1,Antitrust Economics,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.12,raymond sauer,,ECON-4250,2018
+ECON,4260,1,Sem Sport Economics,0.63,0.3,0.0,0.0,0.0,0.0,0.0,0.07,raymond sauer,,ECON-4260,2018
+ECON,4280,1,Cost-Benefit Anlysis,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,robert kenneth fleck,,ECON-4280,2018
+ECON,4980,3,Econ of Entertainment Industry,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,frederick an hanssen,,ECON-4980,2018
+ECON,4980,4,Sel Topic - Why Business?,0.44,0.33,0.19,0.04,0.0,0.0,0.0,0.0,bradley keith hobbs,,ECON-4980,2018
+ECON,4980,5,Sel Topics-Cryptocurrency,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,gerald dwyer,,ECON-4980,2018
+ECON,6050,5,Intro to Econometric,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott barkowski,,ECON-6050,2018
+ECON,8010,1,Microeconomic Theory,0.5,0.13,0.38,0.0,0.0,0.0,0.0,0.0,william dougan,,ECON-8010,2018
+ECON,8040,1,Applied Math Econ,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,,ECON-8040,2018
+ECON,8060,1,Econometrics I,0.13,0.38,0.38,0.0,0.13,0.0,0.0,0.0,paul wayne wilson,,ECON-8060,2018
+ECON,8080,1,Econometrics III,0.17,0.5,0.17,0.0,0.17,0.0,0.0,0.0,paul wayne wilson,,ECON-8080,2018
+ECON,8230,1,Microecon Pub Pol,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,,ECON-8230,2018
+ECON,8990,3,Industrial Organization Theory,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,charles thomas,,ECON-8990,2018
+ECON,8990,5,Sel Topics - Macro Theory II,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,christopher as gorry,,ECON-8990,2018
+ED,1050,1,Educ Orientation,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,jennifer michel hein,,ED-1050,2018
+ED,1050,3,Educ Orientation,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,,ED-1050,2018
+ED,1050,7,Educ Orientation,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,,ED-1050,2018
+ED,1050,8,Educ Orientation,0.84,0.08,0.0,0.0,0.0,0.0,0.0,0.08,amaris joseph tejada,,ED-1050,2018
+ED,1970,1,CI-CONNECTIONS Stud Developmnt,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2018
+ED,1970,2,CI-CONNECTIONS Stud Developmnt,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2018
+ED,1970,3,CI-CONNECTIONS Stud Developmnt,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2018
+ED,1970,4,CI-CONNECTIONS Stud Developmnt,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2018
+ED,1970,5,CI-CONNECTIONS Stud Developmnt,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2018
+ED,1970,6,CI-CONNECTIONS Stud Developmnt,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,deonte brown,,ED-1970,2018
+ED,3010,1,Principles of American Educat,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohammad khan,,ED-3010,2018
+ED,8750,321,Elements of Instructional Effe,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,susan ridg nunamaker,,ED-8750,2018
+ED,9540,1,Curriculum Theory,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,,ED-9540,2018
+EDC,3900,2,Skills for Student Leaders,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2018
+EDC,3900,5,Skills for Student Leaders,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,EDC-3900,2018
+EDC,3990,1,Creative Inq in Counselor Ed,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,jacob frankovich,,EDC-3990,2018
+EDEC,3000,1,Found Early Chld Ed,0.91,0.0,0.0,0.03,0.03,0.0,0.0,0.03,jill chandle shelnut,,EDEC-3000,2018
+EDEC,3010,1,Early Childhood Practicum I,0.89,0.0,0.0,0.04,0.04,0.0,0.0,0.04,jennifer schumpert,,EDEC-3010,2018
+EDEC,4300,1,Early Childhd Math,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sandra mamman linder,,EDEC-4300,2018
+EDEC,4400,1,Early Childhood Engl Lang Art,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-4400,2018
+EDEC,8100,312,Adv Ece Found & Meth,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,sandra mamman linder,,EDEC-8100,2018
+EDEL,3210,1,Pe for the Elem Tchr,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2018
+EDEL,3210,2,Pe for the Elem Tchr,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2018
+EDEL,4870,2,Ele Meth Soc Studies,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,melinda spearman,,EDEL-4870,2018
+EDEL,4880,2,Elem Language Arts Teaching,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,jacquelynn malloy,,EDEL-4880,2018
+EDF,3020,2,Educational Psychology,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,meihua qian,,EDF-3020,2018
+EDF,3340,1,Child Growth and Development,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoob jamil,,EDF-3340,2018
+EDF,3340,3,Child Growth and Development,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,faiza marghoob jamil,,EDF-3340,2018
+EDF,3350,1,Adolescent Growth & Develop,0.41,0.27,0.18,0.05,0.0,0.0,0.0,0.09,david barrett,,EDF-3350,2018
+EDF,4800,2,Digital Media & Learning,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,anne mcmahan grant,,EDF-4800,2018
+EDF,8080,312,Contempor Issues in Assessment,0.8,0.12,0.04,0.0,0.0,0.0,0.0,0.04,eliza darg gallagher,,EDF-8080,2018
+EDF,8710,400,Cultural Diversity in Educatio,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,reginald wilkerson,,EDF-8710,2018
+EDF,9020,1,Learning Sciences Seminar II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,,EDF-9020,2018
+EDF,9270,401,Quant Rsrch & Stats for Ed,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,russell aubre marion,,EDF-9270,2018
+EDHD,3110,1,CI- Research in DM & Learning,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.07,david matthew boyer,,EDHD-3110,2018
+EDL,7150,503,Sch & Comm Relations,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,,EDL-7150,2018
+EDL,7400,500,Curr Plan: Sch Adm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,daniella hall,,EDL-7400,2018
+EDL,7400,501,Curr Plan: Sch Adm,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,daniella hall,,EDL-7400,2018
+EDL,9110,400,Systematic Inq Ed L,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,jane lindle,,EDL-9110,2018
+EDL,9770,1,Div Issues in Hi Ed,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robin je phelps-ward,,EDL-9770,2018
+EDLT,4610,1,Content Area Read/Writing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-4610,2018
+EDLT,4800,1,Found in Adolescent Literacy,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,phillip micha wilder,,EDLT-4800,2018
+EDLT,4800,2,Found in Adolescent Literacy,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,phillip micha wilder,,EDLT-4800,2018
+EDLT,8150,500,Guided Reading & Guided Writng,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,susan king fullerton,,EDLT-8150,2018
+EDLT,8170,300,Content Area Rdg/Wtg: ECE-ELEM,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8170,2018
+EDLT,8170,500,Content Area Rdg/Wtg: ECE-ELEM,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8170,2018
+EDLT,8220,500,Strategies for Teaching ESOL,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-8220,2018
+EDLT,8240,300,Practicum in ESOL,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,rebecca kaminski,,EDLT-8240,2018
+EDLT,8400,501,Early Literacy Assessment I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,,EDLT-8400,2018
+EDLT,8400,502,Early Literacy Assessment I,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,antoinett dibellonia,,EDLT-8400,2018
+EDLT,8400,506,Early Literacy Assessment I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jo anne solesbee,,EDLT-8400,2018
+EDLT,8800,505,Reading Recovery Teacher I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,,EDLT-8800,2018
+EDSC,2260,1,Pr Apprch to Sec Alg,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,stacy megan che,,EDSC-2260,2018
+EDSP,3700,1,Intro to Special Education,0.74,0.18,0.06,0.03,0.0,0.0,0.0,0.0,friggita johnson,,EDSP-3700,2018
+EDSP,3720,1,Char & Instr Individ with LD,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,,EDSP-3720,2018
+EDSP,4920,1,Math Inst Ind W/Dis,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,pamela stecker,,EDSP-4920,2018
+EDSP,4930,1,Clsrm/Beh Mgmt Sp Ed,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,joseph benedict ryan,,EDSP-4930,2018
+EDSP,4940,1,Tchg Rdg Mild Dis,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,abigail anne allen,,EDSP-4940,2018
+EDSP,4960,1,Sp Ed Field Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,wendell kent parker,,EDSP-4960,2018
+EDSP,4970,1,Sec Meth Ind W/Dis,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,wendell kent parker,,EDSP-4970,2018
+EDSP,8120,400,Learning Disabilities Prac Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,catherine griffith,,EDSP-8120,2018
+EDSP,8220,400,Tchg Math Indv W/Dis,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,pamela stecker,,EDSP-8220,2018
+EDSP,8530,1,Legal/Pol Issu Sp Ed,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,,EDSP-8530,2018
+EES,2010,1,Environ Engr Fundamentals I,0.31,0.33,0.14,0.0,0.11,0.0,0.0,0.11,david freedman,,EES-2010,2018
+EES,3030,1,Water Treatment Systems,0.41,0.38,0.14,0.03,0.03,0.0,0.0,0.0,david allen ladner,,EES-3030,2018
+EES,3040,1,Wastewater Treatment Systems,0.31,0.45,0.17,0.07,0.0,0.0,0.0,0.0,sudeep popat,,EES-3040,2018
+EES,3050,1,Water/Wastewater Treatment Lab,0.38,0.38,0.19,0.06,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2018
+EES,3050,2,Water/Wastewater Treatment Lab,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,sudeep popat,,EES-3050,2018
+EES,4010,1,Environmental Engr,0.82,0.16,0.03,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,EES-4010,2018
+EES,4010,2,Environmental Engr,0.27,0.53,0.13,0.03,0.03,0.0,0.0,0.0,mark schlautman,,EES-4010,2018
+EES,4090,1,Intro to Nuc Engr & Radiol Sci,0.18,0.53,0.12,0.12,0.0,0.0,0.0,0.06,timothy devol,,EES-4090,2018
+EES,4300,1,Air Pollution Engineering,0.44,0.31,0.14,0.0,0.03,0.0,0.0,0.08,andrew richa metcalf,,EES-4300,2018
+EES,4800,1,Environmental Risk Assessment,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,nicole eliz martinez,,EES-4800,2018
+EES,4840,1,Solid Waste Mgt,0.35,0.46,0.08,0.08,0.04,0.0,0.0,0.0,ezra lucas hoy cates hoy,,EES-4840,2018
+EES,4860,1,Environmental Sustainability,0.78,0.15,0.04,0.0,0.0,0.0,0.0,0.04,michael anthony dale,,EES-4860,2018
+EES,8020,1,Environ Eng Prin,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-8020,2018
+EES,8430,1,Environmental Chem,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,,EES-8430,2018
+EES,8510,1,Biol Prin Envir Engr,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,kevin thoma finneran,,EES-8510,2018
+EES,8800,1,Env Risk Assessment,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,,EES-8800,2018
+ELE,3010,1,Entrepreneurial Foundations,0.19,0.37,0.37,0.01,0.0,0.0,0.0,0.04,ashley willi parnell,,ELE-3010,2018
+ELE,3010,2,Entrepreneurial Foundations,0.12,0.34,0.36,0.12,0.0,0.0,0.0,0.06,ashley willi parnell,,ELE-3010,2018
+ELE,3020,1,Entrepreneurial Resource Acqu,0.36,0.44,0.17,0.0,0.0,0.0,0.0,0.03,karl bruce kelly,,ELE-3020,2018
+ELE,3020,2,Entrepreneurial Resource Acqu,0.26,0.71,0.03,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,,ELE-3020,2018
+ELE,4020,1,Venture Creation,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,,ELE-4020,2018
+ELE,4990,1,Venture Consulting,0.49,0.46,0.05,0.0,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-4990,2018
+ELE,4990,2,Venture Counsulting,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-4990,2018
+ENGL,1030,1,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,allen swords,,ENGL-1030,2018
+ENGL,1030,2,Composition and Rhetoric,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-1030,2018
+ENGL,1030,3,Composition and Rhetoric,0.26,0.26,0.26,0.05,0.05,0.0,0.0,0.11,chelsea marie clarey,,ENGL-1030,2018
+ENGL,1030,4,Composition and Rhetoric,0.75,0.06,0.0,0.13,0.0,0.0,0.0,0.06,stephanie stripling,,ENGL-1030,2018
+ENGL,1030,6,Composition and Rhetoric,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,,ENGL-1030,2018
+ENGL,1030,8,Composition and Rhetoric,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,chelsea marie clarey,,ENGL-1030,2018
+ENGL,1030,10,Composition and Rhetoric,0.42,0.32,0.16,0.11,0.0,0.0,0.0,0.0,allison nicol harris,,ENGL-1030,2018
+ENGL,1030,11,Composition and Rhetoric,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,allison nicol harris,,ENGL-1030,2018
+ENGL,1030,13,Composition and Rhetoric,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,julia brownlee koets,,ENGL-1030,2018
+ENGL,1030,18,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,,ENGL-1030,2018
+ENGL,1030,19,Composition and Rhetoric,0.74,0.11,0.11,0.05,0.0,0.0,0.0,0.0,stephanie stripling,,ENGL-1030,2018
+ENGL,1030,23,Composition and Rhetoric,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,charissa fryberger,,ENGL-1030,2018
+ENGL,1030,24,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,charissa fryberger,,ENGL-1030,2018
+ENGL,1030,27,Composition and Rhetoric,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,naomi marie white,,ENGL-1030,2018
+ENGL,1030,29,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,eric reid hamilton,,ENGL-1030,2018
+ENGL,1030,32,Composition and Rhetoric,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,blake elizabe bowens,,ENGL-1030,2018
+ENGL,1030,33,Composition and Rhetoric,0.47,0.32,0.11,0.0,0.05,0.0,0.0,0.05,geveryl lee robinson,,ENGL-1030,2018
+ENGL,1030,34,Composition and Rhetoric,0.42,0.26,0.16,0.05,0.11,0.0,0.0,0.0,geveryl lee robinson,,ENGL-1030,2018
+ENGL,1030,35,Composition and Rhetoric,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,blake elizabe bowens,,ENGL-1030,2018
+ENGL,1030,37,Composition and Rhetoric,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,naomi marie white,,ENGL-1030,2018
+ENGL,1030,38,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,,ENGL-1030,2018
+ENGL,1030,39,Composition and Rhetoric,0.58,0.26,0.05,0.0,0.0,0.0,0.0,0.11,julie edewaard,,ENGL-1030,2018
+ENGL,1030,40,Composition and Rhetoric,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,julie edewaard,,ENGL-1030,2018
+ENGL,1030,41,Composition and Rhetoric,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,myers addison enlow,,ENGL-1030,2018
+ENGL,1030,42,Composition and Rhetoric,0.63,0.16,0.11,0.0,0.11,0.0,0.0,0.0,myers addison enlow,,ENGL-1030,2018
+ENGL,1030,43,Composition and Rhetoric,0.63,0.16,0.11,0.0,0.05,0.0,0.0,0.05,jennie eli wakefield,,ENGL-1030,2018
+ENGL,1030,44,Composition and Rhetoric,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,caroline eliza young,,ENGL-1030,2018
+ENGL,1030,45,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,,ENGL-1030,2018
+ENGL,1030,46,Composition and Rhetoric,0.68,0.21,0.0,0.11,0.0,0.0,0.0,0.0,jennie eli wakefield,,ENGL-1030,2018
+ENGL,1030,47,Composition and Rhetoric,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,chloe miche whitaker,,ENGL-1030,2018
+ENGL,1030,48,Composition and Rhetoric,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,chloe miche whitaker,,ENGL-1030,2018
+ENGL,1030,51,Composition and Rhetoric,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,victoria houser,,ENGL-1030,2018
+ENGL,1030,52,Composition and Rhetoric,0.68,0.05,0.16,0.05,0.05,0.0,0.0,0.0,victoria houser,,ENGL-1030,2018
+ENGL,1030,53,Composition and Rhetoric,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,michelle lloyd,,ENGL-1030,2018
+ENGL,1030,55,Composition and Rhetoric,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,michelle lloyd,,ENGL-1030,2018
+ENGL,1030,61,Composition and Rhetoric,0.53,0.26,0.16,0.05,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-1030,2018
+ENGL,1030,71,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,shauna chung,,ENGL-1030,2018
+ENGL,1030,73,Composition and Rhetoric,0.21,0.68,0.0,0.0,0.0,0.0,0.0,0.11,la'cresha ulon green,,ENGL-1030,2018
+ENGL,1030,74,Composition and Rhetoric,0.22,0.44,0.11,0.06,0.0,0.0,0.0,0.17,la'cresha ulon green,,ENGL-1030,2018
+ENGL,1030,75,Composition and Rhetoric,0.39,0.33,0.06,0.0,0.0,0.0,0.0,0.22,kristian wilson,,ENGL-1030,2018
+ENGL,1030,76,Composition and Rhetoric,0.32,0.32,0.05,0.05,0.0,0.0,0.0,0.26,kristian wilson,,ENGL-1030,2018
+ENGL,1030,82,Composition and Rhetoric,0.22,0.5,0.17,0.0,0.06,0.0,0.0,0.06,andrew mathas,,ENGL-1030,2018
+ENGL,1030,83,Composition and Rhetoric,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,,ENGL-1030,2018
+ENGL,2120,3,World Literature,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathle nalley,,ENGL-2120,2018
+ENGL,2120,5,World Literature,0.11,0.58,0.21,0.05,0.05,0.0,0.0,0.0,sarah mae cooper,,ENGL-2120,2018
+ENGL,2120,6,World Literature,0.17,0.5,0.22,0.06,0.0,0.0,0.0,0.06,david charles foltz,,ENGL-2120,2018
+ENGL,2120,7,World Literature,0.22,0.39,0.11,0.11,0.0,0.0,0.0,0.17,david charles foltz,,ENGL-2120,2018
+ENGL,2120,9,World Literature,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,hannah pittma godwin,,ENGL-2120,2018
+ENGL,2120,10,World Literature,0.47,0.26,0.21,0.0,0.0,0.0,0.0,0.05,hannah pittma godwin,,ENGL-2120,2018
+ENGL,2120,11,World Literature,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,hannah pittma godwin,,ENGL-2120,2018
+ENGL,2120,12,World Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathle nalley,,ENGL-2120,2018
+ENGL,2120,13,World Literature,0.42,0.26,0.11,0.11,0.0,0.0,0.0,0.11,heather pri williams,,ENGL-2120,2018
+ENGL,2120,15,World Literature,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,chloe miche whitaker,,ENGL-2120,2018
+ENGL,2120,19,World Literature,0.37,0.37,0.21,0.0,0.0,0.0,0.0,0.05,chloe miche whitaker,,ENGL-2120,2018
+ENGL,2120,20,World Literature,0.47,0.21,0.16,0.0,0.11,0.0,0.0,0.05,hannah pittma godwin,,ENGL-2120,2018
+ENGL,2120,21,World Literature,0.33,0.17,0.33,0.0,0.08,0.0,0.0,0.08,gabriel ande hankins,,ENGL-2120,2018
+ENGL,2120,400,World Literature,0.19,0.48,0.19,0.04,0.04,0.0,0.0,0.07,sarah mae cooper,,ENGL-2120,2018
+ENGL,2120,401,World Literature,0.18,0.47,0.18,0.06,0.06,0.0,0.0,0.06,sarah mae cooper,,ENGL-2120,2018
+ENGL,2120,402,World Literature,0.73,0.15,0.08,0.0,0.04,0.0,0.0,0.0,heather pri williams,,ENGL-2120,2018
+ENGL,2120,403,World Literature,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.04,keri ja crist-wagner,,ENGL-2120,2018
+ENGL,2130,3,British Literature,0.37,0.21,0.21,0.05,0.11,0.0,0.0,0.05,megan noe macalystre,,ENGL-2130,2018
+ENGL,2130,4,British Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john morgenstern,,ENGL-2130,2018
+ENGL,2130,5,British Literature,0.63,0.16,0.16,0.0,0.0,0.0,0.0,0.05,lucian ghita,,ENGL-2130,2018
+ENGL,2130,6,British Literature,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,kriste aldebol-hazle,,ENGL-2130,2018
+ENGL,2130,7,British Literature,0.37,0.37,0.05,0.05,0.0,0.0,0.0,0.16,megan noe macalystre,,ENGL-2130,2018
+ENGL,2130,9,British Literature,0.32,0.42,0.16,0.05,0.05,0.0,0.0,0.0,megan noe macalystre,,ENGL-2130,2018
+ENGL,2130,10,British Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2018
+ENGL,2130,11,British Literature,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,christopher benson,,ENGL-2130,2018
+ENGL,2130,12,British Literature,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2018
+ENGL,2130,13,British Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2018
+ENGL,2130,400,British Literature,0.37,0.48,0.07,0.0,0.04,0.0,0.0,0.04,daniel scott citro,,ENGL-2130,2018
+ENGL,2130,401,British Literature,0.39,0.43,0.11,0.04,0.0,0.0,0.0,0.04,daniel scott citro,,ENGL-2130,2018
+ENGL,2130,402,British Literature,0.48,0.24,0.2,0.0,0.04,0.0,0.0,0.04,kriste aldebol-hazle,,ENGL-2130,2018
+ENGL,2140,1,American Literature,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2018
+ENGL,2140,5,American Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2018
+ENGL,2140,6,American Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,,ENGL-2140,2018
+ENGL,2140,7,American Literature,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,,ENGL-2140,2018
+ENGL,2140,8,American Literature,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john robert smith,,ENGL-2140,2018
+ENGL,2140,14,American Literature,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2018
+ENGL,2140,17,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2018
+ENGL,2140,400,American Literature,0.84,0.12,0.0,0.04,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2018
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,allen swords,,ENGL-2150,2018
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-2150,2018
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.26,0.42,0.11,0.05,0.05,0.0,0.0,0.11,john logan pursley,,ENGL-2150,2018
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.47,0.37,0.05,0.11,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2018
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,sharon kathle nalley,,ENGL-2150,2018
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.42,0.32,0.05,0.11,0.0,0.0,0.0,0.11,andrew mathas,,ENGL-2150,2018
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.47,0.35,0.06,0.0,0.12,0.0,0.0,0.0,andrew mathas,,ENGL-2150,2018
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,david charles foltz,,ENGL-2150,2018
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.16,0.21,0.05,0.05,0.0,0.0,0.0,elizabeth stansell,,ENGL-2150,2018
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-2150,2018
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,allison nicol harris,,ENGL-2150,2018
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.84,0.0,0.05,0.05,0.05,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2018
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,remley meliss makala,,ENGL-2150,2018
+ENGL,2150,18,Lit in 20th-21st Cent Contexts,0.37,0.37,0.11,0.0,0.11,0.0,0.0,0.05,chelsea marie clarey,,ENGL-2150,2018
+ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.47,0.32,0.11,0.0,0.05,0.0,0.0,0.05,david charles foltz,,ENGL-2150,2018
+ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.44,0.39,0.06,0.0,0.0,0.0,0.0,0.11,david charles foltz,,ENGL-2150,2018
+ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,allison nicol harris,,ENGL-2150,2018
+ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2150,2018
+ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.37,0.42,0.11,0.05,0.0,0.0,0.0,0.05,chelsea marie clarey,,ENGL-2150,2018
+ENGL,2150,26,Lit in 20th-21st Cent Contexts,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,daniel scott citro,,ENGL-2150,2018
+ENGL,2150,27,Lit in 20th-21st Cent Contexts,0.72,0.11,0.11,0.06,0.0,0.0,0.0,0.0,remley meliss makala,,ENGL-2150,2018
+ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.42,0.19,0.19,0.0,0.04,0.0,0.0,0.15,candace wiley,,ENGL-2150,2018
+ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.37,0.11,0.15,0.15,0.07,0.0,0.0,0.15,candace wiley,,ENGL-2150,2018
+ENGL,2150,402,Lit in 20th-21st Cent Contexts,0.56,0.26,0.15,0.04,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-2150,2018
+ENGL,2150,403,Lit in 20th-21st Cent Contexts,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,allison nicol harris,,ENGL-2150,2018
+ENGL,3010,1,Great Books of Western World,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,dominic mastroianni,,ENGL-3010,2018
+ENGL,3040,1,Business Writing,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,,ENGL-3040,2018
+ENGL,3040,3,Business Writing,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulon green,,ENGL-3040,2018
+ENGL,3040,4,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulon green,,ENGL-3040,2018
+ENGL,3040,5,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,,ENGL-3040,2018
+ENGL,3040,12,Business Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,heather pri williams,,ENGL-3040,2018
+ENGL,3040,15,Business Writing,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,katalin beck,,ENGL-3040,2018
+ENGL,3040,16,Business Writing,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3040,2018
+ENGL,3040,19,Business Writing,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,,ENGL-3040,2018
+ENGL,3040,20,Business Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,,ENGL-3040,2018
+ENGL,3040,400,Business Writing,0.85,0.05,0.1,0.0,0.0,0.0,0.0,0.0,kriste aldebol-hazle,,ENGL-3040,2018
+ENGL,3040,401,Business Writing,0.78,0.0,0.17,0.06,0.0,0.0,0.0,0.0,kriste aldebol-hazle,,ENGL-3040,2018
+ENGL,3040,402,Business Writing,0.47,0.37,0.05,0.0,0.11,0.0,0.0,0.0,sean williams,,ENGL-3040,2018
+ENGL,3100,1,Crit Writ Lit,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth rivlin,,ENGL-3100,2018
+ENGL,3100,2,Crit Writ Lit,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,cameron fae bushnell,,ENGL-3100,2018
+ENGL,3100,3,Crit Writ Lit,0.58,0.21,0.11,0.0,0.0,0.0,0.0,0.11,kimberly manganelli,,ENGL-3100,2018
+ENGL,3100,4,Crit Writ Lit,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,,ENGL-3100,2018
+ENGL,3120,1,Advanced Composition,0.82,0.0,0.12,0.0,0.06,0.0,0.0,0.0,christopher stuart,,ENGL-3120,2018
+ENGL,3120,2,Advanced Composition,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,christopher stuart,,ENGL-3120,2018
+ENGL,3120,3,Advanced Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,,ENGL-3120,2018
+ENGL,3140,1,Technical Writing,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,william pulley,,ENGL-3140,2018
+ENGL,3140,2,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2018
+ENGL,3140,4,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,,ENGL-3140,2018
+ENGL,3140,6,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,beltran dian quaglia,,ENGL-3140,2018
+ENGL,3140,8,Technical Writing,0.79,0.05,0.05,0.05,0.0,0.0,0.0,0.05,brian lee gaines,,ENGL-3140,2018
+ENGL,3140,11,Technical Writing,0.5,0.33,0.06,0.06,0.0,0.0,0.0,0.06,geveryl lee robinson,,ENGL-3140,2018
+ENGL,3140,12,Technical Writing,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,geveryl lee robinson,,ENGL-3140,2018
+ENGL,3140,13,Technical Writing,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,april obrien,,ENGL-3140,2018
+ENGL,3140,14,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,april obrien,,ENGL-3140,2018
+ENGL,3140,16,Technical Writing,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2018
+ENGL,3140,22,Technical Writing,0.74,0.11,0.0,0.0,0.05,0.0,0.0,0.11,michael david measel,,ENGL-3140,2018
+ENGL,3140,100,Technical Writing (HONORS),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,True,ENGL-3140,2018
+ENGL,3150,1,Scientific Writing & Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-3150,2018
+ENGL,3150,2,Scientific Writing & Comm,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-3150,2018
+ENGL,3150,3,Scientific Writing & Comm,0.53,0.24,0.06,0.06,0.0,0.0,0.0,0.12,william pulley,,ENGL-3150,2018
+ENGL,3150,4,Scientific Writing & Comm,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,william pulley,,ENGL-3150,2018
+ENGL,3150,400,Scientific Writing & Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2018
+ENGL,3150,401,Scientific Writing & Comm,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2018
+ENGL,3150,402,Scientific Writing & Comm,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2018
+ENGL,3150,403,Scientific Writing & Comm,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2018
+ENGL,3150,405,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2018
+ENGL,3450,1,Intr Creative Writing: Fiction,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nicholas chris brown,,ENGL-3450,2018
+ENGL,3460,2,Intr Creative Writing: Poetry,0.61,0.22,0.06,0.06,0.0,0.0,0.0,0.06,sharon kathle nalley,,ENGL-3460,2018
+ENGL,3480,1,Intr Creat Writ: Screenwriting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,,ENGL-3480,2018
+ENGL,3480,2,Intr Creat Writ: Screenwriting,0.67,0.17,0.0,0.0,0.06,0.0,0.0,0.11,julia brownlee koets,,ENGL-3480,2018
+ENGL,3570,1,Film,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,,ENGL-3570,2018
+ENGL,3800,1,Women Writers,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,remley meliss makala,,ENGL-3800,2018
+ENGL,3850,1,Children's Lit,0.6,0.27,0.0,0.0,0.13,0.0,0.0,0.0,megan noe macalystre,,ENGL-3850,2018
+ENGL,3860,1,Adolescent Lit,0.12,0.65,0.24,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-3860,2018
+ENGL,3970,2,Brit Lit Survey II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,,ENGL-3970,2018
+ENGL,3980,2,Amer Lit Survey I,0.26,0.63,0.05,0.0,0.0,0.0,0.0,0.05,susanna ashton,,ENGL-3980,2018
+ENGL,4010,1,Grammar Survey,0.68,0.11,0.11,0.05,0.05,0.0,0.0,0.0,william stockton,,ENGL-4010,2018
+ENGL,4080,1,Chaucer,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,andrew lemons,,ENGL-4080,2018
+ENGL,4180,1,English Novel,0.09,0.64,0.18,0.0,0.0,0.0,0.0,0.09,lee morrissey,,ENGL-4180,2018
+ENGL,4200,1,Amer Lit to 1799,0.4,0.4,0.0,0.0,0.07,0.0,0.0,0.13,jonathan beech field,,ENGL-4200,2018
+ENGL,4210,1,Amer Lit 1800-1899,0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,dominic mastroianni,,ENGL-4210,2018
+ENGL,4280,1,Contemporary Literature,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,matthew hooley,,ENGL-4280,2018
+ENGL,4310,1,Modern Poetry,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-4310,2018
+ENGL,4360,1,Feminist Literary Criticism,0.47,0.29,0.12,0.06,0.0,0.0,0.0,0.06,erin marina goss,,ENGL-4360,2018
+ENGL,4400,1,Literary Theory,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,maria selene bose,,ENGL-4400,2018
+ENGL,4420,1,Cultural Studies,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,maria selene bose,,ENGL-4420,2018
+ENGL,4430,1,Theories of World Literature,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,andrew lemons,,ENGL-4430,2018
+ENGL,4440,1,Renaissance Literature,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4440,2018
+ENGL,4450,1,Fiction Workshop,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-4450,2018
+ENGL,4480,1,Screenwriting Wkshop,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,nicholas chris brown,,ENGL-4480,2018
+ENGL,4510,1,Film Theory and Criticism,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,john robert smith,,ENGL-4510,2018
+ENGL,4510,2,Film Theory and Criticism,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,john robert smith,,ENGL-4510,2018
+ENGL,4520,1,Great Directors,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,olga anatoly volkova,,ENGL-4520,2018
+ENGL,4560,1,Holocaust Lit/Arts,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,steven katz,,ENGL-4560,2018
+ENGL,4600,1,Writing Technologies,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,tharon howard,,ENGL-4600,2018
+ENGL,4780,1,Digital Literacy,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,tharon howard,,ENGL-4780,2018
+ENGL,4920,1,Modern Rhetoric,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,megan eatman,,ENGL-4920,2018
+ENGL,4960,1,Senior Seminar,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jonathan beech field,,ENGL-4960,2018
+ENGL,4960,2,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,,ENGL-4960,2018
+ENGL,4960,3,Senior Seminar,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,erin marina goss,,ENGL-4960,2018
+ENGL,8520,1,Rhetorical Theories & Practice,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,megan eatman,,ENGL-8520,2018
+ENGR,1020,112,Engineering Discipl & Skills,0.13,0.63,0.15,0.03,0.0,0.0,0.0,0.08,sarah grigg,,ENGR-1020,2018
+ENGR,1020,113,Engineering Discipl & Skills,0.18,0.63,0.18,0.0,0.0,0.0,0.0,0.03,sarah grigg,,ENGR-1020,2018
+ENGR,1020,116,Engineering Discipl & Skills,0.4,0.38,0.15,0.0,0.0,0.0,0.0,0.08,michael giebner,,ENGR-1020,2018
+ENGR,1020,211,Engineering Discipl & Skills,0.38,0.4,0.05,0.05,0.05,0.0,0.0,0.07,ashley childers,,ENGR-1020,2018
+ENGR,1020,218,Engineering Discipl & Skills,0.21,0.47,0.21,0.05,0.03,0.0,0.0,0.03,michael giebner,,ENGR-1020,2018
+ENGR,1020,311,Engineering Discipl & Skills,0.24,0.43,0.21,0.02,0.05,0.0,0.0,0.05,john minor,,ENGR-1020,2018
+ENGR,1020,312,Engineering Discipl & Skills,0.33,0.36,0.21,0.02,0.02,0.0,0.0,0.05,john minor,,ENGR-1020,2018
+ENGR,1020,314,Engineering Discipl & Skills,0.51,0.17,0.17,0.07,0.0,0.0,0.0,0.07,ashley childers,,ENGR-1020,2018
+ENGR,1020,315,Engr Discipl & Skills (HON),0.76,0.21,0.0,0.0,0.0,0.0,0.0,0.03,richard watkins,True,ENGR-1020,2018
+ENGR,1020,316,Engineering Discipl & Skills,0.33,0.38,0.14,0.02,0.02,0.0,0.0,0.1,steven brandon,,ENGR-1020,2018
+ENGR,1020,611,Engineering Discipl & Skills,0.37,0.37,0.12,0.07,0.02,0.0,0.0,0.05,irene marie ferrara,,ENGR-1020,2018
+ENGR,1020,612,Engineering Discipl & Skills,0.63,0.2,0.12,0.02,0.02,0.0,0.0,0.0,irene marie ferrara,,ENGR-1020,2018
+ENGR,1020,613,Engineering Discipl & Skills,0.12,0.33,0.3,0.12,0.03,0.0,0.0,0.09,elizabeth an stephan,,ENGR-1020,2018
+ENGR,1020,614,Engineering Discipl & Skills,0.09,0.19,0.13,0.25,0.06,0.0,0.0,0.28,matthew kent miller,,ENGR-1020,2018
+ENGR,1020,615,Engineering Discipl & Skills,0.31,0.36,0.21,0.07,0.0,0.0,0.0,0.05,anthony paul garland,,ENGR-1020,2018
+ENGR,1020,616,Engineering Discipl & Skills,0.04,0.48,0.3,0.07,0.04,0.0,0.0,0.07,andrew isaac neptune,,ENGR-1020,2018
+ENGR,1020,617,Engineering Discipl & Skills,0.34,0.32,0.21,0.0,0.0,0.0,0.0,0.13,anthony paul garland,,ENGR-1020,2018
+ENGR,1020,618,Engineering Discipl & Skills,0.12,0.39,0.27,0.05,0.02,0.0,0.0,0.15,anthony paul garland,,ENGR-1020,2018
+ENGR,1020,811,Engineering Discipl & Skills,0.45,0.38,0.15,0.03,0.0,0.0,0.0,0.0,jonathan broo harcum,,ENGR-1020,2018
+ENGR,1020,812,Engineering Discipl & Skills,0.29,0.49,0.15,0.05,0.0,0.0,0.0,0.02,elizabeth an stephan,,ENGR-1020,2018
+ENGR,1020,813,Engineering Discipl & Skills,0.3,0.43,0.18,0.08,0.0,0.0,0.0,0.03,andrew isaac neptune,,ENGR-1020,2018
+ENGR,1020,814,Engineering Discipl & Skills,0.55,0.3,0.08,0.03,0.0,0.0,0.0,0.05,jonathan broo harcum,,ENGR-1020,2018
+ENGR,1020,815,Engineering Discipl & Skills,0.4,0.5,0.05,0.0,0.05,0.0,0.0,0.0,jonathan broo harcum,,ENGR-1020,2018
+ENGR,1020,816,Engineering Discipl & Skills,0.43,0.38,0.13,0.03,0.0,0.0,0.0,0.05,matthew kent miller,,ENGR-1020,2018
+ENGR,1020,817,Engineering Discipl & Skills,0.23,0.5,0.15,0.08,0.0,0.0,0.0,0.05,matthew kent miller,,ENGR-1020,2018
+ENGR,1020,818,Engineering Discipl & Skills,0.41,0.38,0.05,0.14,0.03,0.0,0.0,0.0,andrew isaac neptune,,ENGR-1020,2018
+ENGR,1020,831,Engr Discipl & Skills (HON),0.69,0.29,0.0,0.0,0.0,0.0,0.0,0.03,jonathan maier,True,ENGR-1020,2018
+ENGR,1020,832,Engr Discipl & Skills (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jonathan maier,True,ENGR-1020,2018
+ENGR,1060,400,Engr Discipline & Skills II,0.0,0.44,0.19,0.19,0.19,0.0,0.0,0.0,mariah so magagnotti,,ENGR-1060,2018
+ENGR,1060,401,Engr Discipline & Skills II,0.17,0.17,0.17,0.17,0.33,0.0,0.0,0.0,mariah so magagnotti,,ENGR-1060,2018
+ENGR,1410,222,Programming & Problem Solving,0.05,0.26,0.32,0.11,0.16,0.0,0.0,0.11,mariah so magagnotti,,ENGR-1410,2018
+ENGR,1410,223,Programming & Problem Solving,0.05,0.16,0.51,0.11,0.03,0.0,0.0,0.14,william martin,,ENGR-1410,2018
+ENGR,1410,226,Programming & Problem Solving,0.13,0.21,0.39,0.11,0.11,0.0,0.0,0.05,mariah so magagnotti,,ENGR-1410,2018
+ENGR,1410,227,Programming & Problem Solving,0.14,0.36,0.31,0.14,0.03,0.0,0.0,0.03,william martin,,ENGR-1410,2018
+ENGR,2080,681,Engr Graphics & Machine Design,0.42,0.33,0.11,0.0,0.08,0.0,0.0,0.06,nighat yasmin,,ENGR-2080,2018
+ENGR,2080,682,Engr Graphics & Machine Design,0.32,0.3,0.22,0.11,0.05,0.0,0.0,0.0,nighat yasmin,,ENGR-2080,2018
+ENGR,2080,683,Engr Graphics & Machine Design,0.44,0.33,0.13,0.0,0.1,0.0,0.0,0.0,kyle walker,,ENGR-2080,2018
+ENGR,2080,684,Engr Graphics & Machine Design,0.37,0.39,0.13,0.0,0.0,0.0,0.0,0.11,kyle walker,,ENGR-2080,2018
+ENGR,2080,685,Engr Graphics & Machine Design,0.5,0.16,0.16,0.03,0.03,0.0,0.0,0.13,samuel coeyman,,ENGR-2080,2018
+ENGR,2080,686,Engr Graphics & Machine Design,0.35,0.32,0.21,0.06,0.06,0.0,0.0,0.0,samuel coeyman,,ENGR-2080,2018
+ENGR,2100,804,CAD & Engineering Applications,0.44,0.18,0.1,0.1,0.1,0.0,0.0,0.08,afshin famili,,ENGR-2100,2018
+ENGR,2100,805,CAD & Engineering Applications,0.45,0.33,0.1,0.03,0.05,0.0,0.0,0.05,nighat yasmin,,ENGR-2100,2018
+ENGR,2100,806,CAD & Engineering Applications,0.55,0.26,0.03,0.05,0.0,0.0,0.0,0.11,afshin famili,,ENGR-2100,2018
+ENGR,2200,115,Evaluating Innovations,0.1,0.65,0.23,0.03,0.0,0.0,0.0,0.0,sarah grigg,,ENGR-2200,2018
+ENR,1010,2,Intro to Envir & Natur Res I,0.82,0.11,0.02,0.0,0.0,0.0,0.0,0.05,emily catheri oakman,,ENR-1010,2018
+ENR,1010,3,Intro to Envir & Natur Res I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,emily catheri oakman,,ENR-1010,2018
+ENR,4290,1,Environ Law & Policy,0.24,0.38,0.27,0.03,0.03,0.0,0.0,0.05,alan johnson,,ENR-4290,2018
+ENR,4290,2,Environ Law & Policy,0.36,0.45,0.11,0.0,0.0,0.0,0.0,0.07,alan johnson,,ENR-4290,2018
+ENSP,2000,1,Intro Environ Sci,0.33,0.47,0.19,0.0,0.02,0.0,0.0,0.0,scott brame,,ENSP-2000,2018
+ENSP,2000,2,Intro Environ Sci,0.69,0.28,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2018
+ENSP,2000,3,Intro Environ Sci,0.57,0.39,0.02,0.0,0.0,0.0,0.0,0.02,minory nammouz,,ENSP-2000,2018
+ENSP,2000,4,Intro Environ Sci,0.56,0.4,0.02,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,,ENSP-2000,2018
+ENSP,2000,5,Intro Environ Sci,0.39,0.39,0.13,0.02,0.0,0.0,0.0,0.07,tom owino,,ENSP-2000,2018
+ENSP,4000,1,Studies in Environmental Sci,0.53,0.35,0.0,0.06,0.0,0.0,0.0,0.06,margaret lo thompson,,ENSP-4000,2018
+ENT,2000,1,Six-Legged Science,0.53,0.4,0.05,0.0,0.0,0.0,0.0,0.03,suellen pometto,,ENT-2000,2018
+ENT,3010,1,Insect Biology and Diversity,0.33,0.33,0.27,0.07,0.0,0.0,0.0,0.0,eric benson,,ENT-3010,2018
+ENTR,1010,3,Entrepreneurial Mindset,0.69,0.23,0.05,0.01,0.01,0.0,0.0,0.01,john michael hannon,,ENTR-1010,2018
+ENTR,1090,6,Creative Inq-Entrepreneurship,0.61,0.3,0.0,0.0,0.0,0.0,0.0,0.09,john michael hannon,,ENTR-1090,2018
+ENTR,2010,4,Sports Entrepreneurship,0.63,0.27,0.03,0.0,0.03,0.0,0.0,0.03,john michael hannon,,ENTR-2010,2018
+ETOX,4300,1,Toxicology,0.54,0.23,0.15,0.08,0.0,0.0,0.0,0.0,lisa bain,,ETOX-4300,2018
+FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.88,0.05,0.02,0.02,0.01,0.0,0.0,0.02,sara lane cothran,,FDSC-1010,2018
+FDSC,3010,1,Food Regulations,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,,FDSC-3010,2018
+FDSC,4010,1,Food Chemistry I,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,feng chen,,FDSC-4010,2018
+FDSC,4040,1,Food Prsv & Process,0.53,0.21,0.21,0.02,0.02,0.0,0.0,0.0,anthony loui pometto,,FDSC-4040,2018
+FDSC,4070,1,Quantity Food Production,0.84,0.1,0.03,0.0,0.03,0.0,0.0,0.0,bridgit deni corbett,,FDSC-4070,2018
+FDSC,4300,1,Dairy Process & Sant,0.52,0.24,0.1,0.14,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-4300,2018
+FDSC,8120,1,Microbial Food Syst,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,xiuping jiang,,FDSC-8120,2018
+FDSC,8210,1,Selected Topics,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,julie kath northcutt,,FDSC-8210,2018
+FIN,2010,401,Intro to Personal Finance,0.95,0.04,0.01,0.0,0.0,0.0,0.0,0.0,joshua harris,,FIN-2010,2018
+FIN,2010,402,Intro to Personal Finance,0.89,0.08,0.01,0.0,0.0,0.0,0.0,0.02,joshua harris,,FIN-2010,2018
+FIN,2010,403,Intro to Personal Finance,0.9,0.07,0.01,0.0,0.01,0.0,0.0,0.01,joshua harris,,FIN-2010,2018
+FIN,2010,404,Intro to Personal Finance,0.78,0.09,0.02,0.02,0.06,0.0,0.0,0.02,joshua harris,,FIN-2010,2018
+FIN,2010,406,Intro to Personal Finance,0.79,0.15,0.0,0.02,0.02,0.0,0.0,0.02,joshua harris,,FIN-2010,2018
+FIN,2010,407,Intro to Personal Finance,0.81,0.1,0.0,0.1,0.0,0.0,0.0,0.0,joshua harris,,FIN-2010,2018
+FIN,3040,1,Risk & Insurance,0.28,0.3,0.23,0.15,0.0,0.0,0.0,0.05,kerri mcmillan,,FIN-3040,2018
+FIN,3050,1,Investment Analysis,0.07,0.29,0.32,0.05,0.17,0.0,0.0,0.1,kerri mcmillan,,FIN-3050,2018
+FIN,3050,2,Investment Analysis,0.08,0.5,0.32,0.03,0.08,0.0,0.0,0.0,kerri mcmillan,,FIN-3050,2018
+FIN,3050,3,Investment Analysis,0.21,0.36,0.28,0.05,0.03,0.0,0.0,0.08,kerri mcmillan,,FIN-3050,2018
+FIN,3050,4,Investment Analysis,0.14,0.25,0.19,0.17,0.14,0.0,0.0,0.11,john alexander,,FIN-3050,2018
+FIN,3060,5,Corporation Finance,0.09,0.45,0.3,0.11,0.02,0.0,0.0,0.04,ramon tolbe franklin,,FIN-3060,2018
+FIN,3060,6,Corporation Finance,0.09,0.27,0.34,0.14,0.09,0.0,0.0,0.07,ramon tolbe franklin,,FIN-3060,2018
+FIN,3060,7,Corporation Finance,0.15,0.26,0.26,0.15,0.0,0.0,0.0,0.17,ramon tolbe franklin,,FIN-3060,2018
+FIN,3060,8,Corporation Finance,0.24,0.41,0.25,0.08,0.0,0.0,0.0,0.02,melvin stith,,FIN-3060,2018
+FIN,3060,9,Corporation Finance,0.29,0.39,0.2,0.1,0.02,0.0,0.0,0.0,melvin stith,,FIN-3060,2018
+FIN,3060,401,Corporation Finance,0.49,0.23,0.23,0.02,0.0,0.0,0.0,0.04,joshua harris,,FIN-3060,2018
+FIN,3060,402,Corporation Finance,0.37,0.42,0.12,0.04,0.02,0.0,0.0,0.04,joshua harris,,FIN-3060,2018
+FIN,3070,1,Prin of Real Estate,0.1,0.22,0.39,0.17,0.1,0.0,0.0,0.02,thomas springer,,FIN-3070,2018
+FIN,3070,2,Prin of Real Estate,0.18,0.32,0.23,0.2,0.0,0.0,0.0,0.07,thomas springer,,FIN-3070,2018
+FIN,3070,3,Prin of Real Estate,0.26,0.42,0.29,0.03,0.0,0.0,0.0,0.0,yannan shen,,FIN-3070,2018
+FIN,3080,3,Fin Inst & Mkts,0.23,0.33,0.36,0.08,0.0,0.0,0.0,0.0,daniel thomas greene,,FIN-3080,2018
+FIN,3080,401,Fin Inst & Mkts,0.21,0.32,0.36,0.09,0.0,0.0,0.0,0.02,daniel thomas greene,,FIN-3080,2018
+FIN,3110,1,Financial Management I,0.12,0.24,0.31,0.12,0.05,0.0,0.0,0.17,jack wolf,,FIN-3110,2018
+FIN,3110,2,Financial Management I,0.12,0.3,0.4,0.12,0.05,0.0,0.0,0.02,jack wolf,,FIN-3110,2018
+FIN,3110,3,Financial Management I,0.28,0.28,0.28,0.13,0.05,0.0,0.0,0.0,jack wolf,,FIN-3110,2018
+FIN,3110,5,Financial Management I,0.16,0.34,0.36,0.11,0.02,0.0,0.0,0.02,weike xu,,FIN-3110,2018
+FIN,3110,6,Financial Management I,0.16,0.43,0.3,0.07,0.04,0.0,0.0,0.0,weike xu,,FIN-3110,2018
+FIN,3120,1,Financial Management II,0.17,0.3,0.37,0.1,0.0,0.0,0.0,0.07,vincent ja intintoli,,FIN-3120,2018
+FIN,3120,2,Financial Management II,0.05,0.31,0.36,0.1,0.14,0.0,0.0,0.05,vincent ja intintoli,,FIN-3120,2018
+FIN,3120,3,Financial Management II,0.24,0.27,0.15,0.07,0.05,0.0,0.0,0.22,blerina zykaj,,FIN-3120,2018
+FIN,3120,4,Financial Management II,0.21,0.39,0.21,0.05,0.04,0.0,0.0,0.09,weike xu,,FIN-3120,2018
+FIN,3120,101,Financial Mgt II (HON),0.7,0.2,0.0,0.1,0.0,0.0,0.0,0.0,vincent ja intintoli,True,FIN-3120,2018
+FIN,4010,1,Corporate Financial Analysis,0.33,0.4,0.17,0.02,0.02,0.0,0.0,0.05,george bran lockhart,,FIN-4010,2018
+FIN,4020,1,Corporate Valuation,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,angela morgan,,FIN-4020,2018
+FIN,4050,1,Portfolio Management & Theory,0.14,0.17,0.44,0.14,0.06,0.0,0.0,0.06,john alexander,,FIN-4050,2018
+FIN,4060,1,Derivatives Analysis,0.34,0.31,0.17,0.07,0.07,0.0,0.0,0.03,blerina zykaj,,FIN-4060,2018
+FIN,4110,1,Int Fin Mgt,0.21,0.46,0.28,0.05,0.0,0.0,0.0,0.0,luke asher devault,,FIN-4110,2018
+FIN,4110,2,Int Fin Mgt,0.22,0.53,0.22,0.03,0.0,0.0,0.0,0.0,luke asher devault,,FIN-4110,2018
+FIN,4170,1,Real Estate Finance,0.24,0.38,0.24,0.1,0.05,0.0,0.0,0.0,yannan shen,,FIN-4170,2018
+FNR,2040,1,Soil Information Systems,0.84,0.1,0.03,0.0,0.02,0.0,0.0,0.02,elena mikhailova,,FNR-2040,2018
+FNR,4990,1,Natural Resources Seminar,0.76,0.21,0.03,0.0,0.0,0.0,0.0,0.0,susan talley guynn,,FNR-4990,2018
+FOR,2050,1,Dendrology,0.24,0.35,0.05,0.22,0.08,0.0,0.0,0.05,donald hagan,,FOR-2050,2018
+FOR,2050,2,Dendrology,0.27,0.37,0.16,0.08,0.02,0.0,0.0,0.1,donald hagan,,FOR-2050,2018
+FOR,2050,3,Dendrology,0.37,0.16,0.11,0.11,0.21,0.0,0.0,0.05,donald hagan,,FOR-2050,2018
+FOR,2210,1,Forest Biology,0.75,0.12,0.1,0.01,0.0,0.0,0.0,0.02,emily catheri oakman,,FOR-2210,2018
+FOR,3020,1,Forest Biometrics,0.24,0.44,0.16,0.16,0.0,0.0,0.0,0.0,lawrence gering,,FOR-3020,2018
+FOR,3040,1,Forest Resource Economics,0.46,0.46,0.07,0.0,0.0,0.0,0.0,0.0,puskar khanal,,FOR-3040,2018
+FOR,4100,1,Harvesting Processes,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,patrick hiesl,,FOR-4100,2018
+FOR,4160,1,Forest Policy and Admin,0.44,0.3,0.22,0.02,0.0,0.0,0.0,0.01,thomas straka,,FOR-4160,2018
+FOR,4170,1,Forest Resource Mgt & Regulatn,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.0,puskar khanal,,FOR-4170,2018
+FOR,4310,1,Recreation Res Plan in For Mgt,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,robert baxter powell,,FOR-4310,2018
+FOR,4340,1,GIS for Natural Resources,0.79,0.19,0.02,0.0,0.0,0.0,0.0,0.0,christopher post,,FOR-4340,2018
+FR,1010,1,Elementary French,0.33,0.33,0.17,0.06,0.0,0.0,0.0,0.11, nedeo anne salces anne,,FR-1010,2018
+FR,1010,2,Elementary French,0.31,0.44,0.19,0.0,0.06,0.0,0.0,0.0, nedeo anne salces anne,,FR-1010,2018
+FR,1010,3,Elementary French,0.13,0.38,0.38,0.06,0.06,0.0,0.0,0.0, nedeo anne salces anne,,FR-1010,2018
+FR,1020,1,Elementary French,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,,FR-1020,2018
+FR,1020,2,Elementary French,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,amy lyn griff sawyer griff,,FR-1020,2018
+FR,2010,2,Intermediate French,0.28,0.56,0.06,0.0,0.06,0.0,0.0,0.06,kenneth davi widgren,,FR-2010,2018
+FR,2010,3,Intermediate French,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,kenneth davi widgren,,FR-2010,2018
+FR,2010,4,Intermediate French,0.33,0.5,0.06,0.06,0.0,0.0,0.0,0.06,tholozany pauline de,,FR-2010,2018
+FR,2020,1,Intermediate French,0.89,0.0,0.05,0.0,0.0,0.0,0.0,0.05,amy lyn griff sawyer griff,,FR-2020,2018
+FR,2020,2,Intermediate French,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,,FR-2020,2018
+FR,2020,3,Intermediate French,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-2020,2018
+FR,2020,4,Intermediate French,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,,FR-2020,2018
+FR,2020,5,Intermediate French,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,kenneth davi widgren,,FR-2020,2018
+FR,3000,1,Survey of French Lit,0.39,0.5,0.0,0.0,0.06,0.0,0.0,0.06,tholozany pauline de,,FR-3000,2018
+FR,3050,1,Int Fr Con & Comp I,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,kenneth davi widgren,,FR-3050,2018
+FR,4120,1,Fr & Francoph Cinema,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,joseph mai,,FR-4120,2018
+FR,4160,1,Fr for Intl Trade II,0.43,0.36,0.14,0.0,0.0,0.0,0.0,0.07,eric touya,,FR-4160,2018
+GC,1020,1,Computer Art & CAD Foundations,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,carol jones,,GC-1020,2018
+GC,1020,2,Computer Art & CAD Foundations,0.5,0.42,0.0,0.0,0.06,0.0,0.0,0.02,carol jones,,GC-1020,2018
+GC,1030,1,G C I for Pkgsc,0.29,0.67,0.05,0.0,0.0,0.0,0.0,0.0,john jacobs,,GC-1030,2018
+GC,1040,1,Graphic Communications I,0.67,0.23,0.05,0.02,0.02,0.0,0.0,0.02,michelle suki bo fox bo,,GC-1040,2018
+GC,2070,1,Graphic Communications II,0.6,0.29,0.02,0.0,0.04,0.0,0.0,0.04,charles tabor weiss,,GC-2070,2018
+GC,3400,1,Digital Imaging and eMedia,0.29,0.48,0.17,0.0,0.04,0.0,0.0,0.02,erica black walker,,GC-3400,2018
+GC,3460,1,Ink and Substrates,0.25,0.36,0.34,0.0,0.05,0.0,0.0,0.0,liam henry 'hara,,GC-3460,2018
+GC,4060,1,Package and Specialty Printing,0.67,0.29,0.02,0.0,0.02,0.0,0.0,0.0,kern cox,,GC-4060,2018
+GC,4400,1,Commercial Printing,0.28,0.59,0.1,0.0,0.03,0.0,0.0,0.0,eric weisenmiller,,GC-4400,2018
+GC,4440,1,Current Dev/Trends in Gr Comm,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,,GC-4440,2018
+GC,4800,1,Senior Seminar in GC,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,charles edwar tonkin,,GC-4800,2018
+GC,4900,1,Media & Film in Dig Age,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,erica black walker,,GC-4900,2018
+GC,4900,3,Digital Media Design,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erica black walker,,GC-4900,2018
+GC,4900,6,GC-UX & Web Design,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erica black walker,,GC-4900,2018
+GC,4900,230,G C Selected Topics-GC Sales,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,,GC-4900,2018
+GEN,1030,1,Careers in Bioch/Gen,0.88,0.07,0.0,0.01,0.03,0.0,0.0,0.01,alison ni starr-moss,,GEN-1030,2018
+GEN,3000,1,Fundamental Genetics,0.29,0.33,0.26,0.03,0.01,0.0,0.0,0.09,kate leanne wil tsai wil,,GEN-3000,2018
+GEN,3000,2,Fundamental Genetics,0.26,0.34,0.25,0.1,0.02,0.0,0.0,0.04,kate leanne wil tsai wil,,GEN-3000,2018
+GEN,3020,1,Molecular & General Genetics,0.57,0.35,0.05,0.01,0.0,0.0,0.0,0.02,jennifer may mason,,GEN-3020,2018
+GEN,3020,2,Molec & General Genetics (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True,GEN-3020,2018
+GEN,3040,1,Molecular Biology Laboratory,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,scott michael tanner,,GEN-3040,2018
+GEN,3040,2,Molecular Biology Laboratory,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-3040,2018
+GEN,3040,3,Molecular Biology Laboratory,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-3040,2018
+GEN,3040,4,Molecular Biology Laboratory,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-3040,2018
+GEN,4100,1,Population & Quant Genetics,0.38,0.44,0.1,0.04,0.02,0.0,0.0,0.02,scott michael tanner,,GEN-4100,2018
+GEN,4100,2,Population & Quant Gen (HON),0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,scott michael tanner,True,GEN-4100,2018
+GEN,4110,1,Population & Quant Gen Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-4110,2018
+GEN,4110,2,Population & Quant Gen Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-4110,2018
+GEN,4110,3,Population & Quant Gen Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-4110,2018
+GEN,4110,4,Population & Quant Gen Lab,0.79,0.0,0.07,0.0,0.07,0.0,0.0,0.07,scott michael tanner,,GEN-4110,2018
+GEN,4400,1,Bioinformatics,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,frank alexand feltus,,GEN-4400,2018
+GEN,4500,1,Comparative Genetics,0.25,0.45,0.25,0.0,0.03,0.0,0.0,0.03,leigh anne clark,,GEN-4500,2018
+GEN,4900,1,Epigenetics,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,rajandeep sin sekhon,,GEN-4900,2018
+GEN,8140,1,Advanced Genetics,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,miriam kristi konkel,,GEN-8140,2018
+GEOG,1030,1,World Regional Geography,0.33,0.42,0.15,0.02,0.02,0.0,0.0,0.06,william church terry,,GEOG-1030,2018
+GEOG,3010,1,Political Geography,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,christa smith,,GEOG-3010,2018
+GEOG,4010,1,Studies in Geography,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william church terry,,GEOG-4010,2018
+GEOL,1010,1,Physical Geology,0.22,0.3,0.18,0.11,0.09,0.0,0.0,0.1,alan coulson,,GEOL-1010,2018
+GEOL,1010,2,Physical Geology,0.24,0.33,0.25,0.05,0.06,0.0,0.0,0.06,alan coulson,,GEOL-1010,2018
+GEOL,1010,4,Physical Geology,0.49,0.29,0.16,0.0,0.02,0.0,0.0,0.04,mary katherin fidler,,GEOL-1010,2018
+GEOL,1030,1,Physical Geol Lab,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2018
+GEOL,1030,2,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,3,Physical Geol Lab,0.42,0.46,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2018
+GEOL,1030,4,Physical Geol Lab,0.38,0.46,0.17,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,5,Physical Geol Lab,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2018
+GEOL,1030,6,Physical Geol Lab,0.57,0.26,0.04,0.04,0.0,0.0,0.0,0.09,alan coulson,,GEOL-1030,2018
+GEOL,1030,7,Physical Geol Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2018
+GEOL,1030,9,Physical Geol Lab,0.32,0.5,0.09,0.05,0.0,0.0,0.0,0.05,alan coulson,,GEOL-1030,2018
+GEOL,1030,10,Physical Geol Lab,0.54,0.13,0.0,0.04,0.17,0.0,0.0,0.13,alan coulson,,GEOL-1030,2018
+GEOL,1030,11,Physical Geol Lab,0.58,0.29,0.04,0.0,0.04,0.0,0.0,0.04,alan coulson,,GEOL-1030,2018
+GEOL,1030,12,Physical Geol Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,13,Physical Geol Lab,0.22,0.48,0.22,0.04,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2018
+GEOL,1120,1,Earth Resources,0.27,0.32,0.23,0.09,0.05,0.0,0.0,0.03,mary katherin fidler,,GEOL-1120,2018
+GEOL,1140,1,Earth Resources Lab,0.58,0.2,0.13,0.02,0.02,0.0,0.0,0.04,mary katherin fidler,,GEOL-1140,2018
+GEOL,2050,1,Mineralogy & Intro Petrology,0.4,0.33,0.13,0.07,0.0,0.0,0.0,0.07,lind shuller-nickles,,GEOL-2050,2018
+GEOL,2070,1,Min & Intro Pet Lab,0.33,0.13,0.27,0.13,0.07,0.0,0.0,0.07,mary katherin fidler,,GEOL-2070,2018
+GEOL,2750,1,Field Methods,0.7,0.0,0.0,0.0,0.0,0.0,0.0,0.3,scott brame,,GEOL-2750,2018
+GEOL,3000,1,Environmental Geology,0.05,0.49,0.31,0.1,0.0,0.0,0.0,0.05,alan coulson,,GEOL-3000,2018
+GEOL,3020,1,Structural Geology,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,alexander tho pullen,,GEOL-3020,2018
+GEOL,4030,1,Invertebrate Paleontology,0.1,0.7,0.0,0.0,0.0,0.0,0.0,0.2,neil smith,,GEOL-4030,2018
+GEOL,4150,1,Analysis Geological Processes,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,lawrence murdoch,,GEOL-4150,2018
+GEOL,4910,1,Research Synthesis I,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,alan coulson,,GEOL-4910,2018
+GEOL,6820,1,Groundwater & Contam Transport,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,,GEOL-6820,2018
+GEOL,7900,501,Biogeography And Geology of SC,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,,GEOL-7900,2018
+GER,1010,2,Elementary German,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-1010,2018
+GER,1010,3,Elementary German,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,oswald harris king,,GER-1010,2018
+GER,1020,1,Elementary German,0.07,0.33,0.2,0.13,0.07,0.0,0.0,0.2, lee ferrell,,GER-1020,2018
+GER,2010,1,Intermediate German,0.25,0.19,0.38,0.13,0.06,0.0,0.0,0.0,johannes schmidt,,GER-2010,2018
+GER,2010,2,Intermediate German,0.08,0.31,0.38,0.23,0.0,0.0,0.0,0.0,johannes schmidt,,GER-2010,2018
+GER,2020,1,Intermediate German,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,gabriela stoicea,,GER-2020,2018
+GER,2020,2,Intermediate German,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,oswald harris king,,GER-2020,2018
+GER,3050,1,Ger Conv & Comp,0.57,0.21,0.21,0.0,0.0,0.0,0.0,0.0, lee ferrell,,GER-3050,2018
+GER,3400,1,German Culture,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,,GER-3400,2018
+HIST,1010,1,History of the United States,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,lee brady wilson,,HIST-1010,2018
+HIST,1010,2,History of the United States,0.21,0.47,0.18,0.09,0.06,0.0,0.0,0.0,john andrew,,HIST-1010,2018
+HIST,1020,1,History of the United States,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,maribel morey,,HIST-1020,2018
+HIST,1220,1,"Hist, Tech & Society",0.36,0.49,0.06,0.05,0.02,0.0,0.0,0.03,pamela mack,,HIST-1220,2018
+HIST,1240,1,Environmental History Survey,0.3,0.3,0.23,0.03,0.03,0.0,0.0,0.1,james bradf jeffries,,HIST-1240,2018
+HIST,1240,2,Environmental History Survey,0.23,0.37,0.23,0.13,0.03,0.0,0.0,0.0,james bradf jeffries,,HIST-1240,2018
+HIST,1720,1,The West and the World I,0.22,0.34,0.26,0.05,0.06,0.0,0.0,0.07,caroline dunn clark,,HIST-1720,2018
+HIST,1720,2,The West and the World I,0.29,0.47,0.15,0.07,0.02,0.0,0.0,0.01,steven marks,,HIST-1720,2018
+HIST,1730,1,The West and the World II,0.19,0.43,0.19,0.05,0.08,0.0,0.0,0.06,michael meng,,HIST-1730,2018
+HIST,1730,2,The West and the World II,0.44,0.3,0.15,0.04,0.0,0.0,0.0,0.07, alan grubb,,HIST-1730,2018
+HIST,2990,1,Historian's Craft,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,thomas kuehn,,HIST-2990,2018
+HIST,2990,3,Historian's Craft,0.59,0.24,0.06,0.06,0.06,0.0,0.0,0.0,michael silvestri,,HIST-2990,2018
+HIST,3010,1,Am Rev & New Nation,0.26,0.53,0.11,0.0,0.11,0.0,0.0,0.0,james bradf jeffries,,HIST-3010,2018
+HIST,3030,1,Civil War & Recon,0.16,0.79,0.0,0.0,0.0,0.0,0.0,0.05,paul christ anderson,,HIST-3030,2018
+HIST,3040,1,Indus & Progr Era,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0, roger grant,,HIST-3040,2018
+HIST,3120,1,Afr Amer Hist 1877 to Present,0.21,0.63,0.11,0.0,0.0,0.0,0.0,0.05,abel bartley,,HIST-3120,2018
+HIST,3240,1,Hist of the South II,0.36,0.4,0.12,0.04,0.04,0.0,0.0,0.04,john andrew,,HIST-3240,2018
+HIST,3280,1,US Legal History to 1890,0.7,0.27,0.03,0.0,0.0,0.0,0.0,0.0,lee brady wilson,,HIST-3280,2018
+HIST,3330,1,Hist of Mod Japan,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,edwin moise,,HIST-3330,2018
+HIST,3380,1,Africa to 1875,0.38,0.25,0.21,0.13,0.0,0.0,0.0,0.04,james burns,,HIST-3380,2018
+HIST,3410,1,Modern Mexico,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,rachel anne moore,,HIST-3410,2018
+HIST,3630,1,Britain Since 1688,0.5,0.38,0.04,0.0,0.0,0.0,0.0,0.08,stephanie barczewski,,HIST-3630,2018
+HIST,3700,1,Medieval History,0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,,HIST-3700,2018
+HIST,3970,1,Modern Middle East,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,,HIST-3970,2018
+HIST,4400,1,Studies in Latin American Hist,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,,HIST-4400,2018
+HIST,4710,1,The Great War,0.57,0.14,0.14,0.0,0.07,0.0,0.0,0.07, alan grubb,,HIST-4710,2018
+HIST,4900,2,Weimar Germany,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,michael meng,,HIST-4900,2018
+HIST,4900,3,Dictatorship&ViolenceIW Europe,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,amit bein,,HIST-4900,2018
+HIST,4920,1,Iraq War,0.2,0.2,0.47,0.07,0.0,0.0,0.0,0.07,edwin moise,,HIST-4920,2018
+HIST,4960,1,European Law,0.2,0.4,0.3,0.0,0.0,0.0,0.0,0.1,thomas kuehn,,HIST-4960,2018
+HLTH,2020,1,Introduction to Public Health,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2018
+HLTH,2020,2,Introduction to Public Health,0.56,0.33,0.1,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2018
+HLTH,2020,3,Introduction to Public Health,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2020,2018
+HLTH,2020,4,Introduction to Public Health,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,becky ann tugman,,HLTH-2020,2018
+HLTH,2020,5,Introduction to Public Health,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2020,2018
+HLTH,2020,400,Introduction to Public Health,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2018
+HLTH,2020,401,Introduction to Public Health,0.53,0.26,0.11,0.0,0.0,0.0,0.0,0.11,ralph stewart welsh,,HLTH-2020,2018
+HLTH,2030,1,Health Care Sys,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,HLTH-2030,2018
+HLTH,2030,2,Health Care Sys,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,HLTH-2030,2018
+HLTH,2030,3,Health Care Sys,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2018
+HLTH,2400,1,Deter of Hlth Behav,0.45,0.42,0.12,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2018
+HLTH,2400,2,Deter of Hlth Behav,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,,HLTH-2400,2018
+HLTH,2400,400,Deter of Hlth Behav,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2018
+HLTH,2600,1,Medical Terminology & Comm,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,karen edwards,,HLTH-2600,2018
+HLTH,2600,2,Medical Terminology & Comm,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,karen edwards,,HLTH-2600,2018
+HLTH,2600,400,Medical Terminology & Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2600,2018
+HLTH,2980,1,Human Health and Disease,0.75,0.16,0.09,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2018
+HLTH,2980,2,Human Health and Disease,0.54,0.31,0.11,0.03,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2980,2018
+HLTH,2980,3,Human Health and Disease,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2980,2018
+HLTH,3400,1,Hlth Prom Prog Plan,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-3400,2018
+HLTH,3610,1,Int Health Care Econ,0.67,0.23,0.03,0.0,0.0,0.0,0.0,0.07,khoa dang truong,,HLTH-3610,2018
+HLTH,3800,1,Epidemiology,0.64,0.27,0.06,0.0,0.0,0.0,0.0,0.03,deborah alma falta,,HLTH-3800,2018
+HLTH,3800,2,Epidemiology,0.42,0.39,0.15,0.0,0.0,0.0,0.0,0.03,deborah alma falta,,HLTH-3800,2018
+HLTH,3800,400,Epidemiology,0.37,0.37,0.21,0.0,0.05,0.0,0.0,0.0,deborah alma falta,,HLTH-3800,2018
+HLTH,3980,1,Health Appraisal Skills,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2018
+HLTH,3980,2,Health Appraisal Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2018
+HLTH,4100,1,Maternal Child Hlth,0.54,0.43,0.04,0.0,0.0,0.0,0.0,0.0,karyn jones,,HLTH-4100,2018
+HLTH,4190,1,Health Sci Internship Prep Sem,0.79,0.1,0.1,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4190,2018
+HLTH,4200,1,Hlth Science Intern,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2018
+HLTH,4400,1,Manag Hlth Serv Org,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,,HLTH-4400,2018
+HLTH,4700,1,Global Health,0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,micky rogers ward,,HLTH-4700,2018
+HLTH,4750,1,Hlthcr Oper Mgmt Res,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,lu shi,,HLTH-4750,2018
+HLTH,4900,1,Res Eval St Pub Hlth,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,karen kemper,,HLTH-4900,2018
+HLTH,4900,2,Res Eval St Pub Hlth,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-4900,2018
+HLTH,4970,4,Aspire to Be Well - CI,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,chloe carolin greene,,HLTH-4970,2018
+HLTH,4970,5,Alcohol & Other Drugs-CI,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,crystal burne fulmer,,HLTH-4970,2018
+HLTH,8030,1,Theories and Determ of Health,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,joel edward williams,,HLTH-8030,2018
+HLTH,8410,1,Foundations of Eval in Health,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,,HLTH-8410,2018
+HON,1940,1,Bioinspired,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,charles beard,True,HON-1940,2018
+HON,2020,1,Who Decides What's Cool?,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,True,HON-2020,2018
+HON,2020,2,World of Ideas,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True,HON-2020,2018
+HON,2050,1,Architecture: Ideas & Practice,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burl brown,True,HON-2050,2018
+HON,2060,3,Puzzles and Paradoxes,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,marilyn reba,True,HON-2060,2018
+HON,2210,1,Frankenstein at 200,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,remley meliss makala,True,HON-2210,2018
+HORT,1010,1,Horticulture,0.86,0.09,0.01,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,,HORT-1010,2018
+HORT,2020,1,Adobe Digital Design,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,janice ann lay,,HORT-2020,2018
+HORT,2020,2,Hydroponics,0.17,0.28,0.19,0.17,0.06,0.0,0.0,0.15,james emerson faust,,HORT-2020,2018
+HORT,2120,1,Turfgrass Culture,0.56,0.38,0.05,0.0,0.0,0.0,0.0,0.0,haibo liu,,HORT-2120,2018
+HORT,2130,2,Turf Culture Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,,HORT-2130,2018
+HORT,3030,1,Landscape Plants,0.09,0.22,0.35,0.16,0.15,0.0,0.0,0.03,robert polomski,,HORT-3030,2018
+HORT,3080,1,Sust Landsc Des Install Maint,0.9,0.08,0.0,0.0,0.03,0.0,0.0,0.0,ellen anita vincent,,HORT-3080,2018
+HORT,4120,1,Adv Turfgrass Mgt,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,lambert mccarty,,HORT-4120,2018
+HP,8070,400,American Architecture,0.6,0.1,0.0,0.0,0.0,0.0,0.0,0.3,carter lee hudgins,,HP-8070,2018
+HP,8080,400,Hist and Theory of Hist Pres,0.56,0.11,0.0,0.0,0.0,0.0,0.0,0.33,carter lee hudgins,,HP-8080,2018
+HP,8090,400,Historical Research Methods,0.5,0.13,0.0,0.0,0.0,0.0,0.0,0.38,katherine pemberton,,HP-8090,2018
+HP,8190,1,"Investig, Docum, Conservation",0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,amalia leifeste,,HP-8190,2018
+HRD,8200,401,Human Perform Improv,0.77,0.14,0.0,0.0,0.0,0.0,0.0,0.09,angela daniel carter,,HRD-8200,2018
+HRD,8450,400,Needs Assess Ed/Ind,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,angela daniel carter,,HRD-8450,2018
+HRD,8600,400,Instruc Mat Devel,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,cynthia sims,,HRD-8600,2018
+IE,2100,1,Des Analysis Wrk Sys,0.49,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jeffery messer,,IE-2100,2018
+IE,3010,1,Systems Design I,0.35,0.49,0.14,0.01,0.0,0.0,0.0,0.01,robert james riggs,,IE-3010,2018
+IE,3600,1,Industrial Apps of Prob/Stat I,0.23,0.25,0.23,0.14,0.08,0.0,0.0,0.06,tugce isik,,IE-3600,2018
+IE,3610,1,Industrial App of Prob/Stat II,0.31,0.41,0.1,0.1,0.04,0.0,0.0,0.04,david neyens,,IE-3610,2018
+IE,3800,1,Deterministic Operations Rsrch,0.17,0.42,0.2,0.05,0.15,0.0,0.0,0.01,joshua tayl margolis,,IE-3800,2018
+IE,3810,1,Probabilistic Operations Rsrch,0.6,0.29,0.07,0.01,0.0,0.0,0.0,0.02,burak eksioglu,,IE-3810,2018
+IE,3840,1,Engr Econ Analysis,0.4,0.2,0.09,0.06,0.05,0.0,0.0,0.19,brian melloy,,IE-3840,2018
+IE,3860,1,Production Planning & Control,0.84,0.12,0.02,0.02,0.0,0.0,0.0,0.0,xiaoxia li,,IE-3860,2018
+IE,4400,1,Decision Support Sys,0.53,0.3,0.06,0.01,0.05,0.0,0.0,0.05,scott jennings mason,,IE-4400,2018
+IE,4460,1,Model & Analysis Mfg Systems,0.37,0.47,0.14,0.0,0.0,0.0,0.0,0.02,robert james riggs,,IE-4460,2018
+IE,4510,1,Investigating Human Error,0.36,0.26,0.28,0.04,0.0,0.0,0.0,0.06,sara lu riggs,,IE-4510,2018
+IE,4530,1,Network Flows for IE Apps,0.36,0.36,0.09,0.0,0.09,0.0,0.0,0.09,burak eksioglu,,IE-4530,2018
+IE,4610,1,Quality Engineering,0.29,0.32,0.27,0.07,0.02,0.0,0.0,0.02,byung rae cho,,IE-4610,2018
+IE,4650,1,Facilities Planning & Design,0.23,0.47,0.18,0.06,0.02,0.0,0.0,0.03,william ferrell,,IE-4650,2018
+IE,4670,1,System Design II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,,IE-4670,2018
+IE,4810,1,App of Prob Models in Ind Engr,0.36,0.27,0.27,0.0,0.0,0.0,0.0,0.09,brian melloy,,IE-4810,2018
+IE,4820,1,Systems Modeling,0.46,0.28,0.18,0.03,0.0,0.0,0.0,0.05,kevin taaffe,,IE-4820,2018
+IE,4820,2,Systems Modeling,0.2,0.44,0.24,0.1,0.02,0.0,0.0,0.0,kevin taaffe,,IE-4820,2018
+IE,4910,3,Human Centered Design & Engr,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,laura michel stanley,,IE-4910,2018
+IE,6460,1,Model & Analysis Mfg Systems,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,,IE-6460,2018
+IE,8000,1,Human Factors Eng,0.15,0.63,0.22,0.0,0.0,0.0,0.0,0.0,david neyens,,IE-8000,2018
+IE,8030,1,Engr Optimization and Apps,0.68,0.26,0.05,0.0,0.01,0.0,0.0,0.0,sandra duni eksioglu,,IE-8030,2018
+IE,8040,1,Mfg Sys Plan & Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,,IE-8040,2018
+IE,8530,1,Foundations of Quality,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,byung rae cho,,IE-8530,2018
+IE,8550,1,SC & Logistics Modeling II,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,kevin taaffe,,IE-8550,2018
+IE,8930,1,Markov Decision Processes,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amin khademi,,IE-8930,2018
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,lisa marie robinson,,INT-1510,2018
+IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,james dougla bennett,,IS-1010,2018
+ITAL,1010,2,Elementary Italian,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,luca barattoni,,ITAL-1010,2018
+ITAL,1010,3,Elementary Italian,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,julia schmidt,,ITAL-1010,2018
+ITAL,1010,4,Elementary Italian,0.23,0.46,0.15,0.0,0.08,0.0,0.0,0.08,julia schmidt,,ITAL-1010,2018
+ITAL,2010,1,Intermediate Italian,0.5,0.11,0.22,0.11,0.0,0.0,0.0,0.06,julia schmidt,,ITAL-2010,2018
+JAPN,1010,1,Elementary Japanese,0.53,0.26,0.05,0.05,0.0,0.0,0.0,0.11,saori suto,,JAPN-1010,2018
+JAPN,1010,2,Elementary Japanese,0.47,0.16,0.21,0.05,0.0,0.0,0.0,0.11,saori suto,,JAPN-1010,2018
+JAPN,1010,3,Elementary Japanese,0.5,0.33,0.08,0.0,0.08,0.0,0.0,0.0,satomi saito,,JAPN-1010,2018
+JAPN,1020,1,Elementary Japanese,0.38,0.31,0.08,0.15,0.0,0.0,0.0,0.08,satomi saito,,JAPN-1020,2018
+JAPN,2010,1,Intermed Japanese,0.46,0.08,0.31,0.08,0.0,0.0,0.0,0.08,saori suto,,JAPN-2010,2018
+JAPN,3050,1,Japanese Conversation & Comp,0.57,0.14,0.07,0.07,0.14,0.0,0.0,0.0,jae allegra takeuchi,,JAPN-3050,2018
+JAPN,4010,1,Japanese Lit in Translation,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,kumiko saito,,JAPN-4010,2018
+JUST,2880,1,The Criminal Justice System,0.5,0.22,0.16,0.04,0.08,0.0,0.0,0.0,margaret tina britz,,JUST-2880,2018
+JUST,4680,1,Criminal Evidence,0.44,0.35,0.09,0.07,0.02,0.0,0.0,0.02,margaret tina britz,,JUST-4680,2018
+JUST,4860,1,Creative Inquiry in CJ,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,margaret tina britz,,JUST-4860,2018
+LANG,3000,1,Intro Linguistics,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,daniel smith,,LANG-3000,2018
+LANG,4540,1,Sel Top in International Film,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,satomi saito,,LANG-4540,2018
+LARC,1150,1,Intro Landscape Architecture,0.77,0.14,0.05,0.0,0.0,0.0,0.0,0.05,mary padua,,LARC-1150,2018
+LARC,1280,1,Technical Graphics,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,,LARC-1280,2018
+LARC,1510,1,Basic Design I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,matthew neal powers,,LARC-1510,2018
+LARC,2510,2,Larch Design Fund,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,,LARC-2510,2018
+LARC,2620,1,Design Implementation I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,robert hewitt,,LARC-2620,2018
+LARC,4530,1,Key Issues in Landscape Arch,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,mary padua,,LARC-4530,2018
+LARC,4620,1,Design Implementation III,0.18,0.59,0.09,0.14,0.0,0.0,0.0,0.0,mary padua,,LARC-4620,2018
+LAW,3220,1,Legal Env of Bus,0.21,0.38,0.31,0.06,0.02,0.0,0.0,0.02,john hine,,LAW-3220,2018
+LAW,3220,4,Legal Env of Bus,0.17,0.37,0.35,0.07,0.02,0.0,0.0,0.02,kenneth sc toussaint,,LAW-3220,2018
+LAW,3220,5,Legal Env of Bus,0.23,0.35,0.31,0.1,0.0,0.0,0.0,0.0,kenneth sc toussaint,,LAW-3220,2018
+LAW,3220,6,Legal Env of Bus,0.37,0.41,0.18,0.02,0.02,0.0,0.0,0.0,kathr kisska-schulze,,LAW-3220,2018
+LAW,3220,7,Legal Env of Bus,0.37,0.49,0.08,0.04,0.02,0.0,0.0,0.0,kathr kisska-schulze,,LAW-3220,2018
+LAW,3220,8,Legal Env of Bus,0.31,0.48,0.1,0.06,0.04,0.0,0.0,0.0,kathr kisska-schulze,,LAW-3220,2018
+LAW,3220,9,Legal Env of Bus,0.3,0.51,0.19,0.0,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2018
+LAW,3220,10,Legal Env of Bus,0.3,0.33,0.26,0.04,0.02,0.0,0.0,0.04,edward ray claggett,,LAW-3220,2018
+LAW,3220,11,Legal Env of Bus,0.42,0.48,0.1,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2018
+LAW,3220,400,Legal Env of Bus,0.37,0.35,0.19,0.02,0.0,0.0,0.0,0.06,virginia ward-vaughn,,LAW-3220,2018
+LAW,3220,401,Legal Env of Bus,0.31,0.44,0.15,0.05,0.02,0.0,0.0,0.05,virginia ward-vaughn,,LAW-3220,2018
+LAW,3220,402,Legal Env of Bus,0.33,0.44,0.14,0.05,0.0,0.0,0.0,0.03,virginia ward-vaughn,,LAW-3220,2018
+LAW,3220,403,Legal Env of Bus,0.3,0.4,0.18,0.07,0.0,0.0,0.0,0.05,virginia ward-vaughn,,LAW-3220,2018
+LAW,3330,1,Real Estate Law,0.0,0.42,0.32,0.16,0.11,0.0,0.0,0.0,kenneth sc toussaint,,LAW-3330,2018
+LAW,3330,2,Real Estate Law,0.17,0.49,0.2,0.11,0.03,0.0,0.0,0.0,kenneth sc toussaint,,LAW-3330,2018
+LAW,4050,1,Construction Law,0.9,0.08,0.0,0.0,0.0,0.0,0.0,0.03,frances edwards,,LAW-4050,2018
+LS,1000,1,Therapeutic Yoga,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dili amin,,LS-1000,2018
+LS,1000,2,Therapeutic Yoga,0.77,0.14,0.05,0.0,0.0,0.0,0.0,0.05,ranjanbala dili amin,,LS-1000,2018
+LS,1000,3,Therapeutic Yoga,0.82,0.09,0.0,0.0,0.05,0.0,0.0,0.05,renee warren gahan,,LS-1000,2018
+LS,1000,8,Intro to Volleyball,0.79,0.07,0.07,0.07,0.0,0.0,0.0,0.0,kelly lynn ator,,LS-1000,2018
+LS,1000,12,Introduction to Salsa,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,malik lewis  baxter c,,LS-1000,2018
+LS,1000,13,Introduction to Salsa Dance,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,malik lewis  baxter c,,LS-1000,2018
+LS,1570,2,Shotgun Sports,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,bonnie duke gill,,LS-1570,2018
+LS,1570,3,Shotgun Sports,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,edward licus prater,,LS-1570,2018
+LS,1580,3,Archery,0.55,0.27,0.0,0.0,0.0,0.0,0.0,0.18,herbert strickland,,LS-1580,2018
+LS,1850,1,Bowling,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,madison neel workman,,LS-1850,2018
+LS,1850,2,Bowling,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,,LS-1850,2018
+LS,1850,3,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,kimberly coury,,LS-1850,2018
+LS,1850,4,Bowling,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,alexandra sandoval,,LS-1850,2018
+LS,1850,5,Bowling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,alexandra sandoval,,LS-1850,2018
+LS,1870,2,Frisbee Sports,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,steven simoneaux,,LS-1870,2018
+LS,1980,9,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,wesley scott womble,,LS-1980,2018
+LS,2270,2,Intro to Swing Dance,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,paul hoke,,LS-2270,2018
+LS,2320,2,Core Training,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,,LS-2320,2018
+LS,2320,3,Core Training,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-2320,2018
+LS,2320,4,Core Training,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,diane moreno,,LS-2320,2018
+LS,2320,5,Core Training,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,,LS-2320,2018
+LS,2350,1,Basic Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2018
+LS,2350,7,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,,LS-2350,2018
+LS,2350,8,Basic Yoga,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,,LS-2350,2018
+LS,2360,1,Power/Ashtanga Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,silica elizab larkin,,LS-2360,2018
+LS,2360,2,Power/Ashtanga Yoga,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,silica elizab larkin,,LS-2360,2018
+LS,2380,2,Vinyasa Flow Yoga,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,nicole eliz martinez,,LS-2380,2018
+LS,2420,1,Meditation and Relax,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2420,2018
+LS,2420,2,Meditation and Relax,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,renee warren gahan,,LS-2420,2018
+LS,2420,5,Meditation and Relax,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dili amin,,LS-2420,2018
+LS,2420,6,Meditation and Relax,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dili amin,,LS-2420,2018
+LS,2420,7,Meditation and Relax,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,,LS-2420,2018
+LS,2420,9,Meditation and Relax,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,kayla lee wardlaw,,LS-2420,2018
+LS,2450,1,Pilates,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,melanie ivey job,,LS-2450,2018
+LS,2450,4,Pilates,0.77,0.05,0.0,0.0,0.14,0.0,0.0,0.05,diane moreno,,LS-2450,2018
+LS,2450,8,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,,LS-2450,2018
+LS,2750,10,First Aid/Cpr,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,christopher loomis,,LS-2750,2018
+MATH,1010,1,Essen Math for Informed Soc,0.33,0.33,0.27,0.07,0.0,0.0,0.0,0.0,bryce pruitt,,MATH-1010,2018
+MATH,1010,2,Essen Math for Informed Soc,0.22,0.33,0.17,0.22,0.0,0.0,0.0,0.06,seth selken,,MATH-1010,2018
+MATH,1010,3,Essen Math for Informed Soc,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,seth selken,,MATH-1010,2018
+MATH,1010,4,Essen Math for Informed Soc,0.47,0.13,0.2,0.13,0.0,0.0,0.0,0.07,alexander joyce,,MATH-1010,2018
+MATH,1010,5,Essen Math for Informed Soc,0.47,0.35,0.06,0.06,0.06,0.0,0.0,0.0,bryce pruitt,,MATH-1010,2018
+MATH,1010,6,Essen Math for Informed Soc,0.39,0.39,0.17,0.0,0.06,0.0,0.0,0.0,alexander joyce,,MATH-1010,2018
+MATH,1010,7,Essen Math for Informed Soc,0.44,0.18,0.21,0.09,0.09,0.0,0.0,0.0,marilyn reba,,MATH-1010,2018
+MATH,1010,8,Essen Math for Informed Soc,0.44,0.31,0.19,0.0,0.0,0.0,0.0,0.06,seth selken,,MATH-1010,2018
+MATH,1010,9,Essen Math for Informed Soc,0.64,0.09,0.18,0.09,0.0,0.0,0.0,0.0,alexander joyce,,MATH-1010,2018
+MATH,1020,1,Business Calculus I,0.24,0.24,0.18,0.24,0.12,0.0,0.0,0.0,hannah grace rollins,,MATH-1020,2018
+MATH,1020,2,Business Calculus I,0.05,0.42,0.26,0.11,0.11,0.0,0.0,0.05,hannah grace rollins,,MATH-1020,2018
+MATH,1020,3,Business Calculus I,0.11,0.39,0.17,0.17,0.06,0.0,0.0,0.11,morgan elston,,MATH-1020,2018
+MATH,1020,4,Business Calculus I,0.06,0.39,0.28,0.28,0.0,0.0,0.0,0.0,morgan elston,,MATH-1020,2018
+MATH,1020,5,Business Calculus I,0.17,0.28,0.22,0.17,0.11,0.0,0.0,0.06,zachary ray johnston,,MATH-1020,2018
+MATH,1020,6,Business Calculus I,0.11,0.37,0.21,0.16,0.05,0.0,0.0,0.11,zachary ray johnston,,MATH-1020,2018
+MATH,1020,7,Business Calculus I,0.22,0.11,0.33,0.17,0.0,0.0,0.0,0.17,michael thomas cowen,,MATH-1020,2018
+MATH,1020,8,Business Calculus I,0.11,0.33,0.5,0.0,0.0,0.0,0.0,0.06,michael thomas cowen,,MATH-1020,2018
+MATH,1020,11,Business Calculus I,0.22,0.22,0.22,0.06,0.11,0.0,0.0,0.17,andrew pangia,,MATH-1020,2018
+MATH,1020,12,Business Calculus I,0.0,0.35,0.29,0.18,0.12,0.0,0.0,0.06,andrew gray pitman,,MATH-1020,2018
+MATH,1020,15,Business Calculus I,0.28,0.17,0.22,0.22,0.06,0.0,0.0,0.06,hemanta kunwar,,MATH-1020,2018
+MATH,1020,16,Business Calculus I,0.11,0.33,0.5,0.06,0.0,0.0,0.0,0.0,andrew gray pitman,,MATH-1020,2018
+MATH,1020,18,Business Calculus I,0.29,0.24,0.35,0.06,0.0,0.0,0.0,0.06,ebenezer eduafo,,MATH-1020,2018
+MATH,1020,19,Business Calculus I,0.28,0.39,0.11,0.06,0.11,0.0,0.0,0.06,andrew pangia,,MATH-1020,2018
+MATH,1020,20,Business Calculus I,0.12,0.29,0.12,0.18,0.24,0.0,0.0,0.06,michael gle eldredge,,MATH-1020,2018
+MATH,1020,21,Business Calculus I,0.22,0.22,0.33,0.06,0.17,0.0,0.0,0.0,hassan kiyadeh hami,,MATH-1020,2018
+MATH,1020,22,Business Calculus I,0.39,0.22,0.11,0.11,0.11,0.0,0.0,0.06,zachary david espe,,MATH-1020,2018
+MATH,1020,23,Business Calculus I,0.32,0.37,0.2,0.02,0.02,0.0,0.0,0.07,tony thanh nguyen,,MATH-1020,2018
+MATH,1020,24,Business Calculus I,0.39,0.28,0.17,0.11,0.0,0.0,0.0,0.06,zachary david espe,,MATH-1020,2018
+MATH,1020,25,Business Calculus I,0.24,0.47,0.12,0.06,0.06,0.0,0.0,0.06,nicholas john porter,,MATH-1020,2018
+MATH,1020,26,Business Calculus I,0.22,0.17,0.28,0.11,0.11,0.0,0.0,0.11,hemanta kunwar,,MATH-1020,2018
+MATH,1020,27,Business Calculus I,0.39,0.17,0.11,0.28,0.0,0.0,0.0,0.06,cameron arnold,,MATH-1020,2018
+MATH,1020,28,Business Calculus I,0.26,0.26,0.26,0.11,0.05,0.0,0.0,0.05,nicholas john porter,,MATH-1020,2018
+MATH,1020,29,Business Calculus I,0.25,0.2,0.28,0.05,0.13,0.0,0.0,0.1,marion hanna,,MATH-1020,2018
+MATH,1020,30,Business Calculus I,0.37,0.21,0.21,0.16,0.05,0.0,0.0,0.0,cameron arnold,,MATH-1020,2018
+MATH,1020,31,Business Calculus I,0.33,0.22,0.17,0.11,0.11,0.0,0.0,0.06,hassan kiyadeh hami,,MATH-1020,2018
+MATH,1020,33,Business Calculus I,0.17,0.17,0.28,0.11,0.17,0.0,0.0,0.11,michael gle eldredge,,MATH-1020,2018
+MATH,1020,34,Business Calculus I,0.24,0.34,0.22,0.1,0.07,0.0,0.0,0.02,marion hanna,,MATH-1020,2018
+MATH,1020,35,Business Calculus I,0.06,0.44,0.06,0.11,0.28,0.0,0.0,0.06,ebenezer eduafo,,MATH-1020,2018
+MATH,1020,38,Business Calculus I,0.29,0.29,0.21,0.14,0.02,0.0,0.0,0.05,tony thanh nguyen,,MATH-1020,2018
+MATH,1020,39,Business Calculus I,0.36,0.19,0.29,0.1,0.02,0.0,0.0,0.05,dyken jennifer  van e,,MATH-1020,2018
+MATH,1020,40,Business Calculus I,0.39,0.27,0.19,0.09,0.03,0.0,0.0,0.02,jennifer marie hanna,,MATH-1020,2018
+MATH,1020,41,Business Calculus I,0.47,0.23,0.18,0.08,0.01,0.0,0.0,0.03,jennifer marie hanna,,MATH-1020,2018
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.87,0.0,0.13,donna simms,,MATH-1040,2018
+MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.79,0.0,0.21,kristina gorsline,,MATH-1040,2018
+MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.68,0.0,0.32,aaron moose,,MATH-1040,2018
+MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,stephen peele,,MATH-1040,2018
+MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.8,0.0,0.2,emma cinatl,,MATH-1040,2018
+MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.87,0.0,0.13,tony thanh nguyen,,MATH-1050,2018
+MATH,1060,1,Calculus of One Variable I,0.21,0.19,0.21,0.07,0.17,0.0,0.0,0.14,timothy fran parrott,,MATH-1060,2018
+MATH,1060,2,Calculus of One Variable I,0.29,0.12,0.29,0.1,0.17,0.0,0.0,0.05,timothy fran parrott,,MATH-1060,2018
+MATH,1060,3,Calculus of One Variable I,0.23,0.2,0.25,0.07,0.16,0.0,0.0,0.09,timothy fran parrott,,MATH-1060,2018
+MATH,1060,4,Calculus of One Variable I,0.09,0.32,0.18,0.14,0.18,0.0,0.0,0.09,sofya alekseeva,,MATH-1060,2018
+MATH,1060,5,Calculus of One Variable I,0.19,0.16,0.19,0.26,0.09,0.0,0.0,0.12,sofya alekseeva,,MATH-1060,2018
+MATH,1060,6,Calculus of One Variable I,0.12,0.33,0.21,0.09,0.14,0.0,0.0,0.12,sofya alekseeva,,MATH-1060,2018
+MATH,1060,8,Calculus of One Variable I,0.36,0.25,0.14,0.06,0.09,0.0,0.0,0.1,judith el cottingham,,MATH-1060,2018
+MATH,1060,10,Calculus of One Variable I,0.24,0.27,0.23,0.05,0.14,0.0,0.0,0.07,judith el cottingham,,MATH-1060,2018
+MATH,1060,12,Calculus of One Variable I,0.32,0.27,0.16,0.07,0.16,0.0,0.0,0.02,hugh geller,,MATH-1060,2018
+MATH,1060,14,Calculus of One Variable I,0.13,0.28,0.16,0.03,0.22,0.0,0.0,0.19,valdez hiram lopez,,MATH-1060,2018
+MATH,1060,15,Calculus of One Variable I,0.27,0.16,0.25,0.16,0.11,0.0,0.0,0.05,blake antho splitter,,MATH-1060,2018
+MATH,1060,16,Calculus of One Variable I,0.33,0.19,0.23,0.07,0.09,0.0,0.0,0.09,stephen peele,,MATH-1060,2018
+MATH,1060,17,Calculus of One Variable I,0.15,0.24,0.12,0.15,0.22,0.0,0.0,0.12,valdez hiram lopez,,MATH-1060,2018
+MATH,1060,18,Calculus of One Variable I,0.17,0.37,0.14,0.09,0.09,0.0,0.0,0.14,marilyn reba,,MATH-1060,2018
+MATH,1060,19,Calculus of One Variable I,0.28,0.3,0.14,0.05,0.16,0.0,0.0,0.07,jason alexander kurz,,MATH-1060,2018
+MATH,1060,201,Calculus of One Variable I,0.44,0.33,0.12,0.05,0.05,0.0,0.0,0.02,camille zerfas,,MATH-1060,2018
+MATH,1060,202,Calculus of One Variable I,0.33,0.36,0.1,0.05,0.12,0.0,0.0,0.05,andrew walton green,,MATH-1060,2018
+MATH,1060,203,Calculus of One Variable I,0.31,0.31,0.23,0.03,0.06,0.0,0.0,0.06,charles lanning,,MATH-1060,2018
+MATH,1060,204,Calculus of One Variable I,0.31,0.31,0.22,0.02,0.09,0.0,0.0,0.04,scott scruggs,,MATH-1060,2018
+MATH,1060,205,Calculus of One Variable I,0.37,0.29,0.2,0.04,0.06,0.0,0.0,0.04,james edward gossell,,MATH-1060,2018
+MATH,1060,206,Calculus of One Variable I,0.2,0.24,0.37,0.0,0.17,0.0,0.0,0.02,catherine mar kenyon,,MATH-1060,2018
+MATH,1060,207,Calculus of One Variable I,0.24,0.33,0.12,0.07,0.14,0.0,0.0,0.1,rachel bass lanning,,MATH-1060,2018
+MATH,1060,208,Calculus of One Variable I,0.39,0.39,0.12,0.05,0.05,0.0,0.0,0.0,todd fenstermacher,,MATH-1060,2018
+MATH,1060,300,Calculus of One Variable I,0.32,0.16,0.29,0.16,0.03,0.0,0.0,0.03,matthew macauley,,MATH-1060,2018
+MATH,1070,1,Differen and Integral Calculus,0.08,0.35,0.38,0.08,0.12,0.0,0.0,0.0,donna simms,,MATH-1070,2018
+MATH,1080,1,Calculus of One Variable II,0.13,0.17,0.2,0.09,0.27,0.0,0.0,0.14,benjamin chris wiles,,MATH-1080,2018
+MATH,1080,2,Calculus of One Variable II,0.23,0.25,0.25,0.14,0.11,0.0,0.0,0.02,timothy cha teitloff,,MATH-1080,2018
+MATH,1080,3,Calculus of One Variable II,0.1,0.26,0.26,0.05,0.18,0.0,0.0,0.15,beth novick,,MATH-1080,2018
+MATH,1080,4,Calculus of One Variable II,0.14,0.23,0.25,0.09,0.2,0.0,0.0,0.09,timothy cha teitloff,,MATH-1080,2018
+MATH,1080,5,Calculus of One Variable II,0.28,0.23,0.3,0.02,0.12,0.0,0.0,0.05,timothy cha teitloff,,MATH-1080,2018
+MATH,1080,6,Calculus of One Variable II,0.27,0.22,0.2,0.07,0.1,0.0,0.0,0.15,meredith nicole burr,,MATH-1080,2018
+MATH,1080,7,Calculus of One Variable II,0.21,0.28,0.21,0.1,0.1,0.0,0.0,0.1,meredith nicole burr,,MATH-1080,2018
+MATH,1080,201,Calculus of One Variable II,0.34,0.14,0.23,0.09,0.11,0.0,0.0,0.09,fun choi john chan john,,MATH-1080,2018
+MATH,1150,1,Contemp Math for Elem Teach I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew mich tyminski,,MATH-1150,2018
+MATH,1150,2,Contemp Math for Elem Teach I,0.5,0.33,0.1,0.05,0.0,0.0,0.0,0.02,eliza darg gallagher,,MATH-1150,2018
+MATH,1160,1,Contemp Math for Elem Teach II,0.6,0.27,0.0,0.0,0.07,0.0,0.0,0.07,nicole alain sinwell,,MATH-1160,2018
+MATH,2060,1,Calculus of Several Variables,0.23,0.3,0.29,0.09,0.06,0.0,0.0,0.03,irina viktorova,,MATH-2060,2018
+MATH,2060,4,Calculus of Several Variables,0.18,0.2,0.22,0.18,0.13,0.0,0.0,0.1,oleg yordanov,,MATH-2060,2018
+MATH,2060,7,Calculus of Several Variables,0.3,0.36,0.17,0.04,0.1,0.0,0.0,0.02,irina viktorova,,MATH-2060,2018
+MATH,2060,10,Calculus of Several Variables,0.24,0.17,0.12,0.26,0.12,0.0,0.0,0.1,terri johnson,,MATH-2060,2018
+MATH,2060,11,Calculus of Several Variables,0.38,0.43,0.05,0.04,0.06,0.0,0.0,0.04,allen anderson guest,,MATH-2060,2018
+MATH,2060,12,Calculus of Several Variables,0.43,0.31,0.14,0.03,0.05,0.0,0.0,0.04,allen anderson guest,,MATH-2060,2018
+MATH,2060,14,Calculus of Several Variables,0.32,0.45,0.17,0.03,0.03,0.0,0.0,0.01,oleg yordanov,,MATH-2060,2018
+MATH,2060,15,Calculus of Several Variables,0.4,0.33,0.24,0.0,0.02,0.0,0.0,0.0,akshay sunil gupte,,MATH-2060,2018
+MATH,2060,19,Calculus of Several Variables,0.14,0.14,0.14,0.28,0.16,0.0,0.0,0.14,terri johnson,,MATH-2060,2018
+MATH,2060,20,Calculus of Several Variables,0.17,0.19,0.11,0.25,0.08,0.0,0.0,0.19,terri johnson,,MATH-2060,2018
+MATH,2060,100,Calc of Several Vars (HON),0.69,0.27,0.02,0.0,0.0,0.0,0.0,0.02,peter kiessler,True,MATH-2060,2018
+MATH,2060,201,Calculus of Several Variables,0.5,0.36,0.07,0.0,0.07,0.0,0.0,0.0,sanwar ahmad,,MATH-2060,2018
+MATH,2060,202,Calculus of Several Variables,0.24,0.31,0.22,0.02,0.04,0.0,0.0,0.16,martin johan schmoll,,MATH-2060,2018
+MATH,2070,1,Business Calculus II,0.12,0.35,0.12,0.06,0.35,0.0,0.0,0.0,haodong li,,MATH-2070,2018
+MATH,2070,2,Business Calculus II,0.0,0.44,0.39,0.06,0.11,0.0,0.0,0.0,haodong li,,MATH-2070,2018
+MATH,2070,3,Business Calculus II,0.0,0.33,0.17,0.22,0.11,0.0,0.0,0.17,thanh thien to,,MATH-2070,2018
+MATH,2070,4,Business Calculus II,0.11,0.33,0.22,0.22,0.11,0.0,0.0,0.0,todd anthony morra,,MATH-2070,2018
+MATH,2070,5,Business Calculus II,0.06,0.13,0.25,0.31,0.19,0.0,0.0,0.06,todd anthony morra,,MATH-2070,2018
+MATH,2070,6,Business Calculus II,0.27,0.07,0.33,0.13,0.07,0.0,0.0,0.13,ville madeleine  st e,,MATH-2070,2018
+MATH,2070,7,Business Calculus II,0.12,0.29,0.35,0.12,0.12,0.0,0.0,0.0,xiaoyuan liu,,MATH-2070,2018
+MATH,2070,8,Business Calculus II,0.17,0.39,0.28,0.06,0.06,0.0,0.0,0.06,xiaoyuan liu,,MATH-2070,2018
+MATH,2070,11,Business Calculus II,0.31,0.32,0.22,0.09,0.06,0.0,0.0,0.0,jennifer ray newton,,MATH-2070,2018
+MATH,2070,13,Business Calculus II,0.29,0.29,0.07,0.29,0.0,0.0,0.0,0.07,thanh thien to,,MATH-2070,2018
+MATH,2070,14,Business Calculus II,0.06,0.24,0.41,0.18,0.06,0.0,0.0,0.06,anna carol bachstein,,MATH-2070,2018
+MATH,2070,15,Business Calculus II,0.17,0.28,0.11,0.33,0.0,0.0,0.0,0.11,anna carol bachstein,,MATH-2070,2018
+MATH,2070,17,Business Calculus II,0.22,0.39,0.22,0.0,0.06,0.0,0.0,0.11,ville madeleine  st e,,MATH-2070,2018
+MATH,2070,18,Business Calculus II,0.33,0.18,0.28,0.14,0.05,0.0,0.0,0.02,jennifer ray newton,,MATH-2070,2018
+MATH,2070,19,Business Calculus II,0.18,0.24,0.18,0.12,0.12,0.0,0.0,0.18,thanh thien to,,MATH-2070,2018
+MATH,2070,20,Business Calculus II,0.0,0.21,0.07,0.14,0.36,0.0,0.0,0.21,todd anthony morra,,MATH-2070,2018
+MATH,2080,3,Intro to Ordin Diff Equations,0.13,0.28,0.41,0.05,0.07,0.0,0.0,0.07,pye phyo aung,,MATH-2080,2018
+MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.3,0.26,0.08,0.09,0.0,0.0,0.05,pye phyo aung,,MATH-2080,2018
+MATH,2080,5,Intro to Ordin Diff Equations,0.2,0.03,0.23,0.1,0.3,0.0,0.0,0.13,julie lassiter,,MATH-2080,2018
+MATH,2080,6,Intro to Ordin Diff Equations,0.14,0.23,0.26,0.14,0.14,0.0,0.0,0.09,julie lassiter,,MATH-2080,2018
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.7,0.13,0.17,0.0,0.0,0.0,0.0,0.0,jeong rock yoon rock,True,MATH-2080,2018
+MATH,2160,1,Geometry for Elem Sch Teachers,0.39,0.39,0.17,0.02,0.02,0.0,0.0,0.0,allison kes stoddard,,MATH-2160,2018
+MATH,2160,2,Geometry for Elem Sch Teachers,0.7,0.2,0.0,0.05,0.0,0.0,0.0,0.05,allison kes stoddard,,MATH-2160,2018
+MATH,2500,1,Intro to Mathematical Sciences,0.95,0.04,0.01,0.0,0.0,0.0,0.0,0.0,mark cawood,,MATH-2500,2018
+MATH,3020,1,Stat for Science & Engineering,0.36,0.3,0.19,0.02,0.06,0.0,0.0,0.06,ellen hepfer breazel,,MATH-3020,2018
+MATH,3020,2,Stat for Science & Engineering,0.36,0.34,0.23,0.02,0.0,0.0,0.0,0.04,ellen hepfer breazel,,MATH-3020,2018
+MATH,3020,4,Stat for Science & Engineering,0.61,0.27,0.11,0.0,0.0,0.0,0.0,0.0,xin liu,,MATH-3020,2018
+MATH,3020,5,Stat for Science & Engineering,0.38,0.4,0.07,0.07,0.07,0.0,0.0,0.02,xiaoqian sun,,MATH-3020,2018
+MATH,3020,6,Stat for Science & Engineering,0.53,0.24,0.06,0.06,0.06,0.0,0.0,0.06, kamronnaher,,MATH-3020,2018
+MATH,3020,7,Stat for Science & Engineering,0.29,0.24,0.29,0.06,0.06,0.0,0.0,0.06, kamronnaher,,MATH-3020,2018
+MATH,3020,9,Stat for Science & Engineering,0.61,0.22,0.06,0.0,0.11,0.0,0.0,0.0,merenchig jayasekara,,MATH-3020,2018
+MATH,3020,10,Stat for Science & Engineering,0.29,0.29,0.14,0.0,0.14,0.0,0.0,0.14,merenchig jayasekara,,MATH-3020,2018
+MATH,3110,3,Linear Algebra,0.36,0.43,0.17,0.02,0.0,0.0,0.0,0.02,wayne goddard,,MATH-3110,2018
+MATH,3110,4,Linear Algebra,0.24,0.31,0.26,0.07,0.12,0.0,0.0,0.0,hui xue,,MATH-3110,2018
+MATH,3110,5,Linear Algebra,0.21,0.21,0.19,0.12,0.16,0.0,0.0,0.12,felice manganiello,,MATH-3110,2018
+MATH,3110,6,Linear Algebra,0.27,0.3,0.14,0.09,0.05,0.0,0.0,0.16,felice manganiello,,MATH-3110,2018
+MATH,3110,7,Linear Algebra,0.23,0.31,0.1,0.05,0.03,0.0,0.0,0.28,xuhong gao,,MATH-3110,2018
+MATH,3110,8,Linear Algebra,0.45,0.24,0.08,0.0,0.11,0.0,0.0,0.13,xuhong gao,,MATH-3110,2018
+MATH,3110,9,Linear Algebra,0.22,0.33,0.28,0.03,0.11,0.0,0.0,0.03,vincent ervin,,MATH-3110,2018
+MATH,3110,100,Linear Algebra (HON),0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,beth novick,True,MATH-3110,2018
+MATH,3110,200,Linear Algebra,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,beth novick,,MATH-3110,2018
+MATH,3190,1,Introduction to Proof,0.28,0.12,0.24,0.16,0.12,0.0,0.0,0.08,elena stan dimitrova,,MATH-3190,2018
+MATH,3190,2,Introduction to Proof,0.44,0.2,0.16,0.04,0.08,0.0,0.0,0.08,elena stan dimitrova,,MATH-3190,2018
+MATH,3600,2,Intermediate Math Computing,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,mark cawood,,MATH-3600,2018
+MATH,3650,1,Numerical Mthds for Engineers,0.14,0.42,0.32,0.04,0.04,0.0,0.0,0.04,eleanor jenkins,,MATH-3650,2018
+MATH,3650,2,Numerical Mthds for Engineers,0.23,0.23,0.4,0.09,0.02,0.0,0.0,0.02,hyesuk lee,,MATH-3650,2018
+MATH,3650,3,Numerical Mthds for Engineers,0.26,0.33,0.24,0.05,0.07,0.0,0.0,0.05,hyesuk lee,,MATH-3650,2018
+MATH,4000,1,Theory of Probability,0.3,0.22,0.3,0.04,0.0,0.0,0.0,0.15,brian fralix,,MATH-4000,2018
+MATH,4000,2,Theory of Probability,0.29,0.26,0.29,0.06,0.09,0.0,0.0,0.03,derek brown,,MATH-4000,2018
+MATH,4020,1,Stat for Sci & Engineering II,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,colin gallagher,,MATH-4020,2018
+MATH,4070,1,Regress & Time-Series Analysis,0.47,0.4,0.0,0.0,0.0,0.0,0.0,0.13,colin gallagher,,MATH-4070,2018
+MATH,4120,2,Algebra I,0.24,0.52,0.2,0.04,0.0,0.0,0.0,0.0,hui xue,,MATH-4120,2018
+MATH,4190,1,Discrete Math Structures I,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,wayne goddard,,MATH-4190,2018
+MATH,4190,2,Discrete Math Structures I,0.48,0.3,0.07,0.0,0.11,0.0,0.0,0.04,beth novick,,MATH-4190,2018
+MATH,4340,1,Adv Engineering Mathematics,0.4,0.15,0.15,0.0,0.05,0.0,0.0,0.25,eleanor jenkins,,MATH-4340,2018
+MATH,4340,2,Adv Engineering Mathematics,0.33,0.33,0.11,0.11,0.06,0.0,0.0,0.06,qingshan chen,,MATH-4340,2018
+MATH,4350,1,Complex Variables,0.67,0.08,0.08,0.08,0.0,0.0,0.0,0.08,shitao liu,,MATH-4350,2018
+MATH,4400,1,Linear Programming,0.57,0.13,0.09,0.09,0.04,0.0,0.0,0.09,yuyuan ouyang,,MATH-4400,2018
+MATH,4530,1,Advanced Calculus I,0.48,0.22,0.19,0.0,0.07,0.0,0.0,0.04,james peterson,,MATH-4530,2018
+MATH,4540,1,Advanced Calculus II,0.46,0.08,0.46,0.0,0.0,0.0,0.0,0.0,james peterson,,MATH-4540,2018
+MATH,4560,1,Topology,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,james bar coykendall,,MATH-4560,2018
+MATH,4630,1,Mathematical Analysis I,0.54,0.23,0.08,0.0,0.0,0.0,0.0,0.15,benjamin jaye,,MATH-4630,2018
+MATH,4910,2,Mathematics of Option Pricing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,mark cawood,,MATH-4910,2018
+MATH,6000,1,Theory of Probability,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,brian fralix,,MATH-6000,2018
+MATH,6340,1,Adv Engineering Mathematics,0.43,0.37,0.1,0.0,0.07,0.0,0.0,0.03,vincent ervin,,MATH-6340,2018
+MATH,8000,1,Probability,0.53,0.2,0.07,0.0,0.0,0.0,0.0,0.2,robert lund,,MATH-8000,2018
+MATH,8010,1,General Linear Hypothesis I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,derek brown,,MATH-8010,2018
+MATH,8050,1,Data Analysis,0.44,0.22,0.11,0.0,0.11,0.0,0.0,0.11,xiaoqian sun,,MATH-8050,2018
+MATH,8100,1,Mathematical Programming,0.5,0.32,0.18,0.0,0.0,0.0,0.0,0.0,boshi yang,,MATH-8100,2018
+MATH,8100,2,Mathematical Programming,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,yuyuan ouyang,,MATH-8100,2018
+MATH,8140,1,Network Flow Programming,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,,MATH-8140,2018
+MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,,MATH-8170,2018
+MATH,8210,1,Linear Analysis,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,benjamin jaye,,MATH-8210,2018
+MATH,8250,1,Intro to Dynamical Syst Theory,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,martin johan schmoll,,MATH-8250,2018
+MATH,8530,1,Matrix Analysis,0.44,0.25,0.19,0.0,0.06,0.0,0.0,0.06,sean sather-wagstaff,,MATH-8530,2018
+MATH,8600,1,Intro to Scientific Computing,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,fei xue,,MATH-8600,2018
+MATH,8610,1,Advanced Numerical Analysis I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,qingshan chen,,MATH-8610,2018
+MATH,8650,1,Data Structures,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,matthew saltzman,,MATH-8650,2018
+MATH,8820,1,Intro to Bayesian Statistics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,,MATH-8820,2018
+MBA,8030,1,Stat Analy of Bus Op,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett wood,,MBA-8030,2018
+MBA,8030,2,Stat Analy of Bus Op,0.51,0.46,0.0,0.0,0.03,0.0,0.0,0.0,william ed kilbourne,,MBA-8030,2018
+MBA,8040,20,Busin Data An & Stat Computing,0.62,0.35,0.0,0.0,0.0,0.0,0.0,0.03,william ed kilbourne,,MBA-8040,2018
+MBA,8060,1,Operations Mgt,0.24,0.56,0.2,0.0,0.0,0.0,0.0,0.0, sridharan,,MBA-8060,2018
+MBA,8060,2,Operations Mgt,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,george kennet morgan,,MBA-8060,2018
+MBA,8070,1,Financial Management,0.67,0.28,0.03,0.0,0.0,0.0,0.0,0.03,george bran lockhart,,MBA-8070,2018
+MBA,8070,2,Financial Management,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,george bran lockhart,,MBA-8070,2018
+MBA,8090,1,Org Beh & Hum Res Mg,0.43,0.55,0.02,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,,MBA-8090,2018
+MBA,8090,2,Org Beh & Hum Res Mg,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,thomas jos zagenczyk,,MBA-8090,2018
+MBA,8180,20,Intro Business Intell & Anlytc,0.79,0.15,0.03,0.0,0.0,0.0,0.0,0.03,heshan sun,,MBA-8180,2018
+MBA,8190,1,Intro to Acc and Fin,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,,MBA-8190,2018
+MBA,8190,2,Intro to Acc and Fin,0.45,0.37,0.03,0.0,0.05,0.0,0.0,0.11,jeffrey mcmillan,,MBA-8190,2018
+MBA,8290,1,Marketing Foundation,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MBA-8290,2018
+MBA,8310,10,Communications and Sales,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,,MBA-8310,2018
+MBA,8370,1,Legal Environ of Bus,0.42,0.45,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2018
+MBA,8370,2,Legal Environ of Bus,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2018
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,,MBA-8400,2018
+MBA,8430,1,Entrepreneurial Accounting,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,annieka philo,,MBA-8430,2018
+MBA,8440,1,Entrepreneurial Law,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8440,2018
+MBA,8450,1,Technology & Innovation Mgt,0.72,0.2,0.04,0.0,0.0,0.0,0.0,0.04,michael george mino,,MBA-8450,2018
+MBA,8480,5,Entrpr Mkting & Digital Strat,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,bruce snyder,,MBA-8480,2018
+MBA,8490,5,Entrepreneurial Strategy,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,matthew charle klein,,MBA-8490,2018
+MBA,8510,1,Bus Operations & Logistics,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0, sridharan,,MBA-8510,2018
+MBA,8540,1,Managerial Accounting,0.35,0.58,0.05,0.0,0.0,0.0,0.0,0.03,emily suzan mccorkle,,MBA-8540,2018
+MBA,8590,1,Mgr Decision Model,0.23,0.27,0.15,0.0,0.27,0.0,0.0,0.08,sara elizabeth yoder,,MBA-8590,2018
+MBA,8590,2,Mgr Decision Model,0.45,0.37,0.18,0.0,0.0,0.0,0.0,0.0,magda gabriela sava,,MBA-8590,2018
+MBA,8590,3,Mgr Decision Model,0.08,0.54,0.31,0.0,0.08,0.0,0.0,0.0,magda gabriela sava,,MBA-8590,2018
+MBA,8600,1,Advanced Marketing Strategy,0.35,0.38,0.25,0.0,0.0,0.0,0.0,0.03,michael dorsch,,MBA-8600,2018
+MBA,8600,2,Advanced Marketing Strategy,0.21,0.56,0.23,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2018
+MBA,8610,2,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,kevin mckenzie,,MBA-8610,2018
+MBA,8620,1,Managerial Economics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,,MBA-8620,2018
+MBA,8620,2,Managerial Economics,0.62,0.34,0.0,0.0,0.0,0.0,0.0,0.03,ronald earle gregory,,MBA-8620,2018
+MBA,8620,4,Managerial Economics,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,,MBA-8620,2018
+MBA,8650,1,Taxation of Business Decisions,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8650,2018
+MBA,8660,21,"Data, Storage, Business Decis",0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,,MBA-8660,2018
+MBA,8700,1,Strategic Management,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,james turner,,MBA-8700,2018
+MBA,8990,2,Creativity,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,,MBA-8990,2018
+ME,2000,1,Sophomore Seminar,0.87,0.04,0.02,0.01,0.01,0.0,0.0,0.05,todd al schweisinger,,ME-2000,2018
+ME,2000,2,Sophomore Seminar,0.83,0.07,0.04,0.02,0.0,0.0,0.0,0.05,todd al schweisinger,,ME-2000,2018
+ME,2010,1,Statics & Dynamics,0.12,0.2,0.29,0.08,0.19,0.0,0.0,0.11,marisa kikendall orr,,ME-2010,2018
+ME,2010,2,Statics & Dynamics,0.11,0.23,0.25,0.07,0.27,0.0,0.0,0.06,paul joseph,,ME-2010,2018
+ME,2010,4,Statics & Dynamics,0.04,0.17,0.23,0.13,0.29,0.0,0.0,0.13,lonny thompson,,ME-2010,2018
+ME,2030,1,Founda Th/Fl Syst,0.0,0.08,0.42,0.17,0.1,0.0,0.0,0.23,john saylor,,ME-2030,2018
+ME,2220,2,Mechanical Engineering Lab I,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,,ME-2220,2018
+ME,2220,3,Mechanical Engineering Lab I,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,5,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,6,Mechanical Engineering Lab I,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,7,Mechanical Engineering Lab I,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,todd al schweisinger,,ME-2220,2018
+ME,2220,8,Mechanical Engineering Lab I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,13,Mechanical Engineering Lab I,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,15,Mechanical Engineering Lab I,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,,ME-2220,2018
+ME,2220,16,Mechanical Engineering Lab I,0.25,0.42,0.25,0.0,0.08,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,3030,1,Thermodynamics,0.3,0.45,0.16,0.02,0.06,0.0,0.0,0.01,yiqiang han,,ME-3030,2018
+ME,3030,2,Thermodynamics,0.3,0.37,0.22,0.08,0.0,0.0,0.0,0.03,yiqiang han,,ME-3030,2018
+ME,3050,1,Model/an Dy Syst,0.19,0.26,0.4,0.05,0.07,0.0,0.0,0.02,joshua bostwick,,ME-3050,2018
+ME,3050,2,Model/an Dy Syst,0.31,0.31,0.2,0.11,0.04,0.0,0.0,0.02,ardalan vahidi,,ME-3050,2018
+ME,3060,1,Fund Machine Design,0.3,0.55,0.09,0.0,0.0,0.0,0.0,0.06,oliver myers,,ME-3060,2018
+ME,3060,2,Fund Machine Design,0.24,0.52,0.22,0.02,0.0,0.0,0.0,0.0,james allen righter,,ME-3060,2018
+ME,3070,1,Found of Mechanical Systems,0.23,0.49,0.2,0.04,0.03,0.0,0.0,0.01,jorge ivan rodriguez,,ME-3070,2018
+ME,3070,2,Found of Mechanical Systems,0.43,0.38,0.14,0.02,0.0,0.0,0.0,0.03,jorge ivan rodriguez,,ME-3070,2018
+ME,3080,1,Fluid Mechanics,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,,ME-3080,2018
+ME,3080,2,Fluid Mechanics,0.28,0.3,0.3,0.04,0.04,0.0,0.0,0.02,yiqiang han,,ME-3080,2018
+ME,3080,3,Fluid Mechanics,0.06,0.44,0.41,0.05,0.03,0.0,0.0,0.01,ethan kung,,ME-3080,2018
+ME,3120,1,Manuf Processes,0.83,0.15,0.01,0.0,0.01,0.0,0.0,0.0,rodr martinez-duarte,,ME-3120,2018
+ME,3330,1,Mechanical Engineering Lab II,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,,ME-3330,2018
+ME,3330,2,Mechanical Engineering Lab II,0.25,0.44,0.25,0.06,0.0,0.0,0.0,0.0,james allen righter,,ME-3330,2018
+ME,3330,3,Mechanical Engineering Lab II,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,,ME-3330,2018
+ME,3330,6,Mechanical Engineering Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,,ME-3330,2018
+ME,3330,7,Mechanical Engineering Lab II,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,james allen righter,,ME-3330,2018
+ME,3330,8,Mechanical Engineering Lab II,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,james allen righter,,ME-3330,2018
+ME,3330,9,Mechanical Engineering Lab II,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,james allen righter,,ME-3330,2018
+ME,3330,10,Mechanical Engineering Lab II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,james allen righter,,ME-3330,2018
+ME,4010,1,Mech Engr Design,0.3,0.59,0.08,0.0,0.0,0.0,0.0,0.03,joshua summers,,ME-4010,2018
+ME,4010,2,Mech Engr Design,0.29,0.59,0.11,0.0,0.02,0.0,0.0,0.0,joshua summers,,ME-4010,2018
+ME,4010,3,Mech Engr Design,0.26,0.59,0.1,0.02,0.03,0.0,0.0,0.0,joshua summers,,ME-4010,2018
+ME,4020,1,Intern in Engr Des,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,cameron turner,,ME-4020,2018
+ME,4020,3,Intern in Engr Des,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2018
+ME,4020,4,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lonny thompson,,ME-4020,2018
+ME,4030,2,Control Dynamic Systems,0.34,0.36,0.26,0.01,0.01,0.0,0.0,0.01,suyi li,,ME-4030,2018
+ME,4210,1,Intro to Comp Flow,0.33,0.43,0.19,0.05,0.0,0.0,0.0,0.0,chenning tong,,ME-4210,2018
+ME,4290,1,Ther Env Control,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,,ME-4290,2018
+ME,4400,1,Matls for Aggr Envir,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,garrett pataky,,ME-4400,2018
+ME,4440,6,Mechanical Engineering Lab III,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2018
+ME,4540,1,Design of Machine Elements,0.24,0.62,0.1,0.0,0.05,0.0,0.0,0.0,hong seok choi,,ME-4540,2018
+ME,4930,14,Sel.Topics ME - NonLinDy&Chas,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,,ME-4930,2018
+ME,4930,39,Sel.Topics ME - Aero Propul,0.47,0.45,0.09,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-4930,2018
+ME,6540,1,Des Machine Elements,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-6540,2018
+ME,6540,843,Des Machine Elements,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-6540,2018
+ME,6930,14,Sel.Topics ME - NonLinDy&Chas,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,,ME-6930,2018
+ME,8010,1,Found of Fluid Mech,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,richard figliola,,ME-8010,2018
+ME,8100,1,Macroscopic Thermo,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,,ME-8100,2018
+ME,8180,1,Intro to Fin Ele Ana,0.44,0.49,0.05,0.0,0.0,0.0,0.0,0.02,gang li,,ME-8180,2018
+ME,8230,1,Control Systems,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,,ME-8230,2018
+ME,8360,1,Fracture Mech,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,,ME-8360,2018
+ME,8460,1,Inter Dynamics,0.56,0.11,0.33,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,,ME-8460,2018
+ME,8710,1,Engr Optimization,0.47,0.35,0.06,0.0,0.06,0.0,0.0,0.06,georges fadel,,ME-8710,2018
+ME,8930,9,Sel Topics - Continuum Mech.,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,gang li,,ME-8930,2018
+ME,8930,27,SelTopics ME - OptimalControls,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,,ME-8930,2018
+ME,8930,37,SelTopics ME - Laser Based Mfg,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,xin zhao,,ME-8930,2018
+MGT,2010,1,Principles of Management,0.38,0.43,0.17,0.02,0.01,0.0,0.0,0.0,katherine clark,,MGT-2010,2018
+MGT,2010,2,Principles of Management,0.56,0.34,0.08,0.01,0.01,0.0,0.0,0.01,tina robbins,,MGT-2010,2018
+MGT,2010,8,Principles of Management,0.33,0.45,0.23,0.0,0.0,0.0,0.0,0.0,christopher mann,,MGT-2010,2018
+MGT,2010,9,Principles of Management,0.3,0.5,0.15,0.03,0.03,0.0,0.0,0.0,christopher mann,,MGT-2010,2018
+MGT,2010,10,Principles of Management,0.25,0.39,0.34,0.0,0.0,0.0,0.0,0.02,ashley willi parnell,,MGT-2010,2018
+MGT,2010,11,Principles of Management,0.16,0.32,0.32,0.11,0.02,0.0,0.0,0.07,ashley willi parnell,,MGT-2010,2018
+MGT,2180,1,Management PC Applications,0.47,0.38,0.08,0.03,0.02,0.0,0.0,0.02,ryan toole,,MGT-2180,2018
+MGT,2180,2,Management PC Applications,0.2,0.56,0.16,0.08,0.0,0.0,0.0,0.0,ryan toole,,MGT-2180,2018
+MGT,3070,1,Human Resource Management,0.38,0.48,0.15,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,,MGT-3070,2018
+MGT,3070,3,Human Resource Management,0.45,0.45,0.08,0.0,0.03,0.0,0.0,0.0,kristin dama scott dama,,MGT-3070,2018
+MGT,3070,4,Human Resource Management,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2018
+MGT,3070,5,Human Resource Management,0.33,0.46,0.21,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,,MGT-3070,2018
+MGT,3070,6,Human Resource Management,0.6,0.33,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2018
+MGT,3070,7,Human Resource Management,0.28,0.55,0.15,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,,MGT-3070,2018
+MGT,3070,8,Human Resource Management,0.42,0.33,0.15,0.06,0.0,0.0,0.0,0.03,priscilla harrison,,MGT-3070,2018
+MGT,3100,1,Intermed Business Statistics,0.07,0.39,0.34,0.08,0.03,0.0,0.0,0.08,janis miller,,MGT-3100,2018
+MGT,3100,2,Intermed Business Statistics,0.37,0.4,0.2,0.03,0.0,0.0,0.0,0.0,mustafa serka akturk,,MGT-3100,2018
+MGT,3100,3,Intermed Business Statistics,0.35,0.3,0.13,0.05,0.08,0.0,0.0,0.1,daniel nielubowicz,,MGT-3100,2018
+MGT,3100,5,Intermed Business Statistics,0.3,0.38,0.23,0.0,0.03,0.0,0.0,0.08,mustafa serka akturk,,MGT-3100,2018
+MGT,3100,6,Intermed Business Statistics,0.2,0.46,0.2,0.02,0.07,0.0,0.0,0.07,magda gabriela sava,,MGT-3100,2018
+MGT,3100,7,Intermed Business Statistics,0.36,0.19,0.17,0.06,0.17,0.0,0.0,0.06,daniel nielubowicz,,MGT-3100,2018
+MGT,3100,8,Intermed Business Statistics,0.31,0.24,0.21,0.05,0.07,0.0,0.0,0.12,iaroslava vo dutchak,,MGT-3100,2018
+MGT,3100,9,Intermed Business Statistics,0.69,0.24,0.05,0.0,0.02,0.0,0.0,0.0,maneeshred ajjuguttu,,MGT-3100,2018
+MGT,3100,10,Intermed Business Statistics,0.56,0.25,0.13,0.03,0.0,0.0,0.0,0.03,jeromy blake snider,,MGT-3100,2018
+MGT,3100,12,Intermed Business Statistics,0.3,0.19,0.24,0.08,0.08,0.0,0.0,0.11,daniel allan detoma,,MGT-3100,2018
+MGT,3120,1,Decision Models for Management,0.22,0.21,0.27,0.08,0.08,0.0,0.0,0.14,sara elizabeth yoder,,MGT-3120,2018
+MGT,3120,2,Decision Models for Management,0.19,0.31,0.34,0.02,0.1,0.0,0.0,0.05,sara elizabeth yoder,,MGT-3120,2018
+MGT,3120,4,Decision Models for Management,0.29,0.37,0.26,0.0,0.05,0.0,0.0,0.03,james turner,,MGT-3120,2018
+MGT,3180,1,Mgt of Info Systems,0.86,0.09,0.02,0.02,0.0,0.0,0.0,0.0,shih lun tseng,,MGT-3180,2018
+MGT,3180,2,Mgt of Info Systems,0.28,0.33,0.3,0.05,0.0,0.0,0.0,0.05,marten risius,,MGT-3180,2018
+MGT,3180,3,Mgt of Info Systems,0.87,0.12,0.02,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,,MGT-3180,2018
+MGT,3180,4,Mgt of Info Systems,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,daniel aaron pienta,,MGT-3180,2018
+MGT,3180,5,Mgt of Info Systems,0.4,0.35,0.23,0.0,0.0,0.0,0.0,0.03,wenxi pu,,MGT-3180,2018
+MGT,3900,1,Operations Management,0.15,0.5,0.28,0.05,0.03,0.0,0.0,0.0,yann ferrand,,MGT-3900,2018
+MGT,3900,2,Operations Management,0.08,0.5,0.38,0.03,0.0,0.0,0.0,0.03,zachary mor leffakis,,MGT-3900,2018
+MGT,3900,4,Operations Management,0.12,0.33,0.26,0.08,0.06,0.0,0.0,0.15, sridharan,,MGT-3900,2018
+MGT,4000,1,Mgt of Organizational Behavior,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2018
+MGT,4000,2,Mgt of Organizational Behavior,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2018
+MGT,4000,3,Mgt of Organizational Behavior,0.25,0.35,0.38,0.0,0.0,0.0,0.0,0.03,thomas jos zagenczyk,,MGT-4000,2018
+MGT,4000,4,Mgt of Organizational Behavior,0.15,0.46,0.28,0.03,0.0,0.0,0.0,0.08,philip roth,,MGT-4000,2018
+MGT,4020,1,Ops Pln and Ctl,0.06,0.33,0.56,0.06,0.0,0.0,0.0,0.0,zachary mor leffakis,,MGT-4020,2018
+MGT,4080,1,Lean Operations,0.14,0.5,0.27,0.05,0.05,0.0,0.0,0.0,zachary mor leffakis,,MGT-4080,2018
+MGT,4110,1,Project Management,0.23,0.6,0.13,0.0,0.0,0.0,0.0,0.05,russell purvis,,MGT-4110,2018
+MGT,4120,1,Supplier Management,0.42,0.53,0.03,0.0,0.03,0.0,0.0,0.0,ahmet colak,,MGT-4120,2018
+MGT,4150,1,Business Strategy,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2018
+MGT,4150,2,Business Strategy,0.16,0.44,0.33,0.02,0.0,0.0,0.0,0.04,james liddle,,MGT-4150,2018
+MGT,4150,3,Business Strategy,0.12,0.64,0.21,0.02,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2018
+MGT,4150,4,Business Strategy,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,,MGT-4150,2018
+MGT,4150,6,Business Strategy,0.11,0.37,0.45,0.05,0.0,0.0,0.0,0.03,james liddle,,MGT-4150,2018
+MGT,4150,9,Business Strategy,0.36,0.52,0.11,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,,MGT-4150,2018
+MGT,4160,1,Special Topics Hr,0.34,0.42,0.18,0.05,0.0,0.0,0.0,0.0,kristin dama scott dama,,MGT-4160,2018
+MGT,4230,1,Intern Bus Mgt,0.07,0.33,0.55,0.0,0.02,0.0,0.0,0.02,wayne stewart,,MGT-4230,2018
+MGT,4230,2,Intern Bus Mgt,0.2,0.15,0.57,0.07,0.02,0.0,0.0,0.0,wayne stewart,,MGT-4230,2018
+MGT,4230,3,Intern Bus Mgt,0.05,0.53,0.38,0.03,0.0,0.0,0.0,0.03,janis miller,,MGT-4230,2018
+MGT,4230,4,Intern Bus Mgt,0.09,0.59,0.25,0.07,0.0,0.0,0.0,0.0,janis miller,,MGT-4230,2018
+MGT,4240,1,Global Supply Chain,0.32,0.44,0.24,0.0,0.0,0.0,0.0,0.0,yann ferrand,,MGT-4240,2018
+MGT,4270,2,Managing Improvement,0.25,0.35,0.35,0.0,0.05,0.0,0.0,0.0,lawrence fredendall,,MGT-4270,2018
+MGT,4310,1,Emp Rights & Resp,0.44,0.49,0.08,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,,MGT-4310,2018
+MGT,4350,1,Pers Interviewing,0.34,0.39,0.16,0.11,0.0,0.0,0.0,0.0,philip roth,,MGT-4350,2018
+MGT,4520,1,Business Analysis,0.21,0.36,0.27,0.03,0.03,0.0,0.0,0.09,marten risius,,MGT-4520,2018
+MGT,8690,1,Project Mgt,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,,MGT-8690,2018
+MICR,2050,1,Introductory Micro,0.38,0.43,0.19,0.01,0.0,0.0,0.0,0.0,john abercrombie,,MICR-2050,2018
+MICR,3050,1,General Microbiology,0.29,0.42,0.24,0.03,0.01,0.0,0.0,0.02,krista barri rudolph,,MICR-3050,2018
+MICR,3050,2,General Microbiology,0.52,0.37,0.09,0.02,0.0,0.0,0.0,0.0,krista barri rudolph,,MICR-3050,2018
+MICR,4010,1,Microbial Diversity & Ecology,0.19,0.34,0.33,0.08,0.02,0.0,0.0,0.05,barbara campbell,,MICR-4010,2018
+MICR,4050,1,Adv Microbial Ecol of Humans,0.5,0.26,0.16,0.09,0.0,0.0,0.0,0.0,kristi jam whitehead,,MICR-4050,2018
+MICR,4140,1,Basic Immunology,0.46,0.28,0.15,0.09,0.0,0.0,0.0,0.02,yanzhang wei,,MICR-4140,2018
+MICR,4150,1,Microbial Genetics,0.2,0.49,0.22,0.09,0.0,0.0,0.0,0.0,min cao,,MICR-4150,2018
+MICR,4160,1,Intro Virology,0.69,0.2,0.09,0.0,0.01,0.0,0.0,0.01,kristi jam whitehead,,MICR-4160,2018
+MICR,4510,1,Advanced Microbiology II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4510,2018
+MICR,4510,2,Advanced Microbiology II,0.45,0.5,0.0,0.0,0.05,0.0,0.0,0.0,harry kurtz,,MICR-4510,2018
+MICR,4510,3,Advanced Microbiology II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4510,2018
+MICR,4560,1,Medical and Vet Parasitology,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kears milhous,,MICR-4560,2018
+MICR,4940,11,CI: Microbes All Around Us,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,kristi jam whitehead,,MICR-4940,2018
+MKT,3010,1,Principles of Marketing,0.19,0.4,0.27,0.1,0.02,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2018
+MKT,3010,2,Principles of Marketing,0.32,0.34,0.21,0.09,0.02,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2018
+MKT,3010,3,Principles of Marketing,0.33,0.33,0.26,0.05,0.02,0.0,0.0,0.01,amanda cooper fine,,MKT-3010,2018
+MKT,3010,4,Principles of Marketing,0.27,0.41,0.24,0.05,0.03,0.0,0.0,0.0,carter will mcelveen,,MKT-3010,2018
+MKT,3010,5,Principles of Marketing,0.36,0.34,0.22,0.06,0.02,0.0,0.0,0.01,carter will mcelveen,,MKT-3010,2018
+MKT,3010,7,Principles of Marketing,0.27,0.41,0.23,0.01,0.01,0.0,0.0,0.07,james gaubert,,MKT-3010,2018
+MKT,3020,1,Consumer Behavior,0.37,0.46,0.15,0.02,0.0,0.0,0.0,0.0,jennifer dia siemens,,MKT-3020,2018
+MKT,3020,2,Consumer Behavior,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,jennifer dia siemens,,MKT-3020,2018
+MKT,3020,3,Consumer Behavior,0.51,0.38,0.09,0.0,0.0,0.0,0.0,0.02,anastasia el thyroff,,MKT-3020,2018
+MKT,3020,4,Consumer Behavior,0.37,0.51,0.12,0.0,0.0,0.0,0.0,0.0,anastasia el thyroff,,MKT-3020,2018
+MKT,3020,5,Consumer Behavior,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,patricia knowles,,MKT-3020,2018
+MKT,3210,1,Sports Marketing,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,,MKT-3210,2018
+MKT,3210,2,Sports Marketing,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,,MKT-3210,2018
+MKT,3220,1,Social Media Marketing,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-3220,2018
+MKT,3220,2,Social Media Marketing,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-3220,2018
+MKT,3220,3,Social Media Marketing,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,michele melto cauley,,MKT-3220,2018
+MKT,3220,4,Social Media Marketing,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michele melto cauley,,MKT-3220,2018
+MKT,3310,1,Marketing Metrics & Analytics,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,oriana rachel aragon,,MKT-3310,2018
+MKT,3310,2,Marketing Metrics & Analytics,0.67,0.28,0.03,0.0,0.03,0.0,0.0,0.0,oriana rachel aragon,,MKT-3310,2018
+MKT,3310,3,Marketing Metrics & Analytics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-3310,2018
+MKT,3310,4,Marketing Metrics & Analytics,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-3310,2018
+MKT,4200,1,Professional Selling,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2018
+MKT,4200,2,Professional Selling,0.71,0.23,0.06,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2018
+MKT,4200,3,Professional Selling,0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4200,2018
+MKT,4200,5,Professional Selling,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,carter will mcelveen,,MKT-4200,2018
+MKT,4230,1,Promotional Strategy,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,patricia knowles,,MKT-4230,2018
+MKT,4230,2,Promotional Strategy,0.77,0.16,0.03,0.03,0.0,0.0,0.0,0.0,michele melto cauley,,MKT-4230,2018
+MKT,4230,3,Promotional Strategy,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,michele melto cauley,,MKT-4230,2018
+MKT,4240,1,Sales Management,0.32,0.62,0.06,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4240,2018
+MKT,4270,1,International Marketing,0.51,0.46,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4270,2018
+MKT,4270,2,International Marketing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4270,2018
+MKT,4270,3,International Marketing,0.26,0.6,0.12,0.0,0.0,0.0,0.0,0.02,thomas poehlman,,MKT-4270,2018
+MKT,4270,4,International Marketing,0.58,0.3,0.1,0.01,0.0,0.0,0.0,0.0,patricia knowles,,MKT-4270,2018
+MKT,4280,1,Services Marketing,0.38,0.49,0.14,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4280,2018
+MKT,4280,2,Services Marketing,0.41,0.46,0.14,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4280,2018
+MKT,4310,3,Marketing Research,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2018
+MKT,4310,4,Marketing Research,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2018
+MKT,4450,1,Macromarketing,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,,MKT-4450,2018
+MKT,4500,3,Strategic Mktg Mgt,0.25,0.5,0.21,0.04,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2018
+MKT,8610,1,Marketing Research,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,,MKT-8610,2018
+MKT,8630,1,Buyer Behavior,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-8630,2018
+ML,2010,1,Leadership Development I,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2010,2018
+ML,2010,2,Leadership Development I,0.76,0.12,0.0,0.06,0.06,0.0,0.0,0.0,vincent john presto,,ML-2010,2018
+ML,2010,3,Leadership Development I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2010,2018
+ML,3010,1,Advanced Leadership I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william cody cleland,,ML-3010,2018
+ML,3010,2,Advanced Leadership I,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,william cody cleland,,ML-3010,2018
+MSE,2100,1,Intro to Materials Science,0.34,0.27,0.16,0.12,0.04,0.0,0.0,0.07,rakhee pani,,MSE-2100,2018
+MSE,2100,2,Intro to Materials Science,0.07,0.29,0.37,0.13,0.06,0.0,0.0,0.07,kai he,,MSE-2100,2018
+MSE,2100,3,Intro to Materials Science,0.24,0.37,0.25,0.06,0.04,0.0,0.0,0.04,kyle brinkman,,MSE-2100,2018
+MSE,2100,4,Intro to Materials Science,0.27,0.33,0.23,0.09,0.04,0.0,0.0,0.04,marian kennedy,,MSE-2100,2018
+MSE,2100,5,Introduction to Materials Sci,0.41,0.29,0.09,0.18,0.0,0.0,0.0,0.03,olga kuksenok,,MSE-2100,2018
+MSE,3010,4,Materials Synthesis & Fabr Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,,MSE-3010,2018
+MSE,3190,1,Materials Proc I,0.35,0.55,0.09,0.0,0.0,0.0,0.0,0.01,rajendra kuma bordia,,MSE-3190,2018
+MSE,3190,2,Materials Proc I,0.2,0.47,0.2,0.13,0.0,0.0,0.0,0.0,rajendra kuma bordia,,MSE-3190,2018
+MSE,3260,1,Thermo of Materials,0.23,0.37,0.26,0.09,0.03,0.0,0.0,0.03,fei peng,,MSE-3260,2018
+MSE,3260,2,Thermo of Materials,0.18,0.47,0.18,0.13,0.0,0.0,0.0,0.03,fei peng,,MSE-3260,2018
+MSE,3270,1,Transport Phenomena,0.38,0.23,0.23,0.08,0.08,0.0,0.0,0.0,ulf daniel schiller,,MSE-3270,2018
+MSE,4020,1,Solid State Material,0.45,0.14,0.3,0.07,0.02,0.0,0.0,0.02,luiz gusta jacobsohn,,MSE-4020,2018
+MSE,4130,1,Noncrystalline Materials,0.54,0.38,0.0,0.04,0.04,0.0,0.0,0.0,jianhua tong,,MSE-4130,2018
+MSE,4150,1,Polymer Sc Engr,0.42,0.33,0.18,0.06,0.0,0.0,0.0,0.0,igor luzinov,,MSE-4150,2018
+MSE,4150,2,Polymer Sc Engr,0.5,0.19,0.24,0.02,0.02,0.0,0.0,0.04,rakhee pani,,MSE-4150,2018
+MSE,4320,1,Manuf Proc & Systems,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,,MSE-4320,2018
+MSE,4580,1,Surf Phen in Ms&E,0.25,0.17,0.33,0.08,0.13,0.0,0.0,0.04,konstantin ge kornev,,MSE-4580,2018
+MSE,4610,1,Polymer & Fiber Materials III,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,philip brown,,MSE-4610,2018
+MSE,4810,1,Undergraduate Research Fundame,0.64,0.22,0.11,0.02,0.0,0.0,0.0,0.0,marian kennedy,,MSE-4810,2018
+MSE,4910,1,Undergraduate Research,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kuma bordia,,MSE-4910,2018
+MSE,8100,1,Fundamentals of Materials Sci,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,igor luzinov,,MSE-8100,2018
+MSE,8260,1,Phase Equil Mat Sys,0.43,0.5,0.0,0.0,0.07,0.0,0.0,0.0,stephen foulger,,MSE-8260,2018
+MSE,8270,1,Kin of Phase Tran,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,konstantin ge kornev,,MSE-8270,2018
+MUSC,1420,1,Music Theory I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david conley,,MUSC-1420,2018
+MUSC,1430,1,Aural Skills I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david conley,,MUSC-1430,2018
+MUSC,1510,2,Applied Music,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,jonathan edwar doyel,,MUSC-1510,2018
+MUSC,2100,2,Music in the Western World,0.53,0.41,0.03,0.0,0.0,0.0,0.0,0.03,lisa sain odom,,MUSC-2100,2018
+MUSC,2100,4,Music in the Western World,0.58,0.1,0.13,0.06,0.0,0.0,0.0,0.13,linda li-bleuel,,MUSC-2100,2018
+MUSC,2100,6,Music in the Western World,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2018
+MUSC,2100,7,Music in the Western World,0.33,0.47,0.17,0.0,0.03,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2018
+MUSC,2100,8,Music in the Western World,0.44,0.48,0.04,0.0,0.0,0.0,0.0,0.04,rhea beth jacobus,,MUSC-2100,2018
+MUSC,2100,12,Music in the Western World,0.72,0.19,0.0,0.0,0.03,0.0,0.0,0.06,lea kibler,,MUSC-2100,2018
+MUSC,3110,1,History of American Music,0.65,0.26,0.03,0.03,0.03,0.0,0.0,0.0,ned hosler,,MUSC-3110,2018
+MUSC,3120,1,History of Jazz,0.75,0.18,0.04,0.04,0.0,0.0,0.0,0.0,eric lapin,,MUSC-3120,2018
+MUSC,3170,1,Hist of Country Mus,0.72,0.19,0.0,0.03,0.03,0.0,0.0,0.03,ned hosler,,MUSC-3170,2018
+MUSC,3180,1,Hist of Audio Tech,0.42,0.37,0.11,0.05,0.05,0.0,0.0,0.0,bruce allen whisler,,MUSC-3180,2018
+MUSC,3610,1,Marching Band,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,,MUSC-3610,2018
+MUSC,3980,1,Special Topics,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,hamilton altstatt,,MUSC-3980,2018
+MUSC,4150,1,Music Hist to 1750,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,linda dzuris,,MUSC-4150,2018
+NPL,3000,1,Nonprofit Leadership,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,christina mari mazer,,NPL-3000,2018
+NPL,3000,2,Nonprofit Leadership,0.33,0.61,0.0,0.0,0.06,0.0,0.0,0.0,bonnie westb stevens,,NPL-3000,2018
+NPL,3000,3,Nonprofit Leadership,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,christina mari mazer,,NPL-3000,2018
+NPL,3000,4,Nonprofit Leadership,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,corey doug brookover,,NPL-3000,2018
+NPL,3000,5,Nonprofit Leadership,0.55,0.2,0.2,0.0,0.05,0.0,0.0,0.0,corey doug brookover,,NPL-3000,2018
+NPL,3000,6,Nonprofit Leadership,0.45,0.45,0.05,0.0,0.05,0.0,0.0,0.0,corey doug brookover,,NPL-3000,2018
+NPL,3000,7,Nonprofit Leadership,0.3,0.5,0.05,0.05,0.0,0.0,0.0,0.1,bonnie westb stevens,,NPL-3000,2018
+NPL,3000,8,Nonprofit Leadership,0.58,0.29,0.08,0.0,0.04,0.0,0.0,0.0,christina mari mazer,,NPL-3000,2018
+NPL,3000,9,Nonprofit Leadership,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,christina mari mazer,,NPL-3000,2018
+NPL,3010,1,NPL Stakeholders,0.5,0.33,0.06,0.0,0.11,0.0,0.0,0.0,christina mari mazer,,NPL-3010,2018
+NPL,3020,1,NPL Fundraising,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,robert brookover,,NPL-3020,2018
+NPL,3030,1,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,corey doug brookover,,NPL-3030,2018
+NPL,3040,1,NPL Risk Management,0.7,0.1,0.0,0.15,0.05,0.0,0.0,0.0,daniel morg anderson,,NPL-3040,2018
+NPL,3050,2,Strat Social Media for NP Org,0.44,0.22,0.19,0.0,0.11,0.0,0.0,0.04,amanda elizabe moore,,NPL-3050,2018
+NURS,3030,1,Nursing of Adults,0.42,0.56,0.02,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2018
+NURS,3040,1,Pathophysiology,0.45,0.35,0.15,0.02,0.03,0.0,0.0,0.0,catherine sik murton,,NURS-3040,2018
+NURS,3040,2,Pathophysiology,0.36,0.55,0.05,0.04,0.0,0.0,0.0,0.0,amy boggs garrison,,NURS-3040,2018
+NURS,3040,400,Pathophysiology,0.44,0.52,0.0,0.04,0.0,0.0,0.0,0.0,amy boggs garrison,,NURS-3040,2018
+NURS,3040,401,Pathophysiology,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,elizabeth cam hassen,,NURS-3040,2018
+NURS,3050,1,Psychosocial Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,,NURS-3050,2018
+NURS,3100,400,Health Assessment,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,,NURS-3100,2018
+NURS,3120,1,Foundations of Nursing,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,,NURS-3120,2018
+NURS,3120,2,Foundations of Nursing,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,,NURS-3120,2018
+NURS,3120,400,Foundations of Nursing,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,,NURS-3120,2018
+NURS,3200,1,Prof in Nurs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3200,2018
+NURS,3300,1,Research in Nursing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-3300,2018
+NURS,3330,400,Health Care Genetics,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,,NURS-3330,2018
+NURS,3400,1,Pharmther Nursing,0.45,0.35,0.12,0.05,0.03,0.0,0.0,0.0,catherine sik murton,,NURS-3400,2018
+NURS,3400,2,Pharmther Nursing,0.39,0.46,0.11,0.04,0.0,0.0,0.0,0.0,jenna lynn seawright,,NURS-3400,2018
+NURS,3400,400,Pharmther Nursing,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jenna lynn seawright,,NURS-3400,2018
+NURS,3600,400,Social Determinants in Health,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,roxanne amerson,,NURS-3600,2018
+NURS,4010,1,Mental Health Nurs,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,,NURS-4010,2018
+NURS,4060,400,Issues in Professionalism,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,,NURS-4060,2018
+NURS,4110,1,Nursing of Children,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,,NURS-4110,2018
+NURS,4120,1,Nurs Women and Fam,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2018
+NURS,4250,400,Community Nursing,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,tiffany leah stewart,,NURS-4250,2018
+NURS,4980,17,Neonatal Abstinence Syndrome,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,heide temples,,NURS-4980,2018
+NURS,8040,400,Dev Nurs Knowledge,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,stephanie clar davis,,NURS-8040,2018
+NURS,8050,400,Pharmaco Adv Nurs,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8050,2018
+NURS,8050,401,Pharmaco Adv Nurs,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8050,2018
+NURS,8060,400,Advan Assessment for Nursing,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,jennifer geter rice,,NURS-8060,2018
+NURS,8090,400,Pathophysiology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,,NURS-8090,2018
+NURS,8180,400,Develop Family in Primary Care,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-8180,2018
+NURS,8190,400,Developing Family,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-8190,2018
+NURS,8200,400,Child & Adol Nursing,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,heide temples,,NURS-8200,2018
+NURS,9010,1,"DNP Role, Theory & Philosophy",0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,jean ellen zavertnik,,NURS-9010,2018
+NURS,9020,1,DNP Clinical Epidem & Biostats,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,veronica parker,,NURS-9020,2018
+NUTR,2030,1,Intro Princ of Human Nutrition,0.86,0.09,0.0,0.01,0.03,0.0,0.0,0.0,bridgit deni corbett,,NUTR-2030,2018
+NUTR,2030,2,Intro Princ of Human Nutrition,0.67,0.25,0.05,0.0,0.0,0.0,0.0,0.02,bridgit deni corbett,,NUTR-2030,2018
+NUTR,2050,400,Nutrition for Nursing Prof,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,,NUTR-2050,2018
+NUTR,2160,1,Evidence-Based Nutrition,0.88,0.06,0.05,0.0,0.01,0.0,0.0,0.0,angela fraser,,NUTR-2160,2018
+NUTR,3020,1,Nutrition Assessment,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,elliot jesch,,NUTR-3020,2018
+NUTR,4240,1,Medical Nutr Thera I,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4240,2018
+NUTR,4510,1,Human Nutrition & Metabolism I,0.31,0.26,0.17,0.17,0.03,0.0,0.0,0.06,elliot jesch,,NUTR-4510,2018
+PA,1010,1,Intro to Perf Arts,0.72,0.2,0.0,0.0,0.08,0.0,0.0,0.0,david hartmann,,PA-1010,2018
+PA,2790,1,Perf Arts Pract I,0.47,0.41,0.0,0.0,0.0,0.0,0.0,0.12,kenneth moore,,PA-2790,2018
+PADM,8210,400,Perspectives on Public Admin,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,thomas walker,,PADM-8210,2018
+PADM,8210,401,Perspectives on Public Admin,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,thomas walker,,PADM-8210,2018
+PADM,8420,400,GIS for Public Administrators,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,david lawrence white,,PADM-8420,2018
+PADM,8450,400,Grant Writing for Public Admin,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,katherin kransteuber,,PADM-8450,2018
+PADM,8530,400,Homeland Sec/Emergency Mgt Law,0.64,0.09,0.0,0.0,0.09,0.0,0.0,0.18,david leigh cook,,PADM-8530,2018
+PADM,8600,400,American Government,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,alfred bundrick,,PADM-8600,2018
+PADM,8670,401,State Government Admin,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,alfred bundrick,,PADM-8670,2018
+PADM,8710,401,Sustainability Practices Appli,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,david morgan young,,PADM-8710,2018
+PAS,3010,1,Intro to Pan African Studies,0.27,0.47,0.15,0.02,0.04,0.0,0.0,0.05,abel bartley,,PAS-3010,2018
+PES,1040,1,Introduction to Plant Sciences,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,,PES-1040,2018
+PES,2020,1,Soils,0.14,0.49,0.27,0.08,0.02,0.0,0.0,0.0,dara michelle park,,PES-2020,2018
+PES,3150,1,Environment and Agriculture,0.3,0.3,0.3,0.0,0.0,0.0,0.0,0.1,suseela appukuttan,,PES-3150,2018
+PHIL,1010,1,Intro to Philosophic Problems,0.38,0.53,0.09,0.0,0.0,0.0,0.0,0.0,kelly smith,,PHIL-1010,2018
+PHIL,1010,2,Intro to Philosophic Problems,0.42,0.32,0.11,0.05,0.11,0.0,0.0,0.0,kelly smith,,PHIL-1010,2018
+PHIL,1010,3,Intro to Philosophic Problems,0.37,0.32,0.11,0.05,0.11,0.0,0.0,0.05,christopher grau,,PHIL-1010,2018
+PHIL,1010,5,Intro to Philosophic Problems,0.56,0.32,0.06,0.0,0.03,0.0,0.0,0.03,david stegall,,PHIL-1010,2018
+PHIL,1010,6,Intro to Philosophic Problems,0.38,0.35,0.03,0.09,0.03,0.0,0.0,0.12,david stegall,,PHIL-1010,2018
+PHIL,1020,5,Introduction to Logic,0.29,0.37,0.03,0.17,0.03,0.0,0.0,0.11,david stegall,,PHIL-1020,2018
+PHIL,1020,6,Introduction to Logic,0.39,0.36,0.09,0.0,0.03,0.0,0.0,0.12,david stegall,,PHIL-1020,2018
+PHIL,1020,7,Introduction to Logic,0.47,0.32,0.18,0.03,0.0,0.0,0.0,0.0,adam gies,,PHIL-1020,2018
+PHIL,1020,8,Introduction to Logic,0.41,0.29,0.12,0.18,0.0,0.0,0.0,0.0,adam gies,,PHIL-1020,2018
+PHIL,1020,9,Introduction to Logic,0.56,0.22,0.11,0.0,0.06,0.0,0.0,0.06,adam gies,,PHIL-1020,2018
+PHIL,1020,10,Introduction to Logic,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,adam gies,,PHIL-1020,2018
+PHIL,1030,1,Introduction to Ethics,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,stephen satris,,PHIL-1030,2018
+PHIL,1030,2,Introduction to Ethics,0.49,0.31,0.09,0.09,0.03,0.0,0.0,0.0,stephen satris,,PHIL-1030,2018
+PHIL,1030,4,Introduction to Ethics,0.59,0.19,0.09,0.0,0.06,0.0,0.0,0.06,edyta joanna kuzian,,PHIL-1030,2018
+PHIL,1030,5,Introduction to Ethics,0.48,0.3,0.15,0.0,0.0,0.0,0.0,0.06,edyta joanna kuzian,,PHIL-1030,2018
+PHIL,1030,6,Introduction to Ethics,0.65,0.26,0.06,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,,PHIL-1030,2018
+PHIL,3040,1,Moral Philosophy,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,todd may,,PHIL-3040,2018
+PHIL,3150,1,Ancient Philosophy,0.39,0.26,0.23,0.03,0.03,0.0,0.0,0.06,stephen satris,,PHIL-3150,2018
+PHIL,3210,1,Crime & Punishment,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,daniel wueste,,PHIL-3210,2018
+PHIL,3430,1,Philosophy of Law,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,brookes colyto brown,,PHIL-3430,2018
+PHIL,3440,1,Business Ethics,0.08,0.69,0.08,0.0,0.08,0.0,0.0,0.08,brookes colyto brown,,PHIL-3440,2018
+PHIL,3480,1,Philosophies of Art,0.67,0.22,0.0,0.06,0.0,0.0,0.0,0.06,christopher grau,,PHIL-3480,2018
+PHIL,3490,1,Gender and Sexuality,0.65,0.12,0.18,0.0,0.0,0.0,0.0,0.06,diane perpich,,PHIL-3490,2018
+PHIL,4020,1,Recovery in Ethics,0.2,0.7,0.0,0.0,0.1,0.0,0.0,0.0,daniel wueste,,PHIL-4020,2018
+PHIL,4220,1,Anarchism,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,todd may,,PHIL-4220,2018
+PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.66,0.32,0.0,0.0,0.0,0.0,0.0,0.02,minory nammouz,,PHSC-1180,2018
+PHYS,1220,1,Physics with Calculus I,0.31,0.25,0.22,0.11,0.06,0.0,0.0,0.05,lih-sin the,,PHYS-1220,2018
+PHYS,1220,2,Physics with Calculus I,0.26,0.38,0.2,0.1,0.02,0.0,0.0,0.04,lih-sin the,,PHYS-1220,2018
+PHYS,1220,7,Physics with Calculus I (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,hugo sanabria,True,PHYS-1220,2018
+PHYS,1240,1,Physics Lab I,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,2,Physics Lab I,0.17,0.67,0.11,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,3,Physics Lab I,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,4,Physics Lab I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,5,Physics Lab I,0.28,0.39,0.28,0.0,0.06,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,6,Physics Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,7,Physics Lab I,0.17,0.56,0.17,0.11,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,8,Physics Lab I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,9,Physics Lab I,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,10,Physics Lab I,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,11,Physics Lab I,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,12,Physics Lab I,0.46,0.31,0.08,0.0,0.0,0.0,0.0,0.15,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,14,Physics Lab I,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,15,Physics Lab I,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,16,Physics Lab I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,17,Physics Lab I,0.69,0.08,0.08,0.0,0.0,0.0,0.0,0.15,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,18,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,19,Physics Lab I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,20,Physics Lab I,0.72,0.17,0.0,0.0,0.11,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,2070,1,General Physics I,0.35,0.31,0.18,0.05,0.06,0.0,0.0,0.05,amy liann pope,,PHYS-2070,2018
+PHYS,2070,2,General Physics I,0.41,0.33,0.16,0.04,0.03,0.0,0.0,0.03,amy liann pope,,PHYS-2070,2018
+PHYS,2070,3,General Physics I,0.44,0.31,0.14,0.05,0.02,0.0,0.0,0.05,amy liann pope,,PHYS-2070,2018
+PHYS,2070,4,General Physics I,0.11,0.33,0.3,0.07,0.07,0.0,0.0,0.11,amy liann pope,,PHYS-2070,2018
+PHYS,2080,1,General Physics II,0.44,0.4,0.09,0.02,0.02,0.0,0.0,0.02,pooja puneet,,PHYS-2080,2018
+PHYS,2090,1,Gen Phys Lab I,0.43,0.43,0.09,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,2,Gen Phys Lab I,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,3,Gen Phys Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,4,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,5,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,6,Gen Phys Lab I,0.21,0.42,0.29,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,7,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,8,Gen Phys Lab I,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,9,Gen Phys Lab I,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,10,Gen Phys Lab I,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,11,Gen Phys Lab I,0.5,0.42,0.04,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,12,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,13,Gen Phys Lab I,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,14,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,15,Gen Phys Lab I,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,16,Gen Phys Lab I,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,17,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,18,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,19,Gen Phys Lab I,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,20,Gen Phys Lab I,0.61,0.35,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,21,Gen Phys Lab I,0.17,0.74,0.0,0.04,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,22,Gen Phys Lab I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,23,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,24,Gen Phys Lab I,0.42,0.46,0.08,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,25,Gen Phys Lab I,0.13,0.83,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,26,Gen Phys Lab I,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,27,Gen Phys Lab I,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2100,1,Gen Phys Lab II,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,2,Gen Phys Lab II,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,3,Gen Phys Lab II,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,4,Gen Phys Lab II,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,6,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,7,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,8,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,9,Gen Phys Lab II,0.96,0.0,0.0,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2210,1,Physics with Calculus II,0.28,0.4,0.23,0.04,0.04,0.0,0.0,0.01,jason stratfor brown,,PHYS-2210,2018
+PHYS,2210,2,Physics with Calculus II,0.18,0.45,0.28,0.06,0.02,0.0,0.0,0.01,jason stratfor brown,,PHYS-2210,2018
+PHYS,2210,3,Physics with Calculus II,0.34,0.44,0.15,0.02,0.03,0.0,0.0,0.01,jason stratfor brown,,PHYS-2210,2018
+PHYS,2210,4,Physics with Calculus II,0.13,0.5,0.26,0.05,0.05,0.0,0.0,0.01,jason stratfor brown,,PHYS-2210,2018
+PHYS,2210,8,Physics with Calculus II (HON),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True,PHYS-2210,2018
+PHYS,2220,1,Physics with Calculus III,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,jian he,,PHYS-2220,2018
+PHYS,2230,1,Physics Lab II,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,2,Physics Lab II,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,3,Physics Lab II,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,4,Physics Lab II,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,5,Physics Lab II,0.29,0.53,0.06,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,6,Physics Lab II,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,7,Physics Lab II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,9,Physics Lab II,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,10,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,11,Physics Lab II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,12,Physics Lab II,0.18,0.76,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,13,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,14,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,17,Physics Lab II,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,,PHYS-2230,2018
+PHYS,2450,1,Physics of Climate,0.51,0.3,0.09,0.01,0.02,0.0,0.0,0.07,gerald lehmacher,,PHYS-2450,2018
+PHYS,3000,1,Intro to Research,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,,PHYS-3000,2018
+PHYS,3120,1,Meth Theor Phys II,0.5,0.2,0.3,0.0,0.0,0.0,0.0,0.0,lih-sin the,,PHYS-3120,2018
+PHYS,3150,1,Intro to Computational Physics,0.64,0.14,0.07,0.0,0.0,0.0,0.0,0.14,emil georgiev alexov,,PHYS-3150,2018
+PHYS,3210,1,Mechanics I,0.23,0.42,0.19,0.04,0.0,0.0,0.0,0.12,stephen rol kaeppler,,PHYS-3210,2018
+PHYS,4410,1,Electromagnetics I,0.33,0.28,0.28,0.06,0.0,0.0,0.0,0.06,xian lu,,PHYS-4410,2018
+PHYS,4550,1,Quantum Physics I,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,sumanta tewari,,PHYS-4550,2018
+PHYS,8110,1,Meth of Theor Phys I,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,feng ding,,PHYS-8110,2018
+PHYS,8210,1,Classical Mech I,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,dieter hartmann,,PHYS-8210,2018
+PHYS,8750,2,Intro to Research Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,,PHYS-8750,2018
+PHYS,9510,1,Quantum Mech I,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,domnita ca marinescu,,PHYS-9510,2018
+PKSC,1010,1,Pkgsc Orientation,0.27,0.53,0.18,0.0,0.0,0.0,0.0,0.01,marcondes pat guerra,,PKSC-1010,2018
+PKSC,1020,1,Intro to Pkg Sci,0.08,0.32,0.3,0.21,0.05,0.0,0.0,0.04,heather batt,,PKSC-1020,2018
+PKSC,2020,1,Packaging Mtl & Mfg,0.29,0.46,0.19,0.06,0.0,0.0,0.0,0.0,marcondes pat guerra,,PKSC-2020,2018
+PKSC,2040,1,Container Systems,0.28,0.53,0.13,0.03,0.03,0.0,0.0,0.0,marcondes pat guerra,,PKSC-2040,2018
+PKSC,3200,1,Pkg Design Theory,0.83,0.04,0.09,0.0,0.0,0.0,0.0,0.04,rupert hurley,,PKSC-3200,2018
+PKSC,4010,1,Packaging Machinery,0.36,0.54,0.05,0.03,0.0,0.0,0.0,0.03,anthony loui pometto,,PKSC-4010,2018
+PKSC,4030,1,Pkg Career Prep,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2018
+PKSC,4040,1,Protective Packaging Prop/Prin,0.4,0.36,0.16,0.0,0.06,0.0,0.0,0.03,gregory batt,,PKSC-4040,2018
+PKSC,4160,1,Appl Polymers in Pkg,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,duncan darby,,PKSC-4160,2018
+PKSC,4200,1,Pkg Design & Dev,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2018
+PKSC,4540,1,Prod Pkg Evl Lab,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2018
+PKSC,4540,2,Prod Pkg Evl Lab,0.25,0.56,0.06,0.0,0.06,0.0,0.0,0.06,gregory batt,,PKSC-4540,2018
+PKSC,4540,3,Prod Pkg Evl Lab,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2018
+PKSC,4540,4,Prod Pkg Evl Lab,0.56,0.25,0.06,0.13,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2018
+PKSC,4640,1,Food & Health Care Pkg Systems,0.6,0.3,0.09,0.0,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2018
+PKSC,4990,7,CI-Packaging  Sci Seminar,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,rupert hurley,,PKSC-4990,2018
+PLPA,3100,1,Principles of Plant Pathology,0.14,0.46,0.39,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,,PLPA-3100,2018
+PLPA,4250,1,Introductory Mycology,0.33,0.25,0.08,0.25,0.08,0.0,0.0,0.0,julia louis kerrigan,,PLPA-4250,2018
+POSC,1010,1,Amer National Govt,0.21,0.44,0.25,0.07,0.0,0.0,0.0,0.04,joseph earl stewart,,POSC-1010,2018
+POSC,1010,2,Amer National Govt,0.54,0.22,0.2,0.02,0.0,0.0,0.0,0.02,jeffrey allen fine,,POSC-1010,2018
+POSC,1020,1,Intro Intl Relations,0.36,0.36,0.15,0.07,0.02,0.0,0.0,0.04,steven vincen miller,,POSC-1020,2018
+POSC,1020,2,Intro Intl Relations,0.19,0.38,0.27,0.05,0.03,0.0,0.0,0.08,zeynep taydas,,POSC-1020,2018
+POSC,1020,3,Intro Intl Relations,0.17,0.37,0.27,0.06,0.08,0.0,0.0,0.05,zeynep taydas,,POSC-1020,2018
+POSC,1040,1,Intro Compar Pol,0.17,0.43,0.26,0.0,0.0,0.0,0.0,0.13,xiaobo hu,,POSC-1040,2018
+POSC,1040,2,Intro Compar Pol,0.29,0.45,0.17,0.05,0.05,0.0,0.0,0.0,katherine amb curtis,,POSC-1040,2018
+POSC,1990,1,Intro Pol Sci,0.6,0.22,0.07,0.04,0.05,0.0,0.0,0.02,meredith- petersheim,,POSC-1990,2018
+POSC,3020,1,State and Loc Gov,0.31,0.49,0.09,0.0,0.09,0.0,0.0,0.02,bruce ransom,,POSC-3020,2018
+POSC,3610,1,International Conflict,0.39,0.22,0.16,0.0,0.12,0.0,0.0,0.1,steven vincen miller,,POSC-3610,2018
+POSC,3630,1,Us Foreign Policy,0.3,0.51,0.11,0.04,0.02,0.0,0.0,0.02,vladimir matic,,POSC-3630,2018
+POSC,3710,1,European Politics,0.41,0.44,0.1,0.0,0.05,0.0,0.0,0.0,vladimir matic,,POSC-3710,2018
+POSC,4030,1,United States Congress,0.26,0.47,0.17,0.04,0.02,0.0,0.0,0.04,jeffrey scott peake,,POSC-4030,2018
+POSC,4210,1,Public Policy,0.12,0.35,0.24,0.06,0.18,0.0,0.0,0.06,adam warber,,POSC-4210,2018
+POSC,4230,1,Urban Politics,0.5,0.28,0.06,0.0,0.06,0.0,0.0,0.11,bruce ransom,,POSC-4230,2018
+POSC,4360,1,Law Courts Politics,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,joseph earl stewart,,POSC-4360,2018
+POSC,4470,1,International Law,0.4,0.23,0.13,0.13,0.0,0.0,0.0,0.1,katherine amb curtis,,POSC-4470,2018
+POSC,4490,1,Political Theory of Capitalism,0.27,0.55,0.09,0.03,0.06,0.0,0.0,0.0,colin denby pearce,,POSC-4490,2018
+POSC,4550,1,Pol Thght of American Founding,0.38,0.34,0.23,0.0,0.04,0.0,0.0,0.0, bradley thompson,,POSC-4550,2018
+POSC,4560,1,Diplomacy,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,vladimir matic,,POSC-4560,2018
+POSC,4760,1,Middle East Politics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,,POSC-4760,2018
+PRTM,2200,10,Foundations of PRTM,0.35,0.43,0.16,0.02,0.02,0.0,0.0,0.02,jamie lynn cathey,,PRTM-2200,2018
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2260,2018
+PRTM,2260,2,Fnd of Mgt Adm PRTM,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth de baldwin,,PRTM-2260,2018
+PRTM,2260,3,Fnd of Mgt Adm PRTM,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2260,2018
+PRTM,2260,4,Fnd of Mgt Adm PRTM,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2260,2018
+PRTM,2260,5,Fnd of Mgt Adm PRTM,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-2260,2018
+PRTM,2260,6,Fnd of Mgt Adm PRTM,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,katrina latric black,,PRTM-2260,2018
+PRTM,2260,7,Fnd of Mgt Adm PRTM,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,katie dudley,,PRTM-2260,2018
+PRTM,2260,8,Fnd of Mgt Adm PRTM,0.69,0.15,0.0,0.08,0.08,0.0,0.0,0.0,lauren eliz stephens,,PRTM-2260,2018
+PRTM,2270,1,Prov of Leisure Exp,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2270,2018
+PRTM,2270,2,Prov of Leisure Exp,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth de baldwin,,PRTM-2270,2018
+PRTM,2270,3,Prov of Leisure Exp,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2270,2018
+PRTM,2270,4,Prov of Leisure Exp,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2270,2018
+PRTM,2270,5,Prov of Leisure Exp,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-2270,2018
+PRTM,2270,6,Prov of Leisure Exp,0.13,0.69,0.06,0.13,0.0,0.0,0.0,0.0,katrina latric black,,PRTM-2270,2018
+PRTM,2270,7,Prov of Leisure Exp,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,katie dudley,,PRTM-2270,2018
+PRTM,2270,8,Prov of Leisure Exp,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,lauren eliz stephens,,PRTM-2270,2018
+PRTM,2290,1,Competency Integration in PRTM,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2290,2018
+PRTM,2290,2,Competency Integration in PRTM,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,elizabeth de baldwin,,PRTM-2290,2018
+PRTM,2290,3,Competency Integration in PRTM,0.33,0.47,0.13,0.07,0.0,0.0,0.0,0.0,robert brookover,,PRTM-2290,2018
+PRTM,2290,4,Competency Integration in PRTM,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2290,2018
+PRTM,2290,5,Competency Integration in PRTM,0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-2290,2018
+PRTM,2290,6,Competency Integration in PRTM,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,katrina latric black,,PRTM-2290,2018
+PRTM,2290,7,Competency Integration in PRTM,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,katie dudley,,PRTM-2290,2018
+PRTM,2290,8,Competency Integration in PRTM,0.77,0.08,0.0,0.08,0.08,0.0,0.0,0.0,lauren eliz stephens,,PRTM-2290,2018
+PRTM,2950,1,Pro Golf Management Seminar II,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-2950,2018
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.52,0.17,0.28,0.0,0.0,0.0,0.0,0.03,daniel morg anderson,,PRTM-3050,2018
+PRTM,3070,2,Facility Operations,0.85,0.09,0.06,0.0,0.0,0.0,0.0,0.0,raymond dunham,,PRTM-3070,2018
+PRTM,3200,1,Recreation Policy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,matthew tyl brownlee,,PRTM-3200,2018
+PRTM,3220,1,Facilitation Techniques in RT,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,,PRTM-3220,2018
+PRTM,3230,1,Prof Prep for RT Practice,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,,PRTM-3230,2018
+PRTM,3240,1,Assessment & Planning in RT,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3240,2018
+PRTM,3300,1,Visit Ser & Interp,0.64,0.14,0.21,0.0,0.0,0.0,0.0,0.0,michael pa blacketer,,PRTM-3300,2018
+PRTM,3430,1,Spl Asp of Tourist B,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,'lisha fogle,,PRTM-3430,2018
+PRTM,3470,1,Sport Tourism,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,gregory phil ramshaw,,PRTM-3470,2018
+PRTM,3520,1,Camp Org and Admin,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,lisa kay-powle olsen,,PRTM-3520,2018
+PRTM,3600,1,Recreation & Amateur Sport Mgt,0.26,0.61,0.09,0.0,0.0,0.0,0.0,0.04,skye arthur-banning,,PRTM-3600,2018
+PRTM,3900,8,PGA GM Player Development,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3900,2018
+PRTM,3920,1,Special Event Management,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,,PRTM-3920,2018
+PRTM,3920,2,Special Event Management,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,,PRTM-3920,2018
+PRTM,3950,1,PGM Seminar III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3950,2018
+PRTM,4030,1,Elem of Rec/Pk Plan,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,robert baxter powell,,PRTM-4030,2018
+PRTM,4210,1,Rec Fin Resc Mgt,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,ryan joseph gagnon,,PRTM-4210,2018
+PRTM,4220,1,Management of RT Services,0.49,0.49,0.03,0.0,0.0,0.0,0.0,0.0,brandi crowe,,PRTM-4220,2018
+PRTM,4450,1,Conventions,0.82,0.09,0.06,0.0,0.0,0.0,0.0,0.03,stephanie perl garst,,PRTM-4450,2018
+PRTM,4470,1,Perspect Intl Travel,0.93,0.0,0.04,0.0,0.04,0.0,0.0,0.0,sheila backman,,PRTM-4470,2018
+PRTM,4510,1,Seminar in CRSCM,0.83,0.09,0.04,0.04,0.0,0.0,0.0,0.0,harrison pa pinckney,,PRTM-4510,2018
+PRTM,4550,1,Adv Program Planning,0.62,0.23,0.08,0.04,0.04,0.0,0.0,0.0,harrison pa pinckney,,PRTM-4550,2018
+PRTM,4740,2,Adv Rec Resource Mgt,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,matthew tyl brownlee,,PRTM-4740,2018
+PRTM,4830,1,Golf Club Mgt & Ops,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-4830,2018
+PRTM,4950,1,Pro Golf Management Seminar IV,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-4950,2018
+PRTM,9000,7,Online Comp Exam,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,jeffrey charle hallo,,PRTM-9000,2018
+PSYC,2010,1,Intro to Psychology,0.52,0.23,0.21,0.0,0.03,0.0,0.0,0.02,chong hyon pak,,PSYC-2010,2018
+PSYC,2010,2,Intro to Psychology,0.27,0.31,0.26,0.08,0.02,0.0,0.0,0.05,edwin brainerd,,PSYC-2010,2018
+PSYC,2010,3,Intro to Psychology,0.33,0.37,0.16,0.08,0.01,0.0,0.0,0.05,jo anne jorgensen,,PSYC-2010,2018
+PSYC,2010,4,Intro to Psychology,0.34,0.39,0.14,0.07,0.0,0.0,0.0,0.06,mary taylor,,PSYC-2010,2018
+PSYC,2010,5,Intro to Psychology (HON),0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,True,PSYC-2010,2018
+PSYC,2890,1,Fundamentals of Psyc Science,0.56,0.34,0.06,0.03,0.01,0.0,0.0,0.01,peggy tyler,,PSYC-2890,2018
+PSYC,3060,1,Human Sexual Behavior,0.51,0.22,0.13,0.06,0.07,0.0,0.0,0.01,bruce michael king,,PSYC-3060,2018
+PSYC,3090,100,Intro Experimental Psychology,0.33,0.39,0.21,0.03,0.02,0.0,0.0,0.02,jennifer bail bisson,,PSYC-3090,2018
+PSYC,3090,200,Intro Experimental Psychology,0.47,0.18,0.19,0.05,0.09,0.0,0.0,0.01,patrick rosopa,,PSYC-3090,2018
+PSYC,3100,100,Advanced Experimental Psych,0.3,0.35,0.25,0.05,0.0,0.0,0.0,0.05,eric mckibben,,PSYC-3100,2018
+PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,thomas britt,,PSYC-3100,2018
+PSYC,3100,300,Advanced Experimental Psych,0.35,0.41,0.06,0.0,0.06,0.0,0.0,0.12,robert campbell,,PSYC-3100,2018
+PSYC,3100,400,Advanced Experimental Psych,0.43,0.43,0.05,0.05,0.0,0.0,0.0,0.05,fred switzer,,PSYC-3100,2018
+PSYC,3100,500,Advanced Experimental Psych,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2018
+PSYC,3100,600,Advanced Experimental Psych,0.35,0.57,0.09,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2018
+PSYC,3240,1,Physiological Psych,0.35,0.29,0.17,0.06,0.07,0.0,0.0,0.06,claudio cantalupo,,PSYC-3240,2018
+PSYC,3240,2,Physiological Psych,0.43,0.26,0.17,0.1,0.01,0.0,0.0,0.01,claudio cantalupo,,PSYC-3240,2018
+PSYC,3310,1,Critical Thinking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3310,2018
+PSYC,3330,1,Cognitive Psych,0.47,0.31,0.1,0.03,0.03,0.0,0.0,0.06,robert campbell,,PSYC-3330,2018
+PSYC,3330,2,Cognitive Psych,0.65,0.26,0.07,0.01,0.0,0.0,0.0,0.0,kaileigh angel byrne,,PSYC-3330,2018
+PSYC,3330,3,Cognitive Psych,0.57,0.26,0.08,0.02,0.05,0.0,0.0,0.03,kaileigh angel byrne,,PSYC-3330,2018
+PSYC,3340,2,Cognitive Psych Lab,0.64,0.29,0.0,0.07,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3340,2018
+PSYC,3340,3,Cognitive Psych Lab,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,kathryn lucaites,,PSYC-3340,2018
+PSYC,3340,4,Cognitive Psych Lab,0.54,0.31,0.0,0.15,0.0,0.0,0.0,0.0,kathryn lucaites,,PSYC-3340,2018
+PSYC,3400,1,Lifespan Developmental Psych,0.68,0.22,0.08,0.01,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3400,2018
+PSYC,3400,2,Lifespan Developmental Psych,0.38,0.44,0.13,0.01,0.0,0.0,0.0,0.04,jennifer bail bisson,,PSYC-3400,2018
+PSYC,3400,3,Lifespan Developmental Psych,0.25,0.3,0.22,0.09,0.1,0.0,0.0,0.04,pamela alley,,PSYC-3400,2018
+PSYC,3520,1,Social Psychology,0.4,0.28,0.25,0.07,0.0,0.0,0.0,0.0,jo anne jorgensen,,PSYC-3520,2018
+PSYC,3640,1,Industrial Psych,0.54,0.3,0.08,0.05,0.0,0.0,0.0,0.03,anton sytine,,PSYC-3640,2018
+PSYC,3640,2,Industrial Psych,0.29,0.37,0.26,0.04,0.0,0.0,0.0,0.03,eric mckibben,,PSYC-3640,2018
+PSYC,3680,1,Organizational Psych,0.25,0.3,0.22,0.08,0.05,0.0,0.0,0.1,eric mckibben,,PSYC-3680,2018
+PSYC,3680,2,Organizational Psych,0.59,0.27,0.09,0.01,0.03,0.0,0.0,0.01,zachary klinefelter,,PSYC-3680,2018
+PSYC,3700,1,Personality,0.49,0.34,0.14,0.01,0.0,0.0,0.0,0.01,john robert hester,,PSYC-3700,2018
+PSYC,3830,1,Abnormal Psychology,0.41,0.34,0.18,0.03,0.03,0.0,0.0,0.01,jo anne jorgensen,,PSYC-3830,2018
+PSYC,3830,2,Abnormal Psychology,0.22,0.26,0.26,0.07,0.15,0.0,0.0,0.04,pamela alley,,PSYC-3830,2018
+PSYC,3830,3,Abnormal Psychology,0.26,0.34,0.17,0.06,0.14,0.0,0.0,0.03,pamela alley,,PSYC-3830,2018
+PSYC,3890,1,Group/Team Dynamics,0.9,0.07,0.0,0.01,0.01,0.0,0.0,0.0,marissa leigh porter,,PSYC-3890,2018
+PSYC,3890,2,Psychology and Culture,0.6,0.21,0.12,0.05,0.02,0.0,0.0,0.0,ceren gunsoy,,PSYC-3890,2018
+PSYC,4080,1,Women and Psychology,0.58,0.17,0.04,0.0,0.04,0.0,0.0,0.17,robin marie kowalski,,PSYC-4080,2018
+PSYC,4150,1,Systems and Theories,0.29,0.46,0.17,0.09,0.0,0.0,0.0,0.0,edwin brainerd,,PSYC-4150,2018
+PSYC,4150,2,Systems and Theories,0.34,0.41,0.16,0.03,0.03,0.0,0.0,0.03,edwin brainerd,,PSYC-4150,2018
+PSYC,4150,3,Systems and Theories,0.8,0.11,0.03,0.0,0.03,0.0,0.0,0.03,michael shreeves,,PSYC-4150,2018
+PSYC,4220,1,Perception,0.29,0.42,0.17,0.0,0.0,0.0,0.0,0.13,claudio cantalupo,,PSYC-4220,2018
+PSYC,4220,2,Perception,0.33,0.15,0.33,0.19,0.0,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2018
+PSYC,4220,3,Perception,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2018
+PSYC,4220,4,Perception,0.72,0.16,0.08,0.0,0.04,0.0,0.0,0.0,darlene edewaard,,PSYC-4220,2018
+PSYC,4350,1,Human Factors,0.58,0.23,0.12,0.04,0.0,0.0,0.0,0.04,laura whitlock,,PSYC-4350,2018
+PSYC,4350,2,Human Factors,0.68,0.2,0.12,0.0,0.0,0.0,0.0,0.0,laura whitlock,,PSYC-4350,2018
+PSYC,4710,1,Psych of Testing,0.46,0.31,0.15,0.08,0.0,0.0,0.0,0.0,zhuo chen,,PSYC-4710,2018
+PSYC,4800,1,Health Psychology,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,james mccubbin,,PSYC-4800,2018
+PSYC,4800,2,Health Psychology,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2018
+PSYC,4820,1,Positive Psychology,0.52,0.3,0.04,0.0,0.0,0.0,0.0,0.13,cynthia pury s,,PSYC-4820,2018
+PSYC,4880,1,Psychotherapy,0.31,0.31,0.08,0.0,0.15,0.0,0.0,0.15,lucinda sorcie quick,,PSYC-4880,2018
+PSYC,4890,1,21st Century Teams,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,marissa leigh porter,,PSYC-4890,2018
+PSYC,4920,1,Senior Laboratory,0.64,0.18,0.09,0.0,0.05,0.0,0.0,0.05,chloe wilson,,PSYC-4920,2018
+PSYC,4920,2,Senior Laboratory,0.77,0.09,0.05,0.0,0.09,0.0,0.0,0.0,chloe wilson,,PSYC-4920,2018
+PSYC,4920,3,Senior Laboratory,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,chloe wilson,,PSYC-4920,2018
+PSYC,4920,4,Senior Laboratory,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,tiffany cooper,,PSYC-4920,2018
+PSYC,8100,1,Research Design I,0.73,0.19,0.0,0.0,0.03,0.0,0.0,0.05, dewayne moore,,PSYC-8100,2018
+PSYC,8520,1,Social Psychology,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,ceren gunsoy,,PSYC-8520,2018
+RED,8000,1,Real Estate Dvlpment,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,robert crei benedict,,RED-8000,2018
+RED,8130,1,Strat in Real Estate,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,phillip river hughes,,RED-8130,2018
+REL,1010,1,Intro to Religion,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,peter cohen,,REL-1010,2018
+REL,1010,2,Intro to Religion,0.28,0.22,0.17,0.17,0.11,0.0,0.0,0.06,peter cohen,,REL-1010,2018
+REL,1010,3,Intro to Religion,0.18,0.38,0.15,0.09,0.09,0.0,0.0,0.12,peter cohen,,REL-1010,2018
+REL,1010,4,Intro to Religion,0.59,0.32,0.06,0.0,0.0,0.0,0.0,0.03,richard ale amesbury,,REL-1010,2018
+REL,1020,2,World Religions,0.3,0.39,0.21,0.0,0.0,0.0,0.0,0.09,robert stephens,,REL-1020,2018
+REL,1020,3,World Religions,0.31,0.46,0.11,0.06,0.03,0.0,0.0,0.03,robert stephens,,REL-1020,2018
+REL,1020,4,World Religions,0.41,0.32,0.21,0.0,0.03,0.0,0.0,0.03,robert stephens,,REL-1020,2018
+REL,3010,1,Old Testament,0.59,0.34,0.03,0.03,0.0,0.0,0.0,0.0,steven grosby,,REL-3010,2018
+REL,3060,1,Judaism,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3060,2018
+REL,3090,1,Religion of the American South,0.6,0.13,0.13,0.0,0.07,0.0,0.0,0.07,elizabeth jemison,,REL-3090,2018
+REL,3110,1,African American Rel,0.41,0.35,0.12,0.0,0.06,0.0,0.0,0.06,elizabeth jemison,,REL-3110,2018
+REL,3130,1,Buddhism,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,robert stephens,,REL-3130,2018
+REL,3150,1,Islam,0.53,0.2,0.13,0.07,0.0,0.0,0.0,0.07,mashal saif,,REL-3150,2018
+REL,3200,1,"Jesus in History, Faith & Film",0.47,0.47,0.0,0.0,0.03,0.0,0.0,0.03,benjamin white,,REL-3200,2018
+REL,4010,1,Stud Biblical Literature & Rel,0.5,0.21,0.07,0.07,0.0,0.0,0.0,0.14,benjamin white,,REL-4010,2018
+RUSS,1010,1,Elementary Russian,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,stephanie ely morris,,RUSS-1010,2018
+RUSS,1010,2,Elementary Russian,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,stephanie ely morris,,RUSS-1010,2018
+RUSS,2010,1,Intermediate Russ,0.29,0.36,0.21,0.0,0.07,0.0,0.0,0.07,olga anatoly volkova,,RUSS-2010,2018
+RUSS,3400,1,19th C Russ Culture,0.54,0.33,0.04,0.0,0.0,0.0,0.0,0.08,olga anatoly volkova,,RUSS-3400,2018
+RUSS,3600,1,Russian Lit to 1910,0.58,0.25,0.13,0.0,0.0,0.0,0.0,0.04,olga anatoly volkova,,RUSS-3600,2018
+SOC,2010,2,Introduction to Sociology,0.89,0.09,0.01,0.0,0.0,0.0,0.0,0.02,andrew he mannheimer,,SOC-2010,2018
+SOC,2010,3,Introduction to Sociology,0.49,0.36,0.09,0.01,0.02,0.0,0.0,0.02,carolyn cand coffman,,SOC-2010,2018
+SOC,2010,4,Introduction to Sociology,0.5,0.35,0.11,0.04,0.0,0.0,0.0,0.01,shannon mcdonough,,SOC-2010,2018
+SOC,2010,5,Introduction to Sociology,0.56,0.27,0.13,0.03,0.01,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2018
+SOC,2010,7,Introduction to Sociology,0.46,0.36,0.14,0.02,0.0,0.0,0.0,0.02,jennifer lea holland,,SOC-2010,2018
+SOC,2040,1,Prof Dev for Sociology Majors,0.41,0.32,0.15,0.05,0.05,0.0,0.0,0.02, catherine mobley,,SOC-2040,2018
+SOC,3040,1,Social Research Methods II,0.32,0.29,0.14,0.21,0.0,0.0,0.0,0.04,ye luo,,SOC-3040,2018
+SOC,3110,1,The Family,0.37,0.51,0.08,0.02,0.02,0.0,0.0,0.0,andrew whitehead,,SOC-3110,2018
+SOC,3400,1,Sport and Society,0.36,0.33,0.24,0.04,0.0,0.0,0.0,0.02,andrew whitehead,,SOC-3400,2018
+SOC,3940,1,Sociology of Mental Illness,0.78,0.2,0.0,0.02,0.0,0.0,0.0,0.0,james rosenberger,,SOC-3940,2018
+SOC,3970,1,Substance Abuse,0.55,0.34,0.11,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,,SOC-3970,2018
+SOC,4040,1,Soc Theory,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,william haller,,SOC-4040,2018
+SOC,4060,1,Qual Rsrch Methods for Soc Sci,0.55,0.18,0.0,0.09,0.0,0.0,0.0,0.18,melissa vogel,,SOC-4060,2018
+SOC,4140,1,Policy&Social Change,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,jennifer lea holland,,SOC-4140,2018
+SOC,4600,1,Race & Ethnicity,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew he mannheimer,,SOC-4600,2018
+SOC,4610,1,Sex & Gender,0.53,0.2,0.18,0.0,0.02,0.0,0.0,0.07,carolyn cand coffman,,SOC-4610,2018
+SOC,4800,1,Medical Sociology,0.82,0.06,0.03,0.0,0.09,0.0,0.0,0.0,carolyn cand coffman,,SOC-4800,2018
+SOC,6060,1,Qual Rsrch Methods for Soc Sci,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,,SOC-6060,2018
+SPAN,1010,1,Elementary Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,,SPAN-1010,2018
+SPAN,1010,2,Elementary Spanish,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,rosa maca pillcurima,,SPAN-1010,2018
+SPAN,1010,3,Elementary Spanish,0.63,0.16,0.05,0.11,0.05,0.0,0.0,0.0,rosa maca pillcurima,,SPAN-1010,2018
+SPAN,1020,1,Elementary Spanish,0.72,0.11,0.06,0.0,0.11,0.0,0.0,0.0,rosa maca pillcurima,,SPAN-1020,2018
+SPAN,1020,2,Elementary Spanish,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,,SPAN-1020,2018
+SPAN,1020,3,Elementary Spanish,0.47,0.26,0.21,0.05,0.0,0.0,0.0,0.0,valderramos zen cruz,,SPAN-1020,2018
+SPAN,1020,4,Elementary Spanish,0.71,0.12,0.06,0.06,0.06,0.0,0.0,0.0,vieyra daniel garcia,,SPAN-1020,2018
+SPAN,1020,5,Elementary Spanish,0.63,0.32,0.0,0.05,0.0,0.0,0.0,0.0,vieyra daniel garcia,,SPAN-1020,2018
+SPAN,1020,6,Elementary Spanish,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,riquelme maria judez,,SPAN-1020,2018
+SPAN,1020,7,Elementary Spanish,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,,SPAN-1020,2018
+SPAN,1020,8,Elementary Spanish,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,vieyra daniel garcia,,SPAN-1020,2018
+SPAN,1020,10,Elementary Spanish,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,debra oak williamson,,SPAN-1020,2018
+SPAN,1020,11,Elementary Spanish,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,debra oak williamson,,SPAN-1020,2018
+SPAN,1020,12,Elementary Spanish,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,adrienne elizab fama,,SPAN-1020,2018
+SPAN,1020,13,Elementary Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,,SPAN-1020,2018
+SPAN,2010,1,Intermediate Spanish,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,riquelme maria judez,,SPAN-2010,2018
+SPAN,2010,2,Intermediate Spanish,0.61,0.0,0.28,0.0,0.11,0.0,0.0,0.0,valderramos zen cruz,,SPAN-2010,2018
+SPAN,2010,3,Intermediate Spanish,0.5,0.33,0.06,0.0,0.06,0.0,0.0,0.06,melva margue persico,,SPAN-2010,2018
+SPAN,2010,4,Intermediate Spanish,0.19,0.75,0.0,0.0,0.0,0.0,0.0,0.06,melva margue persico,,SPAN-2010,2018
+SPAN,2010,7,Intermediate Spanish,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,debra oak williamson,,SPAN-2010,2018
+SPAN,2010,8,Intermediate Spanish,0.5,0.25,0.17,0.08,0.0,0.0,0.0,0.0,debra oak williamson,,SPAN-2010,2018
+SPAN,2010,9,Intermediate Spanish,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,,SPAN-2010,2018
+SPAN,2010,10,Intermediate Spanish,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,ellory schmucker,,SPAN-2010,2018
+SPAN,2010,11,Intermediate Spanish,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,,SPAN-2010,2018
+SPAN,2010,12,Intermediate Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,,SPAN-2010,2018
+SPAN,2010,16,Intermediate Spanish,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2018
+SPAN,2010,17,Intermediate Spanish,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,,SPAN-2010,2018
+SPAN,2020,1,Intermediate Spanish,0.21,0.58,0.16,0.0,0.05,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2018
+SPAN,2020,2,Intermediate Spanish,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,,SPAN-2020,2018
+SPAN,2020,3,Intermediate Spanish,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,,SPAN-2020,2018
+SPAN,2020,4,Intermediate Spanish,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,,SPAN-2020,2018
+SPAN,2020,5,Intermediate Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2020,2018
+SPAN,2020,7,Intermediate Spanish,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2020,2018
+SPAN,2020,8,Intermediate Spanish,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,,SPAN-2020,2018
+SPAN,2020,9,Intermediate Spanish,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,ana paula  miller e,,SPAN-2020,2018
+SPAN,2020,10,Intermediate Spanish,0.47,0.26,0.21,0.0,0.0,0.0,0.0,0.05,valderramos zen cruz,,SPAN-2020,2018
+SPAN,2020,11,Intermediate Spanish,0.24,0.65,0.06,0.0,0.06,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2018
+SPAN,2020,12,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,valderramos zen cruz,,SPAN-2020,2018
+SPAN,2020,13,Intermediate Spanish,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,valderramos zen cruz,,SPAN-2020,2018
+SPAN,2020,14,Intermediate Spanish,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2018
+SPAN,3010,1,Spanish Comp for Health Prof,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,,SPAN-3010,2018
+SPAN,3020,1,Intermed Span Grammar & Comp,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,melva margue persico,,SPAN-3020,2018
+SPAN,3020,2,Intermed Span Grammar & Comp,0.32,0.53,0.05,0.0,0.05,0.0,0.0,0.05,melva margue persico,,SPAN-3020,2018
+SPAN,3020,3,Intermed Span Grammar & Comp,0.53,0.26,0.16,0.0,0.0,0.0,0.0,0.05,daniel smith,,SPAN-3020,2018
+SPAN,3050,1,Intermed Span Convers/Comp I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,moni rojas-de-massei,,SPAN-3050,2018
+SPAN,3050,2,Intermed Span Convers/Comp I,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,moni rojas-de-massei,,SPAN-3050,2018
+SPAN,3050,3,Intermed Span Convers/Comp I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,juana martin-armas,,SPAN-3050,2018
+SPAN,3050,4,Intermed Span Convers/Comp I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,graciela tissera,,SPAN-3050,2018
+SPAN,3050,6,Intermed Span Convers/Comp I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,vieyra daniel garcia,,SPAN-3050,2018
+SPAN,3050,7,Intermed Span Convers/Comp I,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,vieyra daniel garcia,,SPAN-3050,2018
+SPAN,3070,1,The Hispanic World: Spain,0.44,0.28,0.11,0.06,0.11,0.0,0.0,0.0,raquel anido,,SPAN-3070,2018
+SPAN,3080,1,The Hispanic World: Latin Amer,0.44,0.28,0.06,0.0,0.17,0.0,0.0,0.06,tiffany dawn miller,,SPAN-3080,2018
+SPAN,3080,2,The Hispanic World: Latin Amer,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,tiffany dawn miller,,SPAN-3080,2018
+SPAN,3130,2,Span Lit Survey I,0.25,0.38,0.13,0.0,0.19,0.0,0.0,0.06,moni rojas-de-massei,,SPAN-3130,2018
+SPAN,3180,1,Spanish Through Culture,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,george palacios,,SPAN-3180,2018
+SPAN,4010,1,New Spanish Fiction,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,salvador oropesa,,SPAN-4010,2018
+SPAN,4060,2,Narrative Fiction,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,,SPAN-4060,2018
+SPAN,4070,1,Hispanic Film,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,,SPAN-4070,2018
+SPAN,4150,1,Spanish for Health Prof,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,riquelme maria judez,,SPAN-4150,2018
+STAT,2220,1,Statistics in Everyday Life,0.45,0.26,0.19,0.09,0.01,0.0,0.0,0.0,james espey,,STAT-2220,2018
+STAT,2220,2,Statistics in Everyday Life,0.48,0.26,0.17,0.04,0.01,0.0,0.0,0.03,james espey,,STAT-2220,2018
+STAT,2220,3,Statistics in Everyday Life,0.49,0.29,0.11,0.07,0.01,0.0,0.0,0.03,james espey,,STAT-2220,2018
+STAT,2220,4,Statistics in Everyday Life,0.38,0.33,0.15,0.08,0.02,0.0,0.0,0.03,james espey,,STAT-2220,2018
+STAT,2220,5,Statistics in Everyday Life,0.4,0.26,0.18,0.08,0.05,0.0,0.0,0.04,rose martinez-dawson,,STAT-2220,2018
+STAT,2220,6,Statistics in Everyday Life,0.31,0.23,0.28,0.07,0.06,0.0,0.0,0.05,rose martinez-dawson,,STAT-2220,2018
+STAT,2300,1,Statistical Methods I,0.23,0.29,0.27,0.09,0.08,0.0,0.0,0.02,christy jenkin brown,,STAT-2300,2018
+STAT,2300,2,Statistical Methods I,0.33,0.42,0.17,0.04,0.03,0.0,0.0,0.02,christy jenkin brown,,STAT-2300,2018
+STAT,2300,3,Statistical Methods I,0.32,0.35,0.11,0.14,0.04,0.0,0.0,0.04,sharon marie evans,,STAT-2300,2018
+STAT,2300,4,Statistical Methods I,0.29,0.37,0.13,0.08,0.09,0.0,0.0,0.05,sharon marie evans,,STAT-2300,2018
+STAT,2300,5,Statistical Methods I,0.18,0.29,0.17,0.15,0.15,0.0,0.0,0.06, erwin walker,,STAT-2300,2018
+STAT,2300,6,Statistical Methods I,0.13,0.35,0.22,0.08,0.12,0.0,0.0,0.11, erwin walker,,STAT-2300,2018
+STAT,2300,100,Statistical Methods I (HON),0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,christy jenkin brown,True,STAT-2300,2018
+STAT,3090,1,Introductory Business Stats,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,margaret emma brooks,,STAT-3090,2018
+STAT,3090,2,Introductory Business Stats,0.26,0.37,0.21,0.05,0.05,0.0,0.0,0.05,margaret emma brooks,,STAT-3090,2018
+STAT,3090,3,Introductory Business Stats,0.37,0.32,0.16,0.11,0.05,0.0,0.0,0.0,boyoung hur,,STAT-3090,2018
+STAT,3090,4,Introductory Business Stats,0.26,0.26,0.21,0.26,0.0,0.0,0.0,0.0,boyoung hur,,STAT-3090,2018
+STAT,3090,5,Introductory Business Stats,0.28,0.33,0.22,0.17,0.0,0.0,0.0,0.0,tiantian yang,,STAT-3090,2018
+STAT,3090,6,Introductory Business Stats,0.18,0.12,0.06,0.18,0.35,0.0,0.0,0.12,rui gong,,STAT-3090,2018
+STAT,3090,7,Introductory Business Stats,0.26,0.37,0.21,0.11,0.05,0.0,0.0,0.0,yiren ding,,STAT-3090,2018
+STAT,3090,8,Introductory Business Stats,0.12,0.35,0.35,0.12,0.06,0.0,0.0,0.0,yiren ding,,STAT-3090,2018
+STAT,3090,9,Introductory Business Stats,0.47,0.26,0.16,0.11,0.0,0.0,0.0,0.0,brandon lumsden,,STAT-3090,2018
+STAT,3090,10,Introductory Business Stats,0.29,0.18,0.35,0.06,0.06,0.0,0.0,0.06,jiajing niu,,STAT-3090,2018
+STAT,3090,11,Introductory Business Stats,0.26,0.37,0.16,0.05,0.11,0.0,0.0,0.05,anna marie vagnozzi,,STAT-3090,2018
+STAT,3090,12,Introductory Business Stats,0.21,0.21,0.26,0.0,0.16,0.0,0.0,0.16,john charl nicholson,,STAT-3090,2018
+STAT,3090,13,Introductory Business Stats,0.3,0.26,0.2,0.12,0.09,0.0,0.0,0.03,april thomas,,STAT-3090,2018
+STAT,3090,14,Introductory Business Stats,0.37,0.32,0.11,0.05,0.16,0.0,0.0,0.0,kayla doris javier,,STAT-3090,2018
+STAT,3090,15,Introductory Business Stats,0.32,0.39,0.11,0.08,0.09,0.0,0.0,0.01,april thomas,,STAT-3090,2018
+STAT,3090,16,Introductory Business Stats,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,yidan guo,,STAT-3090,2018
+STAT,3090,17,Introductory Business Stats,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,john charl nicholson,,STAT-3090,2018
+STAT,3090,18,Introductory Business Stats,0.22,0.33,0.28,0.11,0.06,0.0,0.0,0.0,feng gao,,STAT-3090,2018
+STAT,3090,19,Introductory Business Stats,0.42,0.32,0.11,0.05,0.11,0.0,0.0,0.0,kayla doris javier,,STAT-3090,2018
+STAT,3090,20,Introductory Business Stats,0.16,0.37,0.26,0.05,0.11,0.0,0.0,0.05,yidan guo,,STAT-3090,2018
+STAT,3090,21,Introductory Business Stats,0.18,0.41,0.24,0.0,0.12,0.0,0.0,0.06,minghua cui,,STAT-3090,2018
+STAT,3090,22,Introductory Business Stats,0.21,0.26,0.21,0.16,0.11,0.0,0.0,0.05,rui gong,,STAT-3090,2018
+STAT,3090,23,Introductory Business Stats,0.47,0.24,0.24,0.06,0.0,0.0,0.0,0.0,tiantian yang,,STAT-3090,2018
+STAT,3090,24,Introductory Business Stats,0.21,0.47,0.26,0.05,0.0,0.0,0.0,0.0,xueheng shi,,STAT-3090,2018
+STAT,3090,25,Introductory Business Stats,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,norman michae snyder,,STAT-3090,2018
+STAT,3090,26,Introductory Business Stats,0.37,0.37,0.16,0.0,0.11,0.0,0.0,0.0,anna marie vagnozzi,,STAT-3090,2018
+STAT,3090,27,Introductory Business Stats,0.32,0.37,0.16,0.11,0.05,0.0,0.0,0.0,sean walk ingimarson,,STAT-3090,2018
+STAT,3090,28,Introductory Business Stats,0.11,0.39,0.28,0.06,0.11,0.0,0.0,0.06,xueheng shi,,STAT-3090,2018
+STAT,3090,29,Introductory Business Stats,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,jiajing niu,,STAT-3090,2018
+STAT,3090,30,Introductory Business Stats,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,norman michae snyder,,STAT-3090,2018
+STAT,3090,31,Introductory Business Stats,0.53,0.21,0.21,0.05,0.0,0.0,0.0,0.0,brandon lumsden,,STAT-3090,2018
+STAT,3090,32,Introductory Business Stats,0.28,0.22,0.33,0.0,0.17,0.0,0.0,0.0,minghua cui,,STAT-3090,2018
+STAT,3090,33,Introductory Business Stats,0.2,0.42,0.27,0.04,0.07,0.0,0.0,0.0,margaret mari wiecek,,STAT-3090,2018
+STAT,3090,34,Introductory Business Stats,0.53,0.21,0.21,0.05,0.0,0.0,0.0,0.0,alan robert hahn,,STAT-3090,2018
+STAT,3090,35,Introductory Business Stats,0.16,0.47,0.32,0.05,0.0,0.0,0.0,0.0,alan robert hahn,,STAT-3090,2018
+STAT,3090,36,Introductory Business Stats,0.21,0.47,0.16,0.05,0.11,0.0,0.0,0.0,feng gao,,STAT-3090,2018
+STAT,3090,37,Introductory Business Stats,0.18,0.29,0.12,0.12,0.24,0.0,0.0,0.06,sean walk ingimarson,,STAT-3090,2018
+STAT,3300,1,Statistical Methods II,0.44,0.17,0.11,0.17,0.06,0.0,0.0,0.06,rose martinez-dawson,,STAT-3300,2018
+STAT,4020,1,Intro to Statistical Computing,0.32,0.44,0.16,0.04,0.04,0.0,0.0,0.0,ellen hepfer breazel,,STAT-4020,2018
+STAT,4110,1,Stat Mthds for Process Control,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,richard steve dubsky,,STAT-4110,2018
+STAT,4110,3,Stat Mthds for Process Control,0.56,0.28,0.11,0.0,0.03,0.0,0.0,0.03,william bridges,,STAT-4110,2018
+STAT,6020,1,Intro to Statistical Computing,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,,STAT-6020,2018
+STAT,8010,3,Statistical Methods I,0.36,0.41,0.05,0.0,0.05,0.0,0.0,0.14,jun luo,,STAT-8010,2018
+STAT,8010,4,Statistical Methods I,0.27,0.09,0.32,0.0,0.05,0.0,0.0,0.27,jun luo,,STAT-8010,2018
+STAT,8010,5,Statistical Methods I,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,joseph daniel bible,,STAT-8010,2018
+STAT,8010,7,Statistical Methods I,0.62,0.29,0.0,0.0,0.0,0.0,0.0,0.1,brook thayer russell,,STAT-8010,2018
+STAT,8020,1,Statistical Methods II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,,STAT-8020,2018
+STAT,8030,1,Regress & Least Squares Anlys,0.57,0.39,0.0,0.0,0.04,0.0,0.0,0.0,brook thayer russell,,STAT-8030,2018
+STS,1010,1,Survey Sci & Techn in Society,0.49,0.49,0.03,0.0,0.0,0.0,0.0,0.0,kenneth davi widgren,,STS-1010,2018
+STS,1010,2,Survey Sci & Techn in Society,0.43,0.37,0.14,0.03,0.0,0.0,0.0,0.03,scott brame,,STS-1010,2018
+STS,1010,3,Survey Sci & Techn in Society,0.49,0.37,0.11,0.0,0.0,0.0,0.0,0.03,elizabeth stansell,,STS-1010,2018
+STS,1010,4,Survey Sci & Techn in Society,0.19,0.5,0.28,0.03,0.0,0.0,0.0,0.0,sarah mae cooper,,STS-1010,2018
+STS,1010,5,Survey Sci & Techn in Society,0.54,0.29,0.09,0.03,0.03,0.0,0.0,0.03,philip randall,,STS-1010,2018
+STS,1010,6,Survey Sci & Techn in Society,0.79,0.06,0.06,0.0,0.03,0.0,0.0,0.06,christine cla murphy,,STS-1010,2018
+STS,1010,7,Survey Sci & Techn in Society,0.31,0.44,0.14,0.03,0.06,0.0,0.0,0.03,megan noe macalystre,,STS-1010,2018
+STS,1010,8,Survey Sci & Techn in Society,0.34,0.4,0.09,0.0,0.03,0.0,0.0,0.14,david charles foltz,,STS-1010,2018
+STS,1010,9,Survey Sci & Techn in Society,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,,STS-1010,2018
+THEA,2100,1,Theatre Appreciation,0.66,0.19,0.06,0.03,0.03,0.0,0.0,0.03,kendra lynet johnson,,THEA-2100,2018
+THEA,2100,2,Theatre Appreciation,0.84,0.06,0.0,0.03,0.03,0.0,0.0,0.03,kerrie kathl seymour,,THEA-2100,2018
+THEA,2100,3,Theatre Appreciation,0.63,0.25,0.06,0.03,0.03,0.0,0.0,0.0,david hartmann,,THEA-2100,2018
+THEA,2100,4,Theatre Appreciation,0.9,0.06,0.0,0.0,0.0,0.0,0.0,0.03,anthony penna,,THEA-2100,2018
+THEA,2100,5,Theatre Appreciation,0.81,0.09,0.03,0.03,0.0,0.0,0.0,0.03,carol collins,,THEA-2100,2018
+THEA,2100,6,Theatre Appreciation,0.53,0.25,0.09,0.13,0.0,0.0,0.0,0.0,jason adkins,,THEA-2100,2018
+THEA,2100,7,Theatre Appreciation,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,jason adkins,,THEA-2100,2018
+THEA,2780,1,Acting I,0.73,0.09,0.09,0.09,0.0,0.0,0.0,0.0,kerrie kathl seymour,,THEA-2780,2018
+THEA,3170,1,African-Amer Thea I,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,kendra lynet johnson,,THEA-3170,2018
+THEA,4290,1,Dramatic Literature I,0.5,0.0,0.1,0.1,0.3,0.0,0.0,0.0,jason adkins,,THEA-4290,2018
+WFB,4100,2,Wildlife Management Techniques,0.29,0.48,0.18,0.02,0.02,0.0,0.0,0.02,james davis,,WFB-4100,2018
+WFB,4180,2,Fisheries Mgt & Conservation,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,troy mason farmer,,WFB-4180,2018
+WFB,4440,1,Wildlife Damage Management,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,,WFB-4440,2018
+WFB,4720,1,Ornithology,0.18,0.55,0.18,0.09,0.0,0.0,0.0,0.0,john cummings,,WFB-4720,2018
+WFB,4770,1,Ichthyology,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,brandon kevi peoples,,WFB-4770,2018
+WFB,4800,1,Waterfowl Ecology & Management,0.61,0.22,0.11,0.03,0.0,0.0,0.0,0.03,richard mar kaminski,,WFB-4800,2018
+WFB,4930,2,Plant & Flora ID/Systematics,0.7,0.18,0.06,0.01,0.0,0.0,0.0,0.04,patrick mcmillan,,WFB-4930,2018
+WFB,6620,1,Wetland Wildlife Biology,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,russell barrett,,WFB-6620,2018
+WFB,6800,1,Waterfowl Ecology & Management,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,richard mar kaminski,,WFB-6800,2018
+WFB,8530,2,Global Chg Eco,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,lydia rie 'halloran,,WFB-8530,2018
+WS,1030,1,Women in Global Perspective,0.6,0.17,0.17,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,,WS-1030,2018
+WS,2300,1,Women and Leadership I,0.55,0.27,0.09,0.05,0.0,0.0,0.0,0.05,mary price,,WS-2300,2018
+WS,3010,1,Intro Women's Studies,0.43,0.43,0.03,0.07,0.0,0.0,0.0,0.03,elizabeth rose adams,,WS-3010,2018
+WS,3010,2,Intro Women's Studies,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth rose adams,,WS-3010,2018
+WS,3490,1,Gender and Sexuality,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,diane perpich,,WS-3490,2018
+YDP,3000,400,Youth Development in Society,0.56,0.36,0.04,0.0,0.04,0.0,0.0,0.0,barry garst,,YDP-3000,2018
+YDP,3050,400,Theory/Phil of Youth Dev Work,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,edmond patric bowers,,YDP-3050,2018
+YDP,3300,1,Designing Effective Youth Prog,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,,YDP-3300,2018
+YDP,3450,1,Creative Activities for Youth,0.9,0.03,0.07,0.0,0.0,0.0,0.0,0.0,kimberly pea johnson,,YDP-3450,2018
+YDP,8000,1,Theories of Youth Development,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,edmond patric bowers,,YDP-8000,2018
+YDP,8030,1,Creative & Ethical Leadership,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,barry garst,,YDP-8030,2018
+YDP,8050,1,Youth Dev in Context of Family,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,,YDP-8050,2018
+YDP,8060,2,Youth Dev in Global Society,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ann marie gillard,,YDP-8060,2018

--- a/bot/cogs/grades_cog/assets/2018_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2018_Fall.csv
@@ -1,2544 +1,2544 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1010,1,Survey of Art & Arch History I,0.42,0.45,0.11,0.01,0.01,0.0,0.0,0.0,beth ann lauritis,AAH-1010,2018
-AAH,2050,1,Art History and Theory I,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,beth ann lauritis,AAH-2050,2018
-AAH,3050,1,Contemporary Art History,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,AAH-3050,2018
-ACCT,2010,1,Financial Accounting Concepts,0.09,0.36,0.27,0.02,0.09,0.0,0.0,0.18,lydia lanc schleifer,ACCT-2010,2018
-ACCT,2010,2,Financial Accounting Concepts,0.28,0.23,0.23,0.13,0.04,0.0,0.0,0.09,emily suzan mccorkle,ACCT-2010,2018
-ACCT,2010,3,Financial Accounting Concepts,0.33,0.48,0.13,0.08,0.0,0.0,0.0,0.0,emily suzan mccorkle,ACCT-2010,2018
-ACCT,2010,4,Financial Accounting Concepts,0.36,0.28,0.21,0.04,0.09,0.0,0.0,0.02,annieka philo,ACCT-2010,2018
-ACCT,2010,5,Financial Accounting Concepts,0.33,0.23,0.19,0.02,0.13,0.0,0.0,0.1,lydia lanc schleifer,ACCT-2010,2018
-ACCT,2010,6,Financial Accounting Concepts,0.24,0.26,0.29,0.07,0.1,0.0,0.0,0.05,annieka philo,ACCT-2010,2018
-ACCT,2010,7,Financial Accounting Concepts,0.17,0.4,0.19,0.07,0.05,0.0,0.0,0.12,emily suzan mccorkle,ACCT-2010,2018
-ACCT,2010,8,Financial Accounting Concepts,0.21,0.35,0.19,0.1,0.04,0.0,0.0,0.1,lydia lanc schleifer,ACCT-2010,2018
-ACCT,2010,9,Financial Accounting Concepts,0.26,0.41,0.21,0.08,0.0,0.0,0.0,0.05,annieka philo,ACCT-2010,2018
-ACCT,2010,10,Financial Accounting Concepts,0.3,0.25,0.23,0.05,0.18,0.0,0.0,0.0,emily suzan mccorkle,ACCT-2010,2018
-ACCT,2010,11,Financial Accounting Concepts,0.16,0.42,0.16,0.05,0.11,0.0,0.0,0.11,charles tegen,ACCT-2010,2018
-ACCT,2010,12,Financial Accounting Concepts,0.26,0.24,0.29,0.08,0.03,0.0,0.0,0.11,philip maiberger,ACCT-2010,2018
-ACCT,2010,13,Financial Accounting Concepts,0.23,0.28,0.36,0.05,0.05,0.0,0.0,0.03,lisa whea birtwistle,ACCT-2010,2018
-ACCT,2010,14,Financial Accounting Concepts,0.37,0.37,0.17,0.07,0.0,0.0,0.0,0.02,lisa whea birtwistle,ACCT-2010,2018
-ACCT,2010,100,Fin Accounting Concepts (HON),0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,lisa whea birtwistle,ACCT-2010,2018
-ACCT,2010,400,Financial Accounting Concepts,0.19,0.43,0.16,0.09,0.07,0.0,0.0,0.06,jeffrey mcmillan,ACCT-2010,2018
-ACCT,2020,1,Managerial Accounting Concepts,0.14,0.2,0.37,0.03,0.09,0.0,0.0,0.17,henry anderson,ACCT-2020,2018
-ACCT,2020,2,Managerial Accounting Concepts,0.25,0.45,0.14,0.05,0.02,0.0,0.0,0.09,henry anderson,ACCT-2020,2018
-ACCT,2020,3,Managerial Accounting Concepts,0.36,0.24,0.18,0.0,0.09,0.0,0.0,0.13,henry anderson,ACCT-2020,2018
-ACCT,2020,4,Managerial Accounting Concepts,0.19,0.35,0.16,0.22,0.0,0.0,0.0,0.08,brian todd carver,ACCT-2020,2018
-ACCT,2020,5,Managerial Accounting Concepts,0.24,0.22,0.2,0.07,0.18,0.0,0.0,0.09,brian todd carver,ACCT-2020,2018
-ACCT,2020,6,Managerial Accounting Concepts,0.11,0.3,0.27,0.09,0.02,0.0,0.0,0.2,brian todd carver,ACCT-2020,2018
-ACCT,2020,7,Managerial Accounting Concepts,0.25,0.29,0.33,0.04,0.02,0.0,0.0,0.06,phebian davis-culler,ACCT-2020,2018
-ACCT,2020,400,Managerial Accounting Concepts,0.25,0.36,0.2,0.09,0.04,0.0,0.0,0.06,henry anderson,ACCT-2020,2018
-ACCT,3030,3,Cost Accounting,0.45,0.37,0.08,0.0,0.08,0.0,0.0,0.02,phebian davis-culler,ACCT-3030,2018
-ACCT,3030,4,Cost Accounting,0.21,0.28,0.3,0.12,0.07,0.0,0.0,0.02,phebian davis-culler,ACCT-3030,2018
-ACCT,3110,1,Intermediate Financial Acct I,0.1,0.33,0.25,0.17,0.08,0.0,0.0,0.06,erin michell hawkins,ACCT-3110,2018
-ACCT,3110,2,Intermediate Financial Acct I,0.16,0.29,0.24,0.13,0.11,0.0,0.0,0.07,erin michell hawkins,ACCT-3110,2018
-ACCT,3110,3,Intermediate Financial Acct I,0.14,0.44,0.23,0.12,0.02,0.0,0.0,0.05,amy melissa donnelly,ACCT-3110,2018
-ACCT,3110,4,Intermediate Financial Acct I,0.09,0.55,0.21,0.06,0.02,0.0,0.0,0.06,amy melissa donnelly,ACCT-3110,2018
-ACCT,3110,400,Intermediate Financial Acct I,0.21,0.35,0.13,0.04,0.08,0.0,0.0,0.19,henry anderson,ACCT-3110,2018
-ACCT,3120,1,Intermediate Financial Acct II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2018
-ACCT,3120,2,Intermediate Financial Acct II,0.1,0.34,0.37,0.07,0.1,0.0,0.0,0.02,jeremy michae vinson,ACCT-3120,2018
-ACCT,3120,3,Intermediate Financial Acct II,0.38,0.41,0.21,0.0,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2018
-ACCT,3120,4,Intermediate Financial Acct II,0.35,0.35,0.25,0.03,0.0,0.0,0.0,0.03,jeremy michae vinson,ACCT-3120,2018
-ACCT,3120,5,Intermediate Financial Acct II,0.26,0.42,0.26,0.0,0.0,0.0,0.0,0.05,terry daniel knause,ACCT-3120,2018
-ACCT,3120,6,Intermediate Financial Acct II,0.33,0.49,0.18,0.0,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2018
-ACCT,3130,1,Intermediate Fin Acct III,0.1,0.31,0.38,0.17,0.05,0.0,0.0,0.0, russell madray,ACCT-3130,2018
-ACCT,3130,2,Intermediate Fin Acct III,0.09,0.45,0.33,0.06,0.03,0.0,0.0,0.03, russell madray,ACCT-3130,2018
-ACCT,3130,3,Intermediate Fin Acct III,0.27,0.37,0.2,0.1,0.05,0.0,0.0,0.02, russell madray,ACCT-3130,2018
-ACCT,3130,4,Intermediate Fin Acct III,0.27,0.27,0.39,0.05,0.02,0.0,0.0,0.0, russell madray,ACCT-3130,2018
-ACCT,3220,1,Accounting Information Systems,0.36,0.27,0.25,0.05,0.02,0.0,0.0,0.05,philip maiberger,ACCT-3220,2018
-ACCT,3220,2,Accounting Information Systems,0.18,0.34,0.24,0.11,0.05,0.0,0.0,0.08,philip maiberger,ACCT-3220,2018
-ACCT,3220,3,Accounting Information Systems,0.16,0.26,0.34,0.11,0.03,0.0,0.0,0.11,philip maiberger,ACCT-3220,2018
-ACCT,4040,1,Individual Taxation,0.5,0.29,0.12,0.06,0.03,0.0,0.0,0.0,lisa whea birtwistle,ACCT-4040,2018
-ACCT,4040,2,Individual Taxation,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2018
-ACCT,4040,3,Individual Taxation,0.57,0.26,0.09,0.06,0.03,0.0,0.0,0.0,sarah martin,ACCT-4040,2018
-ACCT,4080,1,Retire & Estate Plan,0.37,0.52,0.07,0.0,0.0,0.0,0.0,0.04,john hine,ACCT-4080,2018
-ACCT,4100,3,Reporting and Mgmt Control Sys,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,robin radtke,ACCT-4100,2018
-ACCT,4150,1,Auditing,0.2,0.5,0.25,0.05,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-4150,2018
-ACCT,4150,2,Auditing,0.26,0.58,0.11,0.05,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-4150,2018
-ACCT,8510,1,Tax Research,0.07,0.93,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2018
-ACCT,8510,2,Tax Research,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2018
-ACCT,8510,3,Tax Research,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2018
-ACCT,8530,1,Adv Acct Problems,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,ralph edward welton,ACCT-8530,2018
-ACCT,8530,2,Adv Acct Problems,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8530,2018
-ACCT,8530,3,Adv Acct Problems,0.72,0.25,0.0,0.0,0.0,0.0,0.0,0.03,suzanne pearse,ACCT-8530,2018
-ACCT,8550,1,Gov't and Nonprofit Accounting,0.86,0.11,0.03,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2018
-ACCT,8550,2,Gov't and Nonprofit Accounting,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2018
-ACCT,8550,3,Gov't and Nonprofit Accounting,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2018
-ACCT,8650,1,Tax & Bus Decisions,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,ACCT-8650,2018
-ACCT,8720,1,Tax of Flowthroughs,0.32,0.27,0.38,0.0,0.0,0.0,0.0,0.03,thomas dickens,ACCT-8720,2018
-AGED,1020,1,Freshman Seminar,0.8,0.07,0.07,0.07,0.0,0.0,0.0,0.0,catherin dibenedetto,AGED-1020,2018
-AGED,2000,1,Agr Appl of Ed Tech,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,AGED-2000,2018
-AGED,2010,1,Intro to Agric Educ,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2010,2018
-AGED,2040,1,App Ag Calculations,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2040,2018
-AGED,3030,1,Ag Ed Mech Tech,0.4,0.33,0.2,0.07,0.0,0.0,0.0,0.0,alex byrd,AGED-3030,2018
-AGED,4030,1,Prin Adult/Ext Ed,0.79,0.07,0.07,0.0,0.07,0.0,0.0,0.0,alex byrd,AGED-4030,2018
-AGM,1010,1,Intro Ag Mech & Bus,0.62,0.28,0.03,0.03,0.05,0.0,0.0,0.0,hunter massey,AGM-1010,2018
-AGM,2050,1,Prin of Fabrication,0.26,0.48,0.17,0.05,0.05,0.0,0.0,0.0,hunter massey,AGM-2050,2018
-AGM,2060,1,Machinery Mgt,0.33,0.33,0.2,0.07,0.07,0.0,0.0,0.0,hunter massey,AGM-2060,2018
-AGM,2210,1,Land Measurements,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,charles privette,AGM-2210,2018
-AGM,3010,1,Soil Water Conserv,0.45,0.29,0.2,0.04,0.03,0.0,0.0,0.0,calvin sawyer,AGM-3010,2018
-AGM,4000,1,Seminar in Ag Mech & Business,0.04,0.22,0.4,0.24,0.1,0.0,0.0,0.0,john chastain,AGM-4000,2018
-AGM,4020,1,Irrigation System Design,0.12,0.41,0.35,0.06,0.06,0.0,0.0,0.0,charles privette,AGM-4020,2018
-AGM,4050,1,Env Cont in Anim Str,0.11,0.31,0.44,0.13,0.0,0.0,0.0,0.0,john chastain,AGM-4050,2018
-AGM,4060,1,Mech & Hydraulic Sys,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4060,2018
-AGM,4520,1,Mobile Power,0.37,0.48,0.11,0.04,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4520,2018
-AGM,4600,1,Electrical Systems,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,young jo han,AGM-4600,2018
-AGRB,2020,1,Agricultural Economics,0.2,0.29,0.24,0.18,0.05,0.0,0.0,0.04,george apperson,AGRB-2020,2018
-AGRB,2050,1,Agriculture and Society,0.15,0.22,0.3,0.25,0.03,0.0,0.0,0.04,michael vassalos,AGRB-2050,2018
-AGRB,3020,1,Economics of Farm Management,0.11,0.28,0.27,0.27,0.06,0.0,0.0,0.0,michael vassalos,AGRB-3020,2018
-AGRB,3080,1,Quant Agribusiness Analysis I,0.27,0.37,0.2,0.1,0.02,0.0,0.0,0.04,lisha zhang,AGRB-3080,2018
-AGRB,3090,1,Econ of Agricultural Marketing,0.59,0.33,0.04,0.0,0.03,0.0,0.0,0.01,yuliya vale bolotova,AGRB-3090,2018
-AGRB,3570,1,Natural Resources Economics,0.27,0.23,0.27,0.07,0.07,0.0,0.0,0.09,david brian willis,AGRB-3570,2018
-AGRB,4090,1,Commodity Futures Markets,0.13,0.26,0.29,0.21,0.11,0.0,0.0,0.0,george apperson,AGRB-4090,2018
-AGRB,4120,1,Reg Econ Devel Theory & Policy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ronald lamie,AGRB-4120,2018
-AGRB,4520,1,Agricultural Policy,0.24,0.33,0.24,0.15,0.03,0.0,0.0,0.0,michael vassalos,AGRB-4520,2018
-AGRB,4600,1,Agricultural Finance,0.36,0.26,0.26,0.13,0.0,0.0,0.0,0.0,lisha zhang,AGRB-4600,2018
-AL,3440,400,Athletics and Women,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,AL-3440,2018
-AL,3490,400,Principles of Coaching,0.61,0.29,0.07,0.04,0.0,0.0,0.0,0.0,deborah jo cadorette,AL-3490,2018
-AL,3490,401,Principles of Coaching,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,AL-3490,2018
-AL,3490,402,Principles of Coaching,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,john plumblee,AL-3490,2018
-AL,3490,403,Principles of Coaching,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,john plumblee,AL-3490,2018
-AL,3490,404,Principles of Coaching,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,clyde keith connor,AL-3490,2018
-AL,3490,407,Principles of Coaching,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,nicholas phi whitrow,AL-3490,2018
-AL,3490,408,Principles of Coaching,0.56,0.24,0.04,0.04,0.12,0.0,0.0,0.0,nicholas phi whitrow,AL-3490,2018
-AL,3490,409,Principles of Coaching,0.76,0.12,0.0,0.0,0.12,0.0,0.0,0.0,nicholas phi whitrow,AL-3490,2018
-AL,3500,400,Sci Basis I/Ex Phy,0.21,0.38,0.21,0.13,0.0,0.0,0.0,0.08,michael godfrey,AL-3500,2018
-AL,3500,401,Sci Basis I/Ex Phy,0.3,0.35,0.26,0.09,0.0,0.0,0.0,0.0,michael godfrey,AL-3500,2018
-AL,3510,400,Nat'l Coach Cert Prep for AL,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,AL-3510,2018
-AL,3530,400,Athletic Injuries,0.14,0.39,0.32,0.11,0.04,0.0,0.0,0.0,isaac sean colbert,AL-3530,2018
-AL,3530,401,Athletic Injuries,0.28,0.36,0.16,0.08,0.08,0.0,0.0,0.04,isaac sean colbert,AL-3530,2018
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.58,0.21,0.17,0.0,0.0,0.0,0.0,0.04,clyde keith connor,AL-3600,2018
-AL,3610,400,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2018
-AL,3620,400,Psychology of Coaching,0.38,0.12,0.35,0.12,0.04,0.0,0.0,0.0,natalie anne carter,AL-3620,2018
-AL,3620,401,Psychology of Coaching,0.64,0.28,0.04,0.04,0.0,0.0,0.0,0.0,natalie anne carter,AL-3620,2018
-AL,3620,402,Psychology of Coaching,0.44,0.28,0.16,0.08,0.0,0.0,0.0,0.04,natalie anne carter,AL-3620,2018
-AL,3740,400,Coaching Football,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,edmond fry,AL-3740,2018
-AL,3740,401,Coaching Football,0.61,0.09,0.0,0.04,0.04,0.0,0.0,0.22,edmond fry,AL-3740,2018
-AL,3760,400,Coaching Strength/Conditioning,0.72,0.21,0.0,0.0,0.07,0.0,0.0,0.0,edmond fry,AL-3760,2018
-AL,3760,401,Coaching Strength/Conditioning,0.81,0.04,0.04,0.0,0.11,0.0,0.0,0.0,edmond fry,AL-3760,2018
-AL,4380,402,Current Iss in HS Athletics,0.71,0.21,0.0,0.04,0.0,0.0,0.0,0.04,deborah jo cadorette,AL-4380,2018
-AL,4380,403,Media Relations in AL,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,AL-4380,2018
-AL,4380,408,Officiating in AL,0.57,0.22,0.17,0.04,0.0,0.0,0.0,0.0,clyde keith connor,AL-4380,2018
-AL,8380,400,Sp Topics in Intercoll Athlet,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,elliott charles,AL-8380,2018
-AL,8440,400,Surv of Res Mthds in Athletics,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristin kelly frady,AL-8440,2018
-AL,8440,401,Surv of Res Mthds in Athletics,0.71,0.07,0.14,0.0,0.07,0.0,0.0,0.0,kristin kelly frady,AL-8440,2018
-AL,8500,400,Principles Strength and Condit,0.74,0.19,0.07,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8500,2018
-AL,8650,401,Mkt and Comm Respon Interc Ath,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,misty soles,AL-8650,2018
-ANTH,2010,1,Introduction to Anthropology,0.44,0.24,0.18,0.04,0.04,0.0,0.0,0.04,yi wu,ANTH-2010,2018
-ANTH,2010,2,Introduction to Anthropology,0.35,0.33,0.2,0.05,0.02,0.0,0.0,0.05,yi wu,ANTH-2010,2018
-ANTH,2010,3,Introduction to Anthropology,0.4,0.49,0.1,0.0,0.0,0.0,0.0,0.01,david markus,ANTH-2010,2018
-ANTH,2010,4,Introduction to Anthropology,0.3,0.63,0.05,0.0,0.01,0.0,0.0,0.0,david markus,ANTH-2010,2018
-ANTH,2010,5,Introduction to Anthropology,0.36,0.56,0.01,0.03,0.04,0.0,0.0,0.0,david markus,ANTH-2010,2018
-ANTH,3320,1,World Archaeology,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,david markus,ANTH-3320,2018
-ANTH,3510,1,Biological Anthropology,0.37,0.42,0.11,0.05,0.05,0.0,0.0,0.0,lisa rapaport,ANTH-3510,2018
-ANTH,3530,1,Forensic Anthropology,0.24,0.65,0.0,0.12,0.0,0.0,0.0,0.0,katherine weisensee,ANTH-3530,2018
-ANTH,4660,1,Evolution of Human Behav,0.4,0.3,0.1,0.2,0.0,0.0,0.0,0.0,lisa rapaport,ANTH-4660,2018
-ANTH,4960,2,Anth CI: Entrepreneurs in BSHS,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,janie shonta johnson,ANTH-4960,2018
-ARCH,1010,1,Introduction to Architecture,0.63,0.19,0.04,0.01,0.04,0.0,0.0,0.08,sall hambright-belue,ARCH-1010,2018
-ARCH,2040,1,Hist of Modern Arch,0.55,0.32,0.12,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-2040,2018
-ARCH,2510,1,Arch Foundations I,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-2510,2018
-ARCH,2510,2,Arch Foundations I,0.14,0.5,0.29,0.0,0.0,0.0,0.0,0.07,robert silance,ARCH-2510,2018
-ARCH,2510,3,Arch Foundations I,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,dustin grah albright,ARCH-2510,2018
-ARCH,2510,4,Arch Foundations I,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-2510,2018
-ARCH,2510,5,Arch Foundations I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-2510,2018
-ARCH,2510,6,Arch Foundations I,0.54,0.31,0.08,0.08,0.0,0.0,0.0,0.0,timothy sutherland,ARCH-2510,2018
-ARCH,2700,1,Structures I,0.52,0.42,0.06,0.0,0.0,0.0,0.0,0.0,dustin grah albright,ARCH-2700,2018
-ARCH,3500,1,Intro to Urban Contexts,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,ARCH-3500,2018
-ARCH,3500,2,Intro to Urban Contexts,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-3500,2018
-ARCH,3500,3,Intro to Urban Contexts,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-3500,2018
-ARCH,3500,4,Intro to Urban Contexts,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-3500,2018
-ARCH,3500,5,Intro to Urban Contexts,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-3500,2018
-ARCH,3510,3,Studio Clemson,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,michael carlo kleiss,ARCH-3510,2018
-ARCH,3510,4,Studio Clemson,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,ARCH-3510,2018
-ARCH,3540,1,Studio Barcelona,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-3540,2018
-ARCH,4010,1,Architectural Portfolio,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-4010,2018
-ARCH,4010,2,Architectural Portfolio,0.25,0.58,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4010,2018
-ARCH,4010,4,Architectural Portfolio,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,pai liu,ARCH-4010,2018
-ARCH,4140,2,Design Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-4140,2018
-ARCH,6990,9,Freehand Drawing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,ARCH-6990,2018
-ARCH,8100,1,Visualization I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,ARCH-8100,2018
-ARCH,8210,1,Research Methods,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-8210,2018
-ARCH,8360,1,Managing Integr Proj Delivery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,sall hambright-belue,ARCH-8360,2018
-ARCH,8510,1,Design Studio III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-sop heine,ARCH-8510,2018
-ARCH,8510,2,Design Studio III,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,santa cruz da franco da,ARCH-8510,2018
-ARCH,8510,3,Design Studio III,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,ARCH-8510,2018
-ARCH,8600,1,History/Theory I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-8600,2018
-ARCH,8720,1,Production & Assemb,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,ARCH-8720,2018
-ARCH,8810,1,Pro Practice Survey,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,katherine schwennsen,ARCH-8810,2018
-ARCH,8950,1,A+H Studio: Projects,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8950,2018
-ART,1050,1,Foundation Drawing I,0.18,0.18,0.55,0.09,0.0,0.0,0.0,0.0,denise elizabe ayers,ART-1050,2018
-ART,2070,1,Beginning Painting,0.35,0.18,0.29,0.0,0.0,0.0,0.0,0.18,dustin lee massey,ART-2070,2018
-ART,2090,1,Beginning Sculpture,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0, joseph rich manson rich,ART-2090,2018
-ART,2100,5,Art Appreciation,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,angel roche estrella,ART-2100,2018
-ART,2100,400,Art Appreciation,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0, joseph rich manson rich,ART-2100,2018
-ART,2110,1,Begin Printmaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mandy lorai ferguson,ART-2110,2018
-ART,2130,1,Begin Photography,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,amanda denise musick,ART-2130,2018
-ART,2170,1,Beginning Ceramics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,ART-2170,2018
-ART,2210,1,Beginning New Media,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,christina nguye hung,ART-2210,2018
-ART,3050,1,Intermediate Drawing,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,annamarie williams,ART-3050,2018
-AS,1090,1,Air Force Today I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1090,2018
-AS,1090,2,Air Force Today I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1090,2018
-AS,1090,3,Air Force Today I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1090,2018
-AS,2090,1,Dev of Air Power I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2090,2018
-AS,2090,2,Dev of Air Power I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2090,2018
-AS,2090,3,Dev of Air Power I,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2090,2018
-AS,4090,1,Nat Sec Policy I,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4090,2018
-AS,4090,2,Nat Sec Policy I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4090,2018
-ASL,1010,2,Am Sign Lang I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,ASL-1010,2018
-ASL,1010,3,Am Sign Lang I,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,ASL-1010,2018
-ASL,1010,5,Am Sign Lang I,0.79,0.11,0.0,0.05,0.05,0.0,0.0,0.0,dunn kim mar misener mar,ASL-1010,2018
-ASL,1010,6,Am Sign Lang I,0.58,0.21,0.05,0.0,0.11,0.0,0.0,0.05,jason hurdich,ASL-1010,2018
-ASL,1020,1,Am Sign Lang I,0.41,0.24,0.29,0.0,0.0,0.0,0.0,0.06,jason hurdich,ASL-1020,2018
-ASL,1020,2,Am Sign Lang I,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,jason hurdich,ASL-1020,2018
-ASL,2010,1,Am Sign Lang II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,ASL-2010,2018
-ASL,2010,3,Am Sign Lang II,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,ASL-2010,2018
-ASL,2010,4,Am Sign Lang II,0.87,0.07,0.0,0.07,0.0,0.0,0.0,0.0,dunn kim mar misener mar,ASL-2010,2018
-ASL,2020,1,Am Sign Lang II,0.21,0.43,0.14,0.21,0.0,0.0,0.0,0.0,jason hurdich,ASL-2020,2018
-ASL,3010,1,Advanced A S L I,0.65,0.18,0.18,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,ASL-3010,2018
-ASL,3050,1,Deaf Studies,0.83,0.0,0.0,0.06,0.11,0.0,0.0,0.0,jason hurdich,ASL-3050,2018
-ASL,3490,1,Adv App in Asl,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,ASL-3490,2018
-ASTR,1010,1,Solar System Astronomy,0.24,0.32,0.31,0.06,0.03,0.0,0.0,0.05,mate adamkovics,ASTR-1010,2018
-ASTR,1020,1,Stellar Astronomy,0.38,0.28,0.15,0.08,0.05,0.0,0.0,0.06,mark leising,ASTR-1020,2018
-ASTR,1030,1,Solar Systm Astr Lab,0.74,0.13,0.09,0.0,0.0,0.0,0.0,0.04,mark leising,ASTR-1030,2018
-ASTR,1030,2,Solar Systm Astr Lab,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,ASTR-1030,2018
-ASTR,1030,4,Solar Systm Astr Lab,0.4,0.35,0.05,0.0,0.05,0.0,0.0,0.15,mark leising,ASTR-1030,2018
-ASTR,1030,6,Solar Systm Astr Lab,0.62,0.23,0.04,0.04,0.04,0.0,0.0,0.04,mark leising,ASTR-1030,2018
-ASTR,1030,7,Solar Systm Astr Lab,0.82,0.09,0.05,0.0,0.0,0.0,0.0,0.05,mark leising,ASTR-1030,2018
-ASTR,1030,8,Solar Systm Astr Lab,0.54,0.38,0.04,0.04,0.0,0.0,0.0,0.0,mark leising,ASTR-1030,2018
-ASTR,1030,9,Solar Systm Astr Lab,0.72,0.06,0.06,0.0,0.17,0.0,0.0,0.0,mark leising,ASTR-1030,2018
-ASTR,1030,10,Solar Systm Astr Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,mark leising,ASTR-1030,2018
-ASTR,1040,1,Stellar Astr Lab,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,mark leising,ASTR-1040,2018
-ASTR,1040,2,Stellar Astr Lab,0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,mark leising,ASTR-1040,2018
-ASTR,1040,4,Stellar Astr Lab,0.43,0.48,0.0,0.0,0.04,0.0,0.0,0.04,mark leising,ASTR-1040,2018
-ASTR,3020,1,Stellar Astrophysics,0.35,0.41,0.0,0.0,0.06,0.0,0.0,0.18,marco ajello,ASTR-3020,2018
-ASTR,8300,1,Astroph III:Galactic,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,ASTR-8300,2018
-AUD,1850,1,Intro to Audio Tech,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-1850,2018
-AUE,6010,1,Vehicle Dynamics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,AUE-6010,2018
-AUE,8040,699,Autovation for Entrepreneurs,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,AUE-8040,2018
-AUE,8180,1,"Engine Analysis, Design & Exp",0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8180,2018
-AUE,8190,100,Adv Int Combustion Engine Conc,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-8190,2018
-AUE,8280,1,Driveline/Powertrain,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8280,2018
-AUE,8330,30,Auto Manuf Proc Devl,0.18,0.75,0.0,0.0,0.0,0.0,0.0,0.07,michael mears,AUE-8330,2018
-AUE,8350,100,Auto Electronics,0.63,0.32,0.01,0.0,0.0,0.0,0.0,0.03,yunyi jia,AUE-8350,2018
-AUE,8800,2,Vehicle Project Mngt,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,dee ann wood kivett wood,AUE-8800,2018
-AUE,8810,3,Automotive Systems Overview,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,christiaan paredis,AUE-8810,2018
-AUE,8870,8,Meth Vehicle Testing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,AUE-8870,2018
-AVS,1000,1,Orientation to AVS,0.87,0.1,0.01,0.0,0.01,0.0,0.0,0.01,marie owens bolt,AVS-1000,2018
-AVS,1500,1,Intro Animal Science,0.26,0.3,0.21,0.12,0.08,0.0,0.0,0.03,joseph keit bertrand,AVS-1500,2018
-AVS,1500,2,Intro Animal Science,0.33,0.17,0.29,0.1,0.1,0.0,0.0,0.02,joseph keit bertrand,AVS-1500,2018
-AVS,1510,1,Intro Ani Sci Lab,0.48,0.4,0.12,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,AVS-1510,2018
-AVS,1510,2,Intro Ani Sci Lab,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,AVS-1510,2018
-AVS,1510,3,Intro Ani Sci Lab,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,AVS-1510,2018
-AVS,1510,4,Intro Ani Sci Lab,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,alissa moritz,AVS-1510,2018
-AVS,1510,5,Intro Ani Sci Lab,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,AVS-1510,2018
-AVS,1510,6,Intro Ani Sci Lab,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,AVS-1510,2018
-AVS,1510,7,Intro Ani Sci Lab,0.43,0.43,0.1,0.05,0.0,0.0,0.0,0.0,maslyn ann greene,AVS-1510,2018
-AVS,1510,8,Intro Ani Sci Lab,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,AVS-1510,2018
-AVS,2040,1,Horse Care Techniques,0.7,0.22,0.05,0.03,0.0,0.0,0.0,0.0,kristine lang vernon,AVS-2040,2018
-AVS,2060,1,Swine Techniques,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,AVS-2060,2018
-AVS,3010,1,Anat & Phys Dom Ani,0.54,0.22,0.23,0.01,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2018
-AVS,3010,400,Anat & Phys Dom Ani,0.4,0.35,0.18,0.07,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2018
-AVS,3020,1,Livestk Sel Eval I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,AVS-3020,2018
-AVS,3100,1,Animal Health,0.62,0.24,0.12,0.0,0.0,0.0,0.0,0.03,celina marce checura,AVS-3100,2018
-AVS,3700,1,Principles of Animal Nutrition,0.49,0.22,0.21,0.06,0.01,0.0,0.0,0.01,zheng zhou,AVS-3700,2018
-AVS,3750,1,Applied Animal Nutrition,0.23,0.39,0.29,0.06,0.0,0.0,0.0,0.03,gustavo jose lascano,AVS-3750,2018
-AVS,4000,2,AVS Professional Development,0.85,0.0,0.08,0.0,0.0,0.0,0.0,0.08,marie owens bolt,AVS-4000,2018
-AVS,4110,1,Animal Growth and Development,0.49,0.34,0.1,0.05,0.02,0.0,0.0,0.0,susan kay duckett,AVS-4110,2018
-AVS,4140,1,Basic Immunology,0.4,0.4,0.0,0.1,0.0,0.0,0.0,0.1,farzana ferdous,AVS-4140,2018
-AVS,4150,1,Contemporary Issues in AVS,0.82,0.14,0.03,0.02,0.0,0.0,0.0,0.0,heather walker dunn,AVS-4150,2018
-AVS,4160,1,Equine Exercise Phys,0.5,0.45,0.0,0.05,0.0,0.0,0.0,0.0,kristine lang vernon,AVS-4160,2018
-AVS,4500,1,Sustain Livestock Product Sys,0.09,0.64,0.18,0.09,0.0,0.0,0.0,0.0,matias jose aguerre,AVS-4500,2018
-AVS,4530,1,Animal Reproduction,0.61,0.32,0.05,0.0,0.02,0.0,0.0,0.0,tiffany wilmoth,AVS-4530,2018
-AVS,4670,1,Animal Physiology II,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,celina marce checura,AVS-4670,2018
-AVS,4800,1,Vertebrate Endocrinology,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,heather walker dunn,AVS-4800,2018
-AVS,8200,1,Graduate Seminar,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,AVS-8200,2018
-BCHM,1030,1,Careers in Bioch/Gen,0.88,0.03,0.06,0.0,0.01,0.0,0.0,0.02,alison ni starr-moss,BCHM-1030,2018
-BCHM,3010,1,Molecular Biochemistry,0.4,0.29,0.18,0.04,0.07,0.0,0.0,0.02,kerry smith,BCHM-3010,2018
-BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2018
-BCHM,3040,2,Molecular Biology Laboratory,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2018
-BCHM,3040,3,Molecular Biology Laboratory,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2018
-BCHM,3040,4,Molecular Biology Laboratory,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2018
-BCHM,3040,5,Molecular Biology Laboratory,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2018
-BCHM,3050,1,Essen Elements Bioch,0.25,0.34,0.25,0.08,0.05,0.0,0.0,0.04,debra ragland,BCHM-3050,2018
-BCHM,3050,2,Essen Elements Bioch,0.39,0.4,0.13,0.04,0.01,0.0,0.0,0.04,debra ragland,BCHM-3050,2018
-BCHM,4310,1,Physical Approach to Biochem,0.28,0.4,0.25,0.02,0.02,0.0,0.0,0.04,weiguo cao,BCHM-4310,2018
-BCHM,4330,2,Physical Biochemistry Lab,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,geoffrey ford,BCHM-4330,2018
-BCHM,4330,4,Physical Biochemistry Lab,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,geoffrey ford,BCHM-4330,2018
-BCHM,4400,1,Bioinformatics,0.68,0.26,0.0,0.0,0.03,0.0,0.0,0.03,frank alexand feltus,BCHM-4400,2018
-BCHM,4430,1,Molecular Basis of Disease,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,james morris,BCHM-4430,2018
-BCHM,8900,1,Euk Path Journal Club,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,kerry smith,BCHM-8900,2018
-BE,2120,1,Fundamentals of Biosys Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-2120,2018
-BE,3200,1,Principles & Prac of Geomatics,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,tom owino,BE-3200,2018
-BE,4100,1,Biological Kinetics,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4100,2018
-BE,4280,1,Biochem Engr,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4280,2018
-BE,4750,1,BE Capstone Design,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,BE-4750,2018
-BIOE,1010,1,Biol for Bioengr,0.47,0.2,0.27,0.0,0.07,0.0,0.0,0.0,vladimir vlad reukov,BIOE-1010,2018
-BIOE,2010,1,Intro Biomed Engr,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,charles webb,BIOE-2010,2018
-BIOE,2010,2,Intro Biomed Engr,0.27,0.42,0.18,0.04,0.01,0.0,0.0,0.08,charles webb,BIOE-2010,2018
-BIOE,3020,1,Biomaterials,0.75,0.17,0.06,0.0,0.0,0.0,0.0,0.02,alexey alex vertegel,BIOE-3020,2018
-BIOE,3100,1,Engr Analysis of Physiol Proc,0.78,0.2,0.0,0.01,0.0,0.0,0.0,0.0,brian william booth,BIOE-3100,2018
-BIOE,3200,1,Biomechanics,0.55,0.34,0.09,0.02,0.0,0.0,0.0,0.0,jiro nagatomi,BIOE-3200,2018
-BIOE,3210,1,Biofluid Mechanics,0.65,0.16,0.16,0.0,0.03,0.0,0.0,0.0,zhi gao,BIOE-3210,2018
-BIOE,3470,1,Transport Processes in Bioengr,0.44,0.35,0.14,0.03,0.01,0.0,0.0,0.03,renee nicole cottle,BIOE-3470,2018
-BIOE,3700,1,Bioinst & Imaging,0.58,0.32,0.05,0.01,0.01,0.0,0.0,0.03,delphine dean,BIOE-3700,2018
-BIOE,4120,1,Orthopaedic Engr and Pathology,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,melinda harman,BIOE-4120,2018
-BIOE,4400,1,Biopharmaceutical Engineering,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,sarah harcum,BIOE-4400,2018
-BIOE,4480,1,Tissue Engineering,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,angela ant alexander,BIOE-4480,2018
-BIOE,6120,1,Orthopaedic Engr & Pathology,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,BIOE-6120,2018
-BIOE,6350,1,Modeling of Multiphysics Prob,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,BIOE-6350,2018
-BIOE,8010,1,Bio Materials,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,robert latour,BIOE-8010,2018
-BIOE,8020,864,Biocompatibility,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,BIOE-8020,2018
-BIOE,8140,843,Medical Dev Commercialization,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hobey tam,BIOE-8140,2018
-BIOE,8700,1,Bioinstrumentation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,tong ye,BIOE-8700,2018
-BIOL,1010,1,Frontiers in Biology I,0.8,0.1,0.08,0.01,0.01,0.0,0.0,0.0,robert edwar ballard,BIOL-1010,2018
-BIOL,1010,2,Frontiers in Biology I,0.84,0.09,0.05,0.0,0.01,0.0,0.0,0.01,michael childress,BIOL-1010,2018
-BIOL,1030,1,General Biology I,0.2,0.25,0.28,0.11,0.07,0.0,0.0,0.1,nora espinoza,BIOL-1030,2018
-BIOL,1030,2,General Biology I,0.22,0.39,0.25,0.07,0.02,0.0,0.0,0.04,william baldwin,BIOL-1030,2018
-BIOL,1030,3,General Biology I,0.3,0.31,0.24,0.1,0.02,0.0,0.0,0.03,wen chen,BIOL-1030,2018
-BIOL,1030,4,General Biology I,0.16,0.29,0.31,0.09,0.05,0.0,0.0,0.1,salvatore sparace,BIOL-1030,2018
-BIOL,1030,5,General Biology I (HON),0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,nora espinoza,BIOL-1030,2018
-BIOL,1050,1,General Biology Lab I,0.17,0.48,0.22,0.04,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,2,General Biology Lab I,0.35,0.39,0.09,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,3,General Biology Lab I,0.22,0.39,0.26,0.09,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,4,General Biology Lab I,0.17,0.54,0.08,0.04,0.0,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,5,General Biology Lab I,0.18,0.47,0.24,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,6,General Biology Lab I,0.33,0.48,0.05,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,7,General Biology Lab I,0.21,0.5,0.13,0.04,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,8,General Biology Lab I,0.17,0.5,0.25,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,9,General Biology Lab I,0.18,0.5,0.27,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,10,General Biology Lab I,0.14,0.41,0.18,0.14,0.0,0.0,0.0,0.14,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,11,General Biology Lab I,0.29,0.33,0.29,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,12,General Biology Lab I,0.27,0.36,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,13,General Biology Lab I,0.17,0.63,0.13,0.0,0.08,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,14,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,15,General Biology Lab I,0.29,0.38,0.25,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,16,General Biology Lab I,0.17,0.67,0.08,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,17,General Biology Lab I,0.38,0.38,0.17,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,18,General Biology Lab I,0.33,0.38,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,19,General Biology Lab I,0.18,0.59,0.23,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,20,General Biology Lab I,0.35,0.43,0.17,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,21,General Biology Lab I,0.21,0.63,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,22,General Biology Lab I,0.16,0.42,0.16,0.11,0.11,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,23,General Biology Lab I,0.28,0.22,0.28,0.22,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,24,General Biology Lab I,0.05,0.73,0.14,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,25,General Biology Lab I,0.22,0.57,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,26,General Biology Lab I,0.05,0.45,0.27,0.18,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,28,General Biology Lab I,0.21,0.58,0.13,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,29,General Biology Lab I,0.29,0.54,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,31,General Biology Lab I,0.33,0.5,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,32,General Biology Lab I,0.21,0.42,0.25,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,33,General Biology Lab I,0.5,0.33,0.08,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,34,General Biology Lab I,0.24,0.52,0.14,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,35,General Biology Lab I,0.36,0.55,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,37,General Biology Lab I,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,38,General Biology Lab I,0.33,0.42,0.21,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,39,General Biology Lab I,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,40,General Biology Lab I,0.33,0.54,0.08,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,41,General Biology Lab I,0.21,0.5,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,42,General Biology Lab I,0.29,0.58,0.08,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,43,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,44,General Biology Lab I,0.21,0.54,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,45,General Biology Lab I,0.33,0.54,0.08,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,46,General Biology Lab I,0.24,0.52,0.14,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,47,General Biology Lab I,0.25,0.6,0.1,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1050,48,General Biology Lab I,0.33,0.57,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2018
-BIOL,1090,1,Intro to Life Sci,0.83,0.13,0.03,0.01,0.0,0.0,0.0,0.0,renea chris hardwick,BIOL-1090,2018
-BIOL,1100,1,Principles of Biology I,0.36,0.35,0.17,0.05,0.03,0.0,0.0,0.03,renea chris hardwick,BIOL-1100,2018
-BIOL,1100,2,Principles of Biology I (HON),0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,renea chris hardwick,BIOL-1100,2018
-BIOL,1100,3,Principles of Biology I,0.27,0.49,0.16,0.04,0.02,0.0,0.0,0.03, christine minor m,BIOL-1100,2018
-BIOL,1100,4,Principles of Biology I (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,BIOL-1100,2018
-BIOL,2000,2,Biology in the News,0.67,0.11,0.17,0.0,0.0,0.0,0.0,0.06,dylan dittrich-reed,BIOL-2000,2018
-BIOL,2000,3,Biology in the News,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,BIOL-2000,2018
-BIOL,2000,4,Biology in the News,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,BIOL-2000,2018
-BIOL,2110,1,Introduction to Toxicology,0.72,0.24,0.0,0.03,0.0,0.0,0.0,0.0,den hurk peter van peter,BIOL-2110,2018
-BIOL,2220,1,Human Anat and Physiology I,0.26,0.3,0.23,0.09,0.07,0.0,0.0,0.04,john cummings,BIOL-2220,2018
-BIOL,2220,2,Human Anat and Physiology I,0.25,0.37,0.2,0.09,0.07,0.0,0.0,0.02,john cummings,BIOL-2220,2018
-BIOL,3030,1,Vertebrate Biology,0.35,0.25,0.19,0.15,0.03,0.0,0.0,0.04,richard blob,BIOL-3030,2018
-BIOL,3030,2,Vertebrate Biology (HON),0.79,0.17,0.03,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3030,2018
-BIOL,3040,1,Biology of Plants,0.38,0.35,0.19,0.04,0.01,0.0,0.0,0.03,christina wells,BIOL-3040,2018
-BIOL,3070,1,Vertebrate Biology Lab,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,2,Vertebrate Biology Lab,0.63,0.16,0.21,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,3,Vertebrate Biology Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,4,Vertebrate Biology Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,5,Vertebrate Biology Lab,0.45,0.4,0.0,0.0,0.0,0.0,0.0,0.15,richard blob,BIOL-3070,2018
-BIOL,3070,6,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,7,Vertebrate Biology Lab,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,8,Vertebrate Biology Lab,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,9,Vertebrate Biology Lab,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,BIOL-3070,2018
-BIOL,3070,10,Vertebrate Biology Lab,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,11,Vertebrate Biology Lab,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,12,Vertebrate Biology Lab,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2018
-BIOL,3070,13,Vertebrate Biology Lab,0.3,0.5,0.05,0.05,0.0,0.0,0.0,0.1,richard blob,BIOL-3070,2018
-BIOL,3080,1,Biology of Plants Practicum,0.5,0.35,0.05,0.1,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2018
-BIOL,3080,2,Biology of Plants Practicum,0.25,0.25,0.35,0.15,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2018
-BIOL,3080,3,Biology of Plants Practicum,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,nathan redding,BIOL-3080,2018
-BIOL,3080,4,Biology of Plants Practicum,0.33,0.39,0.17,0.11,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2018
-BIOL,3080,5,Biology of Plants Practicum,0.32,0.37,0.32,0.0,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2018
-BIOL,3080,6,Biology of Plants Practicum,0.26,0.26,0.26,0.11,0.0,0.0,0.0,0.11,nathan redding,BIOL-3080,2018
-BIOL,3150,1,Functional Human Anatomy,0.19,0.41,0.25,0.07,0.02,0.0,0.0,0.05,tamara mcnutt-scott,BIOL-3150,2018
-BIOL,3200,1,Field Botany,0.16,0.28,0.25,0.09,0.06,0.0,0.0,0.16,robert edwar ballard,BIOL-3200,2018
-BIOL,3350,1,Evolutionary Biology,0.29,0.38,0.21,0.04,0.05,0.0,0.0,0.02,samantha ann price,BIOL-3350,2018
-BIOL,3510,1,Biological Anthropology,0.53,0.41,0.0,0.06,0.0,0.0,0.0,0.0,lisa rapaport,BIOL-3510,2018
-BIOL,3530,1,Forensic Anthropology,0.35,0.5,0.1,0.05,0.0,0.0,0.0,0.0,katherine weisensee,BIOL-3530,2018
-BIOL,4140,1,Basic Immunology,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,yanzhang wei,BIOL-4140,2018
-BIOL,4200,1,Neurobiology,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4200,2018
-BIOL,4250,1,Introductory Mycology,0.34,0.41,0.19,0.05,0.02,0.0,0.0,0.0,julia louis kerrigan,BIOL-4250,2018
-BIOL,4260,1,Mycology Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,julia louis kerrigan,BIOL-4260,2018
-BIOL,4260,2,Mycology Practicum,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,julia louis kerrigan,BIOL-4260,2018
-BIOL,4400,1,Developmental Animal Biology,0.38,0.28,0.25,0.06,0.01,0.0,0.0,0.01,kara elizabet powder,BIOL-4400,2018
-BIOL,4430,2,Freshwater Ecology,0.19,0.48,0.19,0.03,0.03,0.0,0.0,0.06,john jenkins hains,BIOL-4430,2018
-BIOL,4560,1,Medical and Vet Parasitology,0.67,0.25,0.06,0.0,0.0,0.0,0.0,0.03,wilbur kears milhous,BIOL-4560,2018
-BIOL,4610,1,Cell Biology,0.28,0.45,0.2,0.05,0.0,0.0,0.0,0.02,susan caroli chapman,BIOL-4610,2018
-BIOL,4610,2,Cell Biology (HON),0.65,0.26,0.06,0.03,0.0,0.0,0.0,0.0,susan caroli chapman,BIOL-4610,2018
-BIOL,4620,1,Cell Biology Lab (Lec),0.64,0.32,0.0,0.04,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2018
-BIOL,4620,2,Cell Biology Lab (Lec),0.67,0.3,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2018
-BIOL,4620,3,Cell Biology Lab (Lec),0.64,0.29,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2018
-BIOL,4620,4,Cell Biology Lab (Lec),0.61,0.29,0.04,0.07,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2018
-BIOL,4620,5,Cell Biology Lab (Lec),0.7,0.22,0.0,0.04,0.04,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2018
-BIOL,4620,6,Cell Biology Lab (Lec),0.52,0.37,0.0,0.0,0.0,0.0,0.0,0.11,xianzhong yu,BIOL-4620,2018
-BIOL,4670,1,Principles of Hematology,0.8,0.11,0.0,0.03,0.0,0.0,0.0,0.06,vincent gallicchio,BIOL-4670,2018
-BIOL,4930,5,Sr Sem: Symbiosis,0.8,0.07,0.13,0.0,0.0,0.0,0.0,0.0,matthew turnbull,BIOL-4930,2018
-BIOL,8120,1,Seminar,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,michael sears,BIOL-8120,2018
-BIOL,8200,1,Community Ecology,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,saara dewalt,BIOL-8200,2018
-BIOL,8400,1,Understanding Biological Inq,0.88,0.01,0.02,0.0,0.04,0.0,0.0,0.06,michael childress,BIOL-8400,2018
-BIOL,8420,1,Understand Cellular Processes,0.67,0.24,0.08,0.0,0.02,0.0,0.0,0.0,patricia leota tate,BIOL-8420,2018
-BIOL,8440,1,Understanding the Human Body,0.65,0.27,0.07,0.0,0.0,0.0,0.0,0.01,william baldwin,BIOL-8440,2018
-BIOL,8710,2,MCDB Grad Core,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,lisa bain,BIOL-8710,2018
-BUS,1010,1,Business Foundations,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,william erne tumblin,BUS-1010,2018
-BUS,1010,2,Business Foundations,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,william erne tumblin,BUS-1010,2018
-BUS,1010,3,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william erne tumblin,BUS-1010,2018
-BUS,1010,4,Business Foundations,0.35,0.53,0.06,0.0,0.06,0.0,0.0,0.0,mary ann  prater m,BUS-1010,2018
-BUS,1010,5,Business Foundations,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,mary ann  prater m,BUS-1010,2018
-BUS,1010,6,Business Foundations,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,mary ann  prater m,BUS-1010,2018
-BUS,1010,7,Business Foundations,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,william erne tumblin,BUS-1010,2018
-BUS,1010,8,Business Foundations,0.11,0.39,0.28,0.11,0.11,0.0,0.0,0.0,william erne tumblin,BUS-1010,2018
-BUS,1010,9,Business Foundations,0.22,0.44,0.11,0.17,0.0,0.0,0.0,0.06,william erne tumblin,BUS-1010,2018
-BUS,1010,10,Business Foundations,0.42,0.37,0.11,0.0,0.05,0.0,0.0,0.05,william erne tumblin,BUS-1010,2018
-BUS,1010,11,Business Foundations,0.32,0.42,0.11,0.0,0.11,0.0,0.0,0.05,william erne tumblin,BUS-1010,2018
-BUS,1010,15,Business Foundations,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2018
-BUS,1010,16,Business Foundations,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2018
-BUS,1010,17,Business Foundations,0.36,0.5,0.0,0.0,0.07,0.0,0.0,0.07,donna mccubbin,BUS-1010,2018
-BUS,1010,18,Business Foundations,0.11,0.5,0.28,0.06,0.06,0.0,0.0,0.0,donna mccubbin,BUS-1010,2018
-BUS,1010,19,Business Foundations,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,donna mccubbin,BUS-1010,2018
-BUS,1010,20,Business Foundations,0.21,0.47,0.21,0.0,0.11,0.0,0.0,0.0,donna mccubbin,BUS-1010,2018
-BUS,1010,23,Business Foundations,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2018
-BUS,1010,24,Business Foundations,0.42,0.32,0.16,0.0,0.05,0.0,0.0,0.05,sandy edge,BUS-1010,2018
-BUS,1010,25,Business Foundations,0.39,0.44,0.06,0.06,0.0,0.0,0.0,0.06,sandy edge,BUS-1010,2018
-BUS,1010,26,Business Foundations,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,iulio edward barr de barr,BUS-1010,2018
-BUS,1010,27,Business Foundations,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,iulio edward barr de barr,BUS-1010,2018
-BUS,1010,28,Business Foundations,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,iulio edward barr de barr,BUS-1010,2018
-BUS,1010,29,Business Foundations,0.15,0.32,0.21,0.09,0.11,0.0,0.0,0.13,mary ann  prater m,BUS-1010,2018
-BUS,1010,30,Business Foundations,0.11,0.59,0.26,0.02,0.02,0.0,0.0,0.0,mary ann  prater m,BUS-1010,2018
-BUS,1010,31,Business Foundations,0.29,0.53,0.06,0.06,0.0,0.0,0.0,0.06,mary ann  prater m,BUS-1010,2018
-BUS,1010,33,Business Foundations,0.2,0.47,0.1,0.07,0.03,0.0,0.0,0.13,donna mccubbin,BUS-1010,2018
-BUS,1010,34,Business Foundations,0.37,0.32,0.32,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2018
-BUS,1010,35,Business Foundations,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,william erne tumblin,BUS-1010,2018
-BUS,1010,37,Business Foundations,0.44,0.31,0.19,0.06,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2018
-CE,1990,20,Cr Inq in Civil Engineering,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,bradley putman,CE-1990,2018
-CE,2010,1,Statics,0.34,0.26,0.18,0.04,0.15,0.0,0.0,0.03,qiushi chen,CE-2010,2018
-CE,2010,2,Statics,0.1,0.4,0.26,0.02,0.02,0.0,0.0,0.19,melissa sternhagen,CE-2010,2018
-CE,2010,3,Statics,0.18,0.48,0.2,0.07,0.02,0.0,0.0,0.05,md nasimul chowdhury,CE-2010,2018
-CE,2010,4,Statics,0.11,0.3,0.21,0.12,0.09,0.0,0.0,0.17,melissa sternhagen,CE-2010,2018
-CE,2010,5,Statics,0.24,0.27,0.22,0.07,0.07,0.0,0.0,0.12,qiushi chen,CE-2010,2018
-CE,2010,6,Statics,0.1,0.15,0.2,0.15,0.15,0.0,0.0,0.25,melissa sternhagen,CE-2010,2018
-CE,2010,7,Statics (HON),0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,melissa sternhagen,CE-2010,2018
-CE,2010,8,Statics,0.09,0.34,0.36,0.07,0.02,0.0,0.0,0.11,md nasimul chowdhury,CE-2010,2018
-CE,2060,1,Structural Mechanics,0.07,0.25,0.4,0.17,0.07,0.0,0.0,0.05,melissa sternhagen,CE-2060,2018
-CE,2080,1,Dynamics,0.11,0.44,0.37,0.06,0.03,0.0,0.0,0.0,md nasimul chowdhury,CE-2080,2018
-CE,2550,1,Geomatics,0.3,0.34,0.3,0.01,0.03,0.0,0.0,0.01,wayne sarasua,CE-2550,2018
-CE,3010,1,Structural Analysis,0.34,0.29,0.26,0.03,0.09,0.0,0.0,0.0,stephen csernak,CE-3010,2018
-CE,3010,2,Structural Analysis,0.35,0.4,0.23,0.03,0.0,0.0,0.0,0.0,brandon ross,CE-3010,2018
-CE,3110,1,Transportation Engr,0.47,0.45,0.05,0.0,0.03,0.0,0.0,0.0,jennifer ogle,CE-3110,2018
-CE,3210,1,Geotechnical Engineering,0.38,0.45,0.13,0.05,0.0,0.0,0.0,0.0,shweta shrestha,CE-3210,2018
-CE,3310,1,Constr Engr & Mgmnt,0.44,0.41,0.09,0.05,0.0,0.0,0.0,0.0,james burati,CE-3310,2018
-CE,3410,1,Intro to Fluid Mech,0.36,0.52,0.11,0.02,0.0,0.0,0.0,0.0,nigel gregory kaye,CE-3410,2018
-CE,3410,2,Intro to Fluid Mech,0.28,0.36,0.22,0.04,0.08,0.0,0.0,0.02,abdul khan,CE-3410,2018
-CE,3420,1,Hydraulics & Hydro,0.47,0.38,0.05,0.02,0.04,0.0,0.0,0.04,ashok mishra,CE-3420,2018
-CE,3510,1,Civil Engineering Materials,0.48,0.44,0.06,0.02,0.0,0.0,0.0,0.0,amir esmaeilpoursaee,CE-3510,2018
-CE,3510,2,Civil Engineering Materials,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0,amir esmaeilpoursaee,CE-3510,2018
-CE,3520,1,Econ Eval of Proj,0.4,0.38,0.13,0.02,0.04,0.0,0.0,0.04,zoraya roldan rockow,CE-3520,2018
-CE,4020,1,Reinfor Con Design,0.28,0.51,0.15,0.02,0.02,0.0,0.0,0.02,brandon ross,CE-4020,2018
-CE,4060,1,Struct Steel Design,0.38,0.35,0.24,0.03,0.0,0.0,0.0,0.0,stephen csernak,CE-4060,2018
-CE,4100,1,Traffic Engr Oper,0.27,0.32,0.23,0.05,0.05,0.0,0.0,0.09,wayne sarasua,CE-4100,2018
-CE,4240,1,Earth Slopes & Struc,0.35,0.48,0.13,0.05,0.0,0.0,0.0,0.0,nadaraj ravichandran,CE-4240,2018
-CE,4390,1,Con Eqpmt Sel & Main,0.49,0.38,0.11,0.03,0.0,0.0,0.0,0.0,james burati,CE-4390,2018
-CE,4470,1,Stormwater Managemnt,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,earl hayter,CE-4470,2018
-CE,4560,1,Pave Design & Constr,0.47,0.41,0.09,0.0,0.0,0.0,0.0,0.03,bradley putman,CE-4560,2018
-CE,4590,1,Capstone Design Proj,0.46,0.38,0.11,0.03,0.0,0.0,0.0,0.03,stephen csernak,CE-4590,2018
-CE,4820,1,Groundwater & Contam Transport,0.3,0.3,0.1,0.0,0.0,0.0,0.0,0.3,lawrence murdoch,CE-4820,2018
-CE,4910,1,BIM in Construction Management,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4910,2018
-CE,6100,1,Traffic Engr Oper,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,wayne sarasua,CE-6100,2018
-CE,6240,1,Earth Slopes & Struc,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,nadaraj ravichandran,CE-6240,2018
-CE,6390,1,Con Eqpmt Sel & Main,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james burati,CE-6390,2018
-CE,8020,1,Adv R/C Design,0.38,0.31,0.23,0.0,0.0,0.0,0.0,0.08,thomas edfor cousins,CE-8020,2018
-CE,8220,1,Foundation Engr,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,nadaraj ravichandran,CE-8220,2018
-CE,8260,1,Prop of Concrete,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,prasada ra rangaraju,CE-8260,2018
-CE,8460,1,Flow in Open Chnls,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,abdul khan,CE-8460,2018
-CE,8480,500,Risk Analyt in Supply Chains,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott jennings mason,CE-8480,2018
-CE,8540,1,Travl Demnd Forecast,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,pamela murray-tuite,CE-8540,2018
-CE,8930,3,Risk Assessment,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-8930,2018
-CES,1900,101,CI - LEAD Forward I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,steve richar sanders,CES-1900,2018
-CES,1900,500,CI - PEER/WISE Exp Seminar,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jordon antho gilmore,CES-1900,2018
-CH,1010,1,General Chemistry,0.23,0.31,0.22,0.11,0.1,0.0,0.0,0.04,william we mcwhorter,CH-1010,2018
-CH,1010,2,General Chemistry,0.23,0.34,0.23,0.1,0.03,0.0,0.0,0.06,laura lanni,CH-1010,2018
-CH,1010,3,General Chemistry,0.13,0.36,0.35,0.05,0.06,0.0,0.0,0.06,olt geiculescu,CH-1010,2018
-CH,1010,4,General Chemistry,0.19,0.33,0.19,0.12,0.1,0.0,0.0,0.07,william we mcwhorter,CH-1010,2018
-CH,1010,5,General Chemistry,0.28,0.32,0.19,0.12,0.06,0.0,0.0,0.03,steven lo pellizzeri,CH-1010,2018
-CH,1010,6,General Chemistry,0.2,0.32,0.3,0.07,0.07,0.0,0.0,0.04,elliot ennis,CH-1010,2018
-CH,1010,7,General Chemistry,0.26,0.32,0.22,0.13,0.06,0.0,0.0,0.02,jacob schroeder,CH-1010,2018
-CH,1010,8,General Chemistry,0.33,0.28,0.23,0.07,0.04,0.0,0.0,0.05,princess mycia cox,CH-1010,2018
-CH,1010,9,General Chemistry,0.2,0.29,0.29,0.11,0.08,0.0,0.0,0.04,dennis taylor,CH-1010,2018
-CH,1010,10,General Chemistry,0.3,0.27,0.21,0.07,0.12,0.0,0.0,0.03,thomas hickman,CH-1010,2018
-CH,1010,11,General Chemistry,0.28,0.34,0.21,0.1,0.03,0.0,0.0,0.03,steven lo pellizzeri,CH-1010,2018
-CH,1010,12,General Chemistry,0.27,0.35,0.24,0.06,0.04,0.0,0.0,0.03,elliot ennis,CH-1010,2018
-CH,1010,13,General Chemistry,0.19,0.27,0.26,0.18,0.05,0.0,0.0,0.05,dennis taylor,CH-1010,2018
-CH,1010,50,General Chemistry,0.58,0.29,0.06,0.06,0.0,0.0,0.0,0.0,tania issa houjeiry,CH-1010,2018
-CH,1010,51,General Chemistry (HON),0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,CH-1010,2018
-CH,1010,52,General Chemistry (HON),0.71,0.23,0.06,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,CH-1010,2018
-CH,1010,201,General Chemistry,0.21,0.44,0.25,0.06,0.04,0.0,0.0,0.01,laura lanni,CH-1010,2018
-CH,1010,202,General Chemistry,0.29,0.44,0.19,0.04,0.02,0.0,0.0,0.03,tania issa houjeiry,CH-1010,2018
-CH,1010,203,General Chemistry,0.19,0.45,0.22,0.06,0.03,0.0,0.0,0.05,william we mcwhorter,CH-1010,2018
-CH,1010,204,General Chemistry,0.31,0.34,0.24,0.09,0.01,0.0,0.0,0.02,princess mycia cox,CH-1010,2018
-CH,1020,1,General Chemistry,0.33,0.23,0.22,0.12,0.05,0.0,0.0,0.05,stephen schvaneveldt,CH-1020,2018
-CH,1020,2,General Chemistry,0.33,0.27,0.19,0.14,0.04,0.0,0.0,0.02,stephen schvaneveldt,CH-1020,2018
-CH,1020,3,General Chemistry,0.29,0.29,0.22,0.09,0.02,0.0,0.0,0.08,stephen schvaneveldt,CH-1020,2018
-CH,1020,400,General Chemistry,0.09,0.21,0.23,0.26,0.11,0.0,0.0,0.11,stephen schvaneveldt,CH-1020,2018
-CH,1050,1,Chemistry in Context I,0.19,0.46,0.29,0.03,0.02,0.0,0.0,0.01,elliot ennis,CH-1050,2018
-CH,1050,2,Chemistry in Context I,0.16,0.57,0.15,0.05,0.01,0.0,0.0,0.06,elliot ennis,CH-1050,2018
-CH,2010,1,Survey of Organic Chemistry,0.3,0.37,0.09,0.06,0.13,0.0,0.0,0.05,thomas hickman,CH-2010,2018
-CH,2010,2,Survey of Organic Chemistry,0.46,0.32,0.15,0.08,0.0,0.0,0.0,0.0,thomas hickman,CH-2010,2018
-CH,2020,2,Surv of Organic Chemistry Lab,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,CH-2020,2018
-CH,2020,3,Surv of Organic Chemistry Lab,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,james nelson plampin,CH-2020,2018
-CH,2020,9,Surv of Organic Chemistry Lab,0.82,0.0,0.05,0.0,0.09,0.0,0.0,0.05,james nelson plampin,CH-2020,2018
-CH,2230,1,Organic Chemistry,0.08,0.2,0.25,0.14,0.2,0.0,0.0,0.13,modi wetzler,CH-2230,2018
-CH,2230,2,Organic Chemistry,0.18,0.26,0.24,0.17,0.06,0.0,0.0,0.1,modi wetzler,CH-2230,2018
-CH,2230,3,Organic Chemistry,0.43,0.25,0.15,0.08,0.03,0.0,0.0,0.06,tania issa houjeiry,CH-2230,2018
-CH,2230,4,Organic Chemistry,0.35,0.27,0.18,0.09,0.04,0.0,0.0,0.07,laura lanni,CH-2230,2018
-CH,2230,5,Organic Chemistry,0.55,0.26,0.13,0.03,0.02,0.0,0.0,0.03,rhett smith,CH-2230,2018
-CH,2230,6,Organic Chemistry,0.26,0.23,0.12,0.15,0.15,0.0,0.0,0.09,rhett smith,CH-2230,2018
-CH,2230,7,Organic Chemistry,0.21,0.24,0.23,0.08,0.1,0.0,0.0,0.16,sourav saha,CH-2230,2018
-CH,2240,1,Organic Chemistry,0.22,0.32,0.24,0.13,0.09,0.0,0.0,0.01,jacob schroeder,CH-2240,2018
-CH,2240,2,Organic Chemistry,0.33,0.29,0.2,0.09,0.06,0.0,0.0,0.03,jacob schroeder,CH-2240,2018
-CH,2270,1,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2270,2018
-CH,2270,2,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2018
-CH,2270,5,Organic Chem Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,CH-2270,2018
-CH,2270,6,Organic Chem Lab,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2018
-CH,2270,7,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,CH-2270,2018
-CH,2270,8,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,CH-2270,2018
-CH,2270,13,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,CH-2270,2018
-CH,2270,15,Organic Chem Lab,0.78,0.11,0.0,0.06,0.0,0.0,0.0,0.06,james nelson plampin,CH-2270,2018
-CH,2270,17,Organic Chem Lab,0.47,0.26,0.0,0.05,0.0,0.0,0.0,0.21,james nelson plampin,CH-2270,2018
-CH,2270,18,Organic Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,CH-2270,2018
-CH,2270,19,Organic Chem Lab,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2018
-CH,2270,20,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2018
-CH,2270,22,Organic Chem Lab,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,james nelson plampin,CH-2270,2018
-CH,2270,23,Organic Chem Lab,0.84,0.05,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,CH-2270,2018
-CH,2270,24,Organic Chem Lab,0.67,0.11,0.11,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2018
-CH,2270,25,Organic Chem Lab,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,CH-2270,2018
-CH,2270,26,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,CH-2270,2018
-CH,2270,27,Organic Chem Lab,0.84,0.0,0.0,0.0,0.05,0.0,0.0,0.11,james nelson plampin,CH-2270,2018
-CH,2270,28,Organic Chem Lab,0.78,0.06,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,CH-2270,2018
-CH,2270,29,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2018
-CH,2270,30,Organic Chem Lab,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,CH-2270,2018
-CH,2270,31,Organic Chem Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,CH-2270,2018
-CH,2270,32,Organic Chem Lab,0.69,0.06,0.0,0.0,0.0,0.0,0.0,0.25,james nelson plampin,CH-2270,2018
-CH,2270,33,Organic Chem Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,CH-2270,2018
-CH,2270,35,Organic Chem Lab,0.63,0.06,0.13,0.0,0.06,0.0,0.0,0.13,james nelson plampin,CH-2270,2018
-CH,2270,36,Organic Chem Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,james nelson plampin,CH-2270,2018
-CH,2270,37,Organic Chem Lab,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,CH-2270,2018
-CH,2270,39,Organic Chem Lab,0.73,0.08,0.0,0.0,0.0,0.0,0.0,0.19,james nelson plampin,CH-2270,2018
-CH,2270,40,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,CH-2270,2018
-CH,2280,1,Organic Chem Lab,0.84,0.05,0.0,0.05,0.0,0.0,0.0,0.05,james nelson plampin,CH-2280,2018
-CH,2280,2,Organic Chem Lab,0.82,0.05,0.0,0.05,0.05,0.0,0.0,0.05,james nelson plampin,CH-2280,2018
-CH,2280,4,Organic Chem Lab,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,james nelson plampin,CH-2280,2018
-CH,2280,6,Organic Chem Lab,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,james nelson plampin,CH-2280,2018
-CH,2280,8,Organic Chem Lab,0.88,0.04,0.0,0.0,0.04,0.0,0.0,0.04,james nelson plampin,CH-2280,2018
-CH,2280,9,Organic Chem Lab,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,james nelson plampin,CH-2280,2018
-CH,3130,1,Quantitative Analys,0.37,0.23,0.27,0.07,0.03,0.0,0.0,0.03,olt geiculescu,CH-3130,2018
-CH,3150,1,Quant Analysis Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,perez carlos garcia,CH-3150,2018
-CH,3150,2,Quant Analysis Lab,0.45,0.18,0.18,0.0,0.18,0.0,0.0,0.0,perez carlos garcia,CH-3150,2018
-CH,3300,1,Intro to Phys Chem,0.45,0.39,0.09,0.03,0.0,0.0,0.0,0.03,brian dominy,CH-3300,2018
-CH,3310,1,Physical Chemistry,0.35,0.31,0.23,0.08,0.04,0.0,0.0,0.0,steven stuart,CH-3310,2018
-CH,3320,1,Physical Chemistry,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,arkady kholodenko,CH-3320,2018
-CH,3390,1,Physical Chem Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2018
-CH,3390,2,Physical Chem Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2018
-CH,3390,3,Physical Chem Lab,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,princess mycia cox,CH-3390,2018
-CH,3390,5,Physical Chem Lab,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2018
-CH,3410,1,Introduction to Research,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,stephen creager,CH-3410,2018
-CH,4010,1,Organometallic Chemistry,0.74,0.23,0.0,0.0,0.0,0.0,0.0,0.03,andrew greg tennyson,CH-4010,2018
-CH,4020,1,Inorganic Chemistry,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,joseph kolis,CH-4020,2018
-CH,6020,1,Inorganic Chemistry,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph kolis,CH-6020,2018
-CH,8070,1,Chem Trans Elem,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,julia brumaghim,CH-8070,2018
-CH,8090,1,Chem App/X-Ray Cryst,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,CH-8090,2018
-CH,8210,1,Organic Chem I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ya-ping sun,CH-8210,2018
-CH,8300,1,Fund Phys Chem,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,CH-8300,2018
-CH,8510,3,Grad Student Seminar,0.83,0.15,0.0,0.0,0.0,0.0,0.0,0.03,joseph stua thrasher,CH-8510,2018
-CHE,2110,1,Mass and Energy Balances,0.32,0.29,0.35,0.03,0.0,0.0,0.0,0.0,karen ann high,CHE-2110,2018
-CHE,2110,2,Mass and Energy Balances,0.22,0.25,0.31,0.11,0.07,0.0,0.0,0.04,mark roberts,CHE-2110,2018
-CHE,3210,1,Ch E Thermo II,0.14,0.21,0.3,0.24,0.1,0.0,0.0,0.02,sapna sarupria,CHE-3210,2018
-CHE,3300,1,Mass Trans & Seprtn,0.23,0.16,0.3,0.2,0.11,0.0,0.0,0.0,mark thies,CHE-3300,2018
-CHE,4070,1,Unit Op Lab II,0.18,0.53,0.29,0.0,0.0,0.0,0.0,0.0,christopher norfolk,CHE-4070,2018
-CHE,4310,1,Process Design I,0.31,0.57,0.11,0.01,0.0,0.0,0.0,0.0,david bruce,CHE-4310,2018
-CHE,4500,1,Chem Reaction Engr,0.4,0.41,0.17,0.02,0.0,0.0,0.0,0.0,rachel getman,CHE-4500,2018
-CHE,8030,1,Advanced Transport,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,eric mikel davis,CHE-8030,2018
-CHE,8040,1,Ch E Thermodynamics,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,joseph scott,CHE-8040,2018
-CHE,8050,1,Ch E Kinetics,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,mark alan blenner,CHE-8050,2018
-CHE,8450,4,Systems Biology & Pharmacology,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,marc russ birtwistle,CHE-8450,2018
-CHIN,1010,2,Elementary Chinese,0.27,0.33,0.2,0.0,0.0,0.0,0.0,0.2,ling rao,CHIN-1010,2018
-CHIN,2010,1,Intermediate Chinese,0.55,0.27,0.0,0.09,0.0,0.0,0.0,0.09,ling rao,CHIN-2010,2018
-CHIN,4010,1,Pre-Modern Chinese Literature,0.33,0.38,0.13,0.03,0.05,0.0,0.0,0.1,yanming an,CHIN-4010,2018
-COM,1500,1,Intro to Human Communication,0.72,0.24,0.01,0.0,0.01,0.0,0.0,0.01,daniel leland fecher,COM-1500,2018
-COM,1500,2,Intro to Human Communication,0.64,0.26,0.05,0.01,0.02,0.0,0.0,0.03,daniel leland fecher,COM-1500,2018
-COM,1500,3,Intro to Human Communication,0.75,0.21,0.02,0.01,0.01,0.0,0.0,0.01,daniel leland fecher,COM-1500,2018
-COM,1500,4,Intro to Human Communication,0.64,0.24,0.06,0.02,0.03,0.0,0.0,0.01,marianne herr glaser,COM-1500,2018
-COM,1500,5,Intro to Human Communication,0.65,0.26,0.04,0.02,0.0,0.0,0.0,0.02,marianne herr glaser,COM-1500,2018
-COM,1500,6,Intro to Human Communication,0.53,0.33,0.09,0.0,0.04,0.0,0.0,0.01,marianne herr glaser,COM-1500,2018
-COM,1500,7,Intro to Human Communication,0.55,0.44,0.01,0.0,0.0,0.0,0.0,0.0,daniel leland fecher,COM-1500,2018
-COM,2010,1,Intr to Comm Studies,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,COM-2010,2018
-COM,2010,2,Intr to Comm Studies,0.67,0.27,0.03,0.03,0.0,0.0,0.0,0.0,john steven  spinda w,COM-2010,2018
-COM,2030,1,Mass Communication Theory,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-2030,2018
-COM,2110,1,Qual Comm Research Methods,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-2110,2018
-COM,2110,2,Qual Comm Research Methods,0.58,0.21,0.16,0.05,0.0,0.0,0.0,0.0,stephanie pangborn,COM-2110,2018
-COM,2500,1,Public Speaking,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,vanessa anne condon,COM-2500,2018
-COM,2500,3,Public Speaking,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,caitlin baker,COM-2500,2018
-COM,2500,5,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2018
-COM,2500,6,Public Speaking,0.47,0.37,0.0,0.11,0.0,0.0,0.0,0.05,vanessa anne condon,COM-2500,2018
-COM,2500,7,Public Speaking,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,sara grumble crocker,COM-2500,2018
-COM,2500,8,Public Speaking,0.53,0.26,0.05,0.05,0.05,0.0,0.0,0.05,sara grumble crocker,COM-2500,2018
-COM,2500,9,Public Speaking,0.44,0.28,0.06,0.06,0.06,0.0,0.0,0.11,sara grumble crocker,COM-2500,2018
-COM,2500,10,Public Speaking,0.56,0.11,0.28,0.0,0.06,0.0,0.0,0.0,sara grumble crocker,COM-2500,2018
-COM,2500,11,Public Speaking,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,alyssa christi davis,COM-2500,2018
-COM,2500,12,Public Speaking,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,alyssa christi davis,COM-2500,2018
-COM,2500,13,Public Speaking,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christi davis,COM-2500,2018
-COM,2500,14,Public Speaking,0.78,0.06,0.06,0.0,0.0,0.0,0.0,0.11,pauline matthey,COM-2500,2018
-COM,2500,15,Public Speaking,0.63,0.16,0.0,0.05,0.0,0.0,0.0,0.16,pauline matthey,COM-2500,2018
-COM,2500,16,Public Speaking,0.59,0.35,0.0,0.0,0.06,0.0,0.0,0.0,pauline matthey,COM-2500,2018
-COM,2500,17,Public Speaking,0.35,0.41,0.06,0.0,0.12,0.0,0.0,0.06,pauline matthey,COM-2500,2018
-COM,2500,18,Public Speaking,0.47,0.42,0.0,0.05,0.0,0.0,0.0,0.05,rachelle lei beckner,COM-2500,2018
-COM,2500,19,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,COM-2500,2018
-COM,2500,20,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,COM-2500,2018
-COM,2500,29,Public Speaking,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jumah patricia taweh,COM-2500,2018
-COM,2500,30,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,COM-2500,2018
-COM,2500,400,Public Speaking,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,alexis zachary davis,COM-2500,2018
-COM,2500,401,Public Speaking,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,COM-2500,2018
-COM,2500,403,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,COM-2500,2018
-COM,3080,1,Public Comm & Pop Culture,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3080,2018
-COM,3080,2,Public Comm & Pop Culture,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-3080,2018
-COM,3080,3,Public Comm & Pop Culture,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,COM-3080,2018
-COM,3240,1,"Communication, Sport & Society",0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,COM-3240,2018
-COM,3240,2,"Communication, Sport & Society",0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,COM-3240,2018
-COM,3250,1,Survey of Sports Communication,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,COM-3250,2018
-COM,3260,1,Pr in Sports,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2018
-COM,3260,3,Pr in Sports,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,COM-3260,2018
-COM,3270,1,Sports Media Criticism,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,COM-3270,2018
-COM,3550,1,Principles of Public Relations,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,meghnaa tallapragada,COM-3550,2018
-COM,3560,1,Crisis Communication,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,andrew stephen pyle,COM-3560,2018
-COM,3570,1,Public Relations Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3570,2018
-COM,3640,1,Organizational Comm,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,kristen elai okamoto,COM-3640,2018
-COM,3660,2,EC: Survey of Brand Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lisa willif papenfus,COM-3660,2018
-COM,3660,4,EC: Digital Analytics & Brand,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,alicia nic littleton,COM-3660,2018
-COM,3690,1,Political Comm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-3690,2018
-COM,4250,1,Adv Sports Comm,0.54,0.38,0.0,0.0,0.08,0.0,0.0,0.0,bryan denham,COM-4250,2018
-COM,4300,1,Legal Communication,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,james isaac roberts,COM-4300,2018
-COM,4720,1,Comm in Health Organizations,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kristen elai okamoto,COM-4720,2018
-CPSC,1010,3,Computer Science I,0.24,0.17,0.24,0.1,0.1,0.0,0.0,0.15,christopher plaue,CPSC-1010,2018
-CPSC,1020,1,Computer Science II,0.28,0.18,0.14,0.1,0.18,0.0,0.0,0.12,yvon feaster,CPSC-1020,2018
-CPSC,1020,2,Computer Science II,0.16,0.26,0.28,0.1,0.12,0.0,0.0,0.08,yvon feaster,CPSC-1020,2018
-CPSC,1070,1,Programming Methodology,0.45,0.19,0.15,0.06,0.07,0.0,0.0,0.07,catherine hochrine,CPSC-1070,2018
-CPSC,1110,1,Intro to Programming in C,0.28,0.18,0.26,0.08,0.18,0.0,0.0,0.02,catherine hochrine,CPSC-1110,2018
-CPSC,1110,2,Intro to Programming in C,0.37,0.35,0.06,0.08,0.14,0.0,0.0,0.0,nicolas benja widman,CPSC-1110,2018
-CPSC,1110,3,Intro to Programming in C,0.46,0.24,0.13,0.04,0.07,0.0,0.0,0.07,nicolas benja widman,CPSC-1110,2018
-CPSC,1110,4,Intro to Programming in C,0.25,0.23,0.23,0.11,0.07,0.0,0.0,0.11,james martin,CPSC-1110,2018
-CPSC,2120,1,Algs/Data Structures,0.26,0.32,0.2,0.06,0.08,0.0,0.0,0.08,brian christoph dean,CPSC-2120,2018
-CPSC,2150,1,Software Dev Foundations,0.27,0.31,0.19,0.03,0.07,0.0,0.0,0.14,kevin anton plis,CPSC-2150,2018
-CPSC,2150,2,Software Dev Foundations,0.32,0.31,0.15,0.07,0.08,0.0,0.0,0.07,kevin anton plis,CPSC-2150,2018
-CPSC,2200,1,Microcomputer Appl,0.46,0.31,0.23,0.0,0.0,0.0,0.0,0.0,kevin anton plis,CPSC-2200,2018
-CPSC,2200,2,Microcomputer Appl,0.22,0.3,0.19,0.15,0.11,0.0,0.0,0.04,kevin anton plis,CPSC-2200,2018
-CPSC,2310,1,Intro Computer Org,0.58,0.24,0.1,0.02,0.04,0.0,0.0,0.02,nicolas benja widman,CPSC-2310,2018
-CPSC,2310,2,Intro Computer Org,0.49,0.22,0.16,0.03,0.08,0.0,0.0,0.03,nicolas benja widman,CPSC-2310,2018
-CPSC,2810,1,Selected Topics: TA Class,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher plaue,CPSC-2810,2018
-CPSC,2810,2,Selected Topics: Cybersecurity,0.76,0.08,0.0,0.0,0.0,0.0,0.0,0.16,yvon feaster,CPSC-2810,2018
-CPSC,2910,1,Prof Issues I,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2018
-CPSC,2910,2,Prof Issues I,0.6,0.25,0.0,0.05,0.0,0.0,0.0,0.1,catherine hochrine,CPSC-2910,2018
-CPSC,2910,3,Prof Issues I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2018
-CPSC,2910,4,Prof Issues I,0.6,0.25,0.0,0.05,0.05,0.0,0.0,0.05,catherine hochrine,CPSC-2910,2018
-CPSC,2910,5,Prof Issues I,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,catherine hochrine,CPSC-2910,2018
-CPSC,2920,1,"Computing, Ethics & Society",0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,julian lang brinkley,CPSC-2920,2018
-CPSC,3120,1,Design Analysis of Algorithms,0.07,0.1,0.14,0.14,0.17,0.0,0.0,0.38,pradip srimani,CPSC-3120,2018
-CPSC,3220,1,Intro to Operating Systems,0.62,0.31,0.03,0.0,0.03,0.0,0.0,0.0,brygg anders ullmer,CPSC-3220,2018
-CPSC,3220,3,Intro to Operating Systems,0.19,0.33,0.29,0.0,0.1,0.0,0.0,0.1,pradip srimani,CPSC-3220,2018
-CPSC,3300,1,Computer Systems Org,0.25,0.25,0.4,0.04,0.03,0.0,0.0,0.03,mark smotherman,CPSC-3300,2018
-CPSC,3500,1,Foundations of Computer Sci,0.28,0.13,0.45,0.04,0.0,0.0,0.0,0.09,ilya mark safro,CPSC-3500,2018
-CPSC,3520,1,Programming Systems,0.39,0.29,0.22,0.0,0.02,0.0,0.0,0.08,robert schalkoff,CPSC-3520,2018
-CPSC,3600,1,Network Programming,0.44,0.29,0.15,0.0,0.08,0.0,0.0,0.03,andrew robb,CPSC-3600,2018
-CPSC,3600,2,Network Programming,0.67,0.21,0.07,0.04,0.0,0.0,0.0,0.02,andrew robb,CPSC-3600,2018
-CPSC,3720,1,Software Engineering,0.27,0.38,0.24,0.05,0.0,0.0,0.0,0.05,eileen there kraemer,CPSC-3720,2018
-CPSC,3720,2,Software Engineering,0.21,0.42,0.25,0.06,0.0,0.0,0.0,0.06,murali sitaraman,CPSC-3720,2018
-CPSC,4040,1,Cmptr Graphics Image,0.29,0.24,0.24,0.0,0.12,0.0,0.0,0.12,ioannis karamouzas,CPSC-4040,2018
-CPSC,4050,1,Computer Graphics,0.24,0.18,0.12,0.12,0.24,0.0,0.0,0.12,andrew duchowski,CPSC-4050,2018
-CPSC,4110,1,Virtual Reality Systems,0.27,0.41,0.22,0.05,0.0,0.0,0.0,0.05,sabarish venkat babu,CPSC-4110,2018
-CPSC,4120,1,Eye Tracking Methodology,0.22,0.61,0.04,0.0,0.04,0.0,0.0,0.09,andrew duchowski,CPSC-4120,2018
-CPSC,4140,1,Human and Computer Interaction,0.21,0.56,0.21,0.03,0.0,0.0,0.0,0.0,nathaniel mcneese,CPSC-4140,2018
-CPSC,4160,1,2-D Game Engine Construction,0.54,0.23,0.06,0.02,0.08,0.0,0.0,0.06,brian malloy,CPSC-4160,2018
-CPSC,4200,1,Computer Security Principles,0.61,0.26,0.08,0.0,0.03,0.0,0.0,0.03,yvon feaster,CPSC-4200,2018
-CPSC,4200,2,Computer Security Principles,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,CPSC-4200,2018
-CPSC,4300,1,Applied Data Science,0.25,0.5,0.08,0.17,0.0,0.0,0.0,0.0,alexander chr herzog,CPSC-4300,2018
-CPSC,4440,1,Cloud Computing Architecture,0.32,0.45,0.18,0.0,0.0,0.0,0.0,0.05,amy apon,CPSC-4440,2018
-CPSC,4620,1,Database Management Systems,0.09,0.22,0.22,0.09,0.13,0.0,0.0,0.26,pradip srimani,CPSC-4620,2018
-CPSC,4820,1,Special Topic: Web Programming,0.56,0.1,0.22,0.06,0.06,0.0,0.0,0.0,craig baker,CPSC-4820,2018
-CPSC,4820,4,Spe Topic: HPC Fault Tolerance,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,jon cameron calhoun,CPSC-4820,2018
-CPSC,6040,1,Cptr Graphics Image,0.5,0.07,0.14,0.0,0.0,0.0,0.0,0.29,ioannis karamouzas,CPSC-6040,2018
-CPSC,6110,1,Virtual Reality Systems,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,sabarish venkat babu,CPSC-6110,2018
-CPSC,6140,1,Human and Computer Interaction,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel mcneese,CPSC-6140,2018
-CPSC,6160,1,2-D Game Engine Construction,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,brian malloy,CPSC-6160,2018
-CPSC,6300,1,Applied Data Science,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,CPSC-6300,2018
-CPSC,6440,1,Cloud Computing Architecture,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,amy apon,CPSC-6440,2018
-CPSC,6620,1,Database Management Systems,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,pradip srimani,CPSC-6620,2018
-CPSC,6780,1,Gen Purpose Computation on GPU,0.4,0.4,0.0,0.0,0.2,0.0,0.0,0.0,shuangshuang jin,CPSC-6780,2018
-CPSC,8170,1,Physically Based Animation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,donald henry house,CPSC-8170,2018
-CPSC,8200,1,Parallel Architechture,0.5,0.3,0.1,0.0,0.1,0.0,0.0,0.0,rong ge,CPSC-8200,2018
-CPSC,8270,1,Translation of Progr Languages,0.74,0.13,0.1,0.0,0.0,0.0,0.0,0.03,brian malloy,CPSC-8270,2018
-CPSC,8380,1,Adv Data Structures,0.3,0.2,0.1,0.0,0.1,0.0,0.0,0.3,sandra hedetniemi,CPSC-8380,2018
-CPSC,8480,1,Network Science,0.31,0.31,0.34,0.0,0.0,0.0,0.0,0.03,ilya mark safro,CPSC-8480,2018
-CPSC,8550,1,Embedded Network Sys,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jacob sorber,CPSC-8550,2018
-CPSC,8580,1,Security in Emerging Systems,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,hongxin hu,CPSC-8580,2018
-CPSC,8810,1,Selected Topics: Intro to BDSI,0.67,0.0,0.0,0.0,0.17,0.0,0.0,0.17,brian christoph dean,CPSC-8810,2018
-CRP,8020,1,Site Planning & Infrastructure,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,CRP-8020,2018
-CSM,1000,1,Intro to Construct,0.92,0.07,0.0,0.0,0.0,0.0,0.0,0.02,nathaniel jackson,CSM-1000,2018
-CSM,2010,1,Structures I,0.36,0.21,0.24,0.07,0.02,0.0,0.0,0.1,shima clarke,CSM-2010,2018
-CSM,2020,1,Structures II,0.24,0.18,0.41,0.12,0.0,0.0,0.0,0.06, kent nilsson,CSM-2020,2018
-CSM,2040,1,Cont Documents,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,robert dawson coffey,CSM-2040,2018
-CSM,3040,1,Envir Systems I,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,CSM-3040,2018
-CSM,3040,2,Envir Systems I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,CSM-3040,2018
-CSM,3060,1,Emerging Tech in Construction,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-3060,2018
-CSM,3060,2,Emerging Tech in Construction,0.17,0.59,0.21,0.03,0.0,0.0,0.0,0.0,jason lucas,CSM-3060,2018
-CSM,3510,1,Construction Estimating,0.29,0.32,0.32,0.06,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,CSM-3510,2018
-CSM,3510,2,Construction Estimating,0.35,0.48,0.1,0.06,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,CSM-3510,2018
-CSM,4500,1,Construction Intern,0.4,0.36,0.25,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,CSM-4500,2018
-CSM,4530,1,Const Proj Mgmt,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4530,2018
-CSM,4530,2,Const Proj Mgmt,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4530,2018
-CSM,8630,400,Adv Plan/Sched,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,craig townsend,CSM-8630,2018
-CSM,8650,1,Project Management,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,dennis bausman,CSM-8650,2018
-CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2018
-CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2018
-CU,1000,16,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2018
-CU,1000,19,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2018
-CU,1000,24,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2018
-CU,1000,26,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2018
-CU,1000,27,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2018
-CU,1000,28,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,CU-1000,2018
-CU,1010,1,Univ Success Skills,0.33,0.17,0.28,0.06,0.11,0.0,0.0,0.06,bryn zimmermann babb,CU-1010,2018
-CU,1010,6,Univ Success Skills,0.21,0.16,0.21,0.16,0.11,0.0,0.0,0.16,valerie kay oonk,CU-1010,2018
-CU,1010,7,Univ Success Skills,0.41,0.24,0.18,0.0,0.12,0.0,0.0,0.06,bryn zimmermann babb,CU-1010,2018
-CU,1010,600,Univ Success Skills,0.38,0.42,0.08,0.0,0.13,0.0,0.0,0.0,elizabeth an stephan,CU-1010,2018
-CU,1010,601,Univ Success Skills,0.5,0.21,0.13,0.04,0.0,0.0,0.0,0.13,bridget trogden,CU-1010,2018
-CU,1010,602,Univ Success Skills,0.46,0.29,0.17,0.0,0.04,0.0,0.0,0.04,laurel ann  whisler c,CU-1010,2018
-CU,1010,603,Univ Success Skills,0.55,0.25,0.2,0.0,0.0,0.0,0.0,0.0,abigail stephan,CU-1010,2018
-DPA,3070,1,Method 3d Production,0.45,0.41,0.1,0.0,0.03,0.0,0.0,0.0,tommy van bui,DPA-3070,2018
-DPA,4000,1,Tech Foundations I,0.24,0.24,0.12,0.0,0.06,0.0,0.0,0.35,jessica baron,DPA-4000,2018
-DPA,4020,1,Vis Foundations I,0.27,0.55,0.0,0.0,0.0,0.0,0.0,0.18,anthony summey,DPA-4020,2018
-DPA,4020,2,Vis Foundations I,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,anthony summey,DPA-4020,2018
-DPA,6000,1,Tech Foundations I,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,victor zordan,DPA-6000,2018
-DPA,8070,843,3D Modeling and Animation,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,matias volonte,DPA-8070,2018
-DPA,8090,1,Rendering and Shading,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,DPA-8090,2018
-ECE,2010,1,Logic and Computing Device,0.12,0.27,0.26,0.16,0.15,0.0,0.0,0.04,william reid,ECE-2010,2018
-ECE,2010,1,Logic and Computing Devices,0.12,0.27,0.26,0.16,0.15,0.0,0.0,0.04,william reid,ECE-2010,2018
-ECE,2010,2,Logic & Comp Device (HON),0.8,0.0,0.1,0.0,0.0,0.0,0.0,0.1,william reid,ECE-2010,2018
-ECE,2020,1,Electric Circuits I,0.34,0.23,0.19,0.07,0.1,0.0,0.0,0.06,william harrell,ECE-2020,2018
-ECE,2070,1,Basic Electrical Engineering,0.42,0.38,0.14,0.03,0.01,0.0,0.0,0.03,william tho kolodzey,ECE-2070,2018
-ECE,2070,2,Basic Electrical Engineering,0.38,0.36,0.14,0.02,0.07,0.0,0.0,0.02,fatemeh tooryan,ECE-2070,2018
-ECE,2070,3,Basic Electrical Engineering,0.57,0.31,0.07,0.0,0.01,0.0,0.0,0.03,timothy anglea,ECE-2070,2018
-ECE,2080,1,Basic Electrical Engr Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,3,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,6,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,7,Basic Electrical Engr Lab,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,8,Basic Electrical Engr Lab,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,10,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,12,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,14,Basic Electrical Engr Lab,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,apoorva deep kapadia,ECE-2080,2018
-ECE,2090,3,Logic Lab,0.75,0.0,0.0,0.08,0.08,0.0,0.0,0.08,apoorva deep kapadia,ECE-2090,2018
-ECE,2090,7,Logic Lab,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva deep kapadia,ECE-2090,2018
-ECE,2090,8,Logic Lab,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deep kapadia,ECE-2090,2018
-ECE,2090,13,Logic Lab,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,apoorva deep kapadia,ECE-2090,2018
-ECE,2090,14,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva deep kapadia,ECE-2090,2018
-ECE,2110,1,Elec Engr Lab I,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,ECE-2110,2018
-ECE,2110,2,Elec Engr Lab I,0.44,0.19,0.13,0.13,0.06,0.0,0.0,0.06,apoorva deep kapadia,ECE-2110,2018
-ECE,2110,3,Elec Engr Lab I,0.45,0.25,0.1,0.1,0.05,0.0,0.0,0.05,apoorva deep kapadia,ECE-2110,2018
-ECE,2110,5,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,apoorva deep kapadia,ECE-2110,2018
-ECE,2110,6,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,ECE-2110,2018
-ECE,2110,10,Elec Engr Lab I,0.7,0.1,0.0,0.0,0.0,0.0,0.0,0.2,apoorva deep kapadia,ECE-2110,2018
-ECE,2120,1,Electrical Engineering Lab II,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,apoorva deep kapadia,ECE-2120,2018
-ECE,2120,4,Electrical Engineering Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2120,2018
-ECE,2220,1,Syst Prog Concept,0.18,0.2,0.05,0.0,0.23,0.0,0.0,0.34,lu yu,ECE-2220,2018
-ECE,2230,1,Comp Sys Eng,0.36,0.16,0.27,0.11,0.04,0.0,0.0,0.07,harlan russell,ECE-2230,2018
-ECE,2620,1,Electric Circuits II,0.2,0.26,0.34,0.04,0.08,0.0,0.0,0.08,liang dong,ECE-2620,2018
-ECE,2720,1,Comp Organization,0.06,0.18,0.35,0.24,0.14,0.0,0.0,0.02,william reid,ECE-2720,2018
-ECE,3110,1,Electrical Engineering Lab III,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3110,2018
-ECE,3110,2,Electrical Engineering Lab III,0.75,0.13,0.0,0.06,0.0,0.0,0.0,0.06,apoorva deep kapadia,ECE-3110,2018
-ECE,3110,3,Electrical Engineering Lab III,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,ECE-3110,2018
-ECE,3110,7,Electrical Engineering Lab III,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3110,2018
-ECE,3110,8,Electrical Engineering Lab III,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva deep kapadia,ECE-3110,2018
-ECE,3120,1,Electrical Engineering Lab IV,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3120,2018
-ECE,3120,2,Electrical Engineering Lab IV,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3120,2018
-ECE,3170,1,Rand Signal Analysis,0.23,0.3,0.26,0.1,0.07,0.0,0.0,0.03,stephen hubbard,ECE-3170,2018
-ECE,3200,1,Electronics I,0.24,0.26,0.22,0.15,0.1,0.0,0.0,0.03,stephen hubbard,ECE-3200,2018
-ECE,3200,2,Electronics I (HON),0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,stephen hubbard,ECE-3200,2018
-ECE,3210,1,Electronics II,0.45,0.3,0.15,0.08,0.03,0.0,0.0,0.0,stephen hubbard,ECE-3210,2018
-ECE,3270,1,Dig Comp Design,0.12,0.2,0.24,0.16,0.08,0.0,0.0,0.2,melissa crawle smith,ECE-3270,2018
-ECE,3300,1,Signals & Systems,0.15,0.25,0.27,0.14,0.08,0.0,0.0,0.1,carl baum,ECE-3300,2018
-ECE,3300,2,Signals & Systems (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,ECE-3300,2018
-ECE,3520,1,Programming Systems,0.36,0.59,0.05,0.0,0.0,0.0,0.0,0.0,robert schalkoff,ECE-3520,2018
-ECE,3600,1,Elect Power Engr,0.49,0.23,0.13,0.09,0.02,0.0,0.0,0.04,edward collins,ECE-3600,2018
-ECE,3710,1,Microcontr Interface,0.47,0.26,0.14,0.1,0.02,0.0,0.0,0.0,william reid,ECE-3710,2018
-ECE,3720,3,Micro Int Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3720,4,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3720,6,Micro Int Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3720,7,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3720,9,Micro Int Lab,0.5,0.25,0.0,0.0,0.25,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3720,11,Micro Int Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3800,1,Electromagnetics,0.27,0.27,0.18,0.13,0.11,0.0,0.0,0.04,anthony martin,ECE-3800,2018
-ECE,3810,1,Field Waves & Ckts,0.41,0.44,0.13,0.0,0.03,0.0,0.0,0.0,hai xiao,ECE-3810,2018
-ECE,4090,1,Intr to Linear Control Systems,0.63,0.33,0.03,0.01,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-4090,2018
-ECE,4180,1,Power Syst Analysis,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,ramtin hadidi,ECE-4180,2018
-ECE,4270,1,Communications Sys,0.33,0.47,0.16,0.0,0.0,0.0,0.0,0.05,lu yu,ECE-4270,2018
-ECE,4310,1,Intro to Computer Vision,0.64,0.28,0.03,0.03,0.03,0.0,0.0,0.0,adam hoover,ECE-4310,2018
-ECE,4420,1,Knowledge Engr,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,robert schalkoff,ECE-4420,2018
-ECE,4490,1,Comp Ntwrk Security,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,richard brooks,ECE-4490,2018
-ECE,4610,1,Fundamentals of Solar Energy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,ECE-4610,2018
-ECE,4670,1,Intro to Dig Sig Pro,0.24,0.18,0.47,0.0,0.0,0.0,0.0,0.12,john gowdy,ECE-4670,2018
-ECE,4730,1,Intro Parallel Sys,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,walter ligon,ECE-4730,2018
-ECE,4950,1,Int Sys Design I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-4950,2018
-ECE,4960,1,Int Sys Design II,0.64,0.27,0.07,0.02,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2018
-ECE,6040,1,Semiconductor Devices,0.57,0.14,0.29,0.0,0.0,0.0,0.0,0.0,judson dougl ryckman,ECE-6040,2018
-ECE,6180,1,Power Syst Analysis,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ramtin hadidi,ECE-6180,2018
-ECE,6310,1,Intro to Computer Vision,0.6,0.15,0.1,0.0,0.0,0.0,0.0,0.15,adam hoover,ECE-6310,2018
-ECE,6490,1,Comp Ntwrk Security,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,richard brooks,ECE-6490,2018
-ECE,6590,1,Int Circ Design,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,ECE-6590,2018
-ECE,6670,1,Intro to Dig Sig Pro,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,john gowdy,ECE-6670,2018
-ECE,8010,1,Analysis of Lin Sys,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,richard groff,ECE-8010,2018
-ECE,8010,843,Analysis of Lin Sys,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,richard groff,ECE-8010,2018
-ECON,2000,2,Economic Concepts,0.31,0.26,0.23,0.13,0.03,0.0,0.0,0.05,shubhashrita basu,ECON-2000,2018
-ECON,2000,4,Economic Concepts,0.38,0.43,0.1,0.0,0.08,0.0,0.0,0.03,miren ivankovic,ECON-2000,2018
-ECON,2000,5,Economic Concepts,0.32,0.34,0.26,0.03,0.05,0.0,0.0,0.0,shubhashrita basu,ECON-2000,2018
-ECON,2110,1,Principles of Microeconomics,0.21,0.26,0.32,0.11,0.05,0.0,0.0,0.05,frederick an hanssen,ECON-2110,2018
-ECON,2110,2,Principles of Microeconomics,0.21,0.32,0.26,0.0,0.11,0.0,0.0,0.11,frederick an hanssen,ECON-2110,2018
-ECON,2110,3,Principles of Microeconomics,0.05,0.32,0.47,0.11,0.0,0.0,0.0,0.05,frederick an hanssen,ECON-2110,2018
-ECON,2110,4,Principles of Microeconomics,0.21,0.42,0.26,0.0,0.05,0.0,0.0,0.05,frederick an hanssen,ECON-2110,2018
-ECON,2110,5,Principles of Microeconomics,0.28,0.22,0.28,0.17,0.06,0.0,0.0,0.0,frederick an hanssen,ECON-2110,2018
-ECON,2110,6,Principles of Microeconomics,0.16,0.37,0.26,0.05,0.11,0.0,0.0,0.05,frederick an hanssen,ECON-2110,2018
-ECON,2110,7,Principles of Microeconomics,0.0,0.5,0.33,0.0,0.06,0.0,0.0,0.11,frederick an hanssen,ECON-2110,2018
-ECON,2110,8,Principles of Microeconomics,0.22,0.28,0.28,0.11,0.06,0.0,0.0,0.06,frederick an hanssen,ECON-2110,2018
-ECON,2110,9,Principles of Microeconomics,0.17,0.39,0.33,0.0,0.0,0.0,0.0,0.11,frederick an hanssen,ECON-2110,2018
-ECON,2110,10,Principles of Microeconomics,0.28,0.28,0.28,0.06,0.06,0.0,0.0,0.06,frederick an hanssen,ECON-2110,2018
-ECON,2110,11,Principles of Microeconomics,0.11,0.42,0.21,0.11,0.0,0.0,0.0,0.16,frederick an hanssen,ECON-2110,2018
-ECON,2110,12,Principles of Microeconomics,0.11,0.26,0.32,0.16,0.05,0.0,0.0,0.11,frederick an hanssen,ECON-2110,2018
-ECON,2110,13,Principles of Microeconomics,0.05,0.58,0.26,0.05,0.05,0.0,0.0,0.0,frederick an hanssen,ECON-2110,2018
-ECON,2110,14,Principles of Microeconomics,0.16,0.53,0.16,0.11,0.05,0.0,0.0,0.0,frederick an hanssen,ECON-2110,2018
-ECON,2110,15,Principles of Microeconomics,0.0,0.33,0.56,0.06,0.06,0.0,0.0,0.0,frederick an hanssen,ECON-2110,2018
-ECON,2110,16,Principles of Microeconomics,0.15,0.4,0.25,0.1,0.1,0.0,0.0,0.0,frederick an hanssen,ECON-2110,2018
-ECON,2110,17,Principles of Microeconomics,0.11,0.21,0.42,0.16,0.05,0.0,0.0,0.05,frederick an hanssen,ECON-2110,2018
-ECON,2110,18,Principles of Microeconomics,0.05,0.53,0.05,0.16,0.16,0.0,0.0,0.05,frederick an hanssen,ECON-2110,2018
-ECON,2110,19,Principles of Microeconomics,0.05,0.42,0.11,0.26,0.05,0.0,0.0,0.11,frederick an hanssen,ECON-2110,2018
-ECON,2110,20,Principles of Microeconomics,0.31,0.32,0.22,0.09,0.04,0.0,0.0,0.01,benjamin posmanick,ECON-2110,2018
-ECON,2110,21,Principles of Microeconomics,0.28,0.46,0.21,0.03,0.0,0.0,0.0,0.03,michael makowsky,ECON-2110,2018
-ECON,2110,23,Principles of Microeconomics,0.2,0.29,0.28,0.08,0.1,0.0,0.0,0.04,roksana ghanbariamin,ECON-2110,2018
-ECON,2110,24,Principles of Microeconomics,0.24,0.34,0.3,0.08,0.02,0.0,0.0,0.03,kelsey victo roberts,ECON-2110,2018
-ECON,2110,25,Principles of Microeconomics,0.28,0.56,0.13,0.0,0.03,0.0,0.0,0.0,chen wang,ECON-2110,2018
-ECON,2110,26,Principles of Microeconomics,0.28,0.28,0.26,0.13,0.02,0.0,0.0,0.02,sarah louise wilson,ECON-2110,2018
-ECON,2110,31,Principles of Microeconomics,0.33,0.29,0.26,0.04,0.08,0.0,0.0,0.0,jonathan orry ernest,ECON-2110,2018
-ECON,2110,32,Principles of Microeconomics,0.28,0.52,0.13,0.02,0.04,0.0,0.0,0.0,jacob walloga,ECON-2110,2018
-ECON,2110,33,Principles of Microeconomics,0.33,0.44,0.13,0.0,0.08,0.0,0.0,0.03,liuna issagholian,ECON-2110,2018
-ECON,2110,34,Principles of Microecon (HON),0.45,0.32,0.18,0.05,0.0,0.0,0.0,0.0,charles thomas,ECON-2110,2018
-ECON,2110,35,Principles of Microeconomics,0.25,0.55,0.2,0.0,0.0,0.0,0.0,0.0,chen wang,ECON-2110,2018
-ECON,2110,36,Principles of Microeconomics,0.28,0.4,0.18,0.08,0.06,0.0,0.0,0.0,roksana ghanbariamin,ECON-2110,2018
-ECON,2110,40,Principles of Microeconomics,0.25,0.36,0.21,0.04,0.14,0.0,0.0,0.0,liuna issagholian,ECON-2110,2018
-ECON,2110,41,Principles of Microeconomics,0.48,0.38,0.1,0.02,0.0,0.0,0.0,0.02,jonathan orry ernest,ECON-2110,2018
-ECON,2120,1,Principles of Macroeconomics,0.3,0.41,0.2,0.04,0.03,0.0,0.0,0.03,elijah neilson,ECON-2120,2018
-ECON,2120,2,Principles of Macroeconomics,0.23,0.36,0.32,0.0,0.04,0.0,0.0,0.04,kenneth whaley,ECON-2120,2018
-ECON,2120,3,Principles of Macroeconomics,0.25,0.43,0.25,0.02,0.0,0.0,0.0,0.05,elijah neilson,ECON-2120,2018
-ECON,2120,4,Principles of Macroeconomics,0.25,0.36,0.28,0.06,0.06,0.0,0.0,0.0,wing yin chung,ECON-2120,2018
-ECON,2120,5,Principles of Macroeconomics,0.29,0.39,0.26,0.03,0.0,0.0,0.0,0.03,narendra regmi,ECON-2120,2018
-ECON,2120,6,Principles of Macroeconomics,0.45,0.33,0.13,0.08,0.0,0.0,0.0,0.03,kenneth whaley,ECON-2120,2018
-ECON,2120,7,Principles of Macroeconomics,0.51,0.18,0.18,0.08,0.05,0.0,0.0,0.0,narendra regmi,ECON-2120,2018
-ECON,2120,8,Principles of Macroeconomics,0.67,0.21,0.02,0.0,0.05,0.0,0.0,0.05,tyler francis,ECON-2120,2018
-ECON,2120,9,Principles of Macroeconomics,0.88,0.07,0.05,0.0,0.0,0.0,0.0,0.0,tyler francis,ECON-2120,2018
-ECON,2120,10,Principles of Macroeconomics,0.23,0.36,0.31,0.03,0.05,0.0,0.0,0.03,kyle lance rechard,ECON-2120,2018
-ECON,3020,1,Money and Banking,0.18,0.31,0.33,0.1,0.0,0.0,0.0,0.08,smriti bhargava,ECON-3020,2018
-ECON,3060,1,Managerial Economics,0.2,0.25,0.25,0.18,0.08,0.0,0.0,0.05,steven johnson,ECON-3060,2018
-ECON,3100,1,International Econ,0.19,0.54,0.17,0.06,0.03,0.0,0.0,0.01,scott baier,ECON-3100,2018
-ECON,3140,1,Intermediate Micro,0.28,0.15,0.18,0.08,0.15,0.0,0.0,0.15,patrick warren,ECON-3140,2018
-ECON,3140,2,Intermediate Micro,0.17,0.57,0.15,0.07,0.0,0.0,0.0,0.05,molly espey,ECON-3140,2018
-ECON,3140,3,Intermediate Micro,0.27,0.31,0.2,0.08,0.06,0.0,0.0,0.08,robert kenneth fleck,ECON-3140,2018
-ECON,3140,5,Intermediate Micro,0.26,0.22,0.22,0.15,0.07,0.0,0.0,0.07,yichen christy zhou,ECON-3140,2018
-ECON,3150,1,Intermediate Macro,0.86,0.05,0.02,0.0,0.02,0.0,0.0,0.05,jeremy choquette,ECON-3150,2018
-ECON,3150,2,Intermediate Macro,0.39,0.24,0.17,0.1,0.05,0.0,0.0,0.05,michal jerzmanowski,ECON-3150,2018
-ECON,3190,1,Environmental Econ,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,molly espey,ECON-3190,2018
-ECON,3600,1,Public Choice,0.37,0.29,0.21,0.08,0.0,0.0,0.0,0.05,michael makowsky,ECON-3600,2018
-ECON,4010,1,Labor Mkt Analysis,0.5,0.25,0.08,0.0,0.08,0.0,0.0,0.08,chungsang lam,ECON-4010,2018
-ECON,4020,1,Law and Economics,0.23,0.5,0.15,0.05,0.03,0.0,0.0,0.05,howard nel bodenhorn,ECON-4020,2018
-ECON,4040,1,Comp Econ Systems,0.33,0.07,0.2,0.07,0.13,0.0,0.0,0.2,dari litsukova-bokar,ECON-4040,2018
-ECON,4050,5,Intro to Econometric,0.25,0.23,0.35,0.08,0.06,0.0,0.0,0.04,scott barkowski,ECON-4050,2018
-ECON,4100,1,Economic Development,0.72,0.14,0.03,0.0,0.03,0.0,0.0,0.07,robert tamura,ECON-4100,2018
-ECON,4120,1,International Micro,0.35,0.26,0.17,0.0,0.0,0.0,0.0,0.22,scott baier,ECON-4120,2018
-ECON,4130,1,International Macro,0.45,0.36,0.0,0.0,0.09,0.0,0.0,0.09,michal jerzmanowski,ECON-4130,2018
-ECON,4230,1,Economics of Health,0.51,0.34,0.11,0.0,0.0,0.0,0.0,0.03,devon merritt gorry,ECON-4230,2018
-ECON,4240,1,Organization of Ind,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,matthew lewis,ECON-4240,2018
-ECON,4240,2,Organization of Ind,0.72,0.1,0.1,0.03,0.0,0.0,0.0,0.03,matthew lewis,ECON-4240,2018
-ECON,4250,1,Antitrust Economics,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.12,raymond sauer,ECON-4250,2018
-ECON,4260,1,Sem Sport Economics,0.63,0.3,0.0,0.0,0.0,0.0,0.0,0.07,raymond sauer,ECON-4260,2018
-ECON,4280,1,Cost-Benefit Anlysis,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,robert kenneth fleck,ECON-4280,2018
-ECON,4980,3,Econ of Entertainment Industry,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,frederick an hanssen,ECON-4980,2018
-ECON,4980,4,Sel Topic - Why Business?,0.44,0.33,0.19,0.04,0.0,0.0,0.0,0.0,bradley keith hobbs,ECON-4980,2018
-ECON,4980,5,Sel Topics-Cryptocurrency,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,gerald dwyer,ECON-4980,2018
-ECON,6050,5,Intro to Econometric,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott barkowski,ECON-6050,2018
-ECON,8010,1,Microeconomic Theory,0.5,0.13,0.38,0.0,0.0,0.0,0.0,0.0,william dougan,ECON-8010,2018
-ECON,8040,1,Applied Math Econ,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,ECON-8040,2018
-ECON,8060,1,Econometrics I,0.13,0.38,0.38,0.0,0.13,0.0,0.0,0.0,paul wayne wilson,ECON-8060,2018
-ECON,8080,1,Econometrics III,0.17,0.5,0.17,0.0,0.17,0.0,0.0,0.0,paul wayne wilson,ECON-8080,2018
-ECON,8230,1,Microecon Pub Pol,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,ECON-8230,2018
-ECON,8990,3,Industrial Organization Theory,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,charles thomas,ECON-8990,2018
-ECON,8990,5,Sel Topics - Macro Theory II,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,christopher as gorry,ECON-8990,2018
-ED,1050,1,Educ Orientation,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,jennifer michel hein,ED-1050,2018
-ED,1050,3,Educ Orientation,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,ED-1050,2018
-ED,1050,7,Educ Orientation,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,ED-1050,2018
-ED,1050,8,Educ Orientation,0.84,0.08,0.0,0.0,0.0,0.0,0.0,0.08,amaris joseph tejada,ED-1050,2018
-ED,1970,1,CI-CONNECTIONS Stud Developmnt,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2018
-ED,1970,2,CI-CONNECTIONS Stud Developmnt,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2018
-ED,1970,3,CI-CONNECTIONS Stud Developmnt,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2018
-ED,1970,4,CI-CONNECTIONS Stud Developmnt,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2018
-ED,1970,5,CI-CONNECTIONS Stud Developmnt,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2018
-ED,1970,6,CI-CONNECTIONS Stud Developmnt,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,deonte brown,ED-1970,2018
-ED,3010,1,Principles of American Educat,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohammad khan,ED-3010,2018
-ED,8750,321,Elements of Instructional Effe,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,susan ridg nunamaker,ED-8750,2018
-ED,9540,1,Curriculum Theory,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,ED-9540,2018
-EDC,3900,2,Skills for Student Leaders,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2018
-EDC,3900,5,Skills for Student Leaders,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,EDC-3900,2018
-EDC,3990,1,Creative Inq in Counselor Ed,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,jacob frankovich,EDC-3990,2018
-EDEC,3000,1,Found Early Chld Ed,0.91,0.0,0.0,0.03,0.03,0.0,0.0,0.03,jill chandle shelnut,EDEC-3000,2018
-EDEC,3010,1,Early Childhood Practicum I,0.89,0.0,0.0,0.04,0.04,0.0,0.0,0.04,jennifer schumpert,EDEC-3010,2018
-EDEC,4300,1,Early Childhd Math,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sandra mamman linder,EDEC-4300,2018
-EDEC,4400,1,Early Childhood Engl Lang Art,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-4400,2018
-EDEC,8100,312,Adv Ece Found & Meth,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,sandra mamman linder,EDEC-8100,2018
-EDEL,3210,1,Pe for the Elem Tchr,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2018
-EDEL,3210,2,Pe for the Elem Tchr,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2018
-EDEL,4870,2,Ele Meth Soc Studies,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,melinda spearman,EDEL-4870,2018
-EDEL,4880,2,Elem Language Arts Teaching,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,jacquelynn malloy,EDEL-4880,2018
-EDF,3020,2,Educational Psychology,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,meihua qian,EDF-3020,2018
-EDF,3340,1,Child Growth and Development,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoob jamil,EDF-3340,2018
-EDF,3340,3,Child Growth and Development,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,faiza marghoob jamil,EDF-3340,2018
-EDF,3350,1,Adolescent Growth & Develop,0.41,0.27,0.18,0.05,0.0,0.0,0.0,0.09,david barrett,EDF-3350,2018
-EDF,4800,2,Digital Media & Learning,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,anne mcmahan grant,EDF-4800,2018
-EDF,8080,312,Contempor Issues in Assessment,0.8,0.12,0.04,0.0,0.0,0.0,0.0,0.04,eliza darg gallagher,EDF-8080,2018
-EDF,8710,400,Cultural Diversity in Educatio,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,reginald wilkerson,EDF-8710,2018
-EDF,9020,1,Learning Sciences Seminar II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,EDF-9020,2018
-EDF,9270,401,Quant Rsrch & Stats for Ed,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,russell aubre marion,EDF-9270,2018
-EDHD,3110,1,CI- Research in DM & Learning,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.07,david matthew boyer,EDHD-3110,2018
-EDL,7150,503,Sch & Comm Relations,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,EDL-7150,2018
-EDL,7400,500,Curr Plan: Sch Adm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,daniella hall,EDL-7400,2018
-EDL,7400,501,Curr Plan: Sch Adm,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,daniella hall,EDL-7400,2018
-EDL,9110,400,Systematic Inq Ed L,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,jane lindle,EDL-9110,2018
-EDL,9770,1,Div Issues in Hi Ed,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robin je phelps-ward,EDL-9770,2018
-EDLT,4610,1,Content Area Read/Writing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-4610,2018
-EDLT,4800,1,Found in Adolescent Literacy,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,phillip micha wilder,EDLT-4800,2018
-EDLT,4800,2,Found in Adolescent Literacy,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,phillip micha wilder,EDLT-4800,2018
-EDLT,8150,500,Guided Reading & Guided Writng,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,susan king fullerton,EDLT-8150,2018
-EDLT,8170,300,Content Area Rdg/Wtg: ECE-ELEM,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8170,2018
-EDLT,8170,500,Content Area Rdg/Wtg: ECE-ELEM,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8170,2018
-EDLT,8220,500,Strategies for Teaching ESOL,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-8220,2018
-EDLT,8240,300,Practicum in ESOL,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,rebecca kaminski,EDLT-8240,2018
-EDLT,8400,501,Early Literacy Assessment I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,EDLT-8400,2018
-EDLT,8400,502,Early Literacy Assessment I,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,antoinett dibellonia,EDLT-8400,2018
-EDLT,8400,506,Early Literacy Assessment I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jo anne solesbee,EDLT-8400,2018
-EDLT,8800,505,Reading Recovery Teacher I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,EDLT-8800,2018
-EDSC,2260,1,Pr Apprch to Sec Alg,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,stacy megan che,EDSC-2260,2018
-EDSP,3700,1,Intro to Special Education,0.74,0.18,0.06,0.03,0.0,0.0,0.0,0.0,friggita johnson,EDSP-3700,2018
-EDSP,3720,1,Char & Instr Individ with LD,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,EDSP-3720,2018
-EDSP,4920,1,Math Inst Ind W/Dis,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,pamela stecker,EDSP-4920,2018
-EDSP,4930,1,Clsrm/Beh Mgmt Sp Ed,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,joseph benedict ryan,EDSP-4930,2018
-EDSP,4940,1,Tchg Rdg Mild Dis,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,abigail anne allen,EDSP-4940,2018
-EDSP,4960,1,Sp Ed Field Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,wendell kent parker,EDSP-4960,2018
-EDSP,4970,1,Sec Meth Ind W/Dis,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,wendell kent parker,EDSP-4970,2018
-EDSP,8120,400,Learning Disabilities Prac Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,catherine griffith,EDSP-8120,2018
-EDSP,8220,400,Tchg Math Indv W/Dis,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,pamela stecker,EDSP-8220,2018
-EDSP,8530,1,Legal/Pol Issu Sp Ed,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,EDSP-8530,2018
-EES,2010,1,Environ Engr Fundamentals I,0.31,0.33,0.14,0.0,0.11,0.0,0.0,0.11,david freedman,EES-2010,2018
-EES,3030,1,Water Treatment Systems,0.41,0.38,0.14,0.03,0.03,0.0,0.0,0.0,david allen ladner,EES-3030,2018
-EES,3040,1,Wastewater Treatment Systems,0.31,0.45,0.17,0.07,0.0,0.0,0.0,0.0,sudeep popat,EES-3040,2018
-EES,3050,1,Water/Wastewater Treatment Lab,0.38,0.38,0.19,0.06,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2018
-EES,3050,2,Water/Wastewater Treatment Lab,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,sudeep popat,EES-3050,2018
-EES,4010,1,Environmental Engr,0.82,0.16,0.03,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,EES-4010,2018
-EES,4010,2,Environmental Engr,0.27,0.53,0.13,0.03,0.03,0.0,0.0,0.0,mark schlautman,EES-4010,2018
-EES,4090,1,Intro to Nuc Engr & Radiol Sci,0.18,0.53,0.12,0.12,0.0,0.0,0.0,0.06,timothy devol,EES-4090,2018
-EES,4300,1,Air Pollution Engineering,0.44,0.31,0.14,0.0,0.03,0.0,0.0,0.08,andrew richa metcalf,EES-4300,2018
-EES,4800,1,Environmental Risk Assessment,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,nicole eliz martinez,EES-4800,2018
-EES,4840,1,Solid Waste Mgt,0.35,0.46,0.08,0.08,0.04,0.0,0.0,0.0,ezra lucas hoy cates hoy,EES-4840,2018
-EES,4860,1,Environmental Sustainability,0.78,0.15,0.04,0.0,0.0,0.0,0.0,0.04,michael anthony dale,EES-4860,2018
-EES,8020,1,Environ Eng Prin,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-8020,2018
-EES,8430,1,Environmental Chem,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,EES-8430,2018
-EES,8510,1,Biol Prin Envir Engr,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,kevin thoma finneran,EES-8510,2018
-EES,8800,1,Env Risk Assessment,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,EES-8800,2018
-ELE,3010,1,Entrepreneurial Foundations,0.19,0.37,0.37,0.01,0.0,0.0,0.0,0.04,ashley willi parnell,ELE-3010,2018
-ELE,3010,2,Entrepreneurial Foundations,0.12,0.34,0.36,0.12,0.0,0.0,0.0,0.06,ashley willi parnell,ELE-3010,2018
-ELE,3020,1,Entrepreneurial Resource Acqu,0.36,0.44,0.17,0.0,0.0,0.0,0.0,0.03,karl bruce kelly,ELE-3020,2018
-ELE,3020,2,Entrepreneurial Resource Acqu,0.26,0.71,0.03,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,ELE-3020,2018
-ELE,4020,1,Venture Creation,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,ELE-4020,2018
-ELE,4990,1,Venture Consulting,0.49,0.46,0.05,0.0,0.0,0.0,0.0,0.0,christina kyprianou,ELE-4990,2018
-ELE,4990,2,Venture Counsulting,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,christina kyprianou,ELE-4990,2018
-ENGL,1030,1,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,allen swords,ENGL-1030,2018
-ENGL,1030,2,Composition and Rhetoric,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-1030,2018
-ENGL,1030,3,Composition and Rhetoric,0.26,0.26,0.26,0.05,0.05,0.0,0.0,0.11,chelsea marie clarey,ENGL-1030,2018
-ENGL,1030,4,Composition and Rhetoric,0.75,0.06,0.0,0.13,0.0,0.0,0.0,0.06,stephanie stripling,ENGL-1030,2018
-ENGL,1030,6,Composition and Rhetoric,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,ENGL-1030,2018
-ENGL,1030,8,Composition and Rhetoric,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,chelsea marie clarey,ENGL-1030,2018
-ENGL,1030,10,Composition and Rhetoric,0.42,0.32,0.16,0.11,0.0,0.0,0.0,0.0,allison nicol harris,ENGL-1030,2018
-ENGL,1030,11,Composition and Rhetoric,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,allison nicol harris,ENGL-1030,2018
-ENGL,1030,13,Composition and Rhetoric,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,julia brownlee koets,ENGL-1030,2018
-ENGL,1030,18,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,ENGL-1030,2018
-ENGL,1030,19,Composition and Rhetoric,0.74,0.11,0.11,0.05,0.0,0.0,0.0,0.0,stephanie stripling,ENGL-1030,2018
-ENGL,1030,23,Composition and Rhetoric,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,charissa fryberger,ENGL-1030,2018
-ENGL,1030,24,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,charissa fryberger,ENGL-1030,2018
-ENGL,1030,27,Composition and Rhetoric,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,naomi marie white,ENGL-1030,2018
-ENGL,1030,29,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,eric reid hamilton,ENGL-1030,2018
-ENGL,1030,32,Composition and Rhetoric,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,blake elizabe bowens,ENGL-1030,2018
-ENGL,1030,33,Composition and Rhetoric,0.47,0.32,0.11,0.0,0.05,0.0,0.0,0.05,geveryl lee robinson,ENGL-1030,2018
-ENGL,1030,34,Composition and Rhetoric,0.42,0.26,0.16,0.05,0.11,0.0,0.0,0.0,geveryl lee robinson,ENGL-1030,2018
-ENGL,1030,35,Composition and Rhetoric,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,blake elizabe bowens,ENGL-1030,2018
-ENGL,1030,37,Composition and Rhetoric,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,naomi marie white,ENGL-1030,2018
-ENGL,1030,38,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,ENGL-1030,2018
-ENGL,1030,39,Composition and Rhetoric,0.58,0.26,0.05,0.0,0.0,0.0,0.0,0.11,julie edewaard,ENGL-1030,2018
-ENGL,1030,40,Composition and Rhetoric,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,julie edewaard,ENGL-1030,2018
-ENGL,1030,41,Composition and Rhetoric,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,myers addison enlow,ENGL-1030,2018
-ENGL,1030,42,Composition and Rhetoric,0.63,0.16,0.11,0.0,0.11,0.0,0.0,0.0,myers addison enlow,ENGL-1030,2018
-ENGL,1030,43,Composition and Rhetoric,0.63,0.16,0.11,0.0,0.05,0.0,0.0,0.05,jennie eli wakefield,ENGL-1030,2018
-ENGL,1030,44,Composition and Rhetoric,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,caroline eliza young,ENGL-1030,2018
-ENGL,1030,45,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,ENGL-1030,2018
-ENGL,1030,46,Composition and Rhetoric,0.68,0.21,0.0,0.11,0.0,0.0,0.0,0.0,jennie eli wakefield,ENGL-1030,2018
-ENGL,1030,47,Composition and Rhetoric,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,chloe miche whitaker,ENGL-1030,2018
-ENGL,1030,48,Composition and Rhetoric,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,chloe miche whitaker,ENGL-1030,2018
-ENGL,1030,51,Composition and Rhetoric,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,victoria houser,ENGL-1030,2018
-ENGL,1030,52,Composition and Rhetoric,0.68,0.05,0.16,0.05,0.05,0.0,0.0,0.0,victoria houser,ENGL-1030,2018
-ENGL,1030,53,Composition and Rhetoric,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,michelle lloyd,ENGL-1030,2018
-ENGL,1030,55,Composition and Rhetoric,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,michelle lloyd,ENGL-1030,2018
-ENGL,1030,61,Composition and Rhetoric,0.53,0.26,0.16,0.05,0.0,0.0,0.0,0.0,andrew mathas,ENGL-1030,2018
-ENGL,1030,71,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,shauna chung,ENGL-1030,2018
-ENGL,1030,73,Composition and Rhetoric,0.21,0.68,0.0,0.0,0.0,0.0,0.0,0.11,la'cresha ulon green,ENGL-1030,2018
-ENGL,1030,74,Composition and Rhetoric,0.22,0.44,0.11,0.06,0.0,0.0,0.0,0.17,la'cresha ulon green,ENGL-1030,2018
-ENGL,1030,75,Composition and Rhetoric,0.39,0.33,0.06,0.0,0.0,0.0,0.0,0.22,kristian wilson,ENGL-1030,2018
-ENGL,1030,76,Composition and Rhetoric,0.32,0.32,0.05,0.05,0.0,0.0,0.0,0.26,kristian wilson,ENGL-1030,2018
-ENGL,1030,82,Composition and Rhetoric,0.22,0.5,0.17,0.0,0.06,0.0,0.0,0.06,andrew mathas,ENGL-1030,2018
-ENGL,1030,83,Composition and Rhetoric,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,ENGL-1030,2018
-ENGL,2120,3,World Literature,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathle nalley,ENGL-2120,2018
-ENGL,2120,5,World Literature,0.11,0.58,0.21,0.05,0.05,0.0,0.0,0.0,sarah mae cooper,ENGL-2120,2018
-ENGL,2120,6,World Literature,0.17,0.5,0.22,0.06,0.0,0.0,0.0,0.06,david charles foltz,ENGL-2120,2018
-ENGL,2120,7,World Literature,0.22,0.39,0.11,0.11,0.0,0.0,0.0,0.17,david charles foltz,ENGL-2120,2018
-ENGL,2120,9,World Literature,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,hannah pittma godwin,ENGL-2120,2018
-ENGL,2120,10,World Literature,0.47,0.26,0.21,0.0,0.0,0.0,0.0,0.05,hannah pittma godwin,ENGL-2120,2018
-ENGL,2120,11,World Literature,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,hannah pittma godwin,ENGL-2120,2018
-ENGL,2120,12,World Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathle nalley,ENGL-2120,2018
-ENGL,2120,13,World Literature,0.42,0.26,0.11,0.11,0.0,0.0,0.0,0.11,heather pri williams,ENGL-2120,2018
-ENGL,2120,15,World Literature,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,chloe miche whitaker,ENGL-2120,2018
-ENGL,2120,19,World Literature,0.37,0.37,0.21,0.0,0.0,0.0,0.0,0.05,chloe miche whitaker,ENGL-2120,2018
-ENGL,2120,20,World Literature,0.47,0.21,0.16,0.0,0.11,0.0,0.0,0.05,hannah pittma godwin,ENGL-2120,2018
-ENGL,2120,21,World Literature,0.33,0.17,0.33,0.0,0.08,0.0,0.0,0.08,gabriel ande hankins,ENGL-2120,2018
-ENGL,2120,400,World Literature,0.19,0.48,0.19,0.04,0.04,0.0,0.0,0.07,sarah mae cooper,ENGL-2120,2018
-ENGL,2120,401,World Literature,0.18,0.47,0.18,0.06,0.06,0.0,0.0,0.06,sarah mae cooper,ENGL-2120,2018
-ENGL,2120,402,World Literature,0.73,0.15,0.08,0.0,0.04,0.0,0.0,0.0,heather pri williams,ENGL-2120,2018
-ENGL,2120,403,World Literature,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.04,keri ja crist-wagner,ENGL-2120,2018
-ENGL,2130,3,British Literature,0.37,0.21,0.21,0.05,0.11,0.0,0.0,0.05,megan noe macalystre,ENGL-2130,2018
-ENGL,2130,4,British Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john morgenstern,ENGL-2130,2018
-ENGL,2130,5,British Literature,0.63,0.16,0.16,0.0,0.0,0.0,0.0,0.05,lucian ghita,ENGL-2130,2018
-ENGL,2130,6,British Literature,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,kriste aldebol-hazle,ENGL-2130,2018
-ENGL,2130,7,British Literature,0.37,0.37,0.05,0.05,0.0,0.0,0.0,0.16,megan noe macalystre,ENGL-2130,2018
-ENGL,2130,9,British Literature,0.32,0.42,0.16,0.05,0.05,0.0,0.0,0.0,megan noe macalystre,ENGL-2130,2018
-ENGL,2130,10,British Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2018
-ENGL,2130,11,British Literature,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,christopher benson,ENGL-2130,2018
-ENGL,2130,12,British Literature,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2018
-ENGL,2130,13,British Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2018
-ENGL,2130,400,British Literature,0.37,0.48,0.07,0.0,0.04,0.0,0.0,0.04,daniel scott citro,ENGL-2130,2018
-ENGL,2130,401,British Literature,0.39,0.43,0.11,0.04,0.0,0.0,0.0,0.04,daniel scott citro,ENGL-2130,2018
-ENGL,2130,402,British Literature,0.48,0.24,0.2,0.0,0.04,0.0,0.0,0.04,kriste aldebol-hazle,ENGL-2130,2018
-ENGL,2140,1,American Literature,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2018
-ENGL,2140,5,American Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2018
-ENGL,2140,6,American Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,ENGL-2140,2018
-ENGL,2140,7,American Literature,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,ENGL-2140,2018
-ENGL,2140,8,American Literature,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john robert smith,ENGL-2140,2018
-ENGL,2140,14,American Literature,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,melissa dugan,ENGL-2140,2018
-ENGL,2140,17,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2018
-ENGL,2140,400,American Literature,0.84,0.12,0.0,0.04,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2018
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,allen swords,ENGL-2150,2018
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-2150,2018
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.26,0.42,0.11,0.05,0.05,0.0,0.0,0.11,john logan pursley,ENGL-2150,2018
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.47,0.37,0.05,0.11,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2018
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,sharon kathle nalley,ENGL-2150,2018
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.42,0.32,0.05,0.11,0.0,0.0,0.0,0.11,andrew mathas,ENGL-2150,2018
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.47,0.35,0.06,0.0,0.12,0.0,0.0,0.0,andrew mathas,ENGL-2150,2018
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,david charles foltz,ENGL-2150,2018
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.16,0.21,0.05,0.05,0.0,0.0,0.0,elizabeth stansell,ENGL-2150,2018
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-2150,2018
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,allison nicol harris,ENGL-2150,2018
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.84,0.0,0.05,0.05,0.05,0.0,0.0,0.0,john logan pursley,ENGL-2150,2018
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,remley meliss makala,ENGL-2150,2018
-ENGL,2150,18,Lit in 20th-21st Cent Contexts,0.37,0.37,0.11,0.0,0.11,0.0,0.0,0.05,chelsea marie clarey,ENGL-2150,2018
-ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.47,0.32,0.11,0.0,0.05,0.0,0.0,0.05,david charles foltz,ENGL-2150,2018
-ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.44,0.39,0.06,0.0,0.0,0.0,0.0,0.11,david charles foltz,ENGL-2150,2018
-ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,allison nicol harris,ENGL-2150,2018
-ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2150,2018
-ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.37,0.42,0.11,0.05,0.0,0.0,0.0,0.05,chelsea marie clarey,ENGL-2150,2018
-ENGL,2150,26,Lit in 20th-21st Cent Contexts,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,daniel scott citro,ENGL-2150,2018
-ENGL,2150,27,Lit in 20th-21st Cent Contexts,0.72,0.11,0.11,0.06,0.0,0.0,0.0,0.0,remley meliss makala,ENGL-2150,2018
-ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.42,0.19,0.19,0.0,0.04,0.0,0.0,0.15,candace wiley,ENGL-2150,2018
-ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.37,0.11,0.15,0.15,0.07,0.0,0.0,0.15,candace wiley,ENGL-2150,2018
-ENGL,2150,402,Lit in 20th-21st Cent Contexts,0.56,0.26,0.15,0.04,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-2150,2018
-ENGL,2150,403,Lit in 20th-21st Cent Contexts,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,allison nicol harris,ENGL-2150,2018
-ENGL,3010,1,Great Books of Western World,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,dominic mastroianni,ENGL-3010,2018
-ENGL,3040,1,Business Writing,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,ENGL-3040,2018
-ENGL,3040,3,Business Writing,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulon green,ENGL-3040,2018
-ENGL,3040,4,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulon green,ENGL-3040,2018
-ENGL,3040,5,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,ENGL-3040,2018
-ENGL,3040,12,Business Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,heather pri williams,ENGL-3040,2018
-ENGL,3040,15,Business Writing,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,katalin beck,ENGL-3040,2018
-ENGL,3040,16,Business Writing,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3040,2018
-ENGL,3040,19,Business Writing,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,ENGL-3040,2018
-ENGL,3040,20,Business Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,ENGL-3040,2018
-ENGL,3040,400,Business Writing,0.85,0.05,0.1,0.0,0.0,0.0,0.0,0.0,kriste aldebol-hazle,ENGL-3040,2018
-ENGL,3040,401,Business Writing,0.78,0.0,0.17,0.06,0.0,0.0,0.0,0.0,kriste aldebol-hazle,ENGL-3040,2018
-ENGL,3040,402,Business Writing,0.47,0.37,0.05,0.0,0.11,0.0,0.0,0.0,sean williams,ENGL-3040,2018
-ENGL,3100,1,Crit Writ Lit,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth rivlin,ENGL-3100,2018
-ENGL,3100,2,Crit Writ Lit,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,cameron fae bushnell,ENGL-3100,2018
-ENGL,3100,3,Crit Writ Lit,0.58,0.21,0.11,0.0,0.0,0.0,0.0,0.11,kimberly manganelli,ENGL-3100,2018
-ENGL,3100,4,Crit Writ Lit,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,ENGL-3100,2018
-ENGL,3120,1,Advanced Composition,0.82,0.0,0.12,0.0,0.06,0.0,0.0,0.0,christopher stuart,ENGL-3120,2018
-ENGL,3120,2,Advanced Composition,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,christopher stuart,ENGL-3120,2018
-ENGL,3120,3,Advanced Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,ENGL-3120,2018
-ENGL,3140,1,Technical Writing,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,william pulley,ENGL-3140,2018
-ENGL,3140,2,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2018
-ENGL,3140,4,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,ENGL-3140,2018
-ENGL,3140,6,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,beltran dian quaglia,ENGL-3140,2018
-ENGL,3140,8,Technical Writing,0.79,0.05,0.05,0.05,0.0,0.0,0.0,0.05,brian lee gaines,ENGL-3140,2018
-ENGL,3140,11,Technical Writing,0.5,0.33,0.06,0.06,0.0,0.0,0.0,0.06,geveryl lee robinson,ENGL-3140,2018
-ENGL,3140,12,Technical Writing,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,geveryl lee robinson,ENGL-3140,2018
-ENGL,3140,13,Technical Writing,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,april obrien,ENGL-3140,2018
-ENGL,3140,14,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,april obrien,ENGL-3140,2018
-ENGL,3140,16,Technical Writing,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2018
-ENGL,3140,22,Technical Writing,0.74,0.11,0.0,0.0,0.05,0.0,0.0,0.11,michael david measel,ENGL-3140,2018
-ENGL,3140,100,Technical Writing (HONORS),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2018
-ENGL,3150,1,Scientific Writing & Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-3150,2018
-ENGL,3150,2,Scientific Writing & Comm,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-3150,2018
-ENGL,3150,3,Scientific Writing & Comm,0.53,0.24,0.06,0.06,0.0,0.0,0.0,0.12,william pulley,ENGL-3150,2018
-ENGL,3150,4,Scientific Writing & Comm,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,william pulley,ENGL-3150,2018
-ENGL,3150,400,Scientific Writing & Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2018
-ENGL,3150,401,Scientific Writing & Comm,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2018
-ENGL,3150,402,Scientific Writing & Comm,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2018
-ENGL,3150,403,Scientific Writing & Comm,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2018
-ENGL,3150,405,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2018
-ENGL,3450,1,Intr Creative Writing: Fiction,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nicholas chris brown,ENGL-3450,2018
-ENGL,3460,2,Intr Creative Writing: Poetry,0.61,0.22,0.06,0.06,0.0,0.0,0.0,0.06,sharon kathle nalley,ENGL-3460,2018
-ENGL,3480,1,Intr Creat Writ: Screenwriting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,ENGL-3480,2018
-ENGL,3480,2,Intr Creat Writ: Screenwriting,0.67,0.17,0.0,0.0,0.06,0.0,0.0,0.11,julia brownlee koets,ENGL-3480,2018
-ENGL,3570,1,Film,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,ENGL-3570,2018
-ENGL,3800,1,Women Writers,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,remley meliss makala,ENGL-3800,2018
-ENGL,3850,1,Children's Lit,0.6,0.27,0.0,0.0,0.13,0.0,0.0,0.0,megan noe macalystre,ENGL-3850,2018
-ENGL,3860,1,Adolescent Lit,0.12,0.65,0.24,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-3860,2018
-ENGL,3970,2,Brit Lit Survey II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,ENGL-3970,2018
-ENGL,3980,2,Amer Lit Survey I,0.26,0.63,0.05,0.0,0.0,0.0,0.0,0.05,susanna ashton,ENGL-3980,2018
-ENGL,4010,1,Grammar Survey,0.68,0.11,0.11,0.05,0.05,0.0,0.0,0.0,william stockton,ENGL-4010,2018
-ENGL,4080,1,Chaucer,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,andrew lemons,ENGL-4080,2018
-ENGL,4180,1,English Novel,0.09,0.64,0.18,0.0,0.0,0.0,0.0,0.09,lee morrissey,ENGL-4180,2018
-ENGL,4200,1,Amer Lit to 1799,0.4,0.4,0.0,0.0,0.07,0.0,0.0,0.13,jonathan beech field,ENGL-4200,2018
-ENGL,4210,1,Amer Lit 1800-1899,0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,dominic mastroianni,ENGL-4210,2018
-ENGL,4280,1,Contemporary Literature,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,matthew hooley,ENGL-4280,2018
-ENGL,4310,1,Modern Poetry,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-4310,2018
-ENGL,4360,1,Feminist Literary Criticism,0.47,0.29,0.12,0.06,0.0,0.0,0.0,0.06,erin marina goss,ENGL-4360,2018
-ENGL,4400,1,Literary Theory,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,maria selene bose,ENGL-4400,2018
-ENGL,4420,1,Cultural Studies,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,maria selene bose,ENGL-4420,2018
-ENGL,4430,1,Theories of World Literature,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,andrew lemons,ENGL-4430,2018
-ENGL,4440,1,Renaissance Literature,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-4440,2018
-ENGL,4450,1,Fiction Workshop,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-4450,2018
-ENGL,4480,1,Screenwriting Wkshop,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,nicholas chris brown,ENGL-4480,2018
-ENGL,4510,1,Film Theory and Criticism,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,john robert smith,ENGL-4510,2018
-ENGL,4510,2,Film Theory and Criticism,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,john robert smith,ENGL-4510,2018
-ENGL,4520,1,Great Directors,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,olga anatoly volkova,ENGL-4520,2018
-ENGL,4560,1,Holocaust Lit/Arts,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,steven katz,ENGL-4560,2018
-ENGL,4600,1,Writing Technologies,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,tharon howard,ENGL-4600,2018
-ENGL,4780,1,Digital Literacy,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,tharon howard,ENGL-4780,2018
-ENGL,4920,1,Modern Rhetoric,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,megan eatman,ENGL-4920,2018
-ENGL,4960,1,Senior Seminar,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jonathan beech field,ENGL-4960,2018
-ENGL,4960,2,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,ENGL-4960,2018
-ENGL,4960,3,Senior Seminar,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,erin marina goss,ENGL-4960,2018
-ENGL,8520,1,Rhetorical Theories & Practice,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,megan eatman,ENGL-8520,2018
-ENGR,1020,112,Engineering Discipl & Skills,0.13,0.63,0.15,0.03,0.0,0.0,0.0,0.08,sarah grigg,ENGR-1020,2018
-ENGR,1020,113,Engineering Discipl & Skills,0.18,0.63,0.18,0.0,0.0,0.0,0.0,0.03,sarah grigg,ENGR-1020,2018
-ENGR,1020,116,Engineering Discipl & Skills,0.4,0.38,0.15,0.0,0.0,0.0,0.0,0.08,michael giebner,ENGR-1020,2018
-ENGR,1020,211,Engineering Discipl & Skills,0.38,0.4,0.05,0.05,0.05,0.0,0.0,0.07,ashley childers,ENGR-1020,2018
-ENGR,1020,218,Engineering Discipl & Skills,0.21,0.47,0.21,0.05,0.03,0.0,0.0,0.03,michael giebner,ENGR-1020,2018
-ENGR,1020,311,Engineering Discipl & Skills,0.24,0.43,0.21,0.02,0.05,0.0,0.0,0.05,john minor,ENGR-1020,2018
-ENGR,1020,312,Engineering Discipl & Skills,0.33,0.36,0.21,0.02,0.02,0.0,0.0,0.05,john minor,ENGR-1020,2018
-ENGR,1020,314,Engineering Discipl & Skills,0.51,0.17,0.17,0.07,0.0,0.0,0.0,0.07,ashley childers,ENGR-1020,2018
-ENGR,1020,315,Engr Discipl & Skills (HON),0.76,0.21,0.0,0.0,0.0,0.0,0.0,0.03,richard watkins,ENGR-1020,2018
-ENGR,1020,316,Engineering Discipl & Skills,0.33,0.38,0.14,0.02,0.02,0.0,0.0,0.1,steven brandon,ENGR-1020,2018
-ENGR,1020,611,Engineering Discipl & Skills,0.37,0.37,0.12,0.07,0.02,0.0,0.0,0.05,irene marie ferrara,ENGR-1020,2018
-ENGR,1020,612,Engineering Discipl & Skills,0.63,0.2,0.12,0.02,0.02,0.0,0.0,0.0,irene marie ferrara,ENGR-1020,2018
-ENGR,1020,613,Engineering Discipl & Skills,0.12,0.33,0.3,0.12,0.03,0.0,0.0,0.09,elizabeth an stephan,ENGR-1020,2018
-ENGR,1020,614,Engineering Discipl & Skills,0.09,0.19,0.13,0.25,0.06,0.0,0.0,0.28,matthew kent miller,ENGR-1020,2018
-ENGR,1020,615,Engineering Discipl & Skills,0.31,0.36,0.21,0.07,0.0,0.0,0.0,0.05,anthony paul garland,ENGR-1020,2018
-ENGR,1020,616,Engineering Discipl & Skills,0.04,0.48,0.3,0.07,0.04,0.0,0.0,0.07,andrew isaac neptune,ENGR-1020,2018
-ENGR,1020,617,Engineering Discipl & Skills,0.34,0.32,0.21,0.0,0.0,0.0,0.0,0.13,anthony paul garland,ENGR-1020,2018
-ENGR,1020,618,Engineering Discipl & Skills,0.12,0.39,0.27,0.05,0.02,0.0,0.0,0.15,anthony paul garland,ENGR-1020,2018
-ENGR,1020,811,Engineering Discipl & Skills,0.45,0.38,0.15,0.03,0.0,0.0,0.0,0.0,jonathan broo harcum,ENGR-1020,2018
-ENGR,1020,812,Engineering Discipl & Skills,0.29,0.49,0.15,0.05,0.0,0.0,0.0,0.02,elizabeth an stephan,ENGR-1020,2018
-ENGR,1020,813,Engineering Discipl & Skills,0.3,0.43,0.18,0.08,0.0,0.0,0.0,0.03,andrew isaac neptune,ENGR-1020,2018
-ENGR,1020,814,Engineering Discipl & Skills,0.55,0.3,0.08,0.03,0.0,0.0,0.0,0.05,jonathan broo harcum,ENGR-1020,2018
-ENGR,1020,815,Engineering Discipl & Skills,0.4,0.5,0.05,0.0,0.05,0.0,0.0,0.0,jonathan broo harcum,ENGR-1020,2018
-ENGR,1020,816,Engineering Discipl & Skills,0.43,0.38,0.13,0.03,0.0,0.0,0.0,0.05,matthew kent miller,ENGR-1020,2018
-ENGR,1020,817,Engineering Discipl & Skills,0.23,0.5,0.15,0.08,0.0,0.0,0.0,0.05,matthew kent miller,ENGR-1020,2018
-ENGR,1020,818,Engineering Discipl & Skills,0.41,0.38,0.05,0.14,0.03,0.0,0.0,0.0,andrew isaac neptune,ENGR-1020,2018
-ENGR,1020,831,Engr Discipl & Skills (HON),0.69,0.29,0.0,0.0,0.0,0.0,0.0,0.03,jonathan maier,ENGR-1020,2018
-ENGR,1020,832,Engr Discipl & Skills (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1020,2018
-ENGR,1060,400,Engr Discipline & Skills II,0.0,0.44,0.19,0.19,0.19,0.0,0.0,0.0,mariah so magagnotti,ENGR-1060,2018
-ENGR,1060,401,Engr Discipline & Skills II,0.17,0.17,0.17,0.17,0.33,0.0,0.0,0.0,mariah so magagnotti,ENGR-1060,2018
-ENGR,1410,222,Programming & Problem Solving,0.05,0.26,0.32,0.11,0.16,0.0,0.0,0.11,mariah so magagnotti,ENGR-1410,2018
-ENGR,1410,223,Programming & Problem Solving,0.05,0.16,0.51,0.11,0.03,0.0,0.0,0.14,william martin,ENGR-1410,2018
-ENGR,1410,226,Programming & Problem Solving,0.13,0.21,0.39,0.11,0.11,0.0,0.0,0.05,mariah so magagnotti,ENGR-1410,2018
-ENGR,1410,227,Programming & Problem Solving,0.14,0.36,0.31,0.14,0.03,0.0,0.0,0.03,william martin,ENGR-1410,2018
-ENGR,2080,681,Engr Graphics & Machine Design,0.42,0.33,0.11,0.0,0.08,0.0,0.0,0.06,nighat yasmin,ENGR-2080,2018
-ENGR,2080,682,Engr Graphics & Machine Design,0.32,0.3,0.22,0.11,0.05,0.0,0.0,0.0,nighat yasmin,ENGR-2080,2018
-ENGR,2080,683,Engr Graphics & Machine Design,0.44,0.33,0.13,0.0,0.1,0.0,0.0,0.0,kyle walker,ENGR-2080,2018
-ENGR,2080,684,Engr Graphics & Machine Design,0.37,0.39,0.13,0.0,0.0,0.0,0.0,0.11,kyle walker,ENGR-2080,2018
-ENGR,2080,685,Engr Graphics & Machine Design,0.5,0.16,0.16,0.03,0.03,0.0,0.0,0.13,samuel coeyman,ENGR-2080,2018
-ENGR,2080,686,Engr Graphics & Machine Design,0.35,0.32,0.21,0.06,0.06,0.0,0.0,0.0,samuel coeyman,ENGR-2080,2018
-ENGR,2100,804,CAD & Engineering Applications,0.44,0.18,0.1,0.1,0.1,0.0,0.0,0.08,afshin famili,ENGR-2100,2018
-ENGR,2100,805,CAD & Engineering Applications,0.45,0.33,0.1,0.03,0.05,0.0,0.0,0.05,nighat yasmin,ENGR-2100,2018
-ENGR,2100,806,CAD & Engineering Applications,0.55,0.26,0.03,0.05,0.0,0.0,0.0,0.11,afshin famili,ENGR-2100,2018
-ENGR,2200,115,Evaluating Innovations,0.1,0.65,0.23,0.03,0.0,0.0,0.0,0.0,sarah grigg,ENGR-2200,2018
-ENR,1010,2,Intro to Envir & Natur Res I,0.82,0.11,0.02,0.0,0.0,0.0,0.0,0.05,emily catheri oakman,ENR-1010,2018
-ENR,1010,3,Intro to Envir & Natur Res I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,emily catheri oakman,ENR-1010,2018
-ENR,4290,1,Environ Law & Policy,0.24,0.38,0.27,0.03,0.03,0.0,0.0,0.05,alan johnson,ENR-4290,2018
-ENR,4290,2,Environ Law & Policy,0.36,0.45,0.11,0.0,0.0,0.0,0.0,0.07,alan johnson,ENR-4290,2018
-ENSP,2000,1,Intro Environ Sci,0.33,0.47,0.19,0.0,0.02,0.0,0.0,0.0,scott brame,ENSP-2000,2018
-ENSP,2000,2,Intro Environ Sci,0.69,0.28,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2018
-ENSP,2000,3,Intro Environ Sci,0.57,0.39,0.02,0.0,0.0,0.0,0.0,0.02,minory nammouz,ENSP-2000,2018
-ENSP,2000,4,Intro Environ Sci,0.56,0.4,0.02,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,ENSP-2000,2018
-ENSP,2000,5,Intro Environ Sci,0.39,0.39,0.13,0.02,0.0,0.0,0.0,0.07,tom owino,ENSP-2000,2018
-ENSP,4000,1,Studies in Environmental Sci,0.53,0.35,0.0,0.06,0.0,0.0,0.0,0.06,margaret lo thompson,ENSP-4000,2018
-ENT,2000,1,Six-Legged Science,0.53,0.4,0.05,0.0,0.0,0.0,0.0,0.03,suellen pometto,ENT-2000,2018
-ENT,3010,1,Insect Biology and Diversity,0.33,0.33,0.27,0.07,0.0,0.0,0.0,0.0,eric benson,ENT-3010,2018
-ENTR,1010,3,Entrepreneurial Mindset,0.69,0.23,0.05,0.01,0.01,0.0,0.0,0.01,john michael hannon,ENTR-1010,2018
-ENTR,1090,6,Creative Inq-Entrepreneurship,0.61,0.3,0.0,0.0,0.0,0.0,0.0,0.09,john michael hannon,ENTR-1090,2018
-ENTR,2010,4,Sports Entrepreneurship,0.63,0.27,0.03,0.0,0.03,0.0,0.0,0.03,john michael hannon,ENTR-2010,2018
-ETOX,4300,1,Toxicology,0.54,0.23,0.15,0.08,0.0,0.0,0.0,0.0,lisa bain,ETOX-4300,2018
-FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.88,0.05,0.02,0.02,0.01,0.0,0.0,0.02,sara lane cothran,FDSC-1010,2018
-FDSC,3010,1,Food Regulations,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,FDSC-3010,2018
-FDSC,4010,1,Food Chemistry I,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,feng chen,FDSC-4010,2018
-FDSC,4040,1,Food Prsv & Process,0.53,0.21,0.21,0.02,0.02,0.0,0.0,0.0,anthony loui pometto,FDSC-4040,2018
-FDSC,4070,1,Quantity Food Production,0.84,0.1,0.03,0.0,0.03,0.0,0.0,0.0,bridgit deni corbett,FDSC-4070,2018
-FDSC,4300,1,Dairy Process & Sant,0.52,0.24,0.1,0.14,0.0,0.0,0.0,0.0,john mcgregor,FDSC-4300,2018
-FDSC,8120,1,Microbial Food Syst,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,xiuping jiang,FDSC-8120,2018
-FDSC,8210,1,Selected Topics,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,julie kath northcutt,FDSC-8210,2018
-FIN,2010,401,Intro to Personal Finance,0.95,0.04,0.01,0.0,0.0,0.0,0.0,0.0,joshua harris,FIN-2010,2018
-FIN,2010,402,Intro to Personal Finance,0.89,0.08,0.01,0.0,0.0,0.0,0.0,0.02,joshua harris,FIN-2010,2018
-FIN,2010,403,Intro to Personal Finance,0.9,0.07,0.01,0.0,0.01,0.0,0.0,0.01,joshua harris,FIN-2010,2018
-FIN,2010,404,Intro to Personal Finance,0.78,0.09,0.02,0.02,0.06,0.0,0.0,0.02,joshua harris,FIN-2010,2018
-FIN,2010,406,Intro to Personal Finance,0.79,0.15,0.0,0.02,0.02,0.0,0.0,0.02,joshua harris,FIN-2010,2018
-FIN,2010,407,Intro to Personal Finance,0.81,0.1,0.0,0.1,0.0,0.0,0.0,0.0,joshua harris,FIN-2010,2018
-FIN,3040,1,Risk & Insurance,0.28,0.3,0.23,0.15,0.0,0.0,0.0,0.05,kerri mcmillan,FIN-3040,2018
-FIN,3050,1,Investment Analysis,0.07,0.29,0.32,0.05,0.17,0.0,0.0,0.1,kerri mcmillan,FIN-3050,2018
-FIN,3050,2,Investment Analysis,0.08,0.5,0.32,0.03,0.08,0.0,0.0,0.0,kerri mcmillan,FIN-3050,2018
-FIN,3050,3,Investment Analysis,0.21,0.36,0.28,0.05,0.03,0.0,0.0,0.08,kerri mcmillan,FIN-3050,2018
-FIN,3050,4,Investment Analysis,0.14,0.25,0.19,0.17,0.14,0.0,0.0,0.11,john alexander,FIN-3050,2018
-FIN,3060,5,Corporation Finance,0.09,0.45,0.3,0.11,0.02,0.0,0.0,0.04,ramon tolbe franklin,FIN-3060,2018
-FIN,3060,6,Corporation Finance,0.09,0.27,0.34,0.14,0.09,0.0,0.0,0.07,ramon tolbe franklin,FIN-3060,2018
-FIN,3060,7,Corporation Finance,0.15,0.26,0.26,0.15,0.0,0.0,0.0,0.17,ramon tolbe franklin,FIN-3060,2018
-FIN,3060,8,Corporation Finance,0.24,0.41,0.25,0.08,0.0,0.0,0.0,0.02,melvin stith,FIN-3060,2018
-FIN,3060,9,Corporation Finance,0.29,0.39,0.2,0.1,0.02,0.0,0.0,0.0,melvin stith,FIN-3060,2018
-FIN,3060,401,Corporation Finance,0.49,0.23,0.23,0.02,0.0,0.0,0.0,0.04,joshua harris,FIN-3060,2018
-FIN,3060,402,Corporation Finance,0.37,0.42,0.12,0.04,0.02,0.0,0.0,0.04,joshua harris,FIN-3060,2018
-FIN,3070,1,Prin of Real Estate,0.1,0.22,0.39,0.17,0.1,0.0,0.0,0.02,thomas springer,FIN-3070,2018
-FIN,3070,2,Prin of Real Estate,0.18,0.32,0.23,0.2,0.0,0.0,0.0,0.07,thomas springer,FIN-3070,2018
-FIN,3070,3,Prin of Real Estate,0.26,0.42,0.29,0.03,0.0,0.0,0.0,0.0,yannan shen,FIN-3070,2018
-FIN,3080,3,Fin Inst & Mkts,0.23,0.33,0.36,0.08,0.0,0.0,0.0,0.0,daniel thomas greene,FIN-3080,2018
-FIN,3080,401,Fin Inst & Mkts,0.21,0.32,0.36,0.09,0.0,0.0,0.0,0.02,daniel thomas greene,FIN-3080,2018
-FIN,3110,1,Financial Management I,0.12,0.24,0.31,0.12,0.05,0.0,0.0,0.17,jack wolf,FIN-3110,2018
-FIN,3110,2,Financial Management I,0.12,0.3,0.4,0.12,0.05,0.0,0.0,0.02,jack wolf,FIN-3110,2018
-FIN,3110,3,Financial Management I,0.28,0.28,0.28,0.13,0.05,0.0,0.0,0.0,jack wolf,FIN-3110,2018
-FIN,3110,5,Financial Management I,0.16,0.34,0.36,0.11,0.02,0.0,0.0,0.02,weike xu,FIN-3110,2018
-FIN,3110,6,Financial Management I,0.16,0.43,0.3,0.07,0.04,0.0,0.0,0.0,weike xu,FIN-3110,2018
-FIN,3120,1,Financial Management II,0.17,0.3,0.37,0.1,0.0,0.0,0.0,0.07,vincent ja intintoli,FIN-3120,2018
-FIN,3120,2,Financial Management II,0.05,0.31,0.36,0.1,0.14,0.0,0.0,0.05,vincent ja intintoli,FIN-3120,2018
-FIN,3120,3,Financial Management II,0.24,0.27,0.15,0.07,0.05,0.0,0.0,0.22,blerina zykaj,FIN-3120,2018
-FIN,3120,4,Financial Management II,0.21,0.39,0.21,0.05,0.04,0.0,0.0,0.09,weike xu,FIN-3120,2018
-FIN,3120,101,Financial Mgt II (HON),0.7,0.2,0.0,0.1,0.0,0.0,0.0,0.0,vincent ja intintoli,FIN-3120,2018
-FIN,4010,1,Corporate Financial Analysis,0.33,0.4,0.17,0.02,0.02,0.0,0.0,0.05,george bran lockhart,FIN-4010,2018
-FIN,4020,1,Corporate Valuation,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,angela morgan,FIN-4020,2018
-FIN,4050,1,Portfolio Management & Theory,0.14,0.17,0.44,0.14,0.06,0.0,0.0,0.06,john alexander,FIN-4050,2018
-FIN,4060,1,Derivatives Analysis,0.34,0.31,0.17,0.07,0.07,0.0,0.0,0.03,blerina zykaj,FIN-4060,2018
-FIN,4110,1,Int Fin Mgt,0.21,0.46,0.28,0.05,0.0,0.0,0.0,0.0,luke asher devault,FIN-4110,2018
-FIN,4110,2,Int Fin Mgt,0.22,0.53,0.22,0.03,0.0,0.0,0.0,0.0,luke asher devault,FIN-4110,2018
-FIN,4170,1,Real Estate Finance,0.24,0.38,0.24,0.1,0.05,0.0,0.0,0.0,yannan shen,FIN-4170,2018
-FNR,2040,1,Soil Information Systems,0.84,0.1,0.03,0.0,0.02,0.0,0.0,0.02,elena mikhailova,FNR-2040,2018
-FNR,4990,1,Natural Resources Seminar,0.76,0.21,0.03,0.0,0.0,0.0,0.0,0.0,susan talley guynn,FNR-4990,2018
-FOR,2050,1,Dendrology,0.24,0.35,0.05,0.22,0.08,0.0,0.0,0.05,donald hagan,FOR-2050,2018
-FOR,2050,2,Dendrology,0.27,0.37,0.16,0.08,0.02,0.0,0.0,0.1,donald hagan,FOR-2050,2018
-FOR,2050,3,Dendrology,0.37,0.16,0.11,0.11,0.21,0.0,0.0,0.05,donald hagan,FOR-2050,2018
-FOR,2210,1,Forest Biology,0.75,0.12,0.1,0.01,0.0,0.0,0.0,0.02,emily catheri oakman,FOR-2210,2018
-FOR,3020,1,Forest Biometrics,0.24,0.44,0.16,0.16,0.0,0.0,0.0,0.0,lawrence gering,FOR-3020,2018
-FOR,3040,1,Forest Resource Economics,0.46,0.46,0.07,0.0,0.0,0.0,0.0,0.0,puskar khanal,FOR-3040,2018
-FOR,4100,1,Harvesting Processes,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,patrick hiesl,FOR-4100,2018
-FOR,4160,1,Forest Policy and Admin,0.44,0.3,0.22,0.02,0.0,0.0,0.0,0.01,thomas straka,FOR-4160,2018
-FOR,4170,1,Forest Resource Mgt & Regulatn,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.0,puskar khanal,FOR-4170,2018
-FOR,4310,1,Recreation Res Plan in For Mgt,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,robert baxter powell,FOR-4310,2018
-FOR,4340,1,GIS for Natural Resources,0.79,0.19,0.02,0.0,0.0,0.0,0.0,0.0,christopher post,FOR-4340,2018
-FR,1010,1,Elementary French,0.33,0.33,0.17,0.06,0.0,0.0,0.0,0.11, nedeo anne salces anne,FR-1010,2018
-FR,1010,2,Elementary French,0.31,0.44,0.19,0.0,0.06,0.0,0.0,0.0, nedeo anne salces anne,FR-1010,2018
-FR,1010,3,Elementary French,0.13,0.38,0.38,0.06,0.06,0.0,0.0,0.0, nedeo anne salces anne,FR-1010,2018
-FR,1020,1,Elementary French,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,FR-1020,2018
-FR,1020,2,Elementary French,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,amy lyn griff sawyer griff,FR-1020,2018
-FR,2010,2,Intermediate French,0.28,0.56,0.06,0.0,0.06,0.0,0.0,0.06,kenneth davi widgren,FR-2010,2018
-FR,2010,3,Intermediate French,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,kenneth davi widgren,FR-2010,2018
-FR,2010,4,Intermediate French,0.33,0.5,0.06,0.06,0.0,0.0,0.0,0.06,tholozany pauline de,FR-2010,2018
-FR,2020,1,Intermediate French,0.89,0.0,0.05,0.0,0.0,0.0,0.0,0.05,amy lyn griff sawyer griff,FR-2020,2018
-FR,2020,2,Intermediate French,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,FR-2020,2018
-FR,2020,3,Intermediate French,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,eric touya,FR-2020,2018
-FR,2020,4,Intermediate French,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,FR-2020,2018
-FR,2020,5,Intermediate French,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,kenneth davi widgren,FR-2020,2018
-FR,3000,1,Survey of French Lit,0.39,0.5,0.0,0.0,0.06,0.0,0.0,0.06,tholozany pauline de,FR-3000,2018
-FR,3050,1,Int Fr Con & Comp I,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,kenneth davi widgren,FR-3050,2018
-FR,4120,1,Fr & Francoph Cinema,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,joseph mai,FR-4120,2018
-FR,4160,1,Fr for Intl Trade II,0.43,0.36,0.14,0.0,0.0,0.0,0.0,0.07,eric touya,FR-4160,2018
-GC,1020,1,Computer Art & CAD Foundations,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,carol jones,GC-1020,2018
-GC,1020,2,Computer Art & CAD Foundations,0.5,0.42,0.0,0.0,0.06,0.0,0.0,0.02,carol jones,GC-1020,2018
-GC,1030,1,G C I for Pkgsc,0.29,0.67,0.05,0.0,0.0,0.0,0.0,0.0,john jacobs,GC-1030,2018
-GC,1040,1,Graphic Communications I,0.67,0.23,0.05,0.02,0.02,0.0,0.0,0.02,michelle suki bo fox bo,GC-1040,2018
-GC,2070,1,Graphic Communications II,0.6,0.29,0.02,0.0,0.04,0.0,0.0,0.04,charles tabor weiss,GC-2070,2018
-GC,3400,1,Digital Imaging and eMedia,0.29,0.48,0.17,0.0,0.04,0.0,0.0,0.02,erica black walker,GC-3400,2018
-GC,3460,1,Ink and Substrates,0.25,0.36,0.34,0.0,0.05,0.0,0.0,0.0,liam henry 'hara,GC-3460,2018
-GC,4060,1,Package and Specialty Printing,0.67,0.29,0.02,0.0,0.02,0.0,0.0,0.0,kern cox,GC-4060,2018
-GC,4400,1,Commercial Printing,0.28,0.59,0.1,0.0,0.03,0.0,0.0,0.0,eric weisenmiller,GC-4400,2018
-GC,4440,1,Current Dev/Trends in Gr Comm,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,GC-4440,2018
-GC,4800,1,Senior Seminar in GC,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,charles edwar tonkin,GC-4800,2018
-GC,4900,1,Media & Film in Dig Age,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,erica black walker,GC-4900,2018
-GC,4900,3,Digital Media Design,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erica black walker,GC-4900,2018
-GC,4900,6,GC-UX & Web Design,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erica black walker,GC-4900,2018
-GC,4900,230,G C Selected Topics-GC Sales,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,GC-4900,2018
-GEN,1030,1,Careers in Bioch/Gen,0.88,0.07,0.0,0.01,0.03,0.0,0.0,0.01,alison ni starr-moss,GEN-1030,2018
-GEN,3000,1,Fundamental Genetics,0.29,0.33,0.26,0.03,0.01,0.0,0.0,0.09,kate leanne wil tsai wil,GEN-3000,2018
-GEN,3000,2,Fundamental Genetics,0.26,0.34,0.25,0.1,0.02,0.0,0.0,0.04,kate leanne wil tsai wil,GEN-3000,2018
-GEN,3020,1,Molecular & General Genetics,0.57,0.35,0.05,0.01,0.0,0.0,0.0,0.02,jennifer may mason,GEN-3020,2018
-GEN,3020,2,Molec & General Genetics (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,GEN-3020,2018
-GEN,3040,1,Molecular Biology Laboratory,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,scott michael tanner,GEN-3040,2018
-GEN,3040,2,Molecular Biology Laboratory,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-3040,2018
-GEN,3040,3,Molecular Biology Laboratory,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-3040,2018
-GEN,3040,4,Molecular Biology Laboratory,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-3040,2018
-GEN,4100,1,Population & Quant Genetics,0.38,0.44,0.1,0.04,0.02,0.0,0.0,0.02,scott michael tanner,GEN-4100,2018
-GEN,4100,2,Population & Quant Gen (HON),0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,scott michael tanner,GEN-4100,2018
-GEN,4110,1,Population & Quant Gen Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-4110,2018
-GEN,4110,2,Population & Quant Gen Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-4110,2018
-GEN,4110,3,Population & Quant Gen Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-4110,2018
-GEN,4110,4,Population & Quant Gen Lab,0.79,0.0,0.07,0.0,0.07,0.0,0.0,0.07,scott michael tanner,GEN-4110,2018
-GEN,4400,1,Bioinformatics,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,frank alexand feltus,GEN-4400,2018
-GEN,4500,1,Comparative Genetics,0.25,0.45,0.25,0.0,0.03,0.0,0.0,0.03,leigh anne clark,GEN-4500,2018
-GEN,4900,1,Epigenetics,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,rajandeep sin sekhon,GEN-4900,2018
-GEN,8140,1,Advanced Genetics,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,miriam kristi konkel,GEN-8140,2018
-GEOG,1030,1,World Regional Geography,0.33,0.42,0.15,0.02,0.02,0.0,0.0,0.06,william church terry,GEOG-1030,2018
-GEOG,3010,1,Political Geography,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,christa smith,GEOG-3010,2018
-GEOG,4010,1,Studies in Geography,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william church terry,GEOG-4010,2018
-GEOL,1010,1,Physical Geology,0.22,0.3,0.18,0.11,0.09,0.0,0.0,0.1,alan coulson,GEOL-1010,2018
-GEOL,1010,2,Physical Geology,0.24,0.33,0.25,0.05,0.06,0.0,0.0,0.06,alan coulson,GEOL-1010,2018
-GEOL,1010,4,Physical Geology,0.49,0.29,0.16,0.0,0.02,0.0,0.0,0.04,mary katherin fidler,GEOL-1010,2018
-GEOL,1030,1,Physical Geol Lab,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2018
-GEOL,1030,2,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,3,Physical Geol Lab,0.42,0.46,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2018
-GEOL,1030,4,Physical Geol Lab,0.38,0.46,0.17,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,5,Physical Geol Lab,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2018
-GEOL,1030,6,Physical Geol Lab,0.57,0.26,0.04,0.04,0.0,0.0,0.0,0.09,alan coulson,GEOL-1030,2018
-GEOL,1030,7,Physical Geol Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2018
-GEOL,1030,9,Physical Geol Lab,0.32,0.5,0.09,0.05,0.0,0.0,0.0,0.05,alan coulson,GEOL-1030,2018
-GEOL,1030,10,Physical Geol Lab,0.54,0.13,0.0,0.04,0.17,0.0,0.0,0.13,alan coulson,GEOL-1030,2018
-GEOL,1030,11,Physical Geol Lab,0.58,0.29,0.04,0.0,0.04,0.0,0.0,0.04,alan coulson,GEOL-1030,2018
-GEOL,1030,12,Physical Geol Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,13,Physical Geol Lab,0.22,0.48,0.22,0.04,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2018
-GEOL,1120,1,Earth Resources,0.27,0.32,0.23,0.09,0.05,0.0,0.0,0.03,mary katherin fidler,GEOL-1120,2018
-GEOL,1140,1,Earth Resources Lab,0.58,0.2,0.13,0.02,0.02,0.0,0.0,0.04,mary katherin fidler,GEOL-1140,2018
-GEOL,2050,1,Mineralogy & Intro Petrology,0.4,0.33,0.13,0.07,0.0,0.0,0.0,0.07,lind shuller-nickles,GEOL-2050,2018
-GEOL,2070,1,Min & Intro Pet Lab,0.33,0.13,0.27,0.13,0.07,0.0,0.0,0.07,mary katherin fidler,GEOL-2070,2018
-GEOL,2750,1,Field Methods,0.7,0.0,0.0,0.0,0.0,0.0,0.0,0.3,scott brame,GEOL-2750,2018
-GEOL,3000,1,Environmental Geology,0.05,0.49,0.31,0.1,0.0,0.0,0.0,0.05,alan coulson,GEOL-3000,2018
-GEOL,3020,1,Structural Geology,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,alexander tho pullen,GEOL-3020,2018
-GEOL,4030,1,Invertebrate Paleontology,0.1,0.7,0.0,0.0,0.0,0.0,0.0,0.2,neil smith,GEOL-4030,2018
-GEOL,4150,1,Analysis Geological Processes,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,lawrence murdoch,GEOL-4150,2018
-GEOL,4910,1,Research Synthesis I,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,alan coulson,GEOL-4910,2018
-GEOL,6820,1,Groundwater & Contam Transport,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,GEOL-6820,2018
-GEOL,7900,501,Biogeography And Geology of SC,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,GEOL-7900,2018
-GER,1010,2,Elementary German,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-1010,2018
-GER,1010,3,Elementary German,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,oswald harris king,GER-1010,2018
-GER,1020,1,Elementary German,0.07,0.33,0.2,0.13,0.07,0.0,0.0,0.2, lee ferrell,GER-1020,2018
-GER,2010,1,Intermediate German,0.25,0.19,0.38,0.13,0.06,0.0,0.0,0.0,johannes schmidt,GER-2010,2018
-GER,2010,2,Intermediate German,0.08,0.31,0.38,0.23,0.0,0.0,0.0,0.0,johannes schmidt,GER-2010,2018
-GER,2020,1,Intermediate German,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,gabriela stoicea,GER-2020,2018
-GER,2020,2,Intermediate German,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,oswald harris king,GER-2020,2018
-GER,3050,1,Ger Conv & Comp,0.57,0.21,0.21,0.0,0.0,0.0,0.0,0.0, lee ferrell,GER-3050,2018
-GER,3400,1,German Culture,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,GER-3400,2018
-HIST,1010,1,History of the United States,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,lee brady wilson,HIST-1010,2018
-HIST,1010,2,History of the United States,0.21,0.47,0.18,0.09,0.06,0.0,0.0,0.0,john andrew,HIST-1010,2018
-HIST,1020,1,History of the United States,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,maribel morey,HIST-1020,2018
-HIST,1220,1,"Hist, Tech & Society",0.36,0.49,0.06,0.05,0.02,0.0,0.0,0.03,pamela mack,HIST-1220,2018
-HIST,1240,1,Environmental History Survey,0.3,0.3,0.23,0.03,0.03,0.0,0.0,0.1,james bradf jeffries,HIST-1240,2018
-HIST,1240,2,Environmental History Survey,0.23,0.37,0.23,0.13,0.03,0.0,0.0,0.0,james bradf jeffries,HIST-1240,2018
-HIST,1720,1,The West and the World I,0.22,0.34,0.26,0.05,0.06,0.0,0.0,0.07,caroline dunn clark,HIST-1720,2018
-HIST,1720,2,The West and the World I,0.29,0.47,0.15,0.07,0.02,0.0,0.0,0.01,steven marks,HIST-1720,2018
-HIST,1730,1,The West and the World II,0.19,0.43,0.19,0.05,0.08,0.0,0.0,0.06,michael meng,HIST-1730,2018
-HIST,1730,2,The West and the World II,0.44,0.3,0.15,0.04,0.0,0.0,0.0,0.07, alan grubb,HIST-1730,2018
-HIST,2990,1,Historian's Craft,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,thomas kuehn,HIST-2990,2018
-HIST,2990,3,Historian's Craft,0.59,0.24,0.06,0.06,0.06,0.0,0.0,0.0,michael silvestri,HIST-2990,2018
-HIST,3010,1,Am Rev & New Nation,0.26,0.53,0.11,0.0,0.11,0.0,0.0,0.0,james bradf jeffries,HIST-3010,2018
-HIST,3030,1,Civil War & Recon,0.16,0.79,0.0,0.0,0.0,0.0,0.0,0.05,paul christ anderson,HIST-3030,2018
-HIST,3040,1,Indus & Progr Era,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0, roger grant,HIST-3040,2018
-HIST,3120,1,Afr Amer Hist 1877 to Present,0.21,0.63,0.11,0.0,0.0,0.0,0.0,0.05,abel bartley,HIST-3120,2018
-HIST,3240,1,Hist of the South II,0.36,0.4,0.12,0.04,0.04,0.0,0.0,0.04,john andrew,HIST-3240,2018
-HIST,3280,1,US Legal History to 1890,0.7,0.27,0.03,0.0,0.0,0.0,0.0,0.0,lee brady wilson,HIST-3280,2018
-HIST,3330,1,Hist of Mod Japan,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,edwin moise,HIST-3330,2018
-HIST,3380,1,Africa to 1875,0.38,0.25,0.21,0.13,0.0,0.0,0.0,0.04,james burns,HIST-3380,2018
-HIST,3410,1,Modern Mexico,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,rachel anne moore,HIST-3410,2018
-HIST,3630,1,Britain Since 1688,0.5,0.38,0.04,0.0,0.0,0.0,0.0,0.08,stephanie barczewski,HIST-3630,2018
-HIST,3700,1,Medieval History,0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,HIST-3700,2018
-HIST,3970,1,Modern Middle East,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,HIST-3970,2018
-HIST,4400,1,Studies in Latin American Hist,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,HIST-4400,2018
-HIST,4710,1,The Great War,0.57,0.14,0.14,0.0,0.07,0.0,0.0,0.07, alan grubb,HIST-4710,2018
-HIST,4900,2,Weimar Germany,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,michael meng,HIST-4900,2018
-HIST,4900,3,Dictatorship&ViolenceIW Europe,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,amit bein,HIST-4900,2018
-HIST,4920,1,Iraq War,0.2,0.2,0.47,0.07,0.0,0.0,0.0,0.07,edwin moise,HIST-4920,2018
-HIST,4960,1,European Law,0.2,0.4,0.3,0.0,0.0,0.0,0.0,0.1,thomas kuehn,HIST-4960,2018
-HLTH,2020,1,Introduction to Public Health,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2018
-HLTH,2020,2,Introduction to Public Health,0.56,0.33,0.1,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2018
-HLTH,2020,3,Introduction to Public Health,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2020,2018
-HLTH,2020,4,Introduction to Public Health,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,becky ann tugman,HLTH-2020,2018
-HLTH,2020,5,Introduction to Public Health,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2020,2018
-HLTH,2020,400,Introduction to Public Health,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2018
-HLTH,2020,401,Introduction to Public Health,0.53,0.26,0.11,0.0,0.0,0.0,0.0,0.11,ralph stewart welsh,HLTH-2020,2018
-HLTH,2030,1,Health Care Sys,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,lee alden crandall,HLTH-2030,2018
-HLTH,2030,2,Health Care Sys,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,lee alden crandall,HLTH-2030,2018
-HLTH,2030,3,Health Care Sys,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2018
-HLTH,2400,1,Deter of Hlth Behav,0.45,0.42,0.12,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2018
-HLTH,2400,2,Deter of Hlth Behav,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,HLTH-2400,2018
-HLTH,2400,400,Deter of Hlth Behav,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2018
-HLTH,2600,1,Medical Terminology & Comm,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,karen edwards,HLTH-2600,2018
-HLTH,2600,2,Medical Terminology & Comm,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,karen edwards,HLTH-2600,2018
-HLTH,2600,400,Medical Terminology & Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2600,2018
-HLTH,2980,1,Human Health and Disease,0.75,0.16,0.09,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2018
-HLTH,2980,2,Human Health and Disease,0.54,0.31,0.11,0.03,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2980,2018
-HLTH,2980,3,Human Health and Disease,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2980,2018
-HLTH,3400,1,Hlth Prom Prog Plan,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-3400,2018
-HLTH,3610,1,Int Health Care Econ,0.67,0.23,0.03,0.0,0.0,0.0,0.0,0.07,khoa dang truong,HLTH-3610,2018
-HLTH,3800,1,Epidemiology,0.64,0.27,0.06,0.0,0.0,0.0,0.0,0.03,deborah alma falta,HLTH-3800,2018
-HLTH,3800,2,Epidemiology,0.42,0.39,0.15,0.0,0.0,0.0,0.0,0.03,deborah alma falta,HLTH-3800,2018
-HLTH,3800,400,Epidemiology,0.37,0.37,0.21,0.0,0.05,0.0,0.0,0.0,deborah alma falta,HLTH-3800,2018
-HLTH,3980,1,Health Appraisal Skills,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2018
-HLTH,3980,2,Health Appraisal Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2018
-HLTH,4100,1,Maternal Child Hlth,0.54,0.43,0.04,0.0,0.0,0.0,0.0,0.0,karyn jones,HLTH-4100,2018
-HLTH,4190,1,Health Sci Internship Prep Sem,0.79,0.1,0.1,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4190,2018
-HLTH,4200,1,Hlth Science Intern,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2018
-HLTH,4400,1,Manag Hlth Serv Org,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,HLTH-4400,2018
-HLTH,4700,1,Global Health,0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,micky rogers ward,HLTH-4700,2018
-HLTH,4750,1,Hlthcr Oper Mgmt Res,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,lu shi,HLTH-4750,2018
-HLTH,4900,1,Res Eval St Pub Hlth,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,karen kemper,HLTH-4900,2018
-HLTH,4900,2,Res Eval St Pub Hlth,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-4900,2018
-HLTH,4970,4,Aspire to Be Well - CI,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,chloe carolin greene,HLTH-4970,2018
-HLTH,4970,5,Alcohol & Other Drugs-CI,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,crystal burne fulmer,HLTH-4970,2018
-HLTH,8030,1,Theories and Determ of Health,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,joel edward williams,HLTH-8030,2018
-HLTH,8410,1,Foundations of Eval in Health,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,HLTH-8410,2018
-HON,1940,1,Bioinspired,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,charles beard,HON-1940,2018
-HON,2020,1,Who Decides What's Cool?,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,HON-2020,2018
-HON,2020,2,World of Ideas,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,HON-2020,2018
-HON,2050,1,Architecture: Ideas & Practice,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burl brown,HON-2050,2018
-HON,2060,3,Puzzles and Paradoxes,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,marilyn reba,HON-2060,2018
-HON,2210,1,Frankenstein at 200,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,remley meliss makala,HON-2210,2018
-HORT,1010,1,Horticulture,0.86,0.09,0.01,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,HORT-1010,2018
-HORT,2020,1,Adobe Digital Design,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,janice ann lay,HORT-2020,2018
-HORT,2020,2,Hydroponics,0.17,0.28,0.19,0.17,0.06,0.0,0.0,0.15,james emerson faust,HORT-2020,2018
-HORT,2120,1,Turfgrass Culture,0.56,0.38,0.05,0.0,0.0,0.0,0.0,0.0,haibo liu,HORT-2120,2018
-HORT,2130,2,Turf Culture Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,HORT-2130,2018
-HORT,3030,1,Landscape Plants,0.09,0.22,0.35,0.16,0.15,0.0,0.0,0.03,robert polomski,HORT-3030,2018
-HORT,3080,1,Sust Landsc Des Install Maint,0.9,0.08,0.0,0.0,0.03,0.0,0.0,0.0,ellen anita vincent,HORT-3080,2018
-HORT,4120,1,Adv Turfgrass Mgt,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,lambert mccarty,HORT-4120,2018
-HP,8070,400,American Architecture,0.6,0.1,0.0,0.0,0.0,0.0,0.0,0.3,carter lee hudgins,HP-8070,2018
-HP,8080,400,Hist and Theory of Hist Pres,0.56,0.11,0.0,0.0,0.0,0.0,0.0,0.33,carter lee hudgins,HP-8080,2018
-HP,8090,400,Historical Research Methods,0.5,0.13,0.0,0.0,0.0,0.0,0.0,0.38,katherine pemberton,HP-8090,2018
-HP,8190,1,"Investig, Docum, Conservation",0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,amalia leifeste,HP-8190,2018
-HRD,8200,401,Human Perform Improv,0.77,0.14,0.0,0.0,0.0,0.0,0.0,0.09,angela daniel carter,HRD-8200,2018
-HRD,8450,400,Needs Assess Ed/Ind,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,angela daniel carter,HRD-8450,2018
-HRD,8600,400,Instruc Mat Devel,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,cynthia sims,HRD-8600,2018
-IE,2100,1,Des Analysis Wrk Sys,0.49,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jeffery messer,IE-2100,2018
-IE,3010,1,Systems Design I,0.35,0.49,0.14,0.01,0.0,0.0,0.0,0.01,robert james riggs,IE-3010,2018
-IE,3600,1,Industrial Apps of Prob/Stat I,0.23,0.25,0.23,0.14,0.08,0.0,0.0,0.06,tugce isik,IE-3600,2018
-IE,3610,1,Industrial App of Prob/Stat II,0.31,0.41,0.1,0.1,0.04,0.0,0.0,0.04,david neyens,IE-3610,2018
-IE,3800,1,Deterministic Operations Rsrch,0.17,0.42,0.2,0.05,0.15,0.0,0.0,0.01,joshua tayl margolis,IE-3800,2018
-IE,3810,1,Probabilistic Operations Rsrch,0.6,0.29,0.07,0.01,0.0,0.0,0.0,0.02,burak eksioglu,IE-3810,2018
-IE,3840,1,Engr Econ Analysis,0.4,0.2,0.09,0.06,0.05,0.0,0.0,0.19,brian melloy,IE-3840,2018
-IE,3860,1,Production Planning & Control,0.84,0.12,0.02,0.02,0.0,0.0,0.0,0.0,xiaoxia li,IE-3860,2018
-IE,4400,1,Decision Support Sys,0.53,0.3,0.06,0.01,0.05,0.0,0.0,0.05,scott jennings mason,IE-4400,2018
-IE,4460,1,Model & Analysis Mfg Systems,0.37,0.47,0.14,0.0,0.0,0.0,0.0,0.02,robert james riggs,IE-4460,2018
-IE,4510,1,Investigating Human Error,0.36,0.26,0.28,0.04,0.0,0.0,0.0,0.06,sara lu riggs,IE-4510,2018
-IE,4530,1,Network Flows for IE Apps,0.36,0.36,0.09,0.0,0.09,0.0,0.0,0.09,burak eksioglu,IE-4530,2018
-IE,4610,1,Quality Engineering,0.29,0.32,0.27,0.07,0.02,0.0,0.0,0.02,byung rae cho,IE-4610,2018
-IE,4650,1,Facilities Planning & Design,0.23,0.47,0.18,0.06,0.02,0.0,0.0,0.03,william ferrell,IE-4650,2018
-IE,4670,1,System Design II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,IE-4670,2018
-IE,4810,1,App of Prob Models in Ind Engr,0.36,0.27,0.27,0.0,0.0,0.0,0.0,0.09,brian melloy,IE-4810,2018
-IE,4820,1,Systems Modeling,0.46,0.28,0.18,0.03,0.0,0.0,0.0,0.05,kevin taaffe,IE-4820,2018
-IE,4820,2,Systems Modeling,0.2,0.44,0.24,0.1,0.02,0.0,0.0,0.0,kevin taaffe,IE-4820,2018
-IE,4910,3,Human Centered Design & Engr,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,laura michel stanley,IE-4910,2018
-IE,6460,1,Model & Analysis Mfg Systems,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,IE-6460,2018
-IE,8000,1,Human Factors Eng,0.15,0.63,0.22,0.0,0.0,0.0,0.0,0.0,david neyens,IE-8000,2018
-IE,8030,1,Engr Optimization and Apps,0.68,0.26,0.05,0.0,0.01,0.0,0.0,0.0,sandra duni eksioglu,IE-8030,2018
-IE,8040,1,Mfg Sys Plan & Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,IE-8040,2018
-IE,8530,1,Foundations of Quality,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,byung rae cho,IE-8530,2018
-IE,8550,1,SC & Logistics Modeling II,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,kevin taaffe,IE-8550,2018
-IE,8930,1,Markov Decision Processes,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amin khademi,IE-8930,2018
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,lisa marie robinson,INT-1510,2018
-IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,james dougla bennett,IS-1010,2018
-ITAL,1010,2,Elementary Italian,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,luca barattoni,ITAL-1010,2018
-ITAL,1010,3,Elementary Italian,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,julia schmidt,ITAL-1010,2018
-ITAL,1010,4,Elementary Italian,0.23,0.46,0.15,0.0,0.08,0.0,0.0,0.08,julia schmidt,ITAL-1010,2018
-ITAL,2010,1,Intermediate Italian,0.5,0.11,0.22,0.11,0.0,0.0,0.0,0.06,julia schmidt,ITAL-2010,2018
-JAPN,1010,1,Elementary Japanese,0.53,0.26,0.05,0.05,0.0,0.0,0.0,0.11,saori suto,JAPN-1010,2018
-JAPN,1010,2,Elementary Japanese,0.47,0.16,0.21,0.05,0.0,0.0,0.0,0.11,saori suto,JAPN-1010,2018
-JAPN,1010,3,Elementary Japanese,0.5,0.33,0.08,0.0,0.08,0.0,0.0,0.0,satomi saito,JAPN-1010,2018
-JAPN,1020,1,Elementary Japanese,0.38,0.31,0.08,0.15,0.0,0.0,0.0,0.08,satomi saito,JAPN-1020,2018
-JAPN,2010,1,Intermed Japanese,0.46,0.08,0.31,0.08,0.0,0.0,0.0,0.08,saori suto,JAPN-2010,2018
-JAPN,3050,1,Japanese Conversation & Comp,0.57,0.14,0.07,0.07,0.14,0.0,0.0,0.0,jae allegra takeuchi,JAPN-3050,2018
-JAPN,4010,1,Japanese Lit in Translation,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,kumiko saito,JAPN-4010,2018
-JUST,2880,1,The Criminal Justice System,0.5,0.22,0.16,0.04,0.08,0.0,0.0,0.0,margaret tina britz,JUST-2880,2018
-JUST,4680,1,Criminal Evidence,0.44,0.35,0.09,0.07,0.02,0.0,0.0,0.02,margaret tina britz,JUST-4680,2018
-JUST,4860,1,Creative Inquiry in CJ,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,margaret tina britz,JUST-4860,2018
-LANG,3000,1,Intro Linguistics,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,daniel smith,LANG-3000,2018
-LANG,4540,1,Sel Top in International Film,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,satomi saito,LANG-4540,2018
-LARC,1150,1,Intro Landscape Architecture,0.77,0.14,0.05,0.0,0.0,0.0,0.0,0.05,mary padua,LARC-1150,2018
-LARC,1280,1,Technical Graphics,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,LARC-1280,2018
-LARC,1510,1,Basic Design I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,matthew neal powers,LARC-1510,2018
-LARC,2510,2,Larch Design Fund,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,LARC-2510,2018
-LARC,2620,1,Design Implementation I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,robert hewitt,LARC-2620,2018
-LARC,4530,1,Key Issues in Landscape Arch,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,mary padua,LARC-4530,2018
-LARC,4620,1,Design Implementation III,0.18,0.59,0.09,0.14,0.0,0.0,0.0,0.0,mary padua,LARC-4620,2018
-LAW,3220,1,Legal Env of Bus,0.21,0.38,0.31,0.06,0.02,0.0,0.0,0.02,john hine,LAW-3220,2018
-LAW,3220,4,Legal Env of Bus,0.17,0.37,0.35,0.07,0.02,0.0,0.0,0.02,kenneth sc toussaint,LAW-3220,2018
-LAW,3220,5,Legal Env of Bus,0.23,0.35,0.31,0.1,0.0,0.0,0.0,0.0,kenneth sc toussaint,LAW-3220,2018
-LAW,3220,6,Legal Env of Bus,0.37,0.41,0.18,0.02,0.02,0.0,0.0,0.0,kathr kisska-schulze,LAW-3220,2018
-LAW,3220,7,Legal Env of Bus,0.37,0.49,0.08,0.04,0.02,0.0,0.0,0.0,kathr kisska-schulze,LAW-3220,2018
-LAW,3220,8,Legal Env of Bus,0.31,0.48,0.1,0.06,0.04,0.0,0.0,0.0,kathr kisska-schulze,LAW-3220,2018
-LAW,3220,9,Legal Env of Bus,0.3,0.51,0.19,0.0,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2018
-LAW,3220,10,Legal Env of Bus,0.3,0.33,0.26,0.04,0.02,0.0,0.0,0.04,edward ray claggett,LAW-3220,2018
-LAW,3220,11,Legal Env of Bus,0.42,0.48,0.1,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2018
-LAW,3220,400,Legal Env of Bus,0.37,0.35,0.19,0.02,0.0,0.0,0.0,0.06,virginia ward-vaughn,LAW-3220,2018
-LAW,3220,401,Legal Env of Bus,0.31,0.44,0.15,0.05,0.02,0.0,0.0,0.05,virginia ward-vaughn,LAW-3220,2018
-LAW,3220,402,Legal Env of Bus,0.33,0.44,0.14,0.05,0.0,0.0,0.0,0.03,virginia ward-vaughn,LAW-3220,2018
-LAW,3220,403,Legal Env of Bus,0.3,0.4,0.18,0.07,0.0,0.0,0.0,0.05,virginia ward-vaughn,LAW-3220,2018
-LAW,3330,1,Real Estate Law,0.0,0.42,0.32,0.16,0.11,0.0,0.0,0.0,kenneth sc toussaint,LAW-3330,2018
-LAW,3330,2,Real Estate Law,0.17,0.49,0.2,0.11,0.03,0.0,0.0,0.0,kenneth sc toussaint,LAW-3330,2018
-LAW,4050,1,Construction Law,0.9,0.08,0.0,0.0,0.0,0.0,0.0,0.03,frances edwards,LAW-4050,2018
-LS,1000,1,Therapeutic Yoga,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dili amin,LS-1000,2018
-LS,1000,2,Therapeutic Yoga,0.77,0.14,0.05,0.0,0.0,0.0,0.0,0.05,ranjanbala dili amin,LS-1000,2018
-LS,1000,3,Therapeutic Yoga,0.82,0.09,0.0,0.0,0.05,0.0,0.0,0.05,renee warren gahan,LS-1000,2018
-LS,1000,8,Intro to Volleyball,0.79,0.07,0.07,0.07,0.0,0.0,0.0,0.0,kelly lynn ator,LS-1000,2018
-LS,1000,12,Introduction to Salsa,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,malik lewis  baxter c,LS-1000,2018
-LS,1000,13,Introduction to Salsa Dance,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,malik lewis  baxter c,LS-1000,2018
-LS,1570,2,Shotgun Sports,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,bonnie duke gill,LS-1570,2018
-LS,1570,3,Shotgun Sports,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,edward licus prater,LS-1570,2018
-LS,1580,3,Archery,0.55,0.27,0.0,0.0,0.0,0.0,0.0,0.18,herbert strickland,LS-1580,2018
-LS,1850,1,Bowling,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,madison neel workman,LS-1850,2018
-LS,1850,2,Bowling,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,LS-1850,2018
-LS,1850,3,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,kimberly coury,LS-1850,2018
-LS,1850,4,Bowling,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,alexandra sandoval,LS-1850,2018
-LS,1850,5,Bowling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,alexandra sandoval,LS-1850,2018
-LS,1870,2,Frisbee Sports,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,steven simoneaux,LS-1870,2018
-LS,1980,9,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,wesley scott womble,LS-1980,2018
-LS,2270,2,Intro to Swing Dance,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,paul hoke,LS-2270,2018
-LS,2320,2,Core Training,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,LS-2320,2018
-LS,2320,3,Core Training,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-2320,2018
-LS,2320,4,Core Training,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,diane moreno,LS-2320,2018
-LS,2320,5,Core Training,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,LS-2320,2018
-LS,2350,1,Basic Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2018
-LS,2350,7,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,LS-2350,2018
-LS,2350,8,Basic Yoga,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,LS-2350,2018
-LS,2360,1,Power/Ashtanga Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,silica elizab larkin,LS-2360,2018
-LS,2360,2,Power/Ashtanga Yoga,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,silica elizab larkin,LS-2360,2018
-LS,2380,2,Vinyasa Flow Yoga,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,nicole eliz martinez,LS-2380,2018
-LS,2420,1,Meditation and Relax,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,LS-2420,2018
-LS,2420,2,Meditation and Relax,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,renee warren gahan,LS-2420,2018
-LS,2420,5,Meditation and Relax,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dili amin,LS-2420,2018
-LS,2420,6,Meditation and Relax,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dili amin,LS-2420,2018
-LS,2420,7,Meditation and Relax,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,LS-2420,2018
-LS,2420,9,Meditation and Relax,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,kayla lee wardlaw,LS-2420,2018
-LS,2450,1,Pilates,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,melanie ivey job,LS-2450,2018
-LS,2450,4,Pilates,0.77,0.05,0.0,0.0,0.14,0.0,0.0,0.05,diane moreno,LS-2450,2018
-LS,2450,8,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,LS-2450,2018
-LS,2750,10,First Aid/Cpr,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,christopher loomis,LS-2750,2018
-MATH,1010,1,Essen Math for Informed Soc,0.33,0.33,0.27,0.07,0.0,0.0,0.0,0.0,bryce pruitt,MATH-1010,2018
-MATH,1010,2,Essen Math for Informed Soc,0.22,0.33,0.17,0.22,0.0,0.0,0.0,0.06,seth selken,MATH-1010,2018
-MATH,1010,3,Essen Math for Informed Soc,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,seth selken,MATH-1010,2018
-MATH,1010,4,Essen Math for Informed Soc,0.47,0.13,0.2,0.13,0.0,0.0,0.0,0.07,alexander joyce,MATH-1010,2018
-MATH,1010,5,Essen Math for Informed Soc,0.47,0.35,0.06,0.06,0.06,0.0,0.0,0.0,bryce pruitt,MATH-1010,2018
-MATH,1010,6,Essen Math for Informed Soc,0.39,0.39,0.17,0.0,0.06,0.0,0.0,0.0,alexander joyce,MATH-1010,2018
-MATH,1010,7,Essen Math for Informed Soc,0.44,0.18,0.21,0.09,0.09,0.0,0.0,0.0,marilyn reba,MATH-1010,2018
-MATH,1010,8,Essen Math for Informed Soc,0.44,0.31,0.19,0.0,0.0,0.0,0.0,0.06,seth selken,MATH-1010,2018
-MATH,1010,9,Essen Math for Informed Soc,0.64,0.09,0.18,0.09,0.0,0.0,0.0,0.0,alexander joyce,MATH-1010,2018
-MATH,1020,1,Business Calculus I,0.24,0.24,0.18,0.24,0.12,0.0,0.0,0.0,hannah grace rollins,MATH-1020,2018
-MATH,1020,2,Business Calculus I,0.05,0.42,0.26,0.11,0.11,0.0,0.0,0.05,hannah grace rollins,MATH-1020,2018
-MATH,1020,3,Business Calculus I,0.11,0.39,0.17,0.17,0.06,0.0,0.0,0.11,morgan elston,MATH-1020,2018
-MATH,1020,4,Business Calculus I,0.06,0.39,0.28,0.28,0.0,0.0,0.0,0.0,morgan elston,MATH-1020,2018
-MATH,1020,5,Business Calculus I,0.17,0.28,0.22,0.17,0.11,0.0,0.0,0.06,zachary ray johnston,MATH-1020,2018
-MATH,1020,6,Business Calculus I,0.11,0.37,0.21,0.16,0.05,0.0,0.0,0.11,zachary ray johnston,MATH-1020,2018
-MATH,1020,7,Business Calculus I,0.22,0.11,0.33,0.17,0.0,0.0,0.0,0.17,michael thomas cowen,MATH-1020,2018
-MATH,1020,8,Business Calculus I,0.11,0.33,0.5,0.0,0.0,0.0,0.0,0.06,michael thomas cowen,MATH-1020,2018
-MATH,1020,11,Business Calculus I,0.22,0.22,0.22,0.06,0.11,0.0,0.0,0.17,andrew pangia,MATH-1020,2018
-MATH,1020,12,Business Calculus I,0.0,0.35,0.29,0.18,0.12,0.0,0.0,0.06,andrew gray pitman,MATH-1020,2018
-MATH,1020,15,Business Calculus I,0.28,0.17,0.22,0.22,0.06,0.0,0.0,0.06,hemanta kunwar,MATH-1020,2018
-MATH,1020,16,Business Calculus I,0.11,0.33,0.5,0.06,0.0,0.0,0.0,0.0,andrew gray pitman,MATH-1020,2018
-MATH,1020,18,Business Calculus I,0.29,0.24,0.35,0.06,0.0,0.0,0.0,0.06,ebenezer eduafo,MATH-1020,2018
-MATH,1020,19,Business Calculus I,0.28,0.39,0.11,0.06,0.11,0.0,0.0,0.06,andrew pangia,MATH-1020,2018
-MATH,1020,20,Business Calculus I,0.12,0.29,0.12,0.18,0.24,0.0,0.0,0.06,michael gle eldredge,MATH-1020,2018
-MATH,1020,21,Business Calculus I,0.22,0.22,0.33,0.06,0.17,0.0,0.0,0.0,hassan kiyadeh hami,MATH-1020,2018
-MATH,1020,22,Business Calculus I,0.39,0.22,0.11,0.11,0.11,0.0,0.0,0.06,zachary david espe,MATH-1020,2018
-MATH,1020,23,Business Calculus I,0.32,0.37,0.2,0.02,0.02,0.0,0.0,0.07,tony thanh nguyen,MATH-1020,2018
-MATH,1020,24,Business Calculus I,0.39,0.28,0.17,0.11,0.0,0.0,0.0,0.06,zachary david espe,MATH-1020,2018
-MATH,1020,25,Business Calculus I,0.24,0.47,0.12,0.06,0.06,0.0,0.0,0.06,nicholas john porter,MATH-1020,2018
-MATH,1020,26,Business Calculus I,0.22,0.17,0.28,0.11,0.11,0.0,0.0,0.11,hemanta kunwar,MATH-1020,2018
-MATH,1020,27,Business Calculus I,0.39,0.17,0.11,0.28,0.0,0.0,0.0,0.06,cameron arnold,MATH-1020,2018
-MATH,1020,28,Business Calculus I,0.26,0.26,0.26,0.11,0.05,0.0,0.0,0.05,nicholas john porter,MATH-1020,2018
-MATH,1020,29,Business Calculus I,0.25,0.2,0.28,0.05,0.13,0.0,0.0,0.1,marion hanna,MATH-1020,2018
-MATH,1020,30,Business Calculus I,0.37,0.21,0.21,0.16,0.05,0.0,0.0,0.0,cameron arnold,MATH-1020,2018
-MATH,1020,31,Business Calculus I,0.33,0.22,0.17,0.11,0.11,0.0,0.0,0.06,hassan kiyadeh hami,MATH-1020,2018
-MATH,1020,33,Business Calculus I,0.17,0.17,0.28,0.11,0.17,0.0,0.0,0.11,michael gle eldredge,MATH-1020,2018
-MATH,1020,34,Business Calculus I,0.24,0.34,0.22,0.1,0.07,0.0,0.0,0.02,marion hanna,MATH-1020,2018
-MATH,1020,35,Business Calculus I,0.06,0.44,0.06,0.11,0.28,0.0,0.0,0.06,ebenezer eduafo,MATH-1020,2018
-MATH,1020,38,Business Calculus I,0.29,0.29,0.21,0.14,0.02,0.0,0.0,0.05,tony thanh nguyen,MATH-1020,2018
-MATH,1020,39,Business Calculus I,0.36,0.19,0.29,0.1,0.02,0.0,0.0,0.05,dyken jennifer  van e,MATH-1020,2018
-MATH,1020,40,Business Calculus I,0.39,0.27,0.19,0.09,0.03,0.0,0.0,0.02,jennifer marie hanna,MATH-1020,2018
-MATH,1020,41,Business Calculus I,0.47,0.23,0.18,0.08,0.01,0.0,0.0,0.03,jennifer marie hanna,MATH-1020,2018
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.87,0.0,0.13,donna simms,MATH-1040,2018
-MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.79,0.0,0.21,kristina gorsline,MATH-1040,2018
-MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.68,0.0,0.32,aaron moose,MATH-1040,2018
-MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,stephen peele,MATH-1040,2018
-MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.8,0.0,0.2,emma cinatl,MATH-1040,2018
-MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.87,0.0,0.13,tony thanh nguyen,MATH-1050,2018
-MATH,1060,1,Calculus of One Variable I,0.21,0.19,0.21,0.07,0.17,0.0,0.0,0.14,timothy fran parrott,MATH-1060,2018
-MATH,1060,2,Calculus of One Variable I,0.29,0.12,0.29,0.1,0.17,0.0,0.0,0.05,timothy fran parrott,MATH-1060,2018
-MATH,1060,3,Calculus of One Variable I,0.23,0.2,0.25,0.07,0.16,0.0,0.0,0.09,timothy fran parrott,MATH-1060,2018
-MATH,1060,4,Calculus of One Variable I,0.09,0.32,0.18,0.14,0.18,0.0,0.0,0.09,sofya alekseeva,MATH-1060,2018
-MATH,1060,5,Calculus of One Variable I,0.19,0.16,0.19,0.26,0.09,0.0,0.0,0.12,sofya alekseeva,MATH-1060,2018
-MATH,1060,6,Calculus of One Variable I,0.12,0.33,0.21,0.09,0.14,0.0,0.0,0.12,sofya alekseeva,MATH-1060,2018
-MATH,1060,8,Calculus of One Variable I,0.36,0.25,0.14,0.06,0.09,0.0,0.0,0.1,judith el cottingham,MATH-1060,2018
-MATH,1060,10,Calculus of One Variable I,0.24,0.27,0.23,0.05,0.14,0.0,0.0,0.07,judith el cottingham,MATH-1060,2018
-MATH,1060,12,Calculus of One Variable I,0.32,0.27,0.16,0.07,0.16,0.0,0.0,0.02,hugh geller,MATH-1060,2018
-MATH,1060,14,Calculus of One Variable I,0.13,0.28,0.16,0.03,0.22,0.0,0.0,0.19,valdez hiram lopez,MATH-1060,2018
-MATH,1060,15,Calculus of One Variable I,0.27,0.16,0.25,0.16,0.11,0.0,0.0,0.05,blake antho splitter,MATH-1060,2018
-MATH,1060,16,Calculus of One Variable I,0.33,0.19,0.23,0.07,0.09,0.0,0.0,0.09,stephen peele,MATH-1060,2018
-MATH,1060,17,Calculus of One Variable I,0.15,0.24,0.12,0.15,0.22,0.0,0.0,0.12,valdez hiram lopez,MATH-1060,2018
-MATH,1060,18,Calculus of One Variable I,0.17,0.37,0.14,0.09,0.09,0.0,0.0,0.14,marilyn reba,MATH-1060,2018
-MATH,1060,19,Calculus of One Variable I,0.28,0.3,0.14,0.05,0.16,0.0,0.0,0.07,jason alexander kurz,MATH-1060,2018
-MATH,1060,201,Calculus of One Variable I,0.44,0.33,0.12,0.05,0.05,0.0,0.0,0.02,camille zerfas,MATH-1060,2018
-MATH,1060,202,Calculus of One Variable I,0.33,0.36,0.1,0.05,0.12,0.0,0.0,0.05,andrew walton green,MATH-1060,2018
-MATH,1060,203,Calculus of One Variable I,0.31,0.31,0.23,0.03,0.06,0.0,0.0,0.06,charles lanning,MATH-1060,2018
-MATH,1060,204,Calculus of One Variable I,0.31,0.31,0.22,0.02,0.09,0.0,0.0,0.04,scott scruggs,MATH-1060,2018
-MATH,1060,205,Calculus of One Variable I,0.37,0.29,0.2,0.04,0.06,0.0,0.0,0.04,james edward gossell,MATH-1060,2018
-MATH,1060,206,Calculus of One Variable I,0.2,0.24,0.37,0.0,0.17,0.0,0.0,0.02,catherine mar kenyon,MATH-1060,2018
-MATH,1060,207,Calculus of One Variable I,0.24,0.33,0.12,0.07,0.14,0.0,0.0,0.1,rachel bass lanning,MATH-1060,2018
-MATH,1060,208,Calculus of One Variable I,0.39,0.39,0.12,0.05,0.05,0.0,0.0,0.0,todd fenstermacher,MATH-1060,2018
-MATH,1060,300,Calculus of One Variable I,0.32,0.16,0.29,0.16,0.03,0.0,0.0,0.03,matthew macauley,MATH-1060,2018
-MATH,1070,1,Differen and Integral Calculus,0.08,0.35,0.38,0.08,0.12,0.0,0.0,0.0,donna simms,MATH-1070,2018
-MATH,1080,1,Calculus of One Variable II,0.13,0.17,0.2,0.09,0.27,0.0,0.0,0.14,benjamin chris wiles,MATH-1080,2018
-MATH,1080,2,Calculus of One Variable II,0.23,0.25,0.25,0.14,0.11,0.0,0.0,0.02,timothy cha teitloff,MATH-1080,2018
-MATH,1080,3,Calculus of One Variable II,0.1,0.26,0.26,0.05,0.18,0.0,0.0,0.15,beth novick,MATH-1080,2018
-MATH,1080,4,Calculus of One Variable II,0.14,0.23,0.25,0.09,0.2,0.0,0.0,0.09,timothy cha teitloff,MATH-1080,2018
-MATH,1080,5,Calculus of One Variable II,0.28,0.23,0.3,0.02,0.12,0.0,0.0,0.05,timothy cha teitloff,MATH-1080,2018
-MATH,1080,6,Calculus of One Variable II,0.27,0.22,0.2,0.07,0.1,0.0,0.0,0.15,meredith nicole burr,MATH-1080,2018
-MATH,1080,7,Calculus of One Variable II,0.21,0.28,0.21,0.1,0.1,0.0,0.0,0.1,meredith nicole burr,MATH-1080,2018
-MATH,1080,201,Calculus of One Variable II,0.34,0.14,0.23,0.09,0.11,0.0,0.0,0.09,fun choi john chan john,MATH-1080,2018
-MATH,1150,1,Contemp Math for Elem Teach I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew mich tyminski,MATH-1150,2018
-MATH,1150,2,Contemp Math for Elem Teach I,0.5,0.33,0.1,0.05,0.0,0.0,0.0,0.02,eliza darg gallagher,MATH-1150,2018
-MATH,1160,1,Contemp Math for Elem Teach II,0.6,0.27,0.0,0.0,0.07,0.0,0.0,0.07,nicole alain sinwell,MATH-1160,2018
-MATH,2060,1,Calculus of Several Variables,0.23,0.3,0.29,0.09,0.06,0.0,0.0,0.03,irina viktorova,MATH-2060,2018
-MATH,2060,4,Calculus of Several Variables,0.18,0.2,0.22,0.18,0.13,0.0,0.0,0.1,oleg yordanov,MATH-2060,2018
-MATH,2060,7,Calculus of Several Variables,0.3,0.36,0.17,0.04,0.1,0.0,0.0,0.02,irina viktorova,MATH-2060,2018
-MATH,2060,10,Calculus of Several Variables,0.24,0.17,0.12,0.26,0.12,0.0,0.0,0.1,terri johnson,MATH-2060,2018
-MATH,2060,11,Calculus of Several Variables,0.38,0.43,0.05,0.04,0.06,0.0,0.0,0.04,allen anderson guest,MATH-2060,2018
-MATH,2060,12,Calculus of Several Variables,0.43,0.31,0.14,0.03,0.05,0.0,0.0,0.04,allen anderson guest,MATH-2060,2018
-MATH,2060,14,Calculus of Several Variables,0.32,0.45,0.17,0.03,0.03,0.0,0.0,0.01,oleg yordanov,MATH-2060,2018
-MATH,2060,15,Calculus of Several Variables,0.4,0.33,0.24,0.0,0.02,0.0,0.0,0.0,akshay sunil gupte,MATH-2060,2018
-MATH,2060,19,Calculus of Several Variables,0.14,0.14,0.14,0.28,0.16,0.0,0.0,0.14,terri johnson,MATH-2060,2018
-MATH,2060,20,Calculus of Several Variables,0.17,0.19,0.11,0.25,0.08,0.0,0.0,0.19,terri johnson,MATH-2060,2018
-MATH,2060,100,Calc of Several Vars (HON),0.69,0.27,0.02,0.0,0.0,0.0,0.0,0.02,peter kiessler,MATH-2060,2018
-MATH,2060,201,Calculus of Several Variables,0.5,0.36,0.07,0.0,0.07,0.0,0.0,0.0,sanwar ahmad,MATH-2060,2018
-MATH,2060,202,Calculus of Several Variables,0.24,0.31,0.22,0.02,0.04,0.0,0.0,0.16,martin johan schmoll,MATH-2060,2018
-MATH,2070,1,Business Calculus II,0.12,0.35,0.12,0.06,0.35,0.0,0.0,0.0,haodong li,MATH-2070,2018
-MATH,2070,2,Business Calculus II,0.0,0.44,0.39,0.06,0.11,0.0,0.0,0.0,haodong li,MATH-2070,2018
-MATH,2070,3,Business Calculus II,0.0,0.33,0.17,0.22,0.11,0.0,0.0,0.17,thanh thien to,MATH-2070,2018
-MATH,2070,4,Business Calculus II,0.11,0.33,0.22,0.22,0.11,0.0,0.0,0.0,todd anthony morra,MATH-2070,2018
-MATH,2070,5,Business Calculus II,0.06,0.13,0.25,0.31,0.19,0.0,0.0,0.06,todd anthony morra,MATH-2070,2018
-MATH,2070,6,Business Calculus II,0.27,0.07,0.33,0.13,0.07,0.0,0.0,0.13,ville madeleine  st e,MATH-2070,2018
-MATH,2070,7,Business Calculus II,0.12,0.29,0.35,0.12,0.12,0.0,0.0,0.0,xiaoyuan liu,MATH-2070,2018
-MATH,2070,8,Business Calculus II,0.17,0.39,0.28,0.06,0.06,0.0,0.0,0.06,xiaoyuan liu,MATH-2070,2018
-MATH,2070,11,Business Calculus II,0.31,0.32,0.22,0.09,0.06,0.0,0.0,0.0,jennifer ray newton,MATH-2070,2018
-MATH,2070,13,Business Calculus II,0.29,0.29,0.07,0.29,0.0,0.0,0.0,0.07,thanh thien to,MATH-2070,2018
-MATH,2070,14,Business Calculus II,0.06,0.24,0.41,0.18,0.06,0.0,0.0,0.06,anna carol bachstein,MATH-2070,2018
-MATH,2070,15,Business Calculus II,0.17,0.28,0.11,0.33,0.0,0.0,0.0,0.11,anna carol bachstein,MATH-2070,2018
-MATH,2070,17,Business Calculus II,0.22,0.39,0.22,0.0,0.06,0.0,0.0,0.11,ville madeleine  st e,MATH-2070,2018
-MATH,2070,18,Business Calculus II,0.33,0.18,0.28,0.14,0.05,0.0,0.0,0.02,jennifer ray newton,MATH-2070,2018
-MATH,2070,19,Business Calculus II,0.18,0.24,0.18,0.12,0.12,0.0,0.0,0.18,thanh thien to,MATH-2070,2018
-MATH,2070,20,Business Calculus II,0.0,0.21,0.07,0.14,0.36,0.0,0.0,0.21,todd anthony morra,MATH-2070,2018
-MATH,2080,3,Intro to Ordin Diff Equations,0.13,0.28,0.41,0.05,0.07,0.0,0.0,0.07,pye phyo aung,MATH-2080,2018
-MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.3,0.26,0.08,0.09,0.0,0.0,0.05,pye phyo aung,MATH-2080,2018
-MATH,2080,5,Intro to Ordin Diff Equations,0.2,0.03,0.23,0.1,0.3,0.0,0.0,0.13,julie lassiter,MATH-2080,2018
-MATH,2080,6,Intro to Ordin Diff Equations,0.14,0.23,0.26,0.14,0.14,0.0,0.0,0.09,julie lassiter,MATH-2080,2018
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.7,0.13,0.17,0.0,0.0,0.0,0.0,0.0,jeong rock yoon rock,MATH-2080,2018
-MATH,2160,1,Geometry for Elem Sch Teachers,0.39,0.39,0.17,0.02,0.02,0.0,0.0,0.0,allison kes stoddard,MATH-2160,2018
-MATH,2160,2,Geometry for Elem Sch Teachers,0.7,0.2,0.0,0.05,0.0,0.0,0.0,0.05,allison kes stoddard,MATH-2160,2018
-MATH,2500,1,Intro to Mathematical Sciences,0.95,0.04,0.01,0.0,0.0,0.0,0.0,0.0,mark cawood,MATH-2500,2018
-MATH,3020,1,Stat for Science & Engineering,0.36,0.3,0.19,0.02,0.06,0.0,0.0,0.06,ellen hepfer breazel,MATH-3020,2018
-MATH,3020,2,Stat for Science & Engineering,0.36,0.34,0.23,0.02,0.0,0.0,0.0,0.04,ellen hepfer breazel,MATH-3020,2018
-MATH,3020,4,Stat for Science & Engineering,0.61,0.27,0.11,0.0,0.0,0.0,0.0,0.0,xin liu,MATH-3020,2018
-MATH,3020,5,Stat for Science & Engineering,0.38,0.4,0.07,0.07,0.07,0.0,0.0,0.02,xiaoqian sun,MATH-3020,2018
-MATH,3020,6,Stat for Science & Engineering,0.53,0.24,0.06,0.06,0.06,0.0,0.0,0.06, kamronnaher,MATH-3020,2018
-MATH,3020,7,Stat for Science & Engineering,0.29,0.24,0.29,0.06,0.06,0.0,0.0,0.06, kamronnaher,MATH-3020,2018
-MATH,3020,9,Stat for Science & Engineering,0.61,0.22,0.06,0.0,0.11,0.0,0.0,0.0,merenchig jayasekara,MATH-3020,2018
-MATH,3020,10,Stat for Science & Engineering,0.29,0.29,0.14,0.0,0.14,0.0,0.0,0.14,merenchig jayasekara,MATH-3020,2018
-MATH,3110,3,Linear Algebra,0.36,0.43,0.17,0.02,0.0,0.0,0.0,0.02,wayne goddard,MATH-3110,2018
-MATH,3110,4,Linear Algebra,0.24,0.31,0.26,0.07,0.12,0.0,0.0,0.0,hui xue,MATH-3110,2018
-MATH,3110,5,Linear Algebra,0.21,0.21,0.19,0.12,0.16,0.0,0.0,0.12,felice manganiello,MATH-3110,2018
-MATH,3110,6,Linear Algebra,0.27,0.3,0.14,0.09,0.05,0.0,0.0,0.16,felice manganiello,MATH-3110,2018
-MATH,3110,7,Linear Algebra,0.23,0.31,0.1,0.05,0.03,0.0,0.0,0.28,xuhong gao,MATH-3110,2018
-MATH,3110,8,Linear Algebra,0.45,0.24,0.08,0.0,0.11,0.0,0.0,0.13,xuhong gao,MATH-3110,2018
-MATH,3110,9,Linear Algebra,0.22,0.33,0.28,0.03,0.11,0.0,0.0,0.03,vincent ervin,MATH-3110,2018
-MATH,3110,100,Linear Algebra (HON),0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,beth novick,MATH-3110,2018
-MATH,3110,200,Linear Algebra,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,beth novick,MATH-3110,2018
-MATH,3190,1,Introduction to Proof,0.28,0.12,0.24,0.16,0.12,0.0,0.0,0.08,elena stan dimitrova,MATH-3190,2018
-MATH,3190,2,Introduction to Proof,0.44,0.2,0.16,0.04,0.08,0.0,0.0,0.08,elena stan dimitrova,MATH-3190,2018
-MATH,3600,2,Intermediate Math Computing,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,mark cawood,MATH-3600,2018
-MATH,3650,1,Numerical Mthds for Engineers,0.14,0.42,0.32,0.04,0.04,0.0,0.0,0.04,eleanor jenkins,MATH-3650,2018
-MATH,3650,2,Numerical Mthds for Engineers,0.23,0.23,0.4,0.09,0.02,0.0,0.0,0.02,hyesuk lee,MATH-3650,2018
-MATH,3650,3,Numerical Mthds for Engineers,0.26,0.33,0.24,0.05,0.07,0.0,0.0,0.05,hyesuk lee,MATH-3650,2018
-MATH,4000,1,Theory of Probability,0.3,0.22,0.3,0.04,0.0,0.0,0.0,0.15,brian fralix,MATH-4000,2018
-MATH,4000,2,Theory of Probability,0.29,0.26,0.29,0.06,0.09,0.0,0.0,0.03,derek brown,MATH-4000,2018
-MATH,4020,1,Stat for Sci & Engineering II,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,colin gallagher,MATH-4020,2018
-MATH,4070,1,Regress & Time-Series Analysis,0.47,0.4,0.0,0.0,0.0,0.0,0.0,0.13,colin gallagher,MATH-4070,2018
-MATH,4120,2,Algebra I,0.24,0.52,0.2,0.04,0.0,0.0,0.0,0.0,hui xue,MATH-4120,2018
-MATH,4190,1,Discrete Math Structures I,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,wayne goddard,MATH-4190,2018
-MATH,4190,2,Discrete Math Structures I,0.48,0.3,0.07,0.0,0.11,0.0,0.0,0.04,beth novick,MATH-4190,2018
-MATH,4340,1,Adv Engineering Mathematics,0.4,0.15,0.15,0.0,0.05,0.0,0.0,0.25,eleanor jenkins,MATH-4340,2018
-MATH,4340,2,Adv Engineering Mathematics,0.33,0.33,0.11,0.11,0.06,0.0,0.0,0.06,qingshan chen,MATH-4340,2018
-MATH,4350,1,Complex Variables,0.67,0.08,0.08,0.08,0.0,0.0,0.0,0.08,shitao liu,MATH-4350,2018
-MATH,4400,1,Linear Programming,0.57,0.13,0.09,0.09,0.04,0.0,0.0,0.09,yuyuan ouyang,MATH-4400,2018
-MATH,4530,1,Advanced Calculus I,0.48,0.22,0.19,0.0,0.07,0.0,0.0,0.04,james peterson,MATH-4530,2018
-MATH,4540,1,Advanced Calculus II,0.46,0.08,0.46,0.0,0.0,0.0,0.0,0.0,james peterson,MATH-4540,2018
-MATH,4560,1,Topology,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,james bar coykendall,MATH-4560,2018
-MATH,4630,1,Mathematical Analysis I,0.54,0.23,0.08,0.0,0.0,0.0,0.0,0.15,benjamin jaye,MATH-4630,2018
-MATH,4910,2,Mathematics of Option Pricing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,mark cawood,MATH-4910,2018
-MATH,6000,1,Theory of Probability,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,brian fralix,MATH-6000,2018
-MATH,6340,1,Adv Engineering Mathematics,0.43,0.37,0.1,0.0,0.07,0.0,0.0,0.03,vincent ervin,MATH-6340,2018
-MATH,8000,1,Probability,0.53,0.2,0.07,0.0,0.0,0.0,0.0,0.2,robert lund,MATH-8000,2018
-MATH,8010,1,General Linear Hypothesis I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,derek brown,MATH-8010,2018
-MATH,8050,1,Data Analysis,0.44,0.22,0.11,0.0,0.11,0.0,0.0,0.11,xiaoqian sun,MATH-8050,2018
-MATH,8100,1,Mathematical Programming,0.5,0.32,0.18,0.0,0.0,0.0,0.0,0.0,boshi yang,MATH-8100,2018
-MATH,8100,2,Mathematical Programming,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,yuyuan ouyang,MATH-8100,2018
-MATH,8140,1,Network Flow Programming,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,MATH-8140,2018
-MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,MATH-8170,2018
-MATH,8210,1,Linear Analysis,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,benjamin jaye,MATH-8210,2018
-MATH,8250,1,Intro to Dynamical Syst Theory,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,martin johan schmoll,MATH-8250,2018
-MATH,8530,1,Matrix Analysis,0.44,0.25,0.19,0.0,0.06,0.0,0.0,0.06,sean sather-wagstaff,MATH-8530,2018
-MATH,8600,1,Intro to Scientific Computing,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,fei xue,MATH-8600,2018
-MATH,8610,1,Advanced Numerical Analysis I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,qingshan chen,MATH-8610,2018
-MATH,8650,1,Data Structures,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,matthew saltzman,MATH-8650,2018
-MATH,8820,1,Intro to Bayesian Statistics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,MATH-8820,2018
-MBA,8030,1,Stat Analy of Bus Op,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett wood,MBA-8030,2018
-MBA,8030,2,Stat Analy of Bus Op,0.51,0.46,0.0,0.0,0.03,0.0,0.0,0.0,william ed kilbourne,MBA-8030,2018
-MBA,8040,20,Busin Data An & Stat Computing,0.62,0.35,0.0,0.0,0.0,0.0,0.0,0.03,william ed kilbourne,MBA-8040,2018
-MBA,8060,1,Operations Mgt,0.24,0.56,0.2,0.0,0.0,0.0,0.0,0.0, sridharan,MBA-8060,2018
-MBA,8060,2,Operations Mgt,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,george kennet morgan,MBA-8060,2018
-MBA,8070,1,Financial Management,0.67,0.28,0.03,0.0,0.0,0.0,0.0,0.03,george bran lockhart,MBA-8070,2018
-MBA,8070,2,Financial Management,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,george bran lockhart,MBA-8070,2018
-MBA,8090,1,Org Beh & Hum Res Mg,0.43,0.55,0.02,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,MBA-8090,2018
-MBA,8090,2,Org Beh & Hum Res Mg,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,thomas jos zagenczyk,MBA-8090,2018
-MBA,8180,20,Intro Business Intell & Anlytc,0.79,0.15,0.03,0.0,0.0,0.0,0.0,0.03,heshan sun,MBA-8180,2018
-MBA,8190,1,Intro to Acc and Fin,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,MBA-8190,2018
-MBA,8190,2,Intro to Acc and Fin,0.45,0.37,0.03,0.0,0.05,0.0,0.0,0.11,jeffrey mcmillan,MBA-8190,2018
-MBA,8290,1,Marketing Foundation,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MBA-8290,2018
-MBA,8310,10,Communications and Sales,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,MBA-8310,2018
-MBA,8370,1,Legal Environ of Bus,0.42,0.45,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2018
-MBA,8370,2,Legal Environ of Bus,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2018
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,MBA-8400,2018
-MBA,8430,1,Entrepreneurial Accounting,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,annieka philo,MBA-8430,2018
-MBA,8440,1,Entrepreneurial Law,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8440,2018
-MBA,8450,1,Technology & Innovation Mgt,0.72,0.2,0.04,0.0,0.0,0.0,0.0,0.04,michael george mino,MBA-8450,2018
-MBA,8480,5,Entrpr Mkting & Digital Strat,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,bruce snyder,MBA-8480,2018
-MBA,8490,5,Entrepreneurial Strategy,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,matthew charle klein,MBA-8490,2018
-MBA,8510,1,Bus Operations & Logistics,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0, sridharan,MBA-8510,2018
-MBA,8540,1,Managerial Accounting,0.35,0.58,0.05,0.0,0.0,0.0,0.0,0.03,emily suzan mccorkle,MBA-8540,2018
-MBA,8590,1,Mgr Decision Model,0.23,0.27,0.15,0.0,0.27,0.0,0.0,0.08,sara elizabeth yoder,MBA-8590,2018
-MBA,8590,2,Mgr Decision Model,0.45,0.37,0.18,0.0,0.0,0.0,0.0,0.0,magda gabriela sava,MBA-8590,2018
-MBA,8590,3,Mgr Decision Model,0.08,0.54,0.31,0.0,0.08,0.0,0.0,0.0,magda gabriela sava,MBA-8590,2018
-MBA,8600,1,Advanced Marketing Strategy,0.35,0.38,0.25,0.0,0.0,0.0,0.0,0.03,michael dorsch,MBA-8600,2018
-MBA,8600,2,Advanced Marketing Strategy,0.21,0.56,0.23,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2018
-MBA,8610,2,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,kevin mckenzie,MBA-8610,2018
-MBA,8620,1,Managerial Economics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,MBA-8620,2018
-MBA,8620,2,Managerial Economics,0.62,0.34,0.0,0.0,0.0,0.0,0.0,0.03,ronald earle gregory,MBA-8620,2018
-MBA,8620,4,Managerial Economics,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,MBA-8620,2018
-MBA,8650,1,Taxation of Business Decisions,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8650,2018
-MBA,8660,21,"Data, Storage, Business Decis",0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,MBA-8660,2018
-MBA,8700,1,Strategic Management,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,james turner,MBA-8700,2018
-MBA,8990,2,Creativity,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,MBA-8990,2018
-ME,2000,1,Sophomore Seminar,0.87,0.04,0.02,0.01,0.01,0.0,0.0,0.05,todd al schweisinger,ME-2000,2018
-ME,2000,2,Sophomore Seminar,0.83,0.07,0.04,0.02,0.0,0.0,0.0,0.05,todd al schweisinger,ME-2000,2018
-ME,2010,1,Statics & Dynamics,0.12,0.2,0.29,0.08,0.19,0.0,0.0,0.11,marisa kikendall orr,ME-2010,2018
-ME,2010,2,Statics & Dynamics,0.11,0.23,0.25,0.07,0.27,0.0,0.0,0.06,paul joseph,ME-2010,2018
-ME,2010,4,Statics & Dynamics,0.04,0.17,0.23,0.13,0.29,0.0,0.0,0.13,lonny thompson,ME-2010,2018
-ME,2030,1,Founda Th/Fl Syst,0.0,0.08,0.42,0.17,0.1,0.0,0.0,0.23,john saylor,ME-2030,2018
-ME,2220,2,Mechanical Engineering Lab I,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,ME-2220,2018
-ME,2220,3,Mechanical Engineering Lab I,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,5,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,6,Mechanical Engineering Lab I,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,7,Mechanical Engineering Lab I,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,todd al schweisinger,ME-2220,2018
-ME,2220,8,Mechanical Engineering Lab I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,13,Mechanical Engineering Lab I,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,15,Mechanical Engineering Lab I,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,ME-2220,2018
-ME,2220,16,Mechanical Engineering Lab I,0.25,0.42,0.25,0.0,0.08,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,3030,1,Thermodynamics,0.3,0.45,0.16,0.02,0.06,0.0,0.0,0.01,yiqiang han,ME-3030,2018
-ME,3030,2,Thermodynamics,0.3,0.37,0.22,0.08,0.0,0.0,0.0,0.03,yiqiang han,ME-3030,2018
-ME,3050,1,Model/an Dy Syst,0.19,0.26,0.4,0.05,0.07,0.0,0.0,0.02,joshua bostwick,ME-3050,2018
-ME,3050,2,Model/an Dy Syst,0.31,0.31,0.2,0.11,0.04,0.0,0.0,0.02,ardalan vahidi,ME-3050,2018
-ME,3060,1,Fund Machine Design,0.3,0.55,0.09,0.0,0.0,0.0,0.0,0.06,oliver myers,ME-3060,2018
-ME,3060,2,Fund Machine Design,0.24,0.52,0.22,0.02,0.0,0.0,0.0,0.0,james allen righter,ME-3060,2018
-ME,3070,1,Found of Mechanical Systems,0.23,0.49,0.2,0.04,0.03,0.0,0.0,0.01,jorge ivan rodriguez,ME-3070,2018
-ME,3070,2,Found of Mechanical Systems,0.43,0.38,0.14,0.02,0.0,0.0,0.0,0.03,jorge ivan rodriguez,ME-3070,2018
-ME,3080,1,Fluid Mechanics,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,ME-3080,2018
-ME,3080,2,Fluid Mechanics,0.28,0.3,0.3,0.04,0.04,0.0,0.0,0.02,yiqiang han,ME-3080,2018
-ME,3080,3,Fluid Mechanics,0.06,0.44,0.41,0.05,0.03,0.0,0.0,0.01,ethan kung,ME-3080,2018
-ME,3120,1,Manuf Processes,0.83,0.15,0.01,0.0,0.01,0.0,0.0,0.0,rodr martinez-duarte,ME-3120,2018
-ME,3330,1,Mechanical Engineering Lab II,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,ME-3330,2018
-ME,3330,2,Mechanical Engineering Lab II,0.25,0.44,0.25,0.06,0.0,0.0,0.0,0.0,james allen righter,ME-3330,2018
-ME,3330,3,Mechanical Engineering Lab II,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,ME-3330,2018
-ME,3330,6,Mechanical Engineering Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,ME-3330,2018
-ME,3330,7,Mechanical Engineering Lab II,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,james allen righter,ME-3330,2018
-ME,3330,8,Mechanical Engineering Lab II,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,james allen righter,ME-3330,2018
-ME,3330,9,Mechanical Engineering Lab II,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,james allen righter,ME-3330,2018
-ME,3330,10,Mechanical Engineering Lab II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,james allen righter,ME-3330,2018
-ME,4010,1,Mech Engr Design,0.3,0.59,0.08,0.0,0.0,0.0,0.0,0.03,joshua summers,ME-4010,2018
-ME,4010,2,Mech Engr Design,0.29,0.59,0.11,0.0,0.02,0.0,0.0,0.0,joshua summers,ME-4010,2018
-ME,4010,3,Mech Engr Design,0.26,0.59,0.1,0.02,0.03,0.0,0.0,0.0,joshua summers,ME-4010,2018
-ME,4020,1,Intern in Engr Des,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,cameron turner,ME-4020,2018
-ME,4020,3,Intern in Engr Des,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2018
-ME,4020,4,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lonny thompson,ME-4020,2018
-ME,4030,2,Control Dynamic Systems,0.34,0.36,0.26,0.01,0.01,0.0,0.0,0.01,suyi li,ME-4030,2018
-ME,4210,1,Intro to Comp Flow,0.33,0.43,0.19,0.05,0.0,0.0,0.0,0.0,chenning tong,ME-4210,2018
-ME,4290,1,Ther Env Control,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,ME-4290,2018
-ME,4400,1,Matls for Aggr Envir,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,garrett pataky,ME-4400,2018
-ME,4440,6,Mechanical Engineering Lab III,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2018
-ME,4540,1,Design of Machine Elements,0.24,0.62,0.1,0.0,0.05,0.0,0.0,0.0,hong seok choi,ME-4540,2018
-ME,4930,14,Sel.Topics ME - NonLinDy&Chas,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,ME-4930,2018
-ME,4930,39,Sel.Topics ME - Aero Propul,0.47,0.45,0.09,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-4930,2018
-ME,6540,1,Des Machine Elements,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-6540,2018
-ME,6540,843,Des Machine Elements,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-6540,2018
-ME,6930,14,Sel.Topics ME - NonLinDy&Chas,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,ME-6930,2018
-ME,8010,1,Found of Fluid Mech,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,richard figliola,ME-8010,2018
-ME,8100,1,Macroscopic Thermo,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,ME-8100,2018
-ME,8180,1,Intro to Fin Ele Ana,0.44,0.49,0.05,0.0,0.0,0.0,0.0,0.02,gang li,ME-8180,2018
-ME,8230,1,Control Systems,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,ME-8230,2018
-ME,8360,1,Fracture Mech,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,ME-8360,2018
-ME,8460,1,Inter Dynamics,0.56,0.11,0.33,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,ME-8460,2018
-ME,8710,1,Engr Optimization,0.47,0.35,0.06,0.0,0.06,0.0,0.0,0.06,georges fadel,ME-8710,2018
-ME,8930,9,Sel Topics - Continuum Mech.,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,gang li,ME-8930,2018
-ME,8930,27,SelTopics ME - OptimalControls,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,ME-8930,2018
-ME,8930,37,SelTopics ME - Laser Based Mfg,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,xin zhao,ME-8930,2018
-MGT,2010,1,Principles of Management,0.38,0.43,0.17,0.02,0.01,0.0,0.0,0.0,katherine clark,MGT-2010,2018
-MGT,2010,2,Principles of Management,0.56,0.34,0.08,0.01,0.01,0.0,0.0,0.01,tina robbins,MGT-2010,2018
-MGT,2010,8,Principles of Management,0.33,0.45,0.23,0.0,0.0,0.0,0.0,0.0,christopher mann,MGT-2010,2018
-MGT,2010,9,Principles of Management,0.3,0.5,0.15,0.03,0.03,0.0,0.0,0.0,christopher mann,MGT-2010,2018
-MGT,2010,10,Principles of Management,0.25,0.39,0.34,0.0,0.0,0.0,0.0,0.02,ashley willi parnell,MGT-2010,2018
-MGT,2010,11,Principles of Management,0.16,0.32,0.32,0.11,0.02,0.0,0.0,0.07,ashley willi parnell,MGT-2010,2018
-MGT,2180,1,Management PC Applications,0.47,0.38,0.08,0.03,0.02,0.0,0.0,0.02,ryan toole,MGT-2180,2018
-MGT,2180,2,Management PC Applications,0.2,0.56,0.16,0.08,0.0,0.0,0.0,0.0,ryan toole,MGT-2180,2018
-MGT,3070,1,Human Resource Management,0.38,0.48,0.15,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,MGT-3070,2018
-MGT,3070,3,Human Resource Management,0.45,0.45,0.08,0.0,0.03,0.0,0.0,0.0,kristin dama scott dama,MGT-3070,2018
-MGT,3070,4,Human Resource Management,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2018
-MGT,3070,5,Human Resource Management,0.33,0.46,0.21,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,MGT-3070,2018
-MGT,3070,6,Human Resource Management,0.6,0.33,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2018
-MGT,3070,7,Human Resource Management,0.28,0.55,0.15,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,MGT-3070,2018
-MGT,3070,8,Human Resource Management,0.42,0.33,0.15,0.06,0.0,0.0,0.0,0.03,priscilla harrison,MGT-3070,2018
-MGT,3100,1,Intermed Business Statistics,0.07,0.39,0.34,0.08,0.03,0.0,0.0,0.08,janis miller,MGT-3100,2018
-MGT,3100,2,Intermed Business Statistics,0.37,0.4,0.2,0.03,0.0,0.0,0.0,0.0,mustafa serka akturk,MGT-3100,2018
-MGT,3100,3,Intermed Business Statistics,0.35,0.3,0.13,0.05,0.08,0.0,0.0,0.1,daniel nielubowicz,MGT-3100,2018
-MGT,3100,5,Intermed Business Statistics,0.3,0.38,0.23,0.0,0.03,0.0,0.0,0.08,mustafa serka akturk,MGT-3100,2018
-MGT,3100,6,Intermed Business Statistics,0.2,0.46,0.2,0.02,0.07,0.0,0.0,0.07,magda gabriela sava,MGT-3100,2018
-MGT,3100,7,Intermed Business Statistics,0.36,0.19,0.17,0.06,0.17,0.0,0.0,0.06,daniel nielubowicz,MGT-3100,2018
-MGT,3100,8,Intermed Business Statistics,0.31,0.24,0.21,0.05,0.07,0.0,0.0,0.12,iaroslava vo dutchak,MGT-3100,2018
-MGT,3100,9,Intermed Business Statistics,0.69,0.24,0.05,0.0,0.02,0.0,0.0,0.0,maneeshred ajjuguttu,MGT-3100,2018
-MGT,3100,10,Intermed Business Statistics,0.56,0.25,0.13,0.03,0.0,0.0,0.0,0.03,jeromy blake snider,MGT-3100,2018
-MGT,3100,12,Intermed Business Statistics,0.3,0.19,0.24,0.08,0.08,0.0,0.0,0.11,daniel allan detoma,MGT-3100,2018
-MGT,3120,1,Decision Models for Management,0.22,0.21,0.27,0.08,0.08,0.0,0.0,0.14,sara elizabeth yoder,MGT-3120,2018
-MGT,3120,2,Decision Models for Management,0.19,0.31,0.34,0.02,0.1,0.0,0.0,0.05,sara elizabeth yoder,MGT-3120,2018
-MGT,3120,4,Decision Models for Management,0.29,0.37,0.26,0.0,0.05,0.0,0.0,0.03,james turner,MGT-3120,2018
-MGT,3180,1,Mgt of Info Systems,0.86,0.09,0.02,0.02,0.0,0.0,0.0,0.0,shih lun tseng,MGT-3180,2018
-MGT,3180,2,Mgt of Info Systems,0.28,0.33,0.3,0.05,0.0,0.0,0.0,0.05,marten risius,MGT-3180,2018
-MGT,3180,3,Mgt of Info Systems,0.87,0.12,0.02,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,MGT-3180,2018
-MGT,3180,4,Mgt of Info Systems,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,daniel aaron pienta,MGT-3180,2018
-MGT,3180,5,Mgt of Info Systems,0.4,0.35,0.23,0.0,0.0,0.0,0.0,0.03,wenxi pu,MGT-3180,2018
-MGT,3900,1,Operations Management,0.15,0.5,0.28,0.05,0.03,0.0,0.0,0.0,yann ferrand,MGT-3900,2018
-MGT,3900,2,Operations Management,0.08,0.5,0.38,0.03,0.0,0.0,0.0,0.03,zachary mor leffakis,MGT-3900,2018
-MGT,3900,4,Operations Management,0.12,0.33,0.26,0.08,0.06,0.0,0.0,0.15, sridharan,MGT-3900,2018
-MGT,4000,1,Mgt of Organizational Behavior,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2018
-MGT,4000,2,Mgt of Organizational Behavior,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2018
-MGT,4000,3,Mgt of Organizational Behavior,0.25,0.35,0.38,0.0,0.0,0.0,0.0,0.03,thomas jos zagenczyk,MGT-4000,2018
-MGT,4000,4,Mgt of Organizational Behavior,0.15,0.46,0.28,0.03,0.0,0.0,0.0,0.08,philip roth,MGT-4000,2018
-MGT,4020,1,Ops Pln and Ctl,0.06,0.33,0.56,0.06,0.0,0.0,0.0,0.0,zachary mor leffakis,MGT-4020,2018
-MGT,4080,1,Lean Operations,0.14,0.5,0.27,0.05,0.05,0.0,0.0,0.0,zachary mor leffakis,MGT-4080,2018
-MGT,4110,1,Project Management,0.23,0.6,0.13,0.0,0.0,0.0,0.0,0.05,russell purvis,MGT-4110,2018
-MGT,4120,1,Supplier Management,0.42,0.53,0.03,0.0,0.03,0.0,0.0,0.0,ahmet colak,MGT-4120,2018
-MGT,4150,1,Business Strategy,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2018
-MGT,4150,2,Business Strategy,0.16,0.44,0.33,0.02,0.0,0.0,0.0,0.04,james liddle,MGT-4150,2018
-MGT,4150,3,Business Strategy,0.12,0.64,0.21,0.02,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2018
-MGT,4150,4,Business Strategy,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,MGT-4150,2018
-MGT,4150,6,Business Strategy,0.11,0.37,0.45,0.05,0.0,0.0,0.0,0.03,james liddle,MGT-4150,2018
-MGT,4150,9,Business Strategy,0.36,0.52,0.11,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,MGT-4150,2018
-MGT,4160,1,Special Topics Hr,0.34,0.42,0.18,0.05,0.0,0.0,0.0,0.0,kristin dama scott dama,MGT-4160,2018
-MGT,4230,1,Intern Bus Mgt,0.07,0.33,0.55,0.0,0.02,0.0,0.0,0.02,wayne stewart,MGT-4230,2018
-MGT,4230,2,Intern Bus Mgt,0.2,0.15,0.57,0.07,0.02,0.0,0.0,0.0,wayne stewart,MGT-4230,2018
-MGT,4230,3,Intern Bus Mgt,0.05,0.53,0.38,0.03,0.0,0.0,0.0,0.03,janis miller,MGT-4230,2018
-MGT,4230,4,Intern Bus Mgt,0.09,0.59,0.25,0.07,0.0,0.0,0.0,0.0,janis miller,MGT-4230,2018
-MGT,4240,1,Global Supply Chain,0.32,0.44,0.24,0.0,0.0,0.0,0.0,0.0,yann ferrand,MGT-4240,2018
-MGT,4270,2,Managing Improvement,0.25,0.35,0.35,0.0,0.05,0.0,0.0,0.0,lawrence fredendall,MGT-4270,2018
-MGT,4310,1,Emp Rights & Resp,0.44,0.49,0.08,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,MGT-4310,2018
-MGT,4350,1,Pers Interviewing,0.34,0.39,0.16,0.11,0.0,0.0,0.0,0.0,philip roth,MGT-4350,2018
-MGT,4520,1,Business Analysis,0.21,0.36,0.27,0.03,0.03,0.0,0.0,0.09,marten risius,MGT-4520,2018
-MGT,8690,1,Project Mgt,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,MGT-8690,2018
-MICR,2050,1,Introductory Micro,0.38,0.43,0.19,0.01,0.0,0.0,0.0,0.0,john abercrombie,MICR-2050,2018
-MICR,3050,1,General Microbiology,0.29,0.42,0.24,0.03,0.01,0.0,0.0,0.02,krista barri rudolph,MICR-3050,2018
-MICR,3050,2,General Microbiology,0.52,0.37,0.09,0.02,0.0,0.0,0.0,0.0,krista barri rudolph,MICR-3050,2018
-MICR,4010,1,Microbial Diversity & Ecology,0.19,0.34,0.33,0.08,0.02,0.0,0.0,0.05,barbara campbell,MICR-4010,2018
-MICR,4050,1,Adv Microbial Ecol of Humans,0.5,0.26,0.16,0.09,0.0,0.0,0.0,0.0,kristi jam whitehead,MICR-4050,2018
-MICR,4140,1,Basic Immunology,0.46,0.28,0.15,0.09,0.0,0.0,0.0,0.02,yanzhang wei,MICR-4140,2018
-MICR,4150,1,Microbial Genetics,0.2,0.49,0.22,0.09,0.0,0.0,0.0,0.0,min cao,MICR-4150,2018
-MICR,4160,1,Intro Virology,0.69,0.2,0.09,0.0,0.01,0.0,0.0,0.01,kristi jam whitehead,MICR-4160,2018
-MICR,4510,1,Advanced Microbiology II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4510,2018
-MICR,4510,2,Advanced Microbiology II,0.45,0.5,0.0,0.0,0.05,0.0,0.0,0.0,harry kurtz,MICR-4510,2018
-MICR,4510,3,Advanced Microbiology II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4510,2018
-MICR,4560,1,Medical and Vet Parasitology,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kears milhous,MICR-4560,2018
-MICR,4940,11,CI: Microbes All Around Us,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,kristi jam whitehead,MICR-4940,2018
-MKT,3010,1,Principles of Marketing,0.19,0.4,0.27,0.1,0.02,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2018
-MKT,3010,2,Principles of Marketing,0.32,0.34,0.21,0.09,0.02,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2018
-MKT,3010,3,Principles of Marketing,0.33,0.33,0.26,0.05,0.02,0.0,0.0,0.01,amanda cooper fine,MKT-3010,2018
-MKT,3010,4,Principles of Marketing,0.27,0.41,0.24,0.05,0.03,0.0,0.0,0.0,carter will mcelveen,MKT-3010,2018
-MKT,3010,5,Principles of Marketing,0.36,0.34,0.22,0.06,0.02,0.0,0.0,0.01,carter will mcelveen,MKT-3010,2018
-MKT,3010,7,Principles of Marketing,0.27,0.41,0.23,0.01,0.01,0.0,0.0,0.07,james gaubert,MKT-3010,2018
-MKT,3020,1,Consumer Behavior,0.37,0.46,0.15,0.02,0.0,0.0,0.0,0.0,jennifer dia siemens,MKT-3020,2018
-MKT,3020,2,Consumer Behavior,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,jennifer dia siemens,MKT-3020,2018
-MKT,3020,3,Consumer Behavior,0.51,0.38,0.09,0.0,0.0,0.0,0.0,0.02,anastasia el thyroff,MKT-3020,2018
-MKT,3020,4,Consumer Behavior,0.37,0.51,0.12,0.0,0.0,0.0,0.0,0.0,anastasia el thyroff,MKT-3020,2018
-MKT,3020,5,Consumer Behavior,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,patricia knowles,MKT-3020,2018
-MKT,3210,1,Sports Marketing,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,MKT-3210,2018
-MKT,3210,2,Sports Marketing,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,MKT-3210,2018
-MKT,3220,1,Social Media Marketing,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-3220,2018
-MKT,3220,2,Social Media Marketing,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-3220,2018
-MKT,3220,3,Social Media Marketing,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,michele melto cauley,MKT-3220,2018
-MKT,3220,4,Social Media Marketing,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michele melto cauley,MKT-3220,2018
-MKT,3310,1,Marketing Metrics & Analytics,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,oriana rachel aragon,MKT-3310,2018
-MKT,3310,2,Marketing Metrics & Analytics,0.67,0.28,0.03,0.0,0.03,0.0,0.0,0.0,oriana rachel aragon,MKT-3310,2018
-MKT,3310,3,Marketing Metrics & Analytics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-3310,2018
-MKT,3310,4,Marketing Metrics & Analytics,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-3310,2018
-MKT,4200,1,Professional Selling,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2018
-MKT,4200,2,Professional Selling,0.71,0.23,0.06,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2018
-MKT,4200,3,Professional Selling,0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4200,2018
-MKT,4200,5,Professional Selling,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,carter will mcelveen,MKT-4200,2018
-MKT,4230,1,Promotional Strategy,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,patricia knowles,MKT-4230,2018
-MKT,4230,2,Promotional Strategy,0.77,0.16,0.03,0.03,0.0,0.0,0.0,0.0,michele melto cauley,MKT-4230,2018
-MKT,4230,3,Promotional Strategy,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,michele melto cauley,MKT-4230,2018
-MKT,4240,1,Sales Management,0.32,0.62,0.06,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4240,2018
-MKT,4270,1,International Marketing,0.51,0.46,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-4270,2018
-MKT,4270,2,International Marketing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-4270,2018
-MKT,4270,3,International Marketing,0.26,0.6,0.12,0.0,0.0,0.0,0.0,0.02,thomas poehlman,MKT-4270,2018
-MKT,4270,4,International Marketing,0.58,0.3,0.1,0.01,0.0,0.0,0.0,0.0,patricia knowles,MKT-4270,2018
-MKT,4280,1,Services Marketing,0.38,0.49,0.14,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4280,2018
-MKT,4280,2,Services Marketing,0.41,0.46,0.14,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4280,2018
-MKT,4310,3,Marketing Research,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2018
-MKT,4310,4,Marketing Research,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2018
-MKT,4450,1,Macromarketing,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,MKT-4450,2018
-MKT,4500,3,Strategic Mktg Mgt,0.25,0.5,0.21,0.04,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2018
-MKT,8610,1,Marketing Research,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,MKT-8610,2018
-MKT,8630,1,Buyer Behavior,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,MKT-8630,2018
-ML,2010,1,Leadership Development I,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2010,2018
-ML,2010,2,Leadership Development I,0.76,0.12,0.0,0.06,0.06,0.0,0.0,0.0,vincent john presto,ML-2010,2018
-ML,2010,3,Leadership Development I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2010,2018
-ML,3010,1,Advanced Leadership I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william cody cleland,ML-3010,2018
-ML,3010,2,Advanced Leadership I,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,william cody cleland,ML-3010,2018
-MSE,2100,1,Intro to Materials Science,0.34,0.27,0.16,0.12,0.04,0.0,0.0,0.07,rakhee pani,MSE-2100,2018
-MSE,2100,2,Intro to Materials Science,0.07,0.29,0.37,0.13,0.06,0.0,0.0,0.07,kai he,MSE-2100,2018
-MSE,2100,3,Intro to Materials Science,0.24,0.37,0.25,0.06,0.04,0.0,0.0,0.04,kyle brinkman,MSE-2100,2018
-MSE,2100,4,Intro to Materials Science,0.27,0.33,0.23,0.09,0.04,0.0,0.0,0.04,marian kennedy,MSE-2100,2018
-MSE,2100,5,Introduction to Materials Sci,0.41,0.29,0.09,0.18,0.0,0.0,0.0,0.03,olga kuksenok,MSE-2100,2018
-MSE,3010,4,Materials Synthesis & Fabr Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,MSE-3010,2018
-MSE,3190,1,Materials Proc I,0.35,0.55,0.09,0.0,0.0,0.0,0.0,0.01,rajendra kuma bordia,MSE-3190,2018
-MSE,3190,2,Materials Proc I,0.2,0.47,0.2,0.13,0.0,0.0,0.0,0.0,rajendra kuma bordia,MSE-3190,2018
-MSE,3260,1,Thermo of Materials,0.23,0.37,0.26,0.09,0.03,0.0,0.0,0.03,fei peng,MSE-3260,2018
-MSE,3260,2,Thermo of Materials,0.18,0.47,0.18,0.13,0.0,0.0,0.0,0.03,fei peng,MSE-3260,2018
-MSE,3270,1,Transport Phenomena,0.38,0.23,0.23,0.08,0.08,0.0,0.0,0.0,ulf daniel schiller,MSE-3270,2018
-MSE,4020,1,Solid State Material,0.45,0.14,0.3,0.07,0.02,0.0,0.0,0.02,luiz gusta jacobsohn,MSE-4020,2018
-MSE,4130,1,Noncrystalline Materials,0.54,0.38,0.0,0.04,0.04,0.0,0.0,0.0,jianhua tong,MSE-4130,2018
-MSE,4150,1,Polymer Sc Engr,0.42,0.33,0.18,0.06,0.0,0.0,0.0,0.0,igor luzinov,MSE-4150,2018
-MSE,4150,2,Polymer Sc Engr,0.5,0.19,0.24,0.02,0.02,0.0,0.0,0.04,rakhee pani,MSE-4150,2018
-MSE,4320,1,Manuf Proc & Systems,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,MSE-4320,2018
-MSE,4580,1,Surf Phen in Ms&E,0.25,0.17,0.33,0.08,0.13,0.0,0.0,0.04,konstantin ge kornev,MSE-4580,2018
-MSE,4610,1,Polymer & Fiber Materials III,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,philip brown,MSE-4610,2018
-MSE,4810,1,Undergraduate Research Fundame,0.64,0.22,0.11,0.02,0.0,0.0,0.0,0.0,marian kennedy,MSE-4810,2018
-MSE,4910,1,Undergraduate Research,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kuma bordia,MSE-4910,2018
-MSE,8100,1,Fundamentals of Materials Sci,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,igor luzinov,MSE-8100,2018
-MSE,8260,1,Phase Equil Mat Sys,0.43,0.5,0.0,0.0,0.07,0.0,0.0,0.0,stephen foulger,MSE-8260,2018
-MSE,8270,1,Kin of Phase Tran,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,konstantin ge kornev,MSE-8270,2018
-MUSC,1420,1,Music Theory I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david conley,MUSC-1420,2018
-MUSC,1430,1,Aural Skills I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david conley,MUSC-1430,2018
-MUSC,1510,2,Applied Music,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,jonathan edwar doyel,MUSC-1510,2018
-MUSC,2100,2,Music in the Western World,0.53,0.41,0.03,0.0,0.0,0.0,0.0,0.03,lisa sain odom,MUSC-2100,2018
-MUSC,2100,4,Music in the Western World,0.58,0.1,0.13,0.06,0.0,0.0,0.0,0.13,linda li-bleuel,MUSC-2100,2018
-MUSC,2100,6,Music in the Western World,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2018
-MUSC,2100,7,Music in the Western World,0.33,0.47,0.17,0.0,0.03,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2018
-MUSC,2100,8,Music in the Western World,0.44,0.48,0.04,0.0,0.0,0.0,0.0,0.04,rhea beth jacobus,MUSC-2100,2018
-MUSC,2100,12,Music in the Western World,0.72,0.19,0.0,0.0,0.03,0.0,0.0,0.06,lea kibler,MUSC-2100,2018
-MUSC,3110,1,History of American Music,0.65,0.26,0.03,0.03,0.03,0.0,0.0,0.0,ned hosler,MUSC-3110,2018
-MUSC,3120,1,History of Jazz,0.75,0.18,0.04,0.04,0.0,0.0,0.0,0.0,eric lapin,MUSC-3120,2018
-MUSC,3170,1,Hist of Country Mus,0.72,0.19,0.0,0.03,0.03,0.0,0.0,0.03,ned hosler,MUSC-3170,2018
-MUSC,3180,1,Hist of Audio Tech,0.42,0.37,0.11,0.05,0.05,0.0,0.0,0.0,bruce allen whisler,MUSC-3180,2018
-MUSC,3610,1,Marching Band,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,MUSC-3610,2018
-MUSC,3980,1,Special Topics,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,hamilton altstatt,MUSC-3980,2018
-MUSC,4150,1,Music Hist to 1750,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,linda dzuris,MUSC-4150,2018
-NPL,3000,1,Nonprofit Leadership,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,christina mari mazer,NPL-3000,2018
-NPL,3000,2,Nonprofit Leadership,0.33,0.61,0.0,0.0,0.06,0.0,0.0,0.0,bonnie westb stevens,NPL-3000,2018
-NPL,3000,3,Nonprofit Leadership,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,christina mari mazer,NPL-3000,2018
-NPL,3000,4,Nonprofit Leadership,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,corey doug brookover,NPL-3000,2018
-NPL,3000,5,Nonprofit Leadership,0.55,0.2,0.2,0.0,0.05,0.0,0.0,0.0,corey doug brookover,NPL-3000,2018
-NPL,3000,6,Nonprofit Leadership,0.45,0.45,0.05,0.0,0.05,0.0,0.0,0.0,corey doug brookover,NPL-3000,2018
-NPL,3000,7,Nonprofit Leadership,0.3,0.5,0.05,0.05,0.0,0.0,0.0,0.1,bonnie westb stevens,NPL-3000,2018
-NPL,3000,8,Nonprofit Leadership,0.58,0.29,0.08,0.0,0.04,0.0,0.0,0.0,christina mari mazer,NPL-3000,2018
-NPL,3000,9,Nonprofit Leadership,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,christina mari mazer,NPL-3000,2018
-NPL,3010,1,NPL Stakeholders,0.5,0.33,0.06,0.0,0.11,0.0,0.0,0.0,christina mari mazer,NPL-3010,2018
-NPL,3020,1,NPL Fundraising,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,robert brookover,NPL-3020,2018
-NPL,3030,1,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,corey doug brookover,NPL-3030,2018
-NPL,3040,1,NPL Risk Management,0.7,0.1,0.0,0.15,0.05,0.0,0.0,0.0,daniel morg anderson,NPL-3040,2018
-NPL,3050,2,Strat Social Media for NP Org,0.44,0.22,0.19,0.0,0.11,0.0,0.0,0.04,amanda elizabe moore,NPL-3050,2018
-NURS,3030,1,Nursing of Adults,0.42,0.56,0.02,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2018
-NURS,3040,1,Pathophysiology,0.45,0.35,0.15,0.02,0.03,0.0,0.0,0.0,catherine sik murton,NURS-3040,2018
-NURS,3040,2,Pathophysiology,0.36,0.55,0.05,0.04,0.0,0.0,0.0,0.0,amy boggs garrison,NURS-3040,2018
-NURS,3040,400,Pathophysiology,0.44,0.52,0.0,0.04,0.0,0.0,0.0,0.0,amy boggs garrison,NURS-3040,2018
-NURS,3040,401,Pathophysiology,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,elizabeth cam hassen,NURS-3040,2018
-NURS,3050,1,Psychosocial Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,NURS-3050,2018
-NURS,3100,400,Health Assessment,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,NURS-3100,2018
-NURS,3120,1,Foundations of Nursing,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,NURS-3120,2018
-NURS,3120,2,Foundations of Nursing,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,NURS-3120,2018
-NURS,3120,400,Foundations of Nursing,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,NURS-3120,2018
-NURS,3200,1,Prof in Nurs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3200,2018
-NURS,3300,1,Research in Nursing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-3300,2018
-NURS,3330,400,Health Care Genetics,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,NURS-3330,2018
-NURS,3400,1,Pharmther Nursing,0.45,0.35,0.12,0.05,0.03,0.0,0.0,0.0,catherine sik murton,NURS-3400,2018
-NURS,3400,2,Pharmther Nursing,0.39,0.46,0.11,0.04,0.0,0.0,0.0,0.0,jenna lynn seawright,NURS-3400,2018
-NURS,3400,400,Pharmther Nursing,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jenna lynn seawright,NURS-3400,2018
-NURS,3600,400,Social Determinants in Health,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,roxanne amerson,NURS-3600,2018
-NURS,4010,1,Mental Health Nurs,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,NURS-4010,2018
-NURS,4060,400,Issues in Professionalism,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,NURS-4060,2018
-NURS,4110,1,Nursing of Children,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,NURS-4110,2018
-NURS,4120,1,Nurs Women and Fam,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2018
-NURS,4250,400,Community Nursing,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,tiffany leah stewart,NURS-4250,2018
-NURS,4980,17,Neonatal Abstinence Syndrome,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,heide temples,NURS-4980,2018
-NURS,8040,400,Dev Nurs Knowledge,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,stephanie clar davis,NURS-8040,2018
-NURS,8050,400,Pharmaco Adv Nurs,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8050,2018
-NURS,8050,401,Pharmaco Adv Nurs,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8050,2018
-NURS,8060,400,Advan Assessment for Nursing,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,jennifer geter rice,NURS-8060,2018
-NURS,8090,400,Pathophysiology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,NURS-8090,2018
-NURS,8180,400,Develop Family in Primary Care,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-8180,2018
-NURS,8190,400,Developing Family,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-8190,2018
-NURS,8200,400,Child & Adol Nursing,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,heide temples,NURS-8200,2018
-NURS,9010,1,"DNP Role, Theory & Philosophy",0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,jean ellen zavertnik,NURS-9010,2018
-NURS,9020,1,DNP Clinical Epidem & Biostats,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,veronica parker,NURS-9020,2018
-NUTR,2030,1,Intro Princ of Human Nutrition,0.86,0.09,0.0,0.01,0.03,0.0,0.0,0.0,bridgit deni corbett,NUTR-2030,2018
-NUTR,2030,2,Intro Princ of Human Nutrition,0.67,0.25,0.05,0.0,0.0,0.0,0.0,0.02,bridgit deni corbett,NUTR-2030,2018
-NUTR,2050,400,Nutrition for Nursing Prof,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,NUTR-2050,2018
-NUTR,2160,1,Evidence-Based Nutrition,0.88,0.06,0.05,0.0,0.01,0.0,0.0,0.0,angela fraser,NUTR-2160,2018
-NUTR,3020,1,Nutrition Assessment,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,elliot jesch,NUTR-3020,2018
-NUTR,4240,1,Medical Nutr Thera I,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4240,2018
-NUTR,4510,1,Human Nutrition & Metabolism I,0.31,0.26,0.17,0.17,0.03,0.0,0.0,0.06,elliot jesch,NUTR-4510,2018
-PA,1010,1,Intro to Perf Arts,0.72,0.2,0.0,0.0,0.08,0.0,0.0,0.0,david hartmann,PA-1010,2018
-PA,2790,1,Perf Arts Pract I,0.47,0.41,0.0,0.0,0.0,0.0,0.0,0.12,kenneth moore,PA-2790,2018
-PADM,8210,400,Perspectives on Public Admin,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,thomas walker,PADM-8210,2018
-PADM,8210,401,Perspectives on Public Admin,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,thomas walker,PADM-8210,2018
-PADM,8420,400,GIS for Public Administrators,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,david lawrence white,PADM-8420,2018
-PADM,8450,400,Grant Writing for Public Admin,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,katherin kransteuber,PADM-8450,2018
-PADM,8530,400,Homeland Sec/Emergency Mgt Law,0.64,0.09,0.0,0.0,0.09,0.0,0.0,0.18,david leigh cook,PADM-8530,2018
-PADM,8600,400,American Government,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,alfred bundrick,PADM-8600,2018
-PADM,8670,401,State Government Admin,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,alfred bundrick,PADM-8670,2018
-PADM,8710,401,Sustainability Practices Appli,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,david morgan young,PADM-8710,2018
-PAS,3010,1,Intro to Pan African Studies,0.27,0.47,0.15,0.02,0.04,0.0,0.0,0.05,abel bartley,PAS-3010,2018
-PES,1040,1,Introduction to Plant Sciences,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,PES-1040,2018
-PES,2020,1,Soils,0.14,0.49,0.27,0.08,0.02,0.0,0.0,0.0,dara michelle park,PES-2020,2018
-PES,3150,1,Environment and Agriculture,0.3,0.3,0.3,0.0,0.0,0.0,0.0,0.1,suseela appukuttan,PES-3150,2018
-PHIL,1010,1,Intro to Philosophic Problems,0.38,0.53,0.09,0.0,0.0,0.0,0.0,0.0,kelly smith,PHIL-1010,2018
-PHIL,1010,2,Intro to Philosophic Problems,0.42,0.32,0.11,0.05,0.11,0.0,0.0,0.0,kelly smith,PHIL-1010,2018
-PHIL,1010,3,Intro to Philosophic Problems,0.37,0.32,0.11,0.05,0.11,0.0,0.0,0.05,christopher grau,PHIL-1010,2018
-PHIL,1010,5,Intro to Philosophic Problems,0.56,0.32,0.06,0.0,0.03,0.0,0.0,0.03,david stegall,PHIL-1010,2018
-PHIL,1010,6,Intro to Philosophic Problems,0.38,0.35,0.03,0.09,0.03,0.0,0.0,0.12,david stegall,PHIL-1010,2018
-PHIL,1020,5,Introduction to Logic,0.29,0.37,0.03,0.17,0.03,0.0,0.0,0.11,david stegall,PHIL-1020,2018
-PHIL,1020,6,Introduction to Logic,0.39,0.36,0.09,0.0,0.03,0.0,0.0,0.12,david stegall,PHIL-1020,2018
-PHIL,1020,7,Introduction to Logic,0.47,0.32,0.18,0.03,0.0,0.0,0.0,0.0,adam gies,PHIL-1020,2018
-PHIL,1020,8,Introduction to Logic,0.41,0.29,0.12,0.18,0.0,0.0,0.0,0.0,adam gies,PHIL-1020,2018
-PHIL,1020,9,Introduction to Logic,0.56,0.22,0.11,0.0,0.06,0.0,0.0,0.06,adam gies,PHIL-1020,2018
-PHIL,1020,10,Introduction to Logic,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,adam gies,PHIL-1020,2018
-PHIL,1030,1,Introduction to Ethics,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,stephen satris,PHIL-1030,2018
-PHIL,1030,2,Introduction to Ethics,0.49,0.31,0.09,0.09,0.03,0.0,0.0,0.0,stephen satris,PHIL-1030,2018
-PHIL,1030,4,Introduction to Ethics,0.59,0.19,0.09,0.0,0.06,0.0,0.0,0.06,edyta joanna kuzian,PHIL-1030,2018
-PHIL,1030,5,Introduction to Ethics,0.48,0.3,0.15,0.0,0.0,0.0,0.0,0.06,edyta joanna kuzian,PHIL-1030,2018
-PHIL,1030,6,Introduction to Ethics,0.65,0.26,0.06,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,PHIL-1030,2018
-PHIL,3040,1,Moral Philosophy,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,todd may,PHIL-3040,2018
-PHIL,3150,1,Ancient Philosophy,0.39,0.26,0.23,0.03,0.03,0.0,0.0,0.06,stephen satris,PHIL-3150,2018
-PHIL,3210,1,Crime & Punishment,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,daniel wueste,PHIL-3210,2018
-PHIL,3430,1,Philosophy of Law,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,brookes colyto brown,PHIL-3430,2018
-PHIL,3440,1,Business Ethics,0.08,0.69,0.08,0.0,0.08,0.0,0.0,0.08,brookes colyto brown,PHIL-3440,2018
-PHIL,3480,1,Philosophies of Art,0.67,0.22,0.0,0.06,0.0,0.0,0.0,0.06,christopher grau,PHIL-3480,2018
-PHIL,3490,1,Gender and Sexuality,0.65,0.12,0.18,0.0,0.0,0.0,0.0,0.06,diane perpich,PHIL-3490,2018
-PHIL,4020,1,Recovery in Ethics,0.2,0.7,0.0,0.0,0.1,0.0,0.0,0.0,daniel wueste,PHIL-4020,2018
-PHIL,4220,1,Anarchism,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,todd may,PHIL-4220,2018
-PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.66,0.32,0.0,0.0,0.0,0.0,0.0,0.02,minory nammouz,PHSC-1180,2018
-PHYS,1220,1,Physics with Calculus I,0.31,0.25,0.22,0.11,0.06,0.0,0.0,0.05,lih-sin the,PHYS-1220,2018
-PHYS,1220,2,Physics with Calculus I,0.26,0.38,0.2,0.1,0.02,0.0,0.0,0.04,lih-sin the,PHYS-1220,2018
-PHYS,1220,7,Physics with Calculus I (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,hugo sanabria,PHYS-1220,2018
-PHYS,1240,1,Physics Lab I,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,2,Physics Lab I,0.17,0.67,0.11,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,3,Physics Lab I,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,4,Physics Lab I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,5,Physics Lab I,0.28,0.39,0.28,0.0,0.06,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,6,Physics Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,7,Physics Lab I,0.17,0.56,0.17,0.11,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,8,Physics Lab I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,9,Physics Lab I,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,10,Physics Lab I,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,11,Physics Lab I,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,12,Physics Lab I,0.46,0.31,0.08,0.0,0.0,0.0,0.0,0.15,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,14,Physics Lab I,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,15,Physics Lab I,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,16,Physics Lab I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,17,Physics Lab I,0.69,0.08,0.08,0.0,0.0,0.0,0.0,0.15,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,18,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,19,Physics Lab I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,20,Physics Lab I,0.72,0.17,0.0,0.0,0.11,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,2070,1,General Physics I,0.35,0.31,0.18,0.05,0.06,0.0,0.0,0.05,amy liann pope,PHYS-2070,2018
-PHYS,2070,2,General Physics I,0.41,0.33,0.16,0.04,0.03,0.0,0.0,0.03,amy liann pope,PHYS-2070,2018
-PHYS,2070,3,General Physics I,0.44,0.31,0.14,0.05,0.02,0.0,0.0,0.05,amy liann pope,PHYS-2070,2018
-PHYS,2070,4,General Physics I,0.11,0.33,0.3,0.07,0.07,0.0,0.0,0.11,amy liann pope,PHYS-2070,2018
-PHYS,2080,1,General Physics II,0.44,0.4,0.09,0.02,0.02,0.0,0.0,0.02,pooja puneet,PHYS-2080,2018
-PHYS,2090,1,Gen Phys Lab I,0.43,0.43,0.09,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,2,Gen Phys Lab I,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,3,Gen Phys Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,4,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,5,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,6,Gen Phys Lab I,0.21,0.42,0.29,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,7,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,8,Gen Phys Lab I,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,9,Gen Phys Lab I,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,10,Gen Phys Lab I,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,11,Gen Phys Lab I,0.5,0.42,0.04,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,12,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,13,Gen Phys Lab I,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,14,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,15,Gen Phys Lab I,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,16,Gen Phys Lab I,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,17,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,18,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,19,Gen Phys Lab I,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,20,Gen Phys Lab I,0.61,0.35,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,21,Gen Phys Lab I,0.17,0.74,0.0,0.04,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,22,Gen Phys Lab I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,23,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,24,Gen Phys Lab I,0.42,0.46,0.08,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,25,Gen Phys Lab I,0.13,0.83,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,26,Gen Phys Lab I,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,27,Gen Phys Lab I,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2100,1,Gen Phys Lab II,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,2,Gen Phys Lab II,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,3,Gen Phys Lab II,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,4,Gen Phys Lab II,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,6,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,7,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,8,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,9,Gen Phys Lab II,0.96,0.0,0.0,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2210,1,Physics with Calculus II,0.28,0.4,0.23,0.04,0.04,0.0,0.0,0.01,jason stratfor brown,PHYS-2210,2018
-PHYS,2210,2,Physics with Calculus II,0.18,0.45,0.28,0.06,0.02,0.0,0.0,0.01,jason stratfor brown,PHYS-2210,2018
-PHYS,2210,3,Physics with Calculus II,0.34,0.44,0.15,0.02,0.03,0.0,0.0,0.01,jason stratfor brown,PHYS-2210,2018
-PHYS,2210,4,Physics with Calculus II,0.13,0.5,0.26,0.05,0.05,0.0,0.0,0.01,jason stratfor brown,PHYS-2210,2018
-PHYS,2210,8,Physics with Calculus II (HON),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,PHYS-2210,2018
-PHYS,2220,1,Physics with Calculus III,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,jian he,PHYS-2220,2018
-PHYS,2230,1,Physics Lab II,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,2,Physics Lab II,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,3,Physics Lab II,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,4,Physics Lab II,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,5,Physics Lab II,0.29,0.53,0.06,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,6,Physics Lab II,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,7,Physics Lab II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,9,Physics Lab II,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,10,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,11,Physics Lab II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,12,Physics Lab II,0.18,0.76,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,13,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,14,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,17,Physics Lab II,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,PHYS-2230,2018
-PHYS,2450,1,Physics of Climate,0.51,0.3,0.09,0.01,0.02,0.0,0.0,0.07,gerald lehmacher,PHYS-2450,2018
-PHYS,3000,1,Intro to Research,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,PHYS-3000,2018
-PHYS,3120,1,Meth Theor Phys II,0.5,0.2,0.3,0.0,0.0,0.0,0.0,0.0,lih-sin the,PHYS-3120,2018
-PHYS,3150,1,Intro to Computational Physics,0.64,0.14,0.07,0.0,0.0,0.0,0.0,0.14,emil georgiev alexov,PHYS-3150,2018
-PHYS,3210,1,Mechanics I,0.23,0.42,0.19,0.04,0.0,0.0,0.0,0.12,stephen rol kaeppler,PHYS-3210,2018
-PHYS,4410,1,Electromagnetics I,0.33,0.28,0.28,0.06,0.0,0.0,0.0,0.06,xian lu,PHYS-4410,2018
-PHYS,4550,1,Quantum Physics I,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,sumanta tewari,PHYS-4550,2018
-PHYS,8110,1,Meth of Theor Phys I,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,feng ding,PHYS-8110,2018
-PHYS,8210,1,Classical Mech I,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,dieter hartmann,PHYS-8210,2018
-PHYS,8750,2,Intro to Research Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,PHYS-8750,2018
-PHYS,9510,1,Quantum Mech I,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,domnita ca marinescu,PHYS-9510,2018
-PKSC,1010,1,Pkgsc Orientation,0.27,0.53,0.18,0.0,0.0,0.0,0.0,0.01,marcondes pat guerra,PKSC-1010,2018
-PKSC,1020,1,Intro to Pkg Sci,0.08,0.32,0.3,0.21,0.05,0.0,0.0,0.04,heather batt,PKSC-1020,2018
-PKSC,2020,1,Packaging Mtl & Mfg,0.29,0.46,0.19,0.06,0.0,0.0,0.0,0.0,marcondes pat guerra,PKSC-2020,2018
-PKSC,2040,1,Container Systems,0.28,0.53,0.13,0.03,0.03,0.0,0.0,0.0,marcondes pat guerra,PKSC-2040,2018
-PKSC,3200,1,Pkg Design Theory,0.83,0.04,0.09,0.0,0.0,0.0,0.0,0.04,rupert hurley,PKSC-3200,2018
-PKSC,4010,1,Packaging Machinery,0.36,0.54,0.05,0.03,0.0,0.0,0.0,0.03,anthony loui pometto,PKSC-4010,2018
-PKSC,4030,1,Pkg Career Prep,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2018
-PKSC,4040,1,Protective Packaging Prop/Prin,0.4,0.36,0.16,0.0,0.06,0.0,0.0,0.03,gregory batt,PKSC-4040,2018
-PKSC,4160,1,Appl Polymers in Pkg,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,duncan darby,PKSC-4160,2018
-PKSC,4200,1,Pkg Design & Dev,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2018
-PKSC,4540,1,Prod Pkg Evl Lab,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2018
-PKSC,4540,2,Prod Pkg Evl Lab,0.25,0.56,0.06,0.0,0.06,0.0,0.0,0.06,gregory batt,PKSC-4540,2018
-PKSC,4540,3,Prod Pkg Evl Lab,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2018
-PKSC,4540,4,Prod Pkg Evl Lab,0.56,0.25,0.06,0.13,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2018
-PKSC,4640,1,Food & Health Care Pkg Systems,0.6,0.3,0.09,0.0,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2018
-PKSC,4990,7,CI-Packaging  Sci Seminar,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,rupert hurley,PKSC-4990,2018
-PLPA,3100,1,Principles of Plant Pathology,0.14,0.46,0.39,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,PLPA-3100,2018
-PLPA,4250,1,Introductory Mycology,0.33,0.25,0.08,0.25,0.08,0.0,0.0,0.0,julia louis kerrigan,PLPA-4250,2018
-POSC,1010,1,Amer National Govt,0.21,0.44,0.25,0.07,0.0,0.0,0.0,0.04,joseph earl stewart,POSC-1010,2018
-POSC,1010,2,Amer National Govt,0.54,0.22,0.2,0.02,0.0,0.0,0.0,0.02,jeffrey allen fine,POSC-1010,2018
-POSC,1020,1,Intro Intl Relations,0.36,0.36,0.15,0.07,0.02,0.0,0.0,0.04,steven vincen miller,POSC-1020,2018
-POSC,1020,2,Intro Intl Relations,0.19,0.38,0.27,0.05,0.03,0.0,0.0,0.08,zeynep taydas,POSC-1020,2018
-POSC,1020,3,Intro Intl Relations,0.17,0.37,0.27,0.06,0.08,0.0,0.0,0.05,zeynep taydas,POSC-1020,2018
-POSC,1040,1,Intro Compar Pol,0.17,0.43,0.26,0.0,0.0,0.0,0.0,0.13,xiaobo hu,POSC-1040,2018
-POSC,1040,2,Intro Compar Pol,0.29,0.45,0.17,0.05,0.05,0.0,0.0,0.0,katherine amb curtis,POSC-1040,2018
-POSC,1990,1,Intro Pol Sci,0.6,0.22,0.07,0.04,0.05,0.0,0.0,0.02,meredith- petersheim,POSC-1990,2018
-POSC,3020,1,State and Loc Gov,0.31,0.49,0.09,0.0,0.09,0.0,0.0,0.02,bruce ransom,POSC-3020,2018
-POSC,3610,1,International Conflict,0.39,0.22,0.16,0.0,0.12,0.0,0.0,0.1,steven vincen miller,POSC-3610,2018
-POSC,3630,1,Us Foreign Policy,0.3,0.51,0.11,0.04,0.02,0.0,0.0,0.02,vladimir matic,POSC-3630,2018
-POSC,3710,1,European Politics,0.41,0.44,0.1,0.0,0.05,0.0,0.0,0.0,vladimir matic,POSC-3710,2018
-POSC,4030,1,United States Congress,0.26,0.47,0.17,0.04,0.02,0.0,0.0,0.04,jeffrey scott peake,POSC-4030,2018
-POSC,4210,1,Public Policy,0.12,0.35,0.24,0.06,0.18,0.0,0.0,0.06,adam warber,POSC-4210,2018
-POSC,4230,1,Urban Politics,0.5,0.28,0.06,0.0,0.06,0.0,0.0,0.11,bruce ransom,POSC-4230,2018
-POSC,4360,1,Law Courts Politics,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,joseph earl stewart,POSC-4360,2018
-POSC,4470,1,International Law,0.4,0.23,0.13,0.13,0.0,0.0,0.0,0.1,katherine amb curtis,POSC-4470,2018
-POSC,4490,1,Political Theory of Capitalism,0.27,0.55,0.09,0.03,0.06,0.0,0.0,0.0,colin denby pearce,POSC-4490,2018
-POSC,4550,1,Pol Thght of American Founding,0.38,0.34,0.23,0.0,0.04,0.0,0.0,0.0, bradley thompson,POSC-4550,2018
-POSC,4560,1,Diplomacy,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,vladimir matic,POSC-4560,2018
-POSC,4760,1,Middle East Politics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,POSC-4760,2018
-PRTM,2200,10,Foundations of PRTM,0.35,0.43,0.16,0.02,0.02,0.0,0.0,0.02,jamie lynn cathey,PRTM-2200,2018
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2260,2018
-PRTM,2260,2,Fnd of Mgt Adm PRTM,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth de baldwin,PRTM-2260,2018
-PRTM,2260,3,Fnd of Mgt Adm PRTM,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2260,2018
-PRTM,2260,4,Fnd of Mgt Adm PRTM,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2260,2018
-PRTM,2260,5,Fnd of Mgt Adm PRTM,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,gwynn powell,PRTM-2260,2018
-PRTM,2260,6,Fnd of Mgt Adm PRTM,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,katrina latric black,PRTM-2260,2018
-PRTM,2260,7,Fnd of Mgt Adm PRTM,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,katie dudley,PRTM-2260,2018
-PRTM,2260,8,Fnd of Mgt Adm PRTM,0.69,0.15,0.0,0.08,0.08,0.0,0.0,0.0,lauren eliz stephens,PRTM-2260,2018
-PRTM,2270,1,Prov of Leisure Exp,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2270,2018
-PRTM,2270,2,Prov of Leisure Exp,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth de baldwin,PRTM-2270,2018
-PRTM,2270,3,Prov of Leisure Exp,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-2270,2018
-PRTM,2270,4,Prov of Leisure Exp,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2270,2018
-PRTM,2270,5,Prov of Leisure Exp,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,gwynn powell,PRTM-2270,2018
-PRTM,2270,6,Prov of Leisure Exp,0.13,0.69,0.06,0.13,0.0,0.0,0.0,0.0,katrina latric black,PRTM-2270,2018
-PRTM,2270,7,Prov of Leisure Exp,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,katie dudley,PRTM-2270,2018
-PRTM,2270,8,Prov of Leisure Exp,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,lauren eliz stephens,PRTM-2270,2018
-PRTM,2290,1,Competency Integration in PRTM,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2290,2018
-PRTM,2290,2,Competency Integration in PRTM,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,elizabeth de baldwin,PRTM-2290,2018
-PRTM,2290,3,Competency Integration in PRTM,0.33,0.47,0.13,0.07,0.0,0.0,0.0,0.0,robert brookover,PRTM-2290,2018
-PRTM,2290,4,Competency Integration in PRTM,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2290,2018
-PRTM,2290,5,Competency Integration in PRTM,0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,gwynn powell,PRTM-2290,2018
-PRTM,2290,6,Competency Integration in PRTM,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,katrina latric black,PRTM-2290,2018
-PRTM,2290,7,Competency Integration in PRTM,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,katie dudley,PRTM-2290,2018
-PRTM,2290,8,Competency Integration in PRTM,0.77,0.08,0.0,0.08,0.08,0.0,0.0,0.0,lauren eliz stephens,PRTM-2290,2018
-PRTM,2950,1,Pro Golf Management Seminar II,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-2950,2018
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.52,0.17,0.28,0.0,0.0,0.0,0.0,0.03,daniel morg anderson,PRTM-3050,2018
-PRTM,3070,2,Facility Operations,0.85,0.09,0.06,0.0,0.0,0.0,0.0,0.0,raymond dunham,PRTM-3070,2018
-PRTM,3200,1,Recreation Policy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,matthew tyl brownlee,PRTM-3200,2018
-PRTM,3220,1,Facilitation Techniques in RT,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,PRTM-3220,2018
-PRTM,3230,1,Prof Prep for RT Practice,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,PRTM-3230,2018
-PRTM,3240,1,Assessment & Planning in RT,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3240,2018
-PRTM,3300,1,Visit Ser & Interp,0.64,0.14,0.21,0.0,0.0,0.0,0.0,0.0,michael pa blacketer,PRTM-3300,2018
-PRTM,3430,1,Spl Asp of Tourist B,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,'lisha fogle,PRTM-3430,2018
-PRTM,3470,1,Sport Tourism,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,gregory phil ramshaw,PRTM-3470,2018
-PRTM,3520,1,Camp Org and Admin,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,lisa kay-powle olsen,PRTM-3520,2018
-PRTM,3600,1,Recreation & Amateur Sport Mgt,0.26,0.61,0.09,0.0,0.0,0.0,0.0,0.04,skye arthur-banning,PRTM-3600,2018
-PRTM,3900,8,PGA GM Player Development,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3900,2018
-PRTM,3920,1,Special Event Management,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,PRTM-3920,2018
-PRTM,3920,2,Special Event Management,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,PRTM-3920,2018
-PRTM,3950,1,PGM Seminar III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3950,2018
-PRTM,4030,1,Elem of Rec/Pk Plan,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,robert baxter powell,PRTM-4030,2018
-PRTM,4210,1,Rec Fin Resc Mgt,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,ryan joseph gagnon,PRTM-4210,2018
-PRTM,4220,1,Management of RT Services,0.49,0.49,0.03,0.0,0.0,0.0,0.0,0.0,brandi crowe,PRTM-4220,2018
-PRTM,4450,1,Conventions,0.82,0.09,0.06,0.0,0.0,0.0,0.0,0.03,stephanie perl garst,PRTM-4450,2018
-PRTM,4470,1,Perspect Intl Travel,0.93,0.0,0.04,0.0,0.04,0.0,0.0,0.0,sheila backman,PRTM-4470,2018
-PRTM,4510,1,Seminar in CRSCM,0.83,0.09,0.04,0.04,0.0,0.0,0.0,0.0,harrison pa pinckney,PRTM-4510,2018
-PRTM,4550,1,Adv Program Planning,0.62,0.23,0.08,0.04,0.04,0.0,0.0,0.0,harrison pa pinckney,PRTM-4550,2018
-PRTM,4740,2,Adv Rec Resource Mgt,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,matthew tyl brownlee,PRTM-4740,2018
-PRTM,4830,1,Golf Club Mgt & Ops,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-4830,2018
-PRTM,4950,1,Pro Golf Management Seminar IV,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-4950,2018
-PRTM,9000,7,Online Comp Exam,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,jeffrey charle hallo,PRTM-9000,2018
-PSYC,2010,1,Intro to Psychology,0.52,0.23,0.21,0.0,0.03,0.0,0.0,0.02,chong hyon pak,PSYC-2010,2018
-PSYC,2010,2,Intro to Psychology,0.27,0.31,0.26,0.08,0.02,0.0,0.0,0.05,edwin brainerd,PSYC-2010,2018
-PSYC,2010,3,Intro to Psychology,0.33,0.37,0.16,0.08,0.01,0.0,0.0,0.05,jo anne jorgensen,PSYC-2010,2018
-PSYC,2010,4,Intro to Psychology,0.34,0.39,0.14,0.07,0.0,0.0,0.0,0.06,mary taylor,PSYC-2010,2018
-PSYC,2010,5,Intro to Psychology (HON),0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,PSYC-2010,2018
-PSYC,2890,1,Fundamentals of Psyc Science,0.56,0.34,0.06,0.03,0.01,0.0,0.0,0.01,peggy tyler,PSYC-2890,2018
-PSYC,3060,1,Human Sexual Behavior,0.51,0.22,0.13,0.06,0.07,0.0,0.0,0.01,bruce michael king,PSYC-3060,2018
-PSYC,3090,100,Intro Experimental Psychology,0.33,0.39,0.21,0.03,0.02,0.0,0.0,0.02,jennifer bail bisson,PSYC-3090,2018
-PSYC,3090,200,Intro Experimental Psychology,0.47,0.18,0.19,0.05,0.09,0.0,0.0,0.01,patrick rosopa,PSYC-3090,2018
-PSYC,3100,100,Advanced Experimental Psych,0.3,0.35,0.25,0.05,0.0,0.0,0.0,0.05,eric mckibben,PSYC-3100,2018
-PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,thomas britt,PSYC-3100,2018
-PSYC,3100,300,Advanced Experimental Psych,0.35,0.41,0.06,0.0,0.06,0.0,0.0,0.12,robert campbell,PSYC-3100,2018
-PSYC,3100,400,Advanced Experimental Psych,0.43,0.43,0.05,0.05,0.0,0.0,0.0,0.05,fred switzer,PSYC-3100,2018
-PSYC,3100,500,Advanced Experimental Psych,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2018
-PSYC,3100,600,Advanced Experimental Psych,0.35,0.57,0.09,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2018
-PSYC,3240,1,Physiological Psych,0.35,0.29,0.17,0.06,0.07,0.0,0.0,0.06,claudio cantalupo,PSYC-3240,2018
-PSYC,3240,2,Physiological Psych,0.43,0.26,0.17,0.1,0.01,0.0,0.0,0.01,claudio cantalupo,PSYC-3240,2018
-PSYC,3310,1,Critical Thinking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3310,2018
-PSYC,3330,1,Cognitive Psych,0.47,0.31,0.1,0.03,0.03,0.0,0.0,0.06,robert campbell,PSYC-3330,2018
-PSYC,3330,2,Cognitive Psych,0.65,0.26,0.07,0.01,0.0,0.0,0.0,0.0,kaileigh angel byrne,PSYC-3330,2018
-PSYC,3330,3,Cognitive Psych,0.57,0.26,0.08,0.02,0.05,0.0,0.0,0.03,kaileigh angel byrne,PSYC-3330,2018
-PSYC,3340,2,Cognitive Psych Lab,0.64,0.29,0.0,0.07,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3340,2018
-PSYC,3340,3,Cognitive Psych Lab,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,kathryn lucaites,PSYC-3340,2018
-PSYC,3340,4,Cognitive Psych Lab,0.54,0.31,0.0,0.15,0.0,0.0,0.0,0.0,kathryn lucaites,PSYC-3340,2018
-PSYC,3400,1,Lifespan Developmental Psych,0.68,0.22,0.08,0.01,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3400,2018
-PSYC,3400,2,Lifespan Developmental Psych,0.38,0.44,0.13,0.01,0.0,0.0,0.0,0.04,jennifer bail bisson,PSYC-3400,2018
-PSYC,3400,3,Lifespan Developmental Psych,0.25,0.3,0.22,0.09,0.1,0.0,0.0,0.04,pamela alley,PSYC-3400,2018
-PSYC,3520,1,Social Psychology,0.4,0.28,0.25,0.07,0.0,0.0,0.0,0.0,jo anne jorgensen,PSYC-3520,2018
-PSYC,3640,1,Industrial Psych,0.54,0.3,0.08,0.05,0.0,0.0,0.0,0.03,anton sytine,PSYC-3640,2018
-PSYC,3640,2,Industrial Psych,0.29,0.37,0.26,0.04,0.0,0.0,0.0,0.03,eric mckibben,PSYC-3640,2018
-PSYC,3680,1,Organizational Psych,0.25,0.3,0.22,0.08,0.05,0.0,0.0,0.1,eric mckibben,PSYC-3680,2018
-PSYC,3680,2,Organizational Psych,0.59,0.27,0.09,0.01,0.03,0.0,0.0,0.01,zachary klinefelter,PSYC-3680,2018
-PSYC,3700,1,Personality,0.49,0.34,0.14,0.01,0.0,0.0,0.0,0.01,john robert hester,PSYC-3700,2018
-PSYC,3830,1,Abnormal Psychology,0.41,0.34,0.18,0.03,0.03,0.0,0.0,0.01,jo anne jorgensen,PSYC-3830,2018
-PSYC,3830,2,Abnormal Psychology,0.22,0.26,0.26,0.07,0.15,0.0,0.0,0.04,pamela alley,PSYC-3830,2018
-PSYC,3830,3,Abnormal Psychology,0.26,0.34,0.17,0.06,0.14,0.0,0.0,0.03,pamela alley,PSYC-3830,2018
-PSYC,3890,1,Group/Team Dynamics,0.9,0.07,0.0,0.01,0.01,0.0,0.0,0.0,marissa leigh porter,PSYC-3890,2018
-PSYC,3890,2,Psychology and Culture,0.6,0.21,0.12,0.05,0.02,0.0,0.0,0.0,ceren gunsoy,PSYC-3890,2018
-PSYC,4080,1,Women and Psychology,0.58,0.17,0.04,0.0,0.04,0.0,0.0,0.17,robin marie kowalski,PSYC-4080,2018
-PSYC,4150,1,Systems and Theories,0.29,0.46,0.17,0.09,0.0,0.0,0.0,0.0,edwin brainerd,PSYC-4150,2018
-PSYC,4150,2,Systems and Theories,0.34,0.41,0.16,0.03,0.03,0.0,0.0,0.03,edwin brainerd,PSYC-4150,2018
-PSYC,4150,3,Systems and Theories,0.8,0.11,0.03,0.0,0.03,0.0,0.0,0.03,michael shreeves,PSYC-4150,2018
-PSYC,4220,1,Perception,0.29,0.42,0.17,0.0,0.0,0.0,0.0,0.13,claudio cantalupo,PSYC-4220,2018
-PSYC,4220,2,Perception,0.33,0.15,0.33,0.19,0.0,0.0,0.0,0.0,christopher pagano,PSYC-4220,2018
-PSYC,4220,3,Perception,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,christopher pagano,PSYC-4220,2018
-PSYC,4220,4,Perception,0.72,0.16,0.08,0.0,0.04,0.0,0.0,0.0,darlene edewaard,PSYC-4220,2018
-PSYC,4350,1,Human Factors,0.58,0.23,0.12,0.04,0.0,0.0,0.0,0.04,laura whitlock,PSYC-4350,2018
-PSYC,4350,2,Human Factors,0.68,0.2,0.12,0.0,0.0,0.0,0.0,0.0,laura whitlock,PSYC-4350,2018
-PSYC,4710,1,Psych of Testing,0.46,0.31,0.15,0.08,0.0,0.0,0.0,0.0,zhuo chen,PSYC-4710,2018
-PSYC,4800,1,Health Psychology,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,james mccubbin,PSYC-4800,2018
-PSYC,4800,2,Health Psychology,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,james mccubbin,PSYC-4800,2018
-PSYC,4820,1,Positive Psychology,0.52,0.3,0.04,0.0,0.0,0.0,0.0,0.13,cynthia pury s,PSYC-4820,2018
-PSYC,4880,1,Psychotherapy,0.31,0.31,0.08,0.0,0.15,0.0,0.0,0.15,lucinda sorcie quick,PSYC-4880,2018
-PSYC,4890,1,21st Century Teams,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,marissa leigh porter,PSYC-4890,2018
-PSYC,4920,1,Senior Laboratory,0.64,0.18,0.09,0.0,0.05,0.0,0.0,0.05,chloe wilson,PSYC-4920,2018
-PSYC,4920,2,Senior Laboratory,0.77,0.09,0.05,0.0,0.09,0.0,0.0,0.0,chloe wilson,PSYC-4920,2018
-PSYC,4920,3,Senior Laboratory,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,chloe wilson,PSYC-4920,2018
-PSYC,4920,4,Senior Laboratory,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,tiffany cooper,PSYC-4920,2018
-PSYC,8100,1,Research Design I,0.73,0.19,0.0,0.0,0.03,0.0,0.0,0.05, dewayne moore,PSYC-8100,2018
-PSYC,8520,1,Social Psychology,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,ceren gunsoy,PSYC-8520,2018
-RED,8000,1,Real Estate Dvlpment,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,robert crei benedict,RED-8000,2018
-RED,8130,1,Strat in Real Estate,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,phillip river hughes,RED-8130,2018
-REL,1010,1,Intro to Religion,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,peter cohen,REL-1010,2018
-REL,1010,2,Intro to Religion,0.28,0.22,0.17,0.17,0.11,0.0,0.0,0.06,peter cohen,REL-1010,2018
-REL,1010,3,Intro to Religion,0.18,0.38,0.15,0.09,0.09,0.0,0.0,0.12,peter cohen,REL-1010,2018
-REL,1010,4,Intro to Religion,0.59,0.32,0.06,0.0,0.0,0.0,0.0,0.03,richard ale amesbury,REL-1010,2018
-REL,1020,2,World Religions,0.3,0.39,0.21,0.0,0.0,0.0,0.0,0.09,robert stephens,REL-1020,2018
-REL,1020,3,World Religions,0.31,0.46,0.11,0.06,0.03,0.0,0.0,0.03,robert stephens,REL-1020,2018
-REL,1020,4,World Religions,0.41,0.32,0.21,0.0,0.03,0.0,0.0,0.03,robert stephens,REL-1020,2018
-REL,3010,1,Old Testament,0.59,0.34,0.03,0.03,0.0,0.0,0.0,0.0,steven grosby,REL-3010,2018
-REL,3060,1,Judaism,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3060,2018
-REL,3090,1,Religion of the American South,0.6,0.13,0.13,0.0,0.07,0.0,0.0,0.07,elizabeth jemison,REL-3090,2018
-REL,3110,1,African American Rel,0.41,0.35,0.12,0.0,0.06,0.0,0.0,0.06,elizabeth jemison,REL-3110,2018
-REL,3130,1,Buddhism,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,robert stephens,REL-3130,2018
-REL,3150,1,Islam,0.53,0.2,0.13,0.07,0.0,0.0,0.0,0.07,mashal saif,REL-3150,2018
-REL,3200,1,"Jesus in History, Faith & Film",0.47,0.47,0.0,0.0,0.03,0.0,0.0,0.03,benjamin white,REL-3200,2018
-REL,4010,1,Stud Biblical Literature & Rel,0.5,0.21,0.07,0.07,0.0,0.0,0.0,0.14,benjamin white,REL-4010,2018
-RUSS,1010,1,Elementary Russian,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,stephanie ely morris,RUSS-1010,2018
-RUSS,1010,2,Elementary Russian,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,stephanie ely morris,RUSS-1010,2018
-RUSS,2010,1,Intermediate Russ,0.29,0.36,0.21,0.0,0.07,0.0,0.0,0.07,olga anatoly volkova,RUSS-2010,2018
-RUSS,3400,1,19th C Russ Culture,0.54,0.33,0.04,0.0,0.0,0.0,0.0,0.08,olga anatoly volkova,RUSS-3400,2018
-RUSS,3600,1,Russian Lit to 1910,0.58,0.25,0.13,0.0,0.0,0.0,0.0,0.04,olga anatoly volkova,RUSS-3600,2018
-SOC,2010,2,Introduction to Sociology,0.89,0.09,0.01,0.0,0.0,0.0,0.0,0.02,andrew he mannheimer,SOC-2010,2018
-SOC,2010,3,Introduction to Sociology,0.49,0.36,0.09,0.01,0.02,0.0,0.0,0.02,carolyn cand coffman,SOC-2010,2018
-SOC,2010,4,Introduction to Sociology,0.5,0.35,0.11,0.04,0.0,0.0,0.0,0.01,shannon mcdonough,SOC-2010,2018
-SOC,2010,5,Introduction to Sociology,0.56,0.27,0.13,0.03,0.01,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2018
-SOC,2010,7,Introduction to Sociology,0.46,0.36,0.14,0.02,0.0,0.0,0.0,0.02,jennifer lea holland,SOC-2010,2018
-SOC,2040,1,Prof Dev for Sociology Majors,0.41,0.32,0.15,0.05,0.05,0.0,0.0,0.02, catherine mobley,SOC-2040,2018
-SOC,3040,1,Social Research Methods II,0.32,0.29,0.14,0.21,0.0,0.0,0.0,0.04,ye luo,SOC-3040,2018
-SOC,3110,1,The Family,0.37,0.51,0.08,0.02,0.02,0.0,0.0,0.0,andrew whitehead,SOC-3110,2018
-SOC,3400,1,Sport and Society,0.36,0.33,0.24,0.04,0.0,0.0,0.0,0.02,andrew whitehead,SOC-3400,2018
-SOC,3940,1,Sociology of Mental Illness,0.78,0.2,0.0,0.02,0.0,0.0,0.0,0.0,james rosenberger,SOC-3940,2018
-SOC,3970,1,Substance Abuse,0.55,0.34,0.11,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,SOC-3970,2018
-SOC,4040,1,Soc Theory,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,william haller,SOC-4040,2018
-SOC,4060,1,Qual Rsrch Methods for Soc Sci,0.55,0.18,0.0,0.09,0.0,0.0,0.0,0.18,melissa vogel,SOC-4060,2018
-SOC,4140,1,Policy&Social Change,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,jennifer lea holland,SOC-4140,2018
-SOC,4600,1,Race & Ethnicity,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew he mannheimer,SOC-4600,2018
-SOC,4610,1,Sex & Gender,0.53,0.2,0.18,0.0,0.02,0.0,0.0,0.07,carolyn cand coffman,SOC-4610,2018
-SOC,4800,1,Medical Sociology,0.82,0.06,0.03,0.0,0.09,0.0,0.0,0.0,carolyn cand coffman,SOC-4800,2018
-SOC,6060,1,Qual Rsrch Methods for Soc Sci,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,SOC-6060,2018
-SPAN,1010,1,Elementary Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,SPAN-1010,2018
-SPAN,1010,2,Elementary Spanish,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,rosa maca pillcurima,SPAN-1010,2018
-SPAN,1010,3,Elementary Spanish,0.63,0.16,0.05,0.11,0.05,0.0,0.0,0.0,rosa maca pillcurima,SPAN-1010,2018
-SPAN,1020,1,Elementary Spanish,0.72,0.11,0.06,0.0,0.11,0.0,0.0,0.0,rosa maca pillcurima,SPAN-1020,2018
-SPAN,1020,2,Elementary Spanish,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,SPAN-1020,2018
-SPAN,1020,3,Elementary Spanish,0.47,0.26,0.21,0.05,0.0,0.0,0.0,0.0,valderramos zen cruz,SPAN-1020,2018
-SPAN,1020,4,Elementary Spanish,0.71,0.12,0.06,0.06,0.06,0.0,0.0,0.0,vieyra daniel garcia,SPAN-1020,2018
-SPAN,1020,5,Elementary Spanish,0.63,0.32,0.0,0.05,0.0,0.0,0.0,0.0,vieyra daniel garcia,SPAN-1020,2018
-SPAN,1020,6,Elementary Spanish,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,riquelme maria judez,SPAN-1020,2018
-SPAN,1020,7,Elementary Spanish,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,SPAN-1020,2018
-SPAN,1020,8,Elementary Spanish,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,vieyra daniel garcia,SPAN-1020,2018
-SPAN,1020,10,Elementary Spanish,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,debra oak williamson,SPAN-1020,2018
-SPAN,1020,11,Elementary Spanish,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,debra oak williamson,SPAN-1020,2018
-SPAN,1020,12,Elementary Spanish,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,adrienne elizab fama,SPAN-1020,2018
-SPAN,1020,13,Elementary Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,SPAN-1020,2018
-SPAN,2010,1,Intermediate Spanish,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,riquelme maria judez,SPAN-2010,2018
-SPAN,2010,2,Intermediate Spanish,0.61,0.0,0.28,0.0,0.11,0.0,0.0,0.0,valderramos zen cruz,SPAN-2010,2018
-SPAN,2010,3,Intermediate Spanish,0.5,0.33,0.06,0.0,0.06,0.0,0.0,0.06,melva margue persico,SPAN-2010,2018
-SPAN,2010,4,Intermediate Spanish,0.19,0.75,0.0,0.0,0.0,0.0,0.0,0.06,melva margue persico,SPAN-2010,2018
-SPAN,2010,7,Intermediate Spanish,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,debra oak williamson,SPAN-2010,2018
-SPAN,2010,8,Intermediate Spanish,0.5,0.25,0.17,0.08,0.0,0.0,0.0,0.0,debra oak williamson,SPAN-2010,2018
-SPAN,2010,9,Intermediate Spanish,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,SPAN-2010,2018
-SPAN,2010,10,Intermediate Spanish,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,ellory schmucker,SPAN-2010,2018
-SPAN,2010,11,Intermediate Spanish,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,SPAN-2010,2018
-SPAN,2010,12,Intermediate Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,SPAN-2010,2018
-SPAN,2010,16,Intermediate Spanish,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2018
-SPAN,2010,17,Intermediate Spanish,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,SPAN-2010,2018
-SPAN,2020,1,Intermediate Spanish,0.21,0.58,0.16,0.0,0.05,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2018
-SPAN,2020,2,Intermediate Spanish,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,SPAN-2020,2018
-SPAN,2020,3,Intermediate Spanish,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,SPAN-2020,2018
-SPAN,2020,4,Intermediate Spanish,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,SPAN-2020,2018
-SPAN,2020,5,Intermediate Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2020,2018
-SPAN,2020,7,Intermediate Spanish,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2020,2018
-SPAN,2020,8,Intermediate Spanish,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,SPAN-2020,2018
-SPAN,2020,9,Intermediate Spanish,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,ana paula  miller e,SPAN-2020,2018
-SPAN,2020,10,Intermediate Spanish,0.47,0.26,0.21,0.0,0.0,0.0,0.0,0.05,valderramos zen cruz,SPAN-2020,2018
-SPAN,2020,11,Intermediate Spanish,0.24,0.65,0.06,0.0,0.06,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2018
-SPAN,2020,12,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,valderramos zen cruz,SPAN-2020,2018
-SPAN,2020,13,Intermediate Spanish,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,valderramos zen cruz,SPAN-2020,2018
-SPAN,2020,14,Intermediate Spanish,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2018
-SPAN,3010,1,Spanish Comp for Health Prof,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,SPAN-3010,2018
-SPAN,3020,1,Intermed Span Grammar & Comp,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,melva margue persico,SPAN-3020,2018
-SPAN,3020,2,Intermed Span Grammar & Comp,0.32,0.53,0.05,0.0,0.05,0.0,0.0,0.05,melva margue persico,SPAN-3020,2018
-SPAN,3020,3,Intermed Span Grammar & Comp,0.53,0.26,0.16,0.0,0.0,0.0,0.0,0.05,daniel smith,SPAN-3020,2018
-SPAN,3050,1,Intermed Span Convers/Comp I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,moni rojas-de-massei,SPAN-3050,2018
-SPAN,3050,2,Intermed Span Convers/Comp I,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,moni rojas-de-massei,SPAN-3050,2018
-SPAN,3050,3,Intermed Span Convers/Comp I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,juana martin-armas,SPAN-3050,2018
-SPAN,3050,4,Intermed Span Convers/Comp I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,graciela tissera,SPAN-3050,2018
-SPAN,3050,6,Intermed Span Convers/Comp I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,vieyra daniel garcia,SPAN-3050,2018
-SPAN,3050,7,Intermed Span Convers/Comp I,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,vieyra daniel garcia,SPAN-3050,2018
-SPAN,3070,1,The Hispanic World: Spain,0.44,0.28,0.11,0.06,0.11,0.0,0.0,0.0,raquel anido,SPAN-3070,2018
-SPAN,3080,1,The Hispanic World: Latin Amer,0.44,0.28,0.06,0.0,0.17,0.0,0.0,0.06,tiffany dawn miller,SPAN-3080,2018
-SPAN,3080,2,The Hispanic World: Latin Amer,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,tiffany dawn miller,SPAN-3080,2018
-SPAN,3130,2,Span Lit Survey I,0.25,0.38,0.13,0.0,0.19,0.0,0.0,0.06,moni rojas-de-massei,SPAN-3130,2018
-SPAN,3180,1,Spanish Through Culture,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,george palacios,SPAN-3180,2018
-SPAN,4010,1,New Spanish Fiction,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,salvador oropesa,SPAN-4010,2018
-SPAN,4060,2,Narrative Fiction,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,SPAN-4060,2018
-SPAN,4070,1,Hispanic Film,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,SPAN-4070,2018
-SPAN,4150,1,Spanish for Health Prof,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,riquelme maria judez,SPAN-4150,2018
-STAT,2220,1,Statistics in Everyday Life,0.45,0.26,0.19,0.09,0.01,0.0,0.0,0.0,james espey,STAT-2220,2018
-STAT,2220,2,Statistics in Everyday Life,0.48,0.26,0.17,0.04,0.01,0.0,0.0,0.03,james espey,STAT-2220,2018
-STAT,2220,3,Statistics in Everyday Life,0.49,0.29,0.11,0.07,0.01,0.0,0.0,0.03,james espey,STAT-2220,2018
-STAT,2220,4,Statistics in Everyday Life,0.38,0.33,0.15,0.08,0.02,0.0,0.0,0.03,james espey,STAT-2220,2018
-STAT,2220,5,Statistics in Everyday Life,0.4,0.26,0.18,0.08,0.05,0.0,0.0,0.04,rose martinez-dawson,STAT-2220,2018
-STAT,2220,6,Statistics in Everyday Life,0.31,0.23,0.28,0.07,0.06,0.0,0.0,0.05,rose martinez-dawson,STAT-2220,2018
-STAT,2300,1,Statistical Methods I,0.23,0.29,0.27,0.09,0.08,0.0,0.0,0.02,christy jenkin brown,STAT-2300,2018
-STAT,2300,2,Statistical Methods I,0.33,0.42,0.17,0.04,0.03,0.0,0.0,0.02,christy jenkin brown,STAT-2300,2018
-STAT,2300,3,Statistical Methods I,0.32,0.35,0.11,0.14,0.04,0.0,0.0,0.04,sharon marie evans,STAT-2300,2018
-STAT,2300,4,Statistical Methods I,0.29,0.37,0.13,0.08,0.09,0.0,0.0,0.05,sharon marie evans,STAT-2300,2018
-STAT,2300,5,Statistical Methods I,0.18,0.29,0.17,0.15,0.15,0.0,0.0,0.06, erwin walker,STAT-2300,2018
-STAT,2300,6,Statistical Methods I,0.13,0.35,0.22,0.08,0.12,0.0,0.0,0.11, erwin walker,STAT-2300,2018
-STAT,2300,100,Statistical Methods I (HON),0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,christy jenkin brown,STAT-2300,2018
-STAT,3090,1,Introductory Business Stats,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,margaret emma brooks,STAT-3090,2018
-STAT,3090,2,Introductory Business Stats,0.26,0.37,0.21,0.05,0.05,0.0,0.0,0.05,margaret emma brooks,STAT-3090,2018
-STAT,3090,3,Introductory Business Stats,0.37,0.32,0.16,0.11,0.05,0.0,0.0,0.0,boyoung hur,STAT-3090,2018
-STAT,3090,4,Introductory Business Stats,0.26,0.26,0.21,0.26,0.0,0.0,0.0,0.0,boyoung hur,STAT-3090,2018
-STAT,3090,5,Introductory Business Stats,0.28,0.33,0.22,0.17,0.0,0.0,0.0,0.0,tiantian yang,STAT-3090,2018
-STAT,3090,6,Introductory Business Stats,0.18,0.12,0.06,0.18,0.35,0.0,0.0,0.12,rui gong,STAT-3090,2018
-STAT,3090,7,Introductory Business Stats,0.26,0.37,0.21,0.11,0.05,0.0,0.0,0.0,yiren ding,STAT-3090,2018
-STAT,3090,8,Introductory Business Stats,0.12,0.35,0.35,0.12,0.06,0.0,0.0,0.0,yiren ding,STAT-3090,2018
-STAT,3090,9,Introductory Business Stats,0.47,0.26,0.16,0.11,0.0,0.0,0.0,0.0,brandon lumsden,STAT-3090,2018
-STAT,3090,10,Introductory Business Stats,0.29,0.18,0.35,0.06,0.06,0.0,0.0,0.06,jiajing niu,STAT-3090,2018
-STAT,3090,11,Introductory Business Stats,0.26,0.37,0.16,0.05,0.11,0.0,0.0,0.05,anna marie vagnozzi,STAT-3090,2018
-STAT,3090,12,Introductory Business Stats,0.21,0.21,0.26,0.0,0.16,0.0,0.0,0.16,john charl nicholson,STAT-3090,2018
-STAT,3090,13,Introductory Business Stats,0.3,0.26,0.2,0.12,0.09,0.0,0.0,0.03,april thomas,STAT-3090,2018
-STAT,3090,14,Introductory Business Stats,0.37,0.32,0.11,0.05,0.16,0.0,0.0,0.0,kayla doris javier,STAT-3090,2018
-STAT,3090,15,Introductory Business Stats,0.32,0.39,0.11,0.08,0.09,0.0,0.0,0.01,april thomas,STAT-3090,2018
-STAT,3090,16,Introductory Business Stats,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,yidan guo,STAT-3090,2018
-STAT,3090,17,Introductory Business Stats,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,john charl nicholson,STAT-3090,2018
-STAT,3090,18,Introductory Business Stats,0.22,0.33,0.28,0.11,0.06,0.0,0.0,0.0,feng gao,STAT-3090,2018
-STAT,3090,19,Introductory Business Stats,0.42,0.32,0.11,0.05,0.11,0.0,0.0,0.0,kayla doris javier,STAT-3090,2018
-STAT,3090,20,Introductory Business Stats,0.16,0.37,0.26,0.05,0.11,0.0,0.0,0.05,yidan guo,STAT-3090,2018
-STAT,3090,21,Introductory Business Stats,0.18,0.41,0.24,0.0,0.12,0.0,0.0,0.06,minghua cui,STAT-3090,2018
-STAT,3090,22,Introductory Business Stats,0.21,0.26,0.21,0.16,0.11,0.0,0.0,0.05,rui gong,STAT-3090,2018
-STAT,3090,23,Introductory Business Stats,0.47,0.24,0.24,0.06,0.0,0.0,0.0,0.0,tiantian yang,STAT-3090,2018
-STAT,3090,24,Introductory Business Stats,0.21,0.47,0.26,0.05,0.0,0.0,0.0,0.0,xueheng shi,STAT-3090,2018
-STAT,3090,25,Introductory Business Stats,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,norman michae snyder,STAT-3090,2018
-STAT,3090,26,Introductory Business Stats,0.37,0.37,0.16,0.0,0.11,0.0,0.0,0.0,anna marie vagnozzi,STAT-3090,2018
-STAT,3090,27,Introductory Business Stats,0.32,0.37,0.16,0.11,0.05,0.0,0.0,0.0,sean walk ingimarson,STAT-3090,2018
-STAT,3090,28,Introductory Business Stats,0.11,0.39,0.28,0.06,0.11,0.0,0.0,0.06,xueheng shi,STAT-3090,2018
-STAT,3090,29,Introductory Business Stats,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,jiajing niu,STAT-3090,2018
-STAT,3090,30,Introductory Business Stats,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,norman michae snyder,STAT-3090,2018
-STAT,3090,31,Introductory Business Stats,0.53,0.21,0.21,0.05,0.0,0.0,0.0,0.0,brandon lumsden,STAT-3090,2018
-STAT,3090,32,Introductory Business Stats,0.28,0.22,0.33,0.0,0.17,0.0,0.0,0.0,minghua cui,STAT-3090,2018
-STAT,3090,33,Introductory Business Stats,0.2,0.42,0.27,0.04,0.07,0.0,0.0,0.0,margaret mari wiecek,STAT-3090,2018
-STAT,3090,34,Introductory Business Stats,0.53,0.21,0.21,0.05,0.0,0.0,0.0,0.0,alan robert hahn,STAT-3090,2018
-STAT,3090,35,Introductory Business Stats,0.16,0.47,0.32,0.05,0.0,0.0,0.0,0.0,alan robert hahn,STAT-3090,2018
-STAT,3090,36,Introductory Business Stats,0.21,0.47,0.16,0.05,0.11,0.0,0.0,0.0,feng gao,STAT-3090,2018
-STAT,3090,37,Introductory Business Stats,0.18,0.29,0.12,0.12,0.24,0.0,0.0,0.06,sean walk ingimarson,STAT-3090,2018
-STAT,3300,1,Statistical Methods II,0.44,0.17,0.11,0.17,0.06,0.0,0.0,0.06,rose martinez-dawson,STAT-3300,2018
-STAT,4020,1,Intro to Statistical Computing,0.32,0.44,0.16,0.04,0.04,0.0,0.0,0.0,ellen hepfer breazel,STAT-4020,2018
-STAT,4110,1,Stat Mthds for Process Control,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,richard steve dubsky,STAT-4110,2018
-STAT,4110,3,Stat Mthds for Process Control,0.56,0.28,0.11,0.0,0.03,0.0,0.0,0.03,william bridges,STAT-4110,2018
-STAT,6020,1,Intro to Statistical Computing,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,STAT-6020,2018
-STAT,8010,3,Statistical Methods I,0.36,0.41,0.05,0.0,0.05,0.0,0.0,0.14,jun luo,STAT-8010,2018
-STAT,8010,4,Statistical Methods I,0.27,0.09,0.32,0.0,0.05,0.0,0.0,0.27,jun luo,STAT-8010,2018
-STAT,8010,5,Statistical Methods I,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,joseph daniel bible,STAT-8010,2018
-STAT,8010,7,Statistical Methods I,0.62,0.29,0.0,0.0,0.0,0.0,0.0,0.1,brook thayer russell,STAT-8010,2018
-STAT,8020,1,Statistical Methods II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,STAT-8020,2018
-STAT,8030,1,Regress & Least Squares Anlys,0.57,0.39,0.0,0.0,0.04,0.0,0.0,0.0,brook thayer russell,STAT-8030,2018
-STS,1010,1,Survey Sci & Techn in Society,0.49,0.49,0.03,0.0,0.0,0.0,0.0,0.0,kenneth davi widgren,STS-1010,2018
-STS,1010,2,Survey Sci & Techn in Society,0.43,0.37,0.14,0.03,0.0,0.0,0.0,0.03,scott brame,STS-1010,2018
-STS,1010,3,Survey Sci & Techn in Society,0.49,0.37,0.11,0.0,0.0,0.0,0.0,0.03,elizabeth stansell,STS-1010,2018
-STS,1010,4,Survey Sci & Techn in Society,0.19,0.5,0.28,0.03,0.0,0.0,0.0,0.0,sarah mae cooper,STS-1010,2018
-STS,1010,5,Survey Sci & Techn in Society,0.54,0.29,0.09,0.03,0.03,0.0,0.0,0.03,philip randall,STS-1010,2018
-STS,1010,6,Survey Sci & Techn in Society,0.79,0.06,0.06,0.0,0.03,0.0,0.0,0.06,christine cla murphy,STS-1010,2018
-STS,1010,7,Survey Sci & Techn in Society,0.31,0.44,0.14,0.03,0.06,0.0,0.0,0.03,megan noe macalystre,STS-1010,2018
-STS,1010,8,Survey Sci & Techn in Society,0.34,0.4,0.09,0.0,0.03,0.0,0.0,0.14,david charles foltz,STS-1010,2018
-STS,1010,9,Survey Sci & Techn in Society,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,STS-1010,2018
-THEA,2100,1,Theatre Appreciation,0.66,0.19,0.06,0.03,0.03,0.0,0.0,0.03,kendra lynet johnson,THEA-2100,2018
-THEA,2100,2,Theatre Appreciation,0.84,0.06,0.0,0.03,0.03,0.0,0.0,0.03,kerrie kathl seymour,THEA-2100,2018
-THEA,2100,3,Theatre Appreciation,0.63,0.25,0.06,0.03,0.03,0.0,0.0,0.0,david hartmann,THEA-2100,2018
-THEA,2100,4,Theatre Appreciation,0.9,0.06,0.0,0.0,0.0,0.0,0.0,0.03,anthony penna,THEA-2100,2018
-THEA,2100,5,Theatre Appreciation,0.81,0.09,0.03,0.03,0.0,0.0,0.0,0.03,carol collins,THEA-2100,2018
-THEA,2100,6,Theatre Appreciation,0.53,0.25,0.09,0.13,0.0,0.0,0.0,0.0,jason adkins,THEA-2100,2018
-THEA,2100,7,Theatre Appreciation,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,jason adkins,THEA-2100,2018
-THEA,2780,1,Acting I,0.73,0.09,0.09,0.09,0.0,0.0,0.0,0.0,kerrie kathl seymour,THEA-2780,2018
-THEA,3170,1,African-Amer Thea I,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,kendra lynet johnson,THEA-3170,2018
-THEA,4290,1,Dramatic Literature I,0.5,0.0,0.1,0.1,0.3,0.0,0.0,0.0,jason adkins,THEA-4290,2018
-WFB,4100,2,Wildlife Management Techniques,0.29,0.48,0.18,0.02,0.02,0.0,0.0,0.02,james davis,WFB-4100,2018
-WFB,4180,2,Fisheries Mgt & Conservation,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,troy mason farmer,WFB-4180,2018
-WFB,4440,1,Wildlife Damage Management,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,WFB-4440,2018
-WFB,4720,1,Ornithology,0.18,0.55,0.18,0.09,0.0,0.0,0.0,0.0,john cummings,WFB-4720,2018
-WFB,4770,1,Ichthyology,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,brandon kevi peoples,WFB-4770,2018
-WFB,4800,1,Waterfowl Ecology & Management,0.61,0.22,0.11,0.03,0.0,0.0,0.0,0.03,richard mar kaminski,WFB-4800,2018
-WFB,4930,2,Plant & Flora ID/Systematics,0.7,0.18,0.06,0.01,0.0,0.0,0.0,0.04,patrick mcmillan,WFB-4930,2018
-WFB,6620,1,Wetland Wildlife Biology,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,russell barrett,WFB-6620,2018
-WFB,6800,1,Waterfowl Ecology & Management,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,richard mar kaminski,WFB-6800,2018
-WFB,8530,2,Global Chg Eco,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,lydia rie 'halloran,WFB-8530,2018
-WS,1030,1,Women in Global Perspective,0.6,0.17,0.17,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,WS-1030,2018
-WS,2300,1,Women and Leadership I,0.55,0.27,0.09,0.05,0.0,0.0,0.0,0.05,mary price,WS-2300,2018
-WS,3010,1,Intro Women's Studies,0.43,0.43,0.03,0.07,0.0,0.0,0.0,0.03,elizabeth rose adams,WS-3010,2018
-WS,3010,2,Intro Women's Studies,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth rose adams,WS-3010,2018
-WS,3490,1,Gender and Sexuality,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,diane perpich,WS-3490,2018
-YDP,3000,400,Youth Development in Society,0.56,0.36,0.04,0.0,0.04,0.0,0.0,0.0,barry garst,YDP-3000,2018
-YDP,3050,400,Theory/Phil of Youth Dev Work,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,edmond patric bowers,YDP-3050,2018
-YDP,3300,1,Designing Effective Youth Prog,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,YDP-3300,2018
-YDP,3450,1,Creative Activities for Youth,0.9,0.03,0.07,0.0,0.0,0.0,0.0,0.0,kimberly pea johnson,YDP-3450,2018
-YDP,8000,1,Theories of Youth Development,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,edmond patric bowers,YDP-8000,2018
-YDP,8030,1,Creative & Ethical Leadership,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,barry garst,YDP-8030,2018
-YDP,8050,1,Youth Dev in Context of Family,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,YDP-8050,2018
-YDP,8060,2,Youth Dev in Global Society,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ann marie gillard,YDP-8060,2018
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1010,1,Survey of Art & Arch History I,0.42,0.45,0.11,0.01,0.01,0.0,0.0,0.0,beth ann lauritis,
+AAH,2050,1,Art History and Theory I,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,beth ann lauritis,
+AAH,3050,1,Contemporary Art History,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
+ACCT,2010,1,Financial Accounting Concepts,0.09,0.36,0.27,0.02,0.09,0.0,0.0,0.18,lydia lanc schleifer,
+ACCT,2010,2,Financial Accounting Concepts,0.28,0.23,0.23,0.13,0.04,0.0,0.0,0.09,emily suzan mccorkle,
+ACCT,2010,3,Financial Accounting Concepts,0.33,0.48,0.13,0.08,0.0,0.0,0.0,0.0,emily suzan mccorkle,
+ACCT,2010,4,Financial Accounting Concepts,0.36,0.28,0.21,0.04,0.09,0.0,0.0,0.02,annieka philo,
+ACCT,2010,5,Financial Accounting Concepts,0.33,0.23,0.19,0.02,0.13,0.0,0.0,0.1,lydia lanc schleifer,
+ACCT,2010,6,Financial Accounting Concepts,0.24,0.26,0.29,0.07,0.1,0.0,0.0,0.05,annieka philo,
+ACCT,2010,7,Financial Accounting Concepts,0.17,0.4,0.19,0.07,0.05,0.0,0.0,0.12,emily suzan mccorkle,
+ACCT,2010,8,Financial Accounting Concepts,0.21,0.35,0.19,0.1,0.04,0.0,0.0,0.1,lydia lanc schleifer,
+ACCT,2010,9,Financial Accounting Concepts,0.26,0.41,0.21,0.08,0.0,0.0,0.0,0.05,annieka philo,
+ACCT,2010,10,Financial Accounting Concepts,0.3,0.25,0.23,0.05,0.18,0.0,0.0,0.0,emily suzan mccorkle,
+ACCT,2010,11,Financial Accounting Concepts,0.16,0.42,0.16,0.05,0.11,0.0,0.0,0.11,charles tegen,
+ACCT,2010,12,Financial Accounting Concepts,0.26,0.24,0.29,0.08,0.03,0.0,0.0,0.11,philip maiberger,
+ACCT,2010,13,Financial Accounting Concepts,0.23,0.28,0.36,0.05,0.05,0.0,0.0,0.03,lisa whea birtwistle,
+ACCT,2010,14,Financial Accounting Concepts,0.37,0.37,0.17,0.07,0.0,0.0,0.0,0.02,lisa whea birtwistle,
+ACCT,2010,100,Fin Accounting Concepts (HON),0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,lisa whea birtwistle,True
+ACCT,2010,400,Financial Accounting Concepts,0.19,0.43,0.16,0.09,0.07,0.0,0.0,0.06,jeffrey mcmillan,
+ACCT,2020,1,Managerial Accounting Concepts,0.14,0.2,0.37,0.03,0.09,0.0,0.0,0.17,henry anderson,
+ACCT,2020,2,Managerial Accounting Concepts,0.25,0.45,0.14,0.05,0.02,0.0,0.0,0.09,henry anderson,
+ACCT,2020,3,Managerial Accounting Concepts,0.36,0.24,0.18,0.0,0.09,0.0,0.0,0.13,henry anderson,
+ACCT,2020,4,Managerial Accounting Concepts,0.19,0.35,0.16,0.22,0.0,0.0,0.0,0.08,brian todd carver,
+ACCT,2020,5,Managerial Accounting Concepts,0.24,0.22,0.2,0.07,0.18,0.0,0.0,0.09,brian todd carver,
+ACCT,2020,6,Managerial Accounting Concepts,0.11,0.3,0.27,0.09,0.02,0.0,0.0,0.2,brian todd carver,
+ACCT,2020,7,Managerial Accounting Concepts,0.25,0.29,0.33,0.04,0.02,0.0,0.0,0.06,phebian davis-culler,
+ACCT,2020,400,Managerial Accounting Concepts,0.25,0.36,0.2,0.09,0.04,0.0,0.0,0.06,henry anderson,
+ACCT,3030,3,Cost Accounting,0.45,0.37,0.08,0.0,0.08,0.0,0.0,0.02,phebian davis-culler,
+ACCT,3030,4,Cost Accounting,0.21,0.28,0.3,0.12,0.07,0.0,0.0,0.02,phebian davis-culler,
+ACCT,3110,1,Intermediate Financial Acct I,0.1,0.33,0.25,0.17,0.08,0.0,0.0,0.06,erin michell hawkins,
+ACCT,3110,2,Intermediate Financial Acct I,0.16,0.29,0.24,0.13,0.11,0.0,0.0,0.07,erin michell hawkins,
+ACCT,3110,3,Intermediate Financial Acct I,0.14,0.44,0.23,0.12,0.02,0.0,0.0,0.05,amy melissa donnelly,
+ACCT,3110,4,Intermediate Financial Acct I,0.09,0.55,0.21,0.06,0.02,0.0,0.0,0.06,amy melissa donnelly,
+ACCT,3110,400,Intermediate Financial Acct I,0.21,0.35,0.13,0.04,0.08,0.0,0.0,0.19,henry anderson,
+ACCT,3120,1,Intermediate Financial Acct II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3120,2,Intermediate Financial Acct II,0.1,0.34,0.37,0.07,0.1,0.0,0.0,0.02,jeremy michae vinson,
+ACCT,3120,3,Intermediate Financial Acct II,0.38,0.41,0.21,0.0,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3120,4,Intermediate Financial Acct II,0.35,0.35,0.25,0.03,0.0,0.0,0.0,0.03,jeremy michae vinson,
+ACCT,3120,5,Intermediate Financial Acct II,0.26,0.42,0.26,0.0,0.0,0.0,0.0,0.05,terry daniel knause,
+ACCT,3120,6,Intermediate Financial Acct II,0.33,0.49,0.18,0.0,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3130,1,Intermediate Fin Acct III,0.1,0.31,0.38,0.17,0.05,0.0,0.0,0.0, russell madray,
+ACCT,3130,2,Intermediate Fin Acct III,0.09,0.45,0.33,0.06,0.03,0.0,0.0,0.03, russell madray,
+ACCT,3130,3,Intermediate Fin Acct III,0.27,0.37,0.2,0.1,0.05,0.0,0.0,0.02, russell madray,
+ACCT,3130,4,Intermediate Fin Acct III,0.27,0.27,0.39,0.05,0.02,0.0,0.0,0.0, russell madray,
+ACCT,3220,1,Accounting Information Systems,0.36,0.27,0.25,0.05,0.02,0.0,0.0,0.05,philip maiberger,
+ACCT,3220,2,Accounting Information Systems,0.18,0.34,0.24,0.11,0.05,0.0,0.0,0.08,philip maiberger,
+ACCT,3220,3,Accounting Information Systems,0.16,0.26,0.34,0.11,0.03,0.0,0.0,0.11,philip maiberger,
+ACCT,4040,1,Individual Taxation,0.5,0.29,0.12,0.06,0.03,0.0,0.0,0.0,lisa whea birtwistle,
+ACCT,4040,2,Individual Taxation,0.5,0.31,0.19,0.0,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,3,Individual Taxation,0.57,0.26,0.09,0.06,0.03,0.0,0.0,0.0,sarah martin,
+ACCT,4080,1,Retire & Estate Plan,0.37,0.52,0.07,0.0,0.0,0.0,0.0,0.04,john hine,
+ACCT,4100,3,Reporting and Mgmt Control Sys,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,robin radtke,
+ACCT,4150,1,Auditing,0.2,0.5,0.25,0.05,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,4150,2,Auditing,0.26,0.58,0.11,0.05,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,8510,1,Tax Research,0.07,0.93,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8510,2,Tax Research,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8510,3,Tax Research,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8530,1,Adv Acct Problems,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,ralph edward welton,
+ACCT,8530,2,Adv Acct Problems,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8530,3,Adv Acct Problems,0.72,0.25,0.0,0.0,0.0,0.0,0.0,0.03,suzanne pearse,
+ACCT,8550,1,Gov't and Nonprofit Accounting,0.86,0.11,0.03,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8550,2,Gov't and Nonprofit Accounting,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8550,3,Gov't and Nonprofit Accounting,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8650,1,Tax & Bus Decisions,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
+ACCT,8720,1,Tax of Flowthroughs,0.32,0.27,0.38,0.0,0.0,0.0,0.0,0.03,thomas dickens,
+AGED,1020,1,Freshman Seminar,0.8,0.07,0.07,0.07,0.0,0.0,0.0,0.0,catherin dibenedetto,
+AGED,2000,1,Agr Appl of Ed Tech,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,kevin layfield,
+AGED,2010,1,Intro to Agric Educ,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,2040,1,App Ag Calculations,0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,3030,1,Ag Ed Mech Tech,0.4,0.33,0.2,0.07,0.0,0.0,0.0,0.0,alex byrd,
+AGED,4030,1,Prin Adult/Ext Ed,0.79,0.07,0.07,0.0,0.07,0.0,0.0,0.0,alex byrd,
+AGM,1010,1,Intro Ag Mech & Bus,0.62,0.28,0.03,0.03,0.05,0.0,0.0,0.0,hunter massey,
+AGM,2050,1,Prin of Fabrication,0.26,0.48,0.17,0.05,0.05,0.0,0.0,0.0,hunter massey,
+AGM,2060,1,Machinery Mgt,0.33,0.33,0.2,0.07,0.07,0.0,0.0,0.0,hunter massey,
+AGM,2210,1,Land Measurements,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,charles privette,
+AGM,3010,1,Soil Water Conserv,0.45,0.29,0.2,0.04,0.03,0.0,0.0,0.0,calvin sawyer,
+AGM,4000,1,Seminar in Ag Mech & Business,0.04,0.22,0.4,0.24,0.1,0.0,0.0,0.0,john chastain,
+AGM,4020,1,Irrigation System Design,0.12,0.41,0.35,0.06,0.06,0.0,0.0,0.0,charles privette,
+AGM,4050,1,Env Cont in Anim Str,0.11,0.31,0.44,0.13,0.0,0.0,0.0,0.0,john chastain,
+AGM,4060,1,Mech & Hydraulic Sys,0.27,0.62,0.12,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4520,1,Mobile Power,0.37,0.48,0.11,0.04,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4600,1,Electrical Systems,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,young jo han,
+AGRB,2020,1,Agricultural Economics,0.2,0.29,0.24,0.18,0.05,0.0,0.0,0.04,george apperson,
+AGRB,2050,1,Agriculture and Society,0.15,0.22,0.3,0.25,0.03,0.0,0.0,0.04,michael vassalos,
+AGRB,3020,1,Economics of Farm Management,0.11,0.28,0.27,0.27,0.06,0.0,0.0,0.0,michael vassalos,
+AGRB,3080,1,Quant Agribusiness Analysis I,0.27,0.37,0.2,0.1,0.02,0.0,0.0,0.04,lisha zhang,
+AGRB,3090,1,Econ of Agricultural Marketing,0.59,0.33,0.04,0.0,0.03,0.0,0.0,0.01,yuliya vale bolotova,
+AGRB,3570,1,Natural Resources Economics,0.27,0.23,0.27,0.07,0.07,0.0,0.0,0.09,david brian willis,
+AGRB,4090,1,Commodity Futures Markets,0.13,0.26,0.29,0.21,0.11,0.0,0.0,0.0,george apperson,
+AGRB,4120,1,Reg Econ Devel Theory & Policy,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ronald lamie,
+AGRB,4520,1,Agricultural Policy,0.24,0.33,0.24,0.15,0.03,0.0,0.0,0.0,michael vassalos,
+AGRB,4600,1,Agricultural Finance,0.36,0.26,0.26,0.13,0.0,0.0,0.0,0.0,lisha zhang,
+AL,3440,400,Athletics and Women,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,3490,400,Principles of Coaching,0.61,0.29,0.07,0.04,0.0,0.0,0.0,0.0,deborah jo cadorette,
+AL,3490,401,Principles of Coaching,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,
+AL,3490,402,Principles of Coaching,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,john plumblee,
+AL,3490,403,Principles of Coaching,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,john plumblee,
+AL,3490,404,Principles of Coaching,0.71,0.25,0.0,0.04,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,3490,407,Principles of Coaching,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,nicholas phi whitrow,
+AL,3490,408,Principles of Coaching,0.56,0.24,0.04,0.04,0.12,0.0,0.0,0.0,nicholas phi whitrow,
+AL,3490,409,Principles of Coaching,0.76,0.12,0.0,0.0,0.12,0.0,0.0,0.0,nicholas phi whitrow,
+AL,3500,400,Sci Basis I/Ex Phy,0.21,0.38,0.21,0.13,0.0,0.0,0.0,0.08,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.3,0.35,0.26,0.09,0.0,0.0,0.0,0.0,michael godfrey,
+AL,3510,400,Nat'l Coach Cert Prep for AL,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,
+AL,3530,400,Athletic Injuries,0.14,0.39,0.32,0.11,0.04,0.0,0.0,0.0,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.28,0.36,0.16,0.08,0.08,0.0,0.0,0.04,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.58,0.21,0.17,0.0,0.0,0.0,0.0,0.04,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3620,400,Psychology of Coaching,0.38,0.12,0.35,0.12,0.04,0.0,0.0,0.0,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.64,0.28,0.04,0.04,0.0,0.0,0.0,0.0,natalie anne carter,
+AL,3620,402,Psychology of Coaching,0.44,0.28,0.16,0.08,0.0,0.0,0.0,0.04,natalie anne carter,
+AL,3740,400,Coaching Football,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,edmond fry,
+AL,3740,401,Coaching Football,0.61,0.09,0.0,0.04,0.04,0.0,0.0,0.22,edmond fry,
+AL,3760,400,Coaching Strength/Conditioning,0.72,0.21,0.0,0.0,0.07,0.0,0.0,0.0,edmond fry,
+AL,3760,401,Coaching Strength/Conditioning,0.81,0.04,0.04,0.0,0.11,0.0,0.0,0.0,edmond fry,
+AL,4380,402,Current Iss in HS Athletics,0.71,0.21,0.0,0.04,0.0,0.0,0.0,0.04,deborah jo cadorette,
+AL,4380,403,Media Relations in AL,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,4380,408,Officiating in AL,0.57,0.22,0.17,0.04,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,8380,400,Sp Topics in Intercoll Athlet,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,elliott charles,
+AL,8440,400,Surv of Res Mthds in Athletics,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristin kelly frady,
+AL,8440,401,Surv of Res Mthds in Athletics,0.71,0.07,0.14,0.0,0.07,0.0,0.0,0.0,kristin kelly frady,
+AL,8500,400,Principles Strength and Condit,0.74,0.19,0.07,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8650,401,Mkt and Comm Respon Interc Ath,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,misty soles,
+ANTH,2010,1,Introduction to Anthropology,0.44,0.24,0.18,0.04,0.04,0.0,0.0,0.04,yi wu,
+ANTH,2010,2,Introduction to Anthropology,0.35,0.33,0.2,0.05,0.02,0.0,0.0,0.05,yi wu,
+ANTH,2010,3,Introduction to Anthropology,0.4,0.49,0.1,0.0,0.0,0.0,0.0,0.01,david markus,
+ANTH,2010,4,Introduction to Anthropology,0.3,0.63,0.05,0.0,0.01,0.0,0.0,0.0,david markus,
+ANTH,2010,5,Introduction to Anthropology,0.36,0.56,0.01,0.03,0.04,0.0,0.0,0.0,david markus,
+ANTH,3320,1,World Archaeology,0.53,0.32,0.11,0.05,0.0,0.0,0.0,0.0,david markus,
+ANTH,3510,1,Biological Anthropology,0.37,0.42,0.11,0.05,0.05,0.0,0.0,0.0,lisa rapaport,
+ANTH,3530,1,Forensic Anthropology,0.24,0.65,0.0,0.12,0.0,0.0,0.0,0.0,katherine weisensee,
+ANTH,4660,1,Evolution of Human Behav,0.4,0.3,0.1,0.2,0.0,0.0,0.0,0.0,lisa rapaport,
+ANTH,4960,2,Anth CI: Entrepreneurs in BSHS,0.8,0.0,0.2,0.0,0.0,0.0,0.0,0.0,janie shonta johnson,
+ARCH,1010,1,Introduction to Architecture,0.63,0.19,0.04,0.01,0.04,0.0,0.0,0.08,sall hambright-belue,
+ARCH,2040,1,Hist of Modern Arch,0.55,0.32,0.12,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,2510,1,Arch Foundations I,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,2510,2,Arch Foundations I,0.14,0.5,0.29,0.0,0.0,0.0,0.0,0.07,robert silance,
+ARCH,2510,3,Arch Foundations I,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,dustin grah albright,
+ARCH,2510,4,Arch Foundations I,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,2510,5,Arch Foundations I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,2510,6,Arch Foundations I,0.54,0.31,0.08,0.08,0.0,0.0,0.0,0.0,timothy sutherland,
+ARCH,2700,1,Structures I,0.52,0.42,0.06,0.0,0.0,0.0,0.0,0.0,dustin grah albright,
+ARCH,3500,1,Intro to Urban Contexts,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,douglas hecker,
+ARCH,3500,2,Intro to Urban Contexts,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,3500,3,Intro to Urban Contexts,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,3500,4,Intro to Urban Contexts,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,3500,5,Intro to Urban Contexts,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,3510,3,Studio Clemson,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,michael carlo kleiss,
+ARCH,3510,4,Studio Clemson,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,
+ARCH,3540,1,Studio Barcelona,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4010,1,Architectural Portfolio,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,4010,2,Architectural Portfolio,0.25,0.58,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4010,4,Architectural Portfolio,0.8,0.1,0.0,0.0,0.1,0.0,0.0,0.0,pai liu,
+ARCH,4140,2,Design Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,6990,9,Freehand Drawing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lynn craig,
+ARCH,8100,1,Visualization I,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
+ARCH,8210,1,Research Methods,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8360,1,Managing Integr Proj Delivery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,sall hambright-belue,
+ARCH,8510,1,Design Studio III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-sop heine,
+ARCH,8510,2,Design Studio III,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,santa cruz da franco da,
+ARCH,8510,3,Design Studio III,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,
+ARCH,8600,1,History/Theory I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,8720,1,Production & Assemb,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,
+ARCH,8810,1,Pro Practice Survey,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,katherine schwennsen,
+ARCH,8950,1,A+H Studio: Projects,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ART,1050,1,Foundation Drawing I,0.18,0.18,0.55,0.09,0.0,0.0,0.0,0.0,denise elizabe ayers,
+ART,2070,1,Beginning Painting,0.35,0.18,0.29,0.0,0.0,0.0,0.0,0.18,dustin lee massey,
+ART,2090,1,Beginning Sculpture,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0, joseph rich manson rich,
+ART,2100,5,Art Appreciation,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,angel roche estrella,
+ART,2100,400,Art Appreciation,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0, joseph rich manson rich,
+ART,2110,1,Begin Printmaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mandy lorai ferguson,
+ART,2130,1,Begin Photography,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,amanda denise musick,
+ART,2170,1,Beginning Ceramics,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,
+ART,2210,1,Beginning New Media,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,christina nguye hung,
+ART,3050,1,Intermediate Drawing,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,annamarie williams,
+AS,1090,1,Air Force Today I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,1090,2,Air Force Today I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,1090,3,Air Force Today I,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,2090,1,Dev of Air Power I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,2090,2,Dev of Air Power I,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,2090,3,Dev of Air Power I,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,4090,1,Nat Sec Policy I,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,4090,2,Nat Sec Policy I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+ASL,1010,2,Am Sign Lang I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,
+ASL,1010,3,Am Sign Lang I,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
+ASL,1010,5,Am Sign Lang I,0.79,0.11,0.0,0.05,0.05,0.0,0.0,0.0,dunn kim mar misener mar,
+ASL,1010,6,Am Sign Lang I,0.58,0.21,0.05,0.0,0.11,0.0,0.0,0.05,jason hurdich,
+ASL,1020,1,Am Sign Lang I,0.41,0.24,0.29,0.0,0.0,0.0,0.0,0.06,jason hurdich,
+ASL,1020,2,Am Sign Lang I,0.6,0.2,0.1,0.1,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,2010,1,Am Sign Lang II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,
+ASL,2010,3,Am Sign Lang II,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
+ASL,2010,4,Am Sign Lang II,0.87,0.07,0.0,0.07,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
+ASL,2020,1,Am Sign Lang II,0.21,0.43,0.14,0.21,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,3010,1,Advanced A S L I,0.65,0.18,0.18,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
+ASL,3050,1,Deaf Studies,0.83,0.0,0.0,0.06,0.11,0.0,0.0,0.0,jason hurdich,
+ASL,3490,1,Adv App in Asl,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,
+ASTR,1010,1,Solar System Astronomy,0.24,0.32,0.31,0.06,0.03,0.0,0.0,0.05,mate adamkovics,
+ASTR,1020,1,Stellar Astronomy,0.38,0.28,0.15,0.08,0.05,0.0,0.0,0.06,mark leising,
+ASTR,1030,1,Solar Systm Astr Lab,0.74,0.13,0.09,0.0,0.0,0.0,0.0,0.04,mark leising,
+ASTR,1030,2,Solar Systm Astr Lab,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1030,4,Solar Systm Astr Lab,0.4,0.35,0.05,0.0,0.05,0.0,0.0,0.15,mark leising,
+ASTR,1030,6,Solar Systm Astr Lab,0.62,0.23,0.04,0.04,0.04,0.0,0.0,0.04,mark leising,
+ASTR,1030,7,Solar Systm Astr Lab,0.82,0.09,0.05,0.0,0.0,0.0,0.0,0.05,mark leising,
+ASTR,1030,8,Solar Systm Astr Lab,0.54,0.38,0.04,0.04,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1030,9,Solar Systm Astr Lab,0.72,0.06,0.06,0.0,0.17,0.0,0.0,0.0,mark leising,
+ASTR,1030,10,Solar Systm Astr Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1040,1,Stellar Astr Lab,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,mark leising,
+ASTR,1040,2,Stellar Astr Lab,0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1040,4,Stellar Astr Lab,0.43,0.48,0.0,0.0,0.04,0.0,0.0,0.04,mark leising,
+ASTR,3020,1,Stellar Astrophysics,0.35,0.41,0.0,0.0,0.06,0.0,0.0,0.18,marco ajello,
+ASTR,8300,1,Astroph III:Galactic,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+AUD,1850,1,Intro to Audio Tech,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUE,6010,1,Vehicle Dynamics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8040,699,Autovation for Entrepreneurs,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
+AUE,8180,1,"Engine Analysis, Design & Exp",0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8190,100,Adv Int Combustion Engine Conc,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,8280,1,Driveline/Powertrain,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8330,30,Auto Manuf Proc Devl,0.18,0.75,0.0,0.0,0.0,0.0,0.0,0.07,michael mears,
+AUE,8350,100,Auto Electronics,0.63,0.32,0.01,0.0,0.0,0.0,0.0,0.03,yunyi jia,
+AUE,8800,2,Vehicle Project Mngt,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,dee ann wood kivett wood,
+AUE,8810,3,Automotive Systems Overview,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,christiaan paredis,
+AUE,8870,8,Meth Vehicle Testing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,
+AVS,1000,1,Orientation to AVS,0.87,0.1,0.01,0.0,0.01,0.0,0.0,0.01,marie owens bolt,
+AVS,1500,1,Intro Animal Science,0.26,0.3,0.21,0.12,0.08,0.0,0.0,0.03,joseph keit bertrand,
+AVS,1500,2,Intro Animal Science,0.33,0.17,0.29,0.1,0.1,0.0,0.0,0.02,joseph keit bertrand,
+AVS,1510,1,Intro Ani Sci Lab,0.48,0.4,0.12,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
+AVS,1510,2,Intro Ani Sci Lab,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
+AVS,1510,3,Intro Ani Sci Lab,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
+AVS,1510,4,Intro Ani Sci Lab,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,alissa moritz,
+AVS,1510,5,Intro Ani Sci Lab,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
+AVS,1510,6,Intro Ani Sci Lab,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
+AVS,1510,7,Intro Ani Sci Lab,0.43,0.43,0.1,0.05,0.0,0.0,0.0,0.0,maslyn ann greene,
+AVS,1510,8,Intro Ani Sci Lab,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
+AVS,2040,1,Horse Care Techniques,0.7,0.22,0.05,0.03,0.0,0.0,0.0,0.0,kristine lang vernon,
+AVS,2060,1,Swine Techniques,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
+AVS,3010,1,Anat & Phys Dom Ani,0.54,0.22,0.23,0.01,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,3010,400,Anat & Phys Dom Ani,0.4,0.35,0.18,0.07,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,3020,1,Livestk Sel Eval I,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
+AVS,3100,1,Animal Health,0.62,0.24,0.12,0.0,0.0,0.0,0.0,0.03,celina marce checura,
+AVS,3700,1,Principles of Animal Nutrition,0.49,0.22,0.21,0.06,0.01,0.0,0.0,0.01,zheng zhou,
+AVS,3750,1,Applied Animal Nutrition,0.23,0.39,0.29,0.06,0.0,0.0,0.0,0.03,gustavo jose lascano,
+AVS,4000,2,AVS Professional Development,0.85,0.0,0.08,0.0,0.0,0.0,0.0,0.08,marie owens bolt,
+AVS,4110,1,Animal Growth and Development,0.49,0.34,0.1,0.05,0.02,0.0,0.0,0.0,susan kay duckett,
+AVS,4140,1,Basic Immunology,0.4,0.4,0.0,0.1,0.0,0.0,0.0,0.1,farzana ferdous,
+AVS,4150,1,Contemporary Issues in AVS,0.82,0.14,0.03,0.02,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,4160,1,Equine Exercise Phys,0.5,0.45,0.0,0.05,0.0,0.0,0.0,0.0,kristine lang vernon,
+AVS,4500,1,Sustain Livestock Product Sys,0.09,0.64,0.18,0.09,0.0,0.0,0.0,0.0,matias jose aguerre,
+AVS,4530,1,Animal Reproduction,0.61,0.32,0.05,0.0,0.02,0.0,0.0,0.0,tiffany wilmoth,
+AVS,4670,1,Animal Physiology II,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,celina marce checura,
+AVS,4800,1,Vertebrate Endocrinology,0.69,0.28,0.03,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,8200,1,Graduate Seminar,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,scott lee pratt,
+BCHM,1030,1,Careers in Bioch/Gen,0.88,0.03,0.06,0.0,0.01,0.0,0.0,0.02,alison ni starr-moss,
+BCHM,3010,1,Molecular Biochemistry,0.4,0.29,0.18,0.04,0.07,0.0,0.0,0.02,kerry smith,
+BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3040,2,Molecular Biology Laboratory,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3040,3,Molecular Biology Laboratory,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3040,4,Molecular Biology Laboratory,0.75,0.13,0.0,0.0,0.13,0.0,0.0,0.0,geoffrey ford,
+BCHM,3040,5,Molecular Biology Laboratory,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3050,1,Essen Elements Bioch,0.25,0.34,0.25,0.08,0.05,0.0,0.0,0.04,debra ragland,
+BCHM,3050,2,Essen Elements Bioch,0.39,0.4,0.13,0.04,0.01,0.0,0.0,0.04,debra ragland,
+BCHM,4310,1,Physical Approach to Biochem,0.28,0.4,0.25,0.02,0.02,0.0,0.0,0.04,weiguo cao,
+BCHM,4330,2,Physical Biochemistry Lab,0.7,0.1,0.1,0.0,0.0,0.0,0.0,0.1,geoffrey ford,
+BCHM,4330,4,Physical Biochemistry Lab,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,geoffrey ford,
+BCHM,4400,1,Bioinformatics,0.68,0.26,0.0,0.0,0.03,0.0,0.0,0.03,frank alexand feltus,
+BCHM,4430,1,Molecular Basis of Disease,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,james morris,
+BCHM,8900,1,Euk Path Journal Club,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,kerry smith,
+BE,2120,1,Fundamentals of Biosys Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,3200,1,Principles & Prac of Geomatics,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4100,1,Biological Kinetics,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,4280,1,Biochem Engr,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,terry walker,
+BE,4750,1,BE Capstone Design,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,
+BIOE,1010,1,Biol for Bioengr,0.47,0.2,0.27,0.0,0.07,0.0,0.0,0.0,vladimir vlad reukov,
+BIOE,2010,1,Intro Biomed Engr,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,charles webb,
+BIOE,2010,2,Intro Biomed Engr,0.27,0.42,0.18,0.04,0.01,0.0,0.0,0.08,charles webb,
+BIOE,3020,1,Biomaterials,0.75,0.17,0.06,0.0,0.0,0.0,0.0,0.02,alexey alex vertegel,
+BIOE,3100,1,Engr Analysis of Physiol Proc,0.78,0.2,0.0,0.01,0.0,0.0,0.0,0.0,brian william booth,
+BIOE,3200,1,Biomechanics,0.55,0.34,0.09,0.02,0.0,0.0,0.0,0.0,jiro nagatomi,
+BIOE,3210,1,Biofluid Mechanics,0.65,0.16,0.16,0.0,0.03,0.0,0.0,0.0,zhi gao,
+BIOE,3470,1,Transport Processes in Bioengr,0.44,0.35,0.14,0.03,0.01,0.0,0.0,0.03,renee nicole cottle,
+BIOE,3700,1,Bioinst & Imaging,0.58,0.32,0.05,0.01,0.01,0.0,0.0,0.03,delphine dean,
+BIOE,4120,1,Orthopaedic Engr and Pathology,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,melinda harman,
+BIOE,4400,1,Biopharmaceutical Engineering,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,sarah harcum,
+BIOE,4480,1,Tissue Engineering,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,angela ant alexander,
+BIOE,6120,1,Orthopaedic Engr & Pathology,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,melinda harman,
+BIOE,6350,1,Modeling of Multiphysics Prob,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,
+BIOE,8010,1,Bio Materials,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,robert latour,
+BIOE,8020,864,Biocompatibility,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,narendra vyavahare,
+BIOE,8140,843,Medical Dev Commercialization,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hobey tam,
+BIOE,8700,1,Bioinstrumentation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,tong ye,
+BIOL,1010,1,Frontiers in Biology I,0.8,0.1,0.08,0.01,0.01,0.0,0.0,0.0,robert edwar ballard,
+BIOL,1010,2,Frontiers in Biology I,0.84,0.09,0.05,0.0,0.01,0.0,0.0,0.01,michael childress,
+BIOL,1030,1,General Biology I,0.2,0.25,0.28,0.11,0.07,0.0,0.0,0.1,nora espinoza,
+BIOL,1030,2,General Biology I,0.22,0.39,0.25,0.07,0.02,0.0,0.0,0.04,william baldwin,
+BIOL,1030,3,General Biology I,0.3,0.31,0.24,0.1,0.02,0.0,0.0,0.03,wen chen,
+BIOL,1030,4,General Biology I,0.16,0.29,0.31,0.09,0.05,0.0,0.0,0.1,salvatore sparace,
+BIOL,1030,5,General Biology I (HON),0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
+BIOL,1050,1,General Biology Lab I,0.17,0.48,0.22,0.04,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,2,General Biology Lab I,0.35,0.39,0.09,0.09,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,3,General Biology Lab I,0.22,0.39,0.26,0.09,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,4,General Biology Lab I,0.17,0.54,0.08,0.04,0.0,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,5,General Biology Lab I,0.18,0.47,0.24,0.0,0.06,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1050,6,General Biology Lab I,0.33,0.48,0.05,0.1,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,7,General Biology Lab I,0.21,0.5,0.13,0.04,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,8,General Biology Lab I,0.17,0.5,0.25,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,9,General Biology Lab I,0.18,0.5,0.27,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,10,General Biology Lab I,0.14,0.41,0.18,0.14,0.0,0.0,0.0,0.14,tafadzwa kaisa,
+BIOL,1050,11,General Biology Lab I,0.29,0.33,0.29,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,12,General Biology Lab I,0.27,0.36,0.23,0.05,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,13,General Biology Lab I,0.17,0.63,0.13,0.0,0.08,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,14,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,15,General Biology Lab I,0.29,0.38,0.25,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,16,General Biology Lab I,0.17,0.67,0.08,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,17,General Biology Lab I,0.38,0.38,0.17,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,18,General Biology Lab I,0.33,0.38,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,19,General Biology Lab I,0.18,0.59,0.23,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,20,General Biology Lab I,0.35,0.43,0.17,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,21,General Biology Lab I,0.21,0.63,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,22,General Biology Lab I,0.16,0.42,0.16,0.11,0.11,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,23,General Biology Lab I,0.28,0.22,0.28,0.22,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,24,General Biology Lab I,0.05,0.73,0.14,0.0,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,25,General Biology Lab I,0.22,0.57,0.17,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,26,General Biology Lab I,0.05,0.45,0.27,0.18,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,28,General Biology Lab I,0.21,0.58,0.13,0.0,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,29,General Biology Lab I,0.29,0.54,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,31,General Biology Lab I,0.33,0.5,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,32,General Biology Lab I,0.21,0.42,0.25,0.0,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,33,General Biology Lab I,0.5,0.33,0.08,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,34,General Biology Lab I,0.24,0.52,0.14,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,35,General Biology Lab I,0.36,0.55,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,37,General Biology Lab I,0.42,0.42,0.17,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,38,General Biology Lab I,0.33,0.42,0.21,0.04,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,39,General Biology Lab I,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,40,General Biology Lab I,0.33,0.54,0.08,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,41,General Biology Lab I,0.21,0.5,0.21,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,42,General Biology Lab I,0.29,0.58,0.08,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,43,General Biology Lab I,0.29,0.46,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,44,General Biology Lab I,0.21,0.54,0.17,0.04,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,45,General Biology Lab I,0.33,0.54,0.08,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,46,General Biology Lab I,0.24,0.52,0.14,0.1,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,47,General Biology Lab I,0.25,0.6,0.1,0.0,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,48,General Biology Lab I,0.33,0.57,0.05,0.05,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1090,1,Intro to Life Sci,0.83,0.13,0.03,0.01,0.0,0.0,0.0,0.0,renea chris hardwick,
+BIOL,1100,1,Principles of Biology I,0.36,0.35,0.17,0.05,0.03,0.0,0.0,0.03,renea chris hardwick,
+BIOL,1100,2,Principles of Biology I (HON),0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,renea chris hardwick,True
+BIOL,1100,3,Principles of Biology I,0.27,0.49,0.16,0.04,0.02,0.0,0.0,0.03, christine minor m,
+BIOL,1100,4,Principles of Biology I (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,True
+BIOL,2000,2,Biology in the News,0.67,0.11,0.17,0.0,0.0,0.0,0.0,0.06,dylan dittrich-reed,
+BIOL,2000,3,Biology in the News,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,
+BIOL,2000,4,Biology in the News,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,dylan dittrich-reed,
+BIOL,2110,1,Introduction to Toxicology,0.72,0.24,0.0,0.03,0.0,0.0,0.0,0.0,den hurk peter van peter,
+BIOL,2220,1,Human Anat and Physiology I,0.26,0.3,0.23,0.09,0.07,0.0,0.0,0.04,john cummings,
+BIOL,2220,2,Human Anat and Physiology I,0.25,0.37,0.2,0.09,0.07,0.0,0.0,0.02,john cummings,
+BIOL,3030,1,Vertebrate Biology,0.35,0.25,0.19,0.15,0.03,0.0,0.0,0.04,richard blob,
+BIOL,3030,2,Vertebrate Biology (HON),0.79,0.17,0.03,0.0,0.0,0.0,0.0,0.0,richard blob,True
+BIOL,3040,1,Biology of Plants,0.38,0.35,0.19,0.04,0.01,0.0,0.0,0.03,christina wells,
+BIOL,3070,1,Vertebrate Biology Lab,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,2,Vertebrate Biology Lab,0.63,0.16,0.21,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,3,Vertebrate Biology Lab,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,4,Vertebrate Biology Lab,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,5,Vertebrate Biology Lab,0.45,0.4,0.0,0.0,0.0,0.0,0.0,0.15,richard blob,
+BIOL,3070,6,Vertebrate Biology Lab,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,7,Vertebrate Biology Lab,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,8,Vertebrate Biology Lab,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,9,Vertebrate Biology Lab,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,richard blob,
+BIOL,3070,10,Vertebrate Biology Lab,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,11,Vertebrate Biology Lab,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,12,Vertebrate Biology Lab,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,13,Vertebrate Biology Lab,0.3,0.5,0.05,0.05,0.0,0.0,0.0,0.1,richard blob,
+BIOL,3080,1,Biology of Plants Practicum,0.5,0.35,0.05,0.1,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,2,Biology of Plants Practicum,0.25,0.25,0.35,0.15,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,3,Biology of Plants Practicum,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,nathan redding,
+BIOL,3080,4,Biology of Plants Practicum,0.33,0.39,0.17,0.11,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,5,Biology of Plants Practicum,0.32,0.37,0.32,0.0,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,6,Biology of Plants Practicum,0.26,0.26,0.26,0.11,0.0,0.0,0.0,0.11,nathan redding,
+BIOL,3150,1,Functional Human Anatomy,0.19,0.41,0.25,0.07,0.02,0.0,0.0,0.05,tamara mcnutt-scott,
+BIOL,3200,1,Field Botany,0.16,0.28,0.25,0.09,0.06,0.0,0.0,0.16,robert edwar ballard,
+BIOL,3350,1,Evolutionary Biology,0.29,0.38,0.21,0.04,0.05,0.0,0.0,0.02,samantha ann price,
+BIOL,3510,1,Biological Anthropology,0.53,0.41,0.0,0.06,0.0,0.0,0.0,0.0,lisa rapaport,
+BIOL,3530,1,Forensic Anthropology,0.35,0.5,0.1,0.05,0.0,0.0,0.0,0.0,katherine weisensee,
+BIOL,4140,1,Basic Immunology,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,yanzhang wei,
+BIOL,4200,1,Neurobiology,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4250,1,Introductory Mycology,0.34,0.41,0.19,0.05,0.02,0.0,0.0,0.0,julia louis kerrigan,
+BIOL,4260,1,Mycology Practicum,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,julia louis kerrigan,
+BIOL,4260,2,Mycology Practicum,0.4,0.47,0.07,0.0,0.0,0.0,0.0,0.07,julia louis kerrigan,
+BIOL,4400,1,Developmental Animal Biology,0.38,0.28,0.25,0.06,0.01,0.0,0.0,0.01,kara elizabet powder,
+BIOL,4430,2,Freshwater Ecology,0.19,0.48,0.19,0.03,0.03,0.0,0.0,0.06,john jenkins hains,
+BIOL,4560,1,Medical and Vet Parasitology,0.67,0.25,0.06,0.0,0.0,0.0,0.0,0.03,wilbur kears milhous,
+BIOL,4610,1,Cell Biology,0.28,0.45,0.2,0.05,0.0,0.0,0.0,0.02,susan caroli chapman,
+BIOL,4610,2,Cell Biology (HON),0.65,0.26,0.06,0.03,0.0,0.0,0.0,0.0,susan caroli chapman,True
+BIOL,4620,1,Cell Biology Lab (Lec),0.64,0.32,0.0,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,2,Cell Biology Lab (Lec),0.67,0.3,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,3,Cell Biology Lab (Lec),0.64,0.29,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,4,Cell Biology Lab (Lec),0.61,0.29,0.04,0.07,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.7,0.22,0.0,0.04,0.04,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.52,0.37,0.0,0.0,0.0,0.0,0.0,0.11,xianzhong yu,
+BIOL,4670,1,Principles of Hematology,0.8,0.11,0.0,0.03,0.0,0.0,0.0,0.06,vincent gallicchio,
+BIOL,4930,5,Sr Sem: Symbiosis,0.8,0.07,0.13,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
+BIOL,8120,1,Seminar,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,michael sears,
+BIOL,8200,1,Community Ecology,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,saara dewalt,
+BIOL,8400,1,Understanding Biological Inq,0.88,0.01,0.02,0.0,0.04,0.0,0.0,0.06,michael childress,
+BIOL,8420,1,Understand Cellular Processes,0.67,0.24,0.08,0.0,0.02,0.0,0.0,0.0,patricia leota tate,
+BIOL,8440,1,Understanding the Human Body,0.65,0.27,0.07,0.0,0.0,0.0,0.0,0.01,william baldwin,
+BIOL,8710,2,MCDB Grad Core,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,lisa bain,
+BUS,1010,1,Business Foundations,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,william erne tumblin,
+BUS,1010,2,Business Foundations,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,william erne tumblin,
+BUS,1010,3,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william erne tumblin,
+BUS,1010,4,Business Foundations,0.35,0.53,0.06,0.0,0.06,0.0,0.0,0.0,mary ann  prater m,
+BUS,1010,5,Business Foundations,0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,mary ann  prater m,
+BUS,1010,6,Business Foundations,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,mary ann  prater m,
+BUS,1010,7,Business Foundations,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,william erne tumblin,
+BUS,1010,8,Business Foundations,0.11,0.39,0.28,0.11,0.11,0.0,0.0,0.0,william erne tumblin,
+BUS,1010,9,Business Foundations,0.22,0.44,0.11,0.17,0.0,0.0,0.0,0.06,william erne tumblin,
+BUS,1010,10,Business Foundations,0.42,0.37,0.11,0.0,0.05,0.0,0.0,0.05,william erne tumblin,
+BUS,1010,11,Business Foundations,0.32,0.42,0.11,0.0,0.11,0.0,0.0,0.05,william erne tumblin,
+BUS,1010,15,Business Foundations,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,16,Business Foundations,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,17,Business Foundations,0.36,0.5,0.0,0.0,0.07,0.0,0.0,0.07,donna mccubbin,
+BUS,1010,18,Business Foundations,0.11,0.5,0.28,0.06,0.06,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,19,Business Foundations,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,donna mccubbin,
+BUS,1010,20,Business Foundations,0.21,0.47,0.21,0.0,0.11,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,23,Business Foundations,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,24,Business Foundations,0.42,0.32,0.16,0.0,0.05,0.0,0.0,0.05,sandy edge,
+BUS,1010,25,Business Foundations,0.39,0.44,0.06,0.06,0.0,0.0,0.0,0.06,sandy edge,
+BUS,1010,26,Business Foundations,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,iulio edward barr de barr,
+BUS,1010,27,Business Foundations,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,iulio edward barr de barr,
+BUS,1010,28,Business Foundations,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,iulio edward barr de barr,
+BUS,1010,29,Business Foundations,0.15,0.32,0.21,0.09,0.11,0.0,0.0,0.13,mary ann  prater m,
+BUS,1010,30,Business Foundations,0.11,0.59,0.26,0.02,0.02,0.0,0.0,0.0,mary ann  prater m,
+BUS,1010,31,Business Foundations,0.29,0.53,0.06,0.06,0.0,0.0,0.0,0.06,mary ann  prater m,
+BUS,1010,33,Business Foundations,0.2,0.47,0.1,0.07,0.03,0.0,0.0,0.13,donna mccubbin,
+BUS,1010,34,Business Foundations,0.37,0.32,0.32,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,35,Business Foundations,0.5,0.28,0.11,0.06,0.0,0.0,0.0,0.06,william erne tumblin,
+BUS,1010,37,Business Foundations,0.44,0.31,0.19,0.06,0.0,0.0,0.0,0.0,donna mccubbin,
+CE,1990,20,Cr Inq in Civil Engineering,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,bradley putman,
+CE,2010,1,Statics,0.34,0.26,0.18,0.04,0.15,0.0,0.0,0.03,qiushi chen,
+CE,2010,2,Statics,0.1,0.4,0.26,0.02,0.02,0.0,0.0,0.19,melissa sternhagen,
+CE,2010,3,Statics,0.18,0.48,0.2,0.07,0.02,0.0,0.0,0.05,md nasimul chowdhury,
+CE,2010,4,Statics,0.11,0.3,0.21,0.12,0.09,0.0,0.0,0.17,melissa sternhagen,
+CE,2010,5,Statics,0.24,0.27,0.22,0.07,0.07,0.0,0.0,0.12,qiushi chen,
+CE,2010,6,Statics,0.1,0.15,0.2,0.15,0.15,0.0,0.0,0.25,melissa sternhagen,
+CE,2010,7,Statics (HON),0.2,0.7,0.1,0.0,0.0,0.0,0.0,0.0,melissa sternhagen,True
+CE,2010,8,Statics,0.09,0.34,0.36,0.07,0.02,0.0,0.0,0.11,md nasimul chowdhury,
+CE,2060,1,Structural Mechanics,0.07,0.25,0.4,0.17,0.07,0.0,0.0,0.05,melissa sternhagen,
+CE,2080,1,Dynamics,0.11,0.44,0.37,0.06,0.03,0.0,0.0,0.0,md nasimul chowdhury,
+CE,2550,1,Geomatics,0.3,0.34,0.3,0.01,0.03,0.0,0.0,0.01,wayne sarasua,
+CE,3010,1,Structural Analysis,0.34,0.29,0.26,0.03,0.09,0.0,0.0,0.0,stephen csernak,
+CE,3010,2,Structural Analysis,0.35,0.4,0.23,0.03,0.0,0.0,0.0,0.0,brandon ross,
+CE,3110,1,Transportation Engr,0.47,0.45,0.05,0.0,0.03,0.0,0.0,0.0,jennifer ogle,
+CE,3210,1,Geotechnical Engineering,0.38,0.45,0.13,0.05,0.0,0.0,0.0,0.0,shweta shrestha,
+CE,3310,1,Constr Engr & Mgmnt,0.44,0.41,0.09,0.05,0.0,0.0,0.0,0.0,james burati,
+CE,3410,1,Intro to Fluid Mech,0.36,0.52,0.11,0.02,0.0,0.0,0.0,0.0,nigel gregory kaye,
+CE,3410,2,Intro to Fluid Mech,0.28,0.36,0.22,0.04,0.08,0.0,0.0,0.02,abdul khan,
+CE,3420,1,Hydraulics & Hydro,0.47,0.38,0.05,0.02,0.04,0.0,0.0,0.04,ashok mishra,
+CE,3510,1,Civil Engineering Materials,0.48,0.44,0.06,0.02,0.0,0.0,0.0,0.0,amir esmaeilpoursaee,
+CE,3510,2,Civil Engineering Materials,0.4,0.4,0.15,0.05,0.0,0.0,0.0,0.0,amir esmaeilpoursaee,
+CE,3520,1,Econ Eval of Proj,0.4,0.38,0.13,0.02,0.04,0.0,0.0,0.04,zoraya roldan rockow,
+CE,4020,1,Reinfor Con Design,0.28,0.51,0.15,0.02,0.02,0.0,0.0,0.02,brandon ross,
+CE,4060,1,Struct Steel Design,0.38,0.35,0.24,0.03,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4100,1,Traffic Engr Oper,0.27,0.32,0.23,0.05,0.05,0.0,0.0,0.09,wayne sarasua,
+CE,4240,1,Earth Slopes & Struc,0.35,0.48,0.13,0.05,0.0,0.0,0.0,0.0,nadaraj ravichandran,
+CE,4390,1,Con Eqpmt Sel & Main,0.49,0.38,0.11,0.03,0.0,0.0,0.0,0.0,james burati,
+CE,4470,1,Stormwater Managemnt,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,earl hayter,
+CE,4560,1,Pave Design & Constr,0.47,0.41,0.09,0.0,0.0,0.0,0.0,0.03,bradley putman,
+CE,4590,1,Capstone Design Proj,0.46,0.38,0.11,0.03,0.0,0.0,0.0,0.03,stephen csernak,
+CE,4820,1,Groundwater & Contam Transport,0.3,0.3,0.1,0.0,0.0,0.0,0.0,0.3,lawrence murdoch,
+CE,4910,1,BIM in Construction Management,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,6100,1,Traffic Engr Oper,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
+CE,6240,1,Earth Slopes & Struc,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,nadaraj ravichandran,
+CE,6390,1,Con Eqpmt Sel & Main,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james burati,
+CE,8020,1,Adv R/C Design,0.38,0.31,0.23,0.0,0.0,0.0,0.0,0.08,thomas edfor cousins,
+CE,8220,1,Foundation Engr,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,nadaraj ravichandran,
+CE,8260,1,Prop of Concrete,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,prasada ra rangaraju,
+CE,8460,1,Flow in Open Chnls,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,abdul khan,
+CE,8480,500,Risk Analyt in Supply Chains,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott jennings mason,
+CE,8540,1,Travl Demnd Forecast,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,pamela murray-tuite,
+CE,8930,3,Risk Assessment,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CES,1900,101,CI - LEAD Forward I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,steve richar sanders,
+CES,1900,500,CI - PEER/WISE Exp Seminar,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jordon antho gilmore,
+CH,1010,1,General Chemistry,0.23,0.31,0.22,0.11,0.1,0.0,0.0,0.04,william we mcwhorter,
+CH,1010,2,General Chemistry,0.23,0.34,0.23,0.1,0.03,0.0,0.0,0.06,laura lanni,
+CH,1010,3,General Chemistry,0.13,0.36,0.35,0.05,0.06,0.0,0.0,0.06,olt geiculescu,
+CH,1010,4,General Chemistry,0.19,0.33,0.19,0.12,0.1,0.0,0.0,0.07,william we mcwhorter,
+CH,1010,5,General Chemistry,0.28,0.32,0.19,0.12,0.06,0.0,0.0,0.03,steven lo pellizzeri,
+CH,1010,6,General Chemistry,0.2,0.32,0.3,0.07,0.07,0.0,0.0,0.04,elliot ennis,
+CH,1010,7,General Chemistry,0.26,0.32,0.22,0.13,0.06,0.0,0.0,0.02,jacob schroeder,
+CH,1010,8,General Chemistry,0.33,0.28,0.23,0.07,0.04,0.0,0.0,0.05,princess mycia cox,
+CH,1010,9,General Chemistry,0.2,0.29,0.29,0.11,0.08,0.0,0.0,0.04,dennis taylor,
+CH,1010,10,General Chemistry,0.3,0.27,0.21,0.07,0.12,0.0,0.0,0.03,thomas hickman,
+CH,1010,11,General Chemistry,0.28,0.34,0.21,0.1,0.03,0.0,0.0,0.03,steven lo pellizzeri,
+CH,1010,12,General Chemistry,0.27,0.35,0.24,0.06,0.04,0.0,0.0,0.03,elliot ennis,
+CH,1010,13,General Chemistry,0.19,0.27,0.26,0.18,0.05,0.0,0.0,0.05,dennis taylor,
+CH,1010,50,General Chemistry,0.58,0.29,0.06,0.06,0.0,0.0,0.0,0.0,tania issa houjeiry,
+CH,1010,51,General Chemistry (HON),0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,True
+CH,1010,52,General Chemistry (HON),0.71,0.23,0.06,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True
+CH,1010,201,General Chemistry,0.21,0.44,0.25,0.06,0.04,0.0,0.0,0.01,laura lanni,
+CH,1010,202,General Chemistry,0.29,0.44,0.19,0.04,0.02,0.0,0.0,0.03,tania issa houjeiry,
+CH,1010,203,General Chemistry,0.19,0.45,0.22,0.06,0.03,0.0,0.0,0.05,william we mcwhorter,
+CH,1010,204,General Chemistry,0.31,0.34,0.24,0.09,0.01,0.0,0.0,0.02,princess mycia cox,
+CH,1020,1,General Chemistry,0.33,0.23,0.22,0.12,0.05,0.0,0.0,0.05,stephen schvaneveldt,
+CH,1020,2,General Chemistry,0.33,0.27,0.19,0.14,0.04,0.0,0.0,0.02,stephen schvaneveldt,
+CH,1020,3,General Chemistry,0.29,0.29,0.22,0.09,0.02,0.0,0.0,0.08,stephen schvaneveldt,
+CH,1020,400,General Chemistry,0.09,0.21,0.23,0.26,0.11,0.0,0.0,0.11,stephen schvaneveldt,
+CH,1050,1,Chemistry in Context I,0.19,0.46,0.29,0.03,0.02,0.0,0.0,0.01,elliot ennis,
+CH,1050,2,Chemistry in Context I,0.16,0.57,0.15,0.05,0.01,0.0,0.0,0.06,elliot ennis,
+CH,2010,1,Survey of Organic Chemistry,0.3,0.37,0.09,0.06,0.13,0.0,0.0,0.05,thomas hickman,
+CH,2010,2,Survey of Organic Chemistry,0.46,0.32,0.15,0.08,0.0,0.0,0.0,0.0,thomas hickman,
+CH,2020,2,Surv of Organic Chemistry Lab,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,
+CH,2020,3,Surv of Organic Chemistry Lab,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,james nelson plampin,
+CH,2020,9,Surv of Organic Chemistry Lab,0.82,0.0,0.05,0.0,0.09,0.0,0.0,0.05,james nelson plampin,
+CH,2230,1,Organic Chemistry,0.08,0.2,0.25,0.14,0.2,0.0,0.0,0.13,modi wetzler,
+CH,2230,2,Organic Chemistry,0.18,0.26,0.24,0.17,0.06,0.0,0.0,0.1,modi wetzler,
+CH,2230,3,Organic Chemistry,0.43,0.25,0.15,0.08,0.03,0.0,0.0,0.06,tania issa houjeiry,
+CH,2230,4,Organic Chemistry,0.35,0.27,0.18,0.09,0.04,0.0,0.0,0.07,laura lanni,
+CH,2230,5,Organic Chemistry,0.55,0.26,0.13,0.03,0.02,0.0,0.0,0.03,rhett smith,
+CH,2230,6,Organic Chemistry,0.26,0.23,0.12,0.15,0.15,0.0,0.0,0.09,rhett smith,
+CH,2230,7,Organic Chemistry,0.21,0.24,0.23,0.08,0.1,0.0,0.0,0.16,sourav saha,
+CH,2240,1,Organic Chemistry,0.22,0.32,0.24,0.13,0.09,0.0,0.0,0.01,jacob schroeder,
+CH,2240,2,Organic Chemistry,0.33,0.29,0.2,0.09,0.06,0.0,0.0,0.03,jacob schroeder,
+CH,2270,1,Organic Chem Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2270,2,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,5,Organic Chem Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,
+CH,2270,6,Organic Chem Lab,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,7,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,
+CH,2270,8,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,
+CH,2270,13,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,
+CH,2270,15,Organic Chem Lab,0.78,0.11,0.0,0.06,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2270,17,Organic Chem Lab,0.47,0.26,0.0,0.05,0.0,0.0,0.0,0.21,james nelson plampin,
+CH,2270,18,Organic Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
+CH,2270,19,Organic Chem Lab,0.79,0.05,0.05,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,20,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,22,Organic Chem Lab,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2270,23,Organic Chem Lab,0.84,0.05,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,
+CH,2270,24,Organic Chem Lab,0.67,0.11,0.11,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,25,Organic Chem Lab,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,
+CH,2270,26,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,
+CH,2270,27,Organic Chem Lab,0.84,0.0,0.0,0.0,0.05,0.0,0.0,0.11,james nelson plampin,
+CH,2270,28,Organic Chem Lab,0.78,0.06,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,
+CH,2270,29,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,30,Organic Chem Lab,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,
+CH,2270,31,Organic Chem Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,
+CH,2270,32,Organic Chem Lab,0.69,0.06,0.0,0.0,0.0,0.0,0.0,0.25,james nelson plampin,
+CH,2270,33,Organic Chem Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,james nelson plampin,
+CH,2270,35,Organic Chem Lab,0.63,0.06,0.13,0.0,0.06,0.0,0.0,0.13,james nelson plampin,
+CH,2270,36,Organic Chem Lab,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,james nelson plampin,
+CH,2270,37,Organic Chem Lab,0.85,0.05,0.0,0.0,0.05,0.0,0.0,0.05,james nelson plampin,
+CH,2270,39,Organic Chem Lab,0.73,0.08,0.0,0.0,0.0,0.0,0.0,0.19,james nelson plampin,
+CH,2270,40,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,
+CH,2280,1,Organic Chem Lab,0.84,0.05,0.0,0.05,0.0,0.0,0.0,0.05,james nelson plampin,
+CH,2280,2,Organic Chem Lab,0.82,0.05,0.0,0.05,0.05,0.0,0.0,0.05,james nelson plampin,
+CH,2280,4,Organic Chem Lab,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,james nelson plampin,
+CH,2280,6,Organic Chem Lab,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,james nelson plampin,
+CH,2280,8,Organic Chem Lab,0.88,0.04,0.0,0.0,0.04,0.0,0.0,0.04,james nelson plampin,
+CH,2280,9,Organic Chem Lab,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,james nelson plampin,
+CH,3130,1,Quantitative Analys,0.37,0.23,0.27,0.07,0.03,0.0,0.0,0.03,olt geiculescu,
+CH,3150,1,Quant Analysis Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,perez carlos garcia,
+CH,3150,2,Quant Analysis Lab,0.45,0.18,0.18,0.0,0.18,0.0,0.0,0.0,perez carlos garcia,
+CH,3300,1,Intro to Phys Chem,0.45,0.39,0.09,0.03,0.0,0.0,0.0,0.03,brian dominy,
+CH,3310,1,Physical Chemistry,0.35,0.31,0.23,0.08,0.04,0.0,0.0,0.0,steven stuart,
+CH,3320,1,Physical Chemistry,0.29,0.36,0.36,0.0,0.0,0.0,0.0,0.0,arkady kholodenko,
+CH,3390,1,Physical Chem Lab,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,2,Physical Chem Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,3,Physical Chem Lab,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,princess mycia cox,
+CH,3390,5,Physical Chem Lab,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3410,1,Introduction to Research,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,stephen creager,
+CH,4010,1,Organometallic Chemistry,0.74,0.23,0.0,0.0,0.0,0.0,0.0,0.03,andrew greg tennyson,
+CH,4020,1,Inorganic Chemistry,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,joseph kolis,
+CH,6020,1,Inorganic Chemistry,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,joseph kolis,
+CH,8070,1,Chem Trans Elem,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,julia brumaghim,
+CH,8090,1,Chem App/X-Ray Cryst,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,colin mcmillen,
+CH,8210,1,Organic Chem I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ya-ping sun,
+CH,8300,1,Fund Phys Chem,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,dvora perahia,
+CH,8510,3,Grad Student Seminar,0.83,0.15,0.0,0.0,0.0,0.0,0.0,0.03,joseph stua thrasher,
+CHE,2110,1,Mass and Energy Balances,0.32,0.29,0.35,0.03,0.0,0.0,0.0,0.0,karen ann high,
+CHE,2110,2,Mass and Energy Balances,0.22,0.25,0.31,0.11,0.07,0.0,0.0,0.04,mark roberts,
+CHE,3210,1,Ch E Thermo II,0.14,0.21,0.3,0.24,0.1,0.0,0.0,0.02,sapna sarupria,
+CHE,3300,1,Mass Trans & Seprtn,0.23,0.16,0.3,0.2,0.11,0.0,0.0,0.0,mark thies,
+CHE,4070,1,Unit Op Lab II,0.18,0.53,0.29,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
+CHE,4310,1,Process Design I,0.31,0.57,0.11,0.01,0.0,0.0,0.0,0.0,david bruce,
+CHE,4500,1,Chem Reaction Engr,0.4,0.41,0.17,0.02,0.0,0.0,0.0,0.0,rachel getman,
+CHE,8030,1,Advanced Transport,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,eric mikel davis,
+CHE,8040,1,Ch E Thermodynamics,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,joseph scott,
+CHE,8050,1,Ch E Kinetics,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,mark alan blenner,
+CHE,8450,4,Systems Biology & Pharmacology,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,marc russ birtwistle,
+CHIN,1010,2,Elementary Chinese,0.27,0.33,0.2,0.0,0.0,0.0,0.0,0.2,ling rao,
+CHIN,2010,1,Intermediate Chinese,0.55,0.27,0.0,0.09,0.0,0.0,0.0,0.09,ling rao,
+CHIN,4010,1,Pre-Modern Chinese Literature,0.33,0.38,0.13,0.03,0.05,0.0,0.0,0.1,yanming an,
+COM,1500,1,Intro to Human Communication,0.72,0.24,0.01,0.0,0.01,0.0,0.0,0.01,daniel leland fecher,
+COM,1500,2,Intro to Human Communication,0.64,0.26,0.05,0.01,0.02,0.0,0.0,0.03,daniel leland fecher,
+COM,1500,3,Intro to Human Communication,0.75,0.21,0.02,0.01,0.01,0.0,0.0,0.01,daniel leland fecher,
+COM,1500,4,Intro to Human Communication,0.64,0.24,0.06,0.02,0.03,0.0,0.0,0.01,marianne herr glaser,
+COM,1500,5,Intro to Human Communication,0.65,0.26,0.04,0.02,0.0,0.0,0.0,0.02,marianne herr glaser,
+COM,1500,6,Intro to Human Communication,0.53,0.33,0.09,0.0,0.04,0.0,0.0,0.01,marianne herr glaser,
+COM,1500,7,Intro to Human Communication,0.55,0.44,0.01,0.0,0.0,0.0,0.0,0.0,daniel leland fecher,
+COM,2010,1,Intr to Comm Studies,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,
+COM,2010,2,Intr to Comm Studies,0.67,0.27,0.03,0.03,0.0,0.0,0.0,0.0,john steven  spinda w,
+COM,2030,1,Mass Communication Theory,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,2110,1,Qual Comm Research Methods,0.44,0.39,0.17,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,2110,2,Qual Comm Research Methods,0.58,0.21,0.16,0.05,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,2500,1,Public Speaking,0.65,0.29,0.0,0.0,0.06,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,3,Public Speaking,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,caitlin baker,
+COM,2500,5,Public Speaking,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,6,Public Speaking,0.47,0.37,0.0,0.11,0.0,0.0,0.0,0.05,vanessa anne condon,
+COM,2500,7,Public Speaking,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,sara grumble crocker,
+COM,2500,8,Public Speaking,0.53,0.26,0.05,0.05,0.05,0.0,0.0,0.05,sara grumble crocker,
+COM,2500,9,Public Speaking,0.44,0.28,0.06,0.06,0.06,0.0,0.0,0.11,sara grumble crocker,
+COM,2500,10,Public Speaking,0.56,0.11,0.28,0.0,0.06,0.0,0.0,0.0,sara grumble crocker,
+COM,2500,11,Public Speaking,0.53,0.32,0.05,0.0,0.05,0.0,0.0,0.05,alyssa christi davis,
+COM,2500,12,Public Speaking,0.47,0.42,0.05,0.0,0.05,0.0,0.0,0.0,alyssa christi davis,
+COM,2500,13,Public Speaking,0.53,0.37,0.05,0.0,0.0,0.0,0.0,0.05,alyssa christi davis,
+COM,2500,14,Public Speaking,0.78,0.06,0.06,0.0,0.0,0.0,0.0,0.11,pauline matthey,
+COM,2500,15,Public Speaking,0.63,0.16,0.0,0.05,0.0,0.0,0.0,0.16,pauline matthey,
+COM,2500,16,Public Speaking,0.59,0.35,0.0,0.0,0.06,0.0,0.0,0.0,pauline matthey,
+COM,2500,17,Public Speaking,0.35,0.41,0.06,0.0,0.12,0.0,0.0,0.06,pauline matthey,
+COM,2500,18,Public Speaking,0.47,0.42,0.0,0.05,0.0,0.0,0.0,0.05,rachelle lei beckner,
+COM,2500,19,Public Speaking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,
+COM,2500,20,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,
+COM,2500,29,Public Speaking,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jumah patricia taweh,
+COM,2500,30,Public Speaking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,
+COM,2500,400,Public Speaking,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,alexis zachary davis,
+COM,2500,401,Public Speaking,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
+COM,2500,403,Public Speaking,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
+COM,3080,1,Public Comm & Pop Culture,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3080,2,Public Comm & Pop Culture,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3080,3,Public Comm & Pop Culture,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
+COM,3240,1,"Communication, Sport & Society",0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
+COM,3240,2,"Communication, Sport & Society",0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
+COM,3250,1,Survey of Sports Communication,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
+COM,3260,1,Pr in Sports,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3260,3,Pr in Sports,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,
+COM,3270,1,Sports Media Criticism,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
+COM,3550,1,Principles of Public Relations,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,meghnaa tallapragada,
+COM,3560,1,Crisis Communication,0.53,0.37,0.05,0.0,0.05,0.0,0.0,0.0,andrew stephen pyle,
+COM,3570,1,Public Relations Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3640,1,Organizational Comm,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,kristen elai okamoto,
+COM,3660,2,EC: Survey of Brand Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lisa willif papenfus,
+COM,3660,4,EC: Digital Analytics & Brand,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,alicia nic littleton,
+COM,3690,1,Political Comm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,4250,1,Adv Sports Comm,0.54,0.38,0.0,0.0,0.08,0.0,0.0,0.0,bryan denham,
+COM,4300,1,Legal Communication,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,james isaac roberts,
+COM,4720,1,Comm in Health Organizations,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kristen elai okamoto,
+CPSC,1010,3,Computer Science I,0.24,0.17,0.24,0.1,0.1,0.0,0.0,0.15,christopher plaue,
+CPSC,1020,1,Computer Science II,0.28,0.18,0.14,0.1,0.18,0.0,0.0,0.12,yvon feaster,
+CPSC,1020,2,Computer Science II,0.16,0.26,0.28,0.1,0.12,0.0,0.0,0.08,yvon feaster,
+CPSC,1070,1,Programming Methodology,0.45,0.19,0.15,0.06,0.07,0.0,0.0,0.07,catherine hochrine,
+CPSC,1110,1,Intro to Programming in C,0.28,0.18,0.26,0.08,0.18,0.0,0.0,0.02,catherine hochrine,
+CPSC,1110,2,Intro to Programming in C,0.37,0.35,0.06,0.08,0.14,0.0,0.0,0.0,nicolas benja widman,
+CPSC,1110,3,Intro to Programming in C,0.46,0.24,0.13,0.04,0.07,0.0,0.0,0.07,nicolas benja widman,
+CPSC,1110,4,Intro to Programming in C,0.25,0.23,0.23,0.11,0.07,0.0,0.0,0.11,james martin,
+CPSC,2120,1,Algs/Data Structures,0.26,0.32,0.2,0.06,0.08,0.0,0.0,0.08,brian christoph dean,
+CPSC,2150,1,Software Dev Foundations,0.27,0.31,0.19,0.03,0.07,0.0,0.0,0.14,kevin anton plis,
+CPSC,2150,2,Software Dev Foundations,0.32,0.31,0.15,0.07,0.08,0.0,0.0,0.07,kevin anton plis,
+CPSC,2200,1,Microcomputer Appl,0.46,0.31,0.23,0.0,0.0,0.0,0.0,0.0,kevin anton plis,
+CPSC,2200,2,Microcomputer Appl,0.22,0.3,0.19,0.15,0.11,0.0,0.0,0.04,kevin anton plis,
+CPSC,2310,1,Intro Computer Org,0.58,0.24,0.1,0.02,0.04,0.0,0.0,0.02,nicolas benja widman,
+CPSC,2310,2,Intro Computer Org,0.49,0.22,0.16,0.03,0.08,0.0,0.0,0.03,nicolas benja widman,
+CPSC,2810,1,Selected Topics: TA Class,0.81,0.13,0.0,0.0,0.0,0.0,0.0,0.06,christopher plaue,
+CPSC,2810,2,Selected Topics: Cybersecurity,0.76,0.08,0.0,0.0,0.0,0.0,0.0,0.16,yvon feaster,
+CPSC,2910,1,Prof Issues I,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,2,Prof Issues I,0.6,0.25,0.0,0.05,0.0,0.0,0.0,0.1,catherine hochrine,
+CPSC,2910,3,Prof Issues I,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,4,Prof Issues I,0.6,0.25,0.0,0.05,0.05,0.0,0.0,0.05,catherine hochrine,
+CPSC,2910,5,Prof Issues I,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,catherine hochrine,
+CPSC,2920,1,"Computing, Ethics & Society",0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,julian lang brinkley,
+CPSC,3120,1,Design Analysis of Algorithms,0.07,0.1,0.14,0.14,0.17,0.0,0.0,0.38,pradip srimani,
+CPSC,3220,1,Intro to Operating Systems,0.62,0.31,0.03,0.0,0.03,0.0,0.0,0.0,brygg anders ullmer,
+CPSC,3220,3,Intro to Operating Systems,0.19,0.33,0.29,0.0,0.1,0.0,0.0,0.1,pradip srimani,
+CPSC,3300,1,Computer Systems Org,0.25,0.25,0.4,0.04,0.03,0.0,0.0,0.03,mark smotherman,
+CPSC,3500,1,Foundations of Computer Sci,0.28,0.13,0.45,0.04,0.0,0.0,0.0,0.09,ilya mark safro,
+CPSC,3520,1,Programming Systems,0.39,0.29,0.22,0.0,0.02,0.0,0.0,0.08,robert schalkoff,
+CPSC,3600,1,Network Programming,0.44,0.29,0.15,0.0,0.08,0.0,0.0,0.03,andrew robb,
+CPSC,3600,2,Network Programming,0.67,0.21,0.07,0.04,0.0,0.0,0.0,0.02,andrew robb,
+CPSC,3720,1,Software Engineering,0.27,0.38,0.24,0.05,0.0,0.0,0.0,0.05,eileen there kraemer,
+CPSC,3720,2,Software Engineering,0.21,0.42,0.25,0.06,0.0,0.0,0.0,0.06,murali sitaraman,
+CPSC,4040,1,Cmptr Graphics Image,0.29,0.24,0.24,0.0,0.12,0.0,0.0,0.12,ioannis karamouzas,
+CPSC,4050,1,Computer Graphics,0.24,0.18,0.12,0.12,0.24,0.0,0.0,0.12,andrew duchowski,
+CPSC,4110,1,Virtual Reality Systems,0.27,0.41,0.22,0.05,0.0,0.0,0.0,0.05,sabarish venkat babu,
+CPSC,4120,1,Eye Tracking Methodology,0.22,0.61,0.04,0.0,0.04,0.0,0.0,0.09,andrew duchowski,
+CPSC,4140,1,Human and Computer Interaction,0.21,0.56,0.21,0.03,0.0,0.0,0.0,0.0,nathaniel mcneese,
+CPSC,4160,1,2-D Game Engine Construction,0.54,0.23,0.06,0.02,0.08,0.0,0.0,0.06,brian malloy,
+CPSC,4200,1,Computer Security Principles,0.61,0.26,0.08,0.0,0.03,0.0,0.0,0.03,yvon feaster,
+CPSC,4200,2,Computer Security Principles,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,
+CPSC,4300,1,Applied Data Science,0.25,0.5,0.08,0.17,0.0,0.0,0.0,0.0,alexander chr herzog,
+CPSC,4440,1,Cloud Computing Architecture,0.32,0.45,0.18,0.0,0.0,0.0,0.0,0.05,amy apon,
+CPSC,4620,1,Database Management Systems,0.09,0.22,0.22,0.09,0.13,0.0,0.0,0.26,pradip srimani,
+CPSC,4820,1,Special Topic: Web Programming,0.56,0.1,0.22,0.06,0.06,0.0,0.0,0.0,craig baker,
+CPSC,4820,4,Spe Topic: HPC Fault Tolerance,0.3,0.4,0.2,0.1,0.0,0.0,0.0,0.0,jon cameron calhoun,
+CPSC,6040,1,Cptr Graphics Image,0.5,0.07,0.14,0.0,0.0,0.0,0.0,0.29,ioannis karamouzas,
+CPSC,6110,1,Virtual Reality Systems,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,sabarish venkat babu,
+CPSC,6140,1,Human and Computer Interaction,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel mcneese,
+CPSC,6160,1,2-D Game Engine Construction,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,brian malloy,
+CPSC,6300,1,Applied Data Science,0.32,0.68,0.0,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,
+CPSC,6440,1,Cloud Computing Architecture,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,amy apon,
+CPSC,6620,1,Database Management Systems,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,pradip srimani,
+CPSC,6780,1,Gen Purpose Computation on GPU,0.4,0.4,0.0,0.0,0.2,0.0,0.0,0.0,shuangshuang jin,
+CPSC,8170,1,Physically Based Animation,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,donald henry house,
+CPSC,8200,1,Parallel Architechture,0.5,0.3,0.1,0.0,0.1,0.0,0.0,0.0,rong ge,
+CPSC,8270,1,Translation of Progr Languages,0.74,0.13,0.1,0.0,0.0,0.0,0.0,0.03,brian malloy,
+CPSC,8380,1,Adv Data Structures,0.3,0.2,0.1,0.0,0.1,0.0,0.0,0.3,sandra hedetniemi,
+CPSC,8480,1,Network Science,0.31,0.31,0.34,0.0,0.0,0.0,0.0,0.03,ilya mark safro,
+CPSC,8550,1,Embedded Network Sys,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jacob sorber,
+CPSC,8580,1,Security in Emerging Systems,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,hongxin hu,
+CPSC,8810,1,Selected Topics: Intro to BDSI,0.67,0.0,0.0,0.0,0.17,0.0,0.0,0.17,brian christoph dean,
+CRP,8020,1,Site Planning & Infrastructure,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,
+CSM,1000,1,Intro to Construct,0.92,0.07,0.0,0.0,0.0,0.0,0.0,0.02,nathaniel jackson,
+CSM,2010,1,Structures I,0.36,0.21,0.24,0.07,0.02,0.0,0.0,0.1,shima clarke,
+CSM,2020,1,Structures II,0.24,0.18,0.41,0.12,0.0,0.0,0.0,0.06, kent nilsson,
+CSM,2040,1,Cont Documents,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,robert dawson coffey,
+CSM,3040,1,Envir Systems I,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,
+CSM,3040,2,Envir Systems I,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,
+CSM,3060,1,Emerging Tech in Construction,0.33,0.53,0.13,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,3060,2,Emerging Tech in Construction,0.17,0.59,0.21,0.03,0.0,0.0,0.0,0.0,jason lucas,
+CSM,3510,1,Construction Estimating,0.29,0.32,0.32,0.06,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,
+CSM,3510,2,Construction Estimating,0.35,0.48,0.1,0.06,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,
+CSM,4500,1,Construction Intern,0.4,0.36,0.25,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
+CSM,4530,1,Const Proj Mgmt,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4530,2,Const Proj Mgmt,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8630,400,Adv Plan/Sched,0.86,0.1,0.03,0.0,0.0,0.0,0.0,0.0,craig townsend,
+CSM,8650,1,Project Management,0.53,0.41,0.0,0.0,0.0,0.0,0.0,0.06,dennis bausman,
+CU,1000,8,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,14,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,16,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,19,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,24,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,26,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,27,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,28,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,
+CU,1010,1,Univ Success Skills,0.33,0.17,0.28,0.06,0.11,0.0,0.0,0.06,bryn zimmermann babb,
+CU,1010,6,Univ Success Skills,0.21,0.16,0.21,0.16,0.11,0.0,0.0,0.16,valerie kay oonk,
+CU,1010,7,Univ Success Skills,0.41,0.24,0.18,0.0,0.12,0.0,0.0,0.06,bryn zimmermann babb,
+CU,1010,600,Univ Success Skills,0.38,0.42,0.08,0.0,0.13,0.0,0.0,0.0,elizabeth an stephan,
+CU,1010,601,Univ Success Skills,0.5,0.21,0.13,0.04,0.0,0.0,0.0,0.13,bridget trogden,
+CU,1010,602,Univ Success Skills,0.46,0.29,0.17,0.0,0.04,0.0,0.0,0.04,laurel ann  whisler c,
+CU,1010,603,Univ Success Skills,0.55,0.25,0.2,0.0,0.0,0.0,0.0,0.0,abigail stephan,
+DPA,3070,1,Method 3d Production,0.45,0.41,0.1,0.0,0.03,0.0,0.0,0.0,tommy van bui,
+DPA,4000,1,Tech Foundations I,0.24,0.24,0.12,0.0,0.06,0.0,0.0,0.35,jessica baron,
+DPA,4020,1,Vis Foundations I,0.27,0.55,0.0,0.0,0.0,0.0,0.0,0.18,anthony summey,
+DPA,4020,2,Vis Foundations I,0.45,0.36,0.09,0.0,0.09,0.0,0.0,0.0,anthony summey,
+DPA,6000,1,Tech Foundations I,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,victor zordan,
+DPA,8070,843,3D Modeling and Animation,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,matias volonte,
+DPA,8090,1,Rendering and Shading,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,
+ECE,2010,1,Logic and Computing Device,0.12,0.27,0.26,0.16,0.15,0.0,0.0,0.04,william reid,
+ECE,2010,1,Logic and Computing Devices,0.12,0.27,0.26,0.16,0.15,0.0,0.0,0.04,william reid,
+ECE,2010,2,Logic & Comp Device (HON),0.8,0.0,0.1,0.0,0.0,0.0,0.0,0.1,william reid,True
+ECE,2020,1,Electric Circuits I,0.34,0.23,0.19,0.07,0.1,0.0,0.0,0.06,william harrell,
+ECE,2070,1,Basic Electrical Engineering,0.42,0.38,0.14,0.03,0.01,0.0,0.0,0.03,william tho kolodzey,
+ECE,2070,2,Basic Electrical Engineering,0.38,0.36,0.14,0.02,0.07,0.0,0.0,0.02,fatemeh tooryan,
+ECE,2070,3,Basic Electrical Engineering,0.57,0.31,0.07,0.0,0.01,0.0,0.0,0.03,timothy anglea,
+ECE,2080,1,Basic Electrical Engr Lab,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,
+ECE,2080,3,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2080,6,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2080,7,Basic Electrical Engr Lab,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2080,8,Basic Electrical Engr Lab,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,
+ECE,2080,10,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,
+ECE,2080,12,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,
+ECE,2080,14,Basic Electrical Engr Lab,0.84,0.05,0.05,0.0,0.05,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2090,3,Logic Lab,0.75,0.0,0.0,0.08,0.08,0.0,0.0,0.08,apoorva deep kapadia,
+ECE,2090,7,Logic Lab,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva deep kapadia,
+ECE,2090,8,Logic Lab,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deep kapadia,
+ECE,2090,13,Logic Lab,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,apoorva deep kapadia,
+ECE,2090,14,Logic Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva deep kapadia,
+ECE,2110,1,Elec Engr Lab I,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,
+ECE,2110,2,Elec Engr Lab I,0.44,0.19,0.13,0.13,0.06,0.0,0.0,0.06,apoorva deep kapadia,
+ECE,2110,3,Elec Engr Lab I,0.45,0.25,0.1,0.1,0.05,0.0,0.0,0.05,apoorva deep kapadia,
+ECE,2110,5,Elec Engr Lab I,0.9,0.0,0.0,0.0,0.05,0.0,0.0,0.05,apoorva deep kapadia,
+ECE,2110,6,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deep kapadia,
+ECE,2110,10,Elec Engr Lab I,0.7,0.1,0.0,0.0,0.0,0.0,0.0,0.2,apoorva deep kapadia,
+ECE,2120,1,Electrical Engineering Lab II,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,apoorva deep kapadia,
+ECE,2120,4,Electrical Engineering Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2220,1,Syst Prog Concept,0.18,0.2,0.05,0.0,0.23,0.0,0.0,0.34,lu yu,
+ECE,2230,1,Comp Sys Eng,0.36,0.16,0.27,0.11,0.04,0.0,0.0,0.07,harlan russell,
+ECE,2620,1,Electric Circuits II,0.2,0.26,0.34,0.04,0.08,0.0,0.0,0.08,liang dong,
+ECE,2720,1,Comp Organization,0.06,0.18,0.35,0.24,0.14,0.0,0.0,0.02,william reid,
+ECE,3110,1,Electrical Engineering Lab III,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3110,2,Electrical Engineering Lab III,0.75,0.13,0.0,0.06,0.0,0.0,0.0,0.06,apoorva deep kapadia,
+ECE,3110,3,Electrical Engineering Lab III,0.56,0.31,0.06,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,
+ECE,3110,7,Electrical Engineering Lab III,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3110,8,Electrical Engineering Lab III,0.83,0.0,0.0,0.0,0.08,0.0,0.0,0.08,apoorva deep kapadia,
+ECE,3120,1,Electrical Engineering Lab IV,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3120,2,Electrical Engineering Lab IV,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3170,1,Rand Signal Analysis,0.23,0.3,0.26,0.1,0.07,0.0,0.0,0.03,stephen hubbard,
+ECE,3200,1,Electronics I,0.24,0.26,0.22,0.15,0.1,0.0,0.0,0.03,stephen hubbard,
+ECE,3200,2,Electronics I (HON),0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,stephen hubbard,True
+ECE,3210,1,Electronics II,0.45,0.3,0.15,0.08,0.03,0.0,0.0,0.0,stephen hubbard,
+ECE,3270,1,Dig Comp Design,0.12,0.2,0.24,0.16,0.08,0.0,0.0,0.2,melissa crawle smith,
+ECE,3300,1,Signals & Systems,0.15,0.25,0.27,0.14,0.08,0.0,0.0,0.1,carl baum,
+ECE,3300,2,Signals & Systems (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
+ECE,3520,1,Programming Systems,0.36,0.59,0.05,0.0,0.0,0.0,0.0,0.0,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.49,0.23,0.13,0.09,0.02,0.0,0.0,0.04,edward collins,
+ECE,3710,1,Microcontr Interface,0.47,0.26,0.14,0.1,0.02,0.0,0.0,0.0,william reid,
+ECE,3720,3,Micro Int Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3720,4,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3720,6,Micro Int Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3720,7,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3720,9,Micro Int Lab,0.5,0.25,0.0,0.0,0.25,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3720,11,Micro Int Lab,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3800,1,Electromagnetics,0.27,0.27,0.18,0.13,0.11,0.0,0.0,0.04,anthony martin,
+ECE,3810,1,Field Waves & Ckts,0.41,0.44,0.13,0.0,0.03,0.0,0.0,0.0,hai xiao,
+ECE,4090,1,Intr to Linear Control Systems,0.63,0.33,0.03,0.01,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,4180,1,Power Syst Analysis,0.25,0.33,0.25,0.08,0.0,0.0,0.0,0.08,ramtin hadidi,
+ECE,4270,1,Communications Sys,0.33,0.47,0.16,0.0,0.0,0.0,0.0,0.05,lu yu,
+ECE,4310,1,Intro to Computer Vision,0.64,0.28,0.03,0.03,0.03,0.0,0.0,0.0,adam hoover,
+ECE,4420,1,Knowledge Engr,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,robert schalkoff,
+ECE,4490,1,Comp Ntwrk Security,0.42,0.42,0.0,0.0,0.0,0.0,0.0,0.17,richard brooks,
+ECE,4610,1,Fundamentals of Solar Energy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,
+ECE,4670,1,Intro to Dig Sig Pro,0.24,0.18,0.47,0.0,0.0,0.0,0.0,0.12,john gowdy,
+ECE,4730,1,Intro Parallel Sys,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,walter ligon,
+ECE,4950,1,Int Sys Design I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,4960,1,Int Sys Design II,0.64,0.27,0.07,0.02,0.0,0.0,0.0,0.0,richard groff,
+ECE,6040,1,Semiconductor Devices,0.57,0.14,0.29,0.0,0.0,0.0,0.0,0.0,judson dougl ryckman,
+ECE,6180,1,Power Syst Analysis,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,ramtin hadidi,
+ECE,6310,1,Intro to Computer Vision,0.6,0.15,0.1,0.0,0.0,0.0,0.0,0.15,adam hoover,
+ECE,6490,1,Comp Ntwrk Security,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,richard brooks,
+ECE,6590,1,Int Circ Design,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,
+ECE,6670,1,Intro to Dig Sig Pro,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,john gowdy,
+ECE,8010,1,Analysis of Lin Sys,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,richard groff,
+ECE,8010,843,Analysis of Lin Sys,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,richard groff,
+ECON,2000,2,Economic Concepts,0.31,0.26,0.23,0.13,0.03,0.0,0.0,0.05,shubhashrita basu,
+ECON,2000,4,Economic Concepts,0.38,0.43,0.1,0.0,0.08,0.0,0.0,0.03,miren ivankovic,
+ECON,2000,5,Economic Concepts,0.32,0.34,0.26,0.03,0.05,0.0,0.0,0.0,shubhashrita basu,
+ECON,2110,1,Principles of Microeconomics,0.21,0.26,0.32,0.11,0.05,0.0,0.0,0.05,frederick an hanssen,
+ECON,2110,2,Principles of Microeconomics,0.21,0.32,0.26,0.0,0.11,0.0,0.0,0.11,frederick an hanssen,
+ECON,2110,3,Principles of Microeconomics,0.05,0.32,0.47,0.11,0.0,0.0,0.0,0.05,frederick an hanssen,
+ECON,2110,4,Principles of Microeconomics,0.21,0.42,0.26,0.0,0.05,0.0,0.0,0.05,frederick an hanssen,
+ECON,2110,5,Principles of Microeconomics,0.28,0.22,0.28,0.17,0.06,0.0,0.0,0.0,frederick an hanssen,
+ECON,2110,6,Principles of Microeconomics,0.16,0.37,0.26,0.05,0.11,0.0,0.0,0.05,frederick an hanssen,
+ECON,2110,7,Principles of Microeconomics,0.0,0.5,0.33,0.0,0.06,0.0,0.0,0.11,frederick an hanssen,
+ECON,2110,8,Principles of Microeconomics,0.22,0.28,0.28,0.11,0.06,0.0,0.0,0.06,frederick an hanssen,
+ECON,2110,9,Principles of Microeconomics,0.17,0.39,0.33,0.0,0.0,0.0,0.0,0.11,frederick an hanssen,
+ECON,2110,10,Principles of Microeconomics,0.28,0.28,0.28,0.06,0.06,0.0,0.0,0.06,frederick an hanssen,
+ECON,2110,11,Principles of Microeconomics,0.11,0.42,0.21,0.11,0.0,0.0,0.0,0.16,frederick an hanssen,
+ECON,2110,12,Principles of Microeconomics,0.11,0.26,0.32,0.16,0.05,0.0,0.0,0.11,frederick an hanssen,
+ECON,2110,13,Principles of Microeconomics,0.05,0.58,0.26,0.05,0.05,0.0,0.0,0.0,frederick an hanssen,
+ECON,2110,14,Principles of Microeconomics,0.16,0.53,0.16,0.11,0.05,0.0,0.0,0.0,frederick an hanssen,
+ECON,2110,15,Principles of Microeconomics,0.0,0.33,0.56,0.06,0.06,0.0,0.0,0.0,frederick an hanssen,
+ECON,2110,16,Principles of Microeconomics,0.15,0.4,0.25,0.1,0.1,0.0,0.0,0.0,frederick an hanssen,
+ECON,2110,17,Principles of Microeconomics,0.11,0.21,0.42,0.16,0.05,0.0,0.0,0.05,frederick an hanssen,
+ECON,2110,18,Principles of Microeconomics,0.05,0.53,0.05,0.16,0.16,0.0,0.0,0.05,frederick an hanssen,
+ECON,2110,19,Principles of Microeconomics,0.05,0.42,0.11,0.26,0.05,0.0,0.0,0.11,frederick an hanssen,
+ECON,2110,20,Principles of Microeconomics,0.31,0.32,0.22,0.09,0.04,0.0,0.0,0.01,benjamin posmanick,
+ECON,2110,21,Principles of Microeconomics,0.28,0.46,0.21,0.03,0.0,0.0,0.0,0.03,michael makowsky,
+ECON,2110,23,Principles of Microeconomics,0.2,0.29,0.28,0.08,0.1,0.0,0.0,0.04,roksana ghanbariamin,
+ECON,2110,24,Principles of Microeconomics,0.24,0.34,0.3,0.08,0.02,0.0,0.0,0.03,kelsey victo roberts,
+ECON,2110,25,Principles of Microeconomics,0.28,0.56,0.13,0.0,0.03,0.0,0.0,0.0,chen wang,
+ECON,2110,26,Principles of Microeconomics,0.28,0.28,0.26,0.13,0.02,0.0,0.0,0.02,sarah louise wilson,
+ECON,2110,31,Principles of Microeconomics,0.33,0.29,0.26,0.04,0.08,0.0,0.0,0.0,jonathan orry ernest,
+ECON,2110,32,Principles of Microeconomics,0.28,0.52,0.13,0.02,0.04,0.0,0.0,0.0,jacob walloga,
+ECON,2110,33,Principles of Microeconomics,0.33,0.44,0.13,0.0,0.08,0.0,0.0,0.03,liuna issagholian,
+ECON,2110,34,Principles of Microecon (HON),0.45,0.32,0.18,0.05,0.0,0.0,0.0,0.0,charles thomas,True
+ECON,2110,35,Principles of Microeconomics,0.25,0.55,0.2,0.0,0.0,0.0,0.0,0.0,chen wang,
+ECON,2110,36,Principles of Microeconomics,0.28,0.4,0.18,0.08,0.06,0.0,0.0,0.0,roksana ghanbariamin,
+ECON,2110,40,Principles of Microeconomics,0.25,0.36,0.21,0.04,0.14,0.0,0.0,0.0,liuna issagholian,
+ECON,2110,41,Principles of Microeconomics,0.48,0.38,0.1,0.02,0.0,0.0,0.0,0.02,jonathan orry ernest,
+ECON,2120,1,Principles of Macroeconomics,0.3,0.41,0.2,0.04,0.03,0.0,0.0,0.03,elijah neilson,
+ECON,2120,2,Principles of Macroeconomics,0.23,0.36,0.32,0.0,0.04,0.0,0.0,0.04,kenneth whaley,
+ECON,2120,3,Principles of Macroeconomics,0.25,0.43,0.25,0.02,0.0,0.0,0.0,0.05,elijah neilson,
+ECON,2120,4,Principles of Macroeconomics,0.25,0.36,0.28,0.06,0.06,0.0,0.0,0.0,wing yin chung,
+ECON,2120,5,Principles of Macroeconomics,0.29,0.39,0.26,0.03,0.0,0.0,0.0,0.03,narendra regmi,
+ECON,2120,6,Principles of Macroeconomics,0.45,0.33,0.13,0.08,0.0,0.0,0.0,0.03,kenneth whaley,
+ECON,2120,7,Principles of Macroeconomics,0.51,0.18,0.18,0.08,0.05,0.0,0.0,0.0,narendra regmi,
+ECON,2120,8,Principles of Macroeconomics,0.67,0.21,0.02,0.0,0.05,0.0,0.0,0.05,tyler francis,
+ECON,2120,9,Principles of Macroeconomics,0.88,0.07,0.05,0.0,0.0,0.0,0.0,0.0,tyler francis,
+ECON,2120,10,Principles of Macroeconomics,0.23,0.36,0.31,0.03,0.05,0.0,0.0,0.03,kyle lance rechard,
+ECON,3020,1,Money and Banking,0.18,0.31,0.33,0.1,0.0,0.0,0.0,0.08,smriti bhargava,
+ECON,3060,1,Managerial Economics,0.2,0.25,0.25,0.18,0.08,0.0,0.0,0.05,steven johnson,
+ECON,3100,1,International Econ,0.19,0.54,0.17,0.06,0.03,0.0,0.0,0.01,scott baier,
+ECON,3140,1,Intermediate Micro,0.28,0.15,0.18,0.08,0.15,0.0,0.0,0.15,patrick warren,
+ECON,3140,2,Intermediate Micro,0.17,0.57,0.15,0.07,0.0,0.0,0.0,0.05,molly espey,
+ECON,3140,3,Intermediate Micro,0.27,0.31,0.2,0.08,0.06,0.0,0.0,0.08,robert kenneth fleck,
+ECON,3140,5,Intermediate Micro,0.26,0.22,0.22,0.15,0.07,0.0,0.0,0.07,yichen christy zhou,
+ECON,3150,1,Intermediate Macro,0.86,0.05,0.02,0.0,0.02,0.0,0.0,0.05,jeremy choquette,
+ECON,3150,2,Intermediate Macro,0.39,0.24,0.17,0.1,0.05,0.0,0.0,0.05,michal jerzmanowski,
+ECON,3190,1,Environmental Econ,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,molly espey,
+ECON,3600,1,Public Choice,0.37,0.29,0.21,0.08,0.0,0.0,0.0,0.05,michael makowsky,
+ECON,4010,1,Labor Mkt Analysis,0.5,0.25,0.08,0.0,0.08,0.0,0.0,0.08,chungsang lam,
+ECON,4020,1,Law and Economics,0.23,0.5,0.15,0.05,0.03,0.0,0.0,0.05,howard nel bodenhorn,
+ECON,4040,1,Comp Econ Systems,0.33,0.07,0.2,0.07,0.13,0.0,0.0,0.2,dari litsukova-bokar,
+ECON,4050,5,Intro to Econometric,0.25,0.23,0.35,0.08,0.06,0.0,0.0,0.04,scott barkowski,
+ECON,4100,1,Economic Development,0.72,0.14,0.03,0.0,0.03,0.0,0.0,0.07,robert tamura,
+ECON,4120,1,International Micro,0.35,0.26,0.17,0.0,0.0,0.0,0.0,0.22,scott baier,
+ECON,4130,1,International Macro,0.45,0.36,0.0,0.0,0.09,0.0,0.0,0.09,michal jerzmanowski,
+ECON,4230,1,Economics of Health,0.51,0.34,0.11,0.0,0.0,0.0,0.0,0.03,devon merritt gorry,
+ECON,4240,1,Organization of Ind,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,4240,2,Organization of Ind,0.72,0.1,0.1,0.03,0.0,0.0,0.0,0.03,matthew lewis,
+ECON,4250,1,Antitrust Economics,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.12,raymond sauer,
+ECON,4260,1,Sem Sport Economics,0.63,0.3,0.0,0.0,0.0,0.0,0.0,0.07,raymond sauer,
+ECON,4280,1,Cost-Benefit Anlysis,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,robert kenneth fleck,
+ECON,4980,3,Econ of Entertainment Industry,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,frederick an hanssen,
+ECON,4980,4,Sel Topic - Why Business?,0.44,0.33,0.19,0.04,0.0,0.0,0.0,0.0,bradley keith hobbs,
+ECON,4980,5,Sel Topics-Cryptocurrency,0.73,0.09,0.09,0.0,0.09,0.0,0.0,0.0,gerald dwyer,
+ECON,6050,5,Intro to Econometric,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott barkowski,
+ECON,8010,1,Microeconomic Theory,0.5,0.13,0.38,0.0,0.0,0.0,0.0,0.0,william dougan,
+ECON,8040,1,Applied Math Econ,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,curtis simon,
+ECON,8060,1,Econometrics I,0.13,0.38,0.38,0.0,0.13,0.0,0.0,0.0,paul wayne wilson,
+ECON,8080,1,Econometrics III,0.17,0.5,0.17,0.0,0.17,0.0,0.0,0.0,paul wayne wilson,
+ECON,8230,1,Microecon Pub Pol,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,
+ECON,8990,3,Industrial Organization Theory,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,charles thomas,
+ECON,8990,5,Sel Topics - Macro Theory II,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,christopher as gorry,
+ED,1050,1,Educ Orientation,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,jennifer michel hein,
+ED,1050,3,Educ Orientation,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,
+ED,1050,7,Educ Orientation,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,
+ED,1050,8,Educ Orientation,0.84,0.08,0.0,0.0,0.0,0.0,0.0,0.08,amaris joseph tejada,
+ED,1970,1,CI-CONNECTIONS Stud Developmnt,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,2,CI-CONNECTIONS Stud Developmnt,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,3,CI-CONNECTIONS Stud Developmnt,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,4,CI-CONNECTIONS Stud Developmnt,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,5,CI-CONNECTIONS Stud Developmnt,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,6,CI-CONNECTIONS Stud Developmnt,0.76,0.18,0.0,0.0,0.06,0.0,0.0,0.0,deonte brown,
+ED,3010,1,Principles of American Educat,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,nafees mohammad khan,
+ED,8750,321,Elements of Instructional Effe,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,susan ridg nunamaker,
+ED,9540,1,Curriculum Theory,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDC,3900,2,Skills for Student Leaders,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,5,Skills for Student Leaders,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+EDC,3990,1,Creative Inq in Counselor Ed,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,jacob frankovich,
+EDEC,3000,1,Found Early Chld Ed,0.91,0.0,0.0,0.03,0.03,0.0,0.0,0.03,jill chandle shelnut,
+EDEC,3010,1,Early Childhood Practicum I,0.89,0.0,0.0,0.04,0.04,0.0,0.0,0.04,jennifer schumpert,
+EDEC,4300,1,Early Childhd Math,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sandra mamman linder,
+EDEC,4400,1,Early Childhood Engl Lang Art,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEC,8100,312,Adv Ece Found & Meth,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,sandra mamman linder,
+EDEL,3210,1,Pe for the Elem Tchr,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,3210,2,Pe for the Elem Tchr,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4870,2,Ele Meth Soc Studies,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,melinda spearman,
+EDEL,4880,2,Elem Language Arts Teaching,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,jacquelynn malloy,
+EDF,3020,2,Educational Psychology,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,meihua qian,
+EDF,3340,1,Child Growth and Development,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoob jamil,
+EDF,3340,3,Child Growth and Development,0.89,0.07,0.0,0.0,0.04,0.0,0.0,0.0,faiza marghoob jamil,
+EDF,3350,1,Adolescent Growth & Develop,0.41,0.27,0.18,0.05,0.0,0.0,0.0,0.09,david barrett,
+EDF,4800,2,Digital Media & Learning,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,anne mcmahan grant,
+EDF,8080,312,Contempor Issues in Assessment,0.8,0.12,0.04,0.0,0.0,0.0,0.0,0.04,eliza darg gallagher,
+EDF,8710,400,Cultural Diversity in Educatio,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,reginald wilkerson,
+EDF,9020,1,Learning Sciences Seminar II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
+EDF,9270,401,Quant Rsrch & Stats for Ed,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,russell aubre marion,
+EDHD,3110,1,CI- Research in DM & Learning,0.9,0.03,0.0,0.0,0.0,0.0,0.0,0.07,david matthew boyer,
+EDL,7150,503,Sch & Comm Relations,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,frederick buskey,
+EDL,7400,500,Curr Plan: Sch Adm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,daniella hall,
+EDL,7400,501,Curr Plan: Sch Adm,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,daniella hall,
+EDL,9110,400,Systematic Inq Ed L,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,jane lindle,
+EDL,9770,1,Div Issues in Hi Ed,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robin je phelps-ward,
+EDLT,4610,1,Content Area Read/Writing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,4800,1,Found in Adolescent Literacy,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,phillip micha wilder,
+EDLT,4800,2,Found in Adolescent Literacy,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,phillip micha wilder,
+EDLT,8150,500,Guided Reading & Guided Writng,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,susan king fullerton,
+EDLT,8170,300,Content Area Rdg/Wtg: ECE-ELEM,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8170,500,Content Area Rdg/Wtg: ECE-ELEM,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8220,500,Strategies for Teaching ESOL,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDLT,8240,300,Practicum in ESOL,0.67,0.17,0.0,0.0,0.17,0.0,0.0,0.0,rebecca kaminski,
+EDLT,8400,501,Early Literacy Assessment I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,
+EDLT,8400,502,Early Literacy Assessment I,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,antoinett dibellonia,
+EDLT,8400,506,Early Literacy Assessment I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jo anne solesbee,
+EDLT,8800,505,Reading Recovery Teacher I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,
+EDSC,2260,1,Pr Apprch to Sec Alg,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,stacy megan che,
+EDSP,3700,1,Intro to Special Education,0.74,0.18,0.06,0.03,0.0,0.0,0.0,0.0,friggita johnson,
+EDSP,3720,1,Char & Instr Individ with LD,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,
+EDSP,4920,1,Math Inst Ind W/Dis,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,pamela stecker,
+EDSP,4930,1,Clsrm/Beh Mgmt Sp Ed,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,joseph benedict ryan,
+EDSP,4940,1,Tchg Rdg Mild Dis,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
+EDSP,4960,1,Sp Ed Field Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,wendell kent parker,
+EDSP,4970,1,Sec Meth Ind W/Dis,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,wendell kent parker,
+EDSP,8120,400,Learning Disabilities Prac Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,catherine griffith,
+EDSP,8220,400,Tchg Math Indv W/Dis,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,pamela stecker,
+EDSP,8530,1,Legal/Pol Issu Sp Ed,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
+EES,2010,1,Environ Engr Fundamentals I,0.31,0.33,0.14,0.0,0.11,0.0,0.0,0.11,david freedman,
+EES,3030,1,Water Treatment Systems,0.41,0.38,0.14,0.03,0.03,0.0,0.0,0.0,david allen ladner,
+EES,3040,1,Wastewater Treatment Systems,0.31,0.45,0.17,0.07,0.0,0.0,0.0,0.0,sudeep popat,
+EES,3050,1,Water/Wastewater Treatment Lab,0.38,0.38,0.19,0.06,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3050,2,Water/Wastewater Treatment Lab,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,sudeep popat,
+EES,4010,1,Environmental Engr,0.82,0.16,0.03,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.27,0.53,0.13,0.03,0.03,0.0,0.0,0.0,mark schlautman,
+EES,4090,1,Intro to Nuc Engr & Radiol Sci,0.18,0.53,0.12,0.12,0.0,0.0,0.0,0.06,timothy devol,
+EES,4300,1,Air Pollution Engineering,0.44,0.31,0.14,0.0,0.03,0.0,0.0,0.08,andrew richa metcalf,
+EES,4800,1,Environmental Risk Assessment,0.44,0.42,0.14,0.0,0.0,0.0,0.0,0.0,nicole eliz martinez,
+EES,4840,1,Solid Waste Mgt,0.35,0.46,0.08,0.08,0.04,0.0,0.0,0.0,ezra lucas hoy cates hoy,
+EES,4860,1,Environmental Sustainability,0.78,0.15,0.04,0.0,0.0,0.0,0.0,0.04,michael anthony dale,
+EES,8020,1,Environ Eng Prin,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,8430,1,Environmental Chem,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,
+EES,8510,1,Biol Prin Envir Engr,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,kevin thoma finneran,
+EES,8800,1,Env Risk Assessment,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,timothy devol,
+ELE,3010,1,Entrepreneurial Foundations,0.19,0.37,0.37,0.01,0.0,0.0,0.0,0.04,ashley willi parnell,
+ELE,3010,2,Entrepreneurial Foundations,0.12,0.34,0.36,0.12,0.0,0.0,0.0,0.06,ashley willi parnell,
+ELE,3020,1,Entrepreneurial Resource Acqu,0.36,0.44,0.17,0.0,0.0,0.0,0.0,0.03,karl bruce kelly,
+ELE,3020,2,Entrepreneurial Resource Acqu,0.26,0.71,0.03,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,
+ELE,4020,1,Venture Creation,0.32,0.56,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,
+ELE,4990,1,Venture Consulting,0.49,0.46,0.05,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
+ELE,4990,2,Venture Counsulting,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
+ENGL,1030,1,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,allen swords,
+ENGL,1030,2,Composition and Rhetoric,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,1030,3,Composition and Rhetoric,0.26,0.26,0.26,0.05,0.05,0.0,0.0,0.11,chelsea marie clarey,
+ENGL,1030,4,Composition and Rhetoric,0.75,0.06,0.0,0.13,0.0,0.0,0.0,0.06,stephanie stripling,
+ENGL,1030,6,Composition and Rhetoric,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,
+ENGL,1030,8,Composition and Rhetoric,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,chelsea marie clarey,
+ENGL,1030,10,Composition and Rhetoric,0.42,0.32,0.16,0.11,0.0,0.0,0.0,0.0,allison nicol harris,
+ENGL,1030,11,Composition and Rhetoric,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
+ENGL,1030,13,Composition and Rhetoric,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,julia brownlee koets,
+ENGL,1030,18,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
+ENGL,1030,19,Composition and Rhetoric,0.74,0.11,0.11,0.05,0.0,0.0,0.0,0.0,stephanie stripling,
+ENGL,1030,23,Composition and Rhetoric,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,charissa fryberger,
+ENGL,1030,24,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,charissa fryberger,
+ENGL,1030,27,Composition and Rhetoric,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,naomi marie white,
+ENGL,1030,29,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,eric reid hamilton,
+ENGL,1030,32,Composition and Rhetoric,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,blake elizabe bowens,
+ENGL,1030,33,Composition and Rhetoric,0.47,0.32,0.11,0.0,0.05,0.0,0.0,0.05,geveryl lee robinson,
+ENGL,1030,34,Composition and Rhetoric,0.42,0.26,0.16,0.05,0.11,0.0,0.0,0.0,geveryl lee robinson,
+ENGL,1030,35,Composition and Rhetoric,0.5,0.39,0.06,0.0,0.06,0.0,0.0,0.0,blake elizabe bowens,
+ENGL,1030,37,Composition and Rhetoric,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,naomi marie white,
+ENGL,1030,38,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,
+ENGL,1030,39,Composition and Rhetoric,0.58,0.26,0.05,0.0,0.0,0.0,0.0,0.11,julie edewaard,
+ENGL,1030,40,Composition and Rhetoric,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,julie edewaard,
+ENGL,1030,41,Composition and Rhetoric,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,myers addison enlow,
+ENGL,1030,42,Composition and Rhetoric,0.63,0.16,0.11,0.0,0.11,0.0,0.0,0.0,myers addison enlow,
+ENGL,1030,43,Composition and Rhetoric,0.63,0.16,0.11,0.0,0.05,0.0,0.0,0.05,jennie eli wakefield,
+ENGL,1030,44,Composition and Rhetoric,0.53,0.32,0.11,0.0,0.05,0.0,0.0,0.0,caroline eliza young,
+ENGL,1030,45,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,
+ENGL,1030,46,Composition and Rhetoric,0.68,0.21,0.0,0.11,0.0,0.0,0.0,0.0,jennie eli wakefield,
+ENGL,1030,47,Composition and Rhetoric,0.21,0.53,0.21,0.0,0.05,0.0,0.0,0.0,chloe miche whitaker,
+ENGL,1030,48,Composition and Rhetoric,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,chloe miche whitaker,
+ENGL,1030,51,Composition and Rhetoric,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,victoria houser,
+ENGL,1030,52,Composition and Rhetoric,0.68,0.05,0.16,0.05,0.05,0.0,0.0,0.0,victoria houser,
+ENGL,1030,53,Composition and Rhetoric,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,michelle lloyd,
+ENGL,1030,55,Composition and Rhetoric,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,michelle lloyd,
+ENGL,1030,61,Composition and Rhetoric,0.53,0.26,0.16,0.05,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,1030,71,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,shauna chung,
+ENGL,1030,73,Composition and Rhetoric,0.21,0.68,0.0,0.0,0.0,0.0,0.0,0.11,la'cresha ulon green,
+ENGL,1030,74,Composition and Rhetoric,0.22,0.44,0.11,0.06,0.0,0.0,0.0,0.17,la'cresha ulon green,
+ENGL,1030,75,Composition and Rhetoric,0.39,0.33,0.06,0.0,0.0,0.0,0.0,0.22,kristian wilson,
+ENGL,1030,76,Composition and Rhetoric,0.32,0.32,0.05,0.05,0.0,0.0,0.0,0.26,kristian wilson,
+ENGL,1030,82,Composition and Rhetoric,0.22,0.5,0.17,0.0,0.06,0.0,0.0,0.06,andrew mathas,
+ENGL,1030,83,Composition and Rhetoric,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,
+ENGL,2120,3,World Literature,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathle nalley,
+ENGL,2120,5,World Literature,0.11,0.58,0.21,0.05,0.05,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2120,6,World Literature,0.17,0.5,0.22,0.06,0.0,0.0,0.0,0.06,david charles foltz,
+ENGL,2120,7,World Literature,0.22,0.39,0.11,0.11,0.0,0.0,0.0,0.17,david charles foltz,
+ENGL,2120,9,World Literature,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,hannah pittma godwin,
+ENGL,2120,10,World Literature,0.47,0.26,0.21,0.0,0.0,0.0,0.0,0.05,hannah pittma godwin,
+ENGL,2120,11,World Literature,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,hannah pittma godwin,
+ENGL,2120,12,World Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathle nalley,
+ENGL,2120,13,World Literature,0.42,0.26,0.11,0.11,0.0,0.0,0.0,0.11,heather pri williams,
+ENGL,2120,15,World Literature,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,chloe miche whitaker,
+ENGL,2120,19,World Literature,0.37,0.37,0.21,0.0,0.0,0.0,0.0,0.05,chloe miche whitaker,
+ENGL,2120,20,World Literature,0.47,0.21,0.16,0.0,0.11,0.0,0.0,0.05,hannah pittma godwin,
+ENGL,2120,21,World Literature,0.33,0.17,0.33,0.0,0.08,0.0,0.0,0.08,gabriel ande hankins,
+ENGL,2120,400,World Literature,0.19,0.48,0.19,0.04,0.04,0.0,0.0,0.07,sarah mae cooper,
+ENGL,2120,401,World Literature,0.18,0.47,0.18,0.06,0.06,0.0,0.0,0.06,sarah mae cooper,
+ENGL,2120,402,World Literature,0.73,0.15,0.08,0.0,0.04,0.0,0.0,0.0,heather pri williams,
+ENGL,2120,403,World Literature,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.04,keri ja crist-wagner,
+ENGL,2130,3,British Literature,0.37,0.21,0.21,0.05,0.11,0.0,0.0,0.05,megan noe macalystre,
+ENGL,2130,4,British Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john morgenstern,
+ENGL,2130,5,British Literature,0.63,0.16,0.16,0.0,0.0,0.0,0.0,0.05,lucian ghita,
+ENGL,2130,6,British Literature,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,kriste aldebol-hazle,
+ENGL,2130,7,British Literature,0.37,0.37,0.05,0.05,0.0,0.0,0.0,0.16,megan noe macalystre,
+ENGL,2130,9,British Literature,0.32,0.42,0.16,0.05,0.05,0.0,0.0,0.0,megan noe macalystre,
+ENGL,2130,10,British Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,11,British Literature,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,christopher benson,
+ENGL,2130,12,British Literature,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,13,British Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,400,British Literature,0.37,0.48,0.07,0.0,0.04,0.0,0.0,0.04,daniel scott citro,
+ENGL,2130,401,British Literature,0.39,0.43,0.11,0.04,0.0,0.0,0.0,0.04,daniel scott citro,
+ENGL,2130,402,British Literature,0.48,0.24,0.2,0.0,0.04,0.0,0.0,0.04,kriste aldebol-hazle,
+ENGL,2140,1,American Literature,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,5,American Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,6,American Literature,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
+ENGL,2140,7,American Literature,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
+ENGL,2140,8,American Literature,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,john robert smith,
+ENGL,2140,14,American Literature,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,17,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,400,American Literature,0.84,0.12,0.0,0.04,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,allen swords,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.26,0.42,0.11,0.05,0.05,0.0,0.0,0.11,john logan pursley,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.47,0.37,0.05,0.11,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,sharon kathle nalley,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.42,0.32,0.05,0.11,0.0,0.0,0.0,0.11,andrew mathas,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.47,0.35,0.06,0.0,0.12,0.0,0.0,0.0,andrew mathas,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,david charles foltz,
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.16,0.21,0.05,0.05,0.0,0.0,0.0,elizabeth stansell,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.84,0.0,0.05,0.05,0.05,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,remley meliss makala,
+ENGL,2150,18,Lit in 20th-21st Cent Contexts,0.37,0.37,0.11,0.0,0.11,0.0,0.0,0.05,chelsea marie clarey,
+ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.47,0.32,0.11,0.0,0.05,0.0,0.0,0.05,david charles foltz,
+ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.44,0.39,0.06,0.0,0.0,0.0,0.0,0.11,david charles foltz,
+ENGL,2150,23,Lit in 20th-21st Cent Contexts,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
+ENGL,2150,24,Lit in 20th-21st Cent Contexts,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2150,25,Lit in 20th-21st Cent Contexts,0.37,0.42,0.11,0.05,0.0,0.0,0.0,0.05,chelsea marie clarey,
+ENGL,2150,26,Lit in 20th-21st Cent Contexts,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,daniel scott citro,
+ENGL,2150,27,Lit in 20th-21st Cent Contexts,0.72,0.11,0.11,0.06,0.0,0.0,0.0,0.0,remley meliss makala,
+ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.42,0.19,0.19,0.0,0.04,0.0,0.0,0.15,candace wiley,
+ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.37,0.11,0.15,0.15,0.07,0.0,0.0,0.15,candace wiley,
+ENGL,2150,402,Lit in 20th-21st Cent Contexts,0.56,0.26,0.15,0.04,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,2150,403,Lit in 20th-21st Cent Contexts,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
+ENGL,3010,1,Great Books of Western World,0.4,0.4,0.13,0.0,0.07,0.0,0.0,0.0,dominic mastroianni,
+ENGL,3040,1,Business Writing,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,sean williams,
+ENGL,3040,3,Business Writing,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulon green,
+ENGL,3040,4,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulon green,
+ENGL,3040,5,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
+ENGL,3040,12,Business Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,heather pri williams,
+ENGL,3040,15,Business Writing,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,katalin beck,
+ENGL,3040,16,Business Writing,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3040,19,Business Writing,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
+ENGL,3040,20,Business Writing,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
+ENGL,3040,400,Business Writing,0.85,0.05,0.1,0.0,0.0,0.0,0.0,0.0,kriste aldebol-hazle,
+ENGL,3040,401,Business Writing,0.78,0.0,0.17,0.06,0.0,0.0,0.0,0.0,kriste aldebol-hazle,
+ENGL,3040,402,Business Writing,0.47,0.37,0.05,0.0,0.11,0.0,0.0,0.0,sean williams,
+ENGL,3100,1,Crit Writ Lit,0.42,0.53,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth rivlin,
+ENGL,3100,2,Crit Writ Lit,0.67,0.22,0.0,0.0,0.11,0.0,0.0,0.0,cameron fae bushnell,
+ENGL,3100,3,Crit Writ Lit,0.58,0.21,0.11,0.0,0.0,0.0,0.0,0.11,kimberly manganelli,
+ENGL,3100,4,Crit Writ Lit,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,
+ENGL,3120,1,Advanced Composition,0.82,0.0,0.12,0.0,0.06,0.0,0.0,0.0,christopher stuart,
+ENGL,3120,2,Advanced Composition,0.83,0.11,0.0,0.06,0.0,0.0,0.0,0.0,christopher stuart,
+ENGL,3120,3,Advanced Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,
+ENGL,3140,1,Technical Writing,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,william pulley,
+ENGL,3140,2,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,4,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,
+ENGL,3140,6,Technical Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,beltran dian quaglia,
+ENGL,3140,8,Technical Writing,0.79,0.05,0.05,0.05,0.0,0.0,0.0,0.05,brian lee gaines,
+ENGL,3140,11,Technical Writing,0.5,0.33,0.06,0.06,0.0,0.0,0.0,0.06,geveryl lee robinson,
+ENGL,3140,12,Technical Writing,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,geveryl lee robinson,
+ENGL,3140,13,Technical Writing,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,april obrien,
+ENGL,3140,14,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,april obrien,
+ENGL,3140,16,Technical Writing,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,22,Technical Writing,0.74,0.11,0.0,0.0,0.05,0.0,0.0,0.11,michael david measel,
+ENGL,3140,100,Technical Writing (HONORS),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,True
+ENGL,3150,1,Scientific Writing & Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,3150,2,Scientific Writing & Comm,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,3150,3,Scientific Writing & Comm,0.53,0.24,0.06,0.06,0.0,0.0,0.0,0.12,william pulley,
+ENGL,3150,4,Scientific Writing & Comm,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,william pulley,
+ENGL,3150,400,Scientific Writing & Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,401,Scientific Writing & Comm,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,402,Scientific Writing & Comm,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,403,Scientific Writing & Comm,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,405,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3450,1,Intr Creative Writing: Fiction,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nicholas chris brown,
+ENGL,3460,2,Intr Creative Writing: Poetry,0.61,0.22,0.06,0.06,0.0,0.0,0.0,0.06,sharon kathle nalley,
+ENGL,3480,1,Intr Creat Writ: Screenwriting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,
+ENGL,3480,2,Intr Creat Writ: Screenwriting,0.67,0.17,0.0,0.0,0.06,0.0,0.0,0.11,julia brownlee koets,
+ENGL,3570,1,Film,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,
+ENGL,3800,1,Women Writers,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,remley meliss makala,
+ENGL,3850,1,Children's Lit,0.6,0.27,0.0,0.0,0.13,0.0,0.0,0.0,megan noe macalystre,
+ENGL,3860,1,Adolescent Lit,0.12,0.65,0.24,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,3970,2,Brit Lit Survey II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,
+ENGL,3980,2,Amer Lit Survey I,0.26,0.63,0.05,0.0,0.0,0.0,0.0,0.05,susanna ashton,
+ENGL,4010,1,Grammar Survey,0.68,0.11,0.11,0.05,0.05,0.0,0.0,0.0,william stockton,
+ENGL,4080,1,Chaucer,0.5,0.28,0.22,0.0,0.0,0.0,0.0,0.0,andrew lemons,
+ENGL,4180,1,English Novel,0.09,0.64,0.18,0.0,0.0,0.0,0.0,0.09,lee morrissey,
+ENGL,4200,1,Amer Lit to 1799,0.4,0.4,0.0,0.0,0.07,0.0,0.0,0.13,jonathan beech field,
+ENGL,4210,1,Amer Lit 1800-1899,0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,dominic mastroianni,
+ENGL,4280,1,Contemporary Literature,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,matthew hooley,
+ENGL,4310,1,Modern Poetry,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,4360,1,Feminist Literary Criticism,0.47,0.29,0.12,0.06,0.0,0.0,0.0,0.06,erin marina goss,
+ENGL,4400,1,Literary Theory,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,maria selene bose,
+ENGL,4420,1,Cultural Studies,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,maria selene bose,
+ENGL,4430,1,Theories of World Literature,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,andrew lemons,
+ENGL,4440,1,Renaissance Literature,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4450,1,Fiction Workshop,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,4480,1,Screenwriting Wkshop,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,nicholas chris brown,
+ENGL,4510,1,Film Theory and Criticism,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,john robert smith,
+ENGL,4510,2,Film Theory and Criticism,0.69,0.19,0.13,0.0,0.0,0.0,0.0,0.0,john robert smith,
+ENGL,4520,1,Great Directors,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,olga anatoly volkova,
+ENGL,4560,1,Holocaust Lit/Arts,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,steven katz,
+ENGL,4600,1,Writing Technologies,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,tharon howard,
+ENGL,4780,1,Digital Literacy,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,tharon howard,
+ENGL,4920,1,Modern Rhetoric,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,megan eatman,
+ENGL,4960,1,Senior Seminar,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,jonathan beech field,
+ENGL,4960,2,Senior Seminar,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,4960,3,Senior Seminar,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,erin marina goss,
+ENGL,8520,1,Rhetorical Theories & Practice,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,megan eatman,
+ENGR,1020,112,Engineering Discipl & Skills,0.13,0.63,0.15,0.03,0.0,0.0,0.0,0.08,sarah grigg,
+ENGR,1020,113,Engineering Discipl & Skills,0.18,0.63,0.18,0.0,0.0,0.0,0.0,0.03,sarah grigg,
+ENGR,1020,116,Engineering Discipl & Skills,0.4,0.38,0.15,0.0,0.0,0.0,0.0,0.08,michael giebner,
+ENGR,1020,211,Engineering Discipl & Skills,0.38,0.4,0.05,0.05,0.05,0.0,0.0,0.07,ashley childers,
+ENGR,1020,218,Engineering Discipl & Skills,0.21,0.47,0.21,0.05,0.03,0.0,0.0,0.03,michael giebner,
+ENGR,1020,311,Engineering Discipl & Skills,0.24,0.43,0.21,0.02,0.05,0.0,0.0,0.05,john minor,
+ENGR,1020,312,Engineering Discipl & Skills,0.33,0.36,0.21,0.02,0.02,0.0,0.0,0.05,john minor,
+ENGR,1020,314,Engineering Discipl & Skills,0.51,0.17,0.17,0.07,0.0,0.0,0.0,0.07,ashley childers,
+ENGR,1020,315,Engr Discipl & Skills (HON),0.76,0.21,0.0,0.0,0.0,0.0,0.0,0.03,richard watkins,True
+ENGR,1020,316,Engineering Discipl & Skills,0.33,0.38,0.14,0.02,0.02,0.0,0.0,0.1,steven brandon,
+ENGR,1020,611,Engineering Discipl & Skills,0.37,0.37,0.12,0.07,0.02,0.0,0.0,0.05,irene marie ferrara,
+ENGR,1020,612,Engineering Discipl & Skills,0.63,0.2,0.12,0.02,0.02,0.0,0.0,0.0,irene marie ferrara,
+ENGR,1020,613,Engineering Discipl & Skills,0.12,0.33,0.3,0.12,0.03,0.0,0.0,0.09,elizabeth an stephan,
+ENGR,1020,614,Engineering Discipl & Skills,0.09,0.19,0.13,0.25,0.06,0.0,0.0,0.28,matthew kent miller,
+ENGR,1020,615,Engineering Discipl & Skills,0.31,0.36,0.21,0.07,0.0,0.0,0.0,0.05,anthony paul garland,
+ENGR,1020,616,Engineering Discipl & Skills,0.04,0.48,0.3,0.07,0.04,0.0,0.0,0.07,andrew isaac neptune,
+ENGR,1020,617,Engineering Discipl & Skills,0.34,0.32,0.21,0.0,0.0,0.0,0.0,0.13,anthony paul garland,
+ENGR,1020,618,Engineering Discipl & Skills,0.12,0.39,0.27,0.05,0.02,0.0,0.0,0.15,anthony paul garland,
+ENGR,1020,811,Engineering Discipl & Skills,0.45,0.38,0.15,0.03,0.0,0.0,0.0,0.0,jonathan broo harcum,
+ENGR,1020,812,Engineering Discipl & Skills,0.29,0.49,0.15,0.05,0.0,0.0,0.0,0.02,elizabeth an stephan,
+ENGR,1020,813,Engineering Discipl & Skills,0.3,0.43,0.18,0.08,0.0,0.0,0.0,0.03,andrew isaac neptune,
+ENGR,1020,814,Engineering Discipl & Skills,0.55,0.3,0.08,0.03,0.0,0.0,0.0,0.05,jonathan broo harcum,
+ENGR,1020,815,Engineering Discipl & Skills,0.4,0.5,0.05,0.0,0.05,0.0,0.0,0.0,jonathan broo harcum,
+ENGR,1020,816,Engineering Discipl & Skills,0.43,0.38,0.13,0.03,0.0,0.0,0.0,0.05,matthew kent miller,
+ENGR,1020,817,Engineering Discipl & Skills,0.23,0.5,0.15,0.08,0.0,0.0,0.0,0.05,matthew kent miller,
+ENGR,1020,818,Engineering Discipl & Skills,0.41,0.38,0.05,0.14,0.03,0.0,0.0,0.0,andrew isaac neptune,
+ENGR,1020,831,Engr Discipl & Skills (HON),0.69,0.29,0.0,0.0,0.0,0.0,0.0,0.03,jonathan maier,True
+ENGR,1020,832,Engr Discipl & Skills (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jonathan maier,True
+ENGR,1060,400,Engr Discipline & Skills II,0.0,0.44,0.19,0.19,0.19,0.0,0.0,0.0,mariah so magagnotti,
+ENGR,1060,401,Engr Discipline & Skills II,0.17,0.17,0.17,0.17,0.33,0.0,0.0,0.0,mariah so magagnotti,
+ENGR,1410,222,Programming & Problem Solving,0.05,0.26,0.32,0.11,0.16,0.0,0.0,0.11,mariah so magagnotti,
+ENGR,1410,223,Programming & Problem Solving,0.05,0.16,0.51,0.11,0.03,0.0,0.0,0.14,william martin,
+ENGR,1410,226,Programming & Problem Solving,0.13,0.21,0.39,0.11,0.11,0.0,0.0,0.05,mariah so magagnotti,
+ENGR,1410,227,Programming & Problem Solving,0.14,0.36,0.31,0.14,0.03,0.0,0.0,0.03,william martin,
+ENGR,2080,681,Engr Graphics & Machine Design,0.42,0.33,0.11,0.0,0.08,0.0,0.0,0.06,nighat yasmin,
+ENGR,2080,682,Engr Graphics & Machine Design,0.32,0.3,0.22,0.11,0.05,0.0,0.0,0.0,nighat yasmin,
+ENGR,2080,683,Engr Graphics & Machine Design,0.44,0.33,0.13,0.0,0.1,0.0,0.0,0.0,kyle walker,
+ENGR,2080,684,Engr Graphics & Machine Design,0.37,0.39,0.13,0.0,0.0,0.0,0.0,0.11,kyle walker,
+ENGR,2080,685,Engr Graphics & Machine Design,0.5,0.16,0.16,0.03,0.03,0.0,0.0,0.13,samuel coeyman,
+ENGR,2080,686,Engr Graphics & Machine Design,0.35,0.32,0.21,0.06,0.06,0.0,0.0,0.0,samuel coeyman,
+ENGR,2100,804,CAD & Engineering Applications,0.44,0.18,0.1,0.1,0.1,0.0,0.0,0.08,afshin famili,
+ENGR,2100,805,CAD & Engineering Applications,0.45,0.33,0.1,0.03,0.05,0.0,0.0,0.05,nighat yasmin,
+ENGR,2100,806,CAD & Engineering Applications,0.55,0.26,0.03,0.05,0.0,0.0,0.0,0.11,afshin famili,
+ENGR,2200,115,Evaluating Innovations,0.1,0.65,0.23,0.03,0.0,0.0,0.0,0.0,sarah grigg,
+ENR,1010,2,Intro to Envir & Natur Res I,0.82,0.11,0.02,0.0,0.0,0.0,0.0,0.05,emily catheri oakman,
+ENR,1010,3,Intro to Envir & Natur Res I,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,emily catheri oakman,
+ENR,4290,1,Environ Law & Policy,0.24,0.38,0.27,0.03,0.03,0.0,0.0,0.05,alan johnson,
+ENR,4290,2,Environ Law & Policy,0.36,0.45,0.11,0.0,0.0,0.0,0.0,0.07,alan johnson,
+ENSP,2000,1,Intro Environ Sci,0.33,0.47,0.19,0.0,0.02,0.0,0.0,0.0,scott brame,
+ENSP,2000,2,Intro Environ Sci,0.69,0.28,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2000,3,Intro Environ Sci,0.57,0.39,0.02,0.0,0.0,0.0,0.0,0.02,minory nammouz,
+ENSP,2000,4,Intro Environ Sci,0.56,0.4,0.02,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,
+ENSP,2000,5,Intro Environ Sci,0.39,0.39,0.13,0.02,0.0,0.0,0.0,0.07,tom owino,
+ENSP,4000,1,Studies in Environmental Sci,0.53,0.35,0.0,0.06,0.0,0.0,0.0,0.06,margaret lo thompson,
+ENT,2000,1,Six-Legged Science,0.53,0.4,0.05,0.0,0.0,0.0,0.0,0.03,suellen pometto,
+ENT,3010,1,Insect Biology and Diversity,0.33,0.33,0.27,0.07,0.0,0.0,0.0,0.0,eric benson,
+ENTR,1010,3,Entrepreneurial Mindset,0.69,0.23,0.05,0.01,0.01,0.0,0.0,0.01,john michael hannon,
+ENTR,1090,6,Creative Inq-Entrepreneurship,0.61,0.3,0.0,0.0,0.0,0.0,0.0,0.09,john michael hannon,
+ENTR,2010,4,Sports Entrepreneurship,0.63,0.27,0.03,0.0,0.03,0.0,0.0,0.03,john michael hannon,
+ETOX,4300,1,Toxicology,0.54,0.23,0.15,0.08,0.0,0.0,0.0,0.0,lisa bain,
+FDSC,1010,1,Intro to Food Sci & Hum Nutr,0.88,0.05,0.02,0.02,0.01,0.0,0.0,0.02,sara lane cothran,
+FDSC,3010,1,Food Regulations,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
+FDSC,4010,1,Food Chemistry I,0.51,0.49,0.0,0.0,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4040,1,Food Prsv & Process,0.53,0.21,0.21,0.02,0.02,0.0,0.0,0.0,anthony loui pometto,
+FDSC,4070,1,Quantity Food Production,0.84,0.1,0.03,0.0,0.03,0.0,0.0,0.0,bridgit deni corbett,
+FDSC,4300,1,Dairy Process & Sant,0.52,0.24,0.1,0.14,0.0,0.0,0.0,0.0,john mcgregor,
+FDSC,8120,1,Microbial Food Syst,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,xiuping jiang,
+FDSC,8210,1,Selected Topics,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,julie kath northcutt,
+FIN,2010,401,Intro to Personal Finance,0.95,0.04,0.01,0.0,0.0,0.0,0.0,0.0,joshua harris,
+FIN,2010,402,Intro to Personal Finance,0.89,0.08,0.01,0.0,0.0,0.0,0.0,0.02,joshua harris,
+FIN,2010,403,Intro to Personal Finance,0.9,0.07,0.01,0.0,0.01,0.0,0.0,0.01,joshua harris,
+FIN,2010,404,Intro to Personal Finance,0.78,0.09,0.02,0.02,0.06,0.0,0.0,0.02,joshua harris,
+FIN,2010,406,Intro to Personal Finance,0.79,0.15,0.0,0.02,0.02,0.0,0.0,0.02,joshua harris,
+FIN,2010,407,Intro to Personal Finance,0.81,0.1,0.0,0.1,0.0,0.0,0.0,0.0,joshua harris,
+FIN,3040,1,Risk & Insurance,0.28,0.3,0.23,0.15,0.0,0.0,0.0,0.05,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.07,0.29,0.32,0.05,0.17,0.0,0.0,0.1,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.08,0.5,0.32,0.03,0.08,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.21,0.36,0.28,0.05,0.03,0.0,0.0,0.08,kerri mcmillan,
+FIN,3050,4,Investment Analysis,0.14,0.25,0.19,0.17,0.14,0.0,0.0,0.11,john alexander,
+FIN,3060,5,Corporation Finance,0.09,0.45,0.3,0.11,0.02,0.0,0.0,0.04,ramon tolbe franklin,
+FIN,3060,6,Corporation Finance,0.09,0.27,0.34,0.14,0.09,0.0,0.0,0.07,ramon tolbe franklin,
+FIN,3060,7,Corporation Finance,0.15,0.26,0.26,0.15,0.0,0.0,0.0,0.17,ramon tolbe franklin,
+FIN,3060,8,Corporation Finance,0.24,0.41,0.25,0.08,0.0,0.0,0.0,0.02,melvin stith,
+FIN,3060,9,Corporation Finance,0.29,0.39,0.2,0.1,0.02,0.0,0.0,0.0,melvin stith,
+FIN,3060,401,Corporation Finance,0.49,0.23,0.23,0.02,0.0,0.0,0.0,0.04,joshua harris,
+FIN,3060,402,Corporation Finance,0.37,0.42,0.12,0.04,0.02,0.0,0.0,0.04,joshua harris,
+FIN,3070,1,Prin of Real Estate,0.1,0.22,0.39,0.17,0.1,0.0,0.0,0.02,thomas springer,
+FIN,3070,2,Prin of Real Estate,0.18,0.32,0.23,0.2,0.0,0.0,0.0,0.07,thomas springer,
+FIN,3070,3,Prin of Real Estate,0.26,0.42,0.29,0.03,0.0,0.0,0.0,0.0,yannan shen,
+FIN,3080,3,Fin Inst & Mkts,0.23,0.33,0.36,0.08,0.0,0.0,0.0,0.0,daniel thomas greene,
+FIN,3080,401,Fin Inst & Mkts,0.21,0.32,0.36,0.09,0.0,0.0,0.0,0.02,daniel thomas greene,
+FIN,3110,1,Financial Management I,0.12,0.24,0.31,0.12,0.05,0.0,0.0,0.17,jack wolf,
+FIN,3110,2,Financial Management I,0.12,0.3,0.4,0.12,0.05,0.0,0.0,0.02,jack wolf,
+FIN,3110,3,Financial Management I,0.28,0.28,0.28,0.13,0.05,0.0,0.0,0.0,jack wolf,
+FIN,3110,5,Financial Management I,0.16,0.34,0.36,0.11,0.02,0.0,0.0,0.02,weike xu,
+FIN,3110,6,Financial Management I,0.16,0.43,0.3,0.07,0.04,0.0,0.0,0.0,weike xu,
+FIN,3120,1,Financial Management II,0.17,0.3,0.37,0.1,0.0,0.0,0.0,0.07,vincent ja intintoli,
+FIN,3120,2,Financial Management II,0.05,0.31,0.36,0.1,0.14,0.0,0.0,0.05,vincent ja intintoli,
+FIN,3120,3,Financial Management II,0.24,0.27,0.15,0.07,0.05,0.0,0.0,0.22,blerina zykaj,
+FIN,3120,4,Financial Management II,0.21,0.39,0.21,0.05,0.04,0.0,0.0,0.09,weike xu,
+FIN,3120,101,Financial Mgt II (HON),0.7,0.2,0.0,0.1,0.0,0.0,0.0,0.0,vincent ja intintoli,True
+FIN,4010,1,Corporate Financial Analysis,0.33,0.4,0.17,0.02,0.02,0.0,0.0,0.05,george bran lockhart,
+FIN,4020,1,Corporate Valuation,0.26,0.37,0.26,0.11,0.0,0.0,0.0,0.0,angela morgan,
+FIN,4050,1,Portfolio Management & Theory,0.14,0.17,0.44,0.14,0.06,0.0,0.0,0.06,john alexander,
+FIN,4060,1,Derivatives Analysis,0.34,0.31,0.17,0.07,0.07,0.0,0.0,0.03,blerina zykaj,
+FIN,4110,1,Int Fin Mgt,0.21,0.46,0.28,0.05,0.0,0.0,0.0,0.0,luke asher devault,
+FIN,4110,2,Int Fin Mgt,0.22,0.53,0.22,0.03,0.0,0.0,0.0,0.0,luke asher devault,
+FIN,4170,1,Real Estate Finance,0.24,0.38,0.24,0.1,0.05,0.0,0.0,0.0,yannan shen,
+FNR,2040,1,Soil Information Systems,0.84,0.1,0.03,0.0,0.02,0.0,0.0,0.02,elena mikhailova,
+FNR,4990,1,Natural Resources Seminar,0.76,0.21,0.03,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
+FOR,2050,1,Dendrology,0.24,0.35,0.05,0.22,0.08,0.0,0.0,0.05,donald hagan,
+FOR,2050,2,Dendrology,0.27,0.37,0.16,0.08,0.02,0.0,0.0,0.1,donald hagan,
+FOR,2050,3,Dendrology,0.37,0.16,0.11,0.11,0.21,0.0,0.0,0.05,donald hagan,
+FOR,2210,1,Forest Biology,0.75,0.12,0.1,0.01,0.0,0.0,0.0,0.02,emily catheri oakman,
+FOR,3020,1,Forest Biometrics,0.24,0.44,0.16,0.16,0.0,0.0,0.0,0.0,lawrence gering,
+FOR,3040,1,Forest Resource Economics,0.46,0.46,0.07,0.0,0.0,0.0,0.0,0.0,puskar khanal,
+FOR,4100,1,Harvesting Processes,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,patrick hiesl,
+FOR,4160,1,Forest Policy and Admin,0.44,0.3,0.22,0.02,0.0,0.0,0.0,0.01,thomas straka,
+FOR,4170,1,Forest Resource Mgt & Regulatn,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.0,puskar khanal,
+FOR,4310,1,Recreation Res Plan in For Mgt,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,robert baxter powell,
+FOR,4340,1,GIS for Natural Resources,0.79,0.19,0.02,0.0,0.0,0.0,0.0,0.0,christopher post,
+FR,1010,1,Elementary French,0.33,0.33,0.17,0.06,0.0,0.0,0.0,0.11, nedeo anne salces anne,
+FR,1010,2,Elementary French,0.31,0.44,0.19,0.0,0.06,0.0,0.0,0.0, nedeo anne salces anne,
+FR,1010,3,Elementary French,0.13,0.38,0.38,0.06,0.06,0.0,0.0,0.0, nedeo anne salces anne,
+FR,1020,1,Elementary French,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
+FR,1020,2,Elementary French,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,amy lyn griff sawyer griff,
+FR,2010,2,Intermediate French,0.28,0.56,0.06,0.0,0.06,0.0,0.0,0.06,kenneth davi widgren,
+FR,2010,3,Intermediate French,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,kenneth davi widgren,
+FR,2010,4,Intermediate French,0.33,0.5,0.06,0.06,0.0,0.0,0.0,0.06,tholozany pauline de,
+FR,2020,1,Intermediate French,0.89,0.0,0.05,0.0,0.0,0.0,0.0,0.05,amy lyn griff sawyer griff,
+FR,2020,2,Intermediate French,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,
+FR,2020,3,Intermediate French,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,eric touya,
+FR,2020,4,Intermediate French,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
+FR,2020,5,Intermediate French,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,kenneth davi widgren,
+FR,3000,1,Survey of French Lit,0.39,0.5,0.0,0.0,0.06,0.0,0.0,0.06,tholozany pauline de,
+FR,3050,1,Int Fr Con & Comp I,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,kenneth davi widgren,
+FR,4120,1,Fr & Francoph Cinema,0.65,0.24,0.06,0.0,0.06,0.0,0.0,0.0,joseph mai,
+FR,4160,1,Fr for Intl Trade II,0.43,0.36,0.14,0.0,0.0,0.0,0.0,0.07,eric touya,
+GC,1020,1,Computer Art & CAD Foundations,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,carol jones,
+GC,1020,2,Computer Art & CAD Foundations,0.5,0.42,0.0,0.0,0.06,0.0,0.0,0.02,carol jones,
+GC,1030,1,G C I for Pkgsc,0.29,0.67,0.05,0.0,0.0,0.0,0.0,0.0,john jacobs,
+GC,1040,1,Graphic Communications I,0.67,0.23,0.05,0.02,0.02,0.0,0.0,0.02,michelle suki bo fox bo,
+GC,2070,1,Graphic Communications II,0.6,0.29,0.02,0.0,0.04,0.0,0.0,0.04,charles tabor weiss,
+GC,3400,1,Digital Imaging and eMedia,0.29,0.48,0.17,0.0,0.04,0.0,0.0,0.02,erica black walker,
+GC,3460,1,Ink and Substrates,0.25,0.36,0.34,0.0,0.05,0.0,0.0,0.0,liam henry 'hara,
+GC,4060,1,Package and Specialty Printing,0.67,0.29,0.02,0.0,0.02,0.0,0.0,0.0,kern cox,
+GC,4400,1,Commercial Printing,0.28,0.59,0.1,0.0,0.03,0.0,0.0,0.0,eric weisenmiller,
+GC,4440,1,Current Dev/Trends in Gr Comm,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,
+GC,4800,1,Senior Seminar in GC,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,charles edwar tonkin,
+GC,4900,1,Media & Film in Dig Age,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,erica black walker,
+GC,4900,3,Digital Media Design,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erica black walker,
+GC,4900,6,GC-UX & Web Design,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,erica black walker,
+GC,4900,230,G C Selected Topics-GC Sales,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,john leininger,
+GEN,1030,1,Careers in Bioch/Gen,0.88,0.07,0.0,0.01,0.03,0.0,0.0,0.01,alison ni starr-moss,
+GEN,3000,1,Fundamental Genetics,0.29,0.33,0.26,0.03,0.01,0.0,0.0,0.09,kate leanne wil tsai wil,
+GEN,3000,2,Fundamental Genetics,0.26,0.34,0.25,0.1,0.02,0.0,0.0,0.04,kate leanne wil tsai wil,
+GEN,3020,1,Molecular & General Genetics,0.57,0.35,0.05,0.01,0.0,0.0,0.0,0.02,jennifer may mason,
+GEN,3020,2,Molec & General Genetics (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,True
+GEN,3040,1,Molecular Biology Laboratory,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,scott michael tanner,
+GEN,3040,2,Molecular Biology Laboratory,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,3040,3,Molecular Biology Laboratory,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,3040,4,Molecular Biology Laboratory,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,4100,1,Population & Quant Genetics,0.38,0.44,0.1,0.04,0.02,0.0,0.0,0.02,scott michael tanner,
+GEN,4100,2,Population & Quant Gen (HON),0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,scott michael tanner,True
+GEN,4110,1,Population & Quant Gen Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,4110,2,Population & Quant Gen Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,4110,3,Population & Quant Gen Lab,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,4110,4,Population & Quant Gen Lab,0.79,0.0,0.07,0.0,0.07,0.0,0.0,0.07,scott michael tanner,
+GEN,4400,1,Bioinformatics,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,frank alexand feltus,
+GEN,4500,1,Comparative Genetics,0.25,0.45,0.25,0.0,0.03,0.0,0.0,0.03,leigh anne clark,
+GEN,4900,1,Epigenetics,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,rajandeep sin sekhon,
+GEN,8140,1,Advanced Genetics,0.2,0.8,0.0,0.0,0.0,0.0,0.0,0.0,miriam kristi konkel,
+GEOG,1030,1,World Regional Geography,0.33,0.42,0.15,0.02,0.02,0.0,0.0,0.06,william church terry,
+GEOG,3010,1,Political Geography,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,christa smith,
+GEOG,4010,1,Studies in Geography,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william church terry,
+GEOL,1010,1,Physical Geology,0.22,0.3,0.18,0.11,0.09,0.0,0.0,0.1,alan coulson,
+GEOL,1010,2,Physical Geology,0.24,0.33,0.25,0.05,0.06,0.0,0.0,0.06,alan coulson,
+GEOL,1010,4,Physical Geology,0.49,0.29,0.16,0.0,0.02,0.0,0.0,0.04,mary katherin fidler,
+GEOL,1030,1,Physical Geol Lab,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.42,0.46,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.38,0.46,0.17,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.57,0.26,0.04,0.04,0.0,0.0,0.0,0.09,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.32,0.5,0.09,0.05,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.54,0.13,0.0,0.04,0.17,0.0,0.0,0.13,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.58,0.29,0.04,0.0,0.04,0.0,0.0,0.04,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,13,Physical Geol Lab,0.22,0.48,0.22,0.04,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1120,1,Earth Resources,0.27,0.32,0.23,0.09,0.05,0.0,0.0,0.03,mary katherin fidler,
+GEOL,1140,1,Earth Resources Lab,0.58,0.2,0.13,0.02,0.02,0.0,0.0,0.04,mary katherin fidler,
+GEOL,2050,1,Mineralogy & Intro Petrology,0.4,0.33,0.13,0.07,0.0,0.0,0.0,0.07,lind shuller-nickles,
+GEOL,2070,1,Min & Intro Pet Lab,0.33,0.13,0.27,0.13,0.07,0.0,0.0,0.07,mary katherin fidler,
+GEOL,2750,1,Field Methods,0.7,0.0,0.0,0.0,0.0,0.0,0.0,0.3,scott brame,
+GEOL,3000,1,Environmental Geology,0.05,0.49,0.31,0.1,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,3020,1,Structural Geology,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,alexander tho pullen,
+GEOL,4030,1,Invertebrate Paleontology,0.1,0.7,0.0,0.0,0.0,0.0,0.0,0.2,neil smith,
+GEOL,4150,1,Analysis Geological Processes,0.45,0.27,0.18,0.0,0.09,0.0,0.0,0.0,lawrence murdoch,
+GEOL,4910,1,Research Synthesis I,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,alan coulson,
+GEOL,6820,1,Groundwater & Contam Transport,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
+GEOL,7900,501,Biogeography And Geology of SC,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
+GER,1010,2,Elementary German,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+GER,1010,3,Elementary German,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,oswald harris king,
+GER,1020,1,Elementary German,0.07,0.33,0.2,0.13,0.07,0.0,0.0,0.2, lee ferrell,
+GER,2010,1,Intermediate German,0.25,0.19,0.38,0.13,0.06,0.0,0.0,0.0,johannes schmidt,
+GER,2010,2,Intermediate German,0.08,0.31,0.38,0.23,0.0,0.0,0.0,0.0,johannes schmidt,
+GER,2020,1,Intermediate German,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,gabriela stoicea,
+GER,2020,2,Intermediate German,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,oswald harris king,
+GER,3050,1,Ger Conv & Comp,0.57,0.21,0.21,0.0,0.0,0.0,0.0,0.0, lee ferrell,
+GER,3400,1,German Culture,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,oswald harris king,
+HIST,1010,1,History of the United States,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
+HIST,1010,2,History of the United States,0.21,0.47,0.18,0.09,0.06,0.0,0.0,0.0,john andrew,
+HIST,1020,1,History of the United States,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,maribel morey,
+HIST,1220,1,"Hist, Tech & Society",0.36,0.49,0.06,0.05,0.02,0.0,0.0,0.03,pamela mack,
+HIST,1240,1,Environmental History Survey,0.3,0.3,0.23,0.03,0.03,0.0,0.0,0.1,james bradf jeffries,
+HIST,1240,2,Environmental History Survey,0.23,0.37,0.23,0.13,0.03,0.0,0.0,0.0,james bradf jeffries,
+HIST,1720,1,The West and the World I,0.22,0.34,0.26,0.05,0.06,0.0,0.0,0.07,caroline dunn clark,
+HIST,1720,2,The West and the World I,0.29,0.47,0.15,0.07,0.02,0.0,0.0,0.01,steven marks,
+HIST,1730,1,The West and the World II,0.19,0.43,0.19,0.05,0.08,0.0,0.0,0.06,michael meng,
+HIST,1730,2,The West and the World II,0.44,0.3,0.15,0.04,0.0,0.0,0.0,0.07, alan grubb,
+HIST,2990,1,Historian's Craft,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,thomas kuehn,
+HIST,2990,3,Historian's Craft,0.59,0.24,0.06,0.06,0.06,0.0,0.0,0.0,michael silvestri,
+HIST,3010,1,Am Rev & New Nation,0.26,0.53,0.11,0.0,0.11,0.0,0.0,0.0,james bradf jeffries,
+HIST,3030,1,Civil War & Recon,0.16,0.79,0.0,0.0,0.0,0.0,0.0,0.05,paul christ anderson,
+HIST,3040,1,Indus & Progr Era,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0, roger grant,
+HIST,3120,1,Afr Amer Hist 1877 to Present,0.21,0.63,0.11,0.0,0.0,0.0,0.0,0.05,abel bartley,
+HIST,3240,1,Hist of the South II,0.36,0.4,0.12,0.04,0.04,0.0,0.0,0.04,john andrew,
+HIST,3280,1,US Legal History to 1890,0.7,0.27,0.03,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
+HIST,3330,1,Hist of Mod Japan,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,edwin moise,
+HIST,3380,1,Africa to 1875,0.38,0.25,0.21,0.13,0.0,0.0,0.0,0.04,james burns,
+HIST,3410,1,Modern Mexico,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,rachel anne moore,
+HIST,3630,1,Britain Since 1688,0.5,0.38,0.04,0.0,0.0,0.0,0.0,0.08,stephanie barczewski,
+HIST,3700,1,Medieval History,0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,
+HIST,3970,1,Modern Middle East,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
+HIST,4400,1,Studies in Latin American Hist,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,rachel anne moore,
+HIST,4710,1,The Great War,0.57,0.14,0.14,0.0,0.07,0.0,0.0,0.07, alan grubb,
+HIST,4900,2,Weimar Germany,0.31,0.46,0.08,0.08,0.0,0.0,0.0,0.08,michael meng,
+HIST,4900,3,Dictatorship&ViolenceIW Europe,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,amit bein,
+HIST,4920,1,Iraq War,0.2,0.2,0.47,0.07,0.0,0.0,0.0,0.07,edwin moise,
+HIST,4960,1,European Law,0.2,0.4,0.3,0.0,0.0,0.0,0.0,0.1,thomas kuehn,
+HLTH,2020,1,Introduction to Public Health,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,2,Introduction to Public Health,0.56,0.33,0.1,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,3,Introduction to Public Health,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2020,4,Introduction to Public Health,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,becky ann tugman,
+HLTH,2020,5,Introduction to Public Health,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2020,400,Introduction to Public Health,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,401,Introduction to Public Health,0.53,0.26,0.11,0.0,0.0,0.0,0.0,0.11,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+HLTH,2030,2,Health Care Sys,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+HLTH,2030,3,Health Care Sys,0.47,0.37,0.05,0.05,0.05,0.0,0.0,0.0,tanya lee staton,
+HLTH,2400,1,Deter of Hlth Behav,0.45,0.42,0.12,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2400,2,Deter of Hlth Behav,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
+HLTH,2400,400,Deter of Hlth Behav,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2600,1,Medical Terminology & Comm,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,karen edwards,
+HLTH,2600,2,Medical Terminology & Comm,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,karen edwards,
+HLTH,2600,400,Medical Terminology & Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2980,1,Human Health and Disease,0.75,0.16,0.09,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,2980,2,Human Health and Disease,0.54,0.31,0.11,0.03,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2980,3,Human Health and Disease,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,3400,1,Hlth Prom Prog Plan,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,3610,1,Int Health Care Econ,0.67,0.23,0.03,0.0,0.0,0.0,0.0,0.07,khoa dang truong,
+HLTH,3800,1,Epidemiology,0.64,0.27,0.06,0.0,0.0,0.0,0.0,0.03,deborah alma falta,
+HLTH,3800,2,Epidemiology,0.42,0.39,0.15,0.0,0.0,0.0,0.0,0.03,deborah alma falta,
+HLTH,3800,400,Epidemiology,0.37,0.37,0.21,0.0,0.05,0.0,0.0,0.0,deborah alma falta,
+HLTH,3980,1,Health Appraisal Skills,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,3980,2,Health Appraisal Skills,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4100,1,Maternal Child Hlth,0.54,0.43,0.04,0.0,0.0,0.0,0.0,0.0,karyn jones,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.79,0.1,0.1,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4400,1,Manag Hlth Serv Org,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,
+HLTH,4700,1,Global Health,0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,micky rogers ward,
+HLTH,4750,1,Hlthcr Oper Mgmt Res,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,lu shi,
+HLTH,4900,1,Res Eval St Pub Hlth,0.42,0.32,0.16,0.05,0.05,0.0,0.0,0.0,karen kemper,
+HLTH,4900,2,Res Eval St Pub Hlth,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,4970,4,Aspire to Be Well - CI,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,chloe carolin greene,
+HLTH,4970,5,Alcohol & Other Drugs-CI,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,crystal burne fulmer,
+HLTH,8030,1,Theories and Determ of Health,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,joel edward williams,
+HLTH,8410,1,Foundations of Eval in Health,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,
+HON,1940,1,Bioinspired,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,charles beard,True
+HON,2020,1,Who Decides What's Cool?,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,True
+HON,2020,2,World of Ideas,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True
+HON,2050,1,Architecture: Ideas & Practice,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,timothy burl brown,True
+HON,2060,3,Puzzles and Paradoxes,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,marilyn reba,True
+HON,2210,1,Frankenstein at 200,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,remley meliss makala,True
+HORT,1010,1,Horticulture,0.86,0.09,0.01,0.0,0.0,0.0,0.0,0.03,ellen anita vincent,
+HORT,2020,1,Adobe Digital Design,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,janice ann lay,
+HORT,2020,2,Hydroponics,0.17,0.28,0.19,0.17,0.06,0.0,0.0,0.15,james emerson faust,
+HORT,2120,1,Turfgrass Culture,0.56,0.38,0.05,0.0,0.0,0.0,0.0,0.0,haibo liu,
+HORT,2130,2,Turf Culture Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
+HORT,3030,1,Landscape Plants,0.09,0.22,0.35,0.16,0.15,0.0,0.0,0.03,robert polomski,
+HORT,3080,1,Sust Landsc Des Install Maint,0.9,0.08,0.0,0.0,0.03,0.0,0.0,0.0,ellen anita vincent,
+HORT,4120,1,Adv Turfgrass Mgt,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,lambert mccarty,
+HP,8070,400,American Architecture,0.6,0.1,0.0,0.0,0.0,0.0,0.0,0.3,carter lee hudgins,
+HP,8080,400,Hist and Theory of Hist Pres,0.56,0.11,0.0,0.0,0.0,0.0,0.0,0.33,carter lee hudgins,
+HP,8090,400,Historical Research Methods,0.5,0.13,0.0,0.0,0.0,0.0,0.0,0.38,katherine pemberton,
+HP,8190,1,"Investig, Docum, Conservation",0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,amalia leifeste,
+HRD,8200,401,Human Perform Improv,0.77,0.14,0.0,0.0,0.0,0.0,0.0,0.09,angela daniel carter,
+HRD,8450,400,Needs Assess Ed/Ind,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,angela daniel carter,
+HRD,8600,400,Instruc Mat Devel,0.81,0.16,0.03,0.0,0.0,0.0,0.0,0.0,cynthia sims,
+IE,2100,1,Des Analysis Wrk Sys,0.49,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jeffery messer,
+IE,3010,1,Systems Design I,0.35,0.49,0.14,0.01,0.0,0.0,0.0,0.01,robert james riggs,
+IE,3600,1,Industrial Apps of Prob/Stat I,0.23,0.25,0.23,0.14,0.08,0.0,0.0,0.06,tugce isik,
+IE,3610,1,Industrial App of Prob/Stat II,0.31,0.41,0.1,0.1,0.04,0.0,0.0,0.04,david neyens,
+IE,3800,1,Deterministic Operations Rsrch,0.17,0.42,0.2,0.05,0.15,0.0,0.0,0.01,joshua tayl margolis,
+IE,3810,1,Probabilistic Operations Rsrch,0.6,0.29,0.07,0.01,0.0,0.0,0.0,0.02,burak eksioglu,
+IE,3840,1,Engr Econ Analysis,0.4,0.2,0.09,0.06,0.05,0.0,0.0,0.19,brian melloy,
+IE,3860,1,Production Planning & Control,0.84,0.12,0.02,0.02,0.0,0.0,0.0,0.0,xiaoxia li,
+IE,4400,1,Decision Support Sys,0.53,0.3,0.06,0.01,0.05,0.0,0.0,0.05,scott jennings mason,
+IE,4460,1,Model & Analysis Mfg Systems,0.37,0.47,0.14,0.0,0.0,0.0,0.0,0.02,robert james riggs,
+IE,4510,1,Investigating Human Error,0.36,0.26,0.28,0.04,0.0,0.0,0.0,0.06,sara lu riggs,
+IE,4530,1,Network Flows for IE Apps,0.36,0.36,0.09,0.0,0.09,0.0,0.0,0.09,burak eksioglu,
+IE,4610,1,Quality Engineering,0.29,0.32,0.27,0.07,0.02,0.0,0.0,0.02,byung rae cho,
+IE,4650,1,Facilities Planning & Design,0.23,0.47,0.18,0.06,0.02,0.0,0.0,0.03,william ferrell,
+IE,4670,1,System Design II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,
+IE,4810,1,App of Prob Models in Ind Engr,0.36,0.27,0.27,0.0,0.0,0.0,0.0,0.09,brian melloy,
+IE,4820,1,Systems Modeling,0.46,0.28,0.18,0.03,0.0,0.0,0.0,0.05,kevin taaffe,
+IE,4820,2,Systems Modeling,0.2,0.44,0.24,0.1,0.02,0.0,0.0,0.0,kevin taaffe,
+IE,4910,3,Human Centered Design & Engr,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,laura michel stanley,
+IE,6460,1,Model & Analysis Mfg Systems,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
+IE,8000,1,Human Factors Eng,0.15,0.63,0.22,0.0,0.0,0.0,0.0,0.0,david neyens,
+IE,8030,1,Engr Optimization and Apps,0.68,0.26,0.05,0.0,0.01,0.0,0.0,0.0,sandra duni eksioglu,
+IE,8040,1,Mfg Sys Plan & Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,
+IE,8530,1,Foundations of Quality,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,byung rae cho,
+IE,8550,1,SC & Logistics Modeling II,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,kevin taaffe,
+IE,8930,1,Markov Decision Processes,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amin khademi,
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,lisa marie robinson,
+IS,1010,100,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,james dougla bennett,
+ITAL,1010,2,Elementary Italian,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,luca barattoni,
+ITAL,1010,3,Elementary Italian,0.57,0.36,0.0,0.0,0.0,0.0,0.0,0.07,julia schmidt,
+ITAL,1010,4,Elementary Italian,0.23,0.46,0.15,0.0,0.08,0.0,0.0,0.08,julia schmidt,
+ITAL,2010,1,Intermediate Italian,0.5,0.11,0.22,0.11,0.0,0.0,0.0,0.06,julia schmidt,
+JAPN,1010,1,Elementary Japanese,0.53,0.26,0.05,0.05,0.0,0.0,0.0,0.11,saori suto,
+JAPN,1010,2,Elementary Japanese,0.47,0.16,0.21,0.05,0.0,0.0,0.0,0.11,saori suto,
+JAPN,1010,3,Elementary Japanese,0.5,0.33,0.08,0.0,0.08,0.0,0.0,0.0,satomi saito,
+JAPN,1020,1,Elementary Japanese,0.38,0.31,0.08,0.15,0.0,0.0,0.0,0.08,satomi saito,
+JAPN,2010,1,Intermed Japanese,0.46,0.08,0.31,0.08,0.0,0.0,0.0,0.08,saori suto,
+JAPN,3050,1,Japanese Conversation & Comp,0.57,0.14,0.07,0.07,0.14,0.0,0.0,0.0,jae allegra takeuchi,
+JAPN,4010,1,Japanese Lit in Translation,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,kumiko saito,
+JUST,2880,1,The Criminal Justice System,0.5,0.22,0.16,0.04,0.08,0.0,0.0,0.0,margaret tina britz,
+JUST,4680,1,Criminal Evidence,0.44,0.35,0.09,0.07,0.02,0.0,0.0,0.02,margaret tina britz,
+JUST,4860,1,Creative Inquiry in CJ,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,margaret tina britz,
+LANG,3000,1,Intro Linguistics,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,daniel smith,
+LANG,4540,1,Sel Top in International Film,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,satomi saito,
+LARC,1150,1,Intro Landscape Architecture,0.77,0.14,0.05,0.0,0.0,0.0,0.0,0.05,mary padua,
+LARC,1280,1,Technical Graphics,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
+LARC,1510,1,Basic Design I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
+LARC,2510,2,Larch Design Fund,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,
+LARC,2620,1,Design Implementation I,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,robert hewitt,
+LARC,4530,1,Key Issues in Landscape Arch,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,mary padua,
+LARC,4620,1,Design Implementation III,0.18,0.59,0.09,0.14,0.0,0.0,0.0,0.0,mary padua,
+LAW,3220,1,Legal Env of Bus,0.21,0.38,0.31,0.06,0.02,0.0,0.0,0.02,john hine,
+LAW,3220,4,Legal Env of Bus,0.17,0.37,0.35,0.07,0.02,0.0,0.0,0.02,kenneth sc toussaint,
+LAW,3220,5,Legal Env of Bus,0.23,0.35,0.31,0.1,0.0,0.0,0.0,0.0,kenneth sc toussaint,
+LAW,3220,6,Legal Env of Bus,0.37,0.41,0.18,0.02,0.02,0.0,0.0,0.0,kathr kisska-schulze,
+LAW,3220,7,Legal Env of Bus,0.37,0.49,0.08,0.04,0.02,0.0,0.0,0.0,kathr kisska-schulze,
+LAW,3220,8,Legal Env of Bus,0.31,0.48,0.1,0.06,0.04,0.0,0.0,0.0,kathr kisska-schulze,
+LAW,3220,9,Legal Env of Bus,0.3,0.51,0.19,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,10,Legal Env of Bus,0.3,0.33,0.26,0.04,0.02,0.0,0.0,0.04,edward ray claggett,
+LAW,3220,11,Legal Env of Bus,0.42,0.48,0.1,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,400,Legal Env of Bus,0.37,0.35,0.19,0.02,0.0,0.0,0.0,0.06,virginia ward-vaughn,
+LAW,3220,401,Legal Env of Bus,0.31,0.44,0.15,0.05,0.02,0.0,0.0,0.05,virginia ward-vaughn,
+LAW,3220,402,Legal Env of Bus,0.33,0.44,0.14,0.05,0.0,0.0,0.0,0.03,virginia ward-vaughn,
+LAW,3220,403,Legal Env of Bus,0.3,0.4,0.18,0.07,0.0,0.0,0.0,0.05,virginia ward-vaughn,
+LAW,3330,1,Real Estate Law,0.0,0.42,0.32,0.16,0.11,0.0,0.0,0.0,kenneth sc toussaint,
+LAW,3330,2,Real Estate Law,0.17,0.49,0.2,0.11,0.03,0.0,0.0,0.0,kenneth sc toussaint,
+LAW,4050,1,Construction Law,0.9,0.08,0.0,0.0,0.0,0.0,0.0,0.03,frances edwards,
+LS,1000,1,Therapeutic Yoga,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,ranjanbala dili amin,
+LS,1000,2,Therapeutic Yoga,0.77,0.14,0.05,0.0,0.0,0.0,0.0,0.05,ranjanbala dili amin,
+LS,1000,3,Therapeutic Yoga,0.82,0.09,0.0,0.0,0.05,0.0,0.0,0.05,renee warren gahan,
+LS,1000,8,Intro to Volleyball,0.79,0.07,0.07,0.07,0.0,0.0,0.0,0.0,kelly lynn ator,
+LS,1000,12,Introduction to Salsa,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,malik lewis  baxter c,
+LS,1000,13,Introduction to Salsa Dance,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,malik lewis  baxter c,
+LS,1570,2,Shotgun Sports,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,bonnie duke gill,
+LS,1570,3,Shotgun Sports,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,edward licus prater,
+LS,1580,3,Archery,0.55,0.27,0.0,0.0,0.0,0.0,0.0,0.18,herbert strickland,
+LS,1850,1,Bowling,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.09,madison neel workman,
+LS,1850,2,Bowling,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,
+LS,1850,3,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,kimberly coury,
+LS,1850,4,Bowling,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,alexandra sandoval,
+LS,1850,5,Bowling,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,alexandra sandoval,
+LS,1870,2,Frisbee Sports,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,steven simoneaux,
+LS,1980,9,Golf,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,wesley scott womble,
+LS,2270,2,Intro to Swing Dance,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,paul hoke,
+LS,2320,2,Core Training,0.68,0.21,0.0,0.0,0.05,0.0,0.0,0.05,diane moreno,
+LS,2320,3,Core Training,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,2320,4,Core Training,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,diane moreno,
+LS,2320,5,Core Training,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
+LS,2350,1,Basic Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2350,7,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,
+LS,2350,8,Basic Yoga,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2360,1,Power/Ashtanga Yoga,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,silica elizab larkin,
+LS,2360,2,Power/Ashtanga Yoga,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,silica elizab larkin,
+LS,2380,2,Vinyasa Flow Yoga,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,nicole eliz martinez,
+LS,2420,1,Meditation and Relax,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2420,2,Meditation and Relax,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,renee warren gahan,
+LS,2420,5,Meditation and Relax,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dili amin,
+LS,2420,6,Meditation and Relax,0.88,0.04,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dili amin,
+LS,2420,7,Meditation and Relax,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2420,9,Meditation and Relax,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,kayla lee wardlaw,
+LS,2450,1,Pilates,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,melanie ivey job,
+LS,2450,4,Pilates,0.77,0.05,0.0,0.0,0.14,0.0,0.0,0.05,diane moreno,
+LS,2450,8,Pilates,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
+LS,2750,10,First Aid/Cpr,0.86,0.07,0.07,0.0,0.0,0.0,0.0,0.0,christopher loomis,
+MATH,1010,1,Essen Math for Informed Soc,0.33,0.33,0.27,0.07,0.0,0.0,0.0,0.0,bryce pruitt,
+MATH,1010,2,Essen Math for Informed Soc,0.22,0.33,0.17,0.22,0.0,0.0,0.0,0.06,seth selken,
+MATH,1010,3,Essen Math for Informed Soc,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,seth selken,
+MATH,1010,4,Essen Math for Informed Soc,0.47,0.13,0.2,0.13,0.0,0.0,0.0,0.07,alexander joyce,
+MATH,1010,5,Essen Math for Informed Soc,0.47,0.35,0.06,0.06,0.06,0.0,0.0,0.0,bryce pruitt,
+MATH,1010,6,Essen Math for Informed Soc,0.39,0.39,0.17,0.0,0.06,0.0,0.0,0.0,alexander joyce,
+MATH,1010,7,Essen Math for Informed Soc,0.44,0.18,0.21,0.09,0.09,0.0,0.0,0.0,marilyn reba,
+MATH,1010,8,Essen Math for Informed Soc,0.44,0.31,0.19,0.0,0.0,0.0,0.0,0.06,seth selken,
+MATH,1010,9,Essen Math for Informed Soc,0.64,0.09,0.18,0.09,0.0,0.0,0.0,0.0,alexander joyce,
+MATH,1020,1,Business Calculus I,0.24,0.24,0.18,0.24,0.12,0.0,0.0,0.0,hannah grace rollins,
+MATH,1020,2,Business Calculus I,0.05,0.42,0.26,0.11,0.11,0.0,0.0,0.05,hannah grace rollins,
+MATH,1020,3,Business Calculus I,0.11,0.39,0.17,0.17,0.06,0.0,0.0,0.11,morgan elston,
+MATH,1020,4,Business Calculus I,0.06,0.39,0.28,0.28,0.0,0.0,0.0,0.0,morgan elston,
+MATH,1020,5,Business Calculus I,0.17,0.28,0.22,0.17,0.11,0.0,0.0,0.06,zachary ray johnston,
+MATH,1020,6,Business Calculus I,0.11,0.37,0.21,0.16,0.05,0.0,0.0,0.11,zachary ray johnston,
+MATH,1020,7,Business Calculus I,0.22,0.11,0.33,0.17,0.0,0.0,0.0,0.17,michael thomas cowen,
+MATH,1020,8,Business Calculus I,0.11,0.33,0.5,0.0,0.0,0.0,0.0,0.06,michael thomas cowen,
+MATH,1020,11,Business Calculus I,0.22,0.22,0.22,0.06,0.11,0.0,0.0,0.17,andrew pangia,
+MATH,1020,12,Business Calculus I,0.0,0.35,0.29,0.18,0.12,0.0,0.0,0.06,andrew gray pitman,
+MATH,1020,15,Business Calculus I,0.28,0.17,0.22,0.22,0.06,0.0,0.0,0.06,hemanta kunwar,
+MATH,1020,16,Business Calculus I,0.11,0.33,0.5,0.06,0.0,0.0,0.0,0.0,andrew gray pitman,
+MATH,1020,18,Business Calculus I,0.29,0.24,0.35,0.06,0.0,0.0,0.0,0.06,ebenezer eduafo,
+MATH,1020,19,Business Calculus I,0.28,0.39,0.11,0.06,0.11,0.0,0.0,0.06,andrew pangia,
+MATH,1020,20,Business Calculus I,0.12,0.29,0.12,0.18,0.24,0.0,0.0,0.06,michael gle eldredge,
+MATH,1020,21,Business Calculus I,0.22,0.22,0.33,0.06,0.17,0.0,0.0,0.0,hassan kiyadeh hami,
+MATH,1020,22,Business Calculus I,0.39,0.22,0.11,0.11,0.11,0.0,0.0,0.06,zachary david espe,
+MATH,1020,23,Business Calculus I,0.32,0.37,0.2,0.02,0.02,0.0,0.0,0.07,tony thanh nguyen,
+MATH,1020,24,Business Calculus I,0.39,0.28,0.17,0.11,0.0,0.0,0.0,0.06,zachary david espe,
+MATH,1020,25,Business Calculus I,0.24,0.47,0.12,0.06,0.06,0.0,0.0,0.06,nicholas john porter,
+MATH,1020,26,Business Calculus I,0.22,0.17,0.28,0.11,0.11,0.0,0.0,0.11,hemanta kunwar,
+MATH,1020,27,Business Calculus I,0.39,0.17,0.11,0.28,0.0,0.0,0.0,0.06,cameron arnold,
+MATH,1020,28,Business Calculus I,0.26,0.26,0.26,0.11,0.05,0.0,0.0,0.05,nicholas john porter,
+MATH,1020,29,Business Calculus I,0.25,0.2,0.28,0.05,0.13,0.0,0.0,0.1,marion hanna,
+MATH,1020,30,Business Calculus I,0.37,0.21,0.21,0.16,0.05,0.0,0.0,0.0,cameron arnold,
+MATH,1020,31,Business Calculus I,0.33,0.22,0.17,0.11,0.11,0.0,0.0,0.06,hassan kiyadeh hami,
+MATH,1020,33,Business Calculus I,0.17,0.17,0.28,0.11,0.17,0.0,0.0,0.11,michael gle eldredge,
+MATH,1020,34,Business Calculus I,0.24,0.34,0.22,0.1,0.07,0.0,0.0,0.02,marion hanna,
+MATH,1020,35,Business Calculus I,0.06,0.44,0.06,0.11,0.28,0.0,0.0,0.06,ebenezer eduafo,
+MATH,1020,38,Business Calculus I,0.29,0.29,0.21,0.14,0.02,0.0,0.0,0.05,tony thanh nguyen,
+MATH,1020,39,Business Calculus I,0.36,0.19,0.29,0.1,0.02,0.0,0.0,0.05,dyken jennifer  van e,
+MATH,1020,40,Business Calculus I,0.39,0.27,0.19,0.09,0.03,0.0,0.0,0.02,jennifer marie hanna,
+MATH,1020,41,Business Calculus I,0.47,0.23,0.18,0.08,0.01,0.0,0.0,0.03,jennifer marie hanna,
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.87,0.0,0.13,donna simms,
+MATH,1040,4,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.79,0.0,0.21,kristina gorsline,
+MATH,1040,5,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.68,0.0,0.32,aaron moose,
+MATH,1040,10,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,stephen peele,
+MATH,1040,11,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.8,0.0,0.2,emma cinatl,
+MATH,1050,402,Precalculus,0.0,0.0,0.0,0.0,0.0,0.87,0.0,0.13,tony thanh nguyen,
+MATH,1060,1,Calculus of One Variable I,0.21,0.19,0.21,0.07,0.17,0.0,0.0,0.14,timothy fran parrott,
+MATH,1060,2,Calculus of One Variable I,0.29,0.12,0.29,0.1,0.17,0.0,0.0,0.05,timothy fran parrott,
+MATH,1060,3,Calculus of One Variable I,0.23,0.2,0.25,0.07,0.16,0.0,0.0,0.09,timothy fran parrott,
+MATH,1060,4,Calculus of One Variable I,0.09,0.32,0.18,0.14,0.18,0.0,0.0,0.09,sofya alekseeva,
+MATH,1060,5,Calculus of One Variable I,0.19,0.16,0.19,0.26,0.09,0.0,0.0,0.12,sofya alekseeva,
+MATH,1060,6,Calculus of One Variable I,0.12,0.33,0.21,0.09,0.14,0.0,0.0,0.12,sofya alekseeva,
+MATH,1060,8,Calculus of One Variable I,0.36,0.25,0.14,0.06,0.09,0.0,0.0,0.1,judith el cottingham,
+MATH,1060,10,Calculus of One Variable I,0.24,0.27,0.23,0.05,0.14,0.0,0.0,0.07,judith el cottingham,
+MATH,1060,12,Calculus of One Variable I,0.32,0.27,0.16,0.07,0.16,0.0,0.0,0.02,hugh geller,
+MATH,1060,14,Calculus of One Variable I,0.13,0.28,0.16,0.03,0.22,0.0,0.0,0.19,valdez hiram lopez,
+MATH,1060,15,Calculus of One Variable I,0.27,0.16,0.25,0.16,0.11,0.0,0.0,0.05,blake antho splitter,
+MATH,1060,16,Calculus of One Variable I,0.33,0.19,0.23,0.07,0.09,0.0,0.0,0.09,stephen peele,
+MATH,1060,17,Calculus of One Variable I,0.15,0.24,0.12,0.15,0.22,0.0,0.0,0.12,valdez hiram lopez,
+MATH,1060,18,Calculus of One Variable I,0.17,0.37,0.14,0.09,0.09,0.0,0.0,0.14,marilyn reba,
+MATH,1060,19,Calculus of One Variable I,0.28,0.3,0.14,0.05,0.16,0.0,0.0,0.07,jason alexander kurz,
+MATH,1060,201,Calculus of One Variable I,0.44,0.33,0.12,0.05,0.05,0.0,0.0,0.02,camille zerfas,
+MATH,1060,202,Calculus of One Variable I,0.33,0.36,0.1,0.05,0.12,0.0,0.0,0.05,andrew walton green,
+MATH,1060,203,Calculus of One Variable I,0.31,0.31,0.23,0.03,0.06,0.0,0.0,0.06,charles lanning,
+MATH,1060,204,Calculus of One Variable I,0.31,0.31,0.22,0.02,0.09,0.0,0.0,0.04,scott scruggs,
+MATH,1060,205,Calculus of One Variable I,0.37,0.29,0.2,0.04,0.06,0.0,0.0,0.04,james edward gossell,
+MATH,1060,206,Calculus of One Variable I,0.2,0.24,0.37,0.0,0.17,0.0,0.0,0.02,catherine mar kenyon,
+MATH,1060,207,Calculus of One Variable I,0.24,0.33,0.12,0.07,0.14,0.0,0.0,0.1,rachel bass lanning,
+MATH,1060,208,Calculus of One Variable I,0.39,0.39,0.12,0.05,0.05,0.0,0.0,0.0,todd fenstermacher,
+MATH,1060,300,Calculus of One Variable I,0.32,0.16,0.29,0.16,0.03,0.0,0.0,0.03,matthew macauley,
+MATH,1070,1,Differen and Integral Calculus,0.08,0.35,0.38,0.08,0.12,0.0,0.0,0.0,donna simms,
+MATH,1080,1,Calculus of One Variable II,0.13,0.17,0.2,0.09,0.27,0.0,0.0,0.14,benjamin chris wiles,
+MATH,1080,2,Calculus of One Variable II,0.23,0.25,0.25,0.14,0.11,0.0,0.0,0.02,timothy cha teitloff,
+MATH,1080,3,Calculus of One Variable II,0.1,0.26,0.26,0.05,0.18,0.0,0.0,0.15,beth novick,
+MATH,1080,4,Calculus of One Variable II,0.14,0.23,0.25,0.09,0.2,0.0,0.0,0.09,timothy cha teitloff,
+MATH,1080,5,Calculus of One Variable II,0.28,0.23,0.3,0.02,0.12,0.0,0.0,0.05,timothy cha teitloff,
+MATH,1080,6,Calculus of One Variable II,0.27,0.22,0.2,0.07,0.1,0.0,0.0,0.15,meredith nicole burr,
+MATH,1080,7,Calculus of One Variable II,0.21,0.28,0.21,0.1,0.1,0.0,0.0,0.1,meredith nicole burr,
+MATH,1080,201,Calculus of One Variable II,0.34,0.14,0.23,0.09,0.11,0.0,0.0,0.09,fun choi john chan john,
+MATH,1150,1,Contemp Math for Elem Teach I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew mich tyminski,
+MATH,1150,2,Contemp Math for Elem Teach I,0.5,0.33,0.1,0.05,0.0,0.0,0.0,0.02,eliza darg gallagher,
+MATH,1160,1,Contemp Math for Elem Teach II,0.6,0.27,0.0,0.0,0.07,0.0,0.0,0.07,nicole alain sinwell,
+MATH,2060,1,Calculus of Several Variables,0.23,0.3,0.29,0.09,0.06,0.0,0.0,0.03,irina viktorova,
+MATH,2060,4,Calculus of Several Variables,0.18,0.2,0.22,0.18,0.13,0.0,0.0,0.1,oleg yordanov,
+MATH,2060,7,Calculus of Several Variables,0.3,0.36,0.17,0.04,0.1,0.0,0.0,0.02,irina viktorova,
+MATH,2060,10,Calculus of Several Variables,0.24,0.17,0.12,0.26,0.12,0.0,0.0,0.1,terri johnson,
+MATH,2060,11,Calculus of Several Variables,0.38,0.43,0.05,0.04,0.06,0.0,0.0,0.04,allen anderson guest,
+MATH,2060,12,Calculus of Several Variables,0.43,0.31,0.14,0.03,0.05,0.0,0.0,0.04,allen anderson guest,
+MATH,2060,14,Calculus of Several Variables,0.32,0.45,0.17,0.03,0.03,0.0,0.0,0.01,oleg yordanov,
+MATH,2060,15,Calculus of Several Variables,0.4,0.33,0.24,0.0,0.02,0.0,0.0,0.0,akshay sunil gupte,
+MATH,2060,19,Calculus of Several Variables,0.14,0.14,0.14,0.28,0.16,0.0,0.0,0.14,terri johnson,
+MATH,2060,20,Calculus of Several Variables,0.17,0.19,0.11,0.25,0.08,0.0,0.0,0.19,terri johnson,
+MATH,2060,100,Calc of Several Vars (HON),0.69,0.27,0.02,0.0,0.0,0.0,0.0,0.02,peter kiessler,True
+MATH,2060,201,Calculus of Several Variables,0.5,0.36,0.07,0.0,0.07,0.0,0.0,0.0,sanwar ahmad,
+MATH,2060,202,Calculus of Several Variables,0.24,0.31,0.22,0.02,0.04,0.0,0.0,0.16,martin johan schmoll,
+MATH,2070,1,Business Calculus II,0.12,0.35,0.12,0.06,0.35,0.0,0.0,0.0,haodong li,
+MATH,2070,2,Business Calculus II,0.0,0.44,0.39,0.06,0.11,0.0,0.0,0.0,haodong li,
+MATH,2070,3,Business Calculus II,0.0,0.33,0.17,0.22,0.11,0.0,0.0,0.17,thanh thien to,
+MATH,2070,4,Business Calculus II,0.11,0.33,0.22,0.22,0.11,0.0,0.0,0.0,todd anthony morra,
+MATH,2070,5,Business Calculus II,0.06,0.13,0.25,0.31,0.19,0.0,0.0,0.06,todd anthony morra,
+MATH,2070,6,Business Calculus II,0.27,0.07,0.33,0.13,0.07,0.0,0.0,0.13,ville madeleine  st e,
+MATH,2070,7,Business Calculus II,0.12,0.29,0.35,0.12,0.12,0.0,0.0,0.0,xiaoyuan liu,
+MATH,2070,8,Business Calculus II,0.17,0.39,0.28,0.06,0.06,0.0,0.0,0.06,xiaoyuan liu,
+MATH,2070,11,Business Calculus II,0.31,0.32,0.22,0.09,0.06,0.0,0.0,0.0,jennifer ray newton,
+MATH,2070,13,Business Calculus II,0.29,0.29,0.07,0.29,0.0,0.0,0.0,0.07,thanh thien to,
+MATH,2070,14,Business Calculus II,0.06,0.24,0.41,0.18,0.06,0.0,0.0,0.06,anna carol bachstein,
+MATH,2070,15,Business Calculus II,0.17,0.28,0.11,0.33,0.0,0.0,0.0,0.11,anna carol bachstein,
+MATH,2070,17,Business Calculus II,0.22,0.39,0.22,0.0,0.06,0.0,0.0,0.11,ville madeleine  st e,
+MATH,2070,18,Business Calculus II,0.33,0.18,0.28,0.14,0.05,0.0,0.0,0.02,jennifer ray newton,
+MATH,2070,19,Business Calculus II,0.18,0.24,0.18,0.12,0.12,0.0,0.0,0.18,thanh thien to,
+MATH,2070,20,Business Calculus II,0.0,0.21,0.07,0.14,0.36,0.0,0.0,0.21,todd anthony morra,
+MATH,2080,3,Intro to Ordin Diff Equations,0.13,0.28,0.41,0.05,0.07,0.0,0.0,0.07,pye phyo aung,
+MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.3,0.26,0.08,0.09,0.0,0.0,0.05,pye phyo aung,
+MATH,2080,5,Intro to Ordin Diff Equations,0.2,0.03,0.23,0.1,0.3,0.0,0.0,0.13,julie lassiter,
+MATH,2080,6,Intro to Ordin Diff Equations,0.14,0.23,0.26,0.14,0.14,0.0,0.0,0.09,julie lassiter,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.7,0.13,0.17,0.0,0.0,0.0,0.0,0.0,jeong rock yoon rock,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.39,0.39,0.17,0.02,0.02,0.0,0.0,0.0,allison kes stoddard,
+MATH,2160,2,Geometry for Elem Sch Teachers,0.7,0.2,0.0,0.05,0.0,0.0,0.0,0.05,allison kes stoddard,
+MATH,2500,1,Intro to Mathematical Sciences,0.95,0.04,0.01,0.0,0.0,0.0,0.0,0.0,mark cawood,
+MATH,3020,1,Stat for Science & Engineering,0.36,0.3,0.19,0.02,0.06,0.0,0.0,0.06,ellen hepfer breazel,
+MATH,3020,2,Stat for Science & Engineering,0.36,0.34,0.23,0.02,0.0,0.0,0.0,0.04,ellen hepfer breazel,
+MATH,3020,4,Stat for Science & Engineering,0.61,0.27,0.11,0.0,0.0,0.0,0.0,0.0,xin liu,
+MATH,3020,5,Stat for Science & Engineering,0.38,0.4,0.07,0.07,0.07,0.0,0.0,0.02,xiaoqian sun,
+MATH,3020,6,Stat for Science & Engineering,0.53,0.24,0.06,0.06,0.06,0.0,0.0,0.06, kamronnaher,
+MATH,3020,7,Stat for Science & Engineering,0.29,0.24,0.29,0.06,0.06,0.0,0.0,0.06, kamronnaher,
+MATH,3020,9,Stat for Science & Engineering,0.61,0.22,0.06,0.0,0.11,0.0,0.0,0.0,merenchig jayasekara,
+MATH,3020,10,Stat for Science & Engineering,0.29,0.29,0.14,0.0,0.14,0.0,0.0,0.14,merenchig jayasekara,
+MATH,3110,3,Linear Algebra,0.36,0.43,0.17,0.02,0.0,0.0,0.0,0.02,wayne goddard,
+MATH,3110,4,Linear Algebra,0.24,0.31,0.26,0.07,0.12,0.0,0.0,0.0,hui xue,
+MATH,3110,5,Linear Algebra,0.21,0.21,0.19,0.12,0.16,0.0,0.0,0.12,felice manganiello,
+MATH,3110,6,Linear Algebra,0.27,0.3,0.14,0.09,0.05,0.0,0.0,0.16,felice manganiello,
+MATH,3110,7,Linear Algebra,0.23,0.31,0.1,0.05,0.03,0.0,0.0,0.28,xuhong gao,
+MATH,3110,8,Linear Algebra,0.45,0.24,0.08,0.0,0.11,0.0,0.0,0.13,xuhong gao,
+MATH,3110,9,Linear Algebra,0.22,0.33,0.28,0.03,0.11,0.0,0.0,0.03,vincent ervin,
+MATH,3110,100,Linear Algebra (HON),0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,beth novick,True
+MATH,3110,200,Linear Algebra,0.62,0.23,0.08,0.0,0.08,0.0,0.0,0.0,beth novick,
+MATH,3190,1,Introduction to Proof,0.28,0.12,0.24,0.16,0.12,0.0,0.0,0.08,elena stan dimitrova,
+MATH,3190,2,Introduction to Proof,0.44,0.2,0.16,0.04,0.08,0.0,0.0,0.08,elena stan dimitrova,
+MATH,3600,2,Intermediate Math Computing,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,mark cawood,
+MATH,3650,1,Numerical Mthds for Engineers,0.14,0.42,0.32,0.04,0.04,0.0,0.0,0.04,eleanor jenkins,
+MATH,3650,2,Numerical Mthds for Engineers,0.23,0.23,0.4,0.09,0.02,0.0,0.0,0.02,hyesuk lee,
+MATH,3650,3,Numerical Mthds for Engineers,0.26,0.33,0.24,0.05,0.07,0.0,0.0,0.05,hyesuk lee,
+MATH,4000,1,Theory of Probability,0.3,0.22,0.3,0.04,0.0,0.0,0.0,0.15,brian fralix,
+MATH,4000,2,Theory of Probability,0.29,0.26,0.29,0.06,0.09,0.0,0.0,0.03,derek brown,
+MATH,4020,1,Stat for Sci & Engineering II,0.53,0.27,0.13,0.0,0.0,0.0,0.0,0.07,colin gallagher,
+MATH,4070,1,Regress & Time-Series Analysis,0.47,0.4,0.0,0.0,0.0,0.0,0.0,0.13,colin gallagher,
+MATH,4120,2,Algebra I,0.24,0.52,0.2,0.04,0.0,0.0,0.0,0.0,hui xue,
+MATH,4190,1,Discrete Math Structures I,0.36,0.52,0.08,0.04,0.0,0.0,0.0,0.0,wayne goddard,
+MATH,4190,2,Discrete Math Structures I,0.48,0.3,0.07,0.0,0.11,0.0,0.0,0.04,beth novick,
+MATH,4340,1,Adv Engineering Mathematics,0.4,0.15,0.15,0.0,0.05,0.0,0.0,0.25,eleanor jenkins,
+MATH,4340,2,Adv Engineering Mathematics,0.33,0.33,0.11,0.11,0.06,0.0,0.0,0.06,qingshan chen,
+MATH,4350,1,Complex Variables,0.67,0.08,0.08,0.08,0.0,0.0,0.0,0.08,shitao liu,
+MATH,4400,1,Linear Programming,0.57,0.13,0.09,0.09,0.04,0.0,0.0,0.09,yuyuan ouyang,
+MATH,4530,1,Advanced Calculus I,0.48,0.22,0.19,0.0,0.07,0.0,0.0,0.04,james peterson,
+MATH,4540,1,Advanced Calculus II,0.46,0.08,0.46,0.0,0.0,0.0,0.0,0.0,james peterson,
+MATH,4560,1,Topology,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,james bar coykendall,
+MATH,4630,1,Mathematical Analysis I,0.54,0.23,0.08,0.0,0.0,0.0,0.0,0.15,benjamin jaye,
+MATH,4910,2,Mathematics of Option Pricing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,mark cawood,
+MATH,6000,1,Theory of Probability,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,brian fralix,
+MATH,6340,1,Adv Engineering Mathematics,0.43,0.37,0.1,0.0,0.07,0.0,0.0,0.03,vincent ervin,
+MATH,8000,1,Probability,0.53,0.2,0.07,0.0,0.0,0.0,0.0,0.2,robert lund,
+MATH,8010,1,General Linear Hypothesis I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,derek brown,
+MATH,8050,1,Data Analysis,0.44,0.22,0.11,0.0,0.11,0.0,0.0,0.11,xiaoqian sun,
+MATH,8100,1,Mathematical Programming,0.5,0.32,0.18,0.0,0.0,0.0,0.0,0.0,boshi yang,
+MATH,8100,2,Mathematical Programming,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,yuyuan ouyang,
+MATH,8140,1,Network Flow Programming,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
+MATH,8170,1,Stochastic Mod in Oper Rsrch I,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,xin liu,
+MATH,8210,1,Linear Analysis,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,benjamin jaye,
+MATH,8250,1,Intro to Dynamical Syst Theory,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,martin johan schmoll,
+MATH,8530,1,Matrix Analysis,0.44,0.25,0.19,0.0,0.06,0.0,0.0,0.06,sean sather-wagstaff,
+MATH,8600,1,Intro to Scientific Computing,0.36,0.43,0.14,0.0,0.0,0.0,0.0,0.07,fei xue,
+MATH,8610,1,Advanced Numerical Analysis I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,qingshan chen,
+MATH,8650,1,Data Structures,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,matthew saltzman,
+MATH,8820,1,Intro to Bayesian Statistics,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,christopher mcmahan,
+MBA,8030,1,Stat Analy of Bus Op,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett wood,
+MBA,8030,2,Stat Analy of Bus Op,0.51,0.46,0.0,0.0,0.03,0.0,0.0,0.0,william ed kilbourne,
+MBA,8040,20,Busin Data An & Stat Computing,0.62,0.35,0.0,0.0,0.0,0.0,0.0,0.03,william ed kilbourne,
+MBA,8060,1,Operations Mgt,0.24,0.56,0.2,0.0,0.0,0.0,0.0,0.0, sridharan,
+MBA,8060,2,Operations Mgt,0.22,0.67,0.11,0.0,0.0,0.0,0.0,0.0,george kennet morgan,
+MBA,8070,1,Financial Management,0.67,0.28,0.03,0.0,0.0,0.0,0.0,0.03,george bran lockhart,
+MBA,8070,2,Financial Management,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,george bran lockhart,
+MBA,8090,1,Org Beh & Hum Res Mg,0.43,0.55,0.02,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,
+MBA,8090,2,Org Beh & Hum Res Mg,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,thomas jos zagenczyk,
+MBA,8180,20,Intro Business Intell & Anlytc,0.79,0.15,0.03,0.0,0.0,0.0,0.0,0.03,heshan sun,
+MBA,8190,1,Intro to Acc and Fin,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,
+MBA,8190,2,Intro to Acc and Fin,0.45,0.37,0.03,0.0,0.05,0.0,0.0,0.11,jeffrey mcmillan,
+MBA,8290,1,Marketing Foundation,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MBA,8310,10,Communications and Sales,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,
+MBA,8370,1,Legal Environ of Bus,0.42,0.45,0.13,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8370,2,Legal Environ of Bus,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
+MBA,8430,1,Entrepreneurial Accounting,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,annieka philo,
+MBA,8440,1,Entrepreneurial Law,0.29,0.57,0.14,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8450,1,Technology & Innovation Mgt,0.72,0.2,0.04,0.0,0.0,0.0,0.0,0.04,michael george mino,
+MBA,8480,5,Entrpr Mkting & Digital Strat,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,bruce snyder,
+MBA,8490,5,Entrepreneurial Strategy,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,matthew charle klein,
+MBA,8510,1,Bus Operations & Logistics,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0, sridharan,
+MBA,8540,1,Managerial Accounting,0.35,0.58,0.05,0.0,0.0,0.0,0.0,0.03,emily suzan mccorkle,
+MBA,8590,1,Mgr Decision Model,0.23,0.27,0.15,0.0,0.27,0.0,0.0,0.08,sara elizabeth yoder,
+MBA,8590,2,Mgr Decision Model,0.45,0.37,0.18,0.0,0.0,0.0,0.0,0.0,magda gabriela sava,
+MBA,8590,3,Mgr Decision Model,0.08,0.54,0.31,0.0,0.08,0.0,0.0,0.0,magda gabriela sava,
+MBA,8600,1,Advanced Marketing Strategy,0.35,0.38,0.25,0.0,0.0,0.0,0.0,0.03,michael dorsch,
+MBA,8600,2,Advanced Marketing Strategy,0.21,0.56,0.23,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8610,2,Information Systems,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,kevin mckenzie,
+MBA,8620,1,Managerial Economics,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,scott templeton,
+MBA,8620,2,Managerial Economics,0.62,0.34,0.0,0.0,0.0,0.0,0.0,0.03,ronald earle gregory,
+MBA,8620,4,Managerial Economics,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,
+MBA,8650,1,Taxation of Business Decisions,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8660,21,"Data, Storage, Business Decis",0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
+MBA,8700,1,Strategic Management,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,james turner,
+MBA,8990,2,Creativity,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,kathleen ann kegley,
+ME,2000,1,Sophomore Seminar,0.87,0.04,0.02,0.01,0.01,0.0,0.0,0.05,todd al schweisinger,
+ME,2000,2,Sophomore Seminar,0.83,0.07,0.04,0.02,0.0,0.0,0.0,0.05,todd al schweisinger,
+ME,2010,1,Statics & Dynamics,0.12,0.2,0.29,0.08,0.19,0.0,0.0,0.11,marisa kikendall orr,
+ME,2010,2,Statics & Dynamics,0.11,0.23,0.25,0.07,0.27,0.0,0.0,0.06,paul joseph,
+ME,2010,4,Statics & Dynamics,0.04,0.17,0.23,0.13,0.29,0.0,0.0,0.13,lonny thompson,
+ME,2030,1,Founda Th/Fl Syst,0.0,0.08,0.42,0.17,0.1,0.0,0.0,0.23,john saylor,
+ME,2220,2,Mechanical Engineering Lab I,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,
+ME,2220,3,Mechanical Engineering Lab I,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,5,Mechanical Engineering Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,6,Mechanical Engineering Lab I,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,7,Mechanical Engineering Lab I,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,todd al schweisinger,
+ME,2220,8,Mechanical Engineering Lab I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,13,Mechanical Engineering Lab I,0.06,0.88,0.06,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,15,Mechanical Engineering Lab I,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,
+ME,2220,16,Mechanical Engineering Lab I,0.25,0.42,0.25,0.0,0.08,0.0,0.0,0.0,todd al schweisinger,
+ME,3030,1,Thermodynamics,0.3,0.45,0.16,0.02,0.06,0.0,0.0,0.01,yiqiang han,
+ME,3030,2,Thermodynamics,0.3,0.37,0.22,0.08,0.0,0.0,0.0,0.03,yiqiang han,
+ME,3050,1,Model/an Dy Syst,0.19,0.26,0.4,0.05,0.07,0.0,0.0,0.02,joshua bostwick,
+ME,3050,2,Model/an Dy Syst,0.31,0.31,0.2,0.11,0.04,0.0,0.0,0.02,ardalan vahidi,
+ME,3060,1,Fund Machine Design,0.3,0.55,0.09,0.0,0.0,0.0,0.0,0.06,oliver myers,
+ME,3060,2,Fund Machine Design,0.24,0.52,0.22,0.02,0.0,0.0,0.0,0.0,james allen righter,
+ME,3070,1,Found of Mechanical Systems,0.23,0.49,0.2,0.04,0.03,0.0,0.0,0.01,jorge ivan rodriguez,
+ME,3070,2,Found of Mechanical Systems,0.43,0.38,0.14,0.02,0.0,0.0,0.0,0.03,jorge ivan rodriguez,
+ME,3080,1,Fluid Mechanics,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,
+ME,3080,2,Fluid Mechanics,0.28,0.3,0.3,0.04,0.04,0.0,0.0,0.02,yiqiang han,
+ME,3080,3,Fluid Mechanics,0.06,0.44,0.41,0.05,0.03,0.0,0.0,0.01,ethan kung,
+ME,3120,1,Manuf Processes,0.83,0.15,0.01,0.0,0.01,0.0,0.0,0.0,rodr martinez-duarte,
+ME,3330,1,Mechanical Engineering Lab II,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,
+ME,3330,2,Mechanical Engineering Lab II,0.25,0.44,0.25,0.06,0.0,0.0,0.0,0.0,james allen righter,
+ME,3330,3,Mechanical Engineering Lab II,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,
+ME,3330,6,Mechanical Engineering Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,james allen righter,
+ME,3330,7,Mechanical Engineering Lab II,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,james allen righter,
+ME,3330,8,Mechanical Engineering Lab II,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,james allen righter,
+ME,3330,9,Mechanical Engineering Lab II,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,james allen righter,
+ME,3330,10,Mechanical Engineering Lab II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,james allen righter,
+ME,4010,1,Mech Engr Design,0.3,0.59,0.08,0.0,0.0,0.0,0.0,0.03,joshua summers,
+ME,4010,2,Mech Engr Design,0.29,0.59,0.11,0.0,0.02,0.0,0.0,0.0,joshua summers,
+ME,4010,3,Mech Engr Design,0.26,0.59,0.1,0.02,0.03,0.0,0.0,0.0,joshua summers,
+ME,4020,1,Intern in Engr Des,0.25,0.69,0.06,0.0,0.0,0.0,0.0,0.0,cameron turner,
+ME,4020,3,Intern in Engr Des,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,4,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lonny thompson,
+ME,4030,2,Control Dynamic Systems,0.34,0.36,0.26,0.01,0.01,0.0,0.0,0.01,suyi li,
+ME,4210,1,Intro to Comp Flow,0.33,0.43,0.19,0.05,0.0,0.0,0.0,0.0,chenning tong,
+ME,4290,1,Ther Env Control,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,
+ME,4400,1,Matls for Aggr Envir,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,garrett pataky,
+ME,4440,6,Mechanical Engineering Lab III,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4540,1,Design of Machine Elements,0.24,0.62,0.1,0.0,0.05,0.0,0.0,0.0,hong seok choi,
+ME,4930,14,Sel.Topics ME - NonLinDy&Chas,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,
+ME,4930,39,Sel.Topics ME - Aero Propul,0.47,0.45,0.09,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,6540,1,Des Machine Elements,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+ME,6540,843,Des Machine Elements,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+ME,6930,14,Sel.Topics ME - NonLinDy&Chas,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,
+ME,8010,1,Found of Fluid Mech,0.48,0.38,0.14,0.0,0.0,0.0,0.0,0.0,richard figliola,
+ME,8100,1,Macroscopic Thermo,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jay ochterbeck,
+ME,8180,1,Intro to Fin Ele Ana,0.44,0.49,0.05,0.0,0.0,0.0,0.0,0.02,gang li,
+ME,8230,1,Control Systems,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,
+ME,8360,1,Fracture Mech,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,8460,1,Inter Dynamics,0.56,0.11,0.33,0.0,0.0,0.0,0.0,0.0,phanind tallapragada,
+ME,8710,1,Engr Optimization,0.47,0.35,0.06,0.0,0.06,0.0,0.0,0.06,georges fadel,
+ME,8930,9,Sel Topics - Continuum Mech.,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,gang li,
+ME,8930,27,SelTopics ME - OptimalControls,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
+ME,8930,37,SelTopics ME - Laser Based Mfg,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,xin zhao,
+MGT,2010,1,Principles of Management,0.38,0.43,0.17,0.02,0.01,0.0,0.0,0.0,katherine clark,
+MGT,2010,2,Principles of Management,0.56,0.34,0.08,0.01,0.01,0.0,0.0,0.01,tina robbins,
+MGT,2010,8,Principles of Management,0.33,0.45,0.23,0.0,0.0,0.0,0.0,0.0,christopher mann,
+MGT,2010,9,Principles of Management,0.3,0.5,0.15,0.03,0.03,0.0,0.0,0.0,christopher mann,
+MGT,2010,10,Principles of Management,0.25,0.39,0.34,0.0,0.0,0.0,0.0,0.02,ashley willi parnell,
+MGT,2010,11,Principles of Management,0.16,0.32,0.32,0.11,0.02,0.0,0.0,0.07,ashley willi parnell,
+MGT,2180,1,Management PC Applications,0.47,0.38,0.08,0.03,0.02,0.0,0.0,0.02,ryan toole,
+MGT,2180,2,Management PC Applications,0.2,0.56,0.16,0.08,0.0,0.0,0.0,0.0,ryan toole,
+MGT,3070,1,Human Resource Management,0.38,0.48,0.15,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
+MGT,3070,3,Human Resource Management,0.45,0.45,0.08,0.0,0.03,0.0,0.0,0.0,kristin dama scott dama,
+MGT,3070,4,Human Resource Management,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,5,Human Resource Management,0.33,0.46,0.21,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
+MGT,3070,6,Human Resource Management,0.6,0.33,0.08,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,7,Human Resource Management,0.28,0.55,0.15,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,
+MGT,3070,8,Human Resource Management,0.42,0.33,0.15,0.06,0.0,0.0,0.0,0.03,priscilla harrison,
+MGT,3100,1,Intermed Business Statistics,0.07,0.39,0.34,0.08,0.03,0.0,0.0,0.08,janis miller,
+MGT,3100,2,Intermed Business Statistics,0.37,0.4,0.2,0.03,0.0,0.0,0.0,0.0,mustafa serka akturk,
+MGT,3100,3,Intermed Business Statistics,0.35,0.3,0.13,0.05,0.08,0.0,0.0,0.1,daniel nielubowicz,
+MGT,3100,5,Intermed Business Statistics,0.3,0.38,0.23,0.0,0.03,0.0,0.0,0.08,mustafa serka akturk,
+MGT,3100,6,Intermed Business Statistics,0.2,0.46,0.2,0.02,0.07,0.0,0.0,0.07,magda gabriela sava,
+MGT,3100,7,Intermed Business Statistics,0.36,0.19,0.17,0.06,0.17,0.0,0.0,0.06,daniel nielubowicz,
+MGT,3100,8,Intermed Business Statistics,0.31,0.24,0.21,0.05,0.07,0.0,0.0,0.12,iaroslava vo dutchak,
+MGT,3100,9,Intermed Business Statistics,0.69,0.24,0.05,0.0,0.02,0.0,0.0,0.0,maneeshred ajjuguttu,
+MGT,3100,10,Intermed Business Statistics,0.56,0.25,0.13,0.03,0.0,0.0,0.0,0.03,jeromy blake snider,
+MGT,3100,12,Intermed Business Statistics,0.3,0.19,0.24,0.08,0.08,0.0,0.0,0.11,daniel allan detoma,
+MGT,3120,1,Decision Models for Management,0.22,0.21,0.27,0.08,0.08,0.0,0.0,0.14,sara elizabeth yoder,
+MGT,3120,2,Decision Models for Management,0.19,0.31,0.34,0.02,0.1,0.0,0.0,0.05,sara elizabeth yoder,
+MGT,3120,4,Decision Models for Management,0.29,0.37,0.26,0.0,0.05,0.0,0.0,0.03,james turner,
+MGT,3180,1,Mgt of Info Systems,0.86,0.09,0.02,0.02,0.0,0.0,0.0,0.0,shih lun tseng,
+MGT,3180,2,Mgt of Info Systems,0.28,0.33,0.3,0.05,0.0,0.0,0.0,0.05,marten risius,
+MGT,3180,3,Mgt of Info Systems,0.87,0.12,0.02,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,
+MGT,3180,4,Mgt of Info Systems,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,daniel aaron pienta,
+MGT,3180,5,Mgt of Info Systems,0.4,0.35,0.23,0.0,0.0,0.0,0.0,0.03,wenxi pu,
+MGT,3900,1,Operations Management,0.15,0.5,0.28,0.05,0.03,0.0,0.0,0.0,yann ferrand,
+MGT,3900,2,Operations Management,0.08,0.5,0.38,0.03,0.0,0.0,0.0,0.03,zachary mor leffakis,
+MGT,3900,4,Operations Management,0.12,0.33,0.26,0.08,0.06,0.0,0.0,0.15, sridharan,
+MGT,4000,1,Mgt of Organizational Behavior,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,2,Mgt of Organizational Behavior,0.73,0.25,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,3,Mgt of Organizational Behavior,0.25,0.35,0.38,0.0,0.0,0.0,0.0,0.03,thomas jos zagenczyk,
+MGT,4000,4,Mgt of Organizational Behavior,0.15,0.46,0.28,0.03,0.0,0.0,0.0,0.08,philip roth,
+MGT,4020,1,Ops Pln and Ctl,0.06,0.33,0.56,0.06,0.0,0.0,0.0,0.0,zachary mor leffakis,
+MGT,4080,1,Lean Operations,0.14,0.5,0.27,0.05,0.05,0.0,0.0,0.0,zachary mor leffakis,
+MGT,4110,1,Project Management,0.23,0.6,0.13,0.0,0.0,0.0,0.0,0.05,russell purvis,
+MGT,4120,1,Supplier Management,0.42,0.53,0.03,0.0,0.03,0.0,0.0,0.0,ahmet colak,
+MGT,4150,1,Business Strategy,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,2,Business Strategy,0.16,0.44,0.33,0.02,0.0,0.0,0.0,0.04,james liddle,
+MGT,4150,3,Business Strategy,0.12,0.64,0.21,0.02,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,4,Business Strategy,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
+MGT,4150,6,Business Strategy,0.11,0.37,0.45,0.05,0.0,0.0,0.0,0.03,james liddle,
+MGT,4150,9,Business Strategy,0.36,0.52,0.11,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
+MGT,4160,1,Special Topics Hr,0.34,0.42,0.18,0.05,0.0,0.0,0.0,0.0,kristin dama scott dama,
+MGT,4230,1,Intern Bus Mgt,0.07,0.33,0.55,0.0,0.02,0.0,0.0,0.02,wayne stewart,
+MGT,4230,2,Intern Bus Mgt,0.2,0.15,0.57,0.07,0.02,0.0,0.0,0.0,wayne stewart,
+MGT,4230,3,Intern Bus Mgt,0.05,0.53,0.38,0.03,0.0,0.0,0.0,0.03,janis miller,
+MGT,4230,4,Intern Bus Mgt,0.09,0.59,0.25,0.07,0.0,0.0,0.0,0.0,janis miller,
+MGT,4240,1,Global Supply Chain,0.32,0.44,0.24,0.0,0.0,0.0,0.0,0.0,yann ferrand,
+MGT,4270,2,Managing Improvement,0.25,0.35,0.35,0.0,0.05,0.0,0.0,0.0,lawrence fredendall,
+MGT,4310,1,Emp Rights & Resp,0.44,0.49,0.08,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
+MGT,4350,1,Pers Interviewing,0.34,0.39,0.16,0.11,0.0,0.0,0.0,0.0,philip roth,
+MGT,4520,1,Business Analysis,0.21,0.36,0.27,0.03,0.03,0.0,0.0,0.09,marten risius,
+MGT,8690,1,Project Mgt,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
+MICR,2050,1,Introductory Micro,0.38,0.43,0.19,0.01,0.0,0.0,0.0,0.0,john abercrombie,
+MICR,3050,1,General Microbiology,0.29,0.42,0.24,0.03,0.01,0.0,0.0,0.02,krista barri rudolph,
+MICR,3050,2,General Microbiology,0.52,0.37,0.09,0.02,0.0,0.0,0.0,0.0,krista barri rudolph,
+MICR,4010,1,Microbial Diversity & Ecology,0.19,0.34,0.33,0.08,0.02,0.0,0.0,0.05,barbara campbell,
+MICR,4050,1,Adv Microbial Ecol of Humans,0.5,0.26,0.16,0.09,0.0,0.0,0.0,0.0,kristi jam whitehead,
+MICR,4140,1,Basic Immunology,0.46,0.28,0.15,0.09,0.0,0.0,0.0,0.02,yanzhang wei,
+MICR,4150,1,Microbial Genetics,0.2,0.49,0.22,0.09,0.0,0.0,0.0,0.0,min cao,
+MICR,4160,1,Intro Virology,0.69,0.2,0.09,0.0,0.01,0.0,0.0,0.01,kristi jam whitehead,
+MICR,4510,1,Advanced Microbiology II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4510,2,Advanced Microbiology II,0.45,0.5,0.0,0.0,0.05,0.0,0.0,0.0,harry kurtz,
+MICR,4510,3,Advanced Microbiology II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4560,1,Medical and Vet Parasitology,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kears milhous,
+MICR,4940,11,CI: Microbes All Around Us,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,kristi jam whitehead,
+MKT,3010,1,Principles of Marketing,0.19,0.4,0.27,0.1,0.02,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,2,Principles of Marketing,0.32,0.34,0.21,0.09,0.02,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,3,Principles of Marketing,0.33,0.33,0.26,0.05,0.02,0.0,0.0,0.01,amanda cooper fine,
+MKT,3010,4,Principles of Marketing,0.27,0.41,0.24,0.05,0.03,0.0,0.0,0.0,carter will mcelveen,
+MKT,3010,5,Principles of Marketing,0.36,0.34,0.22,0.06,0.02,0.0,0.0,0.01,carter will mcelveen,
+MKT,3010,7,Principles of Marketing,0.27,0.41,0.23,0.01,0.01,0.0,0.0,0.07,james gaubert,
+MKT,3020,1,Consumer Behavior,0.37,0.46,0.15,0.02,0.0,0.0,0.0,0.0,jennifer dia siemens,
+MKT,3020,2,Consumer Behavior,0.41,0.41,0.18,0.0,0.0,0.0,0.0,0.0,jennifer dia siemens,
+MKT,3020,3,Consumer Behavior,0.51,0.38,0.09,0.0,0.0,0.0,0.0,0.02,anastasia el thyroff,
+MKT,3020,4,Consumer Behavior,0.37,0.51,0.12,0.0,0.0,0.0,0.0,0.0,anastasia el thyroff,
+MKT,3020,5,Consumer Behavior,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,3210,1,Sports Marketing,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,
+MKT,3210,2,Sports Marketing,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,
+MKT,3220,1,Social Media Marketing,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,3220,2,Social Media Marketing,0.82,0.15,0.03,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,3220,3,Social Media Marketing,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,michele melto cauley,
+MKT,3220,4,Social Media Marketing,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michele melto cauley,
+MKT,3310,1,Marketing Metrics & Analytics,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,oriana rachel aragon,
+MKT,3310,2,Marketing Metrics & Analytics,0.67,0.28,0.03,0.0,0.03,0.0,0.0,0.0,oriana rachel aragon,
+MKT,3310,3,Marketing Metrics & Analytics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,3310,4,Marketing Metrics & Analytics,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4200,1,Professional Selling,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,2,Professional Selling,0.71,0.23,0.06,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4200,3,Professional Selling,0.65,0.31,0.04,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4200,5,Professional Selling,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,carter will mcelveen,
+MKT,4230,1,Promotional Strategy,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,4230,2,Promotional Strategy,0.77,0.16,0.03,0.03,0.0,0.0,0.0,0.0,michele melto cauley,
+MKT,4230,3,Promotional Strategy,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,michele melto cauley,
+MKT,4240,1,Sales Management,0.32,0.62,0.06,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4270,1,International Marketing,0.51,0.46,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4270,2,International Marketing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4270,3,International Marketing,0.26,0.6,0.12,0.0,0.0,0.0,0.0,0.02,thomas poehlman,
+MKT,4270,4,International Marketing,0.58,0.3,0.1,0.01,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,4280,1,Services Marketing,0.38,0.49,0.14,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4280,2,Services Marketing,0.41,0.46,0.14,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4310,3,Marketing Research,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,4,Marketing Research,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4450,1,Macromarketing,0.52,0.44,0.04,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,
+MKT,4500,3,Strategic Mktg Mgt,0.25,0.5,0.21,0.04,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,8610,1,Marketing Research,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,
+MKT,8630,1,Buyer Behavior,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
+ML,2010,1,Leadership Development I,0.44,0.33,0.22,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,2010,2,Leadership Development I,0.76,0.12,0.0,0.06,0.06,0.0,0.0,0.0,vincent john presto,
+ML,2010,3,Leadership Development I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,3010,1,Advanced Leadership I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william cody cleland,
+ML,3010,2,Advanced Leadership I,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,william cody cleland,
+MSE,2100,1,Intro to Materials Science,0.34,0.27,0.16,0.12,0.04,0.0,0.0,0.07,rakhee pani,
+MSE,2100,2,Intro to Materials Science,0.07,0.29,0.37,0.13,0.06,0.0,0.0,0.07,kai he,
+MSE,2100,3,Intro to Materials Science,0.24,0.37,0.25,0.06,0.04,0.0,0.0,0.04,kyle brinkman,
+MSE,2100,4,Intro to Materials Science,0.27,0.33,0.23,0.09,0.04,0.0,0.0,0.04,marian kennedy,
+MSE,2100,5,Introduction to Materials Sci,0.41,0.29,0.09,0.18,0.0,0.0,0.0,0.03,olga kuksenok,
+MSE,3010,4,Materials Synthesis & Fabr Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
+MSE,3190,1,Materials Proc I,0.35,0.55,0.09,0.0,0.0,0.0,0.0,0.01,rajendra kuma bordia,
+MSE,3190,2,Materials Proc I,0.2,0.47,0.2,0.13,0.0,0.0,0.0,0.0,rajendra kuma bordia,
+MSE,3260,1,Thermo of Materials,0.23,0.37,0.26,0.09,0.03,0.0,0.0,0.03,fei peng,
+MSE,3260,2,Thermo of Materials,0.18,0.47,0.18,0.13,0.0,0.0,0.0,0.03,fei peng,
+MSE,3270,1,Transport Phenomena,0.38,0.23,0.23,0.08,0.08,0.0,0.0,0.0,ulf daniel schiller,
+MSE,4020,1,Solid State Material,0.45,0.14,0.3,0.07,0.02,0.0,0.0,0.02,luiz gusta jacobsohn,
+MSE,4130,1,Noncrystalline Materials,0.54,0.38,0.0,0.04,0.04,0.0,0.0,0.0,jianhua tong,
+MSE,4150,1,Polymer Sc Engr,0.42,0.33,0.18,0.06,0.0,0.0,0.0,0.0,igor luzinov,
+MSE,4150,2,Polymer Sc Engr,0.5,0.19,0.24,0.02,0.02,0.0,0.0,0.04,rakhee pani,
+MSE,4320,1,Manuf Proc & Systems,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
+MSE,4580,1,Surf Phen in Ms&E,0.25,0.17,0.33,0.08,0.13,0.0,0.0,0.04,konstantin ge kornev,
+MSE,4610,1,Polymer & Fiber Materials III,0.92,0.04,0.0,0.0,0.04,0.0,0.0,0.0,philip brown,
+MSE,4810,1,Undergraduate Research Fundame,0.64,0.22,0.11,0.02,0.0,0.0,0.0,0.0,marian kennedy,
+MSE,4910,1,Undergraduate Research,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kuma bordia,
+MSE,8100,1,Fundamentals of Materials Sci,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,igor luzinov,
+MSE,8260,1,Phase Equil Mat Sys,0.43,0.5,0.0,0.0,0.07,0.0,0.0,0.0,stephen foulger,
+MSE,8270,1,Kin of Phase Tran,0.5,0.33,0.11,0.0,0.06,0.0,0.0,0.0,konstantin ge kornev,
+MUSC,1420,1,Music Theory I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david conley,
+MUSC,1430,1,Aural Skills I,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,david conley,
+MUSC,1510,2,Applied Music,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,jonathan edwar doyel,
+MUSC,2100,2,Music in the Western World,0.53,0.41,0.03,0.0,0.0,0.0,0.0,0.03,lisa sain odom,
+MUSC,2100,4,Music in the Western World,0.58,0.1,0.13,0.06,0.0,0.0,0.0,0.13,linda li-bleuel,
+MUSC,2100,6,Music in the Western World,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,7,Music in the Western World,0.33,0.47,0.17,0.0,0.03,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,8,Music in the Western World,0.44,0.48,0.04,0.0,0.0,0.0,0.0,0.04,rhea beth jacobus,
+MUSC,2100,12,Music in the Western World,0.72,0.19,0.0,0.0,0.03,0.0,0.0,0.06,lea kibler,
+MUSC,3110,1,History of American Music,0.65,0.26,0.03,0.03,0.03,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.75,0.18,0.04,0.04,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,3170,1,Hist of Country Mus,0.72,0.19,0.0,0.03,0.03,0.0,0.0,0.03,ned hosler,
+MUSC,3180,1,Hist of Audio Tech,0.42,0.37,0.11,0.05,0.05,0.0,0.0,0.0,bruce allen whisler,
+MUSC,3610,1,Marching Band,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
+MUSC,3980,1,Special Topics,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,hamilton altstatt,
+MUSC,4150,1,Music Hist to 1750,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,linda dzuris,
+NPL,3000,1,Nonprofit Leadership,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,christina mari mazer,
+NPL,3000,2,Nonprofit Leadership,0.33,0.61,0.0,0.0,0.06,0.0,0.0,0.0,bonnie westb stevens,
+NPL,3000,3,Nonprofit Leadership,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,christina mari mazer,
+NPL,3000,4,Nonprofit Leadership,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,corey doug brookover,
+NPL,3000,5,Nonprofit Leadership,0.55,0.2,0.2,0.0,0.05,0.0,0.0,0.0,corey doug brookover,
+NPL,3000,6,Nonprofit Leadership,0.45,0.45,0.05,0.0,0.05,0.0,0.0,0.0,corey doug brookover,
+NPL,3000,7,Nonprofit Leadership,0.3,0.5,0.05,0.05,0.0,0.0,0.0,0.1,bonnie westb stevens,
+NPL,3000,8,Nonprofit Leadership,0.58,0.29,0.08,0.0,0.04,0.0,0.0,0.0,christina mari mazer,
+NPL,3000,9,Nonprofit Leadership,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,christina mari mazer,
+NPL,3010,1,NPL Stakeholders,0.5,0.33,0.06,0.0,0.11,0.0,0.0,0.0,christina mari mazer,
+NPL,3020,1,NPL Fundraising,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,robert brookover,
+NPL,3030,1,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,corey doug brookover,
+NPL,3040,1,NPL Risk Management,0.7,0.1,0.0,0.15,0.05,0.0,0.0,0.0,daniel morg anderson,
+NPL,3050,2,Strat Social Media for NP Org,0.44,0.22,0.19,0.0,0.11,0.0,0.0,0.04,amanda elizabe moore,
+NURS,3030,1,Nursing of Adults,0.42,0.56,0.02,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3040,1,Pathophysiology,0.45,0.35,0.15,0.02,0.03,0.0,0.0,0.0,catherine sik murton,
+NURS,3040,2,Pathophysiology,0.36,0.55,0.05,0.04,0.0,0.0,0.0,0.0,amy boggs garrison,
+NURS,3040,400,Pathophysiology,0.44,0.52,0.0,0.04,0.0,0.0,0.0,0.0,amy boggs garrison,
+NURS,3040,401,Pathophysiology,0.73,0.23,0.04,0.0,0.0,0.0,0.0,0.0,elizabeth cam hassen,
+NURS,3050,1,Psychosocial Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
+NURS,3100,400,Health Assessment,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,
+NURS,3120,1,Foundations of Nursing,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,
+NURS,3120,2,Foundations of Nursing,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,
+NURS,3120,400,Foundations of Nursing,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,
+NURS,3200,1,Prof in Nurs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3300,1,Research in Nursing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,3330,400,Health Care Genetics,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,
+NURS,3400,1,Pharmther Nursing,0.45,0.35,0.12,0.05,0.03,0.0,0.0,0.0,catherine sik murton,
+NURS,3400,2,Pharmther Nursing,0.39,0.46,0.11,0.04,0.0,0.0,0.0,0.0,jenna lynn seawright,
+NURS,3400,400,Pharmther Nursing,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,jenna lynn seawright,
+NURS,3600,400,Social Determinants in Health,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
+NURS,4010,1,Mental Health Nurs,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,
+NURS,4060,400,Issues in Professionalism,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
+NURS,4110,1,Nursing of Children,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
+NURS,4120,1,Nurs Women and Fam,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4250,400,Community Nursing,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,tiffany leah stewart,
+NURS,4980,17,Neonatal Abstinence Syndrome,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,heide temples,
+NURS,8040,400,Dev Nurs Knowledge,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,stephanie clar davis,
+NURS,8050,400,Pharmaco Adv Nurs,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8050,401,Pharmaco Adv Nurs,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8060,400,Advan Assessment for Nursing,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,jennifer geter rice,
+NURS,8090,400,Pathophysiology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
+NURS,8180,400,Develop Family in Primary Care,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8190,400,Developing Family,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8200,400,Child & Adol Nursing,0.58,0.38,0.0,0.0,0.04,0.0,0.0,0.0,heide temples,
+NURS,9010,1,"DNP Role, Theory & Philosophy",0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,jean ellen zavertnik,
+NURS,9020,1,DNP Clinical Epidem & Biostats,0.38,0.46,0.08,0.0,0.0,0.0,0.0,0.08,veronica parker,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.86,0.09,0.0,0.01,0.03,0.0,0.0,0.0,bridgit deni corbett,
+NUTR,2030,2,Intro Princ of Human Nutrition,0.67,0.25,0.05,0.0,0.0,0.0,0.0,0.02,bridgit deni corbett,
+NUTR,2050,400,Nutrition for Nursing Prof,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
+NUTR,2160,1,Evidence-Based Nutrition,0.88,0.06,0.05,0.0,0.01,0.0,0.0,0.0,angela fraser,
+NUTR,3020,1,Nutrition Assessment,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,elliot jesch,
+NUTR,4240,1,Medical Nutr Thera I,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4510,1,Human Nutrition & Metabolism I,0.31,0.26,0.17,0.17,0.03,0.0,0.0,0.06,elliot jesch,
+PA,1010,1,Intro to Perf Arts,0.72,0.2,0.0,0.0,0.08,0.0,0.0,0.0,david hartmann,
+PA,2790,1,Perf Arts Pract I,0.47,0.41,0.0,0.0,0.0,0.0,0.0,0.12,kenneth moore,
+PADM,8210,400,Perspectives on Public Admin,0.8,0.13,0.0,0.0,0.0,0.0,0.0,0.07,thomas walker,
+PADM,8210,401,Perspectives on Public Admin,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,thomas walker,
+PADM,8420,400,GIS for Public Administrators,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,david lawrence white,
+PADM,8450,400,Grant Writing for Public Admin,0.79,0.07,0.0,0.0,0.0,0.0,0.0,0.14,katherin kransteuber,
+PADM,8530,400,Homeland Sec/Emergency Mgt Law,0.64,0.09,0.0,0.0,0.09,0.0,0.0,0.18,david leigh cook,
+PADM,8600,400,American Government,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
+PADM,8670,401,State Government Admin,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
+PADM,8710,401,Sustainability Practices Appli,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,david morgan young,
+PAS,3010,1,Intro to Pan African Studies,0.27,0.47,0.15,0.02,0.04,0.0,0.0,0.05,abel bartley,
+PES,1040,1,Introduction to Plant Sciences,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,
+PES,2020,1,Soils,0.14,0.49,0.27,0.08,0.02,0.0,0.0,0.0,dara michelle park,
+PES,3150,1,Environment and Agriculture,0.3,0.3,0.3,0.0,0.0,0.0,0.0,0.1,suseela appukuttan,
+PHIL,1010,1,Intro to Philosophic Problems,0.38,0.53,0.09,0.0,0.0,0.0,0.0,0.0,kelly smith,
+PHIL,1010,2,Intro to Philosophic Problems,0.42,0.32,0.11,0.05,0.11,0.0,0.0,0.0,kelly smith,
+PHIL,1010,3,Intro to Philosophic Problems,0.37,0.32,0.11,0.05,0.11,0.0,0.0,0.05,christopher grau,
+PHIL,1010,5,Intro to Philosophic Problems,0.56,0.32,0.06,0.0,0.03,0.0,0.0,0.03,david stegall,
+PHIL,1010,6,Intro to Philosophic Problems,0.38,0.35,0.03,0.09,0.03,0.0,0.0,0.12,david stegall,
+PHIL,1020,5,Introduction to Logic,0.29,0.37,0.03,0.17,0.03,0.0,0.0,0.11,david stegall,
+PHIL,1020,6,Introduction to Logic,0.39,0.36,0.09,0.0,0.03,0.0,0.0,0.12,david stegall,
+PHIL,1020,7,Introduction to Logic,0.47,0.32,0.18,0.03,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1020,8,Introduction to Logic,0.41,0.29,0.12,0.18,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1020,9,Introduction to Logic,0.56,0.22,0.11,0.0,0.06,0.0,0.0,0.06,adam gies,
+PHIL,1020,10,Introduction to Logic,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,adam gies,
+PHIL,1030,1,Introduction to Ethics,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,stephen satris,
+PHIL,1030,2,Introduction to Ethics,0.49,0.31,0.09,0.09,0.03,0.0,0.0,0.0,stephen satris,
+PHIL,1030,4,Introduction to Ethics,0.59,0.19,0.09,0.0,0.06,0.0,0.0,0.06,edyta joanna kuzian,
+PHIL,1030,5,Introduction to Ethics,0.48,0.3,0.15,0.0,0.0,0.0,0.0,0.06,edyta joanna kuzian,
+PHIL,1030,6,Introduction to Ethics,0.65,0.26,0.06,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,
+PHIL,3040,1,Moral Philosophy,0.35,0.47,0.12,0.0,0.0,0.0,0.0,0.06,todd may,
+PHIL,3150,1,Ancient Philosophy,0.39,0.26,0.23,0.03,0.03,0.0,0.0,0.06,stephen satris,
+PHIL,3210,1,Crime & Punishment,0.28,0.72,0.0,0.0,0.0,0.0,0.0,0.0,daniel wueste,
+PHIL,3430,1,Philosophy of Law,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,brookes colyto brown,
+PHIL,3440,1,Business Ethics,0.08,0.69,0.08,0.0,0.08,0.0,0.0,0.08,brookes colyto brown,
+PHIL,3480,1,Philosophies of Art,0.67,0.22,0.0,0.06,0.0,0.0,0.0,0.06,christopher grau,
+PHIL,3490,1,Gender and Sexuality,0.65,0.12,0.18,0.0,0.0,0.0,0.0,0.06,diane perpich,
+PHIL,4020,1,Recovery in Ethics,0.2,0.7,0.0,0.0,0.1,0.0,0.0,0.0,daniel wueste,
+PHIL,4220,1,Anarchism,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,todd may,
+PHSC,1180,1,Intro to Phy & Astr for Ele Ed,0.66,0.32,0.0,0.0,0.0,0.0,0.0,0.02,minory nammouz,
+PHYS,1220,1,Physics with Calculus I,0.31,0.25,0.22,0.11,0.06,0.0,0.0,0.05,lih-sin the,
+PHYS,1220,2,Physics with Calculus I,0.26,0.38,0.2,0.1,0.02,0.0,0.0,0.04,lih-sin the,
+PHYS,1220,7,Physics with Calculus I (HON),0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,hugo sanabria,True
+PHYS,1240,1,Physics Lab I,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,2,Physics Lab I,0.17,0.67,0.11,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,3,Physics Lab I,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,4,Physics Lab I,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,5,Physics Lab I,0.28,0.39,0.28,0.0,0.06,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,6,Physics Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,7,Physics Lab I,0.17,0.56,0.17,0.11,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,8,Physics Lab I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,9,Physics Lab I,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,10,Physics Lab I,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,11,Physics Lab I,0.41,0.29,0.24,0.06,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,12,Physics Lab I,0.46,0.31,0.08,0.0,0.0,0.0,0.0,0.15,daniel ross thompson,
+PHYS,1240,14,Physics Lab I,0.25,0.63,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,
+PHYS,1240,15,Physics Lab I,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,16,Physics Lab I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,17,Physics Lab I,0.69,0.08,0.08,0.0,0.0,0.0,0.0,0.15,daniel ross thompson,
+PHYS,1240,18,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,19,Physics Lab I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,daniel ross thompson,
+PHYS,1240,20,Physics Lab I,0.72,0.17,0.0,0.0,0.11,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2070,1,General Physics I,0.35,0.31,0.18,0.05,0.06,0.0,0.0,0.05,amy liann pope,
+PHYS,2070,2,General Physics I,0.41,0.33,0.16,0.04,0.03,0.0,0.0,0.03,amy liann pope,
+PHYS,2070,3,General Physics I,0.44,0.31,0.14,0.05,0.02,0.0,0.0,0.05,amy liann pope,
+PHYS,2070,4,General Physics I,0.11,0.33,0.3,0.07,0.07,0.0,0.0,0.11,amy liann pope,
+PHYS,2080,1,General Physics II,0.44,0.4,0.09,0.02,0.02,0.0,0.0,0.02,pooja puneet,
+PHYS,2090,1,Gen Phys Lab I,0.43,0.43,0.09,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,2,Gen Phys Lab I,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,3,Gen Phys Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,4,Gen Phys Lab I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,5,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,6,Gen Phys Lab I,0.21,0.42,0.29,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,
+PHYS,2090,7,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,8,Gen Phys Lab I,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,9,Gen Phys Lab I,0.58,0.33,0.0,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,
+PHYS,2090,10,Gen Phys Lab I,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,11,Gen Phys Lab I,0.5,0.42,0.04,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,12,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,13,Gen Phys Lab I,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,14,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,15,Gen Phys Lab I,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,16,Gen Phys Lab I,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,17,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,18,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,19,Gen Phys Lab I,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,20,Gen Phys Lab I,0.61,0.35,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,21,Gen Phys Lab I,0.17,0.74,0.0,0.04,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,22,Gen Phys Lab I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,
+PHYS,2090,23,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,24,Gen Phys Lab I,0.42,0.46,0.08,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,25,Gen Phys Lab I,0.13,0.83,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,26,Gen Phys Lab I,0.38,0.58,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,27,Gen Phys Lab I,0.42,0.54,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,1,Gen Phys Lab II,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,2,Gen Phys Lab II,0.42,0.5,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2100,3,Gen Phys Lab II,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,4,Gen Phys Lab II,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,6,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,7,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,8,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,9,Gen Phys Lab II,0.96,0.0,0.0,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2210,1,Physics with Calculus II,0.28,0.4,0.23,0.04,0.04,0.0,0.0,0.01,jason stratfor brown,
+PHYS,2210,2,Physics with Calculus II,0.18,0.45,0.28,0.06,0.02,0.0,0.0,0.01,jason stratfor brown,
+PHYS,2210,3,Physics with Calculus II,0.34,0.44,0.15,0.02,0.03,0.0,0.0,0.01,jason stratfor brown,
+PHYS,2210,4,Physics with Calculus II,0.13,0.5,0.26,0.05,0.05,0.0,0.0,0.01,jason stratfor brown,
+PHYS,2210,8,Physics with Calculus II (HON),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True
+PHYS,2220,1,Physics with Calculus III,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,jian he,
+PHYS,2230,1,Physics Lab II,0.41,0.47,0.12,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,2,Physics Lab II,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,3,Physics Lab II,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,4,Physics Lab II,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,5,Physics Lab II,0.29,0.53,0.06,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,
+PHYS,2230,6,Physics Lab II,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,7,Physics Lab II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,9,Physics Lab II,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,10,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,11,Physics Lab II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,12,Physics Lab II,0.18,0.76,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,13,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,14,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,17,Physics Lab II,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,
+PHYS,2450,1,Physics of Climate,0.51,0.3,0.09,0.01,0.02,0.0,0.0,0.07,gerald lehmacher,
+PHYS,3000,1,Intro to Research,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,
+PHYS,3120,1,Meth Theor Phys II,0.5,0.2,0.3,0.0,0.0,0.0,0.0,0.0,lih-sin the,
+PHYS,3150,1,Intro to Computational Physics,0.64,0.14,0.07,0.0,0.0,0.0,0.0,0.14,emil georgiev alexov,
+PHYS,3210,1,Mechanics I,0.23,0.42,0.19,0.04,0.0,0.0,0.0,0.12,stephen rol kaeppler,
+PHYS,4410,1,Electromagnetics I,0.33,0.28,0.28,0.06,0.0,0.0,0.0,0.06,xian lu,
+PHYS,4550,1,Quantum Physics I,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05,sumanta tewari,
+PHYS,8110,1,Meth of Theor Phys I,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,feng ding,
+PHYS,8210,1,Classical Mech I,0.21,0.63,0.16,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
+PHYS,8750,2,Intro to Research Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,hugo sanabria,
+PHYS,9510,1,Quantum Mech I,0.21,0.68,0.11,0.0,0.0,0.0,0.0,0.0,domnita ca marinescu,
+PKSC,1010,1,Pkgsc Orientation,0.27,0.53,0.18,0.0,0.0,0.0,0.0,0.01,marcondes pat guerra,
+PKSC,1020,1,Intro to Pkg Sci,0.08,0.32,0.3,0.21,0.05,0.0,0.0,0.04,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.29,0.46,0.19,0.06,0.0,0.0,0.0,0.0,marcondes pat guerra,
+PKSC,2040,1,Container Systems,0.28,0.53,0.13,0.03,0.03,0.0,0.0,0.0,marcondes pat guerra,
+PKSC,3200,1,Pkg Design Theory,0.83,0.04,0.09,0.0,0.0,0.0,0.0,0.04,rupert hurley,
+PKSC,4010,1,Packaging Machinery,0.36,0.54,0.05,0.03,0.0,0.0,0.0,0.03,anthony loui pometto,
+PKSC,4030,1,Pkg Career Prep,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4040,1,Protective Packaging Prop/Prin,0.4,0.36,0.16,0.0,0.06,0.0,0.0,0.03,gregory batt,
+PKSC,4160,1,Appl Polymers in Pkg,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,duncan darby,
+PKSC,4200,1,Pkg Design & Dev,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4540,1,Prod Pkg Evl Lab,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4540,2,Prod Pkg Evl Lab,0.25,0.56,0.06,0.0,0.06,0.0,0.0,0.06,gregory batt,
+PKSC,4540,3,Prod Pkg Evl Lab,0.44,0.38,0.19,0.0,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4540,4,Prod Pkg Evl Lab,0.56,0.25,0.06,0.13,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1,Food & Health Care Pkg Systems,0.6,0.3,0.09,0.0,0.0,0.0,0.0,0.0,kay cooksey,
+PKSC,4990,7,CI-Packaging  Sci Seminar,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,rupert hurley,
+PLPA,3100,1,Principles of Plant Pathology,0.14,0.46,0.39,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,
+PLPA,4250,1,Introductory Mycology,0.33,0.25,0.08,0.25,0.08,0.0,0.0,0.0,julia louis kerrigan,
+POSC,1010,1,Amer National Govt,0.21,0.44,0.25,0.07,0.0,0.0,0.0,0.04,joseph earl stewart,
+POSC,1010,2,Amer National Govt,0.54,0.22,0.2,0.02,0.0,0.0,0.0,0.02,jeffrey allen fine,
+POSC,1020,1,Intro Intl Relations,0.36,0.36,0.15,0.07,0.02,0.0,0.0,0.04,steven vincen miller,
+POSC,1020,2,Intro Intl Relations,0.19,0.38,0.27,0.05,0.03,0.0,0.0,0.08,zeynep taydas,
+POSC,1020,3,Intro Intl Relations,0.17,0.37,0.27,0.06,0.08,0.0,0.0,0.05,zeynep taydas,
+POSC,1040,1,Intro Compar Pol,0.17,0.43,0.26,0.0,0.0,0.0,0.0,0.13,xiaobo hu,
+POSC,1040,2,Intro Compar Pol,0.29,0.45,0.17,0.05,0.05,0.0,0.0,0.0,katherine amb curtis,
+POSC,1990,1,Intro Pol Sci,0.6,0.22,0.07,0.04,0.05,0.0,0.0,0.02,meredith- petersheim,
+POSC,3020,1,State and Loc Gov,0.31,0.49,0.09,0.0,0.09,0.0,0.0,0.02,bruce ransom,
+POSC,3610,1,International Conflict,0.39,0.22,0.16,0.0,0.12,0.0,0.0,0.1,steven vincen miller,
+POSC,3630,1,Us Foreign Policy,0.3,0.51,0.11,0.04,0.02,0.0,0.0,0.02,vladimir matic,
+POSC,3710,1,European Politics,0.41,0.44,0.1,0.0,0.05,0.0,0.0,0.0,vladimir matic,
+POSC,4030,1,United States Congress,0.26,0.47,0.17,0.04,0.02,0.0,0.0,0.04,jeffrey scott peake,
+POSC,4210,1,Public Policy,0.12,0.35,0.24,0.06,0.18,0.0,0.0,0.06,adam warber,
+POSC,4230,1,Urban Politics,0.5,0.28,0.06,0.0,0.06,0.0,0.0,0.11,bruce ransom,
+POSC,4360,1,Law Courts Politics,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,joseph earl stewart,
+POSC,4470,1,International Law,0.4,0.23,0.13,0.13,0.0,0.0,0.0,0.1,katherine amb curtis,
+POSC,4490,1,Political Theory of Capitalism,0.27,0.55,0.09,0.03,0.06,0.0,0.0,0.0,colin denby pearce,
+POSC,4550,1,Pol Thght of American Founding,0.38,0.34,0.23,0.0,0.04,0.0,0.0,0.0, bradley thompson,
+POSC,4560,1,Diplomacy,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,vladimir matic,
+POSC,4760,1,Middle East Politics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
+PRTM,2200,10,Foundations of PRTM,0.35,0.43,0.16,0.02,0.02,0.0,0.0,0.02,jamie lynn cathey,
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2260,2,Fnd of Mgt Adm PRTM,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth de baldwin,
+PRTM,2260,3,Fnd of Mgt Adm PRTM,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2260,4,Fnd of Mgt Adm PRTM,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2260,5,Fnd of Mgt Adm PRTM,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,2260,6,Fnd of Mgt Adm PRTM,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,katrina latric black,
+PRTM,2260,7,Fnd of Mgt Adm PRTM,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,katie dudley,
+PRTM,2260,8,Fnd of Mgt Adm PRTM,0.69,0.15,0.0,0.08,0.08,0.0,0.0,0.0,lauren eliz stephens,
+PRTM,2270,1,Prov of Leisure Exp,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2270,2,Prov of Leisure Exp,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth de baldwin,
+PRTM,2270,3,Prov of Leisure Exp,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2270,4,Prov of Leisure Exp,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2270,5,Prov of Leisure Exp,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,2270,6,Prov of Leisure Exp,0.13,0.69,0.06,0.13,0.0,0.0,0.0,0.0,katrina latric black,
+PRTM,2270,7,Prov of Leisure Exp,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,katie dudley,
+PRTM,2270,8,Prov of Leisure Exp,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,lauren eliz stephens,
+PRTM,2290,1,Competency Integration in PRTM,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2290,2,Competency Integration in PRTM,0.65,0.24,0.06,0.06,0.0,0.0,0.0,0.0,elizabeth de baldwin,
+PRTM,2290,3,Competency Integration in PRTM,0.33,0.47,0.13,0.07,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,2290,4,Competency Integration in PRTM,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2290,5,Competency Integration in PRTM,0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,2290,6,Competency Integration in PRTM,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,katrina latric black,
+PRTM,2290,7,Competency Integration in PRTM,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,katie dudley,
+PRTM,2290,8,Competency Integration in PRTM,0.77,0.08,0.0,0.08,0.08,0.0,0.0,0.0,lauren eliz stephens,
+PRTM,2950,1,Pro Golf Management Seminar II,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.52,0.17,0.28,0.0,0.0,0.0,0.0,0.03,daniel morg anderson,
+PRTM,3070,2,Facility Operations,0.85,0.09,0.06,0.0,0.0,0.0,0.0,0.0,raymond dunham,
+PRTM,3200,1,Recreation Policy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,matthew tyl brownlee,
+PRTM,3220,1,Facilitation Techniques in RT,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,
+PRTM,3230,1,Prof Prep for RT Practice,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,
+PRTM,3240,1,Assessment & Planning in RT,0.74,0.19,0.06,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3300,1,Visit Ser & Interp,0.64,0.14,0.21,0.0,0.0,0.0,0.0,0.0,michael pa blacketer,
+PRTM,3430,1,Spl Asp of Tourist B,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,'lisha fogle,
+PRTM,3470,1,Sport Tourism,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,gregory phil ramshaw,
+PRTM,3520,1,Camp Org and Admin,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,lisa kay-powle olsen,
+PRTM,3600,1,Recreation & Amateur Sport Mgt,0.26,0.61,0.09,0.0,0.0,0.0,0.0,0.04,skye arthur-banning,
+PRTM,3900,8,PGA GM Player Development,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3920,1,Special Event Management,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,
+PRTM,3920,2,Special Event Management,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kenneth backman,
+PRTM,3950,1,PGM Seminar III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,4030,1,Elem of Rec/Pk Plan,0.23,0.46,0.31,0.0,0.0,0.0,0.0,0.0,robert baxter powell,
+PRTM,4210,1,Rec Fin Resc Mgt,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,ryan joseph gagnon,
+PRTM,4220,1,Management of RT Services,0.49,0.49,0.03,0.0,0.0,0.0,0.0,0.0,brandi crowe,
+PRTM,4450,1,Conventions,0.82,0.09,0.06,0.0,0.0,0.0,0.0,0.03,stephanie perl garst,
+PRTM,4470,1,Perspect Intl Travel,0.93,0.0,0.04,0.0,0.04,0.0,0.0,0.0,sheila backman,
+PRTM,4510,1,Seminar in CRSCM,0.83,0.09,0.04,0.04,0.0,0.0,0.0,0.0,harrison pa pinckney,
+PRTM,4550,1,Adv Program Planning,0.62,0.23,0.08,0.04,0.04,0.0,0.0,0.0,harrison pa pinckney,
+PRTM,4740,2,Adv Rec Resource Mgt,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,matthew tyl brownlee,
+PRTM,4830,1,Golf Club Mgt & Ops,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,4950,1,Pro Golf Management Seminar IV,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,9000,7,Online Comp Exam,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,jeffrey charle hallo,
+PSYC,2010,1,Intro to Psychology,0.52,0.23,0.21,0.0,0.03,0.0,0.0,0.02,chong hyon pak,
+PSYC,2010,2,Intro to Psychology,0.27,0.31,0.26,0.08,0.02,0.0,0.0,0.05,edwin brainerd,
+PSYC,2010,3,Intro to Psychology,0.33,0.37,0.16,0.08,0.01,0.0,0.0,0.05,jo anne jorgensen,
+PSYC,2010,4,Intro to Psychology,0.34,0.39,0.14,0.07,0.0,0.0,0.0,0.06,mary taylor,
+PSYC,2010,5,Intro to Psychology (HON),0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,True
+PSYC,2890,1,Fundamentals of Psyc Science,0.56,0.34,0.06,0.03,0.01,0.0,0.0,0.01,peggy tyler,
+PSYC,3060,1,Human Sexual Behavior,0.51,0.22,0.13,0.06,0.07,0.0,0.0,0.01,bruce michael king,
+PSYC,3090,100,Intro Experimental Psychology,0.33,0.39,0.21,0.03,0.02,0.0,0.0,0.02,jennifer bail bisson,
+PSYC,3090,200,Intro Experimental Psychology,0.47,0.18,0.19,0.05,0.09,0.0,0.0,0.01,patrick rosopa,
+PSYC,3100,100,Advanced Experimental Psych,0.3,0.35,0.25,0.05,0.0,0.0,0.0,0.05,eric mckibben,
+PSYC,3100,200,Advanced Experimental Psych,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,thomas britt,
+PSYC,3100,300,Advanced Experimental Psych,0.35,0.41,0.06,0.0,0.06,0.0,0.0,0.12,robert campbell,
+PSYC,3100,400,Advanced Experimental Psych,0.43,0.43,0.05,0.05,0.0,0.0,0.0,0.05,fred switzer,
+PSYC,3100,500,Advanced Experimental Psych,0.53,0.37,0.05,0.05,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,3100,600,Advanced Experimental Psych,0.35,0.57,0.09,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3240,1,Physiological Psych,0.35,0.29,0.17,0.06,0.07,0.0,0.0,0.06,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.43,0.26,0.17,0.1,0.01,0.0,0.0,0.01,claudio cantalupo,
+PSYC,3310,1,Critical Thinking,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3330,1,Cognitive Psych,0.47,0.31,0.1,0.03,0.03,0.0,0.0,0.06,robert campbell,
+PSYC,3330,2,Cognitive Psych,0.65,0.26,0.07,0.01,0.0,0.0,0.0,0.0,kaileigh angel byrne,
+PSYC,3330,3,Cognitive Psych,0.57,0.26,0.08,0.02,0.05,0.0,0.0,0.03,kaileigh angel byrne,
+PSYC,3340,2,Cognitive Psych Lab,0.64,0.29,0.0,0.07,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3340,3,Cognitive Psych Lab,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,kathryn lucaites,
+PSYC,3340,4,Cognitive Psych Lab,0.54,0.31,0.0,0.15,0.0,0.0,0.0,0.0,kathryn lucaites,
+PSYC,3400,1,Lifespan Developmental Psych,0.68,0.22,0.08,0.01,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3400,2,Lifespan Developmental Psych,0.38,0.44,0.13,0.01,0.0,0.0,0.0,0.04,jennifer bail bisson,
+PSYC,3400,3,Lifespan Developmental Psych,0.25,0.3,0.22,0.09,0.1,0.0,0.0,0.04,pamela alley,
+PSYC,3520,1,Social Psychology,0.4,0.28,0.25,0.07,0.0,0.0,0.0,0.0,jo anne jorgensen,
+PSYC,3640,1,Industrial Psych,0.54,0.3,0.08,0.05,0.0,0.0,0.0,0.03,anton sytine,
+PSYC,3640,2,Industrial Psych,0.29,0.37,0.26,0.04,0.0,0.0,0.0,0.03,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.25,0.3,0.22,0.08,0.05,0.0,0.0,0.1,eric mckibben,
+PSYC,3680,2,Organizational Psych,0.59,0.27,0.09,0.01,0.03,0.0,0.0,0.01,zachary klinefelter,
+PSYC,3700,1,Personality,0.49,0.34,0.14,0.01,0.0,0.0,0.0,0.01,john robert hester,
+PSYC,3830,1,Abnormal Psychology,0.41,0.34,0.18,0.03,0.03,0.0,0.0,0.01,jo anne jorgensen,
+PSYC,3830,2,Abnormal Psychology,0.22,0.26,0.26,0.07,0.15,0.0,0.0,0.04,pamela alley,
+PSYC,3830,3,Abnormal Psychology,0.26,0.34,0.17,0.06,0.14,0.0,0.0,0.03,pamela alley,
+PSYC,3890,1,Group/Team Dynamics,0.9,0.07,0.0,0.01,0.01,0.0,0.0,0.0,marissa leigh porter,
+PSYC,3890,2,Psychology and Culture,0.6,0.21,0.12,0.05,0.02,0.0,0.0,0.0,ceren gunsoy,
+PSYC,4080,1,Women and Psychology,0.58,0.17,0.04,0.0,0.04,0.0,0.0,0.17,robin marie kowalski,
+PSYC,4150,1,Systems and Theories,0.29,0.46,0.17,0.09,0.0,0.0,0.0,0.0,edwin brainerd,
+PSYC,4150,2,Systems and Theories,0.34,0.41,0.16,0.03,0.03,0.0,0.0,0.03,edwin brainerd,
+PSYC,4150,3,Systems and Theories,0.8,0.11,0.03,0.0,0.03,0.0,0.0,0.03,michael shreeves,
+PSYC,4220,1,Perception,0.29,0.42,0.17,0.0,0.0,0.0,0.0,0.13,claudio cantalupo,
+PSYC,4220,2,Perception,0.33,0.15,0.33,0.19,0.0,0.0,0.0,0.0,christopher pagano,
+PSYC,4220,3,Perception,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,christopher pagano,
+PSYC,4220,4,Perception,0.72,0.16,0.08,0.0,0.04,0.0,0.0,0.0,darlene edewaard,
+PSYC,4350,1,Human Factors,0.58,0.23,0.12,0.04,0.0,0.0,0.0,0.04,laura whitlock,
+PSYC,4350,2,Human Factors,0.68,0.2,0.12,0.0,0.0,0.0,0.0,0.0,laura whitlock,
+PSYC,4710,1,Psych of Testing,0.46,0.31,0.15,0.08,0.0,0.0,0.0,0.0,zhuo chen,
+PSYC,4800,1,Health Psychology,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,james mccubbin,
+PSYC,4800,2,Health Psychology,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,james mccubbin,
+PSYC,4820,1,Positive Psychology,0.52,0.3,0.04,0.0,0.0,0.0,0.0,0.13,cynthia pury s,
+PSYC,4880,1,Psychotherapy,0.31,0.31,0.08,0.0,0.15,0.0,0.0,0.15,lucinda sorcie quick,
+PSYC,4890,1,21st Century Teams,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,marissa leigh porter,
+PSYC,4920,1,Senior Laboratory,0.64,0.18,0.09,0.0,0.05,0.0,0.0,0.05,chloe wilson,
+PSYC,4920,2,Senior Laboratory,0.77,0.09,0.05,0.0,0.09,0.0,0.0,0.0,chloe wilson,
+PSYC,4920,3,Senior Laboratory,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,chloe wilson,
+PSYC,4920,4,Senior Laboratory,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,tiffany cooper,
+PSYC,8100,1,Research Design I,0.73,0.19,0.0,0.0,0.03,0.0,0.0,0.05, dewayne moore,
+PSYC,8520,1,Social Psychology,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,ceren gunsoy,
+RED,8000,1,Real Estate Dvlpment,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,robert crei benedict,
+RED,8130,1,Strat in Real Estate,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,phillip river hughes,
+REL,1010,1,Intro to Religion,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,peter cohen,
+REL,1010,2,Intro to Religion,0.28,0.22,0.17,0.17,0.11,0.0,0.0,0.06,peter cohen,
+REL,1010,3,Intro to Religion,0.18,0.38,0.15,0.09,0.09,0.0,0.0,0.12,peter cohen,
+REL,1010,4,Intro to Religion,0.59,0.32,0.06,0.0,0.0,0.0,0.0,0.03,richard ale amesbury,
+REL,1020,2,World Religions,0.3,0.39,0.21,0.0,0.0,0.0,0.0,0.09,robert stephens,
+REL,1020,3,World Religions,0.31,0.46,0.11,0.06,0.03,0.0,0.0,0.03,robert stephens,
+REL,1020,4,World Religions,0.41,0.32,0.21,0.0,0.03,0.0,0.0,0.03,robert stephens,
+REL,3010,1,Old Testament,0.59,0.34,0.03,0.03,0.0,0.0,0.0,0.0,steven grosby,
+REL,3060,1,Judaism,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3090,1,Religion of the American South,0.6,0.13,0.13,0.0,0.07,0.0,0.0,0.07,elizabeth jemison,
+REL,3110,1,African American Rel,0.41,0.35,0.12,0.0,0.06,0.0,0.0,0.06,elizabeth jemison,
+REL,3130,1,Buddhism,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,robert stephens,
+REL,3150,1,Islam,0.53,0.2,0.13,0.07,0.0,0.0,0.0,0.07,mashal saif,
+REL,3200,1,"Jesus in History, Faith & Film",0.47,0.47,0.0,0.0,0.03,0.0,0.0,0.03,benjamin white,
+REL,4010,1,Stud Biblical Literature & Rel,0.5,0.21,0.07,0.07,0.0,0.0,0.0,0.14,benjamin white,
+RUSS,1010,1,Elementary Russian,0.6,0.2,0.1,0.0,0.0,0.0,0.0,0.1,stephanie ely morris,
+RUSS,1010,2,Elementary Russian,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,stephanie ely morris,
+RUSS,2010,1,Intermediate Russ,0.29,0.36,0.21,0.0,0.07,0.0,0.0,0.07,olga anatoly volkova,
+RUSS,3400,1,19th C Russ Culture,0.54,0.33,0.04,0.0,0.0,0.0,0.0,0.08,olga anatoly volkova,
+RUSS,3600,1,Russian Lit to 1910,0.58,0.25,0.13,0.0,0.0,0.0,0.0,0.04,olga anatoly volkova,
+SOC,2010,2,Introduction to Sociology,0.89,0.09,0.01,0.0,0.0,0.0,0.0,0.02,andrew he mannheimer,
+SOC,2010,3,Introduction to Sociology,0.49,0.36,0.09,0.01,0.02,0.0,0.0,0.02,carolyn cand coffman,
+SOC,2010,4,Introduction to Sociology,0.5,0.35,0.11,0.04,0.0,0.0,0.0,0.01,shannon mcdonough,
+SOC,2010,5,Introduction to Sociology,0.56,0.27,0.13,0.03,0.01,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,7,Introduction to Sociology,0.46,0.36,0.14,0.02,0.0,0.0,0.0,0.02,jennifer lea holland,
+SOC,2040,1,Prof Dev for Sociology Majors,0.41,0.32,0.15,0.05,0.05,0.0,0.0,0.02, catherine mobley,
+SOC,3040,1,Social Research Methods II,0.32,0.29,0.14,0.21,0.0,0.0,0.0,0.04,ye luo,
+SOC,3110,1,The Family,0.37,0.51,0.08,0.02,0.02,0.0,0.0,0.0,andrew whitehead,
+SOC,3400,1,Sport and Society,0.36,0.33,0.24,0.04,0.0,0.0,0.0,0.02,andrew whitehead,
+SOC,3940,1,Sociology of Mental Illness,0.78,0.2,0.0,0.02,0.0,0.0,0.0,0.0,james rosenberger,
+SOC,3970,1,Substance Abuse,0.55,0.34,0.11,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,
+SOC,4040,1,Soc Theory,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,william haller,
+SOC,4060,1,Qual Rsrch Methods for Soc Sci,0.55,0.18,0.0,0.09,0.0,0.0,0.0,0.18,melissa vogel,
+SOC,4140,1,Policy&Social Change,0.5,0.36,0.09,0.05,0.0,0.0,0.0,0.0,jennifer lea holland,
+SOC,4600,1,Race & Ethnicity,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andrew he mannheimer,
+SOC,4610,1,Sex & Gender,0.53,0.2,0.18,0.0,0.02,0.0,0.0,0.07,carolyn cand coffman,
+SOC,4800,1,Medical Sociology,0.82,0.06,0.03,0.0,0.09,0.0,0.0,0.0,carolyn cand coffman,
+SOC,6060,1,Qual Rsrch Methods for Soc Sci,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,
+SPAN,1010,1,Elementary Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,
+SPAN,1010,2,Elementary Spanish,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,rosa maca pillcurima,
+SPAN,1010,3,Elementary Spanish,0.63,0.16,0.05,0.11,0.05,0.0,0.0,0.0,rosa maca pillcurima,
+SPAN,1020,1,Elementary Spanish,0.72,0.11,0.06,0.0,0.11,0.0,0.0,0.0,rosa maca pillcurima,
+SPAN,1020,2,Elementary Spanish,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
+SPAN,1020,3,Elementary Spanish,0.47,0.26,0.21,0.05,0.0,0.0,0.0,0.0,valderramos zen cruz,
+SPAN,1020,4,Elementary Spanish,0.71,0.12,0.06,0.06,0.06,0.0,0.0,0.0,vieyra daniel garcia,
+SPAN,1020,5,Elementary Spanish,0.63,0.32,0.0,0.05,0.0,0.0,0.0,0.0,vieyra daniel garcia,
+SPAN,1020,6,Elementary Spanish,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,riquelme maria judez,
+SPAN,1020,7,Elementary Spanish,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,
+SPAN,1020,8,Elementary Spanish,0.58,0.26,0.05,0.11,0.0,0.0,0.0,0.0,vieyra daniel garcia,
+SPAN,1020,10,Elementary Spanish,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,debra oak williamson,
+SPAN,1020,11,Elementary Spanish,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,debra oak williamson,
+SPAN,1020,12,Elementary Spanish,0.53,0.35,0.06,0.06,0.0,0.0,0.0,0.0,adrienne elizab fama,
+SPAN,1020,13,Elementary Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,
+SPAN,2010,1,Intermediate Spanish,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,riquelme maria judez,
+SPAN,2010,2,Intermediate Spanish,0.61,0.0,0.28,0.0,0.11,0.0,0.0,0.0,valderramos zen cruz,
+SPAN,2010,3,Intermediate Spanish,0.5,0.33,0.06,0.0,0.06,0.0,0.0,0.06,melva margue persico,
+SPAN,2010,4,Intermediate Spanish,0.19,0.75,0.0,0.0,0.0,0.0,0.0,0.06,melva margue persico,
+SPAN,2010,7,Intermediate Spanish,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,debra oak williamson,
+SPAN,2010,8,Intermediate Spanish,0.5,0.25,0.17,0.08,0.0,0.0,0.0,0.0,debra oak williamson,
+SPAN,2010,9,Intermediate Spanish,0.53,0.42,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,
+SPAN,2010,10,Intermediate Spanish,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,ellory schmucker,
+SPAN,2010,11,Intermediate Spanish,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
+SPAN,2010,12,Intermediate Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
+SPAN,2010,16,Intermediate Spanish,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,17,Intermediate Spanish,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,
+SPAN,2020,1,Intermediate Spanish,0.21,0.58,0.16,0.0,0.05,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,2,Intermediate Spanish,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,
+SPAN,2020,3,Intermediate Spanish,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,adrienne elizab fama,
+SPAN,2020,4,Intermediate Spanish,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,
+SPAN,2020,5,Intermediate Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2020,7,Intermediate Spanish,0.84,0.11,0.0,0.05,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2020,8,Intermediate Spanish,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,
+SPAN,2020,9,Intermediate Spanish,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,ana paula  miller e,
+SPAN,2020,10,Intermediate Spanish,0.47,0.26,0.21,0.0,0.0,0.0,0.0,0.05,valderramos zen cruz,
+SPAN,2020,11,Intermediate Spanish,0.24,0.65,0.06,0.0,0.06,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,12,Intermediate Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,valderramos zen cruz,
+SPAN,2020,13,Intermediate Spanish,0.72,0.17,0.0,0.06,0.0,0.0,0.0,0.06,valderramos zen cruz,
+SPAN,2020,14,Intermediate Spanish,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,3010,1,Spanish Comp for Health Prof,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,3020,1,Intermed Span Grammar & Comp,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,melva margue persico,
+SPAN,3020,2,Intermed Span Grammar & Comp,0.32,0.53,0.05,0.0,0.05,0.0,0.0,0.05,melva margue persico,
+SPAN,3020,3,Intermed Span Grammar & Comp,0.53,0.26,0.16,0.0,0.0,0.0,0.0,0.05,daniel smith,
+SPAN,3050,1,Intermed Span Convers/Comp I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,moni rojas-de-massei,
+SPAN,3050,2,Intermed Span Convers/Comp I,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,moni rojas-de-massei,
+SPAN,3050,3,Intermed Span Convers/Comp I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,juana martin-armas,
+SPAN,3050,4,Intermed Span Convers/Comp I,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,graciela tissera,
+SPAN,3050,6,Intermed Span Convers/Comp I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,vieyra daniel garcia,
+SPAN,3050,7,Intermed Span Convers/Comp I,0.6,0.3,0.0,0.1,0.0,0.0,0.0,0.0,vieyra daniel garcia,
+SPAN,3070,1,The Hispanic World: Spain,0.44,0.28,0.11,0.06,0.11,0.0,0.0,0.0,raquel anido,
+SPAN,3080,1,The Hispanic World: Latin Amer,0.44,0.28,0.06,0.0,0.17,0.0,0.0,0.06,tiffany dawn miller,
+SPAN,3080,2,The Hispanic World: Latin Amer,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,tiffany dawn miller,
+SPAN,3130,2,Span Lit Survey I,0.25,0.38,0.13,0.0,0.19,0.0,0.0,0.06,moni rojas-de-massei,
+SPAN,3180,1,Spanish Through Culture,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,george palacios,
+SPAN,4010,1,New Spanish Fiction,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,salvador oropesa,
+SPAN,4060,2,Narrative Fiction,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
+SPAN,4070,1,Hispanic Film,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,raquel anido,
+SPAN,4150,1,Spanish for Health Prof,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,riquelme maria judez,
+STAT,2220,1,Statistics in Everyday Life,0.45,0.26,0.19,0.09,0.01,0.0,0.0,0.0,james espey,
+STAT,2220,2,Statistics in Everyday Life,0.48,0.26,0.17,0.04,0.01,0.0,0.0,0.03,james espey,
+STAT,2220,3,Statistics in Everyday Life,0.49,0.29,0.11,0.07,0.01,0.0,0.0,0.03,james espey,
+STAT,2220,4,Statistics in Everyday Life,0.38,0.33,0.15,0.08,0.02,0.0,0.0,0.03,james espey,
+STAT,2220,5,Statistics in Everyday Life,0.4,0.26,0.18,0.08,0.05,0.0,0.0,0.04,rose martinez-dawson,
+STAT,2220,6,Statistics in Everyday Life,0.31,0.23,0.28,0.07,0.06,0.0,0.0,0.05,rose martinez-dawson,
+STAT,2300,1,Statistical Methods I,0.23,0.29,0.27,0.09,0.08,0.0,0.0,0.02,christy jenkin brown,
+STAT,2300,2,Statistical Methods I,0.33,0.42,0.17,0.04,0.03,0.0,0.0,0.02,christy jenkin brown,
+STAT,2300,3,Statistical Methods I,0.32,0.35,0.11,0.14,0.04,0.0,0.0,0.04,sharon marie evans,
+STAT,2300,4,Statistical Methods I,0.29,0.37,0.13,0.08,0.09,0.0,0.0,0.05,sharon marie evans,
+STAT,2300,5,Statistical Methods I,0.18,0.29,0.17,0.15,0.15,0.0,0.0,0.06, erwin walker,
+STAT,2300,6,Statistical Methods I,0.13,0.35,0.22,0.08,0.12,0.0,0.0,0.11, erwin walker,
+STAT,2300,100,Statistical Methods I (HON),0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,christy jenkin brown,True
+STAT,3090,1,Introductory Business Stats,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,margaret emma brooks,
+STAT,3090,2,Introductory Business Stats,0.26,0.37,0.21,0.05,0.05,0.0,0.0,0.05,margaret emma brooks,
+STAT,3090,3,Introductory Business Stats,0.37,0.32,0.16,0.11,0.05,0.0,0.0,0.0,boyoung hur,
+STAT,3090,4,Introductory Business Stats,0.26,0.26,0.21,0.26,0.0,0.0,0.0,0.0,boyoung hur,
+STAT,3090,5,Introductory Business Stats,0.28,0.33,0.22,0.17,0.0,0.0,0.0,0.0,tiantian yang,
+STAT,3090,6,Introductory Business Stats,0.18,0.12,0.06,0.18,0.35,0.0,0.0,0.12,rui gong,
+STAT,3090,7,Introductory Business Stats,0.26,0.37,0.21,0.11,0.05,0.0,0.0,0.0,yiren ding,
+STAT,3090,8,Introductory Business Stats,0.12,0.35,0.35,0.12,0.06,0.0,0.0,0.0,yiren ding,
+STAT,3090,9,Introductory Business Stats,0.47,0.26,0.16,0.11,0.0,0.0,0.0,0.0,brandon lumsden,
+STAT,3090,10,Introductory Business Stats,0.29,0.18,0.35,0.06,0.06,0.0,0.0,0.06,jiajing niu,
+STAT,3090,11,Introductory Business Stats,0.26,0.37,0.16,0.05,0.11,0.0,0.0,0.05,anna marie vagnozzi,
+STAT,3090,12,Introductory Business Stats,0.21,0.21,0.26,0.0,0.16,0.0,0.0,0.16,john charl nicholson,
+STAT,3090,13,Introductory Business Stats,0.3,0.26,0.2,0.12,0.09,0.0,0.0,0.03,april thomas,
+STAT,3090,14,Introductory Business Stats,0.37,0.32,0.11,0.05,0.16,0.0,0.0,0.0,kayla doris javier,
+STAT,3090,15,Introductory Business Stats,0.32,0.39,0.11,0.08,0.09,0.0,0.0,0.01,april thomas,
+STAT,3090,16,Introductory Business Stats,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,yidan guo,
+STAT,3090,17,Introductory Business Stats,0.37,0.47,0.11,0.0,0.0,0.0,0.0,0.05,john charl nicholson,
+STAT,3090,18,Introductory Business Stats,0.22,0.33,0.28,0.11,0.06,0.0,0.0,0.0,feng gao,
+STAT,3090,19,Introductory Business Stats,0.42,0.32,0.11,0.05,0.11,0.0,0.0,0.0,kayla doris javier,
+STAT,3090,20,Introductory Business Stats,0.16,0.37,0.26,0.05,0.11,0.0,0.0,0.05,yidan guo,
+STAT,3090,21,Introductory Business Stats,0.18,0.41,0.24,0.0,0.12,0.0,0.0,0.06,minghua cui,
+STAT,3090,22,Introductory Business Stats,0.21,0.26,0.21,0.16,0.11,0.0,0.0,0.05,rui gong,
+STAT,3090,23,Introductory Business Stats,0.47,0.24,0.24,0.06,0.0,0.0,0.0,0.0,tiantian yang,
+STAT,3090,24,Introductory Business Stats,0.21,0.47,0.26,0.05,0.0,0.0,0.0,0.0,xueheng shi,
+STAT,3090,25,Introductory Business Stats,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,norman michae snyder,
+STAT,3090,26,Introductory Business Stats,0.37,0.37,0.16,0.0,0.11,0.0,0.0,0.0,anna marie vagnozzi,
+STAT,3090,27,Introductory Business Stats,0.32,0.37,0.16,0.11,0.05,0.0,0.0,0.0,sean walk ingimarson,
+STAT,3090,28,Introductory Business Stats,0.11,0.39,0.28,0.06,0.11,0.0,0.0,0.06,xueheng shi,
+STAT,3090,29,Introductory Business Stats,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,jiajing niu,
+STAT,3090,30,Introductory Business Stats,0.42,0.37,0.16,0.0,0.05,0.0,0.0,0.0,norman michae snyder,
+STAT,3090,31,Introductory Business Stats,0.53,0.21,0.21,0.05,0.0,0.0,0.0,0.0,brandon lumsden,
+STAT,3090,32,Introductory Business Stats,0.28,0.22,0.33,0.0,0.17,0.0,0.0,0.0,minghua cui,
+STAT,3090,33,Introductory Business Stats,0.2,0.42,0.27,0.04,0.07,0.0,0.0,0.0,margaret mari wiecek,
+STAT,3090,34,Introductory Business Stats,0.53,0.21,0.21,0.05,0.0,0.0,0.0,0.0,alan robert hahn,
+STAT,3090,35,Introductory Business Stats,0.16,0.47,0.32,0.05,0.0,0.0,0.0,0.0,alan robert hahn,
+STAT,3090,36,Introductory Business Stats,0.21,0.47,0.16,0.05,0.11,0.0,0.0,0.0,feng gao,
+STAT,3090,37,Introductory Business Stats,0.18,0.29,0.12,0.12,0.24,0.0,0.0,0.06,sean walk ingimarson,
+STAT,3300,1,Statistical Methods II,0.44,0.17,0.11,0.17,0.06,0.0,0.0,0.06,rose martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.32,0.44,0.16,0.04,0.04,0.0,0.0,0.0,ellen hepfer breazel,
+STAT,4110,1,Stat Mthds for Process Control,0.8,0.1,0.07,0.0,0.0,0.0,0.0,0.03,richard steve dubsky,
+STAT,4110,3,Stat Mthds for Process Control,0.56,0.28,0.11,0.0,0.03,0.0,0.0,0.03,william bridges,
+STAT,6020,1,Intro to Statistical Computing,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,
+STAT,8010,3,Statistical Methods I,0.36,0.41,0.05,0.0,0.05,0.0,0.0,0.14,jun luo,
+STAT,8010,4,Statistical Methods I,0.27,0.09,0.32,0.0,0.05,0.0,0.0,0.27,jun luo,
+STAT,8010,5,Statistical Methods I,0.58,0.38,0.0,0.0,0.0,0.0,0.0,0.04,joseph daniel bible,
+STAT,8010,7,Statistical Methods I,0.62,0.29,0.0,0.0,0.0,0.0,0.0,0.1,brook thayer russell,
+STAT,8020,1,Statistical Methods II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+STAT,8030,1,Regress & Least Squares Anlys,0.57,0.39,0.0,0.0,0.04,0.0,0.0,0.0,brook thayer russell,
+STS,1010,1,Survey Sci & Techn in Society,0.49,0.49,0.03,0.0,0.0,0.0,0.0,0.0,kenneth davi widgren,
+STS,1010,2,Survey Sci & Techn in Society,0.43,0.37,0.14,0.03,0.0,0.0,0.0,0.03,scott brame,
+STS,1010,3,Survey Sci & Techn in Society,0.49,0.37,0.11,0.0,0.0,0.0,0.0,0.03,elizabeth stansell,
+STS,1010,4,Survey Sci & Techn in Society,0.19,0.5,0.28,0.03,0.0,0.0,0.0,0.0,sarah mae cooper,
+STS,1010,5,Survey Sci & Techn in Society,0.54,0.29,0.09,0.03,0.03,0.0,0.0,0.03,philip randall,
+STS,1010,6,Survey Sci & Techn in Society,0.79,0.06,0.06,0.0,0.03,0.0,0.0,0.06,christine cla murphy,
+STS,1010,7,Survey Sci & Techn in Society,0.31,0.44,0.14,0.03,0.06,0.0,0.0,0.03,megan noe macalystre,
+STS,1010,8,Survey Sci & Techn in Society,0.34,0.4,0.09,0.0,0.03,0.0,0.0,0.14,david charles foltz,
+STS,1010,9,Survey Sci & Techn in Society,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+THEA,2100,1,Theatre Appreciation,0.66,0.19,0.06,0.03,0.03,0.0,0.0,0.03,kendra lynet johnson,
+THEA,2100,2,Theatre Appreciation,0.84,0.06,0.0,0.03,0.03,0.0,0.0,0.03,kerrie kathl seymour,
+THEA,2100,3,Theatre Appreciation,0.63,0.25,0.06,0.03,0.03,0.0,0.0,0.0,david hartmann,
+THEA,2100,4,Theatre Appreciation,0.9,0.06,0.0,0.0,0.0,0.0,0.0,0.03,anthony penna,
+THEA,2100,5,Theatre Appreciation,0.81,0.09,0.03,0.03,0.0,0.0,0.0,0.03,carol collins,
+THEA,2100,6,Theatre Appreciation,0.53,0.25,0.09,0.13,0.0,0.0,0.0,0.0,jason adkins,
+THEA,2100,7,Theatre Appreciation,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,jason adkins,
+THEA,2780,1,Acting I,0.73,0.09,0.09,0.09,0.0,0.0,0.0,0.0,kerrie kathl seymour,
+THEA,3170,1,African-Amer Thea I,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,kendra lynet johnson,
+THEA,4290,1,Dramatic Literature I,0.5,0.0,0.1,0.1,0.3,0.0,0.0,0.0,jason adkins,
+WFB,4100,2,Wildlife Management Techniques,0.29,0.48,0.18,0.02,0.02,0.0,0.0,0.02,james davis,
+WFB,4180,2,Fisheries Mgt & Conservation,0.5,0.42,0.0,0.0,0.0,0.0,0.0,0.08,troy mason farmer,
+WFB,4440,1,Wildlife Damage Management,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
+WFB,4720,1,Ornithology,0.18,0.55,0.18,0.09,0.0,0.0,0.0,0.0,john cummings,
+WFB,4770,1,Ichthyology,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,brandon kevi peoples,
+WFB,4800,1,Waterfowl Ecology & Management,0.61,0.22,0.11,0.03,0.0,0.0,0.0,0.03,richard mar kaminski,
+WFB,4930,2,Plant & Flora ID/Systematics,0.7,0.18,0.06,0.01,0.0,0.0,0.0,0.04,patrick mcmillan,
+WFB,6620,1,Wetland Wildlife Biology,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,russell barrett,
+WFB,6800,1,Waterfowl Ecology & Management,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,richard mar kaminski,
+WFB,8530,2,Global Chg Eco,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,lydia rie 'halloran,
+WS,1030,1,Women in Global Perspective,0.6,0.17,0.17,0.0,0.03,0.0,0.0,0.03,sarah mae cooper,
+WS,2300,1,Women and Leadership I,0.55,0.27,0.09,0.05,0.0,0.0,0.0,0.05,mary price,
+WS,3010,1,Intro Women's Studies,0.43,0.43,0.03,0.07,0.0,0.0,0.0,0.03,elizabeth rose adams,
+WS,3010,2,Intro Women's Studies,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,elizabeth rose adams,
+WS,3490,1,Gender and Sexuality,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,diane perpich,
+YDP,3000,400,Youth Development in Society,0.56,0.36,0.04,0.0,0.04,0.0,0.0,0.0,barry garst,
+YDP,3050,400,Theory/Phil of Youth Dev Work,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,edmond patric bowers,
+YDP,3300,1,Designing Effective Youth Prog,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
+YDP,3450,1,Creative Activities for Youth,0.9,0.03,0.07,0.0,0.0,0.0,0.0,0.0,kimberly pea johnson,
+YDP,8000,1,Theories of Youth Development,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,edmond patric bowers,
+YDP,8030,1,Creative & Ethical Leadership,0.68,0.25,0.07,0.0,0.0,0.0,0.0,0.0,barry garst,
+YDP,8050,1,Youth Dev in Context of Family,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william quinn,
+YDP,8060,2,Youth Dev in Global Society,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ann marie gillard,

--- a/bot/cogs/grades_cog/assets/2018_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2018_Spring.csv
@@ -1,2518 +1,2518 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1020,1,Survey of Art & Arch Hist II,0.4,0.4,0.17,0.0,0.01,0.0,0.0,0.01,andrea feeser,
-AAH,2060,1,Art History and Theory II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
-ACCT,2010,1,Financial Accounting Concepts,0.13,0.31,0.29,0.1,0.17,0.0,0.0,0.0,emily suzan mccorkle,
-ACCT,2010,2,Financial Accounting Concepts,0.33,0.38,0.16,0.04,0.07,0.0,0.0,0.02,lydia lanc schleifer,
-ACCT,2010,3,Financial Accounting Concepts,0.28,0.22,0.34,0.08,0.08,0.0,0.0,0.0,annieka philo,
-ACCT,2010,4,Financial Accounting Concepts,0.4,0.28,0.14,0.1,0.04,0.0,0.0,0.04,emily suzan mccorkle,
-ACCT,2010,5,Financial Accounting Concepts,0.41,0.31,0.18,0.02,0.04,0.0,0.0,0.04,annieka philo,
-ACCT,2010,6,Financial Accounting Concepts,0.43,0.31,0.1,0.02,0.06,0.0,0.0,0.08,lydia lanc schleifer,
-ACCT,2010,7,Financial Accounting Concepts,0.31,0.52,0.04,0.02,0.08,0.0,0.0,0.02,lydia lanc schleifer,
-ACCT,2010,8,Financial Accounting Concepts,0.37,0.35,0.16,0.04,0.04,0.0,0.0,0.04,emily suzan mccorkle,
-ACCT,2010,9,Financial Accounting Concepts,0.3,0.32,0.22,0.04,0.1,0.0,0.0,0.02,emily suzan mccorkle,
-ACCT,2010,10,Financial Accounting Concepts,0.18,0.36,0.24,0.12,0.08,0.0,0.0,0.02,james barnes,
-ACCT,2010,11,Financial Accounting Concepts,0.3,0.36,0.2,0.06,0.08,0.0,0.0,0.0,rebecca pennell trax,
-ACCT,2010,12,Financial Accounting Concepts,0.37,0.31,0.18,0.06,0.04,0.0,0.0,0.04,rebecca pennell trax,
-ACCT,2010,13,Financial Accounting Concepts,0.49,0.24,0.1,0.07,0.05,0.0,0.0,0.05,charles tegen,
-ACCT,2010,14,Financial Accounting Concepts,0.29,0.29,0.32,0.03,0.06,0.0,0.0,0.0,philip maiberger,
-ACCT,2010,15,Financial Accounting Concepts,0.24,0.43,0.14,0.1,0.05,0.0,0.0,0.05,lisa whea birtwistle,
-ACCT,2010,16,Financial Accounting Concepts,0.12,0.38,0.22,0.08,0.16,0.0,0.0,0.04,james barnes,
-ACCT,2010,101,Fin Acct Concepts (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,lisa whea birtwistle,True
-ACCT,2010,401,Financial Accounting Concepts,0.31,0.48,0.1,0.08,0.01,0.0,0.0,0.02,jeffrey mcmillan,
-ACCT,2020,1,Managerial Accounting Concepts,0.17,0.34,0.17,0.03,0.06,0.0,0.0,0.23,henry anderson,
-ACCT,2020,2,Managerial Accounting Concepts,0.19,0.28,0.17,0.02,0.02,0.0,0.0,0.33,henry anderson,
-ACCT,2020,3,Managerial Accounting Concepts,0.27,0.29,0.22,0.14,0.06,0.0,0.0,0.02,phebian davis-culler,
-ACCT,2020,4,Managerial Accounting Concepts,0.42,0.33,0.19,0.04,0.02,0.0,0.0,0.0,james milt kohlmeyer,
-ACCT,2020,5,Managerial Accounting Concepts,0.22,0.33,0.13,0.04,0.07,0.0,0.0,0.2,henry anderson,
-ACCT,2020,6,Managerial Accounting Concepts,0.29,0.29,0.21,0.09,0.04,0.0,0.0,0.09,brian todd carver,
-ACCT,2020,7,Managerial Accounting Concepts,0.15,0.31,0.27,0.0,0.17,0.0,0.0,0.1,brian todd carver,
-ACCT,2020,401,Managerial Accounting Concepts,0.33,0.28,0.18,0.05,0.03,0.0,0.0,0.12,henry anderson,
-ACCT,3030,1,Cost Accounting,0.3,0.36,0.23,0.11,0.0,0.0,0.0,0.0,phebian davis-culler,
-ACCT,3030,2,Cost Accounting,0.36,0.27,0.27,0.04,0.04,0.0,0.0,0.02,phebian davis-culler,
-ACCT,3030,3,Cost Accounting,0.2,0.32,0.32,0.07,0.0,0.0,0.0,0.1,jace garrett,
-ACCT,3030,4,Cost Accounting,0.13,0.32,0.36,0.06,0.11,0.0,0.0,0.02,jace garrett,
-ACCT,3110,1,Intermediate Financial Acct I,0.29,0.33,0.19,0.05,0.07,0.0,0.0,0.07,erin michell hawkins,
-ACCT,3110,2,Intermediate Financial Acct I,0.18,0.5,0.23,0.05,0.05,0.0,0.0,0.0,erin michell hawkins,
-ACCT,3110,3,Intermediate Financial Acct I,0.22,0.44,0.2,0.13,0.0,0.0,0.0,0.0,amy melissa donnelly,
-ACCT,3110,4,Intermediate Financial Acct I,0.29,0.33,0.31,0.07,0.0,0.0,0.0,0.0,amy melissa donnelly,
-ACCT,3110,401,Intermediate Financial Acct I,0.49,0.27,0.08,0.06,0.02,0.0,0.0,0.08,henry anderson,
-ACCT,3120,1,Intermediate Financial Acct II,0.0,0.18,0.45,0.18,0.18,0.0,0.0,0.0,jeremy michae vinson,
-ACCT,3120,2,Intermediate Financial Acct II,0.32,0.36,0.25,0.05,0.0,0.0,0.0,0.02,terry daniel knause,
-ACCT,3120,3,Intermediate Financial Acct II,0.23,0.39,0.27,0.09,0.02,0.0,0.0,0.0,jeremy michae vinson,
-ACCT,3120,4,Intermediate Financial Acct II,0.28,0.33,0.33,0.0,0.0,0.0,0.0,0.06,terry daniel knause,
-ACCT,3120,5,Intermediate Financial Acct II,0.36,0.3,0.23,0.11,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3120,6,Intermediate Financial Acct II,0.27,0.4,0.2,0.13,0.0,0.0,0.0,0.0,terry daniel knause,
-ACCT,3130,1,Intermediate Fin Acct III,0.11,0.5,0.21,0.07,0.04,0.0,0.0,0.07, russell madray,
-ACCT,3130,2,Intermediate Fin Acct III,0.16,0.48,0.3,0.02,0.02,0.0,0.0,0.02, russell madray,
-ACCT,3130,3,Intermediate Fin Acct III,0.3,0.49,0.16,0.05,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3130,4,Intermediate Fin Acct III,0.36,0.44,0.15,0.05,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3220,1,Accounting Information Systems,0.17,0.5,0.17,0.03,0.03,0.0,0.0,0.11,philip maiberger,
-ACCT,3220,2,Accounting Information Systems,0.25,0.47,0.22,0.06,0.0,0.0,0.0,0.0,philip maiberger,
-ACCT,3220,3,Accounting Information Systems,0.06,0.23,0.48,0.06,0.03,0.0,0.0,0.13,philip maiberger,
-ACCT,4040,1,Individual Taxation,0.74,0.17,0.06,0.03,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,2,Individual Taxation,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,3,Individual Taxation,0.58,0.3,0.0,0.1,0.03,0.0,0.0,0.0,lisa whea birtwistle,
-ACCT,4040,4,Individual Taxation,0.24,0.38,0.19,0.08,0.08,0.0,0.0,0.03,lisa whea birtwistle,
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.28,0.38,0.33,0.0,0.0,0.0,0.0,0.0,robin radtke,
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.3,0.53,0.15,0.0,0.0,0.0,0.0,0.03,robin radtke,
-ACCT,4150,1,Auditing,0.15,0.49,0.28,0.05,0.03,0.0,0.0,0.0,carl hollingsworth,
-ACCT,4150,2,Auditing,0.17,0.33,0.19,0.17,0.03,0.0,0.0,0.11,carl hollingsworth,
-ACCT,8520,1,Fin Acct Theory/Res,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,ralph edward welton,
-ACCT,8520,2,Fin Acct Theory/Res,0.28,0.59,0.13,0.0,0.0,0.0,0.0,0.0,ralph edward welton,
-ACCT,8540,1,Prof Responsibility,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8540,2,Prof Responsibility,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8540,3,Prof Responsibility,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8620,1,Financial Auditing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,8620,2,Financial Auditing,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,8710,1,Corporate Taxation,0.31,0.64,0.06,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,2,Corporate Taxation,0.15,0.8,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,3,Corporate Taxation,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8730,1,Intl/Spec Tax Topic,0.43,0.47,0.11,0.0,0.0,0.0,0.0,0.0,kathr kisska-schulze,
-ACCT,8740,1,Tax Aspects of Finan Planning,0.42,0.53,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,
-AFLS,2000,1,Agric For Domestic Study Tour,0.0,0.0,0.0,0.0,0.0,0.9,0.05,0.05,jean bertrand,
-AGED,1000,1,Orientation & Field Experience,0.74,0.05,0.0,0.0,0.11,0.0,0.0,0.11,philip fravel,
-AGED,2030,1,Teaching Agriscience,0.33,0.56,0.06,0.0,0.06,0.0,0.0,0.0,catherin dibenedetto,
-AGED,4150,1,Leadership of Vol,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,kevin layfield,
-AGED,4160,1,Ethics and Issues,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,
-AGED,4250,1,Teaching Ag Mechs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGM,2050,1,Prin of Fabrication,0.32,0.53,0.09,0.04,0.0,0.0,0.0,0.02,hunter massey,
-AGM,2060,1,Machinery Mgt,0.34,0.44,0.16,0.03,0.0,0.0,0.0,0.03,hunter massey,
-AGM,2200,1,Calc for Mechanized Agricult,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,young han,
-AGM,2210,1,Land Measurements,0.46,0.27,0.23,0.02,0.02,0.0,0.0,0.0,charles privette,
-AGM,4020,1,Irrigation System Design,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,charles privette,
-AGM,4100,1,Precision Ag Tech,0.46,0.38,0.14,0.02,0.0,0.0,0.0,0.0,hunter massey,
-AGM,4520,1,Mobile Power,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4720,1,Capstone,0.74,0.24,0.02,0.0,0.0,0.0,0.0,0.0,john chastain,
-AGRB,2020,1,Agricultural Economics,0.39,0.24,0.19,0.12,0.03,0.0,0.0,0.03,george apperson,
-AGRB,2050,1,Agriculture and Society,0.26,0.53,0.18,0.04,0.0,0.0,0.0,0.0,george apperson,
-AGRB,3080,1,Quant Agribusiness Analysis I,0.15,0.19,0.38,0.22,0.05,0.0,0.0,0.01,lisha zhang,
-AGRB,3190,1,Agribusiness Management,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,yuliya vale bolotova,
-AGRB,3510,1,Principles of Ag Sales and Ad,0.03,0.65,0.29,0.03,0.0,0.0,0.0,0.0,george apperson,
-AGRB,3570,1,Natural Resources Economics,0.16,0.35,0.24,0.18,0.0,0.0,0.0,0.06,david brian willis,
-AGRB,4020,1,Production Economics,0.28,0.37,0.28,0.05,0.0,0.0,0.0,0.02,michael vassalos,
-AGRB,4080,1,Quant Agribusiness Analysis II,0.32,0.35,0.26,0.06,0.0,0.0,0.0,0.0,lisha zhang,
-AGRB,4520,1,Agricultural Policy,0.14,0.48,0.24,0.12,0.0,0.0,0.0,0.02,michael vassalos,
-AGRB,4560,1,Prices,0.23,0.33,0.26,0.19,0.0,0.0,0.0,0.0,yuliya vale bolotova,
-AL,3490,400,Principles of Coaching,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,
-AL,3490,402,Principles of Coaching,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,julia wright,
-AL,3490,403,Principles of Coaching,0.72,0.12,0.08,0.0,0.04,0.0,0.0,0.04,clyde keith connor,
-AL,3490,406,Principles of Coaching,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john plumblee,
-AL,3490,407,Principles of Coaching,0.68,0.12,0.12,0.04,0.0,0.0,0.0,0.04,john plumblee,
-AL,3490,408,Principles of Coaching,0.76,0.16,0.0,0.0,0.08,0.0,0.0,0.0,deborah jo cadorette,
-AL,3500,400,Sci Basis I/Ex Phy,0.23,0.15,0.38,0.15,0.0,0.0,0.0,0.08,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.17,0.38,0.33,0.08,0.04,0.0,0.0,0.0,michael godfrey,
-AL,3520,400,Kinesiology,0.2,0.4,0.2,0.0,0.0,0.0,0.0,0.2,isaac sean colbert,
-AL,3530,400,Athletic Injuries,0.2,0.32,0.16,0.28,0.04,0.0,0.0,0.0,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.13,0.57,0.13,0.17,0.0,0.0,0.0,0.0,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.58,0.04,0.0,0.04,0.0,0.0,0.0,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.72,0.16,0.04,0.04,0.0,0.0,0.0,0.04,henry oates,
-AL,3610,401,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,Admin/Org of Athletic Programs,0.88,0.0,0.08,0.04,0.0,0.0,0.0,0.0,henry oates,
-AL,3620,400,Psychology of Coaching,0.5,0.23,0.12,0.04,0.12,0.0,0.0,0.0,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.44,0.32,0.16,0.04,0.04,0.0,0.0,0.0,natalie anne carter,
-AL,3620,402,Psychology of Coaching,0.46,0.35,0.08,0.08,0.04,0.0,0.0,0.0,natalie anne carter,
-AL,3720,400,Coaching Basketball,0.76,0.2,0.0,0.0,0.0,0.0,0.0,0.04,edmond fry,
-AL,3740,400,Coaching Football,0.76,0.12,0.08,0.04,0.0,0.0,0.0,0.0,edmond fry,
-AL,3760,400,Coaching Strength/Conditioning,0.8,0.12,0.04,0.0,0.0,0.0,0.0,0.04,edmond fry,
-AL,3760,401,Coaching Strength/Conditioning,0.72,0.08,0.04,0.08,0.04,0.0,0.0,0.04,edmond fry,
-AL,4000,400,Athletic Leadership Internship,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,deborah jo cadorette,
-AL,4380,402,Officiating in Athletic Leader,0.68,0.16,0.12,0.04,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,4380,403,Belief Systems in AL,0.59,0.22,0.15,0.04,0.0,0.0,0.0,0.0,deborah jo cadorette,
-AL,4380,404,Belief Systems in AL,0.71,0.13,0.04,0.13,0.0,0.0,0.0,0.0,deborah jo cadorette,
-AL,8530,400,Legal Iss in Intercoll Athlet,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,
-AL,8530,401,Legal Iss in Intercoll Athlet,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,8630,400,Socio Dynam in Intercol Athlet,0.38,0.48,0.05,0.0,0.05,0.0,0.0,0.05,michael godfrey,
-AL,8630,401,Socio Dynam in Intercol Athlet,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8640,400,Ethical Iss in Collegiate Athl,0.64,0.23,0.09,0.0,0.05,0.0,0.0,0.0,michael godfrey,
-AL,8640,401,Ethical Iss in Collegiate Athl,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8700,400,Intercoll Athletics Finance,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
-ANTH,2010,1,Introduction to Anthropology,0.23,0.48,0.26,0.03,0.0,0.0,0.0,0.0,david markus,
-ANTH,2010,2,Introduction to Anthropology,0.35,0.46,0.11,0.07,0.0,0.0,0.0,0.02,yi wu,
-ANTH,2010,3,Introduction to Anthropology,0.05,0.26,0.35,0.15,0.11,0.0,0.0,0.09,john coggeshall,
-ANTH,2010,4,Introduction to Anthropology,0.43,0.46,0.09,0.0,0.02,0.0,0.0,0.0,david markus,
-ANTH,2050,1,Professional Development,0.79,0.05,0.05,0.05,0.05,0.0,0.0,0.0,melissa vogel,
-ANTH,3200,1,North American Indian Cultures,0.21,0.42,0.17,0.17,0.04,0.0,0.0,0.0,john coggeshall,
-ANTH,3310,1,Archaeology,0.2,0.4,0.3,0.05,0.0,0.0,0.0,0.05,david markus,
-ANTH,3510,1,Biological Anthropology,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,lisa rapaport,
-ANTH,4040,1,Anthropological Theories,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,john coggeshall,
-ANTH,4990,1,Special Topics: Business Anth,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,melissa vogel,
-APEC,8220,1,Public Policy Econ,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david brian willis,
-ARCH,1510,1,Arch Communication,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,sall hambright-belue,
-ARCH,1510,2,Arch Communication,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,1510,3,Arch Communication,0.36,0.43,0.07,0.07,0.0,0.0,0.0,0.07,clarissa mendez,
-ARCH,1510,4,Arch Communication,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,1510,5,Arch Communication,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,jared jeffrey moore,
-ARCH,1510,6,Arch Communication,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,herminia silv machry,
-ARCH,2520,1,Arch Foundations II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,timothy sutherland,
-ARCH,2520,2,Arch Foundations II,0.43,0.36,0.14,0.0,0.0,0.0,0.0,0.07,clarissa mendez,
-ARCH,2520,3,Arch Foundations II,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,criss mills,
-ARCH,2520,4,Arch Foundations II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,2520,5,Arch Foundations II,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,2520,6,Arch Foundations II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,catherine parn smith,
-ARCH,2710,1,Structures II,0.51,0.34,0.09,0.0,0.03,0.0,0.0,0.03,mahmoodreza soltani,
-ARCH,3530,1,Studio Genoa,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4050,1,American Arch Styles 1650-1950,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,4140,1,Design Seminar,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,4160,1,Field Studies,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,4520,1,Synthesis Studio,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,4520,2,Synthesis Studio,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,4520,3,Synthesis Studio,0.07,0.73,0.2,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4520,4,Synthesis Studio,0.5,0.36,0.07,0.07,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,4890,1,Internship,0.4,0.2,0.3,0.0,0.0,0.0,0.0,0.1,ashley jennings,
-ARCH,4990,1,Immersive Virtual Environments,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,david lee,
-ARCH,8110,1,Visualization II,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,douglas hecker,
-ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,8420,1,Arch Studio II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
-ARCH,8610,1,History/Theory II,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8620,1,History/Theory III,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
-ARCH,8650,1,Topics in Health Policy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anjali joseph,
-ARCH,8710,1,Structures II,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,dustin grah albright,
-ARCH,8730,2,Environmental Sys,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
-ARCH,8740,1,Building Process:TR,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
-ARCH,8900,1,Directed Studies,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,sara bayramzadeh,
-ARCH,8920,1,Comprehensive Studio,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ARCH,8920,2,Comprehensive Studio,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dustin grah albright,
-ARCH,8920,3,Comprehensive Studio,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-sop heine,
-ARCH,8920,4,Comprehensive Studio,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8960,1,A+H Studio: Tectonic,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
-ART,1060,1,Foundation Drawing II,0.52,0.38,0.05,0.0,0.0,0.0,0.0,0.05,carly drew,
-ART,1510,1,Foundations Art I,0.62,0.31,0.0,0.08,0.0,0.0,0.0,0.0,daniel bare,
-ART,1520,1,Foundations Art II,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,kooi susan el vander el,
-ART,2050,1,Beginning Life Drawing,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,
-ART,2070,1,Beginning Painting,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,dustin lee massey,
-ART,2100,400,Art Appreciation,0.76,0.14,0.0,0.0,0.0,0.0,0.0,0.1,lydia jane dorsey,
-ART,2100,401,Art Appreciation,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,lydia jane dorsey,
-ART,2100,402,Art Appreciation,0.68,0.14,0.14,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,
-ART,2100,403,Art Appreciation,0.54,0.21,0.11,0.04,0.0,0.0,0.0,0.11,lydia jane dorsey,
-ART,2110,1,Begin Printmaking,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,mandy lorai ferguson,
-ART,2130,1,Begin Photography,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,amanda denise musick,
-ART,2170,1,Beginning Ceramics,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,daniel bare,
-ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,
-AS,1100,1,Air Force Today II,0.29,0.59,0.0,0.06,0.06,0.0,0.0,0.0,michael allen moore,
-AS,1100,2,Air Force Today II,0.33,0.5,0.06,0.06,0.0,0.0,0.0,0.06,michael allen moore,
-AS,1100,3,Air Force Today II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,2100,1,Dev of Air Power II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,2100,2,Dev of Air Power II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,2100,3,Dev of Air Power II,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,3100,2,Af Ldrshp & Mgt II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mari miller,
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,4100,2,Nat Sec Policy II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-ASL,1010,1,Am Sign Lang I,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,jason hurdich,
-ASL,1010,2,Am Sign Lang I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william rya clements,
-ASL,1010,3,Am Sign Lang I,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,william rya clements,
-ASL,1020,1,Am Sign Lang I,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,dunn kim mar misener mar,
-ASL,1020,2,Am Sign Lang I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,william rya clements,
-ASL,1020,3,Am Sign Lang I,0.4,0.5,0.05,0.0,0.05,0.0,0.0,0.0,jason hurdich,
-ASL,1020,4,Am Sign Lang I,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,2020,1,Am Sign Lang II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
-ASL,2020,2,Am Sign Lang II,0.7,0.1,0.15,0.0,0.05,0.0,0.0,0.0,dunn kim mar misener mar,
-ASL,2020,3,Am Sign Lang II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,
-ASL,2020,4,Am Sign Lang II,0.52,0.19,0.29,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASTR,1010,1,Solar System Astronomy,0.39,0.36,0.18,0.01,0.02,0.0,0.0,0.04,amber porter,
-ASTR,1020,1,Stellar Astronomy,0.29,0.38,0.26,0.0,0.02,0.0,0.0,0.05,amber porter,
-ASTR,1020,2,Stellar Astronomy,0.3,0.39,0.19,0.09,0.02,0.0,0.0,0.02,marco ajello,
-ASTR,1030,1,Solar Systm Astr Lab,0.29,0.38,0.13,0.0,0.13,0.0,0.0,0.08,amber porter,
-ASTR,1030,2,Solar Systm Astr Lab,0.4,0.44,0.08,0.04,0.04,0.0,0.0,0.0,amber porter,
-ASTR,1030,3,Solar Systm Astr Lab,0.24,0.44,0.16,0.0,0.08,0.0,0.0,0.08,amber porter,
-ASTR,1040,1,Stellar Astr Lab,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,amber porter,
-ASTR,1040,3,Stellar Astr Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,amber porter,
-ASTR,1040,4,Stellar Astr Lab,0.56,0.31,0.06,0.0,0.06,0.0,0.0,0.0,amber porter,
-ASTR,2200,1,Planetary Science,0.44,0.38,0.06,0.06,0.0,0.0,0.0,0.06,mate adamkovics,
-ASTR,8200,1,Astroph II: Stars,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-AUD,2850,1,Acoustics of Music,0.18,0.36,0.36,0.09,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUD,3860,1,Electronic Comp,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,hamilton altstatt,
-AUE,4020,699,Automobile Powertrain Systems,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,8160,3,Eng Combustion Emiss,0.62,0.28,0.1,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8170,3,Alt Energy Sources,0.21,0.69,0.1,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8500,6,Stability/Safety Sys,0.32,0.65,0.03,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8550,16,Struct/Thermal Analysis Mthds,0.17,0.78,0.06,0.0,0.0,0.0,0.0,0.0,david will schmueser,
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.41,0.44,0.16,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8820,10,Systems Integration Con & Meth,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8860,1,Noise Vibration,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,
-AUE,8930,3,Applied Dynamics,0.14,0.5,0.29,0.0,0.07,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8930,401,Autonomous Driving Techn,0.72,0.2,0.02,0.0,0.0,0.0,0.0,0.07,yunyi jia,
-AUE,8930,699,Autovation 1,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,
-AVS,2000,1,Beef Cattle Tech,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,nathan long,
-AVS,2060,1,Swine Techniques,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
-AVS,2080,1,Teaching Horsemanshp,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
-AVS,3010,1,Anat & Phys Dom Ani,0.56,0.23,0.09,0.02,0.1,0.0,0.0,0.0,tiffany wilmoth,
-AVS,3100,1,Animal Health,0.46,0.35,0.11,0.05,0.0,0.0,0.0,0.03,celina marce checura,
-AVS,3150,1,Animal Welfare,0.48,0.32,0.04,0.08,0.08,0.0,0.0,0.0,peter skewes,
-AVS,3700,1,Principles of Animal Nutrition,0.49,0.26,0.16,0.09,0.0,0.0,0.0,0.0,james rob strickland,
-AVS,4000,1,AVS Professional Development,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
-AVS,4010,1,Beef Production,0.36,0.32,0.2,0.08,0.0,0.0,0.0,0.04,nathan long,
-AVS,4060,2,Seminars & Related Topics,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-AVS,4090,400,Animals & Humans In Society,0.77,0.2,0.0,0.03,0.0,0.0,0.0,0.0,marie owens bolt,
-AVS,4100,1,Domestic Ani Behav,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,peter skewes,
-AVS,4120,1,Advanced Equine Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kristine lang vernon,
-AVS,4130,1,Animal Products,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
-AVS,4140,1,Basic Immunology,0.28,0.38,0.25,0.05,0.0,0.0,0.0,0.05,thomas scott,
-AVS,4140,2,Basic Immunology,0.52,0.16,0.12,0.04,0.0,0.0,0.0,0.16,farzana ferdous,
-AVS,4530,1,Animal Reproduction,0.4,0.3,0.15,0.11,0.0,0.0,0.0,0.04,celina marce checura,
-AVS,4530,400,Animal Reproduction,0.09,0.27,0.55,0.09,0.0,0.0,0.0,0.0,celina marce checura,
-AVS,4550,2,Animal Repro Mgt-Equine,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
-AVS,4700,1,Animal Genetics,0.26,0.15,0.17,0.22,0.07,0.0,0.0,0.13,joseph keit bertrand,
-AVS,8090,1,Ruminant Nutrition,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,gustavo jose lascano,
-BCHM,3010,1,Molecular Biochem,0.1,0.34,0.35,0.09,0.01,0.0,0.0,0.11,meredith teil morris,
-BCHM,3010,2,Molecular Biochem(HON),0.43,0.23,0.2,0.08,0.05,0.0,0.0,0.03,cheryl ingram-smith,True
-BCHM,3040,1,Molecular Biology Laboratory,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,geoffrey ford,
-BCHM,3040,2,Molecular Biology Laboratory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3040,4,Molecular Biology Laboratory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3050,1,Essen Elements Bioch,0.06,0.41,0.32,0.05,0.0,0.0,0.0,0.16,debra ragland,
-BCHM,3050,2,Essen Elements Bioch,0.17,0.38,0.28,0.07,0.0,0.0,0.0,0.1,debra ragland,
-BCHM,3050,3,Essen Elements Bioch,0.24,0.41,0.23,0.08,0.04,0.0,0.0,0.0,geoffrey ford,
-BCHM,4320,1,Bioch of Metabolism,0.55,0.41,0.02,0.0,0.0,0.0,0.0,0.02,kimberly paul,
-BCHM,4340,1,Biochemistry of Metabolism Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,geoffrey ford,
-BCHM,4340,2,Biochemistry of Metabolism Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,4360,1,Genes to Proteins,0.34,0.64,0.02,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
-BCHM,4400,1,Bioinformatics,0.22,0.28,0.28,0.11,0.0,0.0,0.0,0.11,liangjiang wang,
-BCHM,4930,1,Senior Seminar,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james morris,
-BCHM,8100,1,Princ of Molecular Biology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jennifer may mason,
-BE,2100,1,Intro to Biosystems Engr,0.57,0.32,0.0,0.04,0.0,0.0,0.0,0.07,yi zheng,
-BE,3100,1,Biosystems Engr Thermodynamics,0.25,0.5,0.2,0.0,0.0,0.0,0.0,0.05,terry walker,
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.19,0.76,0.05,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4120,1,Be Heat Mass Trans,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,4150,1,Instr & Control for Biosys Eng,0.19,0.57,0.24,0.0,0.0,0.0,0.0,0.0,yi zheng,
-BE,4240,1,Ecological Engineering,0.66,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christophe darnault,
-BE,4380,1,Bioprocess Engineering Design,0.09,0.55,0.36,0.0,0.0,0.0,0.0,0.0,terry walker,
-BIOE,1010,1,Biol for Bioengr,0.35,0.45,0.09,0.0,0.0,0.0,0.0,0.11,vladimir vlad reukov,
-BIOE,2000,1,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,martine laberge,
-BIOE,2010,1,Intro Biomed Engr,0.32,0.36,0.24,0.04,0.0,0.0,0.0,0.04,vladimir vlad reukov,
-BIOE,3020,1,Biomaterials,0.6,0.32,0.04,0.01,0.01,0.0,0.0,0.01,alexey alex vertegel,
-BIOE,3100,1,Engr Analysis of Physiol Proc,0.67,0.26,0.03,0.0,0.03,0.0,0.0,0.03,brian william booth,
-BIOE,3200,1,Biomechanics,0.73,0.23,0.02,0.0,0.02,0.0,0.0,0.0,jiro nagatomi,
-BIOE,3210,1,Biofluid Mechanics,0.33,0.37,0.27,0.01,0.01,0.0,0.0,0.0,sarah harcum,
-BIOE,3470,1,Transport Processes in Bioengr,0.39,0.43,0.13,0.0,0.0,0.0,0.0,0.04,robert latour,
-BIOE,3700,1,Bioinst & Imaging,0.45,0.52,0.02,0.0,0.0,0.0,0.0,0.02,jordon antho gilmore,
-BIOE,4200,1,Sports Engineering,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,cynthia miller smith,
-BIOE,4350,1,Modeling of Multiphysics Prob,0.38,0.38,0.08,0.0,0.08,0.0,0.0,0.08,william richardson,
-BIOE,4490,1,Drug Delivery,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,
-BIOE,4510,39,CI-Inorganic Biomaterials,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vladimir vlad reukov,
-BIOE,6200,1,Sports Engineering,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,cynthia miller smith,
-BIOE,6350,1,Modeling of Multiphysics Prob,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,
-BIOE,8030,1,Polymeric Biomatls,0.22,0.44,0.0,0.0,0.0,0.0,0.0,0.33,narendra vyavahare,
-BIOL,1040,1,General Biology II,0.19,0.3,0.23,0.09,0.08,0.0,0.0,0.11,nora espinoza,
-BIOL,1040,2,General Biology II,0.53,0.31,0.1,0.04,0.01,0.0,0.0,0.01,william surver,
-BIOL,1040,3,General Biology II,0.14,0.24,0.39,0.15,0.05,0.0,0.0,0.02,salvatore sparace,
-BIOL,1040,4,General Biology II (HON),0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
-BIOL,1060,1,Gen Biology Lab II,0.42,0.38,0.13,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,2,Gen Biology Lab II,0.48,0.22,0.13,0.13,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,3,Gen Biology Lab II,0.42,0.17,0.33,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,4,Gen Biology Lab II,0.18,0.14,0.27,0.18,0.09,0.0,0.0,0.14,tafadzwa kaisa,
-BIOL,1060,5,Gen Biology Lab II,0.21,0.07,0.14,0.29,0.29,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,6,Gen Biology Lab II,0.29,0.29,0.29,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,7,Gen Biology Lab II,0.19,0.31,0.25,0.13,0.06,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1060,8,Gen Biology Lab II,0.54,0.25,0.13,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,9,Gen Biology Lab II,0.52,0.22,0.09,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,10,Gen Biology Lab II,0.48,0.22,0.22,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,11,Gen Biology Lab II,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,12,Gen Biology Lab II,0.5,0.25,0.21,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,13,Gen Biology Lab II,0.54,0.13,0.21,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,14,Gen Biology Lab II,0.5,0.18,0.23,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,15,Gen Biology Lab II,0.17,0.43,0.17,0.13,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,16,Gen Biology Lab II,0.41,0.18,0.27,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,18,Gen Biology Lab II,0.21,0.36,0.29,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,19,Gen Biology Lab II,0.08,0.38,0.31,0.23,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,20,Gen Biology Lab II,0.38,0.29,0.25,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,21,Gen Biology Lab II,0.29,0.38,0.25,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1060,22,Gen Biology Lab II,0.53,0.2,0.13,0.0,0.07,0.0,0.0,0.07,tafadzwa kaisa,
-BIOL,1060,24,Gen Biology Lab II,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,26,Gen Biology Lab II,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,27,Gen Biology Lab II,0.5,0.25,0.04,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,29,Gen Biology Lab II,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,30,Gen Biology Lab II,0.59,0.23,0.09,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,31,Gen Biology Lab II,0.36,0.36,0.07,0.14,0.0,0.0,0.0,0.07,tafadzwa kaisa,
-BIOL,1060,32,Gen Biology Lab II,0.55,0.15,0.1,0.15,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,33,Gen Biology Lab II,0.57,0.21,0.14,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,35,Gen Biology Lab II,0.38,0.31,0.25,0.06,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,36,Gen Biology Lab II,0.4,0.2,0.2,0.2,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1110,1,Principles of Biology II,0.21,0.43,0.16,0.08,0.05,0.0,0.0,0.07,dylan dittrich-reed,
-BIOL,1110,3,Principles of Biology II,0.36,0.47,0.11,0.02,0.01,0.0,0.0,0.02,robert kosinski,
-BIOL,1110,4,Prin of Biol II  (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert kosinski,True
-BIOL,1200,1,Biological Inq Lab,0.25,0.45,0.15,0.05,0.0,0.0,0.0,0.1, christine minor m,
-BIOL,1200,2,Biological Inq Lab,0.3,0.45,0.15,0.1,0.0,0.0,0.0,0.0, christine minor m,
-BIOL,1200,3,Biological Inq Lab,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05, christine minor m,
-BIOL,1200,4,Biological Inq Lab,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,
-BIOL,1200,5,Biological Inq Lab,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05, christine minor m,
-BIOL,1200,6,Biological Inq Lab,0.55,0.2,0.2,0.0,0.05,0.0,0.0,0.0, christine minor m,
-BIOL,1230,1,Keys to Human Biol,0.16,0.38,0.25,0.12,0.04,0.0,0.0,0.04, christine minor m,
-BIOL,2000,1,Biology in the News,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,
-BIOL,2040,1,"Environ, Energy and Society",0.36,0.34,0.13,0.06,0.02,0.0,0.0,0.09,john jenkins hains,
-BIOL,2040,2,"Environ, Energy and Society",0.47,0.31,0.08,0.1,0.0,0.0,0.0,0.04,john jenkins hains,
-BIOL,2230,1,Human Anat and Physiology II,0.42,0.37,0.13,0.04,0.03,0.0,0.0,0.01,john cummings,
-BIOL,2230,2,Human Anat and Physiology II,0.36,0.38,0.19,0.05,0.0,0.0,0.0,0.02,john cummings,
-BIOL,3020,1,Invertebrate Biology,0.31,0.33,0.18,0.03,0.05,0.0,0.0,0.1,migueles juan baeza,
-BIOL,3040,1,Biology of Plants,0.15,0.33,0.28,0.15,0.05,0.0,0.0,0.03,robert edwar ballard,
-BIOL,3060,1,Invertebrate Biology Lab,0.39,0.35,0.13,0.0,0.0,0.0,0.0,0.13,migueles juan baeza,
-BIOL,3060,3,Invertebrate Biology Lab,0.47,0.41,0.06,0.0,0.06,0.0,0.0,0.0,migueles juan baeza,
-BIOL,3080,2,Biology of Plants Practicum,0.4,0.3,0.2,0.05,0.0,0.0,0.0,0.05,nathan redding,
-BIOL,3080,3,Biology of Plants Practicum,0.44,0.39,0.06,0.11,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3160,1,Human Physiology,0.3,0.43,0.22,0.04,0.0,0.0,0.0,0.0,tamara mcnutt-scott,
-BIOL,3350,1,Evolutionary Biology,0.44,0.39,0.13,0.03,0.0,0.0,0.0,0.01,margaret ptacek,
-BIOL,3510,1,Biological Anthropology,0.58,0.25,0.08,0.04,0.04,0.0,0.0,0.0,lisa rapaport,
-BIOL,4010,1,Plant Physiology,0.2,0.22,0.22,0.25,0.03,0.0,0.0,0.07,douglas bielenberg,
-BIOL,4020,1,Plant Physiology Lab,0.24,0.59,0.12,0.0,0.0,0.0,0.0,0.06,douglas bielenberg,
-BIOL,4020,2,Plant Physiology Lab,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4100,1,Limnology,0.18,0.45,0.27,0.0,0.0,0.0,0.0,0.11,john jenkins hains,
-BIOL,4140,1,Basic Immunology,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,charles rice,
-BIOL,4340,1,Biological Chem Lab Techniques,0.21,0.21,0.21,0.29,0.0,0.0,0.0,0.07,salvatore sparace,
-BIOL,4340,2,Biological Chem Lab Techniques,0.19,0.31,0.25,0.19,0.06,0.0,0.0,0.0,salvatore sparace,
-BIOL,4400,1,Developmental Animal Biology,0.42,0.28,0.23,0.07,0.0,0.0,0.0,0.0,kara elizabet powder,
-BIOL,4480,1,Marine Ecology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,
-BIOL,4510,1,Biol Variation in Human Pop,0.4,0.2,0.1,0.1,0.1,0.0,0.0,0.1,elizabeth wakefield,
-BIOL,4610,3,Cell Biology,0.2,0.32,0.25,0.15,0.04,0.0,0.0,0.03,lisa bain,
-BIOL,4610,4,Cell Biology (HON),0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,lisa bain,True
-BIOL,4620,1,Cell Biology Lab (Lec),0.81,0.11,0.0,0.04,0.0,0.0,0.0,0.04,xianzhong yu,
-BIOL,4620,2,Cell Biology Lab (Lec),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.74,0.15,0.07,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
-BIOL,4620,8,Cell Biology Lab (Lec),0.85,0.12,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4640,1,Mammalogy,0.63,0.15,0.07,0.11,0.0,0.0,0.0,0.04,john cummings,
-BIOL,4670,1,Principles of Hematology,0.86,0.08,0.06,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,
-BIOL,4700,1,Behavioral Ecology,0.27,0.44,0.18,0.06,0.03,0.0,0.0,0.02,lisa rapaport,
-BIOL,4700,2,Behavioral Ecology (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lisa rapaport,True
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lisa rapaport,
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,lisa rapaport,
-BIOL,4930,3,Sr Sem: Advances in Cancer,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
-BIOL,4930,4,Sr Sem: Immuno & Immunothearpy,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,yanzhang wei,
-BIOL,4930,5,Sr Sem: Nervous Systems,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4930,8,Sr Sem: Defining Sex,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tamara mcnutt-scott,
-BIOL,8430,1,Underst Genetics & Evol Biol,0.82,0.17,0.01,0.0,0.0,0.0,0.0,0.0,renea chris hardwick,
-BIOL,8450,1,Understanding Animal Biology,0.9,0.09,0.01,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
-BIOL,8470,1,Understanding Microbiology,0.57,0.37,0.04,0.0,0.02,0.0,0.0,0.0,harry kurtz,
-BMOL,4250,1,Biomolecular Engineering,0.22,0.35,0.13,0.17,0.0,0.0,0.0,0.13,mark alan blenner,
-BMOL,4290,1,Bioprocess Engineering,0.27,0.15,0.54,0.0,0.04,0.0,0.0,0.0,marc russ birtwistle,
-BUS,1010,1,Business Foundations,0.25,0.5,0.13,0.04,0.08,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,2,Business Foundations,0.28,0.32,0.2,0.08,0.08,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,3,Business Foundations,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,4,Business Foundations,0.21,0.43,0.29,0.0,0.04,0.0,0.0,0.04,william erne tumblin,
-BUS,1010,5,Business Foundations,0.33,0.41,0.0,0.07,0.07,0.0,0.0,0.11,william erne tumblin,
-BUS,1010,6,Business Foundations,0.4,0.36,0.08,0.08,0.04,0.0,0.0,0.04,william erne tumblin,
-BUS,1010,7,Business Foundations,0.33,0.37,0.2,0.03,0.03,0.0,0.0,0.03,donna mccubbin,
-BUS,1010,8,Business Foundations,0.33,0.43,0.13,0.07,0.0,0.0,0.0,0.03,donna mccubbin,
-BUS,1010,9,Business Foundations,0.42,0.23,0.31,0.0,0.0,0.0,0.0,0.04,william erne tumblin,
-BUS,1010,10,Business Foundations,0.58,0.23,0.08,0.04,0.04,0.0,0.0,0.04,william erne tumblin,
-CE,2010,1,Statics,0.36,0.29,0.16,0.05,0.04,0.0,0.0,0.09,barnabas bwambale,
-CE,2010,2,Statics,0.08,0.35,0.3,0.18,0.08,0.0,0.0,0.03,melissa sternhagen,
-CE,2010,3,Statics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,sreeganesh red yerri,
-CE,2010,4,Statics,0.05,0.2,0.24,0.12,0.15,0.0,0.0,0.24,melissa sternhagen,
-CE,2010,5,Statics,0.2,0.32,0.28,0.1,0.01,0.0,0.0,0.09, kent nilsson,
-CE,2010,6,Statics,0.33,0.27,0.29,0.07,0.04,0.0,0.0,0.0,shweta shrestha,
-CE,2060,1,Structural Mechanics,0.39,0.41,0.15,0.02,0.02,0.0,0.0,0.0,mahmoodreza soltani,
-CE,2060,2,Structural Mechanics,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,mahmoodreza soltani,
-CE,2080,1,Dynamics,0.05,0.43,0.27,0.17,0.05,0.0,0.0,0.03,melissa sternhagen,
-CE,2080,2,Dynamics,0.06,0.42,0.36,0.03,0.08,0.0,0.0,0.05,melissa sternhagen,
-CE,2550,1,Geomatics,0.27,0.42,0.27,0.01,0.03,0.0,0.0,0.0,wayne sarasua,
-CE,3010,1,Structural Analysis,0.28,0.33,0.2,0.13,0.04,0.0,0.0,0.02,stephen csernak,
-CE,3110,1,Transportation Engr,0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,pamela murray-tuite,
-CE,3210,1,Geotechnical Engineering,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
-CE,3210,2,Geotechnical Engineering,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
-CE,3310,1,Constr Engr & Mgmnt,0.31,0.52,0.07,0.09,0.0,0.0,0.0,0.0,james burati,
-CE,3410,1,Intro to Fluid Mech,0.28,0.51,0.16,0.03,0.01,0.0,0.0,0.0,nigel gregory kaye,
-CE,3420,1,Hydraulics & Hydro,0.49,0.37,0.11,0.03,0.0,0.0,0.0,0.0,ashok mishra,
-CE,3420,2,Hydraulics & Hydro,0.52,0.33,0.07,0.0,0.0,0.0,0.0,0.07,abdul khan,
-CE,3510,1,Civil Engineering Materials,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,prasada ra rangaraju,
-CE,3520,1,Econ Eval of Proj,0.53,0.33,0.15,0.0,0.0,0.0,0.0,0.0,james burati,
-CE,3520,2,Econ Eval of Proj,0.45,0.49,0.05,0.0,0.0,0.0,0.0,0.01,zoraya roldan rockow,
-CE,3530,1,Professional Seminar,0.95,0.01,0.04,0.0,0.0,0.0,0.0,0.01,thomas edfor cousins,
-CE,4020,1,Reinfor Con Design,0.26,0.3,0.28,0.07,0.02,0.0,0.0,0.07,thomas edfor cousins,
-CE,4070,1,Wood Design,0.62,0.24,0.14,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CE,4080,1,Struct Loads & Sys,0.38,0.46,0.08,0.0,0.08,0.0,0.0,0.0,bryant nielson,
-CE,4110,1,Roadway Geo Design,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
-CE,4120,1,Urban Transport Plan,0.23,0.69,0.0,0.0,0.0,0.0,0.0,0.08,eric morris,
-CE,4210,1,Geotechnical Design,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,nadaraj ravichandran,
-CE,4340,1,Const Est Proj Cont,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,4470,1,Stormwater Managemnt,0.25,0.25,0.35,0.1,0.0,0.0,0.0,0.05,md nasimul chowdhury,
-CE,4590,1,Capstone Design Proj,0.49,0.46,0.04,0.0,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4620,1,Coastal Engr I,0.19,0.41,0.26,0.11,0.04,0.0,0.0,0.0,earl hayter,
-CE,4910,1,Meth & Mgmt of Com & Ind Const,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,steve richar sanders,
-CE,6120,1,Urban Transport Plan,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
-CE,8030,1,Adv Steel Design,0.5,0.38,0.08,0.0,0.04,0.0,0.0,0.0,clinton owen rex,
-CE,8040,1,Prestressed Concrete,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,brandon ross,
-CE,8470,500,Optimization Support Models,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
-CE,8570,500,Uncertainty Modeling Risk Engr,0.78,0.13,0.0,0.0,0.0,0.0,0.0,0.09,elnaz peyghaleh,
-CE,8600,1,Adv Fluid Mech,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,abdul khan,
-CH,1010,1,General Chemistry,0.14,0.3,0.32,0.1,0.07,0.0,0.0,0.08,princess mycia cox,
-CH,1010,2,General Chemistry,0.07,0.28,0.36,0.14,0.06,0.0,0.0,0.08,princess mycia cox,
-CH,1010,3,General Chemistry,0.18,0.38,0.28,0.05,0.06,0.0,0.0,0.05,laura lanni,
-CH,1010,4,General Chemistry,0.17,0.33,0.27,0.11,0.06,0.0,0.0,0.07,william we mcwhorter,
-CH,1010,400,General Chemistry,0.32,0.23,0.13,0.15,0.02,0.0,0.0,0.15,stephen schvaneveldt,
-CH,1020,1,General Chemistry,0.26,0.31,0.26,0.1,0.02,0.0,0.0,0.05,thomas hickman,
-CH,1020,2,General Chemistry,0.42,0.36,0.17,0.03,0.01,0.0,0.0,0.02,tania issa houjeiry,
-CH,1020,3,General Chemistry,0.38,0.37,0.11,0.06,0.02,0.0,0.0,0.08,dennis taylor,
-CH,1020,4,General Chemistry,0.27,0.44,0.19,0.05,0.02,0.0,0.0,0.03,dennis taylor,
-CH,1020,5,General Chemistry,0.18,0.39,0.22,0.1,0.03,0.0,0.0,0.09,william we mcwhorter,
-CH,1020,6,General Chemistry,0.09,0.43,0.26,0.08,0.08,0.0,0.0,0.07,william we mcwhorter,
-CH,1020,7,General Chemistry,0.2,0.42,0.25,0.08,0.0,0.0,0.0,0.03,olt geiculescu,
-CH,1020,8,General Chemistry,0.22,0.44,0.2,0.07,0.02,0.0,0.0,0.05,thomas hickman,
-CH,1020,9,General Chemistry,0.3,0.41,0.18,0.04,0.03,0.0,0.0,0.05,elliot ennis,
-CH,1020,10,General Chemistry,0.23,0.34,0.25,0.07,0.02,0.0,0.0,0.09,jacob schroeder,
-CH,1020,11,General Chemistry,0.28,0.44,0.19,0.02,0.0,0.0,0.0,0.07,dennis taylor,
-CH,1020,50,General Chemistry,0.36,0.27,0.18,0.18,0.0,0.0,0.0,0.0,shiou-jyh hwu,
-CH,1020,51,General Chemistry (HON),0.68,0.26,0.04,0.0,0.0,0.0,0.0,0.02,stephen schvaneveldt,True
-CH,1020,52,General Chemistry (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,stephen schvaneveldt,True
-CH,1020,500,General Chemistry,0.14,0.39,0.29,0.18,0.0,0.0,0.0,0.0,brian gloor,
-CH,1050,1,Chemistry in Context I,0.54,0.37,0.09,0.0,0.0,0.0,0.0,0.0,olt geiculescu,
-CH,1050,2,Chemistry in Context I,0.35,0.38,0.19,0.0,0.04,0.0,0.0,0.04,olt geiculescu,
-CH,1060,1,Chemistry in Context II,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,thomas hickman,
-CH,1520,1,Chemistry Communication,0.67,0.23,0.02,0.0,0.02,0.0,0.0,0.05,richard marcus,
-CH,2010,1,Survey of Organic Chemistry,0.4,0.34,0.13,0.07,0.05,0.0,0.0,0.02,tania issa houjeiry,
-CH,2020,1,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2020,2,Surv of Organic Chemistry Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
-CH,2020,3,Surv of Organic Chemistry Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2020,4,Surv of Organic Chemistry Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
-CH,2050,1,Intro Inorg Chem,0.36,0.43,0.14,0.04,0.0,0.0,0.0,0.04,william pennington,
-CH,2230,1,Organic Chemistry,0.19,0.34,0.16,0.19,0.09,0.0,0.0,0.03,jacob schroeder,
-CH,2230,2,Organic Chemistry,0.28,0.38,0.18,0.08,0.04,0.0,0.0,0.05,jacob schroeder,
-CH,2230,3,Organic Chemistry,0.69,0.22,0.01,0.01,0.04,0.0,0.0,0.04,sourav saha,
-CH,2240,1,Organic Chemistry,0.21,0.21,0.21,0.14,0.08,0.0,0.0,0.16,laura lanni,
-CH,2240,2,Organic Chemistry,0.38,0.33,0.14,0.09,0.02,0.0,0.0,0.03,elliot ennis,
-CH,2240,3,Organic Chemistry,0.29,0.24,0.16,0.11,0.08,0.0,0.0,0.12,laura lanni,
-CH,2240,4,Organic Chemistry,0.35,0.29,0.21,0.03,0.04,0.0,0.0,0.08,rhett smith,
-CH,2240,5,Organic Chemistry,0.28,0.33,0.28,0.06,0.02,0.0,0.0,0.03,elliot ennis,
-CH,2270,1,Organic Chem Lab,0.56,0.19,0.0,0.0,0.0,0.0,0.0,0.25,james nelson plampin,
-CH,2270,2,Organic Chem Lab,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,james nelson plampin,
-CH,2270,3,Organic Chem Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2270,4,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2270,7,Organic Chem Lab,0.89,0.0,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2270,8,Organic Chem Lab,0.67,0.17,0.06,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,12,Organic Chem Lab,0.69,0.13,0.06,0.0,0.06,0.0,0.0,0.06,james nelson plampin,
-CH,2270,13,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,
-CH,2270,16,Organic Chem Lab,0.63,0.13,0.06,0.0,0.0,0.0,0.0,0.19,james nelson plampin,
-CH,2280,3,Organic Chem Lab,0.88,0.0,0.06,0.0,0.06,0.0,0.0,0.0,james nelson plampin,
-CH,2280,6,Organic Chem Lab,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
-CH,2280,7,Organic Chem Lab,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2280,8,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
-CH,2280,9,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
-CH,2280,10,Organic Chem Lab,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,james nelson plampin,
-CH,2280,11,Organic Chem Lab,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
-CH,2280,14,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,
-CH,2280,17,Organic Chem Lab,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2280,19,Organic Chem Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,james nelson plampin,
-CH,2280,20,Organic Chem Lab,0.73,0.07,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,
-CH,2280,22,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
-CH,2280,24,Organic Chem Lab,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
-CH,2280,25,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
-CH,2280,27,Organic Chem Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,james nelson plampin,
-CH,2280,28,Organic Chem Lab,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
-CH,2290,2,Organic Chem Lab,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2290,3,Organic Chem Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,james nelson plampin,
-CH,2290,4,Organic Chem Lab,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,3310,1,Physical Chemistry,0.4,0.3,0.0,0.0,0.1,0.0,0.0,0.2,arkady kholodenko,
-CH,3320,1,Physical Chemistry,0.17,0.42,0.33,0.0,0.08,0.0,0.0,0.0,steven stuart,
-CH,3320,3,Physical Chemistry,0.88,0.11,0.02,0.0,0.0,0.0,0.0,0.0,jason mcneill,
-CH,3320,4,Physical Chemistry,0.41,0.26,0.09,0.06,0.15,0.0,0.0,0.03,leah beck casabianca,
-CH,3400,1,Physical Chem Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,princess mycia cox,
-CH,3400,2,Physical Chem Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3400,4,Physical Chem Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3400,6,Physical Chem Lab,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3600,1,Chemical Biology,0.39,0.42,0.16,0.03,0.0,0.0,0.0,0.0,modi wetzler,
-CH,4110,1,Instrumental Analy,0.12,0.19,0.38,0.12,0.19,0.0,0.0,0.0,george chumanov,
-CH,4120,1,Instr Analysis Lab,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey nathan anker,
-CH,4130,1,Chemistry of Aqueous Systems,0.59,0.22,0.09,0.0,0.0,0.0,0.0,0.09,cindy lee,
-CH,4500,1,Chemistry Capstone,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
-CH,6140,1,Bioanalytical Chem,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,perez carlos garcia,
-CH,8080,1,Chem Non-Metal Elem,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,
-CH,8180,1,Surface Analysis,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,stephen creager,
-CH,8220,1,Organic Chem II,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,daniel whitehead,
-CH,8510,1,Grad Student Seminar,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,
-CHE,1300,1,Intro to Chemical Engineering,0.27,0.25,0.27,0.04,0.04,0.0,0.0,0.14,christopher norfolk,
-CHE,1300,2,Intro to Chemical Engineering,0.17,0.25,0.15,0.06,0.12,0.0,0.0,0.25,christopher norfolk,
-CHE,2200,1,Ch E Thermo I,0.24,0.24,0.24,0.19,0.05,0.0,0.0,0.05,joseph scott,
-CHE,2200,2,Ch E Thermo I,0.15,0.35,0.31,0.08,0.05,0.0,0.0,0.06,jessica marie kelly,
-CHE,2300,1,Fluids/Heat Transfer,0.1,0.21,0.26,0.26,0.13,0.0,0.0,0.05,eric mikel davis,
-CHE,2300,2,Fluids/Heat Transfer,0.15,0.37,0.22,0.15,0.04,0.0,0.0,0.07,eric mikel davis,
-CHE,3070,1,Unit Ops Lab I,0.21,0.52,0.25,0.0,0.0,0.0,0.0,0.02,mark thies,
-CHE,3190,1,Engr Materials,0.17,0.29,0.3,0.16,0.06,0.0,0.0,0.02,amod ogale,
-CHE,3530,2,Proc Dyn & Control,0.41,0.26,0.26,0.04,0.01,0.0,0.0,0.01,mark roberts,
-CHE,4330,1,Process Design II,0.44,0.45,0.11,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,8450,3,Multiscale Modeling,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
-CHIN,1020,1,Elementary Chinese,0.6,0.1,0.2,0.1,0.0,0.0,0.0,0.0,ling rao,
-CHIN,2020,1,Intermediate Chinese,0.47,0.18,0.24,0.12,0.0,0.0,0.0,0.0,ling rao,
-CHIN,3120,1,Philosophy in Ancient China,0.33,0.27,0.13,0.0,0.07,0.0,0.0,0.2,yanming an,
-CHIN,4010,1,Pre-Modern Chinese Literature,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,yanming an,
-COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.93,0.04,0.04,lori marlise pindar,
-COM,1500,1,Intro to Human Communication,0.88,0.11,0.0,0.0,0.01,0.0,0.0,0.0,eddie smith,
-COM,1500,2,Intro to Human Communication,0.58,0.33,0.03,0.02,0.02,0.0,0.0,0.02,daniel leland fecher,
-COM,1500,3,Intro to Human Communication,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,eddie smith,
-COM,1500,4,Intro to Human Communication,0.79,0.19,0.02,0.0,0.0,0.0,0.0,0.0,marianne herr glaser,
-COM,1500,5,Intro to Human Communication,0.66,0.27,0.01,0.02,0.01,0.0,0.0,0.02,marianne herr glaser,
-COM,1500,6,Intro to Human Communication,0.37,0.55,0.04,0.03,0.01,0.0,0.0,0.0,daniel leland fecher,
-COM,2010,1,Intr to Comm Studies,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,
-COM,2010,2,Intr to Comm Studies,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,
-COM,2020,1,Communication Theory,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,2030,1,Mass Communication Theory,0.47,0.43,0.03,0.07,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,2100,1,Quant Comm Research Methods,0.3,0.52,0.19,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
-COM,2500,1,Public Speaking,0.62,0.33,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christi davis,
-COM,2500,2,Public Speaking,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,
-COM,2500,3,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christi davis,
-COM,2500,7,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christi davis,
-COM,2500,8,Public Speaking,0.43,0.24,0.14,0.0,0.05,0.0,0.0,0.14,pauline matthey,
-COM,2500,9,Public Speaking,0.7,0.1,0.05,0.0,0.05,0.0,0.0,0.1,vanessa anne condon,
-COM,2500,10,Public Speaking,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,11,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,12,Public Speaking,0.4,0.4,0.1,0.0,0.0,0.0,0.0,0.1,pauline matthey,
-COM,2500,13,Public Speaking,0.63,0.21,0.05,0.0,0.11,0.0,0.0,0.0,amanda elizabe moore,
-COM,2500,14,Public Speaking,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,amanda elizabe moore,
-COM,2500,15,Public Speaking,0.9,0.0,0.0,0.0,0.1,0.0,0.0,0.0,caitlin baker,
-COM,2500,16,Public Speaking,0.8,0.05,0.05,0.05,0.05,0.0,0.0,0.0,amanda elizabe moore,
-COM,2500,18,Public Speaking,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,19,Public Speaking,0.67,0.24,0.0,0.05,0.05,0.0,0.0,0.0,jumah patricia taweh,
-COM,2500,20,Public Speaking,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,21,Public Speaking,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,
-COM,2500,22,Public Speaking,0.45,0.45,0.05,0.05,0.0,0.0,0.0,0.0,amanda elizabe moore,
-COM,2500,23,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,
-COM,2500,24,Public Speaking,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2500,25,Public Speaking,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,
-COM,2500,29,Public Speaking,0.64,0.23,0.0,0.05,0.05,0.0,0.0,0.05,vanessa anne condon,
-COM,2500,30,Public Speaking,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,31,Public Speaking,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,
-COM,2500,32,Public Speaking,0.71,0.19,0.05,0.0,0.05,0.0,0.0,0.0,sara grumble crocker,
-COM,2500,33,Public Speaking,0.22,0.61,0.06,0.0,0.06,0.0,0.0,0.06,marilyn denise pugh,
-COM,2500,34,Public Speaking,0.21,0.68,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
-COM,2500,35,Public Speaking,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,36,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
-COM,2500,401,Public Speaking,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
-COM,2500,402,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachary davis,
-COM,2500,403,Public Speaking,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alexis zachary davis,
-COM,2500,500,Public Speaking,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,
-COM,2500,501,Public Speaking,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,
-COM,3200,1,Bdcst Production,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,wanda johnson,
-COM,3250,1,Survey of Sports Communication,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3250,2,Survey of Sports Communication,0.87,0.04,0.09,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3300,1,Nonverbal Comm,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,joseph mazer,
-COM,3550,1,Principles of Public Relations,0.71,0.24,0.02,0.0,0.0,0.0,0.0,0.02,meghnaa tallapragada,
-COM,3570,1,Public Relations Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,3610,1,Argue and Debate,0.76,0.19,0.0,0.05,0.0,0.0,0.0,0.0,lindsey dixon,
-COM,3640,1,Organizational Comm,0.57,0.34,0.06,0.02,0.0,0.0,0.0,0.0,kristen elai okamoto,
-COM,3660,6,EC: Digital Analytics & Brand,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alicia nic littleton,
-COM,3660,7,EC: Media Mgmt in Brand Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william reynolds,
-COM,3990,2,CI: Reputation Mgmt,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,mark david land,
-COM,4250,1,Adv Sports Comm,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
-COM,4280,1,Interpers/Family Comm & Sport,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,
-COM,4560,1,PR for Assoc & Nonprofits,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,4560,2,PR for Assoc & Nonprofits,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,4700,1,Comm & Health,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,stephanie pangborn,
-COM,4950,1,Senior Capstone,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,4950,2,Senior Capstone,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,8070,1,Hlt Com Plan & Eval,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,stephanie pangborn,
-COM,8110,1,Comm Research Methods II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,meghnaa tallapragada,
-CPSC,1010,1,Computer Science I,0.17,0.25,0.21,0.06,0.15,0.0,0.0,0.15,catherine hochrine,
-CPSC,1010,2,Computer Science I,0.17,0.19,0.17,0.02,0.24,0.0,0.0,0.22,catherine hochrine,
-CPSC,1020,1,Computer Science II,0.38,0.22,0.12,0.07,0.12,0.0,0.0,0.09,yvon feaster,
-CPSC,1020,2,Computer Science II,0.28,0.16,0.17,0.03,0.17,0.0,0.0,0.19,yvon feaster,
-CPSC,1070,1,Programming Methodology,0.56,0.28,0.12,0.04,0.0,0.0,0.0,0.0,rose lowe,
-CPSC,1110,1,Intro to Programming in C,0.08,0.41,0.25,0.05,0.11,0.0,0.0,0.1,catherine hochrine,
-CPSC,1110,2,Intro to Programming in C,0.43,0.27,0.16,0.02,0.05,0.0,0.0,0.07,nicolas benja widman,
-CPSC,2070,1,Discrete Structures,0.63,0.26,0.02,0.07,0.0,0.0,0.0,0.02,sandra hedetniemi,
-CPSC,2070,2,Discrete Structures,0.31,0.23,0.23,0.08,0.11,0.0,0.0,0.03,larry hodges,
-CPSC,2120,1,Algs/Data Structures,0.32,0.34,0.25,0.05,0.0,0.0,0.0,0.05,wayne goddard,
-CPSC,2120,2,Algs/Data Structures,0.25,0.48,0.2,0.02,0.05,0.0,0.0,0.0,wayne goddard,
-CPSC,2150,1,Software Dev Foundations,0.45,0.28,0.18,0.05,0.03,0.0,0.0,0.02,kevin anton plis,
-CPSC,2150,2,Software Dev Foundations,0.27,0.35,0.24,0.02,0.05,0.0,0.0,0.08,kevin anton plis,
-CPSC,2200,1,Microcomputer Appl,0.52,0.3,0.09,0.0,0.04,0.0,0.0,0.04,kevin anton plis,
-CPSC,2200,2,Microcomputer Appl,0.35,0.43,0.13,0.0,0.09,0.0,0.0,0.0,kevin anton plis,
-CPSC,2310,1,Intro Computer Org,0.45,0.16,0.25,0.05,0.09,0.0,0.0,0.0,rose lowe,
-CPSC,2310,2,Intro Computer Org,0.11,0.34,0.25,0.14,0.14,0.0,0.0,0.02,rose lowe,
-CPSC,2910,1,Prof Issues I,0.65,0.25,0.0,0.05,0.0,0.0,0.0,0.05,catherine hochrine,
-CPSC,2910,2,Prof Issues I,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,catherine hochrine,
-CPSC,2910,3,Prof Issues I,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,3120,1,Design Analysis of Algorithms,0.13,0.13,0.33,0.08,0.21,0.0,0.0,0.13,pradip srimani,
-CPSC,3220,1,Intro to Operating Systems,0.17,0.25,0.14,0.0,0.08,0.0,0.0,0.36,jacob sorber,
-CPSC,3220,2,Intro to Operating Systems,0.79,0.15,0.03,0.03,0.0,0.0,0.0,0.0,carl bryan martin,
-CPSC,3220,3,Intro to Operating Systems,0.17,0.45,0.1,0.07,0.07,0.0,0.0,0.14,zijun wang,
-CPSC,3300,1,Computer Systems Org,0.2,0.35,0.33,0.03,0.1,0.0,0.0,0.0,mark smotherman,
-CPSC,3300,2,Computer Systems Org,0.53,0.25,0.13,0.05,0.03,0.0,0.0,0.03,nicolas benja widman,
-CPSC,3500,1,Foundations of Computer Sci,0.16,0.23,0.47,0.06,0.0,0.0,0.0,0.08,ilya mark safro,
-CPSC,3520,1,Programming Systems,0.31,0.42,0.1,0.01,0.08,0.0,0.0,0.08,robert schalkoff,
-CPSC,3600,1,Network Programming,0.43,0.27,0.22,0.02,0.0,0.0,0.0,0.06,feng luo,
-CPSC,3600,2,Network Programming,0.14,0.5,0.29,0.04,0.0,0.0,0.0,0.04,james martin,
-CPSC,3720,1,Software Engineering,0.2,0.45,0.33,0.0,0.0,0.0,0.0,0.02,murali sitaraman,
-CPSC,3720,2,Software Engineering,0.25,0.44,0.25,0.03,0.03,0.0,0.0,0.0,eileen there kraemer,
-CPSC,4050,1,Computer Graphics,0.29,0.14,0.21,0.18,0.04,0.0,0.0,0.14,victor zordan,
-CPSC,4110,1,Virtual Reality Systems,0.37,0.37,0.14,0.0,0.02,0.0,0.0,0.09,andrew robb,
-CPSC,4140,1,Human and Computer Interaction,0.29,0.33,0.17,0.0,0.0,0.0,0.0,0.21,christopher plaue,
-CPSC,4140,2,Human and Computer Interaction,0.28,0.33,0.28,0.06,0.0,0.0,0.0,0.06,christopher plaue,
-CPSC,4160,1,2-D Game Engine Construction,0.4,0.38,0.1,0.0,0.1,0.0,0.0,0.02,brian malloy,
-CPSC,4240,1,System Admin and Security,0.18,0.56,0.2,0.02,0.0,0.0,0.0,0.04,james martin,
-CPSC,4300,1,Applied Data Science,0.33,0.33,0.28,0.0,0.0,0.0,0.0,0.06,alexander chr herzog,
-CPSC,4620,1,Database Management Systems,0.34,0.45,0.14,0.05,0.02,0.0,0.0,0.0,zijun wang,
-CPSC,4620,2,Database Management Systems,0.44,0.34,0.15,0.02,0.05,0.0,0.0,0.0,kevin anton plis,
-CPSC,4770,1,Distributed/Cluster Computing,0.26,0.62,0.09,0.0,0.0,0.0,0.0,0.03,linh bao ngo,
-CPSC,4820,1,Special Topic: Cloud Comp Arch,0.33,0.43,0.23,0.0,0.0,0.0,0.0,0.0,amy apon,
-CPSC,4820,2,Special Topics: Tang and Embod,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,brygg anders ullmer,
-CPSC,4910,1,Professional Issues II,0.3,0.67,0.03,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,
-CPSC,6110,1,Virtual Reality Systems,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,andrew robb,
-CPSC,6160,1,2-D Game Engine Construction,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,brian malloy,
-CPSC,6300,1,Applied Data Science,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,
-CPSC,8100,1,Intro Artif Intell,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,
-CPSC,8110,1,Technical Character Animation,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,christina soph joerg,
-CPSC,8240,1,Advanced Operating Systems,0.32,0.48,0.08,0.0,0.0,0.0,0.0,0.12,rong ge,
-CPSC,8280,0,Theory of Program. Languages,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,murali sitaraman,
-CPSC,8400,1,Design & Anlys of Algorithms,0.18,0.5,0.25,0.0,0.0,0.0,0.0,0.07,brian christoph dean,
-CPSC,8580,1,Security in Emerging Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,
-CPSC,8650,1,Data Mining,0.27,0.38,0.19,0.0,0.04,0.0,0.0,0.12,zijun wang,
-CPSC,8750,1,Software Architectur,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,john mcgregor,
-CPSC,8810,10,Selected Topics: Motion Planni,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,
-CRP,8020,1,Site Planning & Infrastructure,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,
-CRP,8050,1,Plning Theory & History,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mickey lauria,
-CRP,8090,1,Current Issues in Planning,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
-CRP,8130,1,Transportation Plan Fundament,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,eric morris,
-CRP,8200,1,Negotiation & Develop Resolut,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
-CRP,8220,1,Urban Design,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,thomas willi schurch,
-CRP,8590,2,Plan Terminal Proj,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,
-CRP,8890,1,Selected Topic in Advanced GIS,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,patr carbajales-dale,
-CRP,8890,3,Sel Top Development Finance,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,elora lee raymond,
-CSM,2010,1,Structures I,0.3,0.25,0.2,0.05,0.1,0.0,0.0,0.1,shima clarke,
-CSM,2020,1,Structures II,0.13,0.44,0.23,0.13,0.02,0.0,0.0,0.04,shima clarke,
-CSM,2030,1,Mats & Meth of Const,0.21,0.61,0.14,0.0,0.04,0.0,0.0,0.0,jason lucas,
-CSM,2040,1,Cont Documents,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
-CSM,2050,1,Mats & Methods II,0.24,0.61,0.12,0.0,0.0,0.0,0.0,0.02,jason lucas,
-CSM,3050,1,Envir Systems II,0.26,0.43,0.3,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,
-CSM,3050,2,Envir Systems II,0.37,0.57,0.03,0.03,0.0,0.0,0.0,0.0,joseph micha burgett,
-CSM,3070,1,Sustainable Construction,0.2,0.45,0.25,0.0,0.05,0.0,0.0,0.05,joseph micha burgett,
-CSM,3070,2,Sustainable Construction,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.04,joseph micha burgett,
-CSM,3520,1,Const Scheduling,0.33,0.3,0.33,0.0,0.0,0.0,0.0,0.03,christine piper,
-CSM,3520,2,Const Scheduling,0.18,0.5,0.23,0.09,0.0,0.0,0.0,0.0,christine piper,
-CSM,3530,1,Const Estimating II,0.23,0.6,0.17,0.0,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,
-CSM,3530,2,Const Estimating II,0.32,0.55,0.09,0.0,0.0,0.0,0.0,0.05,rizi seyed  mousavi e,
-CSM,4540,1,Const Capstone,0.36,0.48,0.14,0.02,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8350,401,Integr Proj Deliv Case Studies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shima clarke,
-CSM,8640,1,Construction Bus Strat & Mktg,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christine piper,
-CSM,8640,400,Construction Bus Strat & Mktg,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,christine piper,
-CSM,8660,1,Role in Development,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8660,401,Role in Development,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.86,0.12,0.02,susan whorton,
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.68,0.21,0.11,susan whorton,
-CU,1010,1,Univ Success Skills,0.35,0.2,0.2,0.05,0.1,0.0,0.0,0.1,valerie kay oonk,
-CU,1010,2,Univ Success Skills,0.4,0.2,0.13,0.07,0.07,0.0,0.0,0.13,adam richa mcfarlane,
-CU,1010,3,Univ Success Skills,0.44,0.22,0.17,0.06,0.06,0.0,0.0,0.06,bryn zimmermann babb,
-CU,1010,4,Univ Success Skills,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,sharetta mar bufford,
-CU,1010,5,Univ Success Skills,0.5,0.22,0.22,0.0,0.06,0.0,0.0,0.0,bryn zimmermann babb,
-CU,1010,6,Univ Success Skills,0.29,0.29,0.12,0.0,0.18,0.0,0.0,0.12,taimi olsen,
-CU,1970,2,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.2,0.4,0.4,laurel ann  whisler c,
-CU,2010,1,Sustainability Leadership,0.85,0.12,0.0,0.0,0.04,0.0,0.0,0.0,jennifer marga goree,
-DPA,3070,1,Method 3d Production,0.71,0.14,0.04,0.0,0.0,0.0,0.0,0.11,sarah lydia  martin a,
-DPA,4020,1,Vis Foundations I,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anthony summey,
-DPA,4030,2,Vis Foundations II,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,erik reed,
-DPA,4830,1,Sp Studio Topic: Dig Sculpt In,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,insun kwon,
-ECE,2010,1,Logic and Computing Devices,0.29,0.35,0.23,0.0,0.07,0.0,0.0,0.06,walter ligon,
-ECE,2020,1,Electric Circuits I,0.18,0.17,0.37,0.08,0.15,0.0,0.0,0.05,william harrell,
-ECE,2070,1,Basic Electrical Engineering,0.48,0.36,0.08,0.02,0.0,0.0,0.0,0.05,timothy anglea,
-ECE,2070,2,Basic Electrical Engineering,0.53,0.27,0.12,0.03,0.01,0.0,0.0,0.04,william tho kolodzey,
-ECE,2070,3,Basic Electrical Engineering,0.39,0.33,0.21,0.04,0.0,0.0,0.0,0.03,william tho kolodzey,
-ECE,2080,5,Basic Electrical Engr Lab,0.85,0.0,0.05,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,
-ECE,2080,7,Basic Electrical Engr Lab,0.85,0.0,0.0,0.05,0.05,0.0,0.0,0.05,apoorva deep kapadia,
-ECE,2080,8,Basic Electrical Engr Lab,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,apoorva deep kapadia,
-ECE,2080,15,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2080,18,Basic Electrical Engr Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,
-ECE,2090,1,Logic Lab,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2090,4,Logic Lab,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,apoorva deep kapadia,
-ECE,2110,2,Elec Engr Lab I,0.75,0.1,0.0,0.0,0.1,0.0,0.0,0.05,apoorva deep kapadia,
-ECE,2120,4,Electrical Engineering Lab II,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,apoorva deep kapadia,
-ECE,2120,8,Electrical Engineering Lab II,0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,apoorva deep kapadia,
-ECE,2220,1,Syst Prog Concept,0.24,0.35,0.26,0.01,0.09,0.0,0.0,0.06,william reid,
-ECE,2230,1,Comp Sys Eng,0.15,0.27,0.21,0.09,0.15,0.0,0.0,0.12,jon cameron calhoun,
-ECE,2620,1,Electric Circuits II,0.28,0.34,0.23,0.08,0.02,0.0,0.0,0.05,richard groff,
-ECE,2620,2,Elec Circuits II (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,True
-ECE,2720,1,Comp Organization,0.33,0.39,0.26,0.02,0.0,0.0,0.0,0.0,william reid,
-ECE,2730,1,Computer Org Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2730,3,Computer Org Lab,0.5,0.31,0.13,0.06,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,2730,5,Computer Org Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,apoorva deep kapadia,
-ECE,2730,6,Computer Org Lab,0.63,0.31,0.0,0.06,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3110,2,Electrical Engineering Lab III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3110,3,Electrical Engineering Lab III,0.31,0.44,0.19,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,
-ECE,3110,4,Electrical Engineering Lab III,0.69,0.19,0.0,0.06,0.0,0.0,0.0,0.06,apoorva deep kapadia,
-ECE,3120,2,Electrical Engineering Lab IV,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3170,1,Rand Signal Analysis,0.32,0.28,0.24,0.11,0.03,0.0,0.0,0.04,stephen hubbard,
-ECE,3200,1,Electronics I,0.25,0.28,0.22,0.17,0.08,0.0,0.0,0.0,stephen hubbard,
-ECE,3210,1,Electronics II,0.49,0.34,0.13,0.0,0.02,0.0,0.0,0.02,stephen hubbard,
-ECE,3220,1,Intro Operating Sys,0.16,0.37,0.26,0.0,0.0,0.0,0.0,0.21,jacob sorber,
-ECE,3270,1,Dig Comp Design,0.17,0.19,0.26,0.1,0.07,0.0,0.0,0.21,melissa crawle smith,
-ECE,3300,1,Signals & Systems,0.16,0.24,0.34,0.15,0.06,0.0,0.0,0.04,carl baum,
-ECE,3520,1,Programming Systems,0.58,0.32,0.05,0.03,0.03,0.0,0.0,0.0,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.57,0.11,0.17,0.06,0.03,0.0,0.0,0.06,edward collins,
-ECE,3710,1,Microcontr Interface,0.32,0.32,0.3,0.03,0.0,0.0,0.0,0.03,william reid,
-ECE,3720,1,Micro Int Lab,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3720,3,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3720,5,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3720,7,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,3800,1,Electromagnetics,0.3,0.28,0.2,0.08,0.08,0.0,0.0,0.06,yuan li,
-ECE,3810,1,Field Waves & Ckts,0.36,0.48,0.1,0.04,0.0,0.0,0.0,0.02,anthony martin,
-ECE,4090,1,Intr to Linear Control Systems,0.48,0.43,0.05,0.03,0.03,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,4160,1,Smart Grid,0.52,0.45,0.03,0.0,0.0,0.0,0.0,0.0,gane venayagamoorthy,
-ECE,4200,1,Renewable Energy,0.19,0.19,0.26,0.26,0.0,0.0,0.0,0.1,johan heinric enslin,
-ECE,4270,1,Communications Sys,0.35,0.49,0.07,0.05,0.02,0.0,0.0,0.02,upasan bhattacharyya,
-ECE,4380,1,Computer Commun,0.33,0.33,0.22,0.07,0.0,0.0,0.0,0.04,harlan russell,
-ECE,4400,1,Local Computer Nets,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,
-ECE,4680,1,Embedded Computing,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,
-ECE,4950,1,Int Sys Design I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
-ECE,4960,1,Int Sys Design II,0.59,0.33,0.05,0.02,0.0,0.0,0.0,0.0,richard groff,
-ECE,6200,1,Renewable Energy,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,johan heinric enslin,
-ECE,6680,1,Embedded Computing,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,adam hoover,
-ECE,6930,1,Algorithms VLSI Design Automa.,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,
-ECE,8260,1,Solar Cells,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,rajendra singh,
-ECE,8400,1,Semicond Devices,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
-ECE,8480,1,Telecomm Networks,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
-ECE,8720,1,Artificial Neurl Net,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,robert schalkoff,
-ECE,8720,2,Artificial Neurl Net,0.14,0.43,0.0,0.0,0.14,0.0,0.0,0.29,robert schalkoff,
-ECE,8740,1,Adv Nonlinear Cntrl,0.56,0.33,0.0,0.0,0.11,0.0,0.0,0.0,yongqiang wang,
-ECE,8790,1,FPGA Design & Applications,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,melissa crawle smith,
-ECE,8930,2,Optimiz. Vector Space Methods,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,daniel noneaker,
-ECE,8930,10,Distributed Denial of Service,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,
-ECON,2000,1,Economic Concepts,0.32,0.14,0.3,0.14,0.05,0.0,0.0,0.05,jonathan orry ernest,
-ECON,2000,2,Economic Concepts,0.35,0.35,0.2,0.03,0.03,0.0,0.0,0.05,jonathan orry ernest,
-ECON,2000,3,Economic Concepts,0.46,0.27,0.16,0.11,0.0,0.0,0.0,0.0,miren ivankovic,
-ECON,2110,1,Principles of Microeconomics,0.3,0.28,0.2,0.13,0.03,0.0,0.0,0.08,liuna issagholian,
-ECON,2110,2,Principles of Microeconomics,0.18,0.35,0.28,0.08,0.1,0.0,0.0,0.03,roksana ghanbariamin,
-ECON,2110,3,Principles of Microeconomics,0.12,0.31,0.26,0.12,0.12,0.0,0.0,0.07,benjamin posmanick,
-ECON,2110,4,Principles of Microeconomics,0.32,0.32,0.12,0.12,0.1,0.0,0.0,0.02,kelsey victo roberts,
-ECON,2110,5,Principles of Microeconomics,0.3,0.4,0.23,0.05,0.03,0.0,0.0,0.0,molly espey,
-ECON,2110,6,Principles of Microeconomics,0.19,0.57,0.19,0.0,0.01,0.0,0.0,0.03,chen wang,
-ECON,2110,7,Principles of Microeconomics,0.3,0.42,0.17,0.06,0.04,0.0,0.0,0.01,wing yin chung,
-ECON,2110,8,Principles of Microeconomics,0.28,0.28,0.24,0.1,0.07,0.0,0.0,0.03,sarah louise wilson,
-ECON,2110,10,Principles of Microeconomics,0.39,0.45,0.1,0.02,0.04,0.0,0.0,0.0,jacob walloga,
-ECON,2110,12,Principles of Microeconomics,0.43,0.28,0.18,0.08,0.0,0.0,0.0,0.05,molly espey,
-ECON,2120,1,Principles of Macroeconomics,0.45,0.2,0.15,0.1,0.05,0.0,0.0,0.05,scott baier,
-ECON,2120,2,Principles of Macroeconomics,0.17,0.33,0.28,0.11,0.11,0.0,0.0,0.0,scott baier,
-ECON,2120,3,Principles of Macroeconomics,0.33,0.33,0.28,0.0,0.0,0.0,0.0,0.06,scott baier,
-ECON,2120,4,Principles of Macroeconomics,0.21,0.42,0.32,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,5,Principles of Macroeconomics,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,scott baier,
-ECON,2120,6,Principles of Macroeconomics,0.26,0.21,0.26,0.11,0.05,0.0,0.0,0.11,scott baier,
-ECON,2120,7,Principles of Macroeconomics,0.16,0.42,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,8,Principles of Macroeconomics,0.11,0.47,0.16,0.05,0.11,0.0,0.0,0.11,scott baier,
-ECON,2120,9,Principles of Macroeconomics,0.21,0.37,0.32,0.0,0.05,0.0,0.0,0.05,scott baier,
-ECON,2120,10,Principles of Macroeconomics,0.32,0.53,0.05,0.11,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,11,Principles of Macroeconomics,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,12,Principles of Macroeconomics,0.11,0.42,0.26,0.11,0.11,0.0,0.0,0.0,scott baier,
-ECON,2120,13,Principles of Macroeconomics,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,14,Principles of Macroeconomics,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,15,Principles of Macroeconomics,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,16,Principles of Macroeconomics,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,17,Principles of Macroeconomics,0.21,0.63,0.05,0.0,0.05,0.0,0.0,0.05,scott baier,
-ECON,2120,18,Principles of Macroeconomics,0.21,0.63,0.11,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,19,Principles of Macroeconomics,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,20,Principles of Macroeconomics,0.69,0.22,0.05,0.0,0.03,0.0,0.0,0.0,jeremy choquette,
-ECON,2120,21,Principles of Macroeconomics,0.27,0.45,0.21,0.0,0.03,0.0,0.0,0.03,benjamin tim harbolt,
-ECON,2120,22,Principles of Macroeconomics,0.0,0.2,0.08,0.16,0.0,0.0,0.0,0.56,ralph charles allen,
-ECON,2120,23,Principles of Macroeconomics,0.2,0.11,0.14,0.09,0.03,0.0,0.0,0.43,ralph charles allen,
-ECON,2120,24,Principles of Macroeconomics,0.31,0.48,0.2,0.0,0.01,0.0,0.0,0.0,elijah neilson,
-ECON,2120,25,Principles of Macroeconomics,0.42,0.33,0.19,0.03,0.03,0.0,0.0,0.0,kyle lance rechard,
-ECON,2120,26,Principles of Macroeconomics,0.49,0.33,0.13,0.0,0.05,0.0,0.0,0.0,xiaosong wu,
-ECON,2120,27,Principles of Macroeconomics,0.36,0.38,0.23,0.0,0.0,0.0,0.0,0.03,narendra regmi,
-ECON,2120,28,Principles of Macroecon (HON),0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,christopher as gorry,True
-ECON,3020,1,Money and Banking,0.33,0.33,0.25,0.03,0.05,0.0,0.0,0.03,smriti bhargava,
-ECON,3060,1,Managerial Economics,0.16,0.33,0.25,0.12,0.12,0.0,0.0,0.02,steven johnson,
-ECON,3100,1,International Econ,0.48,0.29,0.18,0.0,0.02,0.0,0.0,0.03,samuel art standaert,
-ECON,3140,1,Intermediate Micro,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,yichen christy zhou,
-ECON,3140,2,Intermediate Micro,0.23,0.38,0.18,0.08,0.05,0.0,0.0,0.1,robert kenneth fleck,
-ECON,3140,3,Intermediate Micro,0.24,0.24,0.19,0.14,0.05,0.0,0.0,0.14,patrick warren,
-ECON,3150,1,Intermediate Macro,0.28,0.38,0.18,0.07,0.04,0.0,0.0,0.05,michal jerzmanowski,
-ECON,3150,2,Intermediate Macro,0.34,0.22,0.32,0.0,0.05,0.0,0.0,0.07,sergey vlad mityakov,
-ECON,3440,1,Property Rights,0.13,0.38,0.25,0.17,0.08,0.0,0.0,0.0,dari litsukova-bokar,
-ECON,3500,1,Moral & Ethical Econ,0.44,0.25,0.19,0.0,0.03,0.0,0.0,0.09,bradley keith hobbs,
-ECON,3500,2,Moral & Ethical Econ,0.15,0.35,0.25,0.1,0.0,0.0,0.0,0.15,bradley keith hobbs,
-ECON,3600,1,Public Choice,0.37,0.37,0.2,0.05,0.0,0.0,0.0,0.02,michael makowsky,
-ECON,4010,1,Labor Mkt Analysis,0.24,0.52,0.21,0.0,0.03,0.0,0.0,0.0,curtis simon,
-ECON,4020,1,Law and Economics,0.18,0.33,0.38,0.09,0.0,0.0,0.0,0.02,thomas winsl hazlett,
-ECON,4050,1,Intro to Econometric,0.27,0.29,0.25,0.07,0.07,0.0,0.0,0.04,scott barkowski,
-ECON,4050,2,Intro to Econometric,0.5,0.36,0.0,0.07,0.07,0.0,0.0,0.0,yichen christy zhou,
-ECON,4200,1,Pub Sector Econ,0.48,0.33,0.0,0.0,0.1,0.0,0.0,0.1,william dougan,
-ECON,4230,1,Economics of Health,0.56,0.33,0.1,0.0,0.0,0.0,0.0,0.0,devon merritt gorry,
-ECON,4240,1,Organization of Ind,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,4240,2,Organization of Ind,0.34,0.41,0.17,0.07,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,4260,1,Sem Sport Economics,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,raymond sauer,
-ECON,4270,1,Dev American Economy,0.21,0.52,0.21,0.07,0.0,0.0,0.0,0.0,howard nel bodenhorn,
-ECON,4400,1,Game Theory,0.28,0.41,0.22,0.0,0.0,0.0,0.0,0.09,charles thomas,
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.08,0.15,0.54,0.08,0.0,0.0,0.0,0.15,scott templeton,
-ECON,6060,1,Advanced Econometric,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,los santos babur de babur,
-ECON,8020,2,Adv Econ Concepts and Applic I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui kin,
-ECON,8050,1,Macroeconomic Theory,0.67,0.07,0.2,0.0,0.0,0.0,0.0,0.07,michal jerzmanowski,
-ECON,8070,1,Econometrics II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chungsang lam,
-ECON,8110,1,Econ of Environment,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,scott templeton,
-ECON,8200,1,Public Finance,0.1,0.8,0.0,0.0,0.0,0.0,0.0,0.1,william dougan,
-ECON,9090,1,Time-Series Econ,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
-ECON,9820,1,Workshop in Ap Econ (Macro),0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,gerald dwyer,
-ED,1050,1,Educ Orientation,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,
-ED,1050,2,Educ Orientation,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,
-ED,8600,303,Classroom-Based Research,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,susan ridg nunamaker,
-ED,8650,1,Curriculum Theory,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-ED,8760,301,"Curric, Instruc, Assess, Learn",0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,stephanie burdette,
-EDC,2990,1,Creative Inq in Counselor Ed,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,kend stewart-tillman,
-EDC,3900,2,Skills for Student Leaders,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,3,Skills for Student Leaders,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,eric pernotto,
-EDC,3900,5,Skills for Student Leaders,0.82,0.06,0.12,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,6,Skills for Student Leaders,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,7,Skills for Student Leaders,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,8,Skills for Student Leaders,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDEC,3020,1,Early Childhood Practicum II,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,andrea emerson,
-EDEL,3100,2,Arts in Ele School,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alison eliza leonard,
-EDEL,3210,1,Pe for the Elem Tchr,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4050,1,Soc Justice-21st Cen,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
-EDEL,4520,2,Elem Methods Math Teaching,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nicole alain sinwell,
-EDEL,4870,1,Ele Meth Soc Studies,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,
-EDF,3010,2,Principles of American Educ,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,amaris joseph tejada,
-EDF,3010,3,Principles of American Educ,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,jennifer michel hein,
-EDF,3020,1,Educational Psychology,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,stephen chou,
-EDF,3020,3,Educational Psychology,0.91,0.06,0.0,0.0,0.03,0.0,0.0,0.0,heather roge brooker,
-EDF,3020,4,Educational Psychology,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,heather roge brooker,
-EDF,3020,5,Educational Psychology,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,stephen chou,
-EDF,3200,1,History of US Education,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,beatrice naff bailey,
-EDF,3340,1,Child Growth and Development,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoob jamil,
-EDF,3350,1,Adolescent Growth & Develop,0.71,0.23,0.0,0.0,0.0,0.0,0.0,0.06,luke rapa,
-EDF,4800,1,Digital Media & Learning,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,300,Digital Media & Learning,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,9710,400,Case Study & Ethnographic Mthd,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,reginald wilkerson,
-EDF,9750,501,Mixed Methods Research,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
-EDHD,3110,1,CI- Research in DM & Learning,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,ryan visser,
-EDHD,8310,502,Lit LOS for Child w /disab II,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,renee gatlin anders,
-EDL,9750,1,College Teaching,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
-EDLT,4620,2,Reading Children's Lit in Elem,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,susan king fullerton,
-EDLT,4630,1,Teaching Rdg/Writing for ELLs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDLT,4670,1,Teaching ESOL in Elem Schools,0.77,0.09,0.09,0.0,0.05,0.0,0.0,0.0,quesada hazel  vega m,
-EDLT,8120,300,Assessment in Reading & Writin,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8120,500,Assessment in Reading & Writin,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8120,501,Assessment in Reading & Writin,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8220,300,Strategies for Teaching ESOL,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,mikel walker cole,
-EDLT,8220,500,Strategies for Teaching ESOL,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,barbara fewell,
-EDLT,8410,501,Early Literacy Inst Strategies,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,susanne at elvington,
-EDLT,8410,502,Early Literacy Inst Strategies,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,
-EDLT,8410,507,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
-EDLT,8810,501,Reading Recovery Teacher II,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,
-EDLT,8830,501,Read Recovery Practicum II,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,
-EDLT,8830,506,Read Recovery Practicum II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,
-EDSA,8110,1,Multicultural Counseling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,
-EDSC,4580,1,Sec Soc Capstone,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,
-EDSP,3700,2,Intro to Special Education,0.92,0.06,0.03,0.0,0.0,0.0,0.0,0.0,shanna eisner hirsch,
-EDSP,3700,4,Intro to Special Education,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,pamela stecker,
-EDSP,3700,300,Intro to Special Education,0.74,0.11,0.09,0.03,0.0,0.0,0.0,0.03,shanna eisner hirsch,
-EDSP,3750,1,Early Intervention Spec Needs,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,abigail anne allen,
-EDSP,4910,1,Ed Assess Ind W/Dis,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,antonis katsiyannis,
-EES,2020,1,Environ Engr Fundamentals II,0.67,0.24,0.06,0.0,0.03,0.0,0.0,0.0,kevin thoma finneran,
-EES,4010,1,Environmental Engr,0.5,0.27,0.11,0.0,0.02,0.0,0.0,0.09,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.32,0.38,0.21,0.0,0.03,0.0,0.0,0.06,ezra lucas hoy cates hoy,
-EES,4750,1,Capstone Design Project,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,4850,1,Hazard Waste Management,0.24,0.55,0.12,0.06,0.0,0.0,0.0,0.03,mark schlautman,
-EES,4860,1,Environmental Sustainability,0.7,0.15,0.15,0.0,0.0,0.0,0.0,0.0,michael anthony dale,
-EES,6110,1,Rad Detection Mmt,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,timothy devol,
-EES,8030,1,Phy/Chem Ops W/WW T,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ezra lucas hoy cates hoy,
-EES,8200,1,Env Systems Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michael anthony dale,
-ELE,3010,1,Entrepreneurial Foundations,0.35,0.63,0.03,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
-ELE,3010,2,Entrepreneurial Foundations,0.2,0.75,0.05,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
-ELE,3010,3,Entrepreneurial Foundations,0.15,0.36,0.41,0.05,0.0,0.0,0.0,0.03,ashley willi parnell,
-ELE,4010,1,Venture Testing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,chad navis,
-ELE,4010,2,Venture Testing,0.65,0.27,0.08,0.0,0.0,0.0,0.0,0.0,chad navis,
-ELE,4020,1,Venture Creation,0.32,0.59,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,
-ELE,4030,1,Venture Growth,0.1,0.47,0.4,0.03,0.0,0.0,0.0,0.0,ashley willi parnell,
-ENGL,1030,1,Composition and Rhetoric,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,
-ENGL,1030,2,Composition and Rhetoric,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,jennie eli wakefield,
-ENGL,1030,3,Composition and Rhetoric,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,carley ama robertson,
-ENGL,1030,4,Composition and Rhetoric,0.47,0.27,0.07,0.0,0.13,0.0,0.0,0.07,carley ama robertson,
-ENGL,1030,5,Composition and Rhetoric,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,jennie eli wakefield,
-ENGL,1030,6,Composition and Rhetoric,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,jennie eli wakefield,
-ENGL,1030,7,Composition and Rhetoric,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,courtne huff-oelberg,
-ENGL,1030,8,Composition and Rhetoric,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,courtne huff-oelberg,
-ENGL,1030,9,Composition and Rhetoric,0.6,0.2,0.0,0.0,0.13,0.0,0.0,0.07,carrie hill,
-ENGL,1030,10,Composition and Rhetoric,0.5,0.33,0.0,0.0,0.06,0.0,0.0,0.11,carrie hill,
-ENGL,1030,12,Composition and Rhetoric,0.76,0.14,0.0,0.0,0.1,0.0,0.0,0.0,michael david measel,
-ENGL,1030,13,Composition and Rhetoric,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,sarah eli richardson,
-ENGL,1030,14,Composition and Rhetoric,0.81,0.0,0.05,0.05,0.05,0.0,0.0,0.05,sarah eli richardson,
-ENGL,1030,15,Composition and Rhetoric,0.5,0.17,0.06,0.0,0.17,0.0,0.0,0.11,abigail maxim,
-ENGL,1030,19,Composition and Rhetoric,0.86,0.05,0.0,0.1,0.0,0.0,0.0,0.0,martha sue karnes,
-ENGL,1030,20,Composition and Rhetoric,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,martha sue karnes,
-ENGL,1030,21,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,sarah margare carter,
-ENGL,1030,22,Composition and Rhetoric,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,sarah margare carter,
-ENGL,1030,26,Composition and Rhetoric,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,1030,28,Composition and Rhetoric,0.48,0.43,0.05,0.0,0.05,0.0,0.0,0.0,allen swords,
-ENGL,1030,36,Composition and Rhetoric,0.71,0.1,0.1,0.0,0.05,0.0,0.0,0.05,david charles foltz,
-ENGL,1030,37,Composition and Rhetoric,0.7,0.15,0.0,0.0,0.05,0.0,0.0,0.1,michelle lloyd,
-ENGL,1030,38,Composition and Rhetoric,0.5,0.35,0.0,0.0,0.1,0.0,0.0,0.05,michelle lloyd,
-ENGL,1030,39,Composition and Rhetoric,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,john conway,
-ENGL,1030,41,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,
-ENGL,1030,42,Composition and Rhetoric,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,caroline eliza young,
-ENGL,1030,43,Composition and Rhetoric,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,
-ENGL,1030,44,Composition and Rhetoric,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,caroline eliza young,
-ENGL,1030,45,Composition and Rhetoric,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,beltran dian quaglia,
-ENGL,1030,46,Composition and Rhetoric,0.86,0.09,0.0,0.0,0.05,0.0,0.0,0.0,beltran dian quaglia,
-ENGL,1030,47,Composition and Rhetoric,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,jane elizabe kuebler,
-ENGL,1030,48,Composition and Rhetoric,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jane elizabe kuebler,
-ENGL,1030,49,Composition and Rhetoric,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,charlotte este lucke,
-ENGL,1030,52,Composition and Rhetoric,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,gabrielle gra nugent,
-ENGL,1030,53,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,
-ENGL,1030,54,Composition and Rhetoric,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,valerie smith,
-ENGL,1030,56,Composition and Rhetoric,0.53,0.33,0.0,0.0,0.13,0.0,0.0,0.0,daniel quin atkinson,
-ENGL,1030,57,Composition and Rhetoric,0.81,0.0,0.0,0.06,0.0,0.0,0.0,0.13,christopher stuart,
-ENGL,1030,58,Composition and Rhetoric,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.1,christopher stuart,
-ENGL,1030,60,Composition and Rhetoric,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,stephen hundley,
-ENGL,1030,61,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,austin gorman,
-ENGL,1030,62,Composition and Rhetoric,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,michael russo,
-ENGL,1030,63,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,
-ENGL,1030,64,Composition and Rhetoric,0.61,0.11,0.17,0.0,0.11,0.0,0.0,0.0,shauna chung,
-ENGL,1030,66,Composition and Rhetoric,0.8,0.0,0.07,0.0,0.07,0.0,0.0,0.07,victoria houser,
-ENGL,1030,67,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,
-ENGL,1030,400,Composition and Rhetoric,0.52,0.43,0.0,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,
-ENGL,1030,401,Composition and Rhetoric,0.61,0.17,0.11,0.0,0.06,0.0,0.0,0.06,la'cresha ulon green,
-ENGL,1030,555,Composition and Rhetoric,0.5,0.43,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth steedley,
-ENGL,2020,500,The Major Forms of Literature,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,
-ENGL,2120,1,World Literature,0.11,0.36,0.39,0.11,0.0,0.0,0.0,0.04,david charles foltz,
-ENGL,2120,2,World Literature,0.25,0.36,0.25,0.0,0.04,0.0,0.0,0.11,david charles foltz,
-ENGL,2120,3,World Literature,0.7,0.2,0.07,0.03,0.0,0.0,0.0,0.0,allison nicol harris,
-ENGL,2120,4,World Literature,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
-ENGL,2120,5,World Literature,0.48,0.34,0.14,0.0,0.0,0.0,0.0,0.03,allison nicol harris,
-ENGL,2120,6,World Literature,0.48,0.34,0.1,0.0,0.03,0.0,0.0,0.03,allison nicol harris,
-ENGL,2120,7,World Literature,0.46,0.35,0.04,0.0,0.0,0.0,0.0,0.15,remley meliss makala,
-ENGL,2120,8,World Literature,0.48,0.19,0.11,0.07,0.04,0.0,0.0,0.11,remley meliss makala,
-ENGL,2120,9,World Literature,0.38,0.31,0.14,0.03,0.0,0.0,0.0,0.14,karen kettnich,
-ENGL,2120,10,World Literature,0.59,0.31,0.03,0.0,0.03,0.0,0.0,0.03,karen kettnich,
-ENGL,2120,12,World Literature,0.45,0.41,0.1,0.0,0.0,0.0,0.0,0.03,sharon kathle nalley,
-ENGL,2120,13,World Literature,0.14,0.64,0.14,0.0,0.07,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2120,14,World Literature,0.24,0.48,0.17,0.0,0.0,0.0,0.0,0.1,sarah mae cooper,
-ENGL,2120,15,World Literature,0.48,0.38,0.1,0.03,0.0,0.0,0.0,0.0,sharon kathle nalley,
-ENGL,2120,16,World Literature,0.27,0.43,0.2,0.0,0.1,0.0,0.0,0.0,andrew mathas,
-ENGL,2120,17,World Literature,0.46,0.25,0.18,0.04,0.04,0.0,0.0,0.04,andrew mathas,
-ENGL,2120,18,World Literature,0.47,0.37,0.1,0.0,0.0,0.0,0.0,0.07,chloe miche whitaker,
-ENGL,2120,19,World Literature,0.53,0.33,0.0,0.0,0.03,0.0,0.0,0.1,chloe miche whitaker,
-ENGL,2120,20,World Literature,0.33,0.44,0.19,0.0,0.0,0.0,0.0,0.04,julia brownlee koets,
-ENGL,2120,21,World Literature,0.24,0.68,0.08,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,
-ENGL,2120,22,World Literature,0.24,0.52,0.07,0.07,0.07,0.0,0.0,0.03,hannah pittma godwin,
-ENGL,2120,23,World Literature,0.41,0.41,0.1,0.03,0.03,0.0,0.0,0.0,hannah pittma godwin,
-ENGL,2120,24,World Literature,0.59,0.1,0.14,0.03,0.07,0.0,0.0,0.07,heather pri williams,
-ENGL,2130,1,British Literature,0.41,0.48,0.0,0.0,0.0,0.0,0.0,0.1,christopher benson,
-ENGL,2130,2,British Literature,0.6,0.3,0.0,0.03,0.03,0.0,0.0,0.03,christopher benson,
-ENGL,2130,3,British Literature,0.45,0.34,0.14,0.03,0.03,0.0,0.0,0.0,megan noe macalystre,
-ENGL,2130,4,British Literature,0.3,0.4,0.1,0.03,0.07,0.0,0.0,0.1,megan noe macalystre,
-ENGL,2130,5,British Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,6,British Literature,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,7,British Literature,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,8,British Literature,0.43,0.47,0.07,0.0,0.0,0.0,0.0,0.03,lucian ghita,
-ENGL,2130,9,British Literature,0.3,0.37,0.1,0.2,0.03,0.0,0.0,0.0,megan noe macalystre,
-ENGL,2130,10,British Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2130,11,British Literature,0.57,0.37,0.03,0.0,0.03,0.0,0.0,0.0,chloe miche whitaker,
-ENGL,2130,12,British Literature,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,chloe miche whitaker,
-ENGL,2130,13,British Literature,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2140,1,American Literature,0.76,0.17,0.03,0.03,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,2,American Literature,0.77,0.13,0.07,0.0,0.03,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,3,American Literature,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,lindsay kathl turner,
-ENGL,2140,4,American Literature,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.07,lindsay kathl turner,
-ENGL,2140,5,American Literature,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,melissa dugan,
-ENGL,2140,6,American Literature,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,9,American Literature,0.55,0.24,0.14,0.07,0.0,0.0,0.0,0.0,jennifer ha forsberg,
-ENGL,2140,10,American Literature,0.52,0.34,0.1,0.0,0.03,0.0,0.0,0.0,jennifer ha forsberg,
-ENGL,2140,11,American Literature,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,12,American Literature,0.6,0.33,0.03,0.03,0.0,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,13,American Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2140,14,American Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2140,15,American Literature,0.7,0.11,0.07,0.0,0.04,0.0,0.0,0.07,erin nicholson gale,
-ENGL,2140,16,American Literature,0.7,0.2,0.03,0.07,0.0,0.0,0.0,0.0,erin nicholson gale,
-ENGL,2140,17,American Literature,0.4,0.33,0.17,0.03,0.07,0.0,0.0,0.0,hannah pittma godwin,
-ENGL,2140,18,American Literature,0.37,0.4,0.1,0.0,0.07,0.0,0.0,0.07,hannah pittma godwin,
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.21,0.48,0.17,0.03,0.1,0.0,0.0,0.0,chelsea marie clarey,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.2,0.43,0.27,0.0,0.07,0.0,0.0,0.03,chelsea marie clarey,
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.31,0.34,0.21,0.07,0.07,0.0,0.0,0.0,chelsea marie clarey,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.34,0.28,0.24,0.0,0.07,0.0,0.0,0.07,chelsea marie clarey,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.46,0.32,0.11,0.0,0.0,0.0,0.0,0.11,david charles foltz,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.41,0.41,0.1,0.0,0.0,0.0,0.0,0.07,david charles foltz,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.67,0.27,0.0,0.0,0.03,0.0,0.0,0.03,remley meliss makala,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.47,0.33,0.07,0.0,0.0,0.0,0.0,0.13,remley meliss makala,
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.23,0.17,0.03,0.0,0.0,0.0,0.03,john logan pursley,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.37,0.33,0.17,0.07,0.0,0.0,0.0,0.07,elizabeth stansell,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.73,0.1,0.1,0.0,0.0,0.0,0.0,0.07,jennifer ha forsberg,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.2,0.7,0.07,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.26,0.67,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.4,0.3,0.17,0.07,0.03,0.0,0.0,0.03,andrew mathas,
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.63,0.2,0.07,0.0,0.07,0.0,0.0,0.03,andrew mathas,
-ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.57,0.18,0.14,0.0,0.04,0.0,0.0,0.07,candace wiley,
-ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.73,0.04,0.04,0.0,0.0,0.0,0.0,0.19,candace wiley,
-ENGL,3010,1,Great Books of Western World,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,3040,1,Business Writing,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,sean williams,
-ENGL,3040,2,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
-ENGL,3040,3,Business Writing,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,
-ENGL,3040,4,Business Writing,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulon green,
-ENGL,3040,5,Business Writing,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulon green,
-ENGL,3040,6,Business Writing,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,la'cresha ulon green,
-ENGL,3040,7,Business Writing,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,
-ENGL,3040,8,Business Writing,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,
-ENGL,3040,9,Business Writing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3040,10,Business Writing,0.48,0.38,0.05,0.0,0.1,0.0,0.0,0.0,katalin beck,
-ENGL,3040,12,Business Writing,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,stephen quigley,
-ENGL,3040,400,Business Writing,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,
-ENGL,3040,401,Business Writing,0.5,0.35,0.15,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,
-ENGL,3040,402,Business Writing,0.63,0.16,0.11,0.05,0.0,0.0,0.0,0.05,kriste aldebol-hazle,
-ENGL,3040,403,Business Writing,0.6,0.25,0.05,0.05,0.05,0.0,0.0,0.0,kriste aldebol-hazle,
-ENGL,3100,1,Crit Writ Lit,0.25,0.44,0.31,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,3100,2,Crit Writ Lit,0.24,0.47,0.18,0.06,0.06,0.0,0.0,0.0,lee morrissey,
-ENGL,3100,3,Crit Writ Lit,0.33,0.38,0.14,0.0,0.05,0.0,0.0,0.1,dominic mastroianni,
-ENGL,3100,4,Crit Writ Lit,0.4,0.45,0.1,0.0,0.0,0.0,0.0,0.05,erin marina goss,
-ENGL,3120,1,Advanced Composition,0.38,0.57,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
-ENGL,3120,2,Advanced Composition,0.57,0.38,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth stansell,
-ENGL,3140,1,Technical Writing,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,2,Technical Writing,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3140,3,Technical Writing,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,eric stephens,
-ENGL,3140,4,Technical Writing,0.81,0.14,0.0,0.05,0.0,0.0,0.0,0.0,eric stephens,
-ENGL,3140,5,Technical Writing,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,heather pri williams,
-ENGL,3140,9,Technical Writing,0.57,0.33,0.0,0.05,0.05,0.0,0.0,0.0,geveryl lee robinson,
-ENGL,3140,10,Technical Writing,0.38,0.57,0.0,0.0,0.0,0.0,0.0,0.05,geveryl lee robinson,
-ENGL,3140,11,Technical Writing,0.35,0.6,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,12,Technical Writing,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,katalin beck,
-ENGL,3140,14,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,samuel jackso fuller,
-ENGL,3140,15,Technical Writing,0.71,0.19,0.05,0.05,0.0,0.0,0.0,0.0,brian lee gaines,
-ENGL,3140,16,Technical Writing,0.81,0.1,0.0,0.0,0.05,0.0,0.0,0.05,brian lee gaines,
-ENGL,3140,20,Technical Writing,0.71,0.14,0.1,0.05,0.0,0.0,0.0,0.0,sharon kathle nalley,
-ENGL,3140,21,Technical Writing,0.86,0.05,0.0,0.05,0.05,0.0,0.0,0.0,joshua wood,
-ENGL,3140,23,Technical Writing,0.52,0.19,0.14,0.05,0.0,0.0,0.0,0.1,heather pri williams,
-ENGL,3140,24,Technical Writing,0.05,0.24,0.19,0.1,0.19,0.0,0.0,0.24,geveryl lee robinson,
-ENGL,3140,400,Technical Writing,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,
-ENGL,3150,1,Scientific Writing & Comm,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,philip randall,
-ENGL,3150,2,Scientific Writing & Comm,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,
-ENGL,3150,3,Scientific Writing & Comm,0.38,0.48,0.1,0.05,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3150,4,Scientific Writing & Comm,0.53,0.24,0.0,0.06,0.06,0.0,0.0,0.12,william pulley,
-ENGL,3150,400,Scientific Writing,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,
-ENGL,3150,401,Scientific Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,402,Scientific Writing & Comm,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,john conway,
-ENGL,3150,404,Scientific Writing,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,philip randall,
-ENGL,3320,1,Visual Communication,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,megan eatman,
-ENGL,3450,1,Structure of Fiction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,3460,1,Structure of Poetry,0.5,0.38,0.06,0.0,0.0,0.0,0.0,0.06,jillian weise,
-ENGL,3480,1,Structure Screenplay,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,julia brownlee koets,
-ENGL,3480,2,Structure Screenplay,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,
-ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,matthew hooley,
-ENGL,3570,1,Film,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,john robert smith,
-ENGL,3570,2,Film,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,john robert smith,
-ENGL,3570,3,Film,0.62,0.33,0.0,0.0,0.05,0.0,0.0,0.0,john robert smith,
-ENGL,3860,1,Adolescent Lit,0.56,0.28,0.06,0.06,0.06,0.0,0.0,0.0,megan noe macalystre,
-ENGL,3970,1,Brit Lit Survey II,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,
-ENGL,3980,1,Amer Lit Survey I,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,kimberly manganelli,
-ENGL,3980,2,Amer Lit Survey I,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,susanna ashton,
-ENGL,4110,1,Shakespeare,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,brian mcgrath,
-ENGL,4110,3,Shakespeare,0.25,0.4,0.3,0.05,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4160,1,Romantic Period,0.36,0.21,0.21,0.21,0.0,0.0,0.0,0.0,brian mcgrath,
-ENGL,4180,1,English Novel,0.42,0.37,0.11,0.0,0.11,0.0,0.0,0.0,david sweeney coombs,
-ENGL,4190,1,Post Col & World Lit,0.4,0.47,0.07,0.07,0.0,0.0,0.0,0.0,cameron fae bushnell,
-ENGL,4210,1,Amer Lit 1800-1899,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,dominic mastroianni,
-ENGL,4280,1,Contemporary Literature,0.53,0.16,0.26,0.0,0.05,0.0,0.0,0.0,william stockton,
-ENGL,4400,1,Literary Theory,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,maria selene bose,
-ENGL,4420,1,Cultural Studies,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
-ENGL,4450,1,Fiction Workshop,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,4460,1,Poetry Workshop,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,jillian weise,
-ENGL,4510,1,Film Theory and Criticism,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,
-ENGL,4540,1,Sel Top in International Film,0.47,0.33,0.13,0.07,0.0,0.0,0.0,0.0,agnieszka skrodzka,
-ENGL,4590,1,Between Damaged Life/Arcades,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,michelle renee ty,
-ENGL,4640,1,Topics in Literature 1700-1899,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,erin marina goss,
-ENGL,4750,1,Writing for Media,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,gabriel ande hankins,
-ENGL,4850,1,Comp & Lang Teachers,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,calandra harri davis,
-ENGL,4890,1,Topics Write & Publ,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,tharon howard,
-ENGL,4920,1,Modern Rhetoric,0.59,0.24,0.06,0.06,0.0,0.0,0.0,0.06,michelle smith,
-ENGL,4960,1,Senior Seminar,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,angela naimou,
-ENGL,4960,2,Senior Seminar,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,michael lemahieu,
-ENGL,4960,3,Senior Seminar,0.69,0.08,0.0,0.23,0.0,0.0,0.0,0.0,michelle renee ty,
-ENGL,8850,1,Composition Theory,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,megan eatman,
-ENGR,1020,211,Engineering Discipl & Skills,0.08,0.29,0.25,0.13,0.17,0.0,0.0,0.08,ashley childers,
-ENGR,1020,212,Engineering Discipl & Skills,0.1,0.33,0.2,0.3,0.03,0.0,0.0,0.03,ashley childers,
-ENGR,1020,213,Engineering Discipl & Skills,0.28,0.28,0.16,0.13,0.06,0.0,0.0,0.09,irene marie ferrara,
-ENGR,1020,214,Engineering Discipl & Skills,0.38,0.23,0.19,0.04,0.15,0.0,0.0,0.0,irene marie ferrara,
-ENGR,1150,321,Engineering Design & Modeling,0.41,0.36,0.05,0.05,0.09,0.0,0.0,0.05,john minor,
-ENGR,1410,215,Programming & Problem Solving,0.3,0.43,0.09,0.04,0.04,0.0,0.0,0.11,jonathan broo harcum,
-ENGR,1410,322,Programming & Problem Solving,0.37,0.3,0.2,0.04,0.0,0.0,0.0,0.09,michael giebner,
-ENGR,1410,323,Programming & Problem Solving,0.2,0.43,0.15,0.13,0.0,0.0,0.0,0.09,michael giebner,
-ENGR,1410,324,Programming & Problem Solving,0.2,0.58,0.09,0.02,0.02,0.0,0.0,0.09,andrew isaac neptune,
-ENGR,1410,325,Programming & Problem Solving,0.38,0.38,0.15,0.02,0.0,0.0,0.0,0.08,andrew isaac neptune,
-ENGR,1410,326,Programming & Problem Solving,0.26,0.44,0.16,0.05,0.0,0.0,0.0,0.09,jonathan broo harcum,
-ENGR,1410,327,Programming & Problem Solving,0.22,0.5,0.2,0.02,0.02,0.0,0.0,0.04,irene marie ferrara,
-ENGR,1410,501,Programming & Problem Solving,0.21,0.29,0.32,0.18,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,1410,621,Programming & Problem Solving,0.43,0.43,0.12,0.0,0.0,0.0,0.0,0.02,elizabeth an stephan,
-ENGR,1410,622,Programming & Problem Solving,0.26,0.55,0.14,0.0,0.0,0.0,0.0,0.05,jonathan broo harcum,
-ENGR,1410,623,Programming & Problem Solving,0.08,0.58,0.26,0.03,0.0,0.0,0.0,0.05,elizabeth an stephan,
-ENGR,1410,624,Programming & Problem Solving,0.3,0.53,0.02,0.07,0.02,0.0,0.0,0.05,sarah grigg,
-ENGR,1410,625,Programming & Problem Solving,0.3,0.41,0.2,0.07,0.02,0.0,0.0,0.0,matthew kent miller,
-ENGR,1410,626,Programming & Problem Solving,0.14,0.48,0.24,0.05,0.0,0.0,0.0,0.1,matthew kent miller,
-ENGR,1410,627,Programming & Problem Solving,0.29,0.48,0.19,0.05,0.0,0.0,0.0,0.0,matthew kent miller,
-ENGR,1410,821,Programming & Problem Solving,0.31,0.33,0.17,0.1,0.05,0.0,0.0,0.05,william martin,
-ENGR,1410,822,Programming & Problem Solving,0.33,0.45,0.14,0.02,0.02,0.0,0.0,0.02,william martin,
-ENGR,1410,823,Program & Prob Solving (HON),0.72,0.26,0.0,0.02,0.0,0.0,0.0,0.0,steven brandon,True
-ENGR,1410,824,Program & Prob Solving (HON),0.65,0.24,0.08,0.0,0.0,0.0,0.0,0.03,steven brandon,True
-ENGR,1410,825,Programming & Problem Solving,0.23,0.45,0.2,0.0,0.07,0.0,0.0,0.05,mariah so magagnotti,
-ENGR,1410,826,Programming & Problem Solving,0.24,0.33,0.29,0.04,0.04,0.0,0.0,0.04,mariah so magagnotti,
-ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.2,0.0,0.0,0.0,0.0,0.07,andrew isaac neptune,
-ENGR,1900,10,CI in Engr I (Robotics),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael benja wooten,
-ENGR,2080,284,Engr Graphics & Machine Design,0.56,0.21,0.15,0.04,0.0,0.0,0.0,0.04,jonathan maier,
-ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.25,0.08,0.0,0.06,0.0,0.0,0.04,anthony paul garland,
-ENGR,2080,286,Engr Graphics & Machine Design,0.4,0.25,0.13,0.06,0.06,0.0,0.0,0.1,anthony paul garland,
-ENGR,2080,382,Engr Graphics & Machine Design,0.6,0.25,0.04,0.02,0.08,0.0,0.0,0.02,nighat yasmin,
-ENGR,2080,384,Engr Graphics & Machine Design,0.54,0.21,0.08,0.06,0.12,0.0,0.0,0.0,jonathan maier,
-ENGR,2080,682,Engr Graphics & Machine Design,0.63,0.29,0.06,0.0,0.02,0.0,0.0,0.0,anthony paul garland,
-ENGR,2080,684,Engr Graphics & Machine Design,0.58,0.27,0.04,0.02,0.06,0.0,0.0,0.02,john minor,
-ENGR,2080,882,Engr Graphics & Machine Design,0.74,0.19,0.0,0.02,0.04,0.0,0.0,0.02,garrison lloy broome,
-ENGR,2080,884,Engr Graphics & Machine Design,0.49,0.31,0.1,0.02,0.04,0.0,0.0,0.04,garrison lloy broome,
-ENGR,2100,104,CAD & Engineering Applications,0.48,0.38,0.06,0.02,0.02,0.0,0.0,0.04,esfandabadi al shams,
-ENGR,2100,105,CAD & Engineering Applications,0.45,0.36,0.11,0.0,0.04,0.0,0.0,0.04,esfandabadi al shams,
-ENGR,2100,201,CAD & Engineering Applications,0.44,0.35,0.16,0.02,0.02,0.0,0.0,0.02,nighat yasmin,
-ENGR,2100,202,CAD & Engineering Applications,0.41,0.3,0.07,0.04,0.11,0.0,0.0,0.07,nighat yasmin,
-ENGR,2200,116,Evaluating Innovations,0.4,0.48,0.04,0.04,0.0,0.0,0.0,0.04,sarah grigg,
-ENGR,2200,117,Evaluating Innovations,0.32,0.48,0.13,0.03,0.0,0.0,0.0,0.03,sarah grigg,
-ENR,1020,1,Intro to Envir & Natur Res II,0.72,0.11,0.06,0.04,0.0,0.0,0.0,0.06,russell barrett,
-ENR,3020,1,Nat Res Measurements,0.62,0.21,0.13,0.0,0.0,0.0,0.0,0.05,lawrence gering,
-ENR,4130,2,Restoration Ecology,0.28,0.5,0.19,0.0,0.0,0.0,0.0,0.03,althea simone hagan,
-ENR,4500,1,Conservation Issues,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,alan johnson,
-ENR,4500,2,Conservation Issues,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
-ENR,6130,2,Restoration Ecology,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,althea simone hagan,
-ENSP,2000,1,Intro Environ Sci,0.36,0.44,0.11,0.05,0.02,0.0,0.0,0.02,tom owino,
-ENSP,2000,2,Intro Environ Sci,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-ENSP,2000,3,Intro Environ Sci,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2000,4,Intro Environ Sci,0.59,0.22,0.13,0.02,0.04,0.0,0.0,0.0,minory nammouz,
-ENSP,2010,1,Environm Sci for Educ Majors,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,4000,1,Studies in Environmental Sci,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,margaret lo thompson,
-ENT,2000,1,Six-Legged Science,0.47,0.3,0.14,0.09,0.0,0.0,0.0,0.0,suellen pometto,
-ENTR,1010,1,Entrepreneurial Mindset,0.72,0.11,0.07,0.01,0.05,0.0,0.0,0.04,john michael hannon,
-ENTR,1090,1,CI- How to Start a Startup,0.81,0.05,0.0,0.0,0.0,0.0,0.0,0.14,john michael hannon,
-ENTR,2010,3,Sports Entrepreneurship,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
-ESED,1990,1,Creative Inq Engr & Sci Ed I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,claire louise dancz,
-ESED,2990,1,Creative Inq Engr & Sci Ed II,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,claire louise dancz,
-ESED,4910,5,Undergraduate Research,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,claire louise dancz,
-ETOX,8300,1,Mechanistic Toxicology,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,
-FDSC,2140,1,Fd Resources & Soc,0.62,0.18,0.1,0.0,0.04,0.0,0.0,0.06,paul dawson,
-FDSC,2150,1,Culinary Fundamental,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,
-FDSC,3040,1,Eval Dairy Products,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-FDSC,4020,1,Food Chemistry II,0.32,0.49,0.12,0.07,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4030,1,Food Ch & Analysis,0.74,0.13,0.11,0.0,0.0,0.0,0.0,0.02,paul dawson,
-FDSC,4080,1,Food Process Eng,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,felix barron,
-FDSC,4090,1,TQM for Food & Pckg Industries,0.61,0.18,0.06,0.09,0.0,0.0,0.0,0.06,john mcgregor,
-FDSC,4100,1,Food Product Dev,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,margaret condrasky,
-FDSC,4170,1,Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
-FIN,2010,401,Intro to Personal Finance,0.92,0.06,0.0,0.0,0.02,0.0,0.0,0.0,joshua harris,
-FIN,2010,402,Intro to Personal Finance,0.87,0.11,0.0,0.02,0.0,0.0,0.0,0.0,joshua harris,
-FIN,2010,403,Intro to Personal Finance,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,joshua harris,
-FIN,2010,404,Intro to Personal Finance,0.79,0.12,0.04,0.01,0.01,0.0,0.0,0.01,joshua harris,
-FIN,2010,405,Intro to Personal Finance,0.75,0.15,0.06,0.0,0.02,0.0,0.0,0.02,joshua harris,
-FIN,2010,406,Intro to Personal Finance,0.76,0.13,0.02,0.02,0.0,0.0,0.0,0.07,joshua harris,
-FIN,3040,1,Risk & Insurance,0.22,0.3,0.48,0.0,0.0,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.11,0.36,0.39,0.04,0.04,0.0,0.0,0.07,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.26,0.37,0.26,0.08,0.0,0.0,0.0,0.03,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.15,0.33,0.48,0.0,0.03,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,4,Investment Analysis,0.15,0.15,0.32,0.24,0.03,0.0,0.0,0.12,john alexander,
-FIN,3060,1,Corporation Finance,0.2,0.14,0.2,0.2,0.2,0.0,0.0,0.08,william holl johnson,
-FIN,3060,2,Corporation Finance,0.37,0.08,0.21,0.21,0.06,0.0,0.0,0.08,william holl johnson,
-FIN,3060,3,Corporation Finance,0.37,0.2,0.1,0.12,0.12,0.0,0.0,0.08,william holl johnson,
-FIN,3060,4,Corporation Finance,0.1,0.18,0.16,0.14,0.22,0.0,0.0,0.2,william holl johnson,
-FIN,3060,5,Corporation Finance,0.06,0.28,0.3,0.24,0.06,0.0,0.0,0.06,ramon tolbe franklin,
-FIN,3060,6,Corporation Finance,0.12,0.29,0.2,0.18,0.14,0.0,0.0,0.06,ramon tolbe franklin,
-FIN,3060,7,Corporation Finance,0.31,0.24,0.28,0.11,0.04,0.0,0.0,0.02,ramon tolbe franklin,
-FIN,3060,8,Corporation Finance,0.19,0.31,0.22,0.19,0.02,0.0,0.0,0.07,ramon tolbe franklin,
-FIN,3070,1,Prin of Real Estate,0.23,0.43,0.26,0.06,0.03,0.0,0.0,0.0,yannan shen,
-FIN,3070,2,Prin of Real Estate,0.23,0.46,0.23,0.06,0.03,0.0,0.0,0.0,yannan shen,
-FIN,3070,3,Prin of Real Estate,0.23,0.26,0.28,0.15,0.05,0.0,0.0,0.03,thomas springer,
-FIN,3080,1,Fin Inst & Mkts,0.16,0.46,0.24,0.05,0.05,0.0,0.0,0.03,daniel thomas greene,
-FIN,3080,2,Fin Inst & Mkts,0.32,0.34,0.29,0.05,0.0,0.0,0.0,0.0,daniel thomas greene,
-FIN,3080,3,Fin Inst & Mkts,0.32,0.29,0.24,0.11,0.05,0.0,0.0,0.0,daniel thomas greene,
-FIN,3110,1,Financial Management I,0.21,0.33,0.18,0.05,0.0,0.0,0.0,0.23,george bran lockhart,
-FIN,3110,2,Financial Management I,0.08,0.35,0.33,0.05,0.08,0.0,0.0,0.13,george bran lockhart,
-FIN,3110,3,Financial Management I,0.18,0.33,0.23,0.0,0.13,0.0,0.0,0.15,george bran lockhart,
-FIN,3110,4,Financial Management I,0.06,0.25,0.44,0.03,0.08,0.0,0.0,0.14,jack wolf,
-FIN,3120,1,Financial Management II,0.24,0.38,0.24,0.08,0.0,0.0,0.0,0.05,blerina zykaj,
-FIN,3120,2,Financial Management II,0.47,0.19,0.28,0.06,0.0,0.0,0.0,0.0,blerina zykaj,
-FIN,3120,3,Financial Management II,0.18,0.41,0.23,0.08,0.03,0.0,0.0,0.08,weike xu,
-FIN,3120,4,Financial Management II,0.14,0.34,0.29,0.11,0.03,0.0,0.0,0.09,weike xu,
-FIN,4030,1,Spreadsheet Apps in Finance,0.23,0.51,0.26,0.0,0.0,0.0,0.0,0.0,vincent ja intintoli,
-FIN,4030,2,Spreadsheet Apps in Finance,0.2,0.4,0.24,0.12,0.04,0.0,0.0,0.0,vincent ja intintoli,
-FIN,4040,1,Financial Modeling,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,jack wolf,
-FIN,4050,1,Portfolio Management & Theory,0.13,0.27,0.23,0.13,0.17,0.0,0.0,0.07,john alexander,
-FIN,4080,1,Mgt of Fin Inst,0.33,0.57,0.1,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4080,2,Mgt of Fin Inst,0.19,0.44,0.31,0.06,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4090,1,Prof Fin Plan Capstone,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,
-FIN,4110,1,Int Fin Mgt,0.27,0.55,0.12,0.06,0.0,0.0,0.0,0.0,luke asher devault,
-FIN,4110,2,Int Fin Mgt,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,luke asher devault,
-FIN,4150,1,Real Estate Investmt,0.24,0.29,0.33,0.14,0.0,0.0,0.0,0.0,thomas springer,
-FIN,4160,1,Real Estate Val,0.31,0.31,0.31,0.0,0.06,0.0,0.0,0.0,valerie lynn hammett,
-FNR,4700,35,Aquaponics,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,lance edward beecher,
-FNR,4700,52,Stream & Reservoir Fish Eco I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,troy mason farmer,
-FNR,4990,1,Natural Resources Seminar,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
-FNR,4990,2,Natural Resources Seminar,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,susan talley guynn,
-FNR,4990,3,Natural Resources Seminar,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
-FOR,1010,1,Intro to Forestry,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,lawrence gering,
-FOR,2060,1,Forestry Ecology,0.23,0.43,0.22,0.04,0.05,0.0,0.0,0.03,donald hagan,
-FOR,3080,1,Remote Sensing in Forestry,0.43,0.47,0.1,0.0,0.0,0.0,0.0,0.0,lawrence gering,
-FOR,4080,1,Wood and Paper Products,0.52,0.29,0.14,0.05,0.0,0.0,0.0,0.0,patricia layton,
-FOR,4150,1,Forest Wildlife Managment,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james davis,
-FOR,4180,1,Forest Resource Valuation,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4340,1,GIS for Natural Resources,0.28,0.58,0.1,0.03,0.0,0.0,0.0,0.03,robert fritz baldwin,
-FOR,4650,1,Silviculture,0.12,0.54,0.31,0.04,0.0,0.0,0.0,0.0,gaofeng wang,
-FOR,6340,1,GIS for Natural Resources,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert fritz baldwin,
-FOR,8120,1,Fire Ecology and Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,gaofeng wang,
-FR,1010,1,Elementary French,0.24,0.53,0.24,0.0,0.0,0.0,0.0,0.0, nedeo anne salces anne,
-FR,1010,2,Elementary French,0.41,0.12,0.29,0.0,0.06,0.0,0.0,0.12, nedeo anne salces anne,
-FR,1010,3,Elementary French,0.29,0.14,0.14,0.21,0.14,0.0,0.0,0.07,kenneth davi widgren,
-FR,1020,1,Elementary French,0.76,0.18,0.0,0.06,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
-FR,1020,2,Elementary French,0.5,0.2,0.2,0.1,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
-FR,2010,2,Intermediate French,0.8,0.16,0.0,0.0,0.04,0.0,0.0,0.0,amy lyn griff sawyer griff,
-FR,2010,3,Intermediate French,0.19,0.5,0.19,0.06,0.0,0.0,0.0,0.06,kenneth davi widgren,
-FR,2010,4,Intermediate French,0.22,0.33,0.33,0.0,0.0,0.0,0.0,0.11,kenneth davi widgren,
-FR,2020,1,Intermediate French,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,tholozany pauline de,
-FR,2020,2,Intermediate French,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
-FR,2020,4,Intermediate French,0.06,0.82,0.12,0.0,0.0,0.0,0.0,0.0,kenneth davi widgren,
-FR,3050,1,Int Fr Con & Comp I,0.59,0.06,0.24,0.0,0.0,0.0,0.0,0.12, nedeo anne salces anne,
-FR,3160,1,Fr for Intl Trade,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,
-FR,3170,1,Contemp French Civ,0.76,0.18,0.0,0.06,0.0,0.0,0.0,0.0,joseph mai,
-FR,4760,1,French Feminism and Theory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,
-GC,1010,1,Orientation to G C,0.5,0.3,0.09,0.0,0.02,0.0,0.0,0.09,john leininger,
-GC,1020,1,Computer Art & CAD Foundations,0.46,0.33,0.1,0.04,0.02,0.0,0.0,0.06,carol jones,
-GC,1030,1,G C I for Pkgsc,0.26,0.55,0.18,0.0,0.0,0.0,0.0,0.0,john jacobs,
-GC,1040,1,Graphic Communications I,0.66,0.21,0.05,0.03,0.02,0.0,0.0,0.03,rebecca suzan edlein,
-GC,2070,1,Graphic Communications II,0.3,0.5,0.07,0.04,0.04,0.0,0.0,0.04,charles tabor weiss,
-GC,3400,1,Digital Imaging and eMedia,0.4,0.43,0.1,0.05,0.0,0.0,0.0,0.03,erica black walker,
-GC,3460,1,Ink and Substrates,0.17,0.61,0.15,0.0,0.04,0.0,0.0,0.02,liam henry 'hara,
-GC,4060,1,Package and Specialty Printing,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,kern cox,
-GC,4400,1,Commercial Printing,0.53,0.33,0.07,0.0,0.03,0.0,0.0,0.03,john leininger,
-GC,4440,1,Current Dev/Trends in Gr Comm,0.73,0.22,0.03,0.03,0.0,0.0,0.0,0.0,samuel ingram,
-GC,4480,1,Plan & Cont Printing Functions,0.83,0.09,0.09,0.0,0.0,0.0,0.0,0.0,nona woolbright,
-GC,4800,1,Senior Seminar in GC,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,charles edwar tonkin,
-GC,4900,2,G C Selected Topics-Sales,0.82,0.06,0.0,0.0,0.0,0.0,0.0,0.12,john leininger,
-GC,4900,3,Select Topic-Dig Media Design,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,erica black walker,
-GEN,3000,1,Fundamental Genetics,0.27,0.29,0.3,0.09,0.03,0.0,0.0,0.03,kate leanne wil tsai wil,
-GEN,3000,2,Fundamental Genetics,0.23,0.41,0.22,0.07,0.01,0.0,0.0,0.05,kate leanne wil tsai wil,
-GEN,3020,1,Molecular & General Genetics,0.36,0.41,0.11,0.05,0.0,0.0,0.0,0.07,rajandeep sin sekhon,
-GEN,3040,1,Molecular Biology Laboratory,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,3040,4,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,4100,1,Population & Quant Genetics,0.38,0.43,0.15,0.02,0.02,0.0,0.0,0.0,scott michael tanner,
-GEN,4110,3,Population & Quant Gen Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
-GEN,4400,1,Bioinformatics,0.53,0.35,0.06,0.0,0.06,0.0,0.0,0.0,liangjiang wang,
-GEN,4700,1,Human Genetics,0.42,0.23,0.15,0.0,0.0,0.0,0.0,0.19,miriam kristi konkel,
-GEN,4900,13,GB Professional Development,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,alison ni starr-moss,
-GEN,4930,3,Senior Seminar,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,alison ni starr-moss,
-GEN,8100,1,Princ of Molecular Biology,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,jennifer may mason,
-GEOG,1010,1,Intro to Geography,0.34,0.37,0.14,0.09,0.0,0.0,0.0,0.06,christa smith,
-GEOG,1030,1,World Regional Geography,0.34,0.46,0.09,0.03,0.03,0.0,0.0,0.04,william church terry,
-GEOL,1010,1,Physical Geology,0.28,0.32,0.2,0.1,0.04,0.0,0.0,0.07,alan coulson,
-GEOL,1010,2,Physical Geology,0.57,0.19,0.1,0.06,0.04,0.0,0.0,0.04,alan coulson,
-GEOL,1010,3,Physical Geology,0.26,0.26,0.21,0.1,0.1,0.0,0.0,0.07,mary katherin fidler,
-GEOL,1030,1,Physical Geol Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.48,0.43,0.0,0.0,0.0,0.0,0.0,0.09,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,9,Physical Geol Lab,0.26,0.39,0.17,0.04,0.0,0.0,0.0,0.13,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.58,0.21,0.13,0.0,0.04,0.0,0.0,0.04,alan coulson,
-GEOL,1030,13,Physical Geol Lab,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,alan coulson,
-GEOL,1120,1,Earth Resources,0.42,0.33,0.17,0.04,0.04,0.0,0.0,0.0,mary katherin fidler,
-GEOL,1140,1,Earth Resources Lab,0.6,0.17,0.13,0.1,0.0,0.0,0.0,0.0,mary katherin fidler,
-GEOL,2020,1,Earth History,0.28,0.44,0.22,0.06,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,3130,1,Sedimentology & Stratigraphy,0.26,0.35,0.39,0.0,0.0,0.0,0.0,0.0,mary katherin fidler,
-GEOL,3180,1,Introduction to Geochemistry,0.46,0.42,0.13,0.0,0.0,0.0,0.0,0.0,brian powell,
-GEOL,4210,1,Gis in Geology,0.74,0.15,0.07,0.04,0.0,0.0,0.0,0.0,scott brame,
-GEOL,7900,501,Biogeography & Geology of SC,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
-GEOL,8030,1,Geostatistics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,stephen micha moysey,
-GEOL,8090,1,Subsurface Remed Mod,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,ronald falta,
-GEOL,8160,1,Aquifer Systems,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
-GER,1010,1,Elementary German,0.11,0.26,0.26,0.05,0.16,0.0,0.0,0.16,isabel meusen,
-GER,1010,2,Elementary German,0.11,0.44,0.11,0.11,0.06,0.0,0.0,0.17,isabel meusen,
-GER,1020,1,Elementary German,0.31,0.38,0.25,0.0,0.06,0.0,0.0,0.0,oswald harris king,
-GER,2010,1,Intermediate German,0.26,0.21,0.42,0.0,0.11,0.0,0.0,0.0, lee ferrell,
-GER,2010,2,Intermediate German,0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,oswald harris king,
-GER,2020,1,Intermediate German,0.4,0.2,0.13,0.2,0.0,0.0,0.0,0.07,gabriela stoicea,
-GER,2020,2,Intermediate German,0.46,0.15,0.23,0.08,0.0,0.0,0.0,0.08,gabriela stoicea,
-GER,3060,1,German Short Story,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,oswald harris king,
-HCC,8810,1,Measurement & Eval,0.38,0.46,0.0,0.0,0.15,0.0,0.0,0.0,bart knijnenburg,
-HCG,9050,1,"Genomics, Ethics & Hlth Policy",0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
-HIST,1010,1,History of the United States,0.53,0.32,0.12,0.0,0.03,0.0,0.0,0.0,james bradf jeffries,
-HIST,1240,1,Environmental History Survey,0.16,0.55,0.21,0.0,0.05,0.0,0.0,0.03,james bradf jeffries,
-HIST,1720,3,The West and the World I,0.26,0.53,0.18,0.0,0.03,0.0,0.0,0.0,thomas kuehn,
-HIST,1730,1,The West and the World II,0.18,0.48,0.13,0.01,0.1,0.0,0.0,0.1, alan grubb,
-HIST,1730,2,The West and the World II,0.18,0.42,0.27,0.04,0.06,0.0,0.0,0.03,michael meng,
-HIST,1730,3,The West and the World II,0.39,0.37,0.16,0.04,0.02,0.0,0.0,0.03,steven marks,
-HIST,2990,1,Historian's Craft,0.54,0.17,0.04,0.04,0.04,0.0,0.0,0.17,michael silvestri,
-HIST,2990,2,Historian's Craft,0.83,0.09,0.0,0.0,0.04,0.0,0.0,0.04,rachel anne moore,
-HIST,3110,1,African American Hist to 1877,0.41,0.33,0.19,0.0,0.0,0.0,0.0,0.07,abel bartley,
-HIST,3230,1,Hist of Amer Tech,0.42,0.46,0.08,0.0,0.0,0.0,0.0,0.04,pamela mack,
-HIST,3240,1,Hist of the South II,0.36,0.19,0.17,0.06,0.14,0.0,0.0,0.08,john andrew,
-HIST,3250,1,Amer Econ Developmt,0.17,0.5,0.08,0.0,0.04,0.0,0.0,0.21,william camp,
-HIST,3260,1,Hist Am Transport,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04, roger grant,
-HIST,3420,1,South Am Since 1800,0.6,0.37,0.0,0.0,0.03,0.0,0.0,0.0,rachel anne moore,
-HIST,3610,1,History of Britain to 1688,0.41,0.41,0.14,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,
-HIST,3810,1,Germany 1918 to 1945,0.22,0.33,0.3,0.0,0.07,0.0,0.0,0.07,michael meng,
-HIST,3900,1,Modern Military History,0.29,0.42,0.25,0.04,0.0,0.0,0.0,0.0,edwin moise,
-HIST,3920,1,Hist U S Environment,0.27,0.5,0.13,0.03,0.03,0.0,0.0,0.03,william camp,
-HIST,3970,1,Modern Middle East,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,amit bein,
-HIST,3980,1,American Military History,0.2,0.43,0.17,0.07,0.07,0.0,0.0,0.07,john andrew,
-HIST,4360,1,Vietnam Wars,0.12,0.53,0.24,0.0,0.12,0.0,0.0,0.0,edwin moise,
-HIST,4600,1,Film and Empire,0.53,0.33,0.07,0.0,0.0,0.0,0.0,0.07,michael silvestri,
-HIST,4930,1,The American City,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,abel bartley,
-HIST,4940,1,Russian Film History,0.29,0.29,0.0,0.0,0.29,0.0,0.0,0.14,steven marks,
-HLTH,2020,1,Introduction to Public Health,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,2,Introduction to Public Health,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2020,400,Introduction to Public Health,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,ralph stewart welsh,
-HLTH,2020,401,Introduction to Public Health,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.52,0.34,0.14,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2030,2,Health Care Sys,0.45,0.48,0.07,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2030,3,Health Care Sys,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
-HLTH,2030,400,Health Care Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2400,1,Deter of Hlth Behav,0.52,0.36,0.04,0.04,0.0,0.0,0.0,0.04,amelia clinkscales,
-HLTH,2400,2,Deter of Hlth Behav,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2400,400,Deter of Hlth Behav,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,2500,1,Health and Fitness,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.04,ralph stewart welsh,
-HLTH,2600,1,Medical Terminology & Comm,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,karen edwards,
-HLTH,2600,2,Medical Terminology & Comm,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,
-HLTH,2980,1,Human Health and Disease,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,2980,2,Human Health and Disease,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,3030,1,Public Health Comm,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
-HLTH,3800,1,Epidemiology,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,hugh spitler,
-HLTH,3800,2,Epidemiology,0.56,0.28,0.16,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,3980,1,Health Appraisal Skills,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,3980,2,Health Appraisal Skills,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.7,0.23,0.08,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.79,0.18,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4310,1,Public & Environ Hlt,0.54,0.33,0.1,0.0,0.0,0.0,0.0,0.03,deborah alma falta,
-HLTH,4700,1,Global Health,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,micky rogers ward,
-HLTH,4780,1,Health Policy Ethics and Law,0.44,0.19,0.25,0.0,0.13,0.0,0.0,0.0,hugh spitler,
-HLTH,4800,1,Comm Hlth Promotion,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,sarah griffin,
-HLTH,4900,1,Res Eval St Pub Hlth,0.55,0.25,0.1,0.05,0.0,0.0,0.0,0.05,karen kemper,
-HLTH,4900,2,Res Eval St Pub Hlth,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,4900,3,Res Eval St Pub Hlth,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,4970,5,Alcohol & Other Drugs CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,crystal burne fulmer,
-HLTH,8110,1,Health Care Delivery Systems,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
-HLTH,8130,500,Population Health and Research,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,
-HLTH,8310,1,Quantitative Analy in Hlth I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,lu shi,
-HON,2020,1,Civil Discourse,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,True
-HON,2050,2,Social Entrepreneurship,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,john michael hannon,True
-HON,2060,1,Intro to Nanotechnology,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,True
-HON,2100,1,Experiencing the Arts,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,mark spede,True
-HON,2210,1,Literature and/as Resistance,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,gabriela stoicea,True
-HON,2210,3,Adventure Novels in Context,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tholozany pauline de,True
-HON,2210,4,Fascism/Anti-fascism Lit,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,gabriel ande hankins,True
-HON,2210,5,American Science Fiction,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,True
-HORT,2020,1,Adobe Digital Design,0.85,0.09,0.0,0.03,0.03,0.0,0.0,0.0,janice ann lay,
-HORT,2110,1,Growing Spring Plnts,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,james emerson faust,
-HORT,4000,1,Water for Agriculture,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,sarah white,
-HORT,4040,1,Plant Propagation,0.18,0.29,0.41,0.12,0.0,0.0,0.0,0.0,jeffrey adelberg,
-HORT,4090,1,Senior Capstone Course,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HORT,4200,1,Applied Turf Physiol,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
-HORT,4270,1,Urban Tree Care,0.06,0.25,0.56,0.13,0.0,0.0,0.0,0.0,robert polomski,
-HORT,4330,1,Turf Weed Management,0.14,0.27,0.55,0.05,0.0,0.0,0.0,0.0,ted whitwell,
-HORT,4610,1,Advanc Landscape Garden Design,0.92,0.0,0.08,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HORT,6040,1,Plant Propagation,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jeffrey adelberg,
-HRD,8470,400,Instru System Design,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,angela daniel carter,
-HRD,8490,400,Eval of T&D/Hrd Prog,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,angela daniel carter,
-HRD,8800,400,Research Concepts,0.76,0.15,0.03,0.0,0.0,0.0,0.0,0.06,kristin kelly frady,
-IE,2100,1,Des Analysis Wrk Sys,0.44,0.42,0.07,0.05,0.0,0.0,0.0,0.02,sara lu riggs,
-IE,3010,1,Systems Design I,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,xiaoxia li,
-IE,3600,1,Industrial Apps of Prob/Stat I,0.39,0.34,0.12,0.08,0.05,0.0,0.0,0.03,mary elizabeth kurz,
-IE,3610,1,Industrial App of Prob/Stat II,0.3,0.34,0.27,0.06,0.02,0.0,0.0,0.02,david neyens,
-IE,3800,1,Deterministic Operations Rsrch,0.27,0.39,0.17,0.1,0.02,0.0,0.0,0.05,ceyda yaba,
-IE,3810,1,Probabilistic Operations Rsrch,0.31,0.21,0.29,0.13,0.02,0.0,0.0,0.05,robert james riggs,
-IE,3840,1,Engr Econ Analysis,0.19,0.19,0.15,0.1,0.09,0.0,0.0,0.29,brian melloy,
-IE,3860,1,Production Planning & Control,0.36,0.23,0.28,0.09,0.04,0.0,0.0,0.0,kevin taaffe,
-IE,4400,1,Decision Support Sys,0.48,0.32,0.13,0.05,0.03,0.0,0.0,0.0,mary elizabeth kurz,
-IE,4570,1,Transp/Logistic Engr,0.33,0.47,0.16,0.05,0.0,0.0,0.0,0.0,sandra duni eksioglu,
-IE,4610,1,Quality Engineering,0.26,0.42,0.14,0.14,0.01,0.0,0.0,0.03,byung rae cho,
-IE,4620,1,Six Sigma Quality,0.38,0.42,0.19,0.01,0.0,0.0,0.0,0.0,robert james riggs,
-IE,4650,1,Facilities Planning & Design,0.9,0.09,0.0,0.01,0.0,0.0,0.0,0.0,xiaoxia li,
-IE,4670,1,System Design II,0.53,0.37,0.1,0.0,0.0,0.0,0.0,0.0,jeffery messer,
-IE,4670,2,System Design II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,
-IE,4820,1,Systems Modeling,0.32,0.33,0.21,0.08,0.05,0.0,0.0,0.02,tugce isik,
-IE,4880,1,Human Factors Eng,0.23,0.57,0.19,0.01,0.0,0.0,0.0,0.0,madathil kapi chalil,
-IE,4910,100,Applied Probabilistic OR,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,brian melloy,
-IE,6570,1,Transp/Logistic Engr,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,sandra duni eksioglu,
-IE,6620,1,Six Sigma Quality,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
-IE,8050,1,Found Qual Engr,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,byung rae cho,
-IE,8520,1,Prescriptive Analytics,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
-IE,8540,1,SC & Logistics Modeling I,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,william ferrell,
-IE,8580,1,Case Study Supply Chn & Logist,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,scott jennings mason,
-IE,8800,1,Adv Meth of Or,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,amin khademi,
-IE,8930,1,Rsrch Method-Human Interaction,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,laura michel stanley,
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,lisa marie robinson,
-INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,caren kelley-hall,
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.85,0.15,0.0,caren kelley-hall,
-INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,caren kelley-hall,
-INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,lisa marie robinson,
-INT,2530,1,UPIC Internship FT 3,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,
-IPM,4010,1,Principles of I P M,0.57,0.29,0.07,0.07,0.0,0.0,0.0,0.0,carmen blubaugh,
-IPM,6010,1,Principles of I P M,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,carmen blubaugh,
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.83,0.16,0.01,meredith fant wilson,
-ITAL,1010,1,Elementary Italian,0.47,0.18,0.12,0.0,0.06,0.0,0.0,0.18,lyudmyla tsykalova,
-ITAL,1020,1,Elementary Italian,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,
-ITAL,1020,2,Elementary Italian,0.39,0.5,0.0,0.06,0.06,0.0,0.0,0.0,julia schmidt,
-ITAL,1020,3,Elementary Italian,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,julia schmidt,
-ITAL,2010,1,Intermediate Italian,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-ITAL,2020,2,Intermediate Italian,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-JAPN,1010,1,Elementary Japanese,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,saori suto,
-JAPN,1010,2,Elementary Japanese,0.2,0.13,0.27,0.13,0.0,0.0,0.0,0.27,saori suto,
-JAPN,1020,2,Elementary Japanese,0.18,0.36,0.45,0.0,0.0,0.0,0.0,0.0,satomi saito,
-JAPN,2010,1,Intermed Japanese,0.58,0.17,0.08,0.0,0.08,0.0,0.0,0.08,saori suto,
-JAPN,2020,1,Intermed Japanese,0.5,0.14,0.21,0.14,0.0,0.0,0.0,0.0,saori suto,
-JAPN,4160,1,Japanese for Int'l Trade II,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jae allegra takeuchi,
-JUST,2880,1,The Criminal Justice System,0.29,0.39,0.3,0.02,0.0,0.0,0.0,0.0,margaret tina britz,
-JUST,4940,1,Organized Crime,0.52,0.29,0.13,0.02,0.04,0.0,0.0,0.0,margaret tina britz,
-LANG,2540,1,Introduction to World Cinemas,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,raquel anido,
-LANG,3000,1,Intro Linguistics,0.58,0.16,0.16,0.0,0.0,0.0,0.0,0.11,jae allegra takeuchi,
-LANG,4620,1,Borders,0.46,0.31,0.0,0.0,0.15,0.0,0.0,0.08,tiffany dawn miller,
-LARC,1160,1,History of Landscape Arch,0.65,0.28,0.03,0.01,0.01,0.0,0.0,0.01,hala fouad nassar,
-LARC,1160,2,History of Landscape Arch,0.17,0.39,0.26,0.13,0.04,0.0,0.0,0.0,hala fouad nassar,
-LARC,1520,1,Basic Design II,0.57,0.3,0.04,0.0,0.09,0.0,0.0,0.0,jessica fernandez,
-LARC,2550,1,Community Design Studio,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
-LARC,3620,1,Design Impl II,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,robert hewitt,
-LARC,3620,2,Design Impl II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,
-LARC,4280,1,Computer-Aided Design,0.55,0.14,0.14,0.05,0.09,0.0,0.0,0.05,jessica fernandez,
-LARC,6810,1,Professional Practice,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,david lycke,
-LARC,8020,1,Orientation II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,paul russell,
-LARC,8300,1,Graduate Seminar I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,thomas willi schurch,
-LAW,3220,1,Legal Env of Bus,0.13,0.22,0.42,0.22,0.0,0.0,0.0,0.0,kenneth sc toussaint,
-LAW,3220,2,Legal Env of Bus,0.28,0.43,0.22,0.02,0.02,0.0,0.0,0.02,edward ray claggett,
-LAW,3220,3,Legal Env of Bus,0.26,0.37,0.26,0.09,0.0,0.0,0.0,0.02,kenneth sc toussaint,
-LAW,3220,4,Legal Env of Bus,0.23,0.36,0.34,0.05,0.02,0.0,0.0,0.0,kenneth sc toussaint,
-LAW,3220,5,Legal Env of Bus,0.11,0.59,0.25,0.05,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,6,Legal Env of Bus,0.22,0.4,0.38,0.0,0.0,0.0,0.0,0.0,judson jahn,
-LAW,3220,7,Legal Env of Bus,0.69,0.29,0.03,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,8,Legal Env of Bus,0.11,0.3,0.52,0.05,0.02,0.0,0.0,0.0,kenneth sc toussaint,
-LAW,3220,9,Legal Env of Bus,0.82,0.16,0.0,0.0,0.0,0.0,0.0,0.02,frances edwards,
-LAW,3220,10,Legal Env of Bus,0.28,0.47,0.16,0.05,0.0,0.0,0.0,0.05,john hine,
-LAW,3220,11,Legal Env of Bus,0.11,0.4,0.29,0.11,0.07,0.0,0.0,0.02,john hine,
-LAW,3220,401,Legal Env of Bus,0.44,0.32,0.16,0.05,0.0,0.0,0.0,0.04,virginia ward-vaughn,
-LAW,3220,402,Legal Env of Bus,0.25,0.31,0.25,0.05,0.07,0.0,0.0,0.07,virginia ward-vaughn,
-LAW,3220,403,Legal Env of Bus,0.33,0.44,0.18,0.0,0.02,0.0,0.0,0.04,virginia ward-vaughn,
-LAW,3220,404,Legal Env of Bus,0.22,0.39,0.24,0.06,0.04,0.0,0.0,0.06,virginia ward-vaughn,
-LAW,3330,1,Real Estate Law,0.14,0.67,0.14,0.02,0.02,0.0,0.0,0.0,judson jahn,
-LAW,4200,1,Int Business Law,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,8480,1,Law Real Estate Prof,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,james ivey warren,
-LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.88,0.04,0.08, lee ferrell,
-LS,1000,4,Introduction to Barre,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,lauren elizab george,
-LS,1000,8,Intro to Salsa Dance,0.54,0.23,0.0,0.0,0.23,0.0,0.0,0.0,malik lewis  baxter c,
-LS,1000,9,Intro to Salsa Dance,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,malik lewis  baxter c,
-LS,1000,10,Intro to Salsa Dance,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,malik lewis  baxter c,
-LS,1000,20,Intro to Volleyball,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,kelly lynn ator,
-LS,1000,23,Therapeutic Yoga,0.77,0.09,0.0,0.0,0.0,0.0,0.0,0.14,renee warren gahan,
-LS,1330,2,Women's Shotgun,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,bonnie duke gill,
-LS,1350,1,Women's Riflery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,hubert cox,
-LS,1410,1,Top Rope Climbing,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,michelle tuday,
-LS,1410,3,Top Rope Climbing,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,michelle tuday,
-LS,1560,12,Riflery,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1570,7,Shotgun Sports,0.7,0.2,0.0,0.1,0.0,0.0,0.0,0.0,john jeffrey price,
-LS,1570,10,Shotgun Sports,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,audrey carolin couch,
-LS,1580,1,Archery,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,
-LS,1580,2,Archery,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,herbert strickland,
-LS,1580,3,Archery,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1640,2,Whitewater Kayaking,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,robert taylor,
-LS,1750,1,Fly Fishing,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james michae harvell,
-LS,1750,2,Fly Fishing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,michael watts,
-LS,1850,2,Bowling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,
-LS,1850,3,Bowling,0.87,0.07,0.0,0.0,0.03,0.0,0.0,0.03,tyler bennett,
-LS,1850,4,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,alexandra sandoval,
-LS,1850,8,Bowling,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,
-LS,1940,3,Racquetball,0.71,0.07,0.0,0.0,0.07,0.0,0.0,0.14,charlie white,
-LS,1980,2,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,jason jordan,
-LS,2270,1,Intro to Swing Dance,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,
-LS,2320,1,Core Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,diane moreno,
-LS,2320,2,Core Training,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,
-LS,2320,3,Core Training,0.76,0.1,0.0,0.0,0.0,0.0,0.0,0.14,diane moreno,
-LS,2320,5,Core Training,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
-LS,2350,3,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,silica elizab larkin,
-LS,2350,5,Basic Yoga,0.73,0.18,0.0,0.0,0.05,0.0,0.0,0.05,renee warren gahan,
-LS,2360,2,Power/Ashtanga Yoga,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,silica elizab larkin,
-LS,2380,2,Vinyasa Flow Yoga,0.69,0.0,0.0,0.0,0.15,0.0,0.0,0.15,nicole eliz martinez,
-LS,2380,3,Vinyasa Flow Yoga,0.71,0.19,0.0,0.0,0.0,0.0,0.0,0.1,kayla lee wardlaw,
-LS,2380,4,Vinyasa Flow Yoga,0.75,0.1,0.0,0.0,0.0,0.0,0.0,0.15,kayla lee wardlaw,
-LS,2420,1,Meditation and Relax,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2420,2,Meditation and Relax,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2420,3,Meditation and Relax,0.64,0.09,0.18,0.05,0.0,0.0,0.0,0.05,renee warren gahan,
-LS,2420,4,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,5,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2450,2,Pilates,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,melanie ivey job,
-LS,2460,2,Intermediate Pilates,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
-LS,2510,2,Running & Jogging,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,corey doug brookover,
-MATH,1010,1,Essen Math for Informed Soc,0.31,0.42,0.19,0.0,0.0,0.0,0.0,0.08,ebenezer eduafo,
-MATH,1010,2,Essen Math for Informed Soc,0.2,0.31,0.17,0.14,0.11,0.0,0.0,0.06,bryce pruitt,
-MATH,1010,3,Essen Math for Informed Soc,0.43,0.09,0.2,0.11,0.14,0.0,0.0,0.03,jun yuan,
-MATH,1010,4,Essen Math for Informed Soc,0.36,0.27,0.24,0.03,0.06,0.0,0.0,0.03,marilyn reba,
-MATH,1020,1,Business Calculus I,0.19,0.28,0.17,0.13,0.13,0.0,0.0,0.11,randy davidson,
-MATH,1020,2,Business Calculus I,0.21,0.22,0.27,0.12,0.13,0.0,0.0,0.05,randy davidson,
-MATH,1020,3,Business Calculus I,0.09,0.26,0.24,0.26,0.07,0.0,0.0,0.09,michael thomas cowen,
-MATH,1020,5,Business Calculus I,0.19,0.33,0.21,0.12,0.07,0.0,0.0,0.07,anna carol bachstein,
-MATH,1020,6,Business Calculus I,0.15,0.18,0.43,0.05,0.13,0.0,0.0,0.08,rachel bass lanning,
-MATH,1020,7,Business Calculus I,0.21,0.21,0.33,0.14,0.07,0.0,0.0,0.02,tony thanh nguyen,
-MATH,1020,9,Business Calculus I,0.19,0.17,0.3,0.11,0.19,0.0,0.0,0.03,randy davidson,
-MATH,1020,11,Business Calculus I,0.2,0.32,0.27,0.07,0.1,0.0,0.0,0.05,li he,
-MATH,1020,12,Business Calculus I,0.2,0.22,0.24,0.12,0.17,0.0,0.0,0.05,tony thanh nguyen,
-MATH,1020,13,Business Calculus I,0.26,0.32,0.22,0.1,0.09,0.0,0.0,0.01,marion hanna,
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.44,0.19,andrew walton green,
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.5,0.13,nicholas ahlstrom,
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.65,0.03,peter westerbaan,
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.55,0.41,0.03,tony thanh nguyen,
-MATH,1060,1,Calculus of One Variable I,0.1,0.13,0.18,0.09,0.33,0.0,0.0,0.17,judith el cottingham,
-MATH,1060,2,Calculus of One Variable I,0.06,0.14,0.34,0.0,0.37,0.0,0.0,0.09,kayla doris javier,
-MATH,1060,3,Calculus of One Variable I,0.05,0.05,0.27,0.15,0.34,0.0,0.0,0.15,xueheng shi,
-MATH,1060,4,Calculus of One Variable I,0.05,0.2,0.2,0.03,0.4,0.0,0.0,0.13,thanh thien to,
-MATH,1060,5,Calculus of One Variable I,0.0,0.06,0.25,0.09,0.5,0.0,0.0,0.09,michael gle eldredge,
-MATH,1060,500,Calculus of One Variable I,0.3,0.3,0.3,0.1,0.0,0.0,0.0,0.0,laura dostert,
-MATH,1070,1,Differen and Integral Calculus,0.13,0.46,0.33,0.04,0.0,0.0,0.0,0.04,donna simms,
-MATH,1070,2,Differen and Integral Calculus,0.28,0.22,0.25,0.13,0.03,0.0,0.0,0.09,donna simms,
-MATH,1070,3,Differen and Integral Calculus,0.11,0.45,0.27,0.11,0.02,0.0,0.0,0.02,stephen peele,
-MATH,1070,4,Differen and Integral Calculus,0.1,0.47,0.27,0.1,0.0,0.0,0.0,0.07,stephen peele,
-MATH,1070,5,Differen and Integral Calculus,0.24,0.3,0.27,0.15,0.03,0.0,0.0,0.0,xiaoyuan liu,
-MATH,1070,6,Differen and Integral Calculus,0.18,0.43,0.23,0.09,0.02,0.0,0.0,0.05,stephen peele,
-MATH,1080,1,Calculus of One Variable II,0.08,0.26,0.16,0.16,0.24,0.0,0.0,0.11,thowhida akther,
-MATH,1080,2,Calculus of One Variable II,0.09,0.17,0.17,0.11,0.29,0.0,0.0,0.17,rui gong,
-MATH,1080,3,Calculus of One Variable II,0.2,0.3,0.18,0.16,0.11,0.0,0.0,0.05,charles lanning,
-MATH,1080,4,Calculus of One Variable II,0.33,0.31,0.11,0.02,0.11,0.0,0.0,0.11,camille zerfas,
-MATH,1080,5,Calculus of One Variable II,0.24,0.3,0.14,0.08,0.16,0.0,0.0,0.08,fun choi john chan john,
-MATH,1080,6,Calculus of One Variable II,0.25,0.16,0.27,0.14,0.14,0.0,0.0,0.05,garrett mi dranichak,
-MATH,1080,7,Calculus of One Variable II,0.16,0.28,0.28,0.05,0.16,0.0,0.0,0.07,pye phyo aung,
-MATH,1080,8,Calculus of One Variable II,0.1,0.28,0.15,0.13,0.15,0.0,0.0,0.18,rebecca ramos,
-MATH,1080,9,Calculus of One Variable II,0.36,0.33,0.13,0.09,0.04,0.0,0.0,0.04,meredith nicole burr,
-MATH,1080,10,Calculus of One Variable II,0.38,0.31,0.18,0.09,0.04,0.0,0.0,0.0,meredith nicole burr,
-MATH,1080,11,Calculus of One Variable II,0.07,0.34,0.3,0.0,0.16,0.0,0.0,0.14,pye phyo aung,
-MATH,1080,100,Calc of One Variable II (HON),0.42,0.32,0.05,0.0,0.0,0.0,0.0,0.21,beth novick,True
-MATH,1080,201,Calculus of One Variable II,0.1,0.29,0.33,0.0,0.14,0.0,0.0,0.14,sanwar ahmad,
-MATH,1080,202,Calculus of One Variable II,0.28,0.33,0.25,0.08,0.03,0.0,0.0,0.05,sergey charnyi,
-MATH,1080,203,Calc of One Variable II,0.17,0.38,0.25,0.04,0.08,0.0,0.0,0.08,amy christine grady,
-MATH,1080,204,Calculus of One Variable II,0.21,0.36,0.21,0.08,0.13,0.0,0.0,0.03,beth novick,
-MATH,1080,205,Calc of One Variable II,0.28,0.35,0.18,0.18,0.0,0.0,0.0,0.03,huixi li,
-MATH,1080,206,Calc of One Variable II,0.21,0.36,0.23,0.15,0.04,0.0,0.0,0.0,kara aile stasikelis,
-MATH,1080,500,Calculus of One Variable II,0.33,0.33,0.11,0.22,0.0,0.0,0.0,0.0,laura dostert,
-MATH,1150,1,Contemp Math for Elem Teach I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,carlos gomez,
-MATH,1160,1,Contemp Math for Elem Teach II,0.45,0.19,0.23,0.03,0.0,0.0,0.0,0.1,allison stoddard,
-MATH,1160,2,Contemp Math for Elem Teach II,0.58,0.3,0.1,0.0,0.03,0.0,0.0,0.0,allison stoddard,
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.9,0.05,0.05,marion hanna,
-MATH,2060,1,Calculus of Several Variables,0.19,0.14,0.38,0.05,0.14,0.0,0.0,0.11,allen anderson guest,
-MATH,2060,2,Calculus of Several Variables,0.21,0.16,0.26,0.03,0.13,0.0,0.0,0.21,allen anderson guest,
-MATH,2060,3,Calculus of Several Variables,0.3,0.19,0.16,0.08,0.24,0.0,0.0,0.03,allen anderson guest,
-MATH,2060,4,Calculus of Several Variables,0.18,0.33,0.21,0.21,0.08,0.0,0.0,0.0,alistair bentley,
-MATH,2060,7,Calculus of Several Variables,0.15,0.33,0.26,0.13,0.03,0.0,0.0,0.1,sofya alekseeva,
-MATH,2060,8,Calculus of Several Variables,0.16,0.41,0.27,0.11,0.02,0.0,0.0,0.02,sofya alekseeva,
-MATH,2060,9,Calculus of Several Variables,0.12,0.37,0.27,0.15,0.05,0.0,0.0,0.05,sofya alekseeva,
-MATH,2060,10,Calculus of Several Variables,0.22,0.36,0.22,0.06,0.06,0.0,0.0,0.06,valdez hiram lopez,
-MATH,2070,1,Business Calculus II,0.38,0.28,0.26,0.08,0.0,0.0,0.0,0.0,jennifer marie hanna,
-MATH,2070,2,Business Calculus II,0.26,0.41,0.18,0.05,0.08,0.0,0.0,0.03,jennifer marie hanna,
-MATH,2070,3,Business Calculus II,0.54,0.26,0.15,0.03,0.0,0.0,0.0,0.03,jennifer marie hanna,
-MATH,2070,4,Business Calculus II,0.22,0.32,0.15,0.13,0.09,0.0,0.0,0.09,judith irene mcknew,
-MATH,2070,5,Business Calculus II,0.28,0.26,0.23,0.13,0.08,0.0,0.0,0.03,judith irene mcknew,
-MATH,2070,6,Business Calculus II,0.33,0.33,0.21,0.05,0.05,0.0,0.0,0.03,todd anthony morra,
-MATH,2070,8,Business Calculus II,0.1,0.31,0.26,0.15,0.1,0.0,0.0,0.08,scott scruggs,
-MATH,2070,9,Business Calculus II,0.41,0.33,0.15,0.05,0.03,0.0,0.0,0.03,emma cinatl,
-MATH,2070,10,Business Calculus II,0.44,0.41,0.08,0.08,0.0,0.0,0.0,0.0,jennifer ray newton,
-MATH,2070,11,Business Calculus II,0.38,0.41,0.18,0.03,0.0,0.0,0.0,0.0,jennifer ray newton,
-MATH,2070,12,Business Calculus II,0.48,0.2,0.15,0.08,0.03,0.0,0.0,0.08,jennifer ray newton,
-MATH,2070,13,Business Calculus II,0.54,0.18,0.1,0.13,0.03,0.0,0.0,0.03,jennifer ray newton,
-MATH,2070,14,Business Calculus II,0.56,0.11,0.22,0.08,0.0,0.0,0.0,0.03,dyken jennifer  van e,
-MATH,2070,15,Business Calculus II,0.29,0.37,0.26,0.03,0.0,0.0,0.0,0.05,madeleine stville,
-MATH,2070,16,Business Calculus II,0.39,0.31,0.06,0.06,0.11,0.0,0.0,0.08,allison stoddard,
-MATH,2080,1,Intro to Ordin Diff Equations,0.29,0.21,0.25,0.08,0.13,0.0,0.0,0.04,terri johnson,
-MATH,2080,2,Intro to Ordin Diff Equations,0.38,0.2,0.27,0.07,0.07,0.0,0.0,0.02,irina viktorova,
-MATH,2080,3,Intro to Ordin Diff Equations,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.05,oleg yordanov,
-MATH,2080,4,Intro to Ordin Diff Equations,0.15,0.39,0.24,0.06,0.06,0.0,0.0,0.09,timothy fran parrott,
-MATH,2080,6,Intro to Ordin Diff Equations,0.4,0.38,0.13,0.07,0.02,0.0,0.0,0.0,timothy cha teitloff,
-MATH,2080,7,Intro to Ordin Diff Equations,0.32,0.35,0.22,0.03,0.08,0.0,0.0,0.0,oleg yordanov,
-MATH,2080,8,Intro to Ordin Diff Equations,0.51,0.16,0.3,0.0,0.0,0.0,0.0,0.03,timothy fran parrott,
-MATH,2080,9,Intro to Ordin Diff Equations,0.26,0.17,0.21,0.07,0.14,0.0,0.0,0.14,terri johnson,
-MATH,2080,10,Intro to Ordin Diff Equations,0.42,0.38,0.16,0.04,0.0,0.0,0.0,0.0,timothy cha teitloff,
-MATH,2080,11,Intro to Ordin Diff Equations,0.21,0.25,0.25,0.11,0.14,0.0,0.0,0.04,julie lassiter,
-MATH,2080,12,Intro to Ordin Diff Equations,0.48,0.46,0.04,0.0,0.0,0.0,0.0,0.02,irina viktorova,
-MATH,2080,13,Intro to Ordin Diff Equations,0.23,0.29,0.14,0.09,0.09,0.0,0.0,0.17,terri johnson,
-MATH,2080,14,Intro to Ordin Diff Equations,0.16,0.22,0.28,0.13,0.09,0.0,0.0,0.13,julie lassiter,
-MATH,2080,15,Intro to Ordin Diff Equations,0.36,0.26,0.14,0.12,0.05,0.0,0.0,0.07,timothy fran parrott,
-MATH,2080,16,Intro to Ordin Diff Equations,0.41,0.25,0.18,0.09,0.0,0.0,0.0,0.07,timothy cha teitloff,
-MATH,2080,17,Intro to Ordin Diff Equations,0.18,0.36,0.32,0.06,0.03,0.0,0.0,0.05,sean sather-wagstaff,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.35,0.43,0.17,0.0,0.0,0.0,0.0,0.04,michael adam burr,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,eliza darg gallagher,
-MATH,3020,1,Stat for Science & Engineering,0.56,0.33,0.03,0.03,0.03,0.0,0.0,0.03,ellen hepfer breazel,
-MATH,3020,2,Stat for Science & Engineering,0.23,0.45,0.28,0.0,0.05,0.0,0.0,0.0,gamage prabh withana,
-MATH,3020,3,Stat for Science & Engineering,0.38,0.46,0.13,0.03,0.0,0.0,0.0,0.0,xiyan tan,
-MATH,3020,4,Stat for Science & Engineering,0.82,0.11,0.05,0.03,0.0,0.0,0.0,0.0,haotian feng,
-MATH,3020,5,Stat for Science & Engineering,0.29,0.26,0.16,0.0,0.13,0.0,0.0,0.16,paul james cubre,
-MATH,3020,6,Stat for Science & Engineering,0.43,0.3,0.26,0.0,0.0,0.0,0.0,0.0,yinggu bao,
-MATH,3020,8,Stat for Science & Engineering,0.25,0.25,0.3,0.05,0.1,0.0,0.0,0.05,patrick gerard,
-MATH,3020,9,Stat for Science & Engineering,0.36,0.36,0.13,0.05,0.1,0.0,0.0,0.0,ellen hepfer breazel,
-MATH,3080,1,College Geometry,0.82,0.06,0.0,0.0,0.12,0.0,0.0,0.0,nicole alain sinwell,
-MATH,3110,1,Linear Algebra,0.27,0.27,0.16,0.07,0.11,0.0,0.0,0.11,svetlana poznanovikj,
-MATH,3110,2,Linear Algebra,0.21,0.51,0.16,0.02,0.0,0.0,0.0,0.09,neil calkin,
-MATH,3110,3,Linear Algebra,0.16,0.32,0.32,0.07,0.07,0.0,0.0,0.07,xuhong gao,
-MATH,3110,4,Linear Algebra,0.29,0.15,0.22,0.1,0.1,0.0,0.0,0.15,xuhong gao,
-MATH,3110,5,Linear Algebra,0.12,0.3,0.19,0.21,0.14,0.0,0.0,0.05,hui xue,
-MATH,3110,6,Linear Algebra,0.17,0.27,0.25,0.21,0.08,0.0,0.0,0.02,hui xue,
-MATH,3110,7,Linear Algebra,0.33,0.24,0.15,0.15,0.07,0.0,0.0,0.07,elena stan dimitrova,
-MATH,3110,200,Linear Algebra,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,kevin james,
-MATH,3190,1,Introduction to Proof,0.31,0.19,0.31,0.04,0.08,0.0,0.0,0.08,james bar coykendall,
-MATH,3190,2,Introduction to Proof,0.58,0.27,0.08,0.0,0.04,0.0,0.0,0.04,malcolm edwar rupert,
-MATH,3600,1,Intermediate Math Computing,0.76,0.12,0.04,0.04,0.0,0.0,0.0,0.04,mark cawood,
-MATH,3600,2,Intermediate Math Computing,0.45,0.18,0.14,0.0,0.05,0.0,0.0,0.18,mark cawood,
-MATH,3650,1,Numerical Mthds for Engineers,0.36,0.27,0.15,0.0,0.15,0.0,0.0,0.06,mengying xiao,
-MATH,3650,2,Numerical Mthds for Engineers,0.41,0.3,0.14,0.03,0.05,0.0,0.0,0.08,christopher cox,
-MATH,3650,3,Numerical Mthds for Engineers,0.26,0.39,0.16,0.06,0.06,0.0,0.0,0.06,vincent ervin,
-MATH,3650,4,Numerical Mthds for Engineers,0.19,0.24,0.27,0.14,0.08,0.0,0.0,0.08,vincent ervin,
-MATH,4000,1,Theory of Probability,0.32,0.48,0.12,0.0,0.0,0.0,0.0,0.08,xiaoqian sun,
-MATH,4000,2,Theory of Probability,0.5,0.21,0.21,0.0,0.07,0.0,0.0,0.0,peter kiessler,
-MATH,4030,1,Intro to Statistical Theory,0.31,0.31,0.31,0.0,0.08,0.0,0.0,0.0,xiaoqian sun,
-MATH,4070,1,Regress & Time-Series Analysis,0.67,0.08,0.08,0.08,0.08,0.0,0.0,0.0,christopher mcmahan,
-MATH,4110,1,Introduction to Combinatorics,0.46,0.31,0.08,0.0,0.0,0.0,0.0,0.15,beth novick,
-MATH,4120,1,Algebra I,0.19,0.52,0.15,0.0,0.11,0.0,0.0,0.04,james bar coykendall,
-MATH,4190,1,Discrete Math Structures I,0.28,0.59,0.1,0.03,0.0,0.0,0.0,0.0,wayne goddard,
-MATH,4190,2,Discrete Math Structures I,0.19,0.34,0.25,0.0,0.16,0.0,0.0,0.06,sean sather-wagstaff,
-MATH,4310,1,Theory of Interest,0.21,0.43,0.29,0.0,0.0,0.0,0.0,0.07, erwin walker,
-MATH,4340,1,Adv Engineering Mathematics,0.25,0.15,0.3,0.15,0.05,0.0,0.0,0.1,hyesuk lee,
-MATH,4340,2,Adv Engineering Mathematics,0.28,0.22,0.25,0.06,0.0,0.0,0.0,0.19,qingshan chen,
-MATH,4400,1,Linear Programming,0.5,0.27,0.04,0.08,0.08,0.0,0.0,0.04,margaret mari wiecek,
-MATH,4530,1,Advanced Calculus I,0.41,0.28,0.17,0.07,0.07,0.0,0.0,0.0,james peterson,
-MATH,4540,1,Advanced Calculus II,0.21,0.38,0.29,0.08,0.04,0.0,0.0,0.0,james peterson,
-MATH,4600,1,Intro to Numerical Analysis I,0.44,0.25,0.13,0.0,0.06,0.0,0.0,0.13,leo rebholz,
-MATH,6000,1,Theory of Probability,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,xiaoqian sun,
-MATH,6340,1,Adv Engineering Mathematics,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
-MATH,6410,1,Intro to Stochastic Models,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
-MATH,8030,1,Stochastic Processes,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,peter kiessler,
-MATH,8040,1,Statistical Inference,0.5,0.19,0.19,0.0,0.06,0.0,0.0,0.06,christopher mcmahan,
-MATH,8050,1,Data Analysis,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ling ma,
-MATH,8090,1,Time Series Analysis,0.44,0.31,0.0,0.0,0.0,0.0,0.0,0.25,colin gallagher,
-MATH,8100,1,Mathematical Programming,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
-MATH,8120,1,Discrete Optimization,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,herve louis kerivin,
-MATH,8130,1,Advanced Linear Programming,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
-MATH,8210,1,Linear Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,benjamin jaye,
-MATH,8220,1,Measure and Integration,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,martin johan schmoll,
-MATH,8530,1,Matrix Analysis,0.6,0.1,0.2,0.0,0.1,0.0,0.0,0.0,elena stan dimitrova,
-MATH,8540,1,Theory of Graphs,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,beth novick,
-MATH,8560,1,Ther of Error-Correcting Codes,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,felice manganiello,
-MATH,8600,1,Intro to Scientific Computing,0.35,0.35,0.12,0.0,0.12,0.0,0.0,0.06,eleanor jenkins,
-MATH,8610,1,Advanced Numerical Analysis I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,fei xue,
-MATH,9830,1,Sel Top in Computational Math,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,timo johanne heister,
-MBA,8030,1,Stat Analy of Bus Op,0.19,0.35,0.27,0.0,0.05,0.0,0.0,0.14,magda gabriela sava,
-MBA,8060,1,Operations Mgt,0.28,0.58,0.14,0.0,0.0,0.0,0.0,0.0,janis miller,
-MBA,8060,20,Operations Mgt,0.42,0.42,0.12,0.0,0.0,0.0,0.0,0.04, sridharan,
-MBA,8070,1,Financial Management,0.56,0.28,0.16,0.0,0.0,0.0,0.0,0.0,melvin stith,
-MBA,8070,2,Financial Management,0.68,0.15,0.13,0.0,0.0,0.0,0.0,0.05,melvin stith,
-MBA,8090,1,Org Beh & Hum Res Mg,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,
-MBA,8090,2,Org Beh & Hum Res Mg,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,
-MBA,8090,3,Org Beh & Hum Res Mg,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,
-MBA,8170,21,Bus Forecasting,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,sukran nilv atadeniz,
-MBA,8190,1,Intro to Acc and Fin,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,melvin stith,
-MBA,8190,2,Intro to Acc and Fin,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,melvin stith,
-MBA,8290,1,Marketing Foundation,0.6,0.36,0.0,0.0,0.0,0.0,0.0,0.04,gary hunter,
-MBA,8330,1,Real Estate Investmt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,franklin bogu wallin,
-MBA,8370,1,Legal Environ of Bus,0.2,0.77,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
-MBA,8430,10,Entrepreneurial Accounting,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,james milt kohlmeyer,
-MBA,8440,10,Entrepreneurial Law,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,scott hile,
-MBA,8450,1,Technology & Innovation Mgt,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8470,1,New Venture Creation,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,
-MBA,8510,10,Bus Operations & Logistics,0.69,0.19,0.04,0.0,0.04,0.0,0.0,0.04,george kennet morgan,
-MBA,8540,1,Managerial Accounting,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
-MBA,8540,2,Managerial Accounting,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
-MBA,8540,3,Managerial Accounting,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
-MBA,8590,1,Mgr Decision Model,0.42,0.33,0.08,0.0,0.06,0.0,0.0,0.11,magda gabriela sava,
-MBA,8590,2,Mgr Decision Model,0.54,0.23,0.15,0.0,0.08,0.0,0.0,0.0,sara elizabeth yoder,
-MBA,8600,1,Advanced Marketing Strategy,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MBA,8610,1,Information Systems,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
-MBA,8620,1,Managerial Economics,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,
-MBA,8620,2,Managerial Economics,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,
-MBA,8700,1,Strategic Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,matthew charle klein,
-MBA,8720,1,Entrepr Finance,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,matthew charle klein,
-MBA,8750,1,Enterprise Develpmnt,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8990,1,Advanced Leadership,0.89,0.06,0.02,0.0,0.0,0.0,0.0,0.02,gail depriest,
-MBA,8990,3,Service Innovation,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
-MBA,8990,4,Bus. Sport. Enter.,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
-MBA,8990,7,Business Analytics Models,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,jennie lynn farmer,
-MBA,8990,20,Analytics & Application,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,heshan sun,
-MBA,8990,22,Marketing Analytics,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,bruce snyder,
-ME,2000,1,Sophomore Seminar,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.02,donald beasley,
-ME,2010,1,Statics & Dynamics,0.06,0.25,0.27,0.16,0.12,0.0,0.0,0.14,marisa kikendall orr,
-ME,2010,2,Statics & Dynamics,0.05,0.25,0.28,0.13,0.2,0.0,0.0,0.1,paul joseph,
-ME,2030,1,Founda Th/Fl Syst,0.24,0.58,0.14,0.01,0.01,0.0,0.0,0.02,yiqiang han,
-ME,2030,2,Founda Th/Fl Syst,0.28,0.28,0.23,0.09,0.08,0.0,0.0,0.05,xiangchun xuan,
-ME,2040,1,Mechanics of Materials,0.31,0.47,0.17,0.04,0.01,0.0,0.0,0.0,gang li,
-ME,2040,2,Mechanics of Materials,0.16,0.52,0.18,0.05,0.05,0.0,0.0,0.05,jorge ivan rodriguez,
-ME,2040,3,Mechanics of Materials,0.28,0.5,0.19,0.03,0.0,0.0,0.0,0.0,garrett pataky,
-ME,2040,303,Mechanics of Materials (HON),0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,garrett pataky,True
-ME,2220,2,Mechanical Engineering Lab I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,3,Mechanical Engineering Lab I,0.21,0.64,0.14,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,5,Mechanical Engineering Lab I,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,6,Mechanical Engineering Lab I,0.19,0.5,0.25,0.0,0.0,0.0,0.0,0.06,todd al schweisinger,
-ME,2220,7,Mechanical Engineering Lab I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,10,Mechanical Engineering Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,todd al schweisinger,
-ME,2220,11,Mechanical Engineering Lab I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,13,Mechanical Engineering Lab I,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,14,Mechanical Engineering Lab I,0.29,0.43,0.21,0.07,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,15,Mechanical Engineering Lab I,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,17,Mechanical Engineering Lab I,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2220,18,Mechanical Engineering Lab I,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,2900,619,CI ME - Savonius Wind Turbine,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,3030,1,Thermodynamics,0.11,0.2,0.53,0.02,0.09,0.0,0.0,0.04,john saylor,
-ME,3030,2,Thermodynamics,0.13,0.32,0.45,0.06,0.0,0.0,0.0,0.04,richard miller,
-ME,3040,1,Heat Transfer,0.03,0.32,0.5,0.11,0.03,0.0,0.0,0.03,jean-marc ge delhaye,
-ME,3040,2,Heat Transfer,0.21,0.36,0.28,0.0,0.11,0.0,0.0,0.04,jean-marc ge delhaye,
-ME,3040,3,Heat Transfer,0.21,0.38,0.21,0.15,0.0,0.0,0.0,0.04,xin zhao,
-ME,3050,1,Model/an Dy Syst,0.21,0.39,0.36,0.01,0.03,0.0,0.0,0.0,phanind tallapragada,
-ME,3050,2,Model/an Dy Syst,0.2,0.37,0.31,0.06,0.05,0.0,0.0,0.02,joshua bostwick,
-ME,3060,1,Fund Machine Design,0.11,0.61,0.23,0.0,0.02,0.0,0.0,0.03,oliver myers,
-ME,3060,2,Fund Machine Design,0.2,0.63,0.12,0.03,0.01,0.0,0.0,0.01,joshua summers,
-ME,3070,1,Found of Mechanical Systems,0.46,0.34,0.11,0.01,0.06,0.0,0.0,0.01,jorge ivan rodriguez,
-ME,3070,2,Found of Mechanical Systems,0.36,0.46,0.16,0.01,0.0,0.0,0.0,0.01,gregory mocko,
-ME,3080,1,Fluid Mechanics,0.21,0.45,0.31,0.03,0.0,0.0,0.0,0.0,chenning tong,
-ME,3080,2,Fluid Mechanics,0.16,0.42,0.39,0.03,0.0,0.0,0.0,0.0,ethan kung,
-ME,3080,3,Fluid Mechanics,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,3100,1,Thermo/Heat Transfer,0.25,0.5,0.17,0.0,0.03,0.0,0.0,0.06,yiqiang han,
-ME,3120,1,Manuf Processes,0.31,0.66,0.03,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-ME,3330,1,Mechanical Engineering Lab II,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,3330,2,Mechanical Engineering Lab II,0.27,0.53,0.13,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,
-ME,3330,3,Mechanical Engineering Lab II,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,3330,5,Mechanical Engineering Lab II,0.1,0.8,0.1,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,3330,6,Mechanical Engineering Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,3330,7,Mechanical Engineering Lab II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,3330,9,Mechanical Engineering Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,3330,11,Mechanical Engineering Lab II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,3330,17,Mechanical Engineering Lab II,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,4010,1,Mech Engr Design,0.85,0.1,0.01,0.01,0.01,0.0,0.0,0.0,cameron turner,
-ME,4020,1,Intern in Engr Des,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,4020,4,Intern in Engr Des,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,5,Intern in Engr Des,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,
-ME,4020,6,Intern in Engr Des,0.3,0.35,0.05,0.3,0.0,0.0,0.0,0.0,nicole gisel coutris,
-ME,4020,7,Intern in Engr Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,8,Intern in Engr Des,0.25,0.6,0.15,0.0,0.0,0.0,0.0,0.0,yue wang,
-ME,4020,9,Intern in Engr Des,0.25,0.45,0.25,0.05,0.0,0.0,0.0,0.0,georges fadel,
-ME,4030,1,Control Dynamic Systems,0.23,0.33,0.4,0.05,0.0,0.0,0.0,0.0,suyi li,
-ME,4030,2,Control Dynamic Systems,0.24,0.4,0.2,0.13,0.02,0.0,0.0,0.0,yue wang,
-ME,4180,1,F E A in M E Design,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,oliver myers,
-ME,4220,1,Design Gas Turbines,0.56,0.27,0.15,0.02,0.0,0.0,0.0,0.0,abhijit som,
-ME,4260,1,Nuclear Energy,0.38,0.32,0.24,0.06,0.0,0.0,0.0,0.0,richard watkins,
-ME,4300,1,Mech Comp Materials,0.19,0.29,0.33,0.14,0.0,0.0,0.0,0.05,huijuan zhao,
-ME,4400,1,Matls for Aggr Envir,0.44,0.31,0.22,0.0,0.03,0.0,0.0,0.0,garrett pataky,
-ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,4440,2,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,4440,5,Mechanical Engineering Lab III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,4440,13,Mechanical Engineering Lab III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
-ME,4930,11,Selected Topics ME (MicroFab),0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,
-ME,4930,24,Sel. Topics ME (Mechatronics),0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4930,34,Sel. Topics in ME (Cardio),0.07,0.79,0.14,0.0,0.0,0.0,0.0,0.0,ethan kung,
-ME,4930,39,Sel Topics ME (Solar Energy),0.35,0.48,0.15,0.02,0.0,0.0,0.0,0.0,daniel fant,
-ME,6300,1,Mech Comp Materials,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,6930,11,Selected Topics ME (MicroFab),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,
-ME,6930,34,Selected Topics in ME (Cardio),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,
-ME,8200,1,Mod Cont Engr,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
-ME,8310,1,Convective Ht Trans,0.45,0.18,0.18,0.0,0.0,0.0,0.0,0.18,xin zhao,
-ME,8370,1,Theory of Elast I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,nicole gisel coutris,
-ME,8450,1,Structural Vibration,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,suyi li,
-ME,8720,1,Design Automatn for Mech Engrs,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,cameron turner,
-ME,8730,1,Res Mthds Coll Desgn,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,joshua summers,
-ME,8930,24,Sel. Topics ME (Mechatronics),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,8930,424,Sel. Topics ME (Mechatronics),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-MGT,2010,1,Principles of Management,0.4,0.4,0.14,0.03,0.01,0.0,0.0,0.01,katherine clark,
-MGT,2010,2,Principles of Management,0.47,0.38,0.1,0.03,0.0,0.0,0.0,0.01,tina robbins,
-MGT,2010,7,Principles of Management,0.23,0.36,0.38,0.03,0.0,0.0,0.0,0.0,christopher mann,
-MGT,2010,8,Principles of Management,0.28,0.4,0.2,0.08,0.0,0.0,0.0,0.05,christopher mann,
-MGT,2010,10,Principles of Management,0.26,0.46,0.2,0.04,0.02,0.0,0.0,0.02,ashley willi parnell,
-MGT,2010,11,Principles of Management,0.3,0.3,0.33,0.0,0.05,0.0,0.0,0.03,ashley willi parnell,
-MGT,2180,1,Management PC Applications,0.52,0.32,0.09,0.03,0.02,0.0,0.0,0.02,ryan toole,
-MGT,2180,2,Management PC Applications,0.33,0.3,0.07,0.04,0.22,0.0,0.0,0.04,ryan toole,
-MGT,3070,1,Human Resource Management,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
-MGT,3070,2,Human Resource Management,0.88,0.08,0.03,0.03,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,3,Human Resource Management,0.3,0.63,0.08,0.0,0.0,0.0,0.0,0.0,priscilla harrison,
-MGT,3070,4,Human Resource Management,0.4,0.53,0.05,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,
-MGT,3070,5,Human Resource Management,0.7,0.28,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,6,Human Resource Management,0.45,0.48,0.05,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,
-MGT,3100,1,Intermed Business Statistics,0.55,0.18,0.25,0.03,0.0,0.0,0.0,0.0,yunsik choi,
-MGT,3100,2,Intermed Business Statistics,0.33,0.33,0.23,0.05,0.03,0.0,0.0,0.05,mustafa serka akturk,
-MGT,3100,3,Intermed Business Statistics,0.23,0.31,0.21,0.08,0.1,0.0,0.0,0.08,yunsik choi,
-MGT,3100,4,Intermed Business Statistics,0.5,0.24,0.07,0.0,0.12,0.0,0.0,0.07,remi charpin,
-MGT,3100,5,Intermed Business Statistics,0.58,0.27,0.13,0.0,0.0,0.0,0.0,0.02,wenxi pu,
-MGT,3100,6,Intermed Business Statistics,0.45,0.32,0.13,0.0,0.05,0.0,0.0,0.05,sukran nilv atadeniz,
-MGT,3100,7,Intermed Business Statistics,0.24,0.44,0.22,0.0,0.02,0.0,0.0,0.07,magda gabriela sava,
-MGT,3100,8,Intermed Business Statistics,0.42,0.26,0.24,0.03,0.03,0.0,0.0,0.03,mustafa serka akturk,
-MGT,3100,10,Intermed Business Statistics,0.49,0.44,0.03,0.05,0.0,0.0,0.0,0.0,sukran nilv atadeniz,
-MGT,3100,11,Intermed Business Statistics,0.64,0.26,0.08,0.0,0.0,0.0,0.0,0.03,thomas simpson,
-MGT,3120,1,Decision Models for Management,0.08,0.26,0.45,0.08,0.09,0.0,0.0,0.05,sara elizabeth yoder,
-MGT,3120,2,Decision Models for Management,0.12,0.27,0.39,0.1,0.07,0.0,0.0,0.04,sara elizabeth yoder,
-MGT,3120,5,Decision Models for Management,0.31,0.39,0.31,0.0,0.0,0.0,0.0,0.0,james turner,
-MGT,3170,1,Logistics Mgmt,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,ahmet colak,
-MGT,3180,1,Mgt of Info Systems,0.15,0.6,0.2,0.0,0.0,0.0,0.0,0.05,russell purvis,
-MGT,3180,2,Mgt of Info Systems,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,marten risius,
-MGT,3180,3,Mgt of Info Systems,0.56,0.36,0.05,0.0,0.03,0.0,0.0,0.0,tina marie esposito,
-MGT,3180,4,Mgt of Info Systems,0.41,0.44,0.1,0.03,0.0,0.0,0.0,0.03,tina marie esposito,
-MGT,3500,1,Intro to Business Analytics,0.29,0.68,0.03,0.0,0.0,0.0,0.0,0.0,siyuan li,
-MGT,3510,1,Business Analytics & Problems,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,sukran nilv atadeniz,
-MGT,3900,1,Ops Mgt,0.43,0.48,0.05,0.0,0.05,0.0,0.0,0.0,maneeshred ajjuguttu,
-MGT,3900,2,Ops Mgt,0.09,0.45,0.3,0.09,0.02,0.0,0.0,0.05,min kyung lee,
-MGT,3900,3,Ops Mgt,0.18,0.2,0.4,0.08,0.0,0.0,0.0,0.15,min kyung lee,
-MGT,3900,4,Ops Mgt,0.11,0.3,0.49,0.11,0.0,0.0,0.0,0.0,zachary mor leffakis,
-MGT,3900,5,Ops Mgt,0.35,0.3,0.3,0.03,0.03,0.0,0.0,0.0,daniel nielubowicz,
-MGT,4000,2,Mgt of Organizational Behavior,0.25,0.43,0.27,0.02,0.02,0.0,0.0,0.0,thomas jos zagenczyk,
-MGT,4000,3,Mgt of Organizational Behavior,0.38,0.33,0.26,0.0,0.03,0.0,0.0,0.0,philip roth,
-MGT,4000,4,Mgt of Organizational Behavior,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4020,1,Ops Pln and Ctl,0.07,0.57,0.21,0.14,0.0,0.0,0.0,0.0,zachary mor leffakis,
-MGT,4080,1,Lean Operations,0.23,0.32,0.36,0.0,0.09,0.0,0.0,0.0,zachary mor leffakis,
-MGT,4110,1,Project Management,0.38,0.43,0.15,0.03,0.0,0.0,0.0,0.03,russell purvis,
-MGT,4120,1,Supplier Management,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,ahmet colak,
-MGT,4150,1,Business Strategy,0.24,0.52,0.21,0.02,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,2,Business Strategy,0.24,0.63,0.11,0.0,0.0,0.0,0.0,0.02,james liddle,
-MGT,4150,3,Business Strategy,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,dennis lee lester,
-MGT,4150,4,Business Strategy,0.43,0.35,0.2,0.02,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,5,Business Strategy,0.4,0.51,0.09,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
-MGT,4150,6,Business Strategy,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
-MGT,4150,7,Business Strategy,0.23,0.6,0.16,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,8,Business Strategy,0.15,0.61,0.24,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,10,Business Strategy,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,dennis lee lester,
-MGT,4160,1,Special Topics Hr,0.62,0.24,0.08,0.0,0.0,0.0,0.0,0.05,alejandra sa kennedy,
-MGT,4230,1,Intern Bus Mgt,0.04,0.59,0.28,0.02,0.02,0.0,0.0,0.04,janis miller,
-MGT,4230,2,Intern Bus Mgt,0.16,0.44,0.27,0.11,0.02,0.0,0.0,0.0,janis miller,
-MGT,4230,3,Intern Bus Mgt,0.09,0.26,0.5,0.09,0.02,0.0,0.0,0.04,wayne stewart,
-MGT,4230,4,Intern Bus Mgt,0.13,0.13,0.56,0.11,0.04,0.0,0.0,0.02,wayne stewart,
-MGT,4240,1,Global Supply Chain,0.26,0.55,0.16,0.03,0.0,0.0,0.0,0.0,yann ferrand,
-MGT,4270,1,Managing Improvement,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,samer ess abdlrahman,
-MGT,4310,1,Emp Rights & Resp,0.24,0.55,0.21,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
-MGT,4350,1,Pers Interviewing,0.33,0.28,0.33,0.0,0.05,0.0,0.0,0.03,philip roth,
-MGT,4520,1,Business Analysis,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,marten risius,
-MGT,4540,1,Systems Implement,0.18,0.47,0.24,0.0,0.06,0.0,0.0,0.06,heshan sun,
-MGT,4550,1,Emerging I T Trends,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
-MGT,4560,1,Business Info Mgt,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,siyuan li,
-MGT,4900,1,Being A Leader,0.7,0.16,0.11,0.0,0.0,0.0,0.0,0.03,christopher mann,
-MGT,4900,2,Being A Leader,0.67,0.19,0.1,0.0,0.0,0.0,0.0,0.05,christopher mann,
-MGT,8120,1,Supply Chain Mgt,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,yann ferrand,
-MICR,3050,1,General Microbiology,0.46,0.36,0.14,0.03,0.01,0.0,0.0,0.0,kristi jam whitehead,
-MICR,3050,2,General Microbiology,0.5,0.25,0.15,0.06,0.01,0.0,0.0,0.02,krista barri rudolph,
-MICR,3050,3,General Microbiology,0.62,0.3,0.03,0.05,0.0,0.0,0.0,0.0,krista barri rudolph,
-MICR,4000,1,Public Health Micro,0.57,0.26,0.09,0.06,0.0,0.0,0.0,0.02,kristi jam whitehead,
-MICR,4020,1,Environmental Micro,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,john michael henson,
-MICR,4070,1,Food and Dairy Micro,0.25,0.46,0.22,0.06,0.0,0.0,0.0,0.0,xiuping jiang,
-MICR,4110,1,Pathogenic Bact,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kears milhous,
-MICR,4120,1,Bacterial Physiology,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.02,wilbur kears milhous,
-MICR,4130,1,Industrial Micro,0.31,0.54,0.11,0.02,0.0,0.0,0.0,0.03,tzuen-rong jer tzeng,
-MICR,4140,1,Basic Immunology,0.69,0.29,0.0,0.0,0.0,0.0,0.0,0.02,charles rice,
-MICR,4170,1,Cancer and Aging,0.64,0.29,0.04,0.01,0.0,0.0,0.0,0.01,yuqing dong,
-MICR,4500,1,Advanced Microbiology I,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4500,2,Advanced Microbiology I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4500,3,Advanced Microbiology I,0.31,0.38,0.23,0.0,0.0,0.0,0.0,0.08,harry kurtz,
-MICR,4520,1,Advanced Microbiology III,0.38,0.5,0.08,0.04,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4520,2,Advanced Microbiology III,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4520,3,Advanced Microbiology III,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,harry kurtz,
-MKT,3010,1,Principles of Marketing,0.26,0.37,0.26,0.07,0.03,0.0,0.0,0.01,carter will mcelveen,
-MKT,3010,2,Principles of Marketing,0.29,0.35,0.29,0.06,0.01,0.0,0.0,0.01,carter will mcelveen,
-MKT,3010,3,Principles of Marketing,0.31,0.4,0.21,0.05,0.01,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,4,Principles of Marketing,0.27,0.4,0.24,0.05,0.03,0.0,0.0,0.01,amanda cooper fine,
-MKT,3010,5,Principles of Marketing,0.15,0.35,0.36,0.07,0.03,0.0,0.0,0.04,james gaubert,
-MKT,3020,1,Consumer Behavior,0.5,0.33,0.15,0.02,0.0,0.0,0.0,0.0,jennifer dia siemens,
-MKT,3020,2,Consumer Behavior,0.41,0.37,0.16,0.04,0.0,0.0,0.0,0.02,jennifer dia siemens,
-MKT,3020,3,Consumer Behavior,0.37,0.4,0.1,0.08,0.04,0.0,0.0,0.02,fitzwater an thyroff,
-MKT,3020,4,Consumer Behavior,0.31,0.48,0.15,0.0,0.02,0.0,0.0,0.04,fitzwater an thyroff,
-MKT,3020,5,Consumer Behavior,0.52,0.41,0.06,0.01,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,3220,1,Social Media Marketing,0.85,0.13,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,
-MKT,3220,2,Social Media Marketing,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,3310,1,Marketing Metrics & Analytics,0.53,0.35,0.08,0.02,0.0,0.0,0.0,0.02,oriana rachel aragon,
-MKT,3310,2,Marketing Metrics & Analytics,0.31,0.47,0.18,0.04,0.0,0.0,0.0,0.0,oriana rachel aragon,
-MKT,3310,3,Marketing Metrics & Analytics,0.23,0.48,0.2,0.05,0.03,0.0,0.0,0.03,peter weathers,
-MKT,3980,1,CI: Sales Experiential,0.81,0.11,0.0,0.02,0.0,0.0,0.0,0.06,carter will mcelveen,
-MKT,4200,1,Professional Selling,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,2,Professional Selling,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,jesse moore,
-MKT,4200,3,Professional Selling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,carter will mcelveen,
-MKT,4200,4,Professional Selling,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4200,5,Professional Selling,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4230,1,Promotional Strategy,0.6,0.3,0.09,0.01,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,4240,1,Sales Management,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4250,1,Retail Management,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4250,2,Retail Management,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4260,1,Business-to-Business,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4260,2,Business-to-Business,0.76,0.08,0.12,0.0,0.04,0.0,0.0,0.0,xianyong wang,
-MKT,4270,1,International Marketing,0.29,0.57,0.12,0.02,0.0,0.0,0.0,0.0,thomas poehlman,
-MKT,4270,2,International Marketing,0.13,0.74,0.08,0.0,0.0,0.0,0.0,0.05,thomas poehlman,
-MKT,4270,3,International Marketing,0.64,0.25,0.1,0.01,0.0,0.0,0.0,0.0,roger gomes,
-MKT,4280,1,Services Marketing,0.58,0.33,0.07,0.0,0.02,0.0,0.0,0.0,james gaubert,
-MKT,4280,2,Services Marketing,0.49,0.37,0.12,0.0,0.0,0.0,0.0,0.02,james gaubert,
-MKT,4310,1,Marketing Research,0.17,0.43,0.33,0.07,0.0,0.0,0.0,0.0,peter weathers,
-MKT,4310,2,Marketing Research,0.3,0.43,0.17,0.0,0.0,0.0,0.0,0.1,william ed kilbourne,
-MKT,4310,3,Marketing Research,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,4,Marketing Research,0.37,0.6,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4330,1,Sport Mkt Strategy,0.66,0.22,0.13,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,
-MKT,4450,1,Macromarketing,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.08,0.41,0.51,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,2,Strategic Mktg Mgt,0.16,0.42,0.39,0.03,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,3,Strategic Mktg Mgt,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,
-MKT,4500,4,Strategic Mktg Mgt,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,
-MKT,8620,1,Quant Methods in Mkt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
-MKT,8650,1,Seminar in Mkt Mgmt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MKT,8660,1,International Marketing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
-ML,1020,1,Leadership Fund II,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,clay wilson etterle,
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,clay wilson etterle,
-ML,1020,3,Leadership Fund II,0.95,0.0,0.0,0.0,0.05,0.0,0.0,0.0,clay wilson etterle,
-ML,2020,1,Leadership Development II,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,2020,2,Leadership Development II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,2020,3,Leadership Development II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,3020,1,Advanced Leadership II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william cody cleland,
-ML,3020,2,Advanced Leadership II,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,william cody cleland,
-ML,4020,1,Organizational Leadership II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kenneth tod crawford,
-MSE,2100,1,Intro to Mat Science,0.34,0.23,0.22,0.07,0.06,0.0,0.0,0.07,rakhee pani,
-MSE,2100,2,Intro to Mat Science,0.35,0.28,0.19,0.09,0.06,0.0,0.0,0.04,ruslan burtovyy,
-MSE,2100,3,Intro to Mat Science,0.25,0.29,0.18,0.13,0.09,0.0,0.0,0.06,fei peng,
-MSE,2100,4,Intro to Mat Science,0.39,0.33,0.14,0.05,0.06,0.0,0.0,0.04,olga kuksenok,
-MSE,3100,1,Intro to Metals and Ceramics,0.53,0.27,0.09,0.02,0.04,0.0,0.0,0.04,jianhua tong,
-MSE,3260,1,Thermo of Materials,0.35,0.31,0.22,0.07,0.03,0.0,0.0,0.01,gary lickfield,
-MSE,3270,1,Transport Phenomena,0.0,0.22,0.33,0.39,0.0,0.0,0.0,0.06,ulf daniel schiller,
-MSE,3280,1,Phase Diagrams,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,eric skaar,
-MSE,3420,1,Struct/Property,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kuma bordia,
-MSE,4150,1,Polymer Sc Engr,0.33,0.44,0.17,0.03,0.0,0.0,0.0,0.03,igor luzinov,
-MSE,4160,1,Electronic Materials,0.62,0.33,0.02,0.0,0.02,0.0,0.0,0.0,kyle brinkman,
-MSE,4220,1,Mech Behavior of Mat,0.53,0.29,0.12,0.0,0.06,0.0,0.0,0.0,vincent yves blouin,
-MSE,4240,1,Optical Materials,0.61,0.17,0.13,0.09,0.0,0.0,0.0,0.0,luiz gusta jacobsohn,
-MSE,4330,1,Comb Sys & Env Emiss,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
-MSE,4450,1,Practice of Mat Engr,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,marek urban,
-MSE,4560,1,Polymer & Fiber Materials II,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,gary lickfield,
-MSE,4590,1,Color Science Lab,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,
-MSE,4590,2,Color Science Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,
-MSE,4810,1,Undergraduate Research Fundame,0.73,0.05,0.09,0.0,0.05,0.0,0.0,0.09,olin mefford,
-MSE,4910,1,Undergraduate Research,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,olin mefford,
-MSE,8190,1,Inorgan Mater Characterization,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,luiz gusta jacobsohn,
-MSE,8260,1,Phase Equil Mat Sys,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,stephen foulger,
-MUSC,1420,1,Music Theory I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,
-MUSC,1430,1,Aural Skills I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,
-MUSC,1440,1,Music Theory II,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,anthony bernarducci,
-MUSC,1510,2,Applied Music,0.67,0.19,0.05,0.0,0.05,0.0,0.0,0.05,jonathan edwar doyel,
-MUSC,1510,18,Applied Music,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david stevenson,
-MUSC,1800,1,Intro to Music Tech,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
-MUSC,2100,2,Music in the Western World,0.5,0.34,0.16,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
-MUSC,2100,3,Music in the Western World,0.29,0.55,0.06,0.0,0.0,0.0,0.0,0.1,rhea beth jacobus,
-MUSC,2100,5,Music in the Western World,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,6,Music in the Western World,0.45,0.52,0.0,0.03,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,7,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,evan michael jacobi,
-MUSC,2100,9,Music in the Western World,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,
-MUSC,3090,1,Surv of Broadway II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
-MUSC,3110,1,History of American Music,0.78,0.13,0.06,0.03,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,eric lapin,
-MUSC,3170,1,Hist of Country Mus,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3180,1,Hist of Audio Tech,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,
-MUSC,3690,1,Symphony Orchestra,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,andrew levin,
-MUSC,3700,1,Clemson University Singers,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,david hartmann,
-MUSC,3710,1,Women's Chorus,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,david hartmann,
-NPL,3000,1,Nonprofit Leadership,0.62,0.27,0.08,0.04,0.0,0.0,0.0,0.0,corey doug brookover,
-NPL,3000,2,Nonprofit Leadership,0.63,0.17,0.13,0.0,0.04,0.0,0.0,0.04,christina mari mazer,
-NPL,3000,3,Nonprofit Leadership,0.58,0.25,0.13,0.04,0.0,0.0,0.0,0.0,christina mari mazer,
-NPL,3000,4,Nonprofit Leadership,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,corey doug brookover,
-NPL,3000,5,Nonprofit Leadership,0.61,0.3,0.04,0.0,0.04,0.0,0.0,0.0,corey doug brookover,
-NPL,3010,2,NPL Stakeholders,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,christina mari mazer,
-NPL,3010,3,NPL Stakeholders,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christina mari mazer,
-NPL,3020,1,NPL Fundraising,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,thomas john orourke,
-NPL,3030,2,NPL Personnel,0.48,0.43,0.09,0.0,0.0,0.0,0.0,0.0,bonnie westb stevens,
-NPL,3030,3,NPL Personnel,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,bonnie westb stevens,
-NPL,3040,1,NPL Risk Management,0.71,0.06,0.06,0.12,0.06,0.0,0.0,0.0,daniel morg anderson,
-NURS,1400,1,Comp App Hlth Care,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
-NURS,1400,2,Comp App Hlth Care,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,janice garris lanham,
-NURS,1400,3,Comp App Hlth Care,0.91,0.03,0.03,0.0,0.0,0.0,0.0,0.03,jenna lynn seawright,
-NURS,3030,1,Nursing of Adults,0.41,0.56,0.02,0.02,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3030,400,Nursing of Adults,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3040,1,Pathophysiology,0.41,0.43,0.09,0.0,0.07,0.0,0.0,0.0,catherine sik murton,
-NURS,3040,401,Pathophysiology,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth cam hassen,
-NURS,3100,1,Health Assessment,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,
-NURS,3100,2,Health Assessment,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,
-NURS,3120,1,Foundations of Nursing,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,
-NURS,3190,400,Health Assessment for RNs,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
-NURS,3200,2,Prof in Nurs,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3230,402,Gerontology Nurs,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,
-NURS,3330,400,Health Care Genetics,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,mary steck,
-NURS,3400,1,Pharmther Nursing,0.37,0.5,0.07,0.04,0.02,0.0,0.0,0.0,catherine sik murton,
-NURS,4010,1,Mental Health Nurs,0.96,0.02,0.02,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,
-NURS,4030,1,Complex Nursing of Adults,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen ra ewing ra,
-NURS,4060,400,Issues in Professionalism,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
-NURS,4110,1,Nursing of Children,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
-NURS,4120,1,Nurs Women and Fam,0.74,0.24,0.0,0.02,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4250,400,Community Nursing,0.73,0.23,0.0,0.0,0.05,0.0,0.0,0.0,tiffany leah stewart,
-NURS,8010,400,Adv Fam & Comm Nrsng,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
-NURS,8010,401,Adv Fam & Comm Nrsng,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
-NURS,8080,400,Nurs Res Stat Analys,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,8080,401,Nurs Res Stat Analys,0.68,0.2,0.12,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,8190,400,Developing Family,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8200,400,Child & Adol Nursing,0.25,0.46,0.21,0.0,0.08,0.0,0.0,0.0,heide temples,
-NURS,8210,400,Adult Nursing,0.41,0.48,0.07,0.0,0.04,0.0,0.0,0.0,tracy king fasolino,
-NURS,8210,401,Adult Nursing,0.43,0.52,0.04,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8230,400,NP Clinical Practicum,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,
-NURS,8270,400,Nurs Education Found,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
-NURS,8840,400,Adult Mental Health,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,
-NURS,8850,400,Mental Health in Primary Care,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.56,0.33,0.05,0.01,0.02,0.0,0.0,0.02,elizabeth durrance,
-NUTR,2030,2,Intro Princ of Human Nutrition,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
-NUTR,2040,1,Nutrition Across Life Cycle,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,bridgit deni corbett,
-NUTR,4200,1,Food and Culture,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,bridgit deni corbett,
-NUTR,4250,1,Medica Nutr Thera II,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4260,1,Community Nutrition,0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,bridgit deni corbett,
-NUTR,4270,1,Nutrition Counseling,0.59,0.23,0.18,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
-NUTR,4550,1,Human Nutr & Metabolism II,0.67,0.12,0.12,0.09,0.0,0.0,0.0,0.0,elliot jesch,
-PA,2790,1,Perf Arts Pract I,0.6,0.13,0.07,0.0,0.07,0.0,0.0,0.13,kenneth moore,
-PA,2800,1,Perf Arts Pract II,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,kenneth moore,
-PADM,8220,400,Public Policy Process,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mellott eka yazykova,
-PADM,8270,400,Public Personnel Admin,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,donna marie kazia,
-PADM,8410,400,Public Data Analysis,0.56,0.19,0.06,0.0,0.19,0.0,0.0,0.0,ronald chrestman,
-PADM,8410,401,Public Data Analysis,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
-PADM,8410,402,Public Data Analysis,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,edmond patric bowers,
-PADM,8450,401,Grant Writing for Public Admin,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katherin kransteuber,
-PADM,8510,400,Emergency Management Fundam,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,charles antho haynes,
-PADM,8550,400,Homeland Sec and Intelligence,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,david leigh cook,
-PADM,8620,400,Administrative Leadership,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,
-PADM,8780,407,Project Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sandra marie batt,
-PAS,1010,2,Africa Atlantic Wrld,0.18,0.53,0.0,0.0,0.06,0.0,0.0,0.24,michael blum,
-PES,2020,1,Soils,0.22,0.47,0.27,0.02,0.02,0.0,0.0,0.02,dara michelle park,
-PES,4220,1,Major World Crops,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,sruthi narayan kutty,
-PES,4230,1,Field Crops: Forages,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,matias jose aguerre,
-PES,4330,1,Landscape & Turf Weed Mgt,0.13,0.38,0.44,0.06,0.0,0.0,0.0,0.0,ted whitwell,
-PES,4460,1,Soil Management,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,dara michelle park,
-PES,4520,1,Soil Fertility and Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
-PES,4530,1,Soil Fertility Laboratory,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
-PES,6520,1,Soil Fertility and Management,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,haibo liu,
-PES,8060,2,Water for Agriculture,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,sarah white,
-PES,8090,1,Analytical Technique,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14, tharayil-santhakumar,
-PHIL,1010,1,Intro to Philosophic Problems,0.61,0.24,0.03,0.0,0.0,0.0,0.0,0.12,david stegall,
-PHIL,1010,2,Intro to Philosophic Problems,0.49,0.23,0.09,0.06,0.0,0.0,0.0,0.14,david stegall,
-PHIL,1010,3,Intro to Philosophic Problems,0.27,0.64,0.03,0.0,0.03,0.0,0.0,0.03,kelly smith,
-PHIL,1010,5,Intro to Philosophic Problems,0.53,0.32,0.03,0.0,0.03,0.0,0.0,0.09,andrew garnar,
-PHIL,1020,1,Introduction to Logic,0.63,0.17,0.06,0.0,0.0,0.0,0.0,0.14,michael hal hannen,
-PHIL,1020,2,Introduction to Logic,0.68,0.18,0.12,0.0,0.0,0.0,0.0,0.03,michael hal hannen,
-PHIL,1020,3,Introduction to Logic,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,michael hal hannen,
-PHIL,1020,4,Introduction to Logic,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,edyta joanna kuzian,
-PHIL,1020,5,Introduction to Logic,0.5,0.25,0.1,0.0,0.1,0.0,0.0,0.05,edyta joanna kuzian,
-PHIL,1020,6,Introduction to Logic,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,adam gies,
-PHIL,1030,2,Introduction to Ethics,0.63,0.23,0.06,0.06,0.03,0.0,0.0,0.0,stephen satris,
-PHIL,1030,3,Introduction to Ethics,0.44,0.41,0.12,0.0,0.0,0.0,0.0,0.03,christopher mi wells,
-PHIL,1030,4,Introduction to Ethics,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1030,5,Introduction to Ethics,0.53,0.37,0.07,0.0,0.0,0.0,0.0,0.03,adam gies,
-PHIL,1030,6,Introduction to Ethics,0.42,0.48,0.03,0.03,0.03,0.0,0.0,0.0,christopher mi wells,
-PHIL,1030,7,Introduction to Ethics,0.81,0.13,0.03,0.0,0.0,0.0,0.0,0.03,adam gies,
-PHIL,1030,8,Introduction to Ethics,0.34,0.47,0.09,0.03,0.0,0.0,0.0,0.06,christopher mi wells,
-PHIL,1030,9,Introduction to Ethics,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,charles starkey,
-PHIL,3040,1,Moral Philosophy,0.32,0.36,0.25,0.0,0.04,0.0,0.0,0.04,todd may,
-PHIL,3050,1,Existentialism,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,david stegall,
-PHIL,3120,1,Philosophy in Ancient China,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,yanming an,
-PHIL,3160,1,Modern Philosophy,0.54,0.37,0.06,0.0,0.0,0.0,0.0,0.03,michael hal hannen,
-PHIL,3210,1,Crime & Punishment,0.3,0.39,0.12,0.06,0.06,0.0,0.0,0.06,daniel wueste,
-PHIL,3260,1,Science and Values,0.57,0.37,0.03,0.0,0.0,0.0,0.0,0.03,andrew garnar,
-PHIL,3260,2,Science and Values,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,
-PHIL,3300,1,Self-Deception,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,todd may,
-PHIL,3300,2,Ethics of Inequality,0.17,0.52,0.09,0.0,0.0,0.0,0.0,0.22,brookes colyto brown,
-PHIL,3330,1,Metaphysics,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,david stegall,
-PHIL,3430,1,Philosophy of Law,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,brookes colyto brown,
-PHIL,3450,1,Environmental Ethics,0.22,0.5,0.22,0.0,0.0,0.0,0.0,0.06,christopher mi wells,
-PHIL,3460,1,Biomedical Ethics,0.38,0.41,0.14,0.0,0.03,0.0,0.0,0.03,charles starkey,
-PHIL,4750,1,Philosophy of Film,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher grau,
-PHSC,1170,1,Intro Chem & Earth,0.74,0.23,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics with Calculus I,0.24,0.32,0.28,0.11,0.01,0.0,0.0,0.03,lih-sin the,
-PHYS,1220,2,Physics with Calculus I,0.24,0.41,0.24,0.06,0.02,0.0,0.0,0.03,lih-sin the,
-PHYS,1220,3,Physics with Calculus I,0.19,0.5,0.23,0.05,0.01,0.0,0.0,0.02,sriparn bhattacharya,
-PHYS,1220,4,Physics with Calculus I,0.25,0.47,0.23,0.02,0.01,0.0,0.0,0.01,sriparn bhattacharya,
-PHYS,1220,5,Physics with Calculus I,0.4,0.46,0.11,0.01,0.0,0.0,0.0,0.01,jason stratfor brown,
-PHYS,1220,8,Physics W/Cal I (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True
-PHYS,1240,1,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,2,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,3,Physics Lab I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,5,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,6,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,7,Physics Lab I,0.56,0.33,0.0,0.06,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,8,Physics Lab I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,9,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,10,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,11,Physics Lab I,0.44,0.44,0.0,0.0,0.06,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,12,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,13,Physics Lab I,0.22,0.72,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,14,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,15,Physics Lab I,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,16,Physics Lab I,0.76,0.12,0.0,0.06,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,17,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,18,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,19,Physics Lab I,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,20,Physics Lab I,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,21,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,22,Physics Lab I,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,23,Physics Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,25,Physics Lab I,0.53,0.24,0.06,0.0,0.12,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,26,Physics Lab I,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,27,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,29,Physics Lab I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,30,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2000,1,Introductory Physics,0.31,0.42,0.17,0.02,0.02,0.0,0.0,0.08,nicolas gr underwood,
-PHYS,2070,1,General Physics I,0.23,0.32,0.25,0.09,0.08,0.0,0.0,0.03,amy liann pope,
-PHYS,2080,1,General Physics II,0.52,0.3,0.11,0.05,0.01,0.0,0.0,0.01,amy liann pope,
-PHYS,2080,2,General Physics II,0.63,0.25,0.1,0.02,0.0,0.0,0.0,0.0,amy liann pope,
-PHYS,2090,1,Gen Phys Lab I,0.29,0.63,0.08,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,2,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,3,Gen Phys Lab I,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,4,Gen Phys Lab I,0.07,0.67,0.2,0.0,0.0,0.0,0.0,0.07,daniel ross thompson,
-PHYS,2090,5,Gen Phys Lab I,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,6,Gen Phys Lab I,0.09,0.74,0.09,0.0,0.04,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,7,Gen Phys Lab I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,daniel ross thompson,
-PHYS,2090,8,Gen Phys Lab I,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,9,Gen Phys Lab I,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,10,Gen Phys Lab I,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,
-PHYS,2100,1,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,2,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,3,Gen Phys Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,4,Gen Phys Lab II,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2100,5,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,6,Gen Phys Lab II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,7,Gen Phys Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,8,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,10,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,11,Gen Phys Lab II,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2100,12,Gen Phys Lab II,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2100,13,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,14,Gen Phys Lab II,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,15,Gen Phys Lab II,0.33,0.63,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,16,Gen Phys Lab II,0.7,0.17,0.04,0.0,0.04,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2100,17,Gen Phys Lab II,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2100,18,Gen Phys Lab II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2210,1,Physics with Calculus II,0.12,0.39,0.4,0.06,0.01,0.0,0.0,0.03,jason stratfor brown,
-PHYS,2210,2,Physics with Calculus II,0.3,0.33,0.24,0.09,0.03,0.0,0.0,0.01,jason stratfor brown,
-PHYS,2210,3,Physics with Calculus II (HON),0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,gerald lehmacher,True
-PHYS,2210,5,Physics with Calculus II,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,murray daw,
-PHYS,2210,500,Physics with Calculus II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,elaine parshall,
-PHYS,2220,1,Physics with Calculus III,0.5,0.31,0.06,0.0,0.0,0.0,0.0,0.13,jian he,
-PHYS,2230,1,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,2,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,3,Physics Lab II,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,
-PHYS,2230,5,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,6,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,7,Physics Lab II,0.06,0.72,0.22,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,8,Physics Lab II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,9,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,500,Physics Lab II,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,elaine parshall,
-PHYS,2400,1,Phys of Weather,0.27,0.39,0.21,0.05,0.02,0.0,0.0,0.06,miguel larsen,
-PHYS,3110,1,Methods Theor Phys,0.28,0.28,0.24,0.08,0.04,0.0,0.0,0.08,lih-sin the,
-PHYS,3220,1,Mechanics II,0.33,0.28,0.06,0.22,0.11,0.0,0.0,0.0,joshua alper,
-PHYS,3260,1,Exper Physics II,0.5,0.31,0.0,0.06,0.0,0.0,0.0,0.13,chad sosolik,
-PHYS,4420,1,Electromagnetics II,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,xian lu,
-PHYS,4560,1,Quantum Physics II,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,ramakrishna podila,
-PHYS,4650,1,Thermo and Stat Mech,0.41,0.35,0.06,0.18,0.0,0.0,0.0,0.0,feng ding,
-PHYS,8150,1,Statistical Therm I,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,jens oberheide,
-PHYS,8190,1,Comp Biophysics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,emil georgiev alexov,
-PHYS,8410,1,Electrodynamics I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
-PHYS,9520,1,Quantum Mech II,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,domnita ca marinescu,
-PKSC,1020,1,Intro to Pkg Sci,0.24,0.42,0.27,0.02,0.04,0.0,0.0,0.01,heather batt,
-PKSC,2010,1,Pkg Perishable Prod,0.13,0.35,0.28,0.08,0.13,0.0,0.0,0.05,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,
-PKSC,2040,1,Container Systems,0.86,0.11,0.03,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,
-PKSC,2060,1,Container Sys Lab,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,
-PKSC,2060,2,Container Sys Lab,0.54,0.38,0.04,0.04,0.0,0.0,0.0,0.0,tyler stuettgen,
-PKSC,2060,3,Container Sys Lab,0.32,0.45,0.18,0.05,0.0,0.0,0.0,0.0,tyler stuettgen,
-PKSC,2200,1,Product & Pkg Design,0.9,0.04,0.0,0.02,0.02,0.0,0.0,0.02,rupert hurley,
-PKSC,3200,1,Pkg Design Theory,0.84,0.14,0.0,0.0,0.0,0.0,0.0,0.02,rupert hurley,
-PKSC,3680,1,Pkg and Society,0.26,0.48,0.18,0.05,0.02,0.0,0.0,0.02,heather batt,
-PKSC,4030,1,Pkg Career Prep,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4200,1,Pkg Design & Dev,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4300,1,Converting Flex Pkg,0.23,0.64,0.09,0.03,0.0,0.0,0.0,0.02,duncan darby,
-PKSC,4400,1,Packaging for Distribution,0.26,0.46,0.23,0.0,0.03,0.0,0.0,0.03,gregory batt,
-PKSC,4400,400,Packaging for Distribution,0.1,0.3,0.45,0.0,0.0,0.0,0.0,0.15,gregory batt,
-PKSC,4640,1,Food & Health Care Pkg Systems,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,kay cooksey,
-PLPA,2130,1,Fungi & Civilization,0.43,0.35,0.12,0.02,0.02,0.0,0.0,0.06,julia louis kerrigan,
-PLPA,4060,1,Diseases/Insects Turfgrasses,0.0,0.82,0.09,0.09,0.0,0.0,0.0,0.0,samuel martin,
-POSC,1010,1,Amer National Govt,0.15,0.35,0.23,0.1,0.06,0.0,0.0,0.1,joseph earl stewart,
-POSC,1010,2,Amer National Govt,0.31,0.29,0.2,0.06,0.14,0.0,0.0,0.0,alfred bundrick,
-POSC,1020,1,Intro Intl Relations,0.56,0.3,0.08,0.0,0.04,0.0,0.0,0.02,brandon mich stewart,
-POSC,1020,2,Intro Intl Relations,0.14,0.37,0.25,0.08,0.06,0.0,0.0,0.08,aron geor tannenbaum,
-POSC,1020,3,Intro Intl Relations,0.33,0.42,0.08,0.02,0.06,0.0,0.0,0.08,steven vincen miller,
-POSC,1030,1,Intro to Political Theory,0.37,0.4,0.14,0.0,0.07,0.0,0.0,0.02,brandon turner,
-POSC,1030,2,Intro to Political Theory,0.1,0.53,0.23,0.07,0.0,0.0,0.0,0.07,colin pearce,
-POSC,1030,3,Intro to Political Theory,0.06,0.58,0.23,0.1,0.03,0.0,0.0,0.0,colin pearce,
-POSC,1030,4,Intro to Political Theory,0.33,0.43,0.13,0.03,0.0,0.0,0.0,0.07,lorianne molinari,
-POSC,1040,1,Intro Compar Pol,0.21,0.58,0.16,0.0,0.0,0.0,0.0,0.05,xiaobo hu,
-POSC,1040,2,Intro Compar Pol,0.51,0.19,0.17,0.02,0.11,0.0,0.0,0.0,brandon mich stewart,
-POSC,1990,1,Intro Pol Sci,0.46,0.21,0.12,0.08,0.08,0.0,0.0,0.06,meredith- petersheim,
-POSC,3020,1,State and Loc Gov,0.19,0.57,0.11,0.03,0.03,0.0,0.0,0.08,bruce ransom,
-POSC,3210,1,Public Admin,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
-POSC,3610,1,International Conflict,0.2,0.23,0.18,0.09,0.18,0.0,0.0,0.11,steven vincen miller,
-POSC,3630,1,Us Foreign Policy,0.21,0.57,0.18,0.0,0.04,0.0,0.0,0.0,jeffrey scott peake,
-POSC,3710,1,European Politics,0.43,0.38,0.07,0.02,0.07,0.0,0.0,0.02,vladimir matic,
-POSC,3710,615,European Politics,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
-POSC,3750,1,European Integration,0.2,0.25,0.3,0.05,0.1,0.0,0.0,0.1,zeynep taydas,
-POSC,4050,1,American Presidency,0.21,0.25,0.17,0.08,0.25,0.0,0.0,0.04,adam warber,
-POSC,4160,1,Int Groups & Soc Mov,0.24,0.39,0.22,0.1,0.0,0.0,0.0,0.05,laura olson,
-POSC,4360,1,Law Courts Politics,0.85,0.06,0.0,0.0,0.0,0.0,0.0,0.09,joseph earl stewart,
-POSC,4370,1,Constitut Law: Rights & Libert,0.48,0.42,0.08,0.0,0.02,0.0,0.0,0.0,daniel frost,
-POSC,4390,1,Religious Liberty & US Const,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,
-POSC,4480,615,Internat'l Political Economy,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
-POSC,4490,1,Political Theory of Capitalism,0.44,0.28,0.12,0.02,0.09,0.0,0.0,0.05,brandon turner,
-POSC,4530,1,American Political Thought,0.47,0.4,0.09,0.0,0.02,0.0,0.0,0.02,lorianne molinari,
-POSC,4660,1,African Politics,0.53,0.21,0.21,0.0,0.05,0.0,0.0,0.0,brandon mich stewart,
-POSC,4710,1,Russian Politics,0.63,0.21,0.04,0.0,0.04,0.0,0.0,0.08,aron geor tannenbaum,
-POSC,4760,1,Middle East Politics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
-POSC,4890,1,Religion in World Politics,0.47,0.29,0.12,0.12,0.0,0.0,0.0,0.0,laura olson,
-PRTM,2200,1,Foundations of PRTM,0.73,0.12,0.06,0.0,0.03,0.0,0.0,0.06,gwynn powell,
-PRTM,2200,2,Foundations of PRTM,0.23,0.41,0.23,0.09,0.05,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2200,3,Foundations of PRTM,0.64,0.16,0.12,0.0,0.08,0.0,0.0,0.0,katrina latric black,
-PRTM,2200,4,Foundations of PRTM,0.65,0.16,0.13,0.06,0.0,0.0,0.0,0.0,lauren eliz stephens,
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2270,1,Prov of Leisure Exp,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2290,1,Competency Integration in PRTM,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2410,1,Intro to CRSCM,0.46,0.36,0.17,0.02,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2600,1,Found of Recreational Therapy,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,brandi crowe,
-PRTM,2650,1,Terminology in RT Practice,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,
-PRTM,2700,1,Intro Rec Res Mgt,0.62,0.35,0.0,0.04,0.0,0.0,0.0,0.0,elizabeth de baldwin,
-PRTM,2810,1,Intro to Golf Mgt,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,2820,1,Principle Golfer Dev,0.58,0.08,0.08,0.25,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.38,0.41,0.18,0.03,0.0,0.0,0.0,0.0,daniel morg anderson,
-PRTM,3070,1,Facility Operations,0.75,0.18,0.0,0.07,0.0,0.0,0.0,0.0,raymond dunham,
-PRTM,3210,1,Recreation Admin,0.5,0.38,0.03,0.03,0.06,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,3250,1,Global Persp in Rec,0.6,0.33,0.03,0.0,0.03,0.0,0.0,0.03,harrison pa pinckney,
-PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nut townsend,
-PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3280,2,Preceptorship in Recr Therapy,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,
-PRTM,3420,1,Intro to Tourism,0.63,0.15,0.1,0.02,0.02,0.0,0.0,0.07,peter judca mkumbo,
-PRTM,3420,2,Intro to Tourism,0.62,0.23,0.08,0.04,0.0,0.0,0.0,0.04,garrett anders stone,
-PRTM,3440,1,Tourism Markets,0.89,0.04,0.04,0.04,0.0,0.0,0.0,0.0,sheila backman,
-PRTM,3440,2,Tourism Markets,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,
-PRTM,3450,1,Tourism Management,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,william norman,
-PRTM,3450,2,Tourism Management,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,'lisha fogle,
-PRTM,3460,1,Heritage Tourism,0.23,0.48,0.15,0.08,0.06,0.0,0.0,0.0,gregory phil ramshaw,
-PRTM,3530,2,Foundations of Camp Counseling,0.67,0.1,0.24,0.0,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,3900,5,Independent Study in PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3910,10,Social Media in PRTM,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,zeynep gedikoglu,
-PRTM,4210,1,Rec Fin Resc Mgt,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,harrison pa pinckney,
-PRTM,4300,1,World Geog Parks,0.35,0.16,0.27,0.18,0.02,0.0,0.0,0.02,robert baxter powell,
-PRTM,4460,2,Community Tourism,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lauren duffy,
-PRTM,4460,3,Community Tourism,0.63,0.33,0.0,0.0,0.04,0.0,0.0,0.0,katie dudley,
-PRTM,4550,1,Adv Program Planning,0.72,0.11,0.0,0.11,0.0,0.0,0.0,0.06,mariela fernandez,
-PRTM,8080,1,Behavioral Aspects,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,robert bixler,
-PRTM,8110,2,Research Methods,0.7,0.22,0.04,0.0,0.04,0.0,0.0,0.0,matthew tyl brownlee,
-PRTM,8110,3,Research Methods,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey charle hallo,
-PRTM,8210,1,Funding Strategies in PRTM,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,8250,1,Populations in PRTM,0.58,0.25,0.0,0.0,0.17,0.0,0.0,0.0,teresa walton tucker,
-PRTM,8720,2,Adv Facilitation Techniq in RT,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,brandi crowe,
-PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.6,0.2,0.13,0.0,0.07,0.0,0.0,0.0,anna-mari chancellor,
-PRTM,8740,2,Mgt of Clinical Process in RT,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,stephen thomas lewis,
-PSYC,2010,1,Intro to Psychology,0.26,0.25,0.19,0.14,0.1,0.0,0.0,0.07,edwin brainerd,
-PSYC,2010,2,Intro to Psychology,0.37,0.32,0.18,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,
-PSYC,2010,3,Intro to Psychology,0.36,0.38,0.13,0.07,0.04,0.0,0.0,0.01,mary taylor,
-PSYC,2010,4,Intro to Psychology,0.45,0.33,0.16,0.03,0.01,0.0,0.0,0.01,mary taylor,
-PSYC,2010,5,Intro to Psychology,0.47,0.37,0.12,0.01,0.01,0.0,0.0,0.01,chong hyon pak,
-PSYC,2010,6,Intro to Psychology,0.64,0.23,0.04,0.06,0.01,0.0,0.0,0.01,chong hyon pak,
-PSYC,2010,8,Intro to Psychology (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
-PSYC,2010,9,Intro to Psychology (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True
-PSYC,2020,3,Intro Psychology Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,nastassia mar savage,
-PSYC,2890,1,Fundamentals of Psyc Science,0.46,0.32,0.13,0.04,0.04,0.0,0.0,0.02,cynthia pury s,
-PSYC,3060,1,Human Sexual Behavior,0.51,0.21,0.14,0.05,0.06,0.0,0.0,0.03,bruce michael king,
-PSYC,3090,100,Intro Experimental Psychology,0.4,0.28,0.18,0.08,0.04,0.0,0.0,0.01,patrick rosopa,
-PSYC,3090,200,Intro Experimental Psychology,0.37,0.3,0.2,0.03,0.09,0.0,0.0,0.01,jennifer bail bisson,
-PSYC,3100,100,Advanced Experimental Psych,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,peggy tyler,
-PSYC,3100,200,Advanced Experimental Psych,0.32,0.24,0.16,0.2,0.04,0.0,0.0,0.04,jennifer bail bisson,
-PSYC,3100,300,Advanced Experimental Psych,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,fred switzer,
-PSYC,3100,400,Advanced Experimental Psych,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,thomas britt,
-PSYC,3100,500,Advanced Experimental Psych,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3100,600,Advanced Experimental Psych,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,3240,1,Physiological Psych,0.41,0.31,0.13,0.07,0.06,0.0,0.0,0.01,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.26,0.28,0.23,0.12,0.04,0.0,0.0,0.07,june pilcher,
-PSYC,3330,1,Cognitive Psych,0.66,0.21,0.11,0.01,0.0,0.0,0.0,0.0,kaileigh angel byrne,
-PSYC,3330,2,Cognitive Psych,0.5,0.34,0.12,0.03,0.0,0.0,0.0,0.01,kaileigh angel byrne,
-PSYC,3340,1,Cognitive Psych Lab,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,laura whitlock,
-PSYC,3340,3,Cognitive Psych Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michael shreeves,
-PSYC,3340,4,Cognitive Psych Lab,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,tiffany cooper,
-PSYC,3400,1,Lifespan Developmental Psych,0.35,0.31,0.21,0.04,0.04,0.0,0.0,0.04,pamela alley,
-PSYC,3520,1,Social Psychology,0.54,0.31,0.13,0.0,0.01,0.0,0.0,0.0,eric mckibben,
-PSYC,3520,2,Social Psychology,0.39,0.33,0.2,0.07,0.0,0.0,0.0,0.01,jo anne jorgensen,
-PSYC,3640,1,Industrial Psych,0.27,0.33,0.29,0.04,0.02,0.0,0.0,0.06,eric mckibben,
-PSYC,3640,2,Industrial Psych,0.33,0.43,0.17,0.04,0.03,0.0,0.0,0.0,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.49,0.33,0.13,0.01,0.01,0.0,0.0,0.01,dana verhoeven,
-PSYC,3700,1,Personality,0.29,0.44,0.19,0.02,0.0,0.0,0.0,0.06,eric mckibben,
-PSYC,3700,2,Personality,0.42,0.42,0.12,0.04,0.0,0.0,0.0,0.0,john robert hester,
-PSYC,3830,1,Abnormal Psychology,0.32,0.45,0.15,0.04,0.02,0.0,0.0,0.02,cynthia pury s,
-PSYC,3830,2,Abnormal Psychology,0.21,0.45,0.21,0.03,0.06,0.0,0.0,0.03,pamela alley,
-PSYC,3830,3,Abnormal Psychology,0.21,0.44,0.21,0.06,0.03,0.0,0.0,0.06,pamela alley,
-PSYC,3890,1,Cross-Cultural Psychology,0.25,0.34,0.22,0.12,0.03,0.0,0.0,0.03,ceren gunsoy,
-PSYC,3890,2,Cross-Cultural Psychology,0.41,0.28,0.16,0.07,0.04,0.0,0.0,0.04,ceren gunsoy,
-PSYC,4080,1,Women and Psychology,0.64,0.12,0.08,0.08,0.08,0.0,0.0,0.0,robin marie kowalski,
-PSYC,4150,1,Systems and Theories,0.33,0.15,0.21,0.15,0.09,0.0,0.0,0.06,edwin brainerd,
-PSYC,4150,2,Systems and Theories,0.38,0.19,0.16,0.06,0.13,0.0,0.0,0.09,edwin brainerd,
-PSYC,4220,1,Perception,0.16,0.36,0.24,0.2,0.04,0.0,0.0,0.0,claudio cantalupo,
-PSYC,4220,2,Perception,0.32,0.2,0.2,0.24,0.04,0.0,0.0,0.0,claudio cantalupo,
-PSYC,4220,3,Perception,0.4,0.28,0.28,0.0,0.04,0.0,0.0,0.0,richard tyrrell,
-PSYC,4350,1,Human Factors,0.52,0.24,0.08,0.08,0.04,0.0,0.0,0.04,laura whitlock,
-PSYC,4430,1,Infant & Child Dev,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,4560,1,Psychophysiology,0.5,0.3,0.05,0.1,0.05,0.0,0.0,0.0,drew michael morris,
-PSYC,4710,1,Psych of Testing,0.33,0.17,0.0,0.08,0.25,0.0,0.0,0.17,zhuo chen,
-PSYC,4800,1,Health Psychology,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,chelsea alyc lenoble,
-PSYC,4880,1,Psychotherapy,0.24,0.53,0.06,0.06,0.06,0.0,0.0,0.06,lucinda sorcie quick,
-PSYC,4890,1,Psychology of Music,0.64,0.28,0.04,0.0,0.0,0.0,0.0,0.04,robert campbell,
-PSYC,4920,1,Senior Laboratory,0.79,0.07,0.11,0.0,0.04,0.0,0.0,0.0,pamela farago,
-PSYC,4920,2,Senior Laboratory,0.82,0.07,0.07,0.04,0.0,0.0,0.0,0.0,pamela farago,
-PSYC,4920,3,Senior Laboratory,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,stephen an robertson,
-PSYC,4920,4,Senior Laboratory,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,stephen an robertson,
-PSYC,4930,100,Pract Clinical Psych,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,heidi marie zinzow,
-PSYC,8130,1,Research Design III,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,patrick rosopa,
-PSYC,8330,1,Adv Cog Psych,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,leo gugerty,
-PSYC,8610,1,Personnel Psych,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,patrick raymark,
-PSYC,8820,1,Occupat Health Psy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert raym sinclair,
-RED,8030,1,Pub-Priv Partnership,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john terrence farris,
-REL,1010,1,Intro to Religion,0.34,0.31,0.22,0.03,0.03,0.0,0.0,0.06,peter cohen,
-REL,1010,2,Intro to Religion,0.29,0.31,0.29,0.03,0.06,0.0,0.0,0.03,peter cohen,
-REL,1010,3,Intro to Religion,0.18,0.33,0.33,0.06,0.03,0.0,0.0,0.06,peter cohen,
-REL,1010,4,Intro to Religion,0.32,0.26,0.32,0.0,0.0,0.0,0.0,0.11,brett patterson,
-REL,1010,5,Intro to Religion,0.16,0.55,0.13,0.1,0.03,0.0,0.0,0.03,brett patterson,
-REL,1020,1,World Religions,0.36,0.52,0.03,0.0,0.0,0.0,0.0,0.09,robert stephens,
-REL,1020,2,World Religions,0.32,0.32,0.21,0.0,0.0,0.0,0.0,0.15,robert stephens,
-REL,1020,4,World Religions,0.34,0.53,0.09,0.0,0.0,0.0,0.0,0.03,robert stephens,
-REL,3000,2,Studying Religion,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,steven grosby,
-REL,3010,1,Old Testament,0.56,0.29,0.06,0.0,0.0,0.0,0.0,0.09,steven grosby,
-REL,3030,1,The Quran,0.46,0.38,0.04,0.0,0.04,0.0,0.0,0.08,mashal saif,
-REL,3070,1,Christian Trad,0.43,0.36,0.18,0.0,0.0,0.0,0.0,0.04,brett patterson,
-REL,3120,1,Hinduism,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert stephens,
-REL,3300,1,Contemporary Issues,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.12,richard ale amesbury,
-RUSS,1020,1,Elementary Russian,0.27,0.55,0.09,0.09,0.0,0.0,0.0,0.0,stephanie ely morris,
-RUSS,1020,2,Elementary Russian,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,stephanie ely morris,
-RUSS,3600,1,Russian Lit to 1910,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,olga anatoly volkova,
-RUSS,3610,1,Russn Lit Since 1910,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,olga anatoly volkova,
-SOC,2010,2,Introduction to Sociology,0.88,0.1,0.0,0.0,0.02,0.0,0.0,0.0,andrew he mannheimer,
-SOC,2010,3,Introduction to Sociology,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.01,andrew he mannheimer,
-SOC,2010,4,Introduction to Sociology,0.39,0.41,0.15,0.04,0.0,0.0,0.0,0.0,carolyn cand coffman,
-SOC,2010,5,Introduction to Sociology,0.51,0.32,0.12,0.01,0.03,0.0,0.0,0.01,carolyn cand coffman,
-SOC,2010,6,Introduction to Sociology,0.65,0.17,0.11,0.02,0.0,0.0,0.0,0.04,carolyn cand coffman,
-SOC,2010,7,Introduction to Sociology,0.73,0.13,0.04,0.04,0.04,0.0,0.0,0.03,stacy leanne smith,
-SOC,2010,8,Introduction to Sociology,0.76,0.11,0.09,0.02,0.02,0.0,0.0,0.0,stacy leanne smith,
-SOC,2010,9,Introduction to Sociology,0.85,0.09,0.02,0.02,0.0,0.0,0.0,0.02,stacy leanne smith,
-SOC,2010,10,Introduction to Sociology,0.51,0.39,0.08,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,11,Introduction to Sociology,0.64,0.26,0.09,0.01,0.0,0.0,0.0,0.0,shannon mcdonough,
-SOC,2010,12,Introduction to Sociology,0.61,0.24,0.1,0.02,0.0,0.0,0.0,0.02,shannon mcdonough,
-SOC,2020,1,Social Problems,0.47,0.36,0.11,0.02,0.04,0.0,0.0,0.0,carolyn cand coffman,
-SOC,3020,1,Research Methods I,0.33,0.27,0.27,0.03,0.03,0.0,0.0,0.07,andrew whitehead,
-SOC,3040,1,Social Research Methods II,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,william haller,
-SOC,3100,1,Marriage & Intimacy,0.62,0.16,0.18,0.0,0.02,0.0,0.0,0.02,carolyn cand coffman,
-SOC,3110,1,The Family,0.36,0.49,0.11,0.04,0.0,0.0,0.0,0.0,traci ann hefner,
-SOC,3600,1,Class & Poverty,0.24,0.49,0.2,0.05,0.02,0.0,0.0,0.0,kenneth robinson,
-SOC,3800,1,Intro Social Service,0.58,0.35,0.04,0.02,0.0,0.0,0.0,0.0,jennifer lea holland,
-SOC,3910,1,Soc of Deviance,0.5,0.38,0.08,0.02,0.02,0.0,0.0,0.0,shannon mcdonough,
-SOC,4040,1,Soc Theory,0.52,0.26,0.13,0.1,0.0,0.0,0.0,0.0,stacy leanne smith,
-SOC,4320,1,Soc of Religion,0.31,0.4,0.29,0.0,0.0,0.0,0.0,0.0,andrew whitehead,
-SOC,4330,1,Global Social Change,0.33,0.38,0.17,0.02,0.05,0.0,0.0,0.05,traci ann hefner,
-SOC,4600,1,Race & Ethnicity,0.77,0.18,0.02,0.02,0.0,0.0,0.0,0.0,andrew he mannheimer,
-SOC,4600,2,Race & Ethnicity,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrew he mannheimer,
-SOC,4610,1,Sex & Gender,0.28,0.35,0.14,0.16,0.07,0.0,0.0,0.0,sarah evelyn winslow,
-SOC,4840,1,Child Abuse,0.81,0.16,0.0,0.0,0.0,0.0,0.0,0.03,james rosenberger,
-SOC,4970,1,Senior Lab,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,jennifer lea holland,
-SPAN,1010,1,Elementary Spanish,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,
-SPAN,1010,2,Elementary Spanish,0.47,0.16,0.26,0.0,0.0,0.0,0.0,0.11,rosa maca pillcurima,
-SPAN,1010,3,Elementary Spanish,0.41,0.14,0.27,0.0,0.09,0.0,0.0,0.09,rosa maca pillcurima,
-SPAN,1020,2,Elementary Spanish,0.32,0.5,0.09,0.05,0.0,0.0,0.0,0.05,ellory schmucker,
-SPAN,1020,3,Elementary Spanish,0.39,0.48,0.09,0.0,0.04,0.0,0.0,0.0,adrienne elizab fama,
-SPAN,1020,4,Elementary Spanish,0.27,0.32,0.32,0.09,0.0,0.0,0.0,0.0,adrienne elizab fama,
-SPAN,1020,5,Elementary Spanish,0.14,0.55,0.23,0.05,0.0,0.0,0.0,0.05,rosa maca pillcurima,
-SPAN,1020,7,Elementary Spanish,0.36,0.36,0.18,0.0,0.09,0.0,0.0,0.0,cathy robison,
-SPAN,1020,8,Elementary Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,debra oak williamson,
-SPAN,1020,9,Elementary Spanish,0.47,0.21,0.26,0.0,0.0,0.0,0.0,0.05,debra oak williamson,
-SPAN,1020,10,Elementary Spanish,0.43,0.38,0.14,0.0,0.05,0.0,0.0,0.0,adrienne elizab fama,
-SPAN,2010,1,Intermediate Spanish,0.23,0.5,0.14,0.05,0.0,0.0,0.0,0.09,cathy robison,
-SPAN,2010,2,Intermediate Spanish,0.26,0.26,0.26,0.11,0.0,0.0,0.0,0.11,cathy robison,
-SPAN,2010,3,Intermediate Spanish,0.39,0.39,0.22,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
-SPAN,2010,4,Intermediate Spanish,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,nora arostegui logue,
-SPAN,2010,5,Intermediate Spanish,0.39,0.44,0.06,0.0,0.06,0.0,0.0,0.06,allison ann hinds,
-SPAN,2010,6,Intermediate Spanish,0.31,0.46,0.0,0.08,0.0,0.0,0.0,0.15,debra oak williamson,
-SPAN,2010,7,Intermediate Spanish,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,debra oak williamson,
-SPAN,2010,8,Intermediate Spanish,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,9,Intermediate Spanish,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,10,Intermediate Spanish,0.65,0.22,0.04,0.04,0.0,0.0,0.0,0.04,vieyra daniel garcia,
-SPAN,2010,12,Intermediate Spanish,0.64,0.07,0.07,0.0,0.07,0.0,0.0,0.14,valderramos zen cruz,
-SPAN,2010,13,Intermediate Spanish,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,
-SPAN,2010,14,Intermediate Spanish,0.61,0.22,0.09,0.0,0.0,0.0,0.0,0.09,ellory schmucker,
-SPAN,2010,16,Intermediate Spanish,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,vieyra daniel garcia,
-SPAN,2020,1,Intermediate Spanish,0.7,0.22,0.04,0.0,0.04,0.0,0.0,0.0,vieyra daniel garcia,
-SPAN,2020,2,Intermediate Spanish,0.71,0.1,0.14,0.05,0.0,0.0,0.0,0.0,vieyra daniel garcia,
-SPAN,2020,3,Intermediate Spanish,0.7,0.17,0.13,0.0,0.0,0.0,0.0,0.0,vieyra daniel garcia,
-SPAN,2020,4,Intermediate Spanish,0.48,0.38,0.1,0.0,0.0,0.0,0.0,0.05,valderramos zen cruz,
-SPAN,2020,5,Intermediate Spanish,0.55,0.23,0.14,0.0,0.0,0.0,0.0,0.09,valderramos zen cruz,
-SPAN,2020,6,Intermediate Spanish,0.52,0.35,0.13,0.0,0.0,0.0,0.0,0.0,valderramos zen cruz,
-SPAN,2020,7,Intermediate Spanish,0.12,0.47,0.12,0.12,0.18,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,8,Intermediate Spanish,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,
-SPAN,2020,9,Intermediate Spanish,0.42,0.42,0.05,0.11,0.0,0.0,0.0,0.0,ana paula  miller e,
-SPAN,2020,10,Intermediate Spanish,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,
-SPAN,2020,11,Intermediate Spanish,0.65,0.26,0.04,0.0,0.0,0.0,0.0,0.04,rodriguez alm garcia,
-SPAN,2020,12,Intermediate Spanish,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
-SPAN,2020,13,Intermediate Spanish,0.19,0.48,0.24,0.0,0.0,0.0,0.0,0.1,juana martin-armas,
-SPAN,2020,14,Intermediate Spanish,0.1,0.5,0.2,0.2,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,2020,15,Intermediate Spanish,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,ana paula  miller e,
-SPAN,2020,20,Intermediate Spanish,0.45,0.23,0.27,0.0,0.0,0.0,0.0,0.05,melva margue persico,
-SPAN,3020,1,Intermed Span Grammar & Comp,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,
-SPAN,3020,2,Intermed Span Grammar & Comp,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,melva margue persico,
-SPAN,3020,3,Intermed Span Grammar & Comp,0.42,0.37,0.05,0.0,0.05,0.0,0.0,0.11,melva margue persico,
-SPAN,3040,1,Intro Hispanic Literary Forms,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,
-SPAN,3040,2,Intro Hispanic Literary Forms,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,rodriguez alm garcia,
-SPAN,3050,1,Intermed Span Convers/Comp I,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,melva margue persico,
-SPAN,3050,2,Intermed Span Convers/Comp I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,riquelme maria judez,
-SPAN,3050,4,Intermed Span Convers/Comp I,0.72,0.17,0.06,0.06,0.0,0.0,0.0,0.0,moni rojas-de-massei,
-SPAN,3060,1,Span Comp for Bus,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,3070,1,The Hispanic World: Spain,0.5,0.44,0.0,0.06,0.0,0.0,0.0,0.0,juana martin-armas,
-SPAN,3080,1,The Hispanic World: Latin Amer,0.24,0.47,0.18,0.0,0.12,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,3130,2,Span Lit Survey I,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william dan holcombe,
-SPAN,4060,1,Narrative Fiction,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,moni rojas-de-massei,
-SPAN,4070,1,Hispanic Film,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,raquel anido,
-SPAN,4170,1,Prof Communication,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
-SPAN,4180,1,Technical Span Health Mgt Prof,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,peralta arelis moore,
-STAT,2220,1,Statistics in Everyday Life,0.38,0.25,0.27,0.04,0.04,0.0,0.0,0.02,james espey,
-STAT,2220,2,Statistics in Everyday Life,0.39,0.31,0.14,0.04,0.06,0.0,0.0,0.06,james espey,
-STAT,2220,3,Statistics in Everyday Life,0.35,0.31,0.17,0.08,0.08,0.0,0.0,0.02,james espey,
-STAT,2220,4,Statistics in Everyday Life,0.27,0.35,0.17,0.1,0.0,0.0,0.0,0.12,james espey,
-STAT,2220,5,Statistics in Everyday Life,0.31,0.43,0.16,0.06,0.02,0.0,0.0,0.02,rose martinez-dawson,
-STAT,2220,6,Statistics in Everyday Life,0.47,0.22,0.18,0.08,0.06,0.0,0.0,0.0,rose martinez-dawson,
-STAT,2220,7,Statistics in Everyday Life,0.27,0.33,0.27,0.08,0.0,0.0,0.0,0.04,jason alexander kurz,
-STAT,2220,8,Statistics in Everyday Life,0.14,0.35,0.22,0.05,0.19,0.0,0.0,0.05,andrew pangia,
-STAT,2300,1,Statistical Methods I,0.22,0.33,0.21,0.11,0.08,0.0,0.0,0.04,april thomas,
-STAT,2300,2,Statistical Methods I,0.32,0.33,0.17,0.12,0.03,0.0,0.0,0.04,christy jenkin brown,
-STAT,2300,3,Statistical Methods I,0.3,0.35,0.16,0.08,0.05,0.0,0.0,0.05, erwin walker,
-STAT,2300,4,Statistical Methods I,0.27,0.3,0.18,0.11,0.08,0.0,0.0,0.06, erwin walker,
-STAT,2300,5,Statistical Methods I,0.21,0.38,0.22,0.08,0.11,0.0,0.0,0.01,elaine mar sotherden,
-STAT,2300,6,Statistical Methods I,0.28,0.41,0.18,0.08,0.04,0.0,0.0,0.01,todd fenstermacher,
-STAT,2300,100,Statistical Methods I (HON),0.73,0.24,0.03,0.0,0.0,0.0,0.0,0.0,christy jenkin brown,True
-STAT,3090,1,Introductory Business Stats,0.16,0.21,0.29,0.08,0.16,0.0,0.0,0.11,tianhui wei,
-STAT,3090,2,Introductory Business Stats,0.14,0.17,0.17,0.19,0.25,0.0,0.0,0.08,matthew saltzman,
-STAT,3090,3,Introductory Business Stats,0.31,0.29,0.12,0.17,0.07,0.0,0.0,0.05,tiantian yang,
-STAT,3090,4,Introductory Business Stats,0.2,0.25,0.16,0.18,0.11,0.0,0.0,0.09,margaret mari wiecek,
-STAT,3090,5,Introductory Business Stats,0.2,0.18,0.23,0.16,0.16,0.0,0.0,0.07,lu sun,
-STAT,3090,6,Introductory Business Stats,0.18,0.3,0.27,0.05,0.2,0.0,0.0,0.0,boyoung hur,
-STAT,3090,7,Introductory Business Stats,0.26,0.31,0.19,0.12,0.1,0.0,0.0,0.02,jiajing niu,
-STAT,3090,8,Introductory Business Stats,0.26,0.21,0.33,0.05,0.13,0.0,0.0,0.03,yisu jia,
-STAT,3090,9,Introductory Business Stats,0.29,0.4,0.26,0.06,0.0,0.0,0.0,0.0,marilyn reba,
-STAT,3090,10,Introductory Business Stats,0.28,0.56,0.06,0.08,0.03,0.0,0.0,0.0,marilyn reba,
-STAT,3090,11,Introductory Business Stats,0.24,0.23,0.26,0.14,0.12,0.0,0.0,0.01,sharon marie evans,
-STAT,3090,12,Introductory Business Stats,0.2,0.34,0.26,0.09,0.08,0.0,0.0,0.02,sharon marie evans,
-STAT,3300,1,Statistical Methods II,0.36,0.36,0.12,0.08,0.04,0.0,0.0,0.04,rose martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.43,0.24,0.1,0.0,0.14,0.0,0.0,0.1,ellen hepfer breazel,
-STAT,4110,1,Stat Mthds for Process Control,0.71,0.18,0.09,0.0,0.03,0.0,0.0,0.0,richard steve dubsky,
-STAT,6020,1,Intro to Statistical Computing,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,
-STAT,8010,1,Statistical Methods I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james rieck,
-STAT,8010,2,Statistical Methods I,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,8010,3,Statistical Methods I,0.32,0.36,0.18,0.0,0.09,0.0,0.0,0.05,james rieck,
-STAT,8010,4,Statistical Methods I,0.43,0.52,0.04,0.0,0.0,0.0,0.0,0.0,patrick gerard,
-STAT,8010,5,Statistical Methods I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,joseph daniel bible,
-STAT,8010,400,Statistical Methods I,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,brook thayer russell,
-STAT,8050,1,Design & Anlys of Experiments,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,william bridges,
-STS,1010,2,Survey of S T S,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,scott brame,
-STS,1010,3,Survey of S T S,0.5,0.36,0.11,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,
-STS,1010,4,Survey of S T S,0.69,0.25,0.03,0.0,0.0,0.0,0.0,0.03,melissa dugan,
-STS,1010,5,Survey of S T S,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,philip randall,
-STS,1010,6,Survey of S T S,0.17,0.51,0.23,0.0,0.0,0.0,0.0,0.09,sarah mae cooper,
-STS,1010,7,Survey of S T S,0.22,0.47,0.25,0.0,0.0,0.0,0.0,0.06,megan noe macalystre,
-STS,1010,8,Survey of S T S,0.27,0.4,0.2,0.03,0.0,0.0,0.0,0.1,david charles foltz,
-STS,1010,9,Survey of S T S,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,stephanie stripling,
-THEA,2100,1,Theatre Appreciation,0.55,0.29,0.06,0.03,0.0,0.0,0.0,0.06,kendra lynet johnson,
-THEA,2100,2,Theatre Appreciation,0.66,0.19,0.06,0.0,0.06,0.0,0.0,0.03,kerrie kathl seymour,
-THEA,2100,3,Theatre Appreciation,0.87,0.06,0.03,0.0,0.0,0.0,0.0,0.03,shannon there robert,
-THEA,2100,5,Theatre Appreciation,0.43,0.47,0.07,0.0,0.0,0.0,0.0,0.03,carol collins,
-THEA,2100,6,Theatre Appreciation,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,
-THEA,2100,7,Theatre Appreciation,0.66,0.28,0.03,0.0,0.0,0.0,0.0,0.03,jason adkins,
-THEA,2790,1,Theatre Practicum,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,matthew leckenbusch,
-THEA,3160,1,Theatre History II,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,peter richard er st. er,
-THEA,3180,1,Afri-Amer Thea II,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,kendra lynet johnson,
-THEA,3770,1,Stagecrafts,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david hartmann,
-THEA,4790,1,Acting II,0.54,0.23,0.08,0.08,0.08,0.0,0.0,0.0,kerrie kathl seymour,
-WFB,3010,1,Wildlife Biology Lab,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,shari lynn rodriguez,
-WFB,3010,2,Wildlife Biology Lab,0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,shari lynn rodriguez,
-WFB,3130,1,Conservation Biology,0.35,0.39,0.16,0.05,0.03,0.0,0.0,0.03,shari lynn rodriguez,
-WFB,3130,2,Conservation Biology,0.27,0.35,0.24,0.08,0.03,0.0,0.0,0.03,shari lynn rodriguez,
-WFB,3500,1,Princ Fish & Wildlife Biology,0.3,0.46,0.2,0.04,0.0,0.0,0.0,0.0,james davis,
-WFB,3500,2,Princ Fish & Wildlife Biology,0.18,0.5,0.25,0.05,0.0,0.0,0.0,0.02,james davis,
-WFB,4120,1,Wildlife Management,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
-WFB,4160,1,Fisheries Techniques,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,brandon kevi peoples,
-WFB,4620,1,Wetland Wildlife Biology,0.74,0.23,0.01,0.0,0.0,0.0,0.0,0.01,russell barrett,
-WFB,4930,2,Quantitative Ecology,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,david scot jachowski,
-WFB,8500,1,Wildlife & Fisheries Ecology,0.44,0.33,0.15,0.0,0.04,0.0,0.0,0.04,susan talley guynn,
-WS,1030,1,Women in Global Perspective,0.88,0.04,0.0,0.04,0.0,0.0,0.0,0.04,annie boiter-jolley,
-WS,1030,2,Women in Global Perspective,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,annie boiter-jolley,
-WS,2400,1,Women and Leadership II,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,diane perpich,
-WS,3010,1,Intro Women's Studies,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,elizabeth rose adams,
-WS,3010,2,Intro Women's Studies,0.68,0.27,0.0,0.0,0.05,0.0,0.0,0.0,elizabeth rose adams,
-YDP,3100,1,Youth Developmt and the Family,0.79,0.14,0.04,0.0,0.04,0.0,0.0,0.0,william quinn,
-YDP,3100,3,Youth Developmt and the Family,0.81,0.07,0.07,0.0,0.04,0.0,0.0,0.0,william quinn,
-YDP,3250,1,Working with Diverse Youth,0.79,0.14,0.04,0.0,0.0,0.0,0.0,0.04,kimberly pea johnson,
-YDP,4400,1,Youth Program Assessmnt & Eval,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,ann marie gillard,
-YDP,4550,1,Youth and Technology,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,david lynn pollock,
-YDP,8010,1,Child/Adolescent Dev,0.68,0.24,0.04,0.0,0.04,0.0,0.0,0.0,edmond patric bowers,
-YDP,8040,1,Assess & Eval of Youth Program,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,
-YDP,8880,1,Special Topics Youth Dev Ldshp,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,barry garst,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1020,1,Survey of Art & Arch Hist II,0.4,0.4,0.17,0.0,0.01,0.0,0.0,0.01,andrea feeser,,AAH-1020,2018
+AAH,2060,1,Art History and Theory II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,,AAH-2060,2018
+ACCT,2010,1,Financial Accounting Concepts,0.13,0.31,0.29,0.1,0.17,0.0,0.0,0.0,emily suzan mccorkle,,ACCT-2010,2018
+ACCT,2010,2,Financial Accounting Concepts,0.33,0.38,0.16,0.04,0.07,0.0,0.0,0.02,lydia lanc schleifer,,ACCT-2010,2018
+ACCT,2010,3,Financial Accounting Concepts,0.28,0.22,0.34,0.08,0.08,0.0,0.0,0.0,annieka philo,,ACCT-2010,2018
+ACCT,2010,4,Financial Accounting Concepts,0.4,0.28,0.14,0.1,0.04,0.0,0.0,0.04,emily suzan mccorkle,,ACCT-2010,2018
+ACCT,2010,5,Financial Accounting Concepts,0.41,0.31,0.18,0.02,0.04,0.0,0.0,0.04,annieka philo,,ACCT-2010,2018
+ACCT,2010,6,Financial Accounting Concepts,0.43,0.31,0.1,0.02,0.06,0.0,0.0,0.08,lydia lanc schleifer,,ACCT-2010,2018
+ACCT,2010,7,Financial Accounting Concepts,0.31,0.52,0.04,0.02,0.08,0.0,0.0,0.02,lydia lanc schleifer,,ACCT-2010,2018
+ACCT,2010,8,Financial Accounting Concepts,0.37,0.35,0.16,0.04,0.04,0.0,0.0,0.04,emily suzan mccorkle,,ACCT-2010,2018
+ACCT,2010,9,Financial Accounting Concepts,0.3,0.32,0.22,0.04,0.1,0.0,0.0,0.02,emily suzan mccorkle,,ACCT-2010,2018
+ACCT,2010,10,Financial Accounting Concepts,0.18,0.36,0.24,0.12,0.08,0.0,0.0,0.02,james barnes,,ACCT-2010,2018
+ACCT,2010,11,Financial Accounting Concepts,0.3,0.36,0.2,0.06,0.08,0.0,0.0,0.0,rebecca pennell trax,,ACCT-2010,2018
+ACCT,2010,12,Financial Accounting Concepts,0.37,0.31,0.18,0.06,0.04,0.0,0.0,0.04,rebecca pennell trax,,ACCT-2010,2018
+ACCT,2010,13,Financial Accounting Concepts,0.49,0.24,0.1,0.07,0.05,0.0,0.0,0.05,charles tegen,,ACCT-2010,2018
+ACCT,2010,14,Financial Accounting Concepts,0.29,0.29,0.32,0.03,0.06,0.0,0.0,0.0,philip maiberger,,ACCT-2010,2018
+ACCT,2010,15,Financial Accounting Concepts,0.24,0.43,0.14,0.1,0.05,0.0,0.0,0.05,lisa whea birtwistle,,ACCT-2010,2018
+ACCT,2010,16,Financial Accounting Concepts,0.12,0.38,0.22,0.08,0.16,0.0,0.0,0.04,james barnes,,ACCT-2010,2018
+ACCT,2010,101,Fin Acct Concepts (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,lisa whea birtwistle,True,ACCT-2010,2018
+ACCT,2010,401,Financial Accounting Concepts,0.31,0.48,0.1,0.08,0.01,0.0,0.0,0.02,jeffrey mcmillan,,ACCT-2010,2018
+ACCT,2020,1,Managerial Accounting Concepts,0.17,0.34,0.17,0.03,0.06,0.0,0.0,0.23,henry anderson,,ACCT-2020,2018
+ACCT,2020,2,Managerial Accounting Concepts,0.19,0.28,0.17,0.02,0.02,0.0,0.0,0.33,henry anderson,,ACCT-2020,2018
+ACCT,2020,3,Managerial Accounting Concepts,0.27,0.29,0.22,0.14,0.06,0.0,0.0,0.02,phebian davis-culler,,ACCT-2020,2018
+ACCT,2020,4,Managerial Accounting Concepts,0.42,0.33,0.19,0.04,0.02,0.0,0.0,0.0,james milt kohlmeyer,,ACCT-2020,2018
+ACCT,2020,5,Managerial Accounting Concepts,0.22,0.33,0.13,0.04,0.07,0.0,0.0,0.2,henry anderson,,ACCT-2020,2018
+ACCT,2020,6,Managerial Accounting Concepts,0.29,0.29,0.21,0.09,0.04,0.0,0.0,0.09,brian todd carver,,ACCT-2020,2018
+ACCT,2020,7,Managerial Accounting Concepts,0.15,0.31,0.27,0.0,0.17,0.0,0.0,0.1,brian todd carver,,ACCT-2020,2018
+ACCT,2020,401,Managerial Accounting Concepts,0.33,0.28,0.18,0.05,0.03,0.0,0.0,0.12,henry anderson,,ACCT-2020,2018
+ACCT,3030,1,Cost Accounting,0.3,0.36,0.23,0.11,0.0,0.0,0.0,0.0,phebian davis-culler,,ACCT-3030,2018
+ACCT,3030,2,Cost Accounting,0.36,0.27,0.27,0.04,0.04,0.0,0.0,0.02,phebian davis-culler,,ACCT-3030,2018
+ACCT,3030,3,Cost Accounting,0.2,0.32,0.32,0.07,0.0,0.0,0.0,0.1,jace garrett,,ACCT-3030,2018
+ACCT,3030,4,Cost Accounting,0.13,0.32,0.36,0.06,0.11,0.0,0.0,0.02,jace garrett,,ACCT-3030,2018
+ACCT,3110,1,Intermediate Financial Acct I,0.29,0.33,0.19,0.05,0.07,0.0,0.0,0.07,erin michell hawkins,,ACCT-3110,2018
+ACCT,3110,2,Intermediate Financial Acct I,0.18,0.5,0.23,0.05,0.05,0.0,0.0,0.0,erin michell hawkins,,ACCT-3110,2018
+ACCT,3110,3,Intermediate Financial Acct I,0.22,0.44,0.2,0.13,0.0,0.0,0.0,0.0,amy melissa donnelly,,ACCT-3110,2018
+ACCT,3110,4,Intermediate Financial Acct I,0.29,0.33,0.31,0.07,0.0,0.0,0.0,0.0,amy melissa donnelly,,ACCT-3110,2018
+ACCT,3110,401,Intermediate Financial Acct I,0.49,0.27,0.08,0.06,0.02,0.0,0.0,0.08,henry anderson,,ACCT-3110,2018
+ACCT,3120,1,Intermediate Financial Acct II,0.0,0.18,0.45,0.18,0.18,0.0,0.0,0.0,jeremy michae vinson,,ACCT-3120,2018
+ACCT,3120,2,Intermediate Financial Acct II,0.32,0.36,0.25,0.05,0.0,0.0,0.0,0.02,terry daniel knause,,ACCT-3120,2018
+ACCT,3120,3,Intermediate Financial Acct II,0.23,0.39,0.27,0.09,0.02,0.0,0.0,0.0,jeremy michae vinson,,ACCT-3120,2018
+ACCT,3120,4,Intermediate Financial Acct II,0.28,0.33,0.33,0.0,0.0,0.0,0.0,0.06,terry daniel knause,,ACCT-3120,2018
+ACCT,3120,5,Intermediate Financial Acct II,0.36,0.3,0.23,0.11,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3120,2018
+ACCT,3120,6,Intermediate Financial Acct II,0.27,0.4,0.2,0.13,0.0,0.0,0.0,0.0,terry daniel knause,,ACCT-3120,2018
+ACCT,3130,1,Intermediate Fin Acct III,0.11,0.5,0.21,0.07,0.04,0.0,0.0,0.07, russell madray,,ACCT-3130,2018
+ACCT,3130,2,Intermediate Fin Acct III,0.16,0.48,0.3,0.02,0.02,0.0,0.0,0.02, russell madray,,ACCT-3130,2018
+ACCT,3130,3,Intermediate Fin Acct III,0.3,0.49,0.16,0.05,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2018
+ACCT,3130,4,Intermediate Fin Acct III,0.36,0.44,0.15,0.05,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2018
+ACCT,3220,1,Accounting Information Systems,0.17,0.5,0.17,0.03,0.03,0.0,0.0,0.11,philip maiberger,,ACCT-3220,2018
+ACCT,3220,2,Accounting Information Systems,0.25,0.47,0.22,0.06,0.0,0.0,0.0,0.0,philip maiberger,,ACCT-3220,2018
+ACCT,3220,3,Accounting Information Systems,0.06,0.23,0.48,0.06,0.03,0.0,0.0,0.13,philip maiberger,,ACCT-3220,2018
+ACCT,4040,1,Individual Taxation,0.74,0.17,0.06,0.03,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2018
+ACCT,4040,2,Individual Taxation,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2018
+ACCT,4040,3,Individual Taxation,0.58,0.3,0.0,0.1,0.03,0.0,0.0,0.0,lisa whea birtwistle,,ACCT-4040,2018
+ACCT,4040,4,Individual Taxation,0.24,0.38,0.19,0.08,0.08,0.0,0.0,0.03,lisa whea birtwistle,,ACCT-4040,2018
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.28,0.38,0.33,0.0,0.0,0.0,0.0,0.0,robin radtke,,ACCT-4100,2018
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.3,0.53,0.15,0.0,0.0,0.0,0.0,0.03,robin radtke,,ACCT-4100,2018
+ACCT,4150,1,Auditing,0.15,0.49,0.28,0.05,0.03,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2018
+ACCT,4150,2,Auditing,0.17,0.33,0.19,0.17,0.03,0.0,0.0,0.11,carl hollingsworth,,ACCT-4150,2018
+ACCT,8520,1,Fin Acct Theory/Res,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,ralph edward welton,,ACCT-8520,2018
+ACCT,8520,2,Fin Acct Theory/Res,0.28,0.59,0.13,0.0,0.0,0.0,0.0,0.0,ralph edward welton,,ACCT-8520,2018
+ACCT,8540,1,Prof Responsibility,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2018
+ACCT,8540,2,Prof Responsibility,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2018
+ACCT,8540,3,Prof Responsibility,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8540,2018
+ACCT,8620,1,Financial Auditing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-8620,2018
+ACCT,8620,2,Financial Auditing,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-8620,2018
+ACCT,8710,1,Corporate Taxation,0.31,0.64,0.06,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2018
+ACCT,8710,2,Corporate Taxation,0.15,0.8,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2018
+ACCT,8710,3,Corporate Taxation,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2018
+ACCT,8730,1,Intl/Spec Tax Topic,0.43,0.47,0.11,0.0,0.0,0.0,0.0,0.0,kathr kisska-schulze,,ACCT-8730,2018
+ACCT,8740,1,Tax Aspects of Finan Planning,0.42,0.53,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,,ACCT-8740,2018
+AFLS,2000,1,Agric For Domestic Study Tour,0.0,0.0,0.0,0.0,0.0,0.9,0.05,0.05,jean bertrand,,AFLS-2000,2018
+AGED,1000,1,Orientation & Field Experience,0.74,0.05,0.0,0.0,0.11,0.0,0.0,0.11,philip fravel,,AGED-1000,2018
+AGED,2030,1,Teaching Agriscience,0.33,0.56,0.06,0.0,0.06,0.0,0.0,0.0,catherin dibenedetto,,AGED-2030,2018
+AGED,4150,1,Leadership of Vol,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,kevin layfield,,AGED-4150,2018
+AGED,4160,1,Ethics and Issues,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,,AGED-4160,2018
+AGED,4250,1,Teaching Ag Mechs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-4250,2018
+AGM,2050,1,Prin of Fabrication,0.32,0.53,0.09,0.04,0.0,0.0,0.0,0.02,hunter massey,,AGM-2050,2018
+AGM,2060,1,Machinery Mgt,0.34,0.44,0.16,0.03,0.0,0.0,0.0,0.03,hunter massey,,AGM-2060,2018
+AGM,2200,1,Calc for Mechanized Agricult,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,young han,,AGM-2200,2018
+AGM,2210,1,Land Measurements,0.46,0.27,0.23,0.02,0.02,0.0,0.0,0.0,charles privette,,AGM-2210,2018
+AGM,4020,1,Irrigation System Design,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,charles privette,,AGM-4020,2018
+AGM,4100,1,Precision Ag Tech,0.46,0.38,0.14,0.02,0.0,0.0,0.0,0.0,hunter massey,,AGM-4100,2018
+AGM,4520,1,Mobile Power,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4520,2018
+AGM,4720,1,Capstone,0.74,0.24,0.02,0.0,0.0,0.0,0.0,0.0,john chastain,,AGM-4720,2018
+AGRB,2020,1,Agricultural Economics,0.39,0.24,0.19,0.12,0.03,0.0,0.0,0.03,george apperson,,AGRB-2020,2018
+AGRB,2050,1,Agriculture and Society,0.26,0.53,0.18,0.04,0.0,0.0,0.0,0.0,george apperson,,AGRB-2050,2018
+AGRB,3080,1,Quant Agribusiness Analysis I,0.15,0.19,0.38,0.22,0.05,0.0,0.0,0.01,lisha zhang,,AGRB-3080,2018
+AGRB,3190,1,Agribusiness Management,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,yuliya vale bolotova,,AGRB-3190,2018
+AGRB,3510,1,Principles of Ag Sales and Ad,0.03,0.65,0.29,0.03,0.0,0.0,0.0,0.0,george apperson,,AGRB-3510,2018
+AGRB,3570,1,Natural Resources Economics,0.16,0.35,0.24,0.18,0.0,0.0,0.0,0.06,david brian willis,,AGRB-3570,2018
+AGRB,4020,1,Production Economics,0.28,0.37,0.28,0.05,0.0,0.0,0.0,0.02,michael vassalos,,AGRB-4020,2018
+AGRB,4080,1,Quant Agribusiness Analysis II,0.32,0.35,0.26,0.06,0.0,0.0,0.0,0.0,lisha zhang,,AGRB-4080,2018
+AGRB,4520,1,Agricultural Policy,0.14,0.48,0.24,0.12,0.0,0.0,0.0,0.02,michael vassalos,,AGRB-4520,2018
+AGRB,4560,1,Prices,0.23,0.33,0.26,0.19,0.0,0.0,0.0,0.0,yuliya vale bolotova,,AGRB-4560,2018
+AL,3490,400,Principles of Coaching,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,,AL-3490,2018
+AL,3490,402,Principles of Coaching,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,julia wright,,AL-3490,2018
+AL,3490,403,Principles of Coaching,0.72,0.12,0.08,0.0,0.04,0.0,0.0,0.04,clyde keith connor,,AL-3490,2018
+AL,3490,406,Principles of Coaching,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john plumblee,,AL-3490,2018
+AL,3490,407,Principles of Coaching,0.68,0.12,0.12,0.04,0.0,0.0,0.0,0.04,john plumblee,,AL-3490,2018
+AL,3490,408,Principles of Coaching,0.76,0.16,0.0,0.0,0.08,0.0,0.0,0.0,deborah jo cadorette,,AL-3490,2018
+AL,3500,400,Sci Basis I/Ex Phy,0.23,0.15,0.38,0.15,0.0,0.0,0.0,0.08,michael godfrey,,AL-3500,2018
+AL,3500,401,Sci Basis I/Ex Phy,0.17,0.38,0.33,0.08,0.04,0.0,0.0,0.0,michael godfrey,,AL-3500,2018
+AL,3520,400,Kinesiology,0.2,0.4,0.2,0.0,0.0,0.0,0.0,0.2,isaac sean colbert,,AL-3520,2018
+AL,3530,400,Athletic Injuries,0.2,0.32,0.16,0.28,0.04,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2018
+AL,3530,401,Athletic Injuries,0.13,0.57,0.13,0.17,0.0,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2018
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.58,0.04,0.0,0.04,0.0,0.0,0.0,clyde keith connor,,AL-3600,2018
+AL,3610,400,Admin/Org of Athletic Programs,0.72,0.16,0.04,0.04,0.0,0.0,0.0,0.04,henry oates,,AL-3610,2018
+AL,3610,401,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2018
+AL,3610,402,Admin/Org of Athletic Programs,0.88,0.0,0.08,0.04,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2018
+AL,3620,400,Psychology of Coaching,0.5,0.23,0.12,0.04,0.12,0.0,0.0,0.0,natalie anne carter,,AL-3620,2018
+AL,3620,401,Psychology of Coaching,0.44,0.32,0.16,0.04,0.04,0.0,0.0,0.0,natalie anne carter,,AL-3620,2018
+AL,3620,402,Psychology of Coaching,0.46,0.35,0.08,0.08,0.04,0.0,0.0,0.0,natalie anne carter,,AL-3620,2018
+AL,3720,400,Coaching Basketball,0.76,0.2,0.0,0.0,0.0,0.0,0.0,0.04,edmond fry,,AL-3720,2018
+AL,3740,400,Coaching Football,0.76,0.12,0.08,0.04,0.0,0.0,0.0,0.0,edmond fry,,AL-3740,2018
+AL,3760,400,Coaching Strength/Conditioning,0.8,0.12,0.04,0.0,0.0,0.0,0.0,0.04,edmond fry,,AL-3760,2018
+AL,3760,401,Coaching Strength/Conditioning,0.72,0.08,0.04,0.08,0.04,0.0,0.0,0.04,edmond fry,,AL-3760,2018
+AL,4000,400,Athletic Leadership Internship,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,deborah jo cadorette,,AL-4000,2018
+AL,4380,402,Officiating in Athletic Leader,0.68,0.16,0.12,0.04,0.0,0.0,0.0,0.0,clyde keith connor,,AL-4380,2018
+AL,4380,403,Belief Systems in AL,0.59,0.22,0.15,0.04,0.0,0.0,0.0,0.0,deborah jo cadorette,,AL-4380,2018
+AL,4380,404,Belief Systems in AL,0.71,0.13,0.04,0.13,0.0,0.0,0.0,0.0,deborah jo cadorette,,AL-4380,2018
+AL,8530,400,Legal Iss in Intercoll Athlet,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,,AL-8530,2018
+AL,8530,401,Legal Iss in Intercoll Athlet,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-8530,2018
+AL,8630,400,Socio Dynam in Intercol Athlet,0.38,0.48,0.05,0.0,0.05,0.0,0.0,0.05,michael godfrey,,AL-8630,2018
+AL,8630,401,Socio Dynam in Intercol Athlet,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8630,2018
+AL,8640,400,Ethical Iss in Collegiate Athl,0.64,0.23,0.09,0.0,0.05,0.0,0.0,0.0,michael godfrey,,AL-8640,2018
+AL,8640,401,Ethical Iss in Collegiate Athl,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8640,2018
+AL,8700,400,Intercoll Athletics Finance,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-8700,2018
+ANTH,2010,1,Introduction to Anthropology,0.23,0.48,0.26,0.03,0.0,0.0,0.0,0.0,david markus,,ANTH-2010,2018
+ANTH,2010,2,Introduction to Anthropology,0.35,0.46,0.11,0.07,0.0,0.0,0.0,0.02,yi wu,,ANTH-2010,2018
+ANTH,2010,3,Introduction to Anthropology,0.05,0.26,0.35,0.15,0.11,0.0,0.0,0.09,john coggeshall,,ANTH-2010,2018
+ANTH,2010,4,Introduction to Anthropology,0.43,0.46,0.09,0.0,0.02,0.0,0.0,0.0,david markus,,ANTH-2010,2018
+ANTH,2050,1,Professional Development,0.79,0.05,0.05,0.05,0.05,0.0,0.0,0.0,melissa vogel,,ANTH-2050,2018
+ANTH,3200,1,North American Indian Cultures,0.21,0.42,0.17,0.17,0.04,0.0,0.0,0.0,john coggeshall,,ANTH-3200,2018
+ANTH,3310,1,Archaeology,0.2,0.4,0.3,0.05,0.0,0.0,0.0,0.05,david markus,,ANTH-3310,2018
+ANTH,3510,1,Biological Anthropology,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,lisa rapaport,,ANTH-3510,2018
+ANTH,4040,1,Anthropological Theories,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,john coggeshall,,ANTH-4040,2018
+ANTH,4990,1,Special Topics: Business Anth,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,melissa vogel,,ANTH-4990,2018
+APEC,8220,1,Public Policy Econ,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david brian willis,,APEC-8220,2018
+ARCH,1510,1,Arch Communication,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,sall hambright-belue,,ARCH-1510,2018
+ARCH,1510,2,Arch Communication,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-1510,2018
+ARCH,1510,3,Arch Communication,0.36,0.43,0.07,0.07,0.0,0.0,0.0,0.07,clarissa mendez,,ARCH-1510,2018
+ARCH,1510,4,Arch Communication,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-1510,2018
+ARCH,1510,5,Arch Communication,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,jared jeffrey moore,,ARCH-1510,2018
+ARCH,1510,6,Arch Communication,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,herminia silv machry,,ARCH-1510,2018
+ARCH,2520,1,Arch Foundations II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,timothy sutherland,,ARCH-2520,2018
+ARCH,2520,2,Arch Foundations II,0.43,0.36,0.14,0.0,0.0,0.0,0.0,0.07,clarissa mendez,,ARCH-2520,2018
+ARCH,2520,3,Arch Foundations II,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,criss mills,,ARCH-2520,2018
+ARCH,2520,4,Arch Foundations II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-2520,2018
+ARCH,2520,5,Arch Foundations II,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-2520,2018
+ARCH,2520,6,Arch Foundations II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,catherine parn smith,,ARCH-2520,2018
+ARCH,2710,1,Structures II,0.51,0.34,0.09,0.0,0.03,0.0,0.0,0.03,mahmoodreza soltani,,ARCH-2710,2018
+ARCH,3530,1,Studio Genoa,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-3530,2018
+ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-3540,2018
+ARCH,4050,1,American Arch Styles 1650-1950,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-4050,2018
+ARCH,4140,1,Design Seminar,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-4140,2018
+ARCH,4160,1,Field Studies,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-4160,2018
+ARCH,4520,1,Synthesis Studio,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-4520,2018
+ARCH,4520,2,Synthesis Studio,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-4520,2018
+ARCH,4520,3,Synthesis Studio,0.07,0.73,0.2,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4520,2018
+ARCH,4520,4,Synthesis Studio,0.5,0.36,0.07,0.07,0.0,0.0,0.0,0.0,joseph schott,,ARCH-4520,2018
+ARCH,4890,1,Internship,0.4,0.2,0.3,0.0,0.0,0.0,0.0,0.1,ashley jennings,,ARCH-4890,2018
+ARCH,4990,1,Immersive Virtual Environments,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,david lee,,ARCH-4990,2018
+ARCH,8110,1,Visualization II,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,douglas hecker,,ARCH-8110,2018
+ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-8120,2018
+ARCH,8420,1,Arch Studio II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,,ARCH-8420,2018
+ARCH,8610,1,History/Theory II,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8610,2018
+ARCH,8620,1,History/Theory III,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,,ARCH-8620,2018
+ARCH,8650,1,Topics in Health Policy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anjali joseph,,ARCH-8650,2018
+ARCH,8710,1,Structures II,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,dustin grah albright,,ARCH-8710,2018
+ARCH,8730,2,Environmental Sys,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,,ARCH-8730,2018
+ARCH,8740,1,Building Process:TR,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,,ARCH-8740,2018
+ARCH,8900,1,Directed Studies,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,sara bayramzadeh,,ARCH-8900,2018
+ARCH,8920,1,Comprehensive Studio,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8920,2018
+ARCH,8920,2,Comprehensive Studio,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dustin grah albright,,ARCH-8920,2018
+ARCH,8920,3,Comprehensive Studio,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-sop heine,,ARCH-8920,2018
+ARCH,8920,4,Comprehensive Studio,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8920,2018
+ARCH,8960,1,A+H Studio: Tectonic,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,,ARCH-8960,2018
+ART,1060,1,Foundation Drawing II,0.52,0.38,0.05,0.0,0.0,0.0,0.0,0.05,carly drew,,ART-1060,2018
+ART,1510,1,Foundations Art I,0.62,0.31,0.0,0.08,0.0,0.0,0.0,0.0,daniel bare,,ART-1510,2018
+ART,1520,1,Foundations Art II,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,kooi susan el vander el,,ART-1520,2018
+ART,2050,1,Beginning Life Drawing,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,,ART-2050,2018
+ART,2070,1,Beginning Painting,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,dustin lee massey,,ART-2070,2018
+ART,2100,400,Art Appreciation,0.76,0.14,0.0,0.0,0.0,0.0,0.0,0.1,lydia jane dorsey,,ART-2100,2018
+ART,2100,401,Art Appreciation,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,lydia jane dorsey,,ART-2100,2018
+ART,2100,402,Art Appreciation,0.68,0.14,0.14,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,,ART-2100,2018
+ART,2100,403,Art Appreciation,0.54,0.21,0.11,0.04,0.0,0.0,0.0,0.11,lydia jane dorsey,,ART-2100,2018
+ART,2110,1,Begin Printmaking,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,mandy lorai ferguson,,ART-2110,2018
+ART,2130,1,Begin Photography,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,amanda denise musick,,ART-2130,2018
+ART,2170,1,Beginning Ceramics,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,daniel bare,,ART-2170,2018
+ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,,ART-3570,2018
+AS,1100,1,Air Force Today II,0.29,0.59,0.0,0.06,0.06,0.0,0.0,0.0,michael allen moore,,AS-1100,2018
+AS,1100,2,Air Force Today II,0.33,0.5,0.06,0.06,0.0,0.0,0.0,0.06,michael allen moore,,AS-1100,2018
+AS,1100,3,Air Force Today II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1100,2018
+AS,2100,1,Dev of Air Power II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2100,2018
+AS,2100,2,Dev of Air Power II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2100,2018
+AS,2100,3,Dev of Air Power II,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2100,2018
+AS,3100,2,Af Ldrshp & Mgt II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mari miller,,AS-3100,2018
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4100,2018
+AS,4100,2,Nat Sec Policy II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4100,2018
+ASL,1010,1,Am Sign Lang I,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,jason hurdich,,ASL-1010,2018
+ASL,1010,2,Am Sign Lang I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william rya clements,,ASL-1010,2018
+ASL,1010,3,Am Sign Lang I,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,william rya clements,,ASL-1010,2018
+ASL,1020,1,Am Sign Lang I,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,dunn kim mar misener mar,,ASL-1020,2018
+ASL,1020,2,Am Sign Lang I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,william rya clements,,ASL-1020,2018
+ASL,1020,3,Am Sign Lang I,0.4,0.5,0.05,0.0,0.05,0.0,0.0,0.0,jason hurdich,,ASL-1020,2018
+ASL,1020,4,Am Sign Lang I,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-1020,2018
+ASL,2020,1,Am Sign Lang II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,,ASL-2020,2018
+ASL,2020,2,Am Sign Lang II,0.7,0.1,0.15,0.0,0.05,0.0,0.0,0.0,dunn kim mar misener mar,,ASL-2020,2018
+ASL,2020,3,Am Sign Lang II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,,ASL-2020,2018
+ASL,2020,4,Am Sign Lang II,0.52,0.19,0.29,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-2020,2018
+ASTR,1010,1,Solar System Astronomy,0.39,0.36,0.18,0.01,0.02,0.0,0.0,0.04,amber porter,,ASTR-1010,2018
+ASTR,1020,1,Stellar Astronomy,0.29,0.38,0.26,0.0,0.02,0.0,0.0,0.05,amber porter,,ASTR-1020,2018
+ASTR,1020,2,Stellar Astronomy,0.3,0.39,0.19,0.09,0.02,0.0,0.0,0.02,marco ajello,,ASTR-1020,2018
+ASTR,1030,1,Solar Systm Astr Lab,0.29,0.38,0.13,0.0,0.13,0.0,0.0,0.08,amber porter,,ASTR-1030,2018
+ASTR,1030,2,Solar Systm Astr Lab,0.4,0.44,0.08,0.04,0.04,0.0,0.0,0.0,amber porter,,ASTR-1030,2018
+ASTR,1030,3,Solar Systm Astr Lab,0.24,0.44,0.16,0.0,0.08,0.0,0.0,0.08,amber porter,,ASTR-1030,2018
+ASTR,1040,1,Stellar Astr Lab,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,amber porter,,ASTR-1040,2018
+ASTR,1040,3,Stellar Astr Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,amber porter,,ASTR-1040,2018
+ASTR,1040,4,Stellar Astr Lab,0.56,0.31,0.06,0.0,0.06,0.0,0.0,0.0,amber porter,,ASTR-1040,2018
+ASTR,2200,1,Planetary Science,0.44,0.38,0.06,0.06,0.0,0.0,0.0,0.06,mate adamkovics,,ASTR-2200,2018
+ASTR,8200,1,Astroph II: Stars,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,,ASTR-8200,2018
+AUD,2850,1,Acoustics of Music,0.18,0.36,0.36,0.09,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-2850,2018
+AUD,3860,1,Electronic Comp,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,hamilton altstatt,,AUD-3860,2018
+AUE,4020,699,Automobile Powertrain Systems,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-4020,2018
+AUE,8160,3,Eng Combustion Emiss,0.62,0.28,0.1,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8160,2018
+AUE,8170,3,Alt Energy Sources,0.21,0.69,0.1,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8170,2018
+AUE,8500,6,Stability/Safety Sys,0.32,0.65,0.03,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8500,2018
+AUE,8550,16,Struct/Thermal Analysis Mthds,0.17,0.78,0.06,0.0,0.0,0.0,0.0,0.0,david will schmueser,,AUE-8550,2018
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.41,0.44,0.16,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8690,2018
+AUE,8820,10,Systems Integration Con & Meth,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8820,2018
+AUE,8860,1,Noise Vibration,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,,AUE-8860,2018
+AUE,8930,3,Applied Dynamics,0.14,0.5,0.29,0.0,0.07,0.0,0.0,0.0,imtiaz ul haque,,AUE-8930,2018
+AUE,8930,401,Autonomous Driving Techn,0.72,0.2,0.02,0.0,0.0,0.0,0.0,0.07,yunyi jia,,AUE-8930,2018
+AUE,8930,699,Autovation 1,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,,AUE-8930,2018
+AVS,2000,1,Beef Cattle Tech,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,nathan long,,AVS-2000,2018
+AVS,2060,1,Swine Techniques,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,,AVS-2060,2018
+AVS,2080,1,Teaching Horsemanshp,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,,AVS-2080,2018
+AVS,3010,1,Anat & Phys Dom Ani,0.56,0.23,0.09,0.02,0.1,0.0,0.0,0.0,tiffany wilmoth,,AVS-3010,2018
+AVS,3100,1,Animal Health,0.46,0.35,0.11,0.05,0.0,0.0,0.0,0.03,celina marce checura,,AVS-3100,2018
+AVS,3150,1,Animal Welfare,0.48,0.32,0.04,0.08,0.08,0.0,0.0,0.0,peter skewes,,AVS-3150,2018
+AVS,3700,1,Principles of Animal Nutrition,0.49,0.26,0.16,0.09,0.0,0.0,0.0,0.0,james rob strickland,,AVS-3700,2018
+AVS,4000,1,AVS Professional Development,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,marie owens bolt,,AVS-4000,2018
+AVS,4010,1,Beef Production,0.36,0.32,0.2,0.08,0.0,0.0,0.0,0.04,nathan long,,AVS-4010,2018
+AVS,4060,2,Seminars & Related Topics,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-4060,2018
+AVS,4090,400,Animals & Humans In Society,0.77,0.2,0.0,0.03,0.0,0.0,0.0,0.0,marie owens bolt,,AVS-4090,2018
+AVS,4100,1,Domestic Ani Behav,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,peter skewes,,AVS-4100,2018
+AVS,4120,1,Advanced Equine Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kristine lang vernon,,AVS-4120,2018
+AVS,4130,1,Animal Products,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,,AVS-4130,2018
+AVS,4140,1,Basic Immunology,0.28,0.38,0.25,0.05,0.0,0.0,0.0,0.05,thomas scott,,AVS-4140,2018
+AVS,4140,2,Basic Immunology,0.52,0.16,0.12,0.04,0.0,0.0,0.0,0.16,farzana ferdous,,AVS-4140,2018
+AVS,4530,1,Animal Reproduction,0.4,0.3,0.15,0.11,0.0,0.0,0.0,0.04,celina marce checura,,AVS-4530,2018
+AVS,4530,400,Animal Reproduction,0.09,0.27,0.55,0.09,0.0,0.0,0.0,0.0,celina marce checura,,AVS-4530,2018
+AVS,4550,2,Animal Repro Mgt-Equine,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,,AVS-4550,2018
+AVS,4700,1,Animal Genetics,0.26,0.15,0.17,0.22,0.07,0.0,0.0,0.13,joseph keit bertrand,,AVS-4700,2018
+AVS,8090,1,Ruminant Nutrition,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,gustavo jose lascano,,AVS-8090,2018
+BCHM,3010,1,Molecular Biochem,0.1,0.34,0.35,0.09,0.01,0.0,0.0,0.11,meredith teil morris,,BCHM-3010,2018
+BCHM,3010,2,Molecular Biochem(HON),0.43,0.23,0.2,0.08,0.05,0.0,0.0,0.03,cheryl ingram-smith,True,BCHM-3010,2018
+BCHM,3040,1,Molecular Biology Laboratory,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,geoffrey ford,,BCHM-3040,2018
+BCHM,3040,2,Molecular Biology Laboratory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2018
+BCHM,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2018
+BCHM,3040,4,Molecular Biology Laboratory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2018
+BCHM,3050,1,Essen Elements Bioch,0.06,0.41,0.32,0.05,0.0,0.0,0.0,0.16,debra ragland,,BCHM-3050,2018
+BCHM,3050,2,Essen Elements Bioch,0.17,0.38,0.28,0.07,0.0,0.0,0.0,0.1,debra ragland,,BCHM-3050,2018
+BCHM,3050,3,Essen Elements Bioch,0.24,0.41,0.23,0.08,0.04,0.0,0.0,0.0,geoffrey ford,,BCHM-3050,2018
+BCHM,4320,1,Bioch of Metabolism,0.55,0.41,0.02,0.0,0.0,0.0,0.0,0.02,kimberly paul,,BCHM-4320,2018
+BCHM,4340,1,Biochemistry of Metabolism Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,geoffrey ford,,BCHM-4340,2018
+BCHM,4340,2,Biochemistry of Metabolism Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-4340,2018
+BCHM,4360,1,Genes to Proteins,0.34,0.64,0.02,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,,BCHM-4360,2018
+BCHM,4400,1,Bioinformatics,0.22,0.28,0.28,0.11,0.0,0.0,0.0,0.11,liangjiang wang,,BCHM-4400,2018
+BCHM,4930,1,Senior Seminar,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james morris,,BCHM-4930,2018
+BCHM,8100,1,Princ of Molecular Biology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jennifer may mason,,BCHM-8100,2018
+BE,2100,1,Intro to Biosystems Engr,0.57,0.32,0.0,0.04,0.0,0.0,0.0,0.07,yi zheng,,BE-2100,2018
+BE,3100,1,Biosystems Engr Thermodynamics,0.25,0.5,0.2,0.0,0.0,0.0,0.0,0.05,terry walker,,BE-3100,2018
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.19,0.76,0.05,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-3220,2018
+BE,4120,1,Be Heat Mass Trans,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4120,2018
+BE,4150,1,Instr & Control for Biosys Eng,0.19,0.57,0.24,0.0,0.0,0.0,0.0,0.0,yi zheng,,BE-4150,2018
+BE,4240,1,Ecological Engineering,0.66,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christophe darnault,,BE-4240,2018
+BE,4380,1,Bioprocess Engineering Design,0.09,0.55,0.36,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4380,2018
+BIOE,1010,1,Biol for Bioengr,0.35,0.45,0.09,0.0,0.0,0.0,0.0,0.11,vladimir vlad reukov,,BIOE-1010,2018
+BIOE,2000,1,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,martine laberge,,BIOE-2000,2018
+BIOE,2010,1,Intro Biomed Engr,0.32,0.36,0.24,0.04,0.0,0.0,0.0,0.04,vladimir vlad reukov,,BIOE-2010,2018
+BIOE,3020,1,Biomaterials,0.6,0.32,0.04,0.01,0.01,0.0,0.0,0.01,alexey alex vertegel,,BIOE-3020,2018
+BIOE,3100,1,Engr Analysis of Physiol Proc,0.67,0.26,0.03,0.0,0.03,0.0,0.0,0.03,brian william booth,,BIOE-3100,2018
+BIOE,3200,1,Biomechanics,0.73,0.23,0.02,0.0,0.02,0.0,0.0,0.0,jiro nagatomi,,BIOE-3200,2018
+BIOE,3210,1,Biofluid Mechanics,0.33,0.37,0.27,0.01,0.01,0.0,0.0,0.0,sarah harcum,,BIOE-3210,2018
+BIOE,3470,1,Transport Processes in Bioengr,0.39,0.43,0.13,0.0,0.0,0.0,0.0,0.04,robert latour,,BIOE-3470,2018
+BIOE,3700,1,Bioinst & Imaging,0.45,0.52,0.02,0.0,0.0,0.0,0.0,0.02,jordon antho gilmore,,BIOE-3700,2018
+BIOE,4200,1,Sports Engineering,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,cynthia miller smith,,BIOE-4200,2018
+BIOE,4350,1,Modeling of Multiphysics Prob,0.38,0.38,0.08,0.0,0.08,0.0,0.0,0.08,william richardson,,BIOE-4350,2018
+BIOE,4490,1,Drug Delivery,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,,BIOE-4490,2018
+BIOE,4510,39,CI-Inorganic Biomaterials,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vladimir vlad reukov,,BIOE-4510,2018
+BIOE,6200,1,Sports Engineering,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,cynthia miller smith,,BIOE-6200,2018
+BIOE,6350,1,Modeling of Multiphysics Prob,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,,BIOE-6350,2018
+BIOE,8030,1,Polymeric Biomatls,0.22,0.44,0.0,0.0,0.0,0.0,0.0,0.33,narendra vyavahare,,BIOE-8030,2018
+BIOL,1040,1,General Biology II,0.19,0.3,0.23,0.09,0.08,0.0,0.0,0.11,nora espinoza,,BIOL-1040,2018
+BIOL,1040,2,General Biology II,0.53,0.31,0.1,0.04,0.01,0.0,0.0,0.01,william surver,,BIOL-1040,2018
+BIOL,1040,3,General Biology II,0.14,0.24,0.39,0.15,0.05,0.0,0.0,0.02,salvatore sparace,,BIOL-1040,2018
+BIOL,1040,4,General Biology II (HON),0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True,BIOL-1040,2018
+BIOL,1060,1,Gen Biology Lab II,0.42,0.38,0.13,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,2,Gen Biology Lab II,0.48,0.22,0.13,0.13,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,3,Gen Biology Lab II,0.42,0.17,0.33,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,4,Gen Biology Lab II,0.18,0.14,0.27,0.18,0.09,0.0,0.0,0.14,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,5,Gen Biology Lab II,0.21,0.07,0.14,0.29,0.29,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,6,Gen Biology Lab II,0.29,0.29,0.29,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,7,Gen Biology Lab II,0.19,0.31,0.25,0.13,0.06,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,8,Gen Biology Lab II,0.54,0.25,0.13,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,9,Gen Biology Lab II,0.52,0.22,0.09,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,10,Gen Biology Lab II,0.48,0.22,0.22,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,11,Gen Biology Lab II,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,12,Gen Biology Lab II,0.5,0.25,0.21,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,13,Gen Biology Lab II,0.54,0.13,0.21,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,14,Gen Biology Lab II,0.5,0.18,0.23,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,15,Gen Biology Lab II,0.17,0.43,0.17,0.13,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,16,Gen Biology Lab II,0.41,0.18,0.27,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,18,Gen Biology Lab II,0.21,0.36,0.29,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,19,Gen Biology Lab II,0.08,0.38,0.31,0.23,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,20,Gen Biology Lab II,0.38,0.29,0.25,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,21,Gen Biology Lab II,0.29,0.38,0.25,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,22,Gen Biology Lab II,0.53,0.2,0.13,0.0,0.07,0.0,0.0,0.07,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,24,Gen Biology Lab II,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,26,Gen Biology Lab II,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,27,Gen Biology Lab II,0.5,0.25,0.04,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,29,Gen Biology Lab II,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,30,Gen Biology Lab II,0.59,0.23,0.09,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,31,Gen Biology Lab II,0.36,0.36,0.07,0.14,0.0,0.0,0.0,0.07,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,32,Gen Biology Lab II,0.55,0.15,0.1,0.15,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,33,Gen Biology Lab II,0.57,0.21,0.14,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,35,Gen Biology Lab II,0.38,0.31,0.25,0.06,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1060,36,Gen Biology Lab II,0.4,0.2,0.2,0.2,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2018
+BIOL,1110,1,Principles of Biology II,0.21,0.43,0.16,0.08,0.05,0.0,0.0,0.07,dylan dittrich-reed,,BIOL-1110,2018
+BIOL,1110,3,Principles of Biology II,0.36,0.47,0.11,0.02,0.01,0.0,0.0,0.02,robert kosinski,,BIOL-1110,2018
+BIOL,1110,4,Prin of Biol II  (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert kosinski,True,BIOL-1110,2018
+BIOL,1200,1,Biological Inq Lab,0.25,0.45,0.15,0.05,0.0,0.0,0.0,0.1, christine minor m,,BIOL-1200,2018
+BIOL,1200,2,Biological Inq Lab,0.3,0.45,0.15,0.1,0.0,0.0,0.0,0.0, christine minor m,,BIOL-1200,2018
+BIOL,1200,3,Biological Inq Lab,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05, christine minor m,,BIOL-1200,2018
+BIOL,1200,4,Biological Inq Lab,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,,BIOL-1200,2018
+BIOL,1200,5,Biological Inq Lab,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05, christine minor m,,BIOL-1200,2018
+BIOL,1200,6,Biological Inq Lab,0.55,0.2,0.2,0.0,0.05,0.0,0.0,0.0, christine minor m,,BIOL-1200,2018
+BIOL,1230,1,Keys to Human Biol,0.16,0.38,0.25,0.12,0.04,0.0,0.0,0.04, christine minor m,,BIOL-1230,2018
+BIOL,2000,1,Biology in the News,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,,BIOL-2000,2018
+BIOL,2040,1,"Environ, Energy and Society",0.36,0.34,0.13,0.06,0.02,0.0,0.0,0.09,john jenkins hains,,BIOL-2040,2018
+BIOL,2040,2,"Environ, Energy and Society",0.47,0.31,0.08,0.1,0.0,0.0,0.0,0.04,john jenkins hains,,BIOL-2040,2018
+BIOL,2230,1,Human Anat and Physiology II,0.42,0.37,0.13,0.04,0.03,0.0,0.0,0.01,john cummings,,BIOL-2230,2018
+BIOL,2230,2,Human Anat and Physiology II,0.36,0.38,0.19,0.05,0.0,0.0,0.0,0.02,john cummings,,BIOL-2230,2018
+BIOL,3020,1,Invertebrate Biology,0.31,0.33,0.18,0.03,0.05,0.0,0.0,0.1,migueles juan baeza,,BIOL-3020,2018
+BIOL,3040,1,Biology of Plants,0.15,0.33,0.28,0.15,0.05,0.0,0.0,0.03,robert edwar ballard,,BIOL-3040,2018
+BIOL,3060,1,Invertebrate Biology Lab,0.39,0.35,0.13,0.0,0.0,0.0,0.0,0.13,migueles juan baeza,,BIOL-3060,2018
+BIOL,3060,3,Invertebrate Biology Lab,0.47,0.41,0.06,0.0,0.06,0.0,0.0,0.0,migueles juan baeza,,BIOL-3060,2018
+BIOL,3080,2,Biology of Plants Practicum,0.4,0.3,0.2,0.05,0.0,0.0,0.0,0.05,nathan redding,,BIOL-3080,2018
+BIOL,3080,3,Biology of Plants Practicum,0.44,0.39,0.06,0.11,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2018
+BIOL,3160,1,Human Physiology,0.3,0.43,0.22,0.04,0.0,0.0,0.0,0.0,tamara mcnutt-scott,,BIOL-3160,2018
+BIOL,3350,1,Evolutionary Biology,0.44,0.39,0.13,0.03,0.0,0.0,0.0,0.01,margaret ptacek,,BIOL-3350,2018
+BIOL,3510,1,Biological Anthropology,0.58,0.25,0.08,0.04,0.04,0.0,0.0,0.0,lisa rapaport,,BIOL-3510,2018
+BIOL,4010,1,Plant Physiology,0.2,0.22,0.22,0.25,0.03,0.0,0.0,0.07,douglas bielenberg,,BIOL-4010,2018
+BIOL,4020,1,Plant Physiology Lab,0.24,0.59,0.12,0.0,0.0,0.0,0.0,0.06,douglas bielenberg,,BIOL-4020,2018
+BIOL,4020,2,Plant Physiology Lab,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,,BIOL-4020,2018
+BIOL,4100,1,Limnology,0.18,0.45,0.27,0.0,0.0,0.0,0.0,0.11,john jenkins hains,,BIOL-4100,2018
+BIOL,4140,1,Basic Immunology,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,charles rice,,BIOL-4140,2018
+BIOL,4340,1,Biological Chem Lab Techniques,0.21,0.21,0.21,0.29,0.0,0.0,0.0,0.07,salvatore sparace,,BIOL-4340,2018
+BIOL,4340,2,Biological Chem Lab Techniques,0.19,0.31,0.25,0.19,0.06,0.0,0.0,0.0,salvatore sparace,,BIOL-4340,2018
+BIOL,4400,1,Developmental Animal Biology,0.42,0.28,0.23,0.07,0.0,0.0,0.0,0.0,kara elizabet powder,,BIOL-4400,2018
+BIOL,4480,1,Marine Ecology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,,BIOL-4480,2018
+BIOL,4510,1,Biol Variation in Human Pop,0.4,0.2,0.1,0.1,0.1,0.0,0.0,0.1,elizabeth wakefield,,BIOL-4510,2018
+BIOL,4610,3,Cell Biology,0.2,0.32,0.25,0.15,0.04,0.0,0.0,0.03,lisa bain,,BIOL-4610,2018
+BIOL,4610,4,Cell Biology (HON),0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,lisa bain,True,BIOL-4610,2018
+BIOL,4620,1,Cell Biology Lab (Lec),0.81,0.11,0.0,0.04,0.0,0.0,0.0,0.04,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,2,Cell Biology Lab (Lec),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,5,Cell Biology Lab (Lec),0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,6,Cell Biology Lab (Lec),0.74,0.15,0.07,0.0,0.0,0.0,0.0,0.04,xianzhong yu,,BIOL-4620,2018
+BIOL,4620,8,Cell Biology Lab (Lec),0.85,0.12,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2018
+BIOL,4640,1,Mammalogy,0.63,0.15,0.07,0.11,0.0,0.0,0.0,0.04,john cummings,,BIOL-4640,2018
+BIOL,4670,1,Principles of Hematology,0.86,0.08,0.06,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,,BIOL-4670,2018
+BIOL,4700,1,Behavioral Ecology,0.27,0.44,0.18,0.06,0.03,0.0,0.0,0.02,lisa rapaport,,BIOL-4700,2018
+BIOL,4700,2,Behavioral Ecology (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lisa rapaport,True,BIOL-4700,2018
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lisa rapaport,,BIOL-4710,2018
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,lisa rapaport,,BIOL-4710,2018
+BIOL,4930,3,Sr Sem: Advances in Cancer,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,,BIOL-4930,2018
+BIOL,4930,4,Sr Sem: Immuno & Immunothearpy,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,yanzhang wei,,BIOL-4930,2018
+BIOL,4930,5,Sr Sem: Nervous Systems,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4930,2018
+BIOL,4930,8,Sr Sem: Defining Sex,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tamara mcnutt-scott,,BIOL-4930,2018
+BIOL,8430,1,Underst Genetics & Evol Biol,0.82,0.17,0.01,0.0,0.0,0.0,0.0,0.0,renea chris hardwick,,BIOL-8430,2018
+BIOL,8450,1,Understanding Animal Biology,0.9,0.09,0.01,0.0,0.0,0.0,0.0,0.0,matthew turnbull,,BIOL-8450,2018
+BIOL,8470,1,Understanding Microbiology,0.57,0.37,0.04,0.0,0.02,0.0,0.0,0.0,harry kurtz,,BIOL-8470,2018
+BMOL,4250,1,Biomolecular Engineering,0.22,0.35,0.13,0.17,0.0,0.0,0.0,0.13,mark alan blenner,,BMOL-4250,2018
+BMOL,4290,1,Bioprocess Engineering,0.27,0.15,0.54,0.0,0.04,0.0,0.0,0.0,marc russ birtwistle,,BMOL-4290,2018
+BUS,1010,1,Business Foundations,0.25,0.5,0.13,0.04,0.08,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2018
+BUS,1010,2,Business Foundations,0.28,0.32,0.2,0.08,0.08,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2018
+BUS,1010,3,Business Foundations,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2018
+BUS,1010,4,Business Foundations,0.21,0.43,0.29,0.0,0.04,0.0,0.0,0.04,william erne tumblin,,BUS-1010,2018
+BUS,1010,5,Business Foundations,0.33,0.41,0.0,0.07,0.07,0.0,0.0,0.11,william erne tumblin,,BUS-1010,2018
+BUS,1010,6,Business Foundations,0.4,0.36,0.08,0.08,0.04,0.0,0.0,0.04,william erne tumblin,,BUS-1010,2018
+BUS,1010,7,Business Foundations,0.33,0.37,0.2,0.03,0.03,0.0,0.0,0.03,donna mccubbin,,BUS-1010,2018
+BUS,1010,8,Business Foundations,0.33,0.43,0.13,0.07,0.0,0.0,0.0,0.03,donna mccubbin,,BUS-1010,2018
+BUS,1010,9,Business Foundations,0.42,0.23,0.31,0.0,0.0,0.0,0.0,0.04,william erne tumblin,,BUS-1010,2018
+BUS,1010,10,Business Foundations,0.58,0.23,0.08,0.04,0.04,0.0,0.0,0.04,william erne tumblin,,BUS-1010,2018
+CE,2010,1,Statics,0.36,0.29,0.16,0.05,0.04,0.0,0.0,0.09,barnabas bwambale,,CE-2010,2018
+CE,2010,2,Statics,0.08,0.35,0.3,0.18,0.08,0.0,0.0,0.03,melissa sternhagen,,CE-2010,2018
+CE,2010,3,Statics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,sreeganesh red yerri,,CE-2010,2018
+CE,2010,4,Statics,0.05,0.2,0.24,0.12,0.15,0.0,0.0,0.24,melissa sternhagen,,CE-2010,2018
+CE,2010,5,Statics,0.2,0.32,0.28,0.1,0.01,0.0,0.0,0.09, kent nilsson,,CE-2010,2018
+CE,2010,6,Statics,0.33,0.27,0.29,0.07,0.04,0.0,0.0,0.0,shweta shrestha,,CE-2010,2018
+CE,2060,1,Structural Mechanics,0.39,0.41,0.15,0.02,0.02,0.0,0.0,0.0,mahmoodreza soltani,,CE-2060,2018
+CE,2060,2,Structural Mechanics,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,mahmoodreza soltani,,CE-2060,2018
+CE,2080,1,Dynamics,0.05,0.43,0.27,0.17,0.05,0.0,0.0,0.03,melissa sternhagen,,CE-2080,2018
+CE,2080,2,Dynamics,0.06,0.42,0.36,0.03,0.08,0.0,0.0,0.05,melissa sternhagen,,CE-2080,2018
+CE,2550,1,Geomatics,0.27,0.42,0.27,0.01,0.03,0.0,0.0,0.0,wayne sarasua,,CE-2550,2018
+CE,3010,1,Structural Analysis,0.28,0.33,0.2,0.13,0.04,0.0,0.0,0.02,stephen csernak,,CE-3010,2018
+CE,3110,1,Transportation Engr,0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,pamela murray-tuite,,CE-3110,2018
+CE,3210,1,Geotechnical Engineering,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,,CE-3210,2018
+CE,3210,2,Geotechnical Engineering,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,,CE-3210,2018
+CE,3310,1,Constr Engr & Mgmnt,0.31,0.52,0.07,0.09,0.0,0.0,0.0,0.0,james burati,,CE-3310,2018
+CE,3410,1,Intro to Fluid Mech,0.28,0.51,0.16,0.03,0.01,0.0,0.0,0.0,nigel gregory kaye,,CE-3410,2018
+CE,3420,1,Hydraulics & Hydro,0.49,0.37,0.11,0.03,0.0,0.0,0.0,0.0,ashok mishra,,CE-3420,2018
+CE,3420,2,Hydraulics & Hydro,0.52,0.33,0.07,0.0,0.0,0.0,0.0,0.07,abdul khan,,CE-3420,2018
+CE,3510,1,Civil Engineering Materials,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,prasada ra rangaraju,,CE-3510,2018
+CE,3520,1,Econ Eval of Proj,0.53,0.33,0.15,0.0,0.0,0.0,0.0,0.0,james burati,,CE-3520,2018
+CE,3520,2,Econ Eval of Proj,0.45,0.49,0.05,0.0,0.0,0.0,0.0,0.01,zoraya roldan rockow,,CE-3520,2018
+CE,3530,1,Professional Seminar,0.95,0.01,0.04,0.0,0.0,0.0,0.0,0.01,thomas edfor cousins,,CE-3530,2018
+CE,4020,1,Reinfor Con Design,0.26,0.3,0.28,0.07,0.02,0.0,0.0,0.07,thomas edfor cousins,,CE-4020,2018
+CE,4070,1,Wood Design,0.62,0.24,0.14,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-4070,2018
+CE,4080,1,Struct Loads & Sys,0.38,0.46,0.08,0.0,0.08,0.0,0.0,0.0,bryant nielson,,CE-4080,2018
+CE,4110,1,Roadway Geo Design,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jennifer ogle,,CE-4110,2018
+CE,4120,1,Urban Transport Plan,0.23,0.69,0.0,0.0,0.0,0.0,0.0,0.08,eric morris,,CE-4120,2018
+CE,4210,1,Geotechnical Design,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,nadaraj ravichandran,,CE-4210,2018
+CE,4340,1,Const Est Proj Cont,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4340,2018
+CE,4470,1,Stormwater Managemnt,0.25,0.25,0.35,0.1,0.0,0.0,0.0,0.05,md nasimul chowdhury,,CE-4470,2018
+CE,4590,1,Capstone Design Proj,0.49,0.46,0.04,0.0,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2018
+CE,4620,1,Coastal Engr I,0.19,0.41,0.26,0.11,0.04,0.0,0.0,0.0,earl hayter,,CE-4620,2018
+CE,4910,1,Meth & Mgmt of Com & Ind Const,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,steve richar sanders,,CE-4910,2018
+CE,6120,1,Urban Transport Plan,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,,CE-6120,2018
+CE,8030,1,Adv Steel Design,0.5,0.38,0.08,0.0,0.04,0.0,0.0,0.0,clinton owen rex,,CE-8030,2018
+CE,8040,1,Prestressed Concrete,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,brandon ross,,CE-8040,2018
+CE,8470,500,Optimization Support Models,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,,CE-8470,2018
+CE,8570,500,Uncertainty Modeling Risk Engr,0.78,0.13,0.0,0.0,0.0,0.0,0.0,0.09,elnaz peyghaleh,,CE-8570,2018
+CE,8600,1,Adv Fluid Mech,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,abdul khan,,CE-8600,2018
+CH,1010,1,General Chemistry,0.14,0.3,0.32,0.1,0.07,0.0,0.0,0.08,princess mycia cox,,CH-1010,2018
+CH,1010,2,General Chemistry,0.07,0.28,0.36,0.14,0.06,0.0,0.0,0.08,princess mycia cox,,CH-1010,2018
+CH,1010,3,General Chemistry,0.18,0.38,0.28,0.05,0.06,0.0,0.0,0.05,laura lanni,,CH-1010,2018
+CH,1010,4,General Chemistry,0.17,0.33,0.27,0.11,0.06,0.0,0.0,0.07,william we mcwhorter,,CH-1010,2018
+CH,1010,400,General Chemistry,0.32,0.23,0.13,0.15,0.02,0.0,0.0,0.15,stephen schvaneveldt,,CH-1010,2018
+CH,1020,1,General Chemistry,0.26,0.31,0.26,0.1,0.02,0.0,0.0,0.05,thomas hickman,,CH-1020,2018
+CH,1020,2,General Chemistry,0.42,0.36,0.17,0.03,0.01,0.0,0.0,0.02,tania issa houjeiry,,CH-1020,2018
+CH,1020,3,General Chemistry,0.38,0.37,0.11,0.06,0.02,0.0,0.0,0.08,dennis taylor,,CH-1020,2018
+CH,1020,4,General Chemistry,0.27,0.44,0.19,0.05,0.02,0.0,0.0,0.03,dennis taylor,,CH-1020,2018
+CH,1020,5,General Chemistry,0.18,0.39,0.22,0.1,0.03,0.0,0.0,0.09,william we mcwhorter,,CH-1020,2018
+CH,1020,6,General Chemistry,0.09,0.43,0.26,0.08,0.08,0.0,0.0,0.07,william we mcwhorter,,CH-1020,2018
+CH,1020,7,General Chemistry,0.2,0.42,0.25,0.08,0.0,0.0,0.0,0.03,olt geiculescu,,CH-1020,2018
+CH,1020,8,General Chemistry,0.22,0.44,0.2,0.07,0.02,0.0,0.0,0.05,thomas hickman,,CH-1020,2018
+CH,1020,9,General Chemistry,0.3,0.41,0.18,0.04,0.03,0.0,0.0,0.05,elliot ennis,,CH-1020,2018
+CH,1020,10,General Chemistry,0.23,0.34,0.25,0.07,0.02,0.0,0.0,0.09,jacob schroeder,,CH-1020,2018
+CH,1020,11,General Chemistry,0.28,0.44,0.19,0.02,0.0,0.0,0.0,0.07,dennis taylor,,CH-1020,2018
+CH,1020,50,General Chemistry,0.36,0.27,0.18,0.18,0.0,0.0,0.0,0.0,shiou-jyh hwu,,CH-1020,2018
+CH,1020,51,General Chemistry (HON),0.68,0.26,0.04,0.0,0.0,0.0,0.0,0.02,stephen schvaneveldt,True,CH-1020,2018
+CH,1020,52,General Chemistry (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,stephen schvaneveldt,True,CH-1020,2018
+CH,1020,500,General Chemistry,0.14,0.39,0.29,0.18,0.0,0.0,0.0,0.0,brian gloor,,CH-1020,2018
+CH,1050,1,Chemistry in Context I,0.54,0.37,0.09,0.0,0.0,0.0,0.0,0.0,olt geiculescu,,CH-1050,2018
+CH,1050,2,Chemistry in Context I,0.35,0.38,0.19,0.0,0.04,0.0,0.0,0.04,olt geiculescu,,CH-1050,2018
+CH,1060,1,Chemistry in Context II,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,thomas hickman,,CH-1060,2018
+CH,1520,1,Chemistry Communication,0.67,0.23,0.02,0.0,0.02,0.0,0.0,0.05,richard marcus,,CH-1520,2018
+CH,2010,1,Survey of Organic Chemistry,0.4,0.34,0.13,0.07,0.05,0.0,0.0,0.02,tania issa houjeiry,,CH-2010,2018
+CH,2020,1,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2020,2018
+CH,2020,2,Surv of Organic Chemistry Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,james nelson plampin,,CH-2020,2018
+CH,2020,3,Surv of Organic Chemistry Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2020,2018
+CH,2020,4,Surv of Organic Chemistry Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,,CH-2020,2018
+CH,2050,1,Intro Inorg Chem,0.36,0.43,0.14,0.04,0.0,0.0,0.0,0.04,william pennington,,CH-2050,2018
+CH,2230,1,Organic Chemistry,0.19,0.34,0.16,0.19,0.09,0.0,0.0,0.03,jacob schroeder,,CH-2230,2018
+CH,2230,2,Organic Chemistry,0.28,0.38,0.18,0.08,0.04,0.0,0.0,0.05,jacob schroeder,,CH-2230,2018
+CH,2230,3,Organic Chemistry,0.69,0.22,0.01,0.01,0.04,0.0,0.0,0.04,sourav saha,,CH-2230,2018
+CH,2240,1,Organic Chemistry,0.21,0.21,0.21,0.14,0.08,0.0,0.0,0.16,laura lanni,,CH-2240,2018
+CH,2240,2,Organic Chemistry,0.38,0.33,0.14,0.09,0.02,0.0,0.0,0.03,elliot ennis,,CH-2240,2018
+CH,2240,3,Organic Chemistry,0.29,0.24,0.16,0.11,0.08,0.0,0.0,0.12,laura lanni,,CH-2240,2018
+CH,2240,4,Organic Chemistry,0.35,0.29,0.21,0.03,0.04,0.0,0.0,0.08,rhett smith,,CH-2240,2018
+CH,2240,5,Organic Chemistry,0.28,0.33,0.28,0.06,0.02,0.0,0.0,0.03,elliot ennis,,CH-2240,2018
+CH,2270,1,Organic Chem Lab,0.56,0.19,0.0,0.0,0.0,0.0,0.0,0.25,james nelson plampin,,CH-2270,2018
+CH,2270,2,Organic Chem Lab,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,james nelson plampin,,CH-2270,2018
+CH,2270,3,Organic Chem Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2270,2018
+CH,2270,4,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2270,2018
+CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2270,2018
+CH,2270,7,Organic Chem Lab,0.89,0.0,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2270,2018
+CH,2270,8,Organic Chem Lab,0.67,0.17,0.06,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2018
+CH,2270,12,Organic Chem Lab,0.69,0.13,0.06,0.0,0.06,0.0,0.0,0.06,james nelson plampin,,CH-2270,2018
+CH,2270,13,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,,CH-2270,2018
+CH,2270,16,Organic Chem Lab,0.63,0.13,0.06,0.0,0.0,0.0,0.0,0.19,james nelson plampin,,CH-2270,2018
+CH,2280,3,Organic Chem Lab,0.88,0.0,0.06,0.0,0.06,0.0,0.0,0.0,james nelson plampin,,CH-2280,2018
+CH,2280,6,Organic Chem Lab,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,,CH-2280,2018
+CH,2280,7,Organic Chem Lab,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2280,2018
+CH,2280,8,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,,CH-2280,2018
+CH,2280,9,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,,CH-2280,2018
+CH,2280,10,Organic Chem Lab,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,james nelson plampin,,CH-2280,2018
+CH,2280,11,Organic Chem Lab,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,,CH-2280,2018
+CH,2280,14,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,,CH-2280,2018
+CH,2280,17,Organic Chem Lab,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2280,2018
+CH,2280,19,Organic Chem Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,james nelson plampin,,CH-2280,2018
+CH,2280,20,Organic Chem Lab,0.73,0.07,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,,CH-2280,2018
+CH,2280,22,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,,CH-2280,2018
+CH,2280,24,Organic Chem Lab,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,,CH-2280,2018
+CH,2280,25,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,,CH-2280,2018
+CH,2280,27,Organic Chem Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,james nelson plampin,,CH-2280,2018
+CH,2280,28,Organic Chem Lab,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,,CH-2280,2018
+CH,2290,2,Organic Chem Lab,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2290,2018
+CH,2290,3,Organic Chem Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,james nelson plampin,,CH-2290,2018
+CH,2290,4,Organic Chem Lab,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2290,2018
+CH,3310,1,Physical Chemistry,0.4,0.3,0.0,0.0,0.1,0.0,0.0,0.2,arkady kholodenko,,CH-3310,2018
+CH,3320,1,Physical Chemistry,0.17,0.42,0.33,0.0,0.08,0.0,0.0,0.0,steven stuart,,CH-3320,2018
+CH,3320,3,Physical Chemistry,0.88,0.11,0.02,0.0,0.0,0.0,0.0,0.0,jason mcneill,,CH-3320,2018
+CH,3320,4,Physical Chemistry,0.41,0.26,0.09,0.06,0.15,0.0,0.0,0.03,leah beck casabianca,,CH-3320,2018
+CH,3400,1,Physical Chem Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,princess mycia cox,,CH-3400,2018
+CH,3400,2,Physical Chem Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2018
+CH,3400,4,Physical Chem Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2018
+CH,3400,6,Physical Chem Lab,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2018
+CH,3600,1,Chemical Biology,0.39,0.42,0.16,0.03,0.0,0.0,0.0,0.0,modi wetzler,,CH-3600,2018
+CH,4110,1,Instrumental Analy,0.12,0.19,0.38,0.12,0.19,0.0,0.0,0.0,george chumanov,,CH-4110,2018
+CH,4120,1,Instr Analysis Lab,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey nathan anker,,CH-4120,2018
+CH,4130,1,Chemistry of Aqueous Systems,0.59,0.22,0.09,0.0,0.0,0.0,0.0,0.09,cindy lee,,CH-4130,2018
+CH,4500,1,Chemistry Capstone,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,,CH-4500,2018
+CH,6140,1,Bioanalytical Chem,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,perez carlos garcia,,CH-6140,2018
+CH,8080,1,Chem Non-Metal Elem,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,,CH-8080,2018
+CH,8180,1,Surface Analysis,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,stephen creager,,CH-8180,2018
+CH,8220,1,Organic Chem II,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,daniel whitehead,,CH-8220,2018
+CH,8510,1,Grad Student Seminar,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,,CH-8510,2018
+CHE,1300,1,Intro to Chemical Engineering,0.27,0.25,0.27,0.04,0.04,0.0,0.0,0.14,christopher norfolk,,CHE-1300,2018
+CHE,1300,2,Intro to Chemical Engineering,0.17,0.25,0.15,0.06,0.12,0.0,0.0,0.25,christopher norfolk,,CHE-1300,2018
+CHE,2200,1,Ch E Thermo I,0.24,0.24,0.24,0.19,0.05,0.0,0.0,0.05,joseph scott,,CHE-2200,2018
+CHE,2200,2,Ch E Thermo I,0.15,0.35,0.31,0.08,0.05,0.0,0.0,0.06,jessica marie kelly,,CHE-2200,2018
+CHE,2300,1,Fluids/Heat Transfer,0.1,0.21,0.26,0.26,0.13,0.0,0.0,0.05,eric mikel davis,,CHE-2300,2018
+CHE,2300,2,Fluids/Heat Transfer,0.15,0.37,0.22,0.15,0.04,0.0,0.0,0.07,eric mikel davis,,CHE-2300,2018
+CHE,3070,1,Unit Ops Lab I,0.21,0.52,0.25,0.0,0.0,0.0,0.0,0.02,mark thies,,CHE-3070,2018
+CHE,3190,1,Engr Materials,0.17,0.29,0.3,0.16,0.06,0.0,0.0,0.02,amod ogale,,CHE-3190,2018
+CHE,3530,2,Proc Dyn & Control,0.41,0.26,0.26,0.04,0.01,0.0,0.0,0.01,mark roberts,,CHE-3530,2018
+CHE,4330,1,Process Design II,0.44,0.45,0.11,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4330,2018
+CHE,8450,3,Multiscale Modeling,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,sapna sarupria,,CHE-8450,2018
+CHIN,1020,1,Elementary Chinese,0.6,0.1,0.2,0.1,0.0,0.0,0.0,0.0,ling rao,,CHIN-1020,2018
+CHIN,2020,1,Intermediate Chinese,0.47,0.18,0.24,0.12,0.0,0.0,0.0,0.0,ling rao,,CHIN-2020,2018
+CHIN,3120,1,Philosophy in Ancient China,0.33,0.27,0.13,0.0,0.07,0.0,0.0,0.2,yanming an,,CHIN-3120,2018
+CHIN,4010,1,Pre-Modern Chinese Literature,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,yanming an,,CHIN-4010,2018
+COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.93,0.04,0.04,lori marlise pindar,,COM-1010,2018
+COM,1500,1,Intro to Human Communication,0.88,0.11,0.0,0.0,0.01,0.0,0.0,0.0,eddie smith,,COM-1500,2018
+COM,1500,2,Intro to Human Communication,0.58,0.33,0.03,0.02,0.02,0.0,0.0,0.02,daniel leland fecher,,COM-1500,2018
+COM,1500,3,Intro to Human Communication,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,eddie smith,,COM-1500,2018
+COM,1500,4,Intro to Human Communication,0.79,0.19,0.02,0.0,0.0,0.0,0.0,0.0,marianne herr glaser,,COM-1500,2018
+COM,1500,5,Intro to Human Communication,0.66,0.27,0.01,0.02,0.01,0.0,0.0,0.02,marianne herr glaser,,COM-1500,2018
+COM,1500,6,Intro to Human Communication,0.37,0.55,0.04,0.03,0.01,0.0,0.0,0.0,daniel leland fecher,,COM-1500,2018
+COM,2010,1,Intr to Comm Studies,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,,COM-2010,2018
+COM,2010,2,Intr to Comm Studies,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,,COM-2010,2018
+COM,2020,1,Communication Theory,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-2020,2018
+COM,2030,1,Mass Communication Theory,0.47,0.43,0.03,0.07,0.0,0.0,0.0,0.0,erin michelle ash,,COM-2030,2018
+COM,2100,1,Quant Comm Research Methods,0.3,0.52,0.19,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,,COM-2100,2018
+COM,2500,1,Public Speaking,0.62,0.33,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christi davis,,COM-2500,2018
+COM,2500,2,Public Speaking,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,,COM-2500,2018
+COM,2500,3,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christi davis,,COM-2500,2018
+COM,2500,7,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christi davis,,COM-2500,2018
+COM,2500,8,Public Speaking,0.43,0.24,0.14,0.0,0.05,0.0,0.0,0.14,pauline matthey,,COM-2500,2018
+COM,2500,9,Public Speaking,0.7,0.1,0.05,0.0,0.05,0.0,0.0,0.1,vanessa anne condon,,COM-2500,2018
+COM,2500,10,Public Speaking,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2018
+COM,2500,11,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2018
+COM,2500,12,Public Speaking,0.4,0.4,0.1,0.0,0.0,0.0,0.0,0.1,pauline matthey,,COM-2500,2018
+COM,2500,13,Public Speaking,0.63,0.21,0.05,0.0,0.11,0.0,0.0,0.0,amanda elizabe moore,,COM-2500,2018
+COM,2500,14,Public Speaking,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,amanda elizabe moore,,COM-2500,2018
+COM,2500,15,Public Speaking,0.9,0.0,0.0,0.0,0.1,0.0,0.0,0.0,caitlin baker,,COM-2500,2018
+COM,2500,16,Public Speaking,0.8,0.05,0.05,0.05,0.05,0.0,0.0,0.0,amanda elizabe moore,,COM-2500,2018
+COM,2500,18,Public Speaking,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2018
+COM,2500,19,Public Speaking,0.67,0.24,0.0,0.05,0.05,0.0,0.0,0.0,jumah patricia taweh,,COM-2500,2018
+COM,2500,20,Public Speaking,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2018
+COM,2500,21,Public Speaking,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,,COM-2500,2018
+COM,2500,22,Public Speaking,0.45,0.45,0.05,0.05,0.0,0.0,0.0,0.0,amanda elizabe moore,,COM-2500,2018
+COM,2500,23,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,,COM-2500,2018
+COM,2500,24,Public Speaking,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2500,2018
+COM,2500,25,Public Speaking,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,,COM-2500,2018
+COM,2500,29,Public Speaking,0.64,0.23,0.0,0.05,0.05,0.0,0.0,0.05,vanessa anne condon,,COM-2500,2018
+COM,2500,30,Public Speaking,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2018
+COM,2500,31,Public Speaking,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,,COM-2500,2018
+COM,2500,32,Public Speaking,0.71,0.19,0.05,0.0,0.05,0.0,0.0,0.0,sara grumble crocker,,COM-2500,2018
+COM,2500,33,Public Speaking,0.22,0.61,0.06,0.0,0.06,0.0,0.0,0.06,marilyn denise pugh,,COM-2500,2018
+COM,2500,34,Public Speaking,0.21,0.68,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,,COM-2500,2018
+COM,2500,35,Public Speaking,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2018
+COM,2500,36,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,,COM-2500,2018
+COM,2500,401,Public Speaking,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,,COM-2500,2018
+COM,2500,402,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachary davis,,COM-2500,2018
+COM,2500,403,Public Speaking,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alexis zachary davis,,COM-2500,2018
+COM,2500,500,Public Speaking,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,,COM-2500,2018
+COM,2500,501,Public Speaking,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,,COM-2500,2018
+COM,3200,1,Bdcst Production,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,wanda johnson,,COM-3200,2018
+COM,3250,1,Survey of Sports Communication,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3250,2018
+COM,3250,2,Survey of Sports Communication,0.87,0.04,0.09,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3250,2018
+COM,3300,1,Nonverbal Comm,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,joseph mazer,,COM-3300,2018
+COM,3550,1,Principles of Public Relations,0.71,0.24,0.02,0.0,0.0,0.0,0.0,0.02,meghnaa tallapragada,,COM-3550,2018
+COM,3570,1,Public Relations Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-3570,2018
+COM,3610,1,Argue and Debate,0.76,0.19,0.0,0.05,0.0,0.0,0.0,0.0,lindsey dixon,,COM-3610,2018
+COM,3640,1,Organizational Comm,0.57,0.34,0.06,0.02,0.0,0.0,0.0,0.0,kristen elai okamoto,,COM-3640,2018
+COM,3660,6,EC: Digital Analytics & Brand,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alicia nic littleton,,COM-3660,2018
+COM,3660,7,EC: Media Mgmt in Brand Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william reynolds,,COM-3660,2018
+COM,3990,2,CI: Reputation Mgmt,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,mark david land,,COM-3990,2018
+COM,4250,1,Adv Sports Comm,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,,COM-4250,2018
+COM,4280,1,Interpers/Family Comm & Sport,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,,COM-4280,2018
+COM,4560,1,PR for Assoc & Nonprofits,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-4560,2018
+COM,4560,2,PR for Assoc & Nonprofits,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-4560,2018
+COM,4700,1,Comm & Health,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,stephanie pangborn,,COM-4700,2018
+COM,4950,1,Senior Capstone,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-4950,2018
+COM,4950,2,Senior Capstone,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-4950,2018
+COM,8070,1,Hlt Com Plan & Eval,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,stephanie pangborn,,COM-8070,2018
+COM,8110,1,Comm Research Methods II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,meghnaa tallapragada,,COM-8110,2018
+CPSC,1010,1,Computer Science I,0.17,0.25,0.21,0.06,0.15,0.0,0.0,0.15,catherine hochrine,,CPSC-1010,2018
+CPSC,1010,2,Computer Science I,0.17,0.19,0.17,0.02,0.24,0.0,0.0,0.22,catherine hochrine,,CPSC-1010,2018
+CPSC,1020,1,Computer Science II,0.38,0.22,0.12,0.07,0.12,0.0,0.0,0.09,yvon feaster,,CPSC-1020,2018
+CPSC,1020,2,Computer Science II,0.28,0.16,0.17,0.03,0.17,0.0,0.0,0.19,yvon feaster,,CPSC-1020,2018
+CPSC,1070,1,Programming Methodology,0.56,0.28,0.12,0.04,0.0,0.0,0.0,0.0,rose lowe,,CPSC-1070,2018
+CPSC,1110,1,Intro to Programming in C,0.08,0.41,0.25,0.05,0.11,0.0,0.0,0.1,catherine hochrine,,CPSC-1110,2018
+CPSC,1110,2,Intro to Programming in C,0.43,0.27,0.16,0.02,0.05,0.0,0.0,0.07,nicolas benja widman,,CPSC-1110,2018
+CPSC,2070,1,Discrete Structures,0.63,0.26,0.02,0.07,0.0,0.0,0.0,0.02,sandra hedetniemi,,CPSC-2070,2018
+CPSC,2070,2,Discrete Structures,0.31,0.23,0.23,0.08,0.11,0.0,0.0,0.03,larry hodges,,CPSC-2070,2018
+CPSC,2120,1,Algs/Data Structures,0.32,0.34,0.25,0.05,0.0,0.0,0.0,0.05,wayne goddard,,CPSC-2120,2018
+CPSC,2120,2,Algs/Data Structures,0.25,0.48,0.2,0.02,0.05,0.0,0.0,0.0,wayne goddard,,CPSC-2120,2018
+CPSC,2150,1,Software Dev Foundations,0.45,0.28,0.18,0.05,0.03,0.0,0.0,0.02,kevin anton plis,,CPSC-2150,2018
+CPSC,2150,2,Software Dev Foundations,0.27,0.35,0.24,0.02,0.05,0.0,0.0,0.08,kevin anton plis,,CPSC-2150,2018
+CPSC,2200,1,Microcomputer Appl,0.52,0.3,0.09,0.0,0.04,0.0,0.0,0.04,kevin anton plis,,CPSC-2200,2018
+CPSC,2200,2,Microcomputer Appl,0.35,0.43,0.13,0.0,0.09,0.0,0.0,0.0,kevin anton plis,,CPSC-2200,2018
+CPSC,2310,1,Intro Computer Org,0.45,0.16,0.25,0.05,0.09,0.0,0.0,0.0,rose lowe,,CPSC-2310,2018
+CPSC,2310,2,Intro Computer Org,0.11,0.34,0.25,0.14,0.14,0.0,0.0,0.02,rose lowe,,CPSC-2310,2018
+CPSC,2910,1,Prof Issues I,0.65,0.25,0.0,0.05,0.0,0.0,0.0,0.05,catherine hochrine,,CPSC-2910,2018
+CPSC,2910,2,Prof Issues I,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,catherine hochrine,,CPSC-2910,2018
+CPSC,2910,3,Prof Issues I,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2018
+CPSC,3120,1,Design Analysis of Algorithms,0.13,0.13,0.33,0.08,0.21,0.0,0.0,0.13,pradip srimani,,CPSC-3120,2018
+CPSC,3220,1,Intro to Operating Systems,0.17,0.25,0.14,0.0,0.08,0.0,0.0,0.36,jacob sorber,,CPSC-3220,2018
+CPSC,3220,2,Intro to Operating Systems,0.79,0.15,0.03,0.03,0.0,0.0,0.0,0.0,carl bryan martin,,CPSC-3220,2018
+CPSC,3220,3,Intro to Operating Systems,0.17,0.45,0.1,0.07,0.07,0.0,0.0,0.14,zijun wang,,CPSC-3220,2018
+CPSC,3300,1,Computer Systems Org,0.2,0.35,0.33,0.03,0.1,0.0,0.0,0.0,mark smotherman,,CPSC-3300,2018
+CPSC,3300,2,Computer Systems Org,0.53,0.25,0.13,0.05,0.03,0.0,0.0,0.03,nicolas benja widman,,CPSC-3300,2018
+CPSC,3500,1,Foundations of Computer Sci,0.16,0.23,0.47,0.06,0.0,0.0,0.0,0.08,ilya mark safro,,CPSC-3500,2018
+CPSC,3520,1,Programming Systems,0.31,0.42,0.1,0.01,0.08,0.0,0.0,0.08,robert schalkoff,,CPSC-3520,2018
+CPSC,3600,1,Network Programming,0.43,0.27,0.22,0.02,0.0,0.0,0.0,0.06,feng luo,,CPSC-3600,2018
+CPSC,3600,2,Network Programming,0.14,0.5,0.29,0.04,0.0,0.0,0.0,0.04,james martin,,CPSC-3600,2018
+CPSC,3720,1,Software Engineering,0.2,0.45,0.33,0.0,0.0,0.0,0.0,0.02,murali sitaraman,,CPSC-3720,2018
+CPSC,3720,2,Software Engineering,0.25,0.44,0.25,0.03,0.03,0.0,0.0,0.0,eileen there kraemer,,CPSC-3720,2018
+CPSC,4050,1,Computer Graphics,0.29,0.14,0.21,0.18,0.04,0.0,0.0,0.14,victor zordan,,CPSC-4050,2018
+CPSC,4110,1,Virtual Reality Systems,0.37,0.37,0.14,0.0,0.02,0.0,0.0,0.09,andrew robb,,CPSC-4110,2018
+CPSC,4140,1,Human and Computer Interaction,0.29,0.33,0.17,0.0,0.0,0.0,0.0,0.21,christopher plaue,,CPSC-4140,2018
+CPSC,4140,2,Human and Computer Interaction,0.28,0.33,0.28,0.06,0.0,0.0,0.0,0.06,christopher plaue,,CPSC-4140,2018
+CPSC,4160,1,2-D Game Engine Construction,0.4,0.38,0.1,0.0,0.1,0.0,0.0,0.02,brian malloy,,CPSC-4160,2018
+CPSC,4240,1,System Admin and Security,0.18,0.56,0.2,0.02,0.0,0.0,0.0,0.04,james martin,,CPSC-4240,2018
+CPSC,4300,1,Applied Data Science,0.33,0.33,0.28,0.0,0.0,0.0,0.0,0.06,alexander chr herzog,,CPSC-4300,2018
+CPSC,4620,1,Database Management Systems,0.34,0.45,0.14,0.05,0.02,0.0,0.0,0.0,zijun wang,,CPSC-4620,2018
+CPSC,4620,2,Database Management Systems,0.44,0.34,0.15,0.02,0.05,0.0,0.0,0.0,kevin anton plis,,CPSC-4620,2018
+CPSC,4770,1,Distributed/Cluster Computing,0.26,0.62,0.09,0.0,0.0,0.0,0.0,0.03,linh bao ngo,,CPSC-4770,2018
+CPSC,4820,1,Special Topic: Cloud Comp Arch,0.33,0.43,0.23,0.0,0.0,0.0,0.0,0.0,amy apon,,CPSC-4820,2018
+CPSC,4820,2,Special Topics: Tang and Embod,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,brygg anders ullmer,,CPSC-4820,2018
+CPSC,4910,1,Professional Issues II,0.3,0.67,0.03,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,,CPSC-4910,2018
+CPSC,6110,1,Virtual Reality Systems,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,andrew robb,,CPSC-6110,2018
+CPSC,6160,1,2-D Game Engine Construction,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,brian malloy,,CPSC-6160,2018
+CPSC,6300,1,Applied Data Science,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,,CPSC-6300,2018
+CPSC,8100,1,Intro Artif Intell,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,,CPSC-8100,2018
+CPSC,8110,1,Technical Character Animation,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,christina soph joerg,,CPSC-8110,2018
+CPSC,8240,1,Advanced Operating Systems,0.32,0.48,0.08,0.0,0.0,0.0,0.0,0.12,rong ge,,CPSC-8240,2018
+CPSC,8280,0,Theory of Program. Languages,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,murali sitaraman,,CPSC-8280,2018
+CPSC,8400,1,Design & Anlys of Algorithms,0.18,0.5,0.25,0.0,0.0,0.0,0.0,0.07,brian christoph dean,,CPSC-8400,2018
+CPSC,8580,1,Security in Emerging Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,,CPSC-8580,2018
+CPSC,8650,1,Data Mining,0.27,0.38,0.19,0.0,0.04,0.0,0.0,0.12,zijun wang,,CPSC-8650,2018
+CPSC,8750,1,Software Architectur,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,john mcgregor,,CPSC-8750,2018
+CPSC,8810,10,Selected Topics: Motion Planni,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,,CPSC-8810,2018
+CRP,8020,1,Site Planning & Infrastructure,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,,CRP-8020,2018
+CRP,8050,1,Plning Theory & History,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mickey lauria,,CRP-8050,2018
+CRP,8090,1,Current Issues in Planning,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,,CRP-8090,2018
+CRP,8130,1,Transportation Plan Fundament,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,eric morris,,CRP-8130,2018
+CRP,8200,1,Negotiation & Develop Resolut,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,,CRP-8200,2018
+CRP,8220,1,Urban Design,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,thomas willi schurch,,CRP-8220,2018
+CRP,8590,2,Plan Terminal Proj,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,,CRP-8590,2018
+CRP,8890,1,Selected Topic in Advanced GIS,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,patr carbajales-dale,,CRP-8890,2018
+CRP,8890,3,Sel Top Development Finance,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,elora lee raymond,,CRP-8890,2018
+CSM,2010,1,Structures I,0.3,0.25,0.2,0.05,0.1,0.0,0.0,0.1,shima clarke,,CSM-2010,2018
+CSM,2020,1,Structures II,0.13,0.44,0.23,0.13,0.02,0.0,0.0,0.04,shima clarke,,CSM-2020,2018
+CSM,2030,1,Mats & Meth of Const,0.21,0.61,0.14,0.0,0.04,0.0,0.0,0.0,jason lucas,,CSM-2030,2018
+CSM,2040,1,Cont Documents,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,,CSM-2040,2018
+CSM,2050,1,Mats & Methods II,0.24,0.61,0.12,0.0,0.0,0.0,0.0,0.02,jason lucas,,CSM-2050,2018
+CSM,3050,1,Envir Systems II,0.26,0.43,0.3,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,,CSM-3050,2018
+CSM,3050,2,Envir Systems II,0.37,0.57,0.03,0.03,0.0,0.0,0.0,0.0,joseph micha burgett,,CSM-3050,2018
+CSM,3070,1,Sustainable Construction,0.2,0.45,0.25,0.0,0.05,0.0,0.0,0.05,joseph micha burgett,,CSM-3070,2018
+CSM,3070,2,Sustainable Construction,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.04,joseph micha burgett,,CSM-3070,2018
+CSM,3520,1,Const Scheduling,0.33,0.3,0.33,0.0,0.0,0.0,0.0,0.03,christine piper,,CSM-3520,2018
+CSM,3520,2,Const Scheduling,0.18,0.5,0.23,0.09,0.0,0.0,0.0,0.0,christine piper,,CSM-3520,2018
+CSM,3530,1,Const Estimating II,0.23,0.6,0.17,0.0,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,,CSM-3530,2018
+CSM,3530,2,Const Estimating II,0.32,0.55,0.09,0.0,0.0,0.0,0.0,0.05,rizi seyed  mousavi e,,CSM-3530,2018
+CSM,4540,1,Const Capstone,0.36,0.48,0.14,0.02,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4540,2018
+CSM,8350,401,Integr Proj Deliv Case Studies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shima clarke,,CSM-8350,2018
+CSM,8640,1,Construction Bus Strat & Mktg,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christine piper,,CSM-8640,2018
+CSM,8640,400,Construction Bus Strat & Mktg,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,christine piper,,CSM-8640,2018
+CSM,8660,1,Role in Development,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8660,2018
+CSM,8660,401,Role in Development,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8660,2018
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.86,0.12,0.02,susan whorton,,CU-1000,2018
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.68,0.21,0.11,susan whorton,,CU-1000,2018
+CU,1010,1,Univ Success Skills,0.35,0.2,0.2,0.05,0.1,0.0,0.0,0.1,valerie kay oonk,,CU-1010,2018
+CU,1010,2,Univ Success Skills,0.4,0.2,0.13,0.07,0.07,0.0,0.0,0.13,adam richa mcfarlane,,CU-1010,2018
+CU,1010,3,Univ Success Skills,0.44,0.22,0.17,0.06,0.06,0.0,0.0,0.06,bryn zimmermann babb,,CU-1010,2018
+CU,1010,4,Univ Success Skills,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,sharetta mar bufford,,CU-1010,2018
+CU,1010,5,Univ Success Skills,0.5,0.22,0.22,0.0,0.06,0.0,0.0,0.0,bryn zimmermann babb,,CU-1010,2018
+CU,1010,6,Univ Success Skills,0.29,0.29,0.12,0.0,0.18,0.0,0.0,0.12,taimi olsen,,CU-1010,2018
+CU,1970,2,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.2,0.4,0.4,laurel ann  whisler c,,CU-1970,2018
+CU,2010,1,Sustainability Leadership,0.85,0.12,0.0,0.0,0.04,0.0,0.0,0.0,jennifer marga goree,,CU-2010,2018
+DPA,3070,1,Method 3d Production,0.71,0.14,0.04,0.0,0.0,0.0,0.0,0.11,sarah lydia  martin a,,DPA-3070,2018
+DPA,4020,1,Vis Foundations I,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anthony summey,,DPA-4020,2018
+DPA,4030,2,Vis Foundations II,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,erik reed,,DPA-4030,2018
+DPA,4830,1,Sp Studio Topic: Dig Sculpt In,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,insun kwon,,DPA-4830,2018
+ECE,2010,1,Logic and Computing Devices,0.29,0.35,0.23,0.0,0.07,0.0,0.0,0.06,walter ligon,,ECE-2010,2018
+ECE,2020,1,Electric Circuits I,0.18,0.17,0.37,0.08,0.15,0.0,0.0,0.05,william harrell,,ECE-2020,2018
+ECE,2070,1,Basic Electrical Engineering,0.48,0.36,0.08,0.02,0.0,0.0,0.0,0.05,timothy anglea,,ECE-2070,2018
+ECE,2070,2,Basic Electrical Engineering,0.53,0.27,0.12,0.03,0.01,0.0,0.0,0.04,william tho kolodzey,,ECE-2070,2018
+ECE,2070,3,Basic Electrical Engineering,0.39,0.33,0.21,0.04,0.0,0.0,0.0,0.03,william tho kolodzey,,ECE-2070,2018
+ECE,2080,5,Basic Electrical Engr Lab,0.85,0.0,0.05,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,7,Basic Electrical Engr Lab,0.85,0.0,0.0,0.05,0.05,0.0,0.0,0.05,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,8,Basic Electrical Engr Lab,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,15,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2080,2018
+ECE,2080,18,Basic Electrical Engr Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,,ECE-2080,2018
+ECE,2090,1,Logic Lab,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2090,2018
+ECE,2090,4,Logic Lab,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,apoorva deep kapadia,,ECE-2090,2018
+ECE,2110,2,Elec Engr Lab I,0.75,0.1,0.0,0.0,0.1,0.0,0.0,0.05,apoorva deep kapadia,,ECE-2110,2018
+ECE,2120,4,Electrical Engineering Lab II,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,apoorva deep kapadia,,ECE-2120,2018
+ECE,2120,8,Electrical Engineering Lab II,0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,apoorva deep kapadia,,ECE-2120,2018
+ECE,2220,1,Syst Prog Concept,0.24,0.35,0.26,0.01,0.09,0.0,0.0,0.06,william reid,,ECE-2220,2018
+ECE,2230,1,Comp Sys Eng,0.15,0.27,0.21,0.09,0.15,0.0,0.0,0.12,jon cameron calhoun,,ECE-2230,2018
+ECE,2620,1,Electric Circuits II,0.28,0.34,0.23,0.08,0.02,0.0,0.0,0.05,richard groff,,ECE-2620,2018
+ECE,2620,2,Elec Circuits II (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,True,ECE-2620,2018
+ECE,2720,1,Comp Organization,0.33,0.39,0.26,0.02,0.0,0.0,0.0,0.0,william reid,,ECE-2720,2018
+ECE,2730,1,Computer Org Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2730,2018
+ECE,2730,3,Computer Org Lab,0.5,0.31,0.13,0.06,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2730,2018
+ECE,2730,5,Computer Org Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,apoorva deep kapadia,,ECE-2730,2018
+ECE,2730,6,Computer Org Lab,0.63,0.31,0.0,0.06,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-2730,2018
+ECE,3110,2,Electrical Engineering Lab III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3110,2018
+ECE,3110,3,Electrical Engineering Lab III,0.31,0.44,0.19,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,,ECE-3110,2018
+ECE,3110,4,Electrical Engineering Lab III,0.69,0.19,0.0,0.06,0.0,0.0,0.0,0.06,apoorva deep kapadia,,ECE-3110,2018
+ECE,3120,2,Electrical Engineering Lab IV,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3120,2018
+ECE,3170,1,Rand Signal Analysis,0.32,0.28,0.24,0.11,0.03,0.0,0.0,0.04,stephen hubbard,,ECE-3170,2018
+ECE,3200,1,Electronics I,0.25,0.28,0.22,0.17,0.08,0.0,0.0,0.0,stephen hubbard,,ECE-3200,2018
+ECE,3210,1,Electronics II,0.49,0.34,0.13,0.0,0.02,0.0,0.0,0.02,stephen hubbard,,ECE-3210,2018
+ECE,3220,1,Intro Operating Sys,0.16,0.37,0.26,0.0,0.0,0.0,0.0,0.21,jacob sorber,,ECE-3220,2018
+ECE,3270,1,Dig Comp Design,0.17,0.19,0.26,0.1,0.07,0.0,0.0,0.21,melissa crawle smith,,ECE-3270,2018
+ECE,3300,1,Signals & Systems,0.16,0.24,0.34,0.15,0.06,0.0,0.0,0.04,carl baum,,ECE-3300,2018
+ECE,3520,1,Programming Systems,0.58,0.32,0.05,0.03,0.03,0.0,0.0,0.0,robert schalkoff,,ECE-3520,2018
+ECE,3600,1,Elect Power Engr,0.57,0.11,0.17,0.06,0.03,0.0,0.0,0.06,edward collins,,ECE-3600,2018
+ECE,3710,1,Microcontr Interface,0.32,0.32,0.3,0.03,0.0,0.0,0.0,0.03,william reid,,ECE-3710,2018
+ECE,3720,1,Micro Int Lab,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3720,3,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3720,5,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3720,7,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-3720,2018
+ECE,3800,1,Electromagnetics,0.3,0.28,0.2,0.08,0.08,0.0,0.0,0.06,yuan li,,ECE-3800,2018
+ECE,3810,1,Field Waves & Ckts,0.36,0.48,0.1,0.04,0.0,0.0,0.0,0.02,anthony martin,,ECE-3810,2018
+ECE,4090,1,Intr to Linear Control Systems,0.48,0.43,0.05,0.03,0.03,0.0,0.0,0.0,apoorva deep kapadia,,ECE-4090,2018
+ECE,4160,1,Smart Grid,0.52,0.45,0.03,0.0,0.0,0.0,0.0,0.0,gane venayagamoorthy,,ECE-4160,2018
+ECE,4200,1,Renewable Energy,0.19,0.19,0.26,0.26,0.0,0.0,0.0,0.1,johan heinric enslin,,ECE-4200,2018
+ECE,4270,1,Communications Sys,0.35,0.49,0.07,0.05,0.02,0.0,0.0,0.02,upasan bhattacharyya,,ECE-4270,2018
+ECE,4380,1,Computer Commun,0.33,0.33,0.22,0.07,0.0,0.0,0.0,0.04,harlan russell,,ECE-4380,2018
+ECE,4400,1,Local Computer Nets,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,,ECE-4400,2018
+ECE,4680,1,Embedded Computing,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,,ECE-4680,2018
+ECE,4950,1,Int Sys Design I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,,ECE-4950,2018
+ECE,4960,1,Int Sys Design II,0.59,0.33,0.05,0.02,0.0,0.0,0.0,0.0,richard groff,,ECE-4960,2018
+ECE,6200,1,Renewable Energy,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,johan heinric enslin,,ECE-6200,2018
+ECE,6680,1,Embedded Computing,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,adam hoover,,ECE-6680,2018
+ECE,6930,1,Algorithms VLSI Design Automa.,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,,ECE-6930,2018
+ECE,8260,1,Solar Cells,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,rajendra singh,,ECE-8260,2018
+ECE,8400,1,Semicond Devices,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,,ECE-8400,2018
+ECE,8480,1,Telecomm Networks,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,,ECE-8480,2018
+ECE,8720,1,Artificial Neurl Net,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,robert schalkoff,,ECE-8720,2018
+ECE,8720,2,Artificial Neurl Net,0.14,0.43,0.0,0.0,0.14,0.0,0.0,0.29,robert schalkoff,,ECE-8720,2018
+ECE,8740,1,Adv Nonlinear Cntrl,0.56,0.33,0.0,0.0,0.11,0.0,0.0,0.0,yongqiang wang,,ECE-8740,2018
+ECE,8790,1,FPGA Design & Applications,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,melissa crawle smith,,ECE-8790,2018
+ECE,8930,2,Optimiz. Vector Space Methods,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,daniel noneaker,,ECE-8930,2018
+ECE,8930,10,Distributed Denial of Service,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,,ECE-8930,2018
+ECON,2000,1,Economic Concepts,0.32,0.14,0.3,0.14,0.05,0.0,0.0,0.05,jonathan orry ernest,,ECON-2000,2018
+ECON,2000,2,Economic Concepts,0.35,0.35,0.2,0.03,0.03,0.0,0.0,0.05,jonathan orry ernest,,ECON-2000,2018
+ECON,2000,3,Economic Concepts,0.46,0.27,0.16,0.11,0.0,0.0,0.0,0.0,miren ivankovic,,ECON-2000,2018
+ECON,2110,1,Principles of Microeconomics,0.3,0.28,0.2,0.13,0.03,0.0,0.0,0.08,liuna issagholian,,ECON-2110,2018
+ECON,2110,2,Principles of Microeconomics,0.18,0.35,0.28,0.08,0.1,0.0,0.0,0.03,roksana ghanbariamin,,ECON-2110,2018
+ECON,2110,3,Principles of Microeconomics,0.12,0.31,0.26,0.12,0.12,0.0,0.0,0.07,benjamin posmanick,,ECON-2110,2018
+ECON,2110,4,Principles of Microeconomics,0.32,0.32,0.12,0.12,0.1,0.0,0.0,0.02,kelsey victo roberts,,ECON-2110,2018
+ECON,2110,5,Principles of Microeconomics,0.3,0.4,0.23,0.05,0.03,0.0,0.0,0.0,molly espey,,ECON-2110,2018
+ECON,2110,6,Principles of Microeconomics,0.19,0.57,0.19,0.0,0.01,0.0,0.0,0.03,chen wang,,ECON-2110,2018
+ECON,2110,7,Principles of Microeconomics,0.3,0.42,0.17,0.06,0.04,0.0,0.0,0.01,wing yin chung,,ECON-2110,2018
+ECON,2110,8,Principles of Microeconomics,0.28,0.28,0.24,0.1,0.07,0.0,0.0,0.03,sarah louise wilson,,ECON-2110,2018
+ECON,2110,10,Principles of Microeconomics,0.39,0.45,0.1,0.02,0.04,0.0,0.0,0.0,jacob walloga,,ECON-2110,2018
+ECON,2110,12,Principles of Microeconomics,0.43,0.28,0.18,0.08,0.0,0.0,0.0,0.05,molly espey,,ECON-2110,2018
+ECON,2120,1,Principles of Macroeconomics,0.45,0.2,0.15,0.1,0.05,0.0,0.0,0.05,scott baier,,ECON-2120,2018
+ECON,2120,2,Principles of Macroeconomics,0.17,0.33,0.28,0.11,0.11,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,3,Principles of Macroeconomics,0.33,0.33,0.28,0.0,0.0,0.0,0.0,0.06,scott baier,,ECON-2120,2018
+ECON,2120,4,Principles of Macroeconomics,0.21,0.42,0.32,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,5,Principles of Macroeconomics,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,scott baier,,ECON-2120,2018
+ECON,2120,6,Principles of Macroeconomics,0.26,0.21,0.26,0.11,0.05,0.0,0.0,0.11,scott baier,,ECON-2120,2018
+ECON,2120,7,Principles of Macroeconomics,0.16,0.42,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,8,Principles of Macroeconomics,0.11,0.47,0.16,0.05,0.11,0.0,0.0,0.11,scott baier,,ECON-2120,2018
+ECON,2120,9,Principles of Macroeconomics,0.21,0.37,0.32,0.0,0.05,0.0,0.0,0.05,scott baier,,ECON-2120,2018
+ECON,2120,10,Principles of Macroeconomics,0.32,0.53,0.05,0.11,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,11,Principles of Macroeconomics,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,12,Principles of Macroeconomics,0.11,0.42,0.26,0.11,0.11,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,13,Principles of Macroeconomics,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,14,Principles of Macroeconomics,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,15,Principles of Macroeconomics,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,16,Principles of Macroeconomics,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,17,Principles of Macroeconomics,0.21,0.63,0.05,0.0,0.05,0.0,0.0,0.05,scott baier,,ECON-2120,2018
+ECON,2120,18,Principles of Macroeconomics,0.21,0.63,0.11,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,19,Principles of Macroeconomics,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2018
+ECON,2120,20,Principles of Macroeconomics,0.69,0.22,0.05,0.0,0.03,0.0,0.0,0.0,jeremy choquette,,ECON-2120,2018
+ECON,2120,21,Principles of Macroeconomics,0.27,0.45,0.21,0.0,0.03,0.0,0.0,0.03,benjamin tim harbolt,,ECON-2120,2018
+ECON,2120,22,Principles of Macroeconomics,0.0,0.2,0.08,0.16,0.0,0.0,0.0,0.56,ralph charles allen,,ECON-2120,2018
+ECON,2120,23,Principles of Macroeconomics,0.2,0.11,0.14,0.09,0.03,0.0,0.0,0.43,ralph charles allen,,ECON-2120,2018
+ECON,2120,24,Principles of Macroeconomics,0.31,0.48,0.2,0.0,0.01,0.0,0.0,0.0,elijah neilson,,ECON-2120,2018
+ECON,2120,25,Principles of Macroeconomics,0.42,0.33,0.19,0.03,0.03,0.0,0.0,0.0,kyle lance rechard,,ECON-2120,2018
+ECON,2120,26,Principles of Macroeconomics,0.49,0.33,0.13,0.0,0.05,0.0,0.0,0.0,xiaosong wu,,ECON-2120,2018
+ECON,2120,27,Principles of Macroeconomics,0.36,0.38,0.23,0.0,0.0,0.0,0.0,0.03,narendra regmi,,ECON-2120,2018
+ECON,2120,28,Principles of Macroecon (HON),0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,christopher as gorry,True,ECON-2120,2018
+ECON,3020,1,Money and Banking,0.33,0.33,0.25,0.03,0.05,0.0,0.0,0.03,smriti bhargava,,ECON-3020,2018
+ECON,3060,1,Managerial Economics,0.16,0.33,0.25,0.12,0.12,0.0,0.0,0.02,steven johnson,,ECON-3060,2018
+ECON,3100,1,International Econ,0.48,0.29,0.18,0.0,0.02,0.0,0.0,0.03,samuel art standaert,,ECON-3100,2018
+ECON,3140,1,Intermediate Micro,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,yichen christy zhou,,ECON-3140,2018
+ECON,3140,2,Intermediate Micro,0.23,0.38,0.18,0.08,0.05,0.0,0.0,0.1,robert kenneth fleck,,ECON-3140,2018
+ECON,3140,3,Intermediate Micro,0.24,0.24,0.19,0.14,0.05,0.0,0.0,0.14,patrick warren,,ECON-3140,2018
+ECON,3150,1,Intermediate Macro,0.28,0.38,0.18,0.07,0.04,0.0,0.0,0.05,michal jerzmanowski,,ECON-3150,2018
+ECON,3150,2,Intermediate Macro,0.34,0.22,0.32,0.0,0.05,0.0,0.0,0.07,sergey vlad mityakov,,ECON-3150,2018
+ECON,3440,1,Property Rights,0.13,0.38,0.25,0.17,0.08,0.0,0.0,0.0,dari litsukova-bokar,,ECON-3440,2018
+ECON,3500,1,Moral & Ethical Econ,0.44,0.25,0.19,0.0,0.03,0.0,0.0,0.09,bradley keith hobbs,,ECON-3500,2018
+ECON,3500,2,Moral & Ethical Econ,0.15,0.35,0.25,0.1,0.0,0.0,0.0,0.15,bradley keith hobbs,,ECON-3500,2018
+ECON,3600,1,Public Choice,0.37,0.37,0.2,0.05,0.0,0.0,0.0,0.02,michael makowsky,,ECON-3600,2018
+ECON,4010,1,Labor Mkt Analysis,0.24,0.52,0.21,0.0,0.03,0.0,0.0,0.0,curtis simon,,ECON-4010,2018
+ECON,4020,1,Law and Economics,0.18,0.33,0.38,0.09,0.0,0.0,0.0,0.02,thomas winsl hazlett,,ECON-4020,2018
+ECON,4050,1,Intro to Econometric,0.27,0.29,0.25,0.07,0.07,0.0,0.0,0.04,scott barkowski,,ECON-4050,2018
+ECON,4050,2,Intro to Econometric,0.5,0.36,0.0,0.07,0.07,0.0,0.0,0.0,yichen christy zhou,,ECON-4050,2018
+ECON,4200,1,Pub Sector Econ,0.48,0.33,0.0,0.0,0.1,0.0,0.0,0.1,william dougan,,ECON-4200,2018
+ECON,4230,1,Economics of Health,0.56,0.33,0.1,0.0,0.0,0.0,0.0,0.0,devon merritt gorry,,ECON-4230,2018
+ECON,4240,1,Organization of Ind,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,matthew lewis,,ECON-4240,2018
+ECON,4240,2,Organization of Ind,0.34,0.41,0.17,0.07,0.0,0.0,0.0,0.0,matthew lewis,,ECON-4240,2018
+ECON,4260,1,Sem Sport Economics,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,raymond sauer,,ECON-4260,2018
+ECON,4270,1,Dev American Economy,0.21,0.52,0.21,0.07,0.0,0.0,0.0,0.0,howard nel bodenhorn,,ECON-4270,2018
+ECON,4400,1,Game Theory,0.28,0.41,0.22,0.0,0.0,0.0,0.0,0.09,charles thomas,,ECON-4400,2018
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.08,0.15,0.54,0.08,0.0,0.0,0.0,0.15,scott templeton,,ECON-4570,2018
+ECON,6060,1,Advanced Econometric,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,los santos babur de babur,,ECON-6060,2018
+ECON,8020,2,Adv Econ Concepts and Applic I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui kin,,ECON-8020,2018
+ECON,8050,1,Macroeconomic Theory,0.67,0.07,0.2,0.0,0.0,0.0,0.0,0.07,michal jerzmanowski,,ECON-8050,2018
+ECON,8070,1,Econometrics II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chungsang lam,,ECON-8070,2018
+ECON,8110,1,Econ of Environment,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,scott templeton,,ECON-8110,2018
+ECON,8200,1,Public Finance,0.1,0.8,0.0,0.0,0.0,0.0,0.0,0.1,william dougan,,ECON-8200,2018
+ECON,9090,1,Time-Series Econ,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,gerald dwyer,,ECON-9090,2018
+ECON,9820,1,Workshop in Ap Econ (Macro),0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,gerald dwyer,,ECON-9820,2018
+ED,1050,1,Educ Orientation,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,,ED-1050,2018
+ED,1050,2,Educ Orientation,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,,ED-1050,2018
+ED,8600,303,Classroom-Based Research,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,susan ridg nunamaker,,ED-8600,2018
+ED,8650,1,Curriculum Theory,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,,ED-8650,2018
+ED,8760,301,"Curric, Instruc, Assess, Learn",0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,stephanie burdette,,ED-8760,2018
+EDC,2990,1,Creative Inq in Counselor Ed,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,kend stewart-tillman,,EDC-2990,2018
+EDC,3900,2,Skills for Student Leaders,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2018
+EDC,3900,3,Skills for Student Leaders,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,eric pernotto,,EDC-3900,2018
+EDC,3900,5,Skills for Student Leaders,0.82,0.06,0.12,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2018
+EDC,3900,6,Skills for Student Leaders,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2018
+EDC,3900,7,Skills for Student Leaders,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2018
+EDC,3900,8,Skills for Student Leaders,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2018
+EDEC,3020,1,Early Childhood Practicum II,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,andrea emerson,,EDEC-3020,2018
+EDEL,3100,2,Arts in Ele School,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alison eliza leonard,,EDEL-3100,2018
+EDEL,3210,1,Pe for the Elem Tchr,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2018
+EDEL,4050,1,Soc Justice-21st Cen,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,,EDEL-4050,2018
+EDEL,4520,2,Elem Methods Math Teaching,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nicole alain sinwell,,EDEL-4520,2018
+EDEL,4870,1,Ele Meth Soc Studies,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,,EDEL-4870,2018
+EDF,3010,2,Principles of American Educ,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,amaris joseph tejada,,EDF-3010,2018
+EDF,3010,3,Principles of American Educ,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,jennifer michel hein,,EDF-3010,2018
+EDF,3020,1,Educational Psychology,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,stephen chou,,EDF-3020,2018
+EDF,3020,3,Educational Psychology,0.91,0.06,0.0,0.0,0.03,0.0,0.0,0.0,heather roge brooker,,EDF-3020,2018
+EDF,3020,4,Educational Psychology,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,heather roge brooker,,EDF-3020,2018
+EDF,3020,5,Educational Psychology,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,stephen chou,,EDF-3020,2018
+EDF,3200,1,History of US Education,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,beatrice naff bailey,,EDF-3200,2018
+EDF,3340,1,Child Growth and Development,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoob jamil,,EDF-3340,2018
+EDF,3350,1,Adolescent Growth & Develop,0.71,0.23,0.0,0.0,0.0,0.0,0.0,0.06,luke rapa,,EDF-3350,2018
+EDF,4800,1,Digital Media & Learning,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2018
+EDF,4800,300,Digital Media & Learning,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2018
+EDF,9710,400,Case Study & Ethnographic Mthd,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,reginald wilkerson,,EDF-9710,2018
+EDF,9750,501,Mixed Methods Research,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,,EDF-9750,2018
+EDHD,3110,1,CI- Research in DM & Learning,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,ryan visser,,EDHD-3110,2018
+EDHD,8310,502,Lit LOS for Child w /disab II,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,renee gatlin anders,,EDHD-8310,2018
+EDL,9750,1,College Teaching,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,,EDL-9750,2018
+EDLT,4620,2,Reading Children's Lit in Elem,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,susan king fullerton,,EDLT-4620,2018
+EDLT,4630,1,Teaching Rdg/Writing for ELLs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-4630,2018
+EDLT,4670,1,Teaching ESOL in Elem Schools,0.77,0.09,0.09,0.0,0.05,0.0,0.0,0.0,quesada hazel  vega m,,EDLT-4670,2018
+EDLT,8120,300,Assessment in Reading & Writin,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8120,2018
+EDLT,8120,500,Assessment in Reading & Writin,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8120,2018
+EDLT,8120,501,Assessment in Reading & Writin,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8120,2018
+EDLT,8220,300,Strategies for Teaching ESOL,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,mikel walker cole,,EDLT-8220,2018
+EDLT,8220,500,Strategies for Teaching ESOL,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-8220,2018
+EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,barbara fewell,,EDLT-8410,2018
+EDLT,8410,501,Early Literacy Inst Strategies,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,susanne at elvington,,EDLT-8410,2018
+EDLT,8410,502,Early Literacy Inst Strategies,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,,EDLT-8410,2018
+EDLT,8410,507,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,,EDLT-8410,2018
+EDLT,8810,501,Reading Recovery Teacher II,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,,EDLT-8810,2018
+EDLT,8830,501,Read Recovery Practicum II,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,,EDLT-8830,2018
+EDLT,8830,506,Read Recovery Practicum II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,,EDLT-8830,2018
+EDSA,8110,1,Multicultural Counseling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,,EDSA-8110,2018
+EDSC,4580,1,Sec Soc Capstone,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,,EDSC-4580,2018
+EDSP,3700,2,Intro to Special Education,0.92,0.06,0.03,0.0,0.0,0.0,0.0,0.0,shanna eisner hirsch,,EDSP-3700,2018
+EDSP,3700,4,Intro to Special Education,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,pamela stecker,,EDSP-3700,2018
+EDSP,3700,300,Intro to Special Education,0.74,0.11,0.09,0.03,0.0,0.0,0.0,0.03,shanna eisner hirsch,,EDSP-3700,2018
+EDSP,3750,1,Early Intervention Spec Needs,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,abigail anne allen,,EDSP-3750,2018
+EDSP,4910,1,Ed Assess Ind W/Dis,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,antonis katsiyannis,,EDSP-4910,2018
+EES,2020,1,Environ Engr Fundamentals II,0.67,0.24,0.06,0.0,0.03,0.0,0.0,0.0,kevin thoma finneran,,EES-2020,2018
+EES,4010,1,Environmental Engr,0.5,0.27,0.11,0.0,0.02,0.0,0.0,0.09,elizabeth carraway,,EES-4010,2018
+EES,4010,2,Environmental Engr,0.32,0.38,0.21,0.0,0.03,0.0,0.0,0.06,ezra lucas hoy cates hoy,,EES-4010,2018
+EES,4750,1,Capstone Design Project,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-4750,2018
+EES,4850,1,Hazard Waste Management,0.24,0.55,0.12,0.06,0.0,0.0,0.0,0.03,mark schlautman,,EES-4850,2018
+EES,4860,1,Environmental Sustainability,0.7,0.15,0.15,0.0,0.0,0.0,0.0,0.0,michael anthony dale,,EES-4860,2018
+EES,6110,1,Rad Detection Mmt,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,timothy devol,,EES-6110,2018
+EES,8030,1,Phy/Chem Ops W/WW T,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ezra lucas hoy cates hoy,,EES-8030,2018
+EES,8200,1,Env Systems Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michael anthony dale,,EES-8200,2018
+ELE,3010,1,Entrepreneurial Foundations,0.35,0.63,0.03,0.0,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2018
+ELE,3010,2,Entrepreneurial Foundations,0.2,0.75,0.05,0.0,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2018
+ELE,3010,3,Entrepreneurial Foundations,0.15,0.36,0.41,0.05,0.0,0.0,0.0,0.03,ashley willi parnell,,ELE-3010,2018
+ELE,4010,1,Venture Testing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,chad navis,,ELE-4010,2018
+ELE,4010,2,Venture Testing,0.65,0.27,0.08,0.0,0.0,0.0,0.0,0.0,chad navis,,ELE-4010,2018
+ELE,4020,1,Venture Creation,0.32,0.59,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,,ELE-4020,2018
+ELE,4030,1,Venture Growth,0.1,0.47,0.4,0.03,0.0,0.0,0.0,0.0,ashley willi parnell,,ELE-4030,2018
+ENGL,1030,1,Composition and Rhetoric,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,,ENGL-1030,2018
+ENGL,1030,2,Composition and Rhetoric,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,jennie eli wakefield,,ENGL-1030,2018
+ENGL,1030,3,Composition and Rhetoric,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,carley ama robertson,,ENGL-1030,2018
+ENGL,1030,4,Composition and Rhetoric,0.47,0.27,0.07,0.0,0.13,0.0,0.0,0.07,carley ama robertson,,ENGL-1030,2018
+ENGL,1030,5,Composition and Rhetoric,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,jennie eli wakefield,,ENGL-1030,2018
+ENGL,1030,6,Composition and Rhetoric,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,jennie eli wakefield,,ENGL-1030,2018
+ENGL,1030,7,Composition and Rhetoric,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,courtne huff-oelberg,,ENGL-1030,2018
+ENGL,1030,8,Composition and Rhetoric,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,courtne huff-oelberg,,ENGL-1030,2018
+ENGL,1030,9,Composition and Rhetoric,0.6,0.2,0.0,0.0,0.13,0.0,0.0,0.07,carrie hill,,ENGL-1030,2018
+ENGL,1030,10,Composition and Rhetoric,0.5,0.33,0.0,0.0,0.06,0.0,0.0,0.11,carrie hill,,ENGL-1030,2018
+ENGL,1030,12,Composition and Rhetoric,0.76,0.14,0.0,0.0,0.1,0.0,0.0,0.0,michael david measel,,ENGL-1030,2018
+ENGL,1030,13,Composition and Rhetoric,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,sarah eli richardson,,ENGL-1030,2018
+ENGL,1030,14,Composition and Rhetoric,0.81,0.0,0.05,0.05,0.05,0.0,0.0,0.05,sarah eli richardson,,ENGL-1030,2018
+ENGL,1030,15,Composition and Rhetoric,0.5,0.17,0.06,0.0,0.17,0.0,0.0,0.11,abigail maxim,,ENGL-1030,2018
+ENGL,1030,19,Composition and Rhetoric,0.86,0.05,0.0,0.1,0.0,0.0,0.0,0.0,martha sue karnes,,ENGL-1030,2018
+ENGL,1030,20,Composition and Rhetoric,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,martha sue karnes,,ENGL-1030,2018
+ENGL,1030,21,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,sarah margare carter,,ENGL-1030,2018
+ENGL,1030,22,Composition and Rhetoric,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,sarah margare carter,,ENGL-1030,2018
+ENGL,1030,26,Composition and Rhetoric,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-1030,2018
+ENGL,1030,28,Composition and Rhetoric,0.48,0.43,0.05,0.0,0.05,0.0,0.0,0.0,allen swords,,ENGL-1030,2018
+ENGL,1030,36,Composition and Rhetoric,0.71,0.1,0.1,0.0,0.05,0.0,0.0,0.05,david charles foltz,,ENGL-1030,2018
+ENGL,1030,37,Composition and Rhetoric,0.7,0.15,0.0,0.0,0.05,0.0,0.0,0.1,michelle lloyd,,ENGL-1030,2018
+ENGL,1030,38,Composition and Rhetoric,0.5,0.35,0.0,0.0,0.1,0.0,0.0,0.05,michelle lloyd,,ENGL-1030,2018
+ENGL,1030,39,Composition and Rhetoric,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,john conway,,ENGL-1030,2018
+ENGL,1030,41,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,,ENGL-1030,2018
+ENGL,1030,42,Composition and Rhetoric,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,caroline eliza young,,ENGL-1030,2018
+ENGL,1030,43,Composition and Rhetoric,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,,ENGL-1030,2018
+ENGL,1030,44,Composition and Rhetoric,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,caroline eliza young,,ENGL-1030,2018
+ENGL,1030,45,Composition and Rhetoric,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,beltran dian quaglia,,ENGL-1030,2018
+ENGL,1030,46,Composition and Rhetoric,0.86,0.09,0.0,0.0,0.05,0.0,0.0,0.0,beltran dian quaglia,,ENGL-1030,2018
+ENGL,1030,47,Composition and Rhetoric,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,jane elizabe kuebler,,ENGL-1030,2018
+ENGL,1030,48,Composition and Rhetoric,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jane elizabe kuebler,,ENGL-1030,2018
+ENGL,1030,49,Composition and Rhetoric,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,charlotte este lucke,,ENGL-1030,2018
+ENGL,1030,52,Composition and Rhetoric,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,gabrielle gra nugent,,ENGL-1030,2018
+ENGL,1030,53,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,,ENGL-1030,2018
+ENGL,1030,54,Composition and Rhetoric,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,valerie smith,,ENGL-1030,2018
+ENGL,1030,56,Composition and Rhetoric,0.53,0.33,0.0,0.0,0.13,0.0,0.0,0.0,daniel quin atkinson,,ENGL-1030,2018
+ENGL,1030,57,Composition and Rhetoric,0.81,0.0,0.0,0.06,0.0,0.0,0.0,0.13,christopher stuart,,ENGL-1030,2018
+ENGL,1030,58,Composition and Rhetoric,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.1,christopher stuart,,ENGL-1030,2018
+ENGL,1030,60,Composition and Rhetoric,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,stephen hundley,,ENGL-1030,2018
+ENGL,1030,61,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,austin gorman,,ENGL-1030,2018
+ENGL,1030,62,Composition and Rhetoric,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,michael russo,,ENGL-1030,2018
+ENGL,1030,63,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,,ENGL-1030,2018
+ENGL,1030,64,Composition and Rhetoric,0.61,0.11,0.17,0.0,0.11,0.0,0.0,0.0,shauna chung,,ENGL-1030,2018
+ENGL,1030,66,Composition and Rhetoric,0.8,0.0,0.07,0.0,0.07,0.0,0.0,0.07,victoria houser,,ENGL-1030,2018
+ENGL,1030,67,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,,ENGL-1030,2018
+ENGL,1030,400,Composition and Rhetoric,0.52,0.43,0.0,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,,ENGL-1030,2018
+ENGL,1030,401,Composition and Rhetoric,0.61,0.17,0.11,0.0,0.06,0.0,0.0,0.06,la'cresha ulon green,,ENGL-1030,2018
+ENGL,1030,555,Composition and Rhetoric,0.5,0.43,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth steedley,,ENGL-1030,2018
+ENGL,2020,500,The Major Forms of Literature,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,,ENGL-2020,2018
+ENGL,2120,1,World Literature,0.11,0.36,0.39,0.11,0.0,0.0,0.0,0.04,david charles foltz,,ENGL-2120,2018
+ENGL,2120,2,World Literature,0.25,0.36,0.25,0.0,0.04,0.0,0.0,0.11,david charles foltz,,ENGL-2120,2018
+ENGL,2120,3,World Literature,0.7,0.2,0.07,0.03,0.0,0.0,0.0,0.0,allison nicol harris,,ENGL-2120,2018
+ENGL,2120,4,World Literature,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,allison nicol harris,,ENGL-2120,2018
+ENGL,2120,5,World Literature,0.48,0.34,0.14,0.0,0.0,0.0,0.0,0.03,allison nicol harris,,ENGL-2120,2018
+ENGL,2120,6,World Literature,0.48,0.34,0.1,0.0,0.03,0.0,0.0,0.03,allison nicol harris,,ENGL-2120,2018
+ENGL,2120,7,World Literature,0.46,0.35,0.04,0.0,0.0,0.0,0.0,0.15,remley meliss makala,,ENGL-2120,2018
+ENGL,2120,8,World Literature,0.48,0.19,0.11,0.07,0.04,0.0,0.0,0.11,remley meliss makala,,ENGL-2120,2018
+ENGL,2120,9,World Literature,0.38,0.31,0.14,0.03,0.0,0.0,0.0,0.14,karen kettnich,,ENGL-2120,2018
+ENGL,2120,10,World Literature,0.59,0.31,0.03,0.0,0.03,0.0,0.0,0.03,karen kettnich,,ENGL-2120,2018
+ENGL,2120,12,World Literature,0.45,0.41,0.1,0.0,0.0,0.0,0.0,0.03,sharon kathle nalley,,ENGL-2120,2018
+ENGL,2120,13,World Literature,0.14,0.64,0.14,0.0,0.07,0.0,0.0,0.0,sarah mae cooper,,ENGL-2120,2018
+ENGL,2120,14,World Literature,0.24,0.48,0.17,0.0,0.0,0.0,0.0,0.1,sarah mae cooper,,ENGL-2120,2018
+ENGL,2120,15,World Literature,0.48,0.38,0.1,0.03,0.0,0.0,0.0,0.0,sharon kathle nalley,,ENGL-2120,2018
+ENGL,2120,16,World Literature,0.27,0.43,0.2,0.0,0.1,0.0,0.0,0.0,andrew mathas,,ENGL-2120,2018
+ENGL,2120,17,World Literature,0.46,0.25,0.18,0.04,0.04,0.0,0.0,0.04,andrew mathas,,ENGL-2120,2018
+ENGL,2120,18,World Literature,0.47,0.37,0.1,0.0,0.0,0.0,0.0,0.07,chloe miche whitaker,,ENGL-2120,2018
+ENGL,2120,19,World Literature,0.53,0.33,0.0,0.0,0.03,0.0,0.0,0.1,chloe miche whitaker,,ENGL-2120,2018
+ENGL,2120,20,World Literature,0.33,0.44,0.19,0.0,0.0,0.0,0.0,0.04,julia brownlee koets,,ENGL-2120,2018
+ENGL,2120,21,World Literature,0.24,0.68,0.08,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,,ENGL-2120,2018
+ENGL,2120,22,World Literature,0.24,0.52,0.07,0.07,0.07,0.0,0.0,0.03,hannah pittma godwin,,ENGL-2120,2018
+ENGL,2120,23,World Literature,0.41,0.41,0.1,0.03,0.03,0.0,0.0,0.0,hannah pittma godwin,,ENGL-2120,2018
+ENGL,2120,24,World Literature,0.59,0.1,0.14,0.03,0.07,0.0,0.0,0.07,heather pri williams,,ENGL-2120,2018
+ENGL,2130,1,British Literature,0.41,0.48,0.0,0.0,0.0,0.0,0.0,0.1,christopher benson,,ENGL-2130,2018
+ENGL,2130,2,British Literature,0.6,0.3,0.0,0.03,0.03,0.0,0.0,0.03,christopher benson,,ENGL-2130,2018
+ENGL,2130,3,British Literature,0.45,0.34,0.14,0.03,0.03,0.0,0.0,0.0,megan noe macalystre,,ENGL-2130,2018
+ENGL,2130,4,British Literature,0.3,0.4,0.1,0.03,0.07,0.0,0.0,0.1,megan noe macalystre,,ENGL-2130,2018
+ENGL,2130,5,British Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2018
+ENGL,2130,6,British Literature,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2018
+ENGL,2130,7,British Literature,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2018
+ENGL,2130,8,British Literature,0.43,0.47,0.07,0.0,0.0,0.0,0.0,0.03,lucian ghita,,ENGL-2130,2018
+ENGL,2130,9,British Literature,0.3,0.37,0.1,0.2,0.03,0.0,0.0,0.0,megan noe macalystre,,ENGL-2130,2018
+ENGL,2130,10,British Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2130,2018
+ENGL,2130,11,British Literature,0.57,0.37,0.03,0.0,0.03,0.0,0.0,0.0,chloe miche whitaker,,ENGL-2130,2018
+ENGL,2130,12,British Literature,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,chloe miche whitaker,,ENGL-2130,2018
+ENGL,2130,13,British Literature,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2130,2018
+ENGL,2140,1,American Literature,0.76,0.17,0.03,0.03,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2018
+ENGL,2140,2,American Literature,0.77,0.13,0.07,0.0,0.03,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2018
+ENGL,2140,3,American Literature,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,lindsay kathl turner,,ENGL-2140,2018
+ENGL,2140,4,American Literature,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.07,lindsay kathl turner,,ENGL-2140,2018
+ENGL,2140,5,American Literature,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,melissa dugan,,ENGL-2140,2018
+ENGL,2140,6,American Literature,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2018
+ENGL,2140,9,American Literature,0.55,0.24,0.14,0.07,0.0,0.0,0.0,0.0,jennifer ha forsberg,,ENGL-2140,2018
+ENGL,2140,10,American Literature,0.52,0.34,0.1,0.0,0.03,0.0,0.0,0.0,jennifer ha forsberg,,ENGL-2140,2018
+ENGL,2140,11,American Literature,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2018
+ENGL,2140,12,American Literature,0.6,0.33,0.03,0.03,0.0,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2018
+ENGL,2140,13,American Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2140,2018
+ENGL,2140,14,American Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2140,2018
+ENGL,2140,15,American Literature,0.7,0.11,0.07,0.0,0.04,0.0,0.0,0.07,erin nicholson gale,,ENGL-2140,2018
+ENGL,2140,16,American Literature,0.7,0.2,0.03,0.07,0.0,0.0,0.0,0.0,erin nicholson gale,,ENGL-2140,2018
+ENGL,2140,17,American Literature,0.4,0.33,0.17,0.03,0.07,0.0,0.0,0.0,hannah pittma godwin,,ENGL-2140,2018
+ENGL,2140,18,American Literature,0.37,0.4,0.1,0.0,0.07,0.0,0.0,0.07,hannah pittma godwin,,ENGL-2140,2018
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.21,0.48,0.17,0.03,0.1,0.0,0.0,0.0,chelsea marie clarey,,ENGL-2150,2018
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.2,0.43,0.27,0.0,0.07,0.0,0.0,0.03,chelsea marie clarey,,ENGL-2150,2018
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.31,0.34,0.21,0.07,0.07,0.0,0.0,0.0,chelsea marie clarey,,ENGL-2150,2018
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.34,0.28,0.24,0.0,0.07,0.0,0.0,0.07,chelsea marie clarey,,ENGL-2150,2018
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.46,0.32,0.11,0.0,0.0,0.0,0.0,0.11,david charles foltz,,ENGL-2150,2018
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.41,0.41,0.1,0.0,0.0,0.0,0.0,0.07,david charles foltz,,ENGL-2150,2018
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.67,0.27,0.0,0.0,0.03,0.0,0.0,0.03,remley meliss makala,,ENGL-2150,2018
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.47,0.33,0.07,0.0,0.0,0.0,0.0,0.13,remley meliss makala,,ENGL-2150,2018
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.23,0.17,0.03,0.0,0.0,0.0,0.03,john logan pursley,,ENGL-2150,2018
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.37,0.33,0.17,0.07,0.0,0.0,0.0,0.07,elizabeth stansell,,ENGL-2150,2018
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.73,0.1,0.1,0.0,0.0,0.0,0.0,0.07,jennifer ha forsberg,,ENGL-2150,2018
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,,ENGL-2150,2018
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.2,0.7,0.07,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,,ENGL-2150,2018
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.26,0.67,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2150,2018
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.4,0.3,0.17,0.07,0.03,0.0,0.0,0.03,andrew mathas,,ENGL-2150,2018
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.63,0.2,0.07,0.0,0.07,0.0,0.0,0.03,andrew mathas,,ENGL-2150,2018
+ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.57,0.18,0.14,0.0,0.04,0.0,0.0,0.07,candace wiley,,ENGL-2150,2018
+ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.73,0.04,0.04,0.0,0.0,0.0,0.0,0.19,candace wiley,,ENGL-2150,2018
+ENGL,3010,1,Great Books of Western World,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-3010,2018
+ENGL,3040,1,Business Writing,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,sean williams,,ENGL-3040,2018
+ENGL,3040,2,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,,ENGL-3040,2018
+ENGL,3040,3,Business Writing,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,,ENGL-3040,2018
+ENGL,3040,4,Business Writing,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulon green,,ENGL-3040,2018
+ENGL,3040,5,Business Writing,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulon green,,ENGL-3040,2018
+ENGL,3040,6,Business Writing,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,la'cresha ulon green,,ENGL-3040,2018
+ENGL,3040,7,Business Writing,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,,ENGL-3040,2018
+ENGL,3040,8,Business Writing,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,,ENGL-3040,2018
+ENGL,3040,9,Business Writing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3040,2018
+ENGL,3040,10,Business Writing,0.48,0.38,0.05,0.0,0.1,0.0,0.0,0.0,katalin beck,,ENGL-3040,2018
+ENGL,3040,12,Business Writing,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,stephen quigley,,ENGL-3040,2018
+ENGL,3040,400,Business Writing,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,,ENGL-3040,2018
+ENGL,3040,401,Business Writing,0.5,0.35,0.15,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,,ENGL-3040,2018
+ENGL,3040,402,Business Writing,0.63,0.16,0.11,0.05,0.0,0.0,0.0,0.05,kriste aldebol-hazle,,ENGL-3040,2018
+ENGL,3040,403,Business Writing,0.6,0.25,0.05,0.05,0.05,0.0,0.0,0.0,kriste aldebol-hazle,,ENGL-3040,2018
+ENGL,3100,1,Crit Writ Lit,0.25,0.44,0.31,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-3100,2018
+ENGL,3100,2,Crit Writ Lit,0.24,0.47,0.18,0.06,0.06,0.0,0.0,0.0,lee morrissey,,ENGL-3100,2018
+ENGL,3100,3,Crit Writ Lit,0.33,0.38,0.14,0.0,0.05,0.0,0.0,0.1,dominic mastroianni,,ENGL-3100,2018
+ENGL,3100,4,Crit Writ Lit,0.4,0.45,0.1,0.0,0.0,0.0,0.0,0.05,erin marina goss,,ENGL-3100,2018
+ENGL,3120,1,Advanced Composition,0.38,0.57,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,,ENGL-3120,2018
+ENGL,3120,2,Advanced Composition,0.57,0.38,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth stansell,,ENGL-3120,2018
+ENGL,3140,1,Technical Writing,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2018
+ENGL,3140,2,Technical Writing,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-3140,2018
+ENGL,3140,3,Technical Writing,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,eric stephens,,ENGL-3140,2018
+ENGL,3140,4,Technical Writing,0.81,0.14,0.0,0.05,0.0,0.0,0.0,0.0,eric stephens,,ENGL-3140,2018
+ENGL,3140,5,Technical Writing,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,heather pri williams,,ENGL-3140,2018
+ENGL,3140,9,Technical Writing,0.57,0.33,0.0,0.05,0.05,0.0,0.0,0.0,geveryl lee robinson,,ENGL-3140,2018
+ENGL,3140,10,Technical Writing,0.38,0.57,0.0,0.0,0.0,0.0,0.0,0.05,geveryl lee robinson,,ENGL-3140,2018
+ENGL,3140,11,Technical Writing,0.35,0.6,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2018
+ENGL,3140,12,Technical Writing,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,katalin beck,,ENGL-3140,2018
+ENGL,3140,14,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,samuel jackso fuller,,ENGL-3140,2018
+ENGL,3140,15,Technical Writing,0.71,0.19,0.05,0.05,0.0,0.0,0.0,0.0,brian lee gaines,,ENGL-3140,2018
+ENGL,3140,16,Technical Writing,0.81,0.1,0.0,0.0,0.05,0.0,0.0,0.05,brian lee gaines,,ENGL-3140,2018
+ENGL,3140,20,Technical Writing,0.71,0.14,0.1,0.05,0.0,0.0,0.0,0.0,sharon kathle nalley,,ENGL-3140,2018
+ENGL,3140,21,Technical Writing,0.86,0.05,0.0,0.05,0.05,0.0,0.0,0.0,joshua wood,,ENGL-3140,2018
+ENGL,3140,23,Technical Writing,0.52,0.19,0.14,0.05,0.0,0.0,0.0,0.1,heather pri williams,,ENGL-3140,2018
+ENGL,3140,24,Technical Writing,0.05,0.24,0.19,0.1,0.19,0.0,0.0,0.24,geveryl lee robinson,,ENGL-3140,2018
+ENGL,3140,400,Technical Writing,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,,ENGL-3140,2018
+ENGL,3150,1,Scientific Writing & Comm,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,philip randall,,ENGL-3150,2018
+ENGL,3150,2,Scientific Writing & Comm,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,,ENGL-3150,2018
+ENGL,3150,3,Scientific Writing & Comm,0.38,0.48,0.1,0.05,0.0,0.0,0.0,0.0,william pulley,,ENGL-3150,2018
+ENGL,3150,4,Scientific Writing & Comm,0.53,0.24,0.0,0.06,0.06,0.0,0.0,0.12,william pulley,,ENGL-3150,2018
+ENGL,3150,400,Scientific Writing,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,,ENGL-3150,2018
+ENGL,3150,401,Scientific Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2018
+ENGL,3150,402,Scientific Writing & Comm,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,john conway,,ENGL-3150,2018
+ENGL,3150,404,Scientific Writing,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,philip randall,,ENGL-3150,2018
+ENGL,3320,1,Visual Communication,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,megan eatman,,ENGL-3320,2018
+ENGL,3450,1,Structure of Fiction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-3450,2018
+ENGL,3460,1,Structure of Poetry,0.5,0.38,0.06,0.0,0.0,0.0,0.0,0.06,jillian weise,,ENGL-3460,2018
+ENGL,3480,1,Structure Screenplay,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,julia brownlee koets,,ENGL-3480,2018
+ENGL,3480,2,Structure Screenplay,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,,ENGL-3480,2018
+ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,matthew hooley,,ENGL-3530,2018
+ENGL,3570,1,Film,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,john robert smith,,ENGL-3570,2018
+ENGL,3570,2,Film,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,john robert smith,,ENGL-3570,2018
+ENGL,3570,3,Film,0.62,0.33,0.0,0.0,0.05,0.0,0.0,0.0,john robert smith,,ENGL-3570,2018
+ENGL,3860,1,Adolescent Lit,0.56,0.28,0.06,0.06,0.06,0.0,0.0,0.0,megan noe macalystre,,ENGL-3860,2018
+ENGL,3970,1,Brit Lit Survey II,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,,ENGL-3970,2018
+ENGL,3980,1,Amer Lit Survey I,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,kimberly manganelli,,ENGL-3980,2018
+ENGL,3980,2,Amer Lit Survey I,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,susanna ashton,,ENGL-3980,2018
+ENGL,4110,1,Shakespeare,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,brian mcgrath,,ENGL-4110,2018
+ENGL,4110,3,Shakespeare,0.25,0.4,0.3,0.05,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4110,2018
+ENGL,4160,1,Romantic Period,0.36,0.21,0.21,0.21,0.0,0.0,0.0,0.0,brian mcgrath,,ENGL-4160,2018
+ENGL,4180,1,English Novel,0.42,0.37,0.11,0.0,0.11,0.0,0.0,0.0,david sweeney coombs,,ENGL-4180,2018
+ENGL,4190,1,Post Col & World Lit,0.4,0.47,0.07,0.07,0.0,0.0,0.0,0.0,cameron fae bushnell,,ENGL-4190,2018
+ENGL,4210,1,Amer Lit 1800-1899,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,dominic mastroianni,,ENGL-4210,2018
+ENGL,4280,1,Contemporary Literature,0.53,0.16,0.26,0.0,0.05,0.0,0.0,0.0,william stockton,,ENGL-4280,2018
+ENGL,4400,1,Literary Theory,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,maria selene bose,,ENGL-4400,2018
+ENGL,4420,1,Cultural Studies,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,,ENGL-4420,2018
+ENGL,4450,1,Fiction Workshop,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-4450,2018
+ENGL,4460,1,Poetry Workshop,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,jillian weise,,ENGL-4460,2018
+ENGL,4510,1,Film Theory and Criticism,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,,ENGL-4510,2018
+ENGL,4540,1,Sel Top in International Film,0.47,0.33,0.13,0.07,0.0,0.0,0.0,0.0,agnieszka skrodzka,,ENGL-4540,2018
+ENGL,4590,1,Between Damaged Life/Arcades,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,michelle renee ty,,ENGL-4590,2018
+ENGL,4640,1,Topics in Literature 1700-1899,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,erin marina goss,,ENGL-4640,2018
+ENGL,4750,1,Writing for Media,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,gabriel ande hankins,,ENGL-4750,2018
+ENGL,4850,1,Comp & Lang Teachers,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,calandra harri davis,,ENGL-4850,2018
+ENGL,4890,1,Topics Write & Publ,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,tharon howard,,ENGL-4890,2018
+ENGL,4920,1,Modern Rhetoric,0.59,0.24,0.06,0.06,0.0,0.0,0.0,0.06,michelle smith,,ENGL-4920,2018
+ENGL,4960,1,Senior Seminar,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,angela naimou,,ENGL-4960,2018
+ENGL,4960,2,Senior Seminar,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,michael lemahieu,,ENGL-4960,2018
+ENGL,4960,3,Senior Seminar,0.69,0.08,0.0,0.23,0.0,0.0,0.0,0.0,michelle renee ty,,ENGL-4960,2018
+ENGL,8850,1,Composition Theory,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,megan eatman,,ENGL-8850,2018
+ENGR,1020,211,Engineering Discipl & Skills,0.08,0.29,0.25,0.13,0.17,0.0,0.0,0.08,ashley childers,,ENGR-1020,2018
+ENGR,1020,212,Engineering Discipl & Skills,0.1,0.33,0.2,0.3,0.03,0.0,0.0,0.03,ashley childers,,ENGR-1020,2018
+ENGR,1020,213,Engineering Discipl & Skills,0.28,0.28,0.16,0.13,0.06,0.0,0.0,0.09,irene marie ferrara,,ENGR-1020,2018
+ENGR,1020,214,Engineering Discipl & Skills,0.38,0.23,0.19,0.04,0.15,0.0,0.0,0.0,irene marie ferrara,,ENGR-1020,2018
+ENGR,1150,321,Engineering Design & Modeling,0.41,0.36,0.05,0.05,0.09,0.0,0.0,0.05,john minor,,ENGR-1150,2018
+ENGR,1410,215,Programming & Problem Solving,0.3,0.43,0.09,0.04,0.04,0.0,0.0,0.11,jonathan broo harcum,,ENGR-1410,2018
+ENGR,1410,322,Programming & Problem Solving,0.37,0.3,0.2,0.04,0.0,0.0,0.0,0.09,michael giebner,,ENGR-1410,2018
+ENGR,1410,323,Programming & Problem Solving,0.2,0.43,0.15,0.13,0.0,0.0,0.0,0.09,michael giebner,,ENGR-1410,2018
+ENGR,1410,324,Programming & Problem Solving,0.2,0.58,0.09,0.02,0.02,0.0,0.0,0.09,andrew isaac neptune,,ENGR-1410,2018
+ENGR,1410,325,Programming & Problem Solving,0.38,0.38,0.15,0.02,0.0,0.0,0.0,0.08,andrew isaac neptune,,ENGR-1410,2018
+ENGR,1410,326,Programming & Problem Solving,0.26,0.44,0.16,0.05,0.0,0.0,0.0,0.09,jonathan broo harcum,,ENGR-1410,2018
+ENGR,1410,327,Programming & Problem Solving,0.22,0.5,0.2,0.02,0.02,0.0,0.0,0.04,irene marie ferrara,,ENGR-1410,2018
+ENGR,1410,501,Programming & Problem Solving,0.21,0.29,0.32,0.18,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1410,2018
+ENGR,1410,621,Programming & Problem Solving,0.43,0.43,0.12,0.0,0.0,0.0,0.0,0.02,elizabeth an stephan,,ENGR-1410,2018
+ENGR,1410,622,Programming & Problem Solving,0.26,0.55,0.14,0.0,0.0,0.0,0.0,0.05,jonathan broo harcum,,ENGR-1410,2018
+ENGR,1410,623,Programming & Problem Solving,0.08,0.58,0.26,0.03,0.0,0.0,0.0,0.05,elizabeth an stephan,,ENGR-1410,2018
+ENGR,1410,624,Programming & Problem Solving,0.3,0.53,0.02,0.07,0.02,0.0,0.0,0.05,sarah grigg,,ENGR-1410,2018
+ENGR,1410,625,Programming & Problem Solving,0.3,0.41,0.2,0.07,0.02,0.0,0.0,0.0,matthew kent miller,,ENGR-1410,2018
+ENGR,1410,626,Programming & Problem Solving,0.14,0.48,0.24,0.05,0.0,0.0,0.0,0.1,matthew kent miller,,ENGR-1410,2018
+ENGR,1410,627,Programming & Problem Solving,0.29,0.48,0.19,0.05,0.0,0.0,0.0,0.0,matthew kent miller,,ENGR-1410,2018
+ENGR,1410,821,Programming & Problem Solving,0.31,0.33,0.17,0.1,0.05,0.0,0.0,0.05,william martin,,ENGR-1410,2018
+ENGR,1410,822,Programming & Problem Solving,0.33,0.45,0.14,0.02,0.02,0.0,0.0,0.02,william martin,,ENGR-1410,2018
+ENGR,1410,823,Program & Prob Solving (HON),0.72,0.26,0.0,0.02,0.0,0.0,0.0,0.0,steven brandon,True,ENGR-1410,2018
+ENGR,1410,824,Program & Prob Solving (HON),0.65,0.24,0.08,0.0,0.0,0.0,0.0,0.03,steven brandon,True,ENGR-1410,2018
+ENGR,1410,825,Programming & Problem Solving,0.23,0.45,0.2,0.0,0.07,0.0,0.0,0.05,mariah so magagnotti,,ENGR-1410,2018
+ENGR,1410,826,Programming & Problem Solving,0.24,0.33,0.29,0.04,0.04,0.0,0.0,0.04,mariah so magagnotti,,ENGR-1410,2018
+ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.2,0.0,0.0,0.0,0.0,0.07,andrew isaac neptune,,ENGR-1410,2018
+ENGR,1900,10,CI in Engr I (Robotics),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael benja wooten,,ENGR-1900,2018
+ENGR,2080,284,Engr Graphics & Machine Design,0.56,0.21,0.15,0.04,0.0,0.0,0.0,0.04,jonathan maier,,ENGR-2080,2018
+ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.25,0.08,0.0,0.06,0.0,0.0,0.04,anthony paul garland,,ENGR-2080,2018
+ENGR,2080,286,Engr Graphics & Machine Design,0.4,0.25,0.13,0.06,0.06,0.0,0.0,0.1,anthony paul garland,,ENGR-2080,2018
+ENGR,2080,382,Engr Graphics & Machine Design,0.6,0.25,0.04,0.02,0.08,0.0,0.0,0.02,nighat yasmin,,ENGR-2080,2018
+ENGR,2080,384,Engr Graphics & Machine Design,0.54,0.21,0.08,0.06,0.12,0.0,0.0,0.0,jonathan maier,,ENGR-2080,2018
+ENGR,2080,682,Engr Graphics & Machine Design,0.63,0.29,0.06,0.0,0.02,0.0,0.0,0.0,anthony paul garland,,ENGR-2080,2018
+ENGR,2080,684,Engr Graphics & Machine Design,0.58,0.27,0.04,0.02,0.06,0.0,0.0,0.02,john minor,,ENGR-2080,2018
+ENGR,2080,882,Engr Graphics & Machine Design,0.74,0.19,0.0,0.02,0.04,0.0,0.0,0.02,garrison lloy broome,,ENGR-2080,2018
+ENGR,2080,884,Engr Graphics & Machine Design,0.49,0.31,0.1,0.02,0.04,0.0,0.0,0.04,garrison lloy broome,,ENGR-2080,2018
+ENGR,2100,104,CAD & Engineering Applications,0.48,0.38,0.06,0.02,0.02,0.0,0.0,0.04,esfandabadi al shams,,ENGR-2100,2018
+ENGR,2100,105,CAD & Engineering Applications,0.45,0.36,0.11,0.0,0.04,0.0,0.0,0.04,esfandabadi al shams,,ENGR-2100,2018
+ENGR,2100,201,CAD & Engineering Applications,0.44,0.35,0.16,0.02,0.02,0.0,0.0,0.02,nighat yasmin,,ENGR-2100,2018
+ENGR,2100,202,CAD & Engineering Applications,0.41,0.3,0.07,0.04,0.11,0.0,0.0,0.07,nighat yasmin,,ENGR-2100,2018
+ENGR,2200,116,Evaluating Innovations,0.4,0.48,0.04,0.04,0.0,0.0,0.0,0.04,sarah grigg,,ENGR-2200,2018
+ENGR,2200,117,Evaluating Innovations,0.32,0.48,0.13,0.03,0.0,0.0,0.0,0.03,sarah grigg,,ENGR-2200,2018
+ENR,1020,1,Intro to Envir & Natur Res II,0.72,0.11,0.06,0.04,0.0,0.0,0.0,0.06,russell barrett,,ENR-1020,2018
+ENR,3020,1,Nat Res Measurements,0.62,0.21,0.13,0.0,0.0,0.0,0.0,0.05,lawrence gering,,ENR-3020,2018
+ENR,4130,2,Restoration Ecology,0.28,0.5,0.19,0.0,0.0,0.0,0.0,0.03,althea simone hagan,,ENR-4130,2018
+ENR,4500,1,Conservation Issues,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,alan johnson,,ENR-4500,2018
+ENR,4500,2,Conservation Issues,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,,ENR-4500,2018
+ENR,6130,2,Restoration Ecology,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,althea simone hagan,,ENR-6130,2018
+ENSP,2000,1,Intro Environ Sci,0.36,0.44,0.11,0.05,0.02,0.0,0.0,0.02,tom owino,,ENSP-2000,2018
+ENSP,2000,2,Intro Environ Sci,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,ENSP-2000,2018
+ENSP,2000,3,Intro Environ Sci,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2018
+ENSP,2000,4,Intro Environ Sci,0.59,0.22,0.13,0.02,0.04,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2018
+ENSP,2010,1,Environm Sci for Educ Majors,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2010,2018
+ENSP,4000,1,Studies in Environmental Sci,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,margaret lo thompson,,ENSP-4000,2018
+ENT,2000,1,Six-Legged Science,0.47,0.3,0.14,0.09,0.0,0.0,0.0,0.0,suellen pometto,,ENT-2000,2018
+ENTR,1010,1,Entrepreneurial Mindset,0.72,0.11,0.07,0.01,0.05,0.0,0.0,0.04,john michael hannon,,ENTR-1010,2018
+ENTR,1090,1,CI- How to Start a Startup,0.81,0.05,0.0,0.0,0.0,0.0,0.0,0.14,john michael hannon,,ENTR-1090,2018
+ENTR,2010,3,Sports Entrepreneurship,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,,ENTR-2010,2018
+ESED,1990,1,Creative Inq Engr & Sci Ed I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,claire louise dancz,,ESED-1990,2018
+ESED,2990,1,Creative Inq Engr & Sci Ed II,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,claire louise dancz,,ESED-2990,2018
+ESED,4910,5,Undergraduate Research,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,claire louise dancz,,ESED-4910,2018
+ETOX,8300,1,Mechanistic Toxicology,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,,ETOX-8300,2018
+FDSC,2140,1,Fd Resources & Soc,0.62,0.18,0.1,0.0,0.04,0.0,0.0,0.06,paul dawson,,FDSC-2140,2018
+FDSC,2150,1,Culinary Fundamental,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,,FDSC-2150,2018
+FDSC,3040,1,Eval Dairy Products,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-3040,2018
+FDSC,4020,1,Food Chemistry II,0.32,0.49,0.12,0.07,0.0,0.0,0.0,0.0,feng chen,,FDSC-4020,2018
+FDSC,4030,1,Food Ch & Analysis,0.74,0.13,0.11,0.0,0.0,0.0,0.0,0.02,paul dawson,,FDSC-4030,2018
+FDSC,4080,1,Food Process Eng,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,felix barron,,FDSC-4080,2018
+FDSC,4090,1,TQM for Food & Pckg Industries,0.61,0.18,0.06,0.09,0.0,0.0,0.0,0.06,john mcgregor,,FDSC-4090,2018
+FDSC,4100,1,Food Product Dev,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,margaret condrasky,,FDSC-4100,2018
+FDSC,4170,1,Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,,FDSC-4170,2018
+FIN,2010,401,Intro to Personal Finance,0.92,0.06,0.0,0.0,0.02,0.0,0.0,0.0,joshua harris,,FIN-2010,2018
+FIN,2010,402,Intro to Personal Finance,0.87,0.11,0.0,0.02,0.0,0.0,0.0,0.0,joshua harris,,FIN-2010,2018
+FIN,2010,403,Intro to Personal Finance,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,joshua harris,,FIN-2010,2018
+FIN,2010,404,Intro to Personal Finance,0.79,0.12,0.04,0.01,0.01,0.0,0.0,0.01,joshua harris,,FIN-2010,2018
+FIN,2010,405,Intro to Personal Finance,0.75,0.15,0.06,0.0,0.02,0.0,0.0,0.02,joshua harris,,FIN-2010,2018
+FIN,2010,406,Intro to Personal Finance,0.76,0.13,0.02,0.02,0.0,0.0,0.0,0.07,joshua harris,,FIN-2010,2018
+FIN,3040,1,Risk & Insurance,0.22,0.3,0.48,0.0,0.0,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2018
+FIN,3050,1,Investment Analysis,0.11,0.36,0.39,0.04,0.04,0.0,0.0,0.07,kerri mcmillan,,FIN-3050,2018
+FIN,3050,2,Investment Analysis,0.26,0.37,0.26,0.08,0.0,0.0,0.0,0.03,kerri mcmillan,,FIN-3050,2018
+FIN,3050,3,Investment Analysis,0.15,0.33,0.48,0.0,0.03,0.0,0.0,0.0,kerri mcmillan,,FIN-3050,2018
+FIN,3050,4,Investment Analysis,0.15,0.15,0.32,0.24,0.03,0.0,0.0,0.12,john alexander,,FIN-3050,2018
+FIN,3060,1,Corporation Finance,0.2,0.14,0.2,0.2,0.2,0.0,0.0,0.08,william holl johnson,,FIN-3060,2018
+FIN,3060,2,Corporation Finance,0.37,0.08,0.21,0.21,0.06,0.0,0.0,0.08,william holl johnson,,FIN-3060,2018
+FIN,3060,3,Corporation Finance,0.37,0.2,0.1,0.12,0.12,0.0,0.0,0.08,william holl johnson,,FIN-3060,2018
+FIN,3060,4,Corporation Finance,0.1,0.18,0.16,0.14,0.22,0.0,0.0,0.2,william holl johnson,,FIN-3060,2018
+FIN,3060,5,Corporation Finance,0.06,0.28,0.3,0.24,0.06,0.0,0.0,0.06,ramon tolbe franklin,,FIN-3060,2018
+FIN,3060,6,Corporation Finance,0.12,0.29,0.2,0.18,0.14,0.0,0.0,0.06,ramon tolbe franklin,,FIN-3060,2018
+FIN,3060,7,Corporation Finance,0.31,0.24,0.28,0.11,0.04,0.0,0.0,0.02,ramon tolbe franklin,,FIN-3060,2018
+FIN,3060,8,Corporation Finance,0.19,0.31,0.22,0.19,0.02,0.0,0.0,0.07,ramon tolbe franklin,,FIN-3060,2018
+FIN,3070,1,Prin of Real Estate,0.23,0.43,0.26,0.06,0.03,0.0,0.0,0.0,yannan shen,,FIN-3070,2018
+FIN,3070,2,Prin of Real Estate,0.23,0.46,0.23,0.06,0.03,0.0,0.0,0.0,yannan shen,,FIN-3070,2018
+FIN,3070,3,Prin of Real Estate,0.23,0.26,0.28,0.15,0.05,0.0,0.0,0.03,thomas springer,,FIN-3070,2018
+FIN,3080,1,Fin Inst & Mkts,0.16,0.46,0.24,0.05,0.05,0.0,0.0,0.03,daniel thomas greene,,FIN-3080,2018
+FIN,3080,2,Fin Inst & Mkts,0.32,0.34,0.29,0.05,0.0,0.0,0.0,0.0,daniel thomas greene,,FIN-3080,2018
+FIN,3080,3,Fin Inst & Mkts,0.32,0.29,0.24,0.11,0.05,0.0,0.0,0.0,daniel thomas greene,,FIN-3080,2018
+FIN,3110,1,Financial Management I,0.21,0.33,0.18,0.05,0.0,0.0,0.0,0.23,george bran lockhart,,FIN-3110,2018
+FIN,3110,2,Financial Management I,0.08,0.35,0.33,0.05,0.08,0.0,0.0,0.13,george bran lockhart,,FIN-3110,2018
+FIN,3110,3,Financial Management I,0.18,0.33,0.23,0.0,0.13,0.0,0.0,0.15,george bran lockhart,,FIN-3110,2018
+FIN,3110,4,Financial Management I,0.06,0.25,0.44,0.03,0.08,0.0,0.0,0.14,jack wolf,,FIN-3110,2018
+FIN,3120,1,Financial Management II,0.24,0.38,0.24,0.08,0.0,0.0,0.0,0.05,blerina zykaj,,FIN-3120,2018
+FIN,3120,2,Financial Management II,0.47,0.19,0.28,0.06,0.0,0.0,0.0,0.0,blerina zykaj,,FIN-3120,2018
+FIN,3120,3,Financial Management II,0.18,0.41,0.23,0.08,0.03,0.0,0.0,0.08,weike xu,,FIN-3120,2018
+FIN,3120,4,Financial Management II,0.14,0.34,0.29,0.11,0.03,0.0,0.0,0.09,weike xu,,FIN-3120,2018
+FIN,4030,1,Spreadsheet Apps in Finance,0.23,0.51,0.26,0.0,0.0,0.0,0.0,0.0,vincent ja intintoli,,FIN-4030,2018
+FIN,4030,2,Spreadsheet Apps in Finance,0.2,0.4,0.24,0.12,0.04,0.0,0.0,0.0,vincent ja intintoli,,FIN-4030,2018
+FIN,4040,1,Financial Modeling,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,jack wolf,,FIN-4040,2018
+FIN,4050,1,Portfolio Management & Theory,0.13,0.27,0.23,0.13,0.17,0.0,0.0,0.07,john alexander,,FIN-4050,2018
+FIN,4080,1,Mgt of Fin Inst,0.33,0.57,0.1,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2018
+FIN,4080,2,Mgt of Fin Inst,0.19,0.44,0.31,0.06,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2018
+FIN,4090,1,Prof Fin Plan Capstone,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,,FIN-4090,2018
+FIN,4110,1,Int Fin Mgt,0.27,0.55,0.12,0.06,0.0,0.0,0.0,0.0,luke asher devault,,FIN-4110,2018
+FIN,4110,2,Int Fin Mgt,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,luke asher devault,,FIN-4110,2018
+FIN,4150,1,Real Estate Investmt,0.24,0.29,0.33,0.14,0.0,0.0,0.0,0.0,thomas springer,,FIN-4150,2018
+FIN,4160,1,Real Estate Val,0.31,0.31,0.31,0.0,0.06,0.0,0.0,0.0,valerie lynn hammett,,FIN-4160,2018
+FNR,4700,35,Aquaponics,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,lance edward beecher,,FNR-4700,2018
+FNR,4700,52,Stream & Reservoir Fish Eco I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,troy mason farmer,,FNR-4700,2018
+FNR,4990,1,Natural Resources Seminar,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,susan talley guynn,,FNR-4990,2018
+FNR,4990,2,Natural Resources Seminar,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,susan talley guynn,,FNR-4990,2018
+FNR,4990,3,Natural Resources Seminar,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,susan talley guynn,,FNR-4990,2018
+FOR,1010,1,Intro to Forestry,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,lawrence gering,,FOR-1010,2018
+FOR,2060,1,Forestry Ecology,0.23,0.43,0.22,0.04,0.05,0.0,0.0,0.03,donald hagan,,FOR-2060,2018
+FOR,3080,1,Remote Sensing in Forestry,0.43,0.47,0.1,0.0,0.0,0.0,0.0,0.0,lawrence gering,,FOR-3080,2018
+FOR,4080,1,Wood and Paper Products,0.52,0.29,0.14,0.05,0.0,0.0,0.0,0.0,patricia layton,,FOR-4080,2018
+FOR,4150,1,Forest Wildlife Managment,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james davis,,FOR-4150,2018
+FOR,4180,1,Forest Resource Valuation,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,thomas straka,,FOR-4180,2018
+FOR,4340,1,GIS for Natural Resources,0.28,0.58,0.1,0.03,0.0,0.0,0.0,0.03,robert fritz baldwin,,FOR-4340,2018
+FOR,4650,1,Silviculture,0.12,0.54,0.31,0.04,0.0,0.0,0.0,0.0,gaofeng wang,,FOR-4650,2018
+FOR,6340,1,GIS for Natural Resources,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert fritz baldwin,,FOR-6340,2018
+FOR,8120,1,Fire Ecology and Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,gaofeng wang,,FOR-8120,2018
+FR,1010,1,Elementary French,0.24,0.53,0.24,0.0,0.0,0.0,0.0,0.0, nedeo anne salces anne,,FR-1010,2018
+FR,1010,2,Elementary French,0.41,0.12,0.29,0.0,0.06,0.0,0.0,0.12, nedeo anne salces anne,,FR-1010,2018
+FR,1010,3,Elementary French,0.29,0.14,0.14,0.21,0.14,0.0,0.0,0.07,kenneth davi widgren,,FR-1010,2018
+FR,1020,1,Elementary French,0.76,0.18,0.0,0.06,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,,FR-1020,2018
+FR,1020,2,Elementary French,0.5,0.2,0.2,0.1,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,,FR-1020,2018
+FR,2010,2,Intermediate French,0.8,0.16,0.0,0.0,0.04,0.0,0.0,0.0,amy lyn griff sawyer griff,,FR-2010,2018
+FR,2010,3,Intermediate French,0.19,0.5,0.19,0.06,0.0,0.0,0.0,0.06,kenneth davi widgren,,FR-2010,2018
+FR,2010,4,Intermediate French,0.22,0.33,0.33,0.0,0.0,0.0,0.0,0.11,kenneth davi widgren,,FR-2010,2018
+FR,2020,1,Intermediate French,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,tholozany pauline de,,FR-2020,2018
+FR,2020,2,Intermediate French,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,,FR-2020,2018
+FR,2020,4,Intermediate French,0.06,0.82,0.12,0.0,0.0,0.0,0.0,0.0,kenneth davi widgren,,FR-2020,2018
+FR,3050,1,Int Fr Con & Comp I,0.59,0.06,0.24,0.0,0.0,0.0,0.0,0.12, nedeo anne salces anne,,FR-3050,2018
+FR,3160,1,Fr for Intl Trade,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-3160,2018
+FR,3170,1,Contemp French Civ,0.76,0.18,0.0,0.06,0.0,0.0,0.0,0.0,joseph mai,,FR-3170,2018
+FR,4760,1,French Feminism and Theory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-4760,2018
+GC,1010,1,Orientation to G C,0.5,0.3,0.09,0.0,0.02,0.0,0.0,0.09,john leininger,,GC-1010,2018
+GC,1020,1,Computer Art & CAD Foundations,0.46,0.33,0.1,0.04,0.02,0.0,0.0,0.06,carol jones,,GC-1020,2018
+GC,1030,1,G C I for Pkgsc,0.26,0.55,0.18,0.0,0.0,0.0,0.0,0.0,john jacobs,,GC-1030,2018
+GC,1040,1,Graphic Communications I,0.66,0.21,0.05,0.03,0.02,0.0,0.0,0.03,rebecca suzan edlein,,GC-1040,2018
+GC,2070,1,Graphic Communications II,0.3,0.5,0.07,0.04,0.04,0.0,0.0,0.04,charles tabor weiss,,GC-2070,2018
+GC,3400,1,Digital Imaging and eMedia,0.4,0.43,0.1,0.05,0.0,0.0,0.0,0.03,erica black walker,,GC-3400,2018
+GC,3460,1,Ink and Substrates,0.17,0.61,0.15,0.0,0.04,0.0,0.0,0.02,liam henry 'hara,,GC-3460,2018
+GC,4060,1,Package and Specialty Printing,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,kern cox,,GC-4060,2018
+GC,4400,1,Commercial Printing,0.53,0.33,0.07,0.0,0.03,0.0,0.0,0.03,john leininger,,GC-4400,2018
+GC,4440,1,Current Dev/Trends in Gr Comm,0.73,0.22,0.03,0.03,0.0,0.0,0.0,0.0,samuel ingram,,GC-4440,2018
+GC,4480,1,Plan & Cont Printing Functions,0.83,0.09,0.09,0.0,0.0,0.0,0.0,0.0,nona woolbright,,GC-4480,2018
+GC,4800,1,Senior Seminar in GC,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,charles edwar tonkin,,GC-4800,2018
+GC,4900,2,G C Selected Topics-Sales,0.82,0.06,0.0,0.0,0.0,0.0,0.0,0.12,john leininger,,GC-4900,2018
+GC,4900,3,Select Topic-Dig Media Design,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,erica black walker,,GC-4900,2018
+GEN,3000,1,Fundamental Genetics,0.27,0.29,0.3,0.09,0.03,0.0,0.0,0.03,kate leanne wil tsai wil,,GEN-3000,2018
+GEN,3000,2,Fundamental Genetics,0.23,0.41,0.22,0.07,0.01,0.0,0.0,0.05,kate leanne wil tsai wil,,GEN-3000,2018
+GEN,3020,1,Molecular & General Genetics,0.36,0.41,0.11,0.05,0.0,0.0,0.0,0.07,rajandeep sin sekhon,,GEN-3020,2018
+GEN,3040,1,Molecular Biology Laboratory,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-3040,2018
+GEN,3040,4,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-3040,2018
+GEN,4100,1,Population & Quant Genetics,0.38,0.43,0.15,0.02,0.02,0.0,0.0,0.0,scott michael tanner,,GEN-4100,2018
+GEN,4110,3,Population & Quant Gen Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,,GEN-4110,2018
+GEN,4400,1,Bioinformatics,0.53,0.35,0.06,0.0,0.06,0.0,0.0,0.0,liangjiang wang,,GEN-4400,2018
+GEN,4700,1,Human Genetics,0.42,0.23,0.15,0.0,0.0,0.0,0.0,0.19,miriam kristi konkel,,GEN-4700,2018
+GEN,4900,13,GB Professional Development,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,alison ni starr-moss,,GEN-4900,2018
+GEN,4930,3,Senior Seminar,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,alison ni starr-moss,,GEN-4930,2018
+GEN,8100,1,Princ of Molecular Biology,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,jennifer may mason,,GEN-8100,2018
+GEOG,1010,1,Intro to Geography,0.34,0.37,0.14,0.09,0.0,0.0,0.0,0.06,christa smith,,GEOG-1010,2018
+GEOG,1030,1,World Regional Geography,0.34,0.46,0.09,0.03,0.03,0.0,0.0,0.04,william church terry,,GEOG-1030,2018
+GEOL,1010,1,Physical Geology,0.28,0.32,0.2,0.1,0.04,0.0,0.0,0.07,alan coulson,,GEOL-1010,2018
+GEOL,1010,2,Physical Geology,0.57,0.19,0.1,0.06,0.04,0.0,0.0,0.04,alan coulson,,GEOL-1010,2018
+GEOL,1010,3,Physical Geology,0.26,0.26,0.21,0.1,0.1,0.0,0.0,0.07,mary katherin fidler,,GEOL-1010,2018
+GEOL,1030,1,Physical Geol Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,2,Physical Geol Lab,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,3,Physical Geol Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,4,Physical Geol Lab,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,5,Physical Geol Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,6,Physical Geol Lab,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2018
+GEOL,1030,7,Physical Geol Lab,0.48,0.43,0.0,0.0,0.0,0.0,0.0,0.09,alan coulson,,GEOL-1030,2018
+GEOL,1030,8,Physical Geol Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,9,Physical Geol Lab,0.26,0.39,0.17,0.04,0.0,0.0,0.0,0.13,alan coulson,,GEOL-1030,2018
+GEOL,1030,11,Physical Geol Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2018
+GEOL,1030,12,Physical Geol Lab,0.58,0.21,0.13,0.0,0.04,0.0,0.0,0.04,alan coulson,,GEOL-1030,2018
+GEOL,1030,13,Physical Geol Lab,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,alan coulson,,GEOL-1030,2018
+GEOL,1120,1,Earth Resources,0.42,0.33,0.17,0.04,0.04,0.0,0.0,0.0,mary katherin fidler,,GEOL-1120,2018
+GEOL,1140,1,Earth Resources Lab,0.6,0.17,0.13,0.1,0.0,0.0,0.0,0.0,mary katherin fidler,,GEOL-1140,2018
+GEOL,2020,1,Earth History,0.28,0.44,0.22,0.06,0.0,0.0,0.0,0.0,alan coulson,,GEOL-2020,2018
+GEOL,3130,1,Sedimentology & Stratigraphy,0.26,0.35,0.39,0.0,0.0,0.0,0.0,0.0,mary katherin fidler,,GEOL-3130,2018
+GEOL,3180,1,Introduction to Geochemistry,0.46,0.42,0.13,0.0,0.0,0.0,0.0,0.0,brian powell,,GEOL-3180,2018
+GEOL,4210,1,Gis in Geology,0.74,0.15,0.07,0.04,0.0,0.0,0.0,0.0,scott brame,,GEOL-4210,2018
+GEOL,7900,501,Biogeography & Geology of SC,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,,GEOL-7900,2018
+GEOL,8030,1,Geostatistics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,stephen micha moysey,,GEOL-8030,2018
+GEOL,8090,1,Subsurface Remed Mod,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,ronald falta,,GEOL-8090,2018
+GEOL,8160,1,Aquifer Systems,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,,GEOL-8160,2018
+GER,1010,1,Elementary German,0.11,0.26,0.26,0.05,0.16,0.0,0.0,0.16,isabel meusen,,GER-1010,2018
+GER,1010,2,Elementary German,0.11,0.44,0.11,0.11,0.06,0.0,0.0,0.17,isabel meusen,,GER-1010,2018
+GER,1020,1,Elementary German,0.31,0.38,0.25,0.0,0.06,0.0,0.0,0.0,oswald harris king,,GER-1020,2018
+GER,2010,1,Intermediate German,0.26,0.21,0.42,0.0,0.11,0.0,0.0,0.0, lee ferrell,,GER-2010,2018
+GER,2010,2,Intermediate German,0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,oswald harris king,,GER-2010,2018
+GER,2020,1,Intermediate German,0.4,0.2,0.13,0.2,0.0,0.0,0.0,0.07,gabriela stoicea,,GER-2020,2018
+GER,2020,2,Intermediate German,0.46,0.15,0.23,0.08,0.0,0.0,0.0,0.08,gabriela stoicea,,GER-2020,2018
+GER,3060,1,German Short Story,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,oswald harris king,,GER-3060,2018
+HCC,8810,1,Measurement & Eval,0.38,0.46,0.0,0.0,0.15,0.0,0.0,0.0,bart knijnenburg,,HCC-8810,2018
+HCG,9050,1,"Genomics, Ethics & Hlth Policy",0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,,HCG-9050,2018
+HIST,1010,1,History of the United States,0.53,0.32,0.12,0.0,0.03,0.0,0.0,0.0,james bradf jeffries,,HIST-1010,2018
+HIST,1240,1,Environmental History Survey,0.16,0.55,0.21,0.0,0.05,0.0,0.0,0.03,james bradf jeffries,,HIST-1240,2018
+HIST,1720,3,The West and the World I,0.26,0.53,0.18,0.0,0.03,0.0,0.0,0.0,thomas kuehn,,HIST-1720,2018
+HIST,1730,1,The West and the World II,0.18,0.48,0.13,0.01,0.1,0.0,0.0,0.1, alan grubb,,HIST-1730,2018
+HIST,1730,2,The West and the World II,0.18,0.42,0.27,0.04,0.06,0.0,0.0,0.03,michael meng,,HIST-1730,2018
+HIST,1730,3,The West and the World II,0.39,0.37,0.16,0.04,0.02,0.0,0.0,0.03,steven marks,,HIST-1730,2018
+HIST,2990,1,Historian's Craft,0.54,0.17,0.04,0.04,0.04,0.0,0.0,0.17,michael silvestri,,HIST-2990,2018
+HIST,2990,2,Historian's Craft,0.83,0.09,0.0,0.0,0.04,0.0,0.0,0.04,rachel anne moore,,HIST-2990,2018
+HIST,3110,1,African American Hist to 1877,0.41,0.33,0.19,0.0,0.0,0.0,0.0,0.07,abel bartley,,HIST-3110,2018
+HIST,3230,1,Hist of Amer Tech,0.42,0.46,0.08,0.0,0.0,0.0,0.0,0.04,pamela mack,,HIST-3230,2018
+HIST,3240,1,Hist of the South II,0.36,0.19,0.17,0.06,0.14,0.0,0.0,0.08,john andrew,,HIST-3240,2018
+HIST,3250,1,Amer Econ Developmt,0.17,0.5,0.08,0.0,0.04,0.0,0.0,0.21,william camp,,HIST-3250,2018
+HIST,3260,1,Hist Am Transport,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04, roger grant,,HIST-3260,2018
+HIST,3420,1,South Am Since 1800,0.6,0.37,0.0,0.0,0.03,0.0,0.0,0.0,rachel anne moore,,HIST-3420,2018
+HIST,3610,1,History of Britain to 1688,0.41,0.41,0.14,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,,HIST-3610,2018
+HIST,3810,1,Germany 1918 to 1945,0.22,0.33,0.3,0.0,0.07,0.0,0.0,0.07,michael meng,,HIST-3810,2018
+HIST,3900,1,Modern Military History,0.29,0.42,0.25,0.04,0.0,0.0,0.0,0.0,edwin moise,,HIST-3900,2018
+HIST,3920,1,Hist U S Environment,0.27,0.5,0.13,0.03,0.03,0.0,0.0,0.03,william camp,,HIST-3920,2018
+HIST,3970,1,Modern Middle East,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,amit bein,,HIST-3970,2018
+HIST,3980,1,American Military History,0.2,0.43,0.17,0.07,0.07,0.0,0.0,0.07,john andrew,,HIST-3980,2018
+HIST,4360,1,Vietnam Wars,0.12,0.53,0.24,0.0,0.12,0.0,0.0,0.0,edwin moise,,HIST-4360,2018
+HIST,4600,1,Film and Empire,0.53,0.33,0.07,0.0,0.0,0.0,0.0,0.07,michael silvestri,,HIST-4600,2018
+HIST,4930,1,The American City,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,abel bartley,,HIST-4930,2018
+HIST,4940,1,Russian Film History,0.29,0.29,0.0,0.0,0.29,0.0,0.0,0.14,steven marks,,HIST-4940,2018
+HLTH,2020,1,Introduction to Public Health,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2018
+HLTH,2020,2,Introduction to Public Health,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2020,2018
+HLTH,2020,400,Introduction to Public Health,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,ralph stewart welsh,,HLTH-2020,2018
+HLTH,2020,401,Introduction to Public Health,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,ralph stewart welsh,,HLTH-2020,2018
+HLTH,2030,1,Health Care Sys,0.52,0.34,0.14,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2018
+HLTH,2030,2,Health Care Sys,0.45,0.48,0.07,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2030,2018
+HLTH,2030,3,Health Care Sys,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,,HLTH-2030,2018
+HLTH,2030,400,Health Care Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2018
+HLTH,2400,1,Deter of Hlth Behav,0.52,0.36,0.04,0.04,0.0,0.0,0.0,0.04,amelia clinkscales,,HLTH-2400,2018
+HLTH,2400,2,Deter of Hlth Behav,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2018
+HLTH,2400,400,Deter of Hlth Behav,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2400,2018
+HLTH,2500,1,Health and Fitness,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.04,ralph stewart welsh,,HLTH-2500,2018
+HLTH,2600,1,Medical Terminology & Comm,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,karen edwards,,HLTH-2600,2018
+HLTH,2600,2,Medical Terminology & Comm,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,,HLTH-2600,2018
+HLTH,2980,1,Human Health and Disease,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2018
+HLTH,2980,2,Human Health and Disease,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2018
+HLTH,3030,1,Public Health Comm,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,,HLTH-3030,2018
+HLTH,3800,1,Epidemiology,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,hugh spitler,,HLTH-3800,2018
+HLTH,3800,2,Epidemiology,0.56,0.28,0.16,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-3800,2018
+HLTH,3980,1,Health Appraisal Skills,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2018
+HLTH,3980,2,Health Appraisal Skills,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2018
+HLTH,4190,1,Health Sci Internship Prep Sem,0.7,0.23,0.08,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4190,2018
+HLTH,4200,1,Hlth Science Intern,0.79,0.18,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2018
+HLTH,4310,1,Public & Environ Hlt,0.54,0.33,0.1,0.0,0.0,0.0,0.0,0.03,deborah alma falta,,HLTH-4310,2018
+HLTH,4700,1,Global Health,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,micky rogers ward,,HLTH-4700,2018
+HLTH,4780,1,Health Policy Ethics and Law,0.44,0.19,0.25,0.0,0.13,0.0,0.0,0.0,hugh spitler,,HLTH-4780,2018
+HLTH,4800,1,Comm Hlth Promotion,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,sarah griffin,,HLTH-4800,2018
+HLTH,4900,1,Res Eval St Pub Hlth,0.55,0.25,0.1,0.05,0.0,0.0,0.0,0.05,karen kemper,,HLTH-4900,2018
+HLTH,4900,2,Res Eval St Pub Hlth,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-4900,2018
+HLTH,4900,3,Res Eval St Pub Hlth,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-4900,2018
+HLTH,4970,5,Alcohol & Other Drugs CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,crystal burne fulmer,,HLTH-4970,2018
+HLTH,8110,1,Health Care Delivery Systems,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,,HLTH-8110,2018
+HLTH,8130,500,Population Health and Research,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,,HLTH-8130,2018
+HLTH,8310,1,Quantitative Analy in Hlth I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,lu shi,,HLTH-8310,2018
+HON,2020,1,Civil Discourse,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,True,HON-2020,2018
+HON,2050,2,Social Entrepreneurship,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,john michael hannon,True,HON-2050,2018
+HON,2060,1,Intro to Nanotechnology,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,True,HON-2060,2018
+HON,2100,1,Experiencing the Arts,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,mark spede,True,HON-2100,2018
+HON,2210,1,Literature and/as Resistance,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,gabriela stoicea,True,HON-2210,2018
+HON,2210,3,Adventure Novels in Context,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tholozany pauline de,True,HON-2210,2018
+HON,2210,4,Fascism/Anti-fascism Lit,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,gabriel ande hankins,True,HON-2210,2018
+HON,2210,5,American Science Fiction,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,True,HON-2210,2018
+HORT,2020,1,Adobe Digital Design,0.85,0.09,0.0,0.03,0.03,0.0,0.0,0.0,janice ann lay,,HORT-2020,2018
+HORT,2110,1,Growing Spring Plnts,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,james emerson faust,,HORT-2110,2018
+HORT,4000,1,Water for Agriculture,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,sarah white,,HORT-4000,2018
+HORT,4040,1,Plant Propagation,0.18,0.29,0.41,0.12,0.0,0.0,0.0,0.0,jeffrey adelberg,,HORT-4040,2018
+HORT,4090,1,Senior Capstone Course,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-4090,2018
+HORT,4200,1,Applied Turf Physiol,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,,HORT-4200,2018
+HORT,4270,1,Urban Tree Care,0.06,0.25,0.56,0.13,0.0,0.0,0.0,0.0,robert polomski,,HORT-4270,2018
+HORT,4330,1,Turf Weed Management,0.14,0.27,0.55,0.05,0.0,0.0,0.0,0.0,ted whitwell,,HORT-4330,2018
+HORT,4610,1,Advanc Landscape Garden Design,0.92,0.0,0.08,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-4610,2018
+HORT,6040,1,Plant Propagation,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jeffrey adelberg,,HORT-6040,2018
+HRD,8470,400,Instru System Design,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,angela daniel carter,,HRD-8470,2018
+HRD,8490,400,Eval of T&D/Hrd Prog,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,angela daniel carter,,HRD-8490,2018
+HRD,8800,400,Research Concepts,0.76,0.15,0.03,0.0,0.0,0.0,0.0,0.06,kristin kelly frady,,HRD-8800,2018
+IE,2100,1,Des Analysis Wrk Sys,0.44,0.42,0.07,0.05,0.0,0.0,0.0,0.02,sara lu riggs,,IE-2100,2018
+IE,3010,1,Systems Design I,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,xiaoxia li,,IE-3010,2018
+IE,3600,1,Industrial Apps of Prob/Stat I,0.39,0.34,0.12,0.08,0.05,0.0,0.0,0.03,mary elizabeth kurz,,IE-3600,2018
+IE,3610,1,Industrial App of Prob/Stat II,0.3,0.34,0.27,0.06,0.02,0.0,0.0,0.02,david neyens,,IE-3610,2018
+IE,3800,1,Deterministic Operations Rsrch,0.27,0.39,0.17,0.1,0.02,0.0,0.0,0.05,ceyda yaba,,IE-3800,2018
+IE,3810,1,Probabilistic Operations Rsrch,0.31,0.21,0.29,0.13,0.02,0.0,0.0,0.05,robert james riggs,,IE-3810,2018
+IE,3840,1,Engr Econ Analysis,0.19,0.19,0.15,0.1,0.09,0.0,0.0,0.29,brian melloy,,IE-3840,2018
+IE,3860,1,Production Planning & Control,0.36,0.23,0.28,0.09,0.04,0.0,0.0,0.0,kevin taaffe,,IE-3860,2018
+IE,4400,1,Decision Support Sys,0.48,0.32,0.13,0.05,0.03,0.0,0.0,0.0,mary elizabeth kurz,,IE-4400,2018
+IE,4570,1,Transp/Logistic Engr,0.33,0.47,0.16,0.05,0.0,0.0,0.0,0.0,sandra duni eksioglu,,IE-4570,2018
+IE,4610,1,Quality Engineering,0.26,0.42,0.14,0.14,0.01,0.0,0.0,0.03,byung rae cho,,IE-4610,2018
+IE,4620,1,Six Sigma Quality,0.38,0.42,0.19,0.01,0.0,0.0,0.0,0.0,robert james riggs,,IE-4620,2018
+IE,4650,1,Facilities Planning & Design,0.9,0.09,0.0,0.01,0.0,0.0,0.0,0.0,xiaoxia li,,IE-4650,2018
+IE,4670,1,System Design II,0.53,0.37,0.1,0.0,0.0,0.0,0.0,0.0,jeffery messer,,IE-4670,2018
+IE,4670,2,System Design II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,,IE-4670,2018
+IE,4820,1,Systems Modeling,0.32,0.33,0.21,0.08,0.05,0.0,0.0,0.02,tugce isik,,IE-4820,2018
+IE,4880,1,Human Factors Eng,0.23,0.57,0.19,0.01,0.0,0.0,0.0,0.0,madathil kapi chalil,,IE-4880,2018
+IE,4910,100,Applied Probabilistic OR,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,brian melloy,,IE-4910,2018
+IE,6570,1,Transp/Logistic Engr,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,sandra duni eksioglu,,IE-6570,2018
+IE,6620,1,Six Sigma Quality,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,,IE-6620,2018
+IE,8050,1,Found Qual Engr,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,byung rae cho,,IE-8050,2018
+IE,8520,1,Prescriptive Analytics,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,,IE-8520,2018
+IE,8540,1,SC & Logistics Modeling I,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,william ferrell,,IE-8540,2018
+IE,8580,1,Case Study Supply Chn & Logist,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,scott jennings mason,,IE-8580,2018
+IE,8800,1,Adv Meth of Or,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,amin khademi,,IE-8800,2018
+IE,8930,1,Rsrch Method-Human Interaction,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,laura michel stanley,,IE-8930,2018
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,lisa marie robinson,,INT-1510,2018
+INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,caren kelley-hall,,INT-1520,2018
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.85,0.15,0.0,caren kelley-hall,,INT-1530,2018
+INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,caren kelley-hall,,INT-1540,2018
+INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,lisa marie robinson,,INT-2510,2018
+INT,2530,1,UPIC Internship FT 3,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,,INT-2530,2018
+IPM,4010,1,Principles of I P M,0.57,0.29,0.07,0.07,0.0,0.0,0.0,0.0,carmen blubaugh,,IPM-4010,2018
+IPM,6010,1,Principles of I P M,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,carmen blubaugh,,IPM-6010,2018
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.83,0.16,0.01,meredith fant wilson,,IS-1010,2018
+ITAL,1010,1,Elementary Italian,0.47,0.18,0.12,0.0,0.06,0.0,0.0,0.18,lyudmyla tsykalova,,ITAL-1010,2018
+ITAL,1020,1,Elementary Italian,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,,ITAL-1020,2018
+ITAL,1020,2,Elementary Italian,0.39,0.5,0.0,0.06,0.06,0.0,0.0,0.0,julia schmidt,,ITAL-1020,2018
+ITAL,1020,3,Elementary Italian,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,julia schmidt,,ITAL-1020,2018
+ITAL,2010,1,Intermediate Italian,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-2010,2018
+ITAL,2020,2,Intermediate Italian,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-2020,2018
+JAPN,1010,1,Elementary Japanese,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,saori suto,,JAPN-1010,2018
+JAPN,1010,2,Elementary Japanese,0.2,0.13,0.27,0.13,0.0,0.0,0.0,0.27,saori suto,,JAPN-1010,2018
+JAPN,1020,2,Elementary Japanese,0.18,0.36,0.45,0.0,0.0,0.0,0.0,0.0,satomi saito,,JAPN-1020,2018
+JAPN,2010,1,Intermed Japanese,0.58,0.17,0.08,0.0,0.08,0.0,0.0,0.08,saori suto,,JAPN-2010,2018
+JAPN,2020,1,Intermed Japanese,0.5,0.14,0.21,0.14,0.0,0.0,0.0,0.0,saori suto,,JAPN-2020,2018
+JAPN,4160,1,Japanese for Int'l Trade II,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jae allegra takeuchi,,JAPN-4160,2018
+JUST,2880,1,The Criminal Justice System,0.29,0.39,0.3,0.02,0.0,0.0,0.0,0.0,margaret tina britz,,JUST-2880,2018
+JUST,4940,1,Organized Crime,0.52,0.29,0.13,0.02,0.04,0.0,0.0,0.0,margaret tina britz,,JUST-4940,2018
+LANG,2540,1,Introduction to World Cinemas,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,raquel anido,,LANG-2540,2018
+LANG,3000,1,Intro Linguistics,0.58,0.16,0.16,0.0,0.0,0.0,0.0,0.11,jae allegra takeuchi,,LANG-3000,2018
+LANG,4620,1,Borders,0.46,0.31,0.0,0.0,0.15,0.0,0.0,0.08,tiffany dawn miller,,LANG-4620,2018
+LARC,1160,1,History of Landscape Arch,0.65,0.28,0.03,0.01,0.01,0.0,0.0,0.01,hala fouad nassar,,LARC-1160,2018
+LARC,1160,2,History of Landscape Arch,0.17,0.39,0.26,0.13,0.04,0.0,0.0,0.0,hala fouad nassar,,LARC-1160,2018
+LARC,1520,1,Basic Design II,0.57,0.3,0.04,0.0,0.09,0.0,0.0,0.0,jessica fernandez,,LARC-1520,2018
+LARC,2550,1,Community Design Studio,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,matthew neal powers,,LARC-2550,2018
+LARC,3620,1,Design Impl II,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,robert hewitt,,LARC-3620,2018
+LARC,3620,2,Design Impl II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,,LARC-3620,2018
+LARC,4280,1,Computer-Aided Design,0.55,0.14,0.14,0.05,0.09,0.0,0.0,0.05,jessica fernandez,,LARC-4280,2018
+LARC,6810,1,Professional Practice,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,david lycke,,LARC-6810,2018
+LARC,8020,1,Orientation II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,paul russell,,LARC-8020,2018
+LARC,8300,1,Graduate Seminar I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,thomas willi schurch,,LARC-8300,2018
+LAW,3220,1,Legal Env of Bus,0.13,0.22,0.42,0.22,0.0,0.0,0.0,0.0,kenneth sc toussaint,,LAW-3220,2018
+LAW,3220,2,Legal Env of Bus,0.28,0.43,0.22,0.02,0.02,0.0,0.0,0.02,edward ray claggett,,LAW-3220,2018
+LAW,3220,3,Legal Env of Bus,0.26,0.37,0.26,0.09,0.0,0.0,0.0,0.02,kenneth sc toussaint,,LAW-3220,2018
+LAW,3220,4,Legal Env of Bus,0.23,0.36,0.34,0.05,0.02,0.0,0.0,0.0,kenneth sc toussaint,,LAW-3220,2018
+LAW,3220,5,Legal Env of Bus,0.11,0.59,0.25,0.05,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2018
+LAW,3220,6,Legal Env of Bus,0.22,0.4,0.38,0.0,0.0,0.0,0.0,0.0,judson jahn,,LAW-3220,2018
+LAW,3220,7,Legal Env of Bus,0.69,0.29,0.03,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2018
+LAW,3220,8,Legal Env of Bus,0.11,0.3,0.52,0.05,0.02,0.0,0.0,0.0,kenneth sc toussaint,,LAW-3220,2018
+LAW,3220,9,Legal Env of Bus,0.82,0.16,0.0,0.0,0.0,0.0,0.0,0.02,frances edwards,,LAW-3220,2018
+LAW,3220,10,Legal Env of Bus,0.28,0.47,0.16,0.05,0.0,0.0,0.0,0.05,john hine,,LAW-3220,2018
+LAW,3220,11,Legal Env of Bus,0.11,0.4,0.29,0.11,0.07,0.0,0.0,0.02,john hine,,LAW-3220,2018
+LAW,3220,401,Legal Env of Bus,0.44,0.32,0.16,0.05,0.0,0.0,0.0,0.04,virginia ward-vaughn,,LAW-3220,2018
+LAW,3220,402,Legal Env of Bus,0.25,0.31,0.25,0.05,0.07,0.0,0.0,0.07,virginia ward-vaughn,,LAW-3220,2018
+LAW,3220,403,Legal Env of Bus,0.33,0.44,0.18,0.0,0.02,0.0,0.0,0.04,virginia ward-vaughn,,LAW-3220,2018
+LAW,3220,404,Legal Env of Bus,0.22,0.39,0.24,0.06,0.04,0.0,0.0,0.06,virginia ward-vaughn,,LAW-3220,2018
+LAW,3330,1,Real Estate Law,0.14,0.67,0.14,0.02,0.02,0.0,0.0,0.0,judson jahn,,LAW-3330,2018
+LAW,4200,1,Int Business Law,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-4200,2018
+LAW,8480,1,Law Real Estate Prof,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,james ivey warren,,LAW-8480,2018
+LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.88,0.04,0.08, lee ferrell,,LIT-1270,2018
+LS,1000,4,Introduction to Barre,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,lauren elizab george,,LS-1000,2018
+LS,1000,8,Intro to Salsa Dance,0.54,0.23,0.0,0.0,0.23,0.0,0.0,0.0,malik lewis  baxter c,,LS-1000,2018
+LS,1000,9,Intro to Salsa Dance,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,malik lewis  baxter c,,LS-1000,2018
+LS,1000,10,Intro to Salsa Dance,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,malik lewis  baxter c,,LS-1000,2018
+LS,1000,20,Intro to Volleyball,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,kelly lynn ator,,LS-1000,2018
+LS,1000,23,Therapeutic Yoga,0.77,0.09,0.0,0.0,0.0,0.0,0.0,0.14,renee warren gahan,,LS-1000,2018
+LS,1330,2,Women's Shotgun,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,bonnie duke gill,,LS-1330,2018
+LS,1350,1,Women's Riflery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,hubert cox,,LS-1350,2018
+LS,1410,1,Top Rope Climbing,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,michelle tuday,,LS-1410,2018
+LS,1410,3,Top Rope Climbing,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,michelle tuday,,LS-1410,2018
+LS,1560,12,Riflery,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,herbert strickland,,LS-1560,2018
+LS,1570,7,Shotgun Sports,0.7,0.2,0.0,0.1,0.0,0.0,0.0,0.0,john jeffrey price,,LS-1570,2018
+LS,1570,10,Shotgun Sports,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,audrey carolin couch,,LS-1570,2018
+LS,1580,1,Archery,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,,LS-1580,2018
+LS,1580,2,Archery,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,herbert strickland,,LS-1580,2018
+LS,1580,3,Archery,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,herbert strickland,,LS-1580,2018
+LS,1640,2,Whitewater Kayaking,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,robert taylor,,LS-1640,2018
+LS,1750,1,Fly Fishing,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james michae harvell,,LS-1750,2018
+LS,1750,2,Fly Fishing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,michael watts,,LS-1750,2018
+LS,1850,2,Bowling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,,LS-1850,2018
+LS,1850,3,Bowling,0.87,0.07,0.0,0.0,0.03,0.0,0.0,0.03,tyler bennett,,LS-1850,2018
+LS,1850,4,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,alexandra sandoval,,LS-1850,2018
+LS,1850,8,Bowling,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,,LS-1850,2018
+LS,1940,3,Racquetball,0.71,0.07,0.0,0.0,0.07,0.0,0.0,0.14,charlie white,,LS-1940,2018
+LS,1980,2,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,jason jordan,,LS-1980,2018
+LS,2270,1,Intro to Swing Dance,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,,LS-2270,2018
+LS,2320,1,Core Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,diane moreno,,LS-2320,2018
+LS,2320,2,Core Training,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,,LS-2320,2018
+LS,2320,3,Core Training,0.76,0.1,0.0,0.0,0.0,0.0,0.0,0.14,diane moreno,,LS-2320,2018
+LS,2320,5,Core Training,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,,LS-2320,2018
+LS,2350,3,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,silica elizab larkin,,LS-2350,2018
+LS,2350,5,Basic Yoga,0.73,0.18,0.0,0.0,0.05,0.0,0.0,0.05,renee warren gahan,,LS-2350,2018
+LS,2360,2,Power/Ashtanga Yoga,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,silica elizab larkin,,LS-2360,2018
+LS,2380,2,Vinyasa Flow Yoga,0.69,0.0,0.0,0.0,0.15,0.0,0.0,0.15,nicole eliz martinez,,LS-2380,2018
+LS,2380,3,Vinyasa Flow Yoga,0.71,0.19,0.0,0.0,0.0,0.0,0.0,0.1,kayla lee wardlaw,,LS-2380,2018
+LS,2380,4,Vinyasa Flow Yoga,0.75,0.1,0.0,0.0,0.0,0.0,0.0,0.15,kayla lee wardlaw,,LS-2380,2018
+LS,2420,1,Meditation and Relax,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2420,2018
+LS,2420,2,Meditation and Relax,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2420,2018
+LS,2420,3,Meditation and Relax,0.64,0.09,0.18,0.05,0.0,0.0,0.0,0.05,renee warren gahan,,LS-2420,2018
+LS,2420,4,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2018
+LS,2420,5,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,,LS-2420,2018
+LS,2450,2,Pilates,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,melanie ivey job,,LS-2450,2018
+LS,2460,2,Intermediate Pilates,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,,LS-2460,2018
+LS,2510,2,Running & Jogging,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,corey doug brookover,,LS-2510,2018
+MATH,1010,1,Essen Math for Informed Soc,0.31,0.42,0.19,0.0,0.0,0.0,0.0,0.08,ebenezer eduafo,,MATH-1010,2018
+MATH,1010,2,Essen Math for Informed Soc,0.2,0.31,0.17,0.14,0.11,0.0,0.0,0.06,bryce pruitt,,MATH-1010,2018
+MATH,1010,3,Essen Math for Informed Soc,0.43,0.09,0.2,0.11,0.14,0.0,0.0,0.03,jun yuan,,MATH-1010,2018
+MATH,1010,4,Essen Math for Informed Soc,0.36,0.27,0.24,0.03,0.06,0.0,0.0,0.03,marilyn reba,,MATH-1010,2018
+MATH,1020,1,Business Calculus I,0.19,0.28,0.17,0.13,0.13,0.0,0.0,0.11,randy davidson,,MATH-1020,2018
+MATH,1020,2,Business Calculus I,0.21,0.22,0.27,0.12,0.13,0.0,0.0,0.05,randy davidson,,MATH-1020,2018
+MATH,1020,3,Business Calculus I,0.09,0.26,0.24,0.26,0.07,0.0,0.0,0.09,michael thomas cowen,,MATH-1020,2018
+MATH,1020,5,Business Calculus I,0.19,0.33,0.21,0.12,0.07,0.0,0.0,0.07,anna carol bachstein,,MATH-1020,2018
+MATH,1020,6,Business Calculus I,0.15,0.18,0.43,0.05,0.13,0.0,0.0,0.08,rachel bass lanning,,MATH-1020,2018
+MATH,1020,7,Business Calculus I,0.21,0.21,0.33,0.14,0.07,0.0,0.0,0.02,tony thanh nguyen,,MATH-1020,2018
+MATH,1020,9,Business Calculus I,0.19,0.17,0.3,0.11,0.19,0.0,0.0,0.03,randy davidson,,MATH-1020,2018
+MATH,1020,11,Business Calculus I,0.2,0.32,0.27,0.07,0.1,0.0,0.0,0.05,li he,,MATH-1020,2018
+MATH,1020,12,Business Calculus I,0.2,0.22,0.24,0.12,0.17,0.0,0.0,0.05,tony thanh nguyen,,MATH-1020,2018
+MATH,1020,13,Business Calculus I,0.26,0.32,0.22,0.1,0.09,0.0,0.0,0.01,marion hanna,,MATH-1020,2018
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.44,0.19,andrew walton green,,MATH-1040,2018
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.5,0.13,nicholas ahlstrom,,MATH-1040,2018
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.65,0.03,peter westerbaan,,MATH-1040,2018
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.55,0.41,0.03,tony thanh nguyen,,MATH-1050,2018
+MATH,1060,1,Calculus of One Variable I,0.1,0.13,0.18,0.09,0.33,0.0,0.0,0.17,judith el cottingham,,MATH-1060,2018
+MATH,1060,2,Calculus of One Variable I,0.06,0.14,0.34,0.0,0.37,0.0,0.0,0.09,kayla doris javier,,MATH-1060,2018
+MATH,1060,3,Calculus of One Variable I,0.05,0.05,0.27,0.15,0.34,0.0,0.0,0.15,xueheng shi,,MATH-1060,2018
+MATH,1060,4,Calculus of One Variable I,0.05,0.2,0.2,0.03,0.4,0.0,0.0,0.13,thanh thien to,,MATH-1060,2018
+MATH,1060,5,Calculus of One Variable I,0.0,0.06,0.25,0.09,0.5,0.0,0.0,0.09,michael gle eldredge,,MATH-1060,2018
+MATH,1060,500,Calculus of One Variable I,0.3,0.3,0.3,0.1,0.0,0.0,0.0,0.0,laura dostert,,MATH-1060,2018
+MATH,1070,1,Differen and Integral Calculus,0.13,0.46,0.33,0.04,0.0,0.0,0.0,0.04,donna simms,,MATH-1070,2018
+MATH,1070,2,Differen and Integral Calculus,0.28,0.22,0.25,0.13,0.03,0.0,0.0,0.09,donna simms,,MATH-1070,2018
+MATH,1070,3,Differen and Integral Calculus,0.11,0.45,0.27,0.11,0.02,0.0,0.0,0.02,stephen peele,,MATH-1070,2018
+MATH,1070,4,Differen and Integral Calculus,0.1,0.47,0.27,0.1,0.0,0.0,0.0,0.07,stephen peele,,MATH-1070,2018
+MATH,1070,5,Differen and Integral Calculus,0.24,0.3,0.27,0.15,0.03,0.0,0.0,0.0,xiaoyuan liu,,MATH-1070,2018
+MATH,1070,6,Differen and Integral Calculus,0.18,0.43,0.23,0.09,0.02,0.0,0.0,0.05,stephen peele,,MATH-1070,2018
+MATH,1080,1,Calculus of One Variable II,0.08,0.26,0.16,0.16,0.24,0.0,0.0,0.11,thowhida akther,,MATH-1080,2018
+MATH,1080,2,Calculus of One Variable II,0.09,0.17,0.17,0.11,0.29,0.0,0.0,0.17,rui gong,,MATH-1080,2018
+MATH,1080,3,Calculus of One Variable II,0.2,0.3,0.18,0.16,0.11,0.0,0.0,0.05,charles lanning,,MATH-1080,2018
+MATH,1080,4,Calculus of One Variable II,0.33,0.31,0.11,0.02,0.11,0.0,0.0,0.11,camille zerfas,,MATH-1080,2018
+MATH,1080,5,Calculus of One Variable II,0.24,0.3,0.14,0.08,0.16,0.0,0.0,0.08,fun choi john chan john,,MATH-1080,2018
+MATH,1080,6,Calculus of One Variable II,0.25,0.16,0.27,0.14,0.14,0.0,0.0,0.05,garrett mi dranichak,,MATH-1080,2018
+MATH,1080,7,Calculus of One Variable II,0.16,0.28,0.28,0.05,0.16,0.0,0.0,0.07,pye phyo aung,,MATH-1080,2018
+MATH,1080,8,Calculus of One Variable II,0.1,0.28,0.15,0.13,0.15,0.0,0.0,0.18,rebecca ramos,,MATH-1080,2018
+MATH,1080,9,Calculus of One Variable II,0.36,0.33,0.13,0.09,0.04,0.0,0.0,0.04,meredith nicole burr,,MATH-1080,2018
+MATH,1080,10,Calculus of One Variable II,0.38,0.31,0.18,0.09,0.04,0.0,0.0,0.0,meredith nicole burr,,MATH-1080,2018
+MATH,1080,11,Calculus of One Variable II,0.07,0.34,0.3,0.0,0.16,0.0,0.0,0.14,pye phyo aung,,MATH-1080,2018
+MATH,1080,100,Calc of One Variable II (HON),0.42,0.32,0.05,0.0,0.0,0.0,0.0,0.21,beth novick,True,MATH-1080,2018
+MATH,1080,201,Calculus of One Variable II,0.1,0.29,0.33,0.0,0.14,0.0,0.0,0.14,sanwar ahmad,,MATH-1080,2018
+MATH,1080,202,Calculus of One Variable II,0.28,0.33,0.25,0.08,0.03,0.0,0.0,0.05,sergey charnyi,,MATH-1080,2018
+MATH,1080,203,Calc of One Variable II,0.17,0.38,0.25,0.04,0.08,0.0,0.0,0.08,amy christine grady,,MATH-1080,2018
+MATH,1080,204,Calculus of One Variable II,0.21,0.36,0.21,0.08,0.13,0.0,0.0,0.03,beth novick,,MATH-1080,2018
+MATH,1080,205,Calc of One Variable II,0.28,0.35,0.18,0.18,0.0,0.0,0.0,0.03,huixi li,,MATH-1080,2018
+MATH,1080,206,Calc of One Variable II,0.21,0.36,0.23,0.15,0.04,0.0,0.0,0.0,kara aile stasikelis,,MATH-1080,2018
+MATH,1080,500,Calculus of One Variable II,0.33,0.33,0.11,0.22,0.0,0.0,0.0,0.0,laura dostert,,MATH-1080,2018
+MATH,1150,1,Contemp Math for Elem Teach I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,carlos gomez,,MATH-1150,2018
+MATH,1160,1,Contemp Math for Elem Teach II,0.45,0.19,0.23,0.03,0.0,0.0,0.0,0.1,allison stoddard,,MATH-1160,2018
+MATH,1160,2,Contemp Math for Elem Teach II,0.58,0.3,0.1,0.0,0.03,0.0,0.0,0.0,allison stoddard,,MATH-1160,2018
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.9,0.05,0.05,marion hanna,,MATH-1990,2018
+MATH,2060,1,Calculus of Several Variables,0.19,0.14,0.38,0.05,0.14,0.0,0.0,0.11,allen anderson guest,,MATH-2060,2018
+MATH,2060,2,Calculus of Several Variables,0.21,0.16,0.26,0.03,0.13,0.0,0.0,0.21,allen anderson guest,,MATH-2060,2018
+MATH,2060,3,Calculus of Several Variables,0.3,0.19,0.16,0.08,0.24,0.0,0.0,0.03,allen anderson guest,,MATH-2060,2018
+MATH,2060,4,Calculus of Several Variables,0.18,0.33,0.21,0.21,0.08,0.0,0.0,0.0,alistair bentley,,MATH-2060,2018
+MATH,2060,7,Calculus of Several Variables,0.15,0.33,0.26,0.13,0.03,0.0,0.0,0.1,sofya alekseeva,,MATH-2060,2018
+MATH,2060,8,Calculus of Several Variables,0.16,0.41,0.27,0.11,0.02,0.0,0.0,0.02,sofya alekseeva,,MATH-2060,2018
+MATH,2060,9,Calculus of Several Variables,0.12,0.37,0.27,0.15,0.05,0.0,0.0,0.05,sofya alekseeva,,MATH-2060,2018
+MATH,2060,10,Calculus of Several Variables,0.22,0.36,0.22,0.06,0.06,0.0,0.0,0.06,valdez hiram lopez,,MATH-2060,2018
+MATH,2070,1,Business Calculus II,0.38,0.28,0.26,0.08,0.0,0.0,0.0,0.0,jennifer marie hanna,,MATH-2070,2018
+MATH,2070,2,Business Calculus II,0.26,0.41,0.18,0.05,0.08,0.0,0.0,0.03,jennifer marie hanna,,MATH-2070,2018
+MATH,2070,3,Business Calculus II,0.54,0.26,0.15,0.03,0.0,0.0,0.0,0.03,jennifer marie hanna,,MATH-2070,2018
+MATH,2070,4,Business Calculus II,0.22,0.32,0.15,0.13,0.09,0.0,0.0,0.09,judith irene mcknew,,MATH-2070,2018
+MATH,2070,5,Business Calculus II,0.28,0.26,0.23,0.13,0.08,0.0,0.0,0.03,judith irene mcknew,,MATH-2070,2018
+MATH,2070,6,Business Calculus II,0.33,0.33,0.21,0.05,0.05,0.0,0.0,0.03,todd anthony morra,,MATH-2070,2018
+MATH,2070,8,Business Calculus II,0.1,0.31,0.26,0.15,0.1,0.0,0.0,0.08,scott scruggs,,MATH-2070,2018
+MATH,2070,9,Business Calculus II,0.41,0.33,0.15,0.05,0.03,0.0,0.0,0.03,emma cinatl,,MATH-2070,2018
+MATH,2070,10,Business Calculus II,0.44,0.41,0.08,0.08,0.0,0.0,0.0,0.0,jennifer ray newton,,MATH-2070,2018
+MATH,2070,11,Business Calculus II,0.38,0.41,0.18,0.03,0.0,0.0,0.0,0.0,jennifer ray newton,,MATH-2070,2018
+MATH,2070,12,Business Calculus II,0.48,0.2,0.15,0.08,0.03,0.0,0.0,0.08,jennifer ray newton,,MATH-2070,2018
+MATH,2070,13,Business Calculus II,0.54,0.18,0.1,0.13,0.03,0.0,0.0,0.03,jennifer ray newton,,MATH-2070,2018
+MATH,2070,14,Business Calculus II,0.56,0.11,0.22,0.08,0.0,0.0,0.0,0.03,dyken jennifer  van e,,MATH-2070,2018
+MATH,2070,15,Business Calculus II,0.29,0.37,0.26,0.03,0.0,0.0,0.0,0.05,madeleine stville,,MATH-2070,2018
+MATH,2070,16,Business Calculus II,0.39,0.31,0.06,0.06,0.11,0.0,0.0,0.08,allison stoddard,,MATH-2070,2018
+MATH,2080,1,Intro to Ordin Diff Equations,0.29,0.21,0.25,0.08,0.13,0.0,0.0,0.04,terri johnson,,MATH-2080,2018
+MATH,2080,2,Intro to Ordin Diff Equations,0.38,0.2,0.27,0.07,0.07,0.0,0.0,0.02,irina viktorova,,MATH-2080,2018
+MATH,2080,3,Intro to Ordin Diff Equations,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.05,oleg yordanov,,MATH-2080,2018
+MATH,2080,4,Intro to Ordin Diff Equations,0.15,0.39,0.24,0.06,0.06,0.0,0.0,0.09,timothy fran parrott,,MATH-2080,2018
+MATH,2080,6,Intro to Ordin Diff Equations,0.4,0.38,0.13,0.07,0.02,0.0,0.0,0.0,timothy cha teitloff,,MATH-2080,2018
+MATH,2080,7,Intro to Ordin Diff Equations,0.32,0.35,0.22,0.03,0.08,0.0,0.0,0.0,oleg yordanov,,MATH-2080,2018
+MATH,2080,8,Intro to Ordin Diff Equations,0.51,0.16,0.3,0.0,0.0,0.0,0.0,0.03,timothy fran parrott,,MATH-2080,2018
+MATH,2080,9,Intro to Ordin Diff Equations,0.26,0.17,0.21,0.07,0.14,0.0,0.0,0.14,terri johnson,,MATH-2080,2018
+MATH,2080,10,Intro to Ordin Diff Equations,0.42,0.38,0.16,0.04,0.0,0.0,0.0,0.0,timothy cha teitloff,,MATH-2080,2018
+MATH,2080,11,Intro to Ordin Diff Equations,0.21,0.25,0.25,0.11,0.14,0.0,0.0,0.04,julie lassiter,,MATH-2080,2018
+MATH,2080,12,Intro to Ordin Diff Equations,0.48,0.46,0.04,0.0,0.0,0.0,0.0,0.02,irina viktorova,,MATH-2080,2018
+MATH,2080,13,Intro to Ordin Diff Equations,0.23,0.29,0.14,0.09,0.09,0.0,0.0,0.17,terri johnson,,MATH-2080,2018
+MATH,2080,14,Intro to Ordin Diff Equations,0.16,0.22,0.28,0.13,0.09,0.0,0.0,0.13,julie lassiter,,MATH-2080,2018
+MATH,2080,15,Intro to Ordin Diff Equations,0.36,0.26,0.14,0.12,0.05,0.0,0.0,0.07,timothy fran parrott,,MATH-2080,2018
+MATH,2080,16,Intro to Ordin Diff Equations,0.41,0.25,0.18,0.09,0.0,0.0,0.0,0.07,timothy cha teitloff,,MATH-2080,2018
+MATH,2080,17,Intro to Ordin Diff Equations,0.18,0.36,0.32,0.06,0.03,0.0,0.0,0.05,sean sather-wagstaff,,MATH-2080,2018
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.35,0.43,0.17,0.0,0.0,0.0,0.0,0.04,michael adam burr,True,MATH-2080,2018
+MATH,2160,1,Geometry for Elem Sch Teachers,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,eliza darg gallagher,,MATH-2160,2018
+MATH,3020,1,Stat for Science & Engineering,0.56,0.33,0.03,0.03,0.03,0.0,0.0,0.03,ellen hepfer breazel,,MATH-3020,2018
+MATH,3020,2,Stat for Science & Engineering,0.23,0.45,0.28,0.0,0.05,0.0,0.0,0.0,gamage prabh withana,,MATH-3020,2018
+MATH,3020,3,Stat for Science & Engineering,0.38,0.46,0.13,0.03,0.0,0.0,0.0,0.0,xiyan tan,,MATH-3020,2018
+MATH,3020,4,Stat for Science & Engineering,0.82,0.11,0.05,0.03,0.0,0.0,0.0,0.0,haotian feng,,MATH-3020,2018
+MATH,3020,5,Stat for Science & Engineering,0.29,0.26,0.16,0.0,0.13,0.0,0.0,0.16,paul james cubre,,MATH-3020,2018
+MATH,3020,6,Stat for Science & Engineering,0.43,0.3,0.26,0.0,0.0,0.0,0.0,0.0,yinggu bao,,MATH-3020,2018
+MATH,3020,8,Stat for Science & Engineering,0.25,0.25,0.3,0.05,0.1,0.0,0.0,0.05,patrick gerard,,MATH-3020,2018
+MATH,3020,9,Stat for Science & Engineering,0.36,0.36,0.13,0.05,0.1,0.0,0.0,0.0,ellen hepfer breazel,,MATH-3020,2018
+MATH,3080,1,College Geometry,0.82,0.06,0.0,0.0,0.12,0.0,0.0,0.0,nicole alain sinwell,,MATH-3080,2018
+MATH,3110,1,Linear Algebra,0.27,0.27,0.16,0.07,0.11,0.0,0.0,0.11,svetlana poznanovikj,,MATH-3110,2018
+MATH,3110,2,Linear Algebra,0.21,0.51,0.16,0.02,0.0,0.0,0.0,0.09,neil calkin,,MATH-3110,2018
+MATH,3110,3,Linear Algebra,0.16,0.32,0.32,0.07,0.07,0.0,0.0,0.07,xuhong gao,,MATH-3110,2018
+MATH,3110,4,Linear Algebra,0.29,0.15,0.22,0.1,0.1,0.0,0.0,0.15,xuhong gao,,MATH-3110,2018
+MATH,3110,5,Linear Algebra,0.12,0.3,0.19,0.21,0.14,0.0,0.0,0.05,hui xue,,MATH-3110,2018
+MATH,3110,6,Linear Algebra,0.17,0.27,0.25,0.21,0.08,0.0,0.0,0.02,hui xue,,MATH-3110,2018
+MATH,3110,7,Linear Algebra,0.33,0.24,0.15,0.15,0.07,0.0,0.0,0.07,elena stan dimitrova,,MATH-3110,2018
+MATH,3110,200,Linear Algebra,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,kevin james,,MATH-3110,2018
+MATH,3190,1,Introduction to Proof,0.31,0.19,0.31,0.04,0.08,0.0,0.0,0.08,james bar coykendall,,MATH-3190,2018
+MATH,3190,2,Introduction to Proof,0.58,0.27,0.08,0.0,0.04,0.0,0.0,0.04,malcolm edwar rupert,,MATH-3190,2018
+MATH,3600,1,Intermediate Math Computing,0.76,0.12,0.04,0.04,0.0,0.0,0.0,0.04,mark cawood,,MATH-3600,2018
+MATH,3600,2,Intermediate Math Computing,0.45,0.18,0.14,0.0,0.05,0.0,0.0,0.18,mark cawood,,MATH-3600,2018
+MATH,3650,1,Numerical Mthds for Engineers,0.36,0.27,0.15,0.0,0.15,0.0,0.0,0.06,mengying xiao,,MATH-3650,2018
+MATH,3650,2,Numerical Mthds for Engineers,0.41,0.3,0.14,0.03,0.05,0.0,0.0,0.08,christopher cox,,MATH-3650,2018
+MATH,3650,3,Numerical Mthds for Engineers,0.26,0.39,0.16,0.06,0.06,0.0,0.0,0.06,vincent ervin,,MATH-3650,2018
+MATH,3650,4,Numerical Mthds for Engineers,0.19,0.24,0.27,0.14,0.08,0.0,0.0,0.08,vincent ervin,,MATH-3650,2018
+MATH,4000,1,Theory of Probability,0.32,0.48,0.12,0.0,0.0,0.0,0.0,0.08,xiaoqian sun,,MATH-4000,2018
+MATH,4000,2,Theory of Probability,0.5,0.21,0.21,0.0,0.07,0.0,0.0,0.0,peter kiessler,,MATH-4000,2018
+MATH,4030,1,Intro to Statistical Theory,0.31,0.31,0.31,0.0,0.08,0.0,0.0,0.0,xiaoqian sun,,MATH-4030,2018
+MATH,4070,1,Regress & Time-Series Analysis,0.67,0.08,0.08,0.08,0.08,0.0,0.0,0.0,christopher mcmahan,,MATH-4070,2018
+MATH,4110,1,Introduction to Combinatorics,0.46,0.31,0.08,0.0,0.0,0.0,0.0,0.15,beth novick,,MATH-4110,2018
+MATH,4120,1,Algebra I,0.19,0.52,0.15,0.0,0.11,0.0,0.0,0.04,james bar coykendall,,MATH-4120,2018
+MATH,4190,1,Discrete Math Structures I,0.28,0.59,0.1,0.03,0.0,0.0,0.0,0.0,wayne goddard,,MATH-4190,2018
+MATH,4190,2,Discrete Math Structures I,0.19,0.34,0.25,0.0,0.16,0.0,0.0,0.06,sean sather-wagstaff,,MATH-4190,2018
+MATH,4310,1,Theory of Interest,0.21,0.43,0.29,0.0,0.0,0.0,0.0,0.07, erwin walker,,MATH-4310,2018
+MATH,4340,1,Adv Engineering Mathematics,0.25,0.15,0.3,0.15,0.05,0.0,0.0,0.1,hyesuk lee,,MATH-4340,2018
+MATH,4340,2,Adv Engineering Mathematics,0.28,0.22,0.25,0.06,0.0,0.0,0.0,0.19,qingshan chen,,MATH-4340,2018
+MATH,4400,1,Linear Programming,0.5,0.27,0.04,0.08,0.08,0.0,0.0,0.04,margaret mari wiecek,,MATH-4400,2018
+MATH,4530,1,Advanced Calculus I,0.41,0.28,0.17,0.07,0.07,0.0,0.0,0.0,james peterson,,MATH-4530,2018
+MATH,4540,1,Advanced Calculus II,0.21,0.38,0.29,0.08,0.04,0.0,0.0,0.0,james peterson,,MATH-4540,2018
+MATH,4600,1,Intro to Numerical Analysis I,0.44,0.25,0.13,0.0,0.06,0.0,0.0,0.13,leo rebholz,,MATH-4600,2018
+MATH,6000,1,Theory of Probability,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,xiaoqian sun,,MATH-6000,2018
+MATH,6340,1,Adv Engineering Mathematics,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,hyesuk lee,,MATH-6340,2018
+MATH,6410,1,Intro to Stochastic Models,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,,MATH-6410,2018
+MATH,8030,1,Stochastic Processes,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,peter kiessler,,MATH-8030,2018
+MATH,8040,1,Statistical Inference,0.5,0.19,0.19,0.0,0.06,0.0,0.0,0.06,christopher mcmahan,,MATH-8040,2018
+MATH,8050,1,Data Analysis,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ling ma,,MATH-8050,2018
+MATH,8090,1,Time Series Analysis,0.44,0.31,0.0,0.0,0.0,0.0,0.0,0.25,colin gallagher,,MATH-8090,2018
+MATH,8100,1,Mathematical Programming,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,,MATH-8100,2018
+MATH,8120,1,Discrete Optimization,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,herve louis kerivin,,MATH-8120,2018
+MATH,8130,1,Advanced Linear Programming,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,,MATH-8130,2018
+MATH,8210,1,Linear Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,benjamin jaye,,MATH-8210,2018
+MATH,8220,1,Measure and Integration,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,martin johan schmoll,,MATH-8220,2018
+MATH,8530,1,Matrix Analysis,0.6,0.1,0.2,0.0,0.1,0.0,0.0,0.0,elena stan dimitrova,,MATH-8530,2018
+MATH,8540,1,Theory of Graphs,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,beth novick,,MATH-8540,2018
+MATH,8560,1,Ther of Error-Correcting Codes,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,felice manganiello,,MATH-8560,2018
+MATH,8600,1,Intro to Scientific Computing,0.35,0.35,0.12,0.0,0.12,0.0,0.0,0.06,eleanor jenkins,,MATH-8600,2018
+MATH,8610,1,Advanced Numerical Analysis I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,fei xue,,MATH-8610,2018
+MATH,9830,1,Sel Top in Computational Math,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,timo johanne heister,,MATH-9830,2018
+MBA,8030,1,Stat Analy of Bus Op,0.19,0.35,0.27,0.0,0.05,0.0,0.0,0.14,magda gabriela sava,,MBA-8030,2018
+MBA,8060,1,Operations Mgt,0.28,0.58,0.14,0.0,0.0,0.0,0.0,0.0,janis miller,,MBA-8060,2018
+MBA,8060,20,Operations Mgt,0.42,0.42,0.12,0.0,0.0,0.0,0.0,0.04, sridharan,,MBA-8060,2018
+MBA,8070,1,Financial Management,0.56,0.28,0.16,0.0,0.0,0.0,0.0,0.0,melvin stith,,MBA-8070,2018
+MBA,8070,2,Financial Management,0.68,0.15,0.13,0.0,0.0,0.0,0.0,0.05,melvin stith,,MBA-8070,2018
+MBA,8090,1,Org Beh & Hum Res Mg,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,,MBA-8090,2018
+MBA,8090,2,Org Beh & Hum Res Mg,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,,MBA-8090,2018
+MBA,8090,3,Org Beh & Hum Res Mg,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,,MBA-8090,2018
+MBA,8170,21,Bus Forecasting,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,sukran nilv atadeniz,,MBA-8170,2018
+MBA,8190,1,Intro to Acc and Fin,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,melvin stith,,MBA-8190,2018
+MBA,8190,2,Intro to Acc and Fin,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,melvin stith,,MBA-8190,2018
+MBA,8290,1,Marketing Foundation,0.6,0.36,0.0,0.0,0.0,0.0,0.0,0.04,gary hunter,,MBA-8290,2018
+MBA,8330,1,Real Estate Investmt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,franklin bogu wallin,,MBA-8330,2018
+MBA,8370,1,Legal Environ of Bus,0.2,0.77,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2018
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,,MBA-8400,2018
+MBA,8430,10,Entrepreneurial Accounting,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,james milt kohlmeyer,,MBA-8430,2018
+MBA,8440,10,Entrepreneurial Law,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,scott hile,,MBA-8440,2018
+MBA,8450,1,Technology & Innovation Mgt,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8450,2018
+MBA,8470,1,New Venture Creation,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,,MBA-8470,2018
+MBA,8510,10,Bus Operations & Logistics,0.69,0.19,0.04,0.0,0.04,0.0,0.0,0.04,george kennet morgan,,MBA-8510,2018
+MBA,8540,1,Managerial Accounting,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,,MBA-8540,2018
+MBA,8540,2,Managerial Accounting,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,,MBA-8540,2018
+MBA,8540,3,Managerial Accounting,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,,MBA-8540,2018
+MBA,8590,1,Mgr Decision Model,0.42,0.33,0.08,0.0,0.06,0.0,0.0,0.11,magda gabriela sava,,MBA-8590,2018
+MBA,8590,2,Mgr Decision Model,0.54,0.23,0.15,0.0,0.08,0.0,0.0,0.0,sara elizabeth yoder,,MBA-8590,2018
+MBA,8600,1,Advanced Marketing Strategy,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MBA-8600,2018
+MBA,8610,1,Information Systems,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,,MBA-8610,2018
+MBA,8620,1,Managerial Economics,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,,MBA-8620,2018
+MBA,8620,2,Managerial Economics,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,,MBA-8620,2018
+MBA,8700,1,Strategic Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,matthew charle klein,,MBA-8700,2018
+MBA,8720,1,Entrepr Finance,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,matthew charle klein,,MBA-8720,2018
+MBA,8750,1,Enterprise Develpmnt,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8750,2018
+MBA,8990,1,Advanced Leadership,0.89,0.06,0.02,0.0,0.0,0.0,0.0,0.02,gail depriest,,MBA-8990,2018
+MBA,8990,3,Service Innovation,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,aleda marie roth,,MBA-8990,2018
+MBA,8990,4,Bus. Sport. Enter.,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,,MBA-8990,2018
+MBA,8990,7,Business Analytics Models,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,jennie lynn farmer,,MBA-8990,2018
+MBA,8990,20,Analytics & Application,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,heshan sun,,MBA-8990,2018
+MBA,8990,22,Marketing Analytics,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,bruce snyder,,MBA-8990,2018
+ME,2000,1,Sophomore Seminar,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.02,donald beasley,,ME-2000,2018
+ME,2010,1,Statics & Dynamics,0.06,0.25,0.27,0.16,0.12,0.0,0.0,0.14,marisa kikendall orr,,ME-2010,2018
+ME,2010,2,Statics & Dynamics,0.05,0.25,0.28,0.13,0.2,0.0,0.0,0.1,paul joseph,,ME-2010,2018
+ME,2030,1,Founda Th/Fl Syst,0.24,0.58,0.14,0.01,0.01,0.0,0.0,0.02,yiqiang han,,ME-2030,2018
+ME,2030,2,Founda Th/Fl Syst,0.28,0.28,0.23,0.09,0.08,0.0,0.0,0.05,xiangchun xuan,,ME-2030,2018
+ME,2040,1,Mechanics of Materials,0.31,0.47,0.17,0.04,0.01,0.0,0.0,0.0,gang li,,ME-2040,2018
+ME,2040,2,Mechanics of Materials,0.16,0.52,0.18,0.05,0.05,0.0,0.0,0.05,jorge ivan rodriguez,,ME-2040,2018
+ME,2040,3,Mechanics of Materials,0.28,0.5,0.19,0.03,0.0,0.0,0.0,0.0,garrett pataky,,ME-2040,2018
+ME,2040,303,Mechanics of Materials (HON),0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,garrett pataky,True,ME-2040,2018
+ME,2220,2,Mechanical Engineering Lab I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,3,Mechanical Engineering Lab I,0.21,0.64,0.14,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,5,Mechanical Engineering Lab I,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,6,Mechanical Engineering Lab I,0.19,0.5,0.25,0.0,0.0,0.0,0.0,0.06,todd al schweisinger,,ME-2220,2018
+ME,2220,7,Mechanical Engineering Lab I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,10,Mechanical Engineering Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,todd al schweisinger,,ME-2220,2018
+ME,2220,11,Mechanical Engineering Lab I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,13,Mechanical Engineering Lab I,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,14,Mechanical Engineering Lab I,0.29,0.43,0.21,0.07,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,15,Mechanical Engineering Lab I,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,17,Mechanical Engineering Lab I,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2220,18,Mechanical Engineering Lab I,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2220,2018
+ME,2900,619,CI ME - Savonius Wind Turbine,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-2900,2018
+ME,3030,1,Thermodynamics,0.11,0.2,0.53,0.02,0.09,0.0,0.0,0.04,john saylor,,ME-3030,2018
+ME,3030,2,Thermodynamics,0.13,0.32,0.45,0.06,0.0,0.0,0.0,0.04,richard miller,,ME-3030,2018
+ME,3040,1,Heat Transfer,0.03,0.32,0.5,0.11,0.03,0.0,0.0,0.03,jean-marc ge delhaye,,ME-3040,2018
+ME,3040,2,Heat Transfer,0.21,0.36,0.28,0.0,0.11,0.0,0.0,0.04,jean-marc ge delhaye,,ME-3040,2018
+ME,3040,3,Heat Transfer,0.21,0.38,0.21,0.15,0.0,0.0,0.0,0.04,xin zhao,,ME-3040,2018
+ME,3050,1,Model/an Dy Syst,0.21,0.39,0.36,0.01,0.03,0.0,0.0,0.0,phanind tallapragada,,ME-3050,2018
+ME,3050,2,Model/an Dy Syst,0.2,0.37,0.31,0.06,0.05,0.0,0.0,0.02,joshua bostwick,,ME-3050,2018
+ME,3060,1,Fund Machine Design,0.11,0.61,0.23,0.0,0.02,0.0,0.0,0.03,oliver myers,,ME-3060,2018
+ME,3060,2,Fund Machine Design,0.2,0.63,0.12,0.03,0.01,0.0,0.0,0.01,joshua summers,,ME-3060,2018
+ME,3070,1,Found of Mechanical Systems,0.46,0.34,0.11,0.01,0.06,0.0,0.0,0.01,jorge ivan rodriguez,,ME-3070,2018
+ME,3070,2,Found of Mechanical Systems,0.36,0.46,0.16,0.01,0.0,0.0,0.0,0.01,gregory mocko,,ME-3070,2018
+ME,3080,1,Fluid Mechanics,0.21,0.45,0.31,0.03,0.0,0.0,0.0,0.0,chenning tong,,ME-3080,2018
+ME,3080,2,Fluid Mechanics,0.16,0.42,0.39,0.03,0.0,0.0,0.0,0.0,ethan kung,,ME-3080,2018
+ME,3080,3,Fluid Mechanics,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-3080,2018
+ME,3100,1,Thermo/Heat Transfer,0.25,0.5,0.17,0.0,0.03,0.0,0.0,0.06,yiqiang han,,ME-3100,2018
+ME,3120,1,Manuf Processes,0.31,0.66,0.03,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-3120,2018
+ME,3330,1,Mechanical Engineering Lab II,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-3330,2018
+ME,3330,2,Mechanical Engineering Lab II,0.27,0.53,0.13,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,,ME-3330,2018
+ME,3330,3,Mechanical Engineering Lab II,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-3330,2018
+ME,3330,5,Mechanical Engineering Lab II,0.1,0.8,0.1,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-3330,2018
+ME,3330,6,Mechanical Engineering Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-3330,2018
+ME,3330,7,Mechanical Engineering Lab II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-3330,2018
+ME,3330,9,Mechanical Engineering Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-3330,2018
+ME,3330,11,Mechanical Engineering Lab II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-3330,2018
+ME,3330,17,Mechanical Engineering Lab II,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-3330,2018
+ME,4010,1,Mech Engr Design,0.85,0.1,0.01,0.01,0.01,0.0,0.0,0.0,cameron turner,,ME-4010,2018
+ME,4020,1,Intern in Engr Des,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-4020,2018
+ME,4020,4,Intern in Engr Des,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2018
+ME,4020,5,Intern in Engr Des,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,,ME-4020,2018
+ME,4020,6,Intern in Engr Des,0.3,0.35,0.05,0.3,0.0,0.0,0.0,0.0,nicole gisel coutris,,ME-4020,2018
+ME,4020,7,Intern in Engr Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2018
+ME,4020,8,Intern in Engr Des,0.25,0.6,0.15,0.0,0.0,0.0,0.0,0.0,yue wang,,ME-4020,2018
+ME,4020,9,Intern in Engr Des,0.25,0.45,0.25,0.05,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2018
+ME,4030,1,Control Dynamic Systems,0.23,0.33,0.4,0.05,0.0,0.0,0.0,0.0,suyi li,,ME-4030,2018
+ME,4030,2,Control Dynamic Systems,0.24,0.4,0.2,0.13,0.02,0.0,0.0,0.0,yue wang,,ME-4030,2018
+ME,4180,1,F E A in M E Design,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,oliver myers,,ME-4180,2018
+ME,4220,1,Design Gas Turbines,0.56,0.27,0.15,0.02,0.0,0.0,0.0,0.0,abhijit som,,ME-4220,2018
+ME,4260,1,Nuclear Energy,0.38,0.32,0.24,0.06,0.0,0.0,0.0,0.0,richard watkins,,ME-4260,2018
+ME,4300,1,Mech Comp Materials,0.19,0.29,0.33,0.14,0.0,0.0,0.0,0.05,huijuan zhao,,ME-4300,2018
+ME,4400,1,Matls for Aggr Envir,0.44,0.31,0.22,0.0,0.03,0.0,0.0,0.0,garrett pataky,,ME-4400,2018
+ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-4440,2018
+ME,4440,2,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-4440,2018
+ME,4440,5,Mechanical Engineering Lab III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-4440,2018
+ME,4440,13,Mechanical Engineering Lab III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,,ME-4440,2018
+ME,4930,11,Selected Topics ME (MicroFab),0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,,ME-4930,2018
+ME,4930,24,Sel. Topics ME (Mechatronics),0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4930,2018
+ME,4930,34,Sel. Topics in ME (Cardio),0.07,0.79,0.14,0.0,0.0,0.0,0.0,0.0,ethan kung,,ME-4930,2018
+ME,4930,39,Sel Topics ME (Solar Energy),0.35,0.48,0.15,0.02,0.0,0.0,0.0,0.0,daniel fant,,ME-4930,2018
+ME,6300,1,Mech Comp Materials,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,,ME-6300,2018
+ME,6930,11,Selected Topics ME (MicroFab),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,,ME-6930,2018
+ME,6930,34,Selected Topics in ME (Cardio),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,,ME-6930,2018
+ME,8200,1,Mod Cont Engr,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,,ME-8200,2018
+ME,8310,1,Convective Ht Trans,0.45,0.18,0.18,0.0,0.0,0.0,0.0,0.18,xin zhao,,ME-8310,2018
+ME,8370,1,Theory of Elast I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,nicole gisel coutris,,ME-8370,2018
+ME,8450,1,Structural Vibration,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,suyi li,,ME-8450,2018
+ME,8720,1,Design Automatn for Mech Engrs,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,cameron turner,,ME-8720,2018
+ME,8730,1,Res Mthds Coll Desgn,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,joshua summers,,ME-8730,2018
+ME,8930,24,Sel. Topics ME (Mechatronics),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-8930,2018
+ME,8930,424,Sel. Topics ME (Mechatronics),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-8930,2018
+MGT,2010,1,Principles of Management,0.4,0.4,0.14,0.03,0.01,0.0,0.0,0.01,katherine clark,,MGT-2010,2018
+MGT,2010,2,Principles of Management,0.47,0.38,0.1,0.03,0.0,0.0,0.0,0.01,tina robbins,,MGT-2010,2018
+MGT,2010,7,Principles of Management,0.23,0.36,0.38,0.03,0.0,0.0,0.0,0.0,christopher mann,,MGT-2010,2018
+MGT,2010,8,Principles of Management,0.28,0.4,0.2,0.08,0.0,0.0,0.0,0.05,christopher mann,,MGT-2010,2018
+MGT,2010,10,Principles of Management,0.26,0.46,0.2,0.04,0.02,0.0,0.0,0.02,ashley willi parnell,,MGT-2010,2018
+MGT,2010,11,Principles of Management,0.3,0.3,0.33,0.0,0.05,0.0,0.0,0.03,ashley willi parnell,,MGT-2010,2018
+MGT,2180,1,Management PC Applications,0.52,0.32,0.09,0.03,0.02,0.0,0.0,0.02,ryan toole,,MGT-2180,2018
+MGT,2180,2,Management PC Applications,0.33,0.3,0.07,0.04,0.22,0.0,0.0,0.04,ryan toole,,MGT-2180,2018
+MGT,3070,1,Human Resource Management,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,,MGT-3070,2018
+MGT,3070,2,Human Resource Management,0.88,0.08,0.03,0.03,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2018
+MGT,3070,3,Human Resource Management,0.3,0.63,0.08,0.0,0.0,0.0,0.0,0.0,priscilla harrison,,MGT-3070,2018
+MGT,3070,4,Human Resource Management,0.4,0.53,0.05,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,,MGT-3070,2018
+MGT,3070,5,Human Resource Management,0.7,0.28,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2018
+MGT,3070,6,Human Resource Management,0.45,0.48,0.05,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,,MGT-3070,2018
+MGT,3100,1,Intermed Business Statistics,0.55,0.18,0.25,0.03,0.0,0.0,0.0,0.0,yunsik choi,,MGT-3100,2018
+MGT,3100,2,Intermed Business Statistics,0.33,0.33,0.23,0.05,0.03,0.0,0.0,0.05,mustafa serka akturk,,MGT-3100,2018
+MGT,3100,3,Intermed Business Statistics,0.23,0.31,0.21,0.08,0.1,0.0,0.0,0.08,yunsik choi,,MGT-3100,2018
+MGT,3100,4,Intermed Business Statistics,0.5,0.24,0.07,0.0,0.12,0.0,0.0,0.07,remi charpin,,MGT-3100,2018
+MGT,3100,5,Intermed Business Statistics,0.58,0.27,0.13,0.0,0.0,0.0,0.0,0.02,wenxi pu,,MGT-3100,2018
+MGT,3100,6,Intermed Business Statistics,0.45,0.32,0.13,0.0,0.05,0.0,0.0,0.05,sukran nilv atadeniz,,MGT-3100,2018
+MGT,3100,7,Intermed Business Statistics,0.24,0.44,0.22,0.0,0.02,0.0,0.0,0.07,magda gabriela sava,,MGT-3100,2018
+MGT,3100,8,Intermed Business Statistics,0.42,0.26,0.24,0.03,0.03,0.0,0.0,0.03,mustafa serka akturk,,MGT-3100,2018
+MGT,3100,10,Intermed Business Statistics,0.49,0.44,0.03,0.05,0.0,0.0,0.0,0.0,sukran nilv atadeniz,,MGT-3100,2018
+MGT,3100,11,Intermed Business Statistics,0.64,0.26,0.08,0.0,0.0,0.0,0.0,0.03,thomas simpson,,MGT-3100,2018
+MGT,3120,1,Decision Models for Management,0.08,0.26,0.45,0.08,0.09,0.0,0.0,0.05,sara elizabeth yoder,,MGT-3120,2018
+MGT,3120,2,Decision Models for Management,0.12,0.27,0.39,0.1,0.07,0.0,0.0,0.04,sara elizabeth yoder,,MGT-3120,2018
+MGT,3120,5,Decision Models for Management,0.31,0.39,0.31,0.0,0.0,0.0,0.0,0.0,james turner,,MGT-3120,2018
+MGT,3170,1,Logistics Mgmt,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,ahmet colak,,MGT-3170,2018
+MGT,3180,1,Mgt of Info Systems,0.15,0.6,0.2,0.0,0.0,0.0,0.0,0.05,russell purvis,,MGT-3180,2018
+MGT,3180,2,Mgt of Info Systems,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,marten risius,,MGT-3180,2018
+MGT,3180,3,Mgt of Info Systems,0.56,0.36,0.05,0.0,0.03,0.0,0.0,0.0,tina marie esposito,,MGT-3180,2018
+MGT,3180,4,Mgt of Info Systems,0.41,0.44,0.1,0.03,0.0,0.0,0.0,0.03,tina marie esposito,,MGT-3180,2018
+MGT,3500,1,Intro to Business Analytics,0.29,0.68,0.03,0.0,0.0,0.0,0.0,0.0,siyuan li,,MGT-3500,2018
+MGT,3510,1,Business Analytics & Problems,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,sukran nilv atadeniz,,MGT-3510,2018
+MGT,3900,1,Ops Mgt,0.43,0.48,0.05,0.0,0.05,0.0,0.0,0.0,maneeshred ajjuguttu,,MGT-3900,2018
+MGT,3900,2,Ops Mgt,0.09,0.45,0.3,0.09,0.02,0.0,0.0,0.05,min kyung lee,,MGT-3900,2018
+MGT,3900,3,Ops Mgt,0.18,0.2,0.4,0.08,0.0,0.0,0.0,0.15,min kyung lee,,MGT-3900,2018
+MGT,3900,4,Ops Mgt,0.11,0.3,0.49,0.11,0.0,0.0,0.0,0.0,zachary mor leffakis,,MGT-3900,2018
+MGT,3900,5,Ops Mgt,0.35,0.3,0.3,0.03,0.03,0.0,0.0,0.0,daniel nielubowicz,,MGT-3900,2018
+MGT,4000,2,Mgt of Organizational Behavior,0.25,0.43,0.27,0.02,0.02,0.0,0.0,0.0,thomas jos zagenczyk,,MGT-4000,2018
+MGT,4000,3,Mgt of Organizational Behavior,0.38,0.33,0.26,0.0,0.03,0.0,0.0,0.0,philip roth,,MGT-4000,2018
+MGT,4000,4,Mgt of Organizational Behavior,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2018
+MGT,4020,1,Ops Pln and Ctl,0.07,0.57,0.21,0.14,0.0,0.0,0.0,0.0,zachary mor leffakis,,MGT-4020,2018
+MGT,4080,1,Lean Operations,0.23,0.32,0.36,0.0,0.09,0.0,0.0,0.0,zachary mor leffakis,,MGT-4080,2018
+MGT,4110,1,Project Management,0.38,0.43,0.15,0.03,0.0,0.0,0.0,0.03,russell purvis,,MGT-4110,2018
+MGT,4120,1,Supplier Management,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,ahmet colak,,MGT-4120,2018
+MGT,4150,1,Business Strategy,0.24,0.52,0.21,0.02,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2018
+MGT,4150,2,Business Strategy,0.24,0.63,0.11,0.0,0.0,0.0,0.0,0.02,james liddle,,MGT-4150,2018
+MGT,4150,3,Business Strategy,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,dennis lee lester,,MGT-4150,2018
+MGT,4150,4,Business Strategy,0.43,0.35,0.2,0.02,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2018
+MGT,4150,5,Business Strategy,0.4,0.51,0.09,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,,MGT-4150,2018
+MGT,4150,6,Business Strategy,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,,MGT-4150,2018
+MGT,4150,7,Business Strategy,0.23,0.6,0.16,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2018
+MGT,4150,8,Business Strategy,0.15,0.61,0.24,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2018
+MGT,4150,10,Business Strategy,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,dennis lee lester,,MGT-4150,2018
+MGT,4160,1,Special Topics Hr,0.62,0.24,0.08,0.0,0.0,0.0,0.0,0.05,alejandra sa kennedy,,MGT-4160,2018
+MGT,4230,1,Intern Bus Mgt,0.04,0.59,0.28,0.02,0.02,0.0,0.0,0.04,janis miller,,MGT-4230,2018
+MGT,4230,2,Intern Bus Mgt,0.16,0.44,0.27,0.11,0.02,0.0,0.0,0.0,janis miller,,MGT-4230,2018
+MGT,4230,3,Intern Bus Mgt,0.09,0.26,0.5,0.09,0.02,0.0,0.0,0.04,wayne stewart,,MGT-4230,2018
+MGT,4230,4,Intern Bus Mgt,0.13,0.13,0.56,0.11,0.04,0.0,0.0,0.02,wayne stewart,,MGT-4230,2018
+MGT,4240,1,Global Supply Chain,0.26,0.55,0.16,0.03,0.0,0.0,0.0,0.0,yann ferrand,,MGT-4240,2018
+MGT,4270,1,Managing Improvement,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,samer ess abdlrahman,,MGT-4270,2018
+MGT,4310,1,Emp Rights & Resp,0.24,0.55,0.21,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,,MGT-4310,2018
+MGT,4350,1,Pers Interviewing,0.33,0.28,0.33,0.0,0.05,0.0,0.0,0.03,philip roth,,MGT-4350,2018
+MGT,4520,1,Business Analysis,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,marten risius,,MGT-4520,2018
+MGT,4540,1,Systems Implement,0.18,0.47,0.24,0.0,0.06,0.0,0.0,0.06,heshan sun,,MGT-4540,2018
+MGT,4550,1,Emerging I T Trends,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,,MGT-4550,2018
+MGT,4560,1,Business Info Mgt,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,siyuan li,,MGT-4560,2018
+MGT,4900,1,Being A Leader,0.7,0.16,0.11,0.0,0.0,0.0,0.0,0.03,christopher mann,,MGT-4900,2018
+MGT,4900,2,Being A Leader,0.67,0.19,0.1,0.0,0.0,0.0,0.0,0.05,christopher mann,,MGT-4900,2018
+MGT,8120,1,Supply Chain Mgt,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,yann ferrand,,MGT-8120,2018
+MICR,3050,1,General Microbiology,0.46,0.36,0.14,0.03,0.01,0.0,0.0,0.0,kristi jam whitehead,,MICR-3050,2018
+MICR,3050,2,General Microbiology,0.5,0.25,0.15,0.06,0.01,0.0,0.0,0.02,krista barri rudolph,,MICR-3050,2018
+MICR,3050,3,General Microbiology,0.62,0.3,0.03,0.05,0.0,0.0,0.0,0.0,krista barri rudolph,,MICR-3050,2018
+MICR,4000,1,Public Health Micro,0.57,0.26,0.09,0.06,0.0,0.0,0.0,0.02,kristi jam whitehead,,MICR-4000,2018
+MICR,4020,1,Environmental Micro,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,john michael henson,,MICR-4020,2018
+MICR,4070,1,Food and Dairy Micro,0.25,0.46,0.22,0.06,0.0,0.0,0.0,0.0,xiuping jiang,,MICR-4070,2018
+MICR,4110,1,Pathogenic Bact,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kears milhous,,MICR-4110,2018
+MICR,4120,1,Bacterial Physiology,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.02,wilbur kears milhous,,MICR-4120,2018
+MICR,4130,1,Industrial Micro,0.31,0.54,0.11,0.02,0.0,0.0,0.0,0.03,tzuen-rong jer tzeng,,MICR-4130,2018
+MICR,4140,1,Basic Immunology,0.69,0.29,0.0,0.0,0.0,0.0,0.0,0.02,charles rice,,MICR-4140,2018
+MICR,4170,1,Cancer and Aging,0.64,0.29,0.04,0.01,0.0,0.0,0.0,0.01,yuqing dong,,MICR-4170,2018
+MICR,4500,1,Advanced Microbiology I,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2018
+MICR,4500,2,Advanced Microbiology I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2018
+MICR,4500,3,Advanced Microbiology I,0.31,0.38,0.23,0.0,0.0,0.0,0.0,0.08,harry kurtz,,MICR-4500,2018
+MICR,4520,1,Advanced Microbiology III,0.38,0.5,0.08,0.04,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4520,2018
+MICR,4520,2,Advanced Microbiology III,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4520,2018
+MICR,4520,3,Advanced Microbiology III,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4520,2018
+MKT,3010,1,Principles of Marketing,0.26,0.37,0.26,0.07,0.03,0.0,0.0,0.01,carter will mcelveen,,MKT-3010,2018
+MKT,3010,2,Principles of Marketing,0.29,0.35,0.29,0.06,0.01,0.0,0.0,0.01,carter will mcelveen,,MKT-3010,2018
+MKT,3010,3,Principles of Marketing,0.31,0.4,0.21,0.05,0.01,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2018
+MKT,3010,4,Principles of Marketing,0.27,0.4,0.24,0.05,0.03,0.0,0.0,0.01,amanda cooper fine,,MKT-3010,2018
+MKT,3010,5,Principles of Marketing,0.15,0.35,0.36,0.07,0.03,0.0,0.0,0.04,james gaubert,,MKT-3010,2018
+MKT,3020,1,Consumer Behavior,0.5,0.33,0.15,0.02,0.0,0.0,0.0,0.0,jennifer dia siemens,,MKT-3020,2018
+MKT,3020,2,Consumer Behavior,0.41,0.37,0.16,0.04,0.0,0.0,0.0,0.02,jennifer dia siemens,,MKT-3020,2018
+MKT,3020,3,Consumer Behavior,0.37,0.4,0.1,0.08,0.04,0.0,0.0,0.02,fitzwater an thyroff,,MKT-3020,2018
+MKT,3020,4,Consumer Behavior,0.31,0.48,0.15,0.0,0.02,0.0,0.0,0.04,fitzwater an thyroff,,MKT-3020,2018
+MKT,3020,5,Consumer Behavior,0.52,0.41,0.06,0.01,0.0,0.0,0.0,0.0,patricia knowles,,MKT-3020,2018
+MKT,3220,1,Social Media Marketing,0.85,0.13,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,,MKT-3220,2018
+MKT,3220,2,Social Media Marketing,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-3220,2018
+MKT,3310,1,Marketing Metrics & Analytics,0.53,0.35,0.08,0.02,0.0,0.0,0.0,0.02,oriana rachel aragon,,MKT-3310,2018
+MKT,3310,2,Marketing Metrics & Analytics,0.31,0.47,0.18,0.04,0.0,0.0,0.0,0.0,oriana rachel aragon,,MKT-3310,2018
+MKT,3310,3,Marketing Metrics & Analytics,0.23,0.48,0.2,0.05,0.03,0.0,0.0,0.03,peter weathers,,MKT-3310,2018
+MKT,3980,1,CI: Sales Experiential,0.81,0.11,0.0,0.02,0.0,0.0,0.0,0.06,carter will mcelveen,,MKT-3980,2018
+MKT,4200,1,Professional Selling,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2018
+MKT,4200,2,Professional Selling,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,jesse moore,,MKT-4200,2018
+MKT,4200,3,Professional Selling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,carter will mcelveen,,MKT-4200,2018
+MKT,4200,4,Professional Selling,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2018
+MKT,4200,5,Professional Selling,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4200,2018
+MKT,4230,1,Promotional Strategy,0.6,0.3,0.09,0.01,0.0,0.0,0.0,0.0,patricia knowles,,MKT-4230,2018
+MKT,4240,1,Sales Management,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4240,2018
+MKT,4250,1,Retail Management,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4250,2018
+MKT,4250,2,Retail Management,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4250,2018
+MKT,4260,1,Business-to-Business,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4260,2018
+MKT,4260,2,Business-to-Business,0.76,0.08,0.12,0.0,0.04,0.0,0.0,0.0,xianyong wang,,MKT-4260,2018
+MKT,4270,1,International Marketing,0.29,0.57,0.12,0.02,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-4270,2018
+MKT,4270,2,International Marketing,0.13,0.74,0.08,0.0,0.0,0.0,0.0,0.05,thomas poehlman,,MKT-4270,2018
+MKT,4270,3,International Marketing,0.64,0.25,0.1,0.01,0.0,0.0,0.0,0.0,roger gomes,,MKT-4270,2018
+MKT,4280,1,Services Marketing,0.58,0.33,0.07,0.0,0.02,0.0,0.0,0.0,james gaubert,,MKT-4280,2018
+MKT,4280,2,Services Marketing,0.49,0.37,0.12,0.0,0.0,0.0,0.0,0.02,james gaubert,,MKT-4280,2018
+MKT,4310,1,Marketing Research,0.17,0.43,0.33,0.07,0.0,0.0,0.0,0.0,peter weathers,,MKT-4310,2018
+MKT,4310,2,Marketing Research,0.3,0.43,0.17,0.0,0.0,0.0,0.0,0.1,william ed kilbourne,,MKT-4310,2018
+MKT,4310,3,Marketing Research,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2018
+MKT,4310,4,Marketing Research,0.37,0.6,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2018
+MKT,4330,1,Sport Mkt Strategy,0.66,0.22,0.13,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,,MKT-4330,2018
+MKT,4450,1,Macromarketing,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,,MKT-4450,2018
+MKT,4500,1,Strategic Mktg Mgt,0.08,0.41,0.51,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2018
+MKT,4500,2,Strategic Mktg Mgt,0.16,0.42,0.39,0.03,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2018
+MKT,4500,3,Strategic Mktg Mgt,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,,MKT-4500,2018
+MKT,4500,4,Strategic Mktg Mgt,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,,MKT-4500,2018
+MKT,8620,1,Quant Methods in Mkt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,,MKT-8620,2018
+MKT,8650,1,Seminar in Mkt Mgmt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MKT-8650,2018
+MKT,8660,1,International Marketing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-8660,2018
+ML,1020,1,Leadership Fund II,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,clay wilson etterle,,ML-1020,2018
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,clay wilson etterle,,ML-1020,2018
+ML,1020,3,Leadership Fund II,0.95,0.0,0.0,0.0,0.05,0.0,0.0,0.0,clay wilson etterle,,ML-1020,2018
+ML,2020,1,Leadership Development II,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2020,2018
+ML,2020,2,Leadership Development II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2020,2018
+ML,2020,3,Leadership Development II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2020,2018
+ML,3020,1,Advanced Leadership II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william cody cleland,,ML-3020,2018
+ML,3020,2,Advanced Leadership II,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,william cody cleland,,ML-3020,2018
+ML,4020,1,Organizational Leadership II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kenneth tod crawford,,ML-4020,2018
+MSE,2100,1,Intro to Mat Science,0.34,0.23,0.22,0.07,0.06,0.0,0.0,0.07,rakhee pani,,MSE-2100,2018
+MSE,2100,2,Intro to Mat Science,0.35,0.28,0.19,0.09,0.06,0.0,0.0,0.04,ruslan burtovyy,,MSE-2100,2018
+MSE,2100,3,Intro to Mat Science,0.25,0.29,0.18,0.13,0.09,0.0,0.0,0.06,fei peng,,MSE-2100,2018
+MSE,2100,4,Intro to Mat Science,0.39,0.33,0.14,0.05,0.06,0.0,0.0,0.04,olga kuksenok,,MSE-2100,2018
+MSE,3100,1,Intro to Metals and Ceramics,0.53,0.27,0.09,0.02,0.04,0.0,0.0,0.04,jianhua tong,,MSE-3100,2018
+MSE,3260,1,Thermo of Materials,0.35,0.31,0.22,0.07,0.03,0.0,0.0,0.01,gary lickfield,,MSE-3260,2018
+MSE,3270,1,Transport Phenomena,0.0,0.22,0.33,0.39,0.0,0.0,0.0,0.06,ulf daniel schiller,,MSE-3270,2018
+MSE,3280,1,Phase Diagrams,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,eric skaar,,MSE-3280,2018
+MSE,3420,1,Struct/Property,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kuma bordia,,MSE-3420,2018
+MSE,4150,1,Polymer Sc Engr,0.33,0.44,0.17,0.03,0.0,0.0,0.0,0.03,igor luzinov,,MSE-4150,2018
+MSE,4160,1,Electronic Materials,0.62,0.33,0.02,0.0,0.02,0.0,0.0,0.0,kyle brinkman,,MSE-4160,2018
+MSE,4220,1,Mech Behavior of Mat,0.53,0.29,0.12,0.0,0.06,0.0,0.0,0.0,vincent yves blouin,,MSE-4220,2018
+MSE,4240,1,Optical Materials,0.61,0.17,0.13,0.09,0.0,0.0,0.0,0.0,luiz gusta jacobsohn,,MSE-4240,2018
+MSE,4330,1,Comb Sys & Env Emiss,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,,MSE-4330,2018
+MSE,4450,1,Practice of Mat Engr,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,marek urban,,MSE-4450,2018
+MSE,4560,1,Polymer & Fiber Materials II,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,gary lickfield,,MSE-4560,2018
+MSE,4590,1,Color Science Lab,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,,MSE-4590,2018
+MSE,4590,2,Color Science Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,,MSE-4590,2018
+MSE,4810,1,Undergraduate Research Fundame,0.73,0.05,0.09,0.0,0.05,0.0,0.0,0.09,olin mefford,,MSE-4810,2018
+MSE,4910,1,Undergraduate Research,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,olin mefford,,MSE-4910,2018
+MSE,8190,1,Inorgan Mater Characterization,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,luiz gusta jacobsohn,,MSE-8190,2018
+MSE,8260,1,Phase Equil Mat Sys,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,stephen foulger,,MSE-8260,2018
+MUSC,1420,1,Music Theory I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,,MUSC-1420,2018
+MUSC,1430,1,Aural Skills I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,,MUSC-1430,2018
+MUSC,1440,1,Music Theory II,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,anthony bernarducci,,MUSC-1440,2018
+MUSC,1510,2,Applied Music,0.67,0.19,0.05,0.0,0.05,0.0,0.0,0.05,jonathan edwar doyel,,MUSC-1510,2018
+MUSC,1510,18,Applied Music,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david stevenson,,MUSC-1510,2018
+MUSC,1800,1,Intro to Music Tech,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,,MUSC-1800,2018
+MUSC,2100,2,Music in the Western World,0.5,0.34,0.16,0.0,0.0,0.0,0.0,0.0,lisa sain odom,,MUSC-2100,2018
+MUSC,2100,3,Music in the Western World,0.29,0.55,0.06,0.0,0.0,0.0,0.0,0.1,rhea beth jacobus,,MUSC-2100,2018
+MUSC,2100,5,Music in the Western World,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2018
+MUSC,2100,6,Music in the Western World,0.45,0.52,0.0,0.03,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2018
+MUSC,2100,7,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,evan michael jacobi,,MUSC-2100,2018
+MUSC,2100,9,Music in the Western World,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,,MUSC-2100,2018
+MUSC,3090,1,Surv of Broadway II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,,MUSC-3090,2018
+MUSC,3110,1,History of American Music,0.78,0.13,0.06,0.03,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3110,2018
+MUSC,3120,1,History of Jazz,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,eric lapin,,MUSC-3120,2018
+MUSC,3170,1,Hist of Country Mus,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3170,2018
+MUSC,3180,1,Hist of Audio Tech,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,,MUSC-3180,2018
+MUSC,3690,1,Symphony Orchestra,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,andrew levin,,MUSC-3690,2018
+MUSC,3700,1,Clemson University Singers,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,david hartmann,,MUSC-3700,2018
+MUSC,3710,1,Women's Chorus,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,david hartmann,,MUSC-3710,2018
+NPL,3000,1,Nonprofit Leadership,0.62,0.27,0.08,0.04,0.0,0.0,0.0,0.0,corey doug brookover,,NPL-3000,2018
+NPL,3000,2,Nonprofit Leadership,0.63,0.17,0.13,0.0,0.04,0.0,0.0,0.04,christina mari mazer,,NPL-3000,2018
+NPL,3000,3,Nonprofit Leadership,0.58,0.25,0.13,0.04,0.0,0.0,0.0,0.0,christina mari mazer,,NPL-3000,2018
+NPL,3000,4,Nonprofit Leadership,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,corey doug brookover,,NPL-3000,2018
+NPL,3000,5,Nonprofit Leadership,0.61,0.3,0.04,0.0,0.04,0.0,0.0,0.0,corey doug brookover,,NPL-3000,2018
+NPL,3010,2,NPL Stakeholders,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,christina mari mazer,,NPL-3010,2018
+NPL,3010,3,NPL Stakeholders,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christina mari mazer,,NPL-3010,2018
+NPL,3020,1,NPL Fundraising,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,thomas john orourke,,NPL-3020,2018
+NPL,3030,2,NPL Personnel,0.48,0.43,0.09,0.0,0.0,0.0,0.0,0.0,bonnie westb stevens,,NPL-3030,2018
+NPL,3030,3,NPL Personnel,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,bonnie westb stevens,,NPL-3030,2018
+NPL,3040,1,NPL Risk Management,0.71,0.06,0.06,0.12,0.06,0.0,0.0,0.0,daniel morg anderson,,NPL-3040,2018
+NURS,1400,1,Comp App Hlth Care,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,,NURS-1400,2018
+NURS,1400,2,Comp App Hlth Care,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,janice garris lanham,,NURS-1400,2018
+NURS,1400,3,Comp App Hlth Care,0.91,0.03,0.03,0.0,0.0,0.0,0.0,0.03,jenna lynn seawright,,NURS-1400,2018
+NURS,3030,1,Nursing of Adults,0.41,0.56,0.02,0.02,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2018
+NURS,3030,400,Nursing of Adults,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2018
+NURS,3040,1,Pathophysiology,0.41,0.43,0.09,0.0,0.07,0.0,0.0,0.0,catherine sik murton,,NURS-3040,2018
+NURS,3040,401,Pathophysiology,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth cam hassen,,NURS-3040,2018
+NURS,3100,1,Health Assessment,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,,NURS-3100,2018
+NURS,3100,2,Health Assessment,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,,NURS-3100,2018
+NURS,3120,1,Foundations of Nursing,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,,NURS-3120,2018
+NURS,3190,400,Health Assessment for RNs,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,,NURS-3190,2018
+NURS,3200,2,Prof in Nurs,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3200,2018
+NURS,3230,402,Gerontology Nurs,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,,NURS-3230,2018
+NURS,3330,400,Health Care Genetics,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,mary steck,,NURS-3330,2018
+NURS,3400,1,Pharmther Nursing,0.37,0.5,0.07,0.04,0.02,0.0,0.0,0.0,catherine sik murton,,NURS-3400,2018
+NURS,4010,1,Mental Health Nurs,0.96,0.02,0.02,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,,NURS-4010,2018
+NURS,4030,1,Complex Nursing of Adults,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen ra ewing ra,,NURS-4030,2018
+NURS,4060,400,Issues in Professionalism,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,,NURS-4060,2018
+NURS,4110,1,Nursing of Children,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,,NURS-4110,2018
+NURS,4120,1,Nurs Women and Fam,0.74,0.24,0.0,0.02,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2018
+NURS,4250,400,Community Nursing,0.73,0.23,0.0,0.0,0.05,0.0,0.0,0.0,tiffany leah stewart,,NURS-4250,2018
+NURS,8010,400,Adv Fam & Comm Nrsng,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,,NURS-8010,2018
+NURS,8010,401,Adv Fam & Comm Nrsng,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,,NURS-8010,2018
+NURS,8080,400,Nurs Res Stat Analys,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-8080,2018
+NURS,8080,401,Nurs Res Stat Analys,0.68,0.2,0.12,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-8080,2018
+NURS,8190,400,Developing Family,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-8190,2018
+NURS,8200,400,Child & Adol Nursing,0.25,0.46,0.21,0.0,0.08,0.0,0.0,0.0,heide temples,,NURS-8200,2018
+NURS,8210,400,Adult Nursing,0.41,0.48,0.07,0.0,0.04,0.0,0.0,0.0,tracy king fasolino,,NURS-8210,2018
+NURS,8210,401,Adult Nursing,0.43,0.52,0.04,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8210,2018
+NURS,8230,400,NP Clinical Practicum,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,,NURS-8230,2018
+NURS,8270,400,Nurs Education Found,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,,NURS-8270,2018
+NURS,8840,400,Adult Mental Health,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,,NURS-8840,2018
+NURS,8850,400,Mental Health in Primary Care,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,,NURS-8850,2018
+NUTR,2030,1,Intro Princ of Human Nutrition,0.56,0.33,0.05,0.01,0.02,0.0,0.0,0.02,elizabeth durrance,,NUTR-2030,2018
+NUTR,2030,2,Intro Princ of Human Nutrition,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,,NUTR-2030,2018
+NUTR,2040,1,Nutrition Across Life Cycle,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,bridgit deni corbett,,NUTR-2040,2018
+NUTR,4200,1,Food and Culture,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,bridgit deni corbett,,NUTR-4200,2018
+NUTR,4250,1,Medica Nutr Thera II,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4250,2018
+NUTR,4260,1,Community Nutrition,0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,bridgit deni corbett,,NUTR-4260,2018
+NUTR,4270,1,Nutrition Counseling,0.59,0.23,0.18,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,,NUTR-4270,2018
+NUTR,4550,1,Human Nutr & Metabolism II,0.67,0.12,0.12,0.09,0.0,0.0,0.0,0.0,elliot jesch,,NUTR-4550,2018
+PA,2790,1,Perf Arts Pract I,0.6,0.13,0.07,0.0,0.07,0.0,0.0,0.13,kenneth moore,,PA-2790,2018
+PA,2800,1,Perf Arts Pract II,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,kenneth moore,,PA-2800,2018
+PADM,8220,400,Public Policy Process,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mellott eka yazykova,,PADM-8220,2018
+PADM,8270,400,Public Personnel Admin,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,donna marie kazia,,PADM-8270,2018
+PADM,8410,400,Public Data Analysis,0.56,0.19,0.06,0.0,0.19,0.0,0.0,0.0,ronald chrestman,,PADM-8410,2018
+PADM,8410,401,Public Data Analysis,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,ronald chrestman,,PADM-8410,2018
+PADM,8410,402,Public Data Analysis,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,edmond patric bowers,,PADM-8410,2018
+PADM,8450,401,Grant Writing for Public Admin,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katherin kransteuber,,PADM-8450,2018
+PADM,8510,400,Emergency Management Fundam,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,charles antho haynes,,PADM-8510,2018
+PADM,8550,400,Homeland Sec and Intelligence,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,david leigh cook,,PADM-8550,2018
+PADM,8620,400,Administrative Leadership,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,,PADM-8620,2018
+PADM,8780,407,Project Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sandra marie batt,,PADM-8780,2018
+PAS,1010,2,Africa Atlantic Wrld,0.18,0.53,0.0,0.0,0.06,0.0,0.0,0.24,michael blum,,PAS-1010,2018
+PES,2020,1,Soils,0.22,0.47,0.27,0.02,0.02,0.0,0.0,0.02,dara michelle park,,PES-2020,2018
+PES,4220,1,Major World Crops,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,sruthi narayan kutty,,PES-4220,2018
+PES,4230,1,Field Crops: Forages,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,matias jose aguerre,,PES-4230,2018
+PES,4330,1,Landscape & Turf Weed Mgt,0.13,0.38,0.44,0.06,0.0,0.0,0.0,0.0,ted whitwell,,PES-4330,2018
+PES,4460,1,Soil Management,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,dara michelle park,,PES-4460,2018
+PES,4520,1,Soil Fertility and Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,,PES-4520,2018
+PES,4530,1,Soil Fertility Laboratory,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,,PES-4530,2018
+PES,6520,1,Soil Fertility and Management,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,haibo liu,,PES-6520,2018
+PES,8060,2,Water for Agriculture,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,sarah white,,PES-8060,2018
+PES,8090,1,Analytical Technique,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14, tharayil-santhakumar,,PES-8090,2018
+PHIL,1010,1,Intro to Philosophic Problems,0.61,0.24,0.03,0.0,0.0,0.0,0.0,0.12,david stegall,,PHIL-1010,2018
+PHIL,1010,2,Intro to Philosophic Problems,0.49,0.23,0.09,0.06,0.0,0.0,0.0,0.14,david stegall,,PHIL-1010,2018
+PHIL,1010,3,Intro to Philosophic Problems,0.27,0.64,0.03,0.0,0.03,0.0,0.0,0.03,kelly smith,,PHIL-1010,2018
+PHIL,1010,5,Intro to Philosophic Problems,0.53,0.32,0.03,0.0,0.03,0.0,0.0,0.09,andrew garnar,,PHIL-1010,2018
+PHIL,1020,1,Introduction to Logic,0.63,0.17,0.06,0.0,0.0,0.0,0.0,0.14,michael hal hannen,,PHIL-1020,2018
+PHIL,1020,2,Introduction to Logic,0.68,0.18,0.12,0.0,0.0,0.0,0.0,0.03,michael hal hannen,,PHIL-1020,2018
+PHIL,1020,3,Introduction to Logic,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,michael hal hannen,,PHIL-1020,2018
+PHIL,1020,4,Introduction to Logic,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,edyta joanna kuzian,,PHIL-1020,2018
+PHIL,1020,5,Introduction to Logic,0.5,0.25,0.1,0.0,0.1,0.0,0.0,0.05,edyta joanna kuzian,,PHIL-1020,2018
+PHIL,1020,6,Introduction to Logic,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,adam gies,,PHIL-1020,2018
+PHIL,1030,2,Introduction to Ethics,0.63,0.23,0.06,0.06,0.03,0.0,0.0,0.0,stephen satris,,PHIL-1030,2018
+PHIL,1030,3,Introduction to Ethics,0.44,0.41,0.12,0.0,0.0,0.0,0.0,0.03,christopher mi wells,,PHIL-1030,2018
+PHIL,1030,4,Introduction to Ethics,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-1030,2018
+PHIL,1030,5,Introduction to Ethics,0.53,0.37,0.07,0.0,0.0,0.0,0.0,0.03,adam gies,,PHIL-1030,2018
+PHIL,1030,6,Introduction to Ethics,0.42,0.48,0.03,0.03,0.03,0.0,0.0,0.0,christopher mi wells,,PHIL-1030,2018
+PHIL,1030,7,Introduction to Ethics,0.81,0.13,0.03,0.0,0.0,0.0,0.0,0.03,adam gies,,PHIL-1030,2018
+PHIL,1030,8,Introduction to Ethics,0.34,0.47,0.09,0.03,0.0,0.0,0.0,0.06,christopher mi wells,,PHIL-1030,2018
+PHIL,1030,9,Introduction to Ethics,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,charles starkey,,PHIL-1030,2018
+PHIL,3040,1,Moral Philosophy,0.32,0.36,0.25,0.0,0.04,0.0,0.0,0.04,todd may,,PHIL-3040,2018
+PHIL,3050,1,Existentialism,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,david stegall,,PHIL-3050,2018
+PHIL,3120,1,Philosophy in Ancient China,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,yanming an,,PHIL-3120,2018
+PHIL,3160,1,Modern Philosophy,0.54,0.37,0.06,0.0,0.0,0.0,0.0,0.03,michael hal hannen,,PHIL-3160,2018
+PHIL,3210,1,Crime & Punishment,0.3,0.39,0.12,0.06,0.06,0.0,0.0,0.06,daniel wueste,,PHIL-3210,2018
+PHIL,3260,1,Science and Values,0.57,0.37,0.03,0.0,0.0,0.0,0.0,0.03,andrew garnar,,PHIL-3260,2018
+PHIL,3260,2,Science and Values,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,,PHIL-3260,2018
+PHIL,3300,1,Self-Deception,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,todd may,,PHIL-3300,2018
+PHIL,3300,2,Ethics of Inequality,0.17,0.52,0.09,0.0,0.0,0.0,0.0,0.22,brookes colyto brown,,PHIL-3300,2018
+PHIL,3330,1,Metaphysics,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,david stegall,,PHIL-3330,2018
+PHIL,3430,1,Philosophy of Law,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,brookes colyto brown,,PHIL-3430,2018
+PHIL,3450,1,Environmental Ethics,0.22,0.5,0.22,0.0,0.0,0.0,0.0,0.06,christopher mi wells,,PHIL-3450,2018
+PHIL,3460,1,Biomedical Ethics,0.38,0.41,0.14,0.0,0.03,0.0,0.0,0.03,charles starkey,,PHIL-3460,2018
+PHIL,4750,1,Philosophy of Film,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher grau,,PHIL-4750,2018
+PHSC,1170,1,Intro Chem & Earth,0.74,0.23,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1170,2018
+PHYS,1220,1,Physics with Calculus I,0.24,0.32,0.28,0.11,0.01,0.0,0.0,0.03,lih-sin the,,PHYS-1220,2018
+PHYS,1220,2,Physics with Calculus I,0.24,0.41,0.24,0.06,0.02,0.0,0.0,0.03,lih-sin the,,PHYS-1220,2018
+PHYS,1220,3,Physics with Calculus I,0.19,0.5,0.23,0.05,0.01,0.0,0.0,0.02,sriparn bhattacharya,,PHYS-1220,2018
+PHYS,1220,4,Physics with Calculus I,0.25,0.47,0.23,0.02,0.01,0.0,0.0,0.01,sriparn bhattacharya,,PHYS-1220,2018
+PHYS,1220,5,Physics with Calculus I,0.4,0.46,0.11,0.01,0.0,0.0,0.0,0.01,jason stratfor brown,,PHYS-1220,2018
+PHYS,1220,8,Physics W/Cal I (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True,PHYS-1220,2018
+PHYS,1240,1,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,2,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,3,Physics Lab I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,5,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,6,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,7,Physics Lab I,0.56,0.33,0.0,0.06,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,8,Physics Lab I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,9,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,10,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,11,Physics Lab I,0.44,0.44,0.0,0.0,0.06,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,12,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,13,Physics Lab I,0.22,0.72,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,14,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,15,Physics Lab I,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,16,Physics Lab I,0.76,0.12,0.0,0.06,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,17,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,18,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,19,Physics Lab I,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,20,Physics Lab I,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,21,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,22,Physics Lab I,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,23,Physics Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,25,Physics Lab I,0.53,0.24,0.06,0.0,0.12,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,26,Physics Lab I,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,27,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,29,Physics Lab I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2018
+PHYS,1240,30,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2018
+PHYS,2000,1,Introductory Physics,0.31,0.42,0.17,0.02,0.02,0.0,0.0,0.08,nicolas gr underwood,,PHYS-2000,2018
+PHYS,2070,1,General Physics I,0.23,0.32,0.25,0.09,0.08,0.0,0.0,0.03,amy liann pope,,PHYS-2070,2018
+PHYS,2080,1,General Physics II,0.52,0.3,0.11,0.05,0.01,0.0,0.0,0.01,amy liann pope,,PHYS-2080,2018
+PHYS,2080,2,General Physics II,0.63,0.25,0.1,0.02,0.0,0.0,0.0,0.0,amy liann pope,,PHYS-2080,2018
+PHYS,2090,1,Gen Phys Lab I,0.29,0.63,0.08,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,2,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,3,Gen Phys Lab I,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,4,Gen Phys Lab I,0.07,0.67,0.2,0.0,0.0,0.0,0.0,0.07,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,5,Gen Phys Lab I,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,6,Gen Phys Lab I,0.09,0.74,0.09,0.0,0.04,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,7,Gen Phys Lab I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,8,Gen Phys Lab I,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,9,Gen Phys Lab I,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2018
+PHYS,2090,10,Gen Phys Lab I,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,,PHYS-2090,2018
+PHYS,2100,1,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,2,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,3,Gen Phys Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,4,Gen Phys Lab II,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,5,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,6,Gen Phys Lab II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,7,Gen Phys Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,8,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,10,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,11,Gen Phys Lab II,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,12,Gen Phys Lab II,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,13,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,14,Gen Phys Lab II,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,15,Gen Phys Lab II,0.33,0.63,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,16,Gen Phys Lab II,0.7,0.17,0.04,0.0,0.04,0.0,0.0,0.04,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,17,Gen Phys Lab II,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2100,2018
+PHYS,2100,18,Gen Phys Lab II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2018
+PHYS,2210,1,Physics with Calculus II,0.12,0.39,0.4,0.06,0.01,0.0,0.0,0.03,jason stratfor brown,,PHYS-2210,2018
+PHYS,2210,2,Physics with Calculus II,0.3,0.33,0.24,0.09,0.03,0.0,0.0,0.01,jason stratfor brown,,PHYS-2210,2018
+PHYS,2210,3,Physics with Calculus II (HON),0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,gerald lehmacher,True,PHYS-2210,2018
+PHYS,2210,5,Physics with Calculus II,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,murray daw,,PHYS-2210,2018
+PHYS,2210,500,Physics with Calculus II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,elaine parshall,,PHYS-2210,2018
+PHYS,2220,1,Physics with Calculus III,0.5,0.31,0.06,0.0,0.0,0.0,0.0,0.13,jian he,,PHYS-2220,2018
+PHYS,2230,1,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,2,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,3,Physics Lab II,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,5,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,6,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,7,Physics Lab II,0.06,0.72,0.22,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,8,Physics Lab II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,9,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2018
+PHYS,2230,500,Physics Lab II,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,elaine parshall,,PHYS-2230,2018
+PHYS,2400,1,Phys of Weather,0.27,0.39,0.21,0.05,0.02,0.0,0.0,0.06,miguel larsen,,PHYS-2400,2018
+PHYS,3110,1,Methods Theor Phys,0.28,0.28,0.24,0.08,0.04,0.0,0.0,0.08,lih-sin the,,PHYS-3110,2018
+PHYS,3220,1,Mechanics II,0.33,0.28,0.06,0.22,0.11,0.0,0.0,0.0,joshua alper,,PHYS-3220,2018
+PHYS,3260,1,Exper Physics II,0.5,0.31,0.0,0.06,0.0,0.0,0.0,0.13,chad sosolik,,PHYS-3260,2018
+PHYS,4420,1,Electromagnetics II,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,xian lu,,PHYS-4420,2018
+PHYS,4560,1,Quantum Physics II,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,ramakrishna podila,,PHYS-4560,2018
+PHYS,4650,1,Thermo and Stat Mech,0.41,0.35,0.06,0.18,0.0,0.0,0.0,0.0,feng ding,,PHYS-4650,2018
+PHYS,8150,1,Statistical Therm I,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,jens oberheide,,PHYS-8150,2018
+PHYS,8190,1,Comp Biophysics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,emil georgiev alexov,,PHYS-8190,2018
+PHYS,8410,1,Electrodynamics I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,,PHYS-8410,2018
+PHYS,9520,1,Quantum Mech II,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,domnita ca marinescu,,PHYS-9520,2018
+PKSC,1020,1,Intro to Pkg Sci,0.24,0.42,0.27,0.02,0.04,0.0,0.0,0.01,heather batt,,PKSC-1020,2018
+PKSC,2010,1,Pkg Perishable Prod,0.13,0.35,0.28,0.08,0.13,0.0,0.0,0.05,heather batt,,PKSC-2010,2018
+PKSC,2020,1,Packaging Mtl & Mfg,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,,PKSC-2020,2018
+PKSC,2040,1,Container Systems,0.86,0.11,0.03,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,,PKSC-2040,2018
+PKSC,2060,1,Container Sys Lab,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,,PKSC-2060,2018
+PKSC,2060,2,Container Sys Lab,0.54,0.38,0.04,0.04,0.0,0.0,0.0,0.0,tyler stuettgen,,PKSC-2060,2018
+PKSC,2060,3,Container Sys Lab,0.32,0.45,0.18,0.05,0.0,0.0,0.0,0.0,tyler stuettgen,,PKSC-2060,2018
+PKSC,2200,1,Product & Pkg Design,0.9,0.04,0.0,0.02,0.02,0.0,0.0,0.02,rupert hurley,,PKSC-2200,2018
+PKSC,3200,1,Pkg Design Theory,0.84,0.14,0.0,0.0,0.0,0.0,0.0,0.02,rupert hurley,,PKSC-3200,2018
+PKSC,3680,1,Pkg and Society,0.26,0.48,0.18,0.05,0.02,0.0,0.0,0.02,heather batt,,PKSC-3680,2018
+PKSC,4030,1,Pkg Career Prep,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2018
+PKSC,4200,1,Pkg Design & Dev,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2018
+PKSC,4300,1,Converting Flex Pkg,0.23,0.64,0.09,0.03,0.0,0.0,0.0,0.02,duncan darby,,PKSC-4300,2018
+PKSC,4400,1,Packaging for Distribution,0.26,0.46,0.23,0.0,0.03,0.0,0.0,0.03,gregory batt,,PKSC-4400,2018
+PKSC,4400,400,Packaging for Distribution,0.1,0.3,0.45,0.0,0.0,0.0,0.0,0.15,gregory batt,,PKSC-4400,2018
+PKSC,4640,1,Food & Health Care Pkg Systems,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2018
+PLPA,2130,1,Fungi & Civilization,0.43,0.35,0.12,0.02,0.02,0.0,0.0,0.06,julia louis kerrigan,,PLPA-2130,2018
+PLPA,4060,1,Diseases/Insects Turfgrasses,0.0,0.82,0.09,0.09,0.0,0.0,0.0,0.0,samuel martin,,PLPA-4060,2018
+POSC,1010,1,Amer National Govt,0.15,0.35,0.23,0.1,0.06,0.0,0.0,0.1,joseph earl stewart,,POSC-1010,2018
+POSC,1010,2,Amer National Govt,0.31,0.29,0.2,0.06,0.14,0.0,0.0,0.0,alfred bundrick,,POSC-1010,2018
+POSC,1020,1,Intro Intl Relations,0.56,0.3,0.08,0.0,0.04,0.0,0.0,0.02,brandon mich stewart,,POSC-1020,2018
+POSC,1020,2,Intro Intl Relations,0.14,0.37,0.25,0.08,0.06,0.0,0.0,0.08,aron geor tannenbaum,,POSC-1020,2018
+POSC,1020,3,Intro Intl Relations,0.33,0.42,0.08,0.02,0.06,0.0,0.0,0.08,steven vincen miller,,POSC-1020,2018
+POSC,1030,1,Intro to Political Theory,0.37,0.4,0.14,0.0,0.07,0.0,0.0,0.02,brandon turner,,POSC-1030,2018
+POSC,1030,2,Intro to Political Theory,0.1,0.53,0.23,0.07,0.0,0.0,0.0,0.07,colin pearce,,POSC-1030,2018
+POSC,1030,3,Intro to Political Theory,0.06,0.58,0.23,0.1,0.03,0.0,0.0,0.0,colin pearce,,POSC-1030,2018
+POSC,1030,4,Intro to Political Theory,0.33,0.43,0.13,0.03,0.0,0.0,0.0,0.07,lorianne molinari,,POSC-1030,2018
+POSC,1040,1,Intro Compar Pol,0.21,0.58,0.16,0.0,0.0,0.0,0.0,0.05,xiaobo hu,,POSC-1040,2018
+POSC,1040,2,Intro Compar Pol,0.51,0.19,0.17,0.02,0.11,0.0,0.0,0.0,brandon mich stewart,,POSC-1040,2018
+POSC,1990,1,Intro Pol Sci,0.46,0.21,0.12,0.08,0.08,0.0,0.0,0.06,meredith- petersheim,,POSC-1990,2018
+POSC,3020,1,State and Loc Gov,0.19,0.57,0.11,0.03,0.03,0.0,0.0,0.08,bruce ransom,,POSC-3020,2018
+POSC,3210,1,Public Admin,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,,POSC-3210,2018
+POSC,3610,1,International Conflict,0.2,0.23,0.18,0.09,0.18,0.0,0.0,0.11,steven vincen miller,,POSC-3610,2018
+POSC,3630,1,Us Foreign Policy,0.21,0.57,0.18,0.0,0.04,0.0,0.0,0.0,jeffrey scott peake,,POSC-3630,2018
+POSC,3710,1,European Politics,0.43,0.38,0.07,0.02,0.07,0.0,0.0,0.02,vladimir matic,,POSC-3710,2018
+POSC,3710,615,European Politics,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,,POSC-3710,2018
+POSC,3750,1,European Integration,0.2,0.25,0.3,0.05,0.1,0.0,0.0,0.1,zeynep taydas,,POSC-3750,2018
+POSC,4050,1,American Presidency,0.21,0.25,0.17,0.08,0.25,0.0,0.0,0.04,adam warber,,POSC-4050,2018
+POSC,4160,1,Int Groups & Soc Mov,0.24,0.39,0.22,0.1,0.0,0.0,0.0,0.05,laura olson,,POSC-4160,2018
+POSC,4360,1,Law Courts Politics,0.85,0.06,0.0,0.0,0.0,0.0,0.0,0.09,joseph earl stewart,,POSC-4360,2018
+POSC,4370,1,Constitut Law: Rights & Libert,0.48,0.42,0.08,0.0,0.02,0.0,0.0,0.0,daniel frost,,POSC-4370,2018
+POSC,4390,1,Religious Liberty & US Const,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,,POSC-4390,2018
+POSC,4480,615,Internat'l Political Economy,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,,POSC-4480,2018
+POSC,4490,1,Political Theory of Capitalism,0.44,0.28,0.12,0.02,0.09,0.0,0.0,0.05,brandon turner,,POSC-4490,2018
+POSC,4530,1,American Political Thought,0.47,0.4,0.09,0.0,0.02,0.0,0.0,0.02,lorianne molinari,,POSC-4530,2018
+POSC,4660,1,African Politics,0.53,0.21,0.21,0.0,0.05,0.0,0.0,0.0,brandon mich stewart,,POSC-4660,2018
+POSC,4710,1,Russian Politics,0.63,0.21,0.04,0.0,0.04,0.0,0.0,0.08,aron geor tannenbaum,,POSC-4710,2018
+POSC,4760,1,Middle East Politics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,,POSC-4760,2018
+POSC,4890,1,Religion in World Politics,0.47,0.29,0.12,0.12,0.0,0.0,0.0,0.0,laura olson,,POSC-4890,2018
+PRTM,2200,1,Foundations of PRTM,0.73,0.12,0.06,0.0,0.03,0.0,0.0,0.06,gwynn powell,,PRTM-2200,2018
+PRTM,2200,2,Foundations of PRTM,0.23,0.41,0.23,0.09,0.05,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2200,2018
+PRTM,2200,3,Foundations of PRTM,0.64,0.16,0.12,0.0,0.08,0.0,0.0,0.0,katrina latric black,,PRTM-2200,2018
+PRTM,2200,4,Foundations of PRTM,0.65,0.16,0.13,0.06,0.0,0.0,0.0,0.0,lauren eliz stephens,,PRTM-2200,2018
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2260,2018
+PRTM,2270,1,Prov of Leisure Exp,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2270,2018
+PRTM,2290,1,Competency Integration in PRTM,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2290,2018
+PRTM,2410,1,Intro to CRSCM,0.46,0.36,0.17,0.02,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2410,2018
+PRTM,2600,1,Found of Recreational Therapy,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,brandi crowe,,PRTM-2600,2018
+PRTM,2650,1,Terminology in RT Practice,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,,PRTM-2650,2018
+PRTM,2700,1,Intro Rec Res Mgt,0.62,0.35,0.0,0.04,0.0,0.0,0.0,0.0,elizabeth de baldwin,,PRTM-2700,2018
+PRTM,2810,1,Intro to Golf Mgt,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,richard lucas,,PRTM-2810,2018
+PRTM,2820,1,Principle Golfer Dev,0.58,0.08,0.08,0.25,0.0,0.0,0.0,0.0,richard lucas,,PRTM-2820,2018
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.38,0.41,0.18,0.03,0.0,0.0,0.0,0.0,daniel morg anderson,,PRTM-3050,2018
+PRTM,3070,1,Facility Operations,0.75,0.18,0.0,0.07,0.0,0.0,0.0,0.0,raymond dunham,,PRTM-3070,2018
+PRTM,3210,1,Recreation Admin,0.5,0.38,0.03,0.03,0.06,0.0,0.0,0.0,jamie lynn cathey,,PRTM-3210,2018
+PRTM,3250,1,Global Persp in Rec,0.6,0.33,0.03,0.0,0.03,0.0,0.0,0.03,harrison pa pinckney,,PRTM-3250,2018
+PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nut townsend,,PRTM-3260,2018
+PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3270,2018
+PRTM,3280,2,Preceptorship in Recr Therapy,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,,PRTM-3280,2018
+PRTM,3420,1,Intro to Tourism,0.63,0.15,0.1,0.02,0.02,0.0,0.0,0.07,peter judca mkumbo,,PRTM-3420,2018
+PRTM,3420,2,Intro to Tourism,0.62,0.23,0.08,0.04,0.0,0.0,0.0,0.04,garrett anders stone,,PRTM-3420,2018
+PRTM,3440,1,Tourism Markets,0.89,0.04,0.04,0.04,0.0,0.0,0.0,0.0,sheila backman,,PRTM-3440,2018
+PRTM,3440,2,Tourism Markets,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,,PRTM-3440,2018
+PRTM,3450,1,Tourism Management,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,william norman,,PRTM-3450,2018
+PRTM,3450,2,Tourism Management,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,'lisha fogle,,PRTM-3450,2018
+PRTM,3460,1,Heritage Tourism,0.23,0.48,0.15,0.08,0.06,0.0,0.0,0.0,gregory phil ramshaw,,PRTM-3460,2018
+PRTM,3530,2,Foundations of Camp Counseling,0.67,0.1,0.24,0.0,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-3530,2018
+PRTM,3900,5,Independent Study in PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3900,2018
+PRTM,3910,10,Social Media in PRTM,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,zeynep gedikoglu,,PRTM-3910,2018
+PRTM,4210,1,Rec Fin Resc Mgt,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,harrison pa pinckney,,PRTM-4210,2018
+PRTM,4300,1,World Geog Parks,0.35,0.16,0.27,0.18,0.02,0.0,0.0,0.02,robert baxter powell,,PRTM-4300,2018
+PRTM,4460,2,Community Tourism,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lauren duffy,,PRTM-4460,2018
+PRTM,4460,3,Community Tourism,0.63,0.33,0.0,0.0,0.04,0.0,0.0,0.0,katie dudley,,PRTM-4460,2018
+PRTM,4550,1,Adv Program Planning,0.72,0.11,0.0,0.11,0.0,0.0,0.0,0.06,mariela fernandez,,PRTM-4550,2018
+PRTM,8080,1,Behavioral Aspects,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,robert bixler,,PRTM-8080,2018
+PRTM,8110,2,Research Methods,0.7,0.22,0.04,0.0,0.04,0.0,0.0,0.0,matthew tyl brownlee,,PRTM-8110,2018
+PRTM,8110,3,Research Methods,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey charle hallo,,PRTM-8110,2018
+PRTM,8210,1,Funding Strategies in PRTM,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-8210,2018
+PRTM,8250,1,Populations in PRTM,0.58,0.25,0.0,0.0,0.17,0.0,0.0,0.0,teresa walton tucker,,PRTM-8250,2018
+PRTM,8720,2,Adv Facilitation Techniq in RT,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,brandi crowe,,PRTM-8720,2018
+PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.6,0.2,0.13,0.0,0.07,0.0,0.0,0.0,anna-mari chancellor,,PRTM-8730,2018
+PRTM,8740,2,Mgt of Clinical Process in RT,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,stephen thomas lewis,,PRTM-8740,2018
+PSYC,2010,1,Intro to Psychology,0.26,0.25,0.19,0.14,0.1,0.0,0.0,0.07,edwin brainerd,,PSYC-2010,2018
+PSYC,2010,2,Intro to Psychology,0.37,0.32,0.18,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,,PSYC-2010,2018
+PSYC,2010,3,Intro to Psychology,0.36,0.38,0.13,0.07,0.04,0.0,0.0,0.01,mary taylor,,PSYC-2010,2018
+PSYC,2010,4,Intro to Psychology,0.45,0.33,0.16,0.03,0.01,0.0,0.0,0.01,mary taylor,,PSYC-2010,2018
+PSYC,2010,5,Intro to Psychology,0.47,0.37,0.12,0.01,0.01,0.0,0.0,0.01,chong hyon pak,,PSYC-2010,2018
+PSYC,2010,6,Intro to Psychology,0.64,0.23,0.04,0.06,0.01,0.0,0.0,0.01,chong hyon pak,,PSYC-2010,2018
+PSYC,2010,8,Intro to Psychology (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True,PSYC-2010,2018
+PSYC,2010,9,Intro to Psychology (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True,PSYC-2010,2018
+PSYC,2020,3,Intro Psychology Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,nastassia mar savage,,PSYC-2020,2018
+PSYC,2890,1,Fundamentals of Psyc Science,0.46,0.32,0.13,0.04,0.04,0.0,0.0,0.02,cynthia pury s,,PSYC-2890,2018
+PSYC,3060,1,Human Sexual Behavior,0.51,0.21,0.14,0.05,0.06,0.0,0.0,0.03,bruce michael king,,PSYC-3060,2018
+PSYC,3090,100,Intro Experimental Psychology,0.4,0.28,0.18,0.08,0.04,0.0,0.0,0.01,patrick rosopa,,PSYC-3090,2018
+PSYC,3090,200,Intro Experimental Psychology,0.37,0.3,0.2,0.03,0.09,0.0,0.0,0.01,jennifer bail bisson,,PSYC-3090,2018
+PSYC,3100,100,Advanced Experimental Psych,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,peggy tyler,,PSYC-3100,2018
+PSYC,3100,200,Advanced Experimental Psych,0.32,0.24,0.16,0.2,0.04,0.0,0.0,0.04,jennifer bail bisson,,PSYC-3100,2018
+PSYC,3100,300,Advanced Experimental Psych,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,fred switzer,,PSYC-3100,2018
+PSYC,3100,400,Advanced Experimental Psych,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,thomas britt,,PSYC-3100,2018
+PSYC,3100,500,Advanced Experimental Psych,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3100,2018
+PSYC,3100,600,Advanced Experimental Psych,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-3100,2018
+PSYC,3240,1,Physiological Psych,0.41,0.31,0.13,0.07,0.06,0.0,0.0,0.01,claudio cantalupo,,PSYC-3240,2018
+PSYC,3240,2,Physiological Psych,0.26,0.28,0.23,0.12,0.04,0.0,0.0,0.07,june pilcher,,PSYC-3240,2018
+PSYC,3330,1,Cognitive Psych,0.66,0.21,0.11,0.01,0.0,0.0,0.0,0.0,kaileigh angel byrne,,PSYC-3330,2018
+PSYC,3330,2,Cognitive Psych,0.5,0.34,0.12,0.03,0.0,0.0,0.0,0.01,kaileigh angel byrne,,PSYC-3330,2018
+PSYC,3340,1,Cognitive Psych Lab,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,laura whitlock,,PSYC-3340,2018
+PSYC,3340,3,Cognitive Psych Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michael shreeves,,PSYC-3340,2018
+PSYC,3340,4,Cognitive Psych Lab,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,tiffany cooper,,PSYC-3340,2018
+PSYC,3400,1,Lifespan Developmental Psych,0.35,0.31,0.21,0.04,0.04,0.0,0.0,0.04,pamela alley,,PSYC-3400,2018
+PSYC,3520,1,Social Psychology,0.54,0.31,0.13,0.0,0.01,0.0,0.0,0.0,eric mckibben,,PSYC-3520,2018
+PSYC,3520,2,Social Psychology,0.39,0.33,0.2,0.07,0.0,0.0,0.0,0.01,jo anne jorgensen,,PSYC-3520,2018
+PSYC,3640,1,Industrial Psych,0.27,0.33,0.29,0.04,0.02,0.0,0.0,0.06,eric mckibben,,PSYC-3640,2018
+PSYC,3640,2,Industrial Psych,0.33,0.43,0.17,0.04,0.03,0.0,0.0,0.0,eric mckibben,,PSYC-3640,2018
+PSYC,3680,1,Organizational Psych,0.49,0.33,0.13,0.01,0.01,0.0,0.0,0.01,dana verhoeven,,PSYC-3680,2018
+PSYC,3700,1,Personality,0.29,0.44,0.19,0.02,0.0,0.0,0.0,0.06,eric mckibben,,PSYC-3700,2018
+PSYC,3700,2,Personality,0.42,0.42,0.12,0.04,0.0,0.0,0.0,0.0,john robert hester,,PSYC-3700,2018
+PSYC,3830,1,Abnormal Psychology,0.32,0.45,0.15,0.04,0.02,0.0,0.0,0.02,cynthia pury s,,PSYC-3830,2018
+PSYC,3830,2,Abnormal Psychology,0.21,0.45,0.21,0.03,0.06,0.0,0.0,0.03,pamela alley,,PSYC-3830,2018
+PSYC,3830,3,Abnormal Psychology,0.21,0.44,0.21,0.06,0.03,0.0,0.0,0.06,pamela alley,,PSYC-3830,2018
+PSYC,3890,1,Cross-Cultural Psychology,0.25,0.34,0.22,0.12,0.03,0.0,0.0,0.03,ceren gunsoy,,PSYC-3890,2018
+PSYC,3890,2,Cross-Cultural Psychology,0.41,0.28,0.16,0.07,0.04,0.0,0.0,0.04,ceren gunsoy,,PSYC-3890,2018
+PSYC,4080,1,Women and Psychology,0.64,0.12,0.08,0.08,0.08,0.0,0.0,0.0,robin marie kowalski,,PSYC-4080,2018
+PSYC,4150,1,Systems and Theories,0.33,0.15,0.21,0.15,0.09,0.0,0.0,0.06,edwin brainerd,,PSYC-4150,2018
+PSYC,4150,2,Systems and Theories,0.38,0.19,0.16,0.06,0.13,0.0,0.0,0.09,edwin brainerd,,PSYC-4150,2018
+PSYC,4220,1,Perception,0.16,0.36,0.24,0.2,0.04,0.0,0.0,0.0,claudio cantalupo,,PSYC-4220,2018
+PSYC,4220,2,Perception,0.32,0.2,0.2,0.24,0.04,0.0,0.0,0.0,claudio cantalupo,,PSYC-4220,2018
+PSYC,4220,3,Perception,0.4,0.28,0.28,0.0,0.04,0.0,0.0,0.0,richard tyrrell,,PSYC-4220,2018
+PSYC,4350,1,Human Factors,0.52,0.24,0.08,0.08,0.04,0.0,0.0,0.04,laura whitlock,,PSYC-4350,2018
+PSYC,4430,1,Infant & Child Dev,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-4430,2018
+PSYC,4560,1,Psychophysiology,0.5,0.3,0.05,0.1,0.05,0.0,0.0,0.0,drew michael morris,,PSYC-4560,2018
+PSYC,4710,1,Psych of Testing,0.33,0.17,0.0,0.08,0.25,0.0,0.0,0.17,zhuo chen,,PSYC-4710,2018
+PSYC,4800,1,Health Psychology,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,chelsea alyc lenoble,,PSYC-4800,2018
+PSYC,4880,1,Psychotherapy,0.24,0.53,0.06,0.06,0.06,0.0,0.0,0.06,lucinda sorcie quick,,PSYC-4880,2018
+PSYC,4890,1,Psychology of Music,0.64,0.28,0.04,0.0,0.0,0.0,0.0,0.04,robert campbell,,PSYC-4890,2018
+PSYC,4920,1,Senior Laboratory,0.79,0.07,0.11,0.0,0.04,0.0,0.0,0.0,pamela farago,,PSYC-4920,2018
+PSYC,4920,2,Senior Laboratory,0.82,0.07,0.07,0.04,0.0,0.0,0.0,0.0,pamela farago,,PSYC-4920,2018
+PSYC,4920,3,Senior Laboratory,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,stephen an robertson,,PSYC-4920,2018
+PSYC,4920,4,Senior Laboratory,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,stephen an robertson,,PSYC-4920,2018
+PSYC,4930,100,Pract Clinical Psych,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,heidi marie zinzow,,PSYC-4930,2018
+PSYC,8130,1,Research Design III,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,patrick rosopa,,PSYC-8130,2018
+PSYC,8330,1,Adv Cog Psych,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,leo gugerty,,PSYC-8330,2018
+PSYC,8610,1,Personnel Psych,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,patrick raymark,,PSYC-8610,2018
+PSYC,8820,1,Occupat Health Psy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert raym sinclair,,PSYC-8820,2018
+RED,8030,1,Pub-Priv Partnership,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john terrence farris,,RED-8030,2018
+REL,1010,1,Intro to Religion,0.34,0.31,0.22,0.03,0.03,0.0,0.0,0.06,peter cohen,,REL-1010,2018
+REL,1010,2,Intro to Religion,0.29,0.31,0.29,0.03,0.06,0.0,0.0,0.03,peter cohen,,REL-1010,2018
+REL,1010,3,Intro to Religion,0.18,0.33,0.33,0.06,0.03,0.0,0.0,0.06,peter cohen,,REL-1010,2018
+REL,1010,4,Intro to Religion,0.32,0.26,0.32,0.0,0.0,0.0,0.0,0.11,brett patterson,,REL-1010,2018
+REL,1010,5,Intro to Religion,0.16,0.55,0.13,0.1,0.03,0.0,0.0,0.03,brett patterson,,REL-1010,2018
+REL,1020,1,World Religions,0.36,0.52,0.03,0.0,0.0,0.0,0.0,0.09,robert stephens,,REL-1020,2018
+REL,1020,2,World Religions,0.32,0.32,0.21,0.0,0.0,0.0,0.0,0.15,robert stephens,,REL-1020,2018
+REL,1020,4,World Religions,0.34,0.53,0.09,0.0,0.0,0.0,0.0,0.03,robert stephens,,REL-1020,2018
+REL,3000,2,Studying Religion,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,steven grosby,,REL-3000,2018
+REL,3010,1,Old Testament,0.56,0.29,0.06,0.0,0.0,0.0,0.0,0.09,steven grosby,,REL-3010,2018
+REL,3030,1,The Quran,0.46,0.38,0.04,0.0,0.04,0.0,0.0,0.08,mashal saif,,REL-3030,2018
+REL,3070,1,Christian Trad,0.43,0.36,0.18,0.0,0.0,0.0,0.0,0.04,brett patterson,,REL-3070,2018
+REL,3120,1,Hinduism,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert stephens,,REL-3120,2018
+REL,3300,1,Contemporary Issues,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.12,richard ale amesbury,,REL-3300,2018
+RUSS,1020,1,Elementary Russian,0.27,0.55,0.09,0.09,0.0,0.0,0.0,0.0,stephanie ely morris,,RUSS-1020,2018
+RUSS,1020,2,Elementary Russian,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,stephanie ely morris,,RUSS-1020,2018
+RUSS,3600,1,Russian Lit to 1910,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,olga anatoly volkova,,RUSS-3600,2018
+RUSS,3610,1,Russn Lit Since 1910,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,olga anatoly volkova,,RUSS-3610,2018
+SOC,2010,2,Introduction to Sociology,0.88,0.1,0.0,0.0,0.02,0.0,0.0,0.0,andrew he mannheimer,,SOC-2010,2018
+SOC,2010,3,Introduction to Sociology,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.01,andrew he mannheimer,,SOC-2010,2018
+SOC,2010,4,Introduction to Sociology,0.39,0.41,0.15,0.04,0.0,0.0,0.0,0.0,carolyn cand coffman,,SOC-2010,2018
+SOC,2010,5,Introduction to Sociology,0.51,0.32,0.12,0.01,0.03,0.0,0.0,0.01,carolyn cand coffman,,SOC-2010,2018
+SOC,2010,6,Introduction to Sociology,0.65,0.17,0.11,0.02,0.0,0.0,0.0,0.04,carolyn cand coffman,,SOC-2010,2018
+SOC,2010,7,Introduction to Sociology,0.73,0.13,0.04,0.04,0.04,0.0,0.0,0.03,stacy leanne smith,,SOC-2010,2018
+SOC,2010,8,Introduction to Sociology,0.76,0.11,0.09,0.02,0.02,0.0,0.0,0.0,stacy leanne smith,,SOC-2010,2018
+SOC,2010,9,Introduction to Sociology,0.85,0.09,0.02,0.02,0.0,0.0,0.0,0.02,stacy leanne smith,,SOC-2010,2018
+SOC,2010,10,Introduction to Sociology,0.51,0.39,0.08,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2018
+SOC,2010,11,Introduction to Sociology,0.64,0.26,0.09,0.01,0.0,0.0,0.0,0.0,shannon mcdonough,,SOC-2010,2018
+SOC,2010,12,Introduction to Sociology,0.61,0.24,0.1,0.02,0.0,0.0,0.0,0.02,shannon mcdonough,,SOC-2010,2018
+SOC,2020,1,Social Problems,0.47,0.36,0.11,0.02,0.04,0.0,0.0,0.0,carolyn cand coffman,,SOC-2020,2018
+SOC,3020,1,Research Methods I,0.33,0.27,0.27,0.03,0.03,0.0,0.0,0.07,andrew whitehead,,SOC-3020,2018
+SOC,3040,1,Social Research Methods II,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,william haller,,SOC-3040,2018
+SOC,3100,1,Marriage & Intimacy,0.62,0.16,0.18,0.0,0.02,0.0,0.0,0.02,carolyn cand coffman,,SOC-3100,2018
+SOC,3110,1,The Family,0.36,0.49,0.11,0.04,0.0,0.0,0.0,0.0,traci ann hefner,,SOC-3110,2018
+SOC,3600,1,Class & Poverty,0.24,0.49,0.2,0.05,0.02,0.0,0.0,0.0,kenneth robinson,,SOC-3600,2018
+SOC,3800,1,Intro Social Service,0.58,0.35,0.04,0.02,0.0,0.0,0.0,0.0,jennifer lea holland,,SOC-3800,2018
+SOC,3910,1,Soc of Deviance,0.5,0.38,0.08,0.02,0.02,0.0,0.0,0.0,shannon mcdonough,,SOC-3910,2018
+SOC,4040,1,Soc Theory,0.52,0.26,0.13,0.1,0.0,0.0,0.0,0.0,stacy leanne smith,,SOC-4040,2018
+SOC,4320,1,Soc of Religion,0.31,0.4,0.29,0.0,0.0,0.0,0.0,0.0,andrew whitehead,,SOC-4320,2018
+SOC,4330,1,Global Social Change,0.33,0.38,0.17,0.02,0.05,0.0,0.0,0.05,traci ann hefner,,SOC-4330,2018
+SOC,4600,1,Race & Ethnicity,0.77,0.18,0.02,0.02,0.0,0.0,0.0,0.0,andrew he mannheimer,,SOC-4600,2018
+SOC,4600,2,Race & Ethnicity,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrew he mannheimer,,SOC-4600,2018
+SOC,4610,1,Sex & Gender,0.28,0.35,0.14,0.16,0.07,0.0,0.0,0.0,sarah evelyn winslow,,SOC-4610,2018
+SOC,4840,1,Child Abuse,0.81,0.16,0.0,0.0,0.0,0.0,0.0,0.03,james rosenberger,,SOC-4840,2018
+SOC,4970,1,Senior Lab,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,jennifer lea holland,,SOC-4970,2018
+SPAN,1010,1,Elementary Spanish,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,,SPAN-1010,2018
+SPAN,1010,2,Elementary Spanish,0.47,0.16,0.26,0.0,0.0,0.0,0.0,0.11,rosa maca pillcurima,,SPAN-1010,2018
+SPAN,1010,3,Elementary Spanish,0.41,0.14,0.27,0.0,0.09,0.0,0.0,0.09,rosa maca pillcurima,,SPAN-1010,2018
+SPAN,1020,2,Elementary Spanish,0.32,0.5,0.09,0.05,0.0,0.0,0.0,0.05,ellory schmucker,,SPAN-1020,2018
+SPAN,1020,3,Elementary Spanish,0.39,0.48,0.09,0.0,0.04,0.0,0.0,0.0,adrienne elizab fama,,SPAN-1020,2018
+SPAN,1020,4,Elementary Spanish,0.27,0.32,0.32,0.09,0.0,0.0,0.0,0.0,adrienne elizab fama,,SPAN-1020,2018
+SPAN,1020,5,Elementary Spanish,0.14,0.55,0.23,0.05,0.0,0.0,0.0,0.05,rosa maca pillcurima,,SPAN-1020,2018
+SPAN,1020,7,Elementary Spanish,0.36,0.36,0.18,0.0,0.09,0.0,0.0,0.0,cathy robison,,SPAN-1020,2018
+SPAN,1020,8,Elementary Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,debra oak williamson,,SPAN-1020,2018
+SPAN,1020,9,Elementary Spanish,0.47,0.21,0.26,0.0,0.0,0.0,0.0,0.05,debra oak williamson,,SPAN-1020,2018
+SPAN,1020,10,Elementary Spanish,0.43,0.38,0.14,0.0,0.05,0.0,0.0,0.0,adrienne elizab fama,,SPAN-1020,2018
+SPAN,2010,1,Intermediate Spanish,0.23,0.5,0.14,0.05,0.0,0.0,0.0,0.09,cathy robison,,SPAN-2010,2018
+SPAN,2010,2,Intermediate Spanish,0.26,0.26,0.26,0.11,0.0,0.0,0.0,0.11,cathy robison,,SPAN-2010,2018
+SPAN,2010,3,Intermediate Spanish,0.39,0.39,0.22,0.0,0.0,0.0,0.0,0.0,allison ann hinds,,SPAN-2010,2018
+SPAN,2010,4,Intermediate Spanish,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,nora arostegui logue,,SPAN-2010,2018
+SPAN,2010,5,Intermediate Spanish,0.39,0.44,0.06,0.0,0.06,0.0,0.0,0.06,allison ann hinds,,SPAN-2010,2018
+SPAN,2010,6,Intermediate Spanish,0.31,0.46,0.0,0.08,0.0,0.0,0.0,0.15,debra oak williamson,,SPAN-2010,2018
+SPAN,2010,7,Intermediate Spanish,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,debra oak williamson,,SPAN-2010,2018
+SPAN,2010,8,Intermediate Spanish,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2018
+SPAN,2010,9,Intermediate Spanish,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2018
+SPAN,2010,10,Intermediate Spanish,0.65,0.22,0.04,0.04,0.0,0.0,0.0,0.04,vieyra daniel garcia,,SPAN-2010,2018
+SPAN,2010,12,Intermediate Spanish,0.64,0.07,0.07,0.0,0.07,0.0,0.0,0.14,valderramos zen cruz,,SPAN-2010,2018
+SPAN,2010,13,Intermediate Spanish,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,,SPAN-2010,2018
+SPAN,2010,14,Intermediate Spanish,0.61,0.22,0.09,0.0,0.0,0.0,0.0,0.09,ellory schmucker,,SPAN-2010,2018
+SPAN,2010,16,Intermediate Spanish,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,vieyra daniel garcia,,SPAN-2010,2018
+SPAN,2020,1,Intermediate Spanish,0.7,0.22,0.04,0.0,0.04,0.0,0.0,0.0,vieyra daniel garcia,,SPAN-2020,2018
+SPAN,2020,2,Intermediate Spanish,0.71,0.1,0.14,0.05,0.0,0.0,0.0,0.0,vieyra daniel garcia,,SPAN-2020,2018
+SPAN,2020,3,Intermediate Spanish,0.7,0.17,0.13,0.0,0.0,0.0,0.0,0.0,vieyra daniel garcia,,SPAN-2020,2018
+SPAN,2020,4,Intermediate Spanish,0.48,0.38,0.1,0.0,0.0,0.0,0.0,0.05,valderramos zen cruz,,SPAN-2020,2018
+SPAN,2020,5,Intermediate Spanish,0.55,0.23,0.14,0.0,0.0,0.0,0.0,0.09,valderramos zen cruz,,SPAN-2020,2018
+SPAN,2020,6,Intermediate Spanish,0.52,0.35,0.13,0.0,0.0,0.0,0.0,0.0,valderramos zen cruz,,SPAN-2020,2018
+SPAN,2020,7,Intermediate Spanish,0.12,0.47,0.12,0.12,0.18,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2018
+SPAN,2020,8,Intermediate Spanish,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,,SPAN-2020,2018
+SPAN,2020,9,Intermediate Spanish,0.42,0.42,0.05,0.11,0.0,0.0,0.0,0.0,ana paula  miller e,,SPAN-2020,2018
+SPAN,2020,10,Intermediate Spanish,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,,SPAN-2020,2018
+SPAN,2020,11,Intermediate Spanish,0.65,0.26,0.04,0.0,0.0,0.0,0.0,0.04,rodriguez alm garcia,,SPAN-2020,2018
+SPAN,2020,12,Intermediate Spanish,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,,SPAN-2020,2018
+SPAN,2020,13,Intermediate Spanish,0.19,0.48,0.24,0.0,0.0,0.0,0.0,0.1,juana martin-armas,,SPAN-2020,2018
+SPAN,2020,14,Intermediate Spanish,0.1,0.5,0.2,0.2,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-2020,2018
+SPAN,2020,15,Intermediate Spanish,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,ana paula  miller e,,SPAN-2020,2018
+SPAN,2020,20,Intermediate Spanish,0.45,0.23,0.27,0.0,0.0,0.0,0.0,0.05,melva margue persico,,SPAN-2020,2018
+SPAN,3020,1,Intermed Span Grammar & Comp,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,,SPAN-3020,2018
+SPAN,3020,2,Intermed Span Grammar & Comp,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,melva margue persico,,SPAN-3020,2018
+SPAN,3020,3,Intermed Span Grammar & Comp,0.42,0.37,0.05,0.0,0.05,0.0,0.0,0.11,melva margue persico,,SPAN-3020,2018
+SPAN,3040,1,Intro Hispanic Literary Forms,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,,SPAN-3040,2018
+SPAN,3040,2,Intro Hispanic Literary Forms,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,rodriguez alm garcia,,SPAN-3040,2018
+SPAN,3050,1,Intermed Span Convers/Comp I,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,melva margue persico,,SPAN-3050,2018
+SPAN,3050,2,Intermed Span Convers/Comp I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,riquelme maria judez,,SPAN-3050,2018
+SPAN,3050,4,Intermed Span Convers/Comp I,0.72,0.17,0.06,0.06,0.0,0.0,0.0,0.0,moni rojas-de-massei,,SPAN-3050,2018
+SPAN,3060,1,Span Comp for Bus,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-3060,2018
+SPAN,3070,1,The Hispanic World: Spain,0.5,0.44,0.0,0.06,0.0,0.0,0.0,0.0,juana martin-armas,,SPAN-3070,2018
+SPAN,3080,1,The Hispanic World: Latin Amer,0.24,0.47,0.18,0.0,0.12,0.0,0.0,0.0,tiffany dawn miller,,SPAN-3080,2018
+SPAN,3130,2,Span Lit Survey I,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william dan holcombe,,SPAN-3130,2018
+SPAN,4060,1,Narrative Fiction,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,moni rojas-de-massei,,SPAN-4060,2018
+SPAN,4070,1,Hispanic Film,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,raquel anido,,SPAN-4070,2018
+SPAN,4170,1,Prof Communication,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,,SPAN-4170,2018
+SPAN,4180,1,Technical Span Health Mgt Prof,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,peralta arelis moore,,SPAN-4180,2018
+STAT,2220,1,Statistics in Everyday Life,0.38,0.25,0.27,0.04,0.04,0.0,0.0,0.02,james espey,,STAT-2220,2018
+STAT,2220,2,Statistics in Everyday Life,0.39,0.31,0.14,0.04,0.06,0.0,0.0,0.06,james espey,,STAT-2220,2018
+STAT,2220,3,Statistics in Everyday Life,0.35,0.31,0.17,0.08,0.08,0.0,0.0,0.02,james espey,,STAT-2220,2018
+STAT,2220,4,Statistics in Everyday Life,0.27,0.35,0.17,0.1,0.0,0.0,0.0,0.12,james espey,,STAT-2220,2018
+STAT,2220,5,Statistics in Everyday Life,0.31,0.43,0.16,0.06,0.02,0.0,0.0,0.02,rose martinez-dawson,,STAT-2220,2018
+STAT,2220,6,Statistics in Everyday Life,0.47,0.22,0.18,0.08,0.06,0.0,0.0,0.0,rose martinez-dawson,,STAT-2220,2018
+STAT,2220,7,Statistics in Everyday Life,0.27,0.33,0.27,0.08,0.0,0.0,0.0,0.04,jason alexander kurz,,STAT-2220,2018
+STAT,2220,8,Statistics in Everyday Life,0.14,0.35,0.22,0.05,0.19,0.0,0.0,0.05,andrew pangia,,STAT-2220,2018
+STAT,2300,1,Statistical Methods I,0.22,0.33,0.21,0.11,0.08,0.0,0.0,0.04,april thomas,,STAT-2300,2018
+STAT,2300,2,Statistical Methods I,0.32,0.33,0.17,0.12,0.03,0.0,0.0,0.04,christy jenkin brown,,STAT-2300,2018
+STAT,2300,3,Statistical Methods I,0.3,0.35,0.16,0.08,0.05,0.0,0.0,0.05, erwin walker,,STAT-2300,2018
+STAT,2300,4,Statistical Methods I,0.27,0.3,0.18,0.11,0.08,0.0,0.0,0.06, erwin walker,,STAT-2300,2018
+STAT,2300,5,Statistical Methods I,0.21,0.38,0.22,0.08,0.11,0.0,0.0,0.01,elaine mar sotherden,,STAT-2300,2018
+STAT,2300,6,Statistical Methods I,0.28,0.41,0.18,0.08,0.04,0.0,0.0,0.01,todd fenstermacher,,STAT-2300,2018
+STAT,2300,100,Statistical Methods I (HON),0.73,0.24,0.03,0.0,0.0,0.0,0.0,0.0,christy jenkin brown,True,STAT-2300,2018
+STAT,3090,1,Introductory Business Stats,0.16,0.21,0.29,0.08,0.16,0.0,0.0,0.11,tianhui wei,,STAT-3090,2018
+STAT,3090,2,Introductory Business Stats,0.14,0.17,0.17,0.19,0.25,0.0,0.0,0.08,matthew saltzman,,STAT-3090,2018
+STAT,3090,3,Introductory Business Stats,0.31,0.29,0.12,0.17,0.07,0.0,0.0,0.05,tiantian yang,,STAT-3090,2018
+STAT,3090,4,Introductory Business Stats,0.2,0.25,0.16,0.18,0.11,0.0,0.0,0.09,margaret mari wiecek,,STAT-3090,2018
+STAT,3090,5,Introductory Business Stats,0.2,0.18,0.23,0.16,0.16,0.0,0.0,0.07,lu sun,,STAT-3090,2018
+STAT,3090,6,Introductory Business Stats,0.18,0.3,0.27,0.05,0.2,0.0,0.0,0.0,boyoung hur,,STAT-3090,2018
+STAT,3090,7,Introductory Business Stats,0.26,0.31,0.19,0.12,0.1,0.0,0.0,0.02,jiajing niu,,STAT-3090,2018
+STAT,3090,8,Introductory Business Stats,0.26,0.21,0.33,0.05,0.13,0.0,0.0,0.03,yisu jia,,STAT-3090,2018
+STAT,3090,9,Introductory Business Stats,0.29,0.4,0.26,0.06,0.0,0.0,0.0,0.0,marilyn reba,,STAT-3090,2018
+STAT,3090,10,Introductory Business Stats,0.28,0.56,0.06,0.08,0.03,0.0,0.0,0.0,marilyn reba,,STAT-3090,2018
+STAT,3090,11,Introductory Business Stats,0.24,0.23,0.26,0.14,0.12,0.0,0.0,0.01,sharon marie evans,,STAT-3090,2018
+STAT,3090,12,Introductory Business Stats,0.2,0.34,0.26,0.09,0.08,0.0,0.0,0.02,sharon marie evans,,STAT-3090,2018
+STAT,3300,1,Statistical Methods II,0.36,0.36,0.12,0.08,0.04,0.0,0.0,0.04,rose martinez-dawson,,STAT-3300,2018
+STAT,4020,1,Intro to Statistical Computing,0.43,0.24,0.1,0.0,0.14,0.0,0.0,0.1,ellen hepfer breazel,,STAT-4020,2018
+STAT,4110,1,Stat Mthds for Process Control,0.71,0.18,0.09,0.0,0.03,0.0,0.0,0.0,richard steve dubsky,,STAT-4110,2018
+STAT,6020,1,Intro to Statistical Computing,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,,STAT-6020,2018
+STAT,8010,1,Statistical Methods I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james rieck,,STAT-8010,2018
+STAT,8010,2,Statistical Methods I,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-8010,2018
+STAT,8010,3,Statistical Methods I,0.32,0.36,0.18,0.0,0.09,0.0,0.0,0.05,james rieck,,STAT-8010,2018
+STAT,8010,4,Statistical Methods I,0.43,0.52,0.04,0.0,0.0,0.0,0.0,0.0,patrick gerard,,STAT-8010,2018
+STAT,8010,5,Statistical Methods I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,joseph daniel bible,,STAT-8010,2018
+STAT,8010,400,Statistical Methods I,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,brook thayer russell,,STAT-8010,2018
+STAT,8050,1,Design & Anlys of Experiments,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,william bridges,,STAT-8050,2018
+STS,1010,2,Survey of S T S,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,scott brame,,STS-1010,2018
+STS,1010,3,Survey of S T S,0.5,0.36,0.11,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,,STS-1010,2018
+STS,1010,4,Survey of S T S,0.69,0.25,0.03,0.0,0.0,0.0,0.0,0.03,melissa dugan,,STS-1010,2018
+STS,1010,5,Survey of S T S,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,philip randall,,STS-1010,2018
+STS,1010,6,Survey of S T S,0.17,0.51,0.23,0.0,0.0,0.0,0.0,0.09,sarah mae cooper,,STS-1010,2018
+STS,1010,7,Survey of S T S,0.22,0.47,0.25,0.0,0.0,0.0,0.0,0.06,megan noe macalystre,,STS-1010,2018
+STS,1010,8,Survey of S T S,0.27,0.4,0.2,0.03,0.0,0.0,0.0,0.1,david charles foltz,,STS-1010,2018
+STS,1010,9,Survey of S T S,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,stephanie stripling,,STS-1010,2018
+THEA,2100,1,Theatre Appreciation,0.55,0.29,0.06,0.03,0.0,0.0,0.0,0.06,kendra lynet johnson,,THEA-2100,2018
+THEA,2100,2,Theatre Appreciation,0.66,0.19,0.06,0.0,0.06,0.0,0.0,0.03,kerrie kathl seymour,,THEA-2100,2018
+THEA,2100,3,Theatre Appreciation,0.87,0.06,0.03,0.0,0.0,0.0,0.0,0.03,shannon there robert,,THEA-2100,2018
+THEA,2100,5,Theatre Appreciation,0.43,0.47,0.07,0.0,0.0,0.0,0.0,0.03,carol collins,,THEA-2100,2018
+THEA,2100,6,Theatre Appreciation,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,,THEA-2100,2018
+THEA,2100,7,Theatre Appreciation,0.66,0.28,0.03,0.0,0.0,0.0,0.0,0.03,jason adkins,,THEA-2100,2018
+THEA,2790,1,Theatre Practicum,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,matthew leckenbusch,,THEA-2790,2018
+THEA,3160,1,Theatre History II,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,peter richard er st. er,,THEA-3160,2018
+THEA,3180,1,Afri-Amer Thea II,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,kendra lynet johnson,,THEA-3180,2018
+THEA,3770,1,Stagecrafts,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david hartmann,,THEA-3770,2018
+THEA,4790,1,Acting II,0.54,0.23,0.08,0.08,0.08,0.0,0.0,0.0,kerrie kathl seymour,,THEA-4790,2018
+WFB,3010,1,Wildlife Biology Lab,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,shari lynn rodriguez,,WFB-3010,2018
+WFB,3010,2,Wildlife Biology Lab,0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,shari lynn rodriguez,,WFB-3010,2018
+WFB,3130,1,Conservation Biology,0.35,0.39,0.16,0.05,0.03,0.0,0.0,0.03,shari lynn rodriguez,,WFB-3130,2018
+WFB,3130,2,Conservation Biology,0.27,0.35,0.24,0.08,0.03,0.0,0.0,0.03,shari lynn rodriguez,,WFB-3130,2018
+WFB,3500,1,Princ Fish & Wildlife Biology,0.3,0.46,0.2,0.04,0.0,0.0,0.0,0.0,james davis,,WFB-3500,2018
+WFB,3500,2,Princ Fish & Wildlife Biology,0.18,0.5,0.25,0.05,0.0,0.0,0.0,0.02,james davis,,WFB-3500,2018
+WFB,4120,1,Wildlife Management,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,,WFB-4120,2018
+WFB,4160,1,Fisheries Techniques,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,brandon kevi peoples,,WFB-4160,2018
+WFB,4620,1,Wetland Wildlife Biology,0.74,0.23,0.01,0.0,0.0,0.0,0.0,0.01,russell barrett,,WFB-4620,2018
+WFB,4930,2,Quantitative Ecology,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,david scot jachowski,,WFB-4930,2018
+WFB,8500,1,Wildlife & Fisheries Ecology,0.44,0.33,0.15,0.0,0.04,0.0,0.0,0.04,susan talley guynn,,WFB-8500,2018
+WS,1030,1,Women in Global Perspective,0.88,0.04,0.0,0.04,0.0,0.0,0.0,0.04,annie boiter-jolley,,WS-1030,2018
+WS,1030,2,Women in Global Perspective,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,annie boiter-jolley,,WS-1030,2018
+WS,2400,1,Women and Leadership II,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,diane perpich,,WS-2400,2018
+WS,3010,1,Intro Women's Studies,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,elizabeth rose adams,,WS-3010,2018
+WS,3010,2,Intro Women's Studies,0.68,0.27,0.0,0.0,0.05,0.0,0.0,0.0,elizabeth rose adams,,WS-3010,2018
+YDP,3100,1,Youth Developmt and the Family,0.79,0.14,0.04,0.0,0.04,0.0,0.0,0.0,william quinn,,YDP-3100,2018
+YDP,3100,3,Youth Developmt and the Family,0.81,0.07,0.07,0.0,0.04,0.0,0.0,0.0,william quinn,,YDP-3100,2018
+YDP,3250,1,Working with Diverse Youth,0.79,0.14,0.04,0.0,0.0,0.0,0.0,0.04,kimberly pea johnson,,YDP-3250,2018
+YDP,4400,1,Youth Program Assessmnt & Eval,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,ann marie gillard,,YDP-4400,2018
+YDP,4550,1,Youth and Technology,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,david lynn pollock,,YDP-4550,2018
+YDP,8010,1,Child/Adolescent Dev,0.68,0.24,0.04,0.0,0.04,0.0,0.0,0.0,edmond patric bowers,,YDP-8010,2018
+YDP,8040,1,Assess & Eval of Youth Program,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,,YDP-8040,2018
+YDP,8880,1,Special Topics Youth Dev Ldshp,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,barry garst,,YDP-8880,2018

--- a/bot/cogs/grades_cog/assets/2018_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2018_Spring.csv
@@ -1,2518 +1,2518 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1020,1,Survey of Art & Arch Hist II,0.4,0.4,0.17,0.0,0.01,0.0,0.0,0.01,andrea feeser,AAH-1020,2018
-AAH,2060,1,Art History and Theory II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,AAH-2060,2018
-ACCT,2010,1,Financial Accounting Concepts,0.13,0.31,0.29,0.1,0.17,0.0,0.0,0.0,emily suzan mccorkle,ACCT-2010,2018
-ACCT,2010,2,Financial Accounting Concepts,0.33,0.38,0.16,0.04,0.07,0.0,0.0,0.02,lydia lanc schleifer,ACCT-2010,2018
-ACCT,2010,3,Financial Accounting Concepts,0.28,0.22,0.34,0.08,0.08,0.0,0.0,0.0,annieka philo,ACCT-2010,2018
-ACCT,2010,4,Financial Accounting Concepts,0.4,0.28,0.14,0.1,0.04,0.0,0.0,0.04,emily suzan mccorkle,ACCT-2010,2018
-ACCT,2010,5,Financial Accounting Concepts,0.41,0.31,0.18,0.02,0.04,0.0,0.0,0.04,annieka philo,ACCT-2010,2018
-ACCT,2010,6,Financial Accounting Concepts,0.43,0.31,0.1,0.02,0.06,0.0,0.0,0.08,lydia lanc schleifer,ACCT-2010,2018
-ACCT,2010,7,Financial Accounting Concepts,0.31,0.52,0.04,0.02,0.08,0.0,0.0,0.02,lydia lanc schleifer,ACCT-2010,2018
-ACCT,2010,8,Financial Accounting Concepts,0.37,0.35,0.16,0.04,0.04,0.0,0.0,0.04,emily suzan mccorkle,ACCT-2010,2018
-ACCT,2010,9,Financial Accounting Concepts,0.3,0.32,0.22,0.04,0.1,0.0,0.0,0.02,emily suzan mccorkle,ACCT-2010,2018
-ACCT,2010,10,Financial Accounting Concepts,0.18,0.36,0.24,0.12,0.08,0.0,0.0,0.02,james barnes,ACCT-2010,2018
-ACCT,2010,11,Financial Accounting Concepts,0.3,0.36,0.2,0.06,0.08,0.0,0.0,0.0,rebecca pennell trax,ACCT-2010,2018
-ACCT,2010,12,Financial Accounting Concepts,0.37,0.31,0.18,0.06,0.04,0.0,0.0,0.04,rebecca pennell trax,ACCT-2010,2018
-ACCT,2010,13,Financial Accounting Concepts,0.49,0.24,0.1,0.07,0.05,0.0,0.0,0.05,charles tegen,ACCT-2010,2018
-ACCT,2010,14,Financial Accounting Concepts,0.29,0.29,0.32,0.03,0.06,0.0,0.0,0.0,philip maiberger,ACCT-2010,2018
-ACCT,2010,15,Financial Accounting Concepts,0.24,0.43,0.14,0.1,0.05,0.0,0.0,0.05,lisa whea birtwistle,ACCT-2010,2018
-ACCT,2010,16,Financial Accounting Concepts,0.12,0.38,0.22,0.08,0.16,0.0,0.0,0.04,james barnes,ACCT-2010,2018
-ACCT,2010,101,Fin Acct Concepts (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,lisa whea birtwistle,ACCT-2010,2018
-ACCT,2010,401,Financial Accounting Concepts,0.31,0.48,0.1,0.08,0.01,0.0,0.0,0.02,jeffrey mcmillan,ACCT-2010,2018
-ACCT,2020,1,Managerial Accounting Concepts,0.17,0.34,0.17,0.03,0.06,0.0,0.0,0.23,henry anderson,ACCT-2020,2018
-ACCT,2020,2,Managerial Accounting Concepts,0.19,0.28,0.17,0.02,0.02,0.0,0.0,0.33,henry anderson,ACCT-2020,2018
-ACCT,2020,3,Managerial Accounting Concepts,0.27,0.29,0.22,0.14,0.06,0.0,0.0,0.02,phebian davis-culler,ACCT-2020,2018
-ACCT,2020,4,Managerial Accounting Concepts,0.42,0.33,0.19,0.04,0.02,0.0,0.0,0.0,james milt kohlmeyer,ACCT-2020,2018
-ACCT,2020,5,Managerial Accounting Concepts,0.22,0.33,0.13,0.04,0.07,0.0,0.0,0.2,henry anderson,ACCT-2020,2018
-ACCT,2020,6,Managerial Accounting Concepts,0.29,0.29,0.21,0.09,0.04,0.0,0.0,0.09,brian todd carver,ACCT-2020,2018
-ACCT,2020,7,Managerial Accounting Concepts,0.15,0.31,0.27,0.0,0.17,0.0,0.0,0.1,brian todd carver,ACCT-2020,2018
-ACCT,2020,401,Managerial Accounting Concepts,0.33,0.28,0.18,0.05,0.03,0.0,0.0,0.12,henry anderson,ACCT-2020,2018
-ACCT,3030,1,Cost Accounting,0.3,0.36,0.23,0.11,0.0,0.0,0.0,0.0,phebian davis-culler,ACCT-3030,2018
-ACCT,3030,2,Cost Accounting,0.36,0.27,0.27,0.04,0.04,0.0,0.0,0.02,phebian davis-culler,ACCT-3030,2018
-ACCT,3030,3,Cost Accounting,0.2,0.32,0.32,0.07,0.0,0.0,0.0,0.1,jace garrett,ACCT-3030,2018
-ACCT,3030,4,Cost Accounting,0.13,0.32,0.36,0.06,0.11,0.0,0.0,0.02,jace garrett,ACCT-3030,2018
-ACCT,3110,1,Intermediate Financial Acct I,0.29,0.33,0.19,0.05,0.07,0.0,0.0,0.07,erin michell hawkins,ACCT-3110,2018
-ACCT,3110,2,Intermediate Financial Acct I,0.18,0.5,0.23,0.05,0.05,0.0,0.0,0.0,erin michell hawkins,ACCT-3110,2018
-ACCT,3110,3,Intermediate Financial Acct I,0.22,0.44,0.2,0.13,0.0,0.0,0.0,0.0,amy melissa donnelly,ACCT-3110,2018
-ACCT,3110,4,Intermediate Financial Acct I,0.29,0.33,0.31,0.07,0.0,0.0,0.0,0.0,amy melissa donnelly,ACCT-3110,2018
-ACCT,3110,401,Intermediate Financial Acct I,0.49,0.27,0.08,0.06,0.02,0.0,0.0,0.08,henry anderson,ACCT-3110,2018
-ACCT,3120,1,Intermediate Financial Acct II,0.0,0.18,0.45,0.18,0.18,0.0,0.0,0.0,jeremy michae vinson,ACCT-3120,2018
-ACCT,3120,2,Intermediate Financial Acct II,0.32,0.36,0.25,0.05,0.0,0.0,0.0,0.02,terry daniel knause,ACCT-3120,2018
-ACCT,3120,3,Intermediate Financial Acct II,0.23,0.39,0.27,0.09,0.02,0.0,0.0,0.0,jeremy michae vinson,ACCT-3120,2018
-ACCT,3120,4,Intermediate Financial Acct II,0.28,0.33,0.33,0.0,0.0,0.0,0.0,0.06,terry daniel knause,ACCT-3120,2018
-ACCT,3120,5,Intermediate Financial Acct II,0.36,0.3,0.23,0.11,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2018
-ACCT,3120,6,Intermediate Financial Acct II,0.27,0.4,0.2,0.13,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2018
-ACCT,3130,1,Intermediate Fin Acct III,0.11,0.5,0.21,0.07,0.04,0.0,0.0,0.07, russell madray,ACCT-3130,2018
-ACCT,3130,2,Intermediate Fin Acct III,0.16,0.48,0.3,0.02,0.02,0.0,0.0,0.02, russell madray,ACCT-3130,2018
-ACCT,3130,3,Intermediate Fin Acct III,0.3,0.49,0.16,0.05,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2018
-ACCT,3130,4,Intermediate Fin Acct III,0.36,0.44,0.15,0.05,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2018
-ACCT,3220,1,Accounting Information Systems,0.17,0.5,0.17,0.03,0.03,0.0,0.0,0.11,philip maiberger,ACCT-3220,2018
-ACCT,3220,2,Accounting Information Systems,0.25,0.47,0.22,0.06,0.0,0.0,0.0,0.0,philip maiberger,ACCT-3220,2018
-ACCT,3220,3,Accounting Information Systems,0.06,0.23,0.48,0.06,0.03,0.0,0.0,0.13,philip maiberger,ACCT-3220,2018
-ACCT,4040,1,Individual Taxation,0.74,0.17,0.06,0.03,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2018
-ACCT,4040,2,Individual Taxation,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2018
-ACCT,4040,3,Individual Taxation,0.58,0.3,0.0,0.1,0.03,0.0,0.0,0.0,lisa whea birtwistle,ACCT-4040,2018
-ACCT,4040,4,Individual Taxation,0.24,0.38,0.19,0.08,0.08,0.0,0.0,0.03,lisa whea birtwistle,ACCT-4040,2018
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.28,0.38,0.33,0.0,0.0,0.0,0.0,0.0,robin radtke,ACCT-4100,2018
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.3,0.53,0.15,0.0,0.0,0.0,0.0,0.03,robin radtke,ACCT-4100,2018
-ACCT,4150,1,Auditing,0.15,0.49,0.28,0.05,0.03,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2018
-ACCT,4150,2,Auditing,0.17,0.33,0.19,0.17,0.03,0.0,0.0,0.11,carl hollingsworth,ACCT-4150,2018
-ACCT,8520,1,Fin Acct Theory/Res,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,ralph edward welton,ACCT-8520,2018
-ACCT,8520,2,Fin Acct Theory/Res,0.28,0.59,0.13,0.0,0.0,0.0,0.0,0.0,ralph edward welton,ACCT-8520,2018
-ACCT,8540,1,Prof Responsibility,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2018
-ACCT,8540,2,Prof Responsibility,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2018
-ACCT,8540,3,Prof Responsibility,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8540,2018
-ACCT,8620,1,Financial Auditing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-8620,2018
-ACCT,8620,2,Financial Auditing,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-8620,2018
-ACCT,8710,1,Corporate Taxation,0.31,0.64,0.06,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2018
-ACCT,8710,2,Corporate Taxation,0.15,0.8,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2018
-ACCT,8710,3,Corporate Taxation,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2018
-ACCT,8730,1,Intl/Spec Tax Topic,0.43,0.47,0.11,0.0,0.0,0.0,0.0,0.0,kathr kisska-schulze,ACCT-8730,2018
-ACCT,8740,1,Tax Aspects of Finan Planning,0.42,0.53,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,ACCT-8740,2018
-AFLS,2000,1,Agric For Domestic Study Tour,0.0,0.0,0.0,0.0,0.0,0.9,0.05,0.05,jean bertrand,AFLS-2000,2018
-AGED,1000,1,Orientation & Field Experience,0.74,0.05,0.0,0.0,0.11,0.0,0.0,0.11,philip fravel,AGED-1000,2018
-AGED,2030,1,Teaching Agriscience,0.33,0.56,0.06,0.0,0.06,0.0,0.0,0.0,catherin dibenedetto,AGED-2030,2018
-AGED,4150,1,Leadership of Vol,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,kevin layfield,AGED-4150,2018
-AGED,4160,1,Ethics and Issues,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,AGED-4160,2018
-AGED,4250,1,Teaching Ag Mechs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-4250,2018
-AGM,2050,1,Prin of Fabrication,0.32,0.53,0.09,0.04,0.0,0.0,0.0,0.02,hunter massey,AGM-2050,2018
-AGM,2060,1,Machinery Mgt,0.34,0.44,0.16,0.03,0.0,0.0,0.0,0.03,hunter massey,AGM-2060,2018
-AGM,2200,1,Calc for Mechanized Agricult,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,young han,AGM-2200,2018
-AGM,2210,1,Land Measurements,0.46,0.27,0.23,0.02,0.02,0.0,0.0,0.0,charles privette,AGM-2210,2018
-AGM,4020,1,Irrigation System Design,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,charles privette,AGM-4020,2018
-AGM,4100,1,Precision Ag Tech,0.46,0.38,0.14,0.02,0.0,0.0,0.0,0.0,hunter massey,AGM-4100,2018
-AGM,4520,1,Mobile Power,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4520,2018
-AGM,4720,1,Capstone,0.74,0.24,0.02,0.0,0.0,0.0,0.0,0.0,john chastain,AGM-4720,2018
-AGRB,2020,1,Agricultural Economics,0.39,0.24,0.19,0.12,0.03,0.0,0.0,0.03,george apperson,AGRB-2020,2018
-AGRB,2050,1,Agriculture and Society,0.26,0.53,0.18,0.04,0.0,0.0,0.0,0.0,george apperson,AGRB-2050,2018
-AGRB,3080,1,Quant Agribusiness Analysis I,0.15,0.19,0.38,0.22,0.05,0.0,0.0,0.01,lisha zhang,AGRB-3080,2018
-AGRB,3190,1,Agribusiness Management,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,yuliya vale bolotova,AGRB-3190,2018
-AGRB,3510,1,Principles of Ag Sales and Ad,0.03,0.65,0.29,0.03,0.0,0.0,0.0,0.0,george apperson,AGRB-3510,2018
-AGRB,3570,1,Natural Resources Economics,0.16,0.35,0.24,0.18,0.0,0.0,0.0,0.06,david brian willis,AGRB-3570,2018
-AGRB,4020,1,Production Economics,0.28,0.37,0.28,0.05,0.0,0.0,0.0,0.02,michael vassalos,AGRB-4020,2018
-AGRB,4080,1,Quant Agribusiness Analysis II,0.32,0.35,0.26,0.06,0.0,0.0,0.0,0.0,lisha zhang,AGRB-4080,2018
-AGRB,4520,1,Agricultural Policy,0.14,0.48,0.24,0.12,0.0,0.0,0.0,0.02,michael vassalos,AGRB-4520,2018
-AGRB,4560,1,Prices,0.23,0.33,0.26,0.19,0.0,0.0,0.0,0.0,yuliya vale bolotova,AGRB-4560,2018
-AL,3490,400,Principles of Coaching,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,AL-3490,2018
-AL,3490,402,Principles of Coaching,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,julia wright,AL-3490,2018
-AL,3490,403,Principles of Coaching,0.72,0.12,0.08,0.0,0.04,0.0,0.0,0.04,clyde keith connor,AL-3490,2018
-AL,3490,406,Principles of Coaching,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john plumblee,AL-3490,2018
-AL,3490,407,Principles of Coaching,0.68,0.12,0.12,0.04,0.0,0.0,0.0,0.04,john plumblee,AL-3490,2018
-AL,3490,408,Principles of Coaching,0.76,0.16,0.0,0.0,0.08,0.0,0.0,0.0,deborah jo cadorette,AL-3490,2018
-AL,3500,400,Sci Basis I/Ex Phy,0.23,0.15,0.38,0.15,0.0,0.0,0.0,0.08,michael godfrey,AL-3500,2018
-AL,3500,401,Sci Basis I/Ex Phy,0.17,0.38,0.33,0.08,0.04,0.0,0.0,0.0,michael godfrey,AL-3500,2018
-AL,3520,400,Kinesiology,0.2,0.4,0.2,0.0,0.0,0.0,0.0,0.2,isaac sean colbert,AL-3520,2018
-AL,3530,400,Athletic Injuries,0.2,0.32,0.16,0.28,0.04,0.0,0.0,0.0,isaac sean colbert,AL-3530,2018
-AL,3530,401,Athletic Injuries,0.13,0.57,0.13,0.17,0.0,0.0,0.0,0.0,isaac sean colbert,AL-3530,2018
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.58,0.04,0.0,0.04,0.0,0.0,0.0,clyde keith connor,AL-3600,2018
-AL,3610,400,Admin/Org of Athletic Programs,0.72,0.16,0.04,0.04,0.0,0.0,0.0,0.04,henry oates,AL-3610,2018
-AL,3610,401,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2018
-AL,3610,402,Admin/Org of Athletic Programs,0.88,0.0,0.08,0.04,0.0,0.0,0.0,0.0,henry oates,AL-3610,2018
-AL,3620,400,Psychology of Coaching,0.5,0.23,0.12,0.04,0.12,0.0,0.0,0.0,natalie anne carter,AL-3620,2018
-AL,3620,401,Psychology of Coaching,0.44,0.32,0.16,0.04,0.04,0.0,0.0,0.0,natalie anne carter,AL-3620,2018
-AL,3620,402,Psychology of Coaching,0.46,0.35,0.08,0.08,0.04,0.0,0.0,0.0,natalie anne carter,AL-3620,2018
-AL,3720,400,Coaching Basketball,0.76,0.2,0.0,0.0,0.0,0.0,0.0,0.04,edmond fry,AL-3720,2018
-AL,3740,400,Coaching Football,0.76,0.12,0.08,0.04,0.0,0.0,0.0,0.0,edmond fry,AL-3740,2018
-AL,3760,400,Coaching Strength/Conditioning,0.8,0.12,0.04,0.0,0.0,0.0,0.0,0.04,edmond fry,AL-3760,2018
-AL,3760,401,Coaching Strength/Conditioning,0.72,0.08,0.04,0.08,0.04,0.0,0.0,0.04,edmond fry,AL-3760,2018
-AL,4000,400,Athletic Leadership Internship,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,deborah jo cadorette,AL-4000,2018
-AL,4380,402,Officiating in Athletic Leader,0.68,0.16,0.12,0.04,0.0,0.0,0.0,0.0,clyde keith connor,AL-4380,2018
-AL,4380,403,Belief Systems in AL,0.59,0.22,0.15,0.04,0.0,0.0,0.0,0.0,deborah jo cadorette,AL-4380,2018
-AL,4380,404,Belief Systems in AL,0.71,0.13,0.04,0.13,0.0,0.0,0.0,0.0,deborah jo cadorette,AL-4380,2018
-AL,8530,400,Legal Iss in Intercoll Athlet,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,AL-8530,2018
-AL,8530,401,Legal Iss in Intercoll Athlet,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,AL-8530,2018
-AL,8630,400,Socio Dynam in Intercol Athlet,0.38,0.48,0.05,0.0,0.05,0.0,0.0,0.05,michael godfrey,AL-8630,2018
-AL,8630,401,Socio Dynam in Intercol Athlet,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8630,2018
-AL,8640,400,Ethical Iss in Collegiate Athl,0.64,0.23,0.09,0.0,0.05,0.0,0.0,0.0,michael godfrey,AL-8640,2018
-AL,8640,401,Ethical Iss in Collegiate Athl,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8640,2018
-AL,8700,400,Intercoll Athletics Finance,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,AL-8700,2018
-ANTH,2010,1,Introduction to Anthropology,0.23,0.48,0.26,0.03,0.0,0.0,0.0,0.0,david markus,ANTH-2010,2018
-ANTH,2010,2,Introduction to Anthropology,0.35,0.46,0.11,0.07,0.0,0.0,0.0,0.02,yi wu,ANTH-2010,2018
-ANTH,2010,3,Introduction to Anthropology,0.05,0.26,0.35,0.15,0.11,0.0,0.0,0.09,john coggeshall,ANTH-2010,2018
-ANTH,2010,4,Introduction to Anthropology,0.43,0.46,0.09,0.0,0.02,0.0,0.0,0.0,david markus,ANTH-2010,2018
-ANTH,2050,1,Professional Development,0.79,0.05,0.05,0.05,0.05,0.0,0.0,0.0,melissa vogel,ANTH-2050,2018
-ANTH,3200,1,North American Indian Cultures,0.21,0.42,0.17,0.17,0.04,0.0,0.0,0.0,john coggeshall,ANTH-3200,2018
-ANTH,3310,1,Archaeology,0.2,0.4,0.3,0.05,0.0,0.0,0.0,0.05,david markus,ANTH-3310,2018
-ANTH,3510,1,Biological Anthropology,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,lisa rapaport,ANTH-3510,2018
-ANTH,4040,1,Anthropological Theories,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,john coggeshall,ANTH-4040,2018
-ANTH,4990,1,Special Topics: Business Anth,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,melissa vogel,ANTH-4990,2018
-APEC,8220,1,Public Policy Econ,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david brian willis,APEC-8220,2018
-ARCH,1510,1,Arch Communication,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,sall hambright-belue,ARCH-1510,2018
-ARCH,1510,2,Arch Communication,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-1510,2018
-ARCH,1510,3,Arch Communication,0.36,0.43,0.07,0.07,0.0,0.0,0.0,0.07,clarissa mendez,ARCH-1510,2018
-ARCH,1510,4,Arch Communication,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-1510,2018
-ARCH,1510,5,Arch Communication,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,jared jeffrey moore,ARCH-1510,2018
-ARCH,1510,6,Arch Communication,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,herminia silv machry,ARCH-1510,2018
-ARCH,2520,1,Arch Foundations II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,timothy sutherland,ARCH-2520,2018
-ARCH,2520,2,Arch Foundations II,0.43,0.36,0.14,0.0,0.0,0.0,0.0,0.07,clarissa mendez,ARCH-2520,2018
-ARCH,2520,3,Arch Foundations II,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,criss mills,ARCH-2520,2018
-ARCH,2520,4,Arch Foundations II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-2520,2018
-ARCH,2520,5,Arch Foundations II,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-2520,2018
-ARCH,2520,6,Arch Foundations II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,catherine parn smith,ARCH-2520,2018
-ARCH,2710,1,Structures II,0.51,0.34,0.09,0.0,0.03,0.0,0.0,0.03,mahmoodreza soltani,ARCH-2710,2018
-ARCH,3530,1,Studio Genoa,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-3530,2018
-ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-3540,2018
-ARCH,4050,1,American Arch Styles 1650-1950,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-4050,2018
-ARCH,4140,1,Design Seminar,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-4140,2018
-ARCH,4160,1,Field Studies,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-4160,2018
-ARCH,4520,1,Synthesis Studio,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-4520,2018
-ARCH,4520,2,Synthesis Studio,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-4520,2018
-ARCH,4520,3,Synthesis Studio,0.07,0.73,0.2,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4520,2018
-ARCH,4520,4,Synthesis Studio,0.5,0.36,0.07,0.07,0.0,0.0,0.0,0.0,joseph schott,ARCH-4520,2018
-ARCH,4890,1,Internship,0.4,0.2,0.3,0.0,0.0,0.0,0.0,0.1,ashley jennings,ARCH-4890,2018
-ARCH,4990,1,Immersive Virtual Environments,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,david lee,ARCH-4990,2018
-ARCH,8110,1,Visualization II,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,douglas hecker,ARCH-8110,2018
-ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-8120,2018
-ARCH,8420,1,Arch Studio II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,ARCH-8420,2018
-ARCH,8610,1,History/Theory II,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8610,2018
-ARCH,8620,1,History/Theory III,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,ARCH-8620,2018
-ARCH,8650,1,Topics in Health Policy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anjali joseph,ARCH-8650,2018
-ARCH,8710,1,Structures II,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,dustin grah albright,ARCH-8710,2018
-ARCH,8730,2,Environmental Sys,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,ARCH-8730,2018
-ARCH,8740,1,Building Process:TR,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,ARCH-8740,2018
-ARCH,8900,1,Directed Studies,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,sara bayramzadeh,ARCH-8900,2018
-ARCH,8920,1,Comprehensive Studio,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8920,2018
-ARCH,8920,2,Comprehensive Studio,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dustin grah albright,ARCH-8920,2018
-ARCH,8920,3,Comprehensive Studio,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-sop heine,ARCH-8920,2018
-ARCH,8920,4,Comprehensive Studio,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8920,2018
-ARCH,8960,1,A+H Studio: Tectonic,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,ARCH-8960,2018
-ART,1060,1,Foundation Drawing II,0.52,0.38,0.05,0.0,0.0,0.0,0.0,0.05,carly drew,ART-1060,2018
-ART,1510,1,Foundations Art I,0.62,0.31,0.0,0.08,0.0,0.0,0.0,0.0,daniel bare,ART-1510,2018
-ART,1520,1,Foundations Art II,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,kooi susan el vander el,ART-1520,2018
-ART,2050,1,Beginning Life Drawing,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,ART-2050,2018
-ART,2070,1,Beginning Painting,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,dustin lee massey,ART-2070,2018
-ART,2100,400,Art Appreciation,0.76,0.14,0.0,0.0,0.0,0.0,0.0,0.1,lydia jane dorsey,ART-2100,2018
-ART,2100,401,Art Appreciation,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,lydia jane dorsey,ART-2100,2018
-ART,2100,402,Art Appreciation,0.68,0.14,0.14,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,ART-2100,2018
-ART,2100,403,Art Appreciation,0.54,0.21,0.11,0.04,0.0,0.0,0.0,0.11,lydia jane dorsey,ART-2100,2018
-ART,2110,1,Begin Printmaking,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,mandy lorai ferguson,ART-2110,2018
-ART,2130,1,Begin Photography,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,amanda denise musick,ART-2130,2018
-ART,2170,1,Beginning Ceramics,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,daniel bare,ART-2170,2018
-ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,ART-3570,2018
-AS,1100,1,Air Force Today II,0.29,0.59,0.0,0.06,0.06,0.0,0.0,0.0,michael allen moore,AS-1100,2018
-AS,1100,2,Air Force Today II,0.33,0.5,0.06,0.06,0.0,0.0,0.0,0.06,michael allen moore,AS-1100,2018
-AS,1100,3,Air Force Today II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1100,2018
-AS,2100,1,Dev of Air Power II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2100,2018
-AS,2100,2,Dev of Air Power II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2100,2018
-AS,2100,3,Dev of Air Power II,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2100,2018
-AS,3100,2,Af Ldrshp & Mgt II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mari miller,AS-3100,2018
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4100,2018
-AS,4100,2,Nat Sec Policy II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4100,2018
-ASL,1010,1,Am Sign Lang I,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,jason hurdich,ASL-1010,2018
-ASL,1010,2,Am Sign Lang I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william rya clements,ASL-1010,2018
-ASL,1010,3,Am Sign Lang I,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,william rya clements,ASL-1010,2018
-ASL,1020,1,Am Sign Lang I,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,dunn kim mar misener mar,ASL-1020,2018
-ASL,1020,2,Am Sign Lang I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,william rya clements,ASL-1020,2018
-ASL,1020,3,Am Sign Lang I,0.4,0.5,0.05,0.0,0.05,0.0,0.0,0.0,jason hurdich,ASL-1020,2018
-ASL,1020,4,Am Sign Lang I,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-1020,2018
-ASL,2020,1,Am Sign Lang II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,ASL-2020,2018
-ASL,2020,2,Am Sign Lang II,0.7,0.1,0.15,0.0,0.05,0.0,0.0,0.0,dunn kim mar misener mar,ASL-2020,2018
-ASL,2020,3,Am Sign Lang II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,ASL-2020,2018
-ASL,2020,4,Am Sign Lang II,0.52,0.19,0.29,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-2020,2018
-ASTR,1010,1,Solar System Astronomy,0.39,0.36,0.18,0.01,0.02,0.0,0.0,0.04,amber porter,ASTR-1010,2018
-ASTR,1020,1,Stellar Astronomy,0.29,0.38,0.26,0.0,0.02,0.0,0.0,0.05,amber porter,ASTR-1020,2018
-ASTR,1020,2,Stellar Astronomy,0.3,0.39,0.19,0.09,0.02,0.0,0.0,0.02,marco ajello,ASTR-1020,2018
-ASTR,1030,1,Solar Systm Astr Lab,0.29,0.38,0.13,0.0,0.13,0.0,0.0,0.08,amber porter,ASTR-1030,2018
-ASTR,1030,2,Solar Systm Astr Lab,0.4,0.44,0.08,0.04,0.04,0.0,0.0,0.0,amber porter,ASTR-1030,2018
-ASTR,1030,3,Solar Systm Astr Lab,0.24,0.44,0.16,0.0,0.08,0.0,0.0,0.08,amber porter,ASTR-1030,2018
-ASTR,1040,1,Stellar Astr Lab,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,amber porter,ASTR-1040,2018
-ASTR,1040,3,Stellar Astr Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,amber porter,ASTR-1040,2018
-ASTR,1040,4,Stellar Astr Lab,0.56,0.31,0.06,0.0,0.06,0.0,0.0,0.0,amber porter,ASTR-1040,2018
-ASTR,2200,1,Planetary Science,0.44,0.38,0.06,0.06,0.0,0.0,0.0,0.06,mate adamkovics,ASTR-2200,2018
-ASTR,8200,1,Astroph II: Stars,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,ASTR-8200,2018
-AUD,2850,1,Acoustics of Music,0.18,0.36,0.36,0.09,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-2850,2018
-AUD,3860,1,Electronic Comp,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,hamilton altstatt,AUD-3860,2018
-AUE,4020,699,Automobile Powertrain Systems,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-4020,2018
-AUE,8160,3,Eng Combustion Emiss,0.62,0.28,0.1,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8160,2018
-AUE,8170,3,Alt Energy Sources,0.21,0.69,0.1,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8170,2018
-AUE,8500,6,Stability/Safety Sys,0.32,0.65,0.03,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8500,2018
-AUE,8550,16,Struct/Thermal Analysis Mthds,0.17,0.78,0.06,0.0,0.0,0.0,0.0,0.0,david will schmueser,AUE-8550,2018
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.41,0.44,0.16,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8690,2018
-AUE,8820,10,Systems Integration Con & Meth,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8820,2018
-AUE,8860,1,Noise Vibration,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,AUE-8860,2018
-AUE,8930,3,Applied Dynamics,0.14,0.5,0.29,0.0,0.07,0.0,0.0,0.0,imtiaz ul haque,AUE-8930,2018
-AUE,8930,401,Autonomous Driving Techn,0.72,0.2,0.02,0.0,0.0,0.0,0.0,0.07,yunyi jia,AUE-8930,2018
-AUE,8930,699,Autovation 1,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,AUE-8930,2018
-AVS,2000,1,Beef Cattle Tech,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,nathan long,AVS-2000,2018
-AVS,2060,1,Swine Techniques,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,AVS-2060,2018
-AVS,2080,1,Teaching Horsemanshp,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,AVS-2080,2018
-AVS,3010,1,Anat & Phys Dom Ani,0.56,0.23,0.09,0.02,0.1,0.0,0.0,0.0,tiffany wilmoth,AVS-3010,2018
-AVS,3100,1,Animal Health,0.46,0.35,0.11,0.05,0.0,0.0,0.0,0.03,celina marce checura,AVS-3100,2018
-AVS,3150,1,Animal Welfare,0.48,0.32,0.04,0.08,0.08,0.0,0.0,0.0,peter skewes,AVS-3150,2018
-AVS,3700,1,Principles of Animal Nutrition,0.49,0.26,0.16,0.09,0.0,0.0,0.0,0.0,james rob strickland,AVS-3700,2018
-AVS,4000,1,AVS Professional Development,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,marie owens bolt,AVS-4000,2018
-AVS,4010,1,Beef Production,0.36,0.32,0.2,0.08,0.0,0.0,0.0,0.04,nathan long,AVS-4010,2018
-AVS,4060,2,Seminars & Related Topics,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-4060,2018
-AVS,4090,400,Animals & Humans In Society,0.77,0.2,0.0,0.03,0.0,0.0,0.0,0.0,marie owens bolt,AVS-4090,2018
-AVS,4100,1,Domestic Ani Behav,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,peter skewes,AVS-4100,2018
-AVS,4120,1,Advanced Equine Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kristine lang vernon,AVS-4120,2018
-AVS,4130,1,Animal Products,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,AVS-4130,2018
-AVS,4140,1,Basic Immunology,0.28,0.38,0.25,0.05,0.0,0.0,0.0,0.05,thomas scott,AVS-4140,2018
-AVS,4140,2,Basic Immunology,0.52,0.16,0.12,0.04,0.0,0.0,0.0,0.16,farzana ferdous,AVS-4140,2018
-AVS,4530,1,Animal Reproduction,0.4,0.3,0.15,0.11,0.0,0.0,0.0,0.04,celina marce checura,AVS-4530,2018
-AVS,4530,400,Animal Reproduction,0.09,0.27,0.55,0.09,0.0,0.0,0.0,0.0,celina marce checura,AVS-4530,2018
-AVS,4550,2,Animal Repro Mgt-Equine,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,AVS-4550,2018
-AVS,4700,1,Animal Genetics,0.26,0.15,0.17,0.22,0.07,0.0,0.0,0.13,joseph keit bertrand,AVS-4700,2018
-AVS,8090,1,Ruminant Nutrition,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,gustavo jose lascano,AVS-8090,2018
-BCHM,3010,1,Molecular Biochem,0.1,0.34,0.35,0.09,0.01,0.0,0.0,0.11,meredith teil morris,BCHM-3010,2018
-BCHM,3010,2,Molecular Biochem(HON),0.43,0.23,0.2,0.08,0.05,0.0,0.0,0.03,cheryl ingram-smith,BCHM-3010,2018
-BCHM,3040,1,Molecular Biology Laboratory,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,geoffrey ford,BCHM-3040,2018
-BCHM,3040,2,Molecular Biology Laboratory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2018
-BCHM,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2018
-BCHM,3040,4,Molecular Biology Laboratory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2018
-BCHM,3050,1,Essen Elements Bioch,0.06,0.41,0.32,0.05,0.0,0.0,0.0,0.16,debra ragland,BCHM-3050,2018
-BCHM,3050,2,Essen Elements Bioch,0.17,0.38,0.28,0.07,0.0,0.0,0.0,0.1,debra ragland,BCHM-3050,2018
-BCHM,3050,3,Essen Elements Bioch,0.24,0.41,0.23,0.08,0.04,0.0,0.0,0.0,geoffrey ford,BCHM-3050,2018
-BCHM,4320,1,Bioch of Metabolism,0.55,0.41,0.02,0.0,0.0,0.0,0.0,0.02,kimberly paul,BCHM-4320,2018
-BCHM,4340,1,Biochemistry of Metabolism Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,geoffrey ford,BCHM-4340,2018
-BCHM,4340,2,Biochemistry of Metabolism Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-4340,2018
-BCHM,4360,1,Genes to Proteins,0.34,0.64,0.02,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,BCHM-4360,2018
-BCHM,4400,1,Bioinformatics,0.22,0.28,0.28,0.11,0.0,0.0,0.0,0.11,liangjiang wang,BCHM-4400,2018
-BCHM,4930,1,Senior Seminar,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james morris,BCHM-4930,2018
-BCHM,8100,1,Princ of Molecular Biology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jennifer may mason,BCHM-8100,2018
-BE,2100,1,Intro to Biosystems Engr,0.57,0.32,0.0,0.04,0.0,0.0,0.0,0.07,yi zheng,BE-2100,2018
-BE,3100,1,Biosystems Engr Thermodynamics,0.25,0.5,0.2,0.0,0.0,0.0,0.0,0.05,terry walker,BE-3100,2018
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.19,0.76,0.05,0.0,0.0,0.0,0.0,0.0,tom owino,BE-3220,2018
-BE,4120,1,Be Heat Mass Trans,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4120,2018
-BE,4150,1,Instr & Control for Biosys Eng,0.19,0.57,0.24,0.0,0.0,0.0,0.0,0.0,yi zheng,BE-4150,2018
-BE,4240,1,Ecological Engineering,0.66,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christophe darnault,BE-4240,2018
-BE,4380,1,Bioprocess Engineering Design,0.09,0.55,0.36,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4380,2018
-BIOE,1010,1,Biol for Bioengr,0.35,0.45,0.09,0.0,0.0,0.0,0.0,0.11,vladimir vlad reukov,BIOE-1010,2018
-BIOE,2000,1,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,martine laberge,BIOE-2000,2018
-BIOE,2010,1,Intro Biomed Engr,0.32,0.36,0.24,0.04,0.0,0.0,0.0,0.04,vladimir vlad reukov,BIOE-2010,2018
-BIOE,3020,1,Biomaterials,0.6,0.32,0.04,0.01,0.01,0.0,0.0,0.01,alexey alex vertegel,BIOE-3020,2018
-BIOE,3100,1,Engr Analysis of Physiol Proc,0.67,0.26,0.03,0.0,0.03,0.0,0.0,0.03,brian william booth,BIOE-3100,2018
-BIOE,3200,1,Biomechanics,0.73,0.23,0.02,0.0,0.02,0.0,0.0,0.0,jiro nagatomi,BIOE-3200,2018
-BIOE,3210,1,Biofluid Mechanics,0.33,0.37,0.27,0.01,0.01,0.0,0.0,0.0,sarah harcum,BIOE-3210,2018
-BIOE,3470,1,Transport Processes in Bioengr,0.39,0.43,0.13,0.0,0.0,0.0,0.0,0.04,robert latour,BIOE-3470,2018
-BIOE,3700,1,Bioinst & Imaging,0.45,0.52,0.02,0.0,0.0,0.0,0.0,0.02,jordon antho gilmore,BIOE-3700,2018
-BIOE,4200,1,Sports Engineering,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,cynthia miller smith,BIOE-4200,2018
-BIOE,4350,1,Modeling of Multiphysics Prob,0.38,0.38,0.08,0.0,0.08,0.0,0.0,0.08,william richardson,BIOE-4350,2018
-BIOE,4490,1,Drug Delivery,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,BIOE-4490,2018
-BIOE,4510,39,CI-Inorganic Biomaterials,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vladimir vlad reukov,BIOE-4510,2018
-BIOE,6200,1,Sports Engineering,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,cynthia miller smith,BIOE-6200,2018
-BIOE,6350,1,Modeling of Multiphysics Prob,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,BIOE-6350,2018
-BIOE,8030,1,Polymeric Biomatls,0.22,0.44,0.0,0.0,0.0,0.0,0.0,0.33,narendra vyavahare,BIOE-8030,2018
-BIOL,1040,1,General Biology II,0.19,0.3,0.23,0.09,0.08,0.0,0.0,0.11,nora espinoza,BIOL-1040,2018
-BIOL,1040,2,General Biology II,0.53,0.31,0.1,0.04,0.01,0.0,0.0,0.01,william surver,BIOL-1040,2018
-BIOL,1040,3,General Biology II,0.14,0.24,0.39,0.15,0.05,0.0,0.0,0.02,salvatore sparace,BIOL-1040,2018
-BIOL,1040,4,General Biology II (HON),0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,BIOL-1040,2018
-BIOL,1060,1,Gen Biology Lab II,0.42,0.38,0.13,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,2,Gen Biology Lab II,0.48,0.22,0.13,0.13,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,3,Gen Biology Lab II,0.42,0.17,0.33,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,4,Gen Biology Lab II,0.18,0.14,0.27,0.18,0.09,0.0,0.0,0.14,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,5,Gen Biology Lab II,0.21,0.07,0.14,0.29,0.29,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,6,Gen Biology Lab II,0.29,0.29,0.29,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,7,Gen Biology Lab II,0.19,0.31,0.25,0.13,0.06,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,8,Gen Biology Lab II,0.54,0.25,0.13,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,9,Gen Biology Lab II,0.52,0.22,0.09,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,10,Gen Biology Lab II,0.48,0.22,0.22,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,11,Gen Biology Lab II,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,12,Gen Biology Lab II,0.5,0.25,0.21,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,13,Gen Biology Lab II,0.54,0.13,0.21,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,14,Gen Biology Lab II,0.5,0.18,0.23,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,15,Gen Biology Lab II,0.17,0.43,0.17,0.13,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,16,Gen Biology Lab II,0.41,0.18,0.27,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,18,Gen Biology Lab II,0.21,0.36,0.29,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,19,Gen Biology Lab II,0.08,0.38,0.31,0.23,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,20,Gen Biology Lab II,0.38,0.29,0.25,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,21,Gen Biology Lab II,0.29,0.38,0.25,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,22,Gen Biology Lab II,0.53,0.2,0.13,0.0,0.07,0.0,0.0,0.07,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,24,Gen Biology Lab II,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,26,Gen Biology Lab II,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,27,Gen Biology Lab II,0.5,0.25,0.04,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,29,Gen Biology Lab II,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,30,Gen Biology Lab II,0.59,0.23,0.09,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,31,Gen Biology Lab II,0.36,0.36,0.07,0.14,0.0,0.0,0.0,0.07,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,32,Gen Biology Lab II,0.55,0.15,0.1,0.15,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,33,Gen Biology Lab II,0.57,0.21,0.14,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,35,Gen Biology Lab II,0.38,0.31,0.25,0.06,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1060,36,Gen Biology Lab II,0.4,0.2,0.2,0.2,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2018
-BIOL,1110,1,Principles of Biology II,0.21,0.43,0.16,0.08,0.05,0.0,0.0,0.07,dylan dittrich-reed,BIOL-1110,2018
-BIOL,1110,3,Principles of Biology II,0.36,0.47,0.11,0.02,0.01,0.0,0.0,0.02,robert kosinski,BIOL-1110,2018
-BIOL,1110,4,Prin of Biol II  (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert kosinski,BIOL-1110,2018
-BIOL,1200,1,Biological Inq Lab,0.25,0.45,0.15,0.05,0.0,0.0,0.0,0.1, christine minor m,BIOL-1200,2018
-BIOL,1200,2,Biological Inq Lab,0.3,0.45,0.15,0.1,0.0,0.0,0.0,0.0, christine minor m,BIOL-1200,2018
-BIOL,1200,3,Biological Inq Lab,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05, christine minor m,BIOL-1200,2018
-BIOL,1200,4,Biological Inq Lab,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,BIOL-1200,2018
-BIOL,1200,5,Biological Inq Lab,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05, christine minor m,BIOL-1200,2018
-BIOL,1200,6,Biological Inq Lab,0.55,0.2,0.2,0.0,0.05,0.0,0.0,0.0, christine minor m,BIOL-1200,2018
-BIOL,1230,1,Keys to Human Biol,0.16,0.38,0.25,0.12,0.04,0.0,0.0,0.04, christine minor m,BIOL-1230,2018
-BIOL,2000,1,Biology in the News,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,BIOL-2000,2018
-BIOL,2040,1,"Environ, Energy and Society",0.36,0.34,0.13,0.06,0.02,0.0,0.0,0.09,john jenkins hains,BIOL-2040,2018
-BIOL,2040,2,"Environ, Energy and Society",0.47,0.31,0.08,0.1,0.0,0.0,0.0,0.04,john jenkins hains,BIOL-2040,2018
-BIOL,2230,1,Human Anat and Physiology II,0.42,0.37,0.13,0.04,0.03,0.0,0.0,0.01,john cummings,BIOL-2230,2018
-BIOL,2230,2,Human Anat and Physiology II,0.36,0.38,0.19,0.05,0.0,0.0,0.0,0.02,john cummings,BIOL-2230,2018
-BIOL,3020,1,Invertebrate Biology,0.31,0.33,0.18,0.03,0.05,0.0,0.0,0.1,migueles juan baeza,BIOL-3020,2018
-BIOL,3040,1,Biology of Plants,0.15,0.33,0.28,0.15,0.05,0.0,0.0,0.03,robert edwar ballard,BIOL-3040,2018
-BIOL,3060,1,Invertebrate Biology Lab,0.39,0.35,0.13,0.0,0.0,0.0,0.0,0.13,migueles juan baeza,BIOL-3060,2018
-BIOL,3060,3,Invertebrate Biology Lab,0.47,0.41,0.06,0.0,0.06,0.0,0.0,0.0,migueles juan baeza,BIOL-3060,2018
-BIOL,3080,2,Biology of Plants Practicum,0.4,0.3,0.2,0.05,0.0,0.0,0.0,0.05,nathan redding,BIOL-3080,2018
-BIOL,3080,3,Biology of Plants Practicum,0.44,0.39,0.06,0.11,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2018
-BIOL,3160,1,Human Physiology,0.3,0.43,0.22,0.04,0.0,0.0,0.0,0.0,tamara mcnutt-scott,BIOL-3160,2018
-BIOL,3350,1,Evolutionary Biology,0.44,0.39,0.13,0.03,0.0,0.0,0.0,0.01,margaret ptacek,BIOL-3350,2018
-BIOL,3510,1,Biological Anthropology,0.58,0.25,0.08,0.04,0.04,0.0,0.0,0.0,lisa rapaport,BIOL-3510,2018
-BIOL,4010,1,Plant Physiology,0.2,0.22,0.22,0.25,0.03,0.0,0.0,0.07,douglas bielenberg,BIOL-4010,2018
-BIOL,4020,1,Plant Physiology Lab,0.24,0.59,0.12,0.0,0.0,0.0,0.0,0.06,douglas bielenberg,BIOL-4020,2018
-BIOL,4020,2,Plant Physiology Lab,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,BIOL-4020,2018
-BIOL,4100,1,Limnology,0.18,0.45,0.27,0.0,0.0,0.0,0.0,0.11,john jenkins hains,BIOL-4100,2018
-BIOL,4140,1,Basic Immunology,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,charles rice,BIOL-4140,2018
-BIOL,4340,1,Biological Chem Lab Techniques,0.21,0.21,0.21,0.29,0.0,0.0,0.0,0.07,salvatore sparace,BIOL-4340,2018
-BIOL,4340,2,Biological Chem Lab Techniques,0.19,0.31,0.25,0.19,0.06,0.0,0.0,0.0,salvatore sparace,BIOL-4340,2018
-BIOL,4400,1,Developmental Animal Biology,0.42,0.28,0.23,0.07,0.0,0.0,0.0,0.0,kara elizabet powder,BIOL-4400,2018
-BIOL,4480,1,Marine Ecology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,BIOL-4480,2018
-BIOL,4510,1,Biol Variation in Human Pop,0.4,0.2,0.1,0.1,0.1,0.0,0.0,0.1,elizabeth wakefield,BIOL-4510,2018
-BIOL,4610,3,Cell Biology,0.2,0.32,0.25,0.15,0.04,0.0,0.0,0.03,lisa bain,BIOL-4610,2018
-BIOL,4610,4,Cell Biology (HON),0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,lisa bain,BIOL-4610,2018
-BIOL,4620,1,Cell Biology Lab (Lec),0.81,0.11,0.0,0.04,0.0,0.0,0.0,0.04,xianzhong yu,BIOL-4620,2018
-BIOL,4620,2,Cell Biology Lab (Lec),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2018
-BIOL,4620,5,Cell Biology Lab (Lec),0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2018
-BIOL,4620,6,Cell Biology Lab (Lec),0.74,0.15,0.07,0.0,0.0,0.0,0.0,0.04,xianzhong yu,BIOL-4620,2018
-BIOL,4620,8,Cell Biology Lab (Lec),0.85,0.12,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2018
-BIOL,4640,1,Mammalogy,0.63,0.15,0.07,0.11,0.0,0.0,0.0,0.04,john cummings,BIOL-4640,2018
-BIOL,4670,1,Principles of Hematology,0.86,0.08,0.06,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,BIOL-4670,2018
-BIOL,4700,1,Behavioral Ecology,0.27,0.44,0.18,0.06,0.03,0.0,0.0,0.02,lisa rapaport,BIOL-4700,2018
-BIOL,4700,2,Behavioral Ecology (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lisa rapaport,BIOL-4700,2018
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lisa rapaport,BIOL-4710,2018
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,lisa rapaport,BIOL-4710,2018
-BIOL,4930,3,Sr Sem: Advances in Cancer,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,BIOL-4930,2018
-BIOL,4930,4,Sr Sem: Immuno & Immunothearpy,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,yanzhang wei,BIOL-4930,2018
-BIOL,4930,5,Sr Sem: Nervous Systems,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4930,2018
-BIOL,4930,8,Sr Sem: Defining Sex,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tamara mcnutt-scott,BIOL-4930,2018
-BIOL,8430,1,Underst Genetics & Evol Biol,0.82,0.17,0.01,0.0,0.0,0.0,0.0,0.0,renea chris hardwick,BIOL-8430,2018
-BIOL,8450,1,Understanding Animal Biology,0.9,0.09,0.01,0.0,0.0,0.0,0.0,0.0,matthew turnbull,BIOL-8450,2018
-BIOL,8470,1,Understanding Microbiology,0.57,0.37,0.04,0.0,0.02,0.0,0.0,0.0,harry kurtz,BIOL-8470,2018
-BMOL,4250,1,Biomolecular Engineering,0.22,0.35,0.13,0.17,0.0,0.0,0.0,0.13,mark alan blenner,BMOL-4250,2018
-BMOL,4290,1,Bioprocess Engineering,0.27,0.15,0.54,0.0,0.04,0.0,0.0,0.0,marc russ birtwistle,BMOL-4290,2018
-BUS,1010,1,Business Foundations,0.25,0.5,0.13,0.04,0.08,0.0,0.0,0.0,donna mccubbin,BUS-1010,2018
-BUS,1010,2,Business Foundations,0.28,0.32,0.2,0.08,0.08,0.0,0.0,0.04,donna mccubbin,BUS-1010,2018
-BUS,1010,3,Business Foundations,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2018
-BUS,1010,4,Business Foundations,0.21,0.43,0.29,0.0,0.04,0.0,0.0,0.04,william erne tumblin,BUS-1010,2018
-BUS,1010,5,Business Foundations,0.33,0.41,0.0,0.07,0.07,0.0,0.0,0.11,william erne tumblin,BUS-1010,2018
-BUS,1010,6,Business Foundations,0.4,0.36,0.08,0.08,0.04,0.0,0.0,0.04,william erne tumblin,BUS-1010,2018
-BUS,1010,7,Business Foundations,0.33,0.37,0.2,0.03,0.03,0.0,0.0,0.03,donna mccubbin,BUS-1010,2018
-BUS,1010,8,Business Foundations,0.33,0.43,0.13,0.07,0.0,0.0,0.0,0.03,donna mccubbin,BUS-1010,2018
-BUS,1010,9,Business Foundations,0.42,0.23,0.31,0.0,0.0,0.0,0.0,0.04,william erne tumblin,BUS-1010,2018
-BUS,1010,10,Business Foundations,0.58,0.23,0.08,0.04,0.04,0.0,0.0,0.04,william erne tumblin,BUS-1010,2018
-CE,2010,1,Statics,0.36,0.29,0.16,0.05,0.04,0.0,0.0,0.09,barnabas bwambale,CE-2010,2018
-CE,2010,2,Statics,0.08,0.35,0.3,0.18,0.08,0.0,0.0,0.03,melissa sternhagen,CE-2010,2018
-CE,2010,3,Statics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,sreeganesh red yerri,CE-2010,2018
-CE,2010,4,Statics,0.05,0.2,0.24,0.12,0.15,0.0,0.0,0.24,melissa sternhagen,CE-2010,2018
-CE,2010,5,Statics,0.2,0.32,0.28,0.1,0.01,0.0,0.0,0.09, kent nilsson,CE-2010,2018
-CE,2010,6,Statics,0.33,0.27,0.29,0.07,0.04,0.0,0.0,0.0,shweta shrestha,CE-2010,2018
-CE,2060,1,Structural Mechanics,0.39,0.41,0.15,0.02,0.02,0.0,0.0,0.0,mahmoodreza soltani,CE-2060,2018
-CE,2060,2,Structural Mechanics,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,mahmoodreza soltani,CE-2060,2018
-CE,2080,1,Dynamics,0.05,0.43,0.27,0.17,0.05,0.0,0.0,0.03,melissa sternhagen,CE-2080,2018
-CE,2080,2,Dynamics,0.06,0.42,0.36,0.03,0.08,0.0,0.0,0.05,melissa sternhagen,CE-2080,2018
-CE,2550,1,Geomatics,0.27,0.42,0.27,0.01,0.03,0.0,0.0,0.0,wayne sarasua,CE-2550,2018
-CE,3010,1,Structural Analysis,0.28,0.33,0.2,0.13,0.04,0.0,0.0,0.02,stephen csernak,CE-3010,2018
-CE,3110,1,Transportation Engr,0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,pamela murray-tuite,CE-3110,2018
-CE,3210,1,Geotechnical Engineering,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,CE-3210,2018
-CE,3210,2,Geotechnical Engineering,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,CE-3210,2018
-CE,3310,1,Constr Engr & Mgmnt,0.31,0.52,0.07,0.09,0.0,0.0,0.0,0.0,james burati,CE-3310,2018
-CE,3410,1,Intro to Fluid Mech,0.28,0.51,0.16,0.03,0.01,0.0,0.0,0.0,nigel gregory kaye,CE-3410,2018
-CE,3420,1,Hydraulics & Hydro,0.49,0.37,0.11,0.03,0.0,0.0,0.0,0.0,ashok mishra,CE-3420,2018
-CE,3420,2,Hydraulics & Hydro,0.52,0.33,0.07,0.0,0.0,0.0,0.0,0.07,abdul khan,CE-3420,2018
-CE,3510,1,Civil Engineering Materials,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,prasada ra rangaraju,CE-3510,2018
-CE,3520,1,Econ Eval of Proj,0.53,0.33,0.15,0.0,0.0,0.0,0.0,0.0,james burati,CE-3520,2018
-CE,3520,2,Econ Eval of Proj,0.45,0.49,0.05,0.0,0.0,0.0,0.0,0.01,zoraya roldan rockow,CE-3520,2018
-CE,3530,1,Professional Seminar,0.95,0.01,0.04,0.0,0.0,0.0,0.0,0.01,thomas edfor cousins,CE-3530,2018
-CE,4020,1,Reinfor Con Design,0.26,0.3,0.28,0.07,0.02,0.0,0.0,0.07,thomas edfor cousins,CE-4020,2018
-CE,4070,1,Wood Design,0.62,0.24,0.14,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-4070,2018
-CE,4080,1,Struct Loads & Sys,0.38,0.46,0.08,0.0,0.08,0.0,0.0,0.0,bryant nielson,CE-4080,2018
-CE,4110,1,Roadway Geo Design,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jennifer ogle,CE-4110,2018
-CE,4120,1,Urban Transport Plan,0.23,0.69,0.0,0.0,0.0,0.0,0.0,0.08,eric morris,CE-4120,2018
-CE,4210,1,Geotechnical Design,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,nadaraj ravichandran,CE-4210,2018
-CE,4340,1,Const Est Proj Cont,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4340,2018
-CE,4470,1,Stormwater Managemnt,0.25,0.25,0.35,0.1,0.0,0.0,0.0,0.05,md nasimul chowdhury,CE-4470,2018
-CE,4590,1,Capstone Design Proj,0.49,0.46,0.04,0.0,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2018
-CE,4620,1,Coastal Engr I,0.19,0.41,0.26,0.11,0.04,0.0,0.0,0.0,earl hayter,CE-4620,2018
-CE,4910,1,Meth & Mgmt of Com & Ind Const,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,steve richar sanders,CE-4910,2018
-CE,6120,1,Urban Transport Plan,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,CE-6120,2018
-CE,8030,1,Adv Steel Design,0.5,0.38,0.08,0.0,0.04,0.0,0.0,0.0,clinton owen rex,CE-8030,2018
-CE,8040,1,Prestressed Concrete,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,brandon ross,CE-8040,2018
-CE,8470,500,Optimization Support Models,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,CE-8470,2018
-CE,8570,500,Uncertainty Modeling Risk Engr,0.78,0.13,0.0,0.0,0.0,0.0,0.0,0.09,elnaz peyghaleh,CE-8570,2018
-CE,8600,1,Adv Fluid Mech,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,abdul khan,CE-8600,2018
-CH,1010,1,General Chemistry,0.14,0.3,0.32,0.1,0.07,0.0,0.0,0.08,princess mycia cox,CH-1010,2018
-CH,1010,2,General Chemistry,0.07,0.28,0.36,0.14,0.06,0.0,0.0,0.08,princess mycia cox,CH-1010,2018
-CH,1010,3,General Chemistry,0.18,0.38,0.28,0.05,0.06,0.0,0.0,0.05,laura lanni,CH-1010,2018
-CH,1010,4,General Chemistry,0.17,0.33,0.27,0.11,0.06,0.0,0.0,0.07,william we mcwhorter,CH-1010,2018
-CH,1010,400,General Chemistry,0.32,0.23,0.13,0.15,0.02,0.0,0.0,0.15,stephen schvaneveldt,CH-1010,2018
-CH,1020,1,General Chemistry,0.26,0.31,0.26,0.1,0.02,0.0,0.0,0.05,thomas hickman,CH-1020,2018
-CH,1020,2,General Chemistry,0.42,0.36,0.17,0.03,0.01,0.0,0.0,0.02,tania issa houjeiry,CH-1020,2018
-CH,1020,3,General Chemistry,0.38,0.37,0.11,0.06,0.02,0.0,0.0,0.08,dennis taylor,CH-1020,2018
-CH,1020,4,General Chemistry,0.27,0.44,0.19,0.05,0.02,0.0,0.0,0.03,dennis taylor,CH-1020,2018
-CH,1020,5,General Chemistry,0.18,0.39,0.22,0.1,0.03,0.0,0.0,0.09,william we mcwhorter,CH-1020,2018
-CH,1020,6,General Chemistry,0.09,0.43,0.26,0.08,0.08,0.0,0.0,0.07,william we mcwhorter,CH-1020,2018
-CH,1020,7,General Chemistry,0.2,0.42,0.25,0.08,0.0,0.0,0.0,0.03,olt geiculescu,CH-1020,2018
-CH,1020,8,General Chemistry,0.22,0.44,0.2,0.07,0.02,0.0,0.0,0.05,thomas hickman,CH-1020,2018
-CH,1020,9,General Chemistry,0.3,0.41,0.18,0.04,0.03,0.0,0.0,0.05,elliot ennis,CH-1020,2018
-CH,1020,10,General Chemistry,0.23,0.34,0.25,0.07,0.02,0.0,0.0,0.09,jacob schroeder,CH-1020,2018
-CH,1020,11,General Chemistry,0.28,0.44,0.19,0.02,0.0,0.0,0.0,0.07,dennis taylor,CH-1020,2018
-CH,1020,50,General Chemistry,0.36,0.27,0.18,0.18,0.0,0.0,0.0,0.0,shiou-jyh hwu,CH-1020,2018
-CH,1020,51,General Chemistry (HON),0.68,0.26,0.04,0.0,0.0,0.0,0.0,0.02,stephen schvaneveldt,CH-1020,2018
-CH,1020,52,General Chemistry (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,stephen schvaneveldt,CH-1020,2018
-CH,1020,500,General Chemistry,0.14,0.39,0.29,0.18,0.0,0.0,0.0,0.0,brian gloor,CH-1020,2018
-CH,1050,1,Chemistry in Context I,0.54,0.37,0.09,0.0,0.0,0.0,0.0,0.0,olt geiculescu,CH-1050,2018
-CH,1050,2,Chemistry in Context I,0.35,0.38,0.19,0.0,0.04,0.0,0.0,0.04,olt geiculescu,CH-1050,2018
-CH,1060,1,Chemistry in Context II,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,thomas hickman,CH-1060,2018
-CH,1520,1,Chemistry Communication,0.67,0.23,0.02,0.0,0.02,0.0,0.0,0.05,richard marcus,CH-1520,2018
-CH,2010,1,Survey of Organic Chemistry,0.4,0.34,0.13,0.07,0.05,0.0,0.0,0.02,tania issa houjeiry,CH-2010,2018
-CH,2020,1,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2020,2018
-CH,2020,2,Surv of Organic Chemistry Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,james nelson plampin,CH-2020,2018
-CH,2020,3,Surv of Organic Chemistry Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2020,2018
-CH,2020,4,Surv of Organic Chemistry Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,CH-2020,2018
-CH,2050,1,Intro Inorg Chem,0.36,0.43,0.14,0.04,0.0,0.0,0.0,0.04,william pennington,CH-2050,2018
-CH,2230,1,Organic Chemistry,0.19,0.34,0.16,0.19,0.09,0.0,0.0,0.03,jacob schroeder,CH-2230,2018
-CH,2230,2,Organic Chemistry,0.28,0.38,0.18,0.08,0.04,0.0,0.0,0.05,jacob schroeder,CH-2230,2018
-CH,2230,3,Organic Chemistry,0.69,0.22,0.01,0.01,0.04,0.0,0.0,0.04,sourav saha,CH-2230,2018
-CH,2240,1,Organic Chemistry,0.21,0.21,0.21,0.14,0.08,0.0,0.0,0.16,laura lanni,CH-2240,2018
-CH,2240,2,Organic Chemistry,0.38,0.33,0.14,0.09,0.02,0.0,0.0,0.03,elliot ennis,CH-2240,2018
-CH,2240,3,Organic Chemistry,0.29,0.24,0.16,0.11,0.08,0.0,0.0,0.12,laura lanni,CH-2240,2018
-CH,2240,4,Organic Chemistry,0.35,0.29,0.21,0.03,0.04,0.0,0.0,0.08,rhett smith,CH-2240,2018
-CH,2240,5,Organic Chemistry,0.28,0.33,0.28,0.06,0.02,0.0,0.0,0.03,elliot ennis,CH-2240,2018
-CH,2270,1,Organic Chem Lab,0.56,0.19,0.0,0.0,0.0,0.0,0.0,0.25,james nelson plampin,CH-2270,2018
-CH,2270,2,Organic Chem Lab,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,james nelson plampin,CH-2270,2018
-CH,2270,3,Organic Chem Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2270,2018
-CH,2270,4,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2270,2018
-CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2270,2018
-CH,2270,7,Organic Chem Lab,0.89,0.0,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2270,2018
-CH,2270,8,Organic Chem Lab,0.67,0.17,0.06,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2018
-CH,2270,12,Organic Chem Lab,0.69,0.13,0.06,0.0,0.06,0.0,0.0,0.06,james nelson plampin,CH-2270,2018
-CH,2270,13,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,CH-2270,2018
-CH,2270,16,Organic Chem Lab,0.63,0.13,0.06,0.0,0.0,0.0,0.0,0.19,james nelson plampin,CH-2270,2018
-CH,2280,3,Organic Chem Lab,0.88,0.0,0.06,0.0,0.06,0.0,0.0,0.0,james nelson plampin,CH-2280,2018
-CH,2280,6,Organic Chem Lab,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,CH-2280,2018
-CH,2280,7,Organic Chem Lab,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2280,2018
-CH,2280,8,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,CH-2280,2018
-CH,2280,9,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,CH-2280,2018
-CH,2280,10,Organic Chem Lab,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,james nelson plampin,CH-2280,2018
-CH,2280,11,Organic Chem Lab,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,CH-2280,2018
-CH,2280,14,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,CH-2280,2018
-CH,2280,17,Organic Chem Lab,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2280,2018
-CH,2280,19,Organic Chem Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,james nelson plampin,CH-2280,2018
-CH,2280,20,Organic Chem Lab,0.73,0.07,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,CH-2280,2018
-CH,2280,22,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,CH-2280,2018
-CH,2280,24,Organic Chem Lab,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,CH-2280,2018
-CH,2280,25,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,CH-2280,2018
-CH,2280,27,Organic Chem Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,james nelson plampin,CH-2280,2018
-CH,2280,28,Organic Chem Lab,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,CH-2280,2018
-CH,2290,2,Organic Chem Lab,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2290,2018
-CH,2290,3,Organic Chem Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,james nelson plampin,CH-2290,2018
-CH,2290,4,Organic Chem Lab,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2290,2018
-CH,3310,1,Physical Chemistry,0.4,0.3,0.0,0.0,0.1,0.0,0.0,0.2,arkady kholodenko,CH-3310,2018
-CH,3320,1,Physical Chemistry,0.17,0.42,0.33,0.0,0.08,0.0,0.0,0.0,steven stuart,CH-3320,2018
-CH,3320,3,Physical Chemistry,0.88,0.11,0.02,0.0,0.0,0.0,0.0,0.0,jason mcneill,CH-3320,2018
-CH,3320,4,Physical Chemistry,0.41,0.26,0.09,0.06,0.15,0.0,0.0,0.03,leah beck casabianca,CH-3320,2018
-CH,3400,1,Physical Chem Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,princess mycia cox,CH-3400,2018
-CH,3400,2,Physical Chem Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2018
-CH,3400,4,Physical Chem Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2018
-CH,3400,6,Physical Chem Lab,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2018
-CH,3600,1,Chemical Biology,0.39,0.42,0.16,0.03,0.0,0.0,0.0,0.0,modi wetzler,CH-3600,2018
-CH,4110,1,Instrumental Analy,0.12,0.19,0.38,0.12,0.19,0.0,0.0,0.0,george chumanov,CH-4110,2018
-CH,4120,1,Instr Analysis Lab,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey nathan anker,CH-4120,2018
-CH,4130,1,Chemistry of Aqueous Systems,0.59,0.22,0.09,0.0,0.0,0.0,0.0,0.09,cindy lee,CH-4130,2018
-CH,4500,1,Chemistry Capstone,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,CH-4500,2018
-CH,6140,1,Bioanalytical Chem,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,perez carlos garcia,CH-6140,2018
-CH,8080,1,Chem Non-Metal Elem,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,CH-8080,2018
-CH,8180,1,Surface Analysis,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,stephen creager,CH-8180,2018
-CH,8220,1,Organic Chem II,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,daniel whitehead,CH-8220,2018
-CH,8510,1,Grad Student Seminar,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,CH-8510,2018
-CHE,1300,1,Intro to Chemical Engineering,0.27,0.25,0.27,0.04,0.04,0.0,0.0,0.14,christopher norfolk,CHE-1300,2018
-CHE,1300,2,Intro to Chemical Engineering,0.17,0.25,0.15,0.06,0.12,0.0,0.0,0.25,christopher norfolk,CHE-1300,2018
-CHE,2200,1,Ch E Thermo I,0.24,0.24,0.24,0.19,0.05,0.0,0.0,0.05,joseph scott,CHE-2200,2018
-CHE,2200,2,Ch E Thermo I,0.15,0.35,0.31,0.08,0.05,0.0,0.0,0.06,jessica marie kelly,CHE-2200,2018
-CHE,2300,1,Fluids/Heat Transfer,0.1,0.21,0.26,0.26,0.13,0.0,0.0,0.05,eric mikel davis,CHE-2300,2018
-CHE,2300,2,Fluids/Heat Transfer,0.15,0.37,0.22,0.15,0.04,0.0,0.0,0.07,eric mikel davis,CHE-2300,2018
-CHE,3070,1,Unit Ops Lab I,0.21,0.52,0.25,0.0,0.0,0.0,0.0,0.02,mark thies,CHE-3070,2018
-CHE,3190,1,Engr Materials,0.17,0.29,0.3,0.16,0.06,0.0,0.0,0.02,amod ogale,CHE-3190,2018
-CHE,3530,2,Proc Dyn & Control,0.41,0.26,0.26,0.04,0.01,0.0,0.0,0.01,mark roberts,CHE-3530,2018
-CHE,4330,1,Process Design II,0.44,0.45,0.11,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4330,2018
-CHE,8450,3,Multiscale Modeling,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,sapna sarupria,CHE-8450,2018
-CHIN,1020,1,Elementary Chinese,0.6,0.1,0.2,0.1,0.0,0.0,0.0,0.0,ling rao,CHIN-1020,2018
-CHIN,2020,1,Intermediate Chinese,0.47,0.18,0.24,0.12,0.0,0.0,0.0,0.0,ling rao,CHIN-2020,2018
-CHIN,3120,1,Philosophy in Ancient China,0.33,0.27,0.13,0.0,0.07,0.0,0.0,0.2,yanming an,CHIN-3120,2018
-CHIN,4010,1,Pre-Modern Chinese Literature,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,yanming an,CHIN-4010,2018
-COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.93,0.04,0.04,lori marlise pindar,COM-1010,2018
-COM,1500,1,Intro to Human Communication,0.88,0.11,0.0,0.0,0.01,0.0,0.0,0.0,eddie smith,COM-1500,2018
-COM,1500,2,Intro to Human Communication,0.58,0.33,0.03,0.02,0.02,0.0,0.0,0.02,daniel leland fecher,COM-1500,2018
-COM,1500,3,Intro to Human Communication,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,eddie smith,COM-1500,2018
-COM,1500,4,Intro to Human Communication,0.79,0.19,0.02,0.0,0.0,0.0,0.0,0.0,marianne herr glaser,COM-1500,2018
-COM,1500,5,Intro to Human Communication,0.66,0.27,0.01,0.02,0.01,0.0,0.0,0.02,marianne herr glaser,COM-1500,2018
-COM,1500,6,Intro to Human Communication,0.37,0.55,0.04,0.03,0.01,0.0,0.0,0.0,daniel leland fecher,COM-1500,2018
-COM,2010,1,Intr to Comm Studies,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,COM-2010,2018
-COM,2010,2,Intr to Comm Studies,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,COM-2010,2018
-COM,2020,1,Communication Theory,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-2020,2018
-COM,2030,1,Mass Communication Theory,0.47,0.43,0.03,0.07,0.0,0.0,0.0,0.0,erin michelle ash,COM-2030,2018
-COM,2100,1,Quant Comm Research Methods,0.3,0.52,0.19,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,COM-2100,2018
-COM,2500,1,Public Speaking,0.62,0.33,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christi davis,COM-2500,2018
-COM,2500,2,Public Speaking,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,COM-2500,2018
-COM,2500,3,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christi davis,COM-2500,2018
-COM,2500,7,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christi davis,COM-2500,2018
-COM,2500,8,Public Speaking,0.43,0.24,0.14,0.0,0.05,0.0,0.0,0.14,pauline matthey,COM-2500,2018
-COM,2500,9,Public Speaking,0.7,0.1,0.05,0.0,0.05,0.0,0.0,0.1,vanessa anne condon,COM-2500,2018
-COM,2500,10,Public Speaking,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2018
-COM,2500,11,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2018
-COM,2500,12,Public Speaking,0.4,0.4,0.1,0.0,0.0,0.0,0.0,0.1,pauline matthey,COM-2500,2018
-COM,2500,13,Public Speaking,0.63,0.21,0.05,0.0,0.11,0.0,0.0,0.0,amanda elizabe moore,COM-2500,2018
-COM,2500,14,Public Speaking,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,amanda elizabe moore,COM-2500,2018
-COM,2500,15,Public Speaking,0.9,0.0,0.0,0.0,0.1,0.0,0.0,0.0,caitlin baker,COM-2500,2018
-COM,2500,16,Public Speaking,0.8,0.05,0.05,0.05,0.05,0.0,0.0,0.0,amanda elizabe moore,COM-2500,2018
-COM,2500,18,Public Speaking,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,COM-2500,2018
-COM,2500,19,Public Speaking,0.67,0.24,0.0,0.05,0.05,0.0,0.0,0.0,jumah patricia taweh,COM-2500,2018
-COM,2500,20,Public Speaking,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2018
-COM,2500,21,Public Speaking,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,COM-2500,2018
-COM,2500,22,Public Speaking,0.45,0.45,0.05,0.05,0.0,0.0,0.0,0.0,amanda elizabe moore,COM-2500,2018
-COM,2500,23,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,COM-2500,2018
-COM,2500,24,Public Speaking,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2500,2018
-COM,2500,25,Public Speaking,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,COM-2500,2018
-COM,2500,29,Public Speaking,0.64,0.23,0.0,0.05,0.05,0.0,0.0,0.05,vanessa anne condon,COM-2500,2018
-COM,2500,30,Public Speaking,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2018
-COM,2500,31,Public Speaking,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,COM-2500,2018
-COM,2500,32,Public Speaking,0.71,0.19,0.05,0.0,0.05,0.0,0.0,0.0,sara grumble crocker,COM-2500,2018
-COM,2500,33,Public Speaking,0.22,0.61,0.06,0.0,0.06,0.0,0.0,0.06,marilyn denise pugh,COM-2500,2018
-COM,2500,34,Public Speaking,0.21,0.68,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,COM-2500,2018
-COM,2500,35,Public Speaking,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2018
-COM,2500,36,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,COM-2500,2018
-COM,2500,401,Public Speaking,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,COM-2500,2018
-COM,2500,402,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachary davis,COM-2500,2018
-COM,2500,403,Public Speaking,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alexis zachary davis,COM-2500,2018
-COM,2500,500,Public Speaking,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,COM-2500,2018
-COM,2500,501,Public Speaking,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,COM-2500,2018
-COM,3200,1,Bdcst Production,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,wanda johnson,COM-3200,2018
-COM,3250,1,Survey of Sports Communication,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3250,2018
-COM,3250,2,Survey of Sports Communication,0.87,0.04,0.09,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3250,2018
-COM,3300,1,Nonverbal Comm,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,joseph mazer,COM-3300,2018
-COM,3550,1,Principles of Public Relations,0.71,0.24,0.02,0.0,0.0,0.0,0.0,0.02,meghnaa tallapragada,COM-3550,2018
-COM,3570,1,Public Relations Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-3570,2018
-COM,3610,1,Argue and Debate,0.76,0.19,0.0,0.05,0.0,0.0,0.0,0.0,lindsey dixon,COM-3610,2018
-COM,3640,1,Organizational Comm,0.57,0.34,0.06,0.02,0.0,0.0,0.0,0.0,kristen elai okamoto,COM-3640,2018
-COM,3660,6,EC: Digital Analytics & Brand,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alicia nic littleton,COM-3660,2018
-COM,3660,7,EC: Media Mgmt in Brand Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william reynolds,COM-3660,2018
-COM,3990,2,CI: Reputation Mgmt,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,mark david land,COM-3990,2018
-COM,4250,1,Adv Sports Comm,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,COM-4250,2018
-COM,4280,1,Interpers/Family Comm & Sport,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,COM-4280,2018
-COM,4560,1,PR for Assoc & Nonprofits,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-4560,2018
-COM,4560,2,PR for Assoc & Nonprofits,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-4560,2018
-COM,4700,1,Comm & Health,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,stephanie pangborn,COM-4700,2018
-COM,4950,1,Senior Capstone,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-4950,2018
-COM,4950,2,Senior Capstone,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-4950,2018
-COM,8070,1,Hlt Com Plan & Eval,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,stephanie pangborn,COM-8070,2018
-COM,8110,1,Comm Research Methods II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,meghnaa tallapragada,COM-8110,2018
-CPSC,1010,1,Computer Science I,0.17,0.25,0.21,0.06,0.15,0.0,0.0,0.15,catherine hochrine,CPSC-1010,2018
-CPSC,1010,2,Computer Science I,0.17,0.19,0.17,0.02,0.24,0.0,0.0,0.22,catherine hochrine,CPSC-1010,2018
-CPSC,1020,1,Computer Science II,0.38,0.22,0.12,0.07,0.12,0.0,0.0,0.09,yvon feaster,CPSC-1020,2018
-CPSC,1020,2,Computer Science II,0.28,0.16,0.17,0.03,0.17,0.0,0.0,0.19,yvon feaster,CPSC-1020,2018
-CPSC,1070,1,Programming Methodology,0.56,0.28,0.12,0.04,0.0,0.0,0.0,0.0,rose lowe,CPSC-1070,2018
-CPSC,1110,1,Intro to Programming in C,0.08,0.41,0.25,0.05,0.11,0.0,0.0,0.1,catherine hochrine,CPSC-1110,2018
-CPSC,1110,2,Intro to Programming in C,0.43,0.27,0.16,0.02,0.05,0.0,0.0,0.07,nicolas benja widman,CPSC-1110,2018
-CPSC,2070,1,Discrete Structures,0.63,0.26,0.02,0.07,0.0,0.0,0.0,0.02,sandra hedetniemi,CPSC-2070,2018
-CPSC,2070,2,Discrete Structures,0.31,0.23,0.23,0.08,0.11,0.0,0.0,0.03,larry hodges,CPSC-2070,2018
-CPSC,2120,1,Algs/Data Structures,0.32,0.34,0.25,0.05,0.0,0.0,0.0,0.05,wayne goddard,CPSC-2120,2018
-CPSC,2120,2,Algs/Data Structures,0.25,0.48,0.2,0.02,0.05,0.0,0.0,0.0,wayne goddard,CPSC-2120,2018
-CPSC,2150,1,Software Dev Foundations,0.45,0.28,0.18,0.05,0.03,0.0,0.0,0.02,kevin anton plis,CPSC-2150,2018
-CPSC,2150,2,Software Dev Foundations,0.27,0.35,0.24,0.02,0.05,0.0,0.0,0.08,kevin anton plis,CPSC-2150,2018
-CPSC,2200,1,Microcomputer Appl,0.52,0.3,0.09,0.0,0.04,0.0,0.0,0.04,kevin anton plis,CPSC-2200,2018
-CPSC,2200,2,Microcomputer Appl,0.35,0.43,0.13,0.0,0.09,0.0,0.0,0.0,kevin anton plis,CPSC-2200,2018
-CPSC,2310,1,Intro Computer Org,0.45,0.16,0.25,0.05,0.09,0.0,0.0,0.0,rose lowe,CPSC-2310,2018
-CPSC,2310,2,Intro Computer Org,0.11,0.34,0.25,0.14,0.14,0.0,0.0,0.02,rose lowe,CPSC-2310,2018
-CPSC,2910,1,Prof Issues I,0.65,0.25,0.0,0.05,0.0,0.0,0.0,0.05,catherine hochrine,CPSC-2910,2018
-CPSC,2910,2,Prof Issues I,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,catherine hochrine,CPSC-2910,2018
-CPSC,2910,3,Prof Issues I,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2018
-CPSC,3120,1,Design Analysis of Algorithms,0.13,0.13,0.33,0.08,0.21,0.0,0.0,0.13,pradip srimani,CPSC-3120,2018
-CPSC,3220,1,Intro to Operating Systems,0.17,0.25,0.14,0.0,0.08,0.0,0.0,0.36,jacob sorber,CPSC-3220,2018
-CPSC,3220,2,Intro to Operating Systems,0.79,0.15,0.03,0.03,0.0,0.0,0.0,0.0,carl bryan martin,CPSC-3220,2018
-CPSC,3220,3,Intro to Operating Systems,0.17,0.45,0.1,0.07,0.07,0.0,0.0,0.14,zijun wang,CPSC-3220,2018
-CPSC,3300,1,Computer Systems Org,0.2,0.35,0.33,0.03,0.1,0.0,0.0,0.0,mark smotherman,CPSC-3300,2018
-CPSC,3300,2,Computer Systems Org,0.53,0.25,0.13,0.05,0.03,0.0,0.0,0.03,nicolas benja widman,CPSC-3300,2018
-CPSC,3500,1,Foundations of Computer Sci,0.16,0.23,0.47,0.06,0.0,0.0,0.0,0.08,ilya mark safro,CPSC-3500,2018
-CPSC,3520,1,Programming Systems,0.31,0.42,0.1,0.01,0.08,0.0,0.0,0.08,robert schalkoff,CPSC-3520,2018
-CPSC,3600,1,Network Programming,0.43,0.27,0.22,0.02,0.0,0.0,0.0,0.06,feng luo,CPSC-3600,2018
-CPSC,3600,2,Network Programming,0.14,0.5,0.29,0.04,0.0,0.0,0.0,0.04,james martin,CPSC-3600,2018
-CPSC,3720,1,Software Engineering,0.2,0.45,0.33,0.0,0.0,0.0,0.0,0.02,murali sitaraman,CPSC-3720,2018
-CPSC,3720,2,Software Engineering,0.25,0.44,0.25,0.03,0.03,0.0,0.0,0.0,eileen there kraemer,CPSC-3720,2018
-CPSC,4050,1,Computer Graphics,0.29,0.14,0.21,0.18,0.04,0.0,0.0,0.14,victor zordan,CPSC-4050,2018
-CPSC,4110,1,Virtual Reality Systems,0.37,0.37,0.14,0.0,0.02,0.0,0.0,0.09,andrew robb,CPSC-4110,2018
-CPSC,4140,1,Human and Computer Interaction,0.29,0.33,0.17,0.0,0.0,0.0,0.0,0.21,christopher plaue,CPSC-4140,2018
-CPSC,4140,2,Human and Computer Interaction,0.28,0.33,0.28,0.06,0.0,0.0,0.0,0.06,christopher plaue,CPSC-4140,2018
-CPSC,4160,1,2-D Game Engine Construction,0.4,0.38,0.1,0.0,0.1,0.0,0.0,0.02,brian malloy,CPSC-4160,2018
-CPSC,4240,1,System Admin and Security,0.18,0.56,0.2,0.02,0.0,0.0,0.0,0.04,james martin,CPSC-4240,2018
-CPSC,4300,1,Applied Data Science,0.33,0.33,0.28,0.0,0.0,0.0,0.0,0.06,alexander chr herzog,CPSC-4300,2018
-CPSC,4620,1,Database Management Systems,0.34,0.45,0.14,0.05,0.02,0.0,0.0,0.0,zijun wang,CPSC-4620,2018
-CPSC,4620,2,Database Management Systems,0.44,0.34,0.15,0.02,0.05,0.0,0.0,0.0,kevin anton plis,CPSC-4620,2018
-CPSC,4770,1,Distributed/Cluster Computing,0.26,0.62,0.09,0.0,0.0,0.0,0.0,0.03,linh bao ngo,CPSC-4770,2018
-CPSC,4820,1,Special Topic: Cloud Comp Arch,0.33,0.43,0.23,0.0,0.0,0.0,0.0,0.0,amy apon,CPSC-4820,2018
-CPSC,4820,2,Special Topics: Tang and Embod,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,brygg anders ullmer,CPSC-4820,2018
-CPSC,4910,1,Professional Issues II,0.3,0.67,0.03,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,CPSC-4910,2018
-CPSC,6110,1,Virtual Reality Systems,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,andrew robb,CPSC-6110,2018
-CPSC,6160,1,2-D Game Engine Construction,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,brian malloy,CPSC-6160,2018
-CPSC,6300,1,Applied Data Science,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,CPSC-6300,2018
-CPSC,8100,1,Intro Artif Intell,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,CPSC-8100,2018
-CPSC,8110,1,Technical Character Animation,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,christina soph joerg,CPSC-8110,2018
-CPSC,8240,1,Advanced Operating Systems,0.32,0.48,0.08,0.0,0.0,0.0,0.0,0.12,rong ge,CPSC-8240,2018
-CPSC,8280,0,Theory of Program. Languages,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,murali sitaraman,CPSC-8280,2018
-CPSC,8400,1,Design & Anlys of Algorithms,0.18,0.5,0.25,0.0,0.0,0.0,0.0,0.07,brian christoph dean,CPSC-8400,2018
-CPSC,8580,1,Security in Emerging Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,CPSC-8580,2018
-CPSC,8650,1,Data Mining,0.27,0.38,0.19,0.0,0.04,0.0,0.0,0.12,zijun wang,CPSC-8650,2018
-CPSC,8750,1,Software Architectur,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,john mcgregor,CPSC-8750,2018
-CPSC,8810,10,Selected Topics: Motion Planni,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,CPSC-8810,2018
-CRP,8020,1,Site Planning & Infrastructure,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,CRP-8020,2018
-CRP,8050,1,Plning Theory & History,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mickey lauria,CRP-8050,2018
-CRP,8090,1,Current Issues in Planning,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,CRP-8090,2018
-CRP,8130,1,Transportation Plan Fundament,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,eric morris,CRP-8130,2018
-CRP,8200,1,Negotiation & Develop Resolut,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,CRP-8200,2018
-CRP,8220,1,Urban Design,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,thomas willi schurch,CRP-8220,2018
-CRP,8590,2,Plan Terminal Proj,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,CRP-8590,2018
-CRP,8890,1,Selected Topic in Advanced GIS,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,patr carbajales-dale,CRP-8890,2018
-CRP,8890,3,Sel Top Development Finance,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,elora lee raymond,CRP-8890,2018
-CSM,2010,1,Structures I,0.3,0.25,0.2,0.05,0.1,0.0,0.0,0.1,shima clarke,CSM-2010,2018
-CSM,2020,1,Structures II,0.13,0.44,0.23,0.13,0.02,0.0,0.0,0.04,shima clarke,CSM-2020,2018
-CSM,2030,1,Mats & Meth of Const,0.21,0.61,0.14,0.0,0.04,0.0,0.0,0.0,jason lucas,CSM-2030,2018
-CSM,2040,1,Cont Documents,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,CSM-2040,2018
-CSM,2050,1,Mats & Methods II,0.24,0.61,0.12,0.0,0.0,0.0,0.0,0.02,jason lucas,CSM-2050,2018
-CSM,3050,1,Envir Systems II,0.26,0.43,0.3,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,CSM-3050,2018
-CSM,3050,2,Envir Systems II,0.37,0.57,0.03,0.03,0.0,0.0,0.0,0.0,joseph micha burgett,CSM-3050,2018
-CSM,3070,1,Sustainable Construction,0.2,0.45,0.25,0.0,0.05,0.0,0.0,0.05,joseph micha burgett,CSM-3070,2018
-CSM,3070,2,Sustainable Construction,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.04,joseph micha burgett,CSM-3070,2018
-CSM,3520,1,Const Scheduling,0.33,0.3,0.33,0.0,0.0,0.0,0.0,0.03,christine piper,CSM-3520,2018
-CSM,3520,2,Const Scheduling,0.18,0.5,0.23,0.09,0.0,0.0,0.0,0.0,christine piper,CSM-3520,2018
-CSM,3530,1,Const Estimating II,0.23,0.6,0.17,0.0,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,CSM-3530,2018
-CSM,3530,2,Const Estimating II,0.32,0.55,0.09,0.0,0.0,0.0,0.0,0.05,rizi seyed  mousavi e,CSM-3530,2018
-CSM,4540,1,Const Capstone,0.36,0.48,0.14,0.02,0.0,0.0,0.0,0.0,dennis bausman,CSM-4540,2018
-CSM,8350,401,Integr Proj Deliv Case Studies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shima clarke,CSM-8350,2018
-CSM,8640,1,Construction Bus Strat & Mktg,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christine piper,CSM-8640,2018
-CSM,8640,400,Construction Bus Strat & Mktg,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,christine piper,CSM-8640,2018
-CSM,8660,1,Role in Development,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8660,2018
-CSM,8660,401,Role in Development,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8660,2018
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.86,0.12,0.02,susan whorton,CU-1000,2018
-CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.68,0.21,0.11,susan whorton,CU-1000,2018
-CU,1010,1,Univ Success Skills,0.35,0.2,0.2,0.05,0.1,0.0,0.0,0.1,valerie kay oonk,CU-1010,2018
-CU,1010,2,Univ Success Skills,0.4,0.2,0.13,0.07,0.07,0.0,0.0,0.13,adam richa mcfarlane,CU-1010,2018
-CU,1010,3,Univ Success Skills,0.44,0.22,0.17,0.06,0.06,0.0,0.0,0.06,bryn zimmermann babb,CU-1010,2018
-CU,1010,4,Univ Success Skills,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,sharetta mar bufford,CU-1010,2018
-CU,1010,5,Univ Success Skills,0.5,0.22,0.22,0.0,0.06,0.0,0.0,0.0,bryn zimmermann babb,CU-1010,2018
-CU,1010,6,Univ Success Skills,0.29,0.29,0.12,0.0,0.18,0.0,0.0,0.12,taimi olsen,CU-1010,2018
-CU,1970,2,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.2,0.4,0.4,laurel ann  whisler c,CU-1970,2018
-CU,2010,1,Sustainability Leadership,0.85,0.12,0.0,0.0,0.04,0.0,0.0,0.0,jennifer marga goree,CU-2010,2018
-DPA,3070,1,Method 3d Production,0.71,0.14,0.04,0.0,0.0,0.0,0.0,0.11,sarah lydia  martin a,DPA-3070,2018
-DPA,4020,1,Vis Foundations I,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anthony summey,DPA-4020,2018
-DPA,4030,2,Vis Foundations II,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,erik reed,DPA-4030,2018
-DPA,4830,1,Sp Studio Topic: Dig Sculpt In,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,insun kwon,DPA-4830,2018
-ECE,2010,1,Logic and Computing Devices,0.29,0.35,0.23,0.0,0.07,0.0,0.0,0.06,walter ligon,ECE-2010,2018
-ECE,2020,1,Electric Circuits I,0.18,0.17,0.37,0.08,0.15,0.0,0.0,0.05,william harrell,ECE-2020,2018
-ECE,2070,1,Basic Electrical Engineering,0.48,0.36,0.08,0.02,0.0,0.0,0.0,0.05,timothy anglea,ECE-2070,2018
-ECE,2070,2,Basic Electrical Engineering,0.53,0.27,0.12,0.03,0.01,0.0,0.0,0.04,william tho kolodzey,ECE-2070,2018
-ECE,2070,3,Basic Electrical Engineering,0.39,0.33,0.21,0.04,0.0,0.0,0.0,0.03,william tho kolodzey,ECE-2070,2018
-ECE,2080,5,Basic Electrical Engr Lab,0.85,0.0,0.05,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,7,Basic Electrical Engr Lab,0.85,0.0,0.0,0.05,0.05,0.0,0.0,0.05,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,8,Basic Electrical Engr Lab,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,15,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2080,2018
-ECE,2080,18,Basic Electrical Engr Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,ECE-2080,2018
-ECE,2090,1,Logic Lab,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,apoorva deep kapadia,ECE-2090,2018
-ECE,2090,4,Logic Lab,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,apoorva deep kapadia,ECE-2090,2018
-ECE,2110,2,Elec Engr Lab I,0.75,0.1,0.0,0.0,0.1,0.0,0.0,0.05,apoorva deep kapadia,ECE-2110,2018
-ECE,2120,4,Electrical Engineering Lab II,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,apoorva deep kapadia,ECE-2120,2018
-ECE,2120,8,Electrical Engineering Lab II,0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,apoorva deep kapadia,ECE-2120,2018
-ECE,2220,1,Syst Prog Concept,0.24,0.35,0.26,0.01,0.09,0.0,0.0,0.06,william reid,ECE-2220,2018
-ECE,2230,1,Comp Sys Eng,0.15,0.27,0.21,0.09,0.15,0.0,0.0,0.12,jon cameron calhoun,ECE-2230,2018
-ECE,2620,1,Electric Circuits II,0.28,0.34,0.23,0.08,0.02,0.0,0.0,0.05,richard groff,ECE-2620,2018
-ECE,2620,2,Elec Circuits II (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2620,2018
-ECE,2720,1,Comp Organization,0.33,0.39,0.26,0.02,0.0,0.0,0.0,0.0,william reid,ECE-2720,2018
-ECE,2730,1,Computer Org Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2730,2018
-ECE,2730,3,Computer Org Lab,0.5,0.31,0.13,0.06,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2730,2018
-ECE,2730,5,Computer Org Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,apoorva deep kapadia,ECE-2730,2018
-ECE,2730,6,Computer Org Lab,0.63,0.31,0.0,0.06,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-2730,2018
-ECE,3110,2,Electrical Engineering Lab III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3110,2018
-ECE,3110,3,Electrical Engineering Lab III,0.31,0.44,0.19,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,ECE-3110,2018
-ECE,3110,4,Electrical Engineering Lab III,0.69,0.19,0.0,0.06,0.0,0.0,0.0,0.06,apoorva deep kapadia,ECE-3110,2018
-ECE,3120,2,Electrical Engineering Lab IV,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3120,2018
-ECE,3170,1,Rand Signal Analysis,0.32,0.28,0.24,0.11,0.03,0.0,0.0,0.04,stephen hubbard,ECE-3170,2018
-ECE,3200,1,Electronics I,0.25,0.28,0.22,0.17,0.08,0.0,0.0,0.0,stephen hubbard,ECE-3200,2018
-ECE,3210,1,Electronics II,0.49,0.34,0.13,0.0,0.02,0.0,0.0,0.02,stephen hubbard,ECE-3210,2018
-ECE,3220,1,Intro Operating Sys,0.16,0.37,0.26,0.0,0.0,0.0,0.0,0.21,jacob sorber,ECE-3220,2018
-ECE,3270,1,Dig Comp Design,0.17,0.19,0.26,0.1,0.07,0.0,0.0,0.21,melissa crawle smith,ECE-3270,2018
-ECE,3300,1,Signals & Systems,0.16,0.24,0.34,0.15,0.06,0.0,0.0,0.04,carl baum,ECE-3300,2018
-ECE,3520,1,Programming Systems,0.58,0.32,0.05,0.03,0.03,0.0,0.0,0.0,robert schalkoff,ECE-3520,2018
-ECE,3600,1,Elect Power Engr,0.57,0.11,0.17,0.06,0.03,0.0,0.0,0.06,edward collins,ECE-3600,2018
-ECE,3710,1,Microcontr Interface,0.32,0.32,0.3,0.03,0.0,0.0,0.0,0.03,william reid,ECE-3710,2018
-ECE,3720,1,Micro Int Lab,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3720,3,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3720,5,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3720,7,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-3720,2018
-ECE,3800,1,Electromagnetics,0.3,0.28,0.2,0.08,0.08,0.0,0.0,0.06,yuan li,ECE-3800,2018
-ECE,3810,1,Field Waves & Ckts,0.36,0.48,0.1,0.04,0.0,0.0,0.0,0.02,anthony martin,ECE-3810,2018
-ECE,4090,1,Intr to Linear Control Systems,0.48,0.43,0.05,0.03,0.03,0.0,0.0,0.0,apoorva deep kapadia,ECE-4090,2018
-ECE,4160,1,Smart Grid,0.52,0.45,0.03,0.0,0.0,0.0,0.0,0.0,gane venayagamoorthy,ECE-4160,2018
-ECE,4200,1,Renewable Energy,0.19,0.19,0.26,0.26,0.0,0.0,0.0,0.1,johan heinric enslin,ECE-4200,2018
-ECE,4270,1,Communications Sys,0.35,0.49,0.07,0.05,0.02,0.0,0.0,0.02,upasan bhattacharyya,ECE-4270,2018
-ECE,4380,1,Computer Commun,0.33,0.33,0.22,0.07,0.0,0.0,0.0,0.04,harlan russell,ECE-4380,2018
-ECE,4400,1,Local Computer Nets,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,ECE-4400,2018
-ECE,4680,1,Embedded Computing,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,ECE-4680,2018
-ECE,4950,1,Int Sys Design I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,ECE-4950,2018
-ECE,4960,1,Int Sys Design II,0.59,0.33,0.05,0.02,0.0,0.0,0.0,0.0,richard groff,ECE-4960,2018
-ECE,6200,1,Renewable Energy,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,johan heinric enslin,ECE-6200,2018
-ECE,6680,1,Embedded Computing,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,adam hoover,ECE-6680,2018
-ECE,6930,1,Algorithms VLSI Design Automa.,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,ECE-6930,2018
-ECE,8260,1,Solar Cells,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,rajendra singh,ECE-8260,2018
-ECE,8400,1,Semicond Devices,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,ECE-8400,2018
-ECE,8480,1,Telecomm Networks,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,ECE-8480,2018
-ECE,8720,1,Artificial Neurl Net,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,robert schalkoff,ECE-8720,2018
-ECE,8720,2,Artificial Neurl Net,0.14,0.43,0.0,0.0,0.14,0.0,0.0,0.29,robert schalkoff,ECE-8720,2018
-ECE,8740,1,Adv Nonlinear Cntrl,0.56,0.33,0.0,0.0,0.11,0.0,0.0,0.0,yongqiang wang,ECE-8740,2018
-ECE,8790,1,FPGA Design & Applications,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,melissa crawle smith,ECE-8790,2018
-ECE,8930,2,Optimiz. Vector Space Methods,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,daniel noneaker,ECE-8930,2018
-ECE,8930,10,Distributed Denial of Service,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,ECE-8930,2018
-ECON,2000,1,Economic Concepts,0.32,0.14,0.3,0.14,0.05,0.0,0.0,0.05,jonathan orry ernest,ECON-2000,2018
-ECON,2000,2,Economic Concepts,0.35,0.35,0.2,0.03,0.03,0.0,0.0,0.05,jonathan orry ernest,ECON-2000,2018
-ECON,2000,3,Economic Concepts,0.46,0.27,0.16,0.11,0.0,0.0,0.0,0.0,miren ivankovic,ECON-2000,2018
-ECON,2110,1,Principles of Microeconomics,0.3,0.28,0.2,0.13,0.03,0.0,0.0,0.08,liuna issagholian,ECON-2110,2018
-ECON,2110,2,Principles of Microeconomics,0.18,0.35,0.28,0.08,0.1,0.0,0.0,0.03,roksana ghanbariamin,ECON-2110,2018
-ECON,2110,3,Principles of Microeconomics,0.12,0.31,0.26,0.12,0.12,0.0,0.0,0.07,benjamin posmanick,ECON-2110,2018
-ECON,2110,4,Principles of Microeconomics,0.32,0.32,0.12,0.12,0.1,0.0,0.0,0.02,kelsey victo roberts,ECON-2110,2018
-ECON,2110,5,Principles of Microeconomics,0.3,0.4,0.23,0.05,0.03,0.0,0.0,0.0,molly espey,ECON-2110,2018
-ECON,2110,6,Principles of Microeconomics,0.19,0.57,0.19,0.0,0.01,0.0,0.0,0.03,chen wang,ECON-2110,2018
-ECON,2110,7,Principles of Microeconomics,0.3,0.42,0.17,0.06,0.04,0.0,0.0,0.01,wing yin chung,ECON-2110,2018
-ECON,2110,8,Principles of Microeconomics,0.28,0.28,0.24,0.1,0.07,0.0,0.0,0.03,sarah louise wilson,ECON-2110,2018
-ECON,2110,10,Principles of Microeconomics,0.39,0.45,0.1,0.02,0.04,0.0,0.0,0.0,jacob walloga,ECON-2110,2018
-ECON,2110,12,Principles of Microeconomics,0.43,0.28,0.18,0.08,0.0,0.0,0.0,0.05,molly espey,ECON-2110,2018
-ECON,2120,1,Principles of Macroeconomics,0.45,0.2,0.15,0.1,0.05,0.0,0.0,0.05,scott baier,ECON-2120,2018
-ECON,2120,2,Principles of Macroeconomics,0.17,0.33,0.28,0.11,0.11,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,3,Principles of Macroeconomics,0.33,0.33,0.28,0.0,0.0,0.0,0.0,0.06,scott baier,ECON-2120,2018
-ECON,2120,4,Principles of Macroeconomics,0.21,0.42,0.32,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,5,Principles of Macroeconomics,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,scott baier,ECON-2120,2018
-ECON,2120,6,Principles of Macroeconomics,0.26,0.21,0.26,0.11,0.05,0.0,0.0,0.11,scott baier,ECON-2120,2018
-ECON,2120,7,Principles of Macroeconomics,0.16,0.42,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,8,Principles of Macroeconomics,0.11,0.47,0.16,0.05,0.11,0.0,0.0,0.11,scott baier,ECON-2120,2018
-ECON,2120,9,Principles of Macroeconomics,0.21,0.37,0.32,0.0,0.05,0.0,0.0,0.05,scott baier,ECON-2120,2018
-ECON,2120,10,Principles of Macroeconomics,0.32,0.53,0.05,0.11,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,11,Principles of Macroeconomics,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,12,Principles of Macroeconomics,0.11,0.42,0.26,0.11,0.11,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,13,Principles of Macroeconomics,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,14,Principles of Macroeconomics,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,15,Principles of Macroeconomics,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,16,Principles of Macroeconomics,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,17,Principles of Macroeconomics,0.21,0.63,0.05,0.0,0.05,0.0,0.0,0.05,scott baier,ECON-2120,2018
-ECON,2120,18,Principles of Macroeconomics,0.21,0.63,0.11,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,19,Principles of Macroeconomics,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2018
-ECON,2120,20,Principles of Macroeconomics,0.69,0.22,0.05,0.0,0.03,0.0,0.0,0.0,jeremy choquette,ECON-2120,2018
-ECON,2120,21,Principles of Macroeconomics,0.27,0.45,0.21,0.0,0.03,0.0,0.0,0.03,benjamin tim harbolt,ECON-2120,2018
-ECON,2120,22,Principles of Macroeconomics,0.0,0.2,0.08,0.16,0.0,0.0,0.0,0.56,ralph charles allen,ECON-2120,2018
-ECON,2120,23,Principles of Macroeconomics,0.2,0.11,0.14,0.09,0.03,0.0,0.0,0.43,ralph charles allen,ECON-2120,2018
-ECON,2120,24,Principles of Macroeconomics,0.31,0.48,0.2,0.0,0.01,0.0,0.0,0.0,elijah neilson,ECON-2120,2018
-ECON,2120,25,Principles of Macroeconomics,0.42,0.33,0.19,0.03,0.03,0.0,0.0,0.0,kyle lance rechard,ECON-2120,2018
-ECON,2120,26,Principles of Macroeconomics,0.49,0.33,0.13,0.0,0.05,0.0,0.0,0.0,xiaosong wu,ECON-2120,2018
-ECON,2120,27,Principles of Macroeconomics,0.36,0.38,0.23,0.0,0.0,0.0,0.0,0.03,narendra regmi,ECON-2120,2018
-ECON,2120,28,Principles of Macroecon (HON),0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,christopher as gorry,ECON-2120,2018
-ECON,3020,1,Money and Banking,0.33,0.33,0.25,0.03,0.05,0.0,0.0,0.03,smriti bhargava,ECON-3020,2018
-ECON,3060,1,Managerial Economics,0.16,0.33,0.25,0.12,0.12,0.0,0.0,0.02,steven johnson,ECON-3060,2018
-ECON,3100,1,International Econ,0.48,0.29,0.18,0.0,0.02,0.0,0.0,0.03,samuel art standaert,ECON-3100,2018
-ECON,3140,1,Intermediate Micro,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,yichen christy zhou,ECON-3140,2018
-ECON,3140,2,Intermediate Micro,0.23,0.38,0.18,0.08,0.05,0.0,0.0,0.1,robert kenneth fleck,ECON-3140,2018
-ECON,3140,3,Intermediate Micro,0.24,0.24,0.19,0.14,0.05,0.0,0.0,0.14,patrick warren,ECON-3140,2018
-ECON,3150,1,Intermediate Macro,0.28,0.38,0.18,0.07,0.04,0.0,0.0,0.05,michal jerzmanowski,ECON-3150,2018
-ECON,3150,2,Intermediate Macro,0.34,0.22,0.32,0.0,0.05,0.0,0.0,0.07,sergey vlad mityakov,ECON-3150,2018
-ECON,3440,1,Property Rights,0.13,0.38,0.25,0.17,0.08,0.0,0.0,0.0,dari litsukova-bokar,ECON-3440,2018
-ECON,3500,1,Moral & Ethical Econ,0.44,0.25,0.19,0.0,0.03,0.0,0.0,0.09,bradley keith hobbs,ECON-3500,2018
-ECON,3500,2,Moral & Ethical Econ,0.15,0.35,0.25,0.1,0.0,0.0,0.0,0.15,bradley keith hobbs,ECON-3500,2018
-ECON,3600,1,Public Choice,0.37,0.37,0.2,0.05,0.0,0.0,0.0,0.02,michael makowsky,ECON-3600,2018
-ECON,4010,1,Labor Mkt Analysis,0.24,0.52,0.21,0.0,0.03,0.0,0.0,0.0,curtis simon,ECON-4010,2018
-ECON,4020,1,Law and Economics,0.18,0.33,0.38,0.09,0.0,0.0,0.0,0.02,thomas winsl hazlett,ECON-4020,2018
-ECON,4050,1,Intro to Econometric,0.27,0.29,0.25,0.07,0.07,0.0,0.0,0.04,scott barkowski,ECON-4050,2018
-ECON,4050,2,Intro to Econometric,0.5,0.36,0.0,0.07,0.07,0.0,0.0,0.0,yichen christy zhou,ECON-4050,2018
-ECON,4200,1,Pub Sector Econ,0.48,0.33,0.0,0.0,0.1,0.0,0.0,0.1,william dougan,ECON-4200,2018
-ECON,4230,1,Economics of Health,0.56,0.33,0.1,0.0,0.0,0.0,0.0,0.0,devon merritt gorry,ECON-4230,2018
-ECON,4240,1,Organization of Ind,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,matthew lewis,ECON-4240,2018
-ECON,4240,2,Organization of Ind,0.34,0.41,0.17,0.07,0.0,0.0,0.0,0.0,matthew lewis,ECON-4240,2018
-ECON,4260,1,Sem Sport Economics,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,raymond sauer,ECON-4260,2018
-ECON,4270,1,Dev American Economy,0.21,0.52,0.21,0.07,0.0,0.0,0.0,0.0,howard nel bodenhorn,ECON-4270,2018
-ECON,4400,1,Game Theory,0.28,0.41,0.22,0.0,0.0,0.0,0.0,0.09,charles thomas,ECON-4400,2018
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.08,0.15,0.54,0.08,0.0,0.0,0.0,0.15,scott templeton,ECON-4570,2018
-ECON,6060,1,Advanced Econometric,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,los santos babur de babur,ECON-6060,2018
-ECON,8020,2,Adv Econ Concepts and Applic I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui kin,ECON-8020,2018
-ECON,8050,1,Macroeconomic Theory,0.67,0.07,0.2,0.0,0.0,0.0,0.0,0.07,michal jerzmanowski,ECON-8050,2018
-ECON,8070,1,Econometrics II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chungsang lam,ECON-8070,2018
-ECON,8110,1,Econ of Environment,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,scott templeton,ECON-8110,2018
-ECON,8200,1,Public Finance,0.1,0.8,0.0,0.0,0.0,0.0,0.0,0.1,william dougan,ECON-8200,2018
-ECON,9090,1,Time-Series Econ,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,gerald dwyer,ECON-9090,2018
-ECON,9820,1,Workshop in Ap Econ (Macro),0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,gerald dwyer,ECON-9820,2018
-ED,1050,1,Educ Orientation,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,ED-1050,2018
-ED,1050,2,Educ Orientation,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,ED-1050,2018
-ED,8600,303,Classroom-Based Research,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,susan ridg nunamaker,ED-8600,2018
-ED,8650,1,Curriculum Theory,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,ED-8650,2018
-ED,8760,301,"Curric, Instruc, Assess, Learn",0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,stephanie burdette,ED-8760,2018
-EDC,2990,1,Creative Inq in Counselor Ed,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,kend stewart-tillman,EDC-2990,2018
-EDC,3900,2,Skills for Student Leaders,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2018
-EDC,3900,3,Skills for Student Leaders,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,eric pernotto,EDC-3900,2018
-EDC,3900,5,Skills for Student Leaders,0.82,0.06,0.12,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2018
-EDC,3900,6,Skills for Student Leaders,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2018
-EDC,3900,7,Skills for Student Leaders,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2018
-EDC,3900,8,Skills for Student Leaders,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2018
-EDEC,3020,1,Early Childhood Practicum II,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,andrea emerson,EDEC-3020,2018
-EDEL,3100,2,Arts in Ele School,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alison eliza leonard,EDEL-3100,2018
-EDEL,3210,1,Pe for the Elem Tchr,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2018
-EDEL,4050,1,Soc Justice-21st Cen,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,EDEL-4050,2018
-EDEL,4520,2,Elem Methods Math Teaching,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nicole alain sinwell,EDEL-4520,2018
-EDEL,4870,1,Ele Meth Soc Studies,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,EDEL-4870,2018
-EDF,3010,2,Principles of American Educ,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,amaris joseph tejada,EDF-3010,2018
-EDF,3010,3,Principles of American Educ,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,jennifer michel hein,EDF-3010,2018
-EDF,3020,1,Educational Psychology,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,stephen chou,EDF-3020,2018
-EDF,3020,3,Educational Psychology,0.91,0.06,0.0,0.0,0.03,0.0,0.0,0.0,heather roge brooker,EDF-3020,2018
-EDF,3020,4,Educational Psychology,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,heather roge brooker,EDF-3020,2018
-EDF,3020,5,Educational Psychology,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,stephen chou,EDF-3020,2018
-EDF,3200,1,History of US Education,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,beatrice naff bailey,EDF-3200,2018
-EDF,3340,1,Child Growth and Development,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoob jamil,EDF-3340,2018
-EDF,3350,1,Adolescent Growth & Develop,0.71,0.23,0.0,0.0,0.0,0.0,0.0,0.06,luke rapa,EDF-3350,2018
-EDF,4800,1,Digital Media & Learning,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2018
-EDF,4800,300,Digital Media & Learning,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2018
-EDF,9710,400,Case Study & Ethnographic Mthd,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,reginald wilkerson,EDF-9710,2018
-EDF,9750,501,Mixed Methods Research,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,EDF-9750,2018
-EDHD,3110,1,CI- Research in DM & Learning,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,ryan visser,EDHD-3110,2018
-EDHD,8310,502,Lit LOS for Child w /disab II,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,renee gatlin anders,EDHD-8310,2018
-EDL,9750,1,College Teaching,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,EDL-9750,2018
-EDLT,4620,2,Reading Children's Lit in Elem,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,susan king fullerton,EDLT-4620,2018
-EDLT,4630,1,Teaching Rdg/Writing for ELLs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-4630,2018
-EDLT,4670,1,Teaching ESOL in Elem Schools,0.77,0.09,0.09,0.0,0.05,0.0,0.0,0.0,quesada hazel  vega m,EDLT-4670,2018
-EDLT,8120,300,Assessment in Reading & Writin,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8120,2018
-EDLT,8120,500,Assessment in Reading & Writin,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8120,2018
-EDLT,8120,501,Assessment in Reading & Writin,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8120,2018
-EDLT,8220,300,Strategies for Teaching ESOL,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,mikel walker cole,EDLT-8220,2018
-EDLT,8220,500,Strategies for Teaching ESOL,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-8220,2018
-EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,barbara fewell,EDLT-8410,2018
-EDLT,8410,501,Early Literacy Inst Strategies,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,susanne at elvington,EDLT-8410,2018
-EDLT,8410,502,Early Literacy Inst Strategies,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,EDLT-8410,2018
-EDLT,8410,507,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,EDLT-8410,2018
-EDLT,8810,501,Reading Recovery Teacher II,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,EDLT-8810,2018
-EDLT,8830,501,Read Recovery Practicum II,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,EDLT-8830,2018
-EDLT,8830,506,Read Recovery Practicum II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,EDLT-8830,2018
-EDSA,8110,1,Multicultural Counseling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,EDSA-8110,2018
-EDSC,4580,1,Sec Soc Capstone,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,EDSC-4580,2018
-EDSP,3700,2,Intro to Special Education,0.92,0.06,0.03,0.0,0.0,0.0,0.0,0.0,shanna eisner hirsch,EDSP-3700,2018
-EDSP,3700,4,Intro to Special Education,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,pamela stecker,EDSP-3700,2018
-EDSP,3700,300,Intro to Special Education,0.74,0.11,0.09,0.03,0.0,0.0,0.0,0.03,shanna eisner hirsch,EDSP-3700,2018
-EDSP,3750,1,Early Intervention Spec Needs,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,abigail anne allen,EDSP-3750,2018
-EDSP,4910,1,Ed Assess Ind W/Dis,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,antonis katsiyannis,EDSP-4910,2018
-EES,2020,1,Environ Engr Fundamentals II,0.67,0.24,0.06,0.0,0.03,0.0,0.0,0.0,kevin thoma finneran,EES-2020,2018
-EES,4010,1,Environmental Engr,0.5,0.27,0.11,0.0,0.02,0.0,0.0,0.09,elizabeth carraway,EES-4010,2018
-EES,4010,2,Environmental Engr,0.32,0.38,0.21,0.0,0.03,0.0,0.0,0.06,ezra lucas hoy cates hoy,EES-4010,2018
-EES,4750,1,Capstone Design Project,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-4750,2018
-EES,4850,1,Hazard Waste Management,0.24,0.55,0.12,0.06,0.0,0.0,0.0,0.03,mark schlautman,EES-4850,2018
-EES,4860,1,Environmental Sustainability,0.7,0.15,0.15,0.0,0.0,0.0,0.0,0.0,michael anthony dale,EES-4860,2018
-EES,6110,1,Rad Detection Mmt,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,timothy devol,EES-6110,2018
-EES,8030,1,Phy/Chem Ops W/WW T,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ezra lucas hoy cates hoy,EES-8030,2018
-EES,8200,1,Env Systems Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michael anthony dale,EES-8200,2018
-ELE,3010,1,Entrepreneurial Foundations,0.35,0.63,0.03,0.0,0.0,0.0,0.0,0.0,christina kyprianou,ELE-3010,2018
-ELE,3010,2,Entrepreneurial Foundations,0.2,0.75,0.05,0.0,0.0,0.0,0.0,0.0,christina kyprianou,ELE-3010,2018
-ELE,3010,3,Entrepreneurial Foundations,0.15,0.36,0.41,0.05,0.0,0.0,0.0,0.03,ashley willi parnell,ELE-3010,2018
-ELE,4010,1,Venture Testing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,chad navis,ELE-4010,2018
-ELE,4010,2,Venture Testing,0.65,0.27,0.08,0.0,0.0,0.0,0.0,0.0,chad navis,ELE-4010,2018
-ELE,4020,1,Venture Creation,0.32,0.59,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,ELE-4020,2018
-ELE,4030,1,Venture Growth,0.1,0.47,0.4,0.03,0.0,0.0,0.0,0.0,ashley willi parnell,ELE-4030,2018
-ENGL,1030,1,Composition and Rhetoric,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,ENGL-1030,2018
-ENGL,1030,2,Composition and Rhetoric,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,jennie eli wakefield,ENGL-1030,2018
-ENGL,1030,3,Composition and Rhetoric,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,carley ama robertson,ENGL-1030,2018
-ENGL,1030,4,Composition and Rhetoric,0.47,0.27,0.07,0.0,0.13,0.0,0.0,0.07,carley ama robertson,ENGL-1030,2018
-ENGL,1030,5,Composition and Rhetoric,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,jennie eli wakefield,ENGL-1030,2018
-ENGL,1030,6,Composition and Rhetoric,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,jennie eli wakefield,ENGL-1030,2018
-ENGL,1030,7,Composition and Rhetoric,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,courtne huff-oelberg,ENGL-1030,2018
-ENGL,1030,8,Composition and Rhetoric,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,courtne huff-oelberg,ENGL-1030,2018
-ENGL,1030,9,Composition and Rhetoric,0.6,0.2,0.0,0.0,0.13,0.0,0.0,0.07,carrie hill,ENGL-1030,2018
-ENGL,1030,10,Composition and Rhetoric,0.5,0.33,0.0,0.0,0.06,0.0,0.0,0.11,carrie hill,ENGL-1030,2018
-ENGL,1030,12,Composition and Rhetoric,0.76,0.14,0.0,0.0,0.1,0.0,0.0,0.0,michael david measel,ENGL-1030,2018
-ENGL,1030,13,Composition and Rhetoric,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,sarah eli richardson,ENGL-1030,2018
-ENGL,1030,14,Composition and Rhetoric,0.81,0.0,0.05,0.05,0.05,0.0,0.0,0.05,sarah eli richardson,ENGL-1030,2018
-ENGL,1030,15,Composition and Rhetoric,0.5,0.17,0.06,0.0,0.17,0.0,0.0,0.11,abigail maxim,ENGL-1030,2018
-ENGL,1030,19,Composition and Rhetoric,0.86,0.05,0.0,0.1,0.0,0.0,0.0,0.0,martha sue karnes,ENGL-1030,2018
-ENGL,1030,20,Composition and Rhetoric,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,martha sue karnes,ENGL-1030,2018
-ENGL,1030,21,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,sarah margare carter,ENGL-1030,2018
-ENGL,1030,22,Composition and Rhetoric,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,sarah margare carter,ENGL-1030,2018
-ENGL,1030,26,Composition and Rhetoric,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-1030,2018
-ENGL,1030,28,Composition and Rhetoric,0.48,0.43,0.05,0.0,0.05,0.0,0.0,0.0,allen swords,ENGL-1030,2018
-ENGL,1030,36,Composition and Rhetoric,0.71,0.1,0.1,0.0,0.05,0.0,0.0,0.05,david charles foltz,ENGL-1030,2018
-ENGL,1030,37,Composition and Rhetoric,0.7,0.15,0.0,0.0,0.05,0.0,0.0,0.1,michelle lloyd,ENGL-1030,2018
-ENGL,1030,38,Composition and Rhetoric,0.5,0.35,0.0,0.0,0.1,0.0,0.0,0.05,michelle lloyd,ENGL-1030,2018
-ENGL,1030,39,Composition and Rhetoric,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,john conway,ENGL-1030,2018
-ENGL,1030,41,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,ENGL-1030,2018
-ENGL,1030,42,Composition and Rhetoric,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,caroline eliza young,ENGL-1030,2018
-ENGL,1030,43,Composition and Rhetoric,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,ENGL-1030,2018
-ENGL,1030,44,Composition and Rhetoric,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,caroline eliza young,ENGL-1030,2018
-ENGL,1030,45,Composition and Rhetoric,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,beltran dian quaglia,ENGL-1030,2018
-ENGL,1030,46,Composition and Rhetoric,0.86,0.09,0.0,0.0,0.05,0.0,0.0,0.0,beltran dian quaglia,ENGL-1030,2018
-ENGL,1030,47,Composition and Rhetoric,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,jane elizabe kuebler,ENGL-1030,2018
-ENGL,1030,48,Composition and Rhetoric,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jane elizabe kuebler,ENGL-1030,2018
-ENGL,1030,49,Composition and Rhetoric,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,charlotte este lucke,ENGL-1030,2018
-ENGL,1030,52,Composition and Rhetoric,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,gabrielle gra nugent,ENGL-1030,2018
-ENGL,1030,53,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,ENGL-1030,2018
-ENGL,1030,54,Composition and Rhetoric,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,valerie smith,ENGL-1030,2018
-ENGL,1030,56,Composition and Rhetoric,0.53,0.33,0.0,0.0,0.13,0.0,0.0,0.0,daniel quin atkinson,ENGL-1030,2018
-ENGL,1030,57,Composition and Rhetoric,0.81,0.0,0.0,0.06,0.0,0.0,0.0,0.13,christopher stuart,ENGL-1030,2018
-ENGL,1030,58,Composition and Rhetoric,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.1,christopher stuart,ENGL-1030,2018
-ENGL,1030,60,Composition and Rhetoric,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,stephen hundley,ENGL-1030,2018
-ENGL,1030,61,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,austin gorman,ENGL-1030,2018
-ENGL,1030,62,Composition and Rhetoric,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,michael russo,ENGL-1030,2018
-ENGL,1030,63,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,ENGL-1030,2018
-ENGL,1030,64,Composition and Rhetoric,0.61,0.11,0.17,0.0,0.11,0.0,0.0,0.0,shauna chung,ENGL-1030,2018
-ENGL,1030,66,Composition and Rhetoric,0.8,0.0,0.07,0.0,0.07,0.0,0.0,0.07,victoria houser,ENGL-1030,2018
-ENGL,1030,67,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,ENGL-1030,2018
-ENGL,1030,400,Composition and Rhetoric,0.52,0.43,0.0,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,ENGL-1030,2018
-ENGL,1030,401,Composition and Rhetoric,0.61,0.17,0.11,0.0,0.06,0.0,0.0,0.06,la'cresha ulon green,ENGL-1030,2018
-ENGL,1030,555,Composition and Rhetoric,0.5,0.43,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth steedley,ENGL-1030,2018
-ENGL,2020,500,The Major Forms of Literature,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,ENGL-2020,2018
-ENGL,2120,1,World Literature,0.11,0.36,0.39,0.11,0.0,0.0,0.0,0.04,david charles foltz,ENGL-2120,2018
-ENGL,2120,2,World Literature,0.25,0.36,0.25,0.0,0.04,0.0,0.0,0.11,david charles foltz,ENGL-2120,2018
-ENGL,2120,3,World Literature,0.7,0.2,0.07,0.03,0.0,0.0,0.0,0.0,allison nicol harris,ENGL-2120,2018
-ENGL,2120,4,World Literature,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,allison nicol harris,ENGL-2120,2018
-ENGL,2120,5,World Literature,0.48,0.34,0.14,0.0,0.0,0.0,0.0,0.03,allison nicol harris,ENGL-2120,2018
-ENGL,2120,6,World Literature,0.48,0.34,0.1,0.0,0.03,0.0,0.0,0.03,allison nicol harris,ENGL-2120,2018
-ENGL,2120,7,World Literature,0.46,0.35,0.04,0.0,0.0,0.0,0.0,0.15,remley meliss makala,ENGL-2120,2018
-ENGL,2120,8,World Literature,0.48,0.19,0.11,0.07,0.04,0.0,0.0,0.11,remley meliss makala,ENGL-2120,2018
-ENGL,2120,9,World Literature,0.38,0.31,0.14,0.03,0.0,0.0,0.0,0.14,karen kettnich,ENGL-2120,2018
-ENGL,2120,10,World Literature,0.59,0.31,0.03,0.0,0.03,0.0,0.0,0.03,karen kettnich,ENGL-2120,2018
-ENGL,2120,12,World Literature,0.45,0.41,0.1,0.0,0.0,0.0,0.0,0.03,sharon kathle nalley,ENGL-2120,2018
-ENGL,2120,13,World Literature,0.14,0.64,0.14,0.0,0.07,0.0,0.0,0.0,sarah mae cooper,ENGL-2120,2018
-ENGL,2120,14,World Literature,0.24,0.48,0.17,0.0,0.0,0.0,0.0,0.1,sarah mae cooper,ENGL-2120,2018
-ENGL,2120,15,World Literature,0.48,0.38,0.1,0.03,0.0,0.0,0.0,0.0,sharon kathle nalley,ENGL-2120,2018
-ENGL,2120,16,World Literature,0.27,0.43,0.2,0.0,0.1,0.0,0.0,0.0,andrew mathas,ENGL-2120,2018
-ENGL,2120,17,World Literature,0.46,0.25,0.18,0.04,0.04,0.0,0.0,0.04,andrew mathas,ENGL-2120,2018
-ENGL,2120,18,World Literature,0.47,0.37,0.1,0.0,0.0,0.0,0.0,0.07,chloe miche whitaker,ENGL-2120,2018
-ENGL,2120,19,World Literature,0.53,0.33,0.0,0.0,0.03,0.0,0.0,0.1,chloe miche whitaker,ENGL-2120,2018
-ENGL,2120,20,World Literature,0.33,0.44,0.19,0.0,0.0,0.0,0.0,0.04,julia brownlee koets,ENGL-2120,2018
-ENGL,2120,21,World Literature,0.24,0.68,0.08,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,ENGL-2120,2018
-ENGL,2120,22,World Literature,0.24,0.52,0.07,0.07,0.07,0.0,0.0,0.03,hannah pittma godwin,ENGL-2120,2018
-ENGL,2120,23,World Literature,0.41,0.41,0.1,0.03,0.03,0.0,0.0,0.0,hannah pittma godwin,ENGL-2120,2018
-ENGL,2120,24,World Literature,0.59,0.1,0.14,0.03,0.07,0.0,0.0,0.07,heather pri williams,ENGL-2120,2018
-ENGL,2130,1,British Literature,0.41,0.48,0.0,0.0,0.0,0.0,0.0,0.1,christopher benson,ENGL-2130,2018
-ENGL,2130,2,British Literature,0.6,0.3,0.0,0.03,0.03,0.0,0.0,0.03,christopher benson,ENGL-2130,2018
-ENGL,2130,3,British Literature,0.45,0.34,0.14,0.03,0.03,0.0,0.0,0.0,megan noe macalystre,ENGL-2130,2018
-ENGL,2130,4,British Literature,0.3,0.4,0.1,0.03,0.07,0.0,0.0,0.1,megan noe macalystre,ENGL-2130,2018
-ENGL,2130,5,British Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2018
-ENGL,2130,6,British Literature,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2018
-ENGL,2130,7,British Literature,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2018
-ENGL,2130,8,British Literature,0.43,0.47,0.07,0.0,0.0,0.0,0.0,0.03,lucian ghita,ENGL-2130,2018
-ENGL,2130,9,British Literature,0.3,0.37,0.1,0.2,0.03,0.0,0.0,0.0,megan noe macalystre,ENGL-2130,2018
-ENGL,2130,10,British Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2130,2018
-ENGL,2130,11,British Literature,0.57,0.37,0.03,0.0,0.03,0.0,0.0,0.0,chloe miche whitaker,ENGL-2130,2018
-ENGL,2130,12,British Literature,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,chloe miche whitaker,ENGL-2130,2018
-ENGL,2130,13,British Literature,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2130,2018
-ENGL,2140,1,American Literature,0.76,0.17,0.03,0.03,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2018
-ENGL,2140,2,American Literature,0.77,0.13,0.07,0.0,0.03,0.0,0.0,0.0,melissa dugan,ENGL-2140,2018
-ENGL,2140,3,American Literature,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,lindsay kathl turner,ENGL-2140,2018
-ENGL,2140,4,American Literature,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.07,lindsay kathl turner,ENGL-2140,2018
-ENGL,2140,5,American Literature,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,melissa dugan,ENGL-2140,2018
-ENGL,2140,6,American Literature,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2018
-ENGL,2140,9,American Literature,0.55,0.24,0.14,0.07,0.0,0.0,0.0,0.0,jennifer ha forsberg,ENGL-2140,2018
-ENGL,2140,10,American Literature,0.52,0.34,0.1,0.0,0.03,0.0,0.0,0.0,jennifer ha forsberg,ENGL-2140,2018
-ENGL,2140,11,American Literature,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2018
-ENGL,2140,12,American Literature,0.6,0.33,0.03,0.03,0.0,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2018
-ENGL,2140,13,American Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2140,2018
-ENGL,2140,14,American Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2140,2018
-ENGL,2140,15,American Literature,0.7,0.11,0.07,0.0,0.04,0.0,0.0,0.07,erin nicholson gale,ENGL-2140,2018
-ENGL,2140,16,American Literature,0.7,0.2,0.03,0.07,0.0,0.0,0.0,0.0,erin nicholson gale,ENGL-2140,2018
-ENGL,2140,17,American Literature,0.4,0.33,0.17,0.03,0.07,0.0,0.0,0.0,hannah pittma godwin,ENGL-2140,2018
-ENGL,2140,18,American Literature,0.37,0.4,0.1,0.0,0.07,0.0,0.0,0.07,hannah pittma godwin,ENGL-2140,2018
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.21,0.48,0.17,0.03,0.1,0.0,0.0,0.0,chelsea marie clarey,ENGL-2150,2018
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.2,0.43,0.27,0.0,0.07,0.0,0.0,0.03,chelsea marie clarey,ENGL-2150,2018
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.31,0.34,0.21,0.07,0.07,0.0,0.0,0.0,chelsea marie clarey,ENGL-2150,2018
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.34,0.28,0.24,0.0,0.07,0.0,0.0,0.07,chelsea marie clarey,ENGL-2150,2018
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.46,0.32,0.11,0.0,0.0,0.0,0.0,0.11,david charles foltz,ENGL-2150,2018
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.41,0.41,0.1,0.0,0.0,0.0,0.0,0.07,david charles foltz,ENGL-2150,2018
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.67,0.27,0.0,0.0,0.03,0.0,0.0,0.03,remley meliss makala,ENGL-2150,2018
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.47,0.33,0.07,0.0,0.0,0.0,0.0,0.13,remley meliss makala,ENGL-2150,2018
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.23,0.17,0.03,0.0,0.0,0.0,0.03,john logan pursley,ENGL-2150,2018
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.37,0.33,0.17,0.07,0.0,0.0,0.0,0.07,elizabeth stansell,ENGL-2150,2018
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.73,0.1,0.1,0.0,0.0,0.0,0.0,0.07,jennifer ha forsberg,ENGL-2150,2018
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,ENGL-2150,2018
-ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.2,0.7,0.07,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,ENGL-2150,2018
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.26,0.67,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2150,2018
-ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.4,0.3,0.17,0.07,0.03,0.0,0.0,0.03,andrew mathas,ENGL-2150,2018
-ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.63,0.2,0.07,0.0,0.07,0.0,0.0,0.03,andrew mathas,ENGL-2150,2018
-ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.57,0.18,0.14,0.0,0.04,0.0,0.0,0.07,candace wiley,ENGL-2150,2018
-ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.73,0.04,0.04,0.0,0.0,0.0,0.0,0.19,candace wiley,ENGL-2150,2018
-ENGL,3010,1,Great Books of Western World,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-3010,2018
-ENGL,3040,1,Business Writing,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,sean williams,ENGL-3040,2018
-ENGL,3040,2,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,ENGL-3040,2018
-ENGL,3040,3,Business Writing,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,ENGL-3040,2018
-ENGL,3040,4,Business Writing,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulon green,ENGL-3040,2018
-ENGL,3040,5,Business Writing,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulon green,ENGL-3040,2018
-ENGL,3040,6,Business Writing,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,la'cresha ulon green,ENGL-3040,2018
-ENGL,3040,7,Business Writing,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,ENGL-3040,2018
-ENGL,3040,8,Business Writing,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,ENGL-3040,2018
-ENGL,3040,9,Business Writing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3040,2018
-ENGL,3040,10,Business Writing,0.48,0.38,0.05,0.0,0.1,0.0,0.0,0.0,katalin beck,ENGL-3040,2018
-ENGL,3040,12,Business Writing,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,stephen quigley,ENGL-3040,2018
-ENGL,3040,400,Business Writing,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,ENGL-3040,2018
-ENGL,3040,401,Business Writing,0.5,0.35,0.15,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,ENGL-3040,2018
-ENGL,3040,402,Business Writing,0.63,0.16,0.11,0.05,0.0,0.0,0.0,0.05,kriste aldebol-hazle,ENGL-3040,2018
-ENGL,3040,403,Business Writing,0.6,0.25,0.05,0.05,0.05,0.0,0.0,0.0,kriste aldebol-hazle,ENGL-3040,2018
-ENGL,3100,1,Crit Writ Lit,0.25,0.44,0.31,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-3100,2018
-ENGL,3100,2,Crit Writ Lit,0.24,0.47,0.18,0.06,0.06,0.0,0.0,0.0,lee morrissey,ENGL-3100,2018
-ENGL,3100,3,Crit Writ Lit,0.33,0.38,0.14,0.0,0.05,0.0,0.0,0.1,dominic mastroianni,ENGL-3100,2018
-ENGL,3100,4,Crit Writ Lit,0.4,0.45,0.1,0.0,0.0,0.0,0.0,0.05,erin marina goss,ENGL-3100,2018
-ENGL,3120,1,Advanced Composition,0.38,0.57,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,ENGL-3120,2018
-ENGL,3120,2,Advanced Composition,0.57,0.38,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth stansell,ENGL-3120,2018
-ENGL,3140,1,Technical Writing,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2018
-ENGL,3140,2,Technical Writing,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-3140,2018
-ENGL,3140,3,Technical Writing,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,eric stephens,ENGL-3140,2018
-ENGL,3140,4,Technical Writing,0.81,0.14,0.0,0.05,0.0,0.0,0.0,0.0,eric stephens,ENGL-3140,2018
-ENGL,3140,5,Technical Writing,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,heather pri williams,ENGL-3140,2018
-ENGL,3140,9,Technical Writing,0.57,0.33,0.0,0.05,0.05,0.0,0.0,0.0,geveryl lee robinson,ENGL-3140,2018
-ENGL,3140,10,Technical Writing,0.38,0.57,0.0,0.0,0.0,0.0,0.0,0.05,geveryl lee robinson,ENGL-3140,2018
-ENGL,3140,11,Technical Writing,0.35,0.6,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2018
-ENGL,3140,12,Technical Writing,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,katalin beck,ENGL-3140,2018
-ENGL,3140,14,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,samuel jackso fuller,ENGL-3140,2018
-ENGL,3140,15,Technical Writing,0.71,0.19,0.05,0.05,0.0,0.0,0.0,0.0,brian lee gaines,ENGL-3140,2018
-ENGL,3140,16,Technical Writing,0.81,0.1,0.0,0.0,0.05,0.0,0.0,0.05,brian lee gaines,ENGL-3140,2018
-ENGL,3140,20,Technical Writing,0.71,0.14,0.1,0.05,0.0,0.0,0.0,0.0,sharon kathle nalley,ENGL-3140,2018
-ENGL,3140,21,Technical Writing,0.86,0.05,0.0,0.05,0.05,0.0,0.0,0.0,joshua wood,ENGL-3140,2018
-ENGL,3140,23,Technical Writing,0.52,0.19,0.14,0.05,0.0,0.0,0.0,0.1,heather pri williams,ENGL-3140,2018
-ENGL,3140,24,Technical Writing,0.05,0.24,0.19,0.1,0.19,0.0,0.0,0.24,geveryl lee robinson,ENGL-3140,2018
-ENGL,3140,400,Technical Writing,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,ENGL-3140,2018
-ENGL,3150,1,Scientific Writing & Comm,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,philip randall,ENGL-3150,2018
-ENGL,3150,2,Scientific Writing & Comm,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,ENGL-3150,2018
-ENGL,3150,3,Scientific Writing & Comm,0.38,0.48,0.1,0.05,0.0,0.0,0.0,0.0,william pulley,ENGL-3150,2018
-ENGL,3150,4,Scientific Writing & Comm,0.53,0.24,0.0,0.06,0.06,0.0,0.0,0.12,william pulley,ENGL-3150,2018
-ENGL,3150,400,Scientific Writing,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,ENGL-3150,2018
-ENGL,3150,401,Scientific Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2018
-ENGL,3150,402,Scientific Writing & Comm,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,john conway,ENGL-3150,2018
-ENGL,3150,404,Scientific Writing,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,philip randall,ENGL-3150,2018
-ENGL,3320,1,Visual Communication,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,megan eatman,ENGL-3320,2018
-ENGL,3450,1,Structure of Fiction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,john logan pursley,ENGL-3450,2018
-ENGL,3460,1,Structure of Poetry,0.5,0.38,0.06,0.0,0.0,0.0,0.0,0.06,jillian weise,ENGL-3460,2018
-ENGL,3480,1,Structure Screenplay,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,julia brownlee koets,ENGL-3480,2018
-ENGL,3480,2,Structure Screenplay,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,ENGL-3480,2018
-ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,matthew hooley,ENGL-3530,2018
-ENGL,3570,1,Film,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,john robert smith,ENGL-3570,2018
-ENGL,3570,2,Film,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,john robert smith,ENGL-3570,2018
-ENGL,3570,3,Film,0.62,0.33,0.0,0.0,0.05,0.0,0.0,0.0,john robert smith,ENGL-3570,2018
-ENGL,3860,1,Adolescent Lit,0.56,0.28,0.06,0.06,0.06,0.0,0.0,0.0,megan noe macalystre,ENGL-3860,2018
-ENGL,3970,1,Brit Lit Survey II,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,ENGL-3970,2018
-ENGL,3980,1,Amer Lit Survey I,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,kimberly manganelli,ENGL-3980,2018
-ENGL,3980,2,Amer Lit Survey I,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,susanna ashton,ENGL-3980,2018
-ENGL,4110,1,Shakespeare,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,brian mcgrath,ENGL-4110,2018
-ENGL,4110,3,Shakespeare,0.25,0.4,0.3,0.05,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-4110,2018
-ENGL,4160,1,Romantic Period,0.36,0.21,0.21,0.21,0.0,0.0,0.0,0.0,brian mcgrath,ENGL-4160,2018
-ENGL,4180,1,English Novel,0.42,0.37,0.11,0.0,0.11,0.0,0.0,0.0,david sweeney coombs,ENGL-4180,2018
-ENGL,4190,1,Post Col & World Lit,0.4,0.47,0.07,0.07,0.0,0.0,0.0,0.0,cameron fae bushnell,ENGL-4190,2018
-ENGL,4210,1,Amer Lit 1800-1899,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,dominic mastroianni,ENGL-4210,2018
-ENGL,4280,1,Contemporary Literature,0.53,0.16,0.26,0.0,0.05,0.0,0.0,0.0,william stockton,ENGL-4280,2018
-ENGL,4400,1,Literary Theory,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,maria selene bose,ENGL-4400,2018
-ENGL,4420,1,Cultural Studies,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,ENGL-4420,2018
-ENGL,4450,1,Fiction Workshop,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-4450,2018
-ENGL,4460,1,Poetry Workshop,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,jillian weise,ENGL-4460,2018
-ENGL,4510,1,Film Theory and Criticism,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,ENGL-4510,2018
-ENGL,4540,1,Sel Top in International Film,0.47,0.33,0.13,0.07,0.0,0.0,0.0,0.0,agnieszka skrodzka,ENGL-4540,2018
-ENGL,4590,1,Between Damaged Life/Arcades,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,michelle renee ty,ENGL-4590,2018
-ENGL,4640,1,Topics in Literature 1700-1899,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,erin marina goss,ENGL-4640,2018
-ENGL,4750,1,Writing for Media,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,gabriel ande hankins,ENGL-4750,2018
-ENGL,4850,1,Comp & Lang Teachers,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,calandra harri davis,ENGL-4850,2018
-ENGL,4890,1,Topics Write & Publ,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,tharon howard,ENGL-4890,2018
-ENGL,4920,1,Modern Rhetoric,0.59,0.24,0.06,0.06,0.0,0.0,0.0,0.06,michelle smith,ENGL-4920,2018
-ENGL,4960,1,Senior Seminar,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,angela naimou,ENGL-4960,2018
-ENGL,4960,2,Senior Seminar,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,michael lemahieu,ENGL-4960,2018
-ENGL,4960,3,Senior Seminar,0.69,0.08,0.0,0.23,0.0,0.0,0.0,0.0,michelle renee ty,ENGL-4960,2018
-ENGL,8850,1,Composition Theory,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,megan eatman,ENGL-8850,2018
-ENGR,1020,211,Engineering Discipl & Skills,0.08,0.29,0.25,0.13,0.17,0.0,0.0,0.08,ashley childers,ENGR-1020,2018
-ENGR,1020,212,Engineering Discipl & Skills,0.1,0.33,0.2,0.3,0.03,0.0,0.0,0.03,ashley childers,ENGR-1020,2018
-ENGR,1020,213,Engineering Discipl & Skills,0.28,0.28,0.16,0.13,0.06,0.0,0.0,0.09,irene marie ferrara,ENGR-1020,2018
-ENGR,1020,214,Engineering Discipl & Skills,0.38,0.23,0.19,0.04,0.15,0.0,0.0,0.0,irene marie ferrara,ENGR-1020,2018
-ENGR,1150,321,Engineering Design & Modeling,0.41,0.36,0.05,0.05,0.09,0.0,0.0,0.05,john minor,ENGR-1150,2018
-ENGR,1410,215,Programming & Problem Solving,0.3,0.43,0.09,0.04,0.04,0.0,0.0,0.11,jonathan broo harcum,ENGR-1410,2018
-ENGR,1410,322,Programming & Problem Solving,0.37,0.3,0.2,0.04,0.0,0.0,0.0,0.09,michael giebner,ENGR-1410,2018
-ENGR,1410,323,Programming & Problem Solving,0.2,0.43,0.15,0.13,0.0,0.0,0.0,0.09,michael giebner,ENGR-1410,2018
-ENGR,1410,324,Programming & Problem Solving,0.2,0.58,0.09,0.02,0.02,0.0,0.0,0.09,andrew isaac neptune,ENGR-1410,2018
-ENGR,1410,325,Programming & Problem Solving,0.38,0.38,0.15,0.02,0.0,0.0,0.0,0.08,andrew isaac neptune,ENGR-1410,2018
-ENGR,1410,326,Programming & Problem Solving,0.26,0.44,0.16,0.05,0.0,0.0,0.0,0.09,jonathan broo harcum,ENGR-1410,2018
-ENGR,1410,327,Programming & Problem Solving,0.22,0.5,0.2,0.02,0.02,0.0,0.0,0.04,irene marie ferrara,ENGR-1410,2018
-ENGR,1410,501,Programming & Problem Solving,0.21,0.29,0.32,0.18,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1410,2018
-ENGR,1410,621,Programming & Problem Solving,0.43,0.43,0.12,0.0,0.0,0.0,0.0,0.02,elizabeth an stephan,ENGR-1410,2018
-ENGR,1410,622,Programming & Problem Solving,0.26,0.55,0.14,0.0,0.0,0.0,0.0,0.05,jonathan broo harcum,ENGR-1410,2018
-ENGR,1410,623,Programming & Problem Solving,0.08,0.58,0.26,0.03,0.0,0.0,0.0,0.05,elizabeth an stephan,ENGR-1410,2018
-ENGR,1410,624,Programming & Problem Solving,0.3,0.53,0.02,0.07,0.02,0.0,0.0,0.05,sarah grigg,ENGR-1410,2018
-ENGR,1410,625,Programming & Problem Solving,0.3,0.41,0.2,0.07,0.02,0.0,0.0,0.0,matthew kent miller,ENGR-1410,2018
-ENGR,1410,626,Programming & Problem Solving,0.14,0.48,0.24,0.05,0.0,0.0,0.0,0.1,matthew kent miller,ENGR-1410,2018
-ENGR,1410,627,Programming & Problem Solving,0.29,0.48,0.19,0.05,0.0,0.0,0.0,0.0,matthew kent miller,ENGR-1410,2018
-ENGR,1410,821,Programming & Problem Solving,0.31,0.33,0.17,0.1,0.05,0.0,0.0,0.05,william martin,ENGR-1410,2018
-ENGR,1410,822,Programming & Problem Solving,0.33,0.45,0.14,0.02,0.02,0.0,0.0,0.02,william martin,ENGR-1410,2018
-ENGR,1410,823,Program & Prob Solving (HON),0.72,0.26,0.0,0.02,0.0,0.0,0.0,0.0,steven brandon,ENGR-1410,2018
-ENGR,1410,824,Program & Prob Solving (HON),0.65,0.24,0.08,0.0,0.0,0.0,0.0,0.03,steven brandon,ENGR-1410,2018
-ENGR,1410,825,Programming & Problem Solving,0.23,0.45,0.2,0.0,0.07,0.0,0.0,0.05,mariah so magagnotti,ENGR-1410,2018
-ENGR,1410,826,Programming & Problem Solving,0.24,0.33,0.29,0.04,0.04,0.0,0.0,0.04,mariah so magagnotti,ENGR-1410,2018
-ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.2,0.0,0.0,0.0,0.0,0.07,andrew isaac neptune,ENGR-1410,2018
-ENGR,1900,10,CI in Engr I (Robotics),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael benja wooten,ENGR-1900,2018
-ENGR,2080,284,Engr Graphics & Machine Design,0.56,0.21,0.15,0.04,0.0,0.0,0.0,0.04,jonathan maier,ENGR-2080,2018
-ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.25,0.08,0.0,0.06,0.0,0.0,0.04,anthony paul garland,ENGR-2080,2018
-ENGR,2080,286,Engr Graphics & Machine Design,0.4,0.25,0.13,0.06,0.06,0.0,0.0,0.1,anthony paul garland,ENGR-2080,2018
-ENGR,2080,382,Engr Graphics & Machine Design,0.6,0.25,0.04,0.02,0.08,0.0,0.0,0.02,nighat yasmin,ENGR-2080,2018
-ENGR,2080,384,Engr Graphics & Machine Design,0.54,0.21,0.08,0.06,0.12,0.0,0.0,0.0,jonathan maier,ENGR-2080,2018
-ENGR,2080,682,Engr Graphics & Machine Design,0.63,0.29,0.06,0.0,0.02,0.0,0.0,0.0,anthony paul garland,ENGR-2080,2018
-ENGR,2080,684,Engr Graphics & Machine Design,0.58,0.27,0.04,0.02,0.06,0.0,0.0,0.02,john minor,ENGR-2080,2018
-ENGR,2080,882,Engr Graphics & Machine Design,0.74,0.19,0.0,0.02,0.04,0.0,0.0,0.02,garrison lloy broome,ENGR-2080,2018
-ENGR,2080,884,Engr Graphics & Machine Design,0.49,0.31,0.1,0.02,0.04,0.0,0.0,0.04,garrison lloy broome,ENGR-2080,2018
-ENGR,2100,104,CAD & Engineering Applications,0.48,0.38,0.06,0.02,0.02,0.0,0.0,0.04,esfandabadi al shams,ENGR-2100,2018
-ENGR,2100,105,CAD & Engineering Applications,0.45,0.36,0.11,0.0,0.04,0.0,0.0,0.04,esfandabadi al shams,ENGR-2100,2018
-ENGR,2100,201,CAD & Engineering Applications,0.44,0.35,0.16,0.02,0.02,0.0,0.0,0.02,nighat yasmin,ENGR-2100,2018
-ENGR,2100,202,CAD & Engineering Applications,0.41,0.3,0.07,0.04,0.11,0.0,0.0,0.07,nighat yasmin,ENGR-2100,2018
-ENGR,2200,116,Evaluating Innovations,0.4,0.48,0.04,0.04,0.0,0.0,0.0,0.04,sarah grigg,ENGR-2200,2018
-ENGR,2200,117,Evaluating Innovations,0.32,0.48,0.13,0.03,0.0,0.0,0.0,0.03,sarah grigg,ENGR-2200,2018
-ENR,1020,1,Intro to Envir & Natur Res II,0.72,0.11,0.06,0.04,0.0,0.0,0.0,0.06,russell barrett,ENR-1020,2018
-ENR,3020,1,Nat Res Measurements,0.62,0.21,0.13,0.0,0.0,0.0,0.0,0.05,lawrence gering,ENR-3020,2018
-ENR,4130,2,Restoration Ecology,0.28,0.5,0.19,0.0,0.0,0.0,0.0,0.03,althea simone hagan,ENR-4130,2018
-ENR,4500,1,Conservation Issues,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,alan johnson,ENR-4500,2018
-ENR,4500,2,Conservation Issues,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,ENR-4500,2018
-ENR,6130,2,Restoration Ecology,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,althea simone hagan,ENR-6130,2018
-ENSP,2000,1,Intro Environ Sci,0.36,0.44,0.11,0.05,0.02,0.0,0.0,0.02,tom owino,ENSP-2000,2018
-ENSP,2000,2,Intro Environ Sci,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,ENSP-2000,2018
-ENSP,2000,3,Intro Environ Sci,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2018
-ENSP,2000,4,Intro Environ Sci,0.59,0.22,0.13,0.02,0.04,0.0,0.0,0.0,minory nammouz,ENSP-2000,2018
-ENSP,2010,1,Environm Sci for Educ Majors,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2010,2018
-ENSP,4000,1,Studies in Environmental Sci,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,margaret lo thompson,ENSP-4000,2018
-ENT,2000,1,Six-Legged Science,0.47,0.3,0.14,0.09,0.0,0.0,0.0,0.0,suellen pometto,ENT-2000,2018
-ENTR,1010,1,Entrepreneurial Mindset,0.72,0.11,0.07,0.01,0.05,0.0,0.0,0.04,john michael hannon,ENTR-1010,2018
-ENTR,1090,1,CI- How to Start a Startup,0.81,0.05,0.0,0.0,0.0,0.0,0.0,0.14,john michael hannon,ENTR-1090,2018
-ENTR,2010,3,Sports Entrepreneurship,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,ENTR-2010,2018
-ESED,1990,1,Creative Inq Engr & Sci Ed I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,claire louise dancz,ESED-1990,2018
-ESED,2990,1,Creative Inq Engr & Sci Ed II,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,claire louise dancz,ESED-2990,2018
-ESED,4910,5,Undergraduate Research,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,claire louise dancz,ESED-4910,2018
-ETOX,8300,1,Mechanistic Toxicology,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,ETOX-8300,2018
-FDSC,2140,1,Fd Resources & Soc,0.62,0.18,0.1,0.0,0.04,0.0,0.0,0.06,paul dawson,FDSC-2140,2018
-FDSC,2150,1,Culinary Fundamental,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,FDSC-2150,2018
-FDSC,3040,1,Eval Dairy Products,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,FDSC-3040,2018
-FDSC,4020,1,Food Chemistry II,0.32,0.49,0.12,0.07,0.0,0.0,0.0,0.0,feng chen,FDSC-4020,2018
-FDSC,4030,1,Food Ch & Analysis,0.74,0.13,0.11,0.0,0.0,0.0,0.0,0.02,paul dawson,FDSC-4030,2018
-FDSC,4080,1,Food Process Eng,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,felix barron,FDSC-4080,2018
-FDSC,4090,1,TQM for Food & Pckg Industries,0.61,0.18,0.06,0.09,0.0,0.0,0.0,0.06,john mcgregor,FDSC-4090,2018
-FDSC,4100,1,Food Product Dev,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,margaret condrasky,FDSC-4100,2018
-FDSC,4170,1,Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,FDSC-4170,2018
-FIN,2010,401,Intro to Personal Finance,0.92,0.06,0.0,0.0,0.02,0.0,0.0,0.0,joshua harris,FIN-2010,2018
-FIN,2010,402,Intro to Personal Finance,0.87,0.11,0.0,0.02,0.0,0.0,0.0,0.0,joshua harris,FIN-2010,2018
-FIN,2010,403,Intro to Personal Finance,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,joshua harris,FIN-2010,2018
-FIN,2010,404,Intro to Personal Finance,0.79,0.12,0.04,0.01,0.01,0.0,0.0,0.01,joshua harris,FIN-2010,2018
-FIN,2010,405,Intro to Personal Finance,0.75,0.15,0.06,0.0,0.02,0.0,0.0,0.02,joshua harris,FIN-2010,2018
-FIN,2010,406,Intro to Personal Finance,0.76,0.13,0.02,0.02,0.0,0.0,0.0,0.07,joshua harris,FIN-2010,2018
-FIN,3040,1,Risk & Insurance,0.22,0.3,0.48,0.0,0.0,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2018
-FIN,3050,1,Investment Analysis,0.11,0.36,0.39,0.04,0.04,0.0,0.0,0.07,kerri mcmillan,FIN-3050,2018
-FIN,3050,2,Investment Analysis,0.26,0.37,0.26,0.08,0.0,0.0,0.0,0.03,kerri mcmillan,FIN-3050,2018
-FIN,3050,3,Investment Analysis,0.15,0.33,0.48,0.0,0.03,0.0,0.0,0.0,kerri mcmillan,FIN-3050,2018
-FIN,3050,4,Investment Analysis,0.15,0.15,0.32,0.24,0.03,0.0,0.0,0.12,john alexander,FIN-3050,2018
-FIN,3060,1,Corporation Finance,0.2,0.14,0.2,0.2,0.2,0.0,0.0,0.08,william holl johnson,FIN-3060,2018
-FIN,3060,2,Corporation Finance,0.37,0.08,0.21,0.21,0.06,0.0,0.0,0.08,william holl johnson,FIN-3060,2018
-FIN,3060,3,Corporation Finance,0.37,0.2,0.1,0.12,0.12,0.0,0.0,0.08,william holl johnson,FIN-3060,2018
-FIN,3060,4,Corporation Finance,0.1,0.18,0.16,0.14,0.22,0.0,0.0,0.2,william holl johnson,FIN-3060,2018
-FIN,3060,5,Corporation Finance,0.06,0.28,0.3,0.24,0.06,0.0,0.0,0.06,ramon tolbe franklin,FIN-3060,2018
-FIN,3060,6,Corporation Finance,0.12,0.29,0.2,0.18,0.14,0.0,0.0,0.06,ramon tolbe franklin,FIN-3060,2018
-FIN,3060,7,Corporation Finance,0.31,0.24,0.28,0.11,0.04,0.0,0.0,0.02,ramon tolbe franklin,FIN-3060,2018
-FIN,3060,8,Corporation Finance,0.19,0.31,0.22,0.19,0.02,0.0,0.0,0.07,ramon tolbe franklin,FIN-3060,2018
-FIN,3070,1,Prin of Real Estate,0.23,0.43,0.26,0.06,0.03,0.0,0.0,0.0,yannan shen,FIN-3070,2018
-FIN,3070,2,Prin of Real Estate,0.23,0.46,0.23,0.06,0.03,0.0,0.0,0.0,yannan shen,FIN-3070,2018
-FIN,3070,3,Prin of Real Estate,0.23,0.26,0.28,0.15,0.05,0.0,0.0,0.03,thomas springer,FIN-3070,2018
-FIN,3080,1,Fin Inst & Mkts,0.16,0.46,0.24,0.05,0.05,0.0,0.0,0.03,daniel thomas greene,FIN-3080,2018
-FIN,3080,2,Fin Inst & Mkts,0.32,0.34,0.29,0.05,0.0,0.0,0.0,0.0,daniel thomas greene,FIN-3080,2018
-FIN,3080,3,Fin Inst & Mkts,0.32,0.29,0.24,0.11,0.05,0.0,0.0,0.0,daniel thomas greene,FIN-3080,2018
-FIN,3110,1,Financial Management I,0.21,0.33,0.18,0.05,0.0,0.0,0.0,0.23,george bran lockhart,FIN-3110,2018
-FIN,3110,2,Financial Management I,0.08,0.35,0.33,0.05,0.08,0.0,0.0,0.13,george bran lockhart,FIN-3110,2018
-FIN,3110,3,Financial Management I,0.18,0.33,0.23,0.0,0.13,0.0,0.0,0.15,george bran lockhart,FIN-3110,2018
-FIN,3110,4,Financial Management I,0.06,0.25,0.44,0.03,0.08,0.0,0.0,0.14,jack wolf,FIN-3110,2018
-FIN,3120,1,Financial Management II,0.24,0.38,0.24,0.08,0.0,0.0,0.0,0.05,blerina zykaj,FIN-3120,2018
-FIN,3120,2,Financial Management II,0.47,0.19,0.28,0.06,0.0,0.0,0.0,0.0,blerina zykaj,FIN-3120,2018
-FIN,3120,3,Financial Management II,0.18,0.41,0.23,0.08,0.03,0.0,0.0,0.08,weike xu,FIN-3120,2018
-FIN,3120,4,Financial Management II,0.14,0.34,0.29,0.11,0.03,0.0,0.0,0.09,weike xu,FIN-3120,2018
-FIN,4030,1,Spreadsheet Apps in Finance,0.23,0.51,0.26,0.0,0.0,0.0,0.0,0.0,vincent ja intintoli,FIN-4030,2018
-FIN,4030,2,Spreadsheet Apps in Finance,0.2,0.4,0.24,0.12,0.04,0.0,0.0,0.0,vincent ja intintoli,FIN-4030,2018
-FIN,4040,1,Financial Modeling,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,jack wolf,FIN-4040,2018
-FIN,4050,1,Portfolio Management & Theory,0.13,0.27,0.23,0.13,0.17,0.0,0.0,0.07,john alexander,FIN-4050,2018
-FIN,4080,1,Mgt of Fin Inst,0.33,0.57,0.1,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2018
-FIN,4080,2,Mgt of Fin Inst,0.19,0.44,0.31,0.06,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2018
-FIN,4090,1,Prof Fin Plan Capstone,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,FIN-4090,2018
-FIN,4110,1,Int Fin Mgt,0.27,0.55,0.12,0.06,0.0,0.0,0.0,0.0,luke asher devault,FIN-4110,2018
-FIN,4110,2,Int Fin Mgt,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,luke asher devault,FIN-4110,2018
-FIN,4150,1,Real Estate Investmt,0.24,0.29,0.33,0.14,0.0,0.0,0.0,0.0,thomas springer,FIN-4150,2018
-FIN,4160,1,Real Estate Val,0.31,0.31,0.31,0.0,0.06,0.0,0.0,0.0,valerie lynn hammett,FIN-4160,2018
-FNR,4700,35,Aquaponics,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,lance edward beecher,FNR-4700,2018
-FNR,4700,52,Stream & Reservoir Fish Eco I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,troy mason farmer,FNR-4700,2018
-FNR,4990,1,Natural Resources Seminar,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,susan talley guynn,FNR-4990,2018
-FNR,4990,2,Natural Resources Seminar,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,susan talley guynn,FNR-4990,2018
-FNR,4990,3,Natural Resources Seminar,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,susan talley guynn,FNR-4990,2018
-FOR,1010,1,Intro to Forestry,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,lawrence gering,FOR-1010,2018
-FOR,2060,1,Forestry Ecology,0.23,0.43,0.22,0.04,0.05,0.0,0.0,0.03,donald hagan,FOR-2060,2018
-FOR,3080,1,Remote Sensing in Forestry,0.43,0.47,0.1,0.0,0.0,0.0,0.0,0.0,lawrence gering,FOR-3080,2018
-FOR,4080,1,Wood and Paper Products,0.52,0.29,0.14,0.05,0.0,0.0,0.0,0.0,patricia layton,FOR-4080,2018
-FOR,4150,1,Forest Wildlife Managment,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james davis,FOR-4150,2018
-FOR,4180,1,Forest Resource Valuation,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,thomas straka,FOR-4180,2018
-FOR,4340,1,GIS for Natural Resources,0.28,0.58,0.1,0.03,0.0,0.0,0.0,0.03,robert fritz baldwin,FOR-4340,2018
-FOR,4650,1,Silviculture,0.12,0.54,0.31,0.04,0.0,0.0,0.0,0.0,gaofeng wang,FOR-4650,2018
-FOR,6340,1,GIS for Natural Resources,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert fritz baldwin,FOR-6340,2018
-FOR,8120,1,Fire Ecology and Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,gaofeng wang,FOR-8120,2018
-FR,1010,1,Elementary French,0.24,0.53,0.24,0.0,0.0,0.0,0.0,0.0, nedeo anne salces anne,FR-1010,2018
-FR,1010,2,Elementary French,0.41,0.12,0.29,0.0,0.06,0.0,0.0,0.12, nedeo anne salces anne,FR-1010,2018
-FR,1010,3,Elementary French,0.29,0.14,0.14,0.21,0.14,0.0,0.0,0.07,kenneth davi widgren,FR-1010,2018
-FR,1020,1,Elementary French,0.76,0.18,0.0,0.06,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,FR-1020,2018
-FR,1020,2,Elementary French,0.5,0.2,0.2,0.1,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,FR-1020,2018
-FR,2010,2,Intermediate French,0.8,0.16,0.0,0.0,0.04,0.0,0.0,0.0,amy lyn griff sawyer griff,FR-2010,2018
-FR,2010,3,Intermediate French,0.19,0.5,0.19,0.06,0.0,0.0,0.0,0.06,kenneth davi widgren,FR-2010,2018
-FR,2010,4,Intermediate French,0.22,0.33,0.33,0.0,0.0,0.0,0.0,0.11,kenneth davi widgren,FR-2010,2018
-FR,2020,1,Intermediate French,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,tholozany pauline de,FR-2020,2018
-FR,2020,2,Intermediate French,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,FR-2020,2018
-FR,2020,4,Intermediate French,0.06,0.82,0.12,0.0,0.0,0.0,0.0,0.0,kenneth davi widgren,FR-2020,2018
-FR,3050,1,Int Fr Con & Comp I,0.59,0.06,0.24,0.0,0.0,0.0,0.0,0.12, nedeo anne salces anne,FR-3050,2018
-FR,3160,1,Fr for Intl Trade,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,FR-3160,2018
-FR,3170,1,Contemp French Civ,0.76,0.18,0.0,0.06,0.0,0.0,0.0,0.0,joseph mai,FR-3170,2018
-FR,4760,1,French Feminism and Theory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,FR-4760,2018
-GC,1010,1,Orientation to G C,0.5,0.3,0.09,0.0,0.02,0.0,0.0,0.09,john leininger,GC-1010,2018
-GC,1020,1,Computer Art & CAD Foundations,0.46,0.33,0.1,0.04,0.02,0.0,0.0,0.06,carol jones,GC-1020,2018
-GC,1030,1,G C I for Pkgsc,0.26,0.55,0.18,0.0,0.0,0.0,0.0,0.0,john jacobs,GC-1030,2018
-GC,1040,1,Graphic Communications I,0.66,0.21,0.05,0.03,0.02,0.0,0.0,0.03,rebecca suzan edlein,GC-1040,2018
-GC,2070,1,Graphic Communications II,0.3,0.5,0.07,0.04,0.04,0.0,0.0,0.04,charles tabor weiss,GC-2070,2018
-GC,3400,1,Digital Imaging and eMedia,0.4,0.43,0.1,0.05,0.0,0.0,0.0,0.03,erica black walker,GC-3400,2018
-GC,3460,1,Ink and Substrates,0.17,0.61,0.15,0.0,0.04,0.0,0.0,0.02,liam henry 'hara,GC-3460,2018
-GC,4060,1,Package and Specialty Printing,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,kern cox,GC-4060,2018
-GC,4400,1,Commercial Printing,0.53,0.33,0.07,0.0,0.03,0.0,0.0,0.03,john leininger,GC-4400,2018
-GC,4440,1,Current Dev/Trends in Gr Comm,0.73,0.22,0.03,0.03,0.0,0.0,0.0,0.0,samuel ingram,GC-4440,2018
-GC,4480,1,Plan & Cont Printing Functions,0.83,0.09,0.09,0.0,0.0,0.0,0.0,0.0,nona woolbright,GC-4480,2018
-GC,4800,1,Senior Seminar in GC,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,charles edwar tonkin,GC-4800,2018
-GC,4900,2,G C Selected Topics-Sales,0.82,0.06,0.0,0.0,0.0,0.0,0.0,0.12,john leininger,GC-4900,2018
-GC,4900,3,Select Topic-Dig Media Design,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,erica black walker,GC-4900,2018
-GEN,3000,1,Fundamental Genetics,0.27,0.29,0.3,0.09,0.03,0.0,0.0,0.03,kate leanne wil tsai wil,GEN-3000,2018
-GEN,3000,2,Fundamental Genetics,0.23,0.41,0.22,0.07,0.01,0.0,0.0,0.05,kate leanne wil tsai wil,GEN-3000,2018
-GEN,3020,1,Molecular & General Genetics,0.36,0.41,0.11,0.05,0.0,0.0,0.0,0.07,rajandeep sin sekhon,GEN-3020,2018
-GEN,3040,1,Molecular Biology Laboratory,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-3040,2018
-GEN,3040,4,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-3040,2018
-GEN,4100,1,Population & Quant Genetics,0.38,0.43,0.15,0.02,0.02,0.0,0.0,0.0,scott michael tanner,GEN-4100,2018
-GEN,4110,3,Population & Quant Gen Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,GEN-4110,2018
-GEN,4400,1,Bioinformatics,0.53,0.35,0.06,0.0,0.06,0.0,0.0,0.0,liangjiang wang,GEN-4400,2018
-GEN,4700,1,Human Genetics,0.42,0.23,0.15,0.0,0.0,0.0,0.0,0.19,miriam kristi konkel,GEN-4700,2018
-GEN,4900,13,GB Professional Development,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,alison ni starr-moss,GEN-4900,2018
-GEN,4930,3,Senior Seminar,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,alison ni starr-moss,GEN-4930,2018
-GEN,8100,1,Princ of Molecular Biology,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,jennifer may mason,GEN-8100,2018
-GEOG,1010,1,Intro to Geography,0.34,0.37,0.14,0.09,0.0,0.0,0.0,0.06,christa smith,GEOG-1010,2018
-GEOG,1030,1,World Regional Geography,0.34,0.46,0.09,0.03,0.03,0.0,0.0,0.04,william church terry,GEOG-1030,2018
-GEOL,1010,1,Physical Geology,0.28,0.32,0.2,0.1,0.04,0.0,0.0,0.07,alan coulson,GEOL-1010,2018
-GEOL,1010,2,Physical Geology,0.57,0.19,0.1,0.06,0.04,0.0,0.0,0.04,alan coulson,GEOL-1010,2018
-GEOL,1010,3,Physical Geology,0.26,0.26,0.21,0.1,0.1,0.0,0.0,0.07,mary katherin fidler,GEOL-1010,2018
-GEOL,1030,1,Physical Geol Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,2,Physical Geol Lab,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,3,Physical Geol Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,4,Physical Geol Lab,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,5,Physical Geol Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,6,Physical Geol Lab,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2018
-GEOL,1030,7,Physical Geol Lab,0.48,0.43,0.0,0.0,0.0,0.0,0.0,0.09,alan coulson,GEOL-1030,2018
-GEOL,1030,8,Physical Geol Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,9,Physical Geol Lab,0.26,0.39,0.17,0.04,0.0,0.0,0.0,0.13,alan coulson,GEOL-1030,2018
-GEOL,1030,11,Physical Geol Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2018
-GEOL,1030,12,Physical Geol Lab,0.58,0.21,0.13,0.0,0.04,0.0,0.0,0.04,alan coulson,GEOL-1030,2018
-GEOL,1030,13,Physical Geol Lab,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,alan coulson,GEOL-1030,2018
-GEOL,1120,1,Earth Resources,0.42,0.33,0.17,0.04,0.04,0.0,0.0,0.0,mary katherin fidler,GEOL-1120,2018
-GEOL,1140,1,Earth Resources Lab,0.6,0.17,0.13,0.1,0.0,0.0,0.0,0.0,mary katherin fidler,GEOL-1140,2018
-GEOL,2020,1,Earth History,0.28,0.44,0.22,0.06,0.0,0.0,0.0,0.0,alan coulson,GEOL-2020,2018
-GEOL,3130,1,Sedimentology & Stratigraphy,0.26,0.35,0.39,0.0,0.0,0.0,0.0,0.0,mary katherin fidler,GEOL-3130,2018
-GEOL,3180,1,Introduction to Geochemistry,0.46,0.42,0.13,0.0,0.0,0.0,0.0,0.0,brian powell,GEOL-3180,2018
-GEOL,4210,1,Gis in Geology,0.74,0.15,0.07,0.04,0.0,0.0,0.0,0.0,scott brame,GEOL-4210,2018
-GEOL,7900,501,Biogeography & Geology of SC,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,GEOL-7900,2018
-GEOL,8030,1,Geostatistics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,stephen micha moysey,GEOL-8030,2018
-GEOL,8090,1,Subsurface Remed Mod,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,ronald falta,GEOL-8090,2018
-GEOL,8160,1,Aquifer Systems,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,GEOL-8160,2018
-GER,1010,1,Elementary German,0.11,0.26,0.26,0.05,0.16,0.0,0.0,0.16,isabel meusen,GER-1010,2018
-GER,1010,2,Elementary German,0.11,0.44,0.11,0.11,0.06,0.0,0.0,0.17,isabel meusen,GER-1010,2018
-GER,1020,1,Elementary German,0.31,0.38,0.25,0.0,0.06,0.0,0.0,0.0,oswald harris king,GER-1020,2018
-GER,2010,1,Intermediate German,0.26,0.21,0.42,0.0,0.11,0.0,0.0,0.0, lee ferrell,GER-2010,2018
-GER,2010,2,Intermediate German,0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,oswald harris king,GER-2010,2018
-GER,2020,1,Intermediate German,0.4,0.2,0.13,0.2,0.0,0.0,0.0,0.07,gabriela stoicea,GER-2020,2018
-GER,2020,2,Intermediate German,0.46,0.15,0.23,0.08,0.0,0.0,0.0,0.08,gabriela stoicea,GER-2020,2018
-GER,3060,1,German Short Story,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,oswald harris king,GER-3060,2018
-HCC,8810,1,Measurement & Eval,0.38,0.46,0.0,0.0,0.15,0.0,0.0,0.0,bart knijnenburg,HCC-8810,2018
-HCG,9050,1,"Genomics, Ethics & Hlth Policy",0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,HCG-9050,2018
-HIST,1010,1,History of the United States,0.53,0.32,0.12,0.0,0.03,0.0,0.0,0.0,james bradf jeffries,HIST-1010,2018
-HIST,1240,1,Environmental History Survey,0.16,0.55,0.21,0.0,0.05,0.0,0.0,0.03,james bradf jeffries,HIST-1240,2018
-HIST,1720,3,The West and the World I,0.26,0.53,0.18,0.0,0.03,0.0,0.0,0.0,thomas kuehn,HIST-1720,2018
-HIST,1730,1,The West and the World II,0.18,0.48,0.13,0.01,0.1,0.0,0.0,0.1, alan grubb,HIST-1730,2018
-HIST,1730,2,The West and the World II,0.18,0.42,0.27,0.04,0.06,0.0,0.0,0.03,michael meng,HIST-1730,2018
-HIST,1730,3,The West and the World II,0.39,0.37,0.16,0.04,0.02,0.0,0.0,0.03,steven marks,HIST-1730,2018
-HIST,2990,1,Historian's Craft,0.54,0.17,0.04,0.04,0.04,0.0,0.0,0.17,michael silvestri,HIST-2990,2018
-HIST,2990,2,Historian's Craft,0.83,0.09,0.0,0.0,0.04,0.0,0.0,0.04,rachel anne moore,HIST-2990,2018
-HIST,3110,1,African American Hist to 1877,0.41,0.33,0.19,0.0,0.0,0.0,0.0,0.07,abel bartley,HIST-3110,2018
-HIST,3230,1,Hist of Amer Tech,0.42,0.46,0.08,0.0,0.0,0.0,0.0,0.04,pamela mack,HIST-3230,2018
-HIST,3240,1,Hist of the South II,0.36,0.19,0.17,0.06,0.14,0.0,0.0,0.08,john andrew,HIST-3240,2018
-HIST,3250,1,Amer Econ Developmt,0.17,0.5,0.08,0.0,0.04,0.0,0.0,0.21,william camp,HIST-3250,2018
-HIST,3260,1,Hist Am Transport,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04, roger grant,HIST-3260,2018
-HIST,3420,1,South Am Since 1800,0.6,0.37,0.0,0.0,0.03,0.0,0.0,0.0,rachel anne moore,HIST-3420,2018
-HIST,3610,1,History of Britain to 1688,0.41,0.41,0.14,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,HIST-3610,2018
-HIST,3810,1,Germany 1918 to 1945,0.22,0.33,0.3,0.0,0.07,0.0,0.0,0.07,michael meng,HIST-3810,2018
-HIST,3900,1,Modern Military History,0.29,0.42,0.25,0.04,0.0,0.0,0.0,0.0,edwin moise,HIST-3900,2018
-HIST,3920,1,Hist U S Environment,0.27,0.5,0.13,0.03,0.03,0.0,0.0,0.03,william camp,HIST-3920,2018
-HIST,3970,1,Modern Middle East,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,amit bein,HIST-3970,2018
-HIST,3980,1,American Military History,0.2,0.43,0.17,0.07,0.07,0.0,0.0,0.07,john andrew,HIST-3980,2018
-HIST,4360,1,Vietnam Wars,0.12,0.53,0.24,0.0,0.12,0.0,0.0,0.0,edwin moise,HIST-4360,2018
-HIST,4600,1,Film and Empire,0.53,0.33,0.07,0.0,0.0,0.0,0.0,0.07,michael silvestri,HIST-4600,2018
-HIST,4930,1,The American City,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,abel bartley,HIST-4930,2018
-HIST,4940,1,Russian Film History,0.29,0.29,0.0,0.0,0.29,0.0,0.0,0.14,steven marks,HIST-4940,2018
-HLTH,2020,1,Introduction to Public Health,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2018
-HLTH,2020,2,Introduction to Public Health,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2020,2018
-HLTH,2020,400,Introduction to Public Health,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,ralph stewart welsh,HLTH-2020,2018
-HLTH,2020,401,Introduction to Public Health,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,ralph stewart welsh,HLTH-2020,2018
-HLTH,2030,1,Health Care Sys,0.52,0.34,0.14,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2018
-HLTH,2030,2,Health Care Sys,0.45,0.48,0.07,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2030,2018
-HLTH,2030,3,Health Care Sys,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,HLTH-2030,2018
-HLTH,2030,400,Health Care Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2018
-HLTH,2400,1,Deter of Hlth Behav,0.52,0.36,0.04,0.04,0.0,0.0,0.0,0.04,amelia clinkscales,HLTH-2400,2018
-HLTH,2400,2,Deter of Hlth Behav,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2018
-HLTH,2400,400,Deter of Hlth Behav,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2400,2018
-HLTH,2500,1,Health and Fitness,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.04,ralph stewart welsh,HLTH-2500,2018
-HLTH,2600,1,Medical Terminology & Comm,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,karen edwards,HLTH-2600,2018
-HLTH,2600,2,Medical Terminology & Comm,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,HLTH-2600,2018
-HLTH,2980,1,Human Health and Disease,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2018
-HLTH,2980,2,Human Health and Disease,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2018
-HLTH,3030,1,Public Health Comm,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,HLTH-3030,2018
-HLTH,3800,1,Epidemiology,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,hugh spitler,HLTH-3800,2018
-HLTH,3800,2,Epidemiology,0.56,0.28,0.16,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-3800,2018
-HLTH,3980,1,Health Appraisal Skills,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2018
-HLTH,3980,2,Health Appraisal Skills,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2018
-HLTH,4190,1,Health Sci Internship Prep Sem,0.7,0.23,0.08,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4190,2018
-HLTH,4200,1,Hlth Science Intern,0.79,0.18,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2018
-HLTH,4310,1,Public & Environ Hlt,0.54,0.33,0.1,0.0,0.0,0.0,0.0,0.03,deborah alma falta,HLTH-4310,2018
-HLTH,4700,1,Global Health,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,micky rogers ward,HLTH-4700,2018
-HLTH,4780,1,Health Policy Ethics and Law,0.44,0.19,0.25,0.0,0.13,0.0,0.0,0.0,hugh spitler,HLTH-4780,2018
-HLTH,4800,1,Comm Hlth Promotion,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,sarah griffin,HLTH-4800,2018
-HLTH,4900,1,Res Eval St Pub Hlth,0.55,0.25,0.1,0.05,0.0,0.0,0.0,0.05,karen kemper,HLTH-4900,2018
-HLTH,4900,2,Res Eval St Pub Hlth,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-4900,2018
-HLTH,4900,3,Res Eval St Pub Hlth,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-4900,2018
-HLTH,4970,5,Alcohol & Other Drugs CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,crystal burne fulmer,HLTH-4970,2018
-HLTH,8110,1,Health Care Delivery Systems,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,HLTH-8110,2018
-HLTH,8130,500,Population Health and Research,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,HLTH-8130,2018
-HLTH,8310,1,Quantitative Analy in Hlth I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,lu shi,HLTH-8310,2018
-HON,2020,1,Civil Discourse,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,HON-2020,2018
-HON,2050,2,Social Entrepreneurship,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,john michael hannon,HON-2050,2018
-HON,2060,1,Intro to Nanotechnology,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,HON-2060,2018
-HON,2100,1,Experiencing the Arts,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,mark spede,HON-2100,2018
-HON,2210,1,Literature and/as Resistance,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,gabriela stoicea,HON-2210,2018
-HON,2210,3,Adventure Novels in Context,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tholozany pauline de,HON-2210,2018
-HON,2210,4,Fascism/Anti-fascism Lit,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,gabriel ande hankins,HON-2210,2018
-HON,2210,5,American Science Fiction,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,HON-2210,2018
-HORT,2020,1,Adobe Digital Design,0.85,0.09,0.0,0.03,0.03,0.0,0.0,0.0,janice ann lay,HORT-2020,2018
-HORT,2110,1,Growing Spring Plnts,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,james emerson faust,HORT-2110,2018
-HORT,4000,1,Water for Agriculture,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,sarah white,HORT-4000,2018
-HORT,4040,1,Plant Propagation,0.18,0.29,0.41,0.12,0.0,0.0,0.0,0.0,jeffrey adelberg,HORT-4040,2018
-HORT,4090,1,Senior Capstone Course,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-4090,2018
-HORT,4200,1,Applied Turf Physiol,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,HORT-4200,2018
-HORT,4270,1,Urban Tree Care,0.06,0.25,0.56,0.13,0.0,0.0,0.0,0.0,robert polomski,HORT-4270,2018
-HORT,4330,1,Turf Weed Management,0.14,0.27,0.55,0.05,0.0,0.0,0.0,0.0,ted whitwell,HORT-4330,2018
-HORT,4610,1,Advanc Landscape Garden Design,0.92,0.0,0.08,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-4610,2018
-HORT,6040,1,Plant Propagation,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jeffrey adelberg,HORT-6040,2018
-HRD,8470,400,Instru System Design,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,angela daniel carter,HRD-8470,2018
-HRD,8490,400,Eval of T&D/Hrd Prog,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,angela daniel carter,HRD-8490,2018
-HRD,8800,400,Research Concepts,0.76,0.15,0.03,0.0,0.0,0.0,0.0,0.06,kristin kelly frady,HRD-8800,2018
-IE,2100,1,Des Analysis Wrk Sys,0.44,0.42,0.07,0.05,0.0,0.0,0.0,0.02,sara lu riggs,IE-2100,2018
-IE,3010,1,Systems Design I,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,xiaoxia li,IE-3010,2018
-IE,3600,1,Industrial Apps of Prob/Stat I,0.39,0.34,0.12,0.08,0.05,0.0,0.0,0.03,mary elizabeth kurz,IE-3600,2018
-IE,3610,1,Industrial App of Prob/Stat II,0.3,0.34,0.27,0.06,0.02,0.0,0.0,0.02,david neyens,IE-3610,2018
-IE,3800,1,Deterministic Operations Rsrch,0.27,0.39,0.17,0.1,0.02,0.0,0.0,0.05,ceyda yaba,IE-3800,2018
-IE,3810,1,Probabilistic Operations Rsrch,0.31,0.21,0.29,0.13,0.02,0.0,0.0,0.05,robert james riggs,IE-3810,2018
-IE,3840,1,Engr Econ Analysis,0.19,0.19,0.15,0.1,0.09,0.0,0.0,0.29,brian melloy,IE-3840,2018
-IE,3860,1,Production Planning & Control,0.36,0.23,0.28,0.09,0.04,0.0,0.0,0.0,kevin taaffe,IE-3860,2018
-IE,4400,1,Decision Support Sys,0.48,0.32,0.13,0.05,0.03,0.0,0.0,0.0,mary elizabeth kurz,IE-4400,2018
-IE,4570,1,Transp/Logistic Engr,0.33,0.47,0.16,0.05,0.0,0.0,0.0,0.0,sandra duni eksioglu,IE-4570,2018
-IE,4610,1,Quality Engineering,0.26,0.42,0.14,0.14,0.01,0.0,0.0,0.03,byung rae cho,IE-4610,2018
-IE,4620,1,Six Sigma Quality,0.38,0.42,0.19,0.01,0.0,0.0,0.0,0.0,robert james riggs,IE-4620,2018
-IE,4650,1,Facilities Planning & Design,0.9,0.09,0.0,0.01,0.0,0.0,0.0,0.0,xiaoxia li,IE-4650,2018
-IE,4670,1,System Design II,0.53,0.37,0.1,0.0,0.0,0.0,0.0,0.0,jeffery messer,IE-4670,2018
-IE,4670,2,System Design II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,IE-4670,2018
-IE,4820,1,Systems Modeling,0.32,0.33,0.21,0.08,0.05,0.0,0.0,0.02,tugce isik,IE-4820,2018
-IE,4880,1,Human Factors Eng,0.23,0.57,0.19,0.01,0.0,0.0,0.0,0.0,madathil kapi chalil,IE-4880,2018
-IE,4910,100,Applied Probabilistic OR,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,brian melloy,IE-4910,2018
-IE,6570,1,Transp/Logistic Engr,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,sandra duni eksioglu,IE-6570,2018
-IE,6620,1,Six Sigma Quality,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,IE-6620,2018
-IE,8050,1,Found Qual Engr,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,byung rae cho,IE-8050,2018
-IE,8520,1,Prescriptive Analytics,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,IE-8520,2018
-IE,8540,1,SC & Logistics Modeling I,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,william ferrell,IE-8540,2018
-IE,8580,1,Case Study Supply Chn & Logist,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,scott jennings mason,IE-8580,2018
-IE,8800,1,Adv Meth of Or,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,amin khademi,IE-8800,2018
-IE,8930,1,Rsrch Method-Human Interaction,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,laura michel stanley,IE-8930,2018
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,lisa marie robinson,INT-1510,2018
-INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,caren kelley-hall,INT-1520,2018
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.85,0.15,0.0,caren kelley-hall,INT-1530,2018
-INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,caren kelley-hall,INT-1540,2018
-INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,lisa marie robinson,INT-2510,2018
-INT,2530,1,UPIC Internship FT 3,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,INT-2530,2018
-IPM,4010,1,Principles of I P M,0.57,0.29,0.07,0.07,0.0,0.0,0.0,0.0,carmen blubaugh,IPM-4010,2018
-IPM,6010,1,Principles of I P M,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,carmen blubaugh,IPM-6010,2018
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.83,0.16,0.01,meredith fant wilson,IS-1010,2018
-ITAL,1010,1,Elementary Italian,0.47,0.18,0.12,0.0,0.06,0.0,0.0,0.18,lyudmyla tsykalova,ITAL-1010,2018
-ITAL,1020,1,Elementary Italian,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,ITAL-1020,2018
-ITAL,1020,2,Elementary Italian,0.39,0.5,0.0,0.06,0.06,0.0,0.0,0.0,julia schmidt,ITAL-1020,2018
-ITAL,1020,3,Elementary Italian,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,julia schmidt,ITAL-1020,2018
-ITAL,2010,1,Intermediate Italian,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-2010,2018
-ITAL,2020,2,Intermediate Italian,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-2020,2018
-JAPN,1010,1,Elementary Japanese,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,saori suto,JAPN-1010,2018
-JAPN,1010,2,Elementary Japanese,0.2,0.13,0.27,0.13,0.0,0.0,0.0,0.27,saori suto,JAPN-1010,2018
-JAPN,1020,2,Elementary Japanese,0.18,0.36,0.45,0.0,0.0,0.0,0.0,0.0,satomi saito,JAPN-1020,2018
-JAPN,2010,1,Intermed Japanese,0.58,0.17,0.08,0.0,0.08,0.0,0.0,0.08,saori suto,JAPN-2010,2018
-JAPN,2020,1,Intermed Japanese,0.5,0.14,0.21,0.14,0.0,0.0,0.0,0.0,saori suto,JAPN-2020,2018
-JAPN,4160,1,Japanese for Int'l Trade II,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jae allegra takeuchi,JAPN-4160,2018
-JUST,2880,1,The Criminal Justice System,0.29,0.39,0.3,0.02,0.0,0.0,0.0,0.0,margaret tina britz,JUST-2880,2018
-JUST,4940,1,Organized Crime,0.52,0.29,0.13,0.02,0.04,0.0,0.0,0.0,margaret tina britz,JUST-4940,2018
-LANG,2540,1,Introduction to World Cinemas,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,raquel anido,LANG-2540,2018
-LANG,3000,1,Intro Linguistics,0.58,0.16,0.16,0.0,0.0,0.0,0.0,0.11,jae allegra takeuchi,LANG-3000,2018
-LANG,4620,1,Borders,0.46,0.31,0.0,0.0,0.15,0.0,0.0,0.08,tiffany dawn miller,LANG-4620,2018
-LARC,1160,1,History of Landscape Arch,0.65,0.28,0.03,0.01,0.01,0.0,0.0,0.01,hala fouad nassar,LARC-1160,2018
-LARC,1160,2,History of Landscape Arch,0.17,0.39,0.26,0.13,0.04,0.0,0.0,0.0,hala fouad nassar,LARC-1160,2018
-LARC,1520,1,Basic Design II,0.57,0.3,0.04,0.0,0.09,0.0,0.0,0.0,jessica fernandez,LARC-1520,2018
-LARC,2550,1,Community Design Studio,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,matthew neal powers,LARC-2550,2018
-LARC,3620,1,Design Impl II,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,robert hewitt,LARC-3620,2018
-LARC,3620,2,Design Impl II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,LARC-3620,2018
-LARC,4280,1,Computer-Aided Design,0.55,0.14,0.14,0.05,0.09,0.0,0.0,0.05,jessica fernandez,LARC-4280,2018
-LARC,6810,1,Professional Practice,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,david lycke,LARC-6810,2018
-LARC,8020,1,Orientation II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,paul russell,LARC-8020,2018
-LARC,8300,1,Graduate Seminar I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,thomas willi schurch,LARC-8300,2018
-LAW,3220,1,Legal Env of Bus,0.13,0.22,0.42,0.22,0.0,0.0,0.0,0.0,kenneth sc toussaint,LAW-3220,2018
-LAW,3220,2,Legal Env of Bus,0.28,0.43,0.22,0.02,0.02,0.0,0.0,0.02,edward ray claggett,LAW-3220,2018
-LAW,3220,3,Legal Env of Bus,0.26,0.37,0.26,0.09,0.0,0.0,0.0,0.02,kenneth sc toussaint,LAW-3220,2018
-LAW,3220,4,Legal Env of Bus,0.23,0.36,0.34,0.05,0.02,0.0,0.0,0.0,kenneth sc toussaint,LAW-3220,2018
-LAW,3220,5,Legal Env of Bus,0.11,0.59,0.25,0.05,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2018
-LAW,3220,6,Legal Env of Bus,0.22,0.4,0.38,0.0,0.0,0.0,0.0,0.0,judson jahn,LAW-3220,2018
-LAW,3220,7,Legal Env of Bus,0.69,0.29,0.03,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2018
-LAW,3220,8,Legal Env of Bus,0.11,0.3,0.52,0.05,0.02,0.0,0.0,0.0,kenneth sc toussaint,LAW-3220,2018
-LAW,3220,9,Legal Env of Bus,0.82,0.16,0.0,0.0,0.0,0.0,0.0,0.02,frances edwards,LAW-3220,2018
-LAW,3220,10,Legal Env of Bus,0.28,0.47,0.16,0.05,0.0,0.0,0.0,0.05,john hine,LAW-3220,2018
-LAW,3220,11,Legal Env of Bus,0.11,0.4,0.29,0.11,0.07,0.0,0.0,0.02,john hine,LAW-3220,2018
-LAW,3220,401,Legal Env of Bus,0.44,0.32,0.16,0.05,0.0,0.0,0.0,0.04,virginia ward-vaughn,LAW-3220,2018
-LAW,3220,402,Legal Env of Bus,0.25,0.31,0.25,0.05,0.07,0.0,0.0,0.07,virginia ward-vaughn,LAW-3220,2018
-LAW,3220,403,Legal Env of Bus,0.33,0.44,0.18,0.0,0.02,0.0,0.0,0.04,virginia ward-vaughn,LAW-3220,2018
-LAW,3220,404,Legal Env of Bus,0.22,0.39,0.24,0.06,0.04,0.0,0.0,0.06,virginia ward-vaughn,LAW-3220,2018
-LAW,3330,1,Real Estate Law,0.14,0.67,0.14,0.02,0.02,0.0,0.0,0.0,judson jahn,LAW-3330,2018
-LAW,4200,1,Int Business Law,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-4200,2018
-LAW,8480,1,Law Real Estate Prof,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,james ivey warren,LAW-8480,2018
-LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.88,0.04,0.08, lee ferrell,LIT-1270,2018
-LS,1000,4,Introduction to Barre,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,lauren elizab george,LS-1000,2018
-LS,1000,8,Intro to Salsa Dance,0.54,0.23,0.0,0.0,0.23,0.0,0.0,0.0,malik lewis  baxter c,LS-1000,2018
-LS,1000,9,Intro to Salsa Dance,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,malik lewis  baxter c,LS-1000,2018
-LS,1000,10,Intro to Salsa Dance,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,malik lewis  baxter c,LS-1000,2018
-LS,1000,20,Intro to Volleyball,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,kelly lynn ator,LS-1000,2018
-LS,1000,23,Therapeutic Yoga,0.77,0.09,0.0,0.0,0.0,0.0,0.0,0.14,renee warren gahan,LS-1000,2018
-LS,1330,2,Women's Shotgun,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,bonnie duke gill,LS-1330,2018
-LS,1350,1,Women's Riflery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,hubert cox,LS-1350,2018
-LS,1410,1,Top Rope Climbing,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,michelle tuday,LS-1410,2018
-LS,1410,3,Top Rope Climbing,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,michelle tuday,LS-1410,2018
-LS,1560,12,Riflery,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,herbert strickland,LS-1560,2018
-LS,1570,7,Shotgun Sports,0.7,0.2,0.0,0.1,0.0,0.0,0.0,0.0,john jeffrey price,LS-1570,2018
-LS,1570,10,Shotgun Sports,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,audrey carolin couch,LS-1570,2018
-LS,1580,1,Archery,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,LS-1580,2018
-LS,1580,2,Archery,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,herbert strickland,LS-1580,2018
-LS,1580,3,Archery,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,herbert strickland,LS-1580,2018
-LS,1640,2,Whitewater Kayaking,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,robert taylor,LS-1640,2018
-LS,1750,1,Fly Fishing,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james michae harvell,LS-1750,2018
-LS,1750,2,Fly Fishing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,michael watts,LS-1750,2018
-LS,1850,2,Bowling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,LS-1850,2018
-LS,1850,3,Bowling,0.87,0.07,0.0,0.0,0.03,0.0,0.0,0.03,tyler bennett,LS-1850,2018
-LS,1850,4,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,alexandra sandoval,LS-1850,2018
-LS,1850,8,Bowling,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,LS-1850,2018
-LS,1940,3,Racquetball,0.71,0.07,0.0,0.0,0.07,0.0,0.0,0.14,charlie white,LS-1940,2018
-LS,1980,2,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,jason jordan,LS-1980,2018
-LS,2270,1,Intro to Swing Dance,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,LS-2270,2018
-LS,2320,1,Core Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,diane moreno,LS-2320,2018
-LS,2320,2,Core Training,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,LS-2320,2018
-LS,2320,3,Core Training,0.76,0.1,0.0,0.0,0.0,0.0,0.0,0.14,diane moreno,LS-2320,2018
-LS,2320,5,Core Training,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,LS-2320,2018
-LS,2350,3,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,silica elizab larkin,LS-2350,2018
-LS,2350,5,Basic Yoga,0.73,0.18,0.0,0.0,0.05,0.0,0.0,0.05,renee warren gahan,LS-2350,2018
-LS,2360,2,Power/Ashtanga Yoga,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,silica elizab larkin,LS-2360,2018
-LS,2380,2,Vinyasa Flow Yoga,0.69,0.0,0.0,0.0,0.15,0.0,0.0,0.15,nicole eliz martinez,LS-2380,2018
-LS,2380,3,Vinyasa Flow Yoga,0.71,0.19,0.0,0.0,0.0,0.0,0.0,0.1,kayla lee wardlaw,LS-2380,2018
-LS,2380,4,Vinyasa Flow Yoga,0.75,0.1,0.0,0.0,0.0,0.0,0.0,0.15,kayla lee wardlaw,LS-2380,2018
-LS,2420,1,Meditation and Relax,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2420,2018
-LS,2420,2,Meditation and Relax,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2420,2018
-LS,2420,3,Meditation and Relax,0.64,0.09,0.18,0.05,0.0,0.0,0.0,0.05,renee warren gahan,LS-2420,2018
-LS,2420,4,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2018
-LS,2420,5,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,LS-2420,2018
-LS,2450,2,Pilates,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,melanie ivey job,LS-2450,2018
-LS,2460,2,Intermediate Pilates,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,LS-2460,2018
-LS,2510,2,Running & Jogging,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,corey doug brookover,LS-2510,2018
-MATH,1010,1,Essen Math for Informed Soc,0.31,0.42,0.19,0.0,0.0,0.0,0.0,0.08,ebenezer eduafo,MATH-1010,2018
-MATH,1010,2,Essen Math for Informed Soc,0.2,0.31,0.17,0.14,0.11,0.0,0.0,0.06,bryce pruitt,MATH-1010,2018
-MATH,1010,3,Essen Math for Informed Soc,0.43,0.09,0.2,0.11,0.14,0.0,0.0,0.03,jun yuan,MATH-1010,2018
-MATH,1010,4,Essen Math for Informed Soc,0.36,0.27,0.24,0.03,0.06,0.0,0.0,0.03,marilyn reba,MATH-1010,2018
-MATH,1020,1,Business Calculus I,0.19,0.28,0.17,0.13,0.13,0.0,0.0,0.11,randy davidson,MATH-1020,2018
-MATH,1020,2,Business Calculus I,0.21,0.22,0.27,0.12,0.13,0.0,0.0,0.05,randy davidson,MATH-1020,2018
-MATH,1020,3,Business Calculus I,0.09,0.26,0.24,0.26,0.07,0.0,0.0,0.09,michael thomas cowen,MATH-1020,2018
-MATH,1020,5,Business Calculus I,0.19,0.33,0.21,0.12,0.07,0.0,0.0,0.07,anna carol bachstein,MATH-1020,2018
-MATH,1020,6,Business Calculus I,0.15,0.18,0.43,0.05,0.13,0.0,0.0,0.08,rachel bass lanning,MATH-1020,2018
-MATH,1020,7,Business Calculus I,0.21,0.21,0.33,0.14,0.07,0.0,0.0,0.02,tony thanh nguyen,MATH-1020,2018
-MATH,1020,9,Business Calculus I,0.19,0.17,0.3,0.11,0.19,0.0,0.0,0.03,randy davidson,MATH-1020,2018
-MATH,1020,11,Business Calculus I,0.2,0.32,0.27,0.07,0.1,0.0,0.0,0.05,li he,MATH-1020,2018
-MATH,1020,12,Business Calculus I,0.2,0.22,0.24,0.12,0.17,0.0,0.0,0.05,tony thanh nguyen,MATH-1020,2018
-MATH,1020,13,Business Calculus I,0.26,0.32,0.22,0.1,0.09,0.0,0.0,0.01,marion hanna,MATH-1020,2018
-MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.44,0.19,andrew walton green,MATH-1040,2018
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.5,0.13,nicholas ahlstrom,MATH-1040,2018
-MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.65,0.03,peter westerbaan,MATH-1040,2018
-MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.55,0.41,0.03,tony thanh nguyen,MATH-1050,2018
-MATH,1060,1,Calculus of One Variable I,0.1,0.13,0.18,0.09,0.33,0.0,0.0,0.17,judith el cottingham,MATH-1060,2018
-MATH,1060,2,Calculus of One Variable I,0.06,0.14,0.34,0.0,0.37,0.0,0.0,0.09,kayla doris javier,MATH-1060,2018
-MATH,1060,3,Calculus of One Variable I,0.05,0.05,0.27,0.15,0.34,0.0,0.0,0.15,xueheng shi,MATH-1060,2018
-MATH,1060,4,Calculus of One Variable I,0.05,0.2,0.2,0.03,0.4,0.0,0.0,0.13,thanh thien to,MATH-1060,2018
-MATH,1060,5,Calculus of One Variable I,0.0,0.06,0.25,0.09,0.5,0.0,0.0,0.09,michael gle eldredge,MATH-1060,2018
-MATH,1060,500,Calculus of One Variable I,0.3,0.3,0.3,0.1,0.0,0.0,0.0,0.0,laura dostert,MATH-1060,2018
-MATH,1070,1,Differen and Integral Calculus,0.13,0.46,0.33,0.04,0.0,0.0,0.0,0.04,donna simms,MATH-1070,2018
-MATH,1070,2,Differen and Integral Calculus,0.28,0.22,0.25,0.13,0.03,0.0,0.0,0.09,donna simms,MATH-1070,2018
-MATH,1070,3,Differen and Integral Calculus,0.11,0.45,0.27,0.11,0.02,0.0,0.0,0.02,stephen peele,MATH-1070,2018
-MATH,1070,4,Differen and Integral Calculus,0.1,0.47,0.27,0.1,0.0,0.0,0.0,0.07,stephen peele,MATH-1070,2018
-MATH,1070,5,Differen and Integral Calculus,0.24,0.3,0.27,0.15,0.03,0.0,0.0,0.0,xiaoyuan liu,MATH-1070,2018
-MATH,1070,6,Differen and Integral Calculus,0.18,0.43,0.23,0.09,0.02,0.0,0.0,0.05,stephen peele,MATH-1070,2018
-MATH,1080,1,Calculus of One Variable II,0.08,0.26,0.16,0.16,0.24,0.0,0.0,0.11,thowhida akther,MATH-1080,2018
-MATH,1080,2,Calculus of One Variable II,0.09,0.17,0.17,0.11,0.29,0.0,0.0,0.17,rui gong,MATH-1080,2018
-MATH,1080,3,Calculus of One Variable II,0.2,0.3,0.18,0.16,0.11,0.0,0.0,0.05,charles lanning,MATH-1080,2018
-MATH,1080,4,Calculus of One Variable II,0.33,0.31,0.11,0.02,0.11,0.0,0.0,0.11,camille zerfas,MATH-1080,2018
-MATH,1080,5,Calculus of One Variable II,0.24,0.3,0.14,0.08,0.16,0.0,0.0,0.08,fun choi john chan john,MATH-1080,2018
-MATH,1080,6,Calculus of One Variable II,0.25,0.16,0.27,0.14,0.14,0.0,0.0,0.05,garrett mi dranichak,MATH-1080,2018
-MATH,1080,7,Calculus of One Variable II,0.16,0.28,0.28,0.05,0.16,0.0,0.0,0.07,pye phyo aung,MATH-1080,2018
-MATH,1080,8,Calculus of One Variable II,0.1,0.28,0.15,0.13,0.15,0.0,0.0,0.18,rebecca ramos,MATH-1080,2018
-MATH,1080,9,Calculus of One Variable II,0.36,0.33,0.13,0.09,0.04,0.0,0.0,0.04,meredith nicole burr,MATH-1080,2018
-MATH,1080,10,Calculus of One Variable II,0.38,0.31,0.18,0.09,0.04,0.0,0.0,0.0,meredith nicole burr,MATH-1080,2018
-MATH,1080,11,Calculus of One Variable II,0.07,0.34,0.3,0.0,0.16,0.0,0.0,0.14,pye phyo aung,MATH-1080,2018
-MATH,1080,100,Calc of One Variable II (HON),0.42,0.32,0.05,0.0,0.0,0.0,0.0,0.21,beth novick,MATH-1080,2018
-MATH,1080,201,Calculus of One Variable II,0.1,0.29,0.33,0.0,0.14,0.0,0.0,0.14,sanwar ahmad,MATH-1080,2018
-MATH,1080,202,Calculus of One Variable II,0.28,0.33,0.25,0.08,0.03,0.0,0.0,0.05,sergey charnyi,MATH-1080,2018
-MATH,1080,203,Calc of One Variable II,0.17,0.38,0.25,0.04,0.08,0.0,0.0,0.08,amy christine grady,MATH-1080,2018
-MATH,1080,204,Calculus of One Variable II,0.21,0.36,0.21,0.08,0.13,0.0,0.0,0.03,beth novick,MATH-1080,2018
-MATH,1080,205,Calc of One Variable II,0.28,0.35,0.18,0.18,0.0,0.0,0.0,0.03,huixi li,MATH-1080,2018
-MATH,1080,206,Calc of One Variable II,0.21,0.36,0.23,0.15,0.04,0.0,0.0,0.0,kara aile stasikelis,MATH-1080,2018
-MATH,1080,500,Calculus of One Variable II,0.33,0.33,0.11,0.22,0.0,0.0,0.0,0.0,laura dostert,MATH-1080,2018
-MATH,1150,1,Contemp Math for Elem Teach I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,carlos gomez,MATH-1150,2018
-MATH,1160,1,Contemp Math for Elem Teach II,0.45,0.19,0.23,0.03,0.0,0.0,0.0,0.1,allison stoddard,MATH-1160,2018
-MATH,1160,2,Contemp Math for Elem Teach II,0.58,0.3,0.1,0.0,0.03,0.0,0.0,0.0,allison stoddard,MATH-1160,2018
-MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.9,0.05,0.05,marion hanna,MATH-1990,2018
-MATH,2060,1,Calculus of Several Variables,0.19,0.14,0.38,0.05,0.14,0.0,0.0,0.11,allen anderson guest,MATH-2060,2018
-MATH,2060,2,Calculus of Several Variables,0.21,0.16,0.26,0.03,0.13,0.0,0.0,0.21,allen anderson guest,MATH-2060,2018
-MATH,2060,3,Calculus of Several Variables,0.3,0.19,0.16,0.08,0.24,0.0,0.0,0.03,allen anderson guest,MATH-2060,2018
-MATH,2060,4,Calculus of Several Variables,0.18,0.33,0.21,0.21,0.08,0.0,0.0,0.0,alistair bentley,MATH-2060,2018
-MATH,2060,7,Calculus of Several Variables,0.15,0.33,0.26,0.13,0.03,0.0,0.0,0.1,sofya alekseeva,MATH-2060,2018
-MATH,2060,8,Calculus of Several Variables,0.16,0.41,0.27,0.11,0.02,0.0,0.0,0.02,sofya alekseeva,MATH-2060,2018
-MATH,2060,9,Calculus of Several Variables,0.12,0.37,0.27,0.15,0.05,0.0,0.0,0.05,sofya alekseeva,MATH-2060,2018
-MATH,2060,10,Calculus of Several Variables,0.22,0.36,0.22,0.06,0.06,0.0,0.0,0.06,valdez hiram lopez,MATH-2060,2018
-MATH,2070,1,Business Calculus II,0.38,0.28,0.26,0.08,0.0,0.0,0.0,0.0,jennifer marie hanna,MATH-2070,2018
-MATH,2070,2,Business Calculus II,0.26,0.41,0.18,0.05,0.08,0.0,0.0,0.03,jennifer marie hanna,MATH-2070,2018
-MATH,2070,3,Business Calculus II,0.54,0.26,0.15,0.03,0.0,0.0,0.0,0.03,jennifer marie hanna,MATH-2070,2018
-MATH,2070,4,Business Calculus II,0.22,0.32,0.15,0.13,0.09,0.0,0.0,0.09,judith irene mcknew,MATH-2070,2018
-MATH,2070,5,Business Calculus II,0.28,0.26,0.23,0.13,0.08,0.0,0.0,0.03,judith irene mcknew,MATH-2070,2018
-MATH,2070,6,Business Calculus II,0.33,0.33,0.21,0.05,0.05,0.0,0.0,0.03,todd anthony morra,MATH-2070,2018
-MATH,2070,8,Business Calculus II,0.1,0.31,0.26,0.15,0.1,0.0,0.0,0.08,scott scruggs,MATH-2070,2018
-MATH,2070,9,Business Calculus II,0.41,0.33,0.15,0.05,0.03,0.0,0.0,0.03,emma cinatl,MATH-2070,2018
-MATH,2070,10,Business Calculus II,0.44,0.41,0.08,0.08,0.0,0.0,0.0,0.0,jennifer ray newton,MATH-2070,2018
-MATH,2070,11,Business Calculus II,0.38,0.41,0.18,0.03,0.0,0.0,0.0,0.0,jennifer ray newton,MATH-2070,2018
-MATH,2070,12,Business Calculus II,0.48,0.2,0.15,0.08,0.03,0.0,0.0,0.08,jennifer ray newton,MATH-2070,2018
-MATH,2070,13,Business Calculus II,0.54,0.18,0.1,0.13,0.03,0.0,0.0,0.03,jennifer ray newton,MATH-2070,2018
-MATH,2070,14,Business Calculus II,0.56,0.11,0.22,0.08,0.0,0.0,0.0,0.03,dyken jennifer  van e,MATH-2070,2018
-MATH,2070,15,Business Calculus II,0.29,0.37,0.26,0.03,0.0,0.0,0.0,0.05,madeleine stville,MATH-2070,2018
-MATH,2070,16,Business Calculus II,0.39,0.31,0.06,0.06,0.11,0.0,0.0,0.08,allison stoddard,MATH-2070,2018
-MATH,2080,1,Intro to Ordin Diff Equations,0.29,0.21,0.25,0.08,0.13,0.0,0.0,0.04,terri johnson,MATH-2080,2018
-MATH,2080,2,Intro to Ordin Diff Equations,0.38,0.2,0.27,0.07,0.07,0.0,0.0,0.02,irina viktorova,MATH-2080,2018
-MATH,2080,3,Intro to Ordin Diff Equations,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.05,oleg yordanov,MATH-2080,2018
-MATH,2080,4,Intro to Ordin Diff Equations,0.15,0.39,0.24,0.06,0.06,0.0,0.0,0.09,timothy fran parrott,MATH-2080,2018
-MATH,2080,6,Intro to Ordin Diff Equations,0.4,0.38,0.13,0.07,0.02,0.0,0.0,0.0,timothy cha teitloff,MATH-2080,2018
-MATH,2080,7,Intro to Ordin Diff Equations,0.32,0.35,0.22,0.03,0.08,0.0,0.0,0.0,oleg yordanov,MATH-2080,2018
-MATH,2080,8,Intro to Ordin Diff Equations,0.51,0.16,0.3,0.0,0.0,0.0,0.0,0.03,timothy fran parrott,MATH-2080,2018
-MATH,2080,9,Intro to Ordin Diff Equations,0.26,0.17,0.21,0.07,0.14,0.0,0.0,0.14,terri johnson,MATH-2080,2018
-MATH,2080,10,Intro to Ordin Diff Equations,0.42,0.38,0.16,0.04,0.0,0.0,0.0,0.0,timothy cha teitloff,MATH-2080,2018
-MATH,2080,11,Intro to Ordin Diff Equations,0.21,0.25,0.25,0.11,0.14,0.0,0.0,0.04,julie lassiter,MATH-2080,2018
-MATH,2080,12,Intro to Ordin Diff Equations,0.48,0.46,0.04,0.0,0.0,0.0,0.0,0.02,irina viktorova,MATH-2080,2018
-MATH,2080,13,Intro to Ordin Diff Equations,0.23,0.29,0.14,0.09,0.09,0.0,0.0,0.17,terri johnson,MATH-2080,2018
-MATH,2080,14,Intro to Ordin Diff Equations,0.16,0.22,0.28,0.13,0.09,0.0,0.0,0.13,julie lassiter,MATH-2080,2018
-MATH,2080,15,Intro to Ordin Diff Equations,0.36,0.26,0.14,0.12,0.05,0.0,0.0,0.07,timothy fran parrott,MATH-2080,2018
-MATH,2080,16,Intro to Ordin Diff Equations,0.41,0.25,0.18,0.09,0.0,0.0,0.0,0.07,timothy cha teitloff,MATH-2080,2018
-MATH,2080,17,Intro to Ordin Diff Equations,0.18,0.36,0.32,0.06,0.03,0.0,0.0,0.05,sean sather-wagstaff,MATH-2080,2018
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.35,0.43,0.17,0.0,0.0,0.0,0.0,0.04,michael adam burr,MATH-2080,2018
-MATH,2160,1,Geometry for Elem Sch Teachers,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,eliza darg gallagher,MATH-2160,2018
-MATH,3020,1,Stat for Science & Engineering,0.56,0.33,0.03,0.03,0.03,0.0,0.0,0.03,ellen hepfer breazel,MATH-3020,2018
-MATH,3020,2,Stat for Science & Engineering,0.23,0.45,0.28,0.0,0.05,0.0,0.0,0.0,gamage prabh withana,MATH-3020,2018
-MATH,3020,3,Stat for Science & Engineering,0.38,0.46,0.13,0.03,0.0,0.0,0.0,0.0,xiyan tan,MATH-3020,2018
-MATH,3020,4,Stat for Science & Engineering,0.82,0.11,0.05,0.03,0.0,0.0,0.0,0.0,haotian feng,MATH-3020,2018
-MATH,3020,5,Stat for Science & Engineering,0.29,0.26,0.16,0.0,0.13,0.0,0.0,0.16,paul james cubre,MATH-3020,2018
-MATH,3020,6,Stat for Science & Engineering,0.43,0.3,0.26,0.0,0.0,0.0,0.0,0.0,yinggu bao,MATH-3020,2018
-MATH,3020,8,Stat for Science & Engineering,0.25,0.25,0.3,0.05,0.1,0.0,0.0,0.05,patrick gerard,MATH-3020,2018
-MATH,3020,9,Stat for Science & Engineering,0.36,0.36,0.13,0.05,0.1,0.0,0.0,0.0,ellen hepfer breazel,MATH-3020,2018
-MATH,3080,1,College Geometry,0.82,0.06,0.0,0.0,0.12,0.0,0.0,0.0,nicole alain sinwell,MATH-3080,2018
-MATH,3110,1,Linear Algebra,0.27,0.27,0.16,0.07,0.11,0.0,0.0,0.11,svetlana poznanovikj,MATH-3110,2018
-MATH,3110,2,Linear Algebra,0.21,0.51,0.16,0.02,0.0,0.0,0.0,0.09,neil calkin,MATH-3110,2018
-MATH,3110,3,Linear Algebra,0.16,0.32,0.32,0.07,0.07,0.0,0.0,0.07,xuhong gao,MATH-3110,2018
-MATH,3110,4,Linear Algebra,0.29,0.15,0.22,0.1,0.1,0.0,0.0,0.15,xuhong gao,MATH-3110,2018
-MATH,3110,5,Linear Algebra,0.12,0.3,0.19,0.21,0.14,0.0,0.0,0.05,hui xue,MATH-3110,2018
-MATH,3110,6,Linear Algebra,0.17,0.27,0.25,0.21,0.08,0.0,0.0,0.02,hui xue,MATH-3110,2018
-MATH,3110,7,Linear Algebra,0.33,0.24,0.15,0.15,0.07,0.0,0.0,0.07,elena stan dimitrova,MATH-3110,2018
-MATH,3110,200,Linear Algebra,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,kevin james,MATH-3110,2018
-MATH,3190,1,Introduction to Proof,0.31,0.19,0.31,0.04,0.08,0.0,0.0,0.08,james bar coykendall,MATH-3190,2018
-MATH,3190,2,Introduction to Proof,0.58,0.27,0.08,0.0,0.04,0.0,0.0,0.04,malcolm edwar rupert,MATH-3190,2018
-MATH,3600,1,Intermediate Math Computing,0.76,0.12,0.04,0.04,0.0,0.0,0.0,0.04,mark cawood,MATH-3600,2018
-MATH,3600,2,Intermediate Math Computing,0.45,0.18,0.14,0.0,0.05,0.0,0.0,0.18,mark cawood,MATH-3600,2018
-MATH,3650,1,Numerical Mthds for Engineers,0.36,0.27,0.15,0.0,0.15,0.0,0.0,0.06,mengying xiao,MATH-3650,2018
-MATH,3650,2,Numerical Mthds for Engineers,0.41,0.3,0.14,0.03,0.05,0.0,0.0,0.08,christopher cox,MATH-3650,2018
-MATH,3650,3,Numerical Mthds for Engineers,0.26,0.39,0.16,0.06,0.06,0.0,0.0,0.06,vincent ervin,MATH-3650,2018
-MATH,3650,4,Numerical Mthds for Engineers,0.19,0.24,0.27,0.14,0.08,0.0,0.0,0.08,vincent ervin,MATH-3650,2018
-MATH,4000,1,Theory of Probability,0.32,0.48,0.12,0.0,0.0,0.0,0.0,0.08,xiaoqian sun,MATH-4000,2018
-MATH,4000,2,Theory of Probability,0.5,0.21,0.21,0.0,0.07,0.0,0.0,0.0,peter kiessler,MATH-4000,2018
-MATH,4030,1,Intro to Statistical Theory,0.31,0.31,0.31,0.0,0.08,0.0,0.0,0.0,xiaoqian sun,MATH-4030,2018
-MATH,4070,1,Regress & Time-Series Analysis,0.67,0.08,0.08,0.08,0.08,0.0,0.0,0.0,christopher mcmahan,MATH-4070,2018
-MATH,4110,1,Introduction to Combinatorics,0.46,0.31,0.08,0.0,0.0,0.0,0.0,0.15,beth novick,MATH-4110,2018
-MATH,4120,1,Algebra I,0.19,0.52,0.15,0.0,0.11,0.0,0.0,0.04,james bar coykendall,MATH-4120,2018
-MATH,4190,1,Discrete Math Structures I,0.28,0.59,0.1,0.03,0.0,0.0,0.0,0.0,wayne goddard,MATH-4190,2018
-MATH,4190,2,Discrete Math Structures I,0.19,0.34,0.25,0.0,0.16,0.0,0.0,0.06,sean sather-wagstaff,MATH-4190,2018
-MATH,4310,1,Theory of Interest,0.21,0.43,0.29,0.0,0.0,0.0,0.0,0.07, erwin walker,MATH-4310,2018
-MATH,4340,1,Adv Engineering Mathematics,0.25,0.15,0.3,0.15,0.05,0.0,0.0,0.1,hyesuk lee,MATH-4340,2018
-MATH,4340,2,Adv Engineering Mathematics,0.28,0.22,0.25,0.06,0.0,0.0,0.0,0.19,qingshan chen,MATH-4340,2018
-MATH,4400,1,Linear Programming,0.5,0.27,0.04,0.08,0.08,0.0,0.0,0.04,margaret mari wiecek,MATH-4400,2018
-MATH,4530,1,Advanced Calculus I,0.41,0.28,0.17,0.07,0.07,0.0,0.0,0.0,james peterson,MATH-4530,2018
-MATH,4540,1,Advanced Calculus II,0.21,0.38,0.29,0.08,0.04,0.0,0.0,0.0,james peterson,MATH-4540,2018
-MATH,4600,1,Intro to Numerical Analysis I,0.44,0.25,0.13,0.0,0.06,0.0,0.0,0.13,leo rebholz,MATH-4600,2018
-MATH,6000,1,Theory of Probability,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,xiaoqian sun,MATH-6000,2018
-MATH,6340,1,Adv Engineering Mathematics,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,hyesuk lee,MATH-6340,2018
-MATH,6410,1,Intro to Stochastic Models,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,MATH-6410,2018
-MATH,8030,1,Stochastic Processes,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,peter kiessler,MATH-8030,2018
-MATH,8040,1,Statistical Inference,0.5,0.19,0.19,0.0,0.06,0.0,0.0,0.06,christopher mcmahan,MATH-8040,2018
-MATH,8050,1,Data Analysis,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ling ma,MATH-8050,2018
-MATH,8090,1,Time Series Analysis,0.44,0.31,0.0,0.0,0.0,0.0,0.0,0.25,colin gallagher,MATH-8090,2018
-MATH,8100,1,Mathematical Programming,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,MATH-8100,2018
-MATH,8120,1,Discrete Optimization,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,herve louis kerivin,MATH-8120,2018
-MATH,8130,1,Advanced Linear Programming,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,MATH-8130,2018
-MATH,8210,1,Linear Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,benjamin jaye,MATH-8210,2018
-MATH,8220,1,Measure and Integration,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,martin johan schmoll,MATH-8220,2018
-MATH,8530,1,Matrix Analysis,0.6,0.1,0.2,0.0,0.1,0.0,0.0,0.0,elena stan dimitrova,MATH-8530,2018
-MATH,8540,1,Theory of Graphs,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,beth novick,MATH-8540,2018
-MATH,8560,1,Ther of Error-Correcting Codes,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,felice manganiello,MATH-8560,2018
-MATH,8600,1,Intro to Scientific Computing,0.35,0.35,0.12,0.0,0.12,0.0,0.0,0.06,eleanor jenkins,MATH-8600,2018
-MATH,8610,1,Advanced Numerical Analysis I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,fei xue,MATH-8610,2018
-MATH,9830,1,Sel Top in Computational Math,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,timo johanne heister,MATH-9830,2018
-MBA,8030,1,Stat Analy of Bus Op,0.19,0.35,0.27,0.0,0.05,0.0,0.0,0.14,magda gabriela sava,MBA-8030,2018
-MBA,8060,1,Operations Mgt,0.28,0.58,0.14,0.0,0.0,0.0,0.0,0.0,janis miller,MBA-8060,2018
-MBA,8060,20,Operations Mgt,0.42,0.42,0.12,0.0,0.0,0.0,0.0,0.04, sridharan,MBA-8060,2018
-MBA,8070,1,Financial Management,0.56,0.28,0.16,0.0,0.0,0.0,0.0,0.0,melvin stith,MBA-8070,2018
-MBA,8070,2,Financial Management,0.68,0.15,0.13,0.0,0.0,0.0,0.0,0.05,melvin stith,MBA-8070,2018
-MBA,8090,1,Org Beh & Hum Res Mg,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,MBA-8090,2018
-MBA,8090,2,Org Beh & Hum Res Mg,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,MBA-8090,2018
-MBA,8090,3,Org Beh & Hum Res Mg,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,MBA-8090,2018
-MBA,8170,21,Bus Forecasting,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,sukran nilv atadeniz,MBA-8170,2018
-MBA,8190,1,Intro to Acc and Fin,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,melvin stith,MBA-8190,2018
-MBA,8190,2,Intro to Acc and Fin,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,melvin stith,MBA-8190,2018
-MBA,8290,1,Marketing Foundation,0.6,0.36,0.0,0.0,0.0,0.0,0.0,0.04,gary hunter,MBA-8290,2018
-MBA,8330,1,Real Estate Investmt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,franklin bogu wallin,MBA-8330,2018
-MBA,8370,1,Legal Environ of Bus,0.2,0.77,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2018
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,MBA-8400,2018
-MBA,8430,10,Entrepreneurial Accounting,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,james milt kohlmeyer,MBA-8430,2018
-MBA,8440,10,Entrepreneurial Law,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,scott hile,MBA-8440,2018
-MBA,8450,1,Technology & Innovation Mgt,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8450,2018
-MBA,8470,1,New Venture Creation,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,MBA-8470,2018
-MBA,8510,10,Bus Operations & Logistics,0.69,0.19,0.04,0.0,0.04,0.0,0.0,0.04,george kennet morgan,MBA-8510,2018
-MBA,8540,1,Managerial Accounting,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,MBA-8540,2018
-MBA,8540,2,Managerial Accounting,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,MBA-8540,2018
-MBA,8540,3,Managerial Accounting,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,MBA-8540,2018
-MBA,8590,1,Mgr Decision Model,0.42,0.33,0.08,0.0,0.06,0.0,0.0,0.11,magda gabriela sava,MBA-8590,2018
-MBA,8590,2,Mgr Decision Model,0.54,0.23,0.15,0.0,0.08,0.0,0.0,0.0,sara elizabeth yoder,MBA-8590,2018
-MBA,8600,1,Advanced Marketing Strategy,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,michael dorsch,MBA-8600,2018
-MBA,8610,1,Information Systems,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,MBA-8610,2018
-MBA,8620,1,Managerial Economics,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,MBA-8620,2018
-MBA,8620,2,Managerial Economics,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,MBA-8620,2018
-MBA,8700,1,Strategic Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,matthew charle klein,MBA-8700,2018
-MBA,8720,1,Entrepr Finance,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,matthew charle klein,MBA-8720,2018
-MBA,8750,1,Enterprise Develpmnt,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8750,2018
-MBA,8990,1,Advanced Leadership,0.89,0.06,0.02,0.0,0.0,0.0,0.0,0.02,gail depriest,MBA-8990,2018
-MBA,8990,3,Service Innovation,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,aleda marie roth,MBA-8990,2018
-MBA,8990,4,Bus. Sport. Enter.,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,MBA-8990,2018
-MBA,8990,7,Business Analytics Models,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,jennie lynn farmer,MBA-8990,2018
-MBA,8990,20,Analytics & Application,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,heshan sun,MBA-8990,2018
-MBA,8990,22,Marketing Analytics,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,bruce snyder,MBA-8990,2018
-ME,2000,1,Sophomore Seminar,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.02,donald beasley,ME-2000,2018
-ME,2010,1,Statics & Dynamics,0.06,0.25,0.27,0.16,0.12,0.0,0.0,0.14,marisa kikendall orr,ME-2010,2018
-ME,2010,2,Statics & Dynamics,0.05,0.25,0.28,0.13,0.2,0.0,0.0,0.1,paul joseph,ME-2010,2018
-ME,2030,1,Founda Th/Fl Syst,0.24,0.58,0.14,0.01,0.01,0.0,0.0,0.02,yiqiang han,ME-2030,2018
-ME,2030,2,Founda Th/Fl Syst,0.28,0.28,0.23,0.09,0.08,0.0,0.0,0.05,xiangchun xuan,ME-2030,2018
-ME,2040,1,Mechanics of Materials,0.31,0.47,0.17,0.04,0.01,0.0,0.0,0.0,gang li,ME-2040,2018
-ME,2040,2,Mechanics of Materials,0.16,0.52,0.18,0.05,0.05,0.0,0.0,0.05,jorge ivan rodriguez,ME-2040,2018
-ME,2040,3,Mechanics of Materials,0.28,0.5,0.19,0.03,0.0,0.0,0.0,0.0,garrett pataky,ME-2040,2018
-ME,2040,303,Mechanics of Materials (HON),0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,garrett pataky,ME-2040,2018
-ME,2220,2,Mechanical Engineering Lab I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,3,Mechanical Engineering Lab I,0.21,0.64,0.14,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,5,Mechanical Engineering Lab I,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,6,Mechanical Engineering Lab I,0.19,0.5,0.25,0.0,0.0,0.0,0.0,0.06,todd al schweisinger,ME-2220,2018
-ME,2220,7,Mechanical Engineering Lab I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,10,Mechanical Engineering Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,todd al schweisinger,ME-2220,2018
-ME,2220,11,Mechanical Engineering Lab I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,13,Mechanical Engineering Lab I,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,14,Mechanical Engineering Lab I,0.29,0.43,0.21,0.07,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,15,Mechanical Engineering Lab I,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,17,Mechanical Engineering Lab I,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2220,18,Mechanical Engineering Lab I,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2220,2018
-ME,2900,619,CI ME - Savonius Wind Turbine,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-2900,2018
-ME,3030,1,Thermodynamics,0.11,0.2,0.53,0.02,0.09,0.0,0.0,0.04,john saylor,ME-3030,2018
-ME,3030,2,Thermodynamics,0.13,0.32,0.45,0.06,0.0,0.0,0.0,0.04,richard miller,ME-3030,2018
-ME,3040,1,Heat Transfer,0.03,0.32,0.5,0.11,0.03,0.0,0.0,0.03,jean-marc ge delhaye,ME-3040,2018
-ME,3040,2,Heat Transfer,0.21,0.36,0.28,0.0,0.11,0.0,0.0,0.04,jean-marc ge delhaye,ME-3040,2018
-ME,3040,3,Heat Transfer,0.21,0.38,0.21,0.15,0.0,0.0,0.0,0.04,xin zhao,ME-3040,2018
-ME,3050,1,Model/an Dy Syst,0.21,0.39,0.36,0.01,0.03,0.0,0.0,0.0,phanind tallapragada,ME-3050,2018
-ME,3050,2,Model/an Dy Syst,0.2,0.37,0.31,0.06,0.05,0.0,0.0,0.02,joshua bostwick,ME-3050,2018
-ME,3060,1,Fund Machine Design,0.11,0.61,0.23,0.0,0.02,0.0,0.0,0.03,oliver myers,ME-3060,2018
-ME,3060,2,Fund Machine Design,0.2,0.63,0.12,0.03,0.01,0.0,0.0,0.01,joshua summers,ME-3060,2018
-ME,3070,1,Found of Mechanical Systems,0.46,0.34,0.11,0.01,0.06,0.0,0.0,0.01,jorge ivan rodriguez,ME-3070,2018
-ME,3070,2,Found of Mechanical Systems,0.36,0.46,0.16,0.01,0.0,0.0,0.0,0.01,gregory mocko,ME-3070,2018
-ME,3080,1,Fluid Mechanics,0.21,0.45,0.31,0.03,0.0,0.0,0.0,0.0,chenning tong,ME-3080,2018
-ME,3080,2,Fluid Mechanics,0.16,0.42,0.39,0.03,0.0,0.0,0.0,0.0,ethan kung,ME-3080,2018
-ME,3080,3,Fluid Mechanics,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-3080,2018
-ME,3100,1,Thermo/Heat Transfer,0.25,0.5,0.17,0.0,0.03,0.0,0.0,0.06,yiqiang han,ME-3100,2018
-ME,3120,1,Manuf Processes,0.31,0.66,0.03,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-3120,2018
-ME,3330,1,Mechanical Engineering Lab II,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-3330,2018
-ME,3330,2,Mechanical Engineering Lab II,0.27,0.53,0.13,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,ME-3330,2018
-ME,3330,3,Mechanical Engineering Lab II,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-3330,2018
-ME,3330,5,Mechanical Engineering Lab II,0.1,0.8,0.1,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-3330,2018
-ME,3330,6,Mechanical Engineering Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-3330,2018
-ME,3330,7,Mechanical Engineering Lab II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-3330,2018
-ME,3330,9,Mechanical Engineering Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-3330,2018
-ME,3330,11,Mechanical Engineering Lab II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-3330,2018
-ME,3330,17,Mechanical Engineering Lab II,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-3330,2018
-ME,4010,1,Mech Engr Design,0.85,0.1,0.01,0.01,0.01,0.0,0.0,0.0,cameron turner,ME-4010,2018
-ME,4020,1,Intern in Engr Des,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-4020,2018
-ME,4020,4,Intern in Engr Des,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2018
-ME,4020,5,Intern in Engr Des,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,ME-4020,2018
-ME,4020,6,Intern in Engr Des,0.3,0.35,0.05,0.3,0.0,0.0,0.0,0.0,nicole gisel coutris,ME-4020,2018
-ME,4020,7,Intern in Engr Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2018
-ME,4020,8,Intern in Engr Des,0.25,0.6,0.15,0.0,0.0,0.0,0.0,0.0,yue wang,ME-4020,2018
-ME,4020,9,Intern in Engr Des,0.25,0.45,0.25,0.05,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2018
-ME,4030,1,Control Dynamic Systems,0.23,0.33,0.4,0.05,0.0,0.0,0.0,0.0,suyi li,ME-4030,2018
-ME,4030,2,Control Dynamic Systems,0.24,0.4,0.2,0.13,0.02,0.0,0.0,0.0,yue wang,ME-4030,2018
-ME,4180,1,F E A in M E Design,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,oliver myers,ME-4180,2018
-ME,4220,1,Design Gas Turbines,0.56,0.27,0.15,0.02,0.0,0.0,0.0,0.0,abhijit som,ME-4220,2018
-ME,4260,1,Nuclear Energy,0.38,0.32,0.24,0.06,0.0,0.0,0.0,0.0,richard watkins,ME-4260,2018
-ME,4300,1,Mech Comp Materials,0.19,0.29,0.33,0.14,0.0,0.0,0.0,0.05,huijuan zhao,ME-4300,2018
-ME,4400,1,Matls for Aggr Envir,0.44,0.31,0.22,0.0,0.03,0.0,0.0,0.0,garrett pataky,ME-4400,2018
-ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-4440,2018
-ME,4440,2,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-4440,2018
-ME,4440,5,Mechanical Engineering Lab III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-4440,2018
-ME,4440,13,Mechanical Engineering Lab III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,ME-4440,2018
-ME,4930,11,Selected Topics ME (MicroFab),0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,ME-4930,2018
-ME,4930,24,Sel. Topics ME (Mechatronics),0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4930,2018
-ME,4930,34,Sel. Topics in ME (Cardio),0.07,0.79,0.14,0.0,0.0,0.0,0.0,0.0,ethan kung,ME-4930,2018
-ME,4930,39,Sel Topics ME (Solar Energy),0.35,0.48,0.15,0.02,0.0,0.0,0.0,0.0,daniel fant,ME-4930,2018
-ME,6300,1,Mech Comp Materials,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,ME-6300,2018
-ME,6930,11,Selected Topics ME (MicroFab),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,ME-6930,2018
-ME,6930,34,Selected Topics in ME (Cardio),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,ME-6930,2018
-ME,8200,1,Mod Cont Engr,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,ME-8200,2018
-ME,8310,1,Convective Ht Trans,0.45,0.18,0.18,0.0,0.0,0.0,0.0,0.18,xin zhao,ME-8310,2018
-ME,8370,1,Theory of Elast I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,nicole gisel coutris,ME-8370,2018
-ME,8450,1,Structural Vibration,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,suyi li,ME-8450,2018
-ME,8720,1,Design Automatn for Mech Engrs,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,cameron turner,ME-8720,2018
-ME,8730,1,Res Mthds Coll Desgn,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,joshua summers,ME-8730,2018
-ME,8930,24,Sel. Topics ME (Mechatronics),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-8930,2018
-ME,8930,424,Sel. Topics ME (Mechatronics),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-8930,2018
-MGT,2010,1,Principles of Management,0.4,0.4,0.14,0.03,0.01,0.0,0.0,0.01,katherine clark,MGT-2010,2018
-MGT,2010,2,Principles of Management,0.47,0.38,0.1,0.03,0.0,0.0,0.0,0.01,tina robbins,MGT-2010,2018
-MGT,2010,7,Principles of Management,0.23,0.36,0.38,0.03,0.0,0.0,0.0,0.0,christopher mann,MGT-2010,2018
-MGT,2010,8,Principles of Management,0.28,0.4,0.2,0.08,0.0,0.0,0.0,0.05,christopher mann,MGT-2010,2018
-MGT,2010,10,Principles of Management,0.26,0.46,0.2,0.04,0.02,0.0,0.0,0.02,ashley willi parnell,MGT-2010,2018
-MGT,2010,11,Principles of Management,0.3,0.3,0.33,0.0,0.05,0.0,0.0,0.03,ashley willi parnell,MGT-2010,2018
-MGT,2180,1,Management PC Applications,0.52,0.32,0.09,0.03,0.02,0.0,0.0,0.02,ryan toole,MGT-2180,2018
-MGT,2180,2,Management PC Applications,0.33,0.3,0.07,0.04,0.22,0.0,0.0,0.04,ryan toole,MGT-2180,2018
-MGT,3070,1,Human Resource Management,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,MGT-3070,2018
-MGT,3070,2,Human Resource Management,0.88,0.08,0.03,0.03,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2018
-MGT,3070,3,Human Resource Management,0.3,0.63,0.08,0.0,0.0,0.0,0.0,0.0,priscilla harrison,MGT-3070,2018
-MGT,3070,4,Human Resource Management,0.4,0.53,0.05,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,MGT-3070,2018
-MGT,3070,5,Human Resource Management,0.7,0.28,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2018
-MGT,3070,6,Human Resource Management,0.45,0.48,0.05,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,MGT-3070,2018
-MGT,3100,1,Intermed Business Statistics,0.55,0.18,0.25,0.03,0.0,0.0,0.0,0.0,yunsik choi,MGT-3100,2018
-MGT,3100,2,Intermed Business Statistics,0.33,0.33,0.23,0.05,0.03,0.0,0.0,0.05,mustafa serka akturk,MGT-3100,2018
-MGT,3100,3,Intermed Business Statistics,0.23,0.31,0.21,0.08,0.1,0.0,0.0,0.08,yunsik choi,MGT-3100,2018
-MGT,3100,4,Intermed Business Statistics,0.5,0.24,0.07,0.0,0.12,0.0,0.0,0.07,remi charpin,MGT-3100,2018
-MGT,3100,5,Intermed Business Statistics,0.58,0.27,0.13,0.0,0.0,0.0,0.0,0.02,wenxi pu,MGT-3100,2018
-MGT,3100,6,Intermed Business Statistics,0.45,0.32,0.13,0.0,0.05,0.0,0.0,0.05,sukran nilv atadeniz,MGT-3100,2018
-MGT,3100,7,Intermed Business Statistics,0.24,0.44,0.22,0.0,0.02,0.0,0.0,0.07,magda gabriela sava,MGT-3100,2018
-MGT,3100,8,Intermed Business Statistics,0.42,0.26,0.24,0.03,0.03,0.0,0.0,0.03,mustafa serka akturk,MGT-3100,2018
-MGT,3100,10,Intermed Business Statistics,0.49,0.44,0.03,0.05,0.0,0.0,0.0,0.0,sukran nilv atadeniz,MGT-3100,2018
-MGT,3100,11,Intermed Business Statistics,0.64,0.26,0.08,0.0,0.0,0.0,0.0,0.03,thomas simpson,MGT-3100,2018
-MGT,3120,1,Decision Models for Management,0.08,0.26,0.45,0.08,0.09,0.0,0.0,0.05,sara elizabeth yoder,MGT-3120,2018
-MGT,3120,2,Decision Models for Management,0.12,0.27,0.39,0.1,0.07,0.0,0.0,0.04,sara elizabeth yoder,MGT-3120,2018
-MGT,3120,5,Decision Models for Management,0.31,0.39,0.31,0.0,0.0,0.0,0.0,0.0,james turner,MGT-3120,2018
-MGT,3170,1,Logistics Mgmt,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,ahmet colak,MGT-3170,2018
-MGT,3180,1,Mgt of Info Systems,0.15,0.6,0.2,0.0,0.0,0.0,0.0,0.05,russell purvis,MGT-3180,2018
-MGT,3180,2,Mgt of Info Systems,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,marten risius,MGT-3180,2018
-MGT,3180,3,Mgt of Info Systems,0.56,0.36,0.05,0.0,0.03,0.0,0.0,0.0,tina marie esposito,MGT-3180,2018
-MGT,3180,4,Mgt of Info Systems,0.41,0.44,0.1,0.03,0.0,0.0,0.0,0.03,tina marie esposito,MGT-3180,2018
-MGT,3500,1,Intro to Business Analytics,0.29,0.68,0.03,0.0,0.0,0.0,0.0,0.0,siyuan li,MGT-3500,2018
-MGT,3510,1,Business Analytics & Problems,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,sukran nilv atadeniz,MGT-3510,2018
-MGT,3900,1,Ops Mgt,0.43,0.48,0.05,0.0,0.05,0.0,0.0,0.0,maneeshred ajjuguttu,MGT-3900,2018
-MGT,3900,2,Ops Mgt,0.09,0.45,0.3,0.09,0.02,0.0,0.0,0.05,min kyung lee,MGT-3900,2018
-MGT,3900,3,Ops Mgt,0.18,0.2,0.4,0.08,0.0,0.0,0.0,0.15,min kyung lee,MGT-3900,2018
-MGT,3900,4,Ops Mgt,0.11,0.3,0.49,0.11,0.0,0.0,0.0,0.0,zachary mor leffakis,MGT-3900,2018
-MGT,3900,5,Ops Mgt,0.35,0.3,0.3,0.03,0.03,0.0,0.0,0.0,daniel nielubowicz,MGT-3900,2018
-MGT,4000,2,Mgt of Organizational Behavior,0.25,0.43,0.27,0.02,0.02,0.0,0.0,0.0,thomas jos zagenczyk,MGT-4000,2018
-MGT,4000,3,Mgt of Organizational Behavior,0.38,0.33,0.26,0.0,0.03,0.0,0.0,0.0,philip roth,MGT-4000,2018
-MGT,4000,4,Mgt of Organizational Behavior,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2018
-MGT,4020,1,Ops Pln and Ctl,0.07,0.57,0.21,0.14,0.0,0.0,0.0,0.0,zachary mor leffakis,MGT-4020,2018
-MGT,4080,1,Lean Operations,0.23,0.32,0.36,0.0,0.09,0.0,0.0,0.0,zachary mor leffakis,MGT-4080,2018
-MGT,4110,1,Project Management,0.38,0.43,0.15,0.03,0.0,0.0,0.0,0.03,russell purvis,MGT-4110,2018
-MGT,4120,1,Supplier Management,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,ahmet colak,MGT-4120,2018
-MGT,4150,1,Business Strategy,0.24,0.52,0.21,0.02,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2018
-MGT,4150,2,Business Strategy,0.24,0.63,0.11,0.0,0.0,0.0,0.0,0.02,james liddle,MGT-4150,2018
-MGT,4150,3,Business Strategy,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,dennis lee lester,MGT-4150,2018
-MGT,4150,4,Business Strategy,0.43,0.35,0.2,0.02,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2018
-MGT,4150,5,Business Strategy,0.4,0.51,0.09,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,MGT-4150,2018
-MGT,4150,6,Business Strategy,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,MGT-4150,2018
-MGT,4150,7,Business Strategy,0.23,0.6,0.16,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2018
-MGT,4150,8,Business Strategy,0.15,0.61,0.24,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2018
-MGT,4150,10,Business Strategy,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,dennis lee lester,MGT-4150,2018
-MGT,4160,1,Special Topics Hr,0.62,0.24,0.08,0.0,0.0,0.0,0.0,0.05,alejandra sa kennedy,MGT-4160,2018
-MGT,4230,1,Intern Bus Mgt,0.04,0.59,0.28,0.02,0.02,0.0,0.0,0.04,janis miller,MGT-4230,2018
-MGT,4230,2,Intern Bus Mgt,0.16,0.44,0.27,0.11,0.02,0.0,0.0,0.0,janis miller,MGT-4230,2018
-MGT,4230,3,Intern Bus Mgt,0.09,0.26,0.5,0.09,0.02,0.0,0.0,0.04,wayne stewart,MGT-4230,2018
-MGT,4230,4,Intern Bus Mgt,0.13,0.13,0.56,0.11,0.04,0.0,0.0,0.02,wayne stewart,MGT-4230,2018
-MGT,4240,1,Global Supply Chain,0.26,0.55,0.16,0.03,0.0,0.0,0.0,0.0,yann ferrand,MGT-4240,2018
-MGT,4270,1,Managing Improvement,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,samer ess abdlrahman,MGT-4270,2018
-MGT,4310,1,Emp Rights & Resp,0.24,0.55,0.21,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,MGT-4310,2018
-MGT,4350,1,Pers Interviewing,0.33,0.28,0.33,0.0,0.05,0.0,0.0,0.03,philip roth,MGT-4350,2018
-MGT,4520,1,Business Analysis,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,marten risius,MGT-4520,2018
-MGT,4540,1,Systems Implement,0.18,0.47,0.24,0.0,0.06,0.0,0.0,0.06,heshan sun,MGT-4540,2018
-MGT,4550,1,Emerging I T Trends,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,MGT-4550,2018
-MGT,4560,1,Business Info Mgt,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,siyuan li,MGT-4560,2018
-MGT,4900,1,Being A Leader,0.7,0.16,0.11,0.0,0.0,0.0,0.0,0.03,christopher mann,MGT-4900,2018
-MGT,4900,2,Being A Leader,0.67,0.19,0.1,0.0,0.0,0.0,0.0,0.05,christopher mann,MGT-4900,2018
-MGT,8120,1,Supply Chain Mgt,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,yann ferrand,MGT-8120,2018
-MICR,3050,1,General Microbiology,0.46,0.36,0.14,0.03,0.01,0.0,0.0,0.0,kristi jam whitehead,MICR-3050,2018
-MICR,3050,2,General Microbiology,0.5,0.25,0.15,0.06,0.01,0.0,0.0,0.02,krista barri rudolph,MICR-3050,2018
-MICR,3050,3,General Microbiology,0.62,0.3,0.03,0.05,0.0,0.0,0.0,0.0,krista barri rudolph,MICR-3050,2018
-MICR,4000,1,Public Health Micro,0.57,0.26,0.09,0.06,0.0,0.0,0.0,0.02,kristi jam whitehead,MICR-4000,2018
-MICR,4020,1,Environmental Micro,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,john michael henson,MICR-4020,2018
-MICR,4070,1,Food and Dairy Micro,0.25,0.46,0.22,0.06,0.0,0.0,0.0,0.0,xiuping jiang,MICR-4070,2018
-MICR,4110,1,Pathogenic Bact,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kears milhous,MICR-4110,2018
-MICR,4120,1,Bacterial Physiology,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.02,wilbur kears milhous,MICR-4120,2018
-MICR,4130,1,Industrial Micro,0.31,0.54,0.11,0.02,0.0,0.0,0.0,0.03,tzuen-rong jer tzeng,MICR-4130,2018
-MICR,4140,1,Basic Immunology,0.69,0.29,0.0,0.0,0.0,0.0,0.0,0.02,charles rice,MICR-4140,2018
-MICR,4170,1,Cancer and Aging,0.64,0.29,0.04,0.01,0.0,0.0,0.0,0.01,yuqing dong,MICR-4170,2018
-MICR,4500,1,Advanced Microbiology I,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2018
-MICR,4500,2,Advanced Microbiology I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2018
-MICR,4500,3,Advanced Microbiology I,0.31,0.38,0.23,0.0,0.0,0.0,0.0,0.08,harry kurtz,MICR-4500,2018
-MICR,4520,1,Advanced Microbiology III,0.38,0.5,0.08,0.04,0.0,0.0,0.0,0.0,harry kurtz,MICR-4520,2018
-MICR,4520,2,Advanced Microbiology III,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4520,2018
-MICR,4520,3,Advanced Microbiology III,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,harry kurtz,MICR-4520,2018
-MKT,3010,1,Principles of Marketing,0.26,0.37,0.26,0.07,0.03,0.0,0.0,0.01,carter will mcelveen,MKT-3010,2018
-MKT,3010,2,Principles of Marketing,0.29,0.35,0.29,0.06,0.01,0.0,0.0,0.01,carter will mcelveen,MKT-3010,2018
-MKT,3010,3,Principles of Marketing,0.31,0.4,0.21,0.05,0.01,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2018
-MKT,3010,4,Principles of Marketing,0.27,0.4,0.24,0.05,0.03,0.0,0.0,0.01,amanda cooper fine,MKT-3010,2018
-MKT,3010,5,Principles of Marketing,0.15,0.35,0.36,0.07,0.03,0.0,0.0,0.04,james gaubert,MKT-3010,2018
-MKT,3020,1,Consumer Behavior,0.5,0.33,0.15,0.02,0.0,0.0,0.0,0.0,jennifer dia siemens,MKT-3020,2018
-MKT,3020,2,Consumer Behavior,0.41,0.37,0.16,0.04,0.0,0.0,0.0,0.02,jennifer dia siemens,MKT-3020,2018
-MKT,3020,3,Consumer Behavior,0.37,0.4,0.1,0.08,0.04,0.0,0.0,0.02,fitzwater an thyroff,MKT-3020,2018
-MKT,3020,4,Consumer Behavior,0.31,0.48,0.15,0.0,0.02,0.0,0.0,0.04,fitzwater an thyroff,MKT-3020,2018
-MKT,3020,5,Consumer Behavior,0.52,0.41,0.06,0.01,0.0,0.0,0.0,0.0,patricia knowles,MKT-3020,2018
-MKT,3220,1,Social Media Marketing,0.85,0.13,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,MKT-3220,2018
-MKT,3220,2,Social Media Marketing,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-3220,2018
-MKT,3310,1,Marketing Metrics & Analytics,0.53,0.35,0.08,0.02,0.0,0.0,0.0,0.02,oriana rachel aragon,MKT-3310,2018
-MKT,3310,2,Marketing Metrics & Analytics,0.31,0.47,0.18,0.04,0.0,0.0,0.0,0.0,oriana rachel aragon,MKT-3310,2018
-MKT,3310,3,Marketing Metrics & Analytics,0.23,0.48,0.2,0.05,0.03,0.0,0.0,0.03,peter weathers,MKT-3310,2018
-MKT,3980,1,CI: Sales Experiential,0.81,0.11,0.0,0.02,0.0,0.0,0.0,0.06,carter will mcelveen,MKT-3980,2018
-MKT,4200,1,Professional Selling,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2018
-MKT,4200,2,Professional Selling,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,jesse moore,MKT-4200,2018
-MKT,4200,3,Professional Selling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,carter will mcelveen,MKT-4200,2018
-MKT,4200,4,Professional Selling,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2018
-MKT,4200,5,Professional Selling,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4200,2018
-MKT,4230,1,Promotional Strategy,0.6,0.3,0.09,0.01,0.0,0.0,0.0,0.0,patricia knowles,MKT-4230,2018
-MKT,4240,1,Sales Management,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4240,2018
-MKT,4250,1,Retail Management,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-4250,2018
-MKT,4250,2,Retail Management,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-4250,2018
-MKT,4260,1,Business-to-Business,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-4260,2018
-MKT,4260,2,Business-to-Business,0.76,0.08,0.12,0.0,0.04,0.0,0.0,0.0,xianyong wang,MKT-4260,2018
-MKT,4270,1,International Marketing,0.29,0.57,0.12,0.02,0.0,0.0,0.0,0.0,thomas poehlman,MKT-4270,2018
-MKT,4270,2,International Marketing,0.13,0.74,0.08,0.0,0.0,0.0,0.0,0.05,thomas poehlman,MKT-4270,2018
-MKT,4270,3,International Marketing,0.64,0.25,0.1,0.01,0.0,0.0,0.0,0.0,roger gomes,MKT-4270,2018
-MKT,4280,1,Services Marketing,0.58,0.33,0.07,0.0,0.02,0.0,0.0,0.0,james gaubert,MKT-4280,2018
-MKT,4280,2,Services Marketing,0.49,0.37,0.12,0.0,0.0,0.0,0.0,0.02,james gaubert,MKT-4280,2018
-MKT,4310,1,Marketing Research,0.17,0.43,0.33,0.07,0.0,0.0,0.0,0.0,peter weathers,MKT-4310,2018
-MKT,4310,2,Marketing Research,0.3,0.43,0.17,0.0,0.0,0.0,0.0,0.1,william ed kilbourne,MKT-4310,2018
-MKT,4310,3,Marketing Research,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2018
-MKT,4310,4,Marketing Research,0.37,0.6,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2018
-MKT,4330,1,Sport Mkt Strategy,0.66,0.22,0.13,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,MKT-4330,2018
-MKT,4450,1,Macromarketing,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,MKT-4450,2018
-MKT,4500,1,Strategic Mktg Mgt,0.08,0.41,0.51,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2018
-MKT,4500,2,Strategic Mktg Mgt,0.16,0.42,0.39,0.03,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2018
-MKT,4500,3,Strategic Mktg Mgt,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,MKT-4500,2018
-MKT,4500,4,Strategic Mktg Mgt,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,MKT-4500,2018
-MKT,8620,1,Quant Methods in Mkt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,MKT-8620,2018
-MKT,8650,1,Seminar in Mkt Mgmt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,MKT-8650,2018
-MKT,8660,1,International Marketing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,MKT-8660,2018
-ML,1020,1,Leadership Fund II,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,clay wilson etterle,ML-1020,2018
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,clay wilson etterle,ML-1020,2018
-ML,1020,3,Leadership Fund II,0.95,0.0,0.0,0.0,0.05,0.0,0.0,0.0,clay wilson etterle,ML-1020,2018
-ML,2020,1,Leadership Development II,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2020,2018
-ML,2020,2,Leadership Development II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2020,2018
-ML,2020,3,Leadership Development II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2020,2018
-ML,3020,1,Advanced Leadership II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william cody cleland,ML-3020,2018
-ML,3020,2,Advanced Leadership II,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,william cody cleland,ML-3020,2018
-ML,4020,1,Organizational Leadership II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kenneth tod crawford,ML-4020,2018
-MSE,2100,1,Intro to Mat Science,0.34,0.23,0.22,0.07,0.06,0.0,0.0,0.07,rakhee pani,MSE-2100,2018
-MSE,2100,2,Intro to Mat Science,0.35,0.28,0.19,0.09,0.06,0.0,0.0,0.04,ruslan burtovyy,MSE-2100,2018
-MSE,2100,3,Intro to Mat Science,0.25,0.29,0.18,0.13,0.09,0.0,0.0,0.06,fei peng,MSE-2100,2018
-MSE,2100,4,Intro to Mat Science,0.39,0.33,0.14,0.05,0.06,0.0,0.0,0.04,olga kuksenok,MSE-2100,2018
-MSE,3100,1,Intro to Metals and Ceramics,0.53,0.27,0.09,0.02,0.04,0.0,0.0,0.04,jianhua tong,MSE-3100,2018
-MSE,3260,1,Thermo of Materials,0.35,0.31,0.22,0.07,0.03,0.0,0.0,0.01,gary lickfield,MSE-3260,2018
-MSE,3270,1,Transport Phenomena,0.0,0.22,0.33,0.39,0.0,0.0,0.0,0.06,ulf daniel schiller,MSE-3270,2018
-MSE,3280,1,Phase Diagrams,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,eric skaar,MSE-3280,2018
-MSE,3420,1,Struct/Property,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kuma bordia,MSE-3420,2018
-MSE,4150,1,Polymer Sc Engr,0.33,0.44,0.17,0.03,0.0,0.0,0.0,0.03,igor luzinov,MSE-4150,2018
-MSE,4160,1,Electronic Materials,0.62,0.33,0.02,0.0,0.02,0.0,0.0,0.0,kyle brinkman,MSE-4160,2018
-MSE,4220,1,Mech Behavior of Mat,0.53,0.29,0.12,0.0,0.06,0.0,0.0,0.0,vincent yves blouin,MSE-4220,2018
-MSE,4240,1,Optical Materials,0.61,0.17,0.13,0.09,0.0,0.0,0.0,0.0,luiz gusta jacobsohn,MSE-4240,2018
-MSE,4330,1,Comb Sys & Env Emiss,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,MSE-4330,2018
-MSE,4450,1,Practice of Mat Engr,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,marek urban,MSE-4450,2018
-MSE,4560,1,Polymer & Fiber Materials II,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,gary lickfield,MSE-4560,2018
-MSE,4590,1,Color Science Lab,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,MSE-4590,2018
-MSE,4590,2,Color Science Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,MSE-4590,2018
-MSE,4810,1,Undergraduate Research Fundame,0.73,0.05,0.09,0.0,0.05,0.0,0.0,0.09,olin mefford,MSE-4810,2018
-MSE,4910,1,Undergraduate Research,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,olin mefford,MSE-4910,2018
-MSE,8190,1,Inorgan Mater Characterization,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,luiz gusta jacobsohn,MSE-8190,2018
-MSE,8260,1,Phase Equil Mat Sys,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,stephen foulger,MSE-8260,2018
-MUSC,1420,1,Music Theory I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,MUSC-1420,2018
-MUSC,1430,1,Aural Skills I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,MUSC-1430,2018
-MUSC,1440,1,Music Theory II,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,anthony bernarducci,MUSC-1440,2018
-MUSC,1510,2,Applied Music,0.67,0.19,0.05,0.0,0.05,0.0,0.0,0.05,jonathan edwar doyel,MUSC-1510,2018
-MUSC,1510,18,Applied Music,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david stevenson,MUSC-1510,2018
-MUSC,1800,1,Intro to Music Tech,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,MUSC-1800,2018
-MUSC,2100,2,Music in the Western World,0.5,0.34,0.16,0.0,0.0,0.0,0.0,0.0,lisa sain odom,MUSC-2100,2018
-MUSC,2100,3,Music in the Western World,0.29,0.55,0.06,0.0,0.0,0.0,0.0,0.1,rhea beth jacobus,MUSC-2100,2018
-MUSC,2100,5,Music in the Western World,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2018
-MUSC,2100,6,Music in the Western World,0.45,0.52,0.0,0.03,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2018
-MUSC,2100,7,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,evan michael jacobi,MUSC-2100,2018
-MUSC,2100,9,Music in the Western World,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,MUSC-2100,2018
-MUSC,3090,1,Surv of Broadway II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,MUSC-3090,2018
-MUSC,3110,1,History of American Music,0.78,0.13,0.06,0.03,0.0,0.0,0.0,0.0,ned hosler,MUSC-3110,2018
-MUSC,3120,1,History of Jazz,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,eric lapin,MUSC-3120,2018
-MUSC,3170,1,Hist of Country Mus,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3170,2018
-MUSC,3180,1,Hist of Audio Tech,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,MUSC-3180,2018
-MUSC,3690,1,Symphony Orchestra,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,andrew levin,MUSC-3690,2018
-MUSC,3700,1,Clemson University Singers,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,david hartmann,MUSC-3700,2018
-MUSC,3710,1,Women's Chorus,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,david hartmann,MUSC-3710,2018
-NPL,3000,1,Nonprofit Leadership,0.62,0.27,0.08,0.04,0.0,0.0,0.0,0.0,corey doug brookover,NPL-3000,2018
-NPL,3000,2,Nonprofit Leadership,0.63,0.17,0.13,0.0,0.04,0.0,0.0,0.04,christina mari mazer,NPL-3000,2018
-NPL,3000,3,Nonprofit Leadership,0.58,0.25,0.13,0.04,0.0,0.0,0.0,0.0,christina mari mazer,NPL-3000,2018
-NPL,3000,4,Nonprofit Leadership,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,corey doug brookover,NPL-3000,2018
-NPL,3000,5,Nonprofit Leadership,0.61,0.3,0.04,0.0,0.04,0.0,0.0,0.0,corey doug brookover,NPL-3000,2018
-NPL,3010,2,NPL Stakeholders,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,christina mari mazer,NPL-3010,2018
-NPL,3010,3,NPL Stakeholders,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christina mari mazer,NPL-3010,2018
-NPL,3020,1,NPL Fundraising,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,thomas john orourke,NPL-3020,2018
-NPL,3030,2,NPL Personnel,0.48,0.43,0.09,0.0,0.0,0.0,0.0,0.0,bonnie westb stevens,NPL-3030,2018
-NPL,3030,3,NPL Personnel,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,bonnie westb stevens,NPL-3030,2018
-NPL,3040,1,NPL Risk Management,0.71,0.06,0.06,0.12,0.06,0.0,0.0,0.0,daniel morg anderson,NPL-3040,2018
-NURS,1400,1,Comp App Hlth Care,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,NURS-1400,2018
-NURS,1400,2,Comp App Hlth Care,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,janice garris lanham,NURS-1400,2018
-NURS,1400,3,Comp App Hlth Care,0.91,0.03,0.03,0.0,0.0,0.0,0.0,0.03,jenna lynn seawright,NURS-1400,2018
-NURS,3030,1,Nursing of Adults,0.41,0.56,0.02,0.02,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2018
-NURS,3030,400,Nursing of Adults,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2018
-NURS,3040,1,Pathophysiology,0.41,0.43,0.09,0.0,0.07,0.0,0.0,0.0,catherine sik murton,NURS-3040,2018
-NURS,3040,401,Pathophysiology,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth cam hassen,NURS-3040,2018
-NURS,3100,1,Health Assessment,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,NURS-3100,2018
-NURS,3100,2,Health Assessment,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,NURS-3100,2018
-NURS,3120,1,Foundations of Nursing,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,NURS-3120,2018
-NURS,3190,400,Health Assessment for RNs,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,NURS-3190,2018
-NURS,3200,2,Prof in Nurs,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3200,2018
-NURS,3230,402,Gerontology Nurs,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,NURS-3230,2018
-NURS,3330,400,Health Care Genetics,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,mary steck,NURS-3330,2018
-NURS,3400,1,Pharmther Nursing,0.37,0.5,0.07,0.04,0.02,0.0,0.0,0.0,catherine sik murton,NURS-3400,2018
-NURS,4010,1,Mental Health Nurs,0.96,0.02,0.02,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,NURS-4010,2018
-NURS,4030,1,Complex Nursing of Adults,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen ra ewing ra,NURS-4030,2018
-NURS,4060,400,Issues in Professionalism,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,NURS-4060,2018
-NURS,4110,1,Nursing of Children,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,NURS-4110,2018
-NURS,4120,1,Nurs Women and Fam,0.74,0.24,0.0,0.02,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2018
-NURS,4250,400,Community Nursing,0.73,0.23,0.0,0.0,0.05,0.0,0.0,0.0,tiffany leah stewart,NURS-4250,2018
-NURS,8010,400,Adv Fam & Comm Nrsng,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,NURS-8010,2018
-NURS,8010,401,Adv Fam & Comm Nrsng,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,NURS-8010,2018
-NURS,8080,400,Nurs Res Stat Analys,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-8080,2018
-NURS,8080,401,Nurs Res Stat Analys,0.68,0.2,0.12,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-8080,2018
-NURS,8190,400,Developing Family,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-8190,2018
-NURS,8200,400,Child & Adol Nursing,0.25,0.46,0.21,0.0,0.08,0.0,0.0,0.0,heide temples,NURS-8200,2018
-NURS,8210,400,Adult Nursing,0.41,0.48,0.07,0.0,0.04,0.0,0.0,0.0,tracy king fasolino,NURS-8210,2018
-NURS,8210,401,Adult Nursing,0.43,0.52,0.04,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8210,2018
-NURS,8230,400,NP Clinical Practicum,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,NURS-8230,2018
-NURS,8270,400,Nurs Education Found,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,NURS-8270,2018
-NURS,8840,400,Adult Mental Health,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,NURS-8840,2018
-NURS,8850,400,Mental Health in Primary Care,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,NURS-8850,2018
-NUTR,2030,1,Intro Princ of Human Nutrition,0.56,0.33,0.05,0.01,0.02,0.0,0.0,0.02,elizabeth durrance,NUTR-2030,2018
-NUTR,2030,2,Intro Princ of Human Nutrition,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,NUTR-2030,2018
-NUTR,2040,1,Nutrition Across Life Cycle,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,bridgit deni corbett,NUTR-2040,2018
-NUTR,4200,1,Food and Culture,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,bridgit deni corbett,NUTR-4200,2018
-NUTR,4250,1,Medica Nutr Thera II,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4250,2018
-NUTR,4260,1,Community Nutrition,0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,bridgit deni corbett,NUTR-4260,2018
-NUTR,4270,1,Nutrition Counseling,0.59,0.23,0.18,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,NUTR-4270,2018
-NUTR,4550,1,Human Nutr & Metabolism II,0.67,0.12,0.12,0.09,0.0,0.0,0.0,0.0,elliot jesch,NUTR-4550,2018
-PA,2790,1,Perf Arts Pract I,0.6,0.13,0.07,0.0,0.07,0.0,0.0,0.13,kenneth moore,PA-2790,2018
-PA,2800,1,Perf Arts Pract II,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,kenneth moore,PA-2800,2018
-PADM,8220,400,Public Policy Process,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mellott eka yazykova,PADM-8220,2018
-PADM,8270,400,Public Personnel Admin,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,donna marie kazia,PADM-8270,2018
-PADM,8410,400,Public Data Analysis,0.56,0.19,0.06,0.0,0.19,0.0,0.0,0.0,ronald chrestman,PADM-8410,2018
-PADM,8410,401,Public Data Analysis,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,ronald chrestman,PADM-8410,2018
-PADM,8410,402,Public Data Analysis,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,edmond patric bowers,PADM-8410,2018
-PADM,8450,401,Grant Writing for Public Admin,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katherin kransteuber,PADM-8450,2018
-PADM,8510,400,Emergency Management Fundam,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,charles antho haynes,PADM-8510,2018
-PADM,8550,400,Homeland Sec and Intelligence,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,david leigh cook,PADM-8550,2018
-PADM,8620,400,Administrative Leadership,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,PADM-8620,2018
-PADM,8780,407,Project Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sandra marie batt,PADM-8780,2018
-PAS,1010,2,Africa Atlantic Wrld,0.18,0.53,0.0,0.0,0.06,0.0,0.0,0.24,michael blum,PAS-1010,2018
-PES,2020,1,Soils,0.22,0.47,0.27,0.02,0.02,0.0,0.0,0.02,dara michelle park,PES-2020,2018
-PES,4220,1,Major World Crops,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,sruthi narayan kutty,PES-4220,2018
-PES,4230,1,Field Crops: Forages,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,matias jose aguerre,PES-4230,2018
-PES,4330,1,Landscape & Turf Weed Mgt,0.13,0.38,0.44,0.06,0.0,0.0,0.0,0.0,ted whitwell,PES-4330,2018
-PES,4460,1,Soil Management,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,dara michelle park,PES-4460,2018
-PES,4520,1,Soil Fertility and Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,PES-4520,2018
-PES,4530,1,Soil Fertility Laboratory,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,PES-4530,2018
-PES,6520,1,Soil Fertility and Management,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,haibo liu,PES-6520,2018
-PES,8060,2,Water for Agriculture,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,sarah white,PES-8060,2018
-PES,8090,1,Analytical Technique,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14, tharayil-santhakumar,PES-8090,2018
-PHIL,1010,1,Intro to Philosophic Problems,0.61,0.24,0.03,0.0,0.0,0.0,0.0,0.12,david stegall,PHIL-1010,2018
-PHIL,1010,2,Intro to Philosophic Problems,0.49,0.23,0.09,0.06,0.0,0.0,0.0,0.14,david stegall,PHIL-1010,2018
-PHIL,1010,3,Intro to Philosophic Problems,0.27,0.64,0.03,0.0,0.03,0.0,0.0,0.03,kelly smith,PHIL-1010,2018
-PHIL,1010,5,Intro to Philosophic Problems,0.53,0.32,0.03,0.0,0.03,0.0,0.0,0.09,andrew garnar,PHIL-1010,2018
-PHIL,1020,1,Introduction to Logic,0.63,0.17,0.06,0.0,0.0,0.0,0.0,0.14,michael hal hannen,PHIL-1020,2018
-PHIL,1020,2,Introduction to Logic,0.68,0.18,0.12,0.0,0.0,0.0,0.0,0.03,michael hal hannen,PHIL-1020,2018
-PHIL,1020,3,Introduction to Logic,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,michael hal hannen,PHIL-1020,2018
-PHIL,1020,4,Introduction to Logic,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,edyta joanna kuzian,PHIL-1020,2018
-PHIL,1020,5,Introduction to Logic,0.5,0.25,0.1,0.0,0.1,0.0,0.0,0.05,edyta joanna kuzian,PHIL-1020,2018
-PHIL,1020,6,Introduction to Logic,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,adam gies,PHIL-1020,2018
-PHIL,1030,2,Introduction to Ethics,0.63,0.23,0.06,0.06,0.03,0.0,0.0,0.0,stephen satris,PHIL-1030,2018
-PHIL,1030,3,Introduction to Ethics,0.44,0.41,0.12,0.0,0.0,0.0,0.0,0.03,christopher mi wells,PHIL-1030,2018
-PHIL,1030,4,Introduction to Ethics,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-1030,2018
-PHIL,1030,5,Introduction to Ethics,0.53,0.37,0.07,0.0,0.0,0.0,0.0,0.03,adam gies,PHIL-1030,2018
-PHIL,1030,6,Introduction to Ethics,0.42,0.48,0.03,0.03,0.03,0.0,0.0,0.0,christopher mi wells,PHIL-1030,2018
-PHIL,1030,7,Introduction to Ethics,0.81,0.13,0.03,0.0,0.0,0.0,0.0,0.03,adam gies,PHIL-1030,2018
-PHIL,1030,8,Introduction to Ethics,0.34,0.47,0.09,0.03,0.0,0.0,0.0,0.06,christopher mi wells,PHIL-1030,2018
-PHIL,1030,9,Introduction to Ethics,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,charles starkey,PHIL-1030,2018
-PHIL,3040,1,Moral Philosophy,0.32,0.36,0.25,0.0,0.04,0.0,0.0,0.04,todd may,PHIL-3040,2018
-PHIL,3050,1,Existentialism,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,david stegall,PHIL-3050,2018
-PHIL,3120,1,Philosophy in Ancient China,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,yanming an,PHIL-3120,2018
-PHIL,3160,1,Modern Philosophy,0.54,0.37,0.06,0.0,0.0,0.0,0.0,0.03,michael hal hannen,PHIL-3160,2018
-PHIL,3210,1,Crime & Punishment,0.3,0.39,0.12,0.06,0.06,0.0,0.0,0.06,daniel wueste,PHIL-3210,2018
-PHIL,3260,1,Science and Values,0.57,0.37,0.03,0.0,0.0,0.0,0.0,0.03,andrew garnar,PHIL-3260,2018
-PHIL,3260,2,Science and Values,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,PHIL-3260,2018
-PHIL,3300,1,Self-Deception,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,todd may,PHIL-3300,2018
-PHIL,3300,2,Ethics of Inequality,0.17,0.52,0.09,0.0,0.0,0.0,0.0,0.22,brookes colyto brown,PHIL-3300,2018
-PHIL,3330,1,Metaphysics,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,david stegall,PHIL-3330,2018
-PHIL,3430,1,Philosophy of Law,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,brookes colyto brown,PHIL-3430,2018
-PHIL,3450,1,Environmental Ethics,0.22,0.5,0.22,0.0,0.0,0.0,0.0,0.06,christopher mi wells,PHIL-3450,2018
-PHIL,3460,1,Biomedical Ethics,0.38,0.41,0.14,0.0,0.03,0.0,0.0,0.03,charles starkey,PHIL-3460,2018
-PHIL,4750,1,Philosophy of Film,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher grau,PHIL-4750,2018
-PHSC,1170,1,Intro Chem & Earth,0.74,0.23,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1170,2018
-PHYS,1220,1,Physics with Calculus I,0.24,0.32,0.28,0.11,0.01,0.0,0.0,0.03,lih-sin the,PHYS-1220,2018
-PHYS,1220,2,Physics with Calculus I,0.24,0.41,0.24,0.06,0.02,0.0,0.0,0.03,lih-sin the,PHYS-1220,2018
-PHYS,1220,3,Physics with Calculus I,0.19,0.5,0.23,0.05,0.01,0.0,0.0,0.02,sriparn bhattacharya,PHYS-1220,2018
-PHYS,1220,4,Physics with Calculus I,0.25,0.47,0.23,0.02,0.01,0.0,0.0,0.01,sriparn bhattacharya,PHYS-1220,2018
-PHYS,1220,5,Physics with Calculus I,0.4,0.46,0.11,0.01,0.0,0.0,0.0,0.01,jason stratfor brown,PHYS-1220,2018
-PHYS,1220,8,Physics W/Cal I (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,PHYS-1220,2018
-PHYS,1240,1,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,2,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,3,Physics Lab I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,5,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,6,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,7,Physics Lab I,0.56,0.33,0.0,0.06,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,8,Physics Lab I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,9,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,10,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,11,Physics Lab I,0.44,0.44,0.0,0.0,0.06,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,12,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,13,Physics Lab I,0.22,0.72,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,14,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,15,Physics Lab I,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,16,Physics Lab I,0.76,0.12,0.0,0.06,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,17,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,18,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,19,Physics Lab I,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,20,Physics Lab I,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,21,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,22,Physics Lab I,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,23,Physics Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,25,Physics Lab I,0.53,0.24,0.06,0.0,0.12,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,26,Physics Lab I,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,27,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,29,Physics Lab I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2018
-PHYS,1240,30,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2018
-PHYS,2000,1,Introductory Physics,0.31,0.42,0.17,0.02,0.02,0.0,0.0,0.08,nicolas gr underwood,PHYS-2000,2018
-PHYS,2070,1,General Physics I,0.23,0.32,0.25,0.09,0.08,0.0,0.0,0.03,amy liann pope,PHYS-2070,2018
-PHYS,2080,1,General Physics II,0.52,0.3,0.11,0.05,0.01,0.0,0.0,0.01,amy liann pope,PHYS-2080,2018
-PHYS,2080,2,General Physics II,0.63,0.25,0.1,0.02,0.0,0.0,0.0,0.0,amy liann pope,PHYS-2080,2018
-PHYS,2090,1,Gen Phys Lab I,0.29,0.63,0.08,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,2,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,3,Gen Phys Lab I,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,4,Gen Phys Lab I,0.07,0.67,0.2,0.0,0.0,0.0,0.0,0.07,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,5,Gen Phys Lab I,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,6,Gen Phys Lab I,0.09,0.74,0.09,0.0,0.04,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,7,Gen Phys Lab I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,8,Gen Phys Lab I,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,9,Gen Phys Lab I,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2018
-PHYS,2090,10,Gen Phys Lab I,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,PHYS-2090,2018
-PHYS,2100,1,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,2,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,3,Gen Phys Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,4,Gen Phys Lab II,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,5,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,6,Gen Phys Lab II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,7,Gen Phys Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,8,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,10,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,11,Gen Phys Lab II,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,12,Gen Phys Lab II,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,13,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,14,Gen Phys Lab II,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,15,Gen Phys Lab II,0.33,0.63,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,16,Gen Phys Lab II,0.7,0.17,0.04,0.0,0.04,0.0,0.0,0.04,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,17,Gen Phys Lab II,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2100,2018
-PHYS,2100,18,Gen Phys Lab II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2018
-PHYS,2210,1,Physics with Calculus II,0.12,0.39,0.4,0.06,0.01,0.0,0.0,0.03,jason stratfor brown,PHYS-2210,2018
-PHYS,2210,2,Physics with Calculus II,0.3,0.33,0.24,0.09,0.03,0.0,0.0,0.01,jason stratfor brown,PHYS-2210,2018
-PHYS,2210,3,Physics with Calculus II (HON),0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,gerald lehmacher,PHYS-2210,2018
-PHYS,2210,5,Physics with Calculus II,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,murray daw,PHYS-2210,2018
-PHYS,2210,500,Physics with Calculus II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,elaine parshall,PHYS-2210,2018
-PHYS,2220,1,Physics with Calculus III,0.5,0.31,0.06,0.0,0.0,0.0,0.0,0.13,jian he,PHYS-2220,2018
-PHYS,2230,1,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,2,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,3,Physics Lab II,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,5,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,6,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,7,Physics Lab II,0.06,0.72,0.22,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,8,Physics Lab II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,9,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2018
-PHYS,2230,500,Physics Lab II,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,elaine parshall,PHYS-2230,2018
-PHYS,2400,1,Phys of Weather,0.27,0.39,0.21,0.05,0.02,0.0,0.0,0.06,miguel larsen,PHYS-2400,2018
-PHYS,3110,1,Methods Theor Phys,0.28,0.28,0.24,0.08,0.04,0.0,0.0,0.08,lih-sin the,PHYS-3110,2018
-PHYS,3220,1,Mechanics II,0.33,0.28,0.06,0.22,0.11,0.0,0.0,0.0,joshua alper,PHYS-3220,2018
-PHYS,3260,1,Exper Physics II,0.5,0.31,0.0,0.06,0.0,0.0,0.0,0.13,chad sosolik,PHYS-3260,2018
-PHYS,4420,1,Electromagnetics II,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,xian lu,PHYS-4420,2018
-PHYS,4560,1,Quantum Physics II,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,ramakrishna podila,PHYS-4560,2018
-PHYS,4650,1,Thermo and Stat Mech,0.41,0.35,0.06,0.18,0.0,0.0,0.0,0.0,feng ding,PHYS-4650,2018
-PHYS,8150,1,Statistical Therm I,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,jens oberheide,PHYS-8150,2018
-PHYS,8190,1,Comp Biophysics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,emil georgiev alexov,PHYS-8190,2018
-PHYS,8410,1,Electrodynamics I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,PHYS-8410,2018
-PHYS,9520,1,Quantum Mech II,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,domnita ca marinescu,PHYS-9520,2018
-PKSC,1020,1,Intro to Pkg Sci,0.24,0.42,0.27,0.02,0.04,0.0,0.0,0.01,heather batt,PKSC-1020,2018
-PKSC,2010,1,Pkg Perishable Prod,0.13,0.35,0.28,0.08,0.13,0.0,0.0,0.05,heather batt,PKSC-2010,2018
-PKSC,2020,1,Packaging Mtl & Mfg,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,PKSC-2020,2018
-PKSC,2040,1,Container Systems,0.86,0.11,0.03,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,PKSC-2040,2018
-PKSC,2060,1,Container Sys Lab,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,PKSC-2060,2018
-PKSC,2060,2,Container Sys Lab,0.54,0.38,0.04,0.04,0.0,0.0,0.0,0.0,tyler stuettgen,PKSC-2060,2018
-PKSC,2060,3,Container Sys Lab,0.32,0.45,0.18,0.05,0.0,0.0,0.0,0.0,tyler stuettgen,PKSC-2060,2018
-PKSC,2200,1,Product & Pkg Design,0.9,0.04,0.0,0.02,0.02,0.0,0.0,0.02,rupert hurley,PKSC-2200,2018
-PKSC,3200,1,Pkg Design Theory,0.84,0.14,0.0,0.0,0.0,0.0,0.0,0.02,rupert hurley,PKSC-3200,2018
-PKSC,3680,1,Pkg and Society,0.26,0.48,0.18,0.05,0.02,0.0,0.0,0.02,heather batt,PKSC-3680,2018
-PKSC,4030,1,Pkg Career Prep,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2018
-PKSC,4200,1,Pkg Design & Dev,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2018
-PKSC,4300,1,Converting Flex Pkg,0.23,0.64,0.09,0.03,0.0,0.0,0.0,0.02,duncan darby,PKSC-4300,2018
-PKSC,4400,1,Packaging for Distribution,0.26,0.46,0.23,0.0,0.03,0.0,0.0,0.03,gregory batt,PKSC-4400,2018
-PKSC,4400,400,Packaging for Distribution,0.1,0.3,0.45,0.0,0.0,0.0,0.0,0.15,gregory batt,PKSC-4400,2018
-PKSC,4640,1,Food & Health Care Pkg Systems,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2018
-PLPA,2130,1,Fungi & Civilization,0.43,0.35,0.12,0.02,0.02,0.0,0.0,0.06,julia louis kerrigan,PLPA-2130,2018
-PLPA,4060,1,Diseases/Insects Turfgrasses,0.0,0.82,0.09,0.09,0.0,0.0,0.0,0.0,samuel martin,PLPA-4060,2018
-POSC,1010,1,Amer National Govt,0.15,0.35,0.23,0.1,0.06,0.0,0.0,0.1,joseph earl stewart,POSC-1010,2018
-POSC,1010,2,Amer National Govt,0.31,0.29,0.2,0.06,0.14,0.0,0.0,0.0,alfred bundrick,POSC-1010,2018
-POSC,1020,1,Intro Intl Relations,0.56,0.3,0.08,0.0,0.04,0.0,0.0,0.02,brandon mich stewart,POSC-1020,2018
-POSC,1020,2,Intro Intl Relations,0.14,0.37,0.25,0.08,0.06,0.0,0.0,0.08,aron geor tannenbaum,POSC-1020,2018
-POSC,1020,3,Intro Intl Relations,0.33,0.42,0.08,0.02,0.06,0.0,0.0,0.08,steven vincen miller,POSC-1020,2018
-POSC,1030,1,Intro to Political Theory,0.37,0.4,0.14,0.0,0.07,0.0,0.0,0.02,brandon turner,POSC-1030,2018
-POSC,1030,2,Intro to Political Theory,0.1,0.53,0.23,0.07,0.0,0.0,0.0,0.07,colin pearce,POSC-1030,2018
-POSC,1030,3,Intro to Political Theory,0.06,0.58,0.23,0.1,0.03,0.0,0.0,0.0,colin pearce,POSC-1030,2018
-POSC,1030,4,Intro to Political Theory,0.33,0.43,0.13,0.03,0.0,0.0,0.0,0.07,lorianne molinari,POSC-1030,2018
-POSC,1040,1,Intro Compar Pol,0.21,0.58,0.16,0.0,0.0,0.0,0.0,0.05,xiaobo hu,POSC-1040,2018
-POSC,1040,2,Intro Compar Pol,0.51,0.19,0.17,0.02,0.11,0.0,0.0,0.0,brandon mich stewart,POSC-1040,2018
-POSC,1990,1,Intro Pol Sci,0.46,0.21,0.12,0.08,0.08,0.0,0.0,0.06,meredith- petersheim,POSC-1990,2018
-POSC,3020,1,State and Loc Gov,0.19,0.57,0.11,0.03,0.03,0.0,0.0,0.08,bruce ransom,POSC-3020,2018
-POSC,3210,1,Public Admin,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,POSC-3210,2018
-POSC,3610,1,International Conflict,0.2,0.23,0.18,0.09,0.18,0.0,0.0,0.11,steven vincen miller,POSC-3610,2018
-POSC,3630,1,Us Foreign Policy,0.21,0.57,0.18,0.0,0.04,0.0,0.0,0.0,jeffrey scott peake,POSC-3630,2018
-POSC,3710,1,European Politics,0.43,0.38,0.07,0.02,0.07,0.0,0.0,0.02,vladimir matic,POSC-3710,2018
-POSC,3710,615,European Politics,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,POSC-3710,2018
-POSC,3750,1,European Integration,0.2,0.25,0.3,0.05,0.1,0.0,0.0,0.1,zeynep taydas,POSC-3750,2018
-POSC,4050,1,American Presidency,0.21,0.25,0.17,0.08,0.25,0.0,0.0,0.04,adam warber,POSC-4050,2018
-POSC,4160,1,Int Groups & Soc Mov,0.24,0.39,0.22,0.1,0.0,0.0,0.0,0.05,laura olson,POSC-4160,2018
-POSC,4360,1,Law Courts Politics,0.85,0.06,0.0,0.0,0.0,0.0,0.0,0.09,joseph earl stewart,POSC-4360,2018
-POSC,4370,1,Constitut Law: Rights & Libert,0.48,0.42,0.08,0.0,0.02,0.0,0.0,0.0,daniel frost,POSC-4370,2018
-POSC,4390,1,Religious Liberty & US Const,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,POSC-4390,2018
-POSC,4480,615,Internat'l Political Economy,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,POSC-4480,2018
-POSC,4490,1,Political Theory of Capitalism,0.44,0.28,0.12,0.02,0.09,0.0,0.0,0.05,brandon turner,POSC-4490,2018
-POSC,4530,1,American Political Thought,0.47,0.4,0.09,0.0,0.02,0.0,0.0,0.02,lorianne molinari,POSC-4530,2018
-POSC,4660,1,African Politics,0.53,0.21,0.21,0.0,0.05,0.0,0.0,0.0,brandon mich stewart,POSC-4660,2018
-POSC,4710,1,Russian Politics,0.63,0.21,0.04,0.0,0.04,0.0,0.0,0.08,aron geor tannenbaum,POSC-4710,2018
-POSC,4760,1,Middle East Politics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,POSC-4760,2018
-POSC,4890,1,Religion in World Politics,0.47,0.29,0.12,0.12,0.0,0.0,0.0,0.0,laura olson,POSC-4890,2018
-PRTM,2200,1,Foundations of PRTM,0.73,0.12,0.06,0.0,0.03,0.0,0.0,0.06,gwynn powell,PRTM-2200,2018
-PRTM,2200,2,Foundations of PRTM,0.23,0.41,0.23,0.09,0.05,0.0,0.0,0.0,jamie lynn cathey,PRTM-2200,2018
-PRTM,2200,3,Foundations of PRTM,0.64,0.16,0.12,0.0,0.08,0.0,0.0,0.0,katrina latric black,PRTM-2200,2018
-PRTM,2200,4,Foundations of PRTM,0.65,0.16,0.13,0.06,0.0,0.0,0.0,0.0,lauren eliz stephens,PRTM-2200,2018
-PRTM,2260,1,Fnd of Mgt Adm PRTM,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2260,2018
-PRTM,2270,1,Prov of Leisure Exp,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2270,2018
-PRTM,2290,1,Competency Integration in PRTM,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2290,2018
-PRTM,2410,1,Intro to CRSCM,0.46,0.36,0.17,0.02,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2410,2018
-PRTM,2600,1,Found of Recreational Therapy,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,brandi crowe,PRTM-2600,2018
-PRTM,2650,1,Terminology in RT Practice,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,PRTM-2650,2018
-PRTM,2700,1,Intro Rec Res Mgt,0.62,0.35,0.0,0.04,0.0,0.0,0.0,0.0,elizabeth de baldwin,PRTM-2700,2018
-PRTM,2810,1,Intro to Golf Mgt,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,richard lucas,PRTM-2810,2018
-PRTM,2820,1,Principle Golfer Dev,0.58,0.08,0.08,0.25,0.0,0.0,0.0,0.0,richard lucas,PRTM-2820,2018
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.38,0.41,0.18,0.03,0.0,0.0,0.0,0.0,daniel morg anderson,PRTM-3050,2018
-PRTM,3070,1,Facility Operations,0.75,0.18,0.0,0.07,0.0,0.0,0.0,0.0,raymond dunham,PRTM-3070,2018
-PRTM,3210,1,Recreation Admin,0.5,0.38,0.03,0.03,0.06,0.0,0.0,0.0,jamie lynn cathey,PRTM-3210,2018
-PRTM,3250,1,Global Persp in Rec,0.6,0.33,0.03,0.0,0.03,0.0,0.0,0.03,harrison pa pinckney,PRTM-3250,2018
-PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nut townsend,PRTM-3260,2018
-PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3270,2018
-PRTM,3280,2,Preceptorship in Recr Therapy,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,PRTM-3280,2018
-PRTM,3420,1,Intro to Tourism,0.63,0.15,0.1,0.02,0.02,0.0,0.0,0.07,peter judca mkumbo,PRTM-3420,2018
-PRTM,3420,2,Intro to Tourism,0.62,0.23,0.08,0.04,0.0,0.0,0.0,0.04,garrett anders stone,PRTM-3420,2018
-PRTM,3440,1,Tourism Markets,0.89,0.04,0.04,0.04,0.0,0.0,0.0,0.0,sheila backman,PRTM-3440,2018
-PRTM,3440,2,Tourism Markets,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,PRTM-3440,2018
-PRTM,3450,1,Tourism Management,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,william norman,PRTM-3450,2018
-PRTM,3450,2,Tourism Management,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,'lisha fogle,PRTM-3450,2018
-PRTM,3460,1,Heritage Tourism,0.23,0.48,0.15,0.08,0.06,0.0,0.0,0.0,gregory phil ramshaw,PRTM-3460,2018
-PRTM,3530,2,Foundations of Camp Counseling,0.67,0.1,0.24,0.0,0.0,0.0,0.0,0.0,gwynn powell,PRTM-3530,2018
-PRTM,3900,5,Independent Study in PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-3900,2018
-PRTM,3910,10,Social Media in PRTM,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,zeynep gedikoglu,PRTM-3910,2018
-PRTM,4210,1,Rec Fin Resc Mgt,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,harrison pa pinckney,PRTM-4210,2018
-PRTM,4300,1,World Geog Parks,0.35,0.16,0.27,0.18,0.02,0.0,0.0,0.02,robert baxter powell,PRTM-4300,2018
-PRTM,4460,2,Community Tourism,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lauren duffy,PRTM-4460,2018
-PRTM,4460,3,Community Tourism,0.63,0.33,0.0,0.0,0.04,0.0,0.0,0.0,katie dudley,PRTM-4460,2018
-PRTM,4550,1,Adv Program Planning,0.72,0.11,0.0,0.11,0.0,0.0,0.0,0.06,mariela fernandez,PRTM-4550,2018
-PRTM,8080,1,Behavioral Aspects,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,robert bixler,PRTM-8080,2018
-PRTM,8110,2,Research Methods,0.7,0.22,0.04,0.0,0.04,0.0,0.0,0.0,matthew tyl brownlee,PRTM-8110,2018
-PRTM,8110,3,Research Methods,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey charle hallo,PRTM-8110,2018
-PRTM,8210,1,Funding Strategies in PRTM,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-8210,2018
-PRTM,8250,1,Populations in PRTM,0.58,0.25,0.0,0.0,0.17,0.0,0.0,0.0,teresa walton tucker,PRTM-8250,2018
-PRTM,8720,2,Adv Facilitation Techniq in RT,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,brandi crowe,PRTM-8720,2018
-PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.6,0.2,0.13,0.0,0.07,0.0,0.0,0.0,anna-mari chancellor,PRTM-8730,2018
-PRTM,8740,2,Mgt of Clinical Process in RT,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,stephen thomas lewis,PRTM-8740,2018
-PSYC,2010,1,Intro to Psychology,0.26,0.25,0.19,0.14,0.1,0.0,0.0,0.07,edwin brainerd,PSYC-2010,2018
-PSYC,2010,2,Intro to Psychology,0.37,0.32,0.18,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,PSYC-2010,2018
-PSYC,2010,3,Intro to Psychology,0.36,0.38,0.13,0.07,0.04,0.0,0.0,0.01,mary taylor,PSYC-2010,2018
-PSYC,2010,4,Intro to Psychology,0.45,0.33,0.16,0.03,0.01,0.0,0.0,0.01,mary taylor,PSYC-2010,2018
-PSYC,2010,5,Intro to Psychology,0.47,0.37,0.12,0.01,0.01,0.0,0.0,0.01,chong hyon pak,PSYC-2010,2018
-PSYC,2010,6,Intro to Psychology,0.64,0.23,0.04,0.06,0.01,0.0,0.0,0.01,chong hyon pak,PSYC-2010,2018
-PSYC,2010,8,Intro to Psychology (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,PSYC-2010,2018
-PSYC,2010,9,Intro to Psychology (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,PSYC-2010,2018
-PSYC,2020,3,Intro Psychology Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,nastassia mar savage,PSYC-2020,2018
-PSYC,2890,1,Fundamentals of Psyc Science,0.46,0.32,0.13,0.04,0.04,0.0,0.0,0.02,cynthia pury s,PSYC-2890,2018
-PSYC,3060,1,Human Sexual Behavior,0.51,0.21,0.14,0.05,0.06,0.0,0.0,0.03,bruce michael king,PSYC-3060,2018
-PSYC,3090,100,Intro Experimental Psychology,0.4,0.28,0.18,0.08,0.04,0.0,0.0,0.01,patrick rosopa,PSYC-3090,2018
-PSYC,3090,200,Intro Experimental Psychology,0.37,0.3,0.2,0.03,0.09,0.0,0.0,0.01,jennifer bail bisson,PSYC-3090,2018
-PSYC,3100,100,Advanced Experimental Psych,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,peggy tyler,PSYC-3100,2018
-PSYC,3100,200,Advanced Experimental Psych,0.32,0.24,0.16,0.2,0.04,0.0,0.0,0.04,jennifer bail bisson,PSYC-3100,2018
-PSYC,3100,300,Advanced Experimental Psych,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,fred switzer,PSYC-3100,2018
-PSYC,3100,400,Advanced Experimental Psych,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,thomas britt,PSYC-3100,2018
-PSYC,3100,500,Advanced Experimental Psych,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3100,2018
-PSYC,3100,600,Advanced Experimental Psych,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-3100,2018
-PSYC,3240,1,Physiological Psych,0.41,0.31,0.13,0.07,0.06,0.0,0.0,0.01,claudio cantalupo,PSYC-3240,2018
-PSYC,3240,2,Physiological Psych,0.26,0.28,0.23,0.12,0.04,0.0,0.0,0.07,june pilcher,PSYC-3240,2018
-PSYC,3330,1,Cognitive Psych,0.66,0.21,0.11,0.01,0.0,0.0,0.0,0.0,kaileigh angel byrne,PSYC-3330,2018
-PSYC,3330,2,Cognitive Psych,0.5,0.34,0.12,0.03,0.0,0.0,0.0,0.01,kaileigh angel byrne,PSYC-3330,2018
-PSYC,3340,1,Cognitive Psych Lab,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,laura whitlock,PSYC-3340,2018
-PSYC,3340,3,Cognitive Psych Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michael shreeves,PSYC-3340,2018
-PSYC,3340,4,Cognitive Psych Lab,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,tiffany cooper,PSYC-3340,2018
-PSYC,3400,1,Lifespan Developmental Psych,0.35,0.31,0.21,0.04,0.04,0.0,0.0,0.04,pamela alley,PSYC-3400,2018
-PSYC,3520,1,Social Psychology,0.54,0.31,0.13,0.0,0.01,0.0,0.0,0.0,eric mckibben,PSYC-3520,2018
-PSYC,3520,2,Social Psychology,0.39,0.33,0.2,0.07,0.0,0.0,0.0,0.01,jo anne jorgensen,PSYC-3520,2018
-PSYC,3640,1,Industrial Psych,0.27,0.33,0.29,0.04,0.02,0.0,0.0,0.06,eric mckibben,PSYC-3640,2018
-PSYC,3640,2,Industrial Psych,0.33,0.43,0.17,0.04,0.03,0.0,0.0,0.0,eric mckibben,PSYC-3640,2018
-PSYC,3680,1,Organizational Psych,0.49,0.33,0.13,0.01,0.01,0.0,0.0,0.01,dana verhoeven,PSYC-3680,2018
-PSYC,3700,1,Personality,0.29,0.44,0.19,0.02,0.0,0.0,0.0,0.06,eric mckibben,PSYC-3700,2018
-PSYC,3700,2,Personality,0.42,0.42,0.12,0.04,0.0,0.0,0.0,0.0,john robert hester,PSYC-3700,2018
-PSYC,3830,1,Abnormal Psychology,0.32,0.45,0.15,0.04,0.02,0.0,0.0,0.02,cynthia pury s,PSYC-3830,2018
-PSYC,3830,2,Abnormal Psychology,0.21,0.45,0.21,0.03,0.06,0.0,0.0,0.03,pamela alley,PSYC-3830,2018
-PSYC,3830,3,Abnormal Psychology,0.21,0.44,0.21,0.06,0.03,0.0,0.0,0.06,pamela alley,PSYC-3830,2018
-PSYC,3890,1,Cross-Cultural Psychology,0.25,0.34,0.22,0.12,0.03,0.0,0.0,0.03,ceren gunsoy,PSYC-3890,2018
-PSYC,3890,2,Cross-Cultural Psychology,0.41,0.28,0.16,0.07,0.04,0.0,0.0,0.04,ceren gunsoy,PSYC-3890,2018
-PSYC,4080,1,Women and Psychology,0.64,0.12,0.08,0.08,0.08,0.0,0.0,0.0,robin marie kowalski,PSYC-4080,2018
-PSYC,4150,1,Systems and Theories,0.33,0.15,0.21,0.15,0.09,0.0,0.0,0.06,edwin brainerd,PSYC-4150,2018
-PSYC,4150,2,Systems and Theories,0.38,0.19,0.16,0.06,0.13,0.0,0.0,0.09,edwin brainerd,PSYC-4150,2018
-PSYC,4220,1,Perception,0.16,0.36,0.24,0.2,0.04,0.0,0.0,0.0,claudio cantalupo,PSYC-4220,2018
-PSYC,4220,2,Perception,0.32,0.2,0.2,0.24,0.04,0.0,0.0,0.0,claudio cantalupo,PSYC-4220,2018
-PSYC,4220,3,Perception,0.4,0.28,0.28,0.0,0.04,0.0,0.0,0.0,richard tyrrell,PSYC-4220,2018
-PSYC,4350,1,Human Factors,0.52,0.24,0.08,0.08,0.04,0.0,0.0,0.04,laura whitlock,PSYC-4350,2018
-PSYC,4430,1,Infant & Child Dev,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-4430,2018
-PSYC,4560,1,Psychophysiology,0.5,0.3,0.05,0.1,0.05,0.0,0.0,0.0,drew michael morris,PSYC-4560,2018
-PSYC,4710,1,Psych of Testing,0.33,0.17,0.0,0.08,0.25,0.0,0.0,0.17,zhuo chen,PSYC-4710,2018
-PSYC,4800,1,Health Psychology,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,chelsea alyc lenoble,PSYC-4800,2018
-PSYC,4880,1,Psychotherapy,0.24,0.53,0.06,0.06,0.06,0.0,0.0,0.06,lucinda sorcie quick,PSYC-4880,2018
-PSYC,4890,1,Psychology of Music,0.64,0.28,0.04,0.0,0.0,0.0,0.0,0.04,robert campbell,PSYC-4890,2018
-PSYC,4920,1,Senior Laboratory,0.79,0.07,0.11,0.0,0.04,0.0,0.0,0.0,pamela farago,PSYC-4920,2018
-PSYC,4920,2,Senior Laboratory,0.82,0.07,0.07,0.04,0.0,0.0,0.0,0.0,pamela farago,PSYC-4920,2018
-PSYC,4920,3,Senior Laboratory,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,stephen an robertson,PSYC-4920,2018
-PSYC,4920,4,Senior Laboratory,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,stephen an robertson,PSYC-4920,2018
-PSYC,4930,100,Pract Clinical Psych,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,heidi marie zinzow,PSYC-4930,2018
-PSYC,8130,1,Research Design III,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,patrick rosopa,PSYC-8130,2018
-PSYC,8330,1,Adv Cog Psych,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,leo gugerty,PSYC-8330,2018
-PSYC,8610,1,Personnel Psych,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,patrick raymark,PSYC-8610,2018
-PSYC,8820,1,Occupat Health Psy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert raym sinclair,PSYC-8820,2018
-RED,8030,1,Pub-Priv Partnership,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john terrence farris,RED-8030,2018
-REL,1010,1,Intro to Religion,0.34,0.31,0.22,0.03,0.03,0.0,0.0,0.06,peter cohen,REL-1010,2018
-REL,1010,2,Intro to Religion,0.29,0.31,0.29,0.03,0.06,0.0,0.0,0.03,peter cohen,REL-1010,2018
-REL,1010,3,Intro to Religion,0.18,0.33,0.33,0.06,0.03,0.0,0.0,0.06,peter cohen,REL-1010,2018
-REL,1010,4,Intro to Religion,0.32,0.26,0.32,0.0,0.0,0.0,0.0,0.11,brett patterson,REL-1010,2018
-REL,1010,5,Intro to Religion,0.16,0.55,0.13,0.1,0.03,0.0,0.0,0.03,brett patterson,REL-1010,2018
-REL,1020,1,World Religions,0.36,0.52,0.03,0.0,0.0,0.0,0.0,0.09,robert stephens,REL-1020,2018
-REL,1020,2,World Religions,0.32,0.32,0.21,0.0,0.0,0.0,0.0,0.15,robert stephens,REL-1020,2018
-REL,1020,4,World Religions,0.34,0.53,0.09,0.0,0.0,0.0,0.0,0.03,robert stephens,REL-1020,2018
-REL,3000,2,Studying Religion,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,steven grosby,REL-3000,2018
-REL,3010,1,Old Testament,0.56,0.29,0.06,0.0,0.0,0.0,0.0,0.09,steven grosby,REL-3010,2018
-REL,3030,1,The Quran,0.46,0.38,0.04,0.0,0.04,0.0,0.0,0.08,mashal saif,REL-3030,2018
-REL,3070,1,Christian Trad,0.43,0.36,0.18,0.0,0.0,0.0,0.0,0.04,brett patterson,REL-3070,2018
-REL,3120,1,Hinduism,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert stephens,REL-3120,2018
-REL,3300,1,Contemporary Issues,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.12,richard ale amesbury,REL-3300,2018
-RUSS,1020,1,Elementary Russian,0.27,0.55,0.09,0.09,0.0,0.0,0.0,0.0,stephanie ely morris,RUSS-1020,2018
-RUSS,1020,2,Elementary Russian,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,stephanie ely morris,RUSS-1020,2018
-RUSS,3600,1,Russian Lit to 1910,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,olga anatoly volkova,RUSS-3600,2018
-RUSS,3610,1,Russn Lit Since 1910,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,olga anatoly volkova,RUSS-3610,2018
-SOC,2010,2,Introduction to Sociology,0.88,0.1,0.0,0.0,0.02,0.0,0.0,0.0,andrew he mannheimer,SOC-2010,2018
-SOC,2010,3,Introduction to Sociology,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.01,andrew he mannheimer,SOC-2010,2018
-SOC,2010,4,Introduction to Sociology,0.39,0.41,0.15,0.04,0.0,0.0,0.0,0.0,carolyn cand coffman,SOC-2010,2018
-SOC,2010,5,Introduction to Sociology,0.51,0.32,0.12,0.01,0.03,0.0,0.0,0.01,carolyn cand coffman,SOC-2010,2018
-SOC,2010,6,Introduction to Sociology,0.65,0.17,0.11,0.02,0.0,0.0,0.0,0.04,carolyn cand coffman,SOC-2010,2018
-SOC,2010,7,Introduction to Sociology,0.73,0.13,0.04,0.04,0.04,0.0,0.0,0.03,stacy leanne smith,SOC-2010,2018
-SOC,2010,8,Introduction to Sociology,0.76,0.11,0.09,0.02,0.02,0.0,0.0,0.0,stacy leanne smith,SOC-2010,2018
-SOC,2010,9,Introduction to Sociology,0.85,0.09,0.02,0.02,0.0,0.0,0.0,0.02,stacy leanne smith,SOC-2010,2018
-SOC,2010,10,Introduction to Sociology,0.51,0.39,0.08,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2018
-SOC,2010,11,Introduction to Sociology,0.64,0.26,0.09,0.01,0.0,0.0,0.0,0.0,shannon mcdonough,SOC-2010,2018
-SOC,2010,12,Introduction to Sociology,0.61,0.24,0.1,0.02,0.0,0.0,0.0,0.02,shannon mcdonough,SOC-2010,2018
-SOC,2020,1,Social Problems,0.47,0.36,0.11,0.02,0.04,0.0,0.0,0.0,carolyn cand coffman,SOC-2020,2018
-SOC,3020,1,Research Methods I,0.33,0.27,0.27,0.03,0.03,0.0,0.0,0.07,andrew whitehead,SOC-3020,2018
-SOC,3040,1,Social Research Methods II,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,william haller,SOC-3040,2018
-SOC,3100,1,Marriage & Intimacy,0.62,0.16,0.18,0.0,0.02,0.0,0.0,0.02,carolyn cand coffman,SOC-3100,2018
-SOC,3110,1,The Family,0.36,0.49,0.11,0.04,0.0,0.0,0.0,0.0,traci ann hefner,SOC-3110,2018
-SOC,3600,1,Class & Poverty,0.24,0.49,0.2,0.05,0.02,0.0,0.0,0.0,kenneth robinson,SOC-3600,2018
-SOC,3800,1,Intro Social Service,0.58,0.35,0.04,0.02,0.0,0.0,0.0,0.0,jennifer lea holland,SOC-3800,2018
-SOC,3910,1,Soc of Deviance,0.5,0.38,0.08,0.02,0.02,0.0,0.0,0.0,shannon mcdonough,SOC-3910,2018
-SOC,4040,1,Soc Theory,0.52,0.26,0.13,0.1,0.0,0.0,0.0,0.0,stacy leanne smith,SOC-4040,2018
-SOC,4320,1,Soc of Religion,0.31,0.4,0.29,0.0,0.0,0.0,0.0,0.0,andrew whitehead,SOC-4320,2018
-SOC,4330,1,Global Social Change,0.33,0.38,0.17,0.02,0.05,0.0,0.0,0.05,traci ann hefner,SOC-4330,2018
-SOC,4600,1,Race & Ethnicity,0.77,0.18,0.02,0.02,0.0,0.0,0.0,0.0,andrew he mannheimer,SOC-4600,2018
-SOC,4600,2,Race & Ethnicity,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrew he mannheimer,SOC-4600,2018
-SOC,4610,1,Sex & Gender,0.28,0.35,0.14,0.16,0.07,0.0,0.0,0.0,sarah evelyn winslow,SOC-4610,2018
-SOC,4840,1,Child Abuse,0.81,0.16,0.0,0.0,0.0,0.0,0.0,0.03,james rosenberger,SOC-4840,2018
-SOC,4970,1,Senior Lab,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,jennifer lea holland,SOC-4970,2018
-SPAN,1010,1,Elementary Spanish,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,SPAN-1010,2018
-SPAN,1010,2,Elementary Spanish,0.47,0.16,0.26,0.0,0.0,0.0,0.0,0.11,rosa maca pillcurima,SPAN-1010,2018
-SPAN,1010,3,Elementary Spanish,0.41,0.14,0.27,0.0,0.09,0.0,0.0,0.09,rosa maca pillcurima,SPAN-1010,2018
-SPAN,1020,2,Elementary Spanish,0.32,0.5,0.09,0.05,0.0,0.0,0.0,0.05,ellory schmucker,SPAN-1020,2018
-SPAN,1020,3,Elementary Spanish,0.39,0.48,0.09,0.0,0.04,0.0,0.0,0.0,adrienne elizab fama,SPAN-1020,2018
-SPAN,1020,4,Elementary Spanish,0.27,0.32,0.32,0.09,0.0,0.0,0.0,0.0,adrienne elizab fama,SPAN-1020,2018
-SPAN,1020,5,Elementary Spanish,0.14,0.55,0.23,0.05,0.0,0.0,0.0,0.05,rosa maca pillcurima,SPAN-1020,2018
-SPAN,1020,7,Elementary Spanish,0.36,0.36,0.18,0.0,0.09,0.0,0.0,0.0,cathy robison,SPAN-1020,2018
-SPAN,1020,8,Elementary Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,debra oak williamson,SPAN-1020,2018
-SPAN,1020,9,Elementary Spanish,0.47,0.21,0.26,0.0,0.0,0.0,0.0,0.05,debra oak williamson,SPAN-1020,2018
-SPAN,1020,10,Elementary Spanish,0.43,0.38,0.14,0.0,0.05,0.0,0.0,0.0,adrienne elizab fama,SPAN-1020,2018
-SPAN,2010,1,Intermediate Spanish,0.23,0.5,0.14,0.05,0.0,0.0,0.0,0.09,cathy robison,SPAN-2010,2018
-SPAN,2010,2,Intermediate Spanish,0.26,0.26,0.26,0.11,0.0,0.0,0.0,0.11,cathy robison,SPAN-2010,2018
-SPAN,2010,3,Intermediate Spanish,0.39,0.39,0.22,0.0,0.0,0.0,0.0,0.0,allison ann hinds,SPAN-2010,2018
-SPAN,2010,4,Intermediate Spanish,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,nora arostegui logue,SPAN-2010,2018
-SPAN,2010,5,Intermediate Spanish,0.39,0.44,0.06,0.0,0.06,0.0,0.0,0.06,allison ann hinds,SPAN-2010,2018
-SPAN,2010,6,Intermediate Spanish,0.31,0.46,0.0,0.08,0.0,0.0,0.0,0.15,debra oak williamson,SPAN-2010,2018
-SPAN,2010,7,Intermediate Spanish,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,debra oak williamson,SPAN-2010,2018
-SPAN,2010,8,Intermediate Spanish,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2018
-SPAN,2010,9,Intermediate Spanish,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2018
-SPAN,2010,10,Intermediate Spanish,0.65,0.22,0.04,0.04,0.0,0.0,0.0,0.04,vieyra daniel garcia,SPAN-2010,2018
-SPAN,2010,12,Intermediate Spanish,0.64,0.07,0.07,0.0,0.07,0.0,0.0,0.14,valderramos zen cruz,SPAN-2010,2018
-SPAN,2010,13,Intermediate Spanish,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,SPAN-2010,2018
-SPAN,2010,14,Intermediate Spanish,0.61,0.22,0.09,0.0,0.0,0.0,0.0,0.09,ellory schmucker,SPAN-2010,2018
-SPAN,2010,16,Intermediate Spanish,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,vieyra daniel garcia,SPAN-2010,2018
-SPAN,2020,1,Intermediate Spanish,0.7,0.22,0.04,0.0,0.04,0.0,0.0,0.0,vieyra daniel garcia,SPAN-2020,2018
-SPAN,2020,2,Intermediate Spanish,0.71,0.1,0.14,0.05,0.0,0.0,0.0,0.0,vieyra daniel garcia,SPAN-2020,2018
-SPAN,2020,3,Intermediate Spanish,0.7,0.17,0.13,0.0,0.0,0.0,0.0,0.0,vieyra daniel garcia,SPAN-2020,2018
-SPAN,2020,4,Intermediate Spanish,0.48,0.38,0.1,0.0,0.0,0.0,0.0,0.05,valderramos zen cruz,SPAN-2020,2018
-SPAN,2020,5,Intermediate Spanish,0.55,0.23,0.14,0.0,0.0,0.0,0.0,0.09,valderramos zen cruz,SPAN-2020,2018
-SPAN,2020,6,Intermediate Spanish,0.52,0.35,0.13,0.0,0.0,0.0,0.0,0.0,valderramos zen cruz,SPAN-2020,2018
-SPAN,2020,7,Intermediate Spanish,0.12,0.47,0.12,0.12,0.18,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2018
-SPAN,2020,8,Intermediate Spanish,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,SPAN-2020,2018
-SPAN,2020,9,Intermediate Spanish,0.42,0.42,0.05,0.11,0.0,0.0,0.0,0.0,ana paula  miller e,SPAN-2020,2018
-SPAN,2020,10,Intermediate Spanish,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,SPAN-2020,2018
-SPAN,2020,11,Intermediate Spanish,0.65,0.26,0.04,0.0,0.0,0.0,0.0,0.04,rodriguez alm garcia,SPAN-2020,2018
-SPAN,2020,12,Intermediate Spanish,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,SPAN-2020,2018
-SPAN,2020,13,Intermediate Spanish,0.19,0.48,0.24,0.0,0.0,0.0,0.0,0.1,juana martin-armas,SPAN-2020,2018
-SPAN,2020,14,Intermediate Spanish,0.1,0.5,0.2,0.2,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-2020,2018
-SPAN,2020,15,Intermediate Spanish,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,ana paula  miller e,SPAN-2020,2018
-SPAN,2020,20,Intermediate Spanish,0.45,0.23,0.27,0.0,0.0,0.0,0.0,0.05,melva margue persico,SPAN-2020,2018
-SPAN,3020,1,Intermed Span Grammar & Comp,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,SPAN-3020,2018
-SPAN,3020,2,Intermed Span Grammar & Comp,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,melva margue persico,SPAN-3020,2018
-SPAN,3020,3,Intermed Span Grammar & Comp,0.42,0.37,0.05,0.0,0.05,0.0,0.0,0.11,melva margue persico,SPAN-3020,2018
-SPAN,3040,1,Intro Hispanic Literary Forms,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,SPAN-3040,2018
-SPAN,3040,2,Intro Hispanic Literary Forms,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,rodriguez alm garcia,SPAN-3040,2018
-SPAN,3050,1,Intermed Span Convers/Comp I,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,melva margue persico,SPAN-3050,2018
-SPAN,3050,2,Intermed Span Convers/Comp I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,riquelme maria judez,SPAN-3050,2018
-SPAN,3050,4,Intermed Span Convers/Comp I,0.72,0.17,0.06,0.06,0.0,0.0,0.0,0.0,moni rojas-de-massei,SPAN-3050,2018
-SPAN,3060,1,Span Comp for Bus,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-3060,2018
-SPAN,3070,1,The Hispanic World: Spain,0.5,0.44,0.0,0.06,0.0,0.0,0.0,0.0,juana martin-armas,SPAN-3070,2018
-SPAN,3080,1,The Hispanic World: Latin Amer,0.24,0.47,0.18,0.0,0.12,0.0,0.0,0.0,tiffany dawn miller,SPAN-3080,2018
-SPAN,3130,2,Span Lit Survey I,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william dan holcombe,SPAN-3130,2018
-SPAN,4060,1,Narrative Fiction,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,moni rojas-de-massei,SPAN-4060,2018
-SPAN,4070,1,Hispanic Film,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,raquel anido,SPAN-4070,2018
-SPAN,4170,1,Prof Communication,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,SPAN-4170,2018
-SPAN,4180,1,Technical Span Health Mgt Prof,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,peralta arelis moore,SPAN-4180,2018
-STAT,2220,1,Statistics in Everyday Life,0.38,0.25,0.27,0.04,0.04,0.0,0.0,0.02,james espey,STAT-2220,2018
-STAT,2220,2,Statistics in Everyday Life,0.39,0.31,0.14,0.04,0.06,0.0,0.0,0.06,james espey,STAT-2220,2018
-STAT,2220,3,Statistics in Everyday Life,0.35,0.31,0.17,0.08,0.08,0.0,0.0,0.02,james espey,STAT-2220,2018
-STAT,2220,4,Statistics in Everyday Life,0.27,0.35,0.17,0.1,0.0,0.0,0.0,0.12,james espey,STAT-2220,2018
-STAT,2220,5,Statistics in Everyday Life,0.31,0.43,0.16,0.06,0.02,0.0,0.0,0.02,rose martinez-dawson,STAT-2220,2018
-STAT,2220,6,Statistics in Everyday Life,0.47,0.22,0.18,0.08,0.06,0.0,0.0,0.0,rose martinez-dawson,STAT-2220,2018
-STAT,2220,7,Statistics in Everyday Life,0.27,0.33,0.27,0.08,0.0,0.0,0.0,0.04,jason alexander kurz,STAT-2220,2018
-STAT,2220,8,Statistics in Everyday Life,0.14,0.35,0.22,0.05,0.19,0.0,0.0,0.05,andrew pangia,STAT-2220,2018
-STAT,2300,1,Statistical Methods I,0.22,0.33,0.21,0.11,0.08,0.0,0.0,0.04,april thomas,STAT-2300,2018
-STAT,2300,2,Statistical Methods I,0.32,0.33,0.17,0.12,0.03,0.0,0.0,0.04,christy jenkin brown,STAT-2300,2018
-STAT,2300,3,Statistical Methods I,0.3,0.35,0.16,0.08,0.05,0.0,0.0,0.05, erwin walker,STAT-2300,2018
-STAT,2300,4,Statistical Methods I,0.27,0.3,0.18,0.11,0.08,0.0,0.0,0.06, erwin walker,STAT-2300,2018
-STAT,2300,5,Statistical Methods I,0.21,0.38,0.22,0.08,0.11,0.0,0.0,0.01,elaine mar sotherden,STAT-2300,2018
-STAT,2300,6,Statistical Methods I,0.28,0.41,0.18,0.08,0.04,0.0,0.0,0.01,todd fenstermacher,STAT-2300,2018
-STAT,2300,100,Statistical Methods I (HON),0.73,0.24,0.03,0.0,0.0,0.0,0.0,0.0,christy jenkin brown,STAT-2300,2018
-STAT,3090,1,Introductory Business Stats,0.16,0.21,0.29,0.08,0.16,0.0,0.0,0.11,tianhui wei,STAT-3090,2018
-STAT,3090,2,Introductory Business Stats,0.14,0.17,0.17,0.19,0.25,0.0,0.0,0.08,matthew saltzman,STAT-3090,2018
-STAT,3090,3,Introductory Business Stats,0.31,0.29,0.12,0.17,0.07,0.0,0.0,0.05,tiantian yang,STAT-3090,2018
-STAT,3090,4,Introductory Business Stats,0.2,0.25,0.16,0.18,0.11,0.0,0.0,0.09,margaret mari wiecek,STAT-3090,2018
-STAT,3090,5,Introductory Business Stats,0.2,0.18,0.23,0.16,0.16,0.0,0.0,0.07,lu sun,STAT-3090,2018
-STAT,3090,6,Introductory Business Stats,0.18,0.3,0.27,0.05,0.2,0.0,0.0,0.0,boyoung hur,STAT-3090,2018
-STAT,3090,7,Introductory Business Stats,0.26,0.31,0.19,0.12,0.1,0.0,0.0,0.02,jiajing niu,STAT-3090,2018
-STAT,3090,8,Introductory Business Stats,0.26,0.21,0.33,0.05,0.13,0.0,0.0,0.03,yisu jia,STAT-3090,2018
-STAT,3090,9,Introductory Business Stats,0.29,0.4,0.26,0.06,0.0,0.0,0.0,0.0,marilyn reba,STAT-3090,2018
-STAT,3090,10,Introductory Business Stats,0.28,0.56,0.06,0.08,0.03,0.0,0.0,0.0,marilyn reba,STAT-3090,2018
-STAT,3090,11,Introductory Business Stats,0.24,0.23,0.26,0.14,0.12,0.0,0.0,0.01,sharon marie evans,STAT-3090,2018
-STAT,3090,12,Introductory Business Stats,0.2,0.34,0.26,0.09,0.08,0.0,0.0,0.02,sharon marie evans,STAT-3090,2018
-STAT,3300,1,Statistical Methods II,0.36,0.36,0.12,0.08,0.04,0.0,0.0,0.04,rose martinez-dawson,STAT-3300,2018
-STAT,4020,1,Intro to Statistical Computing,0.43,0.24,0.1,0.0,0.14,0.0,0.0,0.1,ellen hepfer breazel,STAT-4020,2018
-STAT,4110,1,Stat Mthds for Process Control,0.71,0.18,0.09,0.0,0.03,0.0,0.0,0.0,richard steve dubsky,STAT-4110,2018
-STAT,6020,1,Intro to Statistical Computing,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,STAT-6020,2018
-STAT,8010,1,Statistical Methods I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james rieck,STAT-8010,2018
-STAT,8010,2,Statistical Methods I,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-8010,2018
-STAT,8010,3,Statistical Methods I,0.32,0.36,0.18,0.0,0.09,0.0,0.0,0.05,james rieck,STAT-8010,2018
-STAT,8010,4,Statistical Methods I,0.43,0.52,0.04,0.0,0.0,0.0,0.0,0.0,patrick gerard,STAT-8010,2018
-STAT,8010,5,Statistical Methods I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,joseph daniel bible,STAT-8010,2018
-STAT,8010,400,Statistical Methods I,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,brook thayer russell,STAT-8010,2018
-STAT,8050,1,Design & Anlys of Experiments,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,william bridges,STAT-8050,2018
-STS,1010,2,Survey of S T S,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,scott brame,STS-1010,2018
-STS,1010,3,Survey of S T S,0.5,0.36,0.11,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,STS-1010,2018
-STS,1010,4,Survey of S T S,0.69,0.25,0.03,0.0,0.0,0.0,0.0,0.03,melissa dugan,STS-1010,2018
-STS,1010,5,Survey of S T S,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,philip randall,STS-1010,2018
-STS,1010,6,Survey of S T S,0.17,0.51,0.23,0.0,0.0,0.0,0.0,0.09,sarah mae cooper,STS-1010,2018
-STS,1010,7,Survey of S T S,0.22,0.47,0.25,0.0,0.0,0.0,0.0,0.06,megan noe macalystre,STS-1010,2018
-STS,1010,8,Survey of S T S,0.27,0.4,0.2,0.03,0.0,0.0,0.0,0.1,david charles foltz,STS-1010,2018
-STS,1010,9,Survey of S T S,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,stephanie stripling,STS-1010,2018
-THEA,2100,1,Theatre Appreciation,0.55,0.29,0.06,0.03,0.0,0.0,0.0,0.06,kendra lynet johnson,THEA-2100,2018
-THEA,2100,2,Theatre Appreciation,0.66,0.19,0.06,0.0,0.06,0.0,0.0,0.03,kerrie kathl seymour,THEA-2100,2018
-THEA,2100,3,Theatre Appreciation,0.87,0.06,0.03,0.0,0.0,0.0,0.0,0.03,shannon there robert,THEA-2100,2018
-THEA,2100,5,Theatre Appreciation,0.43,0.47,0.07,0.0,0.0,0.0,0.0,0.03,carol collins,THEA-2100,2018
-THEA,2100,6,Theatre Appreciation,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,THEA-2100,2018
-THEA,2100,7,Theatre Appreciation,0.66,0.28,0.03,0.0,0.0,0.0,0.0,0.03,jason adkins,THEA-2100,2018
-THEA,2790,1,Theatre Practicum,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,matthew leckenbusch,THEA-2790,2018
-THEA,3160,1,Theatre History II,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,peter richard er st. er,THEA-3160,2018
-THEA,3180,1,Afri-Amer Thea II,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,kendra lynet johnson,THEA-3180,2018
-THEA,3770,1,Stagecrafts,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david hartmann,THEA-3770,2018
-THEA,4790,1,Acting II,0.54,0.23,0.08,0.08,0.08,0.0,0.0,0.0,kerrie kathl seymour,THEA-4790,2018
-WFB,3010,1,Wildlife Biology Lab,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,shari lynn rodriguez,WFB-3010,2018
-WFB,3010,2,Wildlife Biology Lab,0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,shari lynn rodriguez,WFB-3010,2018
-WFB,3130,1,Conservation Biology,0.35,0.39,0.16,0.05,0.03,0.0,0.0,0.03,shari lynn rodriguez,WFB-3130,2018
-WFB,3130,2,Conservation Biology,0.27,0.35,0.24,0.08,0.03,0.0,0.0,0.03,shari lynn rodriguez,WFB-3130,2018
-WFB,3500,1,Princ Fish & Wildlife Biology,0.3,0.46,0.2,0.04,0.0,0.0,0.0,0.0,james davis,WFB-3500,2018
-WFB,3500,2,Princ Fish & Wildlife Biology,0.18,0.5,0.25,0.05,0.0,0.0,0.0,0.02,james davis,WFB-3500,2018
-WFB,4120,1,Wildlife Management,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,WFB-4120,2018
-WFB,4160,1,Fisheries Techniques,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,brandon kevi peoples,WFB-4160,2018
-WFB,4620,1,Wetland Wildlife Biology,0.74,0.23,0.01,0.0,0.0,0.0,0.0,0.01,russell barrett,WFB-4620,2018
-WFB,4930,2,Quantitative Ecology,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,david scot jachowski,WFB-4930,2018
-WFB,8500,1,Wildlife & Fisheries Ecology,0.44,0.33,0.15,0.0,0.04,0.0,0.0,0.04,susan talley guynn,WFB-8500,2018
-WS,1030,1,Women in Global Perspective,0.88,0.04,0.0,0.04,0.0,0.0,0.0,0.04,annie boiter-jolley,WS-1030,2018
-WS,1030,2,Women in Global Perspective,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,annie boiter-jolley,WS-1030,2018
-WS,2400,1,Women and Leadership II,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,diane perpich,WS-2400,2018
-WS,3010,1,Intro Women's Studies,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,elizabeth rose adams,WS-3010,2018
-WS,3010,2,Intro Women's Studies,0.68,0.27,0.0,0.0,0.05,0.0,0.0,0.0,elizabeth rose adams,WS-3010,2018
-YDP,3100,1,Youth Developmt and the Family,0.79,0.14,0.04,0.0,0.04,0.0,0.0,0.0,william quinn,YDP-3100,2018
-YDP,3100,3,Youth Developmt and the Family,0.81,0.07,0.07,0.0,0.04,0.0,0.0,0.0,william quinn,YDP-3100,2018
-YDP,3250,1,Working with Diverse Youth,0.79,0.14,0.04,0.0,0.0,0.0,0.0,0.04,kimberly pea johnson,YDP-3250,2018
-YDP,4400,1,Youth Program Assessmnt & Eval,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,ann marie gillard,YDP-4400,2018
-YDP,4550,1,Youth and Technology,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,david lynn pollock,YDP-4550,2018
-YDP,8010,1,Child/Adolescent Dev,0.68,0.24,0.04,0.0,0.04,0.0,0.0,0.0,edmond patric bowers,YDP-8010,2018
-YDP,8040,1,Assess & Eval of Youth Program,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,YDP-8040,2018
-YDP,8880,1,Special Topics Youth Dev Ldshp,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,barry garst,YDP-8880,2018
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1020,1,Survey of Art & Arch Hist II,0.4,0.4,0.17,0.0,0.01,0.0,0.0,0.01,andrea feeser,
+AAH,2060,1,Art History and Theory II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
+ACCT,2010,1,Financial Accounting Concepts,0.13,0.31,0.29,0.1,0.17,0.0,0.0,0.0,emily suzan mccorkle,
+ACCT,2010,2,Financial Accounting Concepts,0.33,0.38,0.16,0.04,0.07,0.0,0.0,0.02,lydia lanc schleifer,
+ACCT,2010,3,Financial Accounting Concepts,0.28,0.22,0.34,0.08,0.08,0.0,0.0,0.0,annieka philo,
+ACCT,2010,4,Financial Accounting Concepts,0.4,0.28,0.14,0.1,0.04,0.0,0.0,0.04,emily suzan mccorkle,
+ACCT,2010,5,Financial Accounting Concepts,0.41,0.31,0.18,0.02,0.04,0.0,0.0,0.04,annieka philo,
+ACCT,2010,6,Financial Accounting Concepts,0.43,0.31,0.1,0.02,0.06,0.0,0.0,0.08,lydia lanc schleifer,
+ACCT,2010,7,Financial Accounting Concepts,0.31,0.52,0.04,0.02,0.08,0.0,0.0,0.02,lydia lanc schleifer,
+ACCT,2010,8,Financial Accounting Concepts,0.37,0.35,0.16,0.04,0.04,0.0,0.0,0.04,emily suzan mccorkle,
+ACCT,2010,9,Financial Accounting Concepts,0.3,0.32,0.22,0.04,0.1,0.0,0.0,0.02,emily suzan mccorkle,
+ACCT,2010,10,Financial Accounting Concepts,0.18,0.36,0.24,0.12,0.08,0.0,0.0,0.02,james barnes,
+ACCT,2010,11,Financial Accounting Concepts,0.3,0.36,0.2,0.06,0.08,0.0,0.0,0.0,rebecca pennell trax,
+ACCT,2010,12,Financial Accounting Concepts,0.37,0.31,0.18,0.06,0.04,0.0,0.0,0.04,rebecca pennell trax,
+ACCT,2010,13,Financial Accounting Concepts,0.49,0.24,0.1,0.07,0.05,0.0,0.0,0.05,charles tegen,
+ACCT,2010,14,Financial Accounting Concepts,0.29,0.29,0.32,0.03,0.06,0.0,0.0,0.0,philip maiberger,
+ACCT,2010,15,Financial Accounting Concepts,0.24,0.43,0.14,0.1,0.05,0.0,0.0,0.05,lisa whea birtwistle,
+ACCT,2010,16,Financial Accounting Concepts,0.12,0.38,0.22,0.08,0.16,0.0,0.0,0.04,james barnes,
+ACCT,2010,101,Fin Acct Concepts (HON),0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,lisa whea birtwistle,True
+ACCT,2010,401,Financial Accounting Concepts,0.31,0.48,0.1,0.08,0.01,0.0,0.0,0.02,jeffrey mcmillan,
+ACCT,2020,1,Managerial Accounting Concepts,0.17,0.34,0.17,0.03,0.06,0.0,0.0,0.23,henry anderson,
+ACCT,2020,2,Managerial Accounting Concepts,0.19,0.28,0.17,0.02,0.02,0.0,0.0,0.33,henry anderson,
+ACCT,2020,3,Managerial Accounting Concepts,0.27,0.29,0.22,0.14,0.06,0.0,0.0,0.02,phebian davis-culler,
+ACCT,2020,4,Managerial Accounting Concepts,0.42,0.33,0.19,0.04,0.02,0.0,0.0,0.0,james milt kohlmeyer,
+ACCT,2020,5,Managerial Accounting Concepts,0.22,0.33,0.13,0.04,0.07,0.0,0.0,0.2,henry anderson,
+ACCT,2020,6,Managerial Accounting Concepts,0.29,0.29,0.21,0.09,0.04,0.0,0.0,0.09,brian todd carver,
+ACCT,2020,7,Managerial Accounting Concepts,0.15,0.31,0.27,0.0,0.17,0.0,0.0,0.1,brian todd carver,
+ACCT,2020,401,Managerial Accounting Concepts,0.33,0.28,0.18,0.05,0.03,0.0,0.0,0.12,henry anderson,
+ACCT,3030,1,Cost Accounting,0.3,0.36,0.23,0.11,0.0,0.0,0.0,0.0,phebian davis-culler,
+ACCT,3030,2,Cost Accounting,0.36,0.27,0.27,0.04,0.04,0.0,0.0,0.02,phebian davis-culler,
+ACCT,3030,3,Cost Accounting,0.2,0.32,0.32,0.07,0.0,0.0,0.0,0.1,jace garrett,
+ACCT,3030,4,Cost Accounting,0.13,0.32,0.36,0.06,0.11,0.0,0.0,0.02,jace garrett,
+ACCT,3110,1,Intermediate Financial Acct I,0.29,0.33,0.19,0.05,0.07,0.0,0.0,0.07,erin michell hawkins,
+ACCT,3110,2,Intermediate Financial Acct I,0.18,0.5,0.23,0.05,0.05,0.0,0.0,0.0,erin michell hawkins,
+ACCT,3110,3,Intermediate Financial Acct I,0.22,0.44,0.2,0.13,0.0,0.0,0.0,0.0,amy melissa donnelly,
+ACCT,3110,4,Intermediate Financial Acct I,0.29,0.33,0.31,0.07,0.0,0.0,0.0,0.0,amy melissa donnelly,
+ACCT,3110,401,Intermediate Financial Acct I,0.49,0.27,0.08,0.06,0.02,0.0,0.0,0.08,henry anderson,
+ACCT,3120,1,Intermediate Financial Acct II,0.0,0.18,0.45,0.18,0.18,0.0,0.0,0.0,jeremy michae vinson,
+ACCT,3120,2,Intermediate Financial Acct II,0.32,0.36,0.25,0.05,0.0,0.0,0.0,0.02,terry daniel knause,
+ACCT,3120,3,Intermediate Financial Acct II,0.23,0.39,0.27,0.09,0.02,0.0,0.0,0.0,jeremy michae vinson,
+ACCT,3120,4,Intermediate Financial Acct II,0.28,0.33,0.33,0.0,0.0,0.0,0.0,0.06,terry daniel knause,
+ACCT,3120,5,Intermediate Financial Acct II,0.36,0.3,0.23,0.11,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3120,6,Intermediate Financial Acct II,0.27,0.4,0.2,0.13,0.0,0.0,0.0,0.0,terry daniel knause,
+ACCT,3130,1,Intermediate Fin Acct III,0.11,0.5,0.21,0.07,0.04,0.0,0.0,0.07, russell madray,
+ACCT,3130,2,Intermediate Fin Acct III,0.16,0.48,0.3,0.02,0.02,0.0,0.0,0.02, russell madray,
+ACCT,3130,3,Intermediate Fin Acct III,0.3,0.49,0.16,0.05,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3130,4,Intermediate Fin Acct III,0.36,0.44,0.15,0.05,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3220,1,Accounting Information Systems,0.17,0.5,0.17,0.03,0.03,0.0,0.0,0.11,philip maiberger,
+ACCT,3220,2,Accounting Information Systems,0.25,0.47,0.22,0.06,0.0,0.0,0.0,0.0,philip maiberger,
+ACCT,3220,3,Accounting Information Systems,0.06,0.23,0.48,0.06,0.03,0.0,0.0,0.13,philip maiberger,
+ACCT,4040,1,Individual Taxation,0.74,0.17,0.06,0.03,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,2,Individual Taxation,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,3,Individual Taxation,0.58,0.3,0.0,0.1,0.03,0.0,0.0,0.0,lisa whea birtwistle,
+ACCT,4040,4,Individual Taxation,0.24,0.38,0.19,0.08,0.08,0.0,0.0,0.03,lisa whea birtwistle,
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.28,0.38,0.33,0.0,0.0,0.0,0.0,0.0,robin radtke,
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.3,0.53,0.15,0.0,0.0,0.0,0.0,0.03,robin radtke,
+ACCT,4150,1,Auditing,0.15,0.49,0.28,0.05,0.03,0.0,0.0,0.0,carl hollingsworth,
+ACCT,4150,2,Auditing,0.17,0.33,0.19,0.17,0.03,0.0,0.0,0.11,carl hollingsworth,
+ACCT,8520,1,Fin Acct Theory/Res,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,ralph edward welton,
+ACCT,8520,2,Fin Acct Theory/Res,0.28,0.59,0.13,0.0,0.0,0.0,0.0,0.0,ralph edward welton,
+ACCT,8540,1,Prof Responsibility,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8540,2,Prof Responsibility,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8540,3,Prof Responsibility,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8620,1,Financial Auditing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,8620,2,Financial Auditing,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,8710,1,Corporate Taxation,0.31,0.64,0.06,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,2,Corporate Taxation,0.15,0.8,0.05,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,3,Corporate Taxation,0.28,0.64,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8730,1,Intl/Spec Tax Topic,0.43,0.47,0.11,0.0,0.0,0.0,0.0,0.0,kathr kisska-schulze,
+ACCT,8740,1,Tax Aspects of Finan Planning,0.42,0.53,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,
+AFLS,2000,1,Agric For Domestic Study Tour,0.0,0.0,0.0,0.0,0.0,0.9,0.05,0.05,jean bertrand,
+AGED,1000,1,Orientation & Field Experience,0.74,0.05,0.0,0.0,0.11,0.0,0.0,0.11,philip fravel,
+AGED,2030,1,Teaching Agriscience,0.33,0.56,0.06,0.0,0.06,0.0,0.0,0.0,catherin dibenedetto,
+AGED,4150,1,Leadership of Vol,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,kevin layfield,
+AGED,4160,1,Ethics and Issues,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0, kirby player,
+AGED,4250,1,Teaching Ag Mechs,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGM,2050,1,Prin of Fabrication,0.32,0.53,0.09,0.04,0.0,0.0,0.0,0.02,hunter massey,
+AGM,2060,1,Machinery Mgt,0.34,0.44,0.16,0.03,0.0,0.0,0.0,0.03,hunter massey,
+AGM,2200,1,Calc for Mechanized Agricult,0.57,0.33,0.05,0.0,0.0,0.0,0.0,0.05,young han,
+AGM,2210,1,Land Measurements,0.46,0.27,0.23,0.02,0.02,0.0,0.0,0.0,charles privette,
+AGM,4020,1,Irrigation System Design,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,charles privette,
+AGM,4100,1,Precision Ag Tech,0.46,0.38,0.14,0.02,0.0,0.0,0.0,0.0,hunter massey,
+AGM,4520,1,Mobile Power,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4720,1,Capstone,0.74,0.24,0.02,0.0,0.0,0.0,0.0,0.0,john chastain,
+AGRB,2020,1,Agricultural Economics,0.39,0.24,0.19,0.12,0.03,0.0,0.0,0.03,george apperson,
+AGRB,2050,1,Agriculture and Society,0.26,0.53,0.18,0.04,0.0,0.0,0.0,0.0,george apperson,
+AGRB,3080,1,Quant Agribusiness Analysis I,0.15,0.19,0.38,0.22,0.05,0.0,0.0,0.01,lisha zhang,
+AGRB,3190,1,Agribusiness Management,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,yuliya vale bolotova,
+AGRB,3510,1,Principles of Ag Sales and Ad,0.03,0.65,0.29,0.03,0.0,0.0,0.0,0.0,george apperson,
+AGRB,3570,1,Natural Resources Economics,0.16,0.35,0.24,0.18,0.0,0.0,0.0,0.06,david brian willis,
+AGRB,4020,1,Production Economics,0.28,0.37,0.28,0.05,0.0,0.0,0.0,0.02,michael vassalos,
+AGRB,4080,1,Quant Agribusiness Analysis II,0.32,0.35,0.26,0.06,0.0,0.0,0.0,0.0,lisha zhang,
+AGRB,4520,1,Agricultural Policy,0.14,0.48,0.24,0.12,0.0,0.0,0.0,0.02,michael vassalos,
+AGRB,4560,1,Prices,0.23,0.33,0.26,0.19,0.0,0.0,0.0,0.0,yuliya vale bolotova,
+AL,3490,400,Principles of Coaching,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,
+AL,3490,402,Principles of Coaching,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,julia wright,
+AL,3490,403,Principles of Coaching,0.72,0.12,0.08,0.0,0.04,0.0,0.0,0.04,clyde keith connor,
+AL,3490,406,Principles of Coaching,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,john plumblee,
+AL,3490,407,Principles of Coaching,0.68,0.12,0.12,0.04,0.0,0.0,0.0,0.04,john plumblee,
+AL,3490,408,Principles of Coaching,0.76,0.16,0.0,0.0,0.08,0.0,0.0,0.0,deborah jo cadorette,
+AL,3500,400,Sci Basis I/Ex Phy,0.23,0.15,0.38,0.15,0.0,0.0,0.0,0.08,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.17,0.38,0.33,0.08,0.04,0.0,0.0,0.0,michael godfrey,
+AL,3520,400,Kinesiology,0.2,0.4,0.2,0.0,0.0,0.0,0.0,0.2,isaac sean colbert,
+AL,3530,400,Athletic Injuries,0.2,0.32,0.16,0.28,0.04,0.0,0.0,0.0,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.13,0.57,0.13,0.17,0.0,0.0,0.0,0.0,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.33,0.58,0.04,0.0,0.04,0.0,0.0,0.0,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.72,0.16,0.04,0.04,0.0,0.0,0.0,0.04,henry oates,
+AL,3610,401,Admin/Org of Athletic Programs,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,Admin/Org of Athletic Programs,0.88,0.0,0.08,0.04,0.0,0.0,0.0,0.0,henry oates,
+AL,3620,400,Psychology of Coaching,0.5,0.23,0.12,0.04,0.12,0.0,0.0,0.0,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.44,0.32,0.16,0.04,0.04,0.0,0.0,0.0,natalie anne carter,
+AL,3620,402,Psychology of Coaching,0.46,0.35,0.08,0.08,0.04,0.0,0.0,0.0,natalie anne carter,
+AL,3720,400,Coaching Basketball,0.76,0.2,0.0,0.0,0.0,0.0,0.0,0.04,edmond fry,
+AL,3740,400,Coaching Football,0.76,0.12,0.08,0.04,0.0,0.0,0.0,0.0,edmond fry,
+AL,3760,400,Coaching Strength/Conditioning,0.8,0.12,0.04,0.0,0.0,0.0,0.0,0.04,edmond fry,
+AL,3760,401,Coaching Strength/Conditioning,0.72,0.08,0.04,0.08,0.04,0.0,0.0,0.04,edmond fry,
+AL,4000,400,Athletic Leadership Internship,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,deborah jo cadorette,
+AL,4380,402,Officiating in Athletic Leader,0.68,0.16,0.12,0.04,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,4380,403,Belief Systems in AL,0.59,0.22,0.15,0.04,0.0,0.0,0.0,0.0,deborah jo cadorette,
+AL,4380,404,Belief Systems in AL,0.71,0.13,0.04,0.13,0.0,0.0,0.0,0.0,deborah jo cadorette,
+AL,8530,400,Legal Iss in Intercoll Athlet,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,
+AL,8530,401,Legal Iss in Intercoll Athlet,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,8630,400,Socio Dynam in Intercol Athlet,0.38,0.48,0.05,0.0,0.05,0.0,0.0,0.05,michael godfrey,
+AL,8630,401,Socio Dynam in Intercol Athlet,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8640,400,Ethical Iss in Collegiate Athl,0.64,0.23,0.09,0.0,0.05,0.0,0.0,0.0,michael godfrey,
+AL,8640,401,Ethical Iss in Collegiate Athl,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8700,400,Intercoll Athletics Finance,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,misty soles,
+ANTH,2010,1,Introduction to Anthropology,0.23,0.48,0.26,0.03,0.0,0.0,0.0,0.0,david markus,
+ANTH,2010,2,Introduction to Anthropology,0.35,0.46,0.11,0.07,0.0,0.0,0.0,0.02,yi wu,
+ANTH,2010,3,Introduction to Anthropology,0.05,0.26,0.35,0.15,0.11,0.0,0.0,0.09,john coggeshall,
+ANTH,2010,4,Introduction to Anthropology,0.43,0.46,0.09,0.0,0.02,0.0,0.0,0.0,david markus,
+ANTH,2050,1,Professional Development,0.79,0.05,0.05,0.05,0.05,0.0,0.0,0.0,melissa vogel,
+ANTH,3200,1,North American Indian Cultures,0.21,0.42,0.17,0.17,0.04,0.0,0.0,0.0,john coggeshall,
+ANTH,3310,1,Archaeology,0.2,0.4,0.3,0.05,0.0,0.0,0.0,0.05,david markus,
+ANTH,3510,1,Biological Anthropology,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,lisa rapaport,
+ANTH,4040,1,Anthropological Theories,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,john coggeshall,
+ANTH,4990,1,Special Topics: Business Anth,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,melissa vogel,
+APEC,8220,1,Public Policy Econ,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,david brian willis,
+ARCH,1510,1,Arch Communication,0.4,0.53,0.0,0.0,0.0,0.0,0.0,0.07,sall hambright-belue,
+ARCH,1510,2,Arch Communication,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,1510,3,Arch Communication,0.36,0.43,0.07,0.07,0.0,0.0,0.0,0.07,clarissa mendez,
+ARCH,1510,4,Arch Communication,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,1510,5,Arch Communication,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,jared jeffrey moore,
+ARCH,1510,6,Arch Communication,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,herminia silv machry,
+ARCH,2520,1,Arch Foundations II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,timothy sutherland,
+ARCH,2520,2,Arch Foundations II,0.43,0.36,0.14,0.0,0.0,0.0,0.0,0.07,clarissa mendez,
+ARCH,2520,3,Arch Foundations II,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,criss mills,
+ARCH,2520,4,Arch Foundations II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,2520,5,Arch Foundations II,0.23,0.62,0.15,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,2520,6,Arch Foundations II,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,catherine parn smith,
+ARCH,2710,1,Structures II,0.51,0.34,0.09,0.0,0.03,0.0,0.0,0.03,mahmoodreza soltani,
+ARCH,3530,1,Studio Genoa,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4050,1,American Arch Styles 1650-1950,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,4140,1,Design Seminar,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,4160,1,Field Studies,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,4520,1,Synthesis Studio,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,4520,2,Synthesis Studio,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,4520,3,Synthesis Studio,0.07,0.73,0.2,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4520,4,Synthesis Studio,0.5,0.36,0.07,0.07,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,4890,1,Internship,0.4,0.2,0.3,0.0,0.0,0.0,0.0,0.1,ashley jennings,
+ARCH,4990,1,Immersive Virtual Environments,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,david lee,
+ARCH,8110,1,Visualization II,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,douglas hecker,
+ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,8420,1,Arch Studio II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
+ARCH,8610,1,History/Theory II,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8620,1,History/Theory III,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,andreea mihalache,
+ARCH,8650,1,Topics in Health Policy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anjali joseph,
+ARCH,8710,1,Structures II,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,dustin grah albright,
+ARCH,8730,2,Environmental Sys,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
+ARCH,8740,1,Building Process:TR,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,joseph schott,
+ARCH,8900,1,Directed Studies,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,sara bayramzadeh,
+ARCH,8920,1,Comprehensive Studio,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ARCH,8920,2,Comprehensive Studio,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,dustin grah albright,
+ARCH,8920,3,Comprehensive Studio,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-sop heine,
+ARCH,8920,4,Comprehensive Studio,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8960,1,A+H Studio: Tectonic,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,byron malet edwards,
+ART,1060,1,Foundation Drawing II,0.52,0.38,0.05,0.0,0.0,0.0,0.0,0.05,carly drew,
+ART,1510,1,Foundations Art I,0.62,0.31,0.0,0.08,0.0,0.0,0.0,0.0,daniel bare,
+ART,1520,1,Foundations Art II,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,kooi susan el vander el,
+ART,2050,1,Beginning Life Drawing,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kathleen ann thum,
+ART,2070,1,Beginning Painting,0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,dustin lee massey,
+ART,2100,400,Art Appreciation,0.76,0.14,0.0,0.0,0.0,0.0,0.0,0.1,lydia jane dorsey,
+ART,2100,401,Art Appreciation,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,lydia jane dorsey,
+ART,2100,402,Art Appreciation,0.68,0.14,0.14,0.04,0.0,0.0,0.0,0.0,lydia jane dorsey,
+ART,2100,403,Art Appreciation,0.54,0.21,0.11,0.04,0.0,0.0,0.0,0.11,lydia jane dorsey,
+ART,2110,1,Begin Printmaking,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,mandy lorai ferguson,
+ART,2130,1,Begin Photography,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,amanda denise musick,
+ART,2170,1,Beginning Ceramics,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,daniel bare,
+ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,
+AS,1100,1,Air Force Today II,0.29,0.59,0.0,0.06,0.06,0.0,0.0,0.0,michael allen moore,
+AS,1100,2,Air Force Today II,0.33,0.5,0.06,0.06,0.0,0.0,0.0,0.06,michael allen moore,
+AS,1100,3,Air Force Today II,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,2100,1,Dev of Air Power II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,2100,2,Dev of Air Power II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,2100,3,Dev of Air Power II,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,3100,2,Af Ldrshp & Mgt II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mari miller,
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,4100,2,Nat Sec Policy II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+ASL,1010,1,Am Sign Lang I,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,jason hurdich,
+ASL,1010,2,Am Sign Lang I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,william rya clements,
+ASL,1010,3,Am Sign Lang I,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,william rya clements,
+ASL,1020,1,Am Sign Lang I,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,dunn kim mar misener mar,
+ASL,1020,2,Am Sign Lang I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,william rya clements,
+ASL,1020,3,Am Sign Lang I,0.4,0.5,0.05,0.0,0.05,0.0,0.0,0.0,jason hurdich,
+ASL,1020,4,Am Sign Lang I,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,2020,1,Am Sign Lang II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dunn kim mar misener mar,
+ASL,2020,2,Am Sign Lang II,0.7,0.1,0.15,0.0,0.05,0.0,0.0,0.0,dunn kim mar misener mar,
+ASL,2020,3,Am Sign Lang II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william rya clements,
+ASL,2020,4,Am Sign Lang II,0.52,0.19,0.29,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASTR,1010,1,Solar System Astronomy,0.39,0.36,0.18,0.01,0.02,0.0,0.0,0.04,amber porter,
+ASTR,1020,1,Stellar Astronomy,0.29,0.38,0.26,0.0,0.02,0.0,0.0,0.05,amber porter,
+ASTR,1020,2,Stellar Astronomy,0.3,0.39,0.19,0.09,0.02,0.0,0.0,0.02,marco ajello,
+ASTR,1030,1,Solar Systm Astr Lab,0.29,0.38,0.13,0.0,0.13,0.0,0.0,0.08,amber porter,
+ASTR,1030,2,Solar Systm Astr Lab,0.4,0.44,0.08,0.04,0.04,0.0,0.0,0.0,amber porter,
+ASTR,1030,3,Solar Systm Astr Lab,0.24,0.44,0.16,0.0,0.08,0.0,0.0,0.08,amber porter,
+ASTR,1040,1,Stellar Astr Lab,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,amber porter,
+ASTR,1040,3,Stellar Astr Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,amber porter,
+ASTR,1040,4,Stellar Astr Lab,0.56,0.31,0.06,0.0,0.06,0.0,0.0,0.0,amber porter,
+ASTR,2200,1,Planetary Science,0.44,0.38,0.06,0.06,0.0,0.0,0.0,0.06,mate adamkovics,
+ASTR,8200,1,Astroph II: Stars,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+AUD,2850,1,Acoustics of Music,0.18,0.36,0.36,0.09,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUD,3860,1,Electronic Comp,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,hamilton altstatt,
+AUE,4020,699,Automobile Powertrain Systems,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,8160,3,Eng Combustion Emiss,0.62,0.28,0.1,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8170,3,Alt Energy Sources,0.21,0.69,0.1,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8500,6,Stability/Safety Sys,0.32,0.65,0.03,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8550,16,Struct/Thermal Analysis Mthds,0.17,0.78,0.06,0.0,0.0,0.0,0.0,0.0,david will schmueser,
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.41,0.44,0.16,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8820,10,Systems Integration Con & Meth,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8860,1,Noise Vibration,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,
+AUE,8930,3,Applied Dynamics,0.14,0.5,0.29,0.0,0.07,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8930,401,Autonomous Driving Techn,0.72,0.2,0.02,0.0,0.0,0.0,0.0,0.07,yunyi jia,
+AUE,8930,699,Autovation 1,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,michael george mino,
+AVS,2000,1,Beef Cattle Tech,0.48,0.33,0.14,0.0,0.0,0.0,0.0,0.05,nathan long,
+AVS,2060,1,Swine Techniques,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
+AVS,2080,1,Teaching Horsemanshp,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
+AVS,3010,1,Anat & Phys Dom Ani,0.56,0.23,0.09,0.02,0.1,0.0,0.0,0.0,tiffany wilmoth,
+AVS,3100,1,Animal Health,0.46,0.35,0.11,0.05,0.0,0.0,0.0,0.03,celina marce checura,
+AVS,3150,1,Animal Welfare,0.48,0.32,0.04,0.08,0.08,0.0,0.0,0.0,peter skewes,
+AVS,3700,1,Principles of Animal Nutrition,0.49,0.26,0.16,0.09,0.0,0.0,0.0,0.0,james rob strickland,
+AVS,4000,1,AVS Professional Development,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,marie owens bolt,
+AVS,4010,1,Beef Production,0.36,0.32,0.2,0.08,0.0,0.0,0.0,0.04,nathan long,
+AVS,4060,2,Seminars & Related Topics,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+AVS,4090,400,Animals & Humans In Society,0.77,0.2,0.0,0.03,0.0,0.0,0.0,0.0,marie owens bolt,
+AVS,4100,1,Domestic Ani Behav,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,peter skewes,
+AVS,4120,1,Advanced Equine Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kristine lang vernon,
+AVS,4130,1,Animal Products,0.68,0.26,0.06,0.0,0.0,0.0,0.0,0.0,richelle lorr miller,
+AVS,4140,1,Basic Immunology,0.28,0.38,0.25,0.05,0.0,0.0,0.0,0.05,thomas scott,
+AVS,4140,2,Basic Immunology,0.52,0.16,0.12,0.04,0.0,0.0,0.0,0.16,farzana ferdous,
+AVS,4530,1,Animal Reproduction,0.4,0.3,0.15,0.11,0.0,0.0,0.0,0.04,celina marce checura,
+AVS,4530,400,Animal Reproduction,0.09,0.27,0.55,0.09,0.0,0.0,0.0,0.0,celina marce checura,
+AVS,4550,2,Animal Repro Mgt-Equine,0.58,0.25,0.17,0.0,0.0,0.0,0.0,0.0,chelsea dru sinclair,
+AVS,4700,1,Animal Genetics,0.26,0.15,0.17,0.22,0.07,0.0,0.0,0.13,joseph keit bertrand,
+AVS,8090,1,Ruminant Nutrition,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,gustavo jose lascano,
+BCHM,3010,1,Molecular Biochem,0.1,0.34,0.35,0.09,0.01,0.0,0.0,0.11,meredith teil morris,
+BCHM,3010,2,Molecular Biochem(HON),0.43,0.23,0.2,0.08,0.05,0.0,0.0,0.03,cheryl ingram-smith,True
+BCHM,3040,1,Molecular Biology Laboratory,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,geoffrey ford,
+BCHM,3040,2,Molecular Biology Laboratory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3040,4,Molecular Biology Laboratory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3050,1,Essen Elements Bioch,0.06,0.41,0.32,0.05,0.0,0.0,0.0,0.16,debra ragland,
+BCHM,3050,2,Essen Elements Bioch,0.17,0.38,0.28,0.07,0.0,0.0,0.0,0.1,debra ragland,
+BCHM,3050,3,Essen Elements Bioch,0.24,0.41,0.23,0.08,0.04,0.0,0.0,0.0,geoffrey ford,
+BCHM,4320,1,Bioch of Metabolism,0.55,0.41,0.02,0.0,0.0,0.0,0.0,0.02,kimberly paul,
+BCHM,4340,1,Biochemistry of Metabolism Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,geoffrey ford,
+BCHM,4340,2,Biochemistry of Metabolism Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,4360,1,Genes to Proteins,0.34,0.64,0.02,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
+BCHM,4400,1,Bioinformatics,0.22,0.28,0.28,0.11,0.0,0.0,0.0,0.11,liangjiang wang,
+BCHM,4930,1,Senior Seminar,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james morris,
+BCHM,8100,1,Princ of Molecular Biology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jennifer may mason,
+BE,2100,1,Intro to Biosystems Engr,0.57,0.32,0.0,0.04,0.0,0.0,0.0,0.07,yi zheng,
+BE,3100,1,Biosystems Engr Thermodynamics,0.25,0.5,0.2,0.0,0.0,0.0,0.0,0.05,terry walker,
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.19,0.76,0.05,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4120,1,Be Heat Mass Trans,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,4150,1,Instr & Control for Biosys Eng,0.19,0.57,0.24,0.0,0.0,0.0,0.0,0.0,yi zheng,
+BE,4240,1,Ecological Engineering,0.66,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christophe darnault,
+BE,4380,1,Bioprocess Engineering Design,0.09,0.55,0.36,0.0,0.0,0.0,0.0,0.0,terry walker,
+BIOE,1010,1,Biol for Bioengr,0.35,0.45,0.09,0.0,0.0,0.0,0.0,0.11,vladimir vlad reukov,
+BIOE,2000,1,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,0.98,0.01,0.01,martine laberge,
+BIOE,2010,1,Intro Biomed Engr,0.32,0.36,0.24,0.04,0.0,0.0,0.0,0.04,vladimir vlad reukov,
+BIOE,3020,1,Biomaterials,0.6,0.32,0.04,0.01,0.01,0.0,0.0,0.01,alexey alex vertegel,
+BIOE,3100,1,Engr Analysis of Physiol Proc,0.67,0.26,0.03,0.0,0.03,0.0,0.0,0.03,brian william booth,
+BIOE,3200,1,Biomechanics,0.73,0.23,0.02,0.0,0.02,0.0,0.0,0.0,jiro nagatomi,
+BIOE,3210,1,Biofluid Mechanics,0.33,0.37,0.27,0.01,0.01,0.0,0.0,0.0,sarah harcum,
+BIOE,3470,1,Transport Processes in Bioengr,0.39,0.43,0.13,0.0,0.0,0.0,0.0,0.04,robert latour,
+BIOE,3700,1,Bioinst & Imaging,0.45,0.52,0.02,0.0,0.0,0.0,0.0,0.02,jordon antho gilmore,
+BIOE,4200,1,Sports Engineering,0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,cynthia miller smith,
+BIOE,4350,1,Modeling of Multiphysics Prob,0.38,0.38,0.08,0.0,0.08,0.0,0.0,0.08,william richardson,
+BIOE,4490,1,Drug Delivery,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,jeoungsoo lee,
+BIOE,4510,39,CI-Inorganic Biomaterials,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vladimir vlad reukov,
+BIOE,6200,1,Sports Engineering,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,cynthia miller smith,
+BIOE,6350,1,Modeling of Multiphysics Prob,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,
+BIOE,8030,1,Polymeric Biomatls,0.22,0.44,0.0,0.0,0.0,0.0,0.0,0.33,narendra vyavahare,
+BIOL,1040,1,General Biology II,0.19,0.3,0.23,0.09,0.08,0.0,0.0,0.11,nora espinoza,
+BIOL,1040,2,General Biology II,0.53,0.31,0.1,0.04,0.01,0.0,0.0,0.01,william surver,
+BIOL,1040,3,General Biology II,0.14,0.24,0.39,0.15,0.05,0.0,0.0,0.02,salvatore sparace,
+BIOL,1040,4,General Biology II (HON),0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
+BIOL,1060,1,Gen Biology Lab II,0.42,0.38,0.13,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,2,Gen Biology Lab II,0.48,0.22,0.13,0.13,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,3,Gen Biology Lab II,0.42,0.17,0.33,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,4,Gen Biology Lab II,0.18,0.14,0.27,0.18,0.09,0.0,0.0,0.14,tafadzwa kaisa,
+BIOL,1060,5,Gen Biology Lab II,0.21,0.07,0.14,0.29,0.29,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,6,Gen Biology Lab II,0.29,0.29,0.29,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,7,Gen Biology Lab II,0.19,0.31,0.25,0.13,0.06,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1060,8,Gen Biology Lab II,0.54,0.25,0.13,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,9,Gen Biology Lab II,0.52,0.22,0.09,0.09,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,10,Gen Biology Lab II,0.48,0.22,0.22,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,11,Gen Biology Lab II,0.5,0.33,0.13,0.0,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,12,Gen Biology Lab II,0.5,0.25,0.21,0.0,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,13,Gen Biology Lab II,0.54,0.13,0.21,0.04,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,14,Gen Biology Lab II,0.5,0.18,0.23,0.05,0.05,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,15,Gen Biology Lab II,0.17,0.43,0.17,0.13,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,16,Gen Biology Lab II,0.41,0.18,0.27,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,18,Gen Biology Lab II,0.21,0.36,0.29,0.14,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,19,Gen Biology Lab II,0.08,0.38,0.31,0.23,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,20,Gen Biology Lab II,0.38,0.29,0.25,0.04,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,21,Gen Biology Lab II,0.29,0.38,0.25,0.0,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1060,22,Gen Biology Lab II,0.53,0.2,0.13,0.0,0.07,0.0,0.0,0.07,tafadzwa kaisa,
+BIOL,1060,24,Gen Biology Lab II,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,26,Gen Biology Lab II,0.67,0.17,0.08,0.08,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,27,Gen Biology Lab II,0.5,0.25,0.04,0.17,0.04,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,29,Gen Biology Lab II,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,30,Gen Biology Lab II,0.59,0.23,0.09,0.05,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,31,Gen Biology Lab II,0.36,0.36,0.07,0.14,0.0,0.0,0.0,0.07,tafadzwa kaisa,
+BIOL,1060,32,Gen Biology Lab II,0.55,0.15,0.1,0.15,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,33,Gen Biology Lab II,0.57,0.21,0.14,0.07,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,35,Gen Biology Lab II,0.38,0.31,0.25,0.06,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,36,Gen Biology Lab II,0.4,0.2,0.2,0.2,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1110,1,Principles of Biology II,0.21,0.43,0.16,0.08,0.05,0.0,0.0,0.07,dylan dittrich-reed,
+BIOL,1110,3,Principles of Biology II,0.36,0.47,0.11,0.02,0.01,0.0,0.0,0.02,robert kosinski,
+BIOL,1110,4,Prin of Biol II  (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,robert kosinski,True
+BIOL,1200,1,Biological Inq Lab,0.25,0.45,0.15,0.05,0.0,0.0,0.0,0.1, christine minor m,
+BIOL,1200,2,Biological Inq Lab,0.3,0.45,0.15,0.1,0.0,0.0,0.0,0.0, christine minor m,
+BIOL,1200,3,Biological Inq Lab,0.37,0.37,0.16,0.05,0.0,0.0,0.0,0.05, christine minor m,
+BIOL,1200,4,Biological Inq Lab,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,
+BIOL,1200,5,Biological Inq Lab,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05, christine minor m,
+BIOL,1200,6,Biological Inq Lab,0.55,0.2,0.2,0.0,0.05,0.0,0.0,0.0, christine minor m,
+BIOL,1230,1,Keys to Human Biol,0.16,0.38,0.25,0.12,0.04,0.0,0.0,0.04, christine minor m,
+BIOL,2000,1,Biology in the News,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0, christine minor m,
+BIOL,2040,1,"Environ, Energy and Society",0.36,0.34,0.13,0.06,0.02,0.0,0.0,0.09,john jenkins hains,
+BIOL,2040,2,"Environ, Energy and Society",0.47,0.31,0.08,0.1,0.0,0.0,0.0,0.04,john jenkins hains,
+BIOL,2230,1,Human Anat and Physiology II,0.42,0.37,0.13,0.04,0.03,0.0,0.0,0.01,john cummings,
+BIOL,2230,2,Human Anat and Physiology II,0.36,0.38,0.19,0.05,0.0,0.0,0.0,0.02,john cummings,
+BIOL,3020,1,Invertebrate Biology,0.31,0.33,0.18,0.03,0.05,0.0,0.0,0.1,migueles juan baeza,
+BIOL,3040,1,Biology of Plants,0.15,0.33,0.28,0.15,0.05,0.0,0.0,0.03,robert edwar ballard,
+BIOL,3060,1,Invertebrate Biology Lab,0.39,0.35,0.13,0.0,0.0,0.0,0.0,0.13,migueles juan baeza,
+BIOL,3060,3,Invertebrate Biology Lab,0.47,0.41,0.06,0.0,0.06,0.0,0.0,0.0,migueles juan baeza,
+BIOL,3080,2,Biology of Plants Practicum,0.4,0.3,0.2,0.05,0.0,0.0,0.0,0.05,nathan redding,
+BIOL,3080,3,Biology of Plants Practicum,0.44,0.39,0.06,0.11,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3160,1,Human Physiology,0.3,0.43,0.22,0.04,0.0,0.0,0.0,0.0,tamara mcnutt-scott,
+BIOL,3350,1,Evolutionary Biology,0.44,0.39,0.13,0.03,0.0,0.0,0.0,0.01,margaret ptacek,
+BIOL,3510,1,Biological Anthropology,0.58,0.25,0.08,0.04,0.04,0.0,0.0,0.0,lisa rapaport,
+BIOL,4010,1,Plant Physiology,0.2,0.22,0.22,0.25,0.03,0.0,0.0,0.07,douglas bielenberg,
+BIOL,4020,1,Plant Physiology Lab,0.24,0.59,0.12,0.0,0.0,0.0,0.0,0.06,douglas bielenberg,
+BIOL,4020,2,Plant Physiology Lab,0.26,0.68,0.05,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4100,1,Limnology,0.18,0.45,0.27,0.0,0.0,0.0,0.0,0.11,john jenkins hains,
+BIOL,4140,1,Basic Immunology,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,charles rice,
+BIOL,4340,1,Biological Chem Lab Techniques,0.21,0.21,0.21,0.29,0.0,0.0,0.0,0.07,salvatore sparace,
+BIOL,4340,2,Biological Chem Lab Techniques,0.19,0.31,0.25,0.19,0.06,0.0,0.0,0.0,salvatore sparace,
+BIOL,4400,1,Developmental Animal Biology,0.42,0.28,0.23,0.07,0.0,0.0,0.0,0.0,kara elizabet powder,
+BIOL,4480,1,Marine Ecology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael childress,
+BIOL,4510,1,Biol Variation in Human Pop,0.4,0.2,0.1,0.1,0.1,0.0,0.0,0.1,elizabeth wakefield,
+BIOL,4610,3,Cell Biology,0.2,0.32,0.25,0.15,0.04,0.0,0.0,0.03,lisa bain,
+BIOL,4610,4,Cell Biology (HON),0.44,0.39,0.11,0.0,0.0,0.0,0.0,0.06,lisa bain,True
+BIOL,4620,1,Cell Biology Lab (Lec),0.81,0.11,0.0,0.04,0.0,0.0,0.0,0.04,xianzhong yu,
+BIOL,4620,2,Cell Biology Lab (Lec),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.74,0.15,0.07,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
+BIOL,4620,8,Cell Biology Lab (Lec),0.85,0.12,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4640,1,Mammalogy,0.63,0.15,0.07,0.11,0.0,0.0,0.0,0.04,john cummings,
+BIOL,4670,1,Principles of Hematology,0.86,0.08,0.06,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,
+BIOL,4700,1,Behavioral Ecology,0.27,0.44,0.18,0.06,0.03,0.0,0.0,0.02,lisa rapaport,
+BIOL,4700,2,Behavioral Ecology (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lisa rapaport,True
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lisa rapaport,
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.63,0.26,0.0,0.0,0.0,0.0,0.0,0.11,lisa rapaport,
+BIOL,4930,3,Sr Sem: Advances in Cancer,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,wen chen,
+BIOL,4930,4,Sr Sem: Immuno & Immunothearpy,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,yanzhang wei,
+BIOL,4930,5,Sr Sem: Nervous Systems,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4930,8,Sr Sem: Defining Sex,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,tamara mcnutt-scott,
+BIOL,8430,1,Underst Genetics & Evol Biol,0.82,0.17,0.01,0.0,0.0,0.0,0.0,0.0,renea chris hardwick,
+BIOL,8450,1,Understanding Animal Biology,0.9,0.09,0.01,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
+BIOL,8470,1,Understanding Microbiology,0.57,0.37,0.04,0.0,0.02,0.0,0.0,0.0,harry kurtz,
+BMOL,4250,1,Biomolecular Engineering,0.22,0.35,0.13,0.17,0.0,0.0,0.0,0.13,mark alan blenner,
+BMOL,4290,1,Bioprocess Engineering,0.27,0.15,0.54,0.0,0.04,0.0,0.0,0.0,marc russ birtwistle,
+BUS,1010,1,Business Foundations,0.25,0.5,0.13,0.04,0.08,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,2,Business Foundations,0.28,0.32,0.2,0.08,0.08,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,3,Business Foundations,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,4,Business Foundations,0.21,0.43,0.29,0.0,0.04,0.0,0.0,0.04,william erne tumblin,
+BUS,1010,5,Business Foundations,0.33,0.41,0.0,0.07,0.07,0.0,0.0,0.11,william erne tumblin,
+BUS,1010,6,Business Foundations,0.4,0.36,0.08,0.08,0.04,0.0,0.0,0.04,william erne tumblin,
+BUS,1010,7,Business Foundations,0.33,0.37,0.2,0.03,0.03,0.0,0.0,0.03,donna mccubbin,
+BUS,1010,8,Business Foundations,0.33,0.43,0.13,0.07,0.0,0.0,0.0,0.03,donna mccubbin,
+BUS,1010,9,Business Foundations,0.42,0.23,0.31,0.0,0.0,0.0,0.0,0.04,william erne tumblin,
+BUS,1010,10,Business Foundations,0.58,0.23,0.08,0.04,0.04,0.0,0.0,0.04,william erne tumblin,
+CE,2010,1,Statics,0.36,0.29,0.16,0.05,0.04,0.0,0.0,0.09,barnabas bwambale,
+CE,2010,2,Statics,0.08,0.35,0.3,0.18,0.08,0.0,0.0,0.03,melissa sternhagen,
+CE,2010,3,Statics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,sreeganesh red yerri,
+CE,2010,4,Statics,0.05,0.2,0.24,0.12,0.15,0.0,0.0,0.24,melissa sternhagen,
+CE,2010,5,Statics,0.2,0.32,0.28,0.1,0.01,0.0,0.0,0.09, kent nilsson,
+CE,2010,6,Statics,0.33,0.27,0.29,0.07,0.04,0.0,0.0,0.0,shweta shrestha,
+CE,2060,1,Structural Mechanics,0.39,0.41,0.15,0.02,0.02,0.0,0.0,0.0,mahmoodreza soltani,
+CE,2060,2,Structural Mechanics,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,mahmoodreza soltani,
+CE,2080,1,Dynamics,0.05,0.43,0.27,0.17,0.05,0.0,0.0,0.03,melissa sternhagen,
+CE,2080,2,Dynamics,0.06,0.42,0.36,0.03,0.08,0.0,0.0,0.05,melissa sternhagen,
+CE,2550,1,Geomatics,0.27,0.42,0.27,0.01,0.03,0.0,0.0,0.0,wayne sarasua,
+CE,3010,1,Structural Analysis,0.28,0.33,0.2,0.13,0.04,0.0,0.0,0.02,stephen csernak,
+CE,3110,1,Transportation Engr,0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,pamela murray-tuite,
+CE,3210,1,Geotechnical Engineering,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
+CE,3210,2,Geotechnical Engineering,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,charng-hsein juang,
+CE,3310,1,Constr Engr & Mgmnt,0.31,0.52,0.07,0.09,0.0,0.0,0.0,0.0,james burati,
+CE,3410,1,Intro to Fluid Mech,0.28,0.51,0.16,0.03,0.01,0.0,0.0,0.0,nigel gregory kaye,
+CE,3420,1,Hydraulics & Hydro,0.49,0.37,0.11,0.03,0.0,0.0,0.0,0.0,ashok mishra,
+CE,3420,2,Hydraulics & Hydro,0.52,0.33,0.07,0.0,0.0,0.0,0.0,0.07,abdul khan,
+CE,3510,1,Civil Engineering Materials,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,prasada ra rangaraju,
+CE,3520,1,Econ Eval of Proj,0.53,0.33,0.15,0.0,0.0,0.0,0.0,0.0,james burati,
+CE,3520,2,Econ Eval of Proj,0.45,0.49,0.05,0.0,0.0,0.0,0.0,0.01,zoraya roldan rockow,
+CE,3530,1,Professional Seminar,0.95,0.01,0.04,0.0,0.0,0.0,0.0,0.01,thomas edfor cousins,
+CE,4020,1,Reinfor Con Design,0.26,0.3,0.28,0.07,0.02,0.0,0.0,0.07,thomas edfor cousins,
+CE,4070,1,Wood Design,0.62,0.24,0.14,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CE,4080,1,Struct Loads & Sys,0.38,0.46,0.08,0.0,0.08,0.0,0.0,0.0,bryant nielson,
+CE,4110,1,Roadway Geo Design,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
+CE,4120,1,Urban Transport Plan,0.23,0.69,0.0,0.0,0.0,0.0,0.0,0.08,eric morris,
+CE,4210,1,Geotechnical Design,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,nadaraj ravichandran,
+CE,4340,1,Const Est Proj Cont,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,4470,1,Stormwater Managemnt,0.25,0.25,0.35,0.1,0.0,0.0,0.0,0.05,md nasimul chowdhury,
+CE,4590,1,Capstone Design Proj,0.49,0.46,0.04,0.0,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4620,1,Coastal Engr I,0.19,0.41,0.26,0.11,0.04,0.0,0.0,0.0,earl hayter,
+CE,4910,1,Meth & Mgmt of Com & Ind Const,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,steve richar sanders,
+CE,6120,1,Urban Transport Plan,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,eric morris,
+CE,8030,1,Adv Steel Design,0.5,0.38,0.08,0.0,0.04,0.0,0.0,0.0,clinton owen rex,
+CE,8040,1,Prestressed Concrete,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,brandon ross,
+CE,8470,500,Optimization Support Models,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
+CE,8570,500,Uncertainty Modeling Risk Engr,0.78,0.13,0.0,0.0,0.0,0.0,0.0,0.09,elnaz peyghaleh,
+CE,8600,1,Adv Fluid Mech,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,abdul khan,
+CH,1010,1,General Chemistry,0.14,0.3,0.32,0.1,0.07,0.0,0.0,0.08,princess mycia cox,
+CH,1010,2,General Chemistry,0.07,0.28,0.36,0.14,0.06,0.0,0.0,0.08,princess mycia cox,
+CH,1010,3,General Chemistry,0.18,0.38,0.28,0.05,0.06,0.0,0.0,0.05,laura lanni,
+CH,1010,4,General Chemistry,0.17,0.33,0.27,0.11,0.06,0.0,0.0,0.07,william we mcwhorter,
+CH,1010,400,General Chemistry,0.32,0.23,0.13,0.15,0.02,0.0,0.0,0.15,stephen schvaneveldt,
+CH,1020,1,General Chemistry,0.26,0.31,0.26,0.1,0.02,0.0,0.0,0.05,thomas hickman,
+CH,1020,2,General Chemistry,0.42,0.36,0.17,0.03,0.01,0.0,0.0,0.02,tania issa houjeiry,
+CH,1020,3,General Chemistry,0.38,0.37,0.11,0.06,0.02,0.0,0.0,0.08,dennis taylor,
+CH,1020,4,General Chemistry,0.27,0.44,0.19,0.05,0.02,0.0,0.0,0.03,dennis taylor,
+CH,1020,5,General Chemistry,0.18,0.39,0.22,0.1,0.03,0.0,0.0,0.09,william we mcwhorter,
+CH,1020,6,General Chemistry,0.09,0.43,0.26,0.08,0.08,0.0,0.0,0.07,william we mcwhorter,
+CH,1020,7,General Chemistry,0.2,0.42,0.25,0.08,0.0,0.0,0.0,0.03,olt geiculescu,
+CH,1020,8,General Chemistry,0.22,0.44,0.2,0.07,0.02,0.0,0.0,0.05,thomas hickman,
+CH,1020,9,General Chemistry,0.3,0.41,0.18,0.04,0.03,0.0,0.0,0.05,elliot ennis,
+CH,1020,10,General Chemistry,0.23,0.34,0.25,0.07,0.02,0.0,0.0,0.09,jacob schroeder,
+CH,1020,11,General Chemistry,0.28,0.44,0.19,0.02,0.0,0.0,0.0,0.07,dennis taylor,
+CH,1020,50,General Chemistry,0.36,0.27,0.18,0.18,0.0,0.0,0.0,0.0,shiou-jyh hwu,
+CH,1020,51,General Chemistry (HON),0.68,0.26,0.04,0.0,0.0,0.0,0.0,0.02,stephen schvaneveldt,True
+CH,1020,52,General Chemistry (HON),0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,stephen schvaneveldt,True
+CH,1020,500,General Chemistry,0.14,0.39,0.29,0.18,0.0,0.0,0.0,0.0,brian gloor,
+CH,1050,1,Chemistry in Context I,0.54,0.37,0.09,0.0,0.0,0.0,0.0,0.0,olt geiculescu,
+CH,1050,2,Chemistry in Context I,0.35,0.38,0.19,0.0,0.04,0.0,0.0,0.04,olt geiculescu,
+CH,1060,1,Chemistry in Context II,0.45,0.35,0.2,0.0,0.0,0.0,0.0,0.0,thomas hickman,
+CH,1520,1,Chemistry Communication,0.67,0.23,0.02,0.0,0.02,0.0,0.0,0.05,richard marcus,
+CH,2010,1,Survey of Organic Chemistry,0.4,0.34,0.13,0.07,0.05,0.0,0.0,0.02,tania issa houjeiry,
+CH,2020,1,Surv of Organic Chemistry Lab,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2020,2,Surv of Organic Chemistry Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
+CH,2020,3,Surv of Organic Chemistry Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2020,4,Surv of Organic Chemistry Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
+CH,2050,1,Intro Inorg Chem,0.36,0.43,0.14,0.04,0.0,0.0,0.0,0.04,william pennington,
+CH,2230,1,Organic Chemistry,0.19,0.34,0.16,0.19,0.09,0.0,0.0,0.03,jacob schroeder,
+CH,2230,2,Organic Chemistry,0.28,0.38,0.18,0.08,0.04,0.0,0.0,0.05,jacob schroeder,
+CH,2230,3,Organic Chemistry,0.69,0.22,0.01,0.01,0.04,0.0,0.0,0.04,sourav saha,
+CH,2240,1,Organic Chemistry,0.21,0.21,0.21,0.14,0.08,0.0,0.0,0.16,laura lanni,
+CH,2240,2,Organic Chemistry,0.38,0.33,0.14,0.09,0.02,0.0,0.0,0.03,elliot ennis,
+CH,2240,3,Organic Chemistry,0.29,0.24,0.16,0.11,0.08,0.0,0.0,0.12,laura lanni,
+CH,2240,4,Organic Chemistry,0.35,0.29,0.21,0.03,0.04,0.0,0.0,0.08,rhett smith,
+CH,2240,5,Organic Chemistry,0.28,0.33,0.28,0.06,0.02,0.0,0.0,0.03,elliot ennis,
+CH,2270,1,Organic Chem Lab,0.56,0.19,0.0,0.0,0.0,0.0,0.0,0.25,james nelson plampin,
+CH,2270,2,Organic Chem Lab,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,james nelson plampin,
+CH,2270,3,Organic Chem Lab,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2270,4,Organic Chem Lab,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2270,6,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2270,7,Organic Chem Lab,0.89,0.0,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2270,8,Organic Chem Lab,0.67,0.17,0.06,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,12,Organic Chem Lab,0.69,0.13,0.06,0.0,0.06,0.0,0.0,0.06,james nelson plampin,
+CH,2270,13,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,
+CH,2270,16,Organic Chem Lab,0.63,0.13,0.06,0.0,0.0,0.0,0.0,0.19,james nelson plampin,
+CH,2280,3,Organic Chem Lab,0.88,0.0,0.06,0.0,0.06,0.0,0.0,0.0,james nelson plampin,
+CH,2280,6,Organic Chem Lab,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
+CH,2280,7,Organic Chem Lab,0.56,0.25,0.13,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2280,8,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
+CH,2280,9,Organic Chem Lab,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
+CH,2280,10,Organic Chem Lab,0.88,0.06,0.0,0.06,0.0,0.0,0.0,0.0,james nelson plampin,
+CH,2280,11,Organic Chem Lab,0.31,0.56,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
+CH,2280,14,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,
+CH,2280,17,Organic Chem Lab,0.81,0.06,0.06,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2280,19,Organic Chem Lab,0.75,0.0,0.0,0.0,0.08,0.0,0.0,0.17,james nelson plampin,
+CH,2280,20,Organic Chem Lab,0.73,0.07,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,
+CH,2280,22,Organic Chem Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james nelson plampin,
+CH,2280,24,Organic Chem Lab,0.56,0.31,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
+CH,2280,25,Organic Chem Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nelson plampin,
+CH,2280,27,Organic Chem Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,james nelson plampin,
+CH,2280,28,Organic Chem Lab,0.8,0.07,0.0,0.0,0.0,0.0,0.0,0.13,james nelson plampin,
+CH,2290,2,Organic Chem Lab,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2290,3,Organic Chem Lab,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,james nelson plampin,
+CH,2290,4,Organic Chem Lab,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,3310,1,Physical Chemistry,0.4,0.3,0.0,0.0,0.1,0.0,0.0,0.2,arkady kholodenko,
+CH,3320,1,Physical Chemistry,0.17,0.42,0.33,0.0,0.08,0.0,0.0,0.0,steven stuart,
+CH,3320,3,Physical Chemistry,0.88,0.11,0.02,0.0,0.0,0.0,0.0,0.0,jason mcneill,
+CH,3320,4,Physical Chemistry,0.41,0.26,0.09,0.06,0.15,0.0,0.0,0.03,leah beck casabianca,
+CH,3400,1,Physical Chem Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,princess mycia cox,
+CH,3400,2,Physical Chem Lab,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3400,4,Physical Chem Lab,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3400,6,Physical Chem Lab,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3600,1,Chemical Biology,0.39,0.42,0.16,0.03,0.0,0.0,0.0,0.0,modi wetzler,
+CH,4110,1,Instrumental Analy,0.12,0.19,0.38,0.12,0.19,0.0,0.0,0.0,george chumanov,
+CH,4120,1,Instr Analysis Lab,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,jeffrey nathan anker,
+CH,4130,1,Chemistry of Aqueous Systems,0.59,0.22,0.09,0.0,0.0,0.0,0.0,0.09,cindy lee,
+CH,4500,1,Chemistry Capstone,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
+CH,6140,1,Bioanalytical Chem,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,perez carlos garcia,
+CH,8080,1,Chem Non-Metal Elem,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,
+CH,8180,1,Surface Analysis,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,stephen creager,
+CH,8220,1,Organic Chem II,0.6,0.2,0.0,0.0,0.2,0.0,0.0,0.0,daniel whitehead,
+CH,8510,1,Grad Student Seminar,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,joseph stua thrasher,
+CHE,1300,1,Intro to Chemical Engineering,0.27,0.25,0.27,0.04,0.04,0.0,0.0,0.14,christopher norfolk,
+CHE,1300,2,Intro to Chemical Engineering,0.17,0.25,0.15,0.06,0.12,0.0,0.0,0.25,christopher norfolk,
+CHE,2200,1,Ch E Thermo I,0.24,0.24,0.24,0.19,0.05,0.0,0.0,0.05,joseph scott,
+CHE,2200,2,Ch E Thermo I,0.15,0.35,0.31,0.08,0.05,0.0,0.0,0.06,jessica marie kelly,
+CHE,2300,1,Fluids/Heat Transfer,0.1,0.21,0.26,0.26,0.13,0.0,0.0,0.05,eric mikel davis,
+CHE,2300,2,Fluids/Heat Transfer,0.15,0.37,0.22,0.15,0.04,0.0,0.0,0.07,eric mikel davis,
+CHE,3070,1,Unit Ops Lab I,0.21,0.52,0.25,0.0,0.0,0.0,0.0,0.02,mark thies,
+CHE,3190,1,Engr Materials,0.17,0.29,0.3,0.16,0.06,0.0,0.0,0.02,amod ogale,
+CHE,3530,2,Proc Dyn & Control,0.41,0.26,0.26,0.04,0.01,0.0,0.0,0.01,mark roberts,
+CHE,4330,1,Process Design II,0.44,0.45,0.11,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,8450,3,Multiscale Modeling,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
+CHIN,1020,1,Elementary Chinese,0.6,0.1,0.2,0.1,0.0,0.0,0.0,0.0,ling rao,
+CHIN,2020,1,Intermediate Chinese,0.47,0.18,0.24,0.12,0.0,0.0,0.0,0.0,ling rao,
+CHIN,3120,1,Philosophy in Ancient China,0.33,0.27,0.13,0.0,0.07,0.0,0.0,0.2,yanming an,
+CHIN,4010,1,Pre-Modern Chinese Literature,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,yanming an,
+COM,1010,1,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,0.93,0.04,0.04,lori marlise pindar,
+COM,1500,1,Intro to Human Communication,0.88,0.11,0.0,0.0,0.01,0.0,0.0,0.0,eddie smith,
+COM,1500,2,Intro to Human Communication,0.58,0.33,0.03,0.02,0.02,0.0,0.0,0.02,daniel leland fecher,
+COM,1500,3,Intro to Human Communication,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,eddie smith,
+COM,1500,4,Intro to Human Communication,0.79,0.19,0.02,0.0,0.0,0.0,0.0,0.0,marianne herr glaser,
+COM,1500,5,Intro to Human Communication,0.66,0.27,0.01,0.02,0.01,0.0,0.0,0.02,marianne herr glaser,
+COM,1500,6,Intro to Human Communication,0.37,0.55,0.04,0.03,0.01,0.0,0.0,0.0,daniel leland fecher,
+COM,2010,1,Intr to Comm Studies,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,
+COM,2010,2,Intr to Comm Studies,0.64,0.28,0.08,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,
+COM,2020,1,Communication Theory,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,2030,1,Mass Communication Theory,0.47,0.43,0.03,0.07,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,2100,1,Quant Comm Research Methods,0.3,0.52,0.19,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
+COM,2500,1,Public Speaking,0.62,0.33,0.0,0.0,0.05,0.0,0.0,0.0,alyssa christi davis,
+COM,2500,2,Public Speaking,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,katie barne mcelveen,
+COM,2500,3,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christi davis,
+COM,2500,7,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christi davis,
+COM,2500,8,Public Speaking,0.43,0.24,0.14,0.0,0.05,0.0,0.0,0.14,pauline matthey,
+COM,2500,9,Public Speaking,0.7,0.1,0.05,0.0,0.05,0.0,0.0,0.1,vanessa anne condon,
+COM,2500,10,Public Speaking,0.76,0.14,0.05,0.05,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,11,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,12,Public Speaking,0.4,0.4,0.1,0.0,0.0,0.0,0.0,0.1,pauline matthey,
+COM,2500,13,Public Speaking,0.63,0.21,0.05,0.0,0.11,0.0,0.0,0.0,amanda elizabe moore,
+COM,2500,14,Public Speaking,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,amanda elizabe moore,
+COM,2500,15,Public Speaking,0.9,0.0,0.0,0.0,0.1,0.0,0.0,0.0,caitlin baker,
+COM,2500,16,Public Speaking,0.8,0.05,0.05,0.05,0.05,0.0,0.0,0.0,amanda elizabe moore,
+COM,2500,18,Public Speaking,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,19,Public Speaking,0.67,0.24,0.0,0.05,0.05,0.0,0.0,0.0,jumah patricia taweh,
+COM,2500,20,Public Speaking,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,21,Public Speaking,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,
+COM,2500,22,Public Speaking,0.45,0.45,0.05,0.05,0.0,0.0,0.0,0.0,amanda elizabe moore,
+COM,2500,23,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,
+COM,2500,24,Public Speaking,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2500,25,Public Speaking,0.86,0.09,0.0,0.0,0.0,0.0,0.0,0.05,caitlin baker,
+COM,2500,29,Public Speaking,0.64,0.23,0.0,0.05,0.05,0.0,0.0,0.05,vanessa anne condon,
+COM,2500,30,Public Speaking,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,31,Public Speaking,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,
+COM,2500,32,Public Speaking,0.71,0.19,0.05,0.0,0.05,0.0,0.0,0.0,sara grumble crocker,
+COM,2500,33,Public Speaking,0.22,0.61,0.06,0.0,0.06,0.0,0.0,0.06,marilyn denise pugh,
+COM,2500,34,Public Speaking,0.21,0.68,0.05,0.0,0.0,0.0,0.0,0.05,marilyn denise pugh,
+COM,2500,35,Public Speaking,0.68,0.21,0.05,0.05,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,36,Public Speaking,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,marilyn denise pugh,
+COM,2500,401,Public Speaking,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
+COM,2500,402,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachary davis,
+COM,2500,403,Public Speaking,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,alexis zachary davis,
+COM,2500,500,Public Speaking,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,
+COM,2500,501,Public Speaking,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,sara grumble crocker,
+COM,3200,1,Bdcst Production,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,wanda johnson,
+COM,3250,1,Survey of Sports Communication,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3250,2,Survey of Sports Communication,0.87,0.04,0.09,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3300,1,Nonverbal Comm,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,joseph mazer,
+COM,3550,1,Principles of Public Relations,0.71,0.24,0.02,0.0,0.0,0.0,0.0,0.02,meghnaa tallapragada,
+COM,3570,1,Public Relations Writing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,3610,1,Argue and Debate,0.76,0.19,0.0,0.05,0.0,0.0,0.0,0.0,lindsey dixon,
+COM,3640,1,Organizational Comm,0.57,0.34,0.06,0.02,0.0,0.0,0.0,0.0,kristen elai okamoto,
+COM,3660,6,EC: Digital Analytics & Brand,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,alicia nic littleton,
+COM,3660,7,EC: Media Mgmt in Brand Comm,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,william reynolds,
+COM,3990,2,CI: Reputation Mgmt,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,mark david land,
+COM,4250,1,Adv Sports Comm,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,gregory keit cranmer,
+COM,4280,1,Interpers/Family Comm & Sport,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john steven  spinda w,
+COM,4560,1,PR for Assoc & Nonprofits,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,4560,2,PR for Assoc & Nonprofits,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,4700,1,Comm & Health,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,stephanie pangborn,
+COM,4950,1,Senior Capstone,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,4950,2,Senior Capstone,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,8070,1,Hlt Com Plan & Eval,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,stephanie pangborn,
+COM,8110,1,Comm Research Methods II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,meghnaa tallapragada,
+CPSC,1010,1,Computer Science I,0.17,0.25,0.21,0.06,0.15,0.0,0.0,0.15,catherine hochrine,
+CPSC,1010,2,Computer Science I,0.17,0.19,0.17,0.02,0.24,0.0,0.0,0.22,catherine hochrine,
+CPSC,1020,1,Computer Science II,0.38,0.22,0.12,0.07,0.12,0.0,0.0,0.09,yvon feaster,
+CPSC,1020,2,Computer Science II,0.28,0.16,0.17,0.03,0.17,0.0,0.0,0.19,yvon feaster,
+CPSC,1070,1,Programming Methodology,0.56,0.28,0.12,0.04,0.0,0.0,0.0,0.0,rose lowe,
+CPSC,1110,1,Intro to Programming in C,0.08,0.41,0.25,0.05,0.11,0.0,0.0,0.1,catherine hochrine,
+CPSC,1110,2,Intro to Programming in C,0.43,0.27,0.16,0.02,0.05,0.0,0.0,0.07,nicolas benja widman,
+CPSC,2070,1,Discrete Structures,0.63,0.26,0.02,0.07,0.0,0.0,0.0,0.02,sandra hedetniemi,
+CPSC,2070,2,Discrete Structures,0.31,0.23,0.23,0.08,0.11,0.0,0.0,0.03,larry hodges,
+CPSC,2120,1,Algs/Data Structures,0.32,0.34,0.25,0.05,0.0,0.0,0.0,0.05,wayne goddard,
+CPSC,2120,2,Algs/Data Structures,0.25,0.48,0.2,0.02,0.05,0.0,0.0,0.0,wayne goddard,
+CPSC,2150,1,Software Dev Foundations,0.45,0.28,0.18,0.05,0.03,0.0,0.0,0.02,kevin anton plis,
+CPSC,2150,2,Software Dev Foundations,0.27,0.35,0.24,0.02,0.05,0.0,0.0,0.08,kevin anton plis,
+CPSC,2200,1,Microcomputer Appl,0.52,0.3,0.09,0.0,0.04,0.0,0.0,0.04,kevin anton plis,
+CPSC,2200,2,Microcomputer Appl,0.35,0.43,0.13,0.0,0.09,0.0,0.0,0.0,kevin anton plis,
+CPSC,2310,1,Intro Computer Org,0.45,0.16,0.25,0.05,0.09,0.0,0.0,0.0,rose lowe,
+CPSC,2310,2,Intro Computer Org,0.11,0.34,0.25,0.14,0.14,0.0,0.0,0.02,rose lowe,
+CPSC,2910,1,Prof Issues I,0.65,0.25,0.0,0.05,0.0,0.0,0.0,0.05,catherine hochrine,
+CPSC,2910,2,Prof Issues I,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,catherine hochrine,
+CPSC,2910,3,Prof Issues I,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,3120,1,Design Analysis of Algorithms,0.13,0.13,0.33,0.08,0.21,0.0,0.0,0.13,pradip srimani,
+CPSC,3220,1,Intro to Operating Systems,0.17,0.25,0.14,0.0,0.08,0.0,0.0,0.36,jacob sorber,
+CPSC,3220,2,Intro to Operating Systems,0.79,0.15,0.03,0.03,0.0,0.0,0.0,0.0,carl bryan martin,
+CPSC,3220,3,Intro to Operating Systems,0.17,0.45,0.1,0.07,0.07,0.0,0.0,0.14,zijun wang,
+CPSC,3300,1,Computer Systems Org,0.2,0.35,0.33,0.03,0.1,0.0,0.0,0.0,mark smotherman,
+CPSC,3300,2,Computer Systems Org,0.53,0.25,0.13,0.05,0.03,0.0,0.0,0.03,nicolas benja widman,
+CPSC,3500,1,Foundations of Computer Sci,0.16,0.23,0.47,0.06,0.0,0.0,0.0,0.08,ilya mark safro,
+CPSC,3520,1,Programming Systems,0.31,0.42,0.1,0.01,0.08,0.0,0.0,0.08,robert schalkoff,
+CPSC,3600,1,Network Programming,0.43,0.27,0.22,0.02,0.0,0.0,0.0,0.06,feng luo,
+CPSC,3600,2,Network Programming,0.14,0.5,0.29,0.04,0.0,0.0,0.0,0.04,james martin,
+CPSC,3720,1,Software Engineering,0.2,0.45,0.33,0.0,0.0,0.0,0.0,0.02,murali sitaraman,
+CPSC,3720,2,Software Engineering,0.25,0.44,0.25,0.03,0.03,0.0,0.0,0.0,eileen there kraemer,
+CPSC,4050,1,Computer Graphics,0.29,0.14,0.21,0.18,0.04,0.0,0.0,0.14,victor zordan,
+CPSC,4110,1,Virtual Reality Systems,0.37,0.37,0.14,0.0,0.02,0.0,0.0,0.09,andrew robb,
+CPSC,4140,1,Human and Computer Interaction,0.29,0.33,0.17,0.0,0.0,0.0,0.0,0.21,christopher plaue,
+CPSC,4140,2,Human and Computer Interaction,0.28,0.33,0.28,0.06,0.0,0.0,0.0,0.06,christopher plaue,
+CPSC,4160,1,2-D Game Engine Construction,0.4,0.38,0.1,0.0,0.1,0.0,0.0,0.02,brian malloy,
+CPSC,4240,1,System Admin and Security,0.18,0.56,0.2,0.02,0.0,0.0,0.0,0.04,james martin,
+CPSC,4300,1,Applied Data Science,0.33,0.33,0.28,0.0,0.0,0.0,0.0,0.06,alexander chr herzog,
+CPSC,4620,1,Database Management Systems,0.34,0.45,0.14,0.05,0.02,0.0,0.0,0.0,zijun wang,
+CPSC,4620,2,Database Management Systems,0.44,0.34,0.15,0.02,0.05,0.0,0.0,0.0,kevin anton plis,
+CPSC,4770,1,Distributed/Cluster Computing,0.26,0.62,0.09,0.0,0.0,0.0,0.0,0.03,linh bao ngo,
+CPSC,4820,1,Special Topic: Cloud Comp Arch,0.33,0.43,0.23,0.0,0.0,0.0,0.0,0.0,amy apon,
+CPSC,4820,2,Special Topics: Tang and Embod,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,brygg anders ullmer,
+CPSC,4910,1,Professional Issues II,0.3,0.67,0.03,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,
+CPSC,6110,1,Virtual Reality Systems,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,andrew robb,
+CPSC,6160,1,2-D Game Engine Construction,0.71,0.24,0.0,0.0,0.06,0.0,0.0,0.0,brian malloy,
+CPSC,6300,1,Applied Data Science,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,alexander chr herzog,
+CPSC,8100,1,Intro Artif Intell,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,feng luo,
+CPSC,8110,1,Technical Character Animation,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,christina soph joerg,
+CPSC,8240,1,Advanced Operating Systems,0.32,0.48,0.08,0.0,0.0,0.0,0.0,0.12,rong ge,
+CPSC,8280,0,Theory of Program. Languages,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,murali sitaraman,
+CPSC,8400,1,Design & Anlys of Algorithms,0.18,0.5,0.25,0.0,0.0,0.0,0.0,0.07,brian christoph dean,
+CPSC,8580,1,Security in Emerging Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,
+CPSC,8650,1,Data Mining,0.27,0.38,0.19,0.0,0.04,0.0,0.0,0.12,zijun wang,
+CPSC,8750,1,Software Architectur,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,john mcgregor,
+CPSC,8810,10,Selected Topics: Motion Planni,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,
+CRP,8020,1,Site Planning & Infrastructure,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,
+CRP,8050,1,Plning Theory & History,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,mickey lauria,
+CRP,8090,1,Current Issues in Planning,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
+CRP,8130,1,Transportation Plan Fundament,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,eric morris,
+CRP,8200,1,Negotiation & Develop Resolut,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
+CRP,8220,1,Urban Design,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,thomas willi schurch,
+CRP,8590,2,Plan Terminal Proj,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,clifford donal ellis,
+CRP,8890,1,Selected Topic in Advanced GIS,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,patr carbajales-dale,
+CRP,8890,3,Sel Top Development Finance,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,elora lee raymond,
+CSM,2010,1,Structures I,0.3,0.25,0.2,0.05,0.1,0.0,0.0,0.1,shima clarke,
+CSM,2020,1,Structures II,0.13,0.44,0.23,0.13,0.02,0.0,0.0,0.04,shima clarke,
+CSM,2030,1,Mats & Meth of Const,0.21,0.61,0.14,0.0,0.04,0.0,0.0,0.0,jason lucas,
+CSM,2040,1,Cont Documents,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
+CSM,2050,1,Mats & Methods II,0.24,0.61,0.12,0.0,0.0,0.0,0.0,0.02,jason lucas,
+CSM,3050,1,Envir Systems II,0.26,0.43,0.3,0.0,0.0,0.0,0.0,0.0,joseph micha burgett,
+CSM,3050,2,Envir Systems II,0.37,0.57,0.03,0.03,0.0,0.0,0.0,0.0,joseph micha burgett,
+CSM,3070,1,Sustainable Construction,0.2,0.45,0.25,0.0,0.05,0.0,0.0,0.05,joseph micha burgett,
+CSM,3070,2,Sustainable Construction,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.04,joseph micha burgett,
+CSM,3520,1,Const Scheduling,0.33,0.3,0.33,0.0,0.0,0.0,0.0,0.03,christine piper,
+CSM,3520,2,Const Scheduling,0.18,0.5,0.23,0.09,0.0,0.0,0.0,0.0,christine piper,
+CSM,3530,1,Const Estimating II,0.23,0.6,0.17,0.0,0.0,0.0,0.0,0.0,rizi seyed  mousavi e,
+CSM,3530,2,Const Estimating II,0.32,0.55,0.09,0.0,0.0,0.0,0.0,0.05,rizi seyed  mousavi e,
+CSM,4540,1,Const Capstone,0.36,0.48,0.14,0.02,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8350,401,Integr Proj Deliv Case Studies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shima clarke,
+CSM,8640,1,Construction Bus Strat & Mktg,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,christine piper,
+CSM,8640,400,Construction Bus Strat & Mktg,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,christine piper,
+CSM,8660,1,Role in Development,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8660,401,Role in Development,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.86,0.12,0.02,susan whorton,
+CU,1000,2,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.68,0.21,0.11,susan whorton,
+CU,1010,1,Univ Success Skills,0.35,0.2,0.2,0.05,0.1,0.0,0.0,0.1,valerie kay oonk,
+CU,1010,2,Univ Success Skills,0.4,0.2,0.13,0.07,0.07,0.0,0.0,0.13,adam richa mcfarlane,
+CU,1010,3,Univ Success Skills,0.44,0.22,0.17,0.06,0.06,0.0,0.0,0.06,bryn zimmermann babb,
+CU,1010,4,Univ Success Skills,0.69,0.13,0.13,0.0,0.0,0.0,0.0,0.06,sharetta mar bufford,
+CU,1010,5,Univ Success Skills,0.5,0.22,0.22,0.0,0.06,0.0,0.0,0.0,bryn zimmermann babb,
+CU,1010,6,Univ Success Skills,0.29,0.29,0.12,0.0,0.18,0.0,0.0,0.12,taimi olsen,
+CU,1970,2,New Student Seminar,0.0,0.0,0.0,0.0,0.0,0.2,0.4,0.4,laurel ann  whisler c,
+CU,2010,1,Sustainability Leadership,0.85,0.12,0.0,0.0,0.04,0.0,0.0,0.0,jennifer marga goree,
+DPA,3070,1,Method 3d Production,0.71,0.14,0.04,0.0,0.0,0.0,0.0,0.11,sarah lydia  martin a,
+DPA,4020,1,Vis Foundations I,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,anthony summey,
+DPA,4030,2,Vis Foundations II,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,erik reed,
+DPA,4830,1,Sp Studio Topic: Dig Sculpt In,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,insun kwon,
+ECE,2010,1,Logic and Computing Devices,0.29,0.35,0.23,0.0,0.07,0.0,0.0,0.06,walter ligon,
+ECE,2020,1,Electric Circuits I,0.18,0.17,0.37,0.08,0.15,0.0,0.0,0.05,william harrell,
+ECE,2070,1,Basic Electrical Engineering,0.48,0.36,0.08,0.02,0.0,0.0,0.0,0.05,timothy anglea,
+ECE,2070,2,Basic Electrical Engineering,0.53,0.27,0.12,0.03,0.01,0.0,0.0,0.04,william tho kolodzey,
+ECE,2070,3,Basic Electrical Engineering,0.39,0.33,0.21,0.04,0.0,0.0,0.0,0.03,william tho kolodzey,
+ECE,2080,5,Basic Electrical Engr Lab,0.85,0.0,0.05,0.0,0.0,0.0,0.0,0.1,apoorva deep kapadia,
+ECE,2080,7,Basic Electrical Engr Lab,0.85,0.0,0.0,0.05,0.05,0.0,0.0,0.05,apoorva deep kapadia,
+ECE,2080,8,Basic Electrical Engr Lab,0.79,0.11,0.0,0.0,0.0,0.0,0.0,0.11,apoorva deep kapadia,
+ECE,2080,15,Basic Electrical Engr Lab,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2080,18,Basic Electrical Engr Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,
+ECE,2090,1,Logic Lab,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2090,4,Logic Lab,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,apoorva deep kapadia,
+ECE,2110,2,Elec Engr Lab I,0.75,0.1,0.0,0.0,0.1,0.0,0.0,0.05,apoorva deep kapadia,
+ECE,2120,4,Electrical Engineering Lab II,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,apoorva deep kapadia,
+ECE,2120,8,Electrical Engineering Lab II,0.6,0.27,0.0,0.0,0.0,0.0,0.0,0.13,apoorva deep kapadia,
+ECE,2220,1,Syst Prog Concept,0.24,0.35,0.26,0.01,0.09,0.0,0.0,0.06,william reid,
+ECE,2230,1,Comp Sys Eng,0.15,0.27,0.21,0.09,0.15,0.0,0.0,0.12,jon cameron calhoun,
+ECE,2620,1,Electric Circuits II,0.28,0.34,0.23,0.08,0.02,0.0,0.0,0.05,richard groff,
+ECE,2620,2,Elec Circuits II (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,True
+ECE,2720,1,Comp Organization,0.33,0.39,0.26,0.02,0.0,0.0,0.0,0.0,william reid,
+ECE,2730,1,Computer Org Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2730,3,Computer Org Lab,0.5,0.31,0.13,0.06,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,2730,5,Computer Org Lab,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,apoorva deep kapadia,
+ECE,2730,6,Computer Org Lab,0.63,0.31,0.0,0.06,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3110,2,Electrical Engineering Lab III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3110,3,Electrical Engineering Lab III,0.31,0.44,0.19,0.0,0.0,0.0,0.0,0.06,apoorva deep kapadia,
+ECE,3110,4,Electrical Engineering Lab III,0.69,0.19,0.0,0.06,0.0,0.0,0.0,0.06,apoorva deep kapadia,
+ECE,3120,2,Electrical Engineering Lab IV,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3170,1,Rand Signal Analysis,0.32,0.28,0.24,0.11,0.03,0.0,0.0,0.04,stephen hubbard,
+ECE,3200,1,Electronics I,0.25,0.28,0.22,0.17,0.08,0.0,0.0,0.0,stephen hubbard,
+ECE,3210,1,Electronics II,0.49,0.34,0.13,0.0,0.02,0.0,0.0,0.02,stephen hubbard,
+ECE,3220,1,Intro Operating Sys,0.16,0.37,0.26,0.0,0.0,0.0,0.0,0.21,jacob sorber,
+ECE,3270,1,Dig Comp Design,0.17,0.19,0.26,0.1,0.07,0.0,0.0,0.21,melissa crawle smith,
+ECE,3300,1,Signals & Systems,0.16,0.24,0.34,0.15,0.06,0.0,0.0,0.04,carl baum,
+ECE,3520,1,Programming Systems,0.58,0.32,0.05,0.03,0.03,0.0,0.0,0.0,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.57,0.11,0.17,0.06,0.03,0.0,0.0,0.06,edward collins,
+ECE,3710,1,Microcontr Interface,0.32,0.32,0.3,0.03,0.0,0.0,0.0,0.03,william reid,
+ECE,3720,1,Micro Int Lab,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3720,3,Micro Int Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3720,5,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3720,7,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,3800,1,Electromagnetics,0.3,0.28,0.2,0.08,0.08,0.0,0.0,0.06,yuan li,
+ECE,3810,1,Field Waves & Ckts,0.36,0.48,0.1,0.04,0.0,0.0,0.0,0.02,anthony martin,
+ECE,4090,1,Intr to Linear Control Systems,0.48,0.43,0.05,0.03,0.03,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,4160,1,Smart Grid,0.52,0.45,0.03,0.0,0.0,0.0,0.0,0.0,gane venayagamoorthy,
+ECE,4200,1,Renewable Energy,0.19,0.19,0.26,0.26,0.0,0.0,0.0,0.1,johan heinric enslin,
+ECE,4270,1,Communications Sys,0.35,0.49,0.07,0.05,0.02,0.0,0.0,0.02,upasan bhattacharyya,
+ECE,4380,1,Computer Commun,0.33,0.33,0.22,0.07,0.0,0.0,0.0,0.04,harlan russell,
+ECE,4400,1,Local Computer Nets,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,kuang-ching wang,
+ECE,4680,1,Embedded Computing,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,adam hoover,
+ECE,4950,1,Int Sys Design I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deep kapadia,
+ECE,4960,1,Int Sys Design II,0.59,0.33,0.05,0.02,0.0,0.0,0.0,0.0,richard groff,
+ECE,6200,1,Renewable Energy,0.5,0.17,0.33,0.0,0.0,0.0,0.0,0.0,johan heinric enslin,
+ECE,6680,1,Embedded Computing,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,adam hoover,
+ECE,6930,1,Algorithms VLSI Design Automa.,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,yingjie lao,
+ECE,8260,1,Solar Cells,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,rajendra singh,
+ECE,8400,1,Semicond Devices,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,william harrell,
+ECE,8480,1,Telecomm Networks,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,harlan russell,
+ECE,8720,1,Artificial Neurl Net,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,robert schalkoff,
+ECE,8720,2,Artificial Neurl Net,0.14,0.43,0.0,0.0,0.14,0.0,0.0,0.29,robert schalkoff,
+ECE,8740,1,Adv Nonlinear Cntrl,0.56,0.33,0.0,0.0,0.11,0.0,0.0,0.0,yongqiang wang,
+ECE,8790,1,FPGA Design & Applications,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,melissa crawle smith,
+ECE,8930,2,Optimiz. Vector Space Methods,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,daniel noneaker,
+ECE,8930,10,Distributed Denial of Service,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,
+ECON,2000,1,Economic Concepts,0.32,0.14,0.3,0.14,0.05,0.0,0.0,0.05,jonathan orry ernest,
+ECON,2000,2,Economic Concepts,0.35,0.35,0.2,0.03,0.03,0.0,0.0,0.05,jonathan orry ernest,
+ECON,2000,3,Economic Concepts,0.46,0.27,0.16,0.11,0.0,0.0,0.0,0.0,miren ivankovic,
+ECON,2110,1,Principles of Microeconomics,0.3,0.28,0.2,0.13,0.03,0.0,0.0,0.08,liuna issagholian,
+ECON,2110,2,Principles of Microeconomics,0.18,0.35,0.28,0.08,0.1,0.0,0.0,0.03,roksana ghanbariamin,
+ECON,2110,3,Principles of Microeconomics,0.12,0.31,0.26,0.12,0.12,0.0,0.0,0.07,benjamin posmanick,
+ECON,2110,4,Principles of Microeconomics,0.32,0.32,0.12,0.12,0.1,0.0,0.0,0.02,kelsey victo roberts,
+ECON,2110,5,Principles of Microeconomics,0.3,0.4,0.23,0.05,0.03,0.0,0.0,0.0,molly espey,
+ECON,2110,6,Principles of Microeconomics,0.19,0.57,0.19,0.0,0.01,0.0,0.0,0.03,chen wang,
+ECON,2110,7,Principles of Microeconomics,0.3,0.42,0.17,0.06,0.04,0.0,0.0,0.01,wing yin chung,
+ECON,2110,8,Principles of Microeconomics,0.28,0.28,0.24,0.1,0.07,0.0,0.0,0.03,sarah louise wilson,
+ECON,2110,10,Principles of Microeconomics,0.39,0.45,0.1,0.02,0.04,0.0,0.0,0.0,jacob walloga,
+ECON,2110,12,Principles of Microeconomics,0.43,0.28,0.18,0.08,0.0,0.0,0.0,0.05,molly espey,
+ECON,2120,1,Principles of Macroeconomics,0.45,0.2,0.15,0.1,0.05,0.0,0.0,0.05,scott baier,
+ECON,2120,2,Principles of Macroeconomics,0.17,0.33,0.28,0.11,0.11,0.0,0.0,0.0,scott baier,
+ECON,2120,3,Principles of Macroeconomics,0.33,0.33,0.28,0.0,0.0,0.0,0.0,0.06,scott baier,
+ECON,2120,4,Principles of Macroeconomics,0.21,0.42,0.32,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,5,Principles of Macroeconomics,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,scott baier,
+ECON,2120,6,Principles of Macroeconomics,0.26,0.21,0.26,0.11,0.05,0.0,0.0,0.11,scott baier,
+ECON,2120,7,Principles of Macroeconomics,0.16,0.42,0.37,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,8,Principles of Macroeconomics,0.11,0.47,0.16,0.05,0.11,0.0,0.0,0.11,scott baier,
+ECON,2120,9,Principles of Macroeconomics,0.21,0.37,0.32,0.0,0.05,0.0,0.0,0.05,scott baier,
+ECON,2120,10,Principles of Macroeconomics,0.32,0.53,0.05,0.11,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,11,Principles of Macroeconomics,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,12,Principles of Macroeconomics,0.11,0.42,0.26,0.11,0.11,0.0,0.0,0.0,scott baier,
+ECON,2120,13,Principles of Macroeconomics,0.47,0.26,0.21,0.0,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,14,Principles of Macroeconomics,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,15,Principles of Macroeconomics,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,16,Principles of Macroeconomics,0.28,0.5,0.22,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,17,Principles of Macroeconomics,0.21,0.63,0.05,0.0,0.05,0.0,0.0,0.05,scott baier,
+ECON,2120,18,Principles of Macroeconomics,0.21,0.63,0.11,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,19,Principles of Macroeconomics,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,20,Principles of Macroeconomics,0.69,0.22,0.05,0.0,0.03,0.0,0.0,0.0,jeremy choquette,
+ECON,2120,21,Principles of Macroeconomics,0.27,0.45,0.21,0.0,0.03,0.0,0.0,0.03,benjamin tim harbolt,
+ECON,2120,22,Principles of Macroeconomics,0.0,0.2,0.08,0.16,0.0,0.0,0.0,0.56,ralph charles allen,
+ECON,2120,23,Principles of Macroeconomics,0.2,0.11,0.14,0.09,0.03,0.0,0.0,0.43,ralph charles allen,
+ECON,2120,24,Principles of Macroeconomics,0.31,0.48,0.2,0.0,0.01,0.0,0.0,0.0,elijah neilson,
+ECON,2120,25,Principles of Macroeconomics,0.42,0.33,0.19,0.03,0.03,0.0,0.0,0.0,kyle lance rechard,
+ECON,2120,26,Principles of Macroeconomics,0.49,0.33,0.13,0.0,0.05,0.0,0.0,0.0,xiaosong wu,
+ECON,2120,27,Principles of Macroeconomics,0.36,0.38,0.23,0.0,0.0,0.0,0.0,0.03,narendra regmi,
+ECON,2120,28,Principles of Macroecon (HON),0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,christopher as gorry,True
+ECON,3020,1,Money and Banking,0.33,0.33,0.25,0.03,0.05,0.0,0.0,0.03,smriti bhargava,
+ECON,3060,1,Managerial Economics,0.16,0.33,0.25,0.12,0.12,0.0,0.0,0.02,steven johnson,
+ECON,3100,1,International Econ,0.48,0.29,0.18,0.0,0.02,0.0,0.0,0.03,samuel art standaert,
+ECON,3140,1,Intermediate Micro,0.33,0.39,0.22,0.0,0.0,0.0,0.0,0.06,yichen christy zhou,
+ECON,3140,2,Intermediate Micro,0.23,0.38,0.18,0.08,0.05,0.0,0.0,0.1,robert kenneth fleck,
+ECON,3140,3,Intermediate Micro,0.24,0.24,0.19,0.14,0.05,0.0,0.0,0.14,patrick warren,
+ECON,3150,1,Intermediate Macro,0.28,0.38,0.18,0.07,0.04,0.0,0.0,0.05,michal jerzmanowski,
+ECON,3150,2,Intermediate Macro,0.34,0.22,0.32,0.0,0.05,0.0,0.0,0.07,sergey vlad mityakov,
+ECON,3440,1,Property Rights,0.13,0.38,0.25,0.17,0.08,0.0,0.0,0.0,dari litsukova-bokar,
+ECON,3500,1,Moral & Ethical Econ,0.44,0.25,0.19,0.0,0.03,0.0,0.0,0.09,bradley keith hobbs,
+ECON,3500,2,Moral & Ethical Econ,0.15,0.35,0.25,0.1,0.0,0.0,0.0,0.15,bradley keith hobbs,
+ECON,3600,1,Public Choice,0.37,0.37,0.2,0.05,0.0,0.0,0.0,0.02,michael makowsky,
+ECON,4010,1,Labor Mkt Analysis,0.24,0.52,0.21,0.0,0.03,0.0,0.0,0.0,curtis simon,
+ECON,4020,1,Law and Economics,0.18,0.33,0.38,0.09,0.0,0.0,0.0,0.02,thomas winsl hazlett,
+ECON,4050,1,Intro to Econometric,0.27,0.29,0.25,0.07,0.07,0.0,0.0,0.04,scott barkowski,
+ECON,4050,2,Intro to Econometric,0.5,0.36,0.0,0.07,0.07,0.0,0.0,0.0,yichen christy zhou,
+ECON,4200,1,Pub Sector Econ,0.48,0.33,0.0,0.0,0.1,0.0,0.0,0.1,william dougan,
+ECON,4230,1,Economics of Health,0.56,0.33,0.1,0.0,0.0,0.0,0.0,0.0,devon merritt gorry,
+ECON,4240,1,Organization of Ind,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,4240,2,Organization of Ind,0.34,0.41,0.17,0.07,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,4260,1,Sem Sport Economics,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,raymond sauer,
+ECON,4270,1,Dev American Economy,0.21,0.52,0.21,0.07,0.0,0.0,0.0,0.0,howard nel bodenhorn,
+ECON,4400,1,Game Theory,0.28,0.41,0.22,0.0,0.0,0.0,0.0,0.09,charles thomas,
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.08,0.15,0.54,0.08,0.0,0.0,0.0,0.15,scott templeton,
+ECON,6060,1,Advanced Econometric,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,los santos babur de babur,
+ECON,8020,2,Adv Econ Concepts and Applic I,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui kin,
+ECON,8050,1,Macroeconomic Theory,0.67,0.07,0.2,0.0,0.0,0.0,0.0,0.07,michal jerzmanowski,
+ECON,8070,1,Econometrics II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,chungsang lam,
+ECON,8110,1,Econ of Environment,0.5,0.38,0.0,0.0,0.13,0.0,0.0,0.0,scott templeton,
+ECON,8200,1,Public Finance,0.1,0.8,0.0,0.0,0.0,0.0,0.0,0.1,william dougan,
+ECON,9090,1,Time-Series Econ,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,gerald dwyer,
+ECON,9820,1,Workshop in Ap Econ (Macro),0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,gerald dwyer,
+ED,1050,1,Educ Orientation,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,amaris joseph tejada,
+ED,1050,2,Educ Orientation,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,
+ED,8600,303,Classroom-Based Research,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,susan ridg nunamaker,
+ED,8650,1,Curriculum Theory,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+ED,8760,301,"Curric, Instruc, Assess, Learn",0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,stephanie burdette,
+EDC,2990,1,Creative Inq in Counselor Ed,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,kend stewart-tillman,
+EDC,3900,2,Skills for Student Leaders,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,3,Skills for Student Leaders,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,eric pernotto,
+EDC,3900,5,Skills for Student Leaders,0.82,0.06,0.12,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,6,Skills for Student Leaders,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,7,Skills for Student Leaders,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,8,Skills for Student Leaders,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDEC,3020,1,Early Childhood Practicum II,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,andrea emerson,
+EDEL,3100,2,Arts in Ele School,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,alison eliza leonard,
+EDEL,3210,1,Pe for the Elem Tchr,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4050,1,Soc Justice-21st Cen,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jacquelynn malloy,
+EDEL,4520,2,Elem Methods Math Teaching,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nicole alain sinwell,
+EDEL,4870,1,Ele Meth Soc Studies,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,
+EDF,3010,2,Principles of American Educ,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,amaris joseph tejada,
+EDF,3010,3,Principles of American Educ,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,jennifer michel hein,
+EDF,3020,1,Educational Psychology,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,stephen chou,
+EDF,3020,3,Educational Psychology,0.91,0.06,0.0,0.0,0.03,0.0,0.0,0.0,heather roge brooker,
+EDF,3020,4,Educational Psychology,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,heather roge brooker,
+EDF,3020,5,Educational Psychology,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,stephen chou,
+EDF,3200,1,History of US Education,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,beatrice naff bailey,
+EDF,3340,1,Child Growth and Development,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,faiza marghoob jamil,
+EDF,3350,1,Adolescent Growth & Develop,0.71,0.23,0.0,0.0,0.0,0.0,0.0,0.06,luke rapa,
+EDF,4800,1,Digital Media & Learning,0.88,0.0,0.06,0.06,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,300,Digital Media & Learning,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,9710,400,Case Study & Ethnographic Mthd,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,reginald wilkerson,
+EDF,9750,501,Mixed Methods Research,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
+EDHD,3110,1,CI- Research in DM & Learning,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,ryan visser,
+EDHD,8310,502,Lit LOS for Child w /disab II,0.91,0.0,0.0,0.0,0.09,0.0,0.0,0.0,renee gatlin anders,
+EDL,9750,1,College Teaching,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,pamela havice,
+EDLT,4620,2,Reading Children's Lit in Elem,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,susan king fullerton,
+EDLT,4630,1,Teaching Rdg/Writing for ELLs,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDLT,4670,1,Teaching ESOL in Elem Schools,0.77,0.09,0.09,0.0,0.05,0.0,0.0,0.0,quesada hazel  vega m,
+EDLT,8120,300,Assessment in Reading & Writin,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8120,500,Assessment in Reading & Writin,0.36,0.55,0.09,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8120,501,Assessment in Reading & Writin,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8220,300,Strategies for Teaching ESOL,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,mikel walker cole,
+EDLT,8220,500,Strategies for Teaching ESOL,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,barbara fewell,
+EDLT,8410,501,Early Literacy Inst Strategies,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,susanne at elvington,
+EDLT,8410,502,Early Literacy Inst Strategies,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,
+EDLT,8410,507,Early Literacy Inst Strategies,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
+EDLT,8810,501,Reading Recovery Teacher II,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,
+EDLT,8830,501,Read Recovery Practicum II,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,jaime adele  dawson h,
+EDLT,8830,506,Read Recovery Practicum II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,
+EDSA,8110,1,Multicultural Counseling,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,
+EDSC,4580,1,Sec Soc Capstone,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,william dav mccorkle,
+EDSP,3700,2,Intro to Special Education,0.92,0.06,0.03,0.0,0.0,0.0,0.0,0.0,shanna eisner hirsch,
+EDSP,3700,4,Intro to Special Education,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,pamela stecker,
+EDSP,3700,300,Intro to Special Education,0.74,0.11,0.09,0.03,0.0,0.0,0.0,0.03,shanna eisner hirsch,
+EDSP,3750,1,Early Intervention Spec Needs,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,abigail anne allen,
+EDSP,4910,1,Ed Assess Ind W/Dis,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,antonis katsiyannis,
+EES,2020,1,Environ Engr Fundamentals II,0.67,0.24,0.06,0.0,0.03,0.0,0.0,0.0,kevin thoma finneran,
+EES,4010,1,Environmental Engr,0.5,0.27,0.11,0.0,0.02,0.0,0.0,0.09,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.32,0.38,0.21,0.0,0.03,0.0,0.0,0.06,ezra lucas hoy cates hoy,
+EES,4750,1,Capstone Design Project,0.83,0.14,0.03,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,4850,1,Hazard Waste Management,0.24,0.55,0.12,0.06,0.0,0.0,0.0,0.03,mark schlautman,
+EES,4860,1,Environmental Sustainability,0.7,0.15,0.15,0.0,0.0,0.0,0.0,0.0,michael anthony dale,
+EES,6110,1,Rad Detection Mmt,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,timothy devol,
+EES,8030,1,Phy/Chem Ops W/WW T,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ezra lucas hoy cates hoy,
+EES,8200,1,Env Systems Analysis,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michael anthony dale,
+ELE,3010,1,Entrepreneurial Foundations,0.35,0.63,0.03,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
+ELE,3010,2,Entrepreneurial Foundations,0.2,0.75,0.05,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
+ELE,3010,3,Entrepreneurial Foundations,0.15,0.36,0.41,0.05,0.0,0.0,0.0,0.03,ashley willi parnell,
+ELE,4010,1,Venture Testing,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,chad navis,
+ELE,4010,2,Venture Testing,0.65,0.27,0.08,0.0,0.0,0.0,0.0,0.0,chad navis,
+ELE,4020,1,Venture Creation,0.32,0.59,0.08,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,
+ELE,4030,1,Venture Growth,0.1,0.47,0.4,0.03,0.0,0.0,0.0,0.0,ashley willi parnell,
+ENGL,1030,1,Composition and Rhetoric,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jennie eli wakefield,
+ENGL,1030,2,Composition and Rhetoric,0.8,0.1,0.0,0.0,0.05,0.0,0.0,0.05,jennie eli wakefield,
+ENGL,1030,3,Composition and Rhetoric,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,carley ama robertson,
+ENGL,1030,4,Composition and Rhetoric,0.47,0.27,0.07,0.0,0.13,0.0,0.0,0.07,carley ama robertson,
+ENGL,1030,5,Composition and Rhetoric,0.8,0.1,0.05,0.0,0.0,0.0,0.0,0.05,jennie eli wakefield,
+ENGL,1030,6,Composition and Rhetoric,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,jennie eli wakefield,
+ENGL,1030,7,Composition and Rhetoric,0.43,0.48,0.05,0.0,0.0,0.0,0.0,0.05,courtne huff-oelberg,
+ENGL,1030,8,Composition and Rhetoric,0.64,0.29,0.0,0.0,0.0,0.0,0.0,0.07,courtne huff-oelberg,
+ENGL,1030,9,Composition and Rhetoric,0.6,0.2,0.0,0.0,0.13,0.0,0.0,0.07,carrie hill,
+ENGL,1030,10,Composition and Rhetoric,0.5,0.33,0.0,0.0,0.06,0.0,0.0,0.11,carrie hill,
+ENGL,1030,12,Composition and Rhetoric,0.76,0.14,0.0,0.0,0.1,0.0,0.0,0.0,michael david measel,
+ENGL,1030,13,Composition and Rhetoric,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,sarah eli richardson,
+ENGL,1030,14,Composition and Rhetoric,0.81,0.0,0.05,0.05,0.05,0.0,0.0,0.05,sarah eli richardson,
+ENGL,1030,15,Composition and Rhetoric,0.5,0.17,0.06,0.0,0.17,0.0,0.0,0.11,abigail maxim,
+ENGL,1030,19,Composition and Rhetoric,0.86,0.05,0.0,0.1,0.0,0.0,0.0,0.0,martha sue karnes,
+ENGL,1030,20,Composition and Rhetoric,0.81,0.1,0.05,0.0,0.0,0.0,0.0,0.05,martha sue karnes,
+ENGL,1030,21,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,sarah margare carter,
+ENGL,1030,22,Composition and Rhetoric,0.58,0.32,0.05,0.0,0.05,0.0,0.0,0.0,sarah margare carter,
+ENGL,1030,26,Composition and Rhetoric,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,1030,28,Composition and Rhetoric,0.48,0.43,0.05,0.0,0.05,0.0,0.0,0.0,allen swords,
+ENGL,1030,36,Composition and Rhetoric,0.71,0.1,0.1,0.0,0.05,0.0,0.0,0.05,david charles foltz,
+ENGL,1030,37,Composition and Rhetoric,0.7,0.15,0.0,0.0,0.05,0.0,0.0,0.1,michelle lloyd,
+ENGL,1030,38,Composition and Rhetoric,0.5,0.35,0.0,0.0,0.1,0.0,0.0,0.05,michelle lloyd,
+ENGL,1030,39,Composition and Rhetoric,0.77,0.15,0.0,0.0,0.08,0.0,0.0,0.0,john conway,
+ENGL,1030,41,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,
+ENGL,1030,42,Composition and Rhetoric,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,caroline eliza young,
+ENGL,1030,43,Composition and Rhetoric,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliza young,
+ENGL,1030,44,Composition and Rhetoric,0.55,0.27,0.09,0.0,0.0,0.0,0.0,0.09,caroline eliza young,
+ENGL,1030,45,Composition and Rhetoric,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,beltran dian quaglia,
+ENGL,1030,46,Composition and Rhetoric,0.86,0.09,0.0,0.0,0.05,0.0,0.0,0.0,beltran dian quaglia,
+ENGL,1030,47,Composition and Rhetoric,0.19,0.69,0.13,0.0,0.0,0.0,0.0,0.0,jane elizabe kuebler,
+ENGL,1030,48,Composition and Rhetoric,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,jane elizabe kuebler,
+ENGL,1030,49,Composition and Rhetoric,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,charlotte este lucke,
+ENGL,1030,52,Composition and Rhetoric,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,gabrielle gra nugent,
+ENGL,1030,53,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,valerie smith,
+ENGL,1030,54,Composition and Rhetoric,0.86,0.05,0.0,0.0,0.0,0.0,0.0,0.1,valerie smith,
+ENGL,1030,56,Composition and Rhetoric,0.53,0.33,0.0,0.0,0.13,0.0,0.0,0.0,daniel quin atkinson,
+ENGL,1030,57,Composition and Rhetoric,0.81,0.0,0.0,0.06,0.0,0.0,0.0,0.13,christopher stuart,
+ENGL,1030,58,Composition and Rhetoric,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.1,christopher stuart,
+ENGL,1030,60,Composition and Rhetoric,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,stephen hundley,
+ENGL,1030,61,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,austin gorman,
+ENGL,1030,62,Composition and Rhetoric,0.73,0.09,0.09,0.0,0.0,0.0,0.0,0.09,michael russo,
+ENGL,1030,63,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,michael russo,
+ENGL,1030,64,Composition and Rhetoric,0.61,0.11,0.17,0.0,0.11,0.0,0.0,0.0,shauna chung,
+ENGL,1030,66,Composition and Rhetoric,0.8,0.0,0.07,0.0,0.07,0.0,0.0,0.07,victoria houser,
+ENGL,1030,67,Composition and Rhetoric,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,
+ENGL,1030,400,Composition and Rhetoric,0.52,0.43,0.0,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,
+ENGL,1030,401,Composition and Rhetoric,0.61,0.17,0.11,0.0,0.06,0.0,0.0,0.06,la'cresha ulon green,
+ENGL,1030,555,Composition and Rhetoric,0.5,0.43,0.03,0.03,0.0,0.0,0.0,0.0,elizabeth steedley,
+ENGL,2020,500,The Major Forms of Literature,0.33,0.59,0.07,0.0,0.0,0.0,0.0,0.0,elizabeth steedley,
+ENGL,2120,1,World Literature,0.11,0.36,0.39,0.11,0.0,0.0,0.0,0.04,david charles foltz,
+ENGL,2120,2,World Literature,0.25,0.36,0.25,0.0,0.04,0.0,0.0,0.11,david charles foltz,
+ENGL,2120,3,World Literature,0.7,0.2,0.07,0.03,0.0,0.0,0.0,0.0,allison nicol harris,
+ENGL,2120,4,World Literature,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,allison nicol harris,
+ENGL,2120,5,World Literature,0.48,0.34,0.14,0.0,0.0,0.0,0.0,0.03,allison nicol harris,
+ENGL,2120,6,World Literature,0.48,0.34,0.1,0.0,0.03,0.0,0.0,0.03,allison nicol harris,
+ENGL,2120,7,World Literature,0.46,0.35,0.04,0.0,0.0,0.0,0.0,0.15,remley meliss makala,
+ENGL,2120,8,World Literature,0.48,0.19,0.11,0.07,0.04,0.0,0.0,0.11,remley meliss makala,
+ENGL,2120,9,World Literature,0.38,0.31,0.14,0.03,0.0,0.0,0.0,0.14,karen kettnich,
+ENGL,2120,10,World Literature,0.59,0.31,0.03,0.0,0.03,0.0,0.0,0.03,karen kettnich,
+ENGL,2120,12,World Literature,0.45,0.41,0.1,0.0,0.0,0.0,0.0,0.03,sharon kathle nalley,
+ENGL,2120,13,World Literature,0.14,0.64,0.14,0.0,0.07,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2120,14,World Literature,0.24,0.48,0.17,0.0,0.0,0.0,0.0,0.1,sarah mae cooper,
+ENGL,2120,15,World Literature,0.48,0.38,0.1,0.03,0.0,0.0,0.0,0.0,sharon kathle nalley,
+ENGL,2120,16,World Literature,0.27,0.43,0.2,0.0,0.1,0.0,0.0,0.0,andrew mathas,
+ENGL,2120,17,World Literature,0.46,0.25,0.18,0.04,0.04,0.0,0.0,0.04,andrew mathas,
+ENGL,2120,18,World Literature,0.47,0.37,0.1,0.0,0.0,0.0,0.0,0.07,chloe miche whitaker,
+ENGL,2120,19,World Literature,0.53,0.33,0.0,0.0,0.03,0.0,0.0,0.1,chloe miche whitaker,
+ENGL,2120,20,World Literature,0.33,0.44,0.19,0.0,0.0,0.0,0.0,0.04,julia brownlee koets,
+ENGL,2120,21,World Literature,0.24,0.68,0.08,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,
+ENGL,2120,22,World Literature,0.24,0.52,0.07,0.07,0.07,0.0,0.0,0.03,hannah pittma godwin,
+ENGL,2120,23,World Literature,0.41,0.41,0.1,0.03,0.03,0.0,0.0,0.0,hannah pittma godwin,
+ENGL,2120,24,World Literature,0.59,0.1,0.14,0.03,0.07,0.0,0.0,0.07,heather pri williams,
+ENGL,2130,1,British Literature,0.41,0.48,0.0,0.0,0.0,0.0,0.0,0.1,christopher benson,
+ENGL,2130,2,British Literature,0.6,0.3,0.0,0.03,0.03,0.0,0.0,0.03,christopher benson,
+ENGL,2130,3,British Literature,0.45,0.34,0.14,0.03,0.03,0.0,0.0,0.0,megan noe macalystre,
+ENGL,2130,4,British Literature,0.3,0.4,0.1,0.03,0.07,0.0,0.0,0.1,megan noe macalystre,
+ENGL,2130,5,British Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,6,British Literature,0.59,0.34,0.07,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,7,British Literature,0.43,0.53,0.03,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,8,British Literature,0.43,0.47,0.07,0.0,0.0,0.0,0.0,0.03,lucian ghita,
+ENGL,2130,9,British Literature,0.3,0.37,0.1,0.2,0.03,0.0,0.0,0.0,megan noe macalystre,
+ENGL,2130,10,British Literature,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2130,11,British Literature,0.57,0.37,0.03,0.0,0.03,0.0,0.0,0.0,chloe miche whitaker,
+ENGL,2130,12,British Literature,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,chloe miche whitaker,
+ENGL,2130,13,British Literature,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2140,1,American Literature,0.76,0.17,0.03,0.03,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,2,American Literature,0.77,0.13,0.07,0.0,0.03,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,3,American Literature,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,lindsay kathl turner,
+ENGL,2140,4,American Literature,0.31,0.62,0.0,0.0,0.0,0.0,0.0,0.07,lindsay kathl turner,
+ENGL,2140,5,American Literature,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,melissa dugan,
+ENGL,2140,6,American Literature,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,9,American Literature,0.55,0.24,0.14,0.07,0.0,0.0,0.0,0.0,jennifer ha forsberg,
+ENGL,2140,10,American Literature,0.52,0.34,0.1,0.0,0.03,0.0,0.0,0.0,jennifer ha forsberg,
+ENGL,2140,11,American Literature,0.63,0.3,0.07,0.0,0.0,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,12,American Literature,0.6,0.33,0.03,0.03,0.0,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,13,American Literature,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2140,14,American Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2140,15,American Literature,0.7,0.11,0.07,0.0,0.04,0.0,0.0,0.07,erin nicholson gale,
+ENGL,2140,16,American Literature,0.7,0.2,0.03,0.07,0.0,0.0,0.0,0.0,erin nicholson gale,
+ENGL,2140,17,American Literature,0.4,0.33,0.17,0.03,0.07,0.0,0.0,0.0,hannah pittma godwin,
+ENGL,2140,18,American Literature,0.37,0.4,0.1,0.0,0.07,0.0,0.0,0.07,hannah pittma godwin,
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.21,0.48,0.17,0.03,0.1,0.0,0.0,0.0,chelsea marie clarey,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.2,0.43,0.27,0.0,0.07,0.0,0.0,0.03,chelsea marie clarey,
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.31,0.34,0.21,0.07,0.07,0.0,0.0,0.0,chelsea marie clarey,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.34,0.28,0.24,0.0,0.07,0.0,0.0,0.07,chelsea marie clarey,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.46,0.32,0.11,0.0,0.0,0.0,0.0,0.11,david charles foltz,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.41,0.41,0.1,0.0,0.0,0.0,0.0,0.07,david charles foltz,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.67,0.27,0.0,0.0,0.03,0.0,0.0,0.03,remley meliss makala,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.47,0.33,0.07,0.0,0.0,0.0,0.0,0.13,remley meliss makala,
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.53,0.23,0.17,0.03,0.0,0.0,0.0,0.03,john logan pursley,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.37,0.33,0.17,0.07,0.0,0.0,0.0,0.07,elizabeth stansell,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.73,0.1,0.1,0.0,0.0,0.0,0.0,0.07,jennifer ha forsberg,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ha forsberg,
+ENGL,2150,13,Lit in 20th-21st Cent Contexts,0.2,0.7,0.07,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.26,0.67,0.07,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2150,15,Lit in 20th-21st Cent Contexts,0.4,0.3,0.17,0.07,0.03,0.0,0.0,0.03,andrew mathas,
+ENGL,2150,16,Lit in 20th-21st Cent Contexts,0.63,0.2,0.07,0.0,0.07,0.0,0.0,0.03,andrew mathas,
+ENGL,2150,400,Lit in 20th-21st Cent Contexts,0.57,0.18,0.14,0.0,0.04,0.0,0.0,0.07,candace wiley,
+ENGL,2150,401,Lit in 20th-21st Cent Contexts,0.73,0.04,0.04,0.0,0.0,0.0,0.0,0.19,candace wiley,
+ENGL,3010,1,Great Books of Western World,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,3040,1,Business Writing,0.42,0.42,0.11,0.0,0.0,0.0,0.0,0.05,sean williams,
+ENGL,3040,2,Business Writing,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
+ENGL,3040,3,Business Writing,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,
+ENGL,3040,4,Business Writing,0.5,0.45,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulon green,
+ENGL,3040,5,Business Writing,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulon green,
+ENGL,3040,6,Business Writing,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,la'cresha ulon green,
+ENGL,3040,7,Business Writing,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,
+ENGL,3040,8,Business Writing,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,
+ENGL,3040,9,Business Writing,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3040,10,Business Writing,0.48,0.38,0.05,0.0,0.1,0.0,0.0,0.0,katalin beck,
+ENGL,3040,12,Business Writing,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,stephen quigley,
+ENGL,3040,400,Business Writing,0.32,0.59,0.09,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,
+ENGL,3040,401,Business Writing,0.5,0.35,0.15,0.0,0.0,0.0,0.0,0.0,crystal pat stephens,
+ENGL,3040,402,Business Writing,0.63,0.16,0.11,0.05,0.0,0.0,0.0,0.05,kriste aldebol-hazle,
+ENGL,3040,403,Business Writing,0.6,0.25,0.05,0.05,0.05,0.0,0.0,0.0,kriste aldebol-hazle,
+ENGL,3100,1,Crit Writ Lit,0.25,0.44,0.31,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,3100,2,Crit Writ Lit,0.24,0.47,0.18,0.06,0.06,0.0,0.0,0.0,lee morrissey,
+ENGL,3100,3,Crit Writ Lit,0.33,0.38,0.14,0.0,0.05,0.0,0.0,0.1,dominic mastroianni,
+ENGL,3100,4,Crit Writ Lit,0.4,0.45,0.1,0.0,0.0,0.0,0.0,0.05,erin marina goss,
+ENGL,3120,1,Advanced Composition,0.38,0.57,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth stansell,
+ENGL,3120,2,Advanced Composition,0.57,0.38,0.0,0.0,0.0,0.0,0.0,0.05,elizabeth stansell,
+ENGL,3140,1,Technical Writing,0.75,0.2,0.0,0.05,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,2,Technical Writing,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3140,3,Technical Writing,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,eric stephens,
+ENGL,3140,4,Technical Writing,0.81,0.14,0.0,0.05,0.0,0.0,0.0,0.0,eric stephens,
+ENGL,3140,5,Technical Writing,0.85,0.05,0.05,0.0,0.0,0.0,0.0,0.05,heather pri williams,
+ENGL,3140,9,Technical Writing,0.57,0.33,0.0,0.05,0.05,0.0,0.0,0.0,geveryl lee robinson,
+ENGL,3140,10,Technical Writing,0.38,0.57,0.0,0.0,0.0,0.0,0.0,0.05,geveryl lee robinson,
+ENGL,3140,11,Technical Writing,0.35,0.6,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,12,Technical Writing,0.62,0.33,0.0,0.0,0.0,0.0,0.0,0.05,katalin beck,
+ENGL,3140,14,Technical Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,samuel jackso fuller,
+ENGL,3140,15,Technical Writing,0.71,0.19,0.05,0.05,0.0,0.0,0.0,0.0,brian lee gaines,
+ENGL,3140,16,Technical Writing,0.81,0.1,0.0,0.0,0.05,0.0,0.0,0.05,brian lee gaines,
+ENGL,3140,20,Technical Writing,0.71,0.14,0.1,0.05,0.0,0.0,0.0,0.0,sharon kathle nalley,
+ENGL,3140,21,Technical Writing,0.86,0.05,0.0,0.05,0.05,0.0,0.0,0.0,joshua wood,
+ENGL,3140,23,Technical Writing,0.52,0.19,0.14,0.05,0.0,0.0,0.0,0.1,heather pri williams,
+ENGL,3140,24,Technical Writing,0.05,0.24,0.19,0.1,0.19,0.0,0.0,0.24,geveryl lee robinson,
+ENGL,3140,400,Technical Writing,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,
+ENGL,3150,1,Scientific Writing & Comm,0.67,0.24,0.05,0.0,0.05,0.0,0.0,0.0,philip randall,
+ENGL,3150,2,Scientific Writing & Comm,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,philip randall,
+ENGL,3150,3,Scientific Writing & Comm,0.38,0.48,0.1,0.05,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3150,4,Scientific Writing & Comm,0.53,0.24,0.0,0.06,0.06,0.0,0.0,0.12,william pulley,
+ENGL,3150,400,Scientific Writing,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,philip randall,
+ENGL,3150,401,Scientific Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,402,Scientific Writing & Comm,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,john conway,
+ENGL,3150,404,Scientific Writing,0.5,0.39,0.0,0.0,0.0,0.0,0.0,0.11,philip randall,
+ENGL,3320,1,Visual Communication,0.68,0.21,0.05,0.0,0.05,0.0,0.0,0.0,megan eatman,
+ENGL,3450,1,Structure of Fiction,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,3460,1,Structure of Poetry,0.5,0.38,0.06,0.0,0.0,0.0,0.0,0.06,jillian weise,
+ENGL,3480,1,Structure Screenplay,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,julia brownlee koets,
+ENGL,3480,2,Structure Screenplay,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,julia brownlee koets,
+ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.63,0.32,0.0,0.0,0.0,0.0,0.0,0.05,matthew hooley,
+ENGL,3570,1,Film,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,john robert smith,
+ENGL,3570,2,Film,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,john robert smith,
+ENGL,3570,3,Film,0.62,0.33,0.0,0.0,0.05,0.0,0.0,0.0,john robert smith,
+ENGL,3860,1,Adolescent Lit,0.56,0.28,0.06,0.06,0.06,0.0,0.0,0.0,megan noe macalystre,
+ENGL,3970,1,Brit Lit Survey II,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,david sweeney coombs,
+ENGL,3980,1,Amer Lit Survey I,0.7,0.25,0.0,0.0,0.05,0.0,0.0,0.0,kimberly manganelli,
+ENGL,3980,2,Amer Lit Survey I,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,susanna ashton,
+ENGL,4110,1,Shakespeare,0.29,0.43,0.14,0.05,0.05,0.0,0.0,0.05,brian mcgrath,
+ENGL,4110,3,Shakespeare,0.25,0.4,0.3,0.05,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4160,1,Romantic Period,0.36,0.21,0.21,0.21,0.0,0.0,0.0,0.0,brian mcgrath,
+ENGL,4180,1,English Novel,0.42,0.37,0.11,0.0,0.11,0.0,0.0,0.0,david sweeney coombs,
+ENGL,4190,1,Post Col & World Lit,0.4,0.47,0.07,0.07,0.0,0.0,0.0,0.0,cameron fae bushnell,
+ENGL,4210,1,Amer Lit 1800-1899,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,dominic mastroianni,
+ENGL,4280,1,Contemporary Literature,0.53,0.16,0.26,0.0,0.05,0.0,0.0,0.0,william stockton,
+ENGL,4400,1,Literary Theory,0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,maria selene bose,
+ENGL,4420,1,Cultural Studies,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
+ENGL,4450,1,Fiction Workshop,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,4460,1,Poetry Workshop,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,jillian weise,
+ENGL,4510,1,Film Theory and Criticism,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,
+ENGL,4540,1,Sel Top in International Film,0.47,0.33,0.13,0.07,0.0,0.0,0.0,0.0,agnieszka skrodzka,
+ENGL,4590,1,Between Damaged Life/Arcades,0.27,0.47,0.13,0.07,0.0,0.0,0.0,0.07,michelle renee ty,
+ENGL,4640,1,Topics in Literature 1700-1899,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,erin marina goss,
+ENGL,4750,1,Writing for Media,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,gabriel ande hankins,
+ENGL,4850,1,Comp & Lang Teachers,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,calandra harri davis,
+ENGL,4890,1,Topics Write & Publ,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,tharon howard,
+ENGL,4920,1,Modern Rhetoric,0.59,0.24,0.06,0.06,0.0,0.0,0.0,0.06,michelle smith,
+ENGL,4960,1,Senior Seminar,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,angela naimou,
+ENGL,4960,2,Senior Seminar,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,michael lemahieu,
+ENGL,4960,3,Senior Seminar,0.69,0.08,0.0,0.23,0.0,0.0,0.0,0.0,michelle renee ty,
+ENGL,8850,1,Composition Theory,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,megan eatman,
+ENGR,1020,211,Engineering Discipl & Skills,0.08,0.29,0.25,0.13,0.17,0.0,0.0,0.08,ashley childers,
+ENGR,1020,212,Engineering Discipl & Skills,0.1,0.33,0.2,0.3,0.03,0.0,0.0,0.03,ashley childers,
+ENGR,1020,213,Engineering Discipl & Skills,0.28,0.28,0.16,0.13,0.06,0.0,0.0,0.09,irene marie ferrara,
+ENGR,1020,214,Engineering Discipl & Skills,0.38,0.23,0.19,0.04,0.15,0.0,0.0,0.0,irene marie ferrara,
+ENGR,1150,321,Engineering Design & Modeling,0.41,0.36,0.05,0.05,0.09,0.0,0.0,0.05,john minor,
+ENGR,1410,215,Programming & Problem Solving,0.3,0.43,0.09,0.04,0.04,0.0,0.0,0.11,jonathan broo harcum,
+ENGR,1410,322,Programming & Problem Solving,0.37,0.3,0.2,0.04,0.0,0.0,0.0,0.09,michael giebner,
+ENGR,1410,323,Programming & Problem Solving,0.2,0.43,0.15,0.13,0.0,0.0,0.0,0.09,michael giebner,
+ENGR,1410,324,Programming & Problem Solving,0.2,0.58,0.09,0.02,0.02,0.0,0.0,0.09,andrew isaac neptune,
+ENGR,1410,325,Programming & Problem Solving,0.38,0.38,0.15,0.02,0.0,0.0,0.0,0.08,andrew isaac neptune,
+ENGR,1410,326,Programming & Problem Solving,0.26,0.44,0.16,0.05,0.0,0.0,0.0,0.09,jonathan broo harcum,
+ENGR,1410,327,Programming & Problem Solving,0.22,0.5,0.2,0.02,0.02,0.0,0.0,0.04,irene marie ferrara,
+ENGR,1410,501,Programming & Problem Solving,0.21,0.29,0.32,0.18,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,1410,621,Programming & Problem Solving,0.43,0.43,0.12,0.0,0.0,0.0,0.0,0.02,elizabeth an stephan,
+ENGR,1410,622,Programming & Problem Solving,0.26,0.55,0.14,0.0,0.0,0.0,0.0,0.05,jonathan broo harcum,
+ENGR,1410,623,Programming & Problem Solving,0.08,0.58,0.26,0.03,0.0,0.0,0.0,0.05,elizabeth an stephan,
+ENGR,1410,624,Programming & Problem Solving,0.3,0.53,0.02,0.07,0.02,0.0,0.0,0.05,sarah grigg,
+ENGR,1410,625,Programming & Problem Solving,0.3,0.41,0.2,0.07,0.02,0.0,0.0,0.0,matthew kent miller,
+ENGR,1410,626,Programming & Problem Solving,0.14,0.48,0.24,0.05,0.0,0.0,0.0,0.1,matthew kent miller,
+ENGR,1410,627,Programming & Problem Solving,0.29,0.48,0.19,0.05,0.0,0.0,0.0,0.0,matthew kent miller,
+ENGR,1410,821,Programming & Problem Solving,0.31,0.33,0.17,0.1,0.05,0.0,0.0,0.05,william martin,
+ENGR,1410,822,Programming & Problem Solving,0.33,0.45,0.14,0.02,0.02,0.0,0.0,0.02,william martin,
+ENGR,1410,823,Program & Prob Solving (HON),0.72,0.26,0.0,0.02,0.0,0.0,0.0,0.0,steven brandon,True
+ENGR,1410,824,Program & Prob Solving (HON),0.65,0.24,0.08,0.0,0.0,0.0,0.0,0.03,steven brandon,True
+ENGR,1410,825,Programming & Problem Solving,0.23,0.45,0.2,0.0,0.07,0.0,0.0,0.05,mariah so magagnotti,
+ENGR,1410,826,Programming & Problem Solving,0.24,0.33,0.29,0.04,0.04,0.0,0.0,0.04,mariah so magagnotti,
+ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.2,0.0,0.0,0.0,0.0,0.07,andrew isaac neptune,
+ENGR,1900,10,CI in Engr I (Robotics),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael benja wooten,
+ENGR,2080,284,Engr Graphics & Machine Design,0.56,0.21,0.15,0.04,0.0,0.0,0.0,0.04,jonathan maier,
+ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.25,0.08,0.0,0.06,0.0,0.0,0.04,anthony paul garland,
+ENGR,2080,286,Engr Graphics & Machine Design,0.4,0.25,0.13,0.06,0.06,0.0,0.0,0.1,anthony paul garland,
+ENGR,2080,382,Engr Graphics & Machine Design,0.6,0.25,0.04,0.02,0.08,0.0,0.0,0.02,nighat yasmin,
+ENGR,2080,384,Engr Graphics & Machine Design,0.54,0.21,0.08,0.06,0.12,0.0,0.0,0.0,jonathan maier,
+ENGR,2080,682,Engr Graphics & Machine Design,0.63,0.29,0.06,0.0,0.02,0.0,0.0,0.0,anthony paul garland,
+ENGR,2080,684,Engr Graphics & Machine Design,0.58,0.27,0.04,0.02,0.06,0.0,0.0,0.02,john minor,
+ENGR,2080,882,Engr Graphics & Machine Design,0.74,0.19,0.0,0.02,0.04,0.0,0.0,0.02,garrison lloy broome,
+ENGR,2080,884,Engr Graphics & Machine Design,0.49,0.31,0.1,0.02,0.04,0.0,0.0,0.04,garrison lloy broome,
+ENGR,2100,104,CAD & Engineering Applications,0.48,0.38,0.06,0.02,0.02,0.0,0.0,0.04,esfandabadi al shams,
+ENGR,2100,105,CAD & Engineering Applications,0.45,0.36,0.11,0.0,0.04,0.0,0.0,0.04,esfandabadi al shams,
+ENGR,2100,201,CAD & Engineering Applications,0.44,0.35,0.16,0.02,0.02,0.0,0.0,0.02,nighat yasmin,
+ENGR,2100,202,CAD & Engineering Applications,0.41,0.3,0.07,0.04,0.11,0.0,0.0,0.07,nighat yasmin,
+ENGR,2200,116,Evaluating Innovations,0.4,0.48,0.04,0.04,0.0,0.0,0.0,0.04,sarah grigg,
+ENGR,2200,117,Evaluating Innovations,0.32,0.48,0.13,0.03,0.0,0.0,0.0,0.03,sarah grigg,
+ENR,1020,1,Intro to Envir & Natur Res II,0.72,0.11,0.06,0.04,0.0,0.0,0.0,0.06,russell barrett,
+ENR,3020,1,Nat Res Measurements,0.62,0.21,0.13,0.0,0.0,0.0,0.0,0.05,lawrence gering,
+ENR,4130,2,Restoration Ecology,0.28,0.5,0.19,0.0,0.0,0.0,0.0,0.03,althea simone hagan,
+ENR,4500,1,Conservation Issues,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,alan johnson,
+ENR,4500,2,Conservation Issues,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,alan johnson,
+ENR,6130,2,Restoration Ecology,0.47,0.47,0.0,0.0,0.07,0.0,0.0,0.0,althea simone hagan,
+ENSP,2000,1,Intro Environ Sci,0.36,0.44,0.11,0.05,0.02,0.0,0.0,0.02,tom owino,
+ENSP,2000,2,Intro Environ Sci,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+ENSP,2000,3,Intro Environ Sci,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2000,4,Intro Environ Sci,0.59,0.22,0.13,0.02,0.04,0.0,0.0,0.0,minory nammouz,
+ENSP,2010,1,Environm Sci for Educ Majors,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,4000,1,Studies in Environmental Sci,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,margaret lo thompson,
+ENT,2000,1,Six-Legged Science,0.47,0.3,0.14,0.09,0.0,0.0,0.0,0.0,suellen pometto,
+ENTR,1010,1,Entrepreneurial Mindset,0.72,0.11,0.07,0.01,0.05,0.0,0.0,0.04,john michael hannon,
+ENTR,1090,1,CI- How to Start a Startup,0.81,0.05,0.0,0.0,0.0,0.0,0.0,0.14,john michael hannon,
+ENTR,2010,3,Sports Entrepreneurship,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
+ESED,1990,1,Creative Inq Engr & Sci Ed I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,claire louise dancz,
+ESED,2990,1,Creative Inq Engr & Sci Ed II,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,claire louise dancz,
+ESED,4910,5,Undergraduate Research,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,claire louise dancz,
+ETOX,8300,1,Mechanistic Toxicology,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,william baldwin,
+FDSC,2140,1,Fd Resources & Soc,0.62,0.18,0.1,0.0,0.04,0.0,0.0,0.06,paul dawson,
+FDSC,2150,1,Culinary Fundamental,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,aubrey dean coffee,
+FDSC,3040,1,Eval Dairy Products,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+FDSC,4020,1,Food Chemistry II,0.32,0.49,0.12,0.07,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4030,1,Food Ch & Analysis,0.74,0.13,0.11,0.0,0.0,0.0,0.0,0.02,paul dawson,
+FDSC,4080,1,Food Process Eng,0.7,0.2,0.05,0.0,0.0,0.0,0.0,0.05,felix barron,
+FDSC,4090,1,TQM for Food & Pckg Industries,0.61,0.18,0.06,0.09,0.0,0.0,0.0,0.06,john mcgregor,
+FDSC,4100,1,Food Product Dev,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,margaret condrasky,
+FDSC,4170,1,Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
+FIN,2010,401,Intro to Personal Finance,0.92,0.06,0.0,0.0,0.02,0.0,0.0,0.0,joshua harris,
+FIN,2010,402,Intro to Personal Finance,0.87,0.11,0.0,0.02,0.0,0.0,0.0,0.0,joshua harris,
+FIN,2010,403,Intro to Personal Finance,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,joshua harris,
+FIN,2010,404,Intro to Personal Finance,0.79,0.12,0.04,0.01,0.01,0.0,0.0,0.01,joshua harris,
+FIN,2010,405,Intro to Personal Finance,0.75,0.15,0.06,0.0,0.02,0.0,0.0,0.02,joshua harris,
+FIN,2010,406,Intro to Personal Finance,0.76,0.13,0.02,0.02,0.0,0.0,0.0,0.07,joshua harris,
+FIN,3040,1,Risk & Insurance,0.22,0.3,0.48,0.0,0.0,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.11,0.36,0.39,0.04,0.04,0.0,0.0,0.07,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.26,0.37,0.26,0.08,0.0,0.0,0.0,0.03,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.15,0.33,0.48,0.0,0.03,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,4,Investment Analysis,0.15,0.15,0.32,0.24,0.03,0.0,0.0,0.12,john alexander,
+FIN,3060,1,Corporation Finance,0.2,0.14,0.2,0.2,0.2,0.0,0.0,0.08,william holl johnson,
+FIN,3060,2,Corporation Finance,0.37,0.08,0.21,0.21,0.06,0.0,0.0,0.08,william holl johnson,
+FIN,3060,3,Corporation Finance,0.37,0.2,0.1,0.12,0.12,0.0,0.0,0.08,william holl johnson,
+FIN,3060,4,Corporation Finance,0.1,0.18,0.16,0.14,0.22,0.0,0.0,0.2,william holl johnson,
+FIN,3060,5,Corporation Finance,0.06,0.28,0.3,0.24,0.06,0.0,0.0,0.06,ramon tolbe franklin,
+FIN,3060,6,Corporation Finance,0.12,0.29,0.2,0.18,0.14,0.0,0.0,0.06,ramon tolbe franklin,
+FIN,3060,7,Corporation Finance,0.31,0.24,0.28,0.11,0.04,0.0,0.0,0.02,ramon tolbe franklin,
+FIN,3060,8,Corporation Finance,0.19,0.31,0.22,0.19,0.02,0.0,0.0,0.07,ramon tolbe franklin,
+FIN,3070,1,Prin of Real Estate,0.23,0.43,0.26,0.06,0.03,0.0,0.0,0.0,yannan shen,
+FIN,3070,2,Prin of Real Estate,0.23,0.46,0.23,0.06,0.03,0.0,0.0,0.0,yannan shen,
+FIN,3070,3,Prin of Real Estate,0.23,0.26,0.28,0.15,0.05,0.0,0.0,0.03,thomas springer,
+FIN,3080,1,Fin Inst & Mkts,0.16,0.46,0.24,0.05,0.05,0.0,0.0,0.03,daniel thomas greene,
+FIN,3080,2,Fin Inst & Mkts,0.32,0.34,0.29,0.05,0.0,0.0,0.0,0.0,daniel thomas greene,
+FIN,3080,3,Fin Inst & Mkts,0.32,0.29,0.24,0.11,0.05,0.0,0.0,0.0,daniel thomas greene,
+FIN,3110,1,Financial Management I,0.21,0.33,0.18,0.05,0.0,0.0,0.0,0.23,george bran lockhart,
+FIN,3110,2,Financial Management I,0.08,0.35,0.33,0.05,0.08,0.0,0.0,0.13,george bran lockhart,
+FIN,3110,3,Financial Management I,0.18,0.33,0.23,0.0,0.13,0.0,0.0,0.15,george bran lockhart,
+FIN,3110,4,Financial Management I,0.06,0.25,0.44,0.03,0.08,0.0,0.0,0.14,jack wolf,
+FIN,3120,1,Financial Management II,0.24,0.38,0.24,0.08,0.0,0.0,0.0,0.05,blerina zykaj,
+FIN,3120,2,Financial Management II,0.47,0.19,0.28,0.06,0.0,0.0,0.0,0.0,blerina zykaj,
+FIN,3120,3,Financial Management II,0.18,0.41,0.23,0.08,0.03,0.0,0.0,0.08,weike xu,
+FIN,3120,4,Financial Management II,0.14,0.34,0.29,0.11,0.03,0.0,0.0,0.09,weike xu,
+FIN,4030,1,Spreadsheet Apps in Finance,0.23,0.51,0.26,0.0,0.0,0.0,0.0,0.0,vincent ja intintoli,
+FIN,4030,2,Spreadsheet Apps in Finance,0.2,0.4,0.24,0.12,0.04,0.0,0.0,0.0,vincent ja intintoli,
+FIN,4040,1,Financial Modeling,0.25,0.33,0.33,0.08,0.0,0.0,0.0,0.0,jack wolf,
+FIN,4050,1,Portfolio Management & Theory,0.13,0.27,0.23,0.13,0.17,0.0,0.0,0.07,john alexander,
+FIN,4080,1,Mgt of Fin Inst,0.33,0.57,0.1,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4080,2,Mgt of Fin Inst,0.19,0.44,0.31,0.06,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4090,1,Prof Fin Plan Capstone,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,
+FIN,4110,1,Int Fin Mgt,0.27,0.55,0.12,0.06,0.0,0.0,0.0,0.0,luke asher devault,
+FIN,4110,2,Int Fin Mgt,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,luke asher devault,
+FIN,4150,1,Real Estate Investmt,0.24,0.29,0.33,0.14,0.0,0.0,0.0,0.0,thomas springer,
+FIN,4160,1,Real Estate Val,0.31,0.31,0.31,0.0,0.06,0.0,0.0,0.0,valerie lynn hammett,
+FNR,4700,35,Aquaponics,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,lance edward beecher,
+FNR,4700,52,Stream & Reservoir Fish Eco I,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,troy mason farmer,
+FNR,4990,1,Natural Resources Seminar,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
+FNR,4990,2,Natural Resources Seminar,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,susan talley guynn,
+FNR,4990,3,Natural Resources Seminar,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
+FOR,1010,1,Intro to Forestry,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,lawrence gering,
+FOR,2060,1,Forestry Ecology,0.23,0.43,0.22,0.04,0.05,0.0,0.0,0.03,donald hagan,
+FOR,3080,1,Remote Sensing in Forestry,0.43,0.47,0.1,0.0,0.0,0.0,0.0,0.0,lawrence gering,
+FOR,4080,1,Wood and Paper Products,0.52,0.29,0.14,0.05,0.0,0.0,0.0,0.0,patricia layton,
+FOR,4150,1,Forest Wildlife Managment,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,james davis,
+FOR,4180,1,Forest Resource Valuation,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4340,1,GIS for Natural Resources,0.28,0.58,0.1,0.03,0.0,0.0,0.0,0.03,robert fritz baldwin,
+FOR,4650,1,Silviculture,0.12,0.54,0.31,0.04,0.0,0.0,0.0,0.0,gaofeng wang,
+FOR,6340,1,GIS for Natural Resources,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert fritz baldwin,
+FOR,8120,1,Fire Ecology and Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,gaofeng wang,
+FR,1010,1,Elementary French,0.24,0.53,0.24,0.0,0.0,0.0,0.0,0.0, nedeo anne salces anne,
+FR,1010,2,Elementary French,0.41,0.12,0.29,0.0,0.06,0.0,0.0,0.12, nedeo anne salces anne,
+FR,1010,3,Elementary French,0.29,0.14,0.14,0.21,0.14,0.0,0.0,0.07,kenneth davi widgren,
+FR,1020,1,Elementary French,0.76,0.18,0.0,0.06,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
+FR,1020,2,Elementary French,0.5,0.2,0.2,0.1,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
+FR,2010,2,Intermediate French,0.8,0.16,0.0,0.0,0.04,0.0,0.0,0.0,amy lyn griff sawyer griff,
+FR,2010,3,Intermediate French,0.19,0.5,0.19,0.06,0.0,0.0,0.0,0.06,kenneth davi widgren,
+FR,2010,4,Intermediate French,0.22,0.33,0.33,0.0,0.0,0.0,0.0,0.11,kenneth davi widgren,
+FR,2020,1,Intermediate French,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,tholozany pauline de,
+FR,2020,2,Intermediate French,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griff sawyer griff,
+FR,2020,4,Intermediate French,0.06,0.82,0.12,0.0,0.0,0.0,0.0,0.0,kenneth davi widgren,
+FR,3050,1,Int Fr Con & Comp I,0.59,0.06,0.24,0.0,0.0,0.0,0.0,0.12, nedeo anne salces anne,
+FR,3160,1,Fr for Intl Trade,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,
+FR,3170,1,Contemp French Civ,0.76,0.18,0.0,0.06,0.0,0.0,0.0,0.0,joseph mai,
+FR,4760,1,French Feminism and Theory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,eric touya,
+GC,1010,1,Orientation to G C,0.5,0.3,0.09,0.0,0.02,0.0,0.0,0.09,john leininger,
+GC,1020,1,Computer Art & CAD Foundations,0.46,0.33,0.1,0.04,0.02,0.0,0.0,0.06,carol jones,
+GC,1030,1,G C I for Pkgsc,0.26,0.55,0.18,0.0,0.0,0.0,0.0,0.0,john jacobs,
+GC,1040,1,Graphic Communications I,0.66,0.21,0.05,0.03,0.02,0.0,0.0,0.03,rebecca suzan edlein,
+GC,2070,1,Graphic Communications II,0.3,0.5,0.07,0.04,0.04,0.0,0.0,0.04,charles tabor weiss,
+GC,3400,1,Digital Imaging and eMedia,0.4,0.43,0.1,0.05,0.0,0.0,0.0,0.03,erica black walker,
+GC,3460,1,Ink and Substrates,0.17,0.61,0.15,0.0,0.04,0.0,0.0,0.02,liam henry 'hara,
+GC,4060,1,Package and Specialty Printing,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,kern cox,
+GC,4400,1,Commercial Printing,0.53,0.33,0.07,0.0,0.03,0.0,0.0,0.03,john leininger,
+GC,4440,1,Current Dev/Trends in Gr Comm,0.73,0.22,0.03,0.03,0.0,0.0,0.0,0.0,samuel ingram,
+GC,4480,1,Plan & Cont Printing Functions,0.83,0.09,0.09,0.0,0.0,0.0,0.0,0.0,nona woolbright,
+GC,4800,1,Senior Seminar in GC,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,charles edwar tonkin,
+GC,4900,2,G C Selected Topics-Sales,0.82,0.06,0.0,0.0,0.0,0.0,0.0,0.12,john leininger,
+GC,4900,3,Select Topic-Dig Media Design,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,erica black walker,
+GEN,3000,1,Fundamental Genetics,0.27,0.29,0.3,0.09,0.03,0.0,0.0,0.03,kate leanne wil tsai wil,
+GEN,3000,2,Fundamental Genetics,0.23,0.41,0.22,0.07,0.01,0.0,0.0,0.05,kate leanne wil tsai wil,
+GEN,3020,1,Molecular & General Genetics,0.36,0.41,0.11,0.05,0.0,0.0,0.0,0.07,rajandeep sin sekhon,
+GEN,3040,1,Molecular Biology Laboratory,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,3040,4,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,4100,1,Population & Quant Genetics,0.38,0.43,0.15,0.02,0.02,0.0,0.0,0.0,scott michael tanner,
+GEN,4110,3,Population & Quant Gen Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,scott michael tanner,
+GEN,4400,1,Bioinformatics,0.53,0.35,0.06,0.0,0.06,0.0,0.0,0.0,liangjiang wang,
+GEN,4700,1,Human Genetics,0.42,0.23,0.15,0.0,0.0,0.0,0.0,0.19,miriam kristi konkel,
+GEN,4900,13,GB Professional Development,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,alison ni starr-moss,
+GEN,4930,3,Senior Seminar,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,alison ni starr-moss,
+GEN,8100,1,Princ of Molecular Biology,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,jennifer may mason,
+GEOG,1010,1,Intro to Geography,0.34,0.37,0.14,0.09,0.0,0.0,0.0,0.06,christa smith,
+GEOG,1030,1,World Regional Geography,0.34,0.46,0.09,0.03,0.03,0.0,0.0,0.04,william church terry,
+GEOL,1010,1,Physical Geology,0.28,0.32,0.2,0.1,0.04,0.0,0.0,0.07,alan coulson,
+GEOL,1010,2,Physical Geology,0.57,0.19,0.1,0.06,0.04,0.0,0.0,0.04,alan coulson,
+GEOL,1010,3,Physical Geology,0.26,0.26,0.21,0.1,0.1,0.0,0.0,0.07,mary katherin fidler,
+GEOL,1030,1,Physical Geol Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.3,0.57,0.13,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.7,0.22,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.48,0.43,0.0,0.0,0.0,0.0,0.0,0.09,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,9,Physical Geol Lab,0.26,0.39,0.17,0.04,0.0,0.0,0.0,0.13,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.58,0.21,0.13,0.0,0.04,0.0,0.0,0.04,alan coulson,
+GEOL,1030,13,Physical Geol Lab,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.08,alan coulson,
+GEOL,1120,1,Earth Resources,0.42,0.33,0.17,0.04,0.04,0.0,0.0,0.0,mary katherin fidler,
+GEOL,1140,1,Earth Resources Lab,0.6,0.17,0.13,0.1,0.0,0.0,0.0,0.0,mary katherin fidler,
+GEOL,2020,1,Earth History,0.28,0.44,0.22,0.06,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,3130,1,Sedimentology & Stratigraphy,0.26,0.35,0.39,0.0,0.0,0.0,0.0,0.0,mary katherin fidler,
+GEOL,3180,1,Introduction to Geochemistry,0.46,0.42,0.13,0.0,0.0,0.0,0.0,0.0,brian powell,
+GEOL,4210,1,Gis in Geology,0.74,0.15,0.07,0.04,0.0,0.0,0.0,0.0,scott brame,
+GEOL,7900,501,Biogeography & Geology of SC,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
+GEOL,8030,1,Geostatistics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,stephen micha moysey,
+GEOL,8090,1,Subsurface Remed Mod,0.22,0.56,0.22,0.0,0.0,0.0,0.0,0.0,ronald falta,
+GEOL,8160,1,Aquifer Systems,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,lawrence murdoch,
+GER,1010,1,Elementary German,0.11,0.26,0.26,0.05,0.16,0.0,0.0,0.16,isabel meusen,
+GER,1010,2,Elementary German,0.11,0.44,0.11,0.11,0.06,0.0,0.0,0.17,isabel meusen,
+GER,1020,1,Elementary German,0.31,0.38,0.25,0.0,0.06,0.0,0.0,0.0,oswald harris king,
+GER,2010,1,Intermediate German,0.26,0.21,0.42,0.0,0.11,0.0,0.0,0.0, lee ferrell,
+GER,2010,2,Intermediate German,0.36,0.45,0.0,0.0,0.0,0.0,0.0,0.18,oswald harris king,
+GER,2020,1,Intermediate German,0.4,0.2,0.13,0.2,0.0,0.0,0.0,0.07,gabriela stoicea,
+GER,2020,2,Intermediate German,0.46,0.15,0.23,0.08,0.0,0.0,0.0,0.08,gabriela stoicea,
+GER,3060,1,German Short Story,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,oswald harris king,
+HCC,8810,1,Measurement & Eval,0.38,0.46,0.0,0.0,0.15,0.0,0.0,0.0,bart knijnenburg,
+HCG,9050,1,"Genomics, Ethics & Hlth Policy",0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,mary steck,
+HIST,1010,1,History of the United States,0.53,0.32,0.12,0.0,0.03,0.0,0.0,0.0,james bradf jeffries,
+HIST,1240,1,Environmental History Survey,0.16,0.55,0.21,0.0,0.05,0.0,0.0,0.03,james bradf jeffries,
+HIST,1720,3,The West and the World I,0.26,0.53,0.18,0.0,0.03,0.0,0.0,0.0,thomas kuehn,
+HIST,1730,1,The West and the World II,0.18,0.48,0.13,0.01,0.1,0.0,0.0,0.1, alan grubb,
+HIST,1730,2,The West and the World II,0.18,0.42,0.27,0.04,0.06,0.0,0.0,0.03,michael meng,
+HIST,1730,3,The West and the World II,0.39,0.37,0.16,0.04,0.02,0.0,0.0,0.03,steven marks,
+HIST,2990,1,Historian's Craft,0.54,0.17,0.04,0.04,0.04,0.0,0.0,0.17,michael silvestri,
+HIST,2990,2,Historian's Craft,0.83,0.09,0.0,0.0,0.04,0.0,0.0,0.04,rachel anne moore,
+HIST,3110,1,African American Hist to 1877,0.41,0.33,0.19,0.0,0.0,0.0,0.0,0.07,abel bartley,
+HIST,3230,1,Hist of Amer Tech,0.42,0.46,0.08,0.0,0.0,0.0,0.0,0.04,pamela mack,
+HIST,3240,1,Hist of the South II,0.36,0.19,0.17,0.06,0.14,0.0,0.0,0.08,john andrew,
+HIST,3250,1,Amer Econ Developmt,0.17,0.5,0.08,0.0,0.04,0.0,0.0,0.21,william camp,
+HIST,3260,1,Hist Am Transport,0.48,0.36,0.12,0.0,0.0,0.0,0.0,0.04, roger grant,
+HIST,3420,1,South Am Since 1800,0.6,0.37,0.0,0.0,0.03,0.0,0.0,0.0,rachel anne moore,
+HIST,3610,1,History of Britain to 1688,0.41,0.41,0.14,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,
+HIST,3810,1,Germany 1918 to 1945,0.22,0.33,0.3,0.0,0.07,0.0,0.0,0.07,michael meng,
+HIST,3900,1,Modern Military History,0.29,0.42,0.25,0.04,0.0,0.0,0.0,0.0,edwin moise,
+HIST,3920,1,Hist U S Environment,0.27,0.5,0.13,0.03,0.03,0.0,0.0,0.03,william camp,
+HIST,3970,1,Modern Middle East,0.5,0.42,0.04,0.0,0.0,0.0,0.0,0.04,amit bein,
+HIST,3980,1,American Military History,0.2,0.43,0.17,0.07,0.07,0.0,0.0,0.07,john andrew,
+HIST,4360,1,Vietnam Wars,0.12,0.53,0.24,0.0,0.12,0.0,0.0,0.0,edwin moise,
+HIST,4600,1,Film and Empire,0.53,0.33,0.07,0.0,0.0,0.0,0.0,0.07,michael silvestri,
+HIST,4930,1,The American City,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,abel bartley,
+HIST,4940,1,Russian Film History,0.29,0.29,0.0,0.0,0.29,0.0,0.0,0.14,steven marks,
+HLTH,2020,1,Introduction to Public Health,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,2,Introduction to Public Health,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2020,400,Introduction to Public Health,0.6,0.3,0.05,0.0,0.0,0.0,0.0,0.05,ralph stewart welsh,
+HLTH,2020,401,Introduction to Public Health,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.52,0.34,0.14,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2030,2,Health Care Sys,0.45,0.48,0.07,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2030,3,Health Care Sys,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lee alden crandall,
+HLTH,2030,400,Health Care Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2400,1,Deter of Hlth Behav,0.52,0.36,0.04,0.04,0.0,0.0,0.0,0.04,amelia clinkscales,
+HLTH,2400,2,Deter of Hlth Behav,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2400,400,Deter of Hlth Behav,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,2500,1,Health and Fitness,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.04,ralph stewart welsh,
+HLTH,2600,1,Medical Terminology & Comm,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,karen edwards,
+HLTH,2600,2,Medical Terminology & Comm,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,
+HLTH,2980,1,Human Health and Disease,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,2980,2,Human Health and Disease,0.43,0.54,0.03,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,3030,1,Public Health Comm,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
+HLTH,3800,1,Epidemiology,0.31,0.62,0.0,0.0,0.08,0.0,0.0,0.0,hugh spitler,
+HLTH,3800,2,Epidemiology,0.56,0.28,0.16,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,3980,1,Health Appraisal Skills,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,3980,2,Health Appraisal Skills,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.7,0.23,0.08,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.79,0.18,0.03,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4310,1,Public & Environ Hlt,0.54,0.33,0.1,0.0,0.0,0.0,0.0,0.03,deborah alma falta,
+HLTH,4700,1,Global Health,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,micky rogers ward,
+HLTH,4780,1,Health Policy Ethics and Law,0.44,0.19,0.25,0.0,0.13,0.0,0.0,0.0,hugh spitler,
+HLTH,4800,1,Comm Hlth Promotion,0.63,0.29,0.08,0.0,0.0,0.0,0.0,0.0,sarah griffin,
+HLTH,4900,1,Res Eval St Pub Hlth,0.55,0.25,0.1,0.05,0.0,0.0,0.0,0.05,karen kemper,
+HLTH,4900,2,Res Eval St Pub Hlth,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,4900,3,Res Eval St Pub Hlth,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,4970,5,Alcohol & Other Drugs CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,crystal burne fulmer,
+HLTH,8110,1,Health Care Delivery Systems,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
+HLTH,8130,500,Population Health and Research,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,sarah griffin,
+HLTH,8310,1,Quantitative Analy in Hlth I,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,lu shi,
+HON,2020,1,Civil Discourse,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,True
+HON,2050,2,Social Entrepreneurship,0.93,0.0,0.0,0.0,0.03,0.0,0.0,0.03,john michael hannon,True
+HON,2060,1,Intro to Nanotechnology,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,True
+HON,2100,1,Experiencing the Arts,0.89,0.05,0.0,0.05,0.0,0.0,0.0,0.0,mark spede,True
+HON,2210,1,Literature and/as Resistance,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,gabriela stoicea,True
+HON,2210,3,Adventure Novels in Context,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,tholozany pauline de,True
+HON,2210,4,Fascism/Anti-fascism Lit,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,gabriel ande hankins,True
+HON,2210,5,American Science Fiction,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,andrew lemons,True
+HORT,2020,1,Adobe Digital Design,0.85,0.09,0.0,0.03,0.03,0.0,0.0,0.0,janice ann lay,
+HORT,2110,1,Growing Spring Plnts,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,james emerson faust,
+HORT,4000,1,Water for Agriculture,0.4,0.4,0.13,0.0,0.0,0.0,0.0,0.07,sarah white,
+HORT,4040,1,Plant Propagation,0.18,0.29,0.41,0.12,0.0,0.0,0.0,0.0,jeffrey adelberg,
+HORT,4090,1,Senior Capstone Course,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HORT,4200,1,Applied Turf Physiol,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
+HORT,4270,1,Urban Tree Care,0.06,0.25,0.56,0.13,0.0,0.0,0.0,0.0,robert polomski,
+HORT,4330,1,Turf Weed Management,0.14,0.27,0.55,0.05,0.0,0.0,0.0,0.0,ted whitwell,
+HORT,4610,1,Advanc Landscape Garden Design,0.92,0.0,0.08,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HORT,6040,1,Plant Propagation,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jeffrey adelberg,
+HRD,8470,400,Instru System Design,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,angela daniel carter,
+HRD,8490,400,Eval of T&D/Hrd Prog,0.76,0.12,0.0,0.0,0.06,0.0,0.0,0.06,angela daniel carter,
+HRD,8800,400,Research Concepts,0.76,0.15,0.03,0.0,0.0,0.0,0.0,0.06,kristin kelly frady,
+IE,2100,1,Des Analysis Wrk Sys,0.44,0.42,0.07,0.05,0.0,0.0,0.0,0.02,sara lu riggs,
+IE,3010,1,Systems Design I,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,xiaoxia li,
+IE,3600,1,Industrial Apps of Prob/Stat I,0.39,0.34,0.12,0.08,0.05,0.0,0.0,0.03,mary elizabeth kurz,
+IE,3610,1,Industrial App of Prob/Stat II,0.3,0.34,0.27,0.06,0.02,0.0,0.0,0.02,david neyens,
+IE,3800,1,Deterministic Operations Rsrch,0.27,0.39,0.17,0.1,0.02,0.0,0.0,0.05,ceyda yaba,
+IE,3810,1,Probabilistic Operations Rsrch,0.31,0.21,0.29,0.13,0.02,0.0,0.0,0.05,robert james riggs,
+IE,3840,1,Engr Econ Analysis,0.19,0.19,0.15,0.1,0.09,0.0,0.0,0.29,brian melloy,
+IE,3860,1,Production Planning & Control,0.36,0.23,0.28,0.09,0.04,0.0,0.0,0.0,kevin taaffe,
+IE,4400,1,Decision Support Sys,0.48,0.32,0.13,0.05,0.03,0.0,0.0,0.0,mary elizabeth kurz,
+IE,4570,1,Transp/Logistic Engr,0.33,0.47,0.16,0.05,0.0,0.0,0.0,0.0,sandra duni eksioglu,
+IE,4610,1,Quality Engineering,0.26,0.42,0.14,0.14,0.01,0.0,0.0,0.03,byung rae cho,
+IE,4620,1,Six Sigma Quality,0.38,0.42,0.19,0.01,0.0,0.0,0.0,0.0,robert james riggs,
+IE,4650,1,Facilities Planning & Design,0.9,0.09,0.0,0.01,0.0,0.0,0.0,0.0,xiaoxia li,
+IE,4670,1,System Design II,0.53,0.37,0.1,0.0,0.0,0.0,0.0,0.0,jeffery messer,
+IE,4670,2,System Design II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,
+IE,4820,1,Systems Modeling,0.32,0.33,0.21,0.08,0.05,0.0,0.0,0.02,tugce isik,
+IE,4880,1,Human Factors Eng,0.23,0.57,0.19,0.01,0.0,0.0,0.0,0.0,madathil kapi chalil,
+IE,4910,100,Applied Probabilistic OR,0.33,0.42,0.17,0.0,0.0,0.0,0.0,0.08,brian melloy,
+IE,6570,1,Transp/Logistic Engr,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,sandra duni eksioglu,
+IE,6620,1,Six Sigma Quality,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
+IE,8050,1,Found Qual Engr,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,byung rae cho,
+IE,8520,1,Prescriptive Analytics,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
+IE,8540,1,SC & Logistics Modeling I,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,william ferrell,
+IE,8580,1,Case Study Supply Chn & Logist,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,scott jennings mason,
+IE,8800,1,Adv Meth of Or,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,amin khademi,
+IE,8930,1,Rsrch Method-Human Interaction,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,laura michel stanley,
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,lisa marie robinson,
+INT,1520,1,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,0.9,0.09,0.01,caren kelley-hall,
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.85,0.15,0.0,caren kelley-hall,
+INT,1540,1,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,caren kelley-hall,
+INT,2510,1,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,0.95,0.05,0.0,lisa marie robinson,
+INT,2530,1,UPIC Internship FT 3,0.0,0.0,0.0,0.0,0.0,0.9,0.1,0.0,caren kelley-hall,
+IPM,4010,1,Principles of I P M,0.57,0.29,0.07,0.07,0.0,0.0,0.0,0.0,carmen blubaugh,
+IPM,6010,1,Principles of I P M,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,carmen blubaugh,
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.83,0.16,0.01,meredith fant wilson,
+ITAL,1010,1,Elementary Italian,0.47,0.18,0.12,0.0,0.06,0.0,0.0,0.18,lyudmyla tsykalova,
+ITAL,1020,1,Elementary Italian,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,
+ITAL,1020,2,Elementary Italian,0.39,0.5,0.0,0.06,0.06,0.0,0.0,0.0,julia schmidt,
+ITAL,1020,3,Elementary Italian,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,julia schmidt,
+ITAL,2010,1,Intermediate Italian,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+ITAL,2020,2,Intermediate Italian,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+JAPN,1010,1,Elementary Japanese,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,saori suto,
+JAPN,1010,2,Elementary Japanese,0.2,0.13,0.27,0.13,0.0,0.0,0.0,0.27,saori suto,
+JAPN,1020,2,Elementary Japanese,0.18,0.36,0.45,0.0,0.0,0.0,0.0,0.0,satomi saito,
+JAPN,2010,1,Intermed Japanese,0.58,0.17,0.08,0.0,0.08,0.0,0.0,0.08,saori suto,
+JAPN,2020,1,Intermed Japanese,0.5,0.14,0.21,0.14,0.0,0.0,0.0,0.0,saori suto,
+JAPN,4160,1,Japanese for Int'l Trade II,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jae allegra takeuchi,
+JUST,2880,1,The Criminal Justice System,0.29,0.39,0.3,0.02,0.0,0.0,0.0,0.0,margaret tina britz,
+JUST,4940,1,Organized Crime,0.52,0.29,0.13,0.02,0.04,0.0,0.0,0.0,margaret tina britz,
+LANG,2540,1,Introduction to World Cinemas,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,raquel anido,
+LANG,3000,1,Intro Linguistics,0.58,0.16,0.16,0.0,0.0,0.0,0.0,0.11,jae allegra takeuchi,
+LANG,4620,1,Borders,0.46,0.31,0.0,0.0,0.15,0.0,0.0,0.08,tiffany dawn miller,
+LARC,1160,1,History of Landscape Arch,0.65,0.28,0.03,0.01,0.01,0.0,0.0,0.01,hala fouad nassar,
+LARC,1160,2,History of Landscape Arch,0.17,0.39,0.26,0.13,0.04,0.0,0.0,0.0,hala fouad nassar,
+LARC,1520,1,Basic Design II,0.57,0.3,0.04,0.0,0.09,0.0,0.0,0.0,jessica fernandez,
+LARC,2550,1,Community Design Studio,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,matthew neal powers,
+LARC,3620,1,Design Impl II,0.6,0.2,0.13,0.07,0.0,0.0,0.0,0.0,robert hewitt,
+LARC,3620,2,Design Impl II,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,paul russell,
+LARC,4280,1,Computer-Aided Design,0.55,0.14,0.14,0.05,0.09,0.0,0.0,0.05,jessica fernandez,
+LARC,6810,1,Professional Practice,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,david lycke,
+LARC,8020,1,Orientation II,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,paul russell,
+LARC,8300,1,Graduate Seminar I,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,thomas willi schurch,
+LAW,3220,1,Legal Env of Bus,0.13,0.22,0.42,0.22,0.0,0.0,0.0,0.0,kenneth sc toussaint,
+LAW,3220,2,Legal Env of Bus,0.28,0.43,0.22,0.02,0.02,0.0,0.0,0.02,edward ray claggett,
+LAW,3220,3,Legal Env of Bus,0.26,0.37,0.26,0.09,0.0,0.0,0.0,0.02,kenneth sc toussaint,
+LAW,3220,4,Legal Env of Bus,0.23,0.36,0.34,0.05,0.02,0.0,0.0,0.0,kenneth sc toussaint,
+LAW,3220,5,Legal Env of Bus,0.11,0.59,0.25,0.05,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,6,Legal Env of Bus,0.22,0.4,0.38,0.0,0.0,0.0,0.0,0.0,judson jahn,
+LAW,3220,7,Legal Env of Bus,0.69,0.29,0.03,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,8,Legal Env of Bus,0.11,0.3,0.52,0.05,0.02,0.0,0.0,0.0,kenneth sc toussaint,
+LAW,3220,9,Legal Env of Bus,0.82,0.16,0.0,0.0,0.0,0.0,0.0,0.02,frances edwards,
+LAW,3220,10,Legal Env of Bus,0.28,0.47,0.16,0.05,0.0,0.0,0.0,0.05,john hine,
+LAW,3220,11,Legal Env of Bus,0.11,0.4,0.29,0.11,0.07,0.0,0.0,0.02,john hine,
+LAW,3220,401,Legal Env of Bus,0.44,0.32,0.16,0.05,0.0,0.0,0.0,0.04,virginia ward-vaughn,
+LAW,3220,402,Legal Env of Bus,0.25,0.31,0.25,0.05,0.07,0.0,0.0,0.07,virginia ward-vaughn,
+LAW,3220,403,Legal Env of Bus,0.33,0.44,0.18,0.0,0.02,0.0,0.0,0.04,virginia ward-vaughn,
+LAW,3220,404,Legal Env of Bus,0.22,0.39,0.24,0.06,0.04,0.0,0.0,0.06,virginia ward-vaughn,
+LAW,3330,1,Real Estate Law,0.14,0.67,0.14,0.02,0.02,0.0,0.0,0.0,judson jahn,
+LAW,4200,1,Int Business Law,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,8480,1,Law Real Estate Prof,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,james ivey warren,
+LIT,1270,1,Intro to L&It,0.0,0.0,0.0,0.0,0.0,0.88,0.04,0.08, lee ferrell,
+LS,1000,4,Introduction to Barre,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,lauren elizab george,
+LS,1000,8,Intro to Salsa Dance,0.54,0.23,0.0,0.0,0.23,0.0,0.0,0.0,malik lewis  baxter c,
+LS,1000,9,Intro to Salsa Dance,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,malik lewis  baxter c,
+LS,1000,10,Intro to Salsa Dance,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,malik lewis  baxter c,
+LS,1000,20,Intro to Volleyball,0.88,0.0,0.0,0.0,0.06,0.0,0.0,0.06,kelly lynn ator,
+LS,1000,23,Therapeutic Yoga,0.77,0.09,0.0,0.0,0.0,0.0,0.0,0.14,renee warren gahan,
+LS,1330,2,Women's Shotgun,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,bonnie duke gill,
+LS,1350,1,Women's Riflery,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,hubert cox,
+LS,1410,1,Top Rope Climbing,0.8,0.07,0.0,0.0,0.07,0.0,0.0,0.07,michelle tuday,
+LS,1410,3,Top Rope Climbing,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,michelle tuday,
+LS,1560,12,Riflery,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1570,7,Shotgun Sports,0.7,0.2,0.0,0.1,0.0,0.0,0.0,0.0,john jeffrey price,
+LS,1570,10,Shotgun Sports,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,audrey carolin couch,
+LS,1580,1,Archery,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,
+LS,1580,2,Archery,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,herbert strickland,
+LS,1580,3,Archery,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1640,2,Whitewater Kayaking,0.82,0.0,0.0,0.0,0.09,0.0,0.0,0.09,robert taylor,
+LS,1750,1,Fly Fishing,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,james michae harvell,
+LS,1750,2,Fly Fishing,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,michael watts,
+LS,1850,2,Bowling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,
+LS,1850,3,Bowling,0.87,0.07,0.0,0.0,0.03,0.0,0.0,0.03,tyler bennett,
+LS,1850,4,Bowling,0.93,0.03,0.0,0.0,0.03,0.0,0.0,0.0,alexandra sandoval,
+LS,1850,8,Bowling,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,kimberly coury,
+LS,1940,3,Racquetball,0.71,0.07,0.0,0.0,0.07,0.0,0.0,0.14,charlie white,
+LS,1980,2,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,jason jordan,
+LS,2270,1,Intro to Swing Dance,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,
+LS,2320,1,Core Training,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,diane moreno,
+LS,2320,2,Core Training,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,
+LS,2320,3,Core Training,0.76,0.1,0.0,0.0,0.0,0.0,0.0,0.14,diane moreno,
+LS,2320,5,Core Training,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
+LS,2350,3,Basic Yoga,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,silica elizab larkin,
+LS,2350,5,Basic Yoga,0.73,0.18,0.0,0.0,0.05,0.0,0.0,0.05,renee warren gahan,
+LS,2360,2,Power/Ashtanga Yoga,0.78,0.0,0.0,0.0,0.0,0.0,0.0,0.22,silica elizab larkin,
+LS,2380,2,Vinyasa Flow Yoga,0.69,0.0,0.0,0.0,0.15,0.0,0.0,0.15,nicole eliz martinez,
+LS,2380,3,Vinyasa Flow Yoga,0.71,0.19,0.0,0.0,0.0,0.0,0.0,0.1,kayla lee wardlaw,
+LS,2380,4,Vinyasa Flow Yoga,0.75,0.1,0.0,0.0,0.0,0.0,0.0,0.15,kayla lee wardlaw,
+LS,2420,1,Meditation and Relax,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2420,2,Meditation and Relax,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2420,3,Meditation and Relax,0.64,0.09,0.18,0.05,0.0,0.0,0.0,0.05,renee warren gahan,
+LS,2420,4,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,5,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2450,2,Pilates,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,melanie ivey job,
+LS,2460,2,Intermediate Pilates,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,melanie ivey job,
+LS,2510,2,Running & Jogging,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,corey doug brookover,
+MATH,1010,1,Essen Math for Informed Soc,0.31,0.42,0.19,0.0,0.0,0.0,0.0,0.08,ebenezer eduafo,
+MATH,1010,2,Essen Math for Informed Soc,0.2,0.31,0.17,0.14,0.11,0.0,0.0,0.06,bryce pruitt,
+MATH,1010,3,Essen Math for Informed Soc,0.43,0.09,0.2,0.11,0.14,0.0,0.0,0.03,jun yuan,
+MATH,1010,4,Essen Math for Informed Soc,0.36,0.27,0.24,0.03,0.06,0.0,0.0,0.03,marilyn reba,
+MATH,1020,1,Business Calculus I,0.19,0.28,0.17,0.13,0.13,0.0,0.0,0.11,randy davidson,
+MATH,1020,2,Business Calculus I,0.21,0.22,0.27,0.12,0.13,0.0,0.0,0.05,randy davidson,
+MATH,1020,3,Business Calculus I,0.09,0.26,0.24,0.26,0.07,0.0,0.0,0.09,michael thomas cowen,
+MATH,1020,5,Business Calculus I,0.19,0.33,0.21,0.12,0.07,0.0,0.0,0.07,anna carol bachstein,
+MATH,1020,6,Business Calculus I,0.15,0.18,0.43,0.05,0.13,0.0,0.0,0.08,rachel bass lanning,
+MATH,1020,7,Business Calculus I,0.21,0.21,0.33,0.14,0.07,0.0,0.0,0.02,tony thanh nguyen,
+MATH,1020,9,Business Calculus I,0.19,0.17,0.3,0.11,0.19,0.0,0.0,0.03,randy davidson,
+MATH,1020,11,Business Calculus I,0.2,0.32,0.27,0.07,0.1,0.0,0.0,0.05,li he,
+MATH,1020,12,Business Calculus I,0.2,0.22,0.24,0.12,0.17,0.0,0.0,0.05,tony thanh nguyen,
+MATH,1020,13,Business Calculus I,0.26,0.32,0.22,0.1,0.09,0.0,0.0,0.01,marion hanna,
+MATH,1040,1,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.36,0.44,0.19,andrew walton green,
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.38,0.5,0.13,nicholas ahlstrom,
+MATH,1040,3,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.33,0.65,0.03,peter westerbaan,
+MATH,1050,401,Precalculus,0.0,0.0,0.0,0.0,0.0,0.55,0.41,0.03,tony thanh nguyen,
+MATH,1060,1,Calculus of One Variable I,0.1,0.13,0.18,0.09,0.33,0.0,0.0,0.17,judith el cottingham,
+MATH,1060,2,Calculus of One Variable I,0.06,0.14,0.34,0.0,0.37,0.0,0.0,0.09,kayla doris javier,
+MATH,1060,3,Calculus of One Variable I,0.05,0.05,0.27,0.15,0.34,0.0,0.0,0.15,xueheng shi,
+MATH,1060,4,Calculus of One Variable I,0.05,0.2,0.2,0.03,0.4,0.0,0.0,0.13,thanh thien to,
+MATH,1060,5,Calculus of One Variable I,0.0,0.06,0.25,0.09,0.5,0.0,0.0,0.09,michael gle eldredge,
+MATH,1060,500,Calculus of One Variable I,0.3,0.3,0.3,0.1,0.0,0.0,0.0,0.0,laura dostert,
+MATH,1070,1,Differen and Integral Calculus,0.13,0.46,0.33,0.04,0.0,0.0,0.0,0.04,donna simms,
+MATH,1070,2,Differen and Integral Calculus,0.28,0.22,0.25,0.13,0.03,0.0,0.0,0.09,donna simms,
+MATH,1070,3,Differen and Integral Calculus,0.11,0.45,0.27,0.11,0.02,0.0,0.0,0.02,stephen peele,
+MATH,1070,4,Differen and Integral Calculus,0.1,0.47,0.27,0.1,0.0,0.0,0.0,0.07,stephen peele,
+MATH,1070,5,Differen and Integral Calculus,0.24,0.3,0.27,0.15,0.03,0.0,0.0,0.0,xiaoyuan liu,
+MATH,1070,6,Differen and Integral Calculus,0.18,0.43,0.23,0.09,0.02,0.0,0.0,0.05,stephen peele,
+MATH,1080,1,Calculus of One Variable II,0.08,0.26,0.16,0.16,0.24,0.0,0.0,0.11,thowhida akther,
+MATH,1080,2,Calculus of One Variable II,0.09,0.17,0.17,0.11,0.29,0.0,0.0,0.17,rui gong,
+MATH,1080,3,Calculus of One Variable II,0.2,0.3,0.18,0.16,0.11,0.0,0.0,0.05,charles lanning,
+MATH,1080,4,Calculus of One Variable II,0.33,0.31,0.11,0.02,0.11,0.0,0.0,0.11,camille zerfas,
+MATH,1080,5,Calculus of One Variable II,0.24,0.3,0.14,0.08,0.16,0.0,0.0,0.08,fun choi john chan john,
+MATH,1080,6,Calculus of One Variable II,0.25,0.16,0.27,0.14,0.14,0.0,0.0,0.05,garrett mi dranichak,
+MATH,1080,7,Calculus of One Variable II,0.16,0.28,0.28,0.05,0.16,0.0,0.0,0.07,pye phyo aung,
+MATH,1080,8,Calculus of One Variable II,0.1,0.28,0.15,0.13,0.15,0.0,0.0,0.18,rebecca ramos,
+MATH,1080,9,Calculus of One Variable II,0.36,0.33,0.13,0.09,0.04,0.0,0.0,0.04,meredith nicole burr,
+MATH,1080,10,Calculus of One Variable II,0.38,0.31,0.18,0.09,0.04,0.0,0.0,0.0,meredith nicole burr,
+MATH,1080,11,Calculus of One Variable II,0.07,0.34,0.3,0.0,0.16,0.0,0.0,0.14,pye phyo aung,
+MATH,1080,100,Calc of One Variable II (HON),0.42,0.32,0.05,0.0,0.0,0.0,0.0,0.21,beth novick,True
+MATH,1080,201,Calculus of One Variable II,0.1,0.29,0.33,0.0,0.14,0.0,0.0,0.14,sanwar ahmad,
+MATH,1080,202,Calculus of One Variable II,0.28,0.33,0.25,0.08,0.03,0.0,0.0,0.05,sergey charnyi,
+MATH,1080,203,Calc of One Variable II,0.17,0.38,0.25,0.04,0.08,0.0,0.0,0.08,amy christine grady,
+MATH,1080,204,Calculus of One Variable II,0.21,0.36,0.21,0.08,0.13,0.0,0.0,0.03,beth novick,
+MATH,1080,205,Calc of One Variable II,0.28,0.35,0.18,0.18,0.0,0.0,0.0,0.03,huixi li,
+MATH,1080,206,Calc of One Variable II,0.21,0.36,0.23,0.15,0.04,0.0,0.0,0.0,kara aile stasikelis,
+MATH,1080,500,Calculus of One Variable II,0.33,0.33,0.11,0.22,0.0,0.0,0.0,0.0,laura dostert,
+MATH,1150,1,Contemp Math for Elem Teach I,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,carlos gomez,
+MATH,1160,1,Contemp Math for Elem Teach II,0.45,0.19,0.23,0.03,0.0,0.0,0.0,0.1,allison stoddard,
+MATH,1160,2,Contemp Math for Elem Teach II,0.58,0.3,0.1,0.0,0.03,0.0,0.0,0.0,allison stoddard,
+MATH,1990,400,Problem Solving in Mathematics,0.0,0.0,0.0,0.0,0.0,0.9,0.05,0.05,marion hanna,
+MATH,2060,1,Calculus of Several Variables,0.19,0.14,0.38,0.05,0.14,0.0,0.0,0.11,allen anderson guest,
+MATH,2060,2,Calculus of Several Variables,0.21,0.16,0.26,0.03,0.13,0.0,0.0,0.21,allen anderson guest,
+MATH,2060,3,Calculus of Several Variables,0.3,0.19,0.16,0.08,0.24,0.0,0.0,0.03,allen anderson guest,
+MATH,2060,4,Calculus of Several Variables,0.18,0.33,0.21,0.21,0.08,0.0,0.0,0.0,alistair bentley,
+MATH,2060,7,Calculus of Several Variables,0.15,0.33,0.26,0.13,0.03,0.0,0.0,0.1,sofya alekseeva,
+MATH,2060,8,Calculus of Several Variables,0.16,0.41,0.27,0.11,0.02,0.0,0.0,0.02,sofya alekseeva,
+MATH,2060,9,Calculus of Several Variables,0.12,0.37,0.27,0.15,0.05,0.0,0.0,0.05,sofya alekseeva,
+MATH,2060,10,Calculus of Several Variables,0.22,0.36,0.22,0.06,0.06,0.0,0.0,0.06,valdez hiram lopez,
+MATH,2070,1,Business Calculus II,0.38,0.28,0.26,0.08,0.0,0.0,0.0,0.0,jennifer marie hanna,
+MATH,2070,2,Business Calculus II,0.26,0.41,0.18,0.05,0.08,0.0,0.0,0.03,jennifer marie hanna,
+MATH,2070,3,Business Calculus II,0.54,0.26,0.15,0.03,0.0,0.0,0.0,0.03,jennifer marie hanna,
+MATH,2070,4,Business Calculus II,0.22,0.32,0.15,0.13,0.09,0.0,0.0,0.09,judith irene mcknew,
+MATH,2070,5,Business Calculus II,0.28,0.26,0.23,0.13,0.08,0.0,0.0,0.03,judith irene mcknew,
+MATH,2070,6,Business Calculus II,0.33,0.33,0.21,0.05,0.05,0.0,0.0,0.03,todd anthony morra,
+MATH,2070,8,Business Calculus II,0.1,0.31,0.26,0.15,0.1,0.0,0.0,0.08,scott scruggs,
+MATH,2070,9,Business Calculus II,0.41,0.33,0.15,0.05,0.03,0.0,0.0,0.03,emma cinatl,
+MATH,2070,10,Business Calculus II,0.44,0.41,0.08,0.08,0.0,0.0,0.0,0.0,jennifer ray newton,
+MATH,2070,11,Business Calculus II,0.38,0.41,0.18,0.03,0.0,0.0,0.0,0.0,jennifer ray newton,
+MATH,2070,12,Business Calculus II,0.48,0.2,0.15,0.08,0.03,0.0,0.0,0.08,jennifer ray newton,
+MATH,2070,13,Business Calculus II,0.54,0.18,0.1,0.13,0.03,0.0,0.0,0.03,jennifer ray newton,
+MATH,2070,14,Business Calculus II,0.56,0.11,0.22,0.08,0.0,0.0,0.0,0.03,dyken jennifer  van e,
+MATH,2070,15,Business Calculus II,0.29,0.37,0.26,0.03,0.0,0.0,0.0,0.05,madeleine stville,
+MATH,2070,16,Business Calculus II,0.39,0.31,0.06,0.06,0.11,0.0,0.0,0.08,allison stoddard,
+MATH,2080,1,Intro to Ordin Diff Equations,0.29,0.21,0.25,0.08,0.13,0.0,0.0,0.04,terri johnson,
+MATH,2080,2,Intro to Ordin Diff Equations,0.38,0.2,0.27,0.07,0.07,0.0,0.0,0.02,irina viktorova,
+MATH,2080,3,Intro to Ordin Diff Equations,0.41,0.48,0.07,0.0,0.0,0.0,0.0,0.05,oleg yordanov,
+MATH,2080,4,Intro to Ordin Diff Equations,0.15,0.39,0.24,0.06,0.06,0.0,0.0,0.09,timothy fran parrott,
+MATH,2080,6,Intro to Ordin Diff Equations,0.4,0.38,0.13,0.07,0.02,0.0,0.0,0.0,timothy cha teitloff,
+MATH,2080,7,Intro to Ordin Diff Equations,0.32,0.35,0.22,0.03,0.08,0.0,0.0,0.0,oleg yordanov,
+MATH,2080,8,Intro to Ordin Diff Equations,0.51,0.16,0.3,0.0,0.0,0.0,0.0,0.03,timothy fran parrott,
+MATH,2080,9,Intro to Ordin Diff Equations,0.26,0.17,0.21,0.07,0.14,0.0,0.0,0.14,terri johnson,
+MATH,2080,10,Intro to Ordin Diff Equations,0.42,0.38,0.16,0.04,0.0,0.0,0.0,0.0,timothy cha teitloff,
+MATH,2080,11,Intro to Ordin Diff Equations,0.21,0.25,0.25,0.11,0.14,0.0,0.0,0.04,julie lassiter,
+MATH,2080,12,Intro to Ordin Diff Equations,0.48,0.46,0.04,0.0,0.0,0.0,0.0,0.02,irina viktorova,
+MATH,2080,13,Intro to Ordin Diff Equations,0.23,0.29,0.14,0.09,0.09,0.0,0.0,0.17,terri johnson,
+MATH,2080,14,Intro to Ordin Diff Equations,0.16,0.22,0.28,0.13,0.09,0.0,0.0,0.13,julie lassiter,
+MATH,2080,15,Intro to Ordin Diff Equations,0.36,0.26,0.14,0.12,0.05,0.0,0.0,0.07,timothy fran parrott,
+MATH,2080,16,Intro to Ordin Diff Equations,0.41,0.25,0.18,0.09,0.0,0.0,0.0,0.07,timothy cha teitloff,
+MATH,2080,17,Intro to Ordin Diff Equations,0.18,0.36,0.32,0.06,0.03,0.0,0.0,0.05,sean sather-wagstaff,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.35,0.43,0.17,0.0,0.0,0.0,0.0,0.04,michael adam burr,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,eliza darg gallagher,
+MATH,3020,1,Stat for Science & Engineering,0.56,0.33,0.03,0.03,0.03,0.0,0.0,0.03,ellen hepfer breazel,
+MATH,3020,2,Stat for Science & Engineering,0.23,0.45,0.28,0.0,0.05,0.0,0.0,0.0,gamage prabh withana,
+MATH,3020,3,Stat for Science & Engineering,0.38,0.46,0.13,0.03,0.0,0.0,0.0,0.0,xiyan tan,
+MATH,3020,4,Stat for Science & Engineering,0.82,0.11,0.05,0.03,0.0,0.0,0.0,0.0,haotian feng,
+MATH,3020,5,Stat for Science & Engineering,0.29,0.26,0.16,0.0,0.13,0.0,0.0,0.16,paul james cubre,
+MATH,3020,6,Stat for Science & Engineering,0.43,0.3,0.26,0.0,0.0,0.0,0.0,0.0,yinggu bao,
+MATH,3020,8,Stat for Science & Engineering,0.25,0.25,0.3,0.05,0.1,0.0,0.0,0.05,patrick gerard,
+MATH,3020,9,Stat for Science & Engineering,0.36,0.36,0.13,0.05,0.1,0.0,0.0,0.0,ellen hepfer breazel,
+MATH,3080,1,College Geometry,0.82,0.06,0.0,0.0,0.12,0.0,0.0,0.0,nicole alain sinwell,
+MATH,3110,1,Linear Algebra,0.27,0.27,0.16,0.07,0.11,0.0,0.0,0.11,svetlana poznanovikj,
+MATH,3110,2,Linear Algebra,0.21,0.51,0.16,0.02,0.0,0.0,0.0,0.09,neil calkin,
+MATH,3110,3,Linear Algebra,0.16,0.32,0.32,0.07,0.07,0.0,0.0,0.07,xuhong gao,
+MATH,3110,4,Linear Algebra,0.29,0.15,0.22,0.1,0.1,0.0,0.0,0.15,xuhong gao,
+MATH,3110,5,Linear Algebra,0.12,0.3,0.19,0.21,0.14,0.0,0.0,0.05,hui xue,
+MATH,3110,6,Linear Algebra,0.17,0.27,0.25,0.21,0.08,0.0,0.0,0.02,hui xue,
+MATH,3110,7,Linear Algebra,0.33,0.24,0.15,0.15,0.07,0.0,0.0,0.07,elena stan dimitrova,
+MATH,3110,200,Linear Algebra,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,kevin james,
+MATH,3190,1,Introduction to Proof,0.31,0.19,0.31,0.04,0.08,0.0,0.0,0.08,james bar coykendall,
+MATH,3190,2,Introduction to Proof,0.58,0.27,0.08,0.0,0.04,0.0,0.0,0.04,malcolm edwar rupert,
+MATH,3600,1,Intermediate Math Computing,0.76,0.12,0.04,0.04,0.0,0.0,0.0,0.04,mark cawood,
+MATH,3600,2,Intermediate Math Computing,0.45,0.18,0.14,0.0,0.05,0.0,0.0,0.18,mark cawood,
+MATH,3650,1,Numerical Mthds for Engineers,0.36,0.27,0.15,0.0,0.15,0.0,0.0,0.06,mengying xiao,
+MATH,3650,2,Numerical Mthds for Engineers,0.41,0.3,0.14,0.03,0.05,0.0,0.0,0.08,christopher cox,
+MATH,3650,3,Numerical Mthds for Engineers,0.26,0.39,0.16,0.06,0.06,0.0,0.0,0.06,vincent ervin,
+MATH,3650,4,Numerical Mthds for Engineers,0.19,0.24,0.27,0.14,0.08,0.0,0.0,0.08,vincent ervin,
+MATH,4000,1,Theory of Probability,0.32,0.48,0.12,0.0,0.0,0.0,0.0,0.08,xiaoqian sun,
+MATH,4000,2,Theory of Probability,0.5,0.21,0.21,0.0,0.07,0.0,0.0,0.0,peter kiessler,
+MATH,4030,1,Intro to Statistical Theory,0.31,0.31,0.31,0.0,0.08,0.0,0.0,0.0,xiaoqian sun,
+MATH,4070,1,Regress & Time-Series Analysis,0.67,0.08,0.08,0.08,0.08,0.0,0.0,0.0,christopher mcmahan,
+MATH,4110,1,Introduction to Combinatorics,0.46,0.31,0.08,0.0,0.0,0.0,0.0,0.15,beth novick,
+MATH,4120,1,Algebra I,0.19,0.52,0.15,0.0,0.11,0.0,0.0,0.04,james bar coykendall,
+MATH,4190,1,Discrete Math Structures I,0.28,0.59,0.1,0.03,0.0,0.0,0.0,0.0,wayne goddard,
+MATH,4190,2,Discrete Math Structures I,0.19,0.34,0.25,0.0,0.16,0.0,0.0,0.06,sean sather-wagstaff,
+MATH,4310,1,Theory of Interest,0.21,0.43,0.29,0.0,0.0,0.0,0.0,0.07, erwin walker,
+MATH,4340,1,Adv Engineering Mathematics,0.25,0.15,0.3,0.15,0.05,0.0,0.0,0.1,hyesuk lee,
+MATH,4340,2,Adv Engineering Mathematics,0.28,0.22,0.25,0.06,0.0,0.0,0.0,0.19,qingshan chen,
+MATH,4400,1,Linear Programming,0.5,0.27,0.04,0.08,0.08,0.0,0.0,0.04,margaret mari wiecek,
+MATH,4530,1,Advanced Calculus I,0.41,0.28,0.17,0.07,0.07,0.0,0.0,0.0,james peterson,
+MATH,4540,1,Advanced Calculus II,0.21,0.38,0.29,0.08,0.04,0.0,0.0,0.0,james peterson,
+MATH,4600,1,Intro to Numerical Analysis I,0.44,0.25,0.13,0.0,0.06,0.0,0.0,0.13,leo rebholz,
+MATH,6000,1,Theory of Probability,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14,xiaoqian sun,
+MATH,6340,1,Adv Engineering Mathematics,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
+MATH,6410,1,Intro to Stochastic Models,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
+MATH,8030,1,Stochastic Processes,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,peter kiessler,
+MATH,8040,1,Statistical Inference,0.5,0.19,0.19,0.0,0.06,0.0,0.0,0.06,christopher mcmahan,
+MATH,8050,1,Data Analysis,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ling ma,
+MATH,8090,1,Time Series Analysis,0.44,0.31,0.0,0.0,0.0,0.0,0.0,0.25,colin gallagher,
+MATH,8100,1,Mathematical Programming,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,akshay sunil gupte,
+MATH,8120,1,Discrete Optimization,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,herve louis kerivin,
+MATH,8130,1,Advanced Linear Programming,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
+MATH,8210,1,Linear Analysis,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,benjamin jaye,
+MATH,8220,1,Measure and Integration,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,martin johan schmoll,
+MATH,8530,1,Matrix Analysis,0.6,0.1,0.2,0.0,0.1,0.0,0.0,0.0,elena stan dimitrova,
+MATH,8540,1,Theory of Graphs,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,beth novick,
+MATH,8560,1,Ther of Error-Correcting Codes,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,felice manganiello,
+MATH,8600,1,Intro to Scientific Computing,0.35,0.35,0.12,0.0,0.12,0.0,0.0,0.06,eleanor jenkins,
+MATH,8610,1,Advanced Numerical Analysis I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,fei xue,
+MATH,9830,1,Sel Top in Computational Math,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,timo johanne heister,
+MBA,8030,1,Stat Analy of Bus Op,0.19,0.35,0.27,0.0,0.05,0.0,0.0,0.14,magda gabriela sava,
+MBA,8060,1,Operations Mgt,0.28,0.58,0.14,0.0,0.0,0.0,0.0,0.0,janis miller,
+MBA,8060,20,Operations Mgt,0.42,0.42,0.12,0.0,0.0,0.0,0.0,0.04, sridharan,
+MBA,8070,1,Financial Management,0.56,0.28,0.16,0.0,0.0,0.0,0.0,0.0,melvin stith,
+MBA,8070,2,Financial Management,0.68,0.15,0.13,0.0,0.0,0.0,0.0,0.05,melvin stith,
+MBA,8090,1,Org Beh & Hum Res Mg,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,
+MBA,8090,2,Org Beh & Hum Res Mg,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,
+MBA,8090,3,Org Beh & Hum Res Mg,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,thomas jos zagenczyk,
+MBA,8170,21,Bus Forecasting,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,sukran nilv atadeniz,
+MBA,8190,1,Intro to Acc and Fin,0.63,0.29,0.09,0.0,0.0,0.0,0.0,0.0,melvin stith,
+MBA,8190,2,Intro to Acc and Fin,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,melvin stith,
+MBA,8290,1,Marketing Foundation,0.6,0.36,0.0,0.0,0.0,0.0,0.0,0.04,gary hunter,
+MBA,8330,1,Real Estate Investmt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,franklin bogu wallin,
+MBA,8370,1,Legal Environ of Bus,0.2,0.77,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
+MBA,8430,10,Entrepreneurial Accounting,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,james milt kohlmeyer,
+MBA,8440,10,Entrepreneurial Law,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,scott hile,
+MBA,8450,1,Technology & Innovation Mgt,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8470,1,New Venture Creation,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth eri powell,
+MBA,8510,10,Bus Operations & Logistics,0.69,0.19,0.04,0.0,0.04,0.0,0.0,0.04,george kennet morgan,
+MBA,8540,1,Managerial Accounting,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
+MBA,8540,2,Managerial Accounting,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
+MBA,8540,3,Managerial Accounting,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
+MBA,8590,1,Mgr Decision Model,0.42,0.33,0.08,0.0,0.06,0.0,0.0,0.11,magda gabriela sava,
+MBA,8590,2,Mgr Decision Model,0.54,0.23,0.15,0.0,0.08,0.0,0.0,0.0,sara elizabeth yoder,
+MBA,8600,1,Advanced Marketing Strategy,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MBA,8610,1,Information Systems,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,russell purvis,
+MBA,8620,1,Managerial Economics,0.52,0.43,0.04,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,
+MBA,8620,2,Managerial Economics,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,
+MBA,8700,1,Strategic Management,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,matthew charle klein,
+MBA,8720,1,Entrepr Finance,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,matthew charle klein,
+MBA,8750,1,Enterprise Develpmnt,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8990,1,Advanced Leadership,0.89,0.06,0.02,0.0,0.0,0.0,0.0,0.02,gail depriest,
+MBA,8990,3,Service Innovation,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
+MBA,8990,4,Bus. Sport. Enter.,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
+MBA,8990,7,Business Analytics Models,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,jennie lynn farmer,
+MBA,8990,20,Analytics & Application,0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,heshan sun,
+MBA,8990,22,Marketing Analytics,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,bruce snyder,
+ME,2000,1,Sophomore Seminar,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.02,donald beasley,
+ME,2010,1,Statics & Dynamics,0.06,0.25,0.27,0.16,0.12,0.0,0.0,0.14,marisa kikendall orr,
+ME,2010,2,Statics & Dynamics,0.05,0.25,0.28,0.13,0.2,0.0,0.0,0.1,paul joseph,
+ME,2030,1,Founda Th/Fl Syst,0.24,0.58,0.14,0.01,0.01,0.0,0.0,0.02,yiqiang han,
+ME,2030,2,Founda Th/Fl Syst,0.28,0.28,0.23,0.09,0.08,0.0,0.0,0.05,xiangchun xuan,
+ME,2040,1,Mechanics of Materials,0.31,0.47,0.17,0.04,0.01,0.0,0.0,0.0,gang li,
+ME,2040,2,Mechanics of Materials,0.16,0.52,0.18,0.05,0.05,0.0,0.0,0.05,jorge ivan rodriguez,
+ME,2040,3,Mechanics of Materials,0.28,0.5,0.19,0.03,0.0,0.0,0.0,0.0,garrett pataky,
+ME,2040,303,Mechanics of Materials (HON),0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,garrett pataky,True
+ME,2220,2,Mechanical Engineering Lab I,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,3,Mechanical Engineering Lab I,0.21,0.64,0.14,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,5,Mechanical Engineering Lab I,0.27,0.67,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,6,Mechanical Engineering Lab I,0.19,0.5,0.25,0.0,0.0,0.0,0.0,0.06,todd al schweisinger,
+ME,2220,7,Mechanical Engineering Lab I,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,10,Mechanical Engineering Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,todd al schweisinger,
+ME,2220,11,Mechanical Engineering Lab I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,13,Mechanical Engineering Lab I,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,14,Mechanical Engineering Lab I,0.29,0.43,0.21,0.07,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,15,Mechanical Engineering Lab I,0.38,0.44,0.19,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,17,Mechanical Engineering Lab I,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2220,18,Mechanical Engineering Lab I,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,2900,619,CI ME - Savonius Wind Turbine,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,3030,1,Thermodynamics,0.11,0.2,0.53,0.02,0.09,0.0,0.0,0.04,john saylor,
+ME,3030,2,Thermodynamics,0.13,0.32,0.45,0.06,0.0,0.0,0.0,0.04,richard miller,
+ME,3040,1,Heat Transfer,0.03,0.32,0.5,0.11,0.03,0.0,0.0,0.03,jean-marc ge delhaye,
+ME,3040,2,Heat Transfer,0.21,0.36,0.28,0.0,0.11,0.0,0.0,0.04,jean-marc ge delhaye,
+ME,3040,3,Heat Transfer,0.21,0.38,0.21,0.15,0.0,0.0,0.0,0.04,xin zhao,
+ME,3050,1,Model/an Dy Syst,0.21,0.39,0.36,0.01,0.03,0.0,0.0,0.0,phanind tallapragada,
+ME,3050,2,Model/an Dy Syst,0.2,0.37,0.31,0.06,0.05,0.0,0.0,0.02,joshua bostwick,
+ME,3060,1,Fund Machine Design,0.11,0.61,0.23,0.0,0.02,0.0,0.0,0.03,oliver myers,
+ME,3060,2,Fund Machine Design,0.2,0.63,0.12,0.03,0.01,0.0,0.0,0.01,joshua summers,
+ME,3070,1,Found of Mechanical Systems,0.46,0.34,0.11,0.01,0.06,0.0,0.0,0.01,jorge ivan rodriguez,
+ME,3070,2,Found of Mechanical Systems,0.36,0.46,0.16,0.01,0.0,0.0,0.0,0.01,gregory mocko,
+ME,3080,1,Fluid Mechanics,0.21,0.45,0.31,0.03,0.0,0.0,0.0,0.0,chenning tong,
+ME,3080,2,Fluid Mechanics,0.16,0.42,0.39,0.03,0.0,0.0,0.0,0.0,ethan kung,
+ME,3080,3,Fluid Mechanics,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,3100,1,Thermo/Heat Transfer,0.25,0.5,0.17,0.0,0.03,0.0,0.0,0.06,yiqiang han,
+ME,3120,1,Manuf Processes,0.31,0.66,0.03,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+ME,3330,1,Mechanical Engineering Lab II,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,3330,2,Mechanical Engineering Lab II,0.27,0.53,0.13,0.0,0.0,0.0,0.0,0.07,todd al schweisinger,
+ME,3330,3,Mechanical Engineering Lab II,0.43,0.5,0.07,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,3330,5,Mechanical Engineering Lab II,0.1,0.8,0.1,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,3330,6,Mechanical Engineering Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,3330,7,Mechanical Engineering Lab II,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,3330,9,Mechanical Engineering Lab II,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,3330,11,Mechanical Engineering Lab II,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,3330,17,Mechanical Engineering Lab II,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,4010,1,Mech Engr Design,0.85,0.1,0.01,0.01,0.01,0.0,0.0,0.0,cameron turner,
+ME,4020,1,Intern in Engr Des,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,4020,4,Intern in Engr Des,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,5,Intern in Engr Des,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,
+ME,4020,6,Intern in Engr Des,0.3,0.35,0.05,0.3,0.0,0.0,0.0,0.0,nicole gisel coutris,
+ME,4020,7,Intern in Engr Des,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,8,Intern in Engr Des,0.25,0.6,0.15,0.0,0.0,0.0,0.0,0.0,yue wang,
+ME,4020,9,Intern in Engr Des,0.25,0.45,0.25,0.05,0.0,0.0,0.0,0.0,georges fadel,
+ME,4030,1,Control Dynamic Systems,0.23,0.33,0.4,0.05,0.0,0.0,0.0,0.0,suyi li,
+ME,4030,2,Control Dynamic Systems,0.24,0.4,0.2,0.13,0.02,0.0,0.0,0.0,yue wang,
+ME,4180,1,F E A in M E Design,0.72,0.26,0.03,0.0,0.0,0.0,0.0,0.0,oliver myers,
+ME,4220,1,Design Gas Turbines,0.56,0.27,0.15,0.02,0.0,0.0,0.0,0.0,abhijit som,
+ME,4260,1,Nuclear Energy,0.38,0.32,0.24,0.06,0.0,0.0,0.0,0.0,richard watkins,
+ME,4300,1,Mech Comp Materials,0.19,0.29,0.33,0.14,0.0,0.0,0.0,0.05,huijuan zhao,
+ME,4400,1,Matls for Aggr Envir,0.44,0.31,0.22,0.0,0.03,0.0,0.0,0.0,garrett pataky,
+ME,4440,1,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,4440,2,Mechanical Engineering Lab III,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,4440,5,Mechanical Engineering Lab III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,4440,13,Mechanical Engineering Lab III,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,todd al schweisinger,
+ME,4930,11,Selected Topics ME (MicroFab),0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,
+ME,4930,24,Sel. Topics ME (Mechatronics),0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4930,34,Sel. Topics in ME (Cardio),0.07,0.79,0.14,0.0,0.0,0.0,0.0,0.0,ethan kung,
+ME,4930,39,Sel Topics ME (Solar Energy),0.35,0.48,0.15,0.02,0.0,0.0,0.0,0.0,daniel fant,
+ME,6300,1,Mech Comp Materials,0.37,0.63,0.0,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,6930,11,Selected Topics ME (MicroFab),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,rodr martinez-duarte,
+ME,6930,34,Selected Topics in ME (Cardio),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,
+ME,8200,1,Mod Cont Engr,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
+ME,8310,1,Convective Ht Trans,0.45,0.18,0.18,0.0,0.0,0.0,0.0,0.18,xin zhao,
+ME,8370,1,Theory of Elast I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,nicole gisel coutris,
+ME,8450,1,Structural Vibration,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,suyi li,
+ME,8720,1,Design Automatn for Mech Engrs,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,cameron turner,
+ME,8730,1,Res Mthds Coll Desgn,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,joshua summers,
+ME,8930,24,Sel. Topics ME (Mechatronics),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,8930,424,Sel. Topics ME (Mechatronics),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+MGT,2010,1,Principles of Management,0.4,0.4,0.14,0.03,0.01,0.0,0.0,0.01,katherine clark,
+MGT,2010,2,Principles of Management,0.47,0.38,0.1,0.03,0.0,0.0,0.0,0.01,tina robbins,
+MGT,2010,7,Principles of Management,0.23,0.36,0.38,0.03,0.0,0.0,0.0,0.0,christopher mann,
+MGT,2010,8,Principles of Management,0.28,0.4,0.2,0.08,0.0,0.0,0.0,0.05,christopher mann,
+MGT,2010,10,Principles of Management,0.26,0.46,0.2,0.04,0.02,0.0,0.0,0.02,ashley willi parnell,
+MGT,2010,11,Principles of Management,0.3,0.3,0.33,0.0,0.05,0.0,0.0,0.03,ashley willi parnell,
+MGT,2180,1,Management PC Applications,0.52,0.32,0.09,0.03,0.02,0.0,0.0,0.02,ryan toole,
+MGT,2180,2,Management PC Applications,0.33,0.3,0.07,0.04,0.22,0.0,0.0,0.04,ryan toole,
+MGT,3070,1,Human Resource Management,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
+MGT,3070,2,Human Resource Management,0.88,0.08,0.03,0.03,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,3,Human Resource Management,0.3,0.63,0.08,0.0,0.0,0.0,0.0,0.0,priscilla harrison,
+MGT,3070,4,Human Resource Management,0.4,0.53,0.05,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,
+MGT,3070,5,Human Resource Management,0.7,0.28,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,6,Human Resource Management,0.45,0.48,0.05,0.0,0.0,0.0,0.0,0.03,leonard jose spooner,
+MGT,3100,1,Intermed Business Statistics,0.55,0.18,0.25,0.03,0.0,0.0,0.0,0.0,yunsik choi,
+MGT,3100,2,Intermed Business Statistics,0.33,0.33,0.23,0.05,0.03,0.0,0.0,0.05,mustafa serka akturk,
+MGT,3100,3,Intermed Business Statistics,0.23,0.31,0.21,0.08,0.1,0.0,0.0,0.08,yunsik choi,
+MGT,3100,4,Intermed Business Statistics,0.5,0.24,0.07,0.0,0.12,0.0,0.0,0.07,remi charpin,
+MGT,3100,5,Intermed Business Statistics,0.58,0.27,0.13,0.0,0.0,0.0,0.0,0.02,wenxi pu,
+MGT,3100,6,Intermed Business Statistics,0.45,0.32,0.13,0.0,0.05,0.0,0.0,0.05,sukran nilv atadeniz,
+MGT,3100,7,Intermed Business Statistics,0.24,0.44,0.22,0.0,0.02,0.0,0.0,0.07,magda gabriela sava,
+MGT,3100,8,Intermed Business Statistics,0.42,0.26,0.24,0.03,0.03,0.0,0.0,0.03,mustafa serka akturk,
+MGT,3100,10,Intermed Business Statistics,0.49,0.44,0.03,0.05,0.0,0.0,0.0,0.0,sukran nilv atadeniz,
+MGT,3100,11,Intermed Business Statistics,0.64,0.26,0.08,0.0,0.0,0.0,0.0,0.03,thomas simpson,
+MGT,3120,1,Decision Models for Management,0.08,0.26,0.45,0.08,0.09,0.0,0.0,0.05,sara elizabeth yoder,
+MGT,3120,2,Decision Models for Management,0.12,0.27,0.39,0.1,0.07,0.0,0.0,0.04,sara elizabeth yoder,
+MGT,3120,5,Decision Models for Management,0.31,0.39,0.31,0.0,0.0,0.0,0.0,0.0,james turner,
+MGT,3170,1,Logistics Mgmt,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,ahmet colak,
+MGT,3180,1,Mgt of Info Systems,0.15,0.6,0.2,0.0,0.0,0.0,0.0,0.05,russell purvis,
+MGT,3180,2,Mgt of Info Systems,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,marten risius,
+MGT,3180,3,Mgt of Info Systems,0.56,0.36,0.05,0.0,0.03,0.0,0.0,0.0,tina marie esposito,
+MGT,3180,4,Mgt of Info Systems,0.41,0.44,0.1,0.03,0.0,0.0,0.0,0.03,tina marie esposito,
+MGT,3500,1,Intro to Business Analytics,0.29,0.68,0.03,0.0,0.0,0.0,0.0,0.0,siyuan li,
+MGT,3510,1,Business Analytics & Problems,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,sukran nilv atadeniz,
+MGT,3900,1,Ops Mgt,0.43,0.48,0.05,0.0,0.05,0.0,0.0,0.0,maneeshred ajjuguttu,
+MGT,3900,2,Ops Mgt,0.09,0.45,0.3,0.09,0.02,0.0,0.0,0.05,min kyung lee,
+MGT,3900,3,Ops Mgt,0.18,0.2,0.4,0.08,0.0,0.0,0.0,0.15,min kyung lee,
+MGT,3900,4,Ops Mgt,0.11,0.3,0.49,0.11,0.0,0.0,0.0,0.0,zachary mor leffakis,
+MGT,3900,5,Ops Mgt,0.35,0.3,0.3,0.03,0.03,0.0,0.0,0.0,daniel nielubowicz,
+MGT,4000,2,Mgt of Organizational Behavior,0.25,0.43,0.27,0.02,0.02,0.0,0.0,0.0,thomas jos zagenczyk,
+MGT,4000,3,Mgt of Organizational Behavior,0.38,0.33,0.26,0.0,0.03,0.0,0.0,0.0,philip roth,
+MGT,4000,4,Mgt of Organizational Behavior,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4020,1,Ops Pln and Ctl,0.07,0.57,0.21,0.14,0.0,0.0,0.0,0.0,zachary mor leffakis,
+MGT,4080,1,Lean Operations,0.23,0.32,0.36,0.0,0.09,0.0,0.0,0.0,zachary mor leffakis,
+MGT,4110,1,Project Management,0.38,0.43,0.15,0.03,0.0,0.0,0.0,0.03,russell purvis,
+MGT,4120,1,Supplier Management,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,ahmet colak,
+MGT,4150,1,Business Strategy,0.24,0.52,0.21,0.02,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,2,Business Strategy,0.24,0.63,0.11,0.0,0.0,0.0,0.0,0.02,james liddle,
+MGT,4150,3,Business Strategy,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,dennis lee lester,
+MGT,4150,4,Business Strategy,0.43,0.35,0.2,0.02,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,5,Business Strategy,0.4,0.51,0.09,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
+MGT,4150,6,Business Strategy,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
+MGT,4150,7,Business Strategy,0.23,0.6,0.16,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,8,Business Strategy,0.15,0.61,0.24,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,10,Business Strategy,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,dennis lee lester,
+MGT,4160,1,Special Topics Hr,0.62,0.24,0.08,0.0,0.0,0.0,0.0,0.05,alejandra sa kennedy,
+MGT,4230,1,Intern Bus Mgt,0.04,0.59,0.28,0.02,0.02,0.0,0.0,0.04,janis miller,
+MGT,4230,2,Intern Bus Mgt,0.16,0.44,0.27,0.11,0.02,0.0,0.0,0.0,janis miller,
+MGT,4230,3,Intern Bus Mgt,0.09,0.26,0.5,0.09,0.02,0.0,0.0,0.04,wayne stewart,
+MGT,4230,4,Intern Bus Mgt,0.13,0.13,0.56,0.11,0.04,0.0,0.0,0.02,wayne stewart,
+MGT,4240,1,Global Supply Chain,0.26,0.55,0.16,0.03,0.0,0.0,0.0,0.0,yann ferrand,
+MGT,4270,1,Managing Improvement,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,samer ess abdlrahman,
+MGT,4310,1,Emp Rights & Resp,0.24,0.55,0.21,0.0,0.0,0.0,0.0,0.0,leonard jose spooner,
+MGT,4350,1,Pers Interviewing,0.33,0.28,0.33,0.0,0.05,0.0,0.0,0.03,philip roth,
+MGT,4520,1,Business Analysis,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,marten risius,
+MGT,4540,1,Systems Implement,0.18,0.47,0.24,0.0,0.06,0.0,0.0,0.06,heshan sun,
+MGT,4550,1,Emerging I T Trends,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,jason thatcher,
+MGT,4560,1,Business Info Mgt,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,siyuan li,
+MGT,4900,1,Being A Leader,0.7,0.16,0.11,0.0,0.0,0.0,0.0,0.03,christopher mann,
+MGT,4900,2,Being A Leader,0.67,0.19,0.1,0.0,0.0,0.0,0.0,0.05,christopher mann,
+MGT,8120,1,Supply Chain Mgt,0.57,0.39,0.04,0.0,0.0,0.0,0.0,0.0,yann ferrand,
+MICR,3050,1,General Microbiology,0.46,0.36,0.14,0.03,0.01,0.0,0.0,0.0,kristi jam whitehead,
+MICR,3050,2,General Microbiology,0.5,0.25,0.15,0.06,0.01,0.0,0.0,0.02,krista barri rudolph,
+MICR,3050,3,General Microbiology,0.62,0.3,0.03,0.05,0.0,0.0,0.0,0.0,krista barri rudolph,
+MICR,4000,1,Public Health Micro,0.57,0.26,0.09,0.06,0.0,0.0,0.0,0.02,kristi jam whitehead,
+MICR,4020,1,Environmental Micro,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,john michael henson,
+MICR,4070,1,Food and Dairy Micro,0.25,0.46,0.22,0.06,0.0,0.0,0.0,0.0,xiuping jiang,
+MICR,4110,1,Pathogenic Bact,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kears milhous,
+MICR,4120,1,Bacterial Physiology,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.02,wilbur kears milhous,
+MICR,4130,1,Industrial Micro,0.31,0.54,0.11,0.02,0.0,0.0,0.0,0.03,tzuen-rong jer tzeng,
+MICR,4140,1,Basic Immunology,0.69,0.29,0.0,0.0,0.0,0.0,0.0,0.02,charles rice,
+MICR,4170,1,Cancer and Aging,0.64,0.29,0.04,0.01,0.0,0.0,0.0,0.01,yuqing dong,
+MICR,4500,1,Advanced Microbiology I,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4500,2,Advanced Microbiology I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4500,3,Advanced Microbiology I,0.31,0.38,0.23,0.0,0.0,0.0,0.0,0.08,harry kurtz,
+MICR,4520,1,Advanced Microbiology III,0.38,0.5,0.08,0.04,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4520,2,Advanced Microbiology III,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4520,3,Advanced Microbiology III,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,harry kurtz,
+MKT,3010,1,Principles of Marketing,0.26,0.37,0.26,0.07,0.03,0.0,0.0,0.01,carter will mcelveen,
+MKT,3010,2,Principles of Marketing,0.29,0.35,0.29,0.06,0.01,0.0,0.0,0.01,carter will mcelveen,
+MKT,3010,3,Principles of Marketing,0.31,0.4,0.21,0.05,0.01,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,4,Principles of Marketing,0.27,0.4,0.24,0.05,0.03,0.0,0.0,0.01,amanda cooper fine,
+MKT,3010,5,Principles of Marketing,0.15,0.35,0.36,0.07,0.03,0.0,0.0,0.04,james gaubert,
+MKT,3020,1,Consumer Behavior,0.5,0.33,0.15,0.02,0.0,0.0,0.0,0.0,jennifer dia siemens,
+MKT,3020,2,Consumer Behavior,0.41,0.37,0.16,0.04,0.0,0.0,0.0,0.02,jennifer dia siemens,
+MKT,3020,3,Consumer Behavior,0.37,0.4,0.1,0.08,0.04,0.0,0.0,0.02,fitzwater an thyroff,
+MKT,3020,4,Consumer Behavior,0.31,0.48,0.15,0.0,0.02,0.0,0.0,0.04,fitzwater an thyroff,
+MKT,3020,5,Consumer Behavior,0.52,0.41,0.06,0.01,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,3220,1,Social Media Marketing,0.85,0.13,0.0,0.03,0.0,0.0,0.0,0.0,lura forcum,
+MKT,3220,2,Social Media Marketing,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,3310,1,Marketing Metrics & Analytics,0.53,0.35,0.08,0.02,0.0,0.0,0.0,0.02,oriana rachel aragon,
+MKT,3310,2,Marketing Metrics & Analytics,0.31,0.47,0.18,0.04,0.0,0.0,0.0,0.0,oriana rachel aragon,
+MKT,3310,3,Marketing Metrics & Analytics,0.23,0.48,0.2,0.05,0.03,0.0,0.0,0.03,peter weathers,
+MKT,3980,1,CI: Sales Experiential,0.81,0.11,0.0,0.02,0.0,0.0,0.0,0.06,carter will mcelveen,
+MKT,4200,1,Professional Selling,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,2,Professional Selling,0.85,0.1,0.0,0.0,0.05,0.0,0.0,0.0,jesse moore,
+MKT,4200,3,Professional Selling,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,carter will mcelveen,
+MKT,4200,4,Professional Selling,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4200,5,Professional Selling,0.66,0.31,0.03,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4230,1,Promotional Strategy,0.6,0.3,0.09,0.01,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,4240,1,Sales Management,0.3,0.55,0.15,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4250,1,Retail Management,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4250,2,Retail Management,0.63,0.19,0.19,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4260,1,Business-to-Business,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4260,2,Business-to-Business,0.76,0.08,0.12,0.0,0.04,0.0,0.0,0.0,xianyong wang,
+MKT,4270,1,International Marketing,0.29,0.57,0.12,0.02,0.0,0.0,0.0,0.0,thomas poehlman,
+MKT,4270,2,International Marketing,0.13,0.74,0.08,0.0,0.0,0.0,0.0,0.05,thomas poehlman,
+MKT,4270,3,International Marketing,0.64,0.25,0.1,0.01,0.0,0.0,0.0,0.0,roger gomes,
+MKT,4280,1,Services Marketing,0.58,0.33,0.07,0.0,0.02,0.0,0.0,0.0,james gaubert,
+MKT,4280,2,Services Marketing,0.49,0.37,0.12,0.0,0.0,0.0,0.0,0.02,james gaubert,
+MKT,4310,1,Marketing Research,0.17,0.43,0.33,0.07,0.0,0.0,0.0,0.0,peter weathers,
+MKT,4310,2,Marketing Research,0.3,0.43,0.17,0.0,0.0,0.0,0.0,0.1,william ed kilbourne,
+MKT,4310,3,Marketing Research,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,4,Marketing Research,0.37,0.6,0.03,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4330,1,Sport Mkt Strategy,0.66,0.22,0.13,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,
+MKT,4450,1,Macromarketing,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,william ed kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.08,0.41,0.51,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,2,Strategic Mktg Mgt,0.16,0.42,0.39,0.03,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,3,Strategic Mktg Mgt,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,
+MKT,4500,4,Strategic Mktg Mgt,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett s,
+MKT,8620,1,Quant Methods in Mkt,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
+MKT,8650,1,Seminar in Mkt Mgmt,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MKT,8660,1,International Marketing,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
+ML,1020,1,Leadership Fund II,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,clay wilson etterle,
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,clay wilson etterle,
+ML,1020,3,Leadership Fund II,0.95,0.0,0.0,0.0,0.05,0.0,0.0,0.0,clay wilson etterle,
+ML,2020,1,Leadership Development II,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,2020,2,Leadership Development II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,2020,3,Leadership Development II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,3020,1,Advanced Leadership II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william cody cleland,
+ML,3020,2,Advanced Leadership II,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,william cody cleland,
+ML,4020,1,Organizational Leadership II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kenneth tod crawford,
+MSE,2100,1,Intro to Mat Science,0.34,0.23,0.22,0.07,0.06,0.0,0.0,0.07,rakhee pani,
+MSE,2100,2,Intro to Mat Science,0.35,0.28,0.19,0.09,0.06,0.0,0.0,0.04,ruslan burtovyy,
+MSE,2100,3,Intro to Mat Science,0.25,0.29,0.18,0.13,0.09,0.0,0.0,0.06,fei peng,
+MSE,2100,4,Intro to Mat Science,0.39,0.33,0.14,0.05,0.06,0.0,0.0,0.04,olga kuksenok,
+MSE,3100,1,Intro to Metals and Ceramics,0.53,0.27,0.09,0.02,0.04,0.0,0.0,0.04,jianhua tong,
+MSE,3260,1,Thermo of Materials,0.35,0.31,0.22,0.07,0.03,0.0,0.0,0.01,gary lickfield,
+MSE,3270,1,Transport Phenomena,0.0,0.22,0.33,0.39,0.0,0.0,0.0,0.06,ulf daniel schiller,
+MSE,3280,1,Phase Diagrams,0.55,0.3,0.15,0.0,0.0,0.0,0.0,0.0,eric skaar,
+MSE,3420,1,Struct/Property,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kuma bordia,
+MSE,4150,1,Polymer Sc Engr,0.33,0.44,0.17,0.03,0.0,0.0,0.0,0.03,igor luzinov,
+MSE,4160,1,Electronic Materials,0.62,0.33,0.02,0.0,0.02,0.0,0.0,0.0,kyle brinkman,
+MSE,4220,1,Mech Behavior of Mat,0.53,0.29,0.12,0.0,0.06,0.0,0.0,0.0,vincent yves blouin,
+MSE,4240,1,Optical Materials,0.61,0.17,0.13,0.09,0.0,0.0,0.0,0.0,luiz gusta jacobsohn,
+MSE,4330,1,Comb Sys & Env Emiss,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
+MSE,4450,1,Practice of Mat Engr,0.0,0.0,0.0,0.0,0.0,0.96,0.04,0.0,marek urban,
+MSE,4560,1,Polymer & Fiber Materials II,0.56,0.36,0.08,0.0,0.0,0.0,0.0,0.0,gary lickfield,
+MSE,4590,1,Color Science Lab,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,
+MSE,4590,2,Color Science Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,philip brown,
+MSE,4810,1,Undergraduate Research Fundame,0.73,0.05,0.09,0.0,0.05,0.0,0.0,0.09,olin mefford,
+MSE,4910,1,Undergraduate Research,0.65,0.24,0.12,0.0,0.0,0.0,0.0,0.0,olin mefford,
+MSE,8190,1,Inorgan Mater Characterization,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,luiz gusta jacobsohn,
+MSE,8260,1,Phase Equil Mat Sys,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,stephen foulger,
+MUSC,1420,1,Music Theory I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,
+MUSC,1430,1,Aural Skills I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,linda li-bleuel,
+MUSC,1440,1,Music Theory II,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,anthony bernarducci,
+MUSC,1510,2,Applied Music,0.67,0.19,0.05,0.0,0.05,0.0,0.0,0.05,jonathan edwar doyel,
+MUSC,1510,18,Applied Music,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david stevenson,
+MUSC,1800,1,Intro to Music Tech,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
+MUSC,2100,2,Music in the Western World,0.5,0.34,0.16,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
+MUSC,2100,3,Music in the Western World,0.29,0.55,0.06,0.0,0.0,0.0,0.0,0.1,rhea beth jacobus,
+MUSC,2100,5,Music in the Western World,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,6,Music in the Western World,0.45,0.52,0.0,0.03,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,7,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,evan michael jacobi,
+MUSC,2100,9,Music in the Western World,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,
+MUSC,3090,1,Surv of Broadway II,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
+MUSC,3110,1,History of American Music,0.78,0.13,0.06,0.03,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,eric lapin,
+MUSC,3170,1,Hist of Country Mus,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3180,1,Hist of Audio Tech,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,
+MUSC,3690,1,Symphony Orchestra,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,andrew levin,
+MUSC,3700,1,Clemson University Singers,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,david hartmann,
+MUSC,3710,1,Women's Chorus,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,david hartmann,
+NPL,3000,1,Nonprofit Leadership,0.62,0.27,0.08,0.04,0.0,0.0,0.0,0.0,corey doug brookover,
+NPL,3000,2,Nonprofit Leadership,0.63,0.17,0.13,0.0,0.04,0.0,0.0,0.04,christina mari mazer,
+NPL,3000,3,Nonprofit Leadership,0.58,0.25,0.13,0.04,0.0,0.0,0.0,0.0,christina mari mazer,
+NPL,3000,4,Nonprofit Leadership,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,corey doug brookover,
+NPL,3000,5,Nonprofit Leadership,0.61,0.3,0.04,0.0,0.04,0.0,0.0,0.0,corey doug brookover,
+NPL,3010,2,NPL Stakeholders,0.54,0.31,0.12,0.0,0.0,0.0,0.0,0.04,christina mari mazer,
+NPL,3010,3,NPL Stakeholders,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christina mari mazer,
+NPL,3020,1,NPL Fundraising,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,thomas john orourke,
+NPL,3030,2,NPL Personnel,0.48,0.43,0.09,0.0,0.0,0.0,0.0,0.0,bonnie westb stevens,
+NPL,3030,3,NPL Personnel,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,bonnie westb stevens,
+NPL,3040,1,NPL Risk Management,0.71,0.06,0.06,0.12,0.06,0.0,0.0,0.0,daniel morg anderson,
+NURS,1400,1,Comp App Hlth Care,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
+NURS,1400,2,Comp App Hlth Care,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,janice garris lanham,
+NURS,1400,3,Comp App Hlth Care,0.91,0.03,0.03,0.0,0.0,0.0,0.0,0.03,jenna lynn seawright,
+NURS,3030,1,Nursing of Adults,0.41,0.56,0.02,0.02,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3030,400,Nursing of Adults,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3040,1,Pathophysiology,0.41,0.43,0.09,0.0,0.07,0.0,0.0,0.0,catherine sik murton,
+NURS,3040,401,Pathophysiology,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth cam hassen,
+NURS,3100,1,Health Assessment,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,
+NURS,3100,2,Health Assessment,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,
+NURS,3120,1,Foundations of Nursing,0.32,0.64,0.04,0.0,0.0,0.0,0.0,0.0,jennifer eli bagwell,
+NURS,3190,400,Health Assessment for RNs,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
+NURS,3200,2,Prof in Nurs,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3230,402,Gerontology Nurs,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,terri aberc teramano,
+NURS,3330,400,Health Care Genetics,0.86,0.1,0.0,0.0,0.0,0.0,0.0,0.05,mary steck,
+NURS,3400,1,Pharmther Nursing,0.37,0.5,0.07,0.04,0.02,0.0,0.0,0.0,catherine sik murton,
+NURS,4010,1,Mental Health Nurs,0.96,0.02,0.02,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,
+NURS,4030,1,Complex Nursing of Adults,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen ra ewing ra,
+NURS,4060,400,Issues in Professionalism,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
+NURS,4110,1,Nursing of Children,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
+NURS,4120,1,Nurs Women and Fam,0.74,0.24,0.0,0.02,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4250,400,Community Nursing,0.73,0.23,0.0,0.0,0.05,0.0,0.0,0.0,tiffany leah stewart,
+NURS,8010,400,Adv Fam & Comm Nrsng,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
+NURS,8010,401,Adv Fam & Comm Nrsng,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
+NURS,8080,400,Nurs Res Stat Analys,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,8080,401,Nurs Res Stat Analys,0.68,0.2,0.12,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,8190,400,Developing Family,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8200,400,Child & Adol Nursing,0.25,0.46,0.21,0.0,0.08,0.0,0.0,0.0,heide temples,
+NURS,8210,400,Adult Nursing,0.41,0.48,0.07,0.0,0.04,0.0,0.0,0.0,tracy king fasolino,
+NURS,8210,401,Adult Nursing,0.43,0.52,0.04,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8230,400,NP Clinical Practicum,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,
+NURS,8270,400,Nurs Education Found,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
+NURS,8840,400,Adult Mental Health,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,
+NURS,8850,400,Mental Health in Primary Care,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebe garrard,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.56,0.33,0.05,0.01,0.02,0.0,0.0,0.02,elizabeth durrance,
+NUTR,2030,2,Intro Princ of Human Nutrition,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
+NUTR,2040,1,Nutrition Across Life Cycle,0.79,0.18,0.0,0.0,0.0,0.0,0.0,0.03,bridgit deni corbett,
+NUTR,4200,1,Food and Culture,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,bridgit deni corbett,
+NUTR,4250,1,Medica Nutr Thera II,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4260,1,Community Nutrition,0.76,0.22,0.02,0.0,0.0,0.0,0.0,0.0,bridgit deni corbett,
+NUTR,4270,1,Nutrition Counseling,0.59,0.23,0.18,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
+NUTR,4550,1,Human Nutr & Metabolism II,0.67,0.12,0.12,0.09,0.0,0.0,0.0,0.0,elliot jesch,
+PA,2790,1,Perf Arts Pract I,0.6,0.13,0.07,0.0,0.07,0.0,0.0,0.13,kenneth moore,
+PA,2800,1,Perf Arts Pract II,0.75,0.08,0.17,0.0,0.0,0.0,0.0,0.0,kenneth moore,
+PADM,8220,400,Public Policy Process,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mellott eka yazykova,
+PADM,8270,400,Public Personnel Admin,0.86,0.07,0.0,0.0,0.07,0.0,0.0,0.0,donna marie kazia,
+PADM,8410,400,Public Data Analysis,0.56,0.19,0.06,0.0,0.19,0.0,0.0,0.0,ronald chrestman,
+PADM,8410,401,Public Data Analysis,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,ronald chrestman,
+PADM,8410,402,Public Data Analysis,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,edmond patric bowers,
+PADM,8450,401,Grant Writing for Public Admin,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,katherin kransteuber,
+PADM,8510,400,Emergency Management Fundam,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,charles antho haynes,
+PADM,8550,400,Homeland Sec and Intelligence,0.73,0.18,0.0,0.0,0.09,0.0,0.0,0.0,david leigh cook,
+PADM,8620,400,Administrative Leadership,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,mark daniel mellott,
+PADM,8780,407,Project Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sandra marie batt,
+PAS,1010,2,Africa Atlantic Wrld,0.18,0.53,0.0,0.0,0.06,0.0,0.0,0.24,michael blum,
+PES,2020,1,Soils,0.22,0.47,0.27,0.02,0.02,0.0,0.0,0.02,dara michelle park,
+PES,4220,1,Major World Crops,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,sruthi narayan kutty,
+PES,4230,1,Field Crops: Forages,0.47,0.33,0.2,0.0,0.0,0.0,0.0,0.0,matias jose aguerre,
+PES,4330,1,Landscape & Turf Weed Mgt,0.13,0.38,0.44,0.06,0.0,0.0,0.0,0.0,ted whitwell,
+PES,4460,1,Soil Management,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,dara michelle park,
+PES,4520,1,Soil Fertility and Management,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
+PES,4530,1,Soil Fertility Laboratory,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,haibo liu,
+PES,6520,1,Soil Fertility and Management,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,haibo liu,
+PES,8060,2,Water for Agriculture,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,sarah white,
+PES,8090,1,Analytical Technique,0.71,0.14,0.0,0.0,0.0,0.0,0.0,0.14, tharayil-santhakumar,
+PHIL,1010,1,Intro to Philosophic Problems,0.61,0.24,0.03,0.0,0.0,0.0,0.0,0.12,david stegall,
+PHIL,1010,2,Intro to Philosophic Problems,0.49,0.23,0.09,0.06,0.0,0.0,0.0,0.14,david stegall,
+PHIL,1010,3,Intro to Philosophic Problems,0.27,0.64,0.03,0.0,0.03,0.0,0.0,0.03,kelly smith,
+PHIL,1010,5,Intro to Philosophic Problems,0.53,0.32,0.03,0.0,0.03,0.0,0.0,0.09,andrew garnar,
+PHIL,1020,1,Introduction to Logic,0.63,0.17,0.06,0.0,0.0,0.0,0.0,0.14,michael hal hannen,
+PHIL,1020,2,Introduction to Logic,0.68,0.18,0.12,0.0,0.0,0.0,0.0,0.03,michael hal hannen,
+PHIL,1020,3,Introduction to Logic,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,michael hal hannen,
+PHIL,1020,4,Introduction to Logic,0.5,0.25,0.2,0.0,0.05,0.0,0.0,0.0,edyta joanna kuzian,
+PHIL,1020,5,Introduction to Logic,0.5,0.25,0.1,0.0,0.1,0.0,0.0,0.05,edyta joanna kuzian,
+PHIL,1020,6,Introduction to Logic,0.63,0.21,0.11,0.0,0.0,0.0,0.0,0.05,adam gies,
+PHIL,1030,2,Introduction to Ethics,0.63,0.23,0.06,0.06,0.03,0.0,0.0,0.0,stephen satris,
+PHIL,1030,3,Introduction to Ethics,0.44,0.41,0.12,0.0,0.0,0.0,0.0,0.03,christopher mi wells,
+PHIL,1030,4,Introduction to Ethics,0.64,0.33,0.03,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1030,5,Introduction to Ethics,0.53,0.37,0.07,0.0,0.0,0.0,0.0,0.03,adam gies,
+PHIL,1030,6,Introduction to Ethics,0.42,0.48,0.03,0.03,0.03,0.0,0.0,0.0,christopher mi wells,
+PHIL,1030,7,Introduction to Ethics,0.81,0.13,0.03,0.0,0.0,0.0,0.0,0.03,adam gies,
+PHIL,1030,8,Introduction to Ethics,0.34,0.47,0.09,0.03,0.0,0.0,0.0,0.06,christopher mi wells,
+PHIL,1030,9,Introduction to Ethics,0.28,0.5,0.17,0.0,0.0,0.0,0.0,0.06,charles starkey,
+PHIL,3040,1,Moral Philosophy,0.32,0.36,0.25,0.0,0.04,0.0,0.0,0.04,todd may,
+PHIL,3050,1,Existentialism,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,david stegall,
+PHIL,3120,1,Philosophy in Ancient China,0.57,0.36,0.0,0.07,0.0,0.0,0.0,0.0,yanming an,
+PHIL,3160,1,Modern Philosophy,0.54,0.37,0.06,0.0,0.0,0.0,0.0,0.03,michael hal hannen,
+PHIL,3210,1,Crime & Punishment,0.3,0.39,0.12,0.06,0.06,0.0,0.0,0.06,daniel wueste,
+PHIL,3260,1,Science and Values,0.57,0.37,0.03,0.0,0.0,0.0,0.0,0.03,andrew garnar,
+PHIL,3260,2,Science and Values,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,andrew garnar,
+PHIL,3300,1,Self-Deception,0.53,0.4,0.0,0.0,0.0,0.0,0.0,0.07,todd may,
+PHIL,3300,2,Ethics of Inequality,0.17,0.52,0.09,0.0,0.0,0.0,0.0,0.22,brookes colyto brown,
+PHIL,3330,1,Metaphysics,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,david stegall,
+PHIL,3430,1,Philosophy of Law,0.28,0.67,0.06,0.0,0.0,0.0,0.0,0.0,brookes colyto brown,
+PHIL,3450,1,Environmental Ethics,0.22,0.5,0.22,0.0,0.0,0.0,0.0,0.06,christopher mi wells,
+PHIL,3460,1,Biomedical Ethics,0.38,0.41,0.14,0.0,0.03,0.0,0.0,0.03,charles starkey,
+PHIL,4750,1,Philosophy of Film,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,christopher grau,
+PHSC,1170,1,Intro Chem & Earth,0.74,0.23,0.02,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics with Calculus I,0.24,0.32,0.28,0.11,0.01,0.0,0.0,0.03,lih-sin the,
+PHYS,1220,2,Physics with Calculus I,0.24,0.41,0.24,0.06,0.02,0.0,0.0,0.03,lih-sin the,
+PHYS,1220,3,Physics with Calculus I,0.19,0.5,0.23,0.05,0.01,0.0,0.0,0.02,sriparn bhattacharya,
+PHYS,1220,4,Physics with Calculus I,0.25,0.47,0.23,0.02,0.01,0.0,0.0,0.01,sriparn bhattacharya,
+PHYS,1220,5,Physics with Calculus I,0.4,0.46,0.11,0.01,0.0,0.0,0.0,0.01,jason stratfor brown,
+PHYS,1220,8,Physics W/Cal I (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True
+PHYS,1240,1,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,2,Physics Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,3,Physics Lab I,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,5,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,6,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,7,Physics Lab I,0.56,0.33,0.0,0.06,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,8,Physics Lab I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,9,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,10,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,11,Physics Lab I,0.44,0.44,0.0,0.0,0.06,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,12,Physics Lab I,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,13,Physics Lab I,0.22,0.72,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,14,Physics Lab I,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,15,Physics Lab I,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,16,Physics Lab I,0.76,0.12,0.0,0.06,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,17,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,18,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,19,Physics Lab I,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,20,Physics Lab I,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,21,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,22,Physics Lab I,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,23,Physics Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,25,Physics Lab I,0.53,0.24,0.06,0.0,0.12,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,26,Physics Lab I,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,27,Physics Lab I,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,29,Physics Lab I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,30,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2000,1,Introductory Physics,0.31,0.42,0.17,0.02,0.02,0.0,0.0,0.08,nicolas gr underwood,
+PHYS,2070,1,General Physics I,0.23,0.32,0.25,0.09,0.08,0.0,0.0,0.03,amy liann pope,
+PHYS,2080,1,General Physics II,0.52,0.3,0.11,0.05,0.01,0.0,0.0,0.01,amy liann pope,
+PHYS,2080,2,General Physics II,0.63,0.25,0.1,0.02,0.0,0.0,0.0,0.0,amy liann pope,
+PHYS,2090,1,Gen Phys Lab I,0.29,0.63,0.08,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,2,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,3,Gen Phys Lab I,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,4,Gen Phys Lab I,0.07,0.67,0.2,0.0,0.0,0.0,0.0,0.07,daniel ross thompson,
+PHYS,2090,5,Gen Phys Lab I,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,6,Gen Phys Lab I,0.09,0.74,0.09,0.0,0.04,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,7,Gen Phys Lab I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,daniel ross thompson,
+PHYS,2090,8,Gen Phys Lab I,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,9,Gen Phys Lab I,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,10,Gen Phys Lab I,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,
+PHYS,2100,1,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,2,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,3,Gen Phys Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,4,Gen Phys Lab II,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2100,5,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,6,Gen Phys Lab II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,7,Gen Phys Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,8,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,10,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,11,Gen Phys Lab II,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2100,12,Gen Phys Lab II,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2100,13,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,14,Gen Phys Lab II,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,15,Gen Phys Lab II,0.33,0.63,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,16,Gen Phys Lab II,0.7,0.17,0.04,0.0,0.04,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2100,17,Gen Phys Lab II,0.83,0.13,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2100,18,Gen Phys Lab II,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2210,1,Physics with Calculus II,0.12,0.39,0.4,0.06,0.01,0.0,0.0,0.03,jason stratfor brown,
+PHYS,2210,2,Physics with Calculus II,0.3,0.33,0.24,0.09,0.03,0.0,0.0,0.01,jason stratfor brown,
+PHYS,2210,3,Physics with Calculus II (HON),0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,gerald lehmacher,True
+PHYS,2210,5,Physics with Calculus II,0.3,0.4,0.3,0.0,0.0,0.0,0.0,0.0,murray daw,
+PHYS,2210,500,Physics with Calculus II,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,elaine parshall,
+PHYS,2220,1,Physics with Calculus III,0.5,0.31,0.06,0.0,0.0,0.0,0.0,0.13,jian he,
+PHYS,2230,1,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,2,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,3,Physics Lab II,0.71,0.18,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,
+PHYS,2230,5,Physics Lab II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,6,Physics Lab II,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,7,Physics Lab II,0.06,0.72,0.22,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,8,Physics Lab II,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,9,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,500,Physics Lab II,0.48,0.48,0.04,0.0,0.0,0.0,0.0,0.0,elaine parshall,
+PHYS,2400,1,Phys of Weather,0.27,0.39,0.21,0.05,0.02,0.0,0.0,0.06,miguel larsen,
+PHYS,3110,1,Methods Theor Phys,0.28,0.28,0.24,0.08,0.04,0.0,0.0,0.08,lih-sin the,
+PHYS,3220,1,Mechanics II,0.33,0.28,0.06,0.22,0.11,0.0,0.0,0.0,joshua alper,
+PHYS,3260,1,Exper Physics II,0.5,0.31,0.0,0.06,0.0,0.0,0.0,0.13,chad sosolik,
+PHYS,4420,1,Electromagnetics II,0.44,0.44,0.06,0.06,0.0,0.0,0.0,0.0,xian lu,
+PHYS,4560,1,Quantum Physics II,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,ramakrishna podila,
+PHYS,4650,1,Thermo and Stat Mech,0.41,0.35,0.06,0.18,0.0,0.0,0.0,0.0,feng ding,
+PHYS,8150,1,Statistical Therm I,0.42,0.37,0.11,0.0,0.0,0.0,0.0,0.11,jens oberheide,
+PHYS,8190,1,Comp Biophysics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,emil georgiev alexov,
+PHYS,8410,1,Electrodynamics I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
+PHYS,9520,1,Quantum Mech II,0.2,0.53,0.27,0.0,0.0,0.0,0.0,0.0,domnita ca marinescu,
+PKSC,1020,1,Intro to Pkg Sci,0.24,0.42,0.27,0.02,0.04,0.0,0.0,0.01,heather batt,
+PKSC,2010,1,Pkg Perishable Prod,0.13,0.35,0.28,0.08,0.13,0.0,0.0,0.05,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,
+PKSC,2040,1,Container Systems,0.86,0.11,0.03,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,
+PKSC,2060,1,Container Sys Lab,0.68,0.24,0.08,0.0,0.0,0.0,0.0,0.0,tyler stuettgen,
+PKSC,2060,2,Container Sys Lab,0.54,0.38,0.04,0.04,0.0,0.0,0.0,0.0,tyler stuettgen,
+PKSC,2060,3,Container Sys Lab,0.32,0.45,0.18,0.05,0.0,0.0,0.0,0.0,tyler stuettgen,
+PKSC,2200,1,Product & Pkg Design,0.9,0.04,0.0,0.02,0.02,0.0,0.0,0.02,rupert hurley,
+PKSC,3200,1,Pkg Design Theory,0.84,0.14,0.0,0.0,0.0,0.0,0.0,0.02,rupert hurley,
+PKSC,3680,1,Pkg and Society,0.26,0.48,0.18,0.05,0.02,0.0,0.0,0.02,heather batt,
+PKSC,4030,1,Pkg Career Prep,0.93,0.03,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4200,1,Pkg Design & Dev,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4300,1,Converting Flex Pkg,0.23,0.64,0.09,0.03,0.0,0.0,0.0,0.02,duncan darby,
+PKSC,4400,1,Packaging for Distribution,0.26,0.46,0.23,0.0,0.03,0.0,0.0,0.03,gregory batt,
+PKSC,4400,400,Packaging for Distribution,0.1,0.3,0.45,0.0,0.0,0.0,0.0,0.15,gregory batt,
+PKSC,4640,1,Food & Health Care Pkg Systems,0.75,0.18,0.07,0.0,0.0,0.0,0.0,0.0,kay cooksey,
+PLPA,2130,1,Fungi & Civilization,0.43,0.35,0.12,0.02,0.02,0.0,0.0,0.06,julia louis kerrigan,
+PLPA,4060,1,Diseases/Insects Turfgrasses,0.0,0.82,0.09,0.09,0.0,0.0,0.0,0.0,samuel martin,
+POSC,1010,1,Amer National Govt,0.15,0.35,0.23,0.1,0.06,0.0,0.0,0.1,joseph earl stewart,
+POSC,1010,2,Amer National Govt,0.31,0.29,0.2,0.06,0.14,0.0,0.0,0.0,alfred bundrick,
+POSC,1020,1,Intro Intl Relations,0.56,0.3,0.08,0.0,0.04,0.0,0.0,0.02,brandon mich stewart,
+POSC,1020,2,Intro Intl Relations,0.14,0.37,0.25,0.08,0.06,0.0,0.0,0.08,aron geor tannenbaum,
+POSC,1020,3,Intro Intl Relations,0.33,0.42,0.08,0.02,0.06,0.0,0.0,0.08,steven vincen miller,
+POSC,1030,1,Intro to Political Theory,0.37,0.4,0.14,0.0,0.07,0.0,0.0,0.02,brandon turner,
+POSC,1030,2,Intro to Political Theory,0.1,0.53,0.23,0.07,0.0,0.0,0.0,0.07,colin pearce,
+POSC,1030,3,Intro to Political Theory,0.06,0.58,0.23,0.1,0.03,0.0,0.0,0.0,colin pearce,
+POSC,1030,4,Intro to Political Theory,0.33,0.43,0.13,0.03,0.0,0.0,0.0,0.07,lorianne molinari,
+POSC,1040,1,Intro Compar Pol,0.21,0.58,0.16,0.0,0.0,0.0,0.0,0.05,xiaobo hu,
+POSC,1040,2,Intro Compar Pol,0.51,0.19,0.17,0.02,0.11,0.0,0.0,0.0,brandon mich stewart,
+POSC,1990,1,Intro Pol Sci,0.46,0.21,0.12,0.08,0.08,0.0,0.0,0.06,meredith- petersheim,
+POSC,3020,1,State and Loc Gov,0.19,0.57,0.11,0.03,0.03,0.0,0.0,0.08,bruce ransom,
+POSC,3210,1,Public Admin,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
+POSC,3610,1,International Conflict,0.2,0.23,0.18,0.09,0.18,0.0,0.0,0.11,steven vincen miller,
+POSC,3630,1,Us Foreign Policy,0.21,0.57,0.18,0.0,0.04,0.0,0.0,0.0,jeffrey scott peake,
+POSC,3710,1,European Politics,0.43,0.38,0.07,0.02,0.07,0.0,0.0,0.02,vladimir matic,
+POSC,3710,615,European Politics,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
+POSC,3750,1,European Integration,0.2,0.25,0.3,0.05,0.1,0.0,0.0,0.1,zeynep taydas,
+POSC,4050,1,American Presidency,0.21,0.25,0.17,0.08,0.25,0.0,0.0,0.04,adam warber,
+POSC,4160,1,Int Groups & Soc Mov,0.24,0.39,0.22,0.1,0.0,0.0,0.0,0.05,laura olson,
+POSC,4360,1,Law Courts Politics,0.85,0.06,0.0,0.0,0.0,0.0,0.0,0.09,joseph earl stewart,
+POSC,4370,1,Constitut Law: Rights & Libert,0.48,0.42,0.08,0.0,0.02,0.0,0.0,0.0,daniel frost,
+POSC,4390,1,Religious Liberty & US Const,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,daniel frost,
+POSC,4480,615,Internat'l Political Economy,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
+POSC,4490,1,Political Theory of Capitalism,0.44,0.28,0.12,0.02,0.09,0.0,0.0,0.05,brandon turner,
+POSC,4530,1,American Political Thought,0.47,0.4,0.09,0.0,0.02,0.0,0.0,0.02,lorianne molinari,
+POSC,4660,1,African Politics,0.53,0.21,0.21,0.0,0.05,0.0,0.0,0.0,brandon mich stewart,
+POSC,4710,1,Russian Politics,0.63,0.21,0.04,0.0,0.04,0.0,0.0,0.08,aron geor tannenbaum,
+POSC,4760,1,Middle East Politics,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
+POSC,4890,1,Religion in World Politics,0.47,0.29,0.12,0.12,0.0,0.0,0.0,0.0,laura olson,
+PRTM,2200,1,Foundations of PRTM,0.73,0.12,0.06,0.0,0.03,0.0,0.0,0.06,gwynn powell,
+PRTM,2200,2,Foundations of PRTM,0.23,0.41,0.23,0.09,0.05,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2200,3,Foundations of PRTM,0.64,0.16,0.12,0.0,0.08,0.0,0.0,0.0,katrina latric black,
+PRTM,2200,4,Foundations of PRTM,0.65,0.16,0.13,0.06,0.0,0.0,0.0,0.0,lauren eliz stephens,
+PRTM,2260,1,Fnd of Mgt Adm PRTM,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2270,1,Prov of Leisure Exp,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2290,1,Competency Integration in PRTM,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2410,1,Intro to CRSCM,0.46,0.36,0.17,0.02,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2600,1,Found of Recreational Therapy,0.8,0.17,0.03,0.0,0.0,0.0,0.0,0.0,brandi crowe,
+PRTM,2650,1,Terminology in RT Practice,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,
+PRTM,2700,1,Intro Rec Res Mgt,0.62,0.35,0.0,0.04,0.0,0.0,0.0,0.0,elizabeth de baldwin,
+PRTM,2810,1,Intro to Golf Mgt,0.31,0.54,0.08,0.08,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,2820,1,Principle Golfer Dev,0.58,0.08,0.08,0.25,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.38,0.41,0.18,0.03,0.0,0.0,0.0,0.0,daniel morg anderson,
+PRTM,3070,1,Facility Operations,0.75,0.18,0.0,0.07,0.0,0.0,0.0,0.0,raymond dunham,
+PRTM,3210,1,Recreation Admin,0.5,0.38,0.03,0.03,0.06,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,3250,1,Global Persp in Rec,0.6,0.33,0.03,0.0,0.03,0.0,0.0,0.03,harrison pa pinckney,
+PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nut townsend,
+PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3280,2,Preceptorship in Recr Therapy,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,stephen thomas lewis,
+PRTM,3420,1,Intro to Tourism,0.63,0.15,0.1,0.02,0.02,0.0,0.0,0.07,peter judca mkumbo,
+PRTM,3420,2,Intro to Tourism,0.62,0.23,0.08,0.04,0.0,0.0,0.0,0.04,garrett anders stone,
+PRTM,3440,1,Tourism Markets,0.89,0.04,0.04,0.04,0.0,0.0,0.0,0.0,sheila backman,
+PRTM,3440,2,Tourism Markets,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sheila backman,
+PRTM,3450,1,Tourism Management,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,william norman,
+PRTM,3450,2,Tourism Management,0.73,0.23,0.03,0.0,0.0,0.0,0.0,0.0,'lisha fogle,
+PRTM,3460,1,Heritage Tourism,0.23,0.48,0.15,0.08,0.06,0.0,0.0,0.0,gregory phil ramshaw,
+PRTM,3530,2,Foundations of Camp Counseling,0.67,0.1,0.24,0.0,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,3900,5,Independent Study in PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3910,10,Social Media in PRTM,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,zeynep gedikoglu,
+PRTM,4210,1,Rec Fin Resc Mgt,0.25,0.42,0.33,0.0,0.0,0.0,0.0,0.0,harrison pa pinckney,
+PRTM,4300,1,World Geog Parks,0.35,0.16,0.27,0.18,0.02,0.0,0.0,0.02,robert baxter powell,
+PRTM,4460,2,Community Tourism,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lauren duffy,
+PRTM,4460,3,Community Tourism,0.63,0.33,0.0,0.0,0.04,0.0,0.0,0.0,katie dudley,
+PRTM,4550,1,Adv Program Planning,0.72,0.11,0.0,0.11,0.0,0.0,0.0,0.06,mariela fernandez,
+PRTM,8080,1,Behavioral Aspects,0.81,0.14,0.0,0.0,0.0,0.0,0.0,0.05,robert bixler,
+PRTM,8110,2,Research Methods,0.7,0.22,0.04,0.0,0.04,0.0,0.0,0.0,matthew tyl brownlee,
+PRTM,8110,3,Research Methods,0.65,0.3,0.04,0.0,0.0,0.0,0.0,0.0,jeffrey charle hallo,
+PRTM,8210,1,Funding Strategies in PRTM,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,8250,1,Populations in PRTM,0.58,0.25,0.0,0.0,0.17,0.0,0.0,0.0,teresa walton tucker,
+PRTM,8720,2,Adv Facilitation Techniq in RT,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,brandi crowe,
+PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.6,0.2,0.13,0.0,0.07,0.0,0.0,0.0,anna-mari chancellor,
+PRTM,8740,2,Mgt of Clinical Process in RT,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,stephen thomas lewis,
+PSYC,2010,1,Intro to Psychology,0.26,0.25,0.19,0.14,0.1,0.0,0.0,0.07,edwin brainerd,
+PSYC,2010,2,Intro to Psychology,0.37,0.32,0.18,0.08,0.03,0.0,0.0,0.03,jo anne jorgensen,
+PSYC,2010,3,Intro to Psychology,0.36,0.38,0.13,0.07,0.04,0.0,0.0,0.01,mary taylor,
+PSYC,2010,4,Intro to Psychology,0.45,0.33,0.16,0.03,0.01,0.0,0.0,0.01,mary taylor,
+PSYC,2010,5,Intro to Psychology,0.47,0.37,0.12,0.01,0.01,0.0,0.0,0.01,chong hyon pak,
+PSYC,2010,6,Intro to Psychology,0.64,0.23,0.04,0.06,0.01,0.0,0.0,0.01,chong hyon pak,
+PSYC,2010,8,Intro to Psychology (HON),0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
+PSYC,2010,9,Intro to Psychology (HON),0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,mary taylor,True
+PSYC,2020,3,Intro Psychology Lab,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,nastassia mar savage,
+PSYC,2890,1,Fundamentals of Psyc Science,0.46,0.32,0.13,0.04,0.04,0.0,0.0,0.02,cynthia pury s,
+PSYC,3060,1,Human Sexual Behavior,0.51,0.21,0.14,0.05,0.06,0.0,0.0,0.03,bruce michael king,
+PSYC,3090,100,Intro Experimental Psychology,0.4,0.28,0.18,0.08,0.04,0.0,0.0,0.01,patrick rosopa,
+PSYC,3090,200,Intro Experimental Psychology,0.37,0.3,0.2,0.03,0.09,0.0,0.0,0.01,jennifer bail bisson,
+PSYC,3100,100,Advanced Experimental Psych,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,peggy tyler,
+PSYC,3100,200,Advanced Experimental Psych,0.32,0.24,0.16,0.2,0.04,0.0,0.0,0.04,jennifer bail bisson,
+PSYC,3100,300,Advanced Experimental Psych,0.68,0.16,0.05,0.05,0.05,0.0,0.0,0.0,fred switzer,
+PSYC,3100,400,Advanced Experimental Psych,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,thomas britt,
+PSYC,3100,500,Advanced Experimental Psych,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3100,600,Advanced Experimental Psych,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,3240,1,Physiological Psych,0.41,0.31,0.13,0.07,0.06,0.0,0.0,0.01,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.26,0.28,0.23,0.12,0.04,0.0,0.0,0.07,june pilcher,
+PSYC,3330,1,Cognitive Psych,0.66,0.21,0.11,0.01,0.0,0.0,0.0,0.0,kaileigh angel byrne,
+PSYC,3330,2,Cognitive Psych,0.5,0.34,0.12,0.03,0.0,0.0,0.0,0.01,kaileigh angel byrne,
+PSYC,3340,1,Cognitive Psych Lab,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,laura whitlock,
+PSYC,3340,3,Cognitive Psych Lab,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,michael shreeves,
+PSYC,3340,4,Cognitive Psych Lab,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,tiffany cooper,
+PSYC,3400,1,Lifespan Developmental Psych,0.35,0.31,0.21,0.04,0.04,0.0,0.0,0.04,pamela alley,
+PSYC,3520,1,Social Psychology,0.54,0.31,0.13,0.0,0.01,0.0,0.0,0.0,eric mckibben,
+PSYC,3520,2,Social Psychology,0.39,0.33,0.2,0.07,0.0,0.0,0.0,0.01,jo anne jorgensen,
+PSYC,3640,1,Industrial Psych,0.27,0.33,0.29,0.04,0.02,0.0,0.0,0.06,eric mckibben,
+PSYC,3640,2,Industrial Psych,0.33,0.43,0.17,0.04,0.03,0.0,0.0,0.0,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.49,0.33,0.13,0.01,0.01,0.0,0.0,0.01,dana verhoeven,
+PSYC,3700,1,Personality,0.29,0.44,0.19,0.02,0.0,0.0,0.0,0.06,eric mckibben,
+PSYC,3700,2,Personality,0.42,0.42,0.12,0.04,0.0,0.0,0.0,0.0,john robert hester,
+PSYC,3830,1,Abnormal Psychology,0.32,0.45,0.15,0.04,0.02,0.0,0.0,0.02,cynthia pury s,
+PSYC,3830,2,Abnormal Psychology,0.21,0.45,0.21,0.03,0.06,0.0,0.0,0.03,pamela alley,
+PSYC,3830,3,Abnormal Psychology,0.21,0.44,0.21,0.06,0.03,0.0,0.0,0.06,pamela alley,
+PSYC,3890,1,Cross-Cultural Psychology,0.25,0.34,0.22,0.12,0.03,0.0,0.0,0.03,ceren gunsoy,
+PSYC,3890,2,Cross-Cultural Psychology,0.41,0.28,0.16,0.07,0.04,0.0,0.0,0.04,ceren gunsoy,
+PSYC,4080,1,Women and Psychology,0.64,0.12,0.08,0.08,0.08,0.0,0.0,0.0,robin marie kowalski,
+PSYC,4150,1,Systems and Theories,0.33,0.15,0.21,0.15,0.09,0.0,0.0,0.06,edwin brainerd,
+PSYC,4150,2,Systems and Theories,0.38,0.19,0.16,0.06,0.13,0.0,0.0,0.09,edwin brainerd,
+PSYC,4220,1,Perception,0.16,0.36,0.24,0.2,0.04,0.0,0.0,0.0,claudio cantalupo,
+PSYC,4220,2,Perception,0.32,0.2,0.2,0.24,0.04,0.0,0.0,0.0,claudio cantalupo,
+PSYC,4220,3,Perception,0.4,0.28,0.28,0.0,0.04,0.0,0.0,0.0,richard tyrrell,
+PSYC,4350,1,Human Factors,0.52,0.24,0.08,0.08,0.04,0.0,0.0,0.04,laura whitlock,
+PSYC,4430,1,Infant & Child Dev,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,4560,1,Psychophysiology,0.5,0.3,0.05,0.1,0.05,0.0,0.0,0.0,drew michael morris,
+PSYC,4710,1,Psych of Testing,0.33,0.17,0.0,0.08,0.25,0.0,0.0,0.17,zhuo chen,
+PSYC,4800,1,Health Psychology,0.9,0.0,0.05,0.05,0.0,0.0,0.0,0.0,chelsea alyc lenoble,
+PSYC,4880,1,Psychotherapy,0.24,0.53,0.06,0.06,0.06,0.0,0.0,0.06,lucinda sorcie quick,
+PSYC,4890,1,Psychology of Music,0.64,0.28,0.04,0.0,0.0,0.0,0.0,0.04,robert campbell,
+PSYC,4920,1,Senior Laboratory,0.79,0.07,0.11,0.0,0.04,0.0,0.0,0.0,pamela farago,
+PSYC,4920,2,Senior Laboratory,0.82,0.07,0.07,0.04,0.0,0.0,0.0,0.0,pamela farago,
+PSYC,4920,3,Senior Laboratory,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,stephen an robertson,
+PSYC,4920,4,Senior Laboratory,0.77,0.15,0.04,0.0,0.04,0.0,0.0,0.0,stephen an robertson,
+PSYC,4930,100,Pract Clinical Psych,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,heidi marie zinzow,
+PSYC,8130,1,Research Design III,0.62,0.29,0.1,0.0,0.0,0.0,0.0,0.0,patrick rosopa,
+PSYC,8330,1,Adv Cog Psych,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,leo gugerty,
+PSYC,8610,1,Personnel Psych,0.42,0.5,0.0,0.0,0.0,0.0,0.0,0.08,patrick raymark,
+PSYC,8820,1,Occupat Health Psy,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert raym sinclair,
+RED,8030,1,Pub-Priv Partnership,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john terrence farris,
+REL,1010,1,Intro to Religion,0.34,0.31,0.22,0.03,0.03,0.0,0.0,0.06,peter cohen,
+REL,1010,2,Intro to Religion,0.29,0.31,0.29,0.03,0.06,0.0,0.0,0.03,peter cohen,
+REL,1010,3,Intro to Religion,0.18,0.33,0.33,0.06,0.03,0.0,0.0,0.06,peter cohen,
+REL,1010,4,Intro to Religion,0.32,0.26,0.32,0.0,0.0,0.0,0.0,0.11,brett patterson,
+REL,1010,5,Intro to Religion,0.16,0.55,0.13,0.1,0.03,0.0,0.0,0.03,brett patterson,
+REL,1020,1,World Religions,0.36,0.52,0.03,0.0,0.0,0.0,0.0,0.09,robert stephens,
+REL,1020,2,World Religions,0.32,0.32,0.21,0.0,0.0,0.0,0.0,0.15,robert stephens,
+REL,1020,4,World Religions,0.34,0.53,0.09,0.0,0.0,0.0,0.0,0.03,robert stephens,
+REL,3000,2,Studying Religion,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,steven grosby,
+REL,3010,1,Old Testament,0.56,0.29,0.06,0.0,0.0,0.0,0.0,0.09,steven grosby,
+REL,3030,1,The Quran,0.46,0.38,0.04,0.0,0.04,0.0,0.0,0.08,mashal saif,
+REL,3070,1,Christian Trad,0.43,0.36,0.18,0.0,0.0,0.0,0.0,0.04,brett patterson,
+REL,3120,1,Hinduism,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,robert stephens,
+REL,3300,1,Contemporary Issues,0.35,0.35,0.18,0.0,0.0,0.0,0.0,0.12,richard ale amesbury,
+RUSS,1020,1,Elementary Russian,0.27,0.55,0.09,0.09,0.0,0.0,0.0,0.0,stephanie ely morris,
+RUSS,1020,2,Elementary Russian,0.7,0.1,0.2,0.0,0.0,0.0,0.0,0.0,stephanie ely morris,
+RUSS,3600,1,Russian Lit to 1910,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,olga anatoly volkova,
+RUSS,3610,1,Russn Lit Since 1910,0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,olga anatoly volkova,
+SOC,2010,2,Introduction to Sociology,0.88,0.1,0.0,0.0,0.02,0.0,0.0,0.0,andrew he mannheimer,
+SOC,2010,3,Introduction to Sociology,0.77,0.16,0.06,0.0,0.0,0.0,0.0,0.01,andrew he mannheimer,
+SOC,2010,4,Introduction to Sociology,0.39,0.41,0.15,0.04,0.0,0.0,0.0,0.0,carolyn cand coffman,
+SOC,2010,5,Introduction to Sociology,0.51,0.32,0.12,0.01,0.03,0.0,0.0,0.01,carolyn cand coffman,
+SOC,2010,6,Introduction to Sociology,0.65,0.17,0.11,0.02,0.0,0.0,0.0,0.04,carolyn cand coffman,
+SOC,2010,7,Introduction to Sociology,0.73,0.13,0.04,0.04,0.04,0.0,0.0,0.03,stacy leanne smith,
+SOC,2010,8,Introduction to Sociology,0.76,0.11,0.09,0.02,0.02,0.0,0.0,0.0,stacy leanne smith,
+SOC,2010,9,Introduction to Sociology,0.85,0.09,0.02,0.02,0.0,0.0,0.0,0.02,stacy leanne smith,
+SOC,2010,10,Introduction to Sociology,0.51,0.39,0.08,0.0,0.02,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,11,Introduction to Sociology,0.64,0.26,0.09,0.01,0.0,0.0,0.0,0.0,shannon mcdonough,
+SOC,2010,12,Introduction to Sociology,0.61,0.24,0.1,0.02,0.0,0.0,0.0,0.02,shannon mcdonough,
+SOC,2020,1,Social Problems,0.47,0.36,0.11,0.02,0.04,0.0,0.0,0.0,carolyn cand coffman,
+SOC,3020,1,Research Methods I,0.33,0.27,0.27,0.03,0.03,0.0,0.0,0.07,andrew whitehead,
+SOC,3040,1,Social Research Methods II,0.57,0.36,0.04,0.0,0.0,0.0,0.0,0.04,william haller,
+SOC,3100,1,Marriage & Intimacy,0.62,0.16,0.18,0.0,0.02,0.0,0.0,0.02,carolyn cand coffman,
+SOC,3110,1,The Family,0.36,0.49,0.11,0.04,0.0,0.0,0.0,0.0,traci ann hefner,
+SOC,3600,1,Class & Poverty,0.24,0.49,0.2,0.05,0.02,0.0,0.0,0.0,kenneth robinson,
+SOC,3800,1,Intro Social Service,0.58,0.35,0.04,0.02,0.0,0.0,0.0,0.0,jennifer lea holland,
+SOC,3910,1,Soc of Deviance,0.5,0.38,0.08,0.02,0.02,0.0,0.0,0.0,shannon mcdonough,
+SOC,4040,1,Soc Theory,0.52,0.26,0.13,0.1,0.0,0.0,0.0,0.0,stacy leanne smith,
+SOC,4320,1,Soc of Religion,0.31,0.4,0.29,0.0,0.0,0.0,0.0,0.0,andrew whitehead,
+SOC,4330,1,Global Social Change,0.33,0.38,0.17,0.02,0.05,0.0,0.0,0.05,traci ann hefner,
+SOC,4600,1,Race & Ethnicity,0.77,0.18,0.02,0.02,0.0,0.0,0.0,0.0,andrew he mannheimer,
+SOC,4600,2,Race & Ethnicity,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrew he mannheimer,
+SOC,4610,1,Sex & Gender,0.28,0.35,0.14,0.16,0.07,0.0,0.0,0.0,sarah evelyn winslow,
+SOC,4840,1,Child Abuse,0.81,0.16,0.0,0.0,0.0,0.0,0.0,0.03,james rosenberger,
+SOC,4970,1,Senior Lab,0.66,0.34,0.0,0.0,0.0,0.0,0.0,0.0,jennifer lea holland,
+SPAN,1010,1,Elementary Spanish,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,rosa maca pillcurima,
+SPAN,1010,2,Elementary Spanish,0.47,0.16,0.26,0.0,0.0,0.0,0.0,0.11,rosa maca pillcurima,
+SPAN,1010,3,Elementary Spanish,0.41,0.14,0.27,0.0,0.09,0.0,0.0,0.09,rosa maca pillcurima,
+SPAN,1020,2,Elementary Spanish,0.32,0.5,0.09,0.05,0.0,0.0,0.0,0.05,ellory schmucker,
+SPAN,1020,3,Elementary Spanish,0.39,0.48,0.09,0.0,0.04,0.0,0.0,0.0,adrienne elizab fama,
+SPAN,1020,4,Elementary Spanish,0.27,0.32,0.32,0.09,0.0,0.0,0.0,0.0,adrienne elizab fama,
+SPAN,1020,5,Elementary Spanish,0.14,0.55,0.23,0.05,0.0,0.0,0.0,0.05,rosa maca pillcurima,
+SPAN,1020,7,Elementary Spanish,0.36,0.36,0.18,0.0,0.09,0.0,0.0,0.0,cathy robison,
+SPAN,1020,8,Elementary Spanish,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,debra oak williamson,
+SPAN,1020,9,Elementary Spanish,0.47,0.21,0.26,0.0,0.0,0.0,0.0,0.05,debra oak williamson,
+SPAN,1020,10,Elementary Spanish,0.43,0.38,0.14,0.0,0.05,0.0,0.0,0.0,adrienne elizab fama,
+SPAN,2010,1,Intermediate Spanish,0.23,0.5,0.14,0.05,0.0,0.0,0.0,0.09,cathy robison,
+SPAN,2010,2,Intermediate Spanish,0.26,0.26,0.26,0.11,0.0,0.0,0.0,0.11,cathy robison,
+SPAN,2010,3,Intermediate Spanish,0.39,0.39,0.22,0.0,0.0,0.0,0.0,0.0,allison ann hinds,
+SPAN,2010,4,Intermediate Spanish,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.05,nora arostegui logue,
+SPAN,2010,5,Intermediate Spanish,0.39,0.44,0.06,0.0,0.06,0.0,0.0,0.06,allison ann hinds,
+SPAN,2010,6,Intermediate Spanish,0.31,0.46,0.0,0.08,0.0,0.0,0.0,0.15,debra oak williamson,
+SPAN,2010,7,Intermediate Spanish,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,debra oak williamson,
+SPAN,2010,8,Intermediate Spanish,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,9,Intermediate Spanish,0.61,0.35,0.04,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,10,Intermediate Spanish,0.65,0.22,0.04,0.04,0.0,0.0,0.0,0.04,vieyra daniel garcia,
+SPAN,2010,12,Intermediate Spanish,0.64,0.07,0.07,0.0,0.07,0.0,0.0,0.14,valderramos zen cruz,
+SPAN,2010,13,Intermediate Spanish,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,
+SPAN,2010,14,Intermediate Spanish,0.61,0.22,0.09,0.0,0.0,0.0,0.0,0.09,ellory schmucker,
+SPAN,2010,16,Intermediate Spanish,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,vieyra daniel garcia,
+SPAN,2020,1,Intermediate Spanish,0.7,0.22,0.04,0.0,0.04,0.0,0.0,0.0,vieyra daniel garcia,
+SPAN,2020,2,Intermediate Spanish,0.71,0.1,0.14,0.05,0.0,0.0,0.0,0.0,vieyra daniel garcia,
+SPAN,2020,3,Intermediate Spanish,0.7,0.17,0.13,0.0,0.0,0.0,0.0,0.0,vieyra daniel garcia,
+SPAN,2020,4,Intermediate Spanish,0.48,0.38,0.1,0.0,0.0,0.0,0.0,0.05,valderramos zen cruz,
+SPAN,2020,5,Intermediate Spanish,0.55,0.23,0.14,0.0,0.0,0.0,0.0,0.09,valderramos zen cruz,
+SPAN,2020,6,Intermediate Spanish,0.52,0.35,0.13,0.0,0.0,0.0,0.0,0.0,valderramos zen cruz,
+SPAN,2020,7,Intermediate Spanish,0.12,0.47,0.12,0.12,0.18,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,8,Intermediate Spanish,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,
+SPAN,2020,9,Intermediate Spanish,0.42,0.42,0.05,0.11,0.0,0.0,0.0,0.0,ana paula  miller e,
+SPAN,2020,10,Intermediate Spanish,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,ana paula  miller e,
+SPAN,2020,11,Intermediate Spanish,0.65,0.26,0.04,0.0,0.0,0.0,0.0,0.04,rodriguez alm garcia,
+SPAN,2020,12,Intermediate Spanish,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,rodriguez alm garcia,
+SPAN,2020,13,Intermediate Spanish,0.19,0.48,0.24,0.0,0.0,0.0,0.0,0.1,juana martin-armas,
+SPAN,2020,14,Intermediate Spanish,0.1,0.5,0.2,0.2,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,2020,15,Intermediate Spanish,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,ana paula  miller e,
+SPAN,2020,20,Intermediate Spanish,0.45,0.23,0.27,0.0,0.0,0.0,0.0,0.05,melva margue persico,
+SPAN,3020,1,Intermed Span Grammar & Comp,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,
+SPAN,3020,2,Intermed Span Grammar & Comp,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,melva margue persico,
+SPAN,3020,3,Intermed Span Grammar & Comp,0.42,0.37,0.05,0.0,0.05,0.0,0.0,0.11,melva margue persico,
+SPAN,3040,1,Intro Hispanic Literary Forms,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,
+SPAN,3040,2,Intro Hispanic Literary Forms,0.71,0.24,0.0,0.0,0.0,0.0,0.0,0.05,rodriguez alm garcia,
+SPAN,3050,1,Intermed Span Convers/Comp I,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,melva margue persico,
+SPAN,3050,2,Intermed Span Convers/Comp I,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,riquelme maria judez,
+SPAN,3050,4,Intermed Span Convers/Comp I,0.72,0.17,0.06,0.06,0.0,0.0,0.0,0.0,moni rojas-de-massei,
+SPAN,3060,1,Span Comp for Bus,0.73,0.2,0.07,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,3070,1,The Hispanic World: Spain,0.5,0.44,0.0,0.06,0.0,0.0,0.0,0.0,juana martin-armas,
+SPAN,3080,1,The Hispanic World: Latin Amer,0.24,0.47,0.18,0.0,0.12,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,3130,2,Span Lit Survey I,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william dan holcombe,
+SPAN,4060,1,Narrative Fiction,0.47,0.33,0.13,0.0,0.0,0.0,0.0,0.07,moni rojas-de-massei,
+SPAN,4070,1,Hispanic Film,0.52,0.38,0.1,0.0,0.0,0.0,0.0,0.0,raquel anido,
+SPAN,4170,1,Prof Communication,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,maureen zamora,
+SPAN,4180,1,Technical Span Health Mgt Prof,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,peralta arelis moore,
+STAT,2220,1,Statistics in Everyday Life,0.38,0.25,0.27,0.04,0.04,0.0,0.0,0.02,james espey,
+STAT,2220,2,Statistics in Everyday Life,0.39,0.31,0.14,0.04,0.06,0.0,0.0,0.06,james espey,
+STAT,2220,3,Statistics in Everyday Life,0.35,0.31,0.17,0.08,0.08,0.0,0.0,0.02,james espey,
+STAT,2220,4,Statistics in Everyday Life,0.27,0.35,0.17,0.1,0.0,0.0,0.0,0.12,james espey,
+STAT,2220,5,Statistics in Everyday Life,0.31,0.43,0.16,0.06,0.02,0.0,0.0,0.02,rose martinez-dawson,
+STAT,2220,6,Statistics in Everyday Life,0.47,0.22,0.18,0.08,0.06,0.0,0.0,0.0,rose martinez-dawson,
+STAT,2220,7,Statistics in Everyday Life,0.27,0.33,0.27,0.08,0.0,0.0,0.0,0.04,jason alexander kurz,
+STAT,2220,8,Statistics in Everyday Life,0.14,0.35,0.22,0.05,0.19,0.0,0.0,0.05,andrew pangia,
+STAT,2300,1,Statistical Methods I,0.22,0.33,0.21,0.11,0.08,0.0,0.0,0.04,april thomas,
+STAT,2300,2,Statistical Methods I,0.32,0.33,0.17,0.12,0.03,0.0,0.0,0.04,christy jenkin brown,
+STAT,2300,3,Statistical Methods I,0.3,0.35,0.16,0.08,0.05,0.0,0.0,0.05, erwin walker,
+STAT,2300,4,Statistical Methods I,0.27,0.3,0.18,0.11,0.08,0.0,0.0,0.06, erwin walker,
+STAT,2300,5,Statistical Methods I,0.21,0.38,0.22,0.08,0.11,0.0,0.0,0.01,elaine mar sotherden,
+STAT,2300,6,Statistical Methods I,0.28,0.41,0.18,0.08,0.04,0.0,0.0,0.01,todd fenstermacher,
+STAT,2300,100,Statistical Methods I (HON),0.73,0.24,0.03,0.0,0.0,0.0,0.0,0.0,christy jenkin brown,True
+STAT,3090,1,Introductory Business Stats,0.16,0.21,0.29,0.08,0.16,0.0,0.0,0.11,tianhui wei,
+STAT,3090,2,Introductory Business Stats,0.14,0.17,0.17,0.19,0.25,0.0,0.0,0.08,matthew saltzman,
+STAT,3090,3,Introductory Business Stats,0.31,0.29,0.12,0.17,0.07,0.0,0.0,0.05,tiantian yang,
+STAT,3090,4,Introductory Business Stats,0.2,0.25,0.16,0.18,0.11,0.0,0.0,0.09,margaret mari wiecek,
+STAT,3090,5,Introductory Business Stats,0.2,0.18,0.23,0.16,0.16,0.0,0.0,0.07,lu sun,
+STAT,3090,6,Introductory Business Stats,0.18,0.3,0.27,0.05,0.2,0.0,0.0,0.0,boyoung hur,
+STAT,3090,7,Introductory Business Stats,0.26,0.31,0.19,0.12,0.1,0.0,0.0,0.02,jiajing niu,
+STAT,3090,8,Introductory Business Stats,0.26,0.21,0.33,0.05,0.13,0.0,0.0,0.03,yisu jia,
+STAT,3090,9,Introductory Business Stats,0.29,0.4,0.26,0.06,0.0,0.0,0.0,0.0,marilyn reba,
+STAT,3090,10,Introductory Business Stats,0.28,0.56,0.06,0.08,0.03,0.0,0.0,0.0,marilyn reba,
+STAT,3090,11,Introductory Business Stats,0.24,0.23,0.26,0.14,0.12,0.0,0.0,0.01,sharon marie evans,
+STAT,3090,12,Introductory Business Stats,0.2,0.34,0.26,0.09,0.08,0.0,0.0,0.02,sharon marie evans,
+STAT,3300,1,Statistical Methods II,0.36,0.36,0.12,0.08,0.04,0.0,0.0,0.04,rose martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.43,0.24,0.1,0.0,0.14,0.0,0.0,0.1,ellen hepfer breazel,
+STAT,4110,1,Stat Mthds for Process Control,0.71,0.18,0.09,0.0,0.03,0.0,0.0,0.0,richard steve dubsky,
+STAT,6020,1,Intro to Statistical Computing,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,
+STAT,8010,1,Statistical Methods I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,james rieck,
+STAT,8010,2,Statistical Methods I,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,8010,3,Statistical Methods I,0.32,0.36,0.18,0.0,0.09,0.0,0.0,0.05,james rieck,
+STAT,8010,4,Statistical Methods I,0.43,0.52,0.04,0.0,0.0,0.0,0.0,0.0,patrick gerard,
+STAT,8010,5,Statistical Methods I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,joseph daniel bible,
+STAT,8010,400,Statistical Methods I,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,brook thayer russell,
+STAT,8050,1,Design & Anlys of Experiments,0.48,0.48,0.0,0.0,0.0,0.0,0.0,0.03,william bridges,
+STS,1010,2,Survey of S T S,0.36,0.45,0.18,0.0,0.0,0.0,0.0,0.0,scott brame,
+STS,1010,3,Survey of S T S,0.5,0.36,0.11,0.03,0.0,0.0,0.0,0.0,elizabeth stansell,
+STS,1010,4,Survey of S T S,0.69,0.25,0.03,0.0,0.0,0.0,0.0,0.03,melissa dugan,
+STS,1010,5,Survey of S T S,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,philip randall,
+STS,1010,6,Survey of S T S,0.17,0.51,0.23,0.0,0.0,0.0,0.0,0.09,sarah mae cooper,
+STS,1010,7,Survey of S T S,0.22,0.47,0.25,0.0,0.0,0.0,0.0,0.06,megan noe macalystre,
+STS,1010,8,Survey of S T S,0.27,0.4,0.2,0.03,0.0,0.0,0.0,0.1,david charles foltz,
+STS,1010,9,Survey of S T S,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,stephanie stripling,
+THEA,2100,1,Theatre Appreciation,0.55,0.29,0.06,0.03,0.0,0.0,0.0,0.06,kendra lynet johnson,
+THEA,2100,2,Theatre Appreciation,0.66,0.19,0.06,0.0,0.06,0.0,0.0,0.03,kerrie kathl seymour,
+THEA,2100,3,Theatre Appreciation,0.87,0.06,0.03,0.0,0.0,0.0,0.0,0.03,shannon there robert,
+THEA,2100,5,Theatre Appreciation,0.43,0.47,0.07,0.0,0.0,0.0,0.0,0.03,carol collins,
+THEA,2100,6,Theatre Appreciation,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,anthony penna,
+THEA,2100,7,Theatre Appreciation,0.66,0.28,0.03,0.0,0.0,0.0,0.0,0.03,jason adkins,
+THEA,2790,1,Theatre Practicum,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,matthew leckenbusch,
+THEA,3160,1,Theatre History II,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,peter richard er st. er,
+THEA,3180,1,Afri-Amer Thea II,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,kendra lynet johnson,
+THEA,3770,1,Stagecrafts,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,david hartmann,
+THEA,4790,1,Acting II,0.54,0.23,0.08,0.08,0.08,0.0,0.0,0.0,kerrie kathl seymour,
+WFB,3010,1,Wildlife Biology Lab,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,shari lynn rodriguez,
+WFB,3010,2,Wildlife Biology Lab,0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,shari lynn rodriguez,
+WFB,3130,1,Conservation Biology,0.35,0.39,0.16,0.05,0.03,0.0,0.0,0.03,shari lynn rodriguez,
+WFB,3130,2,Conservation Biology,0.27,0.35,0.24,0.08,0.03,0.0,0.0,0.03,shari lynn rodriguez,
+WFB,3500,1,Princ Fish & Wildlife Biology,0.3,0.46,0.2,0.04,0.0,0.0,0.0,0.0,james davis,
+WFB,3500,2,Princ Fish & Wildlife Biology,0.18,0.5,0.25,0.05,0.0,0.0,0.0,0.02,james davis,
+WFB,4120,1,Wildlife Management,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
+WFB,4160,1,Fisheries Techniques,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,brandon kevi peoples,
+WFB,4620,1,Wetland Wildlife Biology,0.74,0.23,0.01,0.0,0.0,0.0,0.0,0.01,russell barrett,
+WFB,4930,2,Quantitative Ecology,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,david scot jachowski,
+WFB,8500,1,Wildlife & Fisheries Ecology,0.44,0.33,0.15,0.0,0.04,0.0,0.0,0.04,susan talley guynn,
+WS,1030,1,Women in Global Perspective,0.88,0.04,0.0,0.04,0.0,0.0,0.0,0.04,annie boiter-jolley,
+WS,1030,2,Women in Global Perspective,0.93,0.04,0.0,0.0,0.0,0.0,0.0,0.04,annie boiter-jolley,
+WS,2400,1,Women and Leadership II,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,diane perpich,
+WS,3010,1,Intro Women's Studies,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,elizabeth rose adams,
+WS,3010,2,Intro Women's Studies,0.68,0.27,0.0,0.0,0.05,0.0,0.0,0.0,elizabeth rose adams,
+YDP,3100,1,Youth Developmt and the Family,0.79,0.14,0.04,0.0,0.04,0.0,0.0,0.0,william quinn,
+YDP,3100,3,Youth Developmt and the Family,0.81,0.07,0.07,0.0,0.04,0.0,0.0,0.0,william quinn,
+YDP,3250,1,Working with Diverse Youth,0.79,0.14,0.04,0.0,0.0,0.0,0.0,0.04,kimberly pea johnson,
+YDP,4400,1,Youth Program Assessmnt & Eval,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,ann marie gillard,
+YDP,4550,1,Youth and Technology,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,david lynn pollock,
+YDP,8010,1,Child/Adolescent Dev,0.68,0.24,0.04,0.0,0.04,0.0,0.0,0.0,edmond patric bowers,
+YDP,8040,1,Assess & Eval of Youth Program,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,barry garst,
+YDP,8880,1,Special Topics Youth Dev Ldshp,0.63,0.29,0.04,0.0,0.0,0.0,0.0,0.04,barry garst,

--- a/bot/cogs/grades_cog/assets/2019_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2019_Fall.csv
@@ -1,2896 +1,2821 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1010,1.0,Survey of Art & Arch History I,0.35,0.46,0.15,0.01,0.02,0.0,0.0,0.01,beth ann lauritis,AAH-1010,2019
-AAH,2050,1.0,Art History and Theory I,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,beth ann lauritis,AAH-2050,2019
-AAH,3050,1.0,Contemporary Art History,0.81,0.14,0.0,0.05,0.0,0.0,0.0,0.0,anatole upart,AAH-3050,2019
-ACCT,2010,1.0,Financial Accounting Concepts,0.43,0.29,0.1,0.04,0.04,0.0,0.0,0.1,lydia lancaster folger schleifer,ACCT-2010,2019
-ACCT,2010,2.0,Financial Accounting Concepts,0.42,0.32,0.16,0.02,0.04,0.0,0.0,0.04,lydia lancaster folger schleifer,ACCT-2010,2019
-ACCT,2010,3.0,Financial Accounting Concepts,0.33,0.27,0.22,0.04,0.02,0.0,0.0,0.11,julie grant,ACCT-2010,2019
-ACCT,2010,4.0,Financial Accounting Concepts,0.38,0.24,0.2,0.07,0.02,0.0,0.0,0.09,julie grant,ACCT-2010,2019
-ACCT,2010,5.0,Financial Accounting Concepts,0.5,0.35,0.1,0.0,0.0,0.0,0.0,0.04,lydia lancaster folger schleifer,ACCT-2010,2019
-ACCT,2010,6.0,Financial Accounting Concepts,0.4,0.31,0.13,0.07,0.02,0.0,0.0,0.07,michael john mcguigan,ACCT-2010,2019
-ACCT,2010,7.0,Financial Accounting Concepts,0.16,0.49,0.27,0.0,0.06,0.0,0.0,0.02,carl hollingsworth,ACCT-2010,2019
-ACCT,2010,8.0,Financial Accounting Concepts,0.22,0.31,0.27,0.1,0.04,0.0,0.0,0.06,carl hollingsworth,ACCT-2010,2019
-ACCT,2010,9.0,Financial Accounting Concepts,0.11,0.39,0.3,0.07,0.07,0.0,0.0,0.07,michael john mcguigan,ACCT-2010,2019
-ACCT,2010,10.0,Financial Accounting Concepts,0.37,0.33,0.14,0.06,0.04,0.0,0.0,0.06,charles tegen,ACCT-2010,2019
-ACCT,2010,11.0,Financial Accounting Concepts,0.33,0.28,0.14,0.03,0.08,0.0,0.0,0.14,lisa wheatley birtwistle,ACCT-2010,2019
-ACCT,2010,12.0,Financial Accounting Concepts,0.12,0.35,0.19,0.07,0.12,0.0,0.0,0.16,lisa wheatley birtwistle,ACCT-2010,2019
-ACCT,2010,13.0,Financial Accounting Concepts,0.24,0.24,0.37,0.1,0.0,0.0,0.0,0.05,lisa wheatley birtwistle,ACCT-2010,2019
-ACCT,2010,14.0,Financial Accounting Concepts,0.38,0.45,0.1,0.03,0.0,0.0,0.0,0.03,annieka philo,ACCT-2010,2019
-ACCT,2010,100.0,Fin Accounting Concepts (HON),0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,mary ann  prater,ACCT-2010,2019
-ACCT,2010,111.0,Fin Accounting Concepts (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lisa wheatley birtwistle,ACCT-2010,2019
-ACCT,2010,400.0,Financial Accounting Concepts,0.14,0.22,0.21,0.1,0.07,0.0,0.0,0.26,jeffrey mcmillan,ACCT-2010,2019
-ACCT,2010,401.0,Financial Accounting Concepts,0.33,0.43,0.16,0.04,0.02,0.0,0.0,0.02,emily suzanne mccorkle,ACCT-2010,2019
-ACCT,2020,1.0,Managerial Accounting Concepts,0.31,0.23,0.15,0.03,0.0,0.0,0.0,0.28,henry anderson,ACCT-2020,2019
-ACCT,2020,2.0,Managerial Accounting Concepts,0.27,0.33,0.15,0.06,0.12,0.0,0.0,0.06,henry anderson,ACCT-2020,2019
-ACCT,2020,3.0,Managerial Accounting Concepts,0.18,0.46,0.23,0.0,0.03,0.0,0.0,0.1,henry anderson,ACCT-2020,2019
-ACCT,2020,4.0,Managerial Accounting Concepts,0.26,0.33,0.23,0.0,0.1,0.0,0.0,0.08,henry anderson,ACCT-2020,2019
-ACCT,2020,5.0,Managerial Accounting Concepts,0.21,0.3,0.21,0.09,0.06,0.0,0.0,0.13,brian todd carver,ACCT-2020,2019
-ACCT,2020,6.0,Managerial Accounting Concepts,0.17,0.15,0.37,0.09,0.04,0.0,0.0,0.17,brian todd carver,ACCT-2020,2019
-ACCT,2020,400.0,Managerial Accounting Concepts,0.3,0.29,0.16,0.08,0.03,0.0,0.0,0.13,henry anderson,ACCT-2020,2019
-ACCT,2020,402.0,Managerial Accounting Concepts,0.25,0.23,0.3,0.12,0.04,0.0,0.0,0.05,emily suzanne mccorkle,ACCT-2020,2019
-ACCT,2900,1.0,Special Topics - Soft Skills,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,michael mendonca,ACCT-2900,2019
-ACCT,3030,1.0,Cost Accounting,0.38,0.36,0.21,0.0,0.03,0.0,0.0,0.03,daniel thomas way,ACCT-3030,2019
-ACCT,3030,2.0,Cost Accounting,0.25,0.39,0.31,0.03,0.0,0.0,0.0,0.03,daniel thomas way,ACCT-3030,2019
-ACCT,3030,3.0,Cost Accounting,0.32,0.43,0.14,0.03,0.05,0.0,0.0,0.03,jace garrett,ACCT-3030,2019
-ACCT,3030,4.0,Cost Accounting,0.38,0.27,0.19,0.03,0.03,0.0,0.0,0.11,jace garrett,ACCT-3030,2019
-ACCT,3030,5.0,Cost Accounting,0.55,0.26,0.16,0.0,0.03,0.0,0.0,0.0,sarah martin,ACCT-3030,2019
-ACCT,3110,1.0,Intermediate Financial Acct I,0.17,0.29,0.33,0.0,0.08,0.0,0.0,0.13,annieka philo,ACCT-3110,2019
-ACCT,3110,2.0,Intermediate Financial Acct I,0.16,0.31,0.41,0.06,0.03,0.0,0.0,0.03,amy melissa donnelly,ACCT-3110,2019
-ACCT,3110,3.0,Intermediate Financial Acct I,0.17,0.39,0.11,0.11,0.11,0.0,0.0,0.11,annieka philo,ACCT-3110,2019
-ACCT,3110,4.0,Intermediate Financial Acct I,0.19,0.32,0.39,0.03,0.03,0.0,0.0,0.03,amy melissa donnelly,ACCT-3110,2019
-ACCT,3110,5.0,Intermediate Financial Acct I,0.19,0.52,0.19,0.0,0.0,0.0,0.0,0.1, russell madray,ACCT-3110,2019
-ACCT,3110,6.0,Intermediate Financial Acct I,0.16,0.29,0.26,0.06,0.06,0.0,0.0,0.16,amy melissa donnelly,ACCT-3110,2019
-ACCT,3110,7.0,Intermediate Financial Acct I,0.32,0.42,0.13,0.03,0.06,0.0,0.0,0.03, russell madray,ACCT-3110,2019
-ACCT,3110,8.0,Intermediate Financial Acct I,0.11,0.26,0.26,0.11,0.21,0.0,0.0,0.05,erin michelle hawkins,ACCT-3110,2019
-ACCT,3110,100.0,Intermediate Fin Acct I (HON),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,ACCT-3110,2019
-ACCT,3120,1.0,Intermediate Financial Acct II,0.44,0.17,0.28,0.0,0.06,0.0,0.0,0.06,terry daniel knause,ACCT-3120,2019
-ACCT,3120,2.0,Intermediate Financial Acct II,0.0,0.39,0.39,0.11,0.11,0.0,0.0,0.0, russell madray,ACCT-3120,2019
-ACCT,3120,3.0,Intermediate Financial Acct II,0.2,0.46,0.23,0.06,0.03,0.0,0.0,0.03, russell madray,ACCT-3120,2019
-ACCT,3120,4.0,Intermediate Financial Acct II,0.45,0.42,0.1,0.0,0.0,0.0,0.0,0.03,terry daniel knause,ACCT-3120,2019
-ACCT,3120,5.0,Intermediate Financial Acct II,0.33,0.33,0.31,0.0,0.0,0.0,0.0,0.03,terry daniel knause,ACCT-3120,2019
-ACCT,3120,6.0,Intermediate Financial Acct II,0.31,0.5,0.17,0.0,0.0,0.0,0.0,0.03,terry daniel knause,ACCT-3120,2019
-ACCT,3130,1.0,Analytics for Acct Dec Making,0.57,0.25,0.14,0.0,0.0,0.0,0.0,0.04,babak mammadov,ACCT-3130,2019
-ACCT,3130,2.0,Analytics for Acct Dec Making,0.33,0.4,0.13,0.0,0.07,0.0,0.0,0.07,babak mammadov,ACCT-3130,2019
-ACCT,3130,3.0,Analytics for Acct Dec Making,0.28,0.33,0.28,0.11,0.0,0.0,0.0,0.0,phebian davis-culler,ACCT-3130,2019
-ACCT,3130,4.0,Analytics for Acct Dec Making,0.18,0.64,0.18,0.0,0.0,0.0,0.0,0.0,phebian davis-culler,ACCT-3130,2019
-ACCT,3130,5.0,Analytics for Acct Dec Making,0.32,0.41,0.18,0.0,0.05,0.0,0.0,0.05,phebian davis-culler,ACCT-3130,2019
-ACCT,3130,6.0,Analytics for Acct Dec Making,0.17,0.35,0.3,0.13,0.04,0.0,0.0,0.0,phebian davis-culler,ACCT-3130,2019
-ACCT,3130,105.0,Analytics for Accounting (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,phebian davis-culler,ACCT-3130,2019
-ACCT,3220,1.0,Accounting Information Systems,0.11,0.32,0.21,0.21,0.05,0.0,0.0,0.11,philip maiberger,ACCT-3220,2019
-ACCT,3220,2.0,Accounting Information Systems,0.18,0.42,0.24,0.06,0.03,0.0,0.0,0.06,philip maiberger,ACCT-3220,2019
-ACCT,3220,3.0,Accounting Information Systems,0.1,0.31,0.31,0.1,0.07,0.0,0.0,0.1,philip maiberger,ACCT-3220,2019
-ACCT,3220,4.0,Accounting Information Systems,0.14,0.41,0.21,0.07,0.0,0.0,0.0,0.17,philip maiberger,ACCT-3220,2019
-ACCT,4040,1.0,Individual Taxation,0.64,0.21,0.11,0.0,0.0,0.0,0.0,0.04,sarah martin,ACCT-4040,2019
-ACCT,4040,2.0,Individual Taxation,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2019
-ACCT,4040,3.0,Individual Taxation,0.42,0.33,0.18,0.0,0.03,0.0,0.0,0.03,sarah martin,ACCT-4040,2019
-ACCT,4040,4.0,Individual Taxation,0.06,0.52,0.23,0.1,0.06,0.0,0.0,0.03,lisa wheatley birtwistle,ACCT-4040,2019
-ACCT,4040,101.0,Individual Taxation (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2019
-ACCT,4080,1.0,Retire & Estate Plan,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,john hine,ACCT-4080,2019
-ACCT,4100,1.0,Reporting and Mgmt Control Sys,0.29,0.41,0.26,0.0,0.0,0.0,0.0,0.03,gregory patrick mcphee,ACCT-4100,2019
-ACCT,4100,2.0,Reporting and Mgmt Control Sys,0.38,0.38,0.18,0.06,0.0,0.0,0.0,0.0,gregory patrick mcphee,ACCT-4100,2019
-ACCT,4100,3.0,Reporting and Mgmt Control Sys,0.3,0.55,0.06,0.06,0.0,0.0,0.0,0.03,robin radtke,ACCT-4100,2019
-ACCT,4150,1.0,Auditing,0.37,0.46,0.17,0.0,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-4150,2019
-ACCT,4150,2.0,Auditing,0.26,0.29,0.35,0.1,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-4150,2019
-ACCT,8510,1.0,Tax Research,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,ACCT-8510,2019
-ACCT,8530,1.0,Adv Acct Problems,0.5,0.41,0.06,0.0,0.0,0.0,0.0,0.03,suzanne pearse,ACCT-8530,2019
-ACCT,8530,2.0,Adv Acct Problems,0.45,0.42,0.12,0.0,0.0,0.0,0.0,0.0,suzanne pearse,ACCT-8530,2019
-ACCT,8530,3.0,Adv Acct Problems,0.43,0.33,0.17,0.0,0.07,0.0,0.0,0.0,ralph edward welton,ACCT-8530,2019
-ACCT,8550,1.0,Gov't and Nonprofit Accounting,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2019
-ACCT,8550,2.0,Gov't and Nonprofit Accounting,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2019
-ACCT,8550,3.0,Gov't and Nonprofit Accounting,0.52,0.42,0.06,0.0,0.0,0.0,0.0,0.0,james barnes,ACCT-8550,2019
-ACCT,8630,1.0,Forensics Analysis,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,brian matthew goodson,ACCT-8630,2019
-ACCT,8630,2.0,Forensics Analysis,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,brian matthew goodson,ACCT-8630,2019
-ACCT,8650,1.0,Tax & Bus Decisions,0.25,0.72,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,ACCT-8650,2019
-ACCT,8650,2.0,Tax & Bus Decisions,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,ACCT-8650,2019
-ACCT,8720,1.0,Tax of Flowthroughs,0.21,0.56,0.18,0.0,0.03,0.0,0.0,0.03,thomas dickens,ACCT-8720,2019
-AGED,1020,1.0,Freshman Seminar,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,AGED-1020,2019
-AGED,2000,1.0,Agr Appl of Ed Tech,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,kevin layfield,AGED-2000,2019
-AGED,2010,1.0,Intro to Agric Educ,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,AGED-2010,2019
-AGED,3030,1.0,Ag Ed Mech Tech,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-3030,2019
-AGED,4010,1.0,Instr Methods Ag Ed,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,AGED-4010,2019
-AGED,4030,1.0,Prin Adult/Ext Ed,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-4030,2019
-AGED,4230,400.0,Curriculum,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,AGED-4230,2019
-AGM,1010,1.0,Intro Ag Mech & Bus,0.6,0.2,0.09,0.06,0.03,0.0,0.0,0.03,hunter massey,AGM-1010,2019
-AGM,1010,1.0,Intro Ag Mech & Bus,0.6,0.2,0.09,0.06,0.03,0.0,0.0,0.03,hunter massey,AGM-1010,2019
-AGM,2050,1.0,Prin of Fabrication,0.23,0.54,0.19,0.02,0.0,0.0,0.0,0.02,hunter massey,AGM-2050,2019
-AGM,2050,1.0,Prin of Fabrication,0.23,0.54,0.19,0.02,0.0,0.0,0.0,0.02,hunter massey,AGM-2050,2019
-AGM,2060,1.0,Machinery Mgt,0.23,0.46,0.15,0.08,0.08,0.0,0.0,0.0,hunter massey,AGM-2060,2019
-AGM,2060,1.0,Machinery Mgt,0.23,0.46,0.15,0.08,0.08,0.0,0.0,0.0,hunter massey,AGM-2060,2019
-AGM,2210,1.0,Land Measurements,0.5,0.38,0.09,0.01,0.01,0.0,0.0,0.0,charles privette,AGM-2210,2019
-AGM,3010,1.0,Soil Water Conserv,0.63,0.18,0.18,0.0,0.0,0.0,0.0,0.0,calvin sawyer,AGM-3010,2019
-AGM,4000,1.0,Seminar in Ag Mech & Business,0.28,0.63,0.08,0.0,0.0,0.0,0.0,0.03,john chastain,AGM-4000,2019
-AGM,4020,1.0,Irrigation System Design,0.44,0.46,0.08,0.0,0.03,0.0,0.0,0.0,charles privette,AGM-4020,2019
-AGM,4050,1.0,Env Cont in Anim Str,0.32,0.59,0.08,0.0,0.0,0.0,0.0,0.0,john chastain,AGM-4050,2019
-AGM,4060,1.0,Mech & Hydraulic Sys,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4060,2019
-AGM,4520,1.0,Mobile Power,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,ali bulent koc,AGM-4520,2019
-AGM,4600,1.0,Electrical Systems,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,young jo han,AGM-4600,2019
-AGM,4730,4.0,Ag Safety,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hunter massey,AGM-4730,2019
-AGM,4730,4.0,Ag Safety,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hunter massey,AGM-4730,2019
-AGRB,2020,1.0,Agricultural Economics,0.63,0.26,0.08,0.01,0.01,0.0,0.0,0.01,julie carl pingol ureta,AGRB-2020,2019
-AGRB,2050,1.0,Agriculture and Society,0.14,0.27,0.37,0.17,0.03,0.0,0.0,0.01,michael vassalos,AGRB-2050,2019
-AGRB,3020,1.0,Economics of Farm Management,0.12,0.2,0.31,0.27,0.04,0.0,0.0,0.05,michael vassalos,AGRB-3020,2019
-AGRB,3080,1.0,Quant Agribusiness Analysis I,0.31,0.31,0.31,0.08,0.0,0.0,0.0,0.0,david brian willis,AGRB-3080,2019
-AGRB,3090,1.0,Econ of Agricultural Marketing,0.73,0.2,0.03,0.0,0.01,0.0,0.0,0.03,yuliya valentinovna bolotova,AGRB-3090,2019
-AGRB,3570,1.0,Natural Resources Economics,0.23,0.23,0.26,0.09,0.09,0.0,0.0,0.09,david brian willis,AGRB-3570,2019
-AGRB,4090,1.0,Commodity Futures Markets,0.24,0.48,0.26,0.02,0.0,0.0,0.0,0.0,david baird montgomery,AGRB-4090,2019
-AGRB,4120,1.0,Reg Econ Devel Theory & Policy,0.32,0.32,0.14,0.2,0.02,0.0,0.0,0.0,felipe de figueiredo silva,AGRB-4120,2019
-AGRB,4520,1.0,Agricultural Policy,0.17,0.44,0.31,0.08,0.0,0.0,0.0,0.0,michael vassalos,AGRB-4520,2019
-AGRB,4900,1.0,Special Topics,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael vassalos,AGRB-4900,2019
-AGRB,4910,1.0,"Int, Agrib & Comm & Rural Dev",0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,michael vassalos,AGRB-4910,2019
-AL,3440,400.0,Athletics and Women,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,misty soles,AL-3440,2019
-AL,3490,400.0,Principles of Coaching,0.56,0.24,0.08,0.04,0.0,0.0,0.0,0.08,deborah jo cadorette,AL-3490,2019
-AL,3490,401.0,Principles of Coaching,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,AL-3490,2019
-AL,3490,402.0,Principles of Coaching,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,john plumblee,AL-3490,2019
-AL,3490,403.0,Principles of Coaching,0.52,0.24,0.08,0.04,0.04,0.0,0.0,0.08,clyde keith connor,AL-3490,2019
-AL,3490,404.0,Principles of Coaching,0.48,0.36,0.12,0.0,0.04,0.0,0.0,0.0,john plumblee,AL-3490,2019
-AL,3490,405.0,Principles of Coaching,0.64,0.24,0.04,0.0,0.04,0.0,0.0,0.04,frank mezzanotte,AL-3490,2019
-AL,3490,406.0,Principles of Coaching,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,edmond fry,AL-3490,2019
-AL,3490,407.0,Principles of Coaching,0.64,0.24,0.08,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,AL-3490,2019
-AL,3490,408.0,Principles of Coaching,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,nicholas philip edward whitrow,AL-3490,2019
-AL,3490,409.0,Principles of Coaching,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,nicholas philip edward whitrow,AL-3490,2019
-AL,3490,410.0,Principles of Coaching,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,nicholas philip edward whitrow,AL-3490,2019
-AL,3490,411.0,Principles of Coaching,0.5,0.29,0.17,0.0,0.0,0.0,0.0,0.04,joel neuder,AL-3490,2019
-AL,3500,400.0,Sci Basis I/Ex Phy,0.12,0.54,0.12,0.19,0.0,0.0,0.0,0.04,michael godfrey,AL-3500,2019
-AL,3500,401.0,Sci Basis I/Ex Phy,0.32,0.09,0.23,0.18,0.09,0.0,0.0,0.09,michael godfrey,AL-3500,2019
-AL,3530,400.0,Athletic Injuries,0.32,0.2,0.16,0.12,0.12,0.0,0.0,0.08,isaac sean colbert,AL-3530,2019
-AL,3530,401.0,Athletic Injuries,0.26,0.3,0.3,0.13,0.0,0.0,0.0,0.0,isaac sean colbert,AL-3530,2019
-AL,3600,400.0,Hgh Sch Athl Ethical/Legal Iss,0.29,0.46,0.08,0.17,0.0,0.0,0.0,0.0,clyde keith connor,AL-3600,2019
-AL,3610,400.0,Admin/Org of Athletic Programs,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2019
-AL,3610,401.0,Admin/Org of Athletic Programs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2019
-AL,3620,400.0,Psychology of Coaching,0.31,0.12,0.35,0.12,0.04,0.0,0.0,0.08,natalie anne carter,AL-3620,2019
-AL,3620,401.0,Psychology of Coaching,0.32,0.36,0.2,0.04,0.0,0.0,0.0,0.08,natalie anne carter,AL-3620,2019
-AL,3620,402.0,Psychology of Coaching,0.33,0.17,0.38,0.08,0.04,0.0,0.0,0.0,natalie anne carter,AL-3620,2019
-AL,3740,400.0,Coaching Football,0.77,0.09,0.05,0.05,0.0,0.0,0.0,0.05,edmond fry,AL-3740,2019
-AL,3740,401.0,Coaching Football,0.5,0.23,0.05,0.09,0.05,0.0,0.0,0.09,edmond fry,AL-3740,2019
-AL,3760,400.0,Coaching Strength/Conditioning,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,edmond fry,AL-3760,2019
-AL,3760,401.0,Coaching Strength/Conditioning,0.68,0.08,0.08,0.0,0.04,0.0,0.0,0.12,edmond fry,AL-3760,2019
-AL,4380,402.0,HS Athletic Recruiting,0.57,0.14,0.11,0.0,0.04,0.0,0.0,0.14,deborah jo cadorette,AL-4380,2019
-AL,4380,403.0,Media Relations in AL,0.74,0.07,0.15,0.0,0.04,0.0,0.0,0.0,misty soles,AL-4380,2019
-AL,4380,408.0,Officiating in AL,0.63,0.17,0.04,0.04,0.0,0.0,0.0,0.13,clyde keith connor,AL-4380,2019
-AL,4380,409.0,Coaching Baseball/Softball,0.58,0.17,0.13,0.04,0.0,0.0,0.0,0.08,deborah jo cadorette,AL-4380,2019
-AL,4490,400.0,Athlete Beliefs,0.42,0.42,0.13,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,AL-4490,2019
-AL,8380,400.0,Compliance in Intercoll Athl,0.8,0.05,0.0,0.0,0.05,0.0,0.0,0.1,michael godfrey,AL-8380,2019
-AL,8380,401.0,Compliance in Colleg Athl,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8380,2019
-AL,8440,400.0,Surv of Res Mthds in Athletics,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8440,2019
-AL,8440,401.0,Surv of Res Mthds in Athletics,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8440,2019
-AL,8440,402.0,Surv of Res Mthds in Athletics,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8440,2019
-AL,8490,400.0,Athletic Leadership Dev,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,janna theresa magette,AL-8490,2019
-AL,8490,401.0,Athletic Leadership Dev,0.76,0.1,0.1,0.0,0.0,0.0,0.0,0.05,janna theresa magette,AL-8490,2019
-AL,8490,402.0,Athletic Leadership Dev,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,janna theresa magette,AL-8490,2019
-AL,8500,400.0,Principles Strength and Condit,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8500,2019
-AL,8500,401.0,Principles Strength and Condit,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,michael godfrey,AL-8500,2019
-AL,8650,400.0,Mkt and Comm Respon Interc Ath,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,AL-8650,2019
-AL,8650,402.0,Mkt and Comm Respon Interc Ath,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,AL-8650,2019
-AMFG,6800,864.0,Practicum in Adv Manufacturing,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua summers,AMFG-6800,2019
-ANTH,2010,1.0,Introduction to Anthropology,0.49,0.31,0.12,0.02,0.0,0.0,0.0,0.06,yi wu,ANTH-2010,2019
-ANTH,2010,2.0,Introduction to Anthropology,0.42,0.29,0.18,0.0,0.02,0.0,0.0,0.09,lisa rapaport,ANTH-2010,2019
-ANTH,2010,3.0,Introduction to Anthropology,0.3,0.6,0.09,0.0,0.0,0.0,0.0,0.02,david markus,ANTH-2010,2019
-ANTH,2010,4.0,Introduction to Anthropology,0.36,0.54,0.07,0.01,0.02,0.0,0.0,0.02,david markus,ANTH-2010,2019
-ANTH,2010,5.0,Introduction to Anthropology,0.41,0.39,0.13,0.04,0.0,0.0,0.0,0.02,yi wu,ANTH-2010,2019
-ANTH,3320,1.0,World Archaeology,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,david markus,ANTH-3320,2019
-ANTH,3510,1.0,Biological Anthropology,0.48,0.43,0.05,0.0,0.05,0.0,0.0,0.0,lisa rapaport,ANTH-3510,2019
-ANTH,3530,1.0,Forensic Anthropology,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,katherine weisensee,ANTH-3530,2019
-ANTH,3710,1.0,Language and Culture,0.44,0.44,0.0,0.11,0.0,0.0,0.0,0.0,yanhua zhang,ANTH-3710,2019
-ANTH,4230,1.0,Women in the Developing World,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,ANTH-4230,2019
-ANTH,4990,1.0,"Religion, Magic, Witchcraft",0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,carolyn candace coffman,ANTH-4990,2019
-ARCH,1010,1.0,Introduction to Architecture,0.44,0.35,0.08,0.03,0.03,0.0,0.0,0.07,sallie rebecca hambright-belue,ARCH-1010,2019
-ARCH,2040,1.0,Hist of Modern Arch,0.42,0.48,0.07,0.02,0.0,0.0,0.0,0.01,andreea mihalache,ARCH-2040,2019
-ARCH,2510,1.0,Arch Foundations I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-2510,2019
-ARCH,2510,2.0,Arch Foundations I,0.53,0.35,0.12,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-2510,2019
-ARCH,2510,3.0,Arch Foundations I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,dustin graham albright,ARCH-2510,2019
-ARCH,2510,5.0,Arch Foundations I,0.28,0.28,0.39,0.06,0.0,0.0,0.0,0.0,brandon george pass,ARCH-2510,2019
-ARCH,2510,6.0,Arch Foundations I,0.28,0.39,0.28,0.06,0.0,0.0,0.0,0.0,virginia ellyn melnyk,ARCH-2510,2019
-ARCH,2700,1.0,Structures I,0.59,0.34,0.03,0.0,0.03,0.0,0.0,0.0,dustin graham albright,ARCH-2700,2019
-ARCH,3500,2.0,Intro to Urban Contexts,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-3500,2019
-ARCH,3500,3.0,Intro to Urban Contexts,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-3500,2019
-ARCH,3500,4.0,Intro to Urban Contexts,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-3500,2019
-ARCH,3500,5.0,Intro to Urban Contexts,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-3500,2019
-ARCH,3510,1.0,Studio Clemson,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,ufuk ersoy,ARCH-3510,2019
-ARCH,3510,3.0,Studio Clemson,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michael carlos barrios kleiss,ARCH-3510,2019
-ARCH,3530,1.0,Studio Genoa,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-3530,2019
-ARCH,3540,1.0,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-3540,2019
-ARCH,4010,1.0,Architectural Portfolio,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,virginia ellyn melnyk,ARCH-4010,2019
-ARCH,4010,2.0,Architectural Portfolio,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-4010,2019
-ARCH,4010,3.0,Architectural Portfolio,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4010,2019
-ARCH,4010,4.0,Architectural Portfolio,0.44,0.33,0.17,0.0,0.06,0.0,0.0,0.0,brandon george pass,ARCH-4010,2019
-ARCH,4120,1.0,History Research,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-4120,2019
-ARCH,4140,1.0,Design Seminar,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-4140,2019
-ARCH,4520,1.0,Synthesis Studio,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,ARCH-4520,2019
-ARCH,4710,1.0,Arch Hist of Place,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,jason matthew white,ARCH-4710,2019
-ARCH,6850,1.0,H/Th: Arch+Health,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-6850,2019
-ARCH,8100,1.0,Visualization I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,andreea mihalache,ARCH-8100,2019
-ARCH,8200,1.0,Bldg Design & Constr,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,tori elizabeth wallace-babcock,ARCH-8200,2019
-ARCH,8210,1.0,Research Methods,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,ARCH-8210,2019
-ARCH,8410,1.0,Arch Studio I,0.6,0.0,0.2,0.0,0.0,0.0,0.0,0.2,peter laurence,ARCH-8410,2019
-ARCH,8510,3.0,Design Studio III,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-8510,2019
-ARCH,8600,1.0,History/Theory I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,berrin terim,ARCH-8600,2019
-ARCH,8720,1.0,Production & Assemb,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,ARCH-8720,2019
-ARCH,8970,1.0,A+H Studio: Hospital,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david allison,ARCH-8970,2019
-ART,1050,1.0,Foundation Drawing I,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,denise elizabeth ayers,ART-1050,2019
-ART,1510,1.0,Foundations Art I,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,rachel lynn de cuba,ART-1510,2019
-ART,1520,1.0,Foundations Art II,0.4,0.3,0.0,0.1,0.1,0.0,0.0,0.1,daniel bare,ART-1520,2019
-ART,2070,1.0,Beginning Painting,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,serra raven shuford,ART-2070,2019
-ART,2090,1.0,Beginning Sculpture,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,jordan alexander fowler,ART-2090,2019
-ART,2100,1.0,Art Appreciation,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,dustin massey,ART-2100,2019
-ART,2100,2.0,Art Appreciation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,dustin massey,ART-2100,2019
-ART,2100,3.0,Art Appreciation,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,mark norman brosseau,ART-2100,2019
-ART,2100,5.0,Art Appreciation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,joseph richard manson ,ART-2100,2019
-ART,2100,6.0,Art Appreciation,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,annamarie elizabeth williams,ART-2100,2019
-ART,2130,1.0,Begin Photography,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,haley brooke floyd,ART-2130,2019
-ART,2170,1.0,Beginning Ceramics,0.23,0.54,0.08,0.0,0.08,0.0,0.0,0.08,sara mays,ART-2170,2019
-AS,1090,2.0,Air Force Today I,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,joseph michael blanton,AS-1090,2019
-AS,1090,3.0,Air Force Today I,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,joseph michael blanton,AS-1090,2019
-AS,3090,1.0,A F Leadership Mgt I,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,rachelle marie miller,AS-3090,2019
-AS,3090,2.0,A F Leadership Mgt I,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,rachelle marie miller,AS-3090,2019
-AS,4090,1.0,Nat Sec Policy I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4090,2019
-AS,4090,2.0,Nat Sec Policy I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4090,2019
-ASL,1010,2.0,Am Sign Lang I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-1010,2019
-ASL,1010,5.0,Am Sign Lang I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-1010,2019
-ASL,1020,1.0,Am Sign Lang I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william ryals clements,ASL-1020,2019
-ASL,1020,2.0,Am Sign Lang I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,william ryals clements,ASL-1020,2019
-ASL,1020,3.0,Am Sign Lang I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-1020,2019
-ASL,2010,1.0,Am Sign Lang II,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,kim marlene misener dunn,ASL-2010,2019
-ASL,2010,2.0,Am Sign Lang II,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,kim marlene misener dunn,ASL-2010,2019
-ASL,2010,3.0,Am Sign Lang II,0.8,0.15,0.0,0.05,0.0,0.0,0.0,0.0,kim marlene misener dunn,ASL-2010,2019
-ASL,2020,1.0,Am Sign Lang II,0.63,0.16,0.21,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-2020,2019
-ASL,3010,1.0,Advanced A S L I,0.53,0.21,0.05,0.0,0.0,0.0,0.0,0.21,kim marlene misener dunn,ASL-3010,2019
-ASL,3150,1.0,Survey Interpreting,0.1,0.7,0.0,0.1,0.0,0.0,0.0,0.1,stephen benjamin fitzmaurice,ASL-3150,2019
-ASL,4700,1.0,Dev Sign Lang for Deaf Childrn,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,jody herbert cripps,ASL-4700,2019
-ASTR,1010,1.0,Solar System Astronomy,0.29,0.42,0.22,0.05,0.02,0.0,0.0,0.01,marco ajello,ASTR-1010,2019
-ASTR,1010,2.0,Solar System Astronomy,0.24,0.46,0.23,0.04,0.02,0.0,0.0,0.01,marco ajello,ASTR-1010,2019
-ASTR,1020,1.0,Stellar Astronomy,0.45,0.29,0.11,0.06,0.03,0.0,0.0,0.06,mark leising,ASTR-1020,2019
-ASTR,1030,1.0,Solar Systm Astr Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,david edward connick,ASTR-1030,2019
-ASTR,1030,2.0,Solar Systm Astr Lab,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.0,david edward connick,ASTR-1030,2019
-ASTR,1030,3.0,Solar Systm Astr Lab,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,david edward connick,ASTR-1030,2019
-ASTR,1030,4.0,Solar Systm Astr Lab,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,david edward connick,ASTR-1030,2019
-ASTR,1030,6.0,Solar Systm Astr Lab,0.46,0.46,0.0,0.0,0.08,0.0,0.0,0.0,david edward connick,ASTR-1030,2019
-ASTR,1030,7.0,Solar Systm Astr Lab,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,david edward connick,ASTR-1030,2019
-ASTR,1030,8.0,Solar Systm Astr Lab,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,david edward connick,ASTR-1030,2019
-ASTR,1030,9.0,Solar Systm Astr Lab,0.48,0.43,0.04,0.0,0.0,0.0,0.0,0.04,david edward connick,ASTR-1030,2019
-ASTR,1030,10.0,Solar Systm Astr Lab,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,david edward connick,ASTR-1030,2019
-ASTR,1040,1.0,Stellar Astr Lab,0.46,0.33,0.04,0.04,0.0,0.0,0.0,0.13,david edward connick,ASTR-1040,2019
-ASTR,1040,2.0,Stellar Astr Lab,0.35,0.48,0.09,0.04,0.0,0.0,0.0,0.04,david edward connick,ASTR-1040,2019
-ASTR,1040,4.0,Stellar Astr Lab,0.48,0.26,0.22,0.0,0.0,0.0,0.0,0.04,david edward connick,ASTR-1040,2019
-ASTR,8100,1.0,Astroph I: Radiation,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,ASTR-8100,2019
-ASTR,8750,1.0,Astronomy Seminar,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,marco ajello,ASTR-8750,2019
-AUD,2800,1.0,Sound Reinforcement,0.0,0.8,0.2,0.0,0.0,0.0,0.0,0.0,kenneth moore,AUD-2800,2019
-AUD,3800,1.0,Audio Engineering I,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-3800,2019
-AUE,6010,1.0,Vehicle Dynamics,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,AUE-6010,2019
-AUE,8190,100.0,Adv Int Combustion Engine Conc,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-8190,2019
-AUE,8260,1.0,Vehicle Diagnostics,0.5,0.13,0.38,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,AUE-8260,2019
-AUE,8270,5.0,Auto Cntrl Sys Des,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8270,2019
-AUE,8330,30.0,Auto Manuf Proc Devl,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,AUE-8330,2019
-AUE,8350,100.0,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,yunyi jia,AUE-8350,2019
-AUE,8670,1.0,Veh Manuf Proc I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,AUE-8670,2019
-AUE,8800,2.0,Vehicle Project Mngt,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,johnell brooks,AUE-8800,2019
-AUE,8810,3.0,Automotive Systems Overview,0.54,0.39,0.02,0.0,0.04,0.0,0.0,0.02,christiaan jos jan paredis,AUE-8810,2019
-AUE,8870,8.0,Meth Vehicle Testing,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,AUE-8870,2019
-AVS,1000,1.0,Orientation to AVS,0.66,0.21,0.02,0.02,0.03,0.0,0.0,0.06,kristine lang vernon,AVS-1000,2019
-AVS,1500,1.0,Intro Animal Science,0.28,0.28,0.28,0.08,0.03,0.0,0.0,0.07,joseph keith bertrand,AVS-1500,2019
-AVS,1500,2.0,Intro Animal Science,0.21,0.32,0.24,0.09,0.09,0.0,0.0,0.06,joseph keith bertrand,AVS-1500,2019
-AVS,1510,1.0,Intro Ani Sci Lab,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,AVS-1510,2019
-AVS,1510,2.0,Intro Ani Sci Lab,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,AVS-1510,2019
-AVS,1510,3.0,Intro Ani Sci Lab,0.36,0.56,0.0,0.0,0.0,0.0,0.0,0.08,richelle lorraine miller,AVS-1510,2019
-AVS,1510,5.0,Intro Ani Sci Lab,0.62,0.35,0.04,0.0,0.0,0.0,0.0,0.0,chelsea drumwright sinclair,AVS-1510,2019
-AVS,1510,6.0,Intro Ani Sci Lab,0.69,0.15,0.12,0.0,0.04,0.0,0.0,0.0,chelsea drumwright sinclair,AVS-1510,2019
-AVS,1510,7.0,Intro Ani Sci Lab,0.73,0.19,0.04,0.0,0.0,0.0,0.0,0.04,richelle lorraine miller,AVS-1510,2019
-AVS,1510,8.0,Intro Ani Sci Lab,0.56,0.36,0.0,0.0,0.0,0.0,0.0,0.08,chelsea drumwright sinclair,AVS-1510,2019
-AVS,2040,1.0,Horse Care Techniques,0.72,0.18,0.1,0.0,0.0,0.0,0.0,0.0,chelsea drumwright sinclair,AVS-2040,2019
-AVS,2110,1.0,Meat Processing Techniques,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,richelle lorraine miller,AVS-2110,2019
-AVS,3010,1.0,Anat & Phys Dom Ani,0.58,0.23,0.16,0.03,0.0,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2019
-AVS,3010,400.0,Anat & Phys Dom Ani,0.46,0.32,0.11,0.08,0.03,0.0,0.0,0.0,glenn birrenkott,AVS-3010,2019
-AVS,3020,1.0,Livestk Sel Eval I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,AVS-3020,2019
-AVS,3100,1.0,Animal Health,0.58,0.34,0.06,0.0,0.02,0.0,0.0,0.0,celina marcela checura,AVS-3100,2019
-AVS,3700,1.0,Principles of Animal Nutrition,0.67,0.18,0.09,0.02,0.0,0.0,0.0,0.05,james robert strickland,AVS-3700,2019
-AVS,3750,1.0,Applied Animal Nutrition,0.13,0.47,0.27,0.07,0.0,0.0,0.0,0.07,gustavo jose lascano,AVS-3750,2019
-AVS,4100,1.0,Domestic Ani Behav,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,ahmed badr abdelwahab ali,AVS-4100,2019
-AVS,4110,1.0,Animal Growth and Development,0.34,0.36,0.14,0.05,0.06,0.0,0.0,0.05,susan kay duckett,AVS-4110,2019
-AVS,4150,1.0,Contemporary Issues in AVS,0.79,0.12,0.04,0.01,0.01,0.0,0.0,0.01,heather walker dunn,AVS-4150,2019
-AVS,4160,1.0,Equine Exercise Phys,0.43,0.21,0.29,0.07,0.0,0.0,0.0,0.0,kristine lang vernon,AVS-4160,2019
-AVS,4500,1.0,Sustain Livestock Product Sys,0.18,0.45,0.18,0.0,0.09,0.0,0.0,0.09,matias jose aguerre,AVS-4500,2019
-AVS,4530,1.0,Animal Reproduction,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,tiffany wilmoth,AVS-4530,2019
-AVS,4650,1.0,Animal Physiology I,0.33,0.41,0.18,0.05,0.0,0.0,0.0,0.03,celina marcela checura,AVS-4650,2019
-AVS,4800,1.0,Vertebrate Endocrinology,0.36,0.58,0.06,0.0,0.0,0.0,0.0,0.0,heather walker dunn,AVS-4800,2019
-AVS,4920,1.0,Advanced Fetal Fescue Research,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,susan kay duckett,AVS-4920,2019
-AVS,4920,2.0,Bioinformatics Cancer Gen,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,heather walker dunn,AVS-4920,2019
-AVS,8010,3.0,Principles Scientific Writing,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,jeryl jones,AVS-8010,2019
-BCHM,1030,1.0,Careers in Bioch/Gen,0.85,0.09,0.02,0.02,0.02,0.0,0.0,0.0,joseph paul thames,BCHM-1030,2019
-BCHM,3010,1.0,Molecular Biochemistry,0.32,0.15,0.26,0.09,0.11,0.0,0.0,0.09,cheryl jean ingram-smith,BCHM-3010,2019
-BCHM,3050,1.0,Essen Elements Bioch,0.22,0.37,0.22,0.12,0.04,0.0,0.0,0.04,debra ragland,BCHM-3050,2019
-BCHM,3050,2.0,Essen Elements Bioch,0.22,0.35,0.31,0.07,0.01,0.0,0.0,0.03,debra ragland,BCHM-3050,2019
-BCHM,4310,1.0,Physical Approach to Biochem,0.28,0.39,0.28,0.01,0.03,0.0,0.0,0.0,weiguo cao,BCHM-4310,2019
-BCHM,4330,2.0,Physical Biochemistry Lab,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,geoffrey ford,BCHM-4330,2019
-BCHM,4400,1.0,Bioinformatics,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,frank alexander feltus,BCHM-4400,2019
-BCHM,4430,1.0,Molecular Basis of Disease,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,james morris,BCHM-4430,2019
-BCHM,4910,27.0,CI-CU INVESTORS,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,meredith teilhet morris,BCHM-4910,2019
-BCHM,4910,32.0,CI-DNA Repair (HON),0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael glen sehorn,BCHM-4910,2019
-BCHM,4930,2.0,Senior Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,BCHM-4930,2019
-BCHM,4930,5.0,Senior Seminar,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,BCHM-4930,2019
-BCHM,8140,1.0,Advanced Biochemistry,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,meredith teilhet morris,BCHM-8140,2019
-BE,2100,1.0,Intro to Biosystems Engr,0.76,0.12,0.08,0.0,0.0,0.0,0.0,0.04,jazmine octavia taylor,BE-2100,2019
-BE,3200,1.0,Principles & Prac of Geomatics,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,tom owino,BE-3200,2019
-BE,4100,1.0,Biological Kinetics,0.21,0.43,0.29,0.07,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4100,2019
-BE,4210,1.0,Engr Sys for Soil Water Mgt,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,christophe darnault,BE-4210,2019
-BE,4280,1.0,Biochem Engr,0.4,0.4,0.1,0.1,0.0,0.0,0.0,0.0,terry walker,BE-4280,2019
-BE,4740,1.0,BE Design Project Managment,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,BE-4740,2019
-BE,4750,1.0,BE Capstone Design,0.77,0.0,0.23,0.0,0.0,0.0,0.0,0.0,christophe darnault,BE-4750,2019
-BIOE,1010,1.0,Biol for Bioengr,0.69,0.15,0.08,0.0,0.0,0.0,0.0,0.08,tyler george harvey,BIOE-1010,2019
-BIOE,2010,2.0,Intro Biomed Engr,0.47,0.34,0.13,0.03,0.01,0.0,0.0,0.02,charles webb,BIOE-2010,2019
-BIOE,3020,1.0,Biomaterials,0.69,0.23,0.04,0.02,0.0,0.0,0.0,0.02,alexey alexandrovich vertegel,BIOE-3020,2019
-BIOE,3100,1.0,Engr Analysis of Physiol Proc,0.79,0.16,0.03,0.03,0.0,0.0,0.0,0.0,brian william booth,BIOE-3100,2019
-BIOE,3200,1.0,Biomechanics,0.49,0.41,0.06,0.01,0.01,0.0,0.0,0.01,jiro nagatomi,BIOE-3200,2019
-BIOE,3210,1.0,Biofluid Mechanics,0.53,0.33,0.1,0.0,0.0,0.0,0.0,0.03,zhi gao,BIOE-3210,2019
-BIOE,3470,1.0,Transport Processes in Bioengr,0.63,0.26,0.08,0.03,0.01,0.0,0.0,0.0,renee nicole cottle,BIOE-3470,2019
-BIOE,3700,1.0,Bioinst & Imaging,0.57,0.33,0.09,0.0,0.0,0.0,0.0,0.02,delphine dean,BIOE-3700,2019
-BIOE,4010,2.0,Bioengineering Design Theory,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,BIOE-4010,2019
-BIOE,4030,1.0,Applied Bio E Design,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ravikiran bhaskar singapogu,BIOE-4030,2019
-BIOE,4120,1.0,Orthopaedic Engr and Pathology,0.6,0.35,0.02,0.0,0.0,0.0,0.0,0.02,melinda harman,BIOE-4120,2019
-BIOE,4400,1.0,Biopharmaceutical Engineering,0.26,0.47,0.05,0.0,0.05,0.0,0.0,0.16,sarah harcum,BIOE-4400,2019
-BIOE,4480,1.0,Tissue Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,angela antoinette alexander,BIOE-4480,2019
-BIOE,4510,31.0,CI-Med Design with Arusha Tz,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,delphine dean,BIOE-4510,2019
-BIOE,6120,1.0,Orthopaedic Engr & Pathology,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,melinda harman,BIOE-6120,2019
-BIOE,6350,1.0,Computational Modeling in BIOE,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,BIOE-6350,2019
-BIOE,6400,1.0,Biopharmaceutical Engineering,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,sarah harcum,BIOE-6400,2019
-BIOE,8010,1.0,Bio Materials,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert latour,BIOE-8010,2019
-BIOE,8160,1.0,BioE Professional Development,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,martine laberge,BIOE-8160,2019
-BIOE,8160,843.0,BioE Professional Development,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jeremy gilbert,BIOE-8160,2019
-BIOL,1010,1.0,Frontiers in Biology I,0.8,0.14,0.05,0.0,0.0,0.0,0.0,0.01,michael childress,BIOL-1010,2019
-BIOL,1010,2.0,Frontiers in Biology I,0.83,0.13,0.02,0.0,0.01,0.0,0.0,0.01,michael childress,BIOL-1010,2019
-BIOL,1030,1.0,General Biology I,0.24,0.29,0.27,0.1,0.04,0.0,0.0,0.06,nora espinoza,BIOL-1030,2019
-BIOL,1030,2.0,General Biology I,0.26,0.24,0.17,0.18,0.04,0.0,0.0,0.12,nathan redding,BIOL-1030,2019
-BIOL,1030,3.0,General Biology I,0.23,0.33,0.24,0.07,0.04,0.0,0.0,0.09,wen chen,BIOL-1030,2019
-BIOL,1030,4.0,General Biology I,0.15,0.26,0.35,0.1,0.04,0.0,0.0,0.11,salvatore sparace,BIOL-1030,2019
-BIOL,1030,5.0,General Biology I (HON),0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,nora espinoza,BIOL-1030,2019
-BIOL,1050,1.0,General Biology Lab I,0.0,0.22,0.43,0.22,0.04,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,2.0,General Biology Lab I,0.0,0.17,0.38,0.13,0.08,0.0,0.0,0.25,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,3.0,General Biology Lab I,0.0,0.38,0.17,0.21,0.0,0.0,0.0,0.25,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,4.0,General Biology Lab I,0.0,0.13,0.38,0.29,0.08,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,5.0,General Biology Lab I,0.0,0.29,0.29,0.29,0.13,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,6.0,General Biology Lab I,0.0,0.25,0.54,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,7.0,General Biology Lab I,0.0,0.27,0.23,0.36,0.0,0.0,0.0,0.14,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,8.0,General Biology Lab I,0.0,0.17,0.43,0.13,0.0,0.0,0.0,0.26,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,9.0,General Biology Lab I,0.0,0.17,0.46,0.13,0.08,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,10.0,General Biology Lab I,0.0,0.13,0.43,0.17,0.13,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,11.0,General Biology Lab I,0.0,0.09,0.43,0.26,0.0,0.0,0.0,0.22,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,12.0,General Biology Lab I,0.04,0.25,0.25,0.29,0.0,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,13.0,General Biology Lab I,0.0,0.17,0.42,0.17,0.13,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,14.0,General Biology Lab I,0.0,0.13,0.42,0.25,0.04,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,15.0,General Biology Lab I,0.0,0.13,0.33,0.17,0.13,0.0,0.0,0.25,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,16.0,General Biology Lab I,0.0,0.42,0.46,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,17.0,General Biology Lab I,0.0,0.13,0.5,0.25,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,18.0,General Biology Lab I,0.0,0.13,0.42,0.38,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,19.0,General Biology Lab I,0.04,0.38,0.25,0.17,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,20.0,General Biology Lab I,0.0,0.25,0.5,0.17,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,21.0,General Biology Lab I,0.0,0.21,0.42,0.21,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,22.0,General Biology Lab I,0.0,0.13,0.54,0.17,0.13,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,23.0,General Biology Lab I,0.0,0.09,0.3,0.35,0.17,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,24.0,General Biology Lab I,0.0,0.26,0.39,0.22,0.0,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,25.0,General Biology Lab I,0.0,0.26,0.52,0.04,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,27.0,General Biology Lab I,0.04,0.33,0.46,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,28.0,General Biology Lab I,0.04,0.13,0.42,0.33,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,29.0,General Biology Lab I,0.08,0.29,0.42,0.0,0.04,0.0,0.0,0.17,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,30.0,General Biology Lab I,0.04,0.13,0.63,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,32.0,General Biology Lab I,0.0,0.22,0.3,0.22,0.13,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,33.0,General Biology Lab I,0.0,0.1,0.38,0.24,0.14,0.0,0.0,0.14,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,34.0,General Biology Lab I,0.0,0.35,0.35,0.13,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,35.0,General Biology Lab I,0.0,0.17,0.5,0.25,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,36.0,General Biology Lab I,0.0,0.42,0.25,0.13,0.08,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,37.0,General Biology Lab I,0.21,0.29,0.33,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,38.0,General Biology Lab I,0.0,0.04,0.67,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,39.0,General Biology Lab I,0.04,0.38,0.29,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,40.0,General Biology Lab I,0.0,0.5,0.25,0.17,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,41.0,General Biology Lab I,0.04,0.38,0.38,0.13,0.0,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,42.0,General Biology Lab I,0.04,0.29,0.38,0.17,0.04,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,43.0,General Biology Lab I,0.0,0.33,0.29,0.21,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,44.0,General Biology Lab I,0.04,0.25,0.38,0.17,0.04,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,45.0,General Biology Lab I,0.0,0.25,0.33,0.21,0.17,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1050,46.0,General Biology Lab I,0.0,0.33,0.29,0.08,0.17,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1050,2019
-BIOL,1090,1.0,Intro to Life Sci,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,renea chris hardwick,BIOL-1090,2019
-BIOL,1100,1.0,Principles of Biology I,0.43,0.34,0.15,0.02,0.02,0.0,0.0,0.03,renea chris hardwick,BIOL-1100,2019
-BIOL,1100,2.0,Principles of Biology I (HON),0.81,0.18,0.01,0.0,0.0,0.0,0.0,0.0,verna christine  minor,BIOL-1100,2019
-BIOL,1100,3.0,Principles of Biology I,0.27,0.55,0.16,0.02,0.0,0.0,0.0,0.0,verna christine  minor,BIOL-1100,2019
-BIOL,1100,4.0,Principles of Biology I,0.55,0.29,0.1,0.05,0.02,0.0,0.0,0.0,renea chris hardwick,BIOL-1100,2019
-BIOL,2110,1.0,Introduction to Toxicology,0.44,0.44,0.05,0.02,0.02,0.0,0.0,0.02,peter van den hurk,BIOL-2110,2019
-BIOL,2220,1.0,Human Anat and Physiology I,0.23,0.36,0.24,0.08,0.03,0.0,0.0,0.06,john cummings,BIOL-2220,2019
-BIOL,2220,2.0,Human Anat and Physiology I,0.27,0.37,0.2,0.08,0.04,0.0,0.0,0.05,john cummings,BIOL-2220,2019
-BIOL,3030,1.0,Vertebrate Biology,0.5,0.25,0.13,0.06,0.03,0.0,0.0,0.01,virginia ellen abernathy,BIOL-3030,2019
-BIOL,3030,2.0,Vertebrate Biology (HON),0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,virginia ellen abernathy,BIOL-3030,2019
-BIOL,3030,3.0,Vertebrate Biology,0.53,0.29,0.09,0.09,0.0,0.0,0.0,0.0,virginia ellen abernathy,BIOL-3030,2019
-BIOL,3040,1.0,Biology of Plants,0.19,0.29,0.3,0.19,0.01,0.0,0.0,0.03,nathan redding,BIOL-3040,2019
-BIOL,3070,1.0,Vertebrate Biology Lab,0.36,0.56,0.08,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2019
-BIOL,3070,2.0,Vertebrate Biology Lab,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2019
-BIOL,3070,3.0,Vertebrate Biology Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2019
-BIOL,3070,4.0,Vertebrate Biology Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2019
-BIOL,3070,5.0,Vertebrate Biology Lab,0.21,0.71,0.04,0.0,0.0,0.0,0.0,0.04,richard blob,BIOL-3070,2019
-BIOL,3070,6.0,Vertebrate Biology Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2019
-BIOL,3070,7.0,Vertebrate Biology Lab,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2019
-BIOL,3070,8.0,Vertebrate Biology Lab,0.5,0.38,0.08,0.04,0.0,0.0,0.0,0.0,richard blob,BIOL-3070,2019
-BIOL,3070,9.0,Vertebrate Biology Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,richard blob,BIOL-3070,2019
-BIOL,3080,1.0,Biology of Plants Practicum,0.45,0.35,0.1,0.05,0.0,0.0,0.0,0.05,nathan redding,BIOL-3080,2019
-BIOL,3080,3.0,Biology of Plants Practicum,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2019
-BIOL,3080,4.0,Biology of Plants Practicum,0.25,0.42,0.17,0.17,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2019
-BIOL,3080,5.0,Biology of Plants Practicum,0.13,0.53,0.33,0.0,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2019
-BIOL,3080,6.0,Biology of Plants Practicum,0.13,0.44,0.44,0.0,0.0,0.0,0.0,0.0,nathan redding,BIOL-3080,2019
-BIOL,3150,1.0,Functional Human Anatomy,0.26,0.39,0.19,0.08,0.01,0.0,0.0,0.06,tamara mcnutt-scott,BIOL-3150,2019
-BIOL,3200,1.0,Field Botany,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,robert edward ballard,BIOL-3200,2019
-BIOL,3350,1.0,Evolutionary Biology,0.27,0.44,0.21,0.06,0.02,0.0,0.0,0.01,margaret ptacek,BIOL-3350,2019
-BIOL,3510,1.0,Biological Anthropology,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,lisa rapaport,BIOL-3510,2019
-BIOL,3530,1.0,Forensic Anthropology,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,katherine weisensee,BIOL-3530,2019
-BIOL,4030,1.0,Intro to Applied Genomics,0.15,0.08,0.23,0.0,0.0,0.0,0.0,0.54,vincent paul richards,BIOL-4030,2019
-BIOL,4140,1.0,Basic Immunology,0.28,0.22,0.28,0.11,0.0,0.0,0.0,0.11,yanzhang wei,BIOL-4140,2019
-BIOL,4200,1.0,Neurobiology,0.59,0.31,0.03,0.0,0.0,0.0,0.0,0.06,david feliciano,BIOL-4200,2019
-BIOL,4250,1.0,Introductory Mycology,0.39,0.36,0.13,0.05,0.05,0.0,0.0,0.03,julia louise kerrigan,BIOL-4250,2019
-BIOL,4260,1.0,Mycology Practicum,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,julia louise kerrigan,BIOL-4260,2019
-BIOL,4400,1.0,Developmental Animal Biology,0.34,0.22,0.3,0.1,0.02,0.0,0.0,0.02,kara elizabeth powder,BIOL-4400,2019
-BIOL,4410,1.0,Ecology,0.24,0.38,0.19,0.07,0.01,0.0,0.0,0.1,sharon bewick,BIOL-4410,2019
-BIOL,4530,1.0,Integrative Organismal Biology,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,michael sears,BIOL-4530,2019
-BIOL,4560,1.0,Medical and Vet Parasitology,0.59,0.37,0.0,0.02,0.0,0.0,0.0,0.02,wilbur kearse milhous,BIOL-4560,2019
-BIOL,4610,1.0,Cell Biology,0.36,0.37,0.2,0.03,0.01,0.0,0.0,0.03,susan caroline chapman,BIOL-4610,2019
-BIOL,4610,2.0,Cell Biology (HON),0.58,0.33,0.03,0.0,0.0,0.0,0.0,0.06,susan caroline chapman,BIOL-4610,2019
-BIOL,4620,1.0,Cell Biology Lab (Lec),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,2.0,Cell Biology Lab (Lec),0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,3.0,Cell Biology Lab (Lec),0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,4.0,Cell Biology Lab (Lec),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,5.0,Cell Biology Lab (Lec),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,6.0,Cell Biology Lab (Lec),0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,BIOL-4620,2019
-BIOL,4620,7.0,Cell Biology Lab (Lec),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,8.0,Cell Biology Lab (Lec),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4670,1.0,Principles of Hematology,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.03,vincent gallicchio,BIOL-4670,2019
-BIOL,4890,1.0,Clinical Apps and Medical Prac,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,BIOL-4890,2019
-BIOL,4930,2.0,Sr Sem: Current Topic Biology,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,BIOL-4930,2019
-BIOL,4930,5.0,Sr Sem: Biol Adv in Agricultur,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,salvatore sparace,BIOL-4930,2019
-BIOL,4930,6.0,Sr Sem: Emerging Viruses,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,matthew turnbull,BIOL-4930,2019
-BIOL,4930,7.0,Sr Sem: Negl Infect Dis Povert,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4930,2019
-BIOL,6030,1.0,Intro to Applied Genomics,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,vincent paul richards,BIOL-6030,2019
-BIOL,6610,1.0,Cell Biology,0.2,0.2,0.4,0.0,0.2,0.0,0.0,0.0,susan caroline chapman,BIOL-6610,2019
-BIOL,8400,1.0,Understanding Biological Inq,0.92,0.0,0.04,0.0,0.04,0.0,0.0,0.0,michael childress,BIOL-8400,2019
-BIOL,8420,1.0,Understand Cellular Processes,0.89,0.09,0.0,0.0,0.01,0.0,0.0,0.01,kaustubha ratan qanungo,BIOL-8420,2019
-BIOL,8440,1.0,Understanding the Human Body,0.43,0.43,0.11,0.0,0.03,0.0,0.0,0.0,tamara mcnutt-scott,BIOL-8440,2019
-BMOL,4250,1.0,Biomolecular Engineering,0.23,0.43,0.2,0.08,0.05,0.0,0.0,0.0,marc russel birtwistle,BMOL-4250,2019
-BUS,1010,1.0,Business Foundations,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,william ernest tumblin,BUS-1010,2019
-BUS,1010,2.0,Business Foundations,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,william ernest tumblin,BUS-1010,2019
-BUS,1010,3.0,Business Foundations,0.58,0.21,0.21,0.0,0.0,0.0,0.0,0.0,william ernest tumblin,BUS-1010,2019
-BUS,1010,4.0,Business Foundations,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,5.0,Business Foundations,0.47,0.32,0.11,0.05,0.0,0.0,0.0,0.05,donna mccubbin,BUS-1010,2019
-BUS,1010,6.0,Business Foundations,0.26,0.63,0.11,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,7.0,Business Foundations,0.16,0.68,0.16,0.0,0.0,0.0,0.0,0.0,william ernest tumblin,BUS-1010,2019
-BUS,1010,8.0,Business Foundations,0.16,0.42,0.21,0.05,0.05,0.0,0.0,0.11,william ernest tumblin,BUS-1010,2019
-BUS,1010,9.0,Business Foundations,0.32,0.53,0.11,0.0,0.0,0.0,0.0,0.05,william ernest tumblin,BUS-1010,2019
-BUS,1010,10.0,Business Foundations,0.53,0.29,0.1,0.0,0.0,0.0,0.0,0.08,david lander onan,BUS-1010,2019
-BUS,1010,11.0,Business Foundations,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,david lander onan,BUS-1010,2019
-BUS,1010,12.0,Business Foundations,0.56,0.17,0.22,0.0,0.0,0.0,0.0,0.06,david lander onan,BUS-1010,2019
-BUS,1010,13.0,Business Foundations,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,david lander onan,BUS-1010,2019
-BUS,1010,14.0,Business Foundations,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,david lander onan,BUS-1010,2019
-BUS,1010,15.0,Business Foundations,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,james walter dowis,BUS-1010,2019
-BUS,1010,16.0,Business Foundations,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,james walter dowis,BUS-1010,2019
-BUS,1010,17.0,Business Foundations,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,james walter dowis,BUS-1010,2019
-BUS,1010,18.0,Business Foundations,0.26,0.32,0.26,0.16,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,19.0,Business Foundations,0.53,0.37,0.0,0.05,0.05,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,20.0,Business Foundations,0.11,0.37,0.32,0.05,0.05,0.0,0.0,0.11,donna mccubbin,BUS-1010,2019
-BUS,1010,21.0,Business Foundations,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,22.0,Business Foundations,0.42,0.47,0.0,0.0,0.05,0.0,0.0,0.05,donna mccubbin,BUS-1010,2019
-BUS,1010,23.0,Business Foundations,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2019
-BUS,1010,24.0,Business Foundations,0.32,0.58,0.05,0.0,0.0,0.0,0.0,0.05,sandy edge,BUS-1010,2019
-BUS,1010,25.0,Business Foundations,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2019
-BUS,1010,26.0,Business Foundations,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,william ernest tumblin,BUS-1010,2019
-BUS,1010,27.0,Business Foundations,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,william ernest tumblin,BUS-1010,2019
-BUS,1010,28.0,Business Foundations,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,william ernest tumblin,BUS-1010,2019
-BUS,1010,29.0,Business Foundations,0.53,0.2,0.1,0.02,0.04,0.0,0.0,0.1,james walter dowis,BUS-1010,2019
-BUS,1010,30.0,Business Foundations,0.31,0.37,0.18,0.04,0.02,0.0,0.0,0.08,james walter dowis,BUS-1010,2019
-BUS,1010,31.0,Business Foundations,0.26,0.42,0.21,0.05,0.0,0.0,0.0,0.05,james walter dowis,BUS-1010,2019
-BUS,1010,33.0,Business Foundations,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,edward barry de iulio,BUS-1010,2019
-BUS,1010,34.0,Business Foundations,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,edward barry de iulio,BUS-1010,2019
-BUS,1010,35.0,Business Foundations,0.47,0.26,0.26,0.0,0.0,0.0,0.0,0.0,david lander onan,BUS-1010,2019
-BUS,1010,36.0,Business Foundations,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,37.0,Business Foundations,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,edward barry de iulio,BUS-1010,2019
-BUS,1010,38.0,Business Foundations,0.59,0.31,0.06,0.03,0.0,0.0,0.0,0.0,neil martin monaghan,BUS-1010,2019
-BUS,1010,39.0,Business Foundations,0.59,0.31,0.03,0.0,0.0,0.0,0.0,0.06,neil martin monaghan,BUS-1010,2019
-BUS,1010,40.0,Business Foundations,0.29,0.18,0.18,0.07,0.0,0.0,0.0,0.29,david lander onan,BUS-1010,2019
-BUS,1010,41.0,Business Foundations,0.21,0.31,0.17,0.1,0.07,0.0,0.0,0.14,david lander onan,BUS-1010,2019
-BUS,1010,42.0,Business Foundations,0.42,0.33,0.13,0.04,0.0,0.0,0.0,0.08,donna mccubbin,BUS-1010,2019
-CCPD,1400,1.0,Professional Development,0.75,0.08,0.0,0.0,0.04,0.0,0.0,0.13,rise jean sheriff,CCPD-1400,2019
-CE,1990,20.0,Cr Inq in Civil Engineering,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,bradley putman,CE-1990,2019
-CE,2010,1.0,Statics,0.06,0.3,0.21,0.09,0.06,0.0,0.0,0.28,melissa sternhagen,CE-2010,2019
-CE,2010,2.0,Statics,0.28,0.35,0.23,0.05,0.09,0.0,0.0,0.0,md nasimul hoque chowdhury,CE-2010,2019
-CE,2010,3.0,Statics,0.13,0.36,0.26,0.03,0.08,0.0,0.0,0.15,melissa sternhagen,CE-2010,2019
-CE,2010,4.0,Statics,0.23,0.35,0.23,0.05,0.05,0.0,0.0,0.1,melissa sternhagen,CE-2010,2019
-CE,2010,5.0,Statics,0.39,0.4,0.15,0.02,0.03,0.0,0.0,0.0,weichiang pang,CE-2010,2019
-CE,2010,6.0,Statics,0.23,0.46,0.17,0.06,0.03,0.0,0.0,0.05,md nasimul hoque chowdhury,CE-2010,2019
-CE,2060,1.0,Structural Mechanics,0.11,0.2,0.54,0.09,0.04,0.0,0.0,0.02,melissa sternhagen,CE-2060,2019
-CE,2080,1.0,Dynamics,0.16,0.17,0.5,0.07,0.05,0.0,0.0,0.05,md nasimul hoque chowdhury,CE-2080,2019
-CE,2550,1.0,Geomatics,0.38,0.37,0.22,0.02,0.0,0.0,0.0,0.01,wayne sarasua,CE-2550,2019
-CE,3010,1.0,Structural Analysis,0.3,0.3,0.35,0.0,0.05,0.0,0.0,0.0,stephen csernak,CE-3010,2019
-CE,3010,2.0,Structural Analysis,0.31,0.31,0.2,0.11,0.0,0.0,0.0,0.06,thomas edford cousins,CE-3010,2019
-CE,3110,1.0,Transportation Engr,0.76,0.14,0.06,0.0,0.02,0.0,0.0,0.02,jennifer ogle,CE-3110,2019
-CE,3210,1.0,Geotechnical Engineering,0.19,0.4,0.38,0.04,0.0,0.0,0.0,0.0,ronald andrus,CE-3210,2019
-CE,3310,1.0,Constr Engr & Mgmnt,0.13,0.44,0.38,0.04,0.0,0.0,0.0,0.0,zoraya roldan rockow,CE-3310,2019
-CE,3310,2.0,Constr Engr & Mgmnt,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.03,zoraya roldan rockow,CE-3310,2019
-CE,3410,1.0,Intro to Fluid Mech,0.45,0.39,0.14,0.0,0.0,0.0,0.0,0.02,nigel gregory kaye,CE-3410,2019
-CE,3410,2.0,Intro to Fluid Mech,0.21,0.43,0.23,0.04,0.04,0.0,0.0,0.04,abdul khan,CE-3410,2019
-CE,3420,1.0,Hydraulics & Hydro,0.45,0.39,0.12,0.04,0.0,0.0,0.0,0.0,ashok mishra,CE-3420,2019
-CE,3510,1.0,Civil Engineering Materials,0.38,0.44,0.13,0.03,0.03,0.0,0.0,0.0,prasada rao rangaraju,CE-3510,2019
-CE,3510,2.0,Civil Engineering Materials,0.76,0.22,0.0,0.0,0.0,0.0,0.0,0.02,harish konduru,CE-3510,2019
-CE,3520,1.0,Econ Eval of Proj,0.29,0.4,0.23,0.0,0.02,0.0,0.0,0.06, kent nilsson,CE-3520,2019
-CE,3990,50.0,Cr Inq in Civil Engineering,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jennifer ogle,CE-3990,2019
-CE,3990,102.0,Cr Inq in Civil Engineering,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,weichiang pang,CE-3990,2019
-CE,4010,1.0,Matrix Str Analysis,0.27,0.27,0.13,0.07,0.0,0.0,0.0,0.27,laura mae redmond,CE-4010,2019
-CE,4020,1.0,Reinfor Con Design,0.41,0.45,0.09,0.0,0.0,0.0,0.0,0.05,weichiang pang,CE-4020,2019
-CE,4060,1.0,Struct Steel Design,0.33,0.38,0.19,0.07,0.0,0.0,0.0,0.02,stephen csernak,CE-4060,2019
-CE,4100,1.0,Traffic Engr Oper,0.36,0.52,0.12,0.0,0.0,0.0,0.0,0.0,wayne sarasua,CE-4100,2019
-CE,4240,1.0,Earth Slopes & Struc,0.3,0.4,0.21,0.09,0.0,0.0,0.0,0.0,nadarajah ravichandran,CE-4240,2019
-CE,4330,1.0,Const Plan & Sched,0.56,0.29,0.11,0.04,0.0,0.0,0.0,0.0,tuyen thanh le,CE-4330,2019
-CE,4430,1.0,Water Resources Engr,0.33,0.33,0.17,0.0,0.11,0.0,0.0,0.06,abdul khan,CE-4430,2019
-CE,4470,1.0,Stormwater Managemnt,0.57,0.17,0.22,0.0,0.04,0.0,0.0,0.0,md nasimul hoque chowdhury,CE-4470,2019
-CE,4560,1.0,Pave Design & Constr,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,bradley putman,CE-4560,2019
-CE,4590,1.0,Capstone Design Proj,0.4,0.26,0.28,0.07,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2019
-CE,4820,1.0,Groundwater & Contam Transport,0.33,0.25,0.08,0.17,0.08,0.0,0.0,0.08,lawrence murdoch,CE-4820,2019
-CE,4910,1.0,BIM in Construction Management,0.81,0.14,0.02,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4910,2019
-CE,4910,2.0,Accident Analytics,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,CE-4910,2019
-CE,4990,14.0,Special Projects-Springer II,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,prasada rao rangaraju,CE-4990,2019
-CE,6010,1.0,Matrix Str Analysis,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,laura mae redmond,CE-6010,2019
-CE,6430,1.0,Water Resources Engr,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,abdul khan,CE-6430,2019
-CE,6470,1.0,Stormwater Managemnt,0.67,0.0,0.33,0.0,0.0,0.0,0.0,0.0,md nasimul hoque chowdhury,CE-6470,2019
-CE,8010,1.0,Finite Ele Analysis,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nadarajah ravichandran,CE-8010,2019
-CE,8020,1.0,Adv R/C Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas edford cousins,CE-8020,2019
-CE,8700,500.0,Capstone Design Risk Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,CE-8700,2019
-CE,8930,3.0,Transport Risk & Evacuation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pamela marie murray-tuite,CE-8930,2019
-CE,8930,4.0,Autonomous Vehicle Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-8930,2019
-CE,8930,5.0,Struct Fire Engr & Safety,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,mohannad naser,CE-8930,2019
-CH,1010,1.0,General Chemistry,0.26,0.37,0.2,0.03,0.05,0.0,0.0,0.1,tania houjeiry,CH-1010,2019
-CH,1010,2.0,General Chemistry,0.12,0.4,0.31,0.09,0.02,0.0,0.0,0.06,olt geiculescu,CH-1010,2019
-CH,1010,3.0,General Chemistry,0.21,0.32,0.28,0.08,0.03,0.0,0.0,0.07,william wesley mcwhorter,CH-1010,2019
-CH,1010,4.0,General Chemistry,0.25,0.26,0.22,0.11,0.05,0.0,0.0,0.1,khushi patel,CH-1010,2019
-CH,1010,5.0,General Chemistry,0.28,0.37,0.17,0.06,0.04,0.0,0.0,0.09,dennis taylor,CH-1010,2019
-CH,1010,6.0,General Chemistry,0.29,0.35,0.18,0.08,0.04,0.0,0.0,0.07,elliot ennis,CH-1010,2019
-CH,1010,7.0,General Chemistry,0.17,0.33,0.22,0.09,0.06,0.0,0.0,0.13,william wesley mcwhorter,CH-1010,2019
-CH,1010,8.0,General Chemistry,0.38,0.32,0.12,0.12,0.02,0.0,0.0,0.05,thomas hickman,CH-1010,2019
-CH,1010,9.0,General Chemistry,0.25,0.42,0.25,0.04,0.03,0.0,0.0,0.03,william wesley mcwhorter,CH-1010,2019
-CH,1010,10.0,General Chemistry,0.17,0.38,0.21,0.08,0.08,0.0,0.0,0.08,princess mycia cox,CH-1010,2019
-CH,1010,11.0,General Chemistry,0.37,0.39,0.1,0.06,0.07,0.0,0.0,0.01,thomas hickman,CH-1010,2019
-CH,1010,12.0,General Chemistry,0.32,0.33,0.22,0.04,0.05,0.0,0.0,0.05,dennis taylor,CH-1010,2019
-CH,1010,13.0,General Chemistry,0.27,0.31,0.16,0.15,0.03,0.0,0.0,0.08,princess mycia cox,CH-1010,2019
-CH,1010,14.0,General Chemistry,0.14,0.33,0.3,0.12,0.03,0.0,0.0,0.08,jacob schroeder,CH-1010,2019
-CH,1010,50.0,General Chemistry,0.53,0.33,0.12,0.0,0.02,0.0,0.0,0.0,tania houjeiry,CH-1010,2019
-CH,1010,51.0,General Chemistry (HON),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,joseph stuart thrasher,CH-1010,2019
-CH,1010,52.0,General Chemistry (HON),0.7,0.22,0.08,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,CH-1010,2019
-CH,1010,201.0,General Chemistry,0.18,0.47,0.23,0.06,0.05,0.0,0.0,0.02,elliot ennis,CH-1010,2019
-CH,1010,203.0,General Chemistry,0.24,0.37,0.26,0.06,0.07,0.0,0.0,0.0,jacob schroeder,CH-1010,2019
-CH,1010,204.0,General Chemistry,0.32,0.32,0.23,0.07,0.03,0.0,0.0,0.03,thao thi thanh tran,CH-1010,2019
-CH,1020,1.0,General Chemistry,0.34,0.25,0.21,0.11,0.01,0.0,0.0,0.09,stephen jon schvaneveldt,CH-1020,2019
-CH,1020,2.0,General Chemistry,0.28,0.28,0.2,0.15,0.02,0.0,0.0,0.07,stephen jon schvaneveldt,CH-1020,2019
-CH,1020,3.0,General Chemistry,0.26,0.2,0.31,0.08,0.04,0.0,0.0,0.11,stephen jon schvaneveldt,CH-1020,2019
-CH,1020,400.0,General Chemistry,0.1,0.29,0.17,0.24,0.07,0.0,0.0,0.14,stephen jon schvaneveldt,CH-1020,2019
-CH,1050,1.0,Chemistry in Context I,0.43,0.31,0.16,0.05,0.04,0.0,0.0,0.01,olt geiculescu,CH-1050,2019
-CH,1050,2.0,Chemistry in Context I,0.45,0.4,0.11,0.01,0.01,0.0,0.0,0.02,olt geiculescu,CH-1050,2019
-CH,2010,1.0,Survey of Organic Chemistry,0.62,0.25,0.06,0.04,0.03,0.0,0.0,0.0,tania houjeiry,CH-2010,2019
-CH,2010,2.0,Survey of Organic Chemistry,0.4,0.4,0.13,0.03,0.02,0.0,0.0,0.02,modi wetzler,CH-2010,2019
-CH,2230,1.0,Organic Chemistry,0.09,0.16,0.24,0.14,0.25,0.0,0.0,0.12,modi wetzler,CH-2230,2019
-CH,2230,2.0,Organic Chemistry,0.05,0.23,0.22,0.12,0.16,0.0,0.0,0.21,modi wetzler,CH-2230,2019
-CH,2230,3.0,Organic Chemistry,0.38,0.3,0.2,0.07,0.03,0.0,0.0,0.02,laura lanni,CH-2230,2019
-CH,2230,4.0,Organic Chemistry,0.29,0.25,0.25,0.07,0.08,0.0,0.0,0.06,laura lanni,CH-2230,2019
-CH,2230,5.0,Organic Chemistry,0.4,0.32,0.13,0.03,0.05,0.0,0.0,0.08,rhett smith,CH-2230,2019
-CH,2230,6.0,Organic Chemistry,0.24,0.28,0.26,0.11,0.07,0.0,0.0,0.04,elliot ennis,CH-2230,2019
-CH,2230,7.0,Organic Chemistry,0.14,0.18,0.27,0.2,0.09,0.0,0.0,0.12,elliot ennis,CH-2230,2019
-CH,2230,50.0,Organic Chemistry,0.33,0.43,0.15,0.03,0.03,0.0,0.0,0.03,daniel whitehead,CH-2230,2019
-CH,2240,1.0,Organic Chemistry,0.3,0.2,0.15,0.18,0.09,0.0,0.0,0.09,laura lanni,CH-2240,2019
-CH,2240,2.0,Organic Chemistry,0.23,0.23,0.24,0.14,0.1,0.0,0.0,0.04,thomas hickman,CH-2240,2019
-CH,2270,1.0,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,CH-2270,2019
-CH,2270,3.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2019
-CH,2270,5.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2019
-CH,2270,7.0,Organic Chem Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,CH-2270,2019
-CH,2270,8.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2019
-CH,2270,13.0,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelson plampin,CH-2270,2019
-CH,2270,15.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2019
-CH,2270,16.0,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelson plampin,CH-2270,2019
-CH,2270,19.0,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,CH-2270,2019
-CH,2270,23.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2019
-CH,2270,27.0,Organic Chem Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,CH-2270,2019
-CH,2270,29.0,Organic Chem Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,CH-2270,2019
-CH,2270,32.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2019
-CH,2270,35.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,CH-2270,2019
-CH,2270,39.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,CH-2270,2019
-CH,2270,40.0,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,CH-2270,2019
-CH,2280,4.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,CH-2280,2019
-CH,3130,1.0,Quantitative Analysis,0.55,0.2,0.1,0.03,0.05,0.0,0.0,0.08,jeffrey nathan anker,CH-3130,2019
-CH,3150,1.0,Quant Analysis Lab,0.5,0.2,0.0,0.1,0.1,0.0,0.0,0.1,carlos diego garcia perez,CH-3150,2019
-CH,3150,2.0,Quant Analysis Lab,0.73,0.09,0.0,0.0,0.18,0.0,0.0,0.0,carlos diego garcia perez,CH-3150,2019
-CH,3300,1.0,Intro to Phys Chem,0.52,0.31,0.06,0.05,0.04,0.0,0.0,0.02,brian dominy,CH-3300,2019
-CH,3310,1.0,Physical Chemistry,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,steven stuart,CH-3310,2019
-CH,3390,1.0,Physical Chem Lab,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2019
-CH,3390,2.0,Physical Chem Lab,0.2,0.73,0.07,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2019
-CH,3390,3.0,Physical Chem Lab,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2019
-CH,3390,4.0,Physical Chem Lab,0.33,0.56,0.06,0.06,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2019
-CH,3390,5.0,Physical Chem Lab,0.47,0.47,0.0,0.06,0.0,0.0,0.0,0.0,princess mycia cox,CH-3390,2019
-CH,4010,1.0,Organometallic Chemistry,0.71,0.24,0.0,0.03,0.0,0.0,0.0,0.03,andrew gregory tennyson,CH-4010,2019
-CH,4020,1.0,Inorganic Chemistry,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,joseph kolis,CH-4020,2019
-CH,4210,1.0,Advanced Organic Chemistry,0.3,0.59,0.04,0.04,0.0,0.0,0.0,0.04,jacob schroeder,CH-4210,2019
-CH,8070,1.0,Chem Trans Elem,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,julia brumaghim,CH-8070,2019
-CH,8140,1.0,Analytical Imaging,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,george chumanov,CH-8140,2019
-CH,8160,1.0,Separation Science,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,richard marcus,CH-8160,2019
-CH,8410,1.0,N M R Spectroscopy,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,aleksandr kitaygorodskiy,CH-8410,2019
-CH,8510,1.0,Grad Student Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,CH-8510,2019
-CH,8520,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,joseph stuart thrasher,CH-8520,2019
-CHE,2110,1.0,Mass and Energy Balances,0.35,0.39,0.25,0.0,0.0,0.0,0.0,0.01,karen ann high,CHE-2110,2019
-CHE,2990,3.0,CI in CHE-  YEAST,0.0,0.0,0.0,0.0,0.0,0.75,0.0,0.25,marc russel birtwistle,CHE-2990,2019
-CHE,3210,1.0,Ch E Thermo II,0.22,0.13,0.37,0.15,0.13,0.0,0.0,0.0,mark thies,CHE-3210,2019
-CHE,3300,1.0,Mass Trans & Seprtn,0.25,0.46,0.21,0.03,0.05,0.0,0.0,0.0,david bruce,CHE-3300,2019
-CHE,3990,8.0,CI in CHE- NANO,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jessica marie larsen,CHE-3990,2019
-CHE,3990,9.0,CI- OPEN EDUCATIONAL RESOURCES,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rachel getman,CHE-3990,2019
-CHE,4070,1.0,Unit Op Lab II,0.22,0.66,0.12,0.0,0.0,0.0,0.0,0.0,christopher norfolk,CHE-4070,2019
-CHE,4310,1.0,Process Design I,0.3,0.45,0.25,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4310,2019
-CHE,4500,1.0,Chem Reaction Engr,0.35,0.4,0.22,0.03,0.0,0.0,0.0,0.0,mark roberts,CHE-4500,2019
-CHE,8040,1.0,Ch E Thermodynamics,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,sapna sarupria,CHE-8040,2019
-CHE,8050,1.0,Ch E Kinetics,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,rachel getman,CHE-8050,2019
-CHIN,1010,1.0,Elementary Chinese,0.5,0.2,0.1,0.1,0.0,0.0,0.0,0.1,yanhua zhang,CHIN-1010,2019
-CHIN,1010,2.0,Elementary Chinese,0.33,0.42,0.0,0.17,0.0,0.0,0.0,0.08,yanhua zhang,CHIN-1010,2019
-CHIN,4010,1.0,Pre-Modern Chinese Literature,0.3,0.5,0.1,0.0,0.03,0.0,0.0,0.08,yanming an,CHIN-4010,2019
-COM,1500,1.0,Intro to Human Communication,0.66,0.32,0.01,0.0,0.0,0.0,0.0,0.01,daniel leland fecher,COM-1500,2019
-COM,1500,2.0,Intro to Human Communication,0.73,0.22,0.03,0.0,0.01,0.0,0.0,0.02,daniel leland fecher,COM-1500,2019
-COM,1500,3.0,Intro to Human Communication,0.8,0.14,0.03,0.01,0.0,0.0,0.0,0.01,daniel leland fecher,COM-1500,2019
-COM,1500,4.0,Intro to Human Communication,0.74,0.22,0.02,0.01,0.01,0.0,0.0,0.01,marianne herr glaser,COM-1500,2019
-COM,1500,5.0,Intro to Human Communication,0.74,0.22,0.02,0.0,0.0,0.0,0.0,0.02,marianne herr glaser,COM-1500,2019
-COM,1500,6.0,Intro to Human Communication,0.82,0.14,0.02,0.0,0.0,0.0,0.0,0.02,marianne herr glaser,COM-1500,2019
-COM,1500,7.0,Intro to Human Communication,0.49,0.4,0.07,0.01,0.01,0.0,0.0,0.01,vanessa anne condon,COM-1500,2019
-COM,2010,1.0,Intr to Comm Studies,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2010,2019
-COM,2010,2.0,Intr to Comm Studies,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2010,2019
-COM,2030,1.0,Mass Communication Theory,0.35,0.15,0.45,0.0,0.05,0.0,0.0,0.0,jumah patricia taweh,COM-2030,2019
-COM,2040,1.0,Critical-Cultural Comm Theory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james nicholas gilmore,COM-2040,2019
-COM,2100,1.0,Quant Comm Research Methods,0.33,0.39,0.17,0.06,0.06,0.0,0.0,0.0,gregory keith cranmer,COM-2100,2019
-COM,2110,1.0,Qual Comm Research Methods,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-2110,2019
-COM,2500,2.0,Public Speaking,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,COM-2500,2019
-COM,2500,3.0,Public Speaking,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,COM-2500,2019
-COM,2500,5.0,Public Speaking,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,alyssa christine davis,COM-2500,2019
-COM,2500,6.0,Public Speaking,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christine davis,COM-2500,2019
-COM,2500,7.0,Public Speaking,0.42,0.42,0.05,0.11,0.0,0.0,0.0,0.0,marshall thomas covert,COM-2500,2019
-COM,2500,8.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,marshall thomas covert,COM-2500,2019
-COM,2500,9.0,Public Speaking,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,marshall thomas covert,COM-2500,2019
-COM,2500,10.0,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,marshall thomas covert,COM-2500,2019
-COM,2500,11.0,Public Speaking,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,COM-2500,2019
-COM,2500,17.0,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,COM-2500,2019
-COM,2500,18.0,Public Speaking,0.67,0.22,0.0,0.11,0.0,0.0,0.0,0.0,ashley lauren pikel,COM-2500,2019
-COM,2500,19.0,Public Speaking,0.53,0.37,0.0,0.0,0.0,0.0,0.0,0.11,jumah patricia taweh,COM-2500,2019
-COM,2500,21.0,Public Speaking,0.63,0.26,0.0,0.05,0.05,0.0,0.0,0.0,charles john brewer,COM-2500,2019
-COM,2500,22.0,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,charles john brewer,COM-2500,2019
-COM,2500,23.0,Public Speaking,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,sara grumbles crocker,COM-2500,2019
-COM,2500,24.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,charles john brewer,COM-2500,2019
-COM,2500,25.0,Public Speaking,0.68,0.11,0.05,0.05,0.0,0.0,0.0,0.11,sara grumbles crocker,COM-2500,2019
-COM,2500,26.0,Public Speaking,0.47,0.26,0.11,0.11,0.0,0.0,0.0,0.05,charles john brewer,COM-2500,2019
-COM,2500,27.0,Public Speaking,0.72,0.17,0.06,0.0,0.06,0.0,0.0,0.0,sara grumbles crocker,COM-2500,2019
-COM,2500,28.0,Public Speaking,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,katie barnes mcelveen,COM-2500,2019
-COM,2500,29.0,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel leland fecher,COM-2500,2019
-COM,2500,30.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,elizabeth ann kaszynski gilmore,COM-2500,2019
-COM,2500,33.0,Public Speaking,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,COM-2500,2019
-COM,2500,37.0,Public Speaking (HON),0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,lindsey dixon,COM-2500,2019
-COM,2500,39.0,Public Speaking (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2019
-COM,2500,400.0,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,COM-2500,2019
-COM,2500,401.0,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachary davis,COM-2500,2019
-COM,2500,403.0,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,COM-2500,2019
-COM,3050,1.0,Persuasion,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-3050,2019
-COM,3080,1.0,Public Comm & Pop Culture,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,erin michelle ash,COM-3080,2019
-COM,3240,1.0,"Communication, Sport & Society",0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,katie barnes mcelveen,COM-3240,2019
-COM,3240,2.0,"Communication, Sport & Society",0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katie barnes mcelveen,COM-3240,2019
-COM,3250,2.0,Survey of Sports Communication,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,COM-3250,2019
-COM,3260,1.0,Pr in Sports,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2019
-COM,3260,2.0,Pr in Sports,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3260,2019
-COM,3300,1.0,Nonverbal Communication,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,COM-3300,2019
-COM,3480,1.0,Interpersonal Comm,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,stephanie michelle pangborn,COM-3480,2019
-COM,3550,1.0,Principles of Public Relations,0.56,0.39,0.0,0.0,0.06,0.0,0.0,0.0,rachelle leigh beckner,COM-3550,2019
-COM,3560,1.0,Crisis Communication,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,andrew stephen pyle,COM-3560,2019
-COM,3660,5.0,Corporate Communications,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,. mark barnes,COM-3660,2019
-COM,4250,1.0,Adv Sports Comm,0.29,0.59,0.06,0.06,0.0,0.0,0.0,0.0,bryan denham,COM-4250,2019
-COM,4280,1.0,Interpers/Family Comm & Sport,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,gregory keith cranmer,COM-4280,2019
-COM,4710,1.0,Health Comm in Communities,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,stephanie michelle pangborn,COM-4710,2019
-COM,4950,1.0,Senior Capstone Seminar,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-4950,2019
-COM,8010,1.0,Communication Theory I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,erin michelle ash,COM-8010,2019
-COM,8030,1.0,Comm Technology Studies Survey,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nicholas gilmore,COM-8030,2019
-CPSC,1010,100.0,Computer Science I,0.22,0.37,0.24,0.07,0.07,0.0,0.0,0.04,roger larry van scoy,CPSC-1010,2019
-CPSC,1010,200.0,Computer Science I,0.4,0.23,0.21,0.04,0.04,0.0,0.0,0.08,roger larry van scoy,CPSC-1010,2019
-CPSC,1010,300.0,Computer Science I,0.31,0.27,0.18,0.07,0.13,0.0,0.0,0.04,yu-shan sun,CPSC-1010,2019
-CPSC,1020,1.0,Computer Science II,0.19,0.27,0.32,0.0,0.08,0.0,0.0,0.14,yvon feaster,CPSC-1020,2019
-CPSC,1020,2.0,Computer Science II,0.23,0.17,0.2,0.06,0.17,0.0,0.0,0.17,yvon feaster,CPSC-1020,2019
-CPSC,1020,3.0,Computer Science II,0.03,0.16,0.41,0.16,0.11,0.0,0.0,0.14,catherine hochrine,CPSC-1020,2019
-CPSC,1060,100.0,Intro to Programming in Java,0.26,0.34,0.32,0.03,0.05,0.0,0.0,0.0,svetlana drachova,CPSC-1060,2019
-CPSC,1060,200.0,Intro to Programming in Java,0.28,0.36,0.23,0.06,0.06,0.0,0.0,0.02,svetlana drachova,CPSC-1060,2019
-CPSC,1070,1.0,Programming Methodology,0.25,0.42,0.11,0.03,0.03,0.0,0.0,0.17,donald henry house,CPSC-1070,2019
-CPSC,1070,2.0,Programming Methodology,0.35,0.16,0.27,0.0,0.08,0.0,0.0,0.14,donald henry house,CPSC-1070,2019
-CPSC,1110,1.0,Intro to Programming in C,0.21,0.25,0.21,0.15,0.09,0.0,0.0,0.09,catherine hochrine,CPSC-1110,2019
-CPSC,1110,2.0,Intro to Programming in C,0.3,0.33,0.16,0.13,0.01,0.0,0.0,0.06,yu-shan sun,CPSC-1110,2019
-CPSC,1110,3.0,Intro to Programming in C,0.17,0.26,0.22,0.12,0.14,0.0,0.0,0.09,catherine hochrine,CPSC-1110,2019
-CPSC,1210,1.0,Computational Thinking,0.25,0.46,0.17,0.0,0.04,0.0,0.0,0.08,alexander christoph herzog,CPSC-1210,2019
-CPSC,2070,1.0,Discrete Structures,0.34,0.29,0.19,0.05,0.06,0.0,0.0,0.06,larry hodges,CPSC-2070,2019
-CPSC,2070,2.0,Discrete Structures,0.53,0.24,0.18,0.03,0.03,0.0,0.0,0.0,kai liu,CPSC-2070,2019
-CPSC,2120,1.0,Algs/Data Structures,0.38,0.28,0.2,0.04,0.06,0.0,0.0,0.04,nicolas benjamin widman,CPSC-2120,2019
-CPSC,2120,2.0,Algs/Data Structures,0.36,0.28,0.24,0.0,0.08,0.0,0.0,0.04,nicolas benjamin widman,CPSC-2120,2019
-CPSC,2120,3.0,Algs/Data Structures,0.59,0.19,0.19,0.0,0.0,0.0,0.0,0.04,brian christopher dean,CPSC-2120,2019
-CPSC,2120,4.0,Algs/Data Structures,0.38,0.19,0.29,0.0,0.14,0.0,0.0,0.0,brian christopher dean,CPSC-2120,2019
-CPSC,2150,1.0,Software Dev Foundations,0.32,0.35,0.21,0.05,0.03,0.0,0.0,0.03,kevin anton plis,CPSC-2150,2019
-CPSC,2150,2.0,Software Dev Foundations,0.24,0.32,0.22,0.02,0.08,0.0,0.0,0.12,kevin anton plis,CPSC-2150,2019
-CPSC,2200,1.0,Problem Solving w/ Office Apps,0.33,0.37,0.13,0.15,0.0,0.0,0.0,0.02,kevin anton plis,CPSC-2200,2019
-CPSC,2310,1.0,Intro Computer Org,0.6,0.33,0.05,0.0,0.0,0.0,0.0,0.02,nicolas benjamin widman,CPSC-2310,2019
-CPSC,2310,2.0,Intro Computer Org,0.53,0.18,0.16,0.05,0.05,0.0,0.0,0.02,nicolas benjamin widman,CPSC-2310,2019
-CPSC,2810,3.0,Selected Topics: Cyberdef Trai,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,svetlana drachova,CPSC-2810,2019
-CPSC,2910,1.0,Prof Issues I,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,yvon feaster,CPSC-2910,2019
-CPSC,2910,2.0,Prof Issues I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,yvon feaster,CPSC-2910,2019
-CPSC,2910,3.0,Prof Issues I,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,yvon feaster,CPSC-2910,2019
-CPSC,2910,4.0,Prof Issues I,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2019
-CPSC,2910,5.0,Prof Issues I,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2019
-CPSC,2910,6.0,Prof Issues I,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2019
-CPSC,2920,1.0,"Computing, Ethics & Society",0.79,0.13,0.05,0.0,0.03,0.0,0.0,0.0,julian langston brinkley,CPSC-2920,2019
-CPSC,3220,1.0,Intro to Operating Systems,0.08,0.35,0.22,0.03,0.11,0.0,0.0,0.22,pradip srimani,CPSC-3220,2019
-CPSC,3220,2.0,Intro to Operating Systems,0.18,0.27,0.36,0.15,0.03,0.0,0.0,0.0,mark smotherman,CPSC-3220,2019
-CPSC,3300,1.0,Computer Systems Org,0.38,0.42,0.17,0.02,0.0,0.0,0.0,0.02,tyler allen,CPSC-3300,2019
-CPSC,3500,1.0,Foundations of Computer Sci,0.18,0.2,0.38,0.12,0.04,0.0,0.0,0.08,ilya mark safro,CPSC-3500,2019
-CPSC,3520,1.0,Programming Systems,0.38,0.34,0.14,0.02,0.08,0.0,0.0,0.05,robert schalkoff,CPSC-3520,2019
-CPSC,3600,1.0,Network Programming,0.53,0.15,0.28,0.03,0.03,0.0,0.0,0.0,andrew robb,CPSC-3600,2019
-CPSC,3600,2.0,Network Programming,0.55,0.14,0.21,0.05,0.02,0.0,0.0,0.02,andrew robb,CPSC-3600,2019
-CPSC,3600,3.0,Network Programming,0.47,0.26,0.11,0.0,0.08,0.0,0.0,0.08,jason anderson,CPSC-3600,2019
-CPSC,3720,1.0,Software Engineering,0.31,0.41,0.23,0.0,0.0,0.0,0.0,0.05,eileen theresa kraemer,CPSC-3720,2019
-CPSC,3720,2.0,Software Engineering,0.23,0.56,0.16,0.0,0.04,0.0,0.0,0.02,yu-shan sun,CPSC-3720,2019
-CPSC,4040,1.0,Cmptr Graphics Image,0.56,0.28,0.0,0.0,0.0,0.0,0.0,0.16,ioannis karamouzas,CPSC-4040,2019
-CPSC,4050,1.0,Computer Graphics,0.52,0.19,0.05,0.0,0.05,0.0,0.0,0.19,victor zordan,CPSC-4050,2019
-CPSC,4110,1.0,Virtual Reality Systems,0.46,0.43,0.05,0.0,0.03,0.0,0.0,0.03,sabarish venkat babu,CPSC-4110,2019
-CPSC,4120,1.0,Eye Tracking Methodology,0.43,0.46,0.07,0.0,0.0,0.0,0.0,0.04,andrew duchowski,CPSC-4120,2019
-CPSC,4140,1.0,Human and Computer Interaction,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,nathaniel mcneese,CPSC-4140,2019
-CPSC,4150,1.0,Mobile Device Software Devel,0.23,0.23,0.35,0.08,0.0,0.0,0.0,0.12,christopher plaue,CPSC-4150,2019
-CPSC,4200,1.0,Computer Security Principles,0.67,0.3,0.03,0.0,0.0,0.0,0.0,0.0,long cheng,CPSC-4200,2019
-CPSC,4240,1.0,System Admin and Security,0.1,0.6,0.2,0.1,0.0,0.0,0.0,0.0,svetlana drachova,CPSC-4240,2019
-CPSC,4300,1.0,Applied Data Science,0.36,0.43,0.15,0.02,0.02,0.0,0.0,0.02,alexander christoph herzog,CPSC-4300,2019
-CPSC,4620,1.0,Database Management Systems,0.12,0.38,0.12,0.12,0.0,0.0,0.0,0.27,pradip srimani,CPSC-4620,2019
-CPSC,4770,1.0,Distributed/Cluster Computing,0.39,0.33,0.11,0.06,0.06,0.0,0.0,0.06,shuangshuang jin,CPSC-4770,2019
-CPSC,4820,1.0,Special Topic: Web Programming,0.57,0.21,0.13,0.04,0.02,0.0,0.0,0.02,craig baker,CPSC-4820,2019
-CPSC,4820,2.0,Special Topics: Hands on ML,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,larry hodges,CPSC-4820,2019
-CPSC,4820,4.0,Spe Topic: AI,0.33,0.24,0.1,0.0,0.0,0.0,0.0,0.33,ioannis karamouzas,CPSC-4820,2019
-CPSC,4890,1.0,Programming Team Seminar,0.65,0.15,0.05,0.05,0.0,0.0,0.0,0.1,brian christopher dean,CPSC-4890,2019
-CPSC,4910,1.0,Professional Issues II,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,roger larry van scoy,CPSC-4910,2019
-CPSC,4910,2.0,Professional Issues II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alexander christoph herzog,CPSC-4910,2019
-CPSC,6040,1.0,Cptr Graphics Image,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,ioannis karamouzas,CPSC-6040,2019
-CPSC,6050,1.0,Computer Graphics,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,victor zordan,CPSC-6050,2019
-CPSC,6110,1.0,Virtual Reality Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venkat babu,CPSC-6110,2019
-CPSC,6150,1.0,Mobile Device Software Devel,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,christopher plaue,CPSC-6150,2019
-CPSC,6240,1.0,System Admin and Security,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,svetlana drachova,CPSC-6240,2019
-CPSC,6300,1.0,Applied Data Science,0.82,0.11,0.04,0.0,0.0,0.0,0.0,0.04,kai liu,CPSC-6300,2019
-CPSC,6300,2.0,Applied Data Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xizhou feng,CPSC-6300,2019
-CPSC,6620,1.0,Database Management Systems,0.5,0.33,0.08,0.0,0.0,0.0,0.0,0.08,pradip srimani,CPSC-6620,2019
-CPSC,6820,4.0,Spec Top: AI,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,ioannis karamouzas,CPSC-6820,2019
-CPSC,8040,1.0,Data Visualization,0.74,0.2,0.0,0.0,0.03,0.0,0.0,0.03,federico iuricich,CPSC-8040,2019
-CPSC,8100,1.0,Intro Artif Intell,0.43,0.43,0.02,0.0,0.0,0.0,0.0,0.11,feng luo,CPSC-8100,2019
-CPSC,8170,1.0,Physically Based Animation,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,jerry tessendorf,CPSC-8170,2019
-CPSC,8200,1.0,Parallel Architechture,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,rong ge,CPSC-8200,2019
-CPSC,8380,1.0,Adv Data Structures,0.25,0.5,0.0,0.0,0.13,0.0,0.0,0.13,sandra hedetniemi,CPSC-8380,2019
-CPSC,8480,1.0,Network Science,0.2,0.4,0.25,0.0,0.1,0.0,0.0,0.05,ilya mark safro,CPSC-8480,2019
-CPSC,8520,1.0,Internetworking,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james martin,CPSC-8520,2019
-CPSC,8580,1.0,Security in Emerging Systems,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,hongxin hu,CPSC-8580,2019
-CPSC,8580,843.0,Security in Emerging Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,CPSC-8580,2019
-CPSC,8620,1.0,Database Mngmt System Design,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,nina christine hubig,CPSC-8620,2019
-CPSC,8710,1.0,Found. of Software Engineering,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,murali sitaraman,CPSC-8710,2019
-CSM,1000,1.0,Intro to Construct,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,harnish sharma,CSM-1000,2019
-CSM,2010,1.0,Structures I,0.35,0.43,0.08,0.03,0.0,0.0,0.0,0.11,shima clarke,CSM-2010,2019
-CSM,2020,1.0,Structures II,0.77,0.14,0.03,0.03,0.0,0.0,0.0,0.03,nathaniel jackson,CSM-2020,2019
-CSM,2030,1.0,Mats & Meth of Const,0.33,0.35,0.28,0.0,0.0,0.0,0.0,0.05,jason lucas,CSM-2030,2019
-CSM,2040,1.0,Cont Documents,0.41,0.48,0.07,0.03,0.0,0.0,0.0,0.0,robert dawson coffey,CSM-2040,2019
-CSM,2050,1.0,Mats & Methods II,0.09,0.69,0.23,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,CSM-2050,2019
-CSM,3040,1.0,Envir Systems I,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,joseph michael burgett,CSM-3040,2019
-CSM,3050,1.0,Envir Systems II,0.63,0.11,0.21,0.05,0.0,0.0,0.0,0.0,joseph michael burgett,CSM-3050,2019
-CSM,3060,1.0,Emerging Tech in Construction,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,harnish sharma,CSM-3060,2019
-CSM,3070,1.0,Sustainable Construction,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,harnish sharma,CSM-3070,2019
-CSM,3510,1.0,Construction Estimating,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,seyed ehsan mousavi rizi,CSM-3510,2019
-CSM,3520,401.0,Const Scheduling,0.22,0.72,0.0,0.0,0.0,0.0,0.0,0.06,craig townsend,CSM-3520,2019
-CSM,3530,1.0,Const Estimating II,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,seyed ehsan mousavi rizi,CSM-3530,2019
-CSM,4110,1.0,Safety in Bldg Const,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,nicholas corley,CSM-4110,2019
-CSM,4500,1.0,Construction Intern,0.16,0.43,0.37,0.03,0.0,0.0,0.0,0.0,nathaniel jackson,CSM-4500,2019
-CSM,4530,1.0,Const Proj Mgmt,0.21,0.69,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4530,2019
-CSM,4530,2.0,Const Proj Mgmt,0.43,0.4,0.17,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4530,2019
-CSM,4540,1.0,Const Capstone,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,CSM-4540,2019
-CSM,4610,1.0,Const Econ Seminar,0.66,0.31,0.0,0.0,0.0,0.0,0.0,0.03,catherine nove-josserand,CSM-4610,2019
-CSM,4610,2.0,Const Econ Seminar,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,catherine nove-josserand,CSM-4610,2019
-CSM,4980,2.0,Current Topics-NAHB Comp,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-4980,2019
-CSM,8360,400.0,Managing Integr Proj Delivery,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,shima clarke,CSM-8360,2019
-CSM,8650,1.0,Project Management,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8650,2019
-CSM,8650,400.0,Project Management,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-8650,2019
-CU,1000,26.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2019
-CU,1000,30.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2019
-CU,1000,34.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2019
-CU,1000,37.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,CU-1000,2019
-CU,1000,51.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,CU-1000,2019
-CU,1000,52.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,CU-1000,2019
-CU,1010,1.0,Univ Success Skills,0.5,0.1,0.1,0.0,0.3,0.0,0.0,0.0,cynthia june smith,CU-1010,2019
-CU,1010,8.0,Univ Success Skills,0.5,0.06,0.11,0.0,0.11,0.0,0.0,0.22,catherine maroska neel,CU-1010,2019
-CU,1010,602.0,Univ Success Skills,0.62,0.15,0.15,0.0,0.0,0.0,0.0,0.08,valerie kay oonk,CU-1010,2019
-CU,1010,603.0,Univ Success Skills,0.56,0.23,0.1,0.03,0.08,0.0,0.0,0.0,elizabeth anne stephan,CU-1010,2019
-CU,1010,605.0,Univ Success Skills,0.43,0.24,0.24,0.0,0.1,0.0,0.0,0.0,matthew kent miller,CU-1010,2019
-CU,1010,606.0,Univ Success Skills,0.3,0.3,0.04,0.17,0.17,0.0,0.0,0.0,andrew isaac neptune,CU-1010,2019
-CU,1010,607.0,Univ Success Skills,0.46,0.27,0.14,0.05,0.05,0.0,0.0,0.03,elizabeth anne stephan,CU-1010,2019
-CVT,2260,1.0,Intro Cardiovas Sono,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,eric walker,CVT-2260,2019
-DPA,3070,1.0,Method 3d Production,0.44,0.4,0.08,0.0,0.0,0.0,0.0,0.08,tommy van bui,DPA-3070,2019
-DPA,4000,1.0,Tech Foundations I,0.07,0.29,0.14,0.0,0.07,0.0,0.0,0.43,jessica baron,DPA-4000,2019
-DPA,4020,2.0,Visual Found of Digital Prod,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,anthony summey,DPA-4020,2019
-DPA,4830,1.0,Spec Stud Top in DPA: Dig Scul,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,insun kwon,DPA-4830,2019
-DPA,8070,1.0,3D Modeling and Animation,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,christina sophie joerg,DPA-8070,2019
-DPA,8090,1.0,Rendering and Shading,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,daljit singh dhillon,DPA-8090,2019
-ECAS,1990,101.0,CI LEAD Forward I,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,steve richard sanders,ECAS-1990,2019
-ECE,1990,13.0,CI: Future Engineers,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,melissa crawley smith,ECE-1990,2019
-ECE,1990,14.0,CI: Robot Networks,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,yongqiang wang,ECE-1990,2019
-ECE,2010,1.0,Logic and Computing Devices,0.23,0.28,0.24,0.08,0.08,0.0,0.0,0.08,william reid,ECE-2010,2019
-ECE,2020,1.0,Electric Circuits I,0.2,0.35,0.27,0.08,0.04,0.0,0.0,0.06,william harrell,ECE-2020,2019
-ECE,2070,1.0,Basic Electrical Engineering,0.21,0.22,0.26,0.12,0.07,0.0,0.0,0.12,william thomas kolodzey,ECE-2070,2019
-ECE,2070,2.0,Basic Electrical Engineering,0.29,0.15,0.21,0.18,0.06,0.0,0.0,0.12,wesley green,ECE-2070,2019
-ECE,2070,3.0,Basic Electrical Engineering,0.39,0.23,0.21,0.07,0.04,0.0,0.0,0.06,timothy anglea,ECE-2070,2019
-ECE,2080,1.0,Basic Electrical Engr Lab,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,4.0,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,5.0,Basic Electrical Engr Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,6.0,Basic Electrical Engr Lab,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,7.0,Basic Electrical Engr Lab,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,8.0,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,9.0,Basic Electrical Engr Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,10.0,Basic Electrical Engr Lab,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,12.0,Basic Electrical Engr Lab,0.79,0.0,0.0,0.0,0.21,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,14.0,Basic Electrical Engr Lab,0.71,0.12,0.0,0.0,0.0,0.0,0.0,0.18,apoorva deepak kapadia,ECE-2080,2019
-ECE,2080,15.0,Basic Electrical Engr Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,apoorva deepak kapadia,ECE-2080,2019
-ECE,2090,2.0,Logic & Computing Devices Lab,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,apoorva deepak kapadia,ECE-2090,2019
-ECE,2090,3.0,Logic & Computing Devices Lab,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,ECE-2090,2019
-ECE,2090,4.0,Logic & Computing Devices Lab,0.83,0.08,0.0,0.08,0.0,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2090,2019
-ECE,2090,5.0,Logic & Computing Devices Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,ECE-2090,2019
-ECE,2090,9.0,Logic & Computing Devices Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2090,2019
-ECE,2090,11.0,Logic & Computing Devices Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva deepak kapadia,ECE-2090,2019
-ECE,2090,13.0,Logic & Computing Devices Lab,0.67,0.0,0.0,0.0,0.08,0.0,0.0,0.25,apoorva deepak kapadia,ECE-2090,2019
-ECE,2090,14.0,Logic & Computing Devices Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,ECE-2090,2019
-ECE,2110,1.0,Elec Engr Lab I,0.8,0.1,0.05,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2110,2019
-ECE,2110,2.0,Elec Engr Lab I,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,ECE-2110,2019
-ECE,2110,3.0,Elec Engr Lab I,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,ECE-2110,2019
-ECE,2110,5.0,Elec Engr Lab I,0.7,0.15,0.1,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2110,2019
-ECE,2110,6.0,Elec Engr Lab I,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,ECE-2110,2019
-ECE,2110,8.0,Elec Engr Lab I,0.3,0.4,0.15,0.0,0.05,0.0,0.0,0.1,apoorva deepak kapadia,ECE-2110,2019
-ECE,2110,10.0,Elec Engr Lab I,0.69,0.08,0.23,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2110,2019
-ECE,2120,1.0,Electrical Engineering Lab II,0.81,0.0,0.0,0.0,0.06,0.0,0.0,0.13,apoorva deepak kapadia,ECE-2120,2019
-ECE,2220,1.0,Syst Prog Concept,0.18,0.18,0.16,0.05,0.05,0.0,0.0,0.37,lu yu,ECE-2220,2019
-ECE,2230,1.0,Comp Sys Eng,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,walter ligon,ECE-2230,2019
-ECE,2620,1.0,Electric Circuits II,0.05,0.36,0.32,0.09,0.07,0.0,0.0,0.11,liang dong,ECE-2620,2019
-ECE,2720,1.0,Comp Organization,0.02,0.27,0.5,0.14,0.05,0.0,0.0,0.02,william reid,ECE-2720,2019
-ECE,2730,2.0,Computer Org Lab,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2730,2019
-ECE,2730,3.0,Computer Org Lab,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,ECE-2730,2019
-ECE,3110,2.0,Electrical Engineering Lab III,0.69,0.13,0.0,0.0,0.13,0.0,0.0,0.06,apoorva deepak kapadia,ECE-3110,2019
-ECE,3120,1.0,Electrical Engineering Lab IV,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,ECE-3120,2019
-ECE,3170,1.0,Rand Signal Analysis,0.22,0.28,0.34,0.1,0.04,0.0,0.0,0.01,stephen hubbard,ECE-3170,2019
-ECE,3200,1.0,Electronics I,0.29,0.2,0.23,0.13,0.12,0.0,0.0,0.03,stephen hubbard,ECE-3200,2019
-ECE,3200,2.0,Electronics I (HON),0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,stephen hubbard,ECE-3200,2019
-ECE,3210,1.0,Electronics II,0.22,0.27,0.39,0.12,0.0,0.0,0.0,0.0,stephen hubbard,ECE-3210,2019
-ECE,3220,2.0,Intro Operating Sys,0.35,0.3,0.35,0.0,0.0,0.0,0.0,0.0,mark smotherman,ECE-3220,2019
-ECE,3270,1.0,Dig Comp Design,0.16,0.3,0.27,0.18,0.05,0.0,0.0,0.05,melissa crawley smith,ECE-3270,2019
-ECE,3300,1.0,Signals & Systems,0.23,0.19,0.27,0.15,0.11,0.0,0.0,0.05,carl baum,ECE-3300,2019
-ECE,3300,2.0,Signals & Systems (HON),0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,ECE-3300,2019
-ECE,3520,1.0,Programming Systems,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,robert schalkoff,ECE-3520,2019
-ECE,3600,1.0,Elect Power Engr,0.34,0.26,0.19,0.04,0.09,0.0,0.0,0.08,sukumar makarand brahma,ECE-3600,2019
-ECE,3710,1.0,Microcontr Interface,0.55,0.31,0.08,0.04,0.0,0.0,0.0,0.01,william reid,ECE-3710,2019
-ECE,3720,2.0,Micro Int Lab,0.33,0.33,0.08,0.08,0.08,0.0,0.0,0.08,apoorva deepak kapadia,ECE-3720,2019
-ECE,3720,7.0,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,ECE-3720,2019
-ECE,3800,1.0,Electromagnetics,0.23,0.11,0.23,0.2,0.11,0.0,0.0,0.11,anthony martin,ECE-3800,2019
-ECE,3810,1.0,Field Waves & Ckts,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,hai xiao,ECE-3810,2019
-ECE,4090,1.0,Intr to Linear Control Systems,0.76,0.19,0.03,0.01,0.0,0.0,0.0,0.01,apoorva deepak kapadia,ECE-4090,2019
-ECE,4180,1.0,Power Syst Analysis,0.33,0.25,0.08,0.08,0.08,0.0,0.0,0.17,ramtin hadidi,ECE-4180,2019
-ECE,4270,1.0,Communication Systems,0.22,0.28,0.33,0.09,0.04,0.0,0.0,0.04,lu yu,ECE-4270,2019
-ECE,4310,1.0,Intro to Computer Vision,0.56,0.32,0.08,0.04,0.0,0.0,0.0,0.0,adam hoover,ECE-4310,2019
-ECE,4420,1.0,Knowledge Engineering,0.35,0.4,0.1,0.0,0.1,0.0,0.0,0.05,robert schalkoff,ECE-4420,2019
-ECE,4490,1.0,Comp Ntwrk Security,0.65,0.26,0.0,0.0,0.04,0.0,0.0,0.04,lu yu,ECE-4490,2019
-ECE,4610,1.0,Fundamentals of Solar Energy,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,ECE-4610,2019
-ECE,4670,1.0,Intro to Dig Sig Pro,0.18,0.41,0.24,0.0,0.0,0.0,0.0,0.18,john gowdy,ECE-4670,2019
-ECE,4730,1.0,Intro Parallel Sys,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,walter ligon,ECE-4730,2019
-ECE,4950,1.0,Int Sys Design I,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,apoorva deepak kapadia,ECE-4950,2019
-ECE,4960,1.0,Int Sys Design II,0.53,0.38,0.08,0.0,0.0,0.0,0.0,0.03,richard groff,ECE-4960,2019
-ECE,6040,1.0,Semiconductor Devices,0.63,0.13,0.25,0.0,0.0,0.0,0.0,0.0,judson douglas ryckman,ECE-6040,2019
-ECE,6310,1.0,Intro to Computer Vision,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,adam hoover,ECE-6310,2019
-ECE,6420,1.0,Knowledge Engr,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,robert schalkoff,ECE-6420,2019
-ECE,6490,843.0,Comp Ntwrk Security,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,lu yu,ECE-6490,2019
-ECE,6590,1.0,Int Circ Design,0.43,0.29,0.0,0.0,0.0,0.0,0.0,0.29,yingjie lao,ECE-6590,2019
-ECE,6610,843.0,Fundamentals of Solar Energy,0.2,0.6,0.0,0.0,0.0,0.0,0.0,0.2,rajendra singh,ECE-6610,2019
-ECE,6670,1.0,Intro to Dig Sig Pro,0.2,0.4,0.2,0.0,0.0,0.0,0.0,0.2,john gowdy,ECE-6670,2019
-ECE,6930,844.0,IntroPowerElecTechApps Charls,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,zheyu zhang,ECE-6930,2019
-ECE,8010,1.0,Analysis of Lin Sys,0.43,0.29,0.0,0.0,0.07,0.0,0.0,0.21,richard groff,ECE-8010,2019
-ECE,8040,1.0,Networked Dynamical Systems,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,ECE-8040,2019
-ECE,8540,1.0,Analysis of Tracking Systems,0.61,0.36,0.0,0.0,0.04,0.0,0.0,0.0,adam hoover,ECE-8540,2019
-ECON,2000,2.0,Economic Concepts,0.67,0.23,0.08,0.03,0.0,0.0,0.0,0.0,shubhashrita basu,ECON-2000,2019
-ECON,2000,4.0,Economic Concepts,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,miren ivankovic,ECON-2000,2019
-ECON,2000,5.0,Economic Concepts,0.41,0.35,0.06,0.06,0.06,0.0,0.0,0.06,shubhashrita basu,ECON-2000,2019
-ECON,2110,1.0,Principles of Microeconomics,0.16,0.47,0.32,0.0,0.05,0.0,0.0,0.0,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,2.0,Principles of Microeconomics,0.16,0.42,0.26,0.11,0.0,0.0,0.0,0.05,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,3.0,Principles of Microeconomics,0.05,0.42,0.37,0.05,0.05,0.0,0.0,0.05,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,4.0,Principles of Microeconomics,0.11,0.26,0.53,0.0,0.05,0.0,0.0,0.05,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,5.0,Principles of Microeconomics,0.16,0.58,0.16,0.0,0.05,0.0,0.0,0.05,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,6.0,Principles of Microeconomics,0.24,0.35,0.18,0.06,0.0,0.0,0.0,0.18,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,7.0,Principles of Microeconomics,0.11,0.61,0.22,0.06,0.0,0.0,0.0,0.0,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,8.0,Principles of Microeconomics,0.11,0.42,0.21,0.16,0.0,0.0,0.0,0.11,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,9.0,Principles of Microeconomics,0.0,0.42,0.37,0.16,0.05,0.0,0.0,0.0,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,10.0,Principles of Microeconomics,0.0,0.47,0.42,0.05,0.0,0.0,0.0,0.05,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,11.0,Principles of Microeconomics,0.26,0.26,0.26,0.05,0.11,0.0,0.0,0.05,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,12.0,Principles of Microeconomics,0.11,0.39,0.28,0.11,0.0,0.0,0.0,0.11,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,13.0,Principles of Microeconomics,0.05,0.63,0.21,0.05,0.0,0.0,0.0,0.05,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,14.0,Principles of Microeconomics,0.0,0.5,0.33,0.06,0.06,0.0,0.0,0.06,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,15.0,Principles of Microeconomics,0.11,0.47,0.26,0.11,0.0,0.0,0.0,0.05,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,16.0,Principles of Microeconomics,0.11,0.53,0.37,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,17.0,Principles of Microeconomics,0.21,0.53,0.26,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,18.0,Principles of Microeconomics,0.11,0.17,0.5,0.06,0.06,0.0,0.0,0.11,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,19.0,Principles of Microeconomics,0.17,0.39,0.44,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,ECON-2110,2019
-ECON,2110,20.0,Principles of Microeconomics,0.37,0.3,0.24,0.06,0.01,0.0,0.0,0.01,cory simpkins,ECON-2110,2019
-ECON,2110,21.0,Principles of Microeconomics,0.19,0.37,0.27,0.05,0.06,0.0,0.0,0.06,shirong zhao,ECON-2110,2019
-ECON,2110,23.0,Principles of Microeconomics,0.3,0.45,0.18,0.02,0.03,0.0,0.0,0.03,elijah neilson,ECON-2110,2019
-ECON,2110,24.0,Principles of Microeconomics,0.16,0.56,0.19,0.06,0.0,0.0,0.0,0.02,michael makowsky,ECON-2110,2019
-ECON,2110,25.0,Principles of Microeconomics,0.38,0.4,0.2,0.03,0.0,0.0,0.0,0.0,seyedmajid hashemi,ECON-2110,2019
-ECON,2110,26.0,Principles of Microeconomics,0.27,0.44,0.18,0.02,0.0,0.0,0.0,0.09,khundkar arefin kamal,ECON-2110,2019
-ECON,2110,31.0,Principles of Microeconomics,0.25,0.47,0.18,0.03,0.03,0.0,0.0,0.05,shannon graham,ECON-2110,2019
-ECON,2110,32.0,Principles of Microeconomics,0.19,0.52,0.3,0.0,0.0,0.0,0.0,0.0,haibin jiang,ECON-2110,2019
-ECON,2110,33.0,Principles of Microeconomics,0.51,0.36,0.05,0.0,0.05,0.0,0.0,0.03,seyedmajid hashemi,ECON-2110,2019
-ECON,2110,34.0,Principles of Microecon (HON),0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,charles thomas,ECON-2110,2019
-ECON,2110,35.0,Principles of Microeconomics,0.55,0.33,0.05,0.08,0.0,0.0,0.0,0.0,shilpi mukherjee,ECON-2110,2019
-ECON,2110,36.0,Principles of Microeconomics,0.39,0.33,0.2,0.04,0.0,0.0,0.0,0.04,sarah louise wilson,ECON-2110,2019
-ECON,2110,38.0,Principles of Microeconomics,0.31,0.48,0.17,0.0,0.0,0.0,0.0,0.05,elijah neilson,ECON-2110,2019
-ECON,2110,40.0,Principles of Microeconomics,0.27,0.27,0.27,0.07,0.1,0.0,0.0,0.03,cory simpkins,ECON-2110,2019
-ECON,2110,41.0,Principles of Microeconomics,0.29,0.26,0.21,0.17,0.02,0.0,0.0,0.05,devon merritt haskell gorry,ECON-2110,2019
-ECON,2120,1.0,Principles of Macroeconomics,0.19,0.36,0.2,0.11,0.09,0.0,0.0,0.06,aspen rachel underwood,ECON-2120,2019
-ECON,2120,2.0,Principles of Macroeconomics,0.41,0.3,0.26,0.0,0.0,0.0,0.0,0.02,kenneth whaley,ECON-2120,2019
-ECON,2120,3.0,Principles of Macroeconomics,0.78,0.15,0.05,0.0,0.02,0.0,0.0,0.0,tyler francis,ECON-2120,2019
-ECON,2120,4.0,Principles of Macroeconomics,0.3,0.23,0.28,0.13,0.06,0.0,0.0,0.0,aspen rachel underwood,ECON-2120,2019
-ECON,2120,5.0,Principles of Macroeconomics,0.31,0.36,0.28,0.03,0.0,0.0,0.0,0.03,matthew lee cronin,ECON-2120,2019
-ECON,2120,6.0,Principles of Macroeconomics,0.33,0.48,0.2,0.0,0.0,0.0,0.0,0.0,matthew lee cronin,ECON-2120,2019
-ECON,2120,7.0,Principles of Macroeconomics,0.26,0.44,0.28,0.0,0.03,0.0,0.0,0.0,kenneth whaley,ECON-2120,2019
-ECON,2120,8.0,Principles of Macroeconomics,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.03,jeremy choquette,ECON-2120,2019
-ECON,2120,9.0,Principles of Macroeconomics,0.81,0.17,0.02,0.0,0.0,0.0,0.0,0.0,tyler francis,ECON-2120,2019
-ECON,2120,10.0,Principles of Macroeconomics,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,jeremy choquette,ECON-2120,2019
-ECON,3020,1.0,Money and Banking,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.03,adam markley witham,ECON-3020,2019
-ECON,3060,1.0,Managerial Economics,0.16,0.32,0.22,0.19,0.08,0.0,0.0,0.03,benjamin james posmanick,ECON-3060,2019
-ECON,3100,1.0,International Econ,0.17,0.53,0.24,0.01,0.03,0.0,0.0,0.01,scott baier,ECON-3100,2019
-ECON,3140,1.0,Intermediate Micro,0.18,0.26,0.24,0.1,0.08,0.0,0.0,0.14,patrick warren,ECON-3140,2019
-ECON,3140,2.0,Intermediate Micro,0.2,0.41,0.26,0.08,0.03,0.0,0.0,0.02,molly espey,ECON-3140,2019
-ECON,3140,3.0,Intermediate Micro,0.44,0.27,0.13,0.04,0.04,0.0,0.0,0.07,yichen christy zhou,ECON-3140,2019
-ECON,3140,5.0,Intermediate Micro,0.47,0.26,0.11,0.03,0.03,0.0,0.0,0.11,yichen christy zhou,ECON-3140,2019
-ECON,3150,1.0,Intermediate Macro,0.07,0.23,0.39,0.14,0.11,0.0,0.0,0.07,michal maria jerzmanowski,ECON-3150,2019
-ECON,3150,2.0,Intermediate Macro,0.21,0.26,0.38,0.12,0.0,0.0,0.0,0.03,michal maria jerzmanowski,ECON-3150,2019
-ECON,3190,1.0,Environmental Econ,0.35,0.41,0.16,0.05,0.0,0.0,0.0,0.03,molly espey,ECON-3190,2019
-ECON,3600,1.0,Public Choice,0.29,0.26,0.18,0.11,0.08,0.0,0.0,0.08,michael makowsky,ECON-3600,2019
-ECON,4010,1.0,Labor Mkt Analysis,0.29,0.41,0.24,0.0,0.06,0.0,0.0,0.0,chungsang lam,ECON-4010,2019
-ECON,4020,1.0,Law and Economics,0.21,0.45,0.21,0.07,0.02,0.0,0.0,0.02,howard nelson bodenhorn,ECON-4020,2019
-ECON,4040,1.0,Comp Econ Systems,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,daria litsukova-bokar,ECON-4040,2019
-ECON,4050,5.0,Intro to Econometric,0.18,0.29,0.35,0.14,0.03,0.0,0.0,0.0,scott barkowski,ECON-4050,2019
-ECON,4100,1.0,Economic Development,0.53,0.32,0.05,0.05,0.0,0.0,0.0,0.05,robert tamura,ECON-4100,2019
-ECON,4110,2.0,Econ of Education,0.75,0.18,0.0,0.0,0.04,0.0,0.0,0.04,jorge luis garcia  menendez,ECON-4110,2019
-ECON,4120,1.0,International Micro,0.46,0.38,0.08,0.08,0.0,0.0,0.0,0.0,cheng chen,ECON-4120,2019
-ECON,4230,1.0,Economics of Health,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0,devon merritt haskell gorry,ECON-4230,2019
-ECON,4240,1.0,Organization of Ind,0.53,0.24,0.18,0.06,0.0,0.0,0.0,0.0,matthew lewis,ECON-4240,2019
-ECON,4240,2.0,Organization of Ind,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,matthew lewis,ECON-4240,2019
-ECON,4280,1.0,Cost-Benefit Anlysis,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,robert kenneth fleck,ECON-4280,2019
-ECON,4280,2.0,Cost-Benefit Anlysis,0.45,0.25,0.25,0.05,0.0,0.0,0.0,0.0,robert kenneth fleck,ECON-4280,2019
-ECON,4980,1.0,Selected Topics in Economics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,howard nelson bodenhorn,ECON-4980,2019
-ECON,4980,3.0,History of Economic Thought,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,ECON-4980,2019
-ECON,4980,3.0,History of Economic Thought,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,ECON-4980,2019
-ECON,4980,4.0,Sel Topic - Why Business?,0.34,0.52,0.14,0.0,0.0,0.0,0.0,0.0,lawrence reed watson,ECON-4980,2019
-ECON,4980,5.0,Cryptocurrency and  Blockchain,0.37,0.42,0.16,0.0,0.0,0.0,0.0,0.05,gerald dwyer,ECON-4980,2019
-ECON,4980,6.0,Sel Topic - Why Business?,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,ECON-4980,2019
-ECON,4980,6.0,Sel Topic - Why Business?,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,ECON-4980,2019
-ECON,6050,5.0,Intro to Econometric,0.36,0.27,0.36,0.0,0.0,0.0,0.0,0.0,scott barkowski,ECON-6050,2019
-ECON,8010,1.0,Microeconomic Theory,0.22,0.33,0.33,0.0,0.0,0.0,0.0,0.11,william dougan,ECON-8010,2019
-ECON,8040,1.0,Applied Math Econ,0.36,0.59,0.05,0.0,0.0,0.0,0.0,0.0,curtis simon,ECON-8040,2019
-ECON,8060,1.0,Econometrics I,0.33,0.33,0.25,0.0,0.08,0.0,0.0,0.0,paul wayne wilson,ECON-8060,2019
-ECON,8080,1.0,Econometrics III,0.33,0.33,0.17,0.0,0.17,0.0,0.0,0.0,paul wayne wilson,ECON-8080,2019
-ECON,8230,1.0,Microecon Pub Pol,0.0,0.45,0.36,0.0,0.09,0.0,0.0,0.09,scott templeton,ECON-8230,2019
-ECON,8260,1.0,Econ Theory of Govt Regulation,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,thomas winslow hazlett,ECON-8260,2019
-ECON,9010,1.0,Price Theory,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,charles thomas,ECON-9010,2019
-ED,1050,2.0,Orientation to Education,0.82,0.14,0.0,0.05,0.0,0.0,0.0,0.0,stacy jones,ED-1050,2019
-ED,1050,3.0,Orientation to Education,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,stacy jones,ED-1050,2019
-ED,1050,4.0,Orientation to Education,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,stacy jones,ED-1050,2019
-ED,1050,5.0,Orientation to Education,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,hilary tanck,ED-1050,2019
-ED,1050,6.0,Orientation to Education,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,hilary tanck,ED-1050,2019
-ED,1970,1.0,CI-CONNECTIONS Stud Developmnt,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2019
-ED,1970,2.0,CI-CONNECTIONS Stud Developmnt,0.94,0.0,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2019
-ED,1970,3.0,CI-CONNECTIONS Stud Developmnt,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2019
-ED,1970,5.0,CI-CONNECTIONS Stud Developmnt,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2019
-ED,1970,6.0,CI-CONNECTIONS Stud Developmnt,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-1970,2019
-ED,3010,1.0,Principles of American Educat,0.87,0.0,0.0,0.0,0.04,0.0,0.0,0.09,beatrice naff bailey,ED-3010,2019
-ED,3010,3.0,Principles of American Educat,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,beatrice naff bailey,ED-3010,2019
-ED,3010,4.0,Principles of American Educat,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,nafees mohammad khan,ED-3010,2019
-EDC,8100,400.0,Advising and Supporting,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,mary dolores katalinic,EDC-8100,2019
-EDEC,3360,1.0,Play/Soc Dev-Infts/Young Child,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,marjorie deanna ramey,EDEC-3360,2019
-EDEC,4400,1.0,Early Childhood Engl Lang Art,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,EDEC-4400,2019
-EDEL,3100,3.0,Arts in Ele School,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kathy cochran,EDEL-3100,2019
-EDEL,3210,2.0,Pe for the Elem Tchr,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2019
-EDEL,3210,3.0,Pe for the Elem Tchr,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,deborah smith,EDEL-3210,2019
-EDEL,4510,1.0,Elem Methods in Science Tchg,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,laura cohen eicher,EDEL-4510,2019
-EDEL,4870,1.0,Ele Meth Soc Studies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,EDEL-4870,2019
-EDF,3020,1.0,Educational Psychology,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,meihua qian,EDF-3020,2019
-EDF,3340,1.0,Child Growth and Development,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,amanda elizabeth bennett,EDF-3340,2019
-EDF,3340,3.0,Child Growth and Development,0.74,0.23,0.0,0.03,0.0,0.0,0.0,0.0,faiza marghoob jamil,EDF-3340,2019
-EDF,3350,1.0,Adolescent Growth & Develop,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,EDF-3350,2019
-EDF,4800,1.0,Digital Media & Learning,0.63,0.25,0.08,0.0,0.04,0.0,0.0,0.0,ryan visser,EDF-4800,2019
-EDF,4800,2.0,Digital Media & Learning,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,golnaz arastoopour irgens,EDF-4800,2019
-EDF,4800,3.0,Digital Media & Learning,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,golnaz arastoopour irgens,EDF-4800,2019
-EDF,4800,300.0,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,georgia lousie mckown,EDF-4800,2019
-EDF,4800,301.0,Digital Media & Learning,0.69,0.17,0.07,0.03,0.03,0.0,0.0,0.0,ryan visser,EDF-4800,2019
-EDF,8710,400.0,Cultural Diversity in Educatio,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,reginald wilkerson,EDF-8710,2019
-EDF,9270,1.0,Quant Rsrch & Stats for Ed,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,christy jenkins brown,EDF-9270,2019
-EDF,9270,2.0,Quant Rsrch & Stats for Ed,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,christy jenkins brown,EDF-9270,2019
-EDF,9780,1.0,Multivar Ed Research,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,matthew james madison,EDF-9780,2019
-EDHD,3110,3.0,CI- Children's Lit. Newsletter,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDHD-3110,2019
-EDHD,3110,4.0,CI- Read/Review Child/YA Lit.,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDHD-3110,2019
-EDL,7050,400.0,Contemp Iss in School Leadshp,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,danielle hall,EDL-7050,2019
-EDL,7250,501.0,Law/Ethics for School Leaders,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,betty thompson bagley,EDL-7250,2019
-EDL,9770,2.0,Div Issues in Hi Ed,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,william mccoy,EDL-9770,2019
-EDLT,4600,1.0,Found of Read: Assess & Instr,0.39,0.39,0.17,0.04,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDLT-4600,2019
-EDLT,4600,3.0,Found of Read: Assess & Instr,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,lisa denise aker,EDLT-4600,2019
-EDLT,4600,4.0,Found of Read: Assess & Instr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lisa denise aker,EDLT-4600,2019
-EDLT,4610,1.0,Content Area Read/Writing,0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-4610,2019
-EDLT,4610,2.0,Content Area Read/Writing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-4610,2019
-EDLT,4800,301.0,Found in Adolescent Literacy,0.79,0.14,0.04,0.04,0.0,0.0,0.0,0.0,phillip michael wilder,EDLT-4800,2019
-EDLT,4980,1.0,Cont Area Read/Write Secondary,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,arsenio frankie silva,EDLT-4980,2019
-EDLT,8100,300.0,Foundations: Reading & Writing,0.74,0.17,0.0,0.0,0.0,0.0,0.0,0.09,emily smothers howell,EDLT-8100,2019
-EDLT,8110,300.0,Adv Children's & Yng Adult Lit,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,susan king fullerton,EDLT-8110,2019
-EDLT,8110,301.0,Adv Children's & Yng Adult Lit,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,jonda cecole mcnair,EDLT-8110,2019
-EDLT,8150,300.0,Guided Reading & Guided Writng,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,pamela dunston,EDLT-8150,2019
-EDLT,8220,500.0,Strategies for Teaching ESOL,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,mikel walker cole,EDLT-8220,2019
-EDLT,8270,300.0,Content Area Rdg/Wtg-MS & HS,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,emily smothers howell,EDLT-8270,2019
-EDLT,8400,502.0,Early Literacy Assessment I,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,antoinette dibellonia,EDLT-8400,2019
-EDLT,8400,504.0,Early Literacy Assessment I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,barbara fewell,EDLT-8400,2019
-EDLT,8400,508.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jamie felder white,EDLT-8400,2019
-EDLT,8400,509.0,Early Literacy Assessment I,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,susanne atkinson elvington,EDLT-8400,2019
-EDSA,3900,1.0,Skills for Student Leaders,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDSA-3900,2019
-EDSA,3900,4.0,Skills for Student Leaders,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDSA-3900,2019
-EDSA,3900,6.0,Skills for Student Leaders,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,EDSA-3900,2019
-EDSA,3990,1.0,Creative Inq in Counselor Ed,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,jacob frankovich,EDSA-3990,2019
-EDSA,8040,1.0,Theories Student Dev in Hi Ed,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,EDSA-8040,2019
-EDSA,8040,2.0,Theories Student Dev in Hi Ed,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,EDSA-8040,2019
-EDSA,8100,1.0,Advising and Supporting,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,EDSA-8100,2019
-EDSC,2260,1.0,Pr Apprch to Sec Alg,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,stacy megan che,EDSC-2260,2019
-EDSC,3270,1.0,Practicum Sec Sci,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,christopher david white,EDSC-3270,2019
-EDSC,4240,1.0,Tchng Sec English,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,mary-celeste schreuder,EDSC-4240,2019
-EDSC,4280,1.0,Tchng Secondary Social Studies,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kristen earnise duncan,EDSC-4280,2019
-EDSP,3700,1.0,Intro to Special Education,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,sharon walters,EDSP-3700,2019
-EDSP,3700,2.0,Intro to Special Education,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,friggita johnson,EDSP-3700,2019
-EDSP,3700,4.0,Intro to Special Education,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,wendell kent parker,EDSP-3700,2019
-EDSP,3720,1.0,Char & Instr Individ with LD,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,catherine aurentz griffith,EDSP-3720,2019
-EDSP,3740,1.0,Char & Strat Emot/Behav Disord,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shanna eisner hirsch,EDSP-3740,2019
-EDSP,3750,1.0,Early Intervention Spec Needs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,EDSP-3750,2019
-EDSP,4920,1.0,Math Inst Ind W/Dis,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,EDSP-4920,2019
-EDSP,4930,1.0,Clsrm/Beh Mgmt Sp Ed,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,joseph benedict ryan,EDSP-4930,2019
-EDSP,4940,1.0,Tchg Rdg Mild Dis,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,abigail anne allen,EDSP-4940,2019
-EDSP,8530,400.0,Legal/Pol Issu Sp Ed,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,EDSP-8530,2019
-EES,2010,1.0,Environ Engr Fundamentals I,0.34,0.26,0.24,0.08,0.05,0.0,0.0,0.03,david freedman,EES-2010,2019
-EES,3030,1.0,Water Treatment Systems,0.53,0.27,0.17,0.0,0.0,0.0,0.0,0.03,david allen ladner,EES-3030,2019
-EES,3040,1.0,Wastewater Treatment Systems,0.41,0.41,0.17,0.0,0.0,0.0,0.0,0.0,sudeep popat,EES-3040,2019
-EES,3050,1.0,Water/Wastewater Treatment Lab,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-3050,2019
-EES,3050,2.0,Water/Wastewater Treatment Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,sudeep popat,EES-3050,2019
-EES,4010,1.0,Environmental Engr,0.52,0.35,0.11,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,EES-4010,2019
-EES,4010,2.0,Environmental Engr,0.28,0.45,0.14,0.07,0.07,0.0,0.0,0.0,mark schlautman,EES-4010,2019
-EES,4090,1.0,Intro to Nuc Engr & Radiol Sci,0.29,0.29,0.07,0.14,0.0,0.0,0.0,0.21,timothy devol,EES-4090,2019
-EES,4300,1.0,Air Pollution Engineering,0.3,0.33,0.27,0.07,0.0,0.0,0.0,0.03,andrew richard metcalf,EES-4300,2019
-EES,4800,1.0,Environmental Risk Assessment,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,nicole elizabeth martinez,EES-4800,2019
-EES,4840,1.0,Solid Waste Mgt,0.29,0.5,0.18,0.0,0.0,0.0,0.0,0.03,ezra lucas hoyt cates,EES-4840,2019
-EES,4860,1.0,Environmental Sustainability,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,michael carbajales-dale,EES-4860,2019
-EES,4860,2.0,Environmental Sustainability,0.5,0.33,0.0,0.0,0.08,0.0,0.0,0.08,michael carbajales-dale,EES-4860,2019
-EES,4900,15.0,CI: From Drones to 3D Printing,0.75,0.13,0.0,0.13,0.0,0.0,0.0,0.0,blake andrew lytle,EES-4900,2019
-EES,6860,1.0,Environmental Sustainability,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michael carbajales-dale,EES-6860,2019
-EES,8020,1.0,Environ Eng Prin,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-8020,2019
-EES,8430,1.0,Environmental Chem,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,EES-8430,2019
-EES,8510,1.0,Biol Prin Envir Engr,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,kevin thomas finneran,EES-8510,2019
-ELE,3010,1.0,Entrepreneurial Foundations,0.41,0.29,0.29,0.02,0.0,0.0,0.0,0.0,ashley williams parnell,ELE-3010,2019
-ELE,3010,2.0,Entrepreneurial Foundations,0.16,0.43,0.39,0.0,0.02,0.0,0.0,0.0,ashley williams parnell,ELE-3010,2019
-ELE,3010,3.0,Entrepreneurial Foundations,0.38,0.54,0.05,0.0,0.03,0.0,0.0,0.0,christina kyprianou,ELE-3010,2019
-ELE,3010,4.0,Entrepreneurial Foundations,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,christina kyprianou,ELE-3010,2019
-ELE,3020,3.0,Entrepreneurial Resource Acqu,0.38,0.49,0.14,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,ELE-3020,2019
-ELE,3020,4.0,Entrepreneurial Resource Acqu,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,ELE-3020,2019
-ELE,4020,1.0,Venture Creation,0.35,0.54,0.08,0.0,0.03,0.0,0.0,0.0,william frank dinardo,ELE-4020,2019
-ELE,4030,1.0,Venture Growth,0.59,0.32,0.08,0.0,0.0,0.0,0.0,0.0,james keith hudgins,ELE-4030,2019
-ELE,4990,2.0,Venture Counsulting,0.28,0.63,0.1,0.0,0.0,0.0,0.0,0.0,william frank dinardo,ELE-4990,2019
-ENGL,1030,2.0,Composition and Rhetoric,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,robert andrew welborn,ENGL-1030,2019
-ENGL,1030,3.0,Composition and Rhetoric,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,ENGL-1030,2019
-ENGL,1030,7.0,Composition and Rhetoric,0.16,0.42,0.16,0.11,0.11,0.0,0.0,0.05,chelsea marie clarey,ENGL-1030,2019
-ENGL,1030,10.0,Composition and Rhetoric,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,chelsea marie clarey,ENGL-1030,2019
-ENGL,1030,11.0,Composition and Rhetoric,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,caitlin grace watt,ENGL-1030,2019
-ENGL,1030,12.0,Composition and Rhetoric,0.41,0.41,0.12,0.0,0.0,0.0,0.0,0.06,tareva leselle johnson,ENGL-1030,2019
-ENGL,1030,13.0,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,caitlin grace watt,ENGL-1030,2019
-ENGL,1030,14.0,Composition and Rhetoric,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,tareva leselle johnson,ENGL-1030,2019
-ENGL,1030,15.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,emma jayne stanley,ENGL-1030,2019
-ENGL,1030,16.0,Composition and Rhetoric,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,anna lia  johnson,ENGL-1030,2019
-ENGL,1030,18.0,Composition and Rhetoric,0.74,0.16,0.0,0.0,0.11,0.0,0.0,0.0,allen swords,ENGL-1030,2019
-ENGL,1030,19.0,Composition and Rhetoric,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-1030,2019
-ENGL,1030,20.0,Composition and Rhetoric,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,anna lia  johnson,ENGL-1030,2019
-ENGL,1030,21.0,Composition and Rhetoric,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,mary catherine nestor,ENGL-1030,2019
-ENGL,1030,22.0,Composition and Rhetoric,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,mary catherine nestor,ENGL-1030,2019
-ENGL,1030,23.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,lindsey henley kurz,ENGL-1030,2019
-ENGL,1030,24.0,Composition and Rhetoric,0.63,0.16,0.0,0.0,0.21,0.0,0.0,0.0,sarah elizabeth richardson,ENGL-1030,2019
-ENGL,1030,25.0,Composition and Rhetoric,0.42,0.47,0.0,0.0,0.11,0.0,0.0,0.0,john benjamin fuqua,ENGL-1030,2019
-ENGL,1030,26.0,Composition and Rhetoric,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,kimberly jenerette,ENGL-1030,2019
-ENGL,1030,27.0,Composition and Rhetoric,0.37,0.42,0.05,0.05,0.11,0.0,0.0,0.0,kimberly jenerette,ENGL-1030,2019
-ENGL,1030,28.0,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,hannah taylor,ENGL-1030,2019
-ENGL,1030,29.0,Composition and Rhetoric,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,hannah pittman godwin,ENGL-1030,2019
-ENGL,1030,30.0,Composition and Rhetoric,0.42,0.42,0.11,0.0,0.05,0.0,0.0,0.0,andrew mathas,ENGL-1030,2019
-ENGL,1030,31.0,Composition and Rhetoric,0.76,0.12,0.06,0.0,0.06,0.0,0.0,0.0,joelma soares-sambdman,ENGL-1030,2019
-ENGL,1030,33.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,helen wesley kapp,ENGL-1030,2019
-ENGL,1030,34.0,Composition and Rhetoric,0.39,0.44,0.06,0.0,0.11,0.0,0.0,0.0,john benjamin fuqua,ENGL-1030,2019
-ENGL,1030,35.0,Composition and Rhetoric,0.47,0.42,0.0,0.05,0.0,0.0,0.0,0.05,hannah pittman godwin,ENGL-1030,2019
-ENGL,1030,36.0,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,hannah taylor,ENGL-1030,2019
-ENGL,1030,37.0,Composition and Rhetoric,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,la'cresha ulon green,ENGL-1030,2019
-ENGL,1030,41.0,Composition and Rhetoric,0.74,0.11,0.0,0.0,0.11,0.0,0.0,0.05,cody hunter,ENGL-1030,2019
-ENGL,1030,42.0,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,cody hunter,ENGL-1030,2019
-ENGL,1030,43.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kaitlyn samons,ENGL-1030,2019
-ENGL,1030,45.0,Composition and Rhetoric,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jacob danial richter,ENGL-1030,2019
-ENGL,1030,46.0,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,jacob danial richter,ENGL-1030,2019
-ENGL,1030,49.0,Composition and Rhetoric,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,nicholas rader,ENGL-1030,2019
-ENGL,1030,50.0,Composition and Rhetoric,0.47,0.47,0.0,0.05,0.0,0.0,0.0,0.0,nicholas rader,ENGL-1030,2019
-ENGL,1030,51.0,Composition and Rhetoric,0.42,0.32,0.11,0.05,0.05,0.0,0.0,0.05,jennie elizabeth wakefield,ENGL-1030,2019
-ENGL,1030,52.0,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jennie elizabeth wakefield,ENGL-1030,2019
-ENGL,1030,53.0,Composition and Rhetoric,0.22,0.5,0.22,0.0,0.06,0.0,0.0,0.0,gregory luke chwala,ENGL-1030,2019
-ENGL,1030,54.0,Composition and Rhetoric,0.57,0.36,0.0,0.0,0.07,0.0,0.0,0.0,sethunya mokoko gall,ENGL-1030,2019
-ENGL,1030,55.0,Composition and Rhetoric,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,jennie elizabeth wakefield,ENGL-1030,2019
-ENGL,1030,56.0,Composition and Rhetoric,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,sethunya mokoko gall,ENGL-1030,2019
-ENGL,1030,57.0,Composition and Rhetoric,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,sarah watkins,ENGL-1030,2019
-ENGL,1030,58.0,Composition and Rhetoric,0.79,0.05,0.05,0.05,0.05,0.0,0.0,0.0,kailan smith sindelar,ENGL-1030,2019
-ENGL,1030,60.0,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kailan smith sindelar,ENGL-1030,2019
-ENGL,1030,61.0,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,hwi eun hur,ENGL-1030,2019
-ENGL,1030,64.0,Composition and Rhetoric,0.73,0.13,0.07,0.0,0.0,0.0,0.0,0.07,hwi eun hur,ENGL-1030,2019
-ENGL,1030,65.0,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kelley melissa gillis,ENGL-1030,2019
-ENGL,1030,67.0,Composition and Rhetoric,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,kelley melissa gillis,ENGL-1030,2019
-ENGL,1030,68.0,Composition and Rhetoric,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,juliann teichert,ENGL-1030,2019
-ENGL,1030,69.0,Composition and Rhetoric,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,juliann teichert,ENGL-1030,2019
-ENGL,1030,76.0,Composition and Rhetoric,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,mary adams,ENGL-1030,2019
-ENGL,1030,77.0,Composition and Rhetoric,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,ENGL-1030,2019
-ENGL,1030,78.0,Composition and Rhetoric,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,ENGL-1030,2019
-ENGL,1030,82.0,Composition and Rhetoric,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,ENGL-1030,2019
-ENGL,1030,83.0,Composition and Rhetoric,0.67,0.17,0.0,0.06,0.06,0.0,0.0,0.06,melissa dugan,ENGL-1030,2019
-ENGL,1030,84.0,Composition and Rhetoric,0.65,0.18,0.06,0.0,0.06,0.0,0.0,0.06,bree laran beal,ENGL-1030,2019
-ENGL,1030,85.0,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,joelma soares-sambdman,ENGL-1030,2019
-ENGL,1030,101.0,Composition and Rhetoric (HON),0.78,0.11,0.0,0.11,0.0,0.0,0.0,0.0,chelsea jeanine murdock,ENGL-1030,2019
-ENGL,2120,1.0,World Literature,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,ENGL-2120,2019
-ENGL,2120,2.0,World Literature,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,kenneth michael tuite,ENGL-2120,2019
-ENGL,2120,3.0,World Literature,0.47,0.32,0.0,0.0,0.05,0.0,0.0,0.16,bree laran beal,ENGL-2120,2019
-ENGL,2120,4.0,World Literature,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sarah elissa matalone,ENGL-2120,2019
-ENGL,2120,5.0,World Literature,0.37,0.32,0.21,0.0,0.0,0.0,0.0,0.11,andrew mathas,ENGL-2120,2019
-ENGL,2120,6.0,World Literature,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,david charles foltz,ENGL-2120,2019
-ENGL,2120,7.0,World Literature,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,david charles foltz,ENGL-2120,2019
-ENGL,2120,8.0,World Literature,0.47,0.21,0.21,0.0,0.0,0.0,0.0,0.11,david charles foltz,ENGL-2120,2019
-ENGL,2120,9.0,World Literature,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,sarah elissa matalone,ENGL-2120,2019
-ENGL,2120,10.0,World Literature,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,sarah elissa matalone,ENGL-2120,2019
-ENGL,2120,11.0,World Literature,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,elizabeth anderson stansell,ENGL-2120,2019
-ENGL,2120,12.0,World Literature,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,ENGL-2120,2019
-ENGL,2120,13.0,World Literature,0.5,0.31,0.06,0.0,0.06,0.0,0.0,0.06,hannah pittman godwin,ENGL-2120,2019
-ENGL,2120,14.0,World Literature,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,ENGL-2120,2019
-ENGL,2120,16.0,World Literature,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,ENGL-2120,2019
-ENGL,2120,17.0,World Literature,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,bree laran beal,ENGL-2120,2019
-ENGL,2120,18.0,World Literature,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,john benjamin fuqua,ENGL-2120,2019
-ENGL,2120,19.0,World Literature,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,ENGL-2120,2019
-ENGL,2120,20.0,World Literature,0.5,0.22,0.22,0.0,0.06,0.0,0.0,0.0,elizabeth anderson stansell,ENGL-2120,2019
-ENGL,2120,21.0,World Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,ENGL-2120,2019
-ENGL,2120,22.0,World Literature,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,ENGL-2120,2019
-ENGL,2120,23.0,World Literature,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,ENGL-2120,2019
-ENGL,2120,24.0,World Literature,0.74,0.11,0.11,0.05,0.0,0.0,0.0,0.0,ingrid anna pierce,ENGL-2120,2019
-ENGL,2120,25.0,World Literature,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,ingrid anna pierce,ENGL-2120,2019
-ENGL,2120,26.0,World Literature,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,bree laran beal,ENGL-2120,2019
-ENGL,2120,27.0,World Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,hannah pittman godwin,ENGL-2120,2019
-ENGL,2120,28.0,World Literature,0.47,0.26,0.16,0.0,0.11,0.0,0.0,0.0,andrew mathas,ENGL-2120,2019
-ENGL,2120,29.0,World Literature,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,andrew mathas,ENGL-2120,2019
-ENGL,2120,30.0,World Literature,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,john benjamin fuqua,ENGL-2120,2019
-ENGL,2120,400.0,World Literature,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth anderson stansell,ENGL-2120,2019
-ENGL,2120,401.0,World Literature,0.37,0.37,0.16,0.0,0.0,0.0,0.0,0.11,karen kettnich,ENGL-2120,2019
-ENGL,2120,402.0,World Literature,0.5,0.17,0.17,0.0,0.0,0.0,0.0,0.17,karen kettnich,ENGL-2120,2019
-ENGL,2120,403.0,World Literature,0.21,0.29,0.07,0.07,0.07,0.0,0.0,0.29,sarah elissa matalone,ENGL-2120,2019
-ENGL,2130,2.0,British Literature,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,gregory luke chwala,ENGL-2130,2019
-ENGL,2130,3.0,British Literature,0.29,0.41,0.24,0.06,0.0,0.0,0.0,0.0,gregory luke chwala,ENGL-2130,2019
-ENGL,2130,4.0,British Literature,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,gregory luke chwala,ENGL-2130,2019
-ENGL,2130,5.0,British Literature,0.47,0.21,0.16,0.05,0.05,0.0,0.0,0.05,henna marian messina,ENGL-2130,2019
-ENGL,2130,7.0,British Literature,0.47,0.26,0.16,0.0,0.0,0.0,0.0,0.11,christopher benson,ENGL-2130,2019
-ENGL,2130,8.0,British Literature,0.38,0.31,0.13,0.06,0.06,0.0,0.0,0.06,henna marian messina,ENGL-2130,2019
-ENGL,2130,9.0,British Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-2130,2019
-ENGL,2130,11.0,British Literature,0.58,0.26,0.05,0.05,0.05,0.0,0.0,0.0,lucian ghita,ENGL-2130,2019
-ENGL,2130,100.0,British Literature (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john morgenstern,ENGL-2130,2019
-ENGL,2130,400.0,British Literature,0.32,0.32,0.16,0.11,0.05,0.0,0.0,0.05,kristen louise aldebol-hazle,ENGL-2130,2019
-ENGL,2130,401.0,British Literature,0.56,0.13,0.0,0.0,0.13,0.0,0.0,0.19,kristen louise aldebol-hazle,ENGL-2130,2019
-ENGL,2140,1.0,American Literature,0.42,0.26,0.26,0.0,0.0,0.0,0.0,0.05,mary catherine nestor,ENGL-2140,2019
-ENGL,2140,2.0,American Literature,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,mary catherine nestor,ENGL-2140,2019
-ENGL,2140,3.0,American Literature,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,chelsea marie clarey,ENGL-2140,2019
-ENGL,2140,4.0,American Literature,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,chelsea marie clarey,ENGL-2140,2019
-ENGL,2140,5.0,American Literature,0.63,0.21,0.0,0.0,0.0,0.0,0.0,0.16,kathy elaine nixon,ENGL-2140,2019
-ENGL,2140,6.0,American Literature,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,kathy elaine nixon,ENGL-2140,2019
-ENGL,2140,7.0,American Literature,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,william weldon cunningham,ENGL-2140,2019
-ENGL,2140,8.0,American Literature,0.33,0.33,0.11,0.06,0.0,0.0,0.0,0.17,william weldon cunningham,ENGL-2140,2019
-ENGL,2140,9.0,American Literature,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2019
-ENGL,2140,10.0,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2019
-ENGL,2140,11.0,American Literature,0.21,0.68,0.0,0.0,0.0,0.0,0.0,0.11,patricia sunia,ENGL-2140,2019
-ENGL,2140,12.0,American Literature,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,patricia sunia,ENGL-2140,2019
-ENGL,2140,400.0,American Literature,0.61,0.17,0.11,0.0,0.0,0.0,0.0,0.11,tareva leselle johnson,ENGL-2140,2019
-ENGL,2140,401.0,American Literature,0.58,0.21,0.05,0.05,0.0,0.0,0.0,0.11,tareva leselle johnson,ENGL-2140,2019
-ENGL,2150,1.0,Lit in 20th-21st Cent Contexts,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-2150,2019
-ENGL,2150,2.0,Lit in 20th-21st Cent Contexts,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,allen swords,ENGL-2150,2019
-ENGL,2150,3.0,Lit in 20th-21st Cent Contexts,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,john logan pursley,ENGL-2150,2019
-ENGL,2150,4.0,Lit in 20th-21st Cent Contexts,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2019
-ENGL,2150,5.0,Lit in 20th-21st Cent Contexts,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2019
-ENGL,2150,6.0,Lit in 20th-21st Cent Contexts,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2150,2019
-ENGL,2150,7.0,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2150,2019
-ENGL,2150,8.0,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2150,2019
-ENGL,2150,9.0,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-2150,2019
-ENGL,2150,10.0,Lit in 20th-21st Cent Contexts,0.44,0.33,0.17,0.06,0.0,0.0,0.0,0.0,stephanie lorraine edwards,ENGL-2150,2019
-ENGL,2150,11.0,Lit in 20th-21st Cent Contexts,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,caitlin grace watt,ENGL-2150,2019
-ENGL,2150,12.0,Lit in 20th-21st Cent Contexts,0.68,0.16,0.0,0.0,0.0,0.0,0.0,0.16,caitlin grace watt,ENGL-2150,2019
-ENGL,2150,13.0,Lit in 20th-21st Cent Contexts,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,edward thomas joseph troy,ENGL-2150,2019
-ENGL,2150,14.0,Lit in 20th-21st Cent Contexts,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,jennifer hagen forsberg,ENGL-2150,2019
-ENGL,2150,15.0,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,april ayers lawson,ENGL-2150,2019
-ENGL,2150,16.0,Lit in 20th-21st Cent Contexts,0.11,0.63,0.26,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2150,2019
-ENGL,2150,17.0,Lit in 20th-21st Cent Contexts,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,remley melissa makala,ENGL-2150,2019
-ENGL,2150,18.0,Lit in 20th-21st Cent Contexts,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,edward thomas joseph troy,ENGL-2150,2019
-ENGL,2150,19.0,Lit in 20th-21st Cent Contexts,0.17,0.44,0.11,0.0,0.0,0.0,0.0,0.28,amy monaghan,ENGL-2150,2019
-ENGL,2150,20.0,Lit in 20th-21st Cent Contexts,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,megan noel macalystre,ENGL-2150,2019
-ENGL,2150,21.0,Lit in 20th-21st Cent Contexts,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,megan noel macalystre,ENGL-2150,2019
-ENGL,2150,23.0,Lit in 20th-21st Cent Contexts,0.42,0.32,0.16,0.0,0.05,0.0,0.0,0.05,edward thomas joseph troy,ENGL-2150,2019
-ENGL,2150,24.0,Lit in 20th-21st Cent Contexts,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,stephanie lorraine edwards,ENGL-2150,2019
-ENGL,2150,25.0,Lit in 20th-21st Cent Contexts,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,remley melissa makala,ENGL-2150,2019
-ENGL,2150,26.0,Lit in 20th-21st Cent Contexts,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jennifer hagen forsberg,ENGL-2150,2019
-ENGL,2150,27.0,Lit in 20th-21st Cent Contexts,0.59,0.12,0.12,0.06,0.0,0.0,0.0,0.12,remley melissa makala,ENGL-2150,2019
-ENGL,2150,28.0,Lit in 20th-21st Cent Contexts,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,remley melissa makala,ENGL-2150,2019
-ENGL,2150,29.0,Lit in 20th-21st Cent Contexts,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,stephanie lorraine edwards,ENGL-2150,2019
-ENGL,2150,30.0,Lit in 20th-21st Cent Contexts,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,stephanie lorraine edwards,ENGL-2150,2019
-ENGL,2150,100.0,20th - 21st Century Lit (HON),0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-2150,2019
-ENGL,2150,400.0,Lit in 20th-21st Cent Contexts,0.06,0.53,0.29,0.06,0.0,0.0,0.0,0.06,sarah mae cooper,ENGL-2150,2019
-ENGL,2150,401.0,Lit in 20th-21st Cent Contexts,0.06,0.71,0.06,0.06,0.0,0.0,0.0,0.12,sarah mae cooper,ENGL-2150,2019
-ENGL,2160,1.0,African American Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,ENGL-2160,2019
-ENGL,2160,2.0,African American Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allison nicole harris,ENGL-2160,2019
-ENGL,2160,3.0,African American Literature,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,allison nicole harris,ENGL-2160,2019
-ENGL,2160,4.0,African American Literature,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,allison nicole harris,ENGL-2160,2019
-ENGL,2310,1.0,Intro to Journalism,0.59,0.24,0.12,0.06,0.0,0.0,0.0,0.0,william pulley,ENGL-2310,2019
-ENGL,3040,1.0,Business Writing,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,megan lee pietruszewski,ENGL-3040,2019
-ENGL,3040,2.0,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,patricia sunia,ENGL-3040,2019
-ENGL,3040,3.0,Business Writing,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,megan lee pietruszewski,ENGL-3040,2019
-ENGL,3040,4.0,Business Writing,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,william weldon cunningham,ENGL-3040,2019
-ENGL,3040,5.0,Business Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,megan lee pietruszewski,ENGL-3040,2019
-ENGL,3040,6.0,Business Writing,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,la'cresha ulon green,ENGL-3040,2019
-ENGL,3040,7.0,Business Writing,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,la'cresha ulon green,ENGL-3040,2019
-ENGL,3040,8.0,Business Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william weldon cunningham,ENGL-3040,2019
-ENGL,3040,9.0,Business Writing,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,jennifer hagen forsberg,ENGL-3040,2019
-ENGL,3040,10.0,Business Writing,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,ENGL-3040,2019
-ENGL,3040,11.0,Business Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3040,2019
-ENGL,3040,12.0,Business Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katalin beck,ENGL-3040,2019
-ENGL,3040,15.0,Business Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,patricia sunia,ENGL-3040,2019
-ENGL,3040,21.0,Business Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,jennifer hagen forsberg,ENGL-3040,2019
-ENGL,3040,100.0,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,ENGL-3040,2019
-ENGL,3040,400.0,Business Writing,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,kristen louise aldebol-hazle,ENGL-3040,2019
-ENGL,3040,401.0,Business Writing,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,kristen louise aldebol-hazle,ENGL-3040,2019
-ENGL,3040,402.0,Business Writing,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,katalin beck,ENGL-3040,2019
-ENGL,3040,403.0,Business Writing,0.89,0.0,0.05,0.0,0.05,0.0,0.0,0.0,nancy paxton-wilson,ENGL-3040,2019
-ENGL,3100,1.0,Crit Writ Lit,0.26,0.47,0.05,0.0,0.05,0.0,0.0,0.16,dominic mastroianni,ENGL-3100,2019
-ENGL,3100,2.0,Crit Writ Lit,0.68,0.16,0.05,0.0,0.11,0.0,0.0,0.0,david sweeney coombs,ENGL-3100,2019
-ENGL,3100,3.0,Crit Writ Lit,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,kimberly snyder manganelli,ENGL-3100,2019
-ENGL,3120,1.0,Advanced Composition,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,diane mary quaglia beltran,ENGL-3120,2019
-ENGL,3120,3.0,Advanced Composition,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david charles foltz,ENGL-3120,2019
-ENGL,3120,4.0,Advanced Composition,0.44,0.28,0.17,0.11,0.0,0.0,0.0,0.0,jennie elizabeth wakefield,ENGL-3120,2019
-ENGL,3140,1.0,Technical Writing,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,henna marian messina,ENGL-3140,2019
-ENGL,3140,2.0,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henna marian messina,ENGL-3140,2019
-ENGL,3140,3.0,Technical Writing,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,christopher stuart,ENGL-3140,2019
-ENGL,3140,4.0,Technical Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,christopher stuart,ENGL-3140,2019
-ENGL,3140,5.0,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,charlotte estelle lucke,ENGL-3140,2019
-ENGL,3140,6.0,Technical Writing,0.61,0.22,0.06,0.0,0.06,0.0,0.0,0.06,charlotte estelle lucke,ENGL-3140,2019
-ENGL,3140,7.0,Technical Writing,0.83,0.0,0.06,0.06,0.0,0.0,0.0,0.06,shauna chung,ENGL-3140,2019
-ENGL,3140,11.0,Technical Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,ingrid anna pierce,ENGL-3140,2019
-ENGL,3140,12.0,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ingrid anna pierce,ENGL-3140,2019
-ENGL,3140,13.0,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,heather price williams,ENGL-3140,2019
-ENGL,3140,14.0,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,ENGL-3140,2019
-ENGL,3140,15.0,Technical Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,heather price williams,ENGL-3140,2019
-ENGL,3140,17.0,Technical Writing,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,michelle lloyd,ENGL-3140,2019
-ENGL,3140,19.0,Technical Writing,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,michelle lloyd,ENGL-3140,2019
-ENGL,3140,20.0,Technical Writing,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,kathy elaine nixon,ENGL-3140,2019
-ENGL,3140,22.0,Technical Writing,0.67,0.11,0.06,0.0,0.0,0.0,0.0,0.17,kathy elaine nixon,ENGL-3140,2019
-ENGL,3140,100.0,Technical Writing (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,heather price williams,ENGL-3140,2019
-ENGL,3140,401.0,Technical Writing,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,ENGL-3140,2019
-ENGL,3140,402.0,Technical Writing,0.61,0.22,0.11,0.06,0.0,0.0,0.0,0.0,sharon kathleen nalley,ENGL-3140,2019
-ENGL,3140,403.0,Technical Writing,0.53,0.16,0.11,0.16,0.05,0.0,0.0,0.0,heather price williams,ENGL-3140,2019
-ENGL,3140,404.0,Technical Writing,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,henna marian messina,ENGL-3140,2019
-ENGL,3140,406.0,Technical Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,amy patterson,ENGL-3140,2019
-ENGL,3140,407.0,Technical Writing,0.7,0.1,0.05,0.0,0.1,0.0,0.0,0.05,michael russo,ENGL-3140,2019
-ENGL,3140,408.0,Technical Writing,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,michael russo,ENGL-3140,2019
-ENGL,3150,1.0,Scientific Writing & Comm,0.37,0.32,0.0,0.05,0.16,0.0,0.0,0.11,william pulley,ENGL-3150,2019
-ENGL,3150,2.0,Scientific Writing & Comm,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,william pulley,ENGL-3150,2019
-ENGL,3150,3.0,Scientific Writing & Comm,0.83,0.0,0.0,0.0,0.06,0.0,0.0,0.11,christopher benson,ENGL-3150,2019
-ENGL,3150,6.0,Scientific Writing & Comm,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,william pulley,ENGL-3150,2019
-ENGL,3150,400.0,Scientific Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2019
-ENGL,3150,402.0,Scientific Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2019
-ENGL,3150,403.0,Scientific Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2019
-ENGL,3150,404.0,Scientific Writing,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,heather price williams,ENGL-3150,2019
-ENGL,3150,405.0,Scientific Writing,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,megan lee pietruszewski,ENGL-3150,2019
-ENGL,3450,1.0,Intr Creative Writing: Fiction,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,nicholas christiansen brown,ENGL-3450,2019
-ENGL,3460,1.0,Intr Creative Writing: Poetry,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-3460,2019
-ENGL,3480,1.0,Intr Creat Writ: Screenwriting,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,april ayers lawson,ENGL-3480,2019
-ENGL,3500,1.0,Mythology,0.32,0.32,0.11,0.0,0.11,0.0,0.0,0.16,kenneth michael tuite,ENGL-3500,2019
-ENGL,3530,1.0,Amer Lit-Race/Ethnicity/Migrat,0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,angela naimou,ENGL-3530,2019
-ENGL,3540,1.0,Lit Middle East & North Africa,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,angela naimou,ENGL-3540,2019
-ENGL,3570,1.0,Film,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,john robert smith,ENGL-3570,2019
-ENGL,3570,2.0,Film,0.53,0.24,0.12,0.0,0.06,0.0,0.0,0.06,john robert smith,ENGL-3570,2019
-ENGL,3570,3.0,Film,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2019
-ENGL,3570,4.0,Film,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-3570,2019
-ENGL,3850,1.0,Children's Lit,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,megan noel macalystre,ENGL-3850,2019
-ENGL,3860,1.0,Adolescent Lit,0.42,0.47,0.0,0.0,0.0,0.0,0.0,0.11,allison nicole harris,ENGL-3860,2019
-ENGL,3970,2.0,Brit Lit Survey II,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,brian mcgrath,ENGL-3970,2019
-ENGL,3990,1.0,Amer Lit Survey II,0.41,0.41,0.12,0.0,0.06,0.0,0.0,0.0,rhondda robinson thomas,ENGL-3990,2019
-ENGL,3990,2.0,Amer Lit Survey II,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,daniel scott citro,ENGL-3990,2019
-ENGL,4000,1.0,The English Language,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,andrew lemons,ENGL-4000,2019
-ENGL,4010,2.0,Grammar Survey,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,brian mcgrath,ENGL-4010,2019
-ENGL,4110,1.0,Shakespeare,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-4110,2019
-ENGL,4110,2.0,Shakespeare,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,ENGL-4110,2019
-ENGL,4140,1.0,Milton,0.79,0.05,0.16,0.0,0.0,0.0,0.0,0.0,william stockton,ENGL-4140,2019
-ENGL,4180,1.0,Rise of the Novel in English,0.53,0.37,0.0,0.0,0.0,0.0,0.0,0.11,david sweeney coombs,ENGL-4180,2019
-ENGL,4280,1.0,Contemporary Literature,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,ENGL-4280,2019
-ENGL,4340,1.0,Environmental Lit,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,matthew hooley,ENGL-4340,2019
-ENGL,4360,1.0,Feminist Literary Criticism,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,ENGL-4360,2019
-ENGL,4450,1.0,Fiction Workshop,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,keith morris,ENGL-4450,2019
-ENGL,4480,1.0,Screenwriting Wkshop,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nicholas christiansen brown,ENGL-4480,2019
-ENGL,4500,1.0,Film Genres,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,ENGL-4500,2019
-ENGL,4510,1.0,Film Theory and Criticism,0.4,0.47,0.0,0.07,0.07,0.0,0.0,0.0,agnieszka skrodzka,ENGL-4510,2019
-ENGL,4520,2.0,Great Directors,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,agnieszka skrodzka,ENGL-4520,2019
-ENGL,4540,1.0,Labor in International Cinema,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,edward thomas joseph troy,ENGL-4540,2019
-ENGL,4650,1.0,Topics in Lit:Reading Violence,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,maya sylvia hislop,ENGL-4650,2019
-ENGL,4750,1.0,Writing for Media,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,jonathan beecher field,ENGL-4750,2019
-ENGL,4820,1.0,Afr Am Lit to 1920,0.35,0.29,0.24,0.06,0.0,0.0,0.0,0.06,rhondda robinson thomas,ENGL-4820,2019
-ENGL,4960,2.0,SR Sem: End of Cinema,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,ENGL-4960,2019
-ENGL,4960,3.0,SR Sem: Thinking About Love,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,ENGL-4960,2019
-ENGR,1020,112.0,Engineering Discipl & Skills,0.45,0.38,0.1,0.07,0.0,0.0,0.0,0.0,baker martin,ENGR-1020,2019
-ENGR,1020,117.0,Engineering Discipl & Skills,0.54,0.33,0.1,0.0,0.0,0.0,0.0,0.03,matthew kent miller,ENGR-1020,2019
-ENGR,1020,321.0,Engr Discipl & Skills (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jonathan brooks harcum,ENGR-1020,2019
-ENGR,1020,325.0,Engr Discipl & Skills (HON),0.63,0.33,0.05,0.0,0.0,0.0,0.0,0.0,richard watkins,ENGR-1020,2019
-ENGR,1020,611.0,Engineering Discipl & Skills,0.51,0.34,0.13,0.0,0.0,0.0,0.0,0.02,jonathan brooks harcum,ENGR-1020,2019
-ENGR,1020,612.0,Engineering Discipl & Skills,0.58,0.29,0.06,0.02,0.02,0.0,0.0,0.02,jonathan brooks harcum,ENGR-1020,2019
-ENGR,1020,613.0,Engineering Discipl & Skills,0.24,0.3,0.36,0.06,0.0,0.0,0.0,0.03,andrew isaac neptune,ENGR-1020,2019
-ENGR,1020,614.0,Engineering Discipl & Skills,0.55,0.2,0.14,0.06,0.02,0.0,0.0,0.02,steven brandon,ENGR-1020,2019
-ENGR,1020,615.0,Engineering Discipl & Skills,0.46,0.35,0.13,0.0,0.02,0.0,0.0,0.04,steven brandon,ENGR-1020,2019
-ENGR,1020,617.0,Engineering Discipl & Skills,0.55,0.3,0.09,0.0,0.0,0.0,0.0,0.06,taylor james sorensen,ENGR-1020,2019
-ENGR,1020,618.0,Engineering Discipl & Skills,0.47,0.34,0.11,0.06,0.02,0.0,0.0,0.0,taylor james sorensen,ENGR-1020,2019
-ENGR,1020,712.0,Engineering Discipl & Skills,0.53,0.33,0.08,0.05,0.03,0.0,0.0,0.0,matthew kent miller,ENGR-1020,2019
-ENGR,1020,713.0,Engineering Discipl & Skills,0.39,0.41,0.12,0.05,0.0,0.0,0.0,0.02,matthew kent miller,ENGR-1020,2019
-ENGR,1020,811.0,Engineering Discipl & Skills,0.47,0.39,0.08,0.0,0.02,0.0,0.0,0.04,irene marie ferrara,ENGR-1020,2019
-ENGR,1020,812.0,Engineering Discipl & Skills,0.46,0.38,0.13,0.02,0.02,0.0,0.0,0.0,jonathan maier,ENGR-1020,2019
-ENGR,1020,813.0,Engineering Discipl & Skills,0.45,0.37,0.12,0.04,0.0,0.0,0.0,0.02,jonathan maier,ENGR-1020,2019
-ENGR,1020,814.0,Engineering Discipl & Skills,0.56,0.32,0.07,0.02,0.0,0.0,0.0,0.02,taylor james sorensen,ENGR-1020,2019
-ENGR,1020,815.0,Engineering Discipl & Skills,0.45,0.47,0.05,0.0,0.03,0.0,0.0,0.0,cynthia miller smith,ENGR-1020,2019
-ENGR,1020,816.0,Engineering Discipl & Skills,0.45,0.34,0.18,0.0,0.02,0.0,0.0,0.0,cynthia miller smith,ENGR-1020,2019
-ENGR,1020,817.0,Engineering Discipl & Skills,0.38,0.4,0.04,0.02,0.04,0.0,0.0,0.13,andrew isaac neptune,ENGR-1020,2019
-ENGR,1020,818.0,Engineering Discipl & Skills,0.39,0.41,0.09,0.02,0.02,0.0,0.0,0.07,andrew isaac neptune,ENGR-1020,2019
-ENGR,1060,400.0,Engr Discipline & Skills II,0.1,0.5,0.25,0.15,0.0,0.0,0.0,0.0,irene marie ferrara,ENGR-1060,2019
-ENGR,1410,222.0,Programming & Problem Solving,0.08,0.29,0.18,0.13,0.13,0.0,0.0,0.18,william martin,ENGR-1410,2019
-ENGR,1410,223.0,Programming & Problem Solving,0.08,0.29,0.32,0.13,0.08,0.0,0.0,0.11,william martin,ENGR-1410,2019
-ENGR,1410,226.0,Programming & Problem Solving,0.06,0.31,0.2,0.23,0.06,0.0,0.0,0.14,shubhamkar sanjay kulkarni,ENGR-1410,2019
-ENGR,1410,227.0,Programming & Problem Solving,0.06,0.14,0.36,0.08,0.06,0.0,0.0,0.31,shubhamkar sanjay kulkarni,ENGR-1410,2019
-ENGR,1510,621.0,Engineering Skills,0.29,0.37,0.26,0.05,0.03,0.0,0.0,0.0,elizabeth anne stephan,ENGR-1510,2019
-ENGR,1510,622.0,Engineering Skills,0.21,0.32,0.34,0.05,0.08,0.0,0.0,0.0,elizabeth anne stephan,ENGR-1510,2019
-ENGR,1900,10.0,CI in Engr I Robotics,0.9,0.0,0.0,0.0,0.03,0.0,0.0,0.06,michael benjamin wooten,ENGR-1900,2019
-ENGR,1900,12.0,RISE CI Kinetic Sculpture,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,christopher norfolk,ENGR-1900,2019
-ENGR,1900,193.0,Special Projects in Engr I,0.13,0.44,0.31,0.08,0.05,0.0,0.0,0.0,john minor,ENGR-1900,2019
-ENGR,1900,194.0,Special Projects in Engr I,0.11,0.29,0.29,0.09,0.11,0.0,0.0,0.11,john minor,ENGR-1900,2019
-ENGR,2080,683.0,Engr Graphics & Machine Design,0.37,0.34,0.13,0.03,0.0,0.0,0.0,0.13,nisha dilip gulhane,ENGR-2080,2019
-ENGR,2080,684.0,Engr Graphics & Machine Design,0.36,0.38,0.1,0.03,0.13,0.0,0.0,0.0,apurva patel,ENGR-2080,2019
-ENGR,2080,685.0,Engr Graphics & Machine Design,0.26,0.33,0.13,0.0,0.1,0.0,0.0,0.18,kyle walker,ENGR-2080,2019
-ENGR,2080,686.0,Engr Graphics & Machine Design,0.31,0.31,0.13,0.08,0.08,0.0,0.0,0.1,kyle walker,ENGR-2080,2019
-ENGR,2080,881.0,Engr Graphics & Machine Design,0.41,0.27,0.16,0.0,0.05,0.0,0.0,0.11,nighat yasmin,ENGR-2080,2019
-ENGR,2080,882.0,Engr Graphics & Machine Design,0.49,0.28,0.1,0.03,0.03,0.0,0.0,0.08,nighat yasmin,ENGR-2080,2019
-ENGR,2100,804.0,CAD & Engineering Applications,0.43,0.2,0.22,0.08,0.02,0.0,0.0,0.04,nighat yasmin,ENGR-2100,2019
-ENGR,2100,805.0,CAD & Engineering Applications,0.38,0.31,0.2,0.04,0.04,0.0,0.0,0.02,afshin famili,ENGR-2100,2019
-ENGR,2100,806.0,CAD & Engineering Applications,0.38,0.43,0.12,0.0,0.05,0.0,0.0,0.02,afshin famili,ENGR-2100,2019
-ENGR,2210,316.0,"Technology, Culture and Design",0.44,0.41,0.1,0.0,0.05,0.0,0.0,0.0,jonathan maier,ENGR-2210,2019
-ENR,1010,2.0,Intro to Envir & Natur Res I,0.79,0.13,0.05,0.02,0.0,0.0,0.0,0.02,greg yarrow,ENR-1010,2019
-ENR,1010,3.0,Intro to Envir & Natur Res I,0.74,0.14,0.06,0.05,0.0,0.0,0.0,0.02,greg yarrow,ENR-1010,2019
-ENR,4140,1.0,Plant ID and Systematics,0.73,0.2,0.0,0.0,0.03,0.0,0.0,0.03,patrick mcmillan,ENR-4140,2019
-ENR,4290,1.0,Environ Law & Policy,0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.04,alan johnson,ENR-4290,2019
-ENR,4290,2.0,Environ Law & Policy,0.6,0.3,0.11,0.0,0.0,0.0,0.0,0.0,alan johnson,ENR-4290,2019
-ENSP,2000,1.0,Intro Environ Sci,0.55,0.17,0.17,0.04,0.0,0.0,0.0,0.06,scott brame,ENSP-2000,2019
-ENSP,2000,2.0,Intro Environ Sci,0.64,0.27,0.04,0.0,0.04,0.0,0.0,0.02,minory nammouz,ENSP-2000,2019
-ENSP,2000,3.0,Intro Environ Sci,0.66,0.32,0.0,0.0,0.0,0.0,0.0,0.02,minory nammouz,ENSP-2000,2019
-ENSP,2000,4.0,Intro Environ Sci,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,ENSP-2000,2019
-ENSP,2000,5.0,Intro Environ Sci,0.24,0.58,0.09,0.04,0.0,0.0,0.0,0.04,tom owino,ENSP-2000,2019
-ENSP,2000,6.0,Intro Environ Sci,0.79,0.1,0.1,0.0,0.0,0.0,0.0,0.0,john gregory sherwood,ENSP-2000,2019
-ENSP,4000,1.0,Studies in Environmental Sci,0.63,0.05,0.16,0.11,0.05,0.0,0.0,0.0,margaret louise thompson,ENSP-4000,2019
-ENT,2000,1.0,Six-Legged Science,0.45,0.33,0.18,0.03,0.0,0.0,0.0,0.03,suellen pometto,ENT-2000,2019
-ENT,3010,1.0,Insect Biology and Diversity,0.56,0.25,0.09,0.0,0.03,0.0,0.0,0.06,carmen blubaugh,ENT-3010,2019
-ENTR,1010,3.0,Entrepreneurial Mindset,0.73,0.19,0.02,0.02,0.02,0.0,0.0,0.02,john michael hannon,ENTR-1010,2019
-ENTR,1090,1.0,Creative Inq-Entrepreneurship,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,ENTR-1090,2019
-ENTR,1090,20.0,Lemonade Day,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,david joseph frock,ENTR-1090,2019
-ENTR,2010,4.0,Sports Entrepreneurship,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,john michael hannon,ENTR-2010,2019
-ESED,8000,1.0,Seminar in Engr & Science Educ,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,cindy lee,ESED-8000,2019
-ESED,8500,2.0,Spec Top Engineering & Sci Edu,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,eliza dargan gallagher,ESED-8500,2019
-ESED,8610,2.0,Practicum in Engr & Sci Educ,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,karen ann high,ESED-8610,2019
-ETOX,4300,1.0,Toxicology,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,lisa bain,ETOX-4300,2019
-FDSC,1010,1.0,Intro to Food Sci & Hum Nutr,0.76,0.13,0.04,0.02,0.01,0.0,0.0,0.04,carol hegler,FDSC-1010,2019
-FDSC,3010,1.0,Food Regulations,0.68,0.21,0.0,0.0,0.04,0.0,0.0,0.07,sara lane cothran,FDSC-3010,2019
-FDSC,3060,1.0,Institutional Food Service Mgt,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,FDSC-3060,2019
-FDSC,4010,1.0,Food Chemistry I,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,feng chen,FDSC-4010,2019
-FDSC,4040,1.0,Food Prsv & Process,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,anthony louis pometto,FDSC-4040,2019
-FDSC,4300,1.0,Dairy Process & Sant,0.5,0.19,0.19,0.06,0.0,0.0,0.0,0.06,john mcgregor,FDSC-4300,2019
-FDSC,4500,1.0,Creative Inquiry-Food Science,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth lacey durrance,FDSC-4500,2019
-FDSC,4500,11.0,Creative Inquiry-Food Science,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,paul dawson,FDSC-4500,2019
-FDSC,4500,26.0,Creative Inquiry-Food Science,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,FDSC-4500,2019
-FIN,2010,401.0,Intro to Personal Finance,0.92,0.05,0.01,0.0,0.01,0.0,0.0,0.01,joshua harris,FIN-2010,2019
-FIN,2010,402.0,Intro to Personal Finance,0.89,0.05,0.01,0.02,0.01,0.0,0.0,0.01,joshua harris,FIN-2010,2019
-FIN,3040,1.0,Risk & Insurance,0.11,0.27,0.51,0.03,0.03,0.0,0.0,0.05,kerri mcmillan,FIN-3040,2019
-FIN,3050,1.0,Investment Analysis,0.21,0.21,0.4,0.12,0.0,0.0,0.0,0.05,kerri mcmillan,FIN-3050,2019
-FIN,3050,2.0,Investment Analysis,0.17,0.54,0.24,0.02,0.02,0.0,0.0,0.0,kerri mcmillan,FIN-3050,2019
-FIN,3050,3.0,Investment Analysis,0.2,0.4,0.35,0.05,0.0,0.0,0.0,0.0,kerri mcmillan,FIN-3050,2019
-FIN,3050,4.0,Investment Analysis,0.09,0.35,0.28,0.13,0.02,0.0,0.0,0.13,john alexander,FIN-3050,2019
-FIN,3060,1.0,Corporation Finance,0.32,0.23,0.23,0.14,0.0,0.0,0.0,0.09,ramon tolbert franklin,FIN-3060,2019
-FIN,3060,2.0,Corporation Finance,0.09,0.38,0.22,0.2,0.0,0.0,0.0,0.11,ramon tolbert franklin,FIN-3060,2019
-FIN,3060,3.0,Corporation Finance,0.11,0.32,0.32,0.14,0.05,0.0,0.0,0.07,ramon tolbert franklin,FIN-3060,2019
-FIN,3060,4.0,Corporation Finance,0.04,0.11,0.29,0.42,0.04,0.0,0.0,0.09,ramon tolbert franklin,FIN-3060,2019
-FIN,3060,7.0,Corporation Finance,0.26,0.34,0.28,0.11,0.0,0.0,0.0,0.02,minxing sun,FIN-3060,2019
-FIN,3060,8.0,Corporation Finance,0.29,0.4,0.21,0.04,0.04,0.0,0.0,0.02,minxing sun,FIN-3060,2019
-FIN,3060,9.0,Corporation Finance,0.02,0.38,0.33,0.25,0.02,0.0,0.0,0.0,minxing sun,FIN-3060,2019
-FIN,3060,403.0,Corporation Finance,0.19,0.51,0.21,0.01,0.03,0.0,0.0,0.04,jonathan godbey,FIN-3060,2019
-FIN,3060,404.0,Corporation Finance,0.26,0.4,0.14,0.02,0.08,0.0,0.0,0.11,jonathan godbey,FIN-3060,2019
-FIN,3070,1.0,Prin of Real Estate,0.14,0.44,0.26,0.09,0.05,0.0,0.0,0.02,thomas springer,FIN-3070,2019
-FIN,3070,2.0,Prin of Real Estate,0.2,0.3,0.25,0.2,0.05,0.0,0.0,0.0,thomas springer,FIN-3070,2019
-FIN,3070,5.0,Prin of Real Estate,0.3,0.27,0.24,0.06,0.09,0.0,0.0,0.03,bryan blackwood,FIN-3070,2019
-FIN,3080,1.0,Fin Inst & Mkts,0.34,0.49,0.15,0.0,0.0,0.0,0.0,0.02,lyudmila chernykh,FIN-3080,2019
-FIN,3080,2.0,Fin Inst & Mkts,0.1,0.58,0.28,0.05,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-3080,2019
-FIN,3080,3.0,Fin Inst & Mkts,0.33,0.48,0.17,0.02,0.0,0.0,0.0,0.0,daniel thomas greene,FIN-3080,2019
-FIN,3080,401.0,Fin Inst & Mkts,0.31,0.35,0.31,0.0,0.02,0.0,0.0,0.0,daniel thomas greene,FIN-3080,2019
-FIN,3110,1.0,Financial Management I,0.08,0.28,0.25,0.13,0.13,0.0,0.0,0.15,jack wolf,FIN-3110,2019
-FIN,3110,2.0,Financial Management I,0.06,0.18,0.24,0.12,0.15,0.0,0.0,0.26,jack wolf,FIN-3110,2019
-FIN,3110,3.0,Financial Management I,0.13,0.31,0.38,0.13,0.05,0.0,0.0,0.0,weike xu,FIN-3110,2019
-FIN,3110,4.0,Financial Management I,0.47,0.4,0.11,0.0,0.0,0.0,0.0,0.02,joshua harris,FIN-3110,2019
-FIN,3110,5.0,Financial Management I,0.44,0.31,0.22,0.02,0.0,0.0,0.0,0.0,joshua harris,FIN-3110,2019
-FIN,3110,6.0,Financial Management I,0.24,0.27,0.29,0.09,0.02,0.0,0.0,0.09,joshua harris,FIN-3110,2019
-FIN,3110,102.0,Financial Management I (HON),0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,jack wolf,FIN-3110,2019
-FIN,3120,1.0,Financial Management II,0.15,0.27,0.41,0.1,0.05,0.0,0.0,0.02,vincent james intintoli,FIN-3120,2019
-FIN,3120,2.0,Financial Management II,0.16,0.33,0.31,0.09,0.07,0.0,0.0,0.04,vincent james intintoli,FIN-3120,2019
-FIN,3120,3.0,Financial Management II,0.33,0.3,0.27,0.06,0.0,0.0,0.0,0.03,blerina zykaj,FIN-3120,2019
-FIN,3120,4.0,Financial Management II,0.17,0.24,0.22,0.22,0.07,0.0,0.0,0.09,weike xu,FIN-3120,2019
-FIN,3120,5.0,Financial Management II,0.1,0.44,0.32,0.12,0.02,0.0,0.0,0.0,weike xu,FIN-3120,2019
-FIN,3120,101.0,Financial Mgt II (HON),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,vincent james intintoli,FIN-3120,2019
-FIN,3120,103.0,Financial Mgt II (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,FIN-3120,2019
-FIN,4010,1.0,Corporate Financial Analysis,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,FIN-4010,2019
-FIN,4020,1.0,Corporate Valuation,0.11,0.34,0.34,0.14,0.0,0.0,0.0,0.07,angela morgan,FIN-4020,2019
-FIN,4020,101.0,Corporate Valuation (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,angela morgan,FIN-4020,2019
-FIN,4050,1.0,Portfolio Management & Theory,0.07,0.24,0.36,0.11,0.0,0.0,0.0,0.22,john alexander,FIN-4050,2019
-FIN,4060,1.0,Derivatives Analysis,0.17,0.51,0.17,0.03,0.06,0.0,0.0,0.06,blerina zykaj,FIN-4060,2019
-FIN,4110,1.0,Int Fin Mgt,0.34,0.51,0.15,0.0,0.0,0.0,0.0,0.0,luke asher devault,FIN-4110,2019
-FIN,4110,2.0,Int Fin Mgt,0.58,0.27,0.1,0.02,0.02,0.0,0.0,0.0,luke asher devault,FIN-4110,2019
-FIN,4980,2.0,CI in Finance: CFA,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jack wolf,FIN-4980,2019
-FIN,4980,4.0,CI in Finance: SIE,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,joshua harris,FIN-4980,2019
-FIN,4980,5.0,CI in Finance: AI,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,yannan shen,FIN-4980,2019
-FIN,4980,6.0,CI in Finance: Machine Learnin,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,yannan shen,FIN-4980,2019
-FNR,2040,1.0,Soil Information Systems,0.85,0.1,0.0,0.02,0.0,0.0,0.0,0.03,elena mikhailova,FNR-2040,2019
-FNR,4700,5.0,Landscape Ecology / Appalachia,0.83,0.0,0.0,0.17,0.0,0.0,0.0,0.0,russell barrett,FNR-4700,2019
-FNR,4700,10.0,Kennedy Waterfowl & Wetlands,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,richard marvin kaminski,FNR-4700,2019
-FNR,4700,26.0,Stream Fish Mercury Dynamics,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,troy mason farmer,FNR-4700,2019
-FNR,4700,44.0,Alligator Ecology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,catherine michelle jachowski,FNR-4700,2019
-FNR,4700,129.0,GIS & SIS Applications,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher post,FNR-4700,2019
-FNR,4990,1.0,Natural Resources Seminar,0.55,0.38,0.03,0.0,0.03,0.0,0.0,0.0,susan talley guynn,FNR-4990,2019
-FOR,2050,1.0,Dendrology,0.17,0.42,0.08,0.04,0.13,0.0,0.0,0.17,donald hagan,FOR-2050,2019
-FOR,2050,2.0,Dendrology,0.45,0.21,0.09,0.09,0.06,0.0,0.0,0.09,donald hagan,FOR-2050,2019
-FOR,2050,3.0,Dendrology,0.19,0.13,0.28,0.19,0.09,0.0,0.0,0.13,donald hagan,FOR-2050,2019
-FOR,2210,1.0,Forest Biology,0.18,0.46,0.22,0.04,0.04,0.0,0.0,0.07,jessica ann hartshorn,FOR-2210,2019
-FOR,3020,1.0,Forest Biometrics,0.38,0.54,0.05,0.0,0.0,0.0,0.0,0.03,brian ritter,FOR-3020,2019
-FOR,3040,1.0,Forest Resource Economics,0.67,0.23,0.05,0.05,0.0,0.0,0.0,0.0,puskar khanal,FOR-3040,2019
-FOR,3410,1.0,Wood Procure Pract,0.61,0.3,0.06,0.03,0.0,0.0,0.0,0.0,patrick hiesl,FOR-3410,2019
-FOR,4100,1.0,Harvesting Processes,0.54,0.35,0.12,0.0,0.0,0.0,0.0,0.0,patrick hiesl,FOR-4100,2019
-FOR,4130,1.0,Integrated Forest Pest Mgt,0.57,0.37,0.06,0.0,0.0,0.0,0.0,0.0,jessica ann hartshorn,FOR-4130,2019
-FOR,4150,1.0,Forest Wildlife Managment,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,FOR-4150,2019
-FOR,4160,1.0,Forest Policy and Admin,0.41,0.32,0.24,0.02,0.0,0.0,0.0,0.0,thomas straka,FOR-4160,2019
-FOR,4170,1.0,Forest Resource Mgt & Regulatn,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,FOR-4170,2019
-FOR,4340,1.0,GIS for Natural Resources,0.63,0.31,0.04,0.0,0.0,0.0,0.0,0.02,christopher post,FOR-4340,2019
-FR,1010,1.0,Elementary French,0.0,0.45,0.27,0.18,0.0,0.0,0.0,0.09,anne carole salces  nedeo,FR-1010,2019
-FR,1010,2.0,Elementary French,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,anne carole salces  nedeo,FR-1010,2019
-FR,1010,3.0,Elementary French,0.38,0.19,0.13,0.06,0.13,0.0,0.0,0.13,anne carole salces  nedeo,FR-1010,2019
-FR,1020,1.0,Elementary French,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,FR-1020,2019
-FR,1020,2.0,Elementary French,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,FR-1020,2019
-FR,1020,3.0,Elementary French,0.21,0.43,0.14,0.07,0.07,0.0,0.0,0.07,anne carole salces  nedeo,FR-1020,2019
-FR,2010,1.0,Intermediate French,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,FR-2010,2019
-FR,2010,2.0,Intermediate French,0.0,0.73,0.13,0.07,0.07,0.0,0.0,0.0,kenneth david widgren,FR-2010,2019
-FR,2010,3.0,Intermediate French,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,pauline de tholozany,FR-2010,2019
-FR,2020,1.0,Intermediate French,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,FR-2020,2019
-FR,2020,2.0,Intermediate French,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,FR-2020,2019
-FR,2020,4.0,Intermediate French,0.2,0.47,0.2,0.13,0.0,0.0,0.0,0.0,kenneth david widgren,FR-2020,2019
-FR,3000,1.0,Survey of French Lit,0.67,0.28,0.0,0.06,0.0,0.0,0.0,0.0,pauline de tholozany,FR-3000,2019
-FR,3050,1.0,Int Fr Con & Comp I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kenneth david widgren,FR-3050,2019
-FR,3050,2.0,Int Fr Con & Comp I,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,anne carole salces  nedeo,FR-3050,2019
-FR,3070,1.0,French Civilization,0.6,0.27,0.0,0.07,0.0,0.0,0.0,0.07,eric touya,FR-3070,2019
-FR,4120,1.0,Fr & Francoph Cinema,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joseph mai,FR-4120,2019
-GC,1020,1.0,Computer Art & CAD Foundations,0.47,0.35,0.07,0.02,0.08,0.0,0.0,0.01,carol jones,GC-1020,2019
-GC,1040,1.0,Graphic Communications I,0.63,0.19,0.09,0.0,0.09,0.0,0.0,0.0,michelle suki bost fox,GC-1040,2019
-GC,2070,1.0,Graphic Communications II,0.64,0.28,0.06,0.02,0.0,0.0,0.0,0.0,charles tabor weiss,GC-2070,2019
-GC,3400,1.0,Digital Imaging and eMedia,0.35,0.44,0.15,0.02,0.02,0.0,0.0,0.02,erica black walker,GC-3400,2019
-GC,3460,1.0,Ink and Substrates,0.63,0.32,0.02,0.02,0.0,0.0,0.0,0.0,shu chang,GC-3460,2019
-GC,4060,1.0,Package and Specialty Printing,0.48,0.5,0.03,0.0,0.0,0.0,0.0,0.0,kern cox,GC-4060,2019
-GC,4400,1.0,Commercial Printing,0.44,0.54,0.02,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,GC-4400,2019
-GC,4440,1.0,Current Dev/Trends in Gr Comm,0.42,0.48,0.09,0.0,0.0,0.0,0.0,0.0,liam henry 'hara,GC-4440,2019
-GC,4800,1.0,Senior Seminar in GC,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,charles edward tonkin,GC-4800,2019
-GC,4900,6.0,GC-UX & Web Design,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,erica black walker,GC-4900,2019
-GC,4900,8.0,Strat Messaging in Social Age,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,nigel robertson,GC-4900,2019
-GC,4900,10.0,EC: Concept & Storytelling,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,brian connaughton,GC-4900,2019
-GC,4900,16.0,GC Visual Design & Art Direct,0.75,0.06,0.13,0.0,0.0,0.0,0.0,0.06,erica black walker,GC-4900,2019
-GEN,1030,1.0,Careers in Bioch/Gen,0.81,0.16,0.02,0.0,0.0,0.0,0.0,0.01,joseph paul thames,GEN-1030,2019
-GEN,3000,1.0,Fundamental Genetics,0.47,0.24,0.16,0.05,0.03,0.0,0.0,0.05,marcos tulio oliveira,GEN-3000,2019
-GEN,3000,2.0,Fundamental Genetics,0.43,0.32,0.13,0.04,0.04,0.0,0.0,0.04,marcos tulio oliveira,GEN-3000,2019
-GEN,3020,1.0,Molecular & General Genetics,0.26,0.41,0.23,0.05,0.02,0.0,0.0,0.04,kate leanne willingha tsai,GEN-3020,2019
-GEN,3020,2.0,Molec & General Genetics (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,kate leanne willingha tsai,GEN-3020,2019
-GEN,4100,1.0,Population & Quant Genetics,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,GEN-4100,2019
-GEN,4110,1.0,Population & Quant Gen Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,GEN-4110,2019
-GEN,4110,2.0,Population & Quant Gen Lab,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,kimberly kanapeckas metris,GEN-4110,2019
-GEN,4110,4.0,Population & Quant Gen Lab,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,GEN-4110,2019
-GEN,4400,1.0,Bioinformatics,0.74,0.16,0.02,0.0,0.02,0.0,0.0,0.05,frank alexander feltus,GEN-4400,2019
-GEN,4400,2.0,Bioinformatics (HON),0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,frank alexander feltus,GEN-4400,2019
-GEN,4500,1.0,Comparative Genetics,0.21,0.53,0.21,0.02,0.0,0.0,0.0,0.02,leigh anne clark,GEN-4500,2019
-GEN,4500,2.0,Comparative Genetics (HON),0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,leigh anne clark,GEN-4500,2019
-GEN,4900,1.0,Epigenetics,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,rajandeep singh sekhon,GEN-4900,2019
-GEN,4900,20.0,GB Prof Development,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alison nicole starr-moss,GEN-4900,2019
-GEN,4930,1.0,Senior Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,GEN-4930,2019
-GEN,4930,2.0,Senior Seminar,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,hong luo,GEN-4930,2019
-GEOG,1010,1.0,Intro to Geography,0.39,0.39,0.13,0.03,0.0,0.0,0.0,0.05,christa smith,GEOG-1010,2019
-GEOG,1030,1.0,World Regional Geography,0.27,0.48,0.15,0.06,0.03,0.0,0.0,0.02,william church terry,GEOG-1030,2019
-GEOG,1030,2.0,World Regional Geography,0.35,0.25,0.23,0.05,0.08,0.0,0.0,0.05,william church terry,GEOG-1030,2019
-GEOL,1010,1.0,Physical Geology,0.27,0.3,0.2,0.12,0.06,0.0,0.0,0.05,alan coulson,GEOL-1010,2019
-GEOL,1010,2.0,Physical Geology,0.32,0.31,0.21,0.08,0.05,0.0,0.0,0.03,alan coulson,GEOL-1010,2019
-GEOL,1010,3.0,Physical Geology,0.43,0.34,0.19,0.04,0.0,0.0,0.0,0.0,mary katherine fidler,GEOL-1010,2019
-GEOL,1010,4.0,Physical Geology,0.49,0.24,0.2,0.02,0.04,0.0,0.0,0.0,mary katherine fidler,GEOL-1010,2019
-GEOL,1010,5.0,Physical Geology,0.56,0.21,0.17,0.02,0.02,0.0,0.0,0.02,kelly best lazar,GEOL-1010,2019
-GEOL,1030,1.0,Physical Geol Lab,0.27,0.41,0.14,0.05,0.05,0.0,0.0,0.09,emily don scribner,GEOL-1030,2019
-GEOL,1030,2.0,Physical Geol Lab,0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2019
-GEOL,1030,3.0,Physical Geol Lab,0.42,0.42,0.08,0.0,0.04,0.0,0.0,0.04,alan coulson,GEOL-1030,2019
-GEOL,1030,4.0,Physical Geol Lab,0.71,0.21,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2019
-GEOL,1030,5.0,Physical Geol Lab,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,6.0,Physical Geol Lab,0.54,0.33,0.0,0.04,0.0,0.0,0.0,0.08,alan coulson,GEOL-1030,2019
-GEOL,1030,7.0,Physical Geol Lab,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,8.0,Physical Geol Lab,0.5,0.36,0.0,0.09,0.0,0.0,0.0,0.05,alan coulson,GEOL-1030,2019
-GEOL,1030,9.0,Physical Geol Lab,0.36,0.41,0.09,0.05,0.09,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,10.0,Physical Geol Lab,0.22,0.48,0.13,0.0,0.04,0.0,0.0,0.13,emily don scribner,GEOL-1030,2019
-GEOL,1030,11.0,Physical Geol Lab,0.67,0.17,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,GEOL-1030,2019
-GEOL,1030,12.0,Physical Geol Lab,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,13.0,Physical Geol Lab,0.45,0.41,0.09,0.0,0.05,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,14.0,Physical Geol Lab,0.47,0.27,0.2,0.0,0.07,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,15.0,Physical Geol Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,16.0,Physical Geol Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,17.0,Physical Geol Lab,0.57,0.26,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,GEOL-1030,2019
-GEOL,1120,1.0,Earth Resources,0.36,0.4,0.18,0.04,0.02,0.0,0.0,0.0,emily don scribner,GEOL-1120,2019
-GEOL,1140,1.0,Earth Resources Lab,0.65,0.22,0.08,0.03,0.03,0.0,0.0,0.0,emily don scribner,GEOL-1140,2019
-GEOL,2700,1.0,Sustainable Water,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,GEOL-2700,2019
-GEOL,3000,1.0,Environmental Geology,0.18,0.36,0.32,0.05,0.05,0.0,0.0,0.05,alan coulson,GEOL-3000,2019
-GEOL,4500,1.0,Paleoclimate Change,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,alexander thomas pullen,GEOL-4500,2019
-GEOL,4910,1.0,Research Synthesis I,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-4910,2019
-GEOL,7900,501.0,Biogeography And Geology of SC,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,GEOL-7900,2019
-GER,1010,1.0,Elementary German,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,oswald harris king,GER-1010,2019
-GER,1010,2.0,Elementary German,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,oswald harris king,GER-1010,2019
-GER,1020,2.0,Elementary German,0.58,0.17,0.08,0.0,0.0,0.0,0.0,0.17, lee ferrell,GER-1020,2019
-GER,2010,1.0,Intermediate German,0.22,0.39,0.28,0.06,0.0,0.0,0.0,0.06,johannes schmidt,GER-2010,2019
-GER,2020,1.0,Intermediate German,0.14,0.43,0.29,0.0,0.0,0.0,0.0,0.14,gabriela stoicea,GER-2020,2019
-GER,2600,1.0,Selected Topics in German Lit,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,gabriela stoicea,GER-2600,2019
-GER,3050,1.0,Ger Conv & Comp,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0, lee ferrell,GER-3050,2019
-GER,3400,1.0,German Culture,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,oswald harris king,GER-3400,2019
-HCG,9050,400.0,"Genomics, Ethics & Hlth Policy",0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,linda ward,HCG-9050,2019
-HIST,1010,1.0,History of the United States,0.56,0.39,0.0,0.0,0.03,0.0,0.0,0.03,lee brady wilson,HIST-1010,2019
-HIST,1010,2.0,History of the United States,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,james bradford jeffries,HIST-1010,2019
-HIST,1020,1.0,History of the United States,0.48,0.39,0.1,0.0,0.0,0.0,0.0,0.03,rebecca anna stoil,HIST-1020,2019
-HIST,1220,1.0,"Hist, Tech & Society",0.23,0.54,0.13,0.02,0.04,0.0,0.0,0.03,pamela mack,HIST-1220,2019
-HIST,1240,1.0,Environmental History Survey,0.14,0.42,0.28,0.06,0.03,0.0,0.0,0.08,james bradford jeffries,HIST-1240,2019
-HIST,1240,2.0,Environmental History Survey,0.18,0.36,0.39,0.0,0.0,0.0,0.0,0.07,james bradford jeffries,HIST-1240,2019
-HIST,1720,1.0,The West and the World I,0.43,0.34,0.17,0.0,0.01,0.0,0.0,0.04,steven marks,HIST-1720,2019
-HIST,1720,2.0,The West and the World I,0.41,0.34,0.14,0.03,0.02,0.0,0.0,0.06,kathryn langenfeld,HIST-1720,2019
-HIST,1720,3.0,The West and the World (HON),0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,HIST-1720,2019
-HIST,1720,4.0,The West and the World I,0.37,0.53,0.0,0.0,0.0,0.0,0.0,0.11,thomas kuehn,HIST-1720,2019
-HIST,1730,1.0,The West and the World II,0.52,0.27,0.12,0.02,0.04,0.0,0.0,0.04, alan grubb,HIST-1730,2019
-HIST,2990,1.0,Historian's Craft,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,elizabeth donnelly carney,HIST-2990,2019
-HIST,2990,3.0,Historian's Craft,0.68,0.21,0.0,0.0,0.11,0.0,0.0,0.0,michael silvestri,HIST-2990,2019
-HIST,3040,1.0,Indus & Progr Era,0.5,0.22,0.17,0.06,0.0,0.0,0.0,0.06, roger grant,HIST-3040,2019
-HIST,3060,1.0,US: Postwar World 1945-1975,0.68,0.24,0.0,0.0,0.0,0.0,0.0,0.08,rebecca anna stoil,HIST-3060,2019
-HIST,3240,1.0,Hist of the South II,0.31,0.45,0.03,0.0,0.17,0.0,0.0,0.03,john andrew,HIST-3240,2019
-HIST,3280,1.0,US Legal History to 1890,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,lee brady wilson,HIST-3280,2019
-HIST,3330,1.0,Hist of Mod Japan,0.24,0.38,0.31,0.03,0.03,0.0,0.0,0.0,edwin moise,HIST-3330,2019
-HIST,3370,1.0,History South Africa,0.48,0.28,0.17,0.03,0.03,0.0,0.0,0.0,james burns,HIST-3370,2019
-HIST,3540,1.0,Greek World,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathryn langenfeld,HIST-3540,2019
-HIST,3670,1.0,Modern Ireland,0.53,0.27,0.07,0.07,0.0,0.0,0.0,0.07,michael silvestri,HIST-3670,2019
-HIST,3700,1.0,Medieval History,0.46,0.23,0.08,0.04,0.15,0.0,0.0,0.04,caroline dunn clark,HIST-3700,2019
-HIST,3720,1.0,Renaissance,0.47,0.35,0.06,0.0,0.06,0.0,0.0,0.06,thomas kuehn,HIST-3720,2019
-HIST,3940,1.0,Non-Western History,0.18,0.35,0.18,0.0,0.06,0.0,0.0,0.24,stephanie hassell,HIST-3940,2019
-HIST,3970,1.0,Modern Middle East,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,HIST-3970,2019
-HIST,4000,1.0,Disney Parks,0.56,0.34,0.09,0.0,0.0,0.0,0.0,0.0,stephanie barczewski,HIST-4000,2019
-HIST,4000,2.0,Amer Comparative Frontiers,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08, roger grant,HIST-4000,2019
-HIST,4140,1.0,Study of Hist Museum,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua casmir catalano,HIST-4140,2019
-HIST,4710,1.0,The Great War,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23, alan grubb,HIST-4710,2019
-HIST,4900,2.0,Global History of Slavery,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,stephanie hassell,HIST-4900,2019
-HIST,4900,3.0,Global Impact of Russian Rev,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,HIST-4900,2019
-HIST,4920,1.0,US - Iraq War,0.13,0.33,0.33,0.0,0.07,0.0,0.0,0.13,edwin moise,HIST-4920,2019
-HIST,4930,2.0,Slavery On Film,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,HIST-4930,2019
-HIST,4940,1.0,MiddleEasternSocieties in Film,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,HIST-4940,2019
-HLTH,2020,1.0,Introduction to Public Health,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2019
-HLTH,2020,2.0,Introduction to Public Health,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2019
-HLTH,2020,3.0,Introduction to Public Health,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-2020,2019
-HLTH,2020,4.0,Introduction to Public Health,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2020,2019
-HLTH,2020,5.0,Introduction to Public Health,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2020,2019
-HLTH,2020,400.0,Introduction to Public Health,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2019
-HLTH,2020,402.0,Introduction to Public Health,0.48,0.48,0.0,0.05,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2019
-HLTH,2030,1.0,Health Care Sys,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2019
-HLTH,2030,2.0,Health Care Sys,0.52,0.36,0.12,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2019
-HLTH,2030,400.0,Health Care Sys,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2019
-HLTH,2400,1.0,Deter of Hlth Behav,0.5,0.38,0.08,0.04,0.0,0.0,0.0,0.0,amelia beasley clinkscales,HLTH-2400,2019
-HLTH,2400,2.0,Deter of Hlth Behav,0.6,0.28,0.08,0.0,0.0,0.0,0.0,0.04,amelia beasley clinkscales,HLTH-2400,2019
-HLTH,2400,4.0,Deter of Hlth Behav,0.85,0.12,0.0,0.0,0.04,0.0,0.0,0.0,karyn jones,HLTH-2400,2019
-HLTH,2600,1.0,Medical Terminology & Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,HLTH-2600,2019
-HLTH,2600,3.0,Medical Terminology & Comm,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,karen edwards,HLTH-2600,2019
-HLTH,2980,1.0,Human Health and Disease,0.41,0.51,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2019
-HLTH,2980,2.0,Human Health and Disease,0.63,0.29,0.06,0.03,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2980,2019
-HLTH,3030,1.0,Public Health Comm,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,debra mitchell charles,HLTH-3030,2019
-HLTH,3400,1.0,Hlth Prom Prog Plan,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,johnny long,HLTH-3400,2019
-HLTH,3610,1.0,Int Health Care Econ,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,khoa dang truong,HLTH-3610,2019
-HLTH,3800,1.0,Epidemiology,0.51,0.4,0.06,0.0,0.0,0.0,0.0,0.03,hugh donald spitler,HLTH-3800,2019
-HLTH,3800,2.0,Epidemiology,0.54,0.43,0.03,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-3800,2019
-HLTH,3800,3.0,Epidemiology,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,lu zhang,HLTH-3800,2019
-HLTH,3800,400.0,Epidemiology,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-3800,2019
-HLTH,3980,1.0,Health Appraisal Skills,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2019
-HLTH,3980,2.0,Health Appraisal Skills,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2019
-HLTH,4190,1.0,Health Sci Internship Prep Sem,0.51,0.39,0.07,0.02,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4190,2019
-HLTH,4200,1.0,Hlth Science Intern,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2019
-HLTH,4400,1.0,Manag Hlth Serv Org,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,kathleen buford cartmell,HLTH-4400,2019
-HLTH,4750,1.0,Hlthcr Oper Mgmt Res,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,lu shi,HLTH-4750,2019
-HLTH,4900,2.0,Res Eval St Pub Hlth,0.32,0.48,0.16,0.0,0.04,0.0,0.0,0.0,karen kemper,HLTH-4900,2019
-HLTH,4900,3.0,Res Eval St Pub Hlth,0.44,0.48,0.04,0.0,0.0,0.0,0.0,0.04,jeffrey kingree,HLTH-4900,2019
-HLTH,8120,400.0,Clinical and Translational Sci,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald gimbel,HLTH-8120,2019
-HLTH,8900,2.0,GIS in Public Health,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,patricia carbajales-dale,HLTH-8900,2019
-HON,1920,1.0,Positively Human,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,june pilcher,HON-1920,2019
-HON,1920,2.0,NSP First-Year Seminar,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sarah evelyn winslow,HON-1920,2019
-HON,2020,1.0,Who Decides What's Cool?,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,amanda cooper fine,HON-2020,2019
-HON,2020,2.0,World of Ideas,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,HON-2020,2019
-HON,2020,3.0,Communism and the Berlin Wall,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,michael meng,HON-2020,2019
-HON,2020,4.0,Sexual Health of CU students,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,bruce michael king,HON-2020,2019
-HON,2060,4.0,Why We Eat What We Eat,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,elizabeth lacey durrance,HON-2060,2019
-HON,2210,3.0,The Cultural Work of Comics,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,april susanne pelt,HON-2210,2019
-HORT,1010,1.0,Horticulture,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-1010,2019
-HORT,2020,1.0,Adobe Digital Design,0.75,0.13,0.03,0.03,0.0,0.0,0.0,0.06,janice ann lay,HORT-2020,2019
-HORT,2120,1.0,Turfgrass Culture,0.77,0.16,0.03,0.0,0.03,0.0,0.0,0.0,haibo liu,HORT-2120,2019
-HORT,3030,1.0,Landscape Plants,0.02,0.36,0.29,0.16,0.09,0.0,0.0,0.09,robert polomski,HORT-3030,2019
-HORT,3080,1.0,Sust Landsc Des Install Maint,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-3080,2019
-HORT,4400,1.0,Hydroponics,0.22,0.39,0.28,0.11,0.0,0.0,0.0,0.0,james emerson faust,HORT-4400,2019
-HP,8090,400.0,Historical Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,katherine saunders pemberton,HP-8090,2019
-HRD,8300,400.0,Concepts of H R D,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,angela danielle carter,HRD-8300,2019
-HRD,8300,401.0,Concepts of H R D,0.73,0.19,0.04,0.0,0.0,0.0,0.0,0.04,angela danielle carter,HRD-8300,2019
-HRD,8450,400.0,Needs Assess Ed/Ind,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angela danielle carter,HRD-8450,2019
-HRD,8600,400.0,Instruc Mat Devel,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kristin kelly frady,HRD-8600,2019
-IE,2100,1.0,Des Analysis Wrk Sys,0.35,0.48,0.13,0.01,0.01,0.0,0.0,0.01,jeffery messer,IE-2100,2019
-IE,3010,1.0,Systems Design I,0.45,0.48,0.06,0.0,0.01,0.0,0.0,0.0,shraddhaa narasimha,IE-3010,2019
-IE,3600,1.0,Industrial Apps of Prob/Stat I,0.25,0.3,0.32,0.11,0.03,0.0,0.0,0.0,mary elizabeth kurz,IE-3600,2019
-IE,3610,1.0,Industrial App of Prob/Stat II,0.24,0.32,0.22,0.12,0.05,0.0,0.0,0.05,brian melloy,IE-3610,2019
-IE,3800,1.0,Deterministic Operations Rsrch,0.35,0.35,0.13,0.06,0.07,0.0,0.0,0.04,yongjia song,IE-3800,2019
-IE,3810,1.0,Probabilistic Operations Rsrch,0.52,0.34,0.1,0.02,0.0,0.0,0.0,0.02,caglar caglayan,IE-3810,2019
-IE,3840,1.0,Engr Econ Analysis,0.63,0.26,0.09,0.02,0.0,0.0,0.0,0.01,walter lawrence garvin,IE-3840,2019
-IE,3860,1.0,Production Planning & Control,0.45,0.4,0.1,0.04,0.0,0.0,0.0,0.0,mariah soibhan magagnotti,IE-3860,2019
-IE,4300,1.0,Human Fact Engr in Healthcare,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,david neyens,IE-4300,2019
-IE,4400,1.0,Decision Support Sys,0.34,0.52,0.06,0.0,0.05,0.0,0.0,0.03,scott jennings mason,IE-4400,2019
-IE,4560,1.0,Supply Chain Design & Control,0.14,0.5,0.27,0.0,0.05,0.0,0.0,0.05,william ferrell,IE-4560,2019
-IE,4610,1.0,Quality Engineering,0.35,0.54,0.07,0.02,0.02,0.0,0.0,0.0,mariah soibhan magagnotti,IE-4610,2019
-IE,4610,2.0,Quality Engineering,0.45,0.24,0.21,0.03,0.03,0.0,0.0,0.03,di liu,IE-4610,2019
-IE,4620,1.0,Six Sigma Quality,0.35,0.49,0.11,0.04,0.0,0.0,0.0,0.01,walter lawrence garvin,IE-4620,2019
-IE,4650,1.0,Facilities Planning & Design,0.4,0.38,0.18,0.03,0.01,0.0,0.0,0.0,william ferrell,IE-4650,2019
-IE,4670,1.0,System Design II,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,jeffery messer,IE-4670,2019
-IE,4820,1.0,Systems Modeling,0.06,0.59,0.25,0.03,0.03,0.0,0.0,0.03,kevin taaffe,IE-4820,2019
-IE,4820,2.0,Systems Modeling,0.44,0.41,0.1,0.05,0.0,0.0,0.0,0.0,kevin taaffe,IE-4820,2019
-IE,4880,1.0,Human Factors Eng,0.94,0.04,0.02,0.0,0.0,0.0,0.0,0.0,jamiahus durnad walton,IE-4880,2019
-IE,4880,2.0,Human Factors Eng,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,amro nofan khasawneh,IE-4880,2019
-IE,6560,1.0,Supply Chain Design & Control,0.57,0.32,0.11,0.0,0.0,0.0,0.0,0.0,william ferrell,IE-6560,2019
-IE,6820,1.0,Systems Modeling,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,kevin taaffe,IE-6820,2019
-IE,8000,1.0,Human Factors Eng,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,david neyens,IE-8000,2019
-IE,8020,1.0,Human Comp Sys,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,IE-8020,2019
-IE,8030,1.0,Engr Optimization and Apps,0.27,0.33,0.33,0.0,0.07,0.0,0.0,0.0,scott jennings mason,IE-8030,2019
-IE,8090,1.0,Model Sys Under Risk,0.83,0.06,0.11,0.0,0.0,0.0,0.0,0.0,yongjia song,IE-8090,2019
-IE,8530,1.0,Foundations of Quality,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,robert james riggs,IE-8530,2019
-IE,8550,1.0,SC & Logistics Modeling II,0.88,0.09,0.0,0.0,0.03,0.0,0.0,0.0,kevin taaffe,IE-8550,2019
-INT,1510,1.0,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,lisa marie robinson,INT-1510,2019
-INT,1540,1.0,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.89,0.0,0.11,caren kelley-hall,INT-1540,2019
-ITAL,1010,1.0,Elementary Italian,0.36,0.36,0.09,0.0,0.0,0.0,0.0,0.18,julia schmidt,ITAL-1010,2019
-ITAL,1010,2.0,Elementary Italian,0.42,0.26,0.21,0.0,0.05,0.0,0.0,0.05,julia schmidt,ITAL-1010,2019
-ITAL,1010,3.0,Elementary Italian,0.46,0.31,0.08,0.08,0.0,0.0,0.0,0.08,julia schmidt,ITAL-1010,2019
-ITAL,1020,1.0,Elementary Italian,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,julia schmidt,ITAL-1020,2019
-ITAL,2010,1.0,Intermediate Italian,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,ITAL-2010,2019
-ITAL,2010,2.0,Intermediate Italian,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,ITAL-2010,2019
-ITAL,2020,1.0,Intermediate Italian,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,ITAL-2020,2019
-JAPN,1010,1.0,Elementary Japanese,0.53,0.12,0.12,0.0,0.12,0.0,0.0,0.12,satomi saito,JAPN-1010,2019
-JAPN,1010,2.0,Elementary Japanese,0.44,0.25,0.19,0.0,0.13,0.0,0.0,0.0,satomi saito,JAPN-1010,2019
-JAPN,1010,3.0,Elementary Japanese,0.33,0.17,0.25,0.0,0.17,0.0,0.0,0.08,satomi saito,JAPN-1010,2019
-JAPN,1020,1.0,Elementary Japanese,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,satomi saito,JAPN-1020,2019
-JAPN,2010,3.0,Intermed Japanese,0.42,0.31,0.04,0.12,0.04,0.0,0.0,0.08,jae allegra dibello takeuchi,JAPN-2010,2019
-JAPN,4060,1.0,Intro to Japanese Literature,0.73,0.18,0.0,0.09,0.0,0.0,0.0,0.0,kumiko saito,JAPN-4060,2019
-JAPN,4990,1.0,Sel Topics in Japanese Culture,0.79,0.07,0.07,0.07,0.0,0.0,0.0,0.0,kumiko saito,JAPN-4990,2019
-JUST,2880,1.0,The Criminal Justice System,0.38,0.27,0.21,0.02,0.1,0.0,0.0,0.01,margaret tina britz,JUST-2880,2019
-JUST,2890,1.0,Criminology,0.51,0.36,0.11,0.0,0.02,0.0,0.0,0.0,bryan lee miller,JUST-2890,2019
-JUST,4290,1.0,Justice Administration,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,rhys hester,JUST-4290,2019
-JUST,4680,1.0,Criminal Evidence,0.43,0.22,0.26,0.04,0.04,0.0,0.0,0.02,margaret tina britz,JUST-4680,2019
-JUST,4860,1.0,CI in CJ: Gangsterism in Film,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,margaret tina britz,JUST-4860,2019
-JUST,4910,1.0,Policing,0.81,0.1,0.04,0.0,0.02,0.0,0.0,0.04,shelagh dorn,JUST-4910,2019
-JUST,4920,1.0,Justice Leadership Practicum,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,margaret tina britz,JUST-4920,2019
-JUST,4930,1.0,Corrections,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,bryan lee miller,JUST-4930,2019
-JUST,4990,1.0,Race and Crime,0.69,0.08,0.15,0.0,0.0,0.0,0.0,0.08,brian chad starks,JUST-4990,2019
-JUST,4990,2.0,Intro to Forensic Science,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,tiffany brianne hezel edwards,JUST-4990,2019
-JUST,4990,3.0,Homeland Security/Intelligence,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,shelagh dorn,JUST-4990,2019
-LAIB,1270,1.0,Intro to Lang & Int'l Business,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06, lee ferrell,LAIB-1270,2019
-LARC,1150,1.0,Intro Landscape Architecture,0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,jueminsi wu,LARC-1150,2019
-LARC,1280,1.0,Technical Graphics,0.48,0.38,0.05,0.05,0.0,0.0,0.0,0.05,matthew neal powers,LARC-1280,2019
-LARC,1510,1.0,Basic Design I,0.48,0.38,0.05,0.05,0.0,0.0,0.0,0.05,matthew neal powers,LARC-1510,2019
-LARC,2510,1.0,Larch Design Fund,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,LARC-2510,2019
-LARC,2620,1.0,Design Implementation I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,LARC-2620,2019
-LARC,3510,1.0,Regional Design,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,lara margaret mutel browning,LARC-3510,2019
-LARC,4530,1.0,Key Issues in Landscape Arch,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,LARC-4530,2019
-LARC,4620,1.0,Design Implementation III,0.26,0.37,0.16,0.11,0.0,0.0,0.0,0.11,paul russell,LARC-4620,2019
-LARC,4970,1.0,Plants in the Landscape,0.52,0.3,0.09,0.0,0.09,0.0,0.0,0.0,lara margaret mutel browning,LARC-4970,2019
-LAW,3220,1.0,Legal Env of Bus,0.15,0.46,0.3,0.04,0.02,0.0,0.0,0.02,kenneth scott toussaint,LAW-3220,2019
-LAW,3220,2.0,Legal Env of Bus,0.24,0.3,0.37,0.09,0.0,0.0,0.0,0.0,kenneth scott toussaint,LAW-3220,2019
-LAW,3220,3.0,Legal Env of Bus,0.3,0.52,0.15,0.0,0.02,0.0,0.0,0.0,kathryn kisska-schulze,LAW-3220,2019
-LAW,3220,4.0,Legal Env of Bus,0.36,0.51,0.13,0.0,0.0,0.0,0.0,0.0,kathryn kisska-schulze,LAW-3220,2019
-LAW,3220,5.0,Legal Env of Bus,0.53,0.38,0.09,0.0,0.0,0.0,0.0,0.0,christopher michael edwards,LAW-3220,2019
-LAW,3220,6.0,Legal Env of Bus,0.43,0.43,0.15,0.0,0.0,0.0,0.0,0.0,kathryn kisska-schulze,LAW-3220,2019
-LAW,3220,7.0,Legal Env of Bus,0.64,0.26,0.06,0.0,0.0,0.0,0.0,0.04,christopher michael edwards,LAW-3220,2019
-LAW,3220,8.0,Legal Env of Bus,0.33,0.48,0.17,0.0,0.0,0.0,0.0,0.02,edward ray claggett,LAW-3220,2019
-LAW,3220,9.0,Legal Env of Bus,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2019
-LAW,3220,10.0,Legal Env of Bus,0.23,0.49,0.26,0.02,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2019
-LAW,3220,11.0,Legal Env of Bus,0.26,0.48,0.17,0.04,0.0,0.0,0.0,0.04,john hine,LAW-3220,2019
-LAW,3220,400.0,Legal Env of Bus,0.34,0.34,0.15,0.11,0.02,0.0,0.0,0.03,virginia ls ward-vaughn,LAW-3220,2019
-LAW,3220,401.0,Legal Env of Bus,0.24,0.39,0.2,0.07,0.03,0.0,0.0,0.07,virginia ls ward-vaughn,LAW-3220,2019
-LAW,3220,402.0,Legal Env of Bus,0.33,0.45,0.1,0.03,0.0,0.0,0.0,0.09,virginia ls ward-vaughn,LAW-3220,2019
-LAW,3220,403.0,Legal Env of Bus,0.26,0.48,0.18,0.05,0.02,0.0,0.0,0.02,virginia ls ward-vaughn,LAW-3220,2019
-LAW,3220,404.0,Legal Env of Bus,0.31,0.46,0.17,0.06,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2019
-LAW,3330,1.0,Real Estate Law,0.05,0.36,0.23,0.27,0.09,0.0,0.0,0.0,kenneth scott toussaint,LAW-3330,2019
-LAW,3330,2.0,Real Estate Law,0.18,0.36,0.3,0.03,0.06,0.0,0.0,0.06,kenneth scott toussaint,LAW-3330,2019
-LAW,4050,1.0,Construction Law,0.58,0.27,0.09,0.0,0.0,0.0,0.0,0.06,frances edwards,LAW-4050,2019
-LS,1000,2.0,Therapeutic Yoga,0.59,0.32,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dilipkumar amin,LS-1000,2019
-LS,1000,3.0,Therapeutic Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-1000,2019
-LS,1000,4.0,Introduction to Barre,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-1000,2019
-LS,1000,5.0,Introduction to Barre,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-1000,2019
-LS,1000,8.0,Intro to Volleyball,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,kelly lynn ator,LS-1000,2019
-LS,1000,10.0,FItness Leadership,0.58,0.08,0.08,0.0,0.0,0.0,0.0,0.25,jenny lynn rodgers,LS-1000,2019
-LS,1000,14.0,Introduction to Barre,0.73,0.13,0.13,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-1000,2019
-LS,1000,30.0,Stand up Pabbleboarding,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,merry hannah armstrong,LS-1000,2019
-LS,1410,1.0,Top Rope Climbing,0.73,0.07,0.0,0.07,0.13,0.0,0.0,0.0,thomas caldwell,LS-1410,2019
-LS,1410,3.0,Top Rope Climbing,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,thomas caldwell,LS-1410,2019
-LS,1560,4.0,Riflery,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,hubert cox,LS-1560,2019
-LS,1560,10.0,Riflery,0.7,0.0,0.0,0.0,0.1,0.0,0.0,0.2,douglas bonham stephens,LS-1560,2019
-LS,1560,13.0,Riflery,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,herbert wayne strickland,LS-1560,2019
-LS,1650,3.0,Inland Kayak Touring,0.82,0.0,0.09,0.0,0.09,0.0,0.0,0.0,merry hannah armstrong,LS-1650,2019
-LS,1850,1.0,Bowling,0.8,0.07,0.07,0.0,0.07,0.0,0.0,0.0,madison neely workman,LS-1850,2019
-LS,1850,2.0,Bowling,0.85,0.07,0.04,0.0,0.0,0.0,0.0,0.04,madison neely workman,LS-1850,2019
-LS,1850,3.0,Bowling,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.04,madison neely workman,LS-1850,2019
-LS,1850,7.0,Bowling,0.87,0.04,0.0,0.0,0.04,0.0,0.0,0.04,madison neely workman,LS-1850,2019
-LS,1850,8.0,Bowling,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,megan elizabeth cato,LS-1850,2019
-LS,1850,9.0,Bowling,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,angela rowan,LS-1850,2019
-LS,1850,10.0,Bowling,0.9,0.0,0.0,0.0,0.03,0.0,0.0,0.07,angela rowan,LS-1850,2019
-LS,1980,3.0,Golf,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,wesley scott womble,LS-1980,2019
-LS,1980,7.0,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,wesley scott womble,LS-1980,2019
-LS,2270,1.0,Intro to Swing Dance,0.88,0.0,0.04,0.0,0.0,0.0,0.0,0.08,paul hoke,LS-2270,2019
-LS,2270,2.0,Intro to Swing Dance,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,paul hoke,LS-2270,2019
-LS,2270,3.0,Intro to Swing Dance,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,LS-2270,2019
-LS,2320,1.0,Core Training,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,diane moreno,LS-2320,2019
-LS,2320,2.0,Core Training,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,LS-2320,2019
-LS,2320,3.0,Core Training,0.5,0.23,0.14,0.0,0.0,0.0,0.0,0.14,diane moreno,LS-2320,2019
-LS,2350,1.0,Basic Yoga,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2350,2019
-LS,2380,2.0,Vinyasa Flow Yoga,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,nicole elizabeth martinez,LS-2380,2019
-LS,2420,1.0,Meditation and Relax,0.83,0.04,0.0,0.04,0.04,0.0,0.0,0.04,renee warren gahan,LS-2420,2019
-LS,2420,2.0,Meditation and Relax,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2420,2019
-LS,2420,3.0,Meditation and Relax,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dilipkumar amin,LS-2420,2019
-LS,2420,4.0,Meditation and Relax,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.09,ranjanbala dilipkumar amin,LS-2420,2019
-LS,2420,5.0,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dilipkumar amin,LS-2420,2019
-LS,2420,6.0,Meditation and Relax,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dilipkumar amin,LS-2420,2019
-LS,2420,7.0,Meditation and Relax,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,cara jill wrenn,LS-2420,2019
-LS,2450,1.0,Pilates,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,melanie ivey job,LS-2450,2019
-LS,2450,4.0,Pilates,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,LS-2450,2019
-LS,2450,6.0,Pilates,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,melanie ivey job,LS-2450,2019
-LS,2510,2.0,Running & Jogging,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,corey douglas brookover,LS-2510,2019
-LS,2700,1.0,Sports Officiating,0.64,0.0,0.09,0.0,0.0,0.0,0.0,0.27,christopher warren cox,LS-2700,2019
-LS,2750,3.0,First Aid/Cpr,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,christopher michael loomis,LS-2750,2019
-LS,2750,7.0,First Aid/Cpr,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,christopher michael loomis,LS-2750,2019
-LS,2750,8.0,First Aid/Cpr,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,christopher michael loomis,LS-2750,2019
-LS,3560,2.0,Riflery II,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,hubert cox,LS-3560,2019
-MATH,1010,1.0,Essen Math for Informed Soc,0.53,0.18,0.18,0.06,0.0,0.0,0.0,0.06,alexander joyce,MATH-1010,2019
-MATH,1010,3.0,Essen Math for Informed Soc,0.45,0.36,0.1,0.07,0.0,0.0,0.0,0.02,judith elaine cottingham,MATH-1010,2019
-MATH,1010,4.0,Essen Math for Informed Soc,0.42,0.21,0.21,0.16,0.0,0.0,0.0,0.0,philip de castro,MATH-1010,2019
-MATH,1010,6.0,Essen Math for Informed Soc,0.3,0.38,0.11,0.11,0.05,0.0,0.0,0.05,judith elaine cottingham,MATH-1010,2019
-MATH,1010,7.0,Essen Math for Informed Soc,0.38,0.5,0.08,0.03,0.0,0.0,0.0,0.03,judith elaine cottingham,MATH-1010,2019
-MATH,1010,8.0,Essen Math for Informed Soc,0.14,0.5,0.07,0.21,0.0,0.0,0.0,0.07,philip de castro,MATH-1010,2019
-MATH,1010,9.0,Essen Math for Informed Soc,0.56,0.28,0.06,0.0,0.06,0.0,0.0,0.06,alexander joyce,MATH-1010,2019
-MATH,1020,1.0,Business Calculus I,0.28,0.28,0.28,0.11,0.0,0.0,0.0,0.06,andrew bellucco,MATH-1020,2019
-MATH,1020,2.0,Business Calculus I,0.33,0.22,0.22,0.0,0.11,0.0,0.0,0.11,andrew bellucco,MATH-1020,2019
-MATH,1020,3.0,Business Calculus I,0.37,0.21,0.26,0.11,0.0,0.0,0.0,0.05,tilly grace erwin,MATH-1020,2019
-MATH,1020,4.0,Business Calculus I,0.56,0.19,0.06,0.13,0.0,0.0,0.0,0.06,tilly grace erwin,MATH-1020,2019
-MATH,1020,5.0,Business Calculus I,0.27,0.4,0.13,0.13,0.07,0.0,0.0,0.0,eva murphy,MATH-1020,2019
-MATH,1020,6.0,Business Calculus I,0.22,0.56,0.11,0.06,0.06,0.0,0.0,0.0,eva murphy,MATH-1020,2019
-MATH,1020,7.0,Business Calculus I,0.17,0.22,0.28,0.22,0.0,0.0,0.0,0.11,michael glen eldredge,MATH-1020,2019
-MATH,1020,8.0,Business Calculus I,0.35,0.12,0.18,0.18,0.12,0.0,0.0,0.06,michael glen eldredge,MATH-1020,2019
-MATH,1020,9.0,Business Calculus I,0.39,0.22,0.06,0.06,0.17,0.0,0.0,0.11,tyler sullivan,MATH-1020,2019
-MATH,1020,10.0,Business Calculus I,0.39,0.17,0.06,0.17,0.06,0.0,0.0,0.17,tyler sullivan,MATH-1020,2019
-MATH,1020,11.0,Business Calculus I,0.28,0.33,0.17,0.0,0.06,0.0,0.0,0.17,david luke frost,MATH-1020,2019
-MATH,1020,12.0,Business Calculus I,0.11,0.28,0.17,0.11,0.11,0.0,0.0,0.22,david luke frost,MATH-1020,2019
-MATH,1020,13.0,Business Calculus I,0.21,0.26,0.47,0.0,0.0,0.0,0.0,0.05,yunan wang,MATH-1020,2019
-MATH,1020,14.0,Business Calculus I,0.37,0.37,0.21,0.0,0.0,0.0,0.0,0.05,yunan wang,MATH-1020,2019
-MATH,1020,15.0,Business Calculus I,0.14,0.43,0.36,0.07,0.0,0.0,0.0,0.0,daozhou zhu,MATH-1020,2019
-MATH,1020,16.0,Business Calculus I,0.17,0.42,0.17,0.17,0.08,0.0,0.0,0.0,daozhou zhu,MATH-1020,2019
-MATH,1020,17.0,Business Calculus I,0.08,0.35,0.2,0.13,0.15,0.0,0.0,0.1,neil calkin,MATH-1020,2019
-MATH,1020,19.0,Business Calculus I,0.17,0.28,0.39,0.11,0.0,0.0,0.0,0.06,dominique evelyn forbes,MATH-1020,2019
-MATH,1020,20.0,Business Calculus I,0.26,0.21,0.32,0.11,0.11,0.0,0.0,0.0,dominique evelyn forbes,MATH-1020,2019
-MATH,1020,21.0,Business Calculus I,0.47,0.12,0.24,0.12,0.06,0.0,0.0,0.0,michael thomas cowen,MATH-1020,2019
-MATH,1020,22.0,Business Calculus I,0.39,0.33,0.11,0.11,0.0,0.0,0.0,0.06,michael thomas cowen,MATH-1020,2019
-MATH,1020,23.0,Business Calculus I,0.16,0.26,0.21,0.21,0.0,0.0,0.0,0.16,antonio pierrottet,MATH-1020,2019
-MATH,1020,24.0,Business Calculus I,0.33,0.28,0.28,0.11,0.0,0.0,0.0,0.0,antonio pierrottet,MATH-1020,2019
-MATH,1020,25.0,Business Calculus I,0.33,0.28,0.22,0.06,0.06,0.0,0.0,0.06,hossein faridian,MATH-1020,2019
-MATH,1020,26.0,Business Calculus I,0.13,0.5,0.19,0.0,0.06,0.0,0.0,0.13,hossein faridian,MATH-1020,2019
-MATH,1020,27.0,Business Calculus I,0.17,0.5,0.11,0.17,0.0,0.0,0.0,0.06,shanshan jia,MATH-1020,2019
-MATH,1020,28.0,Business Calculus I,0.33,0.28,0.22,0.06,0.06,0.0,0.0,0.06,morgan elston,MATH-1020,2019
-MATH,1020,29.0,Business Calculus I,0.25,0.31,0.13,0.06,0.19,0.0,0.0,0.06,morgan elston,MATH-1020,2019
-MATH,1020,30.0,Business Calculus I,0.28,0.44,0.11,0.0,0.06,0.0,0.0,0.11,michael byrd,MATH-1020,2019
-MATH,1020,31.0,Business Calculus I,0.22,0.5,0.22,0.0,0.0,0.0,0.0,0.06,michael byrd,MATH-1020,2019
-MATH,1020,32.0,Business Calculus I,0.22,0.22,0.17,0.0,0.22,0.0,0.0,0.17,michael nelson,MATH-1020,2019
-MATH,1020,33.0,Business Calculus I,0.24,0.24,0.41,0.0,0.06,0.0,0.0,0.06,michael nelson,MATH-1020,2019
-MATH,1020,34.0,Business Calculus I,0.17,0.39,0.17,0.17,0.06,0.0,0.0,0.06,hemanta kunwar,MATH-1020,2019
-MATH,1020,35.0,Business Calculus I,0.41,0.29,0.18,0.0,0.0,0.0,0.0,0.12,hemanta kunwar,MATH-1020,2019
-MATH,1020,36.0,Business Calculus I,0.25,0.31,0.25,0.13,0.0,0.0,0.0,0.06,trinity white,MATH-1020,2019
-MATH,1020,37.0,Business Calculus I,0.17,0.39,0.28,0.11,0.06,0.0,0.0,0.0,trinity white,MATH-1020,2019
-MATH,1020,38.0,Business Calculus I,0.39,0.11,0.22,0.0,0.11,0.0,0.0,0.17,shanshan jia,MATH-1020,2019
-MATH,1020,39.0,Business Calculus I,0.16,0.32,0.26,0.11,0.05,0.0,0.0,0.11,joseph swanson,MATH-1020,2019
-MATH,1020,40.0,Business Calculus I,0.32,0.47,0.11,0.11,0.0,0.0,0.0,0.0,joseph swanson,MATH-1020,2019
-MATH,1020,41.0,Business Calculus I,0.33,0.33,0.17,0.17,0.0,0.0,0.0,0.0,elliott degbe,MATH-1020,2019
-MATH,1020,42.0,Business Calculus I,0.33,0.28,0.17,0.17,0.06,0.0,0.0,0.0,elliott degbe,MATH-1020,2019
-MATH,1020,43.0,Business Calculus I,0.49,0.07,0.29,0.1,0.02,0.0,0.0,0.02,randy davidson,MATH-1020,2019
-MATH,1020,44.0,Business Calculus I,0.26,0.36,0.18,0.15,0.05,0.0,0.0,0.0,randy davidson,MATH-1020,2019
-MATH,1020,201.0,Business Calculus I,0.67,0.2,0.07,0.03,0.0,0.0,0.0,0.03,jennifer van dyken,MATH-1020,2019
-MATH,1020,202.0,Business Calculus I,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,marion hanna,MATH-1020,2019
-MATH,1040,1.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,donna simms,MATH-1040,2019
-MATH,1040,3.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,anna caroline bachstein,MATH-1040,2019
-MATH,1040,4.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,aaron moose,MATH-1040,2019
-MATH,1040,5.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,todd anthony morra,MATH-1040,2019
-MATH,1040,6.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,ryann rose cartor,MATH-1040,2019
-MATH,1040,9.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.93,0.0,0.07,zachary david espe,MATH-1040,2019
-MATH,1040,10.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,tony william long,MATH-1040,2019
-MATH,1050,402.0,Precalculus,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.12,tony thanh nguyen,MATH-1050,2019
-MATH,1050,403.0,Precalculus,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,tony thanh nguyen,MATH-1050,2019
-MATH,1060,1.0,Calculus of One Variable I,0.31,0.24,0.19,0.05,0.12,0.0,0.0,0.1,catherine mary kenyon,MATH-1060,2019
-MATH,1060,2.0,Calculus of One Variable I,0.35,0.33,0.14,0.02,0.07,0.0,0.0,0.09,james edward gossell,MATH-1060,2019
-MATH,1060,3.0,Calculus of One Variable I,0.29,0.37,0.12,0.07,0.07,0.0,0.0,0.07,marvin clayton jones,MATH-1060,2019
-MATH,1060,4.0,Calculus of One Variable I,0.29,0.37,0.08,0.0,0.18,0.0,0.0,0.08,sofya alekseeva,MATH-1060,2019
-MATH,1060,5.0,Calculus of One Variable I,0.14,0.31,0.34,0.06,0.09,0.0,0.0,0.06,sofya alekseeva,MATH-1060,2019
-MATH,1060,7.0,Calculus of One Variable I,0.32,0.29,0.2,0.0,0.12,0.0,0.0,0.07,scott scruggs,MATH-1060,2019
-MATH,1060,8.0,Calculus of One Variable I,0.14,0.25,0.19,0.08,0.13,0.0,0.0,0.2,chad robert mangum,MATH-1060,2019
-MATH,1060,10.0,Calculus of One Variable I,0.14,0.26,0.3,0.04,0.12,0.0,0.0,0.15,chad robert mangum,MATH-1060,2019
-MATH,1060,12.0,Calculus of One Variable I,0.38,0.35,0.09,0.0,0.09,0.0,0.0,0.09,jason alexander kurz,MATH-1060,2019
-MATH,1060,13.0,Calculus of One Variable I,0.26,0.36,0.15,0.05,0.13,0.0,0.0,0.05,nathan fontes,MATH-1060,2019
-MATH,1060,14.0,Calculus of One Variable I,0.27,0.3,0.1,0.0,0.17,0.0,0.0,0.17,akshay sunil gupte,MATH-1060,2019
-MATH,1060,201.0,Calculus of One Variable I,0.34,0.27,0.22,0.05,0.1,0.0,0.0,0.02,stephen peele,MATH-1060,2019
-MATH,1060,202.0,Calculus of One Variable I,0.41,0.19,0.28,0.0,0.09,0.0,0.0,0.03,hugh geller,MATH-1060,2019
-MATH,1060,203.0,Calculus of One Variable I,0.25,0.29,0.29,0.08,0.04,0.0,0.0,0.04,sofya alekseeva,MATH-1060,2019
-MATH,1060,204.0,Calculus of One Variable I,0.44,0.29,0.13,0.04,0.09,0.0,0.0,0.0,stephen peele,MATH-1060,2019
-MATH,1060,206.0,Calculus of One Variable I,0.45,0.28,0.18,0.05,0.0,0.0,0.0,0.05,peter westerbaan,MATH-1060,2019
-MATH,1060,300.0,Calculus of One Variable I,0.29,0.29,0.24,0.0,0.1,0.0,0.0,0.1,matthew macauley,MATH-1060,2019
-MATH,1070,1.0,Differen and Integral Calculus,0.0,0.15,0.6,0.1,0.1,0.0,0.0,0.05,donna simms,MATH-1070,2019
-MATH,1080,1.0,Calculus of One Variable II,0.25,0.22,0.19,0.06,0.16,0.0,0.0,0.12,meredith nicole burr,MATH-1080,2019
-MATH,1080,2.0,Calculus of One Variable II,0.23,0.23,0.18,0.1,0.21,0.0,0.0,0.05,blake anthony splitter,MATH-1080,2019
-MATH,1080,3.0,Calculus of One Variable II,0.3,0.24,0.22,0.0,0.19,0.0,0.0,0.05,fei xue,MATH-1080,2019
-MATH,1080,4.0,Calculus of One Variable II,0.15,0.26,0.11,0.07,0.19,0.0,0.0,0.22,terri johnson,MATH-1080,2019
-MATH,1080,5.0,Calculus of One Variable II,0.14,0.11,0.31,0.11,0.22,0.0,0.0,0.11,terri johnson,MATH-1080,2019
-MATH,1080,6.0,Calculus of One Variable II,0.15,0.28,0.23,0.03,0.25,0.0,0.0,0.08,fei xue,MATH-1080,2019
-MATH,1080,7.0,Calculus of One Variable II,0.2,0.16,0.2,0.04,0.24,0.0,0.0,0.16,terri johnson,MATH-1080,2019
-MATH,1080,201.0,Calculus of One Variable II,0.33,0.44,0.11,0.0,0.11,0.0,0.0,0.0,mark cawood,MATH-1080,2019
-MATH,1150,1.0,Contemp Math for Elem Teach I,0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,angel carreras jusino,MATH-1150,2019
-MATH,1150,2.0,Contemp Math for Elem Teach I,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,eliza dargan gallagher,MATH-1150,2019
-MATH,1150,3.0,Contemp Math for Elem Teach I,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,angel carreras jusino,MATH-1150,2019
-MATH,2060,1.0,Calculus of Several Variables,0.23,0.32,0.28,0.1,0.05,0.0,0.0,0.02,irina viktorova,MATH-2060,2019
-MATH,2060,2.0,Calculus of Several Variables,0.12,0.38,0.31,0.05,0.09,0.0,0.0,0.05,irina viktorova,MATH-2060,2019
-MATH,2060,3.0,Calculus of Several Variables,0.32,0.34,0.15,0.1,0.03,0.0,0.0,0.06,oleg yordanov,MATH-2060,2019
-MATH,2060,4.0,Calculus of Several Variables,0.34,0.39,0.17,0.02,0.02,0.0,0.0,0.05,oleg yordanov,MATH-2060,2019
-MATH,2060,5.0,Calculus of Several Variables,0.25,0.29,0.27,0.08,0.08,0.0,0.0,0.03,timothy charles teitloff,MATH-2060,2019
-MATH,2060,6.0,Calculus of Several Variables,0.25,0.41,0.23,0.05,0.04,0.0,0.0,0.02,timothy charles teitloff,MATH-2060,2019
-MATH,2060,7.0,Calculus of Several Variables,0.51,0.44,0.04,0.0,0.0,0.0,0.0,0.0,nantsoina ramiharimanana,MATH-2060,2019
-MATH,2060,8.0,Calculus of Several Variables,0.27,0.25,0.14,0.14,0.05,0.0,0.0,0.16,timothy franklin parrott,MATH-2060,2019
-MATH,2060,9.0,Calculus of Several Variables,0.18,0.3,0.13,0.05,0.2,0.0,0.0,0.15,timothy franklin parrott,MATH-2060,2019
-MATH,2060,10.0,Calculus of Several Variables,0.38,0.3,0.15,0.06,0.11,0.0,0.0,0.0,allen anderson guest,MATH-2060,2019
-MATH,2060,100.0,Calc of Several Vars (HON),0.8,0.16,0.02,0.0,0.02,0.0,0.0,0.0,yuyuan ouyang,MATH-2060,2019
-MATH,2060,201.0,Calculus of Several Variables,0.38,0.33,0.23,0.0,0.0,0.0,0.0,0.08,allen anderson guest,MATH-2060,2019
-MATH,2060,202.0,Calculus of Several Variables,0.47,0.3,0.07,0.1,0.07,0.0,0.0,0.0,allen anderson guest,MATH-2060,2019
-MATH,2070,1.0,Business Calculus II,0.29,0.24,0.18,0.18,0.0,0.0,0.0,0.12,nathaniel nemire,MATH-2070,2019
-MATH,2070,2.0,Business Calculus II,0.37,0.11,0.21,0.11,0.16,0.0,0.0,0.05,nathaniel nemire,MATH-2070,2019
-MATH,2070,3.0,Business Calculus II,0.22,0.22,0.11,0.22,0.11,0.0,0.0,0.11,ebenezer eduafo,MATH-2070,2019
-MATH,2070,4.0,Business Calculus II,0.11,0.0,0.39,0.33,0.11,0.0,0.0,0.06,ebenezer eduafo,MATH-2070,2019
-MATH,2070,5.0,Business Calculus II,0.05,0.32,0.26,0.26,0.05,0.0,0.0,0.05,haodong li,MATH-2070,2019
-MATH,2070,6.0,Business Calculus II,0.19,0.06,0.19,0.13,0.06,0.0,0.0,0.38,haodong li,MATH-2070,2019
-MATH,2070,7.0,Business Calculus II,0.48,0.27,0.16,0.05,0.0,0.0,0.0,0.05,jennifer marie hanna,MATH-2070,2019
-MATH,2070,8.0,Business Calculus II,0.36,0.41,0.09,0.05,0.0,0.0,0.0,0.09,jennifer marie hanna,MATH-2070,2019
-MATH,2070,9.0,Business Calculus II,0.55,0.25,0.07,0.05,0.02,0.0,0.0,0.07,jennifer marie hanna,MATH-2070,2019
-MATH,2070,10.0,Business Calculus II,0.47,0.09,0.24,0.16,0.02,0.0,0.0,0.02,jennifer marie hanna,MATH-2070,2019
-MATH,2070,11.0,Business Calculus II,0.33,0.32,0.15,0.09,0.03,0.0,0.0,0.07,jennifer ray newton,MATH-2070,2019
-MATH,2070,12.0,Business Calculus II,0.29,0.25,0.31,0.09,0.03,0.0,0.0,0.03,jennifer ray newton,MATH-2070,2019
-MATH,2070,13.0,Business Calculus II,0.35,0.18,0.29,0.06,0.06,0.0,0.0,0.06,travis alvarez,MATH-2070,2019
-MATH,2070,14.0,Business Calculus II,0.26,0.21,0.26,0.16,0.0,0.0,0.0,0.11,travis alvarez,MATH-2070,2019
-MATH,2080,1.0,Intro to Ordin Diff Equations,0.16,0.28,0.28,0.05,0.08,0.0,0.0,0.14,jeong rock yoon,MATH-2080,2019
-MATH,2080,2.0,Intro to Ordin Diff Equations,0.1,0.2,0.3,0.17,0.13,0.0,0.0,0.1,julie lassiter,MATH-2080,2019
-MATH,2080,3.0,Intro to Ordin Diff Equations,0.19,0.27,0.22,0.16,0.05,0.0,0.0,0.11,julie lassiter,MATH-2080,2019
-MATH,2080,4.0,Intro to Ordin Diff Equations,0.5,0.38,0.08,0.0,0.03,0.0,0.0,0.03,nantsoina ramiharimanana,MATH-2080,2019
-MATH,2080,5.0,Intro to Ordin Diff Equations,0.26,0.34,0.09,0.11,0.14,0.0,0.0,0.06,timothy franklin parrott,MATH-2080,2019
-MATH,2160,1.0,Geometry for Elem Sch Teachers,0.89,0.05,0.0,0.03,0.03,0.0,0.0,0.0,nicole alaine bannister sinwell,MATH-2160,2019
-MATH,2160,2.0,Geometry for Elem Sch Teachers,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,nicole alaine bannister sinwell,MATH-2160,2019
-MATH,3020,2.0,Stat for Science & Engineering,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,qiong zhang,MATH-3020,2019
-MATH,3020,3.0,Stat for Science & Engineering,0.67,0.25,0.06,0.0,0.03,0.0,0.0,0.0,xiaoqian sun,MATH-3020,2019
-MATH,3020,4.0,Stat for Science & Engineering,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,kayla doris javier,MATH-3020,2019
-MATH,3020,5.0,Stat for Science & Engineering,0.58,0.26,0.11,0.05,0.0,0.0,0.0,0.0,kayla doris javier,MATH-3020,2019
-MATH,3020,6.0,Stat for Science & Engineering,0.47,0.32,0.16,0.0,0.05,0.0,0.0,0.0,todd fenstermacher,MATH-3020,2019
-MATH,3020,7.0,Stat for Science & Engineering,0.26,0.58,0.05,0.05,0.0,0.0,0.0,0.05,todd fenstermacher,MATH-3020,2019
-MATH,3020,8.0,Stat for Science & Engineering,0.26,0.26,0.26,0.05,0.16,0.0,0.0,0.0,zhiyun gong,MATH-3020,2019
-MATH,3020,9.0,Stat for Science & Engineering,0.39,0.19,0.22,0.08,0.06,0.0,0.0,0.06,zhiyun gong,MATH-3020,2019
-MATH,3020,10.0,Stat for Science & Engineering,0.35,0.29,0.18,0.03,0.09,0.0,0.0,0.06,zhiyun gong,MATH-3020,2019
-MATH,3020,13.0,Stat for Science & Engineering,0.23,0.51,0.11,0.09,0.03,0.0,0.0,0.03,xiaoqian sun,MATH-3020,2019
-MATH,3020,14.0,Stat for Science & Engineering,0.31,0.29,0.34,0.0,0.06,0.0,0.0,0.0,ellen hepfer breazel,MATH-3020,2019
-MATH,3110,1.0,Linear Algebra,0.25,0.5,0.21,0.02,0.0,0.0,0.0,0.02,wayne goddard,MATH-3110,2019
-MATH,3110,2.0,Linear Algebra,0.31,0.42,0.25,0.0,0.0,0.0,0.0,0.02,wayne goddard,MATH-3110,2019
-MATH,3110,4.0,Linear Algebra,0.38,0.35,0.15,0.08,0.02,0.0,0.0,0.01,beth novick,MATH-3110,2019
-MATH,3110,5.0,Linear Algebra,0.34,0.26,0.16,0.11,0.13,0.0,0.0,0.0,svetlana poznanovikj,MATH-3110,2019
-MATH,3110,6.0,Linear Algebra,0.27,0.24,0.27,0.11,0.11,0.0,0.0,0.0,svetlana poznanovikj,MATH-3110,2019
-MATH,3110,7.0,Linear Algebra,0.48,0.36,0.11,0.02,0.0,0.0,0.0,0.02,neil calkin,MATH-3110,2019
-MATH,3110,100.0,Linear Algebra (HON),0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,michael adam burr,MATH-3110,2019
-MATH,3190,1.0,Introduction to Proof,0.48,0.29,0.19,0.0,0.05,0.0,0.0,0.0,michael adam burr,MATH-3190,2019
-MATH,3190,2.0,Introduction to Proof,0.3,0.26,0.3,0.0,0.04,0.0,0.0,0.09,james barker coykendall,MATH-3190,2019
-MATH,3600,1.0,Intermediate Math Computing,0.73,0.15,0.06,0.04,0.02,0.0,0.0,0.0,mark cawood,MATH-3600,2019
-MATH,3650,1.0,Numerical Mthds for Engineers,0.14,0.25,0.39,0.06,0.13,0.0,0.0,0.03,eleanor jenkins,MATH-3650,2019
-MATH,3650,2.0,Numerical Mthds for Engineers,0.17,0.42,0.19,0.04,0.04,0.0,0.0,0.15,vincent ervin,MATH-3650,2019
-MATH,3650,3.0,Numerical Mthds for Engineers,0.46,0.36,0.1,0.03,0.03,0.0,0.0,0.03,sibusiso samkele mabuza,MATH-3650,2019
-MATH,3990,1.0,Creative Inquiry in Math,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,irina viktorova,MATH-3990,2019
-MATH,4000,1.0,Theory of Probability,0.22,0.26,0.37,0.04,0.04,0.0,0.0,0.07,brian fralix,MATH-4000,2019
-MATH,4000,2.0,Theory of Probability,0.28,0.5,0.11,0.08,0.03,0.0,0.0,0.0,peter kiessler,MATH-4000,2019
-MATH,4020,1.0,Stat for Sci & Engineering II,0.55,0.0,0.09,0.18,0.0,0.0,0.0,0.18,derek brown,MATH-4020,2019
-MATH,4070,1.0,Regress & Time-Series Analysis,0.5,0.2,0.0,0.1,0.0,0.0,0.0,0.2,robert lund,MATH-4070,2019
-MATH,4120,1.0,Algebra I,0.59,0.14,0.05,0.0,0.09,0.0,0.0,0.14,matthew macauley,MATH-4120,2019
-MATH,4120,2.0,Algebra I,0.32,0.37,0.16,0.05,0.05,0.0,0.0,0.05,hui xue,MATH-4120,2019
-MATH,4190,1.0,Discrete Math Structures I,0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,beth novick,MATH-4190,2019
-MATH,4190,2.0,Discrete Math Structures I,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,beth novick,MATH-4190,2019
-MATH,4310,1.0,Theory of Interest,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0, erwin walker,MATH-4310,2019
-MATH,4340,1.0,Adv Engineering Mathematics,0.26,0.47,0.21,0.0,0.03,0.0,0.0,0.03,qingshan chen,MATH-4340,2019
-MATH,4340,2.0,Adv Engineering Mathematics,0.27,0.36,0.18,0.14,0.05,0.0,0.0,0.0,vincent ervin,MATH-4340,2019
-MATH,4350,1.0,Complex Variables,0.45,0.0,0.45,0.0,0.09,0.0,0.0,0.0,shitao liu,MATH-4350,2019
-MATH,4400,1.0,Linear Programming,0.35,0.35,0.27,0.0,0.04,0.0,0.0,0.0,margaret maria wiecek,MATH-4400,2019
-MATH,4410,1.0,Intro to Stochastic Models,0.57,0.14,0.21,0.0,0.07,0.0,0.0,0.0,xin liu,MATH-4410,2019
-MATH,4530,1.0,Advanced Calculus I,0.43,0.26,0.23,0.03,0.06,0.0,0.0,0.0,benjamin jaye,MATH-4530,2019
-MATH,4540,1.0,Advanced Calculus II,0.3,0.3,0.3,0.0,0.0,0.0,0.0,0.1,james peterson,MATH-4540,2019
-MATH,4630,1.0,Real Analysis I,0.47,0.41,0.0,0.0,0.0,0.0,0.0,0.12,shitao liu,MATH-4630,2019
-MATH,4810,1.0,Putnam Seminar,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,neil calkin,MATH-4810,2019
-MATH,6340,1.0,Adv Engineering Mathematics,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,hyesuk lee,MATH-6340,2019
-MATH,8000,1.0,Probability,0.65,0.24,0.0,0.0,0.06,0.0,0.0,0.06,xin liu,MATH-8000,2019
-MATH,8010,1.0,General Linear Hypothesis I,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,derek brown,MATH-8010,2019
-MATH,8050,1.0,Data Analysis,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,brook thayer russell,MATH-8050,2019
-MATH,8070,1.0,Applied Multivariate Analysis,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,MATH-8070,2019
-MATH,8090,1.0,Time Series Analysis,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert lund,MATH-8090,2019
-MATH,8140,1.0,Network Flow Programming,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,MATH-8140,2019
-MATH,8170,1.0,Stochastic Mod in Oper Rsrch I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,MATH-8170,2019
-MATH,8210,1.0,Linear Analysis,0.52,0.24,0.19,0.0,0.05,0.0,0.0,0.0,mishko mitkovski,MATH-8210,2019
-MATH,8510,1.0,Abstract Algebra I,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,james barker coykendall,MATH-8510,2019
-MATH,8530,1.0,Matrix Analysis,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,xuhong gao,MATH-8530,2019
-MATH,8600,1.0,Intro to Scientific Computing,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,hyesuk lee,MATH-8600,2019
-MATH,8650,1.0,Data Structures,0.46,0.31,0.0,0.0,0.0,0.0,0.0,0.23,timo johannes heister,MATH-8650,2019
-MATH,8850,1.0,Advanced Data Analysis,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,MATH-8850,2019
-MBA,8030,1.0,Stat Analy of Bus Op,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,dee ann wood kivett,MBA-8030,2019
-MBA,8030,2.0,Stat Analy of Bus Op,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william edward kilbourne,MBA-8030,2019
-MBA,8040,20.0,Busin Data An & Stat Computing,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,william edward kilbourne,MBA-8040,2019
-MBA,8060,1.0,Operations Mgt,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MBA-8060,2019
-MBA,8060,2.0,Operations Mgt,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,george kenneth morgan,MBA-8060,2019
-MBA,8070,1.0,Financial Management,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,MBA-8070,2019
-MBA,8070,2.0,Financial Management,0.55,0.4,0.0,0.0,0.05,0.0,0.0,0.0,george brandon lockhart,MBA-8070,2019
-MBA,8070,20.0,Financial Management,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,MBA-8070,2019
-MBA,8090,1.0,Org Beh & Hum Res Mg,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,thomas joseph zagenczyk,MBA-8090,2019
-MBA,8090,2.0,Org Beh & Hum Res Mg,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,thomas joseph zagenczyk,MBA-8090,2019
-MBA,8090,3.0,Org Beh & Hum Res Mg,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,thomas joseph zagenczyk,MBA-8090,2019
-MBA,8180,20.0,Intro Business Intell & Anlytc,0.83,0.14,0.0,0.0,0.0,0.0,0.0,0.03,john frederick tripp,MBA-8180,2019
-MBA,8190,2.0,Intro to Acc and Fin,0.48,0.45,0.07,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,MBA-8190,2019
-MBA,8190,3.0,Intro to Acc and Fin,0.09,0.45,0.14,0.0,0.14,0.0,0.0,0.18,jeffrey mcmillan,MBA-8190,2019
-MBA,8290,1.0,Marketing Foundation,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ankita bakre,MBA-8290,2019
-MBA,8310,10.0,Communications and Sales,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,MBA-8310,2019
-MBA,8370,1.0,Legal Environ of Bus,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8370,2019
-MBA,8370,2.0,Legal Environ of Bus,0.34,0.57,0.06,0.0,0.0,0.0,0.0,0.03,judson jahn,MBA-8370,2019
-MBA,8400,1.0,Entrepreneurship & Venture Mgt,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,prashant prabhu,MBA-8400,2019
-MBA,8410,1.0,Real Estate Finance,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,ryan dietz,MBA-8410,2019
-MBA,8430,1.0,Entrepreneurial Accounting,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,annieka philo,MBA-8430,2019
-MBA,8440,1.0,Entrepreneurial Law,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john hine,MBA-8440,2019
-MBA,8480,1.0,Entrpr Mkting & Digital Strat,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,bruce snyder,MBA-8480,2019
-MBA,8480,5.0,Entrpr Mkting & Digital Strat,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,MBA-8480,2019
-MBA,8490,5.0,Entrepreneurial Strategy,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,matthew charles klein,MBA-8490,2019
-MBA,8510,1.0,Bus Operations & Logistics,0.25,0.56,0.13,0.0,0.0,0.0,0.0,0.06, sridharan,MBA-8510,2019
-MBA,8540,2.0,Managerial Accounting,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.03,emily suzanne mccorkle,MBA-8540,2019
-MBA,8590,1.0,Mgr Decision Model,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,james turner,MBA-8590,2019
-MBA,8590,2.0,Mgr Decision Model,0.29,0.42,0.08,0.0,0.0,0.0,0.0,0.21,magda gabriela sava,MBA-8590,2019
-MBA,8590,3.0,Mgr Decision Model,0.31,0.38,0.13,0.0,0.03,0.0,0.0,0.16,magda gabriela sava,MBA-8590,2019
-MBA,8600,2.0,Advanced Marketing Strategy,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,joseph renato gibson,MBA-8600,2019
-MBA,8610,2.0,Information Systems,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,william kettinger,MBA-8610,2019
-MBA,8620,1.0,Managerial Economics,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,scott templeton,MBA-8620,2019
-MBA,8620,2.0,Managerial Economics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,MBA-8620,2019
-MBA,8620,4.0,Managerial Economics,0.56,0.36,0.04,0.0,0.0,0.0,0.0,0.04,ronald earle gregory,MBA-8620,2019
-MBA,8660,21.0,"Data, Storage, Business Decis",0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,he li,MBA-8660,2019
-MBA,8700,1.0,Strategic Management,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,james turner,MBA-8700,2019
-MBA,8990,2.0,Creativity,0.79,0.14,0.05,0.0,0.0,0.0,0.0,0.02,kathleen ann kegley,MBA-8990,2019
-MBA,8990,4.0,Data Analytics & Visualization,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,john frederick tripp,MBA-8990,2019
-MBA,8990,7.0,Digital Marketing,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,robert andrew fitzwater,MBA-8990,2019
-ME,2000,1.0,Sophomore Seminar,0.91,0.05,0.01,0.0,0.0,0.0,0.0,0.03,todd alan schweisinger,ME-2000,2019
-ME,2000,2.0,Sophomore Seminar,0.74,0.16,0.03,0.01,0.02,0.0,0.0,0.05,todd alan schweisinger,ME-2000,2019
-ME,2010,1.0,Statics & Dynamics,0.07,0.16,0.25,0.09,0.25,0.0,0.0,0.16,gang liu,ME-2010,2019
-ME,2010,2.0,Statics & Dynamics,0.17,0.24,0.31,0.07,0.13,0.0,0.0,0.08,paul joseph,ME-2010,2019
-ME,2010,3.0,Statics & Dynamics,0.05,0.16,0.26,0.15,0.15,0.0,0.0,0.24,gang li,ME-2010,2019
-ME,2010,4.0,Statics & Dynamics,0.02,0.14,0.25,0.17,0.22,0.0,0.0,0.2,marisa kikendall orr,ME-2010,2019
-ME,2030,1.0,Founda Th/Fl Syst,0.42,0.33,0.14,0.05,0.05,0.0,0.0,0.02,sandip dutta,ME-2030,2019
-ME,2030,2.0,Founda Th/Fl Syst,0.27,0.29,0.16,0.16,0.04,0.0,0.0,0.09,xiangchun xuan,ME-2030,2019
-ME,2040,1.0,Mechanics of Materials,0.24,0.51,0.18,0.04,0.04,0.0,0.0,0.0,fadi abdeljawad,ME-2040,2019
-ME,2040,2.0,Mechanics of Materials,0.19,0.53,0.16,0.03,0.03,0.0,0.0,0.06,huijuan zhao,ME-2040,2019
-ME,2220,1.0,Mechanical Engineering Lab I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,douglas scott byrd,ME-2220,2019
-ME,2220,2.0,Mechanical Engineering Lab I,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,ME-2220,2019
-ME,2220,3.0,Mechanical Engineering Lab I,0.13,0.56,0.13,0.0,0.0,0.0,0.0,0.19,douglas scott byrd,ME-2220,2019
-ME,2220,5.0,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,ME-2220,2019
-ME,2220,6.0,Mechanical Engineering Lab I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,ME-2220,2019
-ME,2220,7.0,Mechanical Engineering Lab I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,ME-2220,2019
-ME,2220,8.0,Mechanical Engineering Lab I,0.56,0.31,0.0,0.0,0.06,0.0,0.0,0.06,douglas scott byrd,ME-2220,2019
-ME,2220,10.0,Mechanical Engineering Lab I,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,douglas scott byrd,ME-2220,2019
-ME,2220,11.0,Mechanical Engineering Lab I,0.13,0.53,0.2,0.0,0.0,0.0,0.0,0.13,douglas scott byrd,ME-2220,2019
-ME,2220,13.0,Mechanical Engineering Lab I,0.31,0.5,0.06,0.0,0.0,0.0,0.0,0.13,douglas scott byrd,ME-2220,2019
-ME,2220,15.0,Mechanical Engineering Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,ME-2220,2019
-ME,3030,1.0,Thermodynamics,0.12,0.3,0.33,0.12,0.06,0.0,0.0,0.06,john saylor,ME-3030,2019
-ME,3030,2.0,Thermodynamics,0.23,0.31,0.34,0.11,0.02,0.0,0.0,0.0,yiqiang han,ME-3030,2019
-ME,3030,3.0,Thermodynamics,0.09,0.31,0.47,0.04,0.02,0.0,0.0,0.07,yiqiang han,ME-3030,2019
-ME,3040,1.0,Heat Transfer,0.55,0.35,0.07,0.01,0.0,0.0,0.0,0.01,sandip dutta,ME-3040,2019
-ME,3040,2.0,Heat Transfer,0.09,0.25,0.45,0.09,0.07,0.0,0.0,0.05,geetha pravallika chimata,ME-3040,2019
-ME,3050,1.0,Model/an Dy Syst,0.25,0.34,0.27,0.09,0.05,0.0,0.0,0.0,ardalan vahidi,ME-3050,2019
-ME,3050,2.0,Model/an Dy Syst,0.18,0.35,0.26,0.09,0.09,0.0,0.0,0.03,seyedyasha parvinioskoui,ME-3050,2019
-ME,3060,1.0,Fund Machine Design,0.34,0.38,0.19,0.06,0.02,0.0,0.0,0.0,katherine marie ehlert,ME-3060,2019
-ME,3060,2.0,Fund Machine Design,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,zhaoxu meng,ME-3060,2019
-ME,3060,3.0,Fund Machine Design,0.15,0.34,0.24,0.15,0.07,0.0,0.0,0.05,nafiseh masoudi,ME-3060,2019
-ME,3070,1.0,Found of Mechanical Systems,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,pooya niksiar,ME-3070,2019
-ME,3070,2.0,Found of Mechanical Systems,0.5,0.35,0.08,0.03,0.03,0.0,0.0,0.03,lonny thompson,ME-3070,2019
-ME,3070,3.0,Found of Mechanical Systems,0.67,0.22,0.09,0.0,0.0,0.0,0.0,0.01,pooya niksiar,ME-3070,2019
-ME,3080,1.0,Fluid Mechanics,0.16,0.53,0.24,0.02,0.02,0.0,0.0,0.02,zhen li,ME-3080,2019
-ME,3080,2.0,Fluid Mechanics,0.18,0.2,0.38,0.2,0.02,0.0,0.0,0.02,seyedyasha parvinioskoui,ME-3080,2019
-ME,3080,3.0,Fluid Mechanics,0.26,0.34,0.36,0.03,0.0,0.0,0.0,0.0,ethan kung,ME-3080,2019
-ME,3080,301.0,Fluid Mechanics (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,zhen li,ME-3080,2019
-ME,3120,1.0,Manuf Processes,0.66,0.32,0.02,0.0,0.0,0.0,0.0,0.0,xin zhao,ME-3120,2019
-ME,3120,2.0,Manuf Processes,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,rodrigo martinez-duarte,ME-3120,2019
-ME,3330,1.0,Mechanical Engineering Lab II,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,2.0,Mechanical Engineering Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,5.0,Mechanical Engineering Lab II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,6.0,Mechanical Engineering Lab II,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,gang liu,ME-3330,2019
-ME,3330,8.0,Mechanical Engineering Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,9.0,Mechanical Engineering Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,10.0,Mechanical Engineering Lab II,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,16.0,Mechanical Engineering Lab II,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3900,103.0,CI ME - Autonomous Micro Drone,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,yiqiang han,ME-3900,2019
-ME,4000,1.0,Senior Seminar,0.98,0.01,0.0,0.0,0.01,0.0,0.0,0.0,atul gajanan kelkar,ME-4000,2019
-ME,4010,2.0,Mech Engr Design,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4010,2019
-ME,4010,864.0,Mech Engr Design,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,geetha pravallika chimata,ME-4010,2019
-ME,4020,3.0,Intern in Engr Des,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,pooya niksiar,ME-4020,2019
-ME,4030,1.0,Control Dynamic Systems,0.3,0.27,0.03,0.24,0.15,0.0,0.0,0.0,mohammad naghnaeian,ME-4030,2019
-ME,4030,2.0,Control Dynamic Systems,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,suyi li,ME-4030,2019
-ME,4030,3.0,Control Dynamic Systems,0.73,0.18,0.05,0.05,0.0,0.0,0.0,0.0,hubert bryan riley,ME-4030,2019
-ME,4210,1.0,Intro to Comp Flow,0.43,0.14,0.36,0.07,0.0,0.0,0.0,0.0,chenning tong,ME-4210,2019
-ME,4290,1.0,Ther Env Control,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,jay ochterbeck,ME-4290,2019
-ME,4320,1.0,Advanced Strength of Materials,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,oliver myers,ME-4320,2019
-ME,4340,1.0,Cardiovascular Biomechanics,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,ethan kung,ME-4340,2019
-ME,4440,1.0,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2019
-ME,4440,2.0,Mechanical Engineering Lab III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2019
-ME,4440,5.0,Mechanical Engineering Lab III,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4440,2019
-ME,4580,1.0,Fund Micro/Nano Fabrication,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,rodrigo martinez-duarte,ME-4580,2019
-ME,4710,1.0,Ca Eng Anly & Design,0.32,0.53,0.03,0.03,0.0,0.0,0.0,0.11,georges fadel,ME-4710,2019
-ME,4930,14.0,Sel.Topics ME - NonLinDy&Chas,0.13,0.5,0.38,0.0,0.0,0.0,0.0,0.0,joshua bostwick,ME-4930,2019
-ME,4930,35.0,Sel Topics ME: Smart Materials,0.55,0.34,0.07,0.0,0.0,0.0,0.0,0.03,oliver myers,ME-4930,2019
-ME,4930,39.0,Sel.Topics ME - Aero Propul,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,pooya niksiar,ME-4930,2019
-ME,4930,77.0,Selected Topics ME - Boeing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4930,2019
-ME,6320,1.0,Advanced Strength of Materials,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,oliver myers,ME-6320,2019
-ME,6550,864.0,Design for Manuf,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,joshua summers,ME-6550,2019
-ME,6710,1.0,Ca Eng Anly & Design,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-6710,2019
-ME,6930,14.0,Sel.Topics ME - NonLinDy&Chas,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joshua bostwick,ME-6930,2019
-ME,6930,35.0,Sel Topics ME: Smart Materials,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,oliver myers,ME-6930,2019
-ME,8010,1.0,Found of Fluid Mech,0.36,0.32,0.23,0.0,0.05,0.0,0.0,0.05,richard figliola,ME-8010,2019
-ME,8100,1.0,Macroscopic Thermo,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,jay ochterbeck,ME-8100,2019
-ME,8180,1.0,Intro to Fin Ele Ana,0.7,0.25,0.0,0.0,0.02,0.0,0.0,0.03,lonny thompson,ME-8180,2019
-ME,8180,843.0,Intro to Fin Ele Ana,0.57,0.0,0.29,0.0,0.0,0.0,0.0,0.14,lonny thompson,ME-8180,2019
-ME,8230,1.0,Control Systems,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,ME-8230,2019
-ME,8230,864.0,Control Systems,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,yue wang,ME-8230,2019
-ME,8300,1.0,Cond/Rad Heat Tfr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,ME-8300,2019
-ME,8400,1.0,Plasticity,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,garrett pataky,ME-8400,2019
-ME,8460,1.0,Inter Dynamics,0.5,0.21,0.21,0.0,0.0,0.0,0.0,0.07,phanindra tallapragada,ME-8460,2019
-ME,8700,1.0,Adv Design Methods,0.97,0.02,0.02,0.0,0.0,0.0,0.0,0.0,cameron turner,ME-8700,2019
-ME,8710,1.0,Engr Optimization,0.78,0.13,0.02,0.0,0.0,0.0,0.0,0.07,georges fadel,ME-8710,2019
-ME,8930,2.0,Sel Topics ME: Adv Mfg,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,hong seok choi,ME-8930,2019
-MGT,2010,1.0,Principles of Management,0.35,0.4,0.19,0.03,0.01,0.0,0.0,0.02,katherine clark,MGT-2010,2019
-MGT,2010,2.0,Principles of Management,0.52,0.33,0.11,0.02,0.01,0.0,0.0,0.01,tina robbins,MGT-2010,2019
-MGT,2010,8.0,Principles of Management,0.4,0.35,0.23,0.0,0.0,0.0,0.0,0.03,christopher mann,MGT-2010,2019
-MGT,2010,9.0,Principles of Management,0.26,0.53,0.08,0.11,0.03,0.0,0.0,0.0,christopher mann,MGT-2010,2019
-MGT,2010,10.0,Principles of Management,0.31,0.33,0.31,0.0,0.03,0.0,0.0,0.03,ashley williams parnell,MGT-2010,2019
-MGT,2010,11.0,Principles of Management,0.33,0.31,0.23,0.08,0.0,0.0,0.0,0.05,ashley williams parnell,MGT-2010,2019
-MGT,2010,12.0,Principles of Management,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,nicholas byrd,MGT-2010,2019
-MGT,2010,13.0,Principles of Management,0.79,0.13,0.08,0.0,0.0,0.0,0.0,0.0,shuang liu,MGT-2010,2019
-MGT,2180,1.0,Management PC Applications,0.56,0.29,0.09,0.02,0.02,0.0,0.0,0.02,ryan toole,MGT-2180,2019
-MGT,2180,2.0,Management PC Applications,0.25,0.6,0.03,0.0,0.0,0.0,0.0,0.13,ryan toole,MGT-2180,2019
-MGT,3070,1.0,Human Resource Management,0.46,0.49,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,MGT-3070,2019
-MGT,3070,3.0,Human Resource Management,0.37,0.41,0.15,0.07,0.0,0.0,0.0,0.0,kristin damato scott,MGT-3070,2019
-MGT,3070,4.0,Human Resource Management,0.46,0.49,0.06,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2019
-MGT,3070,5.0,Human Resource Management,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,MGT-3070,2019
-MGT,3070,6.0,Human Resource Management,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2019
-MGT,3070,7.0,Human Resource Management,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,MGT-3070,2019
-MGT,3070,8.0,Human Resource Management,0.2,0.49,0.26,0.03,0.03,0.0,0.0,0.0,priscilla harrison,MGT-3070,2019
-MGT,3100,1.0,Intermed Business Statistics,0.26,0.29,0.32,0.0,0.06,0.0,0.0,0.06,daniel allan detoma,MGT-3100,2019
-MGT,3100,2.0,Intermed Business Statistics,0.37,0.17,0.31,0.03,0.09,0.0,0.0,0.03,mustafa serkan akturk,MGT-3100,2019
-MGT,3100,3.0,Intermed Business Statistics,0.56,0.18,0.15,0.0,0.03,0.0,0.0,0.09,maneeshreddy ajjuguttu,MGT-3100,2019
-MGT,3100,5.0,Intermed Business Statistics,0.4,0.18,0.33,0.03,0.03,0.0,0.0,0.05,mustafa serkan akturk,MGT-3100,2019
-MGT,3100,6.0,Intermed Business Statistics,0.81,0.03,0.05,0.03,0.05,0.0,0.0,0.03,david ford peyton,MGT-3100,2019
-MGT,3100,7.0,Intermed Business Statistics,0.54,0.32,0.03,0.03,0.03,0.0,0.0,0.05,seyed amin seyed haeri,MGT-3100,2019
-MGT,3100,8.0,Intermed Business Statistics,0.65,0.25,0.08,0.0,0.0,0.0,0.0,0.03,david ford peyton,MGT-3100,2019
-MGT,3100,9.0,Intermed Business Statistics,0.51,0.23,0.1,0.1,0.05,0.0,0.0,0.0,david ford peyton,MGT-3100,2019
-MGT,3100,10.0,Intermed Business Statistics,0.45,0.34,0.13,0.03,0.05,0.0,0.0,0.0,jeromy blake snider,MGT-3100,2019
-MGT,3100,12.0,Intermed Business Statistics,0.13,0.31,0.44,0.0,0.03,0.0,0.0,0.1,daniel allan detoma,MGT-3100,2019
-MGT,3100,13.0,Intermed Business Statistics,0.86,0.08,0.03,0.0,0.03,0.0,0.0,0.0,benjamin christopher wiles,MGT-3100,2019
-MGT,3120,1.0,Decision Models for Management,0.29,0.22,0.28,0.11,0.06,0.0,0.0,0.05,sara elizabeth yoder,MGT-3120,2019
-MGT,3120,2.0,Decision Models for Management,0.19,0.14,0.34,0.16,0.14,0.0,0.0,0.03,sara elizabeth yoder,MGT-3120,2019
-MGT,3120,4.0,Decision Models for Management,0.25,0.22,0.32,0.07,0.05,0.0,0.0,0.08,sara elizabeth yoder,MGT-3120,2019
-MGT,3170,1.0,Logistics Mgmt,0.43,0.48,0.09,0.0,0.0,0.0,0.0,0.0,ahmet colak,MGT-3170,2019
-MGT,3180,1.0,Mgt of Info Systems,0.53,0.43,0.05,0.0,0.0,0.0,0.0,0.0,wenxi pu,MGT-3180,2019
-MGT,3180,3.0,Mgt of Info Systems,0.38,0.4,0.03,0.1,0.05,0.0,0.0,0.05,zhihong ke,MGT-3180,2019
-MGT,3180,4.0,Mgt of Info Systems,0.56,0.33,0.09,0.02,0.0,0.0,0.0,0.0,he li,MGT-3180,2019
-MGT,3180,5.0,Mgt of Info Systems,0.4,0.5,0.05,0.0,0.02,0.0,0.0,0.02,wenxi pu,MGT-3180,2019
-MGT,3180,6.0,Mgt of Info Systems,0.69,0.16,0.13,0.02,0.0,0.0,0.0,0.0,shih lun tseng,MGT-3180,2019
-MGT,3180,7.0,Mgt of Info Systems,0.68,0.23,0.07,0.0,0.02,0.0,0.0,0.0,shih lun tseng,MGT-3180,2019
-MGT,3180,8.0,Mgt of Info Systems,0.56,0.06,0.19,0.06,0.08,0.0,0.0,0.06,kevin mckenzie,MGT-3180,2019
-MGT,3500,1.0,Intro to Business Analytics,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,hongki kim,MGT-3500,2019
-MGT,3510,1.0,Business Analytics & Problems,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,david ford peyton,MGT-3510,2019
-MGT,3900,1.0,Operations Management,0.31,0.39,0.11,0.03,0.03,0.0,0.0,0.13, sridharan,MGT-3900,2019
-MGT,3900,2.0,Operations Management,0.29,0.41,0.14,0.05,0.05,0.0,0.0,0.05, sridharan,MGT-3900,2019
-MGT,3900,4.0,Operations Management,0.1,0.2,0.48,0.1,0.08,0.0,0.0,0.05,zachary moran leffakis,MGT-3900,2019
-MGT,3900,5.0,Operations Management,0.46,0.38,0.1,0.03,0.03,0.0,0.0,0.0,benjamin noah grant,MGT-3900,2019
-MGT,3900,6.0,Operations Management,0.28,0.38,0.23,0.05,0.08,0.0,0.0,0.0,benjamin noah grant,MGT-3900,2019
-MGT,4000,1.0,Mgt of Organizational Behavior,0.59,0.39,0.0,0.0,0.0,0.0,0.0,0.02,michael cole,MGT-4000,2019
-MGT,4000,2.0,Mgt of Organizational Behavior,0.73,0.25,0.0,0.03,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2019
-MGT,4000,3.0,Mgt of Organizational Behavior,0.29,0.53,0.16,0.0,0.03,0.0,0.0,0.0,thomas joseph zagenczyk,MGT-4000,2019
-MGT,4000,4.0,Mgt of Organizational Behavior,0.21,0.29,0.32,0.16,0.0,0.0,0.0,0.03,philip roth,MGT-4000,2019
-MGT,4020,1.0,Ops Pln and Ctl,0.06,0.25,0.69,0.0,0.0,0.0,0.0,0.0,zachary moran leffakis,MGT-4020,2019
-MGT,4080,1.0,Lean Operations,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,zachary moran leffakis,MGT-4080,2019
-MGT,4110,1.0,Project Management,0.35,0.43,0.14,0.0,0.03,0.0,0.0,0.05,russell purvis,MGT-4110,2019
-MGT,4120,1.0,Supplier Management,0.48,0.33,0.15,0.0,0.0,0.0,0.0,0.03,ahmet colak,MGT-4120,2019
-MGT,4150,1.0,Business Strategy,0.25,0.53,0.23,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,2.0,Business Strategy,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,3.0,Business Strategy,0.1,0.65,0.25,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,4.0,Business Strategy,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,MGT-4150,2019
-MGT,4150,5.0,Business Strategy (HON),0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,MGT-4150,2019
-MGT,4150,6.0,Business Strategy,0.1,0.56,0.33,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,7.0,Business Strategy,0.45,0.4,0.14,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,MGT-4150,2019
-MGT,4150,8.0,Business Strategy,0.21,0.51,0.28,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,MGT-4150,2019
-MGT,4150,9.0,Business Strategy,0.39,0.53,0.05,0.0,0.0,0.0,0.0,0.03,amy elizabeth ingram,MGT-4150,2019
-MGT,4150,12.0,Business Strategy,0.21,0.5,0.29,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4160,1.0,Special Topics Hr,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,kristin damato scott,MGT-4160,2019
-MGT,4230,1.0,Intern Bus Mgt,0.18,0.18,0.52,0.09,0.02,0.0,0.0,0.0,wayne stewart,MGT-4230,2019
-MGT,4230,2.0,Intern Bus Mgt,0.23,0.38,0.3,0.05,0.05,0.0,0.0,0.0,wayne stewart,MGT-4230,2019
-MGT,4230,3.0,Intern Bus Mgt,0.13,0.45,0.37,0.02,0.03,0.0,0.0,0.0,janis miller,MGT-4230,2019
-MGT,4240,1.0,Global Supply Chain Management,0.32,0.44,0.21,0.0,0.03,0.0,0.0,0.0,yann ferrand,MGT-4240,2019
-MGT,4270,2.0,Managing Improvement,0.27,0.4,0.23,0.0,0.03,0.0,0.0,0.07,lawrence fredendall,MGT-4270,2019
-MGT,4310,1.0,Emp Rights & Resp,0.21,0.62,0.15,0.03,0.0,0.0,0.0,0.0,leonard joseph spooner,MGT-4310,2019
-MGT,4350,1.0,Pers Interviewing,0.42,0.56,0.03,0.0,0.0,0.0,0.0,0.0,philip roth,MGT-4350,2019
-MGT,4520,1.0,Business Analysis,0.24,0.58,0.12,0.0,0.0,0.0,0.0,0.06,russell purvis,MGT-4520,2019
-MGT,4540,1.0,Systems Implement,0.55,0.31,0.1,0.0,0.03,0.0,0.0,0.0,hongki kim,MGT-4540,2019
-MGT,8690,1.0,Project Mgt,0.49,0.49,0.0,0.0,0.0,0.0,0.0,0.02,russell purvis,MGT-8690,2019
-MICR,2050,1.0,Introductory Micro,0.37,0.46,0.16,0.02,0.0,0.0,0.0,0.01,john abercrombie,MICR-2050,2019
-MICR,3050,1.0,General Microbiology,0.39,0.39,0.18,0.02,0.0,0.0,0.0,0.01,krista barrier rudolph,MICR-3050,2019
-MICR,3050,2.0,General Microbiology,0.42,0.39,0.14,0.04,0.0,0.0,0.0,0.0,krista barrier rudolph,MICR-3050,2019
-MICR,4010,1.0,Microbial Diversity & Ecology,0.58,0.22,0.14,0.02,0.02,0.0,0.0,0.02,kristi james whitehead,MICR-4010,2019
-MICR,4010,2.0,Micro Diversity/Ecol (HON),0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristi james whitehead,MICR-4010,2019
-MICR,4050,1.0,Adv Microbial Ecol of Humans,0.49,0.37,0.1,0.02,0.0,0.0,0.0,0.01,kristi james whitehead,MICR-4050,2019
-MICR,4140,1.0,Basic Immunology,0.38,0.45,0.13,0.0,0.02,0.0,0.0,0.02,yanzhang wei,MICR-4140,2019
-MICR,4150,1.0,Microbial Genetics,0.3,0.32,0.3,0.09,0.0,0.0,0.0,0.0,min cao,MICR-4150,2019
-MICR,4160,1.0,Intro Virology,0.79,0.18,0.01,0.01,0.0,0.0,0.0,0.0,kaustubha ratan qanungo,MICR-4160,2019
-MICR,4510,2.0,Advanced Microbiology II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4510,2019
-MICR,4510,3.0,Advanced Microbiology II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4510,2019
-MICR,4510,4.0,Advanced Microbiology II,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4510,2019
-MICR,4930,1.0,Sr Sem: Emerg Infect Diseases,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,kristi james whitehead,MICR-4930,2019
-MKT,3010,1.0,Principles of Marketing,0.2,0.43,0.25,0.08,0.02,0.0,0.0,0.03,amanda cooper fine,MKT-3010,2019
-MKT,3010,2.0,Principles of Marketing,0.29,0.37,0.21,0.1,0.01,0.0,0.0,0.02,amanda cooper fine,MKT-3010,2019
-MKT,3010,3.0,Principles of Marketing,0.29,0.39,0.22,0.08,0.01,0.0,0.0,0.01,amanda cooper fine,MKT-3010,2019
-MKT,3010,4.0,Principles of Marketing,0.27,0.44,0.21,0.06,0.02,0.0,0.0,0.01,carter willis mcelveen,MKT-3010,2019
-MKT,3010,5.0,Principles of Marketing,0.31,0.43,0.21,0.04,0.0,0.0,0.0,0.01,carter willis mcelveen,MKT-3010,2019
-MKT,3010,7.0,Principles of Marketing,0.12,0.56,0.27,0.03,0.01,0.0,0.0,0.01,james gaubert,MKT-3010,2019
-MKT,3020,1.0,Consumer Behavior,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jennifer dianne siemens,MKT-3020,2019
-MKT,3020,2.0,Consumer Behavior,0.69,0.24,0.04,0.02,0.0,0.0,0.0,0.0,jennifer dianne siemens,MKT-3020,2019
-MKT,3020,5.0,Consumer Behavior,0.52,0.38,0.09,0.0,0.01,0.0,0.0,0.0,anastasia elizabeth thyroff,MKT-3020,2019
-MKT,3020,6.0,Consumer Behavior,0.29,0.48,0.15,0.01,0.04,0.0,0.0,0.03,james gaubert,MKT-3020,2019
-MKT,3210,1.0,Sports Marketing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2019
-MKT,3210,2.0,Sports Marketing,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-3210,2019
-MKT,3220,1.0,Social Media Marketing,0.83,0.11,0.0,0.03,0.0,0.0,0.0,0.03,lura forcum,MKT-3220,2019
-MKT,3220,2.0,Social Media Marketing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,MKT-3220,2019
-MKT,3220,3.0,Social Media Marketing,0.67,0.26,0.07,0.0,0.0,0.0,0.0,0.0,michele melton cauley,MKT-3220,2019
-MKT,3220,4.0,Social Media Marketing,0.57,0.37,0.04,0.0,0.02,0.0,0.0,0.0,michele melton cauley,MKT-3220,2019
-MKT,3310,1.0,Marketing Metrics & Analytics,0.73,0.2,0.03,0.0,0.0,0.0,0.0,0.03,oriana rachel aragon,MKT-3310,2019
-MKT,3310,2.0,Marketing Metrics & Analytics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,oriana rachel aragon,MKT-3310,2019
-MKT,3310,3.0,Marketing Metrics & Analytics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-3310,2019
-MKT,3310,4.0,Marketing Metrics & Analytics,0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,xianyong wang,MKT-3310,2019
-MKT,3310,5.0,Marketing Metrics & Analytics,0.19,0.44,0.22,0.04,0.0,0.0,0.0,0.11,peter weathers,MKT-3310,2019
-MKT,3980,1.0,Creative Inquiry in Marketing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james gaubert,MKT-3980,2019
-MKT,4200,1.0,Professional Selling,0.41,0.56,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2019
-MKT,4200,2.0,Professional Selling,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,kevin scott chase,MKT-4200,2019
-MKT,4200,3.0,Professional Selling,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2019
-MKT,4200,5.0,Professional Selling,0.83,0.07,0.07,0.0,0.0,0.0,0.0,0.03,carter willis mcelveen,MKT-4200,2019
-MKT,4200,6.0,Professional Selling,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,MKT-4200,2019
-MKT,4230,2.0,Promotional Strategy,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,michele melton cauley,MKT-4230,2019
-MKT,4230,3.0,Promotional Strategy,0.42,0.48,0.06,0.0,0.03,0.0,0.0,0.0,michele melton cauley,MKT-4230,2019
-MKT,4240,1.0,Sales Management,0.59,0.32,0.05,0.0,0.0,0.0,0.0,0.03,ryan mullins,MKT-4240,2019
-MKT,4260,1.0,Business-to-Business,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4260,2019
-MKT,4270,1.0,International Marketing,0.7,0.24,0.04,0.02,0.0,0.0,0.0,0.0,xianyong wang,MKT-4270,2019
-MKT,4270,2.0,International Marketing,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-4270,2019
-MKT,4270,3.0,International Marketing,0.48,0.33,0.1,0.0,0.03,0.0,0.0,0.08,thomas poehlman,MKT-4270,2019
-MKT,4270,4.0,International Marketing,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4270,2019
-MKT,4280,1.0,Services Marketing,0.21,0.44,0.28,0.05,0.03,0.0,0.0,0.0,angeline close scheinbaum,MKT-4280,2019
-MKT,4280,2.0,Services Marketing,0.15,0.64,0.21,0.0,0.0,0.0,0.0,0.0,angeline close scheinbaum,MKT-4280,2019
-MKT,4310,1.0,Marketing Research,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,michael david giebelhausen,MKT-4310,2019
-MKT,4310,2.0,Marketing Research,0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,michael david giebelhausen,MKT-4310,2019
-MKT,4310,3.0,Marketing Research,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2019
-MKT,4310,4.0,Marketing Research,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2019
-MKT,4500,1.0,Strategic Mktg Mgt,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,annette popp tower,MKT-4500,2019
-MKT,4500,2.0,Strategic Mktg Mgt,0.39,0.52,0.09,0.0,0.0,0.0,0.0,0.0,annette popp tower,MKT-4500,2019
-MKT,4500,3.0,Strategic Mktg Mgt,0.27,0.58,0.15,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2019
-MKT,4500,4.0,Strategic Mktg Mgt,0.19,0.44,0.33,0.04,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2019
-MKT,4950,1.0,Selling Medical Devices,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4950,2019
-MKT,4950,2.0,Applied Selling,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kevin scott chase,MKT-4950,2019
-ML,2010,1.0,Leadership Development I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2010,2019
-ML,2010,3.0,Leadership Development I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2010,2019
-ML,3010,1.0,Advanced Leadership I,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,justin robert merhar,ML-3010,2019
-MSE,2100,1.0,Intro to Materials Science,0.25,0.43,0.22,0.04,0.01,0.0,0.0,0.04,nancy birkner,MSE-2100,2019
-MSE,2100,2.0,Intro to Materials Science,0.44,0.28,0.18,0.08,0.01,0.0,0.0,0.01,rakhee pani,MSE-2100,2019
-MSE,2100,3.0,Intro to Materials Science,0.23,0.43,0.2,0.07,0.03,0.0,0.0,0.03,mark alan johnson,MSE-2100,2019
-MSE,2100,4.0,Intro to Materials Science,0.65,0.21,0.05,0.02,0.04,0.0,0.0,0.02,rakhee pani,MSE-2100,2019
-MSE,2100,5.0,Intro to Materials Science,0.06,0.56,0.19,0.13,0.06,0.0,0.0,0.0,olga kuksenok,MSE-2100,2019
-MSE,2100,6.0,Intro to Materials Science,0.24,0.23,0.26,0.08,0.11,0.0,0.0,0.08,olga kuksenok,MSE-2100,2019
-MSE,3260,1.0,Thermo of Materials,0.36,0.28,0.26,0.04,0.06,0.0,0.0,0.0,fei peng,MSE-3260,2019
-MSE,3260,2.0,Thermo of Materials,0.34,0.32,0.22,0.1,0.02,0.0,0.0,0.0,fei peng,MSE-3260,2019
-MSE,3910,1.0,Research Fundamentals,0.74,0.1,0.03,0.06,0.06,0.0,0.0,0.0,ulf daniel schiller,MSE-3910,2019
-MSE,4130,1.0,Noncrystalline Materials,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,MSE-4130,2019
-MSE,4150,1.0,Polymer Science & Engineering,0.44,0.35,0.06,0.06,0.06,0.0,0.0,0.03,olin mefford,MSE-4150,2019
-MSE,4150,2.0,Polymer Science & Engineering,0.5,0.26,0.24,0.0,0.0,0.0,0.0,0.0,igor luzinov,MSE-4150,2019
-MSE,4320,1.0,Manuf Proc & Systems,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,MSE-4320,2019
-MSE,4580,1.0,Surf Phen in Ms&E,0.3,0.2,0.4,0.0,0.0,0.0,0.0,0.1,konstantin german kornev,MSE-4580,2019
-MSE,4910,1.0,Undergraduate Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ulf daniel schiller,MSE-4910,2019
-MSE,8100,1.0,Fundamentals of Materials Sci,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,igor luzinov,MSE-8100,2019
-MSE,8190,1.0,Inorgan Mater Characterization,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,luiz gustavo jacobsohn,MSE-8190,2019
-MSE,8260,1.0,Phase Equil Mat Sys,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,stephen foulger,MSE-8260,2019
-MSE,8270,1.0,Kin of Phase Tran,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,konstantin german kornev,MSE-8270,2019
-MSE,8510,1.0,Polymer Science I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,marek urban,MSE-8510,2019
-MUSC,1110,4.0,Beginning Class Guitar,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,david stevenson,MUSC-1110,2019
-MUSC,1420,1.0,Music Theory I,0.76,0.06,0.12,0.0,0.0,0.0,0.0,0.06,linda li-bleuel,MUSC-1420,2019
-MUSC,1430,1.0,Aural Skills I,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,linda li-bleuel,MUSC-1430,2019
-MUSC,1510,2.0,Applied Music,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,MUSC-1510,2019
-MUSC,1510,19.0,Applied Music,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,adam michael knight,MUSC-1510,2019
-MUSC,1510,25.0,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,charles wood,MUSC-1510,2019
-MUSC,1520,2.0,Applied Music,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,MUSC-1520,2019
-MUSC,1520,22.0,Applied Music,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathryn layne mauldin,MUSC-1520,2019
-MUSC,2100,1.0,Music in the Western World,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,david conley,MUSC-2100,2019
-MUSC,2100,5.0,Music in the Western World,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,timothy ray hurlburt,MUSC-2100,2019
-MUSC,2100,6.0,Music in the Western World,0.97,0.0,0.03,0.0,0.0,0.0,0.0,0.0,david conley,MUSC-2100,2019
-MUSC,2100,7.0,Music in the Western World,0.42,0.39,0.13,0.03,0.0,0.0,0.0,0.03,rhea beth jacobus,MUSC-2100,2019
-MUSC,2100,8.0,Music in the Western World,0.41,0.41,0.03,0.0,0.06,0.0,0.0,0.09,rhea beth jacobus,MUSC-2100,2019
-MUSC,2100,11.0,Music in the Western World,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,leslie taylor warlick,MUSC-2100,2019
-MUSC,2100,12.0,Music in the Western World,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,MUSC-2100,2019
-MUSC,2100,13.0,Music in the Western World,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,david conley,MUSC-2100,2019
-MUSC,2100,15.0,Music in West World (HON),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2019
-MUSC,2510,2.0,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,MUSC-2510,2019
-MUSC,3080,1.0,Surv of Broadway I,0.67,0.11,0.11,0.0,0.11,0.0,0.0,0.0,lisa sain odom,MUSC-3080,2019
-MUSC,3110,1.0,History of American Music,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,ned hosler,MUSC-3110,2019
-MUSC,3120,1.0,History of Jazz,0.6,0.05,0.1,0.1,0.15,0.0,0.0,0.0,eric lapin,MUSC-3120,2019
-MUSC,3140,1.0,World Music,0.68,0.16,0.1,0.03,0.0,0.0,0.0,0.03,paul buyer,MUSC-3140,2019
-MUSC,3170,1.0,Hist of Country Mus,0.78,0.16,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3170,2019
-MUSC,3180,1.0,Hist of Audio Tech,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,bruce allen whisler,MUSC-3180,2019
-MUSC,3610,1.0,Marching Band,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,MUSC-3610,2019
-MUSC,3700,1.0,Clemson University Singers,0.95,0.03,0.02,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,MUSC-3700,2019
-MUSC,3720,1.0,Men's Chorus,0.94,0.02,0.0,0.0,0.0,0.0,0.0,0.04,anthony bernarducci,MUSC-3720,2019
-MUSC,4150,1.0,Music Hist to 1750,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,linda dzuris,MUSC-4150,2019
-NPL,3000,1.0,Nonprofit Leadership,0.29,0.67,0.0,0.0,0.0,0.0,0.0,0.04,bonnie westbury stevens,NPL-3000,2019
-NPL,3000,2.0,Nonprofit Leadership,0.21,0.58,0.17,0.0,0.0,0.0,0.0,0.04,bonnie westbury stevens,NPL-3000,2019
-NPL,3000,3.0,Nonprofit Leadership,0.72,0.24,0.0,0.04,0.0,0.0,0.0,0.0,christina marie mazer,NPL-3000,2019
-NPL,3000,4.0,Nonprofit Leadership,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,corey douglas brookover,NPL-3000,2019
-NPL,3000,5.0,Nonprofit Leadership,0.41,0.48,0.07,0.0,0.04,0.0,0.0,0.0,corey douglas brookover,NPL-3000,2019
-NPL,3000,6.0,Nonprofit Leadership,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,corey douglas brookover,NPL-3000,2019
-NPL,3000,7.0,Nonprofit Leadership,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,corey douglas brookover,NPL-3000,2019
-NPL,3000,8.0,Nonprofit Leadership,0.74,0.15,0.04,0.07,0.0,0.0,0.0,0.0,christina marie mazer,NPL-3000,2019
-NPL,3000,9.0,Nonprofit Leadership,0.63,0.3,0.04,0.0,0.0,0.0,0.0,0.04,christina marie mazer,NPL-3000,2019
-NPL,3010,1.0,NPL Stakeholders,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,christina marie mazer,NPL-3010,2019
-NPL,3020,1.0,NPL Fundraising,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,joan laura phillips,NPL-3020,2019
-NPL,3030,1.0,NPL Personnel,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,joan laura phillips,NPL-3030,2019
-NPL,3040,1.0,NPL Risk Management,0.74,0.13,0.13,0.0,0.0,0.0,0.0,0.0,daniel morgan anderson,NPL-3040,2019
-NPL,3050,1.0,Strat Social Media for NP Org,0.81,0.11,0.05,0.0,0.0,0.0,0.0,0.03,randi alexandra plake,NPL-3050,2019
-NPL,3050,2.0,Strat Social Media for NP Org,0.83,0.14,0.0,0.02,0.0,0.0,0.0,0.0,randi alexandra plake,NPL-3050,2019
-NURS,1020,3.0,Nrsg Success Skills,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,janice garrison lanham,NURS-1020,2019
-NURS,1400,1.0,Comp App Hlth Care,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,NURS-1400,2019
-NURS,1400,2.0,Comp App Hlth Care,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,janice garrison lanham,NURS-1400,2019
-NURS,3000,1.0,Seminar- Leadership University,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,janice garrison lanham,NURS-3000,2019
-NURS,3030,1.0,Nursing of Adults,0.33,0.6,0.04,0.0,0.0,0.0,0.0,0.02,lena marie burgess,NURS-3030,2019
-NURS,3040,101.0,Pathophysiology,0.4,0.4,0.15,0.03,0.0,0.0,0.0,0.02,catherine sikkema murton,NURS-3040,2019
-NURS,3040,201.0,Pathophysiology,0.24,0.66,0.07,0.0,0.01,0.0,0.0,0.01,amy boggs garrison,NURS-3040,2019
-NURS,3040,400.0,Pathophysiology,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,amy boggs garrison,NURS-3040,2019
-NURS,3040,401.0,Pathophysiology,0.63,0.27,0.07,0.0,0.03,0.0,0.0,0.0,amy boggs garrison,NURS-3040,2019
-NURS,3050,1.0,Psychosocial Nursing,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.02,kevin earle busby,NURS-3050,2019
-NURS,3100,1.0,Health Assessment,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,NURS-3100,2019
-NURS,3100,401.0,Health Assessment,0.83,0.13,0.0,0.0,0.03,0.0,0.0,0.0,jason thrift,NURS-3100,2019
-NURS,3110,1.0,Hlth Promotion Across Lifespan,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,janice garrison lanham,NURS-3110,2019
-NURS,3120,101.0,Foundations of Nursing,0.51,0.47,0.0,0.0,0.0,0.0,0.0,0.02,jennifer elizabeth bagwell,NURS-3120,2019
-NURS,3120,201.0,Foundations of Nursing,0.31,0.65,0.01,0.01,0.0,0.0,0.0,0.01,terri abercrombie teramano,NURS-3120,2019
-NURS,3120,401.0,Foundations of Nursing,0.67,0.3,0.0,0.0,0.03,0.0,0.0,0.0,terri abercrombie teramano,NURS-3120,2019
-NURS,3200,1.0,Prof in Nurs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3200,2019
-NURS,3230,101.0,Gerontology Nursing,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,tawny jenna mcintosh,NURS-3230,2019
-NURS,3300,1.0,Research in Nursing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-3300,2019
-NURS,3300,2.0,Research in Nursing,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,hyewon shin,NURS-3300,2019
-NURS,3330,1.0,Health Care Genetics,0.58,0.36,0.04,0.0,0.0,0.0,0.0,0.02,linda ward,NURS-3330,2019
-NURS,3400,101.0,Pharmther Nursing,0.36,0.44,0.15,0.02,0.02,0.0,0.0,0.02,catherine sikkema murton,NURS-3400,2019
-NURS,3400,201.0,Pharmther Nursing,0.32,0.56,0.09,0.01,0.0,0.0,0.0,0.01,jenna lynn seawright,NURS-3400,2019
-NURS,3400,401.0,Pharmther Nursing,0.57,0.37,0.03,0.0,0.03,0.0,0.0,0.0,jenna lynn seawright,NURS-3400,2019
-NURS,3600,400.0,Social Determinants in Health,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,NURS-3600,2019
-NURS,4010,1.0,Mental Health Nurs,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebecca garrard,NURS-4010,2019
-NURS,4030,101.0,Complex Nursing of Adults,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen rankin ewing,NURS-4030,2019
-NURS,4030,202.0,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john joseph whitcomb,NURS-4030,2019
-NURS,4030,402.0,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john joseph whitcomb,NURS-4030,2019
-NURS,4060,400.0,Issues in Professionalism,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,NURS-4060,2019
-NURS,4110,1.0,Nursing of Children,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,NURS-4110,2019
-NURS,4120,1.0,Nurs Women and Fam,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,erin nicole shepherd,NURS-4120,2019
-NURS,8050,400.0,Pharmaco Adv Nurs,0.33,0.5,0.08,0.0,0.04,0.0,0.0,0.04,tracy king fasolino,NURS-8050,2019
-NURS,8050,401.0,Pharmaco Adv Nurs,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8050,2019
-NURS,8060,400.0,Advan Assessment for Nursing,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,NURS-8060,2019
-NURS,8090,400.0,Pathophysiology,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,NURS-8090,2019
-NURS,8190,400.0,Developing Family,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-8190,2019
-NURS,8200,400.0,Child & Adol Nursing,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-8200,2019
-NURS,9010,1.0,"DNP Role, Theory & Philosophy",0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,jean ellen zavertnik,NURS-9010,2019
-NURS,9020,1.0,DNP Clinical Epidem & Biostats,0.4,0.2,0.0,0.0,0.2,0.0,0.0,0.2,veronica parker,NURS-9020,2019
-NUTR,2030,1.0,Intro Princ of Human Nutrition,0.91,0.08,0.01,0.0,0.0,0.0,0.0,0.0,bridgit denise corbett,NUTR-2030,2019
-NUTR,2030,2.0,Intro Princ of Human Nutrition,0.71,0.24,0.02,0.02,0.0,0.0,0.0,0.0,bridgit denise corbett,NUTR-2030,2019
-NUTR,2040,1.0,Nutrition Across Life Cycle,0.63,0.24,0.11,0.03,0.0,0.0,0.0,0.0,bridgit denise corbett,NUTR-2040,2019
-NUTR,2050,400.0,Nutrition for Nursing Prof,0.37,0.46,0.17,0.0,0.0,0.0,0.0,0.0,elizabeth lacey durrance,NUTR-2050,2019
-NUTR,2160,1.0,Evidence-Based Nutrition,0.84,0.08,0.05,0.0,0.02,0.0,0.0,0.01,angela fraser,NUTR-2160,2019
-NUTR,3020,1.0,Nutrition Assessment,0.63,0.34,0.02,0.0,0.02,0.0,0.0,0.0,elliot jesch,NUTR-3020,2019
-NUTR,4240,1.0,Medical Nutr Thera I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4240,2019
-NUTR,4510,1.0,Human Nutrition & Metabolism I,0.33,0.24,0.21,0.13,0.08,0.0,0.0,0.02,elliot jesch,NUTR-4510,2019
-PA,1010,1.0,Intro to Perf Arts,0.5,0.25,0.13,0.06,0.06,0.0,0.0,0.0,david hartmann,PA-1010,2019
-PA,2790,1.0,Perf Arts Pract I,0.47,0.0,0.06,0.0,0.24,0.0,0.0,0.24,kenneth moore,PA-2790,2019
-PA,3010,1.0,Princip of Arts Administration,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,richard goodstein,PA-3010,2019
-PA,4010,1.0,Capstone Project,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,PA-4010,2019
-PADM,7020,400.0,Research Methods,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ronald chrestman,PADM-7020,2019
-PADM,8210,400.0,Perspectives on Public Admin,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,thomas walker,PADM-8210,2019
-PADM,8220,401.0,Public Policy Process,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,ekaterina yazykova mellott,PADM-8220,2019
-PADM,8290,400.0,Public Financial Management,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,PADM-8290,2019
-PADM,8410,400.0,Public Data Analysis,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,ryan joseph gagnon,PADM-8410,2019
-PADM,8420,400.0,GIS for Public Administrators,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lawrence white,PADM-8420,2019
-PADM,8670,401.0,State Government Admin,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,PADM-8670,2019
-PAS,3010,1.0,Intro to Pan African Studies,0.51,0.41,0.02,0.0,0.04,0.0,0.0,0.01,abel bartley,PAS-3010,2019
-PDBE,8150,1.0,Research Design in EDP,0.43,0.29,0.14,0.0,0.14,0.0,0.0,0.0,mickey lauria,PDBE-8150,2019
-PES,1040,1.0,Introduction to Plant Sciences,0.69,0.24,0.02,0.0,0.0,0.0,0.0,0.04,paula agudelo,PES-1040,2019
-PES,2020,1.0,Soils,0.14,0.51,0.26,0.05,0.0,0.0,0.0,0.04,dara michelle park,PES-2020,2019
-PES,3150,1.0,Environment and Agriculture,0.29,0.67,0.0,0.0,0.05,0.0,0.0,0.0,vidya appukuttan suseela,PES-3150,2019
-PES,4090,1.0,Biology of Invasive Plants,0.67,0.17,0.08,0.0,0.08,0.0,0.0,0.0,nishanth tharayil-santhakumar,PES-4090,2019
-PES,4210,1.0,Princ of Field Crop Production,0.39,0.5,0.0,0.06,0.0,0.0,0.0,0.06,sruthi narayanan kutty,PES-4210,2019
-PES,4850,1.0,Environmental Soil Chemistry,0.55,0.27,0.0,0.0,0.18,0.0,0.0,0.0,haibo liu,PES-4850,2019
-PES,4960,1.0,Sel Top: Soil Judging,0.57,0.0,0.0,0.14,0.14,0.0,0.0,0.14,dara michelle park,PES-4960,2019
-PHIL,1010,2.0,Intro to Philosophic Problems,0.51,0.43,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-1010,2019
-PHIL,1010,3.0,Intro to Philosophic Problems,0.56,0.35,0.06,0.03,0.0,0.0,0.0,0.0,christopher grau,PHIL-1010,2019
-PHIL,1010,7.0,Intro to Philosophic Problems,0.71,0.12,0.0,0.0,0.06,0.0,0.0,0.12,david stegall,PHIL-1010,2019
-PHIL,1010,8.0,Intro to Philosophic Problems,0.53,0.35,0.0,0.06,0.0,0.0,0.0,0.06,david stegall,PHIL-1010,2019
-PHIL,1010,9.0,Intro to Philosophic Problems,0.44,0.36,0.08,0.0,0.03,0.0,0.0,0.08,david stegall,PHIL-1010,2019
-PHIL,1020,1.0,Introduction to Logic,0.4,0.37,0.14,0.06,0.03,0.0,0.0,0.0,adam gies,PHIL-1020,2019
-PHIL,1020,3.0,Introduction to Logic,0.4,0.31,0.29,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-1020,2019
-PHIL,1020,4.0,Introduction to Logic,0.47,0.31,0.0,0.03,0.08,0.0,0.0,0.11,craig bacon,PHIL-1020,2019
-PHIL,1020,7.0,Introduction to Logic,0.37,0.2,0.09,0.09,0.03,0.0,0.0,0.23,david stegall,PHIL-1020,2019
-PHIL,1020,11.0,Introduction to Logic,0.61,0.14,0.11,0.03,0.0,0.0,0.0,0.11,david stegall,PHIL-1020,2019
-PHIL,1020,15.0,Introduction to Logic,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,adam gies,PHIL-1020,2019
-PHIL,1020,16.0,Introduction to Logic,0.16,0.53,0.21,0.05,0.0,0.0,0.0,0.05,edyta joanna kuzian,PHIL-1020,2019
-PHIL,1020,17.0,Introduction to Logic,0.55,0.26,0.11,0.0,0.03,0.0,0.0,0.05,edyta joanna kuzian,PHIL-1020,2019
-PHIL,1020,18.0,Introduction to Logic,0.78,0.13,0.03,0.0,0.0,0.0,0.0,0.06,adam paul omelianchuk,PHIL-1020,2019
-PHIL,1020,19.0,Introduction to Logic,0.69,0.11,0.11,0.0,0.0,0.0,0.0,0.09,adam paul omelianchuk,PHIL-1020,2019
-PHIL,1020,20.0,Introduction to Logic,0.85,0.12,0.0,0.03,0.0,0.0,0.0,0.0,adam paul omelianchuk,PHIL-1020,2019
-PHIL,1030,2.0,Introduction to Ethics,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,stephen satris,PHIL-1030,2019
-PHIL,1030,3.0,Introduction to Ethics,0.4,0.34,0.14,0.06,0.0,0.0,0.0,0.06,david robert antonini,PHIL-1030,2019
-PHIL,1030,6.0,Introduction to Ethics,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,charles starkey,PHIL-1030,2019
-PHIL,1030,8.0,Introduction to Ethics,0.79,0.06,0.06,0.0,0.03,0.0,0.0,0.06,winthrop brent hepburn,PHIL-1030,2019
-PHIL,1030,9.0,Introduction to Ethics,0.5,0.44,0.03,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,PHIL-1030,2019
-PHIL,1030,10.0,Introduction to Ethics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,PHIL-1030,2019
-PHIL,3040,1.0,Moral Philosophy,0.4,0.47,0.07,0.0,0.07,0.0,0.0,0.0,todd may,PHIL-3040,2019
-PHIL,3150,1.0,Ancient Philosophy,0.39,0.42,0.09,0.06,0.0,0.0,0.0,0.03,stephen satris,PHIL-3150,2019
-PHIL,3210,1.0,Crime & Punishment,0.21,0.63,0.11,0.0,0.0,0.0,0.0,0.05,daniel wueste,PHIL-3210,2019
-PHIL,3260,1.0,Science and Values,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,david robert antonini,PHIL-3260,2019
-PHIL,3260,2.0,Science and Values,0.62,0.29,0.06,0.0,0.0,0.0,0.0,0.03,david robert antonini,PHIL-3260,2019
-PHIL,3300,1.0,Animal Rights,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,todd may,PHIL-3300,2019
-PHIL,3430,1.0,Philosophy of Law,0.29,0.47,0.18,0.0,0.0,0.0,0.0,0.06,brookes colyton brown,PHIL-3430,2019
-PHIL,3440,1.0,Business Ethics,0.17,0.5,0.13,0.0,0.04,0.0,0.0,0.17,brookes colyton brown,PHIL-3440,2019
-PHIL,3450,1.0,Environmental Ethics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,adam paul omelianchuk,PHIL-3450,2019
-PHIL,3480,1.0,Philosophies of Art,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christopher grau,PHIL-3480,2019
-PHIL,3510,1.0,Phil of Emotion,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,charles starkey,PHIL-3510,2019
-PHIL,4020,2.0,Topics in Philosophy,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,diane perpich,PHIL-4020,2019
-PHIL,4920,2.0,Creative Inquiry in Philosophy,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,stephen satris,PHIL-4920,2019
-PHSC,1180,1.0,Intro to Phy & Astr for Ele Ed,0.77,0.18,0.03,0.02,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1180,2019
-PHYS,1220,1.0,Physics with Calculus I,0.3,0.26,0.26,0.09,0.06,0.0,0.0,0.04,lih-sin the,PHYS-1220,2019
-PHYS,1220,2.0,Physics with Calculus I,0.21,0.31,0.27,0.07,0.06,0.0,0.0,0.07,lih-sin the,PHYS-1220,2019
-PHYS,1220,3.0,Physics W/Cal I (HON),0.42,0.33,0.08,0.0,0.0,0.0,0.0,0.17,joshua alper,PHYS-1220,2019
-PHYS,1220,4.0,Physics with Calculus I,0.27,0.32,0.05,0.18,0.09,0.0,0.0,0.09,joshua alper,PHYS-1220,2019
-PHYS,1240,1.0,Physics Lab I,0.07,0.14,0.5,0.14,0.07,0.0,0.0,0.07,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,2.0,Physics Lab I,0.09,0.73,0.09,0.09,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,3.0,Physics Lab I,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,4.0,Physics Lab I,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,5.0,Physics Lab I,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,6.0,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,7.0,Physics Lab I,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,8.0,Physics Lab I,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,9.0,Physics Lab I,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,10.0,Physics Lab I,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,11.0,Physics Lab I,0.63,0.19,0.13,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,13.0,Physics Lab I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,14.0,Physics Lab I,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,15.0,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,16.0,Physics Lab I,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,17.0,Physics Lab I,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,18.0,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,19.0,Physics Lab I,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-1240,2019
-PHYS,1240,21.0,Physics Lab I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-1240,2019
-PHYS,2070,1.0,General Physics I,0.24,0.23,0.2,0.15,0.1,0.0,0.0,0.08,amy liann pope,PHYS-2070,2019
-PHYS,2070,2.0,General Physics I,0.31,0.29,0.21,0.08,0.06,0.0,0.0,0.05,amy liann pope,PHYS-2070,2019
-PHYS,2070,3.0,General Physics I,0.19,0.31,0.27,0.07,0.1,0.0,0.0,0.06,amy liann pope,PHYS-2070,2019
-PHYS,2070,4.0,General Physics I,0.23,0.31,0.23,0.13,0.08,0.0,0.0,0.02,david edward connick,PHYS-2070,2019
-PHYS,2080,1.0,General Physics II,0.42,0.34,0.13,0.09,0.03,0.0,0.0,0.0,david edward connick,PHYS-2080,2019
-PHYS,2090,1.0,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,2.0,Gen Phys Lab I,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,3.0,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,4.0,Gen Phys Lab I,0.83,0.09,0.0,0.0,0.0,0.0,0.0,0.09,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,5.0,Gen Phys Lab I,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,6.0,Gen Phys Lab I,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,7.0,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,8.0,Gen Phys Lab I,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,9.0,Gen Phys Lab I,0.65,0.22,0.09,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,10.0,Gen Phys Lab I,0.71,0.17,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,11.0,Gen Phys Lab I,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,12.0,Gen Phys Lab I,0.63,0.21,0.0,0.04,0.04,0.0,0.0,0.08,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,13.0,Gen Phys Lab I,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,14.0,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,15.0,Gen Phys Lab I,0.79,0.04,0.08,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,16.0,Gen Phys Lab I,0.83,0.04,0.09,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,17.0,Gen Phys Lab I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,18.0,Gen Phys Lab I,0.58,0.25,0.04,0.0,0.04,0.0,0.0,0.08,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,19.0,Gen Phys Lab I,0.63,0.33,0.0,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,20.0,Gen Phys Lab I,0.7,0.22,0.09,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,21.0,Gen Phys Lab I,0.33,0.54,0.04,0.0,0.08,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,22.0,Gen Phys Lab I,0.61,0.3,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,23.0,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,24.0,Gen Phys Lab I,0.5,0.38,0.0,0.0,0.04,0.0,0.0,0.08,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,25.0,Gen Phys Lab I,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,26.0,Gen Phys Lab I,0.57,0.35,0.04,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,PHYS-2090,2019
-PHYS,2090,27.0,Gen Phys Lab I,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2090,2019
-PHYS,2100,1.0,Gen Phys Lab II,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2019
-PHYS,2100,2.0,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2019
-PHYS,2100,3.0,Gen Phys Lab II,0.63,0.33,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2019
-PHYS,2100,4.0,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2019
-PHYS,2100,6.0,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2019
-PHYS,2100,7.0,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2019
-PHYS,2100,8.0,Gen Phys Lab II,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,PHYS-2100,2019
-PHYS,2100,9.0,Gen Phys Lab II,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,PHYS-2100,2019
-PHYS,2210,1.0,Physics with Calculus II,0.13,0.43,0.29,0.09,0.03,0.0,0.0,0.03,jason stratford brown,PHYS-2210,2019
-PHYS,2210,2.0,Physics with Calculus II,0.21,0.47,0.24,0.05,0.01,0.0,0.0,0.02,jason stratford brown,PHYS-2210,2019
-PHYS,2210,3.0,Physics with Calculus II,0.37,0.48,0.11,0.02,0.0,0.0,0.0,0.01,chad sosolik,PHYS-2210,2019
-PHYS,2210,4.0,Physics with Calculus II,0.25,0.51,0.18,0.02,0.02,0.0,0.0,0.01,chad sosolik,PHYS-2210,2019
-PHYS,2210,5.0,Physics w/Calculus II(HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,PHYS-2210,2019
-PHYS,2220,1.0,Physics with Calculus III,0.74,0.11,0.05,0.0,0.0,0.0,0.0,0.11,murray daw,PHYS-2220,2019
-PHYS,2230,1.0,Physics Lab II,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,2.0,Physics Lab II,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,3.0,Physics Lab II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,4.0,Physics Lab II,0.17,0.78,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,5.0,Physics Lab II,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,6.0,Physics Lab II,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,7.0,Physics Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,9.0,Physics Lab II,0.29,0.65,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,10.0,Physics Lab II,0.22,0.72,0.0,0.0,0.06,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,11.0,Physics Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,13.0,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,14.0,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2230,17.0,Physics Lab II,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,daniel ross thompson,PHYS-2230,2019
-PHYS,2450,1.0,Physics of Climate,0.37,0.37,0.09,0.05,0.01,0.0,0.0,0.11,jens oberheide,PHYS-2450,2019
-PHYS,3000,1.0,Intro to Research,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean brittain,PHYS-3000,2019
-PHYS,3150,1.0,Intro to Computational Physics,0.4,0.2,0.27,0.0,0.0,0.0,0.0,0.13,jason stratford brown,PHYS-3150,2019
-PHYS,3210,1.0,Mechanics I,0.17,0.41,0.17,0.07,0.0,0.0,0.0,0.17,stephen roland kaeppler,PHYS-3210,2019
-PHYS,3250,1.0,Exper Physics I,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,jianbo gao,PHYS-3250,2019
-PHYS,3990,7.0,CI: K-12 STEM Competitions,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,domnita catalina marinescu,PHYS-3990,2019
-PHYS,4410,1.0,Electromagnetics I,0.24,0.41,0.29,0.0,0.06,0.0,0.0,0.0,xian lu,PHYS-4410,2019
-PHYS,4520,1.0,Nuclear and Particle Physics,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,endre andras takacs,PHYS-4520,2019
-PHYS,4550,1.0,Quantum Physics I,0.15,0.46,0.38,0.0,0.0,0.0,0.0,0.0,gerald lehmacher,PHYS-4550,2019
-PHYS,6550,1.0,Quantum Physics I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,gerald lehmacher,PHYS-6550,2019
-PHYS,8110,1.0,Meth of Theor Phys I,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,feng ding,PHYS-8110,2019
-PHYS,8210,1.0,Classical Mech I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,dieter hartmann,PHYS-8210,2019
-PHYS,9510,1.0,Quantum Mech I,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,sumanta tewari,PHYS-9510,2019
-PKSC,1010,1.0,Pkgsc Orientation,0.9,0.05,0.01,0.01,0.0,0.0,0.0,0.01,patricia guerra marcondes,PKSC-1010,2019
-PKSC,1020,1.0,Intro to Pkg Sci,0.08,0.31,0.33,0.18,0.05,0.0,0.0,0.05,heather batt,PKSC-1020,2019
-PKSC,2010,1.0,Pkg Perishable Prod,0.13,0.28,0.09,0.09,0.22,0.0,0.0,0.19,heather batt,PKSC-2010,2019
-PKSC,2020,1.0,Packaging Mtl & Mfg,0.23,0.4,0.27,0.1,0.0,0.0,0.0,0.0,patricia guerra marcondes,PKSC-2020,2019
-PKSC,2040,1.0,Container Systems,0.31,0.38,0.15,0.0,0.0,0.0,0.0,0.15,patricia guerra marcondes,PKSC-2040,2019
-PKSC,2200,1.0,Product & Pkg Design,0.73,0.14,0.08,0.0,0.05,0.0,0.0,0.0,haley ellis appleby,PKSC-2200,2019
-PKSC,3200,1.0,Pkg Design Theory,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,rupert hurley,PKSC-3200,2019
-PKSC,4010,1.0,Packaging Machinery,0.42,0.38,0.17,0.01,0.01,0.0,0.0,0.0,anthony louis pometto,PKSC-4010,2019
-PKSC,4030,1.0,Packaging Career Preparation,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2019
-PKSC,4040,1.0,Protective Packaging Prop/Prin,0.23,0.44,0.23,0.03,0.04,0.0,0.0,0.03,gregory batt,PKSC-4040,2019
-PKSC,4160,1.0,Application of Polymers in Pkg,0.34,0.56,0.08,0.0,0.02,0.0,0.0,0.0,alicia cutler campbell,PKSC-4160,2019
-PKSC,4200,1.0,Package Design & Development,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2019
-PKSC,4540,1.0,Product & Pkg Evaluation Lab,0.13,0.6,0.2,0.0,0.0,0.0,0.0,0.07,gregory batt,PKSC-4540,2019
-PKSC,4540,2.0,Product & Pkg Evaluation Lab,0.19,0.5,0.06,0.06,0.13,0.0,0.0,0.06,gregory batt,PKSC-4540,2019
-PKSC,4540,3.0,Product & Pkg Evaluation Lab,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2019
-PKSC,4540,4.0,Product & Pkg Evaluation Lab,0.09,0.45,0.27,0.09,0.0,0.0,0.0,0.09,gregory batt,PKSC-4540,2019
-PKSC,4540,5.0,Product & Pkg Evaluation Lab,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,gregory batt,PKSC-4540,2019
-PKSC,4640,1.0,Food & Health Care Pkg Systems,0.58,0.33,0.04,0.02,0.02,0.0,0.0,0.0,kay cooksey,PKSC-4640,2019
-PKSC,4990,7.0,Creative Inquiry Pkg Science,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,rupert hurley,PKSC-4990,2019
-PLPA,3100,1.0,Principles of Plant Pathology,0.26,0.22,0.3,0.19,0.04,0.0,0.0,0.0,steven nye jeffers,PLPA-3100,2019
-PLPA,4250,1.0,Introductory Mycology,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,julia louise kerrigan,PLPA-4250,2019
-PLPA,8020,1.0,Principles of Plant Pathology,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,PLPA-8020,2019
-POSC,1010,1.0,Amer National Govt,0.42,0.35,0.16,0.02,0.04,0.0,0.0,0.02,ethan craig busby,POSC-1010,2019
-POSC,1010,2.0,Amer National Govt,0.32,0.32,0.22,0.12,0.01,0.0,0.0,0.0,robert carey,POSC-1010,2019
-POSC,1020,1.0,Intro Intl Relations,0.31,0.41,0.13,0.07,0.02,0.0,0.0,0.06,steven vincent miller,POSC-1020,2019
-POSC,1020,2.0,Intro Intl Relations,0.4,0.35,0.13,0.03,0.03,0.0,0.0,0.06,tara elizabeth trask,POSC-1020,2019
-POSC,1020,3.0,Intro Intl Relations,0.56,0.29,0.07,0.01,0.03,0.0,0.0,0.04,tara elizabeth trask,POSC-1020,2019
-POSC,1020,4.0,Intro Intl Relations,0.12,0.48,0.12,0.14,0.07,0.0,0.0,0.07,joshua douglas king,POSC-1020,2019
-POSC,1020,5.0,Intro Intl Relations,0.12,0.51,0.27,0.0,0.02,0.0,0.0,0.08,colin denby pearce,POSC-1020,2019
-POSC,1020,6.0,Intro Intl Relations,0.41,0.36,0.12,0.01,0.06,0.0,0.0,0.04,tara elizabeth trask,POSC-1020,2019
-POSC,1030,1.0,Intro to Political Theory,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,derek neal duplessie,POSC-1030,2019
-POSC,1030,2.0,Intro to Political Theory,0.3,0.5,0.13,0.0,0.03,0.0,0.0,0.03,adam michael thomas,POSC-1030,2019
-POSC,1030,3.0,Intro to Political Theory,0.27,0.43,0.2,0.0,0.0,0.0,0.0,0.1,colin denby pearce,POSC-1030,2019
-POSC,1030,4.0,Intro to Political Theory,0.4,0.29,0.23,0.03,0.03,0.0,0.0,0.03,brandon turner,POSC-1030,2019
-POSC,1040,1.0,Intro Compar Pol,0.44,0.28,0.19,0.04,0.0,0.0,0.0,0.06,matthew henry rhodes-purdy,POSC-1040,2019
-POSC,1990,1.0,Intro Pol Sci,0.47,0.32,0.09,0.06,0.02,0.0,0.0,0.04,meredith-joy petersheim,POSC-1990,2019
-POSC,3020,1.0,State and Loc Gov,0.17,0.6,0.1,0.0,0.02,0.0,0.0,0.1,bruce ransom,POSC-3020,2019
-POSC,3050,1.0,CI in Political Sci,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,matthew henry rhodes-purdy,POSC-3050,2019
-POSC,3110,1.0,Model United Nations,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,xiaobo hu,POSC-3110,2019
-POSC,3410,1.0,Quant Meth in Pol Sc,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,ethan craig busby,POSC-3410,2019
-POSC,3610,1.0,International Conflict,0.28,0.22,0.18,0.04,0.22,0.0,0.0,0.06,steven vincent miller,POSC-3610,2019
-POSC,3620,1.0,Intl Organizations,0.21,0.33,0.21,0.04,0.08,0.0,0.0,0.13,zeynep taydas,POSC-3620,2019
-POSC,3620,2.0,Intl Organizations,0.32,0.36,0.08,0.08,0.08,0.0,0.0,0.08,zeynep taydas,POSC-3620,2019
-POSC,3630,1.0,Us Foreign Policy,0.29,0.57,0.09,0.03,0.0,0.0,0.0,0.03,jeffrey scott peake,POSC-3630,2019
-POSC,3710,1.0,European Politics,0.45,0.37,0.08,0.0,0.0,0.0,0.0,0.1,vladimir matic,POSC-3710,2019
-POSC,4030,1.0,United States Congress,0.27,0.31,0.33,0.06,0.02,0.0,0.0,0.02,jeffrey allen fine,POSC-4030,2019
-POSC,4210,1.0,Public Policy,0.17,0.33,0.33,0.06,0.0,0.0,0.0,0.11,adam warber,POSC-4210,2019
-POSC,4300,1.0,Policy Evaluation,0.45,0.18,0.27,0.0,0.0,0.0,0.0,0.09,robert carey,POSC-4300,2019
-POSC,4360,1.0,Law Courts Politics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,POSC-4360,2019
-POSC,4360,2.0,Law Courts Politics,0.74,0.24,0.03,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,POSC-4360,2019
-POSC,4370,1.0,Constitut Law: Rights & Libert,0.4,0.5,0.05,0.0,0.0,0.0,0.0,0.05,kevin gregory vance,POSC-4370,2019
-POSC,4380,1.0,Constitut Law: Struc of Gov,0.56,0.27,0.1,0.02,0.0,0.0,0.0,0.04,christina rose bambrick,POSC-4380,2019
-POSC,4420,1.0,Pol Parties & Elect,0.29,0.43,0.22,0.04,0.0,0.0,0.0,0.02,laura olson,POSC-4420,2019
-POSC,4490,1.0,Political Theory of Capitalism,0.29,0.44,0.24,0.0,0.0,0.0,0.0,0.03,colin denby pearce,POSC-4490,2019
-POSC,4490,2.0,Political Theory of Capitalism,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,brandon turner,POSC-4490,2019
-POSC,4500,1.0,Rights: Theory & Practice,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,christina rose bambrick,POSC-4500,2019
-POSC,4550,1.0,Pol Thght of American Founding,0.52,0.37,0.11,0.0,0.0,0.0,0.0,0.0, bradley thompson,POSC-4550,2019
-POSC,4580,1.0,Political Leadership,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,joshua douglas king,POSC-4580,2019
-POSC,4760,1.0,Middle East Politics,0.5,0.38,0.0,0.0,0.06,0.0,0.0,0.06,vladimir matic,POSC-4760,2019
-POSC,4780,1.0,Latin Amer Politics,0.63,0.23,0.09,0.0,0.06,0.0,0.0,0.0,matthew henry rhodes-purdy,POSC-4780,2019
-POST,8990,1.0,"Markets, Gov't. & Public Pol.",0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert carey,POST-8990,2019
-PRTM,1950,2.0,Pro Golf Management Seminar I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-1950,2019
-PRTM,2110,1.0,Sts Play Rec Tourism,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew mutel browning,PRTM-2110,2019
-PRTM,2200,1.0,Foundations of PRTM,0.16,0.66,0.18,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2200,2019
-PRTM,2200,2.0,Foundations of PRTM,0.34,0.49,0.12,0.03,0.02,0.0,0.0,0.0,teresa walton tucker,PRTM-2200,2019
-PRTM,2260,1.0,Fnd of Mgt Adm PRTM,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2260,2019
-PRTM,2260,2.0,Fnd of Mgt Adm PRTM,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,PRTM-2260,2019
-PRTM,2260,3.0,Fnd of Mgt Adm PRTM,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2260,2019
-PRTM,2260,4.0,Fnd of Mgt Adm PRTM,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2260,2019
-PRTM,2260,5.0,Fnd of Mgt Adm PRTM,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,gwynn powell,PRTM-2260,2019
-PRTM,2260,6.0,Fnd of Mgt Adm PRTM,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,PRTM-2260,2019
-PRTM,2260,7.0,Fnd of Mgt Adm PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,PRTM-2260,2019
-PRTM,2260,8.0,Fnd of Mgt Adm PRTM,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,PRTM-2260,2019
-PRTM,2270,1.0,Prov of Leisure Exp,0.5,0.38,0.06,0.06,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2270,2019
-PRTM,2270,2.0,Prov of Leisure Exp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,PRTM-2270,2019
-PRTM,2270,3.0,Prov of Leisure Exp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2270,2019
-PRTM,2270,4.0,Prov of Leisure Exp,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2270,2019
-PRTM,2270,5.0,Prov of Leisure Exp,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,gwynn powell,PRTM-2270,2019
-PRTM,2270,6.0,Prov of Leisure Exp,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,PRTM-2270,2019
-PRTM,2270,7.0,Prov of Leisure Exp,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,PRTM-2270,2019
-PRTM,2270,8.0,Prov of Leisure Exp,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,PRTM-2270,2019
-PRTM,2290,1.0,Competency Integration in PRTM,0.44,0.38,0.13,0.06,0.0,0.0,0.0,0.0,teresa walton tucker,PRTM-2290,2019
-PRTM,2290,2.0,Competency Integration in PRTM,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,PRTM-2290,2019
-PRTM,2290,3.0,Competency Integration in PRTM,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,francis mcguire,PRTM-2290,2019
-PRTM,2290,4.0,Competency Integration in PRTM,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,PRTM-2290,2019
-PRTM,2290,5.0,Competency Integration in PRTM,0.38,0.38,0.19,0.06,0.0,0.0,0.0,0.0,gwynn powell,PRTM-2290,2019
-PRTM,2290,6.0,Competency Integration in PRTM,0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,jeffrey townsend,PRTM-2290,2019
-PRTM,2290,7.0,Competency Integration in PRTM,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,PRTM-2290,2019
-PRTM,2290,8.0,Competency Integration in PRTM,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,PRTM-2290,2019
-PRTM,2980,9.0,Creative Inquiry in PRTM II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,denise marie anderson,PRTM-2980,2019
-PRTM,3050,1.0,Safety/Risk Mgt PRTM,0.43,0.3,0.13,0.1,0.0,0.0,0.0,0.03,daniel morgan anderson,PRTM-3050,2019
-PRTM,3070,2.0,Facility Operations,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,raymond dunham,PRTM-3070,2019
-PRTM,3200,1.0,Recreation Policy,0.8,0.0,0.1,0.05,0.0,0.0,0.0,0.05,elizabeth perry,PRTM-3200,2019
-PRTM,3240,1.0,Assessment & Planning in RT,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-3240,2019
-PRTM,3300,1.0,Visit Ser & Interp,0.5,0.22,0.22,0.06,0.0,0.0,0.0,0.0,aby lat soukabe sene harper,PRTM-3300,2019
-PRTM,3420,1.0,Intro to Tourism,0.5,0.35,0.06,0.03,0.0,0.0,0.0,0.06,gregory philip ramshaw,PRTM-3420,2019
-PRTM,3430,1.0,Spl Asp of Tourist B,0.53,0.36,0.09,0.0,0.0,0.0,0.0,0.02,william norman,PRTM-3430,2019
-PRTM,3470,1.0,Sport Tourism,0.36,0.36,0.23,0.0,0.0,0.0,0.0,0.05,gregory philip ramshaw,PRTM-3470,2019
-PRTM,3520,1.0,Camp Org and Admin,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,alexsandra dubin,PRTM-3520,2019
-PRTM,3600,1.0,Recreation & Amateur Sport Mgt,0.35,0.35,0.17,0.04,0.0,0.0,0.0,0.09,skye gerald arthur-banning,PRTM-3600,2019
-PRTM,3900,8.0,PGA GM Player Development,0.7,0.15,0.1,0.0,0.0,0.0,0.0,0.05,richard lucas,PRTM-3900,2019
-PRTM,3910,1.0,Issues & Trends in Event Mgmt.,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,stephanie perler garst,PRTM-3910,2019
-PRTM,3920,1.0,Special Event Management,0.95,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,PRTM-3920,2019
-PRTM,4030,1.0,Elem of Rec/Pk Plan,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,samuel gaines,PRTM-4030,2019
-PRTM,4210,1.0,Rec Fin Resc Mgt,0.54,0.39,0.02,0.0,0.02,0.0,0.0,0.02,ryan joseph gagnon,PRTM-4210,2019
-PRTM,4220,2.0,Management of RT Services,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,sandra heath,PRTM-4220,2019
-PRTM,4230,1.0,Adaptive Sports & Recreation,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,jasmine nutter townsend,PRTM-4230,2019
-PRTM,4260,1.0,Trends & Issues in Rec Therapy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,PRTM-4260,2019
-PRTM,4470,1.0,Perspect Intl Travel,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,'lisha fogle,PRTM-4470,2019
-PRTM,4470,2.0,Perspect Intl Travel,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sheila backman,PRTM-4470,2019
-PRTM,4510,1.0,Seminar in CRSCM,0.7,0.19,0.06,0.02,0.02,0.0,0.0,0.0,skye gerald arthur-banning,PRTM-4510,2019
-PRTM,4550,1.0,Adv Program Planning,0.73,0.25,0.02,0.0,0.0,0.0,0.0,0.0,harrison parker pinckney,PRTM-4550,2019
-PRTM,4740,2.0,Adv Rec Resource Mgt,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,matthew tyler james brownlee,PRTM-4740,2019
-PRTM,8080,2.0,Behavioral Aspects,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,iryna sharaievska,PRTM-8080,2019
-PRTM,8080,3.0,Behavioral Aspects,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,lauren duffy,PRTM-8080,2019
-PRTM,8710,1.0,Applied Research in Rec Therap,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,brandi crowe,PRTM-8710,2019
-PRTM,8720,1.0,Adv Facilitation Techniq in RT,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,PRTM-8720,2019
-PRTM,9000,11.0,MS Capstone,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charles hallo,PRTM-9000,2019
-PSYC,2010,1.0,Intro to Psychology,0.3,0.34,0.2,0.07,0.05,0.0,0.0,0.05,edwin brainerd,PSYC-2010,2019
-PSYC,2010,2.0,Intro to Psychology,0.3,0.31,0.2,0.09,0.03,0.0,0.0,0.07,jo jorgensen,PSYC-2010,2019
-PSYC,2010,3.0,Intro to Psychology,0.41,0.33,0.18,0.05,0.03,0.0,0.0,0.01,jo jorgensen,PSYC-2010,2019
-PSYC,2010,4.0,Intro to Psychology,0.49,0.29,0.11,0.01,0.03,0.0,0.0,0.07,chong hyon pak,PSYC-2010,2019
-PSYC,2010,5.0,Intro to Psychology,0.38,0.34,0.16,0.04,0.03,0.0,0.0,0.04,chong hyon pak,PSYC-2010,2019
-PSYC,2010,6.0,Intro to Psychology,0.41,0.33,0.16,0.03,0.03,0.0,0.0,0.04,mary taylor,PSYC-2010,2019
-PSYC,2010,7.0,Intro to Psychology,0.57,0.14,0.2,0.04,0.01,0.0,0.0,0.03,mary taylor,PSYC-2010,2019
-PSYC,2010,8.0,Intro to Psychology,0.37,0.36,0.14,0.04,0.06,0.0,0.0,0.03,fred switzer,PSYC-2010,2019
-PSYC,2010,9.0,Intro to Psychology (HON),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,PSYC-2010,2019
-PSYC,2030,1.0,Fundamentals of Psych Science,0.41,0.37,0.15,0.06,0.01,0.0,0.0,0.01,peggy jean tyler,PSYC-2030,2019
-PSYC,3060,1.0,Human Sexual Behavior,0.51,0.22,0.16,0.05,0.04,0.0,0.0,0.02,bruce michael king,PSYC-3060,2019
-PSYC,3090,100.0,Intro Experimental Psychology,0.35,0.35,0.14,0.08,0.05,0.0,0.0,0.03,jennifer bailey bisson,PSYC-3090,2019
-PSYC,3090,200.0,Intro Experimental Psychology,0.66,0.21,0.14,0.0,0.0,0.0,0.0,0.0,patrick rosopa,PSYC-3090,2019
-PSYC,3100,100.0,Advanced Experimental Psych,0.29,0.41,0.12,0.0,0.12,0.0,0.0,0.06,eric mckibben,PSYC-3100,2019
-PSYC,3100,200.0,Advanced Experimental Psych,0.26,0.47,0.11,0.05,0.05,0.0,0.0,0.05,cynthia pury,PSYC-3100,2019
-PSYC,3100,300.0,Advanced Experimental Psych,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,eric mckibben,PSYC-3100,2019
-PSYC,3100,400.0,Advanced Experimental Psych,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,thomas britt,PSYC-3100,2019
-PSYC,3100,500.0,Advanced Experimental Psych,0.47,0.16,0.16,0.11,0.05,0.0,0.0,0.05,benjamin stephens,PSYC-3100,2019
-PSYC,3100,600.0,Advanced Experimental Psych,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2019
-PSYC,3100,700.0,Advanced Experimental Psych,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2019
-PSYC,3100,800.0,Advanced Experimental Psych,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3100,2019
-PSYC,3240,1.0,Physiological Psych,0.36,0.24,0.2,0.09,0.03,0.0,0.0,0.08,claudio cantalupo,PSYC-3240,2019
-PSYC,3240,2.0,Physiological Psych,0.25,0.22,0.2,0.11,0.05,0.0,0.0,0.18,june pilcher,PSYC-3240,2019
-PSYC,3240,3.0,Physiological Psych,0.29,0.33,0.21,0.07,0.03,0.0,0.0,0.07,claudio cantalupo,PSYC-3240,2019
-PSYC,3310,1.0,Critical Thinking,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3310,2019
-PSYC,3330,1.0,Cognitive Psych,0.68,0.23,0.08,0.01,0.0,0.0,0.0,0.0,kaileigh angela byrne,PSYC-3330,2019
-PSYC,3330,2.0,Cognitive Psych,0.49,0.37,0.11,0.03,0.0,0.0,0.0,0.0,kaileigh angela byrne,PSYC-3330,2019
-PSYC,3340,1.0,Cognitive Psych Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel braden quinn,PSYC-3340,2019
-PSYC,3340,2.0,Cognitive Psych Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,daniel braden quinn,PSYC-3340,2019
-PSYC,3340,3.0,Cognitive Psych Lab,0.76,0.04,0.08,0.04,0.04,0.0,0.0,0.04,laura whitlock,PSYC-3340,2019
-PSYC,3400,1.0,Lifespan Developmental Psych,0.27,0.31,0.21,0.1,0.04,0.0,0.0,0.06,pamela alley,PSYC-3400,2019
-PSYC,3400,2.0,Lifespan Developmental Psych,0.37,0.44,0.11,0.04,0.0,0.0,0.0,0.03,anita pei tam,PSYC-3400,2019
-PSYC,3520,1.0,Social Psychology,0.63,0.26,0.07,0.01,0.0,0.0,0.0,0.03,ceren gunsoy,PSYC-3520,2019
-PSYC,3520,2.0,Social Psychology (HON),0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,PSYC-3520,2019
-PSYC,3570,1.0,Psychology and Culture,0.64,0.23,0.13,0.0,0.0,0.0,0.0,0.0,ceren gunsoy,PSYC-3570,2019
-PSYC,3640,1.0,Industrial Psych,0.97,0.0,0.03,0.0,0.0,0.0,0.0,0.0,joseph ligato,PSYC-3640,2019
-PSYC,3680,1.0,Organizational Psych,0.27,0.29,0.34,0.05,0.02,0.0,0.0,0.03,chloe wilson,PSYC-3680,2019
-PSYC,3700,1.0,Personality,0.54,0.29,0.1,0.04,0.01,0.0,0.0,0.01,john robert hester,PSYC-3700,2019
-PSYC,3830,1.0,Abnormal Psychology,0.43,0.42,0.09,0.01,0.0,0.0,0.0,0.04,heidi marie zinzow,PSYC-3830,2019
-PSYC,3830,2.0,Abnormal Psychology,0.23,0.31,0.2,0.09,0.06,0.0,0.0,0.11,pamela alley,PSYC-3830,2019
-PSYC,3830,3.0,Abnormal Psychology,0.11,0.26,0.34,0.14,0.03,0.0,0.0,0.11,pamela alley,PSYC-3830,2019
-PSYC,3890,1.0,Psychology of Music,0.28,0.28,0.2,0.12,0.12,0.0,0.0,0.0,claudio cantalupo,PSYC-3890,2019
-PSYC,4080,1.0,Women and Psychology,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,PSYC-4080,2019
-PSYC,4150,1.0,Systems and Theories,0.87,0.08,0.03,0.0,0.03,0.0,0.0,0.0,peggy jean tyler,PSYC-4150,2019
-PSYC,4150,2.0,Systems and Theories,0.29,0.35,0.21,0.12,0.0,0.0,0.0,0.03,edwin brainerd,PSYC-4150,2019
-PSYC,4150,3.0,Systems and Theories,0.33,0.3,0.27,0.0,0.06,0.0,0.0,0.03,edwin brainerd,PSYC-4150,2019
-PSYC,4220,1.0,Perception,0.37,0.33,0.22,0.07,0.0,0.0,0.0,0.0,richard tyrrell,PSYC-4220,2019
-PSYC,4220,2.0,Perception,0.33,0.22,0.26,0.15,0.0,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2019
-PSYC,4220,3.0,Perception,0.41,0.3,0.19,0.11,0.0,0.0,0.0,0.0,christopher pagano,PSYC-4220,2019
-PSYC,4430,1.0,Infant & Child Dev,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-4430,2019
-PSYC,4560,1.0,Psychophysiology,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,sarah christine beadle,PSYC-4560,2019
-PSYC,4710,1.0,Psych of Testing,0.64,0.14,0.0,0.0,0.07,0.0,0.0,0.14,zhuo chen,PSYC-4710,2019
-PSYC,4800,1.0,Health Psychology,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,PSYC-4800,2019
-PSYC,4800,2.0,Health Psychology,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,james mccubbin,PSYC-4800,2019
-PSYC,4880,1.0,Psychotherapy,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,lucinda sorciere shealy quick,PSYC-4880,2019
-PSYC,4890,1.0,Sport Psychology,0.25,0.45,0.15,0.1,0.0,0.0,0.0,0.05,anita pei tam,PSYC-4890,2019
-PSYC,4920,1.0,Senior Laboratory,0.8,0.13,0.0,0.07,0.0,0.0,0.0,0.0,zachary paul klinefelter,PSYC-4920,2019
-PSYC,4920,2.0,Senior Laboratory,0.75,0.13,0.0,0.0,0.08,0.0,0.0,0.04,alexander moore,PSYC-4920,2019
-PSYC,4920,4.0,Senior Laboratory,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,zachary paul klinefelter,PSYC-4920,2019
-PSYC,4920,5.0,Senior Laboratory,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,hannah solini,PSYC-4920,2019
-PSYC,4930,100.0,Pract Clinical Psych,0.81,0.13,0.0,0.06,0.0,0.0,0.0,0.0,heidi marie zinzow,PSYC-4930,2019
-PSYC,4980,291.0,Suicide Prevention,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,PSYC-4980,2019
-PSYC,4980,363.0,Psych Religion Spr,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,zhuo chen,PSYC-4980,2019
-PSYC,8100,1.0,Research Design I,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,patrick rosopa,PSYC-8100,2019
-PSYC,8350,1.0,Advanced Human Factors Psych,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,chong hyon pak,PSYC-8350,2019
-PSYC,8620,1.0,Org Psychology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert raymond sinclair,PSYC-8620,2019
-PSYC,8680,1.0,Leadership in Orgs,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,patrick raymark,PSYC-8680,2019
-RED,8010,1.0,Market Analysis,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,thomas andrew fox,RED-8010,2019
-REL,1010,1.0,Intro to Religion,0.32,0.47,0.16,0.05,0.0,0.0,0.0,0.0,peter cohen,REL-1010,2019
-REL,1010,2.0,Intro to Religion,0.32,0.32,0.11,0.11,0.0,0.0,0.0,0.16,peter cohen,REL-1010,2019
-REL,1010,3.0,Intro to Religion,0.43,0.37,0.09,0.06,0.0,0.0,0.0,0.06,peter cohen,REL-1010,2019
-REL,1010,5.0,Intro to Religion,0.5,0.17,0.17,0.0,0.0,0.0,0.0,0.17,brett patterson,REL-1010,2019
-REL,1020,1.0,World Religions (HON),0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,peter cohen,REL-1020,2019
-REL,1020,2.0,World Religions,0.54,0.26,0.14,0.0,0.0,0.0,0.0,0.06,robert stephens,REL-1020,2019
-REL,1020,3.0,World Religions,0.57,0.29,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,REL-1020,2019
-REL,1020,4.0,World Religions,0.51,0.31,0.11,0.0,0.06,0.0,0.0,0.0,robert stephens,REL-1020,2019
-REL,1020,5.0,World Religions,0.14,0.54,0.23,0.09,0.0,0.0,0.0,0.0,brett patterson,REL-1020,2019
-REL,3010,1.0,Old Testament,0.35,0.35,0.15,0.06,0.0,0.0,0.0,0.09,john thames,REL-3010,2019
-REL,3020,1.0,New Testament Lit,0.53,0.41,0.0,0.03,0.0,0.0,0.0,0.03,benjamin white,REL-3020,2019
-REL,3080,1.0,Religions of the Ancient World,0.19,0.53,0.06,0.0,0.03,0.0,0.0,0.19,benjamin white,REL-3080,2019
-REL,3110,1.0,African American Rel,0.47,0.26,0.16,0.05,0.0,0.0,0.0,0.05,elizabeth jemison,REL-3110,2019
-REL,3120,1.0,Hinduism,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,robert stephens,REL-3120,2019
-REL,3300,1.0,Contemporary Issues,0.47,0.35,0.0,0.06,0.06,0.0,0.0,0.06,elizabeth jemison,REL-3300,2019
-RS,3010,1.0,Rural Sociology,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,kenneth robinson,RS-3010,2019
-RS,4010,1.0,Human Ecology,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,RS-4010,2019
-RUSS,3400,1.0,19th C Russ Culture,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,olga anatolyevna volkova,RUSS-3400,2019
-RUSS,3610,1.0,Russn Lit Since 1910,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,olga anatolyevna volkova,RUSS-3610,2019
-SOC,2010,1.0,Introduction to Sociology,0.65,0.29,0.04,0.01,0.0,0.0,0.0,0.01,carolyn candace coffman,SOC-2010,2019
-SOC,2010,2.0,Introduction to Sociology,0.69,0.26,0.04,0.0,0.01,0.0,0.0,0.0,carolyn candace coffman,SOC-2010,2019
-SOC,2010,3.0,Introduction to Sociology,0.56,0.27,0.08,0.02,0.04,0.0,0.0,0.02,miao li,SOC-2010,2019
-SOC,2010,4.0,Introduction to Sociology,0.86,0.12,0.0,0.0,0.01,0.0,0.0,0.0,andrew herman mannheimer,SOC-2010,2019
-SOC,2010,5.0,Introduction to Sociology,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.01,shannon mcdonough,SOC-2010,2019
-SOC,2010,6.0,Introduction to Sociology,0.55,0.33,0.1,0.01,0.0,0.0,0.0,0.01,shannon mcdonough,SOC-2010,2019
-SOC,2010,7.0,Introduction to Sociology,0.6,0.29,0.08,0.0,0.0,0.0,0.0,0.02,jennifer leanne holland,SOC-2010,2019
-SOC,2040,1.0,Prof Dev for Sociology Majors,0.64,0.2,0.09,0.02,0.02,0.0,0.0,0.02, catherine mobley,SOC-2040,2019
-SOC,3020,1.0,Research Methods I,0.4,0.38,0.08,0.08,0.0,0.0,0.0,0.06,andrew whitehead,SOC-3020,2019
-SOC,3040,1.0,Social Research Methods II,0.25,0.45,0.18,0.08,0.03,0.0,0.0,0.03,ye luo,SOC-3040,2019
-SOC,3100,1.0,Marriage & Intimacy,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,heather kettrey,SOC-3100,2019
-SOC,3400,1.0,Sport and Society,0.36,0.43,0.17,0.04,0.0,0.0,0.0,0.0,andrew whitehead,SOC-3400,2019
-SOC,3510,1.0,Collective Behavior,0.27,0.41,0.2,0.08,0.0,0.0,0.0,0.04,matthew john costello,SOC-3510,2019
-SOC,3600,1.0,Class & Poverty,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,william haller,SOC-3600,2019
-SOC,3910,1.0,Soc of Deviance,0.53,0.31,0.12,0.04,0.0,0.0,0.0,0.0,matthew john costello,SOC-3910,2019
-SOC,3940,1.0,Sociology of Mental Illness,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,james rosenberger,SOC-3940,2019
-SOC,3970,1.0,Substance Abuse,0.69,0.27,0.0,0.0,0.04,0.0,0.0,0.0,shannon mcdonough,SOC-3970,2019
-SOC,4030,1.0,"Technol, Environment & Society",0.53,0.26,0.19,0.02,0.0,0.0,0.0,0.0, catherine mobley,SOC-4030,2019
-SOC,4040,1.0,Soc Theory,0.6,0.25,0.0,0.0,0.0,0.0,0.0,0.15,william haller,SOC-4040,2019
-SOC,4140,1.0,Policy&Social Change,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jennifer leanne holland,SOC-4140,2019
-SOC,4440,1.0,Sociology of Educ,0.82,0.14,0.02,0.02,0.0,0.0,0.0,0.0,andrew herman mannheimer,SOC-4440,2019
-SOC,4600,1.0,Race & Ethnicity,0.88,0.02,0.06,0.0,0.02,0.0,0.0,0.02,andrew herman mannheimer,SOC-4600,2019
-SOC,4610,1.0,Sex & Gender,0.55,0.2,0.16,0.02,0.02,0.0,0.0,0.04,minyoung moon,SOC-4610,2019
-SOC,4710,1.0,World Population and Society,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,ye luo,SOC-4710,2019
-SOC,4950,1.0,Field Experience,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0, catherine mobley,SOC-4950,2019
-SOC,8920,1.0,Sel Top: Quantitative Methods,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,miao li,SOC-8920,2019
-SPAN,1010,1.0,Elementary Spanish,0.26,0.47,0.21,0.0,0.05,0.0,0.0,0.0,stephanie elysse morris,SPAN-1010,2019
-SPAN,1010,2.0,Elementary Spanish,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,stephanie elysse morris,SPAN-1010,2019
-SPAN,1010,3.0,Elementary Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,rosa macarena pillcurima,SPAN-1010,2019
-SPAN,1020,1.0,Elementary Spanish,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,rosa macarena pillcurima,SPAN-1020,2019
-SPAN,1020,2.0,Elementary Spanish,0.63,0.25,0.06,0.06,0.0,0.0,0.0,0.0,liliana hernandez,SPAN-1020,2019
-SPAN,1020,3.0,Elementary Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mercedes tejera,SPAN-1020,2019
-SPAN,1020,4.0,Elementary Spanish,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,mercedes tejera,SPAN-1020,2019
-SPAN,1020,5.0,Elementary Spanish,0.39,0.39,0.11,0.11,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,SPAN-1020,2019
-SPAN,1020,6.0,Elementary Spanish,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,SPAN-1020,2019
-SPAN,1020,8.0,Elementary Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-1020,2019
-SPAN,1020,10.0,Elementary Spanish,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,debra oaks williamson,SPAN-1020,2019
-SPAN,1020,11.0,Elementary Spanish,0.47,0.35,0.12,0.0,0.0,0.0,0.0,0.06,debra oaks williamson,SPAN-1020,2019
-SPAN,1020,13.0,Elementary Spanish,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,yezid flores,SPAN-1020,2019
-SPAN,2010,1.0,Intermediate Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,maria rosa judez riquelme,SPAN-2010,2019
-SPAN,2010,2.0,Intermediate Spanish,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,liliana hernandez,SPAN-2010,2019
-SPAN,2010,3.0,Intermediate Spanish,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,SPAN-2010,2019
-SPAN,2010,4.0,Intermediate Spanish,0.71,0.06,0.24,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,SPAN-2010,2019
-SPAN,2010,7.0,Intermediate Spanish,0.53,0.21,0.16,0.0,0.05,0.0,0.0,0.05,debra oaks williamson,SPAN-2010,2019
-SPAN,2010,8.0,Intermediate Spanish,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,debra oaks williamson,SPAN-2010,2019
-SPAN,2010,9.0,Intermediate Spanish,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andrea patricia naranjo,SPAN-2010,2019
-SPAN,2010,10.0,Intermediate Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2019
-SPAN,2010,11.0,Intermediate Spanish,0.47,0.42,0.0,0.11,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2019
-SPAN,2010,12.0,Intermediate Spanish,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,ellory schmucker,SPAN-2010,2019
-SPAN,2010,14.0,Intermediate Spanish,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,nora arostegui logue,SPAN-2010,2019
-SPAN,2010,15.0,Intermediate Spanish,0.33,0.44,0.11,0.0,0.0,0.0,0.0,0.11,zenia beatriz cruz valderramos,SPAN-2010,2019
-SPAN,2010,16.0,Intermediate Spanish,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,SPAN-2010,2019
-SPAN,2010,17.0,Intermediate Spanish,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,maria rosa judez riquelme,SPAN-2010,2019
-SPAN,2010,18.0,Intermediate Spanish,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,mercedes tejera,SPAN-2010,2019
-SPAN,2010,19.0,Intermediate Spanish,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,liliana hernandez,SPAN-2010,2019
-SPAN,2020,1.0,Intermediate Spanish,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,melva marguerite persico,SPAN-2020,2019
-SPAN,2020,2.0,Intermediate Spanish,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,melva marguerite persico,SPAN-2020,2019
-SPAN,2020,3.0,Intermediate Spanish,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,yezid flores,SPAN-2020,2019
-SPAN,2020,4.0,Intermediate Spanish,0.61,0.28,0.0,0.0,0.11,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2019
-SPAN,2020,5.0,Intermediate Spanish,0.74,0.05,0.16,0.0,0.05,0.0,0.0,0.0,yezid flores,SPAN-2020,2019
-SPAN,2020,6.0,Intermediate Spanish,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,rosa macarena pillcurima,SPAN-2020,2019
-SPAN,2020,7.0,Intermediate Spanish,0.63,0.26,0.0,0.0,0.05,0.0,0.0,0.05,rosa macarena pillcurima,SPAN-2020,2019
-SPAN,2020,8.0,Intermediate Spanish,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,ana paula  miller,SPAN-2020,2019
-SPAN,2020,9.0,Intermediate Spanish,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2019
-SPAN,2020,10.0,Intermediate Spanish,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,SPAN-2020,2019
-SPAN,2020,11.0,Intermediate Spanish,0.46,0.46,0.0,0.0,0.0,0.0,0.0,0.08,jose luis ortiz,SPAN-2020,2019
-SPAN,2020,13.0,Intermediate Spanish,0.41,0.24,0.18,0.12,0.0,0.0,0.0,0.06,jose luis ortiz,SPAN-2020,2019
-SPAN,2020,14.0,Intermediate Spanish,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,daniel david garcia vieyra,SPAN-2020,2019
-SPAN,2020,15.0,Intermediate Spanish,0.61,0.22,0.06,0.06,0.0,0.0,0.0,0.06,yezid flores,SPAN-2020,2019
-SPAN,2020,16.0,Intermediate Spanish,0.63,0.16,0.11,0.0,0.0,0.0,0.0,0.11,daniel david garcia vieyra,SPAN-2020,2019
-SPAN,3010,1.0,Spanish Comp for Health Prof,0.12,0.53,0.29,0.06,0.0,0.0,0.0,0.0,tiffany dawn creegan miller,SPAN-3010,2019
-SPAN,3020,1.0,Intermed Span Grammar & Comp,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,melva marguerite persico,SPAN-3020,2019
-SPAN,3020,2.0,Intermed Span Grammar & Comp,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,melva marguerite persico,SPAN-3020,2019
-SPAN,3020,3.0,Intermed Span Grammar & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,SPAN-3020,2019
-SPAN,3040,1.0,Intro Hispanic Literary Forms,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,graciela tissera,SPAN-3040,2019
-SPAN,3050,1.0,Intermed Span Convers/Comp I,0.68,0.21,0.0,0.05,0.0,0.0,0.0,0.05,daniel david garcia vieyra,SPAN-3050,2019
-SPAN,3050,2.0,Intermed Span Convers/Comp I,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,daniel david garcia vieyra,SPAN-3050,2019
-SPAN,3050,3.0,Intermed Span Convers/Comp I,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,SPAN-3050,2019
-SPAN,3050,4.0,Intermed Span Convers/Comp I,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,SPAN-3050,2019
-SPAN,3050,6.0,Intermed Span Convers/Comp I,0.5,0.39,0.0,0.06,0.0,0.0,0.0,0.06,jose luis ortiz,SPAN-3050,2019
-SPAN,3080,1.0,The Hispanic World: Latin Amer,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,tiffany dawn creegan miller,SPAN-3080,2019
-SPAN,3080,2.0,The Hispanic World: Latin Amer,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,SPAN-3080,2019
-SPAN,3130,2.0,Span Lit Survey I,0.29,0.36,0.07,0.0,0.0,0.0,0.0,0.29,monica rojas-de-massei,SPAN-3130,2019
-SPAN,3180,1.0,Spanish Through Culture,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,george palacios,SPAN-3180,2019
-SPAN,4060,1.0,Narrative Fiction,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,monica rojas-de-massei,SPAN-4060,2019
-SPAN,4060,2.0,Narrative Fiction,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,monica rojas-de-massei,SPAN-4060,2019
-SPAN,4070,1.0,Hispanic Film,0.72,0.06,0.22,0.0,0.0,0.0,0.0,0.0,salvador oropesa,SPAN-4070,2019
-SPAN,4190,1.0,Health & Hispanic Community,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,arelis moore peralta,SPAN-4190,2019
-STAT,2220,1.0,Statistics in Everyday Life,0.24,0.38,0.3,0.01,0.01,0.0,0.0,0.05,james espey,STAT-2220,2019
-STAT,2220,2.0,Statistics in Everyday Life,0.27,0.36,0.22,0.05,0.04,0.0,0.0,0.05,james espey,STAT-2220,2019
-STAT,2220,3.0,Statistics in Everyday Life,0.36,0.32,0.2,0.02,0.02,0.0,0.0,0.07,james espey,STAT-2220,2019
-STAT,2220,4.0,Statistics in Everyday Life,0.26,0.28,0.28,0.09,0.02,0.0,0.0,0.06,james espey,STAT-2220,2019
-STAT,2220,5.0,Statistics in Everyday Life,0.32,0.38,0.08,0.1,0.07,0.0,0.0,0.06,rose martinez-dawson,STAT-2220,2019
-STAT,2220,6.0,Statistics in Everyday Life,0.37,0.3,0.15,0.08,0.06,0.0,0.0,0.04,rose martinez-dawson,STAT-2220,2019
-STAT,2220,7.0,Statistics in Everyday Life,0.27,0.4,0.19,0.06,0.02,0.0,0.0,0.06,rose martinez-dawson,STAT-2220,2019
-STAT,2300,1.0,Statistical Methods I,0.46,0.35,0.09,0.05,0.02,0.0,0.0,0.02,paran rebekah norton,STAT-2300,2019
-STAT,2300,2.0,Statistical Methods I,0.38,0.32,0.18,0.04,0.07,0.0,0.0,0.01,paran rebekah norton,STAT-2300,2019
-STAT,2300,3.0,Statistical Methods I,0.27,0.3,0.23,0.11,0.05,0.0,0.0,0.03, erwin walker,STAT-2300,2019
-STAT,2300,4.0,Statistical Methods I,0.27,0.32,0.2,0.1,0.1,0.0,0.0,0.0, erwin walker,STAT-2300,2019
-STAT,2300,5.0,Statistical Methods I,0.3,0.32,0.13,0.09,0.09,0.0,0.0,0.06,paran rebekah norton,STAT-2300,2019
-STAT,2300,6.0,Statistical Methods I,0.29,0.38,0.17,0.06,0.05,0.0,0.0,0.05,sharon marie evans,STAT-2300,2019
-STAT,2300,100.0,Statistical Methods I (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sharon marie evans,STAT-2300,2019
-STAT,3090,1.0,Introductory Business Stats,0.11,0.28,0.28,0.33,0.0,0.0,0.0,0.0,fun choi john chan,STAT-3090,2019
-STAT,3090,2.0,Introductory Business Stats,0.0,0.35,0.35,0.24,0.06,0.0,0.0,0.0,fun choi john chan,STAT-3090,2019
-STAT,3090,3.0,Introductory Business Stats,0.17,0.17,0.39,0.11,0.17,0.0,0.0,0.0,sarah kelly,STAT-3090,2019
-STAT,3090,4.0,Introductory Business Stats,0.21,0.32,0.32,0.05,0.11,0.0,0.0,0.0,sarah kelly,STAT-3090,2019
-STAT,3090,5.0,Introductory Business Stats,0.22,0.33,0.33,0.06,0.06,0.0,0.0,0.0,mary elizabeth saine,STAT-3090,2019
-STAT,3090,6.0,Introductory Business Stats,0.21,0.26,0.37,0.05,0.05,0.0,0.0,0.05,mary elizabeth saine,STAT-3090,2019
-STAT,3090,7.0,Introductory Business Stats,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,sean walker ingimarson,STAT-3090,2019
-STAT,3090,8.0,Introductory Business Stats,0.21,0.37,0.26,0.16,0.0,0.0,0.0,0.0,sean walker ingimarson,STAT-3090,2019
-STAT,3090,9.0,Introductory Business Stats,0.21,0.32,0.16,0.16,0.16,0.0,0.0,0.0,yidan guo,STAT-3090,2019
-STAT,3090,10.0,Introductory Business Stats,0.22,0.33,0.22,0.11,0.11,0.0,0.0,0.0,yidan guo,STAT-3090,2019
-STAT,3090,11.0,Introductory Business Stats,0.32,0.26,0.21,0.11,0.11,0.0,0.0,0.0,rui gong,STAT-3090,2019
-STAT,3090,12.0,Introductory Business Stats,0.26,0.21,0.21,0.05,0.16,0.0,0.0,0.11,rui gong,STAT-3090,2019
-STAT,3090,13.0,Introductory Business Stats,0.29,0.26,0.2,0.14,0.08,0.0,0.0,0.03,april thomas,STAT-3090,2019
-STAT,3090,14.0,Introductory Business Stats,0.36,0.33,0.25,0.02,0.02,0.0,0.0,0.02,april thomas,STAT-3090,2019
-STAT,3090,15.0,Introductory Business Stats,0.47,0.12,0.24,0.0,0.18,0.0,0.0,0.0,molly adams honecker,STAT-3090,2019
-STAT,3090,16.0,Introductory Business Stats,0.53,0.32,0.05,0.0,0.11,0.0,0.0,0.0,molly adams honecker,STAT-3090,2019
-STAT,3090,17.0,Introductory Business Stats,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,xueheng shi,STAT-3090,2019
-STAT,3090,18.0,Introductory Business Stats,0.21,0.53,0.11,0.05,0.0,0.0,0.0,0.11,xueheng shi,STAT-3090,2019
-STAT,3090,19.0,Introductory Business Stats,0.44,0.17,0.0,0.17,0.17,0.0,0.0,0.06,feng gao,STAT-3090,2019
-STAT,3090,20.0,Introductory Business Stats,0.22,0.5,0.22,0.06,0.0,0.0,0.0,0.0,feng gao,STAT-3090,2019
-STAT,3090,21.0,Introductory Business Stats,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,zhengxin wang,STAT-3090,2019
-STAT,3090,22.0,Introductory Business Stats,0.44,0.17,0.28,0.11,0.0,0.0,0.0,0.0,zhengxin wang,STAT-3090,2019
-STAT,3090,23.0,Introductory Business Stats,0.28,0.11,0.33,0.17,0.0,0.0,0.0,0.11,james mckay visser,STAT-3090,2019
-STAT,3090,24.0,Introductory Business Stats,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,james mckay visser,STAT-3090,2019
-STAT,3090,25.0,Introductory Business Stats,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,boyoung hur,STAT-3090,2019
-STAT,3090,26.0,Introductory Business Stats,0.33,0.22,0.39,0.06,0.0,0.0,0.0,0.0,boyoung hur,STAT-3090,2019
-STAT,3090,27.0,Introductory Business Stats,0.22,0.28,0.33,0.0,0.11,0.0,0.0,0.06,siyuan yu,STAT-3090,2019
-STAT,3090,28.0,Introductory Business Stats,0.24,0.29,0.18,0.18,0.06,0.0,0.0,0.06,siyuan yu,STAT-3090,2019
-STAT,3090,29.0,Introductory Business Stats,0.0,0.42,0.21,0.05,0.21,0.0,0.0,0.11,minghua cui,STAT-3090,2019
-STAT,3090,30.0,Introductory Business Stats,0.08,0.38,0.15,0.08,0.15,0.0,0.0,0.15,minghua cui,STAT-3090,2019
-STAT,3090,31.0,Introductory Business Stats,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,tiantian yang,STAT-3090,2019
-STAT,3090,32.0,Introductory Business Stats,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,tiantian yang,STAT-3090,2019
-STAT,3090,33.0,Introductory Business Stats,0.21,0.63,0.11,0.0,0.05,0.0,0.0,0.0,trevor camper,STAT-3090,2019
-STAT,3090,34.0,Introductory Business Stats,0.11,0.37,0.37,0.05,0.11,0.0,0.0,0.0,trevor camper,STAT-3090,2019
-STAT,3090,35.0,Introductory Business Stats,0.06,0.17,0.39,0.22,0.11,0.0,0.0,0.06,jiyun huang,STAT-3090,2019
-STAT,3090,36.0,Introductory Business Stats,0.32,0.37,0.26,0.05,0.0,0.0,0.0,0.0,jiyun huang,STAT-3090,2019
-STAT,3090,37.0,Introductory Business Stats,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,anna marie vagnozzi,STAT-3090,2019
-STAT,3090,38.0,Introductory Business Stats,0.5,0.28,0.17,0.06,0.0,0.0,0.0,0.0,anna marie vagnozzi,STAT-3090,2019
-STAT,3090,39.0,Introductory Business Stats,0.42,0.37,0.11,0.05,0.0,0.0,0.0,0.05,pubudu jayasekara merenchige,STAT-3090,2019
-STAT,3090,40.0,Introductory Business Stats,0.37,0.26,0.21,0.05,0.05,0.0,0.0,0.05,pubudu jayasekara merenchige,STAT-3090,2019
-STAT,3300,1.0,Statistical Methods II,0.22,0.22,0.22,0.0,0.13,0.0,0.0,0.22,rose martinez-dawson,STAT-3300,2019
-STAT,4020,1.0,Intro to Statistical Computing,0.25,0.33,0.08,0.0,0.08,0.0,0.0,0.25,ellen hepfer breazel,STAT-4020,2019
-STAT,4020,2.0,Intro to Statistical Computing,0.38,0.08,0.15,0.08,0.15,0.0,0.0,0.15,ellen hepfer breazel,STAT-4020,2019
-STAT,4110,1.0,Stat Mthds for Process Control,0.68,0.18,0.05,0.05,0.03,0.0,0.0,0.0,richard steven dubsky,STAT-4110,2019
-STAT,4110,2.0,Stat Mthds for Process Control,0.72,0.14,0.09,0.05,0.0,0.0,0.0,0.0,richard steven dubsky,STAT-4110,2019
-STAT,4110,3.0,Stat Mthds for Process Control,0.5,0.21,0.14,0.0,0.05,0.0,0.0,0.1,yu-bo wang,STAT-4110,2019
-STAT,4110,4.0,Stat Mthds for Process Control,0.3,0.32,0.22,0.03,0.11,0.0,0.0,0.03,yu-bo wang,STAT-4110,2019
-STAT,6020,1.0,Intro to Statistical Computing,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,STAT-6020,2019
-STAT,6020,2.0,Intro to Statistical Computing,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,STAT-6020,2019
-STAT,8010,1.0,Statistical Methods I,0.55,0.23,0.18,0.0,0.0,0.0,0.0,0.05,patrick gerard,STAT-8010,2019
-STAT,8010,2.0,Statistical Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah elizabeth kunkel,STAT-8010,2019
-STAT,8010,4.0,Statistical Methods I,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,deborah elizabeth kunkel,STAT-8010,2019
-STAT,8010,5.0,Statistical Methods I,0.56,0.17,0.06,0.0,0.17,0.0,0.0,0.06,jun luo,STAT-8010,2019
-STAT,8010,6.0,Statistical Methods I,0.73,0.14,0.14,0.0,0.0,0.0,0.0,0.0,jun luo,STAT-8010,2019
-STAT,8010,7.0,Statistical Methods I,0.43,0.38,0.14,0.0,0.0,0.0,0.0,0.05,joseph daniel bible,STAT-8010,2019
-STAT,8020,1.0,Statistical Methods II,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-8020,2019
-STAT,8050,1.0,Design & Anlys of Experiments,0.48,0.48,0.03,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-8050,2019
-STS,1010,1.0,Survey Sci & Techn in Society,0.59,0.32,0.0,0.03,0.03,0.0,0.0,0.03,kenneth david widgren,STS-1010,2019
-STS,1010,2.0,Survey Sci & Techn in Society,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,scott brame,STS-1010,2019
-STS,1010,3.0,Survey Sci & Techn in Society,0.67,0.25,0.03,0.03,0.0,0.0,0.0,0.03,elizabeth anderson stansell,STS-1010,2019
-STS,1010,4.0,Survey Sci & Techn in Society,0.69,0.26,0.03,0.0,0.03,0.0,0.0,0.0,ingrid anna pierce,STS-1010,2019
-STS,1010,5.0,Survey Sci & Techn in Society,0.42,0.5,0.06,0.0,0.03,0.0,0.0,0.0,philip randall,STS-1010,2019
-STS,1010,6.0,Survey Sci & Techn in Society,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,STS-1010,2019
-STS,1010,7.0,Survey Sci & Techn in Society,0.44,0.44,0.06,0.0,0.03,0.0,0.0,0.03,megan noel macalystre,STS-1010,2019
-STS,1010,8.0,Survey Sci & Techn in Society,0.44,0.41,0.09,0.0,0.0,0.0,0.0,0.06,david charles foltz,STS-1010,2019
-STS,1010,9.0,Survey Sci & Techn in Society,0.53,0.41,0.03,0.0,0.0,0.0,0.0,0.03,tareva leselle johnson,STS-1010,2019
-STS,1010,10.0,Survey Sci & Techn in Society,0.62,0.29,0.03,0.0,0.0,0.0,0.0,0.06,alexander john billinis,STS-1010,2019
-STS,1010,11.0,Survey Sci & Techn in Society,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,anne mcmahan grant,STS-1010,2019
-SUST,2010,1.0,Sustainability Leadership,0.88,0.03,0.03,0.03,0.03,0.0,0.0,0.0,jennifer margaret goree,SUST-2010,2019
-THEA,2100,1.0,Theatre Appreciation,0.59,0.28,0.09,0.0,0.03,0.0,0.0,0.0,david hartmann,THEA-2100,2019
-THEA,2100,3.0,Theatre Appreciation,0.63,0.23,0.07,0.03,0.0,0.0,0.0,0.03,kendra lynette johnson,THEA-2100,2019
-THEA,2100,5.0,Theatre Appreciation,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-2100,2019
-THEA,2100,6.0,Theatre Appreciation,0.59,0.28,0.09,0.0,0.0,0.0,0.0,0.03,jason adkins,THEA-2100,2019
-THEA,2100,7.0,Theatre Appreciation,0.73,0.1,0.13,0.0,0.03,0.0,0.0,0.0,jason adkins,THEA-2100,2019
-THEA,2770,1.0,Prod Studies in Thea,0.63,0.25,0.08,0.0,0.0,0.0,0.0,0.04,david hartmann,THEA-2770,2019
-THEA,2780,1.0,Acting I,0.75,0.06,0.13,0.06,0.0,0.0,0.0,0.0,kerrie kathleen seymour,THEA-2780,2019
-THEA,2790,1.0,Theatre Practicum,0.57,0.21,0.07,0.0,0.07,0.0,0.0,0.07,matthew leckenbusch,THEA-2790,2019
-THEA,3080,1.0,Surv of Broadway I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,THEA-3080,2019
-THEA,3160,1.0,Theatre History II,0.63,0.21,0.08,0.04,0.04,0.0,0.0,0.0,shannon therese robert,THEA-3160,2019
-THEA,3170,1.0,African-Amer Thea I,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,kendra lynette johnson,THEA-3170,2019
-WFB,3010,2.0,Wildlife Biology Lab,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,shari lynn rodriguez,WFB-3010,2019
-WFB,4100,2.0,Wildlife Management Techniques,0.26,0.66,0.03,0.06,0.0,0.0,0.0,0.0,catherine michelle jachowski,WFB-4100,2019
-WFB,4120,1.0,Wildlife Management,0.67,0.26,0.04,0.04,0.0,0.0,0.0,0.0,greg yarrow,WFB-4120,2019
-WFB,4180,2.0,Fisheries Mgt & Conservation,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,troy mason farmer,WFB-4180,2019
-WFB,4440,1.0,Wildlife Damage Management,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,greg yarrow,WFB-4440,2019
-WFB,4720,1.0,Ornithology,0.27,0.32,0.23,0.09,0.05,0.0,0.0,0.05,neil smith,WFB-4720,2019
-WFB,4770,1.0,Ichthyology,0.71,0.07,0.14,0.07,0.0,0.0,0.0,0.0,brandon kevin peoples,WFB-4770,2019
-WFB,4800,1.0,Waterfowl Ecology & Management,0.4,0.47,0.05,0.0,0.0,0.0,0.0,0.09,richard marvin kaminski,WFB-4800,2019
-WFB,6620,1.0,Wetland Wildlife Biology,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,russell barrett,WFB-6620,2019
-WFB,6800,1.0,Waterfowl Ecology & Management,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,richard marvin kaminski,WFB-6800,2019
-WFB,8610,5.0,Scientific Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stefanie whitmire,WFB-8610,2019
-WFB,8610,10.0,Fisheries Mgt and Conservation,0.67,0.11,0.11,0.0,0.11,0.0,0.0,0.0,troy mason farmer,WFB-8610,2019
-WFB,8610,11.0,Study Design & Data Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,brandon kevin peoples,WFB-8610,2019
-WFB,8610,14.0,Wildlife Resource Selection,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine michelle jachowski,WFB-8610,2019
-WFB,8610,23.0,Aquatic Habitat Management,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,mark scott,WFB-8610,2019
-WS,1030,1.0,Women in Global Perspective,0.5,0.36,0.11,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,WS-1030,2019
-WS,1030,2.0,Women in Global Perspective,0.53,0.39,0.06,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,WS-1030,2019
-WS,2300,1.0,Women and Leadership I,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,mary price,WS-2300,2019
-WS,3010,1.0,Intro Women's Studies,0.47,0.39,0.03,0.03,0.06,0.0,0.0,0.03,elizabeth rose adams,WS-3010,2019
-WS,3010,2.0,Intro Women's Studies,0.58,0.37,0.03,0.0,0.0,0.0,0.0,0.03,elizabeth rose adams,WS-3010,2019
-WS,4230,1.0,Women in the Developing World,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,melissa vogel,WS-4230,2019
-YDP,3000,400.0,Youth Development in Society,0.64,0.2,0.04,0.04,0.04,0.0,0.0,0.04,lauren elizabeth stephens,YDP-3000,2019
-YDP,3050,400.0,Theory/Phil of Youth Dev Work,0.73,0.15,0.08,0.0,0.0,0.0,0.0,0.04,lauren elizabeth stephens,YDP-3050,2019
-YDP,3200,1.0,Youth Dev in Sport/Phys Activ,0.71,0.13,0.08,0.04,0.0,0.0,0.0,0.04,lauren elizabeth stephens,YDP-3200,2019
-YDP,3250,1.0,Working with Diverse Youth,0.76,0.12,0.06,0.0,0.06,0.0,0.0,0.0,kimberly pearson johnson,YDP-3250,2019
-YDP,3300,1.0,Designing Effective Youth Prog,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,kellye rembert,YDP-3300,2019
-YDP,3350,1.0,Youth Activity Leadership,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lauren elizabeth stephens,YDP-3350,2019
-YDP,3450,1.0,Creative Activities for Youth,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kimberly pearson johnson,YDP-3450,2019
-YDP,4450,1.0,Youth Devel Org Administration,0.61,0.17,0.17,0.0,0.0,0.0,0.0,0.04,allison michelle avishai,YDP-4450,2019
-YDP,4500,1.0,Prof Iss & Ethics in Youth Dev,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kayla lee weston,YDP-4500,2019
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1010,1.0,Survey of Art & Arch History I,0.35,0.46,0.15,0.01,0.02,0.0,0.0,0.01,beth ann lauritis,
+AAH,2050,1.0,Art History and Theory I,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,beth ann lauritis,
+AAH,3050,1.0,Contemporary Art History,0.81,0.14,0.0,0.05,0.0,0.0,0.0,0.0,anatole upart,
+ACCT,2010,1.0,Financial Accounting Concepts,0.43,0.29,0.1,0.04,0.04,0.0,0.0,0.1,lydia lancaster folger schleifer,
+ACCT,2010,2.0,Financial Accounting Concepts,0.42,0.32,0.16,0.02,0.04,0.0,0.0,0.04,lydia lancaster folger schleifer,
+ACCT,2010,3.0,Financial Accounting Concepts,0.33,0.27,0.22,0.04,0.02,0.0,0.0,0.11,julie grant,
+ACCT,2010,4.0,Financial Accounting Concepts,0.38,0.24,0.2,0.07,0.02,0.0,0.0,0.09,julie grant,
+ACCT,2010,5.0,Financial Accounting Concepts,0.5,0.35,0.1,0.0,0.0,0.0,0.0,0.04,lydia lancaster folger schleifer,
+ACCT,2010,6.0,Financial Accounting Concepts,0.4,0.31,0.13,0.07,0.02,0.0,0.0,0.07,michael john mcguigan,
+ACCT,2010,7.0,Financial Accounting Concepts,0.16,0.49,0.27,0.0,0.06,0.0,0.0,0.02,carl hollingsworth,
+ACCT,2010,8.0,Financial Accounting Concepts,0.22,0.31,0.27,0.1,0.04,0.0,0.0,0.06,carl hollingsworth,
+ACCT,2010,9.0,Financial Accounting Concepts,0.11,0.39,0.3,0.07,0.07,0.0,0.0,0.07,michael john mcguigan,
+ACCT,2010,10.0,Financial Accounting Concepts,0.37,0.33,0.14,0.06,0.04,0.0,0.0,0.06,charles tegen,
+ACCT,2010,11.0,Financial Accounting Concepts,0.33,0.28,0.14,0.03,0.08,0.0,0.0,0.14,lisa wheatley birtwistle,
+ACCT,2010,12.0,Financial Accounting Concepts,0.12,0.35,0.19,0.07,0.12,0.0,0.0,0.16,lisa wheatley birtwistle,
+ACCT,2010,13.0,Financial Accounting Concepts,0.24,0.24,0.37,0.1,0.0,0.0,0.0,0.05,lisa wheatley birtwistle,
+ACCT,2010,14.0,Financial Accounting Concepts,0.38,0.45,0.1,0.03,0.0,0.0,0.0,0.03,annieka philo,
+ACCT,2010,100.0,Fin Accounting Concepts (HON),0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,mary ann  prater,True
+ACCT,2010,111.0,Fin Accounting Concepts (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lisa wheatley birtwistle,True
+ACCT,2010,400.0,Financial Accounting Concepts,0.14,0.22,0.21,0.1,0.07,0.0,0.0,0.26,jeffrey mcmillan,
+ACCT,2010,401.0,Financial Accounting Concepts,0.33,0.43,0.16,0.04,0.02,0.0,0.0,0.02,emily suzanne mccorkle,
+ACCT,2020,1.0,Managerial Accounting Concepts,0.31,0.23,0.15,0.03,0.0,0.0,0.0,0.28,henry anderson,
+ACCT,2020,2.0,Managerial Accounting Concepts,0.27,0.33,0.15,0.06,0.12,0.0,0.0,0.06,henry anderson,
+ACCT,2020,3.0,Managerial Accounting Concepts,0.18,0.46,0.23,0.0,0.03,0.0,0.0,0.1,henry anderson,
+ACCT,2020,4.0,Managerial Accounting Concepts,0.26,0.33,0.23,0.0,0.1,0.0,0.0,0.08,henry anderson,
+ACCT,2020,5.0,Managerial Accounting Concepts,0.21,0.3,0.21,0.09,0.06,0.0,0.0,0.13,brian todd carver,
+ACCT,2020,6.0,Managerial Accounting Concepts,0.17,0.15,0.37,0.09,0.04,0.0,0.0,0.17,brian todd carver,
+ACCT,2020,400.0,Managerial Accounting Concepts,0.3,0.29,0.16,0.08,0.03,0.0,0.0,0.13,henry anderson,
+ACCT,2020,402.0,Managerial Accounting Concepts,0.25,0.23,0.3,0.12,0.04,0.0,0.0,0.05,emily suzanne mccorkle,
+ACCT,2900,1.0,Special Topics - Soft Skills,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,michael mendonca,
+ACCT,3030,1.0,Cost Accounting,0.38,0.36,0.21,0.0,0.03,0.0,0.0,0.03,daniel thomas way,
+ACCT,3030,2.0,Cost Accounting,0.25,0.39,0.31,0.03,0.0,0.0,0.0,0.03,daniel thomas way,
+ACCT,3030,3.0,Cost Accounting,0.32,0.43,0.14,0.03,0.05,0.0,0.0,0.03,jace garrett,
+ACCT,3030,4.0,Cost Accounting,0.38,0.27,0.19,0.03,0.03,0.0,0.0,0.11,jace garrett,
+ACCT,3030,5.0,Cost Accounting,0.55,0.26,0.16,0.0,0.03,0.0,0.0,0.0,sarah martin,
+ACCT,3110,1.0,Intermediate Financial Acct I,0.17,0.29,0.33,0.0,0.08,0.0,0.0,0.13,annieka philo,
+ACCT,3110,2.0,Intermediate Financial Acct I,0.16,0.31,0.41,0.06,0.03,0.0,0.0,0.03,amy melissa donnelly,
+ACCT,3110,3.0,Intermediate Financial Acct I,0.17,0.39,0.11,0.11,0.11,0.0,0.0,0.11,annieka philo,
+ACCT,3110,4.0,Intermediate Financial Acct I,0.19,0.32,0.39,0.03,0.03,0.0,0.0,0.03,amy melissa donnelly,
+ACCT,3110,5.0,Intermediate Financial Acct I,0.19,0.52,0.19,0.0,0.0,0.0,0.0,0.1, russell madray,
+ACCT,3110,6.0,Intermediate Financial Acct I,0.16,0.29,0.26,0.06,0.06,0.0,0.0,0.16,amy melissa donnelly,
+ACCT,3110,7.0,Intermediate Financial Acct I,0.32,0.42,0.13,0.03,0.06,0.0,0.0,0.03, russell madray,
+ACCT,3110,8.0,Intermediate Financial Acct I,0.11,0.26,0.26,0.11,0.21,0.0,0.0,0.05,erin michelle hawkins,
+ACCT,3110,100.0,Intermediate Fin Acct I (HON),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,True
+ACCT,3120,1.0,Intermediate Financial Acct II,0.44,0.17,0.28,0.0,0.06,0.0,0.0,0.06,terry daniel knause,
+ACCT,3120,2.0,Intermediate Financial Acct II,0.0,0.39,0.39,0.11,0.11,0.0,0.0,0.0, russell madray,
+ACCT,3120,3.0,Intermediate Financial Acct II,0.2,0.46,0.23,0.06,0.03,0.0,0.0,0.03, russell madray,
+ACCT,3120,4.0,Intermediate Financial Acct II,0.45,0.42,0.1,0.0,0.0,0.0,0.0,0.03,terry daniel knause,
+ACCT,3120,5.0,Intermediate Financial Acct II,0.33,0.33,0.31,0.0,0.0,0.0,0.0,0.03,terry daniel knause,
+ACCT,3120,6.0,Intermediate Financial Acct II,0.31,0.5,0.17,0.0,0.0,0.0,0.0,0.03,terry daniel knause,
+ACCT,3130,1.0,Analytics for Acct Dec Making,0.57,0.25,0.14,0.0,0.0,0.0,0.0,0.04,babak mammadov,
+ACCT,3130,2.0,Analytics for Acct Dec Making,0.33,0.4,0.13,0.0,0.07,0.0,0.0,0.07,babak mammadov,
+ACCT,3130,3.0,Analytics for Acct Dec Making,0.28,0.33,0.28,0.11,0.0,0.0,0.0,0.0,phebian davis-culler,
+ACCT,3130,4.0,Analytics for Acct Dec Making,0.18,0.64,0.18,0.0,0.0,0.0,0.0,0.0,phebian davis-culler,
+ACCT,3130,5.0,Analytics for Acct Dec Making,0.32,0.41,0.18,0.0,0.05,0.0,0.0,0.05,phebian davis-culler,
+ACCT,3130,6.0,Analytics for Acct Dec Making,0.17,0.35,0.3,0.13,0.04,0.0,0.0,0.0,phebian davis-culler,
+ACCT,3130,105.0,Analytics for Accounting (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,phebian davis-culler,True
+ACCT,3220,1.0,Accounting Information Systems,0.11,0.32,0.21,0.21,0.05,0.0,0.0,0.11,philip maiberger,
+ACCT,3220,2.0,Accounting Information Systems,0.18,0.42,0.24,0.06,0.03,0.0,0.0,0.06,philip maiberger,
+ACCT,3220,3.0,Accounting Information Systems,0.1,0.31,0.31,0.1,0.07,0.0,0.0,0.1,philip maiberger,
+ACCT,3220,4.0,Accounting Information Systems,0.14,0.41,0.21,0.07,0.0,0.0,0.0,0.17,philip maiberger,
+ACCT,4040,1.0,Individual Taxation,0.64,0.21,0.11,0.0,0.0,0.0,0.0,0.04,sarah martin,
+ACCT,4040,2.0,Individual Taxation,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,3.0,Individual Taxation,0.42,0.33,0.18,0.0,0.03,0.0,0.0,0.03,sarah martin,
+ACCT,4040,4.0,Individual Taxation,0.06,0.52,0.23,0.1,0.06,0.0,0.0,0.03,lisa wheatley birtwistle,
+ACCT,4040,101.0,Individual Taxation (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,True
+ACCT,4080,1.0,Retire & Estate Plan,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,john hine,
+ACCT,4100,1.0,Reporting and Mgmt Control Sys,0.29,0.41,0.26,0.0,0.0,0.0,0.0,0.03,gregory patrick mcphee,
+ACCT,4100,2.0,Reporting and Mgmt Control Sys,0.38,0.38,0.18,0.06,0.0,0.0,0.0,0.0,gregory patrick mcphee,
+ACCT,4100,3.0,Reporting and Mgmt Control Sys,0.3,0.55,0.06,0.06,0.0,0.0,0.0,0.03,robin radtke,
+ACCT,4150,1.0,Auditing,0.37,0.46,0.17,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,4150,2.0,Auditing,0.26,0.29,0.35,0.1,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,8510,1.0,Tax Research,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
+ACCT,8530,1.0,Adv Acct Problems,0.5,0.41,0.06,0.0,0.0,0.0,0.0,0.03,suzanne pearse,
+ACCT,8530,2.0,Adv Acct Problems,0.45,0.42,0.12,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
+ACCT,8530,3.0,Adv Acct Problems,0.43,0.33,0.17,0.0,0.07,0.0,0.0,0.0,ralph edward welton,
+ACCT,8550,1.0,Gov't and Nonprofit Accounting,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8550,2.0,Gov't and Nonprofit Accounting,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8550,3.0,Gov't and Nonprofit Accounting,0.52,0.42,0.06,0.0,0.0,0.0,0.0,0.0,james barnes,
+ACCT,8630,1.0,Forensics Analysis,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,brian matthew goodson,
+ACCT,8630,2.0,Forensics Analysis,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,brian matthew goodson,
+ACCT,8650,1.0,Tax & Bus Decisions,0.25,0.72,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
+ACCT,8650,2.0,Tax & Bus Decisions,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,
+ACCT,8720,1.0,Tax of Flowthroughs,0.21,0.56,0.18,0.0,0.03,0.0,0.0,0.03,thomas dickens,
+AGED,1020,1.0,Freshman Seminar,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,
+AGED,2000,1.0,Agr Appl of Ed Tech,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,kevin layfield,
+AGED,2010,1.0,Intro to Agric Educ,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
+AGED,3030,1.0,Ag Ed Mech Tech,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGED,4010,1.0,Instr Methods Ag Ed,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,
+AGED,4030,1.0,Prin Adult/Ext Ed,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGED,4230,400.0,Curriculum,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,
+AGM,1010,1.0,Intro Ag Mech & Bus,0.6,0.2,0.09,0.06,0.03,0.0,0.0,0.03,hunter massey,
+AGM,1010,1.0,Intro Ag Mech & Bus,0.6,0.2,0.09,0.06,0.03,0.0,0.0,0.03,hunter massey,
+AGM,2050,1.0,Prin of Fabrication,0.23,0.54,0.19,0.02,0.0,0.0,0.0,0.02,hunter massey,
+AGM,2050,1.0,Prin of Fabrication,0.23,0.54,0.19,0.02,0.0,0.0,0.0,0.02,hunter massey,
+AGM,2060,1.0,Machinery Mgt,0.23,0.46,0.15,0.08,0.08,0.0,0.0,0.0,hunter massey,
+AGM,2060,1.0,Machinery Mgt,0.23,0.46,0.15,0.08,0.08,0.0,0.0,0.0,hunter massey,
+AGM,2210,1.0,Land Measurements,0.5,0.38,0.09,0.01,0.01,0.0,0.0,0.0,charles privette,
+AGM,3010,1.0,Soil Water Conserv,0.63,0.18,0.18,0.0,0.0,0.0,0.0,0.0,calvin sawyer,
+AGM,4000,1.0,Seminar in Ag Mech & Business,0.28,0.63,0.08,0.0,0.0,0.0,0.0,0.03,john chastain,
+AGM,4020,1.0,Irrigation System Design,0.44,0.46,0.08,0.0,0.03,0.0,0.0,0.0,charles privette,
+AGM,4050,1.0,Env Cont in Anim Str,0.32,0.59,0.08,0.0,0.0,0.0,0.0,0.0,john chastain,
+AGM,4060,1.0,Mech & Hydraulic Sys,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4520,1.0,Mobile Power,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
+AGM,4600,1.0,Electrical Systems,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,young jo han,
+AGM,4730,4.0,Ag Safety,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hunter massey,
+AGM,4730,4.0,Ag Safety,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hunter massey,
+AGRB,2020,1.0,Agricultural Economics,0.63,0.26,0.08,0.01,0.01,0.0,0.0,0.01,julie carl pingol ureta,
+AGRB,2050,1.0,Agriculture and Society,0.14,0.27,0.37,0.17,0.03,0.0,0.0,0.01,michael vassalos,
+AGRB,3020,1.0,Economics of Farm Management,0.12,0.2,0.31,0.27,0.04,0.0,0.0,0.05,michael vassalos,
+AGRB,3080,1.0,Quant Agribusiness Analysis I,0.31,0.31,0.31,0.08,0.0,0.0,0.0,0.0,david brian willis,
+AGRB,3090,1.0,Econ of Agricultural Marketing,0.73,0.2,0.03,0.0,0.01,0.0,0.0,0.03,yuliya valentinovna bolotova,
+AGRB,3570,1.0,Natural Resources Economics,0.23,0.23,0.26,0.09,0.09,0.0,0.0,0.09,david brian willis,
+AGRB,4090,1.0,Commodity Futures Markets,0.24,0.48,0.26,0.02,0.0,0.0,0.0,0.0,david baird montgomery,
+AGRB,4120,1.0,Reg Econ Devel Theory & Policy,0.32,0.32,0.14,0.2,0.02,0.0,0.0,0.0,felipe de figueiredo silva,
+AGRB,4520,1.0,Agricultural Policy,0.17,0.44,0.31,0.08,0.0,0.0,0.0,0.0,michael vassalos,
+AGRB,4900,1.0,Special Topics,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael vassalos,
+AGRB,4910,1.0,"Int, Agrib & Comm & Rural Dev",0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,michael vassalos,
+AL,3440,400.0,Athletics and Women,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,misty soles,
+AL,3490,400.0,Principles of Coaching,0.56,0.24,0.08,0.04,0.0,0.0,0.0,0.08,deborah jo cadorette,
+AL,3490,401.0,Principles of Coaching,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,
+AL,3490,402.0,Principles of Coaching,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,john plumblee,
+AL,3490,403.0,Principles of Coaching,0.52,0.24,0.08,0.04,0.04,0.0,0.0,0.08,clyde keith connor,
+AL,3490,404.0,Principles of Coaching,0.48,0.36,0.12,0.0,0.04,0.0,0.0,0.0,john plumblee,
+AL,3490,405.0,Principles of Coaching,0.64,0.24,0.04,0.0,0.04,0.0,0.0,0.04,frank mezzanotte,
+AL,3490,406.0,Principles of Coaching,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,edmond fry,
+AL,3490,407.0,Principles of Coaching,0.64,0.24,0.08,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,
+AL,3490,408.0,Principles of Coaching,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,nicholas philip edward whitrow,
+AL,3490,409.0,Principles of Coaching,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,nicholas philip edward whitrow,
+AL,3490,410.0,Principles of Coaching,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,nicholas philip edward whitrow,
+AL,3490,411.0,Principles of Coaching,0.5,0.29,0.17,0.0,0.0,0.0,0.0,0.04,joel neuder,
+AL,3500,400.0,Sci Basis I/Ex Phy,0.12,0.54,0.12,0.19,0.0,0.0,0.0,0.04,michael godfrey,
+AL,3500,401.0,Sci Basis I/Ex Phy,0.32,0.09,0.23,0.18,0.09,0.0,0.0,0.09,michael godfrey,
+AL,3530,400.0,Athletic Injuries,0.32,0.2,0.16,0.12,0.12,0.0,0.0,0.08,isaac sean colbert,
+AL,3530,401.0,Athletic Injuries,0.26,0.3,0.3,0.13,0.0,0.0,0.0,0.0,isaac sean colbert,
+AL,3600,400.0,Hgh Sch Athl Ethical/Legal Iss,0.29,0.46,0.08,0.17,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,3610,400.0,Admin/Org of Athletic Programs,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,401.0,Admin/Org of Athletic Programs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3620,400.0,Psychology of Coaching,0.31,0.12,0.35,0.12,0.04,0.0,0.0,0.08,natalie anne carter,
+AL,3620,401.0,Psychology of Coaching,0.32,0.36,0.2,0.04,0.0,0.0,0.0,0.08,natalie anne carter,
+AL,3620,402.0,Psychology of Coaching,0.33,0.17,0.38,0.08,0.04,0.0,0.0,0.0,natalie anne carter,
+AL,3740,400.0,Coaching Football,0.77,0.09,0.05,0.05,0.0,0.0,0.0,0.05,edmond fry,
+AL,3740,401.0,Coaching Football,0.5,0.23,0.05,0.09,0.05,0.0,0.0,0.09,edmond fry,
+AL,3760,400.0,Coaching Strength/Conditioning,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,edmond fry,
+AL,3760,401.0,Coaching Strength/Conditioning,0.68,0.08,0.08,0.0,0.04,0.0,0.0,0.12,edmond fry,
+AL,4380,402.0,HS Athletic Recruiting,0.57,0.14,0.11,0.0,0.04,0.0,0.0,0.14,deborah jo cadorette,
+AL,4380,403.0,Media Relations in AL,0.74,0.07,0.15,0.0,0.04,0.0,0.0,0.0,misty soles,
+AL,4380,408.0,Officiating in AL,0.63,0.17,0.04,0.04,0.0,0.0,0.0,0.13,clyde keith connor,
+AL,4380,409.0,Coaching Baseball/Softball,0.58,0.17,0.13,0.04,0.0,0.0,0.0,0.08,deborah jo cadorette,
+AL,4490,400.0,Athlete Beliefs,0.42,0.42,0.13,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,
+AL,8380,400.0,Compliance in Intercoll Athl,0.8,0.05,0.0,0.0,0.05,0.0,0.0,0.1,michael godfrey,
+AL,8380,401.0,Compliance in Colleg Athl,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8440,400.0,Surv of Res Mthds in Athletics,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8440,401.0,Surv of Res Mthds in Athletics,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8440,402.0,Surv of Res Mthds in Athletics,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8490,400.0,Athletic Leadership Dev,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,janna theresa magette,
+AL,8490,401.0,Athletic Leadership Dev,0.76,0.1,0.1,0.0,0.0,0.0,0.0,0.05,janna theresa magette,
+AL,8490,402.0,Athletic Leadership Dev,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,janna theresa magette,
+AL,8500,400.0,Principles Strength and Condit,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8500,401.0,Principles Strength and Condit,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,michael godfrey,
+AL,8650,400.0,Mkt and Comm Respon Interc Ath,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,8650,402.0,Mkt and Comm Respon Interc Ath,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,
+AMFG,6800,864.0,Practicum in Adv Manufacturing,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua summers,
+ANTH,2010,1.0,Introduction to Anthropology,0.49,0.31,0.12,0.02,0.0,0.0,0.0,0.06,yi wu,
+ANTH,2010,2.0,Introduction to Anthropology,0.42,0.29,0.18,0.0,0.02,0.0,0.0,0.09,lisa rapaport,
+ANTH,2010,3.0,Introduction to Anthropology,0.3,0.6,0.09,0.0,0.0,0.0,0.0,0.02,david markus,
+ANTH,2010,4.0,Introduction to Anthropology,0.36,0.54,0.07,0.01,0.02,0.0,0.0,0.02,david markus,
+ANTH,2010,5.0,Introduction to Anthropology,0.41,0.39,0.13,0.04,0.0,0.0,0.0,0.02,yi wu,
+ANTH,3320,1.0,World Archaeology,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,david markus,
+ANTH,3510,1.0,Biological Anthropology,0.48,0.43,0.05,0.0,0.05,0.0,0.0,0.0,lisa rapaport,
+ANTH,3530,1.0,Forensic Anthropology,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,katherine weisensee,
+ANTH,3710,1.0,Language and Culture,0.44,0.44,0.0,0.11,0.0,0.0,0.0,0.0,yanhua zhang,
+ANTH,4230,1.0,Women in the Developing World,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,
+ANTH,4990,1.0,"Religion, Magic, Witchcraft",0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,carolyn candace coffman,
+ARCH,1010,1.0,Introduction to Architecture,0.44,0.35,0.08,0.03,0.03,0.0,0.0,0.07,sallie rebecca hambright-belue,
+ARCH,2040,1.0,Hist of Modern Arch,0.42,0.48,0.07,0.02,0.0,0.0,0.0,0.01,andreea mihalache,
+ARCH,2510,1.0,Arch Foundations I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,2510,2.0,Arch Foundations I,0.53,0.35,0.12,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,2510,3.0,Arch Foundations I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,dustin graham albright,
+ARCH,2510,5.0,Arch Foundations I,0.28,0.28,0.39,0.06,0.0,0.0,0.0,0.0,brandon george pass,
+ARCH,2510,6.0,Arch Foundations I,0.28,0.39,0.28,0.06,0.0,0.0,0.0,0.0,virginia ellyn melnyk,
+ARCH,2700,1.0,Structures I,0.59,0.34,0.03,0.0,0.03,0.0,0.0,0.0,dustin graham albright,
+ARCH,3500,2.0,Intro to Urban Contexts,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,3500,3.0,Intro to Urban Contexts,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,3500,4.0,Intro to Urban Contexts,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,3500,5.0,Intro to Urban Contexts,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,3510,1.0,Studio Clemson,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,ufuk ersoy,
+ARCH,3510,3.0,Studio Clemson,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michael carlos barrios kleiss,
+ARCH,3530,1.0,Studio Genoa,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,3540,1.0,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4010,1.0,Architectural Portfolio,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,virginia ellyn melnyk,
+ARCH,4010,2.0,Architectural Portfolio,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,4010,3.0,Architectural Portfolio,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4010,4.0,Architectural Portfolio,0.44,0.33,0.17,0.0,0.06,0.0,0.0,0.0,brandon george pass,
+ARCH,4120,1.0,History Research,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,4140,1.0,Design Seminar,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,4520,1.0,Synthesis Studio,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,
+ARCH,4710,1.0,Arch Hist of Place,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,jason matthew white,
+ARCH,6850,1.0,H/Th: Arch+Health,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8100,1.0,Visualization I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,andreea mihalache,
+ARCH,8200,1.0,Bldg Design & Constr,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,tori elizabeth wallace-babcock,
+ARCH,8210,1.0,Research Methods,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
+ARCH,8410,1.0,Arch Studio I,0.6,0.0,0.2,0.0,0.0,0.0,0.0,0.2,peter laurence,
+ARCH,8510,3.0,Design Studio III,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,8600,1.0,History/Theory I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,berrin terim,
+ARCH,8720,1.0,Production & Assemb,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,
+ARCH,8970,1.0,A+H Studio: Hospital,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
+ART,1050,1.0,Foundation Drawing I,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,denise elizabeth ayers,
+ART,1510,1.0,Foundations Art I,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,rachel lynn de cuba,
+ART,1520,1.0,Foundations Art II,0.4,0.3,0.0,0.1,0.1,0.0,0.0,0.1,daniel bare,
+ART,2070,1.0,Beginning Painting,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,serra raven shuford,
+ART,2090,1.0,Beginning Sculpture,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,jordan alexander fowler,
+ART,2100,1.0,Art Appreciation,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,dustin massey,
+ART,2100,2.0,Art Appreciation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,dustin massey,
+ART,2100,3.0,Art Appreciation,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,mark norman brosseau,
+ART,2100,5.0,Art Appreciation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,joseph richard manson ,
+ART,2100,6.0,Art Appreciation,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,annamarie elizabeth williams,
+ART,2130,1.0,Begin Photography,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,haley brooke floyd,
+ART,2170,1.0,Beginning Ceramics,0.23,0.54,0.08,0.0,0.08,0.0,0.0,0.08,sara mays,
+AS,1090,2.0,Air Force Today I,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,joseph michael blanton,
+AS,1090,3.0,Air Force Today I,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,joseph michael blanton,
+AS,3090,1.0,A F Leadership Mgt I,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,rachelle marie miller,
+AS,3090,2.0,A F Leadership Mgt I,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,rachelle marie miller,
+AS,4090,1.0,Nat Sec Policy I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,4090,2.0,Nat Sec Policy I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+ASL,1010,2.0,Am Sign Lang I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,1010,5.0,Am Sign Lang I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,1020,1.0,Am Sign Lang I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william ryals clements,
+ASL,1020,2.0,Am Sign Lang I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,william ryals clements,
+ASL,1020,3.0,Am Sign Lang I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,2010,1.0,Am Sign Lang II,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,kim marlene misener dunn,
+ASL,2010,2.0,Am Sign Lang II,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,kim marlene misener dunn,
+ASL,2010,3.0,Am Sign Lang II,0.8,0.15,0.0,0.05,0.0,0.0,0.0,0.0,kim marlene misener dunn,
+ASL,2020,1.0,Am Sign Lang II,0.63,0.16,0.21,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,3010,1.0,Advanced A S L I,0.53,0.21,0.05,0.0,0.0,0.0,0.0,0.21,kim marlene misener dunn,
+ASL,3150,1.0,Survey Interpreting,0.1,0.7,0.0,0.1,0.0,0.0,0.0,0.1,stephen benjamin fitzmaurice,
+ASL,4700,1.0,Dev Sign Lang for Deaf Childrn,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,jody herbert cripps,
+ASTR,1010,1.0,Solar System Astronomy,0.29,0.42,0.22,0.05,0.02,0.0,0.0,0.01,marco ajello,
+ASTR,1010,2.0,Solar System Astronomy,0.24,0.46,0.23,0.04,0.02,0.0,0.0,0.01,marco ajello,
+ASTR,1020,1.0,Stellar Astronomy,0.45,0.29,0.11,0.06,0.03,0.0,0.0,0.06,mark leising,
+ASTR,1030,1.0,Solar Systm Astr Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,david edward connick,
+ASTR,1030,2.0,Solar Systm Astr Lab,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.0,david edward connick,
+ASTR,1030,3.0,Solar Systm Astr Lab,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,david edward connick,
+ASTR,1030,4.0,Solar Systm Astr Lab,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,david edward connick,
+ASTR,1030,6.0,Solar Systm Astr Lab,0.46,0.46,0.0,0.0,0.08,0.0,0.0,0.0,david edward connick,
+ASTR,1030,7.0,Solar Systm Astr Lab,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,david edward connick,
+ASTR,1030,8.0,Solar Systm Astr Lab,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,david edward connick,
+ASTR,1030,9.0,Solar Systm Astr Lab,0.48,0.43,0.04,0.0,0.0,0.0,0.0,0.04,david edward connick,
+ASTR,1030,10.0,Solar Systm Astr Lab,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,david edward connick,
+ASTR,1040,1.0,Stellar Astr Lab,0.46,0.33,0.04,0.04,0.0,0.0,0.0,0.13,david edward connick,
+ASTR,1040,2.0,Stellar Astr Lab,0.35,0.48,0.09,0.04,0.0,0.0,0.0,0.04,david edward connick,
+ASTR,1040,4.0,Stellar Astr Lab,0.48,0.26,0.22,0.0,0.0,0.0,0.0,0.04,david edward connick,
+ASTR,8100,1.0,Astroph I: Radiation,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+ASTR,8750,1.0,Astronomy Seminar,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,marco ajello,
+AUD,2800,1.0,Sound Reinforcement,0.0,0.8,0.2,0.0,0.0,0.0,0.0,0.0,kenneth moore,
+AUD,3800,1.0,Audio Engineering I,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUE,6010,1.0,Vehicle Dynamics,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
+AUE,8190,100.0,Adv Int Combustion Engine Conc,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,8260,1.0,Vehicle Diagnostics,0.5,0.13,0.38,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
+AUE,8270,5.0,Auto Cntrl Sys Des,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8330,30.0,Auto Manuf Proc Devl,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
+AUE,8350,100.0,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,yunyi jia,
+AUE,8670,1.0,Veh Manuf Proc I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+AUE,8800,2.0,Vehicle Project Mngt,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,johnell brooks,
+AUE,8810,3.0,Automotive Systems Overview,0.54,0.39,0.02,0.0,0.04,0.0,0.0,0.02,christiaan jos jan paredis,
+AUE,8870,8.0,Meth Vehicle Testing,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,
+AVS,1000,1.0,Orientation to AVS,0.66,0.21,0.02,0.02,0.03,0.0,0.0,0.06,kristine lang vernon,
+AVS,1500,1.0,Intro Animal Science,0.28,0.28,0.28,0.08,0.03,0.0,0.0,0.07,joseph keith bertrand,
+AVS,1500,2.0,Intro Animal Science,0.21,0.32,0.24,0.09,0.09,0.0,0.0,0.06,joseph keith bertrand,
+AVS,1510,1.0,Intro Ani Sci Lab,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,
+AVS,1510,2.0,Intro Ani Sci Lab,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,
+AVS,1510,3.0,Intro Ani Sci Lab,0.36,0.56,0.0,0.0,0.0,0.0,0.0,0.08,richelle lorraine miller,
+AVS,1510,5.0,Intro Ani Sci Lab,0.62,0.35,0.04,0.0,0.0,0.0,0.0,0.0,chelsea drumwright sinclair,
+AVS,1510,6.0,Intro Ani Sci Lab,0.69,0.15,0.12,0.0,0.04,0.0,0.0,0.0,chelsea drumwright sinclair,
+AVS,1510,7.0,Intro Ani Sci Lab,0.73,0.19,0.04,0.0,0.0,0.0,0.0,0.04,richelle lorraine miller,
+AVS,1510,8.0,Intro Ani Sci Lab,0.56,0.36,0.0,0.0,0.0,0.0,0.0,0.08,chelsea drumwright sinclair,
+AVS,2040,1.0,Horse Care Techniques,0.72,0.18,0.1,0.0,0.0,0.0,0.0,0.0,chelsea drumwright sinclair,
+AVS,2110,1.0,Meat Processing Techniques,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,richelle lorraine miller,
+AVS,3010,1.0,Anat & Phys Dom Ani,0.58,0.23,0.16,0.03,0.0,0.0,0.0,0.0,glenn birrenkott,
+AVS,3010,400.0,Anat & Phys Dom Ani,0.46,0.32,0.11,0.08,0.03,0.0,0.0,0.0,glenn birrenkott,
+AVS,3020,1.0,Livestk Sel Eval I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,
+AVS,3100,1.0,Animal Health,0.58,0.34,0.06,0.0,0.02,0.0,0.0,0.0,celina marcela checura,
+AVS,3700,1.0,Principles of Animal Nutrition,0.67,0.18,0.09,0.02,0.0,0.0,0.0,0.05,james robert strickland,
+AVS,3750,1.0,Applied Animal Nutrition,0.13,0.47,0.27,0.07,0.0,0.0,0.0,0.07,gustavo jose lascano,
+AVS,4100,1.0,Domestic Ani Behav,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,ahmed badr abdelwahab ali,
+AVS,4110,1.0,Animal Growth and Development,0.34,0.36,0.14,0.05,0.06,0.0,0.0,0.05,susan kay duckett,
+AVS,4150,1.0,Contemporary Issues in AVS,0.79,0.12,0.04,0.01,0.01,0.0,0.0,0.01,heather walker dunn,
+AVS,4160,1.0,Equine Exercise Phys,0.43,0.21,0.29,0.07,0.0,0.0,0.0,0.0,kristine lang vernon,
+AVS,4500,1.0,Sustain Livestock Product Sys,0.18,0.45,0.18,0.0,0.09,0.0,0.0,0.09,matias jose aguerre,
+AVS,4530,1.0,Animal Reproduction,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,tiffany wilmoth,
+AVS,4650,1.0,Animal Physiology I,0.33,0.41,0.18,0.05,0.0,0.0,0.0,0.03,celina marcela checura,
+AVS,4800,1.0,Vertebrate Endocrinology,0.36,0.58,0.06,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,4920,1.0,Advanced Fetal Fescue Research,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,susan kay duckett,
+AVS,4920,2.0,Bioinformatics Cancer Gen,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,8010,3.0,Principles Scientific Writing,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,jeryl jones,
+BCHM,1030,1.0,Careers in Bioch/Gen,0.85,0.09,0.02,0.02,0.02,0.0,0.0,0.0,joseph paul thames,
+BCHM,3010,1.0,Molecular Biochemistry,0.32,0.15,0.26,0.09,0.11,0.0,0.0,0.09,cheryl jean ingram-smith,
+BCHM,3050,1.0,Essen Elements Bioch,0.22,0.37,0.22,0.12,0.04,0.0,0.0,0.04,debra ragland,
+BCHM,3050,2.0,Essen Elements Bioch,0.22,0.35,0.31,0.07,0.01,0.0,0.0,0.03,debra ragland,
+BCHM,4310,1.0,Physical Approach to Biochem,0.28,0.39,0.28,0.01,0.03,0.0,0.0,0.0,weiguo cao,
+BCHM,4330,2.0,Physical Biochemistry Lab,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,geoffrey ford,
+BCHM,4400,1.0,Bioinformatics,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,frank alexander feltus,
+BCHM,4430,1.0,Molecular Basis of Disease,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,james morris,
+BCHM,4910,27.0,CI-CU INVESTORS,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,meredith teilhet morris,
+BCHM,4910,32.0,CI-DNA Repair (HON),0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael glen sehorn,True
+BCHM,4930,2.0,Senior Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,
+BCHM,4930,5.0,Senior Seminar,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
+BCHM,8140,1.0,Advanced Biochemistry,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,meredith teilhet morris,
+BE,2100,1.0,Intro to Biosystems Engr,0.76,0.12,0.08,0.0,0.0,0.0,0.0,0.04,jazmine octavia taylor,
+BE,3200,1.0,Principles & Prac of Geomatics,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4100,1.0,Biological Kinetics,0.21,0.43,0.29,0.07,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,4210,1.0,Engr Sys for Soil Water Mgt,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,christophe darnault,
+BE,4280,1.0,Biochem Engr,0.4,0.4,0.1,0.1,0.0,0.0,0.0,0.0,terry walker,
+BE,4740,1.0,BE Design Project Managment,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
+BE,4750,1.0,BE Capstone Design,0.77,0.0,0.23,0.0,0.0,0.0,0.0,0.0,christophe darnault,
+BIOE,1010,1.0,Biol for Bioengr,0.69,0.15,0.08,0.0,0.0,0.0,0.0,0.08,tyler george harvey,
+BIOE,2010,2.0,Intro Biomed Engr,0.47,0.34,0.13,0.03,0.01,0.0,0.0,0.02,charles webb,
+BIOE,3020,1.0,Biomaterials,0.69,0.23,0.04,0.02,0.0,0.0,0.0,0.02,alexey alexandrovich vertegel,
+BIOE,3100,1.0,Engr Analysis of Physiol Proc,0.79,0.16,0.03,0.03,0.0,0.0,0.0,0.0,brian william booth,
+BIOE,3200,1.0,Biomechanics,0.49,0.41,0.06,0.01,0.01,0.0,0.0,0.01,jiro nagatomi,
+BIOE,3210,1.0,Biofluid Mechanics,0.53,0.33,0.1,0.0,0.0,0.0,0.0,0.03,zhi gao,
+BIOE,3470,1.0,Transport Processes in Bioengr,0.63,0.26,0.08,0.03,0.01,0.0,0.0,0.0,renee nicole cottle,
+BIOE,3700,1.0,Bioinst & Imaging,0.57,0.33,0.09,0.0,0.0,0.0,0.0,0.02,delphine dean,
+BIOE,4010,2.0,Bioengineering Design Theory,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
+BIOE,4030,1.0,Applied Bio E Design,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ravikiran bhaskar singapogu,
+BIOE,4120,1.0,Orthopaedic Engr and Pathology,0.6,0.35,0.02,0.0,0.0,0.0,0.0,0.02,melinda harman,
+BIOE,4400,1.0,Biopharmaceutical Engineering,0.26,0.47,0.05,0.0,0.05,0.0,0.0,0.16,sarah harcum,
+BIOE,4480,1.0,Tissue Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,angela antoinette alexander,
+BIOE,4510,31.0,CI-Med Design with Arusha Tz,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,delphine dean,
+BIOE,6120,1.0,Orthopaedic Engr & Pathology,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,melinda harman,
+BIOE,6350,1.0,Computational Modeling in BIOE,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,
+BIOE,6400,1.0,Biopharmaceutical Engineering,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,sarah harcum,
+BIOE,8010,1.0,Bio Materials,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert latour,
+BIOE,8160,1.0,BioE Professional Development,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,martine laberge,
+BIOE,8160,843.0,BioE Professional Development,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jeremy gilbert,
+BIOL,1010,1.0,Frontiers in Biology I,0.8,0.14,0.05,0.0,0.0,0.0,0.0,0.01,michael childress,
+BIOL,1010,2.0,Frontiers in Biology I,0.83,0.13,0.02,0.0,0.01,0.0,0.0,0.01,michael childress,
+BIOL,1030,1.0,General Biology I,0.24,0.29,0.27,0.1,0.04,0.0,0.0,0.06,nora espinoza,
+BIOL,1030,2.0,General Biology I,0.26,0.24,0.17,0.18,0.04,0.0,0.0,0.12,nathan redding,
+BIOL,1030,3.0,General Biology I,0.23,0.33,0.24,0.07,0.04,0.0,0.0,0.09,wen chen,
+BIOL,1030,4.0,General Biology I,0.15,0.26,0.35,0.1,0.04,0.0,0.0,0.11,salvatore sparace,
+BIOL,1030,5.0,General Biology I (HON),0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
+BIOL,1050,1.0,General Biology Lab I,0.0,0.22,0.43,0.22,0.04,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,2.0,General Biology Lab I,0.0,0.17,0.38,0.13,0.08,0.0,0.0,0.25,tafadzwa kaisa,
+BIOL,1050,3.0,General Biology Lab I,0.0,0.38,0.17,0.21,0.0,0.0,0.0,0.25,tafadzwa kaisa,
+BIOL,1050,4.0,General Biology Lab I,0.0,0.13,0.38,0.29,0.08,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,5.0,General Biology Lab I,0.0,0.29,0.29,0.29,0.13,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,6.0,General Biology Lab I,0.0,0.25,0.54,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,7.0,General Biology Lab I,0.0,0.27,0.23,0.36,0.0,0.0,0.0,0.14,tafadzwa kaisa,
+BIOL,1050,8.0,General Biology Lab I,0.0,0.17,0.43,0.13,0.0,0.0,0.0,0.26,tafadzwa kaisa,
+BIOL,1050,9.0,General Biology Lab I,0.0,0.17,0.46,0.13,0.08,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,10.0,General Biology Lab I,0.0,0.13,0.43,0.17,0.13,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,11.0,General Biology Lab I,0.0,0.09,0.43,0.26,0.0,0.0,0.0,0.22,tafadzwa kaisa,
+BIOL,1050,12.0,General Biology Lab I,0.04,0.25,0.25,0.29,0.0,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,13.0,General Biology Lab I,0.0,0.17,0.42,0.17,0.13,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,14.0,General Biology Lab I,0.0,0.13,0.42,0.25,0.04,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,15.0,General Biology Lab I,0.0,0.13,0.33,0.17,0.13,0.0,0.0,0.25,tafadzwa kaisa,
+BIOL,1050,16.0,General Biology Lab I,0.0,0.42,0.46,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,17.0,General Biology Lab I,0.0,0.13,0.5,0.25,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,18.0,General Biology Lab I,0.0,0.13,0.42,0.38,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,19.0,General Biology Lab I,0.04,0.38,0.25,0.17,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,20.0,General Biology Lab I,0.0,0.25,0.5,0.17,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,21.0,General Biology Lab I,0.0,0.21,0.42,0.21,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,22.0,General Biology Lab I,0.0,0.13,0.54,0.17,0.13,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,23.0,General Biology Lab I,0.0,0.09,0.3,0.35,0.17,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1050,24.0,General Biology Lab I,0.0,0.26,0.39,0.22,0.0,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,25.0,General Biology Lab I,0.0,0.26,0.52,0.04,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,27.0,General Biology Lab I,0.04,0.33,0.46,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,28.0,General Biology Lab I,0.04,0.13,0.42,0.33,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,29.0,General Biology Lab I,0.08,0.29,0.42,0.0,0.04,0.0,0.0,0.17,tafadzwa kaisa,
+BIOL,1050,30.0,General Biology Lab I,0.04,0.13,0.63,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,32.0,General Biology Lab I,0.0,0.22,0.3,0.22,0.13,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,33.0,General Biology Lab I,0.0,0.1,0.38,0.24,0.14,0.0,0.0,0.14,tafadzwa kaisa,
+BIOL,1050,34.0,General Biology Lab I,0.0,0.35,0.35,0.13,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,35.0,General Biology Lab I,0.0,0.17,0.5,0.25,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,36.0,General Biology Lab I,0.0,0.42,0.25,0.13,0.08,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,37.0,General Biology Lab I,0.21,0.29,0.33,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,38.0,General Biology Lab I,0.0,0.04,0.67,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,39.0,General Biology Lab I,0.04,0.38,0.29,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,40.0,General Biology Lab I,0.0,0.5,0.25,0.17,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,41.0,General Biology Lab I,0.04,0.38,0.38,0.13,0.0,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,42.0,General Biology Lab I,0.04,0.29,0.38,0.17,0.04,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,43.0,General Biology Lab I,0.0,0.33,0.29,0.21,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,44.0,General Biology Lab I,0.04,0.25,0.38,0.17,0.04,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,45.0,General Biology Lab I,0.0,0.25,0.33,0.21,0.17,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,46.0,General Biology Lab I,0.0,0.33,0.29,0.08,0.17,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1090,1.0,Intro to Life Sci,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,renea chris hardwick,
+BIOL,1100,1.0,Principles of Biology I,0.43,0.34,0.15,0.02,0.02,0.0,0.0,0.03,renea chris hardwick,
+BIOL,1100,2.0,Principles of Biology I (HON),0.81,0.18,0.01,0.0,0.0,0.0,0.0,0.0,verna christine  minor,True
+BIOL,1100,3.0,Principles of Biology I,0.27,0.55,0.16,0.02,0.0,0.0,0.0,0.0,verna christine  minor,
+BIOL,1100,4.0,Principles of Biology I,0.55,0.29,0.1,0.05,0.02,0.0,0.0,0.0,renea chris hardwick,
+BIOL,2110,1.0,Introduction to Toxicology,0.44,0.44,0.05,0.02,0.02,0.0,0.0,0.02,peter van den hurk,
+BIOL,2220,1.0,Human Anat and Physiology I,0.23,0.36,0.24,0.08,0.03,0.0,0.0,0.06,john cummings,
+BIOL,2220,2.0,Human Anat and Physiology I,0.27,0.37,0.2,0.08,0.04,0.0,0.0,0.05,john cummings,
+BIOL,3030,1.0,Vertebrate Biology,0.5,0.25,0.13,0.06,0.03,0.0,0.0,0.01,virginia ellen abernathy,
+BIOL,3030,2.0,Vertebrate Biology (HON),0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,virginia ellen abernathy,True
+BIOL,3030,3.0,Vertebrate Biology,0.53,0.29,0.09,0.09,0.0,0.0,0.0,0.0,virginia ellen abernathy,
+BIOL,3040,1.0,Biology of Plants,0.19,0.29,0.3,0.19,0.01,0.0,0.0,0.03,nathan redding,
+BIOL,3070,1.0,Vertebrate Biology Lab,0.36,0.56,0.08,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,2.0,Vertebrate Biology Lab,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,3.0,Vertebrate Biology Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,4.0,Vertebrate Biology Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,5.0,Vertebrate Biology Lab,0.21,0.71,0.04,0.0,0.0,0.0,0.0,0.04,richard blob,
+BIOL,3070,6.0,Vertebrate Biology Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,7.0,Vertebrate Biology Lab,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,8.0,Vertebrate Biology Lab,0.5,0.38,0.08,0.04,0.0,0.0,0.0,0.0,richard blob,
+BIOL,3070,9.0,Vertebrate Biology Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,richard blob,
+BIOL,3080,1.0,Biology of Plants Practicum,0.45,0.35,0.1,0.05,0.0,0.0,0.0,0.05,nathan redding,
+BIOL,3080,3.0,Biology of Plants Practicum,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,4.0,Biology of Plants Practicum,0.25,0.42,0.17,0.17,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,5.0,Biology of Plants Practicum,0.13,0.53,0.33,0.0,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3080,6.0,Biology of Plants Practicum,0.13,0.44,0.44,0.0,0.0,0.0,0.0,0.0,nathan redding,
+BIOL,3150,1.0,Functional Human Anatomy,0.26,0.39,0.19,0.08,0.01,0.0,0.0,0.06,tamara mcnutt-scott,
+BIOL,3200,1.0,Field Botany,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,robert edward ballard,
+BIOL,3350,1.0,Evolutionary Biology,0.27,0.44,0.21,0.06,0.02,0.0,0.0,0.01,margaret ptacek,
+BIOL,3510,1.0,Biological Anthropology,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,lisa rapaport,
+BIOL,3530,1.0,Forensic Anthropology,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,katherine weisensee,
+BIOL,4030,1.0,Intro to Applied Genomics,0.15,0.08,0.23,0.0,0.0,0.0,0.0,0.54,vincent paul richards,
+BIOL,4140,1.0,Basic Immunology,0.28,0.22,0.28,0.11,0.0,0.0,0.0,0.11,yanzhang wei,
+BIOL,4200,1.0,Neurobiology,0.59,0.31,0.03,0.0,0.0,0.0,0.0,0.06,david feliciano,
+BIOL,4250,1.0,Introductory Mycology,0.39,0.36,0.13,0.05,0.05,0.0,0.0,0.03,julia louise kerrigan,
+BIOL,4260,1.0,Mycology Practicum,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,julia louise kerrigan,
+BIOL,4400,1.0,Developmental Animal Biology,0.34,0.22,0.3,0.1,0.02,0.0,0.0,0.02,kara elizabeth powder,
+BIOL,4410,1.0,Ecology,0.24,0.38,0.19,0.07,0.01,0.0,0.0,0.1,sharon bewick,
+BIOL,4530,1.0,Integrative Organismal Biology,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,michael sears,
+BIOL,4560,1.0,Medical and Vet Parasitology,0.59,0.37,0.0,0.02,0.0,0.0,0.0,0.02,wilbur kearse milhous,
+BIOL,4610,1.0,Cell Biology,0.36,0.37,0.2,0.03,0.01,0.0,0.0,0.03,susan caroline chapman,
+BIOL,4610,2.0,Cell Biology (HON),0.58,0.33,0.03,0.0,0.0,0.0,0.0,0.06,susan caroline chapman,True
+BIOL,4620,1.0,Cell Biology Lab (Lec),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,2.0,Cell Biology Lab (Lec),0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,3.0,Cell Biology Lab (Lec),0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,4.0,Cell Biology Lab (Lec),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,5.0,Cell Biology Lab (Lec),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6.0,Cell Biology Lab (Lec),0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
+BIOL,4620,7.0,Cell Biology Lab (Lec),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,8.0,Cell Biology Lab (Lec),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4670,1.0,Principles of Hematology,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.03,vincent gallicchio,
+BIOL,4890,1.0,Clinical Apps and Medical Prac,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,
+BIOL,4930,2.0,Sr Sem: Current Topic Biology,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,
+BIOL,4930,5.0,Sr Sem: Biol Adv in Agricultur,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,salvatore sparace,
+BIOL,4930,6.0,Sr Sem: Emerging Viruses,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,matthew turnbull,
+BIOL,4930,7.0,Sr Sem: Negl Infect Dis Povert,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
+BIOL,6030,1.0,Intro to Applied Genomics,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,vincent paul richards,
+BIOL,6610,1.0,Cell Biology,0.2,0.2,0.4,0.0,0.2,0.0,0.0,0.0,susan caroline chapman,
+BIOL,8400,1.0,Understanding Biological Inq,0.92,0.0,0.04,0.0,0.04,0.0,0.0,0.0,michael childress,
+BIOL,8420,1.0,Understand Cellular Processes,0.89,0.09,0.0,0.0,0.01,0.0,0.0,0.01,kaustubha ratan qanungo,
+BIOL,8440,1.0,Understanding the Human Body,0.43,0.43,0.11,0.0,0.03,0.0,0.0,0.0,tamara mcnutt-scott,
+BMOL,4250,1.0,Biomolecular Engineering,0.23,0.43,0.2,0.08,0.05,0.0,0.0,0.0,marc russel birtwistle,
+BUS,1010,1.0,Business Foundations,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,william ernest tumblin,
+BUS,1010,2.0,Business Foundations,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,william ernest tumblin,
+CE,4910,1.0,BIM in Construction Management,0.81,0.14,0.02,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,4910,2.0,Accident Analytics,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,
+CE,4990,14.0,Special Projects-Springer II,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,prasada rao rangaraju,
+CE,6010,1.0,Matrix Str Analysis,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,laura mae redmond,
+CE,6430,1.0,Water Resources Engr,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,abdul khan,
+CE,6470,1.0,Stormwater Managemnt,0.67,0.0,0.33,0.0,0.0,0.0,0.0,0.0,md nasimul hoque chowdhury,
+CE,8010,1.0,Finite Ele Analysis,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nadarajah ravichandran,
+CE,8020,1.0,Adv R/C Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas edford cousins,
+CE,8700,500.0,Capstone Design Risk Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,
+CE,8930,3.0,Transport Risk & Evacuation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pamela marie murray-tuite,
+CE,8930,4.0,Autonomous Vehicle Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CE,8930,5.0,Struct Fire Engr & Safety,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,mohannad naser,
+CH,1010,1.0,General Chemistry,0.26,0.37,0.2,0.03,0.05,0.0,0.0,0.1,tania houjeiry,
+CH,1010,2.0,General Chemistry,0.12,0.4,0.31,0.09,0.02,0.0,0.0,0.06,olt geiculescu,
+CH,1010,3.0,General Chemistry,0.21,0.32,0.28,0.08,0.03,0.0,0.0,0.07,william wesley mcwhorter,
+CH,1010,4.0,General Chemistry,0.25,0.26,0.22,0.11,0.05,0.0,0.0,0.1,khushi patel,
+CH,1010,5.0,General Chemistry,0.28,0.37,0.17,0.06,0.04,0.0,0.0,0.09,dennis taylor,
+CH,1010,6.0,General Chemistry,0.29,0.35,0.18,0.08,0.04,0.0,0.0,0.07,elliot ennis,
+CH,1010,7.0,General Chemistry,0.17,0.33,0.22,0.09,0.06,0.0,0.0,0.13,william wesley mcwhorter,
+CH,1010,8.0,General Chemistry,0.38,0.32,0.12,0.12,0.02,0.0,0.0,0.05,thomas hickman,
+CH,1010,9.0,General Chemistry,0.25,0.42,0.25,0.04,0.03,0.0,0.0,0.03,william wesley mcwhorter,
+CH,1010,10.0,General Chemistry,0.17,0.38,0.21,0.08,0.08,0.0,0.0,0.08,princess mycia cox,
+CH,1010,11.0,General Chemistry,0.37,0.39,0.1,0.06,0.07,0.0,0.0,0.01,thomas hickman,
+CH,1010,12.0,General Chemistry,0.32,0.33,0.22,0.04,0.05,0.0,0.0,0.05,dennis taylor,
+CH,1010,13.0,General Chemistry,0.27,0.31,0.16,0.15,0.03,0.0,0.0,0.08,princess mycia cox,
+CH,1010,14.0,General Chemistry,0.14,0.33,0.3,0.12,0.03,0.0,0.0,0.08,jacob schroeder,
+CH,1010,50.0,General Chemistry,0.53,0.33,0.12,0.0,0.02,0.0,0.0,0.0,tania houjeiry,
+CH,1010,51.0,General Chemistry (HON),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,joseph stuart thrasher,True
+CH,1010,52.0,General Chemistry (HON),0.7,0.22,0.08,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True
+CH,1010,201.0,General Chemistry,0.18,0.47,0.23,0.06,0.05,0.0,0.0,0.02,elliot ennis,
+CH,1010,203.0,General Chemistry,0.24,0.37,0.26,0.06,0.07,0.0,0.0,0.0,jacob schroeder,
+CH,1010,204.0,General Chemistry,0.32,0.32,0.23,0.07,0.03,0.0,0.0,0.03,thao thi thanh tran,
+CH,1020,1.0,General Chemistry,0.34,0.25,0.21,0.11,0.01,0.0,0.0,0.09,stephen jon schvaneveldt,
+CH,1020,2.0,General Chemistry,0.28,0.28,0.2,0.15,0.02,0.0,0.0,0.07,stephen jon schvaneveldt,
+CH,1020,3.0,General Chemistry,0.26,0.2,0.31,0.08,0.04,0.0,0.0,0.11,stephen jon schvaneveldt,
+CH,1020,400.0,General Chemistry,0.1,0.29,0.17,0.24,0.07,0.0,0.0,0.14,stephen jon schvaneveldt,
+CH,1050,1.0,Chemistry in Context I,0.43,0.31,0.16,0.05,0.04,0.0,0.0,0.01,olt geiculescu,
+CH,1050,2.0,Chemistry in Context I,0.45,0.4,0.11,0.01,0.01,0.0,0.0,0.02,olt geiculescu,
+CH,2010,1.0,Survey of Organic Chemistry,0.62,0.25,0.06,0.04,0.03,0.0,0.0,0.0,tania houjeiry,
+CH,2010,2.0,Survey of Organic Chemistry,0.4,0.4,0.13,0.03,0.02,0.0,0.0,0.02,modi wetzler,
+CH,2230,1.0,Organic Chemistry,0.09,0.16,0.24,0.14,0.25,0.0,0.0,0.12,modi wetzler,
+CH,2230,2.0,Organic Chemistry,0.05,0.23,0.22,0.12,0.16,0.0,0.0,0.21,modi wetzler,
+CH,2230,3.0,Organic Chemistry,0.38,0.3,0.2,0.07,0.03,0.0,0.0,0.02,laura lanni,
+CH,2230,4.0,Organic Chemistry,0.29,0.25,0.25,0.07,0.08,0.0,0.0,0.06,laura lanni,
+CH,2230,5.0,Organic Chemistry,0.4,0.32,0.13,0.03,0.05,0.0,0.0,0.08,rhett smith,
+CH,2230,6.0,Organic Chemistry,0.24,0.28,0.26,0.11,0.07,0.0,0.0,0.04,elliot ennis,
+CH,2230,7.0,Organic Chemistry,0.14,0.18,0.27,0.2,0.09,0.0,0.0,0.12,elliot ennis,
+CH,2230,50.0,Organic Chemistry,0.33,0.43,0.15,0.03,0.03,0.0,0.0,0.03,daniel whitehead,
+CH,2240,1.0,Organic Chemistry,0.3,0.2,0.15,0.18,0.09,0.0,0.0,0.09,laura lanni,
+CH,2240,2.0,Organic Chemistry,0.23,0.23,0.24,0.14,0.1,0.0,0.0,0.04,thomas hickman,
+CH,2270,1.0,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,
+CH,2270,3.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,5.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,7.0,Organic Chem Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,
+CH,2270,8.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,13.0,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelson plampin,
+CH,2270,15.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,16.0,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelson plampin,
+CH,2270,19.0,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,
+CH,2270,23.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,27.0,Organic Chem Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,
+CH,2270,29.0,Organic Chem Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,
+CH,2270,32.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,35.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
+CH,2270,39.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,
+CH,2270,40.0,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,
+CH,2280,4.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,
+CH,3130,1.0,Quantitative Analysis,0.55,0.2,0.1,0.03,0.05,0.0,0.0,0.08,jeffrey nathan anker,
+CH,3150,1.0,Quant Analysis Lab,0.5,0.2,0.0,0.1,0.1,0.0,0.0,0.1,carlos diego garcia perez,
+CH,3150,2.0,Quant Analysis Lab,0.73,0.09,0.0,0.0,0.18,0.0,0.0,0.0,carlos diego garcia perez,
+CH,3300,1.0,Intro to Phys Chem,0.52,0.31,0.06,0.05,0.04,0.0,0.0,0.02,brian dominy,
+CH,3310,1.0,Physical Chemistry,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,steven stuart,
+CH,3390,1.0,Physical Chem Lab,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,2.0,Physical Chem Lab,0.2,0.73,0.07,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,3.0,Physical Chem Lab,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,4.0,Physical Chem Lab,0.33,0.56,0.06,0.06,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3390,5.0,Physical Chem Lab,0.47,0.47,0.0,0.06,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,4010,1.0,Organometallic Chemistry,0.71,0.24,0.0,0.03,0.0,0.0,0.0,0.03,andrew gregory tennyson,
+CH,4020,1.0,Inorganic Chemistry,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,joseph kolis,
+CH,4210,1.0,Advanced Organic Chemistry,0.3,0.59,0.04,0.04,0.0,0.0,0.0,0.04,jacob schroeder,
+CH,8070,1.0,Chem Trans Elem,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
+CH,8140,1.0,Analytical Imaging,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,george chumanov,
+CH,8160,1.0,Separation Science,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,richard marcus,
+CH,8410,1.0,N M R Spectroscopy,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,aleksandr kitaygorodskiy,
+CH,8510,1.0,Grad Student Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,
+CH,8520,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,joseph stuart thrasher,
+CHE,2110,1.0,Mass and Energy Balances,0.35,0.39,0.25,0.0,0.0,0.0,0.0,0.01,karen ann high,
+CHE,2990,3.0,CI in CHE-  YEAST,0.0,0.0,0.0,0.0,0.0,0.75,0.0,0.25,marc russel birtwistle,
+CHE,3210,1.0,Ch E Thermo II,0.22,0.13,0.37,0.15,0.13,0.0,0.0,0.0,mark thies,
+CHE,3300,1.0,Mass Trans & Seprtn,0.25,0.46,0.21,0.03,0.05,0.0,0.0,0.0,david bruce,
+CHE,3990,8.0,CI in CHE- NANO,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jessica marie larsen,
+CHE,3990,9.0,CI- OPEN EDUCATIONAL RESOURCES,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rachel getman,
+CHE,4070,1.0,Unit Op Lab II,0.22,0.66,0.12,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
+CHE,4310,1.0,Process Design I,0.3,0.45,0.25,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,4500,1.0,Chem Reaction Engr,0.35,0.4,0.22,0.03,0.0,0.0,0.0,0.0,mark roberts,
+CHE,8040,1.0,Ch E Thermodynamics,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
+CHE,8050,1.0,Ch E Kinetics,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,rachel getman,
+CHIN,1010,1.0,Elementary Chinese,0.5,0.2,0.1,0.1,0.0,0.0,0.0,0.1,yanhua zhang,
+CHIN,1010,2.0,Elementary Chinese,0.33,0.42,0.0,0.17,0.0,0.0,0.0,0.08,yanhua zhang,
+CHIN,4010,1.0,Pre-Modern Chinese Literature,0.3,0.5,0.1,0.0,0.03,0.0,0.0,0.08,yanming an,
+COM,1500,1.0,Intro to Human Communication,0.66,0.32,0.01,0.0,0.0,0.0,0.0,0.01,daniel leland fecher,
+COM,1500,2.0,Intro to Human Communication,0.73,0.22,0.03,0.0,0.01,0.0,0.0,0.02,daniel leland fecher,
+COM,1500,3.0,Intro to Human Communication,0.8,0.14,0.03,0.01,0.0,0.0,0.0,0.01,daniel leland fecher,
+COM,1500,4.0,Intro to Human Communication,0.74,0.22,0.02,0.01,0.01,0.0,0.0,0.01,marianne herr glaser,
+COM,1500,5.0,Intro to Human Communication,0.74,0.22,0.02,0.0,0.0,0.0,0.0,0.02,marianne herr glaser,
+COM,1500,6.0,Intro to Human Communication,0.82,0.14,0.02,0.0,0.0,0.0,0.0,0.02,marianne herr glaser,
+COM,1500,7.0,Intro to Human Communication,0.49,0.4,0.07,0.01,0.01,0.0,0.0,0.01,vanessa anne condon,
+COM,2010,1.0,Intr to Comm Studies,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2010,2.0,Intr to Comm Studies,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2030,1.0,Mass Communication Theory,0.35,0.15,0.45,0.0,0.05,0.0,0.0,0.0,jumah patricia taweh,
+COM,2040,1.0,Critical-Cultural Comm Theory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james nicholas gilmore,
+COM,2100,1.0,Quant Comm Research Methods,0.33,0.39,0.17,0.06,0.06,0.0,0.0,0.0,gregory keith cranmer,
+COM,2110,1.0,Qual Comm Research Methods,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,2500,2.0,Public Speaking,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,3.0,Public Speaking,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,5.0,Public Speaking,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,alyssa christine davis,
+COM,2500,6.0,Public Speaking,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christine davis,
+COM,2500,7.0,Public Speaking,0.42,0.42,0.05,0.11,0.0,0.0,0.0,0.0,marshall thomas covert,
+COM,2500,8.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,marshall thomas covert,
+COM,2500,9.0,Public Speaking,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,marshall thomas covert,
+COM,2500,10.0,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,marshall thomas covert,
+COM,2500,11.0,Public Speaking,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
+COM,2500,17.0,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,
+COM,2500,18.0,Public Speaking,0.67,0.22,0.0,0.11,0.0,0.0,0.0,0.0,ashley lauren pikel,
+COM,2500,19.0,Public Speaking,0.53,0.37,0.0,0.0,0.0,0.0,0.0,0.11,jumah patricia taweh,
+COM,2500,21.0,Public Speaking,0.63,0.26,0.0,0.05,0.05,0.0,0.0,0.0,charles john brewer,
+COM,2500,22.0,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,charles john brewer,
+COM,2500,23.0,Public Speaking,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,sara grumbles crocker,
+COM,2500,24.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,charles john brewer,
+COM,2500,25.0,Public Speaking,0.68,0.11,0.05,0.05,0.0,0.0,0.0,0.11,sara grumbles crocker,
+COM,2500,26.0,Public Speaking,0.47,0.26,0.11,0.11,0.0,0.0,0.0,0.05,charles john brewer,
+COM,2500,27.0,Public Speaking,0.72,0.17,0.06,0.0,0.06,0.0,0.0,0.0,sara grumbles crocker,
+COM,2500,28.0,Public Speaking,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,katie barnes mcelveen,
+COM,2500,29.0,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel leland fecher,
+COM,2500,30.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,elizabeth ann kaszynski gilmore,
+COM,2500,33.0,Public Speaking,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
+COM,2500,37.0,Public Speaking (HON),0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,lindsey dixon,True
+COM,2500,39.0,Public Speaking (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,True
+COM,2500,400.0,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
+COM,2500,401.0,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachary davis,
+COM,2500,403.0,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
+COM,3050,1.0,Persuasion,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
+COM,3080,1.0,Public Comm & Pop Culture,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,3240,1.0,"Communication, Sport & Society",0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,katie barnes mcelveen,
+COM,3240,2.0,"Communication, Sport & Society",0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katie barnes mcelveen,
+COM,3250,2.0,Survey of Sports Communication,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
+COM,3260,1.0,Pr in Sports,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3260,2.0,Pr in Sports,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3300,1.0,Nonverbal Communication,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
+COM,3480,1.0,Interpersonal Comm,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,stephanie michelle pangborn,
+COM,3550,1.0,Principles of Public Relations,0.56,0.39,0.0,0.0,0.06,0.0,0.0,0.0,rachelle leigh beckner,
+COM,3560,1.0,Crisis Communication,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,andrew stephen pyle,
+COM,3660,5.0,Corporate Communications,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,. mark barnes,
+COM,4250,1.0,Adv Sports Comm,0.29,0.59,0.06,0.06,0.0,0.0,0.0,0.0,bryan denham,
+COM,4280,1.0,Interpers/Family Comm & Sport,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,gregory keith cranmer,
+COM,4710,1.0,Health Comm in Communities,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,stephanie michelle pangborn,
+COM,4950,1.0,Senior Capstone Seminar,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,8010,1.0,Communication Theory I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,erin michelle ash,
+COM,8030,1.0,Comm Technology Studies Survey,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nicholas gilmore,
+CPSC,1010,100.0,Computer Science I,0.22,0.37,0.24,0.07,0.07,0.0,0.0,0.04,roger larry van scoy,
+CPSC,1010,200.0,Computer Science I,0.4,0.23,0.21,0.04,0.04,0.0,0.0,0.08,roger larry van scoy,
+CPSC,1010,300.0,Computer Science I,0.31,0.27,0.18,0.07,0.13,0.0,0.0,0.04,yu-shan sun,
+CPSC,1020,1.0,Computer Science II,0.19,0.27,0.32,0.0,0.08,0.0,0.0,0.14,yvon feaster,
+CPSC,1020,2.0,Computer Science II,0.23,0.17,0.2,0.06,0.17,0.0,0.0,0.17,yvon feaster,
+CPSC,1020,3.0,Computer Science II,0.03,0.16,0.41,0.16,0.11,0.0,0.0,0.14,catherine hochrine,
+CPSC,1060,100.0,Intro to Programming in Java,0.26,0.34,0.32,0.03,0.05,0.0,0.0,0.0,svetlana drachova,
+CPSC,1060,200.0,Intro to Programming in Java,0.28,0.36,0.23,0.06,0.06,0.0,0.0,0.02,svetlana drachova,
+CPSC,1070,1.0,Programming Methodology,0.25,0.42,0.11,0.03,0.03,0.0,0.0,0.17,donald henry house,
+CPSC,1070,2.0,Programming Methodology,0.35,0.16,0.27,0.0,0.08,0.0,0.0,0.14,donald henry house,
+CPSC,1110,1.0,Intro to Programming in C,0.21,0.25,0.21,0.15,0.09,0.0,0.0,0.09,catherine hochrine,
+CPSC,1110,2.0,Intro to Programming in C,0.3,0.33,0.16,0.13,0.01,0.0,0.0,0.06,yu-shan sun,
+CPSC,1110,3.0,Intro to Programming in C,0.17,0.26,0.22,0.12,0.14,0.0,0.0,0.09,catherine hochrine,
+CPSC,1210,1.0,Computational Thinking,0.25,0.46,0.17,0.0,0.04,0.0,0.0,0.08,alexander christoph herzog,
+CPSC,2070,1.0,Discrete Structures,0.34,0.29,0.19,0.05,0.06,0.0,0.0,0.06,larry hodges,
+CPSC,2070,2.0,Discrete Structures,0.53,0.24,0.18,0.03,0.03,0.0,0.0,0.0,kai liu,
+CPSC,2120,1.0,Algs/Data Structures,0.38,0.28,0.2,0.04,0.06,0.0,0.0,0.04,nicolas benjamin widman,
+CPSC,2120,2.0,Algs/Data Structures,0.36,0.28,0.24,0.0,0.08,0.0,0.0,0.04,nicolas benjamin widman,
+CPSC,2120,3.0,Algs/Data Structures,0.59,0.19,0.19,0.0,0.0,0.0,0.0,0.04,brian christopher dean,
+CPSC,2120,4.0,Algs/Data Structures,0.38,0.19,0.29,0.0,0.14,0.0,0.0,0.0,brian christopher dean,
+CPSC,2150,1.0,Software Dev Foundations,0.32,0.35,0.21,0.05,0.03,0.0,0.0,0.03,kevin anton plis,
+CPSC,2150,2.0,Software Dev Foundations,0.24,0.32,0.22,0.02,0.08,0.0,0.0,0.12,kevin anton plis,
+CPSC,2200,1.0,Problem Solving w/ Office Apps,0.33,0.37,0.13,0.15,0.0,0.0,0.0,0.02,kevin anton plis,
+CPSC,2310,1.0,Intro Computer Org,0.6,0.33,0.05,0.0,0.0,0.0,0.0,0.02,nicolas benjamin widman,
+CPSC,2310,2.0,Intro Computer Org,0.53,0.18,0.16,0.05,0.05,0.0,0.0,0.02,nicolas benjamin widman,
+CPSC,2810,3.0,Selected Topics: Cyberdef Trai,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,svetlana drachova,
+CPSC,2910,1.0,Prof Issues I,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,yvon feaster,
+CPSC,2910,2.0,Prof Issues I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,yvon feaster,
+CPSC,2910,3.0,Prof Issues I,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,yvon feaster,
+CPSC,2910,4.0,Prof Issues I,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,5.0,Prof Issues I,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,6.0,Prof Issues I,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2920,1.0,"Computing, Ethics & Society",0.79,0.13,0.05,0.0,0.03,0.0,0.0,0.0,julian langston brinkley,
+CPSC,3220,1.0,Intro to Operating Systems,0.08,0.35,0.22,0.03,0.11,0.0,0.0,0.22,pradip srimani,
+CPSC,3220,2.0,Intro to Operating Systems,0.18,0.27,0.36,0.15,0.03,0.0,0.0,0.0,mark smotherman,
+CPSC,3300,1.0,Computer Systems Org,0.38,0.42,0.17,0.02,0.0,0.0,0.0,0.02,tyler allen,
+CPSC,3500,1.0,Foundations of Computer Sci,0.18,0.2,0.38,0.12,0.04,0.0,0.0,0.08,ilya mark safro,
+CPSC,3520,1.0,Programming Systems,0.38,0.34,0.14,0.02,0.08,0.0,0.0,0.05,robert schalkoff,
+CPSC,3600,1.0,Network Programming,0.53,0.15,0.28,0.03,0.03,0.0,0.0,0.0,andrew robb,
+CPSC,3600,2.0,Network Programming,0.55,0.14,0.21,0.05,0.02,0.0,0.0,0.02,andrew robb,
+CPSC,3600,3.0,Network Programming,0.47,0.26,0.11,0.0,0.08,0.0,0.0,0.08,jason anderson,
+CPSC,3720,1.0,Software Engineering,0.31,0.41,0.23,0.0,0.0,0.0,0.0,0.05,eileen theresa kraemer,
+CPSC,3720,2.0,Software Engineering,0.23,0.56,0.16,0.0,0.04,0.0,0.0,0.02,yu-shan sun,
+CPSC,4040,1.0,Cmptr Graphics Image,0.56,0.28,0.0,0.0,0.0,0.0,0.0,0.16,ioannis karamouzas,
+CPSC,4050,1.0,Computer Graphics,0.52,0.19,0.05,0.0,0.05,0.0,0.0,0.19,victor zordan,
+CPSC,4110,1.0,Virtual Reality Systems,0.46,0.43,0.05,0.0,0.03,0.0,0.0,0.03,sabarish venkat babu,
+CPSC,4120,1.0,Eye Tracking Methodology,0.43,0.46,0.07,0.0,0.0,0.0,0.0,0.04,andrew duchowski,
+CPSC,4140,1.0,Human and Computer Interaction,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,nathaniel mcneese,
+CPSC,4150,1.0,Mobile Device Software Devel,0.23,0.23,0.35,0.08,0.0,0.0,0.0,0.12,christopher plaue,
+CPSC,4200,1.0,Computer Security Principles,0.67,0.3,0.03,0.0,0.0,0.0,0.0,0.0,long cheng,
+CPSC,4240,1.0,System Admin and Security,0.1,0.6,0.2,0.1,0.0,0.0,0.0,0.0,svetlana drachova,
+CPSC,4300,1.0,Applied Data Science,0.36,0.43,0.15,0.02,0.02,0.0,0.0,0.02,alexander christoph herzog,
+CPSC,4620,1.0,Database Management Systems,0.12,0.38,0.12,0.12,0.0,0.0,0.0,0.27,pradip srimani,
+CPSC,4770,1.0,Distributed/Cluster Computing,0.39,0.33,0.11,0.06,0.06,0.0,0.0,0.06,shuangshuang jin,
+CPSC,4820,1.0,Special Topic: Web Programming,0.57,0.21,0.13,0.04,0.02,0.0,0.0,0.02,craig baker,
+CPSC,4820,2.0,Special Topics: Hands on ML,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,larry hodges,
+CPSC,4820,4.0,Spe Topic: AI,0.33,0.24,0.1,0.0,0.0,0.0,0.0,0.33,ioannis karamouzas,
+CPSC,4890,1.0,Programming Team Seminar,0.65,0.15,0.05,0.05,0.0,0.0,0.0,0.1,brian christopher dean,
+CPSC,4910,1.0,Professional Issues II,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,roger larry van scoy,
+CPSC,4910,2.0,Professional Issues II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alexander christoph herzog,
+CPSC,6040,1.0,Cptr Graphics Image,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,ioannis karamouzas,
+CPSC,6050,1.0,Computer Graphics,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,victor zordan,
+CPSC,6110,1.0,Virtual Reality Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venkat babu,
+CPSC,6150,1.0,Mobile Device Software Devel,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,christopher plaue,
+CPSC,6240,1.0,System Admin and Security,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,svetlana drachova,
+CPSC,6300,1.0,Applied Data Science,0.82,0.11,0.04,0.0,0.0,0.0,0.0,0.04,kai liu,
+CPSC,6300,2.0,Applied Data Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xizhou feng,
+CPSC,6620,1.0,Database Management Systems,0.5,0.33,0.08,0.0,0.0,0.0,0.0,0.08,pradip srimani,
+CPSC,6820,4.0,Spec Top: AI,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,ioannis karamouzas,
+CPSC,8040,1.0,Data Visualization,0.74,0.2,0.0,0.0,0.03,0.0,0.0,0.03,federico iuricich,
+CPSC,8100,1.0,Intro Artif Intell,0.43,0.43,0.02,0.0,0.0,0.0,0.0,0.11,feng luo,
+CPSC,8170,1.0,Physically Based Animation,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,jerry tessendorf,
+CPSC,8200,1.0,Parallel Architechture,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,rong ge,
+CPSC,8380,1.0,Adv Data Structures,0.25,0.5,0.0,0.0,0.13,0.0,0.0,0.13,sandra hedetniemi,
+CPSC,8480,1.0,Network Science,0.2,0.4,0.25,0.0,0.1,0.0,0.0,0.05,ilya mark safro,
+CPSC,8520,1.0,Internetworking,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james martin,
+CPSC,8580,1.0,Security in Emerging Systems,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,hongxin hu,
+CPSC,8580,843.0,Security in Emerging Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,
+CPSC,8620,1.0,Database Mngmt System Design,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,nina christine hubig,
+CPSC,8710,1.0,Found. of Software Engineering,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,murali sitaraman,
+CSM,1000,1.0,Intro to Construct,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,harnish sharma,
+CSM,2010,1.0,Structures I,0.35,0.43,0.08,0.03,0.0,0.0,0.0,0.11,shima clarke,
+CSM,2020,1.0,Structures II,0.77,0.14,0.03,0.03,0.0,0.0,0.0,0.03,nathaniel jackson,
+CSM,2030,1.0,Mats & Meth of Const,0.33,0.35,0.28,0.0,0.0,0.0,0.0,0.05,jason lucas,
+CSM,2040,1.0,Cont Documents,0.41,0.48,0.07,0.03,0.0,0.0,0.0,0.0,robert dawson coffey,
+CSM,2050,1.0,Mats & Methods II,0.09,0.69,0.23,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,
+CSM,3040,1.0,Envir Systems I,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,joseph michael burgett,
+CSM,3050,1.0,Envir Systems II,0.63,0.11,0.21,0.05,0.0,0.0,0.0,0.0,joseph michael burgett,
+CSM,3060,1.0,Emerging Tech in Construction,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,harnish sharma,
+CSM,3070,1.0,Sustainable Construction,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,harnish sharma,
+CSM,3510,1.0,Construction Estimating,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,seyed ehsan mousavi rizi,
+CSM,3520,401.0,Const Scheduling,0.22,0.72,0.0,0.0,0.0,0.0,0.0,0.06,craig townsend,
+CSM,3530,1.0,Const Estimating II,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,seyed ehsan mousavi rizi,
+CSM,4110,1.0,Safety in Bldg Const,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,nicholas corley,
+CSM,4500,1.0,Construction Intern,0.16,0.43,0.37,0.03,0.0,0.0,0.0,0.0,nathaniel jackson,
+CSM,4530,1.0,Const Proj Mgmt,0.21,0.69,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4530,2.0,Const Proj Mgmt,0.43,0.4,0.17,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,4540,1.0,Const Capstone,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
+CSM,4610,1.0,Const Econ Seminar,0.66,0.31,0.0,0.0,0.0,0.0,0.0,0.03,catherine nove-josserand,
+CSM,4610,2.0,Const Econ Seminar,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,catherine nove-josserand,
+CSM,4980,2.0,Current Topics-NAHB Comp,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,8360,400.0,Managing Integr Proj Delivery,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,shima clarke,
+CSM,8650,1.0,Project Management,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8650,400.0,Project Management,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CU,1000,26.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,30.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,34.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,37.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
+CU,1000,51.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,
+CU,1000,52.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,
+CU,1010,1.0,Univ Success Skills,0.5,0.1,0.1,0.0,0.3,0.0,0.0,0.0,cynthia june smith,
+CU,1010,8.0,Univ Success Skills,0.5,0.06,0.11,0.0,0.11,0.0,0.0,0.22,catherine maroska neel,
+CU,1010,602.0,Univ Success Skills,0.62,0.15,0.15,0.0,0.0,0.0,0.0,0.08,valerie kay oonk,
+CU,1010,603.0,Univ Success Skills,0.56,0.23,0.1,0.03,0.08,0.0,0.0,0.0,elizabeth anne stephan,
+CU,1010,605.0,Univ Success Skills,0.43,0.24,0.24,0.0,0.1,0.0,0.0,0.0,matthew kent miller,
+CU,1010,606.0,Univ Success Skills,0.3,0.3,0.04,0.17,0.17,0.0,0.0,0.0,andrew isaac neptune,
+CU,1010,607.0,Univ Success Skills,0.46,0.27,0.14,0.05,0.05,0.0,0.0,0.03,elizabeth anne stephan,
+CVT,2260,1.0,Intro Cardiovas Sono,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,eric walker,
+DPA,3070,1.0,Method 3d Production,0.44,0.4,0.08,0.0,0.0,0.0,0.0,0.08,tommy van bui,
+DPA,4000,1.0,Tech Foundations I,0.07,0.29,0.14,0.0,0.07,0.0,0.0,0.43,jessica baron,
+DPA,4020,2.0,Visual Found of Digital Prod,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,anthony summey,
+DPA,4830,1.0,Spec Stud Top in DPA: Dig Scul,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,insun kwon,
+DPA,8070,1.0,3D Modeling and Animation,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,christina sophie joerg,
+DPA,8090,1.0,Rendering and Shading,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,daljit singh dhillon,
+ECAS,1990,101.0,CI LEAD Forward I,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,steve richard sanders,
+ECE,1990,13.0,CI: Future Engineers,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,melissa crawley smith,
+ECE,1990,14.0,CI: Robot Networks,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,yongqiang wang,
+ECE,2010,1.0,Logic and Computing Devices,0.23,0.28,0.24,0.08,0.08,0.0,0.0,0.08,william reid,
+ECE,2020,1.0,Electric Circuits I,0.2,0.35,0.27,0.08,0.04,0.0,0.0,0.06,william harrell,
+ECE,2070,1.0,Basic Electrical Engineering,0.21,0.22,0.26,0.12,0.07,0.0,0.0,0.12,william thomas kolodzey,
+ECE,2070,2.0,Basic Electrical Engineering,0.29,0.15,0.21,0.18,0.06,0.0,0.0,0.12,wesley green,
+ECE,2070,3.0,Basic Electrical Engineering,0.39,0.23,0.21,0.07,0.04,0.0,0.0,0.06,timothy anglea,
+ECE,2080,1.0,Basic Electrical Engr Lab,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
+ECE,2080,4.0,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2080,5.0,Basic Electrical Engr Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,apoorva deepak kapadia,
+ECE,2080,6.0,Basic Electrical Engr Lab,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2080,7.0,Basic Electrical Engr Lab,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deepak kapadia,
+ECE,2080,8.0,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
+ECE,2080,9.0,Basic Electrical Engr Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,apoorva deepak kapadia,
+ECE,2080,10.0,Basic Electrical Engr Lab,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,apoorva deepak kapadia,
+ECE,2080,12.0,Basic Electrical Engr Lab,0.79,0.0,0.0,0.0,0.21,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2080,14.0,Basic Electrical Engr Lab,0.71,0.12,0.0,0.0,0.0,0.0,0.0,0.18,apoorva deepak kapadia,
+ECE,2080,15.0,Basic Electrical Engr Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,apoorva deepak kapadia,
+ECE,2090,2.0,Logic & Computing Devices Lab,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,apoorva deepak kapadia,
+ECE,2090,3.0,Logic & Computing Devices Lab,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,
+ECE,2090,4.0,Logic & Computing Devices Lab,0.83,0.08,0.0,0.08,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2090,5.0,Logic & Computing Devices Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,
+ECE,2090,9.0,Logic & Computing Devices Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2090,11.0,Logic & Computing Devices Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva deepak kapadia,
+ECE,2090,13.0,Logic & Computing Devices Lab,0.67,0.0,0.0,0.0,0.08,0.0,0.0,0.25,apoorva deepak kapadia,
+ECE,2090,14.0,Logic & Computing Devices Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,
+ECE,2110,1.0,Elec Engr Lab I,0.8,0.1,0.05,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2110,2.0,Elec Engr Lab I,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
+ECE,2110,3.0,Elec Engr Lab I,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
+ECE,2110,5.0,Elec Engr Lab I,0.7,0.15,0.1,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2110,6.0,Elec Engr Lab I,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
+ECE,2110,8.0,Elec Engr Lab I,0.3,0.4,0.15,0.0,0.05,0.0,0.0,0.1,apoorva deepak kapadia,
+ECE,2110,10.0,Elec Engr Lab I,0.69,0.08,0.23,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2120,1.0,Electrical Engineering Lab II,0.81,0.0,0.0,0.0,0.06,0.0,0.0,0.13,apoorva deepak kapadia,
+ECE,2220,1.0,Syst Prog Concept,0.18,0.18,0.16,0.05,0.05,0.0,0.0,0.37,lu yu,
+ECE,2230,1.0,Comp Sys Eng,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,walter ligon,
+ECE,2620,1.0,Electric Circuits II,0.05,0.36,0.32,0.09,0.07,0.0,0.0,0.11,liang dong,
+ECE,2720,1.0,Comp Organization,0.02,0.27,0.5,0.14,0.05,0.0,0.0,0.02,william reid,
+ECE,2730,2.0,Computer Org Lab,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,2730,3.0,Computer Org Lab,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,3110,2.0,Electrical Engineering Lab III,0.69,0.13,0.0,0.0,0.13,0.0,0.0,0.06,apoorva deepak kapadia,
+ECE,3120,1.0,Electrical Engineering Lab IV,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
+ECE,3170,1.0,Rand Signal Analysis,0.22,0.28,0.34,0.1,0.04,0.0,0.0,0.01,stephen hubbard,
+ECE,3200,1.0,Electronics I,0.29,0.2,0.23,0.13,0.12,0.0,0.0,0.03,stephen hubbard,
+ECE,3200,2.0,Electronics I (HON),0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,stephen hubbard,True
+ECE,3210,1.0,Electronics II,0.22,0.27,0.39,0.12,0.0,0.0,0.0,0.0,stephen hubbard,
+ECE,3220,2.0,Intro Operating Sys,0.35,0.3,0.35,0.0,0.0,0.0,0.0,0.0,mark smotherman,
+ECE,3270,1.0,Dig Comp Design,0.16,0.3,0.27,0.18,0.05,0.0,0.0,0.05,melissa crawley smith,
+ECE,3300,1.0,Signals & Systems,0.23,0.19,0.27,0.15,0.11,0.0,0.0,0.05,carl baum,
+ECE,3300,2.0,Signals & Systems (HON),0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
+ECE,3520,1.0,Programming Systems,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,robert schalkoff,
+ECE,3600,1.0,Elect Power Engr,0.34,0.26,0.19,0.04,0.09,0.0,0.0,0.08,sukumar makarand brahma,
+ECE,3710,1.0,Microcontr Interface,0.55,0.31,0.08,0.04,0.0,0.0,0.0,0.01,william reid,
+ECE,3720,2.0,Micro Int Lab,0.33,0.33,0.08,0.08,0.08,0.0,0.0,0.08,apoorva deepak kapadia,
+ECE,3720,7.0,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
+ECE,3800,1.0,Electromagnetics,0.23,0.11,0.23,0.2,0.11,0.0,0.0,0.11,anthony martin,
+ECE,3810,1.0,Field Waves & Ckts,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,hai xiao,
+ECE,4090,1.0,Intr to Linear Control Systems,0.76,0.19,0.03,0.01,0.0,0.0,0.0,0.01,apoorva deepak kapadia,
+ECE,4180,1.0,Power Syst Analysis,0.33,0.25,0.08,0.08,0.08,0.0,0.0,0.17,ramtin hadidi,
+ECE,4270,1.0,Communication Systems,0.22,0.28,0.33,0.09,0.04,0.0,0.0,0.04,lu yu,
+ECE,4310,1.0,Intro to Computer Vision,0.56,0.32,0.08,0.04,0.0,0.0,0.0,0.0,adam hoover,
+ECE,4420,1.0,Knowledge Engineering,0.35,0.4,0.1,0.0,0.1,0.0,0.0,0.05,robert schalkoff,
+ECE,4490,1.0,Comp Ntwrk Security,0.65,0.26,0.0,0.0,0.04,0.0,0.0,0.04,lu yu,
+ECE,4610,1.0,Fundamentals of Solar Energy,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,
+ECE,4670,1.0,Intro to Dig Sig Pro,0.18,0.41,0.24,0.0,0.0,0.0,0.0,0.18,john gowdy,
+ECE,4730,1.0,Intro Parallel Sys,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,walter ligon,
+ECE,4950,1.0,Int Sys Design I,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,apoorva deepak kapadia,
+ECE,4960,1.0,Int Sys Design II,0.53,0.38,0.08,0.0,0.0,0.0,0.0,0.03,richard groff,
+ECE,6040,1.0,Semiconductor Devices,0.63,0.13,0.25,0.0,0.0,0.0,0.0,0.0,judson douglas ryckman,
+ECE,6310,1.0,Intro to Computer Vision,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,adam hoover,
+ECE,6420,1.0,Knowledge Engr,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,robert schalkoff,
+ECE,6490,843.0,Comp Ntwrk Security,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,lu yu,
+ECE,6590,1.0,Int Circ Design,0.43,0.29,0.0,0.0,0.0,0.0,0.0,0.29,yingjie lao,
+ECE,6610,843.0,Fundamentals of Solar Energy,0.2,0.6,0.0,0.0,0.0,0.0,0.0,0.2,rajendra singh,
+ECE,6670,1.0,Intro to Dig Sig Pro,0.2,0.4,0.2,0.0,0.0,0.0,0.0,0.2,john gowdy,
+ECE,6930,844.0,IntroPowerElecTechApps Charls,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,zheyu zhang,
+ECE,8010,1.0,Analysis of Lin Sys,0.43,0.29,0.0,0.0,0.07,0.0,0.0,0.21,richard groff,
+ECE,8040,1.0,Networked Dynamical Systems,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,
+ECE,8540,1.0,Analysis of Tracking Systems,0.61,0.36,0.0,0.0,0.04,0.0,0.0,0.0,adam hoover,
+ECON,2000,2.0,Economic Concepts,0.67,0.23,0.08,0.03,0.0,0.0,0.0,0.0,shubhashrita basu,
+ECON,2000,4.0,Economic Concepts,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,miren ivankovic,
+ECON,2000,5.0,Economic Concepts,0.41,0.35,0.06,0.06,0.06,0.0,0.0,0.06,shubhashrita basu,
+ECON,2110,1.0,Principles of Microeconomics,0.16,0.47,0.32,0.0,0.05,0.0,0.0,0.0,frederick andrew hanssen,
+ECON,2110,2.0,Principles of Microeconomics,0.16,0.42,0.26,0.11,0.0,0.0,0.0,0.05,frederick andrew hanssen,
+ECON,2110,3.0,Principles of Microeconomics,0.05,0.42,0.37,0.05,0.05,0.0,0.0,0.05,frederick andrew hanssen,
+ECON,2110,4.0,Principles of Microeconomics,0.11,0.26,0.53,0.0,0.05,0.0,0.0,0.05,frederick andrew hanssen,
+ECON,2110,5.0,Principles of Microeconomics,0.16,0.58,0.16,0.0,0.05,0.0,0.0,0.05,frederick andrew hanssen,
+ECON,2110,6.0,Principles of Microeconomics,0.24,0.35,0.18,0.06,0.0,0.0,0.0,0.18,frederick andrew hanssen,
+ECON,2110,7.0,Principles of Microeconomics,0.11,0.61,0.22,0.06,0.0,0.0,0.0,0.0,frederick andrew hanssen,
+ECON,2110,8.0,Principles of Microeconomics,0.11,0.42,0.21,0.16,0.0,0.0,0.0,0.11,frederick andrew hanssen,
+ECON,2110,9.0,Principles of Microeconomics,0.0,0.42,0.37,0.16,0.05,0.0,0.0,0.0,frederick andrew hanssen,
+ECON,2110,10.0,Principles of Microeconomics,0.0,0.47,0.42,0.05,0.0,0.0,0.0,0.05,frederick andrew hanssen,
+ECON,2110,11.0,Principles of Microeconomics,0.26,0.26,0.26,0.05,0.11,0.0,0.0,0.05,frederick andrew hanssen,
+ECON,2110,12.0,Principles of Microeconomics,0.11,0.39,0.28,0.11,0.0,0.0,0.0,0.11,frederick andrew hanssen,
+ECON,2110,13.0,Principles of Microeconomics,0.05,0.63,0.21,0.05,0.0,0.0,0.0,0.05,frederick andrew hanssen,
+ECON,2110,14.0,Principles of Microeconomics,0.0,0.5,0.33,0.06,0.06,0.0,0.0,0.06,frederick andrew hanssen,
+ECON,2110,15.0,Principles of Microeconomics,0.11,0.47,0.26,0.11,0.0,0.0,0.0,0.05,frederick andrew hanssen,
+ECON,2110,16.0,Principles of Microeconomics,0.11,0.53,0.37,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,
+ECON,2110,17.0,Principles of Microeconomics,0.21,0.53,0.26,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,
+ECON,2110,18.0,Principles of Microeconomics,0.11,0.17,0.5,0.06,0.06,0.0,0.0,0.11,frederick andrew hanssen,
+ECON,2110,19.0,Principles of Microeconomics,0.17,0.39,0.44,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,
+ECON,2110,20.0,Principles of Microeconomics,0.37,0.3,0.24,0.06,0.01,0.0,0.0,0.01,cory simpkins,
+ECON,2110,21.0,Principles of Microeconomics,0.19,0.37,0.27,0.05,0.06,0.0,0.0,0.06,shirong zhao,
+ECON,2110,23.0,Principles of Microeconomics,0.3,0.45,0.18,0.02,0.03,0.0,0.0,0.03,elijah neilson,
+ECON,2110,24.0,Principles of Microeconomics,0.16,0.56,0.19,0.06,0.0,0.0,0.0,0.02,michael makowsky,
+ECON,2110,25.0,Principles of Microeconomics,0.38,0.4,0.2,0.03,0.0,0.0,0.0,0.0,seyedmajid hashemi,
+ECON,2110,26.0,Principles of Microeconomics,0.27,0.44,0.18,0.02,0.0,0.0,0.0,0.09,khundkar arefin kamal,
+ECON,2110,31.0,Principles of Microeconomics,0.25,0.47,0.18,0.03,0.03,0.0,0.0,0.05,shannon graham,
+ECON,2110,32.0,Principles of Microeconomics,0.19,0.52,0.3,0.0,0.0,0.0,0.0,0.0,haibin jiang,
+ECON,2110,33.0,Principles of Microeconomics,0.51,0.36,0.05,0.0,0.05,0.0,0.0,0.03,seyedmajid hashemi,
+ECON,2110,34.0,Principles of Microecon (HON),0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,charles thomas,True
+ECON,2110,35.0,Principles of Microeconomics,0.55,0.33,0.05,0.08,0.0,0.0,0.0,0.0,shilpi mukherjee,
+ECON,2110,36.0,Principles of Microeconomics,0.39,0.33,0.2,0.04,0.0,0.0,0.0,0.04,sarah louise wilson,
+ECON,2110,38.0,Principles of Microeconomics,0.31,0.48,0.17,0.0,0.0,0.0,0.0,0.05,elijah neilson,
+ECON,2110,40.0,Principles of Microeconomics,0.27,0.27,0.27,0.07,0.1,0.0,0.0,0.03,cory simpkins,
+ECON,2110,41.0,Principles of Microeconomics,0.29,0.26,0.21,0.17,0.02,0.0,0.0,0.05,devon merritt haskell gorry,
+ECON,2120,1.0,Principles of Macroeconomics,0.19,0.36,0.2,0.11,0.09,0.0,0.0,0.06,aspen rachel underwood,
+ECON,2120,2.0,Principles of Macroeconomics,0.41,0.3,0.26,0.0,0.0,0.0,0.0,0.02,kenneth whaley,
+ECON,2120,3.0,Principles of Macroeconomics,0.78,0.15,0.05,0.0,0.02,0.0,0.0,0.0,tyler francis,
+ECON,2120,4.0,Principles of Macroeconomics,0.3,0.23,0.28,0.13,0.06,0.0,0.0,0.0,aspen rachel underwood,
+ECON,2120,5.0,Principles of Macroeconomics,0.31,0.36,0.28,0.03,0.0,0.0,0.0,0.03,matthew lee cronin,
+ECON,2120,6.0,Principles of Macroeconomics,0.33,0.48,0.2,0.0,0.0,0.0,0.0,0.0,matthew lee cronin,
+ECON,2120,7.0,Principles of Macroeconomics,0.26,0.44,0.28,0.0,0.03,0.0,0.0,0.0,kenneth whaley,
+ECON,2120,8.0,Principles of Macroeconomics,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.03,jeremy choquette,
+ECON,2120,9.0,Principles of Macroeconomics,0.81,0.17,0.02,0.0,0.0,0.0,0.0,0.0,tyler francis,
+ECON,2120,10.0,Principles of Macroeconomics,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,jeremy choquette,
+ECON,3020,1.0,Money and Banking,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.03,adam markley witham,
+ECON,3060,1.0,Managerial Economics,0.16,0.32,0.22,0.19,0.08,0.0,0.0,0.03,benjamin james posmanick,
+ECON,3100,1.0,International Econ,0.17,0.53,0.24,0.01,0.03,0.0,0.0,0.01,scott baier,
+ECON,3140,1.0,Intermediate Micro,0.18,0.26,0.24,0.1,0.08,0.0,0.0,0.14,patrick warren,
+ECON,3140,2.0,Intermediate Micro,0.2,0.41,0.26,0.08,0.03,0.0,0.0,0.02,molly espey,
+ECON,3140,3.0,Intermediate Micro,0.44,0.27,0.13,0.04,0.04,0.0,0.0,0.07,yichen christy zhou,
+ECON,3140,5.0,Intermediate Micro,0.47,0.26,0.11,0.03,0.03,0.0,0.0,0.11,yichen christy zhou,
+ECON,3150,1.0,Intermediate Macro,0.07,0.23,0.39,0.14,0.11,0.0,0.0,0.07,michal maria jerzmanowski,
+ECON,3150,2.0,Intermediate Macro,0.21,0.26,0.38,0.12,0.0,0.0,0.0,0.03,michal maria jerzmanowski,
+ECON,3190,1.0,Environmental Econ,0.35,0.41,0.16,0.05,0.0,0.0,0.0,0.03,molly espey,
+ECON,3600,1.0,Public Choice,0.29,0.26,0.18,0.11,0.08,0.0,0.0,0.08,michael makowsky,
+ECON,4010,1.0,Labor Mkt Analysis,0.29,0.41,0.24,0.0,0.06,0.0,0.0,0.0,chungsang lam,
+ECON,4020,1.0,Law and Economics,0.21,0.45,0.21,0.07,0.02,0.0,0.0,0.02,howard nelson bodenhorn,
+ECON,4040,1.0,Comp Econ Systems,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,daria litsukova-bokar,
+ECON,4050,5.0,Intro to Econometric,0.18,0.29,0.35,0.14,0.03,0.0,0.0,0.0,scott barkowski,
+ECON,4100,1.0,Economic Development,0.53,0.32,0.05,0.05,0.0,0.0,0.0,0.05,robert tamura,
+ECON,4110,2.0,Econ of Education,0.75,0.18,0.0,0.0,0.04,0.0,0.0,0.04,jorge luis garcia  menendez,
+ECON,4120,1.0,International Micro,0.46,0.38,0.08,0.08,0.0,0.0,0.0,0.0,cheng chen,
+ECON,4230,1.0,Economics of Health,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0,devon merritt haskell gorry,
+ECON,4240,1.0,Organization of Ind,0.53,0.24,0.18,0.06,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,4240,2.0,Organization of Ind,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,matthew lewis,
+ECON,4280,1.0,Cost-Benefit Anlysis,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,robert kenneth fleck,
+ECON,4280,2.0,Cost-Benefit Anlysis,0.45,0.25,0.25,0.05,0.0,0.0,0.0,0.0,robert kenneth fleck,
+ECON,4980,1.0,Selected Topics in Economics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,howard nelson bodenhorn,
+ECON,4980,3.0,History of Economic Thought,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
+ECON,4980,3.0,History of Economic Thought,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
+ECON,4980,4.0,Sel Topic - Why Business?,0.34,0.52,0.14,0.0,0.0,0.0,0.0,0.0,lawrence reed watson,
+ECON,4980,5.0,Cryptocurrency and  Blockchain,0.37,0.42,0.16,0.0,0.0,0.0,0.0,0.05,gerald dwyer,
+ECON,4980,6.0,Sel Topic - Why Business?,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
+ECON,4980,6.0,Sel Topic - Why Business?,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
+ECON,6050,5.0,Intro to Econometric,0.36,0.27,0.36,0.0,0.0,0.0,0.0,0.0,scott barkowski,
+ECON,8010,1.0,Microeconomic Theory,0.22,0.33,0.33,0.0,0.0,0.0,0.0,0.11,william dougan,
+ECON,8040,1.0,Applied Math Econ,0.36,0.59,0.05,0.0,0.0,0.0,0.0,0.0,curtis simon,
+ECON,8060,1.0,Econometrics I,0.33,0.33,0.25,0.0,0.08,0.0,0.0,0.0,paul wayne wilson,
+ECON,8080,1.0,Econometrics III,0.33,0.33,0.17,0.0,0.17,0.0,0.0,0.0,paul wayne wilson,
+ECON,8230,1.0,Microecon Pub Pol,0.0,0.45,0.36,0.0,0.09,0.0,0.0,0.09,scott templeton,
+ECON,8260,1.0,Econ Theory of Govt Regulation,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,thomas winslow hazlett,
+ECON,9010,1.0,Price Theory,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,charles thomas,
+ED,1050,2.0,Orientation to Education,0.82,0.14,0.0,0.05,0.0,0.0,0.0,0.0,stacy jones,
+ED,1050,3.0,Orientation to Education,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,stacy jones,
+ED,1050,4.0,Orientation to Education,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,stacy jones,
+ED,1050,5.0,Orientation to Education,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,hilary tanck,
+ED,1050,6.0,Orientation to Education,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,hilary tanck,
+ED,1970,1.0,CI-CONNECTIONS Stud Developmnt,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,2.0,CI-CONNECTIONS Stud Developmnt,0.94,0.0,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,3.0,CI-CONNECTIONS Stud Developmnt,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,5.0,CI-CONNECTIONS Stud Developmnt,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,1970,6.0,CI-CONNECTIONS Stud Developmnt,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,3010,1.0,Principles of American Educat,0.87,0.0,0.0,0.0,0.04,0.0,0.0,0.09,beatrice naff bailey,
+ED,3010,3.0,Principles of American Educat,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,beatrice naff bailey,
+ED,3010,4.0,Principles of American Educat,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,nafees mohammad khan,
+EDC,8100,400.0,Advising and Supporting,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,mary dolores katalinic,
+EDEC,3360,1.0,Play/Soc Dev-Infts/Young Child,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,marjorie deanna ramey,
+EDEC,4400,1.0,Early Childhood Engl Lang Art,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
+EDEL,3100,3.0,Arts in Ele School,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kathy cochran,
+EDEL,3210,2.0,Pe for the Elem Tchr,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,3210,3.0,Pe for the Elem Tchr,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,deborah smith,
+EDEL,4510,1.0,Elem Methods in Science Tchg,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,laura cohen eicher,
+EDEL,4870,1.0,Ele Meth Soc Studies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+EDF,3020,1.0,Educational Psychology,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,meihua qian,
+EDF,3340,1.0,Child Growth and Development,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,amanda elizabeth bennett,
+EDF,3340,3.0,Child Growth and Development,0.74,0.23,0.0,0.03,0.0,0.0,0.0,0.0,faiza marghoob jamil,
+EDF,3350,1.0,Adolescent Growth & Develop,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
+EDF,4800,1.0,Digital Media & Learning,0.63,0.25,0.08,0.0,0.04,0.0,0.0,0.0,ryan visser,
+EDF,4800,2.0,Digital Media & Learning,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,golnaz arastoopour irgens,
+EDF,4800,3.0,Digital Media & Learning,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,golnaz arastoopour irgens,
+EDF,4800,300.0,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,georgia lousie mckown,
+EDF,4800,301.0,Digital Media & Learning,0.69,0.17,0.07,0.03,0.03,0.0,0.0,0.0,ryan visser,
+EDF,8710,400.0,Cultural Diversity in Educatio,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,reginald wilkerson,
+EDF,9270,1.0,Quant Rsrch & Stats for Ed,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,christy jenkins brown,
+EDF,9270,2.0,Quant Rsrch & Stats for Ed,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,christy jenkins brown,
+EDF,9780,1.0,Multivar Ed Research,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,matthew james madison,
+EDHD,3110,3.0,CI- Children's Lit. Newsletter,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDHD,3110,4.0,CI- Read/Review Child/YA Lit.,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDL,7050,400.0,Contemp Iss in School Leadshp,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,danielle hall,
+EDL,7250,501.0,Law/Ethics for School Leaders,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,betty thompson bagley,
+EDL,9770,2.0,Div Issues in Hi Ed,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,william mccoy,
+EDLT,4600,1.0,Found of Read: Assess & Instr,0.39,0.39,0.17,0.04,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDLT,4600,3.0,Found of Read: Assess & Instr,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,lisa denise aker,
+EDLT,4600,4.0,Found of Read: Assess & Instr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lisa denise aker,
+EDLT,4610,1.0,Content Area Read/Writing,0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,4610,2.0,Content Area Read/Writing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,4800,301.0,Found in Adolescent Literacy,0.79,0.14,0.04,0.04,0.0,0.0,0.0,0.0,phillip michael wilder,
+EDLT,4980,1.0,Cont Area Read/Write Secondary,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,arsenio frankie silva,
+EDLT,8100,300.0,Foundations: Reading & Writing,0.74,0.17,0.0,0.0,0.0,0.0,0.0,0.09,emily smothers howell,
+EDLT,8110,300.0,Adv Children's & Yng Adult Lit,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,susan king fullerton,
+EDLT,8110,301.0,Adv Children's & Yng Adult Lit,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,jonda cecole mcnair,
+EDLT,8150,300.0,Guided Reading & Guided Writng,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,pamela dunston,
+EDLT,8220,500.0,Strategies for Teaching ESOL,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,mikel walker cole,
+EDLT,8270,300.0,Content Area Rdg/Wtg-MS & HS,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,emily smothers howell,
+EDLT,8400,502.0,Early Literacy Assessment I,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,antoinette dibellonia,
+EDLT,8400,504.0,Early Literacy Assessment I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,barbara fewell,
+EDLT,8400,508.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jamie felder white,
+EDLT,8400,509.0,Early Literacy Assessment I,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,susanne atkinson elvington,
+EDSA,3900,1.0,Skills for Student Leaders,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDSA,3900,4.0,Skills for Student Leaders,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDSA,3900,6.0,Skills for Student Leaders,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+EDSA,3990,1.0,Creative Inq in Counselor Ed,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,jacob frankovich,
+EDSA,8040,1.0,Theories Student Dev in Hi Ed,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,
+EDSA,8040,2.0,Theories Student Dev in Hi Ed,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,
+EDSA,8100,1.0,Advising and Supporting,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,
+EDSC,2260,1.0,Pr Apprch to Sec Alg,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,stacy megan che,
+EDSC,3270,1.0,Practicum Sec Sci,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,christopher david white,
+EDSC,4240,1.0,Tchng Sec English,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,mary-celeste schreuder,
+EDSC,4280,1.0,Tchng Secondary Social Studies,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kristen earnise duncan,
+EDSP,3700,1.0,Intro to Special Education,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,sharon walters,
+EDSP,3700,2.0,Intro to Special Education,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,friggita johnson,
+EDSP,3700,4.0,Intro to Special Education,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,wendell kent parker,
+EDSP,3720,1.0,Char & Instr Individ with LD,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,catherine aurentz griffith,
+EDSP,3740,1.0,Char & Strat Emot/Behav Disord,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shanna eisner hirsch,
+EDSP,3750,1.0,Early Intervention Spec Needs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
+EDSP,4920,1.0,Math Inst Ind W/Dis,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,
+EDSP,4930,1.0,Clsrm/Beh Mgmt Sp Ed,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,joseph benedict ryan,
+EDSP,4940,1.0,Tchg Rdg Mild Dis,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
+EDSP,8530,400.0,Legal/Pol Issu Sp Ed,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
+EES,2010,1.0,Environ Engr Fundamentals I,0.34,0.26,0.24,0.08,0.05,0.0,0.0,0.03,david freedman,
+EES,3030,1.0,Water Treatment Systems,0.53,0.27,0.17,0.0,0.0,0.0,0.0,0.03,david allen ladner,
+EES,3040,1.0,Wastewater Treatment Systems,0.41,0.41,0.17,0.0,0.0,0.0,0.0,0.0,sudeep popat,
+EES,3050,1.0,Water/Wastewater Treatment Lab,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,3050,2.0,Water/Wastewater Treatment Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,sudeep popat,
+EES,4010,1.0,Environmental Engr,0.52,0.35,0.11,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,
+EES,4010,2.0,Environmental Engr,0.28,0.45,0.14,0.07,0.07,0.0,0.0,0.0,mark schlautman,
+EES,4090,1.0,Intro to Nuc Engr & Radiol Sci,0.29,0.29,0.07,0.14,0.0,0.0,0.0,0.21,timothy devol,
+EES,4300,1.0,Air Pollution Engineering,0.3,0.33,0.27,0.07,0.0,0.0,0.0,0.03,andrew richard metcalf,
+EES,4800,1.0,Environmental Risk Assessment,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,nicole elizabeth martinez,
+EES,4840,1.0,Solid Waste Mgt,0.29,0.5,0.18,0.0,0.0,0.0,0.0,0.03,ezra lucas hoyt cates,
+EES,4860,1.0,Environmental Sustainability,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,michael carbajales-dale,
+EES,4860,2.0,Environmental Sustainability,0.5,0.33,0.0,0.0,0.08,0.0,0.0,0.08,michael carbajales-dale,
+EES,4900,15.0,CI: From Drones to 3D Printing,0.75,0.13,0.0,0.13,0.0,0.0,0.0,0.0,blake andrew lytle,
+EES,6860,1.0,Environmental Sustainability,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michael carbajales-dale,
+EES,8020,1.0,Environ Eng Prin,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,8430,1.0,Environmental Chem,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,
+EES,8510,1.0,Biol Prin Envir Engr,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,kevin thomas finneran,
+ELE,3010,1.0,Entrepreneurial Foundations,0.41,0.29,0.29,0.02,0.0,0.0,0.0,0.0,ashley williams parnell,
+ELE,3010,2.0,Entrepreneurial Foundations,0.16,0.43,0.39,0.0,0.02,0.0,0.0,0.0,ashley williams parnell,
+ELE,3010,3.0,Entrepreneurial Foundations,0.38,0.54,0.05,0.0,0.03,0.0,0.0,0.0,christina kyprianou,
+ELE,3010,4.0,Entrepreneurial Foundations,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
+ELE,3020,3.0,Entrepreneurial Resource Acqu,0.38,0.49,0.14,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,
+ELE,3020,4.0,Entrepreneurial Resource Acqu,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,
+ELE,4020,1.0,Venture Creation,0.35,0.54,0.08,0.0,0.03,0.0,0.0,0.0,william frank dinardo,
+ELE,4030,1.0,Venture Growth,0.59,0.32,0.08,0.0,0.0,0.0,0.0,0.0,james keith hudgins,
+ELE,4990,2.0,Venture Counsulting,0.28,0.63,0.1,0.0,0.0,0.0,0.0,0.0,william frank dinardo,
+ENGL,1030,2.0,Composition and Rhetoric,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,robert andrew welborn,
+ENGL,1030,3.0,Composition and Rhetoric,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,
+ENGL,1030,7.0,Composition and Rhetoric,0.16,0.42,0.16,0.11,0.11,0.0,0.0,0.05,chelsea marie clarey,
+ENGL,1030,10.0,Composition and Rhetoric,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,chelsea marie clarey,
+ENGL,1030,11.0,Composition and Rhetoric,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,caitlin grace watt,
+ENGL,1030,12.0,Composition and Rhetoric,0.41,0.41,0.12,0.0,0.0,0.0,0.0,0.06,tareva leselle johnson,
+ENGL,1030,13.0,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,caitlin grace watt,
+ENGL,1030,14.0,Composition and Rhetoric,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,tareva leselle johnson,
+ENGL,1030,15.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,emma jayne stanley,
+ENGL,1030,16.0,Composition and Rhetoric,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,anna lia  johnson,
+ENGL,1030,18.0,Composition and Rhetoric,0.74,0.16,0.0,0.0,0.11,0.0,0.0,0.0,allen swords,
+ENGL,1030,19.0,Composition and Rhetoric,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,1030,20.0,Composition and Rhetoric,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,anna lia  johnson,
+ENGL,1030,21.0,Composition and Rhetoric,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,mary catherine nestor,
+ENGL,1030,22.0,Composition and Rhetoric,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,mary catherine nestor,
+ENGL,1030,23.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,lindsey henley kurz,
+ENGL,1030,24.0,Composition and Rhetoric,0.63,0.16,0.0,0.0,0.21,0.0,0.0,0.0,sarah elizabeth richardson,
+ENGL,1030,25.0,Composition and Rhetoric,0.42,0.47,0.0,0.0,0.11,0.0,0.0,0.0,john benjamin fuqua,
+ENGL,1030,26.0,Composition and Rhetoric,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,kimberly jenerette,
+ENGL,1030,27.0,Composition and Rhetoric,0.37,0.42,0.05,0.05,0.11,0.0,0.0,0.0,kimberly jenerette,
+ENGL,1030,28.0,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,hannah taylor,
+ENGL,1030,29.0,Composition and Rhetoric,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,hannah pittman godwin,
+ENGL,1030,30.0,Composition and Rhetoric,0.42,0.42,0.11,0.0,0.05,0.0,0.0,0.0,andrew mathas,
+ENGL,1030,31.0,Composition and Rhetoric,0.76,0.12,0.06,0.0,0.06,0.0,0.0,0.0,joelma soares-sambdman,
+ENGL,1030,33.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,helen wesley kapp,
+ENGL,1030,34.0,Composition and Rhetoric,0.39,0.44,0.06,0.0,0.11,0.0,0.0,0.0,john benjamin fuqua,
+ENGL,1030,35.0,Composition and Rhetoric,0.47,0.42,0.0,0.05,0.0,0.0,0.0,0.05,hannah pittman godwin,
+ENGL,1030,36.0,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,hannah taylor,
+ENGL,1030,37.0,Composition and Rhetoric,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,la'cresha ulon green,
+ENGL,1030,41.0,Composition and Rhetoric,0.74,0.11,0.0,0.0,0.11,0.0,0.0,0.05,cody hunter,
+ENGL,1030,42.0,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,cody hunter,
+ENGL,1030,43.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kaitlyn samons,
+ENGL,1030,45.0,Composition and Rhetoric,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jacob danial richter,
+ENGL,1030,46.0,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,jacob danial richter,
+ENGL,1030,49.0,Composition and Rhetoric,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,nicholas rader,
+ENGL,1030,50.0,Composition and Rhetoric,0.47,0.47,0.0,0.05,0.0,0.0,0.0,0.0,nicholas rader,
+ENGL,1030,51.0,Composition and Rhetoric,0.42,0.32,0.11,0.05,0.05,0.0,0.0,0.05,jennie elizabeth wakefield,
+ENGL,1030,52.0,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jennie elizabeth wakefield,
+ENGL,1030,53.0,Composition and Rhetoric,0.22,0.5,0.22,0.0,0.06,0.0,0.0,0.0,gregory luke chwala,
+ENGL,1030,54.0,Composition and Rhetoric,0.57,0.36,0.0,0.0,0.07,0.0,0.0,0.0,sethunya mokoko gall,
+ENGL,1030,55.0,Composition and Rhetoric,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,jennie elizabeth wakefield,
+ENGL,1030,56.0,Composition and Rhetoric,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,sethunya mokoko gall,
+ENGL,1030,57.0,Composition and Rhetoric,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,sarah watkins,
+ENGL,1030,58.0,Composition and Rhetoric,0.79,0.05,0.05,0.05,0.05,0.0,0.0,0.0,kailan smith sindelar,
+ENGL,1030,60.0,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kailan smith sindelar,
+ENGL,1030,61.0,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,hwi eun hur,
+ENGL,1030,64.0,Composition and Rhetoric,0.73,0.13,0.07,0.0,0.0,0.0,0.0,0.07,hwi eun hur,
+ENGL,1030,65.0,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kelley melissa gillis,
+ENGL,1030,67.0,Composition and Rhetoric,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,kelley melissa gillis,
+ENGL,1030,68.0,Composition and Rhetoric,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,juliann teichert,
+ENGL,1030,69.0,Composition and Rhetoric,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,juliann teichert,
+ENGL,1030,76.0,Composition and Rhetoric,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,mary adams,
+ENGL,1030,77.0,Composition and Rhetoric,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,
+ENGL,1030,78.0,Composition and Rhetoric,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,
+ENGL,1030,82.0,Composition and Rhetoric,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,
+ENGL,1030,83.0,Composition and Rhetoric,0.67,0.17,0.0,0.06,0.06,0.0,0.0,0.06,melissa dugan,
+ENGL,1030,84.0,Composition and Rhetoric,0.65,0.18,0.06,0.0,0.06,0.0,0.0,0.06,bree laran beal,
+ENGL,1030,85.0,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,joelma soares-sambdman,
+ENGL,1030,101.0,Composition and Rhetoric (HON),0.78,0.11,0.0,0.11,0.0,0.0,0.0,0.0,chelsea jeanine murdock,True
+ENGL,2120,1.0,World Literature,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
+ENGL,2120,2.0,World Literature,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,kenneth michael tuite,
+ENGL,2120,3.0,World Literature,0.47,0.32,0.0,0.0,0.05,0.0,0.0,0.16,bree laran beal,
+ENGL,2120,4.0,World Literature,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sarah elissa matalone,
+ENGL,2120,5.0,World Literature,0.37,0.32,0.21,0.0,0.0,0.0,0.0,0.11,andrew mathas,
+ENGL,2120,6.0,World Literature,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,david charles foltz,
+ENGL,2120,7.0,World Literature,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,david charles foltz,
+ENGL,2120,8.0,World Literature,0.47,0.21,0.21,0.0,0.0,0.0,0.0,0.11,david charles foltz,
+ENGL,2120,9.0,World Literature,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,sarah elissa matalone,
+ENGL,2120,10.0,World Literature,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,sarah elissa matalone,
+ENGL,2120,11.0,World Literature,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,elizabeth anderson stansell,
+ENGL,2120,12.0,World Literature,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,
+ENGL,2120,13.0,World Literature,0.5,0.31,0.06,0.0,0.06,0.0,0.0,0.06,hannah pittman godwin,
+ENGL,2120,14.0,World Literature,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,
+ENGL,2120,16.0,World Literature,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,
+ENGL,2120,17.0,World Literature,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,bree laran beal,
+ENGL,2120,18.0,World Literature,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,john benjamin fuqua,
+ENGL,2120,19.0,World Literature,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,
+ENGL,2120,20.0,World Literature,0.5,0.22,0.22,0.0,0.06,0.0,0.0,0.0,elizabeth anderson stansell,
+ENGL,2120,21.0,World Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
+ENGL,2120,22.0,World Literature,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,
+ENGL,2120,23.0,World Literature,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,
+ENGL,2120,24.0,World Literature,0.74,0.11,0.11,0.05,0.0,0.0,0.0,0.0,ingrid anna pierce,
+ENGL,2120,25.0,World Literature,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,ingrid anna pierce,
+ENGL,2120,26.0,World Literature,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,bree laran beal,
+ENGL,2120,27.0,World Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,hannah pittman godwin,
+ENGL,2120,28.0,World Literature,0.47,0.26,0.16,0.0,0.11,0.0,0.0,0.0,andrew mathas,
+ENGL,2120,29.0,World Literature,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,2120,30.0,World Literature,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,john benjamin fuqua,
+ENGL,2120,400.0,World Literature,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth anderson stansell,
+ENGL,2120,401.0,World Literature,0.37,0.37,0.16,0.0,0.0,0.0,0.0,0.11,karen kettnich,
+ENGL,2120,402.0,World Literature,0.5,0.17,0.17,0.0,0.0,0.0,0.0,0.17,karen kettnich,
+ENGL,2120,403.0,World Literature,0.21,0.29,0.07,0.07,0.07,0.0,0.0,0.29,sarah elissa matalone,
+ENGL,2130,2.0,British Literature,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,gregory luke chwala,
+ENGL,2130,3.0,British Literature,0.29,0.41,0.24,0.06,0.0,0.0,0.0,0.0,gregory luke chwala,
+ENGL,2130,4.0,British Literature,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,gregory luke chwala,
+ENGL,2130,5.0,British Literature,0.47,0.21,0.16,0.05,0.05,0.0,0.0,0.05,henna marian messina,
+ENGL,2130,7.0,British Literature,0.47,0.26,0.16,0.0,0.0,0.0,0.0,0.11,christopher benson,
+ENGL,2130,8.0,British Literature,0.38,0.31,0.13,0.06,0.06,0.0,0.0,0.06,henna marian messina,
+ENGL,2130,9.0,British Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,2130,11.0,British Literature,0.58,0.26,0.05,0.05,0.05,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,100.0,British Literature (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john morgenstern,True
+ENGL,2130,400.0,British Literature,0.32,0.32,0.16,0.11,0.05,0.0,0.0,0.05,kristen louise aldebol-hazle,
+ENGL,2130,401.0,British Literature,0.56,0.13,0.0,0.0,0.13,0.0,0.0,0.19,kristen louise aldebol-hazle,
+ENGL,2140,1.0,American Literature,0.42,0.26,0.26,0.0,0.0,0.0,0.0,0.05,mary catherine nestor,
+ENGL,2140,2.0,American Literature,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,mary catherine nestor,
+ENGL,2140,3.0,American Literature,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,chelsea marie clarey,
+ENGL,2140,4.0,American Literature,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,chelsea marie clarey,
+ENGL,2140,5.0,American Literature,0.63,0.21,0.0,0.0,0.0,0.0,0.0,0.16,kathy elaine nixon,
+ENGL,2140,6.0,American Literature,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,kathy elaine nixon,
+ENGL,2140,7.0,American Literature,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,william weldon cunningham,
+ENGL,2140,8.0,American Literature,0.33,0.33,0.11,0.06,0.0,0.0,0.0,0.17,william weldon cunningham,
+ENGL,2140,9.0,American Literature,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,10.0,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,11.0,American Literature,0.21,0.68,0.0,0.0,0.0,0.0,0.0,0.11,patricia sunia,
+ENGL,2140,12.0,American Literature,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,patricia sunia,
+ENGL,2140,400.0,American Literature,0.61,0.17,0.11,0.0,0.0,0.0,0.0,0.11,tareva leselle johnson,
+ENGL,2140,401.0,American Literature,0.58,0.21,0.05,0.05,0.0,0.0,0.0,0.11,tareva leselle johnson,
+ENGL,2150,1.0,Lit in 20th-21st Cent Contexts,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,2150,2.0,Lit in 20th-21st Cent Contexts,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,allen swords,
+ENGL,2150,3.0,Lit in 20th-21st Cent Contexts,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,john logan pursley,
+ENGL,2150,4.0,Lit in 20th-21st Cent Contexts,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,5.0,Lit in 20th-21st Cent Contexts,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,6.0,Lit in 20th-21st Cent Contexts,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2150,7.0,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2150,8.0,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2150,9.0,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,2150,10.0,Lit in 20th-21st Cent Contexts,0.44,0.33,0.17,0.06,0.0,0.0,0.0,0.0,stephanie lorraine edwards,
+ENGL,2150,11.0,Lit in 20th-21st Cent Contexts,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,caitlin grace watt,
+ENGL,2150,12.0,Lit in 20th-21st Cent Contexts,0.68,0.16,0.0,0.0,0.0,0.0,0.0,0.16,caitlin grace watt,
+ENGL,2150,13.0,Lit in 20th-21st Cent Contexts,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,edward thomas joseph troy,
+ENGL,2150,14.0,Lit in 20th-21st Cent Contexts,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,jennifer hagen forsberg,
+ENGL,2150,15.0,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,april ayers lawson,
+ENGL,2150,16.0,Lit in 20th-21st Cent Contexts,0.11,0.63,0.26,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2150,17.0,Lit in 20th-21st Cent Contexts,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,remley melissa makala,
+ENGL,2150,18.0,Lit in 20th-21st Cent Contexts,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,edward thomas joseph troy,
+ENGL,2150,19.0,Lit in 20th-21st Cent Contexts,0.17,0.44,0.11,0.0,0.0,0.0,0.0,0.28,amy monaghan,
+ENGL,2150,20.0,Lit in 20th-21st Cent Contexts,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,megan noel macalystre,
+ENGL,2150,21.0,Lit in 20th-21st Cent Contexts,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,megan noel macalystre,
+ENGL,2150,23.0,Lit in 20th-21st Cent Contexts,0.42,0.32,0.16,0.0,0.05,0.0,0.0,0.05,edward thomas joseph troy,
+ENGL,2150,24.0,Lit in 20th-21st Cent Contexts,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,stephanie lorraine edwards,
+ENGL,2150,25.0,Lit in 20th-21st Cent Contexts,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,remley melissa makala,
+ENGL,2150,26.0,Lit in 20th-21st Cent Contexts,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jennifer hagen forsberg,
+ENGL,2150,27.0,Lit in 20th-21st Cent Contexts,0.59,0.12,0.12,0.06,0.0,0.0,0.0,0.12,remley melissa makala,
+ENGL,2150,28.0,Lit in 20th-21st Cent Contexts,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,remley melissa makala,
+ENGL,2150,29.0,Lit in 20th-21st Cent Contexts,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,stephanie lorraine edwards,
+ENGL,2150,30.0,Lit in 20th-21st Cent Contexts,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,stephanie lorraine edwards,
+ENGL,2150,100.0,20th - 21st Century Lit (HON),0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
+ENGL,2150,400.0,Lit in 20th-21st Cent Contexts,0.06,0.53,0.29,0.06,0.0,0.0,0.0,0.06,sarah mae cooper,
+ENGL,2150,401.0,Lit in 20th-21st Cent Contexts,0.06,0.71,0.06,0.06,0.0,0.0,0.0,0.12,sarah mae cooper,
+ENGL,2160,1.0,African American Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,
+ENGL,2160,2.0,African American Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allison nicole harris,
+ENGL,2160,3.0,African American Literature,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,allison nicole harris,
+ENGL,2160,4.0,African American Literature,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,allison nicole harris,
+ENGL,2310,1.0,Intro to Journalism,0.59,0.24,0.12,0.06,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3040,1.0,Business Writing,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,megan lee pietruszewski,
+ENGL,3040,2.0,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,patricia sunia,
+ENGL,3040,3.0,Business Writing,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,megan lee pietruszewski,
+ENGL,3040,4.0,Business Writing,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,william weldon cunningham,
+ENGL,3040,5.0,Business Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,megan lee pietruszewski,
+ENGL,3040,6.0,Business Writing,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,la'cresha ulon green,
+ENGL,3040,7.0,Business Writing,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,la'cresha ulon green,
+ENGL,3040,8.0,Business Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william weldon cunningham,
+ENGL,3040,9.0,Business Writing,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,jennifer hagen forsberg,
+ENGL,3040,10.0,Business Writing,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,
+ENGL,3040,11.0,Business Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3040,12.0,Business Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katalin beck,
+ENGL,3040,15.0,Business Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,patricia sunia,
+ENGL,3040,21.0,Business Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,jennifer hagen forsberg,
+ENGL,3040,100.0,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
+ENGL,3040,400.0,Business Writing,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,kristen louise aldebol-hazle,
+ENGL,3040,401.0,Business Writing,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,kristen louise aldebol-hazle,
+ENGL,3040,402.0,Business Writing,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,katalin beck,
+ENGL,3040,403.0,Business Writing,0.89,0.0,0.05,0.0,0.05,0.0,0.0,0.0,nancy paxton-wilson,
+ENGL,3100,1.0,Crit Writ Lit,0.26,0.47,0.05,0.0,0.05,0.0,0.0,0.16,dominic mastroianni,
+ENGL,3100,2.0,Crit Writ Lit,0.68,0.16,0.05,0.0,0.11,0.0,0.0,0.0,david sweeney coombs,
+ENGL,3100,3.0,Crit Writ Lit,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,kimberly snyder manganelli,
+ENGL,3120,1.0,Advanced Composition,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,diane mary quaglia beltran,
+ENGL,3120,3.0,Advanced Composition,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david charles foltz,
+ENGL,3120,4.0,Advanced Composition,0.44,0.28,0.17,0.11,0.0,0.0,0.0,0.0,jennie elizabeth wakefield,
+ENGL,3140,1.0,Technical Writing,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,henna marian messina,
+ENGL,3140,2.0,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henna marian messina,
+ENGL,3140,3.0,Technical Writing,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,christopher stuart,
+ENGL,3140,4.0,Technical Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,christopher stuart,
+ENGL,3140,5.0,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,charlotte estelle lucke,
+ENGL,3140,6.0,Technical Writing,0.61,0.22,0.06,0.0,0.06,0.0,0.0,0.06,charlotte estelle lucke,
+ENGL,3140,7.0,Technical Writing,0.83,0.0,0.06,0.06,0.0,0.0,0.0,0.06,shauna chung,
+ENGL,3140,11.0,Technical Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,ingrid anna pierce,
+ENGL,3140,12.0,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ingrid anna pierce,
+ENGL,3140,13.0,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,heather price williams,
+ENGL,3140,14.0,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,
+ENGL,3140,15.0,Technical Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,heather price williams,
+ENGL,3140,17.0,Technical Writing,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,michelle lloyd,
+ENGL,3140,19.0,Technical Writing,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,michelle lloyd,
+ENGL,3140,20.0,Technical Writing,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,kathy elaine nixon,
+ENGL,3140,22.0,Technical Writing,0.67,0.11,0.06,0.0,0.0,0.0,0.0,0.17,kathy elaine nixon,
+ENGL,3140,100.0,Technical Writing (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,heather price williams,True
+ENGL,3140,401.0,Technical Writing,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,
+ENGL,3140,402.0,Technical Writing,0.61,0.22,0.11,0.06,0.0,0.0,0.0,0.0,sharon kathleen nalley,
+ENGL,3140,403.0,Technical Writing,0.53,0.16,0.11,0.16,0.05,0.0,0.0,0.0,heather price williams,
+ENGL,3140,404.0,Technical Writing,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,henna marian messina,
+ENGL,3140,406.0,Technical Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,amy patterson,
+ENGL,3140,407.0,Technical Writing,0.7,0.1,0.05,0.0,0.1,0.0,0.0,0.05,michael russo,
+ENGL,3140,408.0,Technical Writing,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,michael russo,
+ENGL,3150,1.0,Scientific Writing & Comm,0.37,0.32,0.0,0.05,0.16,0.0,0.0,0.11,william pulley,
+ENGL,3150,2.0,Scientific Writing & Comm,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,william pulley,
+ENGL,3150,3.0,Scientific Writing & Comm,0.83,0.0,0.0,0.0,0.06,0.0,0.0,0.11,christopher benson,
+ENGL,3150,6.0,Scientific Writing & Comm,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,william pulley,
+ENGL,3150,400.0,Scientific Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,402.0,Scientific Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,403.0,Scientific Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,404.0,Scientific Writing,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,heather price williams,
+ENGL,3150,405.0,Scientific Writing,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,megan lee pietruszewski,
+ENGL,3450,1.0,Intr Creative Writing: Fiction,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,nicholas christiansen brown,
+ENGL,3460,1.0,Intr Creative Writing: Poetry,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,3480,1.0,Intr Creat Writ: Screenwriting,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,april ayers lawson,
+ENGL,3500,1.0,Mythology,0.32,0.32,0.11,0.0,0.11,0.0,0.0,0.16,kenneth michael tuite,
+ENGL,3530,1.0,Amer Lit-Race/Ethnicity/Migrat,0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,angela naimou,
+ENGL,3540,1.0,Lit Middle East & North Africa,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,angela naimou,
+ENGL,3570,1.0,Film,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,john robert smith,
+ENGL,3570,2.0,Film,0.53,0.24,0.12,0.0,0.06,0.0,0.0,0.06,john robert smith,
+ENGL,3570,3.0,Film,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3570,4.0,Film,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,
+ENGL,3850,1.0,Children's Lit,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,megan noel macalystre,
+ENGL,3860,1.0,Adolescent Lit,0.42,0.47,0.0,0.0,0.0,0.0,0.0,0.11,allison nicole harris,
+ENGL,3970,2.0,Brit Lit Survey II,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,brian mcgrath,
+ENGL,3990,1.0,Amer Lit Survey II,0.41,0.41,0.12,0.0,0.06,0.0,0.0,0.0,rhondda robinson thomas,
+ENGL,3990,2.0,Amer Lit Survey II,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,daniel scott citro,
+ENGL,4000,1.0,The English Language,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,andrew lemons,
+ENGL,4010,2.0,Grammar Survey,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,brian mcgrath,
+ENGL,4110,1.0,Shakespeare,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,4110,2.0,Shakespeare,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,4140,1.0,Milton,0.79,0.05,0.16,0.0,0.0,0.0,0.0,0.0,william stockton,
+ENGL,4180,1.0,Rise of the Novel in English,0.53,0.37,0.0,0.0,0.0,0.0,0.0,0.11,david sweeney coombs,
+ENGL,4280,1.0,Contemporary Literature,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
+ENGL,4340,1.0,Environmental Lit,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,matthew hooley,
+ENGL,4360,1.0,Feminist Literary Criticism,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
+ENGL,4450,1.0,Fiction Workshop,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,keith morris,
+ENGL,4480,1.0,Screenwriting Wkshop,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nicholas christiansen brown,
+ENGL,4500,1.0,Film Genres,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,
+ENGL,4510,1.0,Film Theory and Criticism,0.4,0.47,0.0,0.07,0.07,0.0,0.0,0.0,agnieszka skrodzka,
+ENGL,4520,2.0,Great Directors,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,agnieszka skrodzka,
+ENGL,4540,1.0,Labor in International Cinema,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,edward thomas joseph troy,
+ENGL,4650,1.0,Topics in Lit:Reading Violence,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,maya sylvia hislop,
+ENGL,4750,1.0,Writing for Media,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,jonathan beecher field,
+ENGL,4820,1.0,Afr Am Lit to 1920,0.35,0.29,0.24,0.06,0.0,0.0,0.0,0.06,rhondda robinson thomas,
+ENGL,4960,2.0,SR Sem: End of Cinema,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
+ENGL,4960,3.0,SR Sem: Thinking About Love,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,
+ENGR,1020,112.0,Engineering Discipl & Skills,0.45,0.38,0.1,0.07,0.0,0.0,0.0,0.0,baker martin,
+ENGR,1020,117.0,Engineering Discipl & Skills,0.54,0.33,0.1,0.0,0.0,0.0,0.0,0.03,matthew kent miller,
+ENGR,1020,321.0,Engr Discipl & Skills (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jonathan brooks harcum,True
+ENGR,1020,325.0,Engr Discipl & Skills (HON),0.63,0.33,0.05,0.0,0.0,0.0,0.0,0.0,richard watkins,True
+ENGR,1020,611.0,Engineering Discipl & Skills,0.51,0.34,0.13,0.0,0.0,0.0,0.0,0.02,jonathan brooks harcum,
+ENGR,1020,612.0,Engineering Discipl & Skills,0.58,0.29,0.06,0.02,0.02,0.0,0.0,0.02,jonathan brooks harcum,
+ENGR,1020,613.0,Engineering Discipl & Skills,0.24,0.3,0.36,0.06,0.0,0.0,0.0,0.03,andrew isaac neptune,
+ENGR,1020,614.0,Engineering Discipl & Skills,0.55,0.2,0.14,0.06,0.02,0.0,0.0,0.02,steven brandon,
+ENGR,1020,615.0,Engineering Discipl & Skills,0.46,0.35,0.13,0.0,0.02,0.0,0.0,0.04,steven brandon,
+ENGR,1020,617.0,Engineering Discipl & Skills,0.55,0.3,0.09,0.0,0.0,0.0,0.0,0.06,taylor james sorensen,
+ENGR,1020,618.0,Engineering Discipl & Skills,0.47,0.34,0.11,0.06,0.02,0.0,0.0,0.0,taylor james sorensen,
+ENGR,1020,712.0,Engineering Discipl & Skills,0.53,0.33,0.08,0.05,0.03,0.0,0.0,0.0,matthew kent miller,
+ENGR,1020,713.0,Engineering Discipl & Skills,0.39,0.41,0.12,0.05,0.0,0.0,0.0,0.02,matthew kent miller,
+ENGR,1020,811.0,Engineering Discipl & Skills,0.47,0.39,0.08,0.0,0.02,0.0,0.0,0.04,irene marie ferrara,
+ENGR,1020,812.0,Engineering Discipl & Skills,0.46,0.38,0.13,0.02,0.02,0.0,0.0,0.0,jonathan maier,
+ENGR,1020,813.0,Engineering Discipl & Skills,0.45,0.37,0.12,0.04,0.0,0.0,0.0,0.02,jonathan maier,
+ENGR,1020,814.0,Engineering Discipl & Skills,0.56,0.32,0.07,0.02,0.0,0.0,0.0,0.02,taylor james sorensen,
+ENGR,1020,815.0,Engineering Discipl & Skills,0.45,0.47,0.05,0.0,0.03,0.0,0.0,0.0,cynthia miller smith,
+ENGR,1020,816.0,Engineering Discipl & Skills,0.45,0.34,0.18,0.0,0.02,0.0,0.0,0.0,cynthia miller smith,
+ENGR,1020,817.0,Engineering Discipl & Skills,0.38,0.4,0.04,0.02,0.04,0.0,0.0,0.13,andrew isaac neptune,
+ENGR,1020,818.0,Engineering Discipl & Skills,0.39,0.41,0.09,0.02,0.02,0.0,0.0,0.07,andrew isaac neptune,
+ENGR,1060,400.0,Engr Discipline & Skills II,0.1,0.5,0.25,0.15,0.0,0.0,0.0,0.0,irene marie ferrara,
+ENGR,1410,222.0,Programming & Problem Solving,0.08,0.29,0.18,0.13,0.13,0.0,0.0,0.18,william martin,
+ENGR,1410,223.0,Programming & Problem Solving,0.08,0.29,0.32,0.13,0.08,0.0,0.0,0.11,william martin,
+ENGR,1410,226.0,Programming & Problem Solving,0.06,0.31,0.2,0.23,0.06,0.0,0.0,0.14,shubhamkar sanjay kulkarni,
+ENGR,1410,227.0,Programming & Problem Solving,0.06,0.14,0.36,0.08,0.06,0.0,0.0,0.31,shubhamkar sanjay kulkarni,
+ENGR,1510,621.0,Engineering Skills,0.29,0.37,0.26,0.05,0.03,0.0,0.0,0.0,elizabeth anne stephan,
+ENGR,1510,622.0,Engineering Skills,0.21,0.32,0.34,0.05,0.08,0.0,0.0,0.0,elizabeth anne stephan,
+ENGR,1900,10.0,CI in Engr I Robotics,0.9,0.0,0.0,0.0,0.03,0.0,0.0,0.06,michael benjamin wooten,
+ENGR,1900,12.0,RISE CI Kinetic Sculpture,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,christopher norfolk,
+ENGR,1900,193.0,Special Projects in Engr I,0.13,0.44,0.31,0.08,0.05,0.0,0.0,0.0,john minor,
+ENGR,1900,194.0,Special Projects in Engr I,0.11,0.29,0.29,0.09,0.11,0.0,0.0,0.11,john minor,
+ENGR,2080,683.0,Engr Graphics & Machine Design,0.37,0.34,0.13,0.03,0.0,0.0,0.0,0.13,nisha dilip gulhane,
+ENGR,2080,684.0,Engr Graphics & Machine Design,0.36,0.38,0.1,0.03,0.13,0.0,0.0,0.0,apurva patel,
+ENGR,2080,685.0,Engr Graphics & Machine Design,0.26,0.33,0.13,0.0,0.1,0.0,0.0,0.18,kyle walker,
+ENGR,2080,686.0,Engr Graphics & Machine Design,0.31,0.31,0.13,0.08,0.08,0.0,0.0,0.1,kyle walker,
+ENGR,2080,881.0,Engr Graphics & Machine Design,0.41,0.27,0.16,0.0,0.05,0.0,0.0,0.11,nighat yasmin,
+ENGR,2080,882.0,Engr Graphics & Machine Design,0.49,0.28,0.1,0.03,0.03,0.0,0.0,0.08,nighat yasmin,
+ENGR,2100,804.0,CAD & Engineering Applications,0.43,0.2,0.22,0.08,0.02,0.0,0.0,0.04,nighat yasmin,
+ENGR,2100,805.0,CAD & Engineering Applications,0.38,0.31,0.2,0.04,0.04,0.0,0.0,0.02,afshin famili,
+ENGR,2100,806.0,CAD & Engineering Applications,0.38,0.43,0.12,0.0,0.05,0.0,0.0,0.02,afshin famili,
+ENGR,2210,316.0,"Technology, Culture and Design",0.44,0.41,0.1,0.0,0.05,0.0,0.0,0.0,jonathan maier,
+ENR,1010,2.0,Intro to Envir & Natur Res I,0.79,0.13,0.05,0.02,0.0,0.0,0.0,0.02,greg yarrow,
+ENR,1010,3.0,Intro to Envir & Natur Res I,0.74,0.14,0.06,0.05,0.0,0.0,0.0,0.02,greg yarrow,
+ENR,4140,1.0,Plant ID and Systematics,0.73,0.2,0.0,0.0,0.03,0.0,0.0,0.03,patrick mcmillan,
+ENR,4290,1.0,Environ Law & Policy,0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.04,alan johnson,
+ENR,4290,2.0,Environ Law & Policy,0.6,0.3,0.11,0.0,0.0,0.0,0.0,0.0,alan johnson,
+ENSP,2000,1.0,Intro Environ Sci,0.55,0.17,0.17,0.04,0.0,0.0,0.0,0.06,scott brame,
+ENSP,2000,2.0,Intro Environ Sci,0.64,0.27,0.04,0.0,0.04,0.0,0.0,0.02,minory nammouz,
+ENSP,2000,3.0,Intro Environ Sci,0.66,0.32,0.0,0.0,0.0,0.0,0.0,0.02,minory nammouz,
+ENSP,2000,4.0,Intro Environ Sci,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
+ENSP,2000,5.0,Intro Environ Sci,0.24,0.58,0.09,0.04,0.0,0.0,0.0,0.04,tom owino,
+ENSP,2000,6.0,Intro Environ Sci,0.79,0.1,0.1,0.0,0.0,0.0,0.0,0.0,john gregory sherwood,
+ENSP,4000,1.0,Studies in Environmental Sci,0.63,0.05,0.16,0.11,0.05,0.0,0.0,0.0,margaret louise thompson,
+ENT,2000,1.0,Six-Legged Science,0.45,0.33,0.18,0.03,0.0,0.0,0.0,0.03,suellen pometto,
+ENT,3010,1.0,Insect Biology and Diversity,0.56,0.25,0.09,0.0,0.03,0.0,0.0,0.06,carmen blubaugh,
+ENTR,1010,3.0,Entrepreneurial Mindset,0.73,0.19,0.02,0.02,0.02,0.0,0.0,0.02,john michael hannon,
+ENTR,1090,1.0,Creative Inq-Entrepreneurship,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
+ENTR,1090,20.0,Lemonade Day,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,david joseph frock,
+ENTR,2010,4.0,Sports Entrepreneurship,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,john michael hannon,
+ESED,8000,1.0,Seminar in Engr & Science Educ,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,cindy lee,
+ESED,8500,2.0,Spec Top Engineering & Sci Edu,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,eliza dargan gallagher,
+ESED,8610,2.0,Practicum in Engr & Sci Educ,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,karen ann high,
+ETOX,4300,1.0,Toxicology,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,lisa bain,
+FDSC,1010,1.0,Intro to Food Sci & Hum Nutr,0.76,0.13,0.04,0.02,0.01,0.0,0.0,0.04,carol hegler,
+FDSC,3010,1.0,Food Regulations,0.68,0.21,0.0,0.0,0.04,0.0,0.0,0.07,sara lane cothran,
+FDSC,3060,1.0,Institutional Food Service Mgt,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,
+FDSC,4010,1.0,Food Chemistry I,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,feng chen,
+FDSC,4040,1.0,Food Prsv & Process,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,anthony louis pometto,
+FDSC,4300,1.0,Dairy Process & Sant,0.5,0.19,0.19,0.06,0.0,0.0,0.0,0.06,john mcgregor,
+FDSC,4500,1.0,Creative Inquiry-Food Science,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth lacey durrance,
+FDSC,4500,11.0,Creative Inquiry-Food Science,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,paul dawson,
+FDSC,4500,26.0,Creative Inquiry-Food Science,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
+FIN,2010,401.0,Intro to Personal Finance,0.92,0.05,0.01,0.0,0.01,0.0,0.0,0.01,joshua harris,
+FIN,2010,402.0,Intro to Personal Finance,0.89,0.05,0.01,0.02,0.01,0.0,0.0,0.01,joshua harris,
+FIN,3040,1.0,Risk & Insurance,0.11,0.27,0.51,0.03,0.03,0.0,0.0,0.05,kerri mcmillan,
+FIN,3050,1.0,Investment Analysis,0.21,0.21,0.4,0.12,0.0,0.0,0.0,0.05,kerri mcmillan,
+FIN,3050,2.0,Investment Analysis,0.17,0.54,0.24,0.02,0.02,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,3.0,Investment Analysis,0.2,0.4,0.35,0.05,0.0,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,4.0,Investment Analysis,0.09,0.35,0.28,0.13,0.02,0.0,0.0,0.13,john alexander,
+FIN,3060,1.0,Corporation Finance,0.32,0.23,0.23,0.14,0.0,0.0,0.0,0.09,ramon tolbert franklin,
+FIN,3060,2.0,Corporation Finance,0.09,0.38,0.22,0.2,0.0,0.0,0.0,0.11,ramon tolbert franklin,
+FIN,3060,3.0,Corporation Finance,0.11,0.32,0.32,0.14,0.05,0.0,0.0,0.07,ramon tolbert franklin,
+FIN,3060,4.0,Corporation Finance,0.04,0.11,0.29,0.42,0.04,0.0,0.0,0.09,ramon tolbert franklin,
+FIN,3060,7.0,Corporation Finance,0.26,0.34,0.28,0.11,0.0,0.0,0.0,0.02,minxing sun,
+FIN,3060,8.0,Corporation Finance,0.29,0.4,0.21,0.04,0.04,0.0,0.0,0.02,minxing sun,
+FIN,3060,9.0,Corporation Finance,0.02,0.38,0.33,0.25,0.02,0.0,0.0,0.0,minxing sun,
+FIN,3060,403.0,Corporation Finance,0.19,0.51,0.21,0.01,0.03,0.0,0.0,0.04,jonathan godbey,
+FIN,3060,404.0,Corporation Finance,0.26,0.4,0.14,0.02,0.08,0.0,0.0,0.11,jonathan godbey,
+FIN,3070,1.0,Prin of Real Estate,0.14,0.44,0.26,0.09,0.05,0.0,0.0,0.02,thomas springer,
+FIN,3070,2.0,Prin of Real Estate,0.2,0.3,0.25,0.2,0.05,0.0,0.0,0.0,thomas springer,
+FIN,3070,5.0,Prin of Real Estate,0.3,0.27,0.24,0.06,0.09,0.0,0.0,0.03,bryan blackwood,
+FIN,3080,1.0,Fin Inst & Mkts,0.34,0.49,0.15,0.0,0.0,0.0,0.0,0.02,lyudmila chernykh,
+FIN,3080,2.0,Fin Inst & Mkts,0.1,0.58,0.28,0.05,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,3080,3.0,Fin Inst & Mkts,0.33,0.48,0.17,0.02,0.0,0.0,0.0,0.0,daniel thomas greene,
+FIN,3080,401.0,Fin Inst & Mkts,0.31,0.35,0.31,0.0,0.02,0.0,0.0,0.0,daniel thomas greene,
+FIN,3110,1.0,Financial Management I,0.08,0.28,0.25,0.13,0.13,0.0,0.0,0.15,jack wolf,
+FIN,3110,2.0,Financial Management I,0.06,0.18,0.24,0.12,0.15,0.0,0.0,0.26,jack wolf,
+FIN,3110,3.0,Financial Management I,0.13,0.31,0.38,0.13,0.05,0.0,0.0,0.0,weike xu,
+FIN,3110,4.0,Financial Management I,0.47,0.4,0.11,0.0,0.0,0.0,0.0,0.02,joshua harris,
+FIN,3110,5.0,Financial Management I,0.44,0.31,0.22,0.02,0.0,0.0,0.0,0.0,joshua harris,
+FIN,3110,6.0,Financial Management I,0.24,0.27,0.29,0.09,0.02,0.0,0.0,0.09,joshua harris,
+FIN,3110,102.0,Financial Management I (HON),0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,jack wolf,True
+FIN,3120,1.0,Financial Management II,0.15,0.27,0.41,0.1,0.05,0.0,0.0,0.02,vincent james intintoli,
+FIN,3120,2.0,Financial Management II,0.16,0.33,0.31,0.09,0.07,0.0,0.0,0.04,vincent james intintoli,
+FIN,3120,3.0,Financial Management II,0.33,0.3,0.27,0.06,0.0,0.0,0.0,0.03,blerina zykaj,
+FIN,3120,4.0,Financial Management II,0.17,0.24,0.22,0.22,0.07,0.0,0.0,0.09,weike xu,
+FIN,3120,5.0,Financial Management II,0.1,0.44,0.32,0.12,0.02,0.0,0.0,0.0,weike xu,
+FIN,3120,101.0,Financial Mgt II (HON),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,vincent james intintoli,True
+FIN,3120,103.0,Financial Mgt II (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,True
+FIN,4010,1.0,Corporate Financial Analysis,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,
+FIN,4020,1.0,Corporate Valuation,0.11,0.34,0.34,0.14,0.0,0.0,0.0,0.07,angela morgan,
+FIN,4020,101.0,Corporate Valuation (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,angela morgan,True
+FIN,4050,1.0,Portfolio Management & Theory,0.07,0.24,0.36,0.11,0.0,0.0,0.0,0.22,john alexander,
+FIN,4060,1.0,Derivatives Analysis,0.17,0.51,0.17,0.03,0.06,0.0,0.0,0.06,blerina zykaj,
+FIN,4110,1.0,Int Fin Mgt,0.34,0.51,0.15,0.0,0.0,0.0,0.0,0.0,luke asher devault,
+FIN,4110,2.0,Int Fin Mgt,0.58,0.27,0.1,0.02,0.02,0.0,0.0,0.0,luke asher devault,
+FIN,4980,2.0,CI in Finance: CFA,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jack wolf,
+FIN,4980,4.0,CI in Finance: SIE,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,joshua harris,
+FIN,4980,5.0,CI in Finance: AI,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,yannan shen,
+FIN,4980,6.0,CI in Finance: Machine Learnin,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,yannan shen,
+FNR,2040,1.0,Soil Information Systems,0.85,0.1,0.0,0.02,0.0,0.0,0.0,0.03,elena mikhailova,
+FNR,4700,5.0,Landscape Ecology / Appalachia,0.83,0.0,0.0,0.17,0.0,0.0,0.0,0.0,russell barrett,
+FNR,4700,10.0,Kennedy Waterfowl & Wetlands,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,richard marvin kaminski,
+FNR,4700,26.0,Stream Fish Mercury Dynamics,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,troy mason farmer,
+FNR,4700,44.0,Alligator Ecology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,catherine michelle jachowski,
+FNR,4700,129.0,GIS & SIS Applications,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher post,
+FNR,4990,1.0,Natural Resources Seminar,0.55,0.38,0.03,0.0,0.03,0.0,0.0,0.0,susan talley guynn,
+FOR,2050,1.0,Dendrology,0.17,0.42,0.08,0.04,0.13,0.0,0.0,0.17,donald hagan,
+FOR,2050,2.0,Dendrology,0.45,0.21,0.09,0.09,0.06,0.0,0.0,0.09,donald hagan,
+FOR,2050,3.0,Dendrology,0.19,0.13,0.28,0.19,0.09,0.0,0.0,0.13,donald hagan,
+FOR,2210,1.0,Forest Biology,0.18,0.46,0.22,0.04,0.04,0.0,0.0,0.07,jessica ann hartshorn,
+FOR,3020,1.0,Forest Biometrics,0.38,0.54,0.05,0.0,0.0,0.0,0.0,0.03,brian ritter,
+FOR,3040,1.0,Forest Resource Economics,0.67,0.23,0.05,0.05,0.0,0.0,0.0,0.0,puskar khanal,
+FOR,3410,1.0,Wood Procure Pract,0.61,0.3,0.06,0.03,0.0,0.0,0.0,0.0,patrick hiesl,
+FOR,4100,1.0,Harvesting Processes,0.54,0.35,0.12,0.0,0.0,0.0,0.0,0.0,patrick hiesl,
+FOR,4130,1.0,Integrated Forest Pest Mgt,0.57,0.37,0.06,0.0,0.0,0.0,0.0,0.0,jessica ann hartshorn,
+FOR,4150,1.0,Forest Wildlife Managment,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
+FOR,4160,1.0,Forest Policy and Admin,0.41,0.32,0.24,0.02,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4170,1.0,Forest Resource Mgt & Regulatn,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,
+FOR,4340,1.0,GIS for Natural Resources,0.63,0.31,0.04,0.0,0.0,0.0,0.0,0.02,christopher post,
+FR,1010,1.0,Elementary French,0.0,0.45,0.27,0.18,0.0,0.0,0.0,0.09,anne carole salces  nedeo,
+FR,1010,2.0,Elementary French,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,anne carole salces  nedeo,
+FR,1010,3.0,Elementary French,0.38,0.19,0.13,0.06,0.13,0.0,0.0,0.13,anne carole salces  nedeo,
+FR,1020,1.0,Elementary French,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,
+FR,1020,2.0,Elementary French,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,
+FR,1020,3.0,Elementary French,0.21,0.43,0.14,0.07,0.07,0.0,0.0,0.07,anne carole salces  nedeo,
+FR,2010,1.0,Intermediate French,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,
+FR,2010,2.0,Intermediate French,0.0,0.73,0.13,0.07,0.07,0.0,0.0,0.0,kenneth david widgren,
+FR,2010,3.0,Intermediate French,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,pauline de tholozany,
+FR,2020,1.0,Intermediate French,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,
+FR,2020,2.0,Intermediate French,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,
+FR,2020,4.0,Intermediate French,0.2,0.47,0.2,0.13,0.0,0.0,0.0,0.0,kenneth david widgren,
+FR,3000,1.0,Survey of French Lit,0.67,0.28,0.0,0.06,0.0,0.0,0.0,0.0,pauline de tholozany,
+FR,3050,1.0,Int Fr Con & Comp I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kenneth david widgren,
+FR,3050,2.0,Int Fr Con & Comp I,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,anne carole salces  nedeo,
+FR,3070,1.0,French Civilization,0.6,0.27,0.0,0.07,0.0,0.0,0.0,0.07,eric touya,
+FR,4120,1.0,Fr & Francoph Cinema,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joseph mai,
+GC,1020,1.0,Computer Art & CAD Foundations,0.47,0.35,0.07,0.02,0.08,0.0,0.0,0.01,carol jones,
+GC,1040,1.0,Graphic Communications I,0.63,0.19,0.09,0.0,0.09,0.0,0.0,0.0,michelle suki bost fox,
+GC,2070,1.0,Graphic Communications II,0.64,0.28,0.06,0.02,0.0,0.0,0.0,0.0,charles tabor weiss,
+GC,3400,1.0,Digital Imaging and eMedia,0.35,0.44,0.15,0.02,0.02,0.0,0.0,0.02,erica black walker,
+GC,3460,1.0,Ink and Substrates,0.63,0.32,0.02,0.02,0.0,0.0,0.0,0.0,shu chang,
+GC,4060,1.0,Package and Specialty Printing,0.48,0.5,0.03,0.0,0.0,0.0,0.0,0.0,kern cox,
+GC,4400,1.0,Commercial Printing,0.44,0.54,0.02,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,
+GC,4440,1.0,Current Dev/Trends in Gr Comm,0.42,0.48,0.09,0.0,0.0,0.0,0.0,0.0,liam henry 'hara,
+GC,4800,1.0,Senior Seminar in GC,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,charles edward tonkin,
+GC,4900,6.0,GC-UX & Web Design,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,erica black walker,
+GC,4900,8.0,Strat Messaging in Social Age,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,nigel robertson,
+GC,4900,10.0,EC: Concept & Storytelling,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,brian connaughton,
+GC,4900,16.0,GC Visual Design & Art Direct,0.75,0.06,0.13,0.0,0.0,0.0,0.0,0.06,erica black walker,
+GEN,1030,1.0,Careers in Bioch/Gen,0.81,0.16,0.02,0.0,0.0,0.0,0.0,0.01,joseph paul thames,
+GEN,3000,1.0,Fundamental Genetics,0.47,0.24,0.16,0.05,0.03,0.0,0.0,0.05,marcos tulio oliveira,
+GEN,3000,2.0,Fundamental Genetics,0.43,0.32,0.13,0.04,0.04,0.0,0.0,0.04,marcos tulio oliveira,
+GEN,3020,1.0,Molecular & General Genetics,0.26,0.41,0.23,0.05,0.02,0.0,0.0,0.04,kate leanne willingha tsai,
+GEN,3020,2.0,Molec & General Genetics (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,kate leanne willingha tsai,True
+GEN,4100,1.0,Population & Quant Genetics,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,
+GEN,4110,1.0,Population & Quant Gen Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,
+GEN,4110,2.0,Population & Quant Gen Lab,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,kimberly kanapeckas metris,
+GEN,4110,4.0,Population & Quant Gen Lab,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,
+GEN,4400,1.0,Bioinformatics,0.74,0.16,0.02,0.0,0.02,0.0,0.0,0.05,frank alexander feltus,
+GEN,4400,2.0,Bioinformatics (HON),0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,frank alexander feltus,True
+GEN,4500,1.0,Comparative Genetics,0.21,0.53,0.21,0.02,0.0,0.0,0.0,0.02,leigh anne clark,
+GEN,4500,2.0,Comparative Genetics (HON),0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,leigh anne clark,True
+GEN,4900,1.0,Epigenetics,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,rajandeep singh sekhon,
+GEN,4900,20.0,GB Prof Development,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alison nicole starr-moss,
+GEN,4930,1.0,Senior Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,
+GEN,4930,2.0,Senior Seminar,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,hong luo,
+GEOG,1010,1.0,Intro to Geography,0.39,0.39,0.13,0.03,0.0,0.0,0.0,0.05,christa smith,
+GEOG,1030,1.0,World Regional Geography,0.27,0.48,0.15,0.06,0.03,0.0,0.0,0.02,william church terry,
+GEOG,1030,2.0,World Regional Geography,0.35,0.25,0.23,0.05,0.08,0.0,0.0,0.05,william church terry,
+GEOL,1010,1.0,Physical Geology,0.27,0.3,0.2,0.12,0.06,0.0,0.0,0.05,alan coulson,
+GEOL,1010,2.0,Physical Geology,0.32,0.31,0.21,0.08,0.05,0.0,0.0,0.03,alan coulson,
+GEOL,1010,3.0,Physical Geology,0.43,0.34,0.19,0.04,0.0,0.0,0.0,0.0,mary katherine fidler,
+GEOL,1010,4.0,Physical Geology,0.49,0.24,0.2,0.02,0.04,0.0,0.0,0.0,mary katherine fidler,
+GEOL,1010,5.0,Physical Geology,0.56,0.21,0.17,0.02,0.02,0.0,0.0,0.02,kelly best lazar,
+GEOL,1030,1.0,Physical Geol Lab,0.27,0.41,0.14,0.05,0.05,0.0,0.0,0.09,emily don scribner,
+GEOL,1030,2.0,Physical Geol Lab,0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,3.0,Physical Geol Lab,0.42,0.42,0.08,0.0,0.04,0.0,0.0,0.04,alan coulson,
+GEOL,1030,4.0,Physical Geol Lab,0.71,0.21,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,5.0,Physical Geol Lab,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,6.0,Physical Geol Lab,0.54,0.33,0.0,0.04,0.0,0.0,0.0,0.08,alan coulson,
+GEOL,1030,7.0,Physical Geol Lab,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,8.0,Physical Geol Lab,0.5,0.36,0.0,0.09,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,1030,9.0,Physical Geol Lab,0.36,0.41,0.09,0.05,0.09,0.0,0.0,0.0,alan coulson,
+GEOL,1030,10.0,Physical Geol Lab,0.22,0.48,0.13,0.0,0.04,0.0,0.0,0.13,emily don scribner,
+GEOL,1030,11.0,Physical Geol Lab,0.67,0.17,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,
+GEOL,1030,12.0,Physical Geol Lab,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,13.0,Physical Geol Lab,0.45,0.41,0.09,0.0,0.05,0.0,0.0,0.0,alan coulson,
+GEOL,1030,14.0,Physical Geol Lab,0.47,0.27,0.2,0.0,0.07,0.0,0.0,0.0,alan coulson,
+GEOL,1030,15.0,Physical Geol Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,16.0,Physical Geol Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,17.0,Physical Geol Lab,0.57,0.26,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,
+GEOL,1120,1.0,Earth Resources,0.36,0.4,0.18,0.04,0.02,0.0,0.0,0.0,emily don scribner,
+GEOL,1140,1.0,Earth Resources Lab,0.65,0.22,0.08,0.03,0.03,0.0,0.0,0.0,emily don scribner,
+GEOL,2700,1.0,Sustainable Water,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+GEOL,3000,1.0,Environmental Geology,0.18,0.36,0.32,0.05,0.05,0.0,0.0,0.05,alan coulson,
+GEOL,4500,1.0,Paleoclimate Change,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,alexander thomas pullen,
+GEOL,4910,1.0,Research Synthesis I,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,7900,501.0,Biogeography And Geology of SC,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
+GER,1010,1.0,Elementary German,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,oswald harris king,
+GER,1010,2.0,Elementary German,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,oswald harris king,
+GER,1020,2.0,Elementary German,0.58,0.17,0.08,0.0,0.0,0.0,0.0,0.17, lee ferrell,
+GER,2010,1.0,Intermediate German,0.22,0.39,0.28,0.06,0.0,0.0,0.0,0.06,johannes schmidt,
+GER,2020,1.0,Intermediate German,0.14,0.43,0.29,0.0,0.0,0.0,0.0,0.14,gabriela stoicea,
+GER,2600,1.0,Selected Topics in German Lit,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,gabriela stoicea,
+GER,3050,1.0,Ger Conv & Comp,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0, lee ferrell,
+GER,3400,1.0,German Culture,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,oswald harris king,
+HCG,9050,400.0,"Genomics, Ethics & Hlth Policy",0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,linda ward,
+HIST,1010,1.0,History of the United States,0.56,0.39,0.0,0.0,0.03,0.0,0.0,0.03,lee brady wilson,
+HIST,1010,2.0,History of the United States,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,james bradford jeffries,
+HIST,1020,1.0,History of the United States,0.48,0.39,0.1,0.0,0.0,0.0,0.0,0.03,rebecca anna stoil,
+HIST,1220,1.0,"Hist, Tech & Society",0.23,0.54,0.13,0.02,0.04,0.0,0.0,0.03,pamela mack,
+HIST,1240,1.0,Environmental History Survey,0.14,0.42,0.28,0.06,0.03,0.0,0.0,0.08,james bradford jeffries,
+HIST,1240,2.0,Environmental History Survey,0.18,0.36,0.39,0.0,0.0,0.0,0.0,0.07,james bradford jeffries,
+HIST,1720,1.0,The West and the World I,0.43,0.34,0.17,0.0,0.01,0.0,0.0,0.04,steven marks,
+HIST,1720,2.0,The West and the World I,0.41,0.34,0.14,0.03,0.02,0.0,0.0,0.06,kathryn langenfeld,
+HIST,1720,3.0,The West and the World (HON),0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,True
+HIST,1720,4.0,The West and the World I,0.37,0.53,0.0,0.0,0.0,0.0,0.0,0.11,thomas kuehn,
+HIST,1730,1.0,The West and the World II,0.52,0.27,0.12,0.02,0.04,0.0,0.0,0.04, alan grubb,
+HIST,2990,1.0,Historian's Craft,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,elizabeth donnelly carney,
+HIST,2990,3.0,Historian's Craft,0.68,0.21,0.0,0.0,0.11,0.0,0.0,0.0,michael silvestri,
+HIST,3040,1.0,Indus & Progr Era,0.5,0.22,0.17,0.06,0.0,0.0,0.0,0.06, roger grant,
+HIST,3060,1.0,US: Postwar World 1945-1975,0.68,0.24,0.0,0.0,0.0,0.0,0.0,0.08,rebecca anna stoil,
+HIST,3240,1.0,Hist of the South II,0.31,0.45,0.03,0.0,0.17,0.0,0.0,0.03,john andrew,
+HIST,3280,1.0,US Legal History to 1890,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
+HIST,3330,1.0,Hist of Mod Japan,0.24,0.38,0.31,0.03,0.03,0.0,0.0,0.0,edwin moise,
+HIST,3370,1.0,History South Africa,0.48,0.28,0.17,0.03,0.03,0.0,0.0,0.0,james burns,
+HIST,3540,1.0,Greek World,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathryn langenfeld,
+HIST,3670,1.0,Modern Ireland,0.53,0.27,0.07,0.07,0.0,0.0,0.0,0.07,michael silvestri,
+HIST,3700,1.0,Medieval History,0.46,0.23,0.08,0.04,0.15,0.0,0.0,0.04,caroline dunn clark,
+HIST,3720,1.0,Renaissance,0.47,0.35,0.06,0.0,0.06,0.0,0.0,0.06,thomas kuehn,
+HIST,3940,1.0,Non-Western History,0.18,0.35,0.18,0.0,0.06,0.0,0.0,0.24,stephanie hassell,
+HIST,3970,1.0,Modern Middle East,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
+HIST,4000,1.0,Disney Parks,0.56,0.34,0.09,0.0,0.0,0.0,0.0,0.0,stephanie barczewski,
+HIST,4000,2.0,Amer Comparative Frontiers,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08, roger grant,
+HIST,4140,1.0,Study of Hist Museum,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua casmir catalano,
+HIST,4710,1.0,The Great War,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23, alan grubb,
+HIST,4900,2.0,Global History of Slavery,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,stephanie hassell,
+HIST,4900,3.0,Global Impact of Russian Rev,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,
+HIST,4920,1.0,US - Iraq War,0.13,0.33,0.33,0.0,0.07,0.0,0.0,0.13,edwin moise,
+HIST,4930,2.0,Slavery On Film,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,
+HIST,4940,1.0,MiddleEasternSocieties in Film,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
+HLTH,2020,1.0,Introduction to Public Health,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,2.0,Introduction to Public Health,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,3.0,Introduction to Public Health,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,2020,4.0,Introduction to Public Health,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2020,5.0,Introduction to Public Health,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2020,400.0,Introduction to Public Health,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,402.0,Introduction to Public Health,0.48,0.48,0.0,0.05,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2030,1.0,Health Care Sys,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2030,2.0,Health Care Sys,0.52,0.36,0.12,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2030,400.0,Health Care Sys,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2400,1.0,Deter of Hlth Behav,0.5,0.38,0.08,0.04,0.0,0.0,0.0,0.0,amelia beasley clinkscales,
+HLTH,2400,2.0,Deter of Hlth Behav,0.6,0.28,0.08,0.0,0.0,0.0,0.0,0.04,amelia beasley clinkscales,
+HLTH,2400,4.0,Deter of Hlth Behav,0.85,0.12,0.0,0.0,0.04,0.0,0.0,0.0,karyn jones,
+HLTH,2600,1.0,Medical Terminology & Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,
+HLTH,2600,3.0,Medical Terminology & Comm,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,karen edwards,
+HLTH,2980,1.0,Human Health and Disease,0.41,0.51,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,2980,2.0,Human Health and Disease,0.63,0.29,0.06,0.03,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,3030,1.0,Public Health Comm,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,debra mitchell charles,
+HLTH,3400,1.0,Hlth Prom Prog Plan,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,johnny long,
+HLTH,3610,1.0,Int Health Care Econ,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
+HLTH,3800,1.0,Epidemiology,0.51,0.4,0.06,0.0,0.0,0.0,0.0,0.03,hugh donald spitler,
+HLTH,3800,2.0,Epidemiology,0.54,0.43,0.03,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,3800,3.0,Epidemiology,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,lu zhang,
+HLTH,3800,400.0,Epidemiology,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,3980,1.0,Health Appraisal Skills,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,3980,2.0,Health Appraisal Skills,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4190,1.0,Health Sci Internship Prep Sem,0.51,0.39,0.07,0.02,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4200,1.0,Hlth Science Intern,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4400,1.0,Manag Hlth Serv Org,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,kathleen buford cartmell,
+HLTH,4750,1.0,Hlthcr Oper Mgmt Res,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,lu shi,
+HLTH,4900,2.0,Res Eval St Pub Hlth,0.32,0.48,0.16,0.0,0.04,0.0,0.0,0.0,karen kemper,
+HLTH,4900,3.0,Res Eval St Pub Hlth,0.44,0.48,0.04,0.0,0.0,0.0,0.0,0.04,jeffrey kingree,
+HLTH,8120,400.0,Clinical and Translational Sci,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald gimbel,
+HLTH,8900,2.0,GIS in Public Health,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,patricia carbajales-dale,
+HON,1920,1.0,Positively Human,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,june pilcher,True
+HON,1920,2.0,NSP First-Year Seminar,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sarah evelyn winslow,True
+HON,2020,1.0,Who Decides What's Cool?,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,amanda cooper fine,True
+HON,2020,2.0,World of Ideas,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True
+HON,2020,3.0,Communism and the Berlin Wall,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,michael meng,True
+HON,2020,4.0,Sexual Health of CU students,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,bruce michael king,True
+HON,2060,4.0,Why We Eat What We Eat,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,elizabeth lacey durrance,True
+HON,2210,3.0,The Cultural Work of Comics,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True
+HORT,1010,1.0,Horticulture,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HORT,2020,1.0,Adobe Digital Design,0.75,0.13,0.03,0.03,0.0,0.0,0.0,0.06,janice ann lay,
+HORT,2120,1.0,Turfgrass Culture,0.77,0.16,0.03,0.0,0.03,0.0,0.0,0.0,haibo liu,
+HORT,3030,1.0,Landscape Plants,0.02,0.36,0.29,0.16,0.09,0.0,0.0,0.09,robert polomski,
+HORT,3080,1.0,Sust Landsc Des Install Maint,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HORT,4400,1.0,Hydroponics,0.22,0.39,0.28,0.11,0.0,0.0,0.0,0.0,james emerson faust,
+HP,8090,400.0,Historical Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,katherine saunders pemberton,
+HRD,8300,400.0,Concepts of H R D,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,angela danielle carter,
+HRD,8300,401.0,Concepts of H R D,0.73,0.19,0.04,0.0,0.0,0.0,0.0,0.04,angela danielle carter,
+HRD,8450,400.0,Needs Assess Ed/Ind,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angela danielle carter,
+HRD,8600,400.0,Instruc Mat Devel,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kristin kelly frady,
+IE,2100,1.0,Des Analysis Wrk Sys,0.35,0.48,0.13,0.01,0.01,0.0,0.0,0.01,jeffery messer,
+IE,3010,1.0,Systems Design I,0.45,0.48,0.06,0.0,0.01,0.0,0.0,0.0,shraddhaa narasimha,
+IE,3600,1.0,Industrial Apps of Prob/Stat I,0.25,0.3,0.32,0.11,0.03,0.0,0.0,0.0,mary elizabeth kurz,
+IE,3610,1.0,Industrial App of Prob/Stat II,0.24,0.32,0.22,0.12,0.05,0.0,0.0,0.05,brian melloy,
+IE,3800,1.0,Deterministic Operations Rsrch,0.35,0.35,0.13,0.06,0.07,0.0,0.0,0.04,yongjia song,
+IE,3810,1.0,Probabilistic Operations Rsrch,0.52,0.34,0.1,0.02,0.0,0.0,0.0,0.02,caglar caglayan,
+IE,3840,1.0,Engr Econ Analysis,0.63,0.26,0.09,0.02,0.0,0.0,0.0,0.01,walter lawrence garvin,
+IE,3860,1.0,Production Planning & Control,0.45,0.4,0.1,0.04,0.0,0.0,0.0,0.0,mariah soibhan magagnotti,
+IE,4300,1.0,Human Fact Engr in Healthcare,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,david neyens,
+IE,4400,1.0,Decision Support Sys,0.34,0.52,0.06,0.0,0.05,0.0,0.0,0.03,scott jennings mason,
+IE,4560,1.0,Supply Chain Design & Control,0.14,0.5,0.27,0.0,0.05,0.0,0.0,0.05,william ferrell,
+IE,4610,1.0,Quality Engineering,0.35,0.54,0.07,0.02,0.02,0.0,0.0,0.0,mariah soibhan magagnotti,
+IE,4610,2.0,Quality Engineering,0.45,0.24,0.21,0.03,0.03,0.0,0.0,0.03,di liu,
+IE,4620,1.0,Six Sigma Quality,0.35,0.49,0.11,0.04,0.0,0.0,0.0,0.01,walter lawrence garvin,
+IE,4650,1.0,Facilities Planning & Design,0.4,0.38,0.18,0.03,0.01,0.0,0.0,0.0,william ferrell,
+IE,4670,1.0,System Design II,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,jeffery messer,
+IE,4820,1.0,Systems Modeling,0.06,0.59,0.25,0.03,0.03,0.0,0.0,0.03,kevin taaffe,
+IE,4820,2.0,Systems Modeling,0.44,0.41,0.1,0.05,0.0,0.0,0.0,0.0,kevin taaffe,
+IE,4880,1.0,Human Factors Eng,0.94,0.04,0.02,0.0,0.0,0.0,0.0,0.0,jamiahus durnad walton,
+IE,4880,2.0,Human Factors Eng,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,amro nofan khasawneh,
+IE,6560,1.0,Supply Chain Design & Control,0.57,0.32,0.11,0.0,0.0,0.0,0.0,0.0,william ferrell,
+IE,6820,1.0,Systems Modeling,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,kevin taaffe,
+IE,8000,1.0,Human Factors Eng,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,david neyens,
+IE,8020,1.0,Human Comp Sys,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,
+IE,8030,1.0,Engr Optimization and Apps,0.27,0.33,0.33,0.0,0.07,0.0,0.0,0.0,scott jennings mason,
+IE,8090,1.0,Model Sys Under Risk,0.83,0.06,0.11,0.0,0.0,0.0,0.0,0.0,yongjia song,
+IE,8530,1.0,Foundations of Quality,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,robert james riggs,
+IE,8550,1.0,SC & Logistics Modeling II,0.88,0.09,0.0,0.0,0.03,0.0,0.0,0.0,kevin taaffe,
+INT,1510,1.0,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,lisa marie robinson,
+INT,1540,1.0,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.89,0.0,0.11,caren kelley-hall,
+ITAL,1010,1.0,Elementary Italian,0.36,0.36,0.09,0.0,0.0,0.0,0.0,0.18,julia schmidt,
+ITAL,1010,2.0,Elementary Italian,0.42,0.26,0.21,0.0,0.05,0.0,0.0,0.05,julia schmidt,
+ITAL,1010,3.0,Elementary Italian,0.46,0.31,0.08,0.08,0.0,0.0,0.0,0.08,julia schmidt,
+ITAL,1020,1.0,Elementary Italian,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,julia schmidt,
+ITAL,2010,1.0,Intermediate Italian,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
+ITAL,2010,2.0,Intermediate Italian,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
+ITAL,2020,1.0,Intermediate Italian,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,
+JAPN,1010,1.0,Elementary Japanese,0.53,0.12,0.12,0.0,0.12,0.0,0.0,0.12,satomi saito,
+JAPN,1010,2.0,Elementary Japanese,0.44,0.25,0.19,0.0,0.13,0.0,0.0,0.0,satomi saito,
+JAPN,1010,3.0,Elementary Japanese,0.33,0.17,0.25,0.0,0.17,0.0,0.0,0.08,satomi saito,
+JAPN,1020,1.0,Elementary Japanese,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,satomi saito,
+JAPN,2010,3.0,Intermed Japanese,0.42,0.31,0.04,0.12,0.04,0.0,0.0,0.08,jae allegra dibello takeuchi,
+JAPN,4060,1.0,Intro to Japanese Literature,0.73,0.18,0.0,0.09,0.0,0.0,0.0,0.0,kumiko saito,
+JAPN,4990,1.0,Sel Topics in Japanese Culture,0.79,0.07,0.07,0.07,0.0,0.0,0.0,0.0,kumiko saito,
+JUST,2880,1.0,The Criminal Justice System,0.38,0.27,0.21,0.02,0.1,0.0,0.0,0.01,margaret tina britz,
+JUST,2890,1.0,Criminology,0.51,0.36,0.11,0.0,0.02,0.0,0.0,0.0,bryan lee miller,
+JUST,4290,1.0,Justice Administration,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,rhys hester,
+JUST,4680,1.0,Criminal Evidence,0.43,0.22,0.26,0.04,0.04,0.0,0.0,0.02,margaret tina britz,
+JUST,4860,1.0,CI in CJ: Gangsterism in Film,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,margaret tina britz,
+JUST,4910,1.0,Policing,0.81,0.1,0.04,0.0,0.02,0.0,0.0,0.04,shelagh dorn,
+JUST,4920,1.0,Justice Leadership Practicum,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,margaret tina britz,
+JUST,4930,1.0,Corrections,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,bryan lee miller,
+JUST,4990,1.0,Race and Crime,0.69,0.08,0.15,0.0,0.0,0.0,0.0,0.08,brian chad starks,
+JUST,4990,2.0,Intro to Forensic Science,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,tiffany brianne hezel edwards,
+JUST,4990,3.0,Homeland Security/Intelligence,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,shelagh dorn,
+LAIB,1270,1.0,Intro to Lang & Int'l Business,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06, lee ferrell,
+LARC,1150,1.0,Intro Landscape Architecture,0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,jueminsi wu,
+LARC,1280,1.0,Technical Graphics,0.48,0.38,0.05,0.05,0.0,0.0,0.0,0.05,matthew neal powers,
+LARC,1510,1.0,Basic Design I,0.48,0.38,0.05,0.05,0.0,0.0,0.0,0.05,matthew neal powers,
+LARC,2510,1.0,Larch Design Fund,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,
+LARC,2620,1.0,Design Implementation I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,
+LARC,3510,1.0,Regional Design,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,lara margaret mutel browning,
+LARC,4530,1.0,Key Issues in Landscape Arch,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,
+LARC,4620,1.0,Design Implementation III,0.26,0.37,0.16,0.11,0.0,0.0,0.0,0.11,paul russell,
+LARC,4970,1.0,Plants in the Landscape,0.52,0.3,0.09,0.0,0.09,0.0,0.0,0.0,lara margaret mutel browning,
+LAW,3220,1.0,Legal Env of Bus,0.15,0.46,0.3,0.04,0.02,0.0,0.0,0.02,kenneth scott toussaint,
+LAW,3220,2.0,Legal Env of Bus,0.24,0.3,0.37,0.09,0.0,0.0,0.0,0.0,kenneth scott toussaint,
+LAW,3220,3.0,Legal Env of Bus,0.3,0.52,0.15,0.0,0.02,0.0,0.0,0.0,kathryn kisska-schulze,
+LAW,3220,4.0,Legal Env of Bus,0.36,0.51,0.13,0.0,0.0,0.0,0.0,0.0,kathryn kisska-schulze,
+LAW,3220,5.0,Legal Env of Bus,0.53,0.38,0.09,0.0,0.0,0.0,0.0,0.0,christopher michael edwards,
+LAW,3220,6.0,Legal Env of Bus,0.43,0.43,0.15,0.0,0.0,0.0,0.0,0.0,kathryn kisska-schulze,
+LAW,3220,7.0,Legal Env of Bus,0.64,0.26,0.06,0.0,0.0,0.0,0.0,0.04,christopher michael edwards,
+LAW,3220,8.0,Legal Env of Bus,0.33,0.48,0.17,0.0,0.0,0.0,0.0,0.02,edward ray claggett,
+LAW,3220,9.0,Legal Env of Bus,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,10.0,Legal Env of Bus,0.23,0.49,0.26,0.02,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,11.0,Legal Env of Bus,0.26,0.48,0.17,0.04,0.0,0.0,0.0,0.04,john hine,
+LAW,3220,400.0,Legal Env of Bus,0.34,0.34,0.15,0.11,0.02,0.0,0.0,0.03,virginia ls ward-vaughn,
+LAW,3220,401.0,Legal Env of Bus,0.24,0.39,0.2,0.07,0.03,0.0,0.0,0.07,virginia ls ward-vaughn,
+LAW,3220,402.0,Legal Env of Bus,0.33,0.45,0.1,0.03,0.0,0.0,0.0,0.09,virginia ls ward-vaughn,
+LAW,3220,403.0,Legal Env of Bus,0.26,0.48,0.18,0.05,0.02,0.0,0.0,0.02,virginia ls ward-vaughn,
+LAW,3220,404.0,Legal Env of Bus,0.31,0.46,0.17,0.06,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3330,1.0,Real Estate Law,0.05,0.36,0.23,0.27,0.09,0.0,0.0,0.0,kenneth scott toussaint,
+LAW,3330,2.0,Real Estate Law,0.18,0.36,0.3,0.03,0.06,0.0,0.0,0.06,kenneth scott toussaint,
+LAW,4050,1.0,Construction Law,0.58,0.27,0.09,0.0,0.0,0.0,0.0,0.06,frances edwards,
+LS,1000,2.0,Therapeutic Yoga,0.59,0.32,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dilipkumar amin,
+LS,1000,3.0,Therapeutic Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,1000,4.0,Introduction to Barre,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,1000,5.0,Introduction to Barre,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,1000,8.0,Intro to Volleyball,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,kelly lynn ator,
+LS,1000,10.0,FItness Leadership,0.58,0.08,0.08,0.0,0.0,0.0,0.0,0.25,jenny lynn rodgers,
+LS,1000,14.0,Introduction to Barre,0.73,0.13,0.13,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,1000,30.0,Stand up Pabbleboarding,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,merry hannah armstrong,
+LS,1410,1.0,Top Rope Climbing,0.73,0.07,0.0,0.07,0.13,0.0,0.0,0.0,thomas caldwell,
+LS,1410,3.0,Top Rope Climbing,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,thomas caldwell,
+LS,1560,4.0,Riflery,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,hubert cox,
+LS,1560,10.0,Riflery,0.7,0.0,0.0,0.0,0.1,0.0,0.0,0.2,douglas bonham stephens,
+LS,1560,13.0,Riflery,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,herbert wayne strickland,
+LS,1650,3.0,Inland Kayak Touring,0.82,0.0,0.09,0.0,0.09,0.0,0.0,0.0,merry hannah armstrong,
+LS,1850,1.0,Bowling,0.8,0.07,0.07,0.0,0.07,0.0,0.0,0.0,madison neely workman,
+LS,1850,2.0,Bowling,0.85,0.07,0.04,0.0,0.0,0.0,0.0,0.04,madison neely workman,
+LS,1850,3.0,Bowling,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.04,madison neely workman,
+LS,1850,7.0,Bowling,0.87,0.04,0.0,0.0,0.04,0.0,0.0,0.04,madison neely workman,
+LS,1850,8.0,Bowling,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,megan elizabeth cato,
+LS,1850,9.0,Bowling,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,angela rowan,
+LS,1850,10.0,Bowling,0.9,0.0,0.0,0.0,0.03,0.0,0.0,0.07,angela rowan,
+LS,1980,3.0,Golf,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,wesley scott womble,
+LS,1980,7.0,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,wesley scott womble,
+LS,2270,1.0,Intro to Swing Dance,0.88,0.0,0.04,0.0,0.0,0.0,0.0,0.08,paul hoke,
+LS,2270,2.0,Intro to Swing Dance,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,paul hoke,
+LS,2270,3.0,Intro to Swing Dance,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,
+LS,2320,1.0,Core Training,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,diane moreno,
+LS,2320,2.0,Core Training,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,
+LS,2320,3.0,Core Training,0.5,0.23,0.14,0.0,0.0,0.0,0.0,0.14,diane moreno,
+LS,2350,1.0,Basic Yoga,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2380,2.0,Vinyasa Flow Yoga,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,nicole elizabeth martinez,
+LS,2420,1.0,Meditation and Relax,0.83,0.04,0.0,0.04,0.04,0.0,0.0,0.04,renee warren gahan,
+LS,2420,2.0,Meditation and Relax,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2420,3.0,Meditation and Relax,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dilipkumar amin,
+LS,2420,4.0,Meditation and Relax,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.09,ranjanbala dilipkumar amin,
+LS,2420,5.0,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dilipkumar amin,
+LS,2420,6.0,Meditation and Relax,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dilipkumar amin,
+LS,2420,7.0,Meditation and Relax,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,cara jill wrenn,
+LS,2450,1.0,Pilates,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,melanie ivey job,
+LS,2450,4.0,Pilates,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
+LS,2450,6.0,Pilates,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,melanie ivey job,
+LS,2510,2.0,Running & Jogging,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,corey douglas brookover,
+LS,2700,1.0,Sports Officiating,0.64,0.0,0.09,0.0,0.0,0.0,0.0,0.27,christopher warren cox,
+LS,2750,3.0,First Aid/Cpr,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,christopher michael loomis,
+LS,2750,7.0,First Aid/Cpr,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,christopher michael loomis,
+LS,2750,8.0,First Aid/Cpr,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,christopher michael loomis,
+LS,3560,2.0,Riflery II,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,hubert cox,
+MATH,1010,1.0,Essen Math for Informed Soc,0.53,0.18,0.18,0.06,0.0,0.0,0.0,0.06,alexander joyce,
+MATH,1010,3.0,Essen Math for Informed Soc,0.45,0.36,0.1,0.07,0.0,0.0,0.0,0.02,judith elaine cottingham,
+MATH,1010,4.0,Essen Math for Informed Soc,0.42,0.21,0.21,0.16,0.0,0.0,0.0,0.0,philip de castro,
+MATH,1010,6.0,Essen Math for Informed Soc,0.3,0.38,0.11,0.11,0.05,0.0,0.0,0.05,judith elaine cottingham,
+MATH,1010,7.0,Essen Math for Informed Soc,0.38,0.5,0.08,0.03,0.0,0.0,0.0,0.03,judith elaine cottingham,
+MATH,1010,8.0,Essen Math for Informed Soc,0.14,0.5,0.07,0.21,0.0,0.0,0.0,0.07,philip de castro,
+MATH,1010,9.0,Essen Math for Informed Soc,0.56,0.28,0.06,0.0,0.06,0.0,0.0,0.06,alexander joyce,
+MATH,1020,1.0,Business Calculus I,0.28,0.28,0.28,0.11,0.0,0.0,0.0,0.06,andrew bellucco,
+MATH,1020,2.0,Business Calculus I,0.33,0.22,0.22,0.0,0.11,0.0,0.0,0.11,andrew bellucco,
+MATH,1020,3.0,Business Calculus I,0.37,0.21,0.26,0.11,0.0,0.0,0.0,0.05,tilly grace erwin,
+MATH,1020,4.0,Business Calculus I,0.56,0.19,0.06,0.13,0.0,0.0,0.0,0.06,tilly grace erwin,
+MATH,1020,5.0,Business Calculus I,0.27,0.4,0.13,0.13,0.07,0.0,0.0,0.0,eva murphy,
+MATH,1020,6.0,Business Calculus I,0.22,0.56,0.11,0.06,0.06,0.0,0.0,0.0,eva murphy,
+MATH,1020,7.0,Business Calculus I,0.17,0.22,0.28,0.22,0.0,0.0,0.0,0.11,michael glen eldredge,
+MATH,1020,8.0,Business Calculus I,0.35,0.12,0.18,0.18,0.12,0.0,0.0,0.06,michael glen eldredge,
+MATH,1020,9.0,Business Calculus I,0.39,0.22,0.06,0.06,0.17,0.0,0.0,0.11,tyler sullivan,
+MATH,1020,10.0,Business Calculus I,0.39,0.17,0.06,0.17,0.06,0.0,0.0,0.17,tyler sullivan,
+MATH,1020,11.0,Business Calculus I,0.28,0.33,0.17,0.0,0.06,0.0,0.0,0.17,david luke frost,
+MATH,1020,12.0,Business Calculus I,0.11,0.28,0.17,0.11,0.11,0.0,0.0,0.22,david luke frost,
+MATH,1020,13.0,Business Calculus I,0.21,0.26,0.47,0.0,0.0,0.0,0.0,0.05,yunan wang,
+MATH,1020,14.0,Business Calculus I,0.37,0.37,0.21,0.0,0.0,0.0,0.0,0.05,yunan wang,
+MATH,1020,15.0,Business Calculus I,0.14,0.43,0.36,0.07,0.0,0.0,0.0,0.0,daozhou zhu,
+MATH,1020,16.0,Business Calculus I,0.17,0.42,0.17,0.17,0.08,0.0,0.0,0.0,daozhou zhu,
+MATH,1020,17.0,Business Calculus I,0.08,0.35,0.2,0.13,0.15,0.0,0.0,0.1,neil calkin,
+MATH,1020,19.0,Business Calculus I,0.17,0.28,0.39,0.11,0.0,0.0,0.0,0.06,dominique evelyn forbes,
+MATH,1020,20.0,Business Calculus I,0.26,0.21,0.32,0.11,0.11,0.0,0.0,0.0,dominique evelyn forbes,
+MATH,1020,21.0,Business Calculus I,0.47,0.12,0.24,0.12,0.06,0.0,0.0,0.0,michael thomas cowen,
+MATH,1020,22.0,Business Calculus I,0.39,0.33,0.11,0.11,0.0,0.0,0.0,0.06,michael thomas cowen,
+MATH,1020,23.0,Business Calculus I,0.16,0.26,0.21,0.21,0.0,0.0,0.0,0.16,antonio pierrottet,
+MATH,1020,24.0,Business Calculus I,0.33,0.28,0.28,0.11,0.0,0.0,0.0,0.0,antonio pierrottet,
+MATH,1020,25.0,Business Calculus I,0.33,0.28,0.22,0.06,0.06,0.0,0.0,0.06,hossein faridian,
+MATH,1020,26.0,Business Calculus I,0.13,0.5,0.19,0.0,0.06,0.0,0.0,0.13,hossein faridian,
+MATH,1020,27.0,Business Calculus I,0.17,0.5,0.11,0.17,0.0,0.0,0.0,0.06,shanshan jia,
+MATH,1020,28.0,Business Calculus I,0.33,0.28,0.22,0.06,0.06,0.0,0.0,0.06,morgan elston,
+MATH,1020,29.0,Business Calculus I,0.25,0.31,0.13,0.06,0.19,0.0,0.0,0.06,morgan elston,
+MATH,1020,30.0,Business Calculus I,0.28,0.44,0.11,0.0,0.06,0.0,0.0,0.11,michael byrd,
+MATH,1020,31.0,Business Calculus I,0.22,0.5,0.22,0.0,0.0,0.0,0.0,0.06,michael byrd,
+MATH,1020,32.0,Business Calculus I,0.22,0.22,0.17,0.0,0.22,0.0,0.0,0.17,michael nelson,
+MATH,1020,33.0,Business Calculus I,0.24,0.24,0.41,0.0,0.06,0.0,0.0,0.06,michael nelson,
+MATH,1020,34.0,Business Calculus I,0.17,0.39,0.17,0.17,0.06,0.0,0.0,0.06,hemanta kunwar,
+MATH,1020,35.0,Business Calculus I,0.41,0.29,0.18,0.0,0.0,0.0,0.0,0.12,hemanta kunwar,
+MATH,1020,36.0,Business Calculus I,0.25,0.31,0.25,0.13,0.0,0.0,0.0,0.06,trinity white,
+MATH,1020,37.0,Business Calculus I,0.17,0.39,0.28,0.11,0.06,0.0,0.0,0.0,trinity white,
+MATH,1020,38.0,Business Calculus I,0.39,0.11,0.22,0.0,0.11,0.0,0.0,0.17,shanshan jia,
+MATH,1020,39.0,Business Calculus I,0.16,0.32,0.26,0.11,0.05,0.0,0.0,0.11,joseph swanson,
+MATH,1020,40.0,Business Calculus I,0.32,0.47,0.11,0.11,0.0,0.0,0.0,0.0,joseph swanson,
+MATH,1020,41.0,Business Calculus I,0.33,0.33,0.17,0.17,0.0,0.0,0.0,0.0,elliott degbe,
+MATH,1020,42.0,Business Calculus I,0.33,0.28,0.17,0.17,0.06,0.0,0.0,0.0,elliott degbe,
+MATH,1020,43.0,Business Calculus I,0.49,0.07,0.29,0.1,0.02,0.0,0.0,0.02,randy davidson,
+MATH,1020,44.0,Business Calculus I,0.26,0.36,0.18,0.15,0.05,0.0,0.0,0.0,randy davidson,
+MATH,1020,201.0,Business Calculus I,0.67,0.2,0.07,0.03,0.0,0.0,0.0,0.03,jennifer van dyken,
+MATH,1020,202.0,Business Calculus I,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,marion hanna,
+MATH,1040,1.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,donna simms,
+MATH,1040,3.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,anna caroline bachstein,
+MATH,1040,4.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,aaron moose,
+MATH,1040,5.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,todd anthony morra,
+MATH,1040,6.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,ryann rose cartor,
+MATH,1040,9.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.93,0.0,0.07,zachary david espe,
+MATH,1040,10.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,tony william long,
+MATH,1050,402.0,Precalculus,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.12,tony thanh nguyen,
+MATH,1050,403.0,Precalculus,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,tony thanh nguyen,
+MATH,1060,1.0,Calculus of One Variable I,0.31,0.24,0.19,0.05,0.12,0.0,0.0,0.1,catherine mary kenyon,
+MATH,1060,2.0,Calculus of One Variable I,0.35,0.33,0.14,0.02,0.07,0.0,0.0,0.09,james edward gossell,
+MATH,1060,3.0,Calculus of One Variable I,0.29,0.37,0.12,0.07,0.07,0.0,0.0,0.07,marvin clayton jones,
+MATH,1060,4.0,Calculus of One Variable I,0.29,0.37,0.08,0.0,0.18,0.0,0.0,0.08,sofya alekseeva,
+MATH,1060,5.0,Calculus of One Variable I,0.14,0.31,0.34,0.06,0.09,0.0,0.0,0.06,sofya alekseeva,
+MATH,1060,7.0,Calculus of One Variable I,0.32,0.29,0.2,0.0,0.12,0.0,0.0,0.07,scott scruggs,
+MATH,1060,8.0,Calculus of One Variable I,0.14,0.25,0.19,0.08,0.13,0.0,0.0,0.2,chad robert mangum,
+MATH,1060,10.0,Calculus of One Variable I,0.14,0.26,0.3,0.04,0.12,0.0,0.0,0.15,chad robert mangum,
+MATH,1060,12.0,Calculus of One Variable I,0.38,0.35,0.09,0.0,0.09,0.0,0.0,0.09,jason alexander kurz,
+MATH,1060,13.0,Calculus of One Variable I,0.26,0.36,0.15,0.05,0.13,0.0,0.0,0.05,nathan fontes,
+MATH,1060,14.0,Calculus of One Variable I,0.27,0.3,0.1,0.0,0.17,0.0,0.0,0.17,akshay sunil gupte,
+MATH,1060,201.0,Calculus of One Variable I,0.34,0.27,0.22,0.05,0.1,0.0,0.0,0.02,stephen peele,
+MATH,1060,202.0,Calculus of One Variable I,0.41,0.19,0.28,0.0,0.09,0.0,0.0,0.03,hugh geller,
+MATH,1060,203.0,Calculus of One Variable I,0.25,0.29,0.29,0.08,0.04,0.0,0.0,0.04,sofya alekseeva,
+MATH,1060,204.0,Calculus of One Variable I,0.44,0.29,0.13,0.04,0.09,0.0,0.0,0.0,stephen peele,
+MATH,1060,206.0,Calculus of One Variable I,0.45,0.28,0.18,0.05,0.0,0.0,0.0,0.05,peter westerbaan,
+MATH,1060,300.0,Calculus of One Variable I,0.29,0.29,0.24,0.0,0.1,0.0,0.0,0.1,matthew macauley,
+MATH,1070,1.0,Differen and Integral Calculus,0.0,0.15,0.6,0.1,0.1,0.0,0.0,0.05,donna simms,
+MATH,1080,1.0,Calculus of One Variable II,0.25,0.22,0.19,0.06,0.16,0.0,0.0,0.12,meredith nicole burr,
+MATH,1080,2.0,Calculus of One Variable II,0.23,0.23,0.18,0.1,0.21,0.0,0.0,0.05,blake anthony splitter,
+MATH,1080,3.0,Calculus of One Variable II,0.3,0.24,0.22,0.0,0.19,0.0,0.0,0.05,fei xue,
+MATH,1080,4.0,Calculus of One Variable II,0.15,0.26,0.11,0.07,0.19,0.0,0.0,0.22,terri johnson,
+MATH,1080,5.0,Calculus of One Variable II,0.14,0.11,0.31,0.11,0.22,0.0,0.0,0.11,terri johnson,
+MATH,1080,6.0,Calculus of One Variable II,0.15,0.28,0.23,0.03,0.25,0.0,0.0,0.08,fei xue,
+MATH,1080,7.0,Calculus of One Variable II,0.2,0.16,0.2,0.04,0.24,0.0,0.0,0.16,terri johnson,
+MATH,1080,201.0,Calculus of One Variable II,0.33,0.44,0.11,0.0,0.11,0.0,0.0,0.0,mark cawood,
+MATH,1150,1.0,Contemp Math for Elem Teach I,0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,angel carreras jusino,
+MATH,1150,2.0,Contemp Math for Elem Teach I,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,eliza dargan gallagher,
+MATH,1150,3.0,Contemp Math for Elem Teach I,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,angel carreras jusino,
+MATH,2060,1.0,Calculus of Several Variables,0.23,0.32,0.28,0.1,0.05,0.0,0.0,0.02,irina viktorova,
+MATH,2060,2.0,Calculus of Several Variables,0.12,0.38,0.31,0.05,0.09,0.0,0.0,0.05,irina viktorova,
+MATH,2060,3.0,Calculus of Several Variables,0.32,0.34,0.15,0.1,0.03,0.0,0.0,0.06,oleg yordanov,
+MATH,2060,4.0,Calculus of Several Variables,0.34,0.39,0.17,0.02,0.02,0.0,0.0,0.05,oleg yordanov,
+MATH,2060,5.0,Calculus of Several Variables,0.25,0.29,0.27,0.08,0.08,0.0,0.0,0.03,timothy charles teitloff,
+MATH,2060,6.0,Calculus of Several Variables,0.25,0.41,0.23,0.05,0.04,0.0,0.0,0.02,timothy charles teitloff,
+MATH,2060,7.0,Calculus of Several Variables,0.51,0.44,0.04,0.0,0.0,0.0,0.0,0.0,nantsoina ramiharimanana,
+MATH,2060,8.0,Calculus of Several Variables,0.27,0.25,0.14,0.14,0.05,0.0,0.0,0.16,timothy franklin parrott,
+MATH,2060,9.0,Calculus of Several Variables,0.18,0.3,0.13,0.05,0.2,0.0,0.0,0.15,timothy franklin parrott,
+MATH,2060,10.0,Calculus of Several Variables,0.38,0.3,0.15,0.06,0.11,0.0,0.0,0.0,allen anderson guest,
+MATH,2060,100.0,Calc of Several Vars (HON),0.8,0.16,0.02,0.0,0.02,0.0,0.0,0.0,yuyuan ouyang,True
+MATH,2060,201.0,Calculus of Several Variables,0.38,0.33,0.23,0.0,0.0,0.0,0.0,0.08,allen anderson guest,
+MATH,2060,202.0,Calculus of Several Variables,0.47,0.3,0.07,0.1,0.07,0.0,0.0,0.0,allen anderson guest,
+MATH,2070,1.0,Business Calculus II,0.29,0.24,0.18,0.18,0.0,0.0,0.0,0.12,nathaniel nemire,
+MATH,2070,2.0,Business Calculus II,0.37,0.11,0.21,0.11,0.16,0.0,0.0,0.05,nathaniel nemire,
+MATH,2070,3.0,Business Calculus II,0.22,0.22,0.11,0.22,0.11,0.0,0.0,0.11,ebenezer eduafo,
+MATH,2070,4.0,Business Calculus II,0.11,0.0,0.39,0.33,0.11,0.0,0.0,0.06,ebenezer eduafo,
+MATH,2070,5.0,Business Calculus II,0.05,0.32,0.26,0.26,0.05,0.0,0.0,0.05,haodong li,
+MATH,2070,6.0,Business Calculus II,0.19,0.06,0.19,0.13,0.06,0.0,0.0,0.38,haodong li,
+MATH,2070,7.0,Business Calculus II,0.48,0.27,0.16,0.05,0.0,0.0,0.0,0.05,jennifer marie hanna,
+MATH,2070,8.0,Business Calculus II,0.36,0.41,0.09,0.05,0.0,0.0,0.0,0.09,jennifer marie hanna,
+MATH,2070,9.0,Business Calculus II,0.55,0.25,0.07,0.05,0.02,0.0,0.0,0.07,jennifer marie hanna,
+MATH,2070,10.0,Business Calculus II,0.47,0.09,0.24,0.16,0.02,0.0,0.0,0.02,jennifer marie hanna,
+MATH,2070,11.0,Business Calculus II,0.33,0.32,0.15,0.09,0.03,0.0,0.0,0.07,jennifer ray newton,
+MATH,2070,12.0,Business Calculus II,0.29,0.25,0.31,0.09,0.03,0.0,0.0,0.03,jennifer ray newton,
+MATH,2070,13.0,Business Calculus II,0.35,0.18,0.29,0.06,0.06,0.0,0.0,0.06,travis alvarez,
+MATH,2070,14.0,Business Calculus II,0.26,0.21,0.26,0.16,0.0,0.0,0.0,0.11,travis alvarez,
+MATH,2080,1.0,Intro to Ordin Diff Equations,0.16,0.28,0.28,0.05,0.08,0.0,0.0,0.14,jeong rock yoon,
+MATH,2080,2.0,Intro to Ordin Diff Equations,0.1,0.2,0.3,0.17,0.13,0.0,0.0,0.1,julie lassiter,
+MATH,2080,3.0,Intro to Ordin Diff Equations,0.19,0.27,0.22,0.16,0.05,0.0,0.0,0.11,julie lassiter,
+MATH,2080,4.0,Intro to Ordin Diff Equations,0.5,0.38,0.08,0.0,0.03,0.0,0.0,0.03,nantsoina ramiharimanana,
+MATH,2080,5.0,Intro to Ordin Diff Equations,0.26,0.34,0.09,0.11,0.14,0.0,0.0,0.06,timothy franklin parrott,
+MATH,2160,1.0,Geometry for Elem Sch Teachers,0.89,0.05,0.0,0.03,0.03,0.0,0.0,0.0,nicole alaine bannister sinwell,
+MATH,2160,2.0,Geometry for Elem Sch Teachers,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,nicole alaine bannister sinwell,
+MATH,3020,2.0,Stat for Science & Engineering,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,qiong zhang,
+MATH,3020,3.0,Stat for Science & Engineering,0.67,0.25,0.06,0.0,0.03,0.0,0.0,0.0,xiaoqian sun,
+MATH,3020,4.0,Stat for Science & Engineering,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,kayla doris javier,
+MATH,3020,5.0,Stat for Science & Engineering,0.58,0.26,0.11,0.05,0.0,0.0,0.0,0.0,kayla doris javier,
+MATH,3020,6.0,Stat for Science & Engineering,0.47,0.32,0.16,0.0,0.05,0.0,0.0,0.0,todd fenstermacher,
+MATH,3020,7.0,Stat for Science & Engineering,0.26,0.58,0.05,0.05,0.0,0.0,0.0,0.05,todd fenstermacher,
+MATH,3020,8.0,Stat for Science & Engineering,0.26,0.26,0.26,0.05,0.16,0.0,0.0,0.0,zhiyun gong,
+MATH,3020,9.0,Stat for Science & Engineering,0.39,0.19,0.22,0.08,0.06,0.0,0.0,0.06,zhiyun gong,
+MATH,3020,10.0,Stat for Science & Engineering,0.35,0.29,0.18,0.03,0.09,0.0,0.0,0.06,zhiyun gong,
+MATH,3020,13.0,Stat for Science & Engineering,0.23,0.51,0.11,0.09,0.03,0.0,0.0,0.03,xiaoqian sun,
+MATH,3020,14.0,Stat for Science & Engineering,0.31,0.29,0.34,0.0,0.06,0.0,0.0,0.0,ellen hepfer breazel,
+MATH,3110,1.0,Linear Algebra,0.25,0.5,0.21,0.02,0.0,0.0,0.0,0.02,wayne goddard,
+MATH,3110,2.0,Linear Algebra,0.31,0.42,0.25,0.0,0.0,0.0,0.0,0.02,wayne goddard,
+MATH,3110,4.0,Linear Algebra,0.38,0.35,0.15,0.08,0.02,0.0,0.0,0.01,beth novick,
+MATH,3110,5.0,Linear Algebra,0.34,0.26,0.16,0.11,0.13,0.0,0.0,0.0,svetlana poznanovikj,
+MATH,3110,6.0,Linear Algebra,0.27,0.24,0.27,0.11,0.11,0.0,0.0,0.0,svetlana poznanovikj,
+MATH,3110,7.0,Linear Algebra,0.48,0.36,0.11,0.02,0.0,0.0,0.0,0.02,neil calkin,
+MATH,3110,100.0,Linear Algebra (HON),0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,michael adam burr,True
+MATH,3190,1.0,Introduction to Proof,0.48,0.29,0.19,0.0,0.05,0.0,0.0,0.0,michael adam burr,
+MATH,3190,2.0,Introduction to Proof,0.3,0.26,0.3,0.0,0.04,0.0,0.0,0.09,james barker coykendall,
+MATH,3600,1.0,Intermediate Math Computing,0.73,0.15,0.06,0.04,0.02,0.0,0.0,0.0,mark cawood,
+MATH,3650,1.0,Numerical Mthds for Engineers,0.14,0.25,0.39,0.06,0.13,0.0,0.0,0.03,eleanor jenkins,
+MATH,3650,2.0,Numerical Mthds for Engineers,0.17,0.42,0.19,0.04,0.04,0.0,0.0,0.15,vincent ervin,
+MATH,3650,3.0,Numerical Mthds for Engineers,0.46,0.36,0.1,0.03,0.03,0.0,0.0,0.03,sibusiso samkele mabuza,
+MATH,3990,1.0,Creative Inquiry in Math,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,irina viktorova,
+MATH,4000,1.0,Theory of Probability,0.22,0.26,0.37,0.04,0.04,0.0,0.0,0.07,brian fralix,
+MATH,4000,2.0,Theory of Probability,0.28,0.5,0.11,0.08,0.03,0.0,0.0,0.0,peter kiessler,
+MATH,4020,1.0,Stat for Sci & Engineering II,0.55,0.0,0.09,0.18,0.0,0.0,0.0,0.18,derek brown,
+MATH,4070,1.0,Regress & Time-Series Analysis,0.5,0.2,0.0,0.1,0.0,0.0,0.0,0.2,robert lund,
+MATH,4120,1.0,Algebra I,0.59,0.14,0.05,0.0,0.09,0.0,0.0,0.14,matthew macauley,
+MATH,4120,2.0,Algebra I,0.32,0.37,0.16,0.05,0.05,0.0,0.0,0.05,hui xue,
+MATH,4190,1.0,Discrete Math Structures I,0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,beth novick,
+MATH,4190,2.0,Discrete Math Structures I,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,beth novick,
+MATH,4310,1.0,Theory of Interest,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0, erwin walker,
+MATH,4340,1.0,Adv Engineering Mathematics,0.26,0.47,0.21,0.0,0.03,0.0,0.0,0.03,qingshan chen,
+MATH,4340,2.0,Adv Engineering Mathematics,0.27,0.36,0.18,0.14,0.05,0.0,0.0,0.0,vincent ervin,
+MATH,4350,1.0,Complex Variables,0.45,0.0,0.45,0.0,0.09,0.0,0.0,0.0,shitao liu,
+MATH,4400,1.0,Linear Programming,0.35,0.35,0.27,0.0,0.04,0.0,0.0,0.0,margaret maria wiecek,
+MATH,4410,1.0,Intro to Stochastic Models,0.57,0.14,0.21,0.0,0.07,0.0,0.0,0.0,xin liu,
+MATH,4530,1.0,Advanced Calculus I,0.43,0.26,0.23,0.03,0.06,0.0,0.0,0.0,benjamin jaye,
+MATH,4540,1.0,Advanced Calculus II,0.3,0.3,0.3,0.0,0.0,0.0,0.0,0.1,james peterson,
+MATH,4630,1.0,Real Analysis I,0.47,0.41,0.0,0.0,0.0,0.0,0.0,0.12,shitao liu,
+MATH,4810,1.0,Putnam Seminar,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,neil calkin,
+MATH,6340,1.0,Adv Engineering Mathematics,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
+MATH,8000,1.0,Probability,0.65,0.24,0.0,0.0,0.06,0.0,0.0,0.06,xin liu,
+MATH,8010,1.0,General Linear Hypothesis I,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,derek brown,
+MATH,8050,1.0,Data Analysis,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,brook thayer russell,
+MATH,8070,1.0,Applied Multivariate Analysis,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
+MATH,8090,1.0,Time Series Analysis,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert lund,
+MATH,8140,1.0,Network Flow Programming,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
+MATH,8170,1.0,Stochastic Mod in Oper Rsrch I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
+MATH,8210,1.0,Linear Analysis,0.52,0.24,0.19,0.0,0.05,0.0,0.0,0.0,mishko mitkovski,
+MATH,8510,1.0,Abstract Algebra I,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,james barker coykendall,
+MATH,8530,1.0,Matrix Analysis,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,xuhong gao,
+MATH,8600,1.0,Intro to Scientific Computing,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
+MATH,8650,1.0,Data Structures,0.46,0.31,0.0,0.0,0.0,0.0,0.0,0.23,timo johannes heister,
+MATH,8850,1.0,Advanced Data Analysis,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,
+MBA,8030,1.0,Stat Analy of Bus Op,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,dee ann wood kivett,
+MBA,8030,2.0,Stat Analy of Bus Op,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william edward kilbourne,
+MBA,8040,20.0,Busin Data An & Stat Computing,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,william edward kilbourne,
+MBA,8060,1.0,Operations Mgt,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MBA,8060,2.0,Operations Mgt,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,george kenneth morgan,
+MBA,8070,1.0,Financial Management,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,
+MBA,8070,2.0,Financial Management,0.55,0.4,0.0,0.0,0.05,0.0,0.0,0.0,george brandon lockhart,
+MBA,8070,20.0,Financial Management,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,
+MBA,8090,1.0,Org Beh & Hum Res Mg,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,thomas joseph zagenczyk,
+MBA,8090,2.0,Org Beh & Hum Res Mg,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,thomas joseph zagenczyk,
+MBA,8090,3.0,Org Beh & Hum Res Mg,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,thomas joseph zagenczyk,
+MBA,8180,20.0,Intro Business Intell & Anlytc,0.83,0.14,0.0,0.0,0.0,0.0,0.0,0.03,john frederick tripp,
+MBA,8190,2.0,Intro to Acc and Fin,0.48,0.45,0.07,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,
+MBA,8190,3.0,Intro to Acc and Fin,0.09,0.45,0.14,0.0,0.14,0.0,0.0,0.18,jeffrey mcmillan,
+MBA,8290,1.0,Marketing Foundation,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ankita bakre,
+MBA,8310,10.0,Communications and Sales,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,
+MBA,8370,1.0,Legal Environ of Bus,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8370,2.0,Legal Environ of Bus,0.34,0.57,0.06,0.0,0.0,0.0,0.0,0.03,judson jahn,
+MBA,8400,1.0,Entrepreneurship & Venture Mgt,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,prashant prabhu,
+MBA,8410,1.0,Real Estate Finance,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,ryan dietz,
+MBA,8430,1.0,Entrepreneurial Accounting,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,annieka philo,
+MBA,8440,1.0,Entrepreneurial Law,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john hine,
+MBA,8480,1.0,Entrpr Mkting & Digital Strat,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,bruce snyder,
+MBA,8480,5.0,Entrpr Mkting & Digital Strat,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,
+MBA,8490,5.0,Entrepreneurial Strategy,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,matthew charles klein,
+MBA,8510,1.0,Bus Operations & Logistics,0.25,0.56,0.13,0.0,0.0,0.0,0.0,0.06, sridharan,
+MBA,8540,2.0,Managerial Accounting,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.03,emily suzanne mccorkle,
+MBA,8590,1.0,Mgr Decision Model,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,james turner,
+MBA,8590,2.0,Mgr Decision Model,0.29,0.42,0.08,0.0,0.0,0.0,0.0,0.21,magda gabriela sava,
+MBA,8590,3.0,Mgr Decision Model,0.31,0.38,0.13,0.0,0.03,0.0,0.0,0.16,magda gabriela sava,
+MBA,8600,2.0,Advanced Marketing Strategy,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,joseph renato gibson,
+MBA,8610,2.0,Information Systems,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,william kettinger,
+MBA,8620,1.0,Managerial Economics,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,scott templeton,
+MBA,8620,2.0,Managerial Economics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,
+MBA,8620,4.0,Managerial Economics,0.56,0.36,0.04,0.0,0.0,0.0,0.0,0.04,ronald earle gregory,
+MBA,8660,21.0,"Data, Storage, Business Decis",0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,he li,
+MBA,8700,1.0,Strategic Management,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,james turner,
+MBA,8990,2.0,Creativity,0.79,0.14,0.05,0.0,0.0,0.0,0.0,0.02,kathleen ann kegley,
+MBA,8990,4.0,Data Analytics & Visualization,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,john frederick tripp,
+MBA,8990,7.0,Digital Marketing,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,robert andrew fitzwater,
+ME,2000,1.0,Sophomore Seminar,0.91,0.05,0.01,0.0,0.0,0.0,0.0,0.03,todd alan schweisinger,
+ME,2000,2.0,Sophomore Seminar,0.74,0.16,0.03,0.01,0.02,0.0,0.0,0.05,todd alan schweisinger,
+ME,2010,1.0,Statics & Dynamics,0.07,0.16,0.25,0.09,0.25,0.0,0.0,0.16,gang liu,
+ME,2010,2.0,Statics & Dynamics,0.17,0.24,0.31,0.07,0.13,0.0,0.0,0.08,paul joseph,
+ME,2010,3.0,Statics & Dynamics,0.05,0.16,0.26,0.15,0.15,0.0,0.0,0.24,gang li,
+ME,2010,4.0,Statics & Dynamics,0.02,0.14,0.25,0.17,0.22,0.0,0.0,0.2,marisa kikendall orr,
+ME,2030,1.0,Founda Th/Fl Syst,0.42,0.33,0.14,0.05,0.05,0.0,0.0,0.02,sandip dutta,
+ME,2030,2.0,Founda Th/Fl Syst,0.27,0.29,0.16,0.16,0.04,0.0,0.0,0.09,xiangchun xuan,
+ME,2040,1.0,Mechanics of Materials,0.24,0.51,0.18,0.04,0.04,0.0,0.0,0.0,fadi abdeljawad,
+ME,2040,2.0,Mechanics of Materials,0.19,0.53,0.16,0.03,0.03,0.0,0.0,0.06,huijuan zhao,
+ME,2220,1.0,Mechanical Engineering Lab I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,douglas scott byrd,
+ME,2220,2.0,Mechanical Engineering Lab I,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
+ME,2220,3.0,Mechanical Engineering Lab I,0.13,0.56,0.13,0.0,0.0,0.0,0.0,0.19,douglas scott byrd,
+ME,2220,5.0,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
+ME,2220,6.0,Mechanical Engineering Lab I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
+ME,2220,7.0,Mechanical Engineering Lab I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
+ME,2220,8.0,Mechanical Engineering Lab I,0.56,0.31,0.0,0.0,0.06,0.0,0.0,0.06,douglas scott byrd,
+ME,2220,10.0,Mechanical Engineering Lab I,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,douglas scott byrd,
+ME,2220,11.0,Mechanical Engineering Lab I,0.13,0.53,0.2,0.0,0.0,0.0,0.0,0.13,douglas scott byrd,
+ME,2220,13.0,Mechanical Engineering Lab I,0.31,0.5,0.06,0.0,0.0,0.0,0.0,0.13,douglas scott byrd,
+ME,2220,15.0,Mechanical Engineering Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
+ME,3030,1.0,Thermodynamics,0.12,0.3,0.33,0.12,0.06,0.0,0.0,0.06,john saylor,
+ME,3030,2.0,Thermodynamics,0.23,0.31,0.34,0.11,0.02,0.0,0.0,0.0,yiqiang han,
+ME,3030,3.0,Thermodynamics,0.09,0.31,0.47,0.04,0.02,0.0,0.0,0.07,yiqiang han,
+ME,3040,1.0,Heat Transfer,0.55,0.35,0.07,0.01,0.0,0.0,0.0,0.01,sandip dutta,
+ME,3040,2.0,Heat Transfer,0.09,0.25,0.45,0.09,0.07,0.0,0.0,0.05,geetha pravallika chimata,
+ME,3050,1.0,Model/an Dy Syst,0.25,0.34,0.27,0.09,0.05,0.0,0.0,0.0,ardalan vahidi,
+ME,3050,2.0,Model/an Dy Syst,0.18,0.35,0.26,0.09,0.09,0.0,0.0,0.03,seyedyasha parvinioskoui,
+ME,3060,1.0,Fund Machine Design,0.34,0.38,0.19,0.06,0.02,0.0,0.0,0.0,katherine marie ehlert,
+ME,3060,2.0,Fund Machine Design,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,zhaoxu meng,
+ME,3060,3.0,Fund Machine Design,0.15,0.34,0.24,0.15,0.07,0.0,0.0,0.05,nafiseh masoudi,
+ME,3070,1.0,Found of Mechanical Systems,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,pooya niksiar,
+ME,3070,2.0,Found of Mechanical Systems,0.5,0.35,0.08,0.03,0.03,0.0,0.0,0.03,lonny thompson,
+ME,3070,3.0,Found of Mechanical Systems,0.67,0.22,0.09,0.0,0.0,0.0,0.0,0.01,pooya niksiar,
+ME,3080,1.0,Fluid Mechanics,0.16,0.53,0.24,0.02,0.02,0.0,0.0,0.02,zhen li,
+ME,3080,2.0,Fluid Mechanics,0.18,0.2,0.38,0.2,0.02,0.0,0.0,0.02,seyedyasha parvinioskoui,
+ME,3080,3.0,Fluid Mechanics,0.26,0.34,0.36,0.03,0.0,0.0,0.0,0.0,ethan kung,
+ME,3080,301.0,Fluid Mechanics (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,zhen li,True
+ME,3120,1.0,Manuf Processes,0.66,0.32,0.02,0.0,0.0,0.0,0.0,0.0,xin zhao,
+ME,3120,2.0,Manuf Processes,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,rodrigo martinez-duarte,
+ME,3330,1.0,Mechanical Engineering Lab II,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,2.0,Mechanical Engineering Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,5.0,Mechanical Engineering Lab II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,6.0,Mechanical Engineering Lab II,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,gang liu,
+ME,3330,8.0,Mechanical Engineering Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,9.0,Mechanical Engineering Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,10.0,Mechanical Engineering Lab II,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,16.0,Mechanical Engineering Lab II,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3900,103.0,CI ME - Autonomous Micro Drone,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,yiqiang han,
+ME,4000,1.0,Senior Seminar,0.98,0.01,0.0,0.0,0.01,0.0,0.0,0.0,atul gajanan kelkar,
+ME,4010,2.0,Mech Engr Design,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4010,864.0,Mech Engr Design,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,geetha pravallika chimata,
+ME,4020,3.0,Intern in Engr Des,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,pooya niksiar,
+ME,4030,1.0,Control Dynamic Systems,0.3,0.27,0.03,0.24,0.15,0.0,0.0,0.0,mohammad naghnaeian,
+ME,4030,2.0,Control Dynamic Systems,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,suyi li,
+ME,4030,3.0,Control Dynamic Systems,0.73,0.18,0.05,0.05,0.0,0.0,0.0,0.0,hubert bryan riley,
+ME,4210,1.0,Intro to Comp Flow,0.43,0.14,0.36,0.07,0.0,0.0,0.0,0.0,chenning tong,
+ME,4290,1.0,Ther Env Control,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,jay ochterbeck,
+ME,4320,1.0,Advanced Strength of Materials,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,oliver myers,
+ME,4340,1.0,Cardiovascular Biomechanics,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,ethan kung,
+ME,4440,1.0,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,2.0,Mechanical Engineering Lab III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4440,5.0,Mechanical Engineering Lab III,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4580,1.0,Fund Micro/Nano Fabrication,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,rodrigo martinez-duarte,
+ME,4710,1.0,Ca Eng Anly & Design,0.32,0.53,0.03,0.03,0.0,0.0,0.0,0.11,georges fadel,
+ME,4930,14.0,Sel.Topics ME - NonLinDy&Chas,0.13,0.5,0.38,0.0,0.0,0.0,0.0,0.0,joshua bostwick,
+ME,4930,35.0,Sel Topics ME: Smart Materials,0.55,0.34,0.07,0.0,0.0,0.0,0.0,0.03,oliver myers,
+ME,4930,39.0,Sel.Topics ME - Aero Propul,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,pooya niksiar,
+ME,4930,77.0,Selected Topics ME - Boeing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,6320,1.0,Advanced Strength of Materials,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,oliver myers,
+ME,6550,864.0,Design for Manuf,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,joshua summers,
+ME,6710,1.0,Ca Eng Anly & Design,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,6930,14.0,Sel.Topics ME - NonLinDy&Chas,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joshua bostwick,
+ME,6930,35.0,Sel Topics ME: Smart Materials,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,oliver myers,
+ME,8010,1.0,Found of Fluid Mech,0.36,0.32,0.23,0.0,0.05,0.0,0.0,0.05,richard figliola,
+ME,8100,1.0,Macroscopic Thermo,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,jay ochterbeck,
+ME,8180,1.0,Intro to Fin Ele Ana,0.7,0.25,0.0,0.0,0.02,0.0,0.0,0.03,lonny thompson,
+ME,8180,843.0,Intro to Fin Ele Ana,0.57,0.0,0.29,0.0,0.0,0.0,0.0,0.14,lonny thompson,
+ME,8230,1.0,Control Systems,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,
+ME,8230,864.0,Control Systems,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,yue wang,
+ME,8300,1.0,Cond/Rad Heat Tfr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,
+ME,8400,1.0,Plasticity,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,garrett pataky,
+ME,8460,1.0,Inter Dynamics,0.5,0.21,0.21,0.0,0.0,0.0,0.0,0.07,phanindra tallapragada,
+ME,8700,1.0,Adv Design Methods,0.97,0.02,0.02,0.0,0.0,0.0,0.0,0.0,cameron turner,
+ME,8710,1.0,Engr Optimization,0.78,0.13,0.02,0.0,0.0,0.0,0.0,0.07,georges fadel,
+ME,8930,2.0,Sel Topics ME: Adv Mfg,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,hong seok choi,
+MGT,2010,1.0,Principles of Management,0.35,0.4,0.19,0.03,0.01,0.0,0.0,0.02,katherine clark,
+MGT,2010,2.0,Principles of Management,0.52,0.33,0.11,0.02,0.01,0.0,0.0,0.01,tina robbins,
+MGT,2010,8.0,Principles of Management,0.4,0.35,0.23,0.0,0.0,0.0,0.0,0.03,christopher mann,
+MGT,2010,9.0,Principles of Management,0.26,0.53,0.08,0.11,0.03,0.0,0.0,0.0,christopher mann,
+MGT,2010,10.0,Principles of Management,0.31,0.33,0.31,0.0,0.03,0.0,0.0,0.03,ashley williams parnell,
+MGT,2010,11.0,Principles of Management,0.33,0.31,0.23,0.08,0.0,0.0,0.0,0.05,ashley williams parnell,
+MGT,2010,12.0,Principles of Management,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,nicholas byrd,
+MGT,2010,13.0,Principles of Management,0.79,0.13,0.08,0.0,0.0,0.0,0.0,0.0,shuang liu,
+MGT,2180,1.0,Management PC Applications,0.56,0.29,0.09,0.02,0.02,0.0,0.0,0.02,ryan toole,
+MGT,2180,2.0,Management PC Applications,0.25,0.6,0.03,0.0,0.0,0.0,0.0,0.13,ryan toole,
+MGT,3070,1.0,Human Resource Management,0.46,0.49,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,
+MGT,3070,3.0,Human Resource Management,0.37,0.41,0.15,0.07,0.0,0.0,0.0,0.0,kristin damato scott,
+MGT,3070,4.0,Human Resource Management,0.46,0.49,0.06,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,5.0,Human Resource Management,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,
+MGT,3070,6.0,Human Resource Management,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,7.0,Human Resource Management,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,
+MGT,3070,8.0,Human Resource Management,0.2,0.49,0.26,0.03,0.03,0.0,0.0,0.0,priscilla harrison,
+MGT,3100,1.0,Intermed Business Statistics,0.26,0.29,0.32,0.0,0.06,0.0,0.0,0.06,daniel allan detoma,
+MGT,3100,2.0,Intermed Business Statistics,0.37,0.17,0.31,0.03,0.09,0.0,0.0,0.03,mustafa serkan akturk,
+MGT,3100,3.0,Intermed Business Statistics,0.56,0.18,0.15,0.0,0.03,0.0,0.0,0.09,maneeshreddy ajjuguttu,
+MGT,3100,5.0,Intermed Business Statistics,0.4,0.18,0.33,0.03,0.03,0.0,0.0,0.05,mustafa serkan akturk,
+MGT,3100,6.0,Intermed Business Statistics,0.81,0.03,0.05,0.03,0.05,0.0,0.0,0.03,david ford peyton,
+MGT,3100,7.0,Intermed Business Statistics,0.54,0.32,0.03,0.03,0.03,0.0,0.0,0.05,seyed amin seyed haeri,
+MGT,3100,8.0,Intermed Business Statistics,0.65,0.25,0.08,0.0,0.0,0.0,0.0,0.03,david ford peyton,
+MGT,3100,9.0,Intermed Business Statistics,0.51,0.23,0.1,0.1,0.05,0.0,0.0,0.0,david ford peyton,
+MGT,3100,10.0,Intermed Business Statistics,0.45,0.34,0.13,0.03,0.05,0.0,0.0,0.0,jeromy blake snider,
+MGT,3100,12.0,Intermed Business Statistics,0.13,0.31,0.44,0.0,0.03,0.0,0.0,0.1,daniel allan detoma,
+MGT,3100,13.0,Intermed Business Statistics,0.86,0.08,0.03,0.0,0.03,0.0,0.0,0.0,benjamin christopher wiles,
+MGT,3120,1.0,Decision Models for Management,0.29,0.22,0.28,0.11,0.06,0.0,0.0,0.05,sara elizabeth yoder,
+MGT,3120,2.0,Decision Models for Management,0.19,0.14,0.34,0.16,0.14,0.0,0.0,0.03,sara elizabeth yoder,
+MGT,3120,4.0,Decision Models for Management,0.25,0.22,0.32,0.07,0.05,0.0,0.0,0.08,sara elizabeth yoder,
+MGT,3170,1.0,Logistics Mgmt,0.43,0.48,0.09,0.0,0.0,0.0,0.0,0.0,ahmet colak,
+MGT,3180,1.0,Mgt of Info Systems,0.53,0.43,0.05,0.0,0.0,0.0,0.0,0.0,wenxi pu,
+MGT,3180,3.0,Mgt of Info Systems,0.38,0.4,0.03,0.1,0.05,0.0,0.0,0.05,zhihong ke,
+MGT,3180,4.0,Mgt of Info Systems,0.56,0.33,0.09,0.02,0.0,0.0,0.0,0.0,he li,
+MGT,3180,5.0,Mgt of Info Systems,0.4,0.5,0.05,0.0,0.02,0.0,0.0,0.02,wenxi pu,
+MGT,3180,6.0,Mgt of Info Systems,0.69,0.16,0.13,0.02,0.0,0.0,0.0,0.0,shih lun tseng,
+MGT,3180,7.0,Mgt of Info Systems,0.68,0.23,0.07,0.0,0.02,0.0,0.0,0.0,shih lun tseng,
+MGT,3180,8.0,Mgt of Info Systems,0.56,0.06,0.19,0.06,0.08,0.0,0.0,0.06,kevin mckenzie,
+MGT,3500,1.0,Intro to Business Analytics,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,hongki kim,
+MGT,3510,1.0,Business Analytics & Problems,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,david ford peyton,
+MGT,3900,1.0,Operations Management,0.31,0.39,0.11,0.03,0.03,0.0,0.0,0.13, sridharan,
+MGT,3900,2.0,Operations Management,0.29,0.41,0.14,0.05,0.05,0.0,0.0,0.05, sridharan,
+MGT,3900,4.0,Operations Management,0.1,0.2,0.48,0.1,0.08,0.0,0.0,0.05,zachary moran leffakis,
+MGT,3900,5.0,Operations Management,0.46,0.38,0.1,0.03,0.03,0.0,0.0,0.0,benjamin noah grant,
+MGT,3900,6.0,Operations Management,0.28,0.38,0.23,0.05,0.08,0.0,0.0,0.0,benjamin noah grant,
+MGT,4000,1.0,Mgt of Organizational Behavior,0.59,0.39,0.0,0.0,0.0,0.0,0.0,0.02,michael cole,
+MGT,4000,2.0,Mgt of Organizational Behavior,0.73,0.25,0.0,0.03,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,3.0,Mgt of Organizational Behavior,0.29,0.53,0.16,0.0,0.03,0.0,0.0,0.0,thomas joseph zagenczyk,
+MGT,4000,4.0,Mgt of Organizational Behavior,0.21,0.29,0.32,0.16,0.0,0.0,0.0,0.03,philip roth,
+MGT,4020,1.0,Ops Pln and Ctl,0.06,0.25,0.69,0.0,0.0,0.0,0.0,0.0,zachary moran leffakis,
+MGT,4080,1.0,Lean Operations,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,zachary moran leffakis,
+MGT,4110,1.0,Project Management,0.35,0.43,0.14,0.0,0.03,0.0,0.0,0.05,russell purvis,
+MGT,4120,1.0,Supplier Management,0.48,0.33,0.15,0.0,0.0,0.0,0.0,0.03,ahmet colak,
+MGT,4150,1.0,Business Strategy,0.25,0.53,0.23,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,2.0,Business Strategy,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,3.0,Business Strategy,0.1,0.65,0.25,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,4.0,Business Strategy,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
+MGT,4150,5.0,Business Strategy (HON),0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,True
+MGT,4150,6.0,Business Strategy,0.1,0.56,0.33,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,7.0,Business Strategy,0.45,0.4,0.14,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,
+MGT,4150,8.0,Business Strategy,0.21,0.51,0.28,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,
+MGT,4150,9.0,Business Strategy,0.39,0.53,0.05,0.0,0.0,0.0,0.0,0.03,amy elizabeth ingram,
+MGT,4150,12.0,Business Strategy,0.21,0.5,0.29,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4160,1.0,Special Topics Hr,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,kristin damato scott,
+MGT,4230,1.0,Intern Bus Mgt,0.18,0.18,0.52,0.09,0.02,0.0,0.0,0.0,wayne stewart,
+MGT,4230,2.0,Intern Bus Mgt,0.23,0.38,0.3,0.05,0.05,0.0,0.0,0.0,wayne stewart,
+MGT,4230,3.0,Intern Bus Mgt,0.13,0.45,0.37,0.02,0.03,0.0,0.0,0.0,janis miller,
+MGT,4240,1.0,Global Supply Chain Management,0.32,0.44,0.21,0.0,0.03,0.0,0.0,0.0,yann ferrand,
+MGT,4270,2.0,Managing Improvement,0.27,0.4,0.23,0.0,0.03,0.0,0.0,0.07,lawrence fredendall,
+MGT,4310,1.0,Emp Rights & Resp,0.21,0.62,0.15,0.03,0.0,0.0,0.0,0.0,leonard joseph spooner,
+MGT,4350,1.0,Pers Interviewing,0.42,0.56,0.03,0.0,0.0,0.0,0.0,0.0,philip roth,
+MGT,4520,1.0,Business Analysis,0.24,0.58,0.12,0.0,0.0,0.0,0.0,0.06,russell purvis,
+MGT,4540,1.0,Systems Implement,0.55,0.31,0.1,0.0,0.03,0.0,0.0,0.0,hongki kim,
+MGT,8690,1.0,Project Mgt,0.49,0.49,0.0,0.0,0.0,0.0,0.0,0.02,russell purvis,
+MICR,2050,1.0,Introductory Micro,0.37,0.46,0.16,0.02,0.0,0.0,0.0,0.01,john abercrombie,
+MICR,3050,1.0,General Microbiology,0.39,0.39,0.18,0.02,0.0,0.0,0.0,0.01,krista barrier rudolph,
+MICR,3050,2.0,General Microbiology,0.42,0.39,0.14,0.04,0.0,0.0,0.0,0.0,krista barrier rudolph,
+MICR,4010,1.0,Microbial Diversity & Ecology,0.58,0.22,0.14,0.02,0.02,0.0,0.0,0.02,kristi james whitehead,
+MICR,4010,2.0,Micro Diversity/Ecol (HON),0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristi james whitehead,True
+MICR,4050,1.0,Adv Microbial Ecol of Humans,0.49,0.37,0.1,0.02,0.0,0.0,0.0,0.01,kristi james whitehead,
+MICR,4140,1.0,Basic Immunology,0.38,0.45,0.13,0.0,0.02,0.0,0.0,0.02,yanzhang wei,
+MICR,4150,1.0,Microbial Genetics,0.3,0.32,0.3,0.09,0.0,0.0,0.0,0.0,min cao,
+MICR,4160,1.0,Intro Virology,0.79,0.18,0.01,0.01,0.0,0.0,0.0,0.0,kaustubha ratan qanungo,
+MICR,4510,2.0,Advanced Microbiology II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4510,3.0,Advanced Microbiology II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4510,4.0,Advanced Microbiology II,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4930,1.0,Sr Sem: Emerg Infect Diseases,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,kristi james whitehead,
+MKT,3010,1.0,Principles of Marketing,0.2,0.43,0.25,0.08,0.02,0.0,0.0,0.03,amanda cooper fine,
+MKT,3010,2.0,Principles of Marketing,0.29,0.37,0.21,0.1,0.01,0.0,0.0,0.02,amanda cooper fine,
+MKT,3010,3.0,Principles of Marketing,0.29,0.39,0.22,0.08,0.01,0.0,0.0,0.01,amanda cooper fine,
+MKT,3010,4.0,Principles of Marketing,0.27,0.44,0.21,0.06,0.02,0.0,0.0,0.01,carter willis mcelveen,
+MKT,3010,5.0,Principles of Marketing,0.31,0.43,0.21,0.04,0.0,0.0,0.0,0.01,carter willis mcelveen,
+MKT,3010,7.0,Principles of Marketing,0.12,0.56,0.27,0.03,0.01,0.0,0.0,0.01,james gaubert,
+MKT,3020,1.0,Consumer Behavior,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jennifer dianne siemens,
+MKT,3020,2.0,Consumer Behavior,0.69,0.24,0.04,0.02,0.0,0.0,0.0,0.0,jennifer dianne siemens,
+MKT,3020,5.0,Consumer Behavior,0.52,0.38,0.09,0.0,0.01,0.0,0.0,0.0,anastasia elizabeth thyroff,
+MKT,3020,6.0,Consumer Behavior,0.29,0.48,0.15,0.01,0.04,0.0,0.0,0.03,james gaubert,
+MKT,3210,1.0,Sports Marketing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3210,2.0,Sports Marketing,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,3220,1.0,Social Media Marketing,0.83,0.11,0.0,0.03,0.0,0.0,0.0,0.03,lura forcum,
+MKT,3220,2.0,Social Media Marketing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
+MKT,3220,3.0,Social Media Marketing,0.67,0.26,0.07,0.0,0.0,0.0,0.0,0.0,michele melton cauley,
+MKT,3220,4.0,Social Media Marketing,0.57,0.37,0.04,0.0,0.02,0.0,0.0,0.0,michele melton cauley,
+MKT,3310,1.0,Marketing Metrics & Analytics,0.73,0.2,0.03,0.0,0.0,0.0,0.0,0.03,oriana rachel aragon,
+MKT,3310,2.0,Marketing Metrics & Analytics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,oriana rachel aragon,
+MKT,3310,3.0,Marketing Metrics & Analytics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,3310,4.0,Marketing Metrics & Analytics,0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,xianyong wang,
+MKT,3310,5.0,Marketing Metrics & Analytics,0.19,0.44,0.22,0.04,0.0,0.0,0.0,0.11,peter weathers,
+MKT,3980,1.0,Creative Inquiry in Marketing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james gaubert,
+MKT,4200,1.0,Professional Selling,0.41,0.56,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,2.0,Professional Selling,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,kevin scott chase,
+MKT,4200,3.0,Professional Selling,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4200,5.0,Professional Selling,0.83,0.07,0.07,0.0,0.0,0.0,0.0,0.03,carter willis mcelveen,
+MKT,4200,6.0,Professional Selling,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,
+MKT,4230,2.0,Promotional Strategy,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,michele melton cauley,
+MKT,4230,3.0,Promotional Strategy,0.42,0.48,0.06,0.0,0.03,0.0,0.0,0.0,michele melton cauley,
+MKT,4240,1.0,Sales Management,0.59,0.32,0.05,0.0,0.0,0.0,0.0,0.03,ryan mullins,
+MKT,4260,1.0,Business-to-Business,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4270,1.0,International Marketing,0.7,0.24,0.04,0.02,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4270,2.0,International Marketing,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4270,3.0,International Marketing,0.48,0.33,0.1,0.0,0.03,0.0,0.0,0.08,thomas poehlman,
+MKT,4270,4.0,International Marketing,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4280,1.0,Services Marketing,0.21,0.44,0.28,0.05,0.03,0.0,0.0,0.0,angeline close scheinbaum,
+MKT,4280,2.0,Services Marketing,0.15,0.64,0.21,0.0,0.0,0.0,0.0,0.0,angeline close scheinbaum,
+MKT,4310,1.0,Marketing Research,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,michael david giebelhausen,
+MKT,4310,2.0,Marketing Research,0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,michael david giebelhausen,
+MKT,4310,3.0,Marketing Research,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,4.0,Marketing Research,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4500,1.0,Strategic Mktg Mgt,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,annette popp tower,
+MKT,4500,2.0,Strategic Mktg Mgt,0.39,0.52,0.09,0.0,0.0,0.0,0.0,0.0,annette popp tower,
+MKT,4500,3.0,Strategic Mktg Mgt,0.27,0.58,0.15,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,4.0,Strategic Mktg Mgt,0.19,0.44,0.33,0.04,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4950,1.0,Selling Medical Devices,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4950,2.0,Applied Selling,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kevin scott chase,
+ML,2010,1.0,Leadership Development I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,2010,3.0,Leadership Development I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,3010,1.0,Advanced Leadership I,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,justin robert merhar,
+MSE,2100,1.0,Intro to Materials Science,0.25,0.43,0.22,0.04,0.01,0.0,0.0,0.04,nancy birkner,
+MSE,2100,2.0,Intro to Materials Science,0.44,0.28,0.18,0.08,0.01,0.0,0.0,0.01,rakhee pani,
+MSE,2100,3.0,Intro to Materials Science,0.23,0.43,0.2,0.07,0.03,0.0,0.0,0.03,mark alan johnson,
+MSE,2100,4.0,Intro to Materials Science,0.65,0.21,0.05,0.02,0.04,0.0,0.0,0.02,rakhee pani,
+MSE,2100,5.0,Intro to Materials Science,0.06,0.56,0.19,0.13,0.06,0.0,0.0,0.0,olga kuksenok,
+MSE,2100,6.0,Intro to Materials Science,0.24,0.23,0.26,0.08,0.11,0.0,0.0,0.08,olga kuksenok,
+MSE,3260,1.0,Thermo of Materials,0.36,0.28,0.26,0.04,0.06,0.0,0.0,0.0,fei peng,
+MSE,3260,2.0,Thermo of Materials,0.34,0.32,0.22,0.1,0.02,0.0,0.0,0.0,fei peng,
+MSE,3910,1.0,Research Fundamentals,0.74,0.1,0.03,0.06,0.06,0.0,0.0,0.0,ulf daniel schiller,
+MSE,4130,1.0,Noncrystalline Materials,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
+MSE,4150,1.0,Polymer Science & Engineering,0.44,0.35,0.06,0.06,0.06,0.0,0.0,0.03,olin mefford,
+MSE,4150,2.0,Polymer Science & Engineering,0.5,0.26,0.24,0.0,0.0,0.0,0.0,0.0,igor luzinov,
+MSE,4320,1.0,Manuf Proc & Systems,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
+MSE,4580,1.0,Surf Phen in Ms&E,0.3,0.2,0.4,0.0,0.0,0.0,0.0,0.1,konstantin german kornev,
+MSE,4910,1.0,Undergraduate Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ulf daniel schiller,
+MSE,8100,1.0,Fundamentals of Materials Sci,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,igor luzinov,
+MSE,8190,1.0,Inorgan Mater Characterization,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,luiz gustavo jacobsohn,
+MSE,8260,1.0,Phase Equil Mat Sys,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,stephen foulger,
+MSE,8270,1.0,Kin of Phase Tran,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,konstantin german kornev,
+MSE,8510,1.0,Polymer Science I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,marek urban,
+MUSC,1110,4.0,Beginning Class Guitar,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,david stevenson,
+MUSC,1420,1.0,Music Theory I,0.76,0.06,0.12,0.0,0.0,0.0,0.0,0.06,linda li-bleuel,
+MUSC,1430,1.0,Aural Skills I,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,linda li-bleuel,
+MUSC,1510,2.0,Applied Music,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,
+MUSC,1510,19.0,Applied Music,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,adam michael knight,
+MUSC,1510,25.0,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,charles wood,
+MUSC,1520,2.0,Applied Music,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,
+MUSC,1520,22.0,Applied Music,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathryn layne mauldin,
+MUSC,2100,1.0,Music in the Western World,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,david conley,
+MUSC,2100,5.0,Music in the Western World,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,timothy ray hurlburt,
+MUSC,2100,6.0,Music in the Western World,0.97,0.0,0.03,0.0,0.0,0.0,0.0,0.0,david conley,
+MUSC,2100,7.0,Music in the Western World,0.42,0.39,0.13,0.03,0.0,0.0,0.0,0.03,rhea beth jacobus,
+MUSC,2100,8.0,Music in the Western World,0.41,0.41,0.03,0.0,0.06,0.0,0.0,0.09,rhea beth jacobus,
+MUSC,2100,11.0,Music in the Western World,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,leslie taylor warlick,
+MUSC,2100,12.0,Music in the Western World,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,
+MUSC,2100,13.0,Music in the Western World,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,david conley,
+MUSC,2100,15.0,Music in West World (HON),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,True
+MUSC,2510,2.0,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,
+MUSC,3080,1.0,Surv of Broadway I,0.67,0.11,0.11,0.0,0.11,0.0,0.0,0.0,lisa sain odom,
+MUSC,3110,1.0,History of American Music,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,ned hosler,
+MUSC,3120,1.0,History of Jazz,0.6,0.05,0.1,0.1,0.15,0.0,0.0,0.0,eric lapin,
+MUSC,3140,1.0,World Music,0.68,0.16,0.1,0.03,0.0,0.0,0.0,0.03,paul buyer,
+MUSC,3170,1.0,Hist of Country Mus,0.78,0.16,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3180,1.0,Hist of Audio Tech,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,bruce allen whisler,
+MUSC,3610,1.0,Marching Band,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
+MUSC,3700,1.0,Clemson University Singers,0.95,0.03,0.02,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,
+MUSC,3720,1.0,Men's Chorus,0.94,0.02,0.0,0.0,0.0,0.0,0.0,0.04,anthony bernarducci,
+MUSC,4150,1.0,Music Hist to 1750,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,linda dzuris,
+NPL,3000,1.0,Nonprofit Leadership,0.29,0.67,0.0,0.0,0.0,0.0,0.0,0.04,bonnie westbury stevens,
+NPL,3000,2.0,Nonprofit Leadership,0.21,0.58,0.17,0.0,0.0,0.0,0.0,0.04,bonnie westbury stevens,
+NPL,3000,3.0,Nonprofit Leadership,0.72,0.24,0.0,0.04,0.0,0.0,0.0,0.0,christina marie mazer,
+NPL,3000,4.0,Nonprofit Leadership,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,corey douglas brookover,
+NPL,3000,5.0,Nonprofit Leadership,0.41,0.48,0.07,0.0,0.04,0.0,0.0,0.0,corey douglas brookover,
+NPL,3000,6.0,Nonprofit Leadership,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,corey douglas brookover,
+NPL,3000,7.0,Nonprofit Leadership,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,corey douglas brookover,
+NPL,3000,8.0,Nonprofit Leadership,0.74,0.15,0.04,0.07,0.0,0.0,0.0,0.0,christina marie mazer,
+NPL,3000,9.0,Nonprofit Leadership,0.63,0.3,0.04,0.0,0.0,0.0,0.0,0.04,christina marie mazer,
+NPL,3010,1.0,NPL Stakeholders,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,christina marie mazer,
+NPL,3020,1.0,NPL Fundraising,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,joan laura phillips,
+NPL,3030,1.0,NPL Personnel,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,joan laura phillips,
+NPL,3040,1.0,NPL Risk Management,0.74,0.13,0.13,0.0,0.0,0.0,0.0,0.0,daniel morgan anderson,
+NPL,3050,1.0,Strat Social Media for NP Org,0.81,0.11,0.05,0.0,0.0,0.0,0.0,0.03,randi alexandra plake,
+NPL,3050,2.0,Strat Social Media for NP Org,0.83,0.14,0.0,0.02,0.0,0.0,0.0,0.0,randi alexandra plake,
+NURS,1020,3.0,Nrsg Success Skills,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,janice garrison lanham,
+NURS,1400,1.0,Comp App Hlth Care,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
+NURS,1400,2.0,Comp App Hlth Care,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,janice garrison lanham,
+NURS,3000,1.0,Seminar- Leadership University,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,janice garrison lanham,
+NURS,3030,1.0,Nursing of Adults,0.33,0.6,0.04,0.0,0.0,0.0,0.0,0.02,lena marie burgess,
+NURS,3040,101.0,Pathophysiology,0.4,0.4,0.15,0.03,0.0,0.0,0.0,0.02,catherine sikkema murton,
+NURS,3040,201.0,Pathophysiology,0.24,0.66,0.07,0.0,0.01,0.0,0.0,0.01,amy boggs garrison,
+NURS,3040,400.0,Pathophysiology,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,amy boggs garrison,
+NURS,3040,401.0,Pathophysiology,0.63,0.27,0.07,0.0,0.03,0.0,0.0,0.0,amy boggs garrison,
+NURS,3050,1.0,Psychosocial Nursing,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.02,kevin earle busby,
+NURS,3100,1.0,Health Assessment,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,
+NURS,3100,401.0,Health Assessment,0.83,0.13,0.0,0.0,0.03,0.0,0.0,0.0,jason thrift,
+NURS,3110,1.0,Hlth Promotion Across Lifespan,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,janice garrison lanham,
+NURS,3120,101.0,Foundations of Nursing,0.51,0.47,0.0,0.0,0.0,0.0,0.0,0.02,jennifer elizabeth bagwell,
+NURS,3120,201.0,Foundations of Nursing,0.31,0.65,0.01,0.01,0.0,0.0,0.0,0.01,terri abercrombie teramano,
+NURS,3120,401.0,Foundations of Nursing,0.67,0.3,0.0,0.0,0.03,0.0,0.0,0.0,terri abercrombie teramano,
+NURS,3200,1.0,Prof in Nurs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3230,101.0,Gerontology Nursing,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,tawny jenna mcintosh,
+NURS,3300,1.0,Research in Nursing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,3300,2.0,Research in Nursing,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,hyewon shin,
+NURS,3330,1.0,Health Care Genetics,0.58,0.36,0.04,0.0,0.0,0.0,0.0,0.02,linda ward,
+NURS,3400,101.0,Pharmther Nursing,0.36,0.44,0.15,0.02,0.02,0.0,0.0,0.02,catherine sikkema murton,
+NURS,3400,201.0,Pharmther Nursing,0.32,0.56,0.09,0.01,0.0,0.0,0.0,0.01,jenna lynn seawright,
+NURS,3400,401.0,Pharmther Nursing,0.57,0.37,0.03,0.0,0.03,0.0,0.0,0.0,jenna lynn seawright,
+NURS,3600,400.0,Social Determinants in Health,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
+NURS,4010,1.0,Mental Health Nurs,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebecca garrard,
+NURS,4030,101.0,Complex Nursing of Adults,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen rankin ewing,
+NURS,4030,202.0,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john joseph whitcomb,
+NURS,4030,402.0,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john joseph whitcomb,
+NURS,4060,400.0,Issues in Professionalism,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
+NURS,4110,1.0,Nursing of Children,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,
+NURS,4120,1.0,Nurs Women and Fam,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,erin nicole shepherd,
+NURS,8050,400.0,Pharmaco Adv Nurs,0.33,0.5,0.08,0.0,0.04,0.0,0.0,0.04,tracy king fasolino,
+NURS,8050,401.0,Pharmaco Adv Nurs,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8060,400.0,Advan Assessment for Nursing,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
+NURS,8090,400.0,Pathophysiology,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
+NURS,8190,400.0,Developing Family,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8200,400.0,Child & Adol Nursing,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
+NURS,9010,1.0,"DNP Role, Theory & Philosophy",0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,jean ellen zavertnik,
+NURS,9020,1.0,DNP Clinical Epidem & Biostats,0.4,0.2,0.0,0.0,0.2,0.0,0.0,0.2,veronica parker,
+NUTR,2030,1.0,Intro Princ of Human Nutrition,0.91,0.08,0.01,0.0,0.0,0.0,0.0,0.0,bridgit denise corbett,
+NUTR,2030,2.0,Intro Princ of Human Nutrition,0.71,0.24,0.02,0.02,0.0,0.0,0.0,0.0,bridgit denise corbett,
+NUTR,2040,1.0,Nutrition Across Life Cycle,0.63,0.24,0.11,0.03,0.0,0.0,0.0,0.0,bridgit denise corbett,
+NUTR,2050,400.0,Nutrition for Nursing Prof,0.37,0.46,0.17,0.0,0.0,0.0,0.0,0.0,elizabeth lacey durrance,
+NUTR,2160,1.0,Evidence-Based Nutrition,0.84,0.08,0.05,0.0,0.02,0.0,0.0,0.01,angela fraser,
+NUTR,3020,1.0,Nutrition Assessment,0.63,0.34,0.02,0.0,0.02,0.0,0.0,0.0,elliot jesch,
+NUTR,4240,1.0,Medical Nutr Thera I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4510,1.0,Human Nutrition & Metabolism I,0.33,0.24,0.21,0.13,0.08,0.0,0.0,0.02,elliot jesch,
+PA,1010,1.0,Intro to Perf Arts,0.5,0.25,0.13,0.06,0.06,0.0,0.0,0.0,david hartmann,
+PA,2790,1.0,Perf Arts Pract I,0.47,0.0,0.06,0.0,0.24,0.0,0.0,0.24,kenneth moore,
+PA,3010,1.0,Princip of Arts Administration,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,richard goodstein,
+PA,4010,1.0,Capstone Project,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,
+PADM,7020,400.0,Research Methods,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ronald chrestman,
+PADM,8210,400.0,Perspectives on Public Admin,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,thomas walker,
+PADM,8220,401.0,Public Policy Process,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,ekaterina yazykova mellott,
+PADM,8290,400.0,Public Financial Management,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,
+PADM,8410,400.0,Public Data Analysis,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,ryan joseph gagnon,
+PADM,8420,400.0,GIS for Public Administrators,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lawrence white,
+PADM,8670,401.0,State Government Admin,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
+PAS,3010,1.0,Intro to Pan African Studies,0.51,0.41,0.02,0.0,0.04,0.0,0.0,0.01,abel bartley,
+PDBE,8150,1.0,Research Design in EDP,0.43,0.29,0.14,0.0,0.14,0.0,0.0,0.0,mickey lauria,
+PES,1040,1.0,Introduction to Plant Sciences,0.69,0.24,0.02,0.0,0.0,0.0,0.0,0.04,paula agudelo,
+PES,2020,1.0,Soils,0.14,0.51,0.26,0.05,0.0,0.0,0.0,0.04,dara michelle park,
+PES,3150,1.0,Environment and Agriculture,0.29,0.67,0.0,0.0,0.05,0.0,0.0,0.0,vidya appukuttan suseela,
+PES,4090,1.0,Biology of Invasive Plants,0.67,0.17,0.08,0.0,0.08,0.0,0.0,0.0,nishanth tharayil-santhakumar,
+PES,4210,1.0,Princ of Field Crop Production,0.39,0.5,0.0,0.06,0.0,0.0,0.0,0.06,sruthi narayanan kutty,
+PES,4850,1.0,Environmental Soil Chemistry,0.55,0.27,0.0,0.0,0.18,0.0,0.0,0.0,haibo liu,
+PES,4960,1.0,Sel Top: Soil Judging,0.57,0.0,0.0,0.14,0.14,0.0,0.0,0.14,dara michelle park,
+PHIL,1010,2.0,Intro to Philosophic Problems,0.51,0.43,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1010,3.0,Intro to Philosophic Problems,0.56,0.35,0.06,0.03,0.0,0.0,0.0,0.0,christopher grau,
+PHIL,1010,7.0,Intro to Philosophic Problems,0.71,0.12,0.0,0.0,0.06,0.0,0.0,0.12,david stegall,
+PHIL,1010,8.0,Intro to Philosophic Problems,0.53,0.35,0.0,0.06,0.0,0.0,0.0,0.06,david stegall,
+PHIL,1010,9.0,Intro to Philosophic Problems,0.44,0.36,0.08,0.0,0.03,0.0,0.0,0.08,david stegall,
+PHIL,1020,1.0,Introduction to Logic,0.4,0.37,0.14,0.06,0.03,0.0,0.0,0.0,adam gies,
+PHIL,1020,3.0,Introduction to Logic,0.4,0.31,0.29,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1020,4.0,Introduction to Logic,0.47,0.31,0.0,0.03,0.08,0.0,0.0,0.11,craig bacon,
+PHIL,1020,7.0,Introduction to Logic,0.37,0.2,0.09,0.09,0.03,0.0,0.0,0.23,david stegall,
+PHIL,1020,11.0,Introduction to Logic,0.61,0.14,0.11,0.03,0.0,0.0,0.0,0.11,david stegall,
+PHIL,1020,15.0,Introduction to Logic,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1020,16.0,Introduction to Logic,0.16,0.53,0.21,0.05,0.0,0.0,0.0,0.05,edyta joanna kuzian,
+PHIL,1020,17.0,Introduction to Logic,0.55,0.26,0.11,0.0,0.03,0.0,0.0,0.05,edyta joanna kuzian,
+PHIL,1020,18.0,Introduction to Logic,0.78,0.13,0.03,0.0,0.0,0.0,0.0,0.06,adam paul omelianchuk,
+PHIL,1020,19.0,Introduction to Logic,0.69,0.11,0.11,0.0,0.0,0.0,0.0,0.09,adam paul omelianchuk,
+PHIL,1020,20.0,Introduction to Logic,0.85,0.12,0.0,0.03,0.0,0.0,0.0,0.0,adam paul omelianchuk,
+PHIL,1030,2.0,Introduction to Ethics,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,stephen satris,
+PHIL,1030,3.0,Introduction to Ethics,0.4,0.34,0.14,0.06,0.0,0.0,0.0,0.06,david robert antonini,
+PHIL,1030,6.0,Introduction to Ethics,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,charles starkey,
+PHIL,1030,8.0,Introduction to Ethics,0.79,0.06,0.06,0.0,0.03,0.0,0.0,0.06,winthrop brent hepburn,
+PHIL,1030,9.0,Introduction to Ethics,0.5,0.44,0.03,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,
+PHIL,1030,10.0,Introduction to Ethics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
+PHIL,3040,1.0,Moral Philosophy,0.4,0.47,0.07,0.0,0.07,0.0,0.0,0.0,todd may,
+PHIL,3150,1.0,Ancient Philosophy,0.39,0.42,0.09,0.06,0.0,0.0,0.0,0.03,stephen satris,
+PHIL,3210,1.0,Crime & Punishment,0.21,0.63,0.11,0.0,0.0,0.0,0.0,0.05,daniel wueste,
+PHIL,3260,1.0,Science and Values,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,david robert antonini,
+PHIL,3260,2.0,Science and Values,0.62,0.29,0.06,0.0,0.0,0.0,0.0,0.03,david robert antonini,
+PHIL,3300,1.0,Animal Rights,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,todd may,
+PHIL,3430,1.0,Philosophy of Law,0.29,0.47,0.18,0.0,0.0,0.0,0.0,0.06,brookes colyton brown,
+PHIL,3440,1.0,Business Ethics,0.17,0.5,0.13,0.0,0.04,0.0,0.0,0.17,brookes colyton brown,
+PHIL,3450,1.0,Environmental Ethics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,adam paul omelianchuk,
+PHIL,3480,1.0,Philosophies of Art,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christopher grau,
+PHIL,3510,1.0,Phil of Emotion,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,charles starkey,
+PHIL,4020,2.0,Topics in Philosophy,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,diane perpich,
+PHIL,4920,2.0,Creative Inquiry in Philosophy,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,stephen satris,
+PHSC,1180,1.0,Intro to Phy & Astr for Ele Ed,0.77,0.18,0.03,0.02,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1.0,Physics with Calculus I,0.3,0.26,0.26,0.09,0.06,0.0,0.0,0.04,lih-sin the,
+PHYS,1220,2.0,Physics with Calculus I,0.21,0.31,0.27,0.07,0.06,0.0,0.0,0.07,lih-sin the,
+PHYS,1220,3.0,Physics W/Cal I (HON),0.42,0.33,0.08,0.0,0.0,0.0,0.0,0.17,joshua alper,True
+PHYS,1220,4.0,Physics with Calculus I,0.27,0.32,0.05,0.18,0.09,0.0,0.0,0.09,joshua alper,
+PHYS,1240,1.0,Physics Lab I,0.07,0.14,0.5,0.14,0.07,0.0,0.0,0.07,daniel ross thompson,
+PHYS,1240,2.0,Physics Lab I,0.09,0.73,0.09,0.09,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,3.0,Physics Lab I,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,4.0,Physics Lab I,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,5.0,Physics Lab I,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,6.0,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,7.0,Physics Lab I,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,8.0,Physics Lab I,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,9.0,Physics Lab I,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,10.0,Physics Lab I,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,
+PHYS,1240,11.0,Physics Lab I,0.63,0.19,0.13,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,13.0,Physics Lab I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,14.0,Physics Lab I,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,15.0,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,16.0,Physics Lab I,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,17.0,Physics Lab I,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,18.0,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,1240,19.0,Physics Lab I,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,1240,21.0,Physics Lab I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2070,1.0,General Physics I,0.24,0.23,0.2,0.15,0.1,0.0,0.0,0.08,amy liann pope,
+PHYS,2070,2.0,General Physics I,0.31,0.29,0.21,0.08,0.06,0.0,0.0,0.05,amy liann pope,
+PHYS,2070,3.0,General Physics I,0.19,0.31,0.27,0.07,0.1,0.0,0.0,0.06,amy liann pope,
+PHYS,2070,4.0,General Physics I,0.23,0.31,0.23,0.13,0.08,0.0,0.0,0.02,david edward connick,
+PHYS,2080,1.0,General Physics II,0.42,0.34,0.13,0.09,0.03,0.0,0.0,0.0,david edward connick,
+PHYS,2090,1.0,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,2.0,Gen Phys Lab I,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,3.0,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,4.0,Gen Phys Lab I,0.83,0.09,0.0,0.0,0.0,0.0,0.0,0.09,daniel ross thompson,
+PHYS,2090,5.0,Gen Phys Lab I,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,6.0,Gen Phys Lab I,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,7.0,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,8.0,Gen Phys Lab I,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,9.0,Gen Phys Lab I,0.65,0.22,0.09,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,10.0,Gen Phys Lab I,0.71,0.17,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,
+PHYS,2090,11.0,Gen Phys Lab I,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,12.0,Gen Phys Lab I,0.63,0.21,0.0,0.04,0.04,0.0,0.0,0.08,daniel ross thompson,
+PHYS,2090,13.0,Gen Phys Lab I,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,14.0,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,15.0,Gen Phys Lab I,0.79,0.04,0.08,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,
+PHYS,2090,16.0,Gen Phys Lab I,0.83,0.04,0.09,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,17.0,Gen Phys Lab I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,18.0,Gen Phys Lab I,0.58,0.25,0.04,0.0,0.04,0.0,0.0,0.08,daniel ross thompson,
+PHYS,2090,19.0,Gen Phys Lab I,0.63,0.33,0.0,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,20.0,Gen Phys Lab I,0.7,0.22,0.09,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,21.0,Gen Phys Lab I,0.33,0.54,0.04,0.0,0.08,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,22.0,Gen Phys Lab I,0.61,0.3,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2090,23.0,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,24.0,Gen Phys Lab I,0.5,0.38,0.0,0.0,0.04,0.0,0.0,0.08,daniel ross thompson,
+PHYS,2090,25.0,Gen Phys Lab I,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,26.0,Gen Phys Lab I,0.57,0.35,0.04,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2090,27.0,Gen Phys Lab I,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2100,1.0,Gen Phys Lab II,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,2.0,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,3.0,Gen Phys Lab II,0.63,0.33,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,4.0,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,6.0,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,7.0,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,8.0,Gen Phys Lab II,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2100,9.0,Gen Phys Lab II,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
+PHYS,2210,1.0,Physics with Calculus II,0.13,0.43,0.29,0.09,0.03,0.0,0.0,0.03,jason stratford brown,
+PHYS,2210,2.0,Physics with Calculus II,0.21,0.47,0.24,0.05,0.01,0.0,0.0,0.02,jason stratford brown,
+PHYS,2210,3.0,Physics with Calculus II,0.37,0.48,0.11,0.02,0.0,0.0,0.0,0.01,chad sosolik,
+PHYS,2210,4.0,Physics with Calculus II,0.25,0.51,0.18,0.02,0.02,0.0,0.0,0.01,chad sosolik,
+PHYS,2210,5.0,Physics w/Calculus II(HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True
+PHYS,2220,1.0,Physics with Calculus III,0.74,0.11,0.05,0.0,0.0,0.0,0.0,0.11,murray daw,
+PHYS,2230,1.0,Physics Lab II,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,2.0,Physics Lab II,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,3.0,Physics Lab II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,4.0,Physics Lab II,0.17,0.78,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,5.0,Physics Lab II,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,6.0,Physics Lab II,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,7.0,Physics Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,9.0,Physics Lab II,0.29,0.65,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,10.0,Physics Lab II,0.22,0.72,0.0,0.0,0.06,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,11.0,Physics Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,13.0,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
+PHYS,2230,14.0,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2230,17.0,Physics Lab II,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,daniel ross thompson,
+PHYS,2450,1.0,Physics of Climate,0.37,0.37,0.09,0.05,0.01,0.0,0.0,0.11,jens oberheide,
+PHYS,3000,1.0,Intro to Research,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean brittain,
+PHYS,3150,1.0,Intro to Computational Physics,0.4,0.2,0.27,0.0,0.0,0.0,0.0,0.13,jason stratford brown,
+PHYS,3210,1.0,Mechanics I,0.17,0.41,0.17,0.07,0.0,0.0,0.0,0.17,stephen roland kaeppler,
+PHYS,3250,1.0,Exper Physics I,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,jianbo gao,
+PHYS,3990,7.0,CI: K-12 STEM Competitions,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,domnita catalina marinescu,
+PHYS,4410,1.0,Electromagnetics I,0.24,0.41,0.29,0.0,0.06,0.0,0.0,0.0,xian lu,
+PHYS,4520,1.0,Nuclear and Particle Physics,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,endre andras takacs,
+PHYS,4550,1.0,Quantum Physics I,0.15,0.46,0.38,0.0,0.0,0.0,0.0,0.0,gerald lehmacher,
+PHYS,6550,1.0,Quantum Physics I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,gerald lehmacher,
+PHYS,8110,1.0,Meth of Theor Phys I,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,feng ding,
+PHYS,8210,1.0,Classical Mech I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,dieter hartmann,
+PHYS,9510,1.0,Quantum Mech I,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,sumanta tewari,
+PKSC,1010,1.0,Pkgsc Orientation,0.9,0.05,0.01,0.01,0.0,0.0,0.0,0.01,patricia guerra marcondes,
+PKSC,1020,1.0,Intro to Pkg Sci,0.08,0.31,0.33,0.18,0.05,0.0,0.0,0.05,heather batt,
+PKSC,2010,1.0,Pkg Perishable Prod,0.13,0.28,0.09,0.09,0.22,0.0,0.0,0.19,heather batt,
+PKSC,2020,1.0,Packaging Mtl & Mfg,0.23,0.4,0.27,0.1,0.0,0.0,0.0,0.0,patricia guerra marcondes,
+PKSC,2040,1.0,Container Systems,0.31,0.38,0.15,0.0,0.0,0.0,0.0,0.15,patricia guerra marcondes,
+PKSC,2200,1.0,Product & Pkg Design,0.73,0.14,0.08,0.0,0.05,0.0,0.0,0.0,haley ellis appleby,
+PKSC,3200,1.0,Pkg Design Theory,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,rupert hurley,
+PKSC,4010,1.0,Packaging Machinery,0.42,0.38,0.17,0.01,0.01,0.0,0.0,0.0,anthony louis pometto,
+PKSC,4030,1.0,Packaging Career Preparation,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4040,1.0,Protective Packaging Prop/Prin,0.23,0.44,0.23,0.03,0.04,0.0,0.0,0.03,gregory batt,
+PKSC,4160,1.0,Application of Polymers in Pkg,0.34,0.56,0.08,0.0,0.02,0.0,0.0,0.0,alicia cutler campbell,
+PKSC,4200,1.0,Package Design & Development,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4540,1.0,Product & Pkg Evaluation Lab,0.13,0.6,0.2,0.0,0.0,0.0,0.0,0.07,gregory batt,
+PKSC,4540,2.0,Product & Pkg Evaluation Lab,0.19,0.5,0.06,0.06,0.13,0.0,0.0,0.06,gregory batt,
+PKSC,4540,3.0,Product & Pkg Evaluation Lab,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4540,4.0,Product & Pkg Evaluation Lab,0.09,0.45,0.27,0.09,0.0,0.0,0.0,0.09,gregory batt,
+PKSC,4540,5.0,Product & Pkg Evaluation Lab,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1.0,Food & Health Care Pkg Systems,0.58,0.33,0.04,0.02,0.02,0.0,0.0,0.0,kay cooksey,
+PKSC,4990,7.0,Creative Inquiry Pkg Science,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,rupert hurley,
+PLPA,3100,1.0,Principles of Plant Pathology,0.26,0.22,0.3,0.19,0.04,0.0,0.0,0.0,steven nye jeffers,
+PLPA,4250,1.0,Introductory Mycology,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,julia louise kerrigan,
+PLPA,8020,1.0,Principles of Plant Pathology,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,
+POSC,1010,1.0,Amer National Govt,0.42,0.35,0.16,0.02,0.04,0.0,0.0,0.02,ethan craig busby,
+POSC,1010,2.0,Amer National Govt,0.32,0.32,0.22,0.12,0.01,0.0,0.0,0.0,robert carey,
+POSC,1020,1.0,Intro Intl Relations,0.31,0.41,0.13,0.07,0.02,0.0,0.0,0.06,steven vincent miller,
+POSC,1020,2.0,Intro Intl Relations,0.4,0.35,0.13,0.03,0.03,0.0,0.0,0.06,tara elizabeth trask,
+POSC,1020,3.0,Intro Intl Relations,0.56,0.29,0.07,0.01,0.03,0.0,0.0,0.04,tara elizabeth trask,
+POSC,1020,4.0,Intro Intl Relations,0.12,0.48,0.12,0.14,0.07,0.0,0.0,0.07,joshua douglas king,
+POSC,1020,5.0,Intro Intl Relations,0.12,0.51,0.27,0.0,0.02,0.0,0.0,0.08,colin denby pearce,
+POSC,1020,6.0,Intro Intl Relations,0.41,0.36,0.12,0.01,0.06,0.0,0.0,0.04,tara elizabeth trask,
+POSC,1030,1.0,Intro to Political Theory,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,derek neal duplessie,
+POSC,1030,2.0,Intro to Political Theory,0.3,0.5,0.13,0.0,0.03,0.0,0.0,0.03,adam michael thomas,
+POSC,1030,3.0,Intro to Political Theory,0.27,0.43,0.2,0.0,0.0,0.0,0.0,0.1,colin denby pearce,
+POSC,1030,4.0,Intro to Political Theory,0.4,0.29,0.23,0.03,0.03,0.0,0.0,0.03,brandon turner,
+POSC,1040,1.0,Intro Compar Pol,0.44,0.28,0.19,0.04,0.0,0.0,0.0,0.06,matthew henry rhodes-purdy,
+POSC,1990,1.0,Intro Pol Sci,0.47,0.32,0.09,0.06,0.02,0.0,0.0,0.04,meredith-joy petersheim,
+POSC,3020,1.0,State and Loc Gov,0.17,0.6,0.1,0.0,0.02,0.0,0.0,0.1,bruce ransom,
+POSC,3050,1.0,CI in Political Sci,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,matthew henry rhodes-purdy,True
+POSC,3110,1.0,Model United Nations,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,xiaobo hu,
+POSC,3410,1.0,Quant Meth in Pol Sc,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,ethan craig busby,
+POSC,3610,1.0,International Conflict,0.28,0.22,0.18,0.04,0.22,0.0,0.0,0.06,steven vincent miller,
+POSC,3620,1.0,Intl Organizations,0.21,0.33,0.21,0.04,0.08,0.0,0.0,0.13,zeynep taydas,
+POSC,3620,2.0,Intl Organizations,0.32,0.36,0.08,0.08,0.08,0.0,0.0,0.08,zeynep taydas,
+POSC,3630,1.0,Us Foreign Policy,0.29,0.57,0.09,0.03,0.0,0.0,0.0,0.03,jeffrey scott peake,
+POSC,3710,1.0,European Politics,0.45,0.37,0.08,0.0,0.0,0.0,0.0,0.1,vladimir matic,
+POSC,4030,1.0,United States Congress,0.27,0.31,0.33,0.06,0.02,0.0,0.0,0.02,jeffrey allen fine,
+POSC,4210,1.0,Public Policy,0.17,0.33,0.33,0.06,0.0,0.0,0.0,0.11,adam warber,
+POSC,4300,1.0,Policy Evaluation,0.45,0.18,0.27,0.0,0.0,0.0,0.0,0.09,robert carey,
+POSC,4360,1.0,Law Courts Politics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
+POSC,4360,2.0,Law Courts Politics,0.74,0.24,0.03,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
+POSC,4370,1.0,Constitut Law: Rights & Libert,0.4,0.5,0.05,0.0,0.0,0.0,0.0,0.05,kevin gregory vance,
+POSC,4380,1.0,Constitut Law: Struc of Gov,0.56,0.27,0.1,0.02,0.0,0.0,0.0,0.04,christina rose bambrick,
+POSC,4420,1.0,Pol Parties & Elect,0.29,0.43,0.22,0.04,0.0,0.0,0.0,0.02,laura olson,
+POSC,4490,1.0,Political Theory of Capitalism,0.29,0.44,0.24,0.0,0.0,0.0,0.0,0.03,colin denby pearce,
+POSC,4490,2.0,Political Theory of Capitalism,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,brandon turner,
+POSC,4500,1.0,Rights: Theory & Practice,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,christina rose bambrick,
+POSC,4550,1.0,Pol Thght of American Founding,0.52,0.37,0.11,0.0,0.0,0.0,0.0,0.0, bradley thompson,
+POSC,4580,1.0,Political Leadership,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,joshua douglas king,
+POSC,4760,1.0,Middle East Politics,0.5,0.38,0.0,0.0,0.06,0.0,0.0,0.06,vladimir matic,
+POSC,4780,1.0,Latin Amer Politics,0.63,0.23,0.09,0.0,0.06,0.0,0.0,0.0,matthew henry rhodes-purdy,
+POST,8990,1.0,"Markets, Gov't. & Public Pol.",0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert carey,
+PRTM,1950,2.0,Pro Golf Management Seminar I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,2110,1.0,Sts Play Rec Tourism,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew mutel browning,
+PRTM,2200,1.0,Foundations of PRTM,0.16,0.66,0.18,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2200,2.0,Foundations of PRTM,0.34,0.49,0.12,0.03,0.02,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2260,1.0,Fnd of Mgt Adm PRTM,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2260,2.0,Fnd of Mgt Adm PRTM,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,
+PRTM,2260,3.0,Fnd of Mgt Adm PRTM,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2260,4.0,Fnd of Mgt Adm PRTM,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2260,5.0,Fnd of Mgt Adm PRTM,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,2260,6.0,Fnd of Mgt Adm PRTM,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,
+PRTM,2260,7.0,Fnd of Mgt Adm PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,
+PRTM,2260,8.0,Fnd of Mgt Adm PRTM,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,
+PRTM,2270,1.0,Prov of Leisure Exp,0.5,0.38,0.06,0.06,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2270,2.0,Prov of Leisure Exp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,
+PRTM,2270,3.0,Prov of Leisure Exp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2270,4.0,Prov of Leisure Exp,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2270,5.0,Prov of Leisure Exp,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,2270,6.0,Prov of Leisure Exp,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,
+PRTM,2270,7.0,Prov of Leisure Exp,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,
+PRTM,2270,8.0,Prov of Leisure Exp,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,
+PRTM,2290,1.0,Competency Integration in PRTM,0.44,0.38,0.13,0.06,0.0,0.0,0.0,0.0,teresa walton tucker,
+PRTM,2290,2.0,Competency Integration in PRTM,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,
+PRTM,2290,3.0,Competency Integration in PRTM,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,francis mcguire,
+PRTM,2290,4.0,Competency Integration in PRTM,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
+PRTM,2290,5.0,Competency Integration in PRTM,0.38,0.38,0.19,0.06,0.0,0.0,0.0,0.0,gwynn powell,
+PRTM,2290,6.0,Competency Integration in PRTM,0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,jeffrey townsend,
+PRTM,2290,7.0,Competency Integration in PRTM,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,
+PRTM,2290,8.0,Competency Integration in PRTM,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,
+PRTM,2980,9.0,Creative Inquiry in PRTM II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,denise marie anderson,
+PRTM,3050,1.0,Safety/Risk Mgt PRTM,0.43,0.3,0.13,0.1,0.0,0.0,0.0,0.03,daniel morgan anderson,
+PRTM,3070,2.0,Facility Operations,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,raymond dunham,
+PRTM,3200,1.0,Recreation Policy,0.8,0.0,0.1,0.05,0.0,0.0,0.0,0.05,elizabeth perry,
+PRTM,3240,1.0,Assessment & Planning in RT,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,3300,1.0,Visit Ser & Interp,0.5,0.22,0.22,0.06,0.0,0.0,0.0,0.0,aby lat soukabe sene harper,
+PRTM,3420,1.0,Intro to Tourism,0.5,0.35,0.06,0.03,0.0,0.0,0.0,0.06,gregory philip ramshaw,
+PRTM,3430,1.0,Spl Asp of Tourist B,0.53,0.36,0.09,0.0,0.0,0.0,0.0,0.02,william norman,
+PRTM,3470,1.0,Sport Tourism,0.36,0.36,0.23,0.0,0.0,0.0,0.0,0.05,gregory philip ramshaw,
+PRTM,3520,1.0,Camp Org and Admin,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,alexsandra dubin,
+PRTM,3600,1.0,Recreation & Amateur Sport Mgt,0.35,0.35,0.17,0.04,0.0,0.0,0.0,0.09,skye gerald arthur-banning,
+PRTM,3900,8.0,PGA GM Player Development,0.7,0.15,0.1,0.0,0.0,0.0,0.0,0.05,richard lucas,
+PRTM,3910,1.0,Issues & Trends in Event Mgmt.,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,stephanie perler garst,
+PRTM,3920,1.0,Special Event Management,0.95,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,
+PRTM,4030,1.0,Elem of Rec/Pk Plan,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,samuel gaines,
+PRTM,4210,1.0,Rec Fin Resc Mgt,0.54,0.39,0.02,0.0,0.02,0.0,0.0,0.02,ryan joseph gagnon,
+PRTM,4220,2.0,Management of RT Services,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,sandra heath,
+PRTM,4230,1.0,Adaptive Sports & Recreation,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,jasmine nutter townsend,
+PRTM,4260,1.0,Trends & Issues in Rec Therapy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
+PRTM,4470,1.0,Perspect Intl Travel,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,'lisha fogle,
+PRTM,4470,2.0,Perspect Intl Travel,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sheila backman,
+PRTM,4510,1.0,Seminar in CRSCM,0.7,0.19,0.06,0.02,0.02,0.0,0.0,0.0,skye gerald arthur-banning,
+PRTM,4550,1.0,Adv Program Planning,0.73,0.25,0.02,0.0,0.0,0.0,0.0,0.0,harrison parker pinckney,
+PRTM,4740,2.0,Adv Rec Resource Mgt,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,matthew tyler james brownlee,
+PRTM,8080,2.0,Behavioral Aspects,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,iryna sharaievska,
+PRTM,8080,3.0,Behavioral Aspects,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,lauren duffy,
+PRTM,8710,1.0,Applied Research in Rec Therap,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,brandi crowe,
+PRTM,8720,1.0,Adv Facilitation Techniq in RT,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,
+PRTM,9000,11.0,MS Capstone,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charles hallo,
+PSYC,2010,1.0,Intro to Psychology,0.3,0.34,0.2,0.07,0.05,0.0,0.0,0.05,edwin brainerd,
+PSYC,2010,2.0,Intro to Psychology,0.3,0.31,0.2,0.09,0.03,0.0,0.0,0.07,jo jorgensen,
+PSYC,2010,3.0,Intro to Psychology,0.41,0.33,0.18,0.05,0.03,0.0,0.0,0.01,jo jorgensen,
+PSYC,2010,4.0,Intro to Psychology,0.49,0.29,0.11,0.01,0.03,0.0,0.0,0.07,chong hyon pak,
+PSYC,2010,5.0,Intro to Psychology,0.38,0.34,0.16,0.04,0.03,0.0,0.0,0.04,chong hyon pak,
+PSYC,2010,6.0,Intro to Psychology,0.41,0.33,0.16,0.03,0.03,0.0,0.0,0.04,mary taylor,
+PSYC,2010,7.0,Intro to Psychology,0.57,0.14,0.2,0.04,0.01,0.0,0.0,0.03,mary taylor,
+PSYC,2010,8.0,Intro to Psychology,0.37,0.36,0.14,0.04,0.06,0.0,0.0,0.03,fred switzer,
+PSYC,2010,9.0,Intro to Psychology (HON),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
+PSYC,2030,1.0,Fundamentals of Psych Science,0.41,0.37,0.15,0.06,0.01,0.0,0.0,0.01,peggy jean tyler,
+PSYC,3060,1.0,Human Sexual Behavior,0.51,0.22,0.16,0.05,0.04,0.0,0.0,0.02,bruce michael king,
+PSYC,3090,100.0,Intro Experimental Psychology,0.35,0.35,0.14,0.08,0.05,0.0,0.0,0.03,jennifer bailey bisson,
+PSYC,3090,200.0,Intro Experimental Psychology,0.66,0.21,0.14,0.0,0.0,0.0,0.0,0.0,patrick rosopa,
+PSYC,3100,100.0,Advanced Experimental Psych,0.29,0.41,0.12,0.0,0.12,0.0,0.0,0.06,eric mckibben,
+PSYC,3100,200.0,Advanced Experimental Psych,0.26,0.47,0.11,0.05,0.05,0.0,0.0,0.05,cynthia pury,
+PSYC,3100,300.0,Advanced Experimental Psych,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,3100,400.0,Advanced Experimental Psych,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,thomas britt,
+PSYC,3100,500.0,Advanced Experimental Psych,0.47,0.16,0.16,0.11,0.05,0.0,0.0,0.05,benjamin stephens,
+PSYC,3100,600.0,Advanced Experimental Psych,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3100,700.0,Advanced Experimental Psych,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3100,800.0,Advanced Experimental Psych,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3240,1.0,Physiological Psych,0.36,0.24,0.2,0.09,0.03,0.0,0.0,0.08,claudio cantalupo,
+PSYC,3240,2.0,Physiological Psych,0.25,0.22,0.2,0.11,0.05,0.0,0.0,0.18,june pilcher,
+PSYC,3240,3.0,Physiological Psych,0.29,0.33,0.21,0.07,0.03,0.0,0.0,0.07,claudio cantalupo,
+PSYC,3310,1.0,Critical Thinking,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3330,1.0,Cognitive Psych,0.68,0.23,0.08,0.01,0.0,0.0,0.0,0.0,kaileigh angela byrne,
+PSYC,3330,2.0,Cognitive Psych,0.49,0.37,0.11,0.03,0.0,0.0,0.0,0.0,kaileigh angela byrne,
+PSYC,3340,1.0,Cognitive Psych Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel braden quinn,
+PSYC,3340,2.0,Cognitive Psych Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,daniel braden quinn,
+PSYC,3340,3.0,Cognitive Psych Lab,0.76,0.04,0.08,0.04,0.04,0.0,0.0,0.04,laura whitlock,
+PSYC,3400,1.0,Lifespan Developmental Psych,0.27,0.31,0.21,0.1,0.04,0.0,0.0,0.06,pamela alley,
+PSYC,3400,2.0,Lifespan Developmental Psych,0.37,0.44,0.11,0.04,0.0,0.0,0.0,0.03,anita pei tam,
+PSYC,3520,1.0,Social Psychology,0.63,0.26,0.07,0.01,0.0,0.0,0.0,0.03,ceren gunsoy,
+PSYC,3520,2.0,Social Psychology (HON),0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,True
+PSYC,3570,1.0,Psychology and Culture,0.64,0.23,0.13,0.0,0.0,0.0,0.0,0.0,ceren gunsoy,
+PSYC,3640,1.0,Industrial Psych,0.97,0.0,0.03,0.0,0.0,0.0,0.0,0.0,joseph ligato,
+PSYC,3680,1.0,Organizational Psych,0.27,0.29,0.34,0.05,0.02,0.0,0.0,0.03,chloe wilson,
+PSYC,3700,1.0,Personality,0.54,0.29,0.1,0.04,0.01,0.0,0.0,0.01,john robert hester,
+PSYC,3830,1.0,Abnormal Psychology,0.43,0.42,0.09,0.01,0.0,0.0,0.0,0.04,heidi marie zinzow,
+PSYC,3830,2.0,Abnormal Psychology,0.23,0.31,0.2,0.09,0.06,0.0,0.0,0.11,pamela alley,
+PSYC,3830,3.0,Abnormal Psychology,0.11,0.26,0.34,0.14,0.03,0.0,0.0,0.11,pamela alley,
+PSYC,3890,1.0,Psychology of Music,0.28,0.28,0.2,0.12,0.12,0.0,0.0,0.0,claudio cantalupo,
+PSYC,4080,1.0,Women and Psychology,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,
+PSYC,4150,1.0,Systems and Theories,0.87,0.08,0.03,0.0,0.03,0.0,0.0,0.0,peggy jean tyler,
+PSYC,4150,2.0,Systems and Theories,0.29,0.35,0.21,0.12,0.0,0.0,0.0,0.03,edwin brainerd,
+PSYC,4150,3.0,Systems and Theories,0.33,0.3,0.27,0.0,0.06,0.0,0.0,0.03,edwin brainerd,
+PSYC,4220,1.0,Perception,0.37,0.33,0.22,0.07,0.0,0.0,0.0,0.0,richard tyrrell,
+PSYC,4220,2.0,Perception,0.33,0.22,0.26,0.15,0.0,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4220,3.0,Perception,0.41,0.3,0.19,0.11,0.0,0.0,0.0,0.0,christopher pagano,
+PSYC,4430,1.0,Infant & Child Dev,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,4560,1.0,Psychophysiology,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,sarah christine beadle,
+PSYC,4710,1.0,Psych of Testing,0.64,0.14,0.0,0.0,0.07,0.0,0.0,0.14,zhuo chen,
+PSYC,4800,1.0,Health Psychology,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,
+PSYC,4800,2.0,Health Psychology,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,james mccubbin,
+PSYC,4880,1.0,Psychotherapy,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,lucinda sorciere shealy quick,
+PSYC,4890,1.0,Sport Psychology,0.25,0.45,0.15,0.1,0.0,0.0,0.0,0.05,anita pei tam,
+PSYC,4920,1.0,Senior Laboratory,0.8,0.13,0.0,0.07,0.0,0.0,0.0,0.0,zachary paul klinefelter,
+PSYC,4920,2.0,Senior Laboratory,0.75,0.13,0.0,0.0,0.08,0.0,0.0,0.04,alexander moore,
+PSYC,4920,4.0,Senior Laboratory,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,zachary paul klinefelter,
+PSYC,4920,5.0,Senior Laboratory,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,hannah solini,
+PSYC,4930,100.0,Pract Clinical Psych,0.81,0.13,0.0,0.06,0.0,0.0,0.0,0.0,heidi marie zinzow,
+PSYC,4980,291.0,Suicide Prevention,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,
+PSYC,4980,363.0,Psych Religion Spr,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,zhuo chen,
+PSYC,8100,1.0,Research Design I,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,patrick rosopa,
+PSYC,8350,1.0,Advanced Human Factors Psych,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,chong hyon pak,
+PSYC,8620,1.0,Org Psychology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert raymond sinclair,
+PSYC,8680,1.0,Leadership in Orgs,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,patrick raymark,
+RED,8010,1.0,Market Analysis,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,thomas andrew fox,
+REL,1010,1.0,Intro to Religion,0.32,0.47,0.16,0.05,0.0,0.0,0.0,0.0,peter cohen,
+REL,1010,2.0,Intro to Religion,0.32,0.32,0.11,0.11,0.0,0.0,0.0,0.16,peter cohen,
+REL,1010,3.0,Intro to Religion,0.43,0.37,0.09,0.06,0.0,0.0,0.0,0.06,peter cohen,
+REL,1010,5.0,Intro to Religion,0.5,0.17,0.17,0.0,0.0,0.0,0.0,0.17,brett patterson,
+REL,1020,1.0,World Religions (HON),0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,peter cohen,True
+REL,1020,2.0,World Religions,0.54,0.26,0.14,0.0,0.0,0.0,0.0,0.06,robert stephens,
+REL,1020,3.0,World Religions,0.57,0.29,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,
+REL,1020,4.0,World Religions,0.51,0.31,0.11,0.0,0.06,0.0,0.0,0.0,robert stephens,
+REL,1020,5.0,World Religions,0.14,0.54,0.23,0.09,0.0,0.0,0.0,0.0,brett patterson,
+REL,3010,1.0,Old Testament,0.35,0.35,0.15,0.06,0.0,0.0,0.0,0.09,john thames,
+REL,3020,1.0,New Testament Lit,0.53,0.41,0.0,0.03,0.0,0.0,0.0,0.03,benjamin white,
+REL,3080,1.0,Religions of the Ancient World,0.19,0.53,0.06,0.0,0.03,0.0,0.0,0.19,benjamin white,
+REL,3110,1.0,African American Rel,0.47,0.26,0.16,0.05,0.0,0.0,0.0,0.05,elizabeth jemison,
+REL,3120,1.0,Hinduism,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,robert stephens,
+REL,3300,1.0,Contemporary Issues,0.47,0.35,0.0,0.06,0.06,0.0,0.0,0.06,elizabeth jemison,
+RS,3010,1.0,Rural Sociology,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,kenneth robinson,
+RS,4010,1.0,Human Ecology,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
+RUSS,3400,1.0,19th C Russ Culture,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,olga anatolyevna volkova,
+RUSS,3610,1.0,Russn Lit Since 1910,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,olga anatolyevna volkova,
+SOC,2010,1.0,Introduction to Sociology,0.65,0.29,0.04,0.01,0.0,0.0,0.0,0.01,carolyn candace coffman,
+SOC,2010,2.0,Introduction to Sociology,0.69,0.26,0.04,0.0,0.01,0.0,0.0,0.0,carolyn candace coffman,
+SOC,2010,3.0,Introduction to Sociology,0.56,0.27,0.08,0.02,0.04,0.0,0.0,0.02,miao li,
+SOC,2010,4.0,Introduction to Sociology,0.86,0.12,0.0,0.0,0.01,0.0,0.0,0.0,andrew herman mannheimer,
+SOC,2010,5.0,Introduction to Sociology,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.01,shannon mcdonough,
+SOC,2010,6.0,Introduction to Sociology,0.55,0.33,0.1,0.01,0.0,0.0,0.0,0.01,shannon mcdonough,
+SOC,2010,7.0,Introduction to Sociology,0.6,0.29,0.08,0.0,0.0,0.0,0.0,0.02,jennifer leanne holland,
+SOC,2040,1.0,Prof Dev for Sociology Majors,0.64,0.2,0.09,0.02,0.02,0.0,0.0,0.02, catherine mobley,
+SOC,3020,1.0,Research Methods I,0.4,0.38,0.08,0.08,0.0,0.0,0.0,0.06,andrew whitehead,
+SOC,3040,1.0,Social Research Methods II,0.25,0.45,0.18,0.08,0.03,0.0,0.0,0.03,ye luo,
+SOC,3100,1.0,Marriage & Intimacy,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,heather kettrey,
+SOC,3400,1.0,Sport and Society,0.36,0.43,0.17,0.04,0.0,0.0,0.0,0.0,andrew whitehead,
+SOC,3510,1.0,Collective Behavior,0.27,0.41,0.2,0.08,0.0,0.0,0.0,0.04,matthew john costello,
+SOC,3600,1.0,Class & Poverty,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,william haller,
+SOC,3910,1.0,Soc of Deviance,0.53,0.31,0.12,0.04,0.0,0.0,0.0,0.0,matthew john costello,
+SOC,3940,1.0,Sociology of Mental Illness,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,james rosenberger,
+SOC,3970,1.0,Substance Abuse,0.69,0.27,0.0,0.0,0.04,0.0,0.0,0.0,shannon mcdonough,
+SOC,4030,1.0,"Technol, Environment & Society",0.53,0.26,0.19,0.02,0.0,0.0,0.0,0.0, catherine mobley,
+SOC,4040,1.0,Soc Theory,0.6,0.25,0.0,0.0,0.0,0.0,0.0,0.15,william haller,
+SOC,4140,1.0,Policy&Social Change,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jennifer leanne holland,
+SOC,4440,1.0,Sociology of Educ,0.82,0.14,0.02,0.02,0.0,0.0,0.0,0.0,andrew herman mannheimer,
+SOC,4600,1.0,Race & Ethnicity,0.88,0.02,0.06,0.0,0.02,0.0,0.0,0.02,andrew herman mannheimer,
+SOC,4610,1.0,Sex & Gender,0.55,0.2,0.16,0.02,0.02,0.0,0.0,0.04,minyoung moon,
+SOC,4710,1.0,World Population and Society,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,ye luo,
+SOC,4950,1.0,Field Experience,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0, catherine mobley,
+SOC,8920,1.0,Sel Top: Quantitative Methods,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,miao li,
+SPAN,1010,1.0,Elementary Spanish,0.26,0.47,0.21,0.0,0.05,0.0,0.0,0.0,stephanie elysse morris,
+SPAN,1010,2.0,Elementary Spanish,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,stephanie elysse morris,
+SPAN,1010,3.0,Elementary Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,rosa macarena pillcurima,
+SPAN,1020,1.0,Elementary Spanish,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,rosa macarena pillcurima,
+SPAN,1020,2.0,Elementary Spanish,0.63,0.25,0.06,0.06,0.0,0.0,0.0,0.0,liliana hernandez,
+SPAN,1020,3.0,Elementary Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mercedes tejera,
+SPAN,1020,4.0,Elementary Spanish,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,mercedes tejera,
+SPAN,1020,5.0,Elementary Spanish,0.39,0.39,0.11,0.11,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,
+SPAN,1020,6.0,Elementary Spanish,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,
+SPAN,1020,8.0,Elementary Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,1020,10.0,Elementary Spanish,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,debra oaks williamson,
+SPAN,1020,11.0,Elementary Spanish,0.47,0.35,0.12,0.0,0.0,0.0,0.0,0.06,debra oaks williamson,
+SPAN,1020,13.0,Elementary Spanish,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,yezid flores,
+SPAN,2010,1.0,Intermediate Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,maria rosa judez riquelme,
+SPAN,2010,2.0,Intermediate Spanish,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,liliana hernandez,
+SPAN,2010,3.0,Intermediate Spanish,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,
+SPAN,2010,4.0,Intermediate Spanish,0.71,0.06,0.24,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,
+SPAN,2010,7.0,Intermediate Spanish,0.53,0.21,0.16,0.0,0.05,0.0,0.0,0.05,debra oaks williamson,
+SPAN,2010,8.0,Intermediate Spanish,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,debra oaks williamson,
+SPAN,2010,9.0,Intermediate Spanish,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andrea patricia naranjo,
+SPAN,2010,10.0,Intermediate Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,11.0,Intermediate Spanish,0.47,0.42,0.0,0.11,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,12.0,Intermediate Spanish,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,ellory schmucker,
+SPAN,2010,14.0,Intermediate Spanish,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,nora arostegui logue,
+SPAN,2010,15.0,Intermediate Spanish,0.33,0.44,0.11,0.0,0.0,0.0,0.0,0.11,zenia beatriz cruz valderramos,
+SPAN,2010,16.0,Intermediate Spanish,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,
+SPAN,2010,17.0,Intermediate Spanish,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,maria rosa judez riquelme,
+SPAN,2010,18.0,Intermediate Spanish,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,mercedes tejera,
+SPAN,2010,19.0,Intermediate Spanish,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,liliana hernandez,
+SPAN,2020,1.0,Intermediate Spanish,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,melva marguerite persico,
+SPAN,2020,2.0,Intermediate Spanish,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,melva marguerite persico,
+SPAN,2020,3.0,Intermediate Spanish,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,yezid flores,
+SPAN,2020,4.0,Intermediate Spanish,0.61,0.28,0.0,0.0,0.11,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,5.0,Intermediate Spanish,0.74,0.05,0.16,0.0,0.05,0.0,0.0,0.0,yezid flores,
+SPAN,2020,6.0,Intermediate Spanish,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,rosa macarena pillcurima,
+SPAN,2020,7.0,Intermediate Spanish,0.63,0.26,0.0,0.0,0.05,0.0,0.0,0.05,rosa macarena pillcurima,
+SPAN,2020,8.0,Intermediate Spanish,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,ana paula  miller,
+SPAN,2020,9.0,Intermediate Spanish,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,10.0,Intermediate Spanish,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,
+SPAN,2020,11.0,Intermediate Spanish,0.46,0.46,0.0,0.0,0.0,0.0,0.0,0.08,jose luis ortiz,
+SPAN,2020,13.0,Intermediate Spanish,0.41,0.24,0.18,0.12,0.0,0.0,0.0,0.06,jose luis ortiz,
+SPAN,2020,14.0,Intermediate Spanish,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,daniel david garcia vieyra,
+SPAN,2020,15.0,Intermediate Spanish,0.61,0.22,0.06,0.06,0.0,0.0,0.0,0.06,yezid flores,
+SPAN,2020,16.0,Intermediate Spanish,0.63,0.16,0.11,0.0,0.0,0.0,0.0,0.11,daniel david garcia vieyra,
+SPAN,3010,1.0,Spanish Comp for Health Prof,0.12,0.53,0.29,0.06,0.0,0.0,0.0,0.0,tiffany dawn creegan miller,
+SPAN,3020,1.0,Intermed Span Grammar & Comp,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,melva marguerite persico,
+SPAN,3020,2.0,Intermed Span Grammar & Comp,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,melva marguerite persico,
+SPAN,3020,3.0,Intermed Span Grammar & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
+SPAN,3040,1.0,Intro Hispanic Literary Forms,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,graciela tissera,
+SPAN,3050,1.0,Intermed Span Convers/Comp I,0.68,0.21,0.0,0.05,0.0,0.0,0.0,0.05,daniel david garcia vieyra,
+SPAN,3050,2.0,Intermed Span Convers/Comp I,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,daniel david garcia vieyra,
+SPAN,3050,3.0,Intermed Span Convers/Comp I,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,
+SPAN,3050,4.0,Intermed Span Convers/Comp I,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,
+SPAN,3050,6.0,Intermed Span Convers/Comp I,0.5,0.39,0.0,0.06,0.0,0.0,0.0,0.06,jose luis ortiz,
+SPAN,3080,1.0,The Hispanic World: Latin Amer,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,tiffany dawn creegan miller,
+SPAN,3080,2.0,The Hispanic World: Latin Amer,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,
+SPAN,3130,2.0,Span Lit Survey I,0.29,0.36,0.07,0.0,0.0,0.0,0.0,0.29,monica rojas-de-massei,
+SPAN,3180,1.0,Spanish Through Culture,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,george palacios,
+SPAN,4060,1.0,Narrative Fiction,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,monica rojas-de-massei,
+SPAN,4060,2.0,Narrative Fiction,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,monica rojas-de-massei,
+SPAN,4070,1.0,Hispanic Film,0.72,0.06,0.22,0.0,0.0,0.0,0.0,0.0,salvador oropesa,
+SPAN,4190,1.0,Health & Hispanic Community,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,arelis moore peralta,
+STAT,2220,1.0,Statistics in Everyday Life,0.24,0.38,0.3,0.01,0.01,0.0,0.0,0.05,james espey,
+STAT,2220,2.0,Statistics in Everyday Life,0.27,0.36,0.22,0.05,0.04,0.0,0.0,0.05,james espey,
+STAT,2220,3.0,Statistics in Everyday Life,0.36,0.32,0.2,0.02,0.02,0.0,0.0,0.07,james espey,
+STAT,2220,4.0,Statistics in Everyday Life,0.26,0.28,0.28,0.09,0.02,0.0,0.0,0.06,james espey,
+STAT,2220,5.0,Statistics in Everyday Life,0.32,0.38,0.08,0.1,0.07,0.0,0.0,0.06,rose martinez-dawson,
+STAT,2220,6.0,Statistics in Everyday Life,0.37,0.3,0.15,0.08,0.06,0.0,0.0,0.04,rose martinez-dawson,
+STAT,2220,7.0,Statistics in Everyday Life,0.27,0.4,0.19,0.06,0.02,0.0,0.0,0.06,rose martinez-dawson,
+STAT,2300,1.0,Statistical Methods I,0.46,0.35,0.09,0.05,0.02,0.0,0.0,0.02,paran rebekah norton,
+STAT,2300,2.0,Statistical Methods I,0.38,0.32,0.18,0.04,0.07,0.0,0.0,0.01,paran rebekah norton,
+STAT,2300,3.0,Statistical Methods I,0.27,0.3,0.23,0.11,0.05,0.0,0.0,0.03, erwin walker,
+STAT,2300,4.0,Statistical Methods I,0.27,0.32,0.2,0.1,0.1,0.0,0.0,0.0, erwin walker,
+STAT,2300,5.0,Statistical Methods I,0.3,0.32,0.13,0.09,0.09,0.0,0.0,0.06,paran rebekah norton,
+STAT,2300,6.0,Statistical Methods I,0.29,0.38,0.17,0.06,0.05,0.0,0.0,0.05,sharon marie evans,
+STAT,2300,100.0,Statistical Methods I (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sharon marie evans,True
+STAT,3090,1.0,Introductory Business Stats,0.11,0.28,0.28,0.33,0.0,0.0,0.0,0.0,fun choi john chan,
+STAT,3090,2.0,Introductory Business Stats,0.0,0.35,0.35,0.24,0.06,0.0,0.0,0.0,fun choi john chan,
+STAT,3090,3.0,Introductory Business Stats,0.17,0.17,0.39,0.11,0.17,0.0,0.0,0.0,sarah kelly,
+STAT,3090,4.0,Introductory Business Stats,0.21,0.32,0.32,0.05,0.11,0.0,0.0,0.0,sarah kelly,
+STAT,3090,5.0,Introductory Business Stats,0.22,0.33,0.33,0.06,0.06,0.0,0.0,0.0,mary elizabeth saine,
+STAT,3090,6.0,Introductory Business Stats,0.21,0.26,0.37,0.05,0.05,0.0,0.0,0.05,mary elizabeth saine,
+STAT,3090,7.0,Introductory Business Stats,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,sean walker ingimarson,
+STAT,3090,8.0,Introductory Business Stats,0.21,0.37,0.26,0.16,0.0,0.0,0.0,0.0,sean walker ingimarson,
+STAT,3090,9.0,Introductory Business Stats,0.21,0.32,0.16,0.16,0.16,0.0,0.0,0.0,yidan guo,
+STAT,3090,10.0,Introductory Business Stats,0.22,0.33,0.22,0.11,0.11,0.0,0.0,0.0,yidan guo,
+STAT,3090,11.0,Introductory Business Stats,0.32,0.26,0.21,0.11,0.11,0.0,0.0,0.0,rui gong,
+STAT,3090,12.0,Introductory Business Stats,0.26,0.21,0.21,0.05,0.16,0.0,0.0,0.11,rui gong,
+STAT,3090,13.0,Introductory Business Stats,0.29,0.26,0.2,0.14,0.08,0.0,0.0,0.03,april thomas,
+STAT,3090,14.0,Introductory Business Stats,0.36,0.33,0.25,0.02,0.02,0.0,0.0,0.02,april thomas,
+STAT,3090,15.0,Introductory Business Stats,0.47,0.12,0.24,0.0,0.18,0.0,0.0,0.0,molly adams honecker,
+STAT,3090,16.0,Introductory Business Stats,0.53,0.32,0.05,0.0,0.11,0.0,0.0,0.0,molly adams honecker,
+STAT,3090,17.0,Introductory Business Stats,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,xueheng shi,
+STAT,3090,18.0,Introductory Business Stats,0.21,0.53,0.11,0.05,0.0,0.0,0.0,0.11,xueheng shi,
+STAT,3090,19.0,Introductory Business Stats,0.44,0.17,0.0,0.17,0.17,0.0,0.0,0.06,feng gao,
+STAT,3090,20.0,Introductory Business Stats,0.22,0.5,0.22,0.06,0.0,0.0,0.0,0.0,feng gao,
+STAT,3090,21.0,Introductory Business Stats,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,zhengxin wang,
+STAT,3090,22.0,Introductory Business Stats,0.44,0.17,0.28,0.11,0.0,0.0,0.0,0.0,zhengxin wang,
+STAT,3090,23.0,Introductory Business Stats,0.28,0.11,0.33,0.17,0.0,0.0,0.0,0.11,james mckay visser,
+STAT,3090,24.0,Introductory Business Stats,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,james mckay visser,
+STAT,3090,25.0,Introductory Business Stats,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,boyoung hur,
+STAT,3090,26.0,Introductory Business Stats,0.33,0.22,0.39,0.06,0.0,0.0,0.0,0.0,boyoung hur,
+STAT,3090,27.0,Introductory Business Stats,0.22,0.28,0.33,0.0,0.11,0.0,0.0,0.06,siyuan yu,
+STAT,3090,28.0,Introductory Business Stats,0.24,0.29,0.18,0.18,0.06,0.0,0.0,0.06,siyuan yu,
+STAT,3090,29.0,Introductory Business Stats,0.0,0.42,0.21,0.05,0.21,0.0,0.0,0.11,minghua cui,
+STAT,3090,30.0,Introductory Business Stats,0.08,0.38,0.15,0.08,0.15,0.0,0.0,0.15,minghua cui,
+STAT,3090,31.0,Introductory Business Stats,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,tiantian yang,
+STAT,3090,32.0,Introductory Business Stats,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,tiantian yang,
+STAT,3090,33.0,Introductory Business Stats,0.21,0.63,0.11,0.0,0.05,0.0,0.0,0.0,trevor camper,
+STAT,3090,34.0,Introductory Business Stats,0.11,0.37,0.37,0.05,0.11,0.0,0.0,0.0,trevor camper,
+STAT,3090,35.0,Introductory Business Stats,0.06,0.17,0.39,0.22,0.11,0.0,0.0,0.06,jiyun huang,
+STAT,3090,36.0,Introductory Business Stats,0.32,0.37,0.26,0.05,0.0,0.0,0.0,0.0,jiyun huang,
+STAT,3090,37.0,Introductory Business Stats,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,anna marie vagnozzi,
+STAT,3090,38.0,Introductory Business Stats,0.5,0.28,0.17,0.06,0.0,0.0,0.0,0.0,anna marie vagnozzi,
+STAT,3090,39.0,Introductory Business Stats,0.42,0.37,0.11,0.05,0.0,0.0,0.0,0.05,pubudu jayasekara merenchige,
+STAT,3090,40.0,Introductory Business Stats,0.37,0.26,0.21,0.05,0.05,0.0,0.0,0.05,pubudu jayasekara merenchige,
+STAT,3300,1.0,Statistical Methods II,0.22,0.22,0.22,0.0,0.13,0.0,0.0,0.22,rose martinez-dawson,
+STAT,4020,1.0,Intro to Statistical Computing,0.25,0.33,0.08,0.0,0.08,0.0,0.0,0.25,ellen hepfer breazel,
+STAT,4020,2.0,Intro to Statistical Computing,0.38,0.08,0.15,0.08,0.15,0.0,0.0,0.15,ellen hepfer breazel,
+STAT,4110,1.0,Stat Mthds for Process Control,0.68,0.18,0.05,0.05,0.03,0.0,0.0,0.0,richard steven dubsky,
+STAT,4110,2.0,Stat Mthds for Process Control,0.72,0.14,0.09,0.05,0.0,0.0,0.0,0.0,richard steven dubsky,
+STAT,4110,3.0,Stat Mthds for Process Control,0.5,0.21,0.14,0.0,0.05,0.0,0.0,0.1,yu-bo wang,
+STAT,4110,4.0,Stat Mthds for Process Control,0.3,0.32,0.22,0.03,0.11,0.0,0.0,0.03,yu-bo wang,
+STAT,6020,1.0,Intro to Statistical Computing,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,
+STAT,6020,2.0,Intro to Statistical Computing,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,
+STAT,8010,1.0,Statistical Methods I,0.55,0.23,0.18,0.0,0.0,0.0,0.0,0.05,patrick gerard,
+STAT,8010,2.0,Statistical Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah elizabeth kunkel,
+STAT,8010,4.0,Statistical Methods I,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,deborah elizabeth kunkel,
+STAT,8010,5.0,Statistical Methods I,0.56,0.17,0.06,0.0,0.17,0.0,0.0,0.06,jun luo,
+STAT,8010,6.0,Statistical Methods I,0.73,0.14,0.14,0.0,0.0,0.0,0.0,0.0,jun luo,
+STAT,8010,7.0,Statistical Methods I,0.43,0.38,0.14,0.0,0.0,0.0,0.0,0.05,joseph daniel bible,
+STAT,8020,1.0,Statistical Methods II,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,8050,1.0,Design & Anlys of Experiments,0.48,0.48,0.03,0.0,0.0,0.0,0.0,0.0,william bridges,
+STS,1010,1.0,Survey Sci & Techn in Society,0.59,0.32,0.0,0.03,0.03,0.0,0.0,0.03,kenneth david widgren,
+STS,1010,2.0,Survey Sci & Techn in Society,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,scott brame,
+STS,1010,3.0,Survey Sci & Techn in Society,0.67,0.25,0.03,0.03,0.0,0.0,0.0,0.03,elizabeth anderson stansell,
+STS,1010,4.0,Survey Sci & Techn in Society,0.69,0.26,0.03,0.0,0.03,0.0,0.0,0.0,ingrid anna pierce,
+STS,1010,5.0,Survey Sci & Techn in Society,0.42,0.5,0.06,0.0,0.03,0.0,0.0,0.0,philip randall,
+STS,1010,6.0,Survey Sci & Techn in Society,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,
+STS,1010,7.0,Survey Sci & Techn in Society,0.44,0.44,0.06,0.0,0.03,0.0,0.0,0.03,megan noel macalystre,
+STS,1010,8.0,Survey Sci & Techn in Society,0.44,0.41,0.09,0.0,0.0,0.0,0.0,0.06,david charles foltz,
+STS,1010,9.0,Survey Sci & Techn in Society,0.53,0.41,0.03,0.0,0.0,0.0,0.0,0.03,tareva leselle johnson,
+STS,1010,10.0,Survey Sci & Techn in Society,0.62,0.29,0.03,0.0,0.0,0.0,0.0,0.06,alexander john billinis,
+STS,1010,11.0,Survey Sci & Techn in Society,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,anne mcmahan grant,
+SUST,2010,1.0,Sustainability Leadership,0.88,0.03,0.03,0.03,0.03,0.0,0.0,0.0,jennifer margaret goree,
+THEA,2100,1.0,Theatre Appreciation,0.59,0.28,0.09,0.0,0.03,0.0,0.0,0.0,david hartmann,
+THEA,2100,3.0,Theatre Appreciation,0.63,0.23,0.07,0.03,0.0,0.0,0.0,0.03,kendra lynette johnson,
+THEA,2100,5.0,Theatre Appreciation,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
+THEA,2100,6.0,Theatre Appreciation,0.59,0.28,0.09,0.0,0.0,0.0,0.0,0.03,jason adkins,
+THEA,2100,7.0,Theatre Appreciation,0.73,0.1,0.13,0.0,0.03,0.0,0.0,0.0,jason adkins,
+THEA,2770,1.0,Prod Studies in Thea,0.63,0.25,0.08,0.0,0.0,0.0,0.0,0.04,david hartmann,
+THEA,2780,1.0,Acting I,0.75,0.06,0.13,0.06,0.0,0.0,0.0,0.0,kerrie kathleen seymour,
+THEA,2790,1.0,Theatre Practicum,0.57,0.21,0.07,0.0,0.07,0.0,0.0,0.07,matthew leckenbusch,
+THEA,3080,1.0,Surv of Broadway I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
+THEA,3160,1.0,Theatre History II,0.63,0.21,0.08,0.04,0.04,0.0,0.0,0.0,shannon therese robert,
+THEA,3170,1.0,African-Amer Thea I,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,kendra lynette johnson,
+WFB,3010,2.0,Wildlife Biology Lab,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,shari lynn rodriguez,
+WFB,4100,2.0,Wildlife Management Techniques,0.26,0.66,0.03,0.06,0.0,0.0,0.0,0.0,catherine michelle jachowski,
+WFB,4120,1.0,Wildlife Management,0.67,0.26,0.04,0.04,0.0,0.0,0.0,0.0,greg yarrow,
+WFB,4180,2.0,Fisheries Mgt & Conservation,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,troy mason farmer,
+WFB,4440,1.0,Wildlife Damage Management,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,greg yarrow,
+WFB,4720,1.0,Ornithology,0.27,0.32,0.23,0.09,0.05,0.0,0.0,0.05,neil smith,
+WFB,4770,1.0,Ichthyology,0.71,0.07,0.14,0.07,0.0,0.0,0.0,0.0,brandon kevin peoples,
+WFB,4800,1.0,Waterfowl Ecology & Management,0.4,0.47,0.05,0.0,0.0,0.0,0.0,0.09,richard marvin kaminski,
+WFB,6620,1.0,Wetland Wildlife Biology,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,russell barrett,
+WFB,6800,1.0,Waterfowl Ecology & Management,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,richard marvin kaminski,
+WFB,8610,5.0,Scientific Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stefanie whitmire,
+WFB,8610,10.0,Fisheries Mgt and Conservation,0.67,0.11,0.11,0.0,0.11,0.0,0.0,0.0,troy mason farmer,
+WFB,8610,11.0,Study Design & Data Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,brandon kevin peoples,
+WFB,8610,14.0,Wildlife Resource Selection,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine michelle jachowski,
+WFB,8610,23.0,Aquatic Habitat Management,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,mark scott,
+WS,1030,1.0,Women in Global Perspective,0.5,0.36,0.11,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,
+WS,1030,2.0,Women in Global Perspective,0.53,0.39,0.06,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,
+WS,2300,1.0,Women and Leadership I,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,mary price,
+WS,3010,1.0,Intro Women's Studies,0.47,0.39,0.03,0.03,0.06,0.0,0.0,0.03,elizabeth rose adams,
+WS,3010,2.0,Intro Women's Studies,0.58,0.37,0.03,0.0,0.0,0.0,0.0,0.03,elizabeth rose adams,
+WS,4230,1.0,Women in the Developing World,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,melissa vogel,
+YDP,3000,400.0,Youth Development in Society,0.64,0.2,0.04,0.04,0.04,0.0,0.0,0.04,lauren elizabeth stephens,
+YDP,3050,400.0,Theory/Phil of Youth Dev Work,0.73,0.15,0.08,0.0,0.0,0.0,0.0,0.04,lauren elizabeth stephens,
+YDP,3200,1.0,Youth Dev in Sport/Phys Activ,0.71,0.13,0.08,0.04,0.0,0.0,0.0,0.04,lauren elizabeth stephens,
+YDP,3250,1.0,Working with Diverse Youth,0.76,0.12,0.06,0.0,0.06,0.0,0.0,0.0,kimberly pearson johnson,
+YDP,3300,1.0,Designing Effective Youth Prog,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,kellye rembert,
+YDP,3350,1.0,Youth Activity Leadership,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lauren elizabeth stephens,
+YDP,3450,1.0,Creative Activities for Youth,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kimberly pearson johnson,
+YDP,4450,1.0,Youth Devel Org Administration,0.61,0.17,0.17,0.0,0.0,0.0,0.0,0.04,allison michelle avishai,
+YDP,4500,1.0,Prof Iss & Ethics in Youth Dev,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kayla lee weston,

--- a/bot/cogs/grades_cog/assets/2019_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2019_Fall.csv
@@ -1,2821 +1,2821 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1010,1.0,Survey of Art & Arch History I,0.35,0.46,0.15,0.01,0.02,0.0,0.0,0.01,beth ann lauritis,
-AAH,2050,1.0,Art History and Theory I,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,beth ann lauritis,
-AAH,3050,1.0,Contemporary Art History,0.81,0.14,0.0,0.05,0.0,0.0,0.0,0.0,anatole upart,
-ACCT,2010,1.0,Financial Accounting Concepts,0.43,0.29,0.1,0.04,0.04,0.0,0.0,0.1,lydia lancaster folger schleifer,
-ACCT,2010,2.0,Financial Accounting Concepts,0.42,0.32,0.16,0.02,0.04,0.0,0.0,0.04,lydia lancaster folger schleifer,
-ACCT,2010,3.0,Financial Accounting Concepts,0.33,0.27,0.22,0.04,0.02,0.0,0.0,0.11,julie grant,
-ACCT,2010,4.0,Financial Accounting Concepts,0.38,0.24,0.2,0.07,0.02,0.0,0.0,0.09,julie grant,
-ACCT,2010,5.0,Financial Accounting Concepts,0.5,0.35,0.1,0.0,0.0,0.0,0.0,0.04,lydia lancaster folger schleifer,
-ACCT,2010,6.0,Financial Accounting Concepts,0.4,0.31,0.13,0.07,0.02,0.0,0.0,0.07,michael john mcguigan,
-ACCT,2010,7.0,Financial Accounting Concepts,0.16,0.49,0.27,0.0,0.06,0.0,0.0,0.02,carl hollingsworth,
-ACCT,2010,8.0,Financial Accounting Concepts,0.22,0.31,0.27,0.1,0.04,0.0,0.0,0.06,carl hollingsworth,
-ACCT,2010,9.0,Financial Accounting Concepts,0.11,0.39,0.3,0.07,0.07,0.0,0.0,0.07,michael john mcguigan,
-ACCT,2010,10.0,Financial Accounting Concepts,0.37,0.33,0.14,0.06,0.04,0.0,0.0,0.06,charles tegen,
-ACCT,2010,11.0,Financial Accounting Concepts,0.33,0.28,0.14,0.03,0.08,0.0,0.0,0.14,lisa wheatley birtwistle,
-ACCT,2010,12.0,Financial Accounting Concepts,0.12,0.35,0.19,0.07,0.12,0.0,0.0,0.16,lisa wheatley birtwistle,
-ACCT,2010,13.0,Financial Accounting Concepts,0.24,0.24,0.37,0.1,0.0,0.0,0.0,0.05,lisa wheatley birtwistle,
-ACCT,2010,14.0,Financial Accounting Concepts,0.38,0.45,0.1,0.03,0.0,0.0,0.0,0.03,annieka philo,
-ACCT,2010,100.0,Fin Accounting Concepts (HON),0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,mary ann  prater,True
-ACCT,2010,111.0,Fin Accounting Concepts (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lisa wheatley birtwistle,True
-ACCT,2010,400.0,Financial Accounting Concepts,0.14,0.22,0.21,0.1,0.07,0.0,0.0,0.26,jeffrey mcmillan,
-ACCT,2010,401.0,Financial Accounting Concepts,0.33,0.43,0.16,0.04,0.02,0.0,0.0,0.02,emily suzanne mccorkle,
-ACCT,2020,1.0,Managerial Accounting Concepts,0.31,0.23,0.15,0.03,0.0,0.0,0.0,0.28,henry anderson,
-ACCT,2020,2.0,Managerial Accounting Concepts,0.27,0.33,0.15,0.06,0.12,0.0,0.0,0.06,henry anderson,
-ACCT,2020,3.0,Managerial Accounting Concepts,0.18,0.46,0.23,0.0,0.03,0.0,0.0,0.1,henry anderson,
-ACCT,2020,4.0,Managerial Accounting Concepts,0.26,0.33,0.23,0.0,0.1,0.0,0.0,0.08,henry anderson,
-ACCT,2020,5.0,Managerial Accounting Concepts,0.21,0.3,0.21,0.09,0.06,0.0,0.0,0.13,brian todd carver,
-ACCT,2020,6.0,Managerial Accounting Concepts,0.17,0.15,0.37,0.09,0.04,0.0,0.0,0.17,brian todd carver,
-ACCT,2020,400.0,Managerial Accounting Concepts,0.3,0.29,0.16,0.08,0.03,0.0,0.0,0.13,henry anderson,
-ACCT,2020,402.0,Managerial Accounting Concepts,0.25,0.23,0.3,0.12,0.04,0.0,0.0,0.05,emily suzanne mccorkle,
-ACCT,2900,1.0,Special Topics - Soft Skills,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,michael mendonca,
-ACCT,3030,1.0,Cost Accounting,0.38,0.36,0.21,0.0,0.03,0.0,0.0,0.03,daniel thomas way,
-ACCT,3030,2.0,Cost Accounting,0.25,0.39,0.31,0.03,0.0,0.0,0.0,0.03,daniel thomas way,
-ACCT,3030,3.0,Cost Accounting,0.32,0.43,0.14,0.03,0.05,0.0,0.0,0.03,jace garrett,
-ACCT,3030,4.0,Cost Accounting,0.38,0.27,0.19,0.03,0.03,0.0,0.0,0.11,jace garrett,
-ACCT,3030,5.0,Cost Accounting,0.55,0.26,0.16,0.0,0.03,0.0,0.0,0.0,sarah martin,
-ACCT,3110,1.0,Intermediate Financial Acct I,0.17,0.29,0.33,0.0,0.08,0.0,0.0,0.13,annieka philo,
-ACCT,3110,2.0,Intermediate Financial Acct I,0.16,0.31,0.41,0.06,0.03,0.0,0.0,0.03,amy melissa donnelly,
-ACCT,3110,3.0,Intermediate Financial Acct I,0.17,0.39,0.11,0.11,0.11,0.0,0.0,0.11,annieka philo,
-ACCT,3110,4.0,Intermediate Financial Acct I,0.19,0.32,0.39,0.03,0.03,0.0,0.0,0.03,amy melissa donnelly,
-ACCT,3110,5.0,Intermediate Financial Acct I,0.19,0.52,0.19,0.0,0.0,0.0,0.0,0.1, russell madray,
-ACCT,3110,6.0,Intermediate Financial Acct I,0.16,0.29,0.26,0.06,0.06,0.0,0.0,0.16,amy melissa donnelly,
-ACCT,3110,7.0,Intermediate Financial Acct I,0.32,0.42,0.13,0.03,0.06,0.0,0.0,0.03, russell madray,
-ACCT,3110,8.0,Intermediate Financial Acct I,0.11,0.26,0.26,0.11,0.21,0.0,0.0,0.05,erin michelle hawkins,
-ACCT,3110,100.0,Intermediate Fin Acct I (HON),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,True
-ACCT,3120,1.0,Intermediate Financial Acct II,0.44,0.17,0.28,0.0,0.06,0.0,0.0,0.06,terry daniel knause,
-ACCT,3120,2.0,Intermediate Financial Acct II,0.0,0.39,0.39,0.11,0.11,0.0,0.0,0.0, russell madray,
-ACCT,3120,3.0,Intermediate Financial Acct II,0.2,0.46,0.23,0.06,0.03,0.0,0.0,0.03, russell madray,
-ACCT,3120,4.0,Intermediate Financial Acct II,0.45,0.42,0.1,0.0,0.0,0.0,0.0,0.03,terry daniel knause,
-ACCT,3120,5.0,Intermediate Financial Acct II,0.33,0.33,0.31,0.0,0.0,0.0,0.0,0.03,terry daniel knause,
-ACCT,3120,6.0,Intermediate Financial Acct II,0.31,0.5,0.17,0.0,0.0,0.0,0.0,0.03,terry daniel knause,
-ACCT,3130,1.0,Analytics for Acct Dec Making,0.57,0.25,0.14,0.0,0.0,0.0,0.0,0.04,babak mammadov,
-ACCT,3130,2.0,Analytics for Acct Dec Making,0.33,0.4,0.13,0.0,0.07,0.0,0.0,0.07,babak mammadov,
-ACCT,3130,3.0,Analytics for Acct Dec Making,0.28,0.33,0.28,0.11,0.0,0.0,0.0,0.0,phebian davis-culler,
-ACCT,3130,4.0,Analytics for Acct Dec Making,0.18,0.64,0.18,0.0,0.0,0.0,0.0,0.0,phebian davis-culler,
-ACCT,3130,5.0,Analytics for Acct Dec Making,0.32,0.41,0.18,0.0,0.05,0.0,0.0,0.05,phebian davis-culler,
-ACCT,3130,6.0,Analytics for Acct Dec Making,0.17,0.35,0.3,0.13,0.04,0.0,0.0,0.0,phebian davis-culler,
-ACCT,3130,105.0,Analytics for Accounting (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,phebian davis-culler,True
-ACCT,3220,1.0,Accounting Information Systems,0.11,0.32,0.21,0.21,0.05,0.0,0.0,0.11,philip maiberger,
-ACCT,3220,2.0,Accounting Information Systems,0.18,0.42,0.24,0.06,0.03,0.0,0.0,0.06,philip maiberger,
-ACCT,3220,3.0,Accounting Information Systems,0.1,0.31,0.31,0.1,0.07,0.0,0.0,0.1,philip maiberger,
-ACCT,3220,4.0,Accounting Information Systems,0.14,0.41,0.21,0.07,0.0,0.0,0.0,0.17,philip maiberger,
-ACCT,4040,1.0,Individual Taxation,0.64,0.21,0.11,0.0,0.0,0.0,0.0,0.04,sarah martin,
-ACCT,4040,2.0,Individual Taxation,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,3.0,Individual Taxation,0.42,0.33,0.18,0.0,0.03,0.0,0.0,0.03,sarah martin,
-ACCT,4040,4.0,Individual Taxation,0.06,0.52,0.23,0.1,0.06,0.0,0.0,0.03,lisa wheatley birtwistle,
-ACCT,4040,101.0,Individual Taxation (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,True
-ACCT,4080,1.0,Retire & Estate Plan,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,john hine,
-ACCT,4100,1.0,Reporting and Mgmt Control Sys,0.29,0.41,0.26,0.0,0.0,0.0,0.0,0.03,gregory patrick mcphee,
-ACCT,4100,2.0,Reporting and Mgmt Control Sys,0.38,0.38,0.18,0.06,0.0,0.0,0.0,0.0,gregory patrick mcphee,
-ACCT,4100,3.0,Reporting and Mgmt Control Sys,0.3,0.55,0.06,0.06,0.0,0.0,0.0,0.03,robin radtke,
-ACCT,4150,1.0,Auditing,0.37,0.46,0.17,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,4150,2.0,Auditing,0.26,0.29,0.35,0.1,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,8510,1.0,Tax Research,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,
-ACCT,8530,1.0,Adv Acct Problems,0.5,0.41,0.06,0.0,0.0,0.0,0.0,0.03,suzanne pearse,
-ACCT,8530,2.0,Adv Acct Problems,0.45,0.42,0.12,0.0,0.0,0.0,0.0,0.0,suzanne pearse,
-ACCT,8530,3.0,Adv Acct Problems,0.43,0.33,0.17,0.0,0.07,0.0,0.0,0.0,ralph edward welton,
-ACCT,8550,1.0,Gov't and Nonprofit Accounting,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8550,2.0,Gov't and Nonprofit Accounting,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8550,3.0,Gov't and Nonprofit Accounting,0.52,0.42,0.06,0.0,0.0,0.0,0.0,0.0,james barnes,
-ACCT,8630,1.0,Forensics Analysis,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,brian matthew goodson,
-ACCT,8630,2.0,Forensics Analysis,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,brian matthew goodson,
-ACCT,8650,1.0,Tax & Bus Decisions,0.25,0.72,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,
-ACCT,8650,2.0,Tax & Bus Decisions,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,
-ACCT,8720,1.0,Tax of Flowthroughs,0.21,0.56,0.18,0.0,0.03,0.0,0.0,0.03,thomas dickens,
-AGED,1020,1.0,Freshman Seminar,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,
-AGED,2000,1.0,Agr Appl of Ed Tech,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,kevin layfield,
-AGED,2010,1.0,Intro to Agric Educ,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,
-AGED,3030,1.0,Ag Ed Mech Tech,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGED,4010,1.0,Instr Methods Ag Ed,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,
-AGED,4030,1.0,Prin Adult/Ext Ed,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGED,4230,400.0,Curriculum,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,
-AGM,1010,1.0,Intro Ag Mech & Bus,0.6,0.2,0.09,0.06,0.03,0.0,0.0,0.03,hunter massey,
-AGM,1010,1.0,Intro Ag Mech & Bus,0.6,0.2,0.09,0.06,0.03,0.0,0.0,0.03,hunter massey,
-AGM,2050,1.0,Prin of Fabrication,0.23,0.54,0.19,0.02,0.0,0.0,0.0,0.02,hunter massey,
-AGM,2050,1.0,Prin of Fabrication,0.23,0.54,0.19,0.02,0.0,0.0,0.0,0.02,hunter massey,
-AGM,2060,1.0,Machinery Mgt,0.23,0.46,0.15,0.08,0.08,0.0,0.0,0.0,hunter massey,
-AGM,2060,1.0,Machinery Mgt,0.23,0.46,0.15,0.08,0.08,0.0,0.0,0.0,hunter massey,
-AGM,2210,1.0,Land Measurements,0.5,0.38,0.09,0.01,0.01,0.0,0.0,0.0,charles privette,
-AGM,3010,1.0,Soil Water Conserv,0.63,0.18,0.18,0.0,0.0,0.0,0.0,0.0,calvin sawyer,
-AGM,4000,1.0,Seminar in Ag Mech & Business,0.28,0.63,0.08,0.0,0.0,0.0,0.0,0.03,john chastain,
-AGM,4020,1.0,Irrigation System Design,0.44,0.46,0.08,0.0,0.03,0.0,0.0,0.0,charles privette,
-AGM,4050,1.0,Env Cont in Anim Str,0.32,0.59,0.08,0.0,0.0,0.0,0.0,0.0,john chastain,
-AGM,4060,1.0,Mech & Hydraulic Sys,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4520,1.0,Mobile Power,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,ali bulent koc,
-AGM,4600,1.0,Electrical Systems,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,young jo han,
-AGM,4730,4.0,Ag Safety,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hunter massey,
-AGM,4730,4.0,Ag Safety,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hunter massey,
-AGRB,2020,1.0,Agricultural Economics,0.63,0.26,0.08,0.01,0.01,0.0,0.0,0.01,julie carl pingol ureta,
-AGRB,2050,1.0,Agriculture and Society,0.14,0.27,0.37,0.17,0.03,0.0,0.0,0.01,michael vassalos,
-AGRB,3020,1.0,Economics of Farm Management,0.12,0.2,0.31,0.27,0.04,0.0,0.0,0.05,michael vassalos,
-AGRB,3080,1.0,Quant Agribusiness Analysis I,0.31,0.31,0.31,0.08,0.0,0.0,0.0,0.0,david brian willis,
-AGRB,3090,1.0,Econ of Agricultural Marketing,0.73,0.2,0.03,0.0,0.01,0.0,0.0,0.03,yuliya valentinovna bolotova,
-AGRB,3570,1.0,Natural Resources Economics,0.23,0.23,0.26,0.09,0.09,0.0,0.0,0.09,david brian willis,
-AGRB,4090,1.0,Commodity Futures Markets,0.24,0.48,0.26,0.02,0.0,0.0,0.0,0.0,david baird montgomery,
-AGRB,4120,1.0,Reg Econ Devel Theory & Policy,0.32,0.32,0.14,0.2,0.02,0.0,0.0,0.0,felipe de figueiredo silva,
-AGRB,4520,1.0,Agricultural Policy,0.17,0.44,0.31,0.08,0.0,0.0,0.0,0.0,michael vassalos,
-AGRB,4900,1.0,Special Topics,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael vassalos,
-AGRB,4910,1.0,"Int, Agrib & Comm & Rural Dev",0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,michael vassalos,
-AL,3440,400.0,Athletics and Women,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,misty soles,
-AL,3490,400.0,Principles of Coaching,0.56,0.24,0.08,0.04,0.0,0.0,0.0,0.08,deborah jo cadorette,
-AL,3490,401.0,Principles of Coaching,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,
-AL,3490,402.0,Principles of Coaching,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,john plumblee,
-AL,3490,403.0,Principles of Coaching,0.52,0.24,0.08,0.04,0.04,0.0,0.0,0.08,clyde keith connor,
-AL,3490,404.0,Principles of Coaching,0.48,0.36,0.12,0.0,0.04,0.0,0.0,0.0,john plumblee,
-AL,3490,405.0,Principles of Coaching,0.64,0.24,0.04,0.0,0.04,0.0,0.0,0.04,frank mezzanotte,
-AL,3490,406.0,Principles of Coaching,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,edmond fry,
-AL,3490,407.0,Principles of Coaching,0.64,0.24,0.08,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,
-AL,3490,408.0,Principles of Coaching,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,nicholas philip edward whitrow,
-AL,3490,409.0,Principles of Coaching,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,nicholas philip edward whitrow,
-AL,3490,410.0,Principles of Coaching,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,nicholas philip edward whitrow,
-AL,3490,411.0,Principles of Coaching,0.5,0.29,0.17,0.0,0.0,0.0,0.0,0.04,joel neuder,
-AL,3500,400.0,Sci Basis I/Ex Phy,0.12,0.54,0.12,0.19,0.0,0.0,0.0,0.04,michael godfrey,
-AL,3500,401.0,Sci Basis I/Ex Phy,0.32,0.09,0.23,0.18,0.09,0.0,0.0,0.09,michael godfrey,
-AL,3530,400.0,Athletic Injuries,0.32,0.2,0.16,0.12,0.12,0.0,0.0,0.08,isaac sean colbert,
-AL,3530,401.0,Athletic Injuries,0.26,0.3,0.3,0.13,0.0,0.0,0.0,0.0,isaac sean colbert,
-AL,3600,400.0,Hgh Sch Athl Ethical/Legal Iss,0.29,0.46,0.08,0.17,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,3610,400.0,Admin/Org of Athletic Programs,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,401.0,Admin/Org of Athletic Programs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3620,400.0,Psychology of Coaching,0.31,0.12,0.35,0.12,0.04,0.0,0.0,0.08,natalie anne carter,
-AL,3620,401.0,Psychology of Coaching,0.32,0.36,0.2,0.04,0.0,0.0,0.0,0.08,natalie anne carter,
-AL,3620,402.0,Psychology of Coaching,0.33,0.17,0.38,0.08,0.04,0.0,0.0,0.0,natalie anne carter,
-AL,3740,400.0,Coaching Football,0.77,0.09,0.05,0.05,0.0,0.0,0.0,0.05,edmond fry,
-AL,3740,401.0,Coaching Football,0.5,0.23,0.05,0.09,0.05,0.0,0.0,0.09,edmond fry,
-AL,3760,400.0,Coaching Strength/Conditioning,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,edmond fry,
-AL,3760,401.0,Coaching Strength/Conditioning,0.68,0.08,0.08,0.0,0.04,0.0,0.0,0.12,edmond fry,
-AL,4380,402.0,HS Athletic Recruiting,0.57,0.14,0.11,0.0,0.04,0.0,0.0,0.14,deborah jo cadorette,
-AL,4380,403.0,Media Relations in AL,0.74,0.07,0.15,0.0,0.04,0.0,0.0,0.0,misty soles,
-AL,4380,408.0,Officiating in AL,0.63,0.17,0.04,0.04,0.0,0.0,0.0,0.13,clyde keith connor,
-AL,4380,409.0,Coaching Baseball/Softball,0.58,0.17,0.13,0.04,0.0,0.0,0.0,0.08,deborah jo cadorette,
-AL,4490,400.0,Athlete Beliefs,0.42,0.42,0.13,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,
-AL,8380,400.0,Compliance in Intercoll Athl,0.8,0.05,0.0,0.0,0.05,0.0,0.0,0.1,michael godfrey,
-AL,8380,401.0,Compliance in Colleg Athl,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8440,400.0,Surv of Res Mthds in Athletics,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8440,401.0,Surv of Res Mthds in Athletics,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8440,402.0,Surv of Res Mthds in Athletics,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8490,400.0,Athletic Leadership Dev,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,janna theresa magette,
-AL,8490,401.0,Athletic Leadership Dev,0.76,0.1,0.1,0.0,0.0,0.0,0.0,0.05,janna theresa magette,
-AL,8490,402.0,Athletic Leadership Dev,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,janna theresa magette,
-AL,8500,400.0,Principles Strength and Condit,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8500,401.0,Principles Strength and Condit,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,michael godfrey,
-AL,8650,400.0,Mkt and Comm Respon Interc Ath,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,8650,402.0,Mkt and Comm Respon Interc Ath,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,
-AMFG,6800,864.0,Practicum in Adv Manufacturing,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua summers,
-ANTH,2010,1.0,Introduction to Anthropology,0.49,0.31,0.12,0.02,0.0,0.0,0.0,0.06,yi wu,
-ANTH,2010,2.0,Introduction to Anthropology,0.42,0.29,0.18,0.0,0.02,0.0,0.0,0.09,lisa rapaport,
-ANTH,2010,3.0,Introduction to Anthropology,0.3,0.6,0.09,0.0,0.0,0.0,0.0,0.02,david markus,
-ANTH,2010,4.0,Introduction to Anthropology,0.36,0.54,0.07,0.01,0.02,0.0,0.0,0.02,david markus,
-ANTH,2010,5.0,Introduction to Anthropology,0.41,0.39,0.13,0.04,0.0,0.0,0.0,0.02,yi wu,
-ANTH,3320,1.0,World Archaeology,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,david markus,
-ANTH,3510,1.0,Biological Anthropology,0.48,0.43,0.05,0.0,0.05,0.0,0.0,0.0,lisa rapaport,
-ANTH,3530,1.0,Forensic Anthropology,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,katherine weisensee,
-ANTH,3710,1.0,Language and Culture,0.44,0.44,0.0,0.11,0.0,0.0,0.0,0.0,yanhua zhang,
-ANTH,4230,1.0,Women in the Developing World,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,
-ANTH,4990,1.0,"Religion, Magic, Witchcraft",0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,carolyn candace coffman,
-ARCH,1010,1.0,Introduction to Architecture,0.44,0.35,0.08,0.03,0.03,0.0,0.0,0.07,sallie rebecca hambright-belue,
-ARCH,2040,1.0,Hist of Modern Arch,0.42,0.48,0.07,0.02,0.0,0.0,0.0,0.01,andreea mihalache,
-ARCH,2510,1.0,Arch Foundations I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,2510,2.0,Arch Foundations I,0.53,0.35,0.12,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,2510,3.0,Arch Foundations I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,dustin graham albright,
-ARCH,2510,5.0,Arch Foundations I,0.28,0.28,0.39,0.06,0.0,0.0,0.0,0.0,brandon george pass,
-ARCH,2510,6.0,Arch Foundations I,0.28,0.39,0.28,0.06,0.0,0.0,0.0,0.0,virginia ellyn melnyk,
-ARCH,2700,1.0,Structures I,0.59,0.34,0.03,0.0,0.03,0.0,0.0,0.0,dustin graham albright,
-ARCH,3500,2.0,Intro to Urban Contexts,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,3500,3.0,Intro to Urban Contexts,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,3500,4.0,Intro to Urban Contexts,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,3500,5.0,Intro to Urban Contexts,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,3510,1.0,Studio Clemson,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,ufuk ersoy,
-ARCH,3510,3.0,Studio Clemson,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michael carlos barrios kleiss,
-ARCH,3530,1.0,Studio Genoa,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,3540,1.0,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4010,1.0,Architectural Portfolio,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,virginia ellyn melnyk,
-ARCH,4010,2.0,Architectural Portfolio,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,4010,3.0,Architectural Portfolio,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4010,4.0,Architectural Portfolio,0.44,0.33,0.17,0.0,0.06,0.0,0.0,0.0,brandon george pass,
-ARCH,4120,1.0,History Research,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,4140,1.0,Design Seminar,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,4520,1.0,Synthesis Studio,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,
-ARCH,4710,1.0,Arch Hist of Place,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,jason matthew white,
-ARCH,6850,1.0,H/Th: Arch+Health,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8100,1.0,Visualization I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,andreea mihalache,
-ARCH,8200,1.0,Bldg Design & Constr,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,tori elizabeth wallace-babcock,
-ARCH,8210,1.0,Research Methods,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,
-ARCH,8410,1.0,Arch Studio I,0.6,0.0,0.2,0.0,0.0,0.0,0.0,0.2,peter laurence,
-ARCH,8510,3.0,Design Studio III,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,8600,1.0,History/Theory I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,berrin terim,
-ARCH,8720,1.0,Production & Assemb,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,
-ARCH,8970,1.0,A+H Studio: Hospital,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david allison,
-ART,1050,1.0,Foundation Drawing I,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,denise elizabeth ayers,
-ART,1510,1.0,Foundations Art I,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,rachel lynn de cuba,
-ART,1520,1.0,Foundations Art II,0.4,0.3,0.0,0.1,0.1,0.0,0.0,0.1,daniel bare,
-ART,2070,1.0,Beginning Painting,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,serra raven shuford,
-ART,2090,1.0,Beginning Sculpture,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,jordan alexander fowler,
-ART,2100,1.0,Art Appreciation,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,dustin massey,
-ART,2100,2.0,Art Appreciation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,dustin massey,
-ART,2100,3.0,Art Appreciation,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,mark norman brosseau,
-ART,2100,5.0,Art Appreciation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,joseph richard manson ,
-ART,2100,6.0,Art Appreciation,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,annamarie elizabeth williams,
-ART,2130,1.0,Begin Photography,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,haley brooke floyd,
-ART,2170,1.0,Beginning Ceramics,0.23,0.54,0.08,0.0,0.08,0.0,0.0,0.08,sara mays,
-AS,1090,2.0,Air Force Today I,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,joseph michael blanton,
-AS,1090,3.0,Air Force Today I,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,joseph michael blanton,
-AS,3090,1.0,A F Leadership Mgt I,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,rachelle marie miller,
-AS,3090,2.0,A F Leadership Mgt I,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,rachelle marie miller,
-AS,4090,1.0,Nat Sec Policy I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,4090,2.0,Nat Sec Policy I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-ASL,1010,2.0,Am Sign Lang I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,1010,5.0,Am Sign Lang I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,1020,1.0,Am Sign Lang I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william ryals clements,
-ASL,1020,2.0,Am Sign Lang I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,william ryals clements,
-ASL,1020,3.0,Am Sign Lang I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,2010,1.0,Am Sign Lang II,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,kim marlene misener dunn,
-ASL,2010,2.0,Am Sign Lang II,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,kim marlene misener dunn,
-ASL,2010,3.0,Am Sign Lang II,0.8,0.15,0.0,0.05,0.0,0.0,0.0,0.0,kim marlene misener dunn,
-ASL,2020,1.0,Am Sign Lang II,0.63,0.16,0.21,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,3010,1.0,Advanced A S L I,0.53,0.21,0.05,0.0,0.0,0.0,0.0,0.21,kim marlene misener dunn,
-ASL,3150,1.0,Survey Interpreting,0.1,0.7,0.0,0.1,0.0,0.0,0.0,0.1,stephen benjamin fitzmaurice,
-ASL,4700,1.0,Dev Sign Lang for Deaf Childrn,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,jody herbert cripps,
-ASTR,1010,1.0,Solar System Astronomy,0.29,0.42,0.22,0.05,0.02,0.0,0.0,0.01,marco ajello,
-ASTR,1010,2.0,Solar System Astronomy,0.24,0.46,0.23,0.04,0.02,0.0,0.0,0.01,marco ajello,
-ASTR,1020,1.0,Stellar Astronomy,0.45,0.29,0.11,0.06,0.03,0.0,0.0,0.06,mark leising,
-ASTR,1030,1.0,Solar Systm Astr Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,david edward connick,
-ASTR,1030,2.0,Solar Systm Astr Lab,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.0,david edward connick,
-ASTR,1030,3.0,Solar Systm Astr Lab,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,david edward connick,
-ASTR,1030,4.0,Solar Systm Astr Lab,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,david edward connick,
-ASTR,1030,6.0,Solar Systm Astr Lab,0.46,0.46,0.0,0.0,0.08,0.0,0.0,0.0,david edward connick,
-ASTR,1030,7.0,Solar Systm Astr Lab,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,david edward connick,
-ASTR,1030,8.0,Solar Systm Astr Lab,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,david edward connick,
-ASTR,1030,9.0,Solar Systm Astr Lab,0.48,0.43,0.04,0.0,0.0,0.0,0.0,0.04,david edward connick,
-ASTR,1030,10.0,Solar Systm Astr Lab,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,david edward connick,
-ASTR,1040,1.0,Stellar Astr Lab,0.46,0.33,0.04,0.04,0.0,0.0,0.0,0.13,david edward connick,
-ASTR,1040,2.0,Stellar Astr Lab,0.35,0.48,0.09,0.04,0.0,0.0,0.0,0.04,david edward connick,
-ASTR,1040,4.0,Stellar Astr Lab,0.48,0.26,0.22,0.0,0.0,0.0,0.0,0.04,david edward connick,
-ASTR,8100,1.0,Astroph I: Radiation,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-ASTR,8750,1.0,Astronomy Seminar,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,marco ajello,
-AUD,2800,1.0,Sound Reinforcement,0.0,0.8,0.2,0.0,0.0,0.0,0.0,0.0,kenneth moore,
-AUD,3800,1.0,Audio Engineering I,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUE,6010,1.0,Vehicle Dynamics,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,
-AUE,8190,100.0,Adv Int Combustion Engine Conc,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,8260,1.0,Vehicle Diagnostics,0.5,0.13,0.38,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,
-AUE,8270,5.0,Auto Cntrl Sys Des,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8330,30.0,Auto Manuf Proc Devl,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,
-AUE,8350,100.0,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,yunyi jia,
-AUE,8670,1.0,Veh Manuf Proc I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-AUE,8800,2.0,Vehicle Project Mngt,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,johnell brooks,
-AUE,8810,3.0,Automotive Systems Overview,0.54,0.39,0.02,0.0,0.04,0.0,0.0,0.02,christiaan jos jan paredis,
-AUE,8870,8.0,Meth Vehicle Testing,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,
-AVS,1000,1.0,Orientation to AVS,0.66,0.21,0.02,0.02,0.03,0.0,0.0,0.06,kristine lang vernon,
-AVS,1500,1.0,Intro Animal Science,0.28,0.28,0.28,0.08,0.03,0.0,0.0,0.07,joseph keith bertrand,
-AVS,1500,2.0,Intro Animal Science,0.21,0.32,0.24,0.09,0.09,0.0,0.0,0.06,joseph keith bertrand,
-AVS,1510,1.0,Intro Ani Sci Lab,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,
-AVS,1510,2.0,Intro Ani Sci Lab,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,
-AVS,1510,3.0,Intro Ani Sci Lab,0.36,0.56,0.0,0.0,0.0,0.0,0.0,0.08,richelle lorraine miller,
-AVS,1510,5.0,Intro Ani Sci Lab,0.62,0.35,0.04,0.0,0.0,0.0,0.0,0.0,chelsea drumwright sinclair,
-AVS,1510,6.0,Intro Ani Sci Lab,0.69,0.15,0.12,0.0,0.04,0.0,0.0,0.0,chelsea drumwright sinclair,
-AVS,1510,7.0,Intro Ani Sci Lab,0.73,0.19,0.04,0.0,0.0,0.0,0.0,0.04,richelle lorraine miller,
-AVS,1510,8.0,Intro Ani Sci Lab,0.56,0.36,0.0,0.0,0.0,0.0,0.0,0.08,chelsea drumwright sinclair,
-AVS,2040,1.0,Horse Care Techniques,0.72,0.18,0.1,0.0,0.0,0.0,0.0,0.0,chelsea drumwright sinclair,
-AVS,2110,1.0,Meat Processing Techniques,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,richelle lorraine miller,
-AVS,3010,1.0,Anat & Phys Dom Ani,0.58,0.23,0.16,0.03,0.0,0.0,0.0,0.0,glenn birrenkott,
-AVS,3010,400.0,Anat & Phys Dom Ani,0.46,0.32,0.11,0.08,0.03,0.0,0.0,0.0,glenn birrenkott,
-AVS,3020,1.0,Livestk Sel Eval I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,
-AVS,3100,1.0,Animal Health,0.58,0.34,0.06,0.0,0.02,0.0,0.0,0.0,celina marcela checura,
-AVS,3700,1.0,Principles of Animal Nutrition,0.67,0.18,0.09,0.02,0.0,0.0,0.0,0.05,james robert strickland,
-AVS,3750,1.0,Applied Animal Nutrition,0.13,0.47,0.27,0.07,0.0,0.0,0.0,0.07,gustavo jose lascano,
-AVS,4100,1.0,Domestic Ani Behav,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,ahmed badr abdelwahab ali,
-AVS,4110,1.0,Animal Growth and Development,0.34,0.36,0.14,0.05,0.06,0.0,0.0,0.05,susan kay duckett,
-AVS,4150,1.0,Contemporary Issues in AVS,0.79,0.12,0.04,0.01,0.01,0.0,0.0,0.01,heather walker dunn,
-AVS,4160,1.0,Equine Exercise Phys,0.43,0.21,0.29,0.07,0.0,0.0,0.0,0.0,kristine lang vernon,
-AVS,4500,1.0,Sustain Livestock Product Sys,0.18,0.45,0.18,0.0,0.09,0.0,0.0,0.09,matias jose aguerre,
-AVS,4530,1.0,Animal Reproduction,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,tiffany wilmoth,
-AVS,4650,1.0,Animal Physiology I,0.33,0.41,0.18,0.05,0.0,0.0,0.0,0.03,celina marcela checura,
-AVS,4800,1.0,Vertebrate Endocrinology,0.36,0.58,0.06,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,4920,1.0,Advanced Fetal Fescue Research,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,susan kay duckett,
-AVS,4920,2.0,Bioinformatics Cancer Gen,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,8010,3.0,Principles Scientific Writing,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,jeryl jones,
-BCHM,1030,1.0,Careers in Bioch/Gen,0.85,0.09,0.02,0.02,0.02,0.0,0.0,0.0,joseph paul thames,
-BCHM,3010,1.0,Molecular Biochemistry,0.32,0.15,0.26,0.09,0.11,0.0,0.0,0.09,cheryl jean ingram-smith,
-BCHM,3050,1.0,Essen Elements Bioch,0.22,0.37,0.22,0.12,0.04,0.0,0.0,0.04,debra ragland,
-BCHM,3050,2.0,Essen Elements Bioch,0.22,0.35,0.31,0.07,0.01,0.0,0.0,0.03,debra ragland,
-BCHM,4310,1.0,Physical Approach to Biochem,0.28,0.39,0.28,0.01,0.03,0.0,0.0,0.0,weiguo cao,
-BCHM,4330,2.0,Physical Biochemistry Lab,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,geoffrey ford,
-BCHM,4400,1.0,Bioinformatics,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,frank alexander feltus,
-BCHM,4430,1.0,Molecular Basis of Disease,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,james morris,
-BCHM,4910,27.0,CI-CU INVESTORS,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,meredith teilhet morris,
-BCHM,4910,32.0,CI-DNA Repair (HON),0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael glen sehorn,True
-BCHM,4930,2.0,Senior Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,
-BCHM,4930,5.0,Senior Seminar,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
-BCHM,8140,1.0,Advanced Biochemistry,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,meredith teilhet morris,
-BE,2100,1.0,Intro to Biosystems Engr,0.76,0.12,0.08,0.0,0.0,0.0,0.0,0.04,jazmine octavia taylor,
-BE,3200,1.0,Principles & Prac of Geomatics,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4100,1.0,Biological Kinetics,0.21,0.43,0.29,0.07,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,4210,1.0,Engr Sys for Soil Water Mgt,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,christophe darnault,
-BE,4280,1.0,Biochem Engr,0.4,0.4,0.1,0.1,0.0,0.0,0.0,0.0,terry walker,
-BE,4740,1.0,BE Design Project Managment,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,
-BE,4750,1.0,BE Capstone Design,0.77,0.0,0.23,0.0,0.0,0.0,0.0,0.0,christophe darnault,
-BIOE,1010,1.0,Biol for Bioengr,0.69,0.15,0.08,0.0,0.0,0.0,0.0,0.08,tyler george harvey,
-BIOE,2010,2.0,Intro Biomed Engr,0.47,0.34,0.13,0.03,0.01,0.0,0.0,0.02,charles webb,
-BIOE,3020,1.0,Biomaterials,0.69,0.23,0.04,0.02,0.0,0.0,0.0,0.02,alexey alexandrovich vertegel,
-BIOE,3100,1.0,Engr Analysis of Physiol Proc,0.79,0.16,0.03,0.03,0.0,0.0,0.0,0.0,brian william booth,
-BIOE,3200,1.0,Biomechanics,0.49,0.41,0.06,0.01,0.01,0.0,0.0,0.01,jiro nagatomi,
-BIOE,3210,1.0,Biofluid Mechanics,0.53,0.33,0.1,0.0,0.0,0.0,0.0,0.03,zhi gao,
-BIOE,3470,1.0,Transport Processes in Bioengr,0.63,0.26,0.08,0.03,0.01,0.0,0.0,0.0,renee nicole cottle,
-BIOE,3700,1.0,Bioinst & Imaging,0.57,0.33,0.09,0.0,0.0,0.0,0.0,0.02,delphine dean,
-BIOE,4010,2.0,Bioengineering Design Theory,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,
-BIOE,4030,1.0,Applied Bio E Design,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ravikiran bhaskar singapogu,
-BIOE,4120,1.0,Orthopaedic Engr and Pathology,0.6,0.35,0.02,0.0,0.0,0.0,0.0,0.02,melinda harman,
-BIOE,4400,1.0,Biopharmaceutical Engineering,0.26,0.47,0.05,0.0,0.05,0.0,0.0,0.16,sarah harcum,
-BIOE,4480,1.0,Tissue Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,angela antoinette alexander,
-BIOE,4510,31.0,CI-Med Design with Arusha Tz,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,delphine dean,
-BIOE,6120,1.0,Orthopaedic Engr & Pathology,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,melinda harman,
-BIOE,6350,1.0,Computational Modeling in BIOE,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,
-BIOE,6400,1.0,Biopharmaceutical Engineering,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,sarah harcum,
-BIOE,8010,1.0,Bio Materials,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert latour,
-BIOE,8160,1.0,BioE Professional Development,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,martine laberge,
-BIOE,8160,843.0,BioE Professional Development,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jeremy gilbert,
-BIOL,1010,1.0,Frontiers in Biology I,0.8,0.14,0.05,0.0,0.0,0.0,0.0,0.01,michael childress,
-BIOL,1010,2.0,Frontiers in Biology I,0.83,0.13,0.02,0.0,0.01,0.0,0.0,0.01,michael childress,
-BIOL,1030,1.0,General Biology I,0.24,0.29,0.27,0.1,0.04,0.0,0.0,0.06,nora espinoza,
-BIOL,1030,2.0,General Biology I,0.26,0.24,0.17,0.18,0.04,0.0,0.0,0.12,nathan redding,
-BIOL,1030,3.0,General Biology I,0.23,0.33,0.24,0.07,0.04,0.0,0.0,0.09,wen chen,
-BIOL,1030,4.0,General Biology I,0.15,0.26,0.35,0.1,0.04,0.0,0.0,0.11,salvatore sparace,
-BIOL,1030,5.0,General Biology I (HON),0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,nora espinoza,True
-BIOL,1050,1.0,General Biology Lab I,0.0,0.22,0.43,0.22,0.04,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,2.0,General Biology Lab I,0.0,0.17,0.38,0.13,0.08,0.0,0.0,0.25,tafadzwa kaisa,
-BIOL,1050,3.0,General Biology Lab I,0.0,0.38,0.17,0.21,0.0,0.0,0.0,0.25,tafadzwa kaisa,
-BIOL,1050,4.0,General Biology Lab I,0.0,0.13,0.38,0.29,0.08,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,5.0,General Biology Lab I,0.0,0.29,0.29,0.29,0.13,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,6.0,General Biology Lab I,0.0,0.25,0.54,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,7.0,General Biology Lab I,0.0,0.27,0.23,0.36,0.0,0.0,0.0,0.14,tafadzwa kaisa,
-BIOL,1050,8.0,General Biology Lab I,0.0,0.17,0.43,0.13,0.0,0.0,0.0,0.26,tafadzwa kaisa,
-BIOL,1050,9.0,General Biology Lab I,0.0,0.17,0.46,0.13,0.08,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,10.0,General Biology Lab I,0.0,0.13,0.43,0.17,0.13,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,11.0,General Biology Lab I,0.0,0.09,0.43,0.26,0.0,0.0,0.0,0.22,tafadzwa kaisa,
-BIOL,1050,12.0,General Biology Lab I,0.04,0.25,0.25,0.29,0.0,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,13.0,General Biology Lab I,0.0,0.17,0.42,0.17,0.13,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,14.0,General Biology Lab I,0.0,0.13,0.42,0.25,0.04,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,15.0,General Biology Lab I,0.0,0.13,0.33,0.17,0.13,0.0,0.0,0.25,tafadzwa kaisa,
-BIOL,1050,16.0,General Biology Lab I,0.0,0.42,0.46,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,17.0,General Biology Lab I,0.0,0.13,0.5,0.25,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,18.0,General Biology Lab I,0.0,0.13,0.42,0.38,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,19.0,General Biology Lab I,0.04,0.38,0.25,0.17,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,20.0,General Biology Lab I,0.0,0.25,0.5,0.17,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,21.0,General Biology Lab I,0.0,0.21,0.42,0.21,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,22.0,General Biology Lab I,0.0,0.13,0.54,0.17,0.13,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,23.0,General Biology Lab I,0.0,0.09,0.3,0.35,0.17,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1050,24.0,General Biology Lab I,0.0,0.26,0.39,0.22,0.0,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,25.0,General Biology Lab I,0.0,0.26,0.52,0.04,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,27.0,General Biology Lab I,0.04,0.33,0.46,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,28.0,General Biology Lab I,0.04,0.13,0.42,0.33,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,29.0,General Biology Lab I,0.08,0.29,0.42,0.0,0.04,0.0,0.0,0.17,tafadzwa kaisa,
-BIOL,1050,30.0,General Biology Lab I,0.04,0.13,0.63,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,32.0,General Biology Lab I,0.0,0.22,0.3,0.22,0.13,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,33.0,General Biology Lab I,0.0,0.1,0.38,0.24,0.14,0.0,0.0,0.14,tafadzwa kaisa,
-BIOL,1050,34.0,General Biology Lab I,0.0,0.35,0.35,0.13,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,35.0,General Biology Lab I,0.0,0.17,0.5,0.25,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,36.0,General Biology Lab I,0.0,0.42,0.25,0.13,0.08,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,37.0,General Biology Lab I,0.21,0.29,0.33,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,38.0,General Biology Lab I,0.0,0.04,0.67,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,39.0,General Biology Lab I,0.04,0.38,0.29,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,40.0,General Biology Lab I,0.0,0.5,0.25,0.17,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,41.0,General Biology Lab I,0.04,0.38,0.38,0.13,0.0,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,42.0,General Biology Lab I,0.04,0.29,0.38,0.17,0.04,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,43.0,General Biology Lab I,0.0,0.33,0.29,0.21,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,44.0,General Biology Lab I,0.04,0.25,0.38,0.17,0.04,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,45.0,General Biology Lab I,0.0,0.25,0.33,0.21,0.17,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,46.0,General Biology Lab I,0.0,0.33,0.29,0.08,0.17,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1090,1.0,Intro to Life Sci,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,renea chris hardwick,
-BIOL,1100,1.0,Principles of Biology I,0.43,0.34,0.15,0.02,0.02,0.0,0.0,0.03,renea chris hardwick,
-BIOL,1100,2.0,Principles of Biology I (HON),0.81,0.18,0.01,0.0,0.0,0.0,0.0,0.0,verna christine  minor,True
-BIOL,1100,3.0,Principles of Biology I,0.27,0.55,0.16,0.02,0.0,0.0,0.0,0.0,verna christine  minor,
-BIOL,1100,4.0,Principles of Biology I,0.55,0.29,0.1,0.05,0.02,0.0,0.0,0.0,renea chris hardwick,
-BIOL,2110,1.0,Introduction to Toxicology,0.44,0.44,0.05,0.02,0.02,0.0,0.0,0.02,peter van den hurk,
-BIOL,2220,1.0,Human Anat and Physiology I,0.23,0.36,0.24,0.08,0.03,0.0,0.0,0.06,john cummings,
-BIOL,2220,2.0,Human Anat and Physiology I,0.27,0.37,0.2,0.08,0.04,0.0,0.0,0.05,john cummings,
-BIOL,3030,1.0,Vertebrate Biology,0.5,0.25,0.13,0.06,0.03,0.0,0.0,0.01,virginia ellen abernathy,
-BIOL,3030,2.0,Vertebrate Biology (HON),0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,virginia ellen abernathy,True
-BIOL,3030,3.0,Vertebrate Biology,0.53,0.29,0.09,0.09,0.0,0.0,0.0,0.0,virginia ellen abernathy,
-BIOL,3040,1.0,Biology of Plants,0.19,0.29,0.3,0.19,0.01,0.0,0.0,0.03,nathan redding,
-BIOL,3070,1.0,Vertebrate Biology Lab,0.36,0.56,0.08,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,2.0,Vertebrate Biology Lab,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,3.0,Vertebrate Biology Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,4.0,Vertebrate Biology Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,5.0,Vertebrate Biology Lab,0.21,0.71,0.04,0.0,0.0,0.0,0.0,0.04,richard blob,
-BIOL,3070,6.0,Vertebrate Biology Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,7.0,Vertebrate Biology Lab,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,8.0,Vertebrate Biology Lab,0.5,0.38,0.08,0.04,0.0,0.0,0.0,0.0,richard blob,
-BIOL,3070,9.0,Vertebrate Biology Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,richard blob,
-BIOL,3080,1.0,Biology of Plants Practicum,0.45,0.35,0.1,0.05,0.0,0.0,0.0,0.05,nathan redding,
-BIOL,3080,3.0,Biology of Plants Practicum,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,4.0,Biology of Plants Practicum,0.25,0.42,0.17,0.17,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,5.0,Biology of Plants Practicum,0.13,0.53,0.33,0.0,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3080,6.0,Biology of Plants Practicum,0.13,0.44,0.44,0.0,0.0,0.0,0.0,0.0,nathan redding,
-BIOL,3150,1.0,Functional Human Anatomy,0.26,0.39,0.19,0.08,0.01,0.0,0.0,0.06,tamara mcnutt-scott,
-BIOL,3200,1.0,Field Botany,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,robert edward ballard,
-BIOL,3350,1.0,Evolutionary Biology,0.27,0.44,0.21,0.06,0.02,0.0,0.0,0.01,margaret ptacek,
-BIOL,3510,1.0,Biological Anthropology,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,lisa rapaport,
-BIOL,3530,1.0,Forensic Anthropology,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,katherine weisensee,
-BIOL,4030,1.0,Intro to Applied Genomics,0.15,0.08,0.23,0.0,0.0,0.0,0.0,0.54,vincent paul richards,
-BIOL,4140,1.0,Basic Immunology,0.28,0.22,0.28,0.11,0.0,0.0,0.0,0.11,yanzhang wei,
-BIOL,4200,1.0,Neurobiology,0.59,0.31,0.03,0.0,0.0,0.0,0.0,0.06,david feliciano,
-BIOL,4250,1.0,Introductory Mycology,0.39,0.36,0.13,0.05,0.05,0.0,0.0,0.03,julia louise kerrigan,
-BIOL,4260,1.0,Mycology Practicum,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,julia louise kerrigan,
-BIOL,4400,1.0,Developmental Animal Biology,0.34,0.22,0.3,0.1,0.02,0.0,0.0,0.02,kara elizabeth powder,
-BIOL,4410,1.0,Ecology,0.24,0.38,0.19,0.07,0.01,0.0,0.0,0.1,sharon bewick,
-BIOL,4530,1.0,Integrative Organismal Biology,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,michael sears,
-BIOL,4560,1.0,Medical and Vet Parasitology,0.59,0.37,0.0,0.02,0.0,0.0,0.0,0.02,wilbur kearse milhous,
-BIOL,4610,1.0,Cell Biology,0.36,0.37,0.2,0.03,0.01,0.0,0.0,0.03,susan caroline chapman,
-BIOL,4610,2.0,Cell Biology (HON),0.58,0.33,0.03,0.0,0.0,0.0,0.0,0.06,susan caroline chapman,True
-BIOL,4620,1.0,Cell Biology Lab (Lec),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,2.0,Cell Biology Lab (Lec),0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,3.0,Cell Biology Lab (Lec),0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,4.0,Cell Biology Lab (Lec),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,5.0,Cell Biology Lab (Lec),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6.0,Cell Biology Lab (Lec),0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
-BIOL,4620,7.0,Cell Biology Lab (Lec),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,8.0,Cell Biology Lab (Lec),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4670,1.0,Principles of Hematology,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.03,vincent gallicchio,
-BIOL,4890,1.0,Clinical Apps and Medical Prac,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,
-BIOL,4930,2.0,Sr Sem: Current Topic Biology,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,
-BIOL,4930,5.0,Sr Sem: Biol Adv in Agricultur,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,salvatore sparace,
-BIOL,4930,6.0,Sr Sem: Emerging Viruses,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,matthew turnbull,
-BIOL,4930,7.0,Sr Sem: Negl Infect Dis Povert,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
-BIOL,6030,1.0,Intro to Applied Genomics,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,vincent paul richards,
-BIOL,6610,1.0,Cell Biology,0.2,0.2,0.4,0.0,0.2,0.0,0.0,0.0,susan caroline chapman,
-BIOL,8400,1.0,Understanding Biological Inq,0.92,0.0,0.04,0.0,0.04,0.0,0.0,0.0,michael childress,
-BIOL,8420,1.0,Understand Cellular Processes,0.89,0.09,0.0,0.0,0.01,0.0,0.0,0.01,kaustubha ratan qanungo,
-BIOL,8440,1.0,Understanding the Human Body,0.43,0.43,0.11,0.0,0.03,0.0,0.0,0.0,tamara mcnutt-scott,
-BMOL,4250,1.0,Biomolecular Engineering,0.23,0.43,0.2,0.08,0.05,0.0,0.0,0.0,marc russel birtwistle,
-BUS,1010,1.0,Business Foundations,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,william ernest tumblin,
-BUS,1010,2.0,Business Foundations,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,william ernest tumblin,
-CE,4910,1.0,BIM in Construction Management,0.81,0.14,0.02,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,4910,2.0,Accident Analytics,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,
-CE,4990,14.0,Special Projects-Springer II,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,prasada rao rangaraju,
-CE,6010,1.0,Matrix Str Analysis,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,laura mae redmond,
-CE,6430,1.0,Water Resources Engr,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,abdul khan,
-CE,6470,1.0,Stormwater Managemnt,0.67,0.0,0.33,0.0,0.0,0.0,0.0,0.0,md nasimul hoque chowdhury,
-CE,8010,1.0,Finite Ele Analysis,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nadarajah ravichandran,
-CE,8020,1.0,Adv R/C Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas edford cousins,
-CE,8700,500.0,Capstone Design Risk Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,
-CE,8930,3.0,Transport Risk & Evacuation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pamela marie murray-tuite,
-CE,8930,4.0,Autonomous Vehicle Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CE,8930,5.0,Struct Fire Engr & Safety,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,mohannad naser,
-CH,1010,1.0,General Chemistry,0.26,0.37,0.2,0.03,0.05,0.0,0.0,0.1,tania houjeiry,
-CH,1010,2.0,General Chemistry,0.12,0.4,0.31,0.09,0.02,0.0,0.0,0.06,olt geiculescu,
-CH,1010,3.0,General Chemistry,0.21,0.32,0.28,0.08,0.03,0.0,0.0,0.07,william wesley mcwhorter,
-CH,1010,4.0,General Chemistry,0.25,0.26,0.22,0.11,0.05,0.0,0.0,0.1,khushi patel,
-CH,1010,5.0,General Chemistry,0.28,0.37,0.17,0.06,0.04,0.0,0.0,0.09,dennis taylor,
-CH,1010,6.0,General Chemistry,0.29,0.35,0.18,0.08,0.04,0.0,0.0,0.07,elliot ennis,
-CH,1010,7.0,General Chemistry,0.17,0.33,0.22,0.09,0.06,0.0,0.0,0.13,william wesley mcwhorter,
-CH,1010,8.0,General Chemistry,0.38,0.32,0.12,0.12,0.02,0.0,0.0,0.05,thomas hickman,
-CH,1010,9.0,General Chemistry,0.25,0.42,0.25,0.04,0.03,0.0,0.0,0.03,william wesley mcwhorter,
-CH,1010,10.0,General Chemistry,0.17,0.38,0.21,0.08,0.08,0.0,0.0,0.08,princess mycia cox,
-CH,1010,11.0,General Chemistry,0.37,0.39,0.1,0.06,0.07,0.0,0.0,0.01,thomas hickman,
-CH,1010,12.0,General Chemistry,0.32,0.33,0.22,0.04,0.05,0.0,0.0,0.05,dennis taylor,
-CH,1010,13.0,General Chemistry,0.27,0.31,0.16,0.15,0.03,0.0,0.0,0.08,princess mycia cox,
-CH,1010,14.0,General Chemistry,0.14,0.33,0.3,0.12,0.03,0.0,0.0,0.08,jacob schroeder,
-CH,1010,50.0,General Chemistry,0.53,0.33,0.12,0.0,0.02,0.0,0.0,0.0,tania houjeiry,
-CH,1010,51.0,General Chemistry (HON),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,joseph stuart thrasher,True
-CH,1010,52.0,General Chemistry (HON),0.7,0.22,0.08,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True
-CH,1010,201.0,General Chemistry,0.18,0.47,0.23,0.06,0.05,0.0,0.0,0.02,elliot ennis,
-CH,1010,203.0,General Chemistry,0.24,0.37,0.26,0.06,0.07,0.0,0.0,0.0,jacob schroeder,
-CH,1010,204.0,General Chemistry,0.32,0.32,0.23,0.07,0.03,0.0,0.0,0.03,thao thi thanh tran,
-CH,1020,1.0,General Chemistry,0.34,0.25,0.21,0.11,0.01,0.0,0.0,0.09,stephen jon schvaneveldt,
-CH,1020,2.0,General Chemistry,0.28,0.28,0.2,0.15,0.02,0.0,0.0,0.07,stephen jon schvaneveldt,
-CH,1020,3.0,General Chemistry,0.26,0.2,0.31,0.08,0.04,0.0,0.0,0.11,stephen jon schvaneveldt,
-CH,1020,400.0,General Chemistry,0.1,0.29,0.17,0.24,0.07,0.0,0.0,0.14,stephen jon schvaneveldt,
-CH,1050,1.0,Chemistry in Context I,0.43,0.31,0.16,0.05,0.04,0.0,0.0,0.01,olt geiculescu,
-CH,1050,2.0,Chemistry in Context I,0.45,0.4,0.11,0.01,0.01,0.0,0.0,0.02,olt geiculescu,
-CH,2010,1.0,Survey of Organic Chemistry,0.62,0.25,0.06,0.04,0.03,0.0,0.0,0.0,tania houjeiry,
-CH,2010,2.0,Survey of Organic Chemistry,0.4,0.4,0.13,0.03,0.02,0.0,0.0,0.02,modi wetzler,
-CH,2230,1.0,Organic Chemistry,0.09,0.16,0.24,0.14,0.25,0.0,0.0,0.12,modi wetzler,
-CH,2230,2.0,Organic Chemistry,0.05,0.23,0.22,0.12,0.16,0.0,0.0,0.21,modi wetzler,
-CH,2230,3.0,Organic Chemistry,0.38,0.3,0.2,0.07,0.03,0.0,0.0,0.02,laura lanni,
-CH,2230,4.0,Organic Chemistry,0.29,0.25,0.25,0.07,0.08,0.0,0.0,0.06,laura lanni,
-CH,2230,5.0,Organic Chemistry,0.4,0.32,0.13,0.03,0.05,0.0,0.0,0.08,rhett smith,
-CH,2230,6.0,Organic Chemistry,0.24,0.28,0.26,0.11,0.07,0.0,0.0,0.04,elliot ennis,
-CH,2230,7.0,Organic Chemistry,0.14,0.18,0.27,0.2,0.09,0.0,0.0,0.12,elliot ennis,
-CH,2230,50.0,Organic Chemistry,0.33,0.43,0.15,0.03,0.03,0.0,0.0,0.03,daniel whitehead,
-CH,2240,1.0,Organic Chemistry,0.3,0.2,0.15,0.18,0.09,0.0,0.0,0.09,laura lanni,
-CH,2240,2.0,Organic Chemistry,0.23,0.23,0.24,0.14,0.1,0.0,0.0,0.04,thomas hickman,
-CH,2270,1.0,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,
-CH,2270,3.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,5.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,7.0,Organic Chem Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,
-CH,2270,8.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,13.0,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelson plampin,
-CH,2270,15.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,16.0,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelson plampin,
-CH,2270,19.0,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,
-CH,2270,23.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,27.0,Organic Chem Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,
-CH,2270,29.0,Organic Chem Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,
-CH,2270,32.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,35.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,
-CH,2270,39.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,
-CH,2270,40.0,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,
-CH,2280,4.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,
-CH,3130,1.0,Quantitative Analysis,0.55,0.2,0.1,0.03,0.05,0.0,0.0,0.08,jeffrey nathan anker,
-CH,3150,1.0,Quant Analysis Lab,0.5,0.2,0.0,0.1,0.1,0.0,0.0,0.1,carlos diego garcia perez,
-CH,3150,2.0,Quant Analysis Lab,0.73,0.09,0.0,0.0,0.18,0.0,0.0,0.0,carlos diego garcia perez,
-CH,3300,1.0,Intro to Phys Chem,0.52,0.31,0.06,0.05,0.04,0.0,0.0,0.02,brian dominy,
-CH,3310,1.0,Physical Chemistry,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,steven stuart,
-CH,3390,1.0,Physical Chem Lab,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,2.0,Physical Chem Lab,0.2,0.73,0.07,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,3.0,Physical Chem Lab,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,4.0,Physical Chem Lab,0.33,0.56,0.06,0.06,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3390,5.0,Physical Chem Lab,0.47,0.47,0.0,0.06,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,4010,1.0,Organometallic Chemistry,0.71,0.24,0.0,0.03,0.0,0.0,0.0,0.03,andrew gregory tennyson,
-CH,4020,1.0,Inorganic Chemistry,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,joseph kolis,
-CH,4210,1.0,Advanced Organic Chemistry,0.3,0.59,0.04,0.04,0.0,0.0,0.0,0.04,jacob schroeder,
-CH,8070,1.0,Chem Trans Elem,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,julia brumaghim,
-CH,8140,1.0,Analytical Imaging,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,george chumanov,
-CH,8160,1.0,Separation Science,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,richard marcus,
-CH,8410,1.0,N M R Spectroscopy,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,aleksandr kitaygorodskiy,
-CH,8510,1.0,Grad Student Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,
-CH,8520,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,joseph stuart thrasher,
-CHE,2110,1.0,Mass and Energy Balances,0.35,0.39,0.25,0.0,0.0,0.0,0.0,0.01,karen ann high,
-CHE,2990,3.0,CI in CHE-  YEAST,0.0,0.0,0.0,0.0,0.0,0.75,0.0,0.25,marc russel birtwistle,
-CHE,3210,1.0,Ch E Thermo II,0.22,0.13,0.37,0.15,0.13,0.0,0.0,0.0,mark thies,
-CHE,3300,1.0,Mass Trans & Seprtn,0.25,0.46,0.21,0.03,0.05,0.0,0.0,0.0,david bruce,
-CHE,3990,8.0,CI in CHE- NANO,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jessica marie larsen,
-CHE,3990,9.0,CI- OPEN EDUCATIONAL RESOURCES,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rachel getman,
-CHE,4070,1.0,Unit Op Lab II,0.22,0.66,0.12,0.0,0.0,0.0,0.0,0.0,christopher norfolk,
-CHE,4310,1.0,Process Design I,0.3,0.45,0.25,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,4500,1.0,Chem Reaction Engr,0.35,0.4,0.22,0.03,0.0,0.0,0.0,0.0,mark roberts,
-CHE,8040,1.0,Ch E Thermodynamics,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
-CHE,8050,1.0,Ch E Kinetics,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,rachel getman,
-CHIN,1010,1.0,Elementary Chinese,0.5,0.2,0.1,0.1,0.0,0.0,0.0,0.1,yanhua zhang,
-CHIN,1010,2.0,Elementary Chinese,0.33,0.42,0.0,0.17,0.0,0.0,0.0,0.08,yanhua zhang,
-CHIN,4010,1.0,Pre-Modern Chinese Literature,0.3,0.5,0.1,0.0,0.03,0.0,0.0,0.08,yanming an,
-COM,1500,1.0,Intro to Human Communication,0.66,0.32,0.01,0.0,0.0,0.0,0.0,0.01,daniel leland fecher,
-COM,1500,2.0,Intro to Human Communication,0.73,0.22,0.03,0.0,0.01,0.0,0.0,0.02,daniel leland fecher,
-COM,1500,3.0,Intro to Human Communication,0.8,0.14,0.03,0.01,0.0,0.0,0.0,0.01,daniel leland fecher,
-COM,1500,4.0,Intro to Human Communication,0.74,0.22,0.02,0.01,0.01,0.0,0.0,0.01,marianne herr glaser,
-COM,1500,5.0,Intro to Human Communication,0.74,0.22,0.02,0.0,0.0,0.0,0.0,0.02,marianne herr glaser,
-COM,1500,6.0,Intro to Human Communication,0.82,0.14,0.02,0.0,0.0,0.0,0.0,0.02,marianne herr glaser,
-COM,1500,7.0,Intro to Human Communication,0.49,0.4,0.07,0.01,0.01,0.0,0.0,0.01,vanessa anne condon,
-COM,2010,1.0,Intr to Comm Studies,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2010,2.0,Intr to Comm Studies,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2030,1.0,Mass Communication Theory,0.35,0.15,0.45,0.0,0.05,0.0,0.0,0.0,jumah patricia taweh,
-COM,2040,1.0,Critical-Cultural Comm Theory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james nicholas gilmore,
-COM,2100,1.0,Quant Comm Research Methods,0.33,0.39,0.17,0.06,0.06,0.0,0.0,0.0,gregory keith cranmer,
-COM,2110,1.0,Qual Comm Research Methods,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,2500,2.0,Public Speaking,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,3.0,Public Speaking,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,5.0,Public Speaking,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,alyssa christine davis,
-COM,2500,6.0,Public Speaking,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christine davis,
-COM,2500,7.0,Public Speaking,0.42,0.42,0.05,0.11,0.0,0.0,0.0,0.0,marshall thomas covert,
-COM,2500,8.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,marshall thomas covert,
-COM,2500,9.0,Public Speaking,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,marshall thomas covert,
-COM,2500,10.0,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,marshall thomas covert,
-COM,2500,11.0,Public Speaking,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
-COM,2500,17.0,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,
-COM,2500,18.0,Public Speaking,0.67,0.22,0.0,0.11,0.0,0.0,0.0,0.0,ashley lauren pikel,
-COM,2500,19.0,Public Speaking,0.53,0.37,0.0,0.0,0.0,0.0,0.0,0.11,jumah patricia taweh,
-COM,2500,21.0,Public Speaking,0.63,0.26,0.0,0.05,0.05,0.0,0.0,0.0,charles john brewer,
-COM,2500,22.0,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,charles john brewer,
-COM,2500,23.0,Public Speaking,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,sara grumbles crocker,
-COM,2500,24.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,charles john brewer,
-COM,2500,25.0,Public Speaking,0.68,0.11,0.05,0.05,0.0,0.0,0.0,0.11,sara grumbles crocker,
-COM,2500,26.0,Public Speaking,0.47,0.26,0.11,0.11,0.0,0.0,0.0,0.05,charles john brewer,
-COM,2500,27.0,Public Speaking,0.72,0.17,0.06,0.0,0.06,0.0,0.0,0.0,sara grumbles crocker,
-COM,2500,28.0,Public Speaking,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,katie barnes mcelveen,
-COM,2500,29.0,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel leland fecher,
-COM,2500,30.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,elizabeth ann kaszynski gilmore,
-COM,2500,33.0,Public Speaking,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
-COM,2500,37.0,Public Speaking (HON),0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,lindsey dixon,True
-COM,2500,39.0,Public Speaking (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,True
-COM,2500,400.0,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
-COM,2500,401.0,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachary davis,
-COM,2500,403.0,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,
-COM,3050,1.0,Persuasion,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
-COM,3080,1.0,Public Comm & Pop Culture,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,3240,1.0,"Communication, Sport & Society",0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,katie barnes mcelveen,
-COM,3240,2.0,"Communication, Sport & Society",0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katie barnes mcelveen,
-COM,3250,2.0,Survey of Sports Communication,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
-COM,3260,1.0,Pr in Sports,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3260,2.0,Pr in Sports,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3300,1.0,Nonverbal Communication,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
-COM,3480,1.0,Interpersonal Comm,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,stephanie michelle pangborn,
-COM,3550,1.0,Principles of Public Relations,0.56,0.39,0.0,0.0,0.06,0.0,0.0,0.0,rachelle leigh beckner,
-COM,3560,1.0,Crisis Communication,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,andrew stephen pyle,
-COM,3660,5.0,Corporate Communications,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,. mark barnes,
-COM,4250,1.0,Adv Sports Comm,0.29,0.59,0.06,0.06,0.0,0.0,0.0,0.0,bryan denham,
-COM,4280,1.0,Interpers/Family Comm & Sport,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,gregory keith cranmer,
-COM,4710,1.0,Health Comm in Communities,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,stephanie michelle pangborn,
-COM,4950,1.0,Senior Capstone Seminar,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,8010,1.0,Communication Theory I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,erin michelle ash,
-COM,8030,1.0,Comm Technology Studies Survey,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nicholas gilmore,
-CPSC,1010,100.0,Computer Science I,0.22,0.37,0.24,0.07,0.07,0.0,0.0,0.04,roger larry van scoy,
-CPSC,1010,200.0,Computer Science I,0.4,0.23,0.21,0.04,0.04,0.0,0.0,0.08,roger larry van scoy,
-CPSC,1010,300.0,Computer Science I,0.31,0.27,0.18,0.07,0.13,0.0,0.0,0.04,yu-shan sun,
-CPSC,1020,1.0,Computer Science II,0.19,0.27,0.32,0.0,0.08,0.0,0.0,0.14,yvon feaster,
-CPSC,1020,2.0,Computer Science II,0.23,0.17,0.2,0.06,0.17,0.0,0.0,0.17,yvon feaster,
-CPSC,1020,3.0,Computer Science II,0.03,0.16,0.41,0.16,0.11,0.0,0.0,0.14,catherine hochrine,
-CPSC,1060,100.0,Intro to Programming in Java,0.26,0.34,0.32,0.03,0.05,0.0,0.0,0.0,svetlana drachova,
-CPSC,1060,200.0,Intro to Programming in Java,0.28,0.36,0.23,0.06,0.06,0.0,0.0,0.02,svetlana drachova,
-CPSC,1070,1.0,Programming Methodology,0.25,0.42,0.11,0.03,0.03,0.0,0.0,0.17,donald henry house,
-CPSC,1070,2.0,Programming Methodology,0.35,0.16,0.27,0.0,0.08,0.0,0.0,0.14,donald henry house,
-CPSC,1110,1.0,Intro to Programming in C,0.21,0.25,0.21,0.15,0.09,0.0,0.0,0.09,catherine hochrine,
-CPSC,1110,2.0,Intro to Programming in C,0.3,0.33,0.16,0.13,0.01,0.0,0.0,0.06,yu-shan sun,
-CPSC,1110,3.0,Intro to Programming in C,0.17,0.26,0.22,0.12,0.14,0.0,0.0,0.09,catherine hochrine,
-CPSC,1210,1.0,Computational Thinking,0.25,0.46,0.17,0.0,0.04,0.0,0.0,0.08,alexander christoph herzog,
-CPSC,2070,1.0,Discrete Structures,0.34,0.29,0.19,0.05,0.06,0.0,0.0,0.06,larry hodges,
-CPSC,2070,2.0,Discrete Structures,0.53,0.24,0.18,0.03,0.03,0.0,0.0,0.0,kai liu,
-CPSC,2120,1.0,Algs/Data Structures,0.38,0.28,0.2,0.04,0.06,0.0,0.0,0.04,nicolas benjamin widman,
-CPSC,2120,2.0,Algs/Data Structures,0.36,0.28,0.24,0.0,0.08,0.0,0.0,0.04,nicolas benjamin widman,
-CPSC,2120,3.0,Algs/Data Structures,0.59,0.19,0.19,0.0,0.0,0.0,0.0,0.04,brian christopher dean,
-CPSC,2120,4.0,Algs/Data Structures,0.38,0.19,0.29,0.0,0.14,0.0,0.0,0.0,brian christopher dean,
-CPSC,2150,1.0,Software Dev Foundations,0.32,0.35,0.21,0.05,0.03,0.0,0.0,0.03,kevin anton plis,
-CPSC,2150,2.0,Software Dev Foundations,0.24,0.32,0.22,0.02,0.08,0.0,0.0,0.12,kevin anton plis,
-CPSC,2200,1.0,Problem Solving w/ Office Apps,0.33,0.37,0.13,0.15,0.0,0.0,0.0,0.02,kevin anton plis,
-CPSC,2310,1.0,Intro Computer Org,0.6,0.33,0.05,0.0,0.0,0.0,0.0,0.02,nicolas benjamin widman,
-CPSC,2310,2.0,Intro Computer Org,0.53,0.18,0.16,0.05,0.05,0.0,0.0,0.02,nicolas benjamin widman,
-CPSC,2810,3.0,Selected Topics: Cyberdef Trai,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,svetlana drachova,
-CPSC,2910,1.0,Prof Issues I,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,yvon feaster,
-CPSC,2910,2.0,Prof Issues I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,yvon feaster,
-CPSC,2910,3.0,Prof Issues I,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,yvon feaster,
-CPSC,2910,4.0,Prof Issues I,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,5.0,Prof Issues I,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,6.0,Prof Issues I,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2920,1.0,"Computing, Ethics & Society",0.79,0.13,0.05,0.0,0.03,0.0,0.0,0.0,julian langston brinkley,
-CPSC,3220,1.0,Intro to Operating Systems,0.08,0.35,0.22,0.03,0.11,0.0,0.0,0.22,pradip srimani,
-CPSC,3220,2.0,Intro to Operating Systems,0.18,0.27,0.36,0.15,0.03,0.0,0.0,0.0,mark smotherman,
-CPSC,3300,1.0,Computer Systems Org,0.38,0.42,0.17,0.02,0.0,0.0,0.0,0.02,tyler allen,
-CPSC,3500,1.0,Foundations of Computer Sci,0.18,0.2,0.38,0.12,0.04,0.0,0.0,0.08,ilya mark safro,
-CPSC,3520,1.0,Programming Systems,0.38,0.34,0.14,0.02,0.08,0.0,0.0,0.05,robert schalkoff,
-CPSC,3600,1.0,Network Programming,0.53,0.15,0.28,0.03,0.03,0.0,0.0,0.0,andrew robb,
-CPSC,3600,2.0,Network Programming,0.55,0.14,0.21,0.05,0.02,0.0,0.0,0.02,andrew robb,
-CPSC,3600,3.0,Network Programming,0.47,0.26,0.11,0.0,0.08,0.0,0.0,0.08,jason anderson,
-CPSC,3720,1.0,Software Engineering,0.31,0.41,0.23,0.0,0.0,0.0,0.0,0.05,eileen theresa kraemer,
-CPSC,3720,2.0,Software Engineering,0.23,0.56,0.16,0.0,0.04,0.0,0.0,0.02,yu-shan sun,
-CPSC,4040,1.0,Cmptr Graphics Image,0.56,0.28,0.0,0.0,0.0,0.0,0.0,0.16,ioannis karamouzas,
-CPSC,4050,1.0,Computer Graphics,0.52,0.19,0.05,0.0,0.05,0.0,0.0,0.19,victor zordan,
-CPSC,4110,1.0,Virtual Reality Systems,0.46,0.43,0.05,0.0,0.03,0.0,0.0,0.03,sabarish venkat babu,
-CPSC,4120,1.0,Eye Tracking Methodology,0.43,0.46,0.07,0.0,0.0,0.0,0.0,0.04,andrew duchowski,
-CPSC,4140,1.0,Human and Computer Interaction,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,nathaniel mcneese,
-CPSC,4150,1.0,Mobile Device Software Devel,0.23,0.23,0.35,0.08,0.0,0.0,0.0,0.12,christopher plaue,
-CPSC,4200,1.0,Computer Security Principles,0.67,0.3,0.03,0.0,0.0,0.0,0.0,0.0,long cheng,
-CPSC,4240,1.0,System Admin and Security,0.1,0.6,0.2,0.1,0.0,0.0,0.0,0.0,svetlana drachova,
-CPSC,4300,1.0,Applied Data Science,0.36,0.43,0.15,0.02,0.02,0.0,0.0,0.02,alexander christoph herzog,
-CPSC,4620,1.0,Database Management Systems,0.12,0.38,0.12,0.12,0.0,0.0,0.0,0.27,pradip srimani,
-CPSC,4770,1.0,Distributed/Cluster Computing,0.39,0.33,0.11,0.06,0.06,0.0,0.0,0.06,shuangshuang jin,
-CPSC,4820,1.0,Special Topic: Web Programming,0.57,0.21,0.13,0.04,0.02,0.0,0.0,0.02,craig baker,
-CPSC,4820,2.0,Special Topics: Hands on ML,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,larry hodges,
-CPSC,4820,4.0,Spe Topic: AI,0.33,0.24,0.1,0.0,0.0,0.0,0.0,0.33,ioannis karamouzas,
-CPSC,4890,1.0,Programming Team Seminar,0.65,0.15,0.05,0.05,0.0,0.0,0.0,0.1,brian christopher dean,
-CPSC,4910,1.0,Professional Issues II,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,roger larry van scoy,
-CPSC,4910,2.0,Professional Issues II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alexander christoph herzog,
-CPSC,6040,1.0,Cptr Graphics Image,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,ioannis karamouzas,
-CPSC,6050,1.0,Computer Graphics,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,victor zordan,
-CPSC,6110,1.0,Virtual Reality Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venkat babu,
-CPSC,6150,1.0,Mobile Device Software Devel,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,christopher plaue,
-CPSC,6240,1.0,System Admin and Security,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,svetlana drachova,
-CPSC,6300,1.0,Applied Data Science,0.82,0.11,0.04,0.0,0.0,0.0,0.0,0.04,kai liu,
-CPSC,6300,2.0,Applied Data Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xizhou feng,
-CPSC,6620,1.0,Database Management Systems,0.5,0.33,0.08,0.0,0.0,0.0,0.0,0.08,pradip srimani,
-CPSC,6820,4.0,Spec Top: AI,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,ioannis karamouzas,
-CPSC,8040,1.0,Data Visualization,0.74,0.2,0.0,0.0,0.03,0.0,0.0,0.03,federico iuricich,
-CPSC,8100,1.0,Intro Artif Intell,0.43,0.43,0.02,0.0,0.0,0.0,0.0,0.11,feng luo,
-CPSC,8170,1.0,Physically Based Animation,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,jerry tessendorf,
-CPSC,8200,1.0,Parallel Architechture,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,rong ge,
-CPSC,8380,1.0,Adv Data Structures,0.25,0.5,0.0,0.0,0.13,0.0,0.0,0.13,sandra hedetniemi,
-CPSC,8480,1.0,Network Science,0.2,0.4,0.25,0.0,0.1,0.0,0.0,0.05,ilya mark safro,
-CPSC,8520,1.0,Internetworking,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james martin,
-CPSC,8580,1.0,Security in Emerging Systems,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,hongxin hu,
-CPSC,8580,843.0,Security in Emerging Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,
-CPSC,8620,1.0,Database Mngmt System Design,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,nina christine hubig,
-CPSC,8710,1.0,Found. of Software Engineering,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,murali sitaraman,
-CSM,1000,1.0,Intro to Construct,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,harnish sharma,
-CSM,2010,1.0,Structures I,0.35,0.43,0.08,0.03,0.0,0.0,0.0,0.11,shima clarke,
-CSM,2020,1.0,Structures II,0.77,0.14,0.03,0.03,0.0,0.0,0.0,0.03,nathaniel jackson,
-CSM,2030,1.0,Mats & Meth of Const,0.33,0.35,0.28,0.0,0.0,0.0,0.0,0.05,jason lucas,
-CSM,2040,1.0,Cont Documents,0.41,0.48,0.07,0.03,0.0,0.0,0.0,0.0,robert dawson coffey,
-CSM,2050,1.0,Mats & Methods II,0.09,0.69,0.23,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,
-CSM,3040,1.0,Envir Systems I,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,joseph michael burgett,
-CSM,3050,1.0,Envir Systems II,0.63,0.11,0.21,0.05,0.0,0.0,0.0,0.0,joseph michael burgett,
-CSM,3060,1.0,Emerging Tech in Construction,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,harnish sharma,
-CSM,3070,1.0,Sustainable Construction,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,harnish sharma,
-CSM,3510,1.0,Construction Estimating,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,seyed ehsan mousavi rizi,
-CSM,3520,401.0,Const Scheduling,0.22,0.72,0.0,0.0,0.0,0.0,0.0,0.06,craig townsend,
-CSM,3530,1.0,Const Estimating II,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,seyed ehsan mousavi rizi,
-CSM,4110,1.0,Safety in Bldg Const,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,nicholas corley,
-CSM,4500,1.0,Construction Intern,0.16,0.43,0.37,0.03,0.0,0.0,0.0,0.0,nathaniel jackson,
-CSM,4530,1.0,Const Proj Mgmt,0.21,0.69,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4530,2.0,Const Proj Mgmt,0.43,0.4,0.17,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,4540,1.0,Const Capstone,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
-CSM,4610,1.0,Const Econ Seminar,0.66,0.31,0.0,0.0,0.0,0.0,0.0,0.03,catherine nove-josserand,
-CSM,4610,2.0,Const Econ Seminar,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,catherine nove-josserand,
-CSM,4980,2.0,Current Topics-NAHB Comp,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,8360,400.0,Managing Integr Proj Delivery,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,shima clarke,
-CSM,8650,1.0,Project Management,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8650,400.0,Project Management,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CU,1000,26.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,30.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,34.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,37.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,
-CU,1000,51.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,
-CU,1000,52.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,
-CU,1010,1.0,Univ Success Skills,0.5,0.1,0.1,0.0,0.3,0.0,0.0,0.0,cynthia june smith,
-CU,1010,8.0,Univ Success Skills,0.5,0.06,0.11,0.0,0.11,0.0,0.0,0.22,catherine maroska neel,
-CU,1010,602.0,Univ Success Skills,0.62,0.15,0.15,0.0,0.0,0.0,0.0,0.08,valerie kay oonk,
-CU,1010,603.0,Univ Success Skills,0.56,0.23,0.1,0.03,0.08,0.0,0.0,0.0,elizabeth anne stephan,
-CU,1010,605.0,Univ Success Skills,0.43,0.24,0.24,0.0,0.1,0.0,0.0,0.0,matthew kent miller,
-CU,1010,606.0,Univ Success Skills,0.3,0.3,0.04,0.17,0.17,0.0,0.0,0.0,andrew isaac neptune,
-CU,1010,607.0,Univ Success Skills,0.46,0.27,0.14,0.05,0.05,0.0,0.0,0.03,elizabeth anne stephan,
-CVT,2260,1.0,Intro Cardiovas Sono,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,eric walker,
-DPA,3070,1.0,Method 3d Production,0.44,0.4,0.08,0.0,0.0,0.0,0.0,0.08,tommy van bui,
-DPA,4000,1.0,Tech Foundations I,0.07,0.29,0.14,0.0,0.07,0.0,0.0,0.43,jessica baron,
-DPA,4020,2.0,Visual Found of Digital Prod,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,anthony summey,
-DPA,4830,1.0,Spec Stud Top in DPA: Dig Scul,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,insun kwon,
-DPA,8070,1.0,3D Modeling and Animation,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,christina sophie joerg,
-DPA,8090,1.0,Rendering and Shading,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,daljit singh dhillon,
-ECAS,1990,101.0,CI LEAD Forward I,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,steve richard sanders,
-ECE,1990,13.0,CI: Future Engineers,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,melissa crawley smith,
-ECE,1990,14.0,CI: Robot Networks,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,yongqiang wang,
-ECE,2010,1.0,Logic and Computing Devices,0.23,0.28,0.24,0.08,0.08,0.0,0.0,0.08,william reid,
-ECE,2020,1.0,Electric Circuits I,0.2,0.35,0.27,0.08,0.04,0.0,0.0,0.06,william harrell,
-ECE,2070,1.0,Basic Electrical Engineering,0.21,0.22,0.26,0.12,0.07,0.0,0.0,0.12,william thomas kolodzey,
-ECE,2070,2.0,Basic Electrical Engineering,0.29,0.15,0.21,0.18,0.06,0.0,0.0,0.12,wesley green,
-ECE,2070,3.0,Basic Electrical Engineering,0.39,0.23,0.21,0.07,0.04,0.0,0.0,0.06,timothy anglea,
-ECE,2080,1.0,Basic Electrical Engr Lab,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
-ECE,2080,4.0,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2080,5.0,Basic Electrical Engr Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,apoorva deepak kapadia,
-ECE,2080,6.0,Basic Electrical Engr Lab,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2080,7.0,Basic Electrical Engr Lab,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deepak kapadia,
-ECE,2080,8.0,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
-ECE,2080,9.0,Basic Electrical Engr Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,apoorva deepak kapadia,
-ECE,2080,10.0,Basic Electrical Engr Lab,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,apoorva deepak kapadia,
-ECE,2080,12.0,Basic Electrical Engr Lab,0.79,0.0,0.0,0.0,0.21,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2080,14.0,Basic Electrical Engr Lab,0.71,0.12,0.0,0.0,0.0,0.0,0.0,0.18,apoorva deepak kapadia,
-ECE,2080,15.0,Basic Electrical Engr Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,apoorva deepak kapadia,
-ECE,2090,2.0,Logic & Computing Devices Lab,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,apoorva deepak kapadia,
-ECE,2090,3.0,Logic & Computing Devices Lab,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,
-ECE,2090,4.0,Logic & Computing Devices Lab,0.83,0.08,0.0,0.08,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2090,5.0,Logic & Computing Devices Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,
-ECE,2090,9.0,Logic & Computing Devices Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2090,11.0,Logic & Computing Devices Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva deepak kapadia,
-ECE,2090,13.0,Logic & Computing Devices Lab,0.67,0.0,0.0,0.0,0.08,0.0,0.0,0.25,apoorva deepak kapadia,
-ECE,2090,14.0,Logic & Computing Devices Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,
-ECE,2110,1.0,Elec Engr Lab I,0.8,0.1,0.05,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2110,2.0,Elec Engr Lab I,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
-ECE,2110,3.0,Elec Engr Lab I,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
-ECE,2110,5.0,Elec Engr Lab I,0.7,0.15,0.1,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2110,6.0,Elec Engr Lab I,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
-ECE,2110,8.0,Elec Engr Lab I,0.3,0.4,0.15,0.0,0.05,0.0,0.0,0.1,apoorva deepak kapadia,
-ECE,2110,10.0,Elec Engr Lab I,0.69,0.08,0.23,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2120,1.0,Electrical Engineering Lab II,0.81,0.0,0.0,0.0,0.06,0.0,0.0,0.13,apoorva deepak kapadia,
-ECE,2220,1.0,Syst Prog Concept,0.18,0.18,0.16,0.05,0.05,0.0,0.0,0.37,lu yu,
-ECE,2230,1.0,Comp Sys Eng,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,walter ligon,
-ECE,2620,1.0,Electric Circuits II,0.05,0.36,0.32,0.09,0.07,0.0,0.0,0.11,liang dong,
-ECE,2720,1.0,Comp Organization,0.02,0.27,0.5,0.14,0.05,0.0,0.0,0.02,william reid,
-ECE,2730,2.0,Computer Org Lab,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,2730,3.0,Computer Org Lab,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,3110,2.0,Electrical Engineering Lab III,0.69,0.13,0.0,0.0,0.13,0.0,0.0,0.06,apoorva deepak kapadia,
-ECE,3120,1.0,Electrical Engineering Lab IV,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,
-ECE,3170,1.0,Rand Signal Analysis,0.22,0.28,0.34,0.1,0.04,0.0,0.0,0.01,stephen hubbard,
-ECE,3200,1.0,Electronics I,0.29,0.2,0.23,0.13,0.12,0.0,0.0,0.03,stephen hubbard,
-ECE,3200,2.0,Electronics I (HON),0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,stephen hubbard,True
-ECE,3210,1.0,Electronics II,0.22,0.27,0.39,0.12,0.0,0.0,0.0,0.0,stephen hubbard,
-ECE,3220,2.0,Intro Operating Sys,0.35,0.3,0.35,0.0,0.0,0.0,0.0,0.0,mark smotherman,
-ECE,3270,1.0,Dig Comp Design,0.16,0.3,0.27,0.18,0.05,0.0,0.0,0.05,melissa crawley smith,
-ECE,3300,1.0,Signals & Systems,0.23,0.19,0.27,0.15,0.11,0.0,0.0,0.05,carl baum,
-ECE,3300,2.0,Signals & Systems (HON),0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
-ECE,3520,1.0,Programming Systems,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,robert schalkoff,
-ECE,3600,1.0,Elect Power Engr,0.34,0.26,0.19,0.04,0.09,0.0,0.0,0.08,sukumar makarand brahma,
-ECE,3710,1.0,Microcontr Interface,0.55,0.31,0.08,0.04,0.0,0.0,0.0,0.01,william reid,
-ECE,3720,2.0,Micro Int Lab,0.33,0.33,0.08,0.08,0.08,0.0,0.0,0.08,apoorva deepak kapadia,
-ECE,3720,7.0,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,
-ECE,3800,1.0,Electromagnetics,0.23,0.11,0.23,0.2,0.11,0.0,0.0,0.11,anthony martin,
-ECE,3810,1.0,Field Waves & Ckts,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,hai xiao,
-ECE,4090,1.0,Intr to Linear Control Systems,0.76,0.19,0.03,0.01,0.0,0.0,0.0,0.01,apoorva deepak kapadia,
-ECE,4180,1.0,Power Syst Analysis,0.33,0.25,0.08,0.08,0.08,0.0,0.0,0.17,ramtin hadidi,
-ECE,4270,1.0,Communication Systems,0.22,0.28,0.33,0.09,0.04,0.0,0.0,0.04,lu yu,
-ECE,4310,1.0,Intro to Computer Vision,0.56,0.32,0.08,0.04,0.0,0.0,0.0,0.0,adam hoover,
-ECE,4420,1.0,Knowledge Engineering,0.35,0.4,0.1,0.0,0.1,0.0,0.0,0.05,robert schalkoff,
-ECE,4490,1.0,Comp Ntwrk Security,0.65,0.26,0.0,0.0,0.04,0.0,0.0,0.04,lu yu,
-ECE,4610,1.0,Fundamentals of Solar Energy,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,
-ECE,4670,1.0,Intro to Dig Sig Pro,0.18,0.41,0.24,0.0,0.0,0.0,0.0,0.18,john gowdy,
-ECE,4730,1.0,Intro Parallel Sys,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,walter ligon,
-ECE,4950,1.0,Int Sys Design I,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,apoorva deepak kapadia,
-ECE,4960,1.0,Int Sys Design II,0.53,0.38,0.08,0.0,0.0,0.0,0.0,0.03,richard groff,
-ECE,6040,1.0,Semiconductor Devices,0.63,0.13,0.25,0.0,0.0,0.0,0.0,0.0,judson douglas ryckman,
-ECE,6310,1.0,Intro to Computer Vision,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,adam hoover,
-ECE,6420,1.0,Knowledge Engr,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,robert schalkoff,
-ECE,6490,843.0,Comp Ntwrk Security,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,lu yu,
-ECE,6590,1.0,Int Circ Design,0.43,0.29,0.0,0.0,0.0,0.0,0.0,0.29,yingjie lao,
-ECE,6610,843.0,Fundamentals of Solar Energy,0.2,0.6,0.0,0.0,0.0,0.0,0.0,0.2,rajendra singh,
-ECE,6670,1.0,Intro to Dig Sig Pro,0.2,0.4,0.2,0.0,0.0,0.0,0.0,0.2,john gowdy,
-ECE,6930,844.0,IntroPowerElecTechApps Charls,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,zheyu zhang,
-ECE,8010,1.0,Analysis of Lin Sys,0.43,0.29,0.0,0.0,0.07,0.0,0.0,0.21,richard groff,
-ECE,8040,1.0,Networked Dynamical Systems,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,
-ECE,8540,1.0,Analysis of Tracking Systems,0.61,0.36,0.0,0.0,0.04,0.0,0.0,0.0,adam hoover,
-ECON,2000,2.0,Economic Concepts,0.67,0.23,0.08,0.03,0.0,0.0,0.0,0.0,shubhashrita basu,
-ECON,2000,4.0,Economic Concepts,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,miren ivankovic,
-ECON,2000,5.0,Economic Concepts,0.41,0.35,0.06,0.06,0.06,0.0,0.0,0.06,shubhashrita basu,
-ECON,2110,1.0,Principles of Microeconomics,0.16,0.47,0.32,0.0,0.05,0.0,0.0,0.0,frederick andrew hanssen,
-ECON,2110,2.0,Principles of Microeconomics,0.16,0.42,0.26,0.11,0.0,0.0,0.0,0.05,frederick andrew hanssen,
-ECON,2110,3.0,Principles of Microeconomics,0.05,0.42,0.37,0.05,0.05,0.0,0.0,0.05,frederick andrew hanssen,
-ECON,2110,4.0,Principles of Microeconomics,0.11,0.26,0.53,0.0,0.05,0.0,0.0,0.05,frederick andrew hanssen,
-ECON,2110,5.0,Principles of Microeconomics,0.16,0.58,0.16,0.0,0.05,0.0,0.0,0.05,frederick andrew hanssen,
-ECON,2110,6.0,Principles of Microeconomics,0.24,0.35,0.18,0.06,0.0,0.0,0.0,0.18,frederick andrew hanssen,
-ECON,2110,7.0,Principles of Microeconomics,0.11,0.61,0.22,0.06,0.0,0.0,0.0,0.0,frederick andrew hanssen,
-ECON,2110,8.0,Principles of Microeconomics,0.11,0.42,0.21,0.16,0.0,0.0,0.0,0.11,frederick andrew hanssen,
-ECON,2110,9.0,Principles of Microeconomics,0.0,0.42,0.37,0.16,0.05,0.0,0.0,0.0,frederick andrew hanssen,
-ECON,2110,10.0,Principles of Microeconomics,0.0,0.47,0.42,0.05,0.0,0.0,0.0,0.05,frederick andrew hanssen,
-ECON,2110,11.0,Principles of Microeconomics,0.26,0.26,0.26,0.05,0.11,0.0,0.0,0.05,frederick andrew hanssen,
-ECON,2110,12.0,Principles of Microeconomics,0.11,0.39,0.28,0.11,0.0,0.0,0.0,0.11,frederick andrew hanssen,
-ECON,2110,13.0,Principles of Microeconomics,0.05,0.63,0.21,0.05,0.0,0.0,0.0,0.05,frederick andrew hanssen,
-ECON,2110,14.0,Principles of Microeconomics,0.0,0.5,0.33,0.06,0.06,0.0,0.0,0.06,frederick andrew hanssen,
-ECON,2110,15.0,Principles of Microeconomics,0.11,0.47,0.26,0.11,0.0,0.0,0.0,0.05,frederick andrew hanssen,
-ECON,2110,16.0,Principles of Microeconomics,0.11,0.53,0.37,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,
-ECON,2110,17.0,Principles of Microeconomics,0.21,0.53,0.26,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,
-ECON,2110,18.0,Principles of Microeconomics,0.11,0.17,0.5,0.06,0.06,0.0,0.0,0.11,frederick andrew hanssen,
-ECON,2110,19.0,Principles of Microeconomics,0.17,0.39,0.44,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,
-ECON,2110,20.0,Principles of Microeconomics,0.37,0.3,0.24,0.06,0.01,0.0,0.0,0.01,cory simpkins,
-ECON,2110,21.0,Principles of Microeconomics,0.19,0.37,0.27,0.05,0.06,0.0,0.0,0.06,shirong zhao,
-ECON,2110,23.0,Principles of Microeconomics,0.3,0.45,0.18,0.02,0.03,0.0,0.0,0.03,elijah neilson,
-ECON,2110,24.0,Principles of Microeconomics,0.16,0.56,0.19,0.06,0.0,0.0,0.0,0.02,michael makowsky,
-ECON,2110,25.0,Principles of Microeconomics,0.38,0.4,0.2,0.03,0.0,0.0,0.0,0.0,seyedmajid hashemi,
-ECON,2110,26.0,Principles of Microeconomics,0.27,0.44,0.18,0.02,0.0,0.0,0.0,0.09,khundkar arefin kamal,
-ECON,2110,31.0,Principles of Microeconomics,0.25,0.47,0.18,0.03,0.03,0.0,0.0,0.05,shannon graham,
-ECON,2110,32.0,Principles of Microeconomics,0.19,0.52,0.3,0.0,0.0,0.0,0.0,0.0,haibin jiang,
-ECON,2110,33.0,Principles of Microeconomics,0.51,0.36,0.05,0.0,0.05,0.0,0.0,0.03,seyedmajid hashemi,
-ECON,2110,34.0,Principles of Microecon (HON),0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,charles thomas,True
-ECON,2110,35.0,Principles of Microeconomics,0.55,0.33,0.05,0.08,0.0,0.0,0.0,0.0,shilpi mukherjee,
-ECON,2110,36.0,Principles of Microeconomics,0.39,0.33,0.2,0.04,0.0,0.0,0.0,0.04,sarah louise wilson,
-ECON,2110,38.0,Principles of Microeconomics,0.31,0.48,0.17,0.0,0.0,0.0,0.0,0.05,elijah neilson,
-ECON,2110,40.0,Principles of Microeconomics,0.27,0.27,0.27,0.07,0.1,0.0,0.0,0.03,cory simpkins,
-ECON,2110,41.0,Principles of Microeconomics,0.29,0.26,0.21,0.17,0.02,0.0,0.0,0.05,devon merritt haskell gorry,
-ECON,2120,1.0,Principles of Macroeconomics,0.19,0.36,0.2,0.11,0.09,0.0,0.0,0.06,aspen rachel underwood,
-ECON,2120,2.0,Principles of Macroeconomics,0.41,0.3,0.26,0.0,0.0,0.0,0.0,0.02,kenneth whaley,
-ECON,2120,3.0,Principles of Macroeconomics,0.78,0.15,0.05,0.0,0.02,0.0,0.0,0.0,tyler francis,
-ECON,2120,4.0,Principles of Macroeconomics,0.3,0.23,0.28,0.13,0.06,0.0,0.0,0.0,aspen rachel underwood,
-ECON,2120,5.0,Principles of Macroeconomics,0.31,0.36,0.28,0.03,0.0,0.0,0.0,0.03,matthew lee cronin,
-ECON,2120,6.0,Principles of Macroeconomics,0.33,0.48,0.2,0.0,0.0,0.0,0.0,0.0,matthew lee cronin,
-ECON,2120,7.0,Principles of Macroeconomics,0.26,0.44,0.28,0.0,0.03,0.0,0.0,0.0,kenneth whaley,
-ECON,2120,8.0,Principles of Macroeconomics,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.03,jeremy choquette,
-ECON,2120,9.0,Principles of Macroeconomics,0.81,0.17,0.02,0.0,0.0,0.0,0.0,0.0,tyler francis,
-ECON,2120,10.0,Principles of Macroeconomics,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,jeremy choquette,
-ECON,3020,1.0,Money and Banking,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.03,adam markley witham,
-ECON,3060,1.0,Managerial Economics,0.16,0.32,0.22,0.19,0.08,0.0,0.0,0.03,benjamin james posmanick,
-ECON,3100,1.0,International Econ,0.17,0.53,0.24,0.01,0.03,0.0,0.0,0.01,scott baier,
-ECON,3140,1.0,Intermediate Micro,0.18,0.26,0.24,0.1,0.08,0.0,0.0,0.14,patrick warren,
-ECON,3140,2.0,Intermediate Micro,0.2,0.41,0.26,0.08,0.03,0.0,0.0,0.02,molly espey,
-ECON,3140,3.0,Intermediate Micro,0.44,0.27,0.13,0.04,0.04,0.0,0.0,0.07,yichen christy zhou,
-ECON,3140,5.0,Intermediate Micro,0.47,0.26,0.11,0.03,0.03,0.0,0.0,0.11,yichen christy zhou,
-ECON,3150,1.0,Intermediate Macro,0.07,0.23,0.39,0.14,0.11,0.0,0.0,0.07,michal maria jerzmanowski,
-ECON,3150,2.0,Intermediate Macro,0.21,0.26,0.38,0.12,0.0,0.0,0.0,0.03,michal maria jerzmanowski,
-ECON,3190,1.0,Environmental Econ,0.35,0.41,0.16,0.05,0.0,0.0,0.0,0.03,molly espey,
-ECON,3600,1.0,Public Choice,0.29,0.26,0.18,0.11,0.08,0.0,0.0,0.08,michael makowsky,
-ECON,4010,1.0,Labor Mkt Analysis,0.29,0.41,0.24,0.0,0.06,0.0,0.0,0.0,chungsang lam,
-ECON,4020,1.0,Law and Economics,0.21,0.45,0.21,0.07,0.02,0.0,0.0,0.02,howard nelson bodenhorn,
-ECON,4040,1.0,Comp Econ Systems,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,daria litsukova-bokar,
-ECON,4050,5.0,Intro to Econometric,0.18,0.29,0.35,0.14,0.03,0.0,0.0,0.0,scott barkowski,
-ECON,4100,1.0,Economic Development,0.53,0.32,0.05,0.05,0.0,0.0,0.0,0.05,robert tamura,
-ECON,4110,2.0,Econ of Education,0.75,0.18,0.0,0.0,0.04,0.0,0.0,0.04,jorge luis garcia  menendez,
-ECON,4120,1.0,International Micro,0.46,0.38,0.08,0.08,0.0,0.0,0.0,0.0,cheng chen,
-ECON,4230,1.0,Economics of Health,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0,devon merritt haskell gorry,
-ECON,4240,1.0,Organization of Ind,0.53,0.24,0.18,0.06,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,4240,2.0,Organization of Ind,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,matthew lewis,
-ECON,4280,1.0,Cost-Benefit Anlysis,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,robert kenneth fleck,
-ECON,4280,2.0,Cost-Benefit Anlysis,0.45,0.25,0.25,0.05,0.0,0.0,0.0,0.0,robert kenneth fleck,
-ECON,4980,1.0,Selected Topics in Economics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,howard nelson bodenhorn,
-ECON,4980,3.0,History of Economic Thought,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
-ECON,4980,3.0,History of Economic Thought,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
-ECON,4980,4.0,Sel Topic - Why Business?,0.34,0.52,0.14,0.0,0.0,0.0,0.0,0.0,lawrence reed watson,
-ECON,4980,5.0,Cryptocurrency and  Blockchain,0.37,0.42,0.16,0.0,0.0,0.0,0.0,0.05,gerald dwyer,
-ECON,4980,6.0,Sel Topic - Why Business?,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
-ECON,4980,6.0,Sel Topic - Why Business?,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
-ECON,6050,5.0,Intro to Econometric,0.36,0.27,0.36,0.0,0.0,0.0,0.0,0.0,scott barkowski,
-ECON,8010,1.0,Microeconomic Theory,0.22,0.33,0.33,0.0,0.0,0.0,0.0,0.11,william dougan,
-ECON,8040,1.0,Applied Math Econ,0.36,0.59,0.05,0.0,0.0,0.0,0.0,0.0,curtis simon,
-ECON,8060,1.0,Econometrics I,0.33,0.33,0.25,0.0,0.08,0.0,0.0,0.0,paul wayne wilson,
-ECON,8080,1.0,Econometrics III,0.33,0.33,0.17,0.0,0.17,0.0,0.0,0.0,paul wayne wilson,
-ECON,8230,1.0,Microecon Pub Pol,0.0,0.45,0.36,0.0,0.09,0.0,0.0,0.09,scott templeton,
-ECON,8260,1.0,Econ Theory of Govt Regulation,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,thomas winslow hazlett,
-ECON,9010,1.0,Price Theory,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,charles thomas,
-ED,1050,2.0,Orientation to Education,0.82,0.14,0.0,0.05,0.0,0.0,0.0,0.0,stacy jones,
-ED,1050,3.0,Orientation to Education,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,stacy jones,
-ED,1050,4.0,Orientation to Education,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,stacy jones,
-ED,1050,5.0,Orientation to Education,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,hilary tanck,
-ED,1050,6.0,Orientation to Education,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,hilary tanck,
-ED,1970,1.0,CI-CONNECTIONS Stud Developmnt,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,2.0,CI-CONNECTIONS Stud Developmnt,0.94,0.0,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,3.0,CI-CONNECTIONS Stud Developmnt,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,5.0,CI-CONNECTIONS Stud Developmnt,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,1970,6.0,CI-CONNECTIONS Stud Developmnt,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,3010,1.0,Principles of American Educat,0.87,0.0,0.0,0.0,0.04,0.0,0.0,0.09,beatrice naff bailey,
-ED,3010,3.0,Principles of American Educat,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,beatrice naff bailey,
-ED,3010,4.0,Principles of American Educat,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,nafees mohammad khan,
-EDC,8100,400.0,Advising and Supporting,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,mary dolores katalinic,
-EDEC,3360,1.0,Play/Soc Dev-Infts/Young Child,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,marjorie deanna ramey,
-EDEC,4400,1.0,Early Childhood Engl Lang Art,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,
-EDEL,3100,3.0,Arts in Ele School,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kathy cochran,
-EDEL,3210,2.0,Pe for the Elem Tchr,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,3210,3.0,Pe for the Elem Tchr,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,deborah smith,
-EDEL,4510,1.0,Elem Methods in Science Tchg,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,laura cohen eicher,
-EDEL,4870,1.0,Ele Meth Soc Studies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-EDF,3020,1.0,Educational Psychology,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,meihua qian,
-EDF,3340,1.0,Child Growth and Development,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,amanda elizabeth bennett,
-EDF,3340,3.0,Child Growth and Development,0.74,0.23,0.0,0.03,0.0,0.0,0.0,0.0,faiza marghoob jamil,
-EDF,3350,1.0,Adolescent Growth & Develop,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,
-EDF,4800,1.0,Digital Media & Learning,0.63,0.25,0.08,0.0,0.04,0.0,0.0,0.0,ryan visser,
-EDF,4800,2.0,Digital Media & Learning,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,golnaz arastoopour irgens,
-EDF,4800,3.0,Digital Media & Learning,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,golnaz arastoopour irgens,
-EDF,4800,300.0,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,georgia lousie mckown,
-EDF,4800,301.0,Digital Media & Learning,0.69,0.17,0.07,0.03,0.03,0.0,0.0,0.0,ryan visser,
-EDF,8710,400.0,Cultural Diversity in Educatio,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,reginald wilkerson,
-EDF,9270,1.0,Quant Rsrch & Stats for Ed,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,christy jenkins brown,
-EDF,9270,2.0,Quant Rsrch & Stats for Ed,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,christy jenkins brown,
-EDF,9780,1.0,Multivar Ed Research,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,matthew james madison,
-EDHD,3110,3.0,CI- Children's Lit. Newsletter,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDHD,3110,4.0,CI- Read/Review Child/YA Lit.,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDL,7050,400.0,Contemp Iss in School Leadshp,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,danielle hall,
-EDL,7250,501.0,Law/Ethics for School Leaders,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,betty thompson bagley,
-EDL,9770,2.0,Div Issues in Hi Ed,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,william mccoy,
-EDLT,4600,1.0,Found of Read: Assess & Instr,0.39,0.39,0.17,0.04,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDLT,4600,3.0,Found of Read: Assess & Instr,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,lisa denise aker,
-EDLT,4600,4.0,Found of Read: Assess & Instr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lisa denise aker,
-EDLT,4610,1.0,Content Area Read/Writing,0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,4610,2.0,Content Area Read/Writing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,4800,301.0,Found in Adolescent Literacy,0.79,0.14,0.04,0.04,0.0,0.0,0.0,0.0,phillip michael wilder,
-EDLT,4980,1.0,Cont Area Read/Write Secondary,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,arsenio frankie silva,
-EDLT,8100,300.0,Foundations: Reading & Writing,0.74,0.17,0.0,0.0,0.0,0.0,0.0,0.09,emily smothers howell,
-EDLT,8110,300.0,Adv Children's & Yng Adult Lit,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,susan king fullerton,
-EDLT,8110,301.0,Adv Children's & Yng Adult Lit,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,jonda cecole mcnair,
-EDLT,8150,300.0,Guided Reading & Guided Writng,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,pamela dunston,
-EDLT,8220,500.0,Strategies for Teaching ESOL,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,mikel walker cole,
-EDLT,8270,300.0,Content Area Rdg/Wtg-MS & HS,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,emily smothers howell,
-EDLT,8400,502.0,Early Literacy Assessment I,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,antoinette dibellonia,
-EDLT,8400,504.0,Early Literacy Assessment I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,barbara fewell,
-EDLT,8400,508.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jamie felder white,
-EDLT,8400,509.0,Early Literacy Assessment I,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,susanne atkinson elvington,
-EDSA,3900,1.0,Skills for Student Leaders,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDSA,3900,4.0,Skills for Student Leaders,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDSA,3900,6.0,Skills for Student Leaders,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-EDSA,3990,1.0,Creative Inq in Counselor Ed,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,jacob frankovich,
-EDSA,8040,1.0,Theories Student Dev in Hi Ed,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,
-EDSA,8040,2.0,Theories Student Dev in Hi Ed,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,
-EDSA,8100,1.0,Advising and Supporting,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,
-EDSC,2260,1.0,Pr Apprch to Sec Alg,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,stacy megan che,
-EDSC,3270,1.0,Practicum Sec Sci,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,christopher david white,
-EDSC,4240,1.0,Tchng Sec English,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,mary-celeste schreuder,
-EDSC,4280,1.0,Tchng Secondary Social Studies,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kristen earnise duncan,
-EDSP,3700,1.0,Intro to Special Education,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,sharon walters,
-EDSP,3700,2.0,Intro to Special Education,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,friggita johnson,
-EDSP,3700,4.0,Intro to Special Education,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,wendell kent parker,
-EDSP,3720,1.0,Char & Instr Individ with LD,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,catherine aurentz griffith,
-EDSP,3740,1.0,Char & Strat Emot/Behav Disord,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shanna eisner hirsch,
-EDSP,3750,1.0,Early Intervention Spec Needs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
-EDSP,4920,1.0,Math Inst Ind W/Dis,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,
-EDSP,4930,1.0,Clsrm/Beh Mgmt Sp Ed,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,joseph benedict ryan,
-EDSP,4940,1.0,Tchg Rdg Mild Dis,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
-EDSP,8530,400.0,Legal/Pol Issu Sp Ed,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
-EES,2010,1.0,Environ Engr Fundamentals I,0.34,0.26,0.24,0.08,0.05,0.0,0.0,0.03,david freedman,
-EES,3030,1.0,Water Treatment Systems,0.53,0.27,0.17,0.0,0.0,0.0,0.0,0.03,david allen ladner,
-EES,3040,1.0,Wastewater Treatment Systems,0.41,0.41,0.17,0.0,0.0,0.0,0.0,0.0,sudeep popat,
-EES,3050,1.0,Water/Wastewater Treatment Lab,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,3050,2.0,Water/Wastewater Treatment Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,sudeep popat,
-EES,4010,1.0,Environmental Engr,0.52,0.35,0.11,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,
-EES,4010,2.0,Environmental Engr,0.28,0.45,0.14,0.07,0.07,0.0,0.0,0.0,mark schlautman,
-EES,4090,1.0,Intro to Nuc Engr & Radiol Sci,0.29,0.29,0.07,0.14,0.0,0.0,0.0,0.21,timothy devol,
-EES,4300,1.0,Air Pollution Engineering,0.3,0.33,0.27,0.07,0.0,0.0,0.0,0.03,andrew richard metcalf,
-EES,4800,1.0,Environmental Risk Assessment,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,nicole elizabeth martinez,
-EES,4840,1.0,Solid Waste Mgt,0.29,0.5,0.18,0.0,0.0,0.0,0.0,0.03,ezra lucas hoyt cates,
-EES,4860,1.0,Environmental Sustainability,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,michael carbajales-dale,
-EES,4860,2.0,Environmental Sustainability,0.5,0.33,0.0,0.0,0.08,0.0,0.0,0.08,michael carbajales-dale,
-EES,4900,15.0,CI: From Drones to 3D Printing,0.75,0.13,0.0,0.13,0.0,0.0,0.0,0.0,blake andrew lytle,
-EES,6860,1.0,Environmental Sustainability,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michael carbajales-dale,
-EES,8020,1.0,Environ Eng Prin,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,8430,1.0,Environmental Chem,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,
-EES,8510,1.0,Biol Prin Envir Engr,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,kevin thomas finneran,
-ELE,3010,1.0,Entrepreneurial Foundations,0.41,0.29,0.29,0.02,0.0,0.0,0.0,0.0,ashley williams parnell,
-ELE,3010,2.0,Entrepreneurial Foundations,0.16,0.43,0.39,0.0,0.02,0.0,0.0,0.0,ashley williams parnell,
-ELE,3010,3.0,Entrepreneurial Foundations,0.38,0.54,0.05,0.0,0.03,0.0,0.0,0.0,christina kyprianou,
-ELE,3010,4.0,Entrepreneurial Foundations,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
-ELE,3020,3.0,Entrepreneurial Resource Acqu,0.38,0.49,0.14,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,
-ELE,3020,4.0,Entrepreneurial Resource Acqu,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,
-ELE,4020,1.0,Venture Creation,0.35,0.54,0.08,0.0,0.03,0.0,0.0,0.0,william frank dinardo,
-ELE,4030,1.0,Venture Growth,0.59,0.32,0.08,0.0,0.0,0.0,0.0,0.0,james keith hudgins,
-ELE,4990,2.0,Venture Counsulting,0.28,0.63,0.1,0.0,0.0,0.0,0.0,0.0,william frank dinardo,
-ENGL,1030,2.0,Composition and Rhetoric,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,robert andrew welborn,
-ENGL,1030,3.0,Composition and Rhetoric,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,
-ENGL,1030,7.0,Composition and Rhetoric,0.16,0.42,0.16,0.11,0.11,0.0,0.0,0.05,chelsea marie clarey,
-ENGL,1030,10.0,Composition and Rhetoric,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,chelsea marie clarey,
-ENGL,1030,11.0,Composition and Rhetoric,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,caitlin grace watt,
-ENGL,1030,12.0,Composition and Rhetoric,0.41,0.41,0.12,0.0,0.0,0.0,0.0,0.06,tareva leselle johnson,
-ENGL,1030,13.0,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,caitlin grace watt,
-ENGL,1030,14.0,Composition and Rhetoric,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,tareva leselle johnson,
-ENGL,1030,15.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,emma jayne stanley,
-ENGL,1030,16.0,Composition and Rhetoric,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,anna lia  johnson,
-ENGL,1030,18.0,Composition and Rhetoric,0.74,0.16,0.0,0.0,0.11,0.0,0.0,0.0,allen swords,
-ENGL,1030,19.0,Composition and Rhetoric,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,1030,20.0,Composition and Rhetoric,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,anna lia  johnson,
-ENGL,1030,21.0,Composition and Rhetoric,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,mary catherine nestor,
-ENGL,1030,22.0,Composition and Rhetoric,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,mary catherine nestor,
-ENGL,1030,23.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,lindsey henley kurz,
-ENGL,1030,24.0,Composition and Rhetoric,0.63,0.16,0.0,0.0,0.21,0.0,0.0,0.0,sarah elizabeth richardson,
-ENGL,1030,25.0,Composition and Rhetoric,0.42,0.47,0.0,0.0,0.11,0.0,0.0,0.0,john benjamin fuqua,
-ENGL,1030,26.0,Composition and Rhetoric,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,kimberly jenerette,
-ENGL,1030,27.0,Composition and Rhetoric,0.37,0.42,0.05,0.05,0.11,0.0,0.0,0.0,kimberly jenerette,
-ENGL,1030,28.0,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,hannah taylor,
-ENGL,1030,29.0,Composition and Rhetoric,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,hannah pittman godwin,
-ENGL,1030,30.0,Composition and Rhetoric,0.42,0.42,0.11,0.0,0.05,0.0,0.0,0.0,andrew mathas,
-ENGL,1030,31.0,Composition and Rhetoric,0.76,0.12,0.06,0.0,0.06,0.0,0.0,0.0,joelma soares-sambdman,
-ENGL,1030,33.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,helen wesley kapp,
-ENGL,1030,34.0,Composition and Rhetoric,0.39,0.44,0.06,0.0,0.11,0.0,0.0,0.0,john benjamin fuqua,
-ENGL,1030,35.0,Composition and Rhetoric,0.47,0.42,0.0,0.05,0.0,0.0,0.0,0.05,hannah pittman godwin,
-ENGL,1030,36.0,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,hannah taylor,
-ENGL,1030,37.0,Composition and Rhetoric,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,la'cresha ulon green,
-ENGL,1030,41.0,Composition and Rhetoric,0.74,0.11,0.0,0.0,0.11,0.0,0.0,0.05,cody hunter,
-ENGL,1030,42.0,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,cody hunter,
-ENGL,1030,43.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kaitlyn samons,
-ENGL,1030,45.0,Composition and Rhetoric,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jacob danial richter,
-ENGL,1030,46.0,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,jacob danial richter,
-ENGL,1030,49.0,Composition and Rhetoric,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,nicholas rader,
-ENGL,1030,50.0,Composition and Rhetoric,0.47,0.47,0.0,0.05,0.0,0.0,0.0,0.0,nicholas rader,
-ENGL,1030,51.0,Composition and Rhetoric,0.42,0.32,0.11,0.05,0.05,0.0,0.0,0.05,jennie elizabeth wakefield,
-ENGL,1030,52.0,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jennie elizabeth wakefield,
-ENGL,1030,53.0,Composition and Rhetoric,0.22,0.5,0.22,0.0,0.06,0.0,0.0,0.0,gregory luke chwala,
-ENGL,1030,54.0,Composition and Rhetoric,0.57,0.36,0.0,0.0,0.07,0.0,0.0,0.0,sethunya mokoko gall,
-ENGL,1030,55.0,Composition and Rhetoric,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,jennie elizabeth wakefield,
-ENGL,1030,56.0,Composition and Rhetoric,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,sethunya mokoko gall,
-ENGL,1030,57.0,Composition and Rhetoric,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,sarah watkins,
-ENGL,1030,58.0,Composition and Rhetoric,0.79,0.05,0.05,0.05,0.05,0.0,0.0,0.0,kailan smith sindelar,
-ENGL,1030,60.0,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kailan smith sindelar,
-ENGL,1030,61.0,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,hwi eun hur,
-ENGL,1030,64.0,Composition and Rhetoric,0.73,0.13,0.07,0.0,0.0,0.0,0.0,0.07,hwi eun hur,
-ENGL,1030,65.0,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kelley melissa gillis,
-ENGL,1030,67.0,Composition and Rhetoric,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,kelley melissa gillis,
-ENGL,1030,68.0,Composition and Rhetoric,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,juliann teichert,
-ENGL,1030,69.0,Composition and Rhetoric,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,juliann teichert,
-ENGL,1030,76.0,Composition and Rhetoric,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,mary adams,
-ENGL,1030,77.0,Composition and Rhetoric,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,
-ENGL,1030,78.0,Composition and Rhetoric,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,
-ENGL,1030,82.0,Composition and Rhetoric,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,
-ENGL,1030,83.0,Composition and Rhetoric,0.67,0.17,0.0,0.06,0.06,0.0,0.0,0.06,melissa dugan,
-ENGL,1030,84.0,Composition and Rhetoric,0.65,0.18,0.06,0.0,0.06,0.0,0.0,0.06,bree laran beal,
-ENGL,1030,85.0,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,joelma soares-sambdman,
-ENGL,1030,101.0,Composition and Rhetoric (HON),0.78,0.11,0.0,0.11,0.0,0.0,0.0,0.0,chelsea jeanine murdock,True
-ENGL,2120,1.0,World Literature,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
-ENGL,2120,2.0,World Literature,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,kenneth michael tuite,
-ENGL,2120,3.0,World Literature,0.47,0.32,0.0,0.0,0.05,0.0,0.0,0.16,bree laran beal,
-ENGL,2120,4.0,World Literature,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sarah elissa matalone,
-ENGL,2120,5.0,World Literature,0.37,0.32,0.21,0.0,0.0,0.0,0.0,0.11,andrew mathas,
-ENGL,2120,6.0,World Literature,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,david charles foltz,
-ENGL,2120,7.0,World Literature,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,david charles foltz,
-ENGL,2120,8.0,World Literature,0.47,0.21,0.21,0.0,0.0,0.0,0.0,0.11,david charles foltz,
-ENGL,2120,9.0,World Literature,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,sarah elissa matalone,
-ENGL,2120,10.0,World Literature,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,sarah elissa matalone,
-ENGL,2120,11.0,World Literature,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,elizabeth anderson stansell,
-ENGL,2120,12.0,World Literature,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,
-ENGL,2120,13.0,World Literature,0.5,0.31,0.06,0.0,0.06,0.0,0.0,0.06,hannah pittman godwin,
-ENGL,2120,14.0,World Literature,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,
-ENGL,2120,16.0,World Literature,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,
-ENGL,2120,17.0,World Literature,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,bree laran beal,
-ENGL,2120,18.0,World Literature,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,john benjamin fuqua,
-ENGL,2120,19.0,World Literature,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,
-ENGL,2120,20.0,World Literature,0.5,0.22,0.22,0.0,0.06,0.0,0.0,0.0,elizabeth anderson stansell,
-ENGL,2120,21.0,World Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
-ENGL,2120,22.0,World Literature,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,
-ENGL,2120,23.0,World Literature,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,
-ENGL,2120,24.0,World Literature,0.74,0.11,0.11,0.05,0.0,0.0,0.0,0.0,ingrid anna pierce,
-ENGL,2120,25.0,World Literature,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,ingrid anna pierce,
-ENGL,2120,26.0,World Literature,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,bree laran beal,
-ENGL,2120,27.0,World Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,hannah pittman godwin,
-ENGL,2120,28.0,World Literature,0.47,0.26,0.16,0.0,0.11,0.0,0.0,0.0,andrew mathas,
-ENGL,2120,29.0,World Literature,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,2120,30.0,World Literature,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,john benjamin fuqua,
-ENGL,2120,400.0,World Literature,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth anderson stansell,
-ENGL,2120,401.0,World Literature,0.37,0.37,0.16,0.0,0.0,0.0,0.0,0.11,karen kettnich,
-ENGL,2120,402.0,World Literature,0.5,0.17,0.17,0.0,0.0,0.0,0.0,0.17,karen kettnich,
-ENGL,2120,403.0,World Literature,0.21,0.29,0.07,0.07,0.07,0.0,0.0,0.29,sarah elissa matalone,
-ENGL,2130,2.0,British Literature,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,gregory luke chwala,
-ENGL,2130,3.0,British Literature,0.29,0.41,0.24,0.06,0.0,0.0,0.0,0.0,gregory luke chwala,
-ENGL,2130,4.0,British Literature,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,gregory luke chwala,
-ENGL,2130,5.0,British Literature,0.47,0.21,0.16,0.05,0.05,0.0,0.0,0.05,henna marian messina,
-ENGL,2130,7.0,British Literature,0.47,0.26,0.16,0.0,0.0,0.0,0.0,0.11,christopher benson,
-ENGL,2130,8.0,British Literature,0.38,0.31,0.13,0.06,0.06,0.0,0.0,0.06,henna marian messina,
-ENGL,2130,9.0,British Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,2130,11.0,British Literature,0.58,0.26,0.05,0.05,0.05,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,100.0,British Literature (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john morgenstern,True
-ENGL,2130,400.0,British Literature,0.32,0.32,0.16,0.11,0.05,0.0,0.0,0.05,kristen louise aldebol-hazle,
-ENGL,2130,401.0,British Literature,0.56,0.13,0.0,0.0,0.13,0.0,0.0,0.19,kristen louise aldebol-hazle,
-ENGL,2140,1.0,American Literature,0.42,0.26,0.26,0.0,0.0,0.0,0.0,0.05,mary catherine nestor,
-ENGL,2140,2.0,American Literature,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,mary catherine nestor,
-ENGL,2140,3.0,American Literature,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,chelsea marie clarey,
-ENGL,2140,4.0,American Literature,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,chelsea marie clarey,
-ENGL,2140,5.0,American Literature,0.63,0.21,0.0,0.0,0.0,0.0,0.0,0.16,kathy elaine nixon,
-ENGL,2140,6.0,American Literature,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,kathy elaine nixon,
-ENGL,2140,7.0,American Literature,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,william weldon cunningham,
-ENGL,2140,8.0,American Literature,0.33,0.33,0.11,0.06,0.0,0.0,0.0,0.17,william weldon cunningham,
-ENGL,2140,9.0,American Literature,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,10.0,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,11.0,American Literature,0.21,0.68,0.0,0.0,0.0,0.0,0.0,0.11,patricia sunia,
-ENGL,2140,12.0,American Literature,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,patricia sunia,
-ENGL,2140,400.0,American Literature,0.61,0.17,0.11,0.0,0.0,0.0,0.0,0.11,tareva leselle johnson,
-ENGL,2140,401.0,American Literature,0.58,0.21,0.05,0.05,0.0,0.0,0.0,0.11,tareva leselle johnson,
-ENGL,2150,1.0,Lit in 20th-21st Cent Contexts,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,2150,2.0,Lit in 20th-21st Cent Contexts,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,allen swords,
-ENGL,2150,3.0,Lit in 20th-21st Cent Contexts,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,john logan pursley,
-ENGL,2150,4.0,Lit in 20th-21st Cent Contexts,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,5.0,Lit in 20th-21st Cent Contexts,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,6.0,Lit in 20th-21st Cent Contexts,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2150,7.0,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2150,8.0,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2150,9.0,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,2150,10.0,Lit in 20th-21st Cent Contexts,0.44,0.33,0.17,0.06,0.0,0.0,0.0,0.0,stephanie lorraine edwards,
-ENGL,2150,11.0,Lit in 20th-21st Cent Contexts,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,caitlin grace watt,
-ENGL,2150,12.0,Lit in 20th-21st Cent Contexts,0.68,0.16,0.0,0.0,0.0,0.0,0.0,0.16,caitlin grace watt,
-ENGL,2150,13.0,Lit in 20th-21st Cent Contexts,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,edward thomas joseph troy,
-ENGL,2150,14.0,Lit in 20th-21st Cent Contexts,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,jennifer hagen forsberg,
-ENGL,2150,15.0,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,april ayers lawson,
-ENGL,2150,16.0,Lit in 20th-21st Cent Contexts,0.11,0.63,0.26,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2150,17.0,Lit in 20th-21st Cent Contexts,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,remley melissa makala,
-ENGL,2150,18.0,Lit in 20th-21st Cent Contexts,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,edward thomas joseph troy,
-ENGL,2150,19.0,Lit in 20th-21st Cent Contexts,0.17,0.44,0.11,0.0,0.0,0.0,0.0,0.28,amy monaghan,
-ENGL,2150,20.0,Lit in 20th-21st Cent Contexts,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,megan noel macalystre,
-ENGL,2150,21.0,Lit in 20th-21st Cent Contexts,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,megan noel macalystre,
-ENGL,2150,23.0,Lit in 20th-21st Cent Contexts,0.42,0.32,0.16,0.0,0.05,0.0,0.0,0.05,edward thomas joseph troy,
-ENGL,2150,24.0,Lit in 20th-21st Cent Contexts,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,stephanie lorraine edwards,
-ENGL,2150,25.0,Lit in 20th-21st Cent Contexts,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,remley melissa makala,
-ENGL,2150,26.0,Lit in 20th-21st Cent Contexts,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jennifer hagen forsberg,
-ENGL,2150,27.0,Lit in 20th-21st Cent Contexts,0.59,0.12,0.12,0.06,0.0,0.0,0.0,0.12,remley melissa makala,
-ENGL,2150,28.0,Lit in 20th-21st Cent Contexts,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,remley melissa makala,
-ENGL,2150,29.0,Lit in 20th-21st Cent Contexts,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,stephanie lorraine edwards,
-ENGL,2150,30.0,Lit in 20th-21st Cent Contexts,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,stephanie lorraine edwards,
-ENGL,2150,100.0,20th - 21st Century Lit (HON),0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
-ENGL,2150,400.0,Lit in 20th-21st Cent Contexts,0.06,0.53,0.29,0.06,0.0,0.0,0.0,0.06,sarah mae cooper,
-ENGL,2150,401.0,Lit in 20th-21st Cent Contexts,0.06,0.71,0.06,0.06,0.0,0.0,0.0,0.12,sarah mae cooper,
-ENGL,2160,1.0,African American Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,
-ENGL,2160,2.0,African American Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allison nicole harris,
-ENGL,2160,3.0,African American Literature,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,allison nicole harris,
-ENGL,2160,4.0,African American Literature,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,allison nicole harris,
-ENGL,2310,1.0,Intro to Journalism,0.59,0.24,0.12,0.06,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3040,1.0,Business Writing,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,megan lee pietruszewski,
-ENGL,3040,2.0,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,patricia sunia,
-ENGL,3040,3.0,Business Writing,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,megan lee pietruszewski,
-ENGL,3040,4.0,Business Writing,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,william weldon cunningham,
-ENGL,3040,5.0,Business Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,megan lee pietruszewski,
-ENGL,3040,6.0,Business Writing,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,la'cresha ulon green,
-ENGL,3040,7.0,Business Writing,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,la'cresha ulon green,
-ENGL,3040,8.0,Business Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william weldon cunningham,
-ENGL,3040,9.0,Business Writing,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,jennifer hagen forsberg,
-ENGL,3040,10.0,Business Writing,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,
-ENGL,3040,11.0,Business Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3040,12.0,Business Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katalin beck,
-ENGL,3040,15.0,Business Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,patricia sunia,
-ENGL,3040,21.0,Business Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,jennifer hagen forsberg,
-ENGL,3040,100.0,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
-ENGL,3040,400.0,Business Writing,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,kristen louise aldebol-hazle,
-ENGL,3040,401.0,Business Writing,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,kristen louise aldebol-hazle,
-ENGL,3040,402.0,Business Writing,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,katalin beck,
-ENGL,3040,403.0,Business Writing,0.89,0.0,0.05,0.0,0.05,0.0,0.0,0.0,nancy paxton-wilson,
-ENGL,3100,1.0,Crit Writ Lit,0.26,0.47,0.05,0.0,0.05,0.0,0.0,0.16,dominic mastroianni,
-ENGL,3100,2.0,Crit Writ Lit,0.68,0.16,0.05,0.0,0.11,0.0,0.0,0.0,david sweeney coombs,
-ENGL,3100,3.0,Crit Writ Lit,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,kimberly snyder manganelli,
-ENGL,3120,1.0,Advanced Composition,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,diane mary quaglia beltran,
-ENGL,3120,3.0,Advanced Composition,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david charles foltz,
-ENGL,3120,4.0,Advanced Composition,0.44,0.28,0.17,0.11,0.0,0.0,0.0,0.0,jennie elizabeth wakefield,
-ENGL,3140,1.0,Technical Writing,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,henna marian messina,
-ENGL,3140,2.0,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henna marian messina,
-ENGL,3140,3.0,Technical Writing,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,christopher stuart,
-ENGL,3140,4.0,Technical Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,christopher stuart,
-ENGL,3140,5.0,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,charlotte estelle lucke,
-ENGL,3140,6.0,Technical Writing,0.61,0.22,0.06,0.0,0.06,0.0,0.0,0.06,charlotte estelle lucke,
-ENGL,3140,7.0,Technical Writing,0.83,0.0,0.06,0.06,0.0,0.0,0.0,0.06,shauna chung,
-ENGL,3140,11.0,Technical Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,ingrid anna pierce,
-ENGL,3140,12.0,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ingrid anna pierce,
-ENGL,3140,13.0,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,heather price williams,
-ENGL,3140,14.0,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,
-ENGL,3140,15.0,Technical Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,heather price williams,
-ENGL,3140,17.0,Technical Writing,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,michelle lloyd,
-ENGL,3140,19.0,Technical Writing,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,michelle lloyd,
-ENGL,3140,20.0,Technical Writing,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,kathy elaine nixon,
-ENGL,3140,22.0,Technical Writing,0.67,0.11,0.06,0.0,0.0,0.0,0.0,0.17,kathy elaine nixon,
-ENGL,3140,100.0,Technical Writing (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,heather price williams,True
-ENGL,3140,401.0,Technical Writing,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,
-ENGL,3140,402.0,Technical Writing,0.61,0.22,0.11,0.06,0.0,0.0,0.0,0.0,sharon kathleen nalley,
-ENGL,3140,403.0,Technical Writing,0.53,0.16,0.11,0.16,0.05,0.0,0.0,0.0,heather price williams,
-ENGL,3140,404.0,Technical Writing,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,henna marian messina,
-ENGL,3140,406.0,Technical Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,amy patterson,
-ENGL,3140,407.0,Technical Writing,0.7,0.1,0.05,0.0,0.1,0.0,0.0,0.05,michael russo,
-ENGL,3140,408.0,Technical Writing,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,michael russo,
-ENGL,3150,1.0,Scientific Writing & Comm,0.37,0.32,0.0,0.05,0.16,0.0,0.0,0.11,william pulley,
-ENGL,3150,2.0,Scientific Writing & Comm,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,william pulley,
-ENGL,3150,3.0,Scientific Writing & Comm,0.83,0.0,0.0,0.0,0.06,0.0,0.0,0.11,christopher benson,
-ENGL,3150,6.0,Scientific Writing & Comm,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,william pulley,
-ENGL,3150,400.0,Scientific Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,402.0,Scientific Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,403.0,Scientific Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,404.0,Scientific Writing,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,heather price williams,
-ENGL,3150,405.0,Scientific Writing,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,megan lee pietruszewski,
-ENGL,3450,1.0,Intr Creative Writing: Fiction,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,nicholas christiansen brown,
-ENGL,3460,1.0,Intr Creative Writing: Poetry,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,3480,1.0,Intr Creat Writ: Screenwriting,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,april ayers lawson,
-ENGL,3500,1.0,Mythology,0.32,0.32,0.11,0.0,0.11,0.0,0.0,0.16,kenneth michael tuite,
-ENGL,3530,1.0,Amer Lit-Race/Ethnicity/Migrat,0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,angela naimou,
-ENGL,3540,1.0,Lit Middle East & North Africa,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,angela naimou,
-ENGL,3570,1.0,Film,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,john robert smith,
-ENGL,3570,2.0,Film,0.53,0.24,0.12,0.0,0.06,0.0,0.0,0.06,john robert smith,
-ENGL,3570,3.0,Film,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3570,4.0,Film,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,
-ENGL,3850,1.0,Children's Lit,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,megan noel macalystre,
-ENGL,3860,1.0,Adolescent Lit,0.42,0.47,0.0,0.0,0.0,0.0,0.0,0.11,allison nicole harris,
-ENGL,3970,2.0,Brit Lit Survey II,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,brian mcgrath,
-ENGL,3990,1.0,Amer Lit Survey II,0.41,0.41,0.12,0.0,0.06,0.0,0.0,0.0,rhondda robinson thomas,
-ENGL,3990,2.0,Amer Lit Survey II,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,daniel scott citro,
-ENGL,4000,1.0,The English Language,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,andrew lemons,
-ENGL,4010,2.0,Grammar Survey,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,brian mcgrath,
-ENGL,4110,1.0,Shakespeare,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,4110,2.0,Shakespeare,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,4140,1.0,Milton,0.79,0.05,0.16,0.0,0.0,0.0,0.0,0.0,william stockton,
-ENGL,4180,1.0,Rise of the Novel in English,0.53,0.37,0.0,0.0,0.0,0.0,0.0,0.11,david sweeney coombs,
-ENGL,4280,1.0,Contemporary Literature,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,
-ENGL,4340,1.0,Environmental Lit,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,matthew hooley,
-ENGL,4360,1.0,Feminist Literary Criticism,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
-ENGL,4450,1.0,Fiction Workshop,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,keith morris,
-ENGL,4480,1.0,Screenwriting Wkshop,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nicholas christiansen brown,
-ENGL,4500,1.0,Film Genres,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,
-ENGL,4510,1.0,Film Theory and Criticism,0.4,0.47,0.0,0.07,0.07,0.0,0.0,0.0,agnieszka skrodzka,
-ENGL,4520,2.0,Great Directors,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,agnieszka skrodzka,
-ENGL,4540,1.0,Labor in International Cinema,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,edward thomas joseph troy,
-ENGL,4650,1.0,Topics in Lit:Reading Violence,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,maya sylvia hislop,
-ENGL,4750,1.0,Writing for Media,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,jonathan beecher field,
-ENGL,4820,1.0,Afr Am Lit to 1920,0.35,0.29,0.24,0.06,0.0,0.0,0.0,0.06,rhondda robinson thomas,
-ENGL,4960,2.0,SR Sem: End of Cinema,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
-ENGL,4960,3.0,SR Sem: Thinking About Love,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,
-ENGR,1020,112.0,Engineering Discipl & Skills,0.45,0.38,0.1,0.07,0.0,0.0,0.0,0.0,baker martin,
-ENGR,1020,117.0,Engineering Discipl & Skills,0.54,0.33,0.1,0.0,0.0,0.0,0.0,0.03,matthew kent miller,
-ENGR,1020,321.0,Engr Discipl & Skills (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jonathan brooks harcum,True
-ENGR,1020,325.0,Engr Discipl & Skills (HON),0.63,0.33,0.05,0.0,0.0,0.0,0.0,0.0,richard watkins,True
-ENGR,1020,611.0,Engineering Discipl & Skills,0.51,0.34,0.13,0.0,0.0,0.0,0.0,0.02,jonathan brooks harcum,
-ENGR,1020,612.0,Engineering Discipl & Skills,0.58,0.29,0.06,0.02,0.02,0.0,0.0,0.02,jonathan brooks harcum,
-ENGR,1020,613.0,Engineering Discipl & Skills,0.24,0.3,0.36,0.06,0.0,0.0,0.0,0.03,andrew isaac neptune,
-ENGR,1020,614.0,Engineering Discipl & Skills,0.55,0.2,0.14,0.06,0.02,0.0,0.0,0.02,steven brandon,
-ENGR,1020,615.0,Engineering Discipl & Skills,0.46,0.35,0.13,0.0,0.02,0.0,0.0,0.04,steven brandon,
-ENGR,1020,617.0,Engineering Discipl & Skills,0.55,0.3,0.09,0.0,0.0,0.0,0.0,0.06,taylor james sorensen,
-ENGR,1020,618.0,Engineering Discipl & Skills,0.47,0.34,0.11,0.06,0.02,0.0,0.0,0.0,taylor james sorensen,
-ENGR,1020,712.0,Engineering Discipl & Skills,0.53,0.33,0.08,0.05,0.03,0.0,0.0,0.0,matthew kent miller,
-ENGR,1020,713.0,Engineering Discipl & Skills,0.39,0.41,0.12,0.05,0.0,0.0,0.0,0.02,matthew kent miller,
-ENGR,1020,811.0,Engineering Discipl & Skills,0.47,0.39,0.08,0.0,0.02,0.0,0.0,0.04,irene marie ferrara,
-ENGR,1020,812.0,Engineering Discipl & Skills,0.46,0.38,0.13,0.02,0.02,0.0,0.0,0.0,jonathan maier,
-ENGR,1020,813.0,Engineering Discipl & Skills,0.45,0.37,0.12,0.04,0.0,0.0,0.0,0.02,jonathan maier,
-ENGR,1020,814.0,Engineering Discipl & Skills,0.56,0.32,0.07,0.02,0.0,0.0,0.0,0.02,taylor james sorensen,
-ENGR,1020,815.0,Engineering Discipl & Skills,0.45,0.47,0.05,0.0,0.03,0.0,0.0,0.0,cynthia miller smith,
-ENGR,1020,816.0,Engineering Discipl & Skills,0.45,0.34,0.18,0.0,0.02,0.0,0.0,0.0,cynthia miller smith,
-ENGR,1020,817.0,Engineering Discipl & Skills,0.38,0.4,0.04,0.02,0.04,0.0,0.0,0.13,andrew isaac neptune,
-ENGR,1020,818.0,Engineering Discipl & Skills,0.39,0.41,0.09,0.02,0.02,0.0,0.0,0.07,andrew isaac neptune,
-ENGR,1060,400.0,Engr Discipline & Skills II,0.1,0.5,0.25,0.15,0.0,0.0,0.0,0.0,irene marie ferrara,
-ENGR,1410,222.0,Programming & Problem Solving,0.08,0.29,0.18,0.13,0.13,0.0,0.0,0.18,william martin,
-ENGR,1410,223.0,Programming & Problem Solving,0.08,0.29,0.32,0.13,0.08,0.0,0.0,0.11,william martin,
-ENGR,1410,226.0,Programming & Problem Solving,0.06,0.31,0.2,0.23,0.06,0.0,0.0,0.14,shubhamkar sanjay kulkarni,
-ENGR,1410,227.0,Programming & Problem Solving,0.06,0.14,0.36,0.08,0.06,0.0,0.0,0.31,shubhamkar sanjay kulkarni,
-ENGR,1510,621.0,Engineering Skills,0.29,0.37,0.26,0.05,0.03,0.0,0.0,0.0,elizabeth anne stephan,
-ENGR,1510,622.0,Engineering Skills,0.21,0.32,0.34,0.05,0.08,0.0,0.0,0.0,elizabeth anne stephan,
-ENGR,1900,10.0,CI in Engr I Robotics,0.9,0.0,0.0,0.0,0.03,0.0,0.0,0.06,michael benjamin wooten,
-ENGR,1900,12.0,RISE CI Kinetic Sculpture,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,christopher norfolk,
-ENGR,1900,193.0,Special Projects in Engr I,0.13,0.44,0.31,0.08,0.05,0.0,0.0,0.0,john minor,
-ENGR,1900,194.0,Special Projects in Engr I,0.11,0.29,0.29,0.09,0.11,0.0,0.0,0.11,john minor,
-ENGR,2080,683.0,Engr Graphics & Machine Design,0.37,0.34,0.13,0.03,0.0,0.0,0.0,0.13,nisha dilip gulhane,
-ENGR,2080,684.0,Engr Graphics & Machine Design,0.36,0.38,0.1,0.03,0.13,0.0,0.0,0.0,apurva patel,
-ENGR,2080,685.0,Engr Graphics & Machine Design,0.26,0.33,0.13,0.0,0.1,0.0,0.0,0.18,kyle walker,
-ENGR,2080,686.0,Engr Graphics & Machine Design,0.31,0.31,0.13,0.08,0.08,0.0,0.0,0.1,kyle walker,
-ENGR,2080,881.0,Engr Graphics & Machine Design,0.41,0.27,0.16,0.0,0.05,0.0,0.0,0.11,nighat yasmin,
-ENGR,2080,882.0,Engr Graphics & Machine Design,0.49,0.28,0.1,0.03,0.03,0.0,0.0,0.08,nighat yasmin,
-ENGR,2100,804.0,CAD & Engineering Applications,0.43,0.2,0.22,0.08,0.02,0.0,0.0,0.04,nighat yasmin,
-ENGR,2100,805.0,CAD & Engineering Applications,0.38,0.31,0.2,0.04,0.04,0.0,0.0,0.02,afshin famili,
-ENGR,2100,806.0,CAD & Engineering Applications,0.38,0.43,0.12,0.0,0.05,0.0,0.0,0.02,afshin famili,
-ENGR,2210,316.0,"Technology, Culture and Design",0.44,0.41,0.1,0.0,0.05,0.0,0.0,0.0,jonathan maier,
-ENR,1010,2.0,Intro to Envir & Natur Res I,0.79,0.13,0.05,0.02,0.0,0.0,0.0,0.02,greg yarrow,
-ENR,1010,3.0,Intro to Envir & Natur Res I,0.74,0.14,0.06,0.05,0.0,0.0,0.0,0.02,greg yarrow,
-ENR,4140,1.0,Plant ID and Systematics,0.73,0.2,0.0,0.0,0.03,0.0,0.0,0.03,patrick mcmillan,
-ENR,4290,1.0,Environ Law & Policy,0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.04,alan johnson,
-ENR,4290,2.0,Environ Law & Policy,0.6,0.3,0.11,0.0,0.0,0.0,0.0,0.0,alan johnson,
-ENSP,2000,1.0,Intro Environ Sci,0.55,0.17,0.17,0.04,0.0,0.0,0.0,0.06,scott brame,
-ENSP,2000,2.0,Intro Environ Sci,0.64,0.27,0.04,0.0,0.04,0.0,0.0,0.02,minory nammouz,
-ENSP,2000,3.0,Intro Environ Sci,0.66,0.32,0.0,0.0,0.0,0.0,0.0,0.02,minory nammouz,
-ENSP,2000,4.0,Intro Environ Sci,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,
-ENSP,2000,5.0,Intro Environ Sci,0.24,0.58,0.09,0.04,0.0,0.0,0.0,0.04,tom owino,
-ENSP,2000,6.0,Intro Environ Sci,0.79,0.1,0.1,0.0,0.0,0.0,0.0,0.0,john gregory sherwood,
-ENSP,4000,1.0,Studies in Environmental Sci,0.63,0.05,0.16,0.11,0.05,0.0,0.0,0.0,margaret louise thompson,
-ENT,2000,1.0,Six-Legged Science,0.45,0.33,0.18,0.03,0.0,0.0,0.0,0.03,suellen pometto,
-ENT,3010,1.0,Insect Biology and Diversity,0.56,0.25,0.09,0.0,0.03,0.0,0.0,0.06,carmen blubaugh,
-ENTR,1010,3.0,Entrepreneurial Mindset,0.73,0.19,0.02,0.02,0.02,0.0,0.0,0.02,john michael hannon,
-ENTR,1090,1.0,Creative Inq-Entrepreneurship,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,
-ENTR,1090,20.0,Lemonade Day,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,david joseph frock,
-ENTR,2010,4.0,Sports Entrepreneurship,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,john michael hannon,
-ESED,8000,1.0,Seminar in Engr & Science Educ,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,cindy lee,
-ESED,8500,2.0,Spec Top Engineering & Sci Edu,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,eliza dargan gallagher,
-ESED,8610,2.0,Practicum in Engr & Sci Educ,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,karen ann high,
-ETOX,4300,1.0,Toxicology,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,lisa bain,
-FDSC,1010,1.0,Intro to Food Sci & Hum Nutr,0.76,0.13,0.04,0.02,0.01,0.0,0.0,0.04,carol hegler,
-FDSC,3010,1.0,Food Regulations,0.68,0.21,0.0,0.0,0.04,0.0,0.0,0.07,sara lane cothran,
-FDSC,3060,1.0,Institutional Food Service Mgt,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,
-FDSC,4010,1.0,Food Chemistry I,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,feng chen,
-FDSC,4040,1.0,Food Prsv & Process,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,anthony louis pometto,
-FDSC,4300,1.0,Dairy Process & Sant,0.5,0.19,0.19,0.06,0.0,0.0,0.0,0.06,john mcgregor,
-FDSC,4500,1.0,Creative Inquiry-Food Science,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth lacey durrance,
-FDSC,4500,11.0,Creative Inquiry-Food Science,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,paul dawson,
-FDSC,4500,26.0,Creative Inquiry-Food Science,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
-FIN,2010,401.0,Intro to Personal Finance,0.92,0.05,0.01,0.0,0.01,0.0,0.0,0.01,joshua harris,
-FIN,2010,402.0,Intro to Personal Finance,0.89,0.05,0.01,0.02,0.01,0.0,0.0,0.01,joshua harris,
-FIN,3040,1.0,Risk & Insurance,0.11,0.27,0.51,0.03,0.03,0.0,0.0,0.05,kerri mcmillan,
-FIN,3050,1.0,Investment Analysis,0.21,0.21,0.4,0.12,0.0,0.0,0.0,0.05,kerri mcmillan,
-FIN,3050,2.0,Investment Analysis,0.17,0.54,0.24,0.02,0.02,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,3.0,Investment Analysis,0.2,0.4,0.35,0.05,0.0,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,4.0,Investment Analysis,0.09,0.35,0.28,0.13,0.02,0.0,0.0,0.13,john alexander,
-FIN,3060,1.0,Corporation Finance,0.32,0.23,0.23,0.14,0.0,0.0,0.0,0.09,ramon tolbert franklin,
-FIN,3060,2.0,Corporation Finance,0.09,0.38,0.22,0.2,0.0,0.0,0.0,0.11,ramon tolbert franklin,
-FIN,3060,3.0,Corporation Finance,0.11,0.32,0.32,0.14,0.05,0.0,0.0,0.07,ramon tolbert franklin,
-FIN,3060,4.0,Corporation Finance,0.04,0.11,0.29,0.42,0.04,0.0,0.0,0.09,ramon tolbert franklin,
-FIN,3060,7.0,Corporation Finance,0.26,0.34,0.28,0.11,0.0,0.0,0.0,0.02,minxing sun,
-FIN,3060,8.0,Corporation Finance,0.29,0.4,0.21,0.04,0.04,0.0,0.0,0.02,minxing sun,
-FIN,3060,9.0,Corporation Finance,0.02,0.38,0.33,0.25,0.02,0.0,0.0,0.0,minxing sun,
-FIN,3060,403.0,Corporation Finance,0.19,0.51,0.21,0.01,0.03,0.0,0.0,0.04,jonathan godbey,
-FIN,3060,404.0,Corporation Finance,0.26,0.4,0.14,0.02,0.08,0.0,0.0,0.11,jonathan godbey,
-FIN,3070,1.0,Prin of Real Estate,0.14,0.44,0.26,0.09,0.05,0.0,0.0,0.02,thomas springer,
-FIN,3070,2.0,Prin of Real Estate,0.2,0.3,0.25,0.2,0.05,0.0,0.0,0.0,thomas springer,
-FIN,3070,5.0,Prin of Real Estate,0.3,0.27,0.24,0.06,0.09,0.0,0.0,0.03,bryan blackwood,
-FIN,3080,1.0,Fin Inst & Mkts,0.34,0.49,0.15,0.0,0.0,0.0,0.0,0.02,lyudmila chernykh,
-FIN,3080,2.0,Fin Inst & Mkts,0.1,0.58,0.28,0.05,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,3080,3.0,Fin Inst & Mkts,0.33,0.48,0.17,0.02,0.0,0.0,0.0,0.0,daniel thomas greene,
-FIN,3080,401.0,Fin Inst & Mkts,0.31,0.35,0.31,0.0,0.02,0.0,0.0,0.0,daniel thomas greene,
-FIN,3110,1.0,Financial Management I,0.08,0.28,0.25,0.13,0.13,0.0,0.0,0.15,jack wolf,
-FIN,3110,2.0,Financial Management I,0.06,0.18,0.24,0.12,0.15,0.0,0.0,0.26,jack wolf,
-FIN,3110,3.0,Financial Management I,0.13,0.31,0.38,0.13,0.05,0.0,0.0,0.0,weike xu,
-FIN,3110,4.0,Financial Management I,0.47,0.4,0.11,0.0,0.0,0.0,0.0,0.02,joshua harris,
-FIN,3110,5.0,Financial Management I,0.44,0.31,0.22,0.02,0.0,0.0,0.0,0.0,joshua harris,
-FIN,3110,6.0,Financial Management I,0.24,0.27,0.29,0.09,0.02,0.0,0.0,0.09,joshua harris,
-FIN,3110,102.0,Financial Management I (HON),0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,jack wolf,True
-FIN,3120,1.0,Financial Management II,0.15,0.27,0.41,0.1,0.05,0.0,0.0,0.02,vincent james intintoli,
-FIN,3120,2.0,Financial Management II,0.16,0.33,0.31,0.09,0.07,0.0,0.0,0.04,vincent james intintoli,
-FIN,3120,3.0,Financial Management II,0.33,0.3,0.27,0.06,0.0,0.0,0.0,0.03,blerina zykaj,
-FIN,3120,4.0,Financial Management II,0.17,0.24,0.22,0.22,0.07,0.0,0.0,0.09,weike xu,
-FIN,3120,5.0,Financial Management II,0.1,0.44,0.32,0.12,0.02,0.0,0.0,0.0,weike xu,
-FIN,3120,101.0,Financial Mgt II (HON),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,vincent james intintoli,True
-FIN,3120,103.0,Financial Mgt II (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,True
-FIN,4010,1.0,Corporate Financial Analysis,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,
-FIN,4020,1.0,Corporate Valuation,0.11,0.34,0.34,0.14,0.0,0.0,0.0,0.07,angela morgan,
-FIN,4020,101.0,Corporate Valuation (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,angela morgan,True
-FIN,4050,1.0,Portfolio Management & Theory,0.07,0.24,0.36,0.11,0.0,0.0,0.0,0.22,john alexander,
-FIN,4060,1.0,Derivatives Analysis,0.17,0.51,0.17,0.03,0.06,0.0,0.0,0.06,blerina zykaj,
-FIN,4110,1.0,Int Fin Mgt,0.34,0.51,0.15,0.0,0.0,0.0,0.0,0.0,luke asher devault,
-FIN,4110,2.0,Int Fin Mgt,0.58,0.27,0.1,0.02,0.02,0.0,0.0,0.0,luke asher devault,
-FIN,4980,2.0,CI in Finance: CFA,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jack wolf,
-FIN,4980,4.0,CI in Finance: SIE,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,joshua harris,
-FIN,4980,5.0,CI in Finance: AI,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,yannan shen,
-FIN,4980,6.0,CI in Finance: Machine Learnin,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,yannan shen,
-FNR,2040,1.0,Soil Information Systems,0.85,0.1,0.0,0.02,0.0,0.0,0.0,0.03,elena mikhailova,
-FNR,4700,5.0,Landscape Ecology / Appalachia,0.83,0.0,0.0,0.17,0.0,0.0,0.0,0.0,russell barrett,
-FNR,4700,10.0,Kennedy Waterfowl & Wetlands,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,richard marvin kaminski,
-FNR,4700,26.0,Stream Fish Mercury Dynamics,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,troy mason farmer,
-FNR,4700,44.0,Alligator Ecology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,catherine michelle jachowski,
-FNR,4700,129.0,GIS & SIS Applications,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher post,
-FNR,4990,1.0,Natural Resources Seminar,0.55,0.38,0.03,0.0,0.03,0.0,0.0,0.0,susan talley guynn,
-FOR,2050,1.0,Dendrology,0.17,0.42,0.08,0.04,0.13,0.0,0.0,0.17,donald hagan,
-FOR,2050,2.0,Dendrology,0.45,0.21,0.09,0.09,0.06,0.0,0.0,0.09,donald hagan,
-FOR,2050,3.0,Dendrology,0.19,0.13,0.28,0.19,0.09,0.0,0.0,0.13,donald hagan,
-FOR,2210,1.0,Forest Biology,0.18,0.46,0.22,0.04,0.04,0.0,0.0,0.07,jessica ann hartshorn,
-FOR,3020,1.0,Forest Biometrics,0.38,0.54,0.05,0.0,0.0,0.0,0.0,0.03,brian ritter,
-FOR,3040,1.0,Forest Resource Economics,0.67,0.23,0.05,0.05,0.0,0.0,0.0,0.0,puskar khanal,
-FOR,3410,1.0,Wood Procure Pract,0.61,0.3,0.06,0.03,0.0,0.0,0.0,0.0,patrick hiesl,
-FOR,4100,1.0,Harvesting Processes,0.54,0.35,0.12,0.0,0.0,0.0,0.0,0.0,patrick hiesl,
-FOR,4130,1.0,Integrated Forest Pest Mgt,0.57,0.37,0.06,0.0,0.0,0.0,0.0,0.0,jessica ann hartshorn,
-FOR,4150,1.0,Forest Wildlife Managment,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
-FOR,4160,1.0,Forest Policy and Admin,0.41,0.32,0.24,0.02,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4170,1.0,Forest Resource Mgt & Regulatn,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,
-FOR,4340,1.0,GIS for Natural Resources,0.63,0.31,0.04,0.0,0.0,0.0,0.0,0.02,christopher post,
-FR,1010,1.0,Elementary French,0.0,0.45,0.27,0.18,0.0,0.0,0.0,0.09,anne carole salces  nedeo,
-FR,1010,2.0,Elementary French,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,anne carole salces  nedeo,
-FR,1010,3.0,Elementary French,0.38,0.19,0.13,0.06,0.13,0.0,0.0,0.13,anne carole salces  nedeo,
-FR,1020,1.0,Elementary French,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,
-FR,1020,2.0,Elementary French,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,
-FR,1020,3.0,Elementary French,0.21,0.43,0.14,0.07,0.07,0.0,0.0,0.07,anne carole salces  nedeo,
-FR,2010,1.0,Intermediate French,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,
-FR,2010,2.0,Intermediate French,0.0,0.73,0.13,0.07,0.07,0.0,0.0,0.0,kenneth david widgren,
-FR,2010,3.0,Intermediate French,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,pauline de tholozany,
-FR,2020,1.0,Intermediate French,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,
-FR,2020,2.0,Intermediate French,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,
-FR,2020,4.0,Intermediate French,0.2,0.47,0.2,0.13,0.0,0.0,0.0,0.0,kenneth david widgren,
-FR,3000,1.0,Survey of French Lit,0.67,0.28,0.0,0.06,0.0,0.0,0.0,0.0,pauline de tholozany,
-FR,3050,1.0,Int Fr Con & Comp I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kenneth david widgren,
-FR,3050,2.0,Int Fr Con & Comp I,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,anne carole salces  nedeo,
-FR,3070,1.0,French Civilization,0.6,0.27,0.0,0.07,0.0,0.0,0.0,0.07,eric touya,
-FR,4120,1.0,Fr & Francoph Cinema,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joseph mai,
-GC,1020,1.0,Computer Art & CAD Foundations,0.47,0.35,0.07,0.02,0.08,0.0,0.0,0.01,carol jones,
-GC,1040,1.0,Graphic Communications I,0.63,0.19,0.09,0.0,0.09,0.0,0.0,0.0,michelle suki bost fox,
-GC,2070,1.0,Graphic Communications II,0.64,0.28,0.06,0.02,0.0,0.0,0.0,0.0,charles tabor weiss,
-GC,3400,1.0,Digital Imaging and eMedia,0.35,0.44,0.15,0.02,0.02,0.0,0.0,0.02,erica black walker,
-GC,3460,1.0,Ink and Substrates,0.63,0.32,0.02,0.02,0.0,0.0,0.0,0.0,shu chang,
-GC,4060,1.0,Package and Specialty Printing,0.48,0.5,0.03,0.0,0.0,0.0,0.0,0.0,kern cox,
-GC,4400,1.0,Commercial Printing,0.44,0.54,0.02,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,
-GC,4440,1.0,Current Dev/Trends in Gr Comm,0.42,0.48,0.09,0.0,0.0,0.0,0.0,0.0,liam henry 'hara,
-GC,4800,1.0,Senior Seminar in GC,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,charles edward tonkin,
-GC,4900,6.0,GC-UX & Web Design,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,erica black walker,
-GC,4900,8.0,Strat Messaging in Social Age,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,nigel robertson,
-GC,4900,10.0,EC: Concept & Storytelling,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,brian connaughton,
-GC,4900,16.0,GC Visual Design & Art Direct,0.75,0.06,0.13,0.0,0.0,0.0,0.0,0.06,erica black walker,
-GEN,1030,1.0,Careers in Bioch/Gen,0.81,0.16,0.02,0.0,0.0,0.0,0.0,0.01,joseph paul thames,
-GEN,3000,1.0,Fundamental Genetics,0.47,0.24,0.16,0.05,0.03,0.0,0.0,0.05,marcos tulio oliveira,
-GEN,3000,2.0,Fundamental Genetics,0.43,0.32,0.13,0.04,0.04,0.0,0.0,0.04,marcos tulio oliveira,
-GEN,3020,1.0,Molecular & General Genetics,0.26,0.41,0.23,0.05,0.02,0.0,0.0,0.04,kate leanne willingha tsai,
-GEN,3020,2.0,Molec & General Genetics (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,kate leanne willingha tsai,True
-GEN,4100,1.0,Population & Quant Genetics,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,
-GEN,4110,1.0,Population & Quant Gen Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,
-GEN,4110,2.0,Population & Quant Gen Lab,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,kimberly kanapeckas metris,
-GEN,4110,4.0,Population & Quant Gen Lab,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,
-GEN,4400,1.0,Bioinformatics,0.74,0.16,0.02,0.0,0.02,0.0,0.0,0.05,frank alexander feltus,
-GEN,4400,2.0,Bioinformatics (HON),0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,frank alexander feltus,True
-GEN,4500,1.0,Comparative Genetics,0.21,0.53,0.21,0.02,0.0,0.0,0.0,0.02,leigh anne clark,
-GEN,4500,2.0,Comparative Genetics (HON),0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,leigh anne clark,True
-GEN,4900,1.0,Epigenetics,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,rajandeep singh sekhon,
-GEN,4900,20.0,GB Prof Development,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alison nicole starr-moss,
-GEN,4930,1.0,Senior Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,
-GEN,4930,2.0,Senior Seminar,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,hong luo,
-GEOG,1010,1.0,Intro to Geography,0.39,0.39,0.13,0.03,0.0,0.0,0.0,0.05,christa smith,
-GEOG,1030,1.0,World Regional Geography,0.27,0.48,0.15,0.06,0.03,0.0,0.0,0.02,william church terry,
-GEOG,1030,2.0,World Regional Geography,0.35,0.25,0.23,0.05,0.08,0.0,0.0,0.05,william church terry,
-GEOL,1010,1.0,Physical Geology,0.27,0.3,0.2,0.12,0.06,0.0,0.0,0.05,alan coulson,
-GEOL,1010,2.0,Physical Geology,0.32,0.31,0.21,0.08,0.05,0.0,0.0,0.03,alan coulson,
-GEOL,1010,3.0,Physical Geology,0.43,0.34,0.19,0.04,0.0,0.0,0.0,0.0,mary katherine fidler,
-GEOL,1010,4.0,Physical Geology,0.49,0.24,0.2,0.02,0.04,0.0,0.0,0.0,mary katherine fidler,
-GEOL,1010,5.0,Physical Geology,0.56,0.21,0.17,0.02,0.02,0.0,0.0,0.02,kelly best lazar,
-GEOL,1030,1.0,Physical Geol Lab,0.27,0.41,0.14,0.05,0.05,0.0,0.0,0.09,emily don scribner,
-GEOL,1030,2.0,Physical Geol Lab,0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,3.0,Physical Geol Lab,0.42,0.42,0.08,0.0,0.04,0.0,0.0,0.04,alan coulson,
-GEOL,1030,4.0,Physical Geol Lab,0.71,0.21,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,5.0,Physical Geol Lab,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,6.0,Physical Geol Lab,0.54,0.33,0.0,0.04,0.0,0.0,0.0,0.08,alan coulson,
-GEOL,1030,7.0,Physical Geol Lab,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,8.0,Physical Geol Lab,0.5,0.36,0.0,0.09,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,1030,9.0,Physical Geol Lab,0.36,0.41,0.09,0.05,0.09,0.0,0.0,0.0,alan coulson,
-GEOL,1030,10.0,Physical Geol Lab,0.22,0.48,0.13,0.0,0.04,0.0,0.0,0.13,emily don scribner,
-GEOL,1030,11.0,Physical Geol Lab,0.67,0.17,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,
-GEOL,1030,12.0,Physical Geol Lab,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,13.0,Physical Geol Lab,0.45,0.41,0.09,0.0,0.05,0.0,0.0,0.0,alan coulson,
-GEOL,1030,14.0,Physical Geol Lab,0.47,0.27,0.2,0.0,0.07,0.0,0.0,0.0,alan coulson,
-GEOL,1030,15.0,Physical Geol Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,16.0,Physical Geol Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,17.0,Physical Geol Lab,0.57,0.26,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,
-GEOL,1120,1.0,Earth Resources,0.36,0.4,0.18,0.04,0.02,0.0,0.0,0.0,emily don scribner,
-GEOL,1140,1.0,Earth Resources Lab,0.65,0.22,0.08,0.03,0.03,0.0,0.0,0.0,emily don scribner,
-GEOL,2700,1.0,Sustainable Water,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-GEOL,3000,1.0,Environmental Geology,0.18,0.36,0.32,0.05,0.05,0.0,0.0,0.05,alan coulson,
-GEOL,4500,1.0,Paleoclimate Change,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,alexander thomas pullen,
-GEOL,4910,1.0,Research Synthesis I,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,7900,501.0,Biogeography And Geology of SC,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,
-GER,1010,1.0,Elementary German,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,oswald harris king,
-GER,1010,2.0,Elementary German,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,oswald harris king,
-GER,1020,2.0,Elementary German,0.58,0.17,0.08,0.0,0.0,0.0,0.0,0.17, lee ferrell,
-GER,2010,1.0,Intermediate German,0.22,0.39,0.28,0.06,0.0,0.0,0.0,0.06,johannes schmidt,
-GER,2020,1.0,Intermediate German,0.14,0.43,0.29,0.0,0.0,0.0,0.0,0.14,gabriela stoicea,
-GER,2600,1.0,Selected Topics in German Lit,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,gabriela stoicea,
-GER,3050,1.0,Ger Conv & Comp,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0, lee ferrell,
-GER,3400,1.0,German Culture,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,oswald harris king,
-HCG,9050,400.0,"Genomics, Ethics & Hlth Policy",0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,linda ward,
-HIST,1010,1.0,History of the United States,0.56,0.39,0.0,0.0,0.03,0.0,0.0,0.03,lee brady wilson,
-HIST,1010,2.0,History of the United States,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,james bradford jeffries,
-HIST,1020,1.0,History of the United States,0.48,0.39,0.1,0.0,0.0,0.0,0.0,0.03,rebecca anna stoil,
-HIST,1220,1.0,"Hist, Tech & Society",0.23,0.54,0.13,0.02,0.04,0.0,0.0,0.03,pamela mack,
-HIST,1240,1.0,Environmental History Survey,0.14,0.42,0.28,0.06,0.03,0.0,0.0,0.08,james bradford jeffries,
-HIST,1240,2.0,Environmental History Survey,0.18,0.36,0.39,0.0,0.0,0.0,0.0,0.07,james bradford jeffries,
-HIST,1720,1.0,The West and the World I,0.43,0.34,0.17,0.0,0.01,0.0,0.0,0.04,steven marks,
-HIST,1720,2.0,The West and the World I,0.41,0.34,0.14,0.03,0.02,0.0,0.0,0.06,kathryn langenfeld,
-HIST,1720,3.0,The West and the World (HON),0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,True
-HIST,1720,4.0,The West and the World I,0.37,0.53,0.0,0.0,0.0,0.0,0.0,0.11,thomas kuehn,
-HIST,1730,1.0,The West and the World II,0.52,0.27,0.12,0.02,0.04,0.0,0.0,0.04, alan grubb,
-HIST,2990,1.0,Historian's Craft,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,elizabeth donnelly carney,
-HIST,2990,3.0,Historian's Craft,0.68,0.21,0.0,0.0,0.11,0.0,0.0,0.0,michael silvestri,
-HIST,3040,1.0,Indus & Progr Era,0.5,0.22,0.17,0.06,0.0,0.0,0.0,0.06, roger grant,
-HIST,3060,1.0,US: Postwar World 1945-1975,0.68,0.24,0.0,0.0,0.0,0.0,0.0,0.08,rebecca anna stoil,
-HIST,3240,1.0,Hist of the South II,0.31,0.45,0.03,0.0,0.17,0.0,0.0,0.03,john andrew,
-HIST,3280,1.0,US Legal History to 1890,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
-HIST,3330,1.0,Hist of Mod Japan,0.24,0.38,0.31,0.03,0.03,0.0,0.0,0.0,edwin moise,
-HIST,3370,1.0,History South Africa,0.48,0.28,0.17,0.03,0.03,0.0,0.0,0.0,james burns,
-HIST,3540,1.0,Greek World,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathryn langenfeld,
-HIST,3670,1.0,Modern Ireland,0.53,0.27,0.07,0.07,0.0,0.0,0.0,0.07,michael silvestri,
-HIST,3700,1.0,Medieval History,0.46,0.23,0.08,0.04,0.15,0.0,0.0,0.04,caroline dunn clark,
-HIST,3720,1.0,Renaissance,0.47,0.35,0.06,0.0,0.06,0.0,0.0,0.06,thomas kuehn,
-HIST,3940,1.0,Non-Western History,0.18,0.35,0.18,0.0,0.06,0.0,0.0,0.24,stephanie hassell,
-HIST,3970,1.0,Modern Middle East,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
-HIST,4000,1.0,Disney Parks,0.56,0.34,0.09,0.0,0.0,0.0,0.0,0.0,stephanie barczewski,
-HIST,4000,2.0,Amer Comparative Frontiers,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08, roger grant,
-HIST,4140,1.0,Study of Hist Museum,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua casmir catalano,
-HIST,4710,1.0,The Great War,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23, alan grubb,
-HIST,4900,2.0,Global History of Slavery,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,stephanie hassell,
-HIST,4900,3.0,Global Impact of Russian Rev,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,
-HIST,4920,1.0,US - Iraq War,0.13,0.33,0.33,0.0,0.07,0.0,0.0,0.13,edwin moise,
-HIST,4930,2.0,Slavery On Film,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,
-HIST,4940,1.0,MiddleEasternSocieties in Film,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,
-HLTH,2020,1.0,Introduction to Public Health,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,2.0,Introduction to Public Health,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,3.0,Introduction to Public Health,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,2020,4.0,Introduction to Public Health,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2020,5.0,Introduction to Public Health,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2020,400.0,Introduction to Public Health,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,402.0,Introduction to Public Health,0.48,0.48,0.0,0.05,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2030,1.0,Health Care Sys,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2030,2.0,Health Care Sys,0.52,0.36,0.12,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2030,400.0,Health Care Sys,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2400,1.0,Deter of Hlth Behav,0.5,0.38,0.08,0.04,0.0,0.0,0.0,0.0,amelia beasley clinkscales,
-HLTH,2400,2.0,Deter of Hlth Behav,0.6,0.28,0.08,0.0,0.0,0.0,0.0,0.04,amelia beasley clinkscales,
-HLTH,2400,4.0,Deter of Hlth Behav,0.85,0.12,0.0,0.0,0.04,0.0,0.0,0.0,karyn jones,
-HLTH,2600,1.0,Medical Terminology & Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,
-HLTH,2600,3.0,Medical Terminology & Comm,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,karen edwards,
-HLTH,2980,1.0,Human Health and Disease,0.41,0.51,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,2980,2.0,Human Health and Disease,0.63,0.29,0.06,0.03,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,3030,1.0,Public Health Comm,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,debra mitchell charles,
-HLTH,3400,1.0,Hlth Prom Prog Plan,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,johnny long,
-HLTH,3610,1.0,Int Health Care Econ,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,khoa dang truong,
-HLTH,3800,1.0,Epidemiology,0.51,0.4,0.06,0.0,0.0,0.0,0.0,0.03,hugh donald spitler,
-HLTH,3800,2.0,Epidemiology,0.54,0.43,0.03,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,3800,3.0,Epidemiology,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,lu zhang,
-HLTH,3800,400.0,Epidemiology,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,3980,1.0,Health Appraisal Skills,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,3980,2.0,Health Appraisal Skills,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4190,1.0,Health Sci Internship Prep Sem,0.51,0.39,0.07,0.02,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4200,1.0,Hlth Science Intern,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4400,1.0,Manag Hlth Serv Org,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,kathleen buford cartmell,
-HLTH,4750,1.0,Hlthcr Oper Mgmt Res,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,lu shi,
-HLTH,4900,2.0,Res Eval St Pub Hlth,0.32,0.48,0.16,0.0,0.04,0.0,0.0,0.0,karen kemper,
-HLTH,4900,3.0,Res Eval St Pub Hlth,0.44,0.48,0.04,0.0,0.0,0.0,0.0,0.04,jeffrey kingree,
-HLTH,8120,400.0,Clinical and Translational Sci,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald gimbel,
-HLTH,8900,2.0,GIS in Public Health,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,patricia carbajales-dale,
-HON,1920,1.0,Positively Human,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,june pilcher,True
-HON,1920,2.0,NSP First-Year Seminar,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sarah evelyn winslow,True
-HON,2020,1.0,Who Decides What's Cool?,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,amanda cooper fine,True
-HON,2020,2.0,World of Ideas,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True
-HON,2020,3.0,Communism and the Berlin Wall,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,michael meng,True
-HON,2020,4.0,Sexual Health of CU students,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,bruce michael king,True
-HON,2060,4.0,Why We Eat What We Eat,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,elizabeth lacey durrance,True
-HON,2210,3.0,The Cultural Work of Comics,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True
-HORT,1010,1.0,Horticulture,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HORT,2020,1.0,Adobe Digital Design,0.75,0.13,0.03,0.03,0.0,0.0,0.0,0.06,janice ann lay,
-HORT,2120,1.0,Turfgrass Culture,0.77,0.16,0.03,0.0,0.03,0.0,0.0,0.0,haibo liu,
-HORT,3030,1.0,Landscape Plants,0.02,0.36,0.29,0.16,0.09,0.0,0.0,0.09,robert polomski,
-HORT,3080,1.0,Sust Landsc Des Install Maint,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HORT,4400,1.0,Hydroponics,0.22,0.39,0.28,0.11,0.0,0.0,0.0,0.0,james emerson faust,
-HP,8090,400.0,Historical Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,katherine saunders pemberton,
-HRD,8300,400.0,Concepts of H R D,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,angela danielle carter,
-HRD,8300,401.0,Concepts of H R D,0.73,0.19,0.04,0.0,0.0,0.0,0.0,0.04,angela danielle carter,
-HRD,8450,400.0,Needs Assess Ed/Ind,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angela danielle carter,
-HRD,8600,400.0,Instruc Mat Devel,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kristin kelly frady,
-IE,2100,1.0,Des Analysis Wrk Sys,0.35,0.48,0.13,0.01,0.01,0.0,0.0,0.01,jeffery messer,
-IE,3010,1.0,Systems Design I,0.45,0.48,0.06,0.0,0.01,0.0,0.0,0.0,shraddhaa narasimha,
-IE,3600,1.0,Industrial Apps of Prob/Stat I,0.25,0.3,0.32,0.11,0.03,0.0,0.0,0.0,mary elizabeth kurz,
-IE,3610,1.0,Industrial App of Prob/Stat II,0.24,0.32,0.22,0.12,0.05,0.0,0.0,0.05,brian melloy,
-IE,3800,1.0,Deterministic Operations Rsrch,0.35,0.35,0.13,0.06,0.07,0.0,0.0,0.04,yongjia song,
-IE,3810,1.0,Probabilistic Operations Rsrch,0.52,0.34,0.1,0.02,0.0,0.0,0.0,0.02,caglar caglayan,
-IE,3840,1.0,Engr Econ Analysis,0.63,0.26,0.09,0.02,0.0,0.0,0.0,0.01,walter lawrence garvin,
-IE,3860,1.0,Production Planning & Control,0.45,0.4,0.1,0.04,0.0,0.0,0.0,0.0,mariah soibhan magagnotti,
-IE,4300,1.0,Human Fact Engr in Healthcare,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,david neyens,
-IE,4400,1.0,Decision Support Sys,0.34,0.52,0.06,0.0,0.05,0.0,0.0,0.03,scott jennings mason,
-IE,4560,1.0,Supply Chain Design & Control,0.14,0.5,0.27,0.0,0.05,0.0,0.0,0.05,william ferrell,
-IE,4610,1.0,Quality Engineering,0.35,0.54,0.07,0.02,0.02,0.0,0.0,0.0,mariah soibhan magagnotti,
-IE,4610,2.0,Quality Engineering,0.45,0.24,0.21,0.03,0.03,0.0,0.0,0.03,di liu,
-IE,4620,1.0,Six Sigma Quality,0.35,0.49,0.11,0.04,0.0,0.0,0.0,0.01,walter lawrence garvin,
-IE,4650,1.0,Facilities Planning & Design,0.4,0.38,0.18,0.03,0.01,0.0,0.0,0.0,william ferrell,
-IE,4670,1.0,System Design II,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,jeffery messer,
-IE,4820,1.0,Systems Modeling,0.06,0.59,0.25,0.03,0.03,0.0,0.0,0.03,kevin taaffe,
-IE,4820,2.0,Systems Modeling,0.44,0.41,0.1,0.05,0.0,0.0,0.0,0.0,kevin taaffe,
-IE,4880,1.0,Human Factors Eng,0.94,0.04,0.02,0.0,0.0,0.0,0.0,0.0,jamiahus durnad walton,
-IE,4880,2.0,Human Factors Eng,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,amro nofan khasawneh,
-IE,6560,1.0,Supply Chain Design & Control,0.57,0.32,0.11,0.0,0.0,0.0,0.0,0.0,william ferrell,
-IE,6820,1.0,Systems Modeling,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,kevin taaffe,
-IE,8000,1.0,Human Factors Eng,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,david neyens,
-IE,8020,1.0,Human Comp Sys,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,
-IE,8030,1.0,Engr Optimization and Apps,0.27,0.33,0.33,0.0,0.07,0.0,0.0,0.0,scott jennings mason,
-IE,8090,1.0,Model Sys Under Risk,0.83,0.06,0.11,0.0,0.0,0.0,0.0,0.0,yongjia song,
-IE,8530,1.0,Foundations of Quality,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,robert james riggs,
-IE,8550,1.0,SC & Logistics Modeling II,0.88,0.09,0.0,0.0,0.03,0.0,0.0,0.0,kevin taaffe,
-INT,1510,1.0,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,lisa marie robinson,
-INT,1540,1.0,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.89,0.0,0.11,caren kelley-hall,
-ITAL,1010,1.0,Elementary Italian,0.36,0.36,0.09,0.0,0.0,0.0,0.0,0.18,julia schmidt,
-ITAL,1010,2.0,Elementary Italian,0.42,0.26,0.21,0.0,0.05,0.0,0.0,0.05,julia schmidt,
-ITAL,1010,3.0,Elementary Italian,0.46,0.31,0.08,0.08,0.0,0.0,0.0,0.08,julia schmidt,
-ITAL,1020,1.0,Elementary Italian,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,julia schmidt,
-ITAL,2010,1.0,Intermediate Italian,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
-ITAL,2010,2.0,Intermediate Italian,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,
-ITAL,2020,1.0,Intermediate Italian,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,
-JAPN,1010,1.0,Elementary Japanese,0.53,0.12,0.12,0.0,0.12,0.0,0.0,0.12,satomi saito,
-JAPN,1010,2.0,Elementary Japanese,0.44,0.25,0.19,0.0,0.13,0.0,0.0,0.0,satomi saito,
-JAPN,1010,3.0,Elementary Japanese,0.33,0.17,0.25,0.0,0.17,0.0,0.0,0.08,satomi saito,
-JAPN,1020,1.0,Elementary Japanese,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,satomi saito,
-JAPN,2010,3.0,Intermed Japanese,0.42,0.31,0.04,0.12,0.04,0.0,0.0,0.08,jae allegra dibello takeuchi,
-JAPN,4060,1.0,Intro to Japanese Literature,0.73,0.18,0.0,0.09,0.0,0.0,0.0,0.0,kumiko saito,
-JAPN,4990,1.0,Sel Topics in Japanese Culture,0.79,0.07,0.07,0.07,0.0,0.0,0.0,0.0,kumiko saito,
-JUST,2880,1.0,The Criminal Justice System,0.38,0.27,0.21,0.02,0.1,0.0,0.0,0.01,margaret tina britz,
-JUST,2890,1.0,Criminology,0.51,0.36,0.11,0.0,0.02,0.0,0.0,0.0,bryan lee miller,
-JUST,4290,1.0,Justice Administration,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,rhys hester,
-JUST,4680,1.0,Criminal Evidence,0.43,0.22,0.26,0.04,0.04,0.0,0.0,0.02,margaret tina britz,
-JUST,4860,1.0,CI in CJ: Gangsterism in Film,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,margaret tina britz,
-JUST,4910,1.0,Policing,0.81,0.1,0.04,0.0,0.02,0.0,0.0,0.04,shelagh dorn,
-JUST,4920,1.0,Justice Leadership Practicum,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,margaret tina britz,
-JUST,4930,1.0,Corrections,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,bryan lee miller,
-JUST,4990,1.0,Race and Crime,0.69,0.08,0.15,0.0,0.0,0.0,0.0,0.08,brian chad starks,
-JUST,4990,2.0,Intro to Forensic Science,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,tiffany brianne hezel edwards,
-JUST,4990,3.0,Homeland Security/Intelligence,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,shelagh dorn,
-LAIB,1270,1.0,Intro to Lang & Int'l Business,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06, lee ferrell,
-LARC,1150,1.0,Intro Landscape Architecture,0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,jueminsi wu,
-LARC,1280,1.0,Technical Graphics,0.48,0.38,0.05,0.05,0.0,0.0,0.0,0.05,matthew neal powers,
-LARC,1510,1.0,Basic Design I,0.48,0.38,0.05,0.05,0.0,0.0,0.0,0.05,matthew neal powers,
-LARC,2510,1.0,Larch Design Fund,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,
-LARC,2620,1.0,Design Implementation I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,
-LARC,3510,1.0,Regional Design,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,lara margaret mutel browning,
-LARC,4530,1.0,Key Issues in Landscape Arch,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,
-LARC,4620,1.0,Design Implementation III,0.26,0.37,0.16,0.11,0.0,0.0,0.0,0.11,paul russell,
-LARC,4970,1.0,Plants in the Landscape,0.52,0.3,0.09,0.0,0.09,0.0,0.0,0.0,lara margaret mutel browning,
-LAW,3220,1.0,Legal Env of Bus,0.15,0.46,0.3,0.04,0.02,0.0,0.0,0.02,kenneth scott toussaint,
-LAW,3220,2.0,Legal Env of Bus,0.24,0.3,0.37,0.09,0.0,0.0,0.0,0.0,kenneth scott toussaint,
-LAW,3220,3.0,Legal Env of Bus,0.3,0.52,0.15,0.0,0.02,0.0,0.0,0.0,kathryn kisska-schulze,
-LAW,3220,4.0,Legal Env of Bus,0.36,0.51,0.13,0.0,0.0,0.0,0.0,0.0,kathryn kisska-schulze,
-LAW,3220,5.0,Legal Env of Bus,0.53,0.38,0.09,0.0,0.0,0.0,0.0,0.0,christopher michael edwards,
-LAW,3220,6.0,Legal Env of Bus,0.43,0.43,0.15,0.0,0.0,0.0,0.0,0.0,kathryn kisska-schulze,
-LAW,3220,7.0,Legal Env of Bus,0.64,0.26,0.06,0.0,0.0,0.0,0.0,0.04,christopher michael edwards,
-LAW,3220,8.0,Legal Env of Bus,0.33,0.48,0.17,0.0,0.0,0.0,0.0,0.02,edward ray claggett,
-LAW,3220,9.0,Legal Env of Bus,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,10.0,Legal Env of Bus,0.23,0.49,0.26,0.02,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,11.0,Legal Env of Bus,0.26,0.48,0.17,0.04,0.0,0.0,0.0,0.04,john hine,
-LAW,3220,400.0,Legal Env of Bus,0.34,0.34,0.15,0.11,0.02,0.0,0.0,0.03,virginia ls ward-vaughn,
-LAW,3220,401.0,Legal Env of Bus,0.24,0.39,0.2,0.07,0.03,0.0,0.0,0.07,virginia ls ward-vaughn,
-LAW,3220,402.0,Legal Env of Bus,0.33,0.45,0.1,0.03,0.0,0.0,0.0,0.09,virginia ls ward-vaughn,
-LAW,3220,403.0,Legal Env of Bus,0.26,0.48,0.18,0.05,0.02,0.0,0.0,0.02,virginia ls ward-vaughn,
-LAW,3220,404.0,Legal Env of Bus,0.31,0.46,0.17,0.06,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3330,1.0,Real Estate Law,0.05,0.36,0.23,0.27,0.09,0.0,0.0,0.0,kenneth scott toussaint,
-LAW,3330,2.0,Real Estate Law,0.18,0.36,0.3,0.03,0.06,0.0,0.0,0.06,kenneth scott toussaint,
-LAW,4050,1.0,Construction Law,0.58,0.27,0.09,0.0,0.0,0.0,0.0,0.06,frances edwards,
-LS,1000,2.0,Therapeutic Yoga,0.59,0.32,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dilipkumar amin,
-LS,1000,3.0,Therapeutic Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,1000,4.0,Introduction to Barre,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,1000,5.0,Introduction to Barre,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,1000,8.0,Intro to Volleyball,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,kelly lynn ator,
-LS,1000,10.0,FItness Leadership,0.58,0.08,0.08,0.0,0.0,0.0,0.0,0.25,jenny lynn rodgers,
-LS,1000,14.0,Introduction to Barre,0.73,0.13,0.13,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,1000,30.0,Stand up Pabbleboarding,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,merry hannah armstrong,
-LS,1410,1.0,Top Rope Climbing,0.73,0.07,0.0,0.07,0.13,0.0,0.0,0.0,thomas caldwell,
-LS,1410,3.0,Top Rope Climbing,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,thomas caldwell,
-LS,1560,4.0,Riflery,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,hubert cox,
-LS,1560,10.0,Riflery,0.7,0.0,0.0,0.0,0.1,0.0,0.0,0.2,douglas bonham stephens,
-LS,1560,13.0,Riflery,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,herbert wayne strickland,
-LS,1650,3.0,Inland Kayak Touring,0.82,0.0,0.09,0.0,0.09,0.0,0.0,0.0,merry hannah armstrong,
-LS,1850,1.0,Bowling,0.8,0.07,0.07,0.0,0.07,0.0,0.0,0.0,madison neely workman,
-LS,1850,2.0,Bowling,0.85,0.07,0.04,0.0,0.0,0.0,0.0,0.04,madison neely workman,
-LS,1850,3.0,Bowling,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.04,madison neely workman,
-LS,1850,7.0,Bowling,0.87,0.04,0.0,0.0,0.04,0.0,0.0,0.04,madison neely workman,
-LS,1850,8.0,Bowling,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,megan elizabeth cato,
-LS,1850,9.0,Bowling,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,angela rowan,
-LS,1850,10.0,Bowling,0.9,0.0,0.0,0.0,0.03,0.0,0.0,0.07,angela rowan,
-LS,1980,3.0,Golf,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,wesley scott womble,
-LS,1980,7.0,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,wesley scott womble,
-LS,2270,1.0,Intro to Swing Dance,0.88,0.0,0.04,0.0,0.0,0.0,0.0,0.08,paul hoke,
-LS,2270,2.0,Intro to Swing Dance,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,paul hoke,
-LS,2270,3.0,Intro to Swing Dance,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,
-LS,2320,1.0,Core Training,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,diane moreno,
-LS,2320,2.0,Core Training,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,
-LS,2320,3.0,Core Training,0.5,0.23,0.14,0.0,0.0,0.0,0.0,0.14,diane moreno,
-LS,2350,1.0,Basic Yoga,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2380,2.0,Vinyasa Flow Yoga,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,nicole elizabeth martinez,
-LS,2420,1.0,Meditation and Relax,0.83,0.04,0.0,0.04,0.04,0.0,0.0,0.04,renee warren gahan,
-LS,2420,2.0,Meditation and Relax,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2420,3.0,Meditation and Relax,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dilipkumar amin,
-LS,2420,4.0,Meditation and Relax,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.09,ranjanbala dilipkumar amin,
-LS,2420,5.0,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dilipkumar amin,
-LS,2420,6.0,Meditation and Relax,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dilipkumar amin,
-LS,2420,7.0,Meditation and Relax,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,cara jill wrenn,
-LS,2450,1.0,Pilates,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,melanie ivey job,
-LS,2450,4.0,Pilates,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,
-LS,2450,6.0,Pilates,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,melanie ivey job,
-LS,2510,2.0,Running & Jogging,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,corey douglas brookover,
-LS,2700,1.0,Sports Officiating,0.64,0.0,0.09,0.0,0.0,0.0,0.0,0.27,christopher warren cox,
-LS,2750,3.0,First Aid/Cpr,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,christopher michael loomis,
-LS,2750,7.0,First Aid/Cpr,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,christopher michael loomis,
-LS,2750,8.0,First Aid/Cpr,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,christopher michael loomis,
-LS,3560,2.0,Riflery II,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,hubert cox,
-MATH,1010,1.0,Essen Math for Informed Soc,0.53,0.18,0.18,0.06,0.0,0.0,0.0,0.06,alexander joyce,
-MATH,1010,3.0,Essen Math for Informed Soc,0.45,0.36,0.1,0.07,0.0,0.0,0.0,0.02,judith elaine cottingham,
-MATH,1010,4.0,Essen Math for Informed Soc,0.42,0.21,0.21,0.16,0.0,0.0,0.0,0.0,philip de castro,
-MATH,1010,6.0,Essen Math for Informed Soc,0.3,0.38,0.11,0.11,0.05,0.0,0.0,0.05,judith elaine cottingham,
-MATH,1010,7.0,Essen Math for Informed Soc,0.38,0.5,0.08,0.03,0.0,0.0,0.0,0.03,judith elaine cottingham,
-MATH,1010,8.0,Essen Math for Informed Soc,0.14,0.5,0.07,0.21,0.0,0.0,0.0,0.07,philip de castro,
-MATH,1010,9.0,Essen Math for Informed Soc,0.56,0.28,0.06,0.0,0.06,0.0,0.0,0.06,alexander joyce,
-MATH,1020,1.0,Business Calculus I,0.28,0.28,0.28,0.11,0.0,0.0,0.0,0.06,andrew bellucco,
-MATH,1020,2.0,Business Calculus I,0.33,0.22,0.22,0.0,0.11,0.0,0.0,0.11,andrew bellucco,
-MATH,1020,3.0,Business Calculus I,0.37,0.21,0.26,0.11,0.0,0.0,0.0,0.05,tilly grace erwin,
-MATH,1020,4.0,Business Calculus I,0.56,0.19,0.06,0.13,0.0,0.0,0.0,0.06,tilly grace erwin,
-MATH,1020,5.0,Business Calculus I,0.27,0.4,0.13,0.13,0.07,0.0,0.0,0.0,eva murphy,
-MATH,1020,6.0,Business Calculus I,0.22,0.56,0.11,0.06,0.06,0.0,0.0,0.0,eva murphy,
-MATH,1020,7.0,Business Calculus I,0.17,0.22,0.28,0.22,0.0,0.0,0.0,0.11,michael glen eldredge,
-MATH,1020,8.0,Business Calculus I,0.35,0.12,0.18,0.18,0.12,0.0,0.0,0.06,michael glen eldredge,
-MATH,1020,9.0,Business Calculus I,0.39,0.22,0.06,0.06,0.17,0.0,0.0,0.11,tyler sullivan,
-MATH,1020,10.0,Business Calculus I,0.39,0.17,0.06,0.17,0.06,0.0,0.0,0.17,tyler sullivan,
-MATH,1020,11.0,Business Calculus I,0.28,0.33,0.17,0.0,0.06,0.0,0.0,0.17,david luke frost,
-MATH,1020,12.0,Business Calculus I,0.11,0.28,0.17,0.11,0.11,0.0,0.0,0.22,david luke frost,
-MATH,1020,13.0,Business Calculus I,0.21,0.26,0.47,0.0,0.0,0.0,0.0,0.05,yunan wang,
-MATH,1020,14.0,Business Calculus I,0.37,0.37,0.21,0.0,0.0,0.0,0.0,0.05,yunan wang,
-MATH,1020,15.0,Business Calculus I,0.14,0.43,0.36,0.07,0.0,0.0,0.0,0.0,daozhou zhu,
-MATH,1020,16.0,Business Calculus I,0.17,0.42,0.17,0.17,0.08,0.0,0.0,0.0,daozhou zhu,
-MATH,1020,17.0,Business Calculus I,0.08,0.35,0.2,0.13,0.15,0.0,0.0,0.1,neil calkin,
-MATH,1020,19.0,Business Calculus I,0.17,0.28,0.39,0.11,0.0,0.0,0.0,0.06,dominique evelyn forbes,
-MATH,1020,20.0,Business Calculus I,0.26,0.21,0.32,0.11,0.11,0.0,0.0,0.0,dominique evelyn forbes,
-MATH,1020,21.0,Business Calculus I,0.47,0.12,0.24,0.12,0.06,0.0,0.0,0.0,michael thomas cowen,
-MATH,1020,22.0,Business Calculus I,0.39,0.33,0.11,0.11,0.0,0.0,0.0,0.06,michael thomas cowen,
-MATH,1020,23.0,Business Calculus I,0.16,0.26,0.21,0.21,0.0,0.0,0.0,0.16,antonio pierrottet,
-MATH,1020,24.0,Business Calculus I,0.33,0.28,0.28,0.11,0.0,0.0,0.0,0.0,antonio pierrottet,
-MATH,1020,25.0,Business Calculus I,0.33,0.28,0.22,0.06,0.06,0.0,0.0,0.06,hossein faridian,
-MATH,1020,26.0,Business Calculus I,0.13,0.5,0.19,0.0,0.06,0.0,0.0,0.13,hossein faridian,
-MATH,1020,27.0,Business Calculus I,0.17,0.5,0.11,0.17,0.0,0.0,0.0,0.06,shanshan jia,
-MATH,1020,28.0,Business Calculus I,0.33,0.28,0.22,0.06,0.06,0.0,0.0,0.06,morgan elston,
-MATH,1020,29.0,Business Calculus I,0.25,0.31,0.13,0.06,0.19,0.0,0.0,0.06,morgan elston,
-MATH,1020,30.0,Business Calculus I,0.28,0.44,0.11,0.0,0.06,0.0,0.0,0.11,michael byrd,
-MATH,1020,31.0,Business Calculus I,0.22,0.5,0.22,0.0,0.0,0.0,0.0,0.06,michael byrd,
-MATH,1020,32.0,Business Calculus I,0.22,0.22,0.17,0.0,0.22,0.0,0.0,0.17,michael nelson,
-MATH,1020,33.0,Business Calculus I,0.24,0.24,0.41,0.0,0.06,0.0,0.0,0.06,michael nelson,
-MATH,1020,34.0,Business Calculus I,0.17,0.39,0.17,0.17,0.06,0.0,0.0,0.06,hemanta kunwar,
-MATH,1020,35.0,Business Calculus I,0.41,0.29,0.18,0.0,0.0,0.0,0.0,0.12,hemanta kunwar,
-MATH,1020,36.0,Business Calculus I,0.25,0.31,0.25,0.13,0.0,0.0,0.0,0.06,trinity white,
-MATH,1020,37.0,Business Calculus I,0.17,0.39,0.28,0.11,0.06,0.0,0.0,0.0,trinity white,
-MATH,1020,38.0,Business Calculus I,0.39,0.11,0.22,0.0,0.11,0.0,0.0,0.17,shanshan jia,
-MATH,1020,39.0,Business Calculus I,0.16,0.32,0.26,0.11,0.05,0.0,0.0,0.11,joseph swanson,
-MATH,1020,40.0,Business Calculus I,0.32,0.47,0.11,0.11,0.0,0.0,0.0,0.0,joseph swanson,
-MATH,1020,41.0,Business Calculus I,0.33,0.33,0.17,0.17,0.0,0.0,0.0,0.0,elliott degbe,
-MATH,1020,42.0,Business Calculus I,0.33,0.28,0.17,0.17,0.06,0.0,0.0,0.0,elliott degbe,
-MATH,1020,43.0,Business Calculus I,0.49,0.07,0.29,0.1,0.02,0.0,0.0,0.02,randy davidson,
-MATH,1020,44.0,Business Calculus I,0.26,0.36,0.18,0.15,0.05,0.0,0.0,0.0,randy davidson,
-MATH,1020,201.0,Business Calculus I,0.67,0.2,0.07,0.03,0.0,0.0,0.0,0.03,jennifer van dyken,
-MATH,1020,202.0,Business Calculus I,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,marion hanna,
-MATH,1040,1.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,donna simms,
-MATH,1040,3.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,anna caroline bachstein,
-MATH,1040,4.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,aaron moose,
-MATH,1040,5.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,todd anthony morra,
-MATH,1040,6.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,ryann rose cartor,
-MATH,1040,9.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.93,0.0,0.07,zachary david espe,
-MATH,1040,10.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,tony william long,
-MATH,1050,402.0,Precalculus,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.12,tony thanh nguyen,
-MATH,1050,403.0,Precalculus,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,tony thanh nguyen,
-MATH,1060,1.0,Calculus of One Variable I,0.31,0.24,0.19,0.05,0.12,0.0,0.0,0.1,catherine mary kenyon,
-MATH,1060,2.0,Calculus of One Variable I,0.35,0.33,0.14,0.02,0.07,0.0,0.0,0.09,james edward gossell,
-MATH,1060,3.0,Calculus of One Variable I,0.29,0.37,0.12,0.07,0.07,0.0,0.0,0.07,marvin clayton jones,
-MATH,1060,4.0,Calculus of One Variable I,0.29,0.37,0.08,0.0,0.18,0.0,0.0,0.08,sofya alekseeva,
-MATH,1060,5.0,Calculus of One Variable I,0.14,0.31,0.34,0.06,0.09,0.0,0.0,0.06,sofya alekseeva,
-MATH,1060,7.0,Calculus of One Variable I,0.32,0.29,0.2,0.0,0.12,0.0,0.0,0.07,scott scruggs,
-MATH,1060,8.0,Calculus of One Variable I,0.14,0.25,0.19,0.08,0.13,0.0,0.0,0.2,chad robert mangum,
-MATH,1060,10.0,Calculus of One Variable I,0.14,0.26,0.3,0.04,0.12,0.0,0.0,0.15,chad robert mangum,
-MATH,1060,12.0,Calculus of One Variable I,0.38,0.35,0.09,0.0,0.09,0.0,0.0,0.09,jason alexander kurz,
-MATH,1060,13.0,Calculus of One Variable I,0.26,0.36,0.15,0.05,0.13,0.0,0.0,0.05,nathan fontes,
-MATH,1060,14.0,Calculus of One Variable I,0.27,0.3,0.1,0.0,0.17,0.0,0.0,0.17,akshay sunil gupte,
-MATH,1060,201.0,Calculus of One Variable I,0.34,0.27,0.22,0.05,0.1,0.0,0.0,0.02,stephen peele,
-MATH,1060,202.0,Calculus of One Variable I,0.41,0.19,0.28,0.0,0.09,0.0,0.0,0.03,hugh geller,
-MATH,1060,203.0,Calculus of One Variable I,0.25,0.29,0.29,0.08,0.04,0.0,0.0,0.04,sofya alekseeva,
-MATH,1060,204.0,Calculus of One Variable I,0.44,0.29,0.13,0.04,0.09,0.0,0.0,0.0,stephen peele,
-MATH,1060,206.0,Calculus of One Variable I,0.45,0.28,0.18,0.05,0.0,0.0,0.0,0.05,peter westerbaan,
-MATH,1060,300.0,Calculus of One Variable I,0.29,0.29,0.24,0.0,0.1,0.0,0.0,0.1,matthew macauley,
-MATH,1070,1.0,Differen and Integral Calculus,0.0,0.15,0.6,0.1,0.1,0.0,0.0,0.05,donna simms,
-MATH,1080,1.0,Calculus of One Variable II,0.25,0.22,0.19,0.06,0.16,0.0,0.0,0.12,meredith nicole burr,
-MATH,1080,2.0,Calculus of One Variable II,0.23,0.23,0.18,0.1,0.21,0.0,0.0,0.05,blake anthony splitter,
-MATH,1080,3.0,Calculus of One Variable II,0.3,0.24,0.22,0.0,0.19,0.0,0.0,0.05,fei xue,
-MATH,1080,4.0,Calculus of One Variable II,0.15,0.26,0.11,0.07,0.19,0.0,0.0,0.22,terri johnson,
-MATH,1080,5.0,Calculus of One Variable II,0.14,0.11,0.31,0.11,0.22,0.0,0.0,0.11,terri johnson,
-MATH,1080,6.0,Calculus of One Variable II,0.15,0.28,0.23,0.03,0.25,0.0,0.0,0.08,fei xue,
-MATH,1080,7.0,Calculus of One Variable II,0.2,0.16,0.2,0.04,0.24,0.0,0.0,0.16,terri johnson,
-MATH,1080,201.0,Calculus of One Variable II,0.33,0.44,0.11,0.0,0.11,0.0,0.0,0.0,mark cawood,
-MATH,1150,1.0,Contemp Math for Elem Teach I,0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,angel carreras jusino,
-MATH,1150,2.0,Contemp Math for Elem Teach I,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,eliza dargan gallagher,
-MATH,1150,3.0,Contemp Math for Elem Teach I,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,angel carreras jusino,
-MATH,2060,1.0,Calculus of Several Variables,0.23,0.32,0.28,0.1,0.05,0.0,0.0,0.02,irina viktorova,
-MATH,2060,2.0,Calculus of Several Variables,0.12,0.38,0.31,0.05,0.09,0.0,0.0,0.05,irina viktorova,
-MATH,2060,3.0,Calculus of Several Variables,0.32,0.34,0.15,0.1,0.03,0.0,0.0,0.06,oleg yordanov,
-MATH,2060,4.0,Calculus of Several Variables,0.34,0.39,0.17,0.02,0.02,0.0,0.0,0.05,oleg yordanov,
-MATH,2060,5.0,Calculus of Several Variables,0.25,0.29,0.27,0.08,0.08,0.0,0.0,0.03,timothy charles teitloff,
-MATH,2060,6.0,Calculus of Several Variables,0.25,0.41,0.23,0.05,0.04,0.0,0.0,0.02,timothy charles teitloff,
-MATH,2060,7.0,Calculus of Several Variables,0.51,0.44,0.04,0.0,0.0,0.0,0.0,0.0,nantsoina ramiharimanana,
-MATH,2060,8.0,Calculus of Several Variables,0.27,0.25,0.14,0.14,0.05,0.0,0.0,0.16,timothy franklin parrott,
-MATH,2060,9.0,Calculus of Several Variables,0.18,0.3,0.13,0.05,0.2,0.0,0.0,0.15,timothy franklin parrott,
-MATH,2060,10.0,Calculus of Several Variables,0.38,0.3,0.15,0.06,0.11,0.0,0.0,0.0,allen anderson guest,
-MATH,2060,100.0,Calc of Several Vars (HON),0.8,0.16,0.02,0.0,0.02,0.0,0.0,0.0,yuyuan ouyang,True
-MATH,2060,201.0,Calculus of Several Variables,0.38,0.33,0.23,0.0,0.0,0.0,0.0,0.08,allen anderson guest,
-MATH,2060,202.0,Calculus of Several Variables,0.47,0.3,0.07,0.1,0.07,0.0,0.0,0.0,allen anderson guest,
-MATH,2070,1.0,Business Calculus II,0.29,0.24,0.18,0.18,0.0,0.0,0.0,0.12,nathaniel nemire,
-MATH,2070,2.0,Business Calculus II,0.37,0.11,0.21,0.11,0.16,0.0,0.0,0.05,nathaniel nemire,
-MATH,2070,3.0,Business Calculus II,0.22,0.22,0.11,0.22,0.11,0.0,0.0,0.11,ebenezer eduafo,
-MATH,2070,4.0,Business Calculus II,0.11,0.0,0.39,0.33,0.11,0.0,0.0,0.06,ebenezer eduafo,
-MATH,2070,5.0,Business Calculus II,0.05,0.32,0.26,0.26,0.05,0.0,0.0,0.05,haodong li,
-MATH,2070,6.0,Business Calculus II,0.19,0.06,0.19,0.13,0.06,0.0,0.0,0.38,haodong li,
-MATH,2070,7.0,Business Calculus II,0.48,0.27,0.16,0.05,0.0,0.0,0.0,0.05,jennifer marie hanna,
-MATH,2070,8.0,Business Calculus II,0.36,0.41,0.09,0.05,0.0,0.0,0.0,0.09,jennifer marie hanna,
-MATH,2070,9.0,Business Calculus II,0.55,0.25,0.07,0.05,0.02,0.0,0.0,0.07,jennifer marie hanna,
-MATH,2070,10.0,Business Calculus II,0.47,0.09,0.24,0.16,0.02,0.0,0.0,0.02,jennifer marie hanna,
-MATH,2070,11.0,Business Calculus II,0.33,0.32,0.15,0.09,0.03,0.0,0.0,0.07,jennifer ray newton,
-MATH,2070,12.0,Business Calculus II,0.29,0.25,0.31,0.09,0.03,0.0,0.0,0.03,jennifer ray newton,
-MATH,2070,13.0,Business Calculus II,0.35,0.18,0.29,0.06,0.06,0.0,0.0,0.06,travis alvarez,
-MATH,2070,14.0,Business Calculus II,0.26,0.21,0.26,0.16,0.0,0.0,0.0,0.11,travis alvarez,
-MATH,2080,1.0,Intro to Ordin Diff Equations,0.16,0.28,0.28,0.05,0.08,0.0,0.0,0.14,jeong rock yoon,
-MATH,2080,2.0,Intro to Ordin Diff Equations,0.1,0.2,0.3,0.17,0.13,0.0,0.0,0.1,julie lassiter,
-MATH,2080,3.0,Intro to Ordin Diff Equations,0.19,0.27,0.22,0.16,0.05,0.0,0.0,0.11,julie lassiter,
-MATH,2080,4.0,Intro to Ordin Diff Equations,0.5,0.38,0.08,0.0,0.03,0.0,0.0,0.03,nantsoina ramiharimanana,
-MATH,2080,5.0,Intro to Ordin Diff Equations,0.26,0.34,0.09,0.11,0.14,0.0,0.0,0.06,timothy franklin parrott,
-MATH,2160,1.0,Geometry for Elem Sch Teachers,0.89,0.05,0.0,0.03,0.03,0.0,0.0,0.0,nicole alaine bannister sinwell,
-MATH,2160,2.0,Geometry for Elem Sch Teachers,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,nicole alaine bannister sinwell,
-MATH,3020,2.0,Stat for Science & Engineering,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,qiong zhang,
-MATH,3020,3.0,Stat for Science & Engineering,0.67,0.25,0.06,0.0,0.03,0.0,0.0,0.0,xiaoqian sun,
-MATH,3020,4.0,Stat for Science & Engineering,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,kayla doris javier,
-MATH,3020,5.0,Stat for Science & Engineering,0.58,0.26,0.11,0.05,0.0,0.0,0.0,0.0,kayla doris javier,
-MATH,3020,6.0,Stat for Science & Engineering,0.47,0.32,0.16,0.0,0.05,0.0,0.0,0.0,todd fenstermacher,
-MATH,3020,7.0,Stat for Science & Engineering,0.26,0.58,0.05,0.05,0.0,0.0,0.0,0.05,todd fenstermacher,
-MATH,3020,8.0,Stat for Science & Engineering,0.26,0.26,0.26,0.05,0.16,0.0,0.0,0.0,zhiyun gong,
-MATH,3020,9.0,Stat for Science & Engineering,0.39,0.19,0.22,0.08,0.06,0.0,0.0,0.06,zhiyun gong,
-MATH,3020,10.0,Stat for Science & Engineering,0.35,0.29,0.18,0.03,0.09,0.0,0.0,0.06,zhiyun gong,
-MATH,3020,13.0,Stat for Science & Engineering,0.23,0.51,0.11,0.09,0.03,0.0,0.0,0.03,xiaoqian sun,
-MATH,3020,14.0,Stat for Science & Engineering,0.31,0.29,0.34,0.0,0.06,0.0,0.0,0.0,ellen hepfer breazel,
-MATH,3110,1.0,Linear Algebra,0.25,0.5,0.21,0.02,0.0,0.0,0.0,0.02,wayne goddard,
-MATH,3110,2.0,Linear Algebra,0.31,0.42,0.25,0.0,0.0,0.0,0.0,0.02,wayne goddard,
-MATH,3110,4.0,Linear Algebra,0.38,0.35,0.15,0.08,0.02,0.0,0.0,0.01,beth novick,
-MATH,3110,5.0,Linear Algebra,0.34,0.26,0.16,0.11,0.13,0.0,0.0,0.0,svetlana poznanovikj,
-MATH,3110,6.0,Linear Algebra,0.27,0.24,0.27,0.11,0.11,0.0,0.0,0.0,svetlana poznanovikj,
-MATH,3110,7.0,Linear Algebra,0.48,0.36,0.11,0.02,0.0,0.0,0.0,0.02,neil calkin,
-MATH,3110,100.0,Linear Algebra (HON),0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,michael adam burr,True
-MATH,3190,1.0,Introduction to Proof,0.48,0.29,0.19,0.0,0.05,0.0,0.0,0.0,michael adam burr,
-MATH,3190,2.0,Introduction to Proof,0.3,0.26,0.3,0.0,0.04,0.0,0.0,0.09,james barker coykendall,
-MATH,3600,1.0,Intermediate Math Computing,0.73,0.15,0.06,0.04,0.02,0.0,0.0,0.0,mark cawood,
-MATH,3650,1.0,Numerical Mthds for Engineers,0.14,0.25,0.39,0.06,0.13,0.0,0.0,0.03,eleanor jenkins,
-MATH,3650,2.0,Numerical Mthds for Engineers,0.17,0.42,0.19,0.04,0.04,0.0,0.0,0.15,vincent ervin,
-MATH,3650,3.0,Numerical Mthds for Engineers,0.46,0.36,0.1,0.03,0.03,0.0,0.0,0.03,sibusiso samkele mabuza,
-MATH,3990,1.0,Creative Inquiry in Math,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,irina viktorova,
-MATH,4000,1.0,Theory of Probability,0.22,0.26,0.37,0.04,0.04,0.0,0.0,0.07,brian fralix,
-MATH,4000,2.0,Theory of Probability,0.28,0.5,0.11,0.08,0.03,0.0,0.0,0.0,peter kiessler,
-MATH,4020,1.0,Stat for Sci & Engineering II,0.55,0.0,0.09,0.18,0.0,0.0,0.0,0.18,derek brown,
-MATH,4070,1.0,Regress & Time-Series Analysis,0.5,0.2,0.0,0.1,0.0,0.0,0.0,0.2,robert lund,
-MATH,4120,1.0,Algebra I,0.59,0.14,0.05,0.0,0.09,0.0,0.0,0.14,matthew macauley,
-MATH,4120,2.0,Algebra I,0.32,0.37,0.16,0.05,0.05,0.0,0.0,0.05,hui xue,
-MATH,4190,1.0,Discrete Math Structures I,0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,beth novick,
-MATH,4190,2.0,Discrete Math Structures I,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,beth novick,
-MATH,4310,1.0,Theory of Interest,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0, erwin walker,
-MATH,4340,1.0,Adv Engineering Mathematics,0.26,0.47,0.21,0.0,0.03,0.0,0.0,0.03,qingshan chen,
-MATH,4340,2.0,Adv Engineering Mathematics,0.27,0.36,0.18,0.14,0.05,0.0,0.0,0.0,vincent ervin,
-MATH,4350,1.0,Complex Variables,0.45,0.0,0.45,0.0,0.09,0.0,0.0,0.0,shitao liu,
-MATH,4400,1.0,Linear Programming,0.35,0.35,0.27,0.0,0.04,0.0,0.0,0.0,margaret maria wiecek,
-MATH,4410,1.0,Intro to Stochastic Models,0.57,0.14,0.21,0.0,0.07,0.0,0.0,0.0,xin liu,
-MATH,4530,1.0,Advanced Calculus I,0.43,0.26,0.23,0.03,0.06,0.0,0.0,0.0,benjamin jaye,
-MATH,4540,1.0,Advanced Calculus II,0.3,0.3,0.3,0.0,0.0,0.0,0.0,0.1,james peterson,
-MATH,4630,1.0,Real Analysis I,0.47,0.41,0.0,0.0,0.0,0.0,0.0,0.12,shitao liu,
-MATH,4810,1.0,Putnam Seminar,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,neil calkin,
-MATH,6340,1.0,Adv Engineering Mathematics,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
-MATH,8000,1.0,Probability,0.65,0.24,0.0,0.0,0.06,0.0,0.0,0.06,xin liu,
-MATH,8010,1.0,General Linear Hypothesis I,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,derek brown,
-MATH,8050,1.0,Data Analysis,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,brook thayer russell,
-MATH,8070,1.0,Applied Multivariate Analysis,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,
-MATH,8090,1.0,Time Series Analysis,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert lund,
-MATH,8140,1.0,Network Flow Programming,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
-MATH,8170,1.0,Stochastic Mod in Oper Rsrch I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
-MATH,8210,1.0,Linear Analysis,0.52,0.24,0.19,0.0,0.05,0.0,0.0,0.0,mishko mitkovski,
-MATH,8510,1.0,Abstract Algebra I,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,james barker coykendall,
-MATH,8530,1.0,Matrix Analysis,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,xuhong gao,
-MATH,8600,1.0,Intro to Scientific Computing,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,hyesuk lee,
-MATH,8650,1.0,Data Structures,0.46,0.31,0.0,0.0,0.0,0.0,0.0,0.23,timo johannes heister,
-MATH,8850,1.0,Advanced Data Analysis,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,
-MBA,8030,1.0,Stat Analy of Bus Op,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,dee ann wood kivett,
-MBA,8030,2.0,Stat Analy of Bus Op,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william edward kilbourne,
-MBA,8040,20.0,Busin Data An & Stat Computing,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,william edward kilbourne,
-MBA,8060,1.0,Operations Mgt,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MBA,8060,2.0,Operations Mgt,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,george kenneth morgan,
-MBA,8070,1.0,Financial Management,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,
-MBA,8070,2.0,Financial Management,0.55,0.4,0.0,0.0,0.05,0.0,0.0,0.0,george brandon lockhart,
-MBA,8070,20.0,Financial Management,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,
-MBA,8090,1.0,Org Beh & Hum Res Mg,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,thomas joseph zagenczyk,
-MBA,8090,2.0,Org Beh & Hum Res Mg,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,thomas joseph zagenczyk,
-MBA,8090,3.0,Org Beh & Hum Res Mg,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,thomas joseph zagenczyk,
-MBA,8180,20.0,Intro Business Intell & Anlytc,0.83,0.14,0.0,0.0,0.0,0.0,0.0,0.03,john frederick tripp,
-MBA,8190,2.0,Intro to Acc and Fin,0.48,0.45,0.07,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,
-MBA,8190,3.0,Intro to Acc and Fin,0.09,0.45,0.14,0.0,0.14,0.0,0.0,0.18,jeffrey mcmillan,
-MBA,8290,1.0,Marketing Foundation,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ankita bakre,
-MBA,8310,10.0,Communications and Sales,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,
-MBA,8370,1.0,Legal Environ of Bus,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8370,2.0,Legal Environ of Bus,0.34,0.57,0.06,0.0,0.0,0.0,0.0,0.03,judson jahn,
-MBA,8400,1.0,Entrepreneurship & Venture Mgt,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,prashant prabhu,
-MBA,8410,1.0,Real Estate Finance,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,ryan dietz,
-MBA,8430,1.0,Entrepreneurial Accounting,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,annieka philo,
-MBA,8440,1.0,Entrepreneurial Law,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john hine,
-MBA,8480,1.0,Entrpr Mkting & Digital Strat,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,bruce snyder,
-MBA,8480,5.0,Entrpr Mkting & Digital Strat,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,
-MBA,8490,5.0,Entrepreneurial Strategy,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,matthew charles klein,
-MBA,8510,1.0,Bus Operations & Logistics,0.25,0.56,0.13,0.0,0.0,0.0,0.0,0.06, sridharan,
-MBA,8540,2.0,Managerial Accounting,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.03,emily suzanne mccorkle,
-MBA,8590,1.0,Mgr Decision Model,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,james turner,
-MBA,8590,2.0,Mgr Decision Model,0.29,0.42,0.08,0.0,0.0,0.0,0.0,0.21,magda gabriela sava,
-MBA,8590,3.0,Mgr Decision Model,0.31,0.38,0.13,0.0,0.03,0.0,0.0,0.16,magda gabriela sava,
-MBA,8600,2.0,Advanced Marketing Strategy,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,joseph renato gibson,
-MBA,8610,2.0,Information Systems,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,william kettinger,
-MBA,8620,1.0,Managerial Economics,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,scott templeton,
-MBA,8620,2.0,Managerial Economics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,
-MBA,8620,4.0,Managerial Economics,0.56,0.36,0.04,0.0,0.0,0.0,0.0,0.04,ronald earle gregory,
-MBA,8660,21.0,"Data, Storage, Business Decis",0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,he li,
-MBA,8700,1.0,Strategic Management,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,james turner,
-MBA,8990,2.0,Creativity,0.79,0.14,0.05,0.0,0.0,0.0,0.0,0.02,kathleen ann kegley,
-MBA,8990,4.0,Data Analytics & Visualization,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,john frederick tripp,
-MBA,8990,7.0,Digital Marketing,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,robert andrew fitzwater,
-ME,2000,1.0,Sophomore Seminar,0.91,0.05,0.01,0.0,0.0,0.0,0.0,0.03,todd alan schweisinger,
-ME,2000,2.0,Sophomore Seminar,0.74,0.16,0.03,0.01,0.02,0.0,0.0,0.05,todd alan schweisinger,
-ME,2010,1.0,Statics & Dynamics,0.07,0.16,0.25,0.09,0.25,0.0,0.0,0.16,gang liu,
-ME,2010,2.0,Statics & Dynamics,0.17,0.24,0.31,0.07,0.13,0.0,0.0,0.08,paul joseph,
-ME,2010,3.0,Statics & Dynamics,0.05,0.16,0.26,0.15,0.15,0.0,0.0,0.24,gang li,
-ME,2010,4.0,Statics & Dynamics,0.02,0.14,0.25,0.17,0.22,0.0,0.0,0.2,marisa kikendall orr,
-ME,2030,1.0,Founda Th/Fl Syst,0.42,0.33,0.14,0.05,0.05,0.0,0.0,0.02,sandip dutta,
-ME,2030,2.0,Founda Th/Fl Syst,0.27,0.29,0.16,0.16,0.04,0.0,0.0,0.09,xiangchun xuan,
-ME,2040,1.0,Mechanics of Materials,0.24,0.51,0.18,0.04,0.04,0.0,0.0,0.0,fadi abdeljawad,
-ME,2040,2.0,Mechanics of Materials,0.19,0.53,0.16,0.03,0.03,0.0,0.0,0.06,huijuan zhao,
-ME,2220,1.0,Mechanical Engineering Lab I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,douglas scott byrd,
-ME,2220,2.0,Mechanical Engineering Lab I,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
-ME,2220,3.0,Mechanical Engineering Lab I,0.13,0.56,0.13,0.0,0.0,0.0,0.0,0.19,douglas scott byrd,
-ME,2220,5.0,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
-ME,2220,6.0,Mechanical Engineering Lab I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
-ME,2220,7.0,Mechanical Engineering Lab I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
-ME,2220,8.0,Mechanical Engineering Lab I,0.56,0.31,0.0,0.0,0.06,0.0,0.0,0.06,douglas scott byrd,
-ME,2220,10.0,Mechanical Engineering Lab I,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,douglas scott byrd,
-ME,2220,11.0,Mechanical Engineering Lab I,0.13,0.53,0.2,0.0,0.0,0.0,0.0,0.13,douglas scott byrd,
-ME,2220,13.0,Mechanical Engineering Lab I,0.31,0.5,0.06,0.0,0.0,0.0,0.0,0.13,douglas scott byrd,
-ME,2220,15.0,Mechanical Engineering Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,
-ME,3030,1.0,Thermodynamics,0.12,0.3,0.33,0.12,0.06,0.0,0.0,0.06,john saylor,
-ME,3030,2.0,Thermodynamics,0.23,0.31,0.34,0.11,0.02,0.0,0.0,0.0,yiqiang han,
-ME,3030,3.0,Thermodynamics,0.09,0.31,0.47,0.04,0.02,0.0,0.0,0.07,yiqiang han,
-ME,3040,1.0,Heat Transfer,0.55,0.35,0.07,0.01,0.0,0.0,0.0,0.01,sandip dutta,
-ME,3040,2.0,Heat Transfer,0.09,0.25,0.45,0.09,0.07,0.0,0.0,0.05,geetha pravallika chimata,
-ME,3050,1.0,Model/an Dy Syst,0.25,0.34,0.27,0.09,0.05,0.0,0.0,0.0,ardalan vahidi,
-ME,3050,2.0,Model/an Dy Syst,0.18,0.35,0.26,0.09,0.09,0.0,0.0,0.03,seyedyasha parvinioskoui,
-ME,3060,1.0,Fund Machine Design,0.34,0.38,0.19,0.06,0.02,0.0,0.0,0.0,katherine marie ehlert,
-ME,3060,2.0,Fund Machine Design,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,zhaoxu meng,
-ME,3060,3.0,Fund Machine Design,0.15,0.34,0.24,0.15,0.07,0.0,0.0,0.05,nafiseh masoudi,
-ME,3070,1.0,Found of Mechanical Systems,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,pooya niksiar,
-ME,3070,2.0,Found of Mechanical Systems,0.5,0.35,0.08,0.03,0.03,0.0,0.0,0.03,lonny thompson,
-ME,3070,3.0,Found of Mechanical Systems,0.67,0.22,0.09,0.0,0.0,0.0,0.0,0.01,pooya niksiar,
-ME,3080,1.0,Fluid Mechanics,0.16,0.53,0.24,0.02,0.02,0.0,0.0,0.02,zhen li,
-ME,3080,2.0,Fluid Mechanics,0.18,0.2,0.38,0.2,0.02,0.0,0.0,0.02,seyedyasha parvinioskoui,
-ME,3080,3.0,Fluid Mechanics,0.26,0.34,0.36,0.03,0.0,0.0,0.0,0.0,ethan kung,
-ME,3080,301.0,Fluid Mechanics (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,zhen li,True
-ME,3120,1.0,Manuf Processes,0.66,0.32,0.02,0.0,0.0,0.0,0.0,0.0,xin zhao,
-ME,3120,2.0,Manuf Processes,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,rodrigo martinez-duarte,
-ME,3330,1.0,Mechanical Engineering Lab II,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,2.0,Mechanical Engineering Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,5.0,Mechanical Engineering Lab II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,6.0,Mechanical Engineering Lab II,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,gang liu,
-ME,3330,8.0,Mechanical Engineering Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,9.0,Mechanical Engineering Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,10.0,Mechanical Engineering Lab II,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,16.0,Mechanical Engineering Lab II,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3900,103.0,CI ME - Autonomous Micro Drone,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,yiqiang han,
-ME,4000,1.0,Senior Seminar,0.98,0.01,0.0,0.0,0.01,0.0,0.0,0.0,atul gajanan kelkar,
-ME,4010,2.0,Mech Engr Design,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4010,864.0,Mech Engr Design,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,geetha pravallika chimata,
-ME,4020,3.0,Intern in Engr Des,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,pooya niksiar,
-ME,4030,1.0,Control Dynamic Systems,0.3,0.27,0.03,0.24,0.15,0.0,0.0,0.0,mohammad naghnaeian,
-ME,4030,2.0,Control Dynamic Systems,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,suyi li,
-ME,4030,3.0,Control Dynamic Systems,0.73,0.18,0.05,0.05,0.0,0.0,0.0,0.0,hubert bryan riley,
-ME,4210,1.0,Intro to Comp Flow,0.43,0.14,0.36,0.07,0.0,0.0,0.0,0.0,chenning tong,
-ME,4290,1.0,Ther Env Control,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,jay ochterbeck,
-ME,4320,1.0,Advanced Strength of Materials,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,oliver myers,
-ME,4340,1.0,Cardiovascular Biomechanics,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,ethan kung,
-ME,4440,1.0,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,2.0,Mechanical Engineering Lab III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4440,5.0,Mechanical Engineering Lab III,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4580,1.0,Fund Micro/Nano Fabrication,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,rodrigo martinez-duarte,
-ME,4710,1.0,Ca Eng Anly & Design,0.32,0.53,0.03,0.03,0.0,0.0,0.0,0.11,georges fadel,
-ME,4930,14.0,Sel.Topics ME - NonLinDy&Chas,0.13,0.5,0.38,0.0,0.0,0.0,0.0,0.0,joshua bostwick,
-ME,4930,35.0,Sel Topics ME: Smart Materials,0.55,0.34,0.07,0.0,0.0,0.0,0.0,0.03,oliver myers,
-ME,4930,39.0,Sel.Topics ME - Aero Propul,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,pooya niksiar,
-ME,4930,77.0,Selected Topics ME - Boeing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,6320,1.0,Advanced Strength of Materials,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,oliver myers,
-ME,6550,864.0,Design for Manuf,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,joshua summers,
-ME,6710,1.0,Ca Eng Anly & Design,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,6930,14.0,Sel.Topics ME - NonLinDy&Chas,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joshua bostwick,
-ME,6930,35.0,Sel Topics ME: Smart Materials,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,oliver myers,
-ME,8010,1.0,Found of Fluid Mech,0.36,0.32,0.23,0.0,0.05,0.0,0.0,0.05,richard figliola,
-ME,8100,1.0,Macroscopic Thermo,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,jay ochterbeck,
-ME,8180,1.0,Intro to Fin Ele Ana,0.7,0.25,0.0,0.0,0.02,0.0,0.0,0.03,lonny thompson,
-ME,8180,843.0,Intro to Fin Ele Ana,0.57,0.0,0.29,0.0,0.0,0.0,0.0,0.14,lonny thompson,
-ME,8230,1.0,Control Systems,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,
-ME,8230,864.0,Control Systems,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,yue wang,
-ME,8300,1.0,Cond/Rad Heat Tfr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,
-ME,8400,1.0,Plasticity,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,garrett pataky,
-ME,8460,1.0,Inter Dynamics,0.5,0.21,0.21,0.0,0.0,0.0,0.0,0.07,phanindra tallapragada,
-ME,8700,1.0,Adv Design Methods,0.97,0.02,0.02,0.0,0.0,0.0,0.0,0.0,cameron turner,
-ME,8710,1.0,Engr Optimization,0.78,0.13,0.02,0.0,0.0,0.0,0.0,0.07,georges fadel,
-ME,8930,2.0,Sel Topics ME: Adv Mfg,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,hong seok choi,
-MGT,2010,1.0,Principles of Management,0.35,0.4,0.19,0.03,0.01,0.0,0.0,0.02,katherine clark,
-MGT,2010,2.0,Principles of Management,0.52,0.33,0.11,0.02,0.01,0.0,0.0,0.01,tina robbins,
-MGT,2010,8.0,Principles of Management,0.4,0.35,0.23,0.0,0.0,0.0,0.0,0.03,christopher mann,
-MGT,2010,9.0,Principles of Management,0.26,0.53,0.08,0.11,0.03,0.0,0.0,0.0,christopher mann,
-MGT,2010,10.0,Principles of Management,0.31,0.33,0.31,0.0,0.03,0.0,0.0,0.03,ashley williams parnell,
-MGT,2010,11.0,Principles of Management,0.33,0.31,0.23,0.08,0.0,0.0,0.0,0.05,ashley williams parnell,
-MGT,2010,12.0,Principles of Management,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,nicholas byrd,
-MGT,2010,13.0,Principles of Management,0.79,0.13,0.08,0.0,0.0,0.0,0.0,0.0,shuang liu,
-MGT,2180,1.0,Management PC Applications,0.56,0.29,0.09,0.02,0.02,0.0,0.0,0.02,ryan toole,
-MGT,2180,2.0,Management PC Applications,0.25,0.6,0.03,0.0,0.0,0.0,0.0,0.13,ryan toole,
-MGT,3070,1.0,Human Resource Management,0.46,0.49,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,
-MGT,3070,3.0,Human Resource Management,0.37,0.41,0.15,0.07,0.0,0.0,0.0,0.0,kristin damato scott,
-MGT,3070,4.0,Human Resource Management,0.46,0.49,0.06,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,5.0,Human Resource Management,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,
-MGT,3070,6.0,Human Resource Management,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,7.0,Human Resource Management,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,
-MGT,3070,8.0,Human Resource Management,0.2,0.49,0.26,0.03,0.03,0.0,0.0,0.0,priscilla harrison,
-MGT,3100,1.0,Intermed Business Statistics,0.26,0.29,0.32,0.0,0.06,0.0,0.0,0.06,daniel allan detoma,
-MGT,3100,2.0,Intermed Business Statistics,0.37,0.17,0.31,0.03,0.09,0.0,0.0,0.03,mustafa serkan akturk,
-MGT,3100,3.0,Intermed Business Statistics,0.56,0.18,0.15,0.0,0.03,0.0,0.0,0.09,maneeshreddy ajjuguttu,
-MGT,3100,5.0,Intermed Business Statistics,0.4,0.18,0.33,0.03,0.03,0.0,0.0,0.05,mustafa serkan akturk,
-MGT,3100,6.0,Intermed Business Statistics,0.81,0.03,0.05,0.03,0.05,0.0,0.0,0.03,david ford peyton,
-MGT,3100,7.0,Intermed Business Statistics,0.54,0.32,0.03,0.03,0.03,0.0,0.0,0.05,seyed amin seyed haeri,
-MGT,3100,8.0,Intermed Business Statistics,0.65,0.25,0.08,0.0,0.0,0.0,0.0,0.03,david ford peyton,
-MGT,3100,9.0,Intermed Business Statistics,0.51,0.23,0.1,0.1,0.05,0.0,0.0,0.0,david ford peyton,
-MGT,3100,10.0,Intermed Business Statistics,0.45,0.34,0.13,0.03,0.05,0.0,0.0,0.0,jeromy blake snider,
-MGT,3100,12.0,Intermed Business Statistics,0.13,0.31,0.44,0.0,0.03,0.0,0.0,0.1,daniel allan detoma,
-MGT,3100,13.0,Intermed Business Statistics,0.86,0.08,0.03,0.0,0.03,0.0,0.0,0.0,benjamin christopher wiles,
-MGT,3120,1.0,Decision Models for Management,0.29,0.22,0.28,0.11,0.06,0.0,0.0,0.05,sara elizabeth yoder,
-MGT,3120,2.0,Decision Models for Management,0.19,0.14,0.34,0.16,0.14,0.0,0.0,0.03,sara elizabeth yoder,
-MGT,3120,4.0,Decision Models for Management,0.25,0.22,0.32,0.07,0.05,0.0,0.0,0.08,sara elizabeth yoder,
-MGT,3170,1.0,Logistics Mgmt,0.43,0.48,0.09,0.0,0.0,0.0,0.0,0.0,ahmet colak,
-MGT,3180,1.0,Mgt of Info Systems,0.53,0.43,0.05,0.0,0.0,0.0,0.0,0.0,wenxi pu,
-MGT,3180,3.0,Mgt of Info Systems,0.38,0.4,0.03,0.1,0.05,0.0,0.0,0.05,zhihong ke,
-MGT,3180,4.0,Mgt of Info Systems,0.56,0.33,0.09,0.02,0.0,0.0,0.0,0.0,he li,
-MGT,3180,5.0,Mgt of Info Systems,0.4,0.5,0.05,0.0,0.02,0.0,0.0,0.02,wenxi pu,
-MGT,3180,6.0,Mgt of Info Systems,0.69,0.16,0.13,0.02,0.0,0.0,0.0,0.0,shih lun tseng,
-MGT,3180,7.0,Mgt of Info Systems,0.68,0.23,0.07,0.0,0.02,0.0,0.0,0.0,shih lun tseng,
-MGT,3180,8.0,Mgt of Info Systems,0.56,0.06,0.19,0.06,0.08,0.0,0.0,0.06,kevin mckenzie,
-MGT,3500,1.0,Intro to Business Analytics,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,hongki kim,
-MGT,3510,1.0,Business Analytics & Problems,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,david ford peyton,
-MGT,3900,1.0,Operations Management,0.31,0.39,0.11,0.03,0.03,0.0,0.0,0.13, sridharan,
-MGT,3900,2.0,Operations Management,0.29,0.41,0.14,0.05,0.05,0.0,0.0,0.05, sridharan,
-MGT,3900,4.0,Operations Management,0.1,0.2,0.48,0.1,0.08,0.0,0.0,0.05,zachary moran leffakis,
-MGT,3900,5.0,Operations Management,0.46,0.38,0.1,0.03,0.03,0.0,0.0,0.0,benjamin noah grant,
-MGT,3900,6.0,Operations Management,0.28,0.38,0.23,0.05,0.08,0.0,0.0,0.0,benjamin noah grant,
-MGT,4000,1.0,Mgt of Organizational Behavior,0.59,0.39,0.0,0.0,0.0,0.0,0.0,0.02,michael cole,
-MGT,4000,2.0,Mgt of Organizational Behavior,0.73,0.25,0.0,0.03,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,3.0,Mgt of Organizational Behavior,0.29,0.53,0.16,0.0,0.03,0.0,0.0,0.0,thomas joseph zagenczyk,
-MGT,4000,4.0,Mgt of Organizational Behavior,0.21,0.29,0.32,0.16,0.0,0.0,0.0,0.03,philip roth,
-MGT,4020,1.0,Ops Pln and Ctl,0.06,0.25,0.69,0.0,0.0,0.0,0.0,0.0,zachary moran leffakis,
-MGT,4080,1.0,Lean Operations,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,zachary moran leffakis,
-MGT,4110,1.0,Project Management,0.35,0.43,0.14,0.0,0.03,0.0,0.0,0.05,russell purvis,
-MGT,4120,1.0,Supplier Management,0.48,0.33,0.15,0.0,0.0,0.0,0.0,0.03,ahmet colak,
-MGT,4150,1.0,Business Strategy,0.25,0.53,0.23,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,2.0,Business Strategy,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,3.0,Business Strategy,0.1,0.65,0.25,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,4.0,Business Strategy,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,
-MGT,4150,5.0,Business Strategy (HON),0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,True
-MGT,4150,6.0,Business Strategy,0.1,0.56,0.33,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,7.0,Business Strategy,0.45,0.4,0.14,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,
-MGT,4150,8.0,Business Strategy,0.21,0.51,0.28,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,
-MGT,4150,9.0,Business Strategy,0.39,0.53,0.05,0.0,0.0,0.0,0.0,0.03,amy elizabeth ingram,
-MGT,4150,12.0,Business Strategy,0.21,0.5,0.29,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4160,1.0,Special Topics Hr,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,kristin damato scott,
-MGT,4230,1.0,Intern Bus Mgt,0.18,0.18,0.52,0.09,0.02,0.0,0.0,0.0,wayne stewart,
-MGT,4230,2.0,Intern Bus Mgt,0.23,0.38,0.3,0.05,0.05,0.0,0.0,0.0,wayne stewart,
-MGT,4230,3.0,Intern Bus Mgt,0.13,0.45,0.37,0.02,0.03,0.0,0.0,0.0,janis miller,
-MGT,4240,1.0,Global Supply Chain Management,0.32,0.44,0.21,0.0,0.03,0.0,0.0,0.0,yann ferrand,
-MGT,4270,2.0,Managing Improvement,0.27,0.4,0.23,0.0,0.03,0.0,0.0,0.07,lawrence fredendall,
-MGT,4310,1.0,Emp Rights & Resp,0.21,0.62,0.15,0.03,0.0,0.0,0.0,0.0,leonard joseph spooner,
-MGT,4350,1.0,Pers Interviewing,0.42,0.56,0.03,0.0,0.0,0.0,0.0,0.0,philip roth,
-MGT,4520,1.0,Business Analysis,0.24,0.58,0.12,0.0,0.0,0.0,0.0,0.06,russell purvis,
-MGT,4540,1.0,Systems Implement,0.55,0.31,0.1,0.0,0.03,0.0,0.0,0.0,hongki kim,
-MGT,8690,1.0,Project Mgt,0.49,0.49,0.0,0.0,0.0,0.0,0.0,0.02,russell purvis,
-MICR,2050,1.0,Introductory Micro,0.37,0.46,0.16,0.02,0.0,0.0,0.0,0.01,john abercrombie,
-MICR,3050,1.0,General Microbiology,0.39,0.39,0.18,0.02,0.0,0.0,0.0,0.01,krista barrier rudolph,
-MICR,3050,2.0,General Microbiology,0.42,0.39,0.14,0.04,0.0,0.0,0.0,0.0,krista barrier rudolph,
-MICR,4010,1.0,Microbial Diversity & Ecology,0.58,0.22,0.14,0.02,0.02,0.0,0.0,0.02,kristi james whitehead,
-MICR,4010,2.0,Micro Diversity/Ecol (HON),0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristi james whitehead,True
-MICR,4050,1.0,Adv Microbial Ecol of Humans,0.49,0.37,0.1,0.02,0.0,0.0,0.0,0.01,kristi james whitehead,
-MICR,4140,1.0,Basic Immunology,0.38,0.45,0.13,0.0,0.02,0.0,0.0,0.02,yanzhang wei,
-MICR,4150,1.0,Microbial Genetics,0.3,0.32,0.3,0.09,0.0,0.0,0.0,0.0,min cao,
-MICR,4160,1.0,Intro Virology,0.79,0.18,0.01,0.01,0.0,0.0,0.0,0.0,kaustubha ratan qanungo,
-MICR,4510,2.0,Advanced Microbiology II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4510,3.0,Advanced Microbiology II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4510,4.0,Advanced Microbiology II,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4930,1.0,Sr Sem: Emerg Infect Diseases,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,kristi james whitehead,
-MKT,3010,1.0,Principles of Marketing,0.2,0.43,0.25,0.08,0.02,0.0,0.0,0.03,amanda cooper fine,
-MKT,3010,2.0,Principles of Marketing,0.29,0.37,0.21,0.1,0.01,0.0,0.0,0.02,amanda cooper fine,
-MKT,3010,3.0,Principles of Marketing,0.29,0.39,0.22,0.08,0.01,0.0,0.0,0.01,amanda cooper fine,
-MKT,3010,4.0,Principles of Marketing,0.27,0.44,0.21,0.06,0.02,0.0,0.0,0.01,carter willis mcelveen,
-MKT,3010,5.0,Principles of Marketing,0.31,0.43,0.21,0.04,0.0,0.0,0.0,0.01,carter willis mcelveen,
-MKT,3010,7.0,Principles of Marketing,0.12,0.56,0.27,0.03,0.01,0.0,0.0,0.01,james gaubert,
-MKT,3020,1.0,Consumer Behavior,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jennifer dianne siemens,
-MKT,3020,2.0,Consumer Behavior,0.69,0.24,0.04,0.02,0.0,0.0,0.0,0.0,jennifer dianne siemens,
-MKT,3020,5.0,Consumer Behavior,0.52,0.38,0.09,0.0,0.01,0.0,0.0,0.0,anastasia elizabeth thyroff,
-MKT,3020,6.0,Consumer Behavior,0.29,0.48,0.15,0.01,0.04,0.0,0.0,0.03,james gaubert,
-MKT,3210,1.0,Sports Marketing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3210,2.0,Sports Marketing,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,3220,1.0,Social Media Marketing,0.83,0.11,0.0,0.03,0.0,0.0,0.0,0.03,lura forcum,
-MKT,3220,2.0,Social Media Marketing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,
-MKT,3220,3.0,Social Media Marketing,0.67,0.26,0.07,0.0,0.0,0.0,0.0,0.0,michele melton cauley,
-MKT,3220,4.0,Social Media Marketing,0.57,0.37,0.04,0.0,0.02,0.0,0.0,0.0,michele melton cauley,
-MKT,3310,1.0,Marketing Metrics & Analytics,0.73,0.2,0.03,0.0,0.0,0.0,0.0,0.03,oriana rachel aragon,
-MKT,3310,2.0,Marketing Metrics & Analytics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,oriana rachel aragon,
-MKT,3310,3.0,Marketing Metrics & Analytics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,3310,4.0,Marketing Metrics & Analytics,0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,xianyong wang,
-MKT,3310,5.0,Marketing Metrics & Analytics,0.19,0.44,0.22,0.04,0.0,0.0,0.0,0.11,peter weathers,
-MKT,3980,1.0,Creative Inquiry in Marketing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james gaubert,
-MKT,4200,1.0,Professional Selling,0.41,0.56,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,2.0,Professional Selling,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,kevin scott chase,
-MKT,4200,3.0,Professional Selling,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4200,5.0,Professional Selling,0.83,0.07,0.07,0.0,0.0,0.0,0.0,0.03,carter willis mcelveen,
-MKT,4200,6.0,Professional Selling,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,
-MKT,4230,2.0,Promotional Strategy,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,michele melton cauley,
-MKT,4230,3.0,Promotional Strategy,0.42,0.48,0.06,0.0,0.03,0.0,0.0,0.0,michele melton cauley,
-MKT,4240,1.0,Sales Management,0.59,0.32,0.05,0.0,0.0,0.0,0.0,0.03,ryan mullins,
-MKT,4260,1.0,Business-to-Business,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4270,1.0,International Marketing,0.7,0.24,0.04,0.02,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4270,2.0,International Marketing,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4270,3.0,International Marketing,0.48,0.33,0.1,0.0,0.03,0.0,0.0,0.08,thomas poehlman,
-MKT,4270,4.0,International Marketing,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4280,1.0,Services Marketing,0.21,0.44,0.28,0.05,0.03,0.0,0.0,0.0,angeline close scheinbaum,
-MKT,4280,2.0,Services Marketing,0.15,0.64,0.21,0.0,0.0,0.0,0.0,0.0,angeline close scheinbaum,
-MKT,4310,1.0,Marketing Research,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,michael david giebelhausen,
-MKT,4310,2.0,Marketing Research,0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,michael david giebelhausen,
-MKT,4310,3.0,Marketing Research,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,4.0,Marketing Research,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4500,1.0,Strategic Mktg Mgt,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,annette popp tower,
-MKT,4500,2.0,Strategic Mktg Mgt,0.39,0.52,0.09,0.0,0.0,0.0,0.0,0.0,annette popp tower,
-MKT,4500,3.0,Strategic Mktg Mgt,0.27,0.58,0.15,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,4.0,Strategic Mktg Mgt,0.19,0.44,0.33,0.04,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4950,1.0,Selling Medical Devices,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4950,2.0,Applied Selling,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kevin scott chase,
-ML,2010,1.0,Leadership Development I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,2010,3.0,Leadership Development I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,3010,1.0,Advanced Leadership I,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,justin robert merhar,
-MSE,2100,1.0,Intro to Materials Science,0.25,0.43,0.22,0.04,0.01,0.0,0.0,0.04,nancy birkner,
-MSE,2100,2.0,Intro to Materials Science,0.44,0.28,0.18,0.08,0.01,0.0,0.0,0.01,rakhee pani,
-MSE,2100,3.0,Intro to Materials Science,0.23,0.43,0.2,0.07,0.03,0.0,0.0,0.03,mark alan johnson,
-MSE,2100,4.0,Intro to Materials Science,0.65,0.21,0.05,0.02,0.04,0.0,0.0,0.02,rakhee pani,
-MSE,2100,5.0,Intro to Materials Science,0.06,0.56,0.19,0.13,0.06,0.0,0.0,0.0,olga kuksenok,
-MSE,2100,6.0,Intro to Materials Science,0.24,0.23,0.26,0.08,0.11,0.0,0.0,0.08,olga kuksenok,
-MSE,3260,1.0,Thermo of Materials,0.36,0.28,0.26,0.04,0.06,0.0,0.0,0.0,fei peng,
-MSE,3260,2.0,Thermo of Materials,0.34,0.32,0.22,0.1,0.02,0.0,0.0,0.0,fei peng,
-MSE,3910,1.0,Research Fundamentals,0.74,0.1,0.03,0.06,0.06,0.0,0.0,0.0,ulf daniel schiller,
-MSE,4130,1.0,Noncrystalline Materials,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
-MSE,4150,1.0,Polymer Science & Engineering,0.44,0.35,0.06,0.06,0.06,0.0,0.0,0.03,olin mefford,
-MSE,4150,2.0,Polymer Science & Engineering,0.5,0.26,0.24,0.0,0.0,0.0,0.0,0.0,igor luzinov,
-MSE,4320,1.0,Manuf Proc & Systems,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,
-MSE,4580,1.0,Surf Phen in Ms&E,0.3,0.2,0.4,0.0,0.0,0.0,0.0,0.1,konstantin german kornev,
-MSE,4910,1.0,Undergraduate Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ulf daniel schiller,
-MSE,8100,1.0,Fundamentals of Materials Sci,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,igor luzinov,
-MSE,8190,1.0,Inorgan Mater Characterization,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,luiz gustavo jacobsohn,
-MSE,8260,1.0,Phase Equil Mat Sys,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,stephen foulger,
-MSE,8270,1.0,Kin of Phase Tran,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,konstantin german kornev,
-MSE,8510,1.0,Polymer Science I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,marek urban,
-MUSC,1110,4.0,Beginning Class Guitar,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,david stevenson,
-MUSC,1420,1.0,Music Theory I,0.76,0.06,0.12,0.0,0.0,0.0,0.0,0.06,linda li-bleuel,
-MUSC,1430,1.0,Aural Skills I,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,linda li-bleuel,
-MUSC,1510,2.0,Applied Music,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,
-MUSC,1510,19.0,Applied Music,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,adam michael knight,
-MUSC,1510,25.0,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,charles wood,
-MUSC,1520,2.0,Applied Music,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,
-MUSC,1520,22.0,Applied Music,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathryn layne mauldin,
-MUSC,2100,1.0,Music in the Western World,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,david conley,
-MUSC,2100,5.0,Music in the Western World,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,timothy ray hurlburt,
-MUSC,2100,6.0,Music in the Western World,0.97,0.0,0.03,0.0,0.0,0.0,0.0,0.0,david conley,
-MUSC,2100,7.0,Music in the Western World,0.42,0.39,0.13,0.03,0.0,0.0,0.0,0.03,rhea beth jacobus,
-MUSC,2100,8.0,Music in the Western World,0.41,0.41,0.03,0.0,0.06,0.0,0.0,0.09,rhea beth jacobus,
-MUSC,2100,11.0,Music in the Western World,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,leslie taylor warlick,
-MUSC,2100,12.0,Music in the Western World,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,
-MUSC,2100,13.0,Music in the Western World,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,david conley,
-MUSC,2100,15.0,Music in West World (HON),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,True
-MUSC,2510,2.0,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,
-MUSC,3080,1.0,Surv of Broadway I,0.67,0.11,0.11,0.0,0.11,0.0,0.0,0.0,lisa sain odom,
-MUSC,3110,1.0,History of American Music,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,ned hosler,
-MUSC,3120,1.0,History of Jazz,0.6,0.05,0.1,0.1,0.15,0.0,0.0,0.0,eric lapin,
-MUSC,3140,1.0,World Music,0.68,0.16,0.1,0.03,0.0,0.0,0.0,0.03,paul buyer,
-MUSC,3170,1.0,Hist of Country Mus,0.78,0.16,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3180,1.0,Hist of Audio Tech,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,bruce allen whisler,
-MUSC,3610,1.0,Marching Band,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,
-MUSC,3700,1.0,Clemson University Singers,0.95,0.03,0.02,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,
-MUSC,3720,1.0,Men's Chorus,0.94,0.02,0.0,0.0,0.0,0.0,0.0,0.04,anthony bernarducci,
-MUSC,4150,1.0,Music Hist to 1750,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,linda dzuris,
-NPL,3000,1.0,Nonprofit Leadership,0.29,0.67,0.0,0.0,0.0,0.0,0.0,0.04,bonnie westbury stevens,
-NPL,3000,2.0,Nonprofit Leadership,0.21,0.58,0.17,0.0,0.0,0.0,0.0,0.04,bonnie westbury stevens,
-NPL,3000,3.0,Nonprofit Leadership,0.72,0.24,0.0,0.04,0.0,0.0,0.0,0.0,christina marie mazer,
-NPL,3000,4.0,Nonprofit Leadership,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,corey douglas brookover,
-NPL,3000,5.0,Nonprofit Leadership,0.41,0.48,0.07,0.0,0.04,0.0,0.0,0.0,corey douglas brookover,
-NPL,3000,6.0,Nonprofit Leadership,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,corey douglas brookover,
-NPL,3000,7.0,Nonprofit Leadership,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,corey douglas brookover,
-NPL,3000,8.0,Nonprofit Leadership,0.74,0.15,0.04,0.07,0.0,0.0,0.0,0.0,christina marie mazer,
-NPL,3000,9.0,Nonprofit Leadership,0.63,0.3,0.04,0.0,0.0,0.0,0.0,0.04,christina marie mazer,
-NPL,3010,1.0,NPL Stakeholders,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,christina marie mazer,
-NPL,3020,1.0,NPL Fundraising,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,joan laura phillips,
-NPL,3030,1.0,NPL Personnel,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,joan laura phillips,
-NPL,3040,1.0,NPL Risk Management,0.74,0.13,0.13,0.0,0.0,0.0,0.0,0.0,daniel morgan anderson,
-NPL,3050,1.0,Strat Social Media for NP Org,0.81,0.11,0.05,0.0,0.0,0.0,0.0,0.03,randi alexandra plake,
-NPL,3050,2.0,Strat Social Media for NP Org,0.83,0.14,0.0,0.02,0.0,0.0,0.0,0.0,randi alexandra plake,
-NURS,1020,3.0,Nrsg Success Skills,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,janice garrison lanham,
-NURS,1400,1.0,Comp App Hlth Care,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,
-NURS,1400,2.0,Comp App Hlth Care,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,janice garrison lanham,
-NURS,3000,1.0,Seminar- Leadership University,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,janice garrison lanham,
-NURS,3030,1.0,Nursing of Adults,0.33,0.6,0.04,0.0,0.0,0.0,0.0,0.02,lena marie burgess,
-NURS,3040,101.0,Pathophysiology,0.4,0.4,0.15,0.03,0.0,0.0,0.0,0.02,catherine sikkema murton,
-NURS,3040,201.0,Pathophysiology,0.24,0.66,0.07,0.0,0.01,0.0,0.0,0.01,amy boggs garrison,
-NURS,3040,400.0,Pathophysiology,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,amy boggs garrison,
-NURS,3040,401.0,Pathophysiology,0.63,0.27,0.07,0.0,0.03,0.0,0.0,0.0,amy boggs garrison,
-NURS,3050,1.0,Psychosocial Nursing,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.02,kevin earle busby,
-NURS,3100,1.0,Health Assessment,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,
-NURS,3100,401.0,Health Assessment,0.83,0.13,0.0,0.0,0.03,0.0,0.0,0.0,jason thrift,
-NURS,3110,1.0,Hlth Promotion Across Lifespan,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,janice garrison lanham,
-NURS,3120,101.0,Foundations of Nursing,0.51,0.47,0.0,0.0,0.0,0.0,0.0,0.02,jennifer elizabeth bagwell,
-NURS,3120,201.0,Foundations of Nursing,0.31,0.65,0.01,0.01,0.0,0.0,0.0,0.01,terri abercrombie teramano,
-NURS,3120,401.0,Foundations of Nursing,0.67,0.3,0.0,0.0,0.03,0.0,0.0,0.0,terri abercrombie teramano,
-NURS,3200,1.0,Prof in Nurs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3230,101.0,Gerontology Nursing,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,tawny jenna mcintosh,
-NURS,3300,1.0,Research in Nursing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,3300,2.0,Research in Nursing,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,hyewon shin,
-NURS,3330,1.0,Health Care Genetics,0.58,0.36,0.04,0.0,0.0,0.0,0.0,0.02,linda ward,
-NURS,3400,101.0,Pharmther Nursing,0.36,0.44,0.15,0.02,0.02,0.0,0.0,0.02,catherine sikkema murton,
-NURS,3400,201.0,Pharmther Nursing,0.32,0.56,0.09,0.01,0.0,0.0,0.0,0.01,jenna lynn seawright,
-NURS,3400,401.0,Pharmther Nursing,0.57,0.37,0.03,0.0,0.03,0.0,0.0,0.0,jenna lynn seawright,
-NURS,3600,400.0,Social Determinants in Health,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
-NURS,4010,1.0,Mental Health Nurs,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebecca garrard,
-NURS,4030,101.0,Complex Nursing of Adults,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen rankin ewing,
-NURS,4030,202.0,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john joseph whitcomb,
-NURS,4030,402.0,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john joseph whitcomb,
-NURS,4060,400.0,Issues in Professionalism,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
-NURS,4110,1.0,Nursing of Children,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,
-NURS,4120,1.0,Nurs Women and Fam,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,erin nicole shepherd,
-NURS,8050,400.0,Pharmaco Adv Nurs,0.33,0.5,0.08,0.0,0.04,0.0,0.0,0.04,tracy king fasolino,
-NURS,8050,401.0,Pharmaco Adv Nurs,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8060,400.0,Advan Assessment for Nursing,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
-NURS,8090,400.0,Pathophysiology,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,
-NURS,8190,400.0,Developing Family,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8200,400.0,Child & Adol Nursing,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
-NURS,9010,1.0,"DNP Role, Theory & Philosophy",0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,jean ellen zavertnik,
-NURS,9020,1.0,DNP Clinical Epidem & Biostats,0.4,0.2,0.0,0.0,0.2,0.0,0.0,0.2,veronica parker,
-NUTR,2030,1.0,Intro Princ of Human Nutrition,0.91,0.08,0.01,0.0,0.0,0.0,0.0,0.0,bridgit denise corbett,
-NUTR,2030,2.0,Intro Princ of Human Nutrition,0.71,0.24,0.02,0.02,0.0,0.0,0.0,0.0,bridgit denise corbett,
-NUTR,2040,1.0,Nutrition Across Life Cycle,0.63,0.24,0.11,0.03,0.0,0.0,0.0,0.0,bridgit denise corbett,
-NUTR,2050,400.0,Nutrition for Nursing Prof,0.37,0.46,0.17,0.0,0.0,0.0,0.0,0.0,elizabeth lacey durrance,
-NUTR,2160,1.0,Evidence-Based Nutrition,0.84,0.08,0.05,0.0,0.02,0.0,0.0,0.01,angela fraser,
-NUTR,3020,1.0,Nutrition Assessment,0.63,0.34,0.02,0.0,0.02,0.0,0.0,0.0,elliot jesch,
-NUTR,4240,1.0,Medical Nutr Thera I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4510,1.0,Human Nutrition & Metabolism I,0.33,0.24,0.21,0.13,0.08,0.0,0.0,0.02,elliot jesch,
-PA,1010,1.0,Intro to Perf Arts,0.5,0.25,0.13,0.06,0.06,0.0,0.0,0.0,david hartmann,
-PA,2790,1.0,Perf Arts Pract I,0.47,0.0,0.06,0.0,0.24,0.0,0.0,0.24,kenneth moore,
-PA,3010,1.0,Princip of Arts Administration,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,richard goodstein,
-PA,4010,1.0,Capstone Project,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,
-PADM,7020,400.0,Research Methods,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ronald chrestman,
-PADM,8210,400.0,Perspectives on Public Admin,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,thomas walker,
-PADM,8220,401.0,Public Policy Process,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,ekaterina yazykova mellott,
-PADM,8290,400.0,Public Financial Management,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,
-PADM,8410,400.0,Public Data Analysis,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,ryan joseph gagnon,
-PADM,8420,400.0,GIS for Public Administrators,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lawrence white,
-PADM,8670,401.0,State Government Admin,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
-PAS,3010,1.0,Intro to Pan African Studies,0.51,0.41,0.02,0.0,0.04,0.0,0.0,0.01,abel bartley,
-PDBE,8150,1.0,Research Design in EDP,0.43,0.29,0.14,0.0,0.14,0.0,0.0,0.0,mickey lauria,
-PES,1040,1.0,Introduction to Plant Sciences,0.69,0.24,0.02,0.0,0.0,0.0,0.0,0.04,paula agudelo,
-PES,2020,1.0,Soils,0.14,0.51,0.26,0.05,0.0,0.0,0.0,0.04,dara michelle park,
-PES,3150,1.0,Environment and Agriculture,0.29,0.67,0.0,0.0,0.05,0.0,0.0,0.0,vidya appukuttan suseela,
-PES,4090,1.0,Biology of Invasive Plants,0.67,0.17,0.08,0.0,0.08,0.0,0.0,0.0,nishanth tharayil-santhakumar,
-PES,4210,1.0,Princ of Field Crop Production,0.39,0.5,0.0,0.06,0.0,0.0,0.0,0.06,sruthi narayanan kutty,
-PES,4850,1.0,Environmental Soil Chemistry,0.55,0.27,0.0,0.0,0.18,0.0,0.0,0.0,haibo liu,
-PES,4960,1.0,Sel Top: Soil Judging,0.57,0.0,0.0,0.14,0.14,0.0,0.0,0.14,dara michelle park,
-PHIL,1010,2.0,Intro to Philosophic Problems,0.51,0.43,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1010,3.0,Intro to Philosophic Problems,0.56,0.35,0.06,0.03,0.0,0.0,0.0,0.0,christopher grau,
-PHIL,1010,7.0,Intro to Philosophic Problems,0.71,0.12,0.0,0.0,0.06,0.0,0.0,0.12,david stegall,
-PHIL,1010,8.0,Intro to Philosophic Problems,0.53,0.35,0.0,0.06,0.0,0.0,0.0,0.06,david stegall,
-PHIL,1010,9.0,Intro to Philosophic Problems,0.44,0.36,0.08,0.0,0.03,0.0,0.0,0.08,david stegall,
-PHIL,1020,1.0,Introduction to Logic,0.4,0.37,0.14,0.06,0.03,0.0,0.0,0.0,adam gies,
-PHIL,1020,3.0,Introduction to Logic,0.4,0.31,0.29,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1020,4.0,Introduction to Logic,0.47,0.31,0.0,0.03,0.08,0.0,0.0,0.11,craig bacon,
-PHIL,1020,7.0,Introduction to Logic,0.37,0.2,0.09,0.09,0.03,0.0,0.0,0.23,david stegall,
-PHIL,1020,11.0,Introduction to Logic,0.61,0.14,0.11,0.03,0.0,0.0,0.0,0.11,david stegall,
-PHIL,1020,15.0,Introduction to Logic,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1020,16.0,Introduction to Logic,0.16,0.53,0.21,0.05,0.0,0.0,0.0,0.05,edyta joanna kuzian,
-PHIL,1020,17.0,Introduction to Logic,0.55,0.26,0.11,0.0,0.03,0.0,0.0,0.05,edyta joanna kuzian,
-PHIL,1020,18.0,Introduction to Logic,0.78,0.13,0.03,0.0,0.0,0.0,0.0,0.06,adam paul omelianchuk,
-PHIL,1020,19.0,Introduction to Logic,0.69,0.11,0.11,0.0,0.0,0.0,0.0,0.09,adam paul omelianchuk,
-PHIL,1020,20.0,Introduction to Logic,0.85,0.12,0.0,0.03,0.0,0.0,0.0,0.0,adam paul omelianchuk,
-PHIL,1030,2.0,Introduction to Ethics,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,stephen satris,
-PHIL,1030,3.0,Introduction to Ethics,0.4,0.34,0.14,0.06,0.0,0.0,0.0,0.06,david robert antonini,
-PHIL,1030,6.0,Introduction to Ethics,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,charles starkey,
-PHIL,1030,8.0,Introduction to Ethics,0.79,0.06,0.06,0.0,0.03,0.0,0.0,0.06,winthrop brent hepburn,
-PHIL,1030,9.0,Introduction to Ethics,0.5,0.44,0.03,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,
-PHIL,1030,10.0,Introduction to Ethics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
-PHIL,3040,1.0,Moral Philosophy,0.4,0.47,0.07,0.0,0.07,0.0,0.0,0.0,todd may,
-PHIL,3150,1.0,Ancient Philosophy,0.39,0.42,0.09,0.06,0.0,0.0,0.0,0.03,stephen satris,
-PHIL,3210,1.0,Crime & Punishment,0.21,0.63,0.11,0.0,0.0,0.0,0.0,0.05,daniel wueste,
-PHIL,3260,1.0,Science and Values,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,david robert antonini,
-PHIL,3260,2.0,Science and Values,0.62,0.29,0.06,0.0,0.0,0.0,0.0,0.03,david robert antonini,
-PHIL,3300,1.0,Animal Rights,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,todd may,
-PHIL,3430,1.0,Philosophy of Law,0.29,0.47,0.18,0.0,0.0,0.0,0.0,0.06,brookes colyton brown,
-PHIL,3440,1.0,Business Ethics,0.17,0.5,0.13,0.0,0.04,0.0,0.0,0.17,brookes colyton brown,
-PHIL,3450,1.0,Environmental Ethics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,adam paul omelianchuk,
-PHIL,3480,1.0,Philosophies of Art,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christopher grau,
-PHIL,3510,1.0,Phil of Emotion,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,charles starkey,
-PHIL,4020,2.0,Topics in Philosophy,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,diane perpich,
-PHIL,4920,2.0,Creative Inquiry in Philosophy,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,stephen satris,
-PHSC,1180,1.0,Intro to Phy & Astr for Ele Ed,0.77,0.18,0.03,0.02,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1.0,Physics with Calculus I,0.3,0.26,0.26,0.09,0.06,0.0,0.0,0.04,lih-sin the,
-PHYS,1220,2.0,Physics with Calculus I,0.21,0.31,0.27,0.07,0.06,0.0,0.0,0.07,lih-sin the,
-PHYS,1220,3.0,Physics W/Cal I (HON),0.42,0.33,0.08,0.0,0.0,0.0,0.0,0.17,joshua alper,True
-PHYS,1220,4.0,Physics with Calculus I,0.27,0.32,0.05,0.18,0.09,0.0,0.0,0.09,joshua alper,
-PHYS,1240,1.0,Physics Lab I,0.07,0.14,0.5,0.14,0.07,0.0,0.0,0.07,daniel ross thompson,
-PHYS,1240,2.0,Physics Lab I,0.09,0.73,0.09,0.09,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,3.0,Physics Lab I,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,4.0,Physics Lab I,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,5.0,Physics Lab I,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,6.0,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,7.0,Physics Lab I,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,8.0,Physics Lab I,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,9.0,Physics Lab I,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,10.0,Physics Lab I,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,
-PHYS,1240,11.0,Physics Lab I,0.63,0.19,0.13,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,13.0,Physics Lab I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,14.0,Physics Lab I,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,15.0,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,16.0,Physics Lab I,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,17.0,Physics Lab I,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,18.0,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,1240,19.0,Physics Lab I,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,1240,21.0,Physics Lab I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2070,1.0,General Physics I,0.24,0.23,0.2,0.15,0.1,0.0,0.0,0.08,amy liann pope,
-PHYS,2070,2.0,General Physics I,0.31,0.29,0.21,0.08,0.06,0.0,0.0,0.05,amy liann pope,
-PHYS,2070,3.0,General Physics I,0.19,0.31,0.27,0.07,0.1,0.0,0.0,0.06,amy liann pope,
-PHYS,2070,4.0,General Physics I,0.23,0.31,0.23,0.13,0.08,0.0,0.0,0.02,david edward connick,
-PHYS,2080,1.0,General Physics II,0.42,0.34,0.13,0.09,0.03,0.0,0.0,0.0,david edward connick,
-PHYS,2090,1.0,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,2.0,Gen Phys Lab I,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,3.0,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,4.0,Gen Phys Lab I,0.83,0.09,0.0,0.0,0.0,0.0,0.0,0.09,daniel ross thompson,
-PHYS,2090,5.0,Gen Phys Lab I,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,6.0,Gen Phys Lab I,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,7.0,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,8.0,Gen Phys Lab I,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,9.0,Gen Phys Lab I,0.65,0.22,0.09,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,10.0,Gen Phys Lab I,0.71,0.17,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,
-PHYS,2090,11.0,Gen Phys Lab I,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,12.0,Gen Phys Lab I,0.63,0.21,0.0,0.04,0.04,0.0,0.0,0.08,daniel ross thompson,
-PHYS,2090,13.0,Gen Phys Lab I,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,14.0,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,15.0,Gen Phys Lab I,0.79,0.04,0.08,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,
-PHYS,2090,16.0,Gen Phys Lab I,0.83,0.04,0.09,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,17.0,Gen Phys Lab I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,18.0,Gen Phys Lab I,0.58,0.25,0.04,0.0,0.04,0.0,0.0,0.08,daniel ross thompson,
-PHYS,2090,19.0,Gen Phys Lab I,0.63,0.33,0.0,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,20.0,Gen Phys Lab I,0.7,0.22,0.09,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,21.0,Gen Phys Lab I,0.33,0.54,0.04,0.0,0.08,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,22.0,Gen Phys Lab I,0.61,0.3,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2090,23.0,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,24.0,Gen Phys Lab I,0.5,0.38,0.0,0.0,0.04,0.0,0.0,0.08,daniel ross thompson,
-PHYS,2090,25.0,Gen Phys Lab I,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,26.0,Gen Phys Lab I,0.57,0.35,0.04,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2090,27.0,Gen Phys Lab I,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2100,1.0,Gen Phys Lab II,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,2.0,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,3.0,Gen Phys Lab II,0.63,0.33,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,4.0,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,6.0,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,7.0,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,8.0,Gen Phys Lab II,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2100,9.0,Gen Phys Lab II,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,
-PHYS,2210,1.0,Physics with Calculus II,0.13,0.43,0.29,0.09,0.03,0.0,0.0,0.03,jason stratford brown,
-PHYS,2210,2.0,Physics with Calculus II,0.21,0.47,0.24,0.05,0.01,0.0,0.0,0.02,jason stratford brown,
-PHYS,2210,3.0,Physics with Calculus II,0.37,0.48,0.11,0.02,0.0,0.0,0.0,0.01,chad sosolik,
-PHYS,2210,4.0,Physics with Calculus II,0.25,0.51,0.18,0.02,0.02,0.0,0.0,0.01,chad sosolik,
-PHYS,2210,5.0,Physics w/Calculus II(HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True
-PHYS,2220,1.0,Physics with Calculus III,0.74,0.11,0.05,0.0,0.0,0.0,0.0,0.11,murray daw,
-PHYS,2230,1.0,Physics Lab II,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,2.0,Physics Lab II,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,3.0,Physics Lab II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,4.0,Physics Lab II,0.17,0.78,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,5.0,Physics Lab II,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,6.0,Physics Lab II,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,7.0,Physics Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,9.0,Physics Lab II,0.29,0.65,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,10.0,Physics Lab II,0.22,0.72,0.0,0.0,0.06,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,11.0,Physics Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,13.0,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,
-PHYS,2230,14.0,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2230,17.0,Physics Lab II,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,daniel ross thompson,
-PHYS,2450,1.0,Physics of Climate,0.37,0.37,0.09,0.05,0.01,0.0,0.0,0.11,jens oberheide,
-PHYS,3000,1.0,Intro to Research,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean brittain,
-PHYS,3150,1.0,Intro to Computational Physics,0.4,0.2,0.27,0.0,0.0,0.0,0.0,0.13,jason stratford brown,
-PHYS,3210,1.0,Mechanics I,0.17,0.41,0.17,0.07,0.0,0.0,0.0,0.17,stephen roland kaeppler,
-PHYS,3250,1.0,Exper Physics I,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,jianbo gao,
-PHYS,3990,7.0,CI: K-12 STEM Competitions,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,domnita catalina marinescu,
-PHYS,4410,1.0,Electromagnetics I,0.24,0.41,0.29,0.0,0.06,0.0,0.0,0.0,xian lu,
-PHYS,4520,1.0,Nuclear and Particle Physics,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,endre andras takacs,
-PHYS,4550,1.0,Quantum Physics I,0.15,0.46,0.38,0.0,0.0,0.0,0.0,0.0,gerald lehmacher,
-PHYS,6550,1.0,Quantum Physics I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,gerald lehmacher,
-PHYS,8110,1.0,Meth of Theor Phys I,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,feng ding,
-PHYS,8210,1.0,Classical Mech I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,dieter hartmann,
-PHYS,9510,1.0,Quantum Mech I,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,sumanta tewari,
-PKSC,1010,1.0,Pkgsc Orientation,0.9,0.05,0.01,0.01,0.0,0.0,0.0,0.01,patricia guerra marcondes,
-PKSC,1020,1.0,Intro to Pkg Sci,0.08,0.31,0.33,0.18,0.05,0.0,0.0,0.05,heather batt,
-PKSC,2010,1.0,Pkg Perishable Prod,0.13,0.28,0.09,0.09,0.22,0.0,0.0,0.19,heather batt,
-PKSC,2020,1.0,Packaging Mtl & Mfg,0.23,0.4,0.27,0.1,0.0,0.0,0.0,0.0,patricia guerra marcondes,
-PKSC,2040,1.0,Container Systems,0.31,0.38,0.15,0.0,0.0,0.0,0.0,0.15,patricia guerra marcondes,
-PKSC,2200,1.0,Product & Pkg Design,0.73,0.14,0.08,0.0,0.05,0.0,0.0,0.0,haley ellis appleby,
-PKSC,3200,1.0,Pkg Design Theory,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,rupert hurley,
-PKSC,4010,1.0,Packaging Machinery,0.42,0.38,0.17,0.01,0.01,0.0,0.0,0.0,anthony louis pometto,
-PKSC,4030,1.0,Packaging Career Preparation,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4040,1.0,Protective Packaging Prop/Prin,0.23,0.44,0.23,0.03,0.04,0.0,0.0,0.03,gregory batt,
-PKSC,4160,1.0,Application of Polymers in Pkg,0.34,0.56,0.08,0.0,0.02,0.0,0.0,0.0,alicia cutler campbell,
-PKSC,4200,1.0,Package Design & Development,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4540,1.0,Product & Pkg Evaluation Lab,0.13,0.6,0.2,0.0,0.0,0.0,0.0,0.07,gregory batt,
-PKSC,4540,2.0,Product & Pkg Evaluation Lab,0.19,0.5,0.06,0.06,0.13,0.0,0.0,0.06,gregory batt,
-PKSC,4540,3.0,Product & Pkg Evaluation Lab,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4540,4.0,Product & Pkg Evaluation Lab,0.09,0.45,0.27,0.09,0.0,0.0,0.0,0.09,gregory batt,
-PKSC,4540,5.0,Product & Pkg Evaluation Lab,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1.0,Food & Health Care Pkg Systems,0.58,0.33,0.04,0.02,0.02,0.0,0.0,0.0,kay cooksey,
-PKSC,4990,7.0,Creative Inquiry Pkg Science,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,rupert hurley,
-PLPA,3100,1.0,Principles of Plant Pathology,0.26,0.22,0.3,0.19,0.04,0.0,0.0,0.0,steven nye jeffers,
-PLPA,4250,1.0,Introductory Mycology,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,julia louise kerrigan,
-PLPA,8020,1.0,Principles of Plant Pathology,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,
-POSC,1010,1.0,Amer National Govt,0.42,0.35,0.16,0.02,0.04,0.0,0.0,0.02,ethan craig busby,
-POSC,1010,2.0,Amer National Govt,0.32,0.32,0.22,0.12,0.01,0.0,0.0,0.0,robert carey,
-POSC,1020,1.0,Intro Intl Relations,0.31,0.41,0.13,0.07,0.02,0.0,0.0,0.06,steven vincent miller,
-POSC,1020,2.0,Intro Intl Relations,0.4,0.35,0.13,0.03,0.03,0.0,0.0,0.06,tara elizabeth trask,
-POSC,1020,3.0,Intro Intl Relations,0.56,0.29,0.07,0.01,0.03,0.0,0.0,0.04,tara elizabeth trask,
-POSC,1020,4.0,Intro Intl Relations,0.12,0.48,0.12,0.14,0.07,0.0,0.0,0.07,joshua douglas king,
-POSC,1020,5.0,Intro Intl Relations,0.12,0.51,0.27,0.0,0.02,0.0,0.0,0.08,colin denby pearce,
-POSC,1020,6.0,Intro Intl Relations,0.41,0.36,0.12,0.01,0.06,0.0,0.0,0.04,tara elizabeth trask,
-POSC,1030,1.0,Intro to Political Theory,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,derek neal duplessie,
-POSC,1030,2.0,Intro to Political Theory,0.3,0.5,0.13,0.0,0.03,0.0,0.0,0.03,adam michael thomas,
-POSC,1030,3.0,Intro to Political Theory,0.27,0.43,0.2,0.0,0.0,0.0,0.0,0.1,colin denby pearce,
-POSC,1030,4.0,Intro to Political Theory,0.4,0.29,0.23,0.03,0.03,0.0,0.0,0.03,brandon turner,
-POSC,1040,1.0,Intro Compar Pol,0.44,0.28,0.19,0.04,0.0,0.0,0.0,0.06,matthew henry rhodes-purdy,
-POSC,1990,1.0,Intro Pol Sci,0.47,0.32,0.09,0.06,0.02,0.0,0.0,0.04,meredith-joy petersheim,
-POSC,3020,1.0,State and Loc Gov,0.17,0.6,0.1,0.0,0.02,0.0,0.0,0.1,bruce ransom,
-POSC,3050,1.0,CI in Political Sci,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,matthew henry rhodes-purdy,True
-POSC,3110,1.0,Model United Nations,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,xiaobo hu,
-POSC,3410,1.0,Quant Meth in Pol Sc,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,ethan craig busby,
-POSC,3610,1.0,International Conflict,0.28,0.22,0.18,0.04,0.22,0.0,0.0,0.06,steven vincent miller,
-POSC,3620,1.0,Intl Organizations,0.21,0.33,0.21,0.04,0.08,0.0,0.0,0.13,zeynep taydas,
-POSC,3620,2.0,Intl Organizations,0.32,0.36,0.08,0.08,0.08,0.0,0.0,0.08,zeynep taydas,
-POSC,3630,1.0,Us Foreign Policy,0.29,0.57,0.09,0.03,0.0,0.0,0.0,0.03,jeffrey scott peake,
-POSC,3710,1.0,European Politics,0.45,0.37,0.08,0.0,0.0,0.0,0.0,0.1,vladimir matic,
-POSC,4030,1.0,United States Congress,0.27,0.31,0.33,0.06,0.02,0.0,0.0,0.02,jeffrey allen fine,
-POSC,4210,1.0,Public Policy,0.17,0.33,0.33,0.06,0.0,0.0,0.0,0.11,adam warber,
-POSC,4300,1.0,Policy Evaluation,0.45,0.18,0.27,0.0,0.0,0.0,0.0,0.09,robert carey,
-POSC,4360,1.0,Law Courts Politics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
-POSC,4360,2.0,Law Courts Politics,0.74,0.24,0.03,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
-POSC,4370,1.0,Constitut Law: Rights & Libert,0.4,0.5,0.05,0.0,0.0,0.0,0.0,0.05,kevin gregory vance,
-POSC,4380,1.0,Constitut Law: Struc of Gov,0.56,0.27,0.1,0.02,0.0,0.0,0.0,0.04,christina rose bambrick,
-POSC,4420,1.0,Pol Parties & Elect,0.29,0.43,0.22,0.04,0.0,0.0,0.0,0.02,laura olson,
-POSC,4490,1.0,Political Theory of Capitalism,0.29,0.44,0.24,0.0,0.0,0.0,0.0,0.03,colin denby pearce,
-POSC,4490,2.0,Political Theory of Capitalism,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,brandon turner,
-POSC,4500,1.0,Rights: Theory & Practice,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,christina rose bambrick,
-POSC,4550,1.0,Pol Thght of American Founding,0.52,0.37,0.11,0.0,0.0,0.0,0.0,0.0, bradley thompson,
-POSC,4580,1.0,Political Leadership,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,joshua douglas king,
-POSC,4760,1.0,Middle East Politics,0.5,0.38,0.0,0.0,0.06,0.0,0.0,0.06,vladimir matic,
-POSC,4780,1.0,Latin Amer Politics,0.63,0.23,0.09,0.0,0.06,0.0,0.0,0.0,matthew henry rhodes-purdy,
-POST,8990,1.0,"Markets, Gov't. & Public Pol.",0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert carey,
-PRTM,1950,2.0,Pro Golf Management Seminar I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,2110,1.0,Sts Play Rec Tourism,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew mutel browning,
-PRTM,2200,1.0,Foundations of PRTM,0.16,0.66,0.18,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2200,2.0,Foundations of PRTM,0.34,0.49,0.12,0.03,0.02,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2260,1.0,Fnd of Mgt Adm PRTM,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2260,2.0,Fnd of Mgt Adm PRTM,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,
-PRTM,2260,3.0,Fnd of Mgt Adm PRTM,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2260,4.0,Fnd of Mgt Adm PRTM,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2260,5.0,Fnd of Mgt Adm PRTM,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,2260,6.0,Fnd of Mgt Adm PRTM,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,
-PRTM,2260,7.0,Fnd of Mgt Adm PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,
-PRTM,2260,8.0,Fnd of Mgt Adm PRTM,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,
-PRTM,2270,1.0,Prov of Leisure Exp,0.5,0.38,0.06,0.06,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2270,2.0,Prov of Leisure Exp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,
-PRTM,2270,3.0,Prov of Leisure Exp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2270,4.0,Prov of Leisure Exp,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2270,5.0,Prov of Leisure Exp,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,2270,6.0,Prov of Leisure Exp,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,
-PRTM,2270,7.0,Prov of Leisure Exp,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,
-PRTM,2270,8.0,Prov of Leisure Exp,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,
-PRTM,2290,1.0,Competency Integration in PRTM,0.44,0.38,0.13,0.06,0.0,0.0,0.0,0.0,teresa walton tucker,
-PRTM,2290,2.0,Competency Integration in PRTM,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,
-PRTM,2290,3.0,Competency Integration in PRTM,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,francis mcguire,
-PRTM,2290,4.0,Competency Integration in PRTM,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,
-PRTM,2290,5.0,Competency Integration in PRTM,0.38,0.38,0.19,0.06,0.0,0.0,0.0,0.0,gwynn powell,
-PRTM,2290,6.0,Competency Integration in PRTM,0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,jeffrey townsend,
-PRTM,2290,7.0,Competency Integration in PRTM,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,
-PRTM,2290,8.0,Competency Integration in PRTM,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,
-PRTM,2980,9.0,Creative Inquiry in PRTM II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,denise marie anderson,
-PRTM,3050,1.0,Safety/Risk Mgt PRTM,0.43,0.3,0.13,0.1,0.0,0.0,0.0,0.03,daniel morgan anderson,
-PRTM,3070,2.0,Facility Operations,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,raymond dunham,
-PRTM,3200,1.0,Recreation Policy,0.8,0.0,0.1,0.05,0.0,0.0,0.0,0.05,elizabeth perry,
-PRTM,3240,1.0,Assessment & Planning in RT,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,3300,1.0,Visit Ser & Interp,0.5,0.22,0.22,0.06,0.0,0.0,0.0,0.0,aby lat soukabe sene harper,
-PRTM,3420,1.0,Intro to Tourism,0.5,0.35,0.06,0.03,0.0,0.0,0.0,0.06,gregory philip ramshaw,
-PRTM,3430,1.0,Spl Asp of Tourist B,0.53,0.36,0.09,0.0,0.0,0.0,0.0,0.02,william norman,
-PRTM,3470,1.0,Sport Tourism,0.36,0.36,0.23,0.0,0.0,0.0,0.0,0.05,gregory philip ramshaw,
-PRTM,3520,1.0,Camp Org and Admin,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,alexsandra dubin,
-PRTM,3600,1.0,Recreation & Amateur Sport Mgt,0.35,0.35,0.17,0.04,0.0,0.0,0.0,0.09,skye gerald arthur-banning,
-PRTM,3900,8.0,PGA GM Player Development,0.7,0.15,0.1,0.0,0.0,0.0,0.0,0.05,richard lucas,
-PRTM,3910,1.0,Issues & Trends in Event Mgmt.,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,stephanie perler garst,
-PRTM,3920,1.0,Special Event Management,0.95,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,
-PRTM,4030,1.0,Elem of Rec/Pk Plan,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,samuel gaines,
-PRTM,4210,1.0,Rec Fin Resc Mgt,0.54,0.39,0.02,0.0,0.02,0.0,0.0,0.02,ryan joseph gagnon,
-PRTM,4220,2.0,Management of RT Services,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,sandra heath,
-PRTM,4230,1.0,Adaptive Sports & Recreation,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,jasmine nutter townsend,
-PRTM,4260,1.0,Trends & Issues in Rec Therapy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,
-PRTM,4470,1.0,Perspect Intl Travel,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,'lisha fogle,
-PRTM,4470,2.0,Perspect Intl Travel,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sheila backman,
-PRTM,4510,1.0,Seminar in CRSCM,0.7,0.19,0.06,0.02,0.02,0.0,0.0,0.0,skye gerald arthur-banning,
-PRTM,4550,1.0,Adv Program Planning,0.73,0.25,0.02,0.0,0.0,0.0,0.0,0.0,harrison parker pinckney,
-PRTM,4740,2.0,Adv Rec Resource Mgt,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,matthew tyler james brownlee,
-PRTM,8080,2.0,Behavioral Aspects,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,iryna sharaievska,
-PRTM,8080,3.0,Behavioral Aspects,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,lauren duffy,
-PRTM,8710,1.0,Applied Research in Rec Therap,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,brandi crowe,
-PRTM,8720,1.0,Adv Facilitation Techniq in RT,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,
-PRTM,9000,11.0,MS Capstone,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charles hallo,
-PSYC,2010,1.0,Intro to Psychology,0.3,0.34,0.2,0.07,0.05,0.0,0.0,0.05,edwin brainerd,
-PSYC,2010,2.0,Intro to Psychology,0.3,0.31,0.2,0.09,0.03,0.0,0.0,0.07,jo jorgensen,
-PSYC,2010,3.0,Intro to Psychology,0.41,0.33,0.18,0.05,0.03,0.0,0.0,0.01,jo jorgensen,
-PSYC,2010,4.0,Intro to Psychology,0.49,0.29,0.11,0.01,0.03,0.0,0.0,0.07,chong hyon pak,
-PSYC,2010,5.0,Intro to Psychology,0.38,0.34,0.16,0.04,0.03,0.0,0.0,0.04,chong hyon pak,
-PSYC,2010,6.0,Intro to Psychology,0.41,0.33,0.16,0.03,0.03,0.0,0.0,0.04,mary taylor,
-PSYC,2010,7.0,Intro to Psychology,0.57,0.14,0.2,0.04,0.01,0.0,0.0,0.03,mary taylor,
-PSYC,2010,8.0,Intro to Psychology,0.37,0.36,0.14,0.04,0.06,0.0,0.0,0.03,fred switzer,
-PSYC,2010,9.0,Intro to Psychology (HON),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
-PSYC,2030,1.0,Fundamentals of Psych Science,0.41,0.37,0.15,0.06,0.01,0.0,0.0,0.01,peggy jean tyler,
-PSYC,3060,1.0,Human Sexual Behavior,0.51,0.22,0.16,0.05,0.04,0.0,0.0,0.02,bruce michael king,
-PSYC,3090,100.0,Intro Experimental Psychology,0.35,0.35,0.14,0.08,0.05,0.0,0.0,0.03,jennifer bailey bisson,
-PSYC,3090,200.0,Intro Experimental Psychology,0.66,0.21,0.14,0.0,0.0,0.0,0.0,0.0,patrick rosopa,
-PSYC,3100,100.0,Advanced Experimental Psych,0.29,0.41,0.12,0.0,0.12,0.0,0.0,0.06,eric mckibben,
-PSYC,3100,200.0,Advanced Experimental Psych,0.26,0.47,0.11,0.05,0.05,0.0,0.0,0.05,cynthia pury,
-PSYC,3100,300.0,Advanced Experimental Psych,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,3100,400.0,Advanced Experimental Psych,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,thomas britt,
-PSYC,3100,500.0,Advanced Experimental Psych,0.47,0.16,0.16,0.11,0.05,0.0,0.0,0.05,benjamin stephens,
-PSYC,3100,600.0,Advanced Experimental Psych,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3100,700.0,Advanced Experimental Psych,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3100,800.0,Advanced Experimental Psych,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3240,1.0,Physiological Psych,0.36,0.24,0.2,0.09,0.03,0.0,0.0,0.08,claudio cantalupo,
-PSYC,3240,2.0,Physiological Psych,0.25,0.22,0.2,0.11,0.05,0.0,0.0,0.18,june pilcher,
-PSYC,3240,3.0,Physiological Psych,0.29,0.33,0.21,0.07,0.03,0.0,0.0,0.07,claudio cantalupo,
-PSYC,3310,1.0,Critical Thinking,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3330,1.0,Cognitive Psych,0.68,0.23,0.08,0.01,0.0,0.0,0.0,0.0,kaileigh angela byrne,
-PSYC,3330,2.0,Cognitive Psych,0.49,0.37,0.11,0.03,0.0,0.0,0.0,0.0,kaileigh angela byrne,
-PSYC,3340,1.0,Cognitive Psych Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel braden quinn,
-PSYC,3340,2.0,Cognitive Psych Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,daniel braden quinn,
-PSYC,3340,3.0,Cognitive Psych Lab,0.76,0.04,0.08,0.04,0.04,0.0,0.0,0.04,laura whitlock,
-PSYC,3400,1.0,Lifespan Developmental Psych,0.27,0.31,0.21,0.1,0.04,0.0,0.0,0.06,pamela alley,
-PSYC,3400,2.0,Lifespan Developmental Psych,0.37,0.44,0.11,0.04,0.0,0.0,0.0,0.03,anita pei tam,
-PSYC,3520,1.0,Social Psychology,0.63,0.26,0.07,0.01,0.0,0.0,0.0,0.03,ceren gunsoy,
-PSYC,3520,2.0,Social Psychology (HON),0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,True
-PSYC,3570,1.0,Psychology and Culture,0.64,0.23,0.13,0.0,0.0,0.0,0.0,0.0,ceren gunsoy,
-PSYC,3640,1.0,Industrial Psych,0.97,0.0,0.03,0.0,0.0,0.0,0.0,0.0,joseph ligato,
-PSYC,3680,1.0,Organizational Psych,0.27,0.29,0.34,0.05,0.02,0.0,0.0,0.03,chloe wilson,
-PSYC,3700,1.0,Personality,0.54,0.29,0.1,0.04,0.01,0.0,0.0,0.01,john robert hester,
-PSYC,3830,1.0,Abnormal Psychology,0.43,0.42,0.09,0.01,0.0,0.0,0.0,0.04,heidi marie zinzow,
-PSYC,3830,2.0,Abnormal Psychology,0.23,0.31,0.2,0.09,0.06,0.0,0.0,0.11,pamela alley,
-PSYC,3830,3.0,Abnormal Psychology,0.11,0.26,0.34,0.14,0.03,0.0,0.0,0.11,pamela alley,
-PSYC,3890,1.0,Psychology of Music,0.28,0.28,0.2,0.12,0.12,0.0,0.0,0.0,claudio cantalupo,
-PSYC,4080,1.0,Women and Psychology,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,
-PSYC,4150,1.0,Systems and Theories,0.87,0.08,0.03,0.0,0.03,0.0,0.0,0.0,peggy jean tyler,
-PSYC,4150,2.0,Systems and Theories,0.29,0.35,0.21,0.12,0.0,0.0,0.0,0.03,edwin brainerd,
-PSYC,4150,3.0,Systems and Theories,0.33,0.3,0.27,0.0,0.06,0.0,0.0,0.03,edwin brainerd,
-PSYC,4220,1.0,Perception,0.37,0.33,0.22,0.07,0.0,0.0,0.0,0.0,richard tyrrell,
-PSYC,4220,2.0,Perception,0.33,0.22,0.26,0.15,0.0,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4220,3.0,Perception,0.41,0.3,0.19,0.11,0.0,0.0,0.0,0.0,christopher pagano,
-PSYC,4430,1.0,Infant & Child Dev,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,4560,1.0,Psychophysiology,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,sarah christine beadle,
-PSYC,4710,1.0,Psych of Testing,0.64,0.14,0.0,0.0,0.07,0.0,0.0,0.14,zhuo chen,
-PSYC,4800,1.0,Health Psychology,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,
-PSYC,4800,2.0,Health Psychology,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,james mccubbin,
-PSYC,4880,1.0,Psychotherapy,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,lucinda sorciere shealy quick,
-PSYC,4890,1.0,Sport Psychology,0.25,0.45,0.15,0.1,0.0,0.0,0.0,0.05,anita pei tam,
-PSYC,4920,1.0,Senior Laboratory,0.8,0.13,0.0,0.07,0.0,0.0,0.0,0.0,zachary paul klinefelter,
-PSYC,4920,2.0,Senior Laboratory,0.75,0.13,0.0,0.0,0.08,0.0,0.0,0.04,alexander moore,
-PSYC,4920,4.0,Senior Laboratory,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,zachary paul klinefelter,
-PSYC,4920,5.0,Senior Laboratory,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,hannah solini,
-PSYC,4930,100.0,Pract Clinical Psych,0.81,0.13,0.0,0.06,0.0,0.0,0.0,0.0,heidi marie zinzow,
-PSYC,4980,291.0,Suicide Prevention,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,
-PSYC,4980,363.0,Psych Religion Spr,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,zhuo chen,
-PSYC,8100,1.0,Research Design I,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,patrick rosopa,
-PSYC,8350,1.0,Advanced Human Factors Psych,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,chong hyon pak,
-PSYC,8620,1.0,Org Psychology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert raymond sinclair,
-PSYC,8680,1.0,Leadership in Orgs,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,patrick raymark,
-RED,8010,1.0,Market Analysis,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,thomas andrew fox,
-REL,1010,1.0,Intro to Religion,0.32,0.47,0.16,0.05,0.0,0.0,0.0,0.0,peter cohen,
-REL,1010,2.0,Intro to Religion,0.32,0.32,0.11,0.11,0.0,0.0,0.0,0.16,peter cohen,
-REL,1010,3.0,Intro to Religion,0.43,0.37,0.09,0.06,0.0,0.0,0.0,0.06,peter cohen,
-REL,1010,5.0,Intro to Religion,0.5,0.17,0.17,0.0,0.0,0.0,0.0,0.17,brett patterson,
-REL,1020,1.0,World Religions (HON),0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,peter cohen,True
-REL,1020,2.0,World Religions,0.54,0.26,0.14,0.0,0.0,0.0,0.0,0.06,robert stephens,
-REL,1020,3.0,World Religions,0.57,0.29,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,
-REL,1020,4.0,World Religions,0.51,0.31,0.11,0.0,0.06,0.0,0.0,0.0,robert stephens,
-REL,1020,5.0,World Religions,0.14,0.54,0.23,0.09,0.0,0.0,0.0,0.0,brett patterson,
-REL,3010,1.0,Old Testament,0.35,0.35,0.15,0.06,0.0,0.0,0.0,0.09,john thames,
-REL,3020,1.0,New Testament Lit,0.53,0.41,0.0,0.03,0.0,0.0,0.0,0.03,benjamin white,
-REL,3080,1.0,Religions of the Ancient World,0.19,0.53,0.06,0.0,0.03,0.0,0.0,0.19,benjamin white,
-REL,3110,1.0,African American Rel,0.47,0.26,0.16,0.05,0.0,0.0,0.0,0.05,elizabeth jemison,
-REL,3120,1.0,Hinduism,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,robert stephens,
-REL,3300,1.0,Contemporary Issues,0.47,0.35,0.0,0.06,0.06,0.0,0.0,0.06,elizabeth jemison,
-RS,3010,1.0,Rural Sociology,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,kenneth robinson,
-RS,4010,1.0,Human Ecology,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
-RUSS,3400,1.0,19th C Russ Culture,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,olga anatolyevna volkova,
-RUSS,3610,1.0,Russn Lit Since 1910,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,olga anatolyevna volkova,
-SOC,2010,1.0,Introduction to Sociology,0.65,0.29,0.04,0.01,0.0,0.0,0.0,0.01,carolyn candace coffman,
-SOC,2010,2.0,Introduction to Sociology,0.69,0.26,0.04,0.0,0.01,0.0,0.0,0.0,carolyn candace coffman,
-SOC,2010,3.0,Introduction to Sociology,0.56,0.27,0.08,0.02,0.04,0.0,0.0,0.02,miao li,
-SOC,2010,4.0,Introduction to Sociology,0.86,0.12,0.0,0.0,0.01,0.0,0.0,0.0,andrew herman mannheimer,
-SOC,2010,5.0,Introduction to Sociology,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.01,shannon mcdonough,
-SOC,2010,6.0,Introduction to Sociology,0.55,0.33,0.1,0.01,0.0,0.0,0.0,0.01,shannon mcdonough,
-SOC,2010,7.0,Introduction to Sociology,0.6,0.29,0.08,0.0,0.0,0.0,0.0,0.02,jennifer leanne holland,
-SOC,2040,1.0,Prof Dev for Sociology Majors,0.64,0.2,0.09,0.02,0.02,0.0,0.0,0.02, catherine mobley,
-SOC,3020,1.0,Research Methods I,0.4,0.38,0.08,0.08,0.0,0.0,0.0,0.06,andrew whitehead,
-SOC,3040,1.0,Social Research Methods II,0.25,0.45,0.18,0.08,0.03,0.0,0.0,0.03,ye luo,
-SOC,3100,1.0,Marriage & Intimacy,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,heather kettrey,
-SOC,3400,1.0,Sport and Society,0.36,0.43,0.17,0.04,0.0,0.0,0.0,0.0,andrew whitehead,
-SOC,3510,1.0,Collective Behavior,0.27,0.41,0.2,0.08,0.0,0.0,0.0,0.04,matthew john costello,
-SOC,3600,1.0,Class & Poverty,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,william haller,
-SOC,3910,1.0,Soc of Deviance,0.53,0.31,0.12,0.04,0.0,0.0,0.0,0.0,matthew john costello,
-SOC,3940,1.0,Sociology of Mental Illness,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,james rosenberger,
-SOC,3970,1.0,Substance Abuse,0.69,0.27,0.0,0.0,0.04,0.0,0.0,0.0,shannon mcdonough,
-SOC,4030,1.0,"Technol, Environment & Society",0.53,0.26,0.19,0.02,0.0,0.0,0.0,0.0, catherine mobley,
-SOC,4040,1.0,Soc Theory,0.6,0.25,0.0,0.0,0.0,0.0,0.0,0.15,william haller,
-SOC,4140,1.0,Policy&Social Change,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jennifer leanne holland,
-SOC,4440,1.0,Sociology of Educ,0.82,0.14,0.02,0.02,0.0,0.0,0.0,0.0,andrew herman mannheimer,
-SOC,4600,1.0,Race & Ethnicity,0.88,0.02,0.06,0.0,0.02,0.0,0.0,0.02,andrew herman mannheimer,
-SOC,4610,1.0,Sex & Gender,0.55,0.2,0.16,0.02,0.02,0.0,0.0,0.04,minyoung moon,
-SOC,4710,1.0,World Population and Society,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,ye luo,
-SOC,4950,1.0,Field Experience,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0, catherine mobley,
-SOC,8920,1.0,Sel Top: Quantitative Methods,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,miao li,
-SPAN,1010,1.0,Elementary Spanish,0.26,0.47,0.21,0.0,0.05,0.0,0.0,0.0,stephanie elysse morris,
-SPAN,1010,2.0,Elementary Spanish,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,stephanie elysse morris,
-SPAN,1010,3.0,Elementary Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,rosa macarena pillcurima,
-SPAN,1020,1.0,Elementary Spanish,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,rosa macarena pillcurima,
-SPAN,1020,2.0,Elementary Spanish,0.63,0.25,0.06,0.06,0.0,0.0,0.0,0.0,liliana hernandez,
-SPAN,1020,3.0,Elementary Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mercedes tejera,
-SPAN,1020,4.0,Elementary Spanish,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,mercedes tejera,
-SPAN,1020,5.0,Elementary Spanish,0.39,0.39,0.11,0.11,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,
-SPAN,1020,6.0,Elementary Spanish,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,
-SPAN,1020,8.0,Elementary Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,1020,10.0,Elementary Spanish,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,debra oaks williamson,
-SPAN,1020,11.0,Elementary Spanish,0.47,0.35,0.12,0.0,0.0,0.0,0.0,0.06,debra oaks williamson,
-SPAN,1020,13.0,Elementary Spanish,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,yezid flores,
-SPAN,2010,1.0,Intermediate Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,maria rosa judez riquelme,
-SPAN,2010,2.0,Intermediate Spanish,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,liliana hernandez,
-SPAN,2010,3.0,Intermediate Spanish,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,
-SPAN,2010,4.0,Intermediate Spanish,0.71,0.06,0.24,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,
-SPAN,2010,7.0,Intermediate Spanish,0.53,0.21,0.16,0.0,0.05,0.0,0.0,0.05,debra oaks williamson,
-SPAN,2010,8.0,Intermediate Spanish,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,debra oaks williamson,
-SPAN,2010,9.0,Intermediate Spanish,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andrea patricia naranjo,
-SPAN,2010,10.0,Intermediate Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,11.0,Intermediate Spanish,0.47,0.42,0.0,0.11,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,12.0,Intermediate Spanish,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,ellory schmucker,
-SPAN,2010,14.0,Intermediate Spanish,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,nora arostegui logue,
-SPAN,2010,15.0,Intermediate Spanish,0.33,0.44,0.11,0.0,0.0,0.0,0.0,0.11,zenia beatriz cruz valderramos,
-SPAN,2010,16.0,Intermediate Spanish,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,
-SPAN,2010,17.0,Intermediate Spanish,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,maria rosa judez riquelme,
-SPAN,2010,18.0,Intermediate Spanish,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,mercedes tejera,
-SPAN,2010,19.0,Intermediate Spanish,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,liliana hernandez,
-SPAN,2020,1.0,Intermediate Spanish,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,melva marguerite persico,
-SPAN,2020,2.0,Intermediate Spanish,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,melva marguerite persico,
-SPAN,2020,3.0,Intermediate Spanish,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,yezid flores,
-SPAN,2020,4.0,Intermediate Spanish,0.61,0.28,0.0,0.0,0.11,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,5.0,Intermediate Spanish,0.74,0.05,0.16,0.0,0.05,0.0,0.0,0.0,yezid flores,
-SPAN,2020,6.0,Intermediate Spanish,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,rosa macarena pillcurima,
-SPAN,2020,7.0,Intermediate Spanish,0.63,0.26,0.0,0.0,0.05,0.0,0.0,0.05,rosa macarena pillcurima,
-SPAN,2020,8.0,Intermediate Spanish,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,ana paula  miller,
-SPAN,2020,9.0,Intermediate Spanish,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,10.0,Intermediate Spanish,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,
-SPAN,2020,11.0,Intermediate Spanish,0.46,0.46,0.0,0.0,0.0,0.0,0.0,0.08,jose luis ortiz,
-SPAN,2020,13.0,Intermediate Spanish,0.41,0.24,0.18,0.12,0.0,0.0,0.0,0.06,jose luis ortiz,
-SPAN,2020,14.0,Intermediate Spanish,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,daniel david garcia vieyra,
-SPAN,2020,15.0,Intermediate Spanish,0.61,0.22,0.06,0.06,0.0,0.0,0.0,0.06,yezid flores,
-SPAN,2020,16.0,Intermediate Spanish,0.63,0.16,0.11,0.0,0.0,0.0,0.0,0.11,daniel david garcia vieyra,
-SPAN,3010,1.0,Spanish Comp for Health Prof,0.12,0.53,0.29,0.06,0.0,0.0,0.0,0.0,tiffany dawn creegan miller,
-SPAN,3020,1.0,Intermed Span Grammar & Comp,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,melva marguerite persico,
-SPAN,3020,2.0,Intermed Span Grammar & Comp,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,melva marguerite persico,
-SPAN,3020,3.0,Intermed Span Grammar & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,
-SPAN,3040,1.0,Intro Hispanic Literary Forms,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,graciela tissera,
-SPAN,3050,1.0,Intermed Span Convers/Comp I,0.68,0.21,0.0,0.05,0.0,0.0,0.0,0.05,daniel david garcia vieyra,
-SPAN,3050,2.0,Intermed Span Convers/Comp I,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,daniel david garcia vieyra,
-SPAN,3050,3.0,Intermed Span Convers/Comp I,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,
-SPAN,3050,4.0,Intermed Span Convers/Comp I,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,
-SPAN,3050,6.0,Intermed Span Convers/Comp I,0.5,0.39,0.0,0.06,0.0,0.0,0.0,0.06,jose luis ortiz,
-SPAN,3080,1.0,The Hispanic World: Latin Amer,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,tiffany dawn creegan miller,
-SPAN,3080,2.0,The Hispanic World: Latin Amer,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,
-SPAN,3130,2.0,Span Lit Survey I,0.29,0.36,0.07,0.0,0.0,0.0,0.0,0.29,monica rojas-de-massei,
-SPAN,3180,1.0,Spanish Through Culture,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,george palacios,
-SPAN,4060,1.0,Narrative Fiction,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,monica rojas-de-massei,
-SPAN,4060,2.0,Narrative Fiction,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,monica rojas-de-massei,
-SPAN,4070,1.0,Hispanic Film,0.72,0.06,0.22,0.0,0.0,0.0,0.0,0.0,salvador oropesa,
-SPAN,4190,1.0,Health & Hispanic Community,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,arelis moore peralta,
-STAT,2220,1.0,Statistics in Everyday Life,0.24,0.38,0.3,0.01,0.01,0.0,0.0,0.05,james espey,
-STAT,2220,2.0,Statistics in Everyday Life,0.27,0.36,0.22,0.05,0.04,0.0,0.0,0.05,james espey,
-STAT,2220,3.0,Statistics in Everyday Life,0.36,0.32,0.2,0.02,0.02,0.0,0.0,0.07,james espey,
-STAT,2220,4.0,Statistics in Everyday Life,0.26,0.28,0.28,0.09,0.02,0.0,0.0,0.06,james espey,
-STAT,2220,5.0,Statistics in Everyday Life,0.32,0.38,0.08,0.1,0.07,0.0,0.0,0.06,rose martinez-dawson,
-STAT,2220,6.0,Statistics in Everyday Life,0.37,0.3,0.15,0.08,0.06,0.0,0.0,0.04,rose martinez-dawson,
-STAT,2220,7.0,Statistics in Everyday Life,0.27,0.4,0.19,0.06,0.02,0.0,0.0,0.06,rose martinez-dawson,
-STAT,2300,1.0,Statistical Methods I,0.46,0.35,0.09,0.05,0.02,0.0,0.0,0.02,paran rebekah norton,
-STAT,2300,2.0,Statistical Methods I,0.38,0.32,0.18,0.04,0.07,0.0,0.0,0.01,paran rebekah norton,
-STAT,2300,3.0,Statistical Methods I,0.27,0.3,0.23,0.11,0.05,0.0,0.0,0.03, erwin walker,
-STAT,2300,4.0,Statistical Methods I,0.27,0.32,0.2,0.1,0.1,0.0,0.0,0.0, erwin walker,
-STAT,2300,5.0,Statistical Methods I,0.3,0.32,0.13,0.09,0.09,0.0,0.0,0.06,paran rebekah norton,
-STAT,2300,6.0,Statistical Methods I,0.29,0.38,0.17,0.06,0.05,0.0,0.0,0.05,sharon marie evans,
-STAT,2300,100.0,Statistical Methods I (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sharon marie evans,True
-STAT,3090,1.0,Introductory Business Stats,0.11,0.28,0.28,0.33,0.0,0.0,0.0,0.0,fun choi john chan,
-STAT,3090,2.0,Introductory Business Stats,0.0,0.35,0.35,0.24,0.06,0.0,0.0,0.0,fun choi john chan,
-STAT,3090,3.0,Introductory Business Stats,0.17,0.17,0.39,0.11,0.17,0.0,0.0,0.0,sarah kelly,
-STAT,3090,4.0,Introductory Business Stats,0.21,0.32,0.32,0.05,0.11,0.0,0.0,0.0,sarah kelly,
-STAT,3090,5.0,Introductory Business Stats,0.22,0.33,0.33,0.06,0.06,0.0,0.0,0.0,mary elizabeth saine,
-STAT,3090,6.0,Introductory Business Stats,0.21,0.26,0.37,0.05,0.05,0.0,0.0,0.05,mary elizabeth saine,
-STAT,3090,7.0,Introductory Business Stats,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,sean walker ingimarson,
-STAT,3090,8.0,Introductory Business Stats,0.21,0.37,0.26,0.16,0.0,0.0,0.0,0.0,sean walker ingimarson,
-STAT,3090,9.0,Introductory Business Stats,0.21,0.32,0.16,0.16,0.16,0.0,0.0,0.0,yidan guo,
-STAT,3090,10.0,Introductory Business Stats,0.22,0.33,0.22,0.11,0.11,0.0,0.0,0.0,yidan guo,
-STAT,3090,11.0,Introductory Business Stats,0.32,0.26,0.21,0.11,0.11,0.0,0.0,0.0,rui gong,
-STAT,3090,12.0,Introductory Business Stats,0.26,0.21,0.21,0.05,0.16,0.0,0.0,0.11,rui gong,
-STAT,3090,13.0,Introductory Business Stats,0.29,0.26,0.2,0.14,0.08,0.0,0.0,0.03,april thomas,
-STAT,3090,14.0,Introductory Business Stats,0.36,0.33,0.25,0.02,0.02,0.0,0.0,0.02,april thomas,
-STAT,3090,15.0,Introductory Business Stats,0.47,0.12,0.24,0.0,0.18,0.0,0.0,0.0,molly adams honecker,
-STAT,3090,16.0,Introductory Business Stats,0.53,0.32,0.05,0.0,0.11,0.0,0.0,0.0,molly adams honecker,
-STAT,3090,17.0,Introductory Business Stats,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,xueheng shi,
-STAT,3090,18.0,Introductory Business Stats,0.21,0.53,0.11,0.05,0.0,0.0,0.0,0.11,xueheng shi,
-STAT,3090,19.0,Introductory Business Stats,0.44,0.17,0.0,0.17,0.17,0.0,0.0,0.06,feng gao,
-STAT,3090,20.0,Introductory Business Stats,0.22,0.5,0.22,0.06,0.0,0.0,0.0,0.0,feng gao,
-STAT,3090,21.0,Introductory Business Stats,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,zhengxin wang,
-STAT,3090,22.0,Introductory Business Stats,0.44,0.17,0.28,0.11,0.0,0.0,0.0,0.0,zhengxin wang,
-STAT,3090,23.0,Introductory Business Stats,0.28,0.11,0.33,0.17,0.0,0.0,0.0,0.11,james mckay visser,
-STAT,3090,24.0,Introductory Business Stats,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,james mckay visser,
-STAT,3090,25.0,Introductory Business Stats,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,boyoung hur,
-STAT,3090,26.0,Introductory Business Stats,0.33,0.22,0.39,0.06,0.0,0.0,0.0,0.0,boyoung hur,
-STAT,3090,27.0,Introductory Business Stats,0.22,0.28,0.33,0.0,0.11,0.0,0.0,0.06,siyuan yu,
-STAT,3090,28.0,Introductory Business Stats,0.24,0.29,0.18,0.18,0.06,0.0,0.0,0.06,siyuan yu,
-STAT,3090,29.0,Introductory Business Stats,0.0,0.42,0.21,0.05,0.21,0.0,0.0,0.11,minghua cui,
-STAT,3090,30.0,Introductory Business Stats,0.08,0.38,0.15,0.08,0.15,0.0,0.0,0.15,minghua cui,
-STAT,3090,31.0,Introductory Business Stats,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,tiantian yang,
-STAT,3090,32.0,Introductory Business Stats,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,tiantian yang,
-STAT,3090,33.0,Introductory Business Stats,0.21,0.63,0.11,0.0,0.05,0.0,0.0,0.0,trevor camper,
-STAT,3090,34.0,Introductory Business Stats,0.11,0.37,0.37,0.05,0.11,0.0,0.0,0.0,trevor camper,
-STAT,3090,35.0,Introductory Business Stats,0.06,0.17,0.39,0.22,0.11,0.0,0.0,0.06,jiyun huang,
-STAT,3090,36.0,Introductory Business Stats,0.32,0.37,0.26,0.05,0.0,0.0,0.0,0.0,jiyun huang,
-STAT,3090,37.0,Introductory Business Stats,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,anna marie vagnozzi,
-STAT,3090,38.0,Introductory Business Stats,0.5,0.28,0.17,0.06,0.0,0.0,0.0,0.0,anna marie vagnozzi,
-STAT,3090,39.0,Introductory Business Stats,0.42,0.37,0.11,0.05,0.0,0.0,0.0,0.05,pubudu jayasekara merenchige,
-STAT,3090,40.0,Introductory Business Stats,0.37,0.26,0.21,0.05,0.05,0.0,0.0,0.05,pubudu jayasekara merenchige,
-STAT,3300,1.0,Statistical Methods II,0.22,0.22,0.22,0.0,0.13,0.0,0.0,0.22,rose martinez-dawson,
-STAT,4020,1.0,Intro to Statistical Computing,0.25,0.33,0.08,0.0,0.08,0.0,0.0,0.25,ellen hepfer breazel,
-STAT,4020,2.0,Intro to Statistical Computing,0.38,0.08,0.15,0.08,0.15,0.0,0.0,0.15,ellen hepfer breazel,
-STAT,4110,1.0,Stat Mthds for Process Control,0.68,0.18,0.05,0.05,0.03,0.0,0.0,0.0,richard steven dubsky,
-STAT,4110,2.0,Stat Mthds for Process Control,0.72,0.14,0.09,0.05,0.0,0.0,0.0,0.0,richard steven dubsky,
-STAT,4110,3.0,Stat Mthds for Process Control,0.5,0.21,0.14,0.0,0.05,0.0,0.0,0.1,yu-bo wang,
-STAT,4110,4.0,Stat Mthds for Process Control,0.3,0.32,0.22,0.03,0.11,0.0,0.0,0.03,yu-bo wang,
-STAT,6020,1.0,Intro to Statistical Computing,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,
-STAT,6020,2.0,Intro to Statistical Computing,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,
-STAT,8010,1.0,Statistical Methods I,0.55,0.23,0.18,0.0,0.0,0.0,0.0,0.05,patrick gerard,
-STAT,8010,2.0,Statistical Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah elizabeth kunkel,
-STAT,8010,4.0,Statistical Methods I,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,deborah elizabeth kunkel,
-STAT,8010,5.0,Statistical Methods I,0.56,0.17,0.06,0.0,0.17,0.0,0.0,0.06,jun luo,
-STAT,8010,6.0,Statistical Methods I,0.73,0.14,0.14,0.0,0.0,0.0,0.0,0.0,jun luo,
-STAT,8010,7.0,Statistical Methods I,0.43,0.38,0.14,0.0,0.0,0.0,0.0,0.05,joseph daniel bible,
-STAT,8020,1.0,Statistical Methods II,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,8050,1.0,Design & Anlys of Experiments,0.48,0.48,0.03,0.0,0.0,0.0,0.0,0.0,william bridges,
-STS,1010,1.0,Survey Sci & Techn in Society,0.59,0.32,0.0,0.03,0.03,0.0,0.0,0.03,kenneth david widgren,
-STS,1010,2.0,Survey Sci & Techn in Society,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,scott brame,
-STS,1010,3.0,Survey Sci & Techn in Society,0.67,0.25,0.03,0.03,0.0,0.0,0.0,0.03,elizabeth anderson stansell,
-STS,1010,4.0,Survey Sci & Techn in Society,0.69,0.26,0.03,0.0,0.03,0.0,0.0,0.0,ingrid anna pierce,
-STS,1010,5.0,Survey Sci & Techn in Society,0.42,0.5,0.06,0.0,0.03,0.0,0.0,0.0,philip randall,
-STS,1010,6.0,Survey Sci & Techn in Society,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,
-STS,1010,7.0,Survey Sci & Techn in Society,0.44,0.44,0.06,0.0,0.03,0.0,0.0,0.03,megan noel macalystre,
-STS,1010,8.0,Survey Sci & Techn in Society,0.44,0.41,0.09,0.0,0.0,0.0,0.0,0.06,david charles foltz,
-STS,1010,9.0,Survey Sci & Techn in Society,0.53,0.41,0.03,0.0,0.0,0.0,0.0,0.03,tareva leselle johnson,
-STS,1010,10.0,Survey Sci & Techn in Society,0.62,0.29,0.03,0.0,0.0,0.0,0.0,0.06,alexander john billinis,
-STS,1010,11.0,Survey Sci & Techn in Society,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,anne mcmahan grant,
-SUST,2010,1.0,Sustainability Leadership,0.88,0.03,0.03,0.03,0.03,0.0,0.0,0.0,jennifer margaret goree,
-THEA,2100,1.0,Theatre Appreciation,0.59,0.28,0.09,0.0,0.03,0.0,0.0,0.0,david hartmann,
-THEA,2100,3.0,Theatre Appreciation,0.63,0.23,0.07,0.03,0.0,0.0,0.0,0.03,kendra lynette johnson,
-THEA,2100,5.0,Theatre Appreciation,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,
-THEA,2100,6.0,Theatre Appreciation,0.59,0.28,0.09,0.0,0.0,0.0,0.0,0.03,jason adkins,
-THEA,2100,7.0,Theatre Appreciation,0.73,0.1,0.13,0.0,0.03,0.0,0.0,0.0,jason adkins,
-THEA,2770,1.0,Prod Studies in Thea,0.63,0.25,0.08,0.0,0.0,0.0,0.0,0.04,david hartmann,
-THEA,2780,1.0,Acting I,0.75,0.06,0.13,0.06,0.0,0.0,0.0,0.0,kerrie kathleen seymour,
-THEA,2790,1.0,Theatre Practicum,0.57,0.21,0.07,0.0,0.07,0.0,0.0,0.07,matthew leckenbusch,
-THEA,3080,1.0,Surv of Broadway I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
-THEA,3160,1.0,Theatre History II,0.63,0.21,0.08,0.04,0.04,0.0,0.0,0.0,shannon therese robert,
-THEA,3170,1.0,African-Amer Thea I,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,kendra lynette johnson,
-WFB,3010,2.0,Wildlife Biology Lab,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,shari lynn rodriguez,
-WFB,4100,2.0,Wildlife Management Techniques,0.26,0.66,0.03,0.06,0.0,0.0,0.0,0.0,catherine michelle jachowski,
-WFB,4120,1.0,Wildlife Management,0.67,0.26,0.04,0.04,0.0,0.0,0.0,0.0,greg yarrow,
-WFB,4180,2.0,Fisheries Mgt & Conservation,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,troy mason farmer,
-WFB,4440,1.0,Wildlife Damage Management,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,greg yarrow,
-WFB,4720,1.0,Ornithology,0.27,0.32,0.23,0.09,0.05,0.0,0.0,0.05,neil smith,
-WFB,4770,1.0,Ichthyology,0.71,0.07,0.14,0.07,0.0,0.0,0.0,0.0,brandon kevin peoples,
-WFB,4800,1.0,Waterfowl Ecology & Management,0.4,0.47,0.05,0.0,0.0,0.0,0.0,0.09,richard marvin kaminski,
-WFB,6620,1.0,Wetland Wildlife Biology,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,russell barrett,
-WFB,6800,1.0,Waterfowl Ecology & Management,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,richard marvin kaminski,
-WFB,8610,5.0,Scientific Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stefanie whitmire,
-WFB,8610,10.0,Fisheries Mgt and Conservation,0.67,0.11,0.11,0.0,0.11,0.0,0.0,0.0,troy mason farmer,
-WFB,8610,11.0,Study Design & Data Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,brandon kevin peoples,
-WFB,8610,14.0,Wildlife Resource Selection,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine michelle jachowski,
-WFB,8610,23.0,Aquatic Habitat Management,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,mark scott,
-WS,1030,1.0,Women in Global Perspective,0.5,0.36,0.11,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,
-WS,1030,2.0,Women in Global Perspective,0.53,0.39,0.06,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,
-WS,2300,1.0,Women and Leadership I,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,mary price,
-WS,3010,1.0,Intro Women's Studies,0.47,0.39,0.03,0.03,0.06,0.0,0.0,0.03,elizabeth rose adams,
-WS,3010,2.0,Intro Women's Studies,0.58,0.37,0.03,0.0,0.0,0.0,0.0,0.03,elizabeth rose adams,
-WS,4230,1.0,Women in the Developing World,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,melissa vogel,
-YDP,3000,400.0,Youth Development in Society,0.64,0.2,0.04,0.04,0.04,0.0,0.0,0.04,lauren elizabeth stephens,
-YDP,3050,400.0,Theory/Phil of Youth Dev Work,0.73,0.15,0.08,0.0,0.0,0.0,0.0,0.04,lauren elizabeth stephens,
-YDP,3200,1.0,Youth Dev in Sport/Phys Activ,0.71,0.13,0.08,0.04,0.0,0.0,0.0,0.04,lauren elizabeth stephens,
-YDP,3250,1.0,Working with Diverse Youth,0.76,0.12,0.06,0.0,0.06,0.0,0.0,0.0,kimberly pearson johnson,
-YDP,3300,1.0,Designing Effective Youth Prog,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,kellye rembert,
-YDP,3350,1.0,Youth Activity Leadership,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lauren elizabeth stephens,
-YDP,3450,1.0,Creative Activities for Youth,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kimberly pearson johnson,
-YDP,4450,1.0,Youth Devel Org Administration,0.61,0.17,0.17,0.0,0.0,0.0,0.0,0.04,allison michelle avishai,
-YDP,4500,1.0,Prof Iss & Ethics in Youth Dev,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kayla lee weston,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1010,1.0,Survey of Art & Arch History I,0.35,0.46,0.15,0.01,0.02,0.0,0.0,0.01,beth ann lauritis,,AAH-1010,2019
+AAH,2050,1.0,Art History and Theory I,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,beth ann lauritis,,AAH-2050,2019
+AAH,3050,1.0,Contemporary Art History,0.81,0.14,0.0,0.05,0.0,0.0,0.0,0.0,anatole upart,,AAH-3050,2019
+ACCT,2010,1.0,Financial Accounting Concepts,0.43,0.29,0.1,0.04,0.04,0.0,0.0,0.1,lydia lancaster folger schleifer,,ACCT-2010,2019
+ACCT,2010,2.0,Financial Accounting Concepts,0.42,0.32,0.16,0.02,0.04,0.0,0.0,0.04,lydia lancaster folger schleifer,,ACCT-2010,2019
+ACCT,2010,3.0,Financial Accounting Concepts,0.33,0.27,0.22,0.04,0.02,0.0,0.0,0.11,julie grant,,ACCT-2010,2019
+ACCT,2010,4.0,Financial Accounting Concepts,0.38,0.24,0.2,0.07,0.02,0.0,0.0,0.09,julie grant,,ACCT-2010,2019
+ACCT,2010,5.0,Financial Accounting Concepts,0.5,0.35,0.1,0.0,0.0,0.0,0.0,0.04,lydia lancaster folger schleifer,,ACCT-2010,2019
+ACCT,2010,6.0,Financial Accounting Concepts,0.4,0.31,0.13,0.07,0.02,0.0,0.0,0.07,michael john mcguigan,,ACCT-2010,2019
+ACCT,2010,7.0,Financial Accounting Concepts,0.16,0.49,0.27,0.0,0.06,0.0,0.0,0.02,carl hollingsworth,,ACCT-2010,2019
+ACCT,2010,8.0,Financial Accounting Concepts,0.22,0.31,0.27,0.1,0.04,0.0,0.0,0.06,carl hollingsworth,,ACCT-2010,2019
+ACCT,2010,9.0,Financial Accounting Concepts,0.11,0.39,0.3,0.07,0.07,0.0,0.0,0.07,michael john mcguigan,,ACCT-2010,2019
+ACCT,2010,10.0,Financial Accounting Concepts,0.37,0.33,0.14,0.06,0.04,0.0,0.0,0.06,charles tegen,,ACCT-2010,2019
+ACCT,2010,11.0,Financial Accounting Concepts,0.33,0.28,0.14,0.03,0.08,0.0,0.0,0.14,lisa wheatley birtwistle,,ACCT-2010,2019
+ACCT,2010,12.0,Financial Accounting Concepts,0.12,0.35,0.19,0.07,0.12,0.0,0.0,0.16,lisa wheatley birtwistle,,ACCT-2010,2019
+ACCT,2010,13.0,Financial Accounting Concepts,0.24,0.24,0.37,0.1,0.0,0.0,0.0,0.05,lisa wheatley birtwistle,,ACCT-2010,2019
+ACCT,2010,14.0,Financial Accounting Concepts,0.38,0.45,0.1,0.03,0.0,0.0,0.0,0.03,annieka philo,,ACCT-2010,2019
+ACCT,2010,100.0,Fin Accounting Concepts (HON),0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,mary ann  prater,True,ACCT-2010,2019
+ACCT,2010,111.0,Fin Accounting Concepts (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lisa wheatley birtwistle,True,ACCT-2010,2019
+ACCT,2010,400.0,Financial Accounting Concepts,0.14,0.22,0.21,0.1,0.07,0.0,0.0,0.26,jeffrey mcmillan,,ACCT-2010,2019
+ACCT,2010,401.0,Financial Accounting Concepts,0.33,0.43,0.16,0.04,0.02,0.0,0.0,0.02,emily suzanne mccorkle,,ACCT-2010,2019
+ACCT,2020,1.0,Managerial Accounting Concepts,0.31,0.23,0.15,0.03,0.0,0.0,0.0,0.28,henry anderson,,ACCT-2020,2019
+ACCT,2020,2.0,Managerial Accounting Concepts,0.27,0.33,0.15,0.06,0.12,0.0,0.0,0.06,henry anderson,,ACCT-2020,2019
+ACCT,2020,3.0,Managerial Accounting Concepts,0.18,0.46,0.23,0.0,0.03,0.0,0.0,0.1,henry anderson,,ACCT-2020,2019
+ACCT,2020,4.0,Managerial Accounting Concepts,0.26,0.33,0.23,0.0,0.1,0.0,0.0,0.08,henry anderson,,ACCT-2020,2019
+ACCT,2020,5.0,Managerial Accounting Concepts,0.21,0.3,0.21,0.09,0.06,0.0,0.0,0.13,brian todd carver,,ACCT-2020,2019
+ACCT,2020,6.0,Managerial Accounting Concepts,0.17,0.15,0.37,0.09,0.04,0.0,0.0,0.17,brian todd carver,,ACCT-2020,2019
+ACCT,2020,400.0,Managerial Accounting Concepts,0.3,0.29,0.16,0.08,0.03,0.0,0.0,0.13,henry anderson,,ACCT-2020,2019
+ACCT,2020,402.0,Managerial Accounting Concepts,0.25,0.23,0.3,0.12,0.04,0.0,0.0,0.05,emily suzanne mccorkle,,ACCT-2020,2019
+ACCT,2900,1.0,Special Topics - Soft Skills,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,michael mendonca,,ACCT-2900,2019
+ACCT,3030,1.0,Cost Accounting,0.38,0.36,0.21,0.0,0.03,0.0,0.0,0.03,daniel thomas way,,ACCT-3030,2019
+ACCT,3030,2.0,Cost Accounting,0.25,0.39,0.31,0.03,0.0,0.0,0.0,0.03,daniel thomas way,,ACCT-3030,2019
+ACCT,3030,3.0,Cost Accounting,0.32,0.43,0.14,0.03,0.05,0.0,0.0,0.03,jace garrett,,ACCT-3030,2019
+ACCT,3030,4.0,Cost Accounting,0.38,0.27,0.19,0.03,0.03,0.0,0.0,0.11,jace garrett,,ACCT-3030,2019
+ACCT,3030,5.0,Cost Accounting,0.55,0.26,0.16,0.0,0.03,0.0,0.0,0.0,sarah martin,,ACCT-3030,2019
+ACCT,3110,1.0,Intermediate Financial Acct I,0.17,0.29,0.33,0.0,0.08,0.0,0.0,0.13,annieka philo,,ACCT-3110,2019
+ACCT,3110,2.0,Intermediate Financial Acct I,0.16,0.31,0.41,0.06,0.03,0.0,0.0,0.03,amy melissa donnelly,,ACCT-3110,2019
+ACCT,3110,3.0,Intermediate Financial Acct I,0.17,0.39,0.11,0.11,0.11,0.0,0.0,0.11,annieka philo,,ACCT-3110,2019
+ACCT,3110,4.0,Intermediate Financial Acct I,0.19,0.32,0.39,0.03,0.03,0.0,0.0,0.03,amy melissa donnelly,,ACCT-3110,2019
+ACCT,3110,5.0,Intermediate Financial Acct I,0.19,0.52,0.19,0.0,0.0,0.0,0.0,0.1, russell madray,,ACCT-3110,2019
+ACCT,3110,6.0,Intermediate Financial Acct I,0.16,0.29,0.26,0.06,0.06,0.0,0.0,0.16,amy melissa donnelly,,ACCT-3110,2019
+ACCT,3110,7.0,Intermediate Financial Acct I,0.32,0.42,0.13,0.03,0.06,0.0,0.0,0.03, russell madray,,ACCT-3110,2019
+ACCT,3110,8.0,Intermediate Financial Acct I,0.11,0.26,0.26,0.11,0.21,0.0,0.0,0.05,erin michelle hawkins,,ACCT-3110,2019
+ACCT,3110,100.0,Intermediate Fin Acct I (HON),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,annieka philo,True,ACCT-3110,2019
+ACCT,3120,1.0,Intermediate Financial Acct II,0.44,0.17,0.28,0.0,0.06,0.0,0.0,0.06,terry daniel knause,,ACCT-3120,2019
+ACCT,3120,2.0,Intermediate Financial Acct II,0.0,0.39,0.39,0.11,0.11,0.0,0.0,0.0, russell madray,,ACCT-3120,2019
+ACCT,3120,3.0,Intermediate Financial Acct II,0.2,0.46,0.23,0.06,0.03,0.0,0.0,0.03, russell madray,,ACCT-3120,2019
+ACCT,3120,4.0,Intermediate Financial Acct II,0.45,0.42,0.1,0.0,0.0,0.0,0.0,0.03,terry daniel knause,,ACCT-3120,2019
+ACCT,3120,5.0,Intermediate Financial Acct II,0.33,0.33,0.31,0.0,0.0,0.0,0.0,0.03,terry daniel knause,,ACCT-3120,2019
+ACCT,3120,6.0,Intermediate Financial Acct II,0.31,0.5,0.17,0.0,0.0,0.0,0.0,0.03,terry daniel knause,,ACCT-3120,2019
+ACCT,3130,1.0,Analytics for Acct Dec Making,0.57,0.25,0.14,0.0,0.0,0.0,0.0,0.04,babak mammadov,,ACCT-3130,2019
+ACCT,3130,2.0,Analytics for Acct Dec Making,0.33,0.4,0.13,0.0,0.07,0.0,0.0,0.07,babak mammadov,,ACCT-3130,2019
+ACCT,3130,3.0,Analytics for Acct Dec Making,0.28,0.33,0.28,0.11,0.0,0.0,0.0,0.0,phebian davis-culler,,ACCT-3130,2019
+ACCT,3130,4.0,Analytics for Acct Dec Making,0.18,0.64,0.18,0.0,0.0,0.0,0.0,0.0,phebian davis-culler,,ACCT-3130,2019
+ACCT,3130,5.0,Analytics for Acct Dec Making,0.32,0.41,0.18,0.0,0.05,0.0,0.0,0.05,phebian davis-culler,,ACCT-3130,2019
+ACCT,3130,6.0,Analytics for Acct Dec Making,0.17,0.35,0.3,0.13,0.04,0.0,0.0,0.0,phebian davis-culler,,ACCT-3130,2019
+ACCT,3130,105.0,Analytics for Accounting (HON),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,phebian davis-culler,True,ACCT-3130,2019
+ACCT,3220,1.0,Accounting Information Systems,0.11,0.32,0.21,0.21,0.05,0.0,0.0,0.11,philip maiberger,,ACCT-3220,2019
+ACCT,3220,2.0,Accounting Information Systems,0.18,0.42,0.24,0.06,0.03,0.0,0.0,0.06,philip maiberger,,ACCT-3220,2019
+ACCT,3220,3.0,Accounting Information Systems,0.1,0.31,0.31,0.1,0.07,0.0,0.0,0.1,philip maiberger,,ACCT-3220,2019
+ACCT,3220,4.0,Accounting Information Systems,0.14,0.41,0.21,0.07,0.0,0.0,0.0,0.17,philip maiberger,,ACCT-3220,2019
+ACCT,4040,1.0,Individual Taxation,0.64,0.21,0.11,0.0,0.0,0.0,0.0,0.04,sarah martin,,ACCT-4040,2019
+ACCT,4040,2.0,Individual Taxation,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2019
+ACCT,4040,3.0,Individual Taxation,0.42,0.33,0.18,0.0,0.03,0.0,0.0,0.03,sarah martin,,ACCT-4040,2019
+ACCT,4040,4.0,Individual Taxation,0.06,0.52,0.23,0.1,0.06,0.0,0.0,0.03,lisa wheatley birtwistle,,ACCT-4040,2019
+ACCT,4040,101.0,Individual Taxation (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,True,ACCT-4040,2019
+ACCT,4080,1.0,Retire & Estate Plan,0.69,0.21,0.1,0.0,0.0,0.0,0.0,0.0,john hine,,ACCT-4080,2019
+ACCT,4100,1.0,Reporting and Mgmt Control Sys,0.29,0.41,0.26,0.0,0.0,0.0,0.0,0.03,gregory patrick mcphee,,ACCT-4100,2019
+ACCT,4100,2.0,Reporting and Mgmt Control Sys,0.38,0.38,0.18,0.06,0.0,0.0,0.0,0.0,gregory patrick mcphee,,ACCT-4100,2019
+ACCT,4100,3.0,Reporting and Mgmt Control Sys,0.3,0.55,0.06,0.06,0.0,0.0,0.0,0.03,robin radtke,,ACCT-4100,2019
+ACCT,4150,1.0,Auditing,0.37,0.46,0.17,0.0,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-4150,2019
+ACCT,4150,2.0,Auditing,0.26,0.29,0.35,0.1,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-4150,2019
+ACCT,8510,1.0,Tax Research,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas dickens,,ACCT-8510,2019
+ACCT,8530,1.0,Adv Acct Problems,0.5,0.41,0.06,0.0,0.0,0.0,0.0,0.03,suzanne pearse,,ACCT-8530,2019
+ACCT,8530,2.0,Adv Acct Problems,0.45,0.42,0.12,0.0,0.0,0.0,0.0,0.0,suzanne pearse,,ACCT-8530,2019
+ACCT,8530,3.0,Adv Acct Problems,0.43,0.33,0.17,0.0,0.07,0.0,0.0,0.0,ralph edward welton,,ACCT-8530,2019
+ACCT,8550,1.0,Gov't and Nonprofit Accounting,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2019
+ACCT,8550,2.0,Gov't and Nonprofit Accounting,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2019
+ACCT,8550,3.0,Gov't and Nonprofit Accounting,0.52,0.42,0.06,0.0,0.0,0.0,0.0,0.0,james barnes,,ACCT-8550,2019
+ACCT,8630,1.0,Forensics Analysis,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,brian matthew goodson,,ACCT-8630,2019
+ACCT,8630,2.0,Forensics Analysis,0.55,0.42,0.03,0.0,0.0,0.0,0.0,0.0,brian matthew goodson,,ACCT-8630,2019
+ACCT,8650,1.0,Tax & Bus Decisions,0.25,0.72,0.03,0.0,0.0,0.0,0.0,0.0,judson jahn,,ACCT-8650,2019
+ACCT,8650,2.0,Tax & Bus Decisions,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,judson jahn,,ACCT-8650,2019
+ACCT,8720,1.0,Tax of Flowthroughs,0.21,0.56,0.18,0.0,0.03,0.0,0.0,0.03,thomas dickens,,ACCT-8720,2019
+AGED,1020,1.0,Freshman Seminar,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,,AGED-1020,2019
+AGED,2000,1.0,Agr Appl of Ed Tech,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,kevin layfield,,AGED-2000,2019
+AGED,2010,1.0,Intro to Agric Educ,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,philip fravel,,AGED-2010,2019
+AGED,3030,1.0,Ag Ed Mech Tech,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-3030,2019
+AGED,4010,1.0,Instr Methods Ag Ed,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,,AGED-4010,2019
+AGED,4030,1.0,Prin Adult/Ext Ed,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-4030,2019
+AGED,4230,400.0,Curriculum,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,catherine dibenedetto,,AGED-4230,2019
+AGM,1010,1.0,Intro Ag Mech & Bus,0.6,0.2,0.09,0.06,0.03,0.0,0.0,0.03,hunter massey,,AGM-1010,2019
+AGM,1010,1.0,Intro Ag Mech & Bus,0.6,0.2,0.09,0.06,0.03,0.0,0.0,0.03,hunter massey,,AGM-1010,2019
+AGM,2050,1.0,Prin of Fabrication,0.23,0.54,0.19,0.02,0.0,0.0,0.0,0.02,hunter massey,,AGM-2050,2019
+AGM,2050,1.0,Prin of Fabrication,0.23,0.54,0.19,0.02,0.0,0.0,0.0,0.02,hunter massey,,AGM-2050,2019
+AGM,2060,1.0,Machinery Mgt,0.23,0.46,0.15,0.08,0.08,0.0,0.0,0.0,hunter massey,,AGM-2060,2019
+AGM,2060,1.0,Machinery Mgt,0.23,0.46,0.15,0.08,0.08,0.0,0.0,0.0,hunter massey,,AGM-2060,2019
+AGM,2210,1.0,Land Measurements,0.5,0.38,0.09,0.01,0.01,0.0,0.0,0.0,charles privette,,AGM-2210,2019
+AGM,3010,1.0,Soil Water Conserv,0.63,0.18,0.18,0.0,0.0,0.0,0.0,0.0,calvin sawyer,,AGM-3010,2019
+AGM,4000,1.0,Seminar in Ag Mech & Business,0.28,0.63,0.08,0.0,0.0,0.0,0.0,0.03,john chastain,,AGM-4000,2019
+AGM,4020,1.0,Irrigation System Design,0.44,0.46,0.08,0.0,0.03,0.0,0.0,0.0,charles privette,,AGM-4020,2019
+AGM,4050,1.0,Env Cont in Anim Str,0.32,0.59,0.08,0.0,0.0,0.0,0.0,0.0,john chastain,,AGM-4050,2019
+AGM,4060,1.0,Mech & Hydraulic Sys,0.41,0.45,0.14,0.0,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4060,2019
+AGM,4520,1.0,Mobile Power,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,ali bulent koc,,AGM-4520,2019
+AGM,4600,1.0,Electrical Systems,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,young jo han,,AGM-4600,2019
+AGM,4730,4.0,Ag Safety,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hunter massey,,AGM-4730,2019
+AGM,4730,4.0,Ag Safety,0.53,0.29,0.18,0.0,0.0,0.0,0.0,0.0,hunter massey,,AGM-4730,2019
+AGRB,2020,1.0,Agricultural Economics,0.63,0.26,0.08,0.01,0.01,0.0,0.0,0.01,julie carl pingol ureta,,AGRB-2020,2019
+AGRB,2050,1.0,Agriculture and Society,0.14,0.27,0.37,0.17,0.03,0.0,0.0,0.01,michael vassalos,,AGRB-2050,2019
+AGRB,3020,1.0,Economics of Farm Management,0.12,0.2,0.31,0.27,0.04,0.0,0.0,0.05,michael vassalos,,AGRB-3020,2019
+AGRB,3080,1.0,Quant Agribusiness Analysis I,0.31,0.31,0.31,0.08,0.0,0.0,0.0,0.0,david brian willis,,AGRB-3080,2019
+AGRB,3090,1.0,Econ of Agricultural Marketing,0.73,0.2,0.03,0.0,0.01,0.0,0.0,0.03,yuliya valentinovna bolotova,,AGRB-3090,2019
+AGRB,3570,1.0,Natural Resources Economics,0.23,0.23,0.26,0.09,0.09,0.0,0.0,0.09,david brian willis,,AGRB-3570,2019
+AGRB,4090,1.0,Commodity Futures Markets,0.24,0.48,0.26,0.02,0.0,0.0,0.0,0.0,david baird montgomery,,AGRB-4090,2019
+AGRB,4120,1.0,Reg Econ Devel Theory & Policy,0.32,0.32,0.14,0.2,0.02,0.0,0.0,0.0,felipe de figueiredo silva,,AGRB-4120,2019
+AGRB,4520,1.0,Agricultural Policy,0.17,0.44,0.31,0.08,0.0,0.0,0.0,0.0,michael vassalos,,AGRB-4520,2019
+AGRB,4900,1.0,Special Topics,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,michael vassalos,,AGRB-4900,2019
+AGRB,4910,1.0,"Int, Agrib & Comm & Rural Dev",0.93,0.04,0.04,0.0,0.0,0.0,0.0,0.0,michael vassalos,,AGRB-4910,2019
+AL,3440,400.0,Athletics and Women,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,misty soles,,AL-3440,2019
+AL,3490,400.0,Principles of Coaching,0.56,0.24,0.08,0.04,0.0,0.0,0.0,0.08,deborah jo cadorette,,AL-3490,2019
+AL,3490,401.0,Principles of Coaching,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,deborah jo cadorette,,AL-3490,2019
+AL,3490,402.0,Principles of Coaching,0.58,0.38,0.0,0.04,0.0,0.0,0.0,0.0,john plumblee,,AL-3490,2019
+AL,3490,403.0,Principles of Coaching,0.52,0.24,0.08,0.04,0.04,0.0,0.0,0.08,clyde keith connor,,AL-3490,2019
+AL,3490,404.0,Principles of Coaching,0.48,0.36,0.12,0.0,0.04,0.0,0.0,0.0,john plumblee,,AL-3490,2019
+AL,3490,405.0,Principles of Coaching,0.64,0.24,0.04,0.0,0.04,0.0,0.0,0.04,frank mezzanotte,,AL-3490,2019
+AL,3490,406.0,Principles of Coaching,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,edmond fry,,AL-3490,2019
+AL,3490,407.0,Principles of Coaching,0.64,0.24,0.08,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,,AL-3490,2019
+AL,3490,408.0,Principles of Coaching,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,nicholas philip edward whitrow,,AL-3490,2019
+AL,3490,409.0,Principles of Coaching,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,nicholas philip edward whitrow,,AL-3490,2019
+AL,3490,410.0,Principles of Coaching,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,nicholas philip edward whitrow,,AL-3490,2019
+AL,3490,411.0,Principles of Coaching,0.5,0.29,0.17,0.0,0.0,0.0,0.0,0.04,joel neuder,,AL-3490,2019
+AL,3500,400.0,Sci Basis I/Ex Phy,0.12,0.54,0.12,0.19,0.0,0.0,0.0,0.04,michael godfrey,,AL-3500,2019
+AL,3500,401.0,Sci Basis I/Ex Phy,0.32,0.09,0.23,0.18,0.09,0.0,0.0,0.09,michael godfrey,,AL-3500,2019
+AL,3530,400.0,Athletic Injuries,0.32,0.2,0.16,0.12,0.12,0.0,0.0,0.08,isaac sean colbert,,AL-3530,2019
+AL,3530,401.0,Athletic Injuries,0.26,0.3,0.3,0.13,0.0,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2019
+AL,3600,400.0,Hgh Sch Athl Ethical/Legal Iss,0.29,0.46,0.08,0.17,0.0,0.0,0.0,0.0,clyde keith connor,,AL-3600,2019
+AL,3610,400.0,Admin/Org of Athletic Programs,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2019
+AL,3610,401.0,Admin/Org of Athletic Programs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2019
+AL,3620,400.0,Psychology of Coaching,0.31,0.12,0.35,0.12,0.04,0.0,0.0,0.08,natalie anne carter,,AL-3620,2019
+AL,3620,401.0,Psychology of Coaching,0.32,0.36,0.2,0.04,0.0,0.0,0.0,0.08,natalie anne carter,,AL-3620,2019
+AL,3620,402.0,Psychology of Coaching,0.33,0.17,0.38,0.08,0.04,0.0,0.0,0.0,natalie anne carter,,AL-3620,2019
+AL,3740,400.0,Coaching Football,0.77,0.09,0.05,0.05,0.0,0.0,0.0,0.05,edmond fry,,AL-3740,2019
+AL,3740,401.0,Coaching Football,0.5,0.23,0.05,0.09,0.05,0.0,0.0,0.09,edmond fry,,AL-3740,2019
+AL,3760,400.0,Coaching Strength/Conditioning,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,edmond fry,,AL-3760,2019
+AL,3760,401.0,Coaching Strength/Conditioning,0.68,0.08,0.08,0.0,0.04,0.0,0.0,0.12,edmond fry,,AL-3760,2019
+AL,4380,402.0,HS Athletic Recruiting,0.57,0.14,0.11,0.0,0.04,0.0,0.0,0.14,deborah jo cadorette,,AL-4380,2019
+AL,4380,403.0,Media Relations in AL,0.74,0.07,0.15,0.0,0.04,0.0,0.0,0.0,misty soles,,AL-4380,2019
+AL,4380,408.0,Officiating in AL,0.63,0.17,0.04,0.04,0.0,0.0,0.0,0.13,clyde keith connor,,AL-4380,2019
+AL,4380,409.0,Coaching Baseball/Softball,0.58,0.17,0.13,0.04,0.0,0.0,0.0,0.08,deborah jo cadorette,,AL-4380,2019
+AL,4490,400.0,Athlete Beliefs,0.42,0.42,0.13,0.0,0.0,0.0,0.0,0.04,deborah jo cadorette,,AL-4490,2019
+AL,8380,400.0,Compliance in Intercoll Athl,0.8,0.05,0.0,0.0,0.05,0.0,0.0,0.1,michael godfrey,,AL-8380,2019
+AL,8380,401.0,Compliance in Colleg Athl,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8380,2019
+AL,8440,400.0,Surv of Res Mthds in Athletics,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8440,2019
+AL,8440,401.0,Surv of Res Mthds in Athletics,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8440,2019
+AL,8440,402.0,Surv of Res Mthds in Athletics,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8440,2019
+AL,8490,400.0,Athletic Leadership Dev,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,janna theresa magette,,AL-8490,2019
+AL,8490,401.0,Athletic Leadership Dev,0.76,0.1,0.1,0.0,0.0,0.0,0.0,0.05,janna theresa magette,,AL-8490,2019
+AL,8490,402.0,Athletic Leadership Dev,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,janna theresa magette,,AL-8490,2019
+AL,8500,400.0,Principles Strength and Condit,0.57,0.33,0.1,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8500,2019
+AL,8500,401.0,Principles Strength and Condit,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,michael godfrey,,AL-8500,2019
+AL,8650,400.0,Mkt and Comm Respon Interc Ath,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-8650,2019
+AL,8650,402.0,Mkt and Comm Respon Interc Ath,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-8650,2019
+AMFG,6800,864.0,Practicum in Adv Manufacturing,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua summers,,AMFG-6800,2019
+ANTH,2010,1.0,Introduction to Anthropology,0.49,0.31,0.12,0.02,0.0,0.0,0.0,0.06,yi wu,,ANTH-2010,2019
+ANTH,2010,2.0,Introduction to Anthropology,0.42,0.29,0.18,0.0,0.02,0.0,0.0,0.09,lisa rapaport,,ANTH-2010,2019
+ANTH,2010,3.0,Introduction to Anthropology,0.3,0.6,0.09,0.0,0.0,0.0,0.0,0.02,david markus,,ANTH-2010,2019
+ANTH,2010,4.0,Introduction to Anthropology,0.36,0.54,0.07,0.01,0.02,0.0,0.0,0.02,david markus,,ANTH-2010,2019
+ANTH,2010,5.0,Introduction to Anthropology,0.41,0.39,0.13,0.04,0.0,0.0,0.0,0.02,yi wu,,ANTH-2010,2019
+ANTH,3320,1.0,World Archaeology,0.47,0.42,0.05,0.05,0.0,0.0,0.0,0.0,david markus,,ANTH-3320,2019
+ANTH,3510,1.0,Biological Anthropology,0.48,0.43,0.05,0.0,0.05,0.0,0.0,0.0,lisa rapaport,,ANTH-3510,2019
+ANTH,3530,1.0,Forensic Anthropology,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,katherine weisensee,,ANTH-3530,2019
+ANTH,3710,1.0,Language and Culture,0.44,0.44,0.0,0.11,0.0,0.0,0.0,0.0,yanhua zhang,,ANTH-3710,2019
+ANTH,4230,1.0,Women in the Developing World,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,,ANTH-4230,2019
+ANTH,4990,1.0,"Religion, Magic, Witchcraft",0.73,0.2,0.0,0.0,0.07,0.0,0.0,0.0,carolyn candace coffman,,ANTH-4990,2019
+ARCH,1010,1.0,Introduction to Architecture,0.44,0.35,0.08,0.03,0.03,0.0,0.0,0.07,sallie rebecca hambright-belue,,ARCH-1010,2019
+ARCH,2040,1.0,Hist of Modern Arch,0.42,0.48,0.07,0.02,0.0,0.0,0.0,0.01,andreea mihalache,,ARCH-2040,2019
+ARCH,2510,1.0,Arch Foundations I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-2510,2019
+ARCH,2510,2.0,Arch Foundations I,0.53,0.35,0.12,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-2510,2019
+ARCH,2510,3.0,Arch Foundations I,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,dustin graham albright,,ARCH-2510,2019
+ARCH,2510,5.0,Arch Foundations I,0.28,0.28,0.39,0.06,0.0,0.0,0.0,0.0,brandon george pass,,ARCH-2510,2019
+ARCH,2510,6.0,Arch Foundations I,0.28,0.39,0.28,0.06,0.0,0.0,0.0,0.0,virginia ellyn melnyk,,ARCH-2510,2019
+ARCH,2700,1.0,Structures I,0.59,0.34,0.03,0.0,0.03,0.0,0.0,0.0,dustin graham albright,,ARCH-2700,2019
+ARCH,3500,2.0,Intro to Urban Contexts,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-3500,2019
+ARCH,3500,3.0,Intro to Urban Contexts,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-3500,2019
+ARCH,3500,4.0,Intro to Urban Contexts,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-3500,2019
+ARCH,3500,5.0,Intro to Urban Contexts,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-3500,2019
+ARCH,3510,1.0,Studio Clemson,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,ufuk ersoy,,ARCH-3510,2019
+ARCH,3510,3.0,Studio Clemson,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,michael carlos barrios kleiss,,ARCH-3510,2019
+ARCH,3530,1.0,Studio Genoa,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-3530,2019
+ARCH,3540,1.0,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-3540,2019
+ARCH,4010,1.0,Architectural Portfolio,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,virginia ellyn melnyk,,ARCH-4010,2019
+ARCH,4010,2.0,Architectural Portfolio,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-4010,2019
+ARCH,4010,3.0,Architectural Portfolio,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4010,2019
+ARCH,4010,4.0,Architectural Portfolio,0.44,0.33,0.17,0.0,0.06,0.0,0.0,0.0,brandon george pass,,ARCH-4010,2019
+ARCH,4120,1.0,History Research,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-4120,2019
+ARCH,4140,1.0,Design Seminar,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-4140,2019
+ARCH,4520,1.0,Synthesis Studio,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,,ARCH-4520,2019
+ARCH,4710,1.0,Arch Hist of Place,0.15,0.85,0.0,0.0,0.0,0.0,0.0,0.0,jason matthew white,,ARCH-4710,2019
+ARCH,6850,1.0,H/Th: Arch+Health,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-6850,2019
+ARCH,8100,1.0,Visualization I,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,andreea mihalache,,ARCH-8100,2019
+ARCH,8200,1.0,Bldg Design & Constr,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,tori elizabeth wallace-babcock,,ARCH-8200,2019
+ARCH,8210,1.0,Research Methods,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,dina battisto,,ARCH-8210,2019
+ARCH,8410,1.0,Arch Studio I,0.6,0.0,0.2,0.0,0.0,0.0,0.0,0.2,peter laurence,,ARCH-8410,2019
+ARCH,8510,3.0,Design Studio III,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-8510,2019
+ARCH,8600,1.0,History/Theory I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,berrin terim,,ARCH-8600,2019
+ARCH,8720,1.0,Production & Assemb,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,daniel nevin harding,,ARCH-8720,2019
+ARCH,8970,1.0,A+H Studio: Hospital,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david allison,,ARCH-8970,2019
+ART,1050,1.0,Foundation Drawing I,0.61,0.28,0.0,0.0,0.0,0.0,0.0,0.11,denise elizabeth ayers,,ART-1050,2019
+ART,1510,1.0,Foundations Art I,0.61,0.33,0.0,0.0,0.06,0.0,0.0,0.0,rachel lynn de cuba,,ART-1510,2019
+ART,1520,1.0,Foundations Art II,0.4,0.3,0.0,0.1,0.1,0.0,0.0,0.1,daniel bare,,ART-1520,2019
+ART,2070,1.0,Beginning Painting,0.59,0.29,0.0,0.0,0.0,0.0,0.0,0.12,serra raven shuford,,ART-2070,2019
+ART,2090,1.0,Beginning Sculpture,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,jordan alexander fowler,,ART-2090,2019
+ART,2100,1.0,Art Appreciation,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,dustin massey,,ART-2100,2019
+ART,2100,2.0,Art Appreciation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,dustin massey,,ART-2100,2019
+ART,2100,3.0,Art Appreciation,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,mark norman brosseau,,ART-2100,2019
+ART,2100,5.0,Art Appreciation,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,joseph richard manson ,,ART-2100,2019
+ART,2100,6.0,Art Appreciation,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,annamarie elizabeth williams,,ART-2100,2019
+ART,2130,1.0,Begin Photography,0.85,0.0,0.0,0.0,0.08,0.0,0.0,0.08,haley brooke floyd,,ART-2130,2019
+ART,2170,1.0,Beginning Ceramics,0.23,0.54,0.08,0.0,0.08,0.0,0.0,0.08,sara mays,,ART-2170,2019
+AS,1090,2.0,Air Force Today I,0.82,0.09,0.0,0.0,0.0,0.0,0.0,0.09,joseph michael blanton,,AS-1090,2019
+AS,1090,3.0,Air Force Today I,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,joseph michael blanton,,AS-1090,2019
+AS,3090,1.0,A F Leadership Mgt I,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,rachelle marie miller,,AS-3090,2019
+AS,3090,2.0,A F Leadership Mgt I,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,rachelle marie miller,,AS-3090,2019
+AS,4090,1.0,Nat Sec Policy I,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4090,2019
+AS,4090,2.0,Nat Sec Policy I,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4090,2019
+ASL,1010,2.0,Am Sign Lang I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-1010,2019
+ASL,1010,5.0,Am Sign Lang I,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-1010,2019
+ASL,1020,1.0,Am Sign Lang I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william ryals clements,,ASL-1020,2019
+ASL,1020,2.0,Am Sign Lang I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,william ryals clements,,ASL-1020,2019
+ASL,1020,3.0,Am Sign Lang I,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-1020,2019
+ASL,2010,1.0,Am Sign Lang II,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,kim marlene misener dunn,,ASL-2010,2019
+ASL,2010,2.0,Am Sign Lang II,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,kim marlene misener dunn,,ASL-2010,2019
+ASL,2010,3.0,Am Sign Lang II,0.8,0.15,0.0,0.05,0.0,0.0,0.0,0.0,kim marlene misener dunn,,ASL-2010,2019
+ASL,2020,1.0,Am Sign Lang II,0.63,0.16,0.21,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-2020,2019
+ASL,3010,1.0,Advanced A S L I,0.53,0.21,0.05,0.0,0.0,0.0,0.0,0.21,kim marlene misener dunn,,ASL-3010,2019
+ASL,3150,1.0,Survey Interpreting,0.1,0.7,0.0,0.1,0.0,0.0,0.0,0.1,stephen benjamin fitzmaurice,,ASL-3150,2019
+ASL,4700,1.0,Dev Sign Lang for Deaf Childrn,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,jody herbert cripps,,ASL-4700,2019
+ASTR,1010,1.0,Solar System Astronomy,0.29,0.42,0.22,0.05,0.02,0.0,0.0,0.01,marco ajello,,ASTR-1010,2019
+ASTR,1010,2.0,Solar System Astronomy,0.24,0.46,0.23,0.04,0.02,0.0,0.0,0.01,marco ajello,,ASTR-1010,2019
+ASTR,1020,1.0,Stellar Astronomy,0.45,0.29,0.11,0.06,0.03,0.0,0.0,0.06,mark leising,,ASTR-1020,2019
+ASTR,1030,1.0,Solar Systm Astr Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,david edward connick,,ASTR-1030,2019
+ASTR,1030,2.0,Solar Systm Astr Lab,0.43,0.43,0.13,0.0,0.0,0.0,0.0,0.0,david edward connick,,ASTR-1030,2019
+ASTR,1030,3.0,Solar Systm Astr Lab,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,david edward connick,,ASTR-1030,2019
+ASTR,1030,4.0,Solar Systm Astr Lab,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,david edward connick,,ASTR-1030,2019
+ASTR,1030,6.0,Solar Systm Astr Lab,0.46,0.46,0.0,0.0,0.08,0.0,0.0,0.0,david edward connick,,ASTR-1030,2019
+ASTR,1030,7.0,Solar Systm Astr Lab,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,david edward connick,,ASTR-1030,2019
+ASTR,1030,8.0,Solar Systm Astr Lab,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,david edward connick,,ASTR-1030,2019
+ASTR,1030,9.0,Solar Systm Astr Lab,0.48,0.43,0.04,0.0,0.0,0.0,0.0,0.04,david edward connick,,ASTR-1030,2019
+ASTR,1030,10.0,Solar Systm Astr Lab,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,david edward connick,,ASTR-1030,2019
+ASTR,1040,1.0,Stellar Astr Lab,0.46,0.33,0.04,0.04,0.0,0.0,0.0,0.13,david edward connick,,ASTR-1040,2019
+ASTR,1040,2.0,Stellar Astr Lab,0.35,0.48,0.09,0.04,0.0,0.0,0.0,0.04,david edward connick,,ASTR-1040,2019
+ASTR,1040,4.0,Stellar Astr Lab,0.48,0.26,0.22,0.0,0.0,0.0,0.0,0.04,david edward connick,,ASTR-1040,2019
+ASTR,8100,1.0,Astroph I: Radiation,0.42,0.58,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,,ASTR-8100,2019
+ASTR,8750,1.0,Astronomy Seminar,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,marco ajello,,ASTR-8750,2019
+AUD,2800,1.0,Sound Reinforcement,0.0,0.8,0.2,0.0,0.0,0.0,0.0,0.0,kenneth moore,,AUD-2800,2019
+AUD,3800,1.0,Audio Engineering I,0.33,0.5,0.08,0.08,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-3800,2019
+AUE,6010,1.0,Vehicle Dynamics,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,imtiaz ul haque,,AUE-6010,2019
+AUE,8190,100.0,Adv Int Combustion Engine Conc,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-8190,2019
+AUE,8260,1.0,Vehicle Diagnostics,0.5,0.13,0.38,0.0,0.0,0.0,0.0,0.0,pierluigi pisu,,AUE-8260,2019
+AUE,8270,5.0,Auto Cntrl Sys Des,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8270,2019
+AUE,8330,30.0,Auto Manuf Proc Devl,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,michael mears,,AUE-8330,2019
+AUE,8350,100.0,Auto Electronics,0.7,0.29,0.0,0.0,0.0,0.0,0.0,0.01,yunyi jia,,AUE-8350,2019
+AUE,8670,1.0,Veh Manuf Proc I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,hong seok choi,,AUE-8670,2019
+AUE,8800,2.0,Vehicle Project Mngt,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,johnell brooks,,AUE-8800,2019
+AUE,8810,3.0,Automotive Systems Overview,0.54,0.39,0.02,0.0,0.04,0.0,0.0,0.02,christiaan jos jan paredis,,AUE-8810,2019
+AUE,8870,8.0,Meth Vehicle Testing,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blane poland,,AUE-8870,2019
+AVS,1000,1.0,Orientation to AVS,0.66,0.21,0.02,0.02,0.03,0.0,0.0,0.06,kristine lang vernon,,AVS-1000,2019
+AVS,1500,1.0,Intro Animal Science,0.28,0.28,0.28,0.08,0.03,0.0,0.0,0.07,joseph keith bertrand,,AVS-1500,2019
+AVS,1500,2.0,Intro Animal Science,0.21,0.32,0.24,0.09,0.09,0.0,0.0,0.06,joseph keith bertrand,,AVS-1500,2019
+AVS,1510,1.0,Intro Ani Sci Lab,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,,AVS-1510,2019
+AVS,1510,2.0,Intro Ani Sci Lab,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,,AVS-1510,2019
+AVS,1510,3.0,Intro Ani Sci Lab,0.36,0.56,0.0,0.0,0.0,0.0,0.0,0.08,richelle lorraine miller,,AVS-1510,2019
+AVS,1510,5.0,Intro Ani Sci Lab,0.62,0.35,0.04,0.0,0.0,0.0,0.0,0.0,chelsea drumwright sinclair,,AVS-1510,2019
+AVS,1510,6.0,Intro Ani Sci Lab,0.69,0.15,0.12,0.0,0.04,0.0,0.0,0.0,chelsea drumwright sinclair,,AVS-1510,2019
+AVS,1510,7.0,Intro Ani Sci Lab,0.73,0.19,0.04,0.0,0.0,0.0,0.0,0.04,richelle lorraine miller,,AVS-1510,2019
+AVS,1510,8.0,Intro Ani Sci Lab,0.56,0.36,0.0,0.0,0.0,0.0,0.0,0.08,chelsea drumwright sinclair,,AVS-1510,2019
+AVS,2040,1.0,Horse Care Techniques,0.72,0.18,0.1,0.0,0.0,0.0,0.0,0.0,chelsea drumwright sinclair,,AVS-2040,2019
+AVS,2110,1.0,Meat Processing Techniques,0.87,0.0,0.0,0.0,0.0,0.0,0.0,0.13,richelle lorraine miller,,AVS-2110,2019
+AVS,3010,1.0,Anat & Phys Dom Ani,0.58,0.23,0.16,0.03,0.0,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2019
+AVS,3010,400.0,Anat & Phys Dom Ani,0.46,0.32,0.11,0.08,0.03,0.0,0.0,0.0,glenn birrenkott,,AVS-3010,2019
+AVS,3020,1.0,Livestk Sel Eval I,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,richelle lorraine miller,,AVS-3020,2019
+AVS,3100,1.0,Animal Health,0.58,0.34,0.06,0.0,0.02,0.0,0.0,0.0,celina marcela checura,,AVS-3100,2019
+AVS,3700,1.0,Principles of Animal Nutrition,0.67,0.18,0.09,0.02,0.0,0.0,0.0,0.05,james robert strickland,,AVS-3700,2019
+AVS,3750,1.0,Applied Animal Nutrition,0.13,0.47,0.27,0.07,0.0,0.0,0.0,0.07,gustavo jose lascano,,AVS-3750,2019
+AVS,4100,1.0,Domestic Ani Behav,0.94,0.03,0.03,0.0,0.0,0.0,0.0,0.0,ahmed badr abdelwahab ali,,AVS-4100,2019
+AVS,4110,1.0,Animal Growth and Development,0.34,0.36,0.14,0.05,0.06,0.0,0.0,0.05,susan kay duckett,,AVS-4110,2019
+AVS,4150,1.0,Contemporary Issues in AVS,0.79,0.12,0.04,0.01,0.01,0.0,0.0,0.01,heather walker dunn,,AVS-4150,2019
+AVS,4160,1.0,Equine Exercise Phys,0.43,0.21,0.29,0.07,0.0,0.0,0.0,0.0,kristine lang vernon,,AVS-4160,2019
+AVS,4500,1.0,Sustain Livestock Product Sys,0.18,0.45,0.18,0.0,0.09,0.0,0.0,0.09,matias jose aguerre,,AVS-4500,2019
+AVS,4530,1.0,Animal Reproduction,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,tiffany wilmoth,,AVS-4530,2019
+AVS,4650,1.0,Animal Physiology I,0.33,0.41,0.18,0.05,0.0,0.0,0.0,0.03,celina marcela checura,,AVS-4650,2019
+AVS,4800,1.0,Vertebrate Endocrinology,0.36,0.58,0.06,0.0,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-4800,2019
+AVS,4920,1.0,Advanced Fetal Fescue Research,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,susan kay duckett,,AVS-4920,2019
+AVS,4920,2.0,Bioinformatics Cancer Gen,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-4920,2019
+AVS,8010,3.0,Principles Scientific Writing,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,jeryl jones,,AVS-8010,2019
+BCHM,1030,1.0,Careers in Bioch/Gen,0.85,0.09,0.02,0.02,0.02,0.0,0.0,0.0,joseph paul thames,,BCHM-1030,2019
+BCHM,3010,1.0,Molecular Biochemistry,0.32,0.15,0.26,0.09,0.11,0.0,0.0,0.09,cheryl jean ingram-smith,,BCHM-3010,2019
+BCHM,3050,1.0,Essen Elements Bioch,0.22,0.37,0.22,0.12,0.04,0.0,0.0,0.04,debra ragland,,BCHM-3050,2019
+BCHM,3050,2.0,Essen Elements Bioch,0.22,0.35,0.31,0.07,0.01,0.0,0.0,0.03,debra ragland,,BCHM-3050,2019
+BCHM,4310,1.0,Physical Approach to Biochem,0.28,0.39,0.28,0.01,0.03,0.0,0.0,0.0,weiguo cao,,BCHM-4310,2019
+BCHM,4330,2.0,Physical Biochemistry Lab,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,geoffrey ford,,BCHM-4330,2019
+BCHM,4400,1.0,Bioinformatics,0.73,0.28,0.0,0.0,0.0,0.0,0.0,0.0,frank alexander feltus,,BCHM-4400,2019
+BCHM,4430,1.0,Molecular Basis of Disease,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,james morris,,BCHM-4430,2019
+BCHM,4910,27.0,CI-CU INVESTORS,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,meredith teilhet morris,,BCHM-4910,2019
+BCHM,4910,32.0,CI-DNA Repair (HON),0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael glen sehorn,True,BCHM-4910,2019
+BCHM,4930,2.0,Senior Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lukasz kozubowski,,BCHM-4930,2019
+BCHM,4930,5.0,Senior Seminar,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,,BCHM-4930,2019
+BCHM,8140,1.0,Advanced Biochemistry,0.38,0.38,0.25,0.0,0.0,0.0,0.0,0.0,meredith teilhet morris,,BCHM-8140,2019
+BE,2100,1.0,Intro to Biosystems Engr,0.76,0.12,0.08,0.0,0.0,0.0,0.0,0.04,jazmine octavia taylor,,BE-2100,2019
+BE,3200,1.0,Principles & Prac of Geomatics,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-3200,2019
+BE,4100,1.0,Biological Kinetics,0.21,0.43,0.29,0.07,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4100,2019
+BE,4210,1.0,Engr Sys for Soil Water Mgt,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,christophe darnault,,BE-4210,2019
+BE,4280,1.0,Biochem Engr,0.4,0.4,0.1,0.1,0.0,0.0,0.0,0.0,terry walker,,BE-4280,2019
+BE,4740,1.0,BE Design Project Managment,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,tom owino,,BE-4740,2019
+BE,4750,1.0,BE Capstone Design,0.77,0.0,0.23,0.0,0.0,0.0,0.0,0.0,christophe darnault,,BE-4750,2019
+BIOE,1010,1.0,Biol for Bioengr,0.69,0.15,0.08,0.0,0.0,0.0,0.0,0.08,tyler george harvey,,BIOE-1010,2019
+BIOE,2010,2.0,Intro Biomed Engr,0.47,0.34,0.13,0.03,0.01,0.0,0.0,0.02,charles webb,,BIOE-2010,2019
+BIOE,3020,1.0,Biomaterials,0.69,0.23,0.04,0.02,0.0,0.0,0.0,0.02,alexey alexandrovich vertegel,,BIOE-3020,2019
+BIOE,3100,1.0,Engr Analysis of Physiol Proc,0.79,0.16,0.03,0.03,0.0,0.0,0.0,0.0,brian william booth,,BIOE-3100,2019
+BIOE,3200,1.0,Biomechanics,0.49,0.41,0.06,0.01,0.01,0.0,0.0,0.01,jiro nagatomi,,BIOE-3200,2019
+BIOE,3210,1.0,Biofluid Mechanics,0.53,0.33,0.1,0.0,0.0,0.0,0.0,0.03,zhi gao,,BIOE-3210,2019
+BIOE,3470,1.0,Transport Processes in Bioengr,0.63,0.26,0.08,0.03,0.01,0.0,0.0,0.0,renee nicole cottle,,BIOE-3470,2019
+BIOE,3700,1.0,Bioinst & Imaging,0.57,0.33,0.09,0.0,0.0,0.0,0.0,0.02,delphine dean,,BIOE-3700,2019
+BIOE,4010,2.0,Bioengineering Design Theory,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,john desjardins,,BIOE-4010,2019
+BIOE,4030,1.0,Applied Bio E Design,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ravikiran bhaskar singapogu,,BIOE-4030,2019
+BIOE,4120,1.0,Orthopaedic Engr and Pathology,0.6,0.35,0.02,0.0,0.0,0.0,0.0,0.02,melinda harman,,BIOE-4120,2019
+BIOE,4400,1.0,Biopharmaceutical Engineering,0.26,0.47,0.05,0.0,0.05,0.0,0.0,0.16,sarah harcum,,BIOE-4400,2019
+BIOE,4480,1.0,Tissue Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,angela antoinette alexander,,BIOE-4480,2019
+BIOE,4510,31.0,CI-Med Design with Arusha Tz,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,delphine dean,,BIOE-4510,2019
+BIOE,6120,1.0,Orthopaedic Engr & Pathology,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,melinda harman,,BIOE-6120,2019
+BIOE,6350,1.0,Computational Modeling in BIOE,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,william richardson,,BIOE-6350,2019
+BIOE,6400,1.0,Biopharmaceutical Engineering,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,sarah harcum,,BIOE-6400,2019
+BIOE,8010,1.0,Bio Materials,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert latour,,BIOE-8010,2019
+BIOE,8160,1.0,BioE Professional Development,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,martine laberge,,BIOE-8160,2019
+BIOE,8160,843.0,BioE Professional Development,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,jeremy gilbert,,BIOE-8160,2019
+BIOL,1010,1.0,Frontiers in Biology I,0.8,0.14,0.05,0.0,0.0,0.0,0.0,0.01,michael childress,,BIOL-1010,2019
+BIOL,1010,2.0,Frontiers in Biology I,0.83,0.13,0.02,0.0,0.01,0.0,0.0,0.01,michael childress,,BIOL-1010,2019
+BIOL,1030,1.0,General Biology I,0.24,0.29,0.27,0.1,0.04,0.0,0.0,0.06,nora espinoza,,BIOL-1030,2019
+BIOL,1030,2.0,General Biology I,0.26,0.24,0.17,0.18,0.04,0.0,0.0,0.12,nathan redding,,BIOL-1030,2019
+BIOL,1030,3.0,General Biology I,0.23,0.33,0.24,0.07,0.04,0.0,0.0,0.09,wen chen,,BIOL-1030,2019
+BIOL,1030,4.0,General Biology I,0.15,0.26,0.35,0.1,0.04,0.0,0.0,0.11,salvatore sparace,,BIOL-1030,2019
+BIOL,1030,5.0,General Biology I (HON),0.7,0.25,0.05,0.0,0.0,0.0,0.0,0.0,nora espinoza,True,BIOL-1030,2019
+BIOL,1050,1.0,General Biology Lab I,0.0,0.22,0.43,0.22,0.04,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,2.0,General Biology Lab I,0.0,0.17,0.38,0.13,0.08,0.0,0.0,0.25,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,3.0,General Biology Lab I,0.0,0.38,0.17,0.21,0.0,0.0,0.0,0.25,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,4.0,General Biology Lab I,0.0,0.13,0.38,0.29,0.08,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,5.0,General Biology Lab I,0.0,0.29,0.29,0.29,0.13,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,6.0,General Biology Lab I,0.0,0.25,0.54,0.17,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,7.0,General Biology Lab I,0.0,0.27,0.23,0.36,0.0,0.0,0.0,0.14,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,8.0,General Biology Lab I,0.0,0.17,0.43,0.13,0.0,0.0,0.0,0.26,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,9.0,General Biology Lab I,0.0,0.17,0.46,0.13,0.08,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,10.0,General Biology Lab I,0.0,0.13,0.43,0.17,0.13,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,11.0,General Biology Lab I,0.0,0.09,0.43,0.26,0.0,0.0,0.0,0.22,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,12.0,General Biology Lab I,0.04,0.25,0.25,0.29,0.0,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,13.0,General Biology Lab I,0.0,0.17,0.42,0.17,0.13,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,14.0,General Biology Lab I,0.0,0.13,0.42,0.25,0.04,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,15.0,General Biology Lab I,0.0,0.13,0.33,0.17,0.13,0.0,0.0,0.25,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,16.0,General Biology Lab I,0.0,0.42,0.46,0.08,0.0,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,17.0,General Biology Lab I,0.0,0.13,0.5,0.25,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,18.0,General Biology Lab I,0.0,0.13,0.42,0.38,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,19.0,General Biology Lab I,0.04,0.38,0.25,0.17,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,20.0,General Biology Lab I,0.0,0.25,0.5,0.17,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,21.0,General Biology Lab I,0.0,0.21,0.42,0.21,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,22.0,General Biology Lab I,0.0,0.13,0.54,0.17,0.13,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,23.0,General Biology Lab I,0.0,0.09,0.3,0.35,0.17,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,24.0,General Biology Lab I,0.0,0.26,0.39,0.22,0.0,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,25.0,General Biology Lab I,0.0,0.26,0.52,0.04,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,27.0,General Biology Lab I,0.04,0.33,0.46,0.0,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,28.0,General Biology Lab I,0.04,0.13,0.42,0.33,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,29.0,General Biology Lab I,0.08,0.29,0.42,0.0,0.04,0.0,0.0,0.17,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,30.0,General Biology Lab I,0.04,0.13,0.63,0.08,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,32.0,General Biology Lab I,0.0,0.22,0.3,0.22,0.13,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,33.0,General Biology Lab I,0.0,0.1,0.38,0.24,0.14,0.0,0.0,0.14,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,34.0,General Biology Lab I,0.0,0.35,0.35,0.13,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,35.0,General Biology Lab I,0.0,0.17,0.5,0.25,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,36.0,General Biology Lab I,0.0,0.42,0.25,0.13,0.08,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,37.0,General Biology Lab I,0.21,0.29,0.33,0.08,0.08,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,38.0,General Biology Lab I,0.0,0.04,0.67,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,39.0,General Biology Lab I,0.04,0.38,0.29,0.21,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,40.0,General Biology Lab I,0.0,0.5,0.25,0.17,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,41.0,General Biology Lab I,0.04,0.38,0.38,0.13,0.0,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,42.0,General Biology Lab I,0.04,0.29,0.38,0.17,0.04,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,43.0,General Biology Lab I,0.0,0.33,0.29,0.21,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,44.0,General Biology Lab I,0.04,0.25,0.38,0.17,0.04,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,45.0,General Biology Lab I,0.0,0.25,0.33,0.21,0.17,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1050,46.0,General Biology Lab I,0.0,0.33,0.29,0.08,0.17,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2019
+BIOL,1090,1.0,Intro to Life Sci,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,renea chris hardwick,,BIOL-1090,2019
+BIOL,1100,1.0,Principles of Biology I,0.43,0.34,0.15,0.02,0.02,0.0,0.0,0.03,renea chris hardwick,,BIOL-1100,2019
+BIOL,1100,2.0,Principles of Biology I (HON),0.81,0.18,0.01,0.0,0.0,0.0,0.0,0.0,verna christine  minor,True,BIOL-1100,2019
+BIOL,1100,3.0,Principles of Biology I,0.27,0.55,0.16,0.02,0.0,0.0,0.0,0.0,verna christine  minor,,BIOL-1100,2019
+BIOL,1100,4.0,Principles of Biology I,0.55,0.29,0.1,0.05,0.02,0.0,0.0,0.0,renea chris hardwick,,BIOL-1100,2019
+BIOL,2110,1.0,Introduction to Toxicology,0.44,0.44,0.05,0.02,0.02,0.0,0.0,0.02,peter van den hurk,,BIOL-2110,2019
+BIOL,2220,1.0,Human Anat and Physiology I,0.23,0.36,0.24,0.08,0.03,0.0,0.0,0.06,john cummings,,BIOL-2220,2019
+BIOL,2220,2.0,Human Anat and Physiology I,0.27,0.37,0.2,0.08,0.04,0.0,0.0,0.05,john cummings,,BIOL-2220,2019
+BIOL,3030,1.0,Vertebrate Biology,0.5,0.25,0.13,0.06,0.03,0.0,0.0,0.01,virginia ellen abernathy,,BIOL-3030,2019
+BIOL,3030,2.0,Vertebrate Biology (HON),0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,virginia ellen abernathy,True,BIOL-3030,2019
+BIOL,3030,3.0,Vertebrate Biology,0.53,0.29,0.09,0.09,0.0,0.0,0.0,0.0,virginia ellen abernathy,,BIOL-3030,2019
+BIOL,3040,1.0,Biology of Plants,0.19,0.29,0.3,0.19,0.01,0.0,0.0,0.03,nathan redding,,BIOL-3040,2019
+BIOL,3070,1.0,Vertebrate Biology Lab,0.36,0.56,0.08,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2019
+BIOL,3070,2.0,Vertebrate Biology Lab,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2019
+BIOL,3070,3.0,Vertebrate Biology Lab,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2019
+BIOL,3070,4.0,Vertebrate Biology Lab,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2019
+BIOL,3070,5.0,Vertebrate Biology Lab,0.21,0.71,0.04,0.0,0.0,0.0,0.0,0.04,richard blob,,BIOL-3070,2019
+BIOL,3070,6.0,Vertebrate Biology Lab,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2019
+BIOL,3070,7.0,Vertebrate Biology Lab,0.67,0.29,0.04,0.0,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2019
+BIOL,3070,8.0,Vertebrate Biology Lab,0.5,0.38,0.08,0.04,0.0,0.0,0.0,0.0,richard blob,,BIOL-3070,2019
+BIOL,3070,9.0,Vertebrate Biology Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,richard blob,,BIOL-3070,2019
+BIOL,3080,1.0,Biology of Plants Practicum,0.45,0.35,0.1,0.05,0.0,0.0,0.0,0.05,nathan redding,,BIOL-3080,2019
+BIOL,3080,3.0,Biology of Plants Practicum,0.2,0.6,0.1,0.1,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2019
+BIOL,3080,4.0,Biology of Plants Practicum,0.25,0.42,0.17,0.17,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2019
+BIOL,3080,5.0,Biology of Plants Practicum,0.13,0.53,0.33,0.0,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2019
+BIOL,3080,6.0,Biology of Plants Practicum,0.13,0.44,0.44,0.0,0.0,0.0,0.0,0.0,nathan redding,,BIOL-3080,2019
+BIOL,3150,1.0,Functional Human Anatomy,0.26,0.39,0.19,0.08,0.01,0.0,0.0,0.06,tamara mcnutt-scott,,BIOL-3150,2019
+BIOL,3200,1.0,Field Botany,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,robert edward ballard,,BIOL-3200,2019
+BIOL,3350,1.0,Evolutionary Biology,0.27,0.44,0.21,0.06,0.02,0.0,0.0,0.01,margaret ptacek,,BIOL-3350,2019
+BIOL,3510,1.0,Biological Anthropology,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,lisa rapaport,,BIOL-3510,2019
+BIOL,3530,1.0,Forensic Anthropology,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,katherine weisensee,,BIOL-3530,2019
+BIOL,4030,1.0,Intro to Applied Genomics,0.15,0.08,0.23,0.0,0.0,0.0,0.0,0.54,vincent paul richards,,BIOL-4030,2019
+BIOL,4140,1.0,Basic Immunology,0.28,0.22,0.28,0.11,0.0,0.0,0.0,0.11,yanzhang wei,,BIOL-4140,2019
+BIOL,4200,1.0,Neurobiology,0.59,0.31,0.03,0.0,0.0,0.0,0.0,0.06,david feliciano,,BIOL-4200,2019
+BIOL,4250,1.0,Introductory Mycology,0.39,0.36,0.13,0.05,0.05,0.0,0.0,0.03,julia louise kerrigan,,BIOL-4250,2019
+BIOL,4260,1.0,Mycology Practicum,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,julia louise kerrigan,,BIOL-4260,2019
+BIOL,4400,1.0,Developmental Animal Biology,0.34,0.22,0.3,0.1,0.02,0.0,0.0,0.02,kara elizabeth powder,,BIOL-4400,2019
+BIOL,4410,1.0,Ecology,0.24,0.38,0.19,0.07,0.01,0.0,0.0,0.1,sharon bewick,,BIOL-4410,2019
+BIOL,4530,1.0,Integrative Organismal Biology,0.67,0.27,0.0,0.0,0.0,0.0,0.0,0.07,michael sears,,BIOL-4530,2019
+BIOL,4560,1.0,Medical and Vet Parasitology,0.59,0.37,0.0,0.02,0.0,0.0,0.0,0.02,wilbur kearse milhous,,BIOL-4560,2019
+BIOL,4610,1.0,Cell Biology,0.36,0.37,0.2,0.03,0.01,0.0,0.0,0.03,susan caroline chapman,,BIOL-4610,2019
+BIOL,4610,2.0,Cell Biology (HON),0.58,0.33,0.03,0.0,0.0,0.0,0.0,0.06,susan caroline chapman,True,BIOL-4610,2019
+BIOL,4620,1.0,Cell Biology Lab (Lec),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,2.0,Cell Biology Lab (Lec),0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,3.0,Cell Biology Lab (Lec),0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,4.0,Cell Biology Lab (Lec),0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,5.0,Cell Biology Lab (Lec),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,6.0,Cell Biology Lab (Lec),0.85,0.12,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,7.0,Cell Biology Lab (Lec),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,8.0,Cell Biology Lab (Lec),0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4670,1.0,Principles of Hematology,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.03,vincent gallicchio,,BIOL-4670,2019
+BIOL,4890,1.0,Clinical Apps and Medical Prac,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,,BIOL-4890,2019
+BIOL,4930,2.0,Sr Sem: Current Topic Biology,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,,BIOL-4930,2019
+BIOL,4930,5.0,Sr Sem: Biol Adv in Agricultur,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,salvatore sparace,,BIOL-4930,2019
+BIOL,4930,6.0,Sr Sem: Emerging Viruses,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,matthew turnbull,,BIOL-4930,2019
+BIOL,4930,7.0,Sr Sem: Negl Infect Dis Povert,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,,BIOL-4930,2019
+BIOL,6030,1.0,Intro to Applied Genomics,0.5,0.25,0.13,0.0,0.0,0.0,0.0,0.13,vincent paul richards,,BIOL-6030,2019
+BIOL,6610,1.0,Cell Biology,0.2,0.2,0.4,0.0,0.2,0.0,0.0,0.0,susan caroline chapman,,BIOL-6610,2019
+BIOL,8400,1.0,Understanding Biological Inq,0.92,0.0,0.04,0.0,0.04,0.0,0.0,0.0,michael childress,,BIOL-8400,2019
+BIOL,8420,1.0,Understand Cellular Processes,0.89,0.09,0.0,0.0,0.01,0.0,0.0,0.01,kaustubha ratan qanungo,,BIOL-8420,2019
+BIOL,8440,1.0,Understanding the Human Body,0.43,0.43,0.11,0.0,0.03,0.0,0.0,0.0,tamara mcnutt-scott,,BIOL-8440,2019
+BMOL,4250,1.0,Biomolecular Engineering,0.23,0.43,0.2,0.08,0.05,0.0,0.0,0.0,marc russel birtwistle,,BMOL-4250,2019
+BUS,1010,1.0,Business Foundations,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,william ernest tumblin,,BUS-1010,2019
+BUS,1010,2.0,Business Foundations,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,william ernest tumblin,,BUS-1010,2019
+CE,4910,1.0,BIM in Construction Management,0.81,0.14,0.02,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4910,2019
+CE,4910,2.0,Accident Analytics,0.3,0.5,0.2,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,,CE-4910,2019
+CE,4990,14.0,Special Projects-Springer II,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,prasada rao rangaraju,,CE-4990,2019
+CE,6010,1.0,Matrix Str Analysis,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,laura mae redmond,,CE-6010,2019
+CE,6430,1.0,Water Resources Engr,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,abdul khan,,CE-6430,2019
+CE,6470,1.0,Stormwater Managemnt,0.67,0.0,0.33,0.0,0.0,0.0,0.0,0.0,md nasimul hoque chowdhury,,CE-6470,2019
+CE,8010,1.0,Finite Ele Analysis,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nadarajah ravichandran,,CE-8010,2019
+CE,8020,1.0,Adv R/C Design,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas edford cousins,,CE-8020,2019
+CE,8700,500.0,Capstone Design Risk Engr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,,CE-8700,2019
+CE,8930,3.0,Transport Risk & Evacuation,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,pamela marie murray-tuite,,CE-8930,2019
+CE,8930,4.0,Autonomous Vehicle Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-8930,2019
+CE,8930,5.0,Struct Fire Engr & Safety,0.25,0.67,0.08,0.0,0.0,0.0,0.0,0.0,mohannad naser,,CE-8930,2019
+CH,1010,1.0,General Chemistry,0.26,0.37,0.2,0.03,0.05,0.0,0.0,0.1,tania houjeiry,,CH-1010,2019
+CH,1010,2.0,General Chemistry,0.12,0.4,0.31,0.09,0.02,0.0,0.0,0.06,olt geiculescu,,CH-1010,2019
+CH,1010,3.0,General Chemistry,0.21,0.32,0.28,0.08,0.03,0.0,0.0,0.07,william wesley mcwhorter,,CH-1010,2019
+CH,1010,4.0,General Chemistry,0.25,0.26,0.22,0.11,0.05,0.0,0.0,0.1,khushi patel,,CH-1010,2019
+CH,1010,5.0,General Chemistry,0.28,0.37,0.17,0.06,0.04,0.0,0.0,0.09,dennis taylor,,CH-1010,2019
+CH,1010,6.0,General Chemistry,0.29,0.35,0.18,0.08,0.04,0.0,0.0,0.07,elliot ennis,,CH-1010,2019
+CH,1010,7.0,General Chemistry,0.17,0.33,0.22,0.09,0.06,0.0,0.0,0.13,william wesley mcwhorter,,CH-1010,2019
+CH,1010,8.0,General Chemistry,0.38,0.32,0.12,0.12,0.02,0.0,0.0,0.05,thomas hickman,,CH-1010,2019
+CH,1010,9.0,General Chemistry,0.25,0.42,0.25,0.04,0.03,0.0,0.0,0.03,william wesley mcwhorter,,CH-1010,2019
+CH,1010,10.0,General Chemistry,0.17,0.38,0.21,0.08,0.08,0.0,0.0,0.08,princess mycia cox,,CH-1010,2019
+CH,1010,11.0,General Chemistry,0.37,0.39,0.1,0.06,0.07,0.0,0.0,0.01,thomas hickman,,CH-1010,2019
+CH,1010,12.0,General Chemistry,0.32,0.33,0.22,0.04,0.05,0.0,0.0,0.05,dennis taylor,,CH-1010,2019
+CH,1010,13.0,General Chemistry,0.27,0.31,0.16,0.15,0.03,0.0,0.0,0.08,princess mycia cox,,CH-1010,2019
+CH,1010,14.0,General Chemistry,0.14,0.33,0.3,0.12,0.03,0.0,0.0,0.08,jacob schroeder,,CH-1010,2019
+CH,1010,50.0,General Chemistry,0.53,0.33,0.12,0.0,0.02,0.0,0.0,0.0,tania houjeiry,,CH-1010,2019
+CH,1010,51.0,General Chemistry (HON),0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,joseph stuart thrasher,True,CH-1010,2019
+CH,1010,52.0,General Chemistry (HON),0.7,0.22,0.08,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True,CH-1010,2019
+CH,1010,201.0,General Chemistry,0.18,0.47,0.23,0.06,0.05,0.0,0.0,0.02,elliot ennis,,CH-1010,2019
+CH,1010,203.0,General Chemistry,0.24,0.37,0.26,0.06,0.07,0.0,0.0,0.0,jacob schroeder,,CH-1010,2019
+CH,1010,204.0,General Chemistry,0.32,0.32,0.23,0.07,0.03,0.0,0.0,0.03,thao thi thanh tran,,CH-1010,2019
+CH,1020,1.0,General Chemistry,0.34,0.25,0.21,0.11,0.01,0.0,0.0,0.09,stephen jon schvaneveldt,,CH-1020,2019
+CH,1020,2.0,General Chemistry,0.28,0.28,0.2,0.15,0.02,0.0,0.0,0.07,stephen jon schvaneveldt,,CH-1020,2019
+CH,1020,3.0,General Chemistry,0.26,0.2,0.31,0.08,0.04,0.0,0.0,0.11,stephen jon schvaneveldt,,CH-1020,2019
+CH,1020,400.0,General Chemistry,0.1,0.29,0.17,0.24,0.07,0.0,0.0,0.14,stephen jon schvaneveldt,,CH-1020,2019
+CH,1050,1.0,Chemistry in Context I,0.43,0.31,0.16,0.05,0.04,0.0,0.0,0.01,olt geiculescu,,CH-1050,2019
+CH,1050,2.0,Chemistry in Context I,0.45,0.4,0.11,0.01,0.01,0.0,0.0,0.02,olt geiculescu,,CH-1050,2019
+CH,2010,1.0,Survey of Organic Chemistry,0.62,0.25,0.06,0.04,0.03,0.0,0.0,0.0,tania houjeiry,,CH-2010,2019
+CH,2010,2.0,Survey of Organic Chemistry,0.4,0.4,0.13,0.03,0.02,0.0,0.0,0.02,modi wetzler,,CH-2010,2019
+CH,2230,1.0,Organic Chemistry,0.09,0.16,0.24,0.14,0.25,0.0,0.0,0.12,modi wetzler,,CH-2230,2019
+CH,2230,2.0,Organic Chemistry,0.05,0.23,0.22,0.12,0.16,0.0,0.0,0.21,modi wetzler,,CH-2230,2019
+CH,2230,3.0,Organic Chemistry,0.38,0.3,0.2,0.07,0.03,0.0,0.0,0.02,laura lanni,,CH-2230,2019
+CH,2230,4.0,Organic Chemistry,0.29,0.25,0.25,0.07,0.08,0.0,0.0,0.06,laura lanni,,CH-2230,2019
+CH,2230,5.0,Organic Chemistry,0.4,0.32,0.13,0.03,0.05,0.0,0.0,0.08,rhett smith,,CH-2230,2019
+CH,2230,6.0,Organic Chemistry,0.24,0.28,0.26,0.11,0.07,0.0,0.0,0.04,elliot ennis,,CH-2230,2019
+CH,2230,7.0,Organic Chemistry,0.14,0.18,0.27,0.2,0.09,0.0,0.0,0.12,elliot ennis,,CH-2230,2019
+CH,2230,50.0,Organic Chemistry,0.33,0.43,0.15,0.03,0.03,0.0,0.0,0.03,daniel whitehead,,CH-2230,2019
+CH,2240,1.0,Organic Chemistry,0.3,0.2,0.15,0.18,0.09,0.0,0.0,0.09,laura lanni,,CH-2240,2019
+CH,2240,2.0,Organic Chemistry,0.23,0.23,0.24,0.14,0.1,0.0,0.0,0.04,thomas hickman,,CH-2240,2019
+CH,2270,1.0,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,,CH-2270,2019
+CH,2270,3.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2019
+CH,2270,5.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2019
+CH,2270,7.0,Organic Chem Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james nelson plampin,,CH-2270,2019
+CH,2270,8.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2019
+CH,2270,13.0,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelson plampin,,CH-2270,2019
+CH,2270,15.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2019
+CH,2270,16.0,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelson plampin,,CH-2270,2019
+CH,2270,19.0,Organic Chem Lab,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james nelson plampin,,CH-2270,2019
+CH,2270,23.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2019
+CH,2270,27.0,Organic Chem Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,,CH-2270,2019
+CH,2270,29.0,Organic Chem Lab,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,james nelson plampin,,CH-2270,2019
+CH,2270,32.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2019
+CH,2270,35.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,james nelson plampin,,CH-2270,2019
+CH,2270,39.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,james nelson plampin,,CH-2270,2019
+CH,2270,40.0,Organic Chem Lab,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,james nelson plampin,,CH-2270,2019
+CH,2280,4.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,james nelson plampin,,CH-2280,2019
+CH,3130,1.0,Quantitative Analysis,0.55,0.2,0.1,0.03,0.05,0.0,0.0,0.08,jeffrey nathan anker,,CH-3130,2019
+CH,3150,1.0,Quant Analysis Lab,0.5,0.2,0.0,0.1,0.1,0.0,0.0,0.1,carlos diego garcia perez,,CH-3150,2019
+CH,3150,2.0,Quant Analysis Lab,0.73,0.09,0.0,0.0,0.18,0.0,0.0,0.0,carlos diego garcia perez,,CH-3150,2019
+CH,3300,1.0,Intro to Phys Chem,0.52,0.31,0.06,0.05,0.04,0.0,0.0,0.02,brian dominy,,CH-3300,2019
+CH,3310,1.0,Physical Chemistry,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,steven stuart,,CH-3310,2019
+CH,3390,1.0,Physical Chem Lab,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2019
+CH,3390,2.0,Physical Chem Lab,0.2,0.73,0.07,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2019
+CH,3390,3.0,Physical Chem Lab,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2019
+CH,3390,4.0,Physical Chem Lab,0.33,0.56,0.06,0.06,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2019
+CH,3390,5.0,Physical Chem Lab,0.47,0.47,0.0,0.06,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3390,2019
+CH,4010,1.0,Organometallic Chemistry,0.71,0.24,0.0,0.03,0.0,0.0,0.0,0.03,andrew gregory tennyson,,CH-4010,2019
+CH,4020,1.0,Inorganic Chemistry,0.44,0.44,0.08,0.0,0.04,0.0,0.0,0.0,joseph kolis,,CH-4020,2019
+CH,4210,1.0,Advanced Organic Chemistry,0.3,0.59,0.04,0.04,0.0,0.0,0.0,0.04,jacob schroeder,,CH-4210,2019
+CH,8070,1.0,Chem Trans Elem,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,julia brumaghim,,CH-8070,2019
+CH,8140,1.0,Analytical Imaging,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,george chumanov,,CH-8140,2019
+CH,8160,1.0,Separation Science,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,richard marcus,,CH-8160,2019
+CH,8410,1.0,N M R Spectroscopy,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,aleksandr kitaygorodskiy,,CH-8410,2019
+CH,8510,1.0,Grad Student Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,,CH-8510,2019
+CH,8520,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,joseph stuart thrasher,,CH-8520,2019
+CHE,2110,1.0,Mass and Energy Balances,0.35,0.39,0.25,0.0,0.0,0.0,0.0,0.01,karen ann high,,CHE-2110,2019
+CHE,2990,3.0,CI in CHE-  YEAST,0.0,0.0,0.0,0.0,0.0,0.75,0.0,0.25,marc russel birtwistle,,CHE-2990,2019
+CHE,3210,1.0,Ch E Thermo II,0.22,0.13,0.37,0.15,0.13,0.0,0.0,0.0,mark thies,,CHE-3210,2019
+CHE,3300,1.0,Mass Trans & Seprtn,0.25,0.46,0.21,0.03,0.05,0.0,0.0,0.0,david bruce,,CHE-3300,2019
+CHE,3990,8.0,CI in CHE- NANO,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jessica marie larsen,,CHE-3990,2019
+CHE,3990,9.0,CI- OPEN EDUCATIONAL RESOURCES,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rachel getman,,CHE-3990,2019
+CHE,4070,1.0,Unit Op Lab II,0.22,0.66,0.12,0.0,0.0,0.0,0.0,0.0,christopher norfolk,,CHE-4070,2019
+CHE,4310,1.0,Process Design I,0.3,0.45,0.25,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4310,2019
+CHE,4500,1.0,Chem Reaction Engr,0.35,0.4,0.22,0.03,0.0,0.0,0.0,0.0,mark roberts,,CHE-4500,2019
+CHE,8040,1.0,Ch E Thermodynamics,0.23,0.54,0.23,0.0,0.0,0.0,0.0,0.0,sapna sarupria,,CHE-8040,2019
+CHE,8050,1.0,Ch E Kinetics,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,rachel getman,,CHE-8050,2019
+CHIN,1010,1.0,Elementary Chinese,0.5,0.2,0.1,0.1,0.0,0.0,0.0,0.1,yanhua zhang,,CHIN-1010,2019
+CHIN,1010,2.0,Elementary Chinese,0.33,0.42,0.0,0.17,0.0,0.0,0.0,0.08,yanhua zhang,,CHIN-1010,2019
+CHIN,4010,1.0,Pre-Modern Chinese Literature,0.3,0.5,0.1,0.0,0.03,0.0,0.0,0.08,yanming an,,CHIN-4010,2019
+COM,1500,1.0,Intro to Human Communication,0.66,0.32,0.01,0.0,0.0,0.0,0.0,0.01,daniel leland fecher,,COM-1500,2019
+COM,1500,2.0,Intro to Human Communication,0.73,0.22,0.03,0.0,0.01,0.0,0.0,0.02,daniel leland fecher,,COM-1500,2019
+COM,1500,3.0,Intro to Human Communication,0.8,0.14,0.03,0.01,0.0,0.0,0.0,0.01,daniel leland fecher,,COM-1500,2019
+COM,1500,4.0,Intro to Human Communication,0.74,0.22,0.02,0.01,0.01,0.0,0.0,0.01,marianne herr glaser,,COM-1500,2019
+COM,1500,5.0,Intro to Human Communication,0.74,0.22,0.02,0.0,0.0,0.0,0.0,0.02,marianne herr glaser,,COM-1500,2019
+COM,1500,6.0,Intro to Human Communication,0.82,0.14,0.02,0.0,0.0,0.0,0.0,0.02,marianne herr glaser,,COM-1500,2019
+COM,1500,7.0,Intro to Human Communication,0.49,0.4,0.07,0.01,0.01,0.0,0.0,0.01,vanessa anne condon,,COM-1500,2019
+COM,2010,1.0,Intr to Comm Studies,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2010,2019
+COM,2010,2.0,Intr to Comm Studies,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2010,2019
+COM,2030,1.0,Mass Communication Theory,0.35,0.15,0.45,0.0,0.05,0.0,0.0,0.0,jumah patricia taweh,,COM-2030,2019
+COM,2040,1.0,Critical-Cultural Comm Theory,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james nicholas gilmore,,COM-2040,2019
+COM,2100,1.0,Quant Comm Research Methods,0.33,0.39,0.17,0.06,0.06,0.0,0.0,0.0,gregory keith cranmer,,COM-2100,2019
+COM,2110,1.0,Qual Comm Research Methods,0.67,0.24,0.1,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-2110,2019
+COM,2500,2.0,Public Speaking,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2019
+COM,2500,3.0,Public Speaking,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2019
+COM,2500,5.0,Public Speaking,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,alyssa christine davis,,COM-2500,2019
+COM,2500,6.0,Public Speaking,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christine davis,,COM-2500,2019
+COM,2500,7.0,Public Speaking,0.42,0.42,0.05,0.11,0.0,0.0,0.0,0.0,marshall thomas covert,,COM-2500,2019
+COM,2500,8.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,marshall thomas covert,,COM-2500,2019
+COM,2500,9.0,Public Speaking,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,marshall thomas covert,,COM-2500,2019
+COM,2500,10.0,Public Speaking,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,marshall thomas covert,,COM-2500,2019
+COM,2500,11.0,Public Speaking,0.74,0.16,0.11,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,,COM-2500,2019
+COM,2500,17.0,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,jumah patricia taweh,,COM-2500,2019
+COM,2500,18.0,Public Speaking,0.67,0.22,0.0,0.11,0.0,0.0,0.0,0.0,ashley lauren pikel,,COM-2500,2019
+COM,2500,19.0,Public Speaking,0.53,0.37,0.0,0.0,0.0,0.0,0.0,0.11,jumah patricia taweh,,COM-2500,2019
+COM,2500,21.0,Public Speaking,0.63,0.26,0.0,0.05,0.05,0.0,0.0,0.0,charles john brewer,,COM-2500,2019
+COM,2500,22.0,Public Speaking,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,charles john brewer,,COM-2500,2019
+COM,2500,23.0,Public Speaking,0.79,0.11,0.05,0.05,0.0,0.0,0.0,0.0,sara grumbles crocker,,COM-2500,2019
+COM,2500,24.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,charles john brewer,,COM-2500,2019
+COM,2500,25.0,Public Speaking,0.68,0.11,0.05,0.05,0.0,0.0,0.0,0.11,sara grumbles crocker,,COM-2500,2019
+COM,2500,26.0,Public Speaking,0.47,0.26,0.11,0.11,0.0,0.0,0.0,0.05,charles john brewer,,COM-2500,2019
+COM,2500,27.0,Public Speaking,0.72,0.17,0.06,0.0,0.06,0.0,0.0,0.0,sara grumbles crocker,,COM-2500,2019
+COM,2500,28.0,Public Speaking,0.74,0.11,0.11,0.0,0.05,0.0,0.0,0.0,katie barnes mcelveen,,COM-2500,2019
+COM,2500,29.0,Public Speaking,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel leland fecher,,COM-2500,2019
+COM,2500,30.0,Public Speaking,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,elizabeth ann kaszynski gilmore,,COM-2500,2019
+COM,2500,33.0,Public Speaking,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,,COM-2500,2019
+COM,2500,37.0,Public Speaking (HON),0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,lindsey dixon,True,COM-2500,2019
+COM,2500,39.0,Public Speaking (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,True,COM-2500,2019
+COM,2500,400.0,Public Speaking,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,,COM-2500,2019
+COM,2500,401.0,Public Speaking,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,alexis zachary davis,,COM-2500,2019
+COM,2500,403.0,Public Speaking,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachary davis,,COM-2500,2019
+COM,3050,1.0,Persuasion,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,,COM-3050,2019
+COM,3080,1.0,Public Comm & Pop Culture,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,erin michelle ash,,COM-3080,2019
+COM,3240,1.0,"Communication, Sport & Society",0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,katie barnes mcelveen,,COM-3240,2019
+COM,3240,2.0,"Communication, Sport & Society",0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,katie barnes mcelveen,,COM-3240,2019
+COM,3250,2.0,Survey of Sports Communication,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,,COM-3250,2019
+COM,3260,1.0,Pr in Sports,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2019
+COM,3260,2.0,Pr in Sports,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3260,2019
+COM,3300,1.0,Nonverbal Communication,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,,COM-3300,2019
+COM,3480,1.0,Interpersonal Comm,0.63,0.26,0.11,0.0,0.0,0.0,0.0,0.0,stephanie michelle pangborn,,COM-3480,2019
+COM,3550,1.0,Principles of Public Relations,0.56,0.39,0.0,0.0,0.06,0.0,0.0,0.0,rachelle leigh beckner,,COM-3550,2019
+COM,3560,1.0,Crisis Communication,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,andrew stephen pyle,,COM-3560,2019
+COM,3660,5.0,Corporate Communications,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,. mark barnes,,COM-3660,2019
+COM,4250,1.0,Adv Sports Comm,0.29,0.59,0.06,0.06,0.0,0.0,0.0,0.0,bryan denham,,COM-4250,2019
+COM,4280,1.0,Interpers/Family Comm & Sport,0.32,0.63,0.05,0.0,0.0,0.0,0.0,0.0,gregory keith cranmer,,COM-4280,2019
+COM,4710,1.0,Health Comm in Communities,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,stephanie michelle pangborn,,COM-4710,2019
+COM,4950,1.0,Senior Capstone Seminar,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-4950,2019
+COM,8010,1.0,Communication Theory I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,erin michelle ash,,COM-8010,2019
+COM,8030,1.0,Comm Technology Studies Survey,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,james nicholas gilmore,,COM-8030,2019
+CPSC,1010,100.0,Computer Science I,0.22,0.37,0.24,0.07,0.07,0.0,0.0,0.04,roger larry van scoy,,CPSC-1010,2019
+CPSC,1010,200.0,Computer Science I,0.4,0.23,0.21,0.04,0.04,0.0,0.0,0.08,roger larry van scoy,,CPSC-1010,2019
+CPSC,1010,300.0,Computer Science I,0.31,0.27,0.18,0.07,0.13,0.0,0.0,0.04,yu-shan sun,,CPSC-1010,2019
+CPSC,1020,1.0,Computer Science II,0.19,0.27,0.32,0.0,0.08,0.0,0.0,0.14,yvon feaster,,CPSC-1020,2019
+CPSC,1020,2.0,Computer Science II,0.23,0.17,0.2,0.06,0.17,0.0,0.0,0.17,yvon feaster,,CPSC-1020,2019
+CPSC,1020,3.0,Computer Science II,0.03,0.16,0.41,0.16,0.11,0.0,0.0,0.14,catherine hochrine,,CPSC-1020,2019
+CPSC,1060,100.0,Intro to Programming in Java,0.26,0.34,0.32,0.03,0.05,0.0,0.0,0.0,svetlana drachova,,CPSC-1060,2019
+CPSC,1060,200.0,Intro to Programming in Java,0.28,0.36,0.23,0.06,0.06,0.0,0.0,0.02,svetlana drachova,,CPSC-1060,2019
+CPSC,1070,1.0,Programming Methodology,0.25,0.42,0.11,0.03,0.03,0.0,0.0,0.17,donald henry house,,CPSC-1070,2019
+CPSC,1070,2.0,Programming Methodology,0.35,0.16,0.27,0.0,0.08,0.0,0.0,0.14,donald henry house,,CPSC-1070,2019
+CPSC,1110,1.0,Intro to Programming in C,0.21,0.25,0.21,0.15,0.09,0.0,0.0,0.09,catherine hochrine,,CPSC-1110,2019
+CPSC,1110,2.0,Intro to Programming in C,0.3,0.33,0.16,0.13,0.01,0.0,0.0,0.06,yu-shan sun,,CPSC-1110,2019
+CPSC,1110,3.0,Intro to Programming in C,0.17,0.26,0.22,0.12,0.14,0.0,0.0,0.09,catherine hochrine,,CPSC-1110,2019
+CPSC,1210,1.0,Computational Thinking,0.25,0.46,0.17,0.0,0.04,0.0,0.0,0.08,alexander christoph herzog,,CPSC-1210,2019
+CPSC,2070,1.0,Discrete Structures,0.34,0.29,0.19,0.05,0.06,0.0,0.0,0.06,larry hodges,,CPSC-2070,2019
+CPSC,2070,2.0,Discrete Structures,0.53,0.24,0.18,0.03,0.03,0.0,0.0,0.0,kai liu,,CPSC-2070,2019
+CPSC,2120,1.0,Algs/Data Structures,0.38,0.28,0.2,0.04,0.06,0.0,0.0,0.04,nicolas benjamin widman,,CPSC-2120,2019
+CPSC,2120,2.0,Algs/Data Structures,0.36,0.28,0.24,0.0,0.08,0.0,0.0,0.04,nicolas benjamin widman,,CPSC-2120,2019
+CPSC,2120,3.0,Algs/Data Structures,0.59,0.19,0.19,0.0,0.0,0.0,0.0,0.04,brian christopher dean,,CPSC-2120,2019
+CPSC,2120,4.0,Algs/Data Structures,0.38,0.19,0.29,0.0,0.14,0.0,0.0,0.0,brian christopher dean,,CPSC-2120,2019
+CPSC,2150,1.0,Software Dev Foundations,0.32,0.35,0.21,0.05,0.03,0.0,0.0,0.03,kevin anton plis,,CPSC-2150,2019
+CPSC,2150,2.0,Software Dev Foundations,0.24,0.32,0.22,0.02,0.08,0.0,0.0,0.12,kevin anton plis,,CPSC-2150,2019
+CPSC,2200,1.0,Problem Solving w/ Office Apps,0.33,0.37,0.13,0.15,0.0,0.0,0.0,0.02,kevin anton plis,,CPSC-2200,2019
+CPSC,2310,1.0,Intro Computer Org,0.6,0.33,0.05,0.0,0.0,0.0,0.0,0.02,nicolas benjamin widman,,CPSC-2310,2019
+CPSC,2310,2.0,Intro Computer Org,0.53,0.18,0.16,0.05,0.05,0.0,0.0,0.02,nicolas benjamin widman,,CPSC-2310,2019
+CPSC,2810,3.0,Selected Topics: Cyberdef Trai,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,svetlana drachova,,CPSC-2810,2019
+CPSC,2910,1.0,Prof Issues I,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,yvon feaster,,CPSC-2910,2019
+CPSC,2910,2.0,Prof Issues I,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,yvon feaster,,CPSC-2910,2019
+CPSC,2910,3.0,Prof Issues I,0.68,0.16,0.05,0.0,0.0,0.0,0.0,0.11,yvon feaster,,CPSC-2910,2019
+CPSC,2910,4.0,Prof Issues I,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2019
+CPSC,2910,5.0,Prof Issues I,0.37,0.47,0.11,0.05,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2019
+CPSC,2910,6.0,Prof Issues I,0.56,0.39,0.06,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2019
+CPSC,2920,1.0,"Computing, Ethics & Society",0.79,0.13,0.05,0.0,0.03,0.0,0.0,0.0,julian langston brinkley,,CPSC-2920,2019
+CPSC,3220,1.0,Intro to Operating Systems,0.08,0.35,0.22,0.03,0.11,0.0,0.0,0.22,pradip srimani,,CPSC-3220,2019
+CPSC,3220,2.0,Intro to Operating Systems,0.18,0.27,0.36,0.15,0.03,0.0,0.0,0.0,mark smotherman,,CPSC-3220,2019
+CPSC,3300,1.0,Computer Systems Org,0.38,0.42,0.17,0.02,0.0,0.0,0.0,0.02,tyler allen,,CPSC-3300,2019
+CPSC,3500,1.0,Foundations of Computer Sci,0.18,0.2,0.38,0.12,0.04,0.0,0.0,0.08,ilya mark safro,,CPSC-3500,2019
+CPSC,3520,1.0,Programming Systems,0.38,0.34,0.14,0.02,0.08,0.0,0.0,0.05,robert schalkoff,,CPSC-3520,2019
+CPSC,3600,1.0,Network Programming,0.53,0.15,0.28,0.03,0.03,0.0,0.0,0.0,andrew robb,,CPSC-3600,2019
+CPSC,3600,2.0,Network Programming,0.55,0.14,0.21,0.05,0.02,0.0,0.0,0.02,andrew robb,,CPSC-3600,2019
+CPSC,3600,3.0,Network Programming,0.47,0.26,0.11,0.0,0.08,0.0,0.0,0.08,jason anderson,,CPSC-3600,2019
+CPSC,3720,1.0,Software Engineering,0.31,0.41,0.23,0.0,0.0,0.0,0.0,0.05,eileen theresa kraemer,,CPSC-3720,2019
+CPSC,3720,2.0,Software Engineering,0.23,0.56,0.16,0.0,0.04,0.0,0.0,0.02,yu-shan sun,,CPSC-3720,2019
+CPSC,4040,1.0,Cmptr Graphics Image,0.56,0.28,0.0,0.0,0.0,0.0,0.0,0.16,ioannis karamouzas,,CPSC-4040,2019
+CPSC,4050,1.0,Computer Graphics,0.52,0.19,0.05,0.0,0.05,0.0,0.0,0.19,victor zordan,,CPSC-4050,2019
+CPSC,4110,1.0,Virtual Reality Systems,0.46,0.43,0.05,0.0,0.03,0.0,0.0,0.03,sabarish venkat babu,,CPSC-4110,2019
+CPSC,4120,1.0,Eye Tracking Methodology,0.43,0.46,0.07,0.0,0.0,0.0,0.0,0.04,andrew duchowski,,CPSC-4120,2019
+CPSC,4140,1.0,Human and Computer Interaction,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,nathaniel mcneese,,CPSC-4140,2019
+CPSC,4150,1.0,Mobile Device Software Devel,0.23,0.23,0.35,0.08,0.0,0.0,0.0,0.12,christopher plaue,,CPSC-4150,2019
+CPSC,4200,1.0,Computer Security Principles,0.67,0.3,0.03,0.0,0.0,0.0,0.0,0.0,long cheng,,CPSC-4200,2019
+CPSC,4240,1.0,System Admin and Security,0.1,0.6,0.2,0.1,0.0,0.0,0.0,0.0,svetlana drachova,,CPSC-4240,2019
+CPSC,4300,1.0,Applied Data Science,0.36,0.43,0.15,0.02,0.02,0.0,0.0,0.02,alexander christoph herzog,,CPSC-4300,2019
+CPSC,4620,1.0,Database Management Systems,0.12,0.38,0.12,0.12,0.0,0.0,0.0,0.27,pradip srimani,,CPSC-4620,2019
+CPSC,4770,1.0,Distributed/Cluster Computing,0.39,0.33,0.11,0.06,0.06,0.0,0.0,0.06,shuangshuang jin,,CPSC-4770,2019
+CPSC,4820,1.0,Special Topic: Web Programming,0.57,0.21,0.13,0.04,0.02,0.0,0.0,0.02,craig baker,,CPSC-4820,2019
+CPSC,4820,2.0,Special Topics: Hands on ML,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,larry hodges,,CPSC-4820,2019
+CPSC,4820,4.0,Spe Topic: AI,0.33,0.24,0.1,0.0,0.0,0.0,0.0,0.33,ioannis karamouzas,,CPSC-4820,2019
+CPSC,4890,1.0,Programming Team Seminar,0.65,0.15,0.05,0.05,0.0,0.0,0.0,0.1,brian christopher dean,,CPSC-4890,2019
+CPSC,4910,1.0,Professional Issues II,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,roger larry van scoy,,CPSC-4910,2019
+CPSC,4910,2.0,Professional Issues II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alexander christoph herzog,,CPSC-4910,2019
+CPSC,6040,1.0,Cptr Graphics Image,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,ioannis karamouzas,,CPSC-6040,2019
+CPSC,6050,1.0,Computer Graphics,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,victor zordan,,CPSC-6050,2019
+CPSC,6110,1.0,Virtual Reality Systems,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,sabarish venkat babu,,CPSC-6110,2019
+CPSC,6150,1.0,Mobile Device Software Devel,0.44,0.33,0.11,0.0,0.0,0.0,0.0,0.11,christopher plaue,,CPSC-6150,2019
+CPSC,6240,1.0,System Admin and Security,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,svetlana drachova,,CPSC-6240,2019
+CPSC,6300,1.0,Applied Data Science,0.82,0.11,0.04,0.0,0.0,0.0,0.0,0.04,kai liu,,CPSC-6300,2019
+CPSC,6300,2.0,Applied Data Science,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xizhou feng,,CPSC-6300,2019
+CPSC,6620,1.0,Database Management Systems,0.5,0.33,0.08,0.0,0.0,0.0,0.0,0.08,pradip srimani,,CPSC-6620,2019
+CPSC,6820,4.0,Spec Top: AI,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,ioannis karamouzas,,CPSC-6820,2019
+CPSC,8040,1.0,Data Visualization,0.74,0.2,0.0,0.0,0.03,0.0,0.0,0.03,federico iuricich,,CPSC-8040,2019
+CPSC,8100,1.0,Intro Artif Intell,0.43,0.43,0.02,0.0,0.0,0.0,0.0,0.11,feng luo,,CPSC-8100,2019
+CPSC,8170,1.0,Physically Based Animation,0.33,0.33,0.17,0.0,0.0,0.0,0.0,0.17,jerry tessendorf,,CPSC-8170,2019
+CPSC,8200,1.0,Parallel Architechture,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,rong ge,,CPSC-8200,2019
+CPSC,8380,1.0,Adv Data Structures,0.25,0.5,0.0,0.0,0.13,0.0,0.0,0.13,sandra hedetniemi,,CPSC-8380,2019
+CPSC,8480,1.0,Network Science,0.2,0.4,0.25,0.0,0.1,0.0,0.0,0.05,ilya mark safro,,CPSC-8480,2019
+CPSC,8520,1.0,Internetworking,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,james martin,,CPSC-8520,2019
+CPSC,8580,1.0,Security in Emerging Systems,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,hongxin hu,,CPSC-8580,2019
+CPSC,8580,843.0,Security in Emerging Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,,CPSC-8580,2019
+CPSC,8620,1.0,Database Mngmt System Design,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,nina christine hubig,,CPSC-8620,2019
+CPSC,8710,1.0,Found. of Software Engineering,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,murali sitaraman,,CPSC-8710,2019
+CSM,1000,1.0,Intro to Construct,0.92,0.06,0.0,0.0,0.0,0.0,0.0,0.02,harnish sharma,,CSM-1000,2019
+CSM,2010,1.0,Structures I,0.35,0.43,0.08,0.03,0.0,0.0,0.0,0.11,shima clarke,,CSM-2010,2019
+CSM,2020,1.0,Structures II,0.77,0.14,0.03,0.03,0.0,0.0,0.0,0.03,nathaniel jackson,,CSM-2020,2019
+CSM,2030,1.0,Mats & Meth of Const,0.33,0.35,0.28,0.0,0.0,0.0,0.0,0.05,jason lucas,,CSM-2030,2019
+CSM,2040,1.0,Cont Documents,0.41,0.48,0.07,0.03,0.0,0.0,0.0,0.0,robert dawson coffey,,CSM-2040,2019
+CSM,2050,1.0,Mats & Methods II,0.09,0.69,0.23,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,,CSM-2050,2019
+CSM,3040,1.0,Envir Systems I,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,joseph michael burgett,,CSM-3040,2019
+CSM,3050,1.0,Envir Systems II,0.63,0.11,0.21,0.05,0.0,0.0,0.0,0.0,joseph michael burgett,,CSM-3050,2019
+CSM,3060,1.0,Emerging Tech in Construction,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,harnish sharma,,CSM-3060,2019
+CSM,3070,1.0,Sustainable Construction,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,harnish sharma,,CSM-3070,2019
+CSM,3510,1.0,Construction Estimating,0.35,0.55,0.1,0.0,0.0,0.0,0.0,0.0,seyed ehsan mousavi rizi,,CSM-3510,2019
+CSM,3520,401.0,Const Scheduling,0.22,0.72,0.0,0.0,0.0,0.0,0.0,0.06,craig townsend,,CSM-3520,2019
+CSM,3530,1.0,Const Estimating II,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,seyed ehsan mousavi rizi,,CSM-3530,2019
+CSM,4110,1.0,Safety in Bldg Const,0.56,0.38,0.06,0.0,0.0,0.0,0.0,0.0,nicholas corley,,CSM-4110,2019
+CSM,4500,1.0,Construction Intern,0.16,0.43,0.37,0.03,0.0,0.0,0.0,0.0,nathaniel jackson,,CSM-4500,2019
+CSM,4530,1.0,Const Proj Mgmt,0.21,0.69,0.1,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4530,2019
+CSM,4530,2.0,Const Proj Mgmt,0.43,0.4,0.17,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4530,2019
+CSM,4540,1.0,Const Capstone,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,,CSM-4540,2019
+CSM,4610,1.0,Const Econ Seminar,0.66,0.31,0.0,0.0,0.0,0.0,0.0,0.03,catherine nove-josserand,,CSM-4610,2019
+CSM,4610,2.0,Const Econ Seminar,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,catherine nove-josserand,,CSM-4610,2019
+CSM,4980,2.0,Current Topics-NAHB Comp,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-4980,2019
+CSM,8360,400.0,Managing Integr Proj Delivery,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,shima clarke,,CSM-8360,2019
+CSM,8650,1.0,Project Management,0.2,0.67,0.13,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8650,2019
+CSM,8650,400.0,Project Management,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-8650,2019
+CU,1000,26.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2019
+CU,1000,30.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2019
+CU,1000,34.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2019
+CU,1000,37.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,susan whorton,,CU-1000,2019
+CU,1000,51.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,,CU-1000,2019
+CU,1000,52.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,susan whorton,,CU-1000,2019
+CU,1010,1.0,Univ Success Skills,0.5,0.1,0.1,0.0,0.3,0.0,0.0,0.0,cynthia june smith,,CU-1010,2019
+CU,1010,8.0,Univ Success Skills,0.5,0.06,0.11,0.0,0.11,0.0,0.0,0.22,catherine maroska neel,,CU-1010,2019
+CU,1010,602.0,Univ Success Skills,0.62,0.15,0.15,0.0,0.0,0.0,0.0,0.08,valerie kay oonk,,CU-1010,2019
+CU,1010,603.0,Univ Success Skills,0.56,0.23,0.1,0.03,0.08,0.0,0.0,0.0,elizabeth anne stephan,,CU-1010,2019
+CU,1010,605.0,Univ Success Skills,0.43,0.24,0.24,0.0,0.1,0.0,0.0,0.0,matthew kent miller,,CU-1010,2019
+CU,1010,606.0,Univ Success Skills,0.3,0.3,0.04,0.17,0.17,0.0,0.0,0.0,andrew isaac neptune,,CU-1010,2019
+CU,1010,607.0,Univ Success Skills,0.46,0.27,0.14,0.05,0.05,0.0,0.0,0.03,elizabeth anne stephan,,CU-1010,2019
+CVT,2260,1.0,Intro Cardiovas Sono,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,eric walker,,CVT-2260,2019
+DPA,3070,1.0,Method 3d Production,0.44,0.4,0.08,0.0,0.0,0.0,0.0,0.08,tommy van bui,,DPA-3070,2019
+DPA,4000,1.0,Tech Foundations I,0.07,0.29,0.14,0.0,0.07,0.0,0.0,0.43,jessica baron,,DPA-4000,2019
+DPA,4020,2.0,Visual Found of Digital Prod,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,anthony summey,,DPA-4020,2019
+DPA,4830,1.0,Spec Stud Top in DPA: Dig Scul,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,insun kwon,,DPA-4830,2019
+DPA,8070,1.0,3D Modeling and Animation,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,christina sophie joerg,,DPA-8070,2019
+DPA,8090,1.0,Rendering and Shading,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,daljit singh dhillon,,DPA-8090,2019
+ECAS,1990,101.0,CI LEAD Forward I,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,steve richard sanders,,ECAS-1990,2019
+ECE,1990,13.0,CI: Future Engineers,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,melissa crawley smith,,ECE-1990,2019
+ECE,1990,14.0,CI: Robot Networks,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,yongqiang wang,,ECE-1990,2019
+ECE,2010,1.0,Logic and Computing Devices,0.23,0.28,0.24,0.08,0.08,0.0,0.0,0.08,william reid,,ECE-2010,2019
+ECE,2020,1.0,Electric Circuits I,0.2,0.35,0.27,0.08,0.04,0.0,0.0,0.06,william harrell,,ECE-2020,2019
+ECE,2070,1.0,Basic Electrical Engineering,0.21,0.22,0.26,0.12,0.07,0.0,0.0,0.12,william thomas kolodzey,,ECE-2070,2019
+ECE,2070,2.0,Basic Electrical Engineering,0.29,0.15,0.21,0.18,0.06,0.0,0.0,0.12,wesley green,,ECE-2070,2019
+ECE,2070,3.0,Basic Electrical Engineering,0.39,0.23,0.21,0.07,0.04,0.0,0.0,0.06,timothy anglea,,ECE-2070,2019
+ECE,2080,1.0,Basic Electrical Engr Lab,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,4.0,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,5.0,Basic Electrical Engr Lab,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,6.0,Basic Electrical Engr Lab,0.85,0.1,0.0,0.05,0.0,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,7.0,Basic Electrical Engr Lab,0.75,0.15,0.0,0.0,0.0,0.0,0.0,0.1,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,8.0,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,9.0,Basic Electrical Engr Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,10.0,Basic Electrical Engr Lab,0.84,0.0,0.05,0.0,0.0,0.0,0.0,0.11,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,12.0,Basic Electrical Engr Lab,0.79,0.0,0.0,0.0,0.21,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,14.0,Basic Electrical Engr Lab,0.71,0.12,0.0,0.0,0.0,0.0,0.0,0.18,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2080,15.0,Basic Electrical Engr Lab,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,apoorva deepak kapadia,,ECE-2080,2019
+ECE,2090,2.0,Logic & Computing Devices Lab,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,apoorva deepak kapadia,,ECE-2090,2019
+ECE,2090,3.0,Logic & Computing Devices Lab,0.83,0.0,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,,ECE-2090,2019
+ECE,2090,4.0,Logic & Computing Devices Lab,0.83,0.08,0.0,0.08,0.0,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2090,2019
+ECE,2090,5.0,Logic & Computing Devices Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,,ECE-2090,2019
+ECE,2090,9.0,Logic & Computing Devices Lab,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2090,2019
+ECE,2090,11.0,Logic & Computing Devices Lab,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,apoorva deepak kapadia,,ECE-2090,2019
+ECE,2090,13.0,Logic & Computing Devices Lab,0.67,0.0,0.0,0.0,0.08,0.0,0.0,0.25,apoorva deepak kapadia,,ECE-2090,2019
+ECE,2090,14.0,Logic & Computing Devices Lab,0.58,0.25,0.08,0.0,0.0,0.0,0.0,0.08,apoorva deepak kapadia,,ECE-2090,2019
+ECE,2110,1.0,Elec Engr Lab I,0.8,0.1,0.05,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2110,2019
+ECE,2110,2.0,Elec Engr Lab I,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,,ECE-2110,2019
+ECE,2110,3.0,Elec Engr Lab I,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,,ECE-2110,2019
+ECE,2110,5.0,Elec Engr Lab I,0.7,0.15,0.1,0.0,0.05,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2110,2019
+ECE,2110,6.0,Elec Engr Lab I,0.75,0.2,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,,ECE-2110,2019
+ECE,2110,8.0,Elec Engr Lab I,0.3,0.4,0.15,0.0,0.05,0.0,0.0,0.1,apoorva deepak kapadia,,ECE-2110,2019
+ECE,2110,10.0,Elec Engr Lab I,0.69,0.08,0.23,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2110,2019
+ECE,2120,1.0,Electrical Engineering Lab II,0.81,0.0,0.0,0.0,0.06,0.0,0.0,0.13,apoorva deepak kapadia,,ECE-2120,2019
+ECE,2220,1.0,Syst Prog Concept,0.18,0.18,0.16,0.05,0.05,0.0,0.0,0.37,lu yu,,ECE-2220,2019
+ECE,2230,1.0,Comp Sys Eng,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,walter ligon,,ECE-2230,2019
+ECE,2620,1.0,Electric Circuits II,0.05,0.36,0.32,0.09,0.07,0.0,0.0,0.11,liang dong,,ECE-2620,2019
+ECE,2720,1.0,Comp Organization,0.02,0.27,0.5,0.14,0.05,0.0,0.0,0.02,william reid,,ECE-2720,2019
+ECE,2730,2.0,Computer Org Lab,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2730,2019
+ECE,2730,3.0,Computer Org Lab,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-2730,2019
+ECE,3110,2.0,Electrical Engineering Lab III,0.69,0.13,0.0,0.0,0.13,0.0,0.0,0.06,apoorva deepak kapadia,,ECE-3110,2019
+ECE,3120,1.0,Electrical Engineering Lab IV,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,apoorva deepak kapadia,,ECE-3120,2019
+ECE,3170,1.0,Rand Signal Analysis,0.22,0.28,0.34,0.1,0.04,0.0,0.0,0.01,stephen hubbard,,ECE-3170,2019
+ECE,3200,1.0,Electronics I,0.29,0.2,0.23,0.13,0.12,0.0,0.0,0.03,stephen hubbard,,ECE-3200,2019
+ECE,3200,2.0,Electronics I (HON),0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,stephen hubbard,True,ECE-3200,2019
+ECE,3210,1.0,Electronics II,0.22,0.27,0.39,0.12,0.0,0.0,0.0,0.0,stephen hubbard,,ECE-3210,2019
+ECE,3220,2.0,Intro Operating Sys,0.35,0.3,0.35,0.0,0.0,0.0,0.0,0.0,mark smotherman,,ECE-3220,2019
+ECE,3270,1.0,Dig Comp Design,0.16,0.3,0.27,0.18,0.05,0.0,0.0,0.05,melissa crawley smith,,ECE-3270,2019
+ECE,3300,1.0,Signals & Systems,0.23,0.19,0.27,0.15,0.11,0.0,0.0,0.05,carl baum,,ECE-3300,2019
+ECE,3300,2.0,Signals & Systems (HON),0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True,ECE-3300,2019
+ECE,3520,1.0,Programming Systems,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,robert schalkoff,,ECE-3520,2019
+ECE,3600,1.0,Elect Power Engr,0.34,0.26,0.19,0.04,0.09,0.0,0.0,0.08,sukumar makarand brahma,,ECE-3600,2019
+ECE,3710,1.0,Microcontr Interface,0.55,0.31,0.08,0.04,0.0,0.0,0.0,0.01,william reid,,ECE-3710,2019
+ECE,3720,2.0,Micro Int Lab,0.33,0.33,0.08,0.08,0.08,0.0,0.0,0.08,apoorva deepak kapadia,,ECE-3720,2019
+ECE,3720,7.0,Micro Int Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva deepak kapadia,,ECE-3720,2019
+ECE,3800,1.0,Electromagnetics,0.23,0.11,0.23,0.2,0.11,0.0,0.0,0.11,anthony martin,,ECE-3800,2019
+ECE,3810,1.0,Field Waves & Ckts,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,hai xiao,,ECE-3810,2019
+ECE,4090,1.0,Intr to Linear Control Systems,0.76,0.19,0.03,0.01,0.0,0.0,0.0,0.01,apoorva deepak kapadia,,ECE-4090,2019
+ECE,4180,1.0,Power Syst Analysis,0.33,0.25,0.08,0.08,0.08,0.0,0.0,0.17,ramtin hadidi,,ECE-4180,2019
+ECE,4270,1.0,Communication Systems,0.22,0.28,0.33,0.09,0.04,0.0,0.0,0.04,lu yu,,ECE-4270,2019
+ECE,4310,1.0,Intro to Computer Vision,0.56,0.32,0.08,0.04,0.0,0.0,0.0,0.0,adam hoover,,ECE-4310,2019
+ECE,4420,1.0,Knowledge Engineering,0.35,0.4,0.1,0.0,0.1,0.0,0.0,0.05,robert schalkoff,,ECE-4420,2019
+ECE,4490,1.0,Comp Ntwrk Security,0.65,0.26,0.0,0.0,0.04,0.0,0.0,0.04,lu yu,,ECE-4490,2019
+ECE,4610,1.0,Fundamentals of Solar Energy,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,rajendra singh,,ECE-4610,2019
+ECE,4670,1.0,Intro to Dig Sig Pro,0.18,0.41,0.24,0.0,0.0,0.0,0.0,0.18,john gowdy,,ECE-4670,2019
+ECE,4730,1.0,Intro Parallel Sys,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,walter ligon,,ECE-4730,2019
+ECE,4950,1.0,Int Sys Design I,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,apoorva deepak kapadia,,ECE-4950,2019
+ECE,4960,1.0,Int Sys Design II,0.53,0.38,0.08,0.0,0.0,0.0,0.0,0.03,richard groff,,ECE-4960,2019
+ECE,6040,1.0,Semiconductor Devices,0.63,0.13,0.25,0.0,0.0,0.0,0.0,0.0,judson douglas ryckman,,ECE-6040,2019
+ECE,6310,1.0,Intro to Computer Vision,0.65,0.3,0.0,0.0,0.04,0.0,0.0,0.0,adam hoover,,ECE-6310,2019
+ECE,6420,1.0,Knowledge Engr,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,robert schalkoff,,ECE-6420,2019
+ECE,6490,843.0,Comp Ntwrk Security,0.67,0.0,0.0,0.0,0.33,0.0,0.0,0.0,lu yu,,ECE-6490,2019
+ECE,6590,1.0,Int Circ Design,0.43,0.29,0.0,0.0,0.0,0.0,0.0,0.29,yingjie lao,,ECE-6590,2019
+ECE,6610,843.0,Fundamentals of Solar Energy,0.2,0.6,0.0,0.0,0.0,0.0,0.0,0.2,rajendra singh,,ECE-6610,2019
+ECE,6670,1.0,Intro to Dig Sig Pro,0.2,0.4,0.2,0.0,0.0,0.0,0.0,0.2,john gowdy,,ECE-6670,2019
+ECE,6930,844.0,IntroPowerElecTechApps Charls,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,zheyu zhang,,ECE-6930,2019
+ECE,8010,1.0,Analysis of Lin Sys,0.43,0.29,0.0,0.0,0.07,0.0,0.0,0.21,richard groff,,ECE-8010,2019
+ECE,8040,1.0,Networked Dynamical Systems,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,yongqiang wang,,ECE-8040,2019
+ECE,8540,1.0,Analysis of Tracking Systems,0.61,0.36,0.0,0.0,0.04,0.0,0.0,0.0,adam hoover,,ECE-8540,2019
+ECON,2000,2.0,Economic Concepts,0.67,0.23,0.08,0.03,0.0,0.0,0.0,0.0,shubhashrita basu,,ECON-2000,2019
+ECON,2000,4.0,Economic Concepts,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,miren ivankovic,,ECON-2000,2019
+ECON,2000,5.0,Economic Concepts,0.41,0.35,0.06,0.06,0.06,0.0,0.0,0.06,shubhashrita basu,,ECON-2000,2019
+ECON,2110,1.0,Principles of Microeconomics,0.16,0.47,0.32,0.0,0.05,0.0,0.0,0.0,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,2.0,Principles of Microeconomics,0.16,0.42,0.26,0.11,0.0,0.0,0.0,0.05,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,3.0,Principles of Microeconomics,0.05,0.42,0.37,0.05,0.05,0.0,0.0,0.05,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,4.0,Principles of Microeconomics,0.11,0.26,0.53,0.0,0.05,0.0,0.0,0.05,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,5.0,Principles of Microeconomics,0.16,0.58,0.16,0.0,0.05,0.0,0.0,0.05,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,6.0,Principles of Microeconomics,0.24,0.35,0.18,0.06,0.0,0.0,0.0,0.18,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,7.0,Principles of Microeconomics,0.11,0.61,0.22,0.06,0.0,0.0,0.0,0.0,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,8.0,Principles of Microeconomics,0.11,0.42,0.21,0.16,0.0,0.0,0.0,0.11,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,9.0,Principles of Microeconomics,0.0,0.42,0.37,0.16,0.05,0.0,0.0,0.0,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,10.0,Principles of Microeconomics,0.0,0.47,0.42,0.05,0.0,0.0,0.0,0.05,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,11.0,Principles of Microeconomics,0.26,0.26,0.26,0.05,0.11,0.0,0.0,0.05,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,12.0,Principles of Microeconomics,0.11,0.39,0.28,0.11,0.0,0.0,0.0,0.11,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,13.0,Principles of Microeconomics,0.05,0.63,0.21,0.05,0.0,0.0,0.0,0.05,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,14.0,Principles of Microeconomics,0.0,0.5,0.33,0.06,0.06,0.0,0.0,0.06,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,15.0,Principles of Microeconomics,0.11,0.47,0.26,0.11,0.0,0.0,0.0,0.05,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,16.0,Principles of Microeconomics,0.11,0.53,0.37,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,17.0,Principles of Microeconomics,0.21,0.53,0.26,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,18.0,Principles of Microeconomics,0.11,0.17,0.5,0.06,0.06,0.0,0.0,0.11,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,19.0,Principles of Microeconomics,0.17,0.39,0.44,0.0,0.0,0.0,0.0,0.0,frederick andrew hanssen,,ECON-2110,2019
+ECON,2110,20.0,Principles of Microeconomics,0.37,0.3,0.24,0.06,0.01,0.0,0.0,0.01,cory simpkins,,ECON-2110,2019
+ECON,2110,21.0,Principles of Microeconomics,0.19,0.37,0.27,0.05,0.06,0.0,0.0,0.06,shirong zhao,,ECON-2110,2019
+ECON,2110,23.0,Principles of Microeconomics,0.3,0.45,0.18,0.02,0.03,0.0,0.0,0.03,elijah neilson,,ECON-2110,2019
+ECON,2110,24.0,Principles of Microeconomics,0.16,0.56,0.19,0.06,0.0,0.0,0.0,0.02,michael makowsky,,ECON-2110,2019
+ECON,2110,25.0,Principles of Microeconomics,0.38,0.4,0.2,0.03,0.0,0.0,0.0,0.0,seyedmajid hashemi,,ECON-2110,2019
+ECON,2110,26.0,Principles of Microeconomics,0.27,0.44,0.18,0.02,0.0,0.0,0.0,0.09,khundkar arefin kamal,,ECON-2110,2019
+ECON,2110,31.0,Principles of Microeconomics,0.25,0.47,0.18,0.03,0.03,0.0,0.0,0.05,shannon graham,,ECON-2110,2019
+ECON,2110,32.0,Principles of Microeconomics,0.19,0.52,0.3,0.0,0.0,0.0,0.0,0.0,haibin jiang,,ECON-2110,2019
+ECON,2110,33.0,Principles of Microeconomics,0.51,0.36,0.05,0.0,0.05,0.0,0.0,0.03,seyedmajid hashemi,,ECON-2110,2019
+ECON,2110,34.0,Principles of Microecon (HON),0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,charles thomas,True,ECON-2110,2019
+ECON,2110,35.0,Principles of Microeconomics,0.55,0.33,0.05,0.08,0.0,0.0,0.0,0.0,shilpi mukherjee,,ECON-2110,2019
+ECON,2110,36.0,Principles of Microeconomics,0.39,0.33,0.2,0.04,0.0,0.0,0.0,0.04,sarah louise wilson,,ECON-2110,2019
+ECON,2110,38.0,Principles of Microeconomics,0.31,0.48,0.17,0.0,0.0,0.0,0.0,0.05,elijah neilson,,ECON-2110,2019
+ECON,2110,40.0,Principles of Microeconomics,0.27,0.27,0.27,0.07,0.1,0.0,0.0,0.03,cory simpkins,,ECON-2110,2019
+ECON,2110,41.0,Principles of Microeconomics,0.29,0.26,0.21,0.17,0.02,0.0,0.0,0.05,devon merritt haskell gorry,,ECON-2110,2019
+ECON,2120,1.0,Principles of Macroeconomics,0.19,0.36,0.2,0.11,0.09,0.0,0.0,0.06,aspen rachel underwood,,ECON-2120,2019
+ECON,2120,2.0,Principles of Macroeconomics,0.41,0.3,0.26,0.0,0.0,0.0,0.0,0.02,kenneth whaley,,ECON-2120,2019
+ECON,2120,3.0,Principles of Macroeconomics,0.78,0.15,0.05,0.0,0.02,0.0,0.0,0.0,tyler francis,,ECON-2120,2019
+ECON,2120,4.0,Principles of Macroeconomics,0.3,0.23,0.28,0.13,0.06,0.0,0.0,0.0,aspen rachel underwood,,ECON-2120,2019
+ECON,2120,5.0,Principles of Macroeconomics,0.31,0.36,0.28,0.03,0.0,0.0,0.0,0.03,matthew lee cronin,,ECON-2120,2019
+ECON,2120,6.0,Principles of Macroeconomics,0.33,0.48,0.2,0.0,0.0,0.0,0.0,0.0,matthew lee cronin,,ECON-2120,2019
+ECON,2120,7.0,Principles of Macroeconomics,0.26,0.44,0.28,0.0,0.03,0.0,0.0,0.0,kenneth whaley,,ECON-2120,2019
+ECON,2120,8.0,Principles of Macroeconomics,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.03,jeremy choquette,,ECON-2120,2019
+ECON,2120,9.0,Principles of Macroeconomics,0.81,0.17,0.02,0.0,0.0,0.0,0.0,0.0,tyler francis,,ECON-2120,2019
+ECON,2120,10.0,Principles of Macroeconomics,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,jeremy choquette,,ECON-2120,2019
+ECON,3020,1.0,Money and Banking,0.38,0.38,0.23,0.0,0.0,0.0,0.0,0.03,adam markley witham,,ECON-3020,2019
+ECON,3060,1.0,Managerial Economics,0.16,0.32,0.22,0.19,0.08,0.0,0.0,0.03,benjamin james posmanick,,ECON-3060,2019
+ECON,3100,1.0,International Econ,0.17,0.53,0.24,0.01,0.03,0.0,0.0,0.01,scott baier,,ECON-3100,2019
+ECON,3140,1.0,Intermediate Micro,0.18,0.26,0.24,0.1,0.08,0.0,0.0,0.14,patrick warren,,ECON-3140,2019
+ECON,3140,2.0,Intermediate Micro,0.2,0.41,0.26,0.08,0.03,0.0,0.0,0.02,molly espey,,ECON-3140,2019
+ECON,3140,3.0,Intermediate Micro,0.44,0.27,0.13,0.04,0.04,0.0,0.0,0.07,yichen christy zhou,,ECON-3140,2019
+ECON,3140,5.0,Intermediate Micro,0.47,0.26,0.11,0.03,0.03,0.0,0.0,0.11,yichen christy zhou,,ECON-3140,2019
+ECON,3150,1.0,Intermediate Macro,0.07,0.23,0.39,0.14,0.11,0.0,0.0,0.07,michal maria jerzmanowski,,ECON-3150,2019
+ECON,3150,2.0,Intermediate Macro,0.21,0.26,0.38,0.12,0.0,0.0,0.0,0.03,michal maria jerzmanowski,,ECON-3150,2019
+ECON,3190,1.0,Environmental Econ,0.35,0.41,0.16,0.05,0.0,0.0,0.0,0.03,molly espey,,ECON-3190,2019
+ECON,3600,1.0,Public Choice,0.29,0.26,0.18,0.11,0.08,0.0,0.0,0.08,michael makowsky,,ECON-3600,2019
+ECON,4010,1.0,Labor Mkt Analysis,0.29,0.41,0.24,0.0,0.06,0.0,0.0,0.0,chungsang lam,,ECON-4010,2019
+ECON,4020,1.0,Law and Economics,0.21,0.45,0.21,0.07,0.02,0.0,0.0,0.02,howard nelson bodenhorn,,ECON-4020,2019
+ECON,4040,1.0,Comp Econ Systems,0.3,0.4,0.2,0.0,0.1,0.0,0.0,0.0,daria litsukova-bokar,,ECON-4040,2019
+ECON,4050,5.0,Intro to Econometric,0.18,0.29,0.35,0.14,0.03,0.0,0.0,0.0,scott barkowski,,ECON-4050,2019
+ECON,4100,1.0,Economic Development,0.53,0.32,0.05,0.05,0.0,0.0,0.0,0.05,robert tamura,,ECON-4100,2019
+ECON,4110,2.0,Econ of Education,0.75,0.18,0.0,0.0,0.04,0.0,0.0,0.04,jorge luis garcia  menendez,,ECON-4110,2019
+ECON,4120,1.0,International Micro,0.46,0.38,0.08,0.08,0.0,0.0,0.0,0.0,cheng chen,,ECON-4120,2019
+ECON,4230,1.0,Economics of Health,0.5,0.37,0.13,0.0,0.0,0.0,0.0,0.0,devon merritt haskell gorry,,ECON-4230,2019
+ECON,4240,1.0,Organization of Ind,0.53,0.24,0.18,0.06,0.0,0.0,0.0,0.0,matthew lewis,,ECON-4240,2019
+ECON,4240,2.0,Organization of Ind,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,matthew lewis,,ECON-4240,2019
+ECON,4280,1.0,Cost-Benefit Anlysis,0.53,0.26,0.21,0.0,0.0,0.0,0.0,0.0,robert kenneth fleck,,ECON-4280,2019
+ECON,4280,2.0,Cost-Benefit Anlysis,0.45,0.25,0.25,0.05,0.0,0.0,0.0,0.0,robert kenneth fleck,,ECON-4280,2019
+ECON,4980,1.0,Selected Topics in Economics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,howard nelson bodenhorn,,ECON-4980,2019
+ECON,4980,3.0,History of Economic Thought,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,,ECON-4980,2019
+ECON,4980,3.0,History of Economic Thought,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,,ECON-4980,2019
+ECON,4980,4.0,Sel Topic - Why Business?,0.34,0.52,0.14,0.0,0.0,0.0,0.0,0.0,lawrence reed watson,,ECON-4980,2019
+ECON,4980,5.0,Cryptocurrency and  Blockchain,0.37,0.42,0.16,0.0,0.0,0.0,0.0,0.05,gerald dwyer,,ECON-4980,2019
+ECON,4980,6.0,Sel Topic - Why Business?,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,,ECON-4980,2019
+ECON,4980,6.0,Sel Topic - Why Business?,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,,ECON-4980,2019
+ECON,6050,5.0,Intro to Econometric,0.36,0.27,0.36,0.0,0.0,0.0,0.0,0.0,scott barkowski,,ECON-6050,2019
+ECON,8010,1.0,Microeconomic Theory,0.22,0.33,0.33,0.0,0.0,0.0,0.0,0.11,william dougan,,ECON-8010,2019
+ECON,8040,1.0,Applied Math Econ,0.36,0.59,0.05,0.0,0.0,0.0,0.0,0.0,curtis simon,,ECON-8040,2019
+ECON,8060,1.0,Econometrics I,0.33,0.33,0.25,0.0,0.08,0.0,0.0,0.0,paul wayne wilson,,ECON-8060,2019
+ECON,8080,1.0,Econometrics III,0.33,0.33,0.17,0.0,0.17,0.0,0.0,0.0,paul wayne wilson,,ECON-8080,2019
+ECON,8230,1.0,Microecon Pub Pol,0.0,0.45,0.36,0.0,0.09,0.0,0.0,0.09,scott templeton,,ECON-8230,2019
+ECON,8260,1.0,Econ Theory of Govt Regulation,0.33,0.33,0.0,0.0,0.0,0.0,0.0,0.33,thomas winslow hazlett,,ECON-8260,2019
+ECON,9010,1.0,Price Theory,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,charles thomas,,ECON-9010,2019
+ED,1050,2.0,Orientation to Education,0.82,0.14,0.0,0.05,0.0,0.0,0.0,0.0,stacy jones,,ED-1050,2019
+ED,1050,3.0,Orientation to Education,0.92,0.04,0.0,0.04,0.0,0.0,0.0,0.0,stacy jones,,ED-1050,2019
+ED,1050,4.0,Orientation to Education,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,stacy jones,,ED-1050,2019
+ED,1050,5.0,Orientation to Education,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,hilary tanck,,ED-1050,2019
+ED,1050,6.0,Orientation to Education,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,hilary tanck,,ED-1050,2019
+ED,1970,1.0,CI-CONNECTIONS Stud Developmnt,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2019
+ED,1970,2.0,CI-CONNECTIONS Stud Developmnt,0.94,0.0,0.06,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2019
+ED,1970,3.0,CI-CONNECTIONS Stud Developmnt,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2019
+ED,1970,5.0,CI-CONNECTIONS Stud Developmnt,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2019
+ED,1970,6.0,CI-CONNECTIONS Stud Developmnt,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-1970,2019
+ED,3010,1.0,Principles of American Educat,0.87,0.0,0.0,0.0,0.04,0.0,0.0,0.09,beatrice naff bailey,,ED-3010,2019
+ED,3010,3.0,Principles of American Educat,0.89,0.06,0.0,0.0,0.06,0.0,0.0,0.0,beatrice naff bailey,,ED-3010,2019
+ED,3010,4.0,Principles of American Educat,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,nafees mohammad khan,,ED-3010,2019
+EDC,8100,400.0,Advising and Supporting,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,mary dolores katalinic,,EDC-8100,2019
+EDEC,3360,1.0,Play/Soc Dev-Infts/Young Child,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,marjorie deanna ramey,,EDEC-3360,2019
+EDEC,4400,1.0,Early Childhood Engl Lang Art,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anna henson hall,,EDEC-4400,2019
+EDEL,3100,3.0,Arts in Ele School,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kathy cochran,,EDEL-3100,2019
+EDEL,3210,2.0,Pe for the Elem Tchr,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2019
+EDEL,3210,3.0,Pe for the Elem Tchr,0.74,0.22,0.0,0.0,0.0,0.0,0.0,0.04,deborah smith,,EDEL-3210,2019
+EDEL,4510,1.0,Elem Methods in Science Tchg,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,laura cohen eicher,,EDEL-4510,2019
+EDEL,4870,1.0,Ele Meth Soc Studies,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,,EDEL-4870,2019
+EDF,3020,1.0,Educational Psychology,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,meihua qian,,EDF-3020,2019
+EDF,3340,1.0,Child Growth and Development,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,amanda elizabeth bennett,,EDF-3340,2019
+EDF,3340,3.0,Child Growth and Development,0.74,0.23,0.0,0.03,0.0,0.0,0.0,0.0,faiza marghoob jamil,,EDF-3340,2019
+EDF,3350,1.0,Adolescent Growth & Develop,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,luke rapa,,EDF-3350,2019
+EDF,4800,1.0,Digital Media & Learning,0.63,0.25,0.08,0.0,0.04,0.0,0.0,0.0,ryan visser,,EDF-4800,2019
+EDF,4800,2.0,Digital Media & Learning,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,golnaz arastoopour irgens,,EDF-4800,2019
+EDF,4800,3.0,Digital Media & Learning,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,golnaz arastoopour irgens,,EDF-4800,2019
+EDF,4800,300.0,Digital Media & Learning,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,georgia lousie mckown,,EDF-4800,2019
+EDF,4800,301.0,Digital Media & Learning,0.69,0.17,0.07,0.03,0.03,0.0,0.0,0.0,ryan visser,,EDF-4800,2019
+EDF,8710,400.0,Cultural Diversity in Educatio,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,reginald wilkerson,,EDF-8710,2019
+EDF,9270,1.0,Quant Rsrch & Stats for Ed,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,christy jenkins brown,,EDF-9270,2019
+EDF,9270,2.0,Quant Rsrch & Stats for Ed,0.76,0.16,0.04,0.0,0.0,0.0,0.0,0.04,christy jenkins brown,,EDF-9270,2019
+EDF,9780,1.0,Multivar Ed Research,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,matthew james madison,,EDF-9780,2019
+EDHD,3110,3.0,CI- Children's Lit. Newsletter,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDHD-3110,2019
+EDHD,3110,4.0,CI- Read/Review Child/YA Lit.,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDHD-3110,2019
+EDL,7050,400.0,Contemp Iss in School Leadshp,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,danielle hall,,EDL-7050,2019
+EDL,7250,501.0,Law/Ethics for School Leaders,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,betty thompson bagley,,EDL-7250,2019
+EDL,9770,2.0,Div Issues in Hi Ed,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,william mccoy,,EDL-9770,2019
+EDLT,4600,1.0,Found of Read: Assess & Instr,0.39,0.39,0.17,0.04,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDLT-4600,2019
+EDLT,4600,3.0,Found of Read: Assess & Instr,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,lisa denise aker,,EDLT-4600,2019
+EDLT,4600,4.0,Found of Read: Assess & Instr,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lisa denise aker,,EDLT-4600,2019
+EDLT,4610,1.0,Content Area Read/Writing,0.69,0.27,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-4610,2019
+EDLT,4610,2.0,Content Area Read/Writing,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-4610,2019
+EDLT,4800,301.0,Found in Adolescent Literacy,0.79,0.14,0.04,0.04,0.0,0.0,0.0,0.0,phillip michael wilder,,EDLT-4800,2019
+EDLT,4980,1.0,Cont Area Read/Write Secondary,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,arsenio frankie silva,,EDLT-4980,2019
+EDLT,8100,300.0,Foundations: Reading & Writing,0.74,0.17,0.0,0.0,0.0,0.0,0.0,0.09,emily smothers howell,,EDLT-8100,2019
+EDLT,8110,300.0,Adv Children's & Yng Adult Lit,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,susan king fullerton,,EDLT-8110,2019
+EDLT,8110,301.0,Adv Children's & Yng Adult Lit,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,jonda cecole mcnair,,EDLT-8110,2019
+EDLT,8150,300.0,Guided Reading & Guided Writng,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,pamela dunston,,EDLT-8150,2019
+EDLT,8220,500.0,Strategies for Teaching ESOL,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,mikel walker cole,,EDLT-8220,2019
+EDLT,8270,300.0,Content Area Rdg/Wtg-MS & HS,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,emily smothers howell,,EDLT-8270,2019
+EDLT,8400,502.0,Early Literacy Assessment I,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,antoinette dibellonia,,EDLT-8400,2019
+EDLT,8400,504.0,Early Literacy Assessment I,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,barbara fewell,,EDLT-8400,2019
+EDLT,8400,508.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jamie felder white,,EDLT-8400,2019
+EDLT,8400,509.0,Early Literacy Assessment I,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,susanne atkinson elvington,,EDLT-8400,2019
+EDSA,3900,1.0,Skills for Student Leaders,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDSA-3900,2019
+EDSA,3900,4.0,Skills for Student Leaders,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDSA-3900,2019
+EDSA,3900,6.0,Skills for Student Leaders,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,EDSA-3900,2019
+EDSA,3990,1.0,Creative Inq in Counselor Ed,0.76,0.19,0.0,0.0,0.0,0.0,0.0,0.05,jacob frankovich,,EDSA-3990,2019
+EDSA,8040,1.0,Theories Student Dev in Hi Ed,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,,EDSA-8040,2019
+EDSA,8040,2.0,Theories Student Dev in Hi Ed,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tony cawthon,,EDSA-8040,2019
+EDSA,8100,1.0,Advising and Supporting,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,rachel lynn wagner,,EDSA-8100,2019
+EDSC,2260,1.0,Pr Apprch to Sec Alg,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,stacy megan che,,EDSC-2260,2019
+EDSC,3270,1.0,Practicum Sec Sci,0.71,0.14,0.0,0.0,0.14,0.0,0.0,0.0,christopher david white,,EDSC-3270,2019
+EDSC,4240,1.0,Tchng Sec English,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,mary-celeste schreuder,,EDSC-4240,2019
+EDSC,4280,1.0,Tchng Secondary Social Studies,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,kristen earnise duncan,,EDSC-4280,2019
+EDSP,3700,1.0,Intro to Special Education,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,sharon walters,,EDSP-3700,2019
+EDSP,3700,2.0,Intro to Special Education,0.82,0.12,0.03,0.0,0.0,0.0,0.0,0.03,friggita johnson,,EDSP-3700,2019
+EDSP,3700,4.0,Intro to Special Education,0.93,0.03,0.0,0.0,0.0,0.0,0.0,0.03,wendell kent parker,,EDSP-3700,2019
+EDSP,3720,1.0,Char & Instr Individ with LD,0.9,0.07,0.03,0.0,0.0,0.0,0.0,0.0,catherine aurentz griffith,,EDSP-3720,2019
+EDSP,3740,1.0,Char & Strat Emot/Behav Disord,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,shanna eisner hirsch,,EDSP-3740,2019
+EDSP,3750,1.0,Early Intervention Spec Needs,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,,EDSP-3750,2019
+EDSP,4920,1.0,Math Inst Ind W/Dis,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,pamela stecker,,EDSP-4920,2019
+EDSP,4930,1.0,Clsrm/Beh Mgmt Sp Ed,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,joseph benedict ryan,,EDSP-4930,2019
+EDSP,4940,1.0,Tchg Rdg Mild Dis,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,abigail anne allen,,EDSP-4940,2019
+EDSP,8530,400.0,Legal/Pol Issu Sp Ed,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,,EDSP-8530,2019
+EES,2010,1.0,Environ Engr Fundamentals I,0.34,0.26,0.24,0.08,0.05,0.0,0.0,0.03,david freedman,,EES-2010,2019
+EES,3030,1.0,Water Treatment Systems,0.53,0.27,0.17,0.0,0.0,0.0,0.0,0.03,david allen ladner,,EES-3030,2019
+EES,3040,1.0,Wastewater Treatment Systems,0.41,0.41,0.17,0.0,0.0,0.0,0.0,0.0,sudeep popat,,EES-3040,2019
+EES,3050,1.0,Water/Wastewater Treatment Lab,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-3050,2019
+EES,3050,2.0,Water/Wastewater Treatment Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,sudeep popat,,EES-3050,2019
+EES,4010,1.0,Environmental Engr,0.52,0.35,0.11,0.0,0.0,0.0,0.0,0.02,elizabeth carraway,,EES-4010,2019
+EES,4010,2.0,Environmental Engr,0.28,0.45,0.14,0.07,0.07,0.0,0.0,0.0,mark schlautman,,EES-4010,2019
+EES,4090,1.0,Intro to Nuc Engr & Radiol Sci,0.29,0.29,0.07,0.14,0.0,0.0,0.0,0.21,timothy devol,,EES-4090,2019
+EES,4300,1.0,Air Pollution Engineering,0.3,0.33,0.27,0.07,0.0,0.0,0.0,0.03,andrew richard metcalf,,EES-4300,2019
+EES,4800,1.0,Environmental Risk Assessment,0.38,0.41,0.19,0.0,0.0,0.0,0.0,0.03,nicole elizabeth martinez,,EES-4800,2019
+EES,4840,1.0,Solid Waste Mgt,0.29,0.5,0.18,0.0,0.0,0.0,0.0,0.03,ezra lucas hoyt cates,,EES-4840,2019
+EES,4860,1.0,Environmental Sustainability,0.55,0.27,0.18,0.0,0.0,0.0,0.0,0.0,michael carbajales-dale,,EES-4860,2019
+EES,4860,2.0,Environmental Sustainability,0.5,0.33,0.0,0.0,0.08,0.0,0.0,0.08,michael carbajales-dale,,EES-4860,2019
+EES,4900,15.0,CI: From Drones to 3D Printing,0.75,0.13,0.0,0.13,0.0,0.0,0.0,0.0,blake andrew lytle,,EES-4900,2019
+EES,6860,1.0,Environmental Sustainability,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,michael carbajales-dale,,EES-6860,2019
+EES,8020,1.0,Environ Eng Prin,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-8020,2019
+EES,8430,1.0,Environmental Chem,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,brian powell,,EES-8430,2019
+EES,8510,1.0,Biol Prin Envir Engr,0.45,0.4,0.15,0.0,0.0,0.0,0.0,0.0,kevin thomas finneran,,EES-8510,2019
+ELE,3010,1.0,Entrepreneurial Foundations,0.41,0.29,0.29,0.02,0.0,0.0,0.0,0.0,ashley williams parnell,,ELE-3010,2019
+ELE,3010,2.0,Entrepreneurial Foundations,0.16,0.43,0.39,0.0,0.02,0.0,0.0,0.0,ashley williams parnell,,ELE-3010,2019
+ELE,3010,3.0,Entrepreneurial Foundations,0.38,0.54,0.05,0.0,0.03,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2019
+ELE,3010,4.0,Entrepreneurial Foundations,0.39,0.55,0.06,0.0,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2019
+ELE,3020,3.0,Entrepreneurial Resource Acqu,0.38,0.49,0.14,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,,ELE-3020,2019
+ELE,3020,4.0,Entrepreneurial Resource Acqu,0.39,0.54,0.07,0.0,0.0,0.0,0.0,0.0,karl bruce kelly,,ELE-3020,2019
+ELE,4020,1.0,Venture Creation,0.35,0.54,0.08,0.0,0.03,0.0,0.0,0.0,william frank dinardo,,ELE-4020,2019
+ELE,4030,1.0,Venture Growth,0.59,0.32,0.08,0.0,0.0,0.0,0.0,0.0,james keith hudgins,,ELE-4030,2019
+ELE,4990,2.0,Venture Counsulting,0.28,0.63,0.1,0.0,0.0,0.0,0.0,0.0,william frank dinardo,,ELE-4990,2019
+ENGL,1030,2.0,Composition and Rhetoric,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,robert andrew welborn,,ENGL-1030,2019
+ENGL,1030,3.0,Composition and Rhetoric,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,,ENGL-1030,2019
+ENGL,1030,7.0,Composition and Rhetoric,0.16,0.42,0.16,0.11,0.11,0.0,0.0,0.05,chelsea marie clarey,,ENGL-1030,2019
+ENGL,1030,10.0,Composition and Rhetoric,0.28,0.56,0.11,0.0,0.06,0.0,0.0,0.0,chelsea marie clarey,,ENGL-1030,2019
+ENGL,1030,11.0,Composition and Rhetoric,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,caitlin grace watt,,ENGL-1030,2019
+ENGL,1030,12.0,Composition and Rhetoric,0.41,0.41,0.12,0.0,0.0,0.0,0.0,0.06,tareva leselle johnson,,ENGL-1030,2019
+ENGL,1030,13.0,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,caitlin grace watt,,ENGL-1030,2019
+ENGL,1030,14.0,Composition and Rhetoric,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,tareva leselle johnson,,ENGL-1030,2019
+ENGL,1030,15.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,emma jayne stanley,,ENGL-1030,2019
+ENGL,1030,16.0,Composition and Rhetoric,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,anna lia  johnson,,ENGL-1030,2019
+ENGL,1030,18.0,Composition and Rhetoric,0.74,0.16,0.0,0.0,0.11,0.0,0.0,0.0,allen swords,,ENGL-1030,2019
+ENGL,1030,19.0,Composition and Rhetoric,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-1030,2019
+ENGL,1030,20.0,Composition and Rhetoric,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,anna lia  johnson,,ENGL-1030,2019
+ENGL,1030,21.0,Composition and Rhetoric,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,mary catherine nestor,,ENGL-1030,2019
+ENGL,1030,22.0,Composition and Rhetoric,0.53,0.26,0.11,0.05,0.05,0.0,0.0,0.0,mary catherine nestor,,ENGL-1030,2019
+ENGL,1030,23.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,lindsey henley kurz,,ENGL-1030,2019
+ENGL,1030,24.0,Composition and Rhetoric,0.63,0.16,0.0,0.0,0.21,0.0,0.0,0.0,sarah elizabeth richardson,,ENGL-1030,2019
+ENGL,1030,25.0,Composition and Rhetoric,0.42,0.47,0.0,0.0,0.11,0.0,0.0,0.0,john benjamin fuqua,,ENGL-1030,2019
+ENGL,1030,26.0,Composition and Rhetoric,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,kimberly jenerette,,ENGL-1030,2019
+ENGL,1030,27.0,Composition and Rhetoric,0.37,0.42,0.05,0.05,0.11,0.0,0.0,0.0,kimberly jenerette,,ENGL-1030,2019
+ENGL,1030,28.0,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,hannah taylor,,ENGL-1030,2019
+ENGL,1030,29.0,Composition and Rhetoric,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,hannah pittman godwin,,ENGL-1030,2019
+ENGL,1030,30.0,Composition and Rhetoric,0.42,0.42,0.11,0.0,0.05,0.0,0.0,0.0,andrew mathas,,ENGL-1030,2019
+ENGL,1030,31.0,Composition and Rhetoric,0.76,0.12,0.06,0.0,0.06,0.0,0.0,0.0,joelma soares-sambdman,,ENGL-1030,2019
+ENGL,1030,33.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,helen wesley kapp,,ENGL-1030,2019
+ENGL,1030,34.0,Composition and Rhetoric,0.39,0.44,0.06,0.0,0.11,0.0,0.0,0.0,john benjamin fuqua,,ENGL-1030,2019
+ENGL,1030,35.0,Composition and Rhetoric,0.47,0.42,0.0,0.05,0.0,0.0,0.0,0.05,hannah pittman godwin,,ENGL-1030,2019
+ENGL,1030,36.0,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,hannah taylor,,ENGL-1030,2019
+ENGL,1030,37.0,Composition and Rhetoric,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,la'cresha ulon green,,ENGL-1030,2019
+ENGL,1030,41.0,Composition and Rhetoric,0.74,0.11,0.0,0.0,0.11,0.0,0.0,0.05,cody hunter,,ENGL-1030,2019
+ENGL,1030,42.0,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,cody hunter,,ENGL-1030,2019
+ENGL,1030,43.0,Composition and Rhetoric,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,kaitlyn samons,,ENGL-1030,2019
+ENGL,1030,45.0,Composition and Rhetoric,0.89,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jacob danial richter,,ENGL-1030,2019
+ENGL,1030,46.0,Composition and Rhetoric,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,jacob danial richter,,ENGL-1030,2019
+ENGL,1030,49.0,Composition and Rhetoric,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,nicholas rader,,ENGL-1030,2019
+ENGL,1030,50.0,Composition and Rhetoric,0.47,0.47,0.0,0.05,0.0,0.0,0.0,0.0,nicholas rader,,ENGL-1030,2019
+ENGL,1030,51.0,Composition and Rhetoric,0.42,0.32,0.11,0.05,0.05,0.0,0.0,0.05,jennie elizabeth wakefield,,ENGL-1030,2019
+ENGL,1030,52.0,Composition and Rhetoric,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,jennie elizabeth wakefield,,ENGL-1030,2019
+ENGL,1030,53.0,Composition and Rhetoric,0.22,0.5,0.22,0.0,0.06,0.0,0.0,0.0,gregory luke chwala,,ENGL-1030,2019
+ENGL,1030,54.0,Composition and Rhetoric,0.57,0.36,0.0,0.0,0.07,0.0,0.0,0.0,sethunya mokoko gall,,ENGL-1030,2019
+ENGL,1030,55.0,Composition and Rhetoric,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,jennie elizabeth wakefield,,ENGL-1030,2019
+ENGL,1030,56.0,Composition and Rhetoric,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,sethunya mokoko gall,,ENGL-1030,2019
+ENGL,1030,57.0,Composition and Rhetoric,0.63,0.21,0.16,0.0,0.0,0.0,0.0,0.0,sarah watkins,,ENGL-1030,2019
+ENGL,1030,58.0,Composition and Rhetoric,0.79,0.05,0.05,0.05,0.05,0.0,0.0,0.0,kailan smith sindelar,,ENGL-1030,2019
+ENGL,1030,60.0,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kailan smith sindelar,,ENGL-1030,2019
+ENGL,1030,61.0,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,hwi eun hur,,ENGL-1030,2019
+ENGL,1030,64.0,Composition and Rhetoric,0.73,0.13,0.07,0.0,0.0,0.0,0.0,0.07,hwi eun hur,,ENGL-1030,2019
+ENGL,1030,65.0,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kelley melissa gillis,,ENGL-1030,2019
+ENGL,1030,67.0,Composition and Rhetoric,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,kelley melissa gillis,,ENGL-1030,2019
+ENGL,1030,68.0,Composition and Rhetoric,0.79,0.11,0.0,0.0,0.11,0.0,0.0,0.0,juliann teichert,,ENGL-1030,2019
+ENGL,1030,69.0,Composition and Rhetoric,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,juliann teichert,,ENGL-1030,2019
+ENGL,1030,76.0,Composition and Rhetoric,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,mary adams,,ENGL-1030,2019
+ENGL,1030,77.0,Composition and Rhetoric,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,,ENGL-1030,2019
+ENGL,1030,78.0,Composition and Rhetoric,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,,ENGL-1030,2019
+ENGL,1030,82.0,Composition and Rhetoric,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,melissa dugan,,ENGL-1030,2019
+ENGL,1030,83.0,Composition and Rhetoric,0.67,0.17,0.0,0.06,0.06,0.0,0.0,0.06,melissa dugan,,ENGL-1030,2019
+ENGL,1030,84.0,Composition and Rhetoric,0.65,0.18,0.06,0.0,0.06,0.0,0.0,0.06,bree laran beal,,ENGL-1030,2019
+ENGL,1030,85.0,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,joelma soares-sambdman,,ENGL-1030,2019
+ENGL,1030,101.0,Composition and Rhetoric (HON),0.78,0.11,0.0,0.11,0.0,0.0,0.0,0.0,chelsea jeanine murdock,True,ENGL-1030,2019
+ENGL,2120,1.0,World Literature,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,,ENGL-2120,2019
+ENGL,2120,2.0,World Literature,0.47,0.42,0.11,0.0,0.0,0.0,0.0,0.0,kenneth michael tuite,,ENGL-2120,2019
+ENGL,2120,3.0,World Literature,0.47,0.32,0.0,0.0,0.05,0.0,0.0,0.16,bree laran beal,,ENGL-2120,2019
+ENGL,2120,4.0,World Literature,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sarah elissa matalone,,ENGL-2120,2019
+ENGL,2120,5.0,World Literature,0.37,0.32,0.21,0.0,0.0,0.0,0.0,0.11,andrew mathas,,ENGL-2120,2019
+ENGL,2120,6.0,World Literature,0.32,0.47,0.11,0.0,0.05,0.0,0.0,0.05,david charles foltz,,ENGL-2120,2019
+ENGL,2120,7.0,World Literature,0.59,0.29,0.06,0.0,0.0,0.0,0.0,0.06,david charles foltz,,ENGL-2120,2019
+ENGL,2120,8.0,World Literature,0.47,0.21,0.21,0.0,0.0,0.0,0.0,0.11,david charles foltz,,ENGL-2120,2019
+ENGL,2120,9.0,World Literature,0.59,0.35,0.0,0.0,0.0,0.0,0.0,0.06,sarah elissa matalone,,ENGL-2120,2019
+ENGL,2120,10.0,World Literature,0.68,0.26,0.0,0.0,0.05,0.0,0.0,0.0,sarah elissa matalone,,ENGL-2120,2019
+ENGL,2120,11.0,World Literature,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,elizabeth anderson stansell,,ENGL-2120,2019
+ENGL,2120,12.0,World Literature,0.32,0.58,0.11,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,,ENGL-2120,2019
+ENGL,2120,13.0,World Literature,0.5,0.31,0.06,0.0,0.06,0.0,0.0,0.06,hannah pittman godwin,,ENGL-2120,2019
+ENGL,2120,14.0,World Literature,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,,ENGL-2120,2019
+ENGL,2120,16.0,World Literature,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,,ENGL-2120,2019
+ENGL,2120,17.0,World Literature,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,bree laran beal,,ENGL-2120,2019
+ENGL,2120,18.0,World Literature,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,john benjamin fuqua,,ENGL-2120,2019
+ENGL,2120,19.0,World Literature,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,rene elizabeth fleischbein,,ENGL-2120,2019
+ENGL,2120,20.0,World Literature,0.5,0.22,0.22,0.0,0.06,0.0,0.0,0.0,elizabeth anderson stansell,,ENGL-2120,2019
+ENGL,2120,21.0,World Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,,ENGL-2120,2019
+ENGL,2120,22.0,World Literature,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,,ENGL-2120,2019
+ENGL,2120,23.0,World Literature,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,lindsey henley kurz,,ENGL-2120,2019
+ENGL,2120,24.0,World Literature,0.74,0.11,0.11,0.05,0.0,0.0,0.0,0.0,ingrid anna pierce,,ENGL-2120,2019
+ENGL,2120,25.0,World Literature,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,ingrid anna pierce,,ENGL-2120,2019
+ENGL,2120,26.0,World Literature,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,bree laran beal,,ENGL-2120,2019
+ENGL,2120,27.0,World Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,hannah pittman godwin,,ENGL-2120,2019
+ENGL,2120,28.0,World Literature,0.47,0.26,0.16,0.0,0.11,0.0,0.0,0.0,andrew mathas,,ENGL-2120,2019
+ENGL,2120,29.0,World Literature,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-2120,2019
+ENGL,2120,30.0,World Literature,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,john benjamin fuqua,,ENGL-2120,2019
+ENGL,2120,400.0,World Literature,0.65,0.25,0.1,0.0,0.0,0.0,0.0,0.0,elizabeth anderson stansell,,ENGL-2120,2019
+ENGL,2120,401.0,World Literature,0.37,0.37,0.16,0.0,0.0,0.0,0.0,0.11,karen kettnich,,ENGL-2120,2019
+ENGL,2120,402.0,World Literature,0.5,0.17,0.17,0.0,0.0,0.0,0.0,0.17,karen kettnich,,ENGL-2120,2019
+ENGL,2120,403.0,World Literature,0.21,0.29,0.07,0.07,0.07,0.0,0.0,0.29,sarah elissa matalone,,ENGL-2120,2019
+ENGL,2130,2.0,British Literature,0.42,0.53,0.05,0.0,0.0,0.0,0.0,0.0,gregory luke chwala,,ENGL-2130,2019
+ENGL,2130,3.0,British Literature,0.29,0.41,0.24,0.06,0.0,0.0,0.0,0.0,gregory luke chwala,,ENGL-2130,2019
+ENGL,2130,4.0,British Literature,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,gregory luke chwala,,ENGL-2130,2019
+ENGL,2130,5.0,British Literature,0.47,0.21,0.16,0.05,0.05,0.0,0.0,0.05,henna marian messina,,ENGL-2130,2019
+ENGL,2130,7.0,British Literature,0.47,0.26,0.16,0.0,0.0,0.0,0.0,0.11,christopher benson,,ENGL-2130,2019
+ENGL,2130,8.0,British Literature,0.38,0.31,0.13,0.06,0.06,0.0,0.0,0.06,henna marian messina,,ENGL-2130,2019
+ENGL,2130,9.0,British Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-2130,2019
+ENGL,2130,11.0,British Literature,0.58,0.26,0.05,0.05,0.05,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2019
+ENGL,2130,100.0,British Literature (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,john morgenstern,True,ENGL-2130,2019
+ENGL,2130,400.0,British Literature,0.32,0.32,0.16,0.11,0.05,0.0,0.0,0.05,kristen louise aldebol-hazle,,ENGL-2130,2019
+ENGL,2130,401.0,British Literature,0.56,0.13,0.0,0.0,0.13,0.0,0.0,0.19,kristen louise aldebol-hazle,,ENGL-2130,2019
+ENGL,2140,1.0,American Literature,0.42,0.26,0.26,0.0,0.0,0.0,0.0,0.05,mary catherine nestor,,ENGL-2140,2019
+ENGL,2140,2.0,American Literature,0.47,0.37,0.11,0.05,0.0,0.0,0.0,0.0,mary catherine nestor,,ENGL-2140,2019
+ENGL,2140,3.0,American Literature,0.37,0.26,0.26,0.05,0.0,0.0,0.0,0.05,chelsea marie clarey,,ENGL-2140,2019
+ENGL,2140,4.0,American Literature,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,chelsea marie clarey,,ENGL-2140,2019
+ENGL,2140,5.0,American Literature,0.63,0.21,0.0,0.0,0.0,0.0,0.0,0.16,kathy elaine nixon,,ENGL-2140,2019
+ENGL,2140,6.0,American Literature,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,kathy elaine nixon,,ENGL-2140,2019
+ENGL,2140,7.0,American Literature,0.47,0.37,0.11,0.0,0.05,0.0,0.0,0.0,william weldon cunningham,,ENGL-2140,2019
+ENGL,2140,8.0,American Literature,0.33,0.33,0.11,0.06,0.0,0.0,0.0,0.17,william weldon cunningham,,ENGL-2140,2019
+ENGL,2140,9.0,American Literature,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2019
+ENGL,2140,10.0,American Literature,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2019
+ENGL,2140,11.0,American Literature,0.21,0.68,0.0,0.0,0.0,0.0,0.0,0.11,patricia sunia,,ENGL-2140,2019
+ENGL,2140,12.0,American Literature,0.37,0.53,0.0,0.0,0.05,0.0,0.0,0.05,patricia sunia,,ENGL-2140,2019
+ENGL,2140,400.0,American Literature,0.61,0.17,0.11,0.0,0.0,0.0,0.0,0.11,tareva leselle johnson,,ENGL-2140,2019
+ENGL,2140,401.0,American Literature,0.58,0.21,0.05,0.05,0.0,0.0,0.0,0.11,tareva leselle johnson,,ENGL-2140,2019
+ENGL,2150,1.0,Lit in 20th-21st Cent Contexts,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-2150,2019
+ENGL,2150,2.0,Lit in 20th-21st Cent Contexts,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,allen swords,,ENGL-2150,2019
+ENGL,2150,3.0,Lit in 20th-21st Cent Contexts,0.44,0.39,0.06,0.06,0.0,0.0,0.0,0.06,john logan pursley,,ENGL-2150,2019
+ENGL,2150,4.0,Lit in 20th-21st Cent Contexts,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2019
+ENGL,2150,5.0,Lit in 20th-21st Cent Contexts,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2019
+ENGL,2150,6.0,Lit in 20th-21st Cent Contexts,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2150,2019
+ENGL,2150,7.0,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2150,2019
+ENGL,2150,8.0,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2150,2019
+ENGL,2150,9.0,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-2150,2019
+ENGL,2150,10.0,Lit in 20th-21st Cent Contexts,0.44,0.33,0.17,0.06,0.0,0.0,0.0,0.0,stephanie lorraine edwards,,ENGL-2150,2019
+ENGL,2150,11.0,Lit in 20th-21st Cent Contexts,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,caitlin grace watt,,ENGL-2150,2019
+ENGL,2150,12.0,Lit in 20th-21st Cent Contexts,0.68,0.16,0.0,0.0,0.0,0.0,0.0,0.16,caitlin grace watt,,ENGL-2150,2019
+ENGL,2150,13.0,Lit in 20th-21st Cent Contexts,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,edward thomas joseph troy,,ENGL-2150,2019
+ENGL,2150,14.0,Lit in 20th-21st Cent Contexts,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,jennifer hagen forsberg,,ENGL-2150,2019
+ENGL,2150,15.0,Lit in 20th-21st Cent Contexts,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,april ayers lawson,,ENGL-2150,2019
+ENGL,2150,16.0,Lit in 20th-21st Cent Contexts,0.11,0.63,0.26,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2150,2019
+ENGL,2150,17.0,Lit in 20th-21st Cent Contexts,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,remley melissa makala,,ENGL-2150,2019
+ENGL,2150,18.0,Lit in 20th-21st Cent Contexts,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,edward thomas joseph troy,,ENGL-2150,2019
+ENGL,2150,19.0,Lit in 20th-21st Cent Contexts,0.17,0.44,0.11,0.0,0.0,0.0,0.0,0.28,amy monaghan,,ENGL-2150,2019
+ENGL,2150,20.0,Lit in 20th-21st Cent Contexts,0.26,0.37,0.26,0.05,0.05,0.0,0.0,0.0,megan noel macalystre,,ENGL-2150,2019
+ENGL,2150,21.0,Lit in 20th-21st Cent Contexts,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,megan noel macalystre,,ENGL-2150,2019
+ENGL,2150,23.0,Lit in 20th-21st Cent Contexts,0.42,0.32,0.16,0.0,0.05,0.0,0.0,0.05,edward thomas joseph troy,,ENGL-2150,2019
+ENGL,2150,24.0,Lit in 20th-21st Cent Contexts,0.68,0.11,0.16,0.05,0.0,0.0,0.0,0.0,stephanie lorraine edwards,,ENGL-2150,2019
+ENGL,2150,25.0,Lit in 20th-21st Cent Contexts,0.72,0.11,0.11,0.0,0.0,0.0,0.0,0.06,remley melissa makala,,ENGL-2150,2019
+ENGL,2150,26.0,Lit in 20th-21st Cent Contexts,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,jennifer hagen forsberg,,ENGL-2150,2019
+ENGL,2150,27.0,Lit in 20th-21st Cent Contexts,0.59,0.12,0.12,0.06,0.0,0.0,0.0,0.12,remley melissa makala,,ENGL-2150,2019
+ENGL,2150,28.0,Lit in 20th-21st Cent Contexts,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,remley melissa makala,,ENGL-2150,2019
+ENGL,2150,29.0,Lit in 20th-21st Cent Contexts,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,stephanie lorraine edwards,,ENGL-2150,2019
+ENGL,2150,30.0,Lit in 20th-21st Cent Contexts,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,stephanie lorraine edwards,,ENGL-2150,2019
+ENGL,2150,100.0,20th - 21st Century Lit (HON),0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True,ENGL-2150,2019
+ENGL,2150,400.0,Lit in 20th-21st Cent Contexts,0.06,0.53,0.29,0.06,0.0,0.0,0.0,0.06,sarah mae cooper,,ENGL-2150,2019
+ENGL,2150,401.0,Lit in 20th-21st Cent Contexts,0.06,0.71,0.06,0.06,0.0,0.0,0.0,0.12,sarah mae cooper,,ENGL-2150,2019
+ENGL,2160,1.0,African American Literature,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,,ENGL-2160,2019
+ENGL,2160,2.0,African American Literature,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allison nicole harris,,ENGL-2160,2019
+ENGL,2160,3.0,African American Literature,0.72,0.17,0.11,0.0,0.0,0.0,0.0,0.0,allison nicole harris,,ENGL-2160,2019
+ENGL,2160,4.0,African American Literature,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,allison nicole harris,,ENGL-2160,2019
+ENGL,2310,1.0,Intro to Journalism,0.59,0.24,0.12,0.06,0.0,0.0,0.0,0.0,william pulley,,ENGL-2310,2019
+ENGL,3040,1.0,Business Writing,0.68,0.16,0.11,0.05,0.0,0.0,0.0,0.0,megan lee pietruszewski,,ENGL-3040,2019
+ENGL,3040,2.0,Business Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,patricia sunia,,ENGL-3040,2019
+ENGL,3040,3.0,Business Writing,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,megan lee pietruszewski,,ENGL-3040,2019
+ENGL,3040,4.0,Business Writing,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,william weldon cunningham,,ENGL-3040,2019
+ENGL,3040,5.0,Business Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,megan lee pietruszewski,,ENGL-3040,2019
+ENGL,3040,6.0,Business Writing,0.83,0.06,0.0,0.0,0.0,0.0,0.0,0.11,la'cresha ulon green,,ENGL-3040,2019
+ENGL,3040,7.0,Business Writing,0.5,0.44,0.0,0.0,0.0,0.0,0.0,0.06,la'cresha ulon green,,ENGL-3040,2019
+ENGL,3040,8.0,Business Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william weldon cunningham,,ENGL-3040,2019
+ENGL,3040,9.0,Business Writing,0.74,0.16,0.05,0.0,0.0,0.0,0.0,0.05,jennifer hagen forsberg,,ENGL-3040,2019
+ENGL,3040,10.0,Business Writing,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,la'cresha ulon green,,ENGL-3040,2019
+ENGL,3040,11.0,Business Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3040,2019
+ENGL,3040,12.0,Business Writing,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,katalin beck,,ENGL-3040,2019
+ENGL,3040,15.0,Business Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,patricia sunia,,ENGL-3040,2019
+ENGL,3040,21.0,Business Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,jennifer hagen forsberg,,ENGL-3040,2019
+ENGL,3040,100.0,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,,ENGL-3040,2019
+ENGL,3040,400.0,Business Writing,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,kristen louise aldebol-hazle,,ENGL-3040,2019
+ENGL,3040,401.0,Business Writing,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,kristen louise aldebol-hazle,,ENGL-3040,2019
+ENGL,3040,402.0,Business Writing,0.42,0.32,0.21,0.0,0.0,0.0,0.0,0.05,katalin beck,,ENGL-3040,2019
+ENGL,3040,403.0,Business Writing,0.89,0.0,0.05,0.0,0.05,0.0,0.0,0.0,nancy paxton-wilson,,ENGL-3040,2019
+ENGL,3100,1.0,Crit Writ Lit,0.26,0.47,0.05,0.0,0.05,0.0,0.0,0.16,dominic mastroianni,,ENGL-3100,2019
+ENGL,3100,2.0,Crit Writ Lit,0.68,0.16,0.05,0.0,0.11,0.0,0.0,0.0,david sweeney coombs,,ENGL-3100,2019
+ENGL,3100,3.0,Crit Writ Lit,0.67,0.22,0.06,0.0,0.06,0.0,0.0,0.0,kimberly snyder manganelli,,ENGL-3100,2019
+ENGL,3120,1.0,Advanced Composition,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,diane mary quaglia beltran,,ENGL-3120,2019
+ENGL,3120,3.0,Advanced Composition,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,david charles foltz,,ENGL-3120,2019
+ENGL,3120,4.0,Advanced Composition,0.44,0.28,0.17,0.11,0.0,0.0,0.0,0.0,jennie elizabeth wakefield,,ENGL-3120,2019
+ENGL,3140,1.0,Technical Writing,0.53,0.32,0.11,0.0,0.0,0.0,0.0,0.05,henna marian messina,,ENGL-3140,2019
+ENGL,3140,2.0,Technical Writing,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,henna marian messina,,ENGL-3140,2019
+ENGL,3140,3.0,Technical Writing,0.89,0.0,0.11,0.0,0.0,0.0,0.0,0.0,christopher stuart,,ENGL-3140,2019
+ENGL,3140,4.0,Technical Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,christopher stuart,,ENGL-3140,2019
+ENGL,3140,5.0,Technical Writing,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,charlotte estelle lucke,,ENGL-3140,2019
+ENGL,3140,6.0,Technical Writing,0.61,0.22,0.06,0.0,0.06,0.0,0.0,0.06,charlotte estelle lucke,,ENGL-3140,2019
+ENGL,3140,7.0,Technical Writing,0.83,0.0,0.06,0.06,0.0,0.0,0.0,0.06,shauna chung,,ENGL-3140,2019
+ENGL,3140,11.0,Technical Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,ingrid anna pierce,,ENGL-3140,2019
+ENGL,3140,12.0,Technical Writing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,ingrid anna pierce,,ENGL-3140,2019
+ENGL,3140,13.0,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,heather price williams,,ENGL-3140,2019
+ENGL,3140,14.0,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,eric reid hamilton,,ENGL-3140,2019
+ENGL,3140,15.0,Technical Writing,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,heather price williams,,ENGL-3140,2019
+ENGL,3140,17.0,Technical Writing,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,michelle lloyd,,ENGL-3140,2019
+ENGL,3140,19.0,Technical Writing,0.44,0.5,0.0,0.0,0.0,0.0,0.0,0.06,michelle lloyd,,ENGL-3140,2019
+ENGL,3140,20.0,Technical Writing,0.65,0.24,0.0,0.0,0.0,0.0,0.0,0.12,kathy elaine nixon,,ENGL-3140,2019
+ENGL,3140,22.0,Technical Writing,0.67,0.11,0.06,0.0,0.0,0.0,0.0,0.17,kathy elaine nixon,,ENGL-3140,2019
+ENGL,3140,100.0,Technical Writing (HON),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,heather price williams,True,ENGL-3140,2019
+ENGL,3140,401.0,Technical Writing,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,sharon kathleen nalley,,ENGL-3140,2019
+ENGL,3140,402.0,Technical Writing,0.61,0.22,0.11,0.06,0.0,0.0,0.0,0.0,sharon kathleen nalley,,ENGL-3140,2019
+ENGL,3140,403.0,Technical Writing,0.53,0.16,0.11,0.16,0.05,0.0,0.0,0.0,heather price williams,,ENGL-3140,2019
+ENGL,3140,404.0,Technical Writing,0.5,0.39,0.11,0.0,0.0,0.0,0.0,0.0,henna marian messina,,ENGL-3140,2019
+ENGL,3140,406.0,Technical Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,amy patterson,,ENGL-3140,2019
+ENGL,3140,407.0,Technical Writing,0.7,0.1,0.05,0.0,0.1,0.0,0.0,0.05,michael russo,,ENGL-3140,2019
+ENGL,3140,408.0,Technical Writing,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,michael russo,,ENGL-3140,2019
+ENGL,3150,1.0,Scientific Writing & Comm,0.37,0.32,0.0,0.05,0.16,0.0,0.0,0.11,william pulley,,ENGL-3150,2019
+ENGL,3150,2.0,Scientific Writing & Comm,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,william pulley,,ENGL-3150,2019
+ENGL,3150,3.0,Scientific Writing & Comm,0.83,0.0,0.0,0.0,0.06,0.0,0.0,0.11,christopher benson,,ENGL-3150,2019
+ENGL,3150,6.0,Scientific Writing & Comm,0.53,0.37,0.0,0.0,0.05,0.0,0.0,0.05,william pulley,,ENGL-3150,2019
+ENGL,3150,400.0,Scientific Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2019
+ENGL,3150,402.0,Scientific Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2019
+ENGL,3150,403.0,Scientific Writing,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2019
+ENGL,3150,404.0,Scientific Writing,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,heather price williams,,ENGL-3150,2019
+ENGL,3150,405.0,Scientific Writing,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,megan lee pietruszewski,,ENGL-3150,2019
+ENGL,3450,1.0,Intr Creative Writing: Fiction,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,nicholas christiansen brown,,ENGL-3450,2019
+ENGL,3460,1.0,Intr Creative Writing: Poetry,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-3460,2019
+ENGL,3480,1.0,Intr Creat Writ: Screenwriting,0.84,0.11,0.0,0.0,0.05,0.0,0.0,0.0,april ayers lawson,,ENGL-3480,2019
+ENGL,3500,1.0,Mythology,0.32,0.32,0.11,0.0,0.11,0.0,0.0,0.16,kenneth michael tuite,,ENGL-3500,2019
+ENGL,3530,1.0,Amer Lit-Race/Ethnicity/Migrat,0.8,0.07,0.07,0.0,0.0,0.0,0.0,0.07,angela naimou,,ENGL-3530,2019
+ENGL,3540,1.0,Lit Middle East & North Africa,0.64,0.29,0.07,0.0,0.0,0.0,0.0,0.0,angela naimou,,ENGL-3540,2019
+ENGL,3570,1.0,Film,0.47,0.47,0.05,0.0,0.0,0.0,0.0,0.0,john robert smith,,ENGL-3570,2019
+ENGL,3570,2.0,Film,0.53,0.24,0.12,0.0,0.06,0.0,0.0,0.06,john robert smith,,ENGL-3570,2019
+ENGL,3570,3.0,Film,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2019
+ENGL,3570,4.0,Film,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2019
+ENGL,3850,1.0,Children's Lit,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,megan noel macalystre,,ENGL-3850,2019
+ENGL,3860,1.0,Adolescent Lit,0.42,0.47,0.0,0.0,0.0,0.0,0.0,0.11,allison nicole harris,,ENGL-3860,2019
+ENGL,3970,2.0,Brit Lit Survey II,0.26,0.47,0.16,0.05,0.0,0.0,0.0,0.05,brian mcgrath,,ENGL-3970,2019
+ENGL,3990,1.0,Amer Lit Survey II,0.41,0.41,0.12,0.0,0.06,0.0,0.0,0.0,rhondda robinson thomas,,ENGL-3990,2019
+ENGL,3990,2.0,Amer Lit Survey II,0.88,0.06,0.0,0.0,0.06,0.0,0.0,0.0,daniel scott citro,,ENGL-3990,2019
+ENGL,4000,1.0,The English Language,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,andrew lemons,,ENGL-4000,2019
+ENGL,4010,2.0,Grammar Survey,0.41,0.35,0.24,0.0,0.0,0.0,0.0,0.0,brian mcgrath,,ENGL-4010,2019
+ENGL,4110,1.0,Shakespeare,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-4110,2019
+ENGL,4110,2.0,Shakespeare,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-4110,2019
+ENGL,4140,1.0,Milton,0.79,0.05,0.16,0.0,0.0,0.0,0.0,0.0,william stockton,,ENGL-4140,2019
+ENGL,4180,1.0,Rise of the Novel in English,0.53,0.37,0.0,0.0,0.0,0.0,0.0,0.11,david sweeney coombs,,ENGL-4180,2019
+ENGL,4280,1.0,Contemporary Literature,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,walter edgar hunter,,ENGL-4280,2019
+ENGL,4340,1.0,Environmental Lit,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,matthew hooley,,ENGL-4340,2019
+ENGL,4360,1.0,Feminist Literary Criticism,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,,ENGL-4360,2019
+ENGL,4450,1.0,Fiction Workshop,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,keith morris,,ENGL-4450,2019
+ENGL,4480,1.0,Screenwriting Wkshop,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,nicholas christiansen brown,,ENGL-4480,2019
+ENGL,4500,1.0,Film Genres,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,,ENGL-4500,2019
+ENGL,4510,1.0,Film Theory and Criticism,0.4,0.47,0.0,0.07,0.07,0.0,0.0,0.0,agnieszka skrodzka,,ENGL-4510,2019
+ENGL,4520,2.0,Great Directors,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,agnieszka skrodzka,,ENGL-4520,2019
+ENGL,4540,1.0,Labor in International Cinema,0.36,0.5,0.07,0.0,0.07,0.0,0.0,0.0,edward thomas joseph troy,,ENGL-4540,2019
+ENGL,4650,1.0,Topics in Lit:Reading Violence,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,maya sylvia hislop,,ENGL-4650,2019
+ENGL,4750,1.0,Writing for Media,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,jonathan beecher field,,ENGL-4750,2019
+ENGL,4820,1.0,Afr Am Lit to 1920,0.35,0.29,0.24,0.06,0.0,0.0,0.0,0.06,rhondda robinson thomas,,ENGL-4820,2019
+ENGL,4960,2.0,SR Sem: End of Cinema,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,,ENGL-4960,2019
+ENGL,4960,3.0,SR Sem: Thinking About Love,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,dominic mastroianni,,ENGL-4960,2019
+ENGR,1020,112.0,Engineering Discipl & Skills,0.45,0.38,0.1,0.07,0.0,0.0,0.0,0.0,baker martin,,ENGR-1020,2019
+ENGR,1020,117.0,Engineering Discipl & Skills,0.54,0.33,0.1,0.0,0.0,0.0,0.0,0.03,matthew kent miller,,ENGR-1020,2019
+ENGR,1020,321.0,Engr Discipl & Skills (HON),0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,jonathan brooks harcum,True,ENGR-1020,2019
+ENGR,1020,325.0,Engr Discipl & Skills (HON),0.63,0.33,0.05,0.0,0.0,0.0,0.0,0.0,richard watkins,True,ENGR-1020,2019
+ENGR,1020,611.0,Engineering Discipl & Skills,0.51,0.34,0.13,0.0,0.0,0.0,0.0,0.02,jonathan brooks harcum,,ENGR-1020,2019
+ENGR,1020,612.0,Engineering Discipl & Skills,0.58,0.29,0.06,0.02,0.02,0.0,0.0,0.02,jonathan brooks harcum,,ENGR-1020,2019
+ENGR,1020,613.0,Engineering Discipl & Skills,0.24,0.3,0.36,0.06,0.0,0.0,0.0,0.03,andrew isaac neptune,,ENGR-1020,2019
+ENGR,1020,614.0,Engineering Discipl & Skills,0.55,0.2,0.14,0.06,0.02,0.0,0.0,0.02,steven brandon,,ENGR-1020,2019
+ENGR,1020,615.0,Engineering Discipl & Skills,0.46,0.35,0.13,0.0,0.02,0.0,0.0,0.04,steven brandon,,ENGR-1020,2019
+ENGR,1020,617.0,Engineering Discipl & Skills,0.55,0.3,0.09,0.0,0.0,0.0,0.0,0.06,taylor james sorensen,,ENGR-1020,2019
+ENGR,1020,618.0,Engineering Discipl & Skills,0.47,0.34,0.11,0.06,0.02,0.0,0.0,0.0,taylor james sorensen,,ENGR-1020,2019
+ENGR,1020,712.0,Engineering Discipl & Skills,0.53,0.33,0.08,0.05,0.03,0.0,0.0,0.0,matthew kent miller,,ENGR-1020,2019
+ENGR,1020,713.0,Engineering Discipl & Skills,0.39,0.41,0.12,0.05,0.0,0.0,0.0,0.02,matthew kent miller,,ENGR-1020,2019
+ENGR,1020,811.0,Engineering Discipl & Skills,0.47,0.39,0.08,0.0,0.02,0.0,0.0,0.04,irene marie ferrara,,ENGR-1020,2019
+ENGR,1020,812.0,Engineering Discipl & Skills,0.46,0.38,0.13,0.02,0.02,0.0,0.0,0.0,jonathan maier,,ENGR-1020,2019
+ENGR,1020,813.0,Engineering Discipl & Skills,0.45,0.37,0.12,0.04,0.0,0.0,0.0,0.02,jonathan maier,,ENGR-1020,2019
+ENGR,1020,814.0,Engineering Discipl & Skills,0.56,0.32,0.07,0.02,0.0,0.0,0.0,0.02,taylor james sorensen,,ENGR-1020,2019
+ENGR,1020,815.0,Engineering Discipl & Skills,0.45,0.47,0.05,0.0,0.03,0.0,0.0,0.0,cynthia miller smith,,ENGR-1020,2019
+ENGR,1020,816.0,Engineering Discipl & Skills,0.45,0.34,0.18,0.0,0.02,0.0,0.0,0.0,cynthia miller smith,,ENGR-1020,2019
+ENGR,1020,817.0,Engineering Discipl & Skills,0.38,0.4,0.04,0.02,0.04,0.0,0.0,0.13,andrew isaac neptune,,ENGR-1020,2019
+ENGR,1020,818.0,Engineering Discipl & Skills,0.39,0.41,0.09,0.02,0.02,0.0,0.0,0.07,andrew isaac neptune,,ENGR-1020,2019
+ENGR,1060,400.0,Engr Discipline & Skills II,0.1,0.5,0.25,0.15,0.0,0.0,0.0,0.0,irene marie ferrara,,ENGR-1060,2019
+ENGR,1410,222.0,Programming & Problem Solving,0.08,0.29,0.18,0.13,0.13,0.0,0.0,0.18,william martin,,ENGR-1410,2019
+ENGR,1410,223.0,Programming & Problem Solving,0.08,0.29,0.32,0.13,0.08,0.0,0.0,0.11,william martin,,ENGR-1410,2019
+ENGR,1410,226.0,Programming & Problem Solving,0.06,0.31,0.2,0.23,0.06,0.0,0.0,0.14,shubhamkar sanjay kulkarni,,ENGR-1410,2019
+ENGR,1410,227.0,Programming & Problem Solving,0.06,0.14,0.36,0.08,0.06,0.0,0.0,0.31,shubhamkar sanjay kulkarni,,ENGR-1410,2019
+ENGR,1510,621.0,Engineering Skills,0.29,0.37,0.26,0.05,0.03,0.0,0.0,0.0,elizabeth anne stephan,,ENGR-1510,2019
+ENGR,1510,622.0,Engineering Skills,0.21,0.32,0.34,0.05,0.08,0.0,0.0,0.0,elizabeth anne stephan,,ENGR-1510,2019
+ENGR,1900,10.0,CI in Engr I Robotics,0.9,0.0,0.0,0.0,0.03,0.0,0.0,0.06,michael benjamin wooten,,ENGR-1900,2019
+ENGR,1900,12.0,RISE CI Kinetic Sculpture,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,christopher norfolk,,ENGR-1900,2019
+ENGR,1900,193.0,Special Projects in Engr I,0.13,0.44,0.31,0.08,0.05,0.0,0.0,0.0,john minor,,ENGR-1900,2019
+ENGR,1900,194.0,Special Projects in Engr I,0.11,0.29,0.29,0.09,0.11,0.0,0.0,0.11,john minor,,ENGR-1900,2019
+ENGR,2080,683.0,Engr Graphics & Machine Design,0.37,0.34,0.13,0.03,0.0,0.0,0.0,0.13,nisha dilip gulhane,,ENGR-2080,2019
+ENGR,2080,684.0,Engr Graphics & Machine Design,0.36,0.38,0.1,0.03,0.13,0.0,0.0,0.0,apurva patel,,ENGR-2080,2019
+ENGR,2080,685.0,Engr Graphics & Machine Design,0.26,0.33,0.13,0.0,0.1,0.0,0.0,0.18,kyle walker,,ENGR-2080,2019
+ENGR,2080,686.0,Engr Graphics & Machine Design,0.31,0.31,0.13,0.08,0.08,0.0,0.0,0.1,kyle walker,,ENGR-2080,2019
+ENGR,2080,881.0,Engr Graphics & Machine Design,0.41,0.27,0.16,0.0,0.05,0.0,0.0,0.11,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,882.0,Engr Graphics & Machine Design,0.49,0.28,0.1,0.03,0.03,0.0,0.0,0.08,nighat yasmin,,ENGR-2080,2019
+ENGR,2100,804.0,CAD & Engineering Applications,0.43,0.2,0.22,0.08,0.02,0.0,0.0,0.04,nighat yasmin,,ENGR-2100,2019
+ENGR,2100,805.0,CAD & Engineering Applications,0.38,0.31,0.2,0.04,0.04,0.0,0.0,0.02,afshin famili,,ENGR-2100,2019
+ENGR,2100,806.0,CAD & Engineering Applications,0.38,0.43,0.12,0.0,0.05,0.0,0.0,0.02,afshin famili,,ENGR-2100,2019
+ENGR,2210,316.0,"Technology, Culture and Design",0.44,0.41,0.1,0.0,0.05,0.0,0.0,0.0,jonathan maier,,ENGR-2210,2019
+ENR,1010,2.0,Intro to Envir & Natur Res I,0.79,0.13,0.05,0.02,0.0,0.0,0.0,0.02,greg yarrow,,ENR-1010,2019
+ENR,1010,3.0,Intro to Envir & Natur Res I,0.74,0.14,0.06,0.05,0.0,0.0,0.0,0.02,greg yarrow,,ENR-1010,2019
+ENR,4140,1.0,Plant ID and Systematics,0.73,0.2,0.0,0.0,0.03,0.0,0.0,0.03,patrick mcmillan,,ENR-4140,2019
+ENR,4290,1.0,Environ Law & Policy,0.45,0.45,0.06,0.0,0.0,0.0,0.0,0.04,alan johnson,,ENR-4290,2019
+ENR,4290,2.0,Environ Law & Policy,0.6,0.3,0.11,0.0,0.0,0.0,0.0,0.0,alan johnson,,ENR-4290,2019
+ENSP,2000,1.0,Intro Environ Sci,0.55,0.17,0.17,0.04,0.0,0.0,0.0,0.06,scott brame,,ENSP-2000,2019
+ENSP,2000,2.0,Intro Environ Sci,0.64,0.27,0.04,0.0,0.04,0.0,0.0,0.02,minory nammouz,,ENSP-2000,2019
+ENSP,2000,3.0,Intro Environ Sci,0.66,0.32,0.0,0.0,0.0,0.0,0.0,0.02,minory nammouz,,ENSP-2000,2019
+ENSP,2000,4.0,Intro Environ Sci,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,elizabeth carraway,,ENSP-2000,2019
+ENSP,2000,5.0,Intro Environ Sci,0.24,0.58,0.09,0.04,0.0,0.0,0.0,0.04,tom owino,,ENSP-2000,2019
+ENSP,2000,6.0,Intro Environ Sci,0.79,0.1,0.1,0.0,0.0,0.0,0.0,0.0,john gregory sherwood,,ENSP-2000,2019
+ENSP,4000,1.0,Studies in Environmental Sci,0.63,0.05,0.16,0.11,0.05,0.0,0.0,0.0,margaret louise thompson,,ENSP-4000,2019
+ENT,2000,1.0,Six-Legged Science,0.45,0.33,0.18,0.03,0.0,0.0,0.0,0.03,suellen pometto,,ENT-2000,2019
+ENT,3010,1.0,Insect Biology and Diversity,0.56,0.25,0.09,0.0,0.03,0.0,0.0,0.06,carmen blubaugh,,ENT-3010,2019
+ENTR,1010,3.0,Entrepreneurial Mindset,0.73,0.19,0.02,0.02,0.02,0.0,0.0,0.02,john michael hannon,,ENTR-1010,2019
+ENTR,1090,1.0,Creative Inq-Entrepreneurship,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,john michael hannon,,ENTR-1090,2019
+ENTR,1090,20.0,Lemonade Day,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,david joseph frock,,ENTR-1090,2019
+ENTR,2010,4.0,Sports Entrepreneurship,0.88,0.09,0.03,0.0,0.0,0.0,0.0,0.0,john michael hannon,,ENTR-2010,2019
+ESED,8000,1.0,Seminar in Engr & Science Educ,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,cindy lee,,ESED-8000,2019
+ESED,8500,2.0,Spec Top Engineering & Sci Edu,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,eliza dargan gallagher,,ESED-8500,2019
+ESED,8610,2.0,Practicum in Engr & Sci Educ,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,karen ann high,,ESED-8610,2019
+ETOX,4300,1.0,Toxicology,0.4,0.4,0.0,0.1,0.1,0.0,0.0,0.0,lisa bain,,ETOX-4300,2019
+FDSC,1010,1.0,Intro to Food Sci & Hum Nutr,0.76,0.13,0.04,0.02,0.01,0.0,0.0,0.04,carol hegler,,FDSC-1010,2019
+FDSC,3010,1.0,Food Regulations,0.68,0.21,0.0,0.0,0.04,0.0,0.0,0.07,sara lane cothran,,FDSC-3010,2019
+FDSC,3060,1.0,Institutional Food Service Mgt,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,angela fraser,,FDSC-3060,2019
+FDSC,4010,1.0,Food Chemistry I,0.69,0.27,0.0,0.0,0.0,0.0,0.0,0.04,feng chen,,FDSC-4010,2019
+FDSC,4040,1.0,Food Prsv & Process,0.26,0.53,0.21,0.0,0.0,0.0,0.0,0.0,anthony louis pometto,,FDSC-4040,2019
+FDSC,4300,1.0,Dairy Process & Sant,0.5,0.19,0.19,0.06,0.0,0.0,0.0,0.06,john mcgregor,,FDSC-4300,2019
+FDSC,4500,1.0,Creative Inquiry-Food Science,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth lacey durrance,,FDSC-4500,2019
+FDSC,4500,11.0,Creative Inquiry-Food Science,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,paul dawson,,FDSC-4500,2019
+FDSC,4500,26.0,Creative Inquiry-Food Science,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sara lane cothran,,FDSC-4500,2019
+FIN,2010,401.0,Intro to Personal Finance,0.92,0.05,0.01,0.0,0.01,0.0,0.0,0.01,joshua harris,,FIN-2010,2019
+FIN,2010,402.0,Intro to Personal Finance,0.89,0.05,0.01,0.02,0.01,0.0,0.0,0.01,joshua harris,,FIN-2010,2019
+FIN,3040,1.0,Risk & Insurance,0.11,0.27,0.51,0.03,0.03,0.0,0.0,0.05,kerri mcmillan,,FIN-3040,2019
+FIN,3050,1.0,Investment Analysis,0.21,0.21,0.4,0.12,0.0,0.0,0.0,0.05,kerri mcmillan,,FIN-3050,2019
+FIN,3050,2.0,Investment Analysis,0.17,0.54,0.24,0.02,0.02,0.0,0.0,0.0,kerri mcmillan,,FIN-3050,2019
+FIN,3050,3.0,Investment Analysis,0.2,0.4,0.35,0.05,0.0,0.0,0.0,0.0,kerri mcmillan,,FIN-3050,2019
+FIN,3050,4.0,Investment Analysis,0.09,0.35,0.28,0.13,0.02,0.0,0.0,0.13,john alexander,,FIN-3050,2019
+FIN,3060,1.0,Corporation Finance,0.32,0.23,0.23,0.14,0.0,0.0,0.0,0.09,ramon tolbert franklin,,FIN-3060,2019
+FIN,3060,2.0,Corporation Finance,0.09,0.38,0.22,0.2,0.0,0.0,0.0,0.11,ramon tolbert franklin,,FIN-3060,2019
+FIN,3060,3.0,Corporation Finance,0.11,0.32,0.32,0.14,0.05,0.0,0.0,0.07,ramon tolbert franklin,,FIN-3060,2019
+FIN,3060,4.0,Corporation Finance,0.04,0.11,0.29,0.42,0.04,0.0,0.0,0.09,ramon tolbert franklin,,FIN-3060,2019
+FIN,3060,7.0,Corporation Finance,0.26,0.34,0.28,0.11,0.0,0.0,0.0,0.02,minxing sun,,FIN-3060,2019
+FIN,3060,8.0,Corporation Finance,0.29,0.4,0.21,0.04,0.04,0.0,0.0,0.02,minxing sun,,FIN-3060,2019
+FIN,3060,9.0,Corporation Finance,0.02,0.38,0.33,0.25,0.02,0.0,0.0,0.0,minxing sun,,FIN-3060,2019
+FIN,3060,403.0,Corporation Finance,0.19,0.51,0.21,0.01,0.03,0.0,0.0,0.04,jonathan godbey,,FIN-3060,2019
+FIN,3060,404.0,Corporation Finance,0.26,0.4,0.14,0.02,0.08,0.0,0.0,0.11,jonathan godbey,,FIN-3060,2019
+FIN,3070,1.0,Prin of Real Estate,0.14,0.44,0.26,0.09,0.05,0.0,0.0,0.02,thomas springer,,FIN-3070,2019
+FIN,3070,2.0,Prin of Real Estate,0.2,0.3,0.25,0.2,0.05,0.0,0.0,0.0,thomas springer,,FIN-3070,2019
+FIN,3070,5.0,Prin of Real Estate,0.3,0.27,0.24,0.06,0.09,0.0,0.0,0.03,bryan blackwood,,FIN-3070,2019
+FIN,3080,1.0,Fin Inst & Mkts,0.34,0.49,0.15,0.0,0.0,0.0,0.0,0.02,lyudmila chernykh,,FIN-3080,2019
+FIN,3080,2.0,Fin Inst & Mkts,0.1,0.58,0.28,0.05,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-3080,2019
+FIN,3080,3.0,Fin Inst & Mkts,0.33,0.48,0.17,0.02,0.0,0.0,0.0,0.0,daniel thomas greene,,FIN-3080,2019
+FIN,3080,401.0,Fin Inst & Mkts,0.31,0.35,0.31,0.0,0.02,0.0,0.0,0.0,daniel thomas greene,,FIN-3080,2019
+FIN,3110,1.0,Financial Management I,0.08,0.28,0.25,0.13,0.13,0.0,0.0,0.15,jack wolf,,FIN-3110,2019
+FIN,3110,2.0,Financial Management I,0.06,0.18,0.24,0.12,0.15,0.0,0.0,0.26,jack wolf,,FIN-3110,2019
+FIN,3110,3.0,Financial Management I,0.13,0.31,0.38,0.13,0.05,0.0,0.0,0.0,weike xu,,FIN-3110,2019
+FIN,3110,4.0,Financial Management I,0.47,0.4,0.11,0.0,0.0,0.0,0.0,0.02,joshua harris,,FIN-3110,2019
+FIN,3110,5.0,Financial Management I,0.44,0.31,0.22,0.02,0.0,0.0,0.0,0.0,joshua harris,,FIN-3110,2019
+FIN,3110,6.0,Financial Management I,0.24,0.27,0.29,0.09,0.02,0.0,0.0,0.09,joshua harris,,FIN-3110,2019
+FIN,3110,102.0,Financial Management I (HON),0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,jack wolf,True,FIN-3110,2019
+FIN,3120,1.0,Financial Management II,0.15,0.27,0.41,0.1,0.05,0.0,0.0,0.02,vincent james intintoli,,FIN-3120,2019
+FIN,3120,2.0,Financial Management II,0.16,0.33,0.31,0.09,0.07,0.0,0.0,0.04,vincent james intintoli,,FIN-3120,2019
+FIN,3120,3.0,Financial Management II,0.33,0.3,0.27,0.06,0.0,0.0,0.0,0.03,blerina zykaj,,FIN-3120,2019
+FIN,3120,4.0,Financial Management II,0.17,0.24,0.22,0.22,0.07,0.0,0.0,0.09,weike xu,,FIN-3120,2019
+FIN,3120,5.0,Financial Management II,0.1,0.44,0.32,0.12,0.02,0.0,0.0,0.0,weike xu,,FIN-3120,2019
+FIN,3120,101.0,Financial Mgt II (HON),0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,vincent james intintoli,True,FIN-3120,2019
+FIN,3120,103.0,Financial Mgt II (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,True,FIN-3120,2019
+FIN,4010,1.0,Corporate Financial Analysis,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,,FIN-4010,2019
+FIN,4020,1.0,Corporate Valuation,0.11,0.34,0.34,0.14,0.0,0.0,0.0,0.07,angela morgan,,FIN-4020,2019
+FIN,4020,101.0,Corporate Valuation (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,angela morgan,True,FIN-4020,2019
+FIN,4050,1.0,Portfolio Management & Theory,0.07,0.24,0.36,0.11,0.0,0.0,0.0,0.22,john alexander,,FIN-4050,2019
+FIN,4060,1.0,Derivatives Analysis,0.17,0.51,0.17,0.03,0.06,0.0,0.0,0.06,blerina zykaj,,FIN-4060,2019
+FIN,4110,1.0,Int Fin Mgt,0.34,0.51,0.15,0.0,0.0,0.0,0.0,0.0,luke asher devault,,FIN-4110,2019
+FIN,4110,2.0,Int Fin Mgt,0.58,0.27,0.1,0.02,0.02,0.0,0.0,0.0,luke asher devault,,FIN-4110,2019
+FIN,4980,2.0,CI in Finance: CFA,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,jack wolf,,FIN-4980,2019
+FIN,4980,4.0,CI in Finance: SIE,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,joshua harris,,FIN-4980,2019
+FIN,4980,5.0,CI in Finance: AI,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,yannan shen,,FIN-4980,2019
+FIN,4980,6.0,CI in Finance: Machine Learnin,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,yannan shen,,FIN-4980,2019
+FNR,2040,1.0,Soil Information Systems,0.85,0.1,0.0,0.02,0.0,0.0,0.0,0.03,elena mikhailova,,FNR-2040,2019
+FNR,4700,5.0,Landscape Ecology / Appalachia,0.83,0.0,0.0,0.17,0.0,0.0,0.0,0.0,russell barrett,,FNR-4700,2019
+FNR,4700,10.0,Kennedy Waterfowl & Wetlands,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,richard marvin kaminski,,FNR-4700,2019
+FNR,4700,26.0,Stream Fish Mercury Dynamics,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,troy mason farmer,,FNR-4700,2019
+FNR,4700,44.0,Alligator Ecology,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,catherine michelle jachowski,,FNR-4700,2019
+FNR,4700,129.0,GIS & SIS Applications,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher post,,FNR-4700,2019
+FNR,4990,1.0,Natural Resources Seminar,0.55,0.38,0.03,0.0,0.03,0.0,0.0,0.0,susan talley guynn,,FNR-4990,2019
+FOR,2050,1.0,Dendrology,0.17,0.42,0.08,0.04,0.13,0.0,0.0,0.17,donald hagan,,FOR-2050,2019
+FOR,2050,2.0,Dendrology,0.45,0.21,0.09,0.09,0.06,0.0,0.0,0.09,donald hagan,,FOR-2050,2019
+FOR,2050,3.0,Dendrology,0.19,0.13,0.28,0.19,0.09,0.0,0.0,0.13,donald hagan,,FOR-2050,2019
+FOR,2210,1.0,Forest Biology,0.18,0.46,0.22,0.04,0.04,0.0,0.0,0.07,jessica ann hartshorn,,FOR-2210,2019
+FOR,3020,1.0,Forest Biometrics,0.38,0.54,0.05,0.0,0.0,0.0,0.0,0.03,brian ritter,,FOR-3020,2019
+FOR,3040,1.0,Forest Resource Economics,0.67,0.23,0.05,0.05,0.0,0.0,0.0,0.0,puskar khanal,,FOR-3040,2019
+FOR,3410,1.0,Wood Procure Pract,0.61,0.3,0.06,0.03,0.0,0.0,0.0,0.0,patrick hiesl,,FOR-3410,2019
+FOR,4100,1.0,Harvesting Processes,0.54,0.35,0.12,0.0,0.0,0.0,0.0,0.0,patrick hiesl,,FOR-4100,2019
+FOR,4130,1.0,Integrated Forest Pest Mgt,0.57,0.37,0.06,0.0,0.0,0.0,0.0,0.0,jessica ann hartshorn,,FOR-4130,2019
+FOR,4150,1.0,Forest Wildlife Managment,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,,FOR-4150,2019
+FOR,4160,1.0,Forest Policy and Admin,0.41,0.32,0.24,0.02,0.0,0.0,0.0,0.0,thomas straka,,FOR-4160,2019
+FOR,4170,1.0,Forest Resource Mgt & Regulatn,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,puskar khanal,,FOR-4170,2019
+FOR,4340,1.0,GIS for Natural Resources,0.63,0.31,0.04,0.0,0.0,0.0,0.0,0.02,christopher post,,FOR-4340,2019
+FR,1010,1.0,Elementary French,0.0,0.45,0.27,0.18,0.0,0.0,0.0,0.09,anne carole salces  nedeo,,FR-1010,2019
+FR,1010,2.0,Elementary French,0.29,0.47,0.18,0.06,0.0,0.0,0.0,0.0,anne carole salces  nedeo,,FR-1010,2019
+FR,1010,3.0,Elementary French,0.38,0.19,0.13,0.06,0.13,0.0,0.0,0.13,anne carole salces  nedeo,,FR-1010,2019
+FR,1020,1.0,Elementary French,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,,FR-1020,2019
+FR,1020,2.0,Elementary French,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,,FR-1020,2019
+FR,1020,3.0,Elementary French,0.21,0.43,0.14,0.07,0.07,0.0,0.0,0.07,anne carole salces  nedeo,,FR-1020,2019
+FR,2010,1.0,Intermediate French,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,,FR-2010,2019
+FR,2010,2.0,Intermediate French,0.0,0.73,0.13,0.07,0.07,0.0,0.0,0.0,kenneth david widgren,,FR-2010,2019
+FR,2010,3.0,Intermediate French,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,pauline de tholozany,,FR-2010,2019
+FR,2020,1.0,Intermediate French,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn griffin sawyer,,FR-2020,2019
+FR,2020,2.0,Intermediate French,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,kelly digby peebles,,FR-2020,2019
+FR,2020,4.0,Intermediate French,0.2,0.47,0.2,0.13,0.0,0.0,0.0,0.0,kenneth david widgren,,FR-2020,2019
+FR,3000,1.0,Survey of French Lit,0.67,0.28,0.0,0.06,0.0,0.0,0.0,0.0,pauline de tholozany,,FR-3000,2019
+FR,3050,1.0,Int Fr Con & Comp I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kenneth david widgren,,FR-3050,2019
+FR,3050,2.0,Int Fr Con & Comp I,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,anne carole salces  nedeo,,FR-3050,2019
+FR,3070,1.0,French Civilization,0.6,0.27,0.0,0.07,0.0,0.0,0.0,0.07,eric touya,,FR-3070,2019
+FR,4120,1.0,Fr & Francoph Cinema,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,joseph mai,,FR-4120,2019
+GC,1020,1.0,Computer Art & CAD Foundations,0.47,0.35,0.07,0.02,0.08,0.0,0.0,0.01,carol jones,,GC-1020,2019
+GC,1040,1.0,Graphic Communications I,0.63,0.19,0.09,0.0,0.09,0.0,0.0,0.0,michelle suki bost fox,,GC-1040,2019
+GC,2070,1.0,Graphic Communications II,0.64,0.28,0.06,0.02,0.0,0.0,0.0,0.0,charles tabor weiss,,GC-2070,2019
+GC,3400,1.0,Digital Imaging and eMedia,0.35,0.44,0.15,0.02,0.02,0.0,0.0,0.02,erica black walker,,GC-3400,2019
+GC,3460,1.0,Ink and Substrates,0.63,0.32,0.02,0.02,0.0,0.0,0.0,0.0,shu chang,,GC-3460,2019
+GC,4060,1.0,Package and Specialty Printing,0.48,0.5,0.03,0.0,0.0,0.0,0.0,0.0,kern cox,,GC-4060,2019
+GC,4400,1.0,Commercial Printing,0.44,0.54,0.02,0.0,0.0,0.0,0.0,0.0,eric weisenmiller,,GC-4400,2019
+GC,4440,1.0,Current Dev/Trends in Gr Comm,0.42,0.48,0.09,0.0,0.0,0.0,0.0,0.0,liam henry 'hara,,GC-4440,2019
+GC,4800,1.0,Senior Seminar in GC,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,charles edward tonkin,,GC-4800,2019
+GC,4900,6.0,GC-UX & Web Design,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,erica black walker,,GC-4900,2019
+GC,4900,8.0,Strat Messaging in Social Age,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,nigel robertson,,GC-4900,2019
+GC,4900,10.0,EC: Concept & Storytelling,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,brian connaughton,,GC-4900,2019
+GC,4900,16.0,GC Visual Design & Art Direct,0.75,0.06,0.13,0.0,0.0,0.0,0.0,0.06,erica black walker,,GC-4900,2019
+GEN,1030,1.0,Careers in Bioch/Gen,0.81,0.16,0.02,0.0,0.0,0.0,0.0,0.01,joseph paul thames,,GEN-1030,2019
+GEN,3000,1.0,Fundamental Genetics,0.47,0.24,0.16,0.05,0.03,0.0,0.0,0.05,marcos tulio oliveira,,GEN-3000,2019
+GEN,3000,2.0,Fundamental Genetics,0.43,0.32,0.13,0.04,0.04,0.0,0.0,0.04,marcos tulio oliveira,,GEN-3000,2019
+GEN,3020,1.0,Molecular & General Genetics,0.26,0.41,0.23,0.05,0.02,0.0,0.0,0.04,kate leanne willingha tsai,,GEN-3020,2019
+GEN,3020,2.0,Molec & General Genetics (HON),0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,kate leanne willingha tsai,True,GEN-3020,2019
+GEN,4100,1.0,Population & Quant Genetics,0.71,0.27,0.02,0.0,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,,GEN-4100,2019
+GEN,4110,1.0,Population & Quant Gen Lab,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,,GEN-4110,2019
+GEN,4110,2.0,Population & Quant Gen Lab,0.88,0.0,0.06,0.0,0.0,0.0,0.0,0.06,kimberly kanapeckas metris,,GEN-4110,2019
+GEN,4110,4.0,Population & Quant Gen Lab,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,kimberly kanapeckas metris,,GEN-4110,2019
+GEN,4400,1.0,Bioinformatics,0.74,0.16,0.02,0.0,0.02,0.0,0.0,0.05,frank alexander feltus,,GEN-4400,2019
+GEN,4400,2.0,Bioinformatics (HON),0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,frank alexander feltus,True,GEN-4400,2019
+GEN,4500,1.0,Comparative Genetics,0.21,0.53,0.21,0.02,0.0,0.0,0.0,0.02,leigh anne clark,,GEN-4500,2019
+GEN,4500,2.0,Comparative Genetics (HON),0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,leigh anne clark,True,GEN-4500,2019
+GEN,4900,1.0,Epigenetics,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,rajandeep singh sekhon,,GEN-4900,2019
+GEN,4900,20.0,GB Prof Development,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,alison nicole starr-moss,,GEN-4900,2019
+GEN,4930,1.0,Senior Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,haiying liang,,GEN-4930,2019
+GEN,4930,2.0,Senior Seminar,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,hong luo,,GEN-4930,2019
+GEOG,1010,1.0,Intro to Geography,0.39,0.39,0.13,0.03,0.0,0.0,0.0,0.05,christa smith,,GEOG-1010,2019
+GEOG,1030,1.0,World Regional Geography,0.27,0.48,0.15,0.06,0.03,0.0,0.0,0.02,william church terry,,GEOG-1030,2019
+GEOG,1030,2.0,World Regional Geography,0.35,0.25,0.23,0.05,0.08,0.0,0.0,0.05,william church terry,,GEOG-1030,2019
+GEOL,1010,1.0,Physical Geology,0.27,0.3,0.2,0.12,0.06,0.0,0.0,0.05,alan coulson,,GEOL-1010,2019
+GEOL,1010,2.0,Physical Geology,0.32,0.31,0.21,0.08,0.05,0.0,0.0,0.03,alan coulson,,GEOL-1010,2019
+GEOL,1010,3.0,Physical Geology,0.43,0.34,0.19,0.04,0.0,0.0,0.0,0.0,mary katherine fidler,,GEOL-1010,2019
+GEOL,1010,4.0,Physical Geology,0.49,0.24,0.2,0.02,0.04,0.0,0.0,0.0,mary katherine fidler,,GEOL-1010,2019
+GEOL,1010,5.0,Physical Geology,0.56,0.21,0.17,0.02,0.02,0.0,0.0,0.02,kelly best lazar,,GEOL-1010,2019
+GEOL,1030,1.0,Physical Geol Lab,0.27,0.41,0.14,0.05,0.05,0.0,0.0,0.09,emily don scribner,,GEOL-1030,2019
+GEOL,1030,2.0,Physical Geol Lab,0.58,0.29,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2019
+GEOL,1030,3.0,Physical Geol Lab,0.42,0.42,0.08,0.0,0.04,0.0,0.0,0.04,alan coulson,,GEOL-1030,2019
+GEOL,1030,4.0,Physical Geol Lab,0.71,0.21,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2019
+GEOL,1030,5.0,Physical Geol Lab,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,6.0,Physical Geol Lab,0.54,0.33,0.0,0.04,0.0,0.0,0.0,0.08,alan coulson,,GEOL-1030,2019
+GEOL,1030,7.0,Physical Geol Lab,0.75,0.21,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,8.0,Physical Geol Lab,0.5,0.36,0.0,0.09,0.0,0.0,0.0,0.05,alan coulson,,GEOL-1030,2019
+GEOL,1030,9.0,Physical Geol Lab,0.36,0.41,0.09,0.05,0.09,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,10.0,Physical Geol Lab,0.22,0.48,0.13,0.0,0.04,0.0,0.0,0.13,emily don scribner,,GEOL-1030,2019
+GEOL,1030,11.0,Physical Geol Lab,0.67,0.17,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,,GEOL-1030,2019
+GEOL,1030,12.0,Physical Geol Lab,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,13.0,Physical Geol Lab,0.45,0.41,0.09,0.0,0.05,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,14.0,Physical Geol Lab,0.47,0.27,0.2,0.0,0.07,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,15.0,Physical Geol Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,16.0,Physical Geol Lab,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,17.0,Physical Geol Lab,0.57,0.26,0.04,0.0,0.0,0.0,0.0,0.13,alan coulson,,GEOL-1030,2019
+GEOL,1120,1.0,Earth Resources,0.36,0.4,0.18,0.04,0.02,0.0,0.0,0.0,emily don scribner,,GEOL-1120,2019
+GEOL,1140,1.0,Earth Resources Lab,0.65,0.22,0.08,0.03,0.03,0.0,0.0,0.0,emily don scribner,,GEOL-1140,2019
+GEOL,2700,1.0,Sustainable Water,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,GEOL-2700,2019
+GEOL,3000,1.0,Environmental Geology,0.18,0.36,0.32,0.05,0.05,0.0,0.0,0.05,alan coulson,,GEOL-3000,2019
+GEOL,4500,1.0,Paleoclimate Change,0.62,0.31,0.0,0.0,0.0,0.0,0.0,0.08,alexander thomas pullen,,GEOL-4500,2019
+GEOL,4910,1.0,Research Synthesis I,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-4910,2019
+GEOL,7900,501.0,Biogeography And Geology of SC,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,john robert wagner,,GEOL-7900,2019
+GER,1010,1.0,Elementary German,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,oswald harris king,,GER-1010,2019
+GER,1010,2.0,Elementary German,0.67,0.22,0.06,0.0,0.0,0.0,0.0,0.06,oswald harris king,,GER-1010,2019
+GER,1020,2.0,Elementary German,0.58,0.17,0.08,0.0,0.0,0.0,0.0,0.17, lee ferrell,,GER-1020,2019
+GER,2010,1.0,Intermediate German,0.22,0.39,0.28,0.06,0.0,0.0,0.0,0.06,johannes schmidt,,GER-2010,2019
+GER,2020,1.0,Intermediate German,0.14,0.43,0.29,0.0,0.0,0.0,0.0,0.14,gabriela stoicea,,GER-2020,2019
+GER,2600,1.0,Selected Topics in German Lit,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,gabriela stoicea,,GER-2600,2019
+GER,3050,1.0,Ger Conv & Comp,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0, lee ferrell,,GER-3050,2019
+GER,3400,1.0,German Culture,0.79,0.14,0.0,0.0,0.0,0.0,0.0,0.07,oswald harris king,,GER-3400,2019
+HCG,9050,400.0,"Genomics, Ethics & Hlth Policy",0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,linda ward,,HCG-9050,2019
+HIST,1010,1.0,History of the United States,0.56,0.39,0.0,0.0,0.03,0.0,0.0,0.03,lee brady wilson,,HIST-1010,2019
+HIST,1010,2.0,History of the United States,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,james bradford jeffries,,HIST-1010,2019
+HIST,1020,1.0,History of the United States,0.48,0.39,0.1,0.0,0.0,0.0,0.0,0.03,rebecca anna stoil,,HIST-1020,2019
+HIST,1220,1.0,"Hist, Tech & Society",0.23,0.54,0.13,0.02,0.04,0.0,0.0,0.03,pamela mack,,HIST-1220,2019
+HIST,1240,1.0,Environmental History Survey,0.14,0.42,0.28,0.06,0.03,0.0,0.0,0.08,james bradford jeffries,,HIST-1240,2019
+HIST,1240,2.0,Environmental History Survey,0.18,0.36,0.39,0.0,0.0,0.0,0.0,0.07,james bradford jeffries,,HIST-1240,2019
+HIST,1720,1.0,The West and the World I,0.43,0.34,0.17,0.0,0.01,0.0,0.0,0.04,steven marks,,HIST-1720,2019
+HIST,1720,2.0,The West and the World I,0.41,0.34,0.14,0.03,0.02,0.0,0.0,0.06,kathryn langenfeld,,HIST-1720,2019
+HIST,1720,3.0,The West and the World (HON),0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,True,HIST-1720,2019
+HIST,1720,4.0,The West and the World I,0.37,0.53,0.0,0.0,0.0,0.0,0.0,0.11,thomas kuehn,,HIST-1720,2019
+HIST,1730,1.0,The West and the World II,0.52,0.27,0.12,0.02,0.04,0.0,0.0,0.04, alan grubb,,HIST-1730,2019
+HIST,2990,1.0,Historian's Craft,0.33,0.53,0.07,0.0,0.0,0.0,0.0,0.07,elizabeth donnelly carney,,HIST-2990,2019
+HIST,2990,3.0,Historian's Craft,0.68,0.21,0.0,0.0,0.11,0.0,0.0,0.0,michael silvestri,,HIST-2990,2019
+HIST,3040,1.0,Indus & Progr Era,0.5,0.22,0.17,0.06,0.0,0.0,0.0,0.06, roger grant,,HIST-3040,2019
+HIST,3060,1.0,US: Postwar World 1945-1975,0.68,0.24,0.0,0.0,0.0,0.0,0.0,0.08,rebecca anna stoil,,HIST-3060,2019
+HIST,3240,1.0,Hist of the South II,0.31,0.45,0.03,0.0,0.17,0.0,0.0,0.03,john andrew,,HIST-3240,2019
+HIST,3280,1.0,US Legal History to 1890,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,lee brady wilson,,HIST-3280,2019
+HIST,3330,1.0,Hist of Mod Japan,0.24,0.38,0.31,0.03,0.03,0.0,0.0,0.0,edwin moise,,HIST-3330,2019
+HIST,3370,1.0,History South Africa,0.48,0.28,0.17,0.03,0.03,0.0,0.0,0.0,james burns,,HIST-3370,2019
+HIST,3540,1.0,Greek World,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathryn langenfeld,,HIST-3540,2019
+HIST,3670,1.0,Modern Ireland,0.53,0.27,0.07,0.07,0.0,0.0,0.0,0.07,michael silvestri,,HIST-3670,2019
+HIST,3700,1.0,Medieval History,0.46,0.23,0.08,0.04,0.15,0.0,0.0,0.04,caroline dunn clark,,HIST-3700,2019
+HIST,3720,1.0,Renaissance,0.47,0.35,0.06,0.0,0.06,0.0,0.0,0.06,thomas kuehn,,HIST-3720,2019
+HIST,3940,1.0,Non-Western History,0.18,0.35,0.18,0.0,0.06,0.0,0.0,0.24,stephanie hassell,,HIST-3940,2019
+HIST,3970,1.0,Modern Middle East,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,,HIST-3970,2019
+HIST,4000,1.0,Disney Parks,0.56,0.34,0.09,0.0,0.0,0.0,0.0,0.0,stephanie barczewski,,HIST-4000,2019
+HIST,4000,2.0,Amer Comparative Frontiers,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08, roger grant,,HIST-4000,2019
+HIST,4140,1.0,Study of Hist Museum,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua casmir catalano,,HIST-4140,2019
+HIST,4710,1.0,The Great War,0.77,0.0,0.0,0.0,0.0,0.0,0.0,0.23, alan grubb,,HIST-4710,2019
+HIST,4900,2.0,Global History of Slavery,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,stephanie hassell,,HIST-4900,2019
+HIST,4900,3.0,Global Impact of Russian Rev,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,steven marks,,HIST-4900,2019
+HIST,4920,1.0,US - Iraq War,0.13,0.33,0.33,0.0,0.07,0.0,0.0,0.13,edwin moise,,HIST-4920,2019
+HIST,4930,2.0,Slavery On Film,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,abel bartley,,HIST-4930,2019
+HIST,4940,1.0,MiddleEasternSocieties in Film,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,,HIST-4940,2019
+HLTH,2020,1.0,Introduction to Public Health,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2019
+HLTH,2020,2.0,Introduction to Public Health,0.67,0.31,0.02,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2019
+HLTH,2020,3.0,Introduction to Public Health,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-2020,2019
+HLTH,2020,4.0,Introduction to Public Health,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2020,2019
+HLTH,2020,5.0,Introduction to Public Health,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2020,2019
+HLTH,2020,400.0,Introduction to Public Health,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2019
+HLTH,2020,402.0,Introduction to Public Health,0.48,0.48,0.0,0.05,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2019
+HLTH,2030,1.0,Health Care Sys,0.56,0.4,0.04,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2019
+HLTH,2030,2.0,Health Care Sys,0.52,0.36,0.12,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2019
+HLTH,2030,400.0,Health Care Sys,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2019
+HLTH,2400,1.0,Deter of Hlth Behav,0.5,0.38,0.08,0.04,0.0,0.0,0.0,0.0,amelia beasley clinkscales,,HLTH-2400,2019
+HLTH,2400,2.0,Deter of Hlth Behav,0.6,0.28,0.08,0.0,0.0,0.0,0.0,0.04,amelia beasley clinkscales,,HLTH-2400,2019
+HLTH,2400,4.0,Deter of Hlth Behav,0.85,0.12,0.0,0.0,0.04,0.0,0.0,0.0,karyn jones,,HLTH-2400,2019
+HLTH,2600,1.0,Medical Terminology & Comm,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,,HLTH-2600,2019
+HLTH,2600,3.0,Medical Terminology & Comm,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,karen edwards,,HLTH-2600,2019
+HLTH,2980,1.0,Human Health and Disease,0.41,0.51,0.08,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2019
+HLTH,2980,2.0,Human Health and Disease,0.63,0.29,0.06,0.03,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2980,2019
+HLTH,3030,1.0,Public Health Comm,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,debra mitchell charles,,HLTH-3030,2019
+HLTH,3400,1.0,Hlth Prom Prog Plan,0.59,0.31,0.07,0.0,0.0,0.0,0.0,0.03,johnny long,,HLTH-3400,2019
+HLTH,3610,1.0,Int Health Care Econ,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,khoa dang truong,,HLTH-3610,2019
+HLTH,3800,1.0,Epidemiology,0.51,0.4,0.06,0.0,0.0,0.0,0.0,0.03,hugh donald spitler,,HLTH-3800,2019
+HLTH,3800,2.0,Epidemiology,0.54,0.43,0.03,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-3800,2019
+HLTH,3800,3.0,Epidemiology,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,lu zhang,,HLTH-3800,2019
+HLTH,3800,400.0,Epidemiology,0.35,0.53,0.12,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-3800,2019
+HLTH,3980,1.0,Health Appraisal Skills,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2019
+HLTH,3980,2.0,Health Appraisal Skills,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2019
+HLTH,4190,1.0,Health Sci Internship Prep Sem,0.51,0.39,0.07,0.02,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4190,2019
+HLTH,4200,1.0,Hlth Science Intern,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2019
+HLTH,4400,1.0,Manag Hlth Serv Org,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,kathleen buford cartmell,,HLTH-4400,2019
+HLTH,4750,1.0,Hlthcr Oper Mgmt Res,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,lu shi,,HLTH-4750,2019
+HLTH,4900,2.0,Res Eval St Pub Hlth,0.32,0.48,0.16,0.0,0.04,0.0,0.0,0.0,karen kemper,,HLTH-4900,2019
+HLTH,4900,3.0,Res Eval St Pub Hlth,0.44,0.48,0.04,0.0,0.0,0.0,0.0,0.04,jeffrey kingree,,HLTH-4900,2019
+HLTH,8120,400.0,Clinical and Translational Sci,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,ronald gimbel,,HLTH-8120,2019
+HLTH,8900,2.0,GIS in Public Health,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,patricia carbajales-dale,,HLTH-8900,2019
+HON,1920,1.0,Positively Human,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,june pilcher,True,HON-1920,2019
+HON,1920,2.0,NSP First-Year Seminar,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,sarah evelyn winslow,True,HON-1920,2019
+HON,2020,1.0,Who Decides What's Cool?,0.84,0.11,0.0,0.0,0.0,0.0,0.0,0.05,amanda cooper fine,True,HON-2020,2019
+HON,2020,2.0,World of Ideas,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True,HON-2020,2019
+HON,2020,3.0,Communism and the Berlin Wall,0.81,0.06,0.13,0.0,0.0,0.0,0.0,0.0,michael meng,True,HON-2020,2019
+HON,2020,4.0,Sexual Health of CU students,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,bruce michael king,True,HON-2020,2019
+HON,2060,4.0,Why We Eat What We Eat,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,elizabeth lacey durrance,True,HON-2060,2019
+HON,2210,3.0,The Cultural Work of Comics,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True,HON-2210,2019
+HORT,1010,1.0,Horticulture,0.91,0.06,0.03,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-1010,2019
+HORT,2020,1.0,Adobe Digital Design,0.75,0.13,0.03,0.03,0.0,0.0,0.0,0.06,janice ann lay,,HORT-2020,2019
+HORT,2120,1.0,Turfgrass Culture,0.77,0.16,0.03,0.0,0.03,0.0,0.0,0.0,haibo liu,,HORT-2120,2019
+HORT,3030,1.0,Landscape Plants,0.02,0.36,0.29,0.16,0.09,0.0,0.0,0.09,robert polomski,,HORT-3030,2019
+HORT,3080,1.0,Sust Landsc Des Install Maint,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-3080,2019
+HORT,4400,1.0,Hydroponics,0.22,0.39,0.28,0.11,0.0,0.0,0.0,0.0,james emerson faust,,HORT-4400,2019
+HP,8090,400.0,Historical Research Methods,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,katherine saunders pemberton,,HP-8090,2019
+HRD,8300,400.0,Concepts of H R D,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,angela danielle carter,,HRD-8300,2019
+HRD,8300,401.0,Concepts of H R D,0.73,0.19,0.04,0.0,0.0,0.0,0.0,0.04,angela danielle carter,,HRD-8300,2019
+HRD,8450,400.0,Needs Assess Ed/Ind,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,angela danielle carter,,HRD-8450,2019
+HRD,8600,400.0,Instruc Mat Devel,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kristin kelly frady,,HRD-8600,2019
+IE,2100,1.0,Des Analysis Wrk Sys,0.35,0.48,0.13,0.01,0.01,0.0,0.0,0.01,jeffery messer,,IE-2100,2019
+IE,3010,1.0,Systems Design I,0.45,0.48,0.06,0.0,0.01,0.0,0.0,0.0,shraddhaa narasimha,,IE-3010,2019
+IE,3600,1.0,Industrial Apps of Prob/Stat I,0.25,0.3,0.32,0.11,0.03,0.0,0.0,0.0,mary elizabeth kurz,,IE-3600,2019
+IE,3610,1.0,Industrial App of Prob/Stat II,0.24,0.32,0.22,0.12,0.05,0.0,0.0,0.05,brian melloy,,IE-3610,2019
+IE,3800,1.0,Deterministic Operations Rsrch,0.35,0.35,0.13,0.06,0.07,0.0,0.0,0.04,yongjia song,,IE-3800,2019
+IE,3810,1.0,Probabilistic Operations Rsrch,0.52,0.34,0.1,0.02,0.0,0.0,0.0,0.02,caglar caglayan,,IE-3810,2019
+IE,3840,1.0,Engr Econ Analysis,0.63,0.26,0.09,0.02,0.0,0.0,0.0,0.01,walter lawrence garvin,,IE-3840,2019
+IE,3860,1.0,Production Planning & Control,0.45,0.4,0.1,0.04,0.0,0.0,0.0,0.0,mariah soibhan magagnotti,,IE-3860,2019
+IE,4300,1.0,Human Fact Engr in Healthcare,0.8,0.17,0.0,0.0,0.0,0.0,0.0,0.03,david neyens,,IE-4300,2019
+IE,4400,1.0,Decision Support Sys,0.34,0.52,0.06,0.0,0.05,0.0,0.0,0.03,scott jennings mason,,IE-4400,2019
+IE,4560,1.0,Supply Chain Design & Control,0.14,0.5,0.27,0.0,0.05,0.0,0.0,0.05,william ferrell,,IE-4560,2019
+IE,4610,1.0,Quality Engineering,0.35,0.54,0.07,0.02,0.02,0.0,0.0,0.0,mariah soibhan magagnotti,,IE-4610,2019
+IE,4610,2.0,Quality Engineering,0.45,0.24,0.21,0.03,0.03,0.0,0.0,0.03,di liu,,IE-4610,2019
+IE,4620,1.0,Six Sigma Quality,0.35,0.49,0.11,0.04,0.0,0.0,0.0,0.01,walter lawrence garvin,,IE-4620,2019
+IE,4650,1.0,Facilities Planning & Design,0.4,0.38,0.18,0.03,0.01,0.0,0.0,0.0,william ferrell,,IE-4650,2019
+IE,4670,1.0,System Design II,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,jeffery messer,,IE-4670,2019
+IE,4820,1.0,Systems Modeling,0.06,0.59,0.25,0.03,0.03,0.0,0.0,0.03,kevin taaffe,,IE-4820,2019
+IE,4820,2.0,Systems Modeling,0.44,0.41,0.1,0.05,0.0,0.0,0.0,0.0,kevin taaffe,,IE-4820,2019
+IE,4880,1.0,Human Factors Eng,0.94,0.04,0.02,0.0,0.0,0.0,0.0,0.0,jamiahus durnad walton,,IE-4880,2019
+IE,4880,2.0,Human Factors Eng,0.7,0.2,0.08,0.0,0.0,0.0,0.0,0.02,amro nofan khasawneh,,IE-4880,2019
+IE,6560,1.0,Supply Chain Design & Control,0.57,0.32,0.11,0.0,0.0,0.0,0.0,0.0,william ferrell,,IE-6560,2019
+IE,6820,1.0,Systems Modeling,0.57,0.29,0.0,0.0,0.0,0.0,0.0,0.14,kevin taaffe,,IE-6820,2019
+IE,8000,1.0,Human Factors Eng,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,david neyens,,IE-8000,2019
+IE,8020,1.0,Human Comp Sys,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,kapil chalil madathil,,IE-8020,2019
+IE,8030,1.0,Engr Optimization and Apps,0.27,0.33,0.33,0.0,0.07,0.0,0.0,0.0,scott jennings mason,,IE-8030,2019
+IE,8090,1.0,Model Sys Under Risk,0.83,0.06,0.11,0.0,0.0,0.0,0.0,0.0,yongjia song,,IE-8090,2019
+IE,8530,1.0,Foundations of Quality,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,robert james riggs,,IE-8530,2019
+IE,8550,1.0,SC & Logistics Modeling II,0.88,0.09,0.0,0.0,0.03,0.0,0.0,0.0,kevin taaffe,,IE-8550,2019
+INT,1510,1.0,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,lisa marie robinson,,INT-1510,2019
+INT,1540,1.0,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,0.89,0.0,0.11,caren kelley-hall,,INT-1540,2019
+ITAL,1010,1.0,Elementary Italian,0.36,0.36,0.09,0.0,0.0,0.0,0.0,0.18,julia schmidt,,ITAL-1010,2019
+ITAL,1010,2.0,Elementary Italian,0.42,0.26,0.21,0.0,0.05,0.0,0.0,0.05,julia schmidt,,ITAL-1010,2019
+ITAL,1010,3.0,Elementary Italian,0.46,0.31,0.08,0.08,0.0,0.0,0.0,0.08,julia schmidt,,ITAL-1010,2019
+ITAL,1020,1.0,Elementary Italian,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,julia schmidt,,ITAL-1020,2019
+ITAL,2010,1.0,Intermediate Italian,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,,ITAL-2010,2019
+ITAL,2010,2.0,Intermediate Italian,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,roberto risso,,ITAL-2010,2019
+ITAL,2020,1.0,Intermediate Italian,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,,ITAL-2020,2019
+JAPN,1010,1.0,Elementary Japanese,0.53,0.12,0.12,0.0,0.12,0.0,0.0,0.12,satomi saito,,JAPN-1010,2019
+JAPN,1010,2.0,Elementary Japanese,0.44,0.25,0.19,0.0,0.13,0.0,0.0,0.0,satomi saito,,JAPN-1010,2019
+JAPN,1010,3.0,Elementary Japanese,0.33,0.17,0.25,0.0,0.17,0.0,0.0,0.08,satomi saito,,JAPN-1010,2019
+JAPN,1020,1.0,Elementary Japanese,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,satomi saito,,JAPN-1020,2019
+JAPN,2010,3.0,Intermed Japanese,0.42,0.31,0.04,0.12,0.04,0.0,0.0,0.08,jae allegra dibello takeuchi,,JAPN-2010,2019
+JAPN,4060,1.0,Intro to Japanese Literature,0.73,0.18,0.0,0.09,0.0,0.0,0.0,0.0,kumiko saito,,JAPN-4060,2019
+JAPN,4990,1.0,Sel Topics in Japanese Culture,0.79,0.07,0.07,0.07,0.0,0.0,0.0,0.0,kumiko saito,,JAPN-4990,2019
+JUST,2880,1.0,The Criminal Justice System,0.38,0.27,0.21,0.02,0.1,0.0,0.0,0.01,margaret tina britz,,JUST-2880,2019
+JUST,2890,1.0,Criminology,0.51,0.36,0.11,0.0,0.02,0.0,0.0,0.0,bryan lee miller,,JUST-2890,2019
+JUST,4290,1.0,Justice Administration,0.44,0.33,0.06,0.06,0.0,0.0,0.0,0.11,rhys hester,,JUST-4290,2019
+JUST,4680,1.0,Criminal Evidence,0.43,0.22,0.26,0.04,0.04,0.0,0.0,0.02,margaret tina britz,,JUST-4680,2019
+JUST,4860,1.0,CI in CJ: Gangsterism in Film,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,margaret tina britz,,JUST-4860,2019
+JUST,4910,1.0,Policing,0.81,0.1,0.04,0.0,0.02,0.0,0.0,0.04,shelagh dorn,,JUST-4910,2019
+JUST,4920,1.0,Justice Leadership Practicum,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,margaret tina britz,,JUST-4920,2019
+JUST,4930,1.0,Corrections,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,bryan lee miller,,JUST-4930,2019
+JUST,4990,1.0,Race and Crime,0.69,0.08,0.15,0.0,0.0,0.0,0.0,0.08,brian chad starks,,JUST-4990,2019
+JUST,4990,2.0,Intro to Forensic Science,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,tiffany brianne hezel edwards,,JUST-4990,2019
+JUST,4990,3.0,Homeland Security/Intelligence,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,shelagh dorn,,JUST-4990,2019
+LAIB,1270,1.0,Intro to Lang & Int'l Business,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06, lee ferrell,,LAIB-1270,2019
+LARC,1150,1.0,Intro Landscape Architecture,0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,jueminsi wu,,LARC-1150,2019
+LARC,1280,1.0,Technical Graphics,0.48,0.38,0.05,0.05,0.0,0.0,0.0,0.05,matthew neal powers,,LARC-1280,2019
+LARC,1510,1.0,Basic Design I,0.48,0.38,0.05,0.05,0.0,0.0,0.0,0.05,matthew neal powers,,LARC-1510,2019
+LARC,2510,1.0,Larch Design Fund,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hala fouad nassar,,LARC-2510,2019
+LARC,2620,1.0,Design Implementation I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,robert hewitt,,LARC-2620,2019
+LARC,3510,1.0,Regional Design,0.67,0.17,0.06,0.0,0.11,0.0,0.0,0.0,lara margaret mutel browning,,LARC-3510,2019
+LARC,4530,1.0,Key Issues in Landscape Arch,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,,LARC-4530,2019
+LARC,4620,1.0,Design Implementation III,0.26,0.37,0.16,0.11,0.0,0.0,0.0,0.11,paul russell,,LARC-4620,2019
+LARC,4970,1.0,Plants in the Landscape,0.52,0.3,0.09,0.0,0.09,0.0,0.0,0.0,lara margaret mutel browning,,LARC-4970,2019
+LAW,3220,1.0,Legal Env of Bus,0.15,0.46,0.3,0.04,0.02,0.0,0.0,0.02,kenneth scott toussaint,,LAW-3220,2019
+LAW,3220,2.0,Legal Env of Bus,0.24,0.3,0.37,0.09,0.0,0.0,0.0,0.0,kenneth scott toussaint,,LAW-3220,2019
+LAW,3220,3.0,Legal Env of Bus,0.3,0.52,0.15,0.0,0.02,0.0,0.0,0.0,kathryn kisska-schulze,,LAW-3220,2019
+LAW,3220,4.0,Legal Env of Bus,0.36,0.51,0.13,0.0,0.0,0.0,0.0,0.0,kathryn kisska-schulze,,LAW-3220,2019
+LAW,3220,5.0,Legal Env of Bus,0.53,0.38,0.09,0.0,0.0,0.0,0.0,0.0,christopher michael edwards,,LAW-3220,2019
+LAW,3220,6.0,Legal Env of Bus,0.43,0.43,0.15,0.0,0.0,0.0,0.0,0.0,kathryn kisska-schulze,,LAW-3220,2019
+LAW,3220,7.0,Legal Env of Bus,0.64,0.26,0.06,0.0,0.0,0.0,0.0,0.04,christopher michael edwards,,LAW-3220,2019
+LAW,3220,8.0,Legal Env of Bus,0.33,0.48,0.17,0.0,0.0,0.0,0.0,0.02,edward ray claggett,,LAW-3220,2019
+LAW,3220,9.0,Legal Env of Bus,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2019
+LAW,3220,10.0,Legal Env of Bus,0.23,0.49,0.26,0.02,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2019
+LAW,3220,11.0,Legal Env of Bus,0.26,0.48,0.17,0.04,0.0,0.0,0.0,0.04,john hine,,LAW-3220,2019
+LAW,3220,400.0,Legal Env of Bus,0.34,0.34,0.15,0.11,0.02,0.0,0.0,0.03,virginia ls ward-vaughn,,LAW-3220,2019
+LAW,3220,401.0,Legal Env of Bus,0.24,0.39,0.2,0.07,0.03,0.0,0.0,0.07,virginia ls ward-vaughn,,LAW-3220,2019
+LAW,3220,402.0,Legal Env of Bus,0.33,0.45,0.1,0.03,0.0,0.0,0.0,0.09,virginia ls ward-vaughn,,LAW-3220,2019
+LAW,3220,403.0,Legal Env of Bus,0.26,0.48,0.18,0.05,0.02,0.0,0.0,0.02,virginia ls ward-vaughn,,LAW-3220,2019
+LAW,3220,404.0,Legal Env of Bus,0.31,0.46,0.17,0.06,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2019
+LAW,3330,1.0,Real Estate Law,0.05,0.36,0.23,0.27,0.09,0.0,0.0,0.0,kenneth scott toussaint,,LAW-3330,2019
+LAW,3330,2.0,Real Estate Law,0.18,0.36,0.3,0.03,0.06,0.0,0.0,0.06,kenneth scott toussaint,,LAW-3330,2019
+LAW,4050,1.0,Construction Law,0.58,0.27,0.09,0.0,0.0,0.0,0.0,0.06,frances edwards,,LAW-4050,2019
+LS,1000,2.0,Therapeutic Yoga,0.59,0.32,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dilipkumar amin,,LS-1000,2019
+LS,1000,3.0,Therapeutic Yoga,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-1000,2019
+LS,1000,4.0,Introduction to Barre,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-1000,2019
+LS,1000,5.0,Introduction to Barre,0.79,0.11,0.11,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-1000,2019
+LS,1000,8.0,Intro to Volleyball,0.75,0.06,0.0,0.0,0.0,0.0,0.0,0.19,kelly lynn ator,,LS-1000,2019
+LS,1000,10.0,FItness Leadership,0.58,0.08,0.08,0.0,0.0,0.0,0.0,0.25,jenny lynn rodgers,,LS-1000,2019
+LS,1000,14.0,Introduction to Barre,0.73,0.13,0.13,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-1000,2019
+LS,1000,30.0,Stand up Pabbleboarding,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,merry hannah armstrong,,LS-1000,2019
+LS,1410,1.0,Top Rope Climbing,0.73,0.07,0.0,0.07,0.13,0.0,0.0,0.0,thomas caldwell,,LS-1410,2019
+LS,1410,3.0,Top Rope Climbing,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,thomas caldwell,,LS-1410,2019
+LS,1560,4.0,Riflery,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,hubert cox,,LS-1560,2019
+LS,1560,10.0,Riflery,0.7,0.0,0.0,0.0,0.1,0.0,0.0,0.2,douglas bonham stephens,,LS-1560,2019
+LS,1560,13.0,Riflery,0.67,0.08,0.0,0.0,0.0,0.0,0.0,0.25,herbert wayne strickland,,LS-1560,2019
+LS,1650,3.0,Inland Kayak Touring,0.82,0.0,0.09,0.0,0.09,0.0,0.0,0.0,merry hannah armstrong,,LS-1650,2019
+LS,1850,1.0,Bowling,0.8,0.07,0.07,0.0,0.07,0.0,0.0,0.0,madison neely workman,,LS-1850,2019
+LS,1850,2.0,Bowling,0.85,0.07,0.04,0.0,0.0,0.0,0.0,0.04,madison neely workman,,LS-1850,2019
+LS,1850,3.0,Bowling,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.04,madison neely workman,,LS-1850,2019
+LS,1850,7.0,Bowling,0.87,0.04,0.0,0.0,0.04,0.0,0.0,0.04,madison neely workman,,LS-1850,2019
+LS,1850,8.0,Bowling,0.92,0.0,0.04,0.0,0.0,0.0,0.0,0.04,megan elizabeth cato,,LS-1850,2019
+LS,1850,9.0,Bowling,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,angela rowan,,LS-1850,2019
+LS,1850,10.0,Bowling,0.9,0.0,0.0,0.0,0.03,0.0,0.0,0.07,angela rowan,,LS-1850,2019
+LS,1980,3.0,Golf,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,wesley scott womble,,LS-1980,2019
+LS,1980,7.0,Golf,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,wesley scott womble,,LS-1980,2019
+LS,2270,1.0,Intro to Swing Dance,0.88,0.0,0.04,0.0,0.0,0.0,0.0,0.08,paul hoke,,LS-2270,2019
+LS,2270,2.0,Intro to Swing Dance,0.94,0.0,0.03,0.0,0.0,0.0,0.0,0.03,paul hoke,,LS-2270,2019
+LS,2270,3.0,Intro to Swing Dance,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,paul hoke,,LS-2270,2019
+LS,2320,1.0,Core Training,0.6,0.1,0.1,0.0,0.1,0.0,0.0,0.1,diane moreno,,LS-2320,2019
+LS,2320,2.0,Core Training,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,diane moreno,,LS-2320,2019
+LS,2320,3.0,Core Training,0.5,0.23,0.14,0.0,0.0,0.0,0.0,0.14,diane moreno,,LS-2320,2019
+LS,2350,1.0,Basic Yoga,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2350,2019
+LS,2380,2.0,Vinyasa Flow Yoga,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,nicole elizabeth martinez,,LS-2380,2019
+LS,2420,1.0,Meditation and Relax,0.83,0.04,0.0,0.04,0.04,0.0,0.0,0.04,renee warren gahan,,LS-2420,2019
+LS,2420,2.0,Meditation and Relax,0.91,0.04,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2420,2019
+LS,2420,3.0,Meditation and Relax,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dilipkumar amin,,LS-2420,2019
+LS,2420,4.0,Meditation and Relax,0.86,0.0,0.0,0.0,0.05,0.0,0.0,0.09,ranjanbala dilipkumar amin,,LS-2420,2019
+LS,2420,5.0,Meditation and Relax,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,ranjanbala dilipkumar amin,,LS-2420,2019
+LS,2420,6.0,Meditation and Relax,0.87,0.04,0.0,0.0,0.0,0.0,0.0,0.09,ranjanbala dilipkumar amin,,LS-2420,2019
+LS,2420,7.0,Meditation and Relax,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,cara jill wrenn,,LS-2420,2019
+LS,2450,1.0,Pilates,0.87,0.0,0.0,0.0,0.07,0.0,0.0,0.07,melanie ivey job,,LS-2450,2019
+LS,2450,4.0,Pilates,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,diane moreno,,LS-2450,2019
+LS,2450,6.0,Pilates,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,melanie ivey job,,LS-2450,2019
+LS,2510,2.0,Running & Jogging,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,corey douglas brookover,,LS-2510,2019
+LS,2700,1.0,Sports Officiating,0.64,0.0,0.09,0.0,0.0,0.0,0.0,0.27,christopher warren cox,,LS-2700,2019
+LS,2750,3.0,First Aid/Cpr,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,christopher michael loomis,,LS-2750,2019
+LS,2750,7.0,First Aid/Cpr,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,christopher michael loomis,,LS-2750,2019
+LS,2750,8.0,First Aid/Cpr,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,christopher michael loomis,,LS-2750,2019
+LS,3560,2.0,Riflery II,0.8,0.1,0.0,0.0,0.0,0.0,0.0,0.1,hubert cox,,LS-3560,2019
+MATH,1010,1.0,Essen Math for Informed Soc,0.53,0.18,0.18,0.06,0.0,0.0,0.0,0.06,alexander joyce,,MATH-1010,2019
+MATH,1010,3.0,Essen Math for Informed Soc,0.45,0.36,0.1,0.07,0.0,0.0,0.0,0.02,judith elaine cottingham,,MATH-1010,2019
+MATH,1010,4.0,Essen Math for Informed Soc,0.42,0.21,0.21,0.16,0.0,0.0,0.0,0.0,philip de castro,,MATH-1010,2019
+MATH,1010,6.0,Essen Math for Informed Soc,0.3,0.38,0.11,0.11,0.05,0.0,0.0,0.05,judith elaine cottingham,,MATH-1010,2019
+MATH,1010,7.0,Essen Math for Informed Soc,0.38,0.5,0.08,0.03,0.0,0.0,0.0,0.03,judith elaine cottingham,,MATH-1010,2019
+MATH,1010,8.0,Essen Math for Informed Soc,0.14,0.5,0.07,0.21,0.0,0.0,0.0,0.07,philip de castro,,MATH-1010,2019
+MATH,1010,9.0,Essen Math for Informed Soc,0.56,0.28,0.06,0.0,0.06,0.0,0.0,0.06,alexander joyce,,MATH-1010,2019
+MATH,1020,1.0,Business Calculus I,0.28,0.28,0.28,0.11,0.0,0.0,0.0,0.06,andrew bellucco,,MATH-1020,2019
+MATH,1020,2.0,Business Calculus I,0.33,0.22,0.22,0.0,0.11,0.0,0.0,0.11,andrew bellucco,,MATH-1020,2019
+MATH,1020,3.0,Business Calculus I,0.37,0.21,0.26,0.11,0.0,0.0,0.0,0.05,tilly grace erwin,,MATH-1020,2019
+MATH,1020,4.0,Business Calculus I,0.56,0.19,0.06,0.13,0.0,0.0,0.0,0.06,tilly grace erwin,,MATH-1020,2019
+MATH,1020,5.0,Business Calculus I,0.27,0.4,0.13,0.13,0.07,0.0,0.0,0.0,eva murphy,,MATH-1020,2019
+MATH,1020,6.0,Business Calculus I,0.22,0.56,0.11,0.06,0.06,0.0,0.0,0.0,eva murphy,,MATH-1020,2019
+MATH,1020,7.0,Business Calculus I,0.17,0.22,0.28,0.22,0.0,0.0,0.0,0.11,michael glen eldredge,,MATH-1020,2019
+MATH,1020,8.0,Business Calculus I,0.35,0.12,0.18,0.18,0.12,0.0,0.0,0.06,michael glen eldredge,,MATH-1020,2019
+MATH,1020,9.0,Business Calculus I,0.39,0.22,0.06,0.06,0.17,0.0,0.0,0.11,tyler sullivan,,MATH-1020,2019
+MATH,1020,10.0,Business Calculus I,0.39,0.17,0.06,0.17,0.06,0.0,0.0,0.17,tyler sullivan,,MATH-1020,2019
+MATH,1020,11.0,Business Calculus I,0.28,0.33,0.17,0.0,0.06,0.0,0.0,0.17,david luke frost,,MATH-1020,2019
+MATH,1020,12.0,Business Calculus I,0.11,0.28,0.17,0.11,0.11,0.0,0.0,0.22,david luke frost,,MATH-1020,2019
+MATH,1020,13.0,Business Calculus I,0.21,0.26,0.47,0.0,0.0,0.0,0.0,0.05,yunan wang,,MATH-1020,2019
+MATH,1020,14.0,Business Calculus I,0.37,0.37,0.21,0.0,0.0,0.0,0.0,0.05,yunan wang,,MATH-1020,2019
+MATH,1020,15.0,Business Calculus I,0.14,0.43,0.36,0.07,0.0,0.0,0.0,0.0,daozhou zhu,,MATH-1020,2019
+MATH,1020,16.0,Business Calculus I,0.17,0.42,0.17,0.17,0.08,0.0,0.0,0.0,daozhou zhu,,MATH-1020,2019
+MATH,1020,17.0,Business Calculus I,0.08,0.35,0.2,0.13,0.15,0.0,0.0,0.1,neil calkin,,MATH-1020,2019
+MATH,1020,19.0,Business Calculus I,0.17,0.28,0.39,0.11,0.0,0.0,0.0,0.06,dominique evelyn forbes,,MATH-1020,2019
+MATH,1020,20.0,Business Calculus I,0.26,0.21,0.32,0.11,0.11,0.0,0.0,0.0,dominique evelyn forbes,,MATH-1020,2019
+MATH,1020,21.0,Business Calculus I,0.47,0.12,0.24,0.12,0.06,0.0,0.0,0.0,michael thomas cowen,,MATH-1020,2019
+MATH,1020,22.0,Business Calculus I,0.39,0.33,0.11,0.11,0.0,0.0,0.0,0.06,michael thomas cowen,,MATH-1020,2019
+MATH,1020,23.0,Business Calculus I,0.16,0.26,0.21,0.21,0.0,0.0,0.0,0.16,antonio pierrottet,,MATH-1020,2019
+MATH,1020,24.0,Business Calculus I,0.33,0.28,0.28,0.11,0.0,0.0,0.0,0.0,antonio pierrottet,,MATH-1020,2019
+MATH,1020,25.0,Business Calculus I,0.33,0.28,0.22,0.06,0.06,0.0,0.0,0.06,hossein faridian,,MATH-1020,2019
+MATH,1020,26.0,Business Calculus I,0.13,0.5,0.19,0.0,0.06,0.0,0.0,0.13,hossein faridian,,MATH-1020,2019
+MATH,1020,27.0,Business Calculus I,0.17,0.5,0.11,0.17,0.0,0.0,0.0,0.06,shanshan jia,,MATH-1020,2019
+MATH,1020,28.0,Business Calculus I,0.33,0.28,0.22,0.06,0.06,0.0,0.0,0.06,morgan elston,,MATH-1020,2019
+MATH,1020,29.0,Business Calculus I,0.25,0.31,0.13,0.06,0.19,0.0,0.0,0.06,morgan elston,,MATH-1020,2019
+MATH,1020,30.0,Business Calculus I,0.28,0.44,0.11,0.0,0.06,0.0,0.0,0.11,michael byrd,,MATH-1020,2019
+MATH,1020,31.0,Business Calculus I,0.22,0.5,0.22,0.0,0.0,0.0,0.0,0.06,michael byrd,,MATH-1020,2019
+MATH,1020,32.0,Business Calculus I,0.22,0.22,0.17,0.0,0.22,0.0,0.0,0.17,michael nelson,,MATH-1020,2019
+MATH,1020,33.0,Business Calculus I,0.24,0.24,0.41,0.0,0.06,0.0,0.0,0.06,michael nelson,,MATH-1020,2019
+MATH,1020,34.0,Business Calculus I,0.17,0.39,0.17,0.17,0.06,0.0,0.0,0.06,hemanta kunwar,,MATH-1020,2019
+MATH,1020,35.0,Business Calculus I,0.41,0.29,0.18,0.0,0.0,0.0,0.0,0.12,hemanta kunwar,,MATH-1020,2019
+MATH,1020,36.0,Business Calculus I,0.25,0.31,0.25,0.13,0.0,0.0,0.0,0.06,trinity white,,MATH-1020,2019
+MATH,1020,37.0,Business Calculus I,0.17,0.39,0.28,0.11,0.06,0.0,0.0,0.0,trinity white,,MATH-1020,2019
+MATH,1020,38.0,Business Calculus I,0.39,0.11,0.22,0.0,0.11,0.0,0.0,0.17,shanshan jia,,MATH-1020,2019
+MATH,1020,39.0,Business Calculus I,0.16,0.32,0.26,0.11,0.05,0.0,0.0,0.11,joseph swanson,,MATH-1020,2019
+MATH,1020,40.0,Business Calculus I,0.32,0.47,0.11,0.11,0.0,0.0,0.0,0.0,joseph swanson,,MATH-1020,2019
+MATH,1020,41.0,Business Calculus I,0.33,0.33,0.17,0.17,0.0,0.0,0.0,0.0,elliott degbe,,MATH-1020,2019
+MATH,1020,42.0,Business Calculus I,0.33,0.28,0.17,0.17,0.06,0.0,0.0,0.0,elliott degbe,,MATH-1020,2019
+MATH,1020,43.0,Business Calculus I,0.49,0.07,0.29,0.1,0.02,0.0,0.0,0.02,randy davidson,,MATH-1020,2019
+MATH,1020,44.0,Business Calculus I,0.26,0.36,0.18,0.15,0.05,0.0,0.0,0.0,randy davidson,,MATH-1020,2019
+MATH,1020,201.0,Business Calculus I,0.67,0.2,0.07,0.03,0.0,0.0,0.0,0.03,jennifer van dyken,,MATH-1020,2019
+MATH,1020,202.0,Business Calculus I,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,marion hanna,,MATH-1020,2019
+MATH,1040,1.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,donna simms,,MATH-1040,2019
+MATH,1040,3.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,anna caroline bachstein,,MATH-1040,2019
+MATH,1040,4.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.86,0.0,0.14,aaron moose,,MATH-1040,2019
+MATH,1040,5.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,todd anthony morra,,MATH-1040,2019
+MATH,1040,6.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,ryann rose cartor,,MATH-1040,2019
+MATH,1040,9.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.93,0.0,0.07,zachary david espe,,MATH-1040,2019
+MATH,1040,10.0,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.92,0.0,0.08,tony william long,,MATH-1040,2019
+MATH,1050,402.0,Precalculus,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.12,tony thanh nguyen,,MATH-1050,2019
+MATH,1050,403.0,Precalculus,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,tony thanh nguyen,,MATH-1050,2019
+MATH,1060,1.0,Calculus of One Variable I,0.31,0.24,0.19,0.05,0.12,0.0,0.0,0.1,catherine mary kenyon,,MATH-1060,2019
+MATH,1060,2.0,Calculus of One Variable I,0.35,0.33,0.14,0.02,0.07,0.0,0.0,0.09,james edward gossell,,MATH-1060,2019
+MATH,1060,3.0,Calculus of One Variable I,0.29,0.37,0.12,0.07,0.07,0.0,0.0,0.07,marvin clayton jones,,MATH-1060,2019
+MATH,1060,4.0,Calculus of One Variable I,0.29,0.37,0.08,0.0,0.18,0.0,0.0,0.08,sofya alekseeva,,MATH-1060,2019
+MATH,1060,5.0,Calculus of One Variable I,0.14,0.31,0.34,0.06,0.09,0.0,0.0,0.06,sofya alekseeva,,MATH-1060,2019
+MATH,1060,7.0,Calculus of One Variable I,0.32,0.29,0.2,0.0,0.12,0.0,0.0,0.07,scott scruggs,,MATH-1060,2019
+MATH,1060,8.0,Calculus of One Variable I,0.14,0.25,0.19,0.08,0.13,0.0,0.0,0.2,chad robert mangum,,MATH-1060,2019
+MATH,1060,10.0,Calculus of One Variable I,0.14,0.26,0.3,0.04,0.12,0.0,0.0,0.15,chad robert mangum,,MATH-1060,2019
+MATH,1060,12.0,Calculus of One Variable I,0.38,0.35,0.09,0.0,0.09,0.0,0.0,0.09,jason alexander kurz,,MATH-1060,2019
+MATH,1060,13.0,Calculus of One Variable I,0.26,0.36,0.15,0.05,0.13,0.0,0.0,0.05,nathan fontes,,MATH-1060,2019
+MATH,1060,14.0,Calculus of One Variable I,0.27,0.3,0.1,0.0,0.17,0.0,0.0,0.17,akshay sunil gupte,,MATH-1060,2019
+MATH,1060,201.0,Calculus of One Variable I,0.34,0.27,0.22,0.05,0.1,0.0,0.0,0.02,stephen peele,,MATH-1060,2019
+MATH,1060,202.0,Calculus of One Variable I,0.41,0.19,0.28,0.0,0.09,0.0,0.0,0.03,hugh geller,,MATH-1060,2019
+MATH,1060,203.0,Calculus of One Variable I,0.25,0.29,0.29,0.08,0.04,0.0,0.0,0.04,sofya alekseeva,,MATH-1060,2019
+MATH,1060,204.0,Calculus of One Variable I,0.44,0.29,0.13,0.04,0.09,0.0,0.0,0.0,stephen peele,,MATH-1060,2019
+MATH,1060,206.0,Calculus of One Variable I,0.45,0.28,0.18,0.05,0.0,0.0,0.0,0.05,peter westerbaan,,MATH-1060,2019
+MATH,1060,300.0,Calculus of One Variable I,0.29,0.29,0.24,0.0,0.1,0.0,0.0,0.1,matthew macauley,,MATH-1060,2019
+MATH,1070,1.0,Differen and Integral Calculus,0.0,0.15,0.6,0.1,0.1,0.0,0.0,0.05,donna simms,,MATH-1070,2019
+MATH,1080,1.0,Calculus of One Variable II,0.25,0.22,0.19,0.06,0.16,0.0,0.0,0.12,meredith nicole burr,,MATH-1080,2019
+MATH,1080,2.0,Calculus of One Variable II,0.23,0.23,0.18,0.1,0.21,0.0,0.0,0.05,blake anthony splitter,,MATH-1080,2019
+MATH,1080,3.0,Calculus of One Variable II,0.3,0.24,0.22,0.0,0.19,0.0,0.0,0.05,fei xue,,MATH-1080,2019
+MATH,1080,4.0,Calculus of One Variable II,0.15,0.26,0.11,0.07,0.19,0.0,0.0,0.22,terri johnson,,MATH-1080,2019
+MATH,1080,5.0,Calculus of One Variable II,0.14,0.11,0.31,0.11,0.22,0.0,0.0,0.11,terri johnson,,MATH-1080,2019
+MATH,1080,6.0,Calculus of One Variable II,0.15,0.28,0.23,0.03,0.25,0.0,0.0,0.08,fei xue,,MATH-1080,2019
+MATH,1080,7.0,Calculus of One Variable II,0.2,0.16,0.2,0.04,0.24,0.0,0.0,0.16,terri johnson,,MATH-1080,2019
+MATH,1080,201.0,Calculus of One Variable II,0.33,0.44,0.11,0.0,0.11,0.0,0.0,0.0,mark cawood,,MATH-1080,2019
+MATH,1150,1.0,Contemp Math for Elem Teach I,0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,angel carreras jusino,,MATH-1150,2019
+MATH,1150,2.0,Contemp Math for Elem Teach I,0.82,0.14,0.04,0.0,0.0,0.0,0.0,0.0,eliza dargan gallagher,,MATH-1150,2019
+MATH,1150,3.0,Contemp Math for Elem Teach I,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,angel carreras jusino,,MATH-1150,2019
+MATH,2060,1.0,Calculus of Several Variables,0.23,0.32,0.28,0.1,0.05,0.0,0.0,0.02,irina viktorova,,MATH-2060,2019
+MATH,2060,2.0,Calculus of Several Variables,0.12,0.38,0.31,0.05,0.09,0.0,0.0,0.05,irina viktorova,,MATH-2060,2019
+MATH,2060,3.0,Calculus of Several Variables,0.32,0.34,0.15,0.1,0.03,0.0,0.0,0.06,oleg yordanov,,MATH-2060,2019
+MATH,2060,4.0,Calculus of Several Variables,0.34,0.39,0.17,0.02,0.02,0.0,0.0,0.05,oleg yordanov,,MATH-2060,2019
+MATH,2060,5.0,Calculus of Several Variables,0.25,0.29,0.27,0.08,0.08,0.0,0.0,0.03,timothy charles teitloff,,MATH-2060,2019
+MATH,2060,6.0,Calculus of Several Variables,0.25,0.41,0.23,0.05,0.04,0.0,0.0,0.02,timothy charles teitloff,,MATH-2060,2019
+MATH,2060,7.0,Calculus of Several Variables,0.51,0.44,0.04,0.0,0.0,0.0,0.0,0.0,nantsoina ramiharimanana,,MATH-2060,2019
+MATH,2060,8.0,Calculus of Several Variables,0.27,0.25,0.14,0.14,0.05,0.0,0.0,0.16,timothy franklin parrott,,MATH-2060,2019
+MATH,2060,9.0,Calculus of Several Variables,0.18,0.3,0.13,0.05,0.2,0.0,0.0,0.15,timothy franklin parrott,,MATH-2060,2019
+MATH,2060,10.0,Calculus of Several Variables,0.38,0.3,0.15,0.06,0.11,0.0,0.0,0.0,allen anderson guest,,MATH-2060,2019
+MATH,2060,100.0,Calc of Several Vars (HON),0.8,0.16,0.02,0.0,0.02,0.0,0.0,0.0,yuyuan ouyang,True,MATH-2060,2019
+MATH,2060,201.0,Calculus of Several Variables,0.38,0.33,0.23,0.0,0.0,0.0,0.0,0.08,allen anderson guest,,MATH-2060,2019
+MATH,2060,202.0,Calculus of Several Variables,0.47,0.3,0.07,0.1,0.07,0.0,0.0,0.0,allen anderson guest,,MATH-2060,2019
+MATH,2070,1.0,Business Calculus II,0.29,0.24,0.18,0.18,0.0,0.0,0.0,0.12,nathaniel nemire,,MATH-2070,2019
+MATH,2070,2.0,Business Calculus II,0.37,0.11,0.21,0.11,0.16,0.0,0.0,0.05,nathaniel nemire,,MATH-2070,2019
+MATH,2070,3.0,Business Calculus II,0.22,0.22,0.11,0.22,0.11,0.0,0.0,0.11,ebenezer eduafo,,MATH-2070,2019
+MATH,2070,4.0,Business Calculus II,0.11,0.0,0.39,0.33,0.11,0.0,0.0,0.06,ebenezer eduafo,,MATH-2070,2019
+MATH,2070,5.0,Business Calculus II,0.05,0.32,0.26,0.26,0.05,0.0,0.0,0.05,haodong li,,MATH-2070,2019
+MATH,2070,6.0,Business Calculus II,0.19,0.06,0.19,0.13,0.06,0.0,0.0,0.38,haodong li,,MATH-2070,2019
+MATH,2070,7.0,Business Calculus II,0.48,0.27,0.16,0.05,0.0,0.0,0.0,0.05,jennifer marie hanna,,MATH-2070,2019
+MATH,2070,8.0,Business Calculus II,0.36,0.41,0.09,0.05,0.0,0.0,0.0,0.09,jennifer marie hanna,,MATH-2070,2019
+MATH,2070,9.0,Business Calculus II,0.55,0.25,0.07,0.05,0.02,0.0,0.0,0.07,jennifer marie hanna,,MATH-2070,2019
+MATH,2070,10.0,Business Calculus II,0.47,0.09,0.24,0.16,0.02,0.0,0.0,0.02,jennifer marie hanna,,MATH-2070,2019
+MATH,2070,11.0,Business Calculus II,0.33,0.32,0.15,0.09,0.03,0.0,0.0,0.07,jennifer ray newton,,MATH-2070,2019
+MATH,2070,12.0,Business Calculus II,0.29,0.25,0.31,0.09,0.03,0.0,0.0,0.03,jennifer ray newton,,MATH-2070,2019
+MATH,2070,13.0,Business Calculus II,0.35,0.18,0.29,0.06,0.06,0.0,0.0,0.06,travis alvarez,,MATH-2070,2019
+MATH,2070,14.0,Business Calculus II,0.26,0.21,0.26,0.16,0.0,0.0,0.0,0.11,travis alvarez,,MATH-2070,2019
+MATH,2080,1.0,Intro to Ordin Diff Equations,0.16,0.28,0.28,0.05,0.08,0.0,0.0,0.14,jeong rock yoon,,MATH-2080,2019
+MATH,2080,2.0,Intro to Ordin Diff Equations,0.1,0.2,0.3,0.17,0.13,0.0,0.0,0.1,julie lassiter,,MATH-2080,2019
+MATH,2080,3.0,Intro to Ordin Diff Equations,0.19,0.27,0.22,0.16,0.05,0.0,0.0,0.11,julie lassiter,,MATH-2080,2019
+MATH,2080,4.0,Intro to Ordin Diff Equations,0.5,0.38,0.08,0.0,0.03,0.0,0.0,0.03,nantsoina ramiharimanana,,MATH-2080,2019
+MATH,2080,5.0,Intro to Ordin Diff Equations,0.26,0.34,0.09,0.11,0.14,0.0,0.0,0.06,timothy franklin parrott,,MATH-2080,2019
+MATH,2160,1.0,Geometry for Elem Sch Teachers,0.89,0.05,0.0,0.03,0.03,0.0,0.0,0.0,nicole alaine bannister sinwell,,MATH-2160,2019
+MATH,2160,2.0,Geometry for Elem Sch Teachers,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,nicole alaine bannister sinwell,,MATH-2160,2019
+MATH,3020,2.0,Stat for Science & Engineering,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,qiong zhang,,MATH-3020,2019
+MATH,3020,3.0,Stat for Science & Engineering,0.67,0.25,0.06,0.0,0.03,0.0,0.0,0.0,xiaoqian sun,,MATH-3020,2019
+MATH,3020,4.0,Stat for Science & Engineering,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,kayla doris javier,,MATH-3020,2019
+MATH,3020,5.0,Stat for Science & Engineering,0.58,0.26,0.11,0.05,0.0,0.0,0.0,0.0,kayla doris javier,,MATH-3020,2019
+MATH,3020,6.0,Stat for Science & Engineering,0.47,0.32,0.16,0.0,0.05,0.0,0.0,0.0,todd fenstermacher,,MATH-3020,2019
+MATH,3020,7.0,Stat for Science & Engineering,0.26,0.58,0.05,0.05,0.0,0.0,0.0,0.05,todd fenstermacher,,MATH-3020,2019
+MATH,3020,8.0,Stat for Science & Engineering,0.26,0.26,0.26,0.05,0.16,0.0,0.0,0.0,zhiyun gong,,MATH-3020,2019
+MATH,3020,9.0,Stat for Science & Engineering,0.39,0.19,0.22,0.08,0.06,0.0,0.0,0.06,zhiyun gong,,MATH-3020,2019
+MATH,3020,10.0,Stat for Science & Engineering,0.35,0.29,0.18,0.03,0.09,0.0,0.0,0.06,zhiyun gong,,MATH-3020,2019
+MATH,3020,13.0,Stat for Science & Engineering,0.23,0.51,0.11,0.09,0.03,0.0,0.0,0.03,xiaoqian sun,,MATH-3020,2019
+MATH,3020,14.0,Stat for Science & Engineering,0.31,0.29,0.34,0.0,0.06,0.0,0.0,0.0,ellen hepfer breazel,,MATH-3020,2019
+MATH,3110,1.0,Linear Algebra,0.25,0.5,0.21,0.02,0.0,0.0,0.0,0.02,wayne goddard,,MATH-3110,2019
+MATH,3110,2.0,Linear Algebra,0.31,0.42,0.25,0.0,0.0,0.0,0.0,0.02,wayne goddard,,MATH-3110,2019
+MATH,3110,4.0,Linear Algebra,0.38,0.35,0.15,0.08,0.02,0.0,0.0,0.01,beth novick,,MATH-3110,2019
+MATH,3110,5.0,Linear Algebra,0.34,0.26,0.16,0.11,0.13,0.0,0.0,0.0,svetlana poznanovikj,,MATH-3110,2019
+MATH,3110,6.0,Linear Algebra,0.27,0.24,0.27,0.11,0.11,0.0,0.0,0.0,svetlana poznanovikj,,MATH-3110,2019
+MATH,3110,7.0,Linear Algebra,0.48,0.36,0.11,0.02,0.0,0.0,0.0,0.02,neil calkin,,MATH-3110,2019
+MATH,3110,100.0,Linear Algebra (HON),0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,michael adam burr,True,MATH-3110,2019
+MATH,3190,1.0,Introduction to Proof,0.48,0.29,0.19,0.0,0.05,0.0,0.0,0.0,michael adam burr,,MATH-3190,2019
+MATH,3190,2.0,Introduction to Proof,0.3,0.26,0.3,0.0,0.04,0.0,0.0,0.09,james barker coykendall,,MATH-3190,2019
+MATH,3600,1.0,Intermediate Math Computing,0.73,0.15,0.06,0.04,0.02,0.0,0.0,0.0,mark cawood,,MATH-3600,2019
+MATH,3650,1.0,Numerical Mthds for Engineers,0.14,0.25,0.39,0.06,0.13,0.0,0.0,0.03,eleanor jenkins,,MATH-3650,2019
+MATH,3650,2.0,Numerical Mthds for Engineers,0.17,0.42,0.19,0.04,0.04,0.0,0.0,0.15,vincent ervin,,MATH-3650,2019
+MATH,3650,3.0,Numerical Mthds for Engineers,0.46,0.36,0.1,0.03,0.03,0.0,0.0,0.03,sibusiso samkele mabuza,,MATH-3650,2019
+MATH,3990,1.0,Creative Inquiry in Math,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,irina viktorova,,MATH-3990,2019
+MATH,4000,1.0,Theory of Probability,0.22,0.26,0.37,0.04,0.04,0.0,0.0,0.07,brian fralix,,MATH-4000,2019
+MATH,4000,2.0,Theory of Probability,0.28,0.5,0.11,0.08,0.03,0.0,0.0,0.0,peter kiessler,,MATH-4000,2019
+MATH,4020,1.0,Stat for Sci & Engineering II,0.55,0.0,0.09,0.18,0.0,0.0,0.0,0.18,derek brown,,MATH-4020,2019
+MATH,4070,1.0,Regress & Time-Series Analysis,0.5,0.2,0.0,0.1,0.0,0.0,0.0,0.2,robert lund,,MATH-4070,2019
+MATH,4120,1.0,Algebra I,0.59,0.14,0.05,0.0,0.09,0.0,0.0,0.14,matthew macauley,,MATH-4120,2019
+MATH,4120,2.0,Algebra I,0.32,0.37,0.16,0.05,0.05,0.0,0.0,0.05,hui xue,,MATH-4120,2019
+MATH,4190,1.0,Discrete Math Structures I,0.56,0.25,0.06,0.0,0.0,0.0,0.0,0.13,beth novick,,MATH-4190,2019
+MATH,4190,2.0,Discrete Math Structures I,0.64,0.21,0.07,0.0,0.0,0.0,0.0,0.07,beth novick,,MATH-4190,2019
+MATH,4310,1.0,Theory of Interest,0.2,0.3,0.4,0.0,0.1,0.0,0.0,0.0, erwin walker,,MATH-4310,2019
+MATH,4340,1.0,Adv Engineering Mathematics,0.26,0.47,0.21,0.0,0.03,0.0,0.0,0.03,qingshan chen,,MATH-4340,2019
+MATH,4340,2.0,Adv Engineering Mathematics,0.27,0.36,0.18,0.14,0.05,0.0,0.0,0.0,vincent ervin,,MATH-4340,2019
+MATH,4350,1.0,Complex Variables,0.45,0.0,0.45,0.0,0.09,0.0,0.0,0.0,shitao liu,,MATH-4350,2019
+MATH,4400,1.0,Linear Programming,0.35,0.35,0.27,0.0,0.04,0.0,0.0,0.0,margaret maria wiecek,,MATH-4400,2019
+MATH,4410,1.0,Intro to Stochastic Models,0.57,0.14,0.21,0.0,0.07,0.0,0.0,0.0,xin liu,,MATH-4410,2019
+MATH,4530,1.0,Advanced Calculus I,0.43,0.26,0.23,0.03,0.06,0.0,0.0,0.0,benjamin jaye,,MATH-4530,2019
+MATH,4540,1.0,Advanced Calculus II,0.3,0.3,0.3,0.0,0.0,0.0,0.0,0.1,james peterson,,MATH-4540,2019
+MATH,4630,1.0,Real Analysis I,0.47,0.41,0.0,0.0,0.0,0.0,0.0,0.12,shitao liu,,MATH-4630,2019
+MATH,4810,1.0,Putnam Seminar,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,neil calkin,,MATH-4810,2019
+MATH,6340,1.0,Adv Engineering Mathematics,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,hyesuk lee,,MATH-6340,2019
+MATH,8000,1.0,Probability,0.65,0.24,0.0,0.0,0.06,0.0,0.0,0.06,xin liu,,MATH-8000,2019
+MATH,8010,1.0,General Linear Hypothesis I,0.31,0.54,0.15,0.0,0.0,0.0,0.0,0.0,derek brown,,MATH-8010,2019
+MATH,8050,1.0,Data Analysis,0.68,0.28,0.0,0.0,0.04,0.0,0.0,0.0,brook thayer russell,,MATH-8050,2019
+MATH,8070,1.0,Applied Multivariate Analysis,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,colin gallagher,,MATH-8070,2019
+MATH,8090,1.0,Time Series Analysis,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,robert lund,,MATH-8090,2019
+MATH,8140,1.0,Network Flow Programming,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,matthew saltzman,,MATH-8140,2019
+MATH,8170,1.0,Stochastic Mod in Oper Rsrch I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,,MATH-8170,2019
+MATH,8210,1.0,Linear Analysis,0.52,0.24,0.19,0.0,0.05,0.0,0.0,0.0,mishko mitkovski,,MATH-8210,2019
+MATH,8510,1.0,Abstract Algebra I,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,james barker coykendall,,MATH-8510,2019
+MATH,8530,1.0,Matrix Analysis,0.38,0.25,0.38,0.0,0.0,0.0,0.0,0.0,xuhong gao,,MATH-8530,2019
+MATH,8600,1.0,Intro to Scientific Computing,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,hyesuk lee,,MATH-8600,2019
+MATH,8650,1.0,Data Structures,0.46,0.31,0.0,0.0,0.0,0.0,0.0,0.23,timo johannes heister,,MATH-8650,2019
+MATH,8850,1.0,Advanced Data Analysis,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,,MATH-8850,2019
+MBA,8030,1.0,Stat Analy of Bus Op,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,dee ann wood kivett,,MBA-8030,2019
+MBA,8030,2.0,Stat Analy of Bus Op,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,william edward kilbourne,,MBA-8030,2019
+MBA,8040,20.0,Busin Data An & Stat Computing,0.69,0.28,0.0,0.0,0.0,0.0,0.0,0.03,william edward kilbourne,,MBA-8040,2019
+MBA,8060,1.0,Operations Mgt,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MBA-8060,2019
+MBA,8060,2.0,Operations Mgt,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,george kenneth morgan,,MBA-8060,2019
+MBA,8070,1.0,Financial Management,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,,MBA-8070,2019
+MBA,8070,2.0,Financial Management,0.55,0.4,0.0,0.0,0.05,0.0,0.0,0.0,george brandon lockhart,,MBA-8070,2019
+MBA,8070,20.0,Financial Management,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,george brandon lockhart,,MBA-8070,2019
+MBA,8090,1.0,Org Beh & Hum Res Mg,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,thomas joseph zagenczyk,,MBA-8090,2019
+MBA,8090,2.0,Org Beh & Hum Res Mg,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,thomas joseph zagenczyk,,MBA-8090,2019
+MBA,8090,3.0,Org Beh & Hum Res Mg,0.61,0.33,0.0,0.0,0.0,0.0,0.0,0.06,thomas joseph zagenczyk,,MBA-8090,2019
+MBA,8180,20.0,Intro Business Intell & Anlytc,0.83,0.14,0.0,0.0,0.0,0.0,0.0,0.03,john frederick tripp,,MBA-8180,2019
+MBA,8190,2.0,Intro to Acc and Fin,0.48,0.45,0.07,0.0,0.0,0.0,0.0,0.0,jeffrey mcmillan,,MBA-8190,2019
+MBA,8190,3.0,Intro to Acc and Fin,0.09,0.45,0.14,0.0,0.14,0.0,0.0,0.18,jeffrey mcmillan,,MBA-8190,2019
+MBA,8290,1.0,Marketing Foundation,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,ankita bakre,,MBA-8290,2019
+MBA,8310,10.0,Communications and Sales,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,gregory pickett,,MBA-8310,2019
+MBA,8370,1.0,Legal Environ of Bus,0.61,0.34,0.05,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8370,2019
+MBA,8370,2.0,Legal Environ of Bus,0.34,0.57,0.06,0.0,0.0,0.0,0.0,0.03,judson jahn,,MBA-8370,2019
+MBA,8400,1.0,Entrepreneurship & Venture Mgt,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,prashant prabhu,,MBA-8400,2019
+MBA,8410,1.0,Real Estate Finance,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,ryan dietz,,MBA-8410,2019
+MBA,8430,1.0,Entrepreneurial Accounting,0.38,0.44,0.13,0.0,0.0,0.0,0.0,0.06,annieka philo,,MBA-8430,2019
+MBA,8440,1.0,Entrepreneurial Law,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,john hine,,MBA-8440,2019
+MBA,8480,1.0,Entrpr Mkting & Digital Strat,0.76,0.18,0.0,0.0,0.0,0.0,0.0,0.06,bruce snyder,,MBA-8480,2019
+MBA,8480,5.0,Entrpr Mkting & Digital Strat,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,bruce snyder,,MBA-8480,2019
+MBA,8490,5.0,Entrepreneurial Strategy,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,matthew charles klein,,MBA-8490,2019
+MBA,8510,1.0,Bus Operations & Logistics,0.25,0.56,0.13,0.0,0.0,0.0,0.0,0.06, sridharan,,MBA-8510,2019
+MBA,8540,2.0,Managerial Accounting,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.03,emily suzanne mccorkle,,MBA-8540,2019
+MBA,8590,1.0,Mgr Decision Model,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,james turner,,MBA-8590,2019
+MBA,8590,2.0,Mgr Decision Model,0.29,0.42,0.08,0.0,0.0,0.0,0.0,0.21,magda gabriela sava,,MBA-8590,2019
+MBA,8590,3.0,Mgr Decision Model,0.31,0.38,0.13,0.0,0.03,0.0,0.0,0.16,magda gabriela sava,,MBA-8590,2019
+MBA,8600,2.0,Advanced Marketing Strategy,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,joseph renato gibson,,MBA-8600,2019
+MBA,8610,2.0,Information Systems,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,william kettinger,,MBA-8610,2019
+MBA,8620,1.0,Managerial Economics,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,scott templeton,,MBA-8620,2019
+MBA,8620,2.0,Managerial Economics,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,ronald earle gregory,,MBA-8620,2019
+MBA,8620,4.0,Managerial Economics,0.56,0.36,0.04,0.0,0.0,0.0,0.0,0.04,ronald earle gregory,,MBA-8620,2019
+MBA,8660,21.0,"Data, Storage, Business Decis",0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,he li,,MBA-8660,2019
+MBA,8700,1.0,Strategic Management,0.82,0.12,0.06,0.0,0.0,0.0,0.0,0.0,james turner,,MBA-8700,2019
+MBA,8990,2.0,Creativity,0.79,0.14,0.05,0.0,0.0,0.0,0.0,0.02,kathleen ann kegley,,MBA-8990,2019
+MBA,8990,4.0,Data Analytics & Visualization,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,john frederick tripp,,MBA-8990,2019
+MBA,8990,7.0,Digital Marketing,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,robert andrew fitzwater,,MBA-8990,2019
+ME,2000,1.0,Sophomore Seminar,0.91,0.05,0.01,0.0,0.0,0.0,0.0,0.03,todd alan schweisinger,,ME-2000,2019
+ME,2000,2.0,Sophomore Seminar,0.74,0.16,0.03,0.01,0.02,0.0,0.0,0.05,todd alan schweisinger,,ME-2000,2019
+ME,2010,1.0,Statics & Dynamics,0.07,0.16,0.25,0.09,0.25,0.0,0.0,0.16,gang liu,,ME-2010,2019
+ME,2010,2.0,Statics & Dynamics,0.17,0.24,0.31,0.07,0.13,0.0,0.0,0.08,paul joseph,,ME-2010,2019
+ME,2010,3.0,Statics & Dynamics,0.05,0.16,0.26,0.15,0.15,0.0,0.0,0.24,gang li,,ME-2010,2019
+ME,2010,4.0,Statics & Dynamics,0.02,0.14,0.25,0.17,0.22,0.0,0.0,0.2,marisa kikendall orr,,ME-2010,2019
+ME,2030,1.0,Founda Th/Fl Syst,0.42,0.33,0.14,0.05,0.05,0.0,0.0,0.02,sandip dutta,,ME-2030,2019
+ME,2030,2.0,Founda Th/Fl Syst,0.27,0.29,0.16,0.16,0.04,0.0,0.0,0.09,xiangchun xuan,,ME-2030,2019
+ME,2040,1.0,Mechanics of Materials,0.24,0.51,0.18,0.04,0.04,0.0,0.0,0.0,fadi abdeljawad,,ME-2040,2019
+ME,2040,2.0,Mechanics of Materials,0.19,0.53,0.16,0.03,0.03,0.0,0.0,0.06,huijuan zhao,,ME-2040,2019
+ME,2220,1.0,Mechanical Engineering Lab I,0.44,0.44,0.06,0.0,0.0,0.0,0.0,0.06,douglas scott byrd,,ME-2220,2019
+ME,2220,2.0,Mechanical Engineering Lab I,0.31,0.56,0.13,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,,ME-2220,2019
+ME,2220,3.0,Mechanical Engineering Lab I,0.13,0.56,0.13,0.0,0.0,0.0,0.0,0.19,douglas scott byrd,,ME-2220,2019
+ME,2220,5.0,Mechanical Engineering Lab I,0.44,0.56,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,,ME-2220,2019
+ME,2220,6.0,Mechanical Engineering Lab I,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,,ME-2220,2019
+ME,2220,7.0,Mechanical Engineering Lab I,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,,ME-2220,2019
+ME,2220,8.0,Mechanical Engineering Lab I,0.56,0.31,0.0,0.0,0.06,0.0,0.0,0.06,douglas scott byrd,,ME-2220,2019
+ME,2220,10.0,Mechanical Engineering Lab I,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,douglas scott byrd,,ME-2220,2019
+ME,2220,11.0,Mechanical Engineering Lab I,0.13,0.53,0.2,0.0,0.0,0.0,0.0,0.13,douglas scott byrd,,ME-2220,2019
+ME,2220,13.0,Mechanical Engineering Lab I,0.31,0.5,0.06,0.0,0.0,0.0,0.0,0.13,douglas scott byrd,,ME-2220,2019
+ME,2220,15.0,Mechanical Engineering Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,douglas scott byrd,,ME-2220,2019
+ME,3030,1.0,Thermodynamics,0.12,0.3,0.33,0.12,0.06,0.0,0.0,0.06,john saylor,,ME-3030,2019
+ME,3030,2.0,Thermodynamics,0.23,0.31,0.34,0.11,0.02,0.0,0.0,0.0,yiqiang han,,ME-3030,2019
+ME,3030,3.0,Thermodynamics,0.09,0.31,0.47,0.04,0.02,0.0,0.0,0.07,yiqiang han,,ME-3030,2019
+ME,3040,1.0,Heat Transfer,0.55,0.35,0.07,0.01,0.0,0.0,0.0,0.01,sandip dutta,,ME-3040,2019
+ME,3040,2.0,Heat Transfer,0.09,0.25,0.45,0.09,0.07,0.0,0.0,0.05,geetha pravallika chimata,,ME-3040,2019
+ME,3050,1.0,Model/an Dy Syst,0.25,0.34,0.27,0.09,0.05,0.0,0.0,0.0,ardalan vahidi,,ME-3050,2019
+ME,3050,2.0,Model/an Dy Syst,0.18,0.35,0.26,0.09,0.09,0.0,0.0,0.03,seyedyasha parvinioskoui,,ME-3050,2019
+ME,3060,1.0,Fund Machine Design,0.34,0.38,0.19,0.06,0.02,0.0,0.0,0.0,katherine marie ehlert,,ME-3060,2019
+ME,3060,2.0,Fund Machine Design,0.29,0.53,0.18,0.0,0.0,0.0,0.0,0.0,zhaoxu meng,,ME-3060,2019
+ME,3060,3.0,Fund Machine Design,0.15,0.34,0.24,0.15,0.07,0.0,0.0,0.05,nafiseh masoudi,,ME-3060,2019
+ME,3070,1.0,Found of Mechanical Systems,0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,pooya niksiar,,ME-3070,2019
+ME,3070,2.0,Found of Mechanical Systems,0.5,0.35,0.08,0.03,0.03,0.0,0.0,0.03,lonny thompson,,ME-3070,2019
+ME,3070,3.0,Found of Mechanical Systems,0.67,0.22,0.09,0.0,0.0,0.0,0.0,0.01,pooya niksiar,,ME-3070,2019
+ME,3080,1.0,Fluid Mechanics,0.16,0.53,0.24,0.02,0.02,0.0,0.0,0.02,zhen li,,ME-3080,2019
+ME,3080,2.0,Fluid Mechanics,0.18,0.2,0.38,0.2,0.02,0.0,0.0,0.02,seyedyasha parvinioskoui,,ME-3080,2019
+ME,3080,3.0,Fluid Mechanics,0.26,0.34,0.36,0.03,0.0,0.0,0.0,0.0,ethan kung,,ME-3080,2019
+ME,3080,301.0,Fluid Mechanics (HON),0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,zhen li,True,ME-3080,2019
+ME,3120,1.0,Manuf Processes,0.66,0.32,0.02,0.0,0.0,0.0,0.0,0.0,xin zhao,,ME-3120,2019
+ME,3120,2.0,Manuf Processes,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,rodrigo martinez-duarte,,ME-3120,2019
+ME,3330,1.0,Mechanical Engineering Lab II,0.27,0.53,0.2,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,2.0,Mechanical Engineering Lab II,0.25,0.63,0.13,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,5.0,Mechanical Engineering Lab II,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,6.0,Mechanical Engineering Lab II,0.25,0.69,0.0,0.0,0.0,0.0,0.0,0.06,gang liu,,ME-3330,2019
+ME,3330,8.0,Mechanical Engineering Lab II,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,9.0,Mechanical Engineering Lab II,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,10.0,Mechanical Engineering Lab II,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,16.0,Mechanical Engineering Lab II,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3900,103.0,CI ME - Autonomous Micro Drone,0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,yiqiang han,,ME-3900,2019
+ME,4000,1.0,Senior Seminar,0.98,0.01,0.0,0.0,0.01,0.0,0.0,0.0,atul gajanan kelkar,,ME-4000,2019
+ME,4010,2.0,Mech Engr Design,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4010,2019
+ME,4010,864.0,Mech Engr Design,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,geetha pravallika chimata,,ME-4010,2019
+ME,4020,3.0,Intern in Engr Des,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,pooya niksiar,,ME-4020,2019
+ME,4030,1.0,Control Dynamic Systems,0.3,0.27,0.03,0.24,0.15,0.0,0.0,0.0,mohammad naghnaeian,,ME-4030,2019
+ME,4030,2.0,Control Dynamic Systems,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,suyi li,,ME-4030,2019
+ME,4030,3.0,Control Dynamic Systems,0.73,0.18,0.05,0.05,0.0,0.0,0.0,0.0,hubert bryan riley,,ME-4030,2019
+ME,4210,1.0,Intro to Comp Flow,0.43,0.14,0.36,0.07,0.0,0.0,0.0,0.0,chenning tong,,ME-4210,2019
+ME,4290,1.0,Ther Env Control,0.57,0.35,0.04,0.0,0.0,0.0,0.0,0.04,jay ochterbeck,,ME-4290,2019
+ME,4320,1.0,Advanced Strength of Materials,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,oliver myers,,ME-4320,2019
+ME,4340,1.0,Cardiovascular Biomechanics,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,ethan kung,,ME-4340,2019
+ME,4440,1.0,Mechanical Engineering Lab III,0.13,0.88,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2019
+ME,4440,2.0,Mechanical Engineering Lab III,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2019
+ME,4440,5.0,Mechanical Engineering Lab III,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4440,2019
+ME,4580,1.0,Fund Micro/Nano Fabrication,0.43,0.43,0.07,0.0,0.0,0.0,0.0,0.07,rodrigo martinez-duarte,,ME-4580,2019
+ME,4710,1.0,Ca Eng Anly & Design,0.32,0.53,0.03,0.03,0.0,0.0,0.0,0.11,georges fadel,,ME-4710,2019
+ME,4930,14.0,Sel.Topics ME - NonLinDy&Chas,0.13,0.5,0.38,0.0,0.0,0.0,0.0,0.0,joshua bostwick,,ME-4930,2019
+ME,4930,35.0,Sel Topics ME: Smart Materials,0.55,0.34,0.07,0.0,0.0,0.0,0.0,0.03,oliver myers,,ME-4930,2019
+ME,4930,39.0,Sel.Topics ME - Aero Propul,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,pooya niksiar,,ME-4930,2019
+ME,4930,77.0,Selected Topics ME - Boeing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4930,2019
+ME,6320,1.0,Advanced Strength of Materials,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,oliver myers,,ME-6320,2019
+ME,6550,864.0,Design for Manuf,0.46,0.38,0.15,0.0,0.0,0.0,0.0,0.0,joshua summers,,ME-6550,2019
+ME,6710,1.0,Ca Eng Anly & Design,0.53,0.4,0.07,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-6710,2019
+ME,6930,14.0,Sel.Topics ME - NonLinDy&Chas,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joshua bostwick,,ME-6930,2019
+ME,6930,35.0,Sel Topics ME: Smart Materials,0.85,0.08,0.08,0.0,0.0,0.0,0.0,0.0,oliver myers,,ME-6930,2019
+ME,8010,1.0,Found of Fluid Mech,0.36,0.32,0.23,0.0,0.05,0.0,0.0,0.05,richard figliola,,ME-8010,2019
+ME,8100,1.0,Macroscopic Thermo,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,jay ochterbeck,,ME-8100,2019
+ME,8180,1.0,Intro to Fin Ele Ana,0.7,0.25,0.0,0.0,0.02,0.0,0.0,0.03,lonny thompson,,ME-8180,2019
+ME,8180,843.0,Intro to Fin Ele Ana,0.57,0.0,0.29,0.0,0.0,0.0,0.0,0.14,lonny thompson,,ME-8180,2019
+ME,8230,1.0,Control Systems,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,yue wang,,ME-8230,2019
+ME,8230,864.0,Control Systems,0.45,0.45,0.0,0.0,0.0,0.0,0.0,0.09,yue wang,,ME-8230,2019
+ME,8300,1.0,Cond/Rad Heat Tfr,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,xiangchun xuan,,ME-8300,2019
+ME,8400,1.0,Plasticity,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.11,garrett pataky,,ME-8400,2019
+ME,8460,1.0,Inter Dynamics,0.5,0.21,0.21,0.0,0.0,0.0,0.0,0.07,phanindra tallapragada,,ME-8460,2019
+ME,8700,1.0,Adv Design Methods,0.97,0.02,0.02,0.0,0.0,0.0,0.0,0.0,cameron turner,,ME-8700,2019
+ME,8710,1.0,Engr Optimization,0.78,0.13,0.02,0.0,0.0,0.0,0.0,0.07,georges fadel,,ME-8710,2019
+ME,8930,2.0,Sel Topics ME: Adv Mfg,0.36,0.5,0.09,0.0,0.0,0.0,0.0,0.05,hong seok choi,,ME-8930,2019
+MGT,2010,1.0,Principles of Management,0.35,0.4,0.19,0.03,0.01,0.0,0.0,0.02,katherine clark,,MGT-2010,2019
+MGT,2010,2.0,Principles of Management,0.52,0.33,0.11,0.02,0.01,0.0,0.0,0.01,tina robbins,,MGT-2010,2019
+MGT,2010,8.0,Principles of Management,0.4,0.35,0.23,0.0,0.0,0.0,0.0,0.03,christopher mann,,MGT-2010,2019
+MGT,2010,9.0,Principles of Management,0.26,0.53,0.08,0.11,0.03,0.0,0.0,0.0,christopher mann,,MGT-2010,2019
+MGT,2010,10.0,Principles of Management,0.31,0.33,0.31,0.0,0.03,0.0,0.0,0.03,ashley williams parnell,,MGT-2010,2019
+MGT,2010,11.0,Principles of Management,0.33,0.31,0.23,0.08,0.0,0.0,0.0,0.05,ashley williams parnell,,MGT-2010,2019
+MGT,2010,12.0,Principles of Management,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,nicholas byrd,,MGT-2010,2019
+MGT,2010,13.0,Principles of Management,0.79,0.13,0.08,0.0,0.0,0.0,0.0,0.0,shuang liu,,MGT-2010,2019
+MGT,2180,1.0,Management PC Applications,0.56,0.29,0.09,0.02,0.02,0.0,0.0,0.02,ryan toole,,MGT-2180,2019
+MGT,2180,2.0,Management PC Applications,0.25,0.6,0.03,0.0,0.0,0.0,0.0,0.13,ryan toole,,MGT-2180,2019
+MGT,3070,1.0,Human Resource Management,0.46,0.49,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,,MGT-3070,2019
+MGT,3070,3.0,Human Resource Management,0.37,0.41,0.15,0.07,0.0,0.0,0.0,0.0,kristin damato scott,,MGT-3070,2019
+MGT,3070,4.0,Human Resource Management,0.46,0.49,0.06,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2019
+MGT,3070,5.0,Human Resource Management,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,,MGT-3070,2019
+MGT,3070,6.0,Human Resource Management,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2019
+MGT,3070,7.0,Human Resource Management,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,leonard joseph spooner,,MGT-3070,2019
+MGT,3070,8.0,Human Resource Management,0.2,0.49,0.26,0.03,0.03,0.0,0.0,0.0,priscilla harrison,,MGT-3070,2019
+MGT,3100,1.0,Intermed Business Statistics,0.26,0.29,0.32,0.0,0.06,0.0,0.0,0.06,daniel allan detoma,,MGT-3100,2019
+MGT,3100,2.0,Intermed Business Statistics,0.37,0.17,0.31,0.03,0.09,0.0,0.0,0.03,mustafa serkan akturk,,MGT-3100,2019
+MGT,3100,3.0,Intermed Business Statistics,0.56,0.18,0.15,0.0,0.03,0.0,0.0,0.09,maneeshreddy ajjuguttu,,MGT-3100,2019
+MGT,3100,5.0,Intermed Business Statistics,0.4,0.18,0.33,0.03,0.03,0.0,0.0,0.05,mustafa serkan akturk,,MGT-3100,2019
+MGT,3100,6.0,Intermed Business Statistics,0.81,0.03,0.05,0.03,0.05,0.0,0.0,0.03,david ford peyton,,MGT-3100,2019
+MGT,3100,7.0,Intermed Business Statistics,0.54,0.32,0.03,0.03,0.03,0.0,0.0,0.05,seyed amin seyed haeri,,MGT-3100,2019
+MGT,3100,8.0,Intermed Business Statistics,0.65,0.25,0.08,0.0,0.0,0.0,0.0,0.03,david ford peyton,,MGT-3100,2019
+MGT,3100,9.0,Intermed Business Statistics,0.51,0.23,0.1,0.1,0.05,0.0,0.0,0.0,david ford peyton,,MGT-3100,2019
+MGT,3100,10.0,Intermed Business Statistics,0.45,0.34,0.13,0.03,0.05,0.0,0.0,0.0,jeromy blake snider,,MGT-3100,2019
+MGT,3100,12.0,Intermed Business Statistics,0.13,0.31,0.44,0.0,0.03,0.0,0.0,0.1,daniel allan detoma,,MGT-3100,2019
+MGT,3100,13.0,Intermed Business Statistics,0.86,0.08,0.03,0.0,0.03,0.0,0.0,0.0,benjamin christopher wiles,,MGT-3100,2019
+MGT,3120,1.0,Decision Models for Management,0.29,0.22,0.28,0.11,0.06,0.0,0.0,0.05,sara elizabeth yoder,,MGT-3120,2019
+MGT,3120,2.0,Decision Models for Management,0.19,0.14,0.34,0.16,0.14,0.0,0.0,0.03,sara elizabeth yoder,,MGT-3120,2019
+MGT,3120,4.0,Decision Models for Management,0.25,0.22,0.32,0.07,0.05,0.0,0.0,0.08,sara elizabeth yoder,,MGT-3120,2019
+MGT,3170,1.0,Logistics Mgmt,0.43,0.48,0.09,0.0,0.0,0.0,0.0,0.0,ahmet colak,,MGT-3170,2019
+MGT,3180,1.0,Mgt of Info Systems,0.53,0.43,0.05,0.0,0.0,0.0,0.0,0.0,wenxi pu,,MGT-3180,2019
+MGT,3180,3.0,Mgt of Info Systems,0.38,0.4,0.03,0.1,0.05,0.0,0.0,0.05,zhihong ke,,MGT-3180,2019
+MGT,3180,4.0,Mgt of Info Systems,0.56,0.33,0.09,0.02,0.0,0.0,0.0,0.0,he li,,MGT-3180,2019
+MGT,3180,5.0,Mgt of Info Systems,0.4,0.5,0.05,0.0,0.02,0.0,0.0,0.02,wenxi pu,,MGT-3180,2019
+MGT,3180,6.0,Mgt of Info Systems,0.69,0.16,0.13,0.02,0.0,0.0,0.0,0.0,shih lun tseng,,MGT-3180,2019
+MGT,3180,7.0,Mgt of Info Systems,0.68,0.23,0.07,0.0,0.02,0.0,0.0,0.0,shih lun tseng,,MGT-3180,2019
+MGT,3180,8.0,Mgt of Info Systems,0.56,0.06,0.19,0.06,0.08,0.0,0.0,0.06,kevin mckenzie,,MGT-3180,2019
+MGT,3500,1.0,Intro to Business Analytics,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,hongki kim,,MGT-3500,2019
+MGT,3510,1.0,Business Analytics & Problems,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,david ford peyton,,MGT-3510,2019
+MGT,3900,1.0,Operations Management,0.31,0.39,0.11,0.03,0.03,0.0,0.0,0.13, sridharan,,MGT-3900,2019
+MGT,3900,2.0,Operations Management,0.29,0.41,0.14,0.05,0.05,0.0,0.0,0.05, sridharan,,MGT-3900,2019
+MGT,3900,4.0,Operations Management,0.1,0.2,0.48,0.1,0.08,0.0,0.0,0.05,zachary moran leffakis,,MGT-3900,2019
+MGT,3900,5.0,Operations Management,0.46,0.38,0.1,0.03,0.03,0.0,0.0,0.0,benjamin noah grant,,MGT-3900,2019
+MGT,3900,6.0,Operations Management,0.28,0.38,0.23,0.05,0.08,0.0,0.0,0.0,benjamin noah grant,,MGT-3900,2019
+MGT,4000,1.0,Mgt of Organizational Behavior,0.59,0.39,0.0,0.0,0.0,0.0,0.0,0.02,michael cole,,MGT-4000,2019
+MGT,4000,2.0,Mgt of Organizational Behavior,0.73,0.25,0.0,0.03,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2019
+MGT,4000,3.0,Mgt of Organizational Behavior,0.29,0.53,0.16,0.0,0.03,0.0,0.0,0.0,thomas joseph zagenczyk,,MGT-4000,2019
+MGT,4000,4.0,Mgt of Organizational Behavior,0.21,0.29,0.32,0.16,0.0,0.0,0.0,0.03,philip roth,,MGT-4000,2019
+MGT,4020,1.0,Ops Pln and Ctl,0.06,0.25,0.69,0.0,0.0,0.0,0.0,0.0,zachary moran leffakis,,MGT-4020,2019
+MGT,4080,1.0,Lean Operations,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,zachary moran leffakis,,MGT-4080,2019
+MGT,4110,1.0,Project Management,0.35,0.43,0.14,0.0,0.03,0.0,0.0,0.05,russell purvis,,MGT-4110,2019
+MGT,4120,1.0,Supplier Management,0.48,0.33,0.15,0.0,0.0,0.0,0.0,0.03,ahmet colak,,MGT-4120,2019
+MGT,4150,1.0,Business Strategy,0.25,0.53,0.23,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,2.0,Business Strategy,0.29,0.58,0.13,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,3.0,Business Strategy,0.1,0.65,0.25,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,4.0,Business Strategy,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,,MGT-4150,2019
+MGT,4150,5.0,Business Strategy (HON),0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,amy elizabeth ingram,True,MGT-4150,2019
+MGT,4150,6.0,Business Strategy,0.1,0.56,0.33,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,7.0,Business Strategy,0.45,0.4,0.14,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,,MGT-4150,2019
+MGT,4150,8.0,Business Strategy,0.21,0.51,0.28,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,,MGT-4150,2019
+MGT,4150,9.0,Business Strategy,0.39,0.53,0.05,0.0,0.0,0.0,0.0,0.03,amy elizabeth ingram,,MGT-4150,2019
+MGT,4150,12.0,Business Strategy,0.21,0.5,0.29,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4160,1.0,Special Topics Hr,0.34,0.49,0.17,0.0,0.0,0.0,0.0,0.0,kristin damato scott,,MGT-4160,2019
+MGT,4230,1.0,Intern Bus Mgt,0.18,0.18,0.52,0.09,0.02,0.0,0.0,0.0,wayne stewart,,MGT-4230,2019
+MGT,4230,2.0,Intern Bus Mgt,0.23,0.38,0.3,0.05,0.05,0.0,0.0,0.0,wayne stewart,,MGT-4230,2019
+MGT,4230,3.0,Intern Bus Mgt,0.13,0.45,0.37,0.02,0.03,0.0,0.0,0.0,janis miller,,MGT-4230,2019
+MGT,4240,1.0,Global Supply Chain Management,0.32,0.44,0.21,0.0,0.03,0.0,0.0,0.0,yann ferrand,,MGT-4240,2019
+MGT,4270,2.0,Managing Improvement,0.27,0.4,0.23,0.0,0.03,0.0,0.0,0.07,lawrence fredendall,,MGT-4270,2019
+MGT,4310,1.0,Emp Rights & Resp,0.21,0.62,0.15,0.03,0.0,0.0,0.0,0.0,leonard joseph spooner,,MGT-4310,2019
+MGT,4350,1.0,Pers Interviewing,0.42,0.56,0.03,0.0,0.0,0.0,0.0,0.0,philip roth,,MGT-4350,2019
+MGT,4520,1.0,Business Analysis,0.24,0.58,0.12,0.0,0.0,0.0,0.0,0.06,russell purvis,,MGT-4520,2019
+MGT,4540,1.0,Systems Implement,0.55,0.31,0.1,0.0,0.03,0.0,0.0,0.0,hongki kim,,MGT-4540,2019
+MGT,8690,1.0,Project Mgt,0.49,0.49,0.0,0.0,0.0,0.0,0.0,0.02,russell purvis,,MGT-8690,2019
+MICR,2050,1.0,Introductory Micro,0.37,0.46,0.16,0.02,0.0,0.0,0.0,0.01,john abercrombie,,MICR-2050,2019
+MICR,3050,1.0,General Microbiology,0.39,0.39,0.18,0.02,0.0,0.0,0.0,0.01,krista barrier rudolph,,MICR-3050,2019
+MICR,3050,2.0,General Microbiology,0.42,0.39,0.14,0.04,0.0,0.0,0.0,0.0,krista barrier rudolph,,MICR-3050,2019
+MICR,4010,1.0,Microbial Diversity & Ecology,0.58,0.22,0.14,0.02,0.02,0.0,0.0,0.02,kristi james whitehead,,MICR-4010,2019
+MICR,4010,2.0,Micro Diversity/Ecol (HON),0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,kristi james whitehead,True,MICR-4010,2019
+MICR,4050,1.0,Adv Microbial Ecol of Humans,0.49,0.37,0.1,0.02,0.0,0.0,0.0,0.01,kristi james whitehead,,MICR-4050,2019
+MICR,4140,1.0,Basic Immunology,0.38,0.45,0.13,0.0,0.02,0.0,0.0,0.02,yanzhang wei,,MICR-4140,2019
+MICR,4150,1.0,Microbial Genetics,0.3,0.32,0.3,0.09,0.0,0.0,0.0,0.0,min cao,,MICR-4150,2019
+MICR,4160,1.0,Intro Virology,0.79,0.18,0.01,0.01,0.0,0.0,0.0,0.0,kaustubha ratan qanungo,,MICR-4160,2019
+MICR,4510,2.0,Advanced Microbiology II,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4510,2019
+MICR,4510,3.0,Advanced Microbiology II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4510,2019
+MICR,4510,4.0,Advanced Microbiology II,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4510,2019
+MICR,4930,1.0,Sr Sem: Emerg Infect Diseases,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,kristi james whitehead,,MICR-4930,2019
+MKT,3010,1.0,Principles of Marketing,0.2,0.43,0.25,0.08,0.02,0.0,0.0,0.03,amanda cooper fine,,MKT-3010,2019
+MKT,3010,2.0,Principles of Marketing,0.29,0.37,0.21,0.1,0.01,0.0,0.0,0.02,amanda cooper fine,,MKT-3010,2019
+MKT,3010,3.0,Principles of Marketing,0.29,0.39,0.22,0.08,0.01,0.0,0.0,0.01,amanda cooper fine,,MKT-3010,2019
+MKT,3010,4.0,Principles of Marketing,0.27,0.44,0.21,0.06,0.02,0.0,0.0,0.01,carter willis mcelveen,,MKT-3010,2019
+MKT,3010,5.0,Principles of Marketing,0.31,0.43,0.21,0.04,0.0,0.0,0.0,0.01,carter willis mcelveen,,MKT-3010,2019
+MKT,3010,7.0,Principles of Marketing,0.12,0.56,0.27,0.03,0.01,0.0,0.0,0.01,james gaubert,,MKT-3010,2019
+MKT,3020,1.0,Consumer Behavior,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,jennifer dianne siemens,,MKT-3020,2019
+MKT,3020,2.0,Consumer Behavior,0.69,0.24,0.04,0.02,0.0,0.0,0.0,0.0,jennifer dianne siemens,,MKT-3020,2019
+MKT,3020,5.0,Consumer Behavior,0.52,0.38,0.09,0.0,0.01,0.0,0.0,0.0,anastasia elizabeth thyroff,,MKT-3020,2019
+MKT,3020,6.0,Consumer Behavior,0.29,0.48,0.15,0.01,0.04,0.0,0.0,0.03,james gaubert,,MKT-3020,2019
+MKT,3210,1.0,Sports Marketing,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2019
+MKT,3210,2.0,Sports Marketing,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-3210,2019
+MKT,3220,1.0,Social Media Marketing,0.83,0.11,0.0,0.03,0.0,0.0,0.0,0.03,lura forcum,,MKT-3220,2019
+MKT,3220,2.0,Social Media Marketing,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lura forcum,,MKT-3220,2019
+MKT,3220,3.0,Social Media Marketing,0.67,0.26,0.07,0.0,0.0,0.0,0.0,0.0,michele melton cauley,,MKT-3220,2019
+MKT,3220,4.0,Social Media Marketing,0.57,0.37,0.04,0.0,0.02,0.0,0.0,0.0,michele melton cauley,,MKT-3220,2019
+MKT,3310,1.0,Marketing Metrics & Analytics,0.73,0.2,0.03,0.0,0.0,0.0,0.0,0.03,oriana rachel aragon,,MKT-3310,2019
+MKT,3310,2.0,Marketing Metrics & Analytics,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,oriana rachel aragon,,MKT-3310,2019
+MKT,3310,3.0,Marketing Metrics & Analytics,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-3310,2019
+MKT,3310,4.0,Marketing Metrics & Analytics,0.89,0.07,0.0,0.0,0.0,0.0,0.0,0.04,xianyong wang,,MKT-3310,2019
+MKT,3310,5.0,Marketing Metrics & Analytics,0.19,0.44,0.22,0.04,0.0,0.0,0.0,0.11,peter weathers,,MKT-3310,2019
+MKT,3980,1.0,Creative Inquiry in Marketing,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,james gaubert,,MKT-3980,2019
+MKT,4200,1.0,Professional Selling,0.41,0.56,0.04,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2019
+MKT,4200,2.0,Professional Selling,0.54,0.42,0.04,0.0,0.0,0.0,0.0,0.0,kevin scott chase,,MKT-4200,2019
+MKT,4200,3.0,Professional Selling,0.63,0.33,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2019
+MKT,4200,5.0,Professional Selling,0.83,0.07,0.07,0.0,0.0,0.0,0.0,0.03,carter willis mcelveen,,MKT-4200,2019
+MKT,4200,6.0,Professional Selling,0.72,0.24,0.03,0.0,0.0,0.0,0.0,0.0,gary hunter,,MKT-4200,2019
+MKT,4230,2.0,Promotional Strategy,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,michele melton cauley,,MKT-4230,2019
+MKT,4230,3.0,Promotional Strategy,0.42,0.48,0.06,0.0,0.03,0.0,0.0,0.0,michele melton cauley,,MKT-4230,2019
+MKT,4240,1.0,Sales Management,0.59,0.32,0.05,0.0,0.0,0.0,0.0,0.03,ryan mullins,,MKT-4240,2019
+MKT,4260,1.0,Business-to-Business,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4260,2019
+MKT,4270,1.0,International Marketing,0.7,0.24,0.04,0.02,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4270,2019
+MKT,4270,2.0,International Marketing,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4270,2019
+MKT,4270,3.0,International Marketing,0.48,0.33,0.1,0.0,0.03,0.0,0.0,0.08,thomas poehlman,,MKT-4270,2019
+MKT,4270,4.0,International Marketing,0.82,0.14,0.05,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4270,2019
+MKT,4280,1.0,Services Marketing,0.21,0.44,0.28,0.05,0.03,0.0,0.0,0.0,angeline close scheinbaum,,MKT-4280,2019
+MKT,4280,2.0,Services Marketing,0.15,0.64,0.21,0.0,0.0,0.0,0.0,0.0,angeline close scheinbaum,,MKT-4280,2019
+MKT,4310,1.0,Marketing Research,0.6,0.33,0.07,0.0,0.0,0.0,0.0,0.0,michael david giebelhausen,,MKT-4310,2019
+MKT,4310,2.0,Marketing Research,0.78,0.18,0.04,0.0,0.0,0.0,0.0,0.0,michael david giebelhausen,,MKT-4310,2019
+MKT,4310,3.0,Marketing Research,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2019
+MKT,4310,4.0,Marketing Research,0.59,0.39,0.02,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2019
+MKT,4500,1.0,Strategic Mktg Mgt,0.62,0.27,0.12,0.0,0.0,0.0,0.0,0.0,annette popp tower,,MKT-4500,2019
+MKT,4500,2.0,Strategic Mktg Mgt,0.39,0.52,0.09,0.0,0.0,0.0,0.0,0.0,annette popp tower,,MKT-4500,2019
+MKT,4500,3.0,Strategic Mktg Mgt,0.27,0.58,0.15,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2019
+MKT,4500,4.0,Strategic Mktg Mgt,0.19,0.44,0.33,0.04,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2019
+MKT,4950,1.0,Selling Medical Devices,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4950,2019
+MKT,4950,2.0,Applied Selling,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kevin scott chase,,MKT-4950,2019
+ML,2010,1.0,Leadership Development I,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2010,2019
+ML,2010,3.0,Leadership Development I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2010,2019
+ML,3010,1.0,Advanced Leadership I,0.79,0.16,0.0,0.05,0.0,0.0,0.0,0.0,justin robert merhar,,ML-3010,2019
+MSE,2100,1.0,Intro to Materials Science,0.25,0.43,0.22,0.04,0.01,0.0,0.0,0.04,nancy birkner,,MSE-2100,2019
+MSE,2100,2.0,Intro to Materials Science,0.44,0.28,0.18,0.08,0.01,0.0,0.0,0.01,rakhee pani,,MSE-2100,2019
+MSE,2100,3.0,Intro to Materials Science,0.23,0.43,0.2,0.07,0.03,0.0,0.0,0.03,mark alan johnson,,MSE-2100,2019
+MSE,2100,4.0,Intro to Materials Science,0.65,0.21,0.05,0.02,0.04,0.0,0.0,0.02,rakhee pani,,MSE-2100,2019
+MSE,2100,5.0,Intro to Materials Science,0.06,0.56,0.19,0.13,0.06,0.0,0.0,0.0,olga kuksenok,,MSE-2100,2019
+MSE,2100,6.0,Intro to Materials Science,0.24,0.23,0.26,0.08,0.11,0.0,0.0,0.08,olga kuksenok,,MSE-2100,2019
+MSE,3260,1.0,Thermo of Materials,0.36,0.28,0.26,0.04,0.06,0.0,0.0,0.0,fei peng,,MSE-3260,2019
+MSE,3260,2.0,Thermo of Materials,0.34,0.32,0.22,0.1,0.02,0.0,0.0,0.0,fei peng,,MSE-3260,2019
+MSE,3910,1.0,Research Fundamentals,0.74,0.1,0.03,0.06,0.06,0.0,0.0,0.0,ulf daniel schiller,,MSE-3910,2019
+MSE,4130,1.0,Noncrystalline Materials,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,,MSE-4130,2019
+MSE,4150,1.0,Polymer Science & Engineering,0.44,0.35,0.06,0.06,0.06,0.0,0.0,0.03,olin mefford,,MSE-4150,2019
+MSE,4150,2.0,Polymer Science & Engineering,0.5,0.26,0.24,0.0,0.0,0.0,0.0,0.0,igor luzinov,,MSE-4150,2019
+MSE,4320,1.0,Manuf Proc & Systems,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,john sanders,,MSE-4320,2019
+MSE,4580,1.0,Surf Phen in Ms&E,0.3,0.2,0.4,0.0,0.0,0.0,0.0,0.1,konstantin german kornev,,MSE-4580,2019
+MSE,4910,1.0,Undergraduate Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ulf daniel schiller,,MSE-4910,2019
+MSE,8100,1.0,Fundamentals of Materials Sci,0.61,0.32,0.07,0.0,0.0,0.0,0.0,0.0,igor luzinov,,MSE-8100,2019
+MSE,8190,1.0,Inorgan Mater Characterization,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,luiz gustavo jacobsohn,,MSE-8190,2019
+MSE,8260,1.0,Phase Equil Mat Sys,0.18,0.71,0.12,0.0,0.0,0.0,0.0,0.0,stephen foulger,,MSE-8260,2019
+MSE,8270,1.0,Kin of Phase Tran,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,konstantin german kornev,,MSE-8270,2019
+MSE,8510,1.0,Polymer Science I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,marek urban,,MSE-8510,2019
+MUSC,1110,4.0,Beginning Class Guitar,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,david stevenson,,MUSC-1110,2019
+MUSC,1420,1.0,Music Theory I,0.76,0.06,0.12,0.0,0.0,0.0,0.0,0.06,linda li-bleuel,,MUSC-1420,2019
+MUSC,1430,1.0,Aural Skills I,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,linda li-bleuel,,MUSC-1430,2019
+MUSC,1510,2.0,Applied Music,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,,MUSC-1510,2019
+MUSC,1510,19.0,Applied Music,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,adam michael knight,,MUSC-1510,2019
+MUSC,1510,25.0,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,charles wood,,MUSC-1510,2019
+MUSC,1520,2.0,Applied Music,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,,MUSC-1520,2019
+MUSC,1520,22.0,Applied Music,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kathryn layne mauldin,,MUSC-1520,2019
+MUSC,2100,1.0,Music in the Western World,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,david conley,,MUSC-2100,2019
+MUSC,2100,5.0,Music in the Western World,0.93,0.08,0.0,0.0,0.0,0.0,0.0,0.0,timothy ray hurlburt,,MUSC-2100,2019
+MUSC,2100,6.0,Music in the Western World,0.97,0.0,0.03,0.0,0.0,0.0,0.0,0.0,david conley,,MUSC-2100,2019
+MUSC,2100,7.0,Music in the Western World,0.42,0.39,0.13,0.03,0.0,0.0,0.0,0.03,rhea beth jacobus,,MUSC-2100,2019
+MUSC,2100,8.0,Music in the Western World,0.41,0.41,0.03,0.0,0.06,0.0,0.0,0.09,rhea beth jacobus,,MUSC-2100,2019
+MUSC,2100,11.0,Music in the Western World,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,leslie taylor warlick,,MUSC-2100,2019
+MUSC,2100,12.0,Music in the Western World,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,lea kibler,,MUSC-2100,2019
+MUSC,2100,13.0,Music in the Western World,0.93,0.05,0.0,0.0,0.0,0.0,0.0,0.02,david conley,,MUSC-2100,2019
+MUSC,2100,15.0,Music in West World (HON),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,True,MUSC-2100,2019
+MUSC,2510,2.0,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edward doyel,,MUSC-2510,2019
+MUSC,3080,1.0,Surv of Broadway I,0.67,0.11,0.11,0.0,0.11,0.0,0.0,0.0,lisa sain odom,,MUSC-3080,2019
+MUSC,3110,1.0,History of American Music,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,ned hosler,,MUSC-3110,2019
+MUSC,3120,1.0,History of Jazz,0.6,0.05,0.1,0.1,0.15,0.0,0.0,0.0,eric lapin,,MUSC-3120,2019
+MUSC,3140,1.0,World Music,0.68,0.16,0.1,0.03,0.0,0.0,0.0,0.03,paul buyer,,MUSC-3140,2019
+MUSC,3170,1.0,Hist of Country Mus,0.78,0.16,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3170,2019
+MUSC,3180,1.0,Hist of Audio Tech,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,bruce allen whisler,,MUSC-3180,2019
+MUSC,3610,1.0,Marching Band,0.99,0.0,0.0,0.0,0.0,0.0,0.0,0.01,mark spede,,MUSC-3610,2019
+MUSC,3700,1.0,Clemson University Singers,0.95,0.03,0.02,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,,MUSC-3700,2019
+MUSC,3720,1.0,Men's Chorus,0.94,0.02,0.0,0.0,0.0,0.0,0.0,0.04,anthony bernarducci,,MUSC-3720,2019
+MUSC,4150,1.0,Music Hist to 1750,0.53,0.33,0.13,0.0,0.0,0.0,0.0,0.0,linda dzuris,,MUSC-4150,2019
+NPL,3000,1.0,Nonprofit Leadership,0.29,0.67,0.0,0.0,0.0,0.0,0.0,0.04,bonnie westbury stevens,,NPL-3000,2019
+NPL,3000,2.0,Nonprofit Leadership,0.21,0.58,0.17,0.0,0.0,0.0,0.0,0.04,bonnie westbury stevens,,NPL-3000,2019
+NPL,3000,3.0,Nonprofit Leadership,0.72,0.24,0.0,0.04,0.0,0.0,0.0,0.0,christina marie mazer,,NPL-3000,2019
+NPL,3000,4.0,Nonprofit Leadership,0.56,0.32,0.12,0.0,0.0,0.0,0.0,0.0,corey douglas brookover,,NPL-3000,2019
+NPL,3000,5.0,Nonprofit Leadership,0.41,0.48,0.07,0.0,0.04,0.0,0.0,0.0,corey douglas brookover,,NPL-3000,2019
+NPL,3000,6.0,Nonprofit Leadership,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,corey douglas brookover,,NPL-3000,2019
+NPL,3000,7.0,Nonprofit Leadership,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,corey douglas brookover,,NPL-3000,2019
+NPL,3000,8.0,Nonprofit Leadership,0.74,0.15,0.04,0.07,0.0,0.0,0.0,0.0,christina marie mazer,,NPL-3000,2019
+NPL,3000,9.0,Nonprofit Leadership,0.63,0.3,0.04,0.0,0.0,0.0,0.0,0.04,christina marie mazer,,NPL-3000,2019
+NPL,3010,1.0,NPL Stakeholders,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,christina marie mazer,,NPL-3010,2019
+NPL,3020,1.0,NPL Fundraising,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,joan laura phillips,,NPL-3020,2019
+NPL,3030,1.0,NPL Personnel,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,joan laura phillips,,NPL-3030,2019
+NPL,3040,1.0,NPL Risk Management,0.74,0.13,0.13,0.0,0.0,0.0,0.0,0.0,daniel morgan anderson,,NPL-3040,2019
+NPL,3050,1.0,Strat Social Media for NP Org,0.81,0.11,0.05,0.0,0.0,0.0,0.0,0.03,randi alexandra plake,,NPL-3050,2019
+NPL,3050,2.0,Strat Social Media for NP Org,0.83,0.14,0.0,0.02,0.0,0.0,0.0,0.0,randi alexandra plake,,NPL-3050,2019
+NURS,1020,3.0,Nrsg Success Skills,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,janice garrison lanham,,NURS-1020,2019
+NURS,1400,1.0,Comp App Hlth Care,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,nancy meehan,,NURS-1400,2019
+NURS,1400,2.0,Comp App Hlth Care,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,janice garrison lanham,,NURS-1400,2019
+NURS,3000,1.0,Seminar- Leadership University,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,janice garrison lanham,,NURS-3000,2019
+NURS,3030,1.0,Nursing of Adults,0.33,0.6,0.04,0.0,0.0,0.0,0.0,0.02,lena marie burgess,,NURS-3030,2019
+NURS,3040,101.0,Pathophysiology,0.4,0.4,0.15,0.03,0.0,0.0,0.0,0.02,catherine sikkema murton,,NURS-3040,2019
+NURS,3040,201.0,Pathophysiology,0.24,0.66,0.07,0.0,0.01,0.0,0.0,0.01,amy boggs garrison,,NURS-3040,2019
+NURS,3040,400.0,Pathophysiology,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,amy boggs garrison,,NURS-3040,2019
+NURS,3040,401.0,Pathophysiology,0.63,0.27,0.07,0.0,0.03,0.0,0.0,0.0,amy boggs garrison,,NURS-3040,2019
+NURS,3050,1.0,Psychosocial Nursing,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.02,kevin earle busby,,NURS-3050,2019
+NURS,3100,1.0,Health Assessment,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,tiffany leah stewart,,NURS-3100,2019
+NURS,3100,401.0,Health Assessment,0.83,0.13,0.0,0.0,0.03,0.0,0.0,0.0,jason thrift,,NURS-3100,2019
+NURS,3110,1.0,Hlth Promotion Across Lifespan,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,janice garrison lanham,,NURS-3110,2019
+NURS,3120,101.0,Foundations of Nursing,0.51,0.47,0.0,0.0,0.0,0.0,0.0,0.02,jennifer elizabeth bagwell,,NURS-3120,2019
+NURS,3120,201.0,Foundations of Nursing,0.31,0.65,0.01,0.01,0.0,0.0,0.0,0.01,terri abercrombie teramano,,NURS-3120,2019
+NURS,3120,401.0,Foundations of Nursing,0.67,0.3,0.0,0.0,0.03,0.0,0.0,0.0,terri abercrombie teramano,,NURS-3120,2019
+NURS,3200,1.0,Prof in Nurs,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3200,2019
+NURS,3230,101.0,Gerontology Nursing,0.96,0.02,0.0,0.0,0.0,0.0,0.0,0.02,tawny jenna mcintosh,,NURS-3230,2019
+NURS,3300,1.0,Research in Nursing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-3300,2019
+NURS,3300,2.0,Research in Nursing,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,hyewon shin,,NURS-3300,2019
+NURS,3330,1.0,Health Care Genetics,0.58,0.36,0.04,0.0,0.0,0.0,0.0,0.02,linda ward,,NURS-3330,2019
+NURS,3400,101.0,Pharmther Nursing,0.36,0.44,0.15,0.02,0.02,0.0,0.0,0.02,catherine sikkema murton,,NURS-3400,2019
+NURS,3400,201.0,Pharmther Nursing,0.32,0.56,0.09,0.01,0.0,0.0,0.0,0.01,jenna lynn seawright,,NURS-3400,2019
+NURS,3400,401.0,Pharmther Nursing,0.57,0.37,0.03,0.0,0.03,0.0,0.0,0.0,jenna lynn seawright,,NURS-3400,2019
+NURS,3600,400.0,Social Determinants in Health,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,,NURS-3600,2019
+NURS,4010,1.0,Mental Health Nurs,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,lindsey rebecca garrard,,NURS-4010,2019
+NURS,4030,101.0,Complex Nursing of Adults,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen rankin ewing,,NURS-4030,2019
+NURS,4030,202.0,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john joseph whitcomb,,NURS-4030,2019
+NURS,4030,402.0,Complex Nursing of Adults,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john joseph whitcomb,,NURS-4030,2019
+NURS,4060,400.0,Issues in Professionalism,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,,NURS-4060,2019
+NURS,4110,1.0,Nursing of Children,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0, elizabeth fisher,,NURS-4110,2019
+NURS,4120,1.0,Nurs Women and Fam,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,erin nicole shepherd,,NURS-4120,2019
+NURS,8050,400.0,Pharmaco Adv Nurs,0.33,0.5,0.08,0.0,0.04,0.0,0.0,0.04,tracy king fasolino,,NURS-8050,2019
+NURS,8050,401.0,Pharmaco Adv Nurs,0.33,0.61,0.06,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8050,2019
+NURS,8060,400.0,Advan Assessment for Nursing,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,,NURS-8060,2019
+NURS,8090,400.0,Pathophysiology,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,tracy brock lowe,,NURS-8090,2019
+NURS,8190,400.0,Developing Family,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-8190,2019
+NURS,8200,400.0,Child & Adol Nursing,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-8200,2019
+NURS,9010,1.0,"DNP Role, Theory & Philosophy",0.6,0.0,0.0,0.0,0.0,0.0,0.0,0.4,jean ellen zavertnik,,NURS-9010,2019
+NURS,9020,1.0,DNP Clinical Epidem & Biostats,0.4,0.2,0.0,0.0,0.2,0.0,0.0,0.2,veronica parker,,NURS-9020,2019
+NUTR,2030,1.0,Intro Princ of Human Nutrition,0.91,0.08,0.01,0.0,0.0,0.0,0.0,0.0,bridgit denise corbett,,NUTR-2030,2019
+NUTR,2030,2.0,Intro Princ of Human Nutrition,0.71,0.24,0.02,0.02,0.0,0.0,0.0,0.0,bridgit denise corbett,,NUTR-2030,2019
+NUTR,2040,1.0,Nutrition Across Life Cycle,0.63,0.24,0.11,0.03,0.0,0.0,0.0,0.0,bridgit denise corbett,,NUTR-2040,2019
+NUTR,2050,400.0,Nutrition for Nursing Prof,0.37,0.46,0.17,0.0,0.0,0.0,0.0,0.0,elizabeth lacey durrance,,NUTR-2050,2019
+NUTR,2160,1.0,Evidence-Based Nutrition,0.84,0.08,0.05,0.0,0.02,0.0,0.0,0.01,angela fraser,,NUTR-2160,2019
+NUTR,3020,1.0,Nutrition Assessment,0.63,0.34,0.02,0.0,0.02,0.0,0.0,0.0,elliot jesch,,NUTR-3020,2019
+NUTR,4240,1.0,Medical Nutr Thera I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4240,2019
+NUTR,4510,1.0,Human Nutrition & Metabolism I,0.33,0.24,0.21,0.13,0.08,0.0,0.0,0.02,elliot jesch,,NUTR-4510,2019
+PA,1010,1.0,Intro to Perf Arts,0.5,0.25,0.13,0.06,0.06,0.0,0.0,0.0,david hartmann,,PA-1010,2019
+PA,2790,1.0,Perf Arts Pract I,0.47,0.0,0.06,0.0,0.24,0.0,0.0,0.24,kenneth moore,,PA-2790,2019
+PA,3010,1.0,Princip of Arts Administration,0.72,0.17,0.06,0.0,0.0,0.0,0.0,0.06,richard goodstein,,PA-3010,2019
+PA,4010,1.0,Capstone Project,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,bruce allen whisler,,PA-4010,2019
+PADM,7020,400.0,Research Methods,0.88,0.06,0.0,0.0,0.0,0.0,0.0,0.06,ronald chrestman,,PADM-7020,2019
+PADM,8210,400.0,Perspectives on Public Admin,0.67,0.22,0.0,0.0,0.0,0.0,0.0,0.11,thomas walker,,PADM-8210,2019
+PADM,8220,401.0,Public Policy Process,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,ekaterina yazykova mellott,,PADM-8220,2019
+PADM,8290,400.0,Public Financial Management,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,robert frager,,PADM-8290,2019
+PADM,8410,400.0,Public Data Analysis,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,ryan joseph gagnon,,PADM-8410,2019
+PADM,8420,400.0,GIS for Public Administrators,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lawrence white,,PADM-8420,2019
+PADM,8670,401.0,State Government Admin,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,,PADM-8670,2019
+PAS,3010,1.0,Intro to Pan African Studies,0.51,0.41,0.02,0.0,0.04,0.0,0.0,0.01,abel bartley,,PAS-3010,2019
+PDBE,8150,1.0,Research Design in EDP,0.43,0.29,0.14,0.0,0.14,0.0,0.0,0.0,mickey lauria,,PDBE-8150,2019
+PES,1040,1.0,Introduction to Plant Sciences,0.69,0.24,0.02,0.0,0.0,0.0,0.0,0.04,paula agudelo,,PES-1040,2019
+PES,2020,1.0,Soils,0.14,0.51,0.26,0.05,0.0,0.0,0.0,0.04,dara michelle park,,PES-2020,2019
+PES,3150,1.0,Environment and Agriculture,0.29,0.67,0.0,0.0,0.05,0.0,0.0,0.0,vidya appukuttan suseela,,PES-3150,2019
+PES,4090,1.0,Biology of Invasive Plants,0.67,0.17,0.08,0.0,0.08,0.0,0.0,0.0,nishanth tharayil-santhakumar,,PES-4090,2019
+PES,4210,1.0,Princ of Field Crop Production,0.39,0.5,0.0,0.06,0.0,0.0,0.0,0.06,sruthi narayanan kutty,,PES-4210,2019
+PES,4850,1.0,Environmental Soil Chemistry,0.55,0.27,0.0,0.0,0.18,0.0,0.0,0.0,haibo liu,,PES-4850,2019
+PES,4960,1.0,Sel Top: Soil Judging,0.57,0.0,0.0,0.14,0.14,0.0,0.0,0.14,dara michelle park,,PES-4960,2019
+PHIL,1010,2.0,Intro to Philosophic Problems,0.51,0.43,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-1010,2019
+PHIL,1010,3.0,Intro to Philosophic Problems,0.56,0.35,0.06,0.03,0.0,0.0,0.0,0.0,christopher grau,,PHIL-1010,2019
+PHIL,1010,7.0,Intro to Philosophic Problems,0.71,0.12,0.0,0.0,0.06,0.0,0.0,0.12,david stegall,,PHIL-1010,2019
+PHIL,1010,8.0,Intro to Philosophic Problems,0.53,0.35,0.0,0.06,0.0,0.0,0.0,0.06,david stegall,,PHIL-1010,2019
+PHIL,1010,9.0,Intro to Philosophic Problems,0.44,0.36,0.08,0.0,0.03,0.0,0.0,0.08,david stegall,,PHIL-1010,2019
+PHIL,1020,1.0,Introduction to Logic,0.4,0.37,0.14,0.06,0.03,0.0,0.0,0.0,adam gies,,PHIL-1020,2019
+PHIL,1020,3.0,Introduction to Logic,0.4,0.31,0.29,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-1020,2019
+PHIL,1020,4.0,Introduction to Logic,0.47,0.31,0.0,0.03,0.08,0.0,0.0,0.11,craig bacon,,PHIL-1020,2019
+PHIL,1020,7.0,Introduction to Logic,0.37,0.2,0.09,0.09,0.03,0.0,0.0,0.23,david stegall,,PHIL-1020,2019
+PHIL,1020,11.0,Introduction to Logic,0.61,0.14,0.11,0.03,0.0,0.0,0.0,0.11,david stegall,,PHIL-1020,2019
+PHIL,1020,15.0,Introduction to Logic,0.39,0.33,0.22,0.06,0.0,0.0,0.0,0.0,adam gies,,PHIL-1020,2019
+PHIL,1020,16.0,Introduction to Logic,0.16,0.53,0.21,0.05,0.0,0.0,0.0,0.05,edyta joanna kuzian,,PHIL-1020,2019
+PHIL,1020,17.0,Introduction to Logic,0.55,0.26,0.11,0.0,0.03,0.0,0.0,0.05,edyta joanna kuzian,,PHIL-1020,2019
+PHIL,1020,18.0,Introduction to Logic,0.78,0.13,0.03,0.0,0.0,0.0,0.0,0.06,adam paul omelianchuk,,PHIL-1020,2019
+PHIL,1020,19.0,Introduction to Logic,0.69,0.11,0.11,0.0,0.0,0.0,0.0,0.09,adam paul omelianchuk,,PHIL-1020,2019
+PHIL,1020,20.0,Introduction to Logic,0.85,0.12,0.0,0.03,0.0,0.0,0.0,0.0,adam paul omelianchuk,,PHIL-1020,2019
+PHIL,1030,2.0,Introduction to Ethics,0.79,0.11,0.0,0.0,0.05,0.0,0.0,0.05,stephen satris,,PHIL-1030,2019
+PHIL,1030,3.0,Introduction to Ethics,0.4,0.34,0.14,0.06,0.0,0.0,0.0,0.06,david robert antonini,,PHIL-1030,2019
+PHIL,1030,6.0,Introduction to Ethics,0.44,0.44,0.11,0.0,0.0,0.0,0.0,0.0,charles starkey,,PHIL-1030,2019
+PHIL,1030,8.0,Introduction to Ethics,0.79,0.06,0.06,0.0,0.03,0.0,0.0,0.06,winthrop brent hepburn,,PHIL-1030,2019
+PHIL,1030,9.0,Introduction to Ethics,0.5,0.44,0.03,0.0,0.0,0.0,0.0,0.03,edyta joanna kuzian,,PHIL-1030,2019
+PHIL,1030,10.0,Introduction to Ethics,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,,PHIL-1030,2019
+PHIL,3040,1.0,Moral Philosophy,0.4,0.47,0.07,0.0,0.07,0.0,0.0,0.0,todd may,,PHIL-3040,2019
+PHIL,3150,1.0,Ancient Philosophy,0.39,0.42,0.09,0.06,0.0,0.0,0.0,0.03,stephen satris,,PHIL-3150,2019
+PHIL,3210,1.0,Crime & Punishment,0.21,0.63,0.11,0.0,0.0,0.0,0.0,0.05,daniel wueste,,PHIL-3210,2019
+PHIL,3260,1.0,Science and Values,0.68,0.26,0.03,0.0,0.0,0.0,0.0,0.03,david robert antonini,,PHIL-3260,2019
+PHIL,3260,2.0,Science and Values,0.62,0.29,0.06,0.0,0.0,0.0,0.0,0.03,david robert antonini,,PHIL-3260,2019
+PHIL,3300,1.0,Animal Rights,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,todd may,,PHIL-3300,2019
+PHIL,3430,1.0,Philosophy of Law,0.29,0.47,0.18,0.0,0.0,0.0,0.0,0.06,brookes colyton brown,,PHIL-3430,2019
+PHIL,3440,1.0,Business Ethics,0.17,0.5,0.13,0.0,0.04,0.0,0.0,0.17,brookes colyton brown,,PHIL-3440,2019
+PHIL,3450,1.0,Environmental Ethics,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,adam paul omelianchuk,,PHIL-3450,2019
+PHIL,3480,1.0,Philosophies of Art,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,christopher grau,,PHIL-3480,2019
+PHIL,3510,1.0,Phil of Emotion,0.5,0.33,0.06,0.0,0.0,0.0,0.0,0.11,charles starkey,,PHIL-3510,2019
+PHIL,4020,2.0,Topics in Philosophy,0.54,0.31,0.08,0.0,0.0,0.0,0.0,0.08,diane perpich,,PHIL-4020,2019
+PHIL,4920,2.0,Creative Inquiry in Philosophy,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,stephen satris,,PHIL-4920,2019
+PHSC,1180,1.0,Intro to Phy & Astr for Ele Ed,0.77,0.18,0.03,0.02,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1180,2019
+PHYS,1220,1.0,Physics with Calculus I,0.3,0.26,0.26,0.09,0.06,0.0,0.0,0.04,lih-sin the,,PHYS-1220,2019
+PHYS,1220,2.0,Physics with Calculus I,0.21,0.31,0.27,0.07,0.06,0.0,0.0,0.07,lih-sin the,,PHYS-1220,2019
+PHYS,1220,3.0,Physics W/Cal I (HON),0.42,0.33,0.08,0.0,0.0,0.0,0.0,0.17,joshua alper,True,PHYS-1220,2019
+PHYS,1220,4.0,Physics with Calculus I,0.27,0.32,0.05,0.18,0.09,0.0,0.0,0.09,joshua alper,,PHYS-1220,2019
+PHYS,1240,1.0,Physics Lab I,0.07,0.14,0.5,0.14,0.07,0.0,0.0,0.07,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,2.0,Physics Lab I,0.09,0.73,0.09,0.09,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,3.0,Physics Lab I,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,4.0,Physics Lab I,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,5.0,Physics Lab I,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,6.0,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,7.0,Physics Lab I,0.5,0.39,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,8.0,Physics Lab I,0.61,0.28,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,9.0,Physics Lab I,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,10.0,Physics Lab I,0.76,0.12,0.0,0.0,0.0,0.0,0.0,0.12,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,11.0,Physics Lab I,0.63,0.19,0.13,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,13.0,Physics Lab I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,14.0,Physics Lab I,0.33,0.61,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,15.0,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,16.0,Physics Lab I,0.27,0.45,0.27,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,17.0,Physics Lab I,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,18.0,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,19.0,Physics Lab I,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-1240,2019
+PHYS,1240,21.0,Physics Lab I,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-1240,2019
+PHYS,2070,1.0,General Physics I,0.24,0.23,0.2,0.15,0.1,0.0,0.0,0.08,amy liann pope,,PHYS-2070,2019
+PHYS,2070,2.0,General Physics I,0.31,0.29,0.21,0.08,0.06,0.0,0.0,0.05,amy liann pope,,PHYS-2070,2019
+PHYS,2070,3.0,General Physics I,0.19,0.31,0.27,0.07,0.1,0.0,0.0,0.06,amy liann pope,,PHYS-2070,2019
+PHYS,2070,4.0,General Physics I,0.23,0.31,0.23,0.13,0.08,0.0,0.0,0.02,david edward connick,,PHYS-2070,2019
+PHYS,2080,1.0,General Physics II,0.42,0.34,0.13,0.09,0.03,0.0,0.0,0.0,david edward connick,,PHYS-2080,2019
+PHYS,2090,1.0,Gen Phys Lab I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,2.0,Gen Phys Lab I,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,3.0,Gen Phys Lab I,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,4.0,Gen Phys Lab I,0.83,0.09,0.0,0.0,0.0,0.0,0.0,0.09,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,5.0,Gen Phys Lab I,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,6.0,Gen Phys Lab I,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,7.0,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,8.0,Gen Phys Lab I,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,9.0,Gen Phys Lab I,0.65,0.22,0.09,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,10.0,Gen Phys Lab I,0.71,0.17,0.0,0.0,0.0,0.0,0.0,0.13,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,11.0,Gen Phys Lab I,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,12.0,Gen Phys Lab I,0.63,0.21,0.0,0.04,0.04,0.0,0.0,0.08,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,13.0,Gen Phys Lab I,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,14.0,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,15.0,Gen Phys Lab I,0.79,0.04,0.08,0.0,0.0,0.0,0.0,0.08,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,16.0,Gen Phys Lab I,0.83,0.04,0.09,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,17.0,Gen Phys Lab I,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,18.0,Gen Phys Lab I,0.58,0.25,0.04,0.0,0.04,0.0,0.0,0.08,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,19.0,Gen Phys Lab I,0.63,0.33,0.0,0.04,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,20.0,Gen Phys Lab I,0.7,0.22,0.09,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,21.0,Gen Phys Lab I,0.33,0.54,0.04,0.0,0.08,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,22.0,Gen Phys Lab I,0.61,0.3,0.04,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,23.0,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,24.0,Gen Phys Lab I,0.5,0.38,0.0,0.0,0.04,0.0,0.0,0.08,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,25.0,Gen Phys Lab I,0.5,0.46,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,26.0,Gen Phys Lab I,0.57,0.35,0.04,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,,PHYS-2090,2019
+PHYS,2090,27.0,Gen Phys Lab I,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2090,2019
+PHYS,2100,1.0,Gen Phys Lab II,0.33,0.63,0.04,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2019
+PHYS,2100,2.0,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2019
+PHYS,2100,3.0,Gen Phys Lab II,0.63,0.33,0.0,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2019
+PHYS,2100,4.0,Gen Phys Lab II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2019
+PHYS,2100,6.0,Gen Phys Lab II,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2019
+PHYS,2100,7.0,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2019
+PHYS,2100,8.0,Gen Phys Lab II,0.42,0.5,0.04,0.0,0.04,0.0,0.0,0.0,daniel ross thompson,,PHYS-2100,2019
+PHYS,2100,9.0,Gen Phys Lab II,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ross thompson,,PHYS-2100,2019
+PHYS,2210,1.0,Physics with Calculus II,0.13,0.43,0.29,0.09,0.03,0.0,0.0,0.03,jason stratford brown,,PHYS-2210,2019
+PHYS,2210,2.0,Physics with Calculus II,0.21,0.47,0.24,0.05,0.01,0.0,0.0,0.02,jason stratford brown,,PHYS-2210,2019
+PHYS,2210,3.0,Physics with Calculus II,0.37,0.48,0.11,0.02,0.0,0.0,0.0,0.01,chad sosolik,,PHYS-2210,2019
+PHYS,2210,4.0,Physics with Calculus II,0.25,0.51,0.18,0.02,0.02,0.0,0.0,0.01,chad sosolik,,PHYS-2210,2019
+PHYS,2210,5.0,Physics w/Calculus II(HON),0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,joan marler,True,PHYS-2210,2019
+PHYS,2220,1.0,Physics with Calculus III,0.74,0.11,0.05,0.0,0.0,0.0,0.0,0.11,murray daw,,PHYS-2220,2019
+PHYS,2230,1.0,Physics Lab II,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,2.0,Physics Lab II,0.35,0.65,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,3.0,Physics Lab II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,4.0,Physics Lab II,0.17,0.78,0.06,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,5.0,Physics Lab II,0.56,0.39,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,6.0,Physics Lab II,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,7.0,Physics Lab II,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,9.0,Physics Lab II,0.29,0.65,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,10.0,Physics Lab II,0.22,0.72,0.0,0.0,0.06,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,11.0,Physics Lab II,0.17,0.83,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,13.0,Physics Lab II,0.65,0.29,0.0,0.0,0.0,0.0,0.0,0.06,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,14.0,Physics Lab II,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2230,17.0,Physics Lab II,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,daniel ross thompson,,PHYS-2230,2019
+PHYS,2450,1.0,Physics of Climate,0.37,0.37,0.09,0.05,0.01,0.0,0.0,0.11,jens oberheide,,PHYS-2450,2019
+PHYS,3000,1.0,Intro to Research,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,sean brittain,,PHYS-3000,2019
+PHYS,3150,1.0,Intro to Computational Physics,0.4,0.2,0.27,0.0,0.0,0.0,0.0,0.13,jason stratford brown,,PHYS-3150,2019
+PHYS,3210,1.0,Mechanics I,0.17,0.41,0.17,0.07,0.0,0.0,0.0,0.17,stephen roland kaeppler,,PHYS-3210,2019
+PHYS,3250,1.0,Exper Physics I,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,jianbo gao,,PHYS-3250,2019
+PHYS,3990,7.0,CI: K-12 STEM Competitions,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,domnita catalina marinescu,,PHYS-3990,2019
+PHYS,4410,1.0,Electromagnetics I,0.24,0.41,0.29,0.0,0.06,0.0,0.0,0.0,xian lu,,PHYS-4410,2019
+PHYS,4520,1.0,Nuclear and Particle Physics,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,endre andras takacs,,PHYS-4520,2019
+PHYS,4550,1.0,Quantum Physics I,0.15,0.46,0.38,0.0,0.0,0.0,0.0,0.0,gerald lehmacher,,PHYS-4550,2019
+PHYS,6550,1.0,Quantum Physics I,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,gerald lehmacher,,PHYS-6550,2019
+PHYS,8110,1.0,Meth of Theor Phys I,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,feng ding,,PHYS-8110,2019
+PHYS,8210,1.0,Classical Mech I,0.5,0.4,0.0,0.0,0.0,0.0,0.0,0.1,dieter hartmann,,PHYS-8210,2019
+PHYS,9510,1.0,Quantum Mech I,0.5,0.33,0.0,0.0,0.0,0.0,0.0,0.17,sumanta tewari,,PHYS-9510,2019
+PKSC,1010,1.0,Pkgsc Orientation,0.9,0.05,0.01,0.01,0.0,0.0,0.0,0.01,patricia guerra marcondes,,PKSC-1010,2019
+PKSC,1020,1.0,Intro to Pkg Sci,0.08,0.31,0.33,0.18,0.05,0.0,0.0,0.05,heather batt,,PKSC-1020,2019
+PKSC,2010,1.0,Pkg Perishable Prod,0.13,0.28,0.09,0.09,0.22,0.0,0.0,0.19,heather batt,,PKSC-2010,2019
+PKSC,2020,1.0,Packaging Mtl & Mfg,0.23,0.4,0.27,0.1,0.0,0.0,0.0,0.0,patricia guerra marcondes,,PKSC-2020,2019
+PKSC,2040,1.0,Container Systems,0.31,0.38,0.15,0.0,0.0,0.0,0.0,0.15,patricia guerra marcondes,,PKSC-2040,2019
+PKSC,2200,1.0,Product & Pkg Design,0.73,0.14,0.08,0.0,0.05,0.0,0.0,0.0,haley ellis appleby,,PKSC-2200,2019
+PKSC,3200,1.0,Pkg Design Theory,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,rupert hurley,,PKSC-3200,2019
+PKSC,4010,1.0,Packaging Machinery,0.42,0.38,0.17,0.01,0.01,0.0,0.0,0.0,anthony louis pometto,,PKSC-4010,2019
+PKSC,4030,1.0,Packaging Career Preparation,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2019
+PKSC,4040,1.0,Protective Packaging Prop/Prin,0.23,0.44,0.23,0.03,0.04,0.0,0.0,0.03,gregory batt,,PKSC-4040,2019
+PKSC,4160,1.0,Application of Polymers in Pkg,0.34,0.56,0.08,0.0,0.02,0.0,0.0,0.0,alicia cutler campbell,,PKSC-4160,2019
+PKSC,4200,1.0,Package Design & Development,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2019
+PKSC,4540,1.0,Product & Pkg Evaluation Lab,0.13,0.6,0.2,0.0,0.0,0.0,0.0,0.07,gregory batt,,PKSC-4540,2019
+PKSC,4540,2.0,Product & Pkg Evaluation Lab,0.19,0.5,0.06,0.06,0.13,0.0,0.0,0.06,gregory batt,,PKSC-4540,2019
+PKSC,4540,3.0,Product & Pkg Evaluation Lab,0.33,0.6,0.07,0.0,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2019
+PKSC,4540,4.0,Product & Pkg Evaluation Lab,0.09,0.45,0.27,0.09,0.0,0.0,0.0,0.09,gregory batt,,PKSC-4540,2019
+PKSC,4540,5.0,Product & Pkg Evaluation Lab,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,gregory batt,,PKSC-4540,2019
+PKSC,4640,1.0,Food & Health Care Pkg Systems,0.58,0.33,0.04,0.02,0.02,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2019
+PKSC,4990,7.0,Creative Inquiry Pkg Science,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,rupert hurley,,PKSC-4990,2019
+PLPA,3100,1.0,Principles of Plant Pathology,0.26,0.22,0.3,0.19,0.04,0.0,0.0,0.0,steven nye jeffers,,PLPA-3100,2019
+PLPA,4250,1.0,Introductory Mycology,0.3,0.5,0.1,0.0,0.0,0.0,0.0,0.1,julia louise kerrigan,,PLPA-4250,2019
+PLPA,8020,1.0,Principles of Plant Pathology,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,steven nye jeffers,,PLPA-8020,2019
+POSC,1010,1.0,Amer National Govt,0.42,0.35,0.16,0.02,0.04,0.0,0.0,0.02,ethan craig busby,,POSC-1010,2019
+POSC,1010,2.0,Amer National Govt,0.32,0.32,0.22,0.12,0.01,0.0,0.0,0.0,robert carey,,POSC-1010,2019
+POSC,1020,1.0,Intro Intl Relations,0.31,0.41,0.13,0.07,0.02,0.0,0.0,0.06,steven vincent miller,,POSC-1020,2019
+POSC,1020,2.0,Intro Intl Relations,0.4,0.35,0.13,0.03,0.03,0.0,0.0,0.06,tara elizabeth trask,,POSC-1020,2019
+POSC,1020,3.0,Intro Intl Relations,0.56,0.29,0.07,0.01,0.03,0.0,0.0,0.04,tara elizabeth trask,,POSC-1020,2019
+POSC,1020,4.0,Intro Intl Relations,0.12,0.48,0.12,0.14,0.07,0.0,0.0,0.07,joshua douglas king,,POSC-1020,2019
+POSC,1020,5.0,Intro Intl Relations,0.12,0.51,0.27,0.0,0.02,0.0,0.0,0.08,colin denby pearce,,POSC-1020,2019
+POSC,1020,6.0,Intro Intl Relations,0.41,0.36,0.12,0.01,0.06,0.0,0.0,0.04,tara elizabeth trask,,POSC-1020,2019
+POSC,1030,1.0,Intro to Political Theory,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,derek neal duplessie,,POSC-1030,2019
+POSC,1030,2.0,Intro to Political Theory,0.3,0.5,0.13,0.0,0.03,0.0,0.0,0.03,adam michael thomas,,POSC-1030,2019
+POSC,1030,3.0,Intro to Political Theory,0.27,0.43,0.2,0.0,0.0,0.0,0.0,0.1,colin denby pearce,,POSC-1030,2019
+POSC,1030,4.0,Intro to Political Theory,0.4,0.29,0.23,0.03,0.03,0.0,0.0,0.03,brandon turner,,POSC-1030,2019
+POSC,1040,1.0,Intro Compar Pol,0.44,0.28,0.19,0.04,0.0,0.0,0.0,0.06,matthew henry rhodes-purdy,,POSC-1040,2019
+POSC,1990,1.0,Intro Pol Sci,0.47,0.32,0.09,0.06,0.02,0.0,0.0,0.04,meredith-joy petersheim,,POSC-1990,2019
+POSC,3020,1.0,State and Loc Gov,0.17,0.6,0.1,0.0,0.02,0.0,0.0,0.1,bruce ransom,,POSC-3020,2019
+POSC,3050,1.0,CI in Political Sci,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,matthew henry rhodes-purdy,True,POSC-3050,2019
+POSC,3110,1.0,Model United Nations,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,xiaobo hu,,POSC-3110,2019
+POSC,3410,1.0,Quant Meth in Pol Sc,0.33,0.33,0.28,0.0,0.06,0.0,0.0,0.0,ethan craig busby,,POSC-3410,2019
+POSC,3610,1.0,International Conflict,0.28,0.22,0.18,0.04,0.22,0.0,0.0,0.06,steven vincent miller,,POSC-3610,2019
+POSC,3620,1.0,Intl Organizations,0.21,0.33,0.21,0.04,0.08,0.0,0.0,0.13,zeynep taydas,,POSC-3620,2019
+POSC,3620,2.0,Intl Organizations,0.32,0.36,0.08,0.08,0.08,0.0,0.0,0.08,zeynep taydas,,POSC-3620,2019
+POSC,3630,1.0,Us Foreign Policy,0.29,0.57,0.09,0.03,0.0,0.0,0.0,0.03,jeffrey scott peake,,POSC-3630,2019
+POSC,3710,1.0,European Politics,0.45,0.37,0.08,0.0,0.0,0.0,0.0,0.1,vladimir matic,,POSC-3710,2019
+POSC,4030,1.0,United States Congress,0.27,0.31,0.33,0.06,0.02,0.0,0.0,0.02,jeffrey allen fine,,POSC-4030,2019
+POSC,4210,1.0,Public Policy,0.17,0.33,0.33,0.06,0.0,0.0,0.0,0.11,adam warber,,POSC-4210,2019
+POSC,4300,1.0,Policy Evaluation,0.45,0.18,0.27,0.0,0.0,0.0,0.0,0.09,robert carey,,POSC-4300,2019
+POSC,4360,1.0,Law Courts Politics,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,,POSC-4360,2019
+POSC,4360,2.0,Law Courts Politics,0.74,0.24,0.03,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,,POSC-4360,2019
+POSC,4370,1.0,Constitut Law: Rights & Libert,0.4,0.5,0.05,0.0,0.0,0.0,0.0,0.05,kevin gregory vance,,POSC-4370,2019
+POSC,4380,1.0,Constitut Law: Struc of Gov,0.56,0.27,0.1,0.02,0.0,0.0,0.0,0.04,christina rose bambrick,,POSC-4380,2019
+POSC,4420,1.0,Pol Parties & Elect,0.29,0.43,0.22,0.04,0.0,0.0,0.0,0.02,laura olson,,POSC-4420,2019
+POSC,4490,1.0,Political Theory of Capitalism,0.29,0.44,0.24,0.0,0.0,0.0,0.0,0.03,colin denby pearce,,POSC-4490,2019
+POSC,4490,2.0,Political Theory of Capitalism,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,brandon turner,,POSC-4490,2019
+POSC,4500,1.0,Rights: Theory & Practice,0.28,0.44,0.17,0.06,0.0,0.0,0.0,0.06,christina rose bambrick,,POSC-4500,2019
+POSC,4550,1.0,Pol Thght of American Founding,0.52,0.37,0.11,0.0,0.0,0.0,0.0,0.0, bradley thompson,,POSC-4550,2019
+POSC,4580,1.0,Political Leadership,0.11,0.67,0.22,0.0,0.0,0.0,0.0,0.0,joshua douglas king,,POSC-4580,2019
+POSC,4760,1.0,Middle East Politics,0.5,0.38,0.0,0.0,0.06,0.0,0.0,0.06,vladimir matic,,POSC-4760,2019
+POSC,4780,1.0,Latin Amer Politics,0.63,0.23,0.09,0.0,0.06,0.0,0.0,0.0,matthew henry rhodes-purdy,,POSC-4780,2019
+POST,8990,1.0,"Markets, Gov't. & Public Pol.",0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,robert carey,,POST-8990,2019
+PRTM,1950,2.0,Pro Golf Management Seminar I,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-1950,2019
+PRTM,2110,1.0,Sts Play Rec Tourism,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew mutel browning,,PRTM-2110,2019
+PRTM,2200,1.0,Foundations of PRTM,0.16,0.66,0.18,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2200,2019
+PRTM,2200,2.0,Foundations of PRTM,0.34,0.49,0.12,0.03,0.02,0.0,0.0,0.0,teresa walton tucker,,PRTM-2200,2019
+PRTM,2260,1.0,Fnd of Mgt Adm PRTM,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2260,2019
+PRTM,2260,2.0,Fnd of Mgt Adm PRTM,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,,PRTM-2260,2019
+PRTM,2260,3.0,Fnd of Mgt Adm PRTM,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2260,2019
+PRTM,2260,4.0,Fnd of Mgt Adm PRTM,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2260,2019
+PRTM,2260,5.0,Fnd of Mgt Adm PRTM,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-2260,2019
+PRTM,2260,6.0,Fnd of Mgt Adm PRTM,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,,PRTM-2260,2019
+PRTM,2260,7.0,Fnd of Mgt Adm PRTM,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,,PRTM-2260,2019
+PRTM,2260,8.0,Fnd of Mgt Adm PRTM,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,,PRTM-2260,2019
+PRTM,2270,1.0,Prov of Leisure Exp,0.5,0.38,0.06,0.06,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2270,2019
+PRTM,2270,2.0,Prov of Leisure Exp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,,PRTM-2270,2019
+PRTM,2270,3.0,Prov of Leisure Exp,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2270,2019
+PRTM,2270,4.0,Prov of Leisure Exp,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2270,2019
+PRTM,2270,5.0,Prov of Leisure Exp,0.38,0.5,0.13,0.0,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-2270,2019
+PRTM,2270,6.0,Prov of Leisure Exp,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey townsend,,PRTM-2270,2019
+PRTM,2270,7.0,Prov of Leisure Exp,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,,PRTM-2270,2019
+PRTM,2270,8.0,Prov of Leisure Exp,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,,PRTM-2270,2019
+PRTM,2290,1.0,Competency Integration in PRTM,0.44,0.38,0.13,0.06,0.0,0.0,0.0,0.0,teresa walton tucker,,PRTM-2290,2019
+PRTM,2290,2.0,Competency Integration in PRTM,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,elizabeth dennis baldwin,,PRTM-2290,2019
+PRTM,2290,3.0,Competency Integration in PRTM,0.57,0.29,0.14,0.0,0.0,0.0,0.0,0.0,francis mcguire,,PRTM-2290,2019
+PRTM,2290,4.0,Competency Integration in PRTM,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,jamie lynn cathey,,PRTM-2290,2019
+PRTM,2290,5.0,Competency Integration in PRTM,0.38,0.38,0.19,0.06,0.0,0.0,0.0,0.0,gwynn powell,,PRTM-2290,2019
+PRTM,2290,6.0,Competency Integration in PRTM,0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,jeffrey townsend,,PRTM-2290,2019
+PRTM,2290,7.0,Competency Integration in PRTM,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,deborah anne tysor,,PRTM-2290,2019
+PRTM,2290,8.0,Competency Integration in PRTM,0.4,0.53,0.07,0.0,0.0,0.0,0.0,0.0,thomas ray clanton,,PRTM-2290,2019
+PRTM,2980,9.0,Creative Inquiry in PRTM II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,denise marie anderson,,PRTM-2980,2019
+PRTM,3050,1.0,Safety/Risk Mgt PRTM,0.43,0.3,0.13,0.1,0.0,0.0,0.0,0.03,daniel morgan anderson,,PRTM-3050,2019
+PRTM,3070,2.0,Facility Operations,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,raymond dunham,,PRTM-3070,2019
+PRTM,3200,1.0,Recreation Policy,0.8,0.0,0.1,0.05,0.0,0.0,0.0,0.05,elizabeth perry,,PRTM-3200,2019
+PRTM,3240,1.0,Assessment & Planning in RT,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-3240,2019
+PRTM,3300,1.0,Visit Ser & Interp,0.5,0.22,0.22,0.06,0.0,0.0,0.0,0.0,aby lat soukabe sene harper,,PRTM-3300,2019
+PRTM,3420,1.0,Intro to Tourism,0.5,0.35,0.06,0.03,0.0,0.0,0.0,0.06,gregory philip ramshaw,,PRTM-3420,2019
+PRTM,3430,1.0,Spl Asp of Tourist B,0.53,0.36,0.09,0.0,0.0,0.0,0.0,0.02,william norman,,PRTM-3430,2019
+PRTM,3470,1.0,Sport Tourism,0.36,0.36,0.23,0.0,0.0,0.0,0.0,0.05,gregory philip ramshaw,,PRTM-3470,2019
+PRTM,3520,1.0,Camp Org and Admin,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,alexsandra dubin,,PRTM-3520,2019
+PRTM,3600,1.0,Recreation & Amateur Sport Mgt,0.35,0.35,0.17,0.04,0.0,0.0,0.0,0.09,skye gerald arthur-banning,,PRTM-3600,2019
+PRTM,3900,8.0,PGA GM Player Development,0.7,0.15,0.1,0.0,0.0,0.0,0.0,0.05,richard lucas,,PRTM-3900,2019
+PRTM,3910,1.0,Issues & Trends in Event Mgmt.,0.92,0.04,0.0,0.0,0.0,0.0,0.0,0.04,stephanie perler garst,,PRTM-3910,2019
+PRTM,3920,1.0,Special Event Management,0.95,0.03,0.03,0.0,0.0,0.0,0.0,0.0,kenneth backman,,PRTM-3920,2019
+PRTM,4030,1.0,Elem of Rec/Pk Plan,0.46,0.54,0.0,0.0,0.0,0.0,0.0,0.0,samuel gaines,,PRTM-4030,2019
+PRTM,4210,1.0,Rec Fin Resc Mgt,0.54,0.39,0.02,0.0,0.02,0.0,0.0,0.02,ryan joseph gagnon,,PRTM-4210,2019
+PRTM,4220,2.0,Management of RT Services,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,sandra heath,,PRTM-4220,2019
+PRTM,4230,1.0,Adaptive Sports & Recreation,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,jasmine nutter townsend,,PRTM-4230,2019
+PRTM,4260,1.0,Trends & Issues in Rec Therapy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brent hawkins,,PRTM-4260,2019
+PRTM,4470,1.0,Perspect Intl Travel,0.75,0.21,0.0,0.0,0.04,0.0,0.0,0.0,'lisha fogle,,PRTM-4470,2019
+PRTM,4470,2.0,Perspect Intl Travel,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,sheila backman,,PRTM-4470,2019
+PRTM,4510,1.0,Seminar in CRSCM,0.7,0.19,0.06,0.02,0.02,0.0,0.0,0.0,skye gerald arthur-banning,,PRTM-4510,2019
+PRTM,4550,1.0,Adv Program Planning,0.73,0.25,0.02,0.0,0.0,0.0,0.0,0.0,harrison parker pinckney,,PRTM-4550,2019
+PRTM,4740,2.0,Adv Rec Resource Mgt,0.67,0.25,0.0,0.0,0.0,0.0,0.0,0.08,matthew tyler james brownlee,,PRTM-4740,2019
+PRTM,8080,2.0,Behavioral Aspects,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,iryna sharaievska,,PRTM-8080,2019
+PRTM,8080,3.0,Behavioral Aspects,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,lauren duffy,,PRTM-8080,2019
+PRTM,8710,1.0,Applied Research in Rec Therap,0.6,0.33,0.0,0.0,0.0,0.0,0.0,0.07,brandi crowe,,PRTM-8710,2019
+PRTM,8720,1.0,Adv Facilitation Techniq in RT,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,,PRTM-8720,2019
+PRTM,9000,11.0,MS Capstone,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey charles hallo,,PRTM-9000,2019
+PSYC,2010,1.0,Intro to Psychology,0.3,0.34,0.2,0.07,0.05,0.0,0.0,0.05,edwin brainerd,,PSYC-2010,2019
+PSYC,2010,2.0,Intro to Psychology,0.3,0.31,0.2,0.09,0.03,0.0,0.0,0.07,jo jorgensen,,PSYC-2010,2019
+PSYC,2010,3.0,Intro to Psychology,0.41,0.33,0.18,0.05,0.03,0.0,0.0,0.01,jo jorgensen,,PSYC-2010,2019
+PSYC,2010,4.0,Intro to Psychology,0.49,0.29,0.11,0.01,0.03,0.0,0.0,0.07,chong hyon pak,,PSYC-2010,2019
+PSYC,2010,5.0,Intro to Psychology,0.38,0.34,0.16,0.04,0.03,0.0,0.0,0.04,chong hyon pak,,PSYC-2010,2019
+PSYC,2010,6.0,Intro to Psychology,0.41,0.33,0.16,0.03,0.03,0.0,0.0,0.04,mary taylor,,PSYC-2010,2019
+PSYC,2010,7.0,Intro to Psychology,0.57,0.14,0.2,0.04,0.01,0.0,0.0,0.03,mary taylor,,PSYC-2010,2019
+PSYC,2010,8.0,Intro to Psychology,0.37,0.36,0.14,0.04,0.06,0.0,0.0,0.03,fred switzer,,PSYC-2010,2019
+PSYC,2010,9.0,Intro to Psychology (HON),0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True,PSYC-2010,2019
+PSYC,2030,1.0,Fundamentals of Psych Science,0.41,0.37,0.15,0.06,0.01,0.0,0.0,0.01,peggy jean tyler,,PSYC-2030,2019
+PSYC,3060,1.0,Human Sexual Behavior,0.51,0.22,0.16,0.05,0.04,0.0,0.0,0.02,bruce michael king,,PSYC-3060,2019
+PSYC,3090,100.0,Intro Experimental Psychology,0.35,0.35,0.14,0.08,0.05,0.0,0.0,0.03,jennifer bailey bisson,,PSYC-3090,2019
+PSYC,3090,200.0,Intro Experimental Psychology,0.66,0.21,0.14,0.0,0.0,0.0,0.0,0.0,patrick rosopa,,PSYC-3090,2019
+PSYC,3100,100.0,Advanced Experimental Psych,0.29,0.41,0.12,0.0,0.12,0.0,0.0,0.06,eric mckibben,,PSYC-3100,2019
+PSYC,3100,200.0,Advanced Experimental Psych,0.26,0.47,0.11,0.05,0.05,0.0,0.0,0.05,cynthia pury,,PSYC-3100,2019
+PSYC,3100,300.0,Advanced Experimental Psych,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-3100,2019
+PSYC,3100,400.0,Advanced Experimental Psych,0.59,0.29,0.12,0.0,0.0,0.0,0.0,0.0,thomas britt,,PSYC-3100,2019
+PSYC,3100,500.0,Advanced Experimental Psych,0.47,0.16,0.16,0.11,0.05,0.0,0.0,0.05,benjamin stephens,,PSYC-3100,2019
+PSYC,3100,600.0,Advanced Experimental Psych,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2019
+PSYC,3100,700.0,Advanced Experimental Psych,0.47,0.32,0.21,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2019
+PSYC,3100,800.0,Advanced Experimental Psych,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3100,2019
+PSYC,3240,1.0,Physiological Psych,0.36,0.24,0.2,0.09,0.03,0.0,0.0,0.08,claudio cantalupo,,PSYC-3240,2019
+PSYC,3240,2.0,Physiological Psych,0.25,0.22,0.2,0.11,0.05,0.0,0.0,0.18,june pilcher,,PSYC-3240,2019
+PSYC,3240,3.0,Physiological Psych,0.29,0.33,0.21,0.07,0.03,0.0,0.0,0.07,claudio cantalupo,,PSYC-3240,2019
+PSYC,3310,1.0,Critical Thinking,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3310,2019
+PSYC,3330,1.0,Cognitive Psych,0.68,0.23,0.08,0.01,0.0,0.0,0.0,0.0,kaileigh angela byrne,,PSYC-3330,2019
+PSYC,3330,2.0,Cognitive Psych,0.49,0.37,0.11,0.03,0.0,0.0,0.0,0.0,kaileigh angela byrne,,PSYC-3330,2019
+PSYC,3340,1.0,Cognitive Psych Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel braden quinn,,PSYC-3340,2019
+PSYC,3340,2.0,Cognitive Psych Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,daniel braden quinn,,PSYC-3340,2019
+PSYC,3340,3.0,Cognitive Psych Lab,0.76,0.04,0.08,0.04,0.04,0.0,0.0,0.04,laura whitlock,,PSYC-3340,2019
+PSYC,3400,1.0,Lifespan Developmental Psych,0.27,0.31,0.21,0.1,0.04,0.0,0.0,0.06,pamela alley,,PSYC-3400,2019
+PSYC,3400,2.0,Lifespan Developmental Psych,0.37,0.44,0.11,0.04,0.0,0.0,0.0,0.03,anita pei tam,,PSYC-3400,2019
+PSYC,3520,1.0,Social Psychology,0.63,0.26,0.07,0.01,0.0,0.0,0.0,0.03,ceren gunsoy,,PSYC-3520,2019
+PSYC,3520,2.0,Social Psychology (HON),0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,True,PSYC-3520,2019
+PSYC,3570,1.0,Psychology and Culture,0.64,0.23,0.13,0.0,0.0,0.0,0.0,0.0,ceren gunsoy,,PSYC-3570,2019
+PSYC,3640,1.0,Industrial Psych,0.97,0.0,0.03,0.0,0.0,0.0,0.0,0.0,joseph ligato,,PSYC-3640,2019
+PSYC,3680,1.0,Organizational Psych,0.27,0.29,0.34,0.05,0.02,0.0,0.0,0.03,chloe wilson,,PSYC-3680,2019
+PSYC,3700,1.0,Personality,0.54,0.29,0.1,0.04,0.01,0.0,0.0,0.01,john robert hester,,PSYC-3700,2019
+PSYC,3830,1.0,Abnormal Psychology,0.43,0.42,0.09,0.01,0.0,0.0,0.0,0.04,heidi marie zinzow,,PSYC-3830,2019
+PSYC,3830,2.0,Abnormal Psychology,0.23,0.31,0.2,0.09,0.06,0.0,0.0,0.11,pamela alley,,PSYC-3830,2019
+PSYC,3830,3.0,Abnormal Psychology,0.11,0.26,0.34,0.14,0.03,0.0,0.0,0.11,pamela alley,,PSYC-3830,2019
+PSYC,3890,1.0,Psychology of Music,0.28,0.28,0.2,0.12,0.12,0.0,0.0,0.0,claudio cantalupo,,PSYC-3890,2019
+PSYC,4080,1.0,Women and Psychology,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,robin marie kowalski,,PSYC-4080,2019
+PSYC,4150,1.0,Systems and Theories,0.87,0.08,0.03,0.0,0.03,0.0,0.0,0.0,peggy jean tyler,,PSYC-4150,2019
+PSYC,4150,2.0,Systems and Theories,0.29,0.35,0.21,0.12,0.0,0.0,0.0,0.03,edwin brainerd,,PSYC-4150,2019
+PSYC,4150,3.0,Systems and Theories,0.33,0.3,0.27,0.0,0.06,0.0,0.0,0.03,edwin brainerd,,PSYC-4150,2019
+PSYC,4220,1.0,Perception,0.37,0.33,0.22,0.07,0.0,0.0,0.0,0.0,richard tyrrell,,PSYC-4220,2019
+PSYC,4220,2.0,Perception,0.33,0.22,0.26,0.15,0.0,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2019
+PSYC,4220,3.0,Perception,0.41,0.3,0.19,0.11,0.0,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2019
+PSYC,4430,1.0,Infant & Child Dev,0.69,0.17,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-4430,2019
+PSYC,4560,1.0,Psychophysiology,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,sarah christine beadle,,PSYC-4560,2019
+PSYC,4710,1.0,Psych of Testing,0.64,0.14,0.0,0.0,0.07,0.0,0.0,0.14,zhuo chen,,PSYC-4710,2019
+PSYC,4800,1.0,Health Psychology,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2019
+PSYC,4800,2.0,Health Psychology,0.42,0.5,0.08,0.0,0.0,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2019
+PSYC,4880,1.0,Psychotherapy,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,lucinda sorciere shealy quick,,PSYC-4880,2019
+PSYC,4890,1.0,Sport Psychology,0.25,0.45,0.15,0.1,0.0,0.0,0.0,0.05,anita pei tam,,PSYC-4890,2019
+PSYC,4920,1.0,Senior Laboratory,0.8,0.13,0.0,0.07,0.0,0.0,0.0,0.0,zachary paul klinefelter,,PSYC-4920,2019
+PSYC,4920,2.0,Senior Laboratory,0.75,0.13,0.0,0.0,0.08,0.0,0.0,0.04,alexander moore,,PSYC-4920,2019
+PSYC,4920,4.0,Senior Laboratory,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,zachary paul klinefelter,,PSYC-4920,2019
+PSYC,4920,5.0,Senior Laboratory,0.69,0.15,0.0,0.0,0.0,0.0,0.0,0.15,hannah solini,,PSYC-4920,2019
+PSYC,4930,100.0,Pract Clinical Psych,0.81,0.13,0.0,0.06,0.0,0.0,0.0,0.0,heidi marie zinzow,,PSYC-4930,2019
+PSYC,4980,291.0,Suicide Prevention,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,,PSYC-4980,2019
+PSYC,4980,363.0,Psych Religion Spr,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,zhuo chen,,PSYC-4980,2019
+PSYC,8100,1.0,Research Design I,0.67,0.26,0.04,0.0,0.0,0.0,0.0,0.04,patrick rosopa,,PSYC-8100,2019
+PSYC,8350,1.0,Advanced Human Factors Psych,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,chong hyon pak,,PSYC-8350,2019
+PSYC,8620,1.0,Org Psychology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,robert raymond sinclair,,PSYC-8620,2019
+PSYC,8680,1.0,Leadership in Orgs,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,patrick raymark,,PSYC-8680,2019
+RED,8010,1.0,Market Analysis,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,thomas andrew fox,,RED-8010,2019
+REL,1010,1.0,Intro to Religion,0.32,0.47,0.16,0.05,0.0,0.0,0.0,0.0,peter cohen,,REL-1010,2019
+REL,1010,2.0,Intro to Religion,0.32,0.32,0.11,0.11,0.0,0.0,0.0,0.16,peter cohen,,REL-1010,2019
+REL,1010,3.0,Intro to Religion,0.43,0.37,0.09,0.06,0.0,0.0,0.0,0.06,peter cohen,,REL-1010,2019
+REL,1010,5.0,Intro to Religion,0.5,0.17,0.17,0.0,0.0,0.0,0.0,0.17,brett patterson,,REL-1010,2019
+REL,1020,1.0,World Religions (HON),0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,peter cohen,True,REL-1020,2019
+REL,1020,2.0,World Religions,0.54,0.26,0.14,0.0,0.0,0.0,0.0,0.06,robert stephens,,REL-1020,2019
+REL,1020,3.0,World Religions,0.57,0.29,0.09,0.0,0.03,0.0,0.0,0.03,robert stephens,,REL-1020,2019
+REL,1020,4.0,World Religions,0.51,0.31,0.11,0.0,0.06,0.0,0.0,0.0,robert stephens,,REL-1020,2019
+REL,1020,5.0,World Religions,0.14,0.54,0.23,0.09,0.0,0.0,0.0,0.0,brett patterson,,REL-1020,2019
+REL,3010,1.0,Old Testament,0.35,0.35,0.15,0.06,0.0,0.0,0.0,0.09,john thames,,REL-3010,2019
+REL,3020,1.0,New Testament Lit,0.53,0.41,0.0,0.03,0.0,0.0,0.0,0.03,benjamin white,,REL-3020,2019
+REL,3080,1.0,Religions of the Ancient World,0.19,0.53,0.06,0.0,0.03,0.0,0.0,0.19,benjamin white,,REL-3080,2019
+REL,3110,1.0,African American Rel,0.47,0.26,0.16,0.05,0.0,0.0,0.0,0.05,elizabeth jemison,,REL-3110,2019
+REL,3120,1.0,Hinduism,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,robert stephens,,REL-3120,2019
+REL,3300,1.0,Contemporary Issues,0.47,0.35,0.0,0.06,0.06,0.0,0.0,0.06,elizabeth jemison,,REL-3300,2019
+RS,3010,1.0,Rural Sociology,0.67,0.24,0.05,0.0,0.0,0.0,0.0,0.05,kenneth robinson,,RS-3010,2019
+RS,4010,1.0,Human Ecology,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,,RS-4010,2019
+RUSS,3400,1.0,19th C Russ Culture,0.48,0.35,0.13,0.0,0.0,0.0,0.0,0.04,olga anatolyevna volkova,,RUSS-3400,2019
+RUSS,3610,1.0,Russn Lit Since 1910,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,olga anatolyevna volkova,,RUSS-3610,2019
+SOC,2010,1.0,Introduction to Sociology,0.65,0.29,0.04,0.01,0.0,0.0,0.0,0.01,carolyn candace coffman,,SOC-2010,2019
+SOC,2010,2.0,Introduction to Sociology,0.69,0.26,0.04,0.0,0.01,0.0,0.0,0.0,carolyn candace coffman,,SOC-2010,2019
+SOC,2010,3.0,Introduction to Sociology,0.56,0.27,0.08,0.02,0.04,0.0,0.0,0.02,miao li,,SOC-2010,2019
+SOC,2010,4.0,Introduction to Sociology,0.86,0.12,0.0,0.0,0.01,0.0,0.0,0.0,andrew herman mannheimer,,SOC-2010,2019
+SOC,2010,5.0,Introduction to Sociology,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.01,shannon mcdonough,,SOC-2010,2019
+SOC,2010,6.0,Introduction to Sociology,0.55,0.33,0.1,0.01,0.0,0.0,0.0,0.01,shannon mcdonough,,SOC-2010,2019
+SOC,2010,7.0,Introduction to Sociology,0.6,0.29,0.08,0.0,0.0,0.0,0.0,0.02,jennifer leanne holland,,SOC-2010,2019
+SOC,2040,1.0,Prof Dev for Sociology Majors,0.64,0.2,0.09,0.02,0.02,0.0,0.0,0.02, catherine mobley,,SOC-2040,2019
+SOC,3020,1.0,Research Methods I,0.4,0.38,0.08,0.08,0.0,0.0,0.0,0.06,andrew whitehead,,SOC-3020,2019
+SOC,3040,1.0,Social Research Methods II,0.25,0.45,0.18,0.08,0.03,0.0,0.0,0.03,ye luo,,SOC-3040,2019
+SOC,3100,1.0,Marriage & Intimacy,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,heather kettrey,,SOC-3100,2019
+SOC,3400,1.0,Sport and Society,0.36,0.43,0.17,0.04,0.0,0.0,0.0,0.0,andrew whitehead,,SOC-3400,2019
+SOC,3510,1.0,Collective Behavior,0.27,0.41,0.2,0.08,0.0,0.0,0.0,0.04,matthew john costello,,SOC-3510,2019
+SOC,3600,1.0,Class & Poverty,0.8,0.18,0.0,0.0,0.0,0.0,0.0,0.02,william haller,,SOC-3600,2019
+SOC,3910,1.0,Soc of Deviance,0.53,0.31,0.12,0.04,0.0,0.0,0.0,0.0,matthew john costello,,SOC-3910,2019
+SOC,3940,1.0,Sociology of Mental Illness,0.89,0.09,0.02,0.0,0.0,0.0,0.0,0.0,james rosenberger,,SOC-3940,2019
+SOC,3970,1.0,Substance Abuse,0.69,0.27,0.0,0.0,0.04,0.0,0.0,0.0,shannon mcdonough,,SOC-3970,2019
+SOC,4030,1.0,"Technol, Environment & Society",0.53,0.26,0.19,0.02,0.0,0.0,0.0,0.0, catherine mobley,,SOC-4030,2019
+SOC,4040,1.0,Soc Theory,0.6,0.25,0.0,0.0,0.0,0.0,0.0,0.15,william haller,,SOC-4040,2019
+SOC,4140,1.0,Policy&Social Change,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,jennifer leanne holland,,SOC-4140,2019
+SOC,4440,1.0,Sociology of Educ,0.82,0.14,0.02,0.02,0.0,0.0,0.0,0.0,andrew herman mannheimer,,SOC-4440,2019
+SOC,4600,1.0,Race & Ethnicity,0.88,0.02,0.06,0.0,0.02,0.0,0.0,0.02,andrew herman mannheimer,,SOC-4600,2019
+SOC,4610,1.0,Sex & Gender,0.55,0.2,0.16,0.02,0.02,0.0,0.0,0.04,minyoung moon,,SOC-4610,2019
+SOC,4710,1.0,World Population and Society,0.5,0.43,0.07,0.0,0.0,0.0,0.0,0.0,ye luo,,SOC-4710,2019
+SOC,4950,1.0,Field Experience,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0, catherine mobley,,SOC-4950,2019
+SOC,8920,1.0,Sel Top: Quantitative Methods,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,miao li,,SOC-8920,2019
+SPAN,1010,1.0,Elementary Spanish,0.26,0.47,0.21,0.0,0.05,0.0,0.0,0.0,stephanie elysse morris,,SPAN-1010,2019
+SPAN,1010,2.0,Elementary Spanish,0.37,0.58,0.05,0.0,0.0,0.0,0.0,0.0,stephanie elysse morris,,SPAN-1010,2019
+SPAN,1010,3.0,Elementary Spanish,0.58,0.37,0.05,0.0,0.0,0.0,0.0,0.0,rosa macarena pillcurima,,SPAN-1010,2019
+SPAN,1020,1.0,Elementary Spanish,0.33,0.5,0.11,0.06,0.0,0.0,0.0,0.0,rosa macarena pillcurima,,SPAN-1020,2019
+SPAN,1020,2.0,Elementary Spanish,0.63,0.25,0.06,0.06,0.0,0.0,0.0,0.0,liliana hernandez,,SPAN-1020,2019
+SPAN,1020,3.0,Elementary Spanish,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mercedes tejera,,SPAN-1020,2019
+SPAN,1020,4.0,Elementary Spanish,0.74,0.21,0.0,0.0,0.0,0.0,0.0,0.05,mercedes tejera,,SPAN-1020,2019
+SPAN,1020,5.0,Elementary Spanish,0.39,0.39,0.11,0.11,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,,SPAN-1020,2019
+SPAN,1020,6.0,Elementary Spanish,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,,SPAN-1020,2019
+SPAN,1020,8.0,Elementary Spanish,0.56,0.28,0.17,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-1020,2019
+SPAN,1020,10.0,Elementary Spanish,0.63,0.32,0.0,0.0,0.05,0.0,0.0,0.0,debra oaks williamson,,SPAN-1020,2019
+SPAN,1020,11.0,Elementary Spanish,0.47,0.35,0.12,0.0,0.0,0.0,0.0,0.06,debra oaks williamson,,SPAN-1020,2019
+SPAN,1020,13.0,Elementary Spanish,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,yezid flores,,SPAN-1020,2019
+SPAN,2010,1.0,Intermediate Spanish,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,maria rosa judez riquelme,,SPAN-2010,2019
+SPAN,2010,2.0,Intermediate Spanish,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,liliana hernandez,,SPAN-2010,2019
+SPAN,2010,3.0,Intermediate Spanish,0.72,0.22,0.06,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,,SPAN-2010,2019
+SPAN,2010,4.0,Intermediate Spanish,0.71,0.06,0.24,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,,SPAN-2010,2019
+SPAN,2010,7.0,Intermediate Spanish,0.53,0.21,0.16,0.0,0.05,0.0,0.0,0.05,debra oaks williamson,,SPAN-2010,2019
+SPAN,2010,8.0,Intermediate Spanish,0.47,0.35,0.18,0.0,0.0,0.0,0.0,0.0,debra oaks williamson,,SPAN-2010,2019
+SPAN,2010,9.0,Intermediate Spanish,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,andrea patricia naranjo,,SPAN-2010,2019
+SPAN,2010,10.0,Intermediate Spanish,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2019
+SPAN,2010,11.0,Intermediate Spanish,0.47,0.42,0.0,0.11,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2019
+SPAN,2010,12.0,Intermediate Spanish,0.68,0.21,0.05,0.0,0.0,0.0,0.0,0.05,ellory schmucker,,SPAN-2010,2019
+SPAN,2010,14.0,Intermediate Spanish,0.58,0.37,0.0,0.0,0.0,0.0,0.0,0.05,nora arostegui logue,,SPAN-2010,2019
+SPAN,2010,15.0,Intermediate Spanish,0.33,0.44,0.11,0.0,0.0,0.0,0.0,0.11,zenia beatriz cruz valderramos,,SPAN-2010,2019
+SPAN,2010,16.0,Intermediate Spanish,0.71,0.12,0.12,0.06,0.0,0.0,0.0,0.0,zenia beatriz cruz valderramos,,SPAN-2010,2019
+SPAN,2010,17.0,Intermediate Spanish,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,maria rosa judez riquelme,,SPAN-2010,2019
+SPAN,2010,18.0,Intermediate Spanish,0.63,0.26,0.05,0.0,0.05,0.0,0.0,0.0,mercedes tejera,,SPAN-2010,2019
+SPAN,2010,19.0,Intermediate Spanish,0.82,0.12,0.0,0.0,0.06,0.0,0.0,0.0,liliana hernandez,,SPAN-2010,2019
+SPAN,2020,1.0,Intermediate Spanish,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,melva marguerite persico,,SPAN-2020,2019
+SPAN,2020,2.0,Intermediate Spanish,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,melva marguerite persico,,SPAN-2020,2019
+SPAN,2020,3.0,Intermediate Spanish,0.75,0.13,0.06,0.06,0.0,0.0,0.0,0.0,yezid flores,,SPAN-2020,2019
+SPAN,2020,4.0,Intermediate Spanish,0.61,0.28,0.0,0.0,0.11,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2019
+SPAN,2020,5.0,Intermediate Spanish,0.74,0.05,0.16,0.0,0.05,0.0,0.0,0.0,yezid flores,,SPAN-2020,2019
+SPAN,2020,6.0,Intermediate Spanish,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,rosa macarena pillcurima,,SPAN-2020,2019
+SPAN,2020,7.0,Intermediate Spanish,0.63,0.26,0.0,0.0,0.05,0.0,0.0,0.05,rosa macarena pillcurima,,SPAN-2020,2019
+SPAN,2020,8.0,Intermediate Spanish,0.42,0.37,0.16,0.0,0.0,0.0,0.0,0.05,ana paula  miller,,SPAN-2020,2019
+SPAN,2020,9.0,Intermediate Spanish,0.4,0.55,0.05,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2019
+SPAN,2020,10.0,Intermediate Spanish,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,nora arostegui logue,,SPAN-2020,2019
+SPAN,2020,11.0,Intermediate Spanish,0.46,0.46,0.0,0.0,0.0,0.0,0.0,0.08,jose luis ortiz,,SPAN-2020,2019
+SPAN,2020,13.0,Intermediate Spanish,0.41,0.24,0.18,0.12,0.0,0.0,0.0,0.06,jose luis ortiz,,SPAN-2020,2019
+SPAN,2020,14.0,Intermediate Spanish,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,daniel david garcia vieyra,,SPAN-2020,2019
+SPAN,2020,15.0,Intermediate Spanish,0.61,0.22,0.06,0.06,0.0,0.0,0.0,0.06,yezid flores,,SPAN-2020,2019
+SPAN,2020,16.0,Intermediate Spanish,0.63,0.16,0.11,0.0,0.0,0.0,0.0,0.11,daniel david garcia vieyra,,SPAN-2020,2019
+SPAN,3010,1.0,Spanish Comp for Health Prof,0.12,0.53,0.29,0.06,0.0,0.0,0.0,0.0,tiffany dawn creegan miller,,SPAN-3010,2019
+SPAN,3020,1.0,Intermed Span Grammar & Comp,0.53,0.32,0.05,0.0,0.0,0.0,0.0,0.11,melva marguerite persico,,SPAN-3020,2019
+SPAN,3020,2.0,Intermed Span Grammar & Comp,0.39,0.5,0.06,0.0,0.0,0.0,0.0,0.06,melva marguerite persico,,SPAN-3020,2019
+SPAN,3020,3.0,Intermed Span Grammar & Comp,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,daniel smith,,SPAN-3020,2019
+SPAN,3040,1.0,Intro Hispanic Literary Forms,0.82,0.12,0.0,0.0,0.0,0.0,0.0,0.06,graciela tissera,,SPAN-3040,2019
+SPAN,3050,1.0,Intermed Span Convers/Comp I,0.68,0.21,0.0,0.05,0.0,0.0,0.0,0.05,daniel david garcia vieyra,,SPAN-3050,2019
+SPAN,3050,2.0,Intermed Span Convers/Comp I,0.53,0.26,0.16,0.0,0.05,0.0,0.0,0.0,daniel david garcia vieyra,,SPAN-3050,2019
+SPAN,3050,3.0,Intermed Span Convers/Comp I,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,,SPAN-3050,2019
+SPAN,3050,4.0,Intermed Span Convers/Comp I,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,alma yadhira garcia rodriguez,,SPAN-3050,2019
+SPAN,3050,6.0,Intermed Span Convers/Comp I,0.5,0.39,0.0,0.06,0.0,0.0,0.0,0.06,jose luis ortiz,,SPAN-3050,2019
+SPAN,3080,1.0,The Hispanic World: Latin Amer,0.47,0.35,0.12,0.06,0.0,0.0,0.0,0.0,tiffany dawn creegan miller,,SPAN-3080,2019
+SPAN,3080,2.0,The Hispanic World: Latin Amer,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,george palacios,,SPAN-3080,2019
+SPAN,3130,2.0,Span Lit Survey I,0.29,0.36,0.07,0.0,0.0,0.0,0.0,0.29,monica rojas-de-massei,,SPAN-3130,2019
+SPAN,3180,1.0,Spanish Through Culture,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,george palacios,,SPAN-3180,2019
+SPAN,4060,1.0,Narrative Fiction,0.65,0.24,0.06,0.0,0.0,0.0,0.0,0.06,monica rojas-de-massei,,SPAN-4060,2019
+SPAN,4060,2.0,Narrative Fiction,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,monica rojas-de-massei,,SPAN-4060,2019
+SPAN,4070,1.0,Hispanic Film,0.72,0.06,0.22,0.0,0.0,0.0,0.0,0.0,salvador oropesa,,SPAN-4070,2019
+SPAN,4190,1.0,Health & Hispanic Community,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,arelis moore peralta,,SPAN-4190,2019
+STAT,2220,1.0,Statistics in Everyday Life,0.24,0.38,0.3,0.01,0.01,0.0,0.0,0.05,james espey,,STAT-2220,2019
+STAT,2220,2.0,Statistics in Everyday Life,0.27,0.36,0.22,0.05,0.04,0.0,0.0,0.05,james espey,,STAT-2220,2019
+STAT,2220,3.0,Statistics in Everyday Life,0.36,0.32,0.2,0.02,0.02,0.0,0.0,0.07,james espey,,STAT-2220,2019
+STAT,2220,4.0,Statistics in Everyday Life,0.26,0.28,0.28,0.09,0.02,0.0,0.0,0.06,james espey,,STAT-2220,2019
+STAT,2220,5.0,Statistics in Everyday Life,0.32,0.38,0.08,0.1,0.07,0.0,0.0,0.06,rose martinez-dawson,,STAT-2220,2019
+STAT,2220,6.0,Statistics in Everyday Life,0.37,0.3,0.15,0.08,0.06,0.0,0.0,0.04,rose martinez-dawson,,STAT-2220,2019
+STAT,2220,7.0,Statistics in Everyday Life,0.27,0.4,0.19,0.06,0.02,0.0,0.0,0.06,rose martinez-dawson,,STAT-2220,2019
+STAT,2300,1.0,Statistical Methods I,0.46,0.35,0.09,0.05,0.02,0.0,0.0,0.02,paran rebekah norton,,STAT-2300,2019
+STAT,2300,2.0,Statistical Methods I,0.38,0.32,0.18,0.04,0.07,0.0,0.0,0.01,paran rebekah norton,,STAT-2300,2019
+STAT,2300,3.0,Statistical Methods I,0.27,0.3,0.23,0.11,0.05,0.0,0.0,0.03, erwin walker,,STAT-2300,2019
+STAT,2300,4.0,Statistical Methods I,0.27,0.32,0.2,0.1,0.1,0.0,0.0,0.0, erwin walker,,STAT-2300,2019
+STAT,2300,5.0,Statistical Methods I,0.3,0.32,0.13,0.09,0.09,0.0,0.0,0.06,paran rebekah norton,,STAT-2300,2019
+STAT,2300,6.0,Statistical Methods I,0.29,0.38,0.17,0.06,0.05,0.0,0.0,0.05,sharon marie evans,,STAT-2300,2019
+STAT,2300,100.0,Statistical Methods I (HON),0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,sharon marie evans,True,STAT-2300,2019
+STAT,3090,1.0,Introductory Business Stats,0.11,0.28,0.28,0.33,0.0,0.0,0.0,0.0,fun choi john chan,,STAT-3090,2019
+STAT,3090,2.0,Introductory Business Stats,0.0,0.35,0.35,0.24,0.06,0.0,0.0,0.0,fun choi john chan,,STAT-3090,2019
+STAT,3090,3.0,Introductory Business Stats,0.17,0.17,0.39,0.11,0.17,0.0,0.0,0.0,sarah kelly,,STAT-3090,2019
+STAT,3090,4.0,Introductory Business Stats,0.21,0.32,0.32,0.05,0.11,0.0,0.0,0.0,sarah kelly,,STAT-3090,2019
+STAT,3090,5.0,Introductory Business Stats,0.22,0.33,0.33,0.06,0.06,0.0,0.0,0.0,mary elizabeth saine,,STAT-3090,2019
+STAT,3090,6.0,Introductory Business Stats,0.21,0.26,0.37,0.05,0.05,0.0,0.0,0.05,mary elizabeth saine,,STAT-3090,2019
+STAT,3090,7.0,Introductory Business Stats,0.42,0.26,0.21,0.11,0.0,0.0,0.0,0.0,sean walker ingimarson,,STAT-3090,2019
+STAT,3090,8.0,Introductory Business Stats,0.21,0.37,0.26,0.16,0.0,0.0,0.0,0.0,sean walker ingimarson,,STAT-3090,2019
+STAT,3090,9.0,Introductory Business Stats,0.21,0.32,0.16,0.16,0.16,0.0,0.0,0.0,yidan guo,,STAT-3090,2019
+STAT,3090,10.0,Introductory Business Stats,0.22,0.33,0.22,0.11,0.11,0.0,0.0,0.0,yidan guo,,STAT-3090,2019
+STAT,3090,11.0,Introductory Business Stats,0.32,0.26,0.21,0.11,0.11,0.0,0.0,0.0,rui gong,,STAT-3090,2019
+STAT,3090,12.0,Introductory Business Stats,0.26,0.21,0.21,0.05,0.16,0.0,0.0,0.11,rui gong,,STAT-3090,2019
+STAT,3090,13.0,Introductory Business Stats,0.29,0.26,0.2,0.14,0.08,0.0,0.0,0.03,april thomas,,STAT-3090,2019
+STAT,3090,14.0,Introductory Business Stats,0.36,0.33,0.25,0.02,0.02,0.0,0.0,0.02,april thomas,,STAT-3090,2019
+STAT,3090,15.0,Introductory Business Stats,0.47,0.12,0.24,0.0,0.18,0.0,0.0,0.0,molly adams honecker,,STAT-3090,2019
+STAT,3090,16.0,Introductory Business Stats,0.53,0.32,0.05,0.0,0.11,0.0,0.0,0.0,molly adams honecker,,STAT-3090,2019
+STAT,3090,17.0,Introductory Business Stats,0.32,0.42,0.26,0.0,0.0,0.0,0.0,0.0,xueheng shi,,STAT-3090,2019
+STAT,3090,18.0,Introductory Business Stats,0.21,0.53,0.11,0.05,0.0,0.0,0.0,0.11,xueheng shi,,STAT-3090,2019
+STAT,3090,19.0,Introductory Business Stats,0.44,0.17,0.0,0.17,0.17,0.0,0.0,0.06,feng gao,,STAT-3090,2019
+STAT,3090,20.0,Introductory Business Stats,0.22,0.5,0.22,0.06,0.0,0.0,0.0,0.0,feng gao,,STAT-3090,2019
+STAT,3090,21.0,Introductory Business Stats,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,zhengxin wang,,STAT-3090,2019
+STAT,3090,22.0,Introductory Business Stats,0.44,0.17,0.28,0.11,0.0,0.0,0.0,0.0,zhengxin wang,,STAT-3090,2019
+STAT,3090,23.0,Introductory Business Stats,0.28,0.11,0.33,0.17,0.0,0.0,0.0,0.11,james mckay visser,,STAT-3090,2019
+STAT,3090,24.0,Introductory Business Stats,0.32,0.32,0.21,0.05,0.05,0.0,0.0,0.05,james mckay visser,,STAT-3090,2019
+STAT,3090,25.0,Introductory Business Stats,0.37,0.53,0.11,0.0,0.0,0.0,0.0,0.0,boyoung hur,,STAT-3090,2019
+STAT,3090,26.0,Introductory Business Stats,0.33,0.22,0.39,0.06,0.0,0.0,0.0,0.0,boyoung hur,,STAT-3090,2019
+STAT,3090,27.0,Introductory Business Stats,0.22,0.28,0.33,0.0,0.11,0.0,0.0,0.06,siyuan yu,,STAT-3090,2019
+STAT,3090,28.0,Introductory Business Stats,0.24,0.29,0.18,0.18,0.06,0.0,0.0,0.06,siyuan yu,,STAT-3090,2019
+STAT,3090,29.0,Introductory Business Stats,0.0,0.42,0.21,0.05,0.21,0.0,0.0,0.11,minghua cui,,STAT-3090,2019
+STAT,3090,30.0,Introductory Business Stats,0.08,0.38,0.15,0.08,0.15,0.0,0.0,0.15,minghua cui,,STAT-3090,2019
+STAT,3090,31.0,Introductory Business Stats,0.42,0.32,0.26,0.0,0.0,0.0,0.0,0.0,tiantian yang,,STAT-3090,2019
+STAT,3090,32.0,Introductory Business Stats,0.37,0.42,0.21,0.0,0.0,0.0,0.0,0.0,tiantian yang,,STAT-3090,2019
+STAT,3090,33.0,Introductory Business Stats,0.21,0.63,0.11,0.0,0.05,0.0,0.0,0.0,trevor camper,,STAT-3090,2019
+STAT,3090,34.0,Introductory Business Stats,0.11,0.37,0.37,0.05,0.11,0.0,0.0,0.0,trevor camper,,STAT-3090,2019
+STAT,3090,35.0,Introductory Business Stats,0.06,0.17,0.39,0.22,0.11,0.0,0.0,0.06,jiyun huang,,STAT-3090,2019
+STAT,3090,36.0,Introductory Business Stats,0.32,0.37,0.26,0.05,0.0,0.0,0.0,0.0,jiyun huang,,STAT-3090,2019
+STAT,3090,37.0,Introductory Business Stats,0.63,0.32,0.05,0.0,0.0,0.0,0.0,0.0,anna marie vagnozzi,,STAT-3090,2019
+STAT,3090,38.0,Introductory Business Stats,0.5,0.28,0.17,0.06,0.0,0.0,0.0,0.0,anna marie vagnozzi,,STAT-3090,2019
+STAT,3090,39.0,Introductory Business Stats,0.42,0.37,0.11,0.05,0.0,0.0,0.0,0.05,pubudu jayasekara merenchige,,STAT-3090,2019
+STAT,3090,40.0,Introductory Business Stats,0.37,0.26,0.21,0.05,0.05,0.0,0.0,0.05,pubudu jayasekara merenchige,,STAT-3090,2019
+STAT,3300,1.0,Statistical Methods II,0.22,0.22,0.22,0.0,0.13,0.0,0.0,0.22,rose martinez-dawson,,STAT-3300,2019
+STAT,4020,1.0,Intro to Statistical Computing,0.25,0.33,0.08,0.0,0.08,0.0,0.0,0.25,ellen hepfer breazel,,STAT-4020,2019
+STAT,4020,2.0,Intro to Statistical Computing,0.38,0.08,0.15,0.08,0.15,0.0,0.0,0.15,ellen hepfer breazel,,STAT-4020,2019
+STAT,4110,1.0,Stat Mthds for Process Control,0.68,0.18,0.05,0.05,0.03,0.0,0.0,0.0,richard steven dubsky,,STAT-4110,2019
+STAT,4110,2.0,Stat Mthds for Process Control,0.72,0.14,0.09,0.05,0.0,0.0,0.0,0.0,richard steven dubsky,,STAT-4110,2019
+STAT,4110,3.0,Stat Mthds for Process Control,0.5,0.21,0.14,0.0,0.05,0.0,0.0,0.1,yu-bo wang,,STAT-4110,2019
+STAT,4110,4.0,Stat Mthds for Process Control,0.3,0.32,0.22,0.03,0.11,0.0,0.0,0.03,yu-bo wang,,STAT-4110,2019
+STAT,6020,1.0,Intro to Statistical Computing,0.47,0.47,0.06,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,,STAT-6020,2019
+STAT,6020,2.0,Intro to Statistical Computing,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,ellen hepfer breazel,,STAT-6020,2019
+STAT,8010,1.0,Statistical Methods I,0.55,0.23,0.18,0.0,0.0,0.0,0.0,0.05,patrick gerard,,STAT-8010,2019
+STAT,8010,2.0,Statistical Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,deborah elizabeth kunkel,,STAT-8010,2019
+STAT,8010,4.0,Statistical Methods I,0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,deborah elizabeth kunkel,,STAT-8010,2019
+STAT,8010,5.0,Statistical Methods I,0.56,0.17,0.06,0.0,0.17,0.0,0.0,0.06,jun luo,,STAT-8010,2019
+STAT,8010,6.0,Statistical Methods I,0.73,0.14,0.14,0.0,0.0,0.0,0.0,0.0,jun luo,,STAT-8010,2019
+STAT,8010,7.0,Statistical Methods I,0.43,0.38,0.14,0.0,0.0,0.0,0.0,0.05,joseph daniel bible,,STAT-8010,2019
+STAT,8020,1.0,Statistical Methods II,0.78,0.11,0.11,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-8020,2019
+STAT,8050,1.0,Design & Anlys of Experiments,0.48,0.48,0.03,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-8050,2019
+STS,1010,1.0,Survey Sci & Techn in Society,0.59,0.32,0.0,0.03,0.03,0.0,0.0,0.03,kenneth david widgren,,STS-1010,2019
+STS,1010,2.0,Survey Sci & Techn in Society,0.61,0.33,0.06,0.0,0.0,0.0,0.0,0.0,scott brame,,STS-1010,2019
+STS,1010,3.0,Survey Sci & Techn in Society,0.67,0.25,0.03,0.03,0.0,0.0,0.0,0.03,elizabeth anderson stansell,,STS-1010,2019
+STS,1010,4.0,Survey Sci & Techn in Society,0.69,0.26,0.03,0.0,0.03,0.0,0.0,0.0,ingrid anna pierce,,STS-1010,2019
+STS,1010,5.0,Survey Sci & Techn in Society,0.42,0.5,0.06,0.0,0.03,0.0,0.0,0.0,philip randall,,STS-1010,2019
+STS,1010,6.0,Survey Sci & Techn in Society,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,,STS-1010,2019
+STS,1010,7.0,Survey Sci & Techn in Society,0.44,0.44,0.06,0.0,0.03,0.0,0.0,0.03,megan noel macalystre,,STS-1010,2019
+STS,1010,8.0,Survey Sci & Techn in Society,0.44,0.41,0.09,0.0,0.0,0.0,0.0,0.06,david charles foltz,,STS-1010,2019
+STS,1010,9.0,Survey Sci & Techn in Society,0.53,0.41,0.03,0.0,0.0,0.0,0.0,0.03,tareva leselle johnson,,STS-1010,2019
+STS,1010,10.0,Survey Sci & Techn in Society,0.62,0.29,0.03,0.0,0.0,0.0,0.0,0.06,alexander john billinis,,STS-1010,2019
+STS,1010,11.0,Survey Sci & Techn in Society,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,anne mcmahan grant,,STS-1010,2019
+SUST,2010,1.0,Sustainability Leadership,0.88,0.03,0.03,0.03,0.03,0.0,0.0,0.0,jennifer margaret goree,,SUST-2010,2019
+THEA,2100,1.0,Theatre Appreciation,0.59,0.28,0.09,0.0,0.03,0.0,0.0,0.0,david hartmann,,THEA-2100,2019
+THEA,2100,3.0,Theatre Appreciation,0.63,0.23,0.07,0.03,0.0,0.0,0.0,0.03,kendra lynette johnson,,THEA-2100,2019
+THEA,2100,5.0,Theatre Appreciation,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-2100,2019
+THEA,2100,6.0,Theatre Appreciation,0.59,0.28,0.09,0.0,0.0,0.0,0.0,0.03,jason adkins,,THEA-2100,2019
+THEA,2100,7.0,Theatre Appreciation,0.73,0.1,0.13,0.0,0.03,0.0,0.0,0.0,jason adkins,,THEA-2100,2019
+THEA,2770,1.0,Prod Studies in Thea,0.63,0.25,0.08,0.0,0.0,0.0,0.0,0.04,david hartmann,,THEA-2770,2019
+THEA,2780,1.0,Acting I,0.75,0.06,0.13,0.06,0.0,0.0,0.0,0.0,kerrie kathleen seymour,,THEA-2780,2019
+THEA,2790,1.0,Theatre Practicum,0.57,0.21,0.07,0.0,0.07,0.0,0.0,0.07,matthew leckenbusch,,THEA-2790,2019
+THEA,3080,1.0,Surv of Broadway I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,,THEA-3080,2019
+THEA,3160,1.0,Theatre History II,0.63,0.21,0.08,0.04,0.04,0.0,0.0,0.0,shannon therese robert,,THEA-3160,2019
+THEA,3170,1.0,African-Amer Thea I,0.42,0.37,0.21,0.0,0.0,0.0,0.0,0.0,kendra lynette johnson,,THEA-3170,2019
+WFB,3010,2.0,Wildlife Biology Lab,0.5,0.29,0.14,0.0,0.0,0.0,0.0,0.07,shari lynn rodriguez,,WFB-3010,2019
+WFB,4100,2.0,Wildlife Management Techniques,0.26,0.66,0.03,0.06,0.0,0.0,0.0,0.0,catherine michelle jachowski,,WFB-4100,2019
+WFB,4120,1.0,Wildlife Management,0.67,0.26,0.04,0.04,0.0,0.0,0.0,0.0,greg yarrow,,WFB-4120,2019
+WFB,4180,2.0,Fisheries Mgt & Conservation,0.67,0.29,0.05,0.0,0.0,0.0,0.0,0.0,troy mason farmer,,WFB-4180,2019
+WFB,4440,1.0,Wildlife Damage Management,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,greg yarrow,,WFB-4440,2019
+WFB,4720,1.0,Ornithology,0.27,0.32,0.23,0.09,0.05,0.0,0.0,0.05,neil smith,,WFB-4720,2019
+WFB,4770,1.0,Ichthyology,0.71,0.07,0.14,0.07,0.0,0.0,0.0,0.0,brandon kevin peoples,,WFB-4770,2019
+WFB,4800,1.0,Waterfowl Ecology & Management,0.4,0.47,0.05,0.0,0.0,0.0,0.0,0.09,richard marvin kaminski,,WFB-4800,2019
+WFB,6620,1.0,Wetland Wildlife Biology,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,russell barrett,,WFB-6620,2019
+WFB,6800,1.0,Waterfowl Ecology & Management,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,richard marvin kaminski,,WFB-6800,2019
+WFB,8610,5.0,Scientific Writing,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stefanie whitmire,,WFB-8610,2019
+WFB,8610,10.0,Fisheries Mgt and Conservation,0.67,0.11,0.11,0.0,0.11,0.0,0.0,0.0,troy mason farmer,,WFB-8610,2019
+WFB,8610,11.0,Study Design & Data Analysis,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,brandon kevin peoples,,WFB-8610,2019
+WFB,8610,14.0,Wildlife Resource Selection,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,catherine michelle jachowski,,WFB-8610,2019
+WFB,8610,23.0,Aquatic Habitat Management,0.6,0.2,0.0,0.0,0.1,0.0,0.0,0.1,mark scott,,WFB-8610,2019
+WS,1030,1.0,Women in Global Perspective,0.5,0.36,0.11,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,,WS-1030,2019
+WS,1030,2.0,Women in Global Perspective,0.53,0.39,0.06,0.0,0.0,0.0,0.0,0.03,sarah mae cooper,,WS-1030,2019
+WS,2300,1.0,Women and Leadership I,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,mary price,,WS-2300,2019
+WS,3010,1.0,Intro Women's Studies,0.47,0.39,0.03,0.03,0.06,0.0,0.0,0.03,elizabeth rose adams,,WS-3010,2019
+WS,3010,2.0,Intro Women's Studies,0.58,0.37,0.03,0.0,0.0,0.0,0.0,0.03,elizabeth rose adams,,WS-3010,2019
+WS,4230,1.0,Women in the Developing World,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,melissa vogel,,WS-4230,2019
+YDP,3000,400.0,Youth Development in Society,0.64,0.2,0.04,0.04,0.04,0.0,0.0,0.04,lauren elizabeth stephens,,YDP-3000,2019
+YDP,3050,400.0,Theory/Phil of Youth Dev Work,0.73,0.15,0.08,0.0,0.0,0.0,0.0,0.04,lauren elizabeth stephens,,YDP-3050,2019
+YDP,3200,1.0,Youth Dev in Sport/Phys Activ,0.71,0.13,0.08,0.04,0.0,0.0,0.0,0.04,lauren elizabeth stephens,,YDP-3200,2019
+YDP,3250,1.0,Working with Diverse Youth,0.76,0.12,0.06,0.0,0.06,0.0,0.0,0.0,kimberly pearson johnson,,YDP-3250,2019
+YDP,3300,1.0,Designing Effective Youth Prog,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,kellye rembert,,YDP-3300,2019
+YDP,3350,1.0,Youth Activity Leadership,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,lauren elizabeth stephens,,YDP-3350,2019
+YDP,3450,1.0,Creative Activities for Youth,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kimberly pearson johnson,,YDP-3450,2019
+YDP,4450,1.0,Youth Devel Org Administration,0.61,0.17,0.17,0.0,0.0,0.0,0.0,0.04,allison michelle avishai,,YDP-4450,2019
+YDP,4500,1.0,Prof Iss & Ethics in Youth Dev,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,kayla lee weston,,YDP-4500,2019

--- a/bot/cogs/grades_cog/assets/2019_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2019_Spring.csv
@@ -1,2951 +1,2954 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1020,1,Survey of Art & Arch Hist II,0.46,0.42,0.11,0.0,0.0,0.0,0.0,0.01,beth ann lauritis,AAH-1020,2019
-AAH,2060,1,Art History and Theory II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,AAH-2060,2019
-ACCT,2010,1,Financial Accounting Concepts,0.61,0.2,0.1,0.05,0.0,0.0,0.02,0.02,emily suza mccorkle,ACCT-2010,2019
-ACCT,2010,2,Financial Accounting Concepts,0.31,0.43,0.19,0.05,0.02,0.0,0.0,0.0,emily suza mccorkle,ACCT-2010,2019
-ACCT,2010,3,Financial Accounting Concepts,0.18,0.52,0.2,0.05,0.02,0.0,0.0,0.02,lydia lan schleifer,ACCT-2010,2019
-ACCT,2010,4,Financial Accounting Concepts,0.45,0.33,0.1,0.03,0.03,0.0,0.0,0.08,annieka philo,ACCT-2010,2019
-ACCT,2010,5,Financial Accounting Concepts,0.3,0.43,0.15,0.08,0.03,0.0,0.0,0.03,annieka philo,ACCT-2010,2019
-ACCT,2010,6,Financial Accounting Concepts,0.2,0.43,0.25,0.05,0.03,0.0,0.0,0.05,annieka philo,ACCT-2010,2019
-ACCT,2010,7,Financial Accounting Concepts,0.16,0.48,0.23,0.02,0.07,0.0,0.0,0.05,lydia lan schleifer,ACCT-2010,2019
-ACCT,2010,8,Financial Accounting Concepts,0.07,0.4,0.37,0.07,0.02,0.0,0.0,0.07,lydia lan schleifer,ACCT-2010,2019
-ACCT,2010,9,Financial Accounting Concepts,0.35,0.33,0.2,0.03,0.1,0.0,0.0,0.0,annieka philo,ACCT-2010,2019
-ACCT,2010,10,Financial Accounting Concepts,0.16,0.25,0.25,0.09,0.09,0.0,0.0,0.16,mary ann  prater,ACCT-2010,2019
-ACCT,2010,11,Financial Accounting Concepts,0.31,0.4,0.11,0.03,0.06,0.0,0.0,0.09,charles tegen,ACCT-2010,2019
-ACCT,2010,12,Financial Accounting Concepts,0.3,0.38,0.13,0.0,0.08,0.0,0.0,0.13,lisa whe birtwistle,ACCT-2010,2019
-ACCT,2010,13,Financial Accounting Concepts,0.41,0.31,0.21,0.03,0.0,0.0,0.05,0.0,lisa whe birtwistle,ACCT-2010,2019
-ACCT,2010,14,Financial Accounting Concepts,0.46,0.36,0.13,0.0,0.05,0.0,0.0,0.0,lisa whe birtwistle,ACCT-2010,2019
-ACCT,2010,15,Financial Accounting Concepts,0.34,0.39,0.15,0.07,0.05,0.0,0.0,0.0,james barnes,ACCT-2010,2019
-ACCT,2010,16,Financial Accounting Concepts,0.37,0.33,0.14,0.05,0.07,0.0,0.0,0.05,james barnes,ACCT-2010,2019
-ACCT,2010,17,Financial Accounting Concepts,0.0,0.34,0.41,0.07,0.07,0.0,0.0,0.1,lydia lan schleifer,ACCT-2010,2019
-ACCT,2010,101,Fin Acct Concepts (HON),0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,mary ann  prater,ACCT-2010,2019
-ACCT,2010,401,Financial Accounting Concepts,0.29,0.36,0.18,0.06,0.08,0.0,0.0,0.03,jeffrey mcmillan,ACCT-2010,2019
-ACCT,2020,1,Managerial Accounting Concepts,0.25,0.25,0.29,0.04,0.07,0.0,0.0,0.11,henry anderson,ACCT-2020,2019
-ACCT,2020,2,Managerial Accounting Concepts,0.34,0.26,0.26,0.06,0.03,0.0,0.0,0.06,henry anderson,ACCT-2020,2019
-ACCT,2020,3,Managerial Accounting Concepts,0.41,0.31,0.13,0.05,0.0,0.0,0.03,0.08,henry anderson,ACCT-2020,2019
-ACCT,2020,4,Managerial Accounting Concepts,0.29,0.36,0.24,0.05,0.05,0.0,0.0,0.02,emily suza mccorkle,ACCT-2020,2019
-ACCT,2020,5,Managerial Accounting Concepts,0.33,0.4,0.14,0.05,0.0,0.0,0.05,0.02,emily suza mccorkle,ACCT-2020,2019
-ACCT,2020,6,Managerial Accounting Concepts,0.31,0.27,0.25,0.1,0.02,0.0,0.0,0.04,phebia davis-culler,ACCT-2020,2019
-ACCT,2020,7,Managerial Accounting Concepts,0.23,0.38,0.17,0.09,0.0,0.0,0.13,0.0,phebia davis-culler,ACCT-2020,2019
-ACCT,2020,8,Managerial Accounting Concepts,0.16,0.23,0.37,0.09,0.0,0.0,0.09,0.05,phebia davis-culler,ACCT-2020,2019
-ACCT,2020,401,Managerial Accounting Concepts,0.28,0.35,0.22,0.04,0.01,0.0,0.0,0.11,henry anderson,ACCT-2020,2019
-ACCT,2900,1,Special Topics - Soft Skills,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,michael mendonca,ACCT-2900,2019
-ACCT,3030,1,Cost Accounting,0.38,0.31,0.28,0.03,0.0,0.0,0.0,0.0,babak mammadov,ACCT-3030,2019
-ACCT,3030,2,Cost Accounting,0.29,0.37,0.29,0.05,0.0,0.0,0.0,0.0,babak mammadov,ACCT-3030,2019
-ACCT,3030,3,Cost Accounting,0.12,0.36,0.36,0.06,0.03,0.0,0.0,0.06,jace garrett,ACCT-3030,2019
-ACCT,3030,4,Cost Accounting,0.33,0.25,0.33,0.03,0.03,0.0,0.0,0.03,jace garrett,ACCT-3030,2019
-ACCT,3030,5,Cost Accounting,0.28,0.44,0.08,0.11,0.0,0.0,0.0,0.08,jace garrett,ACCT-3030,2019
-ACCT,3110,1,Intermediate Financial Acct I,0.14,0.29,0.18,0.11,0.21,0.0,0.0,0.07,erin michel hawkins,ACCT-3110,2019
-ACCT,3110,2,Intermediate Financial Acct I,0.19,0.31,0.23,0.08,0.15,0.0,0.0,0.04,erin michel hawkins,ACCT-3110,2019
-ACCT,3110,3,Intermediate Financial Acct I,0.23,0.26,0.32,0.03,0.03,0.0,0.0,0.13,amy meliss donnelly,ACCT-3110,2019
-ACCT,3110,4,Intermediate Financial Acct I,0.28,0.38,0.22,0.09,0.0,0.0,0.0,0.03,amy meliss donnelly,ACCT-3110,2019
-ACCT,3110,5,Intermediate Financial Acct I,0.1,0.42,0.35,0.03,0.0,0.0,0.0,0.1,brian matth goodson,ACCT-3110,2019
-ACCT,3110,6,Intermediate Financial Acct I,0.17,0.23,0.37,0.07,0.0,0.0,0.0,0.17,brian matth goodson,ACCT-3110,2019
-ACCT,3110,401,Intermediate Financial Acct I,0.32,0.22,0.2,0.02,0.05,0.0,0.0,0.2,henry anderson,ACCT-3110,2019
-ACCT,3120,1,Intermediate Financial Acct II,0.16,0.21,0.32,0.11,0.05,0.0,0.0,0.16,jeremy micha vinson,ACCT-3120,2019
-ACCT,3120,2,Intermediate Financial Acct II,0.35,0.26,0.29,0.06,0.0,0.0,0.0,0.03,jeremy micha vinson,ACCT-3120,2019
-ACCT,3120,3,Intermediate Financial Acct II,0.41,0.45,0.1,0.0,0.0,0.0,0.0,0.03,terry daniel knause,ACCT-3120,2019
-ACCT,3120,4,Intermediate Financial Acct II,0.29,0.53,0.12,0.0,0.03,0.0,0.0,0.03,terry daniel knause,ACCT-3120,2019
-ACCT,3120,5,Intermediate Financial Acct II,0.14,0.48,0.29,0.0,0.0,0.0,0.0,0.1,terry daniel knause,ACCT-3120,2019
-ACCT,3120,6,Intermediate Financial Acct II,0.32,0.42,0.16,0.0,0.03,0.0,0.0,0.06,terry daniel knause,ACCT-3120,2019
-ACCT,3120,101,Intermed Fin Acct II (HON),0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,terry daniel knause,ACCT-3120,2019
-ACCT,3130,1,Intermediate Fin Acct III,0.24,0.5,0.24,0.0,0.0,0.0,0.0,0.02, russell madray,ACCT-3130,2019
-ACCT,3130,2,Intermediate Fin Acct III,0.22,0.44,0.2,0.1,0.02,0.0,0.0,0.02, russell madray,ACCT-3130,2019
-ACCT,3130,3,Intermediate Fin Acct III,0.38,0.43,0.17,0.02,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2019
-ACCT,3130,4,Intermediate Fin Acct III,0.45,0.42,0.09,0.03,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2019
-ACCT,3130,101,Intermed Fin Acct III (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0, russell madray,ACCT-3130,2019
-ACCT,3220,1,Accounting Information Systems,0.08,0.25,0.38,0.08,0.04,0.0,0.0,0.17,philip maiberger,ACCT-3220,2019
-ACCT,3220,2,Accounting Information Systems,0.04,0.48,0.3,0.09,0.04,0.0,0.0,0.04,philip maiberger,ACCT-3220,2019
-ACCT,3220,3,Accounting Information Systems,0.21,0.38,0.25,0.08,0.04,0.0,0.0,0.04,philip maiberger,ACCT-3220,2019
-ACCT,3220,4,Accounting Information Systems,0.1,0.38,0.29,0.0,0.0,0.0,0.1,0.14,philip maiberger,ACCT-3220,2019
-ACCT,4040,1,Individual Taxation,0.45,0.36,0.12,0.06,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2019
-ACCT,4040,2,Individual Taxation,0.38,0.35,0.18,0.05,0.03,0.0,0.0,0.03,sarah martin,ACCT-4040,2019
-ACCT,4040,3,Individual Taxation,0.24,0.53,0.16,0.05,0.0,0.0,0.0,0.03,lisa whe birtwistle,ACCT-4040,2019
-ACCT,4040,4,Individual Taxation,0.27,0.27,0.27,0.16,0.03,0.0,0.0,0.0,lisa whe birtwistle,ACCT-4040,2019
-ACCT,4040,101,Individual Taxation (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,ACCT-4040,2019
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,frances kennedy,ACCT-4100,2019
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,frances kennedy,ACCT-4100,2019
-ACCT,4100,3,Reporting and Mgmt Control Sys,0.33,0.5,0.13,0.03,0.0,0.0,0.0,0.0,gregory patr mcphee,ACCT-4100,2019
-ACCT,4150,1,Auditing,0.08,0.42,0.44,0.06,0.0,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2019
-ACCT,4150,2,Auditing,0.26,0.31,0.28,0.15,0.0,0.0,0.0,0.0,carl hollingsworth,ACCT-4150,2019
-ACCT,8520,1,Fin Acct Theory/Res,0.13,0.52,0.32,0.0,0.03,0.0,0.0,0.0,ralph edward welton,ACCT-8520,2019
-ACCT,8520,2,Fin Acct Theory/Res,0.28,0.59,0.14,0.0,0.0,0.0,0.0,0.0,ralph edward welton,ACCT-8520,2019
-ACCT,8540,1,Prof Responsibility,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,ACCT-8540,2019
-ACCT,8540,2,Prof Responsibility,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,robin radtke,ACCT-8540,2019
-ACCT,8540,3,Prof Responsibility,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,ACCT-8540,2019
-ACCT,8620,1,Financial Auditing,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-8620,2019
-ACCT,8620,2,Financial Auditing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,ACCT-8620,2019
-ACCT,8710,1,Corporate Taxation,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2019
-ACCT,8710,2,Corporate Taxation,0.49,0.44,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2019
-ACCT,8710,3,Corporate Taxation,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,derek dalton,ACCT-8710,2019
-ACCT,8730,1,Intl/Spec Tax Topic,0.48,0.39,0.13,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,ACCT-8730,2019
-ACCT,8740,1,Tax Aspects of Finan Planning,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,ACCT-8740,2019
-AGED,1000,1,Orientation & Field Experience,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,philip fravel,AGED-1000,2019
-AGED,2030,1,Teaching Agriscience,0.38,0.54,0.0,0.0,0.0,0.0,0.0,0.08,catheri dibenedetto,AGED-2030,2019
-AGED,8890,1,Intro to Res in Ed,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,AGED-8890,2019
-AGM,2050,1,Prin of Fabrication,0.29,0.42,0.11,0.05,0.08,0.0,0.0,0.05,hunter massey,AGM-2050,2019
-AGM,2060,1,Machinery Mgt,0.28,0.48,0.12,0.04,0.04,0.0,0.0,0.04,hunter massey,AGM-2060,2019
-AGM,2200,1,Calc for Mechanized Agricult,0.37,0.34,0.21,0.05,0.0,0.0,0.0,0.03,aaron paul turner,AGM-2200,2019
-AGM,2210,1,Land Measurements,0.6,0.26,0.13,0.01,0.0,0.0,0.0,0.0,robert gord hammond,AGM-2210,2019
-AGM,2210,1,Land Measurements,0.6,0.26,0.13,0.01,0.0,0.0,0.0,0.0,charles privette,AGM-2210,2019
-AGM,4020,1,Irrigation System Design,0.26,0.51,0.23,0.0,0.0,0.0,0.0,0.0,charles privette,AGM-4020,2019
-AGM,4100,1,Precision Ag Tech,0.36,0.43,0.15,0.06,0.0,0.0,0.0,0.0,hunter massey,AGM-4100,2019
-AGM,4520,1,Mobile Power,0.5,0.39,0.05,0.0,0.03,0.0,0.0,0.03,ali bulent koc,AGM-4520,2019
-AGM,4720,1,Capstone,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,john chastain,AGM-4720,2019
-AGRB,2020,1,Agricultural Economics,0.34,0.37,0.14,0.08,0.07,0.0,0.0,0.0,george apperson,AGRB-2020,2019
-AGRB,2050,1,Agriculture and Society,0.18,0.48,0.22,0.06,0.03,0.0,0.0,0.03,george apperson,AGRB-2050,2019
-AGRB,3080,1,Quant Agribusiness Analysis I,0.15,0.42,0.18,0.15,0.03,0.0,0.0,0.06,lisha zhang,AGRB-3080,2019
-AGRB,3190,1,Agribusiness Management,0.2,0.19,0.3,0.16,0.04,0.0,0.0,0.11,michael vassalos,AGRB-3190,2019
-AGRB,3510,1,Prin of Agricultural Sales Mgt,0.06,0.5,0.38,0.03,0.03,0.0,0.0,0.0,george apperson,AGRB-3510,2019
-AGRB,3570,1,Natural Resources Economics,0.21,0.23,0.36,0.17,0.0,0.0,0.0,0.02,david brian willis,AGRB-3570,2019
-AGRB,4020,1,Production Economics,0.23,0.38,0.0,0.31,0.0,0.0,0.0,0.08,michael vassalos,AGRB-4020,2019
-AGRB,4080,1,Quant Agribusiness Analysis II,0.42,0.33,0.21,0.02,0.02,0.0,0.0,0.0,lisha zhang,AGRB-4080,2019
-AGRB,4560,1,Prices,0.43,0.4,0.12,0.05,0.0,0.0,0.0,0.0,yuliya val bolotova,AGRB-4560,2019
-AL,3490,400,Principles of Coaching,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2019
-AL,3490,401,Principles of Coaching,0.61,0.29,0.11,0.0,0.0,0.0,0.0,0.0,deborah cadorette,AL-3490,2019
-AL,3490,402,Principles of Coaching,0.7,0.11,0.04,0.04,0.04,0.0,0.0,0.07,frank mezzanotte,AL-3490,2019
-AL,3490,403,Principles of Coaching,0.6,0.28,0.04,0.08,0.0,0.0,0.0,0.0,clyde keith connor,AL-3490,2019
-AL,3490,404,Principles of Coaching,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,nicholas ph whitrow,AL-3490,2019
-AL,3490,406,Principles of Coaching,0.6,0.28,0.08,0.0,0.0,0.0,0.0,0.04,john plumblee,AL-3490,2019
-AL,3490,407,Principles of Coaching,0.72,0.12,0.16,0.0,0.0,0.0,0.0,0.0,john plumblee,AL-3490,2019
-AL,3490,408,Principles of Coaching,0.84,0.04,0.08,0.0,0.0,0.0,0.0,0.04,nicholas ph whitrow,AL-3490,2019
-AL,3490,409,Principles of Coaching,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,nicholas ph whitrow,AL-3490,2019
-AL,3490,410,Principles of Coaching,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,edmond fry,AL-3490,2019
-AL,3500,400,Sci Basis I/Ex Phy,0.2,0.24,0.28,0.2,0.04,0.0,0.0,0.04,michael godfrey,AL-3500,2019
-AL,3500,401,Sci Basis I/Ex Phy,0.19,0.26,0.33,0.15,0.04,0.0,0.0,0.04,michael godfrey,AL-3500,2019
-AL,3520,400,Kinesiology,0.27,0.13,0.0,0.2,0.2,0.0,0.0,0.2,isaac sean colbert,AL-3520,2019
-AL,3530,400,Athletic Injuries,0.12,0.32,0.48,0.04,0.04,0.0,0.0,0.0,isaac sean colbert,AL-3530,2019
-AL,3530,401,Athletic Injuries,0.16,0.32,0.4,0.08,0.04,0.0,0.0,0.0,isaac sean colbert,AL-3530,2019
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,clyde keith connor,AL-3600,2019
-AL,3610,400,Admin/Org of Athletic Programs,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2019
-AL,3610,401,Admin/Org of Athletic Programs,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,AL-3610,2019
-AL,3610,402,Admin/Org of Athletic Programs,0.83,0.08,0.04,0.0,0.04,0.0,0.0,0.0,henry oates,AL-3610,2019
-AL,3620,400,Psychology of Coaching,0.24,0.36,0.32,0.0,0.04,0.0,0.0,0.04,natalie anne carter,AL-3620,2019
-AL,3620,401,Psychology of Coaching,0.36,0.36,0.2,0.04,0.0,0.0,0.0,0.04,natalie anne carter,AL-3620,2019
-AL,3620,402,Psychology of Coaching,0.38,0.25,0.29,0.0,0.04,0.0,0.0,0.04,natalie anne carter,AL-3620,2019
-AL,3710,400,Coaching Baseball,0.55,0.3,0.05,0.0,0.0,0.0,0.0,0.1,deborah cadorette,AL-3710,2019
-AL,3720,400,Coaching Basketball,0.72,0.12,0.08,0.04,0.04,0.0,0.0,0.0,edmond fry,AL-3720,2019
-AL,3740,400,Coaching Football,0.48,0.24,0.2,0.08,0.0,0.0,0.0,0.0,edmond fry,AL-3740,2019
-AL,3750,400,Coaching Soccer,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,deborah cadorette,AL-3750,2019
-AL,3760,400,Coaching Strength/Conditioning,0.56,0.19,0.19,0.04,0.0,0.0,0.0,0.04,edmond fry,AL-3760,2019
-AL,3760,401,Coaching Strength/Conditioning,0.58,0.21,0.08,0.0,0.08,0.0,0.0,0.04,edmond fry,AL-3760,2019
-AL,4380,401,Officiating in Athl Leadership,0.68,0.16,0.08,0.04,0.04,0.0,0.0,0.0,clyde keith connor,AL-4380,2019
-AL,4380,403,Social Issues,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,AL-4380,2019
-AL,4490,400,Athlete Beliefs,0.41,0.3,0.15,0.15,0.0,0.0,0.0,0.0,deborah cadorette,AL-4490,2019
-AL,4490,401,Athlete Beliefs,0.58,0.21,0.08,0.04,0.08,0.0,0.0,0.0,deborah cadorette,AL-4490,2019
-AL,8380,400,Intercoll Ath Personnel Mgm,0.85,0.07,0.04,0.0,0.04,0.0,0.0,0.0,kyle mclendon young,AL-8380,2019
-AL,8530,400,Legal Iss in Intercoll Athlet,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,AL-8530,2019
-AL,8630,400,Socio Dynam in Intercol Athlet,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,michael godfrey,AL-8630,2019
-AL,8630,401,Socio Dynam in Intercol Athlet,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,michael godfrey,AL-8630,2019
-AL,8640,400,Ethical Iss in Collegiate Athl,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,janna there magette,AL-8640,2019
-AL,8640,401,Ethical Iss in Collegiate Athl,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.04,janna there magette,AL-8640,2019
-AL,8700,400,Intercoll Athletics Finance,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,AL-8700,2019
-AL,8700,401,Intercoll Athletics Finance,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,misty soles,AL-8700,2019
-ANTH,2010,1,Introduction to Anthropology,0.36,0.56,0.07,0.0,0.0,0.0,0.0,0.01,david markus,ANTH-2010,2019
-ANTH,2010,2,Introduction to Anthropology,0.25,0.64,0.07,0.01,0.0,0.0,0.0,0.02,david markus,ANTH-2010,2019
-ANTH,2010,3,Introduction to Anthropology,0.46,0.32,0.05,0.04,0.04,0.0,0.0,0.11,lisa rapaport,ANTH-2010,2019
-ANTH,2010,4,Introduction to Anthropology,0.47,0.31,0.14,0.03,0.02,0.0,0.0,0.03,yi wu,ANTH-2010,2019
-ANTH,3010,1,Cultural Anthropology,0.07,0.32,0.43,0.14,0.0,0.0,0.04,0.0,john coggeshall,ANTH-3010,2019
-ANTH,3250,1,The Anthropology of Food,0.33,0.24,0.14,0.0,0.0,0.0,0.0,0.29,yi wu,ANTH-3250,2019
-ANTH,3310,1,Archaeology,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,david markus,ANTH-3310,2019
-ANTH,4040,1,Anthropological Theories,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,john coggeshall,ANTH-4040,2019
-ANTH,4800,1,Business Anthropology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,ANTH-4800,2019
-ARCH,1510,1,Arch Communication,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,sal hambright-belue,ARCH-1510,2019
-ARCH,1510,2,Arch Communication,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,ARCH-1510,2019
-ARCH,1510,2,Arch Communication,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,robert silance,ARCH-1510,2019
-ARCH,1510,3,Arch Communication,0.57,0.21,0.0,0.07,0.07,0.0,0.0,0.07,sal hambright-belue,ARCH-1510,2019
-ARCH,1510,3,Arch Communication,0.57,0.21,0.0,0.07,0.07,0.0,0.0,0.07,clarissa mendez,ARCH-1510,2019
-ARCH,1510,4,Arch Communication,0.2,0.6,0.13,0.07,0.0,0.0,0.0,0.0,george schafer,ARCH-1510,2019
-ARCH,1510,4,Arch Communication,0.2,0.6,0.13,0.07,0.0,0.0,0.0,0.0,sal hambright-belue,ARCH-1510,2019
-ARCH,1510,5,Arch Communication,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,sal hambright-belue,ARCH-1510,2019
-ARCH,1510,5,Arch Communication,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,berrin terim,ARCH-1510,2019
-ARCH,1510,6,Arch Communication,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,ARCH-1510,2019
-ARCH,2520,1,Arch Foundations II,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-2520,2019
-ARCH,2520,1,Arch Foundations II,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,brandon george pass,ARCH-2520,2019
-ARCH,2520,2,Arch Foundations II,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,clarissa mendez,ARCH-2520,2019
-ARCH,2520,2,Arch Foundations II,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-2520,2019
-ARCH,2520,3,Arch Foundations II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,ARCH-2520,2019
-ARCH,2520,3,Arch Foundations II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-2520,2019
-ARCH,2520,4,Arch Foundations II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,ARCH-2520,2019
-ARCH,2520,4,Arch Foundations II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-2520,2019
-ARCH,2520,5,Arch Foundations II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,ARCH-2520,2019
-ARCH,2520,5,Arch Foundations II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-2520,2019
-ARCH,2520,6,Arch Foundations II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,berrin terim,ARCH-2520,2019
-ARCH,2520,6,Arch Foundations II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-2520,2019
-ARCH,2700,1,Structures I,0.55,0.09,0.27,0.0,0.09,0.0,0.0,0.0,michael carl kleiss,ARCH-2700,2019
-ARCH,2710,1,Structures II,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,dustin gra albright,ARCH-2710,2019
-ARCH,3510,2,Studio Clemson,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,ARCH-3510,2019
-ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-3540,2019
-ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-3540,2019
-ARCH,4050,1,American Arch Styles 1650-1950,0.63,0.25,0.06,0.0,0.06,0.0,0.0,0.0,robert bruhns,ARCH-4050,2019
-ARCH,4120,2,History Research,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,ARCH-4120,2019
-ARCH,4120,2,History Research,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4120,2019
-ARCH,4140,2,Design Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4140,2019
-ARCH,4140,2,Design Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,ARCH-4140,2019
-ARCH,4210,1,Arch Seminar,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,raymond thadde huff,ARCH-4210,2019
-ARCH,4290,1,Architectural Graphics,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,ashley jennings,ARCH-4290,2019
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,david lee,ARCH-4520,2019
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4520,2019
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-4520,2019
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,george schafer,ARCH-4520,2019
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-4520,2019
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-4520,2019
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-4520,2019
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4520,2019
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4520,2019
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-4520,2019
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4520,2019
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-4520,2019
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4520,2019
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-4520,2019
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-4520,2019
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-4520,2019
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4520,2019
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4520,2019
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-4520,2019
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-4520,2019
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,ARCH-4520,2019
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-4520,2019
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,timothy burl brown,ARCH-4520,2019
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,george schafer,ARCH-4520,2019
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0, franco santa cruz,ARCH-4520,2019
-ARCH,4710,1,Arch Hist of Place,0.08,0.75,0.17,0.0,0.0,0.0,0.0,0.0,jason matthew white,ARCH-4710,2019
-ARCH,8110,1,Visualization II,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,douglas hecker,ARCH-8110,2019
-ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,ARCH-8120,2019
-ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,timothy sutherland,ARCH-8120,2019
-ARCH,8520,7,Design Studio IV,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,ARCH-8520,2019
-ARCH,8610,1,History/Theory II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,ARCH-8610,2019
-ARCH,8620,2,History/Theory III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james thomas,ARCH-8620,2019
-ARCH,8650,1,Topics in Health Policy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anjali joseph,ARCH-8650,2019
-ARCH,8650,1,Topics in Health Policy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deborah mar wingler,ARCH-8650,2019
-ARCH,8710,1,Structures II,0.54,0.31,0.08,0.0,0.08,0.0,0.0,0.0,dustin gra albright,ARCH-8710,2019
-ARCH,8710,1,Structures II,0.54,0.31,0.08,0.0,0.08,0.0,0.0,0.0,timothy burl brown,ARCH-8710,2019
-ARCH,8730,2,Environmental Sys,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,ARCH-8730,2019
-ART,1060,1,Foundation Drawing II,0.5,0.33,0.08,0.0,0.0,0.0,0.0,0.08,denise elizab ayers,ART-1060,2019
-ART,1510,1,Foundations Art I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,ART-1510,2019
-ART,1520,1,Foundations Art II,0.42,0.25,0.25,0.08,0.0,0.0,0.0,0.0,daniel bare,ART-1520,2019
-ART,2050,1,Beginning Life Drawing,0.53,0.29,0.0,0.06,0.06,0.0,0.0,0.06,annamarie williams,ART-2050,2019
-ART,2070,1,Beginning Painting,0.38,0.54,0.0,0.0,0.08,0.0,0.0,0.0,serra raven shuford,ART-2070,2019
-ART,2090,1,Beginning Sculpture,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,ART-2090,2019
-ART,2100,6,Art Appreciation,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,angel roch estrella,ART-2100,2019
-ART,2100,7,Art Appreciation,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,ART-2100,2019
-ART,2100,10,Art Appreciation,0.84,0.12,0.0,0.0,0.04,0.0,0.0,0.0,deighton tay abrams,ART-2100,2019
-ART,2100,11,Art Appreciation,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,ART-2100,2019
-ART,2110,1,Begin Printmaking,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,allison rae johnson,ART-2110,2019
-ART,2130,1,Begin Photography,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,ART-2130,2019
-ART,2170,1,Beginning Ceramics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,sara mays,ART-2170,2019
-ART,3130,1,Photography,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,ART-3130,2019
-ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,ART-3550,2019
-ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,ART-3550,2019
-ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,david detrich,ART-3550,2019
-ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,ART-3570,2019
-ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,ART-3570,2019
-ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,valerie zimany,ART-3570,2019
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-1100,2019
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1100,2019
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,AS-1100,2019
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-1100,2019
-AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,AS-1100,2019
-AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-1100,2019
-AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-1100,2019
-AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-1100,2019
-AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,AS-2100,2019
-AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-2100,2019
-AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2100,2019
-AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-2100,2019
-AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,AS-2100,2019
-AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2100,2019
-AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-2100,2019
-AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,AS-2100,2019
-AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-2100,2019
-AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-2100,2019
-AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-2100,2019
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4100,2019
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-4100,2019
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,AS-4100,2019
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-4100,2019
-AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,AS-4100,2019
-AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,AS-4100,2019
-AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,AS-4100,2019
-AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,AS-4100,2019
-ASL,1010,1,Am Sign Lang I,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,william ry clements,ASL-1010,2019
-ASL,1010,2,Am Sign Lang I,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,william ry clements,ASL-1010,2019
-ASL,1010,3,Am Sign Lang I,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,william ry clements,ASL-1010,2019
-ASL,1020,1,Am Sign Lang I,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-1020,2019
-ASL,1020,2,Am Sign Lang I,0.5,0.38,0.04,0.04,0.04,0.0,0.0,0.0,jason hurdich,ASL-1020,2019
-ASL,1020,3,Am Sign Lang I,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,william ry clements,ASL-1020,2019
-ASL,1020,4,Am Sign Lang I,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,jody herbert cripps,ASL-1020,2019
-ASL,2010,1,Am Sign Lang II,0.31,0.23,0.46,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-2010,2019
-ASL,2010,2,Am Sign Lang II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-2010,2019
-ASL,2020,1,Am Sign Lang II,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-2020,2019
-ASL,2020,2,Am Sign Lang II,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,jason hurdich,ASL-2020,2019
-ASL,2020,3,Am Sign Lang II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,ASL-2020,2019
-ASL,3020,1,Advanced Asl II,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,william ry clements,ASL-3020,2019
-ASL,3050,1,Deaf Studies,0.76,0.12,0.08,0.0,0.04,0.0,0.0,0.0,jason hurdich,ASL-3050,2019
-ASTR,1010,1,Solar System Astronomy,0.41,0.3,0.16,0.06,0.03,0.0,0.0,0.04,david edwar connick,ASTR-1010,2019
-ASTR,1020,2,Stellar Astronomy,0.16,0.23,0.28,0.15,0.0,0.0,0.16,0.03,mate adamkovics,ASTR-1020,2019
-ASTR,1030,1,Solar Systm Astr Lab,0.39,0.39,0.09,0.04,0.0,0.0,0.0,0.09,mark leising,ASTR-1030,2019
-ASTR,1030,2,Solar Systm Astr Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.04,0.0,mark leising,ASTR-1030,2019
-ASTR,1030,3,Solar Systm Astr Lab,0.32,0.48,0.12,0.08,0.0,0.0,0.0,0.0,mark leising,ASTR-1030,2019
-ASTR,1040,1,Stellar Astr Lab,0.3,0.2,0.3,0.0,0.0,0.0,0.1,0.1,mark leising,ASTR-1040,2019
-ASTR,1040,2,Stellar Astr Lab,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,mark leising,ASTR-1040,2019
-ASTR,1040,4,Stellar Astr Lab,0.3,0.55,0.05,0.0,0.05,0.0,0.0,0.05,mark leising,ASTR-1040,2019
-ASTR,3030,1,Galactic Astrophys,0.42,0.33,0.25,0.0,0.0,0.0,0.0,0.0,marco ajello,ASTR-3030,2019
-ASTR,8400,1,Astroph: Cosmology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,ASTR-8400,2019
-ASTR,8750,1,Astronomy Seminar,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,marco ajello,ASTR-8750,2019
-AUD,2850,1,Acoustics of Music,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,AUD-2850,2019
-AUE,4020,699,Adv & Electrified Powertrains,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,zoran filipi,AUE-4020,2019
-AUE,4020,699,Adv & Electrified Powertrains,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,qilun zhu,AUE-4020,2019
-AUE,8160,3,Eng Combustion Emiss,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,robert prucka,AUE-8160,2019
-AUE,8170,410,Alt Energy Sources,0.38,0.44,0.06,0.0,0.13,0.0,0.0,0.0,pierluigi pisu,AUE-8170,2019
-AUE,8500,6,Stability/Safety Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,AUE-8500,2019
-AUE,8550,16,Struct/Thermal Analysis Mthds,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,AUE-8550,2019
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett,AUE-8690,2019
-AUE,8770,405,Light-Weight Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,AUE-8770,2019
-AUE,8860,1,Noise Vibration,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blan poland,AUE-8860,2019
-AUE,8930,401,Autonomous Driving Techn,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,AUE-8930,2019
-AUE,8930,405,Perception and Intelligence,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bing li,AUE-8930,2019
-AVS,2000,1,Beef Cattle Tech,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,nathan long,AVS-2000,2019
-AVS,2030,1,Dairy Sci Techniques,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,heather walker dunn,AVS-2030,2019
-AVS,2090,1,Livestock Exhibition Technique,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,richelle lor miller,AVS-2090,2019
-AVS,3010,1,Anat & Phys Dom Ani,0.71,0.2,0.08,0.0,0.0,0.0,0.0,0.01,tiffany wilmoth,AVS-3010,2019
-AVS,3090,1,Equine Evaluation,0.71,0.12,0.06,0.06,0.06,0.0,0.0,0.0,chelsea dr sinclair,AVS-3090,2019
-AVS,3100,1,Animal Health,0.59,0.25,0.13,0.03,0.0,0.0,0.0,0.0,celina marc checura,AVS-3100,2019
-AVS,3150,1,Animal Welfare,0.47,0.32,0.13,0.09,0.0,0.0,0.0,0.0,heather walker dunn,AVS-3150,2019
-AVS,3700,1,Principles of Animal Nutrition,0.34,0.36,0.17,0.09,0.02,0.0,0.0,0.02,james ro strickland,AVS-3700,2019
-AVS,3750,1,Applied Animal Nutrition,0.35,0.35,0.2,0.1,0.0,0.0,0.0,0.0,mir arguelles-ramos,AVS-3750,2019
-AVS,4100,1,Domestic Ani Behav,0.69,0.21,0.09,0.0,0.0,0.0,0.0,0.01,james ro strickland,AVS-4100,2019
-AVS,4120,1,Advanced Equine Management,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,AVS-4120,2019
-AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,glenn birrenkott,AVS-4130,2019
-AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,richelle lor miller,AVS-4130,2019
-AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,annel greene,AVS-4130,2019
-AVS,4140,1,Basic Immunology,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,farzana ferdous,AVS-4140,2019
-AVS,4220,6,Advanced Fetal Fescue Research,0.85,0.0,0.15,0.0,0.0,0.0,0.0,0.0,susan kay duckett,AVS-4220,2019
-AVS,4530,1,Animal Reproduction,0.22,0.29,0.31,0.13,0.04,0.0,0.0,0.0,celina marc checura,AVS-4530,2019
-AVS,4550,2,Animal Repro Mgt-Equine,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,chelsea dr sinclair,AVS-4550,2019
-AVS,4700,1,Animal Genetics,0.24,0.33,0.21,0.06,0.06,0.0,0.0,0.09,joseph kei bertrand,AVS-4700,2019
-BCHM,3010,1,Molecular Biochemistry,0.17,0.46,0.25,0.03,0.0,0.0,0.0,0.1,meredith tei morris,BCHM-3010,2019
-BCHM,3010,2,Molecular Biochem(HON),0.4,0.29,0.24,0.02,0.02,0.0,0.0,0.02,cheryl ingram-smith,BCHM-3010,2019
-BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2019
-BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,BCHM-3040,2019
-BCHM,3040,4,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-3040,2019
-BCHM,3040,4,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,BCHM-3040,2019
-BCHM,3050,1,Essen Elements Bioch,0.47,0.38,0.11,0.01,0.01,0.0,0.0,0.02,debra ragland,BCHM-3050,2019
-BCHM,3050,2,Essen Elements Bioch,0.53,0.33,0.08,0.03,0.01,0.0,0.0,0.02,debra ragland,BCHM-3050,2019
-BCHM,4320,1,Bioch of Metabolism,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,kimberly paul,BCHM-4320,2019
-BCHM,4340,3,Biochemistry of Metabolism Lab,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-4340,2019
-BCHM,4340,4,Biochemistry of Metabolism Lab,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,geoffrey ford,BCHM-4340,2019
-BCHM,4360,1,Genes to Proteins,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,BCHM-4360,2019
-BCHM,4360,2,Mol Bio Genes to Proteins(HON),0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,BCHM-4360,2019
-BCHM,4400,1,Bioinformatics,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,liangjiang wang,BCHM-4400,2019
-BCHM,4910,35,CI:DNA Repair,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,BCHM-4910,2019
-BCHM,4930,1,Senior Seminar,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,BCHM-4930,2019
-BCHM,8050,1,Issues in Research,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william marcotte,BCHM-8050,2019
-BE,2100,1,Intro to Biosystems Engr,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,jazmine octa taylor,BE-2100,2019
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.31,0.54,0.12,0.04,0.0,0.0,0.0,0.0,tom owino,BE-3220,2019
-BE,4120,1,Be Heat Mass Trans,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,BE-4120,2019
-BE,4150,1,Instr & Control for Biosys Eng,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,rui xiao,BE-4150,2019
-BE,4240,1,Ecological Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,BE-4240,2019
-BE,4380,1,Bioprocess Engineering Design,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,terry walker,BE-4380,2019
-BE,4400,1,Sustainable Energy Engineering,0.36,0.21,0.29,0.14,0.0,0.0,0.0,0.0,jazmine octa taylor,BE-4400,2019
-BIOE,1010,1,Biol for Bioengr,0.6,0.35,0.02,0.0,0.02,0.0,0.0,0.02,vladimir vla reukov,BIOE-1010,2019
-BIOE,1010,1,Biol for Bioengr,0.6,0.35,0.02,0.0,0.02,0.0,0.0,0.02,tyler george harvey,BIOE-1010,2019
-BIOE,2010,1,Intro Biomed Engr,0.44,0.31,0.13,0.13,0.0,0.0,0.0,0.0,vladimir vla reukov,BIOE-2010,2019
-BIOE,3020,1,Biomaterials,0.61,0.29,0.06,0.01,0.0,0.0,0.0,0.03,alexey ale vertegel,BIOE-3020,2019
-BIOE,3100,1,Engr Analysis of Physiol Proc,0.54,0.36,0.07,0.04,0.0,0.0,0.0,0.0,brian william booth,BIOE-3100,2019
-BIOE,3200,1,Biomechanics,0.79,0.18,0.0,0.03,0.0,0.0,0.0,0.0,william richardson,BIOE-3200,2019
-BIOE,3210,1,Biofluid Mechanics,0.25,0.53,0.12,0.07,0.03,0.0,0.0,0.0,sarah harcum,BIOE-3210,2019
-BIOE,3470,1,Transport Processes in Bioengr,0.39,0.36,0.18,0.0,0.0,0.0,0.0,0.07,robert latour,BIOE-3470,2019
-BIOE,3700,1,Bioinst & Imaging,0.37,0.45,0.13,0.03,0.0,0.0,0.0,0.01,jordon anth gilmore,BIOE-3700,2019
-BIOE,4200,1,Sports Engineering,0.65,0.25,0.06,0.02,0.02,0.0,0.0,0.0,cynthia mille smith,BIOE-4200,2019
-BIOE,4490,1,Drug Delivery,0.55,0.35,0.06,0.0,0.03,0.0,0.0,0.0,jeoungsoo lee,BIOE-4490,2019
-BIOE,4510,21,CI - Hands On Tissue Engr,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,BIOE-4510,2019
-BIOE,4510,37,CI-Innov in Bioinstrumentation,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,delphine dean,BIOE-4510,2019
-BIOE,6200,1,Sports Engineering,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,BIOE-6200,2019
-BIOE,6230,1,Cardiovascular Engr and Path,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,martine laberge,BIOE-6230,2019
-BIOE,6230,1,Cardiovascular Engr and Path,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,dan simionescu,BIOE-6230,2019
-BIOE,8130,1,Industrial Bioengineering,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michael taylor,BIOE-8130,2019
-BIOE,8200,1,Structl Biomechanics,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,hai yao,BIOE-8200,2019
-BIOE,8500,2,Mechanobiology,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,BIOE-8500,2019
-BIOL,1040,1,General Biology II,0.32,0.3,0.2,0.09,0.02,0.0,0.0,0.06,nora espinoza,BIOL-1040,2019
-BIOL,1040,2,General Biology II,0.28,0.21,0.29,0.09,0.07,0.0,0.0,0.07,dylan dittrich-reed,BIOL-1040,2019
-BIOL,1040,3,General Biology II,0.14,0.28,0.29,0.12,0.1,0.0,0.0,0.08,salvatore sparace,BIOL-1040,2019
-BIOL,1040,4,General Biology II (HON),0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,BIOL-1040,2019
-BIOL,1060,1,Gen Biology Lab II,0.04,0.29,0.17,0.25,0.17,0.0,0.0,0.08,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,2,Gen Biology Lab II,0.1,0.19,0.38,0.33,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,3,Gen Biology Lab II,0.16,0.21,0.21,0.16,0.26,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,4,Gen Biology Lab II,0.04,0.17,0.25,0.33,0.08,0.0,0.0,0.13,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,5,Gen Biology Lab II,0.13,0.0,0.25,0.06,0.25,0.0,0.0,0.31,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,7,Gen Biology Lab II,0.3,0.1,0.3,0.0,0.3,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,8,Gen Biology Lab II,0.04,0.33,0.42,0.13,0.08,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,9,Gen Biology Lab II,0.06,0.06,0.56,0.31,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,10,Gen Biology Lab II,0.06,0.18,0.29,0.0,0.41,0.0,0.0,0.06,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,11,Gen Biology Lab II,0.09,0.22,0.43,0.17,0.04,0.0,0.0,0.04,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,12,Gen Biology Lab II,0.13,0.19,0.5,0.13,0.06,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,13,Gen Biology Lab II,0.08,0.15,0.54,0.08,0.0,0.0,0.0,0.15,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,14,Gen Biology Lab II,0.05,0.45,0.2,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,15,Gen Biology Lab II,0.06,0.22,0.33,0.17,0.22,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,16,Gen Biology Lab II,0.08,0.33,0.33,0.25,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,18,Gen Biology Lab II,0.05,0.18,0.32,0.32,0.14,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,19,Gen Biology Lab II,0.0,0.27,0.33,0.2,0.2,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,20,Gen Biology Lab II,0.07,0.2,0.2,0.13,0.2,0.0,0.0,0.2,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,21,Gen Biology Lab II,0.14,0.23,0.32,0.14,0.09,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,22,Gen Biology Lab II,0.0,0.18,0.36,0.45,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,24,Gen Biology Lab II,0.04,0.22,0.35,0.26,0.04,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,25,Gen Biology Lab II,0.25,0.25,0.33,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,26,Gen Biology Lab II,0.17,0.43,0.26,0.04,0.09,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,27,Gen Biology Lab II,0.25,0.4,0.15,0.2,0.0,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,28,Gen Biology Lab II,0.21,0.21,0.32,0.21,0.0,0.0,0.0,0.05,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,30,Gen Biology Lab II,0.17,0.35,0.35,0.04,0.0,0.0,0.0,0.09,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1060,32,Gen Biology Lab II,0.07,0.47,0.27,0.07,0.13,0.0,0.0,0.0,tafadzwa kaisa,BIOL-1060,2019
-BIOL,1110,1,Principles of Biology II,0.52,0.33,0.12,0.03,0.0,0.0,0.01,0.0,renea chri hardwick,BIOL-1110,2019
-BIOL,1110,2,Principles of Biology II (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,BIOL-1110,2019
-BIOL,1110,3,Principles of Biology II,0.34,0.43,0.14,0.04,0.05,0.0,0.0,0.02, christine minor,BIOL-1110,2019
-BIOL,1110,4,Prin of Biol II  (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,BIOL-1110,2019
-BIOL,2000,1,Biology in the News,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,tamara mcnutt-scott,BIOL-2000,2019
-BIOL,2040,1,"Environ, Energy and Society",0.6,0.33,0.04,0.02,0.0,0.0,0.0,0.0,john jenkins hains,BIOL-2040,2019
-BIOL,2040,2,"Environ, Energy and Society",0.33,0.41,0.17,0.07,0.0,0.0,0.0,0.01,john jenkins hains,BIOL-2040,2019
-BIOL,2230,1,Human Anat and Physiology II,0.39,0.37,0.16,0.04,0.02,0.0,0.0,0.01,john cummings,BIOL-2230,2019
-BIOL,2230,2,Human Anat and Physiology II,0.41,0.35,0.16,0.04,0.03,0.0,0.0,0.01,john cummings,BIOL-2230,2019
-BIOL,3020,1,Invertebrate Biology,0.32,0.34,0.2,0.07,0.02,0.0,0.0,0.05,juan baeza migueles,BIOL-3020,2019
-BIOL,3040,1,Biology of Plants,0.31,0.24,0.1,0.29,0.07,0.0,0.0,0.0,nathan redding,BIOL-3040,2019
-BIOL,3060,1,Invertebrate Biology Lab,0.33,0.25,0.29,0.08,0.0,0.0,0.0,0.04,juan baeza migueles,BIOL-3060,2019
-BIOL,3060,2,Invertebrate Biology Lab,0.53,0.32,0.05,0.05,0.0,0.0,0.0,0.05,juan baeza migueles,BIOL-3060,2019
-BIOL,3080,1,Biology of Plants Practicum,0.45,0.25,0.1,0.15,0.05,0.0,0.0,0.0,nathan redding,BIOL-3080,2019
-BIOL,3080,2,Biology of Plants Practicum,0.5,0.2,0.2,0.0,0.1,0.0,0.0,0.0,nathan redding,BIOL-3080,2019
-BIOL,3160,1,Human Physiology,0.33,0.43,0.19,0.03,0.01,0.0,0.0,0.01,tamara mcnutt-scott,BIOL-3160,2019
-BIOL,3350,1,Evolutionary Biology,0.43,0.38,0.15,0.02,0.01,0.0,0.0,0.01,margaret ptacek,BIOL-3350,2019
-BIOL,3350,2,Evolutionary Biology (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,margaret ptacek,BIOL-3350,2019
-BIOL,3940,3,CI: What is in our Waters?,0.8,0.0,0.0,0.2,0.0,0.0,0.0,0.0,peter van den hurk,BIOL-3940,2019
-BIOL,4010,1,Plant Physiology,0.17,0.2,0.28,0.21,0.0,0.0,0.08,0.07,douglas bielenberg,BIOL-4010,2019
-BIOL,4020,1,Plant Physiology Lab,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,BIOL-4020,2019
-BIOL,4020,2,Plant Physiology Lab,0.65,0.1,0.2,0.0,0.05,0.0,0.0,0.0,douglas bielenberg,BIOL-4020,2019
-BIOL,4030,1,Intro to Applied Genomics,0.0,0.07,0.36,0.07,0.07,0.0,0.0,0.43,vincent pa richards,BIOL-4030,2019
-BIOL,4140,1,Basic Immunology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,BIOL-4140,2019
-BIOL,4340,1,Biological Chem Lab Techniques,0.14,0.36,0.36,0.07,0.0,0.0,0.0,0.07,salvatore sparace,BIOL-4340,2019
-BIOL,4340,2,Biological Chem Lab Techniques,0.0,0.38,0.38,0.08,0.0,0.0,0.0,0.15,salvatore sparace,BIOL-4340,2019
-BIOL,4610,1,Cell Biology,0.36,0.36,0.15,0.07,0.03,0.0,0.0,0.03,lesly temesvari,BIOL-4610,2019
-BIOL,4610,2,Cell Biology (HON),0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4610,2019
-BIOL,4620,1,Cell Biology Lab (Lec),0.69,0.23,0.04,0.0,0.04,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,2,Cell Biology Lab (Lec),0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,4,Cell Biology Lab (Lec),0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,BIOL-4620,2019
-BIOL,4620,5,Cell Biology Lab (Lec),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,6,Cell Biology Lab (Lec),0.65,0.27,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4620,7,Cell Biology Lab (Lec),0.6,0.28,0.12,0.0,0.0,0.0,0.0,0.0,xianzhong yu,BIOL-4620,2019
-BIOL,4670,1,Principles of Hematology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,BIOL-4670,2019
-BIOL,4700,1,Behavioral Ecology,0.44,0.38,0.14,0.03,0.01,0.0,0.0,0.0,michael childress,BIOL-4700,2019
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,michael childress,BIOL-4710,2019
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.69,0.13,0.06,0.13,0.0,0.0,0.0,0.0,michael childress,BIOL-4710,2019
-BIOL,4710,3,Behavioral Ecology Lab (Lec),0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,michael childress,BIOL-4710,2019
-BIOL,4710,4,Behavioral Ecology Lab (Lec),0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,michael childress,BIOL-4710,2019
-BIOL,4780,1,Exercise Physiology,0.79,0.17,0.0,0.0,0.02,0.0,0.0,0.02,john cummings,BIOL-4780,2019
-BIOL,4800,1,Vertebrate Endocrinology,0.26,0.4,0.21,0.07,0.0,0.0,0.02,0.02,william baldwin,BIOL-4800,2019
-BIOL,4830,1,Stem Cell Biology,0.61,0.32,0.05,0.0,0.0,0.0,0.0,0.02,vincent gallicchio,BIOL-4830,2019
-BIOL,4930,2,Sr Sem: Immuno & Immunotherapy,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,yanzhang wei,BIOL-4930,2019
-BIOL,4930,3,Sr Sem: Nervous Systems,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,BIOL-4930,2019
-BIOL,4930,6,Sr Sem: Biol Behind Our Food,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,peter van den hurk,BIOL-4930,2019
-BIOL,4930,7,Sr Sem: Genomics,0.75,0.19,0.0,0.0,0.0,0.0,0.06,0.0,kara elizabe powder,BIOL-4930,2019
-BIOL,4930,8,Sen Sem: Evolutionary Medicine,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,samantha ann price,BIOL-4930,2019
-BIOL,4940,2,CI: Popular Science Journalism,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,steven katz,BIOL-4940,2019
-BIOL,4940,2,CI: Popular Science Journalism,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,BIOL-4940,2019
-BIOL,4940,9,CI: Marine Conservation & Gen,0.88,0.0,0.0,0.0,0.13,0.0,0.0,0.0,juan baeza migueles,BIOL-4940,2019
-BIOL,6030,1,Intro to Applied Genomics,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,vincent pa richards,BIOL-6030,2019
-BIOL,8430,1,Underst Genetics & Evol Biol,0.63,0.31,0.01,0.0,0.03,0.0,0.0,0.03,margaret ptacek,BIOL-8430,2019
-BIOL,8430,1,Underst Genetics & Evol Biol,0.63,0.31,0.01,0.0,0.03,0.0,0.0,0.03,renea chri hardwick,BIOL-8430,2019
-BIOL,8450,1,Understanding Animal Biology,0.85,0.1,0.0,0.0,0.02,0.0,0.0,0.03,amy lauren anderson,BIOL-8450,2019
-BIOL,8450,1,Understanding Animal Biology,0.85,0.1,0.0,0.0,0.02,0.0,0.0,0.03,matthew turnbull,BIOL-8450,2019
-BIOL,8470,1,Understanding Microbiology,0.72,0.23,0.04,0.0,0.01,0.0,0.0,0.0,harry kurtz,BIOL-8470,2019
-BIOL,8480,1,Understanding Scientific Rsrch,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert edwa ballard,BIOL-8480,2019
-BMOL,4250,1,Biomolecular Engineering,0.15,0.39,0.31,0.09,0.04,0.0,0.0,0.02,mark alan blenner,BMOL-4250,2019
-BMOL,4290,1,Bioprocess Engineering,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,marc rus birtwistle,BMOL-4290,2019
-BMOL,6250,1,Biomolecular Eng,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,mark alan blenner,BMOL-6250,2019
-BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2019
-BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,sandy edge,BUS-1010,2019
-BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,william ern tumblin,BUS-1010,2019
-BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,william ern tumblin,BUS-1010,2019
-BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,sandy edge,BUS-1010,2019
-BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2019
-BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,edward bar de iulio,BUS-1010,2019
-BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,sandy edge,BUS-1010,2019
-BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,william ern tumblin,BUS-1010,2019
-BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,donna mccubbin,BUS-1010,2019
-BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,donna mccubbin,BUS-1010,2019
-BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,edward bar de iulio,BUS-1010,2019
-BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,sandy edge,BUS-1010,2019
-BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,william ern tumblin,BUS-1010,2019
-BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,donna mccubbin,BUS-1010,2019
-BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,sandy edge,BUS-1010,2019
-BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,william ern tumblin,BUS-1010,2019
-BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,BUS-1010,2019
-BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,BUS-1010,2019
-BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,william ern tumblin,BUS-1010,2019
-BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,donna mccubbin,BUS-1010,2019
-BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,sandy edge,BUS-1010,2019
-BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,edward bar de iulio,BUS-1010,2019
-BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,donna mccubbin,BUS-1010,2019
-BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,william ern tumblin,BUS-1010,2019
-BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,sandy edge,BUS-1010,2019
-BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,edward bar de iulio,BUS-1010,2019
-BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,sandy edge,BUS-1010,2019
-BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,william ern tumblin,BUS-1010,2019
-BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,donna mccubbin,BUS-1010,2019
-BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,edward bar de iulio,BUS-1010,2019
-BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,william ern tumblin,BUS-1010,2019
-BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,donna mccubbin,BUS-1010,2019
-BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,sandy edge,BUS-1010,2019
-BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,donna mccubbin,BUS-1010,2019
-BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,william ern tumblin,BUS-1010,2019
-BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,sandy edge,BUS-1010,2019
-BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,edward bar de iulio,BUS-1010,2019
-BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,BUS-1010,2019
-BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,donna mccubbin,BUS-1010,2019
-BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,william ern tumblin,BUS-1010,2019
-BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,sandy edge,BUS-1010,2019
-BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,donna mccubbin,BUS-1010,2019
-BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,sandy edge,BUS-1010,2019
-BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,william ern tumblin,BUS-1010,2019
-BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,edward bar de iulio,BUS-1010,2019
-CE,2010,1,Statics,0.3,0.33,0.12,0.06,0.03,0.0,0.0,0.15,melissa sternhagen,CE-2010,2019
-CE,2010,2,Statics,0.31,0.42,0.25,0.0,0.02,0.0,0.0,0.0,md nasimu chowdhury,CE-2010,2019
-CE,2010,3,Statics,0.17,0.25,0.23,0.17,0.02,0.0,0.0,0.17,melissa sternhagen,CE-2010,2019
-CE,2010,4,Statics,0.16,0.42,0.33,0.02,0.0,0.0,0.0,0.07,md nasimu chowdhury,CE-2010,2019
-CE,2010,5,Statics,0.5,0.16,0.2,0.02,0.11,0.0,0.0,0.0,michael wall stoner,CE-2010,2019
-CE,2010,6,Statics,0.58,0.3,0.1,0.0,0.03,0.0,0.0,0.0,lancelot paul reres,CE-2010,2019
-CE,2010,7,Statics (HON),0.18,0.55,0.18,0.0,0.0,0.0,0.0,0.09,melissa sternhagen,CE-2010,2019
-CE,2060,1,Structural Mechanics,0.51,0.29,0.16,0.02,0.02,0.0,0.0,0.0,thomas edfo cousins,CE-2060,2019
-CE,2060,2,Structural Mechanics,0.19,0.33,0.43,0.02,0.02,0.0,0.0,0.02,melissa sternhagen,CE-2060,2019
-CE,2080,1,Dynamics,0.17,0.42,0.32,0.0,0.03,0.0,0.0,0.06,md nasimu chowdhury,CE-2080,2019
-CE,2080,2,Dynamics,0.12,0.35,0.4,0.05,0.0,0.0,0.0,0.09,md nasimu chowdhury,CE-2080,2019
-CE,2550,1,Geomatics,0.29,0.27,0.32,0.05,0.0,0.0,0.0,0.07,wayne sarasua,CE-2550,2019
-CE,3010,1,Structural Analysis,0.4,0.3,0.26,0.05,0.0,0.0,0.0,0.0,stephen csernak,CE-3010,2019
-CE,3110,1,Transportation Engr,0.68,0.24,0.05,0.01,0.0,0.0,0.0,0.01,pamela murray-tuite,CE-3110,2019
-CE,3210,1,Geotechnical Engineering,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,wenxin liu,CE-3210,2019
-CE,3210,2,Geotechnical Engineering,0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,wenxin liu,CE-3210,2019
-CE,3310,1,Constr Engr & Mgmnt,0.87,0.11,0.0,0.02,0.0,0.0,0.0,0.0,steve richa sanders,CE-3310,2019
-CE,3410,1,Intro to Fluid Mech,0.32,0.46,0.15,0.03,0.0,0.0,0.0,0.03,nigel gregory kaye,CE-3410,2019
-CE,3420,1,Hydraulics & Hydro,0.62,0.35,0.03,0.0,0.0,0.0,0.0,0.0,ashok mishra,CE-3420,2019
-CE,3420,2,Hydraulics & Hydro,0.28,0.47,0.19,0.03,0.03,0.0,0.0,0.0,abdul khan,CE-3420,2019
-CE,3510,1,Civil Engineering Materials,0.43,0.52,0.05,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,CE-3510,2019
-CE,3520,1,Econ Eval of Proj,0.49,0.37,0.09,0.01,0.01,0.0,0.0,0.03, kent nilsson,CE-3520,2019
-CE,3530,1,Professional Seminar,0.96,0.01,0.03,0.01,0.0,0.0,0.0,0.0,ronald andrus,CE-3530,2019
-CE,4020,1,Reinfor Con Design,0.42,0.31,0.22,0.0,0.04,0.0,0.0,0.0,laura mae redmond,CE-4020,2019
-CE,4070,1,Wood Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,CE-4070,2019
-CE,4080,1,Struct Loads & Sys,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,brandon ross,CE-4080,2019
-CE,4110,1,Roadway Geo Design,0.52,0.37,0.07,0.04,0.0,0.0,0.0,0.0,jennifer ogle,CE-4110,2019
-CE,4120,1,Urban Transport Plan,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,sakib khan,CE-4120,2019
-CE,4210,1,Geotechnical Design,0.29,0.46,0.23,0.0,0.0,0.0,0.0,0.03,nadara ravichandran,CE-4210,2019
-CE,4340,1,Const Est Proj Cont,0.35,0.51,0.13,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-4340,2019
-CE,4370,1,Sustainable Energy Proj Design,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,CE-4370,2019
-CE,4590,1,Capstone Design Proj,0.6,0.28,0.1,0.01,0.0,0.0,0.0,0.0,stephen csernak,CE-4590,2019
-CE,4910,1,Corrosion and Oxidation,0.0,0.4,0.0,0.0,0.0,0.0,0.0,0.6,ami esmaeilpoursaee,CE-4910,2019
-CE,4910,2,Des Thinkg for Sustain Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,CE-4910,2019
-CE,4910,3,Intro to Enviro Fluid Mech,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,nigel gregory kaye,CE-4910,2019
-CE,4990,2,Cr Inq in Civil Engineering,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,weichiang pang,CE-4990,2019
-CE,4990,61,Cr Inq in Civil Engineering,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ogle,CE-4990,2019
-CE,4990,201,Special Project - Springer I,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,wayne sarasua,CE-4990,2019
-CE,6340,1,Const Est Proj Cont,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,CE-6340,2019
-CE,6370,1,Sustainable Energy Proj Design,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,CE-6370,2019
-CE,8030,1,Adv Steel Design,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mohannad naser,CE-8030,2019
-CE,8270,1,Spec Cements & Concr,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,CE-8270,2019
-CE,8450,500,Data Mining for Sys Analytics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paris stringfellow,CE-8450,2019
-CE,8470,500,Optimization Support Models,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,CE-8470,2019
-CE,8530,1,Apps in Traffic En,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,CE-8530,2019
-CES,1900,101,CI-LEAD Forward I,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,steve richa sanders,CES-1900,2019
-CES,2900,101,CI - LEAD Forward II,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,steve richa sanders,CES-2900,2019
-CES,3900,101,CI-LEAD Forward III,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,CES-3900,2019
-CH,1010,1,General Chemistry,0.16,0.32,0.21,0.08,0.1,0.0,0.0,0.12,princess mycia cox,CH-1010,2019
-CH,1010,2,General Chemistry,0.23,0.33,0.32,0.04,0.04,0.0,0.0,0.03,jacob schroeder,CH-1010,2019
-CH,1010,3,General Chemistry,0.11,0.4,0.25,0.1,0.06,0.0,0.0,0.08,jacob schroeder,CH-1010,2019
-CH,1010,4,General Chemistry,0.08,0.22,0.39,0.1,0.13,0.0,0.0,0.1,steven pellizzeri,CH-1010,2019
-CH,1010,400,General Chemistry,0.28,0.16,0.15,0.22,0.08,0.0,0.0,0.11,stephe schvaneveldt,CH-1010,2019
-CH,1020,1,General Chemistry,0.24,0.31,0.26,0.06,0.04,0.0,0.0,0.09,steven pellizzeri,CH-1020,2019
-CH,1020,2,General Chemistry,0.27,0.29,0.25,0.09,0.03,0.0,0.0,0.05,william mcwhorter,CH-1020,2019
-CH,1020,3,General Chemistry,0.27,0.36,0.31,0.04,0.01,0.0,0.0,0.02,dennis taylor,CH-1020,2019
-CH,1020,4,General Chemistry,0.3,0.38,0.2,0.05,0.01,0.0,0.0,0.06,dennis taylor,CH-1020,2019
-CH,1020,5,General Chemistry,0.17,0.47,0.25,0.05,0.0,0.0,0.02,0.03,william mcwhorter,CH-1020,2019
-CH,1020,6,General Chemistry,0.1,0.36,0.34,0.09,0.02,0.0,0.0,0.08,olt geiculescu,CH-1020,2019
-CH,1020,7,General Chemistry,0.1,0.39,0.34,0.06,0.01,0.0,0.0,0.1,william mcwhorter,CH-1020,2019
-CH,1020,8,General Chemistry,0.29,0.43,0.21,0.03,0.0,0.0,0.0,0.03,thomas hickman,CH-1020,2019
-CH,1020,9,General Chemistry,0.22,0.45,0.23,0.05,0.0,0.0,0.0,0.05,princess mycia cox,CH-1020,2019
-CH,1020,10,General Chemistry,0.34,0.37,0.23,0.02,0.02,0.0,0.0,0.02,thomas hickman,CH-1020,2019
-CH,1020,11,General Chemistry,0.32,0.33,0.23,0.04,0.02,0.0,0.0,0.05,elliot ennis,CH-1020,2019
-CH,1020,50,General Chemistry,0.65,0.27,0.04,0.0,0.02,0.0,0.0,0.02,stephe schvaneveldt,CH-1020,2019
-CH,1020,51,General Chemistry (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,CH-1020,2019
-CH,1020,52,General Chemistry (HON),0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,CH-1020,2019
-CH,1050,1,Chemistry in Context I,0.34,0.39,0.23,0.0,0.02,0.0,0.0,0.02,olt geiculescu,CH-1050,2019
-CH,1050,2,Chemistry in Context I,0.56,0.25,0.13,0.03,0.0,0.0,0.0,0.03,olt geiculescu,CH-1050,2019
-CH,1060,1,Chemistry in Context II,0.15,0.5,0.15,0.08,0.08,0.0,0.0,0.04,elliot ennis,CH-1060,2019
-CH,1520,1,Chemistry Communication,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,richard marcus,CH-1520,2019
-CH,2010,1,Survey of Organic Chemistry,0.43,0.15,0.23,0.06,0.07,0.0,0.0,0.06,tania issa houjeiry,CH-2010,2019
-CH,2050,1,Intro Inorg Chem,0.55,0.32,0.11,0.0,0.0,0.0,0.0,0.03,william pennington,CH-2050,2019
-CH,2230,1,Organic Chemistry,0.14,0.21,0.31,0.18,0.14,0.0,0.0,0.01,thomas hickman,CH-2230,2019
-CH,2230,2,Organic Chemistry,0.13,0.26,0.27,0.23,0.11,0.0,0.0,0.01,elliot ennis,CH-2230,2019
-CH,2230,3,Organic Chemistry,0.18,0.33,0.22,0.13,0.12,0.0,0.0,0.03,laura lanni,CH-2230,2019
-CH,2240,1,Organic Chemistry,0.53,0.25,0.14,0.04,0.02,0.0,0.0,0.03,tania issa houjeiry,CH-2240,2019
-CH,2240,2,Organic Chemistry,0.38,0.33,0.15,0.07,0.03,0.0,0.0,0.04,laura lanni,CH-2240,2019
-CH,2240,3,Organic Chemistry,0.34,0.19,0.32,0.07,0.07,0.0,0.0,0.01,laura lanni,CH-2240,2019
-CH,2240,4,Organic Chemistry,0.59,0.13,0.19,0.02,0.03,0.0,0.0,0.04,rhett smith,CH-2240,2019
-CH,2240,5,Organic Chemistry,0.55,0.25,0.11,0.07,0.0,0.0,0.0,0.02,rhett smith,CH-2240,2019
-CH,2280,17,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelso plampin,CH-2280,2019
-CH,2280,26,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,CH-2280,2019
-CH,3320,1,Physical Chemistry,0.21,0.37,0.32,0.05,0.0,0.0,0.0,0.05,steven stuart,CH-3320,2019
-CH,3320,3,Physical Chemistry,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,jason mcneill,CH-3320,2019
-CH,3320,5,Physical Chemistry,0.64,0.14,0.11,0.04,0.07,0.0,0.0,0.0,leah bec casabianca,CH-3320,2019
-CH,3400,2,Physical Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2019
-CH,3400,3,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2019
-CH,3400,4,Physical Chem Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,CH-3400,2019
-CH,3600,1,Chemical Biology,0.48,0.31,0.14,0.0,0.0,0.0,0.0,0.07,modi wetzler,CH-3600,2019
-CH,4110,1,Instrumental Analy,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,jeffrey natha anker,CH-4110,2019
-CH,4120,2,Instr Analysis Lab,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,george chumanov,CH-4120,2019
-CH,4130,1,Chemistry of Aqueous Systems,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,cindy lee,CH-4130,2019
-CH,4500,1,Chemistry Capstone,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,CH-4500,2019
-CH,4990,6,Cr Inq in Chemistry IV 1218,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,dev priya arya,CH-4990,2019
-CH,6140,1,Bioanalytical Chem,0.09,0.82,0.09,0.0,0.0,0.0,0.0,0.0,carlos garcia perez,CH-6140,2019
-CH,8130,1,Electrochem Sci,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,stephen creager,CH-8130,2019
-CH,8510,1,Grad Student Seminar,0.83,0.14,0.0,0.0,0.0,0.0,0.0,0.03,joseph stu thrasher,CH-8510,2019
-CH,8510,2,Grad Student Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,CH-8510,2019
-CHE,1300,1,Intro to Chemical Engineering,0.25,0.21,0.21,0.08,0.06,0.0,0.0,0.19,christopher norfolk,CHE-1300,2019
-CHE,1300,2,Intro to Chemical Engineering,0.24,0.2,0.22,0.1,0.08,0.0,0.0,0.18,christopher norfolk,CHE-1300,2019
-CHE,2200,1,Ch E Thermo I,0.13,0.39,0.25,0.13,0.08,0.0,0.0,0.03,jessica mari larsen,CHE-2200,2019
-CHE,2300,1,Fluids/Heat Transfer,0.19,0.18,0.35,0.15,0.11,0.0,0.0,0.01,eric mikel davis,CHE-2300,2019
-CHE,3070,1,Unit Ops Lab I,0.28,0.63,0.07,0.02,0.0,0.0,0.0,0.0,christopher norfolk,CHE-3070,2019
-CHE,3190,1,Engr Materials,0.12,0.33,0.35,0.12,0.03,0.0,0.0,0.05,amod ogale,CHE-3190,2019
-CHE,3190,1,Engr Materials,0.12,0.33,0.35,0.12,0.03,0.0,0.0,0.05,christopher norfolk,CHE-3190,2019
-CHE,3530,1,Proc Dyn & Control,0.24,0.46,0.26,0.02,0.0,0.0,0.0,0.01,mark roberts,CHE-3530,2019
-CHE,3990,13,CI- ARTIFICIAL CHROMOSOMES,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,marc rus birtwistle,CHE-3990,2019
-CHE,4330,1,Process Design II,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,david bruce,CHE-4330,2019
-CHE,8140,1,Numerical Methods,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,joseph scott,CHE-8140,2019
-CHE,8450,5,Statistical Mechanics,0.63,0.13,0.25,0.0,0.0,0.0,0.0,0.0,sapna sarupria,CHE-8450,2019
-CHIN,1010,1,Elementary Chinese,0.61,0.11,0.06,0.0,0.06,0.0,0.0,0.17,yanming an,CHIN-1010,2019
-CHIN,1020,1,Elementary Chinese,0.3,0.3,0.4,0.0,0.0,0.0,0.0,0.0,ling rao,CHIN-1020,2019
-CHIN,3120,1,Philosophy in Ancient China,0.33,0.46,0.08,0.0,0.0,0.0,0.0,0.13,yanming an,CHIN-3120,2019
-COM,1500,1,Intro to Human Communication,0.74,0.25,0.01,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,COM-1500,2019
-COM,1500,2,Intro to Human Communication,0.71,0.25,0.01,0.0,0.03,0.0,0.0,0.0,daniel lelan fecher,COM-1500,2019
-COM,1500,3,Intro to Human Communication,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,COM-1500,2019
-COM,1500,4,Intro to Human Communication,0.7,0.26,0.02,0.01,0.01,0.0,0.0,0.01,marianne her glaser,COM-1500,2019
-COM,1500,5,Intro to Human Communication,0.75,0.17,0.03,0.01,0.02,0.0,0.0,0.01,marianne her glaser,COM-1500,2019
-COM,1500,6,Intro to Human Communication,0.62,0.29,0.06,0.0,0.0,0.0,0.0,0.03,vanessa anne condon,COM-1500,2019
-COM,2010,1,Intr to Comm Studies,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2010,2019
-COM,2010,2,Intr to Comm Studies,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,caitlin baker,COM-2010,2019
-COM,2020,1,Communication Theory,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,COM-2020,2019
-COM,2040,1,Critical-Cultural Comm Theory,0.47,0.26,0.21,0.05,0.0,0.0,0.0,0.0,james nicho gilmore,COM-2040,2019
-COM,2100,1,Quant Comm Research Methods,0.44,0.37,0.11,0.07,0.0,0.0,0.0,0.0,joseph mazer,COM-2100,2019
-COM,2120,1,Crit-Cultural Rsrch Methods,0.74,0.22,0.0,0.04,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2120,2019
-COM,2500,1,Public Speaking,0.71,0.14,0.05,0.0,0.0,0.0,0.0,0.1,caitlin baker,COM-2500,2019
-COM,2500,3,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,charles john brewer,COM-2500,2019
-COM,2500,4,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,charles john brewer,COM-2500,2019
-COM,2500,5,Public Speaking,0.29,0.48,0.1,0.0,0.05,0.0,0.0,0.1,sara grumbl crocker,COM-2500,2019
-COM,2500,6,Public Speaking,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,marshall tho covert,COM-2500,2019
-COM,2500,7,Public Speaking,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,charles john brewer,COM-2500,2019
-COM,2500,8,Public Speaking,0.57,0.33,0.05,0.0,0.05,0.0,0.0,0.0,charles john brewer,COM-2500,2019
-COM,2500,9,Public Speaking,0.52,0.24,0.05,0.1,0.05,0.0,0.0,0.05,ashley lauren pikel,COM-2500,2019
-COM,2500,10,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,COM-2500,2019
-COM,2500,11,Public Speaking,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,COM-2500,2019
-COM,2500,12,Public Speaking,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2019
-COM,2500,13,Public Speaking,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,ashley lauren pikel,COM-2500,2019
-COM,2500,14,Public Speaking,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,COM-2500,2019
-COM,2500,15,Public Speaking,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth gilmore,COM-2500,2019
-COM,2500,16,Public Speaking,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2019
-COM,2500,17,Public Speaking,0.6,0.2,0.15,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2019
-COM,2500,18,Public Speaking,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,COM-2500,2019
-COM,2500,19,Public Speaking (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,rachelle le beckner,COM-2500,2019
-COM,2500,20,Public Speaking,0.67,0.29,0.0,0.05,0.0,0.0,0.0,0.0,katie barn mcelveen,COM-2500,2019
-COM,2500,21,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,blythe kai steelman,COM-2500,2019
-COM,2500,23,Public Speaking,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-2500,2019
-COM,2500,24,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rachelle le beckner,COM-2500,2019
-COM,2500,25,Public Speaking,0.52,0.43,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,COM-2500,2019
-COM,2500,26,Public Speaking (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-2500,2019
-COM,2500,28,Public Speaking (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,COM-2500,2019
-COM,2500,31,Public Speaking,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,marshall tho covert,COM-2500,2019
-COM,2500,32,Public Speaking,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2019
-COM,2500,33,Public Speaking,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,COM-2500,2019
-COM,2500,34,Public Speaking,0.43,0.43,0.05,0.05,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2019
-COM,2500,35,Public Speaking,0.4,0.55,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,COM-2500,2019
-COM,2500,36,Public Speaking,0.25,0.65,0.05,0.05,0.0,0.0,0.0,0.0,marshall tho covert,COM-2500,2019
-COM,2500,37,Public Speaking,0.5,0.35,0.05,0.0,0.0,0.0,0.0,0.1,elizabeth gilmore,COM-2500,2019
-COM,2500,38,Public Speaking,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,marshall tho covert,COM-2500,2019
-COM,2500,400,Public Speaking,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2019
-COM,2500,401,Public Speaking,0.71,0.19,0.0,0.0,0.1,0.0,0.0,0.0,alexis zachar davis,COM-2500,2019
-COM,2500,402,Public Speaking,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,COM-2500,2019
-COM,2500,403,Public Speaking,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,COM-2500,2019
-COM,3070,1,Public Comm of Sts,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,meghna tallapragada,COM-3070,2019
-COM,3240,1,"Communication, Sport & Society",0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,gregory kei cranmer,COM-3240,2019
-COM,3240,2,"Communication, Sport & Society",0.77,0.09,0.05,0.09,0.0,0.0,0.0,0.0,katie barn mcelveen,COM-3240,2019
-COM,3250,1,Survey of Sports Communication,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,COM-3250,2019
-COM,3260,1,Pr in Sports,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,angela pratt,COM-3260,2019
-COM,3260,2,Pr in Sports,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,angela pratt,COM-3260,2019
-COM,3270,1,Sports Media Criticism,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,katie barn mcelveen,COM-3270,2019
-COM,3480,1,Interpersonal Comm,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-3480,2019
-COM,3480,2,Interpersonal Comm,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,COM-3480,2019
-COM,3550,1,Principles of Public Relations,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,meghna tallapragada,COM-3550,2019
-COM,3570,1,Public Relations Writing,0.67,0.21,0.04,0.04,0.0,0.0,0.0,0.04,andrew stephen pyle,COM-3570,2019
-COM,3610,1,Argue and Debate,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,COM-3610,2019
-COM,3640,1,Organizational Comm,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,kristen ela okamoto,COM-3640,2019
-COM,3660,1,Video COMM w/ Adobe CC,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,michael rodgers,COM-3660,2019
-COM,3660,4,Corporate Communications,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,. mark barnes,COM-3660,2019
-COM,4250,1,Adv Sports Comm,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,COM-4250,2019
-COM,4260,1,Social Media and Sports Comm,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4260,2019
-COM,4270,1,Comm in Sports Organizations,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,COM-4270,2019
-COM,4280,1,Interpers/Family Comm & Sport,0.26,0.63,0.05,0.05,0.0,0.0,0.0,0.0,gregory kei cranmer,COM-4280,2019
-COM,4310,1,Legal Communication Trial,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,COM-4310,2019
-COM,4550,1,Gender Communication,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,COM-4550,2019
-COM,4560,1,PR for Assoc & Nonprofits,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,COM-4560,2019
-COM,4700,1,Comm & Health,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,COM-4700,2019
-COM,4950,1,Senior Capstone,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,erin michelle ash,COM-4950,2019
-COM,4950,2,Senior Capstone,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,COM-4950,2019
-COM,8060,1,Health Communication & Culture,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,COM-8060,2019
-CPSC,1010,1,Computer Science I,0.51,0.22,0.12,0.05,0.05,0.0,0.0,0.05,roger larr van scoy,CPSC-1010,2019
-CPSC,1010,2,Computer Science I,0.24,0.35,0.15,0.06,0.11,0.0,0.0,0.09,yu-shan sun,CPSC-1010,2019
-CPSC,1020,1,Computer Science II,0.42,0.27,0.17,0.02,0.04,0.0,0.0,0.08,yvon feaster,CPSC-1020,2019
-CPSC,1020,2,Computer Science II,0.29,0.21,0.25,0.04,0.1,0.0,0.0,0.1,yvon feaster,CPSC-1020,2019
-CPSC,1020,3,Computer Science II,0.13,0.33,0.28,0.02,0.13,0.0,0.0,0.11,catherine hochrine,CPSC-1020,2019
-CPSC,1020,4,Computer Science II,0.27,0.23,0.36,0.05,0.07,0.0,0.0,0.02,mark smotherman,CPSC-1020,2019
-CPSC,1110,1,Intro to Programming in C,0.19,0.22,0.19,0.11,0.06,0.0,0.0,0.22,catherine hochrine,CPSC-1110,2019
-CPSC,1110,2,Intro to Programming in C,0.15,0.3,0.18,0.13,0.1,0.0,0.0,0.15,catherine hochrine,CPSC-1110,2019
-CPSC,1110,3,Intro to Programming in C,0.19,0.25,0.19,0.06,0.16,0.0,0.0,0.16,andrew duchowski,CPSC-1110,2019
-CPSC,2070,1,Discrete Structures,0.69,0.11,0.06,0.0,0.06,0.0,0.0,0.09,sandra hedetniemi,CPSC-2070,2019
-CPSC,2070,2,Discrete Structures,0.42,0.25,0.17,0.11,0.03,0.0,0.0,0.03,larry hodges,CPSC-2070,2019
-CPSC,2120,1,Algs/Data Structures,0.49,0.23,0.06,0.03,0.06,0.0,0.0,0.14,andrew hill,CPSC-2120,2019
-CPSC,2120,2,Algs/Data Structures,0.6,0.17,0.11,0.02,0.04,0.0,0.0,0.06,andrew hill,CPSC-2120,2019
-CPSC,2120,3,Algs/Data Structures,0.53,0.34,0.06,0.02,0.02,0.0,0.0,0.02,andrew hill,CPSC-2120,2019
-CPSC,2150,1,Software Dev Foundations,0.34,0.36,0.14,0.04,0.0,0.0,0.0,0.12,kevin anton plis,CPSC-2150,2019
-CPSC,2150,2,Software Dev Foundations,0.16,0.34,0.18,0.05,0.14,0.0,0.0,0.14,yu-shan sun,CPSC-2150,2019
-CPSC,2150,3,Software Dev Foundations,0.26,0.35,0.16,0.03,0.13,0.0,0.0,0.06,yu-shan sun,CPSC-2150,2019
-CPSC,2200,1,Microcomputer Appl,0.5,0.29,0.07,0.04,0.04,0.0,0.0,0.07,kevin anton plis,CPSC-2200,2019
-CPSC,2200,2,Microcomputer Appl,0.31,0.38,0.23,0.04,0.04,0.0,0.0,0.0,kevin anton plis,CPSC-2200,2019
-CPSC,2310,1,Intro Computer Org,0.45,0.35,0.1,0.04,0.02,0.0,0.0,0.04,nicolas benj widman,CPSC-2310,2019
-CPSC,2310,2,Intro Computer Org,0.42,0.3,0.18,0.08,0.0,0.0,0.0,0.02,nicolas benj widman,CPSC-2310,2019
-CPSC,2810,2,Sel Top: Cyberdefen Comp Train,0.76,0.0,0.0,0.0,0.0,0.0,0.0,0.24,hongda li,CPSC-2810,2019
-CPSC,2910,1,Prof Issues I,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2019
-CPSC,2910,2,Prof Issues I,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,catherine hochrine,CPSC-2910,2019
-CPSC,2910,3,Prof Issues I,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,catherine hochrine,CPSC-2910,2019
-CPSC,2920,1,"Computing, Ethics & Society",0.2,0.28,0.16,0.02,0.04,0.0,0.0,0.3,christopher plaue,CPSC-2920,2019
-CPSC,3120,1,Design Analysis of Algorithms,0.38,0.48,0.12,0.0,0.0,0.0,0.0,0.02,wayne goddard,CPSC-3120,2019
-CPSC,3120,2,Design Analysis of Algorithms,0.33,0.25,0.14,0.03,0.08,0.0,0.0,0.17,federico iuricich,CPSC-3120,2019
-CPSC,3220,1,Intro to Operating Systems,0.19,0.14,0.28,0.05,0.14,0.0,0.0,0.21,jacob sorber,CPSC-3220,2019
-CPSC,3220,2,Intro to Operating Systems,0.37,0.4,0.07,0.02,0.07,0.0,0.0,0.07,rong ge,CPSC-3220,2019
-CPSC,3300,1,Computer Systems Org,0.38,0.31,0.25,0.02,0.04,0.0,0.0,0.0,nicolas benj widman,CPSC-3300,2019
-CPSC,3300,2,Computer Systems Org,0.46,0.22,0.19,0.05,0.05,0.0,0.0,0.03,nicolas benj widman,CPSC-3300,2019
-CPSC,3500,1,Foundations of Computer Sci,0.18,0.16,0.33,0.08,0.06,0.0,0.0,0.18,ilya mark safro,CPSC-3500,2019
-CPSC,3520,1,Programming Systems,0.23,0.38,0.22,0.03,0.03,0.0,0.0,0.11,robert schalkoff,CPSC-3520,2019
-CPSC,3600,1,Network Programming,0.66,0.2,0.09,0.0,0.0,0.0,0.0,0.05,long cheng,CPSC-3600,2019
-CPSC,3600,2,Network Programming,0.36,0.32,0.04,0.0,0.14,0.0,0.0,0.14,zijun wang,CPSC-3600,2019
-CPSC,3710,1,Systems Analysis,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,roger larr van scoy,CPSC-3710,2019
-CPSC,3720,1,Software Engineering,0.41,0.47,0.13,0.0,0.0,0.0,0.0,0.0,paige ann rodeghero,CPSC-3720,2019
-CPSC,3720,2,Software Engineering,0.26,0.56,0.18,0.0,0.0,0.0,0.0,0.0,murali sitaraman,CPSC-3720,2019
-CPSC,3990,2,Adv CI: Sim Meth in Graphs & E,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,luis bermudez,CPSC-3990,2019
-CPSC,3990,2,Adv CI: Sim Meth in Graphs & E,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,victor zordan,CPSC-3990,2019
-CPSC,3990,3,CI: User Exper in VR Games,0.6,0.0,0.0,0.2,0.0,0.0,0.0,0.2,andrew robb,CPSC-3990,2019
-CPSC,4050,1,Computer Graphics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,victor zordan,CPSC-4050,2019
-CPSC,4110,1,Virtual Reality Systems,0.39,0.42,0.15,0.03,0.0,0.0,0.0,0.0,andrew robb,CPSC-4110,2019
-CPSC,4140,1,Human and Computer Interaction,0.49,0.38,0.09,0.0,0.04,0.0,0.0,0.0,sabarish venka babu,CPSC-4140,2019
-CPSC,4160,1,2-D Game Engine Construction,0.49,0.34,0.13,0.0,0.0,0.0,0.02,0.02,brian malloy,CPSC-4160,2019
-CPSC,4180,1,Usable Privacy and Security,0.55,0.23,0.05,0.0,0.05,0.0,0.0,0.14,kelly caine,CPSC-4180,2019
-CPSC,4200,1,Computer Security Principles,0.7,0.27,0.0,0.03,0.0,0.0,0.0,0.0,yvon feaster,CPSC-4200,2019
-CPSC,4240,1,System Admin and Security,0.24,0.7,0.03,0.0,0.0,0.0,0.0,0.03,james martin,CPSC-4240,2019
-CPSC,4440,1,Cloud Computing Architecture,0.29,0.42,0.21,0.0,0.0,0.0,0.0,0.08,amy apon,CPSC-4440,2019
-CPSC,4620,1,Database Management Systems,0.3,0.41,0.22,0.0,0.0,0.0,0.0,0.07,zijun wang,CPSC-4620,2019
-CPSC,4620,2,Database Management Systems,0.42,0.34,0.24,0.0,0.0,0.0,0.0,0.0,kevin anton plis,CPSC-4620,2019
-CPSC,4770,1,Distributed/Cluster Computing,0.56,0.22,0.17,0.0,0.0,0.0,0.0,0.06,shuangshuang jin,CPSC-4770,2019
-CPSC,4820,1,Special Topic: Concurrent Prog,0.36,0.32,0.14,0.0,0.05,0.0,0.0,0.14,eileen ther kraemer,CPSC-4820,2019
-CPSC,4820,2,Special Topics: Tang and Embod,0.46,0.36,0.11,0.04,0.0,0.0,0.0,0.04,brygg anders ullmer,CPSC-4820,2019
-CPSC,4820,3,Special Topic in Computing: AI,0.46,0.13,0.21,0.04,0.04,0.0,0.0,0.13,ioannis karamouzas,CPSC-4820,2019
-CPSC,4910,1,Professional Issues II,0.48,0.45,0.05,0.0,0.0,0.0,0.03,0.0,roger larr van scoy,CPSC-4910,2019
-CPSC,4910,2,Professional Issues II,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,CPSC-4910,2019
-CPSC,4910,3,Professional Issues II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,CPSC-4910,2019
-CPSC,6050,1,Computer Graphics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,victor zordan,CPSC-6050,2019
-CPSC,6110,1,Virtual Reality Systems,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew robb,CPSC-6110,2019
-CPSC,6140,1,Human and Computer Interaction,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,sabarish venka babu,CPSC-6140,2019
-CPSC,6160,1,2-D Game Engine Construction,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,brian malloy,CPSC-6160,2019
-CPSC,6440,1,Cloud Computing Architecture,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,amy apon,CPSC-6440,2019
-CPSC,6620,1,Database Management Systems,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,zijun wang,CPSC-6620,2019
-CPSC,8040,1,Data Visualization,0.7,0.22,0.08,0.0,0.0,0.0,0.0,0.0,federico iuricich,CPSC-8040,2019
-CPSC,8110,1,Technical Character Animation,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,CPSC-8110,2019
-CPSC,8240,1,Advanced Operating Systems,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,rong ge,CPSC-8240,2019
-CPSC,8400,1,Design & Anlys of Algorithms,0.3,0.35,0.2,0.0,0.05,0.0,0.0,0.1,brian christop dean,CPSC-8400,2019
-CPSC,8570,1,Network Technologies Security,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,CPSC-8570,2019
-CPSC,8650,1,Data Mining,0.31,0.38,0.28,0.0,0.0,0.0,0.0,0.03,zijun wang,CPSC-8650,2019
-CPSC,8810,6,Sel Topic: Deep Learning,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,feng luo,CPSC-8810,2019
-CPSC,8810,7,Selected Topics: Moti Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,CPSC-8810,2019
-CSM,1000,1,Intro to Construct,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,CSM-1000,2019
-CSM,2010,1,Structures I,0.61,0.21,0.12,0.03,0.0,0.0,0.0,0.03,shima clarke,CSM-2010,2019
-CSM,2020,1,Structures II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,CSM-2020,2019
-CSM,2030,1,Mats & Meth of Const,0.29,0.55,0.16,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,CSM-2030,2019
-CSM,2040,1,Cont Documents,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,robert dawso coffey,CSM-2040,2019
-CSM,2050,1,Mats & Methods II,0.3,0.63,0.07,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,CSM-2050,2019
-CSM,3040,1,Envir Systems I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3040,2019
-CSM,3050,1,Envir Systems II,0.23,0.53,0.15,0.07,0.02,0.0,0.0,0.0,joseph mich burgett,CSM-3050,2019
-CSM,3060,1,Emerging Tech in Construction,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,jason lucas,CSM-3060,2019
-CSM,3070,1,Sustainable Construction,0.46,0.48,0.05,0.02,0.0,0.0,0.0,0.0,joseph mich burgett,CSM-3070,2019
-CSM,3510,1,Construction Estimating,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,CSM-3510,2019
-CSM,3520,1,Const Scheduling,0.78,0.19,0.0,0.03,0.0,0.0,0.0,0.0,craig townsend,CSM-3520,2019
-CSM,3520,2,Const Scheduling,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-3520,2019
-CSM,3520,2,Const Scheduling,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,jaime cruz,CSM-3520,2019
-CSM,3530,1,Const Estimating II,0.42,0.45,0.13,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,CSM-3530,2019
-CSM,3530,2,Const Estimating II,0.26,0.65,0.1,0.0,0.0,0.0,0.0,0.0,anthony dway harden,CSM-3530,2019
-CSM,4110,1,Safety in Bldg Const,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,nicholas corley,CSM-4110,2019
-CSM,4540,1,Const Capstone,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,dennis bausman,CSM-4540,2019
-CSM,8600,1,Constr Finan Plan & Analysis,0.39,0.57,0.0,0.0,0.0,0.0,0.0,0.04,dennis bausman,CSM-8600,2019
-CSM,8600,401,Constr Finan Plan & Analysis,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,dennis bausman,CSM-8600,2019
-CSM,8680,401,Emerging Tech in Built Environ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jason lucas,CSM-8680,2019
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,susan whorton,CU-1000,2019
-CU,1010,1,Univ Success Skills,0.4,0.1,0.25,0.0,0.05,0.0,0.0,0.2,valerie kay oonk,CU-1010,2019
-CU,1010,2,Univ Success Skills,0.47,0.24,0.18,0.06,0.0,0.0,0.0,0.06,alejandra kennedy,CU-1010,2019
-CU,1010,3,Univ Success Skills,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,bryn zimmerman babb,CU-1010,2019
-CU,1010,5,Univ Success Skills,0.45,0.25,0.15,0.0,0.05,0.0,0.0,0.1,bryn zimmerman babb,CU-1010,2019
-CU,1010,6,Univ Success Skills,0.74,0.11,0.0,0.05,0.11,0.0,0.0,0.0,james garland,CU-1010,2019
-CU,1010,7,Univ Success Skills,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,taimi olsen,CU-1010,2019
-CU,2010,1,Sustainability Leadership,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,CU-2010,2019
-CVT,2250,400,Ultrasound Physics,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ronda kel nicholson,CVT-2250,2019
-DANC,1600,1,Ballet Dance I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,cheryl hosler,DANC-1600,2019
-DPA,3070,1,Method 3d Production,0.37,0.44,0.07,0.04,0.0,0.0,0.0,0.07,tommy van bui,DPA-3070,2019
-DPA,4020,1,Visual Found of Digital Prod,0.5,0.25,0.0,0.0,0.0,0.0,0.0,0.25,anthony summey,DPA-4020,2019
-DPA,4030,1,Vis Foundations II,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,anthony summey,DPA-4030,2019
-DPA,4830,1,Sp Stud Top: Digit Sculp Intro,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,insun kwon,DPA-4830,2019
-DPA,8150,1,Special Effects Compositing,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,DPA-8150,2019
-DPA,8150,843,Special Effects Compositing,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,DPA-8150,2019
-ECE,2010,1,Logic and Computing Device,0.22,0.3,0.22,0.13,0.06,0.0,0.0,0.06,lin zhu,ECE-2010,2019
-ECE,2020,1,Electric Circuits I,0.16,0.31,0.27,0.04,0.15,0.0,0.0,0.07,william harrell,ECE-2020,2019
-ECE,2070,1,Basic Electrical Engineering,0.38,0.36,0.16,0.05,0.02,0.0,0.0,0.02,fatemeh tooryan,ECE-2070,2019
-ECE,2070,2,Basic Electrical Engineering,0.59,0.25,0.09,0.03,0.01,0.0,0.0,0.03,timothy anglea,ECE-2070,2019
-ECE,2070,3,Basic Electrical Engineering,0.23,0.42,0.19,0.02,0.0,0.0,0.12,0.02,william th kolodzey,ECE-2070,2019
-ECE,2080,4,Basic Electrical Engr Lab,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2019
-ECE,2080,10,Basic Electrical Engr Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2019
-ECE,2080,18,Basic Electrical Engr Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2080,2019
-ECE,2080,20,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,ECE-2080,2019
-ECE,2090,3,Logic & Computing Devices Lab,0.27,0.55,0.0,0.0,0.09,0.0,0.0,0.09,apoorva dee kapadia,ECE-2090,2019
-ECE,2110,1,Elec Engr Lab I,0.47,0.21,0.05,0.05,0.05,0.0,0.0,0.16,apoorva dee kapadia,ECE-2110,2019
-ECE,2110,2,Elec Engr Lab I,0.77,0.0,0.15,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,ECE-2110,2019
-ECE,2120,1,Electrical Engineering Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2120,2019
-ECE,2120,6,Electrical Engineering Lab II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2120,2019
-ECE,2120,9,Electrical Engineering Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2120,2019
-ECE,2220,1,Syst Prog Concept,0.18,0.33,0.24,0.04,0.14,0.0,0.0,0.07,william reid,ECE-2220,2019
-ECE,2230,1,Comp Sys Eng,0.18,0.24,0.24,0.03,0.18,0.0,0.0,0.15,jon cameron calhoun,ECE-2230,2019
-ECE,2620,1,Electric Circuits II,0.36,0.34,0.19,0.07,0.04,0.0,0.0,0.0,richard groff,ECE-2620,2019
-ECE,2720,1,Comp Organization,0.37,0.37,0.2,0.02,0.03,0.0,0.0,0.0,william reid,ECE-2720,2019
-ECE,2730,2,Computer Org Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-2730,2019
-ECE,3000,1,Junior Honors Seminar,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,daniel noneaker,ECE-3000,2019
-ECE,3000,1,Junior Honors Seminar,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,carl baum,ECE-3000,2019
-ECE,3110,2,Electrical Engineering Lab III,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2019
-ECE,3110,3,Electrical Engineering Lab III,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2019
-ECE,3110,4,Electrical Engineering Lab III,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3110,2019
-ECE,3110,5,Electrical Engineering Lab III,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,apoorva dee kapadia,ECE-3110,2019
-ECE,3120,3,Electrical Engineering Lab IV,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,ECE-3120,2019
-ECE,3170,1,Rand Signal Analysis,0.3,0.18,0.28,0.13,0.07,0.0,0.0,0.04,stephen hubbard,ECE-3170,2019
-ECE,3200,1,Electronics I,0.3,0.24,0.19,0.16,0.08,0.0,0.0,0.03,stephen hubbard,ECE-3200,2019
-ECE,3210,1,Electronics II,0.35,0.41,0.06,0.14,0.04,0.0,0.0,0.0,stephen hubbard,ECE-3210,2019
-ECE,3220,1,Intro Operating Sys,0.21,0.38,0.24,0.03,0.03,0.0,0.0,0.1,jacob sorber,ECE-3220,2019
-ECE,3220,2,Intro Operating Sys,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,rong ge,ECE-3220,2019
-ECE,3270,1,Dig Comp Design,0.12,0.2,0.22,0.2,0.15,0.0,0.0,0.11,melissa crawl smith,ECE-3270,2019
-ECE,3300,1,Signals & Systems,0.13,0.27,0.27,0.14,0.1,0.0,0.0,0.08,carl baum,ECE-3300,2019
-ECE,3520,1,Programming Systems,0.66,0.3,0.02,0.0,0.0,0.0,0.0,0.02,robert schalkoff,ECE-3520,2019
-ECE,3600,1,Elect Power Engr,0.3,0.24,0.24,0.05,0.0,0.0,0.03,0.14,edward collins,ECE-3600,2019
-ECE,3710,1,Microcontr Interface,0.35,0.44,0.17,0.0,0.05,0.0,0.0,0.0,william reid,ECE-3710,2019
-ECE,3720,3,Micro Int Lab,0.8,0.0,0.1,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,ECE-3720,2019
-ECE,3720,5,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2019
-ECE,3720,7,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-3720,2019
-ECE,3800,1,Electromagnetics,0.24,0.23,0.16,0.08,0.1,0.0,0.0,0.19,yuan li,ECE-3800,2019
-ECE,3810,1,Field Waves & Ckts,0.4,0.4,0.11,0.03,0.0,0.0,0.0,0.06,anthony martin,ECE-3810,2019
-ECE,3990,5,CI: High-Perf. Cluster Comp.,0.8,0.0,0.0,0.2,0.0,0.0,0.0,0.0,jon cameron calhoun,ECE-3990,2019
-ECE,4090,1,Intr to Linear Control Systems,0.68,0.13,0.15,0.0,0.02,0.0,0.0,0.02,ian walker,ECE-4090,2019
-ECE,4160,1,Smart Grid,0.44,0.47,0.06,0.0,0.0,0.0,0.0,0.03,gan venayagamoorthy,ECE-4160,2019
-ECE,4190,1,Elec Mach and Drives,0.25,0.25,0.2,0.15,0.05,0.0,0.0,0.1,johan heinri enslin,ECE-4190,2019
-ECE,4270,1,Communications Sys,0.2,0.23,0.4,0.06,0.03,0.0,0.0,0.09,lu yu,ECE-4270,2019
-ECE,4320,1,Instrumentation,0.1,0.5,0.3,0.1,0.0,0.0,0.0,0.0,goutam koley,ECE-4320,2019
-ECE,4380,1,Computer Commun,0.24,0.29,0.24,0.06,0.0,0.0,0.03,0.15,harlan russell,ECE-4380,2019
-ECE,4400,1,Local Computer Nets,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,kuang-ching wang,ECE-4400,2019
-ECE,4680,1,Embedded Computing,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,adam hoover,ECE-4680,2019
-ECE,4930,12,Industrial Contr & Automation,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,ECE-4930,2019
-ECE,4950,1,Int Sys Design I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,ECE-4950,2019
-ECE,4960,1,Int Sys Design II,0.58,0.34,0.07,0.0,0.0,0.0,0.0,0.01,richard groff,ECE-4960,2019
-ECE,4990,18,CI: Deep Learning & Big Data,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,ECE-4990,2019
-ECE,6190,1,Elec Mach and Drives,0.75,0.0,0.25,0.0,0.0,0.0,0.0,0.0,johan heinri enslin,ECE-6190,2019
-ECE,6680,1,Embedded Computing,0.64,0.0,0.27,0.0,0.0,0.0,0.0,0.09,adam hoover,ECE-6680,2019
-ECE,6930,2,Silicon Photonics Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,judson doug ryckman,ECE-6930,2019
-ECE,6930,26,Optical Fiber Communications,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,liang dong,ECE-6930,2019
-ECE,8170,1,Power System Transients,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ramtin hadidi,ECE-8170,2019
-ECE,8240,1,Pow Sys Protection,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,sukumar maka brahma,ECE-8240,2019
-ECE,8560,1,Pattern Recognition,0.21,0.37,0.16,0.0,0.0,0.0,0.0,0.26,robert schalkoff,ECE-8560,2019
-ECE,8930,8,Advanced Photonic Sensors,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hai xiao,ECE-8930,2019
-ECE,8930,11,Malware Reverse Engineering,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,ECE-8930,2019
-ECE,8930,11,Malware Reverse Engineering,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,ECE-8930,2019
-ECE,8930,843,Malware Rev. Engin. Charleston,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,ECE-8930,2019
-ECE,8930,843,Malware Rev. Engin. Charleston,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,ECE-8930,2019
-ECON,2000,1,Economic Concepts,0.38,0.34,0.16,0.0,0.06,0.0,0.0,0.06,shubhashrita basu,ECON-2000,2019
-ECON,2000,2,Economic Concepts,0.4,0.35,0.13,0.05,0.0,0.0,0.0,0.08,shubhashrita basu,ECON-2000,2019
-ECON,2000,3,Economic Concepts,0.65,0.23,0.03,0.05,0.03,0.0,0.0,0.03,miren ivankovic,ECON-2000,2019
-ECON,2110,1,Principles of Microeconomics,0.4,0.23,0.28,0.08,0.03,0.0,0.0,0.0,sarah louise wilson,ECON-2110,2019
-ECON,2110,2,Principles of Microeconomics,0.3,0.43,0.2,0.03,0.03,0.0,0.0,0.03,roksan ghanbariamin,ECON-2110,2019
-ECON,2110,3,Principles of Microeconomics,0.34,0.27,0.21,0.09,0.08,0.0,0.0,0.01,benjamin posmanick,ECON-2110,2019
-ECON,2110,4,Principles of Microeconomics,0.29,0.53,0.14,0.0,0.02,0.0,0.0,0.02,chen wang,ECON-2110,2019
-ECON,2110,5,Principles of Microeconomics,0.33,0.38,0.2,0.08,0.0,0.0,0.0,0.03,molly espey,ECON-2110,2019
-ECON,2110,6,Principles of Microeconomics,0.08,0.42,0.25,0.15,0.04,0.0,0.0,0.06,liuna issagholian,ECON-2110,2019
-ECON,2110,8,Principles of Microeconomics,0.37,0.34,0.19,0.04,0.02,0.0,0.0,0.04,jonathan orr ernest,ECON-2110,2019
-ECON,2110,10,Principles of Microeconomics,0.42,0.5,0.06,0.0,0.02,0.0,0.0,0.0,jacob walloga,ECON-2110,2019
-ECON,2110,12,Principles of Microeconomics,0.38,0.45,0.13,0.0,0.0,0.0,0.0,0.05,molly espey,ECON-2110,2019
-ECON,2120,1,Principles of Macroeconomics,0.38,0.06,0.5,0.0,0.06,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,2,Principles of Macroeconomics,0.22,0.28,0.39,0.11,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,3,Principles of Macroeconomics,0.28,0.5,0.11,0.06,0.06,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,4,Principles of Macroeconomics,0.11,0.42,0.37,0.11,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,5,Principles of Macroeconomics,0.22,0.33,0.44,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,6,Principles of Macroeconomics,0.5,0.07,0.21,0.07,0.14,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,7,Principles of Macroeconomics,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,8,Principles of Macroeconomics,0.17,0.28,0.44,0.06,0.06,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,9,Principles of Macroeconomics,0.53,0.21,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,10,Principles of Macroeconomics,0.26,0.32,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,11,Principles of Macroeconomics,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,12,Principles of Macroeconomics,0.36,0.14,0.36,0.14,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,13,Principles of Macroeconomics,0.5,0.3,0.15,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,14,Principles of Macroeconomics,0.37,0.42,0.16,0.05,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,15,Principles of Macroeconomics,0.24,0.47,0.18,0.12,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,16,Principles of Macroeconomics,0.61,0.17,0.17,0.06,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,17,Principles of Macroeconomics,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,18,Principles of Macroeconomics,0.42,0.26,0.16,0.05,0.11,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,19,Principles of Macroeconomics,0.22,0.33,0.33,0.11,0.0,0.0,0.0,0.0,scott baier,ECON-2120,2019
-ECON,2120,20,Principles of Macroeconomics,0.31,0.23,0.31,0.05,0.0,0.0,0.03,0.08,narendra regmi,ECON-2120,2019
-ECON,2120,21,Principles of Macroeconomics,0.84,0.14,0.02,0.0,0.0,0.0,0.0,0.0,tyler francis,ECON-2120,2019
-ECON,2120,22,Principles of Macroeconomics,0.43,0.35,0.11,0.0,0.0,0.0,0.0,0.11,kenneth whaley,ECON-2120,2019
-ECON,2120,23,Principles of Macroeconomics,0.39,0.26,0.26,0.0,0.05,0.0,0.0,0.03,kenneth whaley,ECON-2120,2019
-ECON,2120,24,Principles of Macroeconomics,0.36,0.41,0.11,0.02,0.03,0.0,0.0,0.07,elijah neilson,ECON-2120,2019
-ECON,2120,25,Principles of Macroeconomics,0.38,0.29,0.24,0.03,0.03,0.0,0.0,0.03,wing yin chung,ECON-2120,2019
-ECON,2120,26,Principles of Macroeconomics,0.78,0.19,0.0,0.0,0.0,0.0,0.0,0.03,tyler francis,ECON-2120,2019
-ECON,2120,27,Principles of Macroeconomics,0.38,0.38,0.12,0.03,0.09,0.0,0.0,0.0,benjamin ti harbolt,ECON-2120,2019
-ECON,2120,28,Principles of Macroecon (HON),0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,christopher gorry,ECON-2120,2019
-ECON,2120,29,Principles of Macroeconomics,0.28,0.44,0.24,0.04,0.0,0.0,0.0,0.0,scott barkowski,ECON-2120,2019
-ECON,3020,1,Money and Banking,0.15,0.49,0.34,0.0,0.02,0.0,0.0,0.0,smriti bhargava,ECON-3020,2019
-ECON,3060,1,Managerial Economics,0.21,0.28,0.1,0.19,0.14,0.0,0.0,0.09,steven johnson,ECON-3060,2019
-ECON,3100,1,International Econ,0.29,0.54,0.17,0.0,0.0,0.0,0.0,0.0,scott baier,ECON-3100,2019
-ECON,3140,1,Intermediate Micro,0.32,0.24,0.18,0.06,0.03,0.0,0.0,0.18,yichen christy zhou,ECON-3140,2019
-ECON,3140,2,Intermediate Micro,0.23,0.28,0.23,0.15,0.03,0.0,0.0,0.1,robert kennet fleck,ECON-3140,2019
-ECON,3140,4,Intermediate Micro,0.19,0.11,0.22,0.14,0.16,0.0,0.0,0.19,frederick hanssen,ECON-3140,2019
-ECON,3150,1,Intermediate Macro,0.27,0.27,0.2,0.1,0.06,0.0,0.0,0.1,michal jerzmanowski,ECON-3150,2019
-ECON,3150,2,Intermediate Macro,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,jeremy choquette,ECON-3150,2019
-ECON,3440,1,Property Rights,0.22,0.33,0.17,0.17,0.06,0.0,0.0,0.06,dar litsukova-bokar,ECON-3440,2019
-ECON,3500,1,Moral & Ethical Econ,0.56,0.24,0.2,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,ECON-3500,2019
-ECON,3500,2,Moral & Ethical Econ,0.25,0.35,0.15,0.05,0.05,0.0,0.0,0.15,bradley keith hobbs,ECON-3500,2019
-ECON,3600,1,Public Choice,0.3,0.48,0.18,0.03,0.0,0.0,0.0,0.03,michael makowsky,ECON-3600,2019
-ECON,4010,1,Labor Mkt Analysis,0.27,0.47,0.17,0.03,0.03,0.0,0.0,0.03,curtis simon,ECON-4010,2019
-ECON,4020,1,Law and Economics,0.23,0.4,0.28,0.02,0.0,0.0,0.0,0.07,thomas wins hazlett,ECON-4020,2019
-ECON,4050,1,Intro to Econometric,0.33,0.25,0.08,0.25,0.06,0.0,0.0,0.03,scott barkowski,ECON-4050,2019
-ECON,4050,2,Intro to Econometric,0.48,0.23,0.1,0.1,0.03,0.0,0.0,0.06,yichen christy zhou,ECON-4050,2019
-ECON,4110,1,Econ of Education,0.56,0.29,0.06,0.03,0.0,0.0,0.0,0.06, garcia menendez,ECON-4110,2019
-ECON,4200,1,Pub Sector Econ,0.24,0.19,0.48,0.05,0.0,0.0,0.0,0.05,william dougan,ECON-4200,2019
-ECON,4230,1,Economics of Health,0.53,0.29,0.13,0.03,0.0,0.0,0.0,0.03,devon merritt gorry,ECON-4230,2019
-ECON,4260,1,Sem Sport Economics,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,raymond sauer,ECON-4260,2019
-ECON,4270,1,Dev American Economy,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,howard ne bodenhorn,ECON-4270,2019
-ECON,4400,1,Game Theory,0.26,0.13,0.48,0.0,0.04,0.0,0.0,0.09,charles thomas,ECON-4400,2019
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.0,0.18,0.55,0.18,0.09,0.0,0.0,0.0,scott templeton,ECON-4570,2019
-ECON,4980,2,Why Business?,0.28,0.56,0.12,0.0,0.0,0.0,0.0,0.04,bradley keith hobbs,ECON-4980,2019
-ECON,4980,3,Why Business?,0.6,0.3,0.07,0.0,0.0,0.0,0.0,0.02,lawrence ree watson,ECON-4980,2019
-ECON,4980,4,Econ of Arts & Culture,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,ECON-4980,2019
-ECON,4980,5,Sel Topic - Machine Learning,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,chungsang lam,ECON-4980,2019
-ECON,8020,2,Adv Econ Concepts and Applic I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,ECON-8020,2019
-ECON,8050,1,Macroeconomic Theory,0.5,0.14,0.29,0.07,0.0,0.0,0.0,0.0,michal jerzmanowski,ECON-8050,2019
-ECON,9000,5,Sel Topic - Machine Learning,0.25,0.5,0.0,0.0,0.0,0.0,0.0,0.25,chungsang lam,ECON-9000,2019
-ED,1050,2,Orientation to Education,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,ED-1050,2019
-ED,1050,2,Orientation to Education,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,paula bailey adams,ED-1050,2019
-ED,1970,2,Creative Inquiry in Education,0.62,0.29,0.05,0.0,0.0,0.0,0.0,0.05,laurel ann whisler,ED-1970,2019
-ED,1970,2,Creative Inquiry in Education,0.62,0.29,0.05,0.0,0.0,0.0,0.0,0.05,elizabeth stephan,ED-1970,2019
-ED,3200,1,History of US Education,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,nafees mohamma khan,ED-3200,2019
-ED,3970,2,RMAN- Identity & Ldrship Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-3970,2019
-ED,3970,5,CI-Fundamentals of Scholarship,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,cherese france fine,ED-3970,2019
-ED,3970,5,CI-Fundamentals of Scholarship,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,ED-3970,2019
-ED,8090,412,Teacher Residency Internship,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,marshall alan darby,ED-8090,2019
-ED,8090,412,Teacher Residency Internship,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,ED-8090,2019
-ED,8600,1,Classroom-Based Research,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daphne duncan wiles,ED-8600,2019
-ED,8650,1,Curriculum Theory,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,ED-8650,2019
-ED,8750,500,Elements of Instructional Effe,0.93,0.02,0.02,0.0,0.0,0.0,0.0,0.02,susan rid nunamaker,ED-8750,2019
-EDC,2990,1,Creative Inq in Counselor Ed,0.71,0.19,0.1,0.0,0.0,0.0,0.0,0.0,jacob frankovich,EDC-2990,2019
-EDC,3900,1,Skills for Student Leaders,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,erin mayor fogle,EDC-3900,2019
-EDC,3900,4,Skills for Student Leaders,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2019
-EDC,3900,5,Skills for Student Leaders,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2019
-EDC,3900,6,Skills for Student Leaders,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,eric pernotto,EDC-3900,2019
-EDC,3900,10,Skills for Student Leaders,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,eric pernotto,EDC-3900,2019
-EDC,3900,11,Skills for Student Leaders,0.76,0.12,0.06,0.06,0.0,0.0,0.0,0.0,eric pernotto,EDC-3900,2019
-EDC,8850,1,Counseling Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david barrett,EDC-8850,2019
-EDEL,3210,1,Pe for the Elem Tchr,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,EDEL-3210,2019
-EDEL,4510,1,Elem Methods in Science Tchg,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daphne duncan wiles,EDEL-4510,2019
-EDEL,4520,1,Elem Methods Math Teaching,0.86,0.0,0.07,0.0,0.04,0.0,0.0,0.04,stacy jones,EDEL-4520,2019
-EDF,3020,1,Educational Psychology,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,karen rebecca clark,EDF-3020,2019
-EDF,3020,3,Educational Psychology,0.79,0.18,0.03,0.0,0.0,0.0,0.0,0.0,heather rog brooker,EDF-3020,2019
-EDF,3020,5,Educational Psychology,0.65,0.3,0.0,0.03,0.0,0.0,0.0,0.03,heather rog brooker,EDF-3020,2019
-EDF,3020,6,Educational Psychology,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,karen rebecca clark,EDF-3020,2019
-EDF,3340,1,Child Growth and Development,0.88,0.06,0.0,0.0,0.03,0.0,0.0,0.03,robert o'hara,EDF-3340,2019
-EDF,3340,3,Child Growth and Development,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,amanda eliz bennett,EDF-3340,2019
-EDF,3350,3,Adolescent Growth & Develop,0.49,0.33,0.08,0.05,0.03,0.0,0.0,0.03,david barrett,EDF-3350,2019
-EDF,4800,1,Digital Media & Learning,0.82,0.14,0.0,0.05,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2019
-EDF,4800,2,Digital Media & Learning,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2019
-EDF,4800,3,Digital Media & Learning,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,david matthew boyer,EDF-4800,2019
-EDF,4800,300,Digital Media & Learning,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2019
-EDF,4800,301,Digital Media & Learning,0.83,0.09,0.09,0.0,0.0,0.0,0.0,0.0,ryan visser,EDF-4800,2019
-EDF,9710,1,Case Study & Ethnographic Mthd,0.71,0.18,0.0,0.0,0.12,0.0,0.0,0.0,cynthia chri deaton,EDF-9710,2019
-EDF,9790,400,Qualitative Research in Educ,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,reginald wilkerson,EDF-9790,2019
-EDHD,3110,1,CI- Research in DM & Learning,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,ryan visser,EDHD-3110,2019
-EDHD,3110,1,CI- Research in DM & Learning,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,david matthew boyer,EDHD-3110,2019
-EDHD,3110,8,CI- Children's Lit. Newsletter,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDHD-3110,2019
-EDHD,3110,9,CI- Read/Review Child/YA Lit.,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,EDHD-3110,2019
-EDIS,9360,400,Advanced Program Evaluation,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,daniella hall,EDIS-9360,2019
-EDL,9000,400,Prin Edu Leadership,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,aris lane hall,EDL-9000,2019
-EDLT,4620,1,Reading Children's Lit in Elem,0.68,0.21,0.0,0.07,0.0,0.0,0.0,0.04,jonda cecole mcnair,EDLT-4620,2019
-EDLT,4670,1,Teaching ESOL in Elem Schools,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,hazel vega quesada,EDLT-4670,2019
-EDLT,8120,301,Assessment in Reading & Writin,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,rachelle savitz,EDLT-8120,2019
-EDLT,8120,500,Assessment in Reading & Writin,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,EDLT-8120,2019
-EDLT,8220,300,Strategies for Teaching ESOL,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,EDLT-8220,2019
-EDLT,8230,500,Introduction to Linguistics,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,emily smothe howell,EDLT-8230,2019
-EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,EDLT-8410,2019
-EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,EDLT-8410,2019
-EDLT,8410,507,Early Literacy Inst Strategies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,EDLT-8410,2019
-EDLT,8410,507,Early Literacy Inst Strategies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,EDLT-8410,2019
-EDLT,8810,508,Reading Recovery Teacher II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,EDLT-8810,2019
-EDLT,8810,508,Reading Recovery Teacher II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,EDLT-8810,2019
-EDLT,8830,508,Read Recovery Practicum II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,EDLT-8830,2019
-EDLT,8830,508,Read Recovery Practicum II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,EDLT-8830,2019
-EDSP,3700,2,Intro to Special Education,0.56,0.31,0.06,0.06,0.0,0.0,0.0,0.0,friggita johnson,EDSP-3700,2019
-EDSP,3700,4,Intro to Special Education,0.8,0.14,0.03,0.0,0.03,0.0,0.0,0.0,shanna eisne hirsch,EDSP-3700,2019
-EDSP,3700,300,Intro to Special Education,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,EDSP-3700,2019
-EDSP,3730,1,Char & Instr of ID & Autism,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,EDSP-3730,2019
-EDSP,3750,1,Early Intervention Spec Needs,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,abigail anne allen,EDSP-3750,2019
-EDSP,4910,1,Ed Assess Ind W/Dis,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,EDSP-4910,2019
-EDSP,4950,1,Comm & Collab Sp Ed,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,wendell kent parker,EDSP-4950,2019
-EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,wendell kent parker,EDSP-4980,2019
-EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,beverly lu romansky,EDSP-4980,2019
-EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,EDSP-4980,2019
-EES,2020,1,Environ Engr Fundamentals II,0.63,0.22,0.15,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,EES-2020,2019
-EES,4010,1,Environmental Engr,0.63,0.3,0.02,0.0,0.0,0.0,0.0,0.05,elizabeth carraway,EES-4010,2019
-EES,4010,2,Environmental Engr,0.38,0.43,0.08,0.08,0.05,0.0,0.0,0.0,ezra lucas ho cates,EES-4010,2019
-EES,4020,1,Water & Waste Water Treatment,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,mark schlautman,EES-4020,2019
-EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,sudeep popat,EES-4750,2019
-EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,EES-4750,2019
-EES,4850,1,Hazard Waste Management,0.29,0.42,0.16,0.03,0.0,0.0,0.0,0.1,mark schlautman,EES-4850,2019
-EES,4860,1,Environmental Sustainability,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,michael anthon dale,EES-4860,2019
-EES,4860,2,Environmental Sustainability,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,EES-4860,2019
-EES,4900,15,CI: From Drones to 3D Printing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael anthon dale,EES-4900,2019
-EES,4900,15,CI: From Drones to 3D Printing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,pat carbajales-dale,EES-4900,2019
-EES,8330,2,Air Poll Control Sys,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,andrew rich metcalf,EES-8330,2019
-ELE,3010,1,Entrepreneurial Foundations,0.44,0.44,0.1,0.03,0.0,0.0,0.0,0.0,christina kyprianou,ELE-3010,2019
-ELE,3010,2,Entrepreneurial Foundations,0.54,0.35,0.11,0.0,0.0,0.0,0.0,0.0,christina kyprianou,ELE-3010,2019
-ELE,3010,3,Entrepreneurial Foundations,0.15,0.5,0.28,0.0,0.0,0.0,0.0,0.08,ashley will parnell,ELE-3010,2019
-ELE,3010,4,Entrepreneurial Foundations,0.2,0.39,0.37,0.02,0.0,0.0,0.0,0.02,ashley will parnell,ELE-3010,2019
-ELE,3020,1,Entrepreneurial Resource Acqu,0.3,0.6,0.08,0.03,0.0,0.0,0.0,0.0,karl bruce kelly,ELE-3020,2019
-ELE,3020,2,Entrepreneurial Resource Acqu,0.25,0.53,0.2,0.0,0.0,0.0,0.0,0.03,karl bruce kelly,ELE-3020,2019
-ELE,4010,1,Venture Testing,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,chad navis,ELE-4010,2019
-ELE,4010,2,Venture Testing,0.5,0.4,0.08,0.03,0.0,0.0,0.0,0.0,chad navis,ELE-4010,2019
-ELE,4020,1,Venture Creation,0.13,0.73,0.13,0.0,0.0,0.0,0.0,0.0,william fra dinardo,ELE-4020,2019
-ELE,4030,1,Venture Growth,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,james keith hudgins,ELE-4030,2019
-ENGL,1030,1,Composition and Rhetoric,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,allen swords,ENGL-1030,2019
-ENGL,1030,2,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-1030,2019
-ENGL,1030,3,Composition and Rhetoric,0.47,0.27,0.13,0.07,0.0,0.0,0.0,0.07,naomi marie white,ENGL-1030,2019
-ENGL,1030,4,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,naomi marie white,ENGL-1030,2019
-ENGL,1030,5,Composition and Rhetoric,0.5,0.36,0.0,0.07,0.0,0.0,0.0,0.07,kristian wilson,ENGL-1030,2019
-ENGL,1030,6,Composition and Rhetoric,0.33,0.44,0.06,0.0,0.06,0.0,0.0,0.11,kristian wilson,ENGL-1030,2019
-ENGL,1030,8,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,ENGL-1030,2019
-ENGL,1030,9,Composition and Rhetoric,0.5,0.31,0.06,0.0,0.06,0.0,0.0,0.06,myers addison enlow,ENGL-1030,2019
-ENGL,1030,10,Composition and Rhetoric,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,myers addison enlow,ENGL-1030,2019
-ENGL,1030,11,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,julie edewaard,ENGL-1030,2019
-ENGL,1030,12,Composition and Rhetoric,0.86,0.07,0.0,0.07,0.0,0.0,0.0,0.0,julie edewaard,ENGL-1030,2019
-ENGL,1030,14,Composition and Rhetoric,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,blake elizab bowens,ENGL-1030,2019
-ENGL,1030,15,Composition and Rhetoric,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,charissa fryberger,ENGL-1030,2019
-ENGL,1030,16,Composition and Rhetoric,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,charissa fryberger,ENGL-1030,2019
-ENGL,1030,17,Composition and Rhetoric,0.47,0.2,0.0,0.0,0.13,0.0,0.0,0.2,tareva lese johnson,ENGL-1030,2019
-ENGL,1030,18,Composition and Rhetoric,0.29,0.43,0.14,0.0,0.14,0.0,0.0,0.0,chelsea mari clarey,ENGL-1030,2019
-ENGL,1030,19,Composition and Rhetoric,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,la'cresha ulo green,ENGL-1030,2019
-ENGL,1030,20,Composition and Rhetoric,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,ENGL-1030,2019
-ENGL,1030,22,Composition and Rhetoric,0.27,0.33,0.27,0.0,0.07,0.0,0.0,0.07,david charles foltz,ENGL-1030,2019
-ENGL,1030,23,Composition and Rhetoric,0.45,0.18,0.18,0.09,0.0,0.0,0.0,0.09,david charles foltz,ENGL-1030,2019
-ENGL,1030,25,Composition and Rhetoric,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,ENGL-1030,2019
-ENGL,1030,27,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,hannah pittm godwin,ENGL-1030,2019
-ENGL,1030,28,Composition and Rhetoric,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,hannah pittm godwin,ENGL-1030,2019
-ENGL,1030,29,Composition and Rhetoric,0.21,0.57,0.14,0.0,0.07,0.0,0.0,0.0,henna maria messina,ENGL-1030,2019
-ENGL,1030,31,Composition and Rhetoric,0.4,0.1,0.3,0.0,0.0,0.0,0.0,0.2,geveryl le robinson,ENGL-1030,2019
-ENGL,1030,32,Composition and Rhetoric,0.18,0.59,0.18,0.0,0.0,0.0,0.0,0.06,sharon kathl nalley,ENGL-1030,2019
-ENGL,1030,33,Composition and Rhetoric,0.5,0.25,0.0,0.0,0.0,0.0,0.08,0.17,cody hunter,ENGL-1030,2019
-ENGL,1030,34,Composition and Rhetoric,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,cody hunter,ENGL-1030,2019
-ENGL,1030,35,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kailan smi sindelar,ENGL-1030,2019
-ENGL,1030,37,Composition and Rhetoric,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,shauna chung,ENGL-1030,2019
-ENGL,1030,38,Composition and Rhetoric,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,shauna chung,ENGL-1030,2019
-ENGL,1030,39,Composition and Rhetoric,0.53,0.33,0.0,0.0,0.07,0.0,0.0,0.07,jacob dania richter,ENGL-1030,2019
-ENGL,1030,40,Composition and Rhetoric,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,jacob dania richter,ENGL-1030,2019
-ENGL,1030,41,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,sarah el richardson,ENGL-1030,2019
-ENGL,1030,42,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah el richardson,ENGL-1030,2019
-ENGL,1030,45,Composition and Rhetoric,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,ENGL-1030,2019
-ENGL,1030,46,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,ENGL-1030,2019
-ENGL,1030,47,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,caroline eliz young,ENGL-1030,2019
-ENGL,1030,48,Composition and Rhetoric,0.33,0.44,0.11,0.06,0.06,0.0,0.0,0.0,sharon kathl nalley,ENGL-1030,2019
-ENGL,1030,49,Composition and Rhetoric,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,ENGL-1030,2019
-ENGL,1030,50,Composition and Rhetoric,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,ENGL-1030,2019
-ENGL,1030,51,Composition and Rhetoric,0.53,0.33,0.07,0.0,0.0,0.0,0.07,0.0,chloe mich whitaker,ENGL-1030,2019
-ENGL,1030,52,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jennie el wakefield,ENGL-1030,2019
-ENGL,1030,53,Composition and Rhetoric,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,michelle lloyd,ENGL-1030,2019
-ENGL,1030,55,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,caroline eliz young,ENGL-1030,2019
-ENGL,1030,56,Composition and Rhetoric,0.4,0.2,0.2,0.1,0.1,0.0,0.0,0.0,bree laran beal,ENGL-1030,2019
-ENGL,1030,58,Composition and Rhetoric,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,tareva lese johnson,ENGL-1030,2019
-ENGL,1030,59,Composition and Rhetoric,0.43,0.36,0.07,0.07,0.07,0.0,0.0,0.0,mary catheri nestor,ENGL-1030,2019
-ENGL,1030,60,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mary catheri nestor,ENGL-1030,2019
-ENGL,1030,61,Composition and Rhetoric,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,bree laran beal,ENGL-1030,2019
-ENGL,1030,63,Composition and Rhetoric,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,ENGL-1030,2019
-ENGL,1030,65,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-1030,2019
-ENGL,1030,68,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-1030,2019
-ENGL,1030,69,Composition and Rhetoric,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-1030,2019
-ENGL,1030,70,Composition and Rhetoric,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jennifer forsberg,ENGL-1030,2019
-ENGL,1030,71,Composition and Rhetoric,0.55,0.18,0.0,0.27,0.0,0.0,0.0,0.0,bree laran beal,ENGL-1030,2019
-ENGL,1030,73,Composition and Rhetoric,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,caitlin grace watt,ENGL-1030,2019
-ENGL,1030,74,Composition and Rhetoric,0.36,0.36,0.09,0.09,0.09,0.0,0.0,0.0,edward thomas troy,ENGL-1030,2019
-ENGL,1030,75,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,edward thomas troy,ENGL-1030,2019
-ENGL,1030,76,Composition and Rhetoric,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,edward thomas troy,ENGL-1030,2019
-ENGL,1030,77,Composition and Rhetoric,0.36,0.27,0.18,0.0,0.09,0.0,0.0,0.09,tareva lese johnson,ENGL-1030,2019
-ENGL,1030,78,Composition and Rhetoric,0.53,0.24,0.06,0.0,0.0,0.0,0.0,0.18,andrew mathas,ENGL-1030,2019
-ENGL,1030,79,Composition and Rhetoric,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,andrew mathas,ENGL-1030,2019
-ENGL,1030,101,Composition and Rhetoric (HON),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,allison nico harris,ENGL-1030,2019
-ENGL,2120,1,World Literature,0.64,0.18,0.04,0.07,0.04,0.0,0.0,0.02,walter edgar hunter,ENGL-2120,2019
-ENGL,2120,2,World Literature,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,elizabeth stansell,ENGL-2120,2019
-ENGL,2120,4,World Literature,0.71,0.21,0.0,0.04,0.0,0.0,0.0,0.04,elizabeth stansell,ENGL-2120,2019
-ENGL,2120,7,World Literature,0.2,0.48,0.12,0.04,0.04,0.0,0.0,0.12,david charles foltz,ENGL-2120,2019
-ENGL,2120,8,World Literature,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,david charles foltz,ENGL-2120,2019
-ENGL,2120,9,World Literature,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.13,gregory luke chwala,ENGL-2120,2019
-ENGL,2120,10,World Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,gregory luke chwala,ENGL-2120,2019
-ENGL,2120,12,World Literature,0.52,0.24,0.12,0.08,0.0,0.0,0.0,0.04,kathy elaine nixon,ENGL-2120,2019
-ENGL,2120,13,World Literature,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,kathy elaine nixon,ENGL-2120,2019
-ENGL,2120,14,World Literature,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,heather pr williams,ENGL-2120,2019
-ENGL,2120,15,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,heather pr williams,ENGL-2120,2019
-ENGL,2120,16,World Literature,0.4,0.44,0.16,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,ENGL-2120,2019
-ENGL,2120,17,World Literature,0.44,0.48,0.0,0.04,0.0,0.0,0.0,0.04,chloe mich whitaker,ENGL-2120,2019
-ENGL,2120,20,World Literature,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,patricia sunia,ENGL-2120,2019
-ENGL,2120,21,World Literature,0.59,0.32,0.05,0.0,0.0,0.0,0.0,0.05,patricia sunia,ENGL-2120,2019
-ENGL,2120,22,World Literature,0.5,0.29,0.13,0.08,0.0,0.0,0.0,0.0,karen kettnich,ENGL-2120,2019
-ENGL,2120,23,World Literature,0.35,0.43,0.09,0.04,0.04,0.0,0.0,0.04,karen kettnich,ENGL-2120,2019
-ENGL,2120,24,World Literature,0.42,0.53,0.0,0.0,0.05,0.0,0.0,0.0,gregory luke chwala,ENGL-2120,2019
-ENGL,2120,25,World Literature,0.27,0.5,0.18,0.0,0.0,0.0,0.05,0.0,kenneth micha tuite,ENGL-2120,2019
-ENGL,2120,26,World Literature,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,spencer tricker,ENGL-2120,2019
-ENGL,2120,27,World Literature,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,spencer tricker,ENGL-2120,2019
-ENGL,2120,28,World Literature,0.57,0.3,0.0,0.04,0.04,0.0,0.0,0.04,spencer tricker,ENGL-2120,2019
-ENGL,2120,400,World Literature,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,elizabeth stansell,ENGL-2120,2019
-ENGL,2130,1,British Literature,0.48,0.35,0.04,0.0,0.0,0.0,0.0,0.13,krist aldebol-hazle,ENGL-2130,2019
-ENGL,2130,2,British Literature,0.6,0.16,0.08,0.0,0.04,0.0,0.0,0.12,krist aldebol-hazle,ENGL-2130,2019
-ENGL,2130,3,British Literature,0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,megan no macalystre,ENGL-2130,2019
-ENGL,2130,4,British Literature,0.16,0.6,0.12,0.0,0.04,0.0,0.0,0.08,megan no macalystre,ENGL-2130,2019
-ENGL,2130,5,British Literature,0.48,0.36,0.0,0.04,0.04,0.0,0.0,0.08,lucian ghita,ENGL-2130,2019
-ENGL,2130,6,British Literature,0.72,0.2,0.04,0.04,0.0,0.0,0.0,0.0,lucian ghita,ENGL-2130,2019
-ENGL,2130,10,British Literature,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,ENGL-2130,2019
-ENGL,2130,11,British Literature,0.64,0.32,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,ENGL-2130,2019
-ENGL,2130,12,British Literature,0.27,0.32,0.14,0.0,0.18,0.0,0.0,0.09,megan no macalystre,ENGL-2130,2019
-ENGL,2130,13,British Literature,0.6,0.32,0.0,0.08,0.0,0.0,0.0,0.0,daniel scott citro,ENGL-2130,2019
-ENGL,2130,14,British Literature,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ingrid anna pierce,ENGL-2130,2019
-ENGL,2130,15,British Literature,0.76,0.16,0.04,0.04,0.0,0.0,0.0,0.0,ingrid anna pierce,ENGL-2130,2019
-ENGL,2130,16,British Literature,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,caitlin grace watt,ENGL-2130,2019
-ENGL,2130,17,British Literature,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,caitlin grace watt,ENGL-2130,2019
-ENGL,2130,18,British Literature,0.84,0.08,0.0,0.0,0.08,0.0,0.0,0.0,ingrid anna pierce,ENGL-2130,2019
-ENGL,2130,19,British Literature,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,caitlin grace watt,ENGL-2130,2019
-ENGL,2140,1,American Literature,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,melissa dugan,ENGL-2140,2019
-ENGL,2140,2,American Literature,0.64,0.24,0.04,0.04,0.04,0.0,0.0,0.0,melissa dugan,ENGL-2140,2019
-ENGL,2140,3,American Literature,0.29,0.25,0.33,0.08,0.0,0.0,0.0,0.04,chelsea mari clarey,ENGL-2140,2019
-ENGL,2140,4,American Literature,0.12,0.48,0.32,0.0,0.04,0.0,0.0,0.04,chelsea mari clarey,ENGL-2140,2019
-ENGL,2140,5,American Literature,0.26,0.48,0.13,0.0,0.04,0.0,0.0,0.09,remley melis makala,ENGL-2140,2019
-ENGL,2140,6,American Literature,0.5,0.29,0.13,0.0,0.0,0.0,0.0,0.08,remley melis makala,ENGL-2140,2019
-ENGL,2140,7,American Literature,0.27,0.4,0.33,0.0,0.0,0.0,0.0,0.0,chelsea mari clarey,ENGL-2140,2019
-ENGL,2140,8,American Literature,0.43,0.26,0.13,0.0,0.0,0.0,0.0,0.17,remley melis makala,ENGL-2140,2019
-ENGL,2140,11,American Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,ENGL-2140,2019
-ENGL,2140,12,American Literature,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,ENGL-2140,2019
-ENGL,2140,13,American Literature,0.67,0.21,0.04,0.0,0.04,0.0,0.0,0.04,caroline eliz young,ENGL-2140,2019
-ENGL,2140,14,American Literature,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliz young,ENGL-2140,2019
-ENGL,2140,20,American Literature,0.35,0.4,0.05,0.0,0.05,0.0,0.0,0.15,mary catheri nestor,ENGL-2140,2019
-ENGL,2140,21,American Literature,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.04,mary catheri nestor,ENGL-2140,2019
-ENGL,2140,100,American Literature (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,ENGL-2140,2019
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,allison nico harris,ENGL-2150,2019
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.76,0.12,0.04,0.0,0.08,0.0,0.0,0.0,allison nico harris,ENGL-2150,2019
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.56,0.32,0.0,0.04,0.0,0.0,0.0,0.08,lindsey henley kurz,ENGL-2150,2019
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-2150,2019
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,allen swords,ENGL-2150,2019
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,andrew mathas,ENGL-2150,2019
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.48,0.32,0.16,0.04,0.0,0.0,0.0,0.0,andrew mathas,ENGL-2150,2019
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.79,0.13,0.04,0.04,0.0,0.0,0.0,0.0,allison nico harris,ENGL-2150,2019
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.4,0.32,0.2,0.04,0.0,0.0,0.0,0.04,julia brownle koets,ENGL-2150,2019
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.12,0.68,0.16,0.04,0.0,0.0,0.0,0.0,julia brownle koets,ENGL-2150,2019
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-2150,2019
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.05,0.59,0.23,0.05,0.05,0.0,0.0,0.05,sarah mae cooper,ENGL-2150,2019
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,ENGL-2150,2019
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.36,0.36,0.2,0.0,0.0,0.0,0.0,0.08,hannah pittm godwin,ENGL-2150,2019
-ENGL,2150,18,Lit in 20th-21st Cent Contexts,0.76,0.2,0.0,0.0,0.04,0.0,0.0,0.0,lindsey henley kurz,ENGL-2150,2019
-ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,lindsey henley kurz,ENGL-2150,2019
-ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,hannah pittm godwin,ENGL-2150,2019
-ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.6,0.24,0.12,0.04,0.0,0.0,0.0,0.0,john logan pursley,ENGL-2150,2019
-ENGL,2150,100,Lit in 20th-21st Cent (HON),0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,ENGL-2150,2019
-ENGL,2150,405,Lit in 20th-21st Cent Contexts,0.08,0.5,0.27,0.08,0.0,0.0,0.0,0.08,sarah mae cooper,ENGL-2150,2019
-ENGL,2150,406,Lit in 20th-21st Cent Contexts,0.05,0.7,0.25,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,ENGL-2150,2019
-ENGL,2160,1,African American Literature,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,ENGL-2160,2019
-ENGL,2160,2,African American Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,ENGL-2160,2019
-ENGL,2160,3,African American Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,ENGL-2160,2019
-ENGL,2310,1,Intro to Journalism,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,ENGL-2310,2019
-ENGL,3040,1,Business Writing,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,patricia sunia,ENGL-3040,2019
-ENGL,3040,2,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,ENGL-3040,2019
-ENGL,3040,3,Business Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william cunningham,ENGL-3040,2019
-ENGL,3040,4,Business Writing,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,william cunningham,ENGL-3040,2019
-ENGL,3040,5,Business Writing,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,la'cresha ulo green,ENGL-3040,2019
-ENGL,3040,6,Business Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulo green,ENGL-3040,2019
-ENGL,3040,7,Business Writing,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,katalin beck,ENGL-3040,2019
-ENGL,3040,8,Business Writing,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3040,2019
-ENGL,3040,10,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,ENGL-3040,2019
-ENGL,3040,11,Business Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,heather pr williams,ENGL-3040,2019
-ENGL,3040,12,Business Writing,0.37,0.47,0.05,0.11,0.0,0.0,0.0,0.0,heather pr williams,ENGL-3040,2019
-ENGL,3040,13,Business Writing,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,patricia sunia,ENGL-3040,2019
-ENGL,3040,400,Business Writing,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,krist aldebol-hazle,ENGL-3040,2019
-ENGL,3040,401,Business Writing,0.7,0.25,0.0,0.05,0.0,0.0,0.0,0.0,krist aldebol-hazle,ENGL-3040,2019
-ENGL,3040,402,Business Writing,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,megan pietruszewski,ENGL-3040,2019
-ENGL,3040,403,Business Writing,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,megan pietruszewski,ENGL-3040,2019
-ENGL,3040,404,Business Writing,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,heather pr williams,ENGL-3040,2019
-ENGL,3100,1,Crit Writ Lit,0.53,0.12,0.12,0.0,0.0,0.0,0.0,0.24,kimberly manganelli,ENGL-3100,2019
-ENGL,3100,2,Crit Writ Lit,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,erin marina goss,ENGL-3100,2019
-ENGL,3100,3,Crit Writ Lit,0.67,0.29,0.0,0.05,0.0,0.0,0.0,0.0,matthew hooley,ENGL-3100,2019
-ENGL,3120,1,Advanced Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher stuart,ENGL-3120,2019
-ENGL,3120,2,Advanced Composition,0.63,0.19,0.06,0.0,0.06,0.0,0.0,0.06,christopher stuart,ENGL-3120,2019
-ENGL,3120,4,Advanced Composition,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,christopher benson,ENGL-3120,2019
-ENGL,3120,5,Advanced Composition,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,jennie el wakefield,ENGL-3120,2019
-ENGL,3140,1,Technical Writing,0.35,0.55,0.05,0.05,0.0,0.0,0.0,0.0,william cunningham,ENGL-3140,2019
-ENGL,3140,2,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william cunningham,ENGL-3140,2019
-ENGL,3140,3,Technical Writing,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,april 'brien,ENGL-3140,2019
-ENGL,3140,4,Technical Writing,0.53,0.26,0.11,0.05,0.0,0.0,0.0,0.05,april 'brien,ENGL-3140,2019
-ENGL,3140,7,Technical Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2019
-ENGL,3140,8,Technical Writing,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,katalin beck,ENGL-3140,2019
-ENGL,3140,9,Technical Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,henna maria messina,ENGL-3140,2019
-ENGL,3140,10,Technical Writing,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,henna maria messina,ENGL-3140,2019
-ENGL,3140,11,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,brian lee gaines,ENGL-3140,2019
-ENGL,3140,13,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,ENGL-3140,2019
-ENGL,3140,14,Technical Writing,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,dia quaglia beltran,ENGL-3140,2019
-ENGL,3140,21,Technical Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,kathy elaine nixon,ENGL-3140,2019
-ENGL,3140,22,Technical Writing,0.58,0.26,0.0,0.0,0.0,0.0,0.0,0.16,kathy elaine nixon,ENGL-3140,2019
-ENGL,3140,25,Technical Writing,0.67,0.17,0.11,0.0,0.0,0.0,0.0,0.06,megan pietruszewski,ENGL-3140,2019
-ENGL,3140,26,Technical Writing,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,megan pietruszewski,ENGL-3140,2019
-ENGL,3140,30,Technical Writing,0.22,0.56,0.11,0.11,0.0,0.0,0.0,0.0,henna maria messina,ENGL-3140,2019
-ENGL,3140,400,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,ENGL-3140,2019
-ENGL,3140,401,Technical Writing,0.79,0.05,0.05,0.05,0.0,0.0,0.0,0.05,geveryl le robinson,ENGL-3140,2019
-ENGL,3140,402,Technical Writing,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,geveryl le robinson,ENGL-3140,2019
-ENGL,3140,403,Technical Writing,0.74,0.16,0.0,0.0,0.0,0.0,0.0,0.11,geveryl le robinson,ENGL-3140,2019
-ENGL,3150,1,Scientific Writing & Comm,0.35,0.35,0.24,0.06,0.0,0.0,0.0,0.0,william pulley,ENGL-3150,2019
-ENGL,3150,2,Scientific Writing & Comm,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,william pulley,ENGL-3150,2019
-ENGL,3150,3,Scientific Writing & Comm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2019
-ENGL,3150,4,Scientific Writing & Comm,0.5,0.17,0.22,0.0,0.0,0.0,0.0,0.11,william pulley,ENGL-3150,2019
-ENGL,3150,5,Scientific Writing & Comm,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,ENGL-3150,2019
-ENGL,3150,6,Scientific Writing & Comm,0.7,0.15,0.0,0.05,0.05,0.0,0.0,0.05,christopher benson,ENGL-3150,2019
-ENGL,3150,400,Scientific Writing & Comm,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,philip randall,ENGL-3150,2019
-ENGL,3150,402,Scientific Writing & Comm,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,philip randall,ENGL-3150,2019
-ENGL,3150,405,Scientific Writing & Comm,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,philip randall,ENGL-3150,2019
-ENGL,3460,1,Intr Creative Writing: Poetry,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,sarah mae cooper,ENGL-3460,2019
-ENGL,3480,1,Intr Creat Writ: Screenwriting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,julia brownle koets,ENGL-3480,2019
-ENGL,3490,1,Tech/Pop Imagination,0.44,0.25,0.06,0.0,0.19,0.0,0.0,0.06,gabriel and hankins,ENGL-3490,2019
-ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,angela naimou,ENGL-3530,2019
-ENGL,3550,1,Global Studies in Pop Culture,0.22,0.67,0.06,0.0,0.0,0.0,0.0,0.06,spencer tricker,ENGL-3550,2019
-ENGL,3570,1,Film,0.16,0.68,0.05,0.0,0.05,0.0,0.0,0.05,amy monaghan,ENGL-3570,2019
-ENGL,3570,2,Film,0.15,0.7,0.1,0.0,0.05,0.0,0.0,0.0,amy monaghan,ENGL-3570,2019
-ENGL,3570,3,Film,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,john robert smith,ENGL-3570,2019
-ENGL,3570,4,Film,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,ENGL-3570,2019
-ENGL,3860,1,Adolescent Lit,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,megan no macalystre,ENGL-3860,2019
-ENGL,3960,1,Brit Lit Survey I,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,james funk,ENGL-3960,2019
-ENGL,3960,2,Brit Lit Survey I,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,ingrid anna pierce,ENGL-3960,2019
-ENGL,3970,1,Brit Lit Survey II,0.17,0.61,0.17,0.0,0.0,0.0,0.0,0.06,brian mcgrath,ENGL-3970,2019
-ENGL,3980,1,Amer Lit Survey I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,ENGL-3980,2019
-ENGL,3990,1,Amer Lit Survey II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,ENGL-3990,2019
-ENGL,4000,1,The English Language,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,andrew lemons,ENGL-4000,2019
-ENGL,4070,1,Medieval Period,0.8,0.05,0.05,0.05,0.0,0.0,0.0,0.05,andrew lemons,ENGL-4070,2019
-ENGL,4100,1,Drama of English Renaissance,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lucian ghita,ENGL-4100,2019
-ENGL,4110,1,Shakespeare,0.43,0.43,0.0,0.07,0.07,0.0,0.0,0.0,james funk,ENGL-4110,2019
-ENGL,4110,2,Shakespeare,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,james funk,ENGL-4110,2019
-ENGL,4110,3,Shakespeare,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,ENGL-4110,2019
-ENGL,4190,1,Post Col & World Lit,0.73,0.0,0.13,0.0,0.0,0.0,0.0,0.13,angela naimou,ENGL-4190,2019
-ENGL,4210,1,Amer Lit 1800-1899,0.42,0.42,0.11,0.0,0.0,0.0,0.05,0.0,dominic mastroianni,ENGL-4210,2019
-ENGL,4280,1,Contemporary Literature,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,lindsey henley kurz,ENGL-4280,2019
-ENGL,4320,1,Modern Fiction,0.63,0.06,0.25,0.06,0.0,0.0,0.0,0.0,jillian weise,ENGL-4320,2019
-ENGL,4400,1,Literary Theory,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,ENGL-4400,2019
-ENGL,4420,1,Cultural Studies,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,bree laran beal,ENGL-4420,2019
-ENGL,4450,1,Fiction Workshop,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,ENGL-4450,2019
-ENGL,4480,1,Screenwriting Wkshop,0.73,0.2,0.0,0.07,0.0,0.0,0.0,0.0,nicholas chri brown,ENGL-4480,2019
-ENGL,4490,1,Creative Non-Fiction,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,julia brownle koets,ENGL-4490,2019
-ENGL,4500,1,Film Genres,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,john robert smith,ENGL-4500,2019
-ENGL,4510,1,Film Theory and Criticism,0.56,0.22,0.0,0.0,0.22,0.0,0.0,0.0,john robert smith,ENGL-4510,2019
-ENGL,4530,1,Sexuality and the Cinema,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,edward thomas troy,ENGL-4530,2019
-ENGL,4540,1,Sel Top in International Film,0.5,0.25,0.0,0.0,0.0,0.0,0.0,0.25,jamie ann rogers,ENGL-4540,2019
-ENGL,4640,1,Topics in Literature 1700-1899,0.37,0.37,0.11,0.11,0.05,0.0,0.0,0.0,erin marina goss,ENGL-4640,2019
-ENGL,4750,1,Writing for Media,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,ENGL-4750,2019
-ENGL,4830,1,Af Am Lit 1920-Pres,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,tareva lese johnson,ENGL-4830,2019
-ENGL,4850,1,Comp & Lang Teachers,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,ENGL-4850,2019
-ENGL,4910,1,Classical Rhetoric,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,tharon howard,ENGL-4910,2019
-ENGL,4960,4,Senior Seminar,0.67,0.17,0.0,0.0,0.08,0.0,0.0,0.08,kimberly manganelli,ENGL-4960,2019
-ENGR,1020,211,Engineering Discipl & Skills,0.13,0.39,0.16,0.13,0.06,0.0,0.0,0.13,irene marie ferrara,ENGR-1020,2019
-ENGR,1020,211,Engineering Discipl & Skills,0.13,0.39,0.16,0.13,0.06,0.0,0.0,0.13,ashley childers,ENGR-1020,2019
-ENGR,1020,212,Engineering Discipl & Skills,0.13,0.35,0.19,0.06,0.13,0.0,0.0,0.13,ashley childers,ENGR-1020,2019
-ENGR,1020,212,Engineering Discipl & Skills,0.13,0.35,0.19,0.06,0.13,0.0,0.0,0.13,irene marie ferrara,ENGR-1020,2019
-ENGR,1020,213,Engineering Discipl & Skills,0.11,0.32,0.32,0.04,0.04,0.0,0.0,0.18,john minor,ENGR-1020,2019
-ENGR,1020,213,Engineering Discipl & Skills,0.11,0.32,0.32,0.04,0.04,0.0,0.0,0.18,irene marie ferrara,ENGR-1020,2019
-ENGR,1020,214,Engineering Discipl & Skills,0.27,0.2,0.23,0.03,0.07,0.0,0.0,0.2,john minor,ENGR-1020,2019
-ENGR,1020,214,Engineering Discipl & Skills,0.27,0.2,0.23,0.03,0.07,0.0,0.0,0.2,irene marie ferrara,ENGR-1020,2019
-ENGR,1410,123,Programming & Problem Solving,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,matthew kent miller,ENGR-1410,2019
-ENGR,1410,123,Programming & Problem Solving,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,william martin,ENGR-1410,2019
-ENGR,1410,124,Programming & Problem Solving,0.33,0.47,0.19,0.0,0.0,0.0,0.0,0.0,william martin,ENGR-1410,2019
-ENGR,1410,124,Programming & Problem Solving,0.33,0.47,0.19,0.0,0.0,0.0,0.0,0.0,matthew kent miller,ENGR-1410,2019
-ENGR,1410,127,Programming & Problem Solving,0.25,0.5,0.17,0.03,0.0,0.0,0.0,0.06,matthew kent miller,ENGR-1410,2019
-ENGR,1410,127,Programming & Problem Solving,0.25,0.5,0.17,0.03,0.0,0.0,0.0,0.06,william martin,ENGR-1410,2019
-ENGR,1410,324,Programming & Problem Solving,0.35,0.33,0.23,0.05,0.0,0.0,0.0,0.05,mariah magagnotti,ENGR-1410,2019
-ENGR,1410,324,Programming & Problem Solving,0.35,0.33,0.23,0.05,0.0,0.0,0.0,0.05,william martin,ENGR-1410,2019
-ENGR,1410,325,Programming & Problem Solving,0.33,0.44,0.18,0.03,0.0,0.0,0.0,0.03,mariah magagnotti,ENGR-1410,2019
-ENGR,1410,325,Programming & Problem Solving,0.33,0.44,0.18,0.03,0.0,0.0,0.0,0.03,william martin,ENGR-1410,2019
-ENGR,1410,326,Programming & Problem Solving,0.19,0.49,0.14,0.0,0.0,0.0,0.0,0.19,mariah magagnotti,ENGR-1410,2019
-ENGR,1410,326,Programming & Problem Solving,0.19,0.49,0.14,0.0,0.0,0.0,0.0,0.19,william martin,ENGR-1410,2019
-ENGR,1410,621,Programming & Problem Solving,0.19,0.49,0.22,0.03,0.03,0.0,0.0,0.05,william martin,ENGR-1410,2019
-ENGR,1410,621,Programming & Problem Solving,0.19,0.49,0.22,0.03,0.03,0.0,0.0,0.05,john minor,ENGR-1410,2019
-ENGR,1410,622,Programming & Problem Solving,0.28,0.28,0.35,0.0,0.0,0.0,0.0,0.1,john minor,ENGR-1410,2019
-ENGR,1410,622,Programming & Problem Solving,0.28,0.28,0.35,0.0,0.0,0.0,0.0,0.1,william martin,ENGR-1410,2019
-ENGR,1410,623,Programming & Problem Solving,0.41,0.28,0.13,0.03,0.05,0.0,0.0,0.1,john minor,ENGR-1410,2019
-ENGR,1410,623,Programming & Problem Solving,0.41,0.28,0.13,0.03,0.05,0.0,0.0,0.1,william martin,ENGR-1410,2019
-ENGR,1410,624,Programming & Problem Solving,0.18,0.5,0.18,0.08,0.0,0.0,0.0,0.05,william martin,ENGR-1410,2019
-ENGR,1410,624,Programming & Problem Solving,0.18,0.5,0.18,0.08,0.0,0.0,0.0,0.05,michael giebner,ENGR-1410,2019
-ENGR,1410,625,Programming & Problem Solving,0.18,0.37,0.34,0.11,0.0,0.0,0.0,0.0,william martin,ENGR-1410,2019
-ENGR,1410,625,Programming & Problem Solving,0.18,0.37,0.34,0.11,0.0,0.0,0.0,0.0,michael giebner,ENGR-1410,2019
-ENGR,1410,626,Programming & Problem Solving,0.3,0.4,0.13,0.13,0.0,0.0,0.0,0.03,elizabeth stephan,ENGR-1410,2019
-ENGR,1410,626,Programming & Problem Solving,0.3,0.4,0.13,0.13,0.0,0.0,0.0,0.03,william martin,ENGR-1410,2019
-ENGR,1410,627,Programming & Problem Solving,0.35,0.53,0.1,0.0,0.0,0.0,0.0,0.03,jonathan bro harcum,ENGR-1410,2019
-ENGR,1410,627,Programming & Problem Solving,0.35,0.53,0.1,0.0,0.0,0.0,0.0,0.03,william martin,ENGR-1410,2019
-ENGR,1410,721,Programming & Problem Solving,0.19,0.45,0.23,0.06,0.03,0.0,0.0,0.03,william martin,ENGR-1410,2019
-ENGR,1410,721,Programming & Problem Solving,0.19,0.45,0.23,0.06,0.03,0.0,0.0,0.03,john minor,ENGR-1410,2019
-ENGR,1410,722,Programming & Problem Solving,0.5,0.34,0.13,0.0,0.03,0.0,0.0,0.0,elizabeth stephan,ENGR-1410,2019
-ENGR,1410,722,Programming & Problem Solving,0.5,0.34,0.13,0.0,0.03,0.0,0.0,0.0,william martin,ENGR-1410,2019
-ENGR,1410,725,Programming & Problem Solving,0.47,0.25,0.22,0.0,0.03,0.0,0.0,0.03,william martin,ENGR-1410,2019
-ENGR,1410,725,Programming & Problem Solving,0.47,0.25,0.22,0.0,0.03,0.0,0.0,0.03,andrew isaa neptune,ENGR-1410,2019
-ENGR,1410,726,Programming & Problem Solving,0.31,0.38,0.22,0.03,0.0,0.0,0.0,0.06,william martin,ENGR-1410,2019
-ENGR,1410,726,Programming & Problem Solving,0.31,0.38,0.22,0.03,0.0,0.0,0.0,0.06,sarah grigg,ENGR-1410,2019
-ENGR,1410,727,Programming & Problem Solving,0.17,0.57,0.17,0.06,0.0,0.0,0.0,0.03,sarah grigg,ENGR-1410,2019
-ENGR,1410,727,Programming & Problem Solving,0.17,0.57,0.17,0.06,0.0,0.0,0.0,0.03,william martin,ENGR-1410,2019
-ENGR,1410,821,Programming & Problem Solving,0.23,0.58,0.13,0.0,0.03,0.0,0.0,0.03,andrew isaa neptune,ENGR-1410,2019
-ENGR,1410,821,Programming & Problem Solving,0.23,0.58,0.13,0.0,0.03,0.0,0.0,0.03,william martin,ENGR-1410,2019
-ENGR,1410,822,Programming & Problem Solving,0.17,0.5,0.31,0.03,0.0,0.0,0.0,0.0,andrew isaa neptune,ENGR-1410,2019
-ENGR,1410,822,Programming & Problem Solving,0.17,0.5,0.31,0.03,0.0,0.0,0.0,0.0,william martin,ENGR-1410,2019
-ENGR,1410,823,Program & Prob Solving (HON),0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,william martin,ENGR-1410,2019
-ENGR,1410,823,Program & Prob Solving (HON),0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,ENGR-1410,2019
-ENGR,1410,824,Program & Prob Solving (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,ENGR-1410,2019
-ENGR,1410,824,Program & Prob Solving (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william martin,ENGR-1410,2019
-ENGR,1410,825,Programming & Problem Solving,0.21,0.36,0.27,0.06,0.03,0.0,0.0,0.06,jonathan maier,ENGR-1410,2019
-ENGR,1410,825,Programming & Problem Solving,0.21,0.36,0.27,0.06,0.03,0.0,0.0,0.06,william martin,ENGR-1410,2019
-ENGR,1410,826,Programming & Problem Solving,0.29,0.37,0.16,0.03,0.05,0.0,0.0,0.11,william martin,ENGR-1410,2019
-ENGR,1410,826,Programming & Problem Solving,0.29,0.37,0.16,0.03,0.05,0.0,0.0,0.11,jonathan maier,ENGR-1410,2019
-ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.24,0.03,0.0,0.0,0.0,0.0,william martin,ENGR-1410,2019
-ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.24,0.03,0.0,0.0,0.0,0.0,jonathan maier,ENGR-1410,2019
-ENGR,1900,10,CI in Engr I (Robotics),0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,michael benj wooten,ENGR-1900,2019
-ENGR,2080,281,Engr Graphics & Machine Design,0.38,0.44,0.15,0.0,0.0,0.0,0.0,0.04,nighat yasmin,ENGR-2080,2019
-ENGR,2080,281,Engr Graphics & Machine Design,0.38,0.44,0.15,0.0,0.0,0.0,0.0,0.04,samuel coeyman,ENGR-2080,2019
-ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.2,0.07,0.07,0.02,0.0,0.0,0.02,nighat yasmin,ENGR-2080,2019
-ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.2,0.07,0.07,0.02,0.0,0.0,0.02,samuel coeyman,ENGR-2080,2019
-ENGR,2080,284,Engr Graphics & Machine Design,0.62,0.22,0.11,0.04,0.0,0.0,0.0,0.0,nighat yasmin,ENGR-2080,2019
-ENGR,2080,284,Engr Graphics & Machine Design,0.62,0.22,0.11,0.04,0.0,0.0,0.0,0.0,nisha gulhane,ENGR-2080,2019
-ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,natalie pellizzi,ENGR-2080,2019
-ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,nighat yasmin,ENGR-2080,2019
-ENGR,2080,286,Engr Graphics & Machine Design,0.34,0.41,0.11,0.05,0.07,0.0,0.0,0.02,nighat yasmin,ENGR-2080,2019
-ENGR,2080,286,Engr Graphics & Machine Design,0.34,0.41,0.11,0.05,0.07,0.0,0.0,0.02,natalie pellizzi,ENGR-2080,2019
-ENGR,2080,382,Engr Graphics & Machine Design,0.56,0.24,0.09,0.02,0.07,0.0,0.0,0.02,nighat yasmin,ENGR-2080,2019
-ENGR,2080,382,Engr Graphics & Machine Design,0.56,0.24,0.09,0.02,0.07,0.0,0.0,0.02,nisha gulhane,ENGR-2080,2019
-ENGR,2080,682,Engr Graphics & Machine Design,0.59,0.28,0.13,0.0,0.0,0.0,0.0,0.0,kyle walker,ENGR-2080,2019
-ENGR,2080,682,Engr Graphics & Machine Design,0.59,0.28,0.13,0.0,0.0,0.0,0.0,0.0,nighat yasmin,ENGR-2080,2019
-ENGR,2080,684,Engr Graphics & Machine Design,0.6,0.19,0.05,0.02,0.07,0.0,0.0,0.07,nighat yasmin,ENGR-2080,2019
-ENGR,2080,684,Engr Graphics & Machine Design,0.6,0.19,0.05,0.02,0.07,0.0,0.0,0.07,kyle walker,ENGR-2080,2019
-ENGR,2080,882,Engr Graphics & Machine Design,0.6,0.26,0.04,0.04,0.04,0.0,0.0,0.02,nighat yasmin,ENGR-2080,2019
-ENGR,2080,882,Engr Graphics & Machine Design,0.6,0.26,0.04,0.04,0.04,0.0,0.0,0.02,apurva patel,ENGR-2080,2019
-ENGR,2080,884,Engr Graphics & Machine Design,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,nighat yasmin,ENGR-2080,2019
-ENGR,2080,884,Engr Graphics & Machine Design,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,apurva patel,ENGR-2080,2019
-ENGR,2100,101,CAD & Engineering Applications,0.52,0.28,0.04,0.04,0.07,0.0,0.0,0.04,afshin famili,ENGR-2100,2019
-ENGR,2100,101,CAD & Engineering Applications,0.52,0.28,0.04,0.04,0.07,0.0,0.0,0.04,nighat yasmin,ENGR-2100,2019
-ENGR,2100,102,CAD & Engineering Applications,0.44,0.33,0.1,0.08,0.0,0.0,0.0,0.04,nighat yasmin,ENGR-2100,2019
-ENGR,2100,102,CAD & Engineering Applications,0.44,0.33,0.1,0.08,0.0,0.0,0.0,0.04,afshin famili,ENGR-2100,2019
-ENGR,2100,105,CAD & Engineering Applications,0.71,0.19,0.02,0.02,0.02,0.0,0.0,0.02,john minor,ENGR-2100,2019
-ENGR,2100,105,CAD & Engineering Applications,0.71,0.19,0.02,0.02,0.02,0.0,0.0,0.02,nighat yasmin,ENGR-2100,2019
-ENGR,2100,106,CAD & Engineering Applications,0.5,0.35,0.04,0.0,0.02,0.0,0.0,0.08,nighat yasmin,ENGR-2100,2019
-ENGR,2100,106,CAD & Engineering Applications,0.5,0.35,0.04,0.0,0.02,0.0,0.0,0.08,john minor,ENGR-2100,2019
-ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.12,0.08,0.06,0.04,0.0,0.0,0.0,russell barrett,ENR-1020,2019
-ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.12,0.08,0.06,0.04,0.0,0.0,0.0,alan johnson,ENR-1020,2019
-ENR,3020,1,Nat Res Measurements,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,russell barrett,ENR-3020,2019
-ENR,3020,1,Nat Res Measurements,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,lawrence gering,ENR-3020,2019
-ENR,4130,2,Restoration Ecology,0.3,0.4,0.23,0.0,0.0,0.0,0.0,0.07,althea simone hagan,ENR-4130,2019
-ENR,4500,1,Conservation Issues,0.87,0.09,0.0,0.04,0.0,0.0,0.0,0.0,alan johnson,ENR-4500,2019
-ENR,4500,2,Conservation Issues,0.79,0.14,0.03,0.0,0.0,0.0,0.0,0.03,alan johnson,ENR-4500,2019
-ENR,6130,1,Restoration Ecology,0.5,0.21,0.29,0.0,0.0,0.0,0.0,0.0,althea simone hagan,ENR-6130,2019
-ENSP,2000,1,Intro Environ Sci,0.19,0.65,0.09,0.06,0.02,0.0,0.0,0.0,tom owino,ENSP-2000,2019
-ENSP,2000,2,Intro Environ Sci,0.57,0.37,0.0,0.0,0.0,0.0,0.0,0.06,elizabeth carraway,ENSP-2000,2019
-ENSP,2000,3,Intro Environ Sci,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2000,2019
-ENSP,2010,1,Environm Sci for Educ Majors,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,ENSP-2010,2019
-ENSP,4000,1,Studies in Environmental Sci,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,margaret thompson,ENSP-4000,2019
-ENT,2000,1,Six-Legged Science,0.41,0.34,0.15,0.02,0.0,0.0,0.05,0.02,suellen pometto,ENT-2000,2019
-ENT,8700,1,Insect Phys Mol Bio,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,ENT-8700,2019
-ENTR,1010,2,Entrepreneurial Mindset,0.64,0.27,0.05,0.0,0.0,0.0,0.01,0.03,john michael hannon,ENTR-1010,2019
-ENTR,1090,2,How to Start a Startup,0.71,0.07,0.04,0.0,0.0,0.0,0.0,0.18,john michael hannon,ENTR-1090,2019
-ENTR,1090,20,Lemonade Day Pendleton,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david joseph frock,ENTR-1090,2019
-ENTR,2010,1,Sports Entrepreneurship,0.77,0.16,0.05,0.0,0.0,0.0,0.0,0.02,john michael hannon,ENTR-2010,2019
-ESED,8500,1,Spec Top Engineering & Sci Edu,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,cindy lee,ESED-8500,2019
-FCS,2010,1,Introduction to Human Rights,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,matthe hudson-flege,FCS-2010,2019
-FDSC,2140,1,Fd Resources & Soc,0.7,0.23,0.04,0.03,0.0,0.0,0.0,0.0,paul dawson,FDSC-2140,2019
-FDSC,3040,1,Eval Dairy Products,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,john mcgregor,FDSC-3040,2019
-FDSC,3040,1,Eval Dairy Products,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,sara lane cothran,FDSC-3040,2019
-FDSC,4020,1,Food Chemistry II,0.73,0.24,0.02,0.0,0.0,0.0,0.0,0.0,feng chen,FDSC-4020,2019
-FDSC,4030,1,Food Ch & Analysis,0.67,0.27,0.02,0.02,0.0,0.0,0.0,0.02,feng chen,FDSC-4030,2019
-FDSC,4030,1,Food Ch & Analysis,0.67,0.27,0.02,0.02,0.0,0.0,0.0,0.02,paul dawson,FDSC-4030,2019
-FDSC,4080,1,Food Process Eng,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,steven brandon,FDSC-4080,2019
-FDSC,4500,7,Creative Inquiry-Food Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,FDSC-4500,2019
-FDSC,4500,15,Creative Inquiry-Food Science,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vivian haley-zitlin,FDSC-4500,2019
-FDSC,4500,18,Creative Inquiry-Food Science,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,xiuping jiang,FDSC-4500,2019
-FDSC,4500,22,Creative Inquiry-Food Science,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,feng chen,FDSC-4500,2019
-FIN,2010,401,Intro to Personal Finance,0.93,0.01,0.04,0.0,0.01,0.0,0.0,0.0,joshua harris,FIN-2010,2019
-FIN,2010,402,Intro to Personal Finance,0.97,0.01,0.01,0.0,0.0,0.0,0.0,0.0,joshua harris,FIN-2010,2019
-FIN,2010,403,Intro to Personal Finance,0.91,0.01,0.03,0.0,0.03,0.0,0.0,0.01,joshua harris,FIN-2010,2019
-FIN,2010,404,Intro to Personal Finance,0.72,0.16,0.01,0.01,0.06,0.0,0.0,0.03,joshua harris,FIN-2010,2019
-FIN,2010,405,Intro to Personal Finance,0.79,0.15,0.0,0.03,0.0,0.0,0.0,0.03,joshua harris,FIN-2010,2019
-FIN,2010,406,Intro to Personal Finance,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,joshua harris,FIN-2010,2019
-FIN,3040,1,Risk & Insurance,0.2,0.28,0.35,0.08,0.1,0.0,0.0,0.0,kerri mcmillan,FIN-3040,2019
-FIN,3050,1,Investment Analysis,0.17,0.27,0.44,0.05,0.0,0.0,0.0,0.07,kerri mcmillan,FIN-3050,2019
-FIN,3050,2,Investment Analysis,0.26,0.24,0.39,0.05,0.0,0.0,0.0,0.05,kerri mcmillan,FIN-3050,2019
-FIN,3050,3,Investment Analysis,0.18,0.38,0.28,0.05,0.0,0.0,0.0,0.1,kerri mcmillan,FIN-3050,2019
-FIN,3050,4,Investment Analysis,0.17,0.23,0.26,0.11,0.03,0.0,0.0,0.2,john alexander,FIN-3050,2019
-FIN,3060,1,Corporation Finance,0.21,0.3,0.23,0.19,0.02,0.0,0.0,0.04,ramon tolb franklin,FIN-3060,2019
-FIN,3060,2,Corporation Finance,0.21,0.21,0.27,0.19,0.02,0.0,0.0,0.1,ramon tolb franklin,FIN-3060,2019
-FIN,3060,3,Corporation Finance,0.2,0.22,0.24,0.18,0.02,0.0,0.0,0.13,ramon tolb franklin,FIN-3060,2019
-FIN,3060,4,Corporation Finance,0.13,0.2,0.24,0.29,0.04,0.0,0.0,0.09,ramon tolb franklin,FIN-3060,2019
-FIN,3060,9,Corporation Finance,0.12,0.17,0.4,0.24,0.05,0.0,0.0,0.02,charles taylor vick,FIN-3060,2019
-FIN,3060,401,Corporation Finance,0.3,0.25,0.25,0.13,0.03,0.0,0.0,0.04,jonathan godbey,FIN-3060,2019
-FIN,3060,402,Corporation Finance,0.18,0.31,0.32,0.11,0.0,0.0,0.04,0.04,jonathan godbey,FIN-3060,2019
-FIN,3060,601,Corporation Finance,0.06,0.69,0.25,0.0,0.0,0.0,0.0,0.0,jack wolf,FIN-3060,2019
-FIN,3070,1,Prin of Real Estate,0.24,0.42,0.29,0.05,0.0,0.0,0.0,0.0,yannan shen,FIN-3070,2019
-FIN,3070,2,Prin of Real Estate,0.29,0.37,0.24,0.03,0.05,0.0,0.0,0.03,yannan shen,FIN-3070,2019
-FIN,3070,3,Prin of Real Estate,0.24,0.41,0.22,0.11,0.03,0.0,0.0,0.0,thomas springer,FIN-3070,2019
-FIN,3070,4,Prin of Real Estate,0.19,0.19,0.39,0.19,0.03,0.0,0.0,0.0,thomas springer,FIN-3070,2019
-FIN,3080,1,Fin Inst & Mkts,0.21,0.4,0.29,0.07,0.02,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2019
-FIN,3080,2,Fin Inst & Mkts,0.19,0.4,0.33,0.05,0.0,0.0,0.0,0.02,daniel thoma greene,FIN-3080,2019
-FIN,3080,401,Fin Inst & Mkts,0.27,0.51,0.14,0.06,0.02,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2019
-FIN,3080,402,Fin Inst & Mkts,0.12,0.51,0.35,0.02,0.0,0.0,0.0,0.0,daniel thoma greene,FIN-3080,2019
-FIN,3110,2,Financial Management I,0.22,0.32,0.22,0.04,0.01,0.0,0.0,0.18,george bra lockhart,FIN-3110,2019
-FIN,3110,4,Financial Management I,0.22,0.31,0.22,0.06,0.03,0.0,0.0,0.15,george bra lockhart,FIN-3110,2019
-FIN,3110,5,Financial Management I,0.23,0.33,0.26,0.07,0.07,0.0,0.0,0.05,weike xu,FIN-3110,2019
-FIN,3110,102,Financial Management I (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,george bra lockhart,FIN-3110,2019
-FIN,3110,104,Financial Management I (HON),0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,george bra lockhart,FIN-3110,2019
-FIN,3120,1,Financial Management II,0.24,0.4,0.17,0.14,0.0,0.0,0.0,0.05,blerina zykaj,FIN-3120,2019
-FIN,3120,2,Financial Management II,0.28,0.28,0.38,0.03,0.03,0.0,0.0,0.0,blerina zykaj,FIN-3120,2019
-FIN,3120,4,Financial Management II,0.14,0.38,0.31,0.05,0.1,0.0,0.0,0.02,weike xu,FIN-3120,2019
-FIN,3120,5,Financial Management II,0.19,0.35,0.3,0.07,0.05,0.0,0.0,0.05,weike xu,FIN-3120,2019
-FIN,3120,102,Financial Management II (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,FIN-3120,2019
-FIN,3120,401,Financial Management II,0.18,0.27,0.3,0.09,0.07,0.0,0.0,0.09,angela morgan,FIN-3120,2019
-FIN,4020,1,Corporate Valuation,0.16,0.44,0.3,0.07,0.0,0.0,0.0,0.02,angela morgan,FIN-4020,2019
-FIN,4030,1,Spreadsheet Apps in Finance,0.3,0.28,0.23,0.14,0.02,0.0,0.0,0.02,vincent intintoli,FIN-4030,2019
-FIN,4030,2,Spreadsheet Apps in Finance,0.33,0.27,0.33,0.03,0.03,0.0,0.0,0.0,vincent intintoli,FIN-4030,2019
-FIN,4040,1,Financial Modeling,0.14,0.57,0.1,0.14,0.0,0.0,0.0,0.05,jack wolf,FIN-4040,2019
-FIN,4050,1,Portfolio Management & Theory,0.09,0.27,0.42,0.12,0.0,0.0,0.0,0.09,john alexander,FIN-4050,2019
-FIN,4080,1,Mgt of Fin Inst,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2019
-FIN,4080,2,Mgt of Fin Inst,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,FIN-4080,2019
-FIN,4090,1,Professional Financial Plan,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,FIN-4090,2019
-FIN,4110,1,Int Fin Mgt,0.24,0.48,0.21,0.0,0.06,0.0,0.0,0.0,luke asher devault,FIN-4110,2019
-FIN,4110,2,Int Fin Mgt,0.39,0.36,0.18,0.04,0.0,0.0,0.0,0.04,luke asher devault,FIN-4110,2019
-FIN,4150,1,Real Estate Investmt,0.2,0.45,0.3,0.0,0.0,0.0,0.0,0.05,thomas springer,FIN-4150,2019
-FIN,4160,2,Real Estate Val,0.24,0.62,0.14,0.0,0.0,0.0,0.0,0.0,bryan blackwood,FIN-4160,2019
-FIN,4980,2,CI in Finance: CFA,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jack wolf,FIN-4980,2019
-FIN,4980,9,Creative Inquiry in Finance,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,yannan shen,FIN-4980,2019
-FNR,4700,19,Soil Judging Project,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,elena mikhailova,FNR-4700,2019
-FNR,4700,23,Estuarine Fish Ecology I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,troy mason farmer,FNR-4700,2019
-FNR,4700,24,Climate Change/Carolina Fish I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,troy mason farmer,FNR-4700,2019
-FNR,4700,35,Aquaponics,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,lance edwar beecher,FNR-4700,2019
-FNR,4700,37,Growing Food In a Box Techniqs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,FNR-4700,2019
-FNR,4700,44,Alligator Ecology,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,catherine jachowski,FNR-4700,2019
-FNR,4700,46,Tiger Awareness,0.88,0.0,0.0,0.13,0.0,0.0,0.0,0.0,shari lyn rodriguez,FNR-4700,2019
-FNR,4990,3,Natural Resources Seminar,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,susan talley guynn,FNR-4990,2019
-FOR,1010,1,Intro to Forestry,0.7,0.05,0.16,0.03,0.03,0.0,0.0,0.03,lawrence gering,FOR-1010,2019
-FOR,2060,1,Forestry Ecology,0.24,0.31,0.2,0.11,0.0,0.0,0.09,0.05,donald hagan,FOR-2060,2019
-FOR,3080,1,Remote Sensing in Forestry,0.44,0.33,0.19,0.04,0.0,0.0,0.0,0.0,lawrence gering,FOR-3080,2019
-FOR,4080,1,Wood and Paper Products,0.62,0.26,0.1,0.0,0.0,0.0,0.0,0.02,patricia layton,FOR-4080,2019
-FOR,4150,2,Forest Wildlife Managment,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,FOR-4150,2019
-FOR,4180,1,Forest Resource Valuation,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,thomas straka,FOR-4180,2019
-FOR,4340,1,GIS for Natural Resources,0.4,0.48,0.05,0.0,0.0,0.0,0.0,0.08,robert frit baldwin,FOR-4340,2019
-FOR,4650,1,Silviculture,0.26,0.37,0.19,0.15,0.04,0.0,0.0,0.0,gaofeng wang,FOR-4650,2019
-FR,1010,1,Elementary French,0.36,0.27,0.23,0.05,0.09,0.0,0.0,0.0,anne salces  nedeo,FR-1010,2019
-FR,1010,2,Elementary French,0.43,0.36,0.0,0.07,0.14,0.0,0.0,0.0,anne salces  nedeo,FR-1010,2019
-FR,1020,1,Elementary French,0.52,0.22,0.09,0.0,0.0,0.0,0.04,0.13,amy lyn grif sawyer,FR-1020,2019
-FR,1020,2,Elementary French,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-1020,2019
-FR,2010,2,Intermediate French,0.73,0.23,0.0,0.05,0.0,0.0,0.0,0.0,amy lyn grif sawyer,FR-2010,2019
-FR,2010,3,Intermediate French,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,amy lyn grif sawyer,FR-2010,2019
-FR,2020,1,Intermediate French,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,FR-2020,2019
-FR,2020,3,Intermediate French,0.38,0.38,0.13,0.08,0.0,0.0,0.0,0.04,paulin de tholozany,FR-2020,2019
-FR,2020,4,Intermediate French,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,FR-2020,2019
-FR,3050,1,Int Fr Con & Comp I,0.55,0.3,0.1,0.0,0.0,0.0,0.0,0.05,joseph mai,FR-3050,2019
-FR,3160,1,Fr for Intl Trade,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,eric touya,FR-3160,2019
-FR,4100,1,Francophone Literature,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,eric touya,FR-4100,2019
-GC,1010,1,Orientation to G C,0.24,0.59,0.06,0.0,0.06,0.0,0.0,0.06,kern cox,GC-1010,2019
-GC,1020,1,Computer Art & CAD Foundations,0.27,0.38,0.16,0.03,0.08,0.0,0.0,0.08,carol jones,GC-1020,2019
-GC,1030,1,G C I for Pkgsc,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,john jacobs,GC-1030,2019
-GC,1040,1,Graphic Communications I,0.76,0.19,0.02,0.0,0.02,0.0,0.0,0.02,michelle suki  fox,GC-1040,2019
-GC,1990,4,CI in GC I Ph Ch,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nona woolbright,GC-1990,2019
-GC,2070,1,Graphic Communications II,0.57,0.38,0.04,0.0,0.0,0.0,0.0,0.0,charles tabor weiss,GC-2070,2019
-GC,2990,2,CI in GC II-VDP,0.8,0.0,0.0,0.0,0.2,0.0,0.0,0.0,eric weisenmiller,GC-2990,2019
-GC,2990,4,Cr Inquiry in GC II Ph Ch,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,nona woolbright,GC-2990,2019
-GC,3400,1,Digital Imaging and eMedia,0.31,0.56,0.1,0.0,0.0,0.0,0.0,0.03,erica black walker,GC-3400,2019
-GC,3460,1,Ink and Substrates,0.33,0.33,0.26,0.0,0.05,0.0,0.0,0.03,liam henry 'hara,GC-3460,2019
-GC,3720,1,Digital Analytics Brand Comm,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,alicia ni littleton,GC-3720,2019
-GC,3720,1,Digital Analytics Brand Comm,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,katelyn hildebrand,GC-3720,2019
-GC,3730,1,Media Management in Brand Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jaclyn kathl driggs,GC-3730,2019
-GC,3730,1,Media Management in Brand Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,GC-3730,2019
-GC,3740,1,Brand Comm Media Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,GC-3740,2019
-GC,3740,1,Brand Comm Media Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,roger beasley,GC-3740,2019
-GC,4060,1,Package and Specialty Printing,0.17,0.71,0.06,0.0,0.03,0.0,0.0,0.03,kern cox,GC-4060,2019
-GC,4400,1,Commercial Printing,0.29,0.45,0.16,0.0,0.06,0.0,0.0,0.03,eric weisenmiller,GC-4400,2019
-GC,4440,1,Current Dev/Trends in Gr Comm,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,GC-4440,2019
-GC,4480,1,Plan & Cont Printing Functions,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,nona woolbright,GC-4480,2019
-GC,4800,1,Senior Seminar in GC,0.81,0.17,0.02,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,GC-4800,2019
-GC,4900,8,UX & Web Design,0.94,0.0,0.0,0.0,0.06,0.0,0.0,0.0,erica black walker,GC-4900,2019
-GC,4900,230,G C Selected Topics-Sales,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,john leininger,GC-4900,2019
-GEN,3000,1,Fundamental Genetics,0.26,0.29,0.24,0.13,0.05,0.0,0.0,0.03,kate leanne wi tsai,GEN-3000,2019
-GEN,3000,2,Fundamental Genetics,0.36,0.32,0.16,0.06,0.03,0.0,0.0,0.06,kate leanne wi tsai,GEN-3000,2019
-GEN,3020,1,Molecular & General Genetics,0.36,0.32,0.23,0.02,0.02,0.0,0.0,0.05,lukasz kozubowski,GEN-3020,2019
-GEN,3040,1,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,GEN-3040,2019
-GEN,3040,1,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,GEN-3040,2019
-GEN,3040,2,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,GEN-3040,2019
-GEN,3040,2,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,GEN-3040,2019
-GEN,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,GEN-3040,2019
-GEN,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,GEN-3040,2019
-GEN,3040,4,Molecular Biology Laboratory,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,geoffrey ford,GEN-3040,2019
-GEN,3040,4,Molecular Biology Laboratory,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,scott michae tanner,GEN-3040,2019
-GEN,4200,1,Molecular Genetics & Gene Reg,0.27,0.4,0.29,0.03,0.0,0.0,0.0,0.0,miriam krist konkel,GEN-4200,2019
-GEN,4210,2,Mol Gen Gene Reg Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,GEN-4210,2019
-GEN,4400,1,Bioinformatics,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,liangjiang wang,GEN-4400,2019
-GEN,4700,1,Human Genetics,0.25,0.38,0.28,0.06,0.0,0.0,0.0,0.04,leigh anne clark,GEN-4700,2019
-GEN,4900,3,Biomedical Informatics,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,frank alexan feltus,GEN-4900,2019
-GEN,4910,36,CI:DNA Repair (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,GEN-4910,2019
-GEN,4930,3,Senior Seminar,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,haiying liang,GEN-4930,2019
-GEN,6700,1,Human Genetics,0.17,0.17,0.17,0.0,0.0,0.0,0.0,0.5,leigh anne clark,GEN-6700,2019
-GEN,8050,1,Issues in Research,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william marcotte,GEN-8050,2019
-GEOG,1010,1,Intro to Geography,0.4,0.47,0.07,0.03,0.03,0.0,0.0,0.0,christa smith,GEOG-1010,2019
-GEOG,1030,1,World Regional Geography,0.3,0.44,0.15,0.04,0.03,0.0,0.0,0.04,william churc terry,GEOG-1030,2019
-GEOL,1010,1,Physical Geology,0.27,0.29,0.25,0.07,0.07,0.0,0.0,0.05,alan coulson,GEOL-1010,2019
-GEOL,1010,2,Physical Geology,0.34,0.33,0.17,0.04,0.04,0.0,0.0,0.09,alan coulson,GEOL-1010,2019
-GEOL,1010,3,Physical Geology,0.43,0.38,0.11,0.05,0.04,0.0,0.0,0.0,mary katheri fidler,GEOL-1010,2019
-GEOL,1030,1,Physical Geol Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,2,Physical Geol Lab,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,3,Physical Geol Lab,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,alan coulson,GEOL-1030,2019
-GEOL,1030,4,Physical Geol Lab,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2019
-GEOL,1030,5,Physical Geol Lab,0.78,0.13,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2019
-GEOL,1030,6,Physical Geol Lab,0.43,0.3,0.17,0.0,0.0,0.0,0.0,0.09,alan coulson,GEOL-1030,2019
-GEOL,1030,7,Physical Geol Lab,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2019
-GEOL,1030,8,Physical Geol Lab,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,GEOL-1030,2019
-GEOL,1030,10,Physical Geol Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,11,Physical Geol Lab,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,12,Physical Geol Lab,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,14,Physical Geol Lab,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-1030,2019
-GEOL,1030,15,Physical Geol Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,alan coulson,GEOL-1030,2019
-GEOL,1120,1,Earth Resources,0.29,0.35,0.19,0.13,0.01,0.0,0.0,0.03,mary katheri fidler,GEOL-1120,2019
-GEOL,1140,1,Earth Resources Lab,0.64,0.2,0.05,0.05,0.02,0.0,0.0,0.04,mary katheri fidler,GEOL-1140,2019
-GEOL,2020,1,Earth History,0.25,0.45,0.25,0.05,0.0,0.0,0.0,0.0,alan coulson,GEOL-2020,2019
-GEOL,3160,1,Igneous & Metamorphic Petrolog,0.27,0.6,0.13,0.0,0.0,0.0,0.0,0.0,mary katheri fidler,GEOL-3160,2019
-GEOL,4050,1,Surficial Geology,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,alexander th pullen,GEOL-4050,2019
-GEOL,4090,1,Envir & Exploration Geophysics,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,scott dewolf,GEOL-4090,2019
-GEOL,4110,8,Res Probs - Community Outreach,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john robert wagner,GEOL-4110,2019
-GEOL,4210,1,GIS in Geology,0.72,0.16,0.04,0.0,0.04,0.0,0.0,0.04,scott brame,GEOL-4210,2019
-GEOL,4920,1,Resrch Synthesis II,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,GEOL-4920,2019
-GEOL,8170,1,Applied Process Simulation,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,lawrence murdoch,GEOL-8170,2019
-GER,1010,1,Elementary German,0.54,0.23,0.08,0.0,0.0,0.0,0.0,0.15, lee ferrell,GER-1010,2019
-GER,1010,2,Elementary German,0.38,0.31,0.13,0.06,0.0,0.0,0.0,0.13,oswald harris king,GER-1010,2019
-GER,1020,1,Elementary German,0.54,0.15,0.23,0.0,0.0,0.0,0.0,0.08,oswald harris king,GER-1020,2019
-GER,2020,1,Intermediate German,0.24,0.16,0.36,0.16,0.08,0.0,0.0,0.0,johannes schmidt,GER-2020,2019
-GER,3600,1,Ger Lit to 1832,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,GER-3600,2019
-HCG,9890,400,Pharmacogenomics,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,christopher farrell,HCG-9890,2019
-HCG,9890,400,Pharmacogenomics,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,linda ward,HCG-9890,2019
-HIST,1010,1,History of the United States,0.31,0.45,0.14,0.03,0.0,0.0,0.0,0.07,james brad jeffries,HIST-1010,2019
-HIST,1010,2,History of the United States,0.8,0.1,0.0,0.07,0.0,0.0,0.0,0.03,joshua cas catalano,HIST-1010,2019
-HIST,1240,1,Environmental History Survey,0.09,0.46,0.26,0.08,0.05,0.0,0.0,0.06,james brad jeffries,HIST-1240,2019
-HIST,1720,1,The West and the World I,0.53,0.22,0.06,0.03,0.06,0.0,0.0,0.09,kathryn langenfeld,HIST-1720,2019
-HIST,1730,1,The West and the World II,0.19,0.44,0.28,0.03,0.06,0.0,0.0,0.02,michael meng,HIST-1730,2019
-HIST,1730,2,The West and the World II,0.33,0.34,0.18,0.08,0.04,0.0,0.0,0.04,james burns,HIST-1730,2019
-HIST,1730,3,The West and the World II,0.29,0.36,0.32,0.0,0.0,0.0,0.0,0.04, alan grubb,HIST-1730,2019
-HIST,2990,1,Historian's Craft,0.5,0.2,0.1,0.0,0.1,0.0,0.0,0.1,rachel anne moore,HIST-2990,2019
-HIST,2990,2,Historian's Craft,0.59,0.06,0.06,0.0,0.24,0.0,0.0,0.06,michael silvestri,HIST-2990,2019
-HIST,3000,1,History of Colonial America,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,lee brady wilson,HIST-3000,2019
-HIST,3100,1,History of Religion in the US,0.4,0.33,0.07,0.07,0.0,0.0,0.0,0.13,elizabeth jemison,HIST-3100,2019
-HIST,3110,1,African American Hist to 1877,0.27,0.55,0.05,0.0,0.09,0.0,0.0,0.05,abel bartley,HIST-3110,2019
-HIST,3170,1,Hist of NativeAm Rel & Culture,0.15,0.38,0.31,0.08,0.08,0.0,0.0,0.0,james brad jeffries,HIST-3170,2019
-HIST,3220,1,History of Technology,0.39,0.43,0.0,0.04,0.07,0.0,0.0,0.07,pamela mack,HIST-3220,2019
-HIST,3260,1,Hist Am Transport,0.62,0.21,0.1,0.0,0.0,0.0,0.0,0.07, roger grant,HIST-3260,2019
-HIST,3290,1,US Legal History Since 1890,0.29,0.58,0.04,0.0,0.0,0.0,0.0,0.08,maribel morey,HIST-3290,2019
-HIST,3290,2,US Legal History Since 1890,0.3,0.4,0.1,0.0,0.0,0.0,0.0,0.2,maribel morey,HIST-3290,2019
-HIST,3300,1,Hist of Mod China,0.21,0.39,0.18,0.04,0.04,0.0,0.0,0.14,edwin moise,HIST-3300,2019
-HIST,3400,1,Latin America I,0.64,0.29,0.04,0.0,0.0,0.0,0.0,0.04,rachel anne moore,HIST-3400,2019
-HIST,3510,1,Ancient Near East,0.31,0.38,0.25,0.0,0.0,0.0,0.0,0.06,steven grosby,HIST-3510,2019
-HIST,3550,1,Roman World,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,kathryn langenfeld,HIST-3550,2019
-HIST,3610,1,History of Britain to 1688,0.45,0.41,0.1,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,HIST-3610,2019
-HIST,3670,1,Modern Ireland,0.56,0.3,0.07,0.0,0.0,0.0,0.0,0.07,michael silvestri,HIST-3670,2019
-HIST,3890,1,Ben Robertson,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2, alan grubb,HIST-3890,2019
-HIST,3890,2,History of Clemson House,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0, alan grubb,HIST-3890,2019
-HIST,3900,1,Modern Military History,0.15,0.42,0.31,0.0,0.0,0.0,0.0,0.12,edwin moise,HIST-3900,2019
-HIST,3980,1,American Military History,0.37,0.4,0.17,0.03,0.03,0.0,0.0,0.0,john andrew,HIST-3980,2019
-HIST,4380,1,Studies African History,0.67,0.0,0.17,0.0,0.17,0.0,0.0,0.0,stephanie hassell,HIST-4380,2019
-HIST,4380,1,Studies African History,0.67,0.0,0.17,0.0,0.17,0.0,0.0,0.0,james burns,HIST-4380,2019
-HIST,4700,1,Medieval Christianity,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,HIST-4700,2019
-HIST,4700,2,History of Florence,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,thomas kuehn,HIST-4700,2019
-HIST,4710,1,History and Food,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1, alan grubb,HIST-4710,2019
-HIST,4900,1,History of Disney Theme Parks,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,HIST-4900,2019
-HIST,4900,2,Family and Kinship,0.18,0.36,0.36,0.0,0.0,0.0,0.0,0.09,thomas kuehn,HIST-4900,2019
-HIST,4930,1,AfricanAm Soc & Intellectual H,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,abel bartley,HIST-4930,2019
-HIST,8810,1,Historiography,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,HIST-8810,2019
-HLTH,2020,2,Introduction to Public Health,0.67,0.13,0.17,0.04,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2020,2019
-HLTH,2020,400,Introduction to Public Health,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2020,2019
-HLTH,2020,402,Introduction to Public Health,0.42,0.26,0.26,0.0,0.0,0.0,0.0,0.05,ralph stewart welsh,HLTH-2020,2019
-HLTH,2030,1,Health Care Sys,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2019
-HLTH,2030,2,Health Care Sys,0.64,0.24,0.04,0.08,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2030,2019
-HLTH,2030,3,Health Care Sys,0.82,0.15,0.0,0.0,0.03,0.0,0.0,0.0,lee alden crandall,HLTH-2030,2019
-HLTH,2030,400,Health Care Sys,0.35,0.45,0.15,0.05,0.0,0.0,0.0,0.0,tanya lee staton,HLTH-2030,2019
-HLTH,2400,1,Deter of Hlth Behav,0.52,0.31,0.17,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2019
-HLTH,2400,2,Deter of Hlth Behav,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,HLTH-2400,2019
-HLTH,2400,400,Deter of Hlth Behav,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-2400,2019
-HLTH,2500,1,Health and Fitness,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,HLTH-2500,2019
-HLTH,2600,1,Medical Terminology & Comm,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,HLTH-2600,2019
-HLTH,2600,2,Medical Terminology & Comm,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,karen edwards,HLTH-2600,2019
-HLTH,2980,1,Human Health and Disease,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2980,2019
-HLTH,2980,2,Human Health and Disease,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,becky ann tugman,HLTH-2980,2019
-HLTH,2980,3,Human Health and Disease,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-2980,2019
-HLTH,3030,1,Public Health Comm,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,debra mitch charles,HLTH-3030,2019
-HLTH,3800,1,Epidemiology,0.43,0.43,0.09,0.0,0.0,0.0,0.0,0.06,deborah alma falta,HLTH-3800,2019
-HLTH,3980,1,Health Appraisal Skills,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2019
-HLTH,3980,2,Health Appraisal Skills,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-3980,2019
-HLTH,4020,1,Princ Hlth Fitness,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,karen kemper,HLTH-4020,2019
-HLTH,4110,1,Hlth At-Risk Children & Fam,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,HLTH-4110,2019
-HLTH,4190,1,Health Sci Internship Prep Sem,0.63,0.33,0.05,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4190,2019
-HLTH,4200,1,Hlth Science Intern,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,kathleen meyer,HLTH-4200,2019
-HLTH,4310,1,Public & Environ Hlt,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,HLTH-4310,2019
-HLTH,4600,1,Health Info Systems,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,ronald gimbel,HLTH-4600,2019
-HLTH,4700,1,Global Health,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,micky rogers ward,HLTH-4700,2019
-HLTH,4780,1,Health Policy Ethics and Law,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,hugh donald spitler,HLTH-4780,2019
-HLTH,4790,1,Fin Mgmt & Hlth Budg,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,khoa dang truong,HLTH-4790,2019
-HLTH,4800,1,Comm Hlth Promotion,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,HLTH-4800,2019
-HLTH,4900,1,Res Eval St Pub Hlth,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,HLTH-4900,2019
-HLTH,4900,2,Res Eval St Pub Hlth,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-4900,2019
-HLTH,4900,3,Res Eval St Pub Hlth,0.48,0.43,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,HLTH-4900,2019
-HLTH,4980,1,Improving Pop Hlth,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,HLTH-4980,2019
-HLTH,4990,5,Aspire to Be Well CI,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,chloe caroli greene,HLTH-4990,2019
-HLTH,8310,1,Quantitative Analy in Hlth I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,lior mordec rennert,HLTH-8310,2019
-HON,2020,1,Motivation and Learning,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tyler watts,HON-2020,2019
-HON,2030,2,Putin's World,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,olga anatol volkova,HON-2030,2019
-HON,2060,1,Intro to Nanotechnology,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,HON-2060,2019
-HON,2060,1,Intro to Nanotechnology,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,christophe kitchens,HON-2060,2019
-HON,2060,2,Why We Eat What We Eat,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,HON-2060,2019
-HON,2060,3,Great Problems in Math,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,neil calkin,HON-2060,2019
-HON,2090,5,Crisis & Opportunity in Europe,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,HON-2090,2019
-HON,2200,2,Europe in the Age of Dictators,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,HON-2200,2019
-HON,2200,3,Global Policy Process,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey allen fine,HON-2200,2019
-HON,2210,1,Building Imaginary Worlds,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,april susanne pelt,HON-2210,2019
-HON,2210,3,Thinking About Love,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,dominic mastroianni,HON-2210,2019
-HON,2210,4,Movies as Time Travel,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,HON-2210,2019
-HON,2210,5,"Migrants, Exiles, Refugees",0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,lucian ghita,HON-2210,2019
-HORT,2020,1,Adobe Digital Design,0.81,0.06,0.03,0.0,0.03,0.0,0.0,0.06,janice ann lay,HORT-2020,2019
-HORT,2110,1,Growing Spring Plnts,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,james emerson faust,HORT-2110,2019
-HORT,4040,1,Plant Propagation,0.12,0.32,0.37,0.15,0.05,0.0,0.0,0.0,jeffrey adelberg,HORT-4040,2019
-HORT,4050,1,Plant Propagation Techniq Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,HORT-4050,2019
-HORT,4080,4,CI: Hands on Water for Ag,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,sarah white,HORT-4080,2019
-HORT,4080,4,CI: Hands on Water for Ag,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,lauren marie chance,HORT-4080,2019
-HORT,4080,7,Sustain Landscpe Garden Design,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,ellen anita vincent,HORT-4080,2019
-HORT,4090,1,Senior Capstone Course,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,HORT-4090,2019
-HORT,4270,1,Urban Tree Care,0.0,0.3,0.2,0.1,0.0,0.0,0.0,0.4,robert polomski,HORT-4270,2019
-HORT,4330,1,Weed Management,0.17,0.46,0.38,0.0,0.0,0.0,0.0,0.0,ted whitwell,HORT-4330,2019
-HORT,4560,1,Vegetable Crops,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,HORT-4560,2019
-HORT,6040,1,Plant Propagation,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,HORT-6040,2019
-HRD,8250,400,Org Perf Improvement,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,angela danie carter,HRD-8250,2019
-HRD,8470,400,Instru System Design,0.79,0.07,0.0,0.0,0.03,0.0,0.0,0.1,angela danie carter,HRD-8470,2019
-HRD,8490,400,Eval of T&D/Hrd Prog,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,angela danie carter,HRD-8490,2019
-HRD,8800,400,Research Concepts,0.75,0.13,0.0,0.0,0.04,0.0,0.0,0.08,cynthia sims,HRD-8800,2019
-IE,2100,1,Des Analysis Wrk Sys,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,xiaoxia li,IE-2100,2019
-IE,3010,1,Systems Design I,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,amro nofa khasawneh,IE-3010,2019
-IE,3140,1,Seminar in Industrial Engr,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,scott jenning mason,IE-3140,2019
-IE,3600,1,Industrial Apps of Prob/Stat I,0.34,0.29,0.19,0.13,0.02,0.0,0.0,0.04,robert james riggs,IE-3600,2019
-IE,3610,1,Industrial App of Prob/Stat II,0.48,0.25,0.18,0.03,0.02,0.0,0.0,0.05,katherina jurewicz,IE-3610,2019
-IE,3800,1,Deterministic Operations Rsrch,0.28,0.47,0.17,0.04,0.0,0.0,0.03,0.0,sandra dun eksioglu,IE-3800,2019
-IE,3810,1,Probabilistic Operations Rsrch,0.2,0.5,0.23,0.04,0.0,0.0,0.0,0.04,amin khademi,IE-3810,2019
-IE,3840,1,Engr Econ Analysis,0.24,0.22,0.28,0.1,0.0,0.0,0.04,0.1,brian melloy,IE-3840,2019
-IE,3860,1,Production Planning & Control,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,xiaoxia li,IE-3860,2019
-IE,4040,15,Creative Inquiry Research,0.0,0.0,0.0,0.0,0.0,0.83,0.0,0.17,kevin taaffe,IE-4040,2019
-IE,4400,1,Decision Support Sys,0.36,0.48,0.03,0.0,0.09,0.0,0.0,0.03,mary elizabeth kurz,IE-4400,2019
-IE,4570,1,Transp/Logistic Engr,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,sandra dun eksioglu,IE-4570,2019
-IE,4610,1,Quality Engineering,0.29,0.27,0.33,0.07,0.0,0.0,0.0,0.03,byung rae cho,IE-4610,2019
-IE,4620,1,Six Sigma Quality,0.45,0.43,0.09,0.01,0.0,0.0,0.0,0.01,robert james riggs,IE-4620,2019
-IE,4650,1,Facilities Planning & Design,0.49,0.31,0.08,0.05,0.0,0.0,0.01,0.06,brian melloy,IE-4650,2019
-IE,4670,1,System Design II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,walter lawre garvin,IE-4670,2019
-IE,4670,1,System Design II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,IE-4670,2019
-IE,4670,2,System Design II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,walter lawre garvin,IE-4670,2019
-IE,4670,2,System Design II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,IE-4670,2019
-IE,4820,1,Systems Modeling,0.26,0.37,0.21,0.1,0.03,0.0,0.0,0.02,tugce isik,IE-4820,2019
-IE,4860,1,Scheduling,0.27,0.09,0.27,0.09,0.0,0.0,0.0,0.27,scott jenning mason,IE-4860,2019
-IE,4880,1,Human Factors Eng,0.54,0.39,0.02,0.02,0.0,0.0,0.0,0.04,laura miche stanley,IE-4880,2019
-IE,4910,1,Applied Bus. Princples for Eng,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,jeffery messer,IE-4910,2019
-IE,6620,1,Six Sigma Quality,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,IE-6620,2019
-IE,6860,1,Scheduling,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-6860,2019
-IE,6910,1,Supply Chain/Logistics Model,0.61,0.36,0.0,0.0,0.0,0.0,0.0,0.04,william ferrell,IE-6910,2019
-IE,8050,1,Found Qual Engr,0.18,0.73,0.08,0.0,0.0,0.0,0.0,0.02,byung rae cho,IE-8050,2019
-IE,8520,1,Prescriptive Analytics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,IE-8520,2019
-IE,8540,1,SC & Logistics Modeling I,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,IE-8540,2019
-IE,8580,1,Case Study Supply Chn & Logist,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,scott jenning mason,IE-8580,2019
-INNO,4990,990,CEDC - Risk in Puerto Rico,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david vaughn,INNO-4990,2019
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,lisa marie robinson,INT-1510,2019
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,troy nunamaker,INT-1510,2019
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,troy nunamaker,INT-1530,2019
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,caren kelley-hall,INT-1530,2019
-IPM,4010,1,Principles of I P M,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,carmen blubaugh,IPM-4010,2019
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,james dougl bennett,IS-1010,2019
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,joshua leona hudson,IS-1010,2019
-IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,james dougl bennett,IS-1010,2019
-IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,joshua leona hudson,IS-1010,2019
-IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,meredith fan wilson,IS-1010,2019
-IS,2100,615,Sel Top International Studies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,meredith fan wilson,IS-2100,2019
-IS,2100,615,Sel Top International Studies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,joshua leona hudson,IS-2100,2019
-IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,IS-2100,2019
-IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joshua leona hudson,IS-2100,2019
-IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,meredith fan wilson,IS-2100,2019
-ITAL,1010,1,Elementary Italian,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,ITAL-1010,2019
-ITAL,1020,1,Elementary Italian,0.45,0.27,0.18,0.0,0.0,0.0,0.0,0.09,julia schmidt,ITAL-1020,2019
-ITAL,1020,2,Elementary Italian,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,ITAL-1020,2019
-ITAL,1020,3,Elementary Italian,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-1020,2019
-ITAL,2020,1,Intermediate Italian,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,julia schmidt,ITAL-2020,2019
-JAPN,1010,1,Elementary Japanese,0.4,0.2,0.2,0.0,0.0,0.0,0.0,0.2,saori suto,JAPN-1010,2019
-JAPN,1010,2,Elementary Japanese,0.41,0.29,0.18,0.06,0.0,0.0,0.0,0.06,saori suto,JAPN-1010,2019
-JAPN,1020,2,Elementary Japanese,0.45,0.14,0.32,0.05,0.0,0.0,0.0,0.05,satomi saito,JAPN-1020,2019
-JAPN,2020,1,Intermed Japanese,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,saori suto,JAPN-2020,2019
-JAPN,3060,1,Japanese Conversation & Comp,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,kumiko saito,JAPN-3060,2019
-JAPN,4170,2,Japanese Culture and Society,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,jae allegr takeuchi,JAPN-4170,2019
-JUST,2880,1,The Criminal Justice System,0.41,0.31,0.19,0.02,0.05,0.0,0.0,0.02,margaret tina britz,JUST-2880,2019
-JUST,2890,1,Criminology,0.39,0.31,0.2,0.06,0.0,0.0,0.0,0.04,matthew jo costello,JUST-2890,2019
-JUST,4280,1,Criminal Law,0.18,0.55,0.23,0.05,0.0,0.0,0.0,0.0,rhys hester,JUST-4280,2019
-JUST,4910,1,Policing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,shelagh dorn,JUST-4910,2019
-JUST,4930,1,Corrections,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,catherine el burton,JUST-4930,2019
-JUST,4940,1,Organized Crime,0.33,0.33,0.19,0.08,0.06,0.0,0.0,0.0,margaret tina britz,JUST-4940,2019
-JUST,4970,1,Criminal Justice Capstone,0.7,0.22,0.0,0.0,0.04,0.0,0.0,0.04,catherine el burton,JUST-4970,2019
-JUST,4990,1,Criminal Courts,0.28,0.32,0.36,0.0,0.0,0.0,0.0,0.04,rhys hester,JUST-4990,2019
-JUST,4990,2,Ethics in Criminal Justice,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,lance christ miller,JUST-4990,2019
-LANG,2540,1,Introduction to World Cinemas,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,raquel anido,LANG-2540,2019
-LANG,2540,2,Introduction to World Cinemas,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,LANG-2540,2019
-LARC,1160,1,History of Landscape Arch,0.35,0.38,0.17,0.07,0.01,0.0,0.0,0.01,hala fouad nassar,LARC-1160,2019
-LARC,1160,2,History of Landscape Arch,0.27,0.47,0.13,0.13,0.0,0.0,0.0,0.0,hala fouad nassar,LARC-1160,2019
-LARC,1520,1,Basic Design II,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,maria debye counts,LARC-1520,2019
-LARC,2550,1,Community Design Studio,0.74,0.16,0.05,0.0,0.0,0.0,0.05,0.0,matthew neal powers,LARC-2550,2019
-LARC,3620,1,Design Implementation II,0.67,0.1,0.14,0.0,0.1,0.0,0.0,0.0,robert hewitt,LARC-3620,2019
-LARC,4280,1,Computer-Aided Design,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,jueminsi wu,LARC-4280,2019
-LARC,4280,1,Computer-Aided Design,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,xiaotong liu,LARC-4280,2019
-LARC,4550,1,Landscape Arch Exit Project,0.45,0.45,0.0,0.09,0.0,0.0,0.0,0.0,mary padua,LARC-4550,2019
-LARC,4720,1,South Carolina's Landscapes,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,LARC-4720,2019
-LARC,4810,1,Professional Practice,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,christopher counts,LARC-4810,2019
-LARC,4900,1,Urban Issues in Landscape Arch,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,LARC-4900,2019
-LARC,4900,400,Arch History of Place,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,jason matthew white,LARC-4900,2019
-LARC,4970,8,Planting Design,0.74,0.13,0.04,0.0,0.04,0.0,0.0,0.04,matthew neal powers,LARC-4970,2019
-LARC,8520,1,Advanced Urban Design,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,robert hewitt,LARC-8520,2019
-LAW,3220,1,Legal Env of Bus,0.27,0.33,0.36,0.0,0.0,0.0,0.0,0.04,kenneth toussaint,LAW-3220,2019
-LAW,3220,2,Legal Env of Bus,0.16,0.53,0.29,0.0,0.0,0.0,0.0,0.02,kenneth toussaint,LAW-3220,2019
-LAW,3220,3,Legal Env of Bus,0.16,0.41,0.36,0.02,0.0,0.0,0.0,0.05,kenneth toussaint,LAW-3220,2019
-LAW,3220,4,Legal Env of Bus,0.31,0.49,0.13,0.04,0.0,0.0,0.0,0.02,edward ray claggett,LAW-3220,2019
-LAW,3220,5,Legal Env of Bus,0.11,0.62,0.22,0.04,0.0,0.0,0.0,0.0,judson jahn,LAW-3220,2019
-LAW,3220,6,Legal Env of Bus,0.24,0.51,0.24,0.0,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2019
-LAW,3220,7,Legal Env of Bus,0.24,0.47,0.27,0.02,0.0,0.0,0.0,0.0,judson jahn,LAW-3220,2019
-LAW,3220,8,Legal Env of Bus,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-3220,2019
-LAW,3220,9,Legal Env of Bus,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,christopher edwards,LAW-3220,2019
-LAW,3220,10,Legal Env of Bus,0.27,0.47,0.2,0.04,0.0,0.0,0.0,0.02,john hine,LAW-3220,2019
-LAW,3220,11,Legal Env of Bus,0.27,0.36,0.3,0.0,0.05,0.0,0.0,0.02,john hine,LAW-3220,2019
-LAW,3220,401,Legal Env of Bus,0.45,0.31,0.17,0.03,0.0,0.0,0.0,0.03,virgini ward-vaughn,LAW-3220,2019
-LAW,3220,402,Legal Env of Bus,0.32,0.37,0.12,0.03,0.03,0.0,0.0,0.12,virgini ward-vaughn,LAW-3220,2019
-LAW,3220,403,Legal Env of Bus,0.25,0.41,0.21,0.02,0.07,0.0,0.0,0.04,virgini ward-vaughn,LAW-3220,2019
-LAW,3220,404,Legal Env of Bus,0.25,0.4,0.21,0.07,0.0,0.0,0.02,0.05,virgini ward-vaughn,LAW-3220,2019
-LAW,3220,601,Legal Env of Bus,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,edward ray claggett,LAW-3220,2019
-LAW,3330,1,Real Estate Law,0.15,0.27,0.37,0.17,0.05,0.0,0.0,0.0,kenneth toussaint,LAW-3330,2019
-LAW,4200,1,Int Business Law,0.2,0.55,0.2,0.0,0.0,0.0,0.0,0.05,frances edwards,LAW-4200,2019
-LAW,4990,1,Selected Topics - Cyber Law,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,frances edwards,LAW-4990,2019
-LAW,8480,1,Law Real Estate Prof,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,michael le brearley,LAW-8480,2019
-LAW,8480,1,Law Real Estate Prof,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,james ivey warren,LAW-8480,2019
-LS,1000,2,Fitness Leadership,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,jenny lynn rodgers,LS-1000,2019
-LS,1000,4,Introduction to Barre,0.74,0.11,0.05,0.0,0.0,0.0,0.0,0.11,diane moreno,LS-1000,2019
-LS,1000,5,Introduction to Barre,0.71,0.0,0.06,0.06,0.0,0.0,0.0,0.18,diane moreno,LS-1000,2019
-LS,1000,9,Intro to Salsa Dance,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,malik lewis baxter,LS-1000,2019
-LS,1000,19,Therapeutic Yoga,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,LS-1000,2019
-LS,1000,21,Therapeutic Yoga,0.74,0.11,0.0,0.0,0.0,0.0,0.0,0.16,ranjanbala dil amin,LS-1000,2019
-LS,1000,23,Therapeutic Yoga,0.71,0.08,0.08,0.04,0.0,0.0,0.0,0.08,renee warren gahan,LS-1000,2019
-LS,1130,1,Wood Carving,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,louwanda jolley,LS-1130,2019
-LS,1410,2,Top Rope Climbing,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,thomas caldwell,LS-1410,2019
-LS,1560,13,Riflery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,herbert strickland,LS-1560,2019
-LS,1560,19,Riflery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,dominic cirocco,LS-1560,2019
-LS,1580,1,Archery,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,LS-1580,2019
-LS,1580,3,Archery,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,LS-1580,2019
-LS,1580,5,Archery,0.83,0.08,0.0,0.08,0.0,0.0,0.0,0.0,herbert strickland,LS-1580,2019
-LS,1650,1,Inland Kayak Touring,0.82,0.0,0.09,0.0,0.09,0.0,0.0,0.0,caitlin miche henry,LS-1650,2019
-LS,1650,5,Inland Kayak Touring,0.7,0.0,0.2,0.0,0.0,0.0,0.0,0.1,merry han armstrong,LS-1650,2019
-LS,1960,2,Intro to Billiards,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,broadus fleming,LS-1960,2019
-LS,2200,2,Shag,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,LS-2200,2019
-LS,2270,1,Intro to Swing Dance,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,paul hoke,LS-2270,2019
-LS,2270,4,Intro to Swing Dance,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,paul hoke,LS-2270,2019
-LS,2320,1,Core Training,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,diane moreno,LS-2320,2019
-LS,2320,3,Core Training,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,LS-2320,2019
-LS,2320,5,Core Training,0.83,0.08,0.0,0.0,0.04,0.0,0.0,0.04,diane moreno,LS-2320,2019
-LS,2350,1,Basic Yoga,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,LS-2350,2019
-LS,2350,2,Basic Yoga,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,kayla lee wardlaw,LS-2350,2019
-LS,2350,3,Basic Yoga,0.87,0.0,0.04,0.0,0.0,0.0,0.0,0.09,silica eliza larkin,LS-2350,2019
-LS,2350,5,Basic Yoga,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2350,2019
-LS,2360,1,Power/Ashtanga Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,silica eliza larkin,LS-2360,2019
-LS,2360,2,Power/Ashtanga Yoga,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,silica eliza larkin,LS-2360,2019
-LS,2380,4,Vinyasa Flow Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,LS-2380,2019
-LS,2420,1,Meditation and Relax,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,LS-2420,2019
-LS,2420,3,Meditation and Relax,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,LS-2420,2019
-LS,2420,4,Meditation and Relax,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,LS-2420,2019
-LS,2420,10,Meditation and Relax,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,LS-2420,2019
-LS,2420,11,Meditation and Relax,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,LS-2420,2019
-LS,2420,12,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,LS-2420,2019
-LS,2420,13,Meditation and Relax,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,LS-2420,2019
-LS,2450,2,Pilates,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,melanie ivey job,LS-2450,2019
-LS,2450,4,Pilates,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,diane moreno,LS-2450,2019
-LS,2450,5,Pilates,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,diane moreno,LS-2450,2019
-LS,2450,8,Pilates,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,melanie ivey job,LS-2450,2019
-LS,2510,1,Running & Jogging,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,corey dou brookover,LS-2510,2019
-MATH,1010,1,Essen Math for Informed Soc,0.5,0.25,0.13,0.13,0.0,0.0,0.0,0.0,marilyn reba,MATH-1010,2019
-MATH,1010,2,Essen Math for Informed Soc,0.36,0.25,0.22,0.06,0.0,0.0,0.0,0.11,marilyn reba,MATH-1010,2019
-MATH,1010,3,Essen Math for Informed Soc,0.47,0.35,0.09,0.09,0.0,0.0,0.0,0.0,seth selken,MATH-1010,2019
-MATH,1010,4,Essen Math for Informed Soc,0.52,0.24,0.09,0.03,0.06,0.0,0.0,0.06,bryce pruitt,MATH-1010,2019
-MATH,1020,1,Business Calculus I,0.18,0.24,0.28,0.13,0.08,0.0,0.0,0.08,randy davidson,MATH-1020,2019
-MATH,1020,2,Business Calculus I,0.23,0.31,0.23,0.07,0.05,0.0,0.0,0.1,randy davidson,MATH-1020,2019
-MATH,1020,3,Business Calculus I,0.18,0.35,0.12,0.18,0.12,0.0,0.0,0.06,zachary david espe,MATH-1020,2019
-MATH,1020,4,Business Calculus I,0.12,0.27,0.24,0.21,0.12,0.0,0.0,0.03,andrew bellucco,MATH-1020,2019
-MATH,1020,5,Business Calculus I,0.15,0.29,0.29,0.18,0.06,0.0,0.0,0.03,thowhida akther,MATH-1020,2019
-MATH,1020,6,Business Calculus I,0.18,0.41,0.21,0.1,0.05,0.0,0.0,0.05,nathaniel nemire,MATH-1020,2019
-MATH,1020,7,Business Calculus I,0.28,0.18,0.25,0.08,0.18,0.0,0.0,0.05,thowhida akther,MATH-1020,2019
-MATH,1020,8,Business Calculus I,0.17,0.17,0.32,0.22,0.0,0.0,0.05,0.07,thowhida akther,MATH-1020,2019
-MATH,1020,9,Business Calculus I,0.2,0.32,0.32,0.05,0.04,0.0,0.0,0.07,marion hanna,MATH-1020,2019
-MATH,1020,10,Business Calculus I,0.22,0.24,0.17,0.12,0.15,0.0,0.0,0.1,shanshan jia,MATH-1020,2019
-MATH,1020,11,Business Calculus I,0.35,0.33,0.25,0.03,0.05,0.0,0.0,0.0,cameron arnold,MATH-1020,2019
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.85,0.0,0.15,nathan fontes,MATH-1040,2019
-MATH,1060,1,Calculus of One Variable I,0.04,0.14,0.39,0.14,0.21,0.0,0.0,0.09,judith cottingham,MATH-1060,2019
-MATH,1060,2,Calculus of One Variable I,0.08,0.26,0.34,0.13,0.18,0.0,0.0,0.0,catherine ma kenyon,MATH-1060,2019
-MATH,1060,3,Calculus of One Variable I,0.06,0.17,0.39,0.11,0.19,0.0,0.0,0.08,steven taylo edalgo,MATH-1060,2019
-MATH,1060,4,Calculus of One Variable I,0.09,0.3,0.33,0.09,0.09,0.0,0.0,0.09,marilyn reba,MATH-1060,2019
-MATH,1060,5,Calculus of One Variable I,0.14,0.14,0.25,0.11,0.14,0.0,0.0,0.21,luther duncan,MATH-1060,2019
-MATH,1070,1,Differen and Integral Calculus,0.4,0.4,0.15,0.0,0.0,0.0,0.0,0.05,donna simms,MATH-1070,2019
-MATH,1070,2,Differen and Integral Calculus,0.18,0.36,0.36,0.05,0.03,0.0,0.0,0.03,donna simms,MATH-1070,2019
-MATH,1070,3,Differen and Integral Calculus,0.18,0.38,0.26,0.09,0.06,0.0,0.0,0.03,stephen peele,MATH-1070,2019
-MATH,1070,4,Differen and Integral Calculus,0.19,0.24,0.38,0.14,0.0,0.0,0.0,0.05,peter westerbaan,MATH-1070,2019
-MATH,1070,5,Differen and Integral Calculus,0.13,0.47,0.25,0.03,0.13,0.0,0.0,0.0,scott scruggs,MATH-1070,2019
-MATH,1070,6,Differen and Integral Calculus,0.07,0.48,0.43,0.02,0.0,0.0,0.0,0.0,stephen peele,MATH-1070,2019
-MATH,1080,1,Calculus of One Variable II,0.38,0.35,0.2,0.0,0.0,0.0,0.0,0.08,stephen peele,MATH-1080,2019
-MATH,1080,2,Calculus of One Variable II,0.43,0.23,0.2,0.09,0.03,0.0,0.0,0.03,blake anth splitter,MATH-1080,2019
-MATH,1080,3,Calculus of One Variable II,0.18,0.23,0.36,0.05,0.14,0.0,0.0,0.05,timothy fra parrott,MATH-1080,2019
-MATH,1080,4,Calculus of One Variable II,0.18,0.24,0.24,0.05,0.08,0.0,0.0,0.21,timothy fra parrott,MATH-1080,2019
-MATH,1080,5,Calculus of One Variable II,0.36,0.28,0.26,0.0,0.05,0.0,0.0,0.05,hugh geller,MATH-1080,2019
-MATH,1080,6,Calculus of One Variable II,0.13,0.37,0.3,0.05,0.0,0.0,0.09,0.06,timothy ch teitloff,MATH-1080,2019
-MATH,1080,7,Calculus of One Variable II,0.14,0.3,0.28,0.02,0.09,0.0,0.0,0.18,timothy ch teitloff,MATH-1080,2019
-MATH,1080,100,Calc of One Variable II (HON),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,timothy fra parrott,MATH-1080,2019
-MATH,1080,201,Calculus of One Variable II,0.12,0.12,0.35,0.15,0.03,0.0,0.0,0.24,timothy fra parrott,MATH-1080,2019
-MATH,1080,202,Calculus of One Variable II,0.4,0.42,0.12,0.02,0.02,0.0,0.0,0.02,james edwar gossell,MATH-1080,2019
-MATH,1080,203,Calculus of One Variable II,0.25,0.39,0.16,0.0,0.07,0.0,0.0,0.14,andrew walton green,MATH-1080,2019
-MATH,1080,204,Calculus of One Variable II,0.1,0.46,0.34,0.0,0.0,0.0,0.0,0.1,sofya alekseeva,MATH-1080,2019
-MATH,1080,205,Calculus of One Variable II,0.15,0.23,0.38,0.0,0.0,0.0,0.0,0.25,sofya alekseeva,MATH-1080,2019
-MATH,1080,206,Calculus of One Variable II,0.13,0.38,0.23,0.05,0.03,0.0,0.0,0.2,sofya alekseeva,MATH-1080,2019
-MATH,1160,1,Contemp Math for Elem Teach II,0.52,0.3,0.18,0.0,0.0,0.0,0.0,0.0,allison ke stoddard,MATH-1160,2019
-MATH,1160,2,Contemp Math for Elem Teach II,0.57,0.37,0.04,0.0,0.0,0.0,0.0,0.02,allison ke stoddard,MATH-1160,2019
-MATH,2060,1,Calculus of Several Variables,0.09,0.06,0.09,0.15,0.29,0.0,0.0,0.32,terri johnson,MATH-2060,2019
-MATH,2060,2,Calculus of Several Variables,0.03,0.13,0.23,0.2,0.1,0.0,0.0,0.3,terri johnson,MATH-2060,2019
-MATH,2060,3,Calculus of Several Variables,0.24,0.15,0.24,0.09,0.12,0.0,0.0,0.18,terri johnson,MATH-2060,2019
-MATH,2060,4,Calculus of Several Variables,0.03,0.2,0.27,0.13,0.1,0.0,0.0,0.27,julie lassiter,MATH-2060,2019
-MATH,2060,5,Calculus of Several Variables,0.0,0.18,0.24,0.09,0.3,0.0,0.0,0.18,julie lassiter,MATH-2060,2019
-MATH,2060,6,Calculus of Several Variables,0.26,0.34,0.16,0.08,0.13,0.0,0.0,0.03,sanwar ahmad,MATH-2060,2019
-MATH,2060,7,Calculus of Several Variables,0.32,0.32,0.19,0.08,0.08,0.0,0.0,0.0,allen anderso guest,MATH-2060,2019
-MATH,2060,8,Calculus of Several Variables,0.23,0.29,0.19,0.1,0.13,0.0,0.0,0.06,allen anderso guest,MATH-2060,2019
-MATH,2060,9,Calculus of Several Variables,0.24,0.35,0.29,0.03,0.06,0.0,0.0,0.03,allen anderso guest,MATH-2060,2019
-MATH,2060,201,Calculus of Several Variables,0.52,0.39,0.06,0.0,0.0,0.0,0.0,0.03,camille zerfas,MATH-2060,2019
-MATH,2070,1,Business Calculus II,0.45,0.21,0.21,0.05,0.0,0.0,0.0,0.08,jennifer mari hanna,MATH-2070,2019
-MATH,2070,2,Business Calculus II,0.32,0.34,0.16,0.13,0.0,0.0,0.0,0.05,jennifer mari hanna,MATH-2070,2019
-MATH,2070,3,Business Calculus II,0.45,0.24,0.18,0.03,0.05,0.0,0.0,0.05,xiaoyuan liu,MATH-2070,2019
-MATH,2070,4,Business Calculus II,0.22,0.3,0.28,0.11,0.02,0.0,0.0,0.06,jennifer ray newton,MATH-2070,2019
-MATH,2070,5,Business Calculus II,0.38,0.33,0.18,0.1,0.0,0.0,0.0,0.0,jennifer mari hanna,MATH-2070,2019
-MATH,2070,6,Business Calculus II,0.38,0.44,0.13,0.05,0.0,0.0,0.0,0.0,jennifer mari hanna,MATH-2070,2019
-MATH,2070,7,Business Calculus II,0.21,0.46,0.26,0.05,0.0,0.0,0.0,0.03,kayla doris javier,MATH-2070,2019
-MATH,2070,8,Business Calculus II,0.31,0.19,0.28,0.22,0.0,0.0,0.0,0.0,travis alvarez,MATH-2070,2019
-MATH,2070,9,Business Calculus II,0.26,0.32,0.18,0.13,0.0,0.0,0.03,0.08,molly adam honecker,MATH-2070,2019
-MATH,2070,10,Business Calculus II,0.14,0.33,0.33,0.08,0.08,0.0,0.0,0.03,ebenezer eduafo,MATH-2070,2019
-MATH,2070,11,Business Calculus II,0.32,0.32,0.29,0.05,0.0,0.0,0.0,0.03,aaron moose,MATH-2070,2019
-MATH,2070,12,Business Calculus II,0.31,0.36,0.18,0.08,0.0,0.0,0.05,0.03,anna caro bachstein,MATH-2070,2019
-MATH,2070,13,Business Calculus II,0.4,0.29,0.15,0.07,0.02,0.0,0.0,0.06,jennifer ray newton,MATH-2070,2019
-MATH,2070,14,Business Calculus II,0.39,0.42,0.14,0.03,0.0,0.0,0.0,0.03,jennifer van dyken,MATH-2070,2019
-MATH,2070,15,Business Calculus II,0.29,0.52,0.1,0.0,0.1,0.0,0.0,0.0,tony thanh nguyen,MATH-2070,2019
-MATH,2080,1,Intro to Ordin Diff Equations,0.19,0.27,0.32,0.07,0.08,0.0,0.0,0.07,pye phyo aung,MATH-2080,2019
-MATH,2080,2,Intro to Ordin Diff Equations,0.2,0.39,0.32,0.06,0.01,0.0,0.0,0.02,pye phyo aung,MATH-2080,2019
-MATH,2080,3,Intro to Ordin Diff Equations,0.35,0.47,0.13,0.01,0.0,0.0,0.01,0.03,oleg yordanov,MATH-2080,2019
-MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.5,0.23,0.03,0.01,0.0,0.0,0.01,oleg yordanov,MATH-2080,2019
-MATH,2080,5,Intro to Ordin Diff Equations,0.28,0.35,0.24,0.06,0.03,0.0,0.0,0.04,jeong rock yoon,MATH-2080,2019
-MATH,2080,6,Intro to Ordin Diff Equations,0.36,0.28,0.25,0.05,0.02,0.0,0.0,0.04,irina viktorova,MATH-2080,2019
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.54,0.41,0.05,0.0,0.0,0.0,0.0,0.0,matthew macauley,MATH-2080,2019
-MATH,2160,1,Geometry for Elem Sch Teachers,0.79,0.08,0.0,0.04,0.0,0.0,0.0,0.08,nicole alai sinwell,MATH-2160,2019
-MATH,2190,1,Introduction to Cryptography,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,felice manganiello,MATH-2190,2019
-MATH,3020,1,Stat for Science & Engineering,0.25,0.48,0.15,0.0,0.03,0.0,0.0,0.1,xiaoqian sun,MATH-3020,2019
-MATH,3020,2,Stat for Science & Engineering,0.78,0.15,0.08,0.0,0.0,0.0,0.0,0.0,jason alexande kurz,MATH-3020,2019
-MATH,3020,3,Stat for Science & Engineering,0.68,0.23,0.03,0.03,0.0,0.0,0.0,0.05,haotian feng,MATH-3020,2019
-MATH,3020,4,Stat for Science & Engineering,0.35,0.45,0.08,0.0,0.0,0.0,0.0,0.13,todd fenstermacher,MATH-3020,2019
-MATH,3020,5,Stat for Science & Engineering,0.36,0.38,0.08,0.08,0.0,0.0,0.0,0.1, kamronnaher,MATH-3020,2019
-MATH,3020,6,Stat for Science & Engineering,0.73,0.12,0.15,0.0,0.0,0.0,0.0,0.0,jayasekara merenchig,MATH-3020,2019
-MATH,3020,7,Stat for Science & Engineering,0.49,0.32,0.15,0.02,0.0,0.0,0.0,0.02,ellen hepfe breazel,MATH-3020,2019
-MATH,3020,8,Stat for Science & Engineering,0.51,0.32,0.02,0.05,0.0,0.0,0.0,0.1,rui gong,MATH-3020,2019
-MATH,3110,1,Linear Algebra,0.15,0.44,0.26,0.09,0.0,0.0,0.0,0.06,michael adam burr,MATH-3110,2019
-MATH,3110,2,Linear Algebra,0.28,0.25,0.31,0.11,0.0,0.0,0.03,0.03,michael adam burr,MATH-3110,2019
-MATH,3110,4,Linear Algebra,0.29,0.29,0.15,0.24,0.03,0.0,0.0,0.0,mishko mitkovski,MATH-3110,2019
-MATH,3110,5,Linear Algebra,0.46,0.31,0.13,0.03,0.03,0.0,0.0,0.04,nant ramiharimanana,MATH-3110,2019
-MATH,3110,6,Linear Algebra,0.33,0.3,0.11,0.05,0.0,0.0,0.07,0.14,nant ramiharimanana,MATH-3110,2019
-MATH,3110,8,Linear Algebra,0.37,0.26,0.29,0.05,0.03,0.0,0.0,0.0,hui xue,MATH-3110,2019
-MATH,3110,200,Linear Algebra,0.25,0.25,0.31,0.13,0.0,0.0,0.0,0.06,svetlan poznanovikj,MATH-3110,2019
-MATH,3190,1,Introduction to Proof,0.62,0.14,0.14,0.05,0.03,0.0,0.0,0.03,beth novick,MATH-3190,2019
-MATH,3190,2,Introduction to Proof,0.62,0.22,0.11,0.0,0.03,0.0,0.0,0.03,beth novick,MATH-3190,2019
-MATH,3600,1,Intermediate Math Computing,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,mark cawood,MATH-3600,2019
-MATH,3600,2,Intermediate Math Computing,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mark cawood,MATH-3600,2019
-MATH,3650,1,Numerical Mthds for Engineers,0.54,0.33,0.08,0.03,0.03,0.0,0.0,0.0,fei xue,MATH-3650,2019
-MATH,3650,2,Numerical Mthds for Engineers,0.28,0.28,0.2,0.03,0.0,0.0,0.0,0.23,alistair bentley,MATH-3650,2019
-MATH,3650,3,Numerical Mthds for Engineers,0.38,0.28,0.2,0.0,0.13,0.0,0.0,0.03,alistair bentley,MATH-3650,2019
-MATH,3650,4,Numerical Mthds for Engineers,0.31,0.36,0.05,0.1,0.05,0.0,0.0,0.13,alistair bentley,MATH-3650,2019
-MATH,4000,1,Theory of Probability,0.22,0.34,0.24,0.07,0.02,0.0,0.0,0.1,brian fralix,MATH-4000,2019
-MATH,4030,1,Intro to Statistical Theory,0.71,0.07,0.07,0.0,0.0,0.0,0.0,0.14,qiong zhang,MATH-4030,2019
-MATH,4070,1,Regress & Time-Series Analysis,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,robert lund,MATH-4070,2019
-MATH,4100,1,Number Theory,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,hui xue,MATH-4100,2019
-MATH,4120,1,Algebra I,0.24,0.38,0.17,0.0,0.1,0.0,0.0,0.1,james ba coykendall,MATH-4120,2019
-MATH,4190,1,Discrete Math Structures I,0.67,0.28,0.05,0.0,0.0,0.0,0.0,0.0,beth novick,MATH-4190,2019
-MATH,4190,2,Discrete Math Structures I,0.43,0.39,0.11,0.04,0.0,0.0,0.0,0.04,matthew macauley,MATH-4190,2019
-MATH,4310,1,Theory of Interest,0.35,0.35,0.2,0.1,0.0,0.0,0.0,0.0, erwin walker,MATH-4310,2019
-MATH,4320,1,Actuarial Science Seminar II,0.53,0.13,0.27,0.0,0.0,0.0,0.0,0.07, erwin walker,MATH-4320,2019
-MATH,4340,1,Adv Engineering Mathematics,0.2,0.29,0.17,0.17,0.09,0.0,0.0,0.09,hyesuk lee,MATH-4340,2019
-MATH,4340,2,Adv Engineering Mathematics,0.18,0.15,0.36,0.06,0.15,0.0,0.0,0.09,vincent ervin,MATH-4340,2019
-MATH,4400,1,Linear Programming,0.49,0.31,0.09,0.03,0.03,0.0,0.0,0.06,yuyuan ouyang,MATH-4400,2019
-MATH,4530,1,Advanced Calculus I,0.08,0.25,0.33,0.17,0.17,0.0,0.0,0.0,james peterson,MATH-4530,2019
-MATH,4540,1,Advanced Calculus II,0.46,0.33,0.13,0.04,0.0,0.0,0.0,0.04,james peterson,MATH-4540,2019
-MATH,4990,1,Creative Inq-Math Sciences,0.5,0.17,0.17,0.0,0.17,0.0,0.0,0.0,ellen hepfe breazel,MATH-4990,2019
-MATH,6000,1,Theory of Probability,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,MATH-6000,2019
-MATH,6340,1,Adv Engineering Mathematics,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,vincent ervin,MATH-6340,2019
-MATH,8030,1,Stochastic Processes,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,xin liu,MATH-8030,2019
-MATH,8040,1,Statistical Inference,0.55,0.41,0.0,0.0,0.0,0.0,0.0,0.05,colin gallagher,MATH-8040,2019
-MATH,8050,1,Data Analysis,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,xiaoqian sun,MATH-8050,2019
-MATH,8100,1,Mathematical Programming,0.27,0.36,0.27,0.0,0.09,0.0,0.0,0.0,margaret mar wiecek,MATH-8100,2019
-MATH,8110,1,Nonlinear Programming,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,boshi yang,MATH-8110,2019
-MATH,8130,1,Advanced Linear Programming,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,matthew saltzman,MATH-8130,2019
-MATH,8210,1,Linear Analysis,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,martin joha schmoll,MATH-8210,2019
-MATH,8220,1,Measure and Integration,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,benjamin jaye,MATH-8220,2019
-MATH,8500,1,Computational Algebraic Geom,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,MATH-8500,2019
-MATH,8530,1,Matrix Analysis,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,MATH-8530,2019
-MATH,8570,1,Cryptography,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,xuhong gao,MATH-8570,2019
-MATH,8600,1,Intro to Scientific Computing,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,leo rebholz,MATH-8600,2019
-MATH,8660,1,Finite Element Method,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,qingshan chen,MATH-8660,2019
-MBA,8030,1,Stat Analy of Bus Op,0.33,0.39,0.17,0.0,0.0,0.0,0.0,0.11,magda gabriela sava,MBA-8030,2019
-MBA,8060,1,Operations Mgt,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MBA-8060,2019
-MBA,8060,20,Operations Mgt,0.32,0.32,0.35,0.0,0.0,0.0,0.0,0.0, sridharan,MBA-8060,2019
-MBA,8070,1,Financial Management,0.48,0.26,0.22,0.0,0.0,0.0,0.0,0.04,melvin stith,MBA-8070,2019
-MBA,8070,2,Financial Management,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,melvin stith,MBA-8070,2019
-MBA,8090,1,Org Beh & Hum Res Mg,0.55,0.41,0.0,0.0,0.0,0.0,0.0,0.05,thomas jo zagenczyk,MBA-8090,2019
-MBA,8090,2,Org Beh & Hum Res Mg,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,MBA-8090,2019
-MBA,8170,21,Bus Forecasting,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,MBA-8170,2019
-MBA,8190,1,Intro to Acc and Fin,0.41,0.5,0.0,0.0,0.0,0.0,0.0,0.09,jeffrey mcmillan,MBA-8190,2019
-MBA,8190,1,Intro to Acc and Fin,0.41,0.5,0.0,0.0,0.0,0.0,0.0,0.09,george bra lockhart,MBA-8190,2019
-MBA,8290,3,Marketing Foundation,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,gary hunter,MBA-8290,2019
-MBA,8330,1,Real Estate Investmt,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,MBA-8330,2019
-MBA,8370,1,Legal Environ of Bus,0.3,0.59,0.07,0.0,0.0,0.0,0.0,0.04,judson jahn,MBA-8370,2019
-MBA,8370,3,Legal Environ of Bus,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,judson jahn,MBA-8370,2019
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,prashant prabhu,MBA-8400,2019
-MBA,8430,10,Entrepreneurial Accounting,0.67,0.26,0.07,0.0,0.0,0.0,0.0,0.0,gregory patr mcphee,MBA-8430,2019
-MBA,8440,10,Entrepreneurial Law,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,judson jahn,MBA-8440,2019
-MBA,8470,1,New Venture Creation,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,joseph renat gibson,MBA-8470,2019
-MBA,8510,11,Bus Operations & Logistics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,george kenne morgan,MBA-8510,2019
-MBA,8540,1,Managerial Accounting,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,MBA-8540,2019
-MBA,8540,2,Managerial Accounting,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,MBA-8540,2019
-MBA,8540,3,Managerial Accounting,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,MBA-8540,2019
-MBA,8590,1,Mgr Decision Model,0.52,0.41,0.04,0.0,0.0,0.0,0.0,0.04,magda gabriela sava,MBA-8590,2019
-MBA,8590,2,Mgr Decision Model,0.25,0.38,0.19,0.0,0.13,0.0,0.0,0.06,sara elizabet yoder,MBA-8590,2019
-MBA,8600,2,Advanced Marketing Strategy,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph renat gibson,MBA-8600,2019
-MBA,8610,1,Information Systems,0.68,0.3,0.0,0.0,0.0,0.0,0.0,0.02,william kettinger,MBA-8610,2019
-MBA,8610,2,Information Systems,0.68,0.24,0.05,0.0,0.0,0.0,0.0,0.03,william kettinger,MBA-8610,2019
-MBA,8620,1,Managerial Economics,0.68,0.25,0.0,0.0,0.0,0.0,0.0,0.07,ronald earl gregory,MBA-8620,2019
-MBA,8620,2,Managerial Economics,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,MBA-8620,2019
-MBA,8700,1,Strategic Management,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8700,2019
-MBA,8700,2,Strategic Management,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,thomas robert uva,MBA-8700,2019
-MBA,8720,1,Entrepr Finance,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8720,2019
-MBA,8720,2,Entrepr Finance,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,MBA-8720,2019
-MBA,8750,1,Enterprise Develpmnt,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,MBA-8750,2019
-MBA,8800,1,MBA Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,gail depriest,MBA-8800,2019
-MBA,8800,2,MBA Seminar,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,jamie lyn patterson,MBA-8800,2019
-MBA,8990,1,Advanced Leadership,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,gail depriest,MBA-8990,2019
-MBA,8990,3,Service Innovation,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,aleda marie roth,MBA-8990,2019
-MBA,8990,5,International Investment Strgy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,MBA-8990,2019
-MBA,8990,20,Analytics & Application,0.45,0.52,0.03,0.0,0.0,0.0,0.0,0.0,heshan sun,MBA-8990,2019
-ME,2000,1,Sophomore Seminar,0.62,0.25,0.06,0.01,0.0,0.0,0.0,0.06,todd schweisinger,ME-2000,2019
-ME,2010,1,Statics & Dynamics,0.01,0.1,0.33,0.04,0.0,0.0,0.15,0.36,gang liu,ME-2010,2019
-ME,2010,2,Statics & Dynamics,0.03,0.23,0.27,0.1,0.04,0.0,0.0,0.32,paul joseph,ME-2010,2019
-ME,2030,1,Founda Th/Fl Syst,0.24,0.49,0.23,0.03,0.01,0.0,0.0,0.0,sandip dutta,ME-2030,2019
-ME,2030,2,Founda Th/Fl Syst,0.17,0.27,0.47,0.07,0.0,0.0,0.0,0.03,john saylor,ME-2030,2019
-ME,2030,3,Founda Th/Fl Syst,0.24,0.3,0.23,0.15,0.04,0.0,0.0,0.04,xiangchun xuan,ME-2030,2019
-ME,2030,4,Founda Th/Fl Syst,0.33,0.21,0.22,0.1,0.05,0.0,0.0,0.09,jay ochterbeck,ME-2030,2019
-ME,2040,1,Mechanics of Materials,0.3,0.41,0.29,0.0,0.0,0.0,0.0,0.0,gang li,ME-2040,2019
-ME,2040,2,Mechanics of Materials,0.28,0.47,0.22,0.02,0.0,0.0,0.0,0.02,garrett pataky,ME-2040,2019
-ME,2040,3,Mechanics of Materials,0.21,0.49,0.28,0.03,0.0,0.0,0.0,0.0,fadi abdeljawad,ME-2040,2019
-ME,2220,1,Mechanical Engineering Lab I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,ME-2220,2019
-ME,2220,2,Mechanical Engineering Lab I,0.13,0.81,0.06,0.0,0.0,0.0,0.0,0.0,rachel anderson,ME-2220,2019
-ME,2220,3,Mechanical Engineering Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,ME-2220,2019
-ME,2220,4,Mechanical Engineering Lab I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,ME-2220,2019
-ME,2220,5,Mechanical Engineering Lab I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,rachel anderson,ME-2220,2019
-ME,2220,6,Mechanical Engineering Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,ME-2220,2019
-ME,2220,7,Mechanical Engineering Lab I,0.38,0.56,0.0,0.0,0.0,0.0,0.0,0.06,rachel anderson,ME-2220,2019
-ME,2220,8,Mechanical Engineering Lab I,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.13,rachel anderson,ME-2220,2019
-ME,2220,10,Mechanical Engineering Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,rachel anderson,ME-2220,2019
-ME,2220,11,Mechanical Engineering Lab I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,ME-2220,2019
-ME,2220,13,Mechanical Engineering Lab I,0.25,0.5,0.13,0.0,0.06,0.0,0.0,0.06,rachel anderson,ME-2220,2019
-ME,2220,14,Mechanical Engineering Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,rachel anderson,ME-2220,2019
-ME,3030,1,Thermodynamics,0.64,0.18,0.1,0.0,0.04,0.0,0.0,0.04,pooya niksiar,ME-3030,2019
-ME,3030,2,Thermodynamics,0.23,0.32,0.3,0.04,0.07,0.0,0.0,0.05,richard miller,ME-3030,2019
-ME,3040,1,Heat Transfer,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,sandip dutta,ME-3040,2019
-ME,3040,2,Heat Transfer,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-3040,2019
-ME,3040,3,Heat Transfer,0.32,0.32,0.26,0.05,0.05,0.0,0.0,0.0,jay ochterbeck,ME-3040,2019
-ME,3050,1,Model/an Dy Syst,0.32,0.42,0.19,0.06,0.0,0.0,0.0,0.0,chengshi wang,ME-3050,2019
-ME,3050,2,Model/an Dy Syst,0.23,0.49,0.16,0.07,0.05,0.0,0.0,0.0,phanin tallapragada,ME-3050,2019
-ME,3050,3,Model/an Dy Syst,0.22,0.54,0.2,0.0,0.0,0.0,0.0,0.03,douglas scott byrd,ME-3050,2019
-ME,3060,1,Fund Machine Design,0.34,0.51,0.14,0.0,0.01,0.0,0.0,0.0,james allen righter,ME-3060,2019
-ME,3060,2,Fund Machine Design,0.24,0.45,0.24,0.03,0.03,0.0,0.0,0.03,james allen righter,ME-3060,2019
-ME,3070,1,Found of Mechanical Systems,0.43,0.34,0.2,0.0,0.0,0.0,0.0,0.02,jorge iva rodriguez,ME-3070,2019
-ME,3070,3,Found of Mechanical Systems,0.59,0.3,0.04,0.04,0.04,0.0,0.0,0.0,pooya niksiar,ME-3070,2019
-ME,3080,1,Fluid Mechanics,0.17,0.48,0.27,0.02,0.0,0.0,0.0,0.06,chenning tong,ME-3080,2019
-ME,3080,2,Fluid Mechanics,0.47,0.36,0.13,0.02,0.0,0.0,0.0,0.02,yiqiang han,ME-3080,2019
-ME,3100,1,Thermo/Heat Transfer,0.12,0.35,0.35,0.1,0.06,0.0,0.0,0.04,yiqiang han,ME-3100,2019
-ME,3120,1,Manuf Processes,0.25,0.72,0.03,0.0,0.0,0.0,0.0,0.0,hong seok choi,ME-3120,2019
-ME,3330,1,Mechanical Engineering Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,2,Mechanical Engineering Lab II,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,3,Mechanical Engineering Lab II,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,5,Mechanical Engineering Lab II,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,6,Mechanical Engineering Lab II,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,gang liu,ME-3330,2019
-ME,3330,7,Mechanical Engineering Lab II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,9,Mechanical Engineering Lab II,0.31,0.38,0.23,0.0,0.08,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,3330,10,Mechanical Engineering Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,ME-3330,2019
-ME,4000,1,Senior Seminar,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,atul gajanan kelkar,ME-4000,2019
-ME,4010,1,Mech Engr Design,0.28,0.49,0.18,0.04,0.01,0.0,0.01,0.0,joshua summers,ME-4010,2019
-ME,4010,1,Mech Engr Design,0.28,0.49,0.18,0.04,0.01,0.0,0.01,0.0,cameron turner,ME-4010,2019
-ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,ME-4020,2019
-ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,huijuan zhao,ME-4020,2019
-ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yiqiang han,ME-4020,2019
-ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xin zhao,ME-4020,2019
-ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-4020,2019
-ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,sandip dutta,ME-4020,2019
-ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,douglas scott byrd,ME-4020,2019
-ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,jorge iva rodriguez,ME-4020,2019
-ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sandip dutta,ME-4020,2019
-ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,ME-4020,2019
-ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,gang liu,ME-4020,2019
-ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,ME-4020,2019
-ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,john saylor,ME-4020,2019
-ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,joshua bostwick,ME-4020,2019
-ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,richard figliola,ME-4020,2019
-ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2019
-ME,4020,77,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4020,2019
-ME,4020,77,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,ME-4020,2019
-ME,4030,1,Control Dynamic Systems,0.23,0.3,0.34,0.13,0.0,0.0,0.0,0.0,mohammad naghnaeian,ME-4030,2019
-ME,4030,2,Control Dynamic Systems,0.23,0.46,0.23,0.04,0.0,0.0,0.0,0.04,suyi li,ME-4030,2019
-ME,4170,1,Mechatronic Sys Design,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,john wagner,ME-4170,2019
-ME,4180,1,F E A in M E Design,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,oliver myers,ME-4180,2019
-ME,4220,2,Design Gas Turbines,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,abhijit som,ME-4220,2019
-ME,4230,2,Intro Aerodynamics,0.13,0.42,0.42,0.03,0.0,0.0,0.0,0.0,richard figliola,ME-4230,2019
-ME,4260,1,Nuclear Energy,0.37,0.39,0.11,0.08,0.03,0.0,0.0,0.03,richard watkins,ME-4260,2019
-ME,4300,1,Mech Comp Materials,0.23,0.73,0.0,0.0,0.0,0.0,0.0,0.04,gang li,ME-4300,2019
-ME,4340,1,Cardiovascular Biomechanics,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,ethan kung,ME-4340,2019
-ME,4440,1,Mechanical Engineering Lab III,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2019
-ME,4440,5,Mechanical Engineering Lab III,0.13,0.81,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2019
-ME,4440,10,Mechanical Engineering Lab III,0.06,0.81,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2019
-ME,4440,12,Mechanical Engineering Lab III,0.13,0.87,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,ME-4440,2019
-ME,4930,10,Sel Topics ME (Nonlinear Dyn),0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,joshua bostwick,ME-4930,2019
-ME,4930,30,Sel Topics ME--Sustainability,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,ME-4930,2019
-ME,4930,39,Sel Topics ME (Solar Energy),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,daniel fant,ME-4930,2019
-ME,6170,1,Mechatronics System Design,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,john wagner,ME-6170,2019
-ME,6230,1,Intro Aerodynamics,0.4,0.2,0.4,0.0,0.0,0.0,0.0,0.0,richard figliola,ME-6230,2019
-ME,6230,2,Intro Aerodynamics,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,richard figliola,ME-6230,2019
-ME,6300,1,Mech Comp Materials,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,gang li,ME-6300,2019
-ME,6340,1,Cardiovascular Biomechanics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,ME-6340,2019
-ME,6930,2,Sel Topics ME (Microfab),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,ME-6930,2019
-ME,6930,10,Sel Topics ME-Nonlinear Dyn,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,joshua bostwick,ME-6930,2019
-ME,8200,1,Mod Cont Engr,0.3,0.63,0.07,0.0,0.0,0.0,0.0,0.0,yue wang,ME-8200,2019
-ME,8310,1,Convective Ht Trans,0.33,0.47,0.2,0.0,0.0,0.0,0.0,0.0,xin zhao,ME-8310,2019
-ME,8370,1,Theory of Elast I,0.12,0.32,0.44,0.0,0.08,0.0,0.0,0.04,huijuan zhao,ME-8370,2019
-ME,8610,1,Matl Sel Engr Design,0.68,0.3,0.02,0.0,0.0,0.0,0.0,0.0,garrett pataky,ME-8610,2019
-ME,8930,27,Sel Topics ME-Adv Estimation,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,ME-8930,2019
-ME,8930,28,Sel Topics ME: Agent Based Opt,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,cameron turner,ME-8930,2019
-ME,8930,28,Sel Topics ME: Agent Based Opt,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,joshua summers,ME-8930,2019
-MGT,2010,1,Principles of Management,0.37,0.39,0.18,0.03,0.0,0.0,0.02,0.03,katherine clark,MGT-2010,2019
-MGT,2010,2,Principles of Management,0.44,0.37,0.17,0.02,0.0,0.0,0.0,0.01,tina robbins,MGT-2010,2019
-MGT,2010,7,Principles of Management,0.18,0.62,0.15,0.03,0.03,0.0,0.0,0.0,christopher mann,MGT-2010,2019
-MGT,2010,8,Principles of Management,0.39,0.45,0.13,0.03,0.0,0.0,0.0,0.0,christopher mann,MGT-2010,2019
-MGT,2010,10,Principles of Management,0.31,0.28,0.28,0.08,0.0,0.0,0.0,0.05,ashley will parnell,MGT-2010,2019
-MGT,2010,11,Principles of Management,0.18,0.34,0.34,0.08,0.0,0.0,0.0,0.05,ashley will parnell,MGT-2010,2019
-MGT,2180,1,Management PC Applications,0.51,0.36,0.09,0.01,0.01,0.0,0.0,0.02,ryan toole,MGT-2180,2019
-MGT,2180,2,Management PC Applications,0.27,0.59,0.14,0.0,0.0,0.0,0.0,0.0,ryan toole,MGT-2180,2019
-MGT,2970,1,Deloitte Consulting CI,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ryan toole,MGT-2970,2019
-MGT,3070,1,Human Resource Management,0.28,0.65,0.08,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2019
-MGT,3070,2,Human Resource Management,0.5,0.38,0.1,0.03,0.0,0.0,0.0,0.0,michael cole,MGT-3070,2019
-MGT,3070,3,Human Resource Management,0.3,0.51,0.16,0.0,0.0,0.0,0.0,0.03,kristin dam scott,MGT-3070,2019
-MGT,3070,4,Human Resource Management,0.3,0.55,0.1,0.0,0.03,0.0,0.0,0.03,leonard jos spooner,MGT-3070,2019
-MGT,3070,5,Human Resource Management,0.63,0.33,0.03,0.0,0.03,0.0,0.0,0.0,michael cole,MGT-3070,2019
-MGT,3070,6,Human Resource Management,0.43,0.46,0.08,0.0,0.03,0.0,0.0,0.0,leonard jos spooner,MGT-3070,2019
-MGT,3070,8,Human Resource Management,0.32,0.49,0.17,0.0,0.0,0.0,0.0,0.02,priscilla harrison,MGT-3070,2019
-MGT,3100,2,Intermed Business Statistics,0.51,0.26,0.18,0.0,0.0,0.0,0.0,0.05,jeromy blake snider,MGT-3100,2019
-MGT,3100,3,Intermed Business Statistics,0.49,0.21,0.13,0.08,0.03,0.0,0.0,0.08,daniel nielubowicz,MGT-3100,2019
-MGT,3100,4,Intermed Business Statistics,0.44,0.28,0.21,0.0,0.0,0.0,0.0,0.07,iaroslava dutchak,MGT-3100,2019
-MGT,3100,5,Intermed Business Statistics,0.5,0.17,0.12,0.02,0.12,0.0,0.0,0.07,philip roth,MGT-3100,2019
-MGT,3100,6,Intermed Business Statistics,0.55,0.24,0.07,0.01,0.04,0.0,0.0,0.07,benjamin chri wiles,MGT-3100,2019
-MGT,3100,7,Intermed Business Statistics,0.4,0.35,0.2,0.03,0.0,0.0,0.0,0.03,mustafa serk akturk,MGT-3100,2019
-MGT,3100,8,Intermed Business Statistics,0.36,0.36,0.28,0.0,0.0,0.0,0.0,0.0,mustafa serk akturk,MGT-3100,2019
-MGT,3100,10,Intermed Business Statistics,0.47,0.24,0.13,0.07,0.02,0.0,0.0,0.07,iaroslava dutchak,MGT-3100,2019
-MGT,3100,11,Intermed Business Statistics,0.44,0.26,0.23,0.03,0.03,0.0,0.0,0.03,daniel allan detoma,MGT-3100,2019
-MGT,3120,1,Decision Models for Management,0.16,0.31,0.3,0.05,0.13,0.0,0.0,0.06,sara elizabet yoder,MGT-3120,2019
-MGT,3120,2,Decision Models for Management,0.21,0.25,0.34,0.07,0.06,0.0,0.0,0.06,sara elizabet yoder,MGT-3120,2019
-MGT,3120,4,Decision Models for Management,0.29,0.29,0.29,0.03,0.06,0.0,0.0,0.05,james turner,MGT-3120,2019
-MGT,3170,1,Logistics Mgmt,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,ahmet colak,MGT-3170,2019
-MGT,3180,1,Mgt of Info Systems,0.25,0.55,0.18,0.0,0.0,0.0,0.0,0.03,russell purvis,MGT-3180,2019
-MGT,3180,2,Mgt of Info Systems,0.49,0.23,0.26,0.0,0.0,0.0,0.0,0.03,marten risius,MGT-3180,2019
-MGT,3180,3,Mgt of Info Systems,0.69,0.22,0.09,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,MGT-3180,2019
-MGT,3180,4,Mgt of Info Systems,0.23,0.7,0.08,0.0,0.0,0.0,0.0,0.0,wenxi pu,MGT-3180,2019
-MGT,3180,5,Mgt of Info Systems,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,daniel aaron pienta,MGT-3180,2019
-MGT,3500,1,Intro to Business Analytics,0.58,0.26,0.13,0.03,0.0,0.0,0.0,0.0,hongki kim,MGT-3500,2019
-MGT,3510,1,Business Analytics & Problems,0.4,0.4,0.17,0.03,0.0,0.0,0.0,0.0,daniel allan detoma,MGT-3510,2019
-MGT,3900,1,Operations Management,0.3,0.48,0.13,0.05,0.03,0.0,0.0,0.03,ying zhang,MGT-3900,2019
-MGT,3900,2,Operations Management,0.37,0.44,0.15,0.0,0.05,0.0,0.0,0.0,ying zhang,MGT-3900,2019
-MGT,3900,3,Operations Management,0.1,0.43,0.42,0.0,0.0,0.0,0.0,0.04, sridharan,MGT-3900,2019
-MGT,3900,4,Operations Management,0.15,0.33,0.36,0.13,0.0,0.0,0.0,0.03,zachary mo leffakis,MGT-3900,2019
-MGT,3900,6,Operations Management,0.57,0.4,0.02,0.0,0.0,0.0,0.0,0.0,maneeshre ajjuguttu,MGT-3900,2019
-MGT,4000,1,Mgt of Organizational Behavior,0.78,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2019
-MGT,4000,2,Mgt of Organizational Behavior,0.26,0.38,0.33,0.02,0.02,0.0,0.0,0.0,thomas jo zagenczyk,MGT-4000,2019
-MGT,4000,3,Mgt of Organizational Behavior,0.23,0.33,0.26,0.08,0.08,0.0,0.0,0.03,philip roth,MGT-4000,2019
-MGT,4000,4,Mgt of Organizational Behavior,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,MGT-4000,2019
-MGT,4020,1,Ops Pln and Ctl,0.13,0.47,0.4,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4020,2019
-MGT,4080,1,Lean Operations,0.21,0.51,0.26,0.03,0.0,0.0,0.0,0.0,zachary mo leffakis,MGT-4080,2019
-MGT,4110,1,Project Management,0.15,0.51,0.28,0.0,0.03,0.0,0.0,0.03,russell purvis,MGT-4110,2019
-MGT,4120,1,Supplier Management,0.59,0.34,0.03,0.0,0.0,0.0,0.0,0.03,ahmet colak,MGT-4120,2019
-MGT,4150,1,Business Strategy,0.15,0.52,0.33,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,2,Business Strategy,0.07,0.67,0.26,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,3,Business Strategy,0.33,0.59,0.09,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,MGT-4150,2019
-MGT,4150,4,Business Strategy,0.46,0.48,0.07,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,MGT-4150,2019
-MGT,4150,5,Business Strategy,0.26,0.61,0.13,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2019
-MGT,4150,6,Business Strategy,0.48,0.43,0.1,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,MGT-4150,2019
-MGT,4150,7,Business Strategy,0.07,0.57,0.35,0.02,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,8,Business Strategy,0.26,0.7,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,11,Business Strategy,0.1,0.42,0.42,0.06,0.0,0.0,0.0,0.0,wayne stewart,MGT-4150,2019
-MGT,4150,14,Business Strategy,0.15,0.39,0.45,0.0,0.0,0.0,0.0,0.0,james liddle,MGT-4150,2019
-MGT,4150,15,Business Strategy,0.16,0.5,0.25,0.09,0.0,0.0,0.0,0.0,wayne stewart,MGT-4150,2019
-MGT,4160,1,Special Topics Hr,0.23,0.53,0.23,0.03,0.0,0.0,0.0,0.0,kristin dam scott,MGT-4160,2019
-MGT,4230,1,Intern Bus Mgt,0.11,0.53,0.31,0.04,0.0,0.0,0.0,0.0,janis miller,MGT-4230,2019
-MGT,4230,2,Intern Bus Mgt,0.11,0.33,0.47,0.04,0.04,0.0,0.0,0.0,janis miller,MGT-4230,2019
-MGT,4230,3,Intern Bus Mgt,0.13,0.16,0.64,0.04,0.0,0.0,0.0,0.02,wayne stewart,MGT-4230,2019
-MGT,4230,4,Intern Bus Mgt,0.27,0.09,0.57,0.02,0.02,0.0,0.0,0.02,wayne stewart,MGT-4230,2019
-MGT,4230,600,Intern Bus Mgt,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0, sridharan,MGT-4230,2019
-MGT,4240,1,Global Supply Chain Management,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,yann ferrand,MGT-4240,2019
-MGT,4270,1,Managing Improvement,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,MGT-4270,2019
-MGT,4310,1,Emp Rights & Resp,0.15,0.55,0.3,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,MGT-4310,2019
-MGT,4350,1,Pers Interviewing,0.35,0.43,0.18,0.03,0.03,0.0,0.0,0.0,philip roth,MGT-4350,2019
-MGT,4520,1,Business Analysis,0.37,0.11,0.52,0.0,0.0,0.0,0.0,0.0,marten risius,MGT-4520,2019
-MGT,4540,1,Systems Implement,0.43,0.39,0.13,0.04,0.0,0.0,0.0,0.0,hongki kim,MGT-4540,2019
-MGT,4550,1,Emerging I T Trends,0.38,0.5,0.08,0.0,0.0,0.0,0.0,0.04,john frederic tripp,MGT-4550,2019
-MGT,8120,1,Supply Chain Mgt,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,yann ferrand,MGT-8120,2019
-MICR,3050,1,General Microbiology,0.47,0.37,0.11,0.04,0.0,0.0,0.0,0.01,krista barr rudolph,MICR-3050,2019
-MICR,3050,2,General Microbiology,0.39,0.43,0.16,0.01,0.0,0.0,0.0,0.01,kristi ja whitehead,MICR-3050,2019
-MICR,3050,3,General Microbiology,0.68,0.3,0.02,0.0,0.0,0.0,0.0,0.0,krista barr rudolph,MICR-3050,2019
-MICR,4000,1,Public Health Micro,0.6,0.24,0.12,0.04,0.0,0.0,0.0,0.01,kristi ja whitehead,MICR-4000,2019
-MICR,4000,2,Public Health Micro (HON),0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4000,2019
-MICR,4070,1,Food and Dairy Micro,0.27,0.55,0.12,0.04,0.0,0.0,0.0,0.01,xiuping jiang,MICR-4070,2019
-MICR,4110,1,Pathogenic Bact,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kear milhous,MICR-4110,2019
-MICR,4120,1,Bacterial Physiology,0.23,0.35,0.27,0.08,0.05,0.0,0.0,0.02,harry kurtz,MICR-4120,2019
-MICR,4130,1,Industrial Micro,0.42,0.49,0.06,0.02,0.0,0.0,0.0,0.01,tzuen-rong je tzeng,MICR-4130,2019
-MICR,4140,1,Basic Immunology,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,charles rice,MICR-4140,2019
-MICR,4170,1,Cancer and Aging,0.61,0.27,0.1,0.02,0.0,0.0,0.0,0.0,wen chen,MICR-4170,2019
-MICR,4190,1,Intro to Molecular Medicine,0.54,0.27,0.08,0.08,0.0,0.0,0.0,0.04,zhicheng dou,MICR-4190,2019
-MICR,4500,1,Advanced Microbiology I,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2019
-MICR,4500,2,Advanced Microbiology I,0.2,0.67,0.07,0.07,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2019
-MICR,4500,3,Advanced Microbiology I,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2019
-MICR,4500,4,Advanced Microbiology I,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,harry kurtz,MICR-4500,2019
-MICR,4520,1,Advanced Microbiology III,0.8,0.05,0.15,0.0,0.0,0.0,0.0,0.0,min cao,MICR-4520,2019
-MICR,4520,2,Advanced Microbiology III,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,min cao,MICR-4520,2019
-MICR,4520,3,Advanced Microbiology III,0.47,0.32,0.11,0.11,0.0,0.0,0.0,0.0,min cao,MICR-4520,2019
-MICR,4930,5,Sen Sem: Host-Microbe Interact,0.56,0.31,0.06,0.06,0.0,0.0,0.0,0.0,kristi ja whitehead,MICR-4930,2019
-MICR,4940,1,CI: InterKingdom Communication,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,min cao,MICR-4940,2019
-MICR,4940,26,CI: Parasite Biophysics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,joshua alper,MICR-4940,2019
-MKT,3010,1,Principles of Marketing,0.3,0.33,0.25,0.08,0.03,0.0,0.0,0.01,carter wil mcelveen,MKT-3010,2019
-MKT,3010,2,Principles of Marketing,0.32,0.29,0.34,0.03,0.0,0.0,0.01,0.01,carter wil mcelveen,MKT-3010,2019
-MKT,3010,3,Principles of Marketing,0.35,0.34,0.2,0.08,0.01,0.0,0.0,0.03,amanda cooper fine,MKT-3010,2019
-MKT,3010,4,Principles of Marketing,0.29,0.43,0.22,0.06,0.0,0.0,0.0,0.01,amanda cooper fine,MKT-3010,2019
-MKT,3010,5,Principles of Marketing,0.29,0.43,0.18,0.06,0.01,0.0,0.0,0.03,james gaubert,MKT-3010,2019
-MKT,3010,7,Principles of Marketing,0.74,0.2,0.04,0.01,0.0,0.0,0.0,0.01,patricia knowles,MKT-3010,2019
-MKT,3020,1,Consumer Behavior,0.33,0.59,0.05,0.0,0.03,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2019
-MKT,3020,2,Consumer Behavior,0.49,0.41,0.1,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,MKT-3020,2019
-MKT,3020,3,Consumer Behavior,0.35,0.49,0.14,0.0,0.0,0.0,0.0,0.02,anastasia thyroff,MKT-3020,2019
-MKT,3020,4,Consumer Behavior,0.41,0.43,0.17,0.0,0.0,0.0,0.0,0.0,anastasia thyroff,MKT-3020,2019
-MKT,3020,5,Consumer Behavior,0.6,0.37,0.04,0.0,0.0,0.0,0.0,0.0,patricia knowles,MKT-3020,2019
-MKT,3220,1,Social Media Marketing,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michele melt cauley,MKT-3220,2019
-MKT,3220,2,Social Media Marketing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michele melt cauley,MKT-3220,2019
-MKT,3310,1,Marketing Metrics & Analytics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,MKT-3310,2019
-MKT,3310,2,Marketing Metrics & Analytics,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,MKT-3310,2019
-MKT,3310,3,Marketing Metrics & Analytics,0.21,0.41,0.26,0.12,0.0,0.0,0.0,0.0,peter weathers,MKT-3310,2019
-MKT,3310,4,Marketing Metrics & Analytics,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-3310,2019
-MKT,3310,5,Marketing Metrics & Analytics,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-3310,2019
-MKT,3980,1,CI:Sales Experiential,0.93,0.0,0.04,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,MKT-3980,2019
-MKT,4200,1,Professional Selling,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,jesse moore,MKT-4200,2019
-MKT,4200,2,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,MKT-4200,2019
-MKT,4200,3,Professional Selling,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4200,2019
-MKT,4200,4,Professional Selling,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,kevin scott chase,MKT-4200,2019
-MKT,4200,5,Professional Selling,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,kevin scott chase,MKT-4200,2019
-MKT,4230,1,Promotional Strategy,0.82,0.16,0.02,0.0,0.0,0.0,0.0,0.0,michele melt cauley,MKT-4230,2019
-MKT,4230,2,Promotional Strategy,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,michele melt cauley,MKT-4230,2019
-MKT,4240,1,Sales Management,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,ryan mullins,MKT-4240,2019
-MKT,4270,1,International Marketing,0.36,0.53,0.06,0.03,0.03,0.0,0.0,0.0,thomas poehlman,MKT-4270,2019
-MKT,4270,2,International Marketing,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,xianyong wang,MKT-4270,2019
-MKT,4270,3,International Marketing,0.84,0.13,0.02,0.0,0.0,0.0,0.0,0.0,xianyong wang,MKT-4270,2019
-MKT,4270,4,International Marketing,0.47,0.38,0.1,0.03,0.0,0.0,0.0,0.03,patricia knowles,MKT-4270,2019
-MKT,4280,1,Services Marketing,0.55,0.39,0.05,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4280,2019
-MKT,4280,2,Services Marketing,0.53,0.45,0.03,0.0,0.0,0.0,0.0,0.0,james gaubert,MKT-4280,2019
-MKT,4310,1,Marketing Research,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,michae giebelhausen,MKT-4310,2019
-MKT,4310,2,Marketing Research,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,michae giebelhausen,MKT-4310,2019
-MKT,4310,3,Marketing Research,0.4,0.3,0.23,0.0,0.0,0.0,0.0,0.07,william kilbourne,MKT-4310,2019
-MKT,4310,4,Marketing Research,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2019
-MKT,4310,5,Marketing Research,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,MKT-4310,2019
-MKT,4330,1,Sport Mkt Strategy,0.46,0.42,0.12,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,MKT-4330,2019
-MKT,4450,1,Macromarketing,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,william kilbourne,MKT-4450,2019
-MKT,4500,1,Strategic Mktg Mgt,0.13,0.45,0.42,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2019
-MKT,4500,2,Strategic Mktg Mgt,0.13,0.59,0.28,0.0,0.0,0.0,0.0,0.0,mary anne raymond,MKT-4500,2019
-MKT,4500,3,Strategic Mktg Mgt,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-4500,2019
-MKT,4500,4,Strategic Mktg Mgt,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,MKT-4500,2019
-MKT,4500,5,Strategic Mktg Mgt,0.24,0.42,0.3,0.03,0.0,0.0,0.0,0.0,michael dorsch,MKT-4500,2019
-MKT,8620,1,Quant Methods in Mkt,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,MKT-8620,2019
-MKT,8650,1,Seminar in Mkt Mgmt,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,michael dorsch,MKT-8650,2019
-MKT,8660,1,International Marketing,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,MKT-8660,2019
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,aaron javron hills,ML-1020,2019
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,andre kareeth bland,ML-1020,2019
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jonathan jacoba,ML-1020,2019
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,christopher bland,ML-1020,2019
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,brian james gural,ML-1020,2019
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,kenneth to crawford,ML-1020,2019
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2020,2019
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,thomas michae burke,ML-2020,2019
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,christopher bland,ML-2020,2019
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,ML-2020,2019
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,ML-2020,2019
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,ML-2020,2019
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,ML-2020,2019
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,ML-2020,2019
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas michae burke,ML-2020,2019
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,ML-2020,2019
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,ML-2020,2019
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-2020,2019
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,matthew davi jordan,ML-2020,2019
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,andre kareeth bland,ML-2020,2019
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,kenneth to crawford,ML-2020,2019
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,vincent john presto,ML-2020,2019
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,thomas michae burke,ML-2020,2019
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,christopher bland,ML-2020,2019
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,ML-3020,2019
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,justin rober merhar,ML-3020,2019
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,ML-3020,2019
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,spencer blak harmon,ML-3020,2019
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,ML-3020,2019
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,ML-3020,2019
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,justin rober merhar,ML-3020,2019
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,ML-3020,2019
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,ML-3020,2019
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,ML-3020,2019
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,ML-3020,2019
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,spencer blak harmon,ML-3020,2019
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,ML-3900,2019
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,ML-3900,2019
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,ML-3900,2019
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,ML-3900,2019
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,ML-3900,2019
-MSE,2100,1,Intro to Materials Science,0.33,0.27,0.25,0.03,0.08,0.0,0.0,0.03,rakhee pani,MSE-2100,2019
-MSE,2100,3,Intro to Materials Science,0.33,0.3,0.16,0.07,0.08,0.0,0.0,0.05,kai he,MSE-2100,2019
-MSE,2100,4,Intro to Materials Science,0.53,0.25,0.08,0.04,0.04,0.0,0.0,0.05,rakhee pani,MSE-2100,2019
-MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,MSE-3020,2019
-MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,MSE-3020,2019
-MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,MSE-3020,2019
-MSE,3100,1,Intro to Metals and Ceramics,0.63,0.22,0.11,0.0,0.0,0.0,0.04,0.0,jianhua tong,MSE-3100,2019
-MSE,3190,1,Materials Proc I,0.48,0.32,0.2,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,MSE-3190,2019
-MSE,3190,1,Materials Proc I,0.48,0.32,0.2,0.0,0.0,0.0,0.0,0.0,rakhee pani,MSE-3190,2019
-MSE,3190,2,Materials Proc I,0.31,0.31,0.17,0.07,0.03,0.0,0.0,0.1,rajendra kum bordia,MSE-3190,2019
-MSE,3190,2,Materials Proc I,0.31,0.31,0.17,0.07,0.03,0.0,0.0,0.1,rakhee pani,MSE-3190,2019
-MSE,3260,1,Thermo of Materials,0.26,0.43,0.26,0.0,0.0,0.0,0.0,0.06,fei peng,MSE-3260,2019
-MSE,3260,2,Thermo of Materials,0.26,0.26,0.22,0.15,0.04,0.0,0.0,0.07,fei peng,MSE-3260,2019
-MSE,3270,1,Transport Phenomena,0.17,0.35,0.39,0.0,0.0,0.0,0.04,0.04,ulf daniel schiller,MSE-3270,2019
-MSE,3610,2,Proc of Metals & Composites,0.41,0.38,0.14,0.03,0.0,0.0,0.0,0.03,marian kennedy,MSE-3610,2019
-MSE,4020,1,Fundamentals of Solid State,0.5,0.16,0.28,0.06,0.0,0.0,0.0,0.0,luiz gust jacobsohn,MSE-4020,2019
-MSE,4070,1,Senior Capstone Design,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,MSE-4070,2019
-MSE,4150,1,Polymer Sc Engr,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,olin mefford,MSE-4150,2019
-MSE,4220,1,Mech Behavior of Mat,0.61,0.32,0.05,0.0,0.02,0.0,0.0,0.0,vincent yves blouin,MSE-4220,2019
-MSE,4240,1,Optical Materials,0.8,0.07,0.1,0.03,0.0,0.0,0.0,0.0,luiz gust jacobsohn,MSE-4240,2019
-MSE,4330,2,Comb Sys & Env Emiss,0.74,0.16,0.06,0.0,0.0,0.0,0.0,0.03,john sanders,MSE-4330,2019
-MSE,4450,1,Practice of Mat Engr,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,marek urban,MSE-4450,2019
-MSE,4910,1,Undergraduate Research,0.91,0.03,0.0,0.0,0.03,0.0,0.0,0.03,rajendra kum bordia,MSE-4910,2019
-MSE,6020,1,Solid State Material,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,MSE-6020,2019
-MSE,8250,2,Solid State Mtl Sci,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,stephen foulger,MSE-8250,2019
-MSE,8520,2,Polymer Science II,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,igor luzinov,MSE-8520,2019
-MUSC,1110,5,Beginning Class Guitar,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david stevenson,MUSC-1110,2019
-MUSC,1110,6,Beginning Class Guitar,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,david stevenson,MUSC-1110,2019
-MUSC,1430,1,Aural Skills I,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,david conley,MUSC-1430,2019
-MUSC,1510,2,Applied Music,0.63,0.19,0.0,0.0,0.0,0.0,0.0,0.19,jonathan edwa doyel,MUSC-1510,2019
-MUSC,1510,19,Applied Music,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,monty craig,MUSC-1510,2019
-MUSC,1520,1,Applied Music,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,lisa sain odom,MUSC-1520,2019
-MUSC,1520,2,Applied Music,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edwa doyel,MUSC-1520,2019
-MUSC,1520,10,Applied Music,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,paul buyer,MUSC-1520,2019
-MUSC,1800,1,Intro to Music Tech,0.3,0.6,0.0,0.0,0.1,0.0,0.0,0.0,hamilton altstatt,MUSC-1800,2019
-MUSC,1950,1,Creative Inquiry in Music I,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,linda dzuris,MUSC-1950,2019
-MUSC,2100,2,Music in the Western World,0.52,0.26,0.13,0.03,0.0,0.0,0.0,0.06,lisa sain odom,MUSC-2100,2019
-MUSC,2100,4,Music in the Western World,0.48,0.26,0.16,0.03,0.03,0.0,0.0,0.03,rhea beth jacobus,MUSC-2100,2019
-MUSC,2100,5,Music in the Western World,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,MUSC-2100,2019
-MUSC,2100,6,Music in the Western World,0.5,0.34,0.09,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,MUSC-2100,2019
-MUSC,2100,7,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,evan michael jacobi,MUSC-2100,2019
-MUSC,2100,9,Music in the Western World,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,lea kibler,MUSC-2100,2019
-MUSC,2100,10,Music in the Western World,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,linda dzuris,MUSC-2100,2019
-MUSC,2510,2,Applied Music,0.75,0.0,0.0,0.0,0.25,0.0,0.0,0.0,jonathan edwa doyel,MUSC-2510,2019
-MUSC,2520,2,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edwa doyel,MUSC-2520,2019
-MUSC,3090,1,Surv of Broadway II,0.91,0.0,0.0,0.09,0.0,0.0,0.0,0.0,lisa sain odom,MUSC-3090,2019
-MUSC,3110,1,History of American Music,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,MUSC-3110,2019
-MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,eric lapin,MUSC-3120,2019
-MUSC,3170,1,Hist of Country Mus,0.88,0.09,0.0,0.03,0.0,0.0,0.0,0.0,ned hosler,MUSC-3170,2019
-MUSC,3180,1,Hist of Audio Tech,0.39,0.22,0.28,0.06,0.0,0.0,0.0,0.06,bruce allen whisler,MUSC-3180,2019
-MUSC,3310,1,Pep Band,0.95,0.02,0.02,0.02,0.0,0.0,0.0,0.0,timothy ra hurlburt,MUSC-3310,2019
-MUSC,3310,2,Pep Band,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,MUSC-3310,2019
-MUSC,3640,1,Concert Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,timothy ra hurlburt,MUSC-3640,2019
-MUSC,3710,1,Women's Chorus,0.82,0.16,0.0,0.0,0.0,0.0,0.0,0.02,jerrad fenske,MUSC-3710,2019
-MUSC,3720,1,Men's Chorus,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,MUSC-3720,2019
-MUSC,4160,1,Mus Hist Since 1750,0.39,0.26,0.23,0.06,0.0,0.0,0.0,0.06,linda li-bleuel,MUSC-4160,2019
-MUSC,4300,1,Conducting,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mark spede,MUSC-4300,2019
-NPL,3000,1,Nonprofit Leadership,0.75,0.13,0.04,0.08,0.0,0.0,0.0,0.0,corey dou brookover,NPL-3000,2019
-NPL,3000,2,Nonprofit Leadership,0.46,0.42,0.08,0.0,0.04,0.0,0.0,0.0,christina mar mazer,NPL-3000,2019
-NPL,3000,3,Nonprofit Leadership,0.29,0.42,0.17,0.08,0.0,0.0,0.0,0.04,bonnie west stevens,NPL-3000,2019
-NPL,3000,4,Nonprofit Leadership,0.36,0.5,0.05,0.05,0.0,0.0,0.0,0.05,bonnie west stevens,NPL-3000,2019
-NPL,3000,5,Nonprofit Leadership,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,corey dou brookover,NPL-3000,2019
-NPL,3000,6,Nonprofit Leadership,0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,christina mar mazer,NPL-3000,2019
-NPL,3000,7,Nonprofit Leadership,0.61,0.28,0.06,0.06,0.0,0.0,0.0,0.0,corey dou brookover,NPL-3000,2019
-NPL,3000,8,Nonprofit Leadership,0.41,0.34,0.07,0.0,0.17,0.0,0.0,0.0,christina mar mazer,NPL-3000,2019
-NPL,3010,2,NPL Stakeholders,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,NPL-3010,2019
-NPL,3020,1,NPL Fundraising,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,thomas john orourke,NPL-3020,2019
-NPL,3030,2,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,joan laura phillips,NPL-3030,2019
-NPL,3030,2,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,NPL-3030,2019
-NPL,3040,1,NPL Risk Management,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,daniel mor anderson,NPL-3040,2019
-NPL,3050,1,Strat Social Media for NP Org,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,NPL-3050,2019
-NPL,3050,2,Strat Social Media for NP Org,0.38,0.38,0.14,0.03,0.03,0.0,0.0,0.03,amanda elizab moore,NPL-3050,2019
-NURS,1400,1,Comp App Hlth Care,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,nancy meehan,NURS-1400,2019
-NURS,1400,3,Comp App Hlth Care,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,NURS-1400,2019
-NURS,1400,4,Comp App Hlth Care,0.87,0.09,0.02,0.02,0.0,0.0,0.0,0.0,catherine si murton,NURS-1400,2019
-NURS,3030,101,Nursing of Adults,0.19,0.77,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2019
-NURS,3030,101,Nursing of Adults,0.19,0.77,0.04,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,NURS-3030,2019
-NURS,3030,201,Nursing of Adults,0.21,0.66,0.13,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2019
-NURS,3030,201,Nursing of Adults,0.21,0.66,0.13,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,NURS-3030,2019
-NURS,3030,401,Nursing of Adults,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,NURS-3030,2019
-NURS,3030,401,Nursing of Adults,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,NURS-3030,2019
-NURS,3040,1,Pathophysiology,0.32,0.44,0.14,0.08,0.02,0.0,0.0,0.0,catherine si murton,NURS-3040,2019
-NURS,3050,101,Psychosocial Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,NURS-3050,2019
-NURS,3050,401,Psychosocial Nursing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,margaret wetsel,NURS-3050,2019
-NURS,3100,101,Health Assessment,0.94,0.04,0.02,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,NURS-3100,2019
-NURS,3100,201,Health Assessment,0.48,0.5,0.02,0.0,0.0,0.0,0.0,0.0,jason thrift,NURS-3100,2019
-NURS,3120,1,Foundations of Nursing,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,NURS-3120,2019
-NURS,3200,1,Prof in Nurs,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,NURS-3200,2019
-NURS,3230,1,Gerontology Nursing,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,zahra rahemi,NURS-3230,2019
-NURS,3330,101,Health Care Genetics,0.7,0.27,0.02,0.02,0.0,0.0,0.0,0.0,linda ward,NURS-3330,2019
-NURS,3330,400,Health Care Genetics,0.72,0.24,0.0,0.0,0.04,0.0,0.0,0.0,jennifer el bagwell,NURS-3330,2019
-NURS,3330,401,Health Care Genetics,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,NURS-3330,2019
-NURS,3400,1,Pharmther Nursing,0.3,0.48,0.16,0.04,0.0,0.0,0.02,0.0,catherine si murton,NURS-3400,2019
-NURS,3610,400,Ldrshp & Collab in Global Hlth,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,NURS-3610,2019
-NURS,4010,1,Mental Health Nurs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-4010,2019
-NURS,4030,1,Complex Nursing of Adults,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,NURS-4030,2019
-NURS,4110,1,Nursing of Children,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,NURS-4110,2019
-NURS,4120,1,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-4120,2019
-NURS,4120,1,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,kylie padron newsom,NURS-4120,2019
-NURS,4250,400,Community Nursing,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,tiffany lea stewart,NURS-4250,2019
-NURS,8010,400,Adv Fam & Comm Nrsng,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,NURS-8010,2019
-NURS,8010,400,Adv Fam & Comm Nrsng,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,NURS-8010,2019
-NURS,8080,400,Nurs Res Stat Analys,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-8080,2019
-NURS,8080,401,Nurs Res Stat Analys,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,veronica parker,NURS-8080,2019
-NURS,8190,400,Developing Family,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,NURS-8190,2019
-NURS,8200,400,Child & Adol Nursing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,NURS-8200,2019
-NURS,8210,400,Adult Nursing,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8210,2019
-NURS,8210,402,Adult Nursing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,NURS-8210,2019
-NURS,8210,402,Adult Nursing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,NURS-8210,2019
-NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,NURS-8230,2019
-NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,NURS-8230,2019
-NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,NURS-8230,2019
-NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,NURS-8230,2019
-NURS,8850,400,Mental Health in Primary Care,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,NURS-8850,2019
-NURS,9050,400,DNP Health Informatics,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,nancy meehan,NURS-9050,2019
-NUTR,2030,1,Intro Princ of Human Nutrition,0.32,0.42,0.15,0.04,0.01,0.0,0.0,0.05,elizabeth durrance,NUTR-2030,2019
-NUTR,2030,2,Intro Princ of Human Nutrition,0.48,0.39,0.07,0.07,0.0,0.0,0.0,0.0,elizabeth durrance,NUTR-2030,2019
-NUTR,2040,1,Nutrition Across Life Cycle,0.43,0.47,0.05,0.01,0.01,0.0,0.0,0.03,elizabeth durrance,NUTR-2040,2019
-NUTR,3010,1,Food and Culture,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,bridgit den corbett,NUTR-3010,2019
-NUTR,4250,1,Medica Nutr Thera II,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,NUTR-4250,2019
-NUTR,4260,1,Community Nutrition,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alexis stamatikos,NUTR-4260,2019
-NUTR,4270,1,Nutrition Counseling,0.66,0.24,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,NUTR-4270,2019
-NUTR,4550,1,Human Nutr & Metabolism II,0.52,0.38,0.07,0.03,0.0,0.0,0.0,0.0,elliot jesch,NUTR-4550,2019
-PA,2790,1,Perf Arts Pract I,0.33,0.4,0.0,0.0,0.13,0.0,0.0,0.13,kenneth moore,PA-2790,2019
-PA,3010,1,Princip of Arts Administration,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paul buyer,PA-3010,2019
-PA,4010,1,Capstone Project,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,anthony penna,PA-4010,2019
-PADM,8410,401,Public Data Analysis,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,ronald chrestman,PADM-8410,2019
-PADM,8410,402,Public Data Analysis,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,PADM-8410,2019
-PADM,8480,400,Strateg Planning for Pub Admin,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey rand parkey,PADM-8480,2019
-PADM,8480,400,Strateg Planning for Pub Admin,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,maleena yenn parkey,PADM-8480,2019
-PADM,8600,400,American Government,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,alfred bundrick,PADM-8600,2019
-PADM,8660,400,Nonprofit Fundraising,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,victoria bedso hann,PADM-8660,2019
-PADM,8680,400,Local Government Admin,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,PADM-8680,2019
-PES,2020,1,Soils,0.14,0.5,0.33,0.03,0.0,0.0,0.0,0.0,dara michelle park,PES-2020,2019
-PES,4060,2,Living Seed Ark,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,paula agudelo,PES-4060,2019
-PES,4060,2,Living Seed Ark,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,stephen kresovich,PES-4060,2019
-PES,4230,1,Forages and Livestock Systems,0.25,0.38,0.31,0.0,0.0,0.0,0.0,0.06,matias jose aguerre,PES-4230,2019
-PES,4330,1,Weed Management,0.23,0.15,0.54,0.0,0.0,0.0,0.0,0.08,ted whitwell,PES-4330,2019
-PES,4450,1,Regulatory Issues & Policies,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,PES-4450,2019
-PES,4520,1,Soil Fertility and Management,0.69,0.08,0.08,0.0,0.08,0.0,0.0,0.08,haibo liu,PES-4520,2019
-PES,4900,1,Soil Organisms in Plant Growth,0.21,0.5,0.21,0.0,0.0,0.0,0.0,0.07,"appukuttan suseela,",PES-4900,2019
-PES,4960,2,CI: Food Forest,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,julia loui kerrigan,PES-4960,2019
-PES,8010,1,Crop Physiology and Nutrition,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sru narayanan kutty,PES-8010,2019
-PES,8090,1,Analytical Technique,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,PES-8090,2019
-PHIL,1010,1,Intro to Philosophic Problems,0.35,0.35,0.21,0.0,0.03,0.0,0.0,0.06,kelly smith,PHIL-1010,2019
-PHIL,1010,2,Intro to Philosophic Problems,0.32,0.29,0.24,0.0,0.0,0.0,0.0,0.15,david stegall,PHIL-1010,2019
-PHIL,1010,3,Intro to Philosophic Problems,0.43,0.31,0.11,0.06,0.03,0.0,0.0,0.06,david stegall,PHIL-1010,2019
-PHIL,1010,4,Intro to Philosophic Problems,0.53,0.29,0.06,0.03,0.0,0.0,0.0,0.09,david robe antonini,PHIL-1010,2019
-PHIL,1010,5,Intro to Philosophic Problems,0.43,0.34,0.14,0.03,0.03,0.0,0.0,0.03,david robe antonini,PHIL-1010,2019
-PHIL,1010,6,Intro to Philosophic Problems,0.39,0.3,0.09,0.06,0.06,0.0,0.0,0.09,david stegall,PHIL-1010,2019
-PHIL,1010,7,"Intro to Phil, Problems (HON)",0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,christopher grau,PHIL-1010,2019
-PHIL,1020,1,Introduction to Logic,0.67,0.24,0.03,0.06,0.0,0.0,0.0,0.0,edyta joanna kuzian,PHIL-1020,2019
-PHIL,1020,2,Introduction to Logic,0.69,0.14,0.03,0.03,0.0,0.0,0.03,0.09,adam pa omelianchuk,PHIL-1020,2019
-PHIL,1020,3,Introduction to Logic,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,PHIL-1020,2019
-PHIL,1020,6,Introduction to Logic,0.73,0.12,0.09,0.03,0.0,0.0,0.0,0.03,adam pa omelianchuk,PHIL-1020,2019
-PHIL,1020,7,Introduction to Logic,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,adam pa omelianchuk,PHIL-1020,2019
-PHIL,1020,8,Introduction to Logic,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,PHIL-1020,2019
-PHIL,1030,1,Introduction to Ethics,0.36,0.48,0.06,0.06,0.0,0.0,0.0,0.03,stephen satris,PHIL-1030,2019
-PHIL,1030,2,Intro to Ethics (HON),0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,stephen satris,PHIL-1030,2019
-PHIL,1030,3,Introduction to Ethics,0.71,0.23,0.0,0.0,0.03,0.0,0.0,0.03,adam gies,PHIL-1030,2019
-PHIL,1030,4,Introduction to Ethics,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,PHIL-1030,2019
-PHIL,1030,5,Introduction to Ethics,0.22,0.44,0.28,0.0,0.0,0.0,0.0,0.06,charles starkey,PHIL-1030,2019
-PHIL,3030,1,Phil of Religion,0.41,0.41,0.14,0.0,0.0,0.0,0.0,0.03,richard al amesbury,PHIL-3030,2019
-PHIL,3050,1,Existentialism,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david stegall,PHIL-3050,2019
-PHIL,3120,1,Philosophy in Ancient China,0.43,0.29,0.14,0.14,0.0,0.0,0.0,0.0,yanming an,PHIL-3120,2019
-PHIL,3160,1,Modern Philosophy,0.38,0.46,0.04,0.04,0.0,0.0,0.0,0.08,david robe antonini,PHIL-3160,2019
-PHIL,3200,1,Soc and Pol Phil,0.39,0.42,0.13,0.03,0.0,0.0,0.0,0.03,todd may,PHIL-3200,2019
-PHIL,3210,1,Crime & Punishment,0.38,0.42,0.12,0.04,0.04,0.0,0.0,0.0,daniel wueste,PHIL-3210,2019
-PHIL,3260,1,Science and Values,0.8,0.14,0.03,0.0,0.0,0.0,0.0,0.03,adam pa omelianchuk,PHIL-3260,2019
-PHIL,3300,1,Animal Minds & Animal Ethics,0.62,0.12,0.08,0.0,0.04,0.0,0.0,0.15,adam gies,PHIL-3300,2019
-PHIL,3430,1,Philosophy of Law,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,brookes colyt brown,PHIL-3430,2019
-PHIL,3450,1,Environmental Ethics,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,kelly smith,PHIL-3450,2019
-PHIL,3460,1,Biomedical Ethics,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,charles starkey,PHIL-3460,2019
-PHIL,3990,1,Philosophy Portfolio,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,todd may,PHIL-3990,2019
-PHIL,4010,1,Studies in the Hist of Phil,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,stephen satris,PHIL-4010,2019
-PHIL,4020,1,The Limits of Morality,0.6,0.2,0.07,0.0,0.0,0.0,0.0,0.13,todd may,PHIL-4020,2019
-PHIL,4750,1,Philosophy of Film,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,christopher grau,PHIL-4750,2019
-PHSC,1170,1,Intro Chem & Earth,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,PHSC-1170,2019
-PHYS,1220,1,Physics with Calculus I,0.2,0.35,0.25,0.11,0.04,0.0,0.0,0.05,lih-sin the,PHYS-1220,2019
-PHYS,1220,2,Physics with Calculus I,0.31,0.45,0.18,0.03,0.0,0.0,0.02,0.01,lih-sin the,PHYS-1220,2019
-PHYS,1220,3,Physics with Calculus I,0.28,0.41,0.21,0.05,0.03,0.0,0.0,0.02,pooja puneet,PHYS-1220,2019
-PHYS,1220,4,Physics with Calculus I,0.31,0.43,0.22,0.02,0.03,0.0,0.0,0.0,pooja puneet,PHYS-1220,2019
-PHYS,1220,5,Physics with Calculus I,0.34,0.44,0.16,0.03,0.01,0.0,0.0,0.02,jason stratfo brown,PHYS-1220,2019
-PHYS,1220,8,Physics w/Calculus I (HON),0.63,0.23,0.07,0.0,0.0,0.0,0.0,0.07,ramakrishna podila,PHYS-1220,2019
-PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,2,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,2,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,3,Physics Lab I,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,3,Physics Lab I,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,6,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,6,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,7,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,7,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,8,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,8,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,9,Physics Lab I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,9,Physics Lab I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,11,Physics Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,11,Physics Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,13,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,13,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,14,Physics Lab I,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,14,Physics Lab I,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,15,Physics Lab I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,15,Physics Lab I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,16,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,16,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,17,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,17,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,20,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,20,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,21,Physics Lab I,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,21,Physics Lab I,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,22,Physics Lab I,0.43,0.21,0.14,0.0,0.0,0.0,0.0,0.21,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,22,Physics Lab I,0.43,0.21,0.14,0.0,0.0,0.0,0.0,0.21,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,23,Physics Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,23,Physics Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,25,Physics Lab I,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,25,Physics Lab I,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,26,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,26,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,27,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,27,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,29,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,29,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,30,Physics Lab I,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,30,Physics Lab I,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,31,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,31,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,32,Physics Lab I,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,32,Physics Lab I,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,33,Physics Lab I,0.29,0.53,0.12,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,33,Physics Lab I,0.29,0.53,0.12,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,34,Physics Lab I,0.41,0.41,0.06,0.0,0.0,0.0,0.0,0.12,daniel ros thompson,PHYS-1240,2019
-PHYS,1240,34,Physics Lab I,0.41,0.41,0.06,0.0,0.0,0.0,0.0,0.12,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,35,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,PHYS-1240,2019
-PHYS,1240,35,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-1240,2019
-PHYS,2000,1,Introductory Physics,0.31,0.58,0.11,0.0,0.0,0.0,0.0,0.0,pooja puneet,PHYS-2000,2019
-PHYS,2070,1,General Physics I,0.25,0.2,0.25,0.11,0.13,0.0,0.0,0.07,amy liann pope,PHYS-2070,2019
-PHYS,2070,2,General Physics I,0.23,0.25,0.23,0.1,0.1,0.0,0.0,0.08,amy liann pope,PHYS-2070,2019
-PHYS,2080,1,General Physics II,0.58,0.27,0.09,0.04,0.0,0.0,0.01,0.0,amy liann pope,PHYS-2080,2019
-PHYS,2080,2,General Physics II,0.54,0.35,0.09,0.02,0.0,0.0,0.0,0.0,amy liann pope,PHYS-2080,2019
-PHYS,2080,4,General Physics II,0.53,0.29,0.14,0.04,0.0,0.0,0.0,0.0,amy liann pope,PHYS-2080,2019
-PHYS,2090,1,Gen Phys Lab I,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,2,Gen Phys Lab I,0.58,0.33,0.0,0.04,0.0,0.0,0.0,0.04,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,3,Gen Phys Lab I,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,4,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,5,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,6,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,7,Gen Phys Lab I,0.63,0.29,0.0,0.0,0.0,0.0,0.0,0.08,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,8,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,9,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,PHYS-2090,2019
-PHYS,2090,10,Gen Phys Lab I,0.67,0.25,0.04,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,PHYS-2090,2019
-PHYS,2100,2,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,2,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,3,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,3,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,4,Gen Phys Lab II,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,danielle latham,PHYS-2100,2019
-PHYS,2100,4,Gen Phys Lab II,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,5,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,5,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,6,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,6,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,7,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,7,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,8,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,8,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,9,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,9,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,10,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,10,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,11,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,11,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,13,Gen Phys Lab II,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,13,Gen Phys Lab II,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,14,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,14,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,15,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,15,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,16,Gen Phys Lab II,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,danielle latham,PHYS-2100,2019
-PHYS,2100,16,Gen Phys Lab II,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,17,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,17,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,18,Gen Phys Lab II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,18,Gen Phys Lab II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2100,19,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,PHYS-2100,2019
-PHYS,2100,19,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2100,2019
-PHYS,2210,1,Physics with Calculus II,0.15,0.42,0.29,0.05,0.0,0.0,0.06,0.04,jason stratfo brown,PHYS-2210,2019
-PHYS,2210,2,Physics with Calculus II,0.27,0.37,0.22,0.09,0.0,0.0,0.03,0.02,jason stratfo brown,PHYS-2210,2019
-PHYS,2210,3,Physics w/Calculus II (HON),0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,hugo sanabria,PHYS-2210,2019
-PHYS,2210,5,Physics with Calculus II,0.73,0.0,0.13,0.0,0.07,0.0,0.0,0.07,murray daw,PHYS-2210,2019
-PHYS,2230,2,Physics Lab II,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,yamei liu,PHYS-2230,2019
-PHYS,2230,2,Physics Lab II,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2230,2019
-PHYS,2230,3,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-2230,2019
-PHYS,2230,3,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,PHYS-2230,2019
-PHYS,2230,4,Physics Lab II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2230,2019
-PHYS,2230,4,Physics Lab II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,yamei liu,PHYS-2230,2019
-PHYS,2230,5,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,PHYS-2230,2019
-PHYS,2230,5,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,yamei liu,PHYS-2230,2019
-PHYS,2230,6,Physics Lab II,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,PHYS-2230,2019
-PHYS,2230,6,Physics Lab II,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-2230,2019
-PHYS,2230,7,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-2230,2019
-PHYS,2230,7,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,yamei liu,PHYS-2230,2019
-PHYS,2230,8,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,yamei liu,PHYS-2230,2019
-PHYS,2230,8,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,daniel ros thompson,PHYS-2230,2019
-PHYS,2230,9,Physics Lab II,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,PHYS-2230,2019
-PHYS,2230,9,Physics Lab II,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,PHYS-2230,2019
-PHYS,2400,1,Phys of Weather,0.31,0.35,0.19,0.08,0.04,0.0,0.0,0.04,jens oberheide,PHYS-2400,2019
-PHYS,3110,1,Methods Theor Phys,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,lih-sin the,PHYS-3110,2019
-PHYS,3220,1,Mechanics II,0.28,0.17,0.39,0.11,0.06,0.0,0.0,0.0,stephen ro kaeppler,PHYS-3220,2019
-PHYS,3990,1,CI STEM Competition,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,jason stratfo brown,PHYS-3990,2019
-PHYS,4560,1,Quantum Physics II,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,sumanta tewari,PHYS-4560,2019
-PHYS,4650,1,Thermo and Stat Mech,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,mark leising,PHYS-4650,2019
-PHYS,4750,1,Intro to Cellular Biophysics,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,joshua alper,PHYS-4750,2019
-PHYS,8150,1,Statistical Therm I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,celestine hackett,PHYS-8150,2019
-PHYS,8150,1,Statistical Therm I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,dieter hartmann,PHYS-8150,2019
-PHYS,8410,1,Electrodynamics I,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,feng ding,PHYS-8410,2019
-PHYS,9520,1,Quantum Mech II,0.21,0.57,0.14,0.0,0.07,0.0,0.0,0.0,domnita marinescu,PHYS-9520,2019
-PKSC,1020,1,Intro to Pkg Sci,0.14,0.35,0.28,0.08,0.1,0.0,0.0,0.04,heather batt,PKSC-1020,2019
-PKSC,2010,100,Pkg Perishable Prod,0.07,0.24,0.35,0.17,0.1,0.0,0.0,0.07,heather batt,PKSC-2010,2019
-PKSC,2020,1,Packaging Mtl & Mfg,0.33,0.4,0.2,0.0,0.0,0.0,0.0,0.07,pa guerra marcondes,PKSC-2020,2019
-PKSC,2040,1,Container Systems,0.26,0.48,0.2,0.0,0.03,0.0,0.0,0.03,pa guerra marcondes,PKSC-2040,2019
-PKSC,2060,1,Container Sys Lab,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,pa guerra marcondes,PKSC-2060,2019
-PKSC,2060,2,Container Sys Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,pa guerra marcondes,PKSC-2060,2019
-PKSC,2060,3,Container Sys Lab,0.38,0.54,0.0,0.08,0.0,0.0,0.0,0.0,pa guerra marcondes,PKSC-2060,2019
-PKSC,2200,1,Product & Pkg Design,0.85,0.05,0.03,0.03,0.03,0.0,0.0,0.03,haley ellis appleby,PKSC-2200,2019
-PKSC,3680,400,Pkg and Society,0.29,0.53,0.13,0.0,0.04,0.0,0.0,0.01,heather batt,PKSC-3680,2019
-PKSC,4030,1,Pkg Career Prep,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4030,2019
-PKSC,4200,1,Pkg Design & Dev,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,robert kimmel,PKSC-4200,2019
-PKSC,4300,1,Converting Flex Pkg,0.22,0.65,0.12,0.0,0.01,0.0,0.0,0.0,duncan darby,PKSC-4300,2019
-PKSC,4400,1,Packaging for Distribution,0.25,0.45,0.25,0.03,0.03,0.0,0.0,0.0,gregory batt,PKSC-4400,2019
-PKSC,4400,400,Packaging for Distribution,0.02,0.47,0.29,0.08,0.14,0.0,0.0,0.0,gregory batt,PKSC-4400,2019
-PKSC,4640,1,Food & Health Care Pkg Systems,0.63,0.27,0.1,0.0,0.0,0.0,0.0,0.0,kay cooksey,PKSC-4640,2019
-PKSC,4990,3,CI-Packaging  Sci Seminar,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,rupert hurley,PKSC-4990,2019
-PKSC,8220,1,Packaging Dynamics,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,gregory batt,PKSC-8220,2019
-PLPA,2130,1,Fungi & Civilization,0.34,0.39,0.14,0.06,0.03,0.0,0.0,0.04,julia loui kerrigan,PLPA-2130,2019
-POSC,1010,2,Amer National Govt,0.22,0.44,0.18,0.07,0.04,0.0,0.0,0.04,jeffrey scott peake,POSC-1010,2019
-POSC,1010,3,Amer National Govt,0.42,0.26,0.13,0.06,0.13,0.0,0.0,0.0,robert carey,POSC-1010,2019
-POSC,1010,4,Amer National Govt,0.3,0.33,0.2,0.1,0.0,0.0,0.0,0.07,robert carey,POSC-1010,2019
-POSC,1020,1,Intro Intl Relations,0.34,0.45,0.11,0.01,0.04,0.0,0.0,0.06,steven vince miller,POSC-1020,2019
-POSC,1020,2,Intro Intl Relations,0.3,0.47,0.13,0.03,0.05,0.0,0.0,0.03,aron geo tannenbaum,POSC-1020,2019
-POSC,1020,3,Intro Intl Relations,0.43,0.35,0.19,0.0,0.0,0.0,0.0,0.03,marjorie lo jeffrey,POSC-1020,2019
-POSC,1030,1,Intro to Political Theory,0.67,0.08,0.08,0.17,0.0,0.0,0.0,0.0,jay hoffpauir,POSC-1030,2019
-POSC,1030,2,Intro to Political Theory,0.11,0.67,0.11,0.04,0.0,0.0,0.04,0.04,john ant pascarella,POSC-1030,2019
-POSC,1030,3,Intro to Political Theory,0.3,0.26,0.26,0.0,0.13,0.0,0.0,0.04,marjorie lo jeffrey,POSC-1030,2019
-POSC,1030,4,Intro to Political Theory,0.05,0.15,0.5,0.15,0.1,0.0,0.0,0.05,colin denby pearce,POSC-1030,2019
-POSC,1030,5,Intro to Political Theory,0.38,0.31,0.17,0.0,0.0,0.0,0.0,0.14,kevin gregory vance,POSC-1030,2019
-POSC,1040,1,Intro Compar Pol,0.37,0.26,0.28,0.02,0.0,0.0,0.0,0.07,matthe rhodes-purdy,POSC-1040,2019
-POSC,1990,1,Intro Pol Sci,0.23,0.4,0.15,0.06,0.13,0.0,0.0,0.02,meredith petersheim,POSC-1990,2019
-POSC,3020,1,State and Loc Gov,0.1,0.66,0.15,0.02,0.02,0.0,0.0,0.05,bruce ransom,POSC-3020,2019
-POSC,3050,3,Creative Inq in Political Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,xiaobo hu,POSC-3050,2019
-POSC,3210,1,Public Admin,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,robert carey,POSC-3210,2019
-POSC,3410,1,Quant Meth in Pol Sc,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,ethan craig busby,POSC-3410,2019
-POSC,3430,1,Mass Media in Americ Politics,0.68,0.21,0.06,0.0,0.0,0.0,0.0,0.04,ethan craig busby,POSC-3430,2019
-POSC,3630,1,Us Foreign Policy,0.47,0.38,0.09,0.02,0.0,0.0,0.0,0.04,vladimir matic,POSC-3630,2019
-POSC,3710,615,European Politics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,POSC-3710,2019
-POSC,3810,1,African Amer Politic,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,POSC-3810,2019
-POSC,4050,1,American Presidency,0.0,0.28,0.33,0.11,0.22,0.0,0.0,0.06,adam warber,POSC-4050,2019
-POSC,4080,1,Religion and World Politics,0.38,0.38,0.21,0.0,0.0,0.0,0.0,0.04,laura olson,POSC-4080,2019
-POSC,4160,1,Int Groups & Soc Mov,0.26,0.44,0.19,0.12,0.0,0.0,0.0,0.0,laura olson,POSC-4160,2019
-POSC,4210,1,Public Policy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,POSC-4210,2019
-POSC,4360,1,Law Courts Politics,0.57,0.26,0.17,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,POSC-4360,2019
-POSC,4360,2,Law Courts Politics,0.53,0.42,0.06,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,POSC-4360,2019
-POSC,4370,1,Constitut Law: Rights & Libert,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,kevin gregory vance,POSC-4370,2019
-POSC,4370,2,Constitut Law: Rights & Libert,0.7,0.18,0.06,0.0,0.0,0.0,0.0,0.06,kevin gregory vance,POSC-4370,2019
-POSC,4470,1,International Law,0.33,0.17,0.21,0.13,0.13,0.0,0.0,0.04,katherine am curtis,POSC-4470,2019
-POSC,4480,615,Internat'l Political Economy,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,POSC-4480,2019
-POSC,4500,1,Conservatism,0.33,0.33,0.29,0.0,0.0,0.0,0.0,0.05,brandon turner,POSC-4500,2019
-POSC,4530,1,American Political Thought,0.41,0.46,0.11,0.0,0.0,0.0,0.0,0.02,colin denby pearce,POSC-4530,2019
-POSC,4710,1,Russian Politics,0.33,0.49,0.13,0.0,0.02,0.0,0.0,0.02,aron geo tannenbaum,POSC-4710,2019
-POSC,4760,1,Middle East Politics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,POSC-4760,2019
-POSC,4770,1,Chinese Politics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,xiaobo hu,POSC-4770,2019
-POSC,4890,615,Post Conflict Pol. & Society,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,POSC-4890,2019
-POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,meredith petersheim,POSC-4990,2019
-PRTM,2200,1,Foundations of PRTM,0.19,0.5,0.23,0.08,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2200,2019
-PRTM,2270,1,Prov of Leisure Exp,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,PRTM-2270,2019
-PRTM,2270,1,Prov of Leisure Exp,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2270,2019
-PRTM,2290,1,Competency Integration in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,PRTM-2290,2019
-PRTM,2290,1,Competency Integration in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-2290,2019
-PRTM,2410,1,Intro to CRSCM,0.39,0.26,0.26,0.06,0.0,0.0,0.0,0.03,jamie lynn cathey,PRTM-2410,2019
-PRTM,2410,2,Intro to CRSCM,0.23,0.27,0.2,0.1,0.0,0.0,0.1,0.1,jamie lynn cathey,PRTM-2410,2019
-PRTM,2600,1,Found of Recreational Therapy,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,brandi crowe,PRTM-2600,2019
-PRTM,2700,1,Intro Rec Res Mgt,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,PRTM-2700,2019
-PRTM,2810,1,Intro to Golf Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,PRTM-2810,2019
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,daniel mor anderson,PRTM-3050,2019
-PRTM,3070,1,Facility Operations,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,raymond dunham,PRTM-3070,2019
-PRTM,3210,1,Recreation Admin,0.4,0.34,0.14,0.09,0.0,0.0,0.0,0.03,jamie lynn cathey,PRTM-3210,2019
-PRTM,3210,2,Recreation Admin,0.18,0.61,0.12,0.03,0.03,0.0,0.0,0.03,jamie lynn cathey,PRTM-3210,2019
-PRTM,3250,1,Global Persp in Rec,0.2,0.16,0.4,0.04,0.16,0.0,0.0,0.04,harrison pinckney,PRTM-3250,2019
-PRTM,3250,2,Global Persp in Rec,0.5,0.25,0.14,0.07,0.04,0.0,0.0,0.0,harrison pinckney,PRTM-3250,2019
-PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,PRTM-3260,2019
-PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,heather sext torphy,PRTM-3270,2019
-PRTM,3420,1,Intro to Tourism,0.89,0.09,0.03,0.0,0.0,0.0,0.0,0.0,katherine dudley,PRTM-3420,2019
-PRTM,3420,2,Intro to Tourism,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,peter marwa ezra,PRTM-3420,2019
-PRTM,3430,1,Spl Asp of Tourist B,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,kenneth backman,PRTM-3430,2019
-PRTM,3440,1,Tourism Markets,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,sheila backman,PRTM-3440,2019
-PRTM,3440,2,Tourism Markets,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,sheila backman,PRTM-3440,2019
-PRTM,3450,1,Tourism Management,0.41,0.48,0.1,0.0,0.0,0.0,0.0,0.0,william norman,PRTM-3450,2019
-PRTM,3450,2,Tourism Management,0.42,0.56,0.0,0.0,0.0,0.0,0.0,0.03,william norman,PRTM-3450,2019
-PRTM,3460,1,Heritage Tourism,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,PRTM-3460,2019
-PRTM,3460,2,Heritage Tourism,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,gregory phi ramshaw,PRTM-3460,2019
-PRTM,3530,2,Foundations of Camp Counseling,0.7,0.07,0.07,0.03,0.03,0.0,0.0,0.1,gwynn powell,PRTM-3530,2019
-PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,alexsandra dubin,PRTM-3540,2019
-PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,gwynn powell,PRTM-3540,2019
-PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,lisa kay-powl olsen,PRTM-3540,2019
-PRTM,3900,1,PGA GM Player Development,0.56,0.31,0.0,0.13,0.0,0.0,0.0,0.0,richard lucas,PRTM-3900,2019
-PRTM,3900,1,PGA GM Player Development,0.56,0.31,0.0,0.13,0.0,0.0,0.0,0.0,adam savedra,PRTM-3900,2019
-PRTM,4300,1,World Geog Parks,0.76,0.16,0.06,0.0,0.0,0.0,0.0,0.02,tori kleinbort,PRTM-4300,2019
-PRTM,4460,2,Community Tourism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lauren duffy,PRTM-4460,2019
-PRTM,4540,1,Trends in Sport Mgt,0.61,0.22,0.13,0.04,0.0,0.0,0.0,0.0,skye arthur-banning,PRTM-4540,2019
-PRTM,4980,1,Creative Inquiry in PRTM IV,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,katrina latri black,PRTM-4980,2019
-PRTM,4980,1,Creative Inquiry in PRTM IV,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard lucas,PRTM-4980,2019
-PRTM,4980,17,Creative Inquiry in PRTM IV,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,skye arthur-banning,PRTM-4980,2019
-PRTM,4980,18,Creative Inquiry in PRTM IV,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,skye arthur-banning,PRTM-4980,2019
-PRTM,8030,1,Sem Rec & Park Admin,0.67,0.24,0.0,0.0,0.05,0.0,0.0,0.05,skye arthur-banning,PRTM-8030,2019
-PRTM,8110,2,Research Methods,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,rose irene verbos,PRTM-8110,2019
-PRTM,8130,1,Qualitative Research Methods,0.93,0.0,0.04,0.0,0.0,0.0,0.04,0.0,elizabeth baldwin,PRTM-8130,2019
-PRTM,8210,1,Funding Strategies in PRTM,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,PRTM-8210,2019
-PRTM,8250,1,Populations in PRTM,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,PRTM-8250,2019
-PRTM,8440,1,Outdoor Rec Mgt Plng,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,raymond bivens,PRTM-8440,2019
-PRTM,8720,1,Adv Facilitation Techniq in RT,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,PRTM-8720,2019
-PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,PRTM-8730,2019
-PSYC,2010,1,Intro to Psychology,0.33,0.36,0.2,0.06,0.02,0.0,0.0,0.03,jo jorgensen,PSYC-2010,2019
-PSYC,2010,2,Intro to Psychology,0.29,0.26,0.19,0.11,0.1,0.0,0.0,0.05,edwin brainerd,PSYC-2010,2019
-PSYC,2010,3,Intro to Psychology,0.4,0.41,0.13,0.03,0.01,0.0,0.0,0.01,mary taylor,PSYC-2010,2019
-PSYC,2010,4,Intro to Psychology,0.46,0.3,0.09,0.09,0.01,0.0,0.0,0.04,mary taylor,PSYC-2010,2019
-PSYC,2010,6,Intro to Psychology,0.61,0.19,0.09,0.03,0.04,0.0,0.0,0.04,fred switzer,PSYC-2010,2019
-PSYC,2010,7,Intro to Psychology (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,PSYC-2010,2019
-PSYC,2890,1,Fundamentals of Psyc Science,0.55,0.33,0.08,0.01,0.01,0.0,0.0,0.01,peggy jean tyler,PSYC-2890,2019
-PSYC,3060,1,Human Sexual Behavior,0.52,0.24,0.15,0.04,0.03,0.0,0.0,0.02,bruce michael king,PSYC-3060,2019
-PSYC,3090,100,Intro Experimental Psychology,0.51,0.27,0.15,0.03,0.03,0.0,0.0,0.01,jennifer bai bisson,PSYC-3090,2019
-PSYC,3090,200,Intro Experimental Psychology,0.28,0.36,0.24,0.07,0.04,0.0,0.0,0.01,richard tyrrell,PSYC-3090,2019
-PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,michael shreeves,PSYC-3100,2019
-PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,jennifer bai bisson,PSYC-3100,2019
-PSYC,3100,200,Advanced Experimental Psych,0.39,0.44,0.11,0.0,0.06,0.0,0.0,0.0,eric mckibben,PSYC-3100,2019
-PSYC,3100,300,Advanced Experimental Psych,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,joseph ligato,PSYC-3100,2019
-PSYC,3100,300,Advanced Experimental Psych,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,robert ray sinclair,PSYC-3100,2019
-PSYC,3100,400,Advanced Experimental Psych,0.57,0.24,0.14,0.0,0.0,0.0,0.0,0.05,benjamin stephens,PSYC-3100,2019
-PSYC,3100,500,Advanced Experimental Psych,0.38,0.38,0.19,0.05,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2019
-PSYC,3100,600,Advanced Experimental Psych,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,PSYC-3100,2019
-PSYC,3100,700,Advanced Experimental Psych,0.55,0.32,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,PSYC-3100,2019
-PSYC,3240,1,Physiological Psych,0.43,0.27,0.2,0.09,0.0,0.0,0.0,0.01,claudio cantalupo,PSYC-3240,2019
-PSYC,3240,2,Physiological Psych,0.42,0.33,0.15,0.06,0.0,0.0,0.0,0.04,claudio cantalupo,PSYC-3240,2019
-PSYC,3330,1,Cognitive Psych,0.33,0.4,0.17,0.03,0.0,0.0,0.0,0.06,robert campbell,PSYC-3330,2019
-PSYC,3330,2,Cognitive Psych,0.67,0.26,0.03,0.01,0.01,0.0,0.0,0.01,kaileigh ange byrne,PSYC-3330,2019
-PSYC,3330,3,Cognitive Psych,0.51,0.32,0.12,0.03,0.01,0.0,0.0,0.01,daniel braden quinn,PSYC-3330,2019
-PSYC,3340,1,Cognitive Psych Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kathryn lucaites,PSYC-3340,2019
-PSYC,3340,2,Cognitive Psych Lab,0.62,0.14,0.19,0.0,0.0,0.0,0.0,0.05,kathryn lucaites,PSYC-3340,2019
-PSYC,3400,1,Lifespan Developmental Psych,0.25,0.38,0.2,0.09,0.0,0.0,0.0,0.08,pamela alley,PSYC-3400,2019
-PSYC,3400,2,Lifespan Developmental Psych,0.32,0.37,0.21,0.07,0.03,0.0,0.0,0.0,anita pei tam,PSYC-3400,2019
-PSYC,3520,1,Social Psychology,0.51,0.32,0.12,0.01,0.01,0.0,0.0,0.01,ceren gunsoy,PSYC-3520,2019
-PSYC,3520,2,Social Psychology,0.37,0.37,0.16,0.09,0.0,0.0,0.0,0.0,jo jorgensen,PSYC-3520,2019
-PSYC,3520,3,Social Psychology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-3520,2019
-PSYC,3570,1,Psychology and Culture,0.56,0.18,0.18,0.05,0.02,0.0,0.0,0.02,ceren gunsoy,PSYC-3570,2019
-PSYC,3640,1,Industrial Psych,0.15,0.37,0.4,0.08,0.0,0.0,0.0,0.0,eric mckibben,PSYC-3640,2019
-PSYC,3640,2,Industrial Psych,0.28,0.35,0.29,0.06,0.01,0.0,0.0,0.01,eric mckibben,PSYC-3640,2019
-PSYC,3680,1,Organizational Psych,0.69,0.24,0.03,0.01,0.01,0.0,0.0,0.01,anton sytine,PSYC-3680,2019
-PSYC,3700,1,Personality,0.54,0.32,0.09,0.01,0.03,0.0,0.0,0.01,john robert hester,PSYC-3700,2019
-PSYC,3770,1,Psych of Group & Team Dynamics,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,marissa leig porter,PSYC-3770,2019
-PSYC,3830,1,Abnormal Psychology,0.3,0.49,0.16,0.04,0.01,0.0,0.0,0.01,cynthia pury,PSYC-3830,2019
-PSYC,3830,2,Abnormal Psychology,0.4,0.31,0.24,0.06,0.0,0.0,0.0,0.0,jo jorgensen,PSYC-3830,2019
-PSYC,3830,3,Abnormal Psychology,0.24,0.35,0.29,0.03,0.0,0.0,0.06,0.03,pamela alley,PSYC-3830,2019
-PSYC,3830,4,Abnormal Psychology,0.17,0.33,0.33,0.13,0.0,0.0,0.0,0.03,pamela alley,PSYC-3830,2019
-PSYC,4080,1,Women and Psychology,0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,robin mari kowalski,PSYC-4080,2019
-PSYC,4150,1,Systems and Theories,0.24,0.39,0.18,0.06,0.0,0.0,0.0,0.12,robert campbell,PSYC-4150,2019
-PSYC,4150,2,Systems and Theories,0.29,0.18,0.21,0.24,0.09,0.0,0.0,0.0,edwin brainerd,PSYC-4150,2019
-PSYC,4150,3,Systems and Theories,0.33,0.3,0.09,0.09,0.15,0.0,0.0,0.03,edwin brainerd,PSYC-4150,2019
-PSYC,4150,4,Systems and Theories,0.71,0.17,0.06,0.0,0.03,0.0,0.0,0.03,zachary klinefelter,PSYC-4150,2019
-PSYC,4220,1,Perception,0.55,0.09,0.05,0.23,0.0,0.0,0.0,0.09,claudio cantalupo,PSYC-4220,2019
-PSYC,4220,2,Perception,0.2,0.4,0.24,0.12,0.04,0.0,0.0,0.0,christopher pagano,PSYC-4220,2019
-PSYC,4220,3,Perception,0.3,0.17,0.39,0.04,0.04,0.0,0.0,0.04,claudio cantalupo,PSYC-4220,2019
-PSYC,4350,1,Human Factors,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,laura whitlock,PSYC-4350,2019
-PSYC,4710,1,Psych of Testing,0.61,0.17,0.09,0.0,0.04,0.0,0.0,0.09,zhuo chen,PSYC-4710,2019
-PSYC,4800,1,Health Psychology,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,james mccubbin,PSYC-4800,2019
-PSYC,4800,2,Health Psychology,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,james mccubbin,PSYC-4800,2019
-PSYC,4880,1,Psychotherapy,0.41,0.18,0.24,0.06,0.06,0.0,0.0,0.06,heidi marie zinzow,PSYC-4880,2019
-PSYC,4890,1,Organizational Stress,0.75,0.0,0.08,0.0,0.0,0.0,0.0,0.17,chelsea aly lenoble,PSYC-4890,2019
-PSYC,4890,2,Sports Psychology,0.29,0.41,0.24,0.06,0.0,0.0,0.0,0.0,anita pei tam,PSYC-4890,2019
-PSYC,4920,1,Senior Laboratory,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,chloe wilson,PSYC-4920,2019
-PSYC,4920,2,Senior Laboratory,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,chloe wilson,PSYC-4920,2019
-PSYC,4920,3,Senior Laboratory,0.46,0.42,0.04,0.04,0.04,0.0,0.0,0.0,chloe wilson,PSYC-4920,2019
-PSYC,4930,100,Pract Clinical Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,PSYC-4930,2019
-PSYC,4980,31,Autism Research,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,jennifer bai bisson,PSYC-4980,2019
-PSYC,4980,33,Autism Research II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jennifer bai bisson,PSYC-4980,2019
-PSYC,4980,121,Stress and Health,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james mccubbin,PSYC-4980,2019
-PSYC,4980,251,Critical Thinking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,benjamin stephens,PSYC-4980,2019
-PSYC,4980,291,Suicide Prevention,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,martha par thompson,PSYC-4980,2019
-PSYC,4980,291,Suicide Prevention,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,heidi marie zinzow,PSYC-4980,2019
-PSYC,8130,1,Research Design III,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,patrick rosopa,PSYC-8130,2019
-PSYC,8140,1,Quantitative Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,patrick rosopa,PSYC-8140,2019
-PSYC,8630,1,Work Motivation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,fred switzer,PSYC-8630,2019
-RED,8030,1,Pub-Priv Partnership,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,stephen tho buckman,RED-8030,2019
-RED,8160,1,Preservation Feasibility,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,RED-8160,2019
-RED,8890,1,Selected Topics-Entitlement Pr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,thomas andr sherard,RED-8890,2019
-RED,8890,1,Selected Topics-Entitlement Pr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,RED-8890,2019
-RED,8890,2,Selected Topics-Construction O,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,andrew tay norville,RED-8890,2019
-REL,1010,1,Intro to Religion,0.21,0.32,0.29,0.03,0.06,0.0,0.0,0.09,peter cohen,REL-1010,2019
-REL,1010,2,Intro to Religion,0.38,0.29,0.18,0.09,0.03,0.0,0.0,0.03,peter cohen,REL-1010,2019
-REL,1010,3,Intro to Religion,0.2,0.51,0.2,0.06,0.03,0.0,0.0,0.0,peter cohen,REL-1010,2019
-REL,1020,2,World Religions,0.24,0.41,0.32,0.0,0.0,0.0,0.0,0.03,robert stephens,REL-1020,2019
-REL,1020,3,World Religions,0.33,0.36,0.27,0.0,0.03,0.0,0.0,0.0,robert stephens,REL-1020,2019
-REL,1020,4,World Religions,0.26,0.48,0.13,0.0,0.03,0.0,0.0,0.1,robert stephens,REL-1020,2019
-REL,3000,1,Studying Religion,0.41,0.38,0.17,0.0,0.0,0.0,0.0,0.03,benjamin white,REL-3000,2019
-REL,3010,1,Old Testament,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,REL-3010,2019
-REL,3020,1,New Testament Lit,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,benjamin white,REL-3020,2019
-REL,3030,1,The Quran,0.22,0.59,0.11,0.0,0.04,0.0,0.0,0.04,mashal saif,REL-3030,2019
-REL,3070,1,The Christian Tradition,0.17,0.59,0.1,0.0,0.0,0.0,0.0,0.14,brett patterson,REL-3070,2019
-REL,3100,1,History of Religion in the US,0.28,0.44,0.11,0.06,0.0,0.0,0.0,0.11,elizabeth jemison,REL-3100,2019
-REL,3170,1,Hist of Native Am Rel/Culture,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,james brad jeffries,REL-3170,2019
-REL,3350,1,Islam and the West,0.58,0.17,0.08,0.0,0.08,0.0,0.0,0.08,mashal saif,REL-3350,2019
-REL,3510,1,Ancient Near East,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,steven grosby,REL-3510,2019
-RS,4590,1,The Community,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,RS-4590,2019
-RUD,8640,1,Urban Design Seminar II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,broo wortham-galvin,RUD-8640,2019
-RUD,8650,1,Urban Design Vis & Comm II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,chelsea ma anderson,RUD-8650,2019
-RUD,8650,1,Urban Design Vis & Comm II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,broo wortham-galvin,RUD-8650,2019
-RUSS,1020,1,Elementary Russian,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,stephanie el morris,RUSS-1020,2019
-SOC,2010,2,Introduction to Sociology,0.58,0.3,0.1,0.0,0.01,0.0,0.0,0.01,carolyn can coffman,SOC-2010,2019
-SOC,2010,3,Introduction to Sociology,0.88,0.1,0.0,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,SOC-2010,2019
-SOC,2010,4,Introduction to Sociology,0.57,0.33,0.08,0.01,0.01,0.0,0.0,0.01,shannon mcdonough,SOC-2010,2019
-SOC,2010,5,Introduction to Sociology,0.49,0.4,0.09,0.01,0.0,0.0,0.0,0.01,shannon mcdonough,SOC-2010,2019
-SOC,2040,1,Prof Dev for Sociology Majors,0.5,0.25,0.09,0.09,0.06,0.0,0.0,0.0, catherine mobley,SOC-2040,2019
-SOC,3020,1,Research Methods I,0.31,0.47,0.12,0.02,0.02,0.0,0.0,0.06,miao li,SOC-3020,2019
-SOC,3040,1,Social Research Methods II,0.32,0.34,0.24,0.08,0.0,0.0,0.0,0.03,ye luo,SOC-3040,2019
-SOC,3100,1,Marriage & Intimacy,0.68,0.21,0.09,0.0,0.02,0.0,0.0,0.0,carolyn can coffman,SOC-3100,2019
-SOC,3110,1,The Family,0.37,0.47,0.1,0.02,0.02,0.0,0.0,0.02,andrew whitehead,SOC-3110,2019
-SOC,3310,1,Urban Sociology,0.7,0.15,0.07,0.0,0.0,0.0,0.0,0.07,william haller,SOC-3310,2019
-SOC,3500,1,Self & Society,0.67,0.19,0.07,0.05,0.0,0.0,0.0,0.02,carolyn can coffman,SOC-3500,2019
-SOC,3600,1,Class & Poverty,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,kenneth robinson,SOC-3600,2019
-SOC,3800,1,Intro Social Service,0.69,0.22,0.04,0.02,0.02,0.0,0.0,0.0,jennifer le holland,SOC-3800,2019
-SOC,3910,1,Soc of Deviance,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,SOC-3910,2019
-SOC,3920,1,Juvenile Delinquency,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,SOC-3920,2019
-SOC,4040,1,Soc Theory,0.55,0.15,0.25,0.05,0.0,0.0,0.0,0.0,william haller,SOC-4040,2019
-SOC,4320,1,Soc of Religion,0.25,0.41,0.3,0.0,0.0,0.0,0.0,0.05,andrew whitehead,SOC-4320,2019
-SOC,4590,1,The Community,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,kenneth robinson,SOC-4590,2019
-SOC,4600,1,Race & Ethnicity,0.74,0.19,0.05,0.0,0.0,0.0,0.0,0.02,andrew mannheimer,SOC-4600,2019
-SOC,4610,1,Sex & Gender,0.74,0.17,0.04,0.0,0.02,0.0,0.0,0.02,heather kettrey,SOC-4610,2019
-SOC,4800,1,Medical Sociology,0.58,0.17,0.08,0.08,0.0,0.0,0.0,0.08,miao li,SOC-4800,2019
-SOC,4840,1,Child Abuse,0.84,0.1,0.02,0.02,0.0,0.0,0.0,0.02,james rosenberger,SOC-4840,2019
-SOC,4860,1,CI in SOC: Youth Rel Violence,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,carolyn can coffman,SOC-4860,2019
-SOC,4950,1,Field Experience,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jennifer le holland,SOC-4950,2019
-SOC,8050,1,Evaluation Research,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0, catherine mobley,SOC-8050,2019
-SPAN,1010,1,Elementary Spanish,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,rosa mac pillcurima,SPAN-1010,2019
-SPAN,1010,2,Elementary Spanish,0.43,0.35,0.09,0.09,0.0,0.0,0.0,0.04,rosa mac pillcurima,SPAN-1010,2019
-SPAN,1010,3,Elementary Spanish,0.38,0.17,0.13,0.08,0.08,0.0,0.0,0.17,rosa mac pillcurima,SPAN-1010,2019
-SPAN,1020,2,Elementary Spanish,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,andrea patr naranjo,SPAN-1020,2019
-SPAN,1020,3,Elementary Spanish,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-1020,2019
-SPAN,1020,4,Elementary Spanish,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,rosa mac pillcurima,SPAN-1020,2019
-SPAN,1020,5,Elementary Spanish,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-1020,2019
-SPAN,1020,6,Elementary Spanish,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,SPAN-1020,2019
-SPAN,1020,7,Elementary Spanish,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-1020,2019
-SPAN,1020,8,Elementary Spanish,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-1020,2019
-SPAN,1020,9,Elementary Spanish,0.33,0.5,0.0,0.0,0.08,0.0,0.0,0.08,debra oa williamson,SPAN-1020,2019
-SPAN,1020,10,Elementary Spanish,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-1020,2019
-SPAN,2010,1,Intermediate Spanish,0.82,0.09,0.05,0.05,0.0,0.0,0.0,0.0,mercedes tejera,SPAN-2010,2019
-SPAN,2010,2,Intermediate Spanish,0.88,0.0,0.04,0.0,0.04,0.0,0.0,0.04,mercedes tejera,SPAN-2010,2019
-SPAN,2010,3,Intermediate Spanish,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,andrea patr naranjo,SPAN-2010,2019
-SPAN,2010,4,Intermediate Spanish,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,liliana hernandez,SPAN-2010,2019
-SPAN,2010,5,Intermediate Spanish,0.64,0.24,0.04,0.0,0.0,0.0,0.0,0.08,liliana hernandez,SPAN-2010,2019
-SPAN,2010,6,Intermediate Spanish,0.23,0.55,0.09,0.05,0.0,0.0,0.0,0.09,melva margu persico,SPAN-2010,2019
-SPAN,2010,7,Intermediate Spanish,0.3,0.57,0.09,0.04,0.0,0.0,0.0,0.0,melva margu persico,SPAN-2010,2019
-SPAN,2010,8,Intermediate Spanish,0.55,0.2,0.1,0.05,0.1,0.0,0.0,0.0,mari judez riquelme,SPAN-2010,2019
-SPAN,2010,9,Intermediate Spanish,0.72,0.16,0.04,0.0,0.0,0.0,0.0,0.08,mari judez riquelme,SPAN-2010,2019
-SPAN,2010,10,Intermediate Spanish,0.6,0.24,0.16,0.0,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2019
-SPAN,2010,11,Intermediate Spanish,0.65,0.22,0.04,0.09,0.0,0.0,0.0,0.0,ellory schmucker,SPAN-2010,2019
-SPAN,2010,12,Intermediate Spanish,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,SPAN-2010,2019
-SPAN,2010,13,Intermediate Spanish,0.6,0.25,0.05,0.05,0.0,0.0,0.0,0.05,debra oa williamson,SPAN-2010,2019
-SPAN,2020,2,Intermediate Spanish,0.39,0.39,0.11,0.0,0.0,0.0,0.0,0.11,juana martin-armas,SPAN-2020,2019
-SPAN,2020,3,Intermediate Spanish,0.38,0.29,0.24,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,SPAN-2020,2019
-SPAN,2020,4,Intermediate Spanish,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,SPAN-2020,2019
-SPAN,2020,5,Intermediate Spanish,0.4,0.52,0.08,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-2020,2019
-SPAN,2020,6,Intermediate Spanish,0.56,0.32,0.08,0.0,0.04,0.0,0.0,0.0,danie garcia vieyra,SPAN-2020,2019
-SPAN,2020,7,Intermediate Spanish,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,ana paula  miller,SPAN-2020,2019
-SPAN,2020,8,Intermediate Spanish,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,ana paula  miller,SPAN-2020,2019
-SPAN,2020,9,Intermediate Spanish,0.14,0.64,0.14,0.0,0.0,0.0,0.0,0.09,ana paula  miller,SPAN-2020,2019
-SPAN,2020,10,Intermediate Spanish,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,al garcia rodriguez,SPAN-2020,2019
-SPAN,2020,11,Intermediate Spanish,0.52,0.32,0.04,0.04,0.0,0.0,0.0,0.08,al garcia rodriguez,SPAN-2020,2019
-SPAN,2020,12,Intermediate Spanish,0.45,0.41,0.14,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2019
-SPAN,2020,13,Intermediate Spanish,0.48,0.4,0.08,0.0,0.0,0.0,0.0,0.04,adrienne eliza fama,SPAN-2020,2019
-SPAN,2020,14,Intermediate Spanish,0.48,0.36,0.08,0.08,0.0,0.0,0.0,0.0,adrienne eliza fama,SPAN-2020,2019
-SPAN,2020,20,Intermediate Spanish,0.92,0.0,0.04,0.04,0.0,0.0,0.0,0.0,mercedes tejera,SPAN-2020,2019
-SPAN,3010,1,Spanish Comp for Health Prof,0.47,0.4,0.07,0.07,0.0,0.0,0.0,0.0,tiffany dawn miller,SPAN-3010,2019
-SPAN,3020,1,Intermed Span Grammar & Comp,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,SPAN-3020,2019
-SPAN,3020,2,Intermed Span Grammar & Comp,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,melva margu persico,SPAN-3020,2019
-SPAN,3020,3,Intermed Span Grammar & Comp,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,SPAN-3020,2019
-SPAN,3040,2,Intro Hispanic Literary Forms,0.88,0.04,0.04,0.0,0.04,0.0,0.0,0.0,george palacios,SPAN-3040,2019
-SPAN,3050,3,Intermed Span Convers/Comp I,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-3050,2019
-SPAN,3050,4,Intermed Span Convers/Comp I,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-3050,2019
-SPAN,3070,1,The Hispanic World: Spain,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,SPAN-3070,2019
-SPAN,3070,35,The Hispanic World: Spain,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-3070,2019
-SPAN,3080,1,The Hispanic World: Latin Amer,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,tiffany dawn miller,SPAN-3080,2019
-SPAN,3080,2,The Hispanic World: Latin Amer,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,SPAN-3080,2019
-SPAN,3080,30,The Hispanic World: Latin Amer,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,danie garcia vieyra,SPAN-3080,2019
-SPAN,3130,1,Span Lit Survey I,0.3,0.4,0.2,0.0,0.0,0.0,0.0,0.1,mon rojas-de-massei,SPAN-3130,2019
-SPAN,3160,35,Spanish for Int'l Business I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-3160,2019
-SPAN,4030,1,Span Amer Wom Writer,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,SPAN-4030,2019
-SPAN,4060,1,Narrative Fiction,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,SPAN-4060,2019
-SPAN,4070,1,Hispanic Film,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,salvador oropesa,SPAN-4070,2019
-SPAN,4160,35,Spanish for Int'l Trade II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-4160,2019
-SPAN,4190,35,Health & Hispanic Community,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,SPAN-4190,2019
-STAT,2220,1,Statistics in Everyday Life,0.31,0.44,0.1,0.09,0.04,0.0,0.0,0.01,james espey,STAT-2220,2019
-STAT,2220,2,Statistics in Everyday Life,0.47,0.29,0.17,0.03,0.0,0.0,0.0,0.04,james espey,STAT-2220,2019
-STAT,2220,3,Statistics in Everyday Life,0.48,0.36,0.09,0.05,0.02,0.0,0.0,0.0,james espey,STAT-2220,2019
-STAT,2220,4,Statistics in Everyday Life,0.31,0.44,0.16,0.04,0.04,0.0,0.0,0.0,james espey,STAT-2220,2019
-STAT,2220,5,Statistics in Everyday Life,0.4,0.38,0.17,0.04,0.02,0.0,0.0,0.0,ros martinez-dawson,STAT-2220,2019
-STAT,2220,6,Statistics in Everyday Life,0.31,0.36,0.08,0.13,0.08,0.0,0.0,0.05,ros martinez-dawson,STAT-2220,2019
-STAT,2220,7,Statistics in Everyday Life,0.35,0.34,0.15,0.04,0.04,0.0,0.0,0.07,ros martinez-dawson,STAT-2220,2019
-STAT,2300,1,Statistical Methods I,0.09,0.31,0.29,0.11,0.13,0.0,0.0,0.08,morgan elston,STAT-2300,2019
-STAT,2300,2,Statistical Methods I,0.39,0.28,0.18,0.08,0.03,0.0,0.0,0.04,christy jenki brown,STAT-2300,2019
-STAT,2300,3,Statistical Methods I,0.25,0.36,0.15,0.15,0.06,0.0,0.0,0.04, erwin walker,STAT-2300,2019
-STAT,2300,4,Statistical Methods I,0.21,0.41,0.19,0.09,0.08,0.0,0.0,0.03, erwin walker,STAT-2300,2019
-STAT,2300,5,Statistical Methods I,0.37,0.33,0.21,0.06,0.01,0.0,0.0,0.02,sharon marie evans,STAT-2300,2019
-STAT,2300,6,Statistical Methods I,0.39,0.34,0.15,0.07,0.02,0.0,0.0,0.03,sharon marie evans,STAT-2300,2019
-STAT,2300,100,Statistical Methods I (HON),0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,christy jenki brown,STAT-2300,2019
-STAT,3090,1,Introductory Business Stats,0.35,0.41,0.15,0.0,0.06,0.0,0.0,0.03,anna marie vagnozzi,STAT-3090,2019
-STAT,3090,2,Introductory Business Stats,0.45,0.36,0.09,0.06,0.03,0.0,0.0,0.0,kristina gorsline,STAT-3090,2019
-STAT,3090,3,Introductory Business Stats,0.44,0.25,0.19,0.06,0.03,0.0,0.0,0.03,alan robert hahn,STAT-3090,2019
-STAT,3090,4,Introductory Business Stats,0.27,0.45,0.21,0.0,0.0,0.0,0.0,0.06,trevor squires,STAT-3090,2019
-STAT,3090,5,Introductory Business Stats,0.28,0.28,0.28,0.03,0.06,0.0,0.0,0.06,yidan guo,STAT-3090,2019
-STAT,3090,6,Introductory Business Stats,0.39,0.23,0.13,0.03,0.16,0.0,0.0,0.06,yiren ding,STAT-3090,2019
-STAT,3090,7,Introductory Business Stats,0.37,0.26,0.23,0.06,0.03,0.0,0.0,0.06,paran rebeka norton,STAT-3090,2019
-STAT,3090,8,Introductory Business Stats,0.21,0.21,0.24,0.18,0.09,0.0,0.0,0.09,michael thoma cowen,STAT-3090,2019
-STAT,3090,9,Introductory Business Stats,0.18,0.24,0.26,0.18,0.09,0.0,0.0,0.06,sean wal ingimarson,STAT-3090,2019
-STAT,3090,10,Introductory Business Stats,0.38,0.32,0.12,0.09,0.06,0.0,0.0,0.03,zhengxin wang,STAT-3090,2019
-STAT,3090,11,Introductory Business Stats,0.24,0.25,0.31,0.1,0.0,0.0,0.07,0.03,april thomas,STAT-3090,2019
-STAT,3090,12,Introductory Business Stats,0.37,0.29,0.24,0.08,0.0,0.0,0.01,0.0,april thomas,STAT-3090,2019
-STAT,3090,13,Introductory Business Stats,0.29,0.21,0.21,0.18,0.03,0.0,0.0,0.09,xueheng shi,STAT-3090,2019
-STAT,3090,14,Introductory Business Stats,0.32,0.24,0.21,0.09,0.0,0.0,0.15,0.0,fun choi john chan,STAT-3090,2019
-STAT,3090,15,Introductory Business Stats,0.41,0.41,0.12,0.0,0.03,0.0,0.0,0.03,john char nicholson,STAT-3090,2019
-STAT,3300,1,Statistical Methods II,0.44,0.17,0.22,0.06,0.0,0.0,0.0,0.11,ros martinez-dawson,STAT-3300,2019
-STAT,4020,1,Intro to Statistical Computing,0.7,0.1,0.1,0.0,0.05,0.0,0.0,0.05,ellen hepfe breazel,STAT-4020,2019
-STAT,4020,401,Intro to Statistical Computing,0.38,0.31,0.13,0.0,0.0,0.0,0.0,0.19,ellen hepfe breazel,STAT-4020,2019
-STAT,4110,1,Stat Mthds for Process Control,0.62,0.32,0.05,0.0,0.0,0.0,0.0,0.0,william bridges,STAT-4110,2019
-STAT,4110,2,Stat Mthds for Process Control,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard stev dubsky,STAT-4110,2019
-STAT,4110,3,Stat Mthds for Process Control,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,richard stev dubsky,STAT-4110,2019
-STAT,6020,1,Intro to Statistical Computing,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ellen hepfe breazel,STAT-6020,2019
-STAT,6020,401,Intro to Statistical Computing,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,ellen hepfe breazel,STAT-6020,2019
-STAT,8010,2,Statistical Methods I,0.57,0.39,0.0,0.0,0.0,0.0,0.0,0.04,william bridges,STAT-8010,2019
-STAT,8010,3,Statistical Methods I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,deborah eliz kunkel,STAT-8010,2019
-STAT,8010,4,Statistical Methods I,0.61,0.0,0.11,0.0,0.17,0.0,0.0,0.11,jun luo,STAT-8010,2019
-STAT,8010,5,Statistical Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,STAT-8010,2019
-STAT,8010,400,Statistical Methods I,0.41,0.55,0.0,0.0,0.0,0.0,0.0,0.03,brook thaye russell,STAT-8010,2019
-STAT,8010,400,Statistical Methods I,0.41,0.55,0.0,0.0,0.0,0.0,0.0,0.03,deborah eliz kunkel,STAT-8010,2019
-STAT,8050,1,Design & Anlys of Experiments,0.56,0.22,0.04,0.0,0.0,0.0,0.0,0.19,patrick gerard,STAT-8050,2019
-STS,1010,1,Survey Sci & Techn in Society,0.63,0.34,0.0,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,STS-1010,2019
-STS,1010,2,Survey Sci & Techn in Society,0.44,0.35,0.15,0.0,0.0,0.0,0.0,0.06,scott brame,STS-1010,2019
-STS,1010,3,Survey Sci & Techn in Society,0.53,0.33,0.06,0.06,0.0,0.0,0.03,0.0,elizabeth stansell,STS-1010,2019
-STS,1010,4,Survey Sci & Techn in Society,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,STS-1010,2019
-STS,1010,5,Survey Sci & Techn in Society,0.38,0.49,0.08,0.0,0.03,0.0,0.0,0.03,philip randall,STS-1010,2019
-STS,1010,6,Survey Sci & Techn in Society,0.09,0.51,0.17,0.03,0.03,0.0,0.0,0.17,sarah mae cooper,STS-1010,2019
-STS,1010,7,Survey Sci & Techn in Society,0.26,0.43,0.06,0.03,0.14,0.0,0.0,0.09,megan no macalystre,STS-1010,2019
-STS,1010,8,Survey Sci & Techn in Society,0.25,0.59,0.06,0.03,0.0,0.0,0.0,0.06,david charles foltz,STS-1010,2019
-STS,1010,9,Survey Sci & Techn in Society,0.81,0.14,0.03,0.0,0.0,0.0,0.0,0.03,christine cl murphy,STS-1010,2019
-STS,1010,10,Survey Sci & Techn in Society,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alexander billinis,STS-1010,2019
-THEA,2100,1,Theatre Appreciation,0.56,0.28,0.13,0.03,0.0,0.0,0.0,0.0,kerrie kath seymour,THEA-2100,2019
-THEA,2100,2,Theatre Appreciation,0.42,0.29,0.23,0.03,0.0,0.0,0.0,0.03,kendra lyne johnson,THEA-2100,2019
-THEA,2100,4,Theatre Appreciation,0.58,0.32,0.1,0.0,0.0,0.0,0.0,0.0,carol collins,THEA-2100,2019
-THEA,2100,5,Theatre Appreciation,0.59,0.31,0.09,0.0,0.0,0.0,0.0,0.0,jason adkins,THEA-2100,2019
-THEA,2790,1,Theatre Practicum,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,matthew leckenbusch,THEA-2790,2019
-THEA,3090,1,Surv of Broadway II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,THEA-3090,2019
-THEA,3150,1,Theatre History I,0.65,0.29,0.0,0.0,0.03,0.0,0.0,0.03,shannon ther robert,THEA-3150,2019
-THEA,3180,1,Afri-Amer Thea II,0.66,0.21,0.14,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,THEA-3180,2019
-THEA,3740,1,Movement for Actors,0.75,0.0,0.17,0.08,0.0,0.0,0.0,0.0,kerrie kath seymour,THEA-3740,2019
-THEA,3980,1,Special Topics in Theatre,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,THEA-3980,2019
-WFB,3000,1,Wildlife Biology,0.43,0.29,0.2,0.06,0.01,0.0,0.0,0.0,catherine jachowski,WFB-3000,2019
-WFB,3010,1,Wildlife Biology Lab,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,WFB-3010,2019
-WFB,3130,1,Conservation Biology,0.35,0.34,0.24,0.04,0.03,0.0,0.0,0.01,shari lyn rodriguez,WFB-3130,2019
-WFB,3130,2,Conservation Biology,0.29,0.32,0.27,0.05,0.02,0.0,0.0,0.05,shari lyn rodriguez,WFB-3130,2019
-WFB,4120,1,Wildlife Management,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,WFB-4120,2019
-WFB,4160,1,Fisheries Techniques,0.63,0.34,0.02,0.0,0.0,0.0,0.0,0.0,troy mason farmer,WFB-4160,2019
-WFB,4620,1,Wetland Wildlife Biology,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,russell barrett,WFB-4620,2019
-WFB,4680,1,Herpetology,0.38,0.43,0.19,0.0,0.0,0.0,0.0,0.0,jeffrey robert mohr,WFB-4680,2019
-WFB,4930,2,Quantitative Ecology,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.05,laura gigliotti,WFB-4930,2019
-WFB,8500,1,Wildlife & Fisheries Ecology,0.38,0.38,0.05,0.0,0.05,0.0,0.0,0.14,mark scott,WFB-8500,2019
-WFB,8500,1,Wildlife & Fisheries Ecology,0.38,0.38,0.05,0.0,0.05,0.0,0.0,0.14,susan talley guynn,WFB-8500,2019
-WFB,8610,1,Scientific Writing,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,stefanie whitmire,WFB-8610,2019
-WFB,8610,3,Hum Dim/Fisheries & WL -OnLine,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,shari lyn rodriguez,WFB-8610,2019
-WFB,8630,1,Non Thesis Project,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,althea simone hagan,WFB-8630,2019
-WS,1030,1,Women in Global Perspective,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,WS-1030,2019
-WS,3010,1,Intro Women's Studies,0.58,0.33,0.04,0.04,0.0,0.0,0.0,0.0,elizabeth ros adams,WS-3010,2019
-WS,3010,2,Intro Women's Studies,0.46,0.38,0.13,0.0,0.0,0.0,0.0,0.04,elizabeth ros adams,WS-3010,2019
-WS,4010,1,Senior Seminar,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,diane perpich,WS-4010,2019
-YDP,3100,1,Youth Developmt and the Family,0.72,0.16,0.0,0.0,0.04,0.0,0.0,0.08,william quinn,YDP-3100,2019
-YDP,3150,2,Community & Youth Dev Systems,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephen lance,YDP-3150,2019
-YDP,3250,1,Working with Diverse Youth,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,kimberly pe johnson,YDP-3250,2019
-YDP,3350,1,Youth Activity Leadership,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,alexandra sandoval,YDP-3350,2019
-YDP,3400,1,Deliver Effective Youth Progra,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,kellye rembert,YDP-3400,2019
-YDP,4400,1,Youth Program Assessmnt & Eval,0.58,0.26,0.0,0.11,0.0,0.0,0.0,0.05,ann marie gillard,YDP-4400,2019
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1020,1,Survey of Art & Arch Hist II,0.46,0.42,0.11,0.0,0.0,0.0,0.0,0.01,beth ann lauritis,
+AAH,2060,1,Art History and Theory II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
+ACCT,2010,1,Financial Accounting Concepts,0.61,0.2,0.1,0.05,0.0,0.0,0.02,0.02,emily suza mccorkle,
+ACCT,2010,2,Financial Accounting Concepts,0.31,0.43,0.19,0.05,0.02,0.0,0.0,0.0,emily suza mccorkle,
+ACCT,2010,3,Financial Accounting Concepts,0.18,0.52,0.2,0.05,0.02,0.0,0.0,0.02,lydia lan schleifer,
+ACCT,2010,4,Financial Accounting Concepts,0.45,0.33,0.1,0.03,0.03,0.0,0.0,0.08,annieka philo,
+ACCT,2010,5,Financial Accounting Concepts,0.3,0.43,0.15,0.08,0.03,0.0,0.0,0.03,annieka philo,
+ACCT,2010,6,Financial Accounting Concepts,0.2,0.43,0.25,0.05,0.03,0.0,0.0,0.05,annieka philo,
+ACCT,2010,7,Financial Accounting Concepts,0.16,0.48,0.23,0.02,0.07,0.0,0.0,0.05,lydia lan schleifer,
+ACCT,2010,8,Financial Accounting Concepts,0.07,0.4,0.37,0.07,0.02,0.0,0.0,0.07,lydia lan schleifer,
+ACCT,2010,9,Financial Accounting Concepts,0.35,0.33,0.2,0.03,0.1,0.0,0.0,0.0,annieka philo,
+ACCT,2010,10,Financial Accounting Concepts,0.16,0.25,0.25,0.09,0.09,0.0,0.0,0.16,mary ann  prater,
+ACCT,2010,11,Financial Accounting Concepts,0.31,0.4,0.11,0.03,0.06,0.0,0.0,0.09,charles tegen,
+ACCT,2010,12,Financial Accounting Concepts,0.3,0.38,0.13,0.0,0.08,0.0,0.0,0.13,lisa whe birtwistle,
+ACCT,2010,13,Financial Accounting Concepts,0.41,0.31,0.21,0.03,0.0,0.0,0.05,0.0,lisa whe birtwistle,
+ACCT,2010,14,Financial Accounting Concepts,0.46,0.36,0.13,0.0,0.05,0.0,0.0,0.0,lisa whe birtwistle,
+ACCT,2010,15,Financial Accounting Concepts,0.34,0.39,0.15,0.07,0.05,0.0,0.0,0.0,james barnes,
+ACCT,2010,16,Financial Accounting Concepts,0.37,0.33,0.14,0.05,0.07,0.0,0.0,0.05,james barnes,
+ACCT,2010,17,Financial Accounting Concepts,0.0,0.34,0.41,0.07,0.07,0.0,0.0,0.1,lydia lan schleifer,
+ACCT,2010,101,Fin Acct Concepts (HON),0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,mary ann  prater,True
+ACCT,2010,401,Financial Accounting Concepts,0.29,0.36,0.18,0.06,0.08,0.0,0.0,0.03,jeffrey mcmillan,
+ACCT,2020,1,Managerial Accounting Concepts,0.25,0.25,0.29,0.04,0.07,0.0,0.0,0.11,henry anderson,
+ACCT,2020,2,Managerial Accounting Concepts,0.34,0.26,0.26,0.06,0.03,0.0,0.0,0.06,henry anderson,
+ACCT,2020,3,Managerial Accounting Concepts,0.41,0.31,0.13,0.05,0.0,0.0,0.03,0.08,henry anderson,
+ACCT,2020,4,Managerial Accounting Concepts,0.29,0.36,0.24,0.05,0.05,0.0,0.0,0.02,emily suza mccorkle,
+ACCT,2020,5,Managerial Accounting Concepts,0.33,0.4,0.14,0.05,0.0,0.0,0.05,0.02,emily suza mccorkle,
+ACCT,2020,6,Managerial Accounting Concepts,0.31,0.27,0.25,0.1,0.02,0.0,0.0,0.04,phebia davis-culler,
+ACCT,2020,7,Managerial Accounting Concepts,0.23,0.38,0.17,0.09,0.0,0.0,0.13,0.0,phebia davis-culler,
+ACCT,2020,8,Managerial Accounting Concepts,0.16,0.23,0.37,0.09,0.0,0.0,0.09,0.05,phebia davis-culler,
+ACCT,2020,401,Managerial Accounting Concepts,0.28,0.35,0.22,0.04,0.01,0.0,0.0,0.11,henry anderson,
+ACCT,2900,1,Special Topics - Soft Skills,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,michael mendonca,
+ACCT,3030,1,Cost Accounting,0.38,0.31,0.28,0.03,0.0,0.0,0.0,0.0,babak mammadov,
+ACCT,3030,2,Cost Accounting,0.29,0.37,0.29,0.05,0.0,0.0,0.0,0.0,babak mammadov,
+ACCT,3030,3,Cost Accounting,0.12,0.36,0.36,0.06,0.03,0.0,0.0,0.06,jace garrett,
+ACCT,3030,4,Cost Accounting,0.33,0.25,0.33,0.03,0.03,0.0,0.0,0.03,jace garrett,
+ACCT,3030,5,Cost Accounting,0.28,0.44,0.08,0.11,0.0,0.0,0.0,0.08,jace garrett,
+ACCT,3110,1,Intermediate Financial Acct I,0.14,0.29,0.18,0.11,0.21,0.0,0.0,0.07,erin michel hawkins,
+ACCT,3110,2,Intermediate Financial Acct I,0.19,0.31,0.23,0.08,0.15,0.0,0.0,0.04,erin michel hawkins,
+ACCT,3110,3,Intermediate Financial Acct I,0.23,0.26,0.32,0.03,0.03,0.0,0.0,0.13,amy meliss donnelly,
+ACCT,3110,4,Intermediate Financial Acct I,0.28,0.38,0.22,0.09,0.0,0.0,0.0,0.03,amy meliss donnelly,
+ACCT,3110,5,Intermediate Financial Acct I,0.1,0.42,0.35,0.03,0.0,0.0,0.0,0.1,brian matth goodson,
+ACCT,3110,6,Intermediate Financial Acct I,0.17,0.23,0.37,0.07,0.0,0.0,0.0,0.17,brian matth goodson,
+ACCT,3110,401,Intermediate Financial Acct I,0.32,0.22,0.2,0.02,0.05,0.0,0.0,0.2,henry anderson,
+ACCT,3120,1,Intermediate Financial Acct II,0.16,0.21,0.32,0.11,0.05,0.0,0.0,0.16,jeremy micha vinson,
+ACCT,3120,2,Intermediate Financial Acct II,0.35,0.26,0.29,0.06,0.0,0.0,0.0,0.03,jeremy micha vinson,
+ACCT,3120,3,Intermediate Financial Acct II,0.41,0.45,0.1,0.0,0.0,0.0,0.0,0.03,terry daniel knause,
+ACCT,3120,4,Intermediate Financial Acct II,0.29,0.53,0.12,0.0,0.03,0.0,0.0,0.03,terry daniel knause,
+ACCT,3120,5,Intermediate Financial Acct II,0.14,0.48,0.29,0.0,0.0,0.0,0.0,0.1,terry daniel knause,
+ACCT,3120,6,Intermediate Financial Acct II,0.32,0.42,0.16,0.0,0.03,0.0,0.0,0.06,terry daniel knause,
+ACCT,3120,101,Intermed Fin Acct II (HON),0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,terry daniel knause,True
+ACCT,3130,1,Intermediate Fin Acct III,0.24,0.5,0.24,0.0,0.0,0.0,0.0,0.02, russell madray,
+ACCT,3130,2,Intermediate Fin Acct III,0.22,0.44,0.2,0.1,0.02,0.0,0.0,0.02, russell madray,
+ACCT,3130,3,Intermediate Fin Acct III,0.38,0.43,0.17,0.02,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3130,4,Intermediate Fin Acct III,0.45,0.42,0.09,0.03,0.0,0.0,0.0,0.0, russell madray,
+ACCT,3130,101,Intermed Fin Acct III (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0, russell madray,True
+ACCT,3220,1,Accounting Information Systems,0.08,0.25,0.38,0.08,0.04,0.0,0.0,0.17,philip maiberger,
+ACCT,3220,2,Accounting Information Systems,0.04,0.48,0.3,0.09,0.04,0.0,0.0,0.04,philip maiberger,
+ACCT,3220,3,Accounting Information Systems,0.21,0.38,0.25,0.08,0.04,0.0,0.0,0.04,philip maiberger,
+ACCT,3220,4,Accounting Information Systems,0.1,0.38,0.29,0.0,0.0,0.0,0.1,0.14,philip maiberger,
+ACCT,4040,1,Individual Taxation,0.45,0.36,0.12,0.06,0.0,0.0,0.0,0.0,sarah martin,
+ACCT,4040,2,Individual Taxation,0.38,0.35,0.18,0.05,0.03,0.0,0.0,0.03,sarah martin,
+ACCT,4040,3,Individual Taxation,0.24,0.53,0.16,0.05,0.0,0.0,0.0,0.03,lisa whe birtwistle,
+ACCT,4040,4,Individual Taxation,0.27,0.27,0.27,0.16,0.03,0.0,0.0,0.0,lisa whe birtwistle,
+ACCT,4040,101,Individual Taxation (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,True
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,frances kennedy,
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,frances kennedy,
+ACCT,4100,3,Reporting and Mgmt Control Sys,0.33,0.5,0.13,0.03,0.0,0.0,0.0,0.0,gregory patr mcphee,
+ACCT,4150,1,Auditing,0.08,0.42,0.44,0.06,0.0,0.0,0.0,0.0,carl hollingsworth,
+ACCT,4150,2,Auditing,0.26,0.31,0.28,0.15,0.0,0.0,0.0,0.0,carl hollingsworth,
+ACCT,8520,1,Fin Acct Theory/Res,0.13,0.52,0.32,0.0,0.03,0.0,0.0,0.0,ralph edward welton,
+ACCT,8520,2,Fin Acct Theory/Res,0.28,0.59,0.14,0.0,0.0,0.0,0.0,0.0,ralph edward welton,
+ACCT,8540,1,Prof Responsibility,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,
+ACCT,8540,2,Prof Responsibility,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,robin radtke,
+ACCT,8540,3,Prof Responsibility,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,
+ACCT,8620,1,Financial Auditing,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,8620,2,Financial Auditing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
+ACCT,8710,1,Corporate Taxation,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,2,Corporate Taxation,0.49,0.44,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8710,3,Corporate Taxation,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,derek dalton,
+ACCT,8730,1,Intl/Spec Tax Topic,0.48,0.39,0.13,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,
+ACCT,8740,1,Tax Aspects of Finan Planning,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
+AGED,1000,1,Orientation & Field Experience,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,philip fravel,
+AGED,2030,1,Teaching Agriscience,0.38,0.54,0.0,0.0,0.0,0.0,0.0,0.08,catheri dibenedetto,
+AGED,8890,1,Intro to Res in Ed,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
+AGM,2050,1,Prin of Fabrication,0.29,0.42,0.11,0.05,0.08,0.0,0.0,0.05,hunter massey,
+AGM,2060,1,Machinery Mgt,0.28,0.48,0.12,0.04,0.04,0.0,0.0,0.04,hunter massey,
+AGM,2200,1,Calc for Mechanized Agricult,0.37,0.34,0.21,0.05,0.0,0.0,0.0,0.03,aaron paul turner,
+AGM,2210,1,Land Measurements,0.6,0.26,0.13,0.01,0.0,0.0,0.0,0.0,robert gord hammond,
+AGM,2210,1,Land Measurements,0.6,0.26,0.13,0.01,0.0,0.0,0.0,0.0,charles privette,
+AGM,4020,1,Irrigation System Design,0.26,0.51,0.23,0.0,0.0,0.0,0.0,0.0,charles privette,
+AGM,4100,1,Precision Ag Tech,0.36,0.43,0.15,0.06,0.0,0.0,0.0,0.0,hunter massey,
+AGM,4520,1,Mobile Power,0.5,0.39,0.05,0.0,0.03,0.0,0.0,0.03,ali bulent koc,
+AGM,4720,1,Capstone,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,john chastain,
+AGRB,2020,1,Agricultural Economics,0.34,0.37,0.14,0.08,0.07,0.0,0.0,0.0,george apperson,
+AGRB,2050,1,Agriculture and Society,0.18,0.48,0.22,0.06,0.03,0.0,0.0,0.03,george apperson,
+AGRB,3080,1,Quant Agribusiness Analysis I,0.15,0.42,0.18,0.15,0.03,0.0,0.0,0.06,lisha zhang,
+AGRB,3190,1,Agribusiness Management,0.2,0.19,0.3,0.16,0.04,0.0,0.0,0.11,michael vassalos,
+AGRB,3510,1,Prin of Agricultural Sales Mgt,0.06,0.5,0.38,0.03,0.03,0.0,0.0,0.0,george apperson,
+AGRB,3570,1,Natural Resources Economics,0.21,0.23,0.36,0.17,0.0,0.0,0.0,0.02,david brian willis,
+AGRB,4020,1,Production Economics,0.23,0.38,0.0,0.31,0.0,0.0,0.0,0.08,michael vassalos,
+AGRB,4080,1,Quant Agribusiness Analysis II,0.42,0.33,0.21,0.02,0.02,0.0,0.0,0.0,lisha zhang,
+AGRB,4560,1,Prices,0.43,0.4,0.12,0.05,0.0,0.0,0.0,0.0,yuliya val bolotova,
+AL,3490,400,Principles of Coaching,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,401,Principles of Coaching,0.61,0.29,0.11,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,3490,402,Principles of Coaching,0.7,0.11,0.04,0.04,0.04,0.0,0.0,0.07,frank mezzanotte,
+AL,3490,403,Principles of Coaching,0.6,0.28,0.04,0.08,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,3490,404,Principles of Coaching,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,nicholas ph whitrow,
+AL,3490,406,Principles of Coaching,0.6,0.28,0.08,0.0,0.0,0.0,0.0,0.04,john plumblee,
+AL,3490,407,Principles of Coaching,0.72,0.12,0.16,0.0,0.0,0.0,0.0,0.0,john plumblee,
+AL,3490,408,Principles of Coaching,0.84,0.04,0.08,0.0,0.0,0.0,0.0,0.04,nicholas ph whitrow,
+AL,3490,409,Principles of Coaching,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,nicholas ph whitrow,
+AL,3490,410,Principles of Coaching,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,edmond fry,
+AL,3500,400,Sci Basis I/Ex Phy,0.2,0.24,0.28,0.2,0.04,0.0,0.0,0.04,michael godfrey,
+AL,3500,401,Sci Basis I/Ex Phy,0.19,0.26,0.33,0.15,0.04,0.0,0.0,0.04,michael godfrey,
+AL,3520,400,Kinesiology,0.27,0.13,0.0,0.2,0.2,0.0,0.0,0.2,isaac sean colbert,
+AL,3530,400,Athletic Injuries,0.12,0.32,0.48,0.04,0.04,0.0,0.0,0.0,isaac sean colbert,
+AL,3530,401,Athletic Injuries,0.16,0.32,0.4,0.08,0.04,0.0,0.0,0.0,isaac sean colbert,
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,clyde keith connor,
+AL,3610,400,Admin/Org of Athletic Programs,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,401,Admin/Org of Athletic Programs,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
+AL,3610,402,Admin/Org of Athletic Programs,0.83,0.08,0.04,0.0,0.04,0.0,0.0,0.0,henry oates,
+AL,3620,400,Psychology of Coaching,0.24,0.36,0.32,0.0,0.04,0.0,0.0,0.04,natalie anne carter,
+AL,3620,401,Psychology of Coaching,0.36,0.36,0.2,0.04,0.0,0.0,0.0,0.04,natalie anne carter,
+AL,3620,402,Psychology of Coaching,0.38,0.25,0.29,0.0,0.04,0.0,0.0,0.04,natalie anne carter,
+AL,3710,400,Coaching Baseball,0.55,0.3,0.05,0.0,0.0,0.0,0.0,0.1,deborah cadorette,
+AL,3720,400,Coaching Basketball,0.72,0.12,0.08,0.04,0.04,0.0,0.0,0.0,edmond fry,
+AL,3740,400,Coaching Football,0.48,0.24,0.2,0.08,0.0,0.0,0.0,0.0,edmond fry,
+AL,3750,400,Coaching Soccer,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
+AL,3760,400,Coaching Strength/Conditioning,0.56,0.19,0.19,0.04,0.0,0.0,0.0,0.04,edmond fry,
+AL,3760,401,Coaching Strength/Conditioning,0.58,0.21,0.08,0.0,0.08,0.0,0.0,0.04,edmond fry,
+AL,4380,401,Officiating in Athl Leadership,0.68,0.16,0.08,0.04,0.04,0.0,0.0,0.0,clyde keith connor,
+AL,4380,403,Social Issues,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,
+AL,4490,400,Athlete Beliefs,0.41,0.3,0.15,0.15,0.0,0.0,0.0,0.0,deborah cadorette,
+AL,4490,401,Athlete Beliefs,0.58,0.21,0.08,0.04,0.08,0.0,0.0,0.0,deborah cadorette,
+AL,8380,400,Intercoll Ath Personnel Mgm,0.85,0.07,0.04,0.0,0.04,0.0,0.0,0.0,kyle mclendon young,
+AL,8530,400,Legal Iss in Intercoll Athlet,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,
+AL,8630,400,Socio Dynam in Intercol Athlet,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,michael godfrey,
+AL,8630,401,Socio Dynam in Intercol Athlet,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,michael godfrey,
+AL,8640,400,Ethical Iss in Collegiate Athl,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,janna there magette,
+AL,8640,401,Ethical Iss in Collegiate Athl,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.04,janna there magette,
+AL,8700,400,Intercoll Athletics Finance,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,
+AL,8700,401,Intercoll Athletics Finance,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,misty soles,
+ANTH,2010,1,Introduction to Anthropology,0.36,0.56,0.07,0.0,0.0,0.0,0.0,0.01,david markus,
+ANTH,2010,2,Introduction to Anthropology,0.25,0.64,0.07,0.01,0.0,0.0,0.0,0.02,david markus,
+ANTH,2010,3,Introduction to Anthropology,0.46,0.32,0.05,0.04,0.04,0.0,0.0,0.11,lisa rapaport,
+ANTH,2010,4,Introduction to Anthropology,0.47,0.31,0.14,0.03,0.02,0.0,0.0,0.03,yi wu,
+ANTH,3010,1,Cultural Anthropology,0.07,0.32,0.43,0.14,0.0,0.0,0.04,0.0,john coggeshall,
+ANTH,3250,1,The Anthropology of Food,0.33,0.24,0.14,0.0,0.0,0.0,0.0,0.29,yi wu,
+ANTH,3310,1,Archaeology,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,david markus,
+ANTH,4040,1,Anthropological Theories,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,john coggeshall,
+ANTH,4800,1,Business Anthropology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,
+ARCH,1510,1,Arch Communication,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,sal hambright-belue,
+ARCH,1510,2,Arch Communication,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,
+ARCH,1510,2,Arch Communication,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,robert silance,
+ARCH,1510,3,Arch Communication,0.57,0.21,0.0,0.07,0.07,0.0,0.0,0.07,sal hambright-belue,
+ARCH,1510,3,Arch Communication,0.57,0.21,0.0,0.07,0.07,0.0,0.0,0.07,clarissa mendez,
+ARCH,1510,4,Arch Communication,0.2,0.6,0.13,0.07,0.0,0.0,0.0,0.0,george schafer,
+ARCH,1510,4,Arch Communication,0.2,0.6,0.13,0.07,0.0,0.0,0.0,0.0,sal hambright-belue,
+ARCH,1510,5,Arch Communication,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,sal hambright-belue,
+ARCH,1510,5,Arch Communication,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,berrin terim,
+ARCH,1510,6,Arch Communication,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,
+ARCH,2520,1,Arch Foundations II,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,2520,1,Arch Foundations II,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,brandon george pass,
+ARCH,2520,2,Arch Foundations II,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
+ARCH,2520,2,Arch Foundations II,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,2520,3,Arch Foundations II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,
+ARCH,2520,3,Arch Foundations II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,2520,4,Arch Foundations II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
+ARCH,2520,4,Arch Foundations II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,2520,5,Arch Foundations II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
+ARCH,2520,5,Arch Foundations II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,2520,6,Arch Foundations II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,berrin terim,
+ARCH,2520,6,Arch Foundations II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,2700,1,Structures I,0.55,0.09,0.27,0.0,0.09,0.0,0.0,0.0,michael carl kleiss,
+ARCH,2710,1,Structures II,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,dustin gra albright,
+ARCH,3510,2,Studio Clemson,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,
+ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4050,1,American Arch Styles 1650-1950,0.63,0.25,0.06,0.0,0.06,0.0,0.0,0.0,robert bruhns,
+ARCH,4120,2,History Research,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
+ARCH,4120,2,History Research,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4140,2,Design Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4140,2,Design Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
+ARCH,4210,1,Arch Seminar,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,raymond thadde huff,
+ARCH,4290,1,Architectural Graphics,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,ashley jennings,
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,david lee,
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,george schafer,
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
+ARCH,4710,1,Arch Hist of Place,0.08,0.75,0.17,0.0,0.0,0.0,0.0,0.0,jason matthew white,
+ARCH,8110,1,Visualization II,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,douglas hecker,
+ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
+ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,timothy sutherland,
+ARCH,8520,7,Design Studio IV,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
+ARCH,8610,1,History/Theory II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
+ARCH,8620,2,History/Theory III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james thomas,
+ARCH,8650,1,Topics in Health Policy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anjali joseph,
+ARCH,8650,1,Topics in Health Policy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deborah mar wingler,
+ARCH,8710,1,Structures II,0.54,0.31,0.08,0.0,0.08,0.0,0.0,0.0,dustin gra albright,
+ARCH,8710,1,Structures II,0.54,0.31,0.08,0.0,0.08,0.0,0.0,0.0,timothy burl brown,
+ARCH,8730,2,Environmental Sys,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
+ART,1060,1,Foundation Drawing II,0.5,0.33,0.08,0.0,0.0,0.0,0.0,0.08,denise elizab ayers,
+ART,1510,1,Foundations Art I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,
+ART,1520,1,Foundations Art II,0.42,0.25,0.25,0.08,0.0,0.0,0.0,0.0,daniel bare,
+ART,2050,1,Beginning Life Drawing,0.53,0.29,0.0,0.06,0.06,0.0,0.0,0.06,annamarie williams,
+ART,2070,1,Beginning Painting,0.38,0.54,0.0,0.0,0.08,0.0,0.0,0.0,serra raven shuford,
+ART,2090,1,Beginning Sculpture,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
+ART,2100,6,Art Appreciation,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,angel roch estrella,
+ART,2100,7,Art Appreciation,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
+ART,2100,10,Art Appreciation,0.84,0.12,0.0,0.0,0.04,0.0,0.0,0.0,deighton tay abrams,
+ART,2100,11,Art Appreciation,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,
+ART,2110,1,Begin Printmaking,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,allison rae johnson,
+ART,2130,1,Begin Photography,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,
+ART,2170,1,Beginning Ceramics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,sara mays,
+ART,3130,1,Photography,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,
+ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,
+ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
+ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,david detrich,
+ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,
+ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,
+ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,valerie zimany,
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
+AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
+AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
+AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
+AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
+AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
+AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
+AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
+ASL,1010,1,Am Sign Lang I,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,william ry clements,
+ASL,1010,2,Am Sign Lang I,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,william ry clements,
+ASL,1010,3,Am Sign Lang I,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,william ry clements,
+ASL,1020,1,Am Sign Lang I,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,1020,2,Am Sign Lang I,0.5,0.38,0.04,0.04,0.04,0.0,0.0,0.0,jason hurdich,
+ASL,1020,3,Am Sign Lang I,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,william ry clements,
+ASL,1020,4,Am Sign Lang I,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,jody herbert cripps,
+ASL,2010,1,Am Sign Lang II,0.31,0.23,0.46,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2010,2,Am Sign Lang II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2020,1,Am Sign Lang II,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,2020,2,Am Sign Lang II,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,jason hurdich,
+ASL,2020,3,Am Sign Lang II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
+ASL,3020,1,Advanced Asl II,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,william ry clements,
+ASL,3050,1,Deaf Studies,0.76,0.12,0.08,0.0,0.04,0.0,0.0,0.0,jason hurdich,
+ASTR,1010,1,Solar System Astronomy,0.41,0.3,0.16,0.06,0.03,0.0,0.0,0.04,david edwar connick,
+ASTR,1020,2,Stellar Astronomy,0.16,0.23,0.28,0.15,0.0,0.0,0.16,0.03,mate adamkovics,
+ASTR,1030,1,Solar Systm Astr Lab,0.39,0.39,0.09,0.04,0.0,0.0,0.0,0.09,mark leising,
+ASTR,1030,2,Solar Systm Astr Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.04,0.0,mark leising,
+ASTR,1030,3,Solar Systm Astr Lab,0.32,0.48,0.12,0.08,0.0,0.0,0.0,0.0,mark leising,
+ASTR,1040,1,Stellar Astr Lab,0.3,0.2,0.3,0.0,0.0,0.0,0.1,0.1,mark leising,
+ASTR,1040,2,Stellar Astr Lab,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,mark leising,
+ASTR,1040,4,Stellar Astr Lab,0.3,0.55,0.05,0.0,0.05,0.0,0.0,0.05,mark leising,
+ASTR,3030,1,Galactic Astrophys,0.42,0.33,0.25,0.0,0.0,0.0,0.0,0.0,marco ajello,
+ASTR,8400,1,Astroph: Cosmology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
+ASTR,8750,1,Astronomy Seminar,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,marco ajello,
+AUD,2850,1,Acoustics of Music,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
+AUE,4020,699,Adv & Electrified Powertrains,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,zoran filipi,
+AUE,4020,699,Adv & Electrified Powertrains,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,qilun zhu,
+AUE,8160,3,Eng Combustion Emiss,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,robert prucka,
+AUE,8170,410,Alt Energy Sources,0.38,0.44,0.06,0.0,0.13,0.0,0.0,0.0,pierluigi pisu,
+AUE,8500,6,Stability/Safety Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
+AUE,8550,16,Struct/Thermal Analysis Mthds,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett,
+AUE,8770,405,Light-Weight Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,
+AUE,8860,1,Noise Vibration,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blan poland,
+AUE,8930,401,Autonomous Driving Techn,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,
+AUE,8930,405,Perception and Intelligence,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bing li,
+AVS,2000,1,Beef Cattle Tech,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,nathan long,
+AVS,2030,1,Dairy Sci Techniques,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,2090,1,Livestock Exhibition Technique,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
+AVS,3010,1,Anat & Phys Dom Ani,0.71,0.2,0.08,0.0,0.0,0.0,0.0,0.01,tiffany wilmoth,
+AVS,3090,1,Equine Evaluation,0.71,0.12,0.06,0.06,0.06,0.0,0.0,0.0,chelsea dr sinclair,
+AVS,3100,1,Animal Health,0.59,0.25,0.13,0.03,0.0,0.0,0.0,0.0,celina marc checura,
+AVS,3150,1,Animal Welfare,0.47,0.32,0.13,0.09,0.0,0.0,0.0,0.0,heather walker dunn,
+AVS,3700,1,Principles of Animal Nutrition,0.34,0.36,0.17,0.09,0.02,0.0,0.0,0.02,james ro strickland,
+AVS,3750,1,Applied Animal Nutrition,0.35,0.35,0.2,0.1,0.0,0.0,0.0,0.0,mir arguelles-ramos,
+AVS,4100,1,Domestic Ani Behav,0.69,0.21,0.09,0.0,0.0,0.0,0.0,0.01,james ro strickland,
+AVS,4120,1,Advanced Equine Management,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
+AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,glenn birrenkott,
+AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,richelle lor miller,
+AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,annel greene,
+AVS,4140,1,Basic Immunology,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,farzana ferdous,True
+AVS,4220,6,Advanced Fetal Fescue Research,0.85,0.0,0.15,0.0,0.0,0.0,0.0,0.0,susan kay duckett,
+AVS,4530,1,Animal Reproduction,0.22,0.29,0.31,0.13,0.04,0.0,0.0,0.0,celina marc checura,
+AVS,4550,2,Animal Repro Mgt-Equine,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,chelsea dr sinclair,
+AVS,4700,1,Animal Genetics,0.24,0.33,0.21,0.06,0.06,0.0,0.0,0.09,joseph kei bertrand,
+BCHM,3010,1,Molecular Biochemistry,0.17,0.46,0.25,0.03,0.0,0.0,0.0,0.1,meredith tei morris,
+BCHM,3010,2,Molecular Biochem(HON),0.4,0.29,0.24,0.02,0.02,0.0,0.0,0.02,cheryl ingram-smith,True
+BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
+BCHM,3040,4,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,3040,4,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
+BCHM,3050,1,Essen Elements Bioch,0.47,0.38,0.11,0.01,0.01,0.0,0.0,0.02,debra ragland,
+BCHM,3050,2,Essen Elements Bioch,0.53,0.33,0.08,0.03,0.01,0.0,0.0,0.02,debra ragland,
+BCHM,4320,1,Bioch of Metabolism,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,kimberly paul,
+BCHM,4340,3,Biochemistry of Metabolism Lab,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,4340,4,Biochemistry of Metabolism Lab,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+BCHM,4360,1,Genes to Proteins,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
+BCHM,4360,2,Mol Bio Genes to Proteins(HON),0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True
+BCHM,4400,1,Bioinformatics,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,liangjiang wang,
+BCHM,4910,35,CI:DNA Repair,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
+BCHM,4930,1,Senior Seminar,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,
+BCHM,8050,1,Issues in Research,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william marcotte,
+BE,2100,1,Intro to Biosystems Engr,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,jazmine octa taylor,
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.31,0.54,0.12,0.04,0.0,0.0,0.0,0.0,tom owino,
+BE,4120,1,Be Heat Mass Trans,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
+BE,4150,1,Instr & Control for Biosys Eng,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,rui xiao,
+BE,4240,1,Ecological Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,
+BE,4380,1,Bioprocess Engineering Design,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,terry walker,
+BE,4400,1,Sustainable Energy Engineering,0.36,0.21,0.29,0.14,0.0,0.0,0.0,0.0,jazmine octa taylor,
+BIOE,1010,1,Biol for Bioengr,0.6,0.35,0.02,0.0,0.02,0.0,0.0,0.02,vladimir vla reukov,
+BIOE,1010,1,Biol for Bioengr,0.6,0.35,0.02,0.0,0.02,0.0,0.0,0.02,tyler george harvey,
+BIOE,2010,1,Intro Biomed Engr,0.44,0.31,0.13,0.13,0.0,0.0,0.0,0.0,vladimir vla reukov,
+BIOE,3020,1,Biomaterials,0.61,0.29,0.06,0.01,0.0,0.0,0.0,0.03,alexey ale vertegel,
+BIOE,3100,1,Engr Analysis of Physiol Proc,0.54,0.36,0.07,0.04,0.0,0.0,0.0,0.0,brian william booth,
+BIOE,3200,1,Biomechanics,0.79,0.18,0.0,0.03,0.0,0.0,0.0,0.0,william richardson,
+BIOE,3210,1,Biofluid Mechanics,0.25,0.53,0.12,0.07,0.03,0.0,0.0,0.0,sarah harcum,
+BIOE,3470,1,Transport Processes in Bioengr,0.39,0.36,0.18,0.0,0.0,0.0,0.0,0.07,robert latour,
+BIOE,3700,1,Bioinst & Imaging,0.37,0.45,0.13,0.03,0.0,0.0,0.0,0.01,jordon anth gilmore,
+BIOE,4200,1,Sports Engineering,0.65,0.25,0.06,0.02,0.02,0.0,0.0,0.0,cynthia mille smith,
+BIOE,4490,1,Drug Delivery,0.55,0.35,0.06,0.0,0.03,0.0,0.0,0.0,jeoungsoo lee,
+BIOE,4510,21,CI - Hands On Tissue Engr,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
+BIOE,4510,37,CI-Innov in Bioinstrumentation,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,delphine dean,
+BIOE,6200,1,Sports Engineering,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
+BIOE,6230,1,Cardiovascular Engr and Path,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,martine laberge,
+BIOE,6230,1,Cardiovascular Engr and Path,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,dan simionescu,
+BIOE,8130,1,Industrial Bioengineering,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michael taylor,
+BIOE,8200,1,Structl Biomechanics,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,hai yao,
+BIOE,8500,2,Mechanobiology,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,
+BIOL,1040,1,General Biology II,0.32,0.3,0.2,0.09,0.02,0.0,0.0,0.06,nora espinoza,
+BIOL,1040,2,General Biology II,0.28,0.21,0.29,0.09,0.07,0.0,0.0,0.07,dylan dittrich-reed,
+BIOL,1040,3,General Biology II,0.14,0.28,0.29,0.12,0.1,0.0,0.0,0.08,salvatore sparace,
+BIOL,1040,4,General Biology II (HON),0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True
+BIOL,1060,1,Gen Biology Lab II,0.04,0.29,0.17,0.25,0.17,0.0,0.0,0.08,tafadzwa kaisa,
+BIOL,1060,2,Gen Biology Lab II,0.1,0.19,0.38,0.33,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,3,Gen Biology Lab II,0.16,0.21,0.21,0.16,0.26,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,4,Gen Biology Lab II,0.04,0.17,0.25,0.33,0.08,0.0,0.0,0.13,tafadzwa kaisa,
+BIOL,1060,5,Gen Biology Lab II,0.13,0.0,0.25,0.06,0.25,0.0,0.0,0.31,tafadzwa kaisa,
+BIOL,1060,7,Gen Biology Lab II,0.3,0.1,0.3,0.0,0.3,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,8,Gen Biology Lab II,0.04,0.33,0.42,0.13,0.08,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,9,Gen Biology Lab II,0.06,0.06,0.56,0.31,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,10,Gen Biology Lab II,0.06,0.18,0.29,0.0,0.41,0.0,0.0,0.06,tafadzwa kaisa,
+BIOL,1060,11,Gen Biology Lab II,0.09,0.22,0.43,0.17,0.04,0.0,0.0,0.04,tafadzwa kaisa,
+BIOL,1060,12,Gen Biology Lab II,0.13,0.19,0.5,0.13,0.06,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,13,Gen Biology Lab II,0.08,0.15,0.54,0.08,0.0,0.0,0.0,0.15,tafadzwa kaisa,
+BIOL,1060,14,Gen Biology Lab II,0.05,0.45,0.2,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,15,Gen Biology Lab II,0.06,0.22,0.33,0.17,0.22,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,16,Gen Biology Lab II,0.08,0.33,0.33,0.25,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,18,Gen Biology Lab II,0.05,0.18,0.32,0.32,0.14,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,19,Gen Biology Lab II,0.0,0.27,0.33,0.2,0.2,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,20,Gen Biology Lab II,0.07,0.2,0.2,0.13,0.2,0.0,0.0,0.2,tafadzwa kaisa,
+BIOL,1060,21,Gen Biology Lab II,0.14,0.23,0.32,0.14,0.09,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,22,Gen Biology Lab II,0.0,0.18,0.36,0.45,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,24,Gen Biology Lab II,0.04,0.22,0.35,0.26,0.04,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,25,Gen Biology Lab II,0.25,0.25,0.33,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,26,Gen Biology Lab II,0.17,0.43,0.26,0.04,0.09,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,27,Gen Biology Lab II,0.25,0.4,0.15,0.2,0.0,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1060,28,Gen Biology Lab II,0.21,0.21,0.32,0.21,0.0,0.0,0.0,0.05,tafadzwa kaisa,
+BIOL,1060,30,Gen Biology Lab II,0.17,0.35,0.35,0.04,0.0,0.0,0.0,0.09,tafadzwa kaisa,
+BIOL,1060,32,Gen Biology Lab II,0.07,0.47,0.27,0.07,0.13,0.0,0.0,0.0,tafadzwa kaisa,
+BIOL,1110,1,Principles of Biology II,0.52,0.33,0.12,0.03,0.0,0.0,0.01,0.0,renea chri hardwick,
+BIOL,1110,2,Principles of Biology II (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,True
+BIOL,1110,3,Principles of Biology II,0.34,0.43,0.14,0.04,0.05,0.0,0.0,0.02, christine minor,
+BIOL,1110,4,Prin of Biol II  (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,True
+BIOL,2000,1,Biology in the News,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,tamara mcnutt-scott,
+BIOL,2040,1,"Environ, Energy and Society",0.6,0.33,0.04,0.02,0.0,0.0,0.0,0.0,john jenkins hains,
+BIOL,2040,2,"Environ, Energy and Society",0.33,0.41,0.17,0.07,0.0,0.0,0.0,0.01,john jenkins hains,
+BIOL,2230,1,Human Anat and Physiology II,0.39,0.37,0.16,0.04,0.02,0.0,0.0,0.01,john cummings,
+BIOL,2230,2,Human Anat and Physiology II,0.41,0.35,0.16,0.04,0.03,0.0,0.0,0.01,john cummings,
+BIOL,3020,1,Invertebrate Biology,0.32,0.34,0.2,0.07,0.02,0.0,0.0,0.05,juan baeza migueles,
+BIOL,3040,1,Biology of Plants,0.31,0.24,0.1,0.29,0.07,0.0,0.0,0.0,nathan redding,
+BIOL,3060,1,Invertebrate Biology Lab,0.33,0.25,0.29,0.08,0.0,0.0,0.0,0.04,juan baeza migueles,
+BIOL,3060,2,Invertebrate Biology Lab,0.53,0.32,0.05,0.05,0.0,0.0,0.0,0.05,juan baeza migueles,
+BIOL,3080,1,Biology of Plants Practicum,0.45,0.25,0.1,0.15,0.05,0.0,0.0,0.0,nathan redding,
+BIOL,3080,2,Biology of Plants Practicum,0.5,0.2,0.2,0.0,0.1,0.0,0.0,0.0,nathan redding,
+BIOL,3160,1,Human Physiology,0.33,0.43,0.19,0.03,0.01,0.0,0.0,0.01,tamara mcnutt-scott,
+BIOL,3350,1,Evolutionary Biology,0.43,0.38,0.15,0.02,0.01,0.0,0.0,0.01,margaret ptacek,
+BIOL,3350,2,Evolutionary Biology (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,margaret ptacek,True
+BIOL,3940,3,CI: What is in our Waters?,0.8,0.0,0.0,0.2,0.0,0.0,0.0,0.0,peter van den hurk,
+BIOL,4010,1,Plant Physiology,0.17,0.2,0.28,0.21,0.0,0.0,0.08,0.07,douglas bielenberg,
+BIOL,4020,1,Plant Physiology Lab,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4020,2,Plant Physiology Lab,0.65,0.1,0.2,0.0,0.05,0.0,0.0,0.0,douglas bielenberg,
+BIOL,4030,1,Intro to Applied Genomics,0.0,0.07,0.36,0.07,0.07,0.0,0.0,0.43,vincent pa richards,
+BIOL,4140,1,Basic Immunology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,
+BIOL,4340,1,Biological Chem Lab Techniques,0.14,0.36,0.36,0.07,0.0,0.0,0.0,0.07,salvatore sparace,
+BIOL,4340,2,Biological Chem Lab Techniques,0.0,0.38,0.38,0.08,0.0,0.0,0.0,0.15,salvatore sparace,
+BIOL,4610,1,Cell Biology,0.36,0.36,0.15,0.07,0.03,0.0,0.0,0.03,lesly temesvari,
+BIOL,4610,2,Cell Biology (HON),0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True
+BIOL,4620,1,Cell Biology Lab (Lec),0.69,0.23,0.04,0.0,0.04,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,2,Cell Biology Lab (Lec),0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,4,Cell Biology Lab (Lec),0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
+BIOL,4620,5,Cell Biology Lab (Lec),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,6,Cell Biology Lab (Lec),0.65,0.27,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4620,7,Cell Biology Lab (Lec),0.6,0.28,0.12,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
+BIOL,4670,1,Principles of Hematology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,
+BIOL,4700,1,Behavioral Ecology,0.44,0.38,0.14,0.03,0.01,0.0,0.0,0.0,michael childress,
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,michael childress,
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.69,0.13,0.06,0.13,0.0,0.0,0.0,0.0,michael childress,
+BIOL,4710,3,Behavioral Ecology Lab (Lec),0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,michael childress,
+BIOL,4710,4,Behavioral Ecology Lab (Lec),0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,michael childress,
+BIOL,4780,1,Exercise Physiology,0.79,0.17,0.0,0.0,0.02,0.0,0.0,0.02,john cummings,
+BIOL,4800,1,Vertebrate Endocrinology,0.26,0.4,0.21,0.07,0.0,0.0,0.02,0.02,william baldwin,
+BIOL,4830,1,Stem Cell Biology,0.61,0.32,0.05,0.0,0.0,0.0,0.0,0.02,vincent gallicchio,
+BIOL,4930,2,Sr Sem: Immuno & Immunotherapy,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,yanzhang wei,
+BIOL,4930,3,Sr Sem: Nervous Systems,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
+BIOL,4930,6,Sr Sem: Biol Behind Our Food,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,peter van den hurk,
+BIOL,4930,7,Sr Sem: Genomics,0.75,0.19,0.0,0.0,0.0,0.0,0.06,0.0,kara elizabe powder,
+BIOL,4930,8,Sen Sem: Evolutionary Medicine,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,samantha ann price,
+BIOL,4940,2,CI: Popular Science Journalism,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,steven katz,
+BIOL,4940,2,CI: Popular Science Journalism,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
+BIOL,4940,9,CI: Marine Conservation & Gen,0.88,0.0,0.0,0.0,0.13,0.0,0.0,0.0,juan baeza migueles,
+BIOL,6030,1,Intro to Applied Genomics,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,vincent pa richards,
+BIOL,8430,1,Underst Genetics & Evol Biol,0.63,0.31,0.01,0.0,0.03,0.0,0.0,0.03,margaret ptacek,
+BIOL,8430,1,Underst Genetics & Evol Biol,0.63,0.31,0.01,0.0,0.03,0.0,0.0,0.03,renea chri hardwick,
+BIOL,8450,1,Understanding Animal Biology,0.85,0.1,0.0,0.0,0.02,0.0,0.0,0.03,amy lauren anderson,
+BIOL,8450,1,Understanding Animal Biology,0.85,0.1,0.0,0.0,0.02,0.0,0.0,0.03,matthew turnbull,
+BIOL,8470,1,Understanding Microbiology,0.72,0.23,0.04,0.0,0.01,0.0,0.0,0.0,harry kurtz,
+BIOL,8480,1,Understanding Scientific Rsrch,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert edwa ballard,
+BMOL,4250,1,Biomolecular Engineering,0.15,0.39,0.31,0.09,0.04,0.0,0.0,0.02,mark alan blenner,
+BMOL,4290,1,Bioprocess Engineering,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,marc rus birtwistle,
+BMOL,6250,1,Biomolecular Eng,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,mark alan blenner,
+BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,sandy edge,
+BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,sandy edge,
+BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,edward bar de iulio,
+BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,sandy edge,
+BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,william ern tumblin,
+BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,donna mccubbin,
+BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,donna mccubbin,
+BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,edward bar de iulio,
+BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,sandy edge,
+BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,william ern tumblin,
+BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,sandy edge,
+BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
+BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,
+BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,
+BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
+BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,sandy edge,
+BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,edward bar de iulio,
+BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,william ern tumblin,
+BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,sandy edge,
+BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,edward bar de iulio,
+BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,sandy edge,
+BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,william ern tumblin,
+BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,edward bar de iulio,
+BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,william ern tumblin,
+BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,donna mccubbin,
+BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,sandy edge,
+BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,donna mccubbin,
+BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,william ern tumblin,
+BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,sandy edge,
+BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,edward bar de iulio,
+BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,
+BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,donna mccubbin,
+BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
+BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,sandy edge,
+BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,donna mccubbin,
+BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,sandy edge,
+BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,william ern tumblin,
+BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,edward bar de iulio,
+CE,2010,1,Statics,0.3,0.33,0.12,0.06,0.03,0.0,0.0,0.15,melissa sternhagen,
+CE,2010,2,Statics,0.31,0.42,0.25,0.0,0.02,0.0,0.0,0.0,md nasimu chowdhury,
+CE,2010,3,Statics,0.17,0.25,0.23,0.17,0.02,0.0,0.0,0.17,melissa sternhagen,
+CE,2010,4,Statics,0.16,0.42,0.33,0.02,0.0,0.0,0.0,0.07,md nasimu chowdhury,
+CE,2010,5,Statics,0.5,0.16,0.2,0.02,0.11,0.0,0.0,0.0,michael wall stoner,
+CE,2010,6,Statics,0.58,0.3,0.1,0.0,0.03,0.0,0.0,0.0,lancelot paul reres,
+CE,2010,7,Statics (HON),0.18,0.55,0.18,0.0,0.0,0.0,0.0,0.09,melissa sternhagen,True
+CE,2060,1,Structural Mechanics,0.51,0.29,0.16,0.02,0.02,0.0,0.0,0.0,thomas edfo cousins,
+CE,2060,2,Structural Mechanics,0.19,0.33,0.43,0.02,0.02,0.0,0.0,0.02,melissa sternhagen,
+CE,2080,1,Dynamics,0.17,0.42,0.32,0.0,0.03,0.0,0.0,0.06,md nasimu chowdhury,
+CE,2080,2,Dynamics,0.12,0.35,0.4,0.05,0.0,0.0,0.0,0.09,md nasimu chowdhury,
+CE,2550,1,Geomatics,0.29,0.27,0.32,0.05,0.0,0.0,0.0,0.07,wayne sarasua,
+CE,3010,1,Structural Analysis,0.4,0.3,0.26,0.05,0.0,0.0,0.0,0.0,stephen csernak,
+CE,3110,1,Transportation Engr,0.68,0.24,0.05,0.01,0.0,0.0,0.0,0.01,pamela murray-tuite,
+CE,3210,1,Geotechnical Engineering,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,wenxin liu,
+CE,3210,2,Geotechnical Engineering,0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,wenxin liu,
+CE,3310,1,Constr Engr & Mgmnt,0.87,0.11,0.0,0.02,0.0,0.0,0.0,0.0,steve richa sanders,
+CE,3410,1,Intro to Fluid Mech,0.32,0.46,0.15,0.03,0.0,0.0,0.0,0.03,nigel gregory kaye,
+CE,3420,1,Hydraulics & Hydro,0.62,0.35,0.03,0.0,0.0,0.0,0.0,0.0,ashok mishra,
+CE,3420,2,Hydraulics & Hydro,0.28,0.47,0.19,0.03,0.03,0.0,0.0,0.0,abdul khan,
+CE,3510,1,Civil Engineering Materials,0.43,0.52,0.05,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
+CE,3520,1,Econ Eval of Proj,0.49,0.37,0.09,0.01,0.01,0.0,0.0,0.03, kent nilsson,
+CE,3530,1,Professional Seminar,0.96,0.01,0.03,0.01,0.0,0.0,0.0,0.0,ronald andrus,
+CE,4020,1,Reinfor Con Design,0.42,0.31,0.22,0.0,0.04,0.0,0.0,0.0,laura mae redmond,
+CE,4070,1,Wood Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
+CE,4080,1,Struct Loads & Sys,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,brandon ross,
+CE,4110,1,Roadway Geo Design,0.52,0.37,0.07,0.04,0.0,0.0,0.0,0.0,jennifer ogle,
+CE,4120,1,Urban Transport Plan,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,sakib khan,
+CE,4210,1,Geotechnical Design,0.29,0.46,0.23,0.0,0.0,0.0,0.0,0.03,nadara ravichandran,
+CE,4340,1,Const Est Proj Cont,0.35,0.51,0.13,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,4370,1,Sustainable Energy Proj Design,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
+CE,4590,1,Capstone Design Proj,0.6,0.28,0.1,0.01,0.0,0.0,0.0,0.0,stephen csernak,
+CE,4910,1,Corrosion and Oxidation,0.0,0.4,0.0,0.0,0.0,0.0,0.0,0.6,ami esmaeilpoursaee,
+CE,4910,2,Des Thinkg for Sustain Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,
+CE,4910,3,Intro to Enviro Fluid Mech,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,nigel gregory kaye,
+CE,4990,2,Cr Inq in Civil Engineering,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,weichiang pang,
+CE,4990,61,Cr Inq in Civil Engineering,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
+CE,4990,201,Special Project - Springer I,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
+CE,6340,1,Const Est Proj Cont,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
+CE,6370,1,Sustainable Energy Proj Design,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
+CE,8030,1,Adv Steel Design,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mohannad naser,
+CE,8270,1,Spec Cements & Concr,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
+CE,8450,500,Data Mining for Sys Analytics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paris stringfellow,
+CE,8470,500,Optimization Support Models,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
+CE,8530,1,Apps in Traffic En,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
+CES,1900,101,CI-LEAD Forward I,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+CES,2900,101,CI - LEAD Forward II,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+CES,3900,101,CI-LEAD Forward III,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
+CH,1010,1,General Chemistry,0.16,0.32,0.21,0.08,0.1,0.0,0.0,0.12,princess mycia cox,
+CH,1010,2,General Chemistry,0.23,0.33,0.32,0.04,0.04,0.0,0.0,0.03,jacob schroeder,
+CH,1010,3,General Chemistry,0.11,0.4,0.25,0.1,0.06,0.0,0.0,0.08,jacob schroeder,
+CH,1010,4,General Chemistry,0.08,0.22,0.39,0.1,0.13,0.0,0.0,0.1,steven pellizzeri,
+CH,1010,400,General Chemistry,0.28,0.16,0.15,0.22,0.08,0.0,0.0,0.11,stephe schvaneveldt,
+CH,1020,1,General Chemistry,0.24,0.31,0.26,0.06,0.04,0.0,0.0,0.09,steven pellizzeri,
+CH,1020,2,General Chemistry,0.27,0.29,0.25,0.09,0.03,0.0,0.0,0.05,william mcwhorter,
+CH,1020,3,General Chemistry,0.27,0.36,0.31,0.04,0.01,0.0,0.0,0.02,dennis taylor,
+CH,1020,4,General Chemistry,0.3,0.38,0.2,0.05,0.01,0.0,0.0,0.06,dennis taylor,
+CH,1020,5,General Chemistry,0.17,0.47,0.25,0.05,0.0,0.0,0.02,0.03,william mcwhorter,
+CH,1020,6,General Chemistry,0.1,0.36,0.34,0.09,0.02,0.0,0.0,0.08,olt geiculescu,
+CH,1020,7,General Chemistry,0.1,0.39,0.34,0.06,0.01,0.0,0.0,0.1,william mcwhorter,
+CH,1020,8,General Chemistry,0.29,0.43,0.21,0.03,0.0,0.0,0.0,0.03,thomas hickman,
+CH,1020,9,General Chemistry,0.22,0.45,0.23,0.05,0.0,0.0,0.0,0.05,princess mycia cox,
+CH,1020,10,General Chemistry,0.34,0.37,0.23,0.02,0.02,0.0,0.0,0.02,thomas hickman,
+CH,1020,11,General Chemistry,0.32,0.33,0.23,0.04,0.02,0.0,0.0,0.05,elliot ennis,
+CH,1020,50,General Chemistry,0.65,0.27,0.04,0.0,0.02,0.0,0.0,0.02,stephe schvaneveldt,
+CH,1020,51,General Chemistry (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
+CH,1020,52,General Chemistry (HON),0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True
+CH,1050,1,Chemistry in Context I,0.34,0.39,0.23,0.0,0.02,0.0,0.0,0.02,olt geiculescu,
+CH,1050,2,Chemistry in Context I,0.56,0.25,0.13,0.03,0.0,0.0,0.0,0.03,olt geiculescu,
+CH,1060,1,Chemistry in Context II,0.15,0.5,0.15,0.08,0.08,0.0,0.0,0.04,elliot ennis,
+CH,1520,1,Chemistry Communication,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,richard marcus,
+CH,2010,1,Survey of Organic Chemistry,0.43,0.15,0.23,0.06,0.07,0.0,0.0,0.06,tania issa houjeiry,
+CH,2050,1,Intro Inorg Chem,0.55,0.32,0.11,0.0,0.0,0.0,0.0,0.03,william pennington,
+CH,2230,1,Organic Chemistry,0.14,0.21,0.31,0.18,0.14,0.0,0.0,0.01,thomas hickman,
+CH,2230,2,Organic Chemistry,0.13,0.26,0.27,0.23,0.11,0.0,0.0,0.01,elliot ennis,
+CH,2230,3,Organic Chemistry,0.18,0.33,0.22,0.13,0.12,0.0,0.0,0.03,laura lanni,
+CH,2240,1,Organic Chemistry,0.53,0.25,0.14,0.04,0.02,0.0,0.0,0.03,tania issa houjeiry,
+CH,2240,2,Organic Chemistry,0.38,0.33,0.15,0.07,0.03,0.0,0.0,0.04,laura lanni,
+CH,2240,3,Organic Chemistry,0.34,0.19,0.32,0.07,0.07,0.0,0.0,0.01,laura lanni,
+CH,2240,4,Organic Chemistry,0.59,0.13,0.19,0.02,0.03,0.0,0.0,0.04,rhett smith,
+CH,2240,5,Organic Chemistry,0.55,0.25,0.11,0.07,0.0,0.0,0.0,0.02,rhett smith,
+CH,2280,17,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelso plampin,
+CH,2280,26,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
+CH,3320,1,Physical Chemistry,0.21,0.37,0.32,0.05,0.0,0.0,0.0,0.05,steven stuart,
+CH,3320,3,Physical Chemistry,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,jason mcneill,
+CH,3320,5,Physical Chemistry,0.64,0.14,0.11,0.04,0.07,0.0,0.0,0.0,leah bec casabianca,
+CH,3400,2,Physical Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3400,3,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3400,4,Physical Chem Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
+CH,3600,1,Chemical Biology,0.48,0.31,0.14,0.0,0.0,0.0,0.0,0.07,modi wetzler,
+CH,4110,1,Instrumental Analy,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,jeffrey natha anker,
+CH,4120,2,Instr Analysis Lab,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,george chumanov,
+CH,4130,1,Chemistry of Aqueous Systems,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,cindy lee,
+CH,4500,1,Chemistry Capstone,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
+CH,4990,6,Cr Inq in Chemistry IV 1218,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,dev priya arya,
+CH,6140,1,Bioanalytical Chem,0.09,0.82,0.09,0.0,0.0,0.0,0.0,0.0,carlos garcia perez,
+CH,8130,1,Electrochem Sci,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,stephen creager,
+CH,8510,1,Grad Student Seminar,0.83,0.14,0.0,0.0,0.0,0.0,0.0,0.03,joseph stu thrasher,
+CH,8510,2,Grad Student Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,
+CHE,1300,1,Intro to Chemical Engineering,0.25,0.21,0.21,0.08,0.06,0.0,0.0,0.19,christopher norfolk,
+CHE,1300,2,Intro to Chemical Engineering,0.24,0.2,0.22,0.1,0.08,0.0,0.0,0.18,christopher norfolk,
+CHE,2200,1,Ch E Thermo I,0.13,0.39,0.25,0.13,0.08,0.0,0.0,0.03,jessica mari larsen,
+CHE,2300,1,Fluids/Heat Transfer,0.19,0.18,0.35,0.15,0.11,0.0,0.0,0.01,eric mikel davis,
+CHE,3070,1,Unit Ops Lab I,0.28,0.63,0.07,0.02,0.0,0.0,0.0,0.0,christopher norfolk,
+CHE,3190,1,Engr Materials,0.12,0.33,0.35,0.12,0.03,0.0,0.0,0.05,amod ogale,
+CHE,3190,1,Engr Materials,0.12,0.33,0.35,0.12,0.03,0.0,0.0,0.05,christopher norfolk,
+CHE,3530,1,Proc Dyn & Control,0.24,0.46,0.26,0.02,0.0,0.0,0.0,0.01,mark roberts,
+CHE,3990,13,CI- ARTIFICIAL CHROMOSOMES,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,marc rus birtwistle,
+CHE,4330,1,Process Design II,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,david bruce,
+CHE,8140,1,Numerical Methods,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,joseph scott,
+CHE,8450,5,Statistical Mechanics,0.63,0.13,0.25,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
+CHIN,1010,1,Elementary Chinese,0.61,0.11,0.06,0.0,0.06,0.0,0.0,0.17,yanming an,
+CHIN,1020,1,Elementary Chinese,0.3,0.3,0.4,0.0,0.0,0.0,0.0,0.0,ling rao,
+CHIN,3120,1,Philosophy in Ancient China,0.33,0.46,0.08,0.0,0.0,0.0,0.0,0.13,yanming an,
+COM,1500,1,Intro to Human Communication,0.74,0.25,0.01,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,
+COM,1500,2,Intro to Human Communication,0.71,0.25,0.01,0.0,0.03,0.0,0.0,0.0,daniel lelan fecher,
+COM,1500,3,Intro to Human Communication,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,
+COM,1500,4,Intro to Human Communication,0.7,0.26,0.02,0.01,0.01,0.0,0.0,0.01,marianne her glaser,
+COM,1500,5,Intro to Human Communication,0.75,0.17,0.03,0.01,0.02,0.0,0.0,0.01,marianne her glaser,
+COM,1500,6,Intro to Human Communication,0.62,0.29,0.06,0.0,0.0,0.0,0.0,0.03,vanessa anne condon,
+COM,2010,1,Intr to Comm Studies,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2010,2,Intr to Comm Studies,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,caitlin baker,
+COM,2020,1,Communication Theory,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,
+COM,2040,1,Critical-Cultural Comm Theory,0.47,0.26,0.21,0.05,0.0,0.0,0.0,0.0,james nicho gilmore,
+COM,2100,1,Quant Comm Research Methods,0.44,0.37,0.11,0.07,0.0,0.0,0.0,0.0,joseph mazer,
+COM,2120,1,Crit-Cultural Rsrch Methods,0.74,0.22,0.0,0.04,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,1,Public Speaking,0.71,0.14,0.05,0.0,0.0,0.0,0.0,0.1,caitlin baker,
+COM,2500,3,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,charles john brewer,
+COM,2500,4,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,charles john brewer,
+COM,2500,5,Public Speaking,0.29,0.48,0.1,0.0,0.05,0.0,0.0,0.1,sara grumbl crocker,
+COM,2500,6,Public Speaking,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,marshall tho covert,
+COM,2500,7,Public Speaking,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,charles john brewer,
+COM,2500,8,Public Speaking,0.57,0.33,0.05,0.0,0.05,0.0,0.0,0.0,charles john brewer,
+COM,2500,9,Public Speaking,0.52,0.24,0.05,0.1,0.05,0.0,0.0,0.05,ashley lauren pikel,
+COM,2500,10,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
+COM,2500,11,Public Speaking,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
+COM,2500,12,Public Speaking,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
+COM,2500,13,Public Speaking,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,ashley lauren pikel,
+COM,2500,14,Public Speaking,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
+COM,2500,15,Public Speaking,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth gilmore,
+COM,2500,16,Public Speaking,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,17,Public Speaking,0.6,0.2,0.15,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,18,Public Speaking,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
+COM,2500,19,Public Speaking (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,rachelle le beckner,True
+COM,2500,20,Public Speaking,0.67,0.29,0.0,0.05,0.0,0.0,0.0,0.0,katie barn mcelveen,
+COM,2500,21,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,blythe kai steelman,
+COM,2500,23,Public Speaking,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,2500,24,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rachelle le beckner,
+COM,2500,25,Public Speaking,0.52,0.43,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
+COM,2500,26,Public Speaking (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True
+COM,2500,28,Public Speaking (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,True
+COM,2500,31,Public Speaking,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,marshall tho covert,
+COM,2500,32,Public Speaking,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,33,Public Speaking,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
+COM,2500,34,Public Speaking,0.43,0.43,0.05,0.05,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,35,Public Speaking,0.4,0.55,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,
+COM,2500,36,Public Speaking,0.25,0.65,0.05,0.05,0.0,0.0,0.0,0.0,marshall tho covert,
+COM,2500,37,Public Speaking,0.5,0.35,0.05,0.0,0.0,0.0,0.0,0.1,elizabeth gilmore,
+COM,2500,38,Public Speaking,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,marshall tho covert,
+COM,2500,400,Public Speaking,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,401,Public Speaking,0.71,0.19,0.0,0.0,0.1,0.0,0.0,0.0,alexis zachar davis,
+COM,2500,402,Public Speaking,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
+COM,2500,403,Public Speaking,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
+COM,3070,1,Public Comm of Sts,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,meghna tallapragada,
+COM,3240,1,"Communication, Sport & Society",0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,gregory kei cranmer,
+COM,3240,2,"Communication, Sport & Society",0.77,0.09,0.05,0.09,0.0,0.0,0.0,0.0,katie barn mcelveen,
+COM,3250,1,Survey of Sports Communication,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
+COM,3260,1,Pr in Sports,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,angela pratt,
+COM,3260,2,Pr in Sports,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,angela pratt,
+COM,3270,1,Sports Media Criticism,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,katie barn mcelveen,
+COM,3480,1,Interpersonal Comm,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,3480,2,Interpersonal Comm,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
+COM,3550,1,Principles of Public Relations,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,meghna tallapragada,
+COM,3570,1,Public Relations Writing,0.67,0.21,0.04,0.04,0.0,0.0,0.0,0.04,andrew stephen pyle,
+COM,3610,1,Argue and Debate,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
+COM,3640,1,Organizational Comm,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,kristen ela okamoto,
+COM,3660,1,Video COMM w/ Adobe CC,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,michael rodgers,
+COM,3660,4,Corporate Communications,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,. mark barnes,
+COM,4250,1,Adv Sports Comm,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
+COM,4260,1,Social Media and Sports Comm,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4270,1,Comm in Sports Organizations,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
+COM,4280,1,Interpers/Family Comm & Sport,0.26,0.63,0.05,0.05,0.0,0.0,0.0,0.0,gregory kei cranmer,
+COM,4310,1,Legal Communication Trial,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
+COM,4550,1,Gender Communication,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
+COM,4560,1,PR for Assoc & Nonprofits,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
+COM,4700,1,Comm & Health,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
+COM,4950,1,Senior Capstone,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
+COM,4950,2,Senior Capstone,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
+COM,8060,1,Health Communication & Culture,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
+CPSC,1010,1,Computer Science I,0.51,0.22,0.12,0.05,0.05,0.0,0.0,0.05,roger larr van scoy,
+CPSC,1010,2,Computer Science I,0.24,0.35,0.15,0.06,0.11,0.0,0.0,0.09,yu-shan sun,
+CPSC,1020,1,Computer Science II,0.42,0.27,0.17,0.02,0.04,0.0,0.0,0.08,yvon feaster,
+CPSC,1020,2,Computer Science II,0.29,0.21,0.25,0.04,0.1,0.0,0.0,0.1,yvon feaster,
+CPSC,1020,3,Computer Science II,0.13,0.33,0.28,0.02,0.13,0.0,0.0,0.11,catherine hochrine,
+CPSC,1020,4,Computer Science II,0.27,0.23,0.36,0.05,0.07,0.0,0.0,0.02,mark smotherman,
+CPSC,1110,1,Intro to Programming in C,0.19,0.22,0.19,0.11,0.06,0.0,0.0,0.22,catherine hochrine,
+CPSC,1110,2,Intro to Programming in C,0.15,0.3,0.18,0.13,0.1,0.0,0.0,0.15,catherine hochrine,
+CPSC,1110,3,Intro to Programming in C,0.19,0.25,0.19,0.06,0.16,0.0,0.0,0.16,andrew duchowski,
+CPSC,2070,1,Discrete Structures,0.69,0.11,0.06,0.0,0.06,0.0,0.0,0.09,sandra hedetniemi,
+CPSC,2070,2,Discrete Structures,0.42,0.25,0.17,0.11,0.03,0.0,0.0,0.03,larry hodges,
+CPSC,2120,1,Algs/Data Structures,0.49,0.23,0.06,0.03,0.06,0.0,0.0,0.14,andrew hill,
+CPSC,2120,2,Algs/Data Structures,0.6,0.17,0.11,0.02,0.04,0.0,0.0,0.06,andrew hill,
+CPSC,2120,3,Algs/Data Structures,0.53,0.34,0.06,0.02,0.02,0.0,0.0,0.02,andrew hill,
+CPSC,2150,1,Software Dev Foundations,0.34,0.36,0.14,0.04,0.0,0.0,0.0,0.12,kevin anton plis,
+CPSC,2150,2,Software Dev Foundations,0.16,0.34,0.18,0.05,0.14,0.0,0.0,0.14,yu-shan sun,
+CPSC,2150,3,Software Dev Foundations,0.26,0.35,0.16,0.03,0.13,0.0,0.0,0.06,yu-shan sun,
+CPSC,2200,1,Microcomputer Appl,0.5,0.29,0.07,0.04,0.04,0.0,0.0,0.07,kevin anton plis,
+CPSC,2200,2,Microcomputer Appl,0.31,0.38,0.23,0.04,0.04,0.0,0.0,0.0,kevin anton plis,
+CPSC,2310,1,Intro Computer Org,0.45,0.35,0.1,0.04,0.02,0.0,0.0,0.04,nicolas benj widman,
+CPSC,2310,2,Intro Computer Org,0.42,0.3,0.18,0.08,0.0,0.0,0.0,0.02,nicolas benj widman,
+CPSC,2810,2,Sel Top: Cyberdefen Comp Train,0.76,0.0,0.0,0.0,0.0,0.0,0.0,0.24,hongda li,
+CPSC,2910,1,Prof Issues I,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2910,2,Prof Issues I,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,catherine hochrine,
+CPSC,2910,3,Prof Issues I,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
+CPSC,2920,1,"Computing, Ethics & Society",0.2,0.28,0.16,0.02,0.04,0.0,0.0,0.3,christopher plaue,
+CPSC,3120,1,Design Analysis of Algorithms,0.38,0.48,0.12,0.0,0.0,0.0,0.0,0.02,wayne goddard,
+CPSC,3120,2,Design Analysis of Algorithms,0.33,0.25,0.14,0.03,0.08,0.0,0.0,0.17,federico iuricich,
+CPSC,3220,1,Intro to Operating Systems,0.19,0.14,0.28,0.05,0.14,0.0,0.0,0.21,jacob sorber,
+CPSC,3220,2,Intro to Operating Systems,0.37,0.4,0.07,0.02,0.07,0.0,0.0,0.07,rong ge,
+CPSC,3300,1,Computer Systems Org,0.38,0.31,0.25,0.02,0.04,0.0,0.0,0.0,nicolas benj widman,
+CPSC,3300,2,Computer Systems Org,0.46,0.22,0.19,0.05,0.05,0.0,0.0,0.03,nicolas benj widman,
+CPSC,3500,1,Foundations of Computer Sci,0.18,0.16,0.33,0.08,0.06,0.0,0.0,0.18,ilya mark safro,
+CPSC,3520,1,Programming Systems,0.23,0.38,0.22,0.03,0.03,0.0,0.0,0.11,robert schalkoff,
+CPSC,3600,1,Network Programming,0.66,0.2,0.09,0.0,0.0,0.0,0.0,0.05,long cheng,
+CPSC,3600,2,Network Programming,0.36,0.32,0.04,0.0,0.14,0.0,0.0,0.14,zijun wang,
+CPSC,3710,1,Systems Analysis,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,roger larr van scoy,
+CPSC,3720,1,Software Engineering,0.41,0.47,0.13,0.0,0.0,0.0,0.0,0.0,paige ann rodeghero,
+CPSC,3720,2,Software Engineering,0.26,0.56,0.18,0.0,0.0,0.0,0.0,0.0,murali sitaraman,
+CPSC,3990,2,Adv CI: Sim Meth in Graphs & E,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,luis bermudez,
+CPSC,3990,2,Adv CI: Sim Meth in Graphs & E,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,victor zordan,
+CPSC,3990,3,CI: User Exper in VR Games,0.6,0.0,0.0,0.2,0.0,0.0,0.0,0.2,andrew robb,
+CPSC,4050,1,Computer Graphics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,victor zordan,
+CPSC,4110,1,Virtual Reality Systems,0.39,0.42,0.15,0.03,0.0,0.0,0.0,0.0,andrew robb,
+CPSC,4140,1,Human and Computer Interaction,0.49,0.38,0.09,0.0,0.04,0.0,0.0,0.0,sabarish venka babu,
+CPSC,4160,1,2-D Game Engine Construction,0.49,0.34,0.13,0.0,0.0,0.0,0.02,0.02,brian malloy,
+CPSC,4180,1,Usable Privacy and Security,0.55,0.23,0.05,0.0,0.05,0.0,0.0,0.14,kelly caine,
+CPSC,4200,1,Computer Security Principles,0.7,0.27,0.0,0.03,0.0,0.0,0.0,0.0,yvon feaster,
+CPSC,4240,1,System Admin and Security,0.24,0.7,0.03,0.0,0.0,0.0,0.0,0.03,james martin,
+CPSC,4440,1,Cloud Computing Architecture,0.29,0.42,0.21,0.0,0.0,0.0,0.0,0.08,amy apon,
+CPSC,4620,1,Database Management Systems,0.3,0.41,0.22,0.0,0.0,0.0,0.0,0.07,zijun wang,
+CPSC,4620,2,Database Management Systems,0.42,0.34,0.24,0.0,0.0,0.0,0.0,0.0,kevin anton plis,
+CPSC,4770,1,Distributed/Cluster Computing,0.56,0.22,0.17,0.0,0.0,0.0,0.0,0.06,shuangshuang jin,
+CPSC,4820,1,Special Topic: Concurrent Prog,0.36,0.32,0.14,0.0,0.05,0.0,0.0,0.14,eileen ther kraemer,
+CPSC,4820,2,Special Topics: Tang and Embod,0.46,0.36,0.11,0.04,0.0,0.0,0.0,0.04,brygg anders ullmer,
+CPSC,4820,3,Special Topic in Computing: AI,0.46,0.13,0.21,0.04,0.04,0.0,0.0,0.13,ioannis karamouzas,
+CPSC,4910,1,Professional Issues II,0.48,0.45,0.05,0.0,0.0,0.0,0.03,0.0,roger larr van scoy,
+CPSC,4910,2,Professional Issues II,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
+CPSC,4910,3,Professional Issues II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
+CPSC,6050,1,Computer Graphics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,victor zordan,
+CPSC,6110,1,Virtual Reality Systems,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew robb,
+CPSC,6140,1,Human and Computer Interaction,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,sabarish venka babu,
+CPSC,6160,1,2-D Game Engine Construction,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,brian malloy,
+CPSC,6440,1,Cloud Computing Architecture,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,amy apon,
+CPSC,6620,1,Database Management Systems,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,zijun wang,
+CPSC,8040,1,Data Visualization,0.7,0.22,0.08,0.0,0.0,0.0,0.0,0.0,federico iuricich,
+CPSC,8110,1,Technical Character Animation,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
+CPSC,8240,1,Advanced Operating Systems,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,rong ge,
+CPSC,8400,1,Design & Anlys of Algorithms,0.3,0.35,0.2,0.0,0.05,0.0,0.0,0.1,brian christop dean,
+CPSC,8570,1,Network Technologies Security,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,
+CPSC,8650,1,Data Mining,0.31,0.38,0.28,0.0,0.0,0.0,0.0,0.03,zijun wang,
+CPSC,8810,6,Sel Topic: Deep Learning,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,feng luo,
+CPSC,8810,7,Selected Topics: Moti Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,
+CSM,1000,1,Intro to Construct,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
+CSM,2010,1,Structures I,0.61,0.21,0.12,0.03,0.0,0.0,0.0,0.03,shima clarke,
+CSM,2020,1,Structures II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
+CSM,2030,1,Mats & Meth of Const,0.29,0.55,0.16,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,
+CSM,2040,1,Cont Documents,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,robert dawso coffey,
+CSM,2050,1,Mats & Methods II,0.3,0.63,0.07,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,
+CSM,3040,1,Envir Systems I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3050,1,Envir Systems II,0.23,0.53,0.15,0.07,0.02,0.0,0.0,0.0,joseph mich burgett,
+CSM,3060,1,Emerging Tech in Construction,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,jason lucas,
+CSM,3070,1,Sustainable Construction,0.46,0.48,0.05,0.02,0.0,0.0,0.0,0.0,joseph mich burgett,
+CSM,3510,1,Construction Estimating,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,
+CSM,3520,1,Const Scheduling,0.78,0.19,0.0,0.03,0.0,0.0,0.0,0.0,craig townsend,
+CSM,3520,2,Const Scheduling,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,3520,2,Const Scheduling,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,jaime cruz,
+CSM,3530,1,Const Estimating II,0.42,0.45,0.13,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,
+CSM,3530,2,Const Estimating II,0.26,0.65,0.1,0.0,0.0,0.0,0.0,0.0,anthony dway harden,
+CSM,4110,1,Safety in Bldg Const,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,nicholas corley,
+CSM,4540,1,Const Capstone,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,dennis bausman,
+CSM,8600,1,Constr Finan Plan & Analysis,0.39,0.57,0.0,0.0,0.0,0.0,0.0,0.04,dennis bausman,
+CSM,8600,401,Constr Finan Plan & Analysis,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,dennis bausman,
+CSM,8680,401,Emerging Tech in Built Environ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jason lucas,
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,susan whorton,
+CU,1010,1,Univ Success Skills,0.4,0.1,0.25,0.0,0.05,0.0,0.0,0.2,valerie kay oonk,
+CU,1010,2,Univ Success Skills,0.47,0.24,0.18,0.06,0.0,0.0,0.0,0.06,alejandra kennedy,
+CU,1010,3,Univ Success Skills,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,bryn zimmerman babb,
+CU,1010,5,Univ Success Skills,0.45,0.25,0.15,0.0,0.05,0.0,0.0,0.1,bryn zimmerman babb,
+CU,1010,6,Univ Success Skills,0.74,0.11,0.0,0.05,0.11,0.0,0.0,0.0,james garland,
+CU,1010,7,Univ Success Skills,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,taimi olsen,
+CU,2010,1,Sustainability Leadership,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,
+CVT,2250,400,Ultrasound Physics,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ronda kel nicholson,
+DANC,1600,1,Ballet Dance I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,cheryl hosler,
+DPA,3070,1,Method 3d Production,0.37,0.44,0.07,0.04,0.0,0.0,0.0,0.07,tommy van bui,
+DPA,4020,1,Visual Found of Digital Prod,0.5,0.25,0.0,0.0,0.0,0.0,0.0,0.25,anthony summey,
+DPA,4030,1,Vis Foundations II,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,anthony summey,
+DPA,4830,1,Sp Stud Top: Digit Sculp Intro,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,insun kwon,
+DPA,8150,1,Special Effects Compositing,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,
+DPA,8150,843,Special Effects Compositing,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,
+ECE,2010,1,Logic and Computing Device,0.22,0.3,0.22,0.13,0.06,0.0,0.0,0.06,lin zhu,
+ECE,2020,1,Electric Circuits I,0.16,0.31,0.27,0.04,0.15,0.0,0.0,0.07,william harrell,
+ECE,2070,1,Basic Electrical Engineering,0.38,0.36,0.16,0.05,0.02,0.0,0.0,0.02,fatemeh tooryan,
+ECE,2070,2,Basic Electrical Engineering,0.59,0.25,0.09,0.03,0.01,0.0,0.0,0.03,timothy anglea,
+ECE,2070,3,Basic Electrical Engineering,0.23,0.42,0.19,0.02,0.0,0.0,0.12,0.02,william th kolodzey,
+ECE,2080,4,Basic Electrical Engr Lab,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,10,Basic Electrical Engr Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2080,18,Basic Electrical Engr Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2080,20,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
+ECE,2090,3,Logic & Computing Devices Lab,0.27,0.55,0.0,0.0,0.09,0.0,0.0,0.09,apoorva dee kapadia,
+ECE,2110,1,Elec Engr Lab I,0.47,0.21,0.05,0.05,0.05,0.0,0.0,0.16,apoorva dee kapadia,
+ECE,2110,2,Elec Engr Lab I,0.77,0.0,0.15,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
+ECE,2120,1,Electrical Engineering Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2120,6,Electrical Engineering Lab II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2120,9,Electrical Engineering Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,2220,1,Syst Prog Concept,0.18,0.33,0.24,0.04,0.14,0.0,0.0,0.07,william reid,
+ECE,2230,1,Comp Sys Eng,0.18,0.24,0.24,0.03,0.18,0.0,0.0,0.15,jon cameron calhoun,
+ECE,2620,1,Electric Circuits II,0.36,0.34,0.19,0.07,0.04,0.0,0.0,0.0,richard groff,
+ECE,2720,1,Comp Organization,0.37,0.37,0.2,0.02,0.03,0.0,0.0,0.0,william reid,
+ECE,2730,2,Computer Org Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3000,1,Junior Honors Seminar,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
+ECE,3000,1,Junior Honors Seminar,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,carl baum,True
+ECE,3110,2,Electrical Engineering Lab III,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,3,Electrical Engineering Lab III,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,4,Electrical Engineering Lab III,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3110,5,Electrical Engineering Lab III,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,apoorva dee kapadia,
+ECE,3120,3,Electrical Engineering Lab IV,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
+ECE,3170,1,Rand Signal Analysis,0.3,0.18,0.28,0.13,0.07,0.0,0.0,0.04,stephen hubbard,
+ECE,3200,1,Electronics I,0.3,0.24,0.19,0.16,0.08,0.0,0.0,0.03,stephen hubbard,
+ECE,3210,1,Electronics II,0.35,0.41,0.06,0.14,0.04,0.0,0.0,0.0,stephen hubbard,
+ECE,3220,1,Intro Operating Sys,0.21,0.38,0.24,0.03,0.03,0.0,0.0,0.1,jacob sorber,
+ECE,3220,2,Intro Operating Sys,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,rong ge,
+ECE,3270,1,Dig Comp Design,0.12,0.2,0.22,0.2,0.15,0.0,0.0,0.11,melissa crawl smith,
+ECE,3300,1,Signals & Systems,0.13,0.27,0.27,0.14,0.1,0.0,0.0,0.08,carl baum,
+ECE,3520,1,Programming Systems,0.66,0.3,0.02,0.0,0.0,0.0,0.0,0.02,robert schalkoff,
+ECE,3600,1,Elect Power Engr,0.3,0.24,0.24,0.05,0.0,0.0,0.03,0.14,edward collins,
+ECE,3710,1,Microcontr Interface,0.35,0.44,0.17,0.0,0.05,0.0,0.0,0.0,william reid,
+ECE,3720,3,Micro Int Lab,0.8,0.0,0.1,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
+ECE,3720,5,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3720,7,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,3800,1,Electromagnetics,0.24,0.23,0.16,0.08,0.1,0.0,0.0,0.19,yuan li,
+ECE,3810,1,Field Waves & Ckts,0.4,0.4,0.11,0.03,0.0,0.0,0.0,0.06,anthony martin,
+ECE,3990,5,CI: High-Perf. Cluster Comp.,0.8,0.0,0.0,0.2,0.0,0.0,0.0,0.0,jon cameron calhoun,
+ECE,4090,1,Intr to Linear Control Systems,0.68,0.13,0.15,0.0,0.02,0.0,0.0,0.02,ian walker,
+ECE,4160,1,Smart Grid,0.44,0.47,0.06,0.0,0.0,0.0,0.0,0.03,gan venayagamoorthy,
+ECE,4190,1,Elec Mach and Drives,0.25,0.25,0.2,0.15,0.05,0.0,0.0,0.1,johan heinri enslin,
+ECE,4270,1,Communications Sys,0.2,0.23,0.4,0.06,0.03,0.0,0.0,0.09,lu yu,
+ECE,4320,1,Instrumentation,0.1,0.5,0.3,0.1,0.0,0.0,0.0,0.0,goutam koley,
+ECE,4380,1,Computer Commun,0.24,0.29,0.24,0.06,0.0,0.0,0.03,0.15,harlan russell,
+ECE,4400,1,Local Computer Nets,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,kuang-ching wang,
+ECE,4680,1,Embedded Computing,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,adam hoover,
+ECE,4930,12,Industrial Contr & Automation,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
+ECE,4950,1,Int Sys Design I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
+ECE,4960,1,Int Sys Design II,0.58,0.34,0.07,0.0,0.0,0.0,0.0,0.01,richard groff,
+ECE,4990,18,CI: Deep Learning & Big Data,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,
+ECE,6190,1,Elec Mach and Drives,0.75,0.0,0.25,0.0,0.0,0.0,0.0,0.0,johan heinri enslin,
+ECE,6680,1,Embedded Computing,0.64,0.0,0.27,0.0,0.0,0.0,0.0,0.09,adam hoover,
+ECE,6930,2,Silicon Photonics Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,judson doug ryckman,
+ECE,6930,26,Optical Fiber Communications,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,liang dong,
+ECE,8170,1,Power System Transients,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ramtin hadidi,
+ECE,8240,1,Pow Sys Protection,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,sukumar maka brahma,
+ECE,8560,1,Pattern Recognition,0.21,0.37,0.16,0.0,0.0,0.0,0.0,0.26,robert schalkoff,
+ECE,8930,8,Advanced Photonic Sensors,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hai xiao,
+ECE,8930,11,Malware Reverse Engineering,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,
+ECE,8930,11,Malware Reverse Engineering,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,
+ECE,8930,843,Malware Rev. Engin. Charleston,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,
+ECE,8930,843,Malware Rev. Engin. Charleston,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,
+ECON,2000,1,Economic Concepts,0.38,0.34,0.16,0.0,0.06,0.0,0.0,0.06,shubhashrita basu,
+ECON,2000,2,Economic Concepts,0.4,0.35,0.13,0.05,0.0,0.0,0.0,0.08,shubhashrita basu,
+ECON,2000,3,Economic Concepts,0.65,0.23,0.03,0.05,0.03,0.0,0.0,0.03,miren ivankovic,
+ECON,2110,1,Principles of Microeconomics,0.4,0.23,0.28,0.08,0.03,0.0,0.0,0.0,sarah louise wilson,
+ECON,2110,2,Principles of Microeconomics,0.3,0.43,0.2,0.03,0.03,0.0,0.0,0.03,roksan ghanbariamin,
+ECON,2110,3,Principles of Microeconomics,0.34,0.27,0.21,0.09,0.08,0.0,0.0,0.01,benjamin posmanick,
+ECON,2110,4,Principles of Microeconomics,0.29,0.53,0.14,0.0,0.02,0.0,0.0,0.02,chen wang,
+ECON,2110,5,Principles of Microeconomics,0.33,0.38,0.2,0.08,0.0,0.0,0.0,0.03,molly espey,
+ECON,2110,6,Principles of Microeconomics,0.08,0.42,0.25,0.15,0.04,0.0,0.0,0.06,liuna issagholian,
+ECON,2110,8,Principles of Microeconomics,0.37,0.34,0.19,0.04,0.02,0.0,0.0,0.04,jonathan orr ernest,
+ECON,2110,10,Principles of Microeconomics,0.42,0.5,0.06,0.0,0.02,0.0,0.0,0.0,jacob walloga,
+ECON,2110,12,Principles of Microeconomics,0.38,0.45,0.13,0.0,0.0,0.0,0.0,0.05,molly espey,
+ECON,2120,1,Principles of Macroeconomics,0.38,0.06,0.5,0.0,0.06,0.0,0.0,0.0,scott baier,
+ECON,2120,2,Principles of Macroeconomics,0.22,0.28,0.39,0.11,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,3,Principles of Macroeconomics,0.28,0.5,0.11,0.06,0.06,0.0,0.0,0.0,scott baier,
+ECON,2120,4,Principles of Macroeconomics,0.11,0.42,0.37,0.11,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,5,Principles of Macroeconomics,0.22,0.33,0.44,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,6,Principles of Macroeconomics,0.5,0.07,0.21,0.07,0.14,0.0,0.0,0.0,scott baier,
+ECON,2120,7,Principles of Macroeconomics,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,8,Principles of Macroeconomics,0.17,0.28,0.44,0.06,0.06,0.0,0.0,0.0,scott baier,
+ECON,2120,9,Principles of Macroeconomics,0.53,0.21,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,10,Principles of Macroeconomics,0.26,0.32,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,11,Principles of Macroeconomics,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,12,Principles of Macroeconomics,0.36,0.14,0.36,0.14,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,13,Principles of Macroeconomics,0.5,0.3,0.15,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,14,Principles of Macroeconomics,0.37,0.42,0.16,0.05,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,15,Principles of Macroeconomics,0.24,0.47,0.18,0.12,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,16,Principles of Macroeconomics,0.61,0.17,0.17,0.06,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,17,Principles of Macroeconomics,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,scott baier,
+ECON,2120,18,Principles of Macroeconomics,0.42,0.26,0.16,0.05,0.11,0.0,0.0,0.0,scott baier,
+ECON,2120,19,Principles of Macroeconomics,0.22,0.33,0.33,0.11,0.0,0.0,0.0,0.0,scott baier,
+ECON,2120,20,Principles of Macroeconomics,0.31,0.23,0.31,0.05,0.0,0.0,0.03,0.08,narendra regmi,
+ECON,2120,21,Principles of Macroeconomics,0.84,0.14,0.02,0.0,0.0,0.0,0.0,0.0,tyler francis,
+ECON,2120,22,Principles of Macroeconomics,0.43,0.35,0.11,0.0,0.0,0.0,0.0,0.11,kenneth whaley,
+ECON,2120,23,Principles of Macroeconomics,0.39,0.26,0.26,0.0,0.05,0.0,0.0,0.03,kenneth whaley,
+ECON,2120,24,Principles of Macroeconomics,0.36,0.41,0.11,0.02,0.03,0.0,0.0,0.07,elijah neilson,
+ECON,2120,25,Principles of Macroeconomics,0.38,0.29,0.24,0.03,0.03,0.0,0.0,0.03,wing yin chung,
+ECON,2120,26,Principles of Macroeconomics,0.78,0.19,0.0,0.0,0.0,0.0,0.0,0.03,tyler francis,
+ECON,2120,27,Principles of Macroeconomics,0.38,0.38,0.12,0.03,0.09,0.0,0.0,0.0,benjamin ti harbolt,
+ECON,2120,28,Principles of Macroecon (HON),0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,christopher gorry,True
+ECON,2120,29,Principles of Macroeconomics,0.28,0.44,0.24,0.04,0.0,0.0,0.0,0.0,scott barkowski,
+ECON,3020,1,Money and Banking,0.15,0.49,0.34,0.0,0.02,0.0,0.0,0.0,smriti bhargava,
+ECON,3060,1,Managerial Economics,0.21,0.28,0.1,0.19,0.14,0.0,0.0,0.09,steven johnson,
+ECON,3100,1,International Econ,0.29,0.54,0.17,0.0,0.0,0.0,0.0,0.0,scott baier,
+ECON,3140,1,Intermediate Micro,0.32,0.24,0.18,0.06,0.03,0.0,0.0,0.18,yichen christy zhou,
+ECON,3140,2,Intermediate Micro,0.23,0.28,0.23,0.15,0.03,0.0,0.0,0.1,robert kennet fleck,
+ECON,3140,4,Intermediate Micro,0.19,0.11,0.22,0.14,0.16,0.0,0.0,0.19,frederick hanssen,
+ECON,3150,1,Intermediate Macro,0.27,0.27,0.2,0.1,0.06,0.0,0.0,0.1,michal jerzmanowski,
+ECON,3150,2,Intermediate Macro,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,jeremy choquette,
+ECON,3440,1,Property Rights,0.22,0.33,0.17,0.17,0.06,0.0,0.0,0.06,dar litsukova-bokar,
+ECON,3500,1,Moral & Ethical Econ,0.56,0.24,0.2,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
+ECON,3500,2,Moral & Ethical Econ,0.25,0.35,0.15,0.05,0.05,0.0,0.0,0.15,bradley keith hobbs,
+ECON,3600,1,Public Choice,0.3,0.48,0.18,0.03,0.0,0.0,0.0,0.03,michael makowsky,
+ECON,4010,1,Labor Mkt Analysis,0.27,0.47,0.17,0.03,0.03,0.0,0.0,0.03,curtis simon,
+ECON,4020,1,Law and Economics,0.23,0.4,0.28,0.02,0.0,0.0,0.0,0.07,thomas wins hazlett,
+ECON,4050,1,Intro to Econometric,0.33,0.25,0.08,0.25,0.06,0.0,0.0,0.03,scott barkowski,
+ECON,4050,2,Intro to Econometric,0.48,0.23,0.1,0.1,0.03,0.0,0.0,0.06,yichen christy zhou,
+ECON,4110,1,Econ of Education,0.56,0.29,0.06,0.03,0.0,0.0,0.0,0.06, garcia menendez,
+ECON,4200,1,Pub Sector Econ,0.24,0.19,0.48,0.05,0.0,0.0,0.0,0.05,william dougan,
+ECON,4230,1,Economics of Health,0.53,0.29,0.13,0.03,0.0,0.0,0.0,0.03,devon merritt gorry,
+ECON,4260,1,Sem Sport Economics,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,raymond sauer,
+ECON,4270,1,Dev American Economy,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,howard ne bodenhorn,
+ECON,4400,1,Game Theory,0.26,0.13,0.48,0.0,0.04,0.0,0.0,0.09,charles thomas,
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.0,0.18,0.55,0.18,0.09,0.0,0.0,0.0,scott templeton,
+ECON,4980,2,Why Business?,0.28,0.56,0.12,0.0,0.0,0.0,0.0,0.04,bradley keith hobbs,
+ECON,4980,3,Why Business?,0.6,0.3,0.07,0.0,0.0,0.0,0.0,0.02,lawrence ree watson,
+ECON,4980,4,Econ of Arts & Culture,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
+ECON,4980,5,Sel Topic - Machine Learning,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,chungsang lam,
+ECON,8020,2,Adv Econ Concepts and Applic I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
+ECON,8050,1,Macroeconomic Theory,0.5,0.14,0.29,0.07,0.0,0.0,0.0,0.0,michal jerzmanowski,
+ECON,9000,5,Sel Topic - Machine Learning,0.25,0.5,0.0,0.0,0.0,0.0,0.0,0.25,chungsang lam,
+ED,1050,2,Orientation to Education,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
+ED,1050,2,Orientation to Education,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,paula bailey adams,
+ED,1970,2,Creative Inquiry in Education,0.62,0.29,0.05,0.0,0.0,0.0,0.0,0.05,laurel ann whisler,
+ED,1970,2,Creative Inquiry in Education,0.62,0.29,0.05,0.0,0.0,0.0,0.0,0.05,elizabeth stephan,
+ED,3200,1,History of US Education,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,nafees mohamma khan,
+ED,3970,2,RMAN- Identity & Ldrship Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,3970,5,CI-Fundamentals of Scholarship,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,cherese france fine,
+ED,3970,5,CI-Fundamentals of Scholarship,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
+ED,8090,412,Teacher Residency Internship,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,marshall alan darby,
+ED,8090,412,Teacher Residency Internship,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,
+ED,8600,1,Classroom-Based Research,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daphne duncan wiles,
+ED,8650,1,Curriculum Theory,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
+ED,8750,500,Elements of Instructional Effe,0.93,0.02,0.02,0.0,0.0,0.0,0.0,0.02,susan rid nunamaker,
+EDC,2990,1,Creative Inq in Counselor Ed,0.71,0.19,0.1,0.0,0.0,0.0,0.0,0.0,jacob frankovich,
+EDC,3900,1,Skills for Student Leaders,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,erin mayor fogle,
+EDC,3900,4,Skills for Student Leaders,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,5,Skills for Student Leaders,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,3900,6,Skills for Student Leaders,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,eric pernotto,
+EDC,3900,10,Skills for Student Leaders,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,eric pernotto,
+EDC,3900,11,Skills for Student Leaders,0.76,0.12,0.06,0.06,0.0,0.0,0.0,0.0,eric pernotto,
+EDC,8850,1,Counseling Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david barrett,
+EDEL,3210,1,Pe for the Elem Tchr,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
+EDEL,4510,1,Elem Methods in Science Tchg,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daphne duncan wiles,
+EDEL,4520,1,Elem Methods Math Teaching,0.86,0.0,0.07,0.0,0.04,0.0,0.0,0.04,stacy jones,
+EDF,3020,1,Educational Psychology,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,karen rebecca clark,
+EDF,3020,3,Educational Psychology,0.79,0.18,0.03,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
+EDF,3020,5,Educational Psychology,0.65,0.3,0.0,0.03,0.0,0.0,0.0,0.03,heather rog brooker,
+EDF,3020,6,Educational Psychology,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,karen rebecca clark,
+EDF,3340,1,Child Growth and Development,0.88,0.06,0.0,0.0,0.03,0.0,0.0,0.03,robert o'hara,
+EDF,3340,3,Child Growth and Development,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,amanda eliz bennett,
+EDF,3350,3,Adolescent Growth & Develop,0.49,0.33,0.08,0.05,0.03,0.0,0.0,0.03,david barrett,
+EDF,4800,1,Digital Media & Learning,0.82,0.14,0.0,0.05,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,2,Digital Media & Learning,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,3,Digital Media & Learning,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,david matthew boyer,
+EDF,4800,300,Digital Media & Learning,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,4800,301,Digital Media & Learning,0.83,0.09,0.09,0.0,0.0,0.0,0.0,0.0,ryan visser,
+EDF,9710,1,Case Study & Ethnographic Mthd,0.71,0.18,0.0,0.0,0.12,0.0,0.0,0.0,cynthia chri deaton,
+EDF,9790,400,Qualitative Research in Educ,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,reginald wilkerson,
+EDHD,3110,1,CI- Research in DM & Learning,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,ryan visser,
+EDHD,3110,1,CI- Research in DM & Learning,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,david matthew boyer,
+EDHD,3110,8,CI- Children's Lit. Newsletter,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDHD,3110,9,CI- Read/Review Child/YA Lit.,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
+EDIS,9360,400,Advanced Program Evaluation,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,daniella hall,
+EDL,9000,400,Prin Edu Leadership,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,aris lane hall,
+EDLT,4620,1,Reading Children's Lit in Elem,0.68,0.21,0.0,0.07,0.0,0.0,0.0,0.04,jonda cecole mcnair,
+EDLT,4670,1,Teaching ESOL in Elem Schools,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,hazel vega quesada,
+EDLT,8120,301,Assessment in Reading & Writin,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,rachelle savitz,
+EDLT,8120,500,Assessment in Reading & Writin,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,
+EDLT,8220,300,Strategies for Teaching ESOL,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
+EDLT,8230,500,Introduction to Linguistics,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,emily smothe howell,
+EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,
+EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
+EDLT,8410,507,Early Literacy Inst Strategies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,
+EDLT,8410,507,Early Literacy Inst Strategies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,
+EDLT,8810,508,Reading Recovery Teacher II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,
+EDLT,8810,508,Reading Recovery Teacher II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,
+EDLT,8830,508,Read Recovery Practicum II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,
+EDLT,8830,508,Read Recovery Practicum II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,
+EDSP,3700,2,Intro to Special Education,0.56,0.31,0.06,0.06,0.0,0.0,0.0,0.0,friggita johnson,
+EDSP,3700,4,Intro to Special Education,0.8,0.14,0.03,0.0,0.03,0.0,0.0,0.0,shanna eisne hirsch,
+EDSP,3700,300,Intro to Special Education,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,
+EDSP,3730,1,Char & Instr of ID & Autism,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
+EDSP,3750,1,Early Intervention Spec Needs,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
+EDSP,4910,1,Ed Assess Ind W/Dis,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
+EDSP,4950,1,Comm & Collab Sp Ed,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,wendell kent parker,
+EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,wendell kent parker,
+EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,beverly lu romansky,
+EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,
+EES,2020,1,Environ Engr Fundamentals II,0.63,0.22,0.15,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
+EES,4010,1,Environmental Engr,0.63,0.3,0.02,0.0,0.0,0.0,0.0,0.05,elizabeth carraway,
+EES,4010,2,Environmental Engr,0.38,0.43,0.08,0.08,0.05,0.0,0.0,0.0,ezra lucas ho cates,
+EES,4020,1,Water & Waste Water Treatment,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,mark schlautman,
+EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,sudeep popat,
+EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
+EES,4850,1,Hazard Waste Management,0.29,0.42,0.16,0.03,0.0,0.0,0.0,0.1,mark schlautman,
+EES,4860,1,Environmental Sustainability,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,michael anthon dale,
+EES,4860,2,Environmental Sustainability,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
+EES,4900,15,CI: From Drones to 3D Printing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael anthon dale,
+EES,4900,15,CI: From Drones to 3D Printing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,pat carbajales-dale,
+EES,8330,2,Air Poll Control Sys,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,andrew rich metcalf,
+ELE,3010,1,Entrepreneurial Foundations,0.44,0.44,0.1,0.03,0.0,0.0,0.0,0.0,christina kyprianou,
+ELE,3010,2,Entrepreneurial Foundations,0.54,0.35,0.11,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
+ELE,3010,3,Entrepreneurial Foundations,0.15,0.5,0.28,0.0,0.0,0.0,0.0,0.08,ashley will parnell,
+ELE,3010,4,Entrepreneurial Foundations,0.2,0.39,0.37,0.02,0.0,0.0,0.0,0.02,ashley will parnell,
+ELE,3020,1,Entrepreneurial Resource Acqu,0.3,0.6,0.08,0.03,0.0,0.0,0.0,0.0,karl bruce kelly,
+ELE,3020,2,Entrepreneurial Resource Acqu,0.25,0.53,0.2,0.0,0.0,0.0,0.0,0.03,karl bruce kelly,
+ELE,4010,1,Venture Testing,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,chad navis,
+ELE,4010,2,Venture Testing,0.5,0.4,0.08,0.03,0.0,0.0,0.0,0.0,chad navis,
+ELE,4020,1,Venture Creation,0.13,0.73,0.13,0.0,0.0,0.0,0.0,0.0,william fra dinardo,
+ELE,4030,1,Venture Growth,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,james keith hudgins,
+ENGL,1030,1,Composition and Rhetoric,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,allen swords,
+ENGL,1030,2,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,1030,3,Composition and Rhetoric,0.47,0.27,0.13,0.07,0.0,0.0,0.0,0.07,naomi marie white,
+ENGL,1030,4,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,naomi marie white,
+ENGL,1030,5,Composition and Rhetoric,0.5,0.36,0.0,0.07,0.0,0.0,0.0,0.07,kristian wilson,
+ENGL,1030,6,Composition and Rhetoric,0.33,0.44,0.06,0.0,0.06,0.0,0.0,0.11,kristian wilson,
+ENGL,1030,8,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
+ENGL,1030,9,Composition and Rhetoric,0.5,0.31,0.06,0.0,0.06,0.0,0.0,0.06,myers addison enlow,
+ENGL,1030,10,Composition and Rhetoric,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,myers addison enlow,
+ENGL,1030,11,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,julie edewaard,
+ENGL,1030,12,Composition and Rhetoric,0.86,0.07,0.0,0.07,0.0,0.0,0.0,0.0,julie edewaard,
+ENGL,1030,14,Composition and Rhetoric,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,blake elizab bowens,
+ENGL,1030,15,Composition and Rhetoric,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,charissa fryberger,
+ENGL,1030,16,Composition and Rhetoric,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,charissa fryberger,
+ENGL,1030,17,Composition and Rhetoric,0.47,0.2,0.0,0.0,0.13,0.0,0.0,0.2,tareva lese johnson,
+ENGL,1030,18,Composition and Rhetoric,0.29,0.43,0.14,0.0,0.14,0.0,0.0,0.0,chelsea mari clarey,
+ENGL,1030,19,Composition and Rhetoric,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,la'cresha ulo green,
+ENGL,1030,20,Composition and Rhetoric,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
+ENGL,1030,22,Composition and Rhetoric,0.27,0.33,0.27,0.0,0.07,0.0,0.0,0.07,david charles foltz,
+ENGL,1030,23,Composition and Rhetoric,0.45,0.18,0.18,0.09,0.0,0.0,0.0,0.09,david charles foltz,
+ENGL,1030,25,Composition and Rhetoric,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
+ENGL,1030,27,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,hannah pittm godwin,
+ENGL,1030,28,Composition and Rhetoric,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,hannah pittm godwin,
+ENGL,1030,29,Composition and Rhetoric,0.21,0.57,0.14,0.0,0.07,0.0,0.0,0.0,henna maria messina,
+ENGL,1030,31,Composition and Rhetoric,0.4,0.1,0.3,0.0,0.0,0.0,0.0,0.2,geveryl le robinson,
+ENGL,1030,32,Composition and Rhetoric,0.18,0.59,0.18,0.0,0.0,0.0,0.0,0.06,sharon kathl nalley,
+ENGL,1030,33,Composition and Rhetoric,0.5,0.25,0.0,0.0,0.0,0.0,0.08,0.17,cody hunter,
+ENGL,1030,34,Composition and Rhetoric,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,cody hunter,
+ENGL,1030,35,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kailan smi sindelar,
+ENGL,1030,37,Composition and Rhetoric,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,shauna chung,
+ENGL,1030,38,Composition and Rhetoric,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,shauna chung,
+ENGL,1030,39,Composition and Rhetoric,0.53,0.33,0.0,0.0,0.07,0.0,0.0,0.07,jacob dania richter,
+ENGL,1030,40,Composition and Rhetoric,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,jacob dania richter,
+ENGL,1030,41,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,sarah el richardson,
+ENGL,1030,42,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah el richardson,
+ENGL,1030,45,Composition and Rhetoric,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,1030,46,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,
+ENGL,1030,47,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,caroline eliz young,
+ENGL,1030,48,Composition and Rhetoric,0.33,0.44,0.11,0.06,0.06,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,1030,49,Composition and Rhetoric,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,
+ENGL,1030,50,Composition and Rhetoric,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,
+ENGL,1030,51,Composition and Rhetoric,0.53,0.33,0.07,0.0,0.0,0.0,0.07,0.0,chloe mich whitaker,
+ENGL,1030,52,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jennie el wakefield,
+ENGL,1030,53,Composition and Rhetoric,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,michelle lloyd,
+ENGL,1030,55,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,caroline eliz young,
+ENGL,1030,56,Composition and Rhetoric,0.4,0.2,0.2,0.1,0.1,0.0,0.0,0.0,bree laran beal,
+ENGL,1030,58,Composition and Rhetoric,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,tareva lese johnson,
+ENGL,1030,59,Composition and Rhetoric,0.43,0.36,0.07,0.07,0.07,0.0,0.0,0.0,mary catheri nestor,
+ENGL,1030,60,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mary catheri nestor,
+ENGL,1030,61,Composition and Rhetoric,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,bree laran beal,
+ENGL,1030,63,Composition and Rhetoric,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,
+ENGL,1030,65,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,1030,68,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,1030,69,Composition and Rhetoric,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,1030,70,Composition and Rhetoric,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jennifer forsberg,
+ENGL,1030,71,Composition and Rhetoric,0.55,0.18,0.0,0.27,0.0,0.0,0.0,0.0,bree laran beal,
+ENGL,1030,73,Composition and Rhetoric,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,caitlin grace watt,
+ENGL,1030,74,Composition and Rhetoric,0.36,0.36,0.09,0.09,0.09,0.0,0.0,0.0,edward thomas troy,
+ENGL,1030,75,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,edward thomas troy,
+ENGL,1030,76,Composition and Rhetoric,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,edward thomas troy,
+ENGL,1030,77,Composition and Rhetoric,0.36,0.27,0.18,0.0,0.09,0.0,0.0,0.09,tareva lese johnson,
+ENGL,1030,78,Composition and Rhetoric,0.53,0.24,0.06,0.0,0.0,0.0,0.0,0.18,andrew mathas,
+ENGL,1030,79,Composition and Rhetoric,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,1030,101,Composition and Rhetoric (HON),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,allison nico harris,True
+ENGL,2120,1,World Literature,0.64,0.18,0.04,0.07,0.04,0.0,0.0,0.02,walter edgar hunter,
+ENGL,2120,2,World Literature,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,elizabeth stansell,
+ENGL,2120,4,World Literature,0.71,0.21,0.0,0.04,0.0,0.0,0.0,0.04,elizabeth stansell,
+ENGL,2120,7,World Literature,0.2,0.48,0.12,0.04,0.04,0.0,0.0,0.12,david charles foltz,
+ENGL,2120,8,World Literature,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,david charles foltz,
+ENGL,2120,9,World Literature,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.13,gregory luke chwala,
+ENGL,2120,10,World Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,gregory luke chwala,
+ENGL,2120,12,World Literature,0.52,0.24,0.12,0.08,0.0,0.0,0.0,0.04,kathy elaine nixon,
+ENGL,2120,13,World Literature,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,kathy elaine nixon,
+ENGL,2120,14,World Literature,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,heather pr williams,
+ENGL,2120,15,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,heather pr williams,
+ENGL,2120,16,World Literature,0.4,0.44,0.16,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
+ENGL,2120,17,World Literature,0.44,0.48,0.0,0.04,0.0,0.0,0.0,0.04,chloe mich whitaker,
+ENGL,2120,20,World Literature,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,patricia sunia,
+ENGL,2120,21,World Literature,0.59,0.32,0.05,0.0,0.0,0.0,0.0,0.05,patricia sunia,
+ENGL,2120,22,World Literature,0.5,0.29,0.13,0.08,0.0,0.0,0.0,0.0,karen kettnich,
+ENGL,2120,23,World Literature,0.35,0.43,0.09,0.04,0.04,0.0,0.0,0.04,karen kettnich,
+ENGL,2120,24,World Literature,0.42,0.53,0.0,0.0,0.05,0.0,0.0,0.0,gregory luke chwala,
+ENGL,2120,25,World Literature,0.27,0.5,0.18,0.0,0.0,0.0,0.05,0.0,kenneth micha tuite,
+ENGL,2120,26,World Literature,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,spencer tricker,
+ENGL,2120,27,World Literature,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,spencer tricker,
+ENGL,2120,28,World Literature,0.57,0.3,0.0,0.04,0.04,0.0,0.0,0.04,spencer tricker,
+ENGL,2120,400,World Literature,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,elizabeth stansell,
+ENGL,2130,1,British Literature,0.48,0.35,0.04,0.0,0.0,0.0,0.0,0.13,krist aldebol-hazle,
+ENGL,2130,2,British Literature,0.6,0.16,0.08,0.0,0.04,0.0,0.0,0.12,krist aldebol-hazle,
+ENGL,2130,3,British Literature,0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,megan no macalystre,
+ENGL,2130,4,British Literature,0.16,0.6,0.12,0.0,0.04,0.0,0.0,0.08,megan no macalystre,
+ENGL,2130,5,British Literature,0.48,0.36,0.0,0.04,0.04,0.0,0.0,0.08,lucian ghita,
+ENGL,2130,6,British Literature,0.72,0.2,0.04,0.04,0.0,0.0,0.0,0.0,lucian ghita,
+ENGL,2130,10,British Literature,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
+ENGL,2130,11,British Literature,0.64,0.32,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,
+ENGL,2130,12,British Literature,0.27,0.32,0.14,0.0,0.18,0.0,0.0,0.09,megan no macalystre,
+ENGL,2130,13,British Literature,0.6,0.32,0.0,0.08,0.0,0.0,0.0,0.0,daniel scott citro,
+ENGL,2130,14,British Literature,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ingrid anna pierce,
+ENGL,2130,15,British Literature,0.76,0.16,0.04,0.04,0.0,0.0,0.0,0.0,ingrid anna pierce,
+ENGL,2130,16,British Literature,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,caitlin grace watt,
+ENGL,2130,17,British Literature,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,caitlin grace watt,
+ENGL,2130,18,British Literature,0.84,0.08,0.0,0.0,0.08,0.0,0.0,0.0,ingrid anna pierce,
+ENGL,2130,19,British Literature,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,caitlin grace watt,
+ENGL,2140,1,American Literature,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,2,American Literature,0.64,0.24,0.04,0.04,0.04,0.0,0.0,0.0,melissa dugan,
+ENGL,2140,3,American Literature,0.29,0.25,0.33,0.08,0.0,0.0,0.0,0.04,chelsea mari clarey,
+ENGL,2140,4,American Literature,0.12,0.48,0.32,0.0,0.04,0.0,0.0,0.04,chelsea mari clarey,
+ENGL,2140,5,American Literature,0.26,0.48,0.13,0.0,0.04,0.0,0.0,0.09,remley melis makala,
+ENGL,2140,6,American Literature,0.5,0.29,0.13,0.0,0.0,0.0,0.0,0.08,remley melis makala,
+ENGL,2140,7,American Literature,0.27,0.4,0.33,0.0,0.0,0.0,0.0,0.0,chelsea mari clarey,
+ENGL,2140,8,American Literature,0.43,0.26,0.13,0.0,0.0,0.0,0.0,0.17,remley melis makala,
+ENGL,2140,11,American Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,
+ENGL,2140,12,American Literature,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,
+ENGL,2140,13,American Literature,0.67,0.21,0.04,0.0,0.04,0.0,0.0,0.04,caroline eliz young,
+ENGL,2140,14,American Literature,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliz young,
+ENGL,2140,20,American Literature,0.35,0.4,0.05,0.0,0.05,0.0,0.0,0.15,mary catheri nestor,
+ENGL,2140,21,American Literature,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.04,mary catheri nestor,
+ENGL,2140,100,American Literature (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,True
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,allison nico harris,
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.76,0.12,0.04,0.0,0.08,0.0,0.0,0.0,allison nico harris,
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.56,0.32,0.0,0.04,0.0,0.0,0.0,0.08,lindsey henley kurz,
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,allen swords,
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,andrew mathas,
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.48,0.32,0.16,0.04,0.0,0.0,0.0,0.0,andrew mathas,
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.79,0.13,0.04,0.04,0.0,0.0,0.0,0.0,allison nico harris,
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.4,0.32,0.2,0.04,0.0,0.0,0.0,0.04,julia brownle koets,
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.12,0.68,0.16,0.04,0.0,0.0,0.0,0.0,julia brownle koets,
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.05,0.59,0.23,0.05,0.05,0.0,0.0,0.05,sarah mae cooper,
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.36,0.36,0.2,0.0,0.0,0.0,0.0,0.08,hannah pittm godwin,
+ENGL,2150,18,Lit in 20th-21st Cent Contexts,0.76,0.2,0.0,0.0,0.04,0.0,0.0,0.0,lindsey henley kurz,
+ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,lindsey henley kurz,
+ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,hannah pittm godwin,
+ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.6,0.24,0.12,0.04,0.0,0.0,0.0,0.0,john logan pursley,
+ENGL,2150,100,Lit in 20th-21st Cent (HON),0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
+ENGL,2150,405,Lit in 20th-21st Cent Contexts,0.08,0.5,0.27,0.08,0.0,0.0,0.0,0.08,sarah mae cooper,
+ENGL,2150,406,Lit in 20th-21st Cent Contexts,0.05,0.7,0.25,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+ENGL,2160,1,African American Literature,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,
+ENGL,2160,2,African American Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
+ENGL,2160,3,African American Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
+ENGL,2310,1,Intro to Journalism,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3040,1,Business Writing,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,patricia sunia,
+ENGL,3040,2,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
+ENGL,3040,3,Business Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william cunningham,
+ENGL,3040,4,Business Writing,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,william cunningham,
+ENGL,3040,5,Business Writing,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,la'cresha ulo green,
+ENGL,3040,6,Business Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulo green,
+ENGL,3040,7,Business Writing,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,katalin beck,
+ENGL,3040,8,Business Writing,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3040,10,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,
+ENGL,3040,11,Business Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,heather pr williams,
+ENGL,3040,12,Business Writing,0.37,0.47,0.05,0.11,0.0,0.0,0.0,0.0,heather pr williams,
+ENGL,3040,13,Business Writing,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,patricia sunia,
+ENGL,3040,400,Business Writing,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,krist aldebol-hazle,
+ENGL,3040,401,Business Writing,0.7,0.25,0.0,0.05,0.0,0.0,0.0,0.0,krist aldebol-hazle,
+ENGL,3040,402,Business Writing,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,megan pietruszewski,
+ENGL,3040,403,Business Writing,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,megan pietruszewski,
+ENGL,3040,404,Business Writing,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,heather pr williams,
+ENGL,3100,1,Crit Writ Lit,0.53,0.12,0.12,0.0,0.0,0.0,0.0,0.24,kimberly manganelli,
+ENGL,3100,2,Crit Writ Lit,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,erin marina goss,
+ENGL,3100,3,Crit Writ Lit,0.67,0.29,0.0,0.05,0.0,0.0,0.0,0.0,matthew hooley,
+ENGL,3120,1,Advanced Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher stuart,
+ENGL,3120,2,Advanced Composition,0.63,0.19,0.06,0.0,0.06,0.0,0.0,0.06,christopher stuart,
+ENGL,3120,4,Advanced Composition,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,christopher benson,
+ENGL,3120,5,Advanced Composition,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,jennie el wakefield,
+ENGL,3140,1,Technical Writing,0.35,0.55,0.05,0.05,0.0,0.0,0.0,0.0,william cunningham,
+ENGL,3140,2,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william cunningham,
+ENGL,3140,3,Technical Writing,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,april 'brien,
+ENGL,3140,4,Technical Writing,0.53,0.26,0.11,0.05,0.0,0.0,0.0,0.05,april 'brien,
+ENGL,3140,7,Technical Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,8,Technical Writing,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,katalin beck,
+ENGL,3140,9,Technical Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,henna maria messina,
+ENGL,3140,10,Technical Writing,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,henna maria messina,
+ENGL,3140,11,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,brian lee gaines,
+ENGL,3140,13,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,
+ENGL,3140,14,Technical Writing,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,dia quaglia beltran,
+ENGL,3140,21,Technical Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,kathy elaine nixon,
+ENGL,3140,22,Technical Writing,0.58,0.26,0.0,0.0,0.0,0.0,0.0,0.16,kathy elaine nixon,
+ENGL,3140,25,Technical Writing,0.67,0.17,0.11,0.0,0.0,0.0,0.0,0.06,megan pietruszewski,
+ENGL,3140,26,Technical Writing,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,megan pietruszewski,
+ENGL,3140,30,Technical Writing,0.22,0.56,0.11,0.11,0.0,0.0,0.0,0.0,henna maria messina,
+ENGL,3140,400,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,
+ENGL,3140,401,Technical Writing,0.79,0.05,0.05,0.05,0.0,0.0,0.0,0.05,geveryl le robinson,
+ENGL,3140,402,Technical Writing,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,geveryl le robinson,
+ENGL,3140,403,Technical Writing,0.74,0.16,0.0,0.0,0.0,0.0,0.0,0.11,geveryl le robinson,
+ENGL,3150,1,Scientific Writing & Comm,0.35,0.35,0.24,0.06,0.0,0.0,0.0,0.0,william pulley,
+ENGL,3150,2,Scientific Writing & Comm,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,william pulley,
+ENGL,3150,3,Scientific Writing & Comm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,4,Scientific Writing & Comm,0.5,0.17,0.22,0.0,0.0,0.0,0.0,0.11,william pulley,
+ENGL,3150,5,Scientific Writing & Comm,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
+ENGL,3150,6,Scientific Writing & Comm,0.7,0.15,0.0,0.05,0.05,0.0,0.0,0.05,christopher benson,
+ENGL,3150,400,Scientific Writing & Comm,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,philip randall,
+ENGL,3150,402,Scientific Writing & Comm,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,philip randall,
+ENGL,3150,405,Scientific Writing & Comm,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,philip randall,
+ENGL,3460,1,Intr Creative Writing: Poetry,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,sarah mae cooper,
+ENGL,3480,1,Intr Creat Writ: Screenwriting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,julia brownle koets,
+ENGL,3490,1,Tech/Pop Imagination,0.44,0.25,0.06,0.0,0.19,0.0,0.0,0.06,gabriel and hankins,
+ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,angela naimou,
+ENGL,3550,1,Global Studies in Pop Culture,0.22,0.67,0.06,0.0,0.0,0.0,0.0,0.06,spencer tricker,
+ENGL,3570,1,Film,0.16,0.68,0.05,0.0,0.05,0.0,0.0,0.05,amy monaghan,
+ENGL,3570,2,Film,0.15,0.7,0.1,0.0,0.05,0.0,0.0,0.0,amy monaghan,
+ENGL,3570,3,Film,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,john robert smith,
+ENGL,3570,4,Film,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,
+ENGL,3860,1,Adolescent Lit,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,megan no macalystre,
+ENGL,3960,1,Brit Lit Survey I,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,james funk,
+ENGL,3960,2,Brit Lit Survey I,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,ingrid anna pierce,
+ENGL,3970,1,Brit Lit Survey II,0.17,0.61,0.17,0.0,0.0,0.0,0.0,0.06,brian mcgrath,
+ENGL,3980,1,Amer Lit Survey I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,
+ENGL,3990,1,Amer Lit Survey II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,
+ENGL,4000,1,The English Language,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,andrew lemons,
+ENGL,4070,1,Medieval Period,0.8,0.05,0.05,0.05,0.0,0.0,0.0,0.05,andrew lemons,
+ENGL,4100,1,Drama of English Renaissance,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lucian ghita,
+ENGL,4110,1,Shakespeare,0.43,0.43,0.0,0.07,0.07,0.0,0.0,0.0,james funk,
+ENGL,4110,2,Shakespeare,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,james funk,
+ENGL,4110,3,Shakespeare,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
+ENGL,4190,1,Post Col & World Lit,0.73,0.0,0.13,0.0,0.0,0.0,0.0,0.13,angela naimou,
+ENGL,4210,1,Amer Lit 1800-1899,0.42,0.42,0.11,0.0,0.0,0.0,0.05,0.0,dominic mastroianni,
+ENGL,4280,1,Contemporary Literature,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,lindsey henley kurz,
+ENGL,4320,1,Modern Fiction,0.63,0.06,0.25,0.06,0.0,0.0,0.0,0.0,jillian weise,
+ENGL,4400,1,Literary Theory,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
+ENGL,4420,1,Cultural Studies,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,bree laran beal,
+ENGL,4450,1,Fiction Workshop,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
+ENGL,4480,1,Screenwriting Wkshop,0.73,0.2,0.0,0.07,0.0,0.0,0.0,0.0,nicholas chri brown,
+ENGL,4490,1,Creative Non-Fiction,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,julia brownle koets,
+ENGL,4500,1,Film Genres,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,john robert smith,
+ENGL,4510,1,Film Theory and Criticism,0.56,0.22,0.0,0.0,0.22,0.0,0.0,0.0,john robert smith,
+ENGL,4530,1,Sexuality and the Cinema,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,edward thomas troy,
+ENGL,4540,1,Sel Top in International Film,0.5,0.25,0.0,0.0,0.0,0.0,0.0,0.25,jamie ann rogers,
+ENGL,4640,1,Topics in Literature 1700-1899,0.37,0.37,0.11,0.11,0.05,0.0,0.0,0.0,erin marina goss,
+ENGL,4750,1,Writing for Media,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
+ENGL,4830,1,Af Am Lit 1920-Pres,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,tareva lese johnson,
+ENGL,4850,1,Comp & Lang Teachers,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,
+ENGL,4910,1,Classical Rhetoric,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,tharon howard,
+ENGL,4960,4,Senior Seminar,0.67,0.17,0.0,0.0,0.08,0.0,0.0,0.08,kimberly manganelli,
+ENGR,1020,211,Engineering Discipl & Skills,0.13,0.39,0.16,0.13,0.06,0.0,0.0,0.13,irene marie ferrara,
+ENGR,1020,211,Engineering Discipl & Skills,0.13,0.39,0.16,0.13,0.06,0.0,0.0,0.13,ashley childers,
+ENGR,1020,212,Engineering Discipl & Skills,0.13,0.35,0.19,0.06,0.13,0.0,0.0,0.13,ashley childers,
+ENGR,1020,212,Engineering Discipl & Skills,0.13,0.35,0.19,0.06,0.13,0.0,0.0,0.13,irene marie ferrara,
+ENGR,1020,213,Engineering Discipl & Skills,0.11,0.32,0.32,0.04,0.04,0.0,0.0,0.18,john minor,
+ENGR,1020,213,Engineering Discipl & Skills,0.11,0.32,0.32,0.04,0.04,0.0,0.0,0.18,irene marie ferrara,
+ENGR,1020,214,Engineering Discipl & Skills,0.27,0.2,0.23,0.03,0.07,0.0,0.0,0.2,john minor,
+ENGR,1020,214,Engineering Discipl & Skills,0.27,0.2,0.23,0.03,0.07,0.0,0.0,0.2,irene marie ferrara,
+ENGR,1410,123,Programming & Problem Solving,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,matthew kent miller,
+ENGR,1410,123,Programming & Problem Solving,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,william martin,
+ENGR,1410,124,Programming & Problem Solving,0.33,0.47,0.19,0.0,0.0,0.0,0.0,0.0,william martin,
+ENGR,1410,124,Programming & Problem Solving,0.33,0.47,0.19,0.0,0.0,0.0,0.0,0.0,matthew kent miller,
+ENGR,1410,127,Programming & Problem Solving,0.25,0.5,0.17,0.03,0.0,0.0,0.0,0.06,matthew kent miller,
+ENGR,1410,127,Programming & Problem Solving,0.25,0.5,0.17,0.03,0.0,0.0,0.0,0.06,william martin,
+ENGR,1410,324,Programming & Problem Solving,0.35,0.33,0.23,0.05,0.0,0.0,0.0,0.05,mariah magagnotti,
+ENGR,1410,324,Programming & Problem Solving,0.35,0.33,0.23,0.05,0.0,0.0,0.0,0.05,william martin,
+ENGR,1410,325,Programming & Problem Solving,0.33,0.44,0.18,0.03,0.0,0.0,0.0,0.03,mariah magagnotti,
+ENGR,1410,325,Programming & Problem Solving,0.33,0.44,0.18,0.03,0.0,0.0,0.0,0.03,william martin,
+ENGR,1410,326,Programming & Problem Solving,0.19,0.49,0.14,0.0,0.0,0.0,0.0,0.19,mariah magagnotti,
+ENGR,1410,326,Programming & Problem Solving,0.19,0.49,0.14,0.0,0.0,0.0,0.0,0.19,william martin,
+ENGR,1410,621,Programming & Problem Solving,0.19,0.49,0.22,0.03,0.03,0.0,0.0,0.05,william martin,
+ENGR,1410,621,Programming & Problem Solving,0.19,0.49,0.22,0.03,0.03,0.0,0.0,0.05,john minor,
+ENGR,1410,622,Programming & Problem Solving,0.28,0.28,0.35,0.0,0.0,0.0,0.0,0.1,john minor,
+ENGR,1410,622,Programming & Problem Solving,0.28,0.28,0.35,0.0,0.0,0.0,0.0,0.1,william martin,
+ENGR,1410,623,Programming & Problem Solving,0.41,0.28,0.13,0.03,0.05,0.0,0.0,0.1,john minor,
+ENGR,1410,623,Programming & Problem Solving,0.41,0.28,0.13,0.03,0.05,0.0,0.0,0.1,william martin,
+ENGR,1410,624,Programming & Problem Solving,0.18,0.5,0.18,0.08,0.0,0.0,0.0,0.05,william martin,
+ENGR,1410,624,Programming & Problem Solving,0.18,0.5,0.18,0.08,0.0,0.0,0.0,0.05,michael giebner,
+ENGR,1410,625,Programming & Problem Solving,0.18,0.37,0.34,0.11,0.0,0.0,0.0,0.0,william martin,
+ENGR,1410,625,Programming & Problem Solving,0.18,0.37,0.34,0.11,0.0,0.0,0.0,0.0,michael giebner,
+ENGR,1410,626,Programming & Problem Solving,0.3,0.4,0.13,0.13,0.0,0.0,0.0,0.03,elizabeth stephan,
+ENGR,1410,626,Programming & Problem Solving,0.3,0.4,0.13,0.13,0.0,0.0,0.0,0.03,william martin,
+ENGR,1410,627,Programming & Problem Solving,0.35,0.53,0.1,0.0,0.0,0.0,0.0,0.03,jonathan bro harcum,
+ENGR,1410,627,Programming & Problem Solving,0.35,0.53,0.1,0.0,0.0,0.0,0.0,0.03,william martin,
+ENGR,1410,721,Programming & Problem Solving,0.19,0.45,0.23,0.06,0.03,0.0,0.0,0.03,william martin,
+ENGR,1410,721,Programming & Problem Solving,0.19,0.45,0.23,0.06,0.03,0.0,0.0,0.03,john minor,
+ENGR,1410,722,Programming & Problem Solving,0.5,0.34,0.13,0.0,0.03,0.0,0.0,0.0,elizabeth stephan,
+ENGR,1410,722,Programming & Problem Solving,0.5,0.34,0.13,0.0,0.03,0.0,0.0,0.0,william martin,
+ENGR,1410,725,Programming & Problem Solving,0.47,0.25,0.22,0.0,0.03,0.0,0.0,0.03,william martin,
+ENGR,1410,725,Programming & Problem Solving,0.47,0.25,0.22,0.0,0.03,0.0,0.0,0.03,andrew isaa neptune,
+ENGR,1410,726,Programming & Problem Solving,0.31,0.38,0.22,0.03,0.0,0.0,0.0,0.06,william martin,
+ENGR,1410,726,Programming & Problem Solving,0.31,0.38,0.22,0.03,0.0,0.0,0.0,0.06,sarah grigg,
+ENGR,1410,727,Programming & Problem Solving,0.17,0.57,0.17,0.06,0.0,0.0,0.0,0.03,sarah grigg,
+ENGR,1410,727,Programming & Problem Solving,0.17,0.57,0.17,0.06,0.0,0.0,0.0,0.03,william martin,
+ENGR,1410,821,Programming & Problem Solving,0.23,0.58,0.13,0.0,0.03,0.0,0.0,0.03,andrew isaa neptune,
+ENGR,1410,821,Programming & Problem Solving,0.23,0.58,0.13,0.0,0.03,0.0,0.0,0.03,william martin,
+ENGR,1410,822,Programming & Problem Solving,0.17,0.5,0.31,0.03,0.0,0.0,0.0,0.0,andrew isaa neptune,
+ENGR,1410,822,Programming & Problem Solving,0.17,0.5,0.31,0.03,0.0,0.0,0.0,0.0,william martin,
+ENGR,1410,823,Program & Prob Solving (HON),0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,william martin,True
+ENGR,1410,823,Program & Prob Solving (HON),0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,True
+ENGR,1410,824,Program & Prob Solving (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,True
+ENGR,1410,824,Program & Prob Solving (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william martin,True
+ENGR,1410,825,Programming & Problem Solving,0.21,0.36,0.27,0.06,0.03,0.0,0.0,0.06,jonathan maier,
+ENGR,1410,825,Programming & Problem Solving,0.21,0.36,0.27,0.06,0.03,0.0,0.0,0.06,william martin,
+ENGR,1410,826,Programming & Problem Solving,0.29,0.37,0.16,0.03,0.05,0.0,0.0,0.11,william martin,
+ENGR,1410,826,Programming & Problem Solving,0.29,0.37,0.16,0.03,0.05,0.0,0.0,0.11,jonathan maier,
+ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.24,0.03,0.0,0.0,0.0,0.0,william martin,
+ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.24,0.03,0.0,0.0,0.0,0.0,jonathan maier,
+ENGR,1900,10,CI in Engr I (Robotics),0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,michael benj wooten,
+ENGR,2080,281,Engr Graphics & Machine Design,0.38,0.44,0.15,0.0,0.0,0.0,0.0,0.04,nighat yasmin,
+ENGR,2080,281,Engr Graphics & Machine Design,0.38,0.44,0.15,0.0,0.0,0.0,0.0,0.04,samuel coeyman,
+ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.2,0.07,0.07,0.02,0.0,0.0,0.02,nighat yasmin,
+ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.2,0.07,0.07,0.02,0.0,0.0,0.02,samuel coeyman,
+ENGR,2080,284,Engr Graphics & Machine Design,0.62,0.22,0.11,0.04,0.0,0.0,0.0,0.0,nighat yasmin,
+ENGR,2080,284,Engr Graphics & Machine Design,0.62,0.22,0.11,0.04,0.0,0.0,0.0,0.0,nisha gulhane,
+ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,natalie pellizzi,
+ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,nighat yasmin,
+ENGR,2080,286,Engr Graphics & Machine Design,0.34,0.41,0.11,0.05,0.07,0.0,0.0,0.02,nighat yasmin,
+ENGR,2080,286,Engr Graphics & Machine Design,0.34,0.41,0.11,0.05,0.07,0.0,0.0,0.02,natalie pellizzi,
+ENGR,2080,382,Engr Graphics & Machine Design,0.56,0.24,0.09,0.02,0.07,0.0,0.0,0.02,nighat yasmin,
+ENGR,2080,382,Engr Graphics & Machine Design,0.56,0.24,0.09,0.02,0.07,0.0,0.0,0.02,nisha gulhane,
+ENGR,2080,682,Engr Graphics & Machine Design,0.59,0.28,0.13,0.0,0.0,0.0,0.0,0.0,kyle walker,
+ENGR,2080,682,Engr Graphics & Machine Design,0.59,0.28,0.13,0.0,0.0,0.0,0.0,0.0,nighat yasmin,
+ENGR,2080,684,Engr Graphics & Machine Design,0.6,0.19,0.05,0.02,0.07,0.0,0.0,0.07,nighat yasmin,
+ENGR,2080,684,Engr Graphics & Machine Design,0.6,0.19,0.05,0.02,0.07,0.0,0.0,0.07,kyle walker,
+ENGR,2080,882,Engr Graphics & Machine Design,0.6,0.26,0.04,0.04,0.04,0.0,0.0,0.02,nighat yasmin,
+ENGR,2080,882,Engr Graphics & Machine Design,0.6,0.26,0.04,0.04,0.04,0.0,0.0,0.02,apurva patel,
+ENGR,2080,884,Engr Graphics & Machine Design,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,nighat yasmin,
+ENGR,2080,884,Engr Graphics & Machine Design,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,apurva patel,
+ENGR,2100,101,CAD & Engineering Applications,0.52,0.28,0.04,0.04,0.07,0.0,0.0,0.04,afshin famili,
+ENGR,2100,101,CAD & Engineering Applications,0.52,0.28,0.04,0.04,0.07,0.0,0.0,0.04,nighat yasmin,
+ENGR,2100,102,CAD & Engineering Applications,0.44,0.33,0.1,0.08,0.0,0.0,0.0,0.04,nighat yasmin,
+ENGR,2100,102,CAD & Engineering Applications,0.44,0.33,0.1,0.08,0.0,0.0,0.0,0.04,afshin famili,
+ENGR,2100,105,CAD & Engineering Applications,0.71,0.19,0.02,0.02,0.02,0.0,0.0,0.02,john minor,
+ENGR,2100,105,CAD & Engineering Applications,0.71,0.19,0.02,0.02,0.02,0.0,0.0,0.02,nighat yasmin,
+ENGR,2100,106,CAD & Engineering Applications,0.5,0.35,0.04,0.0,0.02,0.0,0.0,0.08,nighat yasmin,
+ENGR,2100,106,CAD & Engineering Applications,0.5,0.35,0.04,0.0,0.02,0.0,0.0,0.08,john minor,
+ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.12,0.08,0.06,0.04,0.0,0.0,0.0,russell barrett,
+ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.12,0.08,0.06,0.04,0.0,0.0,0.0,alan johnson,
+ENR,3020,1,Nat Res Measurements,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,russell barrett,
+ENR,3020,1,Nat Res Measurements,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,lawrence gering,
+ENR,4130,2,Restoration Ecology,0.3,0.4,0.23,0.0,0.0,0.0,0.0,0.07,althea simone hagan,
+ENR,4500,1,Conservation Issues,0.87,0.09,0.0,0.04,0.0,0.0,0.0,0.0,alan johnson,
+ENR,4500,2,Conservation Issues,0.79,0.14,0.03,0.0,0.0,0.0,0.0,0.03,alan johnson,
+ENR,6130,1,Restoration Ecology,0.5,0.21,0.29,0.0,0.0,0.0,0.0,0.0,althea simone hagan,
+ENSP,2000,1,Intro Environ Sci,0.19,0.65,0.09,0.06,0.02,0.0,0.0,0.0,tom owino,
+ENSP,2000,2,Intro Environ Sci,0.57,0.37,0.0,0.0,0.0,0.0,0.0,0.06,elizabeth carraway,
+ENSP,2000,3,Intro Environ Sci,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,2010,1,Environm Sci for Educ Majors,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+ENSP,4000,1,Studies in Environmental Sci,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,margaret thompson,
+ENT,2000,1,Six-Legged Science,0.41,0.34,0.15,0.02,0.0,0.0,0.05,0.02,suellen pometto,
+ENT,8700,1,Insect Phys Mol Bio,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
+ENTR,1010,2,Entrepreneurial Mindset,0.64,0.27,0.05,0.0,0.0,0.0,0.01,0.03,john michael hannon,
+ENTR,1090,2,How to Start a Startup,0.71,0.07,0.04,0.0,0.0,0.0,0.0,0.18,john michael hannon,
+ENTR,1090,20,Lemonade Day Pendleton,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david joseph frock,
+ENTR,2010,1,Sports Entrepreneurship,0.77,0.16,0.05,0.0,0.0,0.0,0.0,0.02,john michael hannon,
+ESED,8500,1,Spec Top Engineering & Sci Edu,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,cindy lee,
+FCS,2010,1,Introduction to Human Rights,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,matthe hudson-flege,
+FDSC,2140,1,Fd Resources & Soc,0.7,0.23,0.04,0.03,0.0,0.0,0.0,0.0,paul dawson,
+FDSC,3040,1,Eval Dairy Products,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+FDSC,3040,1,Eval Dairy Products,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
+FDSC,4020,1,Food Chemistry II,0.73,0.24,0.02,0.0,0.0,0.0,0.0,0.0,feng chen,
+FDSC,4030,1,Food Ch & Analysis,0.67,0.27,0.02,0.02,0.0,0.0,0.0,0.02,feng chen,
+FDSC,4030,1,Food Ch & Analysis,0.67,0.27,0.02,0.02,0.0,0.0,0.0,0.02,paul dawson,
+FDSC,4080,1,Food Process Eng,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,steven brandon,
+FDSC,4500,7,Creative Inquiry-Food Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
+FDSC,4500,15,Creative Inquiry-Food Science,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vivian haley-zitlin,
+FDSC,4500,18,Creative Inquiry-Food Science,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,xiuping jiang,
+FDSC,4500,22,Creative Inquiry-Food Science,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,feng chen,
+FIN,2010,401,Intro to Personal Finance,0.93,0.01,0.04,0.0,0.01,0.0,0.0,0.0,joshua harris,
+FIN,2010,402,Intro to Personal Finance,0.97,0.01,0.01,0.0,0.0,0.0,0.0,0.0,joshua harris,
+FIN,2010,403,Intro to Personal Finance,0.91,0.01,0.03,0.0,0.03,0.0,0.0,0.01,joshua harris,
+FIN,2010,404,Intro to Personal Finance,0.72,0.16,0.01,0.01,0.06,0.0,0.0,0.03,joshua harris,
+FIN,2010,405,Intro to Personal Finance,0.79,0.15,0.0,0.03,0.0,0.0,0.0,0.03,joshua harris,
+FIN,2010,406,Intro to Personal Finance,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,joshua harris,
+FIN,3040,1,Risk & Insurance,0.2,0.28,0.35,0.08,0.1,0.0,0.0,0.0,kerri mcmillan,
+FIN,3050,1,Investment Analysis,0.17,0.27,0.44,0.05,0.0,0.0,0.0,0.07,kerri mcmillan,
+FIN,3050,2,Investment Analysis,0.26,0.24,0.39,0.05,0.0,0.0,0.0,0.05,kerri mcmillan,
+FIN,3050,3,Investment Analysis,0.18,0.38,0.28,0.05,0.0,0.0,0.0,0.1,kerri mcmillan,
+FIN,3050,4,Investment Analysis,0.17,0.23,0.26,0.11,0.03,0.0,0.0,0.2,john alexander,
+FIN,3060,1,Corporation Finance,0.21,0.3,0.23,0.19,0.02,0.0,0.0,0.04,ramon tolb franklin,
+FIN,3060,2,Corporation Finance,0.21,0.21,0.27,0.19,0.02,0.0,0.0,0.1,ramon tolb franklin,
+FIN,3060,3,Corporation Finance,0.2,0.22,0.24,0.18,0.02,0.0,0.0,0.13,ramon tolb franklin,
+FIN,3060,4,Corporation Finance,0.13,0.2,0.24,0.29,0.04,0.0,0.0,0.09,ramon tolb franklin,
+FIN,3060,9,Corporation Finance,0.12,0.17,0.4,0.24,0.05,0.0,0.0,0.02,charles taylor vick,
+FIN,3060,401,Corporation Finance,0.3,0.25,0.25,0.13,0.03,0.0,0.0,0.04,jonathan godbey,
+FIN,3060,402,Corporation Finance,0.18,0.31,0.32,0.11,0.0,0.0,0.04,0.04,jonathan godbey,
+FIN,3060,601,Corporation Finance,0.06,0.69,0.25,0.0,0.0,0.0,0.0,0.0,jack wolf,
+FIN,3070,1,Prin of Real Estate,0.24,0.42,0.29,0.05,0.0,0.0,0.0,0.0,yannan shen,
+FIN,3070,2,Prin of Real Estate,0.29,0.37,0.24,0.03,0.05,0.0,0.0,0.03,yannan shen,
+FIN,3070,3,Prin of Real Estate,0.24,0.41,0.22,0.11,0.03,0.0,0.0,0.0,thomas springer,
+FIN,3070,4,Prin of Real Estate,0.19,0.19,0.39,0.19,0.03,0.0,0.0,0.0,thomas springer,
+FIN,3080,1,Fin Inst & Mkts,0.21,0.4,0.29,0.07,0.02,0.0,0.0,0.0,daniel thoma greene,
+FIN,3080,2,Fin Inst & Mkts,0.19,0.4,0.33,0.05,0.0,0.0,0.0,0.02,daniel thoma greene,
+FIN,3080,401,Fin Inst & Mkts,0.27,0.51,0.14,0.06,0.02,0.0,0.0,0.0,daniel thoma greene,
+FIN,3080,402,Fin Inst & Mkts,0.12,0.51,0.35,0.02,0.0,0.0,0.0,0.0,daniel thoma greene,
+FIN,3110,2,Financial Management I,0.22,0.32,0.22,0.04,0.01,0.0,0.0,0.18,george bra lockhart,
+FIN,3110,4,Financial Management I,0.22,0.31,0.22,0.06,0.03,0.0,0.0,0.15,george bra lockhart,
+FIN,3110,5,Financial Management I,0.23,0.33,0.26,0.07,0.07,0.0,0.0,0.05,weike xu,
+FIN,3110,102,Financial Management I (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,george bra lockhart,True
+FIN,3110,104,Financial Management I (HON),0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,george bra lockhart,True
+FIN,3120,1,Financial Management II,0.24,0.4,0.17,0.14,0.0,0.0,0.0,0.05,blerina zykaj,
+FIN,3120,2,Financial Management II,0.28,0.28,0.38,0.03,0.03,0.0,0.0,0.0,blerina zykaj,
+FIN,3120,4,Financial Management II,0.14,0.38,0.31,0.05,0.1,0.0,0.0,0.02,weike xu,
+FIN,3120,5,Financial Management II,0.19,0.35,0.3,0.07,0.05,0.0,0.0,0.05,weike xu,
+FIN,3120,102,Financial Management II (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,True
+FIN,3120,401,Financial Management II,0.18,0.27,0.3,0.09,0.07,0.0,0.0,0.09,angela morgan,
+FIN,4020,1,Corporate Valuation,0.16,0.44,0.3,0.07,0.0,0.0,0.0,0.02,angela morgan,
+FIN,4030,1,Spreadsheet Apps in Finance,0.3,0.28,0.23,0.14,0.02,0.0,0.0,0.02,vincent intintoli,
+FIN,4030,2,Spreadsheet Apps in Finance,0.33,0.27,0.33,0.03,0.03,0.0,0.0,0.0,vincent intintoli,
+FIN,4040,1,Financial Modeling,0.14,0.57,0.1,0.14,0.0,0.0,0.0,0.05,jack wolf,
+FIN,4050,1,Portfolio Management & Theory,0.09,0.27,0.42,0.12,0.0,0.0,0.0,0.09,john alexander,
+FIN,4080,1,Mgt of Fin Inst,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4080,2,Mgt of Fin Inst,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
+FIN,4090,1,Professional Financial Plan,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,
+FIN,4110,1,Int Fin Mgt,0.24,0.48,0.21,0.0,0.06,0.0,0.0,0.0,luke asher devault,
+FIN,4110,2,Int Fin Mgt,0.39,0.36,0.18,0.04,0.0,0.0,0.0,0.04,luke asher devault,
+FIN,4150,1,Real Estate Investmt,0.2,0.45,0.3,0.0,0.0,0.0,0.0,0.05,thomas springer,
+FIN,4160,2,Real Estate Val,0.24,0.62,0.14,0.0,0.0,0.0,0.0,0.0,bryan blackwood,
+FIN,4980,2,CI in Finance: CFA,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jack wolf,
+FIN,4980,9,Creative Inquiry in Finance,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,yannan shen,
+FNR,4700,19,Soil Judging Project,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,elena mikhailova,
+FNR,4700,23,Estuarine Fish Ecology I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,troy mason farmer,
+FNR,4700,24,Climate Change/Carolina Fish I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,troy mason farmer,
+FNR,4700,35,Aquaponics,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,lance edwar beecher,
+FNR,4700,37,Growing Food In a Box Techniqs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,
+FNR,4700,44,Alligator Ecology,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,catherine jachowski,
+FNR,4700,46,Tiger Awareness,0.88,0.0,0.0,0.13,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+FNR,4990,3,Natural Resources Seminar,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
+FOR,1010,1,Intro to Forestry,0.7,0.05,0.16,0.03,0.03,0.0,0.0,0.03,lawrence gering,
+FOR,2060,1,Forestry Ecology,0.24,0.31,0.2,0.11,0.0,0.0,0.09,0.05,donald hagan,
+FOR,3080,1,Remote Sensing in Forestry,0.44,0.33,0.19,0.04,0.0,0.0,0.0,0.0,lawrence gering,
+FOR,4080,1,Wood and Paper Products,0.62,0.26,0.1,0.0,0.0,0.0,0.0,0.02,patricia layton,
+FOR,4150,2,Forest Wildlife Managment,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
+FOR,4180,1,Forest Resource Valuation,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,thomas straka,
+FOR,4340,1,GIS for Natural Resources,0.4,0.48,0.05,0.0,0.0,0.0,0.0,0.08,robert frit baldwin,
+FOR,4650,1,Silviculture,0.26,0.37,0.19,0.15,0.04,0.0,0.0,0.0,gaofeng wang,
+FR,1010,1,Elementary French,0.36,0.27,0.23,0.05,0.09,0.0,0.0,0.0,anne salces  nedeo,
+FR,1010,2,Elementary French,0.43,0.36,0.0,0.07,0.14,0.0,0.0,0.0,anne salces  nedeo,
+FR,1020,1,Elementary French,0.52,0.22,0.09,0.0,0.0,0.0,0.04,0.13,amy lyn grif sawyer,
+FR,1020,2,Elementary French,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,2,Intermediate French,0.73,0.23,0.0,0.05,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
+FR,2010,3,Intermediate French,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,amy lyn grif sawyer,
+FR,2020,1,Intermediate French,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
+FR,2020,3,Intermediate French,0.38,0.38,0.13,0.08,0.0,0.0,0.0,0.04,paulin de tholozany,
+FR,2020,4,Intermediate French,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
+FR,3050,1,Int Fr Con & Comp I,0.55,0.3,0.1,0.0,0.0,0.0,0.0,0.05,joseph mai,
+FR,3160,1,Fr for Intl Trade,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,eric touya,
+FR,4100,1,Francophone Literature,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,eric touya,
+GC,1010,1,Orientation to G C,0.24,0.59,0.06,0.0,0.06,0.0,0.0,0.06,kern cox,
+GC,1020,1,Computer Art & CAD Foundations,0.27,0.38,0.16,0.03,0.08,0.0,0.0,0.08,carol jones,
+GC,1030,1,G C I for Pkgsc,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,john jacobs,
+GC,1040,1,Graphic Communications I,0.76,0.19,0.02,0.0,0.02,0.0,0.0,0.02,michelle suki  fox,
+GC,1990,4,CI in GC I Ph Ch,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nona woolbright,
+GC,2070,1,Graphic Communications II,0.57,0.38,0.04,0.0,0.0,0.0,0.0,0.0,charles tabor weiss,
+GC,2990,2,CI in GC II-VDP,0.8,0.0,0.0,0.0,0.2,0.0,0.0,0.0,eric weisenmiller,
+GC,2990,4,Cr Inquiry in GC II Ph Ch,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,nona woolbright,
+GC,3400,1,Digital Imaging and eMedia,0.31,0.56,0.1,0.0,0.0,0.0,0.0,0.03,erica black walker,
+GC,3460,1,Ink and Substrates,0.33,0.33,0.26,0.0,0.05,0.0,0.0,0.03,liam henry 'hara,
+GC,3720,1,Digital Analytics Brand Comm,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,alicia ni littleton,
+GC,3720,1,Digital Analytics Brand Comm,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,katelyn hildebrand,
+GC,3730,1,Media Management in Brand Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jaclyn kathl driggs,
+GC,3730,1,Media Management in Brand Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,
+GC,3740,1,Brand Comm Media Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,
+GC,3740,1,Brand Comm Media Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,roger beasley,
+GC,4060,1,Package and Specialty Printing,0.17,0.71,0.06,0.0,0.03,0.0,0.0,0.03,kern cox,
+GC,4400,1,Commercial Printing,0.29,0.45,0.16,0.0,0.06,0.0,0.0,0.03,eric weisenmiller,
+GC,4440,1,Current Dev/Trends in Gr Comm,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,
+GC,4480,1,Plan & Cont Printing Functions,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,nona woolbright,
+GC,4800,1,Senior Seminar in GC,0.81,0.17,0.02,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,
+GC,4900,8,UX & Web Design,0.94,0.0,0.0,0.0,0.06,0.0,0.0,0.0,erica black walker,
+GC,4900,230,G C Selected Topics-Sales,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,john leininger,
+GEN,3000,1,Fundamental Genetics,0.26,0.29,0.24,0.13,0.05,0.0,0.0,0.03,kate leanne wi tsai,
+GEN,3000,2,Fundamental Genetics,0.36,0.32,0.16,0.06,0.03,0.0,0.0,0.06,kate leanne wi tsai,
+GEN,3020,1,Molecular & General Genetics,0.36,0.32,0.23,0.02,0.02,0.0,0.0,0.05,lukasz kozubowski,
+GEN,3040,1,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+GEN,3040,1,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
+GEN,3040,2,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
+GEN,3040,2,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+GEN,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
+GEN,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+GEN,3040,4,Molecular Biology Laboratory,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
+GEN,3040,4,Molecular Biology Laboratory,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
+GEN,4200,1,Molecular Genetics & Gene Reg,0.27,0.4,0.29,0.03,0.0,0.0,0.0,0.0,miriam krist konkel,
+GEN,4210,2,Mol Gen Gene Reg Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
+GEN,4400,1,Bioinformatics,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,liangjiang wang,
+GEN,4700,1,Human Genetics,0.25,0.38,0.28,0.06,0.0,0.0,0.0,0.04,leigh anne clark,
+GEN,4900,3,Biomedical Informatics,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,frank alexan feltus,
+GEN,4910,36,CI:DNA Repair (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True
+GEN,4930,3,Senior Seminar,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,haiying liang,
+GEN,6700,1,Human Genetics,0.17,0.17,0.17,0.0,0.0,0.0,0.0,0.5,leigh anne clark,
+GEN,8050,1,Issues in Research,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william marcotte,
+GEOG,1010,1,Intro to Geography,0.4,0.47,0.07,0.03,0.03,0.0,0.0,0.0,christa smith,
+GEOG,1030,1,World Regional Geography,0.3,0.44,0.15,0.04,0.03,0.0,0.0,0.04,william churc terry,
+GEOL,1010,1,Physical Geology,0.27,0.29,0.25,0.07,0.07,0.0,0.0,0.05,alan coulson,
+GEOL,1010,2,Physical Geology,0.34,0.33,0.17,0.04,0.04,0.0,0.0,0.09,alan coulson,
+GEOL,1010,3,Physical Geology,0.43,0.38,0.11,0.05,0.04,0.0,0.0,0.0,mary katheri fidler,
+GEOL,1030,1,Physical Geol Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,2,Physical Geol Lab,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,3,Physical Geol Lab,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,alan coulson,
+GEOL,1030,4,Physical Geol Lab,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,5,Physical Geol Lab,0.78,0.13,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,6,Physical Geol Lab,0.43,0.3,0.17,0.0,0.0,0.0,0.0,0.09,alan coulson,
+GEOL,1030,7,Physical Geol Lab,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,8,Physical Geol Lab,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
+GEOL,1030,10,Physical Geol Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,11,Physical Geol Lab,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,alan coulson,
+GEOL,1030,12,Physical Geol Lab,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,14,Physical Geol Lab,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,1030,15,Physical Geol Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,alan coulson,
+GEOL,1120,1,Earth Resources,0.29,0.35,0.19,0.13,0.01,0.0,0.0,0.03,mary katheri fidler,
+GEOL,1140,1,Earth Resources Lab,0.64,0.2,0.05,0.05,0.02,0.0,0.0,0.04,mary katheri fidler,
+GEOL,2020,1,Earth History,0.25,0.45,0.25,0.05,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,3160,1,Igneous & Metamorphic Petrolog,0.27,0.6,0.13,0.0,0.0,0.0,0.0,0.0,mary katheri fidler,
+GEOL,4050,1,Surficial Geology,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,alexander th pullen,
+GEOL,4090,1,Envir & Exploration Geophysics,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,scott dewolf,
+GEOL,4110,8,Res Probs - Community Outreach,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john robert wagner,
+GEOL,4210,1,GIS in Geology,0.72,0.16,0.04,0.0,0.04,0.0,0.0,0.04,scott brame,
+GEOL,4920,1,Resrch Synthesis II,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
+GEOL,8170,1,Applied Process Simulation,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,lawrence murdoch,
+GER,1010,1,Elementary German,0.54,0.23,0.08,0.0,0.0,0.0,0.0,0.15, lee ferrell,
+GER,1010,2,Elementary German,0.38,0.31,0.13,0.06,0.0,0.0,0.0,0.13,oswald harris king,
+GER,1020,1,Elementary German,0.54,0.15,0.23,0.0,0.0,0.0,0.0,0.08,oswald harris king,
+GER,2020,1,Intermediate German,0.24,0.16,0.36,0.16,0.08,0.0,0.0,0.0,johannes schmidt,
+GER,3600,1,Ger Lit to 1832,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,
+HCG,9890,400,Pharmacogenomics,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,christopher farrell,
+HCG,9890,400,Pharmacogenomics,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,linda ward,
+HIST,1010,1,History of the United States,0.31,0.45,0.14,0.03,0.0,0.0,0.0,0.07,james brad jeffries,
+HIST,1010,2,History of the United States,0.8,0.1,0.0,0.07,0.0,0.0,0.0,0.03,joshua cas catalano,
+HIST,1240,1,Environmental History Survey,0.09,0.46,0.26,0.08,0.05,0.0,0.0,0.06,james brad jeffries,
+HIST,1720,1,The West and the World I,0.53,0.22,0.06,0.03,0.06,0.0,0.0,0.09,kathryn langenfeld,
+HIST,1730,1,The West and the World II,0.19,0.44,0.28,0.03,0.06,0.0,0.0,0.02,michael meng,
+HIST,1730,2,The West and the World II,0.33,0.34,0.18,0.08,0.04,0.0,0.0,0.04,james burns,
+HIST,1730,3,The West and the World II,0.29,0.36,0.32,0.0,0.0,0.0,0.0,0.04, alan grubb,
+HIST,2990,1,Historian's Craft,0.5,0.2,0.1,0.0,0.1,0.0,0.0,0.1,rachel anne moore,
+HIST,2990,2,Historian's Craft,0.59,0.06,0.06,0.0,0.24,0.0,0.0,0.06,michael silvestri,
+HIST,3000,1,History of Colonial America,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
+HIST,3100,1,History of Religion in the US,0.4,0.33,0.07,0.07,0.0,0.0,0.0,0.13,elizabeth jemison,
+HIST,3110,1,African American Hist to 1877,0.27,0.55,0.05,0.0,0.09,0.0,0.0,0.05,abel bartley,
+HIST,3170,1,Hist of NativeAm Rel & Culture,0.15,0.38,0.31,0.08,0.08,0.0,0.0,0.0,james brad jeffries,
+HIST,3220,1,History of Technology,0.39,0.43,0.0,0.04,0.07,0.0,0.0,0.07,pamela mack,
+HIST,3260,1,Hist Am Transport,0.62,0.21,0.1,0.0,0.0,0.0,0.0,0.07, roger grant,
+HIST,3290,1,US Legal History Since 1890,0.29,0.58,0.04,0.0,0.0,0.0,0.0,0.08,maribel morey,
+HIST,3290,2,US Legal History Since 1890,0.3,0.4,0.1,0.0,0.0,0.0,0.0,0.2,maribel morey,
+HIST,3300,1,Hist of Mod China,0.21,0.39,0.18,0.04,0.04,0.0,0.0,0.14,edwin moise,
+HIST,3400,1,Latin America I,0.64,0.29,0.04,0.0,0.0,0.0,0.0,0.04,rachel anne moore,
+HIST,3510,1,Ancient Near East,0.31,0.38,0.25,0.0,0.0,0.0,0.0,0.06,steven grosby,
+HIST,3550,1,Roman World,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,kathryn langenfeld,
+HIST,3610,1,History of Britain to 1688,0.45,0.41,0.1,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,
+HIST,3670,1,Modern Ireland,0.56,0.3,0.07,0.0,0.0,0.0,0.0,0.07,michael silvestri,
+HIST,3890,1,Ben Robertson,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2, alan grubb,
+HIST,3890,2,History of Clemson House,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0, alan grubb,
+HIST,3900,1,Modern Military History,0.15,0.42,0.31,0.0,0.0,0.0,0.0,0.12,edwin moise,
+HIST,3980,1,American Military History,0.37,0.4,0.17,0.03,0.03,0.0,0.0,0.0,john andrew,
+HIST,4380,1,Studies African History,0.67,0.0,0.17,0.0,0.17,0.0,0.0,0.0,stephanie hassell,
+HIST,4380,1,Studies African History,0.67,0.0,0.17,0.0,0.17,0.0,0.0,0.0,james burns,
+HIST,4700,1,Medieval Christianity,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,
+HIST,4700,2,History of Florence,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,thomas kuehn,
+HIST,4710,1,History and Food,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1, alan grubb,
+HIST,4900,1,History of Disney Theme Parks,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
+HIST,4900,2,Family and Kinship,0.18,0.36,0.36,0.0,0.0,0.0,0.0,0.09,thomas kuehn,
+HIST,4930,1,AfricanAm Soc & Intellectual H,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,abel bartley,
+HIST,8810,1,Historiography,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
+HLTH,2020,2,Introduction to Public Health,0.67,0.13,0.17,0.04,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2020,400,Introduction to Public Health,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2020,402,Introduction to Public Health,0.42,0.26,0.26,0.0,0.0,0.0,0.0,0.05,ralph stewart welsh,
+HLTH,2030,1,Health Care Sys,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2030,2,Health Care Sys,0.64,0.24,0.04,0.08,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2030,3,Health Care Sys,0.82,0.15,0.0,0.0,0.03,0.0,0.0,0.0,lee alden crandall,
+HLTH,2030,400,Health Care Sys,0.35,0.45,0.15,0.05,0.0,0.0,0.0,0.0,tanya lee staton,
+HLTH,2400,1,Deter of Hlth Behav,0.52,0.31,0.17,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2400,2,Deter of Hlth Behav,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
+HLTH,2400,400,Deter of Hlth Behav,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,2500,1,Health and Fitness,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
+HLTH,2600,1,Medical Terminology & Comm,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,
+HLTH,2600,2,Medical Terminology & Comm,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,karen edwards,
+HLTH,2980,1,Human Health and Disease,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2980,2,Human Health and Disease,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
+HLTH,2980,3,Human Health and Disease,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,3030,1,Public Health Comm,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,debra mitch charles,
+HLTH,3800,1,Epidemiology,0.43,0.43,0.09,0.0,0.0,0.0,0.0,0.06,deborah alma falta,
+HLTH,3980,1,Health Appraisal Skills,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,3980,2,Health Appraisal Skills,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4020,1,Princ Hlth Fitness,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,karen kemper,
+HLTH,4110,1,Hlth At-Risk Children & Fam,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
+HLTH,4190,1,Health Sci Internship Prep Sem,0.63,0.33,0.05,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4200,1,Hlth Science Intern,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
+HLTH,4310,1,Public & Environ Hlt,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
+HLTH,4600,1,Health Info Systems,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,ronald gimbel,
+HLTH,4700,1,Global Health,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,micky rogers ward,
+HLTH,4780,1,Health Policy Ethics and Law,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,hugh donald spitler,
+HLTH,4790,1,Fin Mgmt & Hlth Budg,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,khoa dang truong,
+HLTH,4800,1,Comm Hlth Promotion,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
+HLTH,4900,1,Res Eval St Pub Hlth,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,
+HLTH,4900,2,Res Eval St Pub Hlth,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,4900,3,Res Eval St Pub Hlth,0.48,0.43,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
+HLTH,4980,1,Improving Pop Hlth,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
+HLTH,4990,5,Aspire to Be Well CI,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,chloe caroli greene,
+HLTH,8310,1,Quantitative Analy in Hlth I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,lior mordec rennert,
+HON,2020,1,Motivation and Learning,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tyler watts,True
+HON,2030,2,Putin's World,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,olga anatol volkova,True
+HON,2060,1,Intro to Nanotechnology,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,True
+HON,2060,1,Intro to Nanotechnology,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,christophe kitchens,True
+HON,2060,2,Why We Eat What We Eat,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,True
+HON,2060,3,Great Problems in Math,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,neil calkin,True
+HON,2090,5,Crisis & Opportunity in Europe,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True
+HON,2200,2,Europe in the Age of Dictators,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,True
+HON,2200,3,Global Policy Process,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey allen fine,True
+HON,2210,1,Building Imaginary Worlds,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True
+HON,2210,3,Thinking About Love,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,dominic mastroianni,True
+HON,2210,4,Movies as Time Travel,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
+HON,2210,5,"Migrants, Exiles, Refugees",0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,lucian ghita,True
+HORT,2020,1,Adobe Digital Design,0.81,0.06,0.03,0.0,0.03,0.0,0.0,0.06,janice ann lay,
+HORT,2110,1,Growing Spring Plnts,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,james emerson faust,
+HORT,4040,1,Plant Propagation,0.12,0.32,0.37,0.15,0.05,0.0,0.0,0.0,jeffrey adelberg,
+HORT,4050,1,Plant Propagation Techniq Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
+HORT,4080,4,CI: Hands on Water for Ag,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,sarah white,
+HORT,4080,4,CI: Hands on Water for Ag,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,lauren marie chance,
+HORT,4080,7,Sustain Landscpe Garden Design,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,ellen anita vincent,
+HORT,4090,1,Senior Capstone Course,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
+HORT,4270,1,Urban Tree Care,0.0,0.3,0.2,0.1,0.0,0.0,0.0,0.4,robert polomski,
+HORT,4330,1,Weed Management,0.17,0.46,0.38,0.0,0.0,0.0,0.0,0.0,ted whitwell,
+HORT,4560,1,Vegetable Crops,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,
+HORT,6040,1,Plant Propagation,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
+HRD,8250,400,Org Perf Improvement,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,angela danie carter,
+HRD,8470,400,Instru System Design,0.79,0.07,0.0,0.0,0.03,0.0,0.0,0.1,angela danie carter,
+HRD,8490,400,Eval of T&D/Hrd Prog,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,angela danie carter,
+HRD,8800,400,Research Concepts,0.75,0.13,0.0,0.0,0.04,0.0,0.0,0.08,cynthia sims,
+IE,2100,1,Des Analysis Wrk Sys,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,xiaoxia li,
+IE,3010,1,Systems Design I,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,amro nofa khasawneh,
+IE,3140,1,Seminar in Industrial Engr,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,scott jenning mason,
+IE,3600,1,Industrial Apps of Prob/Stat I,0.34,0.29,0.19,0.13,0.02,0.0,0.0,0.04,robert james riggs,
+IE,3610,1,Industrial App of Prob/Stat II,0.48,0.25,0.18,0.03,0.02,0.0,0.0,0.05,katherina jurewicz,
+IE,3800,1,Deterministic Operations Rsrch,0.28,0.47,0.17,0.04,0.0,0.0,0.03,0.0,sandra dun eksioglu,
+IE,3810,1,Probabilistic Operations Rsrch,0.2,0.5,0.23,0.04,0.0,0.0,0.0,0.04,amin khademi,
+IE,3840,1,Engr Econ Analysis,0.24,0.22,0.28,0.1,0.0,0.0,0.04,0.1,brian melloy,
+IE,3860,1,Production Planning & Control,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,xiaoxia li,
+IE,4040,15,Creative Inquiry Research,0.0,0.0,0.0,0.0,0.0,0.83,0.0,0.17,kevin taaffe,
+IE,4400,1,Decision Support Sys,0.36,0.48,0.03,0.0,0.09,0.0,0.0,0.03,mary elizabeth kurz,
+IE,4570,1,Transp/Logistic Engr,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,sandra dun eksioglu,
+IE,4610,1,Quality Engineering,0.29,0.27,0.33,0.07,0.0,0.0,0.0,0.03,byung rae cho,
+IE,4620,1,Six Sigma Quality,0.45,0.43,0.09,0.01,0.0,0.0,0.0,0.01,robert james riggs,
+IE,4650,1,Facilities Planning & Design,0.49,0.31,0.08,0.05,0.0,0.0,0.01,0.06,brian melloy,
+IE,4670,1,System Design II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,walter lawre garvin,
+IE,4670,1,System Design II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,
+IE,4670,2,System Design II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,walter lawre garvin,
+IE,4670,2,System Design II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,
+IE,4820,1,Systems Modeling,0.26,0.37,0.21,0.1,0.03,0.0,0.0,0.02,tugce isik,
+IE,4860,1,Scheduling,0.27,0.09,0.27,0.09,0.0,0.0,0.0,0.27,scott jenning mason,
+IE,4880,1,Human Factors Eng,0.54,0.39,0.02,0.02,0.0,0.0,0.0,0.04,laura miche stanley,
+IE,4910,1,Applied Bus. Princples for Eng,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,jeffery messer,
+IE,6620,1,Six Sigma Quality,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
+IE,6860,1,Scheduling,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+IE,6910,1,Supply Chain/Logistics Model,0.61,0.36,0.0,0.0,0.0,0.0,0.0,0.04,william ferrell,
+IE,8050,1,Found Qual Engr,0.18,0.73,0.08,0.0,0.0,0.0,0.0,0.02,byung rae cho,
+IE,8520,1,Prescriptive Analytics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
+IE,8540,1,SC & Logistics Modeling I,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,
+IE,8580,1,Case Study Supply Chn & Logist,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
+INNO,4990,990,CEDC - Risk in Puerto Rico,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david vaughn,
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,lisa marie robinson,
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,troy nunamaker,
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,troy nunamaker,
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,caren kelley-hall,
+IPM,4010,1,Principles of I P M,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,carmen blubaugh,
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,james dougl bennett,
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,joshua leona hudson,
+IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,james dougl bennett,
+IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,joshua leona hudson,
+IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,meredith fan wilson,
+IS,2100,615,Sel Top International Studies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,meredith fan wilson,
+IS,2100,615,Sel Top International Studies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,joshua leona hudson,
+IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
+IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joshua leona hudson,
+IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,meredith fan wilson,
+ITAL,1010,1,Elementary Italian,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,
+ITAL,1020,1,Elementary Italian,0.45,0.27,0.18,0.0,0.0,0.0,0.0,0.09,julia schmidt,
+ITAL,1020,2,Elementary Italian,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,
+ITAL,1020,3,Elementary Italian,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+ITAL,2020,1,Intermediate Italian,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,julia schmidt,
+JAPN,1010,1,Elementary Japanese,0.4,0.2,0.2,0.0,0.0,0.0,0.0,0.2,saori suto,
+JAPN,1010,2,Elementary Japanese,0.41,0.29,0.18,0.06,0.0,0.0,0.0,0.06,saori suto,
+JAPN,1020,2,Elementary Japanese,0.45,0.14,0.32,0.05,0.0,0.0,0.0,0.05,satomi saito,
+JAPN,2020,1,Intermed Japanese,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,saori suto,
+JAPN,3060,1,Japanese Conversation & Comp,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,kumiko saito,
+JAPN,4170,2,Japanese Culture and Society,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,jae allegr takeuchi,
+JUST,2880,1,The Criminal Justice System,0.41,0.31,0.19,0.02,0.05,0.0,0.0,0.02,margaret tina britz,
+JUST,2890,1,Criminology,0.39,0.31,0.2,0.06,0.0,0.0,0.0,0.04,matthew jo costello,
+JUST,4280,1,Criminal Law,0.18,0.55,0.23,0.05,0.0,0.0,0.0,0.0,rhys hester,
+JUST,4910,1,Policing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,shelagh dorn,
+JUST,4930,1,Corrections,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,catherine el burton,
+JUST,4940,1,Organized Crime,0.33,0.33,0.19,0.08,0.06,0.0,0.0,0.0,margaret tina britz,
+JUST,4970,1,Criminal Justice Capstone,0.7,0.22,0.0,0.0,0.04,0.0,0.0,0.04,catherine el burton,
+JUST,4990,1,Criminal Courts,0.28,0.32,0.36,0.0,0.0,0.0,0.0,0.04,rhys hester,
+JUST,4990,2,Ethics in Criminal Justice,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,lance christ miller,
+LANG,2540,1,Introduction to World Cinemas,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,raquel anido,
+LANG,2540,2,Introduction to World Cinemas,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,
+LARC,1160,1,History of Landscape Arch,0.35,0.38,0.17,0.07,0.01,0.0,0.0,0.01,hala fouad nassar,
+LARC,1160,2,History of Landscape Arch,0.27,0.47,0.13,0.13,0.0,0.0,0.0,0.0,hala fouad nassar,
+LARC,1520,1,Basic Design II,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,maria debye counts,
+LARC,2550,1,Community Design Studio,0.74,0.16,0.05,0.0,0.0,0.0,0.05,0.0,matthew neal powers,
+LARC,3620,1,Design Implementation II,0.67,0.1,0.14,0.0,0.1,0.0,0.0,0.0,robert hewitt,
+LARC,4280,1,Computer-Aided Design,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,jueminsi wu,
+LARC,4280,1,Computer-Aided Design,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,xiaotong liu,
+LARC,4550,1,Landscape Arch Exit Project,0.45,0.45,0.0,0.09,0.0,0.0,0.0,0.0,mary padua,
+LARC,4720,1,South Carolina's Landscapes,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,
+LARC,4810,1,Professional Practice,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,christopher counts,
+LARC,4900,1,Urban Issues in Landscape Arch,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
+LARC,4900,400,Arch History of Place,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,jason matthew white,
+LARC,4970,8,Planting Design,0.74,0.13,0.04,0.0,0.04,0.0,0.0,0.04,matthew neal powers,
+LARC,8520,1,Advanced Urban Design,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,robert hewitt,
+LAW,3220,1,Legal Env of Bus,0.27,0.33,0.36,0.0,0.0,0.0,0.0,0.04,kenneth toussaint,
+LAW,3220,2,Legal Env of Bus,0.16,0.53,0.29,0.0,0.0,0.0,0.0,0.02,kenneth toussaint,
+LAW,3220,3,Legal Env of Bus,0.16,0.41,0.36,0.02,0.0,0.0,0.0,0.05,kenneth toussaint,
+LAW,3220,4,Legal Env of Bus,0.31,0.49,0.13,0.04,0.0,0.0,0.0,0.02,edward ray claggett,
+LAW,3220,5,Legal Env of Bus,0.11,0.62,0.22,0.04,0.0,0.0,0.0,0.0,judson jahn,
+LAW,3220,6,Legal Env of Bus,0.24,0.51,0.24,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3220,7,Legal Env of Bus,0.24,0.47,0.27,0.02,0.0,0.0,0.0,0.0,judson jahn,
+LAW,3220,8,Legal Env of Bus,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,3220,9,Legal Env of Bus,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,christopher edwards,
+LAW,3220,10,Legal Env of Bus,0.27,0.47,0.2,0.04,0.0,0.0,0.0,0.02,john hine,
+LAW,3220,11,Legal Env of Bus,0.27,0.36,0.3,0.0,0.05,0.0,0.0,0.02,john hine,
+LAW,3220,401,Legal Env of Bus,0.45,0.31,0.17,0.03,0.0,0.0,0.0,0.03,virgini ward-vaughn,
+LAW,3220,402,Legal Env of Bus,0.32,0.37,0.12,0.03,0.03,0.0,0.0,0.12,virgini ward-vaughn,
+LAW,3220,403,Legal Env of Bus,0.25,0.41,0.21,0.02,0.07,0.0,0.0,0.04,virgini ward-vaughn,
+LAW,3220,404,Legal Env of Bus,0.25,0.4,0.21,0.07,0.0,0.0,0.02,0.05,virgini ward-vaughn,
+LAW,3220,601,Legal Env of Bus,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
+LAW,3330,1,Real Estate Law,0.15,0.27,0.37,0.17,0.05,0.0,0.0,0.0,kenneth toussaint,
+LAW,4200,1,Int Business Law,0.2,0.55,0.2,0.0,0.0,0.0,0.0,0.05,frances edwards,
+LAW,4990,1,Selected Topics - Cyber Law,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,frances edwards,
+LAW,8480,1,Law Real Estate Prof,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,michael le brearley,
+LAW,8480,1,Law Real Estate Prof,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,james ivey warren,
+LS,1000,2,Fitness Leadership,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,jenny lynn rodgers,
+LS,1000,4,Introduction to Barre,0.74,0.11,0.05,0.0,0.0,0.0,0.0,0.11,diane moreno,
+LS,1000,5,Introduction to Barre,0.71,0.0,0.06,0.06,0.0,0.0,0.0,0.18,diane moreno,
+LS,1000,9,Intro to Salsa Dance,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,malik lewis baxter,
+LS,1000,19,Therapeutic Yoga,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
+LS,1000,21,Therapeutic Yoga,0.74,0.11,0.0,0.0,0.0,0.0,0.0,0.16,ranjanbala dil amin,
+LS,1000,23,Therapeutic Yoga,0.71,0.08,0.08,0.04,0.0,0.0,0.0,0.08,renee warren gahan,
+LS,1130,1,Wood Carving,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,louwanda jolley,
+LS,1410,2,Top Rope Climbing,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,thomas caldwell,
+LS,1560,13,Riflery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,herbert strickland,
+LS,1560,19,Riflery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,dominic cirocco,
+LS,1580,1,Archery,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,
+LS,1580,3,Archery,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1580,5,Archery,0.83,0.08,0.0,0.08,0.0,0.0,0.0,0.0,herbert strickland,
+LS,1650,1,Inland Kayak Touring,0.82,0.0,0.09,0.0,0.09,0.0,0.0,0.0,caitlin miche henry,
+LS,1650,5,Inland Kayak Touring,0.7,0.0,0.2,0.0,0.0,0.0,0.0,0.1,merry han armstrong,
+LS,1960,2,Intro to Billiards,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,broadus fleming,
+LS,2200,2,Shag,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,
+LS,2270,1,Intro to Swing Dance,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,paul hoke,
+LS,2270,4,Intro to Swing Dance,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,paul hoke,
+LS,2320,1,Core Training,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,diane moreno,
+LS,2320,3,Core Training,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
+LS,2320,5,Core Training,0.83,0.08,0.0,0.0,0.04,0.0,0.0,0.04,diane moreno,
+LS,2350,1,Basic Yoga,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,
+LS,2350,2,Basic Yoga,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,kayla lee wardlaw,
+LS,2350,3,Basic Yoga,0.87,0.0,0.04,0.0,0.0,0.0,0.0,0.09,silica eliza larkin,
+LS,2350,5,Basic Yoga,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2360,1,Power/Ashtanga Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,silica eliza larkin,
+LS,2360,2,Power/Ashtanga Yoga,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,silica eliza larkin,
+LS,2380,4,Vinyasa Flow Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
+LS,2420,1,Meditation and Relax,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,
+LS,2420,3,Meditation and Relax,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
+LS,2420,4,Meditation and Relax,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
+LS,2420,10,Meditation and Relax,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,
+LS,2420,11,Meditation and Relax,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,
+LS,2420,12,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
+LS,2420,13,Meditation and Relax,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
+LS,2450,2,Pilates,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,melanie ivey job,
+LS,2450,4,Pilates,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,diane moreno,
+LS,2450,5,Pilates,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,diane moreno,
+LS,2450,8,Pilates,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,melanie ivey job,
+LS,2510,1,Running & Jogging,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,corey dou brookover,
+MATH,1010,1,Essen Math for Informed Soc,0.5,0.25,0.13,0.13,0.0,0.0,0.0,0.0,marilyn reba,
+MATH,1010,2,Essen Math for Informed Soc,0.36,0.25,0.22,0.06,0.0,0.0,0.0,0.11,marilyn reba,
+MATH,1010,3,Essen Math for Informed Soc,0.47,0.35,0.09,0.09,0.0,0.0,0.0,0.0,seth selken,
+MATH,1010,4,Essen Math for Informed Soc,0.52,0.24,0.09,0.03,0.06,0.0,0.0,0.06,bryce pruitt,
+MATH,1020,1,Business Calculus I,0.18,0.24,0.28,0.13,0.08,0.0,0.0,0.08,randy davidson,
+MATH,1020,2,Business Calculus I,0.23,0.31,0.23,0.07,0.05,0.0,0.0,0.1,randy davidson,
+MATH,1020,3,Business Calculus I,0.18,0.35,0.12,0.18,0.12,0.0,0.0,0.06,zachary david espe,
+MATH,1020,4,Business Calculus I,0.12,0.27,0.24,0.21,0.12,0.0,0.0,0.03,andrew bellucco,
+MATH,1020,5,Business Calculus I,0.15,0.29,0.29,0.18,0.06,0.0,0.0,0.03,thowhida akther,
+MATH,1020,6,Business Calculus I,0.18,0.41,0.21,0.1,0.05,0.0,0.0,0.05,nathaniel nemire,
+MATH,1020,7,Business Calculus I,0.28,0.18,0.25,0.08,0.18,0.0,0.0,0.05,thowhida akther,
+MATH,1020,8,Business Calculus I,0.17,0.17,0.32,0.22,0.0,0.0,0.05,0.07,thowhida akther,
+MATH,1020,9,Business Calculus I,0.2,0.32,0.32,0.05,0.04,0.0,0.0,0.07,marion hanna,
+MATH,1020,10,Business Calculus I,0.22,0.24,0.17,0.12,0.15,0.0,0.0,0.1,shanshan jia,
+MATH,1020,11,Business Calculus I,0.35,0.33,0.25,0.03,0.05,0.0,0.0,0.0,cameron arnold,
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.85,0.0,0.15,nathan fontes,
+MATH,1060,1,Calculus of One Variable I,0.04,0.14,0.39,0.14,0.21,0.0,0.0,0.09,judith cottingham,
+MATH,1060,2,Calculus of One Variable I,0.08,0.26,0.34,0.13,0.18,0.0,0.0,0.0,catherine ma kenyon,
+MATH,1060,3,Calculus of One Variable I,0.06,0.17,0.39,0.11,0.19,0.0,0.0,0.08,steven taylo edalgo,
+MATH,1060,4,Calculus of One Variable I,0.09,0.3,0.33,0.09,0.09,0.0,0.0,0.09,marilyn reba,
+MATH,1060,5,Calculus of One Variable I,0.14,0.14,0.25,0.11,0.14,0.0,0.0,0.21,luther duncan,
+MATH,1070,1,Differen and Integral Calculus,0.4,0.4,0.15,0.0,0.0,0.0,0.0,0.05,donna simms,
+MATH,1070,2,Differen and Integral Calculus,0.18,0.36,0.36,0.05,0.03,0.0,0.0,0.03,donna simms,
+MATH,1070,3,Differen and Integral Calculus,0.18,0.38,0.26,0.09,0.06,0.0,0.0,0.03,stephen peele,
+MATH,1070,4,Differen and Integral Calculus,0.19,0.24,0.38,0.14,0.0,0.0,0.0,0.05,peter westerbaan,
+MATH,1070,5,Differen and Integral Calculus,0.13,0.47,0.25,0.03,0.13,0.0,0.0,0.0,scott scruggs,
+MATH,1070,6,Differen and Integral Calculus,0.07,0.48,0.43,0.02,0.0,0.0,0.0,0.0,stephen peele,
+MATH,1080,1,Calculus of One Variable II,0.38,0.35,0.2,0.0,0.0,0.0,0.0,0.08,stephen peele,
+MATH,1080,2,Calculus of One Variable II,0.43,0.23,0.2,0.09,0.03,0.0,0.0,0.03,blake anth splitter,
+MATH,1080,3,Calculus of One Variable II,0.18,0.23,0.36,0.05,0.14,0.0,0.0,0.05,timothy fra parrott,
+MATH,1080,4,Calculus of One Variable II,0.18,0.24,0.24,0.05,0.08,0.0,0.0,0.21,timothy fra parrott,
+MATH,1080,5,Calculus of One Variable II,0.36,0.28,0.26,0.0,0.05,0.0,0.0,0.05,hugh geller,
+MATH,1080,6,Calculus of One Variable II,0.13,0.37,0.3,0.05,0.0,0.0,0.09,0.06,timothy ch teitloff,
+MATH,1080,7,Calculus of One Variable II,0.14,0.3,0.28,0.02,0.09,0.0,0.0,0.18,timothy ch teitloff,
+MATH,1080,100,Calc of One Variable II (HON),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,timothy fra parrott,True
+MATH,1080,201,Calculus of One Variable II,0.12,0.12,0.35,0.15,0.03,0.0,0.0,0.24,timothy fra parrott,
+MATH,1080,202,Calculus of One Variable II,0.4,0.42,0.12,0.02,0.02,0.0,0.0,0.02,james edwar gossell,
+MATH,1080,203,Calculus of One Variable II,0.25,0.39,0.16,0.0,0.07,0.0,0.0,0.14,andrew walton green,
+MATH,1080,204,Calculus of One Variable II,0.1,0.46,0.34,0.0,0.0,0.0,0.0,0.1,sofya alekseeva,
+MATH,1080,205,Calculus of One Variable II,0.15,0.23,0.38,0.0,0.0,0.0,0.0,0.25,sofya alekseeva,
+MATH,1080,206,Calculus of One Variable II,0.13,0.38,0.23,0.05,0.03,0.0,0.0,0.2,sofya alekseeva,
+MATH,1160,1,Contemp Math for Elem Teach II,0.52,0.3,0.18,0.0,0.0,0.0,0.0,0.0,allison ke stoddard,
+MATH,1160,2,Contemp Math for Elem Teach II,0.57,0.37,0.04,0.0,0.0,0.0,0.0,0.02,allison ke stoddard,
+MATH,2060,1,Calculus of Several Variables,0.09,0.06,0.09,0.15,0.29,0.0,0.0,0.32,terri johnson,
+MATH,2060,2,Calculus of Several Variables,0.03,0.13,0.23,0.2,0.1,0.0,0.0,0.3,terri johnson,
+MATH,2060,3,Calculus of Several Variables,0.24,0.15,0.24,0.09,0.12,0.0,0.0,0.18,terri johnson,
+MATH,2060,4,Calculus of Several Variables,0.03,0.2,0.27,0.13,0.1,0.0,0.0,0.27,julie lassiter,
+MATH,2060,5,Calculus of Several Variables,0.0,0.18,0.24,0.09,0.3,0.0,0.0,0.18,julie lassiter,
+MATH,2060,6,Calculus of Several Variables,0.26,0.34,0.16,0.08,0.13,0.0,0.0,0.03,sanwar ahmad,
+MATH,2060,7,Calculus of Several Variables,0.32,0.32,0.19,0.08,0.08,0.0,0.0,0.0,allen anderso guest,
+MATH,2060,8,Calculus of Several Variables,0.23,0.29,0.19,0.1,0.13,0.0,0.0,0.06,allen anderso guest,
+MATH,2060,9,Calculus of Several Variables,0.24,0.35,0.29,0.03,0.06,0.0,0.0,0.03,allen anderso guest,
+MATH,2060,201,Calculus of Several Variables,0.52,0.39,0.06,0.0,0.0,0.0,0.0,0.03,camille zerfas,
+MATH,2070,1,Business Calculus II,0.45,0.21,0.21,0.05,0.0,0.0,0.0,0.08,jennifer mari hanna,
+MATH,2070,2,Business Calculus II,0.32,0.34,0.16,0.13,0.0,0.0,0.0,0.05,jennifer mari hanna,
+MATH,2070,3,Business Calculus II,0.45,0.24,0.18,0.03,0.05,0.0,0.0,0.05,xiaoyuan liu,
+MATH,2070,4,Business Calculus II,0.22,0.3,0.28,0.11,0.02,0.0,0.0,0.06,jennifer ray newton,
+MATH,2070,5,Business Calculus II,0.38,0.33,0.18,0.1,0.0,0.0,0.0,0.0,jennifer mari hanna,
+MATH,2070,6,Business Calculus II,0.38,0.44,0.13,0.05,0.0,0.0,0.0,0.0,jennifer mari hanna,
+MATH,2070,7,Business Calculus II,0.21,0.46,0.26,0.05,0.0,0.0,0.0,0.03,kayla doris javier,
+MATH,2070,8,Business Calculus II,0.31,0.19,0.28,0.22,0.0,0.0,0.0,0.0,travis alvarez,
+MATH,2070,9,Business Calculus II,0.26,0.32,0.18,0.13,0.0,0.0,0.03,0.08,molly adam honecker,
+MATH,2070,10,Business Calculus II,0.14,0.33,0.33,0.08,0.08,0.0,0.0,0.03,ebenezer eduafo,
+MATH,2070,11,Business Calculus II,0.32,0.32,0.29,0.05,0.0,0.0,0.0,0.03,aaron moose,
+MATH,2070,12,Business Calculus II,0.31,0.36,0.18,0.08,0.0,0.0,0.05,0.03,anna caro bachstein,
+MATH,2070,13,Business Calculus II,0.4,0.29,0.15,0.07,0.02,0.0,0.0,0.06,jennifer ray newton,
+MATH,2070,14,Business Calculus II,0.39,0.42,0.14,0.03,0.0,0.0,0.0,0.03,jennifer van dyken,
+MATH,2070,15,Business Calculus II,0.29,0.52,0.1,0.0,0.1,0.0,0.0,0.0,tony thanh nguyen,
+MATH,2080,1,Intro to Ordin Diff Equations,0.19,0.27,0.32,0.07,0.08,0.0,0.0,0.07,pye phyo aung,
+MATH,2080,2,Intro to Ordin Diff Equations,0.2,0.39,0.32,0.06,0.01,0.0,0.0,0.02,pye phyo aung,
+MATH,2080,3,Intro to Ordin Diff Equations,0.35,0.47,0.13,0.01,0.0,0.0,0.01,0.03,oleg yordanov,
+MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.5,0.23,0.03,0.01,0.0,0.0,0.01,oleg yordanov,
+MATH,2080,5,Intro to Ordin Diff Equations,0.28,0.35,0.24,0.06,0.03,0.0,0.0,0.04,jeong rock yoon,
+MATH,2080,6,Intro to Ordin Diff Equations,0.36,0.28,0.25,0.05,0.02,0.0,0.0,0.04,irina viktorova,
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.54,0.41,0.05,0.0,0.0,0.0,0.0,0.0,matthew macauley,True
+MATH,2160,1,Geometry for Elem Sch Teachers,0.79,0.08,0.0,0.04,0.0,0.0,0.0,0.08,nicole alai sinwell,
+MATH,2190,1,Introduction to Cryptography,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,felice manganiello,
+MATH,3020,1,Stat for Science & Engineering,0.25,0.48,0.15,0.0,0.03,0.0,0.0,0.1,xiaoqian sun,
+MATH,3020,2,Stat for Science & Engineering,0.78,0.15,0.08,0.0,0.0,0.0,0.0,0.0,jason alexande kurz,
+MATH,3020,3,Stat for Science & Engineering,0.68,0.23,0.03,0.03,0.0,0.0,0.0,0.05,haotian feng,
+MATH,3020,4,Stat for Science & Engineering,0.35,0.45,0.08,0.0,0.0,0.0,0.0,0.13,todd fenstermacher,
+MATH,3020,5,Stat for Science & Engineering,0.36,0.38,0.08,0.08,0.0,0.0,0.0,0.1, kamronnaher,
+MATH,3020,6,Stat for Science & Engineering,0.73,0.12,0.15,0.0,0.0,0.0,0.0,0.0,jayasekara merenchig,
+MATH,3020,7,Stat for Science & Engineering,0.49,0.32,0.15,0.02,0.0,0.0,0.0,0.02,ellen hepfe breazel,
+MATH,3020,8,Stat for Science & Engineering,0.51,0.32,0.02,0.05,0.0,0.0,0.0,0.1,rui gong,
+MATH,3110,1,Linear Algebra,0.15,0.44,0.26,0.09,0.0,0.0,0.0,0.06,michael adam burr,
+MATH,3110,2,Linear Algebra,0.28,0.25,0.31,0.11,0.0,0.0,0.03,0.03,michael adam burr,
+MATH,3110,4,Linear Algebra,0.29,0.29,0.15,0.24,0.03,0.0,0.0,0.0,mishko mitkovski,
+MATH,3110,5,Linear Algebra,0.46,0.31,0.13,0.03,0.03,0.0,0.0,0.04,nant ramiharimanana,
+MATH,3110,6,Linear Algebra,0.33,0.3,0.11,0.05,0.0,0.0,0.07,0.14,nant ramiharimanana,
+MATH,3110,8,Linear Algebra,0.37,0.26,0.29,0.05,0.03,0.0,0.0,0.0,hui xue,
+MATH,3110,200,Linear Algebra,0.25,0.25,0.31,0.13,0.0,0.0,0.0,0.06,svetlan poznanovikj,
+MATH,3190,1,Introduction to Proof,0.62,0.14,0.14,0.05,0.03,0.0,0.0,0.03,beth novick,
+MATH,3190,2,Introduction to Proof,0.62,0.22,0.11,0.0,0.03,0.0,0.0,0.03,beth novick,
+MATH,3600,1,Intermediate Math Computing,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,mark cawood,
+MATH,3600,2,Intermediate Math Computing,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mark cawood,
+MATH,3650,1,Numerical Mthds for Engineers,0.54,0.33,0.08,0.03,0.03,0.0,0.0,0.0,fei xue,
+MATH,3650,2,Numerical Mthds for Engineers,0.28,0.28,0.2,0.03,0.0,0.0,0.0,0.23,alistair bentley,
+MATH,3650,3,Numerical Mthds for Engineers,0.38,0.28,0.2,0.0,0.13,0.0,0.0,0.03,alistair bentley,
+MATH,3650,4,Numerical Mthds for Engineers,0.31,0.36,0.05,0.1,0.05,0.0,0.0,0.13,alistair bentley,
+MATH,4000,1,Theory of Probability,0.22,0.34,0.24,0.07,0.02,0.0,0.0,0.1,brian fralix,
+MATH,4030,1,Intro to Statistical Theory,0.71,0.07,0.07,0.0,0.0,0.0,0.0,0.14,qiong zhang,
+MATH,4070,1,Regress & Time-Series Analysis,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,robert lund,
+MATH,4100,1,Number Theory,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,hui xue,
+MATH,4120,1,Algebra I,0.24,0.38,0.17,0.0,0.1,0.0,0.0,0.1,james ba coykendall,
+MATH,4190,1,Discrete Math Structures I,0.67,0.28,0.05,0.0,0.0,0.0,0.0,0.0,beth novick,
+MATH,4190,2,Discrete Math Structures I,0.43,0.39,0.11,0.04,0.0,0.0,0.0,0.04,matthew macauley,
+MATH,4310,1,Theory of Interest,0.35,0.35,0.2,0.1,0.0,0.0,0.0,0.0, erwin walker,
+MATH,4320,1,Actuarial Science Seminar II,0.53,0.13,0.27,0.0,0.0,0.0,0.0,0.07, erwin walker,
+MATH,4340,1,Adv Engineering Mathematics,0.2,0.29,0.17,0.17,0.09,0.0,0.0,0.09,hyesuk lee,
+MATH,4340,2,Adv Engineering Mathematics,0.18,0.15,0.36,0.06,0.15,0.0,0.0,0.09,vincent ervin,
+MATH,4400,1,Linear Programming,0.49,0.31,0.09,0.03,0.03,0.0,0.0,0.06,yuyuan ouyang,
+MATH,4530,1,Advanced Calculus I,0.08,0.25,0.33,0.17,0.17,0.0,0.0,0.0,james peterson,
+MATH,4540,1,Advanced Calculus II,0.46,0.33,0.13,0.04,0.0,0.0,0.0,0.04,james peterson,
+MATH,4990,1,Creative Inq-Math Sciences,0.5,0.17,0.17,0.0,0.17,0.0,0.0,0.0,ellen hepfe breazel,
+MATH,6000,1,Theory of Probability,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
+MATH,6340,1,Adv Engineering Mathematics,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,vincent ervin,
+MATH,8030,1,Stochastic Processes,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,xin liu,
+MATH,8040,1,Statistical Inference,0.55,0.41,0.0,0.0,0.0,0.0,0.0,0.05,colin gallagher,
+MATH,8050,1,Data Analysis,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,xiaoqian sun,
+MATH,8100,1,Mathematical Programming,0.27,0.36,0.27,0.0,0.09,0.0,0.0,0.0,margaret mar wiecek,
+MATH,8110,1,Nonlinear Programming,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,boshi yang,
+MATH,8130,1,Advanced Linear Programming,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
+MATH,8210,1,Linear Analysis,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,martin joha schmoll,
+MATH,8220,1,Measure and Integration,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,benjamin jaye,
+MATH,8500,1,Computational Algebraic Geom,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,
+MATH,8530,1,Matrix Analysis,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,
+MATH,8570,1,Cryptography,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,xuhong gao,
+MATH,8600,1,Intro to Scientific Computing,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,leo rebholz,
+MATH,8660,1,Finite Element Method,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,qingshan chen,
+MBA,8030,1,Stat Analy of Bus Op,0.33,0.39,0.17,0.0,0.0,0.0,0.0,0.11,magda gabriela sava,
+MBA,8060,1,Operations Mgt,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MBA,8060,20,Operations Mgt,0.32,0.32,0.35,0.0,0.0,0.0,0.0,0.0, sridharan,
+MBA,8070,1,Financial Management,0.48,0.26,0.22,0.0,0.0,0.0,0.0,0.04,melvin stith,
+MBA,8070,2,Financial Management,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,melvin stith,
+MBA,8090,1,Org Beh & Hum Res Mg,0.55,0.41,0.0,0.0,0.0,0.0,0.0,0.05,thomas jo zagenczyk,
+MBA,8090,2,Org Beh & Hum Res Mg,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
+MBA,8170,21,Bus Forecasting,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,
+MBA,8190,1,Intro to Acc and Fin,0.41,0.5,0.0,0.0,0.0,0.0,0.0,0.09,jeffrey mcmillan,
+MBA,8190,1,Intro to Acc and Fin,0.41,0.5,0.0,0.0,0.0,0.0,0.0,0.09,george bra lockhart,
+MBA,8290,3,Marketing Foundation,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,gary hunter,
+MBA,8330,1,Real Estate Investmt,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,
+MBA,8370,1,Legal Environ of Bus,0.3,0.59,0.07,0.0,0.0,0.0,0.0,0.04,judson jahn,
+MBA,8370,3,Legal Environ of Bus,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,judson jahn,
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
+MBA,8430,10,Entrepreneurial Accounting,0.67,0.26,0.07,0.0,0.0,0.0,0.0,0.0,gregory patr mcphee,
+MBA,8440,10,Entrepreneurial Law,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,judson jahn,
+MBA,8470,1,New Venture Creation,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,joseph renat gibson,
+MBA,8510,11,Bus Operations & Logistics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,george kenne morgan,
+MBA,8540,1,Managerial Accounting,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
+MBA,8540,2,Managerial Accounting,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
+MBA,8540,3,Managerial Accounting,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
+MBA,8590,1,Mgr Decision Model,0.52,0.41,0.04,0.0,0.0,0.0,0.0,0.04,magda gabriela sava,
+MBA,8590,2,Mgr Decision Model,0.25,0.38,0.19,0.0,0.13,0.0,0.0,0.06,sara elizabet yoder,
+MBA,8600,2,Advanced Marketing Strategy,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph renat gibson,
+MBA,8610,1,Information Systems,0.68,0.3,0.0,0.0,0.0,0.0,0.0,0.02,william kettinger,
+MBA,8610,2,Information Systems,0.68,0.24,0.05,0.0,0.0,0.0,0.0,0.03,william kettinger,
+MBA,8620,1,Managerial Economics,0.68,0.25,0.0,0.0,0.0,0.0,0.0,0.07,ronald earl gregory,
+MBA,8620,2,Managerial Economics,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,
+MBA,8700,1,Strategic Management,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8700,2,Strategic Management,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,thomas robert uva,
+MBA,8720,1,Entrepr Finance,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8720,2,Entrepr Finance,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
+MBA,8750,1,Enterprise Develpmnt,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
+MBA,8800,1,MBA Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,gail depriest,
+MBA,8800,2,MBA Seminar,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,jamie lyn patterson,
+MBA,8990,1,Advanced Leadership,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,gail depriest,
+MBA,8990,3,Service Innovation,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
+MBA,8990,5,International Investment Strgy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,
+MBA,8990,20,Analytics & Application,0.45,0.52,0.03,0.0,0.0,0.0,0.0,0.0,heshan sun,
+ME,2000,1,Sophomore Seminar,0.62,0.25,0.06,0.01,0.0,0.0,0.0,0.06,todd schweisinger,
+ME,2010,1,Statics & Dynamics,0.01,0.1,0.33,0.04,0.0,0.0,0.15,0.36,gang liu,
+ME,2010,2,Statics & Dynamics,0.03,0.23,0.27,0.1,0.04,0.0,0.0,0.32,paul joseph,
+ME,2030,1,Founda Th/Fl Syst,0.24,0.49,0.23,0.03,0.01,0.0,0.0,0.0,sandip dutta,
+ME,2030,2,Founda Th/Fl Syst,0.17,0.27,0.47,0.07,0.0,0.0,0.0,0.03,john saylor,
+ME,2030,3,Founda Th/Fl Syst,0.24,0.3,0.23,0.15,0.04,0.0,0.0,0.04,xiangchun xuan,
+ME,2030,4,Founda Th/Fl Syst,0.33,0.21,0.22,0.1,0.05,0.0,0.0,0.09,jay ochterbeck,
+ME,2040,1,Mechanics of Materials,0.3,0.41,0.29,0.0,0.0,0.0,0.0,0.0,gang li,
+ME,2040,2,Mechanics of Materials,0.28,0.47,0.22,0.02,0.0,0.0,0.0,0.02,garrett pataky,
+ME,2040,3,Mechanics of Materials,0.21,0.49,0.28,0.03,0.0,0.0,0.0,0.0,fadi abdeljawad,
+ME,2220,1,Mechanical Engineering Lab I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
+ME,2220,2,Mechanical Engineering Lab I,0.13,0.81,0.06,0.0,0.0,0.0,0.0,0.0,rachel anderson,
+ME,2220,3,Mechanical Engineering Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
+ME,2220,4,Mechanical Engineering Lab I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
+ME,2220,5,Mechanical Engineering Lab I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,rachel anderson,
+ME,2220,6,Mechanical Engineering Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
+ME,2220,7,Mechanical Engineering Lab I,0.38,0.56,0.0,0.0,0.0,0.0,0.0,0.06,rachel anderson,
+ME,2220,8,Mechanical Engineering Lab I,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.13,rachel anderson,
+ME,2220,10,Mechanical Engineering Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,rachel anderson,
+ME,2220,11,Mechanical Engineering Lab I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
+ME,2220,13,Mechanical Engineering Lab I,0.25,0.5,0.13,0.0,0.06,0.0,0.0,0.06,rachel anderson,
+ME,2220,14,Mechanical Engineering Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,rachel anderson,
+ME,3030,1,Thermodynamics,0.64,0.18,0.1,0.0,0.04,0.0,0.0,0.04,pooya niksiar,
+ME,3030,2,Thermodynamics,0.23,0.32,0.3,0.04,0.07,0.0,0.0,0.05,richard miller,
+ME,3040,1,Heat Transfer,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,sandip dutta,
+ME,3040,2,Heat Transfer,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,3040,3,Heat Transfer,0.32,0.32,0.26,0.05,0.05,0.0,0.0,0.0,jay ochterbeck,
+ME,3050,1,Model/an Dy Syst,0.32,0.42,0.19,0.06,0.0,0.0,0.0,0.0,chengshi wang,
+ME,3050,2,Model/an Dy Syst,0.23,0.49,0.16,0.07,0.05,0.0,0.0,0.0,phanin tallapragada,
+ME,3050,3,Model/an Dy Syst,0.22,0.54,0.2,0.0,0.0,0.0,0.0,0.03,douglas scott byrd,
+ME,3060,1,Fund Machine Design,0.34,0.51,0.14,0.0,0.01,0.0,0.0,0.0,james allen righter,
+ME,3060,2,Fund Machine Design,0.24,0.45,0.24,0.03,0.03,0.0,0.0,0.03,james allen righter,
+ME,3070,1,Found of Mechanical Systems,0.43,0.34,0.2,0.0,0.0,0.0,0.0,0.02,jorge iva rodriguez,
+ME,3070,3,Found of Mechanical Systems,0.59,0.3,0.04,0.04,0.04,0.0,0.0,0.0,pooya niksiar,
+ME,3080,1,Fluid Mechanics,0.17,0.48,0.27,0.02,0.0,0.0,0.0,0.06,chenning tong,
+ME,3080,2,Fluid Mechanics,0.47,0.36,0.13,0.02,0.0,0.0,0.0,0.02,yiqiang han,
+ME,3100,1,Thermo/Heat Transfer,0.12,0.35,0.35,0.1,0.06,0.0,0.0,0.04,yiqiang han,
+ME,3120,1,Manuf Processes,0.25,0.72,0.03,0.0,0.0,0.0,0.0,0.0,hong seok choi,
+ME,3330,1,Mechanical Engineering Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,2,Mechanical Engineering Lab II,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,3,Mechanical Engineering Lab II,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,5,Mechanical Engineering Lab II,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,6,Mechanical Engineering Lab II,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,gang liu,
+ME,3330,7,Mechanical Engineering Lab II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,3330,9,Mechanical Engineering Lab II,0.31,0.38,0.23,0.0,0.08,0.0,0.0,0.0,gang liu,
+ME,3330,10,Mechanical Engineering Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,4000,1,Senior Seminar,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,atul gajanan kelkar,
+ME,4010,1,Mech Engr Design,0.28,0.49,0.18,0.04,0.01,0.0,0.01,0.0,joshua summers,
+ME,4010,1,Mech Engr Design,0.28,0.49,0.18,0.04,0.01,0.0,0.01,0.0,cameron turner,
+ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
+ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
+ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yiqiang han,
+ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xin zhao,
+ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,sandip dutta,
+ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,douglas scott byrd,
+ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,jorge iva rodriguez,
+ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sandip dutta,
+ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,
+ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,gang liu,
+ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
+ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,john saylor,
+ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,joshua bostwick,
+ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,richard figliola,
+ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,77,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4020,77,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
+ME,4030,1,Control Dynamic Systems,0.23,0.3,0.34,0.13,0.0,0.0,0.0,0.0,mohammad naghnaeian,
+ME,4030,2,Control Dynamic Systems,0.23,0.46,0.23,0.04,0.0,0.0,0.0,0.04,suyi li,
+ME,4170,1,Mechatronic Sys Design,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,4180,1,F E A in M E Design,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,oliver myers,
+ME,4220,2,Design Gas Turbines,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,abhijit som,
+ME,4230,2,Intro Aerodynamics,0.13,0.42,0.42,0.03,0.0,0.0,0.0,0.0,richard figliola,
+ME,4260,1,Nuclear Energy,0.37,0.39,0.11,0.08,0.03,0.0,0.0,0.03,richard watkins,
+ME,4300,1,Mech Comp Materials,0.23,0.73,0.0,0.0,0.0,0.0,0.0,0.04,gang li,
+ME,4340,1,Cardiovascular Biomechanics,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,ethan kung,
+ME,4440,1,Mechanical Engineering Lab III,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4440,5,Mechanical Engineering Lab III,0.13,0.81,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4440,10,Mechanical Engineering Lab III,0.06,0.81,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4440,12,Mechanical Engineering Lab III,0.13,0.87,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
+ME,4930,10,Sel Topics ME (Nonlinear Dyn),0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,joshua bostwick,
+ME,4930,30,Sel Topics ME--Sustainability,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
+ME,4930,39,Sel Topics ME (Solar Energy),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,daniel fant,
+ME,6170,1,Mechatronics System Design,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,john wagner,
+ME,6230,1,Intro Aerodynamics,0.4,0.2,0.4,0.0,0.0,0.0,0.0,0.0,richard figliola,
+ME,6230,2,Intro Aerodynamics,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,richard figliola,
+ME,6300,1,Mech Comp Materials,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,gang li,
+ME,6340,1,Cardiovascular Biomechanics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,
+ME,6930,2,Sel Topics ME (Microfab),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,
+ME,6930,10,Sel Topics ME-Nonlinear Dyn,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,joshua bostwick,
+ME,8200,1,Mod Cont Engr,0.3,0.63,0.07,0.0,0.0,0.0,0.0,0.0,yue wang,
+ME,8310,1,Convective Ht Trans,0.33,0.47,0.2,0.0,0.0,0.0,0.0,0.0,xin zhao,
+ME,8370,1,Theory of Elast I,0.12,0.32,0.44,0.0,0.08,0.0,0.0,0.04,huijuan zhao,
+ME,8610,1,Matl Sel Engr Design,0.68,0.3,0.02,0.0,0.0,0.0,0.0,0.0,garrett pataky,
+ME,8930,27,Sel Topics ME-Adv Estimation,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
+ME,8930,28,Sel Topics ME: Agent Based Opt,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,cameron turner,
+ME,8930,28,Sel Topics ME: Agent Based Opt,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,joshua summers,
+MGT,2010,1,Principles of Management,0.37,0.39,0.18,0.03,0.0,0.0,0.02,0.03,katherine clark,
+MGT,2010,2,Principles of Management,0.44,0.37,0.17,0.02,0.0,0.0,0.0,0.01,tina robbins,
+MGT,2010,7,Principles of Management,0.18,0.62,0.15,0.03,0.03,0.0,0.0,0.0,christopher mann,
+MGT,2010,8,Principles of Management,0.39,0.45,0.13,0.03,0.0,0.0,0.0,0.0,christopher mann,
+MGT,2010,10,Principles of Management,0.31,0.28,0.28,0.08,0.0,0.0,0.0,0.05,ashley will parnell,
+MGT,2010,11,Principles of Management,0.18,0.34,0.34,0.08,0.0,0.0,0.0,0.05,ashley will parnell,
+MGT,2180,1,Management PC Applications,0.51,0.36,0.09,0.01,0.01,0.0,0.0,0.02,ryan toole,
+MGT,2180,2,Management PC Applications,0.27,0.59,0.14,0.0,0.0,0.0,0.0,0.0,ryan toole,
+MGT,2970,1,Deloitte Consulting CI,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ryan toole,
+MGT,3070,1,Human Resource Management,0.28,0.65,0.08,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,2,Human Resource Management,0.5,0.38,0.1,0.03,0.0,0.0,0.0,0.0,michael cole,
+MGT,3070,3,Human Resource Management,0.3,0.51,0.16,0.0,0.0,0.0,0.0,0.03,kristin dam scott,
+MGT,3070,4,Human Resource Management,0.3,0.55,0.1,0.0,0.03,0.0,0.0,0.03,leonard jos spooner,
+MGT,3070,5,Human Resource Management,0.63,0.33,0.03,0.0,0.03,0.0,0.0,0.0,michael cole,
+MGT,3070,6,Human Resource Management,0.43,0.46,0.08,0.0,0.03,0.0,0.0,0.0,leonard jos spooner,
+MGT,3070,8,Human Resource Management,0.32,0.49,0.17,0.0,0.0,0.0,0.0,0.02,priscilla harrison,
+MGT,3100,2,Intermed Business Statistics,0.51,0.26,0.18,0.0,0.0,0.0,0.0,0.05,jeromy blake snider,
+MGT,3100,3,Intermed Business Statistics,0.49,0.21,0.13,0.08,0.03,0.0,0.0,0.08,daniel nielubowicz,
+MGT,3100,4,Intermed Business Statistics,0.44,0.28,0.21,0.0,0.0,0.0,0.0,0.07,iaroslava dutchak,
+MGT,3100,5,Intermed Business Statistics,0.5,0.17,0.12,0.02,0.12,0.0,0.0,0.07,philip roth,
+MGT,3100,6,Intermed Business Statistics,0.55,0.24,0.07,0.01,0.04,0.0,0.0,0.07,benjamin chri wiles,
+MGT,3100,7,Intermed Business Statistics,0.4,0.35,0.2,0.03,0.0,0.0,0.0,0.03,mustafa serk akturk,
+MGT,3100,8,Intermed Business Statistics,0.36,0.36,0.28,0.0,0.0,0.0,0.0,0.0,mustafa serk akturk,
+MGT,3100,10,Intermed Business Statistics,0.47,0.24,0.13,0.07,0.02,0.0,0.0,0.07,iaroslava dutchak,
+MGT,3100,11,Intermed Business Statistics,0.44,0.26,0.23,0.03,0.03,0.0,0.0,0.03,daniel allan detoma,
+MGT,3120,1,Decision Models for Management,0.16,0.31,0.3,0.05,0.13,0.0,0.0,0.06,sara elizabet yoder,
+MGT,3120,2,Decision Models for Management,0.21,0.25,0.34,0.07,0.06,0.0,0.0,0.06,sara elizabet yoder,
+MGT,3120,4,Decision Models for Management,0.29,0.29,0.29,0.03,0.06,0.0,0.0,0.05,james turner,
+MGT,3170,1,Logistics Mgmt,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,ahmet colak,
+MGT,3180,1,Mgt of Info Systems,0.25,0.55,0.18,0.0,0.0,0.0,0.0,0.03,russell purvis,
+MGT,3180,2,Mgt of Info Systems,0.49,0.23,0.26,0.0,0.0,0.0,0.0,0.03,marten risius,
+MGT,3180,3,Mgt of Info Systems,0.69,0.22,0.09,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,
+MGT,3180,4,Mgt of Info Systems,0.23,0.7,0.08,0.0,0.0,0.0,0.0,0.0,wenxi pu,
+MGT,3180,5,Mgt of Info Systems,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,daniel aaron pienta,
+MGT,3500,1,Intro to Business Analytics,0.58,0.26,0.13,0.03,0.0,0.0,0.0,0.0,hongki kim,
+MGT,3510,1,Business Analytics & Problems,0.4,0.4,0.17,0.03,0.0,0.0,0.0,0.0,daniel allan detoma,
+MGT,3900,1,Operations Management,0.3,0.48,0.13,0.05,0.03,0.0,0.0,0.03,ying zhang,
+MGT,3900,2,Operations Management,0.37,0.44,0.15,0.0,0.05,0.0,0.0,0.0,ying zhang,
+MGT,3900,3,Operations Management,0.1,0.43,0.42,0.0,0.0,0.0,0.0,0.04, sridharan,
+MGT,3900,4,Operations Management,0.15,0.33,0.36,0.13,0.0,0.0,0.0,0.03,zachary mo leffakis,
+MGT,3900,6,Operations Management,0.57,0.4,0.02,0.0,0.0,0.0,0.0,0.0,maneeshre ajjuguttu,
+MGT,4000,1,Mgt of Organizational Behavior,0.78,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4000,2,Mgt of Organizational Behavior,0.26,0.38,0.33,0.02,0.02,0.0,0.0,0.0,thomas jo zagenczyk,
+MGT,4000,3,Mgt of Organizational Behavior,0.23,0.33,0.26,0.08,0.08,0.0,0.0,0.03,philip roth,
+MGT,4000,4,Mgt of Organizational Behavior,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
+MGT,4020,1,Ops Pln and Ctl,0.13,0.47,0.4,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4080,1,Lean Operations,0.21,0.51,0.26,0.03,0.0,0.0,0.0,0.0,zachary mo leffakis,
+MGT,4110,1,Project Management,0.15,0.51,0.28,0.0,0.03,0.0,0.0,0.03,russell purvis,
+MGT,4120,1,Supplier Management,0.59,0.34,0.03,0.0,0.0,0.0,0.0,0.03,ahmet colak,
+MGT,4150,1,Business Strategy,0.15,0.52,0.33,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,2,Business Strategy,0.07,0.67,0.26,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,3,Business Strategy,0.33,0.59,0.09,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,
+MGT,4150,4,Business Strategy,0.46,0.48,0.07,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,
+MGT,4150,5,Business Strategy,0.26,0.61,0.13,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,6,Business Strategy,0.48,0.43,0.1,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
+MGT,4150,7,Business Strategy,0.07,0.57,0.35,0.02,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,8,Business Strategy,0.26,0.7,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,11,Business Strategy,0.1,0.42,0.42,0.06,0.0,0.0,0.0,0.0,wayne stewart,
+MGT,4150,14,Business Strategy,0.15,0.39,0.45,0.0,0.0,0.0,0.0,0.0,james liddle,
+MGT,4150,15,Business Strategy,0.16,0.5,0.25,0.09,0.0,0.0,0.0,0.0,wayne stewart,
+MGT,4160,1,Special Topics Hr,0.23,0.53,0.23,0.03,0.0,0.0,0.0,0.0,kristin dam scott,
+MGT,4230,1,Intern Bus Mgt,0.11,0.53,0.31,0.04,0.0,0.0,0.0,0.0,janis miller,
+MGT,4230,2,Intern Bus Mgt,0.11,0.33,0.47,0.04,0.04,0.0,0.0,0.0,janis miller,
+MGT,4230,3,Intern Bus Mgt,0.13,0.16,0.64,0.04,0.0,0.0,0.0,0.02,wayne stewart,
+MGT,4230,4,Intern Bus Mgt,0.27,0.09,0.57,0.02,0.02,0.0,0.0,0.02,wayne stewart,
+MGT,4230,600,Intern Bus Mgt,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0, sridharan,
+MGT,4240,1,Global Supply Chain Management,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,yann ferrand,
+MGT,4270,1,Managing Improvement,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
+MGT,4310,1,Emp Rights & Resp,0.15,0.55,0.3,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
+MGT,4350,1,Pers Interviewing,0.35,0.43,0.18,0.03,0.03,0.0,0.0,0.0,philip roth,
+MGT,4520,1,Business Analysis,0.37,0.11,0.52,0.0,0.0,0.0,0.0,0.0,marten risius,
+MGT,4540,1,Systems Implement,0.43,0.39,0.13,0.04,0.0,0.0,0.0,0.0,hongki kim,
+MGT,4550,1,Emerging I T Trends,0.38,0.5,0.08,0.0,0.0,0.0,0.0,0.04,john frederic tripp,
+MGT,8120,1,Supply Chain Mgt,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,yann ferrand,
+MICR,3050,1,General Microbiology,0.47,0.37,0.11,0.04,0.0,0.0,0.0,0.01,krista barr rudolph,
+MICR,3050,2,General Microbiology,0.39,0.43,0.16,0.01,0.0,0.0,0.0,0.01,kristi ja whitehead,
+MICR,3050,3,General Microbiology,0.68,0.3,0.02,0.0,0.0,0.0,0.0,0.0,krista barr rudolph,
+MICR,4000,1,Public Health Micro,0.6,0.24,0.12,0.04,0.0,0.0,0.0,0.01,kristi ja whitehead,
+MICR,4000,2,Public Health Micro (HON),0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,True
+MICR,4070,1,Food and Dairy Micro,0.27,0.55,0.12,0.04,0.0,0.0,0.0,0.01,xiuping jiang,
+MICR,4110,1,Pathogenic Bact,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kear milhous,
+MICR,4120,1,Bacterial Physiology,0.23,0.35,0.27,0.08,0.05,0.0,0.0,0.02,harry kurtz,
+MICR,4130,1,Industrial Micro,0.42,0.49,0.06,0.02,0.0,0.0,0.0,0.01,tzuen-rong je tzeng,
+MICR,4140,1,Basic Immunology,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,charles rice,
+MICR,4170,1,Cancer and Aging,0.61,0.27,0.1,0.02,0.0,0.0,0.0,0.0,wen chen,
+MICR,4190,1,Intro to Molecular Medicine,0.54,0.27,0.08,0.08,0.0,0.0,0.0,0.04,zhicheng dou,
+MICR,4500,1,Advanced Microbiology I,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4500,2,Advanced Microbiology I,0.2,0.67,0.07,0.07,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4500,3,Advanced Microbiology I,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4500,4,Advanced Microbiology I,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,harry kurtz,
+MICR,4520,1,Advanced Microbiology III,0.8,0.05,0.15,0.0,0.0,0.0,0.0,0.0,min cao,
+MICR,4520,2,Advanced Microbiology III,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,min cao,
+MICR,4520,3,Advanced Microbiology III,0.47,0.32,0.11,0.11,0.0,0.0,0.0,0.0,min cao,
+MICR,4930,5,Sen Sem: Host-Microbe Interact,0.56,0.31,0.06,0.06,0.0,0.0,0.0,0.0,kristi ja whitehead,
+MICR,4940,1,CI: InterKingdom Communication,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,min cao,
+MICR,4940,26,CI: Parasite Biophysics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,joshua alper,
+MKT,3010,1,Principles of Marketing,0.3,0.33,0.25,0.08,0.03,0.0,0.0,0.01,carter wil mcelveen,
+MKT,3010,2,Principles of Marketing,0.32,0.29,0.34,0.03,0.0,0.0,0.01,0.01,carter wil mcelveen,
+MKT,3010,3,Principles of Marketing,0.35,0.34,0.2,0.08,0.01,0.0,0.0,0.03,amanda cooper fine,
+MKT,3010,4,Principles of Marketing,0.29,0.43,0.22,0.06,0.0,0.0,0.0,0.01,amanda cooper fine,
+MKT,3010,5,Principles of Marketing,0.29,0.43,0.18,0.06,0.01,0.0,0.0,0.03,james gaubert,
+MKT,3010,7,Principles of Marketing,0.74,0.2,0.04,0.01,0.0,0.0,0.0,0.01,patricia knowles,
+MKT,3020,1,Consumer Behavior,0.33,0.59,0.05,0.0,0.03,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,2,Consumer Behavior,0.49,0.41,0.1,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
+MKT,3020,3,Consumer Behavior,0.35,0.49,0.14,0.0,0.0,0.0,0.0,0.02,anastasia thyroff,
+MKT,3020,4,Consumer Behavior,0.41,0.43,0.17,0.0,0.0,0.0,0.0,0.0,anastasia thyroff,
+MKT,3020,5,Consumer Behavior,0.6,0.37,0.04,0.0,0.0,0.0,0.0,0.0,patricia knowles,
+MKT,3220,1,Social Media Marketing,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michele melt cauley,
+MKT,3220,2,Social Media Marketing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michele melt cauley,
+MKT,3310,1,Marketing Metrics & Analytics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,
+MKT,3310,2,Marketing Metrics & Analytics,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,
+MKT,3310,3,Marketing Metrics & Analytics,0.21,0.41,0.26,0.12,0.0,0.0,0.0,0.0,peter weathers,
+MKT,3310,4,Marketing Metrics & Analytics,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,3310,5,Marketing Metrics & Analytics,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,3980,1,CI:Sales Experiential,0.93,0.0,0.04,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,
+MKT,4200,1,Professional Selling,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,jesse moore,
+MKT,4200,2,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
+MKT,4200,3,Professional Selling,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4200,4,Professional Selling,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,kevin scott chase,
+MKT,4200,5,Professional Selling,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,kevin scott chase,
+MKT,4230,1,Promotional Strategy,0.82,0.16,0.02,0.0,0.0,0.0,0.0,0.0,michele melt cauley,
+MKT,4230,2,Promotional Strategy,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,michele melt cauley,
+MKT,4240,1,Sales Management,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,ryan mullins,
+MKT,4270,1,International Marketing,0.36,0.53,0.06,0.03,0.03,0.0,0.0,0.0,thomas poehlman,
+MKT,4270,2,International Marketing,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4270,3,International Marketing,0.84,0.13,0.02,0.0,0.0,0.0,0.0,0.0,xianyong wang,
+MKT,4270,4,International Marketing,0.47,0.38,0.1,0.03,0.0,0.0,0.0,0.03,patricia knowles,
+MKT,4280,1,Services Marketing,0.55,0.39,0.05,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4280,2,Services Marketing,0.53,0.45,0.03,0.0,0.0,0.0,0.0,0.0,james gaubert,
+MKT,4310,1,Marketing Research,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,michae giebelhausen,
+MKT,4310,2,Marketing Research,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,michae giebelhausen,
+MKT,4310,3,Marketing Research,0.4,0.3,0.23,0.0,0.0,0.0,0.0,0.07,william kilbourne,
+MKT,4310,4,Marketing Research,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4310,5,Marketing Research,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,
+MKT,4330,1,Sport Mkt Strategy,0.46,0.42,0.12,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,
+MKT,4450,1,Macromarketing,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,william kilbourne,
+MKT,4500,1,Strategic Mktg Mgt,0.13,0.45,0.42,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,2,Strategic Mktg Mgt,0.13,0.59,0.28,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
+MKT,4500,3,Strategic Mktg Mgt,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,4500,4,Strategic Mktg Mgt,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
+MKT,4500,5,Strategic Mktg Mgt,0.24,0.42,0.3,0.03,0.0,0.0,0.0,0.0,michael dorsch,
+MKT,8620,1,Quant Methods in Mkt,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
+MKT,8650,1,Seminar in Mkt Mgmt,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,michael dorsch,
+MKT,8660,1,International Marketing,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,aaron javron hills,
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,andre kareeth bland,
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jonathan jacoba,
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,christopher bland,
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,brian james gural,
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,kenneth to crawford,
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,thomas michae burke,
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,christopher bland,
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas michae burke,
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,matthew davi jordan,
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,andre kareeth bland,
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,kenneth to crawford,
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,vincent john presto,
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,thomas michae burke,
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,christopher bland,
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,justin rober merhar,
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,spencer blak harmon,
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,justin rober merhar,
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,spencer blak harmon,
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,
+MSE,2100,1,Intro to Materials Science,0.33,0.27,0.25,0.03,0.08,0.0,0.0,0.03,rakhee pani,
+MSE,2100,3,Intro to Materials Science,0.33,0.3,0.16,0.07,0.08,0.0,0.0,0.05,kai he,
+MSE,2100,4,Intro to Materials Science,0.53,0.25,0.08,0.04,0.04,0.0,0.0,0.05,rakhee pani,
+MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
+MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,
+MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
+MSE,3100,1,Intro to Metals and Ceramics,0.63,0.22,0.11,0.0,0.0,0.0,0.04,0.0,jianhua tong,
+MSE,3190,1,Materials Proc I,0.48,0.32,0.2,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,
+MSE,3190,1,Materials Proc I,0.48,0.32,0.2,0.0,0.0,0.0,0.0,0.0,rakhee pani,
+MSE,3190,2,Materials Proc I,0.31,0.31,0.17,0.07,0.03,0.0,0.0,0.1,rajendra kum bordia,
+MSE,3190,2,Materials Proc I,0.31,0.31,0.17,0.07,0.03,0.0,0.0,0.1,rakhee pani,
+MSE,3260,1,Thermo of Materials,0.26,0.43,0.26,0.0,0.0,0.0,0.0,0.06,fei peng,
+MSE,3260,2,Thermo of Materials,0.26,0.26,0.22,0.15,0.04,0.0,0.0,0.07,fei peng,
+MSE,3270,1,Transport Phenomena,0.17,0.35,0.39,0.0,0.0,0.0,0.04,0.04,ulf daniel schiller,
+MSE,3610,2,Proc of Metals & Composites,0.41,0.38,0.14,0.03,0.0,0.0,0.0,0.03,marian kennedy,
+MSE,4020,1,Fundamentals of Solid State,0.5,0.16,0.28,0.06,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,4070,1,Senior Capstone Design,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,
+MSE,4150,1,Polymer Sc Engr,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,olin mefford,
+MSE,4220,1,Mech Behavior of Mat,0.61,0.32,0.05,0.0,0.02,0.0,0.0,0.0,vincent yves blouin,
+MSE,4240,1,Optical Materials,0.8,0.07,0.1,0.03,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,4330,2,Comb Sys & Env Emiss,0.74,0.16,0.06,0.0,0.0,0.0,0.0,0.03,john sanders,
+MSE,4450,1,Practice of Mat Engr,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,marek urban,
+MSE,4910,1,Undergraduate Research,0.91,0.03,0.0,0.0,0.03,0.0,0.0,0.03,rajendra kum bordia,
+MSE,6020,1,Solid State Material,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
+MSE,8250,2,Solid State Mtl Sci,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,stephen foulger,
+MSE,8520,2,Polymer Science II,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,igor luzinov,
+MUSC,1110,5,Beginning Class Guitar,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david stevenson,
+MUSC,1110,6,Beginning Class Guitar,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,david stevenson,
+MUSC,1430,1,Aural Skills I,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,david conley,
+MUSC,1510,2,Applied Music,0.63,0.19,0.0,0.0,0.0,0.0,0.0,0.19,jonathan edwa doyel,
+MUSC,1510,19,Applied Music,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,monty craig,
+MUSC,1520,1,Applied Music,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,lisa sain odom,
+MUSC,1520,2,Applied Music,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edwa doyel,
+MUSC,1520,10,Applied Music,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,paul buyer,
+MUSC,1800,1,Intro to Music Tech,0.3,0.6,0.0,0.0,0.1,0.0,0.0,0.0,hamilton altstatt,
+MUSC,1950,1,Creative Inquiry in Music I,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,linda dzuris,
+MUSC,2100,2,Music in the Western World,0.52,0.26,0.13,0.03,0.0,0.0,0.0,0.06,lisa sain odom,
+MUSC,2100,4,Music in the Western World,0.48,0.26,0.16,0.03,0.03,0.0,0.0,0.03,rhea beth jacobus,
+MUSC,2100,5,Music in the Western World,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
+MUSC,2100,6,Music in the Western World,0.5,0.34,0.09,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
+MUSC,2100,7,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,evan michael jacobi,
+MUSC,2100,9,Music in the Western World,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,lea kibler,
+MUSC,2100,10,Music in the Western World,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,linda dzuris,
+MUSC,2510,2,Applied Music,0.75,0.0,0.0,0.0,0.25,0.0,0.0,0.0,jonathan edwa doyel,
+MUSC,2520,2,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edwa doyel,
+MUSC,3090,1,Surv of Broadway II,0.91,0.0,0.0,0.09,0.0,0.0,0.0,0.0,lisa sain odom,
+MUSC,3110,1,History of American Music,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,eric lapin,
+MUSC,3170,1,Hist of Country Mus,0.88,0.09,0.0,0.03,0.0,0.0,0.0,0.0,ned hosler,
+MUSC,3180,1,Hist of Audio Tech,0.39,0.22,0.28,0.06,0.0,0.0,0.0,0.06,bruce allen whisler,
+MUSC,3310,1,Pep Band,0.95,0.02,0.02,0.02,0.0,0.0,0.0,0.0,timothy ra hurlburt,
+MUSC,3310,2,Pep Band,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,
+MUSC,3640,1,Concert Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,timothy ra hurlburt,
+MUSC,3710,1,Women's Chorus,0.82,0.16,0.0,0.0,0.0,0.0,0.0,0.02,jerrad fenske,
+MUSC,3720,1,Men's Chorus,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,
+MUSC,4160,1,Mus Hist Since 1750,0.39,0.26,0.23,0.06,0.0,0.0,0.0,0.06,linda li-bleuel,
+MUSC,4300,1,Conducting,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mark spede,
+NPL,3000,1,Nonprofit Leadership,0.75,0.13,0.04,0.08,0.0,0.0,0.0,0.0,corey dou brookover,
+NPL,3000,2,Nonprofit Leadership,0.46,0.42,0.08,0.0,0.04,0.0,0.0,0.0,christina mar mazer,
+NPL,3000,3,Nonprofit Leadership,0.29,0.42,0.17,0.08,0.0,0.0,0.0,0.04,bonnie west stevens,
+NPL,3000,4,Nonprofit Leadership,0.36,0.5,0.05,0.05,0.0,0.0,0.0,0.05,bonnie west stevens,
+NPL,3000,5,Nonprofit Leadership,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,corey dou brookover,
+NPL,3000,6,Nonprofit Leadership,0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
+NPL,3000,7,Nonprofit Leadership,0.61,0.28,0.06,0.06,0.0,0.0,0.0,0.0,corey dou brookover,
+NPL,3000,8,Nonprofit Leadership,0.41,0.34,0.07,0.0,0.17,0.0,0.0,0.0,christina mar mazer,
+NPL,3010,2,NPL Stakeholders,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
+NPL,3020,1,NPL Fundraising,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,thomas john orourke,
+NPL,3030,2,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,joan laura phillips,
+NPL,3030,2,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+NPL,3040,1,NPL Risk Management,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,daniel mor anderson,
+NPL,3050,1,Strat Social Media for NP Org,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,
+NPL,3050,2,Strat Social Media for NP Org,0.38,0.38,0.14,0.03,0.03,0.0,0.0,0.03,amanda elizab moore,
+NURS,1400,1,Comp App Hlth Care,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,nancy meehan,
+NURS,1400,3,Comp App Hlth Care,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,
+NURS,1400,4,Comp App Hlth Care,0.87,0.09,0.02,0.02,0.0,0.0,0.0,0.0,catherine si murton,
+NURS,3030,101,Nursing of Adults,0.19,0.77,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3030,101,Nursing of Adults,0.19,0.77,0.04,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,
+NURS,3030,201,Nursing of Adults,0.21,0.66,0.13,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3030,201,Nursing of Adults,0.21,0.66,0.13,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,
+NURS,3030,401,Nursing of Adults,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,
+NURS,3030,401,Nursing of Adults,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
+NURS,3040,1,Pathophysiology,0.32,0.44,0.14,0.08,0.02,0.0,0.0,0.0,catherine si murton,
+NURS,3050,101,Psychosocial Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
+NURS,3050,401,Psychosocial Nursing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,margaret wetsel,
+NURS,3100,101,Health Assessment,0.94,0.04,0.02,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
+NURS,3100,201,Health Assessment,0.48,0.5,0.02,0.0,0.0,0.0,0.0,0.0,jason thrift,
+NURS,3120,1,Foundations of Nursing,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,
+NURS,3200,1,Prof in Nurs,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
+NURS,3230,1,Gerontology Nursing,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,zahra rahemi,
+NURS,3330,101,Health Care Genetics,0.7,0.27,0.02,0.02,0.0,0.0,0.0,0.0,linda ward,
+NURS,3330,400,Health Care Genetics,0.72,0.24,0.0,0.0,0.04,0.0,0.0,0.0,jennifer el bagwell,
+NURS,3330,401,Health Care Genetics,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,
+NURS,3400,1,Pharmther Nursing,0.3,0.48,0.16,0.04,0.0,0.0,0.02,0.0,catherine si murton,
+NURS,3610,400,Ldrshp & Collab in Global Hlth,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
+NURS,4010,1,Mental Health Nurs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NURS,4030,1,Complex Nursing of Adults,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,
+NURS,4110,1,Nursing of Children,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
+NURS,4120,1,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,4120,1,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,kylie padron newsom,
+NURS,4250,400,Community Nursing,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,tiffany lea stewart,
+NURS,8010,400,Adv Fam & Comm Nrsng,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
+NURS,8010,400,Adv Fam & Comm Nrsng,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
+NURS,8080,400,Nurs Res Stat Analys,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,8080,401,Nurs Res Stat Analys,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,veronica parker,
+NURS,8190,400,Developing Family,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
+NURS,8200,400,Child & Adol Nursing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
+NURS,8210,400,Adult Nursing,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8210,402,Adult Nursing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,
+NURS,8210,402,Adult Nursing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
+NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,
+NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,
+NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
+NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,
+NURS,8850,400,Mental Health in Primary Care,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
+NURS,9050,400,DNP Health Informatics,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,nancy meehan,
+NUTR,2030,1,Intro Princ of Human Nutrition,0.32,0.42,0.15,0.04,0.01,0.0,0.0,0.05,elizabeth durrance,
+NUTR,2030,2,Intro Princ of Human Nutrition,0.48,0.39,0.07,0.07,0.0,0.0,0.0,0.0,elizabeth durrance,
+NUTR,2040,1,Nutrition Across Life Cycle,0.43,0.47,0.05,0.01,0.01,0.0,0.0,0.03,elizabeth durrance,
+NUTR,3010,1,Food and Culture,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,bridgit den corbett,
+NUTR,4250,1,Medica Nutr Thera II,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
+NUTR,4260,1,Community Nutrition,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alexis stamatikos,
+NUTR,4270,1,Nutrition Counseling,0.66,0.24,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
+NUTR,4550,1,Human Nutr & Metabolism II,0.52,0.38,0.07,0.03,0.0,0.0,0.0,0.0,elliot jesch,
+PA,2790,1,Perf Arts Pract I,0.33,0.4,0.0,0.0,0.13,0.0,0.0,0.13,kenneth moore,
+PA,3010,1,Princip of Arts Administration,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paul buyer,
+PA,4010,1,Capstone Project,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,anthony penna,
+PADM,8410,401,Public Data Analysis,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,ronald chrestman,
+PADM,8410,402,Public Data Analysis,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
+PADM,8480,400,Strateg Planning for Pub Admin,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey rand parkey,
+PADM,8480,400,Strateg Planning for Pub Admin,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,maleena yenn parkey,
+PADM,8600,400,American Government,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,alfred bundrick,
+PADM,8660,400,Nonprofit Fundraising,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,victoria bedso hann,
+PADM,8680,400,Local Government Admin,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
+PES,2020,1,Soils,0.14,0.5,0.33,0.03,0.0,0.0,0.0,0.0,dara michelle park,
+PES,4060,2,Living Seed Ark,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,paula agudelo,
+PES,4060,2,Living Seed Ark,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,stephen kresovich,
+PES,4230,1,Forages and Livestock Systems,0.25,0.38,0.31,0.0,0.0,0.0,0.0,0.06,matias jose aguerre,
+PES,4330,1,Weed Management,0.23,0.15,0.54,0.0,0.0,0.0,0.0,0.08,ted whitwell,
+PES,4450,1,Regulatory Issues & Policies,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,
+PES,4520,1,Soil Fertility and Management,0.69,0.08,0.08,0.0,0.08,0.0,0.0,0.08,haibo liu,
+PES,4900,1,Soil Organisms in Plant Growth,0.21,0.5,0.21,0.0,0.0,0.0,0.0,0.07,"appukuttan suseela,",
+PES,4960,2,CI: Food Forest,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,julia loui kerrigan,
+PES,8010,1,Crop Physiology and Nutrition,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sru narayanan kutty,
+PES,8090,1,Analytical Technique,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,
+PHIL,1010,1,Intro to Philosophic Problems,0.35,0.35,0.21,0.0,0.03,0.0,0.0,0.06,kelly smith,
+PHIL,1010,2,Intro to Philosophic Problems,0.32,0.29,0.24,0.0,0.0,0.0,0.0,0.15,david stegall,
+PHIL,1010,3,Intro to Philosophic Problems,0.43,0.31,0.11,0.06,0.03,0.0,0.0,0.06,david stegall,
+PHIL,1010,4,Intro to Philosophic Problems,0.53,0.29,0.06,0.03,0.0,0.0,0.0,0.09,david robe antonini,
+PHIL,1010,5,Intro to Philosophic Problems,0.43,0.34,0.14,0.03,0.03,0.0,0.0,0.03,david robe antonini,
+PHIL,1010,6,Intro to Philosophic Problems,0.39,0.3,0.09,0.06,0.06,0.0,0.0,0.09,david stegall,
+PHIL,1010,7,"Intro to Phil, Problems (HON)",0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,christopher grau,True
+PHIL,1020,1,Introduction to Logic,0.67,0.24,0.03,0.06,0.0,0.0,0.0,0.0,edyta joanna kuzian,
+PHIL,1020,2,Introduction to Logic,0.69,0.14,0.03,0.03,0.0,0.0,0.03,0.09,adam pa omelianchuk,
+PHIL,1020,3,Introduction to Logic,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
+PHIL,1020,6,Introduction to Logic,0.73,0.12,0.09,0.03,0.0,0.0,0.0,0.03,adam pa omelianchuk,
+PHIL,1020,7,Introduction to Logic,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,adam pa omelianchuk,
+PHIL,1020,8,Introduction to Logic,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
+PHIL,1030,1,Introduction to Ethics,0.36,0.48,0.06,0.06,0.0,0.0,0.0,0.03,stephen satris,
+PHIL,1030,2,Intro to Ethics (HON),0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,stephen satris,True
+PHIL,1030,3,Introduction to Ethics,0.71,0.23,0.0,0.0,0.03,0.0,0.0,0.03,adam gies,
+PHIL,1030,4,Introduction to Ethics,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,
+PHIL,1030,5,Introduction to Ethics,0.22,0.44,0.28,0.0,0.0,0.0,0.0,0.06,charles starkey,
+PHIL,3030,1,Phil of Religion,0.41,0.41,0.14,0.0,0.0,0.0,0.0,0.03,richard al amesbury,
+PHIL,3050,1,Existentialism,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david stegall,
+PHIL,3120,1,Philosophy in Ancient China,0.43,0.29,0.14,0.14,0.0,0.0,0.0,0.0,yanming an,
+PHIL,3160,1,Modern Philosophy,0.38,0.46,0.04,0.04,0.0,0.0,0.0,0.08,david robe antonini,
+PHIL,3200,1,Soc and Pol Phil,0.39,0.42,0.13,0.03,0.0,0.0,0.0,0.03,todd may,
+PHIL,3210,1,Crime & Punishment,0.38,0.42,0.12,0.04,0.04,0.0,0.0,0.0,daniel wueste,
+PHIL,3260,1,Science and Values,0.8,0.14,0.03,0.0,0.0,0.0,0.0,0.03,adam pa omelianchuk,
+PHIL,3300,1,Animal Minds & Animal Ethics,0.62,0.12,0.08,0.0,0.04,0.0,0.0,0.15,adam gies,
+PHIL,3430,1,Philosophy of Law,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,brookes colyt brown,
+PHIL,3450,1,Environmental Ethics,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,kelly smith,
+PHIL,3460,1,Biomedical Ethics,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,charles starkey,
+PHIL,3990,1,Philosophy Portfolio,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,todd may,
+PHIL,4010,1,Studies in the Hist of Phil,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,stephen satris,
+PHIL,4020,1,The Limits of Morality,0.6,0.2,0.07,0.0,0.0,0.0,0.0,0.13,todd may,
+PHIL,4750,1,Philosophy of Film,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,christopher grau,
+PHSC,1170,1,Intro Chem & Earth,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
+PHYS,1220,1,Physics with Calculus I,0.2,0.35,0.25,0.11,0.04,0.0,0.0,0.05,lih-sin the,
+PHYS,1220,2,Physics with Calculus I,0.31,0.45,0.18,0.03,0.0,0.0,0.02,0.01,lih-sin the,
+PHYS,1220,3,Physics with Calculus I,0.28,0.41,0.21,0.05,0.03,0.0,0.0,0.02,pooja puneet,
+PHYS,1220,4,Physics with Calculus I,0.31,0.43,0.22,0.02,0.03,0.0,0.0,0.0,pooja puneet,
+PHYS,1220,5,Physics with Calculus I,0.34,0.44,0.16,0.03,0.01,0.0,0.0,0.02,jason stratfo brown,
+PHYS,1220,8,Physics w/Calculus I (HON),0.63,0.23,0.07,0.0,0.0,0.0,0.0,0.07,ramakrishna podila,True
+PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
+PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,1240,2,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,2,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,3,Physics Lab I,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,3,Physics Lab I,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,6,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
+PHYS,1240,6,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,1240,7,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,7,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,8,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,8,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,9,Physics Lab I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,daniel ros thompson,
+PHYS,1240,9,Physics Lab I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,bishwambha sengupta,
+PHYS,1240,11,Physics Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,daniel ros thompson,
+PHYS,1240,11,Physics Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,bishwambha sengupta,
+PHYS,1240,13,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,13,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,14,Physics Lab I,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,bishwambha sengupta,
+PHYS,1240,14,Physics Lab I,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,daniel ros thompson,
+PHYS,1240,15,Physics Lab I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,15,Physics Lab I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,16,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,16,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,17,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,17,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,20,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,20,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,21,Physics Lab I,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,21,Physics Lab I,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,22,Physics Lab I,0.43,0.21,0.14,0.0,0.0,0.0,0.0,0.21,daniel ros thompson,
+PHYS,1240,22,Physics Lab I,0.43,0.21,0.14,0.0,0.0,0.0,0.0,0.21,bishwambha sengupta,
+PHYS,1240,23,Physics Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,daniel ros thompson,
+PHYS,1240,23,Physics Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,bishwambha sengupta,
+PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
+PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,1240,25,Physics Lab I,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,25,Physics Lab I,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,26,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,26,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,27,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,27,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,29,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,29,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,30,Physics Lab I,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
+PHYS,1240,30,Physics Lab I,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,1240,31,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,31,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,32,Physics Lab I,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,32,Physics Lab I,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,1240,33,Physics Lab I,0.29,0.53,0.12,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
+PHYS,1240,33,Physics Lab I,0.29,0.53,0.12,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,1240,34,Physics Lab I,0.41,0.41,0.06,0.0,0.0,0.0,0.0,0.12,daniel ros thompson,
+PHYS,1240,34,Physics Lab I,0.41,0.41,0.06,0.0,0.0,0.0,0.0,0.12,bishwambha sengupta,
+PHYS,1240,35,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
+PHYS,1240,35,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2000,1,Introductory Physics,0.31,0.58,0.11,0.0,0.0,0.0,0.0,0.0,pooja puneet,
+PHYS,2070,1,General Physics I,0.25,0.2,0.25,0.11,0.13,0.0,0.0,0.07,amy liann pope,
+PHYS,2070,2,General Physics I,0.23,0.25,0.23,0.1,0.1,0.0,0.0,0.08,amy liann pope,
+PHYS,2080,1,General Physics II,0.58,0.27,0.09,0.04,0.0,0.0,0.01,0.0,amy liann pope,
+PHYS,2080,2,General Physics II,0.54,0.35,0.09,0.02,0.0,0.0,0.0,0.0,amy liann pope,
+PHYS,2080,4,General Physics II,0.53,0.29,0.14,0.04,0.0,0.0,0.0,0.0,amy liann pope,
+PHYS,2090,1,Gen Phys Lab I,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2090,2,Gen Phys Lab I,0.58,0.33,0.0,0.04,0.0,0.0,0.0,0.04,daniel ros thompson,
+PHYS,2090,3,Gen Phys Lab I,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2090,4,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
+PHYS,2090,5,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2090,6,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
+PHYS,2090,7,Gen Phys Lab I,0.63,0.29,0.0,0.0,0.0,0.0,0.0,0.08,daniel ros thompson,
+PHYS,2090,8,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
+PHYS,2090,9,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
+PHYS,2090,10,Gen Phys Lab I,0.67,0.25,0.04,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
+PHYS,2100,2,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,2,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,3,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,3,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,4,Gen Phys Lab II,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,danielle latham,
+PHYS,2100,4,Gen Phys Lab II,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
+PHYS,2100,5,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,5,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,6,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,6,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,7,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,7,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,8,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,8,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,9,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,9,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,10,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,10,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,11,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,11,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,13,Gen Phys Lab II,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,13,Gen Phys Lab II,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,14,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,14,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,15,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,15,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,16,Gen Phys Lab II,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,danielle latham,
+PHYS,2100,16,Gen Phys Lab II,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
+PHYS,2100,17,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,17,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,18,Gen Phys Lab II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,18,Gen Phys Lab II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2100,19,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
+PHYS,2100,19,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2210,1,Physics with Calculus II,0.15,0.42,0.29,0.05,0.0,0.0,0.06,0.04,jason stratfo brown,
+PHYS,2210,2,Physics with Calculus II,0.27,0.37,0.22,0.09,0.0,0.0,0.03,0.02,jason stratfo brown,
+PHYS,2210,3,Physics w/Calculus II (HON),0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True
+PHYS,2210,5,Physics with Calculus II,0.73,0.0,0.13,0.0,0.07,0.0,0.0,0.07,murray daw,
+PHYS,2230,2,Physics Lab II,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,yamei liu,
+PHYS,2230,2,Physics Lab II,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2230,3,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,2230,3,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,
+PHYS,2230,4,Physics Lab II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2230,4,Physics Lab II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,yamei liu,
+PHYS,2230,5,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
+PHYS,2230,5,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,yamei liu,
+PHYS,2230,6,Physics Lab II,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,
+PHYS,2230,6,Physics Lab II,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,2230,7,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,2230,7,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,yamei liu,
+PHYS,2230,8,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,yamei liu,
+PHYS,2230,8,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,daniel ros thompson,
+PHYS,2230,9,Physics Lab II,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,
+PHYS,2230,9,Physics Lab II,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
+PHYS,2400,1,Phys of Weather,0.31,0.35,0.19,0.08,0.04,0.0,0.0,0.04,jens oberheide,
+PHYS,3110,1,Methods Theor Phys,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,lih-sin the,
+PHYS,3220,1,Mechanics II,0.28,0.17,0.39,0.11,0.06,0.0,0.0,0.0,stephen ro kaeppler,
+PHYS,3990,1,CI STEM Competition,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,jason stratfo brown,
+PHYS,4560,1,Quantum Physics II,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,sumanta tewari,
+PHYS,4650,1,Thermo and Stat Mech,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,mark leising,
+PHYS,4750,1,Intro to Cellular Biophysics,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,joshua alper,
+PHYS,8150,1,Statistical Therm I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,celestine hackett,
+PHYS,8150,1,Statistical Therm I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
+PHYS,8410,1,Electrodynamics I,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,feng ding,
+PHYS,9520,1,Quantum Mech II,0.21,0.57,0.14,0.0,0.07,0.0,0.0,0.0,domnita marinescu,
+PKSC,1020,1,Intro to Pkg Sci,0.14,0.35,0.28,0.08,0.1,0.0,0.0,0.04,heather batt,
+PKSC,2010,100,Pkg Perishable Prod,0.07,0.24,0.35,0.17,0.1,0.0,0.0,0.07,heather batt,
+PKSC,2020,1,Packaging Mtl & Mfg,0.33,0.4,0.2,0.0,0.0,0.0,0.0,0.07,pa guerra marcondes,
+PKSC,2040,1,Container Systems,0.26,0.48,0.2,0.0,0.03,0.0,0.0,0.03,pa guerra marcondes,
+PKSC,2060,1,Container Sys Lab,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,pa guerra marcondes,
+PKSC,2060,2,Container Sys Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,pa guerra marcondes,
+PKSC,2060,3,Container Sys Lab,0.38,0.54,0.0,0.08,0.0,0.0,0.0,0.0,pa guerra marcondes,
+PKSC,2200,1,Product & Pkg Design,0.85,0.05,0.03,0.03,0.03,0.0,0.0,0.03,haley ellis appleby,
+PKSC,3680,400,Pkg and Society,0.29,0.53,0.13,0.0,0.04,0.0,0.0,0.01,heather batt,
+PKSC,4030,1,Pkg Career Prep,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4200,1,Pkg Design & Dev,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,robert kimmel,
+PKSC,4300,1,Converting Flex Pkg,0.22,0.65,0.12,0.0,0.01,0.0,0.0,0.0,duncan darby,
+PKSC,4400,1,Packaging for Distribution,0.25,0.45,0.25,0.03,0.03,0.0,0.0,0.0,gregory batt,
+PKSC,4400,400,Packaging for Distribution,0.02,0.47,0.29,0.08,0.14,0.0,0.0,0.0,gregory batt,
+PKSC,4640,1,Food & Health Care Pkg Systems,0.63,0.27,0.1,0.0,0.0,0.0,0.0,0.0,kay cooksey,
+PKSC,4990,3,CI-Packaging  Sci Seminar,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,rupert hurley,
+PKSC,8220,1,Packaging Dynamics,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,gregory batt,
+PLPA,2130,1,Fungi & Civilization,0.34,0.39,0.14,0.06,0.03,0.0,0.0,0.04,julia loui kerrigan,
+POSC,1010,2,Amer National Govt,0.22,0.44,0.18,0.07,0.04,0.0,0.0,0.04,jeffrey scott peake,
+POSC,1010,3,Amer National Govt,0.42,0.26,0.13,0.06,0.13,0.0,0.0,0.0,robert carey,
+POSC,1010,4,Amer National Govt,0.3,0.33,0.2,0.1,0.0,0.0,0.0,0.07,robert carey,
+POSC,1020,1,Intro Intl Relations,0.34,0.45,0.11,0.01,0.04,0.0,0.0,0.06,steven vince miller,
+POSC,1020,2,Intro Intl Relations,0.3,0.47,0.13,0.03,0.05,0.0,0.0,0.03,aron geo tannenbaum,
+POSC,1020,3,Intro Intl Relations,0.43,0.35,0.19,0.0,0.0,0.0,0.0,0.03,marjorie lo jeffrey,
+POSC,1030,1,Intro to Political Theory,0.67,0.08,0.08,0.17,0.0,0.0,0.0,0.0,jay hoffpauir,
+POSC,1030,2,Intro to Political Theory,0.11,0.67,0.11,0.04,0.0,0.0,0.04,0.04,john ant pascarella,
+POSC,1030,3,Intro to Political Theory,0.3,0.26,0.26,0.0,0.13,0.0,0.0,0.04,marjorie lo jeffrey,
+POSC,1030,4,Intro to Political Theory,0.05,0.15,0.5,0.15,0.1,0.0,0.0,0.05,colin denby pearce,
+POSC,1030,5,Intro to Political Theory,0.38,0.31,0.17,0.0,0.0,0.0,0.0,0.14,kevin gregory vance,
+POSC,1040,1,Intro Compar Pol,0.37,0.26,0.28,0.02,0.0,0.0,0.0,0.07,matthe rhodes-purdy,
+POSC,1990,1,Intro Pol Sci,0.23,0.4,0.15,0.06,0.13,0.0,0.0,0.02,meredith petersheim,
+POSC,3020,1,State and Loc Gov,0.1,0.66,0.15,0.02,0.02,0.0,0.0,0.05,bruce ransom,
+POSC,3050,3,Creative Inq in Political Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,xiaobo hu,
+POSC,3210,1,Public Admin,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,robert carey,
+POSC,3410,1,Quant Meth in Pol Sc,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,ethan craig busby,
+POSC,3430,1,Mass Media in Americ Politics,0.68,0.21,0.06,0.0,0.0,0.0,0.0,0.04,ethan craig busby,
+POSC,3630,1,Us Foreign Policy,0.47,0.38,0.09,0.02,0.0,0.0,0.0,0.04,vladimir matic,
+POSC,3710,615,European Politics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
+POSC,3810,1,African Amer Politic,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,
+POSC,4050,1,American Presidency,0.0,0.28,0.33,0.11,0.22,0.0,0.0,0.06,adam warber,
+POSC,4080,1,Religion and World Politics,0.38,0.38,0.21,0.0,0.0,0.0,0.0,0.04,laura olson,
+POSC,4160,1,Int Groups & Soc Mov,0.26,0.44,0.19,0.12,0.0,0.0,0.0,0.0,laura olson,
+POSC,4210,1,Public Policy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
+POSC,4360,1,Law Courts Politics,0.57,0.26,0.17,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
+POSC,4360,2,Law Courts Politics,0.53,0.42,0.06,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
+POSC,4370,1,Constitut Law: Rights & Libert,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,kevin gregory vance,
+POSC,4370,2,Constitut Law: Rights & Libert,0.7,0.18,0.06,0.0,0.0,0.0,0.0,0.06,kevin gregory vance,
+POSC,4470,1,International Law,0.33,0.17,0.21,0.13,0.13,0.0,0.0,0.04,katherine am curtis,
+POSC,4480,615,Internat'l Political Economy,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
+POSC,4500,1,Conservatism,0.33,0.33,0.29,0.0,0.0,0.0,0.0,0.05,brandon turner,
+POSC,4530,1,American Political Thought,0.41,0.46,0.11,0.0,0.0,0.0,0.0,0.02,colin denby pearce,
+POSC,4710,1,Russian Politics,0.33,0.49,0.13,0.0,0.02,0.0,0.0,0.02,aron geo tannenbaum,
+POSC,4760,1,Middle East Politics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
+POSC,4770,1,Chinese Politics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,xiaobo hu,
+POSC,4890,615,Post Conflict Pol. & Society,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
+POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,meredith petersheim,
+PRTM,2200,1,Foundations of PRTM,0.19,0.5,0.23,0.08,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2270,1,Prov of Leisure Exp,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
+PRTM,2270,1,Prov of Leisure Exp,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2290,1,Competency Integration in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
+PRTM,2290,1,Competency Integration in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,2410,1,Intro to CRSCM,0.39,0.26,0.26,0.06,0.0,0.0,0.0,0.03,jamie lynn cathey,
+PRTM,2410,2,Intro to CRSCM,0.23,0.27,0.2,0.1,0.0,0.0,0.1,0.1,jamie lynn cathey,
+PRTM,2600,1,Found of Recreational Therapy,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,brandi crowe,
+PRTM,2700,1,Intro Rec Res Mgt,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
+PRTM,2810,1,Intro to Golf Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,daniel mor anderson,
+PRTM,3070,1,Facility Operations,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,raymond dunham,
+PRTM,3210,1,Recreation Admin,0.4,0.34,0.14,0.09,0.0,0.0,0.0,0.03,jamie lynn cathey,
+PRTM,3210,2,Recreation Admin,0.18,0.61,0.12,0.03,0.03,0.0,0.0,0.03,jamie lynn cathey,
+PRTM,3250,1,Global Persp in Rec,0.2,0.16,0.4,0.04,0.16,0.0,0.0,0.04,harrison pinckney,
+PRTM,3250,2,Global Persp in Rec,0.5,0.25,0.14,0.07,0.04,0.0,0.0,0.0,harrison pinckney,
+PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
+PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,heather sext torphy,
+PRTM,3420,1,Intro to Tourism,0.89,0.09,0.03,0.0,0.0,0.0,0.0,0.0,katherine dudley,
+PRTM,3420,2,Intro to Tourism,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,peter marwa ezra,
+PRTM,3430,1,Spl Asp of Tourist B,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,kenneth backman,
+PRTM,3440,1,Tourism Markets,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,sheila backman,
+PRTM,3440,2,Tourism Markets,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,sheila backman,
+PRTM,3450,1,Tourism Management,0.41,0.48,0.1,0.0,0.0,0.0,0.0,0.0,william norman,
+PRTM,3450,2,Tourism Management,0.42,0.56,0.0,0.0,0.0,0.0,0.0,0.03,william norman,
+PRTM,3460,1,Heritage Tourism,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,
+PRTM,3460,2,Heritage Tourism,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,gregory phi ramshaw,
+PRTM,3530,2,Foundations of Camp Counseling,0.7,0.07,0.07,0.03,0.03,0.0,0.0,0.1,gwynn powell,
+PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,alexsandra dubin,
+PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,gwynn powell,
+PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,lisa kay-powl olsen,
+PRTM,3900,1,PGA GM Player Development,0.56,0.31,0.0,0.13,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,3900,1,PGA GM Player Development,0.56,0.31,0.0,0.13,0.0,0.0,0.0,0.0,adam savedra,
+PRTM,4300,1,World Geog Parks,0.76,0.16,0.06,0.0,0.0,0.0,0.0,0.02,tori kleinbort,
+PRTM,4460,2,Community Tourism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lauren duffy,
+PRTM,4540,1,Trends in Sport Mgt,0.61,0.22,0.13,0.04,0.0,0.0,0.0,0.0,skye arthur-banning,
+PRTM,4980,1,Creative Inquiry in PRTM IV,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,katrina latri black,
+PRTM,4980,1,Creative Inquiry in PRTM IV,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard lucas,
+PRTM,4980,17,Creative Inquiry in PRTM IV,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,skye arthur-banning,
+PRTM,4980,18,Creative Inquiry in PRTM IV,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,skye arthur-banning,
+PRTM,8030,1,Sem Rec & Park Admin,0.67,0.24,0.0,0.0,0.05,0.0,0.0,0.05,skye arthur-banning,
+PRTM,8110,2,Research Methods,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,rose irene verbos,
+PRTM,8130,1,Qualitative Research Methods,0.93,0.0,0.04,0.0,0.0,0.0,0.04,0.0,elizabeth baldwin,
+PRTM,8210,1,Funding Strategies in PRTM,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
+PRTM,8250,1,Populations in PRTM,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
+PRTM,8440,1,Outdoor Rec Mgt Plng,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,raymond bivens,
+PRTM,8720,1,Adv Facilitation Techniq in RT,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,
+PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
+PSYC,2010,1,Intro to Psychology,0.33,0.36,0.2,0.06,0.02,0.0,0.0,0.03,jo jorgensen,
+PSYC,2010,2,Intro to Psychology,0.29,0.26,0.19,0.11,0.1,0.0,0.0,0.05,edwin brainerd,
+PSYC,2010,3,Intro to Psychology,0.4,0.41,0.13,0.03,0.01,0.0,0.0,0.01,mary taylor,
+PSYC,2010,4,Intro to Psychology,0.46,0.3,0.09,0.09,0.01,0.0,0.0,0.04,mary taylor,
+PSYC,2010,6,Intro to Psychology,0.61,0.19,0.09,0.03,0.04,0.0,0.0,0.04,fred switzer,
+PSYC,2010,7,Intro to Psychology (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
+PSYC,2890,1,Fundamentals of Psyc Science,0.55,0.33,0.08,0.01,0.01,0.0,0.0,0.01,peggy jean tyler,
+PSYC,3060,1,Human Sexual Behavior,0.52,0.24,0.15,0.04,0.03,0.0,0.0,0.02,bruce michael king,
+PSYC,3090,100,Intro Experimental Psychology,0.51,0.27,0.15,0.03,0.03,0.0,0.0,0.01,jennifer bai bisson,
+PSYC,3090,200,Intro Experimental Psychology,0.28,0.36,0.24,0.07,0.04,0.0,0.0,0.01,richard tyrrell,
+PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,michael shreeves,
+PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,3100,200,Advanced Experimental Psych,0.39,0.44,0.11,0.0,0.06,0.0,0.0,0.0,eric mckibben,
+PSYC,3100,300,Advanced Experimental Psych,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,joseph ligato,
+PSYC,3100,300,Advanced Experimental Psych,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,robert ray sinclair,
+PSYC,3100,400,Advanced Experimental Psych,0.57,0.24,0.14,0.0,0.0,0.0,0.0,0.05,benjamin stephens,
+PSYC,3100,500,Advanced Experimental Psych,0.38,0.38,0.19,0.05,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3100,600,Advanced Experimental Psych,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
+PSYC,3100,700,Advanced Experimental Psych,0.55,0.32,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
+PSYC,3240,1,Physiological Psych,0.43,0.27,0.2,0.09,0.0,0.0,0.0,0.01,claudio cantalupo,
+PSYC,3240,2,Physiological Psych,0.42,0.33,0.15,0.06,0.0,0.0,0.0,0.04,claudio cantalupo,
+PSYC,3330,1,Cognitive Psych,0.33,0.4,0.17,0.03,0.0,0.0,0.0,0.06,robert campbell,
+PSYC,3330,2,Cognitive Psych,0.67,0.26,0.03,0.01,0.01,0.0,0.0,0.01,kaileigh ange byrne,
+PSYC,3330,3,Cognitive Psych,0.51,0.32,0.12,0.03,0.01,0.0,0.0,0.01,daniel braden quinn,
+PSYC,3340,1,Cognitive Psych Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kathryn lucaites,
+PSYC,3340,2,Cognitive Psych Lab,0.62,0.14,0.19,0.0,0.0,0.0,0.0,0.05,kathryn lucaites,
+PSYC,3400,1,Lifespan Developmental Psych,0.25,0.38,0.2,0.09,0.0,0.0,0.0,0.08,pamela alley,
+PSYC,3400,2,Lifespan Developmental Psych,0.32,0.37,0.21,0.07,0.03,0.0,0.0,0.0,anita pei tam,
+PSYC,3520,1,Social Psychology,0.51,0.32,0.12,0.01,0.01,0.0,0.0,0.01,ceren gunsoy,
+PSYC,3520,2,Social Psychology,0.37,0.37,0.16,0.09,0.0,0.0,0.0,0.0,jo jorgensen,
+PSYC,3520,3,Social Psychology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
+PSYC,3570,1,Psychology and Culture,0.56,0.18,0.18,0.05,0.02,0.0,0.0,0.02,ceren gunsoy,
+PSYC,3640,1,Industrial Psych,0.15,0.37,0.4,0.08,0.0,0.0,0.0,0.0,eric mckibben,
+PSYC,3640,2,Industrial Psych,0.28,0.35,0.29,0.06,0.01,0.0,0.0,0.01,eric mckibben,
+PSYC,3680,1,Organizational Psych,0.69,0.24,0.03,0.01,0.01,0.0,0.0,0.01,anton sytine,
+PSYC,3700,1,Personality,0.54,0.32,0.09,0.01,0.03,0.0,0.0,0.01,john robert hester,
+PSYC,3770,1,Psych of Group & Team Dynamics,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,marissa leig porter,
+PSYC,3830,1,Abnormal Psychology,0.3,0.49,0.16,0.04,0.01,0.0,0.0,0.01,cynthia pury,
+PSYC,3830,2,Abnormal Psychology,0.4,0.31,0.24,0.06,0.0,0.0,0.0,0.0,jo jorgensen,
+PSYC,3830,3,Abnormal Psychology,0.24,0.35,0.29,0.03,0.0,0.0,0.06,0.03,pamela alley,
+PSYC,3830,4,Abnormal Psychology,0.17,0.33,0.33,0.13,0.0,0.0,0.0,0.03,pamela alley,
+PSYC,4080,1,Women and Psychology,0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,robin mari kowalski,
+PSYC,4150,1,Systems and Theories,0.24,0.39,0.18,0.06,0.0,0.0,0.0,0.12,robert campbell,
+PSYC,4150,2,Systems and Theories,0.29,0.18,0.21,0.24,0.09,0.0,0.0,0.0,edwin brainerd,
+PSYC,4150,3,Systems and Theories,0.33,0.3,0.09,0.09,0.15,0.0,0.0,0.03,edwin brainerd,
+PSYC,4150,4,Systems and Theories,0.71,0.17,0.06,0.0,0.03,0.0,0.0,0.03,zachary klinefelter,
+PSYC,4220,1,Perception,0.55,0.09,0.05,0.23,0.0,0.0,0.0,0.09,claudio cantalupo,
+PSYC,4220,2,Perception,0.2,0.4,0.24,0.12,0.04,0.0,0.0,0.0,christopher pagano,
+PSYC,4220,3,Perception,0.3,0.17,0.39,0.04,0.04,0.0,0.0,0.04,claudio cantalupo,
+PSYC,4350,1,Human Factors,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,laura whitlock,
+PSYC,4710,1,Psych of Testing,0.61,0.17,0.09,0.0,0.04,0.0,0.0,0.09,zhuo chen,
+PSYC,4800,1,Health Psychology,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,james mccubbin,
+PSYC,4800,2,Health Psychology,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,james mccubbin,
+PSYC,4880,1,Psychotherapy,0.41,0.18,0.24,0.06,0.06,0.0,0.0,0.06,heidi marie zinzow,
+PSYC,4890,1,Organizational Stress,0.75,0.0,0.08,0.0,0.0,0.0,0.0,0.17,chelsea aly lenoble,
+PSYC,4890,2,Sports Psychology,0.29,0.41,0.24,0.06,0.0,0.0,0.0,0.0,anita pei tam,
+PSYC,4920,1,Senior Laboratory,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,chloe wilson,
+PSYC,4920,2,Senior Laboratory,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,chloe wilson,
+PSYC,4920,3,Senior Laboratory,0.46,0.42,0.04,0.04,0.04,0.0,0.0,0.0,chloe wilson,
+PSYC,4930,100,Pract Clinical Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,
+PSYC,4980,31,Autism Research,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,jennifer bai bisson,
+PSYC,4980,33,Autism Research II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jennifer bai bisson,
+PSYC,4980,121,Stress and Health,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james mccubbin,
+PSYC,4980,251,Critical Thinking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
+PSYC,4980,291,Suicide Prevention,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,martha par thompson,
+PSYC,4980,291,Suicide Prevention,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,heidi marie zinzow,
+PSYC,8130,1,Research Design III,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,patrick rosopa,
+PSYC,8140,1,Quantitative Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,patrick rosopa,
+PSYC,8630,1,Work Motivation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,fred switzer,
+RED,8030,1,Pub-Priv Partnership,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,stephen tho buckman,
+RED,8160,1,Preservation Feasibility,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
+RED,8890,1,Selected Topics-Entitlement Pr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,thomas andr sherard,
+RED,8890,1,Selected Topics-Entitlement Pr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
+RED,8890,2,Selected Topics-Construction O,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,andrew tay norville,
+REL,1010,1,Intro to Religion,0.21,0.32,0.29,0.03,0.06,0.0,0.0,0.09,peter cohen,
+REL,1010,2,Intro to Religion,0.38,0.29,0.18,0.09,0.03,0.0,0.0,0.03,peter cohen,
+REL,1010,3,Intro to Religion,0.2,0.51,0.2,0.06,0.03,0.0,0.0,0.0,peter cohen,
+REL,1020,2,World Religions,0.24,0.41,0.32,0.0,0.0,0.0,0.0,0.03,robert stephens,
+REL,1020,3,World Religions,0.33,0.36,0.27,0.0,0.03,0.0,0.0,0.0,robert stephens,
+REL,1020,4,World Religions,0.26,0.48,0.13,0.0,0.03,0.0,0.0,0.1,robert stephens,
+REL,3000,1,Studying Religion,0.41,0.38,0.17,0.0,0.0,0.0,0.0,0.03,benjamin white,
+REL,3010,1,Old Testament,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,
+REL,3020,1,New Testament Lit,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,benjamin white,
+REL,3030,1,The Quran,0.22,0.59,0.11,0.0,0.04,0.0,0.0,0.04,mashal saif,
+REL,3070,1,The Christian Tradition,0.17,0.59,0.1,0.0,0.0,0.0,0.0,0.14,brett patterson,
+REL,3100,1,History of Religion in the US,0.28,0.44,0.11,0.06,0.0,0.0,0.0,0.11,elizabeth jemison,
+REL,3170,1,Hist of Native Am Rel/Culture,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,james brad jeffries,
+REL,3350,1,Islam and the West,0.58,0.17,0.08,0.0,0.08,0.0,0.0,0.08,mashal saif,
+REL,3510,1,Ancient Near East,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,steven grosby,
+RS,4590,1,The Community,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
+RUD,8640,1,Urban Design Seminar II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,broo wortham-galvin,
+RUD,8650,1,Urban Design Vis & Comm II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,chelsea ma anderson,
+RUD,8650,1,Urban Design Vis & Comm II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,broo wortham-galvin,
+RUSS,1020,1,Elementary Russian,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,stephanie el morris,
+SOC,2010,2,Introduction to Sociology,0.58,0.3,0.1,0.0,0.01,0.0,0.0,0.01,carolyn can coffman,
+SOC,2010,3,Introduction to Sociology,0.88,0.1,0.0,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,
+SOC,2010,4,Introduction to Sociology,0.57,0.33,0.08,0.01,0.01,0.0,0.0,0.01,shannon mcdonough,
+SOC,2010,5,Introduction to Sociology,0.49,0.4,0.09,0.01,0.0,0.0,0.0,0.01,shannon mcdonough,
+SOC,2040,1,Prof Dev for Sociology Majors,0.5,0.25,0.09,0.09,0.06,0.0,0.0,0.0, catherine mobley,
+SOC,3020,1,Research Methods I,0.31,0.47,0.12,0.02,0.02,0.0,0.0,0.06,miao li,
+SOC,3040,1,Social Research Methods II,0.32,0.34,0.24,0.08,0.0,0.0,0.0,0.03,ye luo,
+SOC,3100,1,Marriage & Intimacy,0.68,0.21,0.09,0.0,0.02,0.0,0.0,0.0,carolyn can coffman,
+SOC,3110,1,The Family,0.37,0.47,0.1,0.02,0.02,0.0,0.0,0.02,andrew whitehead,
+SOC,3310,1,Urban Sociology,0.7,0.15,0.07,0.0,0.0,0.0,0.0,0.07,william haller,
+SOC,3500,1,Self & Society,0.67,0.19,0.07,0.05,0.0,0.0,0.0,0.02,carolyn can coffman,
+SOC,3600,1,Class & Poverty,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
+SOC,3800,1,Intro Social Service,0.69,0.22,0.04,0.02,0.02,0.0,0.0,0.0,jennifer le holland,
+SOC,3910,1,Soc of Deviance,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,
+SOC,3920,1,Juvenile Delinquency,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,
+SOC,4040,1,Soc Theory,0.55,0.15,0.25,0.05,0.0,0.0,0.0,0.0,william haller,
+SOC,4320,1,Soc of Religion,0.25,0.41,0.3,0.0,0.0,0.0,0.0,0.05,andrew whitehead,
+SOC,4590,1,The Community,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,kenneth robinson,
+SOC,4600,1,Race & Ethnicity,0.74,0.19,0.05,0.0,0.0,0.0,0.0,0.02,andrew mannheimer,
+SOC,4610,1,Sex & Gender,0.74,0.17,0.04,0.0,0.02,0.0,0.0,0.02,heather kettrey,
+SOC,4800,1,Medical Sociology,0.58,0.17,0.08,0.08,0.0,0.0,0.0,0.08,miao li,
+SOC,4840,1,Child Abuse,0.84,0.1,0.02,0.02,0.0,0.0,0.0,0.02,james rosenberger,
+SOC,4860,1,CI in SOC: Youth Rel Violence,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,carolyn can coffman,
+SOC,4950,1,Field Experience,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
+SOC,8050,1,Evaluation Research,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0, catherine mobley,
+SPAN,1010,1,Elementary Spanish,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,rosa mac pillcurima,
+SPAN,1010,2,Elementary Spanish,0.43,0.35,0.09,0.09,0.0,0.0,0.0,0.04,rosa mac pillcurima,
+SPAN,1010,3,Elementary Spanish,0.38,0.17,0.13,0.08,0.08,0.0,0.0,0.17,rosa mac pillcurima,
+SPAN,1020,2,Elementary Spanish,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,andrea patr naranjo,
+SPAN,1020,3,Elementary Spanish,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,1020,4,Elementary Spanish,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,rosa mac pillcurima,
+SPAN,1020,5,Elementary Spanish,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,1020,6,Elementary Spanish,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,
+SPAN,1020,7,Elementary Spanish,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,1020,8,Elementary Spanish,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,1020,9,Elementary Spanish,0.33,0.5,0.0,0.0,0.08,0.0,0.0,0.08,debra oa williamson,
+SPAN,1020,10,Elementary Spanish,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,1,Intermediate Spanish,0.82,0.09,0.05,0.05,0.0,0.0,0.0,0.0,mercedes tejera,
+SPAN,2010,2,Intermediate Spanish,0.88,0.0,0.04,0.0,0.04,0.0,0.0,0.04,mercedes tejera,
+SPAN,2010,3,Intermediate Spanish,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,andrea patr naranjo,
+SPAN,2010,4,Intermediate Spanish,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,liliana hernandez,
+SPAN,2010,5,Intermediate Spanish,0.64,0.24,0.04,0.0,0.0,0.0,0.0,0.08,liliana hernandez,
+SPAN,2010,6,Intermediate Spanish,0.23,0.55,0.09,0.05,0.0,0.0,0.0,0.09,melva margu persico,
+SPAN,2010,7,Intermediate Spanish,0.3,0.57,0.09,0.04,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,2010,8,Intermediate Spanish,0.55,0.2,0.1,0.05,0.1,0.0,0.0,0.0,mari judez riquelme,
+SPAN,2010,9,Intermediate Spanish,0.72,0.16,0.04,0.0,0.0,0.0,0.0,0.08,mari judez riquelme,
+SPAN,2010,10,Intermediate Spanish,0.6,0.24,0.16,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,11,Intermediate Spanish,0.65,0.22,0.04,0.09,0.0,0.0,0.0,0.0,ellory schmucker,
+SPAN,2010,12,Intermediate Spanish,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
+SPAN,2010,13,Intermediate Spanish,0.6,0.25,0.05,0.05,0.0,0.0,0.0,0.05,debra oa williamson,
+SPAN,2020,2,Intermediate Spanish,0.39,0.39,0.11,0.0,0.0,0.0,0.0,0.11,juana martin-armas,
+SPAN,2020,3,Intermediate Spanish,0.38,0.29,0.24,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,
+SPAN,2020,4,Intermediate Spanish,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
+SPAN,2020,5,Intermediate Spanish,0.4,0.52,0.08,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,2020,6,Intermediate Spanish,0.56,0.32,0.08,0.0,0.04,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,2020,7,Intermediate Spanish,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
+SPAN,2020,8,Intermediate Spanish,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,ana paula  miller,
+SPAN,2020,9,Intermediate Spanish,0.14,0.64,0.14,0.0,0.0,0.0,0.0,0.09,ana paula  miller,
+SPAN,2020,10,Intermediate Spanish,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,al garcia rodriguez,
+SPAN,2020,11,Intermediate Spanish,0.52,0.32,0.04,0.04,0.0,0.0,0.0,0.08,al garcia rodriguez,
+SPAN,2020,12,Intermediate Spanish,0.45,0.41,0.14,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,13,Intermediate Spanish,0.48,0.4,0.08,0.0,0.0,0.0,0.0,0.04,adrienne eliza fama,
+SPAN,2020,14,Intermediate Spanish,0.48,0.36,0.08,0.08,0.0,0.0,0.0,0.0,adrienne eliza fama,
+SPAN,2020,20,Intermediate Spanish,0.92,0.0,0.04,0.04,0.0,0.0,0.0,0.0,mercedes tejera,
+SPAN,3010,1,Spanish Comp for Health Prof,0.47,0.4,0.07,0.07,0.0,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,3020,1,Intermed Span Grammar & Comp,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,
+SPAN,3020,2,Intermed Span Grammar & Comp,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,melva margu persico,
+SPAN,3020,3,Intermed Span Grammar & Comp,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,
+SPAN,3040,2,Intro Hispanic Literary Forms,0.88,0.04,0.04,0.0,0.04,0.0,0.0,0.0,george palacios,
+SPAN,3050,3,Intermed Span Convers/Comp I,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,3050,4,Intermed Span Convers/Comp I,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,3070,1,The Hispanic World: Spain,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,
+SPAN,3070,35,The Hispanic World: Spain,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,3080,1,The Hispanic World: Latin Amer,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,tiffany dawn miller,
+SPAN,3080,2,The Hispanic World: Latin Amer,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
+SPAN,3080,30,The Hispanic World: Latin Amer,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,danie garcia vieyra,
+SPAN,3130,1,Span Lit Survey I,0.3,0.4,0.2,0.0,0.0,0.0,0.0,0.1,mon rojas-de-massei,
+SPAN,3160,35,Spanish for Int'l Business I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,4030,1,Span Amer Wom Writer,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
+SPAN,4060,1,Narrative Fiction,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,
+SPAN,4070,1,Hispanic Film,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,salvador oropesa,
+SPAN,4160,35,Spanish for Int'l Trade II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+SPAN,4190,35,Health & Hispanic Community,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
+STAT,2220,1,Statistics in Everyday Life,0.31,0.44,0.1,0.09,0.04,0.0,0.0,0.01,james espey,
+STAT,2220,2,Statistics in Everyday Life,0.47,0.29,0.17,0.03,0.0,0.0,0.0,0.04,james espey,
+STAT,2220,3,Statistics in Everyday Life,0.48,0.36,0.09,0.05,0.02,0.0,0.0,0.0,james espey,
+STAT,2220,4,Statistics in Everyday Life,0.31,0.44,0.16,0.04,0.04,0.0,0.0,0.0,james espey,
+STAT,2220,5,Statistics in Everyday Life,0.4,0.38,0.17,0.04,0.02,0.0,0.0,0.0,ros martinez-dawson,
+STAT,2220,6,Statistics in Everyday Life,0.31,0.36,0.08,0.13,0.08,0.0,0.0,0.05,ros martinez-dawson,
+STAT,2220,7,Statistics in Everyday Life,0.35,0.34,0.15,0.04,0.04,0.0,0.0,0.07,ros martinez-dawson,
+STAT,2300,1,Statistical Methods I,0.09,0.31,0.29,0.11,0.13,0.0,0.0,0.08,morgan elston,
+STAT,2300,2,Statistical Methods I,0.39,0.28,0.18,0.08,0.03,0.0,0.0,0.04,christy jenki brown,
+STAT,2300,3,Statistical Methods I,0.25,0.36,0.15,0.15,0.06,0.0,0.0,0.04, erwin walker,
+STAT,2300,4,Statistical Methods I,0.21,0.41,0.19,0.09,0.08,0.0,0.0,0.03, erwin walker,
+STAT,2300,5,Statistical Methods I,0.37,0.33,0.21,0.06,0.01,0.0,0.0,0.02,sharon marie evans,
+STAT,2300,6,Statistical Methods I,0.39,0.34,0.15,0.07,0.02,0.0,0.0,0.03,sharon marie evans,
+STAT,2300,100,Statistical Methods I (HON),0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,christy jenki brown,True
+STAT,3090,1,Introductory Business Stats,0.35,0.41,0.15,0.0,0.06,0.0,0.0,0.03,anna marie vagnozzi,
+STAT,3090,2,Introductory Business Stats,0.45,0.36,0.09,0.06,0.03,0.0,0.0,0.0,kristina gorsline,
+STAT,3090,3,Introductory Business Stats,0.44,0.25,0.19,0.06,0.03,0.0,0.0,0.03,alan robert hahn,
+STAT,3090,4,Introductory Business Stats,0.27,0.45,0.21,0.0,0.0,0.0,0.0,0.06,trevor squires,
+STAT,3090,5,Introductory Business Stats,0.28,0.28,0.28,0.03,0.06,0.0,0.0,0.06,yidan guo,
+STAT,3090,6,Introductory Business Stats,0.39,0.23,0.13,0.03,0.16,0.0,0.0,0.06,yiren ding,
+STAT,3090,7,Introductory Business Stats,0.37,0.26,0.23,0.06,0.03,0.0,0.0,0.06,paran rebeka norton,
+STAT,3090,8,Introductory Business Stats,0.21,0.21,0.24,0.18,0.09,0.0,0.0,0.09,michael thoma cowen,
+STAT,3090,9,Introductory Business Stats,0.18,0.24,0.26,0.18,0.09,0.0,0.0,0.06,sean wal ingimarson,
+STAT,3090,10,Introductory Business Stats,0.38,0.32,0.12,0.09,0.06,0.0,0.0,0.03,zhengxin wang,
+STAT,3090,11,Introductory Business Stats,0.24,0.25,0.31,0.1,0.0,0.0,0.07,0.03,april thomas,
+STAT,3090,12,Introductory Business Stats,0.37,0.29,0.24,0.08,0.0,0.0,0.01,0.0,april thomas,
+STAT,3090,13,Introductory Business Stats,0.29,0.21,0.21,0.18,0.03,0.0,0.0,0.09,xueheng shi,
+STAT,3090,14,Introductory Business Stats,0.32,0.24,0.21,0.09,0.0,0.0,0.15,0.0,fun choi john chan,
+STAT,3090,15,Introductory Business Stats,0.41,0.41,0.12,0.0,0.03,0.0,0.0,0.03,john char nicholson,
+STAT,3300,1,Statistical Methods II,0.44,0.17,0.22,0.06,0.0,0.0,0.0,0.11,ros martinez-dawson,
+STAT,4020,1,Intro to Statistical Computing,0.7,0.1,0.1,0.0,0.05,0.0,0.0,0.05,ellen hepfe breazel,
+STAT,4020,401,Intro to Statistical Computing,0.38,0.31,0.13,0.0,0.0,0.0,0.0,0.19,ellen hepfe breazel,
+STAT,4110,1,Stat Mthds for Process Control,0.62,0.32,0.05,0.0,0.0,0.0,0.0,0.0,william bridges,
+STAT,4110,2,Stat Mthds for Process Control,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard stev dubsky,
+STAT,4110,3,Stat Mthds for Process Control,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,richard stev dubsky,
+STAT,6020,1,Intro to Statistical Computing,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ellen hepfe breazel,
+STAT,6020,401,Intro to Statistical Computing,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,ellen hepfe breazel,
+STAT,8010,2,Statistical Methods I,0.57,0.39,0.0,0.0,0.0,0.0,0.0,0.04,william bridges,
+STAT,8010,3,Statistical Methods I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,deborah eliz kunkel,
+STAT,8010,4,Statistical Methods I,0.61,0.0,0.11,0.0,0.17,0.0,0.0,0.11,jun luo,
+STAT,8010,5,Statistical Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,
+STAT,8010,400,Statistical Methods I,0.41,0.55,0.0,0.0,0.0,0.0,0.0,0.03,brook thaye russell,
+STAT,8010,400,Statistical Methods I,0.41,0.55,0.0,0.0,0.0,0.0,0.0,0.03,deborah eliz kunkel,
+STAT,8050,1,Design & Anlys of Experiments,0.56,0.22,0.04,0.0,0.0,0.0,0.0,0.19,patrick gerard,
+STS,1010,1,Survey Sci & Techn in Society,0.63,0.34,0.0,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,
+STS,1010,2,Survey Sci & Techn in Society,0.44,0.35,0.15,0.0,0.0,0.0,0.0,0.06,scott brame,
+STS,1010,3,Survey Sci & Techn in Society,0.53,0.33,0.06,0.06,0.0,0.0,0.03,0.0,elizabeth stansell,
+STS,1010,4,Survey Sci & Techn in Society,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
+STS,1010,5,Survey Sci & Techn in Society,0.38,0.49,0.08,0.0,0.03,0.0,0.0,0.03,philip randall,
+STS,1010,6,Survey Sci & Techn in Society,0.09,0.51,0.17,0.03,0.03,0.0,0.0,0.17,sarah mae cooper,
+STS,1010,7,Survey Sci & Techn in Society,0.26,0.43,0.06,0.03,0.14,0.0,0.0,0.09,megan no macalystre,
+STS,1010,8,Survey Sci & Techn in Society,0.25,0.59,0.06,0.03,0.0,0.0,0.0,0.06,david charles foltz,
+STS,1010,9,Survey Sci & Techn in Society,0.81,0.14,0.03,0.0,0.0,0.0,0.0,0.03,christine cl murphy,
+STS,1010,10,Survey Sci & Techn in Society,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alexander billinis,
+THEA,2100,1,Theatre Appreciation,0.56,0.28,0.13,0.03,0.0,0.0,0.0,0.0,kerrie kath seymour,
+THEA,2100,2,Theatre Appreciation,0.42,0.29,0.23,0.03,0.0,0.0,0.0,0.03,kendra lyne johnson,
+THEA,2100,4,Theatre Appreciation,0.58,0.32,0.1,0.0,0.0,0.0,0.0,0.0,carol collins,
+THEA,2100,5,Theatre Appreciation,0.59,0.31,0.09,0.0,0.0,0.0,0.0,0.0,jason adkins,
+THEA,2790,1,Theatre Practicum,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,matthew leckenbusch,
+THEA,3090,1,Surv of Broadway II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
+THEA,3150,1,Theatre History I,0.65,0.29,0.0,0.0,0.03,0.0,0.0,0.03,shannon ther robert,
+THEA,3180,1,Afri-Amer Thea II,0.66,0.21,0.14,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
+THEA,3740,1,Movement for Actors,0.75,0.0,0.17,0.08,0.0,0.0,0.0,0.0,kerrie kath seymour,
+THEA,3980,1,Special Topics in Theatre,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
+WFB,3000,1,Wildlife Biology,0.43,0.29,0.2,0.06,0.01,0.0,0.0,0.0,catherine jachowski,
+WFB,3010,1,Wildlife Biology Lab,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,3130,1,Conservation Biology,0.35,0.34,0.24,0.04,0.03,0.0,0.0,0.01,shari lyn rodriguez,
+WFB,3130,2,Conservation Biology,0.29,0.32,0.27,0.05,0.02,0.0,0.0,0.05,shari lyn rodriguez,
+WFB,4120,1,Wildlife Management,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
+WFB,4160,1,Fisheries Techniques,0.63,0.34,0.02,0.0,0.0,0.0,0.0,0.0,troy mason farmer,
+WFB,4620,1,Wetland Wildlife Biology,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,russell barrett,
+WFB,4680,1,Herpetology,0.38,0.43,0.19,0.0,0.0,0.0,0.0,0.0,jeffrey robert mohr,
+WFB,4930,2,Quantitative Ecology,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.05,laura gigliotti,
+WFB,8500,1,Wildlife & Fisheries Ecology,0.38,0.38,0.05,0.0,0.05,0.0,0.0,0.14,mark scott,
+WFB,8500,1,Wildlife & Fisheries Ecology,0.38,0.38,0.05,0.0,0.05,0.0,0.0,0.14,susan talley guynn,
+WFB,8610,1,Scientific Writing,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,stefanie whitmire,
+WFB,8610,3,Hum Dim/Fisheries & WL -OnLine,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,shari lyn rodriguez,
+WFB,8630,1,Non Thesis Project,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,althea simone hagan,
+WS,1030,1,Women in Global Perspective,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
+WS,3010,1,Intro Women's Studies,0.58,0.33,0.04,0.04,0.0,0.0,0.0,0.0,elizabeth ros adams,
+WS,3010,2,Intro Women's Studies,0.46,0.38,0.13,0.0,0.0,0.0,0.0,0.04,elizabeth ros adams,
+WS,4010,1,Senior Seminar,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,diane perpich,
+YDP,3100,1,Youth Developmt and the Family,0.72,0.16,0.0,0.0,0.04,0.0,0.0,0.08,william quinn,
+YDP,3150,2,Community & Youth Dev Systems,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephen lance,
+YDP,3250,1,Working with Diverse Youth,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,kimberly pe johnson,
+YDP,3350,1,Youth Activity Leadership,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,alexandra sandoval,
+YDP,3400,1,Deliver Effective Youth Progra,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,kellye rembert,
+YDP,4400,1,Youth Program Assessmnt & Eval,0.58,0.26,0.0,0.11,0.0,0.0,0.0,0.05,ann marie gillard,
+YDP,8010,1,Child/Adolescent Dev,0.85,0.11,0.0,0.0,0.04,0.0,0.0,0.0,edmond patri bowers,
+YDP,8040,1,Assess & Eval of Youth Program,0.7,0.15,0.15,0.0,0.0,0.0,0.0,0.0,barry garst,
+YDP,8880,1,Special Topics Youth Dev Ldshp,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,barry garst,

--- a/bot/cogs/grades_cog/assets/2019_Spring.csv
+++ b/bot/cogs/grades_cog/assets/2019_Spring.csv
@@ -1,2954 +1,2954 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1020,1,Survey of Art & Arch Hist II,0.46,0.42,0.11,0.0,0.0,0.0,0.0,0.01,beth ann lauritis,
-AAH,2060,1,Art History and Theory II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,
-ACCT,2010,1,Financial Accounting Concepts,0.61,0.2,0.1,0.05,0.0,0.0,0.02,0.02,emily suza mccorkle,
-ACCT,2010,2,Financial Accounting Concepts,0.31,0.43,0.19,0.05,0.02,0.0,0.0,0.0,emily suza mccorkle,
-ACCT,2010,3,Financial Accounting Concepts,0.18,0.52,0.2,0.05,0.02,0.0,0.0,0.02,lydia lan schleifer,
-ACCT,2010,4,Financial Accounting Concepts,0.45,0.33,0.1,0.03,0.03,0.0,0.0,0.08,annieka philo,
-ACCT,2010,5,Financial Accounting Concepts,0.3,0.43,0.15,0.08,0.03,0.0,0.0,0.03,annieka philo,
-ACCT,2010,6,Financial Accounting Concepts,0.2,0.43,0.25,0.05,0.03,0.0,0.0,0.05,annieka philo,
-ACCT,2010,7,Financial Accounting Concepts,0.16,0.48,0.23,0.02,0.07,0.0,0.0,0.05,lydia lan schleifer,
-ACCT,2010,8,Financial Accounting Concepts,0.07,0.4,0.37,0.07,0.02,0.0,0.0,0.07,lydia lan schleifer,
-ACCT,2010,9,Financial Accounting Concepts,0.35,0.33,0.2,0.03,0.1,0.0,0.0,0.0,annieka philo,
-ACCT,2010,10,Financial Accounting Concepts,0.16,0.25,0.25,0.09,0.09,0.0,0.0,0.16,mary ann  prater,
-ACCT,2010,11,Financial Accounting Concepts,0.31,0.4,0.11,0.03,0.06,0.0,0.0,0.09,charles tegen,
-ACCT,2010,12,Financial Accounting Concepts,0.3,0.38,0.13,0.0,0.08,0.0,0.0,0.13,lisa whe birtwistle,
-ACCT,2010,13,Financial Accounting Concepts,0.41,0.31,0.21,0.03,0.0,0.0,0.05,0.0,lisa whe birtwistle,
-ACCT,2010,14,Financial Accounting Concepts,0.46,0.36,0.13,0.0,0.05,0.0,0.0,0.0,lisa whe birtwistle,
-ACCT,2010,15,Financial Accounting Concepts,0.34,0.39,0.15,0.07,0.05,0.0,0.0,0.0,james barnes,
-ACCT,2010,16,Financial Accounting Concepts,0.37,0.33,0.14,0.05,0.07,0.0,0.0,0.05,james barnes,
-ACCT,2010,17,Financial Accounting Concepts,0.0,0.34,0.41,0.07,0.07,0.0,0.0,0.1,lydia lan schleifer,
-ACCT,2010,101,Fin Acct Concepts (HON),0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,mary ann  prater,True
-ACCT,2010,401,Financial Accounting Concepts,0.29,0.36,0.18,0.06,0.08,0.0,0.0,0.03,jeffrey mcmillan,
-ACCT,2020,1,Managerial Accounting Concepts,0.25,0.25,0.29,0.04,0.07,0.0,0.0,0.11,henry anderson,
-ACCT,2020,2,Managerial Accounting Concepts,0.34,0.26,0.26,0.06,0.03,0.0,0.0,0.06,henry anderson,
-ACCT,2020,3,Managerial Accounting Concepts,0.41,0.31,0.13,0.05,0.0,0.0,0.03,0.08,henry anderson,
-ACCT,2020,4,Managerial Accounting Concepts,0.29,0.36,0.24,0.05,0.05,0.0,0.0,0.02,emily suza mccorkle,
-ACCT,2020,5,Managerial Accounting Concepts,0.33,0.4,0.14,0.05,0.0,0.0,0.05,0.02,emily suza mccorkle,
-ACCT,2020,6,Managerial Accounting Concepts,0.31,0.27,0.25,0.1,0.02,0.0,0.0,0.04,phebia davis-culler,
-ACCT,2020,7,Managerial Accounting Concepts,0.23,0.38,0.17,0.09,0.0,0.0,0.13,0.0,phebia davis-culler,
-ACCT,2020,8,Managerial Accounting Concepts,0.16,0.23,0.37,0.09,0.0,0.0,0.09,0.05,phebia davis-culler,
-ACCT,2020,401,Managerial Accounting Concepts,0.28,0.35,0.22,0.04,0.01,0.0,0.0,0.11,henry anderson,
-ACCT,2900,1,Special Topics - Soft Skills,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,michael mendonca,
-ACCT,3030,1,Cost Accounting,0.38,0.31,0.28,0.03,0.0,0.0,0.0,0.0,babak mammadov,
-ACCT,3030,2,Cost Accounting,0.29,0.37,0.29,0.05,0.0,0.0,0.0,0.0,babak mammadov,
-ACCT,3030,3,Cost Accounting,0.12,0.36,0.36,0.06,0.03,0.0,0.0,0.06,jace garrett,
-ACCT,3030,4,Cost Accounting,0.33,0.25,0.33,0.03,0.03,0.0,0.0,0.03,jace garrett,
-ACCT,3030,5,Cost Accounting,0.28,0.44,0.08,0.11,0.0,0.0,0.0,0.08,jace garrett,
-ACCT,3110,1,Intermediate Financial Acct I,0.14,0.29,0.18,0.11,0.21,0.0,0.0,0.07,erin michel hawkins,
-ACCT,3110,2,Intermediate Financial Acct I,0.19,0.31,0.23,0.08,0.15,0.0,0.0,0.04,erin michel hawkins,
-ACCT,3110,3,Intermediate Financial Acct I,0.23,0.26,0.32,0.03,0.03,0.0,0.0,0.13,amy meliss donnelly,
-ACCT,3110,4,Intermediate Financial Acct I,0.28,0.38,0.22,0.09,0.0,0.0,0.0,0.03,amy meliss donnelly,
-ACCT,3110,5,Intermediate Financial Acct I,0.1,0.42,0.35,0.03,0.0,0.0,0.0,0.1,brian matth goodson,
-ACCT,3110,6,Intermediate Financial Acct I,0.17,0.23,0.37,0.07,0.0,0.0,0.0,0.17,brian matth goodson,
-ACCT,3110,401,Intermediate Financial Acct I,0.32,0.22,0.2,0.02,0.05,0.0,0.0,0.2,henry anderson,
-ACCT,3120,1,Intermediate Financial Acct II,0.16,0.21,0.32,0.11,0.05,0.0,0.0,0.16,jeremy micha vinson,
-ACCT,3120,2,Intermediate Financial Acct II,0.35,0.26,0.29,0.06,0.0,0.0,0.0,0.03,jeremy micha vinson,
-ACCT,3120,3,Intermediate Financial Acct II,0.41,0.45,0.1,0.0,0.0,0.0,0.0,0.03,terry daniel knause,
-ACCT,3120,4,Intermediate Financial Acct II,0.29,0.53,0.12,0.0,0.03,0.0,0.0,0.03,terry daniel knause,
-ACCT,3120,5,Intermediate Financial Acct II,0.14,0.48,0.29,0.0,0.0,0.0,0.0,0.1,terry daniel knause,
-ACCT,3120,6,Intermediate Financial Acct II,0.32,0.42,0.16,0.0,0.03,0.0,0.0,0.06,terry daniel knause,
-ACCT,3120,101,Intermed Fin Acct II (HON),0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,terry daniel knause,True
-ACCT,3130,1,Intermediate Fin Acct III,0.24,0.5,0.24,0.0,0.0,0.0,0.0,0.02, russell madray,
-ACCT,3130,2,Intermediate Fin Acct III,0.22,0.44,0.2,0.1,0.02,0.0,0.0,0.02, russell madray,
-ACCT,3130,3,Intermediate Fin Acct III,0.38,0.43,0.17,0.02,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3130,4,Intermediate Fin Acct III,0.45,0.42,0.09,0.03,0.0,0.0,0.0,0.0, russell madray,
-ACCT,3130,101,Intermed Fin Acct III (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0, russell madray,True
-ACCT,3220,1,Accounting Information Systems,0.08,0.25,0.38,0.08,0.04,0.0,0.0,0.17,philip maiberger,
-ACCT,3220,2,Accounting Information Systems,0.04,0.48,0.3,0.09,0.04,0.0,0.0,0.04,philip maiberger,
-ACCT,3220,3,Accounting Information Systems,0.21,0.38,0.25,0.08,0.04,0.0,0.0,0.04,philip maiberger,
-ACCT,3220,4,Accounting Information Systems,0.1,0.38,0.29,0.0,0.0,0.0,0.1,0.14,philip maiberger,
-ACCT,4040,1,Individual Taxation,0.45,0.36,0.12,0.06,0.0,0.0,0.0,0.0,sarah martin,
-ACCT,4040,2,Individual Taxation,0.38,0.35,0.18,0.05,0.03,0.0,0.0,0.03,sarah martin,
-ACCT,4040,3,Individual Taxation,0.24,0.53,0.16,0.05,0.0,0.0,0.0,0.03,lisa whe birtwistle,
-ACCT,4040,4,Individual Taxation,0.27,0.27,0.27,0.16,0.03,0.0,0.0,0.0,lisa whe birtwistle,
-ACCT,4040,101,Individual Taxation (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,True
-ACCT,4100,1,Reporting and Mgmt Control Sys,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,frances kennedy,
-ACCT,4100,2,Reporting and Mgmt Control Sys,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,frances kennedy,
-ACCT,4100,3,Reporting and Mgmt Control Sys,0.33,0.5,0.13,0.03,0.0,0.0,0.0,0.0,gregory patr mcphee,
-ACCT,4150,1,Auditing,0.08,0.42,0.44,0.06,0.0,0.0,0.0,0.0,carl hollingsworth,
-ACCT,4150,2,Auditing,0.26,0.31,0.28,0.15,0.0,0.0,0.0,0.0,carl hollingsworth,
-ACCT,8520,1,Fin Acct Theory/Res,0.13,0.52,0.32,0.0,0.03,0.0,0.0,0.0,ralph edward welton,
-ACCT,8520,2,Fin Acct Theory/Res,0.28,0.59,0.14,0.0,0.0,0.0,0.0,0.0,ralph edward welton,
-ACCT,8540,1,Prof Responsibility,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,
-ACCT,8540,2,Prof Responsibility,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,robin radtke,
-ACCT,8540,3,Prof Responsibility,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,
-ACCT,8620,1,Financial Auditing,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,8620,2,Financial Auditing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,
-ACCT,8710,1,Corporate Taxation,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,2,Corporate Taxation,0.49,0.44,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8710,3,Corporate Taxation,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,derek dalton,
-ACCT,8730,1,Intl/Spec Tax Topic,0.48,0.39,0.13,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,
-ACCT,8740,1,Tax Aspects of Finan Planning,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,
-AGED,1000,1,Orientation & Field Experience,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,philip fravel,
-AGED,2030,1,Teaching Agriscience,0.38,0.54,0.0,0.0,0.0,0.0,0.0,0.08,catheri dibenedetto,
-AGED,8890,1,Intro to Res in Ed,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,
-AGM,2050,1,Prin of Fabrication,0.29,0.42,0.11,0.05,0.08,0.0,0.0,0.05,hunter massey,
-AGM,2060,1,Machinery Mgt,0.28,0.48,0.12,0.04,0.04,0.0,0.0,0.04,hunter massey,
-AGM,2200,1,Calc for Mechanized Agricult,0.37,0.34,0.21,0.05,0.0,0.0,0.0,0.03,aaron paul turner,
-AGM,2210,1,Land Measurements,0.6,0.26,0.13,0.01,0.0,0.0,0.0,0.0,robert gord hammond,
-AGM,2210,1,Land Measurements,0.6,0.26,0.13,0.01,0.0,0.0,0.0,0.0,charles privette,
-AGM,4020,1,Irrigation System Design,0.26,0.51,0.23,0.0,0.0,0.0,0.0,0.0,charles privette,
-AGM,4100,1,Precision Ag Tech,0.36,0.43,0.15,0.06,0.0,0.0,0.0,0.0,hunter massey,
-AGM,4520,1,Mobile Power,0.5,0.39,0.05,0.0,0.03,0.0,0.0,0.03,ali bulent koc,
-AGM,4720,1,Capstone,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,john chastain,
-AGRB,2020,1,Agricultural Economics,0.34,0.37,0.14,0.08,0.07,0.0,0.0,0.0,george apperson,
-AGRB,2050,1,Agriculture and Society,0.18,0.48,0.22,0.06,0.03,0.0,0.0,0.03,george apperson,
-AGRB,3080,1,Quant Agribusiness Analysis I,0.15,0.42,0.18,0.15,0.03,0.0,0.0,0.06,lisha zhang,
-AGRB,3190,1,Agribusiness Management,0.2,0.19,0.3,0.16,0.04,0.0,0.0,0.11,michael vassalos,
-AGRB,3510,1,Prin of Agricultural Sales Mgt,0.06,0.5,0.38,0.03,0.03,0.0,0.0,0.0,george apperson,
-AGRB,3570,1,Natural Resources Economics,0.21,0.23,0.36,0.17,0.0,0.0,0.0,0.02,david brian willis,
-AGRB,4020,1,Production Economics,0.23,0.38,0.0,0.31,0.0,0.0,0.0,0.08,michael vassalos,
-AGRB,4080,1,Quant Agribusiness Analysis II,0.42,0.33,0.21,0.02,0.02,0.0,0.0,0.0,lisha zhang,
-AGRB,4560,1,Prices,0.43,0.4,0.12,0.05,0.0,0.0,0.0,0.0,yuliya val bolotova,
-AL,3490,400,Principles of Coaching,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,401,Principles of Coaching,0.61,0.29,0.11,0.0,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,3490,402,Principles of Coaching,0.7,0.11,0.04,0.04,0.04,0.0,0.0,0.07,frank mezzanotte,
-AL,3490,403,Principles of Coaching,0.6,0.28,0.04,0.08,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,3490,404,Principles of Coaching,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,nicholas ph whitrow,
-AL,3490,406,Principles of Coaching,0.6,0.28,0.08,0.0,0.0,0.0,0.0,0.04,john plumblee,
-AL,3490,407,Principles of Coaching,0.72,0.12,0.16,0.0,0.0,0.0,0.0,0.0,john plumblee,
-AL,3490,408,Principles of Coaching,0.84,0.04,0.08,0.0,0.0,0.0,0.0,0.04,nicholas ph whitrow,
-AL,3490,409,Principles of Coaching,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,nicholas ph whitrow,
-AL,3490,410,Principles of Coaching,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,edmond fry,
-AL,3500,400,Sci Basis I/Ex Phy,0.2,0.24,0.28,0.2,0.04,0.0,0.0,0.04,michael godfrey,
-AL,3500,401,Sci Basis I/Ex Phy,0.19,0.26,0.33,0.15,0.04,0.0,0.0,0.04,michael godfrey,
-AL,3520,400,Kinesiology,0.27,0.13,0.0,0.2,0.2,0.0,0.0,0.2,isaac sean colbert,
-AL,3530,400,Athletic Injuries,0.12,0.32,0.48,0.04,0.04,0.0,0.0,0.0,isaac sean colbert,
-AL,3530,401,Athletic Injuries,0.16,0.32,0.4,0.08,0.04,0.0,0.0,0.0,isaac sean colbert,
-AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,clyde keith connor,
-AL,3610,400,Admin/Org of Athletic Programs,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,401,Admin/Org of Athletic Programs,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,
-AL,3610,402,Admin/Org of Athletic Programs,0.83,0.08,0.04,0.0,0.04,0.0,0.0,0.0,henry oates,
-AL,3620,400,Psychology of Coaching,0.24,0.36,0.32,0.0,0.04,0.0,0.0,0.04,natalie anne carter,
-AL,3620,401,Psychology of Coaching,0.36,0.36,0.2,0.04,0.0,0.0,0.0,0.04,natalie anne carter,
-AL,3620,402,Psychology of Coaching,0.38,0.25,0.29,0.0,0.04,0.0,0.0,0.04,natalie anne carter,
-AL,3710,400,Coaching Baseball,0.55,0.3,0.05,0.0,0.0,0.0,0.0,0.1,deborah cadorette,
-AL,3720,400,Coaching Basketball,0.72,0.12,0.08,0.04,0.04,0.0,0.0,0.0,edmond fry,
-AL,3740,400,Coaching Football,0.48,0.24,0.2,0.08,0.0,0.0,0.0,0.0,edmond fry,
-AL,3750,400,Coaching Soccer,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,deborah cadorette,
-AL,3760,400,Coaching Strength/Conditioning,0.56,0.19,0.19,0.04,0.0,0.0,0.0,0.04,edmond fry,
-AL,3760,401,Coaching Strength/Conditioning,0.58,0.21,0.08,0.0,0.08,0.0,0.0,0.04,edmond fry,
-AL,4380,401,Officiating in Athl Leadership,0.68,0.16,0.08,0.04,0.04,0.0,0.0,0.0,clyde keith connor,
-AL,4380,403,Social Issues,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,
-AL,4490,400,Athlete Beliefs,0.41,0.3,0.15,0.15,0.0,0.0,0.0,0.0,deborah cadorette,
-AL,4490,401,Athlete Beliefs,0.58,0.21,0.08,0.04,0.08,0.0,0.0,0.0,deborah cadorette,
-AL,8380,400,Intercoll Ath Personnel Mgm,0.85,0.07,0.04,0.0,0.04,0.0,0.0,0.0,kyle mclendon young,
-AL,8530,400,Legal Iss in Intercoll Athlet,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,
-AL,8630,400,Socio Dynam in Intercol Athlet,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,michael godfrey,
-AL,8630,401,Socio Dynam in Intercol Athlet,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,michael godfrey,
-AL,8640,400,Ethical Iss in Collegiate Athl,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,janna there magette,
-AL,8640,401,Ethical Iss in Collegiate Athl,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.04,janna there magette,
-AL,8700,400,Intercoll Athletics Finance,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,
-AL,8700,401,Intercoll Athletics Finance,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,misty soles,
-ANTH,2010,1,Introduction to Anthropology,0.36,0.56,0.07,0.0,0.0,0.0,0.0,0.01,david markus,
-ANTH,2010,2,Introduction to Anthropology,0.25,0.64,0.07,0.01,0.0,0.0,0.0,0.02,david markus,
-ANTH,2010,3,Introduction to Anthropology,0.46,0.32,0.05,0.04,0.04,0.0,0.0,0.11,lisa rapaport,
-ANTH,2010,4,Introduction to Anthropology,0.47,0.31,0.14,0.03,0.02,0.0,0.0,0.03,yi wu,
-ANTH,3010,1,Cultural Anthropology,0.07,0.32,0.43,0.14,0.0,0.0,0.04,0.0,john coggeshall,
-ANTH,3250,1,The Anthropology of Food,0.33,0.24,0.14,0.0,0.0,0.0,0.0,0.29,yi wu,
-ANTH,3310,1,Archaeology,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,david markus,
-ANTH,4040,1,Anthropological Theories,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,john coggeshall,
-ANTH,4800,1,Business Anthropology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,
-ARCH,1510,1,Arch Communication,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,sal hambright-belue,
-ARCH,1510,2,Arch Communication,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,
-ARCH,1510,2,Arch Communication,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,robert silance,
-ARCH,1510,3,Arch Communication,0.57,0.21,0.0,0.07,0.07,0.0,0.0,0.07,sal hambright-belue,
-ARCH,1510,3,Arch Communication,0.57,0.21,0.0,0.07,0.07,0.0,0.0,0.07,clarissa mendez,
-ARCH,1510,4,Arch Communication,0.2,0.6,0.13,0.07,0.0,0.0,0.0,0.0,george schafer,
-ARCH,1510,4,Arch Communication,0.2,0.6,0.13,0.07,0.0,0.0,0.0,0.0,sal hambright-belue,
-ARCH,1510,5,Arch Communication,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,sal hambright-belue,
-ARCH,1510,5,Arch Communication,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,berrin terim,
-ARCH,1510,6,Arch Communication,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,
-ARCH,2520,1,Arch Foundations II,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,2520,1,Arch Foundations II,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,brandon george pass,
-ARCH,2520,2,Arch Foundations II,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,clarissa mendez,
-ARCH,2520,2,Arch Foundations II,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,2520,3,Arch Foundations II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,
-ARCH,2520,3,Arch Foundations II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,2520,4,Arch Foundations II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,
-ARCH,2520,4,Arch Foundations II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,2520,5,Arch Foundations II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,
-ARCH,2520,5,Arch Foundations II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,2520,6,Arch Foundations II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,berrin terim,
-ARCH,2520,6,Arch Foundations II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,2700,1,Structures I,0.55,0.09,0.27,0.0,0.09,0.0,0.0,0.0,michael carl kleiss,
-ARCH,2710,1,Structures II,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,dustin gra albright,
-ARCH,3510,2,Studio Clemson,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,
-ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4050,1,American Arch Styles 1650-1950,0.63,0.25,0.06,0.0,0.06,0.0,0.0,0.0,robert bruhns,
-ARCH,4120,2,History Research,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,
-ARCH,4120,2,History Research,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4140,2,Design Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4140,2,Design Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,
-ARCH,4210,1,Arch Seminar,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,raymond thadde huff,
-ARCH,4290,1,Architectural Graphics,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,ashley jennings,
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,david lee,
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,timothy burl brown,
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,george schafer,
-ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0, franco santa cruz,
-ARCH,4710,1,Arch Hist of Place,0.08,0.75,0.17,0.0,0.0,0.0,0.0,0.0,jason matthew white,
-ARCH,8110,1,Visualization II,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,douglas hecker,
-ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,
-ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,timothy sutherland,
-ARCH,8520,7,Design Studio IV,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,
-ARCH,8610,1,History/Theory II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,
-ARCH,8620,2,History/Theory III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james thomas,
-ARCH,8650,1,Topics in Health Policy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anjali joseph,
-ARCH,8650,1,Topics in Health Policy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deborah mar wingler,
-ARCH,8710,1,Structures II,0.54,0.31,0.08,0.0,0.08,0.0,0.0,0.0,dustin gra albright,
-ARCH,8710,1,Structures II,0.54,0.31,0.08,0.0,0.08,0.0,0.0,0.0,timothy burl brown,
-ARCH,8730,2,Environmental Sys,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
-ART,1060,1,Foundation Drawing II,0.5,0.33,0.08,0.0,0.0,0.0,0.0,0.08,denise elizab ayers,
-ART,1510,1,Foundations Art I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,
-ART,1520,1,Foundations Art II,0.42,0.25,0.25,0.08,0.0,0.0,0.0,0.0,daniel bare,
-ART,2050,1,Beginning Life Drawing,0.53,0.29,0.0,0.06,0.06,0.0,0.0,0.06,annamarie williams,
-ART,2070,1,Beginning Painting,0.38,0.54,0.0,0.0,0.08,0.0,0.0,0.0,serra raven shuford,
-ART,2090,1,Beginning Sculpture,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
-ART,2100,6,Art Appreciation,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,angel roch estrella,
-ART,2100,7,Art Appreciation,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
-ART,2100,10,Art Appreciation,0.84,0.12,0.0,0.0,0.04,0.0,0.0,0.0,deighton tay abrams,
-ART,2100,11,Art Appreciation,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,
-ART,2110,1,Begin Printmaking,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,allison rae johnson,
-ART,2130,1,Begin Photography,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,
-ART,2170,1,Beginning Ceramics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,sara mays,
-ART,3130,1,Photography,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,
-ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,
-ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,
-ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,david detrich,
-ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,
-ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,
-ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,valerie zimany,
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
-AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
-AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
-AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
-AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
-AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
-AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,
-AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,
-AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,
-AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,
-ASL,1010,1,Am Sign Lang I,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,william ry clements,
-ASL,1010,2,Am Sign Lang I,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,william ry clements,
-ASL,1010,3,Am Sign Lang I,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,william ry clements,
-ASL,1020,1,Am Sign Lang I,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,1020,2,Am Sign Lang I,0.5,0.38,0.04,0.04,0.04,0.0,0.0,0.0,jason hurdich,
-ASL,1020,3,Am Sign Lang I,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,william ry clements,
-ASL,1020,4,Am Sign Lang I,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,jody herbert cripps,
-ASL,2010,1,Am Sign Lang II,0.31,0.23,0.46,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2010,2,Am Sign Lang II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2020,1,Am Sign Lang II,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,2020,2,Am Sign Lang II,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,jason hurdich,
-ASL,2020,3,Am Sign Lang II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,
-ASL,3020,1,Advanced Asl II,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,william ry clements,
-ASL,3050,1,Deaf Studies,0.76,0.12,0.08,0.0,0.04,0.0,0.0,0.0,jason hurdich,
-ASTR,1010,1,Solar System Astronomy,0.41,0.3,0.16,0.06,0.03,0.0,0.0,0.04,david edwar connick,
-ASTR,1020,2,Stellar Astronomy,0.16,0.23,0.28,0.15,0.0,0.0,0.16,0.03,mate adamkovics,
-ASTR,1030,1,Solar Systm Astr Lab,0.39,0.39,0.09,0.04,0.0,0.0,0.0,0.09,mark leising,
-ASTR,1030,2,Solar Systm Astr Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.04,0.0,mark leising,
-ASTR,1030,3,Solar Systm Astr Lab,0.32,0.48,0.12,0.08,0.0,0.0,0.0,0.0,mark leising,
-ASTR,1040,1,Stellar Astr Lab,0.3,0.2,0.3,0.0,0.0,0.0,0.1,0.1,mark leising,
-ASTR,1040,2,Stellar Astr Lab,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,mark leising,
-ASTR,1040,4,Stellar Astr Lab,0.3,0.55,0.05,0.0,0.05,0.0,0.0,0.05,mark leising,
-ASTR,3030,1,Galactic Astrophys,0.42,0.33,0.25,0.0,0.0,0.0,0.0,0.0,marco ajello,
-ASTR,8400,1,Astroph: Cosmology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,
-ASTR,8750,1,Astronomy Seminar,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,marco ajello,
-AUD,2850,1,Acoustics of Music,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,
-AUE,4020,699,Adv & Electrified Powertrains,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,zoran filipi,
-AUE,4020,699,Adv & Electrified Powertrains,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,qilun zhu,
-AUE,8160,3,Eng Combustion Emiss,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,robert prucka,
-AUE,8170,410,Alt Energy Sources,0.38,0.44,0.06,0.0,0.13,0.0,0.0,0.0,pierluigi pisu,
-AUE,8500,6,Stability/Safety Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,
-AUE,8550,16,Struct/Thermal Analysis Mthds,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,
-AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett,
-AUE,8770,405,Light-Weight Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,
-AUE,8860,1,Noise Vibration,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blan poland,
-AUE,8930,401,Autonomous Driving Techn,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,
-AUE,8930,405,Perception and Intelligence,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bing li,
-AVS,2000,1,Beef Cattle Tech,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,nathan long,
-AVS,2030,1,Dairy Sci Techniques,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,2090,1,Livestock Exhibition Technique,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,richelle lor miller,
-AVS,3010,1,Anat & Phys Dom Ani,0.71,0.2,0.08,0.0,0.0,0.0,0.0,0.01,tiffany wilmoth,
-AVS,3090,1,Equine Evaluation,0.71,0.12,0.06,0.06,0.06,0.0,0.0,0.0,chelsea dr sinclair,
-AVS,3100,1,Animal Health,0.59,0.25,0.13,0.03,0.0,0.0,0.0,0.0,celina marc checura,
-AVS,3150,1,Animal Welfare,0.47,0.32,0.13,0.09,0.0,0.0,0.0,0.0,heather walker dunn,
-AVS,3700,1,Principles of Animal Nutrition,0.34,0.36,0.17,0.09,0.02,0.0,0.0,0.02,james ro strickland,
-AVS,3750,1,Applied Animal Nutrition,0.35,0.35,0.2,0.1,0.0,0.0,0.0,0.0,mir arguelles-ramos,
-AVS,4100,1,Domestic Ani Behav,0.69,0.21,0.09,0.0,0.0,0.0,0.0,0.01,james ro strickland,
-AVS,4120,1,Advanced Equine Management,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,
-AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,glenn birrenkott,
-AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,richelle lor miller,
-AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,annel greene,
-AVS,4140,1,Basic Immunology,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,farzana ferdous,True
-AVS,4220,6,Advanced Fetal Fescue Research,0.85,0.0,0.15,0.0,0.0,0.0,0.0,0.0,susan kay duckett,
-AVS,4530,1,Animal Reproduction,0.22,0.29,0.31,0.13,0.04,0.0,0.0,0.0,celina marc checura,
-AVS,4550,2,Animal Repro Mgt-Equine,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,chelsea dr sinclair,
-AVS,4700,1,Animal Genetics,0.24,0.33,0.21,0.06,0.06,0.0,0.0,0.09,joseph kei bertrand,
-BCHM,3010,1,Molecular Biochemistry,0.17,0.46,0.25,0.03,0.0,0.0,0.0,0.1,meredith tei morris,
-BCHM,3010,2,Molecular Biochem(HON),0.4,0.29,0.24,0.02,0.02,0.0,0.0,0.02,cheryl ingram-smith,True
-BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
-BCHM,3040,4,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,3040,4,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
-BCHM,3050,1,Essen Elements Bioch,0.47,0.38,0.11,0.01,0.01,0.0,0.0,0.02,debra ragland,
-BCHM,3050,2,Essen Elements Bioch,0.53,0.33,0.08,0.03,0.01,0.0,0.0,0.02,debra ragland,
-BCHM,4320,1,Bioch of Metabolism,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,kimberly paul,
-BCHM,4340,3,Biochemistry of Metabolism Lab,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,4340,4,Biochemistry of Metabolism Lab,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-BCHM,4360,1,Genes to Proteins,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
-BCHM,4360,2,Mol Bio Genes to Proteins(HON),0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True
-BCHM,4400,1,Bioinformatics,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,liangjiang wang,
-BCHM,4910,35,CI:DNA Repair,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,
-BCHM,4930,1,Senior Seminar,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,
-BCHM,8050,1,Issues in Research,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william marcotte,
-BE,2100,1,Intro to Biosystems Engr,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,jazmine octa taylor,
-BE,3220,1,Sm Wtrshd Hyd & Sed,0.31,0.54,0.12,0.04,0.0,0.0,0.0,0.0,tom owino,
-BE,4120,1,Be Heat Mass Trans,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,
-BE,4150,1,Instr & Control for Biosys Eng,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,rui xiao,
-BE,4240,1,Ecological Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,
-BE,4380,1,Bioprocess Engineering Design,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,terry walker,
-BE,4400,1,Sustainable Energy Engineering,0.36,0.21,0.29,0.14,0.0,0.0,0.0,0.0,jazmine octa taylor,
-BIOE,1010,1,Biol for Bioengr,0.6,0.35,0.02,0.0,0.02,0.0,0.0,0.02,vladimir vla reukov,
-BIOE,1010,1,Biol for Bioengr,0.6,0.35,0.02,0.0,0.02,0.0,0.0,0.02,tyler george harvey,
-BIOE,2010,1,Intro Biomed Engr,0.44,0.31,0.13,0.13,0.0,0.0,0.0,0.0,vladimir vla reukov,
-BIOE,3020,1,Biomaterials,0.61,0.29,0.06,0.01,0.0,0.0,0.0,0.03,alexey ale vertegel,
-BIOE,3100,1,Engr Analysis of Physiol Proc,0.54,0.36,0.07,0.04,0.0,0.0,0.0,0.0,brian william booth,
-BIOE,3200,1,Biomechanics,0.79,0.18,0.0,0.03,0.0,0.0,0.0,0.0,william richardson,
-BIOE,3210,1,Biofluid Mechanics,0.25,0.53,0.12,0.07,0.03,0.0,0.0,0.0,sarah harcum,
-BIOE,3470,1,Transport Processes in Bioengr,0.39,0.36,0.18,0.0,0.0,0.0,0.0,0.07,robert latour,
-BIOE,3700,1,Bioinst & Imaging,0.37,0.45,0.13,0.03,0.0,0.0,0.0,0.01,jordon anth gilmore,
-BIOE,4200,1,Sports Engineering,0.65,0.25,0.06,0.02,0.02,0.0,0.0,0.0,cynthia mille smith,
-BIOE,4490,1,Drug Delivery,0.55,0.35,0.06,0.0,0.03,0.0,0.0,0.0,jeoungsoo lee,
-BIOE,4510,21,CI - Hands On Tissue Engr,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
-BIOE,4510,37,CI-Innov in Bioinstrumentation,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,delphine dean,
-BIOE,6200,1,Sports Engineering,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,
-BIOE,6230,1,Cardiovascular Engr and Path,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,martine laberge,
-BIOE,6230,1,Cardiovascular Engr and Path,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,dan simionescu,
-BIOE,8130,1,Industrial Bioengineering,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michael taylor,
-BIOE,8200,1,Structl Biomechanics,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,hai yao,
-BIOE,8500,2,Mechanobiology,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,
-BIOL,1040,1,General Biology II,0.32,0.3,0.2,0.09,0.02,0.0,0.0,0.06,nora espinoza,
-BIOL,1040,2,General Biology II,0.28,0.21,0.29,0.09,0.07,0.0,0.0,0.07,dylan dittrich-reed,
-BIOL,1040,3,General Biology II,0.14,0.28,0.29,0.12,0.1,0.0,0.0,0.08,salvatore sparace,
-BIOL,1040,4,General Biology II (HON),0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True
-BIOL,1060,1,Gen Biology Lab II,0.04,0.29,0.17,0.25,0.17,0.0,0.0,0.08,tafadzwa kaisa,
-BIOL,1060,2,Gen Biology Lab II,0.1,0.19,0.38,0.33,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,3,Gen Biology Lab II,0.16,0.21,0.21,0.16,0.26,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,4,Gen Biology Lab II,0.04,0.17,0.25,0.33,0.08,0.0,0.0,0.13,tafadzwa kaisa,
-BIOL,1060,5,Gen Biology Lab II,0.13,0.0,0.25,0.06,0.25,0.0,0.0,0.31,tafadzwa kaisa,
-BIOL,1060,7,Gen Biology Lab II,0.3,0.1,0.3,0.0,0.3,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,8,Gen Biology Lab II,0.04,0.33,0.42,0.13,0.08,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,9,Gen Biology Lab II,0.06,0.06,0.56,0.31,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,10,Gen Biology Lab II,0.06,0.18,0.29,0.0,0.41,0.0,0.0,0.06,tafadzwa kaisa,
-BIOL,1060,11,Gen Biology Lab II,0.09,0.22,0.43,0.17,0.04,0.0,0.0,0.04,tafadzwa kaisa,
-BIOL,1060,12,Gen Biology Lab II,0.13,0.19,0.5,0.13,0.06,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,13,Gen Biology Lab II,0.08,0.15,0.54,0.08,0.0,0.0,0.0,0.15,tafadzwa kaisa,
-BIOL,1060,14,Gen Biology Lab II,0.05,0.45,0.2,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,15,Gen Biology Lab II,0.06,0.22,0.33,0.17,0.22,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,16,Gen Biology Lab II,0.08,0.33,0.33,0.25,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,18,Gen Biology Lab II,0.05,0.18,0.32,0.32,0.14,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,19,Gen Biology Lab II,0.0,0.27,0.33,0.2,0.2,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,20,Gen Biology Lab II,0.07,0.2,0.2,0.13,0.2,0.0,0.0,0.2,tafadzwa kaisa,
-BIOL,1060,21,Gen Biology Lab II,0.14,0.23,0.32,0.14,0.09,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,22,Gen Biology Lab II,0.0,0.18,0.36,0.45,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,24,Gen Biology Lab II,0.04,0.22,0.35,0.26,0.04,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,25,Gen Biology Lab II,0.25,0.25,0.33,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,26,Gen Biology Lab II,0.17,0.43,0.26,0.04,0.09,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,27,Gen Biology Lab II,0.25,0.4,0.15,0.2,0.0,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1060,28,Gen Biology Lab II,0.21,0.21,0.32,0.21,0.0,0.0,0.0,0.05,tafadzwa kaisa,
-BIOL,1060,30,Gen Biology Lab II,0.17,0.35,0.35,0.04,0.0,0.0,0.0,0.09,tafadzwa kaisa,
-BIOL,1060,32,Gen Biology Lab II,0.07,0.47,0.27,0.07,0.13,0.0,0.0,0.0,tafadzwa kaisa,
-BIOL,1110,1,Principles of Biology II,0.52,0.33,0.12,0.03,0.0,0.0,0.01,0.0,renea chri hardwick,
-BIOL,1110,2,Principles of Biology II (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,True
-BIOL,1110,3,Principles of Biology II,0.34,0.43,0.14,0.04,0.05,0.0,0.0,0.02, christine minor,
-BIOL,1110,4,Prin of Biol II  (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,True
-BIOL,2000,1,Biology in the News,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,tamara mcnutt-scott,
-BIOL,2040,1,"Environ, Energy and Society",0.6,0.33,0.04,0.02,0.0,0.0,0.0,0.0,john jenkins hains,
-BIOL,2040,2,"Environ, Energy and Society",0.33,0.41,0.17,0.07,0.0,0.0,0.0,0.01,john jenkins hains,
-BIOL,2230,1,Human Anat and Physiology II,0.39,0.37,0.16,0.04,0.02,0.0,0.0,0.01,john cummings,
-BIOL,2230,2,Human Anat and Physiology II,0.41,0.35,0.16,0.04,0.03,0.0,0.0,0.01,john cummings,
-BIOL,3020,1,Invertebrate Biology,0.32,0.34,0.2,0.07,0.02,0.0,0.0,0.05,juan baeza migueles,
-BIOL,3040,1,Biology of Plants,0.31,0.24,0.1,0.29,0.07,0.0,0.0,0.0,nathan redding,
-BIOL,3060,1,Invertebrate Biology Lab,0.33,0.25,0.29,0.08,0.0,0.0,0.0,0.04,juan baeza migueles,
-BIOL,3060,2,Invertebrate Biology Lab,0.53,0.32,0.05,0.05,0.0,0.0,0.0,0.05,juan baeza migueles,
-BIOL,3080,1,Biology of Plants Practicum,0.45,0.25,0.1,0.15,0.05,0.0,0.0,0.0,nathan redding,
-BIOL,3080,2,Biology of Plants Practicum,0.5,0.2,0.2,0.0,0.1,0.0,0.0,0.0,nathan redding,
-BIOL,3160,1,Human Physiology,0.33,0.43,0.19,0.03,0.01,0.0,0.0,0.01,tamara mcnutt-scott,
-BIOL,3350,1,Evolutionary Biology,0.43,0.38,0.15,0.02,0.01,0.0,0.0,0.01,margaret ptacek,
-BIOL,3350,2,Evolutionary Biology (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,margaret ptacek,True
-BIOL,3940,3,CI: What is in our Waters?,0.8,0.0,0.0,0.2,0.0,0.0,0.0,0.0,peter van den hurk,
-BIOL,4010,1,Plant Physiology,0.17,0.2,0.28,0.21,0.0,0.0,0.08,0.07,douglas bielenberg,
-BIOL,4020,1,Plant Physiology Lab,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4020,2,Plant Physiology Lab,0.65,0.1,0.2,0.0,0.05,0.0,0.0,0.0,douglas bielenberg,
-BIOL,4030,1,Intro to Applied Genomics,0.0,0.07,0.36,0.07,0.07,0.0,0.0,0.43,vincent pa richards,
-BIOL,4140,1,Basic Immunology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,
-BIOL,4340,1,Biological Chem Lab Techniques,0.14,0.36,0.36,0.07,0.0,0.0,0.0,0.07,salvatore sparace,
-BIOL,4340,2,Biological Chem Lab Techniques,0.0,0.38,0.38,0.08,0.0,0.0,0.0,0.15,salvatore sparace,
-BIOL,4610,1,Cell Biology,0.36,0.36,0.15,0.07,0.03,0.0,0.0,0.03,lesly temesvari,
-BIOL,4610,2,Cell Biology (HON),0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True
-BIOL,4620,1,Cell Biology Lab (Lec),0.69,0.23,0.04,0.0,0.04,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,2,Cell Biology Lab (Lec),0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,4,Cell Biology Lab (Lec),0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,
-BIOL,4620,5,Cell Biology Lab (Lec),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,6,Cell Biology Lab (Lec),0.65,0.27,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4620,7,Cell Biology Lab (Lec),0.6,0.28,0.12,0.0,0.0,0.0,0.0,0.0,xianzhong yu,
-BIOL,4670,1,Principles of Hematology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,
-BIOL,4700,1,Behavioral Ecology,0.44,0.38,0.14,0.03,0.01,0.0,0.0,0.0,michael childress,
-BIOL,4710,1,Behavioral Ecology Lab (Lec),0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,michael childress,
-BIOL,4710,2,Behavioral Ecology Lab (Lec),0.69,0.13,0.06,0.13,0.0,0.0,0.0,0.0,michael childress,
-BIOL,4710,3,Behavioral Ecology Lab (Lec),0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,michael childress,
-BIOL,4710,4,Behavioral Ecology Lab (Lec),0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,michael childress,
-BIOL,4780,1,Exercise Physiology,0.79,0.17,0.0,0.0,0.02,0.0,0.0,0.02,john cummings,
-BIOL,4800,1,Vertebrate Endocrinology,0.26,0.4,0.21,0.07,0.0,0.0,0.02,0.02,william baldwin,
-BIOL,4830,1,Stem Cell Biology,0.61,0.32,0.05,0.0,0.0,0.0,0.0,0.02,vincent gallicchio,
-BIOL,4930,2,Sr Sem: Immuno & Immunotherapy,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,yanzhang wei,
-BIOL,4930,3,Sr Sem: Nervous Systems,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,
-BIOL,4930,6,Sr Sem: Biol Behind Our Food,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,peter van den hurk,
-BIOL,4930,7,Sr Sem: Genomics,0.75,0.19,0.0,0.0,0.0,0.0,0.06,0.0,kara elizabe powder,
-BIOL,4930,8,Sen Sem: Evolutionary Medicine,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,samantha ann price,
-BIOL,4940,2,CI: Popular Science Journalism,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,steven katz,
-BIOL,4940,2,CI: Popular Science Journalism,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,
-BIOL,4940,9,CI: Marine Conservation & Gen,0.88,0.0,0.0,0.0,0.13,0.0,0.0,0.0,juan baeza migueles,
-BIOL,6030,1,Intro to Applied Genomics,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,vincent pa richards,
-BIOL,8430,1,Underst Genetics & Evol Biol,0.63,0.31,0.01,0.0,0.03,0.0,0.0,0.03,margaret ptacek,
-BIOL,8430,1,Underst Genetics & Evol Biol,0.63,0.31,0.01,0.0,0.03,0.0,0.0,0.03,renea chri hardwick,
-BIOL,8450,1,Understanding Animal Biology,0.85,0.1,0.0,0.0,0.02,0.0,0.0,0.03,amy lauren anderson,
-BIOL,8450,1,Understanding Animal Biology,0.85,0.1,0.0,0.0,0.02,0.0,0.0,0.03,matthew turnbull,
-BIOL,8470,1,Understanding Microbiology,0.72,0.23,0.04,0.0,0.01,0.0,0.0,0.0,harry kurtz,
-BIOL,8480,1,Understanding Scientific Rsrch,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert edwa ballard,
-BMOL,4250,1,Biomolecular Engineering,0.15,0.39,0.31,0.09,0.04,0.0,0.0,0.02,mark alan blenner,
-BMOL,4290,1,Bioprocess Engineering,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,marc rus birtwistle,
-BMOL,6250,1,Biomolecular Eng,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,mark alan blenner,
-BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,sandy edge,
-BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,sandy edge,
-BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,edward bar de iulio,
-BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,sandy edge,
-BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,william ern tumblin,
-BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,donna mccubbin,
-BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,donna mccubbin,
-BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,edward bar de iulio,
-BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,sandy edge,
-BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,william ern tumblin,
-BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,sandy edge,
-BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
-BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,
-BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,
-BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
-BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,sandy edge,
-BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,edward bar de iulio,
-BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,william ern tumblin,
-BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,sandy edge,
-BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,edward bar de iulio,
-BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,sandy edge,
-BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,william ern tumblin,
-BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,edward bar de iulio,
-BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,william ern tumblin,
-BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,donna mccubbin,
-BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,sandy edge,
-BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,donna mccubbin,
-BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,william ern tumblin,
-BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,sandy edge,
-BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,edward bar de iulio,
-BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,
-BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,donna mccubbin,
-BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,william ern tumblin,
-BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,sandy edge,
-BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,donna mccubbin,
-BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,sandy edge,
-BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,william ern tumblin,
-BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,edward bar de iulio,
-CE,2010,1,Statics,0.3,0.33,0.12,0.06,0.03,0.0,0.0,0.15,melissa sternhagen,
-CE,2010,2,Statics,0.31,0.42,0.25,0.0,0.02,0.0,0.0,0.0,md nasimu chowdhury,
-CE,2010,3,Statics,0.17,0.25,0.23,0.17,0.02,0.0,0.0,0.17,melissa sternhagen,
-CE,2010,4,Statics,0.16,0.42,0.33,0.02,0.0,0.0,0.0,0.07,md nasimu chowdhury,
-CE,2010,5,Statics,0.5,0.16,0.2,0.02,0.11,0.0,0.0,0.0,michael wall stoner,
-CE,2010,6,Statics,0.58,0.3,0.1,0.0,0.03,0.0,0.0,0.0,lancelot paul reres,
-CE,2010,7,Statics (HON),0.18,0.55,0.18,0.0,0.0,0.0,0.0,0.09,melissa sternhagen,True
-CE,2060,1,Structural Mechanics,0.51,0.29,0.16,0.02,0.02,0.0,0.0,0.0,thomas edfo cousins,
-CE,2060,2,Structural Mechanics,0.19,0.33,0.43,0.02,0.02,0.0,0.0,0.02,melissa sternhagen,
-CE,2080,1,Dynamics,0.17,0.42,0.32,0.0,0.03,0.0,0.0,0.06,md nasimu chowdhury,
-CE,2080,2,Dynamics,0.12,0.35,0.4,0.05,0.0,0.0,0.0,0.09,md nasimu chowdhury,
-CE,2550,1,Geomatics,0.29,0.27,0.32,0.05,0.0,0.0,0.0,0.07,wayne sarasua,
-CE,3010,1,Structural Analysis,0.4,0.3,0.26,0.05,0.0,0.0,0.0,0.0,stephen csernak,
-CE,3110,1,Transportation Engr,0.68,0.24,0.05,0.01,0.0,0.0,0.0,0.01,pamela murray-tuite,
-CE,3210,1,Geotechnical Engineering,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,wenxin liu,
-CE,3210,2,Geotechnical Engineering,0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,wenxin liu,
-CE,3310,1,Constr Engr & Mgmnt,0.87,0.11,0.0,0.02,0.0,0.0,0.0,0.0,steve richa sanders,
-CE,3410,1,Intro to Fluid Mech,0.32,0.46,0.15,0.03,0.0,0.0,0.0,0.03,nigel gregory kaye,
-CE,3420,1,Hydraulics & Hydro,0.62,0.35,0.03,0.0,0.0,0.0,0.0,0.0,ashok mishra,
-CE,3420,2,Hydraulics & Hydro,0.28,0.47,0.19,0.03,0.03,0.0,0.0,0.0,abdul khan,
-CE,3510,1,Civil Engineering Materials,0.43,0.52,0.05,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
-CE,3520,1,Econ Eval of Proj,0.49,0.37,0.09,0.01,0.01,0.0,0.0,0.03, kent nilsson,
-CE,3530,1,Professional Seminar,0.96,0.01,0.03,0.01,0.0,0.0,0.0,0.0,ronald andrus,
-CE,4020,1,Reinfor Con Design,0.42,0.31,0.22,0.0,0.04,0.0,0.0,0.0,laura mae redmond,
-CE,4070,1,Wood Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,
-CE,4080,1,Struct Loads & Sys,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,brandon ross,
-CE,4110,1,Roadway Geo Design,0.52,0.37,0.07,0.04,0.0,0.0,0.0,0.0,jennifer ogle,
-CE,4120,1,Urban Transport Plan,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,sakib khan,
-CE,4210,1,Geotechnical Design,0.29,0.46,0.23,0.0,0.0,0.0,0.0,0.03,nadara ravichandran,
-CE,4340,1,Const Est Proj Cont,0.35,0.51,0.13,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,4370,1,Sustainable Energy Proj Design,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
-CE,4590,1,Capstone Design Proj,0.6,0.28,0.1,0.01,0.0,0.0,0.0,0.0,stephen csernak,
-CE,4910,1,Corrosion and Oxidation,0.0,0.4,0.0,0.0,0.0,0.0,0.0,0.6,ami esmaeilpoursaee,
-CE,4910,2,Des Thinkg for Sustain Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,
-CE,4910,3,Intro to Enviro Fluid Mech,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,nigel gregory kaye,
-CE,4990,2,Cr Inq in Civil Engineering,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,weichiang pang,
-CE,4990,61,Cr Inq in Civil Engineering,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ogle,
-CE,4990,201,Special Project - Springer I,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,wayne sarasua,
-CE,6340,1,Const Est Proj Cont,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,
-CE,6370,1,Sustainable Energy Proj Design,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,
-CE,8030,1,Adv Steel Design,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mohannad naser,
-CE,8270,1,Spec Cements & Concr,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,
-CE,8450,500,Data Mining for Sys Analytics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paris stringfellow,
-CE,8470,500,Optimization Support Models,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
-CE,8530,1,Apps in Traffic En,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,
-CES,1900,101,CI-LEAD Forward I,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-CES,2900,101,CI - LEAD Forward II,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-CES,3900,101,CI-LEAD Forward III,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,
-CH,1010,1,General Chemistry,0.16,0.32,0.21,0.08,0.1,0.0,0.0,0.12,princess mycia cox,
-CH,1010,2,General Chemistry,0.23,0.33,0.32,0.04,0.04,0.0,0.0,0.03,jacob schroeder,
-CH,1010,3,General Chemistry,0.11,0.4,0.25,0.1,0.06,0.0,0.0,0.08,jacob schroeder,
-CH,1010,4,General Chemistry,0.08,0.22,0.39,0.1,0.13,0.0,0.0,0.1,steven pellizzeri,
-CH,1010,400,General Chemistry,0.28,0.16,0.15,0.22,0.08,0.0,0.0,0.11,stephe schvaneveldt,
-CH,1020,1,General Chemistry,0.24,0.31,0.26,0.06,0.04,0.0,0.0,0.09,steven pellizzeri,
-CH,1020,2,General Chemistry,0.27,0.29,0.25,0.09,0.03,0.0,0.0,0.05,william mcwhorter,
-CH,1020,3,General Chemistry,0.27,0.36,0.31,0.04,0.01,0.0,0.0,0.02,dennis taylor,
-CH,1020,4,General Chemistry,0.3,0.38,0.2,0.05,0.01,0.0,0.0,0.06,dennis taylor,
-CH,1020,5,General Chemistry,0.17,0.47,0.25,0.05,0.0,0.0,0.02,0.03,william mcwhorter,
-CH,1020,6,General Chemistry,0.1,0.36,0.34,0.09,0.02,0.0,0.0,0.08,olt geiculescu,
-CH,1020,7,General Chemistry,0.1,0.39,0.34,0.06,0.01,0.0,0.0,0.1,william mcwhorter,
-CH,1020,8,General Chemistry,0.29,0.43,0.21,0.03,0.0,0.0,0.0,0.03,thomas hickman,
-CH,1020,9,General Chemistry,0.22,0.45,0.23,0.05,0.0,0.0,0.0,0.05,princess mycia cox,
-CH,1020,10,General Chemistry,0.34,0.37,0.23,0.02,0.02,0.0,0.0,0.02,thomas hickman,
-CH,1020,11,General Chemistry,0.32,0.33,0.23,0.04,0.02,0.0,0.0,0.05,elliot ennis,
-CH,1020,50,General Chemistry,0.65,0.27,0.04,0.0,0.02,0.0,0.0,0.02,stephe schvaneveldt,
-CH,1020,51,General Chemistry (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True
-CH,1020,52,General Chemistry (HON),0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True
-CH,1050,1,Chemistry in Context I,0.34,0.39,0.23,0.0,0.02,0.0,0.0,0.02,olt geiculescu,
-CH,1050,2,Chemistry in Context I,0.56,0.25,0.13,0.03,0.0,0.0,0.0,0.03,olt geiculescu,
-CH,1060,1,Chemistry in Context II,0.15,0.5,0.15,0.08,0.08,0.0,0.0,0.04,elliot ennis,
-CH,1520,1,Chemistry Communication,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,richard marcus,
-CH,2010,1,Survey of Organic Chemistry,0.43,0.15,0.23,0.06,0.07,0.0,0.0,0.06,tania issa houjeiry,
-CH,2050,1,Intro Inorg Chem,0.55,0.32,0.11,0.0,0.0,0.0,0.0,0.03,william pennington,
-CH,2230,1,Organic Chemistry,0.14,0.21,0.31,0.18,0.14,0.0,0.0,0.01,thomas hickman,
-CH,2230,2,Organic Chemistry,0.13,0.26,0.27,0.23,0.11,0.0,0.0,0.01,elliot ennis,
-CH,2230,3,Organic Chemistry,0.18,0.33,0.22,0.13,0.12,0.0,0.0,0.03,laura lanni,
-CH,2240,1,Organic Chemistry,0.53,0.25,0.14,0.04,0.02,0.0,0.0,0.03,tania issa houjeiry,
-CH,2240,2,Organic Chemistry,0.38,0.33,0.15,0.07,0.03,0.0,0.0,0.04,laura lanni,
-CH,2240,3,Organic Chemistry,0.34,0.19,0.32,0.07,0.07,0.0,0.0,0.01,laura lanni,
-CH,2240,4,Organic Chemistry,0.59,0.13,0.19,0.02,0.03,0.0,0.0,0.04,rhett smith,
-CH,2240,5,Organic Chemistry,0.55,0.25,0.11,0.07,0.0,0.0,0.0,0.02,rhett smith,
-CH,2280,17,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelso plampin,
-CH,2280,26,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,
-CH,3320,1,Physical Chemistry,0.21,0.37,0.32,0.05,0.0,0.0,0.0,0.05,steven stuart,
-CH,3320,3,Physical Chemistry,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,jason mcneill,
-CH,3320,5,Physical Chemistry,0.64,0.14,0.11,0.04,0.07,0.0,0.0,0.0,leah bec casabianca,
-CH,3400,2,Physical Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3400,3,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3400,4,Physical Chem Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,
-CH,3600,1,Chemical Biology,0.48,0.31,0.14,0.0,0.0,0.0,0.0,0.07,modi wetzler,
-CH,4110,1,Instrumental Analy,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,jeffrey natha anker,
-CH,4120,2,Instr Analysis Lab,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,george chumanov,
-CH,4130,1,Chemistry of Aqueous Systems,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,cindy lee,
-CH,4500,1,Chemistry Capstone,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,
-CH,4990,6,Cr Inq in Chemistry IV 1218,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,dev priya arya,
-CH,6140,1,Bioanalytical Chem,0.09,0.82,0.09,0.0,0.0,0.0,0.0,0.0,carlos garcia perez,
-CH,8130,1,Electrochem Sci,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,stephen creager,
-CH,8510,1,Grad Student Seminar,0.83,0.14,0.0,0.0,0.0,0.0,0.0,0.03,joseph stu thrasher,
-CH,8510,2,Grad Student Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,
-CHE,1300,1,Intro to Chemical Engineering,0.25,0.21,0.21,0.08,0.06,0.0,0.0,0.19,christopher norfolk,
-CHE,1300,2,Intro to Chemical Engineering,0.24,0.2,0.22,0.1,0.08,0.0,0.0,0.18,christopher norfolk,
-CHE,2200,1,Ch E Thermo I,0.13,0.39,0.25,0.13,0.08,0.0,0.0,0.03,jessica mari larsen,
-CHE,2300,1,Fluids/Heat Transfer,0.19,0.18,0.35,0.15,0.11,0.0,0.0,0.01,eric mikel davis,
-CHE,3070,1,Unit Ops Lab I,0.28,0.63,0.07,0.02,0.0,0.0,0.0,0.0,christopher norfolk,
-CHE,3190,1,Engr Materials,0.12,0.33,0.35,0.12,0.03,0.0,0.0,0.05,amod ogale,
-CHE,3190,1,Engr Materials,0.12,0.33,0.35,0.12,0.03,0.0,0.0,0.05,christopher norfolk,
-CHE,3530,1,Proc Dyn & Control,0.24,0.46,0.26,0.02,0.0,0.0,0.0,0.01,mark roberts,
-CHE,3990,13,CI- ARTIFICIAL CHROMOSOMES,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,marc rus birtwistle,
-CHE,4330,1,Process Design II,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,david bruce,
-CHE,8140,1,Numerical Methods,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,joseph scott,
-CHE,8450,5,Statistical Mechanics,0.63,0.13,0.25,0.0,0.0,0.0,0.0,0.0,sapna sarupria,
-CHIN,1010,1,Elementary Chinese,0.61,0.11,0.06,0.0,0.06,0.0,0.0,0.17,yanming an,
-CHIN,1020,1,Elementary Chinese,0.3,0.3,0.4,0.0,0.0,0.0,0.0,0.0,ling rao,
-CHIN,3120,1,Philosophy in Ancient China,0.33,0.46,0.08,0.0,0.0,0.0,0.0,0.13,yanming an,
-COM,1500,1,Intro to Human Communication,0.74,0.25,0.01,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,
-COM,1500,2,Intro to Human Communication,0.71,0.25,0.01,0.0,0.03,0.0,0.0,0.0,daniel lelan fecher,
-COM,1500,3,Intro to Human Communication,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,
-COM,1500,4,Intro to Human Communication,0.7,0.26,0.02,0.01,0.01,0.0,0.0,0.01,marianne her glaser,
-COM,1500,5,Intro to Human Communication,0.75,0.17,0.03,0.01,0.02,0.0,0.0,0.01,marianne her glaser,
-COM,1500,6,Intro to Human Communication,0.62,0.29,0.06,0.0,0.0,0.0,0.0,0.03,vanessa anne condon,
-COM,2010,1,Intr to Comm Studies,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2010,2,Intr to Comm Studies,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,caitlin baker,
-COM,2020,1,Communication Theory,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,
-COM,2040,1,Critical-Cultural Comm Theory,0.47,0.26,0.21,0.05,0.0,0.0,0.0,0.0,james nicho gilmore,
-COM,2100,1,Quant Comm Research Methods,0.44,0.37,0.11,0.07,0.0,0.0,0.0,0.0,joseph mazer,
-COM,2120,1,Crit-Cultural Rsrch Methods,0.74,0.22,0.0,0.04,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,1,Public Speaking,0.71,0.14,0.05,0.0,0.0,0.0,0.0,0.1,caitlin baker,
-COM,2500,3,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,charles john brewer,
-COM,2500,4,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,charles john brewer,
-COM,2500,5,Public Speaking,0.29,0.48,0.1,0.0,0.05,0.0,0.0,0.1,sara grumbl crocker,
-COM,2500,6,Public Speaking,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,marshall tho covert,
-COM,2500,7,Public Speaking,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,charles john brewer,
-COM,2500,8,Public Speaking,0.57,0.33,0.05,0.0,0.05,0.0,0.0,0.0,charles john brewer,
-COM,2500,9,Public Speaking,0.52,0.24,0.05,0.1,0.05,0.0,0.0,0.05,ashley lauren pikel,
-COM,2500,10,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
-COM,2500,11,Public Speaking,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,
-COM,2500,12,Public Speaking,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,
-COM,2500,13,Public Speaking,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,ashley lauren pikel,
-COM,2500,14,Public Speaking,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
-COM,2500,15,Public Speaking,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth gilmore,
-COM,2500,16,Public Speaking,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,17,Public Speaking,0.6,0.2,0.15,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,18,Public Speaking,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,
-COM,2500,19,Public Speaking (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,rachelle le beckner,True
-COM,2500,20,Public Speaking,0.67,0.29,0.0,0.05,0.0,0.0,0.0,0.0,katie barn mcelveen,
-COM,2500,21,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,blythe kai steelman,
-COM,2500,23,Public Speaking,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,2500,24,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rachelle le beckner,
-COM,2500,25,Public Speaking,0.52,0.43,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,
-COM,2500,26,Public Speaking (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True
-COM,2500,28,Public Speaking (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,True
-COM,2500,31,Public Speaking,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,marshall tho covert,
-COM,2500,32,Public Speaking,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,33,Public Speaking,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,
-COM,2500,34,Public Speaking,0.43,0.43,0.05,0.05,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,35,Public Speaking,0.4,0.55,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,
-COM,2500,36,Public Speaking,0.25,0.65,0.05,0.05,0.0,0.0,0.0,0.0,marshall tho covert,
-COM,2500,37,Public Speaking,0.5,0.35,0.05,0.0,0.0,0.0,0.0,0.1,elizabeth gilmore,
-COM,2500,38,Public Speaking,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,marshall tho covert,
-COM,2500,400,Public Speaking,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,401,Public Speaking,0.71,0.19,0.0,0.0,0.1,0.0,0.0,0.0,alexis zachar davis,
-COM,2500,402,Public Speaking,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,
-COM,2500,403,Public Speaking,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,
-COM,3070,1,Public Comm of Sts,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,meghna tallapragada,
-COM,3240,1,"Communication, Sport & Society",0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,gregory kei cranmer,
-COM,3240,2,"Communication, Sport & Society",0.77,0.09,0.05,0.09,0.0,0.0,0.0,0.0,katie barn mcelveen,
-COM,3250,1,Survey of Sports Communication,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,
-COM,3260,1,Pr in Sports,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,angela pratt,
-COM,3260,2,Pr in Sports,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,angela pratt,
-COM,3270,1,Sports Media Criticism,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,katie barn mcelveen,
-COM,3480,1,Interpersonal Comm,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,3480,2,Interpersonal Comm,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,
-COM,3550,1,Principles of Public Relations,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,meghna tallapragada,
-COM,3570,1,Public Relations Writing,0.67,0.21,0.04,0.04,0.0,0.0,0.0,0.04,andrew stephen pyle,
-COM,3610,1,Argue and Debate,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,
-COM,3640,1,Organizational Comm,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,kristen ela okamoto,
-COM,3660,1,Video COMM w/ Adobe CC,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,michael rodgers,
-COM,3660,4,Corporate Communications,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,. mark barnes,
-COM,4250,1,Adv Sports Comm,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,
-COM,4260,1,Social Media and Sports Comm,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4270,1,Comm in Sports Organizations,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,
-COM,4280,1,Interpers/Family Comm & Sport,0.26,0.63,0.05,0.05,0.0,0.0,0.0,0.0,gregory kei cranmer,
-COM,4310,1,Legal Communication Trial,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,
-COM,4550,1,Gender Communication,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
-COM,4560,1,PR for Assoc & Nonprofits,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,
-COM,4700,1,Comm & Health,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,
-COM,4950,1,Senior Capstone,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,erin michelle ash,
-COM,4950,2,Senior Capstone,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,
-COM,8060,1,Health Communication & Culture,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,
-CPSC,1010,1,Computer Science I,0.51,0.22,0.12,0.05,0.05,0.0,0.0,0.05,roger larr van scoy,
-CPSC,1010,2,Computer Science I,0.24,0.35,0.15,0.06,0.11,0.0,0.0,0.09,yu-shan sun,
-CPSC,1020,1,Computer Science II,0.42,0.27,0.17,0.02,0.04,0.0,0.0,0.08,yvon feaster,
-CPSC,1020,2,Computer Science II,0.29,0.21,0.25,0.04,0.1,0.0,0.0,0.1,yvon feaster,
-CPSC,1020,3,Computer Science II,0.13,0.33,0.28,0.02,0.13,0.0,0.0,0.11,catherine hochrine,
-CPSC,1020,4,Computer Science II,0.27,0.23,0.36,0.05,0.07,0.0,0.0,0.02,mark smotherman,
-CPSC,1110,1,Intro to Programming in C,0.19,0.22,0.19,0.11,0.06,0.0,0.0,0.22,catherine hochrine,
-CPSC,1110,2,Intro to Programming in C,0.15,0.3,0.18,0.13,0.1,0.0,0.0,0.15,catherine hochrine,
-CPSC,1110,3,Intro to Programming in C,0.19,0.25,0.19,0.06,0.16,0.0,0.0,0.16,andrew duchowski,
-CPSC,2070,1,Discrete Structures,0.69,0.11,0.06,0.0,0.06,0.0,0.0,0.09,sandra hedetniemi,
-CPSC,2070,2,Discrete Structures,0.42,0.25,0.17,0.11,0.03,0.0,0.0,0.03,larry hodges,
-CPSC,2120,1,Algs/Data Structures,0.49,0.23,0.06,0.03,0.06,0.0,0.0,0.14,andrew hill,
-CPSC,2120,2,Algs/Data Structures,0.6,0.17,0.11,0.02,0.04,0.0,0.0,0.06,andrew hill,
-CPSC,2120,3,Algs/Data Structures,0.53,0.34,0.06,0.02,0.02,0.0,0.0,0.02,andrew hill,
-CPSC,2150,1,Software Dev Foundations,0.34,0.36,0.14,0.04,0.0,0.0,0.0,0.12,kevin anton plis,
-CPSC,2150,2,Software Dev Foundations,0.16,0.34,0.18,0.05,0.14,0.0,0.0,0.14,yu-shan sun,
-CPSC,2150,3,Software Dev Foundations,0.26,0.35,0.16,0.03,0.13,0.0,0.0,0.06,yu-shan sun,
-CPSC,2200,1,Microcomputer Appl,0.5,0.29,0.07,0.04,0.04,0.0,0.0,0.07,kevin anton plis,
-CPSC,2200,2,Microcomputer Appl,0.31,0.38,0.23,0.04,0.04,0.0,0.0,0.0,kevin anton plis,
-CPSC,2310,1,Intro Computer Org,0.45,0.35,0.1,0.04,0.02,0.0,0.0,0.04,nicolas benj widman,
-CPSC,2310,2,Intro Computer Org,0.42,0.3,0.18,0.08,0.0,0.0,0.0,0.02,nicolas benj widman,
-CPSC,2810,2,Sel Top: Cyberdefen Comp Train,0.76,0.0,0.0,0.0,0.0,0.0,0.0,0.24,hongda li,
-CPSC,2910,1,Prof Issues I,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2910,2,Prof Issues I,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,catherine hochrine,
-CPSC,2910,3,Prof Issues I,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,catherine hochrine,
-CPSC,2920,1,"Computing, Ethics & Society",0.2,0.28,0.16,0.02,0.04,0.0,0.0,0.3,christopher plaue,
-CPSC,3120,1,Design Analysis of Algorithms,0.38,0.48,0.12,0.0,0.0,0.0,0.0,0.02,wayne goddard,
-CPSC,3120,2,Design Analysis of Algorithms,0.33,0.25,0.14,0.03,0.08,0.0,0.0,0.17,federico iuricich,
-CPSC,3220,1,Intro to Operating Systems,0.19,0.14,0.28,0.05,0.14,0.0,0.0,0.21,jacob sorber,
-CPSC,3220,2,Intro to Operating Systems,0.37,0.4,0.07,0.02,0.07,0.0,0.0,0.07,rong ge,
-CPSC,3300,1,Computer Systems Org,0.38,0.31,0.25,0.02,0.04,0.0,0.0,0.0,nicolas benj widman,
-CPSC,3300,2,Computer Systems Org,0.46,0.22,0.19,0.05,0.05,0.0,0.0,0.03,nicolas benj widman,
-CPSC,3500,1,Foundations of Computer Sci,0.18,0.16,0.33,0.08,0.06,0.0,0.0,0.18,ilya mark safro,
-CPSC,3520,1,Programming Systems,0.23,0.38,0.22,0.03,0.03,0.0,0.0,0.11,robert schalkoff,
-CPSC,3600,1,Network Programming,0.66,0.2,0.09,0.0,0.0,0.0,0.0,0.05,long cheng,
-CPSC,3600,2,Network Programming,0.36,0.32,0.04,0.0,0.14,0.0,0.0,0.14,zijun wang,
-CPSC,3710,1,Systems Analysis,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,roger larr van scoy,
-CPSC,3720,1,Software Engineering,0.41,0.47,0.13,0.0,0.0,0.0,0.0,0.0,paige ann rodeghero,
-CPSC,3720,2,Software Engineering,0.26,0.56,0.18,0.0,0.0,0.0,0.0,0.0,murali sitaraman,
-CPSC,3990,2,Adv CI: Sim Meth in Graphs & E,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,luis bermudez,
-CPSC,3990,2,Adv CI: Sim Meth in Graphs & E,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,victor zordan,
-CPSC,3990,3,CI: User Exper in VR Games,0.6,0.0,0.0,0.2,0.0,0.0,0.0,0.2,andrew robb,
-CPSC,4050,1,Computer Graphics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,victor zordan,
-CPSC,4110,1,Virtual Reality Systems,0.39,0.42,0.15,0.03,0.0,0.0,0.0,0.0,andrew robb,
-CPSC,4140,1,Human and Computer Interaction,0.49,0.38,0.09,0.0,0.04,0.0,0.0,0.0,sabarish venka babu,
-CPSC,4160,1,2-D Game Engine Construction,0.49,0.34,0.13,0.0,0.0,0.0,0.02,0.02,brian malloy,
-CPSC,4180,1,Usable Privacy and Security,0.55,0.23,0.05,0.0,0.05,0.0,0.0,0.14,kelly caine,
-CPSC,4200,1,Computer Security Principles,0.7,0.27,0.0,0.03,0.0,0.0,0.0,0.0,yvon feaster,
-CPSC,4240,1,System Admin and Security,0.24,0.7,0.03,0.0,0.0,0.0,0.0,0.03,james martin,
-CPSC,4440,1,Cloud Computing Architecture,0.29,0.42,0.21,0.0,0.0,0.0,0.0,0.08,amy apon,
-CPSC,4620,1,Database Management Systems,0.3,0.41,0.22,0.0,0.0,0.0,0.0,0.07,zijun wang,
-CPSC,4620,2,Database Management Systems,0.42,0.34,0.24,0.0,0.0,0.0,0.0,0.0,kevin anton plis,
-CPSC,4770,1,Distributed/Cluster Computing,0.56,0.22,0.17,0.0,0.0,0.0,0.0,0.06,shuangshuang jin,
-CPSC,4820,1,Special Topic: Concurrent Prog,0.36,0.32,0.14,0.0,0.05,0.0,0.0,0.14,eileen ther kraemer,
-CPSC,4820,2,Special Topics: Tang and Embod,0.46,0.36,0.11,0.04,0.0,0.0,0.0,0.04,brygg anders ullmer,
-CPSC,4820,3,Special Topic in Computing: AI,0.46,0.13,0.21,0.04,0.04,0.0,0.0,0.13,ioannis karamouzas,
-CPSC,4910,1,Professional Issues II,0.48,0.45,0.05,0.0,0.0,0.0,0.03,0.0,roger larr van scoy,
-CPSC,4910,2,Professional Issues II,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
-CPSC,4910,3,Professional Issues II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,
-CPSC,6050,1,Computer Graphics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,victor zordan,
-CPSC,6110,1,Virtual Reality Systems,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew robb,
-CPSC,6140,1,Human and Computer Interaction,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,sabarish venka babu,
-CPSC,6160,1,2-D Game Engine Construction,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,brian malloy,
-CPSC,6440,1,Cloud Computing Architecture,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,amy apon,
-CPSC,6620,1,Database Management Systems,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,zijun wang,
-CPSC,8040,1,Data Visualization,0.7,0.22,0.08,0.0,0.0,0.0,0.0,0.0,federico iuricich,
-CPSC,8110,1,Technical Character Animation,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,
-CPSC,8240,1,Advanced Operating Systems,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,rong ge,
-CPSC,8400,1,Design & Anlys of Algorithms,0.3,0.35,0.2,0.0,0.05,0.0,0.0,0.1,brian christop dean,
-CPSC,8570,1,Network Technologies Security,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,
-CPSC,8650,1,Data Mining,0.31,0.38,0.28,0.0,0.0,0.0,0.0,0.03,zijun wang,
-CPSC,8810,6,Sel Topic: Deep Learning,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,feng luo,
-CPSC,8810,7,Selected Topics: Moti Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,
-CSM,1000,1,Intro to Construct,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
-CSM,2010,1,Structures I,0.61,0.21,0.12,0.03,0.0,0.0,0.0,0.03,shima clarke,
-CSM,2020,1,Structures II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,
-CSM,2030,1,Mats & Meth of Const,0.29,0.55,0.16,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,
-CSM,2040,1,Cont Documents,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,robert dawso coffey,
-CSM,2050,1,Mats & Methods II,0.3,0.63,0.07,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,
-CSM,3040,1,Envir Systems I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3050,1,Envir Systems II,0.23,0.53,0.15,0.07,0.02,0.0,0.0,0.0,joseph mich burgett,
-CSM,3060,1,Emerging Tech in Construction,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,jason lucas,
-CSM,3070,1,Sustainable Construction,0.46,0.48,0.05,0.02,0.0,0.0,0.0,0.0,joseph mich burgett,
-CSM,3510,1,Construction Estimating,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,
-CSM,3520,1,Const Scheduling,0.78,0.19,0.0,0.03,0.0,0.0,0.0,0.0,craig townsend,
-CSM,3520,2,Const Scheduling,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,3520,2,Const Scheduling,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,jaime cruz,
-CSM,3530,1,Const Estimating II,0.42,0.45,0.13,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,
-CSM,3530,2,Const Estimating II,0.26,0.65,0.1,0.0,0.0,0.0,0.0,0.0,anthony dway harden,
-CSM,4110,1,Safety in Bldg Const,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,nicholas corley,
-CSM,4540,1,Const Capstone,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,dennis bausman,
-CSM,8600,1,Constr Finan Plan & Analysis,0.39,0.57,0.0,0.0,0.0,0.0,0.0,0.04,dennis bausman,
-CSM,8600,401,Constr Finan Plan & Analysis,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,dennis bausman,
-CSM,8680,401,Emerging Tech in Built Environ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jason lucas,
-CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,susan whorton,
-CU,1010,1,Univ Success Skills,0.4,0.1,0.25,0.0,0.05,0.0,0.0,0.2,valerie kay oonk,
-CU,1010,2,Univ Success Skills,0.47,0.24,0.18,0.06,0.0,0.0,0.0,0.06,alejandra kennedy,
-CU,1010,3,Univ Success Skills,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,bryn zimmerman babb,
-CU,1010,5,Univ Success Skills,0.45,0.25,0.15,0.0,0.05,0.0,0.0,0.1,bryn zimmerman babb,
-CU,1010,6,Univ Success Skills,0.74,0.11,0.0,0.05,0.11,0.0,0.0,0.0,james garland,
-CU,1010,7,Univ Success Skills,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,taimi olsen,
-CU,2010,1,Sustainability Leadership,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,
-CVT,2250,400,Ultrasound Physics,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ronda kel nicholson,
-DANC,1600,1,Ballet Dance I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,cheryl hosler,
-DPA,3070,1,Method 3d Production,0.37,0.44,0.07,0.04,0.0,0.0,0.0,0.07,tommy van bui,
-DPA,4020,1,Visual Found of Digital Prod,0.5,0.25,0.0,0.0,0.0,0.0,0.0,0.25,anthony summey,
-DPA,4030,1,Vis Foundations II,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,anthony summey,
-DPA,4830,1,Sp Stud Top: Digit Sculp Intro,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,insun kwon,
-DPA,8150,1,Special Effects Compositing,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,
-DPA,8150,843,Special Effects Compositing,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,
-ECE,2010,1,Logic and Computing Device,0.22,0.3,0.22,0.13,0.06,0.0,0.0,0.06,lin zhu,
-ECE,2020,1,Electric Circuits I,0.16,0.31,0.27,0.04,0.15,0.0,0.0,0.07,william harrell,
-ECE,2070,1,Basic Electrical Engineering,0.38,0.36,0.16,0.05,0.02,0.0,0.0,0.02,fatemeh tooryan,
-ECE,2070,2,Basic Electrical Engineering,0.59,0.25,0.09,0.03,0.01,0.0,0.0,0.03,timothy anglea,
-ECE,2070,3,Basic Electrical Engineering,0.23,0.42,0.19,0.02,0.0,0.0,0.12,0.02,william th kolodzey,
-ECE,2080,4,Basic Electrical Engr Lab,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,10,Basic Electrical Engr Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2080,18,Basic Electrical Engr Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2080,20,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,
-ECE,2090,3,Logic & Computing Devices Lab,0.27,0.55,0.0,0.0,0.09,0.0,0.0,0.09,apoorva dee kapadia,
-ECE,2110,1,Elec Engr Lab I,0.47,0.21,0.05,0.05,0.05,0.0,0.0,0.16,apoorva dee kapadia,
-ECE,2110,2,Elec Engr Lab I,0.77,0.0,0.15,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,
-ECE,2120,1,Electrical Engineering Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2120,6,Electrical Engineering Lab II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2120,9,Electrical Engineering Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,2220,1,Syst Prog Concept,0.18,0.33,0.24,0.04,0.14,0.0,0.0,0.07,william reid,
-ECE,2230,1,Comp Sys Eng,0.18,0.24,0.24,0.03,0.18,0.0,0.0,0.15,jon cameron calhoun,
-ECE,2620,1,Electric Circuits II,0.36,0.34,0.19,0.07,0.04,0.0,0.0,0.0,richard groff,
-ECE,2720,1,Comp Organization,0.37,0.37,0.2,0.02,0.03,0.0,0.0,0.0,william reid,
-ECE,2730,2,Computer Org Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3000,1,Junior Honors Seminar,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True
-ECE,3000,1,Junior Honors Seminar,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,carl baum,True
-ECE,3110,2,Electrical Engineering Lab III,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,3,Electrical Engineering Lab III,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,4,Electrical Engineering Lab III,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3110,5,Electrical Engineering Lab III,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,apoorva dee kapadia,
-ECE,3120,3,Electrical Engineering Lab IV,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
-ECE,3170,1,Rand Signal Analysis,0.3,0.18,0.28,0.13,0.07,0.0,0.0,0.04,stephen hubbard,
-ECE,3200,1,Electronics I,0.3,0.24,0.19,0.16,0.08,0.0,0.0,0.03,stephen hubbard,
-ECE,3210,1,Electronics II,0.35,0.41,0.06,0.14,0.04,0.0,0.0,0.0,stephen hubbard,
-ECE,3220,1,Intro Operating Sys,0.21,0.38,0.24,0.03,0.03,0.0,0.0,0.1,jacob sorber,
-ECE,3220,2,Intro Operating Sys,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,rong ge,
-ECE,3270,1,Dig Comp Design,0.12,0.2,0.22,0.2,0.15,0.0,0.0,0.11,melissa crawl smith,
-ECE,3300,1,Signals & Systems,0.13,0.27,0.27,0.14,0.1,0.0,0.0,0.08,carl baum,
-ECE,3520,1,Programming Systems,0.66,0.3,0.02,0.0,0.0,0.0,0.0,0.02,robert schalkoff,
-ECE,3600,1,Elect Power Engr,0.3,0.24,0.24,0.05,0.0,0.0,0.03,0.14,edward collins,
-ECE,3710,1,Microcontr Interface,0.35,0.44,0.17,0.0,0.05,0.0,0.0,0.0,william reid,
-ECE,3720,3,Micro Int Lab,0.8,0.0,0.1,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,
-ECE,3720,5,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3720,7,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,3800,1,Electromagnetics,0.24,0.23,0.16,0.08,0.1,0.0,0.0,0.19,yuan li,
-ECE,3810,1,Field Waves & Ckts,0.4,0.4,0.11,0.03,0.0,0.0,0.0,0.06,anthony martin,
-ECE,3990,5,CI: High-Perf. Cluster Comp.,0.8,0.0,0.0,0.2,0.0,0.0,0.0,0.0,jon cameron calhoun,
-ECE,4090,1,Intr to Linear Control Systems,0.68,0.13,0.15,0.0,0.02,0.0,0.0,0.02,ian walker,
-ECE,4160,1,Smart Grid,0.44,0.47,0.06,0.0,0.0,0.0,0.0,0.03,gan venayagamoorthy,
-ECE,4190,1,Elec Mach and Drives,0.25,0.25,0.2,0.15,0.05,0.0,0.0,0.1,johan heinri enslin,
-ECE,4270,1,Communications Sys,0.2,0.23,0.4,0.06,0.03,0.0,0.0,0.09,lu yu,
-ECE,4320,1,Instrumentation,0.1,0.5,0.3,0.1,0.0,0.0,0.0,0.0,goutam koley,
-ECE,4380,1,Computer Commun,0.24,0.29,0.24,0.06,0.0,0.0,0.03,0.15,harlan russell,
-ECE,4400,1,Local Computer Nets,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,kuang-ching wang,
-ECE,4680,1,Embedded Computing,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,adam hoover,
-ECE,4930,12,Industrial Contr & Automation,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,
-ECE,4950,1,Int Sys Design I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,
-ECE,4960,1,Int Sys Design II,0.58,0.34,0.07,0.0,0.0,0.0,0.0,0.01,richard groff,
-ECE,4990,18,CI: Deep Learning & Big Data,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,
-ECE,6190,1,Elec Mach and Drives,0.75,0.0,0.25,0.0,0.0,0.0,0.0,0.0,johan heinri enslin,
-ECE,6680,1,Embedded Computing,0.64,0.0,0.27,0.0,0.0,0.0,0.0,0.09,adam hoover,
-ECE,6930,2,Silicon Photonics Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,judson doug ryckman,
-ECE,6930,26,Optical Fiber Communications,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,liang dong,
-ECE,8170,1,Power System Transients,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ramtin hadidi,
-ECE,8240,1,Pow Sys Protection,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,sukumar maka brahma,
-ECE,8560,1,Pattern Recognition,0.21,0.37,0.16,0.0,0.0,0.0,0.0,0.26,robert schalkoff,
-ECE,8930,8,Advanced Photonic Sensors,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hai xiao,
-ECE,8930,11,Malware Reverse Engineering,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,
-ECE,8930,11,Malware Reverse Engineering,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,
-ECE,8930,843,Malware Rev. Engin. Charleston,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,
-ECE,8930,843,Malware Rev. Engin. Charleston,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,
-ECON,2000,1,Economic Concepts,0.38,0.34,0.16,0.0,0.06,0.0,0.0,0.06,shubhashrita basu,
-ECON,2000,2,Economic Concepts,0.4,0.35,0.13,0.05,0.0,0.0,0.0,0.08,shubhashrita basu,
-ECON,2000,3,Economic Concepts,0.65,0.23,0.03,0.05,0.03,0.0,0.0,0.03,miren ivankovic,
-ECON,2110,1,Principles of Microeconomics,0.4,0.23,0.28,0.08,0.03,0.0,0.0,0.0,sarah louise wilson,
-ECON,2110,2,Principles of Microeconomics,0.3,0.43,0.2,0.03,0.03,0.0,0.0,0.03,roksan ghanbariamin,
-ECON,2110,3,Principles of Microeconomics,0.34,0.27,0.21,0.09,0.08,0.0,0.0,0.01,benjamin posmanick,
-ECON,2110,4,Principles of Microeconomics,0.29,0.53,0.14,0.0,0.02,0.0,0.0,0.02,chen wang,
-ECON,2110,5,Principles of Microeconomics,0.33,0.38,0.2,0.08,0.0,0.0,0.0,0.03,molly espey,
-ECON,2110,6,Principles of Microeconomics,0.08,0.42,0.25,0.15,0.04,0.0,0.0,0.06,liuna issagholian,
-ECON,2110,8,Principles of Microeconomics,0.37,0.34,0.19,0.04,0.02,0.0,0.0,0.04,jonathan orr ernest,
-ECON,2110,10,Principles of Microeconomics,0.42,0.5,0.06,0.0,0.02,0.0,0.0,0.0,jacob walloga,
-ECON,2110,12,Principles of Microeconomics,0.38,0.45,0.13,0.0,0.0,0.0,0.0,0.05,molly espey,
-ECON,2120,1,Principles of Macroeconomics,0.38,0.06,0.5,0.0,0.06,0.0,0.0,0.0,scott baier,
-ECON,2120,2,Principles of Macroeconomics,0.22,0.28,0.39,0.11,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,3,Principles of Macroeconomics,0.28,0.5,0.11,0.06,0.06,0.0,0.0,0.0,scott baier,
-ECON,2120,4,Principles of Macroeconomics,0.11,0.42,0.37,0.11,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,5,Principles of Macroeconomics,0.22,0.33,0.44,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,6,Principles of Macroeconomics,0.5,0.07,0.21,0.07,0.14,0.0,0.0,0.0,scott baier,
-ECON,2120,7,Principles of Macroeconomics,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,8,Principles of Macroeconomics,0.17,0.28,0.44,0.06,0.06,0.0,0.0,0.0,scott baier,
-ECON,2120,9,Principles of Macroeconomics,0.53,0.21,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,10,Principles of Macroeconomics,0.26,0.32,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,11,Principles of Macroeconomics,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,12,Principles of Macroeconomics,0.36,0.14,0.36,0.14,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,13,Principles of Macroeconomics,0.5,0.3,0.15,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,14,Principles of Macroeconomics,0.37,0.42,0.16,0.05,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,15,Principles of Macroeconomics,0.24,0.47,0.18,0.12,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,16,Principles of Macroeconomics,0.61,0.17,0.17,0.06,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,17,Principles of Macroeconomics,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,scott baier,
-ECON,2120,18,Principles of Macroeconomics,0.42,0.26,0.16,0.05,0.11,0.0,0.0,0.0,scott baier,
-ECON,2120,19,Principles of Macroeconomics,0.22,0.33,0.33,0.11,0.0,0.0,0.0,0.0,scott baier,
-ECON,2120,20,Principles of Macroeconomics,0.31,0.23,0.31,0.05,0.0,0.0,0.03,0.08,narendra regmi,
-ECON,2120,21,Principles of Macroeconomics,0.84,0.14,0.02,0.0,0.0,0.0,0.0,0.0,tyler francis,
-ECON,2120,22,Principles of Macroeconomics,0.43,0.35,0.11,0.0,0.0,0.0,0.0,0.11,kenneth whaley,
-ECON,2120,23,Principles of Macroeconomics,0.39,0.26,0.26,0.0,0.05,0.0,0.0,0.03,kenneth whaley,
-ECON,2120,24,Principles of Macroeconomics,0.36,0.41,0.11,0.02,0.03,0.0,0.0,0.07,elijah neilson,
-ECON,2120,25,Principles of Macroeconomics,0.38,0.29,0.24,0.03,0.03,0.0,0.0,0.03,wing yin chung,
-ECON,2120,26,Principles of Macroeconomics,0.78,0.19,0.0,0.0,0.0,0.0,0.0,0.03,tyler francis,
-ECON,2120,27,Principles of Macroeconomics,0.38,0.38,0.12,0.03,0.09,0.0,0.0,0.0,benjamin ti harbolt,
-ECON,2120,28,Principles of Macroecon (HON),0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,christopher gorry,True
-ECON,2120,29,Principles of Macroeconomics,0.28,0.44,0.24,0.04,0.0,0.0,0.0,0.0,scott barkowski,
-ECON,3020,1,Money and Banking,0.15,0.49,0.34,0.0,0.02,0.0,0.0,0.0,smriti bhargava,
-ECON,3060,1,Managerial Economics,0.21,0.28,0.1,0.19,0.14,0.0,0.0,0.09,steven johnson,
-ECON,3100,1,International Econ,0.29,0.54,0.17,0.0,0.0,0.0,0.0,0.0,scott baier,
-ECON,3140,1,Intermediate Micro,0.32,0.24,0.18,0.06,0.03,0.0,0.0,0.18,yichen christy zhou,
-ECON,3140,2,Intermediate Micro,0.23,0.28,0.23,0.15,0.03,0.0,0.0,0.1,robert kennet fleck,
-ECON,3140,4,Intermediate Micro,0.19,0.11,0.22,0.14,0.16,0.0,0.0,0.19,frederick hanssen,
-ECON,3150,1,Intermediate Macro,0.27,0.27,0.2,0.1,0.06,0.0,0.0,0.1,michal jerzmanowski,
-ECON,3150,2,Intermediate Macro,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,jeremy choquette,
-ECON,3440,1,Property Rights,0.22,0.33,0.17,0.17,0.06,0.0,0.0,0.06,dar litsukova-bokar,
-ECON,3500,1,Moral & Ethical Econ,0.56,0.24,0.2,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,
-ECON,3500,2,Moral & Ethical Econ,0.25,0.35,0.15,0.05,0.05,0.0,0.0,0.15,bradley keith hobbs,
-ECON,3600,1,Public Choice,0.3,0.48,0.18,0.03,0.0,0.0,0.0,0.03,michael makowsky,
-ECON,4010,1,Labor Mkt Analysis,0.27,0.47,0.17,0.03,0.03,0.0,0.0,0.03,curtis simon,
-ECON,4020,1,Law and Economics,0.23,0.4,0.28,0.02,0.0,0.0,0.0,0.07,thomas wins hazlett,
-ECON,4050,1,Intro to Econometric,0.33,0.25,0.08,0.25,0.06,0.0,0.0,0.03,scott barkowski,
-ECON,4050,2,Intro to Econometric,0.48,0.23,0.1,0.1,0.03,0.0,0.0,0.06,yichen christy zhou,
-ECON,4110,1,Econ of Education,0.56,0.29,0.06,0.03,0.0,0.0,0.0,0.06, garcia menendez,
-ECON,4200,1,Pub Sector Econ,0.24,0.19,0.48,0.05,0.0,0.0,0.0,0.05,william dougan,
-ECON,4230,1,Economics of Health,0.53,0.29,0.13,0.03,0.0,0.0,0.0,0.03,devon merritt gorry,
-ECON,4260,1,Sem Sport Economics,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,raymond sauer,
-ECON,4270,1,Dev American Economy,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,howard ne bodenhorn,
-ECON,4400,1,Game Theory,0.26,0.13,0.48,0.0,0.04,0.0,0.0,0.09,charles thomas,
-ECON,4570,1,"Nat Res Use, Technol & Policy",0.0,0.18,0.55,0.18,0.09,0.0,0.0,0.0,scott templeton,
-ECON,4980,2,Why Business?,0.28,0.56,0.12,0.0,0.0,0.0,0.0,0.04,bradley keith hobbs,
-ECON,4980,3,Why Business?,0.6,0.3,0.07,0.0,0.0,0.0,0.0,0.02,lawrence ree watson,
-ECON,4980,4,Econ of Arts & Culture,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
-ECON,4980,5,Sel Topic - Machine Learning,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,chungsang lam,
-ECON,8020,2,Adv Econ Concepts and Applic I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,
-ECON,8050,1,Macroeconomic Theory,0.5,0.14,0.29,0.07,0.0,0.0,0.0,0.0,michal jerzmanowski,
-ECON,9000,5,Sel Topic - Machine Learning,0.25,0.5,0.0,0.0,0.0,0.0,0.0,0.25,chungsang lam,
-ED,1050,2,Orientation to Education,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,
-ED,1050,2,Orientation to Education,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,paula bailey adams,
-ED,1970,2,Creative Inquiry in Education,0.62,0.29,0.05,0.0,0.0,0.0,0.0,0.05,laurel ann whisler,
-ED,1970,2,Creative Inquiry in Education,0.62,0.29,0.05,0.0,0.0,0.0,0.0,0.05,elizabeth stephan,
-ED,3200,1,History of US Education,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,nafees mohamma khan,
-ED,3970,2,RMAN- Identity & Ldrship Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,3970,5,CI-Fundamentals of Scholarship,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,cherese france fine,
-ED,3970,5,CI-Fundamentals of Scholarship,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,
-ED,8090,412,Teacher Residency Internship,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,marshall alan darby,
-ED,8090,412,Teacher Residency Internship,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,
-ED,8600,1,Classroom-Based Research,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daphne duncan wiles,
-ED,8650,1,Curriculum Theory,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,
-ED,8750,500,Elements of Instructional Effe,0.93,0.02,0.02,0.0,0.0,0.0,0.0,0.02,susan rid nunamaker,
-EDC,2990,1,Creative Inq in Counselor Ed,0.71,0.19,0.1,0.0,0.0,0.0,0.0,0.0,jacob frankovich,
-EDC,3900,1,Skills for Student Leaders,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,erin mayor fogle,
-EDC,3900,4,Skills for Student Leaders,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,5,Skills for Student Leaders,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,3900,6,Skills for Student Leaders,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,eric pernotto,
-EDC,3900,10,Skills for Student Leaders,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,eric pernotto,
-EDC,3900,11,Skills for Student Leaders,0.76,0.12,0.06,0.06,0.0,0.0,0.0,0.0,eric pernotto,
-EDC,8850,1,Counseling Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david barrett,
-EDEL,3210,1,Pe for the Elem Tchr,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,
-EDEL,4510,1,Elem Methods in Science Tchg,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daphne duncan wiles,
-EDEL,4520,1,Elem Methods Math Teaching,0.86,0.0,0.07,0.0,0.04,0.0,0.0,0.04,stacy jones,
-EDF,3020,1,Educational Psychology,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,karen rebecca clark,
-EDF,3020,3,Educational Psychology,0.79,0.18,0.03,0.0,0.0,0.0,0.0,0.0,heather rog brooker,
-EDF,3020,5,Educational Psychology,0.65,0.3,0.0,0.03,0.0,0.0,0.0,0.03,heather rog brooker,
-EDF,3020,6,Educational Psychology,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,karen rebecca clark,
-EDF,3340,1,Child Growth and Development,0.88,0.06,0.0,0.0,0.03,0.0,0.0,0.03,robert o'hara,
-EDF,3340,3,Child Growth and Development,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,amanda eliz bennett,
-EDF,3350,3,Adolescent Growth & Develop,0.49,0.33,0.08,0.05,0.03,0.0,0.0,0.03,david barrett,
-EDF,4800,1,Digital Media & Learning,0.82,0.14,0.0,0.05,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,2,Digital Media & Learning,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,3,Digital Media & Learning,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,david matthew boyer,
-EDF,4800,300,Digital Media & Learning,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,4800,301,Digital Media & Learning,0.83,0.09,0.09,0.0,0.0,0.0,0.0,0.0,ryan visser,
-EDF,9710,1,Case Study & Ethnographic Mthd,0.71,0.18,0.0,0.0,0.12,0.0,0.0,0.0,cynthia chri deaton,
-EDF,9790,400,Qualitative Research in Educ,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,reginald wilkerson,
-EDHD,3110,1,CI- Research in DM & Learning,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,ryan visser,
-EDHD,3110,1,CI- Research in DM & Learning,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,david matthew boyer,
-EDHD,3110,8,CI- Children's Lit. Newsletter,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDHD,3110,9,CI- Read/Review Child/YA Lit.,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,
-EDIS,9360,400,Advanced Program Evaluation,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,daniella hall,
-EDL,9000,400,Prin Edu Leadership,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,aris lane hall,
-EDLT,4620,1,Reading Children's Lit in Elem,0.68,0.21,0.0,0.07,0.0,0.0,0.0,0.04,jonda cecole mcnair,
-EDLT,4670,1,Teaching ESOL in Elem Schools,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,hazel vega quesada,
-EDLT,8120,301,Assessment in Reading & Writin,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,rachelle savitz,
-EDLT,8120,500,Assessment in Reading & Writin,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,
-EDLT,8220,300,Strategies for Teaching ESOL,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,
-EDLT,8230,500,Introduction to Linguistics,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,emily smothe howell,
-EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,
-EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,
-EDLT,8410,507,Early Literacy Inst Strategies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,
-EDLT,8410,507,Early Literacy Inst Strategies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,
-EDLT,8810,508,Reading Recovery Teacher II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,
-EDLT,8810,508,Reading Recovery Teacher II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,
-EDLT,8830,508,Read Recovery Practicum II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,
-EDLT,8830,508,Read Recovery Practicum II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,
-EDSP,3700,2,Intro to Special Education,0.56,0.31,0.06,0.06,0.0,0.0,0.0,0.0,friggita johnson,
-EDSP,3700,4,Intro to Special Education,0.8,0.14,0.03,0.0,0.03,0.0,0.0,0.0,shanna eisne hirsch,
-EDSP,3700,300,Intro to Special Education,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,
-EDSP,3730,1,Char & Instr of ID & Autism,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
-EDSP,3750,1,Early Intervention Spec Needs,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,abigail anne allen,
-EDSP,4910,1,Ed Assess Ind W/Dis,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,
-EDSP,4950,1,Comm & Collab Sp Ed,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,wendell kent parker,
-EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,wendell kent parker,
-EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,beverly lu romansky,
-EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,
-EES,2020,1,Environ Engr Fundamentals II,0.63,0.22,0.15,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,
-EES,4010,1,Environmental Engr,0.63,0.3,0.02,0.0,0.0,0.0,0.0,0.05,elizabeth carraway,
-EES,4010,2,Environmental Engr,0.38,0.43,0.08,0.08,0.05,0.0,0.0,0.0,ezra lucas ho cates,
-EES,4020,1,Water & Waste Water Treatment,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,mark schlautman,
-EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,sudeep popat,
-EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,
-EES,4850,1,Hazard Waste Management,0.29,0.42,0.16,0.03,0.0,0.0,0.0,0.1,mark schlautman,
-EES,4860,1,Environmental Sustainability,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,michael anthon dale,
-EES,4860,2,Environmental Sustainability,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,
-EES,4900,15,CI: From Drones to 3D Printing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael anthon dale,
-EES,4900,15,CI: From Drones to 3D Printing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,pat carbajales-dale,
-EES,8330,2,Air Poll Control Sys,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,andrew rich metcalf,
-ELE,3010,1,Entrepreneurial Foundations,0.44,0.44,0.1,0.03,0.0,0.0,0.0,0.0,christina kyprianou,
-ELE,3010,2,Entrepreneurial Foundations,0.54,0.35,0.11,0.0,0.0,0.0,0.0,0.0,christina kyprianou,
-ELE,3010,3,Entrepreneurial Foundations,0.15,0.5,0.28,0.0,0.0,0.0,0.0,0.08,ashley will parnell,
-ELE,3010,4,Entrepreneurial Foundations,0.2,0.39,0.37,0.02,0.0,0.0,0.0,0.02,ashley will parnell,
-ELE,3020,1,Entrepreneurial Resource Acqu,0.3,0.6,0.08,0.03,0.0,0.0,0.0,0.0,karl bruce kelly,
-ELE,3020,2,Entrepreneurial Resource Acqu,0.25,0.53,0.2,0.0,0.0,0.0,0.0,0.03,karl bruce kelly,
-ELE,4010,1,Venture Testing,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,chad navis,
-ELE,4010,2,Venture Testing,0.5,0.4,0.08,0.03,0.0,0.0,0.0,0.0,chad navis,
-ELE,4020,1,Venture Creation,0.13,0.73,0.13,0.0,0.0,0.0,0.0,0.0,william fra dinardo,
-ELE,4030,1,Venture Growth,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,james keith hudgins,
-ENGL,1030,1,Composition and Rhetoric,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,allen swords,
-ENGL,1030,2,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,1030,3,Composition and Rhetoric,0.47,0.27,0.13,0.07,0.0,0.0,0.0,0.07,naomi marie white,
-ENGL,1030,4,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,naomi marie white,
-ENGL,1030,5,Composition and Rhetoric,0.5,0.36,0.0,0.07,0.0,0.0,0.0,0.07,kristian wilson,
-ENGL,1030,6,Composition and Rhetoric,0.33,0.44,0.06,0.0,0.06,0.0,0.0,0.11,kristian wilson,
-ENGL,1030,8,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
-ENGL,1030,9,Composition and Rhetoric,0.5,0.31,0.06,0.0,0.06,0.0,0.0,0.06,myers addison enlow,
-ENGL,1030,10,Composition and Rhetoric,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,myers addison enlow,
-ENGL,1030,11,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,julie edewaard,
-ENGL,1030,12,Composition and Rhetoric,0.86,0.07,0.0,0.07,0.0,0.0,0.0,0.0,julie edewaard,
-ENGL,1030,14,Composition and Rhetoric,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,blake elizab bowens,
-ENGL,1030,15,Composition and Rhetoric,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,charissa fryberger,
-ENGL,1030,16,Composition and Rhetoric,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,charissa fryberger,
-ENGL,1030,17,Composition and Rhetoric,0.47,0.2,0.0,0.0,0.13,0.0,0.0,0.2,tareva lese johnson,
-ENGL,1030,18,Composition and Rhetoric,0.29,0.43,0.14,0.0,0.14,0.0,0.0,0.0,chelsea mari clarey,
-ENGL,1030,19,Composition and Rhetoric,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,la'cresha ulo green,
-ENGL,1030,20,Composition and Rhetoric,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,
-ENGL,1030,22,Composition and Rhetoric,0.27,0.33,0.27,0.0,0.07,0.0,0.0,0.07,david charles foltz,
-ENGL,1030,23,Composition and Rhetoric,0.45,0.18,0.18,0.09,0.0,0.0,0.0,0.09,david charles foltz,
-ENGL,1030,25,Composition and Rhetoric,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,
-ENGL,1030,27,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,hannah pittm godwin,
-ENGL,1030,28,Composition and Rhetoric,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,hannah pittm godwin,
-ENGL,1030,29,Composition and Rhetoric,0.21,0.57,0.14,0.0,0.07,0.0,0.0,0.0,henna maria messina,
-ENGL,1030,31,Composition and Rhetoric,0.4,0.1,0.3,0.0,0.0,0.0,0.0,0.2,geveryl le robinson,
-ENGL,1030,32,Composition and Rhetoric,0.18,0.59,0.18,0.0,0.0,0.0,0.0,0.06,sharon kathl nalley,
-ENGL,1030,33,Composition and Rhetoric,0.5,0.25,0.0,0.0,0.0,0.0,0.08,0.17,cody hunter,
-ENGL,1030,34,Composition and Rhetoric,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,cody hunter,
-ENGL,1030,35,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kailan smi sindelar,
-ENGL,1030,37,Composition and Rhetoric,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,shauna chung,
-ENGL,1030,38,Composition and Rhetoric,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,shauna chung,
-ENGL,1030,39,Composition and Rhetoric,0.53,0.33,0.0,0.0,0.07,0.0,0.0,0.07,jacob dania richter,
-ENGL,1030,40,Composition and Rhetoric,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,jacob dania richter,
-ENGL,1030,41,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,sarah el richardson,
-ENGL,1030,42,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah el richardson,
-ENGL,1030,45,Composition and Rhetoric,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,1030,46,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,
-ENGL,1030,47,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,caroline eliz young,
-ENGL,1030,48,Composition and Rhetoric,0.33,0.44,0.11,0.06,0.06,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,1030,49,Composition and Rhetoric,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,
-ENGL,1030,50,Composition and Rhetoric,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,
-ENGL,1030,51,Composition and Rhetoric,0.53,0.33,0.07,0.0,0.0,0.0,0.07,0.0,chloe mich whitaker,
-ENGL,1030,52,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jennie el wakefield,
-ENGL,1030,53,Composition and Rhetoric,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,michelle lloyd,
-ENGL,1030,55,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,caroline eliz young,
-ENGL,1030,56,Composition and Rhetoric,0.4,0.2,0.2,0.1,0.1,0.0,0.0,0.0,bree laran beal,
-ENGL,1030,58,Composition and Rhetoric,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,tareva lese johnson,
-ENGL,1030,59,Composition and Rhetoric,0.43,0.36,0.07,0.07,0.07,0.0,0.0,0.0,mary catheri nestor,
-ENGL,1030,60,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mary catheri nestor,
-ENGL,1030,61,Composition and Rhetoric,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,bree laran beal,
-ENGL,1030,63,Composition and Rhetoric,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,
-ENGL,1030,65,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,1030,68,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,1030,69,Composition and Rhetoric,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,1030,70,Composition and Rhetoric,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jennifer forsberg,
-ENGL,1030,71,Composition and Rhetoric,0.55,0.18,0.0,0.27,0.0,0.0,0.0,0.0,bree laran beal,
-ENGL,1030,73,Composition and Rhetoric,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,caitlin grace watt,
-ENGL,1030,74,Composition and Rhetoric,0.36,0.36,0.09,0.09,0.09,0.0,0.0,0.0,edward thomas troy,
-ENGL,1030,75,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,edward thomas troy,
-ENGL,1030,76,Composition and Rhetoric,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,edward thomas troy,
-ENGL,1030,77,Composition and Rhetoric,0.36,0.27,0.18,0.0,0.09,0.0,0.0,0.09,tareva lese johnson,
-ENGL,1030,78,Composition and Rhetoric,0.53,0.24,0.06,0.0,0.0,0.0,0.0,0.18,andrew mathas,
-ENGL,1030,79,Composition and Rhetoric,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,1030,101,Composition and Rhetoric (HON),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,allison nico harris,True
-ENGL,2120,1,World Literature,0.64,0.18,0.04,0.07,0.04,0.0,0.0,0.02,walter edgar hunter,
-ENGL,2120,2,World Literature,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,elizabeth stansell,
-ENGL,2120,4,World Literature,0.71,0.21,0.0,0.04,0.0,0.0,0.0,0.04,elizabeth stansell,
-ENGL,2120,7,World Literature,0.2,0.48,0.12,0.04,0.04,0.0,0.0,0.12,david charles foltz,
-ENGL,2120,8,World Literature,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,david charles foltz,
-ENGL,2120,9,World Literature,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.13,gregory luke chwala,
-ENGL,2120,10,World Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,gregory luke chwala,
-ENGL,2120,12,World Literature,0.52,0.24,0.12,0.08,0.0,0.0,0.0,0.04,kathy elaine nixon,
-ENGL,2120,13,World Literature,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,kathy elaine nixon,
-ENGL,2120,14,World Literature,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,heather pr williams,
-ENGL,2120,15,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,heather pr williams,
-ENGL,2120,16,World Literature,0.4,0.44,0.16,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,
-ENGL,2120,17,World Literature,0.44,0.48,0.0,0.04,0.0,0.0,0.0,0.04,chloe mich whitaker,
-ENGL,2120,20,World Literature,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,patricia sunia,
-ENGL,2120,21,World Literature,0.59,0.32,0.05,0.0,0.0,0.0,0.0,0.05,patricia sunia,
-ENGL,2120,22,World Literature,0.5,0.29,0.13,0.08,0.0,0.0,0.0,0.0,karen kettnich,
-ENGL,2120,23,World Literature,0.35,0.43,0.09,0.04,0.04,0.0,0.0,0.04,karen kettnich,
-ENGL,2120,24,World Literature,0.42,0.53,0.0,0.0,0.05,0.0,0.0,0.0,gregory luke chwala,
-ENGL,2120,25,World Literature,0.27,0.5,0.18,0.0,0.0,0.0,0.05,0.0,kenneth micha tuite,
-ENGL,2120,26,World Literature,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,spencer tricker,
-ENGL,2120,27,World Literature,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,spencer tricker,
-ENGL,2120,28,World Literature,0.57,0.3,0.0,0.04,0.04,0.0,0.0,0.04,spencer tricker,
-ENGL,2120,400,World Literature,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,elizabeth stansell,
-ENGL,2130,1,British Literature,0.48,0.35,0.04,0.0,0.0,0.0,0.0,0.13,krist aldebol-hazle,
-ENGL,2130,2,British Literature,0.6,0.16,0.08,0.0,0.04,0.0,0.0,0.12,krist aldebol-hazle,
-ENGL,2130,3,British Literature,0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,megan no macalystre,
-ENGL,2130,4,British Literature,0.16,0.6,0.12,0.0,0.04,0.0,0.0,0.08,megan no macalystre,
-ENGL,2130,5,British Literature,0.48,0.36,0.0,0.04,0.04,0.0,0.0,0.08,lucian ghita,
-ENGL,2130,6,British Literature,0.72,0.2,0.04,0.04,0.0,0.0,0.0,0.0,lucian ghita,
-ENGL,2130,10,British Literature,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,
-ENGL,2130,11,British Literature,0.64,0.32,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,
-ENGL,2130,12,British Literature,0.27,0.32,0.14,0.0,0.18,0.0,0.0,0.09,megan no macalystre,
-ENGL,2130,13,British Literature,0.6,0.32,0.0,0.08,0.0,0.0,0.0,0.0,daniel scott citro,
-ENGL,2130,14,British Literature,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ingrid anna pierce,
-ENGL,2130,15,British Literature,0.76,0.16,0.04,0.04,0.0,0.0,0.0,0.0,ingrid anna pierce,
-ENGL,2130,16,British Literature,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,caitlin grace watt,
-ENGL,2130,17,British Literature,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,caitlin grace watt,
-ENGL,2130,18,British Literature,0.84,0.08,0.0,0.0,0.08,0.0,0.0,0.0,ingrid anna pierce,
-ENGL,2130,19,British Literature,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,caitlin grace watt,
-ENGL,2140,1,American Literature,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,2,American Literature,0.64,0.24,0.04,0.04,0.04,0.0,0.0,0.0,melissa dugan,
-ENGL,2140,3,American Literature,0.29,0.25,0.33,0.08,0.0,0.0,0.0,0.04,chelsea mari clarey,
-ENGL,2140,4,American Literature,0.12,0.48,0.32,0.0,0.04,0.0,0.0,0.04,chelsea mari clarey,
-ENGL,2140,5,American Literature,0.26,0.48,0.13,0.0,0.04,0.0,0.0,0.09,remley melis makala,
-ENGL,2140,6,American Literature,0.5,0.29,0.13,0.0,0.0,0.0,0.0,0.08,remley melis makala,
-ENGL,2140,7,American Literature,0.27,0.4,0.33,0.0,0.0,0.0,0.0,0.0,chelsea mari clarey,
-ENGL,2140,8,American Literature,0.43,0.26,0.13,0.0,0.0,0.0,0.0,0.17,remley melis makala,
-ENGL,2140,11,American Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,
-ENGL,2140,12,American Literature,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,
-ENGL,2140,13,American Literature,0.67,0.21,0.04,0.0,0.04,0.0,0.0,0.04,caroline eliz young,
-ENGL,2140,14,American Literature,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliz young,
-ENGL,2140,20,American Literature,0.35,0.4,0.05,0.0,0.05,0.0,0.0,0.15,mary catheri nestor,
-ENGL,2140,21,American Literature,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.04,mary catheri nestor,
-ENGL,2140,100,American Literature (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,True
-ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,allison nico harris,
-ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.76,0.12,0.04,0.0,0.08,0.0,0.0,0.0,allison nico harris,
-ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.56,0.32,0.0,0.04,0.0,0.0,0.0,0.08,lindsey henley kurz,
-ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,allen swords,
-ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,andrew mathas,
-ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.48,0.32,0.16,0.04,0.0,0.0,0.0,0.0,andrew mathas,
-ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.79,0.13,0.04,0.04,0.0,0.0,0.0,0.0,allison nico harris,
-ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.4,0.32,0.2,0.04,0.0,0.0,0.0,0.04,julia brownle koets,
-ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.12,0.68,0.16,0.04,0.0,0.0,0.0,0.0,julia brownle koets,
-ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.05,0.59,0.23,0.05,0.05,0.0,0.0,0.05,sarah mae cooper,
-ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,
-ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.36,0.36,0.2,0.0,0.0,0.0,0.0,0.08,hannah pittm godwin,
-ENGL,2150,18,Lit in 20th-21st Cent Contexts,0.76,0.2,0.0,0.0,0.04,0.0,0.0,0.0,lindsey henley kurz,
-ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,lindsey henley kurz,
-ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,hannah pittm godwin,
-ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.6,0.24,0.12,0.04,0.0,0.0,0.0,0.0,john logan pursley,
-ENGL,2150,100,Lit in 20th-21st Cent (HON),0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
-ENGL,2150,405,Lit in 20th-21st Cent Contexts,0.08,0.5,0.27,0.08,0.0,0.0,0.0,0.08,sarah mae cooper,
-ENGL,2150,406,Lit in 20th-21st Cent Contexts,0.05,0.7,0.25,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-ENGL,2160,1,African American Literature,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,
-ENGL,2160,2,African American Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
-ENGL,2160,3,African American Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,
-ENGL,2310,1,Intro to Journalism,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3040,1,Business Writing,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,patricia sunia,
-ENGL,3040,2,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,
-ENGL,3040,3,Business Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william cunningham,
-ENGL,3040,4,Business Writing,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,william cunningham,
-ENGL,3040,5,Business Writing,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,la'cresha ulo green,
-ENGL,3040,6,Business Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulo green,
-ENGL,3040,7,Business Writing,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,katalin beck,
-ENGL,3040,8,Business Writing,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3040,10,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,
-ENGL,3040,11,Business Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,heather pr williams,
-ENGL,3040,12,Business Writing,0.37,0.47,0.05,0.11,0.0,0.0,0.0,0.0,heather pr williams,
-ENGL,3040,13,Business Writing,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,patricia sunia,
-ENGL,3040,400,Business Writing,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,krist aldebol-hazle,
-ENGL,3040,401,Business Writing,0.7,0.25,0.0,0.05,0.0,0.0,0.0,0.0,krist aldebol-hazle,
-ENGL,3040,402,Business Writing,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,megan pietruszewski,
-ENGL,3040,403,Business Writing,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,megan pietruszewski,
-ENGL,3040,404,Business Writing,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,heather pr williams,
-ENGL,3100,1,Crit Writ Lit,0.53,0.12,0.12,0.0,0.0,0.0,0.0,0.24,kimberly manganelli,
-ENGL,3100,2,Crit Writ Lit,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,erin marina goss,
-ENGL,3100,3,Crit Writ Lit,0.67,0.29,0.0,0.05,0.0,0.0,0.0,0.0,matthew hooley,
-ENGL,3120,1,Advanced Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher stuart,
-ENGL,3120,2,Advanced Composition,0.63,0.19,0.06,0.0,0.06,0.0,0.0,0.06,christopher stuart,
-ENGL,3120,4,Advanced Composition,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,christopher benson,
-ENGL,3120,5,Advanced Composition,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,jennie el wakefield,
-ENGL,3140,1,Technical Writing,0.35,0.55,0.05,0.05,0.0,0.0,0.0,0.0,william cunningham,
-ENGL,3140,2,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william cunningham,
-ENGL,3140,3,Technical Writing,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,april 'brien,
-ENGL,3140,4,Technical Writing,0.53,0.26,0.11,0.05,0.0,0.0,0.0,0.05,april 'brien,
-ENGL,3140,7,Technical Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,8,Technical Writing,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,katalin beck,
-ENGL,3140,9,Technical Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,henna maria messina,
-ENGL,3140,10,Technical Writing,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,henna maria messina,
-ENGL,3140,11,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,brian lee gaines,
-ENGL,3140,13,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,
-ENGL,3140,14,Technical Writing,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,dia quaglia beltran,
-ENGL,3140,21,Technical Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,kathy elaine nixon,
-ENGL,3140,22,Technical Writing,0.58,0.26,0.0,0.0,0.0,0.0,0.0,0.16,kathy elaine nixon,
-ENGL,3140,25,Technical Writing,0.67,0.17,0.11,0.0,0.0,0.0,0.0,0.06,megan pietruszewski,
-ENGL,3140,26,Technical Writing,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,megan pietruszewski,
-ENGL,3140,30,Technical Writing,0.22,0.56,0.11,0.11,0.0,0.0,0.0,0.0,henna maria messina,
-ENGL,3140,400,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,
-ENGL,3140,401,Technical Writing,0.79,0.05,0.05,0.05,0.0,0.0,0.0,0.05,geveryl le robinson,
-ENGL,3140,402,Technical Writing,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,geveryl le robinson,
-ENGL,3140,403,Technical Writing,0.74,0.16,0.0,0.0,0.0,0.0,0.0,0.11,geveryl le robinson,
-ENGL,3150,1,Scientific Writing & Comm,0.35,0.35,0.24,0.06,0.0,0.0,0.0,0.0,william pulley,
-ENGL,3150,2,Scientific Writing & Comm,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,william pulley,
-ENGL,3150,3,Scientific Writing & Comm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,4,Scientific Writing & Comm,0.5,0.17,0.22,0.0,0.0,0.0,0.0,0.11,william pulley,
-ENGL,3150,5,Scientific Writing & Comm,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,
-ENGL,3150,6,Scientific Writing & Comm,0.7,0.15,0.0,0.05,0.05,0.0,0.0,0.05,christopher benson,
-ENGL,3150,400,Scientific Writing & Comm,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,philip randall,
-ENGL,3150,402,Scientific Writing & Comm,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,philip randall,
-ENGL,3150,405,Scientific Writing & Comm,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,philip randall,
-ENGL,3460,1,Intr Creative Writing: Poetry,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,sarah mae cooper,
-ENGL,3480,1,Intr Creat Writ: Screenwriting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,julia brownle koets,
-ENGL,3490,1,Tech/Pop Imagination,0.44,0.25,0.06,0.0,0.19,0.0,0.0,0.06,gabriel and hankins,
-ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,angela naimou,
-ENGL,3550,1,Global Studies in Pop Culture,0.22,0.67,0.06,0.0,0.0,0.0,0.0,0.06,spencer tricker,
-ENGL,3570,1,Film,0.16,0.68,0.05,0.0,0.05,0.0,0.0,0.05,amy monaghan,
-ENGL,3570,2,Film,0.15,0.7,0.1,0.0,0.05,0.0,0.0,0.0,amy monaghan,
-ENGL,3570,3,Film,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,john robert smith,
-ENGL,3570,4,Film,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,
-ENGL,3860,1,Adolescent Lit,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,megan no macalystre,
-ENGL,3960,1,Brit Lit Survey I,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,james funk,
-ENGL,3960,2,Brit Lit Survey I,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,ingrid anna pierce,
-ENGL,3970,1,Brit Lit Survey II,0.17,0.61,0.17,0.0,0.0,0.0,0.0,0.06,brian mcgrath,
-ENGL,3980,1,Amer Lit Survey I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,
-ENGL,3990,1,Amer Lit Survey II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,
-ENGL,4000,1,The English Language,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,andrew lemons,
-ENGL,4070,1,Medieval Period,0.8,0.05,0.05,0.05,0.0,0.0,0.0,0.05,andrew lemons,
-ENGL,4100,1,Drama of English Renaissance,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lucian ghita,
-ENGL,4110,1,Shakespeare,0.43,0.43,0.0,0.07,0.07,0.0,0.0,0.0,james funk,
-ENGL,4110,2,Shakespeare,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,james funk,
-ENGL,4110,3,Shakespeare,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,
-ENGL,4190,1,Post Col & World Lit,0.73,0.0,0.13,0.0,0.0,0.0,0.0,0.13,angela naimou,
-ENGL,4210,1,Amer Lit 1800-1899,0.42,0.42,0.11,0.0,0.0,0.0,0.05,0.0,dominic mastroianni,
-ENGL,4280,1,Contemporary Literature,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,lindsey henley kurz,
-ENGL,4320,1,Modern Fiction,0.63,0.06,0.25,0.06,0.0,0.0,0.0,0.0,jillian weise,
-ENGL,4400,1,Literary Theory,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,
-ENGL,4420,1,Cultural Studies,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,bree laran beal,
-ENGL,4450,1,Fiction Workshop,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,
-ENGL,4480,1,Screenwriting Wkshop,0.73,0.2,0.0,0.07,0.0,0.0,0.0,0.0,nicholas chri brown,
-ENGL,4490,1,Creative Non-Fiction,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,julia brownle koets,
-ENGL,4500,1,Film Genres,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,john robert smith,
-ENGL,4510,1,Film Theory and Criticism,0.56,0.22,0.0,0.0,0.22,0.0,0.0,0.0,john robert smith,
-ENGL,4530,1,Sexuality and the Cinema,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,edward thomas troy,
-ENGL,4540,1,Sel Top in International Film,0.5,0.25,0.0,0.0,0.0,0.0,0.0,0.25,jamie ann rogers,
-ENGL,4640,1,Topics in Literature 1700-1899,0.37,0.37,0.11,0.11,0.05,0.0,0.0,0.0,erin marina goss,
-ENGL,4750,1,Writing for Media,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,
-ENGL,4830,1,Af Am Lit 1920-Pres,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,tareva lese johnson,
-ENGL,4850,1,Comp & Lang Teachers,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,
-ENGL,4910,1,Classical Rhetoric,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,tharon howard,
-ENGL,4960,4,Senior Seminar,0.67,0.17,0.0,0.0,0.08,0.0,0.0,0.08,kimberly manganelli,
-ENGR,1020,211,Engineering Discipl & Skills,0.13,0.39,0.16,0.13,0.06,0.0,0.0,0.13,irene marie ferrara,
-ENGR,1020,211,Engineering Discipl & Skills,0.13,0.39,0.16,0.13,0.06,0.0,0.0,0.13,ashley childers,
-ENGR,1020,212,Engineering Discipl & Skills,0.13,0.35,0.19,0.06,0.13,0.0,0.0,0.13,ashley childers,
-ENGR,1020,212,Engineering Discipl & Skills,0.13,0.35,0.19,0.06,0.13,0.0,0.0,0.13,irene marie ferrara,
-ENGR,1020,213,Engineering Discipl & Skills,0.11,0.32,0.32,0.04,0.04,0.0,0.0,0.18,john minor,
-ENGR,1020,213,Engineering Discipl & Skills,0.11,0.32,0.32,0.04,0.04,0.0,0.0,0.18,irene marie ferrara,
-ENGR,1020,214,Engineering Discipl & Skills,0.27,0.2,0.23,0.03,0.07,0.0,0.0,0.2,john minor,
-ENGR,1020,214,Engineering Discipl & Skills,0.27,0.2,0.23,0.03,0.07,0.0,0.0,0.2,irene marie ferrara,
-ENGR,1410,123,Programming & Problem Solving,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,matthew kent miller,
-ENGR,1410,123,Programming & Problem Solving,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,william martin,
-ENGR,1410,124,Programming & Problem Solving,0.33,0.47,0.19,0.0,0.0,0.0,0.0,0.0,william martin,
-ENGR,1410,124,Programming & Problem Solving,0.33,0.47,0.19,0.0,0.0,0.0,0.0,0.0,matthew kent miller,
-ENGR,1410,127,Programming & Problem Solving,0.25,0.5,0.17,0.03,0.0,0.0,0.0,0.06,matthew kent miller,
-ENGR,1410,127,Programming & Problem Solving,0.25,0.5,0.17,0.03,0.0,0.0,0.0,0.06,william martin,
-ENGR,1410,324,Programming & Problem Solving,0.35,0.33,0.23,0.05,0.0,0.0,0.0,0.05,mariah magagnotti,
-ENGR,1410,324,Programming & Problem Solving,0.35,0.33,0.23,0.05,0.0,0.0,0.0,0.05,william martin,
-ENGR,1410,325,Programming & Problem Solving,0.33,0.44,0.18,0.03,0.0,0.0,0.0,0.03,mariah magagnotti,
-ENGR,1410,325,Programming & Problem Solving,0.33,0.44,0.18,0.03,0.0,0.0,0.0,0.03,william martin,
-ENGR,1410,326,Programming & Problem Solving,0.19,0.49,0.14,0.0,0.0,0.0,0.0,0.19,mariah magagnotti,
-ENGR,1410,326,Programming & Problem Solving,0.19,0.49,0.14,0.0,0.0,0.0,0.0,0.19,william martin,
-ENGR,1410,621,Programming & Problem Solving,0.19,0.49,0.22,0.03,0.03,0.0,0.0,0.05,william martin,
-ENGR,1410,621,Programming & Problem Solving,0.19,0.49,0.22,0.03,0.03,0.0,0.0,0.05,john minor,
-ENGR,1410,622,Programming & Problem Solving,0.28,0.28,0.35,0.0,0.0,0.0,0.0,0.1,john minor,
-ENGR,1410,622,Programming & Problem Solving,0.28,0.28,0.35,0.0,0.0,0.0,0.0,0.1,william martin,
-ENGR,1410,623,Programming & Problem Solving,0.41,0.28,0.13,0.03,0.05,0.0,0.0,0.1,john minor,
-ENGR,1410,623,Programming & Problem Solving,0.41,0.28,0.13,0.03,0.05,0.0,0.0,0.1,william martin,
-ENGR,1410,624,Programming & Problem Solving,0.18,0.5,0.18,0.08,0.0,0.0,0.0,0.05,william martin,
-ENGR,1410,624,Programming & Problem Solving,0.18,0.5,0.18,0.08,0.0,0.0,0.0,0.05,michael giebner,
-ENGR,1410,625,Programming & Problem Solving,0.18,0.37,0.34,0.11,0.0,0.0,0.0,0.0,william martin,
-ENGR,1410,625,Programming & Problem Solving,0.18,0.37,0.34,0.11,0.0,0.0,0.0,0.0,michael giebner,
-ENGR,1410,626,Programming & Problem Solving,0.3,0.4,0.13,0.13,0.0,0.0,0.0,0.03,elizabeth stephan,
-ENGR,1410,626,Programming & Problem Solving,0.3,0.4,0.13,0.13,0.0,0.0,0.0,0.03,william martin,
-ENGR,1410,627,Programming & Problem Solving,0.35,0.53,0.1,0.0,0.0,0.0,0.0,0.03,jonathan bro harcum,
-ENGR,1410,627,Programming & Problem Solving,0.35,0.53,0.1,0.0,0.0,0.0,0.0,0.03,william martin,
-ENGR,1410,721,Programming & Problem Solving,0.19,0.45,0.23,0.06,0.03,0.0,0.0,0.03,william martin,
-ENGR,1410,721,Programming & Problem Solving,0.19,0.45,0.23,0.06,0.03,0.0,0.0,0.03,john minor,
-ENGR,1410,722,Programming & Problem Solving,0.5,0.34,0.13,0.0,0.03,0.0,0.0,0.0,elizabeth stephan,
-ENGR,1410,722,Programming & Problem Solving,0.5,0.34,0.13,0.0,0.03,0.0,0.0,0.0,william martin,
-ENGR,1410,725,Programming & Problem Solving,0.47,0.25,0.22,0.0,0.03,0.0,0.0,0.03,william martin,
-ENGR,1410,725,Programming & Problem Solving,0.47,0.25,0.22,0.0,0.03,0.0,0.0,0.03,andrew isaa neptune,
-ENGR,1410,726,Programming & Problem Solving,0.31,0.38,0.22,0.03,0.0,0.0,0.0,0.06,william martin,
-ENGR,1410,726,Programming & Problem Solving,0.31,0.38,0.22,0.03,0.0,0.0,0.0,0.06,sarah grigg,
-ENGR,1410,727,Programming & Problem Solving,0.17,0.57,0.17,0.06,0.0,0.0,0.0,0.03,sarah grigg,
-ENGR,1410,727,Programming & Problem Solving,0.17,0.57,0.17,0.06,0.0,0.0,0.0,0.03,william martin,
-ENGR,1410,821,Programming & Problem Solving,0.23,0.58,0.13,0.0,0.03,0.0,0.0,0.03,andrew isaa neptune,
-ENGR,1410,821,Programming & Problem Solving,0.23,0.58,0.13,0.0,0.03,0.0,0.0,0.03,william martin,
-ENGR,1410,822,Programming & Problem Solving,0.17,0.5,0.31,0.03,0.0,0.0,0.0,0.0,andrew isaa neptune,
-ENGR,1410,822,Programming & Problem Solving,0.17,0.5,0.31,0.03,0.0,0.0,0.0,0.0,william martin,
-ENGR,1410,823,Program & Prob Solving (HON),0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,william martin,True
-ENGR,1410,823,Program & Prob Solving (HON),0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,True
-ENGR,1410,824,Program & Prob Solving (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,True
-ENGR,1410,824,Program & Prob Solving (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william martin,True
-ENGR,1410,825,Programming & Problem Solving,0.21,0.36,0.27,0.06,0.03,0.0,0.0,0.06,jonathan maier,
-ENGR,1410,825,Programming & Problem Solving,0.21,0.36,0.27,0.06,0.03,0.0,0.0,0.06,william martin,
-ENGR,1410,826,Programming & Problem Solving,0.29,0.37,0.16,0.03,0.05,0.0,0.0,0.11,william martin,
-ENGR,1410,826,Programming & Problem Solving,0.29,0.37,0.16,0.03,0.05,0.0,0.0,0.11,jonathan maier,
-ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.24,0.03,0.0,0.0,0.0,0.0,william martin,
-ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.24,0.03,0.0,0.0,0.0,0.0,jonathan maier,
-ENGR,1900,10,CI in Engr I (Robotics),0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,michael benj wooten,
-ENGR,2080,281,Engr Graphics & Machine Design,0.38,0.44,0.15,0.0,0.0,0.0,0.0,0.04,nighat yasmin,
-ENGR,2080,281,Engr Graphics & Machine Design,0.38,0.44,0.15,0.0,0.0,0.0,0.0,0.04,samuel coeyman,
-ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.2,0.07,0.07,0.02,0.0,0.0,0.02,nighat yasmin,
-ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.2,0.07,0.07,0.02,0.0,0.0,0.02,samuel coeyman,
-ENGR,2080,284,Engr Graphics & Machine Design,0.62,0.22,0.11,0.04,0.0,0.0,0.0,0.0,nighat yasmin,
-ENGR,2080,284,Engr Graphics & Machine Design,0.62,0.22,0.11,0.04,0.0,0.0,0.0,0.0,nisha gulhane,
-ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,natalie pellizzi,
-ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,nighat yasmin,
-ENGR,2080,286,Engr Graphics & Machine Design,0.34,0.41,0.11,0.05,0.07,0.0,0.0,0.02,nighat yasmin,
-ENGR,2080,286,Engr Graphics & Machine Design,0.34,0.41,0.11,0.05,0.07,0.0,0.0,0.02,natalie pellizzi,
-ENGR,2080,382,Engr Graphics & Machine Design,0.56,0.24,0.09,0.02,0.07,0.0,0.0,0.02,nighat yasmin,
-ENGR,2080,382,Engr Graphics & Machine Design,0.56,0.24,0.09,0.02,0.07,0.0,0.0,0.02,nisha gulhane,
-ENGR,2080,682,Engr Graphics & Machine Design,0.59,0.28,0.13,0.0,0.0,0.0,0.0,0.0,kyle walker,
-ENGR,2080,682,Engr Graphics & Machine Design,0.59,0.28,0.13,0.0,0.0,0.0,0.0,0.0,nighat yasmin,
-ENGR,2080,684,Engr Graphics & Machine Design,0.6,0.19,0.05,0.02,0.07,0.0,0.0,0.07,nighat yasmin,
-ENGR,2080,684,Engr Graphics & Machine Design,0.6,0.19,0.05,0.02,0.07,0.0,0.0,0.07,kyle walker,
-ENGR,2080,882,Engr Graphics & Machine Design,0.6,0.26,0.04,0.04,0.04,0.0,0.0,0.02,nighat yasmin,
-ENGR,2080,882,Engr Graphics & Machine Design,0.6,0.26,0.04,0.04,0.04,0.0,0.0,0.02,apurva patel,
-ENGR,2080,884,Engr Graphics & Machine Design,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,nighat yasmin,
-ENGR,2080,884,Engr Graphics & Machine Design,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,apurva patel,
-ENGR,2100,101,CAD & Engineering Applications,0.52,0.28,0.04,0.04,0.07,0.0,0.0,0.04,afshin famili,
-ENGR,2100,101,CAD & Engineering Applications,0.52,0.28,0.04,0.04,0.07,0.0,0.0,0.04,nighat yasmin,
-ENGR,2100,102,CAD & Engineering Applications,0.44,0.33,0.1,0.08,0.0,0.0,0.0,0.04,nighat yasmin,
-ENGR,2100,102,CAD & Engineering Applications,0.44,0.33,0.1,0.08,0.0,0.0,0.0,0.04,afshin famili,
-ENGR,2100,105,CAD & Engineering Applications,0.71,0.19,0.02,0.02,0.02,0.0,0.0,0.02,john minor,
-ENGR,2100,105,CAD & Engineering Applications,0.71,0.19,0.02,0.02,0.02,0.0,0.0,0.02,nighat yasmin,
-ENGR,2100,106,CAD & Engineering Applications,0.5,0.35,0.04,0.0,0.02,0.0,0.0,0.08,nighat yasmin,
-ENGR,2100,106,CAD & Engineering Applications,0.5,0.35,0.04,0.0,0.02,0.0,0.0,0.08,john minor,
-ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.12,0.08,0.06,0.04,0.0,0.0,0.0,russell barrett,
-ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.12,0.08,0.06,0.04,0.0,0.0,0.0,alan johnson,
-ENR,3020,1,Nat Res Measurements,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,russell barrett,
-ENR,3020,1,Nat Res Measurements,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,lawrence gering,
-ENR,4130,2,Restoration Ecology,0.3,0.4,0.23,0.0,0.0,0.0,0.0,0.07,althea simone hagan,
-ENR,4500,1,Conservation Issues,0.87,0.09,0.0,0.04,0.0,0.0,0.0,0.0,alan johnson,
-ENR,4500,2,Conservation Issues,0.79,0.14,0.03,0.0,0.0,0.0,0.0,0.03,alan johnson,
-ENR,6130,1,Restoration Ecology,0.5,0.21,0.29,0.0,0.0,0.0,0.0,0.0,althea simone hagan,
-ENSP,2000,1,Intro Environ Sci,0.19,0.65,0.09,0.06,0.02,0.0,0.0,0.0,tom owino,
-ENSP,2000,2,Intro Environ Sci,0.57,0.37,0.0,0.0,0.0,0.0,0.0,0.06,elizabeth carraway,
-ENSP,2000,3,Intro Environ Sci,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,2010,1,Environm Sci for Educ Majors,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-ENSP,4000,1,Studies in Environmental Sci,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,margaret thompson,
-ENT,2000,1,Six-Legged Science,0.41,0.34,0.15,0.02,0.0,0.0,0.05,0.02,suellen pometto,
-ENT,8700,1,Insect Phys Mol Bio,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,
-ENTR,1010,2,Entrepreneurial Mindset,0.64,0.27,0.05,0.0,0.0,0.0,0.01,0.03,john michael hannon,
-ENTR,1090,2,How to Start a Startup,0.71,0.07,0.04,0.0,0.0,0.0,0.0,0.18,john michael hannon,
-ENTR,1090,20,Lemonade Day Pendleton,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david joseph frock,
-ENTR,2010,1,Sports Entrepreneurship,0.77,0.16,0.05,0.0,0.0,0.0,0.0,0.02,john michael hannon,
-ESED,8500,1,Spec Top Engineering & Sci Edu,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,cindy lee,
-FCS,2010,1,Introduction to Human Rights,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,matthe hudson-flege,
-FDSC,2140,1,Fd Resources & Soc,0.7,0.23,0.04,0.03,0.0,0.0,0.0,0.0,paul dawson,
-FDSC,3040,1,Eval Dairy Products,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-FDSC,3040,1,Eval Dairy Products,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,sara lane cothran,
-FDSC,4020,1,Food Chemistry II,0.73,0.24,0.02,0.0,0.0,0.0,0.0,0.0,feng chen,
-FDSC,4030,1,Food Ch & Analysis,0.67,0.27,0.02,0.02,0.0,0.0,0.0,0.02,feng chen,
-FDSC,4030,1,Food Ch & Analysis,0.67,0.27,0.02,0.02,0.0,0.0,0.0,0.02,paul dawson,
-FDSC,4080,1,Food Process Eng,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,steven brandon,
-FDSC,4500,7,Creative Inquiry-Food Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,
-FDSC,4500,15,Creative Inquiry-Food Science,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vivian haley-zitlin,
-FDSC,4500,18,Creative Inquiry-Food Science,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,xiuping jiang,
-FDSC,4500,22,Creative Inquiry-Food Science,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,feng chen,
-FIN,2010,401,Intro to Personal Finance,0.93,0.01,0.04,0.0,0.01,0.0,0.0,0.0,joshua harris,
-FIN,2010,402,Intro to Personal Finance,0.97,0.01,0.01,0.0,0.0,0.0,0.0,0.0,joshua harris,
-FIN,2010,403,Intro to Personal Finance,0.91,0.01,0.03,0.0,0.03,0.0,0.0,0.01,joshua harris,
-FIN,2010,404,Intro to Personal Finance,0.72,0.16,0.01,0.01,0.06,0.0,0.0,0.03,joshua harris,
-FIN,2010,405,Intro to Personal Finance,0.79,0.15,0.0,0.03,0.0,0.0,0.0,0.03,joshua harris,
-FIN,2010,406,Intro to Personal Finance,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,joshua harris,
-FIN,3040,1,Risk & Insurance,0.2,0.28,0.35,0.08,0.1,0.0,0.0,0.0,kerri mcmillan,
-FIN,3050,1,Investment Analysis,0.17,0.27,0.44,0.05,0.0,0.0,0.0,0.07,kerri mcmillan,
-FIN,3050,2,Investment Analysis,0.26,0.24,0.39,0.05,0.0,0.0,0.0,0.05,kerri mcmillan,
-FIN,3050,3,Investment Analysis,0.18,0.38,0.28,0.05,0.0,0.0,0.0,0.1,kerri mcmillan,
-FIN,3050,4,Investment Analysis,0.17,0.23,0.26,0.11,0.03,0.0,0.0,0.2,john alexander,
-FIN,3060,1,Corporation Finance,0.21,0.3,0.23,0.19,0.02,0.0,0.0,0.04,ramon tolb franklin,
-FIN,3060,2,Corporation Finance,0.21,0.21,0.27,0.19,0.02,0.0,0.0,0.1,ramon tolb franklin,
-FIN,3060,3,Corporation Finance,0.2,0.22,0.24,0.18,0.02,0.0,0.0,0.13,ramon tolb franklin,
-FIN,3060,4,Corporation Finance,0.13,0.2,0.24,0.29,0.04,0.0,0.0,0.09,ramon tolb franklin,
-FIN,3060,9,Corporation Finance,0.12,0.17,0.4,0.24,0.05,0.0,0.0,0.02,charles taylor vick,
-FIN,3060,401,Corporation Finance,0.3,0.25,0.25,0.13,0.03,0.0,0.0,0.04,jonathan godbey,
-FIN,3060,402,Corporation Finance,0.18,0.31,0.32,0.11,0.0,0.0,0.04,0.04,jonathan godbey,
-FIN,3060,601,Corporation Finance,0.06,0.69,0.25,0.0,0.0,0.0,0.0,0.0,jack wolf,
-FIN,3070,1,Prin of Real Estate,0.24,0.42,0.29,0.05,0.0,0.0,0.0,0.0,yannan shen,
-FIN,3070,2,Prin of Real Estate,0.29,0.37,0.24,0.03,0.05,0.0,0.0,0.03,yannan shen,
-FIN,3070,3,Prin of Real Estate,0.24,0.41,0.22,0.11,0.03,0.0,0.0,0.0,thomas springer,
-FIN,3070,4,Prin of Real Estate,0.19,0.19,0.39,0.19,0.03,0.0,0.0,0.0,thomas springer,
-FIN,3080,1,Fin Inst & Mkts,0.21,0.4,0.29,0.07,0.02,0.0,0.0,0.0,daniel thoma greene,
-FIN,3080,2,Fin Inst & Mkts,0.19,0.4,0.33,0.05,0.0,0.0,0.0,0.02,daniel thoma greene,
-FIN,3080,401,Fin Inst & Mkts,0.27,0.51,0.14,0.06,0.02,0.0,0.0,0.0,daniel thoma greene,
-FIN,3080,402,Fin Inst & Mkts,0.12,0.51,0.35,0.02,0.0,0.0,0.0,0.0,daniel thoma greene,
-FIN,3110,2,Financial Management I,0.22,0.32,0.22,0.04,0.01,0.0,0.0,0.18,george bra lockhart,
-FIN,3110,4,Financial Management I,0.22,0.31,0.22,0.06,0.03,0.0,0.0,0.15,george bra lockhart,
-FIN,3110,5,Financial Management I,0.23,0.33,0.26,0.07,0.07,0.0,0.0,0.05,weike xu,
-FIN,3110,102,Financial Management I (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,george bra lockhart,True
-FIN,3110,104,Financial Management I (HON),0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,george bra lockhart,True
-FIN,3120,1,Financial Management II,0.24,0.4,0.17,0.14,0.0,0.0,0.0,0.05,blerina zykaj,
-FIN,3120,2,Financial Management II,0.28,0.28,0.38,0.03,0.03,0.0,0.0,0.0,blerina zykaj,
-FIN,3120,4,Financial Management II,0.14,0.38,0.31,0.05,0.1,0.0,0.0,0.02,weike xu,
-FIN,3120,5,Financial Management II,0.19,0.35,0.3,0.07,0.05,0.0,0.0,0.05,weike xu,
-FIN,3120,102,Financial Management II (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,True
-FIN,3120,401,Financial Management II,0.18,0.27,0.3,0.09,0.07,0.0,0.0,0.09,angela morgan,
-FIN,4020,1,Corporate Valuation,0.16,0.44,0.3,0.07,0.0,0.0,0.0,0.02,angela morgan,
-FIN,4030,1,Spreadsheet Apps in Finance,0.3,0.28,0.23,0.14,0.02,0.0,0.0,0.02,vincent intintoli,
-FIN,4030,2,Spreadsheet Apps in Finance,0.33,0.27,0.33,0.03,0.03,0.0,0.0,0.0,vincent intintoli,
-FIN,4040,1,Financial Modeling,0.14,0.57,0.1,0.14,0.0,0.0,0.0,0.05,jack wolf,
-FIN,4050,1,Portfolio Management & Theory,0.09,0.27,0.42,0.12,0.0,0.0,0.0,0.09,john alexander,
-FIN,4080,1,Mgt of Fin Inst,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4080,2,Mgt of Fin Inst,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,
-FIN,4090,1,Professional Financial Plan,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,
-FIN,4110,1,Int Fin Mgt,0.24,0.48,0.21,0.0,0.06,0.0,0.0,0.0,luke asher devault,
-FIN,4110,2,Int Fin Mgt,0.39,0.36,0.18,0.04,0.0,0.0,0.0,0.04,luke asher devault,
-FIN,4150,1,Real Estate Investmt,0.2,0.45,0.3,0.0,0.0,0.0,0.0,0.05,thomas springer,
-FIN,4160,2,Real Estate Val,0.24,0.62,0.14,0.0,0.0,0.0,0.0,0.0,bryan blackwood,
-FIN,4980,2,CI in Finance: CFA,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jack wolf,
-FIN,4980,9,Creative Inquiry in Finance,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,yannan shen,
-FNR,4700,19,Soil Judging Project,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,elena mikhailova,
-FNR,4700,23,Estuarine Fish Ecology I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,troy mason farmer,
-FNR,4700,24,Climate Change/Carolina Fish I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,troy mason farmer,
-FNR,4700,35,Aquaponics,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,lance edwar beecher,
-FNR,4700,37,Growing Food In a Box Techniqs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,
-FNR,4700,44,Alligator Ecology,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,catherine jachowski,
-FNR,4700,46,Tiger Awareness,0.88,0.0,0.0,0.13,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-FNR,4990,3,Natural Resources Seminar,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,susan talley guynn,
-FOR,1010,1,Intro to Forestry,0.7,0.05,0.16,0.03,0.03,0.0,0.0,0.03,lawrence gering,
-FOR,2060,1,Forestry Ecology,0.24,0.31,0.2,0.11,0.0,0.0,0.09,0.05,donald hagan,
-FOR,3080,1,Remote Sensing in Forestry,0.44,0.33,0.19,0.04,0.0,0.0,0.0,0.0,lawrence gering,
-FOR,4080,1,Wood and Paper Products,0.62,0.26,0.1,0.0,0.0,0.0,0.0,0.02,patricia layton,
-FOR,4150,2,Forest Wildlife Managment,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
-FOR,4180,1,Forest Resource Valuation,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,thomas straka,
-FOR,4340,1,GIS for Natural Resources,0.4,0.48,0.05,0.0,0.0,0.0,0.0,0.08,robert frit baldwin,
-FOR,4650,1,Silviculture,0.26,0.37,0.19,0.15,0.04,0.0,0.0,0.0,gaofeng wang,
-FR,1010,1,Elementary French,0.36,0.27,0.23,0.05,0.09,0.0,0.0,0.0,anne salces  nedeo,
-FR,1010,2,Elementary French,0.43,0.36,0.0,0.07,0.14,0.0,0.0,0.0,anne salces  nedeo,
-FR,1020,1,Elementary French,0.52,0.22,0.09,0.0,0.0,0.0,0.04,0.13,amy lyn grif sawyer,
-FR,1020,2,Elementary French,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,2,Intermediate French,0.73,0.23,0.0,0.05,0.0,0.0,0.0,0.0,amy lyn grif sawyer,
-FR,2010,3,Intermediate French,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,amy lyn grif sawyer,
-FR,2020,1,Intermediate French,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,
-FR,2020,3,Intermediate French,0.38,0.38,0.13,0.08,0.0,0.0,0.0,0.04,paulin de tholozany,
-FR,2020,4,Intermediate French,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,
-FR,3050,1,Int Fr Con & Comp I,0.55,0.3,0.1,0.0,0.0,0.0,0.0,0.05,joseph mai,
-FR,3160,1,Fr for Intl Trade,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,eric touya,
-FR,4100,1,Francophone Literature,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,eric touya,
-GC,1010,1,Orientation to G C,0.24,0.59,0.06,0.0,0.06,0.0,0.0,0.06,kern cox,
-GC,1020,1,Computer Art & CAD Foundations,0.27,0.38,0.16,0.03,0.08,0.0,0.0,0.08,carol jones,
-GC,1030,1,G C I for Pkgsc,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,john jacobs,
-GC,1040,1,Graphic Communications I,0.76,0.19,0.02,0.0,0.02,0.0,0.0,0.02,michelle suki  fox,
-GC,1990,4,CI in GC I Ph Ch,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nona woolbright,
-GC,2070,1,Graphic Communications II,0.57,0.38,0.04,0.0,0.0,0.0,0.0,0.0,charles tabor weiss,
-GC,2990,2,CI in GC II-VDP,0.8,0.0,0.0,0.0,0.2,0.0,0.0,0.0,eric weisenmiller,
-GC,2990,4,Cr Inquiry in GC II Ph Ch,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,nona woolbright,
-GC,3400,1,Digital Imaging and eMedia,0.31,0.56,0.1,0.0,0.0,0.0,0.0,0.03,erica black walker,
-GC,3460,1,Ink and Substrates,0.33,0.33,0.26,0.0,0.05,0.0,0.0,0.03,liam henry 'hara,
-GC,3720,1,Digital Analytics Brand Comm,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,alicia ni littleton,
-GC,3720,1,Digital Analytics Brand Comm,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,katelyn hildebrand,
-GC,3730,1,Media Management in Brand Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jaclyn kathl driggs,
-GC,3730,1,Media Management in Brand Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,
-GC,3740,1,Brand Comm Media Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,
-GC,3740,1,Brand Comm Media Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,roger beasley,
-GC,4060,1,Package and Specialty Printing,0.17,0.71,0.06,0.0,0.03,0.0,0.0,0.03,kern cox,
-GC,4400,1,Commercial Printing,0.29,0.45,0.16,0.0,0.06,0.0,0.0,0.03,eric weisenmiller,
-GC,4440,1,Current Dev/Trends in Gr Comm,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,
-GC,4480,1,Plan & Cont Printing Functions,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,nona woolbright,
-GC,4800,1,Senior Seminar in GC,0.81,0.17,0.02,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,
-GC,4900,8,UX & Web Design,0.94,0.0,0.0,0.0,0.06,0.0,0.0,0.0,erica black walker,
-GC,4900,230,G C Selected Topics-Sales,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,john leininger,
-GEN,3000,1,Fundamental Genetics,0.26,0.29,0.24,0.13,0.05,0.0,0.0,0.03,kate leanne wi tsai,
-GEN,3000,2,Fundamental Genetics,0.36,0.32,0.16,0.06,0.03,0.0,0.0,0.06,kate leanne wi tsai,
-GEN,3020,1,Molecular & General Genetics,0.36,0.32,0.23,0.02,0.02,0.0,0.0,0.05,lukasz kozubowski,
-GEN,3040,1,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-GEN,3040,1,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
-GEN,3040,2,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
-GEN,3040,2,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-GEN,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
-GEN,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-GEN,3040,4,Molecular Biology Laboratory,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,geoffrey ford,
-GEN,3040,4,Molecular Biology Laboratory,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
-GEN,4200,1,Molecular Genetics & Gene Reg,0.27,0.4,0.29,0.03,0.0,0.0,0.0,0.0,miriam krist konkel,
-GEN,4210,2,Mol Gen Gene Reg Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,
-GEN,4400,1,Bioinformatics,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,liangjiang wang,
-GEN,4700,1,Human Genetics,0.25,0.38,0.28,0.06,0.0,0.0,0.0,0.04,leigh anne clark,
-GEN,4900,3,Biomedical Informatics,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,frank alexan feltus,
-GEN,4910,36,CI:DNA Repair (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True
-GEN,4930,3,Senior Seminar,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,haiying liang,
-GEN,6700,1,Human Genetics,0.17,0.17,0.17,0.0,0.0,0.0,0.0,0.5,leigh anne clark,
-GEN,8050,1,Issues in Research,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william marcotte,
-GEOG,1010,1,Intro to Geography,0.4,0.47,0.07,0.03,0.03,0.0,0.0,0.0,christa smith,
-GEOG,1030,1,World Regional Geography,0.3,0.44,0.15,0.04,0.03,0.0,0.0,0.04,william churc terry,
-GEOL,1010,1,Physical Geology,0.27,0.29,0.25,0.07,0.07,0.0,0.0,0.05,alan coulson,
-GEOL,1010,2,Physical Geology,0.34,0.33,0.17,0.04,0.04,0.0,0.0,0.09,alan coulson,
-GEOL,1010,3,Physical Geology,0.43,0.38,0.11,0.05,0.04,0.0,0.0,0.0,mary katheri fidler,
-GEOL,1030,1,Physical Geol Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,2,Physical Geol Lab,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,3,Physical Geol Lab,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,alan coulson,
-GEOL,1030,4,Physical Geol Lab,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,5,Physical Geol Lab,0.78,0.13,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,6,Physical Geol Lab,0.43,0.3,0.17,0.0,0.0,0.0,0.0,0.09,alan coulson,
-GEOL,1030,7,Physical Geol Lab,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,8,Physical Geol Lab,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,
-GEOL,1030,10,Physical Geol Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,11,Physical Geol Lab,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,alan coulson,
-GEOL,1030,12,Physical Geol Lab,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,14,Physical Geol Lab,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,1030,15,Physical Geol Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,alan coulson,
-GEOL,1120,1,Earth Resources,0.29,0.35,0.19,0.13,0.01,0.0,0.0,0.03,mary katheri fidler,
-GEOL,1140,1,Earth Resources Lab,0.64,0.2,0.05,0.05,0.02,0.0,0.0,0.04,mary katheri fidler,
-GEOL,2020,1,Earth History,0.25,0.45,0.25,0.05,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,3160,1,Igneous & Metamorphic Petrolog,0.27,0.6,0.13,0.0,0.0,0.0,0.0,0.0,mary katheri fidler,
-GEOL,4050,1,Surficial Geology,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,alexander th pullen,
-GEOL,4090,1,Envir & Exploration Geophysics,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,scott dewolf,
-GEOL,4110,8,Res Probs - Community Outreach,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john robert wagner,
-GEOL,4210,1,GIS in Geology,0.72,0.16,0.04,0.0,0.04,0.0,0.0,0.04,scott brame,
-GEOL,4920,1,Resrch Synthesis II,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,
-GEOL,8170,1,Applied Process Simulation,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,lawrence murdoch,
-GER,1010,1,Elementary German,0.54,0.23,0.08,0.0,0.0,0.0,0.0,0.15, lee ferrell,
-GER,1010,2,Elementary German,0.38,0.31,0.13,0.06,0.0,0.0,0.0,0.13,oswald harris king,
-GER,1020,1,Elementary German,0.54,0.15,0.23,0.0,0.0,0.0,0.0,0.08,oswald harris king,
-GER,2020,1,Intermediate German,0.24,0.16,0.36,0.16,0.08,0.0,0.0,0.0,johannes schmidt,
-GER,3600,1,Ger Lit to 1832,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,
-HCG,9890,400,Pharmacogenomics,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,christopher farrell,
-HCG,9890,400,Pharmacogenomics,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,linda ward,
-HIST,1010,1,History of the United States,0.31,0.45,0.14,0.03,0.0,0.0,0.0,0.07,james brad jeffries,
-HIST,1010,2,History of the United States,0.8,0.1,0.0,0.07,0.0,0.0,0.0,0.03,joshua cas catalano,
-HIST,1240,1,Environmental History Survey,0.09,0.46,0.26,0.08,0.05,0.0,0.0,0.06,james brad jeffries,
-HIST,1720,1,The West and the World I,0.53,0.22,0.06,0.03,0.06,0.0,0.0,0.09,kathryn langenfeld,
-HIST,1730,1,The West and the World II,0.19,0.44,0.28,0.03,0.06,0.0,0.0,0.02,michael meng,
-HIST,1730,2,The West and the World II,0.33,0.34,0.18,0.08,0.04,0.0,0.0,0.04,james burns,
-HIST,1730,3,The West and the World II,0.29,0.36,0.32,0.0,0.0,0.0,0.0,0.04, alan grubb,
-HIST,2990,1,Historian's Craft,0.5,0.2,0.1,0.0,0.1,0.0,0.0,0.1,rachel anne moore,
-HIST,2990,2,Historian's Craft,0.59,0.06,0.06,0.0,0.24,0.0,0.0,0.06,michael silvestri,
-HIST,3000,1,History of Colonial America,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,lee brady wilson,
-HIST,3100,1,History of Religion in the US,0.4,0.33,0.07,0.07,0.0,0.0,0.0,0.13,elizabeth jemison,
-HIST,3110,1,African American Hist to 1877,0.27,0.55,0.05,0.0,0.09,0.0,0.0,0.05,abel bartley,
-HIST,3170,1,Hist of NativeAm Rel & Culture,0.15,0.38,0.31,0.08,0.08,0.0,0.0,0.0,james brad jeffries,
-HIST,3220,1,History of Technology,0.39,0.43,0.0,0.04,0.07,0.0,0.0,0.07,pamela mack,
-HIST,3260,1,Hist Am Transport,0.62,0.21,0.1,0.0,0.0,0.0,0.0,0.07, roger grant,
-HIST,3290,1,US Legal History Since 1890,0.29,0.58,0.04,0.0,0.0,0.0,0.0,0.08,maribel morey,
-HIST,3290,2,US Legal History Since 1890,0.3,0.4,0.1,0.0,0.0,0.0,0.0,0.2,maribel morey,
-HIST,3300,1,Hist of Mod China,0.21,0.39,0.18,0.04,0.04,0.0,0.0,0.14,edwin moise,
-HIST,3400,1,Latin America I,0.64,0.29,0.04,0.0,0.0,0.0,0.0,0.04,rachel anne moore,
-HIST,3510,1,Ancient Near East,0.31,0.38,0.25,0.0,0.0,0.0,0.0,0.06,steven grosby,
-HIST,3550,1,Roman World,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,kathryn langenfeld,
-HIST,3610,1,History of Britain to 1688,0.45,0.41,0.1,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,
-HIST,3670,1,Modern Ireland,0.56,0.3,0.07,0.0,0.0,0.0,0.0,0.07,michael silvestri,
-HIST,3890,1,Ben Robertson,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2, alan grubb,
-HIST,3890,2,History of Clemson House,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0, alan grubb,
-HIST,3900,1,Modern Military History,0.15,0.42,0.31,0.0,0.0,0.0,0.0,0.12,edwin moise,
-HIST,3980,1,American Military History,0.37,0.4,0.17,0.03,0.03,0.0,0.0,0.0,john andrew,
-HIST,4380,1,Studies African History,0.67,0.0,0.17,0.0,0.17,0.0,0.0,0.0,stephanie hassell,
-HIST,4380,1,Studies African History,0.67,0.0,0.17,0.0,0.17,0.0,0.0,0.0,james burns,
-HIST,4700,1,Medieval Christianity,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,
-HIST,4700,2,History of Florence,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,thomas kuehn,
-HIST,4710,1,History and Food,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1, alan grubb,
-HIST,4900,1,History of Disney Theme Parks,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
-HIST,4900,2,Family and Kinship,0.18,0.36,0.36,0.0,0.0,0.0,0.0,0.09,thomas kuehn,
-HIST,4930,1,AfricanAm Soc & Intellectual H,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,abel bartley,
-HIST,8810,1,Historiography,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,
-HLTH,2020,2,Introduction to Public Health,0.67,0.13,0.17,0.04,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2020,400,Introduction to Public Health,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2020,402,Introduction to Public Health,0.42,0.26,0.26,0.0,0.0,0.0,0.0,0.05,ralph stewart welsh,
-HLTH,2030,1,Health Care Sys,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2030,2,Health Care Sys,0.64,0.24,0.04,0.08,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2030,3,Health Care Sys,0.82,0.15,0.0,0.0,0.03,0.0,0.0,0.0,lee alden crandall,
-HLTH,2030,400,Health Care Sys,0.35,0.45,0.15,0.05,0.0,0.0,0.0,0.0,tanya lee staton,
-HLTH,2400,1,Deter of Hlth Behav,0.52,0.31,0.17,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2400,2,Deter of Hlth Behav,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
-HLTH,2400,400,Deter of Hlth Behav,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,2500,1,Health and Fitness,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,
-HLTH,2600,1,Medical Terminology & Comm,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,
-HLTH,2600,2,Medical Terminology & Comm,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,karen edwards,
-HLTH,2980,1,Human Health and Disease,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2980,2,Human Health and Disease,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,becky ann tugman,
-HLTH,2980,3,Human Health and Disease,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,3030,1,Public Health Comm,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,debra mitch charles,
-HLTH,3800,1,Epidemiology,0.43,0.43,0.09,0.0,0.0,0.0,0.0,0.06,deborah alma falta,
-HLTH,3980,1,Health Appraisal Skills,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,3980,2,Health Appraisal Skills,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4020,1,Princ Hlth Fitness,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,karen kemper,
-HLTH,4110,1,Hlth At-Risk Children & Fam,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,
-HLTH,4190,1,Health Sci Internship Prep Sem,0.63,0.33,0.05,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4200,1,Hlth Science Intern,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,kathleen meyer,
-HLTH,4310,1,Public & Environ Hlt,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,
-HLTH,4600,1,Health Info Systems,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,ronald gimbel,
-HLTH,4700,1,Global Health,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,micky rogers ward,
-HLTH,4780,1,Health Policy Ethics and Law,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,hugh donald spitler,
-HLTH,4790,1,Fin Mgmt & Hlth Budg,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,khoa dang truong,
-HLTH,4800,1,Comm Hlth Promotion,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,
-HLTH,4900,1,Res Eval St Pub Hlth,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,
-HLTH,4900,2,Res Eval St Pub Hlth,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,4900,3,Res Eval St Pub Hlth,0.48,0.43,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,
-HLTH,4980,1,Improving Pop Hlth,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,
-HLTH,4990,5,Aspire to Be Well CI,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,chloe caroli greene,
-HLTH,8310,1,Quantitative Analy in Hlth I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,lior mordec rennert,
-HON,2020,1,Motivation and Learning,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tyler watts,True
-HON,2030,2,Putin's World,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,olga anatol volkova,True
-HON,2060,1,Intro to Nanotechnology,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,True
-HON,2060,1,Intro to Nanotechnology,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,christophe kitchens,True
-HON,2060,2,Why We Eat What We Eat,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,True
-HON,2060,3,Great Problems in Math,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,neil calkin,True
-HON,2090,5,Crisis & Opportunity in Europe,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True
-HON,2200,2,Europe in the Age of Dictators,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,True
-HON,2200,3,Global Policy Process,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey allen fine,True
-HON,2210,1,Building Imaginary Worlds,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True
-HON,2210,3,Thinking About Love,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,dominic mastroianni,True
-HON,2210,4,Movies as Time Travel,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True
-HON,2210,5,"Migrants, Exiles, Refugees",0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,lucian ghita,True
-HORT,2020,1,Adobe Digital Design,0.81,0.06,0.03,0.0,0.03,0.0,0.0,0.06,janice ann lay,
-HORT,2110,1,Growing Spring Plnts,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,james emerson faust,
-HORT,4040,1,Plant Propagation,0.12,0.32,0.37,0.15,0.05,0.0,0.0,0.0,jeffrey adelberg,
-HORT,4050,1,Plant Propagation Techniq Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
-HORT,4080,4,CI: Hands on Water for Ag,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,sarah white,
-HORT,4080,4,CI: Hands on Water for Ag,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,lauren marie chance,
-HORT,4080,7,Sustain Landscpe Garden Design,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,ellen anita vincent,
-HORT,4090,1,Senior Capstone Course,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,
-HORT,4270,1,Urban Tree Care,0.0,0.3,0.2,0.1,0.0,0.0,0.0,0.4,robert polomski,
-HORT,4330,1,Weed Management,0.17,0.46,0.38,0.0,0.0,0.0,0.0,0.0,ted whitwell,
-HORT,4560,1,Vegetable Crops,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,
-HORT,6040,1,Plant Propagation,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,
-HRD,8250,400,Org Perf Improvement,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,angela danie carter,
-HRD,8470,400,Instru System Design,0.79,0.07,0.0,0.0,0.03,0.0,0.0,0.1,angela danie carter,
-HRD,8490,400,Eval of T&D/Hrd Prog,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,angela danie carter,
-HRD,8800,400,Research Concepts,0.75,0.13,0.0,0.0,0.04,0.0,0.0,0.08,cynthia sims,
-IE,2100,1,Des Analysis Wrk Sys,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,xiaoxia li,
-IE,3010,1,Systems Design I,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,amro nofa khasawneh,
-IE,3140,1,Seminar in Industrial Engr,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,scott jenning mason,
-IE,3600,1,Industrial Apps of Prob/Stat I,0.34,0.29,0.19,0.13,0.02,0.0,0.0,0.04,robert james riggs,
-IE,3610,1,Industrial App of Prob/Stat II,0.48,0.25,0.18,0.03,0.02,0.0,0.0,0.05,katherina jurewicz,
-IE,3800,1,Deterministic Operations Rsrch,0.28,0.47,0.17,0.04,0.0,0.0,0.03,0.0,sandra dun eksioglu,
-IE,3810,1,Probabilistic Operations Rsrch,0.2,0.5,0.23,0.04,0.0,0.0,0.0,0.04,amin khademi,
-IE,3840,1,Engr Econ Analysis,0.24,0.22,0.28,0.1,0.0,0.0,0.04,0.1,brian melloy,
-IE,3860,1,Production Planning & Control,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,xiaoxia li,
-IE,4040,15,Creative Inquiry Research,0.0,0.0,0.0,0.0,0.0,0.83,0.0,0.17,kevin taaffe,
-IE,4400,1,Decision Support Sys,0.36,0.48,0.03,0.0,0.09,0.0,0.0,0.03,mary elizabeth kurz,
-IE,4570,1,Transp/Logistic Engr,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,sandra dun eksioglu,
-IE,4610,1,Quality Engineering,0.29,0.27,0.33,0.07,0.0,0.0,0.0,0.03,byung rae cho,
-IE,4620,1,Six Sigma Quality,0.45,0.43,0.09,0.01,0.0,0.0,0.0,0.01,robert james riggs,
-IE,4650,1,Facilities Planning & Design,0.49,0.31,0.08,0.05,0.0,0.0,0.01,0.06,brian melloy,
-IE,4670,1,System Design II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,walter lawre garvin,
-IE,4670,1,System Design II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,
-IE,4670,2,System Design II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,walter lawre garvin,
-IE,4670,2,System Design II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,
-IE,4820,1,Systems Modeling,0.26,0.37,0.21,0.1,0.03,0.0,0.0,0.02,tugce isik,
-IE,4860,1,Scheduling,0.27,0.09,0.27,0.09,0.0,0.0,0.0,0.27,scott jenning mason,
-IE,4880,1,Human Factors Eng,0.54,0.39,0.02,0.02,0.0,0.0,0.0,0.04,laura miche stanley,
-IE,4910,1,Applied Bus. Princples for Eng,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,jeffery messer,
-IE,6620,1,Six Sigma Quality,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,
-IE,6860,1,Scheduling,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-IE,6910,1,Supply Chain/Logistics Model,0.61,0.36,0.0,0.0,0.0,0.0,0.0,0.04,william ferrell,
-IE,8050,1,Found Qual Engr,0.18,0.73,0.08,0.0,0.0,0.0,0.0,0.02,byung rae cho,
-IE,8520,1,Prescriptive Analytics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,
-IE,8540,1,SC & Logistics Modeling I,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,
-IE,8580,1,Case Study Supply Chn & Logist,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,scott jenning mason,
-INNO,4990,990,CEDC - Risk in Puerto Rico,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david vaughn,
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,lisa marie robinson,
-INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,troy nunamaker,
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,troy nunamaker,
-INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,caren kelley-hall,
-IPM,4010,1,Principles of I P M,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,carmen blubaugh,
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,james dougl bennett,
-IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,joshua leona hudson,
-IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,james dougl bennett,
-IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,joshua leona hudson,
-IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,meredith fan wilson,
-IS,2100,615,Sel Top International Studies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,meredith fan wilson,
-IS,2100,615,Sel Top International Studies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,joshua leona hudson,
-IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
-IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joshua leona hudson,
-IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,meredith fan wilson,
-ITAL,1010,1,Elementary Italian,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,
-ITAL,1020,1,Elementary Italian,0.45,0.27,0.18,0.0,0.0,0.0,0.0,0.09,julia schmidt,
-ITAL,1020,2,Elementary Italian,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,
-ITAL,1020,3,Elementary Italian,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-ITAL,2020,1,Intermediate Italian,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,julia schmidt,
-JAPN,1010,1,Elementary Japanese,0.4,0.2,0.2,0.0,0.0,0.0,0.0,0.2,saori suto,
-JAPN,1010,2,Elementary Japanese,0.41,0.29,0.18,0.06,0.0,0.0,0.0,0.06,saori suto,
-JAPN,1020,2,Elementary Japanese,0.45,0.14,0.32,0.05,0.0,0.0,0.0,0.05,satomi saito,
-JAPN,2020,1,Intermed Japanese,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,saori suto,
-JAPN,3060,1,Japanese Conversation & Comp,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,kumiko saito,
-JAPN,4170,2,Japanese Culture and Society,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,jae allegr takeuchi,
-JUST,2880,1,The Criminal Justice System,0.41,0.31,0.19,0.02,0.05,0.0,0.0,0.02,margaret tina britz,
-JUST,2890,1,Criminology,0.39,0.31,0.2,0.06,0.0,0.0,0.0,0.04,matthew jo costello,
-JUST,4280,1,Criminal Law,0.18,0.55,0.23,0.05,0.0,0.0,0.0,0.0,rhys hester,
-JUST,4910,1,Policing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,shelagh dorn,
-JUST,4930,1,Corrections,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,catherine el burton,
-JUST,4940,1,Organized Crime,0.33,0.33,0.19,0.08,0.06,0.0,0.0,0.0,margaret tina britz,
-JUST,4970,1,Criminal Justice Capstone,0.7,0.22,0.0,0.0,0.04,0.0,0.0,0.04,catherine el burton,
-JUST,4990,1,Criminal Courts,0.28,0.32,0.36,0.0,0.0,0.0,0.0,0.04,rhys hester,
-JUST,4990,2,Ethics in Criminal Justice,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,lance christ miller,
-LANG,2540,1,Introduction to World Cinemas,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,raquel anido,
-LANG,2540,2,Introduction to World Cinemas,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,
-LARC,1160,1,History of Landscape Arch,0.35,0.38,0.17,0.07,0.01,0.0,0.0,0.01,hala fouad nassar,
-LARC,1160,2,History of Landscape Arch,0.27,0.47,0.13,0.13,0.0,0.0,0.0,0.0,hala fouad nassar,
-LARC,1520,1,Basic Design II,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,maria debye counts,
-LARC,2550,1,Community Design Studio,0.74,0.16,0.05,0.0,0.0,0.0,0.05,0.0,matthew neal powers,
-LARC,3620,1,Design Implementation II,0.67,0.1,0.14,0.0,0.1,0.0,0.0,0.0,robert hewitt,
-LARC,4280,1,Computer-Aided Design,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,jueminsi wu,
-LARC,4280,1,Computer-Aided Design,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,xiaotong liu,
-LARC,4550,1,Landscape Arch Exit Project,0.45,0.45,0.0,0.09,0.0,0.0,0.0,0.0,mary padua,
-LARC,4720,1,South Carolina's Landscapes,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,
-LARC,4810,1,Professional Practice,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,christopher counts,
-LARC,4900,1,Urban Issues in Landscape Arch,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,
-LARC,4900,400,Arch History of Place,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,jason matthew white,
-LARC,4970,8,Planting Design,0.74,0.13,0.04,0.0,0.04,0.0,0.0,0.04,matthew neal powers,
-LARC,8520,1,Advanced Urban Design,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,robert hewitt,
-LAW,3220,1,Legal Env of Bus,0.27,0.33,0.36,0.0,0.0,0.0,0.0,0.04,kenneth toussaint,
-LAW,3220,2,Legal Env of Bus,0.16,0.53,0.29,0.0,0.0,0.0,0.0,0.02,kenneth toussaint,
-LAW,3220,3,Legal Env of Bus,0.16,0.41,0.36,0.02,0.0,0.0,0.0,0.05,kenneth toussaint,
-LAW,3220,4,Legal Env of Bus,0.31,0.49,0.13,0.04,0.0,0.0,0.0,0.02,edward ray claggett,
-LAW,3220,5,Legal Env of Bus,0.11,0.62,0.22,0.04,0.0,0.0,0.0,0.0,judson jahn,
-LAW,3220,6,Legal Env of Bus,0.24,0.51,0.24,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3220,7,Legal Env of Bus,0.24,0.47,0.27,0.02,0.0,0.0,0.0,0.0,judson jahn,
-LAW,3220,8,Legal Env of Bus,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,3220,9,Legal Env of Bus,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,christopher edwards,
-LAW,3220,10,Legal Env of Bus,0.27,0.47,0.2,0.04,0.0,0.0,0.0,0.02,john hine,
-LAW,3220,11,Legal Env of Bus,0.27,0.36,0.3,0.0,0.05,0.0,0.0,0.02,john hine,
-LAW,3220,401,Legal Env of Bus,0.45,0.31,0.17,0.03,0.0,0.0,0.0,0.03,virgini ward-vaughn,
-LAW,3220,402,Legal Env of Bus,0.32,0.37,0.12,0.03,0.03,0.0,0.0,0.12,virgini ward-vaughn,
-LAW,3220,403,Legal Env of Bus,0.25,0.41,0.21,0.02,0.07,0.0,0.0,0.04,virgini ward-vaughn,
-LAW,3220,404,Legal Env of Bus,0.25,0.4,0.21,0.07,0.0,0.0,0.02,0.05,virgini ward-vaughn,
-LAW,3220,601,Legal Env of Bus,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,edward ray claggett,
-LAW,3330,1,Real Estate Law,0.15,0.27,0.37,0.17,0.05,0.0,0.0,0.0,kenneth toussaint,
-LAW,4200,1,Int Business Law,0.2,0.55,0.2,0.0,0.0,0.0,0.0,0.05,frances edwards,
-LAW,4990,1,Selected Topics - Cyber Law,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,frances edwards,
-LAW,8480,1,Law Real Estate Prof,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,michael le brearley,
-LAW,8480,1,Law Real Estate Prof,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,james ivey warren,
-LS,1000,2,Fitness Leadership,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,jenny lynn rodgers,
-LS,1000,4,Introduction to Barre,0.74,0.11,0.05,0.0,0.0,0.0,0.0,0.11,diane moreno,
-LS,1000,5,Introduction to Barre,0.71,0.0,0.06,0.06,0.0,0.0,0.0,0.18,diane moreno,
-LS,1000,9,Intro to Salsa Dance,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,malik lewis baxter,
-LS,1000,19,Therapeutic Yoga,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
-LS,1000,21,Therapeutic Yoga,0.74,0.11,0.0,0.0,0.0,0.0,0.0,0.16,ranjanbala dil amin,
-LS,1000,23,Therapeutic Yoga,0.71,0.08,0.08,0.04,0.0,0.0,0.0,0.08,renee warren gahan,
-LS,1130,1,Wood Carving,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,louwanda jolley,
-LS,1410,2,Top Rope Climbing,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,thomas caldwell,
-LS,1560,13,Riflery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,herbert strickland,
-LS,1560,19,Riflery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,dominic cirocco,
-LS,1580,1,Archery,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,
-LS,1580,3,Archery,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1580,5,Archery,0.83,0.08,0.0,0.08,0.0,0.0,0.0,0.0,herbert strickland,
-LS,1650,1,Inland Kayak Touring,0.82,0.0,0.09,0.0,0.09,0.0,0.0,0.0,caitlin miche henry,
-LS,1650,5,Inland Kayak Touring,0.7,0.0,0.2,0.0,0.0,0.0,0.0,0.1,merry han armstrong,
-LS,1960,2,Intro to Billiards,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,broadus fleming,
-LS,2200,2,Shag,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,
-LS,2270,1,Intro to Swing Dance,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,paul hoke,
-LS,2270,4,Intro to Swing Dance,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,paul hoke,
-LS,2320,1,Core Training,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,diane moreno,
-LS,2320,3,Core Training,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,
-LS,2320,5,Core Training,0.83,0.08,0.0,0.0,0.04,0.0,0.0,0.04,diane moreno,
-LS,2350,1,Basic Yoga,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,
-LS,2350,2,Basic Yoga,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,kayla lee wardlaw,
-LS,2350,3,Basic Yoga,0.87,0.0,0.04,0.0,0.0,0.0,0.0,0.09,silica eliza larkin,
-LS,2350,5,Basic Yoga,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2360,1,Power/Ashtanga Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,silica eliza larkin,
-LS,2360,2,Power/Ashtanga Yoga,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,silica eliza larkin,
-LS,2380,4,Vinyasa Flow Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,
-LS,2420,1,Meditation and Relax,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,
-LS,2420,3,Meditation and Relax,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,
-LS,2420,4,Meditation and Relax,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,
-LS,2420,10,Meditation and Relax,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,
-LS,2420,11,Meditation and Relax,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,
-LS,2420,12,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,
-LS,2420,13,Meditation and Relax,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,
-LS,2450,2,Pilates,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,melanie ivey job,
-LS,2450,4,Pilates,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,diane moreno,
-LS,2450,5,Pilates,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,diane moreno,
-LS,2450,8,Pilates,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,melanie ivey job,
-LS,2510,1,Running & Jogging,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,corey dou brookover,
-MATH,1010,1,Essen Math for Informed Soc,0.5,0.25,0.13,0.13,0.0,0.0,0.0,0.0,marilyn reba,
-MATH,1010,2,Essen Math for Informed Soc,0.36,0.25,0.22,0.06,0.0,0.0,0.0,0.11,marilyn reba,
-MATH,1010,3,Essen Math for Informed Soc,0.47,0.35,0.09,0.09,0.0,0.0,0.0,0.0,seth selken,
-MATH,1010,4,Essen Math for Informed Soc,0.52,0.24,0.09,0.03,0.06,0.0,0.0,0.06,bryce pruitt,
-MATH,1020,1,Business Calculus I,0.18,0.24,0.28,0.13,0.08,0.0,0.0,0.08,randy davidson,
-MATH,1020,2,Business Calculus I,0.23,0.31,0.23,0.07,0.05,0.0,0.0,0.1,randy davidson,
-MATH,1020,3,Business Calculus I,0.18,0.35,0.12,0.18,0.12,0.0,0.0,0.06,zachary david espe,
-MATH,1020,4,Business Calculus I,0.12,0.27,0.24,0.21,0.12,0.0,0.0,0.03,andrew bellucco,
-MATH,1020,5,Business Calculus I,0.15,0.29,0.29,0.18,0.06,0.0,0.0,0.03,thowhida akther,
-MATH,1020,6,Business Calculus I,0.18,0.41,0.21,0.1,0.05,0.0,0.0,0.05,nathaniel nemire,
-MATH,1020,7,Business Calculus I,0.28,0.18,0.25,0.08,0.18,0.0,0.0,0.05,thowhida akther,
-MATH,1020,8,Business Calculus I,0.17,0.17,0.32,0.22,0.0,0.0,0.05,0.07,thowhida akther,
-MATH,1020,9,Business Calculus I,0.2,0.32,0.32,0.05,0.04,0.0,0.0,0.07,marion hanna,
-MATH,1020,10,Business Calculus I,0.22,0.24,0.17,0.12,0.15,0.0,0.0,0.1,shanshan jia,
-MATH,1020,11,Business Calculus I,0.35,0.33,0.25,0.03,0.05,0.0,0.0,0.0,cameron arnold,
-MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.85,0.0,0.15,nathan fontes,
-MATH,1060,1,Calculus of One Variable I,0.04,0.14,0.39,0.14,0.21,0.0,0.0,0.09,judith cottingham,
-MATH,1060,2,Calculus of One Variable I,0.08,0.26,0.34,0.13,0.18,0.0,0.0,0.0,catherine ma kenyon,
-MATH,1060,3,Calculus of One Variable I,0.06,0.17,0.39,0.11,0.19,0.0,0.0,0.08,steven taylo edalgo,
-MATH,1060,4,Calculus of One Variable I,0.09,0.3,0.33,0.09,0.09,0.0,0.0,0.09,marilyn reba,
-MATH,1060,5,Calculus of One Variable I,0.14,0.14,0.25,0.11,0.14,0.0,0.0,0.21,luther duncan,
-MATH,1070,1,Differen and Integral Calculus,0.4,0.4,0.15,0.0,0.0,0.0,0.0,0.05,donna simms,
-MATH,1070,2,Differen and Integral Calculus,0.18,0.36,0.36,0.05,0.03,0.0,0.0,0.03,donna simms,
-MATH,1070,3,Differen and Integral Calculus,0.18,0.38,0.26,0.09,0.06,0.0,0.0,0.03,stephen peele,
-MATH,1070,4,Differen and Integral Calculus,0.19,0.24,0.38,0.14,0.0,0.0,0.0,0.05,peter westerbaan,
-MATH,1070,5,Differen and Integral Calculus,0.13,0.47,0.25,0.03,0.13,0.0,0.0,0.0,scott scruggs,
-MATH,1070,6,Differen and Integral Calculus,0.07,0.48,0.43,0.02,0.0,0.0,0.0,0.0,stephen peele,
-MATH,1080,1,Calculus of One Variable II,0.38,0.35,0.2,0.0,0.0,0.0,0.0,0.08,stephen peele,
-MATH,1080,2,Calculus of One Variable II,0.43,0.23,0.2,0.09,0.03,0.0,0.0,0.03,blake anth splitter,
-MATH,1080,3,Calculus of One Variable II,0.18,0.23,0.36,0.05,0.14,0.0,0.0,0.05,timothy fra parrott,
-MATH,1080,4,Calculus of One Variable II,0.18,0.24,0.24,0.05,0.08,0.0,0.0,0.21,timothy fra parrott,
-MATH,1080,5,Calculus of One Variable II,0.36,0.28,0.26,0.0,0.05,0.0,0.0,0.05,hugh geller,
-MATH,1080,6,Calculus of One Variable II,0.13,0.37,0.3,0.05,0.0,0.0,0.09,0.06,timothy ch teitloff,
-MATH,1080,7,Calculus of One Variable II,0.14,0.3,0.28,0.02,0.09,0.0,0.0,0.18,timothy ch teitloff,
-MATH,1080,100,Calc of One Variable II (HON),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,timothy fra parrott,True
-MATH,1080,201,Calculus of One Variable II,0.12,0.12,0.35,0.15,0.03,0.0,0.0,0.24,timothy fra parrott,
-MATH,1080,202,Calculus of One Variable II,0.4,0.42,0.12,0.02,0.02,0.0,0.0,0.02,james edwar gossell,
-MATH,1080,203,Calculus of One Variable II,0.25,0.39,0.16,0.0,0.07,0.0,0.0,0.14,andrew walton green,
-MATH,1080,204,Calculus of One Variable II,0.1,0.46,0.34,0.0,0.0,0.0,0.0,0.1,sofya alekseeva,
-MATH,1080,205,Calculus of One Variable II,0.15,0.23,0.38,0.0,0.0,0.0,0.0,0.25,sofya alekseeva,
-MATH,1080,206,Calculus of One Variable II,0.13,0.38,0.23,0.05,0.03,0.0,0.0,0.2,sofya alekseeva,
-MATH,1160,1,Contemp Math for Elem Teach II,0.52,0.3,0.18,0.0,0.0,0.0,0.0,0.0,allison ke stoddard,
-MATH,1160,2,Contemp Math for Elem Teach II,0.57,0.37,0.04,0.0,0.0,0.0,0.0,0.02,allison ke stoddard,
-MATH,2060,1,Calculus of Several Variables,0.09,0.06,0.09,0.15,0.29,0.0,0.0,0.32,terri johnson,
-MATH,2060,2,Calculus of Several Variables,0.03,0.13,0.23,0.2,0.1,0.0,0.0,0.3,terri johnson,
-MATH,2060,3,Calculus of Several Variables,0.24,0.15,0.24,0.09,0.12,0.0,0.0,0.18,terri johnson,
-MATH,2060,4,Calculus of Several Variables,0.03,0.2,0.27,0.13,0.1,0.0,0.0,0.27,julie lassiter,
-MATH,2060,5,Calculus of Several Variables,0.0,0.18,0.24,0.09,0.3,0.0,0.0,0.18,julie lassiter,
-MATH,2060,6,Calculus of Several Variables,0.26,0.34,0.16,0.08,0.13,0.0,0.0,0.03,sanwar ahmad,
-MATH,2060,7,Calculus of Several Variables,0.32,0.32,0.19,0.08,0.08,0.0,0.0,0.0,allen anderso guest,
-MATH,2060,8,Calculus of Several Variables,0.23,0.29,0.19,0.1,0.13,0.0,0.0,0.06,allen anderso guest,
-MATH,2060,9,Calculus of Several Variables,0.24,0.35,0.29,0.03,0.06,0.0,0.0,0.03,allen anderso guest,
-MATH,2060,201,Calculus of Several Variables,0.52,0.39,0.06,0.0,0.0,0.0,0.0,0.03,camille zerfas,
-MATH,2070,1,Business Calculus II,0.45,0.21,0.21,0.05,0.0,0.0,0.0,0.08,jennifer mari hanna,
-MATH,2070,2,Business Calculus II,0.32,0.34,0.16,0.13,0.0,0.0,0.0,0.05,jennifer mari hanna,
-MATH,2070,3,Business Calculus II,0.45,0.24,0.18,0.03,0.05,0.0,0.0,0.05,xiaoyuan liu,
-MATH,2070,4,Business Calculus II,0.22,0.3,0.28,0.11,0.02,0.0,0.0,0.06,jennifer ray newton,
-MATH,2070,5,Business Calculus II,0.38,0.33,0.18,0.1,0.0,0.0,0.0,0.0,jennifer mari hanna,
-MATH,2070,6,Business Calculus II,0.38,0.44,0.13,0.05,0.0,0.0,0.0,0.0,jennifer mari hanna,
-MATH,2070,7,Business Calculus II,0.21,0.46,0.26,0.05,0.0,0.0,0.0,0.03,kayla doris javier,
-MATH,2070,8,Business Calculus II,0.31,0.19,0.28,0.22,0.0,0.0,0.0,0.0,travis alvarez,
-MATH,2070,9,Business Calculus II,0.26,0.32,0.18,0.13,0.0,0.0,0.03,0.08,molly adam honecker,
-MATH,2070,10,Business Calculus II,0.14,0.33,0.33,0.08,0.08,0.0,0.0,0.03,ebenezer eduafo,
-MATH,2070,11,Business Calculus II,0.32,0.32,0.29,0.05,0.0,0.0,0.0,0.03,aaron moose,
-MATH,2070,12,Business Calculus II,0.31,0.36,0.18,0.08,0.0,0.0,0.05,0.03,anna caro bachstein,
-MATH,2070,13,Business Calculus II,0.4,0.29,0.15,0.07,0.02,0.0,0.0,0.06,jennifer ray newton,
-MATH,2070,14,Business Calculus II,0.39,0.42,0.14,0.03,0.0,0.0,0.0,0.03,jennifer van dyken,
-MATH,2070,15,Business Calculus II,0.29,0.52,0.1,0.0,0.1,0.0,0.0,0.0,tony thanh nguyen,
-MATH,2080,1,Intro to Ordin Diff Equations,0.19,0.27,0.32,0.07,0.08,0.0,0.0,0.07,pye phyo aung,
-MATH,2080,2,Intro to Ordin Diff Equations,0.2,0.39,0.32,0.06,0.01,0.0,0.0,0.02,pye phyo aung,
-MATH,2080,3,Intro to Ordin Diff Equations,0.35,0.47,0.13,0.01,0.0,0.0,0.01,0.03,oleg yordanov,
-MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.5,0.23,0.03,0.01,0.0,0.0,0.01,oleg yordanov,
-MATH,2080,5,Intro to Ordin Diff Equations,0.28,0.35,0.24,0.06,0.03,0.0,0.0,0.04,jeong rock yoon,
-MATH,2080,6,Intro to Ordin Diff Equations,0.36,0.28,0.25,0.05,0.02,0.0,0.0,0.04,irina viktorova,
-MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.54,0.41,0.05,0.0,0.0,0.0,0.0,0.0,matthew macauley,True
-MATH,2160,1,Geometry for Elem Sch Teachers,0.79,0.08,0.0,0.04,0.0,0.0,0.0,0.08,nicole alai sinwell,
-MATH,2190,1,Introduction to Cryptography,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,felice manganiello,
-MATH,3020,1,Stat for Science & Engineering,0.25,0.48,0.15,0.0,0.03,0.0,0.0,0.1,xiaoqian sun,
-MATH,3020,2,Stat for Science & Engineering,0.78,0.15,0.08,0.0,0.0,0.0,0.0,0.0,jason alexande kurz,
-MATH,3020,3,Stat for Science & Engineering,0.68,0.23,0.03,0.03,0.0,0.0,0.0,0.05,haotian feng,
-MATH,3020,4,Stat for Science & Engineering,0.35,0.45,0.08,0.0,0.0,0.0,0.0,0.13,todd fenstermacher,
-MATH,3020,5,Stat for Science & Engineering,0.36,0.38,0.08,0.08,0.0,0.0,0.0,0.1, kamronnaher,
-MATH,3020,6,Stat for Science & Engineering,0.73,0.12,0.15,0.0,0.0,0.0,0.0,0.0,jayasekara merenchig,
-MATH,3020,7,Stat for Science & Engineering,0.49,0.32,0.15,0.02,0.0,0.0,0.0,0.02,ellen hepfe breazel,
-MATH,3020,8,Stat for Science & Engineering,0.51,0.32,0.02,0.05,0.0,0.0,0.0,0.1,rui gong,
-MATH,3110,1,Linear Algebra,0.15,0.44,0.26,0.09,0.0,0.0,0.0,0.06,michael adam burr,
-MATH,3110,2,Linear Algebra,0.28,0.25,0.31,0.11,0.0,0.0,0.03,0.03,michael adam burr,
-MATH,3110,4,Linear Algebra,0.29,0.29,0.15,0.24,0.03,0.0,0.0,0.0,mishko mitkovski,
-MATH,3110,5,Linear Algebra,0.46,0.31,0.13,0.03,0.03,0.0,0.0,0.04,nant ramiharimanana,
-MATH,3110,6,Linear Algebra,0.33,0.3,0.11,0.05,0.0,0.0,0.07,0.14,nant ramiharimanana,
-MATH,3110,8,Linear Algebra,0.37,0.26,0.29,0.05,0.03,0.0,0.0,0.0,hui xue,
-MATH,3110,200,Linear Algebra,0.25,0.25,0.31,0.13,0.0,0.0,0.0,0.06,svetlan poznanovikj,
-MATH,3190,1,Introduction to Proof,0.62,0.14,0.14,0.05,0.03,0.0,0.0,0.03,beth novick,
-MATH,3190,2,Introduction to Proof,0.62,0.22,0.11,0.0,0.03,0.0,0.0,0.03,beth novick,
-MATH,3600,1,Intermediate Math Computing,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,mark cawood,
-MATH,3600,2,Intermediate Math Computing,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mark cawood,
-MATH,3650,1,Numerical Mthds for Engineers,0.54,0.33,0.08,0.03,0.03,0.0,0.0,0.0,fei xue,
-MATH,3650,2,Numerical Mthds for Engineers,0.28,0.28,0.2,0.03,0.0,0.0,0.0,0.23,alistair bentley,
-MATH,3650,3,Numerical Mthds for Engineers,0.38,0.28,0.2,0.0,0.13,0.0,0.0,0.03,alistair bentley,
-MATH,3650,4,Numerical Mthds for Engineers,0.31,0.36,0.05,0.1,0.05,0.0,0.0,0.13,alistair bentley,
-MATH,4000,1,Theory of Probability,0.22,0.34,0.24,0.07,0.02,0.0,0.0,0.1,brian fralix,
-MATH,4030,1,Intro to Statistical Theory,0.71,0.07,0.07,0.0,0.0,0.0,0.0,0.14,qiong zhang,
-MATH,4070,1,Regress & Time-Series Analysis,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,robert lund,
-MATH,4100,1,Number Theory,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,hui xue,
-MATH,4120,1,Algebra I,0.24,0.38,0.17,0.0,0.1,0.0,0.0,0.1,james ba coykendall,
-MATH,4190,1,Discrete Math Structures I,0.67,0.28,0.05,0.0,0.0,0.0,0.0,0.0,beth novick,
-MATH,4190,2,Discrete Math Structures I,0.43,0.39,0.11,0.04,0.0,0.0,0.0,0.04,matthew macauley,
-MATH,4310,1,Theory of Interest,0.35,0.35,0.2,0.1,0.0,0.0,0.0,0.0, erwin walker,
-MATH,4320,1,Actuarial Science Seminar II,0.53,0.13,0.27,0.0,0.0,0.0,0.0,0.07, erwin walker,
-MATH,4340,1,Adv Engineering Mathematics,0.2,0.29,0.17,0.17,0.09,0.0,0.0,0.09,hyesuk lee,
-MATH,4340,2,Adv Engineering Mathematics,0.18,0.15,0.36,0.06,0.15,0.0,0.0,0.09,vincent ervin,
-MATH,4400,1,Linear Programming,0.49,0.31,0.09,0.03,0.03,0.0,0.0,0.06,yuyuan ouyang,
-MATH,4530,1,Advanced Calculus I,0.08,0.25,0.33,0.17,0.17,0.0,0.0,0.0,james peterson,
-MATH,4540,1,Advanced Calculus II,0.46,0.33,0.13,0.04,0.0,0.0,0.0,0.04,james peterson,
-MATH,4990,1,Creative Inq-Math Sciences,0.5,0.17,0.17,0.0,0.17,0.0,0.0,0.0,ellen hepfe breazel,
-MATH,6000,1,Theory of Probability,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,
-MATH,6340,1,Adv Engineering Mathematics,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,vincent ervin,
-MATH,8030,1,Stochastic Processes,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,xin liu,
-MATH,8040,1,Statistical Inference,0.55,0.41,0.0,0.0,0.0,0.0,0.0,0.05,colin gallagher,
-MATH,8050,1,Data Analysis,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,xiaoqian sun,
-MATH,8100,1,Mathematical Programming,0.27,0.36,0.27,0.0,0.09,0.0,0.0,0.0,margaret mar wiecek,
-MATH,8110,1,Nonlinear Programming,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,boshi yang,
-MATH,8130,1,Advanced Linear Programming,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,matthew saltzman,
-MATH,8210,1,Linear Analysis,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,martin joha schmoll,
-MATH,8220,1,Measure and Integration,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,benjamin jaye,
-MATH,8500,1,Computational Algebraic Geom,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,
-MATH,8530,1,Matrix Analysis,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,
-MATH,8570,1,Cryptography,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,xuhong gao,
-MATH,8600,1,Intro to Scientific Computing,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,leo rebholz,
-MATH,8660,1,Finite Element Method,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,qingshan chen,
-MBA,8030,1,Stat Analy of Bus Op,0.33,0.39,0.17,0.0,0.0,0.0,0.0,0.11,magda gabriela sava,
-MBA,8060,1,Operations Mgt,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MBA,8060,20,Operations Mgt,0.32,0.32,0.35,0.0,0.0,0.0,0.0,0.0, sridharan,
-MBA,8070,1,Financial Management,0.48,0.26,0.22,0.0,0.0,0.0,0.0,0.04,melvin stith,
-MBA,8070,2,Financial Management,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,melvin stith,
-MBA,8090,1,Org Beh & Hum Res Mg,0.55,0.41,0.0,0.0,0.0,0.0,0.0,0.05,thomas jo zagenczyk,
-MBA,8090,2,Org Beh & Hum Res Mg,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,
-MBA,8170,21,Bus Forecasting,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,
-MBA,8190,1,Intro to Acc and Fin,0.41,0.5,0.0,0.0,0.0,0.0,0.0,0.09,jeffrey mcmillan,
-MBA,8190,1,Intro to Acc and Fin,0.41,0.5,0.0,0.0,0.0,0.0,0.0,0.09,george bra lockhart,
-MBA,8290,3,Marketing Foundation,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,gary hunter,
-MBA,8330,1,Real Estate Investmt,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,
-MBA,8370,1,Legal Environ of Bus,0.3,0.59,0.07,0.0,0.0,0.0,0.0,0.04,judson jahn,
-MBA,8370,3,Legal Environ of Bus,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,judson jahn,
-MBA,8400,1,Entrepreneurship & Venture Mgt,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,prashant prabhu,
-MBA,8430,10,Entrepreneurial Accounting,0.67,0.26,0.07,0.0,0.0,0.0,0.0,0.0,gregory patr mcphee,
-MBA,8440,10,Entrepreneurial Law,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,judson jahn,
-MBA,8470,1,New Venture Creation,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,joseph renat gibson,
-MBA,8510,11,Bus Operations & Logistics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,george kenne morgan,
-MBA,8540,1,Managerial Accounting,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
-MBA,8540,2,Managerial Accounting,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
-MBA,8540,3,Managerial Accounting,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,
-MBA,8590,1,Mgr Decision Model,0.52,0.41,0.04,0.0,0.0,0.0,0.0,0.04,magda gabriela sava,
-MBA,8590,2,Mgr Decision Model,0.25,0.38,0.19,0.0,0.13,0.0,0.0,0.06,sara elizabet yoder,
-MBA,8600,2,Advanced Marketing Strategy,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph renat gibson,
-MBA,8610,1,Information Systems,0.68,0.3,0.0,0.0,0.0,0.0,0.0,0.02,william kettinger,
-MBA,8610,2,Information Systems,0.68,0.24,0.05,0.0,0.0,0.0,0.0,0.03,william kettinger,
-MBA,8620,1,Managerial Economics,0.68,0.25,0.0,0.0,0.0,0.0,0.0,0.07,ronald earl gregory,
-MBA,8620,2,Managerial Economics,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,
-MBA,8700,1,Strategic Management,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8700,2,Strategic Management,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,thomas robert uva,
-MBA,8720,1,Entrepr Finance,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8720,2,Entrepr Finance,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,
-MBA,8750,1,Enterprise Develpmnt,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,
-MBA,8800,1,MBA Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,gail depriest,
-MBA,8800,2,MBA Seminar,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,jamie lyn patterson,
-MBA,8990,1,Advanced Leadership,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,gail depriest,
-MBA,8990,3,Service Innovation,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,aleda marie roth,
-MBA,8990,5,International Investment Strgy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,
-MBA,8990,20,Analytics & Application,0.45,0.52,0.03,0.0,0.0,0.0,0.0,0.0,heshan sun,
-ME,2000,1,Sophomore Seminar,0.62,0.25,0.06,0.01,0.0,0.0,0.0,0.06,todd schweisinger,
-ME,2010,1,Statics & Dynamics,0.01,0.1,0.33,0.04,0.0,0.0,0.15,0.36,gang liu,
-ME,2010,2,Statics & Dynamics,0.03,0.23,0.27,0.1,0.04,0.0,0.0,0.32,paul joseph,
-ME,2030,1,Founda Th/Fl Syst,0.24,0.49,0.23,0.03,0.01,0.0,0.0,0.0,sandip dutta,
-ME,2030,2,Founda Th/Fl Syst,0.17,0.27,0.47,0.07,0.0,0.0,0.0,0.03,john saylor,
-ME,2030,3,Founda Th/Fl Syst,0.24,0.3,0.23,0.15,0.04,0.0,0.0,0.04,xiangchun xuan,
-ME,2030,4,Founda Th/Fl Syst,0.33,0.21,0.22,0.1,0.05,0.0,0.0,0.09,jay ochterbeck,
-ME,2040,1,Mechanics of Materials,0.3,0.41,0.29,0.0,0.0,0.0,0.0,0.0,gang li,
-ME,2040,2,Mechanics of Materials,0.28,0.47,0.22,0.02,0.0,0.0,0.0,0.02,garrett pataky,
-ME,2040,3,Mechanics of Materials,0.21,0.49,0.28,0.03,0.0,0.0,0.0,0.0,fadi abdeljawad,
-ME,2220,1,Mechanical Engineering Lab I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
-ME,2220,2,Mechanical Engineering Lab I,0.13,0.81,0.06,0.0,0.0,0.0,0.0,0.0,rachel anderson,
-ME,2220,3,Mechanical Engineering Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
-ME,2220,4,Mechanical Engineering Lab I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
-ME,2220,5,Mechanical Engineering Lab I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,rachel anderson,
-ME,2220,6,Mechanical Engineering Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
-ME,2220,7,Mechanical Engineering Lab I,0.38,0.56,0.0,0.0,0.0,0.0,0.0,0.06,rachel anderson,
-ME,2220,8,Mechanical Engineering Lab I,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.13,rachel anderson,
-ME,2220,10,Mechanical Engineering Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,rachel anderson,
-ME,2220,11,Mechanical Engineering Lab I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,
-ME,2220,13,Mechanical Engineering Lab I,0.25,0.5,0.13,0.0,0.06,0.0,0.0,0.06,rachel anderson,
-ME,2220,14,Mechanical Engineering Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,rachel anderson,
-ME,3030,1,Thermodynamics,0.64,0.18,0.1,0.0,0.04,0.0,0.0,0.04,pooya niksiar,
-ME,3030,2,Thermodynamics,0.23,0.32,0.3,0.04,0.07,0.0,0.0,0.05,richard miller,
-ME,3040,1,Heat Transfer,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,sandip dutta,
-ME,3040,2,Heat Transfer,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,3040,3,Heat Transfer,0.32,0.32,0.26,0.05,0.05,0.0,0.0,0.0,jay ochterbeck,
-ME,3050,1,Model/an Dy Syst,0.32,0.42,0.19,0.06,0.0,0.0,0.0,0.0,chengshi wang,
-ME,3050,2,Model/an Dy Syst,0.23,0.49,0.16,0.07,0.05,0.0,0.0,0.0,phanin tallapragada,
-ME,3050,3,Model/an Dy Syst,0.22,0.54,0.2,0.0,0.0,0.0,0.0,0.03,douglas scott byrd,
-ME,3060,1,Fund Machine Design,0.34,0.51,0.14,0.0,0.01,0.0,0.0,0.0,james allen righter,
-ME,3060,2,Fund Machine Design,0.24,0.45,0.24,0.03,0.03,0.0,0.0,0.03,james allen righter,
-ME,3070,1,Found of Mechanical Systems,0.43,0.34,0.2,0.0,0.0,0.0,0.0,0.02,jorge iva rodriguez,
-ME,3070,3,Found of Mechanical Systems,0.59,0.3,0.04,0.04,0.04,0.0,0.0,0.0,pooya niksiar,
-ME,3080,1,Fluid Mechanics,0.17,0.48,0.27,0.02,0.0,0.0,0.0,0.06,chenning tong,
-ME,3080,2,Fluid Mechanics,0.47,0.36,0.13,0.02,0.0,0.0,0.0,0.02,yiqiang han,
-ME,3100,1,Thermo/Heat Transfer,0.12,0.35,0.35,0.1,0.06,0.0,0.0,0.04,yiqiang han,
-ME,3120,1,Manuf Processes,0.25,0.72,0.03,0.0,0.0,0.0,0.0,0.0,hong seok choi,
-ME,3330,1,Mechanical Engineering Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,2,Mechanical Engineering Lab II,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,3,Mechanical Engineering Lab II,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,5,Mechanical Engineering Lab II,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,6,Mechanical Engineering Lab II,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,gang liu,
-ME,3330,7,Mechanical Engineering Lab II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,3330,9,Mechanical Engineering Lab II,0.31,0.38,0.23,0.0,0.08,0.0,0.0,0.0,gang liu,
-ME,3330,10,Mechanical Engineering Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,4000,1,Senior Seminar,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,atul gajanan kelkar,
-ME,4010,1,Mech Engr Design,0.28,0.49,0.18,0.04,0.01,0.0,0.01,0.0,joshua summers,
-ME,4010,1,Mech Engr Design,0.28,0.49,0.18,0.04,0.01,0.0,0.01,0.0,cameron turner,
-ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
-ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,huijuan zhao,
-ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yiqiang han,
-ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xin zhao,
-ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,sandip dutta,
-ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,douglas scott byrd,
-ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,jorge iva rodriguez,
-ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sandip dutta,
-ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,
-ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,gang liu,
-ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,
-ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,john saylor,
-ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,joshua bostwick,
-ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,richard figliola,
-ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,77,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4020,77,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,
-ME,4030,1,Control Dynamic Systems,0.23,0.3,0.34,0.13,0.0,0.0,0.0,0.0,mohammad naghnaeian,
-ME,4030,2,Control Dynamic Systems,0.23,0.46,0.23,0.04,0.0,0.0,0.0,0.04,suyi li,
-ME,4170,1,Mechatronic Sys Design,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,4180,1,F E A in M E Design,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,oliver myers,
-ME,4220,2,Design Gas Turbines,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,abhijit som,
-ME,4230,2,Intro Aerodynamics,0.13,0.42,0.42,0.03,0.0,0.0,0.0,0.0,richard figliola,
-ME,4260,1,Nuclear Energy,0.37,0.39,0.11,0.08,0.03,0.0,0.0,0.03,richard watkins,
-ME,4300,1,Mech Comp Materials,0.23,0.73,0.0,0.0,0.0,0.0,0.0,0.04,gang li,
-ME,4340,1,Cardiovascular Biomechanics,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,ethan kung,
-ME,4440,1,Mechanical Engineering Lab III,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4440,5,Mechanical Engineering Lab III,0.13,0.81,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4440,10,Mechanical Engineering Lab III,0.06,0.81,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4440,12,Mechanical Engineering Lab III,0.13,0.87,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,
-ME,4930,10,Sel Topics ME (Nonlinear Dyn),0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,joshua bostwick,
-ME,4930,30,Sel Topics ME--Sustainability,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,
-ME,4930,39,Sel Topics ME (Solar Energy),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,daniel fant,
-ME,6170,1,Mechatronics System Design,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,john wagner,
-ME,6230,1,Intro Aerodynamics,0.4,0.2,0.4,0.0,0.0,0.0,0.0,0.0,richard figliola,
-ME,6230,2,Intro Aerodynamics,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,richard figliola,
-ME,6300,1,Mech Comp Materials,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,gang li,
-ME,6340,1,Cardiovascular Biomechanics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,
-ME,6930,2,Sel Topics ME (Microfab),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,
-ME,6930,10,Sel Topics ME-Nonlinear Dyn,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,joshua bostwick,
-ME,8200,1,Mod Cont Engr,0.3,0.63,0.07,0.0,0.0,0.0,0.0,0.0,yue wang,
-ME,8310,1,Convective Ht Trans,0.33,0.47,0.2,0.0,0.0,0.0,0.0,0.0,xin zhao,
-ME,8370,1,Theory of Elast I,0.12,0.32,0.44,0.0,0.08,0.0,0.0,0.04,huijuan zhao,
-ME,8610,1,Matl Sel Engr Design,0.68,0.3,0.02,0.0,0.0,0.0,0.0,0.0,garrett pataky,
-ME,8930,27,Sel Topics ME-Adv Estimation,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,
-ME,8930,28,Sel Topics ME: Agent Based Opt,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,cameron turner,
-ME,8930,28,Sel Topics ME: Agent Based Opt,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,joshua summers,
-MGT,2010,1,Principles of Management,0.37,0.39,0.18,0.03,0.0,0.0,0.02,0.03,katherine clark,
-MGT,2010,2,Principles of Management,0.44,0.37,0.17,0.02,0.0,0.0,0.0,0.01,tina robbins,
-MGT,2010,7,Principles of Management,0.18,0.62,0.15,0.03,0.03,0.0,0.0,0.0,christopher mann,
-MGT,2010,8,Principles of Management,0.39,0.45,0.13,0.03,0.0,0.0,0.0,0.0,christopher mann,
-MGT,2010,10,Principles of Management,0.31,0.28,0.28,0.08,0.0,0.0,0.0,0.05,ashley will parnell,
-MGT,2010,11,Principles of Management,0.18,0.34,0.34,0.08,0.0,0.0,0.0,0.05,ashley will parnell,
-MGT,2180,1,Management PC Applications,0.51,0.36,0.09,0.01,0.01,0.0,0.0,0.02,ryan toole,
-MGT,2180,2,Management PC Applications,0.27,0.59,0.14,0.0,0.0,0.0,0.0,0.0,ryan toole,
-MGT,2970,1,Deloitte Consulting CI,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ryan toole,
-MGT,3070,1,Human Resource Management,0.28,0.65,0.08,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,2,Human Resource Management,0.5,0.38,0.1,0.03,0.0,0.0,0.0,0.0,michael cole,
-MGT,3070,3,Human Resource Management,0.3,0.51,0.16,0.0,0.0,0.0,0.0,0.03,kristin dam scott,
-MGT,3070,4,Human Resource Management,0.3,0.55,0.1,0.0,0.03,0.0,0.0,0.03,leonard jos spooner,
-MGT,3070,5,Human Resource Management,0.63,0.33,0.03,0.0,0.03,0.0,0.0,0.0,michael cole,
-MGT,3070,6,Human Resource Management,0.43,0.46,0.08,0.0,0.03,0.0,0.0,0.0,leonard jos spooner,
-MGT,3070,8,Human Resource Management,0.32,0.49,0.17,0.0,0.0,0.0,0.0,0.02,priscilla harrison,
-MGT,3100,2,Intermed Business Statistics,0.51,0.26,0.18,0.0,0.0,0.0,0.0,0.05,jeromy blake snider,
-MGT,3100,3,Intermed Business Statistics,0.49,0.21,0.13,0.08,0.03,0.0,0.0,0.08,daniel nielubowicz,
-MGT,3100,4,Intermed Business Statistics,0.44,0.28,0.21,0.0,0.0,0.0,0.0,0.07,iaroslava dutchak,
-MGT,3100,5,Intermed Business Statistics,0.5,0.17,0.12,0.02,0.12,0.0,0.0,0.07,philip roth,
-MGT,3100,6,Intermed Business Statistics,0.55,0.24,0.07,0.01,0.04,0.0,0.0,0.07,benjamin chri wiles,
-MGT,3100,7,Intermed Business Statistics,0.4,0.35,0.2,0.03,0.0,0.0,0.0,0.03,mustafa serk akturk,
-MGT,3100,8,Intermed Business Statistics,0.36,0.36,0.28,0.0,0.0,0.0,0.0,0.0,mustafa serk akturk,
-MGT,3100,10,Intermed Business Statistics,0.47,0.24,0.13,0.07,0.02,0.0,0.0,0.07,iaroslava dutchak,
-MGT,3100,11,Intermed Business Statistics,0.44,0.26,0.23,0.03,0.03,0.0,0.0,0.03,daniel allan detoma,
-MGT,3120,1,Decision Models for Management,0.16,0.31,0.3,0.05,0.13,0.0,0.0,0.06,sara elizabet yoder,
-MGT,3120,2,Decision Models for Management,0.21,0.25,0.34,0.07,0.06,0.0,0.0,0.06,sara elizabet yoder,
-MGT,3120,4,Decision Models for Management,0.29,0.29,0.29,0.03,0.06,0.0,0.0,0.05,james turner,
-MGT,3170,1,Logistics Mgmt,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,ahmet colak,
-MGT,3180,1,Mgt of Info Systems,0.25,0.55,0.18,0.0,0.0,0.0,0.0,0.03,russell purvis,
-MGT,3180,2,Mgt of Info Systems,0.49,0.23,0.26,0.0,0.0,0.0,0.0,0.03,marten risius,
-MGT,3180,3,Mgt of Info Systems,0.69,0.22,0.09,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,
-MGT,3180,4,Mgt of Info Systems,0.23,0.7,0.08,0.0,0.0,0.0,0.0,0.0,wenxi pu,
-MGT,3180,5,Mgt of Info Systems,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,daniel aaron pienta,
-MGT,3500,1,Intro to Business Analytics,0.58,0.26,0.13,0.03,0.0,0.0,0.0,0.0,hongki kim,
-MGT,3510,1,Business Analytics & Problems,0.4,0.4,0.17,0.03,0.0,0.0,0.0,0.0,daniel allan detoma,
-MGT,3900,1,Operations Management,0.3,0.48,0.13,0.05,0.03,0.0,0.0,0.03,ying zhang,
-MGT,3900,2,Operations Management,0.37,0.44,0.15,0.0,0.05,0.0,0.0,0.0,ying zhang,
-MGT,3900,3,Operations Management,0.1,0.43,0.42,0.0,0.0,0.0,0.0,0.04, sridharan,
-MGT,3900,4,Operations Management,0.15,0.33,0.36,0.13,0.0,0.0,0.0,0.03,zachary mo leffakis,
-MGT,3900,6,Operations Management,0.57,0.4,0.02,0.0,0.0,0.0,0.0,0.0,maneeshre ajjuguttu,
-MGT,4000,1,Mgt of Organizational Behavior,0.78,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4000,2,Mgt of Organizational Behavior,0.26,0.38,0.33,0.02,0.02,0.0,0.0,0.0,thomas jo zagenczyk,
-MGT,4000,3,Mgt of Organizational Behavior,0.23,0.33,0.26,0.08,0.08,0.0,0.0,0.03,philip roth,
-MGT,4000,4,Mgt of Organizational Behavior,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,
-MGT,4020,1,Ops Pln and Ctl,0.13,0.47,0.4,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4080,1,Lean Operations,0.21,0.51,0.26,0.03,0.0,0.0,0.0,0.0,zachary mo leffakis,
-MGT,4110,1,Project Management,0.15,0.51,0.28,0.0,0.03,0.0,0.0,0.03,russell purvis,
-MGT,4120,1,Supplier Management,0.59,0.34,0.03,0.0,0.0,0.0,0.0,0.03,ahmet colak,
-MGT,4150,1,Business Strategy,0.15,0.52,0.33,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,2,Business Strategy,0.07,0.67,0.26,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,3,Business Strategy,0.33,0.59,0.09,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,
-MGT,4150,4,Business Strategy,0.46,0.48,0.07,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,
-MGT,4150,5,Business Strategy,0.26,0.61,0.13,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,6,Business Strategy,0.48,0.43,0.1,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,
-MGT,4150,7,Business Strategy,0.07,0.57,0.35,0.02,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,8,Business Strategy,0.26,0.7,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,11,Business Strategy,0.1,0.42,0.42,0.06,0.0,0.0,0.0,0.0,wayne stewart,
-MGT,4150,14,Business Strategy,0.15,0.39,0.45,0.0,0.0,0.0,0.0,0.0,james liddle,
-MGT,4150,15,Business Strategy,0.16,0.5,0.25,0.09,0.0,0.0,0.0,0.0,wayne stewart,
-MGT,4160,1,Special Topics Hr,0.23,0.53,0.23,0.03,0.0,0.0,0.0,0.0,kristin dam scott,
-MGT,4230,1,Intern Bus Mgt,0.11,0.53,0.31,0.04,0.0,0.0,0.0,0.0,janis miller,
-MGT,4230,2,Intern Bus Mgt,0.11,0.33,0.47,0.04,0.04,0.0,0.0,0.0,janis miller,
-MGT,4230,3,Intern Bus Mgt,0.13,0.16,0.64,0.04,0.0,0.0,0.0,0.02,wayne stewart,
-MGT,4230,4,Intern Bus Mgt,0.27,0.09,0.57,0.02,0.02,0.0,0.0,0.02,wayne stewart,
-MGT,4230,600,Intern Bus Mgt,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0, sridharan,
-MGT,4240,1,Global Supply Chain Management,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,yann ferrand,
-MGT,4270,1,Managing Improvement,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,
-MGT,4310,1,Emp Rights & Resp,0.15,0.55,0.3,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,
-MGT,4350,1,Pers Interviewing,0.35,0.43,0.18,0.03,0.03,0.0,0.0,0.0,philip roth,
-MGT,4520,1,Business Analysis,0.37,0.11,0.52,0.0,0.0,0.0,0.0,0.0,marten risius,
-MGT,4540,1,Systems Implement,0.43,0.39,0.13,0.04,0.0,0.0,0.0,0.0,hongki kim,
-MGT,4550,1,Emerging I T Trends,0.38,0.5,0.08,0.0,0.0,0.0,0.0,0.04,john frederic tripp,
-MGT,8120,1,Supply Chain Mgt,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,yann ferrand,
-MICR,3050,1,General Microbiology,0.47,0.37,0.11,0.04,0.0,0.0,0.0,0.01,krista barr rudolph,
-MICR,3050,2,General Microbiology,0.39,0.43,0.16,0.01,0.0,0.0,0.0,0.01,kristi ja whitehead,
-MICR,3050,3,General Microbiology,0.68,0.3,0.02,0.0,0.0,0.0,0.0,0.0,krista barr rudolph,
-MICR,4000,1,Public Health Micro,0.6,0.24,0.12,0.04,0.0,0.0,0.0,0.01,kristi ja whitehead,
-MICR,4000,2,Public Health Micro (HON),0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,True
-MICR,4070,1,Food and Dairy Micro,0.27,0.55,0.12,0.04,0.0,0.0,0.0,0.01,xiuping jiang,
-MICR,4110,1,Pathogenic Bact,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kear milhous,
-MICR,4120,1,Bacterial Physiology,0.23,0.35,0.27,0.08,0.05,0.0,0.0,0.02,harry kurtz,
-MICR,4130,1,Industrial Micro,0.42,0.49,0.06,0.02,0.0,0.0,0.0,0.01,tzuen-rong je tzeng,
-MICR,4140,1,Basic Immunology,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,charles rice,
-MICR,4170,1,Cancer and Aging,0.61,0.27,0.1,0.02,0.0,0.0,0.0,0.0,wen chen,
-MICR,4190,1,Intro to Molecular Medicine,0.54,0.27,0.08,0.08,0.0,0.0,0.0,0.04,zhicheng dou,
-MICR,4500,1,Advanced Microbiology I,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4500,2,Advanced Microbiology I,0.2,0.67,0.07,0.07,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4500,3,Advanced Microbiology I,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4500,4,Advanced Microbiology I,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,harry kurtz,
-MICR,4520,1,Advanced Microbiology III,0.8,0.05,0.15,0.0,0.0,0.0,0.0,0.0,min cao,
-MICR,4520,2,Advanced Microbiology III,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,min cao,
-MICR,4520,3,Advanced Microbiology III,0.47,0.32,0.11,0.11,0.0,0.0,0.0,0.0,min cao,
-MICR,4930,5,Sen Sem: Host-Microbe Interact,0.56,0.31,0.06,0.06,0.0,0.0,0.0,0.0,kristi ja whitehead,
-MICR,4940,1,CI: InterKingdom Communication,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,min cao,
-MICR,4940,26,CI: Parasite Biophysics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,joshua alper,
-MKT,3010,1,Principles of Marketing,0.3,0.33,0.25,0.08,0.03,0.0,0.0,0.01,carter wil mcelveen,
-MKT,3010,2,Principles of Marketing,0.32,0.29,0.34,0.03,0.0,0.0,0.01,0.01,carter wil mcelveen,
-MKT,3010,3,Principles of Marketing,0.35,0.34,0.2,0.08,0.01,0.0,0.0,0.03,amanda cooper fine,
-MKT,3010,4,Principles of Marketing,0.29,0.43,0.22,0.06,0.0,0.0,0.0,0.01,amanda cooper fine,
-MKT,3010,5,Principles of Marketing,0.29,0.43,0.18,0.06,0.01,0.0,0.0,0.03,james gaubert,
-MKT,3010,7,Principles of Marketing,0.74,0.2,0.04,0.01,0.0,0.0,0.0,0.01,patricia knowles,
-MKT,3020,1,Consumer Behavior,0.33,0.59,0.05,0.0,0.03,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,2,Consumer Behavior,0.49,0.41,0.1,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,
-MKT,3020,3,Consumer Behavior,0.35,0.49,0.14,0.0,0.0,0.0,0.0,0.02,anastasia thyroff,
-MKT,3020,4,Consumer Behavior,0.41,0.43,0.17,0.0,0.0,0.0,0.0,0.0,anastasia thyroff,
-MKT,3020,5,Consumer Behavior,0.6,0.37,0.04,0.0,0.0,0.0,0.0,0.0,patricia knowles,
-MKT,3220,1,Social Media Marketing,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michele melt cauley,
-MKT,3220,2,Social Media Marketing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michele melt cauley,
-MKT,3310,1,Marketing Metrics & Analytics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,
-MKT,3310,2,Marketing Metrics & Analytics,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,
-MKT,3310,3,Marketing Metrics & Analytics,0.21,0.41,0.26,0.12,0.0,0.0,0.0,0.0,peter weathers,
-MKT,3310,4,Marketing Metrics & Analytics,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,3310,5,Marketing Metrics & Analytics,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,3980,1,CI:Sales Experiential,0.93,0.0,0.04,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,
-MKT,4200,1,Professional Selling,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,jesse moore,
-MKT,4200,2,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,
-MKT,4200,3,Professional Selling,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4200,4,Professional Selling,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,kevin scott chase,
-MKT,4200,5,Professional Selling,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,kevin scott chase,
-MKT,4230,1,Promotional Strategy,0.82,0.16,0.02,0.0,0.0,0.0,0.0,0.0,michele melt cauley,
-MKT,4230,2,Promotional Strategy,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,michele melt cauley,
-MKT,4240,1,Sales Management,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,ryan mullins,
-MKT,4270,1,International Marketing,0.36,0.53,0.06,0.03,0.03,0.0,0.0,0.0,thomas poehlman,
-MKT,4270,2,International Marketing,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4270,3,International Marketing,0.84,0.13,0.02,0.0,0.0,0.0,0.0,0.0,xianyong wang,
-MKT,4270,4,International Marketing,0.47,0.38,0.1,0.03,0.0,0.0,0.0,0.03,patricia knowles,
-MKT,4280,1,Services Marketing,0.55,0.39,0.05,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4280,2,Services Marketing,0.53,0.45,0.03,0.0,0.0,0.0,0.0,0.0,james gaubert,
-MKT,4310,1,Marketing Research,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,michae giebelhausen,
-MKT,4310,2,Marketing Research,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,michae giebelhausen,
-MKT,4310,3,Marketing Research,0.4,0.3,0.23,0.0,0.0,0.0,0.0,0.07,william kilbourne,
-MKT,4310,4,Marketing Research,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4310,5,Marketing Research,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,
-MKT,4330,1,Sport Mkt Strategy,0.46,0.42,0.12,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,
-MKT,4450,1,Macromarketing,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,william kilbourne,
-MKT,4500,1,Strategic Mktg Mgt,0.13,0.45,0.42,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,2,Strategic Mktg Mgt,0.13,0.59,0.28,0.0,0.0,0.0,0.0,0.0,mary anne raymond,
-MKT,4500,3,Strategic Mktg Mgt,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,4500,4,Strategic Mktg Mgt,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,
-MKT,4500,5,Strategic Mktg Mgt,0.24,0.42,0.3,0.03,0.0,0.0,0.0,0.0,michael dorsch,
-MKT,8620,1,Quant Methods in Mkt,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,
-MKT,8650,1,Seminar in Mkt Mgmt,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,michael dorsch,
-MKT,8660,1,International Marketing,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,aaron javron hills,
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,andre kareeth bland,
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jonathan jacoba,
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,christopher bland,
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,brian james gural,
-ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,kenneth to crawford,
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,thomas michae burke,
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,christopher bland,
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
-ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas michae burke,
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,
-ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,matthew davi jordan,
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,andre kareeth bland,
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,kenneth to crawford,
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,vincent john presto,
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,thomas michae burke,
-ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,christopher bland,
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,justin rober merhar,
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,spencer blak harmon,
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,
-ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,justin rober merhar,
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,
-ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,spencer blak harmon,
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,
-ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,
-MSE,2100,1,Intro to Materials Science,0.33,0.27,0.25,0.03,0.08,0.0,0.0,0.03,rakhee pani,
-MSE,2100,3,Intro to Materials Science,0.33,0.3,0.16,0.07,0.08,0.0,0.0,0.05,kai he,
-MSE,2100,4,Intro to Materials Science,0.53,0.25,0.08,0.04,0.04,0.0,0.0,0.05,rakhee pani,
-MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,
-MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,
-MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,
-MSE,3100,1,Intro to Metals and Ceramics,0.63,0.22,0.11,0.0,0.0,0.0,0.04,0.0,jianhua tong,
-MSE,3190,1,Materials Proc I,0.48,0.32,0.2,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,
-MSE,3190,1,Materials Proc I,0.48,0.32,0.2,0.0,0.0,0.0,0.0,0.0,rakhee pani,
-MSE,3190,2,Materials Proc I,0.31,0.31,0.17,0.07,0.03,0.0,0.0,0.1,rajendra kum bordia,
-MSE,3190,2,Materials Proc I,0.31,0.31,0.17,0.07,0.03,0.0,0.0,0.1,rakhee pani,
-MSE,3260,1,Thermo of Materials,0.26,0.43,0.26,0.0,0.0,0.0,0.0,0.06,fei peng,
-MSE,3260,2,Thermo of Materials,0.26,0.26,0.22,0.15,0.04,0.0,0.0,0.07,fei peng,
-MSE,3270,1,Transport Phenomena,0.17,0.35,0.39,0.0,0.0,0.0,0.04,0.04,ulf daniel schiller,
-MSE,3610,2,Proc of Metals & Composites,0.41,0.38,0.14,0.03,0.0,0.0,0.0,0.03,marian kennedy,
-MSE,4020,1,Fundamentals of Solid State,0.5,0.16,0.28,0.06,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,4070,1,Senior Capstone Design,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,
-MSE,4150,1,Polymer Sc Engr,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,olin mefford,
-MSE,4220,1,Mech Behavior of Mat,0.61,0.32,0.05,0.0,0.02,0.0,0.0,0.0,vincent yves blouin,
-MSE,4240,1,Optical Materials,0.8,0.07,0.1,0.03,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,4330,2,Comb Sys & Env Emiss,0.74,0.16,0.06,0.0,0.0,0.0,0.0,0.03,john sanders,
-MSE,4450,1,Practice of Mat Engr,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,marek urban,
-MSE,4910,1,Undergraduate Research,0.91,0.03,0.0,0.0,0.03,0.0,0.0,0.03,rajendra kum bordia,
-MSE,6020,1,Solid State Material,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,
-MSE,8250,2,Solid State Mtl Sci,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,stephen foulger,
-MSE,8520,2,Polymer Science II,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,igor luzinov,
-MUSC,1110,5,Beginning Class Guitar,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david stevenson,
-MUSC,1110,6,Beginning Class Guitar,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,david stevenson,
-MUSC,1430,1,Aural Skills I,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,david conley,
-MUSC,1510,2,Applied Music,0.63,0.19,0.0,0.0,0.0,0.0,0.0,0.19,jonathan edwa doyel,
-MUSC,1510,19,Applied Music,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,monty craig,
-MUSC,1520,1,Applied Music,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,lisa sain odom,
-MUSC,1520,2,Applied Music,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edwa doyel,
-MUSC,1520,10,Applied Music,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,paul buyer,
-MUSC,1800,1,Intro to Music Tech,0.3,0.6,0.0,0.0,0.1,0.0,0.0,0.0,hamilton altstatt,
-MUSC,1950,1,Creative Inquiry in Music I,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,linda dzuris,
-MUSC,2100,2,Music in the Western World,0.52,0.26,0.13,0.03,0.0,0.0,0.0,0.06,lisa sain odom,
-MUSC,2100,4,Music in the Western World,0.48,0.26,0.16,0.03,0.03,0.0,0.0,0.03,rhea beth jacobus,
-MUSC,2100,5,Music in the Western World,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,
-MUSC,2100,6,Music in the Western World,0.5,0.34,0.09,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,
-MUSC,2100,7,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,evan michael jacobi,
-MUSC,2100,9,Music in the Western World,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,lea kibler,
-MUSC,2100,10,Music in the Western World,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,linda dzuris,
-MUSC,2510,2,Applied Music,0.75,0.0,0.0,0.0,0.25,0.0,0.0,0.0,jonathan edwa doyel,
-MUSC,2520,2,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edwa doyel,
-MUSC,3090,1,Surv of Broadway II,0.91,0.0,0.0,0.09,0.0,0.0,0.0,0.0,lisa sain odom,
-MUSC,3110,1,History of American Music,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,eric lapin,
-MUSC,3170,1,Hist of Country Mus,0.88,0.09,0.0,0.03,0.0,0.0,0.0,0.0,ned hosler,
-MUSC,3180,1,Hist of Audio Tech,0.39,0.22,0.28,0.06,0.0,0.0,0.0,0.06,bruce allen whisler,
-MUSC,3310,1,Pep Band,0.95,0.02,0.02,0.02,0.0,0.0,0.0,0.0,timothy ra hurlburt,
-MUSC,3310,2,Pep Band,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,
-MUSC,3640,1,Concert Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,timothy ra hurlburt,
-MUSC,3710,1,Women's Chorus,0.82,0.16,0.0,0.0,0.0,0.0,0.0,0.02,jerrad fenske,
-MUSC,3720,1,Men's Chorus,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,
-MUSC,4160,1,Mus Hist Since 1750,0.39,0.26,0.23,0.06,0.0,0.0,0.0,0.06,linda li-bleuel,
-MUSC,4300,1,Conducting,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mark spede,
-NPL,3000,1,Nonprofit Leadership,0.75,0.13,0.04,0.08,0.0,0.0,0.0,0.0,corey dou brookover,
-NPL,3000,2,Nonprofit Leadership,0.46,0.42,0.08,0.0,0.04,0.0,0.0,0.0,christina mar mazer,
-NPL,3000,3,Nonprofit Leadership,0.29,0.42,0.17,0.08,0.0,0.0,0.0,0.04,bonnie west stevens,
-NPL,3000,4,Nonprofit Leadership,0.36,0.5,0.05,0.05,0.0,0.0,0.0,0.05,bonnie west stevens,
-NPL,3000,5,Nonprofit Leadership,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,corey dou brookover,
-NPL,3000,6,Nonprofit Leadership,0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
-NPL,3000,7,Nonprofit Leadership,0.61,0.28,0.06,0.06,0.0,0.0,0.0,0.0,corey dou brookover,
-NPL,3000,8,Nonprofit Leadership,0.41,0.34,0.07,0.0,0.17,0.0,0.0,0.0,christina mar mazer,
-NPL,3010,2,NPL Stakeholders,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,
-NPL,3020,1,NPL Fundraising,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,thomas john orourke,
-NPL,3030,2,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,joan laura phillips,
-NPL,3030,2,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-NPL,3040,1,NPL Risk Management,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,daniel mor anderson,
-NPL,3050,1,Strat Social Media for NP Org,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,
-NPL,3050,2,Strat Social Media for NP Org,0.38,0.38,0.14,0.03,0.03,0.0,0.0,0.03,amanda elizab moore,
-NURS,1400,1,Comp App Hlth Care,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,nancy meehan,
-NURS,1400,3,Comp App Hlth Care,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,
-NURS,1400,4,Comp App Hlth Care,0.87,0.09,0.02,0.02,0.0,0.0,0.0,0.0,catherine si murton,
-NURS,3030,101,Nursing of Adults,0.19,0.77,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3030,101,Nursing of Adults,0.19,0.77,0.04,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,
-NURS,3030,201,Nursing of Adults,0.21,0.66,0.13,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3030,201,Nursing of Adults,0.21,0.66,0.13,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,
-NURS,3030,401,Nursing of Adults,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,
-NURS,3030,401,Nursing of Adults,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,
-NURS,3040,1,Pathophysiology,0.32,0.44,0.14,0.08,0.02,0.0,0.0,0.0,catherine si murton,
-NURS,3050,101,Psychosocial Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,
-NURS,3050,401,Psychosocial Nursing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,margaret wetsel,
-NURS,3100,101,Health Assessment,0.94,0.04,0.02,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,
-NURS,3100,201,Health Assessment,0.48,0.5,0.02,0.0,0.0,0.0,0.0,0.0,jason thrift,
-NURS,3120,1,Foundations of Nursing,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,
-NURS,3200,1,Prof in Nurs,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,
-NURS,3230,1,Gerontology Nursing,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,zahra rahemi,
-NURS,3330,101,Health Care Genetics,0.7,0.27,0.02,0.02,0.0,0.0,0.0,0.0,linda ward,
-NURS,3330,400,Health Care Genetics,0.72,0.24,0.0,0.0,0.04,0.0,0.0,0.0,jennifer el bagwell,
-NURS,3330,401,Health Care Genetics,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,
-NURS,3400,1,Pharmther Nursing,0.3,0.48,0.16,0.04,0.0,0.0,0.02,0.0,catherine si murton,
-NURS,3610,400,Ldrshp & Collab in Global Hlth,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,
-NURS,4010,1,Mental Health Nurs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NURS,4030,1,Complex Nursing of Adults,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,
-NURS,4110,1,Nursing of Children,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,
-NURS,4120,1,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,4120,1,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,kylie padron newsom,
-NURS,4250,400,Community Nursing,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,tiffany lea stewart,
-NURS,8010,400,Adv Fam & Comm Nrsng,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,
-NURS,8010,400,Adv Fam & Comm Nrsng,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
-NURS,8080,400,Nurs Res Stat Analys,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,8080,401,Nurs Res Stat Analys,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,veronica parker,
-NURS,8190,400,Developing Family,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,
-NURS,8200,400,Child & Adol Nursing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,
-NURS,8210,400,Adult Nursing,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8210,402,Adult Nursing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,
-NURS,8210,402,Adult Nursing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,
-NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,
-NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,
-NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,
-NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,
-NURS,8850,400,Mental Health in Primary Care,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,
-NURS,9050,400,DNP Health Informatics,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,nancy meehan,
-NUTR,2030,1,Intro Princ of Human Nutrition,0.32,0.42,0.15,0.04,0.01,0.0,0.0,0.05,elizabeth durrance,
-NUTR,2030,2,Intro Princ of Human Nutrition,0.48,0.39,0.07,0.07,0.0,0.0,0.0,0.0,elizabeth durrance,
-NUTR,2040,1,Nutrition Across Life Cycle,0.43,0.47,0.05,0.01,0.01,0.0,0.0,0.03,elizabeth durrance,
-NUTR,3010,1,Food and Culture,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,bridgit den corbett,
-NUTR,4250,1,Medica Nutr Thera II,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,
-NUTR,4260,1,Community Nutrition,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alexis stamatikos,
-NUTR,4270,1,Nutrition Counseling,0.66,0.24,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,
-NUTR,4550,1,Human Nutr & Metabolism II,0.52,0.38,0.07,0.03,0.0,0.0,0.0,0.0,elliot jesch,
-PA,2790,1,Perf Arts Pract I,0.33,0.4,0.0,0.0,0.13,0.0,0.0,0.13,kenneth moore,
-PA,3010,1,Princip of Arts Administration,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paul buyer,
-PA,4010,1,Capstone Project,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,anthony penna,
-PADM,8410,401,Public Data Analysis,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,ronald chrestman,
-PADM,8410,402,Public Data Analysis,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,
-PADM,8480,400,Strateg Planning for Pub Admin,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey rand parkey,
-PADM,8480,400,Strateg Planning for Pub Admin,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,maleena yenn parkey,
-PADM,8600,400,American Government,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,alfred bundrick,
-PADM,8660,400,Nonprofit Fundraising,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,victoria bedso hann,
-PADM,8680,400,Local Government Admin,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,
-PES,2020,1,Soils,0.14,0.5,0.33,0.03,0.0,0.0,0.0,0.0,dara michelle park,
-PES,4060,2,Living Seed Ark,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,paula agudelo,
-PES,4060,2,Living Seed Ark,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,stephen kresovich,
-PES,4230,1,Forages and Livestock Systems,0.25,0.38,0.31,0.0,0.0,0.0,0.0,0.06,matias jose aguerre,
-PES,4330,1,Weed Management,0.23,0.15,0.54,0.0,0.0,0.0,0.0,0.08,ted whitwell,
-PES,4450,1,Regulatory Issues & Policies,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,
-PES,4520,1,Soil Fertility and Management,0.69,0.08,0.08,0.0,0.08,0.0,0.0,0.08,haibo liu,
-PES,4900,1,Soil Organisms in Plant Growth,0.21,0.5,0.21,0.0,0.0,0.0,0.0,0.07,"appukuttan suseela,",
-PES,4960,2,CI: Food Forest,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,julia loui kerrigan,
-PES,8010,1,Crop Physiology and Nutrition,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sru narayanan kutty,
-PES,8090,1,Analytical Technique,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,
-PHIL,1010,1,Intro to Philosophic Problems,0.35,0.35,0.21,0.0,0.03,0.0,0.0,0.06,kelly smith,
-PHIL,1010,2,Intro to Philosophic Problems,0.32,0.29,0.24,0.0,0.0,0.0,0.0,0.15,david stegall,
-PHIL,1010,3,Intro to Philosophic Problems,0.43,0.31,0.11,0.06,0.03,0.0,0.0,0.06,david stegall,
-PHIL,1010,4,Intro to Philosophic Problems,0.53,0.29,0.06,0.03,0.0,0.0,0.0,0.09,david robe antonini,
-PHIL,1010,5,Intro to Philosophic Problems,0.43,0.34,0.14,0.03,0.03,0.0,0.0,0.03,david robe antonini,
-PHIL,1010,6,Intro to Philosophic Problems,0.39,0.3,0.09,0.06,0.06,0.0,0.0,0.09,david stegall,
-PHIL,1010,7,"Intro to Phil, Problems (HON)",0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,christopher grau,True
-PHIL,1020,1,Introduction to Logic,0.67,0.24,0.03,0.06,0.0,0.0,0.0,0.0,edyta joanna kuzian,
-PHIL,1020,2,Introduction to Logic,0.69,0.14,0.03,0.03,0.0,0.0,0.03,0.09,adam pa omelianchuk,
-PHIL,1020,3,Introduction to Logic,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
-PHIL,1020,6,Introduction to Logic,0.73,0.12,0.09,0.03,0.0,0.0,0.0,0.03,adam pa omelianchuk,
-PHIL,1020,7,Introduction to Logic,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,adam pa omelianchuk,
-PHIL,1020,8,Introduction to Logic,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,
-PHIL,1030,1,Introduction to Ethics,0.36,0.48,0.06,0.06,0.0,0.0,0.0,0.03,stephen satris,
-PHIL,1030,2,Intro to Ethics (HON),0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,stephen satris,True
-PHIL,1030,3,Introduction to Ethics,0.71,0.23,0.0,0.0,0.03,0.0,0.0,0.03,adam gies,
-PHIL,1030,4,Introduction to Ethics,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,
-PHIL,1030,5,Introduction to Ethics,0.22,0.44,0.28,0.0,0.0,0.0,0.0,0.06,charles starkey,
-PHIL,3030,1,Phil of Religion,0.41,0.41,0.14,0.0,0.0,0.0,0.0,0.03,richard al amesbury,
-PHIL,3050,1,Existentialism,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david stegall,
-PHIL,3120,1,Philosophy in Ancient China,0.43,0.29,0.14,0.14,0.0,0.0,0.0,0.0,yanming an,
-PHIL,3160,1,Modern Philosophy,0.38,0.46,0.04,0.04,0.0,0.0,0.0,0.08,david robe antonini,
-PHIL,3200,1,Soc and Pol Phil,0.39,0.42,0.13,0.03,0.0,0.0,0.0,0.03,todd may,
-PHIL,3210,1,Crime & Punishment,0.38,0.42,0.12,0.04,0.04,0.0,0.0,0.0,daniel wueste,
-PHIL,3260,1,Science and Values,0.8,0.14,0.03,0.0,0.0,0.0,0.0,0.03,adam pa omelianchuk,
-PHIL,3300,1,Animal Minds & Animal Ethics,0.62,0.12,0.08,0.0,0.04,0.0,0.0,0.15,adam gies,
-PHIL,3430,1,Philosophy of Law,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,brookes colyt brown,
-PHIL,3450,1,Environmental Ethics,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,kelly smith,
-PHIL,3460,1,Biomedical Ethics,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,charles starkey,
-PHIL,3990,1,Philosophy Portfolio,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,todd may,
-PHIL,4010,1,Studies in the Hist of Phil,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,stephen satris,
-PHIL,4020,1,The Limits of Morality,0.6,0.2,0.07,0.0,0.0,0.0,0.0,0.13,todd may,
-PHIL,4750,1,Philosophy of Film,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,christopher grau,
-PHSC,1170,1,Intro Chem & Earth,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,
-PHYS,1220,1,Physics with Calculus I,0.2,0.35,0.25,0.11,0.04,0.0,0.0,0.05,lih-sin the,
-PHYS,1220,2,Physics with Calculus I,0.31,0.45,0.18,0.03,0.0,0.0,0.02,0.01,lih-sin the,
-PHYS,1220,3,Physics with Calculus I,0.28,0.41,0.21,0.05,0.03,0.0,0.0,0.02,pooja puneet,
-PHYS,1220,4,Physics with Calculus I,0.31,0.43,0.22,0.02,0.03,0.0,0.0,0.0,pooja puneet,
-PHYS,1220,5,Physics with Calculus I,0.34,0.44,0.16,0.03,0.01,0.0,0.0,0.02,jason stratfo brown,
-PHYS,1220,8,Physics w/Calculus I (HON),0.63,0.23,0.07,0.0,0.0,0.0,0.0,0.07,ramakrishna podila,True
-PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
-PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,1240,2,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,2,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,3,Physics Lab I,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,3,Physics Lab I,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,6,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
-PHYS,1240,6,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,1240,7,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,7,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,8,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,8,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,9,Physics Lab I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,daniel ros thompson,
-PHYS,1240,9,Physics Lab I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,bishwambha sengupta,
-PHYS,1240,11,Physics Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,daniel ros thompson,
-PHYS,1240,11,Physics Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,bishwambha sengupta,
-PHYS,1240,13,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,13,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,14,Physics Lab I,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,bishwambha sengupta,
-PHYS,1240,14,Physics Lab I,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,daniel ros thompson,
-PHYS,1240,15,Physics Lab I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,15,Physics Lab I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,16,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,16,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,17,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,17,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,20,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,20,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,21,Physics Lab I,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,21,Physics Lab I,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,22,Physics Lab I,0.43,0.21,0.14,0.0,0.0,0.0,0.0,0.21,daniel ros thompson,
-PHYS,1240,22,Physics Lab I,0.43,0.21,0.14,0.0,0.0,0.0,0.0,0.21,bishwambha sengupta,
-PHYS,1240,23,Physics Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,daniel ros thompson,
-PHYS,1240,23,Physics Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,bishwambha sengupta,
-PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
-PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,1240,25,Physics Lab I,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,25,Physics Lab I,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,26,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,26,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,27,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,27,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,29,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,29,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,30,Physics Lab I,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
-PHYS,1240,30,Physics Lab I,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,1240,31,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,31,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,32,Physics Lab I,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,32,Physics Lab I,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,1240,33,Physics Lab I,0.29,0.53,0.12,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,
-PHYS,1240,33,Physics Lab I,0.29,0.53,0.12,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,1240,34,Physics Lab I,0.41,0.41,0.06,0.0,0.0,0.0,0.0,0.12,daniel ros thompson,
-PHYS,1240,34,Physics Lab I,0.41,0.41,0.06,0.0,0.0,0.0,0.0,0.12,bishwambha sengupta,
-PHYS,1240,35,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,
-PHYS,1240,35,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2000,1,Introductory Physics,0.31,0.58,0.11,0.0,0.0,0.0,0.0,0.0,pooja puneet,
-PHYS,2070,1,General Physics I,0.25,0.2,0.25,0.11,0.13,0.0,0.0,0.07,amy liann pope,
-PHYS,2070,2,General Physics I,0.23,0.25,0.23,0.1,0.1,0.0,0.0,0.08,amy liann pope,
-PHYS,2080,1,General Physics II,0.58,0.27,0.09,0.04,0.0,0.0,0.01,0.0,amy liann pope,
-PHYS,2080,2,General Physics II,0.54,0.35,0.09,0.02,0.0,0.0,0.0,0.0,amy liann pope,
-PHYS,2080,4,General Physics II,0.53,0.29,0.14,0.04,0.0,0.0,0.0,0.0,amy liann pope,
-PHYS,2090,1,Gen Phys Lab I,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2090,2,Gen Phys Lab I,0.58,0.33,0.0,0.04,0.0,0.0,0.0,0.04,daniel ros thompson,
-PHYS,2090,3,Gen Phys Lab I,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2090,4,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
-PHYS,2090,5,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2090,6,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
-PHYS,2090,7,Gen Phys Lab I,0.63,0.29,0.0,0.0,0.0,0.0,0.0,0.08,daniel ros thompson,
-PHYS,2090,8,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
-PHYS,2090,9,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
-PHYS,2090,10,Gen Phys Lab I,0.67,0.25,0.04,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
-PHYS,2100,2,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,2,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,3,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,3,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,4,Gen Phys Lab II,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,danielle latham,
-PHYS,2100,4,Gen Phys Lab II,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
-PHYS,2100,5,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,5,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,6,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,6,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,7,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,7,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,8,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,8,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,9,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,9,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,10,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,10,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,11,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,11,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,13,Gen Phys Lab II,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,13,Gen Phys Lab II,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,14,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,14,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,15,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,15,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,16,Gen Phys Lab II,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,danielle latham,
-PHYS,2100,16,Gen Phys Lab II,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,
-PHYS,2100,17,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,17,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,18,Gen Phys Lab II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,18,Gen Phys Lab II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2100,19,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,
-PHYS,2100,19,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2210,1,Physics with Calculus II,0.15,0.42,0.29,0.05,0.0,0.0,0.06,0.04,jason stratfo brown,
-PHYS,2210,2,Physics with Calculus II,0.27,0.37,0.22,0.09,0.0,0.0,0.03,0.02,jason stratfo brown,
-PHYS,2210,3,Physics w/Calculus II (HON),0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True
-PHYS,2210,5,Physics with Calculus II,0.73,0.0,0.13,0.0,0.07,0.0,0.0,0.07,murray daw,
-PHYS,2230,2,Physics Lab II,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,yamei liu,
-PHYS,2230,2,Physics Lab II,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2230,3,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,2230,3,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,
-PHYS,2230,4,Physics Lab II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2230,4,Physics Lab II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,yamei liu,
-PHYS,2230,5,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,
-PHYS,2230,5,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,yamei liu,
-PHYS,2230,6,Physics Lab II,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,
-PHYS,2230,6,Physics Lab II,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,2230,7,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,2230,7,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,yamei liu,
-PHYS,2230,8,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,yamei liu,
-PHYS,2230,8,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,daniel ros thompson,
-PHYS,2230,9,Physics Lab II,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,
-PHYS,2230,9,Physics Lab II,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,
-PHYS,2400,1,Phys of Weather,0.31,0.35,0.19,0.08,0.04,0.0,0.0,0.04,jens oberheide,
-PHYS,3110,1,Methods Theor Phys,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,lih-sin the,
-PHYS,3220,1,Mechanics II,0.28,0.17,0.39,0.11,0.06,0.0,0.0,0.0,stephen ro kaeppler,
-PHYS,3990,1,CI STEM Competition,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,jason stratfo brown,
-PHYS,4560,1,Quantum Physics II,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,sumanta tewari,
-PHYS,4650,1,Thermo and Stat Mech,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,mark leising,
-PHYS,4750,1,Intro to Cellular Biophysics,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,joshua alper,
-PHYS,8150,1,Statistical Therm I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,celestine hackett,
-PHYS,8150,1,Statistical Therm I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,dieter hartmann,
-PHYS,8410,1,Electrodynamics I,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,feng ding,
-PHYS,9520,1,Quantum Mech II,0.21,0.57,0.14,0.0,0.07,0.0,0.0,0.0,domnita marinescu,
-PKSC,1020,1,Intro to Pkg Sci,0.14,0.35,0.28,0.08,0.1,0.0,0.0,0.04,heather batt,
-PKSC,2010,100,Pkg Perishable Prod,0.07,0.24,0.35,0.17,0.1,0.0,0.0,0.07,heather batt,
-PKSC,2020,1,Packaging Mtl & Mfg,0.33,0.4,0.2,0.0,0.0,0.0,0.0,0.07,pa guerra marcondes,
-PKSC,2040,1,Container Systems,0.26,0.48,0.2,0.0,0.03,0.0,0.0,0.03,pa guerra marcondes,
-PKSC,2060,1,Container Sys Lab,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,pa guerra marcondes,
-PKSC,2060,2,Container Sys Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,pa guerra marcondes,
-PKSC,2060,3,Container Sys Lab,0.38,0.54,0.0,0.08,0.0,0.0,0.0,0.0,pa guerra marcondes,
-PKSC,2200,1,Product & Pkg Design,0.85,0.05,0.03,0.03,0.03,0.0,0.0,0.03,haley ellis appleby,
-PKSC,3680,400,Pkg and Society,0.29,0.53,0.13,0.0,0.04,0.0,0.0,0.01,heather batt,
-PKSC,4030,1,Pkg Career Prep,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4200,1,Pkg Design & Dev,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,robert kimmel,
-PKSC,4300,1,Converting Flex Pkg,0.22,0.65,0.12,0.0,0.01,0.0,0.0,0.0,duncan darby,
-PKSC,4400,1,Packaging for Distribution,0.25,0.45,0.25,0.03,0.03,0.0,0.0,0.0,gregory batt,
-PKSC,4400,400,Packaging for Distribution,0.02,0.47,0.29,0.08,0.14,0.0,0.0,0.0,gregory batt,
-PKSC,4640,1,Food & Health Care Pkg Systems,0.63,0.27,0.1,0.0,0.0,0.0,0.0,0.0,kay cooksey,
-PKSC,4990,3,CI-Packaging  Sci Seminar,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,rupert hurley,
-PKSC,8220,1,Packaging Dynamics,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,gregory batt,
-PLPA,2130,1,Fungi & Civilization,0.34,0.39,0.14,0.06,0.03,0.0,0.0,0.04,julia loui kerrigan,
-POSC,1010,2,Amer National Govt,0.22,0.44,0.18,0.07,0.04,0.0,0.0,0.04,jeffrey scott peake,
-POSC,1010,3,Amer National Govt,0.42,0.26,0.13,0.06,0.13,0.0,0.0,0.0,robert carey,
-POSC,1010,4,Amer National Govt,0.3,0.33,0.2,0.1,0.0,0.0,0.0,0.07,robert carey,
-POSC,1020,1,Intro Intl Relations,0.34,0.45,0.11,0.01,0.04,0.0,0.0,0.06,steven vince miller,
-POSC,1020,2,Intro Intl Relations,0.3,0.47,0.13,0.03,0.05,0.0,0.0,0.03,aron geo tannenbaum,
-POSC,1020,3,Intro Intl Relations,0.43,0.35,0.19,0.0,0.0,0.0,0.0,0.03,marjorie lo jeffrey,
-POSC,1030,1,Intro to Political Theory,0.67,0.08,0.08,0.17,0.0,0.0,0.0,0.0,jay hoffpauir,
-POSC,1030,2,Intro to Political Theory,0.11,0.67,0.11,0.04,0.0,0.0,0.04,0.04,john ant pascarella,
-POSC,1030,3,Intro to Political Theory,0.3,0.26,0.26,0.0,0.13,0.0,0.0,0.04,marjorie lo jeffrey,
-POSC,1030,4,Intro to Political Theory,0.05,0.15,0.5,0.15,0.1,0.0,0.0,0.05,colin denby pearce,
-POSC,1030,5,Intro to Political Theory,0.38,0.31,0.17,0.0,0.0,0.0,0.0,0.14,kevin gregory vance,
-POSC,1040,1,Intro Compar Pol,0.37,0.26,0.28,0.02,0.0,0.0,0.0,0.07,matthe rhodes-purdy,
-POSC,1990,1,Intro Pol Sci,0.23,0.4,0.15,0.06,0.13,0.0,0.0,0.02,meredith petersheim,
-POSC,3020,1,State and Loc Gov,0.1,0.66,0.15,0.02,0.02,0.0,0.0,0.05,bruce ransom,
-POSC,3050,3,Creative Inq in Political Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,xiaobo hu,
-POSC,3210,1,Public Admin,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,robert carey,
-POSC,3410,1,Quant Meth in Pol Sc,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,ethan craig busby,
-POSC,3430,1,Mass Media in Americ Politics,0.68,0.21,0.06,0.0,0.0,0.0,0.0,0.04,ethan craig busby,
-POSC,3630,1,Us Foreign Policy,0.47,0.38,0.09,0.02,0.0,0.0,0.0,0.04,vladimir matic,
-POSC,3710,615,European Politics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
-POSC,3810,1,African Amer Politic,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,
-POSC,4050,1,American Presidency,0.0,0.28,0.33,0.11,0.22,0.0,0.0,0.06,adam warber,
-POSC,4080,1,Religion and World Politics,0.38,0.38,0.21,0.0,0.0,0.0,0.0,0.04,laura olson,
-POSC,4160,1,Int Groups & Soc Mov,0.26,0.44,0.19,0.12,0.0,0.0,0.0,0.0,laura olson,
-POSC,4210,1,Public Policy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
-POSC,4360,1,Law Courts Politics,0.57,0.26,0.17,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
-POSC,4360,2,Law Courts Politics,0.53,0.42,0.06,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,
-POSC,4370,1,Constitut Law: Rights & Libert,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,kevin gregory vance,
-POSC,4370,2,Constitut Law: Rights & Libert,0.7,0.18,0.06,0.0,0.0,0.0,0.0,0.06,kevin gregory vance,
-POSC,4470,1,International Law,0.33,0.17,0.21,0.13,0.13,0.0,0.0,0.04,katherine am curtis,
-POSC,4480,615,Internat'l Political Economy,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
-POSC,4500,1,Conservatism,0.33,0.33,0.29,0.0,0.0,0.0,0.0,0.05,brandon turner,
-POSC,4530,1,American Political Thought,0.41,0.46,0.11,0.0,0.0,0.0,0.0,0.02,colin denby pearce,
-POSC,4710,1,Russian Politics,0.33,0.49,0.13,0.0,0.02,0.0,0.0,0.02,aron geo tannenbaum,
-POSC,4760,1,Middle East Politics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,
-POSC,4770,1,Chinese Politics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,xiaobo hu,
-POSC,4890,615,Post Conflict Pol. & Society,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,
-POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,meredith petersheim,
-PRTM,2200,1,Foundations of PRTM,0.19,0.5,0.23,0.08,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2270,1,Prov of Leisure Exp,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
-PRTM,2270,1,Prov of Leisure Exp,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2290,1,Competency Integration in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,
-PRTM,2290,1,Competency Integration in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,2410,1,Intro to CRSCM,0.39,0.26,0.26,0.06,0.0,0.0,0.0,0.03,jamie lynn cathey,
-PRTM,2410,2,Intro to CRSCM,0.23,0.27,0.2,0.1,0.0,0.0,0.1,0.1,jamie lynn cathey,
-PRTM,2600,1,Found of Recreational Therapy,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,brandi crowe,
-PRTM,2700,1,Intro Rec Res Mgt,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,
-PRTM,2810,1,Intro to Golf Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,3050,1,Safety/Risk Mgt PRTM,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,daniel mor anderson,
-PRTM,3070,1,Facility Operations,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,raymond dunham,
-PRTM,3210,1,Recreation Admin,0.4,0.34,0.14,0.09,0.0,0.0,0.0,0.03,jamie lynn cathey,
-PRTM,3210,2,Recreation Admin,0.18,0.61,0.12,0.03,0.03,0.0,0.0,0.03,jamie lynn cathey,
-PRTM,3250,1,Global Persp in Rec,0.2,0.16,0.4,0.04,0.16,0.0,0.0,0.04,harrison pinckney,
-PRTM,3250,2,Global Persp in Rec,0.5,0.25,0.14,0.07,0.04,0.0,0.0,0.0,harrison pinckney,
-PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,
-PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,heather sext torphy,
-PRTM,3420,1,Intro to Tourism,0.89,0.09,0.03,0.0,0.0,0.0,0.0,0.0,katherine dudley,
-PRTM,3420,2,Intro to Tourism,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,peter marwa ezra,
-PRTM,3430,1,Spl Asp of Tourist B,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,kenneth backman,
-PRTM,3440,1,Tourism Markets,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,sheila backman,
-PRTM,3440,2,Tourism Markets,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,sheila backman,
-PRTM,3450,1,Tourism Management,0.41,0.48,0.1,0.0,0.0,0.0,0.0,0.0,william norman,
-PRTM,3450,2,Tourism Management,0.42,0.56,0.0,0.0,0.0,0.0,0.0,0.03,william norman,
-PRTM,3460,1,Heritage Tourism,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,
-PRTM,3460,2,Heritage Tourism,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,gregory phi ramshaw,
-PRTM,3530,2,Foundations of Camp Counseling,0.7,0.07,0.07,0.03,0.03,0.0,0.0,0.1,gwynn powell,
-PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,alexsandra dubin,
-PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,gwynn powell,
-PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,lisa kay-powl olsen,
-PRTM,3900,1,PGA GM Player Development,0.56,0.31,0.0,0.13,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,3900,1,PGA GM Player Development,0.56,0.31,0.0,0.13,0.0,0.0,0.0,0.0,adam savedra,
-PRTM,4300,1,World Geog Parks,0.76,0.16,0.06,0.0,0.0,0.0,0.0,0.02,tori kleinbort,
-PRTM,4460,2,Community Tourism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lauren duffy,
-PRTM,4540,1,Trends in Sport Mgt,0.61,0.22,0.13,0.04,0.0,0.0,0.0,0.0,skye arthur-banning,
-PRTM,4980,1,Creative Inquiry in PRTM IV,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,katrina latri black,
-PRTM,4980,1,Creative Inquiry in PRTM IV,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard lucas,
-PRTM,4980,17,Creative Inquiry in PRTM IV,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,skye arthur-banning,
-PRTM,4980,18,Creative Inquiry in PRTM IV,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,skye arthur-banning,
-PRTM,8030,1,Sem Rec & Park Admin,0.67,0.24,0.0,0.0,0.05,0.0,0.0,0.05,skye arthur-banning,
-PRTM,8110,2,Research Methods,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,rose irene verbos,
-PRTM,8130,1,Qualitative Research Methods,0.93,0.0,0.04,0.0,0.0,0.0,0.04,0.0,elizabeth baldwin,
-PRTM,8210,1,Funding Strategies in PRTM,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,
-PRTM,8250,1,Populations in PRTM,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,
-PRTM,8440,1,Outdoor Rec Mgt Plng,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,raymond bivens,
-PRTM,8720,1,Adv Facilitation Techniq in RT,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,
-PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,
-PSYC,2010,1,Intro to Psychology,0.33,0.36,0.2,0.06,0.02,0.0,0.0,0.03,jo jorgensen,
-PSYC,2010,2,Intro to Psychology,0.29,0.26,0.19,0.11,0.1,0.0,0.0,0.05,edwin brainerd,
-PSYC,2010,3,Intro to Psychology,0.4,0.41,0.13,0.03,0.01,0.0,0.0,0.01,mary taylor,
-PSYC,2010,4,Intro to Psychology,0.46,0.3,0.09,0.09,0.01,0.0,0.0,0.04,mary taylor,
-PSYC,2010,6,Intro to Psychology,0.61,0.19,0.09,0.03,0.04,0.0,0.0,0.04,fred switzer,
-PSYC,2010,7,Intro to Psychology (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True
-PSYC,2890,1,Fundamentals of Psyc Science,0.55,0.33,0.08,0.01,0.01,0.0,0.0,0.01,peggy jean tyler,
-PSYC,3060,1,Human Sexual Behavior,0.52,0.24,0.15,0.04,0.03,0.0,0.0,0.02,bruce michael king,
-PSYC,3090,100,Intro Experimental Psychology,0.51,0.27,0.15,0.03,0.03,0.0,0.0,0.01,jennifer bai bisson,
-PSYC,3090,200,Intro Experimental Psychology,0.28,0.36,0.24,0.07,0.04,0.0,0.0,0.01,richard tyrrell,
-PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,michael shreeves,
-PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,3100,200,Advanced Experimental Psych,0.39,0.44,0.11,0.0,0.06,0.0,0.0,0.0,eric mckibben,
-PSYC,3100,300,Advanced Experimental Psych,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,joseph ligato,
-PSYC,3100,300,Advanced Experimental Psych,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,robert ray sinclair,
-PSYC,3100,400,Advanced Experimental Psych,0.57,0.24,0.14,0.0,0.0,0.0,0.0,0.05,benjamin stephens,
-PSYC,3100,500,Advanced Experimental Psych,0.38,0.38,0.19,0.05,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3100,600,Advanced Experimental Psych,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,
-PSYC,3100,700,Advanced Experimental Psych,0.55,0.32,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,
-PSYC,3240,1,Physiological Psych,0.43,0.27,0.2,0.09,0.0,0.0,0.0,0.01,claudio cantalupo,
-PSYC,3240,2,Physiological Psych,0.42,0.33,0.15,0.06,0.0,0.0,0.0,0.04,claudio cantalupo,
-PSYC,3330,1,Cognitive Psych,0.33,0.4,0.17,0.03,0.0,0.0,0.0,0.06,robert campbell,
-PSYC,3330,2,Cognitive Psych,0.67,0.26,0.03,0.01,0.01,0.0,0.0,0.01,kaileigh ange byrne,
-PSYC,3330,3,Cognitive Psych,0.51,0.32,0.12,0.03,0.01,0.0,0.0,0.01,daniel braden quinn,
-PSYC,3340,1,Cognitive Psych Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kathryn lucaites,
-PSYC,3340,2,Cognitive Psych Lab,0.62,0.14,0.19,0.0,0.0,0.0,0.0,0.05,kathryn lucaites,
-PSYC,3400,1,Lifespan Developmental Psych,0.25,0.38,0.2,0.09,0.0,0.0,0.0,0.08,pamela alley,
-PSYC,3400,2,Lifespan Developmental Psych,0.32,0.37,0.21,0.07,0.03,0.0,0.0,0.0,anita pei tam,
-PSYC,3520,1,Social Psychology,0.51,0.32,0.12,0.01,0.01,0.0,0.0,0.01,ceren gunsoy,
-PSYC,3520,2,Social Psychology,0.37,0.37,0.16,0.09,0.0,0.0,0.0,0.0,jo jorgensen,
-PSYC,3520,3,Social Psychology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True
-PSYC,3570,1,Psychology and Culture,0.56,0.18,0.18,0.05,0.02,0.0,0.0,0.02,ceren gunsoy,
-PSYC,3640,1,Industrial Psych,0.15,0.37,0.4,0.08,0.0,0.0,0.0,0.0,eric mckibben,
-PSYC,3640,2,Industrial Psych,0.28,0.35,0.29,0.06,0.01,0.0,0.0,0.01,eric mckibben,
-PSYC,3680,1,Organizational Psych,0.69,0.24,0.03,0.01,0.01,0.0,0.0,0.01,anton sytine,
-PSYC,3700,1,Personality,0.54,0.32,0.09,0.01,0.03,0.0,0.0,0.01,john robert hester,
-PSYC,3770,1,Psych of Group & Team Dynamics,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,marissa leig porter,
-PSYC,3830,1,Abnormal Psychology,0.3,0.49,0.16,0.04,0.01,0.0,0.0,0.01,cynthia pury,
-PSYC,3830,2,Abnormal Psychology,0.4,0.31,0.24,0.06,0.0,0.0,0.0,0.0,jo jorgensen,
-PSYC,3830,3,Abnormal Psychology,0.24,0.35,0.29,0.03,0.0,0.0,0.06,0.03,pamela alley,
-PSYC,3830,4,Abnormal Psychology,0.17,0.33,0.33,0.13,0.0,0.0,0.0,0.03,pamela alley,
-PSYC,4080,1,Women and Psychology,0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,robin mari kowalski,
-PSYC,4150,1,Systems and Theories,0.24,0.39,0.18,0.06,0.0,0.0,0.0,0.12,robert campbell,
-PSYC,4150,2,Systems and Theories,0.29,0.18,0.21,0.24,0.09,0.0,0.0,0.0,edwin brainerd,
-PSYC,4150,3,Systems and Theories,0.33,0.3,0.09,0.09,0.15,0.0,0.0,0.03,edwin brainerd,
-PSYC,4150,4,Systems and Theories,0.71,0.17,0.06,0.0,0.03,0.0,0.0,0.03,zachary klinefelter,
-PSYC,4220,1,Perception,0.55,0.09,0.05,0.23,0.0,0.0,0.0,0.09,claudio cantalupo,
-PSYC,4220,2,Perception,0.2,0.4,0.24,0.12,0.04,0.0,0.0,0.0,christopher pagano,
-PSYC,4220,3,Perception,0.3,0.17,0.39,0.04,0.04,0.0,0.0,0.04,claudio cantalupo,
-PSYC,4350,1,Human Factors,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,laura whitlock,
-PSYC,4710,1,Psych of Testing,0.61,0.17,0.09,0.0,0.04,0.0,0.0,0.09,zhuo chen,
-PSYC,4800,1,Health Psychology,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,james mccubbin,
-PSYC,4800,2,Health Psychology,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,james mccubbin,
-PSYC,4880,1,Psychotherapy,0.41,0.18,0.24,0.06,0.06,0.0,0.0,0.06,heidi marie zinzow,
-PSYC,4890,1,Organizational Stress,0.75,0.0,0.08,0.0,0.0,0.0,0.0,0.17,chelsea aly lenoble,
-PSYC,4890,2,Sports Psychology,0.29,0.41,0.24,0.06,0.0,0.0,0.0,0.0,anita pei tam,
-PSYC,4920,1,Senior Laboratory,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,chloe wilson,
-PSYC,4920,2,Senior Laboratory,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,chloe wilson,
-PSYC,4920,3,Senior Laboratory,0.46,0.42,0.04,0.04,0.04,0.0,0.0,0.0,chloe wilson,
-PSYC,4930,100,Pract Clinical Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,
-PSYC,4980,31,Autism Research,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,jennifer bai bisson,
-PSYC,4980,33,Autism Research II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jennifer bai bisson,
-PSYC,4980,121,Stress and Health,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james mccubbin,
-PSYC,4980,251,Critical Thinking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,benjamin stephens,
-PSYC,4980,291,Suicide Prevention,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,martha par thompson,
-PSYC,4980,291,Suicide Prevention,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,heidi marie zinzow,
-PSYC,8130,1,Research Design III,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,patrick rosopa,
-PSYC,8140,1,Quantitative Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,patrick rosopa,
-PSYC,8630,1,Work Motivation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,fred switzer,
-RED,8030,1,Pub-Priv Partnership,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,stephen tho buckman,
-RED,8160,1,Preservation Feasibility,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,
-RED,8890,1,Selected Topics-Entitlement Pr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,thomas andr sherard,
-RED,8890,1,Selected Topics-Entitlement Pr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,
-RED,8890,2,Selected Topics-Construction O,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,andrew tay norville,
-REL,1010,1,Intro to Religion,0.21,0.32,0.29,0.03,0.06,0.0,0.0,0.09,peter cohen,
-REL,1010,2,Intro to Religion,0.38,0.29,0.18,0.09,0.03,0.0,0.0,0.03,peter cohen,
-REL,1010,3,Intro to Religion,0.2,0.51,0.2,0.06,0.03,0.0,0.0,0.0,peter cohen,
-REL,1020,2,World Religions,0.24,0.41,0.32,0.0,0.0,0.0,0.0,0.03,robert stephens,
-REL,1020,3,World Religions,0.33,0.36,0.27,0.0,0.03,0.0,0.0,0.0,robert stephens,
-REL,1020,4,World Religions,0.26,0.48,0.13,0.0,0.03,0.0,0.0,0.1,robert stephens,
-REL,3000,1,Studying Religion,0.41,0.38,0.17,0.0,0.0,0.0,0.0,0.03,benjamin white,
-REL,3010,1,Old Testament,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,
-REL,3020,1,New Testament Lit,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,benjamin white,
-REL,3030,1,The Quran,0.22,0.59,0.11,0.0,0.04,0.0,0.0,0.04,mashal saif,
-REL,3070,1,The Christian Tradition,0.17,0.59,0.1,0.0,0.0,0.0,0.0,0.14,brett patterson,
-REL,3100,1,History of Religion in the US,0.28,0.44,0.11,0.06,0.0,0.0,0.0,0.11,elizabeth jemison,
-REL,3170,1,Hist of Native Am Rel/Culture,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,james brad jeffries,
-REL,3350,1,Islam and the West,0.58,0.17,0.08,0.0,0.08,0.0,0.0,0.08,mashal saif,
-REL,3510,1,Ancient Near East,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,steven grosby,
-RS,4590,1,The Community,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
-RUD,8640,1,Urban Design Seminar II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,broo wortham-galvin,
-RUD,8650,1,Urban Design Vis & Comm II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,chelsea ma anderson,
-RUD,8650,1,Urban Design Vis & Comm II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,broo wortham-galvin,
-RUSS,1020,1,Elementary Russian,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,stephanie el morris,
-SOC,2010,2,Introduction to Sociology,0.58,0.3,0.1,0.0,0.01,0.0,0.0,0.01,carolyn can coffman,
-SOC,2010,3,Introduction to Sociology,0.88,0.1,0.0,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,
-SOC,2010,4,Introduction to Sociology,0.57,0.33,0.08,0.01,0.01,0.0,0.0,0.01,shannon mcdonough,
-SOC,2010,5,Introduction to Sociology,0.49,0.4,0.09,0.01,0.0,0.0,0.0,0.01,shannon mcdonough,
-SOC,2040,1,Prof Dev for Sociology Majors,0.5,0.25,0.09,0.09,0.06,0.0,0.0,0.0, catherine mobley,
-SOC,3020,1,Research Methods I,0.31,0.47,0.12,0.02,0.02,0.0,0.0,0.06,miao li,
-SOC,3040,1,Social Research Methods II,0.32,0.34,0.24,0.08,0.0,0.0,0.0,0.03,ye luo,
-SOC,3100,1,Marriage & Intimacy,0.68,0.21,0.09,0.0,0.02,0.0,0.0,0.0,carolyn can coffman,
-SOC,3110,1,The Family,0.37,0.47,0.1,0.02,0.02,0.0,0.0,0.02,andrew whitehead,
-SOC,3310,1,Urban Sociology,0.7,0.15,0.07,0.0,0.0,0.0,0.0,0.07,william haller,
-SOC,3500,1,Self & Society,0.67,0.19,0.07,0.05,0.0,0.0,0.0,0.02,carolyn can coffman,
-SOC,3600,1,Class & Poverty,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,kenneth robinson,
-SOC,3800,1,Intro Social Service,0.69,0.22,0.04,0.02,0.02,0.0,0.0,0.0,jennifer le holland,
-SOC,3910,1,Soc of Deviance,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,
-SOC,3920,1,Juvenile Delinquency,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,
-SOC,4040,1,Soc Theory,0.55,0.15,0.25,0.05,0.0,0.0,0.0,0.0,william haller,
-SOC,4320,1,Soc of Religion,0.25,0.41,0.3,0.0,0.0,0.0,0.0,0.05,andrew whitehead,
-SOC,4590,1,The Community,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,kenneth robinson,
-SOC,4600,1,Race & Ethnicity,0.74,0.19,0.05,0.0,0.0,0.0,0.0,0.02,andrew mannheimer,
-SOC,4610,1,Sex & Gender,0.74,0.17,0.04,0.0,0.02,0.0,0.0,0.02,heather kettrey,
-SOC,4800,1,Medical Sociology,0.58,0.17,0.08,0.08,0.0,0.0,0.0,0.08,miao li,
-SOC,4840,1,Child Abuse,0.84,0.1,0.02,0.02,0.0,0.0,0.0,0.02,james rosenberger,
-SOC,4860,1,CI in SOC: Youth Rel Violence,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,carolyn can coffman,
-SOC,4950,1,Field Experience,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jennifer le holland,
-SOC,8050,1,Evaluation Research,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0, catherine mobley,
-SPAN,1010,1,Elementary Spanish,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,rosa mac pillcurima,
-SPAN,1010,2,Elementary Spanish,0.43,0.35,0.09,0.09,0.0,0.0,0.0,0.04,rosa mac pillcurima,
-SPAN,1010,3,Elementary Spanish,0.38,0.17,0.13,0.08,0.08,0.0,0.0,0.17,rosa mac pillcurima,
-SPAN,1020,2,Elementary Spanish,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,andrea patr naranjo,
-SPAN,1020,3,Elementary Spanish,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,1020,4,Elementary Spanish,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,rosa mac pillcurima,
-SPAN,1020,5,Elementary Spanish,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,1020,6,Elementary Spanish,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,
-SPAN,1020,7,Elementary Spanish,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,1020,8,Elementary Spanish,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,1020,9,Elementary Spanish,0.33,0.5,0.0,0.0,0.08,0.0,0.0,0.08,debra oa williamson,
-SPAN,1020,10,Elementary Spanish,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,1,Intermediate Spanish,0.82,0.09,0.05,0.05,0.0,0.0,0.0,0.0,mercedes tejera,
-SPAN,2010,2,Intermediate Spanish,0.88,0.0,0.04,0.0,0.04,0.0,0.0,0.04,mercedes tejera,
-SPAN,2010,3,Intermediate Spanish,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,andrea patr naranjo,
-SPAN,2010,4,Intermediate Spanish,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,liliana hernandez,
-SPAN,2010,5,Intermediate Spanish,0.64,0.24,0.04,0.0,0.0,0.0,0.0,0.08,liliana hernandez,
-SPAN,2010,6,Intermediate Spanish,0.23,0.55,0.09,0.05,0.0,0.0,0.0,0.09,melva margu persico,
-SPAN,2010,7,Intermediate Spanish,0.3,0.57,0.09,0.04,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,2010,8,Intermediate Spanish,0.55,0.2,0.1,0.05,0.1,0.0,0.0,0.0,mari judez riquelme,
-SPAN,2010,9,Intermediate Spanish,0.72,0.16,0.04,0.0,0.0,0.0,0.0,0.08,mari judez riquelme,
-SPAN,2010,10,Intermediate Spanish,0.6,0.24,0.16,0.0,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,11,Intermediate Spanish,0.65,0.22,0.04,0.09,0.0,0.0,0.0,0.0,ellory schmucker,
-SPAN,2010,12,Intermediate Spanish,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,
-SPAN,2010,13,Intermediate Spanish,0.6,0.25,0.05,0.05,0.0,0.0,0.0,0.05,debra oa williamson,
-SPAN,2020,2,Intermediate Spanish,0.39,0.39,0.11,0.0,0.0,0.0,0.0,0.11,juana martin-armas,
-SPAN,2020,3,Intermediate Spanish,0.38,0.29,0.24,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,
-SPAN,2020,4,Intermediate Spanish,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,
-SPAN,2020,5,Intermediate Spanish,0.4,0.52,0.08,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,2020,6,Intermediate Spanish,0.56,0.32,0.08,0.0,0.04,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,2020,7,Intermediate Spanish,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,ana paula  miller,
-SPAN,2020,8,Intermediate Spanish,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,ana paula  miller,
-SPAN,2020,9,Intermediate Spanish,0.14,0.64,0.14,0.0,0.0,0.0,0.0,0.09,ana paula  miller,
-SPAN,2020,10,Intermediate Spanish,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,al garcia rodriguez,
-SPAN,2020,11,Intermediate Spanish,0.52,0.32,0.04,0.04,0.0,0.0,0.0,0.08,al garcia rodriguez,
-SPAN,2020,12,Intermediate Spanish,0.45,0.41,0.14,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,13,Intermediate Spanish,0.48,0.4,0.08,0.0,0.0,0.0,0.0,0.04,adrienne eliza fama,
-SPAN,2020,14,Intermediate Spanish,0.48,0.36,0.08,0.08,0.0,0.0,0.0,0.0,adrienne eliza fama,
-SPAN,2020,20,Intermediate Spanish,0.92,0.0,0.04,0.04,0.0,0.0,0.0,0.0,mercedes tejera,
-SPAN,3010,1,Spanish Comp for Health Prof,0.47,0.4,0.07,0.07,0.0,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,3020,1,Intermed Span Grammar & Comp,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,
-SPAN,3020,2,Intermed Span Grammar & Comp,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,melva margu persico,
-SPAN,3020,3,Intermed Span Grammar & Comp,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,
-SPAN,3040,2,Intro Hispanic Literary Forms,0.88,0.04,0.04,0.0,0.04,0.0,0.0,0.0,george palacios,
-SPAN,3050,3,Intermed Span Convers/Comp I,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,3050,4,Intermed Span Convers/Comp I,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,3070,1,The Hispanic World: Spain,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,
-SPAN,3070,35,The Hispanic World: Spain,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,3080,1,The Hispanic World: Latin Amer,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,tiffany dawn miller,
-SPAN,3080,2,The Hispanic World: Latin Amer,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,
-SPAN,3080,30,The Hispanic World: Latin Amer,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,danie garcia vieyra,
-SPAN,3130,1,Span Lit Survey I,0.3,0.4,0.2,0.0,0.0,0.0,0.0,0.1,mon rojas-de-massei,
-SPAN,3160,35,Spanish for Int'l Business I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,4030,1,Span Amer Wom Writer,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,
-SPAN,4060,1,Narrative Fiction,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,
-SPAN,4070,1,Hispanic Film,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,salvador oropesa,
-SPAN,4160,35,Spanish for Int'l Trade II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-SPAN,4190,35,Health & Hispanic Community,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,
-STAT,2220,1,Statistics in Everyday Life,0.31,0.44,0.1,0.09,0.04,0.0,0.0,0.01,james espey,
-STAT,2220,2,Statistics in Everyday Life,0.47,0.29,0.17,0.03,0.0,0.0,0.0,0.04,james espey,
-STAT,2220,3,Statistics in Everyday Life,0.48,0.36,0.09,0.05,0.02,0.0,0.0,0.0,james espey,
-STAT,2220,4,Statistics in Everyday Life,0.31,0.44,0.16,0.04,0.04,0.0,0.0,0.0,james espey,
-STAT,2220,5,Statistics in Everyday Life,0.4,0.38,0.17,0.04,0.02,0.0,0.0,0.0,ros martinez-dawson,
-STAT,2220,6,Statistics in Everyday Life,0.31,0.36,0.08,0.13,0.08,0.0,0.0,0.05,ros martinez-dawson,
-STAT,2220,7,Statistics in Everyday Life,0.35,0.34,0.15,0.04,0.04,0.0,0.0,0.07,ros martinez-dawson,
-STAT,2300,1,Statistical Methods I,0.09,0.31,0.29,0.11,0.13,0.0,0.0,0.08,morgan elston,
-STAT,2300,2,Statistical Methods I,0.39,0.28,0.18,0.08,0.03,0.0,0.0,0.04,christy jenki brown,
-STAT,2300,3,Statistical Methods I,0.25,0.36,0.15,0.15,0.06,0.0,0.0,0.04, erwin walker,
-STAT,2300,4,Statistical Methods I,0.21,0.41,0.19,0.09,0.08,0.0,0.0,0.03, erwin walker,
-STAT,2300,5,Statistical Methods I,0.37,0.33,0.21,0.06,0.01,0.0,0.0,0.02,sharon marie evans,
-STAT,2300,6,Statistical Methods I,0.39,0.34,0.15,0.07,0.02,0.0,0.0,0.03,sharon marie evans,
-STAT,2300,100,Statistical Methods I (HON),0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,christy jenki brown,True
-STAT,3090,1,Introductory Business Stats,0.35,0.41,0.15,0.0,0.06,0.0,0.0,0.03,anna marie vagnozzi,
-STAT,3090,2,Introductory Business Stats,0.45,0.36,0.09,0.06,0.03,0.0,0.0,0.0,kristina gorsline,
-STAT,3090,3,Introductory Business Stats,0.44,0.25,0.19,0.06,0.03,0.0,0.0,0.03,alan robert hahn,
-STAT,3090,4,Introductory Business Stats,0.27,0.45,0.21,0.0,0.0,0.0,0.0,0.06,trevor squires,
-STAT,3090,5,Introductory Business Stats,0.28,0.28,0.28,0.03,0.06,0.0,0.0,0.06,yidan guo,
-STAT,3090,6,Introductory Business Stats,0.39,0.23,0.13,0.03,0.16,0.0,0.0,0.06,yiren ding,
-STAT,3090,7,Introductory Business Stats,0.37,0.26,0.23,0.06,0.03,0.0,0.0,0.06,paran rebeka norton,
-STAT,3090,8,Introductory Business Stats,0.21,0.21,0.24,0.18,0.09,0.0,0.0,0.09,michael thoma cowen,
-STAT,3090,9,Introductory Business Stats,0.18,0.24,0.26,0.18,0.09,0.0,0.0,0.06,sean wal ingimarson,
-STAT,3090,10,Introductory Business Stats,0.38,0.32,0.12,0.09,0.06,0.0,0.0,0.03,zhengxin wang,
-STAT,3090,11,Introductory Business Stats,0.24,0.25,0.31,0.1,0.0,0.0,0.07,0.03,april thomas,
-STAT,3090,12,Introductory Business Stats,0.37,0.29,0.24,0.08,0.0,0.0,0.01,0.0,april thomas,
-STAT,3090,13,Introductory Business Stats,0.29,0.21,0.21,0.18,0.03,0.0,0.0,0.09,xueheng shi,
-STAT,3090,14,Introductory Business Stats,0.32,0.24,0.21,0.09,0.0,0.0,0.15,0.0,fun choi john chan,
-STAT,3090,15,Introductory Business Stats,0.41,0.41,0.12,0.0,0.03,0.0,0.0,0.03,john char nicholson,
-STAT,3300,1,Statistical Methods II,0.44,0.17,0.22,0.06,0.0,0.0,0.0,0.11,ros martinez-dawson,
-STAT,4020,1,Intro to Statistical Computing,0.7,0.1,0.1,0.0,0.05,0.0,0.0,0.05,ellen hepfe breazel,
-STAT,4020,401,Intro to Statistical Computing,0.38,0.31,0.13,0.0,0.0,0.0,0.0,0.19,ellen hepfe breazel,
-STAT,4110,1,Stat Mthds for Process Control,0.62,0.32,0.05,0.0,0.0,0.0,0.0,0.0,william bridges,
-STAT,4110,2,Stat Mthds for Process Control,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard stev dubsky,
-STAT,4110,3,Stat Mthds for Process Control,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,richard stev dubsky,
-STAT,6020,1,Intro to Statistical Computing,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ellen hepfe breazel,
-STAT,6020,401,Intro to Statistical Computing,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,ellen hepfe breazel,
-STAT,8010,2,Statistical Methods I,0.57,0.39,0.0,0.0,0.0,0.0,0.0,0.04,william bridges,
-STAT,8010,3,Statistical Methods I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,deborah eliz kunkel,
-STAT,8010,4,Statistical Methods I,0.61,0.0,0.11,0.0,0.17,0.0,0.0,0.11,jun luo,
-STAT,8010,5,Statistical Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,
-STAT,8010,400,Statistical Methods I,0.41,0.55,0.0,0.0,0.0,0.0,0.0,0.03,brook thaye russell,
-STAT,8010,400,Statistical Methods I,0.41,0.55,0.0,0.0,0.0,0.0,0.0,0.03,deborah eliz kunkel,
-STAT,8050,1,Design & Anlys of Experiments,0.56,0.22,0.04,0.0,0.0,0.0,0.0,0.19,patrick gerard,
-STS,1010,1,Survey Sci & Techn in Society,0.63,0.34,0.0,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,
-STS,1010,2,Survey Sci & Techn in Society,0.44,0.35,0.15,0.0,0.0,0.0,0.0,0.06,scott brame,
-STS,1010,3,Survey Sci & Techn in Society,0.53,0.33,0.06,0.06,0.0,0.0,0.03,0.0,elizabeth stansell,
-STS,1010,4,Survey Sci & Techn in Society,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,
-STS,1010,5,Survey Sci & Techn in Society,0.38,0.49,0.08,0.0,0.03,0.0,0.0,0.03,philip randall,
-STS,1010,6,Survey Sci & Techn in Society,0.09,0.51,0.17,0.03,0.03,0.0,0.0,0.17,sarah mae cooper,
-STS,1010,7,Survey Sci & Techn in Society,0.26,0.43,0.06,0.03,0.14,0.0,0.0,0.09,megan no macalystre,
-STS,1010,8,Survey Sci & Techn in Society,0.25,0.59,0.06,0.03,0.0,0.0,0.0,0.06,david charles foltz,
-STS,1010,9,Survey Sci & Techn in Society,0.81,0.14,0.03,0.0,0.0,0.0,0.0,0.03,christine cl murphy,
-STS,1010,10,Survey Sci & Techn in Society,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alexander billinis,
-THEA,2100,1,Theatre Appreciation,0.56,0.28,0.13,0.03,0.0,0.0,0.0,0.0,kerrie kath seymour,
-THEA,2100,2,Theatre Appreciation,0.42,0.29,0.23,0.03,0.0,0.0,0.0,0.03,kendra lyne johnson,
-THEA,2100,4,Theatre Appreciation,0.58,0.32,0.1,0.0,0.0,0.0,0.0,0.0,carol collins,
-THEA,2100,5,Theatre Appreciation,0.59,0.31,0.09,0.0,0.0,0.0,0.0,0.0,jason adkins,
-THEA,2790,1,Theatre Practicum,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,matthew leckenbusch,
-THEA,3090,1,Surv of Broadway II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,
-THEA,3150,1,Theatre History I,0.65,0.29,0.0,0.0,0.03,0.0,0.0,0.03,shannon ther robert,
-THEA,3180,1,Afri-Amer Thea II,0.66,0.21,0.14,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,
-THEA,3740,1,Movement for Actors,0.75,0.0,0.17,0.08,0.0,0.0,0.0,0.0,kerrie kath seymour,
-THEA,3980,1,Special Topics in Theatre,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,
-WFB,3000,1,Wildlife Biology,0.43,0.29,0.2,0.06,0.01,0.0,0.0,0.0,catherine jachowski,
-WFB,3010,1,Wildlife Biology Lab,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,3130,1,Conservation Biology,0.35,0.34,0.24,0.04,0.03,0.0,0.0,0.01,shari lyn rodriguez,
-WFB,3130,2,Conservation Biology,0.29,0.32,0.27,0.05,0.02,0.0,0.0,0.05,shari lyn rodriguez,
-WFB,4120,1,Wildlife Management,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,
-WFB,4160,1,Fisheries Techniques,0.63,0.34,0.02,0.0,0.0,0.0,0.0,0.0,troy mason farmer,
-WFB,4620,1,Wetland Wildlife Biology,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,russell barrett,
-WFB,4680,1,Herpetology,0.38,0.43,0.19,0.0,0.0,0.0,0.0,0.0,jeffrey robert mohr,
-WFB,4930,2,Quantitative Ecology,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.05,laura gigliotti,
-WFB,8500,1,Wildlife & Fisheries Ecology,0.38,0.38,0.05,0.0,0.05,0.0,0.0,0.14,mark scott,
-WFB,8500,1,Wildlife & Fisheries Ecology,0.38,0.38,0.05,0.0,0.05,0.0,0.0,0.14,susan talley guynn,
-WFB,8610,1,Scientific Writing,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,stefanie whitmire,
-WFB,8610,3,Hum Dim/Fisheries & WL -OnLine,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,shari lyn rodriguez,
-WFB,8630,1,Non Thesis Project,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,althea simone hagan,
-WS,1030,1,Women in Global Perspective,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,
-WS,3010,1,Intro Women's Studies,0.58,0.33,0.04,0.04,0.0,0.0,0.0,0.0,elizabeth ros adams,
-WS,3010,2,Intro Women's Studies,0.46,0.38,0.13,0.0,0.0,0.0,0.0,0.04,elizabeth ros adams,
-WS,4010,1,Senior Seminar,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,diane perpich,
-YDP,3100,1,Youth Developmt and the Family,0.72,0.16,0.0,0.0,0.04,0.0,0.0,0.08,william quinn,
-YDP,3150,2,Community & Youth Dev Systems,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephen lance,
-YDP,3250,1,Working with Diverse Youth,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,kimberly pe johnson,
-YDP,3350,1,Youth Activity Leadership,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,alexandra sandoval,
-YDP,3400,1,Deliver Effective Youth Progra,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,kellye rembert,
-YDP,4400,1,Youth Program Assessmnt & Eval,0.58,0.26,0.0,0.11,0.0,0.0,0.0,0.05,ann marie gillard,
-YDP,8010,1,Child/Adolescent Dev,0.85,0.11,0.0,0.0,0.04,0.0,0.0,0.0,edmond patri bowers,
-YDP,8040,1,Assess & Eval of Youth Program,0.7,0.15,0.15,0.0,0.0,0.0,0.0,0.0,barry garst,
-YDP,8880,1,Special Topics Youth Dev Ldshp,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,barry garst,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1020,1,Survey of Art & Arch Hist II,0.46,0.42,0.11,0.0,0.0,0.0,0.0,0.01,beth ann lauritis,,AAH-1020,2019
+AAH,2060,1,Art History and Theory II,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,andrea feeser,,AAH-2060,2019
+ACCT,2010,1,Financial Accounting Concepts,0.61,0.2,0.1,0.05,0.0,0.0,0.02,0.02,emily suza mccorkle,,ACCT-2010,2019
+ACCT,2010,2,Financial Accounting Concepts,0.31,0.43,0.19,0.05,0.02,0.0,0.0,0.0,emily suza mccorkle,,ACCT-2010,2019
+ACCT,2010,3,Financial Accounting Concepts,0.18,0.52,0.2,0.05,0.02,0.0,0.0,0.02,lydia lan schleifer,,ACCT-2010,2019
+ACCT,2010,4,Financial Accounting Concepts,0.45,0.33,0.1,0.03,0.03,0.0,0.0,0.08,annieka philo,,ACCT-2010,2019
+ACCT,2010,5,Financial Accounting Concepts,0.3,0.43,0.15,0.08,0.03,0.0,0.0,0.03,annieka philo,,ACCT-2010,2019
+ACCT,2010,6,Financial Accounting Concepts,0.2,0.43,0.25,0.05,0.03,0.0,0.0,0.05,annieka philo,,ACCT-2010,2019
+ACCT,2010,7,Financial Accounting Concepts,0.16,0.48,0.23,0.02,0.07,0.0,0.0,0.05,lydia lan schleifer,,ACCT-2010,2019
+ACCT,2010,8,Financial Accounting Concepts,0.07,0.4,0.37,0.07,0.02,0.0,0.0,0.07,lydia lan schleifer,,ACCT-2010,2019
+ACCT,2010,9,Financial Accounting Concepts,0.35,0.33,0.2,0.03,0.1,0.0,0.0,0.0,annieka philo,,ACCT-2010,2019
+ACCT,2010,10,Financial Accounting Concepts,0.16,0.25,0.25,0.09,0.09,0.0,0.0,0.16,mary ann  prater,,ACCT-2010,2019
+ACCT,2010,11,Financial Accounting Concepts,0.31,0.4,0.11,0.03,0.06,0.0,0.0,0.09,charles tegen,,ACCT-2010,2019
+ACCT,2010,12,Financial Accounting Concepts,0.3,0.38,0.13,0.0,0.08,0.0,0.0,0.13,lisa whe birtwistle,,ACCT-2010,2019
+ACCT,2010,13,Financial Accounting Concepts,0.41,0.31,0.21,0.03,0.0,0.0,0.05,0.0,lisa whe birtwistle,,ACCT-2010,2019
+ACCT,2010,14,Financial Accounting Concepts,0.46,0.36,0.13,0.0,0.05,0.0,0.0,0.0,lisa whe birtwistle,,ACCT-2010,2019
+ACCT,2010,15,Financial Accounting Concepts,0.34,0.39,0.15,0.07,0.05,0.0,0.0,0.0,james barnes,,ACCT-2010,2019
+ACCT,2010,16,Financial Accounting Concepts,0.37,0.33,0.14,0.05,0.07,0.0,0.0,0.05,james barnes,,ACCT-2010,2019
+ACCT,2010,17,Financial Accounting Concepts,0.0,0.34,0.41,0.07,0.07,0.0,0.0,0.1,lydia lan schleifer,,ACCT-2010,2019
+ACCT,2010,101,Fin Acct Concepts (HON),0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,mary ann  prater,True,ACCT-2010,2019
+ACCT,2010,401,Financial Accounting Concepts,0.29,0.36,0.18,0.06,0.08,0.0,0.0,0.03,jeffrey mcmillan,,ACCT-2010,2019
+ACCT,2020,1,Managerial Accounting Concepts,0.25,0.25,0.29,0.04,0.07,0.0,0.0,0.11,henry anderson,,ACCT-2020,2019
+ACCT,2020,2,Managerial Accounting Concepts,0.34,0.26,0.26,0.06,0.03,0.0,0.0,0.06,henry anderson,,ACCT-2020,2019
+ACCT,2020,3,Managerial Accounting Concepts,0.41,0.31,0.13,0.05,0.0,0.0,0.03,0.08,henry anderson,,ACCT-2020,2019
+ACCT,2020,4,Managerial Accounting Concepts,0.29,0.36,0.24,0.05,0.05,0.0,0.0,0.02,emily suza mccorkle,,ACCT-2020,2019
+ACCT,2020,5,Managerial Accounting Concepts,0.33,0.4,0.14,0.05,0.0,0.0,0.05,0.02,emily suza mccorkle,,ACCT-2020,2019
+ACCT,2020,6,Managerial Accounting Concepts,0.31,0.27,0.25,0.1,0.02,0.0,0.0,0.04,phebia davis-culler,,ACCT-2020,2019
+ACCT,2020,7,Managerial Accounting Concepts,0.23,0.38,0.17,0.09,0.0,0.0,0.13,0.0,phebia davis-culler,,ACCT-2020,2019
+ACCT,2020,8,Managerial Accounting Concepts,0.16,0.23,0.37,0.09,0.0,0.0,0.09,0.05,phebia davis-culler,,ACCT-2020,2019
+ACCT,2020,401,Managerial Accounting Concepts,0.28,0.35,0.22,0.04,0.01,0.0,0.0,0.11,henry anderson,,ACCT-2020,2019
+ACCT,2900,1,Special Topics - Soft Skills,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,michael mendonca,,ACCT-2900,2019
+ACCT,3030,1,Cost Accounting,0.38,0.31,0.28,0.03,0.0,0.0,0.0,0.0,babak mammadov,,ACCT-3030,2019
+ACCT,3030,2,Cost Accounting,0.29,0.37,0.29,0.05,0.0,0.0,0.0,0.0,babak mammadov,,ACCT-3030,2019
+ACCT,3030,3,Cost Accounting,0.12,0.36,0.36,0.06,0.03,0.0,0.0,0.06,jace garrett,,ACCT-3030,2019
+ACCT,3030,4,Cost Accounting,0.33,0.25,0.33,0.03,0.03,0.0,0.0,0.03,jace garrett,,ACCT-3030,2019
+ACCT,3030,5,Cost Accounting,0.28,0.44,0.08,0.11,0.0,0.0,0.0,0.08,jace garrett,,ACCT-3030,2019
+ACCT,3110,1,Intermediate Financial Acct I,0.14,0.29,0.18,0.11,0.21,0.0,0.0,0.07,erin michel hawkins,,ACCT-3110,2019
+ACCT,3110,2,Intermediate Financial Acct I,0.19,0.31,0.23,0.08,0.15,0.0,0.0,0.04,erin michel hawkins,,ACCT-3110,2019
+ACCT,3110,3,Intermediate Financial Acct I,0.23,0.26,0.32,0.03,0.03,0.0,0.0,0.13,amy meliss donnelly,,ACCT-3110,2019
+ACCT,3110,4,Intermediate Financial Acct I,0.28,0.38,0.22,0.09,0.0,0.0,0.0,0.03,amy meliss donnelly,,ACCT-3110,2019
+ACCT,3110,5,Intermediate Financial Acct I,0.1,0.42,0.35,0.03,0.0,0.0,0.0,0.1,brian matth goodson,,ACCT-3110,2019
+ACCT,3110,6,Intermediate Financial Acct I,0.17,0.23,0.37,0.07,0.0,0.0,0.0,0.17,brian matth goodson,,ACCT-3110,2019
+ACCT,3110,401,Intermediate Financial Acct I,0.32,0.22,0.2,0.02,0.05,0.0,0.0,0.2,henry anderson,,ACCT-3110,2019
+ACCT,3120,1,Intermediate Financial Acct II,0.16,0.21,0.32,0.11,0.05,0.0,0.0,0.16,jeremy micha vinson,,ACCT-3120,2019
+ACCT,3120,2,Intermediate Financial Acct II,0.35,0.26,0.29,0.06,0.0,0.0,0.0,0.03,jeremy micha vinson,,ACCT-3120,2019
+ACCT,3120,3,Intermediate Financial Acct II,0.41,0.45,0.1,0.0,0.0,0.0,0.0,0.03,terry daniel knause,,ACCT-3120,2019
+ACCT,3120,4,Intermediate Financial Acct II,0.29,0.53,0.12,0.0,0.03,0.0,0.0,0.03,terry daniel knause,,ACCT-3120,2019
+ACCT,3120,5,Intermediate Financial Acct II,0.14,0.48,0.29,0.0,0.0,0.0,0.0,0.1,terry daniel knause,,ACCT-3120,2019
+ACCT,3120,6,Intermediate Financial Acct II,0.32,0.42,0.16,0.0,0.03,0.0,0.0,0.06,terry daniel knause,,ACCT-3120,2019
+ACCT,3120,101,Intermed Fin Acct II (HON),0.67,0.25,0.08,0.0,0.0,0.0,0.0,0.0,terry daniel knause,True,ACCT-3120,2019
+ACCT,3130,1,Intermediate Fin Acct III,0.24,0.5,0.24,0.0,0.0,0.0,0.0,0.02, russell madray,,ACCT-3130,2019
+ACCT,3130,2,Intermediate Fin Acct III,0.22,0.44,0.2,0.1,0.02,0.0,0.0,0.02, russell madray,,ACCT-3130,2019
+ACCT,3130,3,Intermediate Fin Acct III,0.38,0.43,0.17,0.02,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2019
+ACCT,3130,4,Intermediate Fin Acct III,0.45,0.42,0.09,0.03,0.0,0.0,0.0,0.0, russell madray,,ACCT-3130,2019
+ACCT,3130,101,Intermed Fin Acct III (HON),0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0, russell madray,True,ACCT-3130,2019
+ACCT,3220,1,Accounting Information Systems,0.08,0.25,0.38,0.08,0.04,0.0,0.0,0.17,philip maiberger,,ACCT-3220,2019
+ACCT,3220,2,Accounting Information Systems,0.04,0.48,0.3,0.09,0.04,0.0,0.0,0.04,philip maiberger,,ACCT-3220,2019
+ACCT,3220,3,Accounting Information Systems,0.21,0.38,0.25,0.08,0.04,0.0,0.0,0.04,philip maiberger,,ACCT-3220,2019
+ACCT,3220,4,Accounting Information Systems,0.1,0.38,0.29,0.0,0.0,0.0,0.1,0.14,philip maiberger,,ACCT-3220,2019
+ACCT,4040,1,Individual Taxation,0.45,0.36,0.12,0.06,0.0,0.0,0.0,0.0,sarah martin,,ACCT-4040,2019
+ACCT,4040,2,Individual Taxation,0.38,0.35,0.18,0.05,0.03,0.0,0.0,0.03,sarah martin,,ACCT-4040,2019
+ACCT,4040,3,Individual Taxation,0.24,0.53,0.16,0.05,0.0,0.0,0.0,0.03,lisa whe birtwistle,,ACCT-4040,2019
+ACCT,4040,4,Individual Taxation,0.27,0.27,0.27,0.16,0.03,0.0,0.0,0.0,lisa whe birtwistle,,ACCT-4040,2019
+ACCT,4040,101,Individual Taxation (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,sarah martin,True,ACCT-4040,2019
+ACCT,4100,1,Reporting and Mgmt Control Sys,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,frances kennedy,,ACCT-4100,2019
+ACCT,4100,2,Reporting and Mgmt Control Sys,0.79,0.18,0.04,0.0,0.0,0.0,0.0,0.0,frances kennedy,,ACCT-4100,2019
+ACCT,4100,3,Reporting and Mgmt Control Sys,0.33,0.5,0.13,0.03,0.0,0.0,0.0,0.0,gregory patr mcphee,,ACCT-4100,2019
+ACCT,4150,1,Auditing,0.08,0.42,0.44,0.06,0.0,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2019
+ACCT,4150,2,Auditing,0.26,0.31,0.28,0.15,0.0,0.0,0.0,0.0,carl hollingsworth,,ACCT-4150,2019
+ACCT,8520,1,Fin Acct Theory/Res,0.13,0.52,0.32,0.0,0.03,0.0,0.0,0.0,ralph edward welton,,ACCT-8520,2019
+ACCT,8520,2,Fin Acct Theory/Res,0.28,0.59,0.14,0.0,0.0,0.0,0.0,0.0,ralph edward welton,,ACCT-8520,2019
+ACCT,8540,1,Prof Responsibility,0.3,0.7,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,,ACCT-8540,2019
+ACCT,8540,2,Prof Responsibility,0.58,0.39,0.03,0.0,0.0,0.0,0.0,0.0,robin radtke,,ACCT-8540,2019
+ACCT,8540,3,Prof Responsibility,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,robin radtke,,ACCT-8540,2019
+ACCT,8620,1,Financial Auditing,0.47,0.53,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-8620,2019
+ACCT,8620,2,Financial Auditing,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,nancy lee harp,,ACCT-8620,2019
+ACCT,8710,1,Corporate Taxation,0.3,0.61,0.09,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2019
+ACCT,8710,2,Corporate Taxation,0.49,0.44,0.08,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2019
+ACCT,8710,3,Corporate Taxation,0.46,0.43,0.11,0.0,0.0,0.0,0.0,0.0,derek dalton,,ACCT-8710,2019
+ACCT,8730,1,Intl/Spec Tax Topic,0.48,0.39,0.13,0.0,0.0,0.0,0.0,0.0,kath kisska-schulze,,ACCT-8730,2019
+ACCT,8740,1,Tax Aspects of Finan Planning,0.41,0.59,0.0,0.0,0.0,0.0,0.0,0.0,judson jahn,,ACCT-8740,2019
+AGED,1000,1,Orientation & Field Experience,0.72,0.17,0.0,0.0,0.06,0.0,0.0,0.06,philip fravel,,AGED-1000,2019
+AGED,2030,1,Teaching Agriscience,0.38,0.54,0.0,0.0,0.0,0.0,0.0,0.08,catheri dibenedetto,,AGED-2030,2019
+AGED,8890,1,Intro to Res in Ed,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alex byrd,,AGED-8890,2019
+AGM,2050,1,Prin of Fabrication,0.29,0.42,0.11,0.05,0.08,0.0,0.0,0.05,hunter massey,,AGM-2050,2019
+AGM,2060,1,Machinery Mgt,0.28,0.48,0.12,0.04,0.04,0.0,0.0,0.04,hunter massey,,AGM-2060,2019
+AGM,2200,1,Calc for Mechanized Agricult,0.37,0.34,0.21,0.05,0.0,0.0,0.0,0.03,aaron paul turner,,AGM-2200,2019
+AGM,2210,1,Land Measurements,0.6,0.26,0.13,0.01,0.0,0.0,0.0,0.0,robert gord hammond,,AGM-2210,2019
+AGM,2210,1,Land Measurements,0.6,0.26,0.13,0.01,0.0,0.0,0.0,0.0,charles privette,,AGM-2210,2019
+AGM,4020,1,Irrigation System Design,0.26,0.51,0.23,0.0,0.0,0.0,0.0,0.0,charles privette,,AGM-4020,2019
+AGM,4100,1,Precision Ag Tech,0.36,0.43,0.15,0.06,0.0,0.0,0.0,0.0,hunter massey,,AGM-4100,2019
+AGM,4520,1,Mobile Power,0.5,0.39,0.05,0.0,0.03,0.0,0.0,0.03,ali bulent koc,,AGM-4520,2019
+AGM,4720,1,Capstone,0.68,0.28,0.04,0.0,0.0,0.0,0.0,0.0,john chastain,,AGM-4720,2019
+AGRB,2020,1,Agricultural Economics,0.34,0.37,0.14,0.08,0.07,0.0,0.0,0.0,george apperson,,AGRB-2020,2019
+AGRB,2050,1,Agriculture and Society,0.18,0.48,0.22,0.06,0.03,0.0,0.0,0.03,george apperson,,AGRB-2050,2019
+AGRB,3080,1,Quant Agribusiness Analysis I,0.15,0.42,0.18,0.15,0.03,0.0,0.0,0.06,lisha zhang,,AGRB-3080,2019
+AGRB,3190,1,Agribusiness Management,0.2,0.19,0.3,0.16,0.04,0.0,0.0,0.11,michael vassalos,,AGRB-3190,2019
+AGRB,3510,1,Prin of Agricultural Sales Mgt,0.06,0.5,0.38,0.03,0.03,0.0,0.0,0.0,george apperson,,AGRB-3510,2019
+AGRB,3570,1,Natural Resources Economics,0.21,0.23,0.36,0.17,0.0,0.0,0.0,0.02,david brian willis,,AGRB-3570,2019
+AGRB,4020,1,Production Economics,0.23,0.38,0.0,0.31,0.0,0.0,0.0,0.08,michael vassalos,,AGRB-4020,2019
+AGRB,4080,1,Quant Agribusiness Analysis II,0.42,0.33,0.21,0.02,0.02,0.0,0.0,0.0,lisha zhang,,AGRB-4080,2019
+AGRB,4560,1,Prices,0.43,0.4,0.12,0.05,0.0,0.0,0.0,0.0,yuliya val bolotova,,AGRB-4560,2019
+AL,3490,400,Principles of Coaching,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2019
+AL,3490,401,Principles of Coaching,0.61,0.29,0.11,0.0,0.0,0.0,0.0,0.0,deborah cadorette,,AL-3490,2019
+AL,3490,402,Principles of Coaching,0.7,0.11,0.04,0.04,0.04,0.0,0.0,0.07,frank mezzanotte,,AL-3490,2019
+AL,3490,403,Principles of Coaching,0.6,0.28,0.04,0.08,0.0,0.0,0.0,0.0,clyde keith connor,,AL-3490,2019
+AL,3490,404,Principles of Coaching,0.89,0.07,0.04,0.0,0.0,0.0,0.0,0.0,nicholas ph whitrow,,AL-3490,2019
+AL,3490,406,Principles of Coaching,0.6,0.28,0.08,0.0,0.0,0.0,0.0,0.04,john plumblee,,AL-3490,2019
+AL,3490,407,Principles of Coaching,0.72,0.12,0.16,0.0,0.0,0.0,0.0,0.0,john plumblee,,AL-3490,2019
+AL,3490,408,Principles of Coaching,0.84,0.04,0.08,0.0,0.0,0.0,0.0,0.04,nicholas ph whitrow,,AL-3490,2019
+AL,3490,409,Principles of Coaching,0.88,0.08,0.0,0.0,0.04,0.0,0.0,0.0,nicholas ph whitrow,,AL-3490,2019
+AL,3490,410,Principles of Coaching,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,edmond fry,,AL-3490,2019
+AL,3500,400,Sci Basis I/Ex Phy,0.2,0.24,0.28,0.2,0.04,0.0,0.0,0.04,michael godfrey,,AL-3500,2019
+AL,3500,401,Sci Basis I/Ex Phy,0.19,0.26,0.33,0.15,0.04,0.0,0.0,0.04,michael godfrey,,AL-3500,2019
+AL,3520,400,Kinesiology,0.27,0.13,0.0,0.2,0.2,0.0,0.0,0.2,isaac sean colbert,,AL-3520,2019
+AL,3530,400,Athletic Injuries,0.12,0.32,0.48,0.04,0.04,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2019
+AL,3530,401,Athletic Injuries,0.16,0.32,0.4,0.08,0.04,0.0,0.0,0.0,isaac sean colbert,,AL-3530,2019
+AL,3600,400,Hgh Sch Athl Ethical/Legal Iss,0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,clyde keith connor,,AL-3600,2019
+AL,3610,400,Admin/Org of Athletic Programs,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2019
+AL,3610,401,Admin/Org of Athletic Programs,0.78,0.19,0.04,0.0,0.0,0.0,0.0,0.0,henry oates,,AL-3610,2019
+AL,3610,402,Admin/Org of Athletic Programs,0.83,0.08,0.04,0.0,0.04,0.0,0.0,0.0,henry oates,,AL-3610,2019
+AL,3620,400,Psychology of Coaching,0.24,0.36,0.32,0.0,0.04,0.0,0.0,0.04,natalie anne carter,,AL-3620,2019
+AL,3620,401,Psychology of Coaching,0.36,0.36,0.2,0.04,0.0,0.0,0.0,0.04,natalie anne carter,,AL-3620,2019
+AL,3620,402,Psychology of Coaching,0.38,0.25,0.29,0.0,0.04,0.0,0.0,0.04,natalie anne carter,,AL-3620,2019
+AL,3710,400,Coaching Baseball,0.55,0.3,0.05,0.0,0.0,0.0,0.0,0.1,deborah cadorette,,AL-3710,2019
+AL,3720,400,Coaching Basketball,0.72,0.12,0.08,0.04,0.04,0.0,0.0,0.0,edmond fry,,AL-3720,2019
+AL,3740,400,Coaching Football,0.48,0.24,0.2,0.08,0.0,0.0,0.0,0.0,edmond fry,,AL-3740,2019
+AL,3750,400,Coaching Soccer,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,deborah cadorette,,AL-3750,2019
+AL,3760,400,Coaching Strength/Conditioning,0.56,0.19,0.19,0.04,0.0,0.0,0.0,0.04,edmond fry,,AL-3760,2019
+AL,3760,401,Coaching Strength/Conditioning,0.58,0.21,0.08,0.0,0.08,0.0,0.0,0.04,edmond fry,,AL-3760,2019
+AL,4380,401,Officiating in Athl Leadership,0.68,0.16,0.08,0.04,0.04,0.0,0.0,0.0,clyde keith connor,,AL-4380,2019
+AL,4380,403,Social Issues,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,misty soles,,AL-4380,2019
+AL,4490,400,Athlete Beliefs,0.41,0.3,0.15,0.15,0.0,0.0,0.0,0.0,deborah cadorette,,AL-4490,2019
+AL,4490,401,Athlete Beliefs,0.58,0.21,0.08,0.04,0.08,0.0,0.0,0.0,deborah cadorette,,AL-4490,2019
+AL,8380,400,Intercoll Ath Personnel Mgm,0.85,0.07,0.04,0.0,0.04,0.0,0.0,0.0,kyle mclendon young,,AL-8380,2019
+AL,8530,400,Legal Iss in Intercoll Athlet,0.81,0.15,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,,AL-8530,2019
+AL,8630,400,Socio Dynam in Intercol Athlet,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,michael godfrey,,AL-8630,2019
+AL,8630,401,Socio Dynam in Intercol Athlet,0.58,0.26,0.11,0.0,0.05,0.0,0.0,0.0,michael godfrey,,AL-8630,2019
+AL,8640,400,Ethical Iss in Collegiate Athl,0.85,0.11,0.04,0.0,0.0,0.0,0.0,0.0,janna there magette,,AL-8640,2019
+AL,8640,401,Ethical Iss in Collegiate Athl,0.69,0.19,0.08,0.0,0.0,0.0,0.0,0.04,janna there magette,,AL-8640,2019
+AL,8700,400,Intercoll Athletics Finance,0.84,0.12,0.0,0.0,0.0,0.0,0.0,0.04,misty soles,,AL-8700,2019
+AL,8700,401,Intercoll Athletics Finance,0.87,0.07,0.0,0.0,0.07,0.0,0.0,0.0,misty soles,,AL-8700,2019
+ANTH,2010,1,Introduction to Anthropology,0.36,0.56,0.07,0.0,0.0,0.0,0.0,0.01,david markus,,ANTH-2010,2019
+ANTH,2010,2,Introduction to Anthropology,0.25,0.64,0.07,0.01,0.0,0.0,0.0,0.02,david markus,,ANTH-2010,2019
+ANTH,2010,3,Introduction to Anthropology,0.46,0.32,0.05,0.04,0.04,0.0,0.0,0.11,lisa rapaport,,ANTH-2010,2019
+ANTH,2010,4,Introduction to Anthropology,0.47,0.31,0.14,0.03,0.02,0.0,0.0,0.03,yi wu,,ANTH-2010,2019
+ANTH,3010,1,Cultural Anthropology,0.07,0.32,0.43,0.14,0.0,0.0,0.04,0.0,john coggeshall,,ANTH-3010,2019
+ANTH,3250,1,The Anthropology of Food,0.33,0.24,0.14,0.0,0.0,0.0,0.0,0.29,yi wu,,ANTH-3250,2019
+ANTH,3310,1,Archaeology,0.71,0.26,0.03,0.0,0.0,0.0,0.0,0.0,david markus,,ANTH-3310,2019
+ANTH,4040,1,Anthropological Theories,0.27,0.55,0.18,0.0,0.0,0.0,0.0,0.0,john coggeshall,,ANTH-4040,2019
+ANTH,4800,1,Business Anthropology,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,melissa vogel,,ANTH-4800,2019
+ARCH,1510,1,Arch Communication,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,sal hambright-belue,,ARCH-1510,2019
+ARCH,1510,2,Arch Communication,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,,ARCH-1510,2019
+ARCH,1510,2,Arch Communication,0.31,0.44,0.25,0.0,0.0,0.0,0.0,0.0,robert silance,,ARCH-1510,2019
+ARCH,1510,3,Arch Communication,0.57,0.21,0.0,0.07,0.07,0.0,0.0,0.07,sal hambright-belue,,ARCH-1510,2019
+ARCH,1510,3,Arch Communication,0.57,0.21,0.0,0.07,0.07,0.0,0.0,0.07,clarissa mendez,,ARCH-1510,2019
+ARCH,1510,4,Arch Communication,0.2,0.6,0.13,0.07,0.0,0.0,0.0,0.0,george schafer,,ARCH-1510,2019
+ARCH,1510,4,Arch Communication,0.2,0.6,0.13,0.07,0.0,0.0,0.0,0.0,sal hambright-belue,,ARCH-1510,2019
+ARCH,1510,5,Arch Communication,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,sal hambright-belue,,ARCH-1510,2019
+ARCH,1510,5,Arch Communication,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,berrin terim,,ARCH-1510,2019
+ARCH,1510,6,Arch Communication,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,sal hambright-belue,,ARCH-1510,2019
+ARCH,2520,1,Arch Foundations II,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-2520,2019
+ARCH,2520,1,Arch Foundations II,0.36,0.57,0.07,0.0,0.0,0.0,0.0,0.0,brandon george pass,,ARCH-2520,2019
+ARCH,2520,2,Arch Foundations II,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,clarissa mendez,,ARCH-2520,2019
+ARCH,2520,2,Arch Foundations II,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-2520,2019
+ARCH,2520,3,Arch Foundations II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,criss mills,,ARCH-2520,2019
+ARCH,2520,3,Arch Foundations II,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-2520,2019
+ARCH,2520,4,Arch Foundations II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,robert bruhns,,ARCH-2520,2019
+ARCH,2520,4,Arch Foundations II,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-2520,2019
+ARCH,2520,5,Arch Foundations II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph choma,,ARCH-2520,2019
+ARCH,2520,5,Arch Foundations II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-2520,2019
+ARCH,2520,6,Arch Foundations II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,berrin terim,,ARCH-2520,2019
+ARCH,2520,6,Arch Foundations II,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-2520,2019
+ARCH,2700,1,Structures I,0.55,0.09,0.27,0.0,0.09,0.0,0.0,0.0,michael carl kleiss,,ARCH-2700,2019
+ARCH,2710,1,Structures II,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,dustin gra albright,,ARCH-2710,2019
+ARCH,3510,2,Studio Clemson,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,daniel nevi harding,,ARCH-3510,2019
+ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-3540,2019
+ARCH,3540,1,Studio Barcelona,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-3540,2019
+ARCH,4050,1,American Arch Styles 1650-1950,0.63,0.25,0.06,0.0,0.06,0.0,0.0,0.0,robert bruhns,,ARCH-4050,2019
+ARCH,4120,2,History Research,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,henrique houayek,,ARCH-4120,2019
+ARCH,4120,2,History Research,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4120,2019
+ARCH,4140,2,Design Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4140,2019
+ARCH,4140,2,Design Seminar,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,miguel roldan,,ARCH-4140,2019
+ARCH,4210,1,Arch Seminar,0.27,0.73,0.0,0.0,0.0,0.0,0.0,0.0,raymond thadde huff,,ARCH-4210,2019
+ARCH,4290,1,Architectural Graphics,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,ashley jennings,,ARCH-4290,2019
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,david lee,,ARCH-4520,2019
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4520,2019
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-4520,2019
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,george schafer,,ARCH-4520,2019
+ARCH,4520,1,Synthesis Studio,0.0,0.67,0.25,0.08,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-4520,2019
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-4520,2019
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-4520,2019
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4520,2019
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4520,2019
+ARCH,4520,2,Synthesis Studio,0.0,0.67,0.33,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-4520,2019
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4520,2019
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-4520,2019
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4520,2019
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-4520,2019
+ARCH,4520,3,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-4520,2019
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-4520,2019
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4520,2019
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4520,2019
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-4520,2019
+ARCH,4520,4,Synthesis Studio,0.0,0.83,0.17,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-4520,2019
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,ulrike ann-so heine,,ARCH-4520,2019
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-4520,2019
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,timothy burl brown,,ARCH-4520,2019
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0,george schafer,,ARCH-4520,2019
+ARCH,4520,5,Synthesis Studio,0.0,0.73,0.27,0.0,0.0,0.0,0.0,0.0, franco santa cruz,,ARCH-4520,2019
+ARCH,4710,1,Arch Hist of Place,0.08,0.75,0.17,0.0,0.0,0.0,0.0,0.0,jason matthew white,,ARCH-4710,2019
+ARCH,8110,1,Visualization II,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,douglas hecker,,ARCH-8110,2019
+ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david lee,,ARCH-8120,2019
+ARCH,8120,1,Computational Design Methods,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,timothy sutherland,,ARCH-8120,2019
+ARCH,8520,7,Design Studio IV,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,julie poe wilkerson,,ARCH-8520,2019
+ARCH,8610,1,History/Theory II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ufuk ersoy,,ARCH-8610,2019
+ARCH,8620,2,History/Theory III,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,james thomas,,ARCH-8620,2019
+ARCH,8650,1,Topics in Health Policy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,anjali joseph,,ARCH-8650,2019
+ARCH,8650,1,Topics in Health Policy,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deborah mar wingler,,ARCH-8650,2019
+ARCH,8710,1,Structures II,0.54,0.31,0.08,0.0,0.08,0.0,0.0,0.0,dustin gra albright,,ARCH-8710,2019
+ARCH,8710,1,Structures II,0.54,0.31,0.08,0.0,0.08,0.0,0.0,0.0,timothy burl brown,,ARCH-8710,2019
+ARCH,8730,2,Environmental Sys,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,,ARCH-8730,2019
+ART,1060,1,Foundation Drawing II,0.5,0.33,0.08,0.0,0.0,0.0,0.0,0.08,denise elizab ayers,,ART-1060,2019
+ART,1510,1,Foundations Art I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,,ART-1510,2019
+ART,1520,1,Foundations Art II,0.42,0.25,0.25,0.08,0.0,0.0,0.0,0.0,daniel bare,,ART-1520,2019
+ART,2050,1,Beginning Life Drawing,0.53,0.29,0.0,0.06,0.06,0.0,0.0,0.06,annamarie williams,,ART-2050,2019
+ART,2070,1,Beginning Painting,0.38,0.54,0.0,0.0,0.08,0.0,0.0,0.0,serra raven shuford,,ART-2070,2019
+ART,2090,1,Beginning Sculpture,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,,ART-2090,2019
+ART,2100,6,Art Appreciation,0.79,0.17,0.0,0.0,0.0,0.0,0.0,0.04,angel roch estrella,,ART-2100,2019
+ART,2100,7,Art Appreciation,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,,ART-2100,2019
+ART,2100,10,Art Appreciation,0.84,0.12,0.0,0.0,0.04,0.0,0.0,0.0,deighton tay abrams,,ART-2100,2019
+ART,2100,11,Art Appreciation,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,,ART-2100,2019
+ART,2110,1,Begin Printmaking,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,allison rae johnson,,ART-2110,2019
+ART,2130,1,Begin Photography,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,,ART-2130,2019
+ART,2170,1,Beginning Ceramics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,sara mays,,ART-2170,2019
+ART,3130,1,Photography,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,anderson wrangle,,ART-3130,2019
+ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,de woodward-detrich,,ART-3550,2019
+ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,joseph ric manson ,,ART-3550,2019
+ART,3550,1,Atelier InSite-Creat Inq I,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0,david detrich,,ART-3550,2019
+ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,daniel bare,,ART-3570,2019
+ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,deighton tay abrams,,ART-3570,2019
+ART,3570,1,Community Supported Art - CI,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,valerie zimany,,ART-3570,2019
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-1100,2019
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1100,2019
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,,AS-1100,2019
+AS,1100,1,Air Force Today II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-1100,2019
+AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,,AS-1100,2019
+AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-1100,2019
+AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-1100,2019
+AS,1100,2,Air Force Today II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-1100,2019
+AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,,AS-2100,2019
+AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-2100,2019
+AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2100,2019
+AS,2100,1,Dev of Air Power II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-2100,2019
+AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,,AS-2100,2019
+AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2100,2019
+AS,2100,2,Dev of Air Power II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-2100,2019
+AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,,AS-2100,2019
+AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-2100,2019
+AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-2100,2019
+AS,2100,3,Dev of Air Power II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-2100,2019
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4100,2019
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-4100,2019
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,,AS-4100,2019
+AS,4100,1,Nat Sec Policy II,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-4100,2019
+AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,michael allen moore,,AS-4100,2019
+AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,keith balts,,AS-4100,2019
+AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,brock lusk,,AS-4100,2019
+AS,4100,2,Nat Sec Policy II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,rachelle mar miller,,AS-4100,2019
+ASL,1010,1,Am Sign Lang I,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,william ry clements,,ASL-1010,2019
+ASL,1010,2,Am Sign Lang I,0.8,0.16,0.0,0.0,0.0,0.0,0.0,0.04,william ry clements,,ASL-1010,2019
+ASL,1010,3,Am Sign Lang I,0.84,0.12,0.04,0.0,0.0,0.0,0.0,0.0,william ry clements,,ASL-1010,2019
+ASL,1020,1,Am Sign Lang I,0.61,0.22,0.17,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-1020,2019
+ASL,1020,2,Am Sign Lang I,0.5,0.38,0.04,0.04,0.04,0.0,0.0,0.0,jason hurdich,,ASL-1020,2019
+ASL,1020,3,Am Sign Lang I,0.63,0.25,0.06,0.0,0.0,0.0,0.0,0.06,william ry clements,,ASL-1020,2019
+ASL,1020,4,Am Sign Lang I,0.6,0.25,0.15,0.0,0.0,0.0,0.0,0.0,jody herbert cripps,,ASL-1020,2019
+ASL,2010,1,Am Sign Lang II,0.31,0.23,0.46,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-2010,2019
+ASL,2010,2,Am Sign Lang II,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-2010,2019
+ASL,2020,1,Am Sign Lang II,0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-2020,2019
+ASL,2020,2,Am Sign Lang II,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,jason hurdich,,ASL-2020,2019
+ASL,2020,3,Am Sign Lang II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,kim ma misener dunn,,ASL-2020,2019
+ASL,3020,1,Advanced Asl II,0.82,0.09,0.09,0.0,0.0,0.0,0.0,0.0,william ry clements,,ASL-3020,2019
+ASL,3050,1,Deaf Studies,0.76,0.12,0.08,0.0,0.04,0.0,0.0,0.0,jason hurdich,,ASL-3050,2019
+ASTR,1010,1,Solar System Astronomy,0.41,0.3,0.16,0.06,0.03,0.0,0.0,0.04,david edwar connick,,ASTR-1010,2019
+ASTR,1020,2,Stellar Astronomy,0.16,0.23,0.28,0.15,0.0,0.0,0.16,0.03,mate adamkovics,,ASTR-1020,2019
+ASTR,1030,1,Solar Systm Astr Lab,0.39,0.39,0.09,0.04,0.0,0.0,0.0,0.09,mark leising,,ASTR-1030,2019
+ASTR,1030,2,Solar Systm Astr Lab,0.54,0.42,0.0,0.0,0.0,0.0,0.04,0.0,mark leising,,ASTR-1030,2019
+ASTR,1030,3,Solar Systm Astr Lab,0.32,0.48,0.12,0.08,0.0,0.0,0.0,0.0,mark leising,,ASTR-1030,2019
+ASTR,1040,1,Stellar Astr Lab,0.3,0.2,0.3,0.0,0.0,0.0,0.1,0.1,mark leising,,ASTR-1040,2019
+ASTR,1040,2,Stellar Astr Lab,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,mark leising,,ASTR-1040,2019
+ASTR,1040,4,Stellar Astr Lab,0.3,0.55,0.05,0.0,0.05,0.0,0.0,0.05,mark leising,,ASTR-1040,2019
+ASTR,3030,1,Galactic Astrophys,0.42,0.33,0.25,0.0,0.0,0.0,0.0,0.0,marco ajello,,ASTR-3030,2019
+ASTR,8400,1,Astroph: Cosmology,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,bradley meyer,,ASTR-8400,2019
+ASTR,8750,1,Astronomy Seminar,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,marco ajello,,ASTR-8750,2019
+AUD,2850,1,Acoustics of Music,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,hamilton altstatt,,AUD-2850,2019
+AUE,4020,699,Adv & Electrified Powertrains,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,zoran filipi,,AUE-4020,2019
+AUE,4020,699,Adv & Electrified Powertrains,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,qilun zhu,,AUE-4020,2019
+AUE,8160,3,Eng Combustion Emiss,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,robert prucka,,AUE-8160,2019
+AUE,8170,410,Alt Energy Sources,0.38,0.44,0.06,0.0,0.13,0.0,0.0,0.0,pierluigi pisu,,AUE-8170,2019
+AUE,8500,6,Stability/Safety Sys,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,beshah ayalew,,AUE-8500,2019
+AUE,8550,16,Struct/Thermal Analysis Mthds,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david wil schmueser,,AUE-8550,2019
+AUE,8690,8,Qual Assur Automotiv Manuf Sys,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,dee ann wood kivett,,AUE-8690,2019
+AUE,8770,405,Light-Weight Design,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,fadi kama abu-farha,,AUE-8770,2019
+AUE,8860,1,Noise Vibration,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey blan poland,,AUE-8860,2019
+AUE,8930,401,Autonomous Driving Techn,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,yunyi jia,,AUE-8930,2019
+AUE,8930,405,Perception and Intelligence,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bing li,,AUE-8930,2019
+AVS,2000,1,Beef Cattle Tech,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,nathan long,,AVS-2000,2019
+AVS,2030,1,Dairy Sci Techniques,0.93,0.05,0.02,0.0,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-2030,2019
+AVS,2090,1,Livestock Exhibition Technique,0.89,0.08,0.03,0.0,0.0,0.0,0.0,0.0,richelle lor miller,,AVS-2090,2019
+AVS,3010,1,Anat & Phys Dom Ani,0.71,0.2,0.08,0.0,0.0,0.0,0.0,0.01,tiffany wilmoth,,AVS-3010,2019
+AVS,3090,1,Equine Evaluation,0.71,0.12,0.06,0.06,0.06,0.0,0.0,0.0,chelsea dr sinclair,,AVS-3090,2019
+AVS,3100,1,Animal Health,0.59,0.25,0.13,0.03,0.0,0.0,0.0,0.0,celina marc checura,,AVS-3100,2019
+AVS,3150,1,Animal Welfare,0.47,0.32,0.13,0.09,0.0,0.0,0.0,0.0,heather walker dunn,,AVS-3150,2019
+AVS,3700,1,Principles of Animal Nutrition,0.34,0.36,0.17,0.09,0.02,0.0,0.0,0.02,james ro strickland,,AVS-3700,2019
+AVS,3750,1,Applied Animal Nutrition,0.35,0.35,0.2,0.1,0.0,0.0,0.0,0.0,mir arguelles-ramos,,AVS-3750,2019
+AVS,4100,1,Domestic Ani Behav,0.69,0.21,0.09,0.0,0.0,0.0,0.0,0.01,james ro strickland,,AVS-4100,2019
+AVS,4120,1,Advanced Equine Management,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,kristine lan vernon,,AVS-4120,2019
+AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,glenn birrenkott,,AVS-4130,2019
+AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,richelle lor miller,,AVS-4130,2019
+AVS,4130,1,Animal Products,0.47,0.36,0.14,0.01,0.0,0.0,0.0,0.01,annel greene,,AVS-4130,2019
+AVS,4140,1,Basic Immunology,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,farzana ferdous,True,AVS-4140,2019
+AVS,4220,6,Advanced Fetal Fescue Research,0.85,0.0,0.15,0.0,0.0,0.0,0.0,0.0,susan kay duckett,,AVS-4220,2019
+AVS,4530,1,Animal Reproduction,0.22,0.29,0.31,0.13,0.04,0.0,0.0,0.0,celina marc checura,,AVS-4530,2019
+AVS,4550,2,Animal Repro Mgt-Equine,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,chelsea dr sinclair,,AVS-4550,2019
+AVS,4700,1,Animal Genetics,0.24,0.33,0.21,0.06,0.06,0.0,0.0,0.09,joseph kei bertrand,,AVS-4700,2019
+BCHM,3010,1,Molecular Biochemistry,0.17,0.46,0.25,0.03,0.0,0.0,0.0,0.1,meredith tei morris,,BCHM-3010,2019
+BCHM,3010,2,Molecular Biochem(HON),0.4,0.29,0.24,0.02,0.02,0.0,0.0,0.02,cheryl ingram-smith,True,BCHM-3010,2019
+BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2019
+BCHM,3040,1,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,,BCHM-3040,2019
+BCHM,3040,4,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-3040,2019
+BCHM,3040,4,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,,BCHM-3040,2019
+BCHM,3050,1,Essen Elements Bioch,0.47,0.38,0.11,0.01,0.01,0.0,0.0,0.02,debra ragland,,BCHM-3050,2019
+BCHM,3050,2,Essen Elements Bioch,0.53,0.33,0.08,0.03,0.01,0.0,0.0,0.02,debra ragland,,BCHM-3050,2019
+BCHM,4320,1,Bioch of Metabolism,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,kimberly paul,,BCHM-4320,2019
+BCHM,4340,3,Biochemistry of Metabolism Lab,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-4340,2019
+BCHM,4340,4,Biochemistry of Metabolism Lab,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,BCHM-4340,2019
+BCHM,4360,1,Genes to Proteins,0.29,0.47,0.24,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,,BCHM-4360,2019
+BCHM,4360,2,Mol Bio Genes to Proteins(HON),0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True,BCHM-4360,2019
+BCHM,4400,1,Bioinformatics,0.74,0.11,0.05,0.05,0.0,0.0,0.0,0.05,liangjiang wang,,BCHM-4400,2019
+BCHM,4910,35,CI:DNA Repair,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,,BCHM-4910,2019
+BCHM,4930,1,Senior Seminar,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,weiguo cao,,BCHM-4930,2019
+BCHM,8050,1,Issues in Research,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,william marcotte,,BCHM-8050,2019
+BE,2100,1,Intro to Biosystems Engr,0.43,0.48,0.1,0.0,0.0,0.0,0.0,0.0,jazmine octa taylor,,BE-2100,2019
+BE,3220,1,Sm Wtrshd Hyd & Sed,0.31,0.54,0.12,0.04,0.0,0.0,0.0,0.0,tom owino,,BE-3220,2019
+BE,4120,1,Be Heat Mass Trans,0.42,0.42,0.16,0.0,0.0,0.0,0.0,0.0,caye marie drapcho,,BE-4120,2019
+BE,4150,1,Instr & Control for Biosys Eng,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,rui xiao,,BE-4150,2019
+BE,4240,1,Ecological Engineering,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,christophe darnault,,BE-4240,2019
+BE,4380,1,Bioprocess Engineering Design,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,terry walker,,BE-4380,2019
+BE,4400,1,Sustainable Energy Engineering,0.36,0.21,0.29,0.14,0.0,0.0,0.0,0.0,jazmine octa taylor,,BE-4400,2019
+BIOE,1010,1,Biol for Bioengr,0.6,0.35,0.02,0.0,0.02,0.0,0.0,0.02,vladimir vla reukov,,BIOE-1010,2019
+BIOE,1010,1,Biol for Bioengr,0.6,0.35,0.02,0.0,0.02,0.0,0.0,0.02,tyler george harvey,,BIOE-1010,2019
+BIOE,2010,1,Intro Biomed Engr,0.44,0.31,0.13,0.13,0.0,0.0,0.0,0.0,vladimir vla reukov,,BIOE-2010,2019
+BIOE,3020,1,Biomaterials,0.61,0.29,0.06,0.01,0.0,0.0,0.0,0.03,alexey ale vertegel,,BIOE-3020,2019
+BIOE,3100,1,Engr Analysis of Physiol Proc,0.54,0.36,0.07,0.04,0.0,0.0,0.0,0.0,brian william booth,,BIOE-3100,2019
+BIOE,3200,1,Biomechanics,0.79,0.18,0.0,0.03,0.0,0.0,0.0,0.0,william richardson,,BIOE-3200,2019
+BIOE,3210,1,Biofluid Mechanics,0.25,0.53,0.12,0.07,0.03,0.0,0.0,0.0,sarah harcum,,BIOE-3210,2019
+BIOE,3470,1,Transport Processes in Bioengr,0.39,0.36,0.18,0.0,0.0,0.0,0.0,0.07,robert latour,,BIOE-3470,2019
+BIOE,3700,1,Bioinst & Imaging,0.37,0.45,0.13,0.03,0.0,0.0,0.0,0.01,jordon anth gilmore,,BIOE-3700,2019
+BIOE,4200,1,Sports Engineering,0.65,0.25,0.06,0.02,0.02,0.0,0.0,0.0,cynthia mille smith,,BIOE-4200,2019
+BIOE,4490,1,Drug Delivery,0.55,0.35,0.06,0.0,0.03,0.0,0.0,0.0,jeoungsoo lee,,BIOE-4490,2019
+BIOE,4510,21,CI - Hands On Tissue Engr,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,,BIOE-4510,2019
+BIOE,4510,37,CI-Innov in Bioinstrumentation,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,delphine dean,,BIOE-4510,2019
+BIOE,6200,1,Sports Engineering,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,cynthia mille smith,,BIOE-6200,2019
+BIOE,6230,1,Cardiovascular Engr and Path,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,martine laberge,,BIOE-6230,2019
+BIOE,6230,1,Cardiovascular Engr and Path,0.97,0.0,0.0,0.0,0.0,0.0,0.0,0.03,dan simionescu,,BIOE-6230,2019
+BIOE,8130,1,Industrial Bioengineering,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michael taylor,,BIOE-8130,2019
+BIOE,8200,1,Structl Biomechanics,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,hai yao,,BIOE-8200,2019
+BIOE,8500,2,Mechanobiology,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,jiro nagatomi,,BIOE-8500,2019
+BIOL,1040,1,General Biology II,0.32,0.3,0.2,0.09,0.02,0.0,0.0,0.06,nora espinoza,,BIOL-1040,2019
+BIOL,1040,2,General Biology II,0.28,0.21,0.29,0.09,0.07,0.0,0.0,0.07,dylan dittrich-reed,,BIOL-1040,2019
+BIOL,1040,3,General Biology II,0.14,0.28,0.29,0.12,0.1,0.0,0.0,0.08,salvatore sparace,,BIOL-1040,2019
+BIOL,1040,4,General Biology II (HON),0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,nora espinoza,True,BIOL-1040,2019
+BIOL,1060,1,Gen Biology Lab II,0.04,0.29,0.17,0.25,0.17,0.0,0.0,0.08,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,2,Gen Biology Lab II,0.1,0.19,0.38,0.33,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,3,Gen Biology Lab II,0.16,0.21,0.21,0.16,0.26,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,4,Gen Biology Lab II,0.04,0.17,0.25,0.33,0.08,0.0,0.0,0.13,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,5,Gen Biology Lab II,0.13,0.0,0.25,0.06,0.25,0.0,0.0,0.31,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,7,Gen Biology Lab II,0.3,0.1,0.3,0.0,0.3,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,8,Gen Biology Lab II,0.04,0.33,0.42,0.13,0.08,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,9,Gen Biology Lab II,0.06,0.06,0.56,0.31,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,10,Gen Biology Lab II,0.06,0.18,0.29,0.0,0.41,0.0,0.0,0.06,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,11,Gen Biology Lab II,0.09,0.22,0.43,0.17,0.04,0.0,0.0,0.04,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,12,Gen Biology Lab II,0.13,0.19,0.5,0.13,0.06,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,13,Gen Biology Lab II,0.08,0.15,0.54,0.08,0.0,0.0,0.0,0.15,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,14,Gen Biology Lab II,0.05,0.45,0.2,0.2,0.1,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,15,Gen Biology Lab II,0.06,0.22,0.33,0.17,0.22,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,16,Gen Biology Lab II,0.08,0.33,0.33,0.25,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,18,Gen Biology Lab II,0.05,0.18,0.32,0.32,0.14,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,19,Gen Biology Lab II,0.0,0.27,0.33,0.2,0.2,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,20,Gen Biology Lab II,0.07,0.2,0.2,0.13,0.2,0.0,0.0,0.2,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,21,Gen Biology Lab II,0.14,0.23,0.32,0.14,0.09,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,22,Gen Biology Lab II,0.0,0.18,0.36,0.45,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,24,Gen Biology Lab II,0.04,0.22,0.35,0.26,0.04,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,25,Gen Biology Lab II,0.25,0.25,0.33,0.17,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,26,Gen Biology Lab II,0.17,0.43,0.26,0.04,0.09,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,27,Gen Biology Lab II,0.25,0.4,0.15,0.2,0.0,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,28,Gen Biology Lab II,0.21,0.21,0.32,0.21,0.0,0.0,0.0,0.05,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,30,Gen Biology Lab II,0.17,0.35,0.35,0.04,0.0,0.0,0.0,0.09,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1060,32,Gen Biology Lab II,0.07,0.47,0.27,0.07,0.13,0.0,0.0,0.0,tafadzwa kaisa,,BIOL-1060,2019
+BIOL,1110,1,Principles of Biology II,0.52,0.33,0.12,0.03,0.0,0.0,0.01,0.0,renea chri hardwick,,BIOL-1110,2019
+BIOL,1110,2,Principles of Biology II (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,renea chri hardwick,True,BIOL-1110,2019
+BIOL,1110,3,Principles of Biology II,0.34,0.43,0.14,0.04,0.05,0.0,0.0,0.02, christine minor,,BIOL-1110,2019
+BIOL,1110,4,Prin of Biol II  (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0, christine minor,True,BIOL-1110,2019
+BIOL,2000,1,Biology in the News,0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,tamara mcnutt-scott,,BIOL-2000,2019
+BIOL,2040,1,"Environ, Energy and Society",0.6,0.33,0.04,0.02,0.0,0.0,0.0,0.0,john jenkins hains,,BIOL-2040,2019
+BIOL,2040,2,"Environ, Energy and Society",0.33,0.41,0.17,0.07,0.0,0.0,0.0,0.01,john jenkins hains,,BIOL-2040,2019
+BIOL,2230,1,Human Anat and Physiology II,0.39,0.37,0.16,0.04,0.02,0.0,0.0,0.01,john cummings,,BIOL-2230,2019
+BIOL,2230,2,Human Anat and Physiology II,0.41,0.35,0.16,0.04,0.03,0.0,0.0,0.01,john cummings,,BIOL-2230,2019
+BIOL,3020,1,Invertebrate Biology,0.32,0.34,0.2,0.07,0.02,0.0,0.0,0.05,juan baeza migueles,,BIOL-3020,2019
+BIOL,3040,1,Biology of Plants,0.31,0.24,0.1,0.29,0.07,0.0,0.0,0.0,nathan redding,,BIOL-3040,2019
+BIOL,3060,1,Invertebrate Biology Lab,0.33,0.25,0.29,0.08,0.0,0.0,0.0,0.04,juan baeza migueles,,BIOL-3060,2019
+BIOL,3060,2,Invertebrate Biology Lab,0.53,0.32,0.05,0.05,0.0,0.0,0.0,0.05,juan baeza migueles,,BIOL-3060,2019
+BIOL,3080,1,Biology of Plants Practicum,0.45,0.25,0.1,0.15,0.05,0.0,0.0,0.0,nathan redding,,BIOL-3080,2019
+BIOL,3080,2,Biology of Plants Practicum,0.5,0.2,0.2,0.0,0.1,0.0,0.0,0.0,nathan redding,,BIOL-3080,2019
+BIOL,3160,1,Human Physiology,0.33,0.43,0.19,0.03,0.01,0.0,0.0,0.01,tamara mcnutt-scott,,BIOL-3160,2019
+BIOL,3350,1,Evolutionary Biology,0.43,0.38,0.15,0.02,0.01,0.0,0.0,0.01,margaret ptacek,,BIOL-3350,2019
+BIOL,3350,2,Evolutionary Biology (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,margaret ptacek,True,BIOL-3350,2019
+BIOL,3940,3,CI: What is in our Waters?,0.8,0.0,0.0,0.2,0.0,0.0,0.0,0.0,peter van den hurk,,BIOL-3940,2019
+BIOL,4010,1,Plant Physiology,0.17,0.2,0.28,0.21,0.0,0.0,0.08,0.07,douglas bielenberg,,BIOL-4010,2019
+BIOL,4020,1,Plant Physiology Lab,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,douglas bielenberg,,BIOL-4020,2019
+BIOL,4020,2,Plant Physiology Lab,0.65,0.1,0.2,0.0,0.05,0.0,0.0,0.0,douglas bielenberg,,BIOL-4020,2019
+BIOL,4030,1,Intro to Applied Genomics,0.0,0.07,0.36,0.07,0.07,0.0,0.0,0.43,vincent pa richards,,BIOL-4030,2019
+BIOL,4140,1,Basic Immunology,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,charles rice,,BIOL-4140,2019
+BIOL,4340,1,Biological Chem Lab Techniques,0.14,0.36,0.36,0.07,0.0,0.0,0.0,0.07,salvatore sparace,,BIOL-4340,2019
+BIOL,4340,2,Biological Chem Lab Techniques,0.0,0.38,0.38,0.08,0.0,0.0,0.0,0.15,salvatore sparace,,BIOL-4340,2019
+BIOL,4610,1,Cell Biology,0.36,0.36,0.15,0.07,0.03,0.0,0.0,0.03,lesly temesvari,,BIOL-4610,2019
+BIOL,4610,2,Cell Biology (HON),0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,True,BIOL-4610,2019
+BIOL,4620,1,Cell Biology Lab (Lec),0.69,0.23,0.04,0.0,0.04,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,2,Cell Biology Lab (Lec),0.77,0.19,0.0,0.0,0.04,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,4,Cell Biology Lab (Lec),0.67,0.3,0.0,0.0,0.0,0.0,0.0,0.04,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,5,Cell Biology Lab (Lec),0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,6,Cell Biology Lab (Lec),0.65,0.27,0.04,0.04,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4620,7,Cell Biology Lab (Lec),0.6,0.28,0.12,0.0,0.0,0.0,0.0,0.0,xianzhong yu,,BIOL-4620,2019
+BIOL,4670,1,Principles of Hematology,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,vincent gallicchio,,BIOL-4670,2019
+BIOL,4700,1,Behavioral Ecology,0.44,0.38,0.14,0.03,0.01,0.0,0.0,0.0,michael childress,,BIOL-4700,2019
+BIOL,4710,1,Behavioral Ecology Lab (Lec),0.5,0.4,0.05,0.0,0.0,0.0,0.0,0.05,michael childress,,BIOL-4710,2019
+BIOL,4710,2,Behavioral Ecology Lab (Lec),0.69,0.13,0.06,0.13,0.0,0.0,0.0,0.0,michael childress,,BIOL-4710,2019
+BIOL,4710,3,Behavioral Ecology Lab (Lec),0.71,0.14,0.0,0.0,0.07,0.0,0.0,0.07,michael childress,,BIOL-4710,2019
+BIOL,4710,4,Behavioral Ecology Lab (Lec),0.67,0.2,0.07,0.07,0.0,0.0,0.0,0.0,michael childress,,BIOL-4710,2019
+BIOL,4780,1,Exercise Physiology,0.79,0.17,0.0,0.0,0.02,0.0,0.0,0.02,john cummings,,BIOL-4780,2019
+BIOL,4800,1,Vertebrate Endocrinology,0.26,0.4,0.21,0.07,0.0,0.0,0.02,0.02,william baldwin,,BIOL-4800,2019
+BIOL,4830,1,Stem Cell Biology,0.61,0.32,0.05,0.0,0.0,0.0,0.0,0.02,vincent gallicchio,,BIOL-4830,2019
+BIOL,4930,2,Sr Sem: Immuno & Immunotherapy,0.76,0.12,0.12,0.0,0.0,0.0,0.0,0.0,yanzhang wei,,BIOL-4930,2019
+BIOL,4930,3,Sr Sem: Nervous Systems,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david feliciano,,BIOL-4930,2019
+BIOL,4930,6,Sr Sem: Biol Behind Our Food,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,peter van den hurk,,BIOL-4930,2019
+BIOL,4930,7,Sr Sem: Genomics,0.75,0.19,0.0,0.0,0.0,0.0,0.06,0.0,kara elizabe powder,,BIOL-4930,2019
+BIOL,4930,8,Sen Sem: Evolutionary Medicine,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,samantha ann price,,BIOL-4930,2019
+BIOL,4940,2,CI: Popular Science Journalism,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,steven katz,,BIOL-4940,2019
+BIOL,4940,2,CI: Popular Science Journalism,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,lesly temesvari,,BIOL-4940,2019
+BIOL,4940,9,CI: Marine Conservation & Gen,0.88,0.0,0.0,0.0,0.13,0.0,0.0,0.0,juan baeza migueles,,BIOL-4940,2019
+BIOL,6030,1,Intro to Applied Genomics,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,vincent pa richards,,BIOL-6030,2019
+BIOL,8430,1,Underst Genetics & Evol Biol,0.63,0.31,0.01,0.0,0.03,0.0,0.0,0.03,margaret ptacek,,BIOL-8430,2019
+BIOL,8430,1,Underst Genetics & Evol Biol,0.63,0.31,0.01,0.0,0.03,0.0,0.0,0.03,renea chri hardwick,,BIOL-8430,2019
+BIOL,8450,1,Understanding Animal Biology,0.85,0.1,0.0,0.0,0.02,0.0,0.0,0.03,amy lauren anderson,,BIOL-8450,2019
+BIOL,8450,1,Understanding Animal Biology,0.85,0.1,0.0,0.0,0.02,0.0,0.0,0.03,matthew turnbull,,BIOL-8450,2019
+BIOL,8470,1,Understanding Microbiology,0.72,0.23,0.04,0.0,0.01,0.0,0.0,0.0,harry kurtz,,BIOL-8470,2019
+BIOL,8480,1,Understanding Scientific Rsrch,0.95,0.02,0.0,0.0,0.0,0.0,0.0,0.02,robert edwa ballard,,BIOL-8480,2019
+BMOL,4250,1,Biomolecular Engineering,0.15,0.39,0.31,0.09,0.04,0.0,0.0,0.02,mark alan blenner,,BMOL-4250,2019
+BMOL,4290,1,Bioprocess Engineering,0.4,0.3,0.3,0.0,0.0,0.0,0.0,0.0,marc rus birtwistle,,BMOL-4290,2019
+BMOL,6250,1,Biomolecular Eng,0.71,0.14,0.14,0.0,0.0,0.0,0.0,0.0,mark alan blenner,,BMOL-6250,2019
+BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2019
+BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,sandy edge,,BUS-1010,2019
+BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2019
+BUS,1010,1,Business Foundations,0.35,0.39,0.26,0.0,0.0,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2019
+BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2019
+BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2019
+BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,sandy edge,,BUS-1010,2019
+BUS,1010,2,Business Foundations,0.42,0.38,0.15,0.0,0.04,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2019
+BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,edward bar de iulio,,BUS-1010,2019
+BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,sandy edge,,BUS-1010,2019
+BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,william ern tumblin,,BUS-1010,2019
+BUS,1010,3,Business Foundations,0.42,0.38,0.08,0.04,0.0,0.0,0.0,0.08,donna mccubbin,,BUS-1010,2019
+BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,donna mccubbin,,BUS-1010,2019
+BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,edward bar de iulio,,BUS-1010,2019
+BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,sandy edge,,BUS-1010,2019
+BUS,1010,4,Business Foundations,0.52,0.28,0.16,0.0,0.04,0.0,0.0,0.0,william ern tumblin,,BUS-1010,2019
+BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2019
+BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,sandy edge,,BUS-1010,2019
+BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,william ern tumblin,,BUS-1010,2019
+BUS,1010,5,Business Foundations,0.46,0.25,0.21,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,,BUS-1010,2019
+BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,,BUS-1010,2019
+BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,william ern tumblin,,BUS-1010,2019
+BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2019
+BUS,1010,6,Business Foundations,0.3,0.44,0.19,0.04,0.0,0.0,0.0,0.04,sandy edge,,BUS-1010,2019
+BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,edward bar de iulio,,BUS-1010,2019
+BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2019
+BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,william ern tumblin,,BUS-1010,2019
+BUS,1010,7,Business Foundations,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,sandy edge,,BUS-1010,2019
+BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,edward bar de iulio,,BUS-1010,2019
+BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,sandy edge,,BUS-1010,2019
+BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,william ern tumblin,,BUS-1010,2019
+BUS,1010,8,Business Foundations,0.5,0.38,0.08,0.0,0.0,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2019
+BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,edward bar de iulio,,BUS-1010,2019
+BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,william ern tumblin,,BUS-1010,2019
+BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,donna mccubbin,,BUS-1010,2019
+BUS,1010,9,Business Foundations,0.27,0.35,0.15,0.08,0.08,0.0,0.0,0.08,sandy edge,,BUS-1010,2019
+BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,donna mccubbin,,BUS-1010,2019
+BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,william ern tumblin,,BUS-1010,2019
+BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,sandy edge,,BUS-1010,2019
+BUS,1010,10,Business Foundations,0.31,0.34,0.21,0.07,0.0,0.0,0.0,0.07,edward bar de iulio,,BUS-1010,2019
+BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,edward bar de iulio,,BUS-1010,2019
+BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,donna mccubbin,,BUS-1010,2019
+BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,william ern tumblin,,BUS-1010,2019
+BUS,1010,12,Business Foundations,0.3,0.3,0.3,0.04,0.0,0.0,0.0,0.04,sandy edge,,BUS-1010,2019
+BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,donna mccubbin,,BUS-1010,2019
+BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,sandy edge,,BUS-1010,2019
+BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,william ern tumblin,,BUS-1010,2019
+BUS,1010,13,Business Foundations,0.46,0.27,0.19,0.0,0.0,0.0,0.0,0.08,edward bar de iulio,,BUS-1010,2019
+CE,2010,1,Statics,0.3,0.33,0.12,0.06,0.03,0.0,0.0,0.15,melissa sternhagen,,CE-2010,2019
+CE,2010,2,Statics,0.31,0.42,0.25,0.0,0.02,0.0,0.0,0.0,md nasimu chowdhury,,CE-2010,2019
+CE,2010,3,Statics,0.17,0.25,0.23,0.17,0.02,0.0,0.0,0.17,melissa sternhagen,,CE-2010,2019
+CE,2010,4,Statics,0.16,0.42,0.33,0.02,0.0,0.0,0.0,0.07,md nasimu chowdhury,,CE-2010,2019
+CE,2010,5,Statics,0.5,0.16,0.2,0.02,0.11,0.0,0.0,0.0,michael wall stoner,,CE-2010,2019
+CE,2010,6,Statics,0.58,0.3,0.1,0.0,0.03,0.0,0.0,0.0,lancelot paul reres,,CE-2010,2019
+CE,2010,7,Statics (HON),0.18,0.55,0.18,0.0,0.0,0.0,0.0,0.09,melissa sternhagen,True,CE-2010,2019
+CE,2060,1,Structural Mechanics,0.51,0.29,0.16,0.02,0.02,0.0,0.0,0.0,thomas edfo cousins,,CE-2060,2019
+CE,2060,2,Structural Mechanics,0.19,0.33,0.43,0.02,0.02,0.0,0.0,0.02,melissa sternhagen,,CE-2060,2019
+CE,2080,1,Dynamics,0.17,0.42,0.32,0.0,0.03,0.0,0.0,0.06,md nasimu chowdhury,,CE-2080,2019
+CE,2080,2,Dynamics,0.12,0.35,0.4,0.05,0.0,0.0,0.0,0.09,md nasimu chowdhury,,CE-2080,2019
+CE,2550,1,Geomatics,0.29,0.27,0.32,0.05,0.0,0.0,0.0,0.07,wayne sarasua,,CE-2550,2019
+CE,3010,1,Structural Analysis,0.4,0.3,0.26,0.05,0.0,0.0,0.0,0.0,stephen csernak,,CE-3010,2019
+CE,3110,1,Transportation Engr,0.68,0.24,0.05,0.01,0.0,0.0,0.0,0.01,pamela murray-tuite,,CE-3110,2019
+CE,3210,1,Geotechnical Engineering,0.87,0.09,0.04,0.0,0.0,0.0,0.0,0.0,wenxin liu,,CE-3210,2019
+CE,3210,2,Geotechnical Engineering,0.59,0.3,0.11,0.0,0.0,0.0,0.0,0.0,wenxin liu,,CE-3210,2019
+CE,3310,1,Constr Engr & Mgmnt,0.87,0.11,0.0,0.02,0.0,0.0,0.0,0.0,steve richa sanders,,CE-3310,2019
+CE,3410,1,Intro to Fluid Mech,0.32,0.46,0.15,0.03,0.0,0.0,0.0,0.03,nigel gregory kaye,,CE-3410,2019
+CE,3420,1,Hydraulics & Hydro,0.62,0.35,0.03,0.0,0.0,0.0,0.0,0.0,ashok mishra,,CE-3420,2019
+CE,3420,2,Hydraulics & Hydro,0.28,0.47,0.19,0.03,0.03,0.0,0.0,0.0,abdul khan,,CE-3420,2019
+CE,3510,1,Civil Engineering Materials,0.43,0.52,0.05,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,,CE-3510,2019
+CE,3520,1,Econ Eval of Proj,0.49,0.37,0.09,0.01,0.01,0.0,0.0,0.03, kent nilsson,,CE-3520,2019
+CE,3530,1,Professional Seminar,0.96,0.01,0.03,0.01,0.0,0.0,0.0,0.0,ronald andrus,,CE-3530,2019
+CE,4020,1,Reinfor Con Design,0.42,0.31,0.22,0.0,0.04,0.0,0.0,0.0,laura mae redmond,,CE-4020,2019
+CE,4070,1,Wood Design,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,weichiang pang,,CE-4070,2019
+CE,4080,1,Struct Loads & Sys,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,brandon ross,,CE-4080,2019
+CE,4110,1,Roadway Geo Design,0.52,0.37,0.07,0.04,0.0,0.0,0.0,0.0,jennifer ogle,,CE-4110,2019
+CE,4120,1,Urban Transport Plan,0.37,0.48,0.15,0.0,0.0,0.0,0.0,0.0,sakib khan,,CE-4120,2019
+CE,4210,1,Geotechnical Design,0.29,0.46,0.23,0.0,0.0,0.0,0.0,0.03,nadara ravichandran,,CE-4210,2019
+CE,4340,1,Const Est Proj Cont,0.35,0.51,0.13,0.02,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-4340,2019
+CE,4370,1,Sustainable Energy Proj Design,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,,CE-4370,2019
+CE,4590,1,Capstone Design Proj,0.6,0.28,0.1,0.01,0.0,0.0,0.0,0.0,stephen csernak,,CE-4590,2019
+CE,4910,1,Corrosion and Oxidation,0.0,0.4,0.0,0.0,0.0,0.0,0.0,0.6,ami esmaeilpoursaee,,CE-4910,2019
+CE,4910,2,Des Thinkg for Sustain Systems,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,kap chalil madathil,,CE-4910,2019
+CE,4910,3,Intro to Enviro Fluid Mech,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,nigel gregory kaye,,CE-4910,2019
+CE,4990,2,Cr Inq in Civil Engineering,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,weichiang pang,,CE-4990,2019
+CE,4990,61,Cr Inq in Civil Engineering,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jennifer ogle,,CE-4990,2019
+CE,4990,201,Special Project - Springer I,0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,wayne sarasua,,CE-4990,2019
+CE,6340,1,Const Est Proj Cont,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kalyan ram piratla,,CE-6340,2019
+CE,6370,1,Sustainable Energy Proj Design,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,david morgan young,,CE-6370,2019
+CE,8030,1,Adv Steel Design,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,mohannad naser,,CE-8030,2019
+CE,8270,1,Spec Cements & Concr,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,prasada rangaraju,,CE-8270,2019
+CE,8450,500,Data Mining for Sys Analytics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paris stringfellow,,CE-8450,2019
+CE,8470,500,Optimization Support Models,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,,CE-8470,2019
+CE,8530,1,Apps in Traffic En,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,mashrur chowdhury,,CE-8530,2019
+CES,1900,101,CI-LEAD Forward I,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,CES-1900,2019
+CES,2900,101,CI - LEAD Forward II,0.64,0.18,0.18,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,CES-2900,2019
+CES,3900,101,CI-LEAD Forward III,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,steve richa sanders,,CES-3900,2019
+CH,1010,1,General Chemistry,0.16,0.32,0.21,0.08,0.1,0.0,0.0,0.12,princess mycia cox,,CH-1010,2019
+CH,1010,2,General Chemistry,0.23,0.33,0.32,0.04,0.04,0.0,0.0,0.03,jacob schroeder,,CH-1010,2019
+CH,1010,3,General Chemistry,0.11,0.4,0.25,0.1,0.06,0.0,0.0,0.08,jacob schroeder,,CH-1010,2019
+CH,1010,4,General Chemistry,0.08,0.22,0.39,0.1,0.13,0.0,0.0,0.1,steven pellizzeri,,CH-1010,2019
+CH,1010,400,General Chemistry,0.28,0.16,0.15,0.22,0.08,0.0,0.0,0.11,stephe schvaneveldt,,CH-1010,2019
+CH,1020,1,General Chemistry,0.24,0.31,0.26,0.06,0.04,0.0,0.0,0.09,steven pellizzeri,,CH-1020,2019
+CH,1020,2,General Chemistry,0.27,0.29,0.25,0.09,0.03,0.0,0.0,0.05,william mcwhorter,,CH-1020,2019
+CH,1020,3,General Chemistry,0.27,0.36,0.31,0.04,0.01,0.0,0.0,0.02,dennis taylor,,CH-1020,2019
+CH,1020,4,General Chemistry,0.3,0.38,0.2,0.05,0.01,0.0,0.0,0.06,dennis taylor,,CH-1020,2019
+CH,1020,5,General Chemistry,0.17,0.47,0.25,0.05,0.0,0.0,0.02,0.03,william mcwhorter,,CH-1020,2019
+CH,1020,6,General Chemistry,0.1,0.36,0.34,0.09,0.02,0.0,0.0,0.08,olt geiculescu,,CH-1020,2019
+CH,1020,7,General Chemistry,0.1,0.39,0.34,0.06,0.01,0.0,0.0,0.1,william mcwhorter,,CH-1020,2019
+CH,1020,8,General Chemistry,0.29,0.43,0.21,0.03,0.0,0.0,0.0,0.03,thomas hickman,,CH-1020,2019
+CH,1020,9,General Chemistry,0.22,0.45,0.23,0.05,0.0,0.0,0.0,0.05,princess mycia cox,,CH-1020,2019
+CH,1020,10,General Chemistry,0.34,0.37,0.23,0.02,0.02,0.0,0.0,0.02,thomas hickman,,CH-1020,2019
+CH,1020,11,General Chemistry,0.32,0.33,0.23,0.04,0.02,0.0,0.0,0.05,elliot ennis,,CH-1020,2019
+CH,1020,50,General Chemistry,0.65,0.27,0.04,0.0,0.02,0.0,0.0,0.02,stephe schvaneveldt,,CH-1020,2019
+CH,1020,51,General Chemistry (HON),0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephe schvaneveldt,True,CH-1020,2019
+CH,1020,52,General Chemistry (HON),0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,shiou-jyh hwu,True,CH-1020,2019
+CH,1050,1,Chemistry in Context I,0.34,0.39,0.23,0.0,0.02,0.0,0.0,0.02,olt geiculescu,,CH-1050,2019
+CH,1050,2,Chemistry in Context I,0.56,0.25,0.13,0.03,0.0,0.0,0.0,0.03,olt geiculescu,,CH-1050,2019
+CH,1060,1,Chemistry in Context II,0.15,0.5,0.15,0.08,0.08,0.0,0.0,0.04,elliot ennis,,CH-1060,2019
+CH,1520,1,Chemistry Communication,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,richard marcus,,CH-1520,2019
+CH,2010,1,Survey of Organic Chemistry,0.43,0.15,0.23,0.06,0.07,0.0,0.0,0.06,tania issa houjeiry,,CH-2010,2019
+CH,2050,1,Intro Inorg Chem,0.55,0.32,0.11,0.0,0.0,0.0,0.0,0.03,william pennington,,CH-2050,2019
+CH,2230,1,Organic Chemistry,0.14,0.21,0.31,0.18,0.14,0.0,0.0,0.01,thomas hickman,,CH-2230,2019
+CH,2230,2,Organic Chemistry,0.13,0.26,0.27,0.23,0.11,0.0,0.0,0.01,elliot ennis,,CH-2230,2019
+CH,2230,3,Organic Chemistry,0.18,0.33,0.22,0.13,0.12,0.0,0.0,0.03,laura lanni,,CH-2230,2019
+CH,2240,1,Organic Chemistry,0.53,0.25,0.14,0.04,0.02,0.0,0.0,0.03,tania issa houjeiry,,CH-2240,2019
+CH,2240,2,Organic Chemistry,0.38,0.33,0.15,0.07,0.03,0.0,0.0,0.04,laura lanni,,CH-2240,2019
+CH,2240,3,Organic Chemistry,0.34,0.19,0.32,0.07,0.07,0.0,0.0,0.01,laura lanni,,CH-2240,2019
+CH,2240,4,Organic Chemistry,0.59,0.13,0.19,0.02,0.03,0.0,0.0,0.04,rhett smith,,CH-2240,2019
+CH,2240,5,Organic Chemistry,0.55,0.25,0.11,0.07,0.0,0.0,0.0,0.02,rhett smith,,CH-2240,2019
+CH,2280,17,Organic Chem Lab,0.84,0.0,0.0,0.0,0.0,0.0,0.0,0.16,james nelso plampin,,CH-2280,2019
+CH,2280,26,Organic Chem Lab,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,james nelso plampin,,CH-2280,2019
+CH,3320,1,Physical Chemistry,0.21,0.37,0.32,0.05,0.0,0.0,0.0,0.05,steven stuart,,CH-3320,2019
+CH,3320,3,Physical Chemistry,0.88,0.04,0.08,0.0,0.0,0.0,0.0,0.0,jason mcneill,,CH-3320,2019
+CH,3320,5,Physical Chemistry,0.64,0.14,0.11,0.04,0.07,0.0,0.0,0.0,leah bec casabianca,,CH-3320,2019
+CH,3400,2,Physical Chem Lab,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2019
+CH,3400,3,Physical Chem Lab,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2019
+CH,3400,4,Physical Chem Lab,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,princess mycia cox,,CH-3400,2019
+CH,3600,1,Chemical Biology,0.48,0.31,0.14,0.0,0.0,0.0,0.0,0.07,modi wetzler,,CH-3600,2019
+CH,4110,1,Instrumental Analy,0.45,0.4,0.1,0.0,0.0,0.0,0.0,0.05,jeffrey natha anker,,CH-4110,2019
+CH,4120,2,Instr Analysis Lab,0.7,0.1,0.0,0.0,0.1,0.0,0.0,0.1,george chumanov,,CH-4120,2019
+CH,4130,1,Chemistry of Aqueous Systems,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,cindy lee,,CH-4130,2019
+CH,4500,1,Chemistry Capstone,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,tania issa houjeiry,,CH-4500,2019
+CH,4990,6,Cr Inq in Chemistry IV 1218,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,dev priya arya,,CH-4990,2019
+CH,6140,1,Bioanalytical Chem,0.09,0.82,0.09,0.0,0.0,0.0,0.0,0.0,carlos garcia perez,,CH-6140,2019
+CH,8130,1,Electrochem Sci,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,stephen creager,,CH-8130,2019
+CH,8510,1,Grad Student Seminar,0.83,0.14,0.0,0.0,0.0,0.0,0.0,0.03,joseph stu thrasher,,CH-8510,2019
+CH,8510,2,Grad Student Seminar,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,steven stuart,,CH-8510,2019
+CHE,1300,1,Intro to Chemical Engineering,0.25,0.21,0.21,0.08,0.06,0.0,0.0,0.19,christopher norfolk,,CHE-1300,2019
+CHE,1300,2,Intro to Chemical Engineering,0.24,0.2,0.22,0.1,0.08,0.0,0.0,0.18,christopher norfolk,,CHE-1300,2019
+CHE,2200,1,Ch E Thermo I,0.13,0.39,0.25,0.13,0.08,0.0,0.0,0.03,jessica mari larsen,,CHE-2200,2019
+CHE,2300,1,Fluids/Heat Transfer,0.19,0.18,0.35,0.15,0.11,0.0,0.0,0.01,eric mikel davis,,CHE-2300,2019
+CHE,3070,1,Unit Ops Lab I,0.28,0.63,0.07,0.02,0.0,0.0,0.0,0.0,christopher norfolk,,CHE-3070,2019
+CHE,3190,1,Engr Materials,0.12,0.33,0.35,0.12,0.03,0.0,0.0,0.05,amod ogale,,CHE-3190,2019
+CHE,3190,1,Engr Materials,0.12,0.33,0.35,0.12,0.03,0.0,0.0,0.05,christopher norfolk,,CHE-3190,2019
+CHE,3530,1,Proc Dyn & Control,0.24,0.46,0.26,0.02,0.0,0.0,0.0,0.01,mark roberts,,CHE-3530,2019
+CHE,3990,13,CI- ARTIFICIAL CHROMOSOMES,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,marc rus birtwistle,,CHE-3990,2019
+CHE,4330,1,Process Design II,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,david bruce,,CHE-4330,2019
+CHE,8140,1,Numerical Methods,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,joseph scott,,CHE-8140,2019
+CHE,8450,5,Statistical Mechanics,0.63,0.13,0.25,0.0,0.0,0.0,0.0,0.0,sapna sarupria,,CHE-8450,2019
+CHIN,1010,1,Elementary Chinese,0.61,0.11,0.06,0.0,0.06,0.0,0.0,0.17,yanming an,,CHIN-1010,2019
+CHIN,1020,1,Elementary Chinese,0.3,0.3,0.4,0.0,0.0,0.0,0.0,0.0,ling rao,,CHIN-1020,2019
+CHIN,3120,1,Philosophy in Ancient China,0.33,0.46,0.08,0.0,0.0,0.0,0.0,0.13,yanming an,,CHIN-3120,2019
+COM,1500,1,Intro to Human Communication,0.74,0.25,0.01,0.0,0.0,0.0,0.0,0.0,daniel lelan fecher,,COM-1500,2019
+COM,1500,2,Intro to Human Communication,0.71,0.25,0.01,0.0,0.03,0.0,0.0,0.0,daniel lelan fecher,,COM-1500,2019
+COM,1500,3,Intro to Human Communication,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.01,daniel lelan fecher,,COM-1500,2019
+COM,1500,4,Intro to Human Communication,0.7,0.26,0.02,0.01,0.01,0.0,0.0,0.01,marianne her glaser,,COM-1500,2019
+COM,1500,5,Intro to Human Communication,0.75,0.17,0.03,0.01,0.02,0.0,0.0,0.01,marianne her glaser,,COM-1500,2019
+COM,1500,6,Intro to Human Communication,0.62,0.29,0.06,0.0,0.0,0.0,0.0,0.03,vanessa anne condon,,COM-1500,2019
+COM,2010,1,Intr to Comm Studies,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2010,2019
+COM,2010,2,Intr to Comm Studies,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,caitlin baker,,COM-2010,2019
+COM,2020,1,Communication Theory,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,pauline matthey,,COM-2020,2019
+COM,2040,1,Critical-Cultural Comm Theory,0.47,0.26,0.21,0.05,0.0,0.0,0.0,0.0,james nicho gilmore,,COM-2040,2019
+COM,2100,1,Quant Comm Research Methods,0.44,0.37,0.11,0.07,0.0,0.0,0.0,0.0,joseph mazer,,COM-2100,2019
+COM,2120,1,Crit-Cultural Rsrch Methods,0.74,0.22,0.0,0.04,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2120,2019
+COM,2500,1,Public Speaking,0.71,0.14,0.05,0.0,0.0,0.0,0.0,0.1,caitlin baker,,COM-2500,2019
+COM,2500,3,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,charles john brewer,,COM-2500,2019
+COM,2500,4,Public Speaking,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,charles john brewer,,COM-2500,2019
+COM,2500,5,Public Speaking,0.29,0.48,0.1,0.0,0.05,0.0,0.0,0.1,sara grumbl crocker,,COM-2500,2019
+COM,2500,6,Public Speaking,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,marshall tho covert,,COM-2500,2019
+COM,2500,7,Public Speaking,0.75,0.2,0.05,0.0,0.0,0.0,0.0,0.0,charles john brewer,,COM-2500,2019
+COM,2500,8,Public Speaking,0.57,0.33,0.05,0.0,0.05,0.0,0.0,0.0,charles john brewer,,COM-2500,2019
+COM,2500,9,Public Speaking,0.52,0.24,0.05,0.1,0.05,0.0,0.0,0.05,ashley lauren pikel,,COM-2500,2019
+COM,2500,10,Public Speaking,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,,COM-2500,2019
+COM,2500,11,Public Speaking,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,ashley lauren pikel,,COM-2500,2019
+COM,2500,12,Public Speaking,0.76,0.14,0.1,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,,COM-2500,2019
+COM,2500,13,Public Speaking,0.67,0.29,0.0,0.0,0.05,0.0,0.0,0.0,ashley lauren pikel,,COM-2500,2019
+COM,2500,14,Public Speaking,0.52,0.43,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,,COM-2500,2019
+COM,2500,15,Public Speaking,0.33,0.62,0.05,0.0,0.0,0.0,0.0,0.0,elizabeth gilmore,,COM-2500,2019
+COM,2500,16,Public Speaking,0.81,0.1,0.05,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2019
+COM,2500,17,Public Speaking,0.6,0.2,0.15,0.0,0.05,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2019
+COM,2500,18,Public Speaking,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,jumah patrici taweh,,COM-2500,2019
+COM,2500,19,Public Speaking (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,rachelle le beckner,True,COM-2500,2019
+COM,2500,20,Public Speaking,0.67,0.29,0.0,0.05,0.0,0.0,0.0,0.0,katie barn mcelveen,,COM-2500,2019
+COM,2500,21,Public Speaking,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,blythe kai steelman,,COM-2500,2019
+COM,2500,23,Public Speaking,0.81,0.14,0.05,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-2500,2019
+COM,2500,24,Public Speaking,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,rachelle le beckner,,COM-2500,2019
+COM,2500,25,Public Speaking,0.52,0.43,0.05,0.0,0.0,0.0,0.0,0.0,vanessa anne condon,,COM-2500,2019
+COM,2500,26,Public Speaking (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,True,COM-2500,2019
+COM,2500,28,Public Speaking (HON),0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jumah patrici taweh,True,COM-2500,2019
+COM,2500,31,Public Speaking,0.57,0.38,0.05,0.0,0.0,0.0,0.0,0.0,marshall tho covert,,COM-2500,2019
+COM,2500,32,Public Speaking,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2019
+COM,2500,33,Public Speaking,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,sara grumbl crocker,,COM-2500,2019
+COM,2500,34,Public Speaking,0.43,0.43,0.05,0.05,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2019
+COM,2500,35,Public Speaking,0.4,0.55,0.0,0.0,0.0,0.0,0.0,0.05,pauline matthey,,COM-2500,2019
+COM,2500,36,Public Speaking,0.25,0.65,0.05,0.05,0.0,0.0,0.0,0.0,marshall tho covert,,COM-2500,2019
+COM,2500,37,Public Speaking,0.5,0.35,0.05,0.0,0.0,0.0,0.0,0.1,elizabeth gilmore,,COM-2500,2019
+COM,2500,38,Public Speaking,0.62,0.33,0.05,0.0,0.0,0.0,0.0,0.0,marshall tho covert,,COM-2500,2019
+COM,2500,400,Public Speaking,0.77,0.18,0.05,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2019
+COM,2500,401,Public Speaking,0.71,0.19,0.0,0.0,0.1,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2019
+COM,2500,402,Public Speaking,0.86,0.05,0.05,0.0,0.0,0.0,0.0,0.05,alexis zachar davis,,COM-2500,2019
+COM,2500,403,Public Speaking,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,alexis zachar davis,,COM-2500,2019
+COM,3070,1,Public Comm of Sts,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,meghna tallapragada,,COM-3070,2019
+COM,3240,1,"Communication, Sport & Society",0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,gregory kei cranmer,,COM-3240,2019
+COM,3240,2,"Communication, Sport & Society",0.77,0.09,0.05,0.09,0.0,0.0,0.0,0.0,katie barn mcelveen,,COM-3240,2019
+COM,3250,1,Survey of Sports Communication,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,angela pratt,,COM-3250,2019
+COM,3260,1,Pr in Sports,0.72,0.24,0.0,0.0,0.0,0.0,0.0,0.04,angela pratt,,COM-3260,2019
+COM,3260,2,Pr in Sports,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,angela pratt,,COM-3260,2019
+COM,3270,1,Sports Media Criticism,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,katie barn mcelveen,,COM-3270,2019
+COM,3480,1,Interpersonal Comm,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-3480,2019
+COM,3480,2,Interpersonal Comm,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,alyssa christ davis,,COM-3480,2019
+COM,3550,1,Principles of Public Relations,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,meghna tallapragada,,COM-3550,2019
+COM,3570,1,Public Relations Writing,0.67,0.21,0.04,0.04,0.0,0.0,0.0,0.04,andrew stephen pyle,,COM-3570,2019
+COM,3610,1,Argue and Debate,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lindsey dixon,,COM-3610,2019
+COM,3640,1,Organizational Comm,0.7,0.26,0.04,0.0,0.0,0.0,0.0,0.0,kristen ela okamoto,,COM-3640,2019
+COM,3660,1,Video COMM w/ Adobe CC,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,michael rodgers,,COM-3660,2019
+COM,3660,4,Corporate Communications,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,. mark barnes,,COM-3660,2019
+COM,4250,1,Adv Sports Comm,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bryan denham,,COM-4250,2019
+COM,4260,1,Social Media and Sports Comm,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4260,2019
+COM,4270,1,Comm in Sports Organizations,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,john steven spinda,,COM-4270,2019
+COM,4280,1,Interpers/Family Comm & Sport,0.26,0.63,0.05,0.05,0.0,0.0,0.0,0.0,gregory kei cranmer,,COM-4280,2019
+COM,4310,1,Legal Communication Trial,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,james isaac roberts,,COM-4310,2019
+COM,4550,1,Gender Communication,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,,COM-4550,2019
+COM,4560,1,PR for Assoc & Nonprofits,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,andrew stephen pyle,,COM-4560,2019
+COM,4700,1,Comm & Health,0.47,0.37,0.16,0.0,0.0,0.0,0.0,0.0,stephanie pangborn,,COM-4700,2019
+COM,4950,1,Senior Capstone,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,erin michelle ash,,COM-4950,2019
+COM,4950,2,Senior Capstone,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,darren linvill,,COM-4950,2019
+COM,8060,1,Health Communication & Culture,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,david travers scott,,COM-8060,2019
+CPSC,1010,1,Computer Science I,0.51,0.22,0.12,0.05,0.05,0.0,0.0,0.05,roger larr van scoy,,CPSC-1010,2019
+CPSC,1010,2,Computer Science I,0.24,0.35,0.15,0.06,0.11,0.0,0.0,0.09,yu-shan sun,,CPSC-1010,2019
+CPSC,1020,1,Computer Science II,0.42,0.27,0.17,0.02,0.04,0.0,0.0,0.08,yvon feaster,,CPSC-1020,2019
+CPSC,1020,2,Computer Science II,0.29,0.21,0.25,0.04,0.1,0.0,0.0,0.1,yvon feaster,,CPSC-1020,2019
+CPSC,1020,3,Computer Science II,0.13,0.33,0.28,0.02,0.13,0.0,0.0,0.11,catherine hochrine,,CPSC-1020,2019
+CPSC,1020,4,Computer Science II,0.27,0.23,0.36,0.05,0.07,0.0,0.0,0.02,mark smotherman,,CPSC-1020,2019
+CPSC,1110,1,Intro to Programming in C,0.19,0.22,0.19,0.11,0.06,0.0,0.0,0.22,catherine hochrine,,CPSC-1110,2019
+CPSC,1110,2,Intro to Programming in C,0.15,0.3,0.18,0.13,0.1,0.0,0.0,0.15,catherine hochrine,,CPSC-1110,2019
+CPSC,1110,3,Intro to Programming in C,0.19,0.25,0.19,0.06,0.16,0.0,0.0,0.16,andrew duchowski,,CPSC-1110,2019
+CPSC,2070,1,Discrete Structures,0.69,0.11,0.06,0.0,0.06,0.0,0.0,0.09,sandra hedetniemi,,CPSC-2070,2019
+CPSC,2070,2,Discrete Structures,0.42,0.25,0.17,0.11,0.03,0.0,0.0,0.03,larry hodges,,CPSC-2070,2019
+CPSC,2120,1,Algs/Data Structures,0.49,0.23,0.06,0.03,0.06,0.0,0.0,0.14,andrew hill,,CPSC-2120,2019
+CPSC,2120,2,Algs/Data Structures,0.6,0.17,0.11,0.02,0.04,0.0,0.0,0.06,andrew hill,,CPSC-2120,2019
+CPSC,2120,3,Algs/Data Structures,0.53,0.34,0.06,0.02,0.02,0.0,0.0,0.02,andrew hill,,CPSC-2120,2019
+CPSC,2150,1,Software Dev Foundations,0.34,0.36,0.14,0.04,0.0,0.0,0.0,0.12,kevin anton plis,,CPSC-2150,2019
+CPSC,2150,2,Software Dev Foundations,0.16,0.34,0.18,0.05,0.14,0.0,0.0,0.14,yu-shan sun,,CPSC-2150,2019
+CPSC,2150,3,Software Dev Foundations,0.26,0.35,0.16,0.03,0.13,0.0,0.0,0.06,yu-shan sun,,CPSC-2150,2019
+CPSC,2200,1,Microcomputer Appl,0.5,0.29,0.07,0.04,0.04,0.0,0.0,0.07,kevin anton plis,,CPSC-2200,2019
+CPSC,2200,2,Microcomputer Appl,0.31,0.38,0.23,0.04,0.04,0.0,0.0,0.0,kevin anton plis,,CPSC-2200,2019
+CPSC,2310,1,Intro Computer Org,0.45,0.35,0.1,0.04,0.02,0.0,0.0,0.04,nicolas benj widman,,CPSC-2310,2019
+CPSC,2310,2,Intro Computer Org,0.42,0.3,0.18,0.08,0.0,0.0,0.0,0.02,nicolas benj widman,,CPSC-2310,2019
+CPSC,2810,2,Sel Top: Cyberdefen Comp Train,0.76,0.0,0.0,0.0,0.0,0.0,0.0,0.24,hongda li,,CPSC-2810,2019
+CPSC,2910,1,Prof Issues I,0.44,0.28,0.28,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2019
+CPSC,2910,2,Prof Issues I,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,catherine hochrine,,CPSC-2910,2019
+CPSC,2910,3,Prof Issues I,0.58,0.26,0.16,0.0,0.0,0.0,0.0,0.0,catherine hochrine,,CPSC-2910,2019
+CPSC,2920,1,"Computing, Ethics & Society",0.2,0.28,0.16,0.02,0.04,0.0,0.0,0.3,christopher plaue,,CPSC-2920,2019
+CPSC,3120,1,Design Analysis of Algorithms,0.38,0.48,0.12,0.0,0.0,0.0,0.0,0.02,wayne goddard,,CPSC-3120,2019
+CPSC,3120,2,Design Analysis of Algorithms,0.33,0.25,0.14,0.03,0.08,0.0,0.0,0.17,federico iuricich,,CPSC-3120,2019
+CPSC,3220,1,Intro to Operating Systems,0.19,0.14,0.28,0.05,0.14,0.0,0.0,0.21,jacob sorber,,CPSC-3220,2019
+CPSC,3220,2,Intro to Operating Systems,0.37,0.4,0.07,0.02,0.07,0.0,0.0,0.07,rong ge,,CPSC-3220,2019
+CPSC,3300,1,Computer Systems Org,0.38,0.31,0.25,0.02,0.04,0.0,0.0,0.0,nicolas benj widman,,CPSC-3300,2019
+CPSC,3300,2,Computer Systems Org,0.46,0.22,0.19,0.05,0.05,0.0,0.0,0.03,nicolas benj widman,,CPSC-3300,2019
+CPSC,3500,1,Foundations of Computer Sci,0.18,0.16,0.33,0.08,0.06,0.0,0.0,0.18,ilya mark safro,,CPSC-3500,2019
+CPSC,3520,1,Programming Systems,0.23,0.38,0.22,0.03,0.03,0.0,0.0,0.11,robert schalkoff,,CPSC-3520,2019
+CPSC,3600,1,Network Programming,0.66,0.2,0.09,0.0,0.0,0.0,0.0,0.05,long cheng,,CPSC-3600,2019
+CPSC,3600,2,Network Programming,0.36,0.32,0.04,0.0,0.14,0.0,0.0,0.14,zijun wang,,CPSC-3600,2019
+CPSC,3710,1,Systems Analysis,0.45,0.3,0.25,0.0,0.0,0.0,0.0,0.0,roger larr van scoy,,CPSC-3710,2019
+CPSC,3720,1,Software Engineering,0.41,0.47,0.13,0.0,0.0,0.0,0.0,0.0,paige ann rodeghero,,CPSC-3720,2019
+CPSC,3720,2,Software Engineering,0.26,0.56,0.18,0.0,0.0,0.0,0.0,0.0,murali sitaraman,,CPSC-3720,2019
+CPSC,3990,2,Adv CI: Sim Meth in Graphs & E,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,luis bermudez,,CPSC-3990,2019
+CPSC,3990,2,Adv CI: Sim Meth in Graphs & E,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,victor zordan,,CPSC-3990,2019
+CPSC,3990,3,CI: User Exper in VR Games,0.6,0.0,0.0,0.2,0.0,0.0,0.0,0.2,andrew robb,,CPSC-3990,2019
+CPSC,4050,1,Computer Graphics,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,victor zordan,,CPSC-4050,2019
+CPSC,4110,1,Virtual Reality Systems,0.39,0.42,0.15,0.03,0.0,0.0,0.0,0.0,andrew robb,,CPSC-4110,2019
+CPSC,4140,1,Human and Computer Interaction,0.49,0.38,0.09,0.0,0.04,0.0,0.0,0.0,sabarish venka babu,,CPSC-4140,2019
+CPSC,4160,1,2-D Game Engine Construction,0.49,0.34,0.13,0.0,0.0,0.0,0.02,0.02,brian malloy,,CPSC-4160,2019
+CPSC,4180,1,Usable Privacy and Security,0.55,0.23,0.05,0.0,0.05,0.0,0.0,0.14,kelly caine,,CPSC-4180,2019
+CPSC,4200,1,Computer Security Principles,0.7,0.27,0.0,0.03,0.0,0.0,0.0,0.0,yvon feaster,,CPSC-4200,2019
+CPSC,4240,1,System Admin and Security,0.24,0.7,0.03,0.0,0.0,0.0,0.0,0.03,james martin,,CPSC-4240,2019
+CPSC,4440,1,Cloud Computing Architecture,0.29,0.42,0.21,0.0,0.0,0.0,0.0,0.08,amy apon,,CPSC-4440,2019
+CPSC,4620,1,Database Management Systems,0.3,0.41,0.22,0.0,0.0,0.0,0.0,0.07,zijun wang,,CPSC-4620,2019
+CPSC,4620,2,Database Management Systems,0.42,0.34,0.24,0.0,0.0,0.0,0.0,0.0,kevin anton plis,,CPSC-4620,2019
+CPSC,4770,1,Distributed/Cluster Computing,0.56,0.22,0.17,0.0,0.0,0.0,0.0,0.06,shuangshuang jin,,CPSC-4770,2019
+CPSC,4820,1,Special Topic: Concurrent Prog,0.36,0.32,0.14,0.0,0.05,0.0,0.0,0.14,eileen ther kraemer,,CPSC-4820,2019
+CPSC,4820,2,Special Topics: Tang and Embod,0.46,0.36,0.11,0.04,0.0,0.0,0.0,0.04,brygg anders ullmer,,CPSC-4820,2019
+CPSC,4820,3,Special Topic in Computing: AI,0.46,0.13,0.21,0.04,0.04,0.0,0.0,0.13,ioannis karamouzas,,CPSC-4820,2019
+CPSC,4910,1,Professional Issues II,0.48,0.45,0.05,0.0,0.0,0.0,0.03,0.0,roger larr van scoy,,CPSC-4910,2019
+CPSC,4910,2,Professional Issues II,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,,CPSC-4910,2019
+CPSC,4910,3,Professional Issues II,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,alexander ch herzog,,CPSC-4910,2019
+CPSC,6050,1,Computer Graphics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,victor zordan,,CPSC-6050,2019
+CPSC,6110,1,Virtual Reality Systems,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andrew robb,,CPSC-6110,2019
+CPSC,6140,1,Human and Computer Interaction,0.78,0.11,0.0,0.0,0.11,0.0,0.0,0.0,sabarish venka babu,,CPSC-6140,2019
+CPSC,6160,1,2-D Game Engine Construction,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,brian malloy,,CPSC-6160,2019
+CPSC,6440,1,Cloud Computing Architecture,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,amy apon,,CPSC-6440,2019
+CPSC,6620,1,Database Management Systems,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,zijun wang,,CPSC-6620,2019
+CPSC,8040,1,Data Visualization,0.7,0.22,0.08,0.0,0.0,0.0,0.0,0.0,federico iuricich,,CPSC-8040,2019
+CPSC,8110,1,Technical Character Animation,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,christina sop joerg,,CPSC-8110,2019
+CPSC,8240,1,Advanced Operating Systems,0.33,0.5,0.0,0.0,0.0,0.0,0.0,0.17,rong ge,,CPSC-8240,2019
+CPSC,8400,1,Design & Anlys of Algorithms,0.3,0.35,0.2,0.0,0.05,0.0,0.0,0.1,brian christop dean,,CPSC-8400,2019
+CPSC,8570,1,Network Technologies Security,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,hongxin hu,,CPSC-8570,2019
+CPSC,8650,1,Data Mining,0.31,0.38,0.28,0.0,0.0,0.0,0.0,0.03,zijun wang,,CPSC-8650,2019
+CPSC,8810,6,Sel Topic: Deep Learning,0.86,0.11,0.0,0.0,0.0,0.0,0.0,0.03,feng luo,,CPSC-8810,2019
+CPSC,8810,7,Selected Topics: Moti Planning,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,ioannis karamouzas,,CPSC-8810,2019
+CSM,1000,1,Intro to Construct,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,,CSM-1000,2019
+CSM,2010,1,Structures I,0.61,0.21,0.12,0.03,0.0,0.0,0.0,0.03,shima clarke,,CSM-2010,2019
+CSM,2020,1,Structures II,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,nathaniel jackson,,CSM-2020,2019
+CSM,2030,1,Mats & Meth of Const,0.29,0.55,0.16,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,,CSM-2030,2019
+CSM,2040,1,Cont Documents,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,robert dawso coffey,,CSM-2040,2019
+CSM,2050,1,Mats & Methods II,0.3,0.63,0.07,0.0,0.0,0.0,0.0,0.0,dhaval gajjar,,CSM-2050,2019
+CSM,3040,1,Envir Systems I,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3040,2019
+CSM,3050,1,Envir Systems II,0.23,0.53,0.15,0.07,0.02,0.0,0.0,0.0,joseph mich burgett,,CSM-3050,2019
+CSM,3060,1,Emerging Tech in Construction,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,jason lucas,,CSM-3060,2019
+CSM,3070,1,Sustainable Construction,0.46,0.48,0.05,0.02,0.0,0.0,0.0,0.0,joseph mich burgett,,CSM-3070,2019
+CSM,3510,1,Construction Estimating,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,,CSM-3510,2019
+CSM,3520,1,Const Scheduling,0.78,0.19,0.0,0.03,0.0,0.0,0.0,0.0,craig townsend,,CSM-3520,2019
+CSM,3520,2,Const Scheduling,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-3520,2019
+CSM,3520,2,Const Scheduling,0.47,0.5,0.03,0.0,0.0,0.0,0.0,0.0,jaime cruz,,CSM-3520,2019
+CSM,3530,1,Const Estimating II,0.42,0.45,0.13,0.0,0.0,0.0,0.0,0.0,seyed mousavi rizi,,CSM-3530,2019
+CSM,3530,2,Const Estimating II,0.26,0.65,0.1,0.0,0.0,0.0,0.0,0.0,anthony dway harden,,CSM-3530,2019
+CSM,4110,1,Safety in Bldg Const,0.68,0.29,0.03,0.0,0.0,0.0,0.0,0.0,nicholas corley,,CSM-4110,2019
+CSM,4540,1,Const Capstone,0.5,0.47,0.03,0.0,0.0,0.0,0.0,0.0,dennis bausman,,CSM-4540,2019
+CSM,8600,1,Constr Finan Plan & Analysis,0.39,0.57,0.0,0.0,0.0,0.0,0.0,0.04,dennis bausman,,CSM-8600,2019
+CSM,8600,401,Constr Finan Plan & Analysis,0.4,0.4,0.0,0.0,0.0,0.0,0.0,0.2,dennis bausman,,CSM-8600,2019
+CSM,8680,401,Emerging Tech in Built Environ,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,jason lucas,,CSM-8680,2019
+CU,1000,1,Clemson Connect,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,susan whorton,,CU-1000,2019
+CU,1010,1,Univ Success Skills,0.4,0.1,0.25,0.0,0.05,0.0,0.0,0.2,valerie kay oonk,,CU-1010,2019
+CU,1010,2,Univ Success Skills,0.47,0.24,0.18,0.06,0.0,0.0,0.0,0.06,alejandra kennedy,,CU-1010,2019
+CU,1010,3,Univ Success Skills,0.47,0.37,0.11,0.0,0.0,0.0,0.0,0.05,bryn zimmerman babb,,CU-1010,2019
+CU,1010,5,Univ Success Skills,0.45,0.25,0.15,0.0,0.05,0.0,0.0,0.1,bryn zimmerman babb,,CU-1010,2019
+CU,1010,6,Univ Success Skills,0.74,0.11,0.0,0.05,0.11,0.0,0.0,0.0,james garland,,CU-1010,2019
+CU,1010,7,Univ Success Skills,0.7,0.1,0.1,0.0,0.1,0.0,0.0,0.0,taimi olsen,,CU-1010,2019
+CU,2010,1,Sustainability Leadership,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,jennifer marg goree,,CU-2010,2019
+CVT,2250,400,Ultrasound Physics,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ronda kel nicholson,,CVT-2250,2019
+DANC,1600,1,Ballet Dance I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,cheryl hosler,,DANC-1600,2019
+DPA,3070,1,Method 3d Production,0.37,0.44,0.07,0.04,0.0,0.0,0.0,0.07,tommy van bui,,DPA-3070,2019
+DPA,4020,1,Visual Found of Digital Prod,0.5,0.25,0.0,0.0,0.0,0.0,0.0,0.25,anthony summey,,DPA-4020,2019
+DPA,4030,1,Vis Foundations II,0.29,0.43,0.29,0.0,0.0,0.0,0.0,0.0,anthony summey,,DPA-4030,2019
+DPA,4830,1,Sp Stud Top: Digit Sculp Intro,0.56,0.38,0.0,0.0,0.0,0.0,0.0,0.06,insun kwon,,DPA-4830,2019
+DPA,8150,1,Special Effects Compositing,0.38,0.63,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,,DPA-8150,2019
+DPA,8150,843,Special Effects Compositing,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,eric patterson,,DPA-8150,2019
+ECE,2010,1,Logic and Computing Device,0.22,0.3,0.22,0.13,0.06,0.0,0.0,0.06,lin zhu,,ECE-2010,2019
+ECE,2020,1,Electric Circuits I,0.16,0.31,0.27,0.04,0.15,0.0,0.0,0.07,william harrell,,ECE-2020,2019
+ECE,2070,1,Basic Electrical Engineering,0.38,0.36,0.16,0.05,0.02,0.0,0.0,0.02,fatemeh tooryan,,ECE-2070,2019
+ECE,2070,2,Basic Electrical Engineering,0.59,0.25,0.09,0.03,0.01,0.0,0.0,0.03,timothy anglea,,ECE-2070,2019
+ECE,2070,3,Basic Electrical Engineering,0.23,0.42,0.19,0.02,0.0,0.0,0.12,0.02,william th kolodzey,,ECE-2070,2019
+ECE,2080,4,Basic Electrical Engr Lab,0.89,0.0,0.0,0.0,0.05,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2019
+ECE,2080,10,Basic Electrical Engr Lab,0.89,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2019
+ECE,2080,18,Basic Electrical Engr Lab,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2080,2019
+ECE,2080,20,Basic Electrical Engr Lab,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,apoorva dee kapadia,,ECE-2080,2019
+ECE,2090,3,Logic & Computing Devices Lab,0.27,0.55,0.0,0.0,0.09,0.0,0.0,0.09,apoorva dee kapadia,,ECE-2090,2019
+ECE,2110,1,Elec Engr Lab I,0.47,0.21,0.05,0.05,0.05,0.0,0.0,0.16,apoorva dee kapadia,,ECE-2110,2019
+ECE,2110,2,Elec Engr Lab I,0.77,0.0,0.15,0.0,0.0,0.0,0.0,0.08,apoorva dee kapadia,,ECE-2110,2019
+ECE,2120,1,Electrical Engineering Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2120,2019
+ECE,2120,6,Electrical Engineering Lab II,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2120,2019
+ECE,2120,9,Electrical Engineering Lab II,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2120,2019
+ECE,2220,1,Syst Prog Concept,0.18,0.33,0.24,0.04,0.14,0.0,0.0,0.07,william reid,,ECE-2220,2019
+ECE,2230,1,Comp Sys Eng,0.18,0.24,0.24,0.03,0.18,0.0,0.0,0.15,jon cameron calhoun,,ECE-2230,2019
+ECE,2620,1,Electric Circuits II,0.36,0.34,0.19,0.07,0.04,0.0,0.0,0.0,richard groff,,ECE-2620,2019
+ECE,2720,1,Comp Organization,0.37,0.37,0.2,0.02,0.03,0.0,0.0,0.0,william reid,,ECE-2720,2019
+ECE,2730,2,Computer Org Lab,0.79,0.14,0.07,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-2730,2019
+ECE,3000,1,Junior Honors Seminar,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,daniel noneaker,True,ECE-3000,2019
+ECE,3000,1,Junior Honors Seminar,0.88,0.0,0.13,0.0,0.0,0.0,0.0,0.0,carl baum,True,ECE-3000,2019
+ECE,3110,2,Electrical Engineering Lab III,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2019
+ECE,3110,3,Electrical Engineering Lab III,0.67,0.27,0.07,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2019
+ECE,3110,4,Electrical Engineering Lab III,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3110,2019
+ECE,3110,5,Electrical Engineering Lab III,0.36,0.45,0.09,0.0,0.0,0.0,0.0,0.09,apoorva dee kapadia,,ECE-3110,2019
+ECE,3120,3,Electrical Engineering Lab IV,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,,ECE-3120,2019
+ECE,3170,1,Rand Signal Analysis,0.3,0.18,0.28,0.13,0.07,0.0,0.0,0.04,stephen hubbard,,ECE-3170,2019
+ECE,3200,1,Electronics I,0.3,0.24,0.19,0.16,0.08,0.0,0.0,0.03,stephen hubbard,,ECE-3200,2019
+ECE,3210,1,Electronics II,0.35,0.41,0.06,0.14,0.04,0.0,0.0,0.0,stephen hubbard,,ECE-3210,2019
+ECE,3220,1,Intro Operating Sys,0.21,0.38,0.24,0.03,0.03,0.0,0.0,0.1,jacob sorber,,ECE-3220,2019
+ECE,3220,2,Intro Operating Sys,0.55,0.27,0.0,0.09,0.09,0.0,0.0,0.0,rong ge,,ECE-3220,2019
+ECE,3270,1,Dig Comp Design,0.12,0.2,0.22,0.2,0.15,0.0,0.0,0.11,melissa crawl smith,,ECE-3270,2019
+ECE,3300,1,Signals & Systems,0.13,0.27,0.27,0.14,0.1,0.0,0.0,0.08,carl baum,,ECE-3300,2019
+ECE,3520,1,Programming Systems,0.66,0.3,0.02,0.0,0.0,0.0,0.0,0.02,robert schalkoff,,ECE-3520,2019
+ECE,3600,1,Elect Power Engr,0.3,0.24,0.24,0.05,0.0,0.0,0.03,0.14,edward collins,,ECE-3600,2019
+ECE,3710,1,Microcontr Interface,0.35,0.44,0.17,0.0,0.05,0.0,0.0,0.0,william reid,,ECE-3710,2019
+ECE,3720,3,Micro Int Lab,0.8,0.0,0.1,0.0,0.0,0.0,0.0,0.1,apoorva dee kapadia,,ECE-3720,2019
+ECE,3720,5,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2019
+ECE,3720,7,Micro Int Lab,0.83,0.08,0.08,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-3720,2019
+ECE,3800,1,Electromagnetics,0.24,0.23,0.16,0.08,0.1,0.0,0.0,0.19,yuan li,,ECE-3800,2019
+ECE,3810,1,Field Waves & Ckts,0.4,0.4,0.11,0.03,0.0,0.0,0.0,0.06,anthony martin,,ECE-3810,2019
+ECE,3990,5,CI: High-Perf. Cluster Comp.,0.8,0.0,0.0,0.2,0.0,0.0,0.0,0.0,jon cameron calhoun,,ECE-3990,2019
+ECE,4090,1,Intr to Linear Control Systems,0.68,0.13,0.15,0.0,0.02,0.0,0.0,0.02,ian walker,,ECE-4090,2019
+ECE,4160,1,Smart Grid,0.44,0.47,0.06,0.0,0.0,0.0,0.0,0.03,gan venayagamoorthy,,ECE-4160,2019
+ECE,4190,1,Elec Mach and Drives,0.25,0.25,0.2,0.15,0.05,0.0,0.0,0.1,johan heinri enslin,,ECE-4190,2019
+ECE,4270,1,Communications Sys,0.2,0.23,0.4,0.06,0.03,0.0,0.0,0.09,lu yu,,ECE-4270,2019
+ECE,4320,1,Instrumentation,0.1,0.5,0.3,0.1,0.0,0.0,0.0,0.0,goutam koley,,ECE-4320,2019
+ECE,4380,1,Computer Commun,0.24,0.29,0.24,0.06,0.0,0.0,0.03,0.15,harlan russell,,ECE-4380,2019
+ECE,4400,1,Local Computer Nets,0.54,0.38,0.04,0.0,0.0,0.0,0.0,0.04,kuang-ching wang,,ECE-4400,2019
+ECE,4680,1,Embedded Computing,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,adam hoover,,ECE-4680,2019
+ECE,4930,12,Industrial Contr & Automation,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,apoorva dee kapadia,,ECE-4930,2019
+ECE,4950,1,Int Sys Design I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,apoorva dee kapadia,,ECE-4950,2019
+ECE,4960,1,Int Sys Design II,0.58,0.34,0.07,0.0,0.0,0.0,0.0,0.01,richard groff,,ECE-4960,2019
+ECE,4990,18,CI: Deep Learning & Big Data,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,melissa crawl smith,,ECE-4990,2019
+ECE,6190,1,Elec Mach and Drives,0.75,0.0,0.25,0.0,0.0,0.0,0.0,0.0,johan heinri enslin,,ECE-6190,2019
+ECE,6680,1,Embedded Computing,0.64,0.0,0.27,0.0,0.0,0.0,0.0,0.09,adam hoover,,ECE-6680,2019
+ECE,6930,2,Silicon Photonics Design,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,judson doug ryckman,,ECE-6930,2019
+ECE,6930,26,Optical Fiber Communications,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,liang dong,,ECE-6930,2019
+ECE,8170,1,Power System Transients,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,ramtin hadidi,,ECE-8170,2019
+ECE,8240,1,Pow Sys Protection,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,sukumar maka brahma,,ECE-8240,2019
+ECE,8560,1,Pattern Recognition,0.21,0.37,0.16,0.0,0.0,0.0,0.0,0.26,robert schalkoff,,ECE-8560,2019
+ECE,8930,8,Advanced Photonic Sensors,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,hai xiao,,ECE-8930,2019
+ECE,8930,11,Malware Reverse Engineering,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,,ECE-8930,2019
+ECE,8930,11,Malware Reverse Engineering,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,,ECE-8930,2019
+ECE,8930,843,Malware Rev. Engin. Charleston,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,richard brooks,,ECE-8930,2019
+ECE,8930,843,Malware Rev. Engin. Charleston,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,lu yu,,ECE-8930,2019
+ECON,2000,1,Economic Concepts,0.38,0.34,0.16,0.0,0.06,0.0,0.0,0.06,shubhashrita basu,,ECON-2000,2019
+ECON,2000,2,Economic Concepts,0.4,0.35,0.13,0.05,0.0,0.0,0.0,0.08,shubhashrita basu,,ECON-2000,2019
+ECON,2000,3,Economic Concepts,0.65,0.23,0.03,0.05,0.03,0.0,0.0,0.03,miren ivankovic,,ECON-2000,2019
+ECON,2110,1,Principles of Microeconomics,0.4,0.23,0.28,0.08,0.03,0.0,0.0,0.0,sarah louise wilson,,ECON-2110,2019
+ECON,2110,2,Principles of Microeconomics,0.3,0.43,0.2,0.03,0.03,0.0,0.0,0.03,roksan ghanbariamin,,ECON-2110,2019
+ECON,2110,3,Principles of Microeconomics,0.34,0.27,0.21,0.09,0.08,0.0,0.0,0.01,benjamin posmanick,,ECON-2110,2019
+ECON,2110,4,Principles of Microeconomics,0.29,0.53,0.14,0.0,0.02,0.0,0.0,0.02,chen wang,,ECON-2110,2019
+ECON,2110,5,Principles of Microeconomics,0.33,0.38,0.2,0.08,0.0,0.0,0.0,0.03,molly espey,,ECON-2110,2019
+ECON,2110,6,Principles of Microeconomics,0.08,0.42,0.25,0.15,0.04,0.0,0.0,0.06,liuna issagholian,,ECON-2110,2019
+ECON,2110,8,Principles of Microeconomics,0.37,0.34,0.19,0.04,0.02,0.0,0.0,0.04,jonathan orr ernest,,ECON-2110,2019
+ECON,2110,10,Principles of Microeconomics,0.42,0.5,0.06,0.0,0.02,0.0,0.0,0.0,jacob walloga,,ECON-2110,2019
+ECON,2110,12,Principles of Microeconomics,0.38,0.45,0.13,0.0,0.0,0.0,0.0,0.05,molly espey,,ECON-2110,2019
+ECON,2120,1,Principles of Macroeconomics,0.38,0.06,0.5,0.0,0.06,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,2,Principles of Macroeconomics,0.22,0.28,0.39,0.11,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,3,Principles of Macroeconomics,0.28,0.5,0.11,0.06,0.06,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,4,Principles of Macroeconomics,0.11,0.42,0.37,0.11,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,5,Principles of Macroeconomics,0.22,0.33,0.44,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,6,Principles of Macroeconomics,0.5,0.07,0.21,0.07,0.14,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,7,Principles of Macroeconomics,0.21,0.42,0.26,0.05,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,8,Principles of Macroeconomics,0.17,0.28,0.44,0.06,0.06,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,9,Principles of Macroeconomics,0.53,0.21,0.26,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,10,Principles of Macroeconomics,0.26,0.32,0.42,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,11,Principles of Macroeconomics,0.33,0.33,0.33,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,12,Principles of Macroeconomics,0.36,0.14,0.36,0.14,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,13,Principles of Macroeconomics,0.5,0.3,0.15,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,14,Principles of Macroeconomics,0.37,0.42,0.16,0.05,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,15,Principles of Macroeconomics,0.24,0.47,0.18,0.12,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,16,Principles of Macroeconomics,0.61,0.17,0.17,0.06,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,17,Principles of Macroeconomics,0.32,0.47,0.16,0.0,0.05,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,18,Principles of Macroeconomics,0.42,0.26,0.16,0.05,0.11,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,19,Principles of Macroeconomics,0.22,0.33,0.33,0.11,0.0,0.0,0.0,0.0,scott baier,,ECON-2120,2019
+ECON,2120,20,Principles of Macroeconomics,0.31,0.23,0.31,0.05,0.0,0.0,0.03,0.08,narendra regmi,,ECON-2120,2019
+ECON,2120,21,Principles of Macroeconomics,0.84,0.14,0.02,0.0,0.0,0.0,0.0,0.0,tyler francis,,ECON-2120,2019
+ECON,2120,22,Principles of Macroeconomics,0.43,0.35,0.11,0.0,0.0,0.0,0.0,0.11,kenneth whaley,,ECON-2120,2019
+ECON,2120,23,Principles of Macroeconomics,0.39,0.26,0.26,0.0,0.05,0.0,0.0,0.03,kenneth whaley,,ECON-2120,2019
+ECON,2120,24,Principles of Macroeconomics,0.36,0.41,0.11,0.02,0.03,0.0,0.0,0.07,elijah neilson,,ECON-2120,2019
+ECON,2120,25,Principles of Macroeconomics,0.38,0.29,0.24,0.03,0.03,0.0,0.0,0.03,wing yin chung,,ECON-2120,2019
+ECON,2120,26,Principles of Macroeconomics,0.78,0.19,0.0,0.0,0.0,0.0,0.0,0.03,tyler francis,,ECON-2120,2019
+ECON,2120,27,Principles of Macroeconomics,0.38,0.38,0.12,0.03,0.09,0.0,0.0,0.0,benjamin ti harbolt,,ECON-2120,2019
+ECON,2120,28,Principles of Macroecon (HON),0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,christopher gorry,True,ECON-2120,2019
+ECON,2120,29,Principles of Macroeconomics,0.28,0.44,0.24,0.04,0.0,0.0,0.0,0.0,scott barkowski,,ECON-2120,2019
+ECON,3020,1,Money and Banking,0.15,0.49,0.34,0.0,0.02,0.0,0.0,0.0,smriti bhargava,,ECON-3020,2019
+ECON,3060,1,Managerial Economics,0.21,0.28,0.1,0.19,0.14,0.0,0.0,0.09,steven johnson,,ECON-3060,2019
+ECON,3100,1,International Econ,0.29,0.54,0.17,0.0,0.0,0.0,0.0,0.0,scott baier,,ECON-3100,2019
+ECON,3140,1,Intermediate Micro,0.32,0.24,0.18,0.06,0.03,0.0,0.0,0.18,yichen christy zhou,,ECON-3140,2019
+ECON,3140,2,Intermediate Micro,0.23,0.28,0.23,0.15,0.03,0.0,0.0,0.1,robert kennet fleck,,ECON-3140,2019
+ECON,3140,4,Intermediate Micro,0.19,0.11,0.22,0.14,0.16,0.0,0.0,0.19,frederick hanssen,,ECON-3140,2019
+ECON,3150,1,Intermediate Macro,0.27,0.27,0.2,0.1,0.06,0.0,0.0,0.1,michal jerzmanowski,,ECON-3150,2019
+ECON,3150,2,Intermediate Macro,0.7,0.25,0.0,0.0,0.0,0.0,0.0,0.05,jeremy choquette,,ECON-3150,2019
+ECON,3440,1,Property Rights,0.22,0.33,0.17,0.17,0.06,0.0,0.0,0.06,dar litsukova-bokar,,ECON-3440,2019
+ECON,3500,1,Moral & Ethical Econ,0.56,0.24,0.2,0.0,0.0,0.0,0.0,0.0,bradley keith hobbs,,ECON-3500,2019
+ECON,3500,2,Moral & Ethical Econ,0.25,0.35,0.15,0.05,0.05,0.0,0.0,0.15,bradley keith hobbs,,ECON-3500,2019
+ECON,3600,1,Public Choice,0.3,0.48,0.18,0.03,0.0,0.0,0.0,0.03,michael makowsky,,ECON-3600,2019
+ECON,4010,1,Labor Mkt Analysis,0.27,0.47,0.17,0.03,0.03,0.0,0.0,0.03,curtis simon,,ECON-4010,2019
+ECON,4020,1,Law and Economics,0.23,0.4,0.28,0.02,0.0,0.0,0.0,0.07,thomas wins hazlett,,ECON-4020,2019
+ECON,4050,1,Intro to Econometric,0.33,0.25,0.08,0.25,0.06,0.0,0.0,0.03,scott barkowski,,ECON-4050,2019
+ECON,4050,2,Intro to Econometric,0.48,0.23,0.1,0.1,0.03,0.0,0.0,0.06,yichen christy zhou,,ECON-4050,2019
+ECON,4110,1,Econ of Education,0.56,0.29,0.06,0.03,0.0,0.0,0.0,0.06, garcia menendez,,ECON-4110,2019
+ECON,4200,1,Pub Sector Econ,0.24,0.19,0.48,0.05,0.0,0.0,0.0,0.05,william dougan,,ECON-4200,2019
+ECON,4230,1,Economics of Health,0.53,0.29,0.13,0.03,0.0,0.0,0.0,0.03,devon merritt gorry,,ECON-4230,2019
+ECON,4260,1,Sem Sport Economics,0.45,0.36,0.18,0.0,0.0,0.0,0.0,0.0,raymond sauer,,ECON-4260,2019
+ECON,4270,1,Dev American Economy,0.36,0.5,0.14,0.0,0.0,0.0,0.0,0.0,howard ne bodenhorn,,ECON-4270,2019
+ECON,4400,1,Game Theory,0.26,0.13,0.48,0.0,0.04,0.0,0.0,0.09,charles thomas,,ECON-4400,2019
+ECON,4570,1,"Nat Res Use, Technol & Policy",0.0,0.18,0.55,0.18,0.09,0.0,0.0,0.0,scott templeton,,ECON-4570,2019
+ECON,4980,2,Why Business?,0.28,0.56,0.12,0.0,0.0,0.0,0.0,0.04,bradley keith hobbs,,ECON-4980,2019
+ECON,4980,3,Why Business?,0.6,0.3,0.07,0.0,0.0,0.0,0.0,0.02,lawrence ree watson,,ECON-4980,2019
+ECON,4980,4,Econ of Arts & Culture,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,,ECON-4980,2019
+ECON,4980,5,Sel Topic - Machine Learning,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,chungsang lam,,ECON-4980,2019
+ECON,8020,2,Adv Econ Concepts and Applic I,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,kevin ka kin tsui,,ECON-8020,2019
+ECON,8050,1,Macroeconomic Theory,0.5,0.14,0.29,0.07,0.0,0.0,0.0,0.0,michal jerzmanowski,,ECON-8050,2019
+ECON,9000,5,Sel Topic - Machine Learning,0.25,0.5,0.0,0.0,0.0,0.0,0.0,0.25,chungsang lam,,ECON-9000,2019
+ED,1050,2,Orientation to Education,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,amaris josep tejada,,ED-1050,2019
+ED,1050,2,Orientation to Education,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,paula bailey adams,,ED-1050,2019
+ED,1970,2,Creative Inquiry in Education,0.62,0.29,0.05,0.0,0.0,0.0,0.0,0.05,laurel ann whisler,,ED-1970,2019
+ED,1970,2,Creative Inquiry in Education,0.62,0.29,0.05,0.0,0.0,0.0,0.0,0.05,elizabeth stephan,,ED-1970,2019
+ED,3200,1,History of US Education,0.78,0.11,0.06,0.0,0.0,0.0,0.0,0.06,nafees mohamma khan,,ED-3200,2019
+ED,3970,2,RMAN- Identity & Ldrship Exp,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-3970,2019
+ED,3970,5,CI-Fundamentals of Scholarship,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,cherese france fine,,ED-3970,2019
+ED,3970,5,CI-Fundamentals of Scholarship,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,deonte brown,,ED-3970,2019
+ED,8090,412,Teacher Residency Internship,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,marshall alan darby,,ED-8090,2019
+ED,8090,412,Teacher Residency Internship,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,corrie leigh martin,,ED-8090,2019
+ED,8600,1,Classroom-Based Research,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daphne duncan wiles,,ED-8600,2019
+ED,8650,1,Curriculum Theory,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,melinda spearman,,ED-8650,2019
+ED,8750,500,Elements of Instructional Effe,0.93,0.02,0.02,0.0,0.0,0.0,0.0,0.02,susan rid nunamaker,,ED-8750,2019
+EDC,2990,1,Creative Inq in Counselor Ed,0.71,0.19,0.1,0.0,0.0,0.0,0.0,0.0,jacob frankovich,,EDC-2990,2019
+EDC,3900,1,Skills for Student Leaders,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,erin mayor fogle,,EDC-3900,2019
+EDC,3900,4,Skills for Student Leaders,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2019
+EDC,3900,5,Skills for Student Leaders,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2019
+EDC,3900,6,Skills for Student Leaders,0.79,0.07,0.07,0.0,0.0,0.0,0.0,0.07,eric pernotto,,EDC-3900,2019
+EDC,3900,10,Skills for Student Leaders,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,eric pernotto,,EDC-3900,2019
+EDC,3900,11,Skills for Student Leaders,0.76,0.12,0.06,0.06,0.0,0.0,0.0,0.0,eric pernotto,,EDC-3900,2019
+EDC,8850,1,Counseling Research,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,david barrett,,EDC-8850,2019
+EDEL,3210,1,Pe for the Elem Tchr,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,deborah smith,,EDEL-3210,2019
+EDEL,4510,1,Elem Methods in Science Tchg,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,daphne duncan wiles,,EDEL-4510,2019
+EDEL,4520,1,Elem Methods Math Teaching,0.86,0.0,0.07,0.0,0.04,0.0,0.0,0.04,stacy jones,,EDEL-4520,2019
+EDF,3020,1,Educational Psychology,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,karen rebecca clark,,EDF-3020,2019
+EDF,3020,3,Educational Psychology,0.79,0.18,0.03,0.0,0.0,0.0,0.0,0.0,heather rog brooker,,EDF-3020,2019
+EDF,3020,5,Educational Psychology,0.65,0.3,0.0,0.03,0.0,0.0,0.0,0.03,heather rog brooker,,EDF-3020,2019
+EDF,3020,6,Educational Psychology,0.84,0.13,0.0,0.0,0.0,0.0,0.0,0.03,karen rebecca clark,,EDF-3020,2019
+EDF,3340,1,Child Growth and Development,0.88,0.06,0.0,0.0,0.03,0.0,0.0,0.03,robert o'hara,,EDF-3340,2019
+EDF,3340,3,Child Growth and Development,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,amanda eliz bennett,,EDF-3340,2019
+EDF,3350,3,Adolescent Growth & Develop,0.49,0.33,0.08,0.05,0.03,0.0,0.0,0.03,david barrett,,EDF-3350,2019
+EDF,4800,1,Digital Media & Learning,0.82,0.14,0.0,0.05,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2019
+EDF,4800,2,Digital Media & Learning,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2019
+EDF,4800,3,Digital Media & Learning,0.96,0.0,0.0,0.0,0.0,0.0,0.0,0.04,david matthew boyer,,EDF-4800,2019
+EDF,4800,300,Digital Media & Learning,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2019
+EDF,4800,301,Digital Media & Learning,0.83,0.09,0.09,0.0,0.0,0.0,0.0,0.0,ryan visser,,EDF-4800,2019
+EDF,9710,1,Case Study & Ethnographic Mthd,0.71,0.18,0.0,0.0,0.12,0.0,0.0,0.0,cynthia chri deaton,,EDF-9710,2019
+EDF,9790,400,Qualitative Research in Educ,0.75,0.13,0.0,0.0,0.06,0.0,0.0,0.06,reginald wilkerson,,EDF-9790,2019
+EDHD,3110,1,CI- Research in DM & Learning,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,ryan visser,,EDHD-3110,2019
+EDHD,3110,1,CI- Research in DM & Learning,0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,david matthew boyer,,EDHD-3110,2019
+EDHD,3110,8,CI- Children's Lit. Newsletter,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDHD-3110,2019
+EDHD,3110,9,CI- Read/Review Child/YA Lit.,0.86,0.0,0.14,0.0,0.0,0.0,0.0,0.0,jonda cecole mcnair,,EDHD-3110,2019
+EDIS,9360,400,Advanced Program Evaluation,0.63,0.31,0.0,0.0,0.0,0.0,0.0,0.06,daniella hall,,EDIS-9360,2019
+EDL,9000,400,Prin Edu Leadership,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,aris lane hall,,EDL-9000,2019
+EDLT,4620,1,Reading Children's Lit in Elem,0.68,0.21,0.0,0.07,0.0,0.0,0.0,0.04,jonda cecole mcnair,,EDLT-4620,2019
+EDLT,4670,1,Teaching ESOL in Elem Schools,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,hazel vega quesada,,EDLT-4670,2019
+EDLT,8120,301,Assessment in Reading & Writin,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,rachelle savitz,,EDLT-8120,2019
+EDLT,8120,500,Assessment in Reading & Writin,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,pamela dunston,,EDLT-8120,2019
+EDLT,8220,300,Strategies for Teaching ESOL,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mikel walker cole,,EDLT-8220,2019
+EDLT,8230,500,Introduction to Linguistics,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,emily smothe howell,,EDLT-8230,2019
+EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,morgan jones bowie,,EDLT-8410,2019
+EDLT,8410,500,Early Literacy Inst Strategies,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,anita moore,,EDLT-8410,2019
+EDLT,8410,507,Early Literacy Inst Strategies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,,EDLT-8410,2019
+EDLT,8410,507,Early Literacy Inst Strategies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,,EDLT-8410,2019
+EDLT,8810,508,Reading Recovery Teacher II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,,EDLT-8810,2019
+EDLT,8810,508,Reading Recovery Teacher II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,,EDLT-8810,2019
+EDLT,8830,508,Read Recovery Practicum II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,mary petters,,EDLT-8830,2019
+EDLT,8830,508,Read Recovery Practicum II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,renee gatlin anders,,EDLT-8830,2019
+EDSP,3700,2,Intro to Special Education,0.56,0.31,0.06,0.06,0.0,0.0,0.0,0.0,friggita johnson,,EDSP-3700,2019
+EDSP,3700,4,Intro to Special Education,0.8,0.14,0.03,0.0,0.03,0.0,0.0,0.0,shanna eisne hirsch,,EDSP-3700,2019
+EDSP,3700,300,Intro to Special Education,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,shanna eisne hirsch,,EDSP-3700,2019
+EDSP,3730,1,Char & Instr of ID & Autism,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,abigail anne allen,,EDSP-3730,2019
+EDSP,3750,1,Early Intervention Spec Needs,0.77,0.15,0.08,0.0,0.0,0.0,0.0,0.0,abigail anne allen,,EDSP-3750,2019
+EDSP,4910,1,Ed Assess Ind W/Dis,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,antonis katsiyannis,,EDSP-4910,2019
+EDSP,4950,1,Comm & Collab Sp Ed,0.84,0.05,0.11,0.0,0.0,0.0,0.0,0.0,wendell kent parker,,EDSP-4950,2019
+EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,wendell kent parker,,EDSP-4980,2019
+EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,beverly lu romansky,,EDSP-4980,2019
+EDSP,4980,7,Directed Teaching,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,catherine griffith,,EDSP-4980,2019
+EES,2020,1,Environ Engr Fundamentals II,0.63,0.22,0.15,0.0,0.0,0.0,0.0,0.0,kevin thom finneran,,EES-2020,2019
+EES,4010,1,Environmental Engr,0.63,0.3,0.02,0.0,0.0,0.0,0.0,0.05,elizabeth carraway,,EES-4010,2019
+EES,4010,2,Environmental Engr,0.38,0.43,0.08,0.08,0.05,0.0,0.0,0.0,ezra lucas ho cates,,EES-4010,2019
+EES,4020,1,Water & Waste Water Treatment,0.4,0.5,0.0,0.0,0.0,0.0,0.0,0.1,mark schlautman,,EES-4020,2019
+EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,sudeep popat,,EES-4750,2019
+EES,4750,1,Capstone Design Project,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,david allen ladner,,EES-4750,2019
+EES,4850,1,Hazard Waste Management,0.29,0.42,0.16,0.03,0.0,0.0,0.0,0.1,mark schlautman,,EES-4850,2019
+EES,4860,1,Environmental Sustainability,0.55,0.4,0.0,0.0,0.0,0.0,0.0,0.05,michael anthon dale,,EES-4860,2019
+EES,4860,2,Environmental Sustainability,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,michael anthon dale,,EES-4860,2019
+EES,4900,15,CI: From Drones to 3D Printing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,michael anthon dale,,EES-4900,2019
+EES,4900,15,CI: From Drones to 3D Printing,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,pat carbajales-dale,,EES-4900,2019
+EES,8330,2,Air Poll Control Sys,0.4,0.4,0.2,0.0,0.0,0.0,0.0,0.0,andrew rich metcalf,,EES-8330,2019
+ELE,3010,1,Entrepreneurial Foundations,0.44,0.44,0.1,0.03,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2019
+ELE,3010,2,Entrepreneurial Foundations,0.54,0.35,0.11,0.0,0.0,0.0,0.0,0.0,christina kyprianou,,ELE-3010,2019
+ELE,3010,3,Entrepreneurial Foundations,0.15,0.5,0.28,0.0,0.0,0.0,0.0,0.08,ashley will parnell,,ELE-3010,2019
+ELE,3010,4,Entrepreneurial Foundations,0.2,0.39,0.37,0.02,0.0,0.0,0.0,0.02,ashley will parnell,,ELE-3010,2019
+ELE,3020,1,Entrepreneurial Resource Acqu,0.3,0.6,0.08,0.03,0.0,0.0,0.0,0.0,karl bruce kelly,,ELE-3020,2019
+ELE,3020,2,Entrepreneurial Resource Acqu,0.25,0.53,0.2,0.0,0.0,0.0,0.0,0.03,karl bruce kelly,,ELE-3020,2019
+ELE,4010,1,Venture Testing,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,chad navis,,ELE-4010,2019
+ELE,4010,2,Venture Testing,0.5,0.4,0.08,0.03,0.0,0.0,0.0,0.0,chad navis,,ELE-4010,2019
+ELE,4020,1,Venture Creation,0.13,0.73,0.13,0.0,0.0,0.0,0.0,0.0,william fra dinardo,,ELE-4020,2019
+ELE,4030,1,Venture Growth,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,james keith hudgins,,ELE-4030,2019
+ENGL,1030,1,Composition and Rhetoric,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,allen swords,,ENGL-1030,2019
+ENGL,1030,2,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-1030,2019
+ENGL,1030,3,Composition and Rhetoric,0.47,0.27,0.13,0.07,0.0,0.0,0.0,0.07,naomi marie white,,ENGL-1030,2019
+ENGL,1030,4,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.0,0.0,0.0,0.05,naomi marie white,,ENGL-1030,2019
+ENGL,1030,5,Composition and Rhetoric,0.5,0.36,0.0,0.07,0.0,0.0,0.0,0.07,kristian wilson,,ENGL-1030,2019
+ENGL,1030,6,Composition and Rhetoric,0.33,0.44,0.06,0.0,0.06,0.0,0.0,0.11,kristian wilson,,ENGL-1030,2019
+ENGL,1030,8,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,,ENGL-1030,2019
+ENGL,1030,9,Composition and Rhetoric,0.5,0.31,0.06,0.0,0.06,0.0,0.0,0.06,myers addison enlow,,ENGL-1030,2019
+ENGL,1030,10,Composition and Rhetoric,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,myers addison enlow,,ENGL-1030,2019
+ENGL,1030,11,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,julie edewaard,,ENGL-1030,2019
+ENGL,1030,12,Composition and Rhetoric,0.86,0.07,0.0,0.07,0.0,0.0,0.0,0.0,julie edewaard,,ENGL-1030,2019
+ENGL,1030,14,Composition and Rhetoric,0.69,0.15,0.15,0.0,0.0,0.0,0.0,0.0,blake elizab bowens,,ENGL-1030,2019
+ENGL,1030,15,Composition and Rhetoric,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,charissa fryberger,,ENGL-1030,2019
+ENGL,1030,16,Composition and Rhetoric,0.87,0.07,0.0,0.0,0.0,0.0,0.0,0.07,charissa fryberger,,ENGL-1030,2019
+ENGL,1030,17,Composition and Rhetoric,0.47,0.2,0.0,0.0,0.13,0.0,0.0,0.2,tareva lese johnson,,ENGL-1030,2019
+ENGL,1030,18,Composition and Rhetoric,0.29,0.43,0.14,0.0,0.14,0.0,0.0,0.0,chelsea mari clarey,,ENGL-1030,2019
+ENGL,1030,19,Composition and Rhetoric,0.36,0.5,0.07,0.0,0.0,0.0,0.0,0.07,la'cresha ulo green,,ENGL-1030,2019
+ENGL,1030,20,Composition and Rhetoric,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,la'cresha ulo green,,ENGL-1030,2019
+ENGL,1030,22,Composition and Rhetoric,0.27,0.33,0.27,0.0,0.07,0.0,0.0,0.07,david charles foltz,,ENGL-1030,2019
+ENGL,1030,23,Composition and Rhetoric,0.45,0.18,0.18,0.09,0.0,0.0,0.0,0.09,david charles foltz,,ENGL-1030,2019
+ENGL,1030,25,Composition and Rhetoric,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,stephanie stripling,,ENGL-1030,2019
+ENGL,1030,27,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,hannah pittm godwin,,ENGL-1030,2019
+ENGL,1030,28,Composition and Rhetoric,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.05,hannah pittm godwin,,ENGL-1030,2019
+ENGL,1030,29,Composition and Rhetoric,0.21,0.57,0.14,0.0,0.07,0.0,0.0,0.0,henna maria messina,,ENGL-1030,2019
+ENGL,1030,31,Composition and Rhetoric,0.4,0.1,0.3,0.0,0.0,0.0,0.0,0.2,geveryl le robinson,,ENGL-1030,2019
+ENGL,1030,32,Composition and Rhetoric,0.18,0.59,0.18,0.0,0.0,0.0,0.0,0.06,sharon kathl nalley,,ENGL-1030,2019
+ENGL,1030,33,Composition and Rhetoric,0.5,0.25,0.0,0.0,0.0,0.0,0.08,0.17,cody hunter,,ENGL-1030,2019
+ENGL,1030,34,Composition and Rhetoric,0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,cody hunter,,ENGL-1030,2019
+ENGL,1030,35,Composition and Rhetoric,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,kailan smi sindelar,,ENGL-1030,2019
+ENGL,1030,37,Composition and Rhetoric,0.79,0.16,0.05,0.0,0.0,0.0,0.0,0.0,shauna chung,,ENGL-1030,2019
+ENGL,1030,38,Composition and Rhetoric,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,shauna chung,,ENGL-1030,2019
+ENGL,1030,39,Composition and Rhetoric,0.53,0.33,0.0,0.0,0.07,0.0,0.0,0.07,jacob dania richter,,ENGL-1030,2019
+ENGL,1030,40,Composition and Rhetoric,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,jacob dania richter,,ENGL-1030,2019
+ENGL,1030,41,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,sarah el richardson,,ENGL-1030,2019
+ENGL,1030,42,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,sarah el richardson,,ENGL-1030,2019
+ENGL,1030,45,Composition and Rhetoric,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,,ENGL-1030,2019
+ENGL,1030,46,Composition and Rhetoric,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,,ENGL-1030,2019
+ENGL,1030,47,Composition and Rhetoric,0.68,0.21,0.0,0.0,0.0,0.0,0.0,0.11,caroline eliz young,,ENGL-1030,2019
+ENGL,1030,48,Composition and Rhetoric,0.33,0.44,0.11,0.06,0.06,0.0,0.0,0.0,sharon kathl nalley,,ENGL-1030,2019
+ENGL,1030,49,Composition and Rhetoric,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,,ENGL-1030,2019
+ENGL,1030,50,Composition and Rhetoric,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,victoria houser,,ENGL-1030,2019
+ENGL,1030,51,Composition and Rhetoric,0.53,0.33,0.07,0.0,0.0,0.0,0.07,0.0,chloe mich whitaker,,ENGL-1030,2019
+ENGL,1030,52,Composition and Rhetoric,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,jennie el wakefield,,ENGL-1030,2019
+ENGL,1030,53,Composition and Rhetoric,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,michelle lloyd,,ENGL-1030,2019
+ENGL,1030,55,Composition and Rhetoric,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,caroline eliz young,,ENGL-1030,2019
+ENGL,1030,56,Composition and Rhetoric,0.4,0.2,0.2,0.1,0.1,0.0,0.0,0.0,bree laran beal,,ENGL-1030,2019
+ENGL,1030,58,Composition and Rhetoric,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,tareva lese johnson,,ENGL-1030,2019
+ENGL,1030,59,Composition and Rhetoric,0.43,0.36,0.07,0.07,0.07,0.0,0.0,0.0,mary catheri nestor,,ENGL-1030,2019
+ENGL,1030,60,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,mary catheri nestor,,ENGL-1030,2019
+ENGL,1030,61,Composition and Rhetoric,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,bree laran beal,,ENGL-1030,2019
+ENGL,1030,63,Composition and Rhetoric,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,remley melis makala,,ENGL-1030,2019
+ENGL,1030,65,Composition and Rhetoric,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-1030,2019
+ENGL,1030,68,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-1030,2019
+ENGL,1030,69,Composition and Rhetoric,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-1030,2019
+ENGL,1030,70,Composition and Rhetoric,0.74,0.21,0.0,0.05,0.0,0.0,0.0,0.0,jennifer forsberg,,ENGL-1030,2019
+ENGL,1030,71,Composition and Rhetoric,0.55,0.18,0.0,0.27,0.0,0.0,0.0,0.0,bree laran beal,,ENGL-1030,2019
+ENGL,1030,73,Composition and Rhetoric,0.71,0.21,0.0,0.0,0.0,0.0,0.0,0.07,caitlin grace watt,,ENGL-1030,2019
+ENGL,1030,74,Composition and Rhetoric,0.36,0.36,0.09,0.09,0.09,0.0,0.0,0.0,edward thomas troy,,ENGL-1030,2019
+ENGL,1030,75,Composition and Rhetoric,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,edward thomas troy,,ENGL-1030,2019
+ENGL,1030,76,Composition and Rhetoric,0.38,0.54,0.08,0.0,0.0,0.0,0.0,0.0,edward thomas troy,,ENGL-1030,2019
+ENGL,1030,77,Composition and Rhetoric,0.36,0.27,0.18,0.0,0.09,0.0,0.0,0.09,tareva lese johnson,,ENGL-1030,2019
+ENGL,1030,78,Composition and Rhetoric,0.53,0.24,0.06,0.0,0.0,0.0,0.0,0.18,andrew mathas,,ENGL-1030,2019
+ENGL,1030,79,Composition and Rhetoric,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-1030,2019
+ENGL,1030,101,Composition and Rhetoric (HON),0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,allison nico harris,True,ENGL-1030,2019
+ENGL,2120,1,World Literature,0.64,0.18,0.04,0.07,0.04,0.0,0.0,0.02,walter edgar hunter,,ENGL-2120,2019
+ENGL,2120,2,World Literature,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,elizabeth stansell,,ENGL-2120,2019
+ENGL,2120,4,World Literature,0.71,0.21,0.0,0.04,0.0,0.0,0.0,0.04,elizabeth stansell,,ENGL-2120,2019
+ENGL,2120,7,World Literature,0.2,0.48,0.12,0.04,0.04,0.0,0.0,0.12,david charles foltz,,ENGL-2120,2019
+ENGL,2120,8,World Literature,0.25,0.58,0.13,0.0,0.0,0.0,0.0,0.04,david charles foltz,,ENGL-2120,2019
+ENGL,2120,9,World Literature,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.13,gregory luke chwala,,ENGL-2120,2019
+ENGL,2120,10,World Literature,0.53,0.37,0.11,0.0,0.0,0.0,0.0,0.0,gregory luke chwala,,ENGL-2120,2019
+ENGL,2120,12,World Literature,0.52,0.24,0.12,0.08,0.0,0.0,0.0,0.04,kathy elaine nixon,,ENGL-2120,2019
+ENGL,2120,13,World Literature,0.71,0.21,0.08,0.0,0.0,0.0,0.0,0.0,kathy elaine nixon,,ENGL-2120,2019
+ENGL,2120,14,World Literature,0.64,0.32,0.04,0.0,0.0,0.0,0.0,0.0,heather pr williams,,ENGL-2120,2019
+ENGL,2120,15,World Literature,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,heather pr williams,,ENGL-2120,2019
+ENGL,2120,16,World Literature,0.4,0.44,0.16,0.0,0.0,0.0,0.0,0.0,chloe mich whitaker,,ENGL-2120,2019
+ENGL,2120,17,World Literature,0.44,0.48,0.0,0.04,0.0,0.0,0.0,0.04,chloe mich whitaker,,ENGL-2120,2019
+ENGL,2120,20,World Literature,0.28,0.6,0.12,0.0,0.0,0.0,0.0,0.0,patricia sunia,,ENGL-2120,2019
+ENGL,2120,21,World Literature,0.59,0.32,0.05,0.0,0.0,0.0,0.0,0.05,patricia sunia,,ENGL-2120,2019
+ENGL,2120,22,World Literature,0.5,0.29,0.13,0.08,0.0,0.0,0.0,0.0,karen kettnich,,ENGL-2120,2019
+ENGL,2120,23,World Literature,0.35,0.43,0.09,0.04,0.04,0.0,0.0,0.04,karen kettnich,,ENGL-2120,2019
+ENGL,2120,24,World Literature,0.42,0.53,0.0,0.0,0.05,0.0,0.0,0.0,gregory luke chwala,,ENGL-2120,2019
+ENGL,2120,25,World Literature,0.27,0.5,0.18,0.0,0.0,0.0,0.05,0.0,kenneth micha tuite,,ENGL-2120,2019
+ENGL,2120,26,World Literature,0.5,0.36,0.07,0.0,0.0,0.0,0.0,0.07,spencer tricker,,ENGL-2120,2019
+ENGL,2120,27,World Literature,0.6,0.32,0.04,0.0,0.0,0.0,0.0,0.04,spencer tricker,,ENGL-2120,2019
+ENGL,2120,28,World Literature,0.57,0.3,0.0,0.04,0.04,0.0,0.0,0.04,spencer tricker,,ENGL-2120,2019
+ENGL,2120,400,World Literature,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,elizabeth stansell,,ENGL-2120,2019
+ENGL,2130,1,British Literature,0.48,0.35,0.04,0.0,0.0,0.0,0.0,0.13,krist aldebol-hazle,,ENGL-2130,2019
+ENGL,2130,2,British Literature,0.6,0.16,0.08,0.0,0.04,0.0,0.0,0.12,krist aldebol-hazle,,ENGL-2130,2019
+ENGL,2130,3,British Literature,0.36,0.36,0.24,0.04,0.0,0.0,0.0,0.0,megan no macalystre,,ENGL-2130,2019
+ENGL,2130,4,British Literature,0.16,0.6,0.12,0.0,0.04,0.0,0.0,0.08,megan no macalystre,,ENGL-2130,2019
+ENGL,2130,5,British Literature,0.48,0.36,0.0,0.04,0.04,0.0,0.0,0.08,lucian ghita,,ENGL-2130,2019
+ENGL,2130,6,British Literature,0.72,0.2,0.04,0.04,0.0,0.0,0.0,0.0,lucian ghita,,ENGL-2130,2019
+ENGL,2130,10,British Literature,0.67,0.29,0.0,0.0,0.0,0.0,0.0,0.04,daniel scott citro,,ENGL-2130,2019
+ENGL,2130,11,British Literature,0.64,0.32,0.0,0.0,0.0,0.0,0.0,0.04,lucian ghita,,ENGL-2130,2019
+ENGL,2130,12,British Literature,0.27,0.32,0.14,0.0,0.18,0.0,0.0,0.09,megan no macalystre,,ENGL-2130,2019
+ENGL,2130,13,British Literature,0.6,0.32,0.0,0.08,0.0,0.0,0.0,0.0,daniel scott citro,,ENGL-2130,2019
+ENGL,2130,14,British Literature,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,ingrid anna pierce,,ENGL-2130,2019
+ENGL,2130,15,British Literature,0.76,0.16,0.04,0.04,0.0,0.0,0.0,0.0,ingrid anna pierce,,ENGL-2130,2019
+ENGL,2130,16,British Literature,0.75,0.17,0.04,0.0,0.04,0.0,0.0,0.0,caitlin grace watt,,ENGL-2130,2019
+ENGL,2130,17,British Literature,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,caitlin grace watt,,ENGL-2130,2019
+ENGL,2130,18,British Literature,0.84,0.08,0.0,0.0,0.08,0.0,0.0,0.0,ingrid anna pierce,,ENGL-2130,2019
+ENGL,2130,19,British Literature,0.82,0.09,0.0,0.0,0.09,0.0,0.0,0.0,caitlin grace watt,,ENGL-2130,2019
+ENGL,2140,1,American Literature,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2019
+ENGL,2140,2,American Literature,0.64,0.24,0.04,0.04,0.04,0.0,0.0,0.0,melissa dugan,,ENGL-2140,2019
+ENGL,2140,3,American Literature,0.29,0.25,0.33,0.08,0.0,0.0,0.0,0.04,chelsea mari clarey,,ENGL-2140,2019
+ENGL,2140,4,American Literature,0.12,0.48,0.32,0.0,0.04,0.0,0.0,0.04,chelsea mari clarey,,ENGL-2140,2019
+ENGL,2140,5,American Literature,0.26,0.48,0.13,0.0,0.04,0.0,0.0,0.09,remley melis makala,,ENGL-2140,2019
+ENGL,2140,6,American Literature,0.5,0.29,0.13,0.0,0.0,0.0,0.0,0.08,remley melis makala,,ENGL-2140,2019
+ENGL,2140,7,American Literature,0.27,0.4,0.33,0.0,0.0,0.0,0.0,0.0,chelsea mari clarey,,ENGL-2140,2019
+ENGL,2140,8,American Literature,0.43,0.26,0.13,0.0,0.0,0.0,0.0,0.17,remley melis makala,,ENGL-2140,2019
+ENGL,2140,11,American Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,,ENGL-2140,2019
+ENGL,2140,12,American Literature,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,jennifer forsberg,,ENGL-2140,2019
+ENGL,2140,13,American Literature,0.67,0.21,0.04,0.0,0.04,0.0,0.0,0.04,caroline eliz young,,ENGL-2140,2019
+ENGL,2140,14,American Literature,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,caroline eliz young,,ENGL-2140,2019
+ENGL,2140,20,American Literature,0.35,0.4,0.05,0.0,0.05,0.0,0.0,0.15,mary catheri nestor,,ENGL-2140,2019
+ENGL,2140,21,American Literature,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.04,mary catheri nestor,,ENGL-2140,2019
+ENGL,2140,100,American Literature (HON),0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,True,ENGL-2140,2019
+ENGL,2150,1,Lit in 20th-21st Cent Contexts,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,allison nico harris,,ENGL-2150,2019
+ENGL,2150,2,Lit in 20th-21st Cent Contexts,0.76,0.12,0.04,0.0,0.08,0.0,0.0,0.0,allison nico harris,,ENGL-2150,2019
+ENGL,2150,3,Lit in 20th-21st Cent Contexts,0.56,0.32,0.0,0.04,0.0,0.0,0.0,0.08,lindsey henley kurz,,ENGL-2150,2019
+ENGL,2150,4,Lit in 20th-21st Cent Contexts,0.8,0.16,0.04,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-2150,2019
+ENGL,2150,5,Lit in 20th-21st Cent Contexts,0.76,0.2,0.04,0.0,0.0,0.0,0.0,0.0,allen swords,,ENGL-2150,2019
+ENGL,2150,6,Lit in 20th-21st Cent Contexts,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,andrew mathas,,ENGL-2150,2019
+ENGL,2150,7,Lit in 20th-21st Cent Contexts,0.48,0.32,0.16,0.04,0.0,0.0,0.0,0.0,andrew mathas,,ENGL-2150,2019
+ENGL,2150,8,Lit in 20th-21st Cent Contexts,0.79,0.13,0.04,0.04,0.0,0.0,0.0,0.0,allison nico harris,,ENGL-2150,2019
+ENGL,2150,9,Lit in 20th-21st Cent Contexts,0.4,0.32,0.2,0.04,0.0,0.0,0.0,0.04,julia brownle koets,,ENGL-2150,2019
+ENGL,2150,10,Lit in 20th-21st Cent Contexts,0.12,0.68,0.16,0.04,0.0,0.0,0.0,0.0,julia brownle koets,,ENGL-2150,2019
+ENGL,2150,11,Lit in 20th-21st Cent Contexts,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-2150,2019
+ENGL,2150,12,Lit in 20th-21st Cent Contexts,0.05,0.59,0.23,0.05,0.05,0.0,0.0,0.05,sarah mae cooper,,ENGL-2150,2019
+ENGL,2150,14,Lit in 20th-21st Cent Contexts,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,sharon kathl nalley,,ENGL-2150,2019
+ENGL,2150,17,Lit in 20th-21st Cent Contexts,0.36,0.36,0.2,0.0,0.0,0.0,0.0,0.08,hannah pittm godwin,,ENGL-2150,2019
+ENGL,2150,18,Lit in 20th-21st Cent Contexts,0.76,0.2,0.0,0.0,0.04,0.0,0.0,0.0,lindsey henley kurz,,ENGL-2150,2019
+ENGL,2150,19,Lit in 20th-21st Cent Contexts,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,lindsey henley kurz,,ENGL-2150,2019
+ENGL,2150,20,Lit in 20th-21st Cent Contexts,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,hannah pittm godwin,,ENGL-2150,2019
+ENGL,2150,21,Lit in 20th-21st Cent Contexts,0.6,0.24,0.12,0.04,0.0,0.0,0.0,0.0,john logan pursley,,ENGL-2150,2019
+ENGL,2150,100,Lit in 20th-21st Cent (HON),0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True,ENGL-2150,2019
+ENGL,2150,405,Lit in 20th-21st Cent Contexts,0.08,0.5,0.27,0.08,0.0,0.0,0.0,0.08,sarah mae cooper,,ENGL-2150,2019
+ENGL,2150,406,Lit in 20th-21st Cent Contexts,0.05,0.7,0.25,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,ENGL-2150,2019
+ENGL,2160,1,African American Literature,0.72,0.2,0.08,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,,ENGL-2160,2019
+ENGL,2160,2,African American Literature,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,,ENGL-2160,2019
+ENGL,2160,3,African American Literature,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,jamie ann rogers,,ENGL-2160,2019
+ENGL,2310,1,Intro to Journalism,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,william pulley,,ENGL-2310,2019
+ENGL,3040,1,Business Writing,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,patricia sunia,,ENGL-3040,2019
+ENGL,3040,2,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,ashley cowden fisk,,ENGL-3040,2019
+ENGL,3040,3,Business Writing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,william cunningham,,ENGL-3040,2019
+ENGL,3040,4,Business Writing,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,william cunningham,,ENGL-3040,2019
+ENGL,3040,5,Business Writing,0.72,0.11,0.06,0.0,0.06,0.0,0.0,0.06,la'cresha ulo green,,ENGL-3040,2019
+ENGL,3040,6,Business Writing,0.68,0.26,0.0,0.0,0.0,0.0,0.0,0.05,la'cresha ulo green,,ENGL-3040,2019
+ENGL,3040,7,Business Writing,0.47,0.42,0.05,0.0,0.0,0.0,0.0,0.05,katalin beck,,ENGL-3040,2019
+ENGL,3040,8,Business Writing,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3040,2019
+ENGL,3040,10,Business Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,nancy paxton-wilson,,ENGL-3040,2019
+ENGL,3040,11,Business Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,heather pr williams,,ENGL-3040,2019
+ENGL,3040,12,Business Writing,0.37,0.47,0.05,0.11,0.0,0.0,0.0,0.0,heather pr williams,,ENGL-3040,2019
+ENGL,3040,13,Business Writing,0.84,0.05,0.05,0.0,0.0,0.0,0.0,0.05,patricia sunia,,ENGL-3040,2019
+ENGL,3040,400,Business Writing,0.85,0.1,0.0,0.0,0.0,0.0,0.0,0.05,krist aldebol-hazle,,ENGL-3040,2019
+ENGL,3040,401,Business Writing,0.7,0.25,0.0,0.05,0.0,0.0,0.0,0.0,krist aldebol-hazle,,ENGL-3040,2019
+ENGL,3040,402,Business Writing,0.7,0.2,0.05,0.0,0.05,0.0,0.0,0.0,megan pietruszewski,,ENGL-3040,2019
+ENGL,3040,403,Business Writing,0.65,0.3,0.05,0.0,0.0,0.0,0.0,0.0,megan pietruszewski,,ENGL-3040,2019
+ENGL,3040,404,Business Writing,0.58,0.37,0.0,0.0,0.05,0.0,0.0,0.0,heather pr williams,,ENGL-3040,2019
+ENGL,3100,1,Crit Writ Lit,0.53,0.12,0.12,0.0,0.0,0.0,0.0,0.24,kimberly manganelli,,ENGL-3100,2019
+ENGL,3100,2,Crit Writ Lit,0.32,0.42,0.21,0.0,0.0,0.0,0.0,0.05,erin marina goss,,ENGL-3100,2019
+ENGL,3100,3,Crit Writ Lit,0.67,0.29,0.0,0.05,0.0,0.0,0.0,0.0,matthew hooley,,ENGL-3100,2019
+ENGL,3120,1,Advanced Composition,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher stuart,,ENGL-3120,2019
+ENGL,3120,2,Advanced Composition,0.63,0.19,0.06,0.0,0.06,0.0,0.0,0.06,christopher stuart,,ENGL-3120,2019
+ENGL,3120,4,Advanced Composition,0.75,0.17,0.0,0.0,0.0,0.0,0.0,0.08,christopher benson,,ENGL-3120,2019
+ENGL,3120,5,Advanced Composition,0.4,0.4,0.07,0.07,0.0,0.0,0.0,0.07,jennie el wakefield,,ENGL-3120,2019
+ENGL,3140,1,Technical Writing,0.35,0.55,0.05,0.05,0.0,0.0,0.0,0.0,william cunningham,,ENGL-3140,2019
+ENGL,3140,2,Technical Writing,0.68,0.26,0.05,0.0,0.0,0.0,0.0,0.0,william cunningham,,ENGL-3140,2019
+ENGL,3140,3,Technical Writing,0.58,0.26,0.11,0.0,0.0,0.0,0.0,0.05,april 'brien,,ENGL-3140,2019
+ENGL,3140,4,Technical Writing,0.53,0.26,0.11,0.05,0.0,0.0,0.0,0.05,april 'brien,,ENGL-3140,2019
+ENGL,3140,7,Technical Writing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2019
+ENGL,3140,8,Technical Writing,0.59,0.35,0.06,0.0,0.0,0.0,0.0,0.0,katalin beck,,ENGL-3140,2019
+ENGL,3140,9,Technical Writing,0.68,0.21,0.11,0.0,0.0,0.0,0.0,0.0,henna maria messina,,ENGL-3140,2019
+ENGL,3140,10,Technical Writing,0.58,0.32,0.11,0.0,0.0,0.0,0.0,0.0,henna maria messina,,ENGL-3140,2019
+ENGL,3140,11,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,brian lee gaines,,ENGL-3140,2019
+ENGL,3140,13,Technical Writing,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,dia quaglia beltran,,ENGL-3140,2019
+ENGL,3140,14,Technical Writing,0.89,0.05,0.0,0.0,0.05,0.0,0.0,0.0,dia quaglia beltran,,ENGL-3140,2019
+ENGL,3140,21,Technical Writing,0.89,0.05,0.05,0.0,0.0,0.0,0.0,0.0,kathy elaine nixon,,ENGL-3140,2019
+ENGL,3140,22,Technical Writing,0.58,0.26,0.0,0.0,0.0,0.0,0.0,0.16,kathy elaine nixon,,ENGL-3140,2019
+ENGL,3140,25,Technical Writing,0.67,0.17,0.11,0.0,0.0,0.0,0.0,0.06,megan pietruszewski,,ENGL-3140,2019
+ENGL,3140,26,Technical Writing,0.74,0.16,0.05,0.0,0.05,0.0,0.0,0.0,megan pietruszewski,,ENGL-3140,2019
+ENGL,3140,30,Technical Writing,0.22,0.56,0.11,0.11,0.0,0.0,0.0,0.0,henna maria messina,,ENGL-3140,2019
+ENGL,3140,400,Technical Writing,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jan rune holmevik,,ENGL-3140,2019
+ENGL,3140,401,Technical Writing,0.79,0.05,0.05,0.05,0.0,0.0,0.0,0.05,geveryl le robinson,,ENGL-3140,2019
+ENGL,3140,402,Technical Writing,0.55,0.3,0.1,0.05,0.0,0.0,0.0,0.0,geveryl le robinson,,ENGL-3140,2019
+ENGL,3140,403,Technical Writing,0.74,0.16,0.0,0.0,0.0,0.0,0.0,0.11,geveryl le robinson,,ENGL-3140,2019
+ENGL,3150,1,Scientific Writing & Comm,0.35,0.35,0.24,0.06,0.0,0.0,0.0,0.0,william pulley,,ENGL-3150,2019
+ENGL,3150,2,Scientific Writing & Comm,0.56,0.22,0.11,0.0,0.0,0.0,0.0,0.11,william pulley,,ENGL-3150,2019
+ENGL,3150,3,Scientific Writing & Comm,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2019
+ENGL,3150,4,Scientific Writing & Comm,0.5,0.17,0.22,0.0,0.0,0.0,0.0,0.11,william pulley,,ENGL-3150,2019
+ENGL,3150,5,Scientific Writing & Comm,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,christopher benson,,ENGL-3150,2019
+ENGL,3150,6,Scientific Writing & Comm,0.7,0.15,0.0,0.05,0.05,0.0,0.0,0.05,christopher benson,,ENGL-3150,2019
+ENGL,3150,400,Scientific Writing & Comm,0.74,0.21,0.05,0.0,0.0,0.0,0.0,0.0,philip randall,,ENGL-3150,2019
+ENGL,3150,402,Scientific Writing & Comm,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,philip randall,,ENGL-3150,2019
+ENGL,3150,405,Scientific Writing & Comm,0.75,0.19,0.0,0.0,0.06,0.0,0.0,0.0,philip randall,,ENGL-3150,2019
+ENGL,3460,1,Intr Creative Writing: Poetry,0.67,0.28,0.0,0.0,0.0,0.0,0.0,0.06,sarah mae cooper,,ENGL-3460,2019
+ENGL,3480,1,Intr Creat Writ: Screenwriting,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,julia brownle koets,,ENGL-3480,2019
+ENGL,3490,1,Tech/Pop Imagination,0.44,0.25,0.06,0.0,0.19,0.0,0.0,0.06,gabriel and hankins,,ENGL-3490,2019
+ENGL,3530,1,Amer Lit-Race/Ethnicity/Migrat,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,angela naimou,,ENGL-3530,2019
+ENGL,3550,1,Global Studies in Pop Culture,0.22,0.67,0.06,0.0,0.0,0.0,0.0,0.06,spencer tricker,,ENGL-3550,2019
+ENGL,3570,1,Film,0.16,0.68,0.05,0.0,0.05,0.0,0.0,0.05,amy monaghan,,ENGL-3570,2019
+ENGL,3570,2,Film,0.15,0.7,0.1,0.0,0.05,0.0,0.0,0.0,amy monaghan,,ENGL-3570,2019
+ENGL,3570,3,Film,0.65,0.3,0.0,0.0,0.0,0.0,0.0,0.05,john robert smith,,ENGL-3570,2019
+ENGL,3570,4,Film,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,john robert smith,,ENGL-3570,2019
+ENGL,3860,1,Adolescent Lit,0.75,0.2,0.0,0.0,0.05,0.0,0.0,0.0,megan no macalystre,,ENGL-3860,2019
+ENGL,3960,1,Brit Lit Survey I,0.37,0.47,0.16,0.0,0.0,0.0,0.0,0.0,james funk,,ENGL-3960,2019
+ENGL,3960,2,Brit Lit Survey I,0.79,0.16,0.0,0.0,0.05,0.0,0.0,0.0,ingrid anna pierce,,ENGL-3960,2019
+ENGL,3970,1,Brit Lit Survey II,0.17,0.61,0.17,0.0,0.0,0.0,0.0,0.06,brian mcgrath,,ENGL-3970,2019
+ENGL,3980,1,Amer Lit Survey I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jonathan beec field,,ENGL-3980,2019
+ENGL,3990,1,Amer Lit Survey II,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,maya sylvia hislop,,ENGL-3990,2019
+ENGL,4000,1,The English Language,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,andrew lemons,,ENGL-4000,2019
+ENGL,4070,1,Medieval Period,0.8,0.05,0.05,0.05,0.0,0.0,0.0,0.05,andrew lemons,,ENGL-4070,2019
+ENGL,4100,1,Drama of English Renaissance,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.06,lucian ghita,,ENGL-4100,2019
+ENGL,4110,1,Shakespeare,0.43,0.43,0.0,0.07,0.07,0.0,0.0,0.0,james funk,,ENGL-4110,2019
+ENGL,4110,2,Shakespeare,0.47,0.41,0.12,0.0,0.0,0.0,0.0,0.0,james funk,,ENGL-4110,2019
+ENGL,4110,3,Shakespeare,0.53,0.47,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth rivlin,,ENGL-4110,2019
+ENGL,4190,1,Post Col & World Lit,0.73,0.0,0.13,0.0,0.0,0.0,0.0,0.13,angela naimou,,ENGL-4190,2019
+ENGL,4210,1,Amer Lit 1800-1899,0.42,0.42,0.11,0.0,0.0,0.0,0.05,0.0,dominic mastroianni,,ENGL-4210,2019
+ENGL,4280,1,Contemporary Literature,0.69,0.23,0.0,0.0,0.08,0.0,0.0,0.0,lindsey henley kurz,,ENGL-4280,2019
+ENGL,4320,1,Modern Fiction,0.63,0.06,0.25,0.06,0.0,0.0,0.0,0.0,jillian weise,,ENGL-4320,2019
+ENGL,4400,1,Literary Theory,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,maria selene bose,,ENGL-4400,2019
+ENGL,4420,1,Cultural Studies,0.56,0.31,0.13,0.0,0.0,0.0,0.0,0.0,bree laran beal,,ENGL-4420,2019
+ENGL,4450,1,Fiction Workshop,0.69,0.23,0.08,0.0,0.0,0.0,0.0,0.0,nicholas chri brown,,ENGL-4450,2019
+ENGL,4480,1,Screenwriting Wkshop,0.73,0.2,0.0,0.07,0.0,0.0,0.0,0.0,nicholas chri brown,,ENGL-4480,2019
+ENGL,4490,1,Creative Non-Fiction,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,julia brownle koets,,ENGL-4490,2019
+ENGL,4500,1,Film Genres,0.89,0.0,0.0,0.0,0.06,0.0,0.0,0.06,john robert smith,,ENGL-4500,2019
+ENGL,4510,1,Film Theory and Criticism,0.56,0.22,0.0,0.0,0.22,0.0,0.0,0.0,john robert smith,,ENGL-4510,2019
+ENGL,4530,1,Sexuality and the Cinema,0.65,0.29,0.06,0.0,0.0,0.0,0.0,0.0,edward thomas troy,,ENGL-4530,2019
+ENGL,4540,1,Sel Top in International Film,0.5,0.25,0.0,0.0,0.0,0.0,0.0,0.25,jamie ann rogers,,ENGL-4540,2019
+ENGL,4640,1,Topics in Literature 1700-1899,0.37,0.37,0.11,0.11,0.05,0.0,0.0,0.0,erin marina goss,,ENGL-4640,2019
+ENGL,4750,1,Writing for Media,0.76,0.18,0.06,0.0,0.0,0.0,0.0,0.0,gabriel and hankins,,ENGL-4750,2019
+ENGL,4830,1,Af Am Lit 1920-Pres,0.32,0.53,0.11,0.0,0.05,0.0,0.0,0.0,tareva lese johnson,,ENGL-4830,2019
+ENGL,4850,1,Comp & Lang Teachers,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,sus cridland-hughes,,ENGL-4850,2019
+ENGL,4910,1,Classical Rhetoric,0.2,0.6,0.2,0.0,0.0,0.0,0.0,0.0,tharon howard,,ENGL-4910,2019
+ENGL,4960,4,Senior Seminar,0.67,0.17,0.0,0.0,0.08,0.0,0.0,0.08,kimberly manganelli,,ENGL-4960,2019
+ENGR,1020,211,Engineering Discipl & Skills,0.13,0.39,0.16,0.13,0.06,0.0,0.0,0.13,irene marie ferrara,,ENGR-1020,2019
+ENGR,1020,211,Engineering Discipl & Skills,0.13,0.39,0.16,0.13,0.06,0.0,0.0,0.13,ashley childers,,ENGR-1020,2019
+ENGR,1020,212,Engineering Discipl & Skills,0.13,0.35,0.19,0.06,0.13,0.0,0.0,0.13,ashley childers,,ENGR-1020,2019
+ENGR,1020,212,Engineering Discipl & Skills,0.13,0.35,0.19,0.06,0.13,0.0,0.0,0.13,irene marie ferrara,,ENGR-1020,2019
+ENGR,1020,213,Engineering Discipl & Skills,0.11,0.32,0.32,0.04,0.04,0.0,0.0,0.18,john minor,,ENGR-1020,2019
+ENGR,1020,213,Engineering Discipl & Skills,0.11,0.32,0.32,0.04,0.04,0.0,0.0,0.18,irene marie ferrara,,ENGR-1020,2019
+ENGR,1020,214,Engineering Discipl & Skills,0.27,0.2,0.23,0.03,0.07,0.0,0.0,0.2,john minor,,ENGR-1020,2019
+ENGR,1020,214,Engineering Discipl & Skills,0.27,0.2,0.23,0.03,0.07,0.0,0.0,0.2,irene marie ferrara,,ENGR-1020,2019
+ENGR,1410,123,Programming & Problem Solving,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,matthew kent miller,,ENGR-1410,2019
+ENGR,1410,123,Programming & Problem Solving,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,william martin,,ENGR-1410,2019
+ENGR,1410,124,Programming & Problem Solving,0.33,0.47,0.19,0.0,0.0,0.0,0.0,0.0,william martin,,ENGR-1410,2019
+ENGR,1410,124,Programming & Problem Solving,0.33,0.47,0.19,0.0,0.0,0.0,0.0,0.0,matthew kent miller,,ENGR-1410,2019
+ENGR,1410,127,Programming & Problem Solving,0.25,0.5,0.17,0.03,0.0,0.0,0.0,0.06,matthew kent miller,,ENGR-1410,2019
+ENGR,1410,127,Programming & Problem Solving,0.25,0.5,0.17,0.03,0.0,0.0,0.0,0.06,william martin,,ENGR-1410,2019
+ENGR,1410,324,Programming & Problem Solving,0.35,0.33,0.23,0.05,0.0,0.0,0.0,0.05,mariah magagnotti,,ENGR-1410,2019
+ENGR,1410,324,Programming & Problem Solving,0.35,0.33,0.23,0.05,0.0,0.0,0.0,0.05,william martin,,ENGR-1410,2019
+ENGR,1410,325,Programming & Problem Solving,0.33,0.44,0.18,0.03,0.0,0.0,0.0,0.03,mariah magagnotti,,ENGR-1410,2019
+ENGR,1410,325,Programming & Problem Solving,0.33,0.44,0.18,0.03,0.0,0.0,0.0,0.03,william martin,,ENGR-1410,2019
+ENGR,1410,326,Programming & Problem Solving,0.19,0.49,0.14,0.0,0.0,0.0,0.0,0.19,mariah magagnotti,,ENGR-1410,2019
+ENGR,1410,326,Programming & Problem Solving,0.19,0.49,0.14,0.0,0.0,0.0,0.0,0.19,william martin,,ENGR-1410,2019
+ENGR,1410,621,Programming & Problem Solving,0.19,0.49,0.22,0.03,0.03,0.0,0.0,0.05,william martin,,ENGR-1410,2019
+ENGR,1410,621,Programming & Problem Solving,0.19,0.49,0.22,0.03,0.03,0.0,0.0,0.05,john minor,,ENGR-1410,2019
+ENGR,1410,622,Programming & Problem Solving,0.28,0.28,0.35,0.0,0.0,0.0,0.0,0.1,john minor,,ENGR-1410,2019
+ENGR,1410,622,Programming & Problem Solving,0.28,0.28,0.35,0.0,0.0,0.0,0.0,0.1,william martin,,ENGR-1410,2019
+ENGR,1410,623,Programming & Problem Solving,0.41,0.28,0.13,0.03,0.05,0.0,0.0,0.1,john minor,,ENGR-1410,2019
+ENGR,1410,623,Programming & Problem Solving,0.41,0.28,0.13,0.03,0.05,0.0,0.0,0.1,william martin,,ENGR-1410,2019
+ENGR,1410,624,Programming & Problem Solving,0.18,0.5,0.18,0.08,0.0,0.0,0.0,0.05,william martin,,ENGR-1410,2019
+ENGR,1410,624,Programming & Problem Solving,0.18,0.5,0.18,0.08,0.0,0.0,0.0,0.05,michael giebner,,ENGR-1410,2019
+ENGR,1410,625,Programming & Problem Solving,0.18,0.37,0.34,0.11,0.0,0.0,0.0,0.0,william martin,,ENGR-1410,2019
+ENGR,1410,625,Programming & Problem Solving,0.18,0.37,0.34,0.11,0.0,0.0,0.0,0.0,michael giebner,,ENGR-1410,2019
+ENGR,1410,626,Programming & Problem Solving,0.3,0.4,0.13,0.13,0.0,0.0,0.0,0.03,elizabeth stephan,,ENGR-1410,2019
+ENGR,1410,626,Programming & Problem Solving,0.3,0.4,0.13,0.13,0.0,0.0,0.0,0.03,william martin,,ENGR-1410,2019
+ENGR,1410,627,Programming & Problem Solving,0.35,0.53,0.1,0.0,0.0,0.0,0.0,0.03,jonathan bro harcum,,ENGR-1410,2019
+ENGR,1410,627,Programming & Problem Solving,0.35,0.53,0.1,0.0,0.0,0.0,0.0,0.03,william martin,,ENGR-1410,2019
+ENGR,1410,721,Programming & Problem Solving,0.19,0.45,0.23,0.06,0.03,0.0,0.0,0.03,william martin,,ENGR-1410,2019
+ENGR,1410,721,Programming & Problem Solving,0.19,0.45,0.23,0.06,0.03,0.0,0.0,0.03,john minor,,ENGR-1410,2019
+ENGR,1410,722,Programming & Problem Solving,0.5,0.34,0.13,0.0,0.03,0.0,0.0,0.0,elizabeth stephan,,ENGR-1410,2019
+ENGR,1410,722,Programming & Problem Solving,0.5,0.34,0.13,0.0,0.03,0.0,0.0,0.0,william martin,,ENGR-1410,2019
+ENGR,1410,725,Programming & Problem Solving,0.47,0.25,0.22,0.0,0.03,0.0,0.0,0.03,william martin,,ENGR-1410,2019
+ENGR,1410,725,Programming & Problem Solving,0.47,0.25,0.22,0.0,0.03,0.0,0.0,0.03,andrew isaa neptune,,ENGR-1410,2019
+ENGR,1410,726,Programming & Problem Solving,0.31,0.38,0.22,0.03,0.0,0.0,0.0,0.06,william martin,,ENGR-1410,2019
+ENGR,1410,726,Programming & Problem Solving,0.31,0.38,0.22,0.03,0.0,0.0,0.0,0.06,sarah grigg,,ENGR-1410,2019
+ENGR,1410,727,Programming & Problem Solving,0.17,0.57,0.17,0.06,0.0,0.0,0.0,0.03,sarah grigg,,ENGR-1410,2019
+ENGR,1410,727,Programming & Problem Solving,0.17,0.57,0.17,0.06,0.0,0.0,0.0,0.03,william martin,,ENGR-1410,2019
+ENGR,1410,821,Programming & Problem Solving,0.23,0.58,0.13,0.0,0.03,0.0,0.0,0.03,andrew isaa neptune,,ENGR-1410,2019
+ENGR,1410,821,Programming & Problem Solving,0.23,0.58,0.13,0.0,0.03,0.0,0.0,0.03,william martin,,ENGR-1410,2019
+ENGR,1410,822,Programming & Problem Solving,0.17,0.5,0.31,0.03,0.0,0.0,0.0,0.0,andrew isaa neptune,,ENGR-1410,2019
+ENGR,1410,822,Programming & Problem Solving,0.17,0.5,0.31,0.03,0.0,0.0,0.0,0.0,william martin,,ENGR-1410,2019
+ENGR,1410,823,Program & Prob Solving (HON),0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,william martin,True,ENGR-1410,2019
+ENGR,1410,823,Program & Prob Solving (HON),0.74,0.23,0.03,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,True,ENGR-1410,2019
+ENGR,1410,824,Program & Prob Solving (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jonathan bro harcum,True,ENGR-1410,2019
+ENGR,1410,824,Program & Prob Solving (HON),0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,william martin,True,ENGR-1410,2019
+ENGR,1410,825,Programming & Problem Solving,0.21,0.36,0.27,0.06,0.03,0.0,0.0,0.06,jonathan maier,,ENGR-1410,2019
+ENGR,1410,825,Programming & Problem Solving,0.21,0.36,0.27,0.06,0.03,0.0,0.0,0.06,william martin,,ENGR-1410,2019
+ENGR,1410,826,Programming & Problem Solving,0.29,0.37,0.16,0.03,0.05,0.0,0.0,0.11,william martin,,ENGR-1410,2019
+ENGR,1410,826,Programming & Problem Solving,0.29,0.37,0.16,0.03,0.05,0.0,0.0,0.11,jonathan maier,,ENGR-1410,2019
+ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.24,0.03,0.0,0.0,0.0,0.0,william martin,,ENGR-1410,2019
+ENGR,1410,827,Programming & Problem Solving,0.24,0.5,0.24,0.03,0.0,0.0,0.0,0.0,jonathan maier,,ENGR-1410,2019
+ENGR,1900,10,CI in Engr I (Robotics),0.86,0.0,0.0,0.0,0.0,0.0,0.0,0.14,michael benj wooten,,ENGR-1900,2019
+ENGR,2080,281,Engr Graphics & Machine Design,0.38,0.44,0.15,0.0,0.0,0.0,0.0,0.04,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,281,Engr Graphics & Machine Design,0.38,0.44,0.15,0.0,0.0,0.0,0.0,0.04,samuel coeyman,,ENGR-2080,2019
+ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.2,0.07,0.07,0.02,0.0,0.0,0.02,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,282,Engr Graphics & Machine Design,0.61,0.2,0.07,0.07,0.02,0.0,0.0,0.02,samuel coeyman,,ENGR-2080,2019
+ENGR,2080,284,Engr Graphics & Machine Design,0.62,0.22,0.11,0.04,0.0,0.0,0.0,0.0,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,284,Engr Graphics & Machine Design,0.62,0.22,0.11,0.04,0.0,0.0,0.0,0.0,nisha gulhane,,ENGR-2080,2019
+ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,natalie pellizzi,,ENGR-2080,2019
+ENGR,2080,285,Engr Graphics & Machine Design,0.57,0.32,0.09,0.02,0.0,0.0,0.0,0.0,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,286,Engr Graphics & Machine Design,0.34,0.41,0.11,0.05,0.07,0.0,0.0,0.02,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,286,Engr Graphics & Machine Design,0.34,0.41,0.11,0.05,0.07,0.0,0.0,0.02,natalie pellizzi,,ENGR-2080,2019
+ENGR,2080,382,Engr Graphics & Machine Design,0.56,0.24,0.09,0.02,0.07,0.0,0.0,0.02,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,382,Engr Graphics & Machine Design,0.56,0.24,0.09,0.02,0.07,0.0,0.0,0.02,nisha gulhane,,ENGR-2080,2019
+ENGR,2080,682,Engr Graphics & Machine Design,0.59,0.28,0.13,0.0,0.0,0.0,0.0,0.0,kyle walker,,ENGR-2080,2019
+ENGR,2080,682,Engr Graphics & Machine Design,0.59,0.28,0.13,0.0,0.0,0.0,0.0,0.0,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,684,Engr Graphics & Machine Design,0.6,0.19,0.05,0.02,0.07,0.0,0.0,0.07,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,684,Engr Graphics & Machine Design,0.6,0.19,0.05,0.02,0.07,0.0,0.0,0.07,kyle walker,,ENGR-2080,2019
+ENGR,2080,882,Engr Graphics & Machine Design,0.6,0.26,0.04,0.04,0.04,0.0,0.0,0.02,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,882,Engr Graphics & Machine Design,0.6,0.26,0.04,0.04,0.04,0.0,0.0,0.02,apurva patel,,ENGR-2080,2019
+ENGR,2080,884,Engr Graphics & Machine Design,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,nighat yasmin,,ENGR-2080,2019
+ENGR,2080,884,Engr Graphics & Machine Design,0.4,0.45,0.1,0.05,0.0,0.0,0.0,0.0,apurva patel,,ENGR-2080,2019
+ENGR,2100,101,CAD & Engineering Applications,0.52,0.28,0.04,0.04,0.07,0.0,0.0,0.04,afshin famili,,ENGR-2100,2019
+ENGR,2100,101,CAD & Engineering Applications,0.52,0.28,0.04,0.04,0.07,0.0,0.0,0.04,nighat yasmin,,ENGR-2100,2019
+ENGR,2100,102,CAD & Engineering Applications,0.44,0.33,0.1,0.08,0.0,0.0,0.0,0.04,nighat yasmin,,ENGR-2100,2019
+ENGR,2100,102,CAD & Engineering Applications,0.44,0.33,0.1,0.08,0.0,0.0,0.0,0.04,afshin famili,,ENGR-2100,2019
+ENGR,2100,105,CAD & Engineering Applications,0.71,0.19,0.02,0.02,0.02,0.0,0.0,0.02,john minor,,ENGR-2100,2019
+ENGR,2100,105,CAD & Engineering Applications,0.71,0.19,0.02,0.02,0.02,0.0,0.0,0.02,nighat yasmin,,ENGR-2100,2019
+ENGR,2100,106,CAD & Engineering Applications,0.5,0.35,0.04,0.0,0.02,0.0,0.0,0.08,nighat yasmin,,ENGR-2100,2019
+ENGR,2100,106,CAD & Engineering Applications,0.5,0.35,0.04,0.0,0.02,0.0,0.0,0.08,john minor,,ENGR-2100,2019
+ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.12,0.08,0.06,0.04,0.0,0.0,0.0,russell barrett,,ENR-1020,2019
+ENR,1020,1,Intro to Envir & Natur Res II,0.7,0.12,0.08,0.06,0.04,0.0,0.0,0.0,alan johnson,,ENR-1020,2019
+ENR,3020,1,Nat Res Measurements,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,russell barrett,,ENR-3020,2019
+ENR,3020,1,Nat Res Measurements,0.6,0.37,0.03,0.0,0.0,0.0,0.0,0.0,lawrence gering,,ENR-3020,2019
+ENR,4130,2,Restoration Ecology,0.3,0.4,0.23,0.0,0.0,0.0,0.0,0.07,althea simone hagan,,ENR-4130,2019
+ENR,4500,1,Conservation Issues,0.87,0.09,0.0,0.04,0.0,0.0,0.0,0.0,alan johnson,,ENR-4500,2019
+ENR,4500,2,Conservation Issues,0.79,0.14,0.03,0.0,0.0,0.0,0.0,0.03,alan johnson,,ENR-4500,2019
+ENR,6130,1,Restoration Ecology,0.5,0.21,0.29,0.0,0.0,0.0,0.0,0.0,althea simone hagan,,ENR-6130,2019
+ENSP,2000,1,Intro Environ Sci,0.19,0.65,0.09,0.06,0.02,0.0,0.0,0.0,tom owino,,ENSP-2000,2019
+ENSP,2000,2,Intro Environ Sci,0.57,0.37,0.0,0.0,0.0,0.0,0.0,0.06,elizabeth carraway,,ENSP-2000,2019
+ENSP,2000,3,Intro Environ Sci,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2000,2019
+ENSP,2010,1,Environm Sci for Educ Majors,0.92,0.04,0.04,0.0,0.0,0.0,0.0,0.0,minory nammouz,,ENSP-2010,2019
+ENSP,4000,1,Studies in Environmental Sci,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,margaret thompson,,ENSP-4000,2019
+ENT,2000,1,Six-Legged Science,0.41,0.34,0.15,0.02,0.0,0.0,0.05,0.02,suellen pometto,,ENT-2000,2019
+ENT,8700,1,Insect Phys Mol Bio,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,matthew turnbull,,ENT-8700,2019
+ENTR,1010,2,Entrepreneurial Mindset,0.64,0.27,0.05,0.0,0.0,0.0,0.01,0.03,john michael hannon,,ENTR-1010,2019
+ENTR,1090,2,How to Start a Startup,0.71,0.07,0.04,0.0,0.0,0.0,0.0,0.18,john michael hannon,,ENTR-1090,2019
+ENTR,1090,20,Lemonade Day Pendleton,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,david joseph frock,,ENTR-1090,2019
+ENTR,2010,1,Sports Entrepreneurship,0.77,0.16,0.05,0.0,0.0,0.0,0.0,0.02,john michael hannon,,ENTR-2010,2019
+ESED,8500,1,Spec Top Engineering & Sci Edu,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,cindy lee,,ESED-8500,2019
+FCS,2010,1,Introduction to Human Rights,0.75,0.08,0.0,0.0,0.08,0.0,0.0,0.08,matthe hudson-flege,,FCS-2010,2019
+FDSC,2140,1,Fd Resources & Soc,0.7,0.23,0.04,0.03,0.0,0.0,0.0,0.0,paul dawson,,FDSC-2140,2019
+FDSC,3040,1,Eval Dairy Products,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-3040,2019
+FDSC,3040,1,Eval Dairy Products,0.78,0.06,0.17,0.0,0.0,0.0,0.0,0.0,sara lane cothran,,FDSC-3040,2019
+FDSC,4020,1,Food Chemistry II,0.73,0.24,0.02,0.0,0.0,0.0,0.0,0.0,feng chen,,FDSC-4020,2019
+FDSC,4030,1,Food Ch & Analysis,0.67,0.27,0.02,0.02,0.0,0.0,0.0,0.02,feng chen,,FDSC-4030,2019
+FDSC,4030,1,Food Ch & Analysis,0.67,0.27,0.02,0.02,0.0,0.0,0.0,0.02,paul dawson,,FDSC-4030,2019
+FDSC,4080,1,Food Process Eng,0.4,0.27,0.2,0.07,0.0,0.0,0.0,0.07,steven brandon,,FDSC-4080,2019
+FDSC,4500,7,Creative Inquiry-Food Science,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,john mcgregor,,FDSC-4500,2019
+FDSC,4500,15,Creative Inquiry-Food Science,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,vivian haley-zitlin,,FDSC-4500,2019
+FDSC,4500,18,Creative Inquiry-Food Science,0.67,0.0,0.0,0.0,0.0,0.0,0.0,0.33,xiuping jiang,,FDSC-4500,2019
+FDSC,4500,22,Creative Inquiry-Food Science,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,feng chen,,FDSC-4500,2019
+FIN,2010,401,Intro to Personal Finance,0.93,0.01,0.04,0.0,0.01,0.0,0.0,0.0,joshua harris,,FIN-2010,2019
+FIN,2010,402,Intro to Personal Finance,0.97,0.01,0.01,0.0,0.0,0.0,0.0,0.0,joshua harris,,FIN-2010,2019
+FIN,2010,403,Intro to Personal Finance,0.91,0.01,0.03,0.0,0.03,0.0,0.0,0.01,joshua harris,,FIN-2010,2019
+FIN,2010,404,Intro to Personal Finance,0.72,0.16,0.01,0.01,0.06,0.0,0.0,0.03,joshua harris,,FIN-2010,2019
+FIN,2010,405,Intro to Personal Finance,0.79,0.15,0.0,0.03,0.0,0.0,0.0,0.03,joshua harris,,FIN-2010,2019
+FIN,2010,406,Intro to Personal Finance,0.7,0.2,0.0,0.0,0.1,0.0,0.0,0.0,joshua harris,,FIN-2010,2019
+FIN,3040,1,Risk & Insurance,0.2,0.28,0.35,0.08,0.1,0.0,0.0,0.0,kerri mcmillan,,FIN-3040,2019
+FIN,3050,1,Investment Analysis,0.17,0.27,0.44,0.05,0.0,0.0,0.0,0.07,kerri mcmillan,,FIN-3050,2019
+FIN,3050,2,Investment Analysis,0.26,0.24,0.39,0.05,0.0,0.0,0.0,0.05,kerri mcmillan,,FIN-3050,2019
+FIN,3050,3,Investment Analysis,0.18,0.38,0.28,0.05,0.0,0.0,0.0,0.1,kerri mcmillan,,FIN-3050,2019
+FIN,3050,4,Investment Analysis,0.17,0.23,0.26,0.11,0.03,0.0,0.0,0.2,john alexander,,FIN-3050,2019
+FIN,3060,1,Corporation Finance,0.21,0.3,0.23,0.19,0.02,0.0,0.0,0.04,ramon tolb franklin,,FIN-3060,2019
+FIN,3060,2,Corporation Finance,0.21,0.21,0.27,0.19,0.02,0.0,0.0,0.1,ramon tolb franklin,,FIN-3060,2019
+FIN,3060,3,Corporation Finance,0.2,0.22,0.24,0.18,0.02,0.0,0.0,0.13,ramon tolb franklin,,FIN-3060,2019
+FIN,3060,4,Corporation Finance,0.13,0.2,0.24,0.29,0.04,0.0,0.0,0.09,ramon tolb franklin,,FIN-3060,2019
+FIN,3060,9,Corporation Finance,0.12,0.17,0.4,0.24,0.05,0.0,0.0,0.02,charles taylor vick,,FIN-3060,2019
+FIN,3060,401,Corporation Finance,0.3,0.25,0.25,0.13,0.03,0.0,0.0,0.04,jonathan godbey,,FIN-3060,2019
+FIN,3060,402,Corporation Finance,0.18,0.31,0.32,0.11,0.0,0.0,0.04,0.04,jonathan godbey,,FIN-3060,2019
+FIN,3060,601,Corporation Finance,0.06,0.69,0.25,0.0,0.0,0.0,0.0,0.0,jack wolf,,FIN-3060,2019
+FIN,3070,1,Prin of Real Estate,0.24,0.42,0.29,0.05,0.0,0.0,0.0,0.0,yannan shen,,FIN-3070,2019
+FIN,3070,2,Prin of Real Estate,0.29,0.37,0.24,0.03,0.05,0.0,0.0,0.03,yannan shen,,FIN-3070,2019
+FIN,3070,3,Prin of Real Estate,0.24,0.41,0.22,0.11,0.03,0.0,0.0,0.0,thomas springer,,FIN-3070,2019
+FIN,3070,4,Prin of Real Estate,0.19,0.19,0.39,0.19,0.03,0.0,0.0,0.0,thomas springer,,FIN-3070,2019
+FIN,3080,1,Fin Inst & Mkts,0.21,0.4,0.29,0.07,0.02,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2019
+FIN,3080,2,Fin Inst & Mkts,0.19,0.4,0.33,0.05,0.0,0.0,0.0,0.02,daniel thoma greene,,FIN-3080,2019
+FIN,3080,401,Fin Inst & Mkts,0.27,0.51,0.14,0.06,0.02,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2019
+FIN,3080,402,Fin Inst & Mkts,0.12,0.51,0.35,0.02,0.0,0.0,0.0,0.0,daniel thoma greene,,FIN-3080,2019
+FIN,3110,2,Financial Management I,0.22,0.32,0.22,0.04,0.01,0.0,0.0,0.18,george bra lockhart,,FIN-3110,2019
+FIN,3110,4,Financial Management I,0.22,0.31,0.22,0.06,0.03,0.0,0.0,0.15,george bra lockhart,,FIN-3110,2019
+FIN,3110,5,Financial Management I,0.23,0.33,0.26,0.07,0.07,0.0,0.0,0.05,weike xu,,FIN-3110,2019
+FIN,3110,102,Financial Management I (HON),0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,george bra lockhart,True,FIN-3110,2019
+FIN,3110,104,Financial Management I (HON),0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,george bra lockhart,True,FIN-3110,2019
+FIN,3120,1,Financial Management II,0.24,0.4,0.17,0.14,0.0,0.0,0.0,0.05,blerina zykaj,,FIN-3120,2019
+FIN,3120,2,Financial Management II,0.28,0.28,0.38,0.03,0.03,0.0,0.0,0.0,blerina zykaj,,FIN-3120,2019
+FIN,3120,4,Financial Management II,0.14,0.38,0.31,0.05,0.1,0.0,0.0,0.02,weike xu,,FIN-3120,2019
+FIN,3120,5,Financial Management II,0.19,0.35,0.3,0.07,0.05,0.0,0.0,0.05,weike xu,,FIN-3120,2019
+FIN,3120,102,Financial Management II (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,True,FIN-3120,2019
+FIN,3120,401,Financial Management II,0.18,0.27,0.3,0.09,0.07,0.0,0.0,0.09,angela morgan,,FIN-3120,2019
+FIN,4020,1,Corporate Valuation,0.16,0.44,0.3,0.07,0.0,0.0,0.0,0.02,angela morgan,,FIN-4020,2019
+FIN,4030,1,Spreadsheet Apps in Finance,0.3,0.28,0.23,0.14,0.02,0.0,0.0,0.02,vincent intintoli,,FIN-4030,2019
+FIN,4030,2,Spreadsheet Apps in Finance,0.33,0.27,0.33,0.03,0.03,0.0,0.0,0.0,vincent intintoli,,FIN-4030,2019
+FIN,4040,1,Financial Modeling,0.14,0.57,0.1,0.14,0.0,0.0,0.0,0.05,jack wolf,,FIN-4040,2019
+FIN,4050,1,Portfolio Management & Theory,0.09,0.27,0.42,0.12,0.0,0.0,0.0,0.09,john alexander,,FIN-4050,2019
+FIN,4080,1,Mgt of Fin Inst,0.25,0.56,0.19,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2019
+FIN,4080,2,Mgt of Fin Inst,0.47,0.4,0.13,0.0,0.0,0.0,0.0,0.0,lyudmila chernykh,,FIN-4080,2019
+FIN,4090,1,Professional Financial Plan,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,joshua harris,,FIN-4090,2019
+FIN,4110,1,Int Fin Mgt,0.24,0.48,0.21,0.0,0.06,0.0,0.0,0.0,luke asher devault,,FIN-4110,2019
+FIN,4110,2,Int Fin Mgt,0.39,0.36,0.18,0.04,0.0,0.0,0.0,0.04,luke asher devault,,FIN-4110,2019
+FIN,4150,1,Real Estate Investmt,0.2,0.45,0.3,0.0,0.0,0.0,0.0,0.05,thomas springer,,FIN-4150,2019
+FIN,4160,2,Real Estate Val,0.24,0.62,0.14,0.0,0.0,0.0,0.0,0.0,bryan blackwood,,FIN-4160,2019
+FIN,4980,2,CI in Finance: CFA,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,jack wolf,,FIN-4980,2019
+FIN,4980,9,Creative Inquiry in Finance,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,yannan shen,,FIN-4980,2019
+FNR,4700,19,Soil Judging Project,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,elena mikhailova,,FNR-4700,2019
+FNR,4700,23,Estuarine Fish Ecology I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,troy mason farmer,,FNR-4700,2019
+FNR,4700,24,Climate Change/Carolina Fish I,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,troy mason farmer,,FNR-4700,2019
+FNR,4700,35,Aquaponics,0.63,0.13,0.13,0.0,0.0,0.0,0.0,0.13,lance edwar beecher,,FNR-4700,2019
+FNR,4700,37,Growing Food In a Box Techniqs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lance edwar beecher,,FNR-4700,2019
+FNR,4700,44,Alligator Ecology,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,catherine jachowski,,FNR-4700,2019
+FNR,4700,46,Tiger Awareness,0.88,0.0,0.0,0.13,0.0,0.0,0.0,0.0,shari lyn rodriguez,,FNR-4700,2019
+FNR,4990,3,Natural Resources Seminar,0.87,0.07,0.07,0.0,0.0,0.0,0.0,0.0,susan talley guynn,,FNR-4990,2019
+FOR,1010,1,Intro to Forestry,0.7,0.05,0.16,0.03,0.03,0.0,0.0,0.03,lawrence gering,,FOR-1010,2019
+FOR,2060,1,Forestry Ecology,0.24,0.31,0.2,0.11,0.0,0.0,0.09,0.05,donald hagan,,FOR-2060,2019
+FOR,3080,1,Remote Sensing in Forestry,0.44,0.33,0.19,0.04,0.0,0.0,0.0,0.0,lawrence gering,,FOR-3080,2019
+FOR,4080,1,Wood and Paper Products,0.62,0.26,0.1,0.0,0.0,0.0,0.0,0.02,patricia layton,,FOR-4080,2019
+FOR,4150,2,Forest Wildlife Managment,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,,FOR-4150,2019
+FOR,4180,1,Forest Resource Valuation,0.32,0.52,0.16,0.0,0.0,0.0,0.0,0.0,thomas straka,,FOR-4180,2019
+FOR,4340,1,GIS for Natural Resources,0.4,0.48,0.05,0.0,0.0,0.0,0.0,0.08,robert frit baldwin,,FOR-4340,2019
+FOR,4650,1,Silviculture,0.26,0.37,0.19,0.15,0.04,0.0,0.0,0.0,gaofeng wang,,FOR-4650,2019
+FR,1010,1,Elementary French,0.36,0.27,0.23,0.05,0.09,0.0,0.0,0.0,anne salces  nedeo,,FR-1010,2019
+FR,1010,2,Elementary French,0.43,0.36,0.0,0.07,0.14,0.0,0.0,0.0,anne salces  nedeo,,FR-1010,2019
+FR,1020,1,Elementary French,0.52,0.22,0.09,0.0,0.0,0.0,0.04,0.13,amy lyn grif sawyer,,FR-1020,2019
+FR,1020,2,Elementary French,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-1020,2019
+FR,2010,2,Intermediate French,0.73,0.23,0.0,0.05,0.0,0.0,0.0,0.0,amy lyn grif sawyer,,FR-2010,2019
+FR,2010,3,Intermediate French,0.63,0.33,0.0,0.0,0.0,0.0,0.0,0.04,amy lyn grif sawyer,,FR-2010,2019
+FR,2020,1,Intermediate French,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,kenneth dav widgren,,FR-2020,2019
+FR,2020,3,Intermediate French,0.38,0.38,0.13,0.08,0.0,0.0,0.0,0.04,paulin de tholozany,,FR-2020,2019
+FR,2020,4,Intermediate French,0.3,0.6,0.1,0.0,0.0,0.0,0.0,0.0,kelly digby peebles,,FR-2020,2019
+FR,3050,1,Int Fr Con & Comp I,0.55,0.3,0.1,0.0,0.0,0.0,0.0,0.05,joseph mai,,FR-3050,2019
+FR,3160,1,Fr for Intl Trade,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,eric touya,,FR-3160,2019
+FR,4100,1,Francophone Literature,0.71,0.21,0.0,0.0,0.07,0.0,0.0,0.0,eric touya,,FR-4100,2019
+GC,1010,1,Orientation to G C,0.24,0.59,0.06,0.0,0.06,0.0,0.0,0.06,kern cox,,GC-1010,2019
+GC,1020,1,Computer Art & CAD Foundations,0.27,0.38,0.16,0.03,0.08,0.0,0.0,0.08,carol jones,,GC-1020,2019
+GC,1030,1,G C I for Pkgsc,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,john jacobs,,GC-1030,2019
+GC,1040,1,Graphic Communications I,0.76,0.19,0.02,0.0,0.02,0.0,0.0,0.02,michelle suki  fox,,GC-1040,2019
+GC,1990,4,CI in GC I Ph Ch,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,nona woolbright,,GC-1990,2019
+GC,2070,1,Graphic Communications II,0.57,0.38,0.04,0.0,0.0,0.0,0.0,0.0,charles tabor weiss,,GC-2070,2019
+GC,2990,2,CI in GC II-VDP,0.8,0.0,0.0,0.0,0.2,0.0,0.0,0.0,eric weisenmiller,,GC-2990,2019
+GC,2990,4,Cr Inquiry in GC II Ph Ch,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,nona woolbright,,GC-2990,2019
+GC,3400,1,Digital Imaging and eMedia,0.31,0.56,0.1,0.0,0.0,0.0,0.0,0.03,erica black walker,,GC-3400,2019
+GC,3460,1,Ink and Substrates,0.33,0.33,0.26,0.0,0.05,0.0,0.0,0.03,liam henry 'hara,,GC-3460,2019
+GC,3720,1,Digital Analytics Brand Comm,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,alicia ni littleton,,GC-3720,2019
+GC,3720,1,Digital Analytics Brand Comm,0.74,0.16,0.0,0.11,0.0,0.0,0.0,0.0,katelyn hildebrand,,GC-3720,2019
+GC,3730,1,Media Management in Brand Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,jaclyn kathl driggs,,GC-3730,2019
+GC,3730,1,Media Management in Brand Comm,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,,GC-3730,2019
+GC,3740,1,Brand Comm Media Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,katelyn hildebrand,,GC-3740,2019
+GC,3740,1,Brand Comm Media Strategy,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,roger beasley,,GC-3740,2019
+GC,4060,1,Package and Specialty Printing,0.17,0.71,0.06,0.0,0.03,0.0,0.0,0.03,kern cox,,GC-4060,2019
+GC,4400,1,Commercial Printing,0.29,0.45,0.16,0.0,0.06,0.0,0.0,0.03,eric weisenmiller,,GC-4400,2019
+GC,4440,1,Current Dev/Trends in Gr Comm,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,samuel ingram,,GC-4440,2019
+GC,4480,1,Plan & Cont Printing Functions,0.78,0.19,0.03,0.0,0.0,0.0,0.0,0.0,nona woolbright,,GC-4480,2019
+GC,4800,1,Senior Seminar in GC,0.81,0.17,0.02,0.0,0.0,0.0,0.0,0.0,charles edwa tonkin,,GC-4800,2019
+GC,4900,8,UX & Web Design,0.94,0.0,0.0,0.0,0.06,0.0,0.0,0.0,erica black walker,,GC-4900,2019
+GC,4900,230,G C Selected Topics-Sales,0.75,0.17,0.0,0.0,0.08,0.0,0.0,0.0,john leininger,,GC-4900,2019
+GEN,3000,1,Fundamental Genetics,0.26,0.29,0.24,0.13,0.05,0.0,0.0,0.03,kate leanne wi tsai,,GEN-3000,2019
+GEN,3000,2,Fundamental Genetics,0.36,0.32,0.16,0.06,0.03,0.0,0.0,0.06,kate leanne wi tsai,,GEN-3000,2019
+GEN,3020,1,Molecular & General Genetics,0.36,0.32,0.23,0.02,0.02,0.0,0.0,0.05,lukasz kozubowski,,GEN-3020,2019
+GEN,3040,1,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,GEN-3040,2019
+GEN,3040,1,Molecular Biology Laboratory,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,,GEN-3040,2019
+GEN,3040,2,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,,GEN-3040,2019
+GEN,3040,2,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,GEN-3040,2019
+GEN,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,,GEN-3040,2019
+GEN,3040,3,Molecular Biology Laboratory,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,GEN-3040,2019
+GEN,3040,4,Molecular Biology Laboratory,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,geoffrey ford,,GEN-3040,2019
+GEN,3040,4,Molecular Biology Laboratory,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,scott michae tanner,,GEN-3040,2019
+GEN,4200,1,Molecular Genetics & Gene Reg,0.27,0.4,0.29,0.03,0.0,0.0,0.0,0.0,miriam krist konkel,,GEN-4200,2019
+GEN,4210,2,Mol Gen Gene Reg Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,scott michae tanner,,GEN-4210,2019
+GEN,4400,1,Bioinformatics,0.56,0.33,0.06,0.06,0.0,0.0,0.0,0.0,liangjiang wang,,GEN-4400,2019
+GEN,4700,1,Human Genetics,0.25,0.38,0.28,0.06,0.0,0.0,0.0,0.04,leigh anne clark,,GEN-4700,2019
+GEN,4900,3,Biomedical Informatics,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,frank alexan feltus,,GEN-4900,2019
+GEN,4910,36,CI:DNA Repair (HON),0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,michael glen sehorn,True,GEN-4910,2019
+GEN,4930,3,Senior Seminar,0.93,0.0,0.07,0.0,0.0,0.0,0.0,0.0,haiying liang,,GEN-4930,2019
+GEN,6700,1,Human Genetics,0.17,0.17,0.17,0.0,0.0,0.0,0.0,0.5,leigh anne clark,,GEN-6700,2019
+GEN,8050,1,Issues in Research,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,william marcotte,,GEN-8050,2019
+GEOG,1010,1,Intro to Geography,0.4,0.47,0.07,0.03,0.03,0.0,0.0,0.0,christa smith,,GEOG-1010,2019
+GEOG,1030,1,World Regional Geography,0.3,0.44,0.15,0.04,0.03,0.0,0.0,0.04,william churc terry,,GEOG-1030,2019
+GEOL,1010,1,Physical Geology,0.27,0.29,0.25,0.07,0.07,0.0,0.0,0.05,alan coulson,,GEOL-1010,2019
+GEOL,1010,2,Physical Geology,0.34,0.33,0.17,0.04,0.04,0.0,0.0,0.09,alan coulson,,GEOL-1010,2019
+GEOL,1010,3,Physical Geology,0.43,0.38,0.11,0.05,0.04,0.0,0.0,0.0,mary katheri fidler,,GEOL-1010,2019
+GEOL,1030,1,Physical Geol Lab,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,2,Physical Geol Lab,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,3,Physical Geol Lab,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,alan coulson,,GEOL-1030,2019
+GEOL,1030,4,Physical Geol Lab,0.71,0.17,0.08,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2019
+GEOL,1030,5,Physical Geol Lab,0.78,0.13,0.04,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2019
+GEOL,1030,6,Physical Geol Lab,0.43,0.3,0.17,0.0,0.0,0.0,0.0,0.09,alan coulson,,GEOL-1030,2019
+GEOL,1030,7,Physical Geol Lab,0.71,0.25,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2019
+GEOL,1030,8,Physical Geol Lab,0.91,0.04,0.0,0.0,0.0,0.0,0.0,0.04,alan coulson,,GEOL-1030,2019
+GEOL,1030,10,Physical Geol Lab,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,11,Physical Geol Lab,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,12,Physical Geol Lab,0.29,0.46,0.25,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,14,Physical Geol Lab,0.38,0.52,0.1,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-1030,2019
+GEOL,1030,15,Physical Geol Lab,0.73,0.2,0.0,0.0,0.0,0.0,0.0,0.07,alan coulson,,GEOL-1030,2019
+GEOL,1120,1,Earth Resources,0.29,0.35,0.19,0.13,0.01,0.0,0.0,0.03,mary katheri fidler,,GEOL-1120,2019
+GEOL,1140,1,Earth Resources Lab,0.64,0.2,0.05,0.05,0.02,0.0,0.0,0.04,mary katheri fidler,,GEOL-1140,2019
+GEOL,2020,1,Earth History,0.25,0.45,0.25,0.05,0.0,0.0,0.0,0.0,alan coulson,,GEOL-2020,2019
+GEOL,3160,1,Igneous & Metamorphic Petrolog,0.27,0.6,0.13,0.0,0.0,0.0,0.0,0.0,mary katheri fidler,,GEOL-3160,2019
+GEOL,4050,1,Surficial Geology,0.62,0.38,0.0,0.0,0.0,0.0,0.0,0.0,alexander th pullen,,GEOL-4050,2019
+GEOL,4090,1,Envir & Exploration Geophysics,0.69,0.25,0.06,0.0,0.0,0.0,0.0,0.0,scott dewolf,,GEOL-4090,2019
+GEOL,4110,8,Res Probs - Community Outreach,0.93,0.0,0.0,0.0,0.0,0.0,0.0,0.07,john robert wagner,,GEOL-4110,2019
+GEOL,4210,1,GIS in Geology,0.72,0.16,0.04,0.0,0.04,0.0,0.0,0.04,scott brame,,GEOL-4210,2019
+GEOL,4920,1,Resrch Synthesis II,0.58,0.33,0.08,0.0,0.0,0.0,0.0,0.0,alan coulson,,GEOL-4920,2019
+GEOL,8170,1,Applied Process Simulation,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,lawrence murdoch,,GEOL-8170,2019
+GER,1010,1,Elementary German,0.54,0.23,0.08,0.0,0.0,0.0,0.0,0.15, lee ferrell,,GER-1010,2019
+GER,1010,2,Elementary German,0.38,0.31,0.13,0.06,0.0,0.0,0.0,0.13,oswald harris king,,GER-1010,2019
+GER,1020,1,Elementary German,0.54,0.15,0.23,0.0,0.0,0.0,0.0,0.08,oswald harris king,,GER-1020,2019
+GER,2020,1,Intermediate German,0.24,0.16,0.36,0.16,0.08,0.0,0.0,0.0,johannes schmidt,,GER-2020,2019
+GER,3600,1,Ger Lit to 1832,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,johannes schmidt,,GER-3600,2019
+HCG,9890,400,Pharmacogenomics,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,christopher farrell,,HCG-9890,2019
+HCG,9890,400,Pharmacogenomics,0.91,0.0,0.0,0.0,0.0,0.0,0.0,0.09,linda ward,,HCG-9890,2019
+HIST,1010,1,History of the United States,0.31,0.45,0.14,0.03,0.0,0.0,0.0,0.07,james brad jeffries,,HIST-1010,2019
+HIST,1010,2,History of the United States,0.8,0.1,0.0,0.07,0.0,0.0,0.0,0.03,joshua cas catalano,,HIST-1010,2019
+HIST,1240,1,Environmental History Survey,0.09,0.46,0.26,0.08,0.05,0.0,0.0,0.06,james brad jeffries,,HIST-1240,2019
+HIST,1720,1,The West and the World I,0.53,0.22,0.06,0.03,0.06,0.0,0.0,0.09,kathryn langenfeld,,HIST-1720,2019
+HIST,1730,1,The West and the World II,0.19,0.44,0.28,0.03,0.06,0.0,0.0,0.02,michael meng,,HIST-1730,2019
+HIST,1730,2,The West and the World II,0.33,0.34,0.18,0.08,0.04,0.0,0.0,0.04,james burns,,HIST-1730,2019
+HIST,1730,3,The West and the World II,0.29,0.36,0.32,0.0,0.0,0.0,0.0,0.04, alan grubb,,HIST-1730,2019
+HIST,2990,1,Historian's Craft,0.5,0.2,0.1,0.0,0.1,0.0,0.0,0.1,rachel anne moore,,HIST-2990,2019
+HIST,2990,2,Historian's Craft,0.59,0.06,0.06,0.0,0.24,0.0,0.0,0.06,michael silvestri,,HIST-2990,2019
+HIST,3000,1,History of Colonial America,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,lee brady wilson,,HIST-3000,2019
+HIST,3100,1,History of Religion in the US,0.4,0.33,0.07,0.07,0.0,0.0,0.0,0.13,elizabeth jemison,,HIST-3100,2019
+HIST,3110,1,African American Hist to 1877,0.27,0.55,0.05,0.0,0.09,0.0,0.0,0.05,abel bartley,,HIST-3110,2019
+HIST,3170,1,Hist of NativeAm Rel & Culture,0.15,0.38,0.31,0.08,0.08,0.0,0.0,0.0,james brad jeffries,,HIST-3170,2019
+HIST,3220,1,History of Technology,0.39,0.43,0.0,0.04,0.07,0.0,0.0,0.07,pamela mack,,HIST-3220,2019
+HIST,3260,1,Hist Am Transport,0.62,0.21,0.1,0.0,0.0,0.0,0.0,0.07, roger grant,,HIST-3260,2019
+HIST,3290,1,US Legal History Since 1890,0.29,0.58,0.04,0.0,0.0,0.0,0.0,0.08,maribel morey,,HIST-3290,2019
+HIST,3290,2,US Legal History Since 1890,0.3,0.4,0.1,0.0,0.0,0.0,0.0,0.2,maribel morey,,HIST-3290,2019
+HIST,3300,1,Hist of Mod China,0.21,0.39,0.18,0.04,0.04,0.0,0.0,0.14,edwin moise,,HIST-3300,2019
+HIST,3400,1,Latin America I,0.64,0.29,0.04,0.0,0.0,0.0,0.0,0.04,rachel anne moore,,HIST-3400,2019
+HIST,3510,1,Ancient Near East,0.31,0.38,0.25,0.0,0.0,0.0,0.0,0.06,steven grosby,,HIST-3510,2019
+HIST,3550,1,Roman World,0.54,0.38,0.04,0.0,0.04,0.0,0.0,0.0,kathryn langenfeld,,HIST-3550,2019
+HIST,3610,1,History of Britain to 1688,0.45,0.41,0.1,0.0,0.0,0.0,0.0,0.03,caroline dunn clark,,HIST-3610,2019
+HIST,3670,1,Modern Ireland,0.56,0.3,0.07,0.0,0.0,0.0,0.0,0.07,michael silvestri,,HIST-3670,2019
+HIST,3890,1,Ben Robertson,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2, alan grubb,,HIST-3890,2019
+HIST,3890,2,History of Clemson House,0.83,0.0,0.17,0.0,0.0,0.0,0.0,0.0, alan grubb,,HIST-3890,2019
+HIST,3900,1,Modern Military History,0.15,0.42,0.31,0.0,0.0,0.0,0.0,0.12,edwin moise,,HIST-3900,2019
+HIST,3980,1,American Military History,0.37,0.4,0.17,0.03,0.03,0.0,0.0,0.0,john andrew,,HIST-3980,2019
+HIST,4380,1,Studies African History,0.67,0.0,0.17,0.0,0.17,0.0,0.0,0.0,stephanie hassell,,HIST-4380,2019
+HIST,4380,1,Studies African History,0.67,0.0,0.17,0.0,0.17,0.0,0.0,0.0,james burns,,HIST-4380,2019
+HIST,4700,1,Medieval Christianity,0.29,0.65,0.06,0.0,0.0,0.0,0.0,0.0,caroline dunn clark,,HIST-4700,2019
+HIST,4700,2,History of Florence,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,thomas kuehn,,HIST-4700,2019
+HIST,4710,1,History and Food,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1, alan grubb,,HIST-4710,2019
+HIST,4900,1,History of Disney Theme Parks,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,,HIST-4900,2019
+HIST,4900,2,Family and Kinship,0.18,0.36,0.36,0.0,0.0,0.0,0.0,0.09,thomas kuehn,,HIST-4900,2019
+HIST,4930,1,AfricanAm Soc & Intellectual H,0.71,0.24,0.05,0.0,0.0,0.0,0.0,0.0,abel bartley,,HIST-4930,2019
+HIST,8810,1,Historiography,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,stephani barczewski,,HIST-8810,2019
+HLTH,2020,2,Introduction to Public Health,0.67,0.13,0.17,0.04,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2020,2019
+HLTH,2020,400,Introduction to Public Health,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2020,2019
+HLTH,2020,402,Introduction to Public Health,0.42,0.26,0.26,0.0,0.0,0.0,0.0,0.05,ralph stewart welsh,,HLTH-2020,2019
+HLTH,2030,1,Health Care Sys,0.53,0.43,0.03,0.0,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2019
+HLTH,2030,2,Health Care Sys,0.64,0.24,0.04,0.08,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2030,2019
+HLTH,2030,3,Health Care Sys,0.82,0.15,0.0,0.0,0.03,0.0,0.0,0.0,lee alden crandall,,HLTH-2030,2019
+HLTH,2030,400,Health Care Sys,0.35,0.45,0.15,0.05,0.0,0.0,0.0,0.0,tanya lee staton,,HLTH-2030,2019
+HLTH,2400,1,Deter of Hlth Behav,0.52,0.31,0.17,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2019
+HLTH,2400,2,Deter of Hlth Behav,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,,HLTH-2400,2019
+HLTH,2400,400,Deter of Hlth Behav,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-2400,2019
+HLTH,2500,1,Health and Fitness,0.67,0.22,0.11,0.0,0.0,0.0,0.0,0.0,ralph stewart welsh,,HLTH-2500,2019
+HLTH,2600,1,Medical Terminology & Comm,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,karen edwards,,HLTH-2600,2019
+HLTH,2600,2,Medical Terminology & Comm,0.9,0.05,0.05,0.0,0.0,0.0,0.0,0.0,karen edwards,,HLTH-2600,2019
+HLTH,2980,1,Human Health and Disease,0.76,0.19,0.05,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2980,2019
+HLTH,2980,2,Human Health and Disease,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,becky ann tugman,,HLTH-2980,2019
+HLTH,2980,3,Human Health and Disease,0.5,0.41,0.09,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-2980,2019
+HLTH,3030,1,Public Health Comm,0.75,0.19,0.06,0.0,0.0,0.0,0.0,0.0,debra mitch charles,,HLTH-3030,2019
+HLTH,3800,1,Epidemiology,0.43,0.43,0.09,0.0,0.0,0.0,0.0,0.06,deborah alma falta,,HLTH-3800,2019
+HLTH,3980,1,Health Appraisal Skills,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2019
+HLTH,3980,2,Health Appraisal Skills,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-3980,2019
+HLTH,4020,1,Princ Hlth Fitness,0.33,0.42,0.25,0.0,0.0,0.0,0.0,0.0,karen kemper,,HLTH-4020,2019
+HLTH,4110,1,Hlth At-Risk Children & Fam,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,karyn jones,,HLTH-4110,2019
+HLTH,4190,1,Health Sci Internship Prep Sem,0.63,0.33,0.05,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4190,2019
+HLTH,4200,1,Hlth Science Intern,0.86,0.11,0.04,0.0,0.0,0.0,0.0,0.0,kathleen meyer,,HLTH-4200,2019
+HLTH,4310,1,Public & Environ Hlt,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,deborah alma falta,,HLTH-4310,2019
+HLTH,4600,1,Health Info Systems,0.64,0.21,0.14,0.0,0.0,0.0,0.0,0.0,ronald gimbel,,HLTH-4600,2019
+HLTH,4700,1,Global Health,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,micky rogers ward,,HLTH-4700,2019
+HLTH,4780,1,Health Policy Ethics and Law,0.39,0.39,0.17,0.0,0.0,0.0,0.0,0.06,hugh donald spitler,,HLTH-4780,2019
+HLTH,4790,1,Fin Mgmt & Hlth Budg,0.5,0.25,0.19,0.0,0.06,0.0,0.0,0.0,khoa dang truong,,HLTH-4790,2019
+HLTH,4800,1,Comm Hlth Promotion,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,johnny long,,HLTH-4800,2019
+HLTH,4900,1,Res Eval St Pub Hlth,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lu shi,,HLTH-4900,2019
+HLTH,4900,2,Res Eval St Pub Hlth,0.59,0.27,0.14,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-4900,2019
+HLTH,4900,3,Res Eval St Pub Hlth,0.48,0.43,0.09,0.0,0.0,0.0,0.0,0.0,jeffrey kingree,,HLTH-4900,2019
+HLTH,4980,1,Improving Pop Hlth,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,amelia clinkscales,,HLTH-4980,2019
+HLTH,4990,5,Aspire to Be Well CI,0.9,0.05,0.0,0.0,0.0,0.0,0.0,0.05,chloe caroli greene,,HLTH-4990,2019
+HLTH,8310,1,Quantitative Analy in Hlth I,0.8,0.1,0.1,0.0,0.0,0.0,0.0,0.0,lior mordec rennert,,HLTH-8310,2019
+HON,2020,1,Motivation and Learning,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,tyler watts,True,HON-2020,2019
+HON,2030,2,Putin's World,0.8,0.13,0.0,0.0,0.07,0.0,0.0,0.0,olga anatol volkova,True,HON-2030,2019
+HON,2060,1,Intro to Nanotechnology,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,olin mefford,True,HON-2060,2019
+HON,2060,1,Intro to Nanotechnology,0.69,0.25,0.0,0.0,0.0,0.0,0.0,0.06,christophe kitchens,True,HON-2060,2019
+HON,2060,2,Why We Eat What We Eat,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,True,HON-2060,2019
+HON,2060,3,Great Problems in Math,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,neil calkin,True,HON-2060,2019
+HON,2090,5,Crisis & Opportunity in Europe,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,william lasser,True,HON-2090,2019
+HON,2200,2,Europe in the Age of Dictators,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,amit bein,True,HON-2200,2019
+HON,2200,3,Global Policy Process,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey allen fine,True,HON-2200,2019
+HON,2210,1,Building Imaginary Worlds,0.95,0.0,0.05,0.0,0.0,0.0,0.0,0.0,april susanne pelt,True,HON-2210,2019
+HON,2210,3,Thinking About Love,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,dominic mastroianni,True,HON-2210,2019
+HON,2210,4,Movies as Time Travel,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,amy monaghan,True,HON-2210,2019
+HON,2210,5,"Migrants, Exiles, Refugees",0.95,0.0,0.0,0.0,0.0,0.0,0.0,0.05,lucian ghita,True,HON-2210,2019
+HORT,2020,1,Adobe Digital Design,0.81,0.06,0.03,0.0,0.03,0.0,0.0,0.06,janice ann lay,,HORT-2020,2019
+HORT,2110,1,Growing Spring Plnts,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,james emerson faust,,HORT-2110,2019
+HORT,4040,1,Plant Propagation,0.12,0.32,0.37,0.15,0.05,0.0,0.0,0.0,jeffrey adelberg,,HORT-4040,2019
+HORT,4050,1,Plant Propagation Techniq Lab,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,,HORT-4050,2019
+HORT,4080,4,CI: Hands on Water for Ag,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,sarah white,,HORT-4080,2019
+HORT,4080,4,CI: Hands on Water for Ag,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,lauren marie chance,,HORT-4080,2019
+HORT,4080,7,Sustain Landscpe Garden Design,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,ellen anita vincent,,HORT-4080,2019
+HORT,4090,1,Senior Capstone Course,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ellen anita vincent,,HORT-4090,2019
+HORT,4270,1,Urban Tree Care,0.0,0.3,0.2,0.1,0.0,0.0,0.0,0.4,robert polomski,,HORT-4270,2019
+HORT,4330,1,Weed Management,0.17,0.46,0.38,0.0,0.0,0.0,0.0,0.0,ted whitwell,,HORT-4330,2019
+HORT,4560,1,Vegetable Crops,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,dilruksh thavarajah,,HORT-4560,2019
+HORT,6040,1,Plant Propagation,0.67,0.17,0.17,0.0,0.0,0.0,0.0,0.0,jeffrey adelberg,,HORT-6040,2019
+HRD,8250,400,Org Perf Improvement,0.91,0.06,0.0,0.0,0.0,0.0,0.0,0.03,angela danie carter,,HRD-8250,2019
+HRD,8470,400,Instru System Design,0.79,0.07,0.0,0.0,0.03,0.0,0.0,0.1,angela danie carter,,HRD-8470,2019
+HRD,8490,400,Eval of T&D/Hrd Prog,0.9,0.07,0.0,0.0,0.0,0.0,0.0,0.03,angela danie carter,,HRD-8490,2019
+HRD,8800,400,Research Concepts,0.75,0.13,0.0,0.0,0.04,0.0,0.0,0.08,cynthia sims,,HRD-8800,2019
+IE,2100,1,Des Analysis Wrk Sys,0.68,0.32,0.0,0.0,0.0,0.0,0.0,0.0,xiaoxia li,,IE-2100,2019
+IE,3010,1,Systems Design I,0.85,0.12,0.03,0.0,0.0,0.0,0.0,0.0,amro nofa khasawneh,,IE-3010,2019
+IE,3140,1,Seminar in Industrial Engr,0.0,0.0,0.0,0.0,0.0,0.99,0.0,0.01,scott jenning mason,,IE-3140,2019
+IE,3600,1,Industrial Apps of Prob/Stat I,0.34,0.29,0.19,0.13,0.02,0.0,0.0,0.04,robert james riggs,,IE-3600,2019
+IE,3610,1,Industrial App of Prob/Stat II,0.48,0.25,0.18,0.03,0.02,0.0,0.0,0.05,katherina jurewicz,,IE-3610,2019
+IE,3800,1,Deterministic Operations Rsrch,0.28,0.47,0.17,0.04,0.0,0.0,0.03,0.0,sandra dun eksioglu,,IE-3800,2019
+IE,3810,1,Probabilistic Operations Rsrch,0.2,0.5,0.23,0.04,0.0,0.0,0.0,0.04,amin khademi,,IE-3810,2019
+IE,3840,1,Engr Econ Analysis,0.24,0.22,0.28,0.1,0.0,0.0,0.04,0.1,brian melloy,,IE-3840,2019
+IE,3860,1,Production Planning & Control,0.98,0.02,0.0,0.0,0.0,0.0,0.0,0.0,xiaoxia li,,IE-3860,2019
+IE,4040,15,Creative Inquiry Research,0.0,0.0,0.0,0.0,0.0,0.83,0.0,0.17,kevin taaffe,,IE-4040,2019
+IE,4400,1,Decision Support Sys,0.36,0.48,0.03,0.0,0.09,0.0,0.0,0.03,mary elizabeth kurz,,IE-4400,2019
+IE,4570,1,Transp/Logistic Engr,0.71,0.22,0.02,0.0,0.0,0.0,0.0,0.04,sandra dun eksioglu,,IE-4570,2019
+IE,4610,1,Quality Engineering,0.29,0.27,0.33,0.07,0.0,0.0,0.0,0.03,byung rae cho,,IE-4610,2019
+IE,4620,1,Six Sigma Quality,0.45,0.43,0.09,0.01,0.0,0.0,0.0,0.01,robert james riggs,,IE-4620,2019
+IE,4650,1,Facilities Planning & Design,0.49,0.31,0.08,0.05,0.0,0.0,0.01,0.06,brian melloy,,IE-4650,2019
+IE,4670,1,System Design II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,walter lawre garvin,,IE-4670,2019
+IE,4670,1,System Design II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,,IE-4670,2019
+IE,4670,2,System Design II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,walter lawre garvin,,IE-4670,2019
+IE,4670,2,System Design II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,jeffery messer,,IE-4670,2019
+IE,4820,1,Systems Modeling,0.26,0.37,0.21,0.1,0.03,0.0,0.0,0.02,tugce isik,,IE-4820,2019
+IE,4860,1,Scheduling,0.27,0.09,0.27,0.09,0.0,0.0,0.0,0.27,scott jenning mason,,IE-4860,2019
+IE,4880,1,Human Factors Eng,0.54,0.39,0.02,0.02,0.0,0.0,0.0,0.04,laura miche stanley,,IE-4880,2019
+IE,4910,1,Applied Bus. Princples for Eng,0.78,0.2,0.02,0.0,0.0,0.0,0.0,0.0,jeffery messer,,IE-4910,2019
+IE,6620,1,Six Sigma Quality,0.55,0.45,0.0,0.0,0.0,0.0,0.0,0.0,robert james riggs,,IE-6620,2019
+IE,6860,1,Scheduling,0.21,0.42,0.37,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-6860,2019
+IE,6910,1,Supply Chain/Logistics Model,0.61,0.36,0.0,0.0,0.0,0.0,0.0,0.04,william ferrell,,IE-6910,2019
+IE,8050,1,Found Qual Engr,0.18,0.73,0.08,0.0,0.0,0.0,0.0,0.02,byung rae cho,,IE-8050,2019
+IE,8520,1,Prescriptive Analytics,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan cole smith,,IE-8520,2019
+IE,8540,1,SC & Logistics Modeling I,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,william ferrell,,IE-8540,2019
+IE,8580,1,Case Study Supply Chn & Logist,0.68,0.27,0.05,0.0,0.0,0.0,0.0,0.0,scott jenning mason,,IE-8580,2019
+INNO,4990,990,CEDC - Risk in Puerto Rico,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david vaughn,,INNO-4990,2019
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,lisa marie robinson,,INT-1510,2019
+INT,1510,1,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,0.96,0.0,0.04,troy nunamaker,,INT-1510,2019
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,troy nunamaker,,INT-1530,2019
+INT,1530,1,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,0.97,0.0,0.03,caren kelley-hall,,INT-1530,2019
+IPM,4010,1,Principles of I P M,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,carmen blubaugh,,IPM-4010,2019
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,james dougl bennett,,IS-1010,2019
+IS,1010,1,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.88,0.0,0.13,joshua leona hudson,,IS-1010,2019
+IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,james dougl bennett,,IS-1010,2019
+IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,joshua leona hudson,,IS-1010,2019
+IS,1010,3,CCA International Experience,0.0,0.0,0.0,0.0,0.0,0.9,0.0,0.1,meredith fan wilson,,IS-1010,2019
+IS,2100,615,Sel Top International Studies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,meredith fan wilson,,IS-2100,2019
+IS,2100,615,Sel Top International Studies,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,joshua leona hudson,,IS-2100,2019
+IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,,IS-2100,2019
+IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,joshua leona hudson,,IS-2100,2019
+IS,2100,616,"Serbian Lang., Culture & Hist.",0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,meredith fan wilson,,IS-2100,2019
+ITAL,1010,1,Elementary Italian,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,,ITAL-1010,2019
+ITAL,1020,1,Elementary Italian,0.45,0.27,0.18,0.0,0.0,0.0,0.0,0.09,julia schmidt,,ITAL-1020,2019
+ITAL,1020,2,Elementary Italian,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,luca barattoni,,ITAL-1020,2019
+ITAL,1020,3,Elementary Italian,0.45,0.45,0.09,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-1020,2019
+ITAL,2020,1,Intermediate Italian,0.57,0.3,0.13,0.0,0.0,0.0,0.0,0.0,julia schmidt,,ITAL-2020,2019
+JAPN,1010,1,Elementary Japanese,0.4,0.2,0.2,0.0,0.0,0.0,0.0,0.2,saori suto,,JAPN-1010,2019
+JAPN,1010,2,Elementary Japanese,0.41,0.29,0.18,0.06,0.0,0.0,0.0,0.06,saori suto,,JAPN-1010,2019
+JAPN,1020,2,Elementary Japanese,0.45,0.14,0.32,0.05,0.0,0.0,0.0,0.05,satomi saito,,JAPN-1020,2019
+JAPN,2020,1,Intermed Japanese,0.6,0.3,0.0,0.0,0.1,0.0,0.0,0.0,saori suto,,JAPN-2020,2019
+JAPN,3060,1,Japanese Conversation & Comp,0.5,0.3,0.2,0.0,0.0,0.0,0.0,0.0,kumiko saito,,JAPN-3060,2019
+JAPN,4170,2,Japanese Culture and Society,0.73,0.09,0.18,0.0,0.0,0.0,0.0,0.0,jae allegr takeuchi,,JAPN-4170,2019
+JUST,2880,1,The Criminal Justice System,0.41,0.31,0.19,0.02,0.05,0.0,0.0,0.02,margaret tina britz,,JUST-2880,2019
+JUST,2890,1,Criminology,0.39,0.31,0.2,0.06,0.0,0.0,0.0,0.04,matthew jo costello,,JUST-2890,2019
+JUST,4280,1,Criminal Law,0.18,0.55,0.23,0.05,0.0,0.0,0.0,0.0,rhys hester,,JUST-4280,2019
+JUST,4910,1,Policing,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,shelagh dorn,,JUST-4910,2019
+JUST,4930,1,Corrections,0.85,0.11,0.0,0.0,0.0,0.0,0.0,0.04,catherine el burton,,JUST-4930,2019
+JUST,4940,1,Organized Crime,0.33,0.33,0.19,0.08,0.06,0.0,0.0,0.0,margaret tina britz,,JUST-4940,2019
+JUST,4970,1,Criminal Justice Capstone,0.7,0.22,0.0,0.0,0.04,0.0,0.0,0.04,catherine el burton,,JUST-4970,2019
+JUST,4990,1,Criminal Courts,0.28,0.32,0.36,0.0,0.0,0.0,0.0,0.04,rhys hester,,JUST-4990,2019
+JUST,4990,2,Ethics in Criminal Justice,0.74,0.17,0.04,0.0,0.0,0.0,0.0,0.04,lance christ miller,,JUST-4990,2019
+LANG,2540,1,Introduction to World Cinemas,0.75,0.1,0.1,0.0,0.0,0.0,0.0,0.05,raquel anido,,LANG-2540,2019
+LANG,2540,2,Introduction to World Cinemas,0.6,0.35,0.05,0.0,0.0,0.0,0.0,0.0,olga anatol volkova,,LANG-2540,2019
+LARC,1160,1,History of Landscape Arch,0.35,0.38,0.17,0.07,0.01,0.0,0.0,0.01,hala fouad nassar,,LARC-1160,2019
+LARC,1160,2,History of Landscape Arch,0.27,0.47,0.13,0.13,0.0,0.0,0.0,0.0,hala fouad nassar,,LARC-1160,2019
+LARC,1520,1,Basic Design II,0.53,0.42,0.0,0.0,0.0,0.0,0.0,0.05,maria debye counts,,LARC-1520,2019
+LARC,2550,1,Community Design Studio,0.74,0.16,0.05,0.0,0.0,0.0,0.05,0.0,matthew neal powers,,LARC-2550,2019
+LARC,3620,1,Design Implementation II,0.67,0.1,0.14,0.0,0.1,0.0,0.0,0.0,robert hewitt,,LARC-3620,2019
+LARC,4280,1,Computer-Aided Design,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,jueminsi wu,,LARC-4280,2019
+LARC,4280,1,Computer-Aided Design,0.69,0.19,0.06,0.0,0.0,0.0,0.0,0.06,xiaotong liu,,LARC-4280,2019
+LARC,4550,1,Landscape Arch Exit Project,0.45,0.45,0.0,0.09,0.0,0.0,0.0,0.0,mary padua,,LARC-4550,2019
+LARC,4720,1,South Carolina's Landscapes,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,mary padua,,LARC-4720,2019
+LARC,4810,1,Professional Practice,0.67,0.2,0.13,0.0,0.0,0.0,0.0,0.0,christopher counts,,LARC-4810,2019
+LARC,4900,1,Urban Issues in Landscape Arch,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,thomas will schurch,,LARC-4900,2019
+LARC,4900,400,Arch History of Place,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,jason matthew white,,LARC-4900,2019
+LARC,4970,8,Planting Design,0.74,0.13,0.04,0.0,0.04,0.0,0.0,0.04,matthew neal powers,,LARC-4970,2019
+LARC,8520,1,Advanced Urban Design,0.6,0.2,0.2,0.0,0.0,0.0,0.0,0.0,robert hewitt,,LARC-8520,2019
+LAW,3220,1,Legal Env of Bus,0.27,0.33,0.36,0.0,0.0,0.0,0.0,0.04,kenneth toussaint,,LAW-3220,2019
+LAW,3220,2,Legal Env of Bus,0.16,0.53,0.29,0.0,0.0,0.0,0.0,0.02,kenneth toussaint,,LAW-3220,2019
+LAW,3220,3,Legal Env of Bus,0.16,0.41,0.36,0.02,0.0,0.0,0.0,0.05,kenneth toussaint,,LAW-3220,2019
+LAW,3220,4,Legal Env of Bus,0.31,0.49,0.13,0.04,0.0,0.0,0.0,0.02,edward ray claggett,,LAW-3220,2019
+LAW,3220,5,Legal Env of Bus,0.11,0.62,0.22,0.04,0.0,0.0,0.0,0.0,judson jahn,,LAW-3220,2019
+LAW,3220,6,Legal Env of Bus,0.24,0.51,0.24,0.0,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2019
+LAW,3220,7,Legal Env of Bus,0.24,0.47,0.27,0.02,0.0,0.0,0.0,0.0,judson jahn,,LAW-3220,2019
+LAW,3220,8,Legal Env of Bus,0.59,0.32,0.09,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-3220,2019
+LAW,3220,9,Legal Env of Bus,0.44,0.47,0.09,0.0,0.0,0.0,0.0,0.0,christopher edwards,,LAW-3220,2019
+LAW,3220,10,Legal Env of Bus,0.27,0.47,0.2,0.04,0.0,0.0,0.0,0.02,john hine,,LAW-3220,2019
+LAW,3220,11,Legal Env of Bus,0.27,0.36,0.3,0.0,0.05,0.0,0.0,0.02,john hine,,LAW-3220,2019
+LAW,3220,401,Legal Env of Bus,0.45,0.31,0.17,0.03,0.0,0.0,0.0,0.03,virgini ward-vaughn,,LAW-3220,2019
+LAW,3220,402,Legal Env of Bus,0.32,0.37,0.12,0.03,0.03,0.0,0.0,0.12,virgini ward-vaughn,,LAW-3220,2019
+LAW,3220,403,Legal Env of Bus,0.25,0.41,0.21,0.02,0.07,0.0,0.0,0.04,virgini ward-vaughn,,LAW-3220,2019
+LAW,3220,404,Legal Env of Bus,0.25,0.4,0.21,0.07,0.0,0.0,0.02,0.05,virgini ward-vaughn,,LAW-3220,2019
+LAW,3220,601,Legal Env of Bus,0.31,0.65,0.04,0.0,0.0,0.0,0.0,0.0,edward ray claggett,,LAW-3220,2019
+LAW,3330,1,Real Estate Law,0.15,0.27,0.37,0.17,0.05,0.0,0.0,0.0,kenneth toussaint,,LAW-3330,2019
+LAW,4200,1,Int Business Law,0.2,0.55,0.2,0.0,0.0,0.0,0.0,0.05,frances edwards,,LAW-4200,2019
+LAW,4990,1,Selected Topics - Cyber Law,0.71,0.18,0.12,0.0,0.0,0.0,0.0,0.0,frances edwards,,LAW-4990,2019
+LAW,8480,1,Law Real Estate Prof,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,michael le brearley,,LAW-8480,2019
+LAW,8480,1,Law Real Estate Prof,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,james ivey warren,,LAW-8480,2019
+LS,1000,2,Fitness Leadership,0.79,0.0,0.0,0.0,0.0,0.0,0.0,0.21,jenny lynn rodgers,,LS-1000,2019
+LS,1000,4,Introduction to Barre,0.74,0.11,0.05,0.0,0.0,0.0,0.0,0.11,diane moreno,,LS-1000,2019
+LS,1000,5,Introduction to Barre,0.71,0.0,0.06,0.06,0.0,0.0,0.0,0.18,diane moreno,,LS-1000,2019
+LS,1000,9,Intro to Salsa Dance,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,malik lewis baxter,,LS-1000,2019
+LS,1000,19,Therapeutic Yoga,0.8,0.15,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,,LS-1000,2019
+LS,1000,21,Therapeutic Yoga,0.74,0.11,0.0,0.0,0.0,0.0,0.0,0.16,ranjanbala dil amin,,LS-1000,2019
+LS,1000,23,Therapeutic Yoga,0.71,0.08,0.08,0.04,0.0,0.0,0.0,0.08,renee warren gahan,,LS-1000,2019
+LS,1130,1,Wood Carving,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,louwanda jolley,,LS-1130,2019
+LS,1410,2,Top Rope Climbing,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,thomas caldwell,,LS-1410,2019
+LS,1560,13,Riflery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,herbert strickland,,LS-1560,2019
+LS,1560,19,Riflery,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,dominic cirocco,,LS-1560,2019
+LS,1580,1,Archery,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,herbert strickland,,LS-1580,2019
+LS,1580,3,Archery,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,herbert strickland,,LS-1580,2019
+LS,1580,5,Archery,0.83,0.08,0.0,0.08,0.0,0.0,0.0,0.0,herbert strickland,,LS-1580,2019
+LS,1650,1,Inland Kayak Touring,0.82,0.0,0.09,0.0,0.09,0.0,0.0,0.0,caitlin miche henry,,LS-1650,2019
+LS,1650,5,Inland Kayak Touring,0.7,0.0,0.2,0.0,0.0,0.0,0.0,0.1,merry han armstrong,,LS-1650,2019
+LS,1960,2,Intro to Billiards,0.86,0.07,0.0,0.0,0.0,0.0,0.0,0.07,broadus fleming,,LS-1960,2019
+LS,2200,2,Shag,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,broadus fleming,,LS-2200,2019
+LS,2270,1,Intro to Swing Dance,0.9,0.03,0.03,0.0,0.0,0.0,0.0,0.03,paul hoke,,LS-2270,2019
+LS,2270,4,Intro to Swing Dance,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,paul hoke,,LS-2270,2019
+LS,2320,1,Core Training,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,diane moreno,,LS-2320,2019
+LS,2320,3,Core Training,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,diane moreno,,LS-2320,2019
+LS,2320,5,Core Training,0.83,0.08,0.0,0.0,0.04,0.0,0.0,0.04,diane moreno,,LS-2320,2019
+LS,2350,1,Basic Yoga,0.79,0.16,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,,LS-2350,2019
+LS,2350,2,Basic Yoga,0.85,0.05,0.0,0.0,0.0,0.0,0.0,0.1,kayla lee wardlaw,,LS-2350,2019
+LS,2350,3,Basic Yoga,0.87,0.0,0.04,0.0,0.0,0.0,0.0,0.09,silica eliza larkin,,LS-2350,2019
+LS,2350,5,Basic Yoga,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2350,2019
+LS,2360,1,Power/Ashtanga Yoga,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,silica eliza larkin,,LS-2360,2019
+LS,2360,2,Power/Ashtanga Yoga,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,silica eliza larkin,,LS-2360,2019
+LS,2380,4,Vinyasa Flow Yoga,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kayla lee wardlaw,,LS-2380,2019
+LS,2420,1,Meditation and Relax,0.77,0.18,0.0,0.0,0.0,0.0,0.0,0.05,kayla lee wardlaw,,LS-2420,2019
+LS,2420,3,Meditation and Relax,0.79,0.13,0.04,0.0,0.0,0.0,0.0,0.04,renee warren gahan,,LS-2420,2019
+LS,2420,4,Meditation and Relax,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,renee warren gahan,,LS-2420,2019
+LS,2420,10,Meditation and Relax,0.79,0.13,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,,LS-2420,2019
+LS,2420,11,Meditation and Relax,0.85,0.08,0.0,0.0,0.0,0.0,0.0,0.08,ranjanbala dil amin,,LS-2420,2019
+LS,2420,12,Meditation and Relax,0.87,0.04,0.04,0.0,0.0,0.0,0.0,0.04,ranjanbala dil amin,,LS-2420,2019
+LS,2420,13,Meditation and Relax,0.82,0.14,0.0,0.0,0.0,0.0,0.0,0.05,ranjanbala dil amin,,LS-2420,2019
+LS,2450,2,Pilates,0.86,0.0,0.07,0.0,0.0,0.0,0.0,0.07,melanie ivey job,,LS-2450,2019
+LS,2450,4,Pilates,0.9,0.0,0.05,0.0,0.0,0.0,0.0,0.05,diane moreno,,LS-2450,2019
+LS,2450,5,Pilates,0.88,0.04,0.0,0.0,0.0,0.0,0.0,0.08,diane moreno,,LS-2450,2019
+LS,2450,8,Pilates,0.85,0.0,0.0,0.0,0.0,0.0,0.0,0.15,melanie ivey job,,LS-2450,2019
+LS,2510,1,Running & Jogging,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,corey dou brookover,,LS-2510,2019
+MATH,1010,1,Essen Math for Informed Soc,0.5,0.25,0.13,0.13,0.0,0.0,0.0,0.0,marilyn reba,,MATH-1010,2019
+MATH,1010,2,Essen Math for Informed Soc,0.36,0.25,0.22,0.06,0.0,0.0,0.0,0.11,marilyn reba,,MATH-1010,2019
+MATH,1010,3,Essen Math for Informed Soc,0.47,0.35,0.09,0.09,0.0,0.0,0.0,0.0,seth selken,,MATH-1010,2019
+MATH,1010,4,Essen Math for Informed Soc,0.52,0.24,0.09,0.03,0.06,0.0,0.0,0.06,bryce pruitt,,MATH-1010,2019
+MATH,1020,1,Business Calculus I,0.18,0.24,0.28,0.13,0.08,0.0,0.0,0.08,randy davidson,,MATH-1020,2019
+MATH,1020,2,Business Calculus I,0.23,0.31,0.23,0.07,0.05,0.0,0.0,0.1,randy davidson,,MATH-1020,2019
+MATH,1020,3,Business Calculus I,0.18,0.35,0.12,0.18,0.12,0.0,0.0,0.06,zachary david espe,,MATH-1020,2019
+MATH,1020,4,Business Calculus I,0.12,0.27,0.24,0.21,0.12,0.0,0.0,0.03,andrew bellucco,,MATH-1020,2019
+MATH,1020,5,Business Calculus I,0.15,0.29,0.29,0.18,0.06,0.0,0.0,0.03,thowhida akther,,MATH-1020,2019
+MATH,1020,6,Business Calculus I,0.18,0.41,0.21,0.1,0.05,0.0,0.0,0.05,nathaniel nemire,,MATH-1020,2019
+MATH,1020,7,Business Calculus I,0.28,0.18,0.25,0.08,0.18,0.0,0.0,0.05,thowhida akther,,MATH-1020,2019
+MATH,1020,8,Business Calculus I,0.17,0.17,0.32,0.22,0.0,0.0,0.05,0.07,thowhida akther,,MATH-1020,2019
+MATH,1020,9,Business Calculus I,0.2,0.32,0.32,0.05,0.04,0.0,0.0,0.07,marion hanna,,MATH-1020,2019
+MATH,1020,10,Business Calculus I,0.22,0.24,0.17,0.12,0.15,0.0,0.0,0.1,shanshan jia,,MATH-1020,2019
+MATH,1020,11,Business Calculus I,0.35,0.33,0.25,0.03,0.05,0.0,0.0,0.0,cameron arnold,,MATH-1020,2019
+MATH,1040,2,Precalc & Intro Differen Calc,0.0,0.0,0.0,0.0,0.0,0.85,0.0,0.15,nathan fontes,,MATH-1040,2019
+MATH,1060,1,Calculus of One Variable I,0.04,0.14,0.39,0.14,0.21,0.0,0.0,0.09,judith cottingham,,MATH-1060,2019
+MATH,1060,2,Calculus of One Variable I,0.08,0.26,0.34,0.13,0.18,0.0,0.0,0.0,catherine ma kenyon,,MATH-1060,2019
+MATH,1060,3,Calculus of One Variable I,0.06,0.17,0.39,0.11,0.19,0.0,0.0,0.08,steven taylo edalgo,,MATH-1060,2019
+MATH,1060,4,Calculus of One Variable I,0.09,0.3,0.33,0.09,0.09,0.0,0.0,0.09,marilyn reba,,MATH-1060,2019
+MATH,1060,5,Calculus of One Variable I,0.14,0.14,0.25,0.11,0.14,0.0,0.0,0.21,luther duncan,,MATH-1060,2019
+MATH,1070,1,Differen and Integral Calculus,0.4,0.4,0.15,0.0,0.0,0.0,0.0,0.05,donna simms,,MATH-1070,2019
+MATH,1070,2,Differen and Integral Calculus,0.18,0.36,0.36,0.05,0.03,0.0,0.0,0.03,donna simms,,MATH-1070,2019
+MATH,1070,3,Differen and Integral Calculus,0.18,0.38,0.26,0.09,0.06,0.0,0.0,0.03,stephen peele,,MATH-1070,2019
+MATH,1070,4,Differen and Integral Calculus,0.19,0.24,0.38,0.14,0.0,0.0,0.0,0.05,peter westerbaan,,MATH-1070,2019
+MATH,1070,5,Differen and Integral Calculus,0.13,0.47,0.25,0.03,0.13,0.0,0.0,0.0,scott scruggs,,MATH-1070,2019
+MATH,1070,6,Differen and Integral Calculus,0.07,0.48,0.43,0.02,0.0,0.0,0.0,0.0,stephen peele,,MATH-1070,2019
+MATH,1080,1,Calculus of One Variable II,0.38,0.35,0.2,0.0,0.0,0.0,0.0,0.08,stephen peele,,MATH-1080,2019
+MATH,1080,2,Calculus of One Variable II,0.43,0.23,0.2,0.09,0.03,0.0,0.0,0.03,blake anth splitter,,MATH-1080,2019
+MATH,1080,3,Calculus of One Variable II,0.18,0.23,0.36,0.05,0.14,0.0,0.0,0.05,timothy fra parrott,,MATH-1080,2019
+MATH,1080,4,Calculus of One Variable II,0.18,0.24,0.24,0.05,0.08,0.0,0.0,0.21,timothy fra parrott,,MATH-1080,2019
+MATH,1080,5,Calculus of One Variable II,0.36,0.28,0.26,0.0,0.05,0.0,0.0,0.05,hugh geller,,MATH-1080,2019
+MATH,1080,6,Calculus of One Variable II,0.13,0.37,0.3,0.05,0.0,0.0,0.09,0.06,timothy ch teitloff,,MATH-1080,2019
+MATH,1080,7,Calculus of One Variable II,0.14,0.3,0.28,0.02,0.09,0.0,0.0,0.18,timothy ch teitloff,,MATH-1080,2019
+MATH,1080,100,Calc of One Variable II (HON),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,timothy fra parrott,True,MATH-1080,2019
+MATH,1080,201,Calculus of One Variable II,0.12,0.12,0.35,0.15,0.03,0.0,0.0,0.24,timothy fra parrott,,MATH-1080,2019
+MATH,1080,202,Calculus of One Variable II,0.4,0.42,0.12,0.02,0.02,0.0,0.0,0.02,james edwar gossell,,MATH-1080,2019
+MATH,1080,203,Calculus of One Variable II,0.25,0.39,0.16,0.0,0.07,0.0,0.0,0.14,andrew walton green,,MATH-1080,2019
+MATH,1080,204,Calculus of One Variable II,0.1,0.46,0.34,0.0,0.0,0.0,0.0,0.1,sofya alekseeva,,MATH-1080,2019
+MATH,1080,205,Calculus of One Variable II,0.15,0.23,0.38,0.0,0.0,0.0,0.0,0.25,sofya alekseeva,,MATH-1080,2019
+MATH,1080,206,Calculus of One Variable II,0.13,0.38,0.23,0.05,0.03,0.0,0.0,0.2,sofya alekseeva,,MATH-1080,2019
+MATH,1160,1,Contemp Math for Elem Teach II,0.52,0.3,0.18,0.0,0.0,0.0,0.0,0.0,allison ke stoddard,,MATH-1160,2019
+MATH,1160,2,Contemp Math for Elem Teach II,0.57,0.37,0.04,0.0,0.0,0.0,0.0,0.02,allison ke stoddard,,MATH-1160,2019
+MATH,2060,1,Calculus of Several Variables,0.09,0.06,0.09,0.15,0.29,0.0,0.0,0.32,terri johnson,,MATH-2060,2019
+MATH,2060,2,Calculus of Several Variables,0.03,0.13,0.23,0.2,0.1,0.0,0.0,0.3,terri johnson,,MATH-2060,2019
+MATH,2060,3,Calculus of Several Variables,0.24,0.15,0.24,0.09,0.12,0.0,0.0,0.18,terri johnson,,MATH-2060,2019
+MATH,2060,4,Calculus of Several Variables,0.03,0.2,0.27,0.13,0.1,0.0,0.0,0.27,julie lassiter,,MATH-2060,2019
+MATH,2060,5,Calculus of Several Variables,0.0,0.18,0.24,0.09,0.3,0.0,0.0,0.18,julie lassiter,,MATH-2060,2019
+MATH,2060,6,Calculus of Several Variables,0.26,0.34,0.16,0.08,0.13,0.0,0.0,0.03,sanwar ahmad,,MATH-2060,2019
+MATH,2060,7,Calculus of Several Variables,0.32,0.32,0.19,0.08,0.08,0.0,0.0,0.0,allen anderso guest,,MATH-2060,2019
+MATH,2060,8,Calculus of Several Variables,0.23,0.29,0.19,0.1,0.13,0.0,0.0,0.06,allen anderso guest,,MATH-2060,2019
+MATH,2060,9,Calculus of Several Variables,0.24,0.35,0.29,0.03,0.06,0.0,0.0,0.03,allen anderso guest,,MATH-2060,2019
+MATH,2060,201,Calculus of Several Variables,0.52,0.39,0.06,0.0,0.0,0.0,0.0,0.03,camille zerfas,,MATH-2060,2019
+MATH,2070,1,Business Calculus II,0.45,0.21,0.21,0.05,0.0,0.0,0.0,0.08,jennifer mari hanna,,MATH-2070,2019
+MATH,2070,2,Business Calculus II,0.32,0.34,0.16,0.13,0.0,0.0,0.0,0.05,jennifer mari hanna,,MATH-2070,2019
+MATH,2070,3,Business Calculus II,0.45,0.24,0.18,0.03,0.05,0.0,0.0,0.05,xiaoyuan liu,,MATH-2070,2019
+MATH,2070,4,Business Calculus II,0.22,0.3,0.28,0.11,0.02,0.0,0.0,0.06,jennifer ray newton,,MATH-2070,2019
+MATH,2070,5,Business Calculus II,0.38,0.33,0.18,0.1,0.0,0.0,0.0,0.0,jennifer mari hanna,,MATH-2070,2019
+MATH,2070,6,Business Calculus II,0.38,0.44,0.13,0.05,0.0,0.0,0.0,0.0,jennifer mari hanna,,MATH-2070,2019
+MATH,2070,7,Business Calculus II,0.21,0.46,0.26,0.05,0.0,0.0,0.0,0.03,kayla doris javier,,MATH-2070,2019
+MATH,2070,8,Business Calculus II,0.31,0.19,0.28,0.22,0.0,0.0,0.0,0.0,travis alvarez,,MATH-2070,2019
+MATH,2070,9,Business Calculus II,0.26,0.32,0.18,0.13,0.0,0.0,0.03,0.08,molly adam honecker,,MATH-2070,2019
+MATH,2070,10,Business Calculus II,0.14,0.33,0.33,0.08,0.08,0.0,0.0,0.03,ebenezer eduafo,,MATH-2070,2019
+MATH,2070,11,Business Calculus II,0.32,0.32,0.29,0.05,0.0,0.0,0.0,0.03,aaron moose,,MATH-2070,2019
+MATH,2070,12,Business Calculus II,0.31,0.36,0.18,0.08,0.0,0.0,0.05,0.03,anna caro bachstein,,MATH-2070,2019
+MATH,2070,13,Business Calculus II,0.4,0.29,0.15,0.07,0.02,0.0,0.0,0.06,jennifer ray newton,,MATH-2070,2019
+MATH,2070,14,Business Calculus II,0.39,0.42,0.14,0.03,0.0,0.0,0.0,0.03,jennifer van dyken,,MATH-2070,2019
+MATH,2070,15,Business Calculus II,0.29,0.52,0.1,0.0,0.1,0.0,0.0,0.0,tony thanh nguyen,,MATH-2070,2019
+MATH,2080,1,Intro to Ordin Diff Equations,0.19,0.27,0.32,0.07,0.08,0.0,0.0,0.07,pye phyo aung,,MATH-2080,2019
+MATH,2080,2,Intro to Ordin Diff Equations,0.2,0.39,0.32,0.06,0.01,0.0,0.0,0.02,pye phyo aung,,MATH-2080,2019
+MATH,2080,3,Intro to Ordin Diff Equations,0.35,0.47,0.13,0.01,0.0,0.0,0.01,0.03,oleg yordanov,,MATH-2080,2019
+MATH,2080,4,Intro to Ordin Diff Equations,0.22,0.5,0.23,0.03,0.01,0.0,0.0,0.01,oleg yordanov,,MATH-2080,2019
+MATH,2080,5,Intro to Ordin Diff Equations,0.28,0.35,0.24,0.06,0.03,0.0,0.0,0.04,jeong rock yoon,,MATH-2080,2019
+MATH,2080,6,Intro to Ordin Diff Equations,0.36,0.28,0.25,0.05,0.02,0.0,0.0,0.04,irina viktorova,,MATH-2080,2019
+MATH,2080,100,Intro to Ordin Diff Eqns (HON),0.54,0.41,0.05,0.0,0.0,0.0,0.0,0.0,matthew macauley,True,MATH-2080,2019
+MATH,2160,1,Geometry for Elem Sch Teachers,0.79,0.08,0.0,0.04,0.0,0.0,0.0,0.08,nicole alai sinwell,,MATH-2160,2019
+MATH,2190,1,Introduction to Cryptography,0.47,0.32,0.16,0.0,0.0,0.0,0.0,0.05,felice manganiello,,MATH-2190,2019
+MATH,3020,1,Stat for Science & Engineering,0.25,0.48,0.15,0.0,0.03,0.0,0.0,0.1,xiaoqian sun,,MATH-3020,2019
+MATH,3020,2,Stat for Science & Engineering,0.78,0.15,0.08,0.0,0.0,0.0,0.0,0.0,jason alexande kurz,,MATH-3020,2019
+MATH,3020,3,Stat for Science & Engineering,0.68,0.23,0.03,0.03,0.0,0.0,0.0,0.05,haotian feng,,MATH-3020,2019
+MATH,3020,4,Stat for Science & Engineering,0.35,0.45,0.08,0.0,0.0,0.0,0.0,0.13,todd fenstermacher,,MATH-3020,2019
+MATH,3020,5,Stat for Science & Engineering,0.36,0.38,0.08,0.08,0.0,0.0,0.0,0.1, kamronnaher,,MATH-3020,2019
+MATH,3020,6,Stat for Science & Engineering,0.73,0.12,0.15,0.0,0.0,0.0,0.0,0.0,jayasekara merenchig,,MATH-3020,2019
+MATH,3020,7,Stat for Science & Engineering,0.49,0.32,0.15,0.02,0.0,0.0,0.0,0.02,ellen hepfe breazel,,MATH-3020,2019
+MATH,3020,8,Stat for Science & Engineering,0.51,0.32,0.02,0.05,0.0,0.0,0.0,0.1,rui gong,,MATH-3020,2019
+MATH,3110,1,Linear Algebra,0.15,0.44,0.26,0.09,0.0,0.0,0.0,0.06,michael adam burr,,MATH-3110,2019
+MATH,3110,2,Linear Algebra,0.28,0.25,0.31,0.11,0.0,0.0,0.03,0.03,michael adam burr,,MATH-3110,2019
+MATH,3110,4,Linear Algebra,0.29,0.29,0.15,0.24,0.03,0.0,0.0,0.0,mishko mitkovski,,MATH-3110,2019
+MATH,3110,5,Linear Algebra,0.46,0.31,0.13,0.03,0.03,0.0,0.0,0.04,nant ramiharimanana,,MATH-3110,2019
+MATH,3110,6,Linear Algebra,0.33,0.3,0.11,0.05,0.0,0.0,0.07,0.14,nant ramiharimanana,,MATH-3110,2019
+MATH,3110,8,Linear Algebra,0.37,0.26,0.29,0.05,0.03,0.0,0.0,0.0,hui xue,,MATH-3110,2019
+MATH,3110,200,Linear Algebra,0.25,0.25,0.31,0.13,0.0,0.0,0.0,0.06,svetlan poznanovikj,,MATH-3110,2019
+MATH,3190,1,Introduction to Proof,0.62,0.14,0.14,0.05,0.03,0.0,0.0,0.03,beth novick,,MATH-3190,2019
+MATH,3190,2,Introduction to Proof,0.62,0.22,0.11,0.0,0.03,0.0,0.0,0.03,beth novick,,MATH-3190,2019
+MATH,3600,1,Intermediate Math Computing,0.68,0.26,0.0,0.05,0.0,0.0,0.0,0.0,mark cawood,,MATH-3600,2019
+MATH,3600,2,Intermediate Math Computing,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,mark cawood,,MATH-3600,2019
+MATH,3650,1,Numerical Mthds for Engineers,0.54,0.33,0.08,0.03,0.03,0.0,0.0,0.0,fei xue,,MATH-3650,2019
+MATH,3650,2,Numerical Mthds for Engineers,0.28,0.28,0.2,0.03,0.0,0.0,0.0,0.23,alistair bentley,,MATH-3650,2019
+MATH,3650,3,Numerical Mthds for Engineers,0.38,0.28,0.2,0.0,0.13,0.0,0.0,0.03,alistair bentley,,MATH-3650,2019
+MATH,3650,4,Numerical Mthds for Engineers,0.31,0.36,0.05,0.1,0.05,0.0,0.0,0.13,alistair bentley,,MATH-3650,2019
+MATH,4000,1,Theory of Probability,0.22,0.34,0.24,0.07,0.02,0.0,0.0,0.1,brian fralix,,MATH-4000,2019
+MATH,4030,1,Intro to Statistical Theory,0.71,0.07,0.07,0.0,0.0,0.0,0.0,0.14,qiong zhang,,MATH-4030,2019
+MATH,4070,1,Regress & Time-Series Analysis,0.38,0.46,0.15,0.0,0.0,0.0,0.0,0.0,robert lund,,MATH-4070,2019
+MATH,4100,1,Number Theory,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,hui xue,,MATH-4100,2019
+MATH,4120,1,Algebra I,0.24,0.38,0.17,0.0,0.1,0.0,0.0,0.1,james ba coykendall,,MATH-4120,2019
+MATH,4190,1,Discrete Math Structures I,0.67,0.28,0.05,0.0,0.0,0.0,0.0,0.0,beth novick,,MATH-4190,2019
+MATH,4190,2,Discrete Math Structures I,0.43,0.39,0.11,0.04,0.0,0.0,0.0,0.04,matthew macauley,,MATH-4190,2019
+MATH,4310,1,Theory of Interest,0.35,0.35,0.2,0.1,0.0,0.0,0.0,0.0, erwin walker,,MATH-4310,2019
+MATH,4320,1,Actuarial Science Seminar II,0.53,0.13,0.27,0.0,0.0,0.0,0.0,0.07, erwin walker,,MATH-4320,2019
+MATH,4340,1,Adv Engineering Mathematics,0.2,0.29,0.17,0.17,0.09,0.0,0.0,0.09,hyesuk lee,,MATH-4340,2019
+MATH,4340,2,Adv Engineering Mathematics,0.18,0.15,0.36,0.06,0.15,0.0,0.0,0.09,vincent ervin,,MATH-4340,2019
+MATH,4400,1,Linear Programming,0.49,0.31,0.09,0.03,0.03,0.0,0.0,0.06,yuyuan ouyang,,MATH-4400,2019
+MATH,4530,1,Advanced Calculus I,0.08,0.25,0.33,0.17,0.17,0.0,0.0,0.0,james peterson,,MATH-4530,2019
+MATH,4540,1,Advanced Calculus II,0.46,0.33,0.13,0.04,0.0,0.0,0.0,0.04,james peterson,,MATH-4540,2019
+MATH,4990,1,Creative Inq-Math Sciences,0.5,0.17,0.17,0.0,0.17,0.0,0.0,0.0,ellen hepfe breazel,,MATH-4990,2019
+MATH,6000,1,Theory of Probability,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,brian fralix,,MATH-6000,2019
+MATH,6340,1,Adv Engineering Mathematics,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,vincent ervin,,MATH-6340,2019
+MATH,8030,1,Stochastic Processes,0.77,0.15,0.0,0.0,0.0,0.0,0.0,0.08,xin liu,,MATH-8030,2019
+MATH,8040,1,Statistical Inference,0.55,0.41,0.0,0.0,0.0,0.0,0.0,0.05,colin gallagher,,MATH-8040,2019
+MATH,8050,1,Data Analysis,0.67,0.08,0.08,0.0,0.0,0.0,0.0,0.17,xiaoqian sun,,MATH-8050,2019
+MATH,8100,1,Mathematical Programming,0.27,0.36,0.27,0.0,0.09,0.0,0.0,0.0,margaret mar wiecek,,MATH-8100,2019
+MATH,8110,1,Nonlinear Programming,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,boshi yang,,MATH-8110,2019
+MATH,8130,1,Advanced Linear Programming,0.31,0.46,0.23,0.0,0.0,0.0,0.0,0.0,matthew saltzman,,MATH-8130,2019
+MATH,8210,1,Linear Analysis,0.5,0.38,0.0,0.0,0.0,0.0,0.0,0.13,martin joha schmoll,,MATH-8210,2019
+MATH,8220,1,Measure and Integration,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,benjamin jaye,,MATH-8220,2019
+MATH,8500,1,Computational Algebraic Geom,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,michael adam burr,,MATH-8500,2019
+MATH,8530,1,Matrix Analysis,0.77,0.08,0.15,0.0,0.0,0.0,0.0,0.0,svetlan poznanovikj,,MATH-8530,2019
+MATH,8570,1,Cryptography,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,xuhong gao,,MATH-8570,2019
+MATH,8600,1,Intro to Scientific Computing,0.58,0.32,0.05,0.0,0.0,0.0,0.0,0.05,leo rebholz,,MATH-8600,2019
+MATH,8660,1,Finite Element Method,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,qingshan chen,,MATH-8660,2019
+MBA,8030,1,Stat Analy of Bus Op,0.33,0.39,0.17,0.0,0.0,0.0,0.0,0.11,magda gabriela sava,,MBA-8030,2019
+MBA,8060,1,Operations Mgt,0.45,0.55,0.0,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MBA-8060,2019
+MBA,8060,20,Operations Mgt,0.32,0.32,0.35,0.0,0.0,0.0,0.0,0.0, sridharan,,MBA-8060,2019
+MBA,8070,1,Financial Management,0.48,0.26,0.22,0.0,0.0,0.0,0.0,0.04,melvin stith,,MBA-8070,2019
+MBA,8070,2,Financial Management,0.79,0.11,0.05,0.0,0.0,0.0,0.0,0.05,melvin stith,,MBA-8070,2019
+MBA,8090,1,Org Beh & Hum Res Mg,0.55,0.41,0.0,0.0,0.0,0.0,0.0,0.05,thomas jo zagenczyk,,MBA-8090,2019
+MBA,8090,2,Org Beh & Hum Res Mg,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,thomas jo zagenczyk,,MBA-8090,2019
+MBA,8170,21,Bus Forecasting,0.59,0.41,0.0,0.0,0.0,0.0,0.0,0.0,sukran nil atadeniz,,MBA-8170,2019
+MBA,8190,1,Intro to Acc and Fin,0.41,0.5,0.0,0.0,0.0,0.0,0.0,0.09,jeffrey mcmillan,,MBA-8190,2019
+MBA,8190,1,Intro to Acc and Fin,0.41,0.5,0.0,0.0,0.0,0.0,0.0,0.09,george bra lockhart,,MBA-8190,2019
+MBA,8290,3,Marketing Foundation,0.63,0.25,0.0,0.0,0.0,0.0,0.0,0.13,gary hunter,,MBA-8290,2019
+MBA,8330,1,Real Estate Investmt,0.17,0.67,0.17,0.0,0.0,0.0,0.0,0.0,franklin bog wallin,,MBA-8330,2019
+MBA,8370,1,Legal Environ of Bus,0.3,0.59,0.07,0.0,0.0,0.0,0.0,0.04,judson jahn,,MBA-8370,2019
+MBA,8370,3,Legal Environ of Bus,0.33,0.58,0.0,0.0,0.0,0.0,0.0,0.08,judson jahn,,MBA-8370,2019
+MBA,8400,1,Entrepreneurship & Venture Mgt,0.33,0.58,0.08,0.0,0.0,0.0,0.0,0.0,prashant prabhu,,MBA-8400,2019
+MBA,8430,10,Entrepreneurial Accounting,0.67,0.26,0.07,0.0,0.0,0.0,0.0,0.0,gregory patr mcphee,,MBA-8430,2019
+MBA,8440,10,Entrepreneurial Law,0.54,0.39,0.07,0.0,0.0,0.0,0.0,0.0,judson jahn,,MBA-8440,2019
+MBA,8470,1,New Venture Creation,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,joseph renat gibson,,MBA-8470,2019
+MBA,8510,11,Bus Operations & Logistics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,george kenne morgan,,MBA-8510,2019
+MBA,8540,1,Managerial Accounting,0.48,0.52,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,,MBA-8540,2019
+MBA,8540,2,Managerial Accounting,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,,MBA-8540,2019
+MBA,8540,3,Managerial Accounting,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,derek dalton,,MBA-8540,2019
+MBA,8590,1,Mgr Decision Model,0.52,0.41,0.04,0.0,0.0,0.0,0.0,0.04,magda gabriela sava,,MBA-8590,2019
+MBA,8590,2,Mgr Decision Model,0.25,0.38,0.19,0.0,0.13,0.0,0.0,0.06,sara elizabet yoder,,MBA-8590,2019
+MBA,8600,2,Advanced Marketing Strategy,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,joseph renat gibson,,MBA-8600,2019
+MBA,8610,1,Information Systems,0.68,0.3,0.0,0.0,0.0,0.0,0.0,0.02,william kettinger,,MBA-8610,2019
+MBA,8610,2,Information Systems,0.68,0.24,0.05,0.0,0.0,0.0,0.0,0.03,william kettinger,,MBA-8610,2019
+MBA,8620,1,Managerial Economics,0.68,0.25,0.0,0.0,0.0,0.0,0.0,0.07,ronald earl gregory,,MBA-8620,2019
+MBA,8620,2,Managerial Economics,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,ronald earl gregory,,MBA-8620,2019
+MBA,8700,1,Strategic Management,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8700,2019
+MBA,8700,2,Strategic Management,0.4,0.6,0.0,0.0,0.0,0.0,0.0,0.0,thomas robert uva,,MBA-8700,2019
+MBA,8720,1,Entrepr Finance,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8720,2019
+MBA,8720,2,Entrepr Finance,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,matthew charl klein,,MBA-8720,2019
+MBA,8750,1,Enterprise Develpmnt,0.29,0.71,0.0,0.0,0.0,0.0,0.0,0.0,michael george mino,,MBA-8750,2019
+MBA,8800,1,MBA Seminar,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,gail depriest,,MBA-8800,2019
+MBA,8800,2,MBA Seminar,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,jamie lyn patterson,,MBA-8800,2019
+MBA,8990,1,Advanced Leadership,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,gail depriest,,MBA-8990,2019
+MBA,8990,3,Service Innovation,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0,aleda marie roth,,MBA-8990,2019
+MBA,8990,5,International Investment Strgy,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,blerina zykaj,,MBA-8990,2019
+MBA,8990,20,Analytics & Application,0.45,0.52,0.03,0.0,0.0,0.0,0.0,0.0,heshan sun,,MBA-8990,2019
+ME,2000,1,Sophomore Seminar,0.62,0.25,0.06,0.01,0.0,0.0,0.0,0.06,todd schweisinger,,ME-2000,2019
+ME,2010,1,Statics & Dynamics,0.01,0.1,0.33,0.04,0.0,0.0,0.15,0.36,gang liu,,ME-2010,2019
+ME,2010,2,Statics & Dynamics,0.03,0.23,0.27,0.1,0.04,0.0,0.0,0.32,paul joseph,,ME-2010,2019
+ME,2030,1,Founda Th/Fl Syst,0.24,0.49,0.23,0.03,0.01,0.0,0.0,0.0,sandip dutta,,ME-2030,2019
+ME,2030,2,Founda Th/Fl Syst,0.17,0.27,0.47,0.07,0.0,0.0,0.0,0.03,john saylor,,ME-2030,2019
+ME,2030,3,Founda Th/Fl Syst,0.24,0.3,0.23,0.15,0.04,0.0,0.0,0.04,xiangchun xuan,,ME-2030,2019
+ME,2030,4,Founda Th/Fl Syst,0.33,0.21,0.22,0.1,0.05,0.0,0.0,0.09,jay ochterbeck,,ME-2030,2019
+ME,2040,1,Mechanics of Materials,0.3,0.41,0.29,0.0,0.0,0.0,0.0,0.0,gang li,,ME-2040,2019
+ME,2040,2,Mechanics of Materials,0.28,0.47,0.22,0.02,0.0,0.0,0.0,0.02,garrett pataky,,ME-2040,2019
+ME,2040,3,Mechanics of Materials,0.21,0.49,0.28,0.03,0.0,0.0,0.0,0.0,fadi abdeljawad,,ME-2040,2019
+ME,2220,1,Mechanical Engineering Lab I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,,ME-2220,2019
+ME,2220,2,Mechanical Engineering Lab I,0.13,0.81,0.06,0.0,0.0,0.0,0.0,0.0,rachel anderson,,ME-2220,2019
+ME,2220,3,Mechanical Engineering Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,,ME-2220,2019
+ME,2220,4,Mechanical Engineering Lab I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,,ME-2220,2019
+ME,2220,5,Mechanical Engineering Lab I,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,rachel anderson,,ME-2220,2019
+ME,2220,6,Mechanical Engineering Lab I,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,,ME-2220,2019
+ME,2220,7,Mechanical Engineering Lab I,0.38,0.56,0.0,0.0,0.0,0.0,0.0,0.06,rachel anderson,,ME-2220,2019
+ME,2220,8,Mechanical Engineering Lab I,0.44,0.44,0.0,0.0,0.0,0.0,0.0,0.13,rachel anderson,,ME-2220,2019
+ME,2220,10,Mechanical Engineering Lab I,0.25,0.5,0.13,0.0,0.0,0.0,0.0,0.13,rachel anderson,,ME-2220,2019
+ME,2220,11,Mechanical Engineering Lab I,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,rachel anderson,,ME-2220,2019
+ME,2220,13,Mechanical Engineering Lab I,0.25,0.5,0.13,0.0,0.06,0.0,0.0,0.06,rachel anderson,,ME-2220,2019
+ME,2220,14,Mechanical Engineering Lab I,0.63,0.31,0.06,0.0,0.0,0.0,0.0,0.0,rachel anderson,,ME-2220,2019
+ME,3030,1,Thermodynamics,0.64,0.18,0.1,0.0,0.04,0.0,0.0,0.04,pooya niksiar,,ME-3030,2019
+ME,3030,2,Thermodynamics,0.23,0.32,0.3,0.04,0.07,0.0,0.0,0.05,richard miller,,ME-3030,2019
+ME,3040,1,Heat Transfer,0.41,0.53,0.06,0.0,0.0,0.0,0.0,0.0,sandip dutta,,ME-3040,2019
+ME,3040,2,Heat Transfer,0.6,0.3,0.1,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-3040,2019
+ME,3040,3,Heat Transfer,0.32,0.32,0.26,0.05,0.05,0.0,0.0,0.0,jay ochterbeck,,ME-3040,2019
+ME,3050,1,Model/an Dy Syst,0.32,0.42,0.19,0.06,0.0,0.0,0.0,0.0,chengshi wang,,ME-3050,2019
+ME,3050,2,Model/an Dy Syst,0.23,0.49,0.16,0.07,0.05,0.0,0.0,0.0,phanin tallapragada,,ME-3050,2019
+ME,3050,3,Model/an Dy Syst,0.22,0.54,0.2,0.0,0.0,0.0,0.0,0.03,douglas scott byrd,,ME-3050,2019
+ME,3060,1,Fund Machine Design,0.34,0.51,0.14,0.0,0.01,0.0,0.0,0.0,james allen righter,,ME-3060,2019
+ME,3060,2,Fund Machine Design,0.24,0.45,0.24,0.03,0.03,0.0,0.0,0.03,james allen righter,,ME-3060,2019
+ME,3070,1,Found of Mechanical Systems,0.43,0.34,0.2,0.0,0.0,0.0,0.0,0.02,jorge iva rodriguez,,ME-3070,2019
+ME,3070,3,Found of Mechanical Systems,0.59,0.3,0.04,0.04,0.04,0.0,0.0,0.0,pooya niksiar,,ME-3070,2019
+ME,3080,1,Fluid Mechanics,0.17,0.48,0.27,0.02,0.0,0.0,0.0,0.06,chenning tong,,ME-3080,2019
+ME,3080,2,Fluid Mechanics,0.47,0.36,0.13,0.02,0.0,0.0,0.0,0.02,yiqiang han,,ME-3080,2019
+ME,3100,1,Thermo/Heat Transfer,0.12,0.35,0.35,0.1,0.06,0.0,0.0,0.04,yiqiang han,,ME-3100,2019
+ME,3120,1,Manuf Processes,0.25,0.72,0.03,0.0,0.0,0.0,0.0,0.0,hong seok choi,,ME-3120,2019
+ME,3330,1,Mechanical Engineering Lab II,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,2,Mechanical Engineering Lab II,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,3,Mechanical Engineering Lab II,0.38,0.56,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,5,Mechanical Engineering Lab II,0.5,0.44,0.06,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,6,Mechanical Engineering Lab II,0.44,0.38,0.13,0.0,0.0,0.0,0.0,0.06,gang liu,,ME-3330,2019
+ME,3330,7,Mechanical Engineering Lab II,0.43,0.57,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,9,Mechanical Engineering Lab II,0.31,0.38,0.23,0.0,0.08,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,3330,10,Mechanical Engineering Lab II,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-3330,2019
+ME,4000,1,Senior Seminar,0.98,0.01,0.0,0.0,0.0,0.0,0.0,0.01,atul gajanan kelkar,,ME-4000,2019
+ME,4010,1,Mech Engr Design,0.28,0.49,0.18,0.04,0.01,0.0,0.01,0.0,joshua summers,,ME-4010,2019
+ME,4010,1,Mech Engr Design,0.28,0.49,0.18,0.04,0.01,0.0,0.01,0.0,cameron turner,,ME-4010,2019
+ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,,ME-4020,2019
+ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4020,1,Intern in Engr Des,0.73,0.0,0.27,0.0,0.0,0.0,0.0,0.0,huijuan zhao,,ME-4020,2019
+ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,yiqiang han,,ME-4020,2019
+ME,4020,3,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,xin zhao,,ME-4020,2019
+ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-4020,2019
+ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4020,4,Intern in Engr Des,0.47,0.47,0.07,0.0,0.0,0.0,0.0,0.0,sandip dutta,,ME-4020,2019
+ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,douglas scott byrd,,ME-4020,2019
+ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,jorge iva rodriguez,,ME-4020,2019
+ME,4020,5,Intern in Engr Des,0.53,0.4,0.0,0.07,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,sandip dutta,,ME-4020,2019
+ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,,ME-4020,2019
+ME,4020,8,Intern in Engr Des,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,gang liu,,ME-4020,2019
+ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4020,9,Intern in Engr Des,0.44,0.44,0.13,0.0,0.0,0.0,0.0,0.0,jorge iva rodriguez,,ME-4020,2019
+ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,john saylor,,ME-4020,2019
+ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4020,10,Intern in Engr Des,0.47,0.07,0.13,0.33,0.0,0.0,0.0,0.0,joshua bostwick,,ME-4020,2019
+ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,richard figliola,,ME-4020,2019
+ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4020,11,Intern in Engr Des,0.43,0.43,0.14,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2019
+ME,4020,77,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4020,2019
+ME,4020,77,Intern in Engr Des,0.63,0.38,0.0,0.0,0.0,0.0,0.0,0.0,georges fadel,,ME-4020,2019
+ME,4030,1,Control Dynamic Systems,0.23,0.3,0.34,0.13,0.0,0.0,0.0,0.0,mohammad naghnaeian,,ME-4030,2019
+ME,4030,2,Control Dynamic Systems,0.23,0.46,0.23,0.04,0.0,0.0,0.0,0.04,suyi li,,ME-4030,2019
+ME,4170,1,Mechatronic Sys Design,0.84,0.11,0.05,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-4170,2019
+ME,4180,1,F E A in M E Design,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,oliver myers,,ME-4180,2019
+ME,4220,2,Design Gas Turbines,0.55,0.35,0.1,0.0,0.0,0.0,0.0,0.0,abhijit som,,ME-4220,2019
+ME,4230,2,Intro Aerodynamics,0.13,0.42,0.42,0.03,0.0,0.0,0.0,0.0,richard figliola,,ME-4230,2019
+ME,4260,1,Nuclear Energy,0.37,0.39,0.11,0.08,0.03,0.0,0.0,0.03,richard watkins,,ME-4260,2019
+ME,4300,1,Mech Comp Materials,0.23,0.73,0.0,0.0,0.0,0.0,0.0,0.04,gang li,,ME-4300,2019
+ME,4340,1,Cardiovascular Biomechanics,0.25,0.5,0.25,0.0,0.0,0.0,0.0,0.0,ethan kung,,ME-4340,2019
+ME,4440,1,Mechanical Engineering Lab III,0.19,0.81,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2019
+ME,4440,5,Mechanical Engineering Lab III,0.13,0.81,0.06,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2019
+ME,4440,10,Mechanical Engineering Lab III,0.06,0.81,0.13,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2019
+ME,4440,12,Mechanical Engineering Lab III,0.13,0.87,0.0,0.0,0.0,0.0,0.0,0.0,todd schweisinger,,ME-4440,2019
+ME,4930,10,Sel Topics ME (Nonlinear Dyn),0.45,0.27,0.27,0.0,0.0,0.0,0.0,0.0,joshua bostwick,,ME-4930,2019
+ME,4930,30,Sel Topics ME--Sustainability,0.61,0.39,0.0,0.0,0.0,0.0,0.0,0.0,gregory mocko,,ME-4930,2019
+ME,4930,39,Sel Topics ME (Solar Energy),0.81,0.15,0.04,0.0,0.0,0.0,0.0,0.0,daniel fant,,ME-4930,2019
+ME,6170,1,Mechatronics System Design,0.62,0.31,0.08,0.0,0.0,0.0,0.0,0.0,john wagner,,ME-6170,2019
+ME,6230,1,Intro Aerodynamics,0.4,0.2,0.4,0.0,0.0,0.0,0.0,0.0,richard figliola,,ME-6230,2019
+ME,6230,2,Intro Aerodynamics,0.67,0.17,0.0,0.0,0.0,0.0,0.0,0.17,richard figliola,,ME-6230,2019
+ME,6300,1,Mech Comp Materials,0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,gang li,,ME-6300,2019
+ME,6340,1,Cardiovascular Biomechanics,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,ethan kung,,ME-6340,2019
+ME,6930,2,Sel Topics ME (Microfab),0.33,0.67,0.0,0.0,0.0,0.0,0.0,0.0,rod martinez-duarte,,ME-6930,2019
+ME,6930,10,Sel Topics ME-Nonlinear Dyn,0.43,0.29,0.29,0.0,0.0,0.0,0.0,0.0,joshua bostwick,,ME-6930,2019
+ME,8200,1,Mod Cont Engr,0.3,0.63,0.07,0.0,0.0,0.0,0.0,0.0,yue wang,,ME-8200,2019
+ME,8310,1,Convective Ht Trans,0.33,0.47,0.2,0.0,0.0,0.0,0.0,0.0,xin zhao,,ME-8310,2019
+ME,8370,1,Theory of Elast I,0.12,0.32,0.44,0.0,0.08,0.0,0.0,0.04,huijuan zhao,,ME-8370,2019
+ME,8610,1,Matl Sel Engr Design,0.68,0.3,0.02,0.0,0.0,0.0,0.0,0.0,garrett pataky,,ME-8610,2019
+ME,8930,27,Sel Topics ME-Adv Estimation,0.5,0.38,0.13,0.0,0.0,0.0,0.0,0.0,ardalan vahidi,,ME-8930,2019
+ME,8930,28,Sel Topics ME: Agent Based Opt,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,cameron turner,,ME-8930,2019
+ME,8930,28,Sel Topics ME: Agent Based Opt,0.89,0.0,0.0,0.0,0.11,0.0,0.0,0.0,joshua summers,,ME-8930,2019
+MGT,2010,1,Principles of Management,0.37,0.39,0.18,0.03,0.0,0.0,0.02,0.03,katherine clark,,MGT-2010,2019
+MGT,2010,2,Principles of Management,0.44,0.37,0.17,0.02,0.0,0.0,0.0,0.01,tina robbins,,MGT-2010,2019
+MGT,2010,7,Principles of Management,0.18,0.62,0.15,0.03,0.03,0.0,0.0,0.0,christopher mann,,MGT-2010,2019
+MGT,2010,8,Principles of Management,0.39,0.45,0.13,0.03,0.0,0.0,0.0,0.0,christopher mann,,MGT-2010,2019
+MGT,2010,10,Principles of Management,0.31,0.28,0.28,0.08,0.0,0.0,0.0,0.05,ashley will parnell,,MGT-2010,2019
+MGT,2010,11,Principles of Management,0.18,0.34,0.34,0.08,0.0,0.0,0.0,0.05,ashley will parnell,,MGT-2010,2019
+MGT,2180,1,Management PC Applications,0.51,0.36,0.09,0.01,0.01,0.0,0.0,0.02,ryan toole,,MGT-2180,2019
+MGT,2180,2,Management PC Applications,0.27,0.59,0.14,0.0,0.0,0.0,0.0,0.0,ryan toole,,MGT-2180,2019
+MGT,2970,1,Deloitte Consulting CI,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,ryan toole,,MGT-2970,2019
+MGT,3070,1,Human Resource Management,0.28,0.65,0.08,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2019
+MGT,3070,2,Human Resource Management,0.5,0.38,0.1,0.03,0.0,0.0,0.0,0.0,michael cole,,MGT-3070,2019
+MGT,3070,3,Human Resource Management,0.3,0.51,0.16,0.0,0.0,0.0,0.0,0.03,kristin dam scott,,MGT-3070,2019
+MGT,3070,4,Human Resource Management,0.3,0.55,0.1,0.0,0.03,0.0,0.0,0.03,leonard jos spooner,,MGT-3070,2019
+MGT,3070,5,Human Resource Management,0.63,0.33,0.03,0.0,0.03,0.0,0.0,0.0,michael cole,,MGT-3070,2019
+MGT,3070,6,Human Resource Management,0.43,0.46,0.08,0.0,0.03,0.0,0.0,0.0,leonard jos spooner,,MGT-3070,2019
+MGT,3070,8,Human Resource Management,0.32,0.49,0.17,0.0,0.0,0.0,0.0,0.02,priscilla harrison,,MGT-3070,2019
+MGT,3100,2,Intermed Business Statistics,0.51,0.26,0.18,0.0,0.0,0.0,0.0,0.05,jeromy blake snider,,MGT-3100,2019
+MGT,3100,3,Intermed Business Statistics,0.49,0.21,0.13,0.08,0.03,0.0,0.0,0.08,daniel nielubowicz,,MGT-3100,2019
+MGT,3100,4,Intermed Business Statistics,0.44,0.28,0.21,0.0,0.0,0.0,0.0,0.07,iaroslava dutchak,,MGT-3100,2019
+MGT,3100,5,Intermed Business Statistics,0.5,0.17,0.12,0.02,0.12,0.0,0.0,0.07,philip roth,,MGT-3100,2019
+MGT,3100,6,Intermed Business Statistics,0.55,0.24,0.07,0.01,0.04,0.0,0.0,0.07,benjamin chri wiles,,MGT-3100,2019
+MGT,3100,7,Intermed Business Statistics,0.4,0.35,0.2,0.03,0.0,0.0,0.0,0.03,mustafa serk akturk,,MGT-3100,2019
+MGT,3100,8,Intermed Business Statistics,0.36,0.36,0.28,0.0,0.0,0.0,0.0,0.0,mustafa serk akturk,,MGT-3100,2019
+MGT,3100,10,Intermed Business Statistics,0.47,0.24,0.13,0.07,0.02,0.0,0.0,0.07,iaroslava dutchak,,MGT-3100,2019
+MGT,3100,11,Intermed Business Statistics,0.44,0.26,0.23,0.03,0.03,0.0,0.0,0.03,daniel allan detoma,,MGT-3100,2019
+MGT,3120,1,Decision Models for Management,0.16,0.31,0.3,0.05,0.13,0.0,0.0,0.06,sara elizabet yoder,,MGT-3120,2019
+MGT,3120,2,Decision Models for Management,0.21,0.25,0.34,0.07,0.06,0.0,0.0,0.06,sara elizabet yoder,,MGT-3120,2019
+MGT,3120,4,Decision Models for Management,0.29,0.29,0.29,0.03,0.06,0.0,0.0,0.05,james turner,,MGT-3120,2019
+MGT,3170,1,Logistics Mgmt,0.58,0.38,0.04,0.0,0.0,0.0,0.0,0.0,ahmet colak,,MGT-3170,2019
+MGT,3180,1,Mgt of Info Systems,0.25,0.55,0.18,0.0,0.0,0.0,0.0,0.03,russell purvis,,MGT-3180,2019
+MGT,3180,2,Mgt of Info Systems,0.49,0.23,0.26,0.0,0.0,0.0,0.0,0.03,marten risius,,MGT-3180,2019
+MGT,3180,3,Mgt of Info Systems,0.69,0.22,0.09,0.0,0.0,0.0,0.0,0.0,daniel aaron pienta,,MGT-3180,2019
+MGT,3180,4,Mgt of Info Systems,0.23,0.7,0.08,0.0,0.0,0.0,0.0,0.0,wenxi pu,,MGT-3180,2019
+MGT,3180,5,Mgt of Info Systems,0.78,0.2,0.0,0.0,0.0,0.0,0.0,0.02,daniel aaron pienta,,MGT-3180,2019
+MGT,3500,1,Intro to Business Analytics,0.58,0.26,0.13,0.03,0.0,0.0,0.0,0.0,hongki kim,,MGT-3500,2019
+MGT,3510,1,Business Analytics & Problems,0.4,0.4,0.17,0.03,0.0,0.0,0.0,0.0,daniel allan detoma,,MGT-3510,2019
+MGT,3900,1,Operations Management,0.3,0.48,0.13,0.05,0.03,0.0,0.0,0.03,ying zhang,,MGT-3900,2019
+MGT,3900,2,Operations Management,0.37,0.44,0.15,0.0,0.05,0.0,0.0,0.0,ying zhang,,MGT-3900,2019
+MGT,3900,3,Operations Management,0.1,0.43,0.42,0.0,0.0,0.0,0.0,0.04, sridharan,,MGT-3900,2019
+MGT,3900,4,Operations Management,0.15,0.33,0.36,0.13,0.0,0.0,0.0,0.03,zachary mo leffakis,,MGT-3900,2019
+MGT,3900,6,Operations Management,0.57,0.4,0.02,0.0,0.0,0.0,0.0,0.0,maneeshre ajjuguttu,,MGT-3900,2019
+MGT,4000,1,Mgt of Organizational Behavior,0.78,0.23,0.0,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2019
+MGT,4000,2,Mgt of Organizational Behavior,0.26,0.38,0.33,0.02,0.02,0.0,0.0,0.0,thomas jo zagenczyk,,MGT-4000,2019
+MGT,4000,3,Mgt of Organizational Behavior,0.23,0.33,0.26,0.08,0.08,0.0,0.0,0.03,philip roth,,MGT-4000,2019
+MGT,4000,4,Mgt of Organizational Behavior,0.88,0.1,0.03,0.0,0.0,0.0,0.0,0.0,michael cole,,MGT-4000,2019
+MGT,4020,1,Ops Pln and Ctl,0.13,0.47,0.4,0.0,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4020,2019
+MGT,4080,1,Lean Operations,0.21,0.51,0.26,0.03,0.0,0.0,0.0,0.0,zachary mo leffakis,,MGT-4080,2019
+MGT,4110,1,Project Management,0.15,0.51,0.28,0.0,0.03,0.0,0.0,0.03,russell purvis,,MGT-4110,2019
+MGT,4120,1,Supplier Management,0.59,0.34,0.03,0.0,0.0,0.0,0.0,0.03,ahmet colak,,MGT-4120,2019
+MGT,4150,1,Business Strategy,0.15,0.52,0.33,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,2,Business Strategy,0.07,0.67,0.26,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,3,Business Strategy,0.33,0.59,0.09,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,,MGT-4150,2019
+MGT,4150,4,Business Strategy,0.46,0.48,0.07,0.0,0.0,0.0,0.0,0.0,matt calvin hersel,,MGT-4150,2019
+MGT,4150,5,Business Strategy,0.26,0.61,0.13,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2019
+MGT,4150,6,Business Strategy,0.48,0.43,0.1,0.0,0.0,0.0,0.0,0.0,amy elizabet ingram,,MGT-4150,2019
+MGT,4150,7,Business Strategy,0.07,0.57,0.35,0.02,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,8,Business Strategy,0.26,0.7,0.04,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,11,Business Strategy,0.1,0.42,0.42,0.06,0.0,0.0,0.0,0.0,wayne stewart,,MGT-4150,2019
+MGT,4150,14,Business Strategy,0.15,0.39,0.45,0.0,0.0,0.0,0.0,0.0,james liddle,,MGT-4150,2019
+MGT,4150,15,Business Strategy,0.16,0.5,0.25,0.09,0.0,0.0,0.0,0.0,wayne stewart,,MGT-4150,2019
+MGT,4160,1,Special Topics Hr,0.23,0.53,0.23,0.03,0.0,0.0,0.0,0.0,kristin dam scott,,MGT-4160,2019
+MGT,4230,1,Intern Bus Mgt,0.11,0.53,0.31,0.04,0.0,0.0,0.0,0.0,janis miller,,MGT-4230,2019
+MGT,4230,2,Intern Bus Mgt,0.11,0.33,0.47,0.04,0.04,0.0,0.0,0.0,janis miller,,MGT-4230,2019
+MGT,4230,3,Intern Bus Mgt,0.13,0.16,0.64,0.04,0.0,0.0,0.0,0.02,wayne stewart,,MGT-4230,2019
+MGT,4230,4,Intern Bus Mgt,0.27,0.09,0.57,0.02,0.02,0.0,0.0,0.02,wayne stewart,,MGT-4230,2019
+MGT,4230,600,Intern Bus Mgt,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0, sridharan,,MGT-4230,2019
+MGT,4240,1,Global Supply Chain Management,0.46,0.46,0.08,0.0,0.0,0.0,0.0,0.0,yann ferrand,,MGT-4240,2019
+MGT,4270,1,Managing Improvement,0.5,0.36,0.14,0.0,0.0,0.0,0.0,0.0,lawrence fredendall,,MGT-4270,2019
+MGT,4310,1,Emp Rights & Resp,0.15,0.55,0.3,0.0,0.0,0.0,0.0,0.0,leonard jos spooner,,MGT-4310,2019
+MGT,4350,1,Pers Interviewing,0.35,0.43,0.18,0.03,0.03,0.0,0.0,0.0,philip roth,,MGT-4350,2019
+MGT,4520,1,Business Analysis,0.37,0.11,0.52,0.0,0.0,0.0,0.0,0.0,marten risius,,MGT-4520,2019
+MGT,4540,1,Systems Implement,0.43,0.39,0.13,0.04,0.0,0.0,0.0,0.0,hongki kim,,MGT-4540,2019
+MGT,4550,1,Emerging I T Trends,0.38,0.5,0.08,0.0,0.0,0.0,0.0,0.04,john frederic tripp,,MGT-4550,2019
+MGT,8120,1,Supply Chain Mgt,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,yann ferrand,,MGT-8120,2019
+MICR,3050,1,General Microbiology,0.47,0.37,0.11,0.04,0.0,0.0,0.0,0.01,krista barr rudolph,,MICR-3050,2019
+MICR,3050,2,General Microbiology,0.39,0.43,0.16,0.01,0.0,0.0,0.0,0.01,kristi ja whitehead,,MICR-3050,2019
+MICR,3050,3,General Microbiology,0.68,0.3,0.02,0.0,0.0,0.0,0.0,0.0,krista barr rudolph,,MICR-3050,2019
+MICR,4000,1,Public Health Micro,0.6,0.24,0.12,0.04,0.0,0.0,0.0,0.01,kristi ja whitehead,,MICR-4000,2019
+MICR,4000,2,Public Health Micro (HON),0.64,0.27,0.09,0.0,0.0,0.0,0.0,0.0,kristi ja whitehead,True,MICR-4000,2019
+MICR,4070,1,Food and Dairy Micro,0.27,0.55,0.12,0.04,0.0,0.0,0.0,0.01,xiuping jiang,,MICR-4070,2019
+MICR,4110,1,Pathogenic Bact,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,wilbur kear milhous,,MICR-4110,2019
+MICR,4120,1,Bacterial Physiology,0.23,0.35,0.27,0.08,0.05,0.0,0.0,0.02,harry kurtz,,MICR-4120,2019
+MICR,4130,1,Industrial Micro,0.42,0.49,0.06,0.02,0.0,0.0,0.0,0.01,tzuen-rong je tzeng,,MICR-4130,2019
+MICR,4140,1,Basic Immunology,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,charles rice,,MICR-4140,2019
+MICR,4170,1,Cancer and Aging,0.61,0.27,0.1,0.02,0.0,0.0,0.0,0.0,wen chen,,MICR-4170,2019
+MICR,4190,1,Intro to Molecular Medicine,0.54,0.27,0.08,0.08,0.0,0.0,0.0,0.04,zhicheng dou,,MICR-4190,2019
+MICR,4500,1,Advanced Microbiology I,0.2,0.5,0.3,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2019
+MICR,4500,2,Advanced Microbiology I,0.2,0.67,0.07,0.07,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2019
+MICR,4500,3,Advanced Microbiology I,0.45,0.45,0.1,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2019
+MICR,4500,4,Advanced Microbiology I,0.21,0.58,0.21,0.0,0.0,0.0,0.0,0.0,harry kurtz,,MICR-4500,2019
+MICR,4520,1,Advanced Microbiology III,0.8,0.05,0.15,0.0,0.0,0.0,0.0,0.0,min cao,,MICR-4520,2019
+MICR,4520,2,Advanced Microbiology III,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,min cao,,MICR-4520,2019
+MICR,4520,3,Advanced Microbiology III,0.47,0.32,0.11,0.11,0.0,0.0,0.0,0.0,min cao,,MICR-4520,2019
+MICR,4930,5,Sen Sem: Host-Microbe Interact,0.56,0.31,0.06,0.06,0.0,0.0,0.0,0.0,kristi ja whitehead,,MICR-4930,2019
+MICR,4940,1,CI: InterKingdom Communication,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,min cao,,MICR-4940,2019
+MICR,4940,26,CI: Parasite Biophysics,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,joshua alper,,MICR-4940,2019
+MKT,3010,1,Principles of Marketing,0.3,0.33,0.25,0.08,0.03,0.0,0.0,0.01,carter wil mcelveen,,MKT-3010,2019
+MKT,3010,2,Principles of Marketing,0.32,0.29,0.34,0.03,0.0,0.0,0.01,0.01,carter wil mcelveen,,MKT-3010,2019
+MKT,3010,3,Principles of Marketing,0.35,0.34,0.2,0.08,0.01,0.0,0.0,0.03,amanda cooper fine,,MKT-3010,2019
+MKT,3010,4,Principles of Marketing,0.29,0.43,0.22,0.06,0.0,0.0,0.0,0.01,amanda cooper fine,,MKT-3010,2019
+MKT,3010,5,Principles of Marketing,0.29,0.43,0.18,0.06,0.01,0.0,0.0,0.03,james gaubert,,MKT-3010,2019
+MKT,3010,7,Principles of Marketing,0.74,0.2,0.04,0.01,0.0,0.0,0.0,0.01,patricia knowles,,MKT-3010,2019
+MKT,3020,1,Consumer Behavior,0.33,0.59,0.05,0.0,0.03,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2019
+MKT,3020,2,Consumer Behavior,0.49,0.41,0.1,0.0,0.0,0.0,0.0,0.0,jennifer di siemens,,MKT-3020,2019
+MKT,3020,3,Consumer Behavior,0.35,0.49,0.14,0.0,0.0,0.0,0.0,0.02,anastasia thyroff,,MKT-3020,2019
+MKT,3020,4,Consumer Behavior,0.41,0.43,0.17,0.0,0.0,0.0,0.0,0.0,anastasia thyroff,,MKT-3020,2019
+MKT,3020,5,Consumer Behavior,0.6,0.37,0.04,0.0,0.0,0.0,0.0,0.0,patricia knowles,,MKT-3020,2019
+MKT,3220,1,Social Media Marketing,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,michele melt cauley,,MKT-3220,2019
+MKT,3220,2,Social Media Marketing,0.84,0.16,0.0,0.0,0.0,0.0,0.0,0.0,michele melt cauley,,MKT-3220,2019
+MKT,3310,1,Marketing Metrics & Analytics,0.57,0.43,0.0,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,,MKT-3310,2019
+MKT,3310,2,Marketing Metrics & Analytics,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,oriana rache aragon,,MKT-3310,2019
+MKT,3310,3,Marketing Metrics & Analytics,0.21,0.41,0.26,0.12,0.0,0.0,0.0,0.0,peter weathers,,MKT-3310,2019
+MKT,3310,4,Marketing Metrics & Analytics,0.59,0.34,0.06,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-3310,2019
+MKT,3310,5,Marketing Metrics & Analytics,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-3310,2019
+MKT,3980,1,CI:Sales Experiential,0.93,0.0,0.04,0.0,0.0,0.0,0.0,0.02,carter wil mcelveen,,MKT-3980,2019
+MKT,4200,1,Professional Selling,0.66,0.28,0.07,0.0,0.0,0.0,0.0,0.0,jesse moore,,MKT-4200,2019
+MKT,4200,2,Professional Selling,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,carter wil mcelveen,,MKT-4200,2019
+MKT,4200,3,Professional Selling,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4200,2019
+MKT,4200,4,Professional Selling,0.57,0.4,0.03,0.0,0.0,0.0,0.0,0.0,kevin scott chase,,MKT-4200,2019
+MKT,4200,5,Professional Selling,0.53,0.44,0.03,0.0,0.0,0.0,0.0,0.0,kevin scott chase,,MKT-4200,2019
+MKT,4230,1,Promotional Strategy,0.82,0.16,0.02,0.0,0.0,0.0,0.0,0.0,michele melt cauley,,MKT-4230,2019
+MKT,4230,2,Promotional Strategy,0.9,0.05,0.0,0.05,0.0,0.0,0.0,0.0,michele melt cauley,,MKT-4230,2019
+MKT,4240,1,Sales Management,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,ryan mullins,,MKT-4240,2019
+MKT,4270,1,International Marketing,0.36,0.53,0.06,0.03,0.03,0.0,0.0,0.0,thomas poehlman,,MKT-4270,2019
+MKT,4270,2,International Marketing,0.76,0.18,0.04,0.02,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4270,2019
+MKT,4270,3,International Marketing,0.84,0.13,0.02,0.0,0.0,0.0,0.0,0.0,xianyong wang,,MKT-4270,2019
+MKT,4270,4,International Marketing,0.47,0.38,0.1,0.03,0.0,0.0,0.0,0.03,patricia knowles,,MKT-4270,2019
+MKT,4280,1,Services Marketing,0.55,0.39,0.05,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4280,2019
+MKT,4280,2,Services Marketing,0.53,0.45,0.03,0.0,0.0,0.0,0.0,0.0,james gaubert,,MKT-4280,2019
+MKT,4310,1,Marketing Research,0.39,0.44,0.17,0.0,0.0,0.0,0.0,0.0,michae giebelhausen,,MKT-4310,2019
+MKT,4310,2,Marketing Research,0.56,0.33,0.11,0.0,0.0,0.0,0.0,0.0,michae giebelhausen,,MKT-4310,2019
+MKT,4310,3,Marketing Research,0.4,0.3,0.23,0.0,0.0,0.0,0.0,0.07,william kilbourne,,MKT-4310,2019
+MKT,4310,4,Marketing Research,0.39,0.61,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2019
+MKT,4310,5,Marketing Research,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,scott darren swain,,MKT-4310,2019
+MKT,4330,1,Sport Mkt Strategy,0.46,0.42,0.12,0.0,0.0,0.0,0.0,0.0,amanda cooper fine,,MKT-4330,2019
+MKT,4450,1,Macromarketing,0.59,0.38,0.03,0.0,0.0,0.0,0.0,0.0,william kilbourne,,MKT-4450,2019
+MKT,4500,1,Strategic Mktg Mgt,0.13,0.45,0.42,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2019
+MKT,4500,2,Strategic Mktg Mgt,0.13,0.59,0.28,0.0,0.0,0.0,0.0,0.0,mary anne raymond,,MKT-4500,2019
+MKT,4500,3,Strategic Mktg Mgt,0.74,0.26,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-4500,2019
+MKT,4500,4,Strategic Mktg Mgt,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,delancy bennett,,MKT-4500,2019
+MKT,4500,5,Strategic Mktg Mgt,0.24,0.42,0.3,0.03,0.0,0.0,0.0,0.0,michael dorsch,,MKT-4500,2019
+MKT,8620,1,Quant Methods in Mkt,0.38,0.62,0.0,0.0,0.0,0.0,0.0,0.0,peter weathers,,MKT-8620,2019
+MKT,8650,1,Seminar in Mkt Mgmt,0.29,0.5,0.21,0.0,0.0,0.0,0.0,0.0,michael dorsch,,MKT-8650,2019
+MKT,8660,1,International Marketing,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,thomas poehlman,,MKT-8660,2019
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,aaron javron hills,,ML-1020,2019
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,andre kareeth bland,,ML-1020,2019
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,jonathan jacoba,,ML-1020,2019
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,christopher bland,,ML-1020,2019
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,brian james gural,,ML-1020,2019
+ML,1020,2,Leadership Fund II,0.89,0.0,0.0,0.0,0.0,0.0,0.0,0.11,kenneth to crawford,,ML-1020,2019
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2020,2019
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,thomas michae burke,,ML-2020,2019
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,christopher bland,,ML-2020,2019
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,,ML-2020,2019
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,,ML-2020,2019
+ML,2020,1,Leadership Development II,0.67,0.11,0.22,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,,ML-2020,2019
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,,ML-2020,2019
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,,ML-2020,2019
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,thomas michae burke,,ML-2020,2019
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,,ML-2020,2019
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,,ML-2020,2019
+ML,2020,2,Leadership Development II,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-2020,2019
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,matthew davi jordan,,ML-2020,2019
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,andre kareeth bland,,ML-2020,2019
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,kenneth to crawford,,ML-2020,2019
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,vincent john presto,,ML-2020,2019
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,thomas michae burke,,ML-2020,2019
+ML,2020,3,Leadership Development II,0.69,0.23,0.0,0.0,0.0,0.0,0.0,0.08,christopher bland,,ML-2020,2019
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,,ML-3020,2019
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,justin rober merhar,,ML-3020,2019
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,,ML-3020,2019
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,spencer blak harmon,,ML-3020,2019
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,,ML-3020,2019
+ML,3020,1,Advanced Leadership II,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,,ML-3020,2019
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,justin rober merhar,,ML-3020,2019
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,,ML-3020,2019
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,,ML-3020,2019
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,,ML-3020,2019
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,william cod cleland,,ML-3020,2019
+ML,3020,2,Advanced Leadership II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,spencer blak harmon,,ML-3020,2019
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,kenneth to crawford,,ML-3900,2019
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,andre kareeth bland,,ML-3900,2019
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,vincent john presto,,ML-3900,2019
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,christopher bland,,ML-3900,2019
+ML,3900,1,American Army Military Exper,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,matthew davi jordan,,ML-3900,2019
+MSE,2100,1,Intro to Materials Science,0.33,0.27,0.25,0.03,0.08,0.0,0.0,0.03,rakhee pani,,MSE-2100,2019
+MSE,2100,3,Intro to Materials Science,0.33,0.3,0.16,0.07,0.08,0.0,0.0,0.05,kai he,,MSE-2100,2019
+MSE,2100,4,Intro to Materials Science,0.53,0.25,0.08,0.04,0.04,0.0,0.0,0.05,rakhee pani,,MSE-2100,2019
+MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jianhua tong,,MSE-3020,2019
+MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,,MSE-3020,2019
+MSE,3020,4,Materials Characterization Lab,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,vincent yves blouin,,MSE-3020,2019
+MSE,3100,1,Intro to Metals and Ceramics,0.63,0.22,0.11,0.0,0.0,0.0,0.04,0.0,jianhua tong,,MSE-3100,2019
+MSE,3190,1,Materials Proc I,0.48,0.32,0.2,0.0,0.0,0.0,0.0,0.0,rajendra kum bordia,,MSE-3190,2019
+MSE,3190,1,Materials Proc I,0.48,0.32,0.2,0.0,0.0,0.0,0.0,0.0,rakhee pani,,MSE-3190,2019
+MSE,3190,2,Materials Proc I,0.31,0.31,0.17,0.07,0.03,0.0,0.0,0.1,rajendra kum bordia,,MSE-3190,2019
+MSE,3190,2,Materials Proc I,0.31,0.31,0.17,0.07,0.03,0.0,0.0,0.1,rakhee pani,,MSE-3190,2019
+MSE,3260,1,Thermo of Materials,0.26,0.43,0.26,0.0,0.0,0.0,0.0,0.06,fei peng,,MSE-3260,2019
+MSE,3260,2,Thermo of Materials,0.26,0.26,0.22,0.15,0.04,0.0,0.0,0.07,fei peng,,MSE-3260,2019
+MSE,3270,1,Transport Phenomena,0.17,0.35,0.39,0.0,0.0,0.0,0.04,0.04,ulf daniel schiller,,MSE-3270,2019
+MSE,3610,2,Proc of Metals & Composites,0.41,0.38,0.14,0.03,0.0,0.0,0.0,0.03,marian kennedy,,MSE-3610,2019
+MSE,4020,1,Fundamentals of Solid State,0.5,0.16,0.28,0.06,0.0,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-4020,2019
+MSE,4070,1,Senior Capstone Design,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,john ballato,,MSE-4070,2019
+MSE,4150,1,Polymer Sc Engr,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,olin mefford,,MSE-4150,2019
+MSE,4220,1,Mech Behavior of Mat,0.61,0.32,0.05,0.0,0.02,0.0,0.0,0.0,vincent yves blouin,,MSE-4220,2019
+MSE,4240,1,Optical Materials,0.8,0.07,0.1,0.03,0.0,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-4240,2019
+MSE,4330,2,Comb Sys & Env Emiss,0.74,0.16,0.06,0.0,0.0,0.0,0.0,0.03,john sanders,,MSE-4330,2019
+MSE,4450,1,Practice of Mat Engr,0.0,0.0,0.0,0.0,0.0,0.95,0.0,0.05,marek urban,,MSE-4450,2019
+MSE,4910,1,Undergraduate Research,0.91,0.03,0.0,0.0,0.03,0.0,0.0,0.03,rajendra kum bordia,,MSE-4910,2019
+MSE,6020,1,Solid State Material,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,luiz gust jacobsohn,,MSE-6020,2019
+MSE,8250,2,Solid State Mtl Sci,0.21,0.79,0.0,0.0,0.0,0.0,0.0,0.0,stephen foulger,,MSE-8250,2019
+MSE,8520,2,Polymer Science II,0.55,0.4,0.05,0.0,0.0,0.0,0.0,0.0,igor luzinov,,MSE-8520,2019
+MUSC,1110,5,Beginning Class Guitar,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,david stevenson,,MUSC-1110,2019
+MUSC,1110,6,Beginning Class Guitar,0.8,0.0,0.0,0.0,0.1,0.0,0.0,0.1,david stevenson,,MUSC-1110,2019
+MUSC,1430,1,Aural Skills I,0.75,0.19,0.0,0.0,0.0,0.0,0.0,0.06,david conley,,MUSC-1430,2019
+MUSC,1510,2,Applied Music,0.63,0.19,0.0,0.0,0.0,0.0,0.0,0.19,jonathan edwa doyel,,MUSC-1510,2019
+MUSC,1510,19,Applied Music,0.9,0.0,0.0,0.0,0.0,0.0,0.0,0.1,monty craig,,MUSC-1510,2019
+MUSC,1520,1,Applied Music,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,lisa sain odom,,MUSC-1520,2019
+MUSC,1520,2,Applied Music,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edwa doyel,,MUSC-1520,2019
+MUSC,1520,10,Applied Music,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,paul buyer,,MUSC-1520,2019
+MUSC,1800,1,Intro to Music Tech,0.3,0.6,0.0,0.0,0.1,0.0,0.0,0.0,hamilton altstatt,,MUSC-1800,2019
+MUSC,1950,1,Creative Inquiry in Music I,0.73,0.18,0.0,0.0,0.0,0.0,0.0,0.09,linda dzuris,,MUSC-1950,2019
+MUSC,2100,2,Music in the Western World,0.52,0.26,0.13,0.03,0.0,0.0,0.0,0.06,lisa sain odom,,MUSC-2100,2019
+MUSC,2100,4,Music in the Western World,0.48,0.26,0.16,0.03,0.03,0.0,0.0,0.03,rhea beth jacobus,,MUSC-2100,2019
+MUSC,2100,5,Music in the Western World,0.36,0.43,0.21,0.0,0.0,0.0,0.0,0.0,rhea beth jacobus,,MUSC-2100,2019
+MUSC,2100,6,Music in the Western World,0.5,0.34,0.09,0.0,0.0,0.0,0.0,0.06,rhea beth jacobus,,MUSC-2100,2019
+MUSC,2100,7,Music in the Western World,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,evan michael jacobi,,MUSC-2100,2019
+MUSC,2100,9,Music in the Western World,0.81,0.13,0.06,0.0,0.0,0.0,0.0,0.0,lea kibler,,MUSC-2100,2019
+MUSC,2100,10,Music in the Western World,0.72,0.22,0.03,0.0,0.0,0.0,0.0,0.03,linda dzuris,,MUSC-2100,2019
+MUSC,2510,2,Applied Music,0.75,0.0,0.0,0.0,0.25,0.0,0.0,0.0,jonathan edwa doyel,,MUSC-2510,2019
+MUSC,2520,2,Applied Music,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jonathan edwa doyel,,MUSC-2520,2019
+MUSC,3090,1,Surv of Broadway II,0.91,0.0,0.0,0.09,0.0,0.0,0.0,0.0,lisa sain odom,,MUSC-3090,2019
+MUSC,3110,1,History of American Music,0.84,0.09,0.06,0.0,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3110,2019
+MUSC,3120,1,History of Jazz,0.74,0.21,0.0,0.0,0.05,0.0,0.0,0.0,eric lapin,,MUSC-3120,2019
+MUSC,3170,1,Hist of Country Mus,0.88,0.09,0.0,0.03,0.0,0.0,0.0,0.0,ned hosler,,MUSC-3170,2019
+MUSC,3180,1,Hist of Audio Tech,0.39,0.22,0.28,0.06,0.0,0.0,0.0,0.06,bruce allen whisler,,MUSC-3180,2019
+MUSC,3310,1,Pep Band,0.95,0.02,0.02,0.02,0.0,0.0,0.0,0.0,timothy ra hurlburt,,MUSC-3310,2019
+MUSC,3310,2,Pep Band,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,timothy ra hurlburt,,MUSC-3310,2019
+MUSC,3640,1,Concert Band,0.98,0.0,0.0,0.0,0.0,0.0,0.0,0.02,timothy ra hurlburt,,MUSC-3640,2019
+MUSC,3710,1,Women's Chorus,0.82,0.16,0.0,0.0,0.0,0.0,0.0,0.02,jerrad fenske,,MUSC-3710,2019
+MUSC,3720,1,Men's Chorus,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,anthony bernarducci,,MUSC-3720,2019
+MUSC,4160,1,Mus Hist Since 1750,0.39,0.26,0.23,0.06,0.0,0.0,0.0,0.06,linda li-bleuel,,MUSC-4160,2019
+MUSC,4300,1,Conducting,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,mark spede,,MUSC-4300,2019
+NPL,3000,1,Nonprofit Leadership,0.75,0.13,0.04,0.08,0.0,0.0,0.0,0.0,corey dou brookover,,NPL-3000,2019
+NPL,3000,2,Nonprofit Leadership,0.46,0.42,0.08,0.0,0.04,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2019
+NPL,3000,3,Nonprofit Leadership,0.29,0.42,0.17,0.08,0.0,0.0,0.0,0.04,bonnie west stevens,,NPL-3000,2019
+NPL,3000,4,Nonprofit Leadership,0.36,0.5,0.05,0.05,0.0,0.0,0.0,0.05,bonnie west stevens,,NPL-3000,2019
+NPL,3000,5,Nonprofit Leadership,0.72,0.25,0.03,0.0,0.0,0.0,0.0,0.0,corey dou brookover,,NPL-3000,2019
+NPL,3000,6,Nonprofit Leadership,0.61,0.3,0.09,0.0,0.0,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2019
+NPL,3000,7,Nonprofit Leadership,0.61,0.28,0.06,0.06,0.0,0.0,0.0,0.0,corey dou brookover,,NPL-3000,2019
+NPL,3000,8,Nonprofit Leadership,0.41,0.34,0.07,0.0,0.17,0.0,0.0,0.0,christina mar mazer,,NPL-3000,2019
+NPL,3010,2,NPL Stakeholders,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,christina mar mazer,,NPL-3010,2019
+NPL,3020,1,NPL Fundraising,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,thomas john orourke,,NPL-3020,2019
+NPL,3030,2,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,joan laura phillips,,NPL-3030,2019
+NPL,3030,2,NPL Personnel,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,NPL-3030,2019
+NPL,3040,1,NPL Risk Management,0.74,0.13,0.09,0.0,0.04,0.0,0.0,0.0,daniel mor anderson,,NPL-3040,2019
+NPL,3050,1,Strat Social Media for NP Org,0.55,0.36,0.09,0.0,0.0,0.0,0.0,0.0,amanda elizab moore,,NPL-3050,2019
+NPL,3050,2,Strat Social Media for NP Org,0.38,0.38,0.14,0.03,0.03,0.0,0.0,0.03,amanda elizab moore,,NPL-3050,2019
+NURS,1400,1,Comp App Hlth Care,0.9,0.08,0.03,0.0,0.0,0.0,0.0,0.0,nancy meehan,,NURS-1400,2019
+NURS,1400,3,Comp App Hlth Care,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jason thrift,,NURS-1400,2019
+NURS,1400,4,Comp App Hlth Care,0.87,0.09,0.02,0.02,0.0,0.0,0.0,0.0,catherine si murton,,NURS-1400,2019
+NURS,3030,101,Nursing of Adults,0.19,0.77,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2019
+NURS,3030,101,Nursing of Adults,0.19,0.77,0.04,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,,NURS-3030,2019
+NURS,3030,201,Nursing of Adults,0.21,0.66,0.13,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2019
+NURS,3030,201,Nursing of Adults,0.21,0.66,0.13,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,,NURS-3030,2019
+NURS,3030,401,Nursing of Adults,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,megan eliz mayfield,,NURS-3030,2019
+NURS,3030,401,Nursing of Adults,0.46,0.5,0.04,0.0,0.0,0.0,0.0,0.0,lena marie burgess,,NURS-3030,2019
+NURS,3040,1,Pathophysiology,0.32,0.44,0.14,0.08,0.02,0.0,0.0,0.0,catherine si murton,,NURS-3040,2019
+NURS,3050,101,Psychosocial Nursing,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,kevin earle busby,,NURS-3050,2019
+NURS,3050,401,Psychosocial Nursing,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,margaret wetsel,,NURS-3050,2019
+NURS,3100,101,Health Assessment,0.94,0.04,0.02,0.0,0.0,0.0,0.0,0.0,tiffany lea stewart,,NURS-3100,2019
+NURS,3100,201,Health Assessment,0.48,0.5,0.02,0.0,0.0,0.0,0.0,0.0,jason thrift,,NURS-3100,2019
+NURS,3120,1,Foundations of Nursing,0.49,0.49,0.02,0.0,0.0,0.0,0.0,0.0,jennifer el bagwell,,NURS-3120,2019
+NURS,3200,1,Prof in Nurs,0.93,0.07,0.0,0.0,0.0,0.0,0.0,0.0,deborah willoughby,,NURS-3200,2019
+NURS,3230,1,Gerontology Nursing,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,zahra rahemi,,NURS-3230,2019
+NURS,3330,101,Health Care Genetics,0.7,0.27,0.02,0.02,0.0,0.0,0.0,0.0,linda ward,,NURS-3330,2019
+NURS,3330,400,Health Care Genetics,0.72,0.24,0.0,0.0,0.04,0.0,0.0,0.0,jennifer el bagwell,,NURS-3330,2019
+NURS,3330,401,Health Care Genetics,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,jane marie deluca,,NURS-3330,2019
+NURS,3400,1,Pharmther Nursing,0.3,0.48,0.16,0.04,0.0,0.0,0.02,0.0,catherine si murton,,NURS-3400,2019
+NURS,3610,400,Ldrshp & Collab in Global Hlth,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,roxanne amerson,,NURS-3610,2019
+NURS,4010,1,Mental Health Nurs,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-4010,2019
+NURS,4030,1,Complex Nursing of Adults,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,nancy ellen  ewing,,NURS-4030,2019
+NURS,4110,1,Nursing of Children,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,terry kaye busby,,NURS-4110,2019
+NURS,4120,1,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-4120,2019
+NURS,4120,1,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0.0,0.0,0.0,kylie padron newsom,,NURS-4120,2019
+NURS,4250,400,Community Nursing,0.83,0.13,0.0,0.0,0.04,0.0,0.0,0.0,tiffany lea stewart,,NURS-4250,2019
+NURS,8010,400,Adv Fam & Comm Nrsng,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,shirley mae timmons,,NURS-8010,2019
+NURS,8010,400,Adv Fam & Comm Nrsng,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,,NURS-8010,2019
+NURS,8080,400,Nurs Res Stat Analys,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-8080,2019
+NURS,8080,401,Nurs Res Stat Analys,0.8,0.15,0.05,0.0,0.0,0.0,0.0,0.0,veronica parker,,NURS-8080,2019
+NURS,8190,400,Developing Family,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,lisa miller,,NURS-8190,2019
+NURS,8200,400,Child & Adol Nursing,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,heide temples,,NURS-8200,2019
+NURS,8210,400,Adult Nursing,0.25,0.75,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8210,2019
+NURS,8210,402,Adult Nursing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,,NURS-8210,2019
+NURS,8210,402,Adult Nursing,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,tracy king fasolino,,NURS-8210,2019
+NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,kelly jordan smith,,NURS-8230,2019
+NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,stephanie cla davis,,NURS-8230,2019
+NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,jennifer geter rice,,NURS-8230,2019
+NURS,8230,404,NP Clinical Practicum,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,rosanne pruitt,,NURS-8230,2019
+NURS,8850,400,Mental Health in Primary Care,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,lindsey reb garrard,,NURS-8850,2019
+NURS,9050,400,DNP Health Informatics,0.67,0.11,0.0,0.0,0.0,0.0,0.0,0.22,nancy meehan,,NURS-9050,2019
+NUTR,2030,1,Intro Princ of Human Nutrition,0.32,0.42,0.15,0.04,0.01,0.0,0.0,0.05,elizabeth durrance,,NUTR-2030,2019
+NUTR,2030,2,Intro Princ of Human Nutrition,0.48,0.39,0.07,0.07,0.0,0.0,0.0,0.0,elizabeth durrance,,NUTR-2030,2019
+NUTR,2040,1,Nutrition Across Life Cycle,0.43,0.47,0.05,0.01,0.01,0.0,0.0,0.03,elizabeth durrance,,NUTR-2040,2019
+NUTR,3010,1,Food and Culture,0.95,0.05,0.0,0.0,0.0,0.0,0.0,0.0,bridgit den corbett,,NUTR-3010,2019
+NUTR,4250,1,Medica Nutr Thera II,0.63,0.37,0.0,0.0,0.0,0.0,0.0,0.0,vivian haley-zitlin,,NUTR-4250,2019
+NUTR,4260,1,Community Nutrition,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,alexis stamatikos,,NUTR-4260,2019
+NUTR,4270,1,Nutrition Counseling,0.66,0.24,0.11,0.0,0.0,0.0,0.0,0.0,elizabeth durrance,,NUTR-4270,2019
+NUTR,4550,1,Human Nutr & Metabolism II,0.52,0.38,0.07,0.03,0.0,0.0,0.0,0.0,elliot jesch,,NUTR-4550,2019
+PA,2790,1,Perf Arts Pract I,0.33,0.4,0.0,0.0,0.13,0.0,0.0,0.13,kenneth moore,,PA-2790,2019
+PA,3010,1,Princip of Arts Administration,0.75,0.25,0.0,0.0,0.0,0.0,0.0,0.0,paul buyer,,PA-3010,2019
+PA,4010,1,Capstone Project,0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,anthony penna,,PA-4010,2019
+PADM,8410,401,Public Data Analysis,0.6,0.3,0.0,0.0,0.0,0.0,0.0,0.1,ronald chrestman,,PADM-8410,2019
+PADM,8410,402,Public Data Analysis,0.33,0.56,0.11,0.0,0.0,0.0,0.0,0.0,edmond patri bowers,,PADM-8410,2019
+PADM,8480,400,Strateg Planning for Pub Admin,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey rand parkey,,PADM-8480,2019
+PADM,8480,400,Strateg Planning for Pub Admin,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,maleena yenn parkey,,PADM-8480,2019
+PADM,8600,400,American Government,0.6,0.2,0.0,0.0,0.0,0.0,0.0,0.2,alfred bundrick,,PADM-8600,2019
+PADM,8660,400,Nonprofit Fundraising,0.75,0.08,0.08,0.0,0.0,0.0,0.0,0.08,victoria bedso hann,,PADM-8660,2019
+PADM,8680,400,Local Government Admin,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,alfred bundrick,,PADM-8680,2019
+PES,2020,1,Soils,0.14,0.5,0.33,0.03,0.0,0.0,0.0,0.0,dara michelle park,,PES-2020,2019
+PES,4060,2,Living Seed Ark,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,paula agudelo,,PES-4060,2019
+PES,4060,2,Living Seed Ark,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.12,stephen kresovich,,PES-4060,2019
+PES,4230,1,Forages and Livestock Systems,0.25,0.38,0.31,0.0,0.0,0.0,0.0,0.06,matias jose aguerre,,PES-4230,2019
+PES,4330,1,Weed Management,0.23,0.15,0.54,0.0,0.0,0.0,0.0,0.08,ted whitwell,,PES-4330,2019
+PES,4450,1,Regulatory Issues & Policies,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,paula agudelo,,PES-4450,2019
+PES,4520,1,Soil Fertility and Management,0.69,0.08,0.08,0.0,0.08,0.0,0.0,0.08,haibo liu,,PES-4520,2019
+PES,4900,1,Soil Organisms in Plant Growth,0.21,0.5,0.21,0.0,0.0,0.0,0.0,0.07,"appukuttan suseela,",,PES-4900,2019
+PES,4960,2,CI: Food Forest,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,julia loui kerrigan,,PES-4960,2019
+PES,8010,1,Crop Physiology and Nutrition,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,sru narayanan kutty,,PES-8010,2019
+PES,8090,1,Analytical Technique,0.54,0.46,0.0,0.0,0.0,0.0,0.0,0.0,tharayil-santhakumar,,PES-8090,2019
+PHIL,1010,1,Intro to Philosophic Problems,0.35,0.35,0.21,0.0,0.03,0.0,0.0,0.06,kelly smith,,PHIL-1010,2019
+PHIL,1010,2,Intro to Philosophic Problems,0.32,0.29,0.24,0.0,0.0,0.0,0.0,0.15,david stegall,,PHIL-1010,2019
+PHIL,1010,3,Intro to Philosophic Problems,0.43,0.31,0.11,0.06,0.03,0.0,0.0,0.06,david stegall,,PHIL-1010,2019
+PHIL,1010,4,Intro to Philosophic Problems,0.53,0.29,0.06,0.03,0.0,0.0,0.0,0.09,david robe antonini,,PHIL-1010,2019
+PHIL,1010,5,Intro to Philosophic Problems,0.43,0.34,0.14,0.03,0.03,0.0,0.0,0.03,david robe antonini,,PHIL-1010,2019
+PHIL,1010,6,Intro to Philosophic Problems,0.39,0.3,0.09,0.06,0.06,0.0,0.0,0.09,david stegall,,PHIL-1010,2019
+PHIL,1010,7,"Intro to Phil, Problems (HON)",0.56,0.33,0.06,0.0,0.0,0.0,0.0,0.06,christopher grau,True,PHIL-1010,2019
+PHIL,1020,1,Introduction to Logic,0.67,0.24,0.03,0.06,0.0,0.0,0.0,0.0,edyta joanna kuzian,,PHIL-1020,2019
+PHIL,1020,2,Introduction to Logic,0.69,0.14,0.03,0.03,0.0,0.0,0.03,0.09,adam pa omelianchuk,,PHIL-1020,2019
+PHIL,1020,3,Introduction to Logic,0.63,0.34,0.03,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,,PHIL-1020,2019
+PHIL,1020,6,Introduction to Logic,0.73,0.12,0.09,0.03,0.0,0.0,0.0,0.03,adam pa omelianchuk,,PHIL-1020,2019
+PHIL,1020,7,Introduction to Logic,0.8,0.15,0.0,0.0,0.05,0.0,0.0,0.0,adam pa omelianchuk,,PHIL-1020,2019
+PHIL,1020,8,Introduction to Logic,0.71,0.24,0.06,0.0,0.0,0.0,0.0,0.0,edyta joanna kuzian,,PHIL-1020,2019
+PHIL,1030,1,Introduction to Ethics,0.36,0.48,0.06,0.06,0.0,0.0,0.0,0.03,stephen satris,,PHIL-1030,2019
+PHIL,1030,2,Intro to Ethics (HON),0.6,0.27,0.13,0.0,0.0,0.0,0.0,0.0,stephen satris,True,PHIL-1030,2019
+PHIL,1030,3,Introduction to Ethics,0.71,0.23,0.0,0.0,0.03,0.0,0.0,0.03,adam gies,,PHIL-1030,2019
+PHIL,1030,4,Introduction to Ethics,0.83,0.11,0.06,0.0,0.0,0.0,0.0,0.0,adam gies,,PHIL-1030,2019
+PHIL,1030,5,Introduction to Ethics,0.22,0.44,0.28,0.0,0.0,0.0,0.0,0.06,charles starkey,,PHIL-1030,2019
+PHIL,3030,1,Phil of Religion,0.41,0.41,0.14,0.0,0.0,0.0,0.0,0.03,richard al amesbury,,PHIL-3030,2019
+PHIL,3050,1,Existentialism,0.76,0.24,0.0,0.0,0.0,0.0,0.0,0.0,david stegall,,PHIL-3050,2019
+PHIL,3120,1,Philosophy in Ancient China,0.43,0.29,0.14,0.14,0.0,0.0,0.0,0.0,yanming an,,PHIL-3120,2019
+PHIL,3160,1,Modern Philosophy,0.38,0.46,0.04,0.04,0.0,0.0,0.0,0.08,david robe antonini,,PHIL-3160,2019
+PHIL,3200,1,Soc and Pol Phil,0.39,0.42,0.13,0.03,0.0,0.0,0.0,0.03,todd may,,PHIL-3200,2019
+PHIL,3210,1,Crime & Punishment,0.38,0.42,0.12,0.04,0.04,0.0,0.0,0.0,daniel wueste,,PHIL-3210,2019
+PHIL,3260,1,Science and Values,0.8,0.14,0.03,0.0,0.0,0.0,0.0,0.03,adam pa omelianchuk,,PHIL-3260,2019
+PHIL,3300,1,Animal Minds & Animal Ethics,0.62,0.12,0.08,0.0,0.04,0.0,0.0,0.15,adam gies,,PHIL-3300,2019
+PHIL,3430,1,Philosophy of Law,0.19,0.69,0.06,0.0,0.0,0.0,0.0,0.06,brookes colyt brown,,PHIL-3430,2019
+PHIL,3450,1,Environmental Ethics,0.78,0.17,0.0,0.0,0.06,0.0,0.0,0.0,kelly smith,,PHIL-3450,2019
+PHIL,3460,1,Biomedical Ethics,0.46,0.46,0.04,0.0,0.04,0.0,0.0,0.0,charles starkey,,PHIL-3460,2019
+PHIL,3990,1,Philosophy Portfolio,0.33,0.5,0.17,0.0,0.0,0.0,0.0,0.0,todd may,,PHIL-3990,2019
+PHIL,4010,1,Studies in the Hist of Phil,0.27,0.64,0.09,0.0,0.0,0.0,0.0,0.0,stephen satris,,PHIL-4010,2019
+PHIL,4020,1,The Limits of Morality,0.6,0.2,0.07,0.0,0.0,0.0,0.0,0.13,todd may,,PHIL-4020,2019
+PHIL,4750,1,Philosophy of Film,0.55,0.35,0.05,0.0,0.0,0.0,0.0,0.05,christopher grau,,PHIL-4750,2019
+PHSC,1170,1,Intro Chem & Earth,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,minory nammouz,,PHSC-1170,2019
+PHYS,1220,1,Physics with Calculus I,0.2,0.35,0.25,0.11,0.04,0.0,0.0,0.05,lih-sin the,,PHYS-1220,2019
+PHYS,1220,2,Physics with Calculus I,0.31,0.45,0.18,0.03,0.0,0.0,0.02,0.01,lih-sin the,,PHYS-1220,2019
+PHYS,1220,3,Physics with Calculus I,0.28,0.41,0.21,0.05,0.03,0.0,0.0,0.02,pooja puneet,,PHYS-1220,2019
+PHYS,1220,4,Physics with Calculus I,0.31,0.43,0.22,0.02,0.03,0.0,0.0,0.0,pooja puneet,,PHYS-1220,2019
+PHYS,1220,5,Physics with Calculus I,0.34,0.44,0.16,0.03,0.01,0.0,0.0,0.02,jason stratfo brown,,PHYS-1220,2019
+PHYS,1220,8,Physics w/Calculus I (HON),0.63,0.23,0.07,0.0,0.0,0.0,0.0,0.07,ramakrishna podila,True,PHYS-1220,2019
+PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,1,Physics Lab I,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,2,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,2,Physics Lab I,0.67,0.28,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,3,Physics Lab I,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,3,Physics Lab I,0.72,0.22,0.0,0.0,0.06,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,4,Physics Lab I,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,5,Physics Lab I,0.88,0.06,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,6,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,6,Physics Lab I,0.83,0.11,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,7,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,7,Physics Lab I,0.44,0.5,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,8,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,8,Physics Lab I,0.18,0.82,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,9,Physics Lab I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,9,Physics Lab I,0.56,0.33,0.0,0.0,0.0,0.0,0.0,0.11,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,11,Physics Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,11,Physics Lab I,0.55,0.36,0.0,0.0,0.0,0.0,0.0,0.09,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,13,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,13,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,14,Physics Lab I,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,14,Physics Lab I,0.75,0.13,0.0,0.0,0.0,0.0,0.0,0.13,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,15,Physics Lab I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,15,Physics Lab I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,16,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,16,Physics Lab I,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,17,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,17,Physics Lab I,0.72,0.28,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,18,Physics Lab I,0.39,0.56,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,20,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,20,Physics Lab I,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,21,Physics Lab I,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,21,Physics Lab I,0.59,0.29,0.06,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,22,Physics Lab I,0.43,0.21,0.14,0.0,0.0,0.0,0.0,0.21,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,22,Physics Lab I,0.43,0.21,0.14,0.0,0.0,0.0,0.0,0.21,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,23,Physics Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,23,Physics Lab I,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,24,Physics Lab I,0.89,0.06,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,25,Physics Lab I,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,25,Physics Lab I,0.38,0.5,0.06,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,26,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,26,Physics Lab I,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,27,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,27,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,29,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,29,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,30,Physics Lab I,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,30,Physics Lab I,0.33,0.56,0.06,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,31,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,31,Physics Lab I,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,32,Physics Lab I,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,32,Physics Lab I,0.59,0.35,0.0,0.06,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,33,Physics Lab I,0.29,0.53,0.12,0.0,0.0,0.0,0.0,0.06,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,33,Physics Lab I,0.29,0.53,0.12,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,34,Physics Lab I,0.41,0.41,0.06,0.0,0.0,0.0,0.0,0.12,daniel ros thompson,,PHYS-1240,2019
+PHYS,1240,34,Physics Lab I,0.41,0.41,0.06,0.0,0.0,0.0,0.0,0.12,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,35,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,bishwambha sengupta,,PHYS-1240,2019
+PHYS,1240,35,Physics Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-1240,2019
+PHYS,2000,1,Introductory Physics,0.31,0.58,0.11,0.0,0.0,0.0,0.0,0.0,pooja puneet,,PHYS-2000,2019
+PHYS,2070,1,General Physics I,0.25,0.2,0.25,0.11,0.13,0.0,0.0,0.07,amy liann pope,,PHYS-2070,2019
+PHYS,2070,2,General Physics I,0.23,0.25,0.23,0.1,0.1,0.0,0.0,0.08,amy liann pope,,PHYS-2070,2019
+PHYS,2080,1,General Physics II,0.58,0.27,0.09,0.04,0.0,0.0,0.01,0.0,amy liann pope,,PHYS-2080,2019
+PHYS,2080,2,General Physics II,0.54,0.35,0.09,0.02,0.0,0.0,0.0,0.0,amy liann pope,,PHYS-2080,2019
+PHYS,2080,4,General Physics II,0.53,0.29,0.14,0.04,0.0,0.0,0.0,0.0,amy liann pope,,PHYS-2080,2019
+PHYS,2090,1,Gen Phys Lab I,0.67,0.25,0.0,0.08,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,2,Gen Phys Lab I,0.58,0.33,0.0,0.04,0.0,0.0,0.0,0.04,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,3,Gen Phys Lab I,0.52,0.48,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,4,Gen Phys Lab I,0.54,0.42,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,5,Gen Phys Lab I,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,6,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,7,Gen Phys Lab I,0.63,0.29,0.0,0.0,0.0,0.0,0.0,0.08,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,8,Gen Phys Lab I,0.88,0.08,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,9,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,,PHYS-2090,2019
+PHYS,2090,10,Gen Phys Lab I,0.67,0.25,0.04,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,,PHYS-2090,2019
+PHYS,2100,2,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,2,Gen Phys Lab II,0.88,0.08,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,3,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,3,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,4,Gen Phys Lab II,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,danielle latham,,PHYS-2100,2019
+PHYS,2100,4,Gen Phys Lab II,0.5,0.46,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,5,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,5,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,6,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,6,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,7,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,7,Gen Phys Lab II,0.63,0.33,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,8,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,8,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,9,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,9,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,10,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,10,Gen Phys Lab II,0.92,0.08,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,11,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,11,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,13,Gen Phys Lab II,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,13,Gen Phys Lab II,0.83,0.13,0.0,0.04,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,14,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,14,Gen Phys Lab II,0.96,0.04,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,15,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,15,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,16,Gen Phys Lab II,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,danielle latham,,PHYS-2100,2019
+PHYS,2100,16,Gen Phys Lab II,0.87,0.09,0.0,0.0,0.0,0.0,0.0,0.04,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,17,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,17,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,18,Gen Phys Lab II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,18,Gen Phys Lab II,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2100,19,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,danielle latham,,PHYS-2100,2019
+PHYS,2100,19,Gen Phys Lab II,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2100,2019
+PHYS,2210,1,Physics with Calculus II,0.15,0.42,0.29,0.05,0.0,0.0,0.06,0.04,jason stratfo brown,,PHYS-2210,2019
+PHYS,2210,2,Physics with Calculus II,0.27,0.37,0.22,0.09,0.0,0.0,0.03,0.02,jason stratfo brown,,PHYS-2210,2019
+PHYS,2210,3,Physics w/Calculus II (HON),0.8,0.13,0.07,0.0,0.0,0.0,0.0,0.0,hugo sanabria,True,PHYS-2210,2019
+PHYS,2210,5,Physics with Calculus II,0.73,0.0,0.13,0.0,0.07,0.0,0.0,0.07,murray daw,,PHYS-2210,2019
+PHYS,2230,2,Physics Lab II,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,yamei liu,,PHYS-2230,2019
+PHYS,2230,2,Physics Lab II,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2230,2019
+PHYS,2230,3,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-2230,2019
+PHYS,2230,3,Physics Lab II,0.39,0.56,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,,PHYS-2230,2019
+PHYS,2230,4,Physics Lab II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2230,2019
+PHYS,2230,4,Physics Lab II,0.94,0.06,0.0,0.0,0.0,0.0,0.0,0.0,yamei liu,,PHYS-2230,2019
+PHYS,2230,5,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,daniel ros thompson,,PHYS-2230,2019
+PHYS,2230,5,Physics Lab II,0.29,0.59,0.12,0.0,0.0,0.0,0.0,0.0,yamei liu,,PHYS-2230,2019
+PHYS,2230,6,Physics Lab II,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,,PHYS-2230,2019
+PHYS,2230,6,Physics Lab II,0.94,0.0,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-2230,2019
+PHYS,2230,7,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-2230,2019
+PHYS,2230,7,Physics Lab II,0.29,0.59,0.06,0.0,0.0,0.0,0.0,0.06,yamei liu,,PHYS-2230,2019
+PHYS,2230,8,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,yamei liu,,PHYS-2230,2019
+PHYS,2230,8,Physics Lab II,0.78,0.11,0.0,0.0,0.0,0.0,0.0,0.11,daniel ros thompson,,PHYS-2230,2019
+PHYS,2230,9,Physics Lab II,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,yamei liu,,PHYS-2230,2019
+PHYS,2230,9,Physics Lab II,0.72,0.22,0.0,0.0,0.0,0.0,0.0,0.06,daniel ros thompson,,PHYS-2230,2019
+PHYS,2400,1,Phys of Weather,0.31,0.35,0.19,0.08,0.04,0.0,0.0,0.04,jens oberheide,,PHYS-2400,2019
+PHYS,3110,1,Methods Theor Phys,0.37,0.21,0.37,0.05,0.0,0.0,0.0,0.0,lih-sin the,,PHYS-3110,2019
+PHYS,3220,1,Mechanics II,0.28,0.17,0.39,0.11,0.06,0.0,0.0,0.0,stephen ro kaeppler,,PHYS-3220,2019
+PHYS,3990,1,CI STEM Competition,0.0,0.0,0.0,0.0,0.0,0.94,0.0,0.06,jason stratfo brown,,PHYS-3990,2019
+PHYS,4560,1,Quantum Physics II,0.58,0.17,0.25,0.0,0.0,0.0,0.0,0.0,sumanta tewari,,PHYS-4560,2019
+PHYS,4650,1,Thermo and Stat Mech,0.39,0.5,0.11,0.0,0.0,0.0,0.0,0.0,mark leising,,PHYS-4650,2019
+PHYS,4750,1,Intro to Cellular Biophysics,0.5,0.2,0.2,0.0,0.0,0.0,0.0,0.1,joshua alper,,PHYS-4750,2019
+PHYS,8150,1,Statistical Therm I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,celestine hackett,,PHYS-8150,2019
+PHYS,8150,1,Statistical Therm I,0.35,0.59,0.06,0.0,0.0,0.0,0.0,0.0,dieter hartmann,,PHYS-8150,2019
+PHYS,8410,1,Electrodynamics I,0.43,0.29,0.21,0.0,0.07,0.0,0.0,0.0,feng ding,,PHYS-8410,2019
+PHYS,9520,1,Quantum Mech II,0.21,0.57,0.14,0.0,0.07,0.0,0.0,0.0,domnita marinescu,,PHYS-9520,2019
+PKSC,1020,1,Intro to Pkg Sci,0.14,0.35,0.28,0.08,0.1,0.0,0.0,0.04,heather batt,,PKSC-1020,2019
+PKSC,2010,100,Pkg Perishable Prod,0.07,0.24,0.35,0.17,0.1,0.0,0.0,0.07,heather batt,,PKSC-2010,2019
+PKSC,2020,1,Packaging Mtl & Mfg,0.33,0.4,0.2,0.0,0.0,0.0,0.0,0.07,pa guerra marcondes,,PKSC-2020,2019
+PKSC,2040,1,Container Systems,0.26,0.48,0.2,0.0,0.03,0.0,0.0,0.03,pa guerra marcondes,,PKSC-2040,2019
+PKSC,2060,1,Container Sys Lab,0.76,0.16,0.08,0.0,0.0,0.0,0.0,0.0,pa guerra marcondes,,PKSC-2060,2019
+PKSC,2060,2,Container Sys Lab,0.83,0.08,0.0,0.0,0.0,0.0,0.0,0.08,pa guerra marcondes,,PKSC-2060,2019
+PKSC,2060,3,Container Sys Lab,0.38,0.54,0.0,0.08,0.0,0.0,0.0,0.0,pa guerra marcondes,,PKSC-2060,2019
+PKSC,2200,1,Product & Pkg Design,0.85,0.05,0.03,0.03,0.03,0.0,0.0,0.03,haley ellis appleby,,PKSC-2200,2019
+PKSC,3680,400,Pkg and Society,0.29,0.53,0.13,0.0,0.04,0.0,0.0,0.01,heather batt,,PKSC-3680,2019
+PKSC,4030,1,Pkg Career Prep,0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4030,2019
+PKSC,4200,1,Pkg Design & Dev,0.58,0.29,0.13,0.0,0.0,0.0,0.0,0.0,robert kimmel,,PKSC-4200,2019
+PKSC,4300,1,Converting Flex Pkg,0.22,0.65,0.12,0.0,0.01,0.0,0.0,0.0,duncan darby,,PKSC-4300,2019
+PKSC,4400,1,Packaging for Distribution,0.25,0.45,0.25,0.03,0.03,0.0,0.0,0.0,gregory batt,,PKSC-4400,2019
+PKSC,4400,400,Packaging for Distribution,0.02,0.47,0.29,0.08,0.14,0.0,0.0,0.0,gregory batt,,PKSC-4400,2019
+PKSC,4640,1,Food & Health Care Pkg Systems,0.63,0.27,0.1,0.0,0.0,0.0,0.0,0.0,kay cooksey,,PKSC-4640,2019
+PKSC,4990,3,CI-Packaging  Sci Seminar,0.92,0.0,0.0,0.0,0.0,0.0,0.0,0.08,rupert hurley,,PKSC-4990,2019
+PKSC,8220,1,Packaging Dynamics,0.75,0.0,0.0,0.0,0.0,0.0,0.0,0.25,gregory batt,,PKSC-8220,2019
+PLPA,2130,1,Fungi & Civilization,0.34,0.39,0.14,0.06,0.03,0.0,0.0,0.04,julia loui kerrigan,,PLPA-2130,2019
+POSC,1010,2,Amer National Govt,0.22,0.44,0.18,0.07,0.04,0.0,0.0,0.04,jeffrey scott peake,,POSC-1010,2019
+POSC,1010,3,Amer National Govt,0.42,0.26,0.13,0.06,0.13,0.0,0.0,0.0,robert carey,,POSC-1010,2019
+POSC,1010,4,Amer National Govt,0.3,0.33,0.2,0.1,0.0,0.0,0.0,0.07,robert carey,,POSC-1010,2019
+POSC,1020,1,Intro Intl Relations,0.34,0.45,0.11,0.01,0.04,0.0,0.0,0.06,steven vince miller,,POSC-1020,2019
+POSC,1020,2,Intro Intl Relations,0.3,0.47,0.13,0.03,0.05,0.0,0.0,0.03,aron geo tannenbaum,,POSC-1020,2019
+POSC,1020,3,Intro Intl Relations,0.43,0.35,0.19,0.0,0.0,0.0,0.0,0.03,marjorie lo jeffrey,,POSC-1020,2019
+POSC,1030,1,Intro to Political Theory,0.67,0.08,0.08,0.17,0.0,0.0,0.0,0.0,jay hoffpauir,,POSC-1030,2019
+POSC,1030,2,Intro to Political Theory,0.11,0.67,0.11,0.04,0.0,0.0,0.04,0.04,john ant pascarella,,POSC-1030,2019
+POSC,1030,3,Intro to Political Theory,0.3,0.26,0.26,0.0,0.13,0.0,0.0,0.04,marjorie lo jeffrey,,POSC-1030,2019
+POSC,1030,4,Intro to Political Theory,0.05,0.15,0.5,0.15,0.1,0.0,0.0,0.05,colin denby pearce,,POSC-1030,2019
+POSC,1030,5,Intro to Political Theory,0.38,0.31,0.17,0.0,0.0,0.0,0.0,0.14,kevin gregory vance,,POSC-1030,2019
+POSC,1040,1,Intro Compar Pol,0.37,0.26,0.28,0.02,0.0,0.0,0.0,0.07,matthe rhodes-purdy,,POSC-1040,2019
+POSC,1990,1,Intro Pol Sci,0.23,0.4,0.15,0.06,0.13,0.0,0.0,0.02,meredith petersheim,,POSC-1990,2019
+POSC,3020,1,State and Loc Gov,0.1,0.66,0.15,0.02,0.02,0.0,0.0,0.05,bruce ransom,,POSC-3020,2019
+POSC,3050,3,Creative Inq in Political Sci,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,xiaobo hu,,POSC-3050,2019
+POSC,3210,1,Public Admin,0.75,0.17,0.08,0.0,0.0,0.0,0.0,0.0,robert carey,,POSC-3210,2019
+POSC,3410,1,Quant Meth in Pol Sc,0.29,0.64,0.07,0.0,0.0,0.0,0.0,0.0,ethan craig busby,,POSC-3410,2019
+POSC,3430,1,Mass Media in Americ Politics,0.68,0.21,0.06,0.0,0.0,0.0,0.0,0.04,ethan craig busby,,POSC-3430,2019
+POSC,3630,1,Us Foreign Policy,0.47,0.38,0.09,0.02,0.0,0.0,0.0,0.04,vladimir matic,,POSC-3630,2019
+POSC,3710,615,European Politics,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,,POSC-3710,2019
+POSC,3810,1,African Amer Politic,0.36,0.64,0.0,0.0,0.0,0.0,0.0,0.0,bruce ransom,,POSC-3810,2019
+POSC,4050,1,American Presidency,0.0,0.28,0.33,0.11,0.22,0.0,0.0,0.06,adam warber,,POSC-4050,2019
+POSC,4080,1,Religion and World Politics,0.38,0.38,0.21,0.0,0.0,0.0,0.0,0.04,laura olson,,POSC-4080,2019
+POSC,4160,1,Int Groups & Soc Mov,0.26,0.44,0.19,0.12,0.0,0.0,0.0,0.0,laura olson,,POSC-4160,2019
+POSC,4210,1,Public Policy,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,,POSC-4210,2019
+POSC,4360,1,Law Courts Politics,0.57,0.26,0.17,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,,POSC-4360,2019
+POSC,4360,2,Law Courts Politics,0.53,0.42,0.06,0.0,0.0,0.0,0.0,0.0,joseph earl stewart,,POSC-4360,2019
+POSC,4370,1,Constitut Law: Rights & Libert,0.5,0.4,0.07,0.0,0.0,0.0,0.0,0.03,kevin gregory vance,,POSC-4370,2019
+POSC,4370,2,Constitut Law: Rights & Libert,0.7,0.18,0.06,0.0,0.0,0.0,0.0,0.06,kevin gregory vance,,POSC-4370,2019
+POSC,4470,1,International Law,0.33,0.17,0.21,0.13,0.13,0.0,0.0,0.04,katherine am curtis,,POSC-4470,2019
+POSC,4480,615,Internat'l Political Economy,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,,POSC-4480,2019
+POSC,4500,1,Conservatism,0.33,0.33,0.29,0.0,0.0,0.0,0.0,0.05,brandon turner,,POSC-4500,2019
+POSC,4530,1,American Political Thought,0.41,0.46,0.11,0.0,0.0,0.0,0.0,0.02,colin denby pearce,,POSC-4530,2019
+POSC,4710,1,Russian Politics,0.33,0.49,0.13,0.0,0.02,0.0,0.0,0.02,aron geo tannenbaum,,POSC-4710,2019
+POSC,4760,1,Middle East Politics,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,vladimir matic,,POSC-4760,2019
+POSC,4770,1,Chinese Politics,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,xiaobo hu,,POSC-4770,2019
+POSC,4890,615,Post Conflict Pol. & Society,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jeffrey scott peake,,POSC-4890,2019
+POSC,4990,1,Prof Dev in Poli Sci,0.0,0.0,0.0,0.0,0.0,0.98,0.0,0.02,meredith petersheim,,POSC-4990,2019
+PRTM,2200,1,Foundations of PRTM,0.19,0.5,0.23,0.08,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2200,2019
+PRTM,2270,1,Prov of Leisure Exp,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,,PRTM-2270,2019
+PRTM,2270,1,Prov of Leisure Exp,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2270,2019
+PRTM,2290,1,Competency Integration in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,herbert chancellor,,PRTM-2290,2019
+PRTM,2290,1,Competency Integration in PRTM,0.83,0.17,0.0,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-2290,2019
+PRTM,2410,1,Intro to CRSCM,0.39,0.26,0.26,0.06,0.0,0.0,0.0,0.03,jamie lynn cathey,,PRTM-2410,2019
+PRTM,2410,2,Intro to CRSCM,0.23,0.27,0.2,0.1,0.0,0.0,0.1,0.1,jamie lynn cathey,,PRTM-2410,2019
+PRTM,2600,1,Found of Recreational Therapy,0.74,0.22,0.04,0.0,0.0,0.0,0.0,0.0,brandi crowe,,PRTM-2600,2019
+PRTM,2700,1,Intro Rec Res Mgt,0.71,0.25,0.04,0.0,0.0,0.0,0.0,0.0,elizabeth baldwin,,PRTM-2700,2019
+PRTM,2810,1,Intro to Golf Mgt,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,adam savedra,,PRTM-2810,2019
+PRTM,3050,1,Safety/Risk Mgt PRTM,0.2,0.47,0.27,0.07,0.0,0.0,0.0,0.0,daniel mor anderson,,PRTM-3050,2019
+PRTM,3070,1,Facility Operations,0.81,0.13,0.0,0.0,0.06,0.0,0.0,0.0,raymond dunham,,PRTM-3070,2019
+PRTM,3210,1,Recreation Admin,0.4,0.34,0.14,0.09,0.0,0.0,0.0,0.03,jamie lynn cathey,,PRTM-3210,2019
+PRTM,3210,2,Recreation Admin,0.18,0.61,0.12,0.03,0.03,0.0,0.0,0.03,jamie lynn cathey,,PRTM-3210,2019
+PRTM,3250,1,Global Persp in Rec,0.2,0.16,0.4,0.04,0.16,0.0,0.0,0.04,harrison pinckney,,PRTM-3250,2019
+PRTM,3250,2,Global Persp in Rec,0.5,0.25,0.14,0.07,0.04,0.0,0.0,0.0,harrison pinckney,,PRTM-3250,2019
+PRTM,3260,2,RT Imp & Eval: Phys Hlth Cond,0.77,0.23,0.0,0.0,0.0,0.0,0.0,0.0,jasmine nu townsend,,PRTM-3260,2019
+PRTM,3270,2,RT Impl & Eval: Ment Hlth Cond,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,heather sext torphy,,PRTM-3270,2019
+PRTM,3420,1,Intro to Tourism,0.89,0.09,0.03,0.0,0.0,0.0,0.0,0.0,katherine dudley,,PRTM-3420,2019
+PRTM,3420,2,Intro to Tourism,0.64,0.27,0.0,0.0,0.0,0.0,0.0,0.09,peter marwa ezra,,PRTM-3420,2019
+PRTM,3430,1,Spl Asp of Tourist B,0.53,0.41,0.06,0.0,0.0,0.0,0.0,0.0,kenneth backman,,PRTM-3430,2019
+PRTM,3440,1,Tourism Markets,0.65,0.23,0.08,0.0,0.0,0.0,0.0,0.04,sheila backman,,PRTM-3440,2019
+PRTM,3440,2,Tourism Markets,0.87,0.1,0.03,0.0,0.0,0.0,0.0,0.0,sheila backman,,PRTM-3440,2019
+PRTM,3450,1,Tourism Management,0.41,0.48,0.1,0.0,0.0,0.0,0.0,0.0,william norman,,PRTM-3450,2019
+PRTM,3450,2,Tourism Management,0.42,0.56,0.0,0.0,0.0,0.0,0.0,0.03,william norman,,PRTM-3450,2019
+PRTM,3460,1,Heritage Tourism,0.5,0.25,0.25,0.0,0.0,0.0,0.0,0.0,gregory phi ramshaw,,PRTM-3460,2019
+PRTM,3460,2,Heritage Tourism,0.41,0.47,0.06,0.0,0.0,0.0,0.0,0.06,gregory phi ramshaw,,PRTM-3460,2019
+PRTM,3530,2,Foundations of Camp Counseling,0.7,0.07,0.07,0.03,0.03,0.0,0.0,0.1,gwynn powell,,PRTM-3530,2019
+PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,alexsandra dubin,,PRTM-3540,2019
+PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,gwynn powell,,PRTM-3540,2019
+PRTM,3540,1,Youth Development in Camp,0.87,0.03,0.03,0.0,0.02,0.0,0.01,0.03,lisa kay-powl olsen,,PRTM-3540,2019
+PRTM,3900,1,PGA GM Player Development,0.56,0.31,0.0,0.13,0.0,0.0,0.0,0.0,richard lucas,,PRTM-3900,2019
+PRTM,3900,1,PGA GM Player Development,0.56,0.31,0.0,0.13,0.0,0.0,0.0,0.0,adam savedra,,PRTM-3900,2019
+PRTM,4300,1,World Geog Parks,0.76,0.16,0.06,0.0,0.0,0.0,0.0,0.02,tori kleinbort,,PRTM-4300,2019
+PRTM,4460,2,Community Tourism,0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,lauren duffy,,PRTM-4460,2019
+PRTM,4540,1,Trends in Sport Mgt,0.61,0.22,0.13,0.04,0.0,0.0,0.0,0.0,skye arthur-banning,,PRTM-4540,2019
+PRTM,4980,1,Creative Inquiry in PRTM IV,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,katrina latri black,,PRTM-4980,2019
+PRTM,4980,1,Creative Inquiry in PRTM IV,0.5,0.5,0.0,0.0,0.0,0.0,0.0,0.0,richard lucas,,PRTM-4980,2019
+PRTM,4980,17,Creative Inquiry in PRTM IV,0.88,0.0,0.0,0.0,0.0,0.0,0.0,0.13,skye arthur-banning,,PRTM-4980,2019
+PRTM,4980,18,Creative Inquiry in PRTM IV,0.82,0.0,0.0,0.0,0.0,0.0,0.0,0.18,skye arthur-banning,,PRTM-4980,2019
+PRTM,8030,1,Sem Rec & Park Admin,0.67,0.24,0.0,0.0,0.05,0.0,0.0,0.05,skye arthur-banning,,PRTM-8030,2019
+PRTM,8110,2,Research Methods,0.84,0.13,0.03,0.0,0.0,0.0,0.0,0.0,rose irene verbos,,PRTM-8110,2019
+PRTM,8130,1,Qualitative Research Methods,0.93,0.0,0.04,0.0,0.0,0.0,0.04,0.0,elizabeth baldwin,,PRTM-8130,2019
+PRTM,8210,1,Funding Strategies in PRTM,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,robert brookover,,PRTM-8210,2019
+PRTM,8250,1,Populations in PRTM,0.75,0.13,0.13,0.0,0.0,0.0,0.0,0.0,teresa walto tucker,,PRTM-8250,2019
+PRTM,8440,1,Outdoor Rec Mgt Plng,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,raymond bivens,,PRTM-8440,2019
+PRTM,8720,1,Adv Facilitation Techniq in RT,0.64,0.36,0.0,0.0,0.0,0.0,0.0,0.0,brandi crowe,,PRTM-8720,2019
+PRTM,8730,2,Adv Theory & Ap in Rec Therapy,0.88,0.12,0.0,0.0,0.0,0.0,0.0,0.0,anna-mar chancellor,,PRTM-8730,2019
+PSYC,2010,1,Intro to Psychology,0.33,0.36,0.2,0.06,0.02,0.0,0.0,0.03,jo jorgensen,,PSYC-2010,2019
+PSYC,2010,2,Intro to Psychology,0.29,0.26,0.19,0.11,0.1,0.0,0.0,0.05,edwin brainerd,,PSYC-2010,2019
+PSYC,2010,3,Intro to Psychology,0.4,0.41,0.13,0.03,0.01,0.0,0.0,0.01,mary taylor,,PSYC-2010,2019
+PSYC,2010,4,Intro to Psychology,0.46,0.3,0.09,0.09,0.01,0.0,0.0,0.04,mary taylor,,PSYC-2010,2019
+PSYC,2010,6,Intro to Psychology,0.61,0.19,0.09,0.03,0.04,0.0,0.0,0.04,fred switzer,,PSYC-2010,2019
+PSYC,2010,7,Intro to Psychology (HON),0.9,0.1,0.0,0.0,0.0,0.0,0.0,0.0,christopher pagano,True,PSYC-2010,2019
+PSYC,2890,1,Fundamentals of Psyc Science,0.55,0.33,0.08,0.01,0.01,0.0,0.0,0.01,peggy jean tyler,,PSYC-2890,2019
+PSYC,3060,1,Human Sexual Behavior,0.52,0.24,0.15,0.04,0.03,0.0,0.0,0.02,bruce michael king,,PSYC-3060,2019
+PSYC,3090,100,Intro Experimental Psychology,0.51,0.27,0.15,0.03,0.03,0.0,0.0,0.01,jennifer bai bisson,,PSYC-3090,2019
+PSYC,3090,200,Intro Experimental Psychology,0.28,0.36,0.24,0.07,0.04,0.0,0.0,0.01,richard tyrrell,,PSYC-3090,2019
+PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,michael shreeves,,PSYC-3100,2019
+PSYC,3100,100,Advanced Experimental Psych,0.28,0.44,0.17,0.11,0.0,0.0,0.0,0.0,jennifer bai bisson,,PSYC-3100,2019
+PSYC,3100,200,Advanced Experimental Psych,0.39,0.44,0.11,0.0,0.06,0.0,0.0,0.0,eric mckibben,,PSYC-3100,2019
+PSYC,3100,300,Advanced Experimental Psych,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,joseph ligato,,PSYC-3100,2019
+PSYC,3100,300,Advanced Experimental Psych,0.5,0.25,0.15,0.0,0.1,0.0,0.0,0.0,robert ray sinclair,,PSYC-3100,2019
+PSYC,3100,400,Advanced Experimental Psych,0.57,0.24,0.14,0.0,0.0,0.0,0.0,0.05,benjamin stephens,,PSYC-3100,2019
+PSYC,3100,500,Advanced Experimental Psych,0.38,0.38,0.19,0.05,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2019
+PSYC,3100,600,Advanced Experimental Psych,0.58,0.42,0.0,0.0,0.0,0.0,0.0,0.0,leo gugerty,,PSYC-3100,2019
+PSYC,3100,700,Advanced Experimental Psych,0.55,0.32,0.14,0.0,0.0,0.0,0.0,0.0,sarah mae sanborn,,PSYC-3100,2019
+PSYC,3240,1,Physiological Psych,0.43,0.27,0.2,0.09,0.0,0.0,0.0,0.01,claudio cantalupo,,PSYC-3240,2019
+PSYC,3240,2,Physiological Psych,0.42,0.33,0.15,0.06,0.0,0.0,0.0,0.04,claudio cantalupo,,PSYC-3240,2019
+PSYC,3330,1,Cognitive Psych,0.33,0.4,0.17,0.03,0.0,0.0,0.0,0.06,robert campbell,,PSYC-3330,2019
+PSYC,3330,2,Cognitive Psych,0.67,0.26,0.03,0.01,0.01,0.0,0.0,0.01,kaileigh ange byrne,,PSYC-3330,2019
+PSYC,3330,3,Cognitive Psych,0.51,0.32,0.12,0.03,0.01,0.0,0.0,0.01,daniel braden quinn,,PSYC-3330,2019
+PSYC,3340,1,Cognitive Psych Lab,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,kathryn lucaites,,PSYC-3340,2019
+PSYC,3340,2,Cognitive Psych Lab,0.62,0.14,0.19,0.0,0.0,0.0,0.0,0.05,kathryn lucaites,,PSYC-3340,2019
+PSYC,3400,1,Lifespan Developmental Psych,0.25,0.38,0.2,0.09,0.0,0.0,0.0,0.08,pamela alley,,PSYC-3400,2019
+PSYC,3400,2,Lifespan Developmental Psych,0.32,0.37,0.21,0.07,0.03,0.0,0.0,0.0,anita pei tam,,PSYC-3400,2019
+PSYC,3520,1,Social Psychology,0.51,0.32,0.12,0.01,0.01,0.0,0.0,0.01,ceren gunsoy,,PSYC-3520,2019
+PSYC,3520,2,Social Psychology,0.37,0.37,0.16,0.09,0.0,0.0,0.0,0.0,jo jorgensen,,PSYC-3520,2019
+PSYC,3520,3,Social Psychology (HON),0.79,0.21,0.0,0.0,0.0,0.0,0.0,0.0,robin mari kowalski,True,PSYC-3520,2019
+PSYC,3570,1,Psychology and Culture,0.56,0.18,0.18,0.05,0.02,0.0,0.0,0.02,ceren gunsoy,,PSYC-3570,2019
+PSYC,3640,1,Industrial Psych,0.15,0.37,0.4,0.08,0.0,0.0,0.0,0.0,eric mckibben,,PSYC-3640,2019
+PSYC,3640,2,Industrial Psych,0.28,0.35,0.29,0.06,0.01,0.0,0.0,0.01,eric mckibben,,PSYC-3640,2019
+PSYC,3680,1,Organizational Psych,0.69,0.24,0.03,0.01,0.01,0.0,0.0,0.01,anton sytine,,PSYC-3680,2019
+PSYC,3700,1,Personality,0.54,0.32,0.09,0.01,0.03,0.0,0.0,0.01,john robert hester,,PSYC-3700,2019
+PSYC,3770,1,Psych of Group & Team Dynamics,0.95,0.03,0.0,0.0,0.0,0.0,0.0,0.03,marissa leig porter,,PSYC-3770,2019
+PSYC,3830,1,Abnormal Psychology,0.3,0.49,0.16,0.04,0.01,0.0,0.0,0.01,cynthia pury,,PSYC-3830,2019
+PSYC,3830,2,Abnormal Psychology,0.4,0.31,0.24,0.06,0.0,0.0,0.0,0.0,jo jorgensen,,PSYC-3830,2019
+PSYC,3830,3,Abnormal Psychology,0.24,0.35,0.29,0.03,0.0,0.0,0.06,0.03,pamela alley,,PSYC-3830,2019
+PSYC,3830,4,Abnormal Psychology,0.17,0.33,0.33,0.13,0.0,0.0,0.0,0.03,pamela alley,,PSYC-3830,2019
+PSYC,4080,1,Women and Psychology,0.54,0.33,0.08,0.04,0.0,0.0,0.0,0.0,robin mari kowalski,,PSYC-4080,2019
+PSYC,4150,1,Systems and Theories,0.24,0.39,0.18,0.06,0.0,0.0,0.0,0.12,robert campbell,,PSYC-4150,2019
+PSYC,4150,2,Systems and Theories,0.29,0.18,0.21,0.24,0.09,0.0,0.0,0.0,edwin brainerd,,PSYC-4150,2019
+PSYC,4150,3,Systems and Theories,0.33,0.3,0.09,0.09,0.15,0.0,0.0,0.03,edwin brainerd,,PSYC-4150,2019
+PSYC,4150,4,Systems and Theories,0.71,0.17,0.06,0.0,0.03,0.0,0.0,0.03,zachary klinefelter,,PSYC-4150,2019
+PSYC,4220,1,Perception,0.55,0.09,0.05,0.23,0.0,0.0,0.0,0.09,claudio cantalupo,,PSYC-4220,2019
+PSYC,4220,2,Perception,0.2,0.4,0.24,0.12,0.04,0.0,0.0,0.0,christopher pagano,,PSYC-4220,2019
+PSYC,4220,3,Perception,0.3,0.17,0.39,0.04,0.04,0.0,0.0,0.04,claudio cantalupo,,PSYC-4220,2019
+PSYC,4350,1,Human Factors,0.46,0.42,0.08,0.0,0.0,0.0,0.0,0.04,laura whitlock,,PSYC-4350,2019
+PSYC,4710,1,Psych of Testing,0.61,0.17,0.09,0.0,0.04,0.0,0.0,0.09,zhuo chen,,PSYC-4710,2019
+PSYC,4800,1,Health Psychology,0.63,0.25,0.13,0.0,0.0,0.0,0.0,0.0,james mccubbin,,PSYC-4800,2019
+PSYC,4800,2,Health Psychology,0.52,0.32,0.12,0.0,0.0,0.0,0.0,0.04,james mccubbin,,PSYC-4800,2019
+PSYC,4880,1,Psychotherapy,0.41,0.18,0.24,0.06,0.06,0.0,0.0,0.06,heidi marie zinzow,,PSYC-4880,2019
+PSYC,4890,1,Organizational Stress,0.75,0.0,0.08,0.0,0.0,0.0,0.0,0.17,chelsea aly lenoble,,PSYC-4890,2019
+PSYC,4890,2,Sports Psychology,0.29,0.41,0.24,0.06,0.0,0.0,0.0,0.0,anita pei tam,,PSYC-4890,2019
+PSYC,4920,1,Senior Laboratory,0.72,0.16,0.08,0.0,0.0,0.0,0.0,0.04,chloe wilson,,PSYC-4920,2019
+PSYC,4920,2,Senior Laboratory,0.79,0.17,0.04,0.0,0.0,0.0,0.0,0.0,chloe wilson,,PSYC-4920,2019
+PSYC,4920,3,Senior Laboratory,0.46,0.42,0.04,0.04,0.04,0.0,0.0,0.0,chloe wilson,,PSYC-4920,2019
+PSYC,4930,100,Pract Clinical Psych,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,heidi marie zinzow,,PSYC-4930,2019
+PSYC,4980,31,Autism Research,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,jennifer bai bisson,,PSYC-4980,2019
+PSYC,4980,33,Autism Research II,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,jennifer bai bisson,,PSYC-4980,2019
+PSYC,4980,121,Stress and Health,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,james mccubbin,,PSYC-4980,2019
+PSYC,4980,251,Critical Thinking,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,benjamin stephens,,PSYC-4980,2019
+PSYC,4980,291,Suicide Prevention,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,martha par thompson,,PSYC-4980,2019
+PSYC,4980,291,Suicide Prevention,0.71,0.0,0.0,0.0,0.0,0.0,0.0,0.29,heidi marie zinzow,,PSYC-4980,2019
+PSYC,8130,1,Research Design III,0.57,0.36,0.07,0.0,0.0,0.0,0.0,0.0,patrick rosopa,,PSYC-8130,2019
+PSYC,8140,1,Quantitative Lab,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,patrick rosopa,,PSYC-8140,2019
+PSYC,8630,1,Work Motivation,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,fred switzer,,PSYC-8630,2019
+RED,8030,1,Pub-Priv Partnership,0.73,0.18,0.09,0.0,0.0,0.0,0.0,0.0,stephen tho buckman,,RED-8030,2019
+RED,8160,1,Preservation Feasibility,0.31,0.69,0.0,0.0,0.0,0.0,0.0,0.0,robert cre benedict,,RED-8160,2019
+RED,8890,1,Selected Topics-Entitlement Pr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,thomas andr sherard,,RED-8890,2019
+RED,8890,1,Selected Topics-Entitlement Pr,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,barry nocks,,RED-8890,2019
+RED,8890,2,Selected Topics-Construction O,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,andrew tay norville,,RED-8890,2019
+REL,1010,1,Intro to Religion,0.21,0.32,0.29,0.03,0.06,0.0,0.0,0.09,peter cohen,,REL-1010,2019
+REL,1010,2,Intro to Religion,0.38,0.29,0.18,0.09,0.03,0.0,0.0,0.03,peter cohen,,REL-1010,2019
+REL,1010,3,Intro to Religion,0.2,0.51,0.2,0.06,0.03,0.0,0.0,0.0,peter cohen,,REL-1010,2019
+REL,1020,2,World Religions,0.24,0.41,0.32,0.0,0.0,0.0,0.0,0.03,robert stephens,,REL-1020,2019
+REL,1020,3,World Religions,0.33,0.36,0.27,0.0,0.03,0.0,0.0,0.0,robert stephens,,REL-1020,2019
+REL,1020,4,World Religions,0.26,0.48,0.13,0.0,0.03,0.0,0.0,0.1,robert stephens,,REL-1020,2019
+REL,3000,1,Studying Religion,0.41,0.38,0.17,0.0,0.0,0.0,0.0,0.03,benjamin white,,REL-3000,2019
+REL,3010,1,Old Testament,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,steven grosby,,REL-3010,2019
+REL,3020,1,New Testament Lit,0.42,0.48,0.06,0.0,0.0,0.0,0.0,0.03,benjamin white,,REL-3020,2019
+REL,3030,1,The Quran,0.22,0.59,0.11,0.0,0.04,0.0,0.0,0.04,mashal saif,,REL-3030,2019
+REL,3070,1,The Christian Tradition,0.17,0.59,0.1,0.0,0.0,0.0,0.0,0.14,brett patterson,,REL-3070,2019
+REL,3100,1,History of Religion in the US,0.28,0.44,0.11,0.06,0.0,0.0,0.0,0.11,elizabeth jemison,,REL-3100,2019
+REL,3170,1,Hist of Native Am Rel/Culture,0.17,0.58,0.17,0.0,0.0,0.0,0.0,0.08,james brad jeffries,,REL-3170,2019
+REL,3350,1,Islam and the West,0.58,0.17,0.08,0.0,0.08,0.0,0.0,0.08,mashal saif,,REL-3350,2019
+REL,3510,1,Ancient Near East,0.5,0.33,0.11,0.0,0.0,0.0,0.0,0.06,steven grosby,,REL-3510,2019
+RS,4590,1,The Community,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,kenneth robinson,,RS-4590,2019
+RUD,8640,1,Urban Design Seminar II,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,broo wortham-galvin,,RUD-8640,2019
+RUD,8650,1,Urban Design Vis & Comm II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,chelsea ma anderson,,RUD-8650,2019
+RUD,8650,1,Urban Design Vis & Comm II,0.67,0.33,0.0,0.0,0.0,0.0,0.0,0.0,broo wortham-galvin,,RUD-8650,2019
+RUSS,1020,1,Elementary Russian,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,stephanie el morris,,RUSS-1020,2019
+SOC,2010,2,Introduction to Sociology,0.58,0.3,0.1,0.0,0.01,0.0,0.0,0.01,carolyn can coffman,,SOC-2010,2019
+SOC,2010,3,Introduction to Sociology,0.88,0.1,0.0,0.0,0.0,0.0,0.0,0.01,andrew mannheimer,,SOC-2010,2019
+SOC,2010,4,Introduction to Sociology,0.57,0.33,0.08,0.01,0.01,0.0,0.0,0.01,shannon mcdonough,,SOC-2010,2019
+SOC,2010,5,Introduction to Sociology,0.49,0.4,0.09,0.01,0.0,0.0,0.0,0.01,shannon mcdonough,,SOC-2010,2019
+SOC,2040,1,Prof Dev for Sociology Majors,0.5,0.25,0.09,0.09,0.06,0.0,0.0,0.0, catherine mobley,,SOC-2040,2019
+SOC,3020,1,Research Methods I,0.31,0.47,0.12,0.02,0.02,0.0,0.0,0.06,miao li,,SOC-3020,2019
+SOC,3040,1,Social Research Methods II,0.32,0.34,0.24,0.08,0.0,0.0,0.0,0.03,ye luo,,SOC-3040,2019
+SOC,3100,1,Marriage & Intimacy,0.68,0.21,0.09,0.0,0.02,0.0,0.0,0.0,carolyn can coffman,,SOC-3100,2019
+SOC,3110,1,The Family,0.37,0.47,0.1,0.02,0.02,0.0,0.0,0.02,andrew whitehead,,SOC-3110,2019
+SOC,3310,1,Urban Sociology,0.7,0.15,0.07,0.0,0.0,0.0,0.0,0.07,william haller,,SOC-3310,2019
+SOC,3500,1,Self & Society,0.67,0.19,0.07,0.05,0.0,0.0,0.0,0.02,carolyn can coffman,,SOC-3500,2019
+SOC,3600,1,Class & Poverty,0.52,0.4,0.08,0.0,0.0,0.0,0.0,0.0,kenneth robinson,,SOC-3600,2019
+SOC,3800,1,Intro Social Service,0.69,0.22,0.04,0.02,0.02,0.0,0.0,0.0,jennifer le holland,,SOC-3800,2019
+SOC,3910,1,Soc of Deviance,0.62,0.31,0.07,0.0,0.0,0.0,0.0,0.0,shannon mcdonough,,SOC-3910,2019
+SOC,3920,1,Juvenile Delinquency,0.85,0.15,0.0,0.0,0.0,0.0,0.0,0.0,andrew mannheimer,,SOC-3920,2019
+SOC,4040,1,Soc Theory,0.55,0.15,0.25,0.05,0.0,0.0,0.0,0.0,william haller,,SOC-4040,2019
+SOC,4320,1,Soc of Religion,0.25,0.41,0.3,0.0,0.0,0.0,0.0,0.05,andrew whitehead,,SOC-4320,2019
+SOC,4590,1,The Community,0.43,0.43,0.0,0.0,0.0,0.0,0.0,0.14,kenneth robinson,,SOC-4590,2019
+SOC,4600,1,Race & Ethnicity,0.74,0.19,0.05,0.0,0.0,0.0,0.0,0.02,andrew mannheimer,,SOC-4600,2019
+SOC,4610,1,Sex & Gender,0.74,0.17,0.04,0.0,0.02,0.0,0.0,0.02,heather kettrey,,SOC-4610,2019
+SOC,4800,1,Medical Sociology,0.58,0.17,0.08,0.08,0.0,0.0,0.0,0.08,miao li,,SOC-4800,2019
+SOC,4840,1,Child Abuse,0.84,0.1,0.02,0.02,0.0,0.0,0.0,0.02,james rosenberger,,SOC-4840,2019
+SOC,4860,1,CI in SOC: Youth Rel Violence,0.83,0.0,0.0,0.0,0.0,0.0,0.0,0.17,carolyn can coffman,,SOC-4860,2019
+SOC,4950,1,Field Experience,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,jennifer le holland,,SOC-4950,2019
+SOC,8050,1,Evaluation Research,0.5,0.33,0.17,0.0,0.0,0.0,0.0,0.0, catherine mobley,,SOC-8050,2019
+SPAN,1010,1,Elementary Spanish,0.53,0.29,0.06,0.0,0.0,0.0,0.0,0.12,rosa mac pillcurima,,SPAN-1010,2019
+SPAN,1010,2,Elementary Spanish,0.43,0.35,0.09,0.09,0.0,0.0,0.0,0.04,rosa mac pillcurima,,SPAN-1010,2019
+SPAN,1010,3,Elementary Spanish,0.38,0.17,0.13,0.08,0.08,0.0,0.0,0.17,rosa mac pillcurima,,SPAN-1010,2019
+SPAN,1020,2,Elementary Spanish,0.71,0.21,0.07,0.0,0.0,0.0,0.0,0.0,andrea patr naranjo,,SPAN-1020,2019
+SPAN,1020,3,Elementary Spanish,0.73,0.27,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-1020,2019
+SPAN,1020,4,Elementary Spanish,0.81,0.1,0.1,0.0,0.0,0.0,0.0,0.0,rosa mac pillcurima,,SPAN-1020,2019
+SPAN,1020,5,Elementary Spanish,0.6,0.36,0.04,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-1020,2019
+SPAN,1020,6,Elementary Spanish,0.7,0.2,0.0,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,,SPAN-1020,2019
+SPAN,1020,7,Elementary Spanish,0.58,0.32,0.05,0.05,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-1020,2019
+SPAN,1020,8,Elementary Spanish,0.5,0.45,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-1020,2019
+SPAN,1020,9,Elementary Spanish,0.33,0.5,0.0,0.0,0.08,0.0,0.0,0.08,debra oa williamson,,SPAN-1020,2019
+SPAN,1020,10,Elementary Spanish,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-1020,2019
+SPAN,2010,1,Intermediate Spanish,0.82,0.09,0.05,0.05,0.0,0.0,0.0,0.0,mercedes tejera,,SPAN-2010,2019
+SPAN,2010,2,Intermediate Spanish,0.88,0.0,0.04,0.0,0.04,0.0,0.0,0.04,mercedes tejera,,SPAN-2010,2019
+SPAN,2010,3,Intermediate Spanish,0.86,0.09,0.05,0.0,0.0,0.0,0.0,0.0,andrea patr naranjo,,SPAN-2010,2019
+SPAN,2010,4,Intermediate Spanish,0.72,0.22,0.0,0.06,0.0,0.0,0.0,0.0,liliana hernandez,,SPAN-2010,2019
+SPAN,2010,5,Intermediate Spanish,0.64,0.24,0.04,0.0,0.0,0.0,0.0,0.08,liliana hernandez,,SPAN-2010,2019
+SPAN,2010,6,Intermediate Spanish,0.23,0.55,0.09,0.05,0.0,0.0,0.0,0.09,melva margu persico,,SPAN-2010,2019
+SPAN,2010,7,Intermediate Spanish,0.3,0.57,0.09,0.04,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-2010,2019
+SPAN,2010,8,Intermediate Spanish,0.55,0.2,0.1,0.05,0.1,0.0,0.0,0.0,mari judez riquelme,,SPAN-2010,2019
+SPAN,2010,9,Intermediate Spanish,0.72,0.16,0.04,0.0,0.0,0.0,0.0,0.08,mari judez riquelme,,SPAN-2010,2019
+SPAN,2010,10,Intermediate Spanish,0.6,0.24,0.16,0.0,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2019
+SPAN,2010,11,Intermediate Spanish,0.65,0.22,0.04,0.09,0.0,0.0,0.0,0.0,ellory schmucker,,SPAN-2010,2019
+SPAN,2010,12,Intermediate Spanish,0.45,0.5,0.05,0.0,0.0,0.0,0.0,0.0,debra oa williamson,,SPAN-2010,2019
+SPAN,2010,13,Intermediate Spanish,0.6,0.25,0.05,0.05,0.0,0.0,0.0,0.05,debra oa williamson,,SPAN-2010,2019
+SPAN,2020,2,Intermediate Spanish,0.39,0.39,0.11,0.0,0.0,0.0,0.0,0.11,juana martin-armas,,SPAN-2020,2019
+SPAN,2020,3,Intermediate Spanish,0.38,0.29,0.24,0.0,0.0,0.0,0.0,0.1,ze cruz valderramos,,SPAN-2020,2019
+SPAN,2020,4,Intermediate Spanish,0.56,0.44,0.0,0.0,0.0,0.0,0.0,0.0,ze cruz valderramos,,SPAN-2020,2019
+SPAN,2020,5,Intermediate Spanish,0.4,0.52,0.08,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-2020,2019
+SPAN,2020,6,Intermediate Spanish,0.56,0.32,0.08,0.0,0.04,0.0,0.0,0.0,danie garcia vieyra,,SPAN-2020,2019
+SPAN,2020,7,Intermediate Spanish,0.5,0.42,0.08,0.0,0.0,0.0,0.0,0.0,ana paula  miller,,SPAN-2020,2019
+SPAN,2020,8,Intermediate Spanish,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.04,ana paula  miller,,SPAN-2020,2019
+SPAN,2020,9,Intermediate Spanish,0.14,0.64,0.14,0.0,0.0,0.0,0.0,0.09,ana paula  miller,,SPAN-2020,2019
+SPAN,2020,10,Intermediate Spanish,0.64,0.16,0.12,0.04,0.0,0.0,0.0,0.04,al garcia rodriguez,,SPAN-2020,2019
+SPAN,2020,11,Intermediate Spanish,0.52,0.32,0.04,0.04,0.0,0.0,0.0,0.08,al garcia rodriguez,,SPAN-2020,2019
+SPAN,2020,12,Intermediate Spanish,0.45,0.41,0.14,0.0,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2019
+SPAN,2020,13,Intermediate Spanish,0.48,0.4,0.08,0.0,0.0,0.0,0.0,0.04,adrienne eliza fama,,SPAN-2020,2019
+SPAN,2020,14,Intermediate Spanish,0.48,0.36,0.08,0.08,0.0,0.0,0.0,0.0,adrienne eliza fama,,SPAN-2020,2019
+SPAN,2020,20,Intermediate Spanish,0.92,0.0,0.04,0.04,0.0,0.0,0.0,0.0,mercedes tejera,,SPAN-2020,2019
+SPAN,3010,1,Spanish Comp for Health Prof,0.47,0.4,0.07,0.07,0.0,0.0,0.0,0.0,tiffany dawn miller,,SPAN-3010,2019
+SPAN,3020,1,Intermed Span Grammar & Comp,0.87,0.13,0.0,0.0,0.0,0.0,0.0,0.0,george palacios,,SPAN-3020,2019
+SPAN,3020,2,Intermed Span Grammar & Comp,0.45,0.36,0.09,0.0,0.0,0.0,0.0,0.09,melva margu persico,,SPAN-3020,2019
+SPAN,3020,3,Intermed Span Grammar & Comp,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,melva margu persico,,SPAN-3020,2019
+SPAN,3040,2,Intro Hispanic Literary Forms,0.88,0.04,0.04,0.0,0.04,0.0,0.0,0.0,george palacios,,SPAN-3040,2019
+SPAN,3050,3,Intermed Span Convers/Comp I,0.86,0.1,0.05,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-3050,2019
+SPAN,3050,4,Intermed Span Convers/Comp I,0.72,0.24,0.04,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-3050,2019
+SPAN,3070,1,The Hispanic World: Spain,0.65,0.35,0.0,0.0,0.0,0.0,0.0,0.0,raquel anido,,SPAN-3070,2019
+SPAN,3070,35,The Hispanic World: Spain,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-3070,2019
+SPAN,3080,1,The Hispanic World: Latin Amer,0.53,0.42,0.0,0.05,0.0,0.0,0.0,0.0,tiffany dawn miller,,SPAN-3080,2019
+SPAN,3080,2,The Hispanic World: Latin Amer,0.78,0.17,0.06,0.0,0.0,0.0,0.0,0.0,al garcia rodriguez,,SPAN-3080,2019
+SPAN,3080,30,The Hispanic World: Latin Amer,0.8,0.0,0.0,0.0,0.0,0.0,0.0,0.2,danie garcia vieyra,,SPAN-3080,2019
+SPAN,3130,1,Span Lit Survey I,0.3,0.4,0.2,0.0,0.0,0.0,0.0,0.1,mon rojas-de-massei,,SPAN-3130,2019
+SPAN,3160,35,Spanish for Int'l Business I,0.69,0.31,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-3160,2019
+SPAN,4030,1,Span Amer Wom Writer,0.86,0.14,0.0,0.0,0.0,0.0,0.0,0.0,graciela tissera,,SPAN-4030,2019
+SPAN,4060,1,Narrative Fiction,0.5,0.4,0.1,0.0,0.0,0.0,0.0,0.0,mon rojas-de-massei,,SPAN-4060,2019
+SPAN,4070,1,Hispanic Film,0.54,0.38,0.08,0.0,0.0,0.0,0.0,0.0,salvador oropesa,,SPAN-4070,2019
+SPAN,4160,35,Spanish for Int'l Trade II,0.7,0.3,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-4160,2019
+SPAN,4190,35,Health & Hispanic Community,0.82,0.18,0.0,0.0,0.0,0.0,0.0,0.0,danie garcia vieyra,,SPAN-4190,2019
+STAT,2220,1,Statistics in Everyday Life,0.31,0.44,0.1,0.09,0.04,0.0,0.0,0.01,james espey,,STAT-2220,2019
+STAT,2220,2,Statistics in Everyday Life,0.47,0.29,0.17,0.03,0.0,0.0,0.0,0.04,james espey,,STAT-2220,2019
+STAT,2220,3,Statistics in Everyday Life,0.48,0.36,0.09,0.05,0.02,0.0,0.0,0.0,james espey,,STAT-2220,2019
+STAT,2220,4,Statistics in Everyday Life,0.31,0.44,0.16,0.04,0.04,0.0,0.0,0.0,james espey,,STAT-2220,2019
+STAT,2220,5,Statistics in Everyday Life,0.4,0.38,0.17,0.04,0.02,0.0,0.0,0.0,ros martinez-dawson,,STAT-2220,2019
+STAT,2220,6,Statistics in Everyday Life,0.31,0.36,0.08,0.13,0.08,0.0,0.0,0.05,ros martinez-dawson,,STAT-2220,2019
+STAT,2220,7,Statistics in Everyday Life,0.35,0.34,0.15,0.04,0.04,0.0,0.0,0.07,ros martinez-dawson,,STAT-2220,2019
+STAT,2300,1,Statistical Methods I,0.09,0.31,0.29,0.11,0.13,0.0,0.0,0.08,morgan elston,,STAT-2300,2019
+STAT,2300,2,Statistical Methods I,0.39,0.28,0.18,0.08,0.03,0.0,0.0,0.04,christy jenki brown,,STAT-2300,2019
+STAT,2300,3,Statistical Methods I,0.25,0.36,0.15,0.15,0.06,0.0,0.0,0.04, erwin walker,,STAT-2300,2019
+STAT,2300,4,Statistical Methods I,0.21,0.41,0.19,0.09,0.08,0.0,0.0,0.03, erwin walker,,STAT-2300,2019
+STAT,2300,5,Statistical Methods I,0.37,0.33,0.21,0.06,0.01,0.0,0.0,0.02,sharon marie evans,,STAT-2300,2019
+STAT,2300,6,Statistical Methods I,0.39,0.34,0.15,0.07,0.02,0.0,0.0,0.03,sharon marie evans,,STAT-2300,2019
+STAT,2300,100,Statistical Methods I (HON),0.59,0.36,0.05,0.0,0.0,0.0,0.0,0.0,christy jenki brown,True,STAT-2300,2019
+STAT,3090,1,Introductory Business Stats,0.35,0.41,0.15,0.0,0.06,0.0,0.0,0.03,anna marie vagnozzi,,STAT-3090,2019
+STAT,3090,2,Introductory Business Stats,0.45,0.36,0.09,0.06,0.03,0.0,0.0,0.0,kristina gorsline,,STAT-3090,2019
+STAT,3090,3,Introductory Business Stats,0.44,0.25,0.19,0.06,0.03,0.0,0.0,0.03,alan robert hahn,,STAT-3090,2019
+STAT,3090,4,Introductory Business Stats,0.27,0.45,0.21,0.0,0.0,0.0,0.0,0.06,trevor squires,,STAT-3090,2019
+STAT,3090,5,Introductory Business Stats,0.28,0.28,0.28,0.03,0.06,0.0,0.0,0.06,yidan guo,,STAT-3090,2019
+STAT,3090,6,Introductory Business Stats,0.39,0.23,0.13,0.03,0.16,0.0,0.0,0.06,yiren ding,,STAT-3090,2019
+STAT,3090,7,Introductory Business Stats,0.37,0.26,0.23,0.06,0.03,0.0,0.0,0.06,paran rebeka norton,,STAT-3090,2019
+STAT,3090,8,Introductory Business Stats,0.21,0.21,0.24,0.18,0.09,0.0,0.0,0.09,michael thoma cowen,,STAT-3090,2019
+STAT,3090,9,Introductory Business Stats,0.18,0.24,0.26,0.18,0.09,0.0,0.0,0.06,sean wal ingimarson,,STAT-3090,2019
+STAT,3090,10,Introductory Business Stats,0.38,0.32,0.12,0.09,0.06,0.0,0.0,0.03,zhengxin wang,,STAT-3090,2019
+STAT,3090,11,Introductory Business Stats,0.24,0.25,0.31,0.1,0.0,0.0,0.07,0.03,april thomas,,STAT-3090,2019
+STAT,3090,12,Introductory Business Stats,0.37,0.29,0.24,0.08,0.0,0.0,0.01,0.0,april thomas,,STAT-3090,2019
+STAT,3090,13,Introductory Business Stats,0.29,0.21,0.21,0.18,0.03,0.0,0.0,0.09,xueheng shi,,STAT-3090,2019
+STAT,3090,14,Introductory Business Stats,0.32,0.24,0.21,0.09,0.0,0.0,0.15,0.0,fun choi john chan,,STAT-3090,2019
+STAT,3090,15,Introductory Business Stats,0.41,0.41,0.12,0.0,0.03,0.0,0.0,0.03,john char nicholson,,STAT-3090,2019
+STAT,3300,1,Statistical Methods II,0.44,0.17,0.22,0.06,0.0,0.0,0.0,0.11,ros martinez-dawson,,STAT-3300,2019
+STAT,4020,1,Intro to Statistical Computing,0.7,0.1,0.1,0.0,0.05,0.0,0.0,0.05,ellen hepfe breazel,,STAT-4020,2019
+STAT,4020,401,Intro to Statistical Computing,0.38,0.31,0.13,0.0,0.0,0.0,0.0,0.19,ellen hepfe breazel,,STAT-4020,2019
+STAT,4110,1,Stat Mthds for Process Control,0.62,0.32,0.05,0.0,0.0,0.0,0.0,0.0,william bridges,,STAT-4110,2019
+STAT,4110,2,Stat Mthds for Process Control,0.81,0.19,0.0,0.0,0.0,0.0,0.0,0.0,richard stev dubsky,,STAT-4110,2019
+STAT,4110,3,Stat Mthds for Process Control,0.7,0.2,0.1,0.0,0.0,0.0,0.0,0.0,richard stev dubsky,,STAT-4110,2019
+STAT,6020,1,Intro to Statistical Computing,0.4,0.5,0.1,0.0,0.0,0.0,0.0,0.0,ellen hepfe breazel,,STAT-6020,2019
+STAT,6020,401,Intro to Statistical Computing,0.33,0.5,0.08,0.0,0.0,0.0,0.0,0.08,ellen hepfe breazel,,STAT-6020,2019
+STAT,8010,2,Statistical Methods I,0.57,0.39,0.0,0.0,0.0,0.0,0.0,0.04,william bridges,,STAT-8010,2019
+STAT,8010,3,Statistical Methods I,0.42,0.47,0.11,0.0,0.0,0.0,0.0,0.0,deborah eliz kunkel,,STAT-8010,2019
+STAT,8010,4,Statistical Methods I,0.61,0.0,0.11,0.0,0.17,0.0,0.0,0.11,jun luo,,STAT-8010,2019
+STAT,8010,5,Statistical Methods I,0.71,0.29,0.0,0.0,0.0,0.0,0.0,0.0,joseph daniel bible,,STAT-8010,2019
+STAT,8010,400,Statistical Methods I,0.41,0.55,0.0,0.0,0.0,0.0,0.0,0.03,brook thaye russell,,STAT-8010,2019
+STAT,8010,400,Statistical Methods I,0.41,0.55,0.0,0.0,0.0,0.0,0.0,0.03,deborah eliz kunkel,,STAT-8010,2019
+STAT,8050,1,Design & Anlys of Experiments,0.56,0.22,0.04,0.0,0.0,0.0,0.0,0.19,patrick gerard,,STAT-8050,2019
+STS,1010,1,Survey Sci & Techn in Society,0.63,0.34,0.0,0.0,0.0,0.0,0.0,0.03,kenneth dav widgren,,STS-1010,2019
+STS,1010,2,Survey Sci & Techn in Society,0.44,0.35,0.15,0.0,0.0,0.0,0.0,0.06,scott brame,,STS-1010,2019
+STS,1010,3,Survey Sci & Techn in Society,0.53,0.33,0.06,0.06,0.0,0.0,0.03,0.0,elizabeth stansell,,STS-1010,2019
+STS,1010,4,Survey Sci & Techn in Society,0.97,0.03,0.0,0.0,0.0,0.0,0.0,0.0,melissa dugan,,STS-1010,2019
+STS,1010,5,Survey Sci & Techn in Society,0.38,0.49,0.08,0.0,0.03,0.0,0.0,0.03,philip randall,,STS-1010,2019
+STS,1010,6,Survey Sci & Techn in Society,0.09,0.51,0.17,0.03,0.03,0.0,0.0,0.17,sarah mae cooper,,STS-1010,2019
+STS,1010,7,Survey Sci & Techn in Society,0.26,0.43,0.06,0.03,0.14,0.0,0.0,0.09,megan no macalystre,,STS-1010,2019
+STS,1010,8,Survey Sci & Techn in Society,0.25,0.59,0.06,0.03,0.0,0.0,0.0,0.06,david charles foltz,,STS-1010,2019
+STS,1010,9,Survey Sci & Techn in Society,0.81,0.14,0.03,0.0,0.0,0.0,0.0,0.03,christine cl murphy,,STS-1010,2019
+STS,1010,10,Survey Sci & Techn in Society,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,alexander billinis,,STS-1010,2019
+THEA,2100,1,Theatre Appreciation,0.56,0.28,0.13,0.03,0.0,0.0,0.0,0.0,kerrie kath seymour,,THEA-2100,2019
+THEA,2100,2,Theatre Appreciation,0.42,0.29,0.23,0.03,0.0,0.0,0.0,0.03,kendra lyne johnson,,THEA-2100,2019
+THEA,2100,4,Theatre Appreciation,0.58,0.32,0.1,0.0,0.0,0.0,0.0,0.0,carol collins,,THEA-2100,2019
+THEA,2100,5,Theatre Appreciation,0.59,0.31,0.09,0.0,0.0,0.0,0.0,0.0,jason adkins,,THEA-2100,2019
+THEA,2790,1,Theatre Practicum,0.88,0.0,0.0,0.06,0.0,0.0,0.0,0.06,matthew leckenbusch,,THEA-2790,2019
+THEA,3090,1,Surv of Broadway II,0.8,0.2,0.0,0.0,0.0,0.0,0.0,0.0,lisa sain odom,,THEA-3090,2019
+THEA,3150,1,Theatre History I,0.65,0.29,0.0,0.0,0.03,0.0,0.0,0.03,shannon ther robert,,THEA-3150,2019
+THEA,3180,1,Afri-Amer Thea II,0.66,0.21,0.14,0.0,0.0,0.0,0.0,0.0,kendra lyne johnson,,THEA-3180,2019
+THEA,3740,1,Movement for Actors,0.75,0.0,0.17,0.08,0.0,0.0,0.0,0.0,kerrie kath seymour,,THEA-3740,2019
+THEA,3980,1,Special Topics in Theatre,0.6,0.4,0.0,0.0,0.0,0.0,0.0,0.0,shannon ther robert,,THEA-3980,2019
+WFB,3000,1,Wildlife Biology,0.43,0.29,0.2,0.06,0.01,0.0,0.0,0.0,catherine jachowski,,WFB-3000,2019
+WFB,3010,1,Wildlife Biology Lab,0.61,0.28,0.11,0.0,0.0,0.0,0.0,0.0,shari lyn rodriguez,,WFB-3010,2019
+WFB,3130,1,Conservation Biology,0.35,0.34,0.24,0.04,0.03,0.0,0.0,0.01,shari lyn rodriguez,,WFB-3130,2019
+WFB,3130,2,Conservation Biology,0.29,0.32,0.27,0.05,0.02,0.0,0.0,0.05,shari lyn rodriguez,,WFB-3130,2019
+WFB,4120,1,Wildlife Management,0.78,0.22,0.0,0.0,0.0,0.0,0.0,0.0,greg yarrow,,WFB-4120,2019
+WFB,4160,1,Fisheries Techniques,0.63,0.34,0.02,0.0,0.0,0.0,0.0,0.0,troy mason farmer,,WFB-4160,2019
+WFB,4620,1,Wetland Wildlife Biology,0.55,0.39,0.06,0.0,0.0,0.0,0.0,0.0,russell barrett,,WFB-4620,2019
+WFB,4680,1,Herpetology,0.38,0.43,0.19,0.0,0.0,0.0,0.0,0.0,jeffrey robert mohr,,WFB-4680,2019
+WFB,4930,2,Quantitative Ecology,0.43,0.52,0.0,0.0,0.0,0.0,0.0,0.05,laura gigliotti,,WFB-4930,2019
+WFB,8500,1,Wildlife & Fisheries Ecology,0.38,0.38,0.05,0.0,0.05,0.0,0.0,0.14,mark scott,,WFB-8500,2019
+WFB,8500,1,Wildlife & Fisheries Ecology,0.38,0.38,0.05,0.0,0.05,0.0,0.0,0.14,susan talley guynn,,WFB-8500,2019
+WFB,8610,1,Scientific Writing,0.47,0.47,0.0,0.0,0.0,0.0,0.0,0.07,stefanie whitmire,,WFB-8610,2019
+WFB,8610,3,Hum Dim/Fisheries & WL -OnLine,0.79,0.14,0.0,0.0,0.07,0.0,0.0,0.0,shari lyn rodriguez,,WFB-8610,2019
+WFB,8630,1,Non Thesis Project,0.82,0.0,0.09,0.0,0.0,0.0,0.0,0.09,althea simone hagan,,WFB-8630,2019
+WS,1030,1,Women in Global Perspective,0.78,0.17,0.04,0.0,0.0,0.0,0.0,0.0,sarah mae cooper,,WS-1030,2019
+WS,3010,1,Intro Women's Studies,0.58,0.33,0.04,0.04,0.0,0.0,0.0,0.0,elizabeth ros adams,,WS-3010,2019
+WS,3010,2,Intro Women's Studies,0.46,0.38,0.13,0.0,0.0,0.0,0.0,0.04,elizabeth ros adams,,WS-3010,2019
+WS,4010,1,Senior Seminar,0.69,0.13,0.19,0.0,0.0,0.0,0.0,0.0,diane perpich,,WS-4010,2019
+YDP,3100,1,Youth Developmt and the Family,0.72,0.16,0.0,0.0,0.04,0.0,0.0,0.08,william quinn,,YDP-3100,2019
+YDP,3150,2,Community & Youth Dev Systems,0.89,0.11,0.0,0.0,0.0,0.0,0.0,0.0,stephen lance,,YDP-3150,2019
+YDP,3250,1,Working with Diverse Youth,0.94,0.03,0.0,0.0,0.0,0.0,0.0,0.03,kimberly pe johnson,,YDP-3250,2019
+YDP,3350,1,Youth Activity Leadership,0.82,0.14,0.0,0.0,0.05,0.0,0.0,0.0,alexandra sandoval,,YDP-3350,2019
+YDP,3400,1,Deliver Effective Youth Progra,0.85,0.1,0.05,0.0,0.0,0.0,0.0,0.0,kellye rembert,,YDP-3400,2019
+YDP,4400,1,Youth Program Assessmnt & Eval,0.58,0.26,0.0,0.11,0.0,0.0,0.0,0.05,ann marie gillard,,YDP-4400,2019
+YDP,8010,1,Child/Adolescent Dev,0.85,0.11,0.0,0.0,0.04,0.0,0.0,0.0,edmond patri bowers,,YDP-8010,2019
+YDP,8040,1,Assess & Eval of Youth Program,0.7,0.15,0.15,0.0,0.0,0.0,0.0,0.0,barry garst,,YDP-8040,2019
+YDP,8880,1,Special Topics Youth Dev Ldshp,0.73,0.23,0.05,0.0,0.0,0.0,0.0,0.0,barry garst,,YDP-8880,2019

--- a/bot/cogs/grades_cog/assets/2020_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2020_Fall.csv
@@ -1,3020 +1,3020 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
-AAH,1010,1.0,Survey of Art & Arch Histor,0.51,0.4,0.04,0.02,0.0,0%,0.0,0.03,beth ann lauritis,
-AAH,2050,1.0,Art History and Theory I,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.0,beth ann lauritis,
-AAH,3050,1.0,Contemporary Art History,0.58,0.37,0.0,0.05,0.0,0%,0.0,0.0,andrea feeser,
-ACCT,2010,1.0,Financial Accounting Conc,0.36,0.38,0.2,0.02,0.02,0%,0.0,0.02,lydia schleifer,
-ACCT,2010,2.0,Financial Accounting Conc,0.44,0.31,0.15,0.02,0.04,0%,0.0,0.05,lydia schleifer,
-ACCT,2010,3.0,Financial Accounting Conc,0.17,0.32,0.25,0.07,0.12,0%,0.0,0.07,robert wahlman,
-ACCT,2010,4.0,Financial Accounting Conc,0.26,0.26,0.26,0.13,0.03,0%,0.0,0.08,charles tegen,
-ACCT,2010,5.0,Financial Accounting Conc,0.41,0.36,0.13,0.03,0.05,0%,0.0,0.03,charles tegen,
-ACCT,2010,6.0,Financial Accounting Conc,0.45,0.33,0.05,0.05,0.05,0%,0.0,0.08,julie grant,
-ACCT,2010,7.0,Financial Accounting Conc,0.21,0.44,0.31,0.03,0.0,0%,0.0,0.03,julie grant,
-ACCT,2010,8.0,Financial Accounting Conc,0.51,0.33,0.07,0.07,0.0,0%,0.0,0.02,lydia schleifer,
-ACCT,2010,9.0,Financial Accounting Conc,0.38,0.3,0.18,0.1,0.05,0%,0.0,0.0,julie grant,
-ACCT,2010,10.0,Financial Accounting Conc,0.5,0.2,0.23,0.08,0.0,0%,0.0,0.0,julie grant,
-ACCT,2010,11.0,Financial Accounting Conc,0.35,0.31,0.21,0.04,0.08,0%,0.0,0.0,lisa birtwistle,
-ACCT,2010,12.0,Financial Accounting Conc,0.28,0.39,0.25,0.0,0.03,0%,0.0,0.03,lisa birtwistle,
-ACCT,2010,13.0,Financial Accounting Conc,0.34,0.39,0.13,0.03,0.05,0%,0.0,0.05,lisa birtwistle,
-ACCT,2010,14.0,Financial Accounting Conc,0.18,0.32,0.28,0.1,0.0,0%,0.0,0.12,jeffrey mcmillan,
-ACCT,2010,15.0,Financial Accounting Conc,0.23,0.34,0.31,0.03,0.0,0%,0.0,0.09,carl hollingsworth,
-ACCT,2010,400.0,Financial Accounting Conc,0.09,0.28,0.36,0.12,0.05,0%,0.0,0.1,jeffrey mcmillan,
-ACCT,2010,401.0,Financial Accounting Conc,0.26,0.21,0.26,0.11,0.09,0%,0.0,0.07,emily mccorkle,
-ACCT,2020,1.0,Managerial Accounting Co,0.38,0.43,0.18,0.03,0.0,0%,0.0,0.0,robin radtke,
-ACCT,2020,2.0,Managerial Accounting Co,0.4,0.28,0.18,0.03,0.03,0%,0.0,0.1,robin radtke,
-ACCT,2020,3.0,Managerial Accounting Co,0.21,0.13,0.3,0.11,0.09,0%,0.0,0.15,brian todd carver,
-ACCT,2020,4.0,Managerial Accounting Co,0.12,0.29,0.19,0.12,0.1,0%,0.0,0.17,brian todd carver,
-ACCT,2020,400.0,Managerial Accounting Co,0.23,0.49,0.23,0.0,0.0,0%,0.0,0.05,robin radtke,
-ACCT,2020,401.0,Managerial Accounting Co,0.28,0.33,0.17,0.1,0.05,0%,0.0,0.07,emily mccorkle,
-ACCT,2020,402.0,Managerial Accounting Co,0.33,0.22,0.28,0.05,0.03,0%,0.0,0.09,emily mccorkle,
-ACCT,2020,403.0,Managerial Accounting Co,0.1,0.4,0.15,0.2,0.08,0%,0.0,0.08,emily mccorkle,
-ACCT,2020,404.0,Managerial Accounting Co,0.1,0.28,0.26,0.13,0.08,0%,0.0,0.15,emily mccorkle,
-ACCT,3030,1.0,Cost Accounting,0.38,0.35,0.23,0.03,0.03,0%,0.0,0.0,daniel thomas way,
-ACCT,3030,2.0,Cost Accounting,0.25,0.33,0.35,0.03,0.03,0%,0.0,0.03,daniel thomas way,
-ACCT,3030,3.0,Cost Accounting,0.26,0.32,0.32,0.05,0.03,0%,0.0,0.03,jace garrett,
-ACCT,3030,4.0,Cost Accounting,0.16,0.42,0.26,0.0,0.05,0%,0.0,0.11,jace garrett,
-ACCT,3030,5.0,Cost Accounting,0.77,0.13,0.08,0.03,0.0,0%,0.0,0.0,sarah martin,
-ACCT,3110,1.0,Intermediate Financial Acc,0.17,0.34,0.31,0.03,0.07,0%,0.0,0.07,amy donnelly,
-ACCT,3110,2.0,Intermediate Financial Acc,0.3,0.3,0.3,0.04,0.07,0%,0.0,0.0,amy donnelly,
-ACCT,3110,3.0,Intermediate Financial Acc,0.31,0.38,0.23,0.04,0.0,0%,0.0,0.04,annieka philo,
-ACCT,3110,4.0,Intermediate Financial Acc,0.26,0.35,0.23,0.06,0.06,0%,0.0,0.03,annieka philo,
-ACCT,3110,5.0,Intermediate Financial Acc,0.04,0.25,0.36,0.11,0.18,0%,0.0,0.07, russell madray,
-ACCT,3110,6.0,Intermediate Financial Acc,0.18,0.42,0.18,0.06,0.09,0%,0.0,0.06, russell madray,
-ACCT,3110,7.0,Intermediate Financial Acc,0.19,0.41,0.28,0.0,0.0,0%,0.0,0.09, russell madray,
-ACCT,3110,8.0,Intermediate Financial Acc,0.23,0.42,0.1,0.19,0.03,0%,0.0,0.03, russell madray,
-ACCT,3120,1.0,Intermediate Financial Acc,0.1,0.41,0.31,0.05,0.05,0%,0.0,0.08,jeremy vinson,
-ACCT,3120,2.0,Intermediate Financial Acc,0.33,0.44,0.17,0.0,0.03,0%,0.0,0.03,jeremy vinson,
-ACCT,3120,3.0,Intermediate Financial Acc,0.14,0.23,0.31,0.14,0.11,0%,0.0,0.06,terry daniel knause,
-ACCT,3120,4.0,Intermediate Financial Acc,0.17,0.4,0.3,0.07,0.0,0%,0.0,0.07,terry daniel knause,
-ACCT,3120,5.0,Intermediate Financial Acc,0.18,0.36,0.3,0.06,0.09,0%,0.0,0.0,terry daniel knause,
-ACCT,3120,6.0,Intermediate Financial Acc,0.22,0.42,0.17,0.06,0.14,0%,0.0,0.0,terry daniel knause,
-ACCT,3130,1.0,Analytics for Acct Dec Mak,0.69,0.29,0.03,0.0,0.0,0%,0.0,0.0,james barnes,
-ACCT,3130,2.0,Analytics for Acct Dec Mak,0.89,0.09,0.0,0.03,0.0,0%,0.0,0.0,james barnes,
-ACCT,3130,3.0,Analytics for Acct Dec Mak,0.27,0.38,0.15,0.15,0.04,0%,0.0,0.0,phebian davis-culler,
-ACCT,3130,4.0,Analytics for Acct Dec Mak,0.25,0.39,0.25,0.0,0.11,0%,0.0,0.0,phebian davis-culler,
-ACCT,3130,5.0,Analytics for Acct Dec Mak,0.25,0.3,0.3,0.1,0.05,0%,0.0,0.0,phebian davis-culler,
-ACCT,3220,1.0,Accounting Information Sy,0.15,0.19,0.42,0.08,0.12,0%,0.0,0.04,philip maiberger,
-ACCT,3220,2.0,Accounting Information Sy,0.27,0.31,0.35,0.0,0.04,0%,0.0,0.04,philip maiberger,
-ACCT,3220,3.0,Accounting Information Sy,0.13,0.3,0.23,0.17,0.07,0%,0.0,0.1,philip maiberger,
-ACCT,3220,4.0,Accounting Information Sy,0.11,0.29,0.25,0.11,0.04,0%,0.0,0.21,philip maiberger,
-ACCT,4040,1.0,Individual Taxation,0.61,0.32,0.04,0.0,0.0,0%,0.0,0.04,sarah martin,
-ACCT,4040,2.0,Individual Taxation,0.46,0.29,0.23,0.0,0.03,0%,0.0,0.0,sarah martin,
-ACCT,4040,3.0,Individual Taxation,0.47,0.41,0.09,0.0,0.03,0%,0.0,0.0,lisa birtwistle,
-ACCT,4040,4.0,Individual Taxation,0.49,0.29,0.17,0.03,0.03,0%,0.0,0.0,sarah martin,
-ACCT,4080,1.0,Retire & Estate Plan,0.28,0.5,0.16,0.03,0.0,0%,0.0,0.03,john hine,
-ACCT,4100,2.0,Reporting and Mgmt Contr,0.24,0.39,0.33,0.03,0.0,0%,0.0,0.0,gregory mcphee,
-ACCT,4100,3.0,Reporting and Mgmt Contr,0.33,0.45,0.18,0.03,0.0,0%,0.0,0.0,gregory mcphee,
-ACCT,4150,1.0,Auditing,0.28,0.38,0.19,0.13,0.03,0%,0.0,0.0,nancy lee harp,
-ACCT,4150,2.0,Auditing,0.38,0.46,0.13,0.04,0.0,0%,0.0,0.0,nancy lee harp,
-ACCT,8510,1.0,Tax Research,0.41,0.53,0.03,0.0,0.0,0%,0.0,0.03,thomas dickens,
-ACCT,8530,1.0,Adv Acct Problems,0.74,0.15,0.04,0.0,0.0,0%,0.0,0.07,suzanne pearse,
-ACCT,8530,2.0,Adv Acct Problems,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0,suzanne pearse,
-ACCT,8530,3.0,Adv Acct Problems,0.45,0.45,0.03,0.0,0.03,0%,0.0,0.03,ralph edward welton,
-ACCT,8570,1.0,CPA Exam Review-B,0.0,0.0,0.0,0.0,0.0,96%,0.03,0.01,james barnes,
-ACCT,8630,1.0,Forensics Analysis,0.48,0.45,0.03,0.0,0.0,0%,0.0,0.03,brian goodson,
-ACCT,8630,2.0,Forensics Analysis,0.35,0.62,0.03,0.0,0.0,0%,0.0,0.0,brian goodson,
-ACCT,8650,1.0,Tax & Bus Decisions,0.55,0.39,0.06,0.0,0.0,0%,0.0,0.0,judson jahn,
-ACCT,8650,2.0,Tax & Bus Decisions,0.41,0.56,0.04,0.0,0.0,0%,0.0,0.0,judson jahn,
-ACCT,8680,1.0,Advanced Accounting Anal,0.47,0.47,0.06,0.0,0.0,0%,0.0,0.0,marc cussatt,
-ACCT,8680,2.0,Advanced Accounting Anal,0.59,0.34,0.03,0.0,0.0,0%,0.0,0.03,marc cussatt,
-ACCT,8680,3.0,Advanced Accounting Anal,0.39,0.55,0.03,0.0,0.0,0%,0.0,0.03,marc cussatt,
-ACCT,8720,1.0,Tax of Flowthroughs,0.25,0.44,0.28,0.0,0.0,0%,0.0,0.03,thomas dickens,
-AGED,1020,1.0,Freshman Seminar,0.58,0.33,0.0,0.08,0.0,0%,0.0,0.0, dibenedetto,
-AGED,2000,1.0,Agr Appl of Ed Tech,0.62,0.0,0.08,0.0,0.0,0%,0.0,0.15,kevin layfield,
-AGED,2010,1.0,Intro to Agric Educ,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,philip fravel,
-AGED,2040,1.0,App Ag Calculations,0.29,0.57,0.0,0.07,0.07,0%,0.0,0.0,philip fravel,
-AGED,3030,1.0,Ag Ed Mech Tech,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,christopher eck,
-AGED,8100,3.0,Clin Ag Ed Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,kevin layfield,
-AGM,1010,1.0,Intro Ag Mech & Bus,0.47,0.34,0.11,0.03,0.03,0%,0.0,0.03,hunter massey,
-AGM,2050,1.0,Prin of Fabrication,0.22,0.51,0.22,0.04,0.0,0%,0.0,0.02,hunter massey,
-AGM,2210,1.0,Land Measurements,0.45,0.31,0.09,0.04,0.07,0%,0.0,0.04,brennan teddy,
-AGM,3010,1.0,Soil Water Conserv,0.45,0.29,0.22,0.0,0.02,0%,0.0,0.02,calvin sawyer,
-AGM,4000,1.0,Seminar in Ag Mech & Busi,0.13,0.29,0.32,0.24,0.03,0%,0.0,0.0,john chastain,
-AGM,4020,1.0,Irrigation System Design,0.24,0.24,0.24,0.1,0.19,0%,0.0,0.0,charles privette,
-AGM,4050,1.0,Env Cont in Anim Str,0.05,0.27,0.35,0.22,0.11,0%,0.0,0.0,john chastain,
-AGM,4060,1.0,Mech & Hydraulic Sys,0.39,0.48,0.11,0.0,0.02,0%,0.0,0.0,ali bulent koc,
-AGM,4600,1.0,Electrical Systems,0.69,0.29,0.02,0.0,0.0,0%,0.0,0.0,charles privette,
-AGM,4730,4.0,Ag Safety,0.61,0.22,0.11,0.06,0.0,0%,0.0,0.0,hunter massey,
-AGRB,2020,1.0,Agricultural Economics,0.7,0.17,0.03,0.03,0.05,0%,0.0,0.01,julie carl pingol ureta pingol,
-AGRB,2050,1.0,Agriculture and Society,0.16,0.16,0.22,0.31,0.11,0%,0.0,0.04,michael vassalos,
-AGRB,3020,1.0,Economics of Farm Manag,0.16,0.13,0.15,0.28,0.08,0%,0.0,0.2,michael vassalos,
-AGRB,3080,2.0,Quant Agribusiness Analysi,0.12,0.21,0.14,0.33,0.1,0%,0.0,0.1,lisha zhang,
-AGRB,3570,1.0,Natural Resources Econom,0.2,0.11,0.23,0.18,0.11,0%,0.0,0.16,david brian willis,
-AGRB,4120,1.0,Reg Econ Devel Theory & P,0.3,0.22,0.11,0.16,0.08,0%,0.0,0.08,figueiredo silva de,
-AGRB,4520,1.0,Agricultural Policy,0.14,0.21,0.19,0.28,0.14,0%,0.0,0.05,michael vassalos,
-AGRB,4600,2.0,Agricultural Finance,0.18,0.33,0.23,0.18,0.03,0%,0.0,0.03,lisha zhang,
-AGRB,4910,1.0,"Int, Agrib & Comm & Rural",0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,michael vassalos,
-AL,3490,400.0,Principles of Coaching,0.64,0.24,0.12,0.0,0.0,0%,0.0,0.0,deborah cadorette,
-AL,3490,401.0,Principles of Coaching,0.48,0.32,0.08,0.0,0.08,0%,0.0,0.04,deborah cadorette,
-AL,3490,402.0,Principles of Coaching,0.52,0.32,0.12,0.0,0.04,0%,0.0,0.0,deborah cadorette,
-AL,3490,403.0,Principles of Coaching,0.65,0.17,0.13,0.04,0.0,0%,0.0,0.0,deborah cadorette,
-AL,3490,405.0,Principles of Coaching,0.73,0.2,0.0,0.07,0.0,0%,0.0,0.0,frank mezzanotte,
-AL,3490,406.0,Principles of Coaching,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,frank mezzanotte,
-AL,3490,408.0,Principles of Coaching,0.48,0.26,0.17,0.04,0.0,0%,0.0,0.0,john plumblee,
-AL,3490,409.0,Principles of Coaching,0.88,0.04,0.08,0.0,0.0,0%,0.0,0.0,edmond fry,
-AL,3490,410.0,Principles of Coaching,0.59,0.18,0.14,0.05,0.0,0%,0.0,0.05,joel neuder,
-AL,3490,411.0,Principles of Coaching,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,nicholas whitrow,
-AL,3500,400.0,Sci Basis I/Ex Phy,0.27,0.38,0.23,0.04,0.0,0%,0.0,0.08,michael godfrey,
-AL,3500,401.0,Sci Basis I/Ex Phy,0.44,0.32,0.2,0.04,0.0,0%,0.0,0.0,isaac sean colbert,
-AL,3530,400.0,Athletic Injuries,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,isaac sean colbert,
-AL,3530,401.0,Athletic Injuries,0.8,0.12,0.04,0.04,0.0,0%,0.0,0.0,isaac sean colbert,
-AL,3600,400.0,Hgh Sch Athl Ethical/Legal,0.37,0.53,0.11,0.0,0.0,0%,0.0,0.0,clyde keith connor,
-AL,3610,400.0,Admin/Org of Athletic Pro,0.76,0.2,0.04,0.0,0.0,0%,0.0,0.0,henry oates,
-AL,3610,401.0,Admin/Org of Athletic Pro,0.76,0.2,0.04,0.0,0.0,0%,0.0,0.0,henry oates,
-AL,3610,402.0,Admin/Org of Athletic Pro,0.35,0.35,0.2,0.0,0.1,0%,0.0,0.0,john plumblee,
-AL,3620,400.0,Psychology of Coaching,0.33,0.42,0.17,0.04,0.04,0%,0.0,0.0,natalie anne carter,
-AL,3620,401.0,Psychology of Coaching,0.28,0.36,0.24,0.12,0.0,0%,0.0,0.0,natalie anne carter,
-AL,3620,402.0,Psychology of Coaching,0.32,0.24,0.32,0.08,0.04,0%,0.0,0.0,natalie anne carter,
-AL,3740,400.0,Coaching Football,0.52,0.16,0.16,0.04,0.04,0%,0.0,0.08,edmond fry,
-AL,3740,401.0,Coaching Football,0.45,0.18,0.18,0.09,0.05,0%,0.0,0.05,edmond fry,
-AL,3760,400.0,Coaching Strength/Conditi,0.67,0.13,0.08,0.0,0.08,0%,0.0,0.04,edmond fry,
-AL,3760,401.0,Coaching Strength/Conditi,0.68,0.2,0.04,0.0,0.04,0%,0.0,0.04,edmond fry,
-AL,4000,400.0,Athletic Leadership Interns,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,deborah cadorette,
-AL,4380,402.0,HS Athletic Recruiting,0.61,0.13,0.17,0.04,0.04,0%,0.0,0.0,justin hickey,
-AL,4380,404.0,Emerging Issues and Trend,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.0,misty soles,
-AL,4380,408.0,Officiating in AL,0.75,0.2,0.0,0.05,0.0,0%,0.0,0.0,clyde keith connor,
-AL,4380,409.0,Coaching Baseball/Softball,0.71,0.06,0.24,0.0,0.0,0%,0.0,0.0,justin hickey,
-AL,8440,401.0,Surv of Res Mthds in Athle,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,michael godfrey,
-AL,8440,402.0,Surv of Res Mthds in Athle,0.75,0.08,0.08,0.0,0.08,0%,0.0,0.0,michael godfrey,
-AL,8490,401.0,Athletic Leadership Dev,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,janna magette,
-AL,8490,402.0,Athletic Leadership Dev,0.6,0.25,0.0,0.0,0.15,0%,0.0,0.0,janna magette,
-AL,8500,400.0,Principles Strength and Co,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,michael godfrey,
-AL,8500,401.0,Principles Strength and Co,0.58,0.37,0.0,0.0,0.05,0%,0.0,0.0,michael godfrey,
-AL,8630,400.0,Socio Dynam in Intercol At,0.55,0.27,0.0,0.0,0.09,0%,0.0,0.09,michael godfrey,
-ANTH,2010,1.0,Introduction to Anthropol,0.35,0.34,0.17,0.08,0.03,0%,0.0,0.04,yi wu,
-ANTH,2010,2.0,Introduction to Anthropol,0.22,0.48,0.18,0.05,0.04,0%,0.0,0.04,yi wu,
-ANTH,2010,3.0,Introduction to Anthropol,0.06,0.16,0.24,0.04,0.13,0%,0.0,0.37,john coggeshall,
-ANTH,2010,4.0,Introduction to Anthropol,0.58,0.3,0.04,0.0,0.02,0%,0.0,0.04,david markus,
-ANTH,2010,5.0,Introduction to Anthropol,0.67,0.23,0.04,0.0,0.04,0%,0.0,0.02,david markus,
-ANTH,2010,6.0,Introduction to Anthropol,0.04,0.34,0.2,0.11,0.04,0%,0.0,0.27,john coggeshall,
-ANTH,2010,7.0,Introduction to Anthropol,0.62,0.35,0.04,0.0,0.0,0%,0.0,0.0,david markus,
-ANTH,3010,1.0,Cultural Anthropology,0.14,0.32,0.39,0.07,0.04,0%,0.0,0.04,john coggeshall,
-ANTH,3200,1.0,North American Indian Cul,0.13,0.27,0.2,0.13,0.2,0%,0.0,0.07,john coggeshall,
-ANTH,3320,1.0,World Archaeology,0.4,0.44,0.08,0.0,0.04,0%,0.0,0.04,david markus,
-ANTH,3510,1.0,Biological Anthropology,0.66,0.13,0.13,0.0,0.06,0%,0.0,0.03,katherine weisensee,
-ANTH,4280,1.0,"Law, Culture and Society",0.57,0.21,0.0,0.0,0.14,0%,0.0,0.07,yi wu,
-ARCH,1010,1.0,Introduction to Architectur,0.42,0.35,0.03,0.02,0.04,0%,0.0,0.07, hambright-belue,
-ARCH,2040,1.0,Hist of Modern Arch,0.56,0.31,0.11,0.01,0.0,0%,0.0,0.0,andreea mihalache,
-ARCH,2510,1.0,Arch Foundations I,0.86,0.07,0.07,0.0,0.0,0%,0.0,0.0,joseph choma,
-ARCH,2510,2.0,Arch Foundations I,0.43,0.36,0.21,0.0,0.0,0%,0.0,0.0,brandon george pass,
-ARCH,2510,3.0,Arch Foundations I,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,virginia ellyn melnyk,
-ARCH,2510,4.0,Arch Foundations I,0.62,0.23,0.08,0.0,0.08,0%,0.0,0.0,byron jefferies,
-ARCH,2510,5.0,Arch Foundations I,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,kendall roberts,
-ARCH,2510,6.0,Arch Foundations I,0.46,0.31,0.08,0.08,0.0,0%,0.0,0.08,timothy sutherland,
-ARCH,2700,1.0,Structures I,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,grace fulmer,
-ARCH,2710,1.0,Structures II,0.48,0.33,0.07,0.0,0.04,0%,0.0,0.0,amy christine trick,
-ARCH,3500,1.0,Intro to Urban Contexts,0.47,0.47,0.0,0.0,0.0,0%,0.0,0.06,douglas hecker,
-ARCH,3500,2.0,Intro to Urban Contexts,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,berrin terim,
-ARCH,3500,3.0,Intro to Urban Contexts,0.33,0.56,0.11,0.0,0.0,0%,0.0,0.0,david lee,
-ARCH,3500,4.0,Intro to Urban Contexts,0.69,0.13,0.19,0.0,0.0,0%,0.0,0.0,clarissa mendez,
-ARCH,3500,5.0,Intro to Urban Contexts,0.4,0.4,0.2,0.0,0.0,0%,0.0,0.0,julie poe wilkerson,
-ARCH,3510,1.0,Studio Clemson,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,dustin albright,
-ARCH,3540,1.0,Studio Barcelona,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,
-ARCH,4010,1.0,Architectural Portfolio,0.62,0.24,0.1,0.0,0.0,0%,0.0,0.05,clarissa mendez,
-ARCH,4010,2.0,Architectural Portfolio,0.59,0.29,0.12,0.0,0.0,0%,0.0,0.0,virginia ellyn melnyk,
-ARCH,4010,3.0,Architectural Portfolio,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,george schafer,
-ARCH,4010,4.0,Architectural Portfolio,0.57,0.33,0.05,0.0,0.05,0%,0.0,0.0,brandon george pass,
-ARCH,4120,2.0,History Research,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,
-ARCH,4140,2.0,Design Seminar,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,
-ARCH,6850,1.0,H/Th: Arch+Health,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dina battisto,
-ARCH,8100,1.0,Visualization I,0.83,0.09,0.04,0.0,0.0,0%,0.0,0.0,joseph choma,
-ARCH,8210,1.0,Research Methods,0.83,0.15,0.0,0.0,0.0,0%,0.0,0.02,dina battisto,
-ARCH,8410,1.0,Arch Studio I,0.55,0.36,0.0,0.0,0.0,0%,0.0,0.0,peter laurence,
-ARCH,8410,2.0,Arch Studio I,0.6,0.3,0.0,0.0,0.1,0%,0.0,0.0,ufuk ersoy,
-ARCH,8510,1.0,Design Studio III,0.33,0.58,0.08,0.0,0.0,0%,0.0,0.0,ulrike ann- heine,
-ARCH,8510,2.0,Design Studio III,0.17,0.83,0.0,0.0,0.0,0%,0.0,0.0,santa cruz franco,
-ARCH,8510,3.0,Design Studio III,0.31,0.54,0.08,0.0,0.0,0%,0.0,0.08,george schafer,
-ARCH,8570,1.0,Design Studio V,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,dustin albright,
-ARCH,8570,4.0,Design Studio V,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,raymond huff,
-ARCH,8600,1.0,History/Theory I,0.57,0.38,0.0,0.0,0.0,0%,0.0,0.0,berrin terim,
-ARCH,8700,1.0,Structures I,0.71,0.12,0.06,0.0,0.06,0%,0.0,0.0,dustin albright,
-ARCH,8790,2.0,Digtial Manufacturing Proc,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,douglas hecker,
-ARCH,8810,1.0,Pro Practice Survey,0.76,0.22,0.0,0.0,0.0,0%,0.0,0.02,byron malet edwards,
-ARCH,8950,1.0,A+H Studio: Projects,0.35,0.59,0.0,0.0,0.0,0%,0.0,0.0,david allison,
-ART,1050,1.0,Foundation Drawing I,0.6,0.2,0.1,0.1,0.0,0%,0.0,0.0,lori brook johnson,
-ART,1510,1.0,Foundations Art I,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,cuba rachel lynn de lynn,
-ART,1510,2.0,Foundations Art I,0.6,0.3,0.0,0.1,0.0,0%,0.0,0.0,brooks harris stevens,
-ART,2100,1.0,Art Appreciation,0.91,0.0,0.0,0.05,0.05,0%,0.0,0.0,dustin massey,
-ART,2100,2.0,Art Appreciation,0.86,0.09,0.0,0.05,0.0,0%,0.0,0.0,megan waller,
-ART,2100,4.0,Art Appreciation,0.82,0.09,0.0,0.05,0.0,0%,0.0,0.05,dustin massey,
-ART,2100,5.0,Art Appreciation,0.91,0.05,0.0,0.0,0.05,0%,0.0,0.0,drie katherine van,
-ART,2100,6.0,Art Appreciation,0.75,0.15,0.05,0.0,0.05,0%,0.0,0.0,dustin massey,
-ART,2150,1.0,Begin Graphic Design,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,david sidney gerhard,
-ART,4200,1.0,Time Base & Digital Art Fn,0.5,0.1,0.1,0.0,0.2,0%,0.0,0.1,cuba rachel lynn de lynn,
-AS,1090,1.0,Heritage & Values of USAF,0.82,0.06,0.0,0.0,0.0,0%,0.0,0.12,joseph blanton,
-AS,1090,2.0,Heritage & Values of USAF,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,joseph blanton,
-AS,1090,3.0,Heritage & Values of USAF,0.94,0.0,0.06,0.0,0.0,0%,0.0,0.0,joseph blanton,
-AS,2090,2.0,Team & Ldrshp Fundamen,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,ryan pierce,
-AS,3090,1.0,Leading & Effective Comm,0.91,0.0,0.09,0.0,0.0,0%,0.0,0.0,wayne leneau,
-ASL,1010,1.0,Am Sign Lang I,0.58,0.21,0.21,0.0,0.0,0%,0.0,0.0,jason hurdich,
-ASL,1010,2.0,Am Sign Lang I,0.83,0.08,0.04,0.0,0.04,0%,0.0,0.0,william clements,
-ASL,1010,3.0,Am Sign Lang I,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,william clements,
-ASL,1010,4.0,Am Sign Lang I,0.76,0.16,0.08,0.0,0.0,0%,0.0,0.0,jody herbert cripps,
-ASL,1020,1.0,Am Sign Lang I,0.7,0.17,0.09,0.0,0.0,0%,0.0,0.04,jason hurdich,
-ASL,1020,2.0,Am Sign Lang I,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,jason hurdich,
-ASL,2010,1.0,Am Sign Lang II,0.67,0.21,0.0,0.08,0.0,0%,0.0,0.04,dunn kim misener,
-ASL,2010,2.0,Am Sign Lang II,0.63,0.33,0.04,0.0,0.0,0%,0.0,0.0,dunn kim misener,
-ASL,2020,1.0,Am Sign Lang II,0.31,0.56,0.13,0.0,0.0,0%,0.0,0.0,jason hurdich,
-ASL,2020,2.0,Am Sign Lang II,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dunn kim misener,
-ASL,3010,1.0,Advanced A S L I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dunn kim misener,
-ASL,3490,2.0,Adv App in Asl,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.0,william clements,
-ASL,4010,1.0,Linguistics of ASL,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,jody herbert cripps,
-ASTR,1010,1.0,Solar System Astronomy,0.61,0.22,0.07,0.06,0.01,0%,0.0,0.02,david connick,
-ASTR,1010,2.0,Solar System Astronomy,0.57,0.32,0.05,0.03,0.02,0%,0.0,0.01,david connick,
-ASTR,1020,1.0,Stellar Astronomy,0.57,0.28,0.1,0.01,0.03,0%,0.0,0.01,joan marler,
-ASTR,1030,1.0,Solar Systm Astr Lab,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,david connick,
-ASTR,1030,2.0,Solar Systm Astr Lab,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,david connick,
-ASTR,1030,3.0,Solar Systm Astr Lab,0.5,0.38,0.0,0.04,0.0,0%,0.0,0.08,david connick,
-ASTR,1030,4.0,Solar Systm Astr Lab,0.45,0.41,0.05,0.0,0.05,0%,0.0,0.05,david connick,
-ASTR,1030,5.0,Solar Systm Astr Lab,0.5,0.38,0.04,0.04,0.04,0%,0.0,0.0,david connick,
-ASTR,1030,6.0,Solar Systm Astr Lab,0.7,0.22,0.0,0.04,0.0,0%,0.0,0.04,david connick,
-ASTR,1030,7.0,Solar Systm Astr Lab,0.39,0.48,0.09,0.0,0.04,0%,0.0,0.0,david connick,
-ASTR,1030,8.0,Solar Systm Astr Lab,0.43,0.39,0.09,0.0,0.09,0%,0.0,0.0,david connick,
-ASTR,1030,9.0,Solar Systm Astr Lab,0.48,0.43,0.0,0.0,0.04,0%,0.0,0.04,david connick,
-ASTR,1030,10.0,Solar Systm Astr Lab,0.38,0.54,0.0,0.08,0.0,0%,0.0,0.0,david connick,
-ASTR,1030,11.0,Solar Systm Astr Lab,0.71,0.13,0.13,0.0,0.04,0%,0.0,0.0,david connick,
-ASTR,1040,1.0,Stellar Astr Lab,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,david connick,
-ASTR,1040,2.0,Stellar Astr Lab,0.79,0.04,0.13,0.0,0.04,0%,0.0,0.0,david connick,
-ASTR,1040,4.0,Stellar Astr Lab,0.74,0.22,0.04,0.0,0.0,0%,0.0,0.0,david connick,
-ASTR,3020,1.0,Stellar Astrophysics,0.53,0.33,0.07,0.0,0.0,0%,0.0,0.07,mark leising,
-AUD,1850,1.0,Intro to Audio Tech,0.46,0.23,0.08,0.08,0.08,0%,0.0,0.08,hamilton altstatt,
-AUD,2800,1.0,Sound Reinforcement,0.3,0.5,0.1,0.0,0.1,0%,0.0,0.0,kenneth moore,
-AUE,6010,1.0,Vehicle Dynamics,0.7,0.25,0.0,0.0,0.0,0%,0.0,0.05,matthias schmid,
-AUE,6020,1.0,Adv & Electrified Powertra,0.5,0.19,0.13,0.0,0.06,0%,0.0,0.13,benjamin lawler,
-AUE,6080,1.0,Vehicle Testing & Characte,0.5,0.23,0.23,0.0,0.0,0%,0.0,0.0,james potter,
-AUE,6930,3.0,Lightweight Design Using C,0.71,0.23,0.03,0.0,0.0,0%,0.0,0.03,srikanth pilla,
-AUE,8260,1.0,Vehicle Diagnostics,0.38,0.54,0.0,0.0,0.0,0%,0.0,0.08,pierluigi pisu,
-AUE,8270,1.0,Auto Cntrl Sys Des,0.73,0.17,0.05,0.0,0.0,0%,0.0,0.05,qilun zhu,
-AUE,8330,30.0,Auto Manuf Proc Devl,0.53,0.41,0.03,0.0,0.0,0%,0.0,0.03,michael mears,
-AUE,8350,100.0,Auto Electronics,0.73,0.2,0.0,0.0,0.0,0%,0.0,0.07,yunyi jia,
-AUE,8570,1.0,Light-Weight Automotive,0.86,0.0,0.14,0.0,0.0,0%,0.0,0.0,david schmueser,
-AUE,8690,1.0,Qual Assur Automotiv Ma,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,dee ann wood kivett wood,
-AUE,8700,1.0,Automotive Business Conc,0.6,0.36,0.02,0.0,0.0,0%,0.0,0.02,johnell brooks,
-AUE,8810,3.0,Automotive Systems Over,0.4,0.4,0.12,0.0,0.0,0%,0.0,0.08,christiaan paredis,
-AUE,8930,1.0,Adv Vehicle Struct Analysis,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,david schmueser,
-AUE,8930,5.0,Robust Predictive Control,0.52,0.22,0.22,0.0,0.0,0%,0.0,0.04,beshah ayalew,
-AUE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert prucka,
-AUE,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yunyi jia,
-AUE,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,srikanth pilla,
-AUE,9910,21.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rahul rai,
-AVS,1000,1.0,Orientation to AVS,0.79,0.1,0.07,0.02,0.02,0%,0.0,0.01,kristine lang vernon,
-AVS,1500,1.0,Intro Animal Science,0.26,0.46,0.23,0.04,0.01,0%,0.0,0.01,joseph bertrand,
-AVS,1500,2.0,Intro Animal Science,0.2,0.47,0.24,0.06,0.0,0%,0.0,0.02,joseph bertrand,
-AVS,1510,1.0,Intro Ani Sci Lab,0.6,0.32,0.08,0.0,0.0,0%,0.0,0.0,richelle miller,
-AVS,1510,2.0,Intro Ani Sci Lab,0.86,0.1,0.0,0.05,0.0,0%,0.0,0.0,richelle miller,
-AVS,1510,3.0,Intro Ani Sci Lab,0.67,0.25,0.04,0.04,0.0,0%,0.0,0.0,richelle miller,
-AVS,1510,5.0,Intro Ani Sci Lab,0.55,0.25,0.05,0.1,0.0,0%,0.0,0.05,richelle miller,
-AVS,1510,6.0,Intro Ani Sci Lab,0.61,0.26,0.04,0.09,0.0,0%,0.0,0.0,richelle miller,
-AVS,1510,7.0,Intro Ani Sci Lab,0.81,0.13,0.0,0.0,0.0,0%,0.0,0.06,richelle miller,
-AVS,1510,8.0,Intro Ani Sci Lab,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,richelle miller,
-AVS,1510,9.0,Intro Ani Sci Lab,0.43,0.5,0.07,0.0,0.0,0%,0.0,0.0,richelle miller,
-AVS,2040,1.0,Horse Care Techniques,0.87,0.1,0.0,0.0,0.03,0%,0.0,0.0,chelsea sinclair,
-AVS,3010,1.0,Anat & Phys Dom Ani,0.67,0.26,0.04,0.0,0.0,0%,0.0,0.02,glenn birrenkott,
-AVS,3010,400.0,Anat & Phys Dom Ani,0.54,0.42,0.0,0.04,0.0,0%,0.0,0.0,glenn birrenkott,
-AVS,3100,1.0,Animal Health,0.78,0.16,0.03,0.0,0.03,0%,0.0,0.0,james strickland,
-AVS,3700,1.0,Principles of Animal Nutriti,0.59,0.25,0.08,0.02,0.0,0%,0.0,0.03,james strickland,
-AVS,3750,1.0,Applied Animal Nutrition,0.22,0.39,0.26,0.04,0.0,0%,0.0,0.09,gustavo jose lascano,
-AVS,4100,1.0,Domestic Ani Behav,0.84,0.08,0.07,0.01,0.0,0%,0.0,0.0,ahmed badr ali,
-AVS,4100,2.0,Domestic Ani Behav,0.88,0.06,0.06,0.0,0.0,0%,0.0,0.0,ahmed badr ali,
-AVS,4110,1.0,Animal Growth and Develo,0.58,0.24,0.06,0.05,0.05,0%,0.0,0.03,susan kay duckett,
-AVS,4150,1.0,Contemporary Issues in AV,0.57,0.33,0.04,0.01,0.03,0%,0.0,0.01,chelsea sinclair,
-AVS,4160,1.0,Equine Exercise Phys,0.47,0.37,0.05,0.0,0.11,0%,0.0,0.0,kristine lang vernon,
-AVS,4500,1.0,Sustain Livestock Product,0.27,0.67,0.07,0.0,0.0,0%,0.0,0.0,matias jose aguerre,
-AVS,4530,1.0,Animal Reproduction,0.13,0.49,0.13,0.18,0.0,0%,0.0,0.07,scott lee pratt,
-AVS,4650,1.0,Animal Physiology I,0.74,0.15,0.07,0.04,0.0,0%,0.0,0.0,heather walker dunn,
-AVS,4800,1.0,Vertebrate Endocrinology,0.81,0.13,0.03,0.0,0.03,0%,0.0,0.0,heather walker dunn,
-AVS,4910,13.0,Analysis of Natural Produc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,james strickland,
-AVS,4920,6.0,Grazing Horses CI,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,brittany perron,
-AVS,8070,1.0,Prin of Sci Writing in AFLS,0.54,0.31,0.0,0.0,0.0,0%,0.0,0.15,jeryl jones,
-BCHM,1030,1.0,Careers in Bioch/Gen,0.83,0.1,0.02,0.0,0.04,0%,0.0,0.02,alison starr-moss,
-BCHM,3010,1.0,Molecular Biochemistry,0.54,0.26,0.1,0.08,0.02,0%,0.0,0.0,cheryl ingram-smith,
-BCHM,3050,2.0,Essen Elements Bioch,0.45,0.33,0.17,0.0,0.04,0%,0.0,0.01,heidi anderson,
-BCHM,3050,3.0,Essen Elements Bioch,0.34,0.37,0.14,0.04,0.08,0%,0.0,0.03,suchitra chavan,
-BCHM,3050,4.0,Essen Elements Bioch,0.58,0.31,0.07,0.02,0.01,0%,0.0,0.01,heidi anderson,
-BCHM,3050,5.0,Essen Elements Bioch,0.33,0.45,0.12,0.05,0.0,0%,0.0,0.04,suchitra chavan,
-BCHM,4310,1.0,Physical Approach to Bioch,0.35,0.33,0.26,0.05,0.01,0%,0.0,0.0,weiguo cao,
-BCHM,4310,2.0,Phys App to Bioch (HON),0.5,0.42,0.08,0.0,0.0,0%,0.0,0.0,weiguo cao,True
-BCHM,4330,1.0,Physical Biochemistry Lab,0.81,0.13,0.06,0.0,0.0,0%,0.0,0.0,geoffrey ford,
-BCHM,4330,2.0,Physical Biochemistry Lab,0.81,0.13,0.0,0.0,0.06,0%,0.0,0.0,geoffrey ford,
-BCHM,4330,3.0,Physical Biochemistry Lab,0.81,0.06,0.13,0.0,0.0,0%,0.0,0.0,geoffrey ford,
-BCHM,4330,4.0,Physical Biochemistry Lab,0.88,0.06,0.0,0.06,0.0,0%,0.0,0.0,geoffrey ford,
-BCHM,4330,5.0,Physical Biochemistry Lab,0.76,0.0,0.12,0.06,0.06,0%,0.0,0.0,geoffrey ford,
-BCHM,4400,1.0,Bioinformatics,0.82,0.05,0.05,0.0,0.07,0%,0.0,0.02,frank feltus,
-BCHM,4430,1.0,Molecular Basis of Disease,0.55,0.36,0.09,0.0,0.0,0%,0.0,0.0,james morris,
-BCHM,8250,1.0,Seminar I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rajandeep sekhon,
-BDSI,8000,1.0,Biomed Data Sci & Info Se,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brian dean,
-BE,2100,1.0,Intro to Biosystems Engr,0.85,0.11,0.0,0.0,0.0,0%,0.0,0.04,gamboa vanegas,
-BE,3200,1.0,Principles & Prac of Geom,0.59,0.32,0.09,0.0,0.0,0%,0.0,0.0,tom owino,
-BE,4100,1.0,Biological Kinetics,0.22,0.57,0.22,0.0,0.0,0%,0.0,0.0,caye marie drapcho,
-BE,4150,1.0,Instr & Control for Biosys E,0.53,0.33,0.0,0.07,0.07,0%,0.0,0.0,rui xiao,
-BE,4210,1.0,Engr Sys for Soil Water Mg,0.81,0.06,0.13,0.0,0.0,0%,0.0,0.0,christophe darnault,
-BE,4740,1.0,BE Design Project Managm,0.88,0.06,0.06,0.0,0.0,0%,0.0,0.0,tom owino,
-BE,4750,1.0,BE Capstone Design,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,christophe darnault,
-BIOE,1010,1.0,Biol for Bioengr,0.67,0.2,0.07,0.0,0.0,0%,0.0,0.0,tyler george harvey,
-BIOE,2000,1.0,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,98%,0.0,0.01,agneta simionescu,
-BIOE,2010,2.0,Intro Biomed Engr,0.4,0.5,0.07,0.02,0.01,0%,0.0,0.01,charles webb,
-BIOE,3000,1.0,Bioeng Ethics Entrepreneu,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,tyler george harvey,
-BIOE,3020,1.0,Biomaterials,0.67,0.25,0.05,0.0,0.0,0%,0.0,0.03,alexey vertegel,
-BIOE,3100,1.0,Engr Analysis of Physiol Pr,0.85,0.14,0.01,0.0,0.0,0%,0.0,0.0,brian william booth,
-BIOE,3200,1.0,Biomechanics,0.68,0.3,0.0,0.0,0.0,0%,0.0,0.03,jiro nagatomi,
-BIOE,3210,1.0,Biofluid Mechanics,0.62,0.31,0.07,0.0,0.0,0%,0.0,0.0,zhi gao,
-BIOE,3460,1.0,Biomolecular Thermodyna,0.43,0.41,0.14,0.0,0.0,0%,0.0,0.01,robert latour,
-BIOE,3470,1.0,Transport Processes in Bio,0.8,0.14,0.02,0.04,0.0,0%,0.0,0.0,renee nicole cottle,
-BIOE,3700,1.0,Bioinst & Imaging,0.67,0.3,0.04,0.0,0.0,0%,0.0,0.0,jordon gilmore,
-BIOE,4000,1.0,Bioengr Leadshp & MedTe,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,martine laberge,
-BIOE,4010,1.0,Bioengineering Design The,0.97,0.03,0.0,0.0,0.0,0%,0.0,0.0,john desjardins,
-BIOE,4010,2.0,Bioengineering Design The,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,john desjardins,
-BIOE,4030,1.0,Applied Bio E Design,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,ravikiran singapogu,
-BIOE,4120,1.0,Orthopaedic Engr and Path,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,melinda harman,
-BIOE,4350,1.0,Computational Modeling i,0.61,0.33,0.0,0.0,0.0,0%,0.0,0.06,william richardson,
-BIOE,4400,1.0,Biopharmaceutical Engine,0.37,0.42,0.05,0.0,0.0,0%,0.0,0.16,sarah harcum,
-BIOE,4480,1.0,Tissue Engineering,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,angela alexander,
-BIOE,6120,1.0,Orthopaedic Engr & Pathol,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,melinda harman,
-BIOE,6340,1.0,Cardiovascular Biomechani,0.5,0.33,0.17,0.0,0.0,0%,0.0,0.0,ethan kung,
-BIOE,6350,1.0,Computational Modeling i,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,william richardson,
-BIOE,6400,1.0,Biopharmaceutical Engine,0.42,0.5,0.0,0.0,0.0,0%,0.0,0.08,sarah harcum,
-BIOE,8000,843.0,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,ann catherine foley,
-BIOE,8020,1.0,Biocompatibility,0.25,0.75,0.0,0.0,0.0,0%,0.0,0.0,narendra vyavahare,
-BIOE,8900,2.0,Bioengineering Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy mercuri,
-BIOE,9910,3.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,john desjardins,
-BIOE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melinda harman,
-BIOE,9910,11.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy mercuri,
-BIOE,9910,13.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,william richardson,
-BIOE,9910,17.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,narendra vyavahare,
-BIOE,9910,805.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy gilbert,
-BIOL,1010,1.0,Frontiers in Biology I,0.82,0.13,0.03,0.0,0.01,0%,0.0,0.01,michael childress,
-BIOL,1010,2.0,Frontiers in Biology I,0.87,0.09,0.01,0.01,0.01,0%,0.0,0.0,michael childress,
-BIOL,1030,1.0,General Biology I,0.29,0.25,0.24,0.12,0.08,0%,0.0,0.02,nora espinoza,
-BIOL,1030,2.0,General Biology I,0.27,0.38,0.18,0.08,0.04,0%,0.0,0.05,cassandra joy may,
-BIOL,1030,3.0,General Biology I,0.24,0.22,0.4,0.01,0.05,0%,0.0,0.07,salvatore sparace,
-BIOL,1030,4.0,General Biology I,0.22,0.29,0.22,0.11,0.08,0%,0.0,0.09,nathan redding,
-BIOL,1030,5.0,General Biology I (HON),0.48,0.33,0.19,0.0,0.0,0%,0.0,0.0,nora espinoza,True
-BIOL,1040,1.0,General Biology II,0.52,0.39,0.06,0.0,0.0,0%,0.0,0.03,donna weinbrenner,
-BIOL,1050,1.0,General Biology Lab I,0.63,0.17,0.08,0.04,0.04,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,2.0,General Biology Lab I,0.91,0.04,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,3.0,General Biology Lab I,0.58,0.25,0.08,0.0,0.0,0%,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,4.0,General Biology Lab I,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,5.0,General Biology Lab I,0.61,0.26,0.09,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,6.0,General Biology Lab I,0.5,0.33,0.04,0.0,0.0,0%,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,7.0,General Biology Lab I,0.42,0.46,0.04,0.04,0.04,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,8.0,General Biology Lab I,0.83,0.04,0.0,0.04,0.04,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,9.0,General Biology Lab I,0.42,0.21,0.08,0.08,0.04,0%,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,10.0,General Biology Lab I,0.22,0.3,0.3,0.0,0.09,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,11.0,General Biology Lab I,0.46,0.33,0.08,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,12.0,General Biology Lab I,0.17,0.5,0.04,0.0,0.08,0%,0.0,0.21,tafadzwa kaisa,
-BIOL,1050,13.0,General Biology Lab I,0.46,0.29,0.08,0.08,0.04,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,14.0,General Biology Lab I,0.29,0.5,0.08,0.04,0.08,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,15.0,General Biology Lab I,0.52,0.3,0.0,0.0,0.13,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,16.0,General Biology Lab I,0.63,0.33,0.04,0.0,0.0,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,17.0,General Biology Lab I,0.33,0.38,0.08,0.08,0.08,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,18.0,General Biology Lab I,0.48,0.26,0.0,0.04,0.09,0%,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,19.0,General Biology Lab I,0.54,0.29,0.0,0.04,0.04,0%,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,20.0,General Biology Lab I,0.74,0.13,0.09,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,21.0,General Biology Lab I,0.46,0.29,0.08,0.04,0.13,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,22.0,General Biology Lab I,0.54,0.21,0.08,0.08,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,23.0,General Biology Lab I,0.58,0.17,0.08,0.0,0.04,0%,0.0,0.13,tafadzwa kaisa,
-BIOL,1050,24.0,General Biology Lab I,0.64,0.05,0.14,0.09,0.09,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,25.0,General Biology Lab I,0.57,0.29,0.07,0.0,0.0,0%,0.0,0.07,tafadzwa kaisa,
-BIOL,1050,26.0,General Biology Lab I,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,27.0,General Biology Lab I,0.5,0.21,0.17,0.08,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,28.0,General Biology Lab I,0.67,0.17,0.08,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,29.0,General Biology Lab I,0.79,0.04,0.13,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,30.0,General Biology Lab I,0.42,0.25,0.08,0.08,0.13,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,31.0,General Biology Lab I,0.75,0.17,0.0,0.04,0.04,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,32.0,General Biology Lab I,0.58,0.25,0.08,0.0,0.0,0%,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,33.0,General Biology Lab I,0.33,0.33,0.1,0.0,0.1,0%,0.0,0.14,tafadzwa kaisa,
-BIOL,1050,34.0,General Biology Lab I,0.88,0.04,0.04,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,35.0,General Biology Lab I,0.63,0.17,0.04,0.04,0.08,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,36.0,General Biology Lab I,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,37.0,General Biology Lab I,0.58,0.13,0.21,0.04,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,38.0,General Biology Lab I,0.83,0.04,0.04,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,39.0,General Biology Lab I,0.75,0.13,0.04,0.0,0.08,0%,0.0,0.0,tafadzwa kaisa,
-BIOL,1050,40.0,General Biology Lab I,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,41.0,General Biology Lab I,0.71,0.25,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
-BIOL,1050,42.0,General Biology Lab I,0.71,0.13,0.0,0.04,0.04,0%,0.0,0.08,tafadzwa kaisa,
-BIOL,1050,43.0,General Biology Lab I,0.29,0.33,0.1,0.14,0.1,0%,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,44.0,General Biology Lab I,0.68,0.18,0.0,0.0,0.05,0%,0.0,0.05,tafadzwa kaisa,
-BIOL,1050,45.0,General Biology Lab I,0.45,0.27,0.09,0.09,0.0,0%,0.0,0.09,tafadzwa kaisa,
-BIOL,1090,1.0,Intro to Life Sci,0.8,0.17,0.03,0.0,0.0,0%,0.0,0.0,renea chris hardwick,
-BIOL,1100,1.0,Principles of Biology I,0.41,0.38,0.09,0.04,0.03,0%,0.0,0.05,renea chris hardwick,
-BIOL,1100,2.0,Principles of Biology I,0.56,0.28,0.1,0.05,0.01,0%,0.0,0.0,renea chris hardwick,
-BIOL,1100,3.0,Principles of Biology I,0.36,0.33,0.2,0.03,0.03,0%,0.0,0.06,verna minor,
-BIOL,1100,4.0,Principles of Biology I,0.28,0.47,0.15,0.06,0.04,0%,0.0,0.0,verna minor,
-BIOL,1100,5.0,Principles of Biology I (HO,0.79,0.14,0.04,0.0,0.04,0%,0.0,0.0,verna minor,True
-BIOL,1230,1.0,Keys to Human Biol,0.21,0.34,0.26,0.06,0.09,0%,0.0,0.04,lisa ruggiero wagner,
-BIOL,2220,1.0,Human Anat and Physiolog,0.21,0.28,0.3,0.1,0.07,0%,0.0,0.04,john cummings,
-BIOL,2220,3.0,Human Anat and Physiolog,0.28,0.38,0.17,0.11,0.04,0%,0.0,0.03,john cummings,
-BIOL,3030,1.0,Vertebrate Biology,0.53,0.29,0.11,0.05,0.03,0%,0.0,0.01,virginia abernathy,
-BIOL,3030,2.0,Vertebrate Biology (HON),0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,virginia abernathy,True
-BIOL,3030,3.0,Vertebrate Biology,0.55,0.27,0.13,0.03,0.02,0%,0.0,0.0,virginia abernathy,
-BIOL,3040,1.0,Biology of Plants,0.29,0.27,0.18,0.16,0.08,0%,0.0,0.02,nathan redding,
-BIOL,3070,1.0,Vertebrate Biology Lab,0.69,0.23,0.08,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,3070,2.0,Vertebrate Biology Lab,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,3070,4.0,Vertebrate Biology Lab,0.6,0.36,0.04,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,3070,5.0,Vertebrate Biology Lab,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,3070,6.0,Vertebrate Biology Lab,0.84,0.08,0.04,0.0,0.0,0%,0.0,0.04,richard blob,
-BIOL,3070,7.0,Vertebrate Biology Lab,0.6,0.28,0.12,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,3070,8.0,Vertebrate Biology Lab,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,3070,9.0,Vertebrate Biology Lab,0.72,0.24,0.04,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,3070,10.0,Vertebrate Biology Lab,0.5,0.33,0.06,0.06,0.06,0%,0.0,0.0,richard blob,
-BIOL,3070,11.0,Vertebrate Biology Lab,0.6,0.32,0.08,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,3080,1.0,Biology of Plants Practicu,0.64,0.27,0.0,0.0,0.0,0%,0.0,0.09,nathan redding,
-BIOL,3080,3.0,Biology of Plants Practicu,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,nathan redding,
-BIOL,3080,4.0,Biology of Plants Practicu,0.55,0.27,0.09,0.09,0.0,0%,0.0,0.0,nathan redding,
-BIOL,3080,5.0,Biology of Plants Practicu,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,nathan redding,
-BIOL,3150,1.0,Functional Human Anatom,0.4,0.39,0.12,0.04,0.02,0%,0.0,0.03, mcnutt-scott,
-BIOL,3350,1.0,Evolutionary Biology,0.35,0.45,0.14,0.04,0.01,0%,0.0,0.02,matthew koski,
-BIOL,3510,1.0,Biological Anthropology,0.86,0.07,0.04,0.04,0.0,0%,0.0,0.0,katherine weisensee,
-BIOL,4030,1.0,Intro to Applied Genomics,0.38,0.13,0.25,0.0,0.13,0%,0.0,0.13,vincent paul richards,
-BIOL,4200,1.0,Neurobiology,0.97,0.0,0.0,0.0,0.02,0%,0.0,0.02,david feliciano,
-BIOL,4250,1.0,Introductory Mycology,0.32,0.33,0.2,0.06,0.02,0%,0.0,0.06,julia louise kerrigan,
-BIOL,4260,1.0,Mycology Practicum,0.71,0.21,0.0,0.0,0.07,0%,0.0,0.0,julia louise kerrigan,
-BIOL,4260,2.0,Mycology Practicum,0.6,0.2,0.0,0.07,0.0,0%,0.0,0.13,julia louise kerrigan,
-BIOL,4400,1.0,Developmental Animal Bio,0.4,0.29,0.17,0.13,0.0,0%,0.0,0.02,kara powder,
-BIOL,4410,1.0,Ecology,0.46,0.36,0.1,0.05,0.01,0%,0.0,0.0,sharon bewick,
-BIOL,4420,1.0,Biogeography,0.58,0.21,0.15,0.03,0.0,0%,0.0,0.03,michael sears,
-BIOL,4610,1.0,Cell Biology,0.67,0.3,0.03,0.0,0.0,0%,0.0,0.0,susan chapman,
-BIOL,4610,2.0,Cell Biology (HON),0.71,0.21,0.08,0.0,0.0,0%,0.0,0.0,susan chapman,True
-BIOL,4610,3.0,Cell Biology,0.56,0.4,0.04,0.0,0.0,0%,0.0,0.0,susan chapman,
-BIOL,4620,1.0,Cell Biology Lab (Lec),0.82,0.14,0.0,0.04,0.0,0%,0.0,0.0,xianzhong yu,
-BIOL,4620,3.0,Cell Biology Lab (Lec),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,xianzhong yu,
-BIOL,4620,4.0,Cell Biology Lab (Lec),0.72,0.08,0.12,0.08,0.0,0%,0.0,0.0,xianzhong yu,
-BIOL,4620,5.0,Cell Biology Lab (Lec),0.93,0.04,0.04,0.0,0.0,0%,0.0,0.0,xianzhong yu,
-BIOL,4620,6.0,Cell Biology Lab (Lec),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,xianzhong yu,
-BIOL,4620,7.0,Cell Biology Lab (Lec),0.92,0.04,0.0,0.0,0.04,0%,0.0,0.0,xianzhong yu,
-BIOL,4620,8.0,Cell Biology Lab (Lec),0.77,0.08,0.08,0.0,0.08,0%,0.0,0.0,xianzhong yu,
-BIOL,4670,1.0,Principles of Hematology,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,vincent gallicchio,
-BIOL,4750,1.0,Comparative Physiology,0.48,0.2,0.16,0.06,0.08,0%,0.0,0.02,matthew turnbull,
-BIOL,4800,1.0,Vertebrate Endocrinology,0.4,0.3,0.3,0.0,0.0,0%,0.0,0.0,william baldwin,
-BIOL,4930,2.0,Sr Sem:Extinct & Macro Ev,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,nora espinoza,
-BIOL,6030,1.0,Intro to Applied Genomics,0.23,0.62,0.08,0.0,0.08,0%,0.0,0.0,vincent paul richards,
-BIOL,8000,1.0,Concepts in EEOB,0.86,0.0,0.14,0.0,0.0,0%,0.0,0.0,richard blob,
-BIOL,8010,1.0,Concepts in MCDB,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,zhicheng dou,
-BIOL,8070,1.0,Readings in MCDB,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,zhicheng dou,
-BIOL,8070,2.0,Readings in Evolution,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jennifer hodge,
-BIOL,8070,3.0,Readings in Ecology,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert fritz baldwin,
-BIOL,8120,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,zhicheng dou,
-BIOL,8130,1.0,Grad Teach Assist Colloqui,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,john cummings,
-BIOL,8400,1.0,Understanding Biological I,0.53,0.16,0.03,0.0,0.06,0%,0.0,0.16,virginia abernathy,
-BIOL,8420,1.0,Understand Cellular Proce,0.56,0.27,0.11,0.0,0.0,0%,0.0,0.03,kaustubha qanungo,
-BIOL,8440,1.0,Understanding the Human,0.49,0.35,0.1,0.0,0.02,0%,0.0,0.03, mcnutt-scott,
-BMOL,4250,1.0,Biomolecular Engineering,0.52,0.21,0.12,0.06,0.05,0%,0.0,0.05,marc birtwistle,
-BUS,1010,2.0,Business Foundations,0.53,0.37,0.11,0.0,0.0,0%,0.0,0.0,william tumblin,
-BUS,1010,3.0,Business Foundations,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,
-BUS,1010,4.0,Business Foundations,0.37,0.58,0.0,0.0,0.05,0%,0.0,0.0,william tumblin,
-BUS,1010,6.0,Business Foundations,0.4,0.4,0.1,0.1,0.0,0%,0.0,0.0,neil monaghan,
-BUS,1010,8.0,Business Foundations,0.42,0.29,0.16,0.02,0.07,0%,0.0,0.04,alexandra hazleton,
-BUS,1010,10.0,Business Foundations,0.58,0.21,0.08,0.04,0.08,0%,0.0,0.0,sandy edge,
-BUS,1010,11.0,Business Foundations,0.46,0.54,0.0,0.0,0.0,0%,0.0,0.0,sandy edge,
-BUS,1010,12.0,Business Foundations,0.48,0.39,0.13,0.0,0.0,0%,0.0,0.0,sandy edge,
-BUS,1010,14.0,Business Foundations,0.23,0.48,0.2,0.03,0.05,0%,0.0,0.02,keith balts,
-BUS,1010,15.0,Business Foundations,0.83,0.08,0.04,0.04,0.0,0%,0.0,0.0,iulio edward barry de barry,
-BUS,1010,16.0,Business Foundations,0.58,0.29,0.08,0.0,0.04,0%,0.0,0.0,iulio edward barry de barry,
-BUS,1010,17.0,Business Foundations,0.83,0.08,0.0,0.08,0.0,0%,0.0,0.0,iulio edward barry de barry,
-BUS,1010,18.0,Business Foundations,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,lawrence watson,
-BUS,1010,19.0,Business Foundations,0.58,0.26,0.16,0.0,0.0,0%,0.0,0.0,lawrence watson,
-BUS,1010,20.0,Business Foundations,0.26,0.58,0.11,0.0,0.0,0%,0.0,0.05,william tumblin,
-BUS,1010,21.0,Business Foundations,0.39,0.39,0.17,0.06,0.0,0%,0.0,0.0,james walter dowis,
-BUS,1010,22.0,Business Foundations,0.47,0.41,0.06,0.0,0.0,0%,0.0,0.06,james walter dowis,
-BUS,1010,23.0,Business Foundations,0.56,0.22,0.22,0.0,0.0,0%,0.0,0.0,james walter dowis,
-BUS,1010,25.0,Business Foundations,0.6,0.3,0.05,0.05,0.0,0%,0.0,0.0,james walter dowis,
-BUS,1010,26.0,Business Foundations,0.8,0.1,0.0,0.0,0.05,0%,0.0,0.05,james walter dowis,
-BUS,1010,27.0,Business Foundations,0.56,0.38,0.06,0.0,0.0,0%,0.0,0.0,james walter dowis,
-BUS,1010,30.0,Business Foundations,0.54,0.29,0.17,0.0,0.0,0%,0.0,0.0,keith balts,
-BUS,1010,31.0,Business Foundations,0.21,0.5,0.25,0.0,0.0,0%,0.0,0.04,keith balts,
-BUS,1010,33.0,Business Foundations,0.7,0.2,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,
-BUS,1010,34.0,Business Foundations,0.55,0.4,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,
-BUS,1010,35.0,Business Foundations,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,william tumblin,
-BUS,1010,36.0,Business Foundations,0.32,0.36,0.12,0.12,0.06,0%,0.0,0.03,neil monaghan,
-BUS,1010,37.0,Business Foundations,0.4,0.34,0.18,0.05,0.02,0%,0.0,0.02,neil monaghan,
-BUS,1010,39.0,Business Foundations,0.5,0.25,0.15,0.0,0.1,0%,0.0,0.0,james walter dowis,
-BUS,1010,40.0,Business Foundations,0.35,0.4,0.15,0.05,0.0,0%,0.0,0.05,james walter dowis,
-BUS,1010,41.0,Business Foundations,0.7,0.25,0.0,0.05,0.0,0%,0.0,0.0,james walter dowis,
-BUS,1010,43.0,Business Foundations,0.42,0.13,0.33,0.13,0.0,0%,0.0,0.0,keith balts,
-BUS,1010,44.0,Business Foundations,0.42,0.33,0.21,0.0,0.04,0%,0.0,0.0,keith balts,
-BUS,1010,45.0,Business Foundations,0.38,0.38,0.21,0.04,0.0,0%,0.0,0.0,keith balts,
-BUS,1010,47.0,Business Foundations,0.45,0.45,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,
-BUS,1010,48.0,Business Foundations,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,
-BUS,1010,49.0,Business Foundations,0.6,0.3,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,
-BUS,1010,50.0,Business Foundations,0.3,0.33,0.16,0.06,0.05,0%,0.0,0.1,alexandra hazleton,
-BUS,1010,51.0,Business Foundations,0.26,0.37,0.19,0.06,0.06,0%,0.0,0.05,alexandra hazleton,
-CCPD,1400,1.0,Professional Development,0.85,0.08,0.04,0.0,0.0,0%,0.0,0.04,rise jean sheriff,
-CE,2010,1.0,Statics,0.11,0.41,0.3,0.05,0.14,0%,0.0,0.0,michael stoner,
-CE,2010,2.0,Statics,0.62,0.21,0.14,0.0,0.02,0%,0.0,0.0,md chowdhury,
-CE,2010,3.0,Statics,0.12,0.34,0.2,0.08,0.08,0%,0.0,0.18,melissa sternhagen,
-CE,2010,4.0,Statics,0.17,0.13,0.28,0.02,0.11,0%,0.0,0.3,melissa sternhagen,
-CE,2010,5.0,Statics,0.26,0.38,0.25,0.05,0.05,0%,0.0,0.02,mohannad naser,
-CE,2010,6.0,Statics,0.37,0.43,0.11,0.06,0.02,0%,0.0,0.02,md chowdhury,
-CE,2010,8.0,Statics,0.38,0.4,0.15,0.05,0.03,0%,0.0,0.0,michael stoner,
-CE,2060,1.0,Structural Mechanics,0.03,0.13,0.44,0.15,0.06,0%,0.0,0.19,melissa sternhagen,
-CE,2080,1.0,Dynamics,0.19,0.4,0.33,0.02,0.03,0%,0.0,0.03,md chowdhury,
-CE,2550,1.0,Geomatics,0.27,0.43,0.2,0.09,0.0,0%,0.0,0.02,wayne sarasua,
-CE,2990,16.0,CE - Springer I - Lecture,0.67,0.25,0.08,0.0,0.0,0%,0.0,0.0,wayne sarasua,
-CE,2990,116.0,CE - Springer I - Lab,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,wayne sarasua,
-CE,2990,216.0,CE - Springer I - Lab,0.5,0.33,0.17,0.0,0.0,0%,0.0,0.0,wayne sarasua,
-CE,3010,1.0,Structural Analysis,0.19,0.45,0.28,0.04,0.02,0%,0.0,0.02,stephen csernak,
-CE,3010,2.0,Structural Analysis,0.34,0.34,0.28,0.0,0.0,0%,0.0,0.03,thomas cousins,
-CE,3110,1.0,Transportation Engr,0.74,0.11,0.08,0.0,0.03,0%,0.0,0.03,jennifer ogle,
-CE,3210,1.0,Geotechnical Engineering,0.47,0.31,0.12,0.08,0.0,0%,0.0,0.02,qiushi chen,
-CE,3310,1.0,Constr Engr & Mgmnt,0.44,0.42,0.1,0.01,0.01,0%,0.0,0.01,zoraya rockow,
-CE,3410,1.0,Intro to Fluid Mechanics,0.68,0.24,0.07,0.02,0.0,0%,0.0,0.0,nigel gregory kaye,
-CE,3410,2.0,Intro to Fluid Mechanics,0.27,0.35,0.18,0.06,0.1,0%,0.0,0.04,abdul khan,
-CE,3420,1.0,Hydraulics & Hydro,0.64,0.2,0.11,0.04,0.02,0%,0.0,0.0,ashok mishra,
-CE,3510,1.0,Civil Engineering Materials,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0, esmaeilpoursaee,
-CE,3510,2.0,Civil Engineering Materials,0.88,0.1,0.0,0.0,0.0,0%,0.0,0.02, esmaeilpoursaee,
-CE,3520,1.0,Econ Eval of Proj,0.63,0.32,0.04,0.0,0.01,0%,0.0,0.0,da li,
-CE,4010,1.0,Matrix Str Analysis,0.24,0.35,0.18,0.12,0.12,0%,0.0,0.0,laura mae redmond,
-CE,4020,1.0,Reinfor Con Design,0.35,0.41,0.09,0.09,0.03,0%,0.0,0.03,laura mae redmond,
-CE,4060,1.0,Struct Steel Design,0.47,0.37,0.1,0.07,0.0,0%,0.0,0.0,stephen csernak,
-CE,4100,1.0,Traffic Engr Oper,0.32,0.23,0.18,0.18,0.05,0%,0.0,0.05,wayne sarasua,
-CE,4240,1.0,Earth Slopes & Struc,0.3,0.32,0.25,0.14,0.0,0%,0.0,0.0, ravichandran,
-CE,4330,1.0,Const Plan & Sched,0.52,0.3,0.17,0.0,0.0,0%,0.0,0.0,tuyen thanh le,
-CE,4340,1.0,Const Est Proj Cont,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,kalyan ram piratla,
-CE,4470,1.0,Stormwater Managemnt,0.4,0.37,0.13,0.1,0.0,0%,0.0,0.0,md chowdhury,
-CE,4560,1.0,Pave Design & Constr,0.17,0.57,0.19,0.0,0.02,0%,0.0,0.05,bradley putman,
-CE,4590,1.0,Capstone Design Proj,0.28,0.49,0.21,0.03,0.0,0%,0.0,0.0,zoraya rockow,
-CE,4910,1.0,BIM in Construction Mana,0.64,0.27,0.0,0.0,0.05,0%,0.0,0.05,kalyan ram piratla,
-CE,4910,3.0,Intro to Proj Mgt,0.62,0.29,0.05,0.0,0.0,0%,0.0,0.05,zoraya rockow,
-CE,4990,109.0,Cr Inq in CE - CEment,0.82,0.14,0.0,0.0,0.0,0%,0.0,0.0,candice bolding,
-CE,6010,1.0,Matrix Str Analysis,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,laura mae redmond,
-CE,6910,5.0,Adv Concrete Technology,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,prasada rangaraju,
-CE,8030,1.0,Adv Steel Design,0.32,0.58,0.05,0.0,0.05,0%,0.0,0.0,mohannad naser,
-CE,8080,1.0,Earthquake Engr,0.9,0.05,0.0,0.0,0.05,0%,0.0,0.0,weichiang pang,
-CE,8460,1.0,Flow in Open Chnls,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,abdul khan,
-CE,8540,1.0,Travl Demnd Forecast,0.57,0.14,0.0,0.0,0.0,0%,0.0,0.0,pamela murray-tuite,
-CE,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jennifer ogle,
-CE,9910,18.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mashrur chowdhury,
-CH,1010,1.0,General Chemistry,0.17,0.38,0.16,0.1,0.09,0%,0.0,0.09,thomas hickman,
-CH,1010,2.0,General Chemistry,0.15,0.35,0.18,0.09,0.09,0%,0.0,0.13,thao thi thanh tran thanh,
-CH,1010,3.0,General Chemistry,0.16,0.39,0.16,0.12,0.06,0%,0.0,0.1,william mcwhorter,
-CH,1010,4.0,General Chemistry,0.23,0.28,0.26,0.12,0.07,0%,0.0,0.04,jacob schroeder,
-CH,1010,5.0,General Chemistry,0.28,0.27,0.21,0.12,0.07,0%,0.0,0.05,thomas hickman,
-CH,1010,6.0,General Chemistry,0.31,0.29,0.18,0.08,0.05,0%,0.0,0.1,dennis taylor,
-CH,1010,7.0,General Chemistry,0.12,0.27,0.24,0.1,0.17,0%,0.0,0.11,olt geiculescu,
-CH,1010,8.0,General Chemistry,0.11,0.29,0.26,0.08,0.08,0%,0.0,0.18,princess mycia cox,
-CH,1010,9.0,General Chemistry,0.23,0.42,0.19,0.08,0.05,0%,0.0,0.04,ashlyn dennis smith,
-CH,1010,10.0,General Chemistry,0.22,0.22,0.26,0.12,0.1,0%,0.0,0.08,william mcwhorter,
-CH,1010,11.0,General Chemistry,0.25,0.42,0.14,0.09,0.08,0%,0.0,0.02,thomas hickman,
-CH,1010,12.0,General Chemistry,0.32,0.31,0.21,0.05,0.03,0%,0.0,0.08,ashlyn dennis smith,
-CH,1010,13.0,General Chemistry,0.21,0.29,0.19,0.1,0.08,0%,0.0,0.13,princess mycia cox,
-CH,1010,14.0,General Chemistry,0.25,0.34,0.25,0.07,0.06,0%,0.0,0.05,tania houjeiry,
-CH,1010,15.0,General Chemistry,0.24,0.29,0.17,0.15,0.05,0%,0.0,0.11,dennis taylor,
-CH,1010,16.0,General Chemistry,0.1,0.39,0.25,0.08,0.08,0%,0.0,0.08,jacob schroeder,
-CH,1010,50.0,General Chemistry,0.36,0.45,0.05,0.09,0.05,0%,0.0,0.0,tania houjeiry,
-CH,1010,71.0,General Chemistry (HON),0.5,0.4,0.05,0.0,0.05,0%,0.0,0.0,joseph thrasher,True
-CH,1010,72.0,General Chemistry (HON),0.57,0.29,0.07,0.07,0.0,0%,0.0,0.0,shiou-jyh hwu,True
-CH,1010,400.0,General Chemistry,0.03,0.18,0.2,0.13,0.18,0%,0.0,0.3,princess mycia cox,
-CH,1020,1.0,General Chemistry,0.31,0.24,0.2,0.16,0.04,0%,0.0,0.04, schvaneveldt,
-CH,1020,2.0,General Chemistry,0.32,0.18,0.24,0.1,0.08,0%,0.0,0.07, schvaneveldt,
-CH,1020,3.0,General Chemistry,0.26,0.28,0.27,0.1,0.04,0%,0.0,0.05, schvaneveldt,
-CH,1020,400.0,General Chemistry,0.23,0.19,0.19,0.19,0.08,0%,0.0,0.13, schvaneveldt,
-CH,1050,2.0,Chemistry in Context I,0.63,0.24,0.07,0.01,0.03,0%,0.0,0.03,olt geiculescu,
-CH,2010,1.0,Survey of Organic Chemist,0.94,0.06,0.01,0.0,0.0,0%,0.0,0.0,modi wetzler,
-CH,2230,1.0,Organic Chemistry,0.43,0.32,0.11,0.06,0.08,0%,0.0,0.02,tania houjeiry,
-CH,2230,2.0,Organic Chemistry,0.22,0.21,0.3,0.12,0.1,0%,0.0,0.04,modi wetzler,
-CH,2230,3.0,Organic Chemistry,0.48,0.21,0.14,0.07,0.06,0%,0.0,0.04,elliot ennis,
-CH,2230,4.0,Organic Chemistry,0.31,0.28,0.17,0.09,0.1,0%,0.0,0.05,modi wetzler,
-CH,2230,6.0,Organic Chemistry,0.5,0.26,0.12,0.03,0.05,0%,0.0,0.03,rhett smith,
-CH,2230,7.0,Organic Chemistry,0.46,0.25,0.1,0.04,0.09,0%,0.0,0.05,rhett smith,
-CH,2230,8.0,Organic Chemistry,0.23,0.15,0.33,0.14,0.13,0%,0.0,0.03,william mcwhorter,
-CH,2230,50.0,Organic Chemistry,0.27,0.47,0.2,0.0,0.07,0%,0.0,0.0,byoungmoo kim,
-CH,2240,1.0,Organic Chemistry,0.29,0.17,0.18,0.13,0.15,0%,0.0,0.08,elliot ennis,
-CH,2240,2.0,Organic Chemistry,0.19,0.18,0.22,0.23,0.1,0%,0.0,0.09,elliot ennis,
-CH,2270,9.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,
-CH,2270,13.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,james plampin,
-CH,2270,18.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,
-CH,2270,28.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,james plampin,
-CH,2280,1.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,
-CH,2280,2.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.09,james plampin,
-CH,2280,4.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,
-CH,2280,5.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.09,james plampin,
-CH,2280,6.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,
-CH,2280,7.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,
-CH,3130,1.0,Quantitative Analysis,0.22,0.31,0.24,0.11,0.04,0%,0.0,0.07,olt geiculescu,
-CH,3150,1.0,Quant Analysis Lab,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,jeffrey nathan anker,
-CH,3150,2.0,Quant Analysis Lab,0.73,0.0,0.09,0.0,0.0,0%,0.0,0.18,jeffrey nathan anker,
-CH,3150,3.0,Quant Analysis Lab,0.31,0.31,0.08,0.0,0.23,0%,0.0,0.0,jeffrey nathan anker,
-CH,3300,1.0,Intro to Phys Chem,0.61,0.22,0.07,0.01,0.03,0%,0.0,0.04,brian dominy,
-CH,3310,1.0,Physical Chemistry,0.34,0.36,0.18,0.02,0.1,0%,0.0,0.0,steven stuart,
-CH,3390,1.0,Physical Chem Lab,0.71,0.19,0.05,0.0,0.05,0%,0.0,0.0,princess mycia cox,
-CH,3390,2.0,Physical Chem Lab,0.58,0.26,0.16,0.0,0.0,0%,0.0,0.0,princess mycia cox,
-CH,3390,3.0,Physical Chem Lab,0.74,0.11,0.0,0.0,0.0,0%,0.0,0.16,princess mycia cox,
-CH,3390,4.0,Physical Chem Lab,0.76,0.19,0.0,0.0,0.05,0%,0.0,0.0,princess mycia cox,
-CH,3390,5.0,Physical Chem Lab,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,princess mycia cox,
-CH,3410,1.0,Introduction to Research,0.76,0.08,0.04,0.02,0.1,0%,0.0,0.0,perez carlos garcia,
-CH,4020,1.0,Inorganic Chemistry,0.5,0.42,0.02,0.0,0.04,0%,0.0,0.02,joseph kolis,
-CH,4210,1.0,Advanced Organic Chemist,0.33,0.44,0.22,0.0,0.0,0%,0.0,0.0,jacob schroeder,
-CH,6020,1.0,Inorganic Chemistry,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,joseph kolis,
-CH,6210,1.0,Adv Organic Chem,0.17,0.5,0.17,0.0,0.0,0%,0.0,0.17,jacob schroeder,
-CH,8070,1.0,Chem Trans Elem,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,julia brumaghim,
-CH,8120,1.0,Chemical Spectroscopic M,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,george chumanov,
-CH,8150,1.0,Mass Spectrometry,0.36,0.36,0.27,0.0,0.0,0%,0.0,0.0,richard marcus,
-CH,8210,1.0,Organic Chem I,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,ya-ping sun,
-CH,8370,1.0,Quantum Chemistry,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,leah beck casabianca,
-CH,8510,2.0,Grad Student Seminar,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,sourav saha,
-CH,8520,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,93%,0.03,0.03,joseph thrasher,
-CH,9910,2.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel whitehead,
-CH,9910,7.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rhett smith,
-CH,9910,11.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,richard marcus,
-CH,9910,25.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey nathan anker,
-CH,9910,99.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,perez carlos garcia,
-CHE,2110,1.0,Mass and Energy Balances,0.24,0.29,0.26,0.12,0.05,0%,0.0,0.05,mark roberts,
-CHE,3070,1.0,Unit Ops Lab I,0.18,0.47,0.35,0.0,0.0,0%,0.0,0.0,christopher norfolk,
-CHE,3210,1.0,Ch E Thermo II,0.08,0.27,0.39,0.19,0.03,0%,0.0,0.03,sapna sarupria,
-CHE,3300,1.0,Mass Trans & Seprtn,0.35,0.26,0.26,0.08,0.03,0%,0.0,0.03,david bruce,
-CHE,4070,1.0,Unit Op Lab II,0.28,0.4,0.29,0.03,0.0,0%,0.0,0.0,christopher norfolk,
-CHE,4310,1.0,Process Design I,0.26,0.53,0.18,0.01,0.01,0%,0.0,0.0,suzanne deirdre roat,
-CHE,4430,1.0,"Safety, Env & Prof Practice",0.86,0.11,0.04,0.0,0.0,0%,0.0,0.0,scott husson,
-CHE,4500,1.0,Chem Reaction Engr,0.29,0.39,0.2,0.09,0.03,0%,0.0,0.0,rachel getman,
-CHE,6130,1.0,Polymer Composite Engine,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,amod ogale,
-CHE,8030,1.0,Advanced Transport,0.45,0.45,0.09,0.0,0.0,0%,0.0,0.0,eric mikel davis,
-CHE,8900,1.0,GAANN SEMINAR,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eric mikel davis,
-CHE,8950,1.0,Graduate Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jessica marie larsen,
-CHE,9910,2.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mark alan blenner,
-CHE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,scott husson,
-CHE,9910,11.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sapna sarupria,
-CHE,9910,13.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mark thies,
-CHIN,1010,2.0,Elementary Chinese,0.38,0.0,0.15,0.0,0.15,0%,0.0,0.31,yanhua zhang,
-CHIN,3130,1.0,Philosophy in Modern Chin,0.5,0.25,0.05,0.0,0.05,0%,0.0,0.15,yanming an,
-CHIN,4990,1.0,Slct Tpcs Chin Cult,0.35,0.45,0.15,0.0,0.0,0%,0.0,0.05,kyle david anderson,
-COM,1010,1.0,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,96%,0.0,0.04,lori marlise pindar,
-COM,1500,1.0,Intro to Human Communic,0.86,0.07,0.03,0.01,0.01,0%,0.0,0.01,daniel leland fecher,
-COM,1500,2.0,Intro to Human Communic,0.73,0.18,0.03,0.02,0.02,0%,0.0,0.01,daniel leland fecher,
-COM,1500,3.0,Intro to Human Communic,0.78,0.16,0.05,0.01,0.0,0%,0.0,0.0,daniel leland fecher,
-COM,1500,4.0,Intro to Human Communic,0.82,0.11,0.03,0.01,0.02,0%,0.0,0.02,marianne herr glaser,
-COM,1500,5.0,Intro to Human Communic,0.82,0.11,0.02,0.02,0.02,0%,0.0,0.01,marianne herr glaser,
-COM,1500,6.0,Intro to Human Communic,0.79,0.16,0.03,0.01,0.0,0%,0.0,0.01,marianne herr glaser,
-COM,1500,7.0,Intro to Human Communic,0.73,0.12,0.08,0.03,0.03,0%,0.0,0.01,vanessa condon,
-COM,2010,1.0,Intr to Comm Studies,0.67,0.19,0.04,0.0,0.04,0%,0.0,0.07,caitlin baker,
-COM,2010,2.0,Intr to Comm Studies,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,caitlin baker,
-COM,2020,1.0,Communication Theory,0.75,0.21,0.04,0.0,0.0,0%,0.0,0.0,kristen okamoto,
-COM,2040,1.0,Critical-Cultural Comm The,0.65,0.17,0.13,0.0,0.04,0%,0.0,0.0,james gilmore,
-COM,2100,1.0,Quant Comm Research Me,0.44,0.48,0.08,0.0,0.0,0%,0.0,0.0,erin michelle ash,
-COM,2500,2.0,Public Speaking,0.6,0.3,0.05,0.0,0.05,0%,0.0,0.0,sara crocker,
-COM,2500,3.0,Public Speaking,0.6,0.25,0.05,0.05,0.0,0%,0.0,0.05,elizabeth gilmore,
-COM,2500,4.0,Public Speaking,0.75,0.15,0.1,0.0,0.0,0%,0.0,0.0,elizabeth gilmore,
-COM,2500,5.0,Public Speaking,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,alyssa christine davis,
-COM,2500,6.0,Public Speaking,0.7,0.25,0.05,0.0,0.0,0%,0.0,0.0,alyssa christine davis,
-COM,2500,7.0,Public Speaking,0.65,0.3,0.05,0.0,0.0,0%,0.0,0.0,sara crocker,
-COM,2500,8.0,Public Speaking,0.55,0.35,0.05,0.0,0.05,0%,0.0,0.0,ashley lauren pikel,
-COM,2500,9.0,Public Speaking,0.65,0.1,0.15,0.0,0.05,0%,0.0,0.05,sara crocker,
-COM,2500,10.0,Public Speaking,0.47,0.37,0.05,0.05,0.05,0%,0.0,0.0,ashley lauren pikel,
-COM,2500,11.0,Public Speaking,0.68,0.21,0.05,0.0,0.0,0%,0.0,0.05,ashley lauren pikel,
-COM,2500,14.0,Public Speaking,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,elizabeth gilmore,
-COM,2500,16.0,Public Speaking,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,jumah patricia taweh,
-COM,2500,17.0,Public Speaking,0.79,0.05,0.05,0.0,0.11,0%,0.0,0.0,jumah patricia taweh,
-COM,2500,18.0,Public Speaking,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,marshall covert,
-COM,2500,19.0,Public Speaking,0.79,0.16,0.0,0.0,0.0,0%,0.0,0.05,jumah patricia taweh,
-COM,2500,20.0,Public Speaking,0.75,0.15,0.05,0.0,0.0,0%,0.0,0.05,vanessa condon,
-COM,2500,21.0,Public Speaking,0.75,0.2,0.0,0.0,0.0,0%,0.0,0.05,charles john brewer,
-COM,2500,22.0,Public Speaking,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,charles john brewer,
-COM,2500,23.0,Public Speaking,0.74,0.16,0.11,0.0,0.0,0%,0.0,0.0,charles john brewer,
-COM,2500,24.0,Public Speaking,0.78,0.17,0.0,0.0,0.06,0%,0.0,0.0,charles john brewer,
-COM,2500,25.0,Public Speaking,0.6,0.35,0.0,0.05,0.0,0%,0.0,0.0,marshall covert,
-COM,2500,26.0,Public Speaking,0.55,0.35,0.05,0.0,0.05,0%,0.0,0.0,marshall covert,
-COM,2500,27.0,Public Speaking,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,marshall covert,
-COM,2500,28.0,Public Speaking,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,katie mcelveen,
-COM,2500,29.0,Public Speaking,0.74,0.16,0.05,0.05,0.0,0%,0.0,0.0,vanessa condon,
-COM,2500,31.0,Public Speaking,0.85,0.0,0.05,0.05,0.05,0%,0.0,0.0,katie mcelveen,
-COM,2500,33.0,Public Speaking,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,ashley lauren pikel,
-COM,2500,401.0,Public Speaking,0.8,0.15,0.0,0.0,0.05,0%,0.0,0.0,alexis zachary davis,
-COM,2500,402.0,Public Speaking,0.75,0.1,0.1,0.05,0.0,0%,0.0,0.0,alexis zachary davis,
-COM,2500,403.0,Public Speaking,0.85,0.05,0.0,0.0,0.1,0%,0.0,0.0,alexis zachary davis,
-COM,3050,1.0,Persuasion,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,lindsey dixon,
-COM,3200,1.0,Bdcst Production,0.87,0.0,0.04,0.04,0.04,0%,0.0,0.0,wanda johnson,
-COM,3240,1.0,"Communication, Sport & S",0.68,0.2,0.04,0.0,0.04,0%,0.0,0.04,brandon boatwright,
-COM,3240,2.0,"Communication, Sport & S",0.5,0.32,0.18,0.0,0.0,0%,0.0,0.0,brandon boatwright,
-COM,3250,1.0,Survey of Sports Communi,0.67,0.17,0.13,0.03,0.0,0%,0.0,0.0,virginia harrison,
-COM,3260,1.0,Pr in Sports,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,katie mcelveen,
-COM,3260,2.0,Pr in Sports,0.83,0.07,0.03,0.0,0.0,0%,0.0,0.07,katie mcelveen,
-COM,3270,1.0,Sports Media Criticism,0.32,0.64,0.0,0.0,0.0,0%,0.0,0.04,bryan denham,
-COM,3550,1.0,Principles of Public Relatio,0.5,0.27,0.14,0.05,0.0,0%,0.0,0.05,jordan morehouse,
-COM,3570,1.0,Public Relations Writing,0.52,0.29,0.05,0.05,0.05,0%,0.0,0.05,jordan morehouse,
-COM,3660,3.0,Ugrad Comm Tutors,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,alyssa christine davis,
-COM,3660,4.0,Storytelling and Reporting,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,nigel robertson,
-COM,3900,1.0,Communication Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,lori marlise pindar,
-COM,4280,1.0,Interpers/Family Comm &,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,gregory cranmer,
-COM,4560,1.0,PR for Assoc & Nonprofits,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,virginia harrison,
-COM,4700,1.0,Comm & Health,0.36,0.45,0.14,0.0,0.0,0%,0.0,0.05,victoria wingate,
-COM,4800,1.0,Intercultural Comm,0.8,0.16,0.04,0.0,0.0,0%,0.0,0.0,andrew stephen pyle,
-COM,4800,2.0,Intercultural Comm,0.92,0.04,0.0,0.0,0.04,0%,0.0,0.0,andrew stephen pyle,
-COM,4950,2.0,Senior Capstone Seminar,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,david travers scott,
-COM,8000,1.0,Communication Pedagogy,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel leland fecher,
-COM,8010,1.0,Communication Theory I,0.73,0.18,0.0,0.0,0.0,0%,0.0,0.09,darren linvill,
-COM,8100,1.0,Comm Research Methods I,0.47,0.4,0.13,0.0,0.0,0%,0.0,0.0,gregory cranmer,
-COM,8270,1.0,Sports Media,0.57,0.29,0.0,0.0,0.0,0%,0.0,0.14,bryan denham,
-COM,8910,1.0,Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,erin michelle ash,
-COOP,1010,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
-COOP,1020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
-COOP,1030,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
-COOP,2010,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
-COOP,2020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
-COOP,6020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,'neil burton,
-CPSC,1010,10.0,Computer Science I,0.15,0.31,0.25,0.04,0.1,0%,0.0,0.13,scoy roger larry van larry,
-CPSC,1010,20.0,Computer Science I,0.39,0.2,0.16,0.1,0.02,0%,0.0,0.14,carrie lynn russell,
-CPSC,1010,30.0,Computer Science I,0.2,0.37,0.2,0.06,0.06,0%,0.0,0.12,carrie lynn russell,
-CPSC,1020,10.0,Computer Science II,0.24,0.29,0.18,0.11,0.07,0%,0.0,0.11,catherine kittelstad,
-CPSC,1060,10.0,Intro to Programming in Ja,0.37,0.24,0.11,0.05,0.11,0%,0.0,0.13,svetlana drachova,
-CPSC,1060,20.0,Intro to Programming in Ja,0.31,0.17,0.22,0.19,0.08,0%,0.0,0.03,svetlana drachova,
-CPSC,1060,30.0,Intro to Programming in Ja,0.14,0.11,0.33,0.14,0.14,0%,0.0,0.14,christina joerg,
-CPSC,1070,1.0,Programming Methodolog,0.26,0.27,0.27,0.04,0.07,0%,0.0,0.1,christopher plaue,
-CPSC,1110,1.0,Intro to Programming in C,0.34,0.31,0.16,0.05,0.06,0%,0.0,0.07,andrew duchowski,
-CPSC,1110,2.0,Intro to Programming in C,0.39,0.27,0.22,0.04,0.02,0%,0.0,0.06,nicolas widman,
-CPSC,1210,1.0,Computational Thinking,0.26,0.26,0.34,0.03,0.05,0%,0.0,0.05,mitch shue,
-CPSC,1900,1.0,Teaching Assist Fundamen,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eileen kraemer,
-CPSC,2070,1.0,Discrete Structures,0.44,0.37,0.14,0.03,0.02,0%,0.0,0.0,larry hodges,
-CPSC,2070,2.0,Discrete Structures,0.38,0.27,0.29,0.06,0.0,0%,0.0,0.0,larry hodges,
-CPSC,2070,3.0,Discrete Structures,0.46,0.19,0.3,0.0,0.03,0%,0.0,0.03,pradip srimani,
-CPSC,2120,1.0,Algs/Data Structures,0.52,0.16,0.11,0.07,0.08,0%,0.0,0.05,nicolas widman,
-CPSC,2120,2.0,Algs/Data Structures,0.48,0.18,0.1,0.03,0.13,0%,0.0,0.08,nicolas widman,
-CPSC,2120,101.0,Algs/Data Structures,0.4,0.2,0.04,0.04,0.08,0%,0.0,0.24,brian dean,
-CPSC,2120,102.0,Algs/Data Structures,0.28,0.24,0.28,0.0,0.04,0%,0.0,0.16,brian dean,
-CPSC,2120,103.0,Algs/Data Structures,0.17,0.26,0.3,0.04,0.09,0%,0.0,0.13,brian dean,
-CPSC,2150,1.0,Software Dev Foundations,0.22,0.27,0.2,0.07,0.16,0%,0.0,0.09,yu-shan sun,
-CPSC,2150,2.0,Software Dev Foundations,0.24,0.24,0.2,0.02,0.13,0%,0.0,0.17,yu-shan sun,
-CPSC,2150,3.0,Software Dev Foundations,0.15,0.25,0.2,0.1,0.15,0%,0.0,0.15,murali sitaraman,
-CPSC,2200,1.0,Problem Solving w/ Office,0.52,0.22,0.14,0.06,0.04,0%,0.0,0.02,catherine kittelstad,
-CPSC,2310,1.0,Intro Computer Org,0.23,0.29,0.28,0.03,0.1,0%,0.0,0.07,yvon feaster,
-CPSC,2910,1.0,Prof Issues I,0.83,0.1,0.0,0.03,0.03,0%,0.0,0.0,constance taylor,
-CPSC,2910,2.0,Prof Issues I,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,constance taylor,
-CPSC,2910,3.0,Prof Issues I,0.68,0.1,0.13,0.06,0.0,0%,0.0,0.03,constance taylor,
-CPSC,2920,1.0,"Computing, Ethics & Societ",0.8,0.05,0.08,0.0,0.03,0%,0.0,0.05,julian brinkley,
-CPSC,3220,1.0,Intro to Operating Systems,0.31,0.21,0.1,0.04,0.09,0%,0.0,0.21,jacob sorber,
-CPSC,3220,2.0,Intro to Operating Systems,0.59,0.17,0.04,0.0,0.04,0%,0.0,0.04,brygg anders ullmer,
-CPSC,3300,1.0,Computer Systems Org,0.4,0.33,0.15,0.08,0.01,0%,0.0,0.03,mark smotherman,
-CPSC,3500,1.0,Foundations of Computer,0.2,0.37,0.27,0.0,0.1,0%,0.0,0.06,sandra hedetniemi,
-CPSC,3520,1.0,Programming Systems,0.76,0.1,0.06,0.01,0.06,0%,0.0,0.01,yongkai wu,
-CPSC,3600,1.0,Network Programming,0.48,0.26,0.13,0.03,0.04,0%,0.0,0.05,andrew robb,
-CPSC,3720,1.0,Software Engineering,0.25,0.44,0.24,0.05,0.02,0%,0.0,0.0,yu-shan sun,
-CPSC,3720,2.0,Software Engineering,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,constance taylor,
-CPSC,3750,1.0,Web Application Develop,0.52,0.27,0.06,0.04,0.1,0%,0.0,0.0,craig baker,
-CPSC,4030,1.0,Data Visualization,0.21,0.5,0.21,0.0,0.04,0%,0.0,0.04,federico iuricich,
-CPSC,4040,1.0,Cmptr Graphics Image,0.76,0.12,0.0,0.0,0.06,0%,0.0,0.06,jerry tessendorf,
-CPSC,4050,1.0,Computer Graphics,0.38,0.17,0.04,0.04,0.0,0%,0.0,0.33,yin yang,
-CPSC,4110,1.0,Virtual Reality Systems,0.57,0.3,0.13,0.0,0.0,0%,0.0,0.0,sabarish venkat babu,
-CPSC,4140,1.0,Human and Computer Inte,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,nathaniel mcneese,
-CPSC,4160,1.0,2-D Game Engine Construc,0.58,0.15,0.08,0.05,0.08,0%,0.0,0.08,victor zordan,
-CPSC,4200,1.0,Computer Security Principl,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,long cheng,
-CPSC,4240,1.0,System Admin and Securit,0.63,0.33,0.0,0.0,0.04,0%,0.0,0.0,svetlana drachova,
-CPSC,4300,1.0,Applied Data Science,0.41,0.3,0.07,0.0,0.07,0%,0.0,0.07,xizhou feng,
-CPSC,4300,2.0,Applied Data Science,0.53,0.12,0.18,0.0,0.12,0%,0.0,0.06,alexander herzog,
-CPSC,4420,1.0,Artificial Intelligence,0.71,0.14,0.1,0.0,0.05,0%,0.0,0.0,ioannis karamouzas,
-CPSC,4430,1.0,Machine Learning: Impl &,0.83,0.13,0.0,0.0,0.04,0%,0.0,0.0,larry hodges,
-CPSC,4440,1.0,Cloud Computing Architect,0.35,0.61,0.04,0.0,0.0,0%,0.0,0.0,mitch shue,
-CPSC,4620,1.0,Database Management Sy,0.48,0.19,0.14,0.0,0.14,0%,0.0,0.05,pradip srimani,
-CPSC,4620,2.0,Database Management Sy,0.33,0.5,0.06,0.0,0.0,0%,0.0,0.11,zijun wang,
-CPSC,4770,1.0,Distributed/Cluster Compu,0.47,0.37,0.05,0.0,0.05,0%,0.0,0.05,shuangshuang jin,
-CPSC,4780,1.0,Gen Purpose Computation,0.27,0.18,0.0,0.09,0.18,0%,0.0,0.27,shuangshuang jin,
-CPSC,4890,1.0,Programming Team Semin,0.67,0.27,0.07,0.0,0.0,0%,0.0,0.0,brian dean,
-CPSC,4910,1.0,Professional Issues II,0.53,0.43,0.03,0.0,0.0,0%,0.0,0.0,scoy roger larry van larry,
-CPSC,4910,2.0,Professional Issues II,0.28,0.52,0.16,0.04,0.0,0%,0.0,0.0,scoy roger larry van larry,
-CPSC,4910,3.0,Professional Issues II,0.78,0.17,0.04,0.0,0.0,0%,0.0,0.0,alexander herzog,
-CPSC,6040,1.0,Cptr Graphics Image,0.83,0.11,0.06,0.0,0.0,0%,0.0,0.0,jerry tessendorf,
-CPSC,6050,1.0,Computer Graphics,0.69,0.15,0.08,0.0,0.0,0%,0.0,0.08,yin yang,
-CPSC,6110,1.0,Virtual Reality Systems,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,sabarish venkat babu,
-CPSC,6160,1.0,2-D Game Engine Construc,0.71,0.14,0.0,0.0,0.14,0%,0.0,0.0,victor zordan,
-CPSC,6300,2.0,Applied Data Science,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,alexander herzog,
-CPSC,6420,1.0,Artificial Intelligence,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,ioannis karamouzas,
-CPSC,6440,1.0,Cloud Computing Architect,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,mitch shue,
-CPSC,6620,1.0,Database Management Sy,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,pradip srimani,
-CPSC,6620,2.0,Database Management Sy,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,zijun wang,
-CPSC,6770,1.0,Distributed/Cluster Compu,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,shuangshuang jin,
-CPSC,6810,1.0,Ind Study: MSCS Ready,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,eileen kraemer,
-CPSC,6810,2.0,MSCS Ready: mod 2,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,eileen kraemer,
-CPSC,8200,1.0,Parallel Architechture,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,rong ge,
-CPSC,8420,1.0,Advanced Machine Learni,0.5,0.13,0.22,0.0,0.0,0%,0.0,0.16,kai liu,
-CPSC,8470,1.0,Intro to Information Retrie,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,feng luo,
-CPSC,8480,1.0,Network Science,0.59,0.18,0.12,0.0,0.06,0%,0.0,0.06,ilya mark safro,
-CPSC,8510,1.0,Soft Sys Data Comm,0.67,0.11,0.11,0.0,0.0,0%,0.0,0.11,james martin,
-CPSC,8580,1.0,Security in Emerging Syste,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,hongxin hu,
-CPSC,8710,1.0,Found. of Software Engine,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,paige rodeghero,
-CPSC,9500,1.0,Sel Top:SoC Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,long cheng,
-CPSC,9500,2.0,Sel Topics: CS Edu Researc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eileen kraemer,
-CPSC,9500,843.0,Sel Topics: SOC Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,long cheng,
-CPSC,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brian dean,
-CPSC,9910,14.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,hongxin hu,
-CPSC,9910,24.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,feng luo,
-CRP,4010,1.0,Intro to City & Regional Pla,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,john albert gaber,
-CRP,8010,1.0,Planning Process & Legal F,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,caitlin dyckman,
-CRP,8030,2.0,Quan Analysis for Planners,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,eric morris,
-CRP,8080,1.0,Land Use and Compreh Pla,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,santiago luis ramos,
-CRP,8140,1.0,Public Transit,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,eric morris,
-CRP,8580,2.0,Mixed Mthds for Planning,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,clifford donald ellis,
-CRP,8940,1.0,Professional Planning Semi,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,barry nocks,
-CSM,1000,1.0,Intro to Construct,0.81,0.1,0.0,0.03,0.06,0%,0.0,0.0,thomas fuduric,
-CSM,2010,1.0,Structures I,0.07,0.29,0.21,0.29,0.07,0%,0.0,0.07,shima clarke,
-CSM,2010,2.0,Structures I,0.0,0.36,0.14,0.21,0.14,0%,0.0,0.14,shima clarke,
-CSM,2010,401.0,Structures I,0.15,0.46,0.15,0.15,0.0,0%,0.0,0.08,shima clarke,
-CSM,2010,402.0,Structures I,0.0,0.08,0.54,0.15,0.0,0%,0.0,0.23,shima clarke,
-CSM,2030,401.0,Mats & Meth of Const,0.19,0.44,0.31,0.02,0.04,0%,0.0,0.0,jason lucas,
-CSM,2040,401.0,Cont Documents,0.38,0.41,0.1,0.1,0.0,0%,0.0,0.0,robert coffey,
-CSM,2050,1.0,Mats & Methods II,0.59,0.22,0.14,0.03,0.03,0%,0.0,0.0,nathaniel jackson,
-CSM,2060,1.0,Construction Science Work,0.82,0.06,0.12,0.0,0.0,0%,0.0,0.0,nathaniel jackson,
-CSM,2060,2.0,Construction Science Work,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,nathaniel jackson,
-CSM,2070,1.0,Construction Industry Sem,0.6,0.14,0.14,0.05,0.07,0%,0.0,0.0,thomas fuduric,
-CSM,3040,401.0,Environmental Systems I,0.48,0.39,0.09,0.02,0.02,0%,0.0,0.0,joseph burgett,
-CSM,3050,1.0,Environmental Systems II,0.15,0.38,0.31,0.0,0.12,0%,0.0,0.04,joseph burgett,
-CSM,3060,1.0,Emerging Tech in Construc,0.84,0.06,0.03,0.03,0.03,0%,0.0,0.0,harnish sharma,
-CSM,3060,401.0,Emerging Tech in Construc,0.68,0.18,0.09,0.0,0.0,0%,0.0,0.05,harnish sharma,
-CSM,3070,1.0,Sustainable Construction,0.54,0.42,0.0,0.0,0.04,0%,0.0,0.0,harnish sharma,
-CSM,3510,1.0,Construction Estimating,0.29,0.48,0.06,0.06,0.08,0%,0.0,0.02,rizi seyed mousavi,
-CSM,3520,1.0,Const Scheduling,0.38,0.46,0.13,0.04,0.0,0%,0.0,0.0,dennis bausman,
-CSM,3530,401.0,Const Estimating II,0.48,0.43,0.04,0.04,0.0,0%,0.0,0.0,anthony harden,
-CSM,4110,401.0,Safety in Bldg Const,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,nicholas corley,
-CSM,4500,1.0,Construction Internship,0.66,0.21,0.1,0.0,0.0,0%,0.0,0.03,nathaniel jackson,
-CSM,4530,1.0,Const Proj Mgmt,0.69,0.27,0.04,0.0,0.0,0%,0.0,0.0,dennis bausman,
-CSM,4540,1.0,Construction Capstone,0.6,0.33,0.07,0.0,0.0,0%,0.0,0.0,vivek sharma,
-CSM,4610,1.0,Const Econ Seminar,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0, nove-josserand,
-CSM,4980,2.0,Current Topics-NAHB Com,0.71,0.21,0.07,0.0,0.0,0%,0.0,0.0,jason lucas,
-CSM,8520,400.0,Const Mgmt Research,0.45,0.55,0.0,0.0,0.0,0%,0.0,0.0,vivek sharma,
-CSM,8650,400.0,Project Management,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,dhaval gajjar,
-CU,1000,37.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.15,0.0,susan whorton,
-CU,1000,38.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,84%,0.12,0.01,susan whorton,
-CU,1000,52.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.13,0.0,susan whorton,
-CU,1000,53.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.15,0.01,susan whorton,
-CU,1000,54.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,84%,0.12,0.01,susan whorton,
-CU,1000,57.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,79%,0.18,0.01,susan whorton,
-CU,1000,58.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,77%,0.17,0.0,susan whorton,
-CU,1000,59.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,79%,0.14,0.01,susan whorton,
-CU,1000,60.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,83%,0.13,0.0,susan whorton,
-CU,1000,61.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,71%,0.28,0.01,susan whorton,
-CU,1000,62.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,73%,0.26,0.0,susan whorton,
-CU,1000,63.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,70%,0.29,0.0,susan whorton,
-CU,1000,64.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,64%,0.27,0.02,susan whorton,
-CU,1000,65.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,69%,0.26,0.01,susan whorton,
-CU,1000,66.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,65%,0.32,0.01,susan whorton,
-CU,1000,67.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,susan whorton,
-CU,1010,1.0,Univ Success Skills,0.53,0.07,0.13,0.0,0.13,0%,0.0,0.13,bryn babb,
-CU,1010,6.0,Univ Success Skills,0.7,0.1,0.1,0.0,0.1,0%,0.0,0.0,catherine neel,
-CU,1110,4.0,Intro Supplemental Instruc,0.0,0.0,0.0,0.0,0.0,91%,0.0,0.09,rachel anderson,
-CU,1110,5.0,Intro Supplemental Instruc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rachel anderson,
-DPA,3070,1.0,Method 3d Production,0.21,0.13,0.04,0.0,0.17,0%,0.0,0.46,da costa florencio,
-DPA,4000,1.0,Tech Foundations I,0.47,0.18,0.06,0.06,0.18,0%,0.0,0.06,jessica baron,
-DPA,4020,1.0,Visual Found of Digital Pro,0.64,0.27,0.09,0.0,0.0,0%,0.0,0.0,anthony summey,
-DPA,4020,2.0,Visual Found of Digital Pro,0.23,0.54,0.08,0.0,0.15,0%,0.0,0.0,anthony summey,
-DPA,6000,843.0,Tech Foundations I,0.33,0.33,0.33,0.0,0.0,0%,0.0,0.0,eric patterson,
-DPA,6830,842.0,Spe Stu Top in DPA: Dig Ci,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,eric patterson,
-DPA,8090,1.0,Rendering and Shading,0.5,0.3,0.2,0.0,0.0,0%,0.0,0.0,daljit singh dhillon,
-DSA,8010,401.0,Statistical Methods I,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,deborah kunkel,
-DSA,8030,401.0,Intro to Statistical Computi,0.56,0.33,0.0,0.0,0.0,0%,0.0,0.11,ellen hepfer breazel,
-DSA,8640,1.0,Programming for Data Scie,0.83,0.1,0.03,0.0,0.0,0%,0.0,0.03,hongki kim,
-ECAS,2990,201.0,CI CU Eng for Dev Countrie,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,david vaughn,
-ECAS,2990,301.0,CI SPECTRA,0.8,0.0,0.1,0.0,0.0,0%,0.0,0.1,joshua summers,
-ECE,2010,1.0,Logic and Computing Devic,0.28,0.33,0.25,0.04,0.04,0%,0.0,0.04,hassan raza,
-ECE,2010,2.0,Logic & Comp Device (HO,0.53,0.2,0.13,0.07,0.07,0%,0.0,0.0,william reid,True
-ECE,2020,1.0,Electric Circuits I,0.15,0.32,0.25,0.09,0.11,0%,0.0,0.09,william harrell,
-ECE,2070,1.0,Basic Electrical Engineering,0.31,0.22,0.21,0.15,0.04,0%,0.0,0.07,wesley green,
-ECE,2070,2.0,Basic Electrical Engineering,0.2,0.2,0.28,0.11,0.13,0%,0.0,0.08,jeffrey osterberg,
-ECE,2070,3.0,Basic Electrical Engineering,0.37,0.32,0.18,0.08,0.05,0%,0.0,0.01,timothy anglea,
-ECE,2080,1.0,Basic Electrical Engr Lab,0.7,0.15,0.05,0.0,0.0,0%,0.0,0.1,apoorva kapadia,
-ECE,2080,2.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,
-ECE,2080,7.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,
-ECE,2080,8.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0%,0.0,0.1,apoorva kapadia,
-ECE,2080,9.0,Basic Electrical Engr Lab,0.88,0.0,0.0,0.0,0.06,0%,0.0,0.06,apoorva kapadia,
-ECE,2080,10.0,Basic Electrical Engr Lab,0.89,0.06,0.0,0.0,0.06,0%,0.0,0.0,apoorva kapadia,
-ECE,2080,13.0,Basic Electrical Engr Lab,0.7,0.1,0.0,0.0,0.1,0%,0.0,0.1,apoorva kapadia,
-ECE,2080,14.0,Basic Electrical Engr Lab,0.89,0.0,0.05,0.0,0.0,0%,0.0,0.05,apoorva kapadia,
-ECE,2080,15.0,Basic Electrical Engr Lab,0.85,0.05,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,
-ECE,2090,1.0,Logic & Computing Device,0.77,0.08,0.0,0.0,0.08,0%,0.0,0.08,apoorva kapadia,
-ECE,2090,2.0,Logic & Computing Device,0.75,0.0,0.0,0.0,0.25,0%,0.0,0.0,apoorva kapadia,
-ECE,2090,3.0,Logic & Computing Device,0.67,0.25,0.0,0.0,0.08,0%,0.0,0.0,apoorva kapadia,
-ECE,2090,4.0,Logic & Computing Device,0.45,0.09,0.09,0.09,0.18,0%,0.0,0.09,apoorva kapadia,
-ECE,2090,5.0,Logic & Computing Device,0.33,0.67,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
-ECE,2090,6.0,Logic & Computing Device,0.7,0.0,0.0,0.0,0.1,0%,0.0,0.2,apoorva kapadia,
-ECE,2090,7.0,Logic & Computing Device,0.77,0.0,0.0,0.0,0.08,0%,0.0,0.15,apoorva kapadia,
-ECE,2090,12.0,Logic & Computing Device,0.36,0.18,0.0,0.0,0.0,0%,0.0,0.45,apoorva kapadia,
-ECE,2110,1.0,Elec Engr Lab I,0.7,0.15,0.1,0.0,0.05,0%,0.0,0.0,apoorva kapadia,
-ECE,2110,2.0,Elec Engr Lab I,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,apoorva kapadia,
-ECE,2110,3.0,Elec Engr Lab I,0.55,0.15,0.05,0.0,0.0,0%,0.0,0.25,apoorva kapadia,
-ECE,2110,5.0,Elec Engr Lab I,0.85,0.0,0.0,0.0,0.15,0%,0.0,0.0,apoorva kapadia,
-ECE,2110,6.0,Elec Engr Lab I,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
-ECE,2110,7.0,Elec Engr Lab I,0.7,0.1,0.0,0.0,0.0,0%,0.0,0.2,apoorva kapadia,
-ECE,2110,8.0,Elec Engr Lab I,0.58,0.26,0.05,0.0,0.0,0%,0.0,0.11,apoorva kapadia,
-ECE,2110,9.0,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.05,0%,0.0,0.0,apoorva kapadia,
-ECE,2110,10.0,Elec Engr Lab I,0.64,0.0,0.0,0.0,0.09,0%,0.0,0.27,apoorva kapadia,
-ECE,2120,1.0,Electrical Engineering Lab I,0.64,0.0,0.14,0.0,0.14,0%,0.0,0.07,apoorva kapadia,
-ECE,2120,3.0,Electrical Engineering Lab I,0.85,0.0,0.0,0.0,0.0,0%,0.0,0.15,apoorva kapadia,
-ECE,2120,4.0,Electrical Engineering Lab I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
-ECE,2220,1.0,Syst Prog Concept,0.3,0.21,0.12,0.03,0.18,0%,0.0,0.15,lu yu,
-ECE,2230,1.0,Comp Sys Eng,0.22,0.24,0.19,0.17,0.02,0%,0.0,0.17,harlan russell,
-ECE,2620,1.0,Electric Circuits II,0.61,0.2,0.07,0.0,0.1,0%,0.0,0.02,liang dong,
-ECE,2720,1.0,Comp Organization,0.19,0.37,0.28,0.07,0.07,0%,0.0,0.02,william reid,
-ECE,2730,2.0,Computer Org Lab,0.46,0.38,0.08,0.0,0.08,0%,0.0,0.0,apoorva kapadia,
-ECE,2730,3.0,Computer Org Lab,0.38,0.38,0.13,0.06,0.0,0%,0.0,0.06,apoorva kapadia,
-ECE,2730,5.0,Computer Org Lab,0.5,0.3,0.1,0.0,0.0,0%,0.0,0.1,apoorva kapadia,
-ECE,3110,2.0,Electrical Engineering Lab I,0.73,0.13,0.0,0.07,0.07,0%,0.0,0.0,apoorva kapadia,
-ECE,3110,3.0,Electrical Engineering Lab I,0.81,0.13,0.0,0.0,0.0,0%,0.0,0.06,apoorva kapadia,
-ECE,3110,4.0,Electrical Engineering Lab I,0.53,0.18,0.0,0.0,0.24,0%,0.0,0.06,apoorva kapadia,
-ECE,3110,7.0,Electrical Engineering Lab I,0.65,0.12,0.06,0.0,0.0,0%,0.0,0.18,apoorva kapadia,
-ECE,3110,9.0,Electrical Engineering Lab I,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
-ECE,3120,1.0,Electrical Engineering Lab I,0.75,0.15,0.0,0.05,0.05,0%,0.0,0.0,apoorva kapadia,
-ECE,3120,2.0,Electrical Engineering Lab I,0.75,0.13,0.06,0.0,0.06,0%,0.0,0.0,apoorva kapadia,
-ECE,3170,1.0,Rand Signal Analysis,0.52,0.31,0.1,0.03,0.0,0%,0.0,0.05,stephen hubbard,
-ECE,3200,1.0,Electronics I,0.42,0.18,0.17,0.1,0.08,0%,0.0,0.05,stephen hubbard,
-ECE,3200,2.0,Electronics I (HON),0.4,0.5,0.1,0.0,0.0,0%,0.0,0.0,stephen hubbard,True
-ECE,3210,1.0,Electronics II,0.36,0.44,0.21,0.0,0.0,0%,0.0,0.0,tehseen raza,
-ECE,3220,1.0,Intro Operating Sys,0.25,0.19,0.19,0.13,0.13,0%,0.0,0.13,jacob sorber,
-ECE,3270,1.0,Dig Comp Design,0.35,0.41,0.11,0.0,0.05,0%,0.0,0.08,walter ligon,
-ECE,3300,1.0,Signals & Systems,0.22,0.18,0.21,0.13,0.16,0%,0.0,0.1,carl baum,
-ECE,3300,2.0,Signals & Systems (HON),0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,daniel noneaker,True
-ECE,3520,1.0,Programming Systems,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,yongkai wu,
-ECE,3600,1.0,Elect Power Engr,0.2,0.27,0.07,0.07,0.27,0%,0.0,0.13,sukumar brahma,
-ECE,3710,1.0,Microcontr Interface,0.31,0.38,0.18,0.02,0.1,0%,0.0,0.01,william reid,
-ECE,3720,1.0,Micro Int Lab,0.77,0.08,0.0,0.0,0.08,0%,0.0,0.08,apoorva kapadia,
-ECE,3720,2.0,Micro Int Lab,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
-ECE,3720,3.0,Micro Int Lab,0.46,0.23,0.08,0.0,0.23,0%,0.0,0.0,apoorva kapadia,
-ECE,3720,4.0,Micro Int Lab,0.5,0.08,0.08,0.08,0.0,0%,0.0,0.25,apoorva kapadia,
-ECE,3720,5.0,Micro Int Lab,0.73,0.18,0.0,0.0,0.09,0%,0.0,0.0,apoorva kapadia,
-ECE,3720,6.0,Micro Int Lab,0.77,0.0,0.0,0.0,0.15,0%,0.0,0.08,apoorva kapadia,
-ECE,3720,7.0,Micro Int Lab,0.75,0.0,0.0,0.08,0.0,0%,0.0,0.17,apoorva kapadia,
-ECE,3720,8.0,Micro Int Lab,0.54,0.0,0.08,0.08,0.08,0%,0.0,0.23,apoorva kapadia,
-ECE,3720,9.0,Micro Int Lab,0.33,0.25,0.08,0.0,0.17,0%,0.0,0.17,apoorva kapadia,
-ECE,3720,11.0,Micro Int Lab,0.45,0.27,0.0,0.0,0.09,0%,0.0,0.18,apoorva kapadia,
-ECE,3800,1.0,Electromagnetics,0.08,0.14,0.26,0.08,0.22,0%,0.0,0.22,anthony martin,
-ECE,3810,1.0,Field Waves & Ckts,0.33,0.5,0.15,0.0,0.0,0%,0.0,0.02,tehseen raza,
-ECE,4090,1.0,Intr to Linear Control Syste,0.73,0.24,0.02,0.01,0.0,0%,0.0,0.0,apoorva kapadia,
-ECE,4180,1.0,Power Syst Analysis,0.41,0.35,0.0,0.12,0.0,0%,0.0,0.12,ramtin hadidi,
-ECE,4270,1.0,Communication Systems,0.23,0.4,0.25,0.03,0.03,0%,0.0,0.06,lu yu,
-ECE,4310,1.0,Intro to Computer Vision,0.61,0.33,0.06,0.0,0.0,0%,0.0,0.0,adam hoover,
-ECE,4420,1.0,Knowledge Engineering,0.87,0.0,0.0,0.0,0.07,0%,0.0,0.07,ao ren,
-ECE,4490,1.0,Comp Ntwrk Security,0.33,0.24,0.05,0.05,0.0,0%,0.0,0.29,richard brooks,
-ECE,4610,1.0,Fundamentals of Solar Ene,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,rajendra singh,
-ECE,4670,1.0,Intro to Dig Sig Pro,0.31,0.44,0.19,0.06,0.0,0%,0.0,0.0,john gowdy,
-ECE,4730,1.0,Intro Parallel Sys,0.4,0.48,0.0,0.0,0.08,0%,0.0,0.04,walter ligon,
-ECE,4950,1.0,Int Sys Design I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
-ECE,4960,1.0,Int Sys Design II,0.7,0.26,0.04,0.0,0.0,0%,0.0,0.0,richard groff,
-ECE,6040,1.0,Semiconductor Devices,0.67,0.22,0.11,0.0,0.0,0%,0.0,0.0,judson ryckman,
-ECE,6310,1.0,Intro to Computer Vision,0.74,0.11,0.16,0.0,0.0,0%,0.0,0.0,adam hoover,
-ECE,6360,1.0,Microwave Circuits,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,pingshan wang,
-ECE,6490,1.0,Comp Ntwrk Security,0.71,0.14,0.0,0.0,0.0,0%,0.0,0.14,richard brooks,
-ECE,6590,1.0,Int Circ Design,0.36,0.36,0.0,0.0,0.0,0%,0.0,0.18,yingjie lao,
-ECE,6670,1.0,Intro to Dig Sig Pro,0.75,0.0,0.08,0.0,0.0,0%,0.0,0.17,john gowdy,
-ECE,8010,1.0,Analysis of Lin Sys,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,richard groff,
-ECE,8020,1.0,Elec Motor Cntl,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0, edrington,
-ECE,8020,843.0,Elec Motor Cntl,0.6,0.2,0.0,0.0,0.2,0%,0.0,0.0, edrington,
-ECE,8040,1.0,Networked Dynamical Syst,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,yongqiang wang,
-ECE,8120,1.0,Adv Electronic Materials/D,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,goutam koley,
-ECE,8270,1.0,Finite Dif Meth Emag,0.33,0.17,0.0,0.0,0.0,0%,0.0,0.17,anthony martin,
-ECE,8540,1.0,Analysis of Tracking Syste,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,adam hoover,
-ECE,8620,1.0,Com Appl Pwr Sys,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0, venayagamoorthy,
-ECE,8910,16.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,adam hoover,
-ECE,8910,39.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melissa smith,
-ECE,8910,44.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sukumar brahma,
-ECE,9910,21.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,goutam koley,
-ECE,9910,32.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yingjie lao,
-ECE,9910,39.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melissa smith,
-ECE,9910,41.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, venayagamoorthy,
-ECON,2000,2.0,Economic Concepts,0.68,0.25,0.05,0.0,0.0,0%,0.0,0.03,shubhashrita basu,
-ECON,2000,4.0,Economic Concepts,0.46,0.34,0.17,0.0,0.03,0%,0.0,0.0,miren ivankovic,
-ECON,2000,5.0,Economic Concepts,0.64,0.33,0.03,0.0,0.0,0%,0.0,0.0,shubhashrita basu,
-ECON,2050,1.0,Why Business?,0.63,0.23,0.05,0.02,0.05,0%,0.0,0.02,lawrence watson,
-ECON,2110,1.0,Principles of Microeconom,0.11,0.26,0.32,0.11,0.11,0%,0.0,0.11,frederick hanssen,
-ECON,2110,2.0,Principles of Microeconom,0.05,0.37,0.42,0.05,0.11,0%,0.0,0.0,frederick hanssen,
-ECON,2110,3.0,Principles of Microeconom,0.05,0.42,0.42,0.05,0.05,0%,0.0,0.0,frederick hanssen,
-ECON,2110,4.0,Principles of Microeconom,0.16,0.47,0.21,0.0,0.0,0%,0.0,0.16,frederick hanssen,
-ECON,2110,5.0,Principles of Microeconom,0.0,0.58,0.16,0.05,0.11,0%,0.0,0.11,frederick hanssen,
-ECON,2110,6.0,Principles of Microeconom,0.06,0.44,0.28,0.06,0.17,0%,0.0,0.0,frederick hanssen,
-ECON,2110,7.0,Principles of Microeconom,0.05,0.32,0.37,0.11,0.16,0%,0.0,0.0,frederick hanssen,
-ECON,2110,8.0,Principles of Microeconom,0.16,0.37,0.37,0.05,0.0,0%,0.0,0.05,frederick hanssen,
-ECON,2110,9.0,Principles of Microeconom,0.11,0.42,0.21,0.05,0.0,0%,0.0,0.21,frederick hanssen,
-ECON,2110,10.0,Principles of Microeconom,0.0,0.32,0.58,0.0,0.05,0%,0.0,0.05,frederick hanssen,
-ECON,2110,11.0,Principles of Microeconom,0.11,0.37,0.26,0.11,0.11,0%,0.0,0.05,frederick hanssen,
-ECON,2110,12.0,Principles of Microeconom,0.0,0.47,0.21,0.05,0.05,0%,0.0,0.21,frederick hanssen,
-ECON,2110,13.0,Principles of Microeconom,0.0,0.79,0.11,0.05,0.0,0%,0.0,0.05,frederick hanssen,
-ECON,2110,14.0,Principles of Microeconom,0.16,0.42,0.32,0.05,0.0,0%,0.0,0.05,frederick hanssen,
-ECON,2110,15.0,Principles of Microeconom,0.05,0.47,0.16,0.05,0.05,0%,0.0,0.21,frederick hanssen,
-ECON,2110,16.0,Principles of Microeconom,0.05,0.32,0.32,0.11,0.11,0%,0.0,0.11,frederick hanssen,
-ECON,2110,17.0,Principles of Microeconom,0.16,0.47,0.32,0.0,0.0,0%,0.0,0.05,frederick hanssen,
-ECON,2110,18.0,Principles of Microeconom,0.11,0.63,0.11,0.0,0.05,0%,0.0,0.11,frederick hanssen,
-ECON,2110,19.0,Principles of Microeconom,0.05,0.26,0.53,0.05,0.0,0%,0.0,0.11,frederick hanssen,
-ECON,2110,20.0,Principles of Microeconom,0.25,0.44,0.22,0.06,0.01,0%,0.0,0.01,scott baier,
-ECON,2110,21.0,Principles of Microeconom,0.2,0.56,0.2,0.01,0.03,0%,0.0,0.0,scott baier,
-ECON,2110,23.0,Principles of Microeconom,0.68,0.23,0.05,0.0,0.02,0%,0.0,0.01,seyedmajid hashemi,
-ECON,2110,24.0,Principles of Microeconom,0.34,0.26,0.22,0.09,0.05,0%,0.0,0.05,devon merritt gorry,
-ECON,2110,25.0,Principles of Microeconom,0.48,0.29,0.21,0.0,0.02,0%,0.0,0.0,cory simpkins,
-ECON,2110,26.0,Principles of Microeconom,0.72,0.2,0.02,0.02,0.0,0%,0.0,0.02,tabitha knott,
-ECON,2110,31.0,Principles of Microeconom,0.62,0.29,0.07,0.01,0.0,0%,0.0,0.01,seyedmajid hashemi,
-ECON,2110,32.0,Principles of Microeconom,0.23,0.51,0.19,0.01,0.06,0%,0.0,0.0,scott baier,
-ECON,2110,33.0,Principles of Microeconom,0.67,0.19,0.1,0.0,0.05,0%,0.0,0.0,shilpi mukherjee,
-ECON,2110,34.0,Principles of Microecon (H,0.39,0.48,0.04,0.09,0.0,0%,0.0,0.0,charles thomas,True
-ECON,2110,35.0,Principles of Microeconom,0.38,0.52,0.07,0.0,0.0,0%,0.0,0.02,cory simpkins,
-ECON,2110,36.0,Principles of Microeconom,0.57,0.37,0.04,0.0,0.0,0%,0.0,0.01,tabitha knott,
-ECON,2110,38.0,Principles of Microeconom,0.4,0.4,0.1,0.02,0.05,0%,0.0,0.02,guncha babajanova,
-ECON,2110,40.0,Principles of Microeconom,0.61,0.17,0.07,0.07,0.05,0%,0.0,0.02,shilpi mukherjee,
-ECON,2110,41.0,Principles of Microeconom,0.5,0.43,0.05,0.0,0.0,0%,0.0,0.02,guncha babajanova,
-ECON,2120,1.0,Principles of Macroecono,0.15,0.44,0.25,0.13,0.04,0%,0.0,0.0,yinlin dai,
-ECON,2120,2.0,Principles of Macroecono,0.37,0.45,0.14,0.02,0.0,0%,0.0,0.02,bradley keith hobbs,
-ECON,2120,3.0,Principles of Macroecono,0.5,0.3,0.12,0.02,0.05,0%,0.0,0.02,krishna khatri,
-ECON,2120,4.0,Principles of Macroecono,0.72,0.22,0.06,0.0,0.0,0%,0.0,0.0,tyler francis,
-ECON,2120,5.0,Principles of Macroecono,0.48,0.33,0.1,0.03,0.03,0%,0.0,0.05,matthew lee cronin,
-ECON,2120,6.0,Principles of Macroecono,0.41,0.46,0.05,0.03,0.03,0%,0.0,0.03,matthew lee cronin,
-ECON,2120,7.0,Principles of Macroecono,0.78,0.15,0.04,0.01,0.01,0%,0.0,0.0,tyler francis,
-ECON,2120,8.0,Principles of Macroecono,0.19,0.45,0.21,0.1,0.03,0%,0.0,0.02,mason bixenman,
-ECON,2120,9.0,Principles of Macroecono,0.28,0.28,0.14,0.14,0.14,0%,0.0,0.03,yinlin dai,
-ECON,2120,10.0,Principles of Macroecono,0.35,0.48,0.15,0.03,0.0,0%,0.0,0.0,illia polovnikov,
-ECON,3020,1.0,Money and Banking,0.65,0.25,0.08,0.0,0.03,0%,0.0,0.0,adam witham,
-ECON,3030,2.0,Economics and Sports,0.37,0.47,0.11,0.0,0.03,0%,0.0,0.03,raymond sauer,
-ECON,3060,2.0,Managerial Economics,0.33,0.33,0.17,0.0,0.03,0%,0.0,0.13,miren ivankovic,
-ECON,3100,2.0,International Econ,0.36,0.43,0.15,0.04,0.0,0%,0.0,0.03,scott baier,
-ECON,3140,1.0,Intermediate Micro,0.41,0.17,0.2,0.11,0.04,0%,0.0,0.07,patrick warren,
-ECON,3140,3.0,Intermediate Micro,0.22,0.15,0.2,0.11,0.28,0%,0.0,0.04,frederick hanssen,
-ECON,3140,5.0,Intermediate Micro,0.37,0.4,0.18,0.02,0.02,0%,0.0,0.02,molly espey,
-ECON,3150,2.0,Intermediate Macro,0.09,0.4,0.27,0.09,0.09,0%,0.0,0.07, jerzmanowski,
-ECON,3150,4.0,Intermediate Macro,0.74,0.18,0.03,0.0,0.06,0%,0.0,0.0,scott baier,
-ECON,3150,5.0,Intermediate Macro,0.92,0.03,0.0,0.0,0.03,0%,0.0,0.03,scott baier,
-ECON,3190,1.0,Environmental Econ,0.42,0.4,0.08,0.02,0.04,0%,0.0,0.04,molly espey,
-ECON,3500,1.0,Moral & Ethical Econ,0.25,0.33,0.08,0.0,0.17,0%,0.0,0.17,bradley keith hobbs,
-ECON,3600,1.0,Public Choice,0.44,0.3,0.16,0.06,0.0,0%,0.0,0.04,michael makowsky,
-ECON,4010,1.0,Labor Mkt Analysis,0.36,0.33,0.06,0.06,0.12,0%,0.0,0.06,chungsang lam,
-ECON,4020,1.0,Law and Economics,0.32,0.34,0.18,0.07,0.02,0%,0.0,0.07,howard bodenhorn,
-ECON,4040,1.0,Comp Econ Systems,0.19,0.38,0.24,0.0,0.05,0%,0.0,0.14, litsukova-bokar,
-ECON,4050,1.0,Intro to Econometric,0.46,0.19,0.15,0.08,0.08,0%,0.0,0.04,yichen christy zhou,
-ECON,4050,5.0,Intro to Econometric,0.4,0.26,0.17,0.06,0.11,0%,0.0,0.0,scott barkowski,
-ECON,4100,1.0,Economic Development,0.71,0.1,0.14,0.05,0.0,0%,0.0,0.0,robert tamura,
-ECON,4230,1.0,Economics of Health,0.45,0.28,0.1,0.05,0.08,0%,0.0,0.0,devon merritt gorry,
-ECON,4240,1.0,Organization of Ind,0.61,0.22,0.17,0.0,0.0,0%,0.0,0.0,matthew lewis,
-ECON,4280,1.0,Cost-Benefit Anlysis,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,robert kenneth fleck,
-ECON,4980,2.0,Economics Data Analytics,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,raymond sauer,
-ECON,4980,3.0,Machine Learning I,0.45,0.18,0.0,0.0,0.18,0%,0.0,0.18,chungsang lam,
-ECON,6060,1.0,Advanced Econometric,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,scott baier,
-ECON,6280,1.0,Cost-Benefit Anlysis,0.67,0.17,0.17,0.0,0.0,0%,0.0,0.0,robert kenneth fleck,
-ECON,8010,1.0,Microeconomic Theory,0.33,0.33,0.2,0.0,0.07,0%,0.0,0.0,william dougan,
-ECON,8040,1.0,Applied Math Econ,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,curtis simon,
-ECON,8080,1.0,Econometrics III,0.12,0.76,0.12,0.0,0.0,0%,0.0,0.0,paul wayne wilson,
-ECON,8160,1.0,Labor Economics,0.4,0.4,0.0,0.0,0.0,0%,0.0,0.2,curtis simon,
-ECON,8230,1.0,Microecon Pub Pol,0.17,0.67,0.08,0.0,0.0,0%,0.0,0.08,scott templeton,
-ECON,8990,5.0,Sel Topics - Macro Theory I,0.57,0.43,0.0,0.0,0.0,0%,0.0,0.0,christopher gorry,
-ECON,9000,2.0,Econometrics I,0.2,0.6,0.2,0.0,0.0,0%,0.0,0.0, menendez garcia,
-ECON,9000,3.0,Econometrics II,0.35,0.5,0.15,0.0,0.0,0%,0.0,0.0, menendez garcia,
-ECON,9010,1.0,Price Theory,0.6,0.2,0.2,0.0,0.0,0%,0.0,0.0,charles thomas,
-ECON,9810,1.0,App Econ Analysis,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,howard bodenhorn,
-ECON,9820,2.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,frederick hanssen,
-ECON,9820,3.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,curtis simon,
-ECON,9820,4.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,william dougan,
-ECON,9820,5.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert tamura,
-ECON,9910,4.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gerald dwyer,
-ED,1050,6.0,Orientation to Education,0.88,0.04,0.0,0.0,0.04,0%,0.0,0.04,hilary tanck,
-ED,1050,7.0,Orientation to Education,0.8,0.13,0.0,0.0,0.07,0%,0.0,0.0,yashica latimer,
-ED,1050,8.0,Orientation to Education,0.79,0.07,0.0,0.0,0.07,0%,0.0,0.07,yashica latimer,
-ED,1050,9.0,Orientation to Education,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.03,yashica latimer,
-ED,1970,4.0,CI-CONNECTIONS Stud Dev,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,deonte brown,
-ED,3010,1.0,Principles of American Edu,0.85,0.04,0.0,0.0,0.11,0%,0.0,0.0,beatrice naff bailey,
-ED,3010,3.0,Principles of American Edu,0.92,0.0,0.0,0.0,0.08,0%,0.0,0.0,beatrice naff bailey,
-ED,8090,450.0,Teacher Residency Interns,0.93,0.05,0.0,0.0,0.0,0%,0.0,0.03,corrie leigh martin,
-ED,8480,450.0,Teacher Residency Semina,0.98,0.0,0.0,0.0,0.0,0%,0.0,0.02,laura cohen eicher,
-ED,8750,331.0,Elements of Instructional E,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,anna morrison,
-ED,8990,331.0,Capstone Research Project,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,daphne wiles,
-EDC,8140,401.0,Develpmnt of Counseling S,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,barbara boyd,
-EDC,8410,400.0,School Counseling Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,amanda rumsey,
-EDC,8460,400.0,Clinical Ment Hlth Coun Int,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,corrine sackett,
-EDC,8460,401.0,Clinical Ment Hlth Coun Int,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david scott,
-EDEC,4300,1.0,Early Childhd Math,0.93,0.04,0.0,0.0,0.0,0%,0.0,0.04,sandra linder,
-EDEC,4400,1.0,Early Childhood Engl Lang,0.86,0.11,0.0,0.0,0.0,0%,0.0,0.04,anna henson hall,
-EDEL,3210,2.0,Pe for the Elem Tchr,0.46,0.46,0.03,0.0,0.03,0%,0.0,0.03,deborah smith,
-EDEL,3210,3.0,Pe for the Elem Tchr,0.48,0.45,0.07,0.0,0.0,0%,0.0,0.0,deborah smith,
-EDEL,4510,1.0,Elem Methods in Science T,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,cynthia deaton,
-EDEL,4870,2.0,Ele Meth Soc Studies,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,melinda spearman,
-EDF,3020,1.0,Educational Psychology,0.88,0.09,0.0,0.0,0.0,0%,0.0,0.03,meihua qian,
-EDF,3020,2.0,Educational Psychology,0.86,0.11,0.0,0.0,0.0,0%,0.0,0.03,meihua qian,
-EDF,3080,1.0,Classroom Assessment,0.95,0.03,0.0,0.03,0.0,0%,0.0,0.0,quesada hazel vega,
-EDF,3080,2.0,Classroom Assessment,0.86,0.0,0.07,0.03,0.0,0%,0.0,0.03,quesada hazel vega,
-EDF,3340,1.0,Child Growth and Develop,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,faiza marghoob jamil,
-EDF,3340,3.0,Child Growth and Develop,0.7,0.22,0.05,0.0,0.03,0%,0.0,0.0,faiza marghoob jamil,
-EDF,3350,1.0,Adolescent Growth & Dev,0.9,0.07,0.0,0.0,0.0,0%,0.0,0.03,luke rapa,
-EDF,4800,1.0,Digital Media & Learning,0.64,0.23,0.0,0.05,0.09,0%,0.0,0.0,ryan visser,
-EDF,4800,2.0,Digital Media & Learning,0.87,0.0,0.09,0.0,0.04,0%,0.0,0.0,ryan visser,
-EDF,4800,300.0,Digital Media & Learning,0.9,0.07,0.03,0.0,0.0,0%,0.0,0.0,ryan visser,
-EDF,4800,302.0,Digital Media & Learning,0.93,0.04,0.04,0.0,0.0,0%,0.0,0.0,irgens arastoopour,
-EDF,8200,300.0,Effective Online Teaching,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,amanda bennett,
-EDF,8200,301.0,Effective Online Teaching,0.69,0.13,0.0,0.0,0.06,0%,0.0,0.13,robert todd kane,
-EDF,8200,500.0,Effective Online Teaching,0.88,0.04,0.0,0.0,0.04,0%,0.0,0.0,april susanne pelt,
-EDF,8200,501.0,Effective Online Teaching,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,valerie wheeler,
-EDF,8200,502.0,Effective Online Teaching,0.56,0.3,0.04,0.0,0.11,0%,0.0,0.0,amanda bennett,
-EDF,8200,505.0,Effective Online Teaching,0.83,0.0,0.03,0.0,0.14,0%,0.0,0.0,robert todd kane,
-EDF,8210,500.0,Online Course Manageme,0.81,0.04,0.0,0.0,0.12,0%,0.0,0.0,allyson marie wilcox,
-EDF,8210,501.0,Online Course Manageme,0.82,0.14,0.0,0.0,0.04,0%,0.0,0.0,karen bunch franklin,
-EDF,8210,502.0,Online Course Manageme,0.78,0.04,0.0,0.0,0.19,0%,0.0,0.0,robert todd kane,
-EDF,8210,505.0,Online Course Manageme,0.7,0.19,0.0,0.0,0.11,0%,0.0,0.0,amanda bennett,
-EDF,9270,1.0,Quant Rsrch & Stats for Ed,0.75,0.0,0.13,0.0,0.0,0%,0.0,0.13,christy jenkins brown,
-EDF,9790,1.0,Qualitative Research in Ed,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,melinda spearman,
-EDL,8200,400.0,Politics of Educ,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,danielle hall,
-EDL,8850,400.0,Diversity & School Commu,0.9,0.07,0.0,0.0,0.0,0%,0.0,0.0,reginald wilkerson,
-EDL,9770,2.0,Div Issues in Hi Ed,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,helen steele,
-EDL,9880,1.0,Directed Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,danielle hall,
-EDL,9910,3.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,natasha croom,
-EDL,9910,5.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,hans william klar,
-EDL,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jane lindle,
-EDL,9910,7.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,danielle hall,
-EDL,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,reginald wilkerson,
-EDL,9910,10.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,noelle paufler,
-EDLL,8050,401.0,Contemp Iss in School Lea,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.0,hans william klar,
-EDLL,8550,400.0,Secondary Sch Internship I,0.6,0.0,0.2,0.0,0.0,0%,0.0,0.0,melissa bryant burns,
-EDLT,4590,1.0,Teaching Reading Grades K,0.93,0.04,0.0,0.0,0.0,0%,0.0,0.04,lisa denise aker,
-EDLT,4600,1.0,Found of Read: Assess & In,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,hayley hoover,
-EDLT,4600,2.0,Found of Read: Assess & In,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,lisa denise aker,
-EDLT,4600,4.0,Found of Read: Assess & In,0.69,0.13,0.06,0.0,0.13,0%,0.0,0.0,polly wingate,
-EDLT,4610,1.0,Content Area Read/Writin,0.75,0.21,0.04,0.0,0.0,0%,0.0,0.0,pamela dunston,
-EDLT,4610,2.0,Content Area Read/Writin,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,pamela dunston,
-EDLT,4800,300.0,Found in Adolescent Litera,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,daniel stockwell,
-EDLT,4800,301.0,Found in Adolescent Litera,0.68,0.11,0.16,0.0,0.0,0%,0.0,0.05,daniel stockwell,
-EDLT,4980,1.0,Cont Area Read/Write Sec,0.86,0.1,0.0,0.0,0.0,0%,0.0,0.03,rachelle savitz,
-EDLT,8110,301.0,Adv Children's & Yng Adult,0.5,0.33,0.0,0.0,0.0,0%,0.0,0.0,susan king fullerton,
-EDLT,8150,301.0,Guided Reading & Guided,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,pamela dunston,
-EDLT,8190,300.0,Coaching for Literacy Educ,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,rachelle savitz,
-EDLT,8400,501.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,barbara fewell,
-EDLT,8400,510.0,Early Literacy Assessment I,0.89,0.0,0.11,0.0,0.0,0%,0.0,0.0,kimberly floyd,
-EDLT,8400,511.0,Early Literacy Assessment I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,renee gatlin anders,
-EDLT,8400,515.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,susanne elvington,
-EDLT,8400,516.0,Early Literacy Assessment I,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,ellen adkins sanford,
-EDSA,3900,6.0,Skills for Student Leaders,0.81,0.14,0.05,0.0,0.0,0%,0.0,0.0,deonte brown,
-EDSA,3990,1.0,Creative Inq in Counselor E,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,jacob frankovich,
-EDSA,8040,2.0,Theories Student Dev in Hi,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,tony cawthon,
-EDSA,8440,1.0,Student Affairs Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,tony cawthon,
-EDSC,2260,1.0,Pr Apprch to Sec Alg,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,stacy megan che,
-EDSC,4240,1.0,Tchng Sec English,0.8,0.07,0.13,0.0,0.0,0%,0.0,0.0, cridland-hughes,
-EDSC,4280,1.0,Tchng Secondary Social St,0.85,0.08,0.0,0.0,0.0,0%,0.0,0.08,kristen duncan,
-EDSP,3700,1.0,Intro to Special Education,0.91,0.06,0.03,0.0,0.0,0%,0.0,0.0,sharon walters,
-EDSP,3700,2.0,Intro to Special Education,0.73,0.23,0.0,0.0,0.0,0%,0.0,0.04,catherine griffith,
-EDSP,3700,4.0,Intro to Special Education,0.82,0.09,0.09,0.0,0.0,0%,0.0,0.0,catherine griffith,
-EDSP,3720,1.0,Char & Instr Individ with L,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,catherine griffith,
-EDSP,3740,1.0,Char & Strat Emot/Behav,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,shanna eisner hirsch,
-EDSP,3750,1.0,Early Intervention Spec Ne,0.84,0.12,0.0,0.0,0.04,0%,0.0,0.0,tracy denise garrett,
-EDSP,3750,2.0,Early Intervention Spec Ne,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,tracy denise garrett,
-EDSP,4920,1.0,Math Inst Ind W/Dis,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,pamela stecker,
-EDSP,4930,1.0,Clsrm/Beh Mgmt Sp Ed,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,joseph benedict ryan,
-EDSP,4960,1.0,Sp Ed Field Exp,0.93,0.03,0.03,0.0,0.0,0%,0.0,0.0,wendell kent parker,
-EES,2010,1.0,Environ Engr Fundamental,0.32,0.34,0.21,0.05,0.03,0%,0.0,0.05,david freedman,
-EES,3030,1.0,Water Treatment Systems,0.32,0.5,0.14,0.04,0.0,0%,0.0,0.0,david allen ladner,
-EES,3040,1.0,Wastewater Treatment Sy,0.56,0.19,0.26,0.0,0.0,0%,0.0,0.0,sudeep popat,
-EES,3050,1.0,Water/Wastewater Treat,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,david allen ladner,
-EES,3050,2.0,Water/Wastewater Treat,0.64,0.14,0.07,0.0,0.07,0%,0.0,0.0,sudeep popat,
-EES,4010,1.0,Environmental Engr,0.67,0.22,0.09,0.02,0.0,0%,0.0,0.0,elizabeth carraway,
-EES,4010,2.0,Environmental Engr,0.25,0.5,0.25,0.0,0.0,0%,0.0,0.0,mark schlautman,
-EES,4090,1.0,Intro to Nuc Engr & Radiol,0.22,0.39,0.06,0.33,0.0,0%,0.0,0.0,timothy devol,
-EES,4300,1.0,Air Pollution Engineering,0.38,0.38,0.16,0.03,0.06,0%,0.0,0.0,andrew metcalf,
-EES,4800,1.0,Environmental Risk Assess,0.41,0.28,0.21,0.07,0.03,0%,0.0,0.0,nicole martinez,
-EES,4840,1.0,Solid Waste Mgt,0.5,0.31,0.15,0.04,0.0,0%,0.0,0.0,ezra lucas hoyt cates hoyt,
-EES,4860,2.0,Environmental Sustainabili,0.6,0.25,0.05,0.0,0.0,0%,0.0,0.1, carbajales-dale,
-EES,6100,1.0,Environ Radiation Protecti,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.2,nicole martinez,
-EES,8020,1.0,Environ Eng Prin,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,david allen ladner,
-EES,8060,1.0,Design Env Control,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0, carbajales-dale,
-EES,8430,1.0,Environmental Chem,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,brian powell,
-EES,8430,2.0,Environmental Chem,0.5,0.38,0.0,0.0,0.0,0%,0.0,0.13,brian powell,
-EES,8510,1.0,Biol Prin Envir Engr,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,kevin finneran,
-EES,8610,1.0,Environmental Engr & Sci S,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sudeep popat,
-EES,8800,1.0,Env Risk Assessment,0.3,0.7,0.0,0.0,0.0,0%,0.0,0.0,timothy devol,
-ELE,3010,1.0,Entrepreneurial Foundatio,0.28,0.28,0.28,0.07,0.07,0%,0.0,0.02,ashley parnell,
-ELE,3010,2.0,Entrepreneurial Foundatio,0.22,0.27,0.34,0.07,0.02,0%,0.0,0.07,ashley parnell,
-ELE,3010,3.0,Entrepreneurial Foundatio,0.62,0.28,0.08,0.03,0.0,0%,0.0,0.0,lori leigh tribble,
-ELE,3010,4.0,Entrepreneurial Foundatio,0.32,0.46,0.19,0.0,0.03,0%,0.0,0.0,lori leigh tribble,
-ELE,3010,5.0,Entrepreneurial Foundatio,0.56,0.25,0.13,0.03,0.0,0%,0.0,0.03,lori leigh tribble,
-ELE,4020,1.0,Venture Planning,0.2,0.7,0.11,0.0,0.0,0%,0.0,0.0,william dinardo,
-ELE,4040,1.0,Entrepreneurial Resource,0.68,0.2,0.1,0.0,0.0,0%,0.0,0.02,james keith hudgins,
-ELE,4060,1.0,Venture Consulting,0.35,0.63,0.03,0.0,0.0,0%,0.0,0.0,william dinardo,
-ENGL,1030,7.0,Composition and Rhetoric,0.48,0.43,0.1,0.0,0.0,0%,0.0,0.0,allen swords,
-ENGL,1030,8.0,Composition and Rhetoric,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,allen swords,
-ENGL,1030,43.0,Composition and Rhetoric,0.71,0.14,0.0,0.0,0.14,0%,0.0,0.0,hannah taylor,
-ENGL,1030,44.0,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,hannah taylor,
-ENGL,1030,47.0,Composition and Rhetoric,0.4,0.45,0.0,0.05,0.05,0%,0.0,0.05,cody hunter,
-ENGL,1030,48.0,Composition and Rhetoric,0.6,0.1,0.05,0.0,0.15,0%,0.0,0.1,cody hunter,
-ENGL,1030,49.0,Composition and Rhetoric,0.62,0.24,0.05,0.0,0.0,0%,0.0,0.1,nicholas rader,
-ENGL,1030,50.0,Composition and Rhetoric,0.86,0.05,0.0,0.0,0.05,0%,0.0,0.05,nicholas rader,
-ENGL,1030,51.0,Composition and Rhetoric,0.76,0.0,0.05,0.0,0.14,0%,0.0,0.05,sethunya gall,
-ENGL,1030,400.0,Composition and Rhetoric,0.57,0.29,0.0,0.0,0.14,0%,0.0,0.0,kailan smith sindelar,
-ENGL,1030,401.0,Composition and Rhetoric,0.57,0.33,0.0,0.0,0.1,0%,0.0,0.0,kailan smith sindelar,
-ENGL,1030,402.0,Composition and Rhetoric,0.86,0.1,0.0,0.0,0.05,0%,0.0,0.0,jonathan burgess,
-ENGL,1030,403.0,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,jonathan burgess,
-ENGL,1030,404.0,Composition and Rhetoric,0.57,0.24,0.0,0.0,0.14,0%,0.0,0.05,eric reid hamilton,
-ENGL,1030,405.0,Composition and Rhetoric,0.48,0.24,0.05,0.14,0.1,0%,0.0,0.0,dennis ranahan,
-ENGL,1030,406.0,Composition and Rhetoric,0.81,0.05,0.0,0.05,0.05,0%,0.0,0.05,jacob danial richter,
-ENGL,1030,407.0,Composition and Rhetoric,0.33,0.39,0.11,0.0,0.11,0%,0.0,0.06,sheila lalwani,
-ENGL,1030,408.0,Composition and Rhetoric,0.06,0.41,0.24,0.12,0.18,0%,0.0,0.0,sheila lalwani,
-ENGL,1030,409.0,Composition and Rhetoric,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,jordan harris frith,
-ENGL,1030,410.0,Composition and Rhetoric,0.5,0.2,0.1,0.0,0.15,0%,0.0,0.05,hailee mccraw,
-ENGL,1030,411.0,Composition and Rhetoric,0.29,0.19,0.14,0.05,0.19,0%,0.0,0.14,hailee mccraw,
-ENGL,1030,412.0,Composition and Rhetoric,0.5,0.3,0.1,0.0,0.1,0%,0.0,0.0,miranda campbell,
-ENGL,1030,413.0,Composition and Rhetoric,0.47,0.26,0.21,0.0,0.05,0%,0.0,0.0,miranda campbell,
-ENGL,1030,414.0,Composition and Rhetoric,0.45,0.2,0.1,0.15,0.05,0%,0.0,0.05,edward thomas troy,
-ENGL,1030,415.0,Composition and Rhetoric,0.71,0.1,0.14,0.0,0.0,0%,0.0,0.05,lindsay scott,
-ENGL,1030,416.0,Composition and Rhetoric,0.53,0.18,0.06,0.06,0.06,0%,0.0,0.06,jennie wakefield,
-ENGL,1030,420.0,Composition and Rhetoric,0.62,0.19,0.05,0.05,0.0,0%,0.0,0.05,jennie wakefield,
-ENGL,1030,421.0,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,aparna shastri,
-ENGL,1030,423.0,Composition and Rhetoric,0.89,0.06,0.0,0.0,0.0,0%,0.0,0.06,amanda platz,
-ENGL,1030,425.0,Composition and Rhetoric,0.83,0.06,0.0,0.06,0.0,0%,0.0,0.06,aparna shastri,
-ENGL,1030,426.0,Composition and Rhetoric,0.78,0.06,0.0,0.0,0.11,0%,0.0,0.06,laura caroline dunn,
-ENGL,1030,427.0,Composition and Rhetoric,0.58,0.16,0.11,0.11,0.05,0%,0.0,0.0,laura caroline dunn,
-ENGL,1030,428.0,Composition and Rhetoric,0.89,0.05,0.0,0.05,0.0,0%,0.0,0.0,nicole marie stout,
-ENGL,1030,429.0,Composition and Rhetoric,0.68,0.16,0.05,0.11,0.0,0%,0.0,0.0,amanda platz,
-ENGL,1030,430.0,Composition and Rhetoric,0.5,0.2,0.15,0.1,0.0,0%,0.0,0.05,edward thomas troy,
-ENGL,1030,431.0,Composition and Rhetoric,0.63,0.11,0.11,0.05,0.05,0%,0.0,0.05,edward thomas troy,
-ENGL,1030,435.0,Composition and Rhetoric,0.5,0.35,0.1,0.0,0.05,0%,0.0,0.0,edward thomas troy,
-ENGL,1030,436.0,Composition and Rhetoric,0.88,0.0,0.0,0.13,0.0,0%,0.0,0.0,nicole marie stout,
-ENGL,1030,437.0,Composition and Rhetoric,0.78,0.0,0.06,0.0,0.11,0%,0.0,0.06,kaitlyn samons,
-ENGL,1030,445.0,Composition and Rhetoric,0.78,0.17,0.06,0.0,0.0,0%,0.0,0.0,dennis ranahan,
-ENGL,1030,446.0,Composition and Rhetoric,0.6,0.15,0.1,0.05,0.0,0%,0.0,0.1,mary frankovich,
-ENGL,1030,453.0,Composition and Rhetoric,0.68,0.16,0.05,0.05,0.0,0%,0.0,0.05,mary frankovich,
-ENGL,1030,454.0,Composition and Rhetoric,0.75,0.15,0.0,0.0,0.05,0%,0.0,0.05,sarah richardson,
-ENGL,1030,456.0,Composition and Rhetoric,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,sarah richardson,
-ENGL,1030,457.0,Composition and Rhetoric,0.84,0.0,0.05,0.05,0.05,0%,0.0,0.0,michael vaughan,
-ENGL,1030,459.0,Composition and Rhetoric,0.83,0.06,0.11,0.0,0.0,0%,0.0,0.0,michael vaughan,
-ENGL,1030,460.0,Composition and Rhetoric,0.72,0.11,0.11,0.0,0.06,0%,0.0,0.0,caroline kinderthain,
-ENGL,1030,461.0,Composition and Rhetoric,0.69,0.19,0.06,0.0,0.0,0%,0.0,0.06,kylie carlson,
-ENGL,1030,464.0,Composition and Rhetoric,0.78,0.06,0.0,0.11,0.06,0%,0.0,0.0,kylie carlson,
-ENGL,1030,465.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0%,0.0,0.0,rebecca rea  ross s,
-ENGL,1030,467.0,Composition and Rhetoric,0.38,0.38,0.06,0.0,0.13,0%,0.0,0.06,rebecca rea  ross s,
-ENGL,1030,468.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0%,0.0,0.0,samantha keebler,
-ENGL,1030,469.0,Composition and Rhetoric,0.67,0.06,0.06,0.06,0.11,0%,0.0,0.06,samantha keebler,
-ENGL,1030,470.0,Composition and Rhetoric,0.69,0.06,0.13,0.0,0.06,0%,0.0,0.06,jenny washburne,
-ENGL,1030,471.0,Composition and Rhetoric,0.59,0.35,0.06,0.0,0.0,0%,0.0,0.0,jenny washburne,
-ENGL,1030,475.0,Composition and Rhetoric,0.41,0.06,0.29,0.12,0.0,0%,0.0,0.12,victoria lynn carrico,
-ENGL,1030,476.0,Composition and Rhetoric,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,victoria lynn carrico,
-ENGL,1030,477.0,Composition and Rhetoric,0.42,0.37,0.11,0.11,0.0,0%,0.0,0.0,kimberly groves,
-ENGL,1030,478.0,Composition and Rhetoric,0.67,0.11,0.06,0.0,0.0,0%,0.0,0.17,kimberly groves,
-ENGL,1030,482.0,Composition and Rhetoric,0.78,0.06,0.0,0.0,0.06,0%,0.0,0.11,kaitlyn samons,
-ENGL,1030,484.0,Composition and Rhetoric,0.5,0.22,0.28,0.0,0.0,0%,0.0,0.0,allison daniel,
-ENGL,1030,485.0,Composition and Rhetoric,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,allison daniel,
-ENGL,2020,1.0,Lit Forms and Creative Wri,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,melissa dugan,
-ENGL,2020,2.0,Lit Forms and Creative Wri,0.7,0.26,0.0,0.0,0.04,0%,0.0,0.0,melissa dugan,
-ENGL,2020,4.0,Lit Forms and Creative Wri,0.52,0.4,0.08,0.0,0.0,0%,0.0,0.0,keith morris,
-ENGL,2020,5.0,Lit Forms and Creative Wri,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,john logan pursley,
-ENGL,2020,400.0,Lit Forms and Creative Wri,0.68,0.2,0.04,0.08,0.0,0%,0.0,0.0,stephanie edwards,
-ENGL,2020,401.0,Lit Forms and Creative Wri,0.44,0.32,0.12,0.04,0.0,0%,0.0,0.08,stephanie edwards,
-ENGL,2020,402.0,Lit Forms and Creative Wri,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,jillian weise,
-ENGL,2020,403.0,Lit Forms and Creative Wri,0.52,0.28,0.04,0.08,0.08,0%,0.0,0.0,stephanie edwards,
-ENGL,2120,1.0,World Literature,0.48,0.28,0.08,0.04,0.08,0%,0.0,0.04,andrew mathas,
-ENGL,2120,2.0,World Literature,0.52,0.16,0.2,0.0,0.08,0%,0.0,0.04,caitlin grace watt,
-ENGL,2120,3.0,World Literature,0.44,0.28,0.08,0.0,0.12,0%,0.0,0.08,kenneth tuite,
-ENGL,2120,9.0,World Literature,0.56,0.16,0.12,0.04,0.08,0%,0.0,0.04,caitlin grace watt,
-ENGL,2120,10.0,World Literature,0.56,0.24,0.2,0.0,0.0,0%,0.0,0.0,caitlin grace watt,
-ENGL,2120,11.0,World Literature,0.48,0.24,0.2,0.04,0.04,0%,0.0,0.0,caitlin grace watt,
-ENGL,2120,13.0,World Literature,0.64,0.24,0.08,0.0,0.0,0%,0.0,0.04,remley makala,
-ENGL,2120,17.0,World Literature,0.78,0.17,0.0,0.0,0.04,0%,0.0,0.0,remley makala,
-ENGL,2120,21.0,World Literature,0.84,0.08,0.0,0.04,0.0,0%,0.0,0.04,remley makala,
-ENGL,2120,22.0,World Literature,0.36,0.32,0.08,0.0,0.16,0%,0.0,0.08,david charles foltz,
-ENGL,2120,23.0,World Literature,0.5,0.27,0.09,0.05,0.0,0%,0.0,0.05,david charles foltz,
-ENGL,2120,24.0,World Literature,0.42,0.25,0.21,0.04,0.0,0%,0.0,0.04,david charles foltz,
-ENGL,2120,25.0,World Literature,0.48,0.24,0.12,0.08,0.04,0%,0.0,0.04,david charles foltz,
-ENGL,2120,26.0,World Literature,0.64,0.2,0.12,0.0,0.0,0%,0.0,0.04,john benjamin fuqua,
-ENGL,2120,27.0,World Literature,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,john benjamin fuqua,
-ENGL,2120,28.0,World Literature,0.4,0.36,0.0,0.08,0.16,0%,0.0,0.0,andrew mathas,
-ENGL,2120,400.0,World Literature,0.17,0.46,0.17,0.04,0.04,0%,0.0,0.13,sarah mae cooper,
-ENGL,2120,401.0,World Literature,0.25,0.5,0.17,0.0,0.0,0%,0.0,0.08,sarah mae cooper,
-ENGL,2120,402.0,World Literature,0.6,0.12,0.08,0.08,0.0,0%,0.0,0.12,sharon nalley,
-ENGL,2120,403.0,World Literature,0.64,0.16,0.04,0.0,0.04,0%,0.0,0.12,sharon nalley,
-ENGL,2120,404.0,World Literature,0.28,0.6,0.04,0.04,0.0,0%,0.0,0.04,sarah mae cooper,
-ENGL,2120,405.0,World Literature,0.88,0.0,0.12,0.0,0.0,0%,0.0,0.0,melissa dugan,
-ENGL,2120,406.0,World Literature,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,walter edgar hunter,
-ENGL,2120,407.0,World Literature,0.32,0.45,0.18,0.0,0.0,0%,0.0,0.05,daniel scott citro,
-ENGL,2120,408.0,World Literature,0.36,0.36,0.0,0.09,0.0,0%,0.0,0.18,daniel scott citro,
-ENGL,2120,409.0,World Literature,0.64,0.16,0.08,0.12,0.0,0%,0.0,0.0,sharon nalley,
-ENGL,2120,410.0,World Literature,0.56,0.2,0.04,0.12,0.04,0%,0.0,0.04,sharon nalley,
-ENGL,2120,411.0,World Literature,0.85,0.08,0.0,0.0,0.08,0%,0.0,0.0,walter edgar hunter,
-ENGL,2120,412.0,World Literature,0.63,0.13,0.13,0.0,0.0,0%,0.0,0.13,henna messina,
-ENGL,2120,413.0,World Literature,0.4,0.4,0.04,0.04,0.0,0%,0.0,0.12,henna messina,
-ENGL,2120,414.0,World Literature,0.55,0.36,0.0,0.0,0.0,0%,0.0,0.09,maziyar faridi,
-ENGL,2120,415.0,World Literature,0.4,0.48,0.04,0.0,0.0,0%,0.0,0.08,maziyar faridi,
-ENGL,2120,416.0,World Literature,0.72,0.24,0.0,0.04,0.0,0%,0.0,0.0,hannah godwin,
-ENGL,2120,417.0,World Literature,0.72,0.24,0.0,0.04,0.0,0%,0.0,0.0,hannah godwin,
-ENGL,2120,418.0,World Literature,0.84,0.12,0.0,0.0,0.0,0%,0.0,0.04,hannah godwin,
-ENGL,2120,419.0,World Literature,0.29,0.46,0.21,0.0,0.0,0%,0.0,0.0,sarah mae cooper,
-ENGL,2130,1.0,British Literature,0.6,0.2,0.07,0.07,0.07,0%,0.0,0.0,william stockton,
-ENGL,2130,2.0,British Literature,0.67,0.13,0.13,0.0,0.0,0%,0.0,0.07,william stockton,
-ENGL,2130,3.0,British Literature,0.6,0.27,0.13,0.0,0.0,0%,0.0,0.0,william stockton,
-ENGL,2130,4.0,British Literature,0.48,0.4,0.0,0.0,0.04,0%,0.0,0.08,john benjamin fuqua,
-ENGL,2130,5.0,British Literature,0.54,0.25,0.08,0.04,0.04,0%,0.0,0.04,remley makala,
-ENGL,2130,6.0,British Literature,0.67,0.25,0.04,0.0,0.04,0%,0.0,0.0,lucian ghita,
-ENGL,2130,7.0,British Literature,0.72,0.2,0.08,0.0,0.0,0%,0.0,0.0,lucian ghita,
-ENGL,2130,8.0,British Literature,0.84,0.08,0.08,0.0,0.0,0%,0.0,0.0,lucian ghita,
-ENGL,2130,400.0,British Literature,0.61,0.3,0.0,0.0,0.04,0%,0.0,0.0,daniel scott citro,
-ENGL,2130,401.0,British Literature,0.3,0.43,0.04,0.04,0.09,0%,0.0,0.04,daniel scott citro,
-ENGL,2130,402.0,British Literature,0.48,0.16,0.24,0.0,0.0,0%,0.0,0.08,henna messina,
-ENGL,2130,403.0,British Literature,0.61,0.3,0.0,0.0,0.04,0%,0.0,0.04,daniel scott citro,
-ENGL,2130,404.0,British Literature,0.4,0.52,0.0,0.0,0.04,0%,0.0,0.04,ingrid anna pierce,
-ENGL,2140,1.0,American Literature,0.08,0.56,0.2,0.0,0.04,0%,0.0,0.12,chelsea marie clarey,
-ENGL,2140,2.0,American Literature,0.13,0.58,0.25,0.0,0.04,0%,0.0,0.0,chelsea marie clarey,
-ENGL,2140,3.0,American Literature,0.25,0.42,0.21,0.04,0.04,0%,0.0,0.0,chelsea marie clarey,
-ENGL,2140,4.0,American Literature,0.22,0.3,0.17,0.04,0.04,0%,0.0,0.22,chelsea marie clarey,
-ENGL,2140,7.0,American Literature,0.84,0.08,0.0,0.04,0.0,0%,0.0,0.04,melissa dugan,
-ENGL,2140,8.0,American Literature,0.88,0.04,0.0,0.04,0.04,0%,0.0,0.0,melissa dugan,
-ENGL,2140,400.0,American Literature,0.38,0.38,0.25,0.0,0.0,0%,0.0,0.0,clare mullaney,
-ENGL,2140,401.0,American Literature,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,jennifer forsberg,
-ENGL,2140,402.0,American Literature,0.39,0.3,0.13,0.0,0.09,0%,0.0,0.09,karen kettnich,
-ENGL,2140,403.0,American Literature,0.43,0.43,0.04,0.0,0.09,0%,0.0,0.0,karen kettnich,
-ENGL,2140,404.0,American Literature,0.6,0.24,0.08,0.0,0.0,0%,0.0,0.08,jennifer forsberg,
-ENGL,2140,405.0,American Literature,0.68,0.16,0.16,0.0,0.0,0%,0.0,0.0,david charles foltz,
-ENGL,2140,406.0,American Literature,0.8,0.08,0.0,0.0,0.04,0%,0.0,0.08,sharon nalley,
-ENGL,2140,407.0,American Literature,0.5,0.25,0.17,0.0,0.04,0%,0.0,0.04,mary nestor,
-ENGL,2150,5.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.12,0.04,0.04,0%,0.0,0.0,william cunningham,
-ENGL,2150,7.0,Lit in 20th-21st Cent Conte,0.2,0.32,0.4,0.0,0.08,0%,0.0,0.0,megan macalystre,
-ENGL,2150,8.0,Lit in 20th-21st Cent Conte,0.52,0.24,0.12,0.08,0.0,0%,0.0,0.04,william cunningham,
-ENGL,2150,9.0,Lit in 20th-21st Cent Conte,0.48,0.35,0.04,0.0,0.09,0%,0.0,0.04,gregory luke chwala,
-ENGL,2150,10.0,Lit in 20th-21st Cent Conte,0.24,0.59,0.06,0.0,0.0,0%,0.0,0.12,gregory luke chwala,
-ENGL,2150,11.0,Lit in 20th-21st Cent Conte,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,allen swords,
-ENGL,2150,12.0,Lit in 20th-21st Cent Conte,0.84,0.12,0.04,0.0,0.0,0%,0.0,0.0,allen swords,
-ENGL,2150,14.0,Lit in 20th-21st Cent Conte,0.5,0.28,0.06,0.11,0.0,0%,0.0,0.06,gregory luke chwala,
-ENGL,2150,15.0,Lit in 20th-21st Cent Conte,0.58,0.38,0.0,0.0,0.04,0%,0.0,0.0,john logan pursley,
-ENGL,2150,16.0,Lit in 20th-21st Cent Conte,0.64,0.28,0.04,0.0,0.04,0%,0.0,0.0,john logan pursley,
-ENGL,2150,17.0,Lit in 20th-21st Cent Conte,0.36,0.32,0.12,0.0,0.12,0%,0.0,0.08,megan macalystre,
-ENGL,2150,18.0,Lit in 20th-21st Cent Conte,0.56,0.28,0.08,0.04,0.04,0%,0.0,0.0,elizabeth stansell,
-ENGL,2150,21.0,Lit in 20th-21st Cent Conte,0.52,0.3,0.09,0.04,0.04,0%,0.0,0.0,megan macalystre,
-ENGL,2150,22.0,Lit in 20th-21st Cent Conte,0.64,0.24,0.04,0.0,0.04,0%,0.0,0.04,john logan pursley,
-ENGL,2150,27.0,Lit in 20th-21st Cent Conte,0.64,0.32,0.0,0.0,0.0,0%,0.0,0.04,elizabeth stansell,
-ENGL,2150,29.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.08,0.08,0.04,0%,0.0,0.0,andrew mathas,
-ENGL,2150,30.0,Lit in 20th-21st Cent Conte,0.68,0.12,0.12,0.0,0.08,0%,0.0,0.0,andrew mathas,
-ENGL,2150,400.0,Lit in 20th-21st Cent Conte,0.6,0.24,0.12,0.0,0.04,0%,0.0,0.0,elizabeth stansell,
-ENGL,2150,401.0,Lit in 20th-21st Cent Conte,0.48,0.26,0.17,0.0,0.0,0%,0.0,0.04,gregory luke chwala,
-ENGL,2150,402.0,Lit in 20th-21st Cent Conte,0.72,0.16,0.0,0.04,0.0,0%,0.0,0.08,heather williams,
-ENGL,2150,403.0,Lit in 20th-21st Cent Conte,0.76,0.16,0.08,0.0,0.0,0%,0.0,0.0,heather williams,
-ENGL,2150,404.0,Lit in 20th-21st Cent Conte,0.54,0.13,0.0,0.04,0.17,0%,0.0,0.13,jamie ann rogers,
-ENGL,2150,405.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.12,0.04,0.0,0%,0.0,0.04,mary nestor,
-ENGL,2150,406.0,Lit in 20th-21st Cent Conte,0.4,0.48,0.0,0.0,0.12,0%,0.0,0.0,mary nestor,
-ENGL,2150,407.0,Lit in 20th-21st Cent Conte,0.76,0.16,0.04,0.0,0.04,0%,0.0,0.0,april ayers lawson,
-ENGL,2150,409.0,Lit in 20th-21st Cent Conte,0.48,0.26,0.13,0.0,0.09,0%,0.0,0.04,sarah matalone,
-ENGL,2150,410.0,Lit in 20th-21st Cent Conte,0.52,0.28,0.04,0.0,0.04,0%,0.0,0.12,sarah matalone,
-ENGL,2150,411.0,Lit in 20th-21st Cent Conte,0.48,0.28,0.0,0.0,0.04,0%,0.0,0.2,tareva johnson,
-ENGL,2150,412.0,Lit in 20th-21st Cent Conte,0.54,0.25,0.0,0.0,0.08,0%,0.0,0.13,tareva johnson,
-ENGL,2150,413.0,Lit in 20th-21st Cent Conte,0.84,0.14,0.02,0.0,0.0,0%,0.0,0.0,david coombs,
-ENGL,2160,4.0,African American Literatur,0.44,0.32,0.12,0.04,0.0,0%,0.0,0.08,patricia sunia,
-ENGL,2160,400.0,African American Literatur,0.44,0.24,0.08,0.0,0.04,0%,0.0,0.2,tareva johnson,
-ENGL,2160,401.0,African American Literatur,0.44,0.24,0.08,0.0,0.08,0%,0.0,0.12,tareva johnson,
-ENGL,2160,402.0,African American Literatur,0.76,0.12,0.04,0.0,0.04,0%,0.0,0.04,jamie ann rogers,
-ENGL,2160,403.0,African American Literatur,0.68,0.12,0.04,0.04,0.08,0%,0.0,0.04,jamie ann rogers,
-ENGL,2160,404.0,African American Literatur,0.68,0.12,0.12,0.0,0.0,0%,0.0,0.04,jamie ann rogers,
-ENGL,2310,400.0,Intro to Journalism,0.71,0.19,0.0,0.0,0.05,0%,0.0,0.05,william pulley,
-ENGL,3010,1.0,Great Books of Western W,0.6,0.2,0.0,0.0,0.2,0%,0.0,0.0,dominic mastroianni,
-ENGL,3040,2.0,Business Writing,0.81,0.14,0.05,0.0,0.0,0%,0.0,0.0,ashley cowden fisk,
-ENGL,3040,400.0,Business Writing,0.77,0.14,0.0,0.05,0.05,0%,0.0,0.0,heather williams,
-ENGL,3040,401.0,Business Writing,0.86,0.1,0.05,0.0,0.0,0%,0.0,0.0,heather williams,
-ENGL,3040,402.0,Business Writing,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,
-ENGL,3040,403.0,Business Writing,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,
-ENGL,3040,404.0,Business Writing,0.71,0.19,0.0,0.0,0.0,0%,0.0,0.1,la'cresha ulon green,
-ENGL,3040,405.0,Business Writing,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,
-ENGL,3040,406.0,Business Writing,0.67,0.24,0.05,0.0,0.05,0%,0.0,0.0,ingrid anna pierce,
-ENGL,3040,407.0,Business Writing,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ingrid anna pierce,
-ENGL,3040,408.0,Business Writing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,ingrid anna pierce,
-ENGL,3040,409.0,Business Writing,0.59,0.23,0.14,0.0,0.0,0%,0.0,0.05,jennifer forsberg,
-ENGL,3040,410.0,Business Writing,0.67,0.19,0.14,0.0,0.0,0%,0.0,0.0,jennifer forsberg,
-ENGL,3040,411.0,Business Writing,0.67,0.19,0.14,0.0,0.0,0%,0.0,0.0,jennifer forsberg,
-ENGL,3040,414.0,Business Writing,0.86,0.1,0.0,0.0,0.05,0%,0.0,0.0,patricia sunia,
-ENGL,3100,1.0,Crit Writ Lit,0.43,0.43,0.0,0.05,0.1,0%,0.0,0.0,brian mcgrath,
-ENGL,3100,2.0,Crit Writ Lit,0.91,0.05,0.0,0.0,0.0,0%,0.0,0.05,matthew hooley,
-ENGL,3100,4.0,Crit Writ Lit,0.45,0.32,0.05,0.09,0.0,0%,0.0,0.05,cameron bushnell,
-ENGL,3120,1.0,Advanced Composition,0.43,0.33,0.05,0.0,0.14,0%,0.0,0.05,shauna chung,
-ENGL,3120,2.0,Advanced Composition,0.38,0.33,0.14,0.0,0.1,0%,0.0,0.05,shauna chung,
-ENGL,3140,7.0,Technical Writing,0.62,0.29,0.05,0.0,0.05,0%,0.0,0.0,william cunningham,
-ENGL,3140,8.0,Technical Writing,0.57,0.33,0.0,0.0,0.1,0%,0.0,0.0,william cunningham,
-ENGL,3140,401.0,Technical Writing,0.73,0.14,0.0,0.05,0.05,0%,0.0,0.05,katalin beck,
-ENGL,3140,402.0,Technical Writing,0.62,0.24,0.05,0.0,0.05,0%,0.0,0.05,katalin beck,
-ENGL,3140,405.0,Technical Writing,0.71,0.1,0.05,0.1,0.0,0%,0.0,0.05,henna messina,
-ENGL,3140,406.0,Technical Writing,0.76,0.05,0.14,0.05,0.0,0%,0.0,0.0,henna messina,
-ENGL,3140,407.0,Technical Writing,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,megan pietruszewski,
-ENGL,3140,409.0,Technical Writing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,megan pietruszewski,
-ENGL,3140,410.0,Technical Writing,0.81,0.1,0.0,0.0,0.1,0%,0.0,0.0,beltran quaglia,
-ENGL,3140,411.0,Technical Writing,0.76,0.14,0.0,0.0,0.0,0%,0.0,0.1,beltran quaglia,
-ENGL,3140,412.0,Technical Writing,0.85,0.05,0.0,0.0,0.0,0%,0.0,0.1,michelle lloyd,
-ENGL,3140,413.0,Technical Writing,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,michelle lloyd,
-ENGL,3140,414.0,Technical Writing,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,hannah godwin,
-ENGL,3140,416.0,Technical Writing,0.8,0.1,0.05,0.0,0.0,0%,0.0,0.05,michael measel,
-ENGL,3140,417.0,Technical Writing,0.71,0.14,0.0,0.05,0.05,0%,0.0,0.05,michael measel,
-ENGL,3140,418.0,Technical Writing,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,victoria houser,
-ENGL,3140,419.0,Technical Writing,0.62,0.19,0.14,0.05,0.0,0%,0.0,0.0,victoria houser,
-ENGL,3140,420.0,Technical Writing,0.62,0.29,0.1,0.0,0.0,0%,0.0,0.0,katalin beck,
-ENGL,3150,400.0,Scientific Writing & Comm,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,philip randall,
-ENGL,3150,401.0,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,philip randall,
-ENGL,3150,402.0,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,philip randall,
-ENGL,3150,404.0,Scientific Writing & Comm,0.83,0.11,0.06,0.0,0.0,0%,0.0,0.0,megan pietruszewski,
-ENGL,3150,405.0,Scientific Writing & Comm,0.71,0.14,0.05,0.0,0.05,0%,0.0,0.05,megan pietruszewski,
-ENGL,3150,406.0,Scientific Writing & Comm,0.68,0.26,0.0,0.0,0.05,0%,0.0,0.0,william pulley,
-ENGL,3150,407.0,Scientific Writing & Comm,0.57,0.24,0.1,0.05,0.05,0%,0.0,0.0,william pulley,
-ENGL,3150,408.0,Scientific Writing & Comm,0.5,0.3,0.1,0.0,0.05,0%,0.0,0.05,william pulley,
-ENGL,3150,409.0,Scientific Writing & Comm,0.9,0.0,0.05,0.0,0.05,0%,0.0,0.0,sheila lalwani,
-ENGL,3150,410.0,Scientific Writing & Comm,0.85,0.0,0.05,0.05,0.0,0%,0.0,0.05,sheila lalwani,
-ENGL,3450,400.0,Intr Creative Writing: Ficti,0.7,0.15,0.1,0.0,0.05,0%,0.0,0.0,sarah matalone,
-ENGL,3450,401.0,Intr Creative Writing: Ficti,0.48,0.29,0.05,0.0,0.1,0%,0.0,0.1,sarah matalone,
-ENGL,3460,400.0,Intr Creative Writing: Poet,0.6,0.25,0.1,0.0,0.05,0%,0.0,0.0,stephanie edwards,
-ENGL,3480,400.0,Intr Creat Writ: Screenwrit,0.79,0.0,0.0,0.0,0.11,0%,0.0,0.11,april ayers lawson,
-ENGL,3480,401.0,Intr Creat Writ: Screenwrit,0.85,0.0,0.0,0.0,0.05,0%,0.0,0.1,april ayers lawson,
-ENGL,3490,1.0,Tech/Pop Imagination,0.5,0.33,0.11,0.0,0.06,0%,0.0,0.0,michelle smith,
-ENGL,3500,1.0,Mythology,0.22,0.33,0.17,0.06,0.11,0%,0.0,0.06,kenneth tuite,
-ENGL,3570,4.0,Film,0.68,0.26,0.0,0.0,0.0,0%,0.0,0.0,john robert smith,
-ENGL,3570,400.0,Film,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,amy monaghan,
-ENGL,3570,401.0,Film,0.47,0.26,0.11,0.0,0.05,0%,0.0,0.05,amy monaghan,
-ENGL,3570,402.0,Film,0.3,0.4,0.1,0.0,0.1,0%,0.0,0.1,amy monaghan,
-ENGL,3850,1.0,Children's Lit,0.39,0.5,0.06,0.0,0.06,0%,0.0,0.0,megan macalystre,
-ENGL,3860,400.0,Adolescent Lit,0.23,0.31,0.23,0.0,0.08,0%,0.0,0.08,amy monaghan,
-ENGL,3970,2.0,Brit Lit Survey II,0.62,0.24,0.1,0.0,0.05,0%,0.0,0.0,david coombs,
-ENGL,3980,400.0,Amer Lit Survey I,0.75,0.1,0.15,0.0,0.0,0%,0.0,0.0,kimberly manganelli,
-ENGL,3990,1.0,Amer Lit Survey II,0.7,0.15,0.05,0.0,0.05,0%,0.0,0.05,dominic mastroianni,
-ENGL,4010,2.0,Grammar Survey,0.36,0.29,0.29,0.07,0.0,0%,0.0,0.0,brian mcgrath,
-ENGL,4110,401.0,Shakespeare,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,andrew lemons,
-ENGL,4110,402.0,Shakespeare,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,andrew lemons,
-ENGL,4280,2.0,Contemporary Literature,0.38,0.31,0.08,0.0,0.08,0%,0.0,0.15,michael lemahieu,
-ENGL,4360,1.0,Feminist Literary Criticism,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,erin marina goss,
-ENGL,4400,1.0,Literary Theory,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,matthew hooley,
-ENGL,4410,400.0,Literary Editing,0.23,0.46,0.23,0.0,0.0,0%,0.0,0.0,clare mullaney,
-ENGL,4440,1.0,Renaissance Literature,0.29,0.47,0.06,0.0,0.18,0%,0.0,0.0,william stockton,
-ENGL,4450,1.0,Fiction Workshop,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,nicholas brown,
-ENGL,4480,2.0,Screenwriting Wkshop,0.58,0.17,0.08,0.17,0.0,0%,0.0,0.0,nicholas brown,
-ENGL,4510,1.0,Film Theory and Criticism,0.53,0.37,0.11,0.0,0.0,0%,0.0,0.0,agnieszka skrodzka,
-ENGL,4520,2.0,Great Directors,0.48,0.14,0.14,0.0,0.0,0%,0.0,0.0,john robert smith,
-ENGL,4640,1.0,Topics in Literature 1700-1,0.42,0.25,0.17,0.17,0.0,0%,0.0,0.0,erin marina goss,
-ENGL,4750,400.0,Writing for Media,0.5,0.31,0.13,0.0,0.0,0%,0.0,0.06,jonathan field,
-ENGL,4820,1.0,Afr Am Lit to 1920,0.38,0.38,0.19,0.0,0.0,0%,0.0,0.05,rhondda thomas,
-ENGL,4830,1.0,Af Am Lit 1920-Pres,0.58,0.32,0.05,0.0,0.0,0%,0.0,0.05,maya sylvia hislop,
-ENGL,4920,400.0,Modern Rhetoric,0.69,0.08,0.08,0.0,0.15,0%,0.0,0.0,megan eatman,
-ENGL,4960,2.0,Senior Seminar,0.75,0.08,0.0,0.0,0.08,0%,0.0,0.08,michelle smith,
-ENGL,4960,400.0,Senior Seminar,0.79,0.07,0.07,0.0,0.0,0%,0.0,0.0,jonathan field,
-ENGL,8080,400.0,Top Renaiss & Restoration,0.86,0.07,0.0,0.0,0.07,0%,0.0,0.0,elizabeth rivlin,
-ENGL,8100,400.0,Literary Criticism & Theory,0.18,0.36,0.09,0.0,0.09,0%,0.0,0.18,lee morrissey,
-ENGL,8310,1.0,Special Topics,0.8,0.13,0.0,0.0,0.0,0%,0.0,0.07,maya sylvia hislop,
-ENGL,8910,1.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gabriel hankins,
-ENGR,1000,101.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,steven brandon,
-ENGR,1000,102.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,steven brandon,
-ENGR,1000,103.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,89%,0.09,0.02,steven brandon,
-ENGR,1000,104.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,88%,0.1,0.02,steven brandon,
-ENGR,1010,392.0,Survey of Mathematical To,0.25,0.33,0.17,0.08,0.0,0%,0.0,0.17,andrew neptune,
-ENGR,1010,395.0,Survey of Mathematical To,0.29,0.46,0.13,0.0,0.08,0%,0.0,0.04,andrew neptune,
-ENGR,1010,396.0,Survey of Mathematical To,0.34,0.41,0.1,0.0,0.07,0%,0.0,0.07,andrew neptune,
-ENGR,1020,223.0,Engr Dis & Skills (HON),0.76,0.22,0.0,0.02,0.0,0%,0.0,0.0,richard watkins,True
-ENGR,1020,311.0,Engineering Discipl & Skills,0.32,0.39,0.03,0.13,0.03,0%,0.0,0.11,john minor,
-ENGR,1020,313.0,Engineering Discipl & Skills,0.52,0.22,0.17,0.0,0.04,0%,0.0,0.04,john minor,
-ENGR,1020,314.0,Engineering Discipl & Skills,0.67,0.26,0.05,0.02,0.0,0%,0.0,0.0,elizabeth stephan,
-ENGR,1020,317.0,Engineering Discipl & Skills,0.27,0.36,0.16,0.07,0.07,0%,0.0,0.09,katherine ehlert,
-ENGR,1020,318.0,Engineering Discipl & Skills,0.41,0.36,0.05,0.07,0.07,0%,0.0,0.05,katherine ehlert,
-ENGR,1020,611.0,Engineering Discipl & Skills,0.47,0.29,0.04,0.02,0.07,0%,0.0,0.11,baker martin,
-ENGR,1020,612.0,Engineering Discipl & Skills,0.52,0.22,0.13,0.02,0.0,0%,0.0,0.11,baker martin,
-ENGR,1020,613.0,Engineering Discipl & Skills,0.64,0.19,0.09,0.02,0.04,0%,0.0,0.02,taylor sorensen,
-ENGR,1020,614.0,Engineering Discipl & Skills,0.67,0.15,0.13,0.02,0.0,0%,0.0,0.02,taylor sorensen,
-ENGR,1020,615.0,Engineering Discipl & Skills,0.69,0.21,0.02,0.05,0.02,0%,0.0,0.0,taylor sorensen,
-ENGR,1020,616.0,Engineering Discipl & Skills,0.5,0.22,0.11,0.0,0.04,0%,0.0,0.13,joseph overlin chapa,
-ENGR,1020,617.0,Engineering Discipl & Skills,0.63,0.21,0.09,0.0,0.07,0%,0.0,0.0,joseph overlin chapa,
-ENGR,1020,618.0,Engineering Discipl & Skills,0.47,0.36,0.07,0.04,0.0,0%,0.0,0.07,joseph overlin chapa,
-ENGR,1020,801.0,Engineering Discipl & Skills,0.4,0.3,0.15,0.02,0.09,0%,0.0,0.04,irene marie ferrara,
-ENGR,1020,808.0,Engineering Discipl & Skills,0.41,0.28,0.2,0.04,0.02,0%,0.0,0.04,jonathan maier,
-ENGR,1020,812.0,Engineering Discipl & Skills,0.58,0.24,0.04,0.07,0.02,0%,0.0,0.04,irene marie ferrara,
-ENGR,1020,813.0,Engineering Discipl & Skills,0.6,0.23,0.12,0.0,0.02,0%,0.0,0.02,irene marie ferrara,
-ENGR,1020,814.0,Engineering Discipl & Skills,0.43,0.34,0.14,0.02,0.02,0%,0.0,0.05,michael waldrop,
-ENGR,1020,815.0,Engineering Discipl & Skills,0.48,0.3,0.15,0.0,0.02,0%,0.0,0.04,michael waldrop,
-ENGR,1020,816.0,Engineering Discipl & Skills,0.38,0.31,0.21,0.02,0.02,0%,0.0,0.05,michael waldrop,
-ENGR,1020,817.0,Engineering Discipl & Skills,0.47,0.3,0.13,0.0,0.04,0%,0.0,0.06,jonathan maier,
-ENGR,1020,881.0,Engr Discp & Skils (HON),0.68,0.24,0.03,0.0,0.0,0%,0.0,0.06,jonathan maier,True
-ENGR,1100,206.0,Engineering Success Skills,0.64,0.21,0.04,0.07,0.0,0%,0.0,0.04,jonathan harcum,
-ENGR,1100,603.0,Engineering Success Skills,0.72,0.12,0.08,0.0,0.0,0%,0.0,0.08,jonathan harcum,
-ENGR,1100,802.0,Engineering Success Skills,0.88,0.08,0.0,0.0,0.04,0%,0.0,0.0,jonathan harcum,
-ENGR,1410,223.0,Programming & Problem S,0.07,0.14,0.27,0.09,0.14,0%,0.0,0.16,steven brandon,
-ENGR,1410,226.0,Programming & Problem S,0.07,0.2,0.36,0.04,0.13,0%,0.0,0.11,william martin,
-ENGR,1410,227.0,Programming & Problem S,0.13,0.29,0.29,0.02,0.11,0%,0.0,0.13,william martin,
-ENGR,1510,322.0,Engineering Skills,0.41,0.37,0.07,0.0,0.04,0%,0.0,0.11,matthew kent miller,
-ENGR,1510,323.0,Engineering Skills,0.28,0.44,0.12,0.0,0.12,0%,0.0,0.04,matthew kent miller,
-ENGR,1510,325.0,Engineering Skills,0.36,0.28,0.2,0.04,0.0,0%,0.0,0.12,matthew kent miller,
-ENGR,1900,219.0,CI 3D Maker Space SOP,0.83,0.0,0.17,0.0,0.0,0%,0.0,0.0,todd schweisinger,
-ENGR,2080,681.0,Engr Graphics & Machine,0.44,0.25,0.13,0.0,0.08,0%,0.0,0.1,kyle walker,
-ENGR,2080,682.0,Engr Graphics & Machine,0.56,0.25,0.1,0.0,0.0,0%,0.0,0.06,vishal thomas,
-ENGR,2080,684.0,Engr Graphics & Machine,0.39,0.22,0.06,0.06,0.08,0%,0.0,0.12,jennifer paige brown,
-ENGR,2080,685.0,Engr Graphics & Machine,0.45,0.24,0.18,0.0,0.08,0%,0.0,0.04,jessica plaunt,
-ENGR,2080,686.0,Engr Graphics & Machine,0.57,0.17,0.06,0.04,0.02,0%,0.0,0.13,nighat yasmin,
-ENGR,2100,804.0,CAD & Engineering Applica,0.47,0.2,0.16,0.02,0.09,0%,0.0,0.07,naini shervin shoai,
-ENGR,2100,805.0,CAD & Engineering Applica,0.35,0.33,0.13,0.07,0.07,0%,0.0,0.07,nighat yasmin,
-ENGR,2100,806.0,CAD & Engineering Applica,0.2,0.39,0.13,0.02,0.09,0%,0.0,0.17,naini shervin shoai,
-ENR,1010,2.0,Intro to Envir & Natur Res I,0.47,0.27,0.18,0.02,0.05,0%,0.0,0.0, guggenheimer,
-ENR,1010,3.0,Intro to Envir & Natur Res I,0.52,0.22,0.13,0.05,0.08,0%,0.0,0.0, guggenheimer,
-ENR,4290,1.0,Environ Law & Policy,0.64,0.19,0.11,0.02,0.02,0%,0.0,0.02,alan johnson,
-ENR,4290,2.0,Environ Law & Policy,0.73,0.13,0.04,0.04,0.02,0%,0.0,0.02,alan johnson,
-ENSP,2000,1.0,Intro Environ Sci,0.57,0.32,0.06,0.0,0.02,0%,0.0,0.02,scott brame,
-ENSP,2000,2.0,Intro Environ Sci,0.95,0.04,0.02,0.0,0.0,0%,0.0,0.0,minory nammouz,
-ENSP,2000,3.0,Intro Environ Sci,0.87,0.09,0.0,0.02,0.0,0%,0.0,0.02,minory nammouz,
-ENSP,2000,4.0,Intro Environ Sci,0.58,0.26,0.05,0.05,0.02,0%,0.0,0.04,elizabeth carraway,
-ENSP,2000,5.0,Intro Environ Sci,0.63,0.24,0.09,0.0,0.02,0%,0.0,0.02,tom owino,
-ENSP,2000,6.0,Intro Environ Sci,0.4,0.55,0.05,0.0,0.0,0%,0.0,0.0,emily don scribner,
-ENSP,4000,1.0,Studies in Environmental S,0.57,0.17,0.04,0.0,0.17,0%,0.0,0.0,margaret thompson,
-ENT,3010,1.0,Insect Biology and Diversit,0.52,0.1,0.14,0.0,0.14,0%,0.0,0.1,michael ferro,
-ENT,8100,1.0,Bio & Phylogeog of S. Appa,0.64,0.09,0.27,0.0,0.0,0%,0.0,0.0,michael caterino,
-ENTR,1010,3.0,Entrepreneurial Mindset,0.85,0.09,0.03,0.01,0.02,0%,0.0,0.01,john michael hannon,
-ENTR,1090,1.0,Creative Inq-Entrepreneur,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,john michael hannon,
-ENTR,2010,4.0,Sports Entrepreneurship,0.58,0.26,0.05,0.0,0.05,0%,0.0,0.05,john michael hannon,
-ESED,8100,1.0,Orientation to ESME Resea,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eliza gallagher,
-ESED,8720,1.0,Action Research in STEM E,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.0,karen ann high,
-ESED,9910,3.0,Dissertation Rsrch and Wri,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eliza gallagher,
-ESED,9910,5.0,Dissertation Rsrch and Wri,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,karen ann high,
-ETOX,4300,1.0,Toxicology,0.5,0.18,0.18,0.05,0.05,0%,0.0,0.05,lisa bain,
-ETOX,6300,1.0,Toxicology,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,lisa bain,
-ETOX,8610,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,den hurk peter van peter,
-FDSC,1010,1.0,Intro to Food Sci & Hum N,0.65,0.27,0.05,0.01,0.01,0%,0.0,0.01,carol hegler,
-FDSC,3010,1.0,Food Regulations,0.81,0.15,0.04,0.0,0.0,0%,0.0,0.0,sara lane cothran,
-FDSC,4010,1.0,Food Chemistry I,0.45,0.5,0.05,0.0,0.0,0%,0.0,0.0,feng chen,
-FDSC,4500,12.0,Creative Inquiry-Food Scie,0.82,0.0,0.09,0.0,0.0,0%,0.0,0.09,paul dawson,
-FDSC,6010,1.0,Food Chem I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,feng chen,
-FDSC,8120,1.0,Microbial Food Syst,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,xiuping jiang,
-FIN,2010,401.0,Intro to Personal Finance I,0.98,0.01,0.0,0.0,0.01,0%,0.0,0.01,joshua harris,
-FIN,2010,402.0,Intro to Personal Finance I,0.84,0.08,0.04,0.02,0.02,0%,0.0,0.0,joshua harris,
-FIN,2020,401.0,Intro to Personal Finance II,0.97,0.0,0.0,0.0,0.02,0%,0.0,0.01,joshua harris,
-FIN,3040,1.0,Risk & Insurance,0.22,0.42,0.24,0.11,0.0,0%,0.0,0.0,kerri mcmillan,
-FIN,3050,1.0,Investment Analysis,0.16,0.25,0.41,0.14,0.02,0%,0.0,0.02,kerri mcmillan,
-FIN,3050,2.0,Investment Analysis,0.22,0.29,0.33,0.09,0.04,0%,0.0,0.02,kerri mcmillan,
-FIN,3050,3.0,Investment Analysis,0.16,0.27,0.32,0.07,0.07,0%,0.0,0.11,kerri mcmillan,
-FIN,3050,4.0,Investment Analysis,0.13,0.22,0.29,0.18,0.04,0%,0.0,0.13,john alexander,
-FIN,3060,1.0,Corporation Finance,0.47,0.27,0.14,0.04,0.04,0%,0.0,0.03,ramon franklin,
-FIN,3060,2.0,Corporation Finance,0.36,0.36,0.13,0.04,0.07,0%,0.0,0.04,ramon franklin,
-FIN,3060,3.0,Corporation Finance,0.25,0.25,0.27,0.16,0.02,0%,0.0,0.04,minxing sun,
-FIN,3060,4.0,Corporation Finance,0.16,0.38,0.25,0.16,0.0,0%,0.0,0.05,minxing sun,
-FIN,3060,5.0,Corporation Finance,0.07,0.21,0.5,0.21,0.0,0%,0.0,0.0,minxing sun,
-FIN,3060,6.0,Corporation Finance,0.55,0.23,0.11,0.04,0.0,0%,0.0,0.04,ramon franklin,
-FIN,3060,7.0,Corporation Finance,0.18,0.29,0.29,0.08,0.06,0%,0.0,0.1,taufique samdani,
-FIN,3060,401.0,Corporation Finance,0.48,0.27,0.15,0.0,0.04,0%,0.0,0.06,jonathan godbey,
-FIN,3060,402.0,Corporation Finance,0.46,0.22,0.18,0.1,0.0,0%,0.0,0.02,jonathan godbey,
-FIN,3070,1.0,Prin of Real Estate,0.26,0.21,0.23,0.23,0.05,0%,0.0,0.03,thomas springer,
-FIN,3070,2.0,Prin of Real Estate,0.36,0.18,0.28,0.15,0.03,0%,0.0,0.0,thomas springer,
-FIN,3070,5.0,Prin of Real Estate,0.21,0.46,0.26,0.05,0.03,0%,0.0,0.0,bryan blackwood,
-FIN,3080,1.0,Fin Inst & Mkts,0.6,0.28,0.1,0.03,0.0,0%,0.0,0.0,lyudmila chernykh,
-FIN,3080,2.0,Fin Inst & Mkts,0.74,0.21,0.03,0.03,0.0,0%,0.0,0.0,lyudmila chernykh,
-FIN,3080,3.0,Fin Inst & Mkts,0.36,0.44,0.18,0.03,0.0,0%,0.0,0.0,daniel greene,
-FIN,3080,401.0,Fin Inst & Mkts,0.44,0.3,0.24,0.0,0.02,0%,0.0,0.0,daniel greene,
-FIN,3110,1.0,Financial Management I,0.11,0.14,0.09,0.11,0.31,0%,0.0,0.23,jack wolf,
-FIN,3110,2.0,Financial Management I,0.08,0.03,0.36,0.08,0.26,0%,0.0,0.21,jack wolf,
-FIN,3110,3.0,Financial Management I,0.09,0.33,0.28,0.14,0.16,0%,0.0,0.0,weike xu,
-FIN,3110,4.0,Financial Management I,0.54,0.3,0.09,0.06,0.0,0%,0.0,0.01,joshua harris,
-FIN,3110,5.0,Financial Management I,0.46,0.39,0.14,0.0,0.01,0%,0.0,0.0,joshua harris,
-FIN,3120,1.0,Financial Management II,0.14,0.39,0.35,0.04,0.02,0%,0.0,0.06,weike xu,
-FIN,3120,2.0,Financial Management II,0.16,0.52,0.26,0.04,0.02,0%,0.0,0.0,weike xu,
-FIN,3120,3.0,Financial Management II,0.24,0.34,0.24,0.08,0.02,0%,0.0,0.08,taufique samdani,
-FIN,3120,4.0,Financial Management II,0.1,0.41,0.14,0.14,0.02,0%,0.0,0.18,taufique samdani,
-FIN,3120,5.0,Financial Management II,0.45,0.23,0.14,0.0,0.07,0%,0.0,0.11,arash dayani,
-FIN,3120,6.0,Financial Management II,0.35,0.15,0.2,0.05,0.15,0%,0.0,0.1,arash dayani,
-FIN,4010,1.0,Corporate Financial Analys,0.63,0.15,0.2,0.03,0.0,0%,0.0,0.0,george lockhart,
-FIN,4010,2.0,Corporate Financial Analys,0.55,0.3,0.13,0.0,0.0,0%,0.0,0.03,george lockhart,
-FIN,4020,1.0,Corporate Valuation,0.22,0.3,0.26,0.11,0.04,0%,0.0,0.07,angela morgan,
-FIN,4020,101.0,Corporate Valuation (HON,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,angela morgan,True
-FIN,4030,1.0,Spreadsheet Apps in Finan,0.26,0.24,0.38,0.09,0.0,0%,0.0,0.03,vincent intintoli,
-FIN,4030,2.0,Spreadsheet Apps in Finan,0.27,0.4,0.13,0.13,0.07,0%,0.0,0.0,vincent intintoli,
-FIN,4050,1.0,Portfolio Management & T,0.16,0.14,0.28,0.21,0.09,0%,0.0,0.12,john alexander,
-FIN,4060,1.0,Derivatives Analysis,0.14,0.34,0.37,0.09,0.03,0%,0.0,0.03,blerina zykaj,
-FIN,4110,1.0,Int Fin Mgt,0.29,0.53,0.16,0.03,0.0,0%,0.0,0.0,luke asher devault,
-FIN,4110,2.0,Int Fin Mgt,0.2,0.58,0.2,0.03,0.0,0%,0.0,0.0,luke asher devault,
-FIN,4150,1.0,Real Estate Investmt,0.31,0.19,0.35,0.0,0.08,0%,0.0,0.08,thomas springer,
-FIN,4980,7.0,CI in Finance: SIE,0.9,0.0,0.0,0.0,0.0,0%,0.0,0.1,joshua harris,
-FNR,2040,1.0,Soil Information Systems,0.79,0.16,0.03,0.0,0.0,0%,0.0,0.02,elena mikhailova,
-FNR,4990,1.0,Natural Resources Seminar,0.86,0.05,0.0,0.0,0.05,0%,0.0,0.05,robert fritz baldwin,
-FOR,2050,1.0,Dendrology,0.66,0.13,0.05,0.08,0.08,0%,0.0,0.0,donald hagan,
-FOR,2050,2.0,Dendrology,0.56,0.18,0.09,0.06,0.03,0%,0.0,0.09,donald hagan,
-FOR,2050,3.0,Dendrology,0.66,0.17,0.11,0.0,0.06,0%,0.0,0.0,donald hagan,
-FOR,2210,2.0,Forest Biology,0.95,0.03,0.0,0.0,0.0,0%,0.0,0.02,patrick mcmillan,
-FOR,3040,1.0,Forest Resource Economic,0.81,0.16,0.0,0.03,0.0,0%,0.0,0.0,puskar khanal,
-FOR,3410,1.0,Wood Procure Pract,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,patrick hiesl,
-FOR,4100,1.0,Harvesting Processes,0.63,0.3,0.0,0.07,0.0,0%,0.0,0.0,patrick hiesl,
-FOR,4130,1.0,Forest Protection,0.77,0.2,0.0,0.03,0.0,0%,0.0,0.0,jessica hartshorn,
-FOR,4150,1.0,Forest Wildlife Managmen,0.44,0.31,0.19,0.0,0.0,0%,0.0,0.06,greg yarrow,
-FOR,4160,1.0,Forest Policy and Admin,0.78,0.16,0.05,0.0,0.0,0%,0.0,0.01,patricia layton,
-FOR,4170,1.0,Forest Resource Mgt & Re,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,puskar khanal,
-FOR,4310,1.0,Recreation Res Plan in For,0.52,0.39,0.1,0.0,0.0,0%,0.0,0.0,robert baxter powell,
-FOR,4340,1.0,GIS for Natural Resources,0.79,0.12,0.02,0.02,0.0,0%,0.0,0.0,christopher post,
-FOR,8910,2.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,donald hagan,
-FOR,8930,22.0,Professional Development,0.57,0.14,0.0,0.0,0.0,0%,0.0,0.14,david jachowski,
-FR,1010,1.0,Elementary French,0.61,0.22,0.04,0.0,0.09,0%,0.0,0.04,amy lyn sawyer,
-FR,1010,2.0,Elementary French,0.48,0.26,0.13,0.04,0.09,0%,0.0,0.0,amy lyn sawyer,
-FR,1020,2.0,Elementary French,0.2,0.3,0.1,0.2,0.1,0%,0.0,0.1, nedeo anne salces anne,
-FR,1020,3.0,Elementary French,0.13,0.44,0.25,0.0,0.0,0%,0.0,0.19, nedeo anne salces anne,
-FR,2010,1.0,Intermediate French,0.18,0.73,0.09,0.0,0.0,0%,0.0,0.0,kenneth widgren,
-FR,2010,2.0,Intermediate French,0.61,0.22,0.13,0.0,0.0,0%,0.0,0.04,amy lyn sawyer,
-FR,2010,3.0,Intermediate French,0.72,0.28,0.0,0.0,0.0,0%,0.0,0.0,tholozany de,
-FR,2020,1.0,Intermediate French,0.5,0.36,0.05,0.05,0.0,0%,0.0,0.05,eric touya,
-FR,2020,2.0,Intermediate French,0.42,0.42,0.04,0.0,0.04,0%,0.0,0.08,kenneth widgren,
-FR,2020,3.0,Intermediate French,0.67,0.17,0.17,0.0,0.0,0%,0.0,0.0,amy lyn sawyer,
-FR,3000,1.0,Survey of French Lit,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,tholozany de,
-FR,3050,1.0,Int Fr Con & Comp I,0.53,0.4,0.0,0.0,0.0,0%,0.0,0.07,kenneth widgren,
-FR,3050,2.0,Int Fr Con & Comp I,0.4,0.47,0.0,0.0,0.0,0%,0.0,0.13, nedeo anne salces anne,
-FR,3070,1.0,French Civilization,0.87,0.09,0.04,0.0,0.0,0%,0.0,0.0,kelly digby peebles,
-FR,3120,2.0,Writing in French I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,kenneth widgren,
-FR,4120,1.0,Fr & Francoph Cinema,0.77,0.15,0.0,0.0,0.08,0%,0.0,0.0,joseph mai,
-GC,1010,2.0,Orientation to G C,0.0,0.0,0.0,0.0,0.0,96%,0.04,0.0,nona woolbright,
-GC,1020,1.0,Computer Art & CAD Foun,0.67,0.19,0.05,0.03,0.03,0%,0.0,0.02,amanda bridges,
-GC,1040,1.0,Graphic Communications I,0.64,0.23,0.02,0.02,0.09,0%,0.0,0.0,michelle suki fox,
-GC,2070,1.0,Graphic Communications II,0.76,0.17,0.05,0.0,0.0,0%,0.0,0.02,charles tabor weiss,
-GC,2400,1.0,Intro to Web Design and D,0.64,0.21,0.07,0.0,0.07,0%,0.0,0.0,william stevens,
-GC,3400,1.0,Digital Imaging,0.38,0.33,0.18,0.03,0.08,0%,0.0,0.0,erica black walker,
-GC,3460,1.0,Ink and Substrates,0.57,0.33,0.11,0.0,0.0,0%,0.0,0.0,shu chang,
-GC,3730,1.0,Media Management in Bra,0.76,0.17,0.07,0.0,0.0,0%,0.0,0.0,jaclyn driggs,
-GC,3740,2.0,Brand Communications Str,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,jacqueline reed herr,
-GC,3760,1.0,Brand Comm Capstone Se,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,katelyn hildebrand,
-GC,4060,1.0,Package and Specialty Prin,0.38,0.53,0.06,0.0,0.03,0%,0.0,0.0,carol jones,
-GC,4400,1.0,Commercial Printing,0.4,0.51,0.05,0.0,0.0,0%,0.0,0.0,eric weisenmiller,
-GC,4440,1.0,Current Dev/Trends in Gr,0.43,0.45,0.1,0.02,0.0,0%,0.0,0.0,liam henry 'hara,
-GC,4480,1.0,Plan & Cont Printing Functi,0.93,0.03,0.0,0.03,0.0,0%,0.0,0.0,nona woolbright,
-GC,4800,1.0,Senior Seminar in GC,0.83,0.1,0.05,0.0,0.0,0%,0.0,0.0,charles tonkin,
-GC,4900,5.0,Videography & Visual Effec,0.67,0.25,0.08,0.0,0.0,0%,0.0,0.0,erica black walker,
-GC,8970,1.0,G C Research Prob I,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.0,nona woolbright,
-GEN,1030,1.0,Careers in Bioch/Gen,0.83,0.1,0.06,0.0,0.02,0%,0.0,0.0,alison starr-moss,
-GEN,3000,1.0,Fundamental Genetics,0.74,0.18,0.08,0.0,0.0,0%,0.0,0.0,michael harris,
-GEN,3000,2.0,Fundamental Genetics,0.7,0.27,0.01,0.0,0.02,0%,0.0,0.0,todd lyda,
-GEN,3000,6.0,Fundamental Genetics,0.28,0.4,0.19,0.04,0.07,0%,0.0,0.01,haiying liang,
-GEN,3020,1.0,Molec & General Genetics,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,kate leanne tsai,True
-GEN,3020,2.0,Molecular & General Gene,0.43,0.37,0.11,0.01,0.03,0%,0.0,0.05,kate leanne tsai,
-GEN,3020,4.0,Molecular & General Gene,0.18,0.41,0.27,0.05,0.0,0%,0.0,0.09,kate leanne tsai,
-GEN,4100,1.0,Population & Quant Genet,0.59,0.36,0.02,0.0,0.0,0%,0.0,0.02,metris kanapeckas,
-GEN,4100,2.0,Population & Quant Gen (,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,metris kanapeckas,True
-GEN,4110,3.0,Population & Quant Gen L,0.81,0.06,0.06,0.0,0.0,0%,0.0,0.06,metris kanapeckas,
-GEN,4110,4.0,Population & Quant Gen L,0.5,0.17,0.25,0.0,0.08,0%,0.0,0.0,metris kanapeckas,
-GEN,4400,1.0,Bioinformatics,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.13,frank feltus,
-GEN,4500,1.0,Comparative Genetics,0.25,0.45,0.16,0.0,0.0,0%,0.0,0.14,leigh anne clark,
-GEN,4500,2.0,Comparative Genetics (HO,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,leigh anne clark,True
-GEN,8050,1.0,Issues in Research,0.67,0.17,0.0,0.0,0.0,0%,0.0,0.0,julia frugoli,
-GEN,8250,1.0,Seminar I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rajandeep sekhon,
-GEOG,1010,1.0,Intro to Geography,0.78,0.13,0.05,0.03,0.0,0%,0.0,0.03,christa smith,
-GEOG,1030,2.0,World Regional Geography,0.38,0.37,0.11,0.06,0.03,0%,0.0,0.03,william church terry,
-GEOG,4100,1.0,Geog of the American Sout,0.83,0.0,0.0,0.0,0.08,0%,0.0,0.0,christa smith,
-GEOL,1010,1.0,Physical Geology,0.62,0.26,0.06,0.04,0.02,0%,0.0,0.01,alan coulson,
-GEOL,1010,2.0,Physical Geology,0.6,0.28,0.08,0.03,0.01,0%,0.0,0.01,alan coulson,
-GEOL,1010,3.0,Physical Geology,0.56,0.31,0.08,0.03,0.03,0%,0.0,0.0,mary katherine fidler,
-GEOL,1010,4.0,Physical Geology,0.46,0.41,0.11,0.0,0.01,0%,0.0,0.01,mary katherine fidler,
-GEOL,1030,1.0,Physical Geol Lab,0.55,0.36,0.0,0.05,0.0,0%,0.0,0.05,alan coulson,
-GEOL,1030,2.0,Physical Geol Lab,0.71,0.17,0.04,0.0,0.08,0%,0.0,0.0,alan coulson,
-GEOL,1030,3.0,Physical Geol Lab,0.64,0.05,0.05,0.09,0.14,0%,0.0,0.05,alan coulson,
-GEOL,1030,4.0,Physical Geol Lab,0.52,0.17,0.22,0.04,0.04,0%,0.0,0.0,alan coulson,
-GEOL,1030,5.0,Physical Geol Lab,0.55,0.2,0.15,0.05,0.0,0%,0.0,0.05,alan coulson,
-GEOL,1030,6.0,Physical Geol Lab,0.67,0.24,0.05,0.05,0.0,0%,0.0,0.0,alan coulson,
-GEOL,1030,7.0,Physical Geol Lab,0.78,0.09,0.0,0.0,0.09,0%,0.0,0.04,alan coulson,
-GEOL,1030,8.0,Physical Geol Lab,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,alan coulson,
-GEOL,1030,9.0,Physical Geol Lab,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,alan coulson,
-GEOL,1030,11.0,Physical Geol Lab,0.75,0.1,0.15,0.0,0.0,0%,0.0,0.0,alan coulson,
-GEOL,1030,12.0,Physical Geol Lab,0.86,0.09,0.0,0.0,0.05,0%,0.0,0.0,alan coulson,
-GEOL,1030,13.0,Physical Geol Lab,0.55,0.3,0.05,0.0,0.0,0%,0.0,0.1,alan coulson,
-GEOL,1030,14.0,Physical Geol Lab,0.55,0.35,0.0,0.05,0.05,0%,0.0,0.0,alan coulson,
-GEOL,1030,15.0,Physical Geol Lab,0.6,0.3,0.1,0.0,0.0,0%,0.0,0.0,alan coulson,
-GEOL,1030,16.0,Physical Geol Lab,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,alan coulson,
-GEOL,1030,17.0,Physical Geol Lab,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,alan coulson,
-GEOL,1030,18.0,Physical Geol Lab,0.64,0.18,0.14,0.0,0.05,0%,0.0,0.0,alan coulson,
-GEOL,1030,19.0,Physical Geol Lab,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,alan coulson,
-GEOL,1120,1.0,Earth Resources,0.51,0.3,0.13,0.04,0.01,0%,0.0,0.02,emily don scribner,
-GEOL,1140,1.0,Earth Resources Lab,0.55,0.29,0.11,0.01,0.0,0%,0.0,0.04,emily don scribner,
-GEOL,1200,1.0,Natural Hazards,0.48,0.4,0.1,0.0,0.03,0%,0.0,0.0,emily don scribner,
-GEOL,2050,1.0,Mineralogy & Intro Petrolo,0.29,0.71,0.0,0.0,0.0,0%,0.0,0.0, shuller-nickles,
-GEOL,2070,1.0,Min & Intro Pet Lab,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,mary katherine fidler,
-GEOL,2700,1.0,Sustainable Water,0.51,0.31,0.09,0.0,0.03,0%,0.0,0.06,melissa ranhofer,
-GEOL,3000,1.0,Environmental Geology,0.38,0.53,0.09,0.0,0.0,0%,0.0,0.0,alan coulson,
-GEOL,3020,1.0,Structural Geology,0.55,0.36,0.0,0.09,0.0,0%,0.0,0.0,alexander pullen,
-GEOL,4820,1.0,Groundwater & Contam Tr,0.3,0.2,0.1,0.1,0.1,0%,0.0,0.2,lawrence murdoch,
-GEOL,4910,1.0,Research Synthesis I,0.5,0.3,0.1,0.0,0.1,0%,0.0,0.0,alan coulson,
-GEOL,6150,1.0,Analysis Geological Proces,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.0,lawrence murdoch,
-GEOL,8080,1.0,Groundwater Modeling,0.14,0.57,0.14,0.0,0.0,0%,0.0,0.0,ronald falta,
-GEOL,8610,1.0,Geology Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sudeep popat,
-GER,1010,1.0,Elementary German,0.7,0.2,0.0,0.1,0.0,0%,0.0,0.0,oswald harris king,
-GER,1020,1.0,Elementary German,0.21,0.29,0.21,0.14,0.07,0%,0.0,0.07, lee ferrell,
-GER,2010,1.0,Intermediate German,0.25,0.31,0.25,0.0,0.06,0%,0.0,0.0,johannes schmidt,
-GER,2020,1.0,Intermediate German,0.63,0.31,0.06,0.0,0.0,0%,0.0,0.0, lee ferrell,
-GER,2600,1.0,Selected Topics-Doppelgan,0.67,0.21,0.0,0.0,0.04,0%,0.0,0.08,gabriela stoicea,
-GER,2600,2.0,Selected Topics-Doppelgan,0.32,0.41,0.09,0.09,0.0,0%,0.0,0.09,gabriela stoicea,
-GER,3050,1.0,Ger Conv & Comp,0.65,0.24,0.06,0.0,0.0,0%,0.0,0.06, lee ferrell,
-GER,3600,1.0,Ger Lit to 1832,0.69,0.23,0.0,0.0,0.0,0%,0.0,0.0,johannes schmidt,
-GRAD,8030,1.0,Intl Teaching Fellowship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david fleming,
-GRAD,8030,2.0,Intl Teaching Fellowship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david fleming,
-HCC,8330,1.0,HCC Research Methods,0.6,0.27,0.07,0.0,0.07,0%,0.0,0.0,kelly caine,
-HCC,9500,1.0,HATLab seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,bart knijnenburg,
-HCC,9500,3.0,Human Centered XR Resea,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sabarish venkat babu,
-HCC,9910,7.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,bart knijnenburg,
-HCG,9070,400.0,Applied Health Genetics,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,sara moir sarasua,
-HCG,9910,401.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jane marie deluca,
-HIST,1010,1.0,History of the United State,0.63,0.33,0.0,0.03,0.0,0%,0.0,0.03,lee brady wilson,
-HIST,1010,2.0,History of the United State,0.17,0.53,0.17,0.03,0.03,0%,0.0,0.07,james jeffries,
-HIST,1220,1.0,"Hist, Tech & Society",0.44,0.33,0.05,0.05,0.06,0%,0.0,0.07,pamela mack,
-HIST,1240,1.0,Environmental History Sur,0.19,0.56,0.17,0.0,0.03,0%,0.0,0.06,james jeffries,
-HIST,1240,2.0,Environmental History Sur,0.18,0.69,0.05,0.0,0.03,0%,0.0,0.05,james jeffries,
-HIST,1720,1.0,The West and the World I,0.68,0.24,0.05,0.0,0.01,0%,0.0,0.02,steven marks,
-HIST,1720,2.0,The West and the World I,0.7,0.13,0.03,0.03,0.0,0%,0.0,0.1,christine hilliard,
-HIST,1720,3.0,The West and the World I,0.28,0.38,0.14,0.02,0.11,0%,0.0,0.07,caroline dunn dunn,
-HIST,1730,1.0,The West and the World II,0.22,0.46,0.18,0.01,0.05,0%,0.0,0.08, alan grubb,
-HIST,1730,2.0,The West and the World II,0.72,0.21,0.0,0.03,0.03,0%,0.0,0.0,archana venkatesh,
-HIST,2140,1.0,Introduction to Public Hist,0.63,0.25,0.0,0.06,0.0,0%,0.0,0.0,joshua catalano,
-HIST,2990,1.0,Historian's Craft,0.63,0.11,0.05,0.0,0.16,0%,0.0,0.05,rachel anne moore,
-HIST,2990,3.0,Historian's Craft,0.44,0.38,0.13,0.0,0.06,0%,0.0,0.0,michael meng,
-HIST,3000,1.0,History of Colonial Americ,0.81,0.16,0.0,0.0,0.0,0%,0.0,0.03,lee brady wilson,
-HIST,3040,1.0,Industrialism&Progressive,0.78,0.17,0.0,0.0,0.06,0%,0.0,0.0, roger grant,
-HIST,3060,1.0,US: Postwar World 1945-1,0.73,0.13,0.0,0.0,0.0,0%,0.0,0.07,rebecca anna stoil,
-HIST,3100,1.0,History of Religion in the U,0.38,0.31,0.06,0.0,0.06,0%,0.0,0.13,elizabeth jemison,
-HIST,3120,1.0,Afr Amer Hist 1877 to Pres,0.38,0.45,0.03,0.03,0.07,0%,0.0,0.03,abel bartley,
-HIST,3240,1.0,Hist of the South II,0.24,0.59,0.0,0.03,0.14,0%,0.0,0.0,john andrew,
-HIST,3330,1.0,Hist of Mod Japan,0.32,0.39,0.25,0.0,0.04,0%,0.0,0.0,edwin moise,
-HIST,3610,1.0,History of Britain to 1688,0.7,0.23,0.03,0.0,0.03,0%,0.0,0.0,seefeldt tara wood,
-HIST,3630,1.0,Britain Since 1688,0.77,0.2,0.0,0.0,0.0,0%,0.0,0.03, barczewski,
-HIST,3670,1.0,Modern Ireland,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,michael silvestri,
-HIST,3840,1.0,Hist of Mod France,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.0, alan grubb,
-HIST,3900,1.0,Modern Military History,0.24,0.48,0.14,0.0,0.0,0%,0.0,0.0,edwin moise,
-HIST,4700,1.0,Europe Women and Gend,0.7,0.2,0.0,0.0,0.0,0%,0.0,0.1,christine hilliard,
-HIST,4710,1.0,Moscow 1937,0.59,0.24,0.06,0.0,0.0,0%,0.0,0.06,steven marks,
-HIST,4870,1.0,World War II,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,john andrew,
-HIST,4900,1.0,DictatorshipViolence20thC,0.56,0.19,0.06,0.0,0.0,0%,0.0,0.0,amit bein,
-HIST,4900,2.0,Northern Ireland &The Tro,0.67,0.28,0.06,0.0,0.0,0%,0.0,0.0,michael silvestri,
-HIST,4940,2.0,Medieval Witchcraft & Her,0.53,0.33,0.07,0.07,0.0,0%,0.0,0.0,seefeldt tara wood,
-HIST,8000,1.0,Historical Methods,0.67,0.22,0.0,0.0,0.0,0%,0.0,0.0,michael meng,
-HIST,8910,1.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,michael meng,
-HLTH,2020,1.0,Introduction to Public Heal,0.47,0.32,0.11,0.11,0.0,0%,0.0,0.0,jeffrey kingree,
-HLTH,2020,2.0,Introduction to Public Heal,0.64,0.31,0.05,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,
-HLTH,2020,3.0,Introduction to Public Heal,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,
-HLTH,2020,4.0,Introduction to Public Heal,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.06,marvina jones,
-HLTH,2020,5.0,Introduction to Public Heal,0.68,0.21,0.05,0.05,0.0,0%,0.0,0.0,becky ann tugman,
-HLTH,2020,400.0,Introduction to Public Heal,0.61,0.26,0.09,0.0,0.0,0%,0.0,0.04,ralph stewart welsh,
-HLTH,2020,401.0,Introduction to Public Heal,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,
-HLTH,2030,1.0,Health Care Sys,0.59,0.41,0.0,0.0,0.0,0%,0.0,0.0,tanya lee staton,
-HLTH,2030,2.0,Health Care Sys,0.75,0.16,0.06,0.03,0.0,0%,0.0,0.0,tanya lee staton,
-HLTH,2030,3.0,Health Care Sys,0.72,0.22,0.06,0.0,0.0,0%,0.0,0.0,sarah bauer floyd,
-HLTH,2030,400.0,Health Care Sys,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,tanya lee staton,
-HLTH,2400,1.0,Deter of Hlth Behav,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,amelia clinkscales,
-HLTH,2400,2.0,Deter of Hlth Behav,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,amelia clinkscales,
-HLTH,2400,3.0,Deter of Hlth Behav,0.63,0.37,0.0,0.0,0.0,0%,0.0,0.0,laura jane rolke,
-HLTH,2600,400.0,Medical Terminology & Co,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,karen edwards,
-HLTH,2980,1.0,Human Health and Disease,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,becky ann tugman,
-HLTH,2980,2.0,Human Health and Disease,0.66,0.26,0.09,0.0,0.0,0%,0.0,0.0,johnny long,
-HLTH,2980,3.0,Human Health and Disease,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,brooke brittain,
-HLTH,3050,1.0,Body Resp Hlth Beh,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,karen kemper,
-HLTH,3400,1.0,Hlth Prom Prog Plan,0.5,0.45,0.05,0.0,0.0,0%,0.0,0.0,johnny long,
-HLTH,3610,1.0,Int Health Care Econ,0.83,0.06,0.09,0.0,0.03,0%,0.0,0.0,khoa dang truong,
-HLTH,3800,1.0,Epidemiology,0.82,0.15,0.03,0.0,0.0,0%,0.0,0.0,lu zhang,
-HLTH,3800,2.0,Epidemiology,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,lu zhang,
-HLTH,3800,3.0,Epidemiology,0.63,0.3,0.07,0.0,0.0,0%,0.0,0.0,deborah alma falta,
-HLTH,3800,400.0,Epidemiology,0.26,0.42,0.21,0.05,0.05,0%,0.0,0.0,deborah alma falta,
-HLTH,3980,1.0,Health Appraisal Skills,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,kathleen meyer,
-HLTH,3980,2.0,Health Appraisal Skills,0.54,0.46,0.0,0.0,0.0,0%,0.0,0.0,kathleen meyer,
-HLTH,4000,1.0,Infec Disease & Exposure,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,tanya lee staton,
-HLTH,4190,1.0,Health Sci Internship Prep,0.79,0.15,0.05,0.0,0.0,0%,0.0,0.0,kathleen meyer,
-HLTH,4200,1.0,Hlth Science Intern,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,kathleen meyer,
-HLTH,4200,3.0,Hlth Science Intern,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,kathleen meyer,
-HLTH,4400,1.0,Manag Hlth Serv Org,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,lu shi,
-HLTH,4700,1.0,Global Health,0.93,0.0,0.03,0.0,0.03,0%,0.0,0.0,micky rogers ward,
-HLTH,4750,1.0,Hlthcr Oper Mgmt Res,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,lu shi,
-HLTH,4900,1.0,Res Eval St Pub Hlth,0.79,0.14,0.0,0.04,0.0,0%,0.0,0.04,jeffrey kingree,
-HLTH,4900,2.0,Res Eval St Pub Hlth,0.79,0.17,0.0,0.04,0.0,0%,0.0,0.0,jeffrey kingree,
-HLTH,4980,1.0,Improving Pop Hlth,0.45,0.36,0.05,0.09,0.0,0%,0.0,0.0,hugh donald spitler,
-HLTH,8090,400.0,Epidemiological Res,0.65,0.24,0.0,0.0,0.0,0%,0.0,0.06,sara wagner robb,
-HLTH,8120,500.0,Clinical and Translational S,0.71,0.24,0.0,0.0,0.0,0%,0.0,0.05,ronald gimbel,
-HLTH,8140,500.0,Health Sys Quality Improv,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,windsor sherrill,
-HLTH,8210,1.0,Health Research I,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,sara wagner robb,
-HLTH,8890,1.0,Sem in App Hlth Rsrch & E,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,karen kemper,
-HON,2020,1.0,Who Decides What's Cool?,0.74,0.21,0.0,0.0,0.0,0%,0.0,0.05,amanda cooper fine,True
-HON,2030,4.0,Views of History/Ancient,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,yanming an,True
-HON,2050,5.0,Entrepreneurship,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,john michael hannon,True
-HON,2210,1.0,Monster Culture and Socie,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,mary nestor,True
-HORT,1010,1.0,Horticulture,0.95,0.03,0.0,0.0,0.0,0%,0.0,0.02,ellen anita vincent,
-HORT,2020,1.0,Adobe Digital Design,0.85,0.04,0.0,0.0,0.0,0%,0.0,0.11,janice ann lay,
-HORT,2120,1.0,Turfgrass Culture,0.84,0.14,0.0,0.0,0.03,0%,0.0,0.0,haibo liu,
-HORT,2130,2.0,Turfgrass Culture Lab,0.73,0.0,0.18,0.0,0.09,0%,0.0,0.0,haibo liu,
-HORT,3030,1.0,Woody Landscape Plant ID,0.15,0.23,0.2,0.13,0.3,0%,0.0,0.0,robert polomski,
-HORT,3080,1.0,Sust Landsc Des Install Mai,0.85,0.09,0.06,0.0,0.0,0%,0.0,0.0,ellen anita vincent,
-HORT,3090,1.0,Sust Landsc Des Lab,0.5,0.1,0.0,0.0,0.4,0%,0.0,0.0,shannon barrett,
-HORT,4120,1.0,Adv Turfgrass Mgt,0.6,0.2,0.1,0.1,0.0,0%,0.0,0.0,lambert mccarty,
-HORT,4400,1.0,Hydroponics,0.42,0.33,0.25,0.0,0.0,0%,0.0,0.0,james emerson faust,
-HP,8010,1.0,Preservation Law and Econ,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,william jackson cook,
-HP,8020,1.0,Hist Preserv Research Sem,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jon marcoux,
-HP,8190,1.0,"Investig, Docum, Conserva",0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,amalia leifeste,
-HP,8230,400.0,Historic American Interiors,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,elizabeth ryan,
-HP,8920,1.0,Special Topics Paying for P,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,amalia leifeste,
-HRD,8300,400.0,Concepts of H R D,0.92,0.05,0.03,0.0,0.0,0%,0.0,0.0,angela carter,
-HRD,8470,400.0,Instru System Design,0.82,0.1,0.0,0.0,0.03,0%,0.0,0.03,angela carter,
-HUM,3090,1.0,Studies in Humanities,0.74,0.21,0.0,0.0,0.0,0%,0.0,0.05,jennie wakefield,
-HUM,3090,2.0,Studies in Humanities,0.65,0.2,0.1,0.0,0.05,0%,0.0,0.0,jennie wakefield,
-IE,2100,1.0,Des Analysis Wrk Sys,0.54,0.4,0.03,0.01,0.0,0%,0.0,0.02,sudeep hegde,
-IE,3010,1.0,Systems Design I,0.44,0.46,0.08,0.03,0.0,0%,0.0,0.0,paris stringfellow,
-IE,3140,1.0,Seminar in Industrial Engr,0.0,0.0,0.0,0.0,0.0,97%,0.03,0.0,jeffrey kharoufeh,
-IE,3600,1.0,Industrial Apps of Prob/Sta,0.31,0.44,0.15,0.04,0.04,0%,0.0,0.04,tugce isik,
-IE,3610,1.0,Industrial App of Prob/Stat,0.33,0.38,0.17,0.03,0.03,0%,0.0,0.05,hamed rahimian,
-IE,3800,1.0,Deterministic Operations R,0.43,0.31,0.14,0.07,0.03,0%,0.0,0.02,yongjia song,
-IE,3810,1.0,Probabilistic Operations Rs,0.34,0.46,0.15,0.03,0.02,0%,0.0,0.0,amin khademi,
-IE,3840,1.0,Engr Econ Analysis,0.39,0.33,0.09,0.02,0.0,0%,0.0,0.17,brian melloy,
-IE,3840,2.0,Engr Econ Analysis,0.05,0.14,0.24,0.1,0.0,0%,0.0,0.48,brian melloy,
-IE,3860,1.0,Production Planning & Con,0.62,0.27,0.09,0.01,0.0,0%,0.0,0.0,mariah magagnotti,
-IE,4300,1.0,Human Fact Engr in Health,0.73,0.17,0.04,0.0,0.04,0%,0.0,0.02,david neyens,
-IE,4400,2.0,Decision Support Sys,0.32,0.49,0.05,0.0,0.08,0%,0.0,0.04,scott jennings mason,
-IE,4560,1.0,Supply Chain Design & Con,0.19,0.43,0.14,0.1,0.0,0%,0.0,0.05,william ferrell,
-IE,4570,1.0,Transp/Logistic Engr,0.72,0.2,0.06,0.0,0.0,0%,0.0,0.03,emily tucker,
-IE,4610,1.0,Quality Engineering,0.63,0.24,0.07,0.02,0.04,0%,0.0,0.01,mariah magagnotti,
-IE,4650,1.0,Facilities Planning & Desig,0.53,0.38,0.07,0.01,0.01,0%,0.0,0.0,william ferrell,
-IE,4670,1.0,System Design II,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,scott jennings mason,
-IE,4820,1.0,Systems Modeling,0.42,0.47,0.07,0.03,0.0,0%,0.0,0.0,kevin taaffe,
-IE,4820,2.0,Systems Modeling,0.58,0.27,0.09,0.0,0.0,0%,0.0,0.06,kevin taaffe,
-IE,4880,2.0,Human Factors Eng,0.87,0.12,0.0,0.01,0.0,0%,0.0,0.0,jamiahus walton,
-IE,6300,1.0,Human Fact Engr in Health,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,david neyens,
-IE,6560,1.0,Supply Chain Design & Con,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,william ferrell,
-IE,6570,1.0,Transp/Logistic Engr,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,emily tucker,
-IE,8030,1.0,Engr Optimization and App,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,thomas sharkey,
-IE,8090,1.0,Model Sys Under Risk,0.33,0.61,0.0,0.0,0.0,0%,0.0,0.06,jeffrey kharoufeh,
-IE,8530,1.0,Foundations of Quality,0.75,0.21,0.0,0.0,0.04,0%,0.0,0.0,ozgur kabadurmus,
-IE,8550,1.0,SC & Logistics Modeling II,0.88,0.04,0.08,0.0,0.0,0%,0.0,0.0,kevin taaffe,
-IE,8930,18.0,Optimization under Uncert,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,yongjia song,
-IE,9910,18.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yongjia song,
-INNO,3990,4.0,IBM Watson in the Watt,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,dane smith,
-INNO,4990,3.0,IBM Watson in the Watt,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.2,dane smith,
-INT,1510,1.0,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,90%,0.06,0.04,lisa marie robinson,
-INT,1520,1.0,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,96%,0.04,0.0,caren kelley-hall,
-INT,1530,1.0,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,94%,0.04,0.02,caren kelley-hall,
-INT,1540,1.0,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,95%,0.0,0.05,caren kelley-hall,
-INT,2010,1.0,Off-Campus Internship FT,0.0,0.0,0.0,0.0,0.0,91%,0.0,0.0,brittany paige neely,
-INT,2510,1.0,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,86%,0.14,0.0,lisa marie robinson,
-INT,2520,1.0,UPIC Internship FT 2,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,caren kelley-hall,
-INT,2530,1.0,UPIC Internship FT 3,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,caren kelley-hall,
-INT,8010,1.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,
-INT,8010,2.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,
-INT,8010,3.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,
-ITAL,1010,2.0,Elementary Italian,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,julia schmidt,
-ITAL,1010,3.0,Elementary Italian,0.83,0.11,0.0,0.0,0.0,0%,0.0,0.06,luca barattoni,
-ITAL,1020,1.0,Elementary Italian,0.65,0.29,0.0,0.06,0.0,0%,0.0,0.0,julia schmidt,
-JAPN,1010,1.0,Elementary Japanese,0.64,0.23,0.05,0.0,0.09,0%,0.0,0.0,kumiko saito,
-JAPN,1010,2.0,Elementary Japanese,0.45,0.14,0.18,0.0,0.14,0%,0.0,0.09,kumiko saito,
-JAPN,1020,1.0,Elementary Japanese,0.5,0.39,0.0,0.0,0.11,0%,0.0,0.0,satomi saito,
-JAPN,2010,1.0,Intermed Japanese,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,satomi saito,
-JAPN,3050,1.0,Japanese Conversation & C,0.75,0.06,0.06,0.0,0.0,0%,0.0,0.06,jae allegra takeuchi,
-JAPN,4010,1.0,Japanese Lit in Translation,0.79,0.08,0.04,0.0,0.0,0%,0.0,0.04,kumiko saito,
-JAPN,4990,1.0,Sel Topics in Japanese Cult,0.54,0.31,0.0,0.0,0.0,0%,0.0,0.08,satomi saito,
-JUST,2050,1.0,Professional Development,0.77,0.1,0.0,0.1,0.0,0%,0.0,0.03,margaret tina britz,
-JUST,2880,1.0,The Criminal Justice Syste,0.6,0.15,0.1,0.06,0.04,0%,0.0,0.04,margaret tina britz,
-JUST,2880,2.0,The Criminal Justice Syste,0.75,0.24,0.0,0.0,0.0,0%,0.0,0.02,kyle david mclean,
-JUST,2890,1.0,Criminology,0.51,0.29,0.1,0.06,0.02,0%,0.0,0.02,matthew costello,
-JUST,3280,1.0,Criminal Courts,0.5,0.42,0.08,0.0,0.0,0%,0.0,0.0,rhys hester,
-JUST,3960,1.0,Drugs and Crime,0.31,0.31,0.23,0.03,0.09,0%,0.0,0.03,brian chad starks,
-JUST,4290,1.0,Justice Administration,0.45,0.4,0.1,0.05,0.0,0%,0.0,0.0,rhys hester,
-JUST,4680,1.0,Criminal Evidence,0.59,0.14,0.14,0.03,0.05,0%,0.0,0.05,margaret tina britz,
-JUST,4860,1.0,CI in CJ: Gangsterism in Fil,0.62,0.12,0.04,0.08,0.15,0%,0.0,0.0,margaret tina britz,
-JUST,4910,1.0,Policing,0.86,0.08,0.05,0.0,0.0,0%,0.0,0.0,kyle david mclean,
-JUST,4930,1.0,Corrections,0.6,0.28,0.07,0.02,0.02,0%,0.0,0.0,bryan lee miller,
-JUST,4990,1.0,Sexual Assault and IPV,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,heather kettrey,
-LAIB,1270,1.0,Intro to Lang & Int'l Busine,0.0,0.0,0.0,0.0,0.0,90%,0.1,0.0,jae allegra takeuchi,
-LANG,3000,1.0,Intro Linguistics,0.56,0.33,0.0,0.0,0.11,0%,0.0,0.0,daniel smith,
-LANG,4990,1.0,Language Portfolio,0.0,0.0,0.0,0.0,0.0,92%,0.0,0.08,su- chen,
-LARC,1150,1.0,Intro Landscape Architectu,0.61,0.25,0.14,0.0,0.0,0%,0.0,0.0,jueminsi wu,
-LARC,1280,1.0,Technical Graphics,0.57,0.32,0.11,0.0,0.0,0%,0.0,0.0,matthew powers,
-LARC,1510,1.0,Basic Design I,0.61,0.32,0.07,0.0,0.0,0%,0.0,0.0,matthew powers,
-LARC,2140,1.0,Plants in the Landscape,0.65,0.25,0.05,0.05,0.0,0%,0.0,0.0,lara browning,
-LARC,3510,1.0,Regional Design,0.63,0.11,0.11,0.05,0.05,0%,0.0,0.05,lara browning,
-LARC,4530,1.0,Key Issues in Landscape Ar,0.57,0.38,0.05,0.0,0.0,0%,0.0,0.0,mary padua,
-LARC,4620,1.0,Design Implementation III,0.5,0.25,0.1,0.05,0.0,0%,0.0,0.1,paul russell,
-LARC,8210,1.0,Research Methods,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,hala fouad nassar,
-LAW,3220,1.0,Legal Env of Bus,0.22,0.36,0.24,0.12,0.04,0%,0.0,0.02,kenneth toussaint,
-LAW,3220,2.0,Legal Env of Bus,0.27,0.33,0.31,0.0,0.1,0%,0.0,0.0,kenneth toussaint,
-LAW,3220,3.0,Legal Env of Bus,0.4,0.44,0.1,0.04,0.0,0%,0.0,0.02, kisska-schulze,
-LAW,3220,4.0,Legal Env of Bus,0.32,0.42,0.22,0.04,0.0,0%,0.0,0.0, kisska-schulze,
-LAW,3220,5.0,Legal Env of Bus,0.72,0.26,0.02,0.0,0.0,0%,0.0,0.0,christopher edwards,
-LAW,3220,6.0,Legal Env of Bus,0.8,0.18,0.0,0.0,0.0,0%,0.0,0.02,christopher edwards,
-LAW,3220,7.0,Legal Env of Bus,0.24,0.37,0.29,0.08,0.0,0%,0.0,0.02, kisska-schulze,
-LAW,3220,8.0,Legal Env of Bus,0.58,0.35,0.08,0.0,0.0,0%,0.0,0.0,edward ray claggett,
-LAW,3220,9.0,Legal Env of Bus,0.59,0.32,0.05,0.02,0.0,0%,0.0,0.02,frances edwards,
-LAW,3220,10.0,Legal Env of Bus,0.4,0.43,0.13,0.03,0.03,0%,0.0,0.0,edward ray claggett,
-LAW,3220,11.0,Legal Env of Bus,0.15,0.44,0.29,0.07,0.0,0%,0.0,0.05,john hine,
-LAW,3220,12.0,Legal Env of Bus,0.48,0.37,0.13,0.0,0.0,0%,0.0,0.02,frances edwards,
-LAW,3220,400.0,Legal Env of Bus,0.36,0.32,0.21,0.07,0.02,0%,0.0,0.02, ward-vaughn,
-LAW,3220,401.0,Legal Env of Bus,0.23,0.53,0.12,0.07,0.03,0%,0.0,0.02, ward-vaughn,
-LAW,3220,402.0,Legal Env of Bus,0.34,0.38,0.21,0.03,0.0,0%,0.0,0.03, ward-vaughn,
-LAW,3220,403.0,Legal Env of Bus,0.33,0.36,0.14,0.07,0.07,0%,0.0,0.03, ward-vaughn,
-LAW,3330,1.0,Real Estate Law,0.26,0.34,0.34,0.0,0.06,0%,0.0,0.0,kenneth toussaint,
-LAW,3330,2.0,Real Estate Law,0.44,0.42,0.11,0.0,0.03,0%,0.0,0.0,kenneth toussaint,
-LAW,4050,1.0,Construction Law,0.87,0.11,0.0,0.0,0.0,0%,0.0,0.03,frances edwards,
-LIH,3970,1.0,Cr Inq-Language & Intl Hea,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.1,kelly digby peebles,
-LS,1000,1.0,Therapeutic Yoga,0.78,0.0,0.0,0.0,0.0,0%,0.0,0.22,ranjanbala amin,
-LS,1000,15.0,"Stress, Coping, & Flourishi",0.83,0.09,0.03,0.0,0.02,0%,0.0,0.02,cynthia pury s,
-LS,1000,16.0,"Stress, Coping, & Flourishi",0.67,0.09,0.12,0.05,0.02,0%,0.0,0.02,cynthia pury s,
-LS,1000,50.0,Facilitating Social Gatherin,0.75,0.05,0.05,0.05,0.1,0%,0.0,0.0,paul hoke,
-LS,1750,2.0,Fly Fishing,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.2,michael watts,
-LS,1850,2.0,Bowling,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.04,madison workman,
-LS,1850,3.0,Bowling,0.71,0.21,0.0,0.0,0.0,0%,0.0,0.07,madison workman,
-LS,1850,4.0,Bowling,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,madison workman,
-LS,1850,5.0,Bowling,0.88,0.0,0.0,0.0,0.06,0%,0.0,0.06,angela rowan,
-LS,1980,5.0,Golf,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.12,wesley womble,
-LS,2320,1.0,Core Training,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,diane moreno,
-LS,2320,4.0,Core Training,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,diane moreno,
-LS,2350,1.0,Basic Yoga,0.76,0.1,0.1,0.0,0.0,0%,0.0,0.05,renee warren gahan,
-LS,2350,5.0,Basic Yoga,0.86,0.0,0.05,0.0,0.0,0%,0.0,0.09,brandy segura,
-LS,2350,6.0,Basic Yoga,0.89,0.05,0.05,0.0,0.0,0%,0.0,0.0,brandy segura,
-LS,2350,8.0,Basic Yoga,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,brandy segura,
-LS,2420,1.0,Meditation and Relax,0.87,0.0,0.04,0.04,0.0,0%,0.0,0.04,renee warren gahan,
-LS,2420,2.0,Meditation and Relax,0.88,0.0,0.04,0.0,0.04,0%,0.0,0.04,renee warren gahan,
-LS,2420,3.0,Meditation and Relax,0.7,0.17,0.04,0.04,0.0,0%,0.0,0.04,ranjanbala amin,
-LS,2420,4.0,Meditation and Relax,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ranjanbala amin,
-LS,2420,9.0,Meditation and Relax,0.77,0.09,0.09,0.0,0.05,0%,0.0,0.0,renee warren gahan,
-LS,2420,10.0,Meditation and Relax,0.59,0.14,0.05,0.09,0.09,0%,0.0,0.05,renee warren gahan,
-LS,2450,5.0,Pilates,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.13,diane moreno,
-LS,2750,8.0,Red Cross First Aid/CPR,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,christopher loomis,
-LS,2780,1.0,Wilderness First Aid,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,emily grace turke,
-MATH,1010,1.0,Essen Math for Informed S,0.09,0.43,0.3,0.02,0.02,0%,0.0,0.13,chad mangum,
-MATH,1010,2.0,Essen Math for Informed S,0.25,0.39,0.27,0.02,0.07,0%,0.0,0.0,chad mangum,
-MATH,1010,3.0,Essen Math for Informed S,0.22,0.31,0.22,0.09,0.09,0%,0.0,0.07,chad mangum,
-MATH,1010,4.0,Essen Math for Informed S,0.17,0.48,0.24,0.02,0.02,0%,0.0,0.07,kristen savary,
-MATH,1010,5.0,Essen Math for Informed S,0.07,0.36,0.14,0.12,0.19,0%,0.0,0.12,jacob lee britton,
-MATH,1010,6.0,Essen Math for Informed S,0.13,0.28,0.35,0.15,0.09,0%,0.0,0.0,sarah kelly,
-MATH,1020,1.0,Business Calculus I,0.36,0.23,0.15,0.13,0.09,0%,0.0,0.04,randy davidson,
-MATH,1020,2.0,Business Calculus I,0.21,0.34,0.28,0.09,0.04,0%,0.0,0.04,randy davidson,
-MATH,1020,3.0,Business Calculus I,0.06,0.26,0.3,0.22,0.1,0%,0.0,0.06,freeman slaughter,
-MATH,1020,4.0,Business Calculus I,0.19,0.38,0.21,0.12,0.07,0%,0.0,0.02,joseph swanson,
-MATH,1020,5.0,Business Calculus I,0.25,0.28,0.18,0.15,0.13,0%,0.0,0.03,ryan wolanzyk,
-MATH,1020,6.0,Business Calculus I,0.11,0.26,0.21,0.21,0.08,0%,0.0,0.13,duygu vargun,
-MATH,1020,7.0,Business Calculus I,0.25,0.3,0.2,0.08,0.08,0%,0.0,0.1,rodrigo smith,
-MATH,1020,8.0,Business Calculus I,0.22,0.33,0.14,0.11,0.14,0%,0.0,0.06,rakhi goswami,
-MATH,1020,9.0,Business Calculus I,0.29,0.29,0.14,0.14,0.1,0%,0.0,0.05,benjamin hamlin,
-MATH,1020,10.0,Business Calculus I,0.2,0.34,0.24,0.0,0.1,0%,0.0,0.1,luke szramowski,
-MATH,1020,11.0,Business Calculus I,0.13,0.36,0.18,0.21,0.1,0%,0.0,0.03,sarah otterbeck,
-MATH,1020,12.0,Business Calculus I,0.17,0.44,0.22,0.1,0.07,0%,0.0,0.0,emily tidwell,
-MATH,1020,13.0,Business Calculus I,0.12,0.37,0.22,0.15,0.02,0%,0.0,0.12,adam nathaniel price,
-MATH,1020,14.0,Business Calculus I,0.29,0.44,0.12,0.05,0.07,0%,0.0,0.02, gracia-guzman,
-MATH,1020,15.0,Business Calculus I,0.13,0.38,0.23,0.1,0.03,0%,0.0,0.13,robert melville,
-MATH,1020,16.0,Business Calculus I,0.27,0.34,0.22,0.1,0.02,0%,0.0,0.05,heidi- shuttleworth,
-MATH,1020,17.0,Business Calculus I,0.07,0.36,0.29,0.07,0.1,0%,0.0,0.12,elizabeth hawkins,
-MATH,1020,18.0,Business Calculus I,0.15,0.27,0.29,0.02,0.12,0%,0.0,0.15,emma soriano,
-MATH,1020,19.0,Business Calculus I,0.31,0.29,0.16,0.11,0.04,0%,0.0,0.09,michael cowen,
-MATH,1020,20.0,Business Calculus I,0.18,0.34,0.2,0.02,0.16,0%,0.0,0.09,morgan elston,
-MATH,1020,21.0,Business Calculus I,0.22,0.27,0.22,0.13,0.11,0%,0.0,0.04,michael foss,
-MATH,1020,22.0,Business Calculus I,0.22,0.37,0.15,0.1,0.05,0%,0.0,0.12,james mckay visser,
-MATH,1020,23.0,Business Calculus I,0.14,0.19,0.27,0.27,0.14,0%,0.0,0.0,james palmer,
-MATH,1020,201.0,Business Calculus I,0.52,0.31,0.1,0.05,0.02,0%,0.0,0.0,dyken jennifer  van e,
-MATH,1020,202.0,Business Calculus I,0.43,0.45,0.05,0.08,0.0,0%,0.0,0.0,marion hanna,
-MATH,1030,401.0,Elementary Functions,0.56,0.36,0.0,0.0,0.08,0%,0.0,0.0,david costanzo,
-MATH,1030,402.0,Elementary Functions,0.54,0.27,0.04,0.04,0.12,0%,0.0,0.0,david costanzo,
-MATH,1030,403.0,Elementary Functions,0.46,0.32,0.0,0.04,0.14,0%,0.0,0.04,david costanzo,
-MATH,1040,1.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,59%,0.38,0.03,donna simms,
-MATH,1040,2.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,67%,0.29,0.04,catherine kenyon,
-MATH,1040,3.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.32,0.05,catherine kenyon,
-MATH,1040,4.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,60%,0.36,0.04,michael nelson,
-MATH,1040,5.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.29,0.07,catherine kenyon,
-MATH,1040,6.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.31,0.05,trinity white,
-MATH,1040,7.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,69%,0.28,0.03,tony thanh nguyen,
-MATH,1040,9.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,48%,0.39,0.13,tony thanh nguyen,
-MATH,1040,10.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,38%,0.6,0.0,todd anthony morra,
-MATH,1040,201.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,81%,0.16,0.03,tony thanh nguyen,
-MATH,1040,202.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.33,0.03,travis alvarez,
-MATH,1050,401.0,Precalculus,0.0,0.0,0.0,0.0,0.0,74%,0.26,0.0,jennifer marie hanna,
-MATH,1050,402.0,Precalculus,0.0,0.0,0.0,0.0,0.0,75%,0.24,0.01,jennifer marie hanna,
-MATH,1050,403.0,Precalculus,0.0,0.0,0.0,0.0,0.0,70%,0.26,0.03,jennifer marie hanna,
-MATH,1060,1.0,Calculus of One Variable I,0.25,0.33,0.25,0.0,0.13,0%,0.0,0.05,david luke frost,
-MATH,1060,2.0,Calculus of One Variable I,0.21,0.35,0.19,0.0,0.16,0%,0.0,0.09,allen anderson guest,
-MATH,1060,3.0,Calculus of One Variable I,0.36,0.23,0.14,0.02,0.2,0%,0.0,0.05,yunan wang,
-MATH,1060,4.0,Calculus of One Variable I,0.41,0.27,0.09,0.02,0.18,0%,0.0,0.02,allen anderson guest,
-MATH,1060,5.0,Calculus of One Variable I,0.22,0.38,0.18,0.04,0.09,0%,0.0,0.09,allen anderson guest,
-MATH,1060,6.0,Calculus of One Variable I,0.3,0.33,0.24,0.06,0.07,0%,0.0,0.0,james gossell,
-MATH,1060,7.0,Calculus of One Variable I,0.24,0.4,0.17,0.07,0.1,0%,0.0,0.02,felice manganiello,
-MATH,1060,8.0,Calculus of One Variable I,0.18,0.29,0.27,0.03,0.17,0%,0.0,0.06,felice manganiello,
-MATH,1060,9.0,Calculus of One Variable I,0.18,0.27,0.32,0.0,0.2,0%,0.0,0.02,sofya alekseeva,
-MATH,1060,10.0,Calculus of One Variable I,0.1,0.21,0.26,0.14,0.17,0%,0.0,0.1,sofya alekseeva,
-MATH,1060,11.0,Calculus of One Variable I,0.23,0.38,0.17,0.04,0.06,0%,0.0,0.13,hugh geller,
-MATH,1060,12.0,Calculus of One Variable I,0.19,0.33,0.11,0.07,0.22,0%,0.0,0.07,hossein faridian,
-MATH,1060,13.0,Calculus of One Variable I,0.28,0.25,0.22,0.03,0.19,0%,0.0,0.03,blake james smith,
-MATH,1060,14.0,Calculus of One Variable I,0.2,0.33,0.23,0.0,0.2,0%,0.0,0.05,michael byrd,
-MATH,1060,201.0,Calculus of One Variable I,0.38,0.29,0.22,0.0,0.11,0%,0.0,0.0,jason alexander kurz,
-MATH,1060,202.0,Calculus of One Variable I,0.38,0.36,0.09,0.04,0.11,0%,0.0,0.02,stephen peele,
-MATH,1060,203.0,Calculus of One Variable I,0.38,0.29,0.18,0.02,0.09,0%,0.0,0.04,nathan fontes,
-MATH,1060,204.0,Calculus of One Variable I,0.53,0.22,0.09,0.02,0.07,0%,0.0,0.07,zachary david espe,
-MATH,1060,205.0,Calculus of One Variable I,0.11,0.24,0.36,0.04,0.13,0%,0.0,0.11,sofya alekseeva,
-MATH,1060,300.0,Calculus of One Variable I,0.27,0.55,0.0,0.0,0.09,0%,0.0,0.09,matthew macauley,
-MATH,1070,1.0,Differen and Integral Calcu,0.11,0.07,0.48,0.04,0.11,0%,0.0,0.19,donna simms,
-MATH,1080,1.0,Calculus of One Variable II,0.27,0.21,0.19,0.04,0.23,0%,0.0,0.07,meredith nicole burr,
-MATH,1080,2.0,Calculus of One Variable II,0.32,0.14,0.14,0.05,0.24,0%,0.0,0.11,fei xue,
-MATH,1080,3.0,Calculus of One Variable II,0.19,0.19,0.19,0.0,0.19,0%,0.0,0.24,scott scruggs,
-MATH,1080,4.0,Calculus of One Variable II,0.05,0.26,0.23,0.09,0.21,0%,0.0,0.16,peter westerbaan,
-MATH,1080,5.0,Calculus of One Variable II,0.17,0.14,0.1,0.1,0.24,0%,0.0,0.24,cody stockdale,
-MATH,1080,6.0,Calculus of One Variable II,0.14,0.16,0.27,0.05,0.18,0%,0.0,0.18,cody stockdale,
-MATH,1080,7.0,Calculus of One Variable II,0.24,0.17,0.05,0.1,0.22,0%,0.0,0.22,blake splitter,
-MATH,1080,201.0,Calculus of One Variable II,0.58,0.27,0.04,0.04,0.08,0%,0.0,0.0,meredith nicole burr,
-MATH,1150,1.0,Contemp Math for Elem T,0.73,0.21,0.04,0.02,0.0,0%,0.0,0.0,jusino carreras,
-MATH,1150,2.0,Contemp Math for Elem T,0.69,0.25,0.02,0.0,0.02,0%,0.0,0.02,jusino carreras,
-MATH,1160,1.0,Contemp Math for Elem T,0.62,0.24,0.14,0.0,0.0,0%,0.0,0.0,jusino carreras,
-MATH,1990,401.0,Problem Solving in Mathe,0.0,0.0,0.0,0.0,0.0,98%,0.02,0.0,marion hanna,
-MATH,1990,403.0,Problem Solving in Mathe,0.0,0.0,0.0,0.0,0.0,95%,0.04,0.01,marion hanna,
-MATH,2060,1.0,Calculus of Several Variabl,0.55,0.2,0.1,0.03,0.07,0%,0.0,0.05,oleg yordanov,
-MATH,2060,2.0,Calculus of Several Variabl,0.6,0.15,0.14,0.05,0.02,0%,0.0,0.04,oleg yordanov,
-MATH,2060,3.0,Calculus of Several Variabl,0.23,0.42,0.23,0.04,0.05,0%,0.0,0.04,tony william long,
-MATH,2060,4.0,Calculus of Several Variabl,0.41,0.3,0.16,0.04,0.03,0%,0.0,0.07,tony william long,
-MATH,2060,5.0,Calculus of Several Variabl,0.35,0.19,0.22,0.12,0.09,0%,0.0,0.04,timothy teitloff,
-MATH,2060,6.0,Calculus of Several Variabl,0.43,0.37,0.13,0.02,0.0,0%,0.0,0.06,irina viktorova,
-MATH,2060,7.0,Calculus of Several Variabl,0.35,0.39,0.17,0.01,0.04,0%,0.0,0.03,irina viktorova,
-MATH,2060,100.0,Calc of Several Vars (HON),0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,yuyuan ouyang,True
-MATH,2060,201.0,Calculus of Several Variabl,0.32,0.26,0.26,0.08,0.08,0%,0.0,0.0,timothy teitloff,
-MATH,2070,1.0,Business Calculus II,0.29,0.21,0.33,0.08,0.04,0%,0.0,0.06,jennifer ray newton,
-MATH,2070,2.0,Business Calculus II,0.36,0.28,0.15,0.09,0.06,0%,0.0,0.06,nathaniel nemire,
-MATH,2070,3.0,Business Calculus II,0.19,0.47,0.15,0.09,0.06,0%,0.0,0.04,jennifer ray newton,
-MATH,2070,4.0,Business Calculus II,0.19,0.16,0.26,0.1,0.06,0%,0.0,0.23,daozhou zhu,
-MATH,2070,5.0,Business Calculus II,0.27,0.38,0.22,0.04,0.04,0%,0.0,0.04,tyler sullivan,
-MATH,2070,6.0,Business Calculus II,0.33,0.3,0.11,0.07,0.09,0%,0.0,0.09,ville madeleine  st e,
-MATH,2070,7.0,Business Calculus II,0.05,0.22,0.22,0.3,0.11,0%,0.0,0.11,antonio pierrottet,
-MATH,2070,8.0,Business Calculus II,0.11,0.25,0.23,0.11,0.06,0%,0.0,0.25,todd fenstermacher,
-MATH,2070,9.0,Business Calculus II,0.16,0.33,0.1,0.1,0.12,0%,0.0,0.2,todd fenstermacher,
-MATH,2070,10.0,Business Calculus II,0.2,0.22,0.22,0.1,0.1,0%,0.0,0.17,eva murphy,
-MATH,2070,11.0,Business Calculus II,0.21,0.17,0.14,0.17,0.28,0%,0.0,0.03,anna bachstein,
-MATH,2070,12.0,Business Calculus II,0.3,0.26,0.21,0.09,0.09,0%,0.0,0.05,elliott degbe,
-MATH,2070,13.0,Business Calculus II,0.21,0.38,0.21,0.1,0.05,0%,0.0,0.05,jennifer ray newton,
-MATH,2070,14.0,Business Calculus II,0.04,0.24,0.15,0.15,0.15,0%,0.0,0.26,rachel bass lanning,
-MATH,2080,1.0,Intro to Ordin Diff Equatio,0.5,0.18,0.11,0.0,0.11,0%,0.0,0.11,timothy parrott,
-MATH,2080,2.0,Intro to Ordin Diff Equatio,0.48,0.31,0.13,0.02,0.06,0%,0.0,0.0,timothy parrott,
-MATH,2080,3.0,Intro to Ordin Diff Equatio,0.37,0.14,0.16,0.04,0.22,0%,0.0,0.06,timothy parrott,
-MATH,2080,4.0,Intro to Ordin Diff Equatio,0.17,0.17,0.27,0.1,0.21,0%,0.0,0.08,jeong rock yoon rock,
-MATH,2080,5.0,Intro to Ordin Diff Equatio,0.3,0.09,0.16,0.09,0.18,0%,0.0,0.18,jeong rock yoon rock,
-MATH,2080,6.0,Intro to Ordin Diff Equatio,0.61,0.29,0.04,0.02,0.02,0%,0.0,0.02,leo rebholz,
-MATH,2160,1.0,Geometry for Elem Sch Te,0.94,0.0,0.0,0.0,0.03,0%,0.0,0.03,nicole alaine sinwell,
-MATH,2160,2.0,Geometry for Elem Sch Te,0.93,0.03,0.0,0.0,0.03,0%,0.0,0.0,nicole alaine sinwell,
-MATH,2160,3.0,Geometry for Elem Sch Te,0.69,0.28,0.03,0.0,0.0,0%,0.0,0.0,jusino carreras,
-MATH,3020,1.0,Stat for Science & Enginee,0.83,0.1,0.02,0.02,0.02,0%,0.0,0.0,qiong zhang,
-MATH,3020,2.0,Stat for Science & Enginee,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,xin liu,
-MATH,3020,3.0,Stat for Science & Enginee,0.16,0.33,0.23,0.1,0.05,0%,0.0,0.12,zhiyun gong,
-MATH,3020,4.0,Stat for Science & Enginee,0.24,0.37,0.2,0.05,0.07,0%,0.0,0.08,zhiyun gong,
-MATH,3110,1.0,Linear Algebra,0.39,0.43,0.1,0.0,0.04,0%,0.0,0.04,wayne goddard,
-MATH,3110,2.0,Linear Algebra,0.56,0.31,0.07,0.02,0.04,0%,0.0,0.0, ramiharimanana,
-MATH,3110,3.0,Linear Algebra,0.64,0.27,0.07,0.02,0.0,0%,0.0,0.0, ramiharimanana,
-MATH,3110,4.0,Linear Algebra,0.44,0.31,0.17,0.03,0.03,0%,0.0,0.03,beth novick,
-MATH,3110,5.0,Linear Algebra,0.35,0.33,0.19,0.02,0.06,0%,0.0,0.04,xuhong gao,
-MATH,3110,6.0,Linear Algebra,0.53,0.28,0.07,0.07,0.05,0%,0.0,0.0,benjamin breen,
-MATH,3160,1.0,Prob Solving for Math Tea,0.79,0.14,0.0,0.04,0.04,0%,0.0,0.0,andrew tyminski,
-MATH,3160,2.0,Prob Solving for Math Tea,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,andrew tyminski,
-MATH,3190,1.0,Introduction to Proof,0.17,0.39,0.3,0.09,0.04,0%,0.0,0.0,hui xue,
-MATH,3190,2.0,Introduction to Proof,0.63,0.19,0.07,0.04,0.07,0%,0.0,0.0,ryann rose cartor,
-MATH,3600,1.0,Intermediate Math Compu,0.7,0.0,0.0,0.0,0.1,0%,0.0,0.2,neil calkin,
-MATH,3600,2.0,Intermediate Math Compu,0.39,0.39,0.06,0.0,0.03,0%,0.0,0.06,wayne goddard,
-MATH,3650,1.0,Numerical Mthds for Engin,0.44,0.4,0.11,0.02,0.0,0%,0.0,0.02,qingshan chen,
-MATH,3650,2.0,Numerical Mthds for Engin,0.29,0.22,0.31,0.04,0.04,0%,0.0,0.09,eleanor jenkins,
-MATH,3650,3.0,Numerical Mthds for Engin,0.34,0.26,0.18,0.05,0.05,0%,0.0,0.11,eleanor jenkins,
-MATH,3650,4.0,Numerical Mthds for Engin,0.64,0.16,0.11,0.04,0.0,0%,0.0,0.04,sibusiso mabuza,
-MATH,4000,1.0,Theory of Probability,0.62,0.27,0.12,0.0,0.0,0%,0.0,0.0,peter kiessler,
-MATH,4000,2.0,Theory of Probability,0.25,0.46,0.14,0.0,0.11,0%,0.0,0.04,xinyi li,
-MATH,4020,1.0,Stats for Science and Engr I,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,derek brown,
-MATH,4070,1.0,Regress & Time-Series Ana,0.57,0.19,0.05,0.0,0.05,0%,0.0,0.14,colin gallagher,
-MATH,4080,1.0,Secondary Math Analysis,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,eliza gallagher,
-MATH,4100,1.0,Number Theory,0.27,0.45,0.27,0.0,0.0,0%,0.0,0.0,hui xue,
-MATH,4120,1.0,Algebra I,0.26,0.32,0.37,0.0,0.0,0%,0.0,0.05,james coykendall,
-MATH,4120,2.0,Algebra I,0.43,0.39,0.09,0.09,0.0,0%,0.0,0.0, ramiharimanana,
-MATH,4190,1.0,Discrete Math Structures I,0.71,0.19,0.05,0.0,0.05,0%,0.0,0.0,beth novick,
-MATH,4190,2.0,Discrete Math Structures I,0.64,0.3,0.03,0.0,0.0,0%,0.0,0.03,beth novick,
-MATH,4310,1.0,Theory of Interest,0.26,0.21,0.26,0.11,0.05,0%,0.0,0.0, erwin walker,
-MATH,4340,1.0,Adv Engineering Mathema,0.23,0.27,0.2,0.03,0.1,0%,0.0,0.17,vincent ervin,
-MATH,4340,2.0,Adv Engineering Mathema,0.27,0.12,0.12,0.19,0.15,0%,0.0,0.15,hyesuk lee,
-MATH,4400,1.0,Linear Programming,0.35,0.43,0.08,0.03,0.05,0%,0.0,0.05,boshi yang,
-MATH,4410,1.0,Intro to Stochastic Models,0.64,0.09,0.09,0.0,0.0,0%,0.0,0.18,brian fralix,
-MATH,4530,1.0,Advanced Calculus I,0.14,0.56,0.24,0.02,0.02,0%,0.0,0.02,martin schmoll,
-MATH,4540,1.0,Advanced Calculus II,0.17,0.5,0.11,0.06,0.11,0%,0.0,0.06,martin schmoll,
-MATH,4910,1.0,Math of Options Pricing,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,mark cawood,
-MATH,4920,2.0,Professional Development,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,randy davidson,
-MATH,6340,1.0,Adv Engineering Mathema,0.38,0.38,0.13,0.0,0.0,0%,0.0,0.13,hyesuk lee,
-MATH,8000,1.0,Probability,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,qiong zhang,
-MATH,8010,1.0,General Linear Hypothesis,0.62,0.31,0.08,0.0,0.0,0%,0.0,0.0,xiaoqian sun,
-MATH,8050,1.0,Data Analysis,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,brook thayer russell,
-MATH,8090,1.0,Time Series Analysis,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,xin liu,
-MATH,8120,1.0,Discrete Optimization,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,matthew saltzman,
-MATH,8190,1.0,Multicriteria Optimization,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,margaret wiecek,
-MATH,8210,1.0,Linear Analysis,0.56,0.33,0.06,0.0,0.0,0%,0.0,0.06,mishko mitkovski,
-MATH,8510,1.0,Abstract Algebra I,0.29,0.65,0.06,0.0,0.0,0%,0.0,0.0,michael adam burr,
-MATH,8530,1.0,Matrix Analysis,0.53,0.47,0.0,0.0,0.0,0%,0.0,0.0,matthew macauley,
-MATH,8550,1.0,Combinatorial Analysis,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,svetlana poznanovikj,
-MATH,8600,1.0,Intro to Scientific Computi,0.38,0.54,0.08,0.0,0.0,0%,0.0,0.0,vincent ervin,
-MATH,8650,1.0,Data Structures,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,sibusiso mabuza,
-MATH,8820,1.0,Intro to Bayesian Statistics,0.67,0.29,0.0,0.0,0.0,0%,0.0,0.04,deborah kunkel,
-MATH,9010,1.0,Probability Theory I,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,brian fralix,
-MATH,9830,1.0,Advanced Theories for PD,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,qingshan chen,
-MATH,9830,2.0,High Performance FEM,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,timo heister,
-MATH,9850,1.0,Homological Ring Properti,0.71,0.0,0.14,0.0,0.0,0%,0.0,0.0, sather-wagstaff,
-MATH,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,derek brown,
-MATH,9910,10.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, mcmahan,
-MATH,9910,16.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, sather-wagstaff,
-MBA,8030,2.0,Stat Analy of Bus Op,0.53,0.29,0.12,0.0,0.0,0%,0.0,0.06,william kilbourne,
-MBA,8030,3.0,Stat Analy of Bus Op,0.61,0.28,0.0,0.0,0.0,0%,0.0,0.11,magda gabriela sava,
-MBA,8030,4.0,Stat Analy of Bus Op,0.61,0.36,0.0,0.0,0.04,0%,0.0,0.0,magda gabriela sava,
-MBA,8040,20.0,Busin Data An & Stat Com,0.59,0.26,0.03,0.0,0.12,0%,0.0,0.0,william kilbourne,
-MBA,8060,1.0,Operations Mgt,0.8,0.16,0.02,0.0,0.0,0%,0.0,0.02,lawrence fredendall,
-MBA,8060,3.0,Operations Mgt,0.73,0.23,0.03,0.0,0.0,0%,0.0,0.0,lawrence fredendall,
-MBA,8070,1.0,Financial Management,0.48,0.43,0.03,0.0,0.0,0%,0.0,0.08,george lockhart,
-MBA,8070,2.0,Financial Management,0.43,0.47,0.0,0.0,0.0,0%,0.0,0.1,george lockhart,
-MBA,8070,20.0,Financial Management,0.7,0.26,0.04,0.0,0.0,0%,0.0,0.0,george lockhart,
-MBA,8090,1.0,Org Beh & Hum Res Mg,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,thomas zagenczyk,
-MBA,8090,2.0,Org Beh & Hum Res Mg,0.76,0.21,0.0,0.0,0.0,0%,0.0,0.03,thomas zagenczyk,
-MBA,8090,3.0,Org Beh & Hum Res Mg,0.75,0.23,0.0,0.0,0.0,0%,0.0,0.03,thomas zagenczyk,
-MBA,8180,20.0,Business Intell & Data Anly,0.79,0.12,0.03,0.0,0.06,0%,0.0,0.0,john frederick tripp,
-MBA,8190,2.0,Intro to Acc and Fin,0.41,0.33,0.18,0.0,0.0,0%,0.0,0.08,jeffrey mcmillan,
-MBA,8190,3.0,Intro to Acc and Fin,0.44,0.33,0.18,0.0,0.0,0%,0.0,0.05,jeffrey mcmillan,
-MBA,8290,1.0,Marketing Foundation,0.9,0.05,0.0,0.0,0.0,0%,0.0,0.05,ankita bakre,
-MBA,8310,10.0,Communications and Sales,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,gregory pickett,
-MBA,8360,1.0,Real Estate Principles,0.2,0.73,0.0,0.0,0.0,0%,0.0,0.07,stephen buckman,
-MBA,8370,1.0,Legal Environ of Bus,0.43,0.5,0.08,0.0,0.0,0%,0.0,0.0,judson jahn,
-MBA,8370,2.0,Legal Environ of Bus,0.35,0.55,0.08,0.0,0.0,0%,0.0,0.03,judson jahn,
-MBA,8410,1.0,Real Estate Finance,0.81,0.06,0.0,0.0,0.0,0%,0.0,0.06,larry bradley harvey,
-MBA,8430,1.0,Entrepreneurial Accountin,0.36,0.36,0.27,0.0,0.0,0%,0.0,0.0,annieka philo,
-MBA,8470,1.0,New Venture Creation,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,joseph gibson,
-MBA,8490,5.0,Entrepreneurial Strategy,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,matthew klein,
-MBA,8500,3.0,Bus Communications,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,
-MBA,8500,30.0,Bus Communications,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,
-MBA,8540,2.0,Managerial Accounting,0.46,0.41,0.11,0.0,0.0,0%,0.0,0.02,emily mccorkle,
-MBA,8590,1.0,Mgr Decision Model,0.32,0.41,0.09,0.0,0.05,0%,0.0,0.14,james turner,
-MBA,8590,2.0,Mgr Decision Model,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.08,magda gabriela sava,
-MBA,8590,3.0,Mgr Decision Model,0.71,0.18,0.0,0.0,0.0,0%,0.0,0.12,magda gabriela sava,
-MBA,8600,2.0,Advanced Marketing Strat,0.67,0.27,0.0,0.0,0.0,0%,0.0,0.07,pravin nath,
-MBA,8600,3.0,Advanced Marketing Strat,0.8,0.13,0.0,0.0,0.0,0%,0.0,0.07,pravin nath,
-MBA,8610,1.0,Information Systems,0.41,0.59,0.0,0.0,0.0,0%,0.0,0.0,william kettinger,
-MBA,8610,2.0,Information Systems,0.67,0.27,0.03,0.0,0.03,0%,0.0,0.0,william kettinger,
-MBA,8620,1.0,Managerial Economics,0.39,0.5,0.06,0.0,0.0,0%,0.0,0.06,scott templeton,
-MBA,8620,2.0,Managerial Economics,0.63,0.37,0.0,0.0,0.0,0%,0.0,0.0,ronald earle gregory,
-MBA,8620,4.0,Managerial Economics,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ronald earle gregory,
-MBA,8660,21.0,Big Data Mgmt for Analytic,0.81,0.15,0.04,0.0,0.0,0%,0.0,0.0,he li,
-MBA,8700,3.0,Strategic Management,0.67,0.25,0.0,0.0,0.0,0%,0.0,0.08,thomas robert uva,
-MBA,8800,2.0,Career Mgt,0.0,0.0,0.0,0.0,0.0,93%,0.0,0.0,jamie lynn patterson,
-MBA,8800,3.0,MBA Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,
-MBA,8800,30.0,MBA Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,
-MBA,8810,1.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,
-MBA,8810,2.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,
-MBA,8810,3.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,
-MBA,8810,5.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gail depriest,
-MBA,8880,5.0,MBA Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gregory pickett,
-MBA,8880,11.0,MBA Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gregory pickett,
-MBA,8990,2.0,Creativity,0.75,0.2,0.03,0.0,0.03,0%,0.0,0.0,kathleen ann kegley,
-MBA,8990,4.0,Data Analytics & Visualizati,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,john frederick tripp,
-MBA,8990,5.0,Business Analytics Models,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.04,jennie lynn farmer,
-MBA,8990,10.0,Six Sigma,0.81,0.14,0.0,0.0,0.0,0%,0.0,0.05,dee ann wood kivett wood,
-ME,2000,400.0,Sophomore Seminar,0.55,0.21,0.08,0.04,0.06,0%,0.0,0.06,todd schweisinger,
-ME,2010,1.0,Statics & Dynamics,0.0,0.13,0.23,0.09,0.39,0%,0.0,0.16,marisa kikendall orr,
-ME,2010,2.0,Statics & Dynamics,0.23,0.15,0.28,0.09,0.19,0%,0.0,0.06,paul joseph,
-ME,2010,3.0,Statics & Dynamics,0.11,0.08,0.15,0.15,0.44,0%,0.0,0.08,gang liu,
-ME,2010,4.0,Statics & Dynamics,0.06,0.1,0.09,0.06,0.43,0%,0.0,0.26, parvinioskoui,
-ME,2030,1.0,Founda Th/Fl Syst,0.15,0.34,0.43,0.09,0.0,0%,0.0,0.0,xiangchun xuan,
-ME,2030,2.0,Founda Th/Fl Syst,0.13,0.49,0.29,0.0,0.04,0%,0.0,0.04,yiqiang han,
-ME,2040,1.0,Mechanics of Materials,0.02,0.2,0.39,0.13,0.15,0%,0.0,0.02,gang liu,
-ME,2040,2.0,Mechanics of Materials,0.11,0.39,0.36,0.11,0.03,0%,0.0,0.0,huijuan zhao,
-ME,2220,1.0,Mechanical Engineering La,0.25,0.63,0.13,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
-ME,2220,2.0,Mechanical Engineering La,0.31,0.69,0.0,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
-ME,2220,5.0,Mechanical Engineering La,0.38,0.56,0.06,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
-ME,2220,6.0,Mechanical Engineering La,0.63,0.25,0.06,0.0,0.06,0%,0.0,0.0,douglas scott byrd,
-ME,2220,7.0,Mechanical Engineering La,0.31,0.56,0.06,0.06,0.0,0%,0.0,0.0,douglas scott byrd,
-ME,2220,8.0,Mechanical Engineering La,0.25,0.5,0.19,0.06,0.0,0%,0.0,0.0,douglas scott byrd,
-ME,2220,10.0,Mechanical Engineering La,0.25,0.44,0.06,0.06,0.06,0%,0.0,0.13,douglas scott byrd,
-ME,2220,13.0,Mechanical Engineering La,0.63,0.31,0.06,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
-ME,2220,14.0,Mechanical Engineering La,0.13,0.38,0.13,0.06,0.13,0%,0.0,0.19,douglas scott byrd,
-ME,2220,15.0,Mechanical Engineering La,0.25,0.44,0.31,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
-ME,3000,301.0,Junior Honors Seminar (H,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,joshua bostwick,True
-ME,3030,1.0,Thermodynamics,0.19,0.24,0.14,0.14,0.16,0%,0.0,0.14,john saylor,
-ME,3030,2.0,Thermodynamics,0.7,0.16,0.1,0.02,0.02,0%,0.0,0.02,sandip dutta,
-ME,3030,3.0,Thermodynamics,0.82,0.13,0.04,0.0,0.02,0%,0.0,0.0,sandip dutta,
-ME,3040,1.0,Heat Transfer,0.14,0.59,0.21,0.0,0.07,0%,0.0,0.0,xin zhao,
-ME,3040,2.0,Heat Transfer,0.38,0.4,0.19,0.04,0.0,0%,0.0,0.0,xin zhao,
-ME,3040,3.0,Heat Transfer,0.73,0.19,0.04,0.02,0.0,0%,0.0,0.02,sandip dutta,
-ME,3050,1.0,Model/an Dy Syst,0.26,0.35,0.33,0.02,0.05,0%,0.0,0.0,ardalan vahidi,
-ME,3050,2.0,Model/an Dy Syst,0.21,0.48,0.19,0.1,0.0,0%,0.0,0.02,ge lv,
-ME,3050,3.0,Model/an Dy Syst,0.21,0.39,0.21,0.0,0.12,0%,0.0,0.06,joshua bostwick,
-ME,3060,1.0,Fund Machine Design,0.35,0.38,0.17,0.04,0.04,0%,0.0,0.0,douglas scott byrd,
-ME,3060,2.0,Fund Machine Design,0.73,0.24,0.02,0.0,0.0,0%,0.0,0.02,zhaoxu meng,
-ME,3070,1.0,Found of Mechanical Syste,0.73,0.21,0.04,0.0,0.02,0%,0.0,0.0,lonny thompson,
-ME,3070,2.0,Found of Mechanical Syste,0.32,0.35,0.16,0.03,0.13,0%,0.0,0.0,katherine ehlert,
-ME,3070,3.0,Found of Mechanical Syste,0.32,0.38,0.13,0.06,0.06,0%,0.0,0.04,chengshi wang,
-ME,3080,1.0,Fluid Mechanics,0.22,0.47,0.25,0.04,0.0,0%,0.0,0.02,xiangchun xuan,
-ME,3080,2.0,Fluid Mechanics,0.27,0.6,0.13,0.0,0.0,0%,0.0,0.0,ethan kung,
-ME,3080,3.0,Fluid Mechanics,0.35,0.51,0.14,0.0,0.0,0%,0.0,0.0,zhen li,
-ME,3120,1.0,Manuf Processes,0.24,0.63,0.11,0.0,0.02,0%,0.0,0.0,hong seok choi,
-ME,3120,2.0,Manuf Processes,0.68,0.26,0.05,0.01,0.0,0%,0.0,0.0, martinez-duarte,
-ME,3330,1.0,Mechanical Engineering La,0.44,0.5,0.06,0.0,0.0,0%,0.0,0.0,yiqiang han,
-ME,3330,2.0,Mechanical Engineering La,0.44,0.5,0.0,0.0,0.0,0%,0.0,0.06,yiqiang han,
-ME,3330,3.0,Mechanical Engineering La,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.07,yiqiang han,
-ME,3330,4.0,Mechanical Engineering La,0.27,0.64,0.0,0.0,0.09,0%,0.0,0.0,yiqiang han,
-ME,3330,5.0,Mechanical Engineering La,0.38,0.5,0.06,0.0,0.0,0%,0.0,0.06,yiqiang han,
-ME,3330,6.0,Mechanical Engineering La,0.56,0.31,0.13,0.0,0.0,0%,0.0,0.0,yiqiang han,
-ME,3330,7.0,Mechanical Engineering La,0.6,0.2,0.1,0.0,0.1,0%,0.0,0.0,yiqiang han,
-ME,3330,10.0,Mechanical Engineering La,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,
-ME,3330,13.0,Mechanical Engineering La,0.56,0.31,0.06,0.06,0.0,0%,0.0,0.0,yiqiang han,
-ME,3330,14.0,Mechanical Engineering La,0.47,0.53,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,
-ME,4000,400.0,Senior Seminar,0.86,0.1,0.03,0.01,0.01,0%,0.0,0.0,atul gajanan kelkar,
-ME,4010,1.0,Mech Engr Design,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,timothy guggisberg,
-ME,4010,2.0,Mech Engr Design,0.23,0.77,0.0,0.0,0.0,0%,0.0,0.0,gregory mocko,
-ME,4010,400.0,Mech Engr Design,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,geetha chimata,
-ME,4020,1.0,Intern in Engr Des,0.61,0.33,0.06,0.0,0.0,0%,0.0,0.0,sandip dutta,
-ME,4020,3.0,Intern in Engr Des,0.47,0.35,0.18,0.0,0.0,0%,0.0,0.0,yiqiang han,
-ME,4020,4.0,Intern in Engr Des,0.38,0.62,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,
-ME,4020,5.0,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,timothy guggisberg,
-ME,4030,1.0,Control Dynamic Systems,0.15,0.23,0.22,0.2,0.13,0%,0.0,0.03, naghnaeian,
-ME,4030,2.0,Control Dynamic Systems,0.42,0.4,0.12,0.05,0.02,0%,0.0,0.0,umesh vaidya,
-ME,4030,3.0,Control Dynamic Systems,0.37,0.47,0.16,0.0,0.0,0%,0.0,0.0, tallapragada,
-ME,4210,1.0,Intro to Comp Flow,0.43,0.3,0.26,0.0,0.0,0%,0.0,0.0,chenning tong,
-ME,4290,1.0,Ther Env Control,0.63,0.25,0.0,0.04,0.0,0%,0.0,0.04,jay ochterbeck,
-ME,4300,1.0,Mech Comp Materials,0.63,0.13,0.21,0.0,0.0,0%,0.0,0.04,lonny thompson,
-ME,4320,1.0,Advanced Strength of Mat,0.79,0.18,0.0,0.0,0.0,0%,0.0,0.0,oliver myers,
-ME,4340,1.0,Cardiovascular Biomechani,0.25,0.46,0.17,0.0,0.04,0%,0.0,0.04,ethan kung,
-ME,4400,1.0,Materials for Aggressive E,0.59,0.3,0.11,0.0,0.0,0%,0.0,0.0,garrett pataky,
-ME,4440,1.0,Mechanical Engineering La,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,2.0,Mechanical Engineering La,0.38,0.5,0.13,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,3.0,Mechanical Engineering La,0.06,0.88,0.06,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,4.0,Mechanical Engineering La,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,5.0,Mechanical Engineering La,0.25,0.75,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,6.0,Mechanical Engineering La,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,7.0,Mechanical Engineering La,0.33,0.67,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,8.0,Mechanical Engineering La,0.54,0.46,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,9.0,Mechanical Engineering La,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4440,13.0,Mechanical Engineering La,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
-ME,4550,400.0,Design for Manuf,0.53,0.24,0.16,0.02,0.04,0%,0.0,0.0,joshua summers,
-ME,4580,1.0,Fund Micro/Nano Fabricati,0.41,0.45,0.05,0.0,0.0,0%,0.0,0.05, martinez-duarte,
-ME,4930,29.0,Sel Topics ME - Vibrations,0.36,0.36,0.14,0.11,0.0,0%,0.0,0.04,suyi li,
-ME,6300,1.0,Mech Comp Materials,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,lonny thompson,
-ME,6320,1.0,Advanced Strength of Mat,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,oliver myers,
-ME,6340,1.0,Cardiovascular Biomechani,0.4,0.4,0.2,0.0,0.0,0%,0.0,0.0,ethan kung,
-ME,6550,400.0,Design for Manuf,0.43,0.36,0.07,0.0,0.07,0%,0.0,0.07,joshua summers,
-ME,6580,1.0,Fund Micro/Nano Fabricati,0.2,0.6,0.2,0.0,0.0,0%,0.0,0.0, martinez-duarte,
-ME,6930,24.0,Sel Topics - Automotive Sa,0.9,0.05,0.0,0.0,0.05,0%,0.0,0.0,john wagner,
-ME,6930,865.0,Sel Topics - Metrology (VT,0.6,0.3,0.0,0.0,0.0,0%,0.0,0.1,geetha chimata,
-ME,8010,1.0,Found of Fluid Mech,0.73,0.2,0.0,0.0,0.0,0%,0.0,0.07,richard figliola,
-ME,8010,843.0,Found of Fluid Mech,0.4,0.2,0.0,0.0,0.0,0%,0.0,0.4,richard figliola,
-ME,8100,1.0,Macroscopic Thermo,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,jay ochterbeck,
-ME,8180,1.0,Intro to Fin Ele Ana,0.31,0.49,0.09,0.0,0.0,0%,0.0,0.11,gang li,
-ME,8230,1.0,Control Systems,0.78,0.0,0.11,0.0,0.0,0%,0.0,0.11,yue wang,
-ME,8360,1.0,Fracture Mech,0.38,0.13,0.13,0.0,0.0,0%,0.0,0.38,huijuan zhao,
-ME,8460,1.0,Inter Dynamics,0.33,0.42,0.08,0.0,0.0,0%,0.0,0.08, tallapragada,
-ME,8610,1.0,Matl Sel Engr Design,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,garrett pataky,
-ME,8610,864.0,Matl Sel Engr Design,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,garrett pataky,
-ME,8700,1.0,Adv Design Methods,0.25,0.58,0.0,0.0,0.0,0%,0.0,0.08,gregory mocko,
-ME,8710,1.0,Engr Optimization,0.72,0.14,0.07,0.0,0.0,0%,0.0,0.03,cameron turner,
-ME,8910,16.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,joshua summers,
-ME,8910,28.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,cameron turner,
-ME,8930,8.0,Sel Topics ME: Continuum,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,fadi abdeljawad,
-ME,8930,27.0,Sel Topics ME - Optimal Co,0.38,0.57,0.0,0.0,0.0,0%,0.0,0.0,ardalan vahidi,
-ME,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gang li,
-ME,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yue wang,
-ME,9910,29.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,suyi li,
-MGT,2010,1.0,Principles of Management,0.46,0.43,0.09,0.0,0.01,0%,0.0,0.0,katherine clark,
-MGT,2010,2.0,Principles of Management,0.75,0.22,0.01,0.0,0.02,0%,0.0,0.0,jonathan preedom,
-MGT,2010,3.0,Principles of Management,0.93,0.03,0.03,0.0,0.0,0%,0.0,0.0,sheena laxton,True
-MGT,2010,8.0,Principles of Management,0.86,0.07,0.02,0.0,0.0,0%,0.0,0.05,shuang liu,
-MGT,2010,9.0,Principles of Management,0.4,0.4,0.19,0.02,0.0,0%,0.0,0.0,ashley parnell,
-MGT,2010,10.0,Principles of Management,0.48,0.33,0.17,0.0,0.02,0%,0.0,0.0,ashley parnell,
-MGT,2010,11.0,Principles of Management,0.95,0.0,0.02,0.0,0.02,0%,0.0,0.0,jingyuan tian,
-MGT,2010,12.0,Principles of Management,0.8,0.1,0.0,0.0,0.05,0%,0.0,0.05,zhiwei xing,
-MGT,2010,13.0,Principles of Management,0.21,0.41,0.24,0.1,0.03,0%,0.0,0.01,christopher mann,
-MGT,2010,14.0,Principles of Management,0.77,0.2,0.01,0.0,0.01,0%,0.0,0.01,sharon sheridan,
-MGT,2010,15.0,Principles of Management,0.72,0.14,0.05,0.09,0.0,0%,0.0,0.0,hongli ye,
-MGT,2010,18.0,Principles of Management,0.93,0.05,0.0,0.0,0.0,0%,0.0,0.03,yao chen,
-MGT,2180,1.0,Management PC Applicati,0.84,0.12,0.03,0.01,0.0,0%,0.0,0.01,ryan toole,
-MGT,2180,2.0,Management PC Applicati,0.71,0.19,0.03,0.02,0.05,0%,0.0,0.01,ryan toole,
-MGT,2180,3.0,Management PC Applicati,0.59,0.26,0.06,0.03,0.05,0%,0.0,0.01,jeromy blake snider,
-MGT,3070,1.0,Human Resource Manage,0.6,0.29,0.05,0.05,0.0,0%,0.0,0.02,michael cole,
-MGT,3070,4.0,Human Resource Manage,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,leonard spooner,
-MGT,3070,5.0,Human Resource Manage,0.62,0.24,0.03,0.03,0.08,0%,0.0,0.0,kristin scott,
-MGT,3070,6.0,Human Resource Manage,0.71,0.26,0.03,0.0,0.0,0%,0.0,0.0,leonard spooner,
-MGT,3070,7.0,Human Resource Manage,0.23,0.54,0.15,0.08,0.0,0%,0.0,0.0,priscilla harrison,
-MGT,3070,8.0,Human Resource Manage,0.63,0.34,0.02,0.0,0.0,0%,0.0,0.0,michael cole,
-MGT,3070,9.0,Human Resource Manage,0.55,0.39,0.06,0.0,0.0,0%,0.0,0.0,leonard spooner,
-MGT,3100,1.0,Intermed Business Statistic,0.41,0.35,0.16,0.05,0.03,0%,0.0,0.0,jaeyoung kim,
-MGT,3100,2.0,Intermed Business Statistic,0.68,0.1,0.13,0.0,0.03,0%,0.0,0.08,haeri seyed seyed,
-MGT,3100,3.0,Intermed Business Statistic,0.41,0.35,0.06,0.0,0.03,0%,0.0,0.15,mustafa akturk,
-MGT,3100,5.0,Intermed Business Statistic,0.45,0.31,0.18,0.03,0.01,0%,0.0,0.02,mustafa akturk,
-MGT,3100,6.0,Intermed Business Statistic,0.41,0.24,0.22,0.0,0.07,0%,0.0,0.05,philip roth,
-MGT,3100,7.0,Intermed Business Statistic,0.61,0.26,0.11,0.0,0.03,0%,0.0,0.0, ajjuguttu,
-MGT,3100,8.0,Intermed Business Statistic,0.27,0.33,0.17,0.07,0.1,0%,0.0,0.07,jeromy blake snider,
-MGT,3100,9.0,Intermed Business Statistic,0.79,0.12,0.07,0.02,0.0,0%,0.0,0.0,david ford peyton,
-MGT,3100,10.0,Intermed Business Statistic,0.5,0.33,0.08,0.0,0.03,0%,0.0,0.06,david ford peyton,
-MGT,3100,12.0,Intermed Business Statistic,0.68,0.12,0.15,0.0,0.03,0%,0.0,0.03,david ford peyton,
-MGT,3100,13.0,Intermed Business Statistic,0.41,0.28,0.09,0.06,0.03,0%,0.0,0.06,benjamin wiles,
-MGT,3120,5.0,Decision Models for Mana,0.09,0.13,0.28,0.13,0.28,0%,0.0,0.11,sara elizabeth yoder,
-MGT,3120,6.0,Decision Models for Mana,0.09,0.22,0.27,0.16,0.19,0%,0.0,0.03,sara elizabeth yoder,
-MGT,3120,9.0,Decision Models for Mana,0.12,0.18,0.22,0.09,0.27,0%,0.0,0.12,sara elizabeth yoder,
-MGT,3180,1.0,Mgt of Info Systems,0.67,0.2,0.13,0.0,0.0,0%,0.0,0.0,nedumkallel pius,
-MGT,3180,3.0,Mgt of Info Systems,0.59,0.26,0.11,0.02,0.02,0%,0.0,0.0,kevin mckenzie,
-MGT,3180,4.0,Mgt of Info Systems,0.64,0.26,0.02,0.06,0.02,0%,0.0,0.0,iaroslava dutchak,
-MGT,3180,6.0,Mgt of Info Systems,0.35,0.27,0.18,0.12,0.04,0%,0.0,0.04,zhihong ke,
-MGT,3180,7.0,Mgt of Info Systems,0.38,0.38,0.13,0.04,0.02,0%,0.0,0.04,iaroslava dutchak,
-MGT,3180,9.0,Mgt of Info Systems,0.47,0.33,0.07,0.02,0.0,0%,0.0,0.12,pranith abbaraju,
-MGT,3500,1.0,Business Intel/Data Analyti,0.59,0.32,0.05,0.0,0.05,0%,0.0,0.0,david ford peyton,
-MGT,3900,1.0,Operations Management,0.04,0.25,0.43,0.11,0.11,0%,0.0,0.07,zachary leffakis,
-MGT,3900,2.0,Operations Management,0.14,0.49,0.3,0.08,0.0,0%,0.0,0.0,zachary leffakis,
-MGT,3900,4.0,Operations Management,0.41,0.39,0.17,0.01,0.02,0%,0.0,0.0,ying zhang,
-MGT,3900,5.0,Operations Management,0.3,0.51,0.16,0.03,0.01,0%,0.0,0.0,ying zhang,
-MGT,3900,7.0,Operations Management,0.16,0.66,0.17,0.0,0.01,0%,0.0,0.01, sridharan,
-MGT,4000,1.0,Mgt of Organizational Beh,0.8,0.18,0.0,0.03,0.0,0%,0.0,0.0,michael cole,
-MGT,4000,2.0,Mgt of Organizational Beh,0.73,0.25,0.0,0.0,0.0,0%,0.0,0.03,michael cole,
-MGT,4000,3.0,Mgt of Organizational Beh,0.23,0.4,0.28,0.05,0.0,0%,0.0,0.05,thomas zagenczyk,
-MGT,4000,4.0,Mgt of Organizational Beh,0.46,0.41,0.11,0.0,0.03,0%,0.0,0.0,sara joy krivacek,
-MGT,4020,1.0,Ops Pln and Ctl,0.07,0.27,0.27,0.07,0.17,0%,0.0,0.13,zachary leffakis,
-MGT,4080,1.0,Lean Operations,0.06,0.35,0.41,0.06,0.12,0%,0.0,0.0,zachary leffakis,
-MGT,4110,1.0,Project Management,0.33,0.5,0.13,0.0,0.0,0%,0.0,0.0,russell purvis,
-MGT,4120,1.0,Supplier Management,0.48,0.45,0.03,0.0,0.0,0%,0.0,0.03,ahmet colak,
-MGT,4150,2.0,Business Strategy,0.23,0.4,0.38,0.0,0.0,0%,0.0,0.0,james liddle,
-MGT,4150,3.0,Business Strategy,0.09,0.64,0.24,0.02,0.0,0%,0.0,0.0,james liddle,
-MGT,4150,4.0,Business Strategy,0.11,0.6,0.27,0.0,0.0,0%,0.0,0.02,james liddle,
-MGT,4150,6.0,Business Strategy,0.24,0.6,0.13,0.02,0.0,0%,0.0,0.0,amy elizabeth ingram,
-MGT,4150,7.0,Business Strategy,0.56,0.37,0.06,0.0,0.01,0%,0.0,0.0,matt calvin hersel,
-MGT,4150,8.0,Business Strategy,0.2,0.66,0.14,0.0,0.0,0%,0.0,0.0,amy elizabeth ingram,
-MGT,4150,9.0,Business Strategy,0.55,0.26,0.19,0.0,0.0,0%,0.0,0.0,paul robert bonney,
-MGT,4160,1.0,Special Topics Hr,0.58,0.34,0.05,0.0,0.03,0%,0.0,0.0,kristin scott,
-MGT,4230,1.0,Intern Bus Mgt,0.17,0.06,0.56,0.06,0.06,0%,0.0,0.08,wayne stewart,
-MGT,4230,2.0,Intern Bus Mgt,0.31,0.14,0.47,0.02,0.04,0%,0.0,0.02,wayne stewart,
-MGT,4230,4.0,Intern Bus Mgt,0.13,0.36,0.47,0.0,0.04,0%,0.0,0.0,monica simsek,
-MGT,4230,5.0,Intern Bus Mgt,0.09,0.47,0.45,0.0,0.0,0%,0.0,0.0,monica simsek,
-MGT,4240,1.0,Global Supply Chain Mana,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,ahmet colak,
-MGT,4270,2.0,Managing Improvement,0.18,0.53,0.24,0.06,0.0,0%,0.0,0.0,lawrence fredendall,
-MGT,4310,1.0,Emp Rights & Resp,0.38,0.54,0.05,0.0,0.0,0%,0.0,0.03,leonard spooner,
-MGT,4350,1.0,Pers Interviewing,0.37,0.49,0.12,0.0,0.02,0%,0.0,0.0,philip roth,
-MGT,4500,3.0,Desc & Pred Business Anal,0.55,0.09,0.27,0.0,0.09,0%,0.0,0.0,zhihong ke,
-MGT,4520,1.0,Business Analysis,0.27,0.55,0.09,0.0,0.09,0%,0.0,0.0,russell purvis,
-MGT,4540,1.0,Business Analytics Progra,0.44,0.22,0.22,0.03,0.0,0%,0.0,0.08,hongki kim,
-MGT,4560,1.0,Business Data Managemen,0.57,0.37,0.03,0.03,0.0,0%,0.0,0.0,he li,
-MGT,4970,5.0,CI- Deloitte Consulting,0.79,0.05,0.0,0.0,0.0,0%,0.0,0.16,ryan toole,
-MGT,8690,1.0,Project Mgt,0.39,0.61,0.0,0.0,0.0,0%,0.0,0.0,russell purvis,
-MICR,2050,1.0,Introductory Micro,0.5,0.41,0.08,0.0,0.01,0%,0.0,0.0,john abercrombie,
-MICR,3050,1.0,General Microbiology,0.82,0.1,0.04,0.01,0.01,0%,0.0,0.02,tzuen-rong tzeng,
-MICR,3050,2.0,General Microbiology,0.46,0.32,0.14,0.06,0.01,0%,0.0,0.02,krista rudolph,
-MICR,3050,3.0,General Microbiology,0.54,0.31,0.12,0.04,0.0,0%,0.0,0.0,krista rudolph,
-MICR,4010,1.0,Microbial Diversity & Ecolo,0.7,0.21,0.07,0.02,0.0,0%,0.0,0.0,kristi whitehead,
-MICR,4010,2.0,Micro Diversity/Ecol (HON,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,kristi whitehead,True
-MICR,4050,1.0,Adv Microbial Ecol of Hum,0.67,0.21,0.06,0.04,0.01,0%,0.0,0.01,kristi whitehead,
-MICR,4140,1.0,Basic Immunology,0.83,0.15,0.0,0.0,0.0,0%,0.0,0.01,charles rice,
-MICR,4150,1.0,Microbial Genetics,0.19,0.49,0.21,0.09,0.02,0%,0.0,0.0,min cao,
-MICR,4160,1.0,Intro Virology,0.47,0.36,0.12,0.0,0.0,0%,0.0,0.05,kaustubha qanungo,
-MICR,4510,1.0,Advanced Microbiology II,0.28,0.67,0.0,0.0,0.06,0%,0.0,0.0,harry kurtz,
-MICR,4510,2.0,Advanced Microbiology II,0.21,0.58,0.21,0.0,0.0,0%,0.0,0.0,harry kurtz,
-MICR,4510,3.0,Advanced Microbiology II,0.15,0.38,0.38,0.0,0.08,0%,0.0,0.0,harry kurtz,
-MICR,6050,1.0,Adv Microbial Ecol of Hum,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,kristi whitehead,
-MICR,6140,1.0,Basic Immunology,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,charles rice,
-MICR,8040,1.0,Sel Top: MICR Core,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,barbara campbell,
-MICR,8070,1.0,Micro Journal Club,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,barbara campbell,
-MKT,3010,1.0,Principles of Marketing,0.21,0.31,0.31,0.11,0.03,0%,0.0,0.02,amanda cooper fine,
-MKT,3010,2.0,Principles of Marketing,0.23,0.35,0.27,0.09,0.04,0%,0.0,0.02,amanda cooper fine,
-MKT,3010,3.0,Principles of Marketing,0.3,0.33,0.23,0.08,0.03,0%,0.0,0.03,amanda cooper fine,
-MKT,3010,4.0,Principles of Marketing,0.57,0.29,0.07,0.01,0.01,0%,0.0,0.05,james gaubert,
-MKT,3010,5.0,Principles of Marketing,0.49,0.3,0.12,0.01,0.04,0%,0.0,0.03,james gaubert,
-MKT,3010,7.0,Principles of Marketing,0.49,0.37,0.07,0.01,0.02,0%,0.0,0.03,lura forcum,
-MKT,3020,1.0,Consumer Behavior,0.8,0.12,0.04,0.02,0.02,0%,0.0,0.0,cony ming shen ho shen,
-MKT,3020,2.0,Consumer Behavior,0.86,0.1,0.02,0.0,0.02,0%,0.0,0.0,cony ming shen ho shen,
-MKT,3020,3.0,Consumer Behavior,0.92,0.05,0.01,0.0,0.01,0%,0.0,0.0,cony ming shen ho shen,
-MKT,3020,5.0,Consumer Behavior,0.58,0.28,0.08,0.06,0.0,0%,0.0,0.0,anastasia thyroff,
-MKT,3020,6.0,Consumer Behavior,0.63,0.24,0.08,0.06,0.0,0%,0.0,0.0,anastasia thyroff,
-MKT,3210,1.0,Sports Marketing,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,delancy bennett s,
-MKT,3220,1.0,Social Media Marketing,0.74,0.15,0.04,0.04,0.02,0%,0.0,0.02,robert fitzwater,
-MKT,3310,1.0,Marketing Metrics & Analy,0.72,0.22,0.0,0.0,0.0,0%,0.0,0.06,oriana rachel aragon,
-MKT,3310,2.0,Marketing Metrics & Analy,0.63,0.2,0.14,0.03,0.0,0%,0.0,0.0,oriana rachel aragon,
-MKT,3310,3.0,Marketing Metrics & Analy,0.69,0.29,0.0,0.03,0.0,0%,0.0,0.0,xianyong wang,
-MKT,3310,4.0,Marketing Metrics & Analy,0.59,0.35,0.03,0.03,0.0,0%,0.0,0.0,xianyong wang,
-MKT,4200,2.0,Professional Selling,0.79,0.15,0.03,0.0,0.03,0%,0.0,0.0,jesse moore,
-MKT,4200,5.0,Professional Selling,0.86,0.1,0.03,0.0,0.0,0%,0.0,0.0,carter mcelveen,
-MKT,4200,6.0,Professional Selling,0.64,0.21,0.03,0.0,0.06,0%,0.0,0.06,jesse moore,
-MKT,4200,7.0,Professional Selling,0.75,0.21,0.0,0.0,0.0,0%,0.0,0.04,carter mcelveen,
-MKT,4220,1.0,Applied Selling,0.45,0.55,0.0,0.0,0.0,0%,0.0,0.0,ryan mullins,
-MKT,4230,2.0,Promotional Strategy,0.78,0.18,0.04,0.0,0.0,0%,0.0,0.0,michele cauley,
-MKT,4230,3.0,Promotional Strategy,0.5,0.43,0.04,0.02,0.02,0%,0.0,0.0,michele cauley,
-MKT,4230,4.0,Promotional Strategy,0.69,0.23,0.05,0.02,0.02,0%,0.0,0.0,michele cauley,
-MKT,4240,1.0,Sales Management,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,ryan mullins,
-MKT,4260,1.0,Business-to-Business,0.44,0.46,0.08,0.03,0.0,0%,0.0,0.0,james gaubert,
-MKT,4270,1.0,International Marketing,0.53,0.38,0.05,0.05,0.0,0%,0.0,0.0,xianyong wang,
-MKT,4270,2.0,International Marketing,0.52,0.36,0.12,0.0,0.0,0%,0.0,0.0,xianyong wang,
-MKT,4270,3.0,International Marketing,0.75,0.23,0.0,0.0,0.0,0%,0.0,0.03,thomas poehlman,
-MKT,4270,4.0,International Marketing,0.6,0.33,0.05,0.0,0.03,0%,0.0,0.0,thomas poehlman,
-MKT,4270,5.0,International Marketing,0.37,0.51,0.09,0.01,0.0,0%,0.0,0.01,xianyong wang,
-MKT,4280,1.0,Services Marketing,0.53,0.33,0.1,0.02,0.02,0%,0.0,0.0, scheinbaum,
-MKT,4280,2.0,Services Marketing,0.38,0.45,0.15,0.03,0.0,0%,0.0,0.0, scheinbaum,
-MKT,4310,1.0,Marketing Research,0.6,0.34,0.0,0.03,0.03,0%,0.0,0.0, giebelhausen,
-MKT,4310,2.0,Marketing Research,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0, giebelhausen,
-MKT,4310,3.0,Marketing Research,0.33,0.52,0.15,0.0,0.0,0%,0.0,0.0,peter weathers,
-MKT,4310,5.0,Marketing Research,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,scott darren swain,
-MKT,4430,1.0,Advertising Strategy,0.92,0.06,0.02,0.0,0.0,0%,0.0,0.0,scott darren swain,
-MKT,4500,1.0,Strategic Mktg Mgt,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,annette popp tower,
-MKT,4500,2.0,Strategic Mktg Mgt,0.4,0.48,0.08,0.0,0.04,0%,0.0,0.0,annette popp tower,
-MKT,4500,3.0,Strategic Mktg Mgt,0.2,0.48,0.32,0.0,0.0,0%,0.0,0.0,mary anne raymond,
-MKT,4500,4.0,Strategic Mktg Mgt,0.62,0.35,0.04,0.0,0.0,0%,0.0,0.0,michele cauley,
-ML,1010,1.0,Leadership Fundamentals I,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,joseph david velez,
-ML,1010,2.0,Leadership Fundamentals I,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,joseph david velez,
-ML,1010,3.0,Leadership Fundamentals I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,joseph david velez,
-ML,2010,1.0,Leadership Development I,0.88,0.06,0.0,0.0,0.06,0%,0.0,0.0,michael scott gibson,
-ML,2010,2.0,Leadership Development I,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,michael scott gibson,
-ML,2010,3.0,Leadership Development I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,michael scott gibson,
-ML,3010,2.0,Advanced Leadership I,0.95,0.0,0.0,0.0,0.0,0%,0.0,0.05,justin robert merhar,
-MSE,2100,1.0,Intro to Materials Science,0.46,0.39,0.07,0.02,0.04,0%,0.0,0.02,kimberly weirich,
-MSE,2100,2.0,Intro to Materials Science,0.3,0.4,0.15,0.04,0.06,0%,0.0,0.06,kai he,
-MSE,2100,3.0,Intro to Materials Science,0.95,0.05,0.0,0.0,0.0,0%,0.0,0.0,john ballato,
-MSE,2100,4.0,Intro to Materials Science,0.39,0.45,0.12,0.02,0.01,0%,0.0,0.01,mark alan johnson,
-MSE,2100,6.0,Intro to Materials Science,0.71,0.2,0.05,0.01,0.01,0%,0.0,0.01,olga kuksenok,
-MSE,3010,1.0,Materials Synthesis & Fabr,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,rakhee pani,
-MSE,3010,3.0,Materials Synthesis & Fabr,0.71,0.14,0.14,0.0,0.0,0%,0.0,0.0,rakhee pani,
-MSE,3260,2.0,Thermodynamics of Mater,0.22,0.41,0.19,0.06,0.06,0%,0.0,0.03,fei peng,
-MSE,3450,1.0,Practice of Materials Engr,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marek urban,
-MSE,3910,1.0,Research Fundamentals,0.68,0.05,0.11,0.05,0.0,0%,0.0,0.05,ulf daniel schiller,
-MSE,4130,1.0,Noncrystalline Materials,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,ming tang,
-MSE,4150,1.0,Polymer Science & Engine,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,olin mefford,
-MSE,4150,2.0,Polymer Science & Engine,0.73,0.13,0.08,0.0,0.01,0%,0.0,0.05,rakhee pani,
-MSE,4320,1.0,Manufacturing Proc & Syst,0.82,0.14,0.0,0.0,0.05,0%,0.0,0.0,john sanders,
-MSE,8000,1.0,Seminar in Materials Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,kai he,
-MSE,8100,1.0,Fundamentals of Materials,0.64,0.32,0.04,0.0,0.0,0%,0.0,0.0,rajendra bordia,
-MSE,8190,1.0,Inorgan Mater Characteriz,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,luiz jacobsohn,
-MSE,8260,1.0,Phase Equil Mat Sys,0.15,0.69,0.15,0.0,0.0,0%,0.0,0.0,stephen foulger,
-MSE,8270,1.0,Kin of Phase Tran,0.5,0.27,0.23,0.0,0.0,0%,0.0,0.0,konstantin kornev,
-MSE,8510,1.0,Polymer Science I,0.71,0.21,0.0,0.0,0.0,0%,0.0,0.07,marek urban,
-MSE,9910,19.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jianhua tong,
-MSE,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marek urban,
-MTSA,8420,1.0,Road Safety Culture,0.93,0.0,0.0,0.0,0.0,0%,0.0,0.07,kim alexander,
-MUSC,1420,1.0,Music Theory I,0.7,0.2,0.05,0.05,0.0,0%,0.0,0.0,linda li-bleuel,
-MUSC,1430,1.0,Aural Skills I,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,linda li-bleuel,
-MUSC,1510,2.0,Applied Music for Non Maj,0.58,0.17,0.0,0.08,0.0,0%,0.0,0.17,jonathan doyel,
-MUSC,2100,2.0,Music in the Western Worl,0.71,0.23,0.0,0.0,0.0,0%,0.0,0.06,rhea beth jacobus,
-MUSC,2100,5.0,Music in the Western Worl,0.95,0.03,0.0,0.0,0.03,0%,0.0,0.0,timothy ray hurlburt,
-MUSC,2100,6.0,Music in the Western Worl,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,david conley,
-MUSC,2100,7.0,Music in the Western Worl,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0,rhea beth jacobus,
-MUSC,2100,8.0,Music in the Western Worl,0.6,0.3,0.03,0.03,0.0,0%,0.0,0.03,rhea beth jacobus,
-MUSC,2100,11.0,Music in the Western Worl,0.84,0.03,0.06,0.0,0.0,0%,0.0,0.06,leslie taylor warlick,
-MUSC,2100,12.0,Music in the Western Worl,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,lea kibler,
-MUSC,2100,13.0,Music in the Western Worl,0.93,0.08,0.0,0.0,0.0,0%,0.0,0.0,david conley,
-MUSC,3120,1.0,History of Jazz,0.52,0.32,0.16,0.0,0.0,0%,0.0,0.0,richard goodstein,
-MUSC,3140,1.0,World Music,0.88,0.09,0.03,0.0,0.0,0%,0.0,0.0,paul buyer,
-MUSC,3180,1.0,Hist of Audio Tech,0.67,0.22,0.06,0.06,0.0,0%,0.0,0.0,bruce allen whisler,
-MUSC,3610,1.0,Marching Band,0.99,0.0,0.0,0.0,0.01,0%,0.0,0.01,mark spede,
-MUSC,3620,1.0,Symphonic Band,0.93,0.0,0.0,0.0,0.0,0%,0.0,0.02,mark spede,True
-MUSC,3690,1.0,Symphony Orchestra,0.93,0.0,0.0,0.0,0.02,0%,0.0,0.05,andrew levin,True
-MUSC,4150,1.0,Music Hist to 1750,0.86,0.07,0.07,0.0,0.0,0%,0.0,0.0,eric lapin,
-NPL,3000,1.0,Nonprofit Leadership,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,christina mazer,
-NPL,3000,2.0,Nonprofit Leadership,0.33,0.33,0.14,0.0,0.05,0%,0.0,0.14,bonnie stevens,
-NPL,3000,3.0,Nonprofit Leadership,0.35,0.48,0.17,0.0,0.0,0%,0.0,0.0,bonnie stevens,
-NPL,3000,4.0,Nonprofit Leadership,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,corey brookover,
-NPL,3000,5.0,Nonprofit Leadership,0.7,0.22,0.09,0.0,0.0,0%,0.0,0.0,lauren george,
-NPL,3000,6.0,Nonprofit Leadership,0.61,0.3,0.09,0.0,0.0,0%,0.0,0.0,corey brookover,
-NPL,3000,7.0,Nonprofit Leadership,0.62,0.33,0.0,0.0,0.0,0%,0.0,0.05,lauren george,
-NPL,3000,8.0,Nonprofit Leadership,0.8,0.08,0.04,0.0,0.04,0%,0.0,0.04,lauren george,
-NPL,3000,9.0,Nonprofit Leadership,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,lauren george,
-NPL,3000,10.0,Nonprofit Leadership,0.64,0.27,0.09,0.0,0.0,0%,0.0,0.0,christina mazer,
-NPL,3000,11.0,Nonprofit Leadership,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,christina mazer,
-NPL,3000,12.0,Nonprofit Leadership,0.58,0.29,0.08,0.04,0.0,0%,0.0,0.0,corey brookover,
-NPL,3000,13.0,Nonprofit Leadership,0.74,0.22,0.0,0.0,0.0,0%,0.0,0.04,corey brookover,
-NPL,3010,1.0,NPL Stakeholders,0.46,0.5,0.04,0.0,0.0,0%,0.0,0.0,christina mazer,
-NPL,3020,1.0,NPL Fundraising,0.78,0.14,0.08,0.0,0.0,0%,0.0,0.0,joan laura phillips,
-NPL,3030,1.0,NPL Personnel,0.91,0.03,0.0,0.0,0.0,0%,0.0,0.03,joan laura phillips,
-NPL,3040,1.0,NPL Risk Management,0.58,0.35,0.06,0.0,0.0,0%,0.0,0.0,daniel anderson,
-NPL,3050,1.0,Strat Social Media for NP,0.85,0.09,0.05,0.0,0.0,0%,0.0,0.0,randi plake,
-NPL,3050,2.0,Strat Social Media for NP,0.8,0.07,0.07,0.02,0.04,0%,0.0,0.0,randi plake,
-NPL,4900,1.0,Non-Profit Lead Preceptor,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,corey brookover,
-NURS,3030,1.0,Nursing of Adults,0.24,0.71,0.05,0.0,0.0,0%,0.0,0.0,lena marie burgess,
-NURS,3040,101.0,Pathophysiology,0.43,0.43,0.1,0.03,0.02,0%,0.0,0.0,catherine murton,
-NURS,3040,201.0,Pathophysiology,0.52,0.38,0.06,0.03,0.01,0%,0.0,0.0,amy boggs garrison,
-NURS,3040,300.0,Pathophysiology,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,amy boggs garrison,
-NURS,3040,401.0,Pathophysiology,0.64,0.32,0.05,0.0,0.0,0%,0.0,0.0,amy boggs garrison,
-NURS,3050,1.0,Psychosocial Nursing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,kevin earle busby,
-NURS,3100,1.0,Health Assessment,0.68,0.3,0.0,0.0,0.03,0%,0.0,0.0,tiffany leah stewart,
-NURS,3100,402.0,Health Assessment,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,jason thrift,
-NURS,3120,101.0,Foundations of Nursing,0.61,0.36,0.03,0.0,0.0,0%,0.0,0.0,jennifer bagwell,
-NURS,3120,211.0,Foundations of Nursing,0.48,0.52,0.0,0.0,0.0,0%,0.0,0.0,terri teramano,
-NURS,3120,212.0,Foundations of Nursing,0.28,0.56,0.16,0.0,0.0,0%,0.0,0.0,terri teramano,
-NURS,3120,411.0,Foundations of Nursing,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,terri teramano,
-NURS,3190,300.0,Health Assessment for RNs,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,tiffany leah stewart,
-NURS,3230,201.0,Gerontology Nursing,0.95,0.05,0.0,0.0,0.0,0%,0.0,0.0,zahra rahemi,
-NURS,3300,1.0,Research in Nursing,0.9,0.05,0.03,0.0,0.03,0%,0.0,0.0,veronica parker,
-NURS,3330,1.0,Health Care Genetics,0.41,0.51,0.05,0.02,0.0,0%,0.0,0.0,linda ward,
-NURS,3400,101.0,Pharmther Nursing,0.4,0.43,0.12,0.03,0.02,0%,0.0,0.0,catherine murton,
-NURS,3400,201.0,Pharmther Nursing,0.56,0.33,0.09,0.02,0.0,0%,0.0,0.0,jenna lynn seawright,
-NURS,3400,401.0,Pharmther Nursing,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,jenna lynn seawright,
-NURS,4010,1.0,Mental Health Nurs,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,lindsey garrard,
-NURS,4030,101.0,Complex Nursing of Adults,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,taylor jean oneal,
-NURS,4030,201.0,Complex Nursing of Adults,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,taylor jean oneal,
-NURS,4060,300.0,Issues in Professionalism,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,shirley mae timmons,
-NURS,4110,1.0,Nursing of Children,0.53,0.47,0.0,0.0,0.0,0%,0.0,0.0, elizabeth fisher,
-NURS,4120,1.0,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0%,0.0,0.0,erin nicole shepherd,
-NURS,4250,300.0,Community Nursing,0.62,0.31,0.0,0.0,0.08,0%,0.0,0.0,tiffany leah stewart,
-NURS,8040,401.0,Dev Nurs Knowledge,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,kim ann pickett,
-NURS,8050,400.0,Pharmaco Adv Nurs,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,tracy king fasolino,
-NURS,8050,401.0,Pharmaco Adv Nurs,0.67,0.25,0.0,0.0,0.08,0%,0.0,0.0,tracy king fasolino,
-NURS,8060,400.0,Advan Assessment for Nur,0.27,0.68,0.05,0.0,0.0,0%,0.0,0.0,jennifer geter rice,
-NURS,8090,400.0,Pathophysiology,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,tracy brock lowe,
-NURS,8180,400.0,Develop Family in Primary,0.33,0.5,0.0,0.0,0.0,0%,0.0,0.17,lisa miller,
-NURS,8190,400.0,Developing Family,0.38,0.56,0.0,0.0,0.0,0%,0.0,0.0,lisa miller,
-NURS,8200,400.0,Child & Adol Nursing,0.63,0.31,0.0,0.0,0.0,0%,0.0,0.0,heide temples,
-NURS,8220,401.0,Gerontology Nursing,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.0,nicole joy davis,
-NURS,8820,400.0,Primary Care Elders,0.75,0.0,0.0,0.0,0.0,0%,0.0,0.0,kimberly trammell,
-NUTR,2030,1.0,Intro Princ of Human Nutri,0.75,0.21,0.03,0.0,0.0,0%,0.0,0.01,bridgit corbett,
-NUTR,2030,2.0,Intro Princ of Human Nutri,0.47,0.42,0.07,0.0,0.0,0%,0.0,0.05,bridgit corbett,
-NUTR,2050,400.0,Nutrition for Nursing Prof,0.53,0.45,0.02,0.0,0.0,0%,0.0,0.0,bridgit corbett,
-NUTR,2160,1.0,Evidence-Based Nutrition,0.76,0.08,0.08,0.05,0.01,0%,0.0,0.01,angela fraser,
-NUTR,3020,1.0,Nutrition Assessment,0.8,0.18,0.0,0.0,0.0,0%,0.0,0.02,elliot jesch,
-NUTR,4240,1.0,Medical Nutr Thera I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,vivian haley-zitlin,
-NUTR,4510,1.0,Human Nutrition & Metab,0.2,0.3,0.3,0.05,0.13,0%,0.0,0.03,elliot jesch,
-PA,1010,1.0,Intro to Perf Arts,0.68,0.26,0.03,0.0,0.0,0%,0.0,0.03,david hartmann,
-PA,3010,1.0,Princip of Arts Administrati,0.38,0.46,0.08,0.08,0.0,0%,0.0,0.0,richard goodstein,
-PA,4010,1.0,Capstone Project,0.6,0.3,0.0,0.0,0.0,0%,0.0,0.0,bruce allen whisler,
-PADM,7020,400.0,Research Methods,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,ronald chrestman,
-PADM,7020,401.0,Research Methods,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,ronald chrestman,
-PADM,8220,400.0,Public Policy Process,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,mellott yazykova,
-PADM,8290,400.0,Public Financial Managem,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.0,robert frager,
-PADM,8410,402.0,Public Data Analysis,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,scott schmidt,
-PADM,8420,400.0,GIS for Public Administrato,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,david white,
-PADM,8500,400.0,Homeland Security Funda,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,lori ann dickes,
-PADM,8520,401.0,Emergency Mgt Planning,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,kevin todd staley,
-PADM,8630,400.0,Contemporary Admin Orgs,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,lori ann dickes,
-PADM,8640,400.0,Legal Aspects of Non-Profi,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,margaret elise baker,
-PADM,8670,401.0,State Government Admin,0.77,0.15,0.0,0.0,0.0,0%,0.0,0.0,alfred bundrick,
-PAS,3010,2.0,Intro to Pan African Studie,0.62,0.18,0.12,0.03,0.0,0%,0.0,0.06, stewart-tillman,
-PDBE,8120,1.0,Seminar in EDP,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mickey lauria,
-PDBE,8150,1.0,Research Design in EDP,0.63,0.0,0.38,0.0,0.0,0%,0.0,0.0,mickey lauria,
-PES,1040,1.0,Introduction to Plant Scien,0.78,0.16,0.03,0.0,0.0,0%,0.0,0.03,paula agudelo,
-PES,2020,1.0,Soils,0.57,0.31,0.1,0.02,0.0,0%,0.0,0.0,dara michelle park,
-PES,3150,1.0,Environment and Agricultu,0.62,0.33,0.05,0.0,0.0,0%,0.0,0.0,suseela appukuttan,
-PES,4090,1.0,Biology of Invasive Plants,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0, tharayil-,
-PES,4550,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, tharayil-,
-PES,4850,1.0,Environmental Soil Chemis,0.71,0.24,0.0,0.0,0.0,0%,0.0,0.06,haibo liu,
-PES,8250,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, tharayil-,
-PHIL,1010,1.0,Intro to Philosophic Proble,0.7,0.24,0.0,0.0,0.0,0%,0.0,0.06,david stegall,
-PHIL,1010,2.0,Intro to Philosophic Proble,0.54,0.34,0.06,0.0,0.0,0%,0.0,0.06,david stegall,
-PHIL,1010,3.0,Intro to Philosophic Proble,0.47,0.35,0.09,0.0,0.0,0%,0.0,0.09,david stegall,
-PHIL,1010,4.0,Intro to Philosophic Proble,0.65,0.24,0.06,0.0,0.06,0%,0.0,0.0,claire kirwin,
-PHIL,1010,5.0,Intro to Philosophic Proble,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,claire kirwin,
-PHIL,1020,1.0,Introduction to Logic,0.49,0.29,0.14,0.03,0.03,0%,0.0,0.03,pascal brixel,
-PHIL,1020,2.0,Introduction to Logic,0.69,0.23,0.09,0.0,0.0,0%,0.0,0.0,adam gies,
-PHIL,1020,3.0,Introduction to Logic,0.58,0.27,0.15,0.0,0.0,0%,0.0,0.0,adam gies,
-PHIL,1020,4.0,Introduction to Logic,0.37,0.43,0.14,0.03,0.0,0%,0.0,0.03,adam gies,
-PHIL,1020,5.0,Introduction to Logic,0.41,0.47,0.09,0.0,0.0,0%,0.0,0.03,edyta joanna kuzian,
-PHIL,1020,6.0,Introduction to Logic,0.46,0.4,0.11,0.03,0.0,0%,0.0,0.0,edyta joanna kuzian,
-PHIL,1020,7.0,Introduction to Logic,0.63,0.26,0.0,0.0,0.05,0%,0.0,0.05,pascal brixel,
-PHIL,1020,8.0,Introduction to Logic,0.36,0.47,0.11,0.0,0.03,0%,0.0,0.03,edyta joanna kuzian,
-PHIL,1020,9.0,Introduction to Logic,0.31,0.37,0.23,0.09,0.0,0%,0.0,0.0,adam gies,
-PHIL,1030,1.0,Introduction to Ethics,0.57,0.37,0.03,0.0,0.0,0%,0.0,0.03,daniel wueste,
-PHIL,1030,2.0,Introduction to Ethics,0.39,0.42,0.16,0.03,0.0,0%,0.0,0.0,charles starkey,
-PHIL,1030,3.0,Introduction to Ethics,0.81,0.1,0.0,0.0,0.05,0%,0.0,0.05,david stegall,
-PHIL,1030,4.0,Introduction to Ethics,0.57,0.23,0.17,0.03,0.0,0%,0.0,0.0,edyta joanna kuzian,
-PHIL,1030,5.0,Introduction to Ethics,0.47,0.39,0.0,0.03,0.06,0%,0.0,0.06,david antonini,
-PHIL,3040,1.0,Moral Philosophy,0.44,0.47,0.06,0.0,0.0,0%,0.0,0.03,todd may,
-PHIL,3150,2.0,Ancient Philosophy,0.66,0.2,0.06,0.03,0.03,0%,0.0,0.03,stephen satris,
-PHIL,3210,1.0,Crime & Punishment,0.53,0.41,0.06,0.0,0.0,0%,0.0,0.0,daniel wueste,
-PHIL,3260,1.0,Science and Values,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,david antonini,
-PHIL,3260,2.0,Science and Values,0.61,0.33,0.0,0.03,0.0,0%,0.0,0.03,david antonini,
-PHIL,3260,3.0,Science and Values,0.73,0.22,0.0,0.0,0.03,0%,0.0,0.03,kelly smith,
-PHIL,3300,1.0,Contemporary Issues in Ph,0.41,0.47,0.0,0.0,0.0,0%,0.0,0.06,todd may,
-PHIL,3330,1.0,Metaphysics,0.68,0.16,0.05,0.05,0.0,0%,0.0,0.05,adam gies,
-PHIL,3430,1.0,Philosophy of Law,0.35,0.47,0.18,0.0,0.0,0%,0.0,0.0,brookes brown,
-PHIL,3440,1.0,Business Ethics,0.18,0.58,0.15,0.0,0.0,0%,0.0,0.09,brookes brown,
-PHIL,3460,1.0,Biomedical Ethics,0.41,0.47,0.12,0.0,0.0,0%,0.0,0.0,charles starkey,
-PHIL,3480,1.0,Philosophies of Art,0.38,0.5,0.13,0.0,0.0,0%,0.0,0.0,edyta joanna kuzian,
-PHSC,1180,1.0,"Intro Phys, Astron & Earth",0.76,0.16,0.03,0.03,0.02,0%,0.0,0.0,minory nammouz,
-PHSC,1180,2.0,"Intro Phys, Astron & Earth",0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,minory nammouz,
-PHYS,1220,1.0,Physics with Calculus I,0.25,0.29,0.29,0.09,0.02,0%,0.0,0.07,lih-sin the,
-PHYS,1220,2.0,Physics with Calculus I,0.17,0.34,0.3,0.07,0.06,0%,0.0,0.05,lih-sin the,
-PHYS,1220,4.0,Physics with Calculus I,0.26,0.47,0.16,0.0,0.05,0%,0.0,0.05,hugo sanabria,
-PHYS,1220,5.0,Physics with Calculus I (HO,0.56,0.39,0.0,0.0,0.0,0%,0.0,0.06,emil georgiev alexov,True
-PHYS,1240,1.0,Physics Lab I,0.82,0.12,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,1240,2.0,Physics Lab I,0.67,0.11,0.17,0.0,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,1240,3.0,Physics Lab I,0.5,0.25,0.13,0.06,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,1240,4.0,Physics Lab I,0.53,0.24,0.0,0.12,0.06,0%,0.0,0.06,daniel thompson,
-PHYS,1240,6.0,Physics Lab I,0.67,0.22,0.11,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,1240,7.0,Physics Lab I,0.72,0.17,0.0,0.0,0.06,0%,0.0,0.06,daniel thompson,
-PHYS,1240,8.0,Physics Lab I,0.83,0.06,0.06,0.0,0.06,0%,0.0,0.0,daniel thompson,
-PHYS,1240,9.0,Physics Lab I,0.86,0.0,0.0,0.0,0.0,0%,0.0,0.14,daniel thompson,
-PHYS,1240,10.0,Physics Lab I,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.07,daniel thompson,
-PHYS,1240,11.0,Physics Lab I,0.67,0.06,0.06,0.0,0.11,0%,0.0,0.11,daniel thompson,
-PHYS,1240,12.0,Physics Lab I,0.7,0.2,0.1,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,1240,13.0,Physics Lab I,0.82,0.0,0.12,0.06,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,1240,14.0,Physics Lab I,0.72,0.11,0.0,0.11,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,1240,15.0,Physics Lab I,0.67,0.22,0.0,0.06,0.06,0%,0.0,0.0,daniel thompson,
-PHYS,1240,16.0,Physics Lab I,0.67,0.22,0.0,0.11,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,1240,17.0,Physics Lab I,0.78,0.06,0.06,0.06,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,1240,18.0,Physics Lab I,0.76,0.18,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,1240,19.0,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,1240,21.0,Physics Lab I,0.71,0.21,0.0,0.0,0.07,0%,0.0,0.0,daniel thompson,
-PHYS,1240,22.0,Physics Lab I,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,2070,1.0,General Physics I,0.32,0.29,0.18,0.06,0.08,0%,0.0,0.06,amy liann pope,
-PHYS,2070,2.0,General Physics I,0.42,0.32,0.13,0.04,0.03,0%,0.0,0.05,amy liann pope,
-PHYS,2070,3.0,General Physics I,0.46,0.29,0.15,0.05,0.02,0%,0.0,0.04,amy liann pope,
-PHYS,2080,1.0,General Physics II,0.35,0.41,0.13,0.03,0.05,0%,0.0,0.02,pooja puneet,
-PHYS,2090,1.0,Gen Phys Lab I,0.5,0.25,0.04,0.08,0.04,0%,0.0,0.08,daniel thompson,
-PHYS,2090,2.0,Gen Phys Lab I,0.57,0.35,0.09,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2090,3.0,Gen Phys Lab I,0.54,0.29,0.04,0.0,0.08,0%,0.0,0.04,daniel thompson,
-PHYS,2090,4.0,Gen Phys Lab I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2090,5.0,Gen Phys Lab I,0.63,0.21,0.13,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2090,6.0,Gen Phys Lab I,0.65,0.1,0.1,0.05,0.0,0%,0.0,0.1,daniel thompson,
-PHYS,2090,7.0,Gen Phys Lab I,0.74,0.26,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2090,8.0,Gen Phys Lab I,0.67,0.21,0.08,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2090,9.0,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2090,10.0,Gen Phys Lab I,0.7,0.22,0.0,0.0,0.04,0%,0.0,0.04,daniel thompson,
-PHYS,2090,11.0,Gen Phys Lab I,0.71,0.08,0.13,0.0,0.04,0%,0.0,0.04,daniel thompson,
-PHYS,2090,12.0,Gen Phys Lab I,0.91,0.04,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2090,13.0,Gen Phys Lab I,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2090,14.0,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2090,15.0,Gen Phys Lab I,0.54,0.25,0.13,0.0,0.0,0%,0.0,0.08,daniel thompson,
-PHYS,2090,16.0,Gen Phys Lab I,0.79,0.13,0.0,0.0,0.0,0%,0.0,0.08,daniel thompson,
-PHYS,2090,17.0,Gen Phys Lab I,0.83,0.09,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2090,18.0,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2090,19.0,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2090,20.0,Gen Phys Lab I,0.43,0.48,0.0,0.0,0.05,0%,0.0,0.05,daniel thompson,
-PHYS,2090,21.0,Gen Phys Lab I,0.72,0.22,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,2090,22.0,Gen Phys Lab I,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2090,23.0,Gen Phys Lab I,0.75,0.17,0.0,0.0,0.0,0%,0.0,0.08,daniel thompson,
-PHYS,2090,24.0,Gen Phys Lab I,0.58,0.21,0.11,0.0,0.0,0%,0.0,0.11,daniel thompson,
-PHYS,2090,25.0,Gen Phys Lab I,0.82,0.14,0.0,0.0,0.0,0%,0.0,0.05,daniel thompson,
-PHYS,2090,26.0,Gen Phys Lab I,0.36,0.36,0.14,0.05,0.0,0%,0.0,0.09,daniel thompson,
-PHYS,2090,27.0,Gen Phys Lab I,0.75,0.08,0.04,0.04,0.04,0%,0.0,0.04,daniel thompson,
-PHYS,2100,1.0,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2100,2.0,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2100,3.0,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2100,4.0,Gen Phys Lab II,0.91,0.0,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2100,6.0,Gen Phys Lab II,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2100,7.0,Gen Phys Lab II,0.88,0.04,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2100,8.0,Gen Phys Lab II,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2100,9.0,Gen Phys Lab II,0.96,0.0,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,
-PHYS,2210,1.0,Physics with Calculus II,0.24,0.37,0.27,0.04,0.02,0%,0.0,0.05,jason brown,
-PHYS,2210,2.0,Physics with Calculus II,0.46,0.37,0.11,0.04,0.01,0%,0.0,0.02,pooja puneet,
-PHYS,2210,3.0,Physics with Calculus II,0.28,0.39,0.19,0.07,0.04,0%,0.0,0.03,pooja puneet,
-PHYS,2210,4.0,Physics with Calculus II,0.26,0.43,0.19,0.07,0.03,0%,0.0,0.01,jason brown,
-PHYS,2210,5.0,Physics w/Calculus II(HON),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,endre andras takacs,True
-PHYS,2220,1.0,Physics with Calculus III,0.78,0.13,0.04,0.0,0.0,0%,0.0,0.04,murray daw,
-PHYS,2230,1.0,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,2.0,Physics Lab II,0.22,0.61,0.11,0.0,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,2230,3.0,Physics Lab II,0.39,0.5,0.06,0.06,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,4.0,Physics Lab II,0.44,0.44,0.11,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,5.0,Physics Lab II,0.74,0.26,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,6.0,Physics Lab II,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,7.0,Physics Lab II,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,9.0,Physics Lab II,0.72,0.28,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,10.0,Physics Lab II,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,11.0,Physics Lab II,0.2,0.67,0.07,0.0,0.0,0%,0.0,0.07,daniel thompson,
-PHYS,2230,12.0,Physics Lab II,0.72,0.22,0.0,0.0,0.06,0%,0.0,0.0,daniel thompson,
-PHYS,2230,13.0,Physics Lab II,0.67,0.17,0.11,0.0,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,2230,14.0,Physics Lab II,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
-PHYS,2230,15.0,Physics Lab II,0.22,0.67,0.0,0.0,0.0,0%,0.0,0.11,daniel thompson,
-PHYS,2240,1.0,Physics Lab III,0.75,0.13,0.06,0.0,0.0,0%,0.0,0.06,daniel thompson,
-PHYS,2450,1.0,Physics of Climate,0.62,0.23,0.06,0.01,0.02,0%,0.0,0.06,jens oberheide,
-PHYS,3000,1.0,Intro to Research,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,jianbo gao,
-PHYS,3120,1.0,Meth Theor Phys II,0.64,0.18,0.09,0.09,0.0,0%,0.0,0.0,lih-sin the,
-PHYS,3150,1.0,Intro to Computational Ph,0.46,0.27,0.19,0.0,0.0,0%,0.0,0.08,jason brown,
-PHYS,3210,1.0,Mechanics I,0.48,0.35,0.06,0.0,0.03,0%,0.0,0.06,feng ding,
-PHYS,3250,1.0,Electronics for Physicists,0.74,0.21,0.05,0.0,0.0,0%,0.0,0.0,chad sosolik,
-PHYS,4410,1.0,Electromagnetics I,0.47,0.29,0.12,0.0,0.06,0%,0.0,0.06,ramakrishna podila,
-PHYS,4550,1.0,Quantum Physics I,0.48,0.24,0.19,0.05,0.0,0%,0.0,0.05,gerald lehmacher,
-PHYS,8110,1.0,Meth of Theor Phys I,0.23,0.77,0.0,0.0,0.0,0%,0.0,0.0,domnita marinescu,
-PHYS,8180,1.0,Cellular Biophysics,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,joshua alper,
-PHYS,8210,1.0,Classical Mech I,0.18,0.82,0.0,0.0,0.0,0%,0.0,0.0,stephen kaeppler,
-PHYS,8750,2.0,Intro to Research Seminar,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,jianbo gao,
-PHYS,8750,13.0,Numerical Fluid Dynamics,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,xian lu,
-PHYS,9510,1.0,Quantum Mech I,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,sumanta tewari,
-PHYS,9530,1.0,Quantum Field Theory,0.44,0.56,0.0,0.0,0.0,0%,0.0,0.0,bradley meyer,
-PHYS,9910,12.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marco ajello,
-PKSC,1010,1.0,Pkgsc Orientation,0.82,0.12,0.04,0.02,0.0,0%,0.0,0.0,marcondes guerra,
-PKSC,1020,1.0,Intro to Pkg Sci,0.24,0.24,0.28,0.13,0.08,0%,0.0,0.04,heather batt,
-PKSC,2010,1.0,Pkg Perishable Prod,0.08,0.35,0.32,0.11,0.05,0%,0.0,0.08,heather batt,
-PKSC,2020,1.0,Packaging Mtl & Mfg,0.3,0.3,0.38,0.02,0.0,0%,0.0,0.0,marcondes guerra,
-PKSC,2040,1.0,Container Systems,0.2,0.6,0.13,0.07,0.0,0%,0.0,0.0,marcondes guerra,
-PKSC,2060,1.0,Container Sys Lab,0.57,0.36,0.07,0.0,0.0,0%,0.0,0.0,marcondes guerra,
-PKSC,2200,1.0,Product & Pkg Design,0.76,0.2,0.05,0.0,0.0,0%,0.0,0.0,haley ellis appleby,
-PKSC,3200,1.0,Pkg Design Theory,0.79,0.11,0.0,0.0,0.0,0%,0.0,0.11,rupert hurley,
-PKSC,4010,1.0,Packaging Machinery,0.09,0.6,0.26,0.0,0.04,0%,0.0,0.02,anthony pometto,
-PKSC,4040,1.0,Protective Packaging Prop,0.22,0.35,0.25,0.07,0.05,0%,0.0,0.05,gregory batt,
-PKSC,4160,1.0,Application of Polymers in,0.3,0.52,0.13,0.0,0.0,0%,0.0,0.05,alicia campbell,
-PKSC,4200,1.0,Package Design & Develop,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,robert kimmel,
-PKSC,4540,1.0,Product & Pkg Evaluation L,0.44,0.56,0.0,0.0,0.0,0%,0.0,0.0,gregory batt,
-PKSC,4540,3.0,Product & Pkg Evaluation L,0.19,0.5,0.19,0.06,0.0,0%,0.0,0.06,gregory batt,
-PKSC,4540,5.0,Product & Pkg Evaluation L,0.07,0.64,0.07,0.0,0.07,0%,0.0,0.14,gregory batt,
-PKSC,4640,1.0,Food & Health Care Pkg Sy,0.73,0.19,0.06,0.0,0.02,0%,0.0,0.0,kay cooksey,
-PLPA,3100,1.0,Principles of Plant Patholo,0.31,0.31,0.24,0.07,0.07,0%,0.0,0.0,steven nye jeffers,
-PLPA,8020,1.0,Principles of Plant Patholo,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,steven nye jeffers,
-POSC,1010,1.0,Amer National Govt,0.11,0.58,0.16,0.11,0.05,0%,0.0,0.0,robert carey,
-POSC,1010,2.0,Amer National Govt,0.35,0.43,0.18,0.0,0.02,0%,0.0,0.02,robert carey,
-POSC,1010,3.0,Amer National Govt,0.6,0.36,0.0,0.0,0.0,0%,0.0,0.04,joseph earl stewart,
-POSC,1010,4.0,Amer National Govt,0.46,0.36,0.12,0.0,0.02,0%,0.0,0.04,robert carey,
-POSC,1020,1.0,Intro Intl Relations,0.77,0.15,0.05,0.02,0.02,0%,0.0,0.0,steven vincent miller,
-POSC,1020,2.0,Intro Intl Relations,0.42,0.39,0.11,0.03,0.03,0%,0.0,0.03, petersheim,
-POSC,1020,3.0,Intro Intl Relations,0.36,0.45,0.07,0.0,0.07,0%,0.0,0.05,tara elizabeth trask,
-POSC,1020,4.0,Intro Intl Relations,0.55,0.41,0.0,0.0,0.04,0%,0.0,0.0,colin denby pearce,
-POSC,1020,5.0,Intro Intl Relations,0.35,0.4,0.09,0.01,0.09,0%,0.0,0.06,tara elizabeth trask,
-POSC,1030,1.0,Intro to Political Theory,0.66,0.21,0.03,0.03,0.03,0%,0.0,0.03,adam thomas,
-POSC,1030,2.0,Intro to Political Theory,0.33,0.61,0.0,0.0,0.06,0%,0.0,0.0,colin denby pearce,
-POSC,1030,3.0,Intro to Political Theory,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,derek neal duplessie,
-POSC,1030,4.0,Intro to Political Theory,0.48,0.28,0.17,0.0,0.07,0%,0.0,0.0,brandon turner,
-POSC,1030,5.0,Intro to Political Theory,0.71,0.17,0.08,0.0,0.0,0%,0.0,0.04,jay hoffpauir,
-POSC,1030,8.0,Intro to Political Theory,0.27,0.5,0.1,0.07,0.03,0%,0.0,0.03,elizabeth 'arrivee,
-POSC,1040,1.0,Intro Compar Pol,0.17,0.34,0.19,0.05,0.17,0%,0.0,0.07,katherine curtis,
-POSC,1040,2.0,Intro Compar Pol,0.47,0.29,0.06,0.04,0.04,0%,0.0,0.1, rhodes-purdy,
-POSC,1990,1.0,Intro Pol Sci,0.52,0.36,0.1,0.0,0.02,0%,0.0,0.0, petersheim,
-POSC,3020,1.0,State and Loc Gov,0.3,0.58,0.0,0.0,0.02,0%,0.0,0.06,bruce ransom,
-POSC,3410,1.0,Quant Meth in Pol Sc,0.23,0.27,0.23,0.0,0.18,0%,0.0,0.05,steven vincent miller,
-POSC,3610,1.0,International Conflict,0.4,0.23,0.13,0.06,0.06,0%,0.0,0.11,tara elizabeth trask,
-POSC,3620,1.0,Intl Organizations,0.31,0.31,0.17,0.1,0.03,0%,0.0,0.07,zeynep taydas,
-POSC,3620,2.0,Intl Organizations,0.37,0.33,0.07,0.15,0.07,0%,0.0,0.0,zeynep taydas,
-POSC,3630,1.0,Us Foreign Policy,0.68,0.24,0.0,0.0,0.08,0%,0.0,0.0,vladimir matic,
-POSC,3630,2.0,Us Foreign Policy,0.18,0.52,0.12,0.0,0.12,0%,0.0,0.06,jeffrey scott peake,
-POSC,3750,1.0,European Integration,0.21,0.32,0.16,0.11,0.13,0%,0.0,0.08,katherine curtis,
-POSC,4050,1.0,The American Presidency,0.31,0.42,0.06,0.02,0.06,0%,0.0,0.13,adam warber,
-POSC,4090,2.0,Dir Stud in American Politi,0.79,0.0,0.05,0.0,0.0,0%,0.0,0.05,karyn jones,
-POSC,4210,1.0,Public Policy,0.58,0.15,0.04,0.04,0.12,0%,0.0,0.04,grant anthony allard,
-POSC,4230,1.0,Urban Politics,0.53,0.27,0.0,0.0,0.13,0%,0.0,0.0,bruce ransom,
-POSC,4360,1.0,Law Courts Politics,0.77,0.18,0.0,0.0,0.0,0%,0.0,0.0,joseph earl stewart,
-POSC,4360,2.0,Law Courts Politics,0.89,0.07,0.0,0.0,0.0,0%,0.0,0.02,joseph earl stewart,
-POSC,4370,1.0,Constitut Law: Rights & Lib,0.5,0.27,0.14,0.02,0.05,0%,0.0,0.02,kevin gregory vance,
-POSC,4370,2.0,Constitut Law: Rights & Lib,0.66,0.3,0.02,0.0,0.0,0%,0.0,0.02,kevin gregory vance,
-POSC,4420,1.0,Pol Parties & Elect,0.43,0.32,0.19,0.05,0.0,0%,0.0,0.0,laura olson,
-POSC,4490,1.0,Political Theory of Capitalis,0.38,0.52,0.05,0.0,0.05,0%,0.0,0.0,colin denby pearce,
-POSC,4490,2.0,Political Theory of Capitalis,0.62,0.3,0.05,0.0,0.03,0%,0.0,0.0,brandon turner,
-POSC,4500,1.0,Rev. Constitutionalism,0.75,0.08,0.08,0.0,0.08,0%,0.0,0.0, bradley thompson,
-POSC,4550,1.0,Pol Thght of American Fou,0.73,0.22,0.04,0.02,0.0,0%,0.0,0.0,jay hoffpauir,
-POSC,4760,1.0,Middle East Politics,0.84,0.11,0.0,0.0,0.0,0%,0.0,0.05,vladimir matic,
-POSC,4770,1.0,Chinese Politics,0.53,0.27,0.0,0.0,0.0,0%,0.0,0.07,xiaobo hu,
-POSC,4890,1.0,Populism,0.69,0.15,0.0,0.0,0.0,0%,0.0,0.15, rhodes-purdy,
-POST,9000,1.0,Prof Development Public P,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,laura olson,
-PRTM,1980,1.0,Creative Inquiry in PRTM I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,denise anderson,
-PRTM,2000,1.0,Profession & Practice in PR,0.86,0.09,0.05,0.0,0.0,0%,0.0,0.0,teresa tucker,
-PRTM,2000,2.0,Profession & Practice in PR,0.79,0.16,0.05,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,
-PRTM,2000,3.0,Profession & Practice in PR,0.68,0.26,0.05,0.0,0.0,0%,0.0,0.0,herbert chancellor,
-PRTM,2000,4.0,Profession & Practice in PR,0.68,0.11,0.0,0.05,0.16,0%,0.0,0.0,jeffrey townsend,
-PRTM,2000,5.0,Profession & Practice in PR,0.74,0.16,0.0,0.11,0.0,0%,0.0,0.0,thomas ray clanton,
-PRTM,2060,1.0,Practicum I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,
-PRTM,2070,1.0,Practicum II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,
-PRTM,2070,2.0,Practicum II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,adam savedra,
-PRTM,2110,1.0,Sts Play Rec Tourism,0.84,0.09,0.02,0.0,0.04,0%,0.0,0.01,matthew browning,
-PRTM,2200,1.0,Foundations of PRTM,0.82,0.14,0.05,0.0,0.0,0%,0.0,0.0,teresa tucker,
-PRTM,2200,2.0,Foundations of PRTM,0.53,0.42,0.05,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,
-PRTM,2200,3.0,Foundations of PRTM,0.63,0.32,0.0,0.05,0.0,0%,0.0,0.0,herbert chancellor,
-PRTM,2200,4.0,Foundations of PRTM,0.37,0.42,0.11,0.05,0.05,0%,0.0,0.0,jeffrey townsend,
-PRTM,2200,5.0,Foundations of PRTM,0.65,0.29,0.06,0.0,0.0,0%,0.0,0.0,thomas ray clanton,
-PRTM,2260,1.0,Fnd of Mgt Adm PRTM,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,teresa tucker,
-PRTM,2260,2.0,Fnd of Mgt Adm PRTM,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,
-PRTM,2260,3.0,Fnd of Mgt Adm PRTM,0.68,0.21,0.11,0.0,0.0,0%,0.0,0.0,herbert chancellor,
-PRTM,2260,4.0,Fnd of Mgt Adm PRTM,0.58,0.32,0.0,0.05,0.05,0%,0.0,0.0,jeffrey townsend,
-PRTM,2260,5.0,Fnd of Mgt Adm PRTM,0.74,0.21,0.05,0.0,0.0,0%,0.0,0.0,thomas ray clanton,
-PRTM,2290,1.0,Competency Integration in,0.68,0.23,0.09,0.0,0.0,0%,0.0,0.0,teresa tucker,
-PRTM,2290,2.0,Competency Integration in,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,
-PRTM,2290,3.0,Competency Integration in,0.63,0.11,0.16,0.11,0.0,0%,0.0,0.0,herbert chancellor,
-PRTM,2290,4.0,Competency Integration in,0.42,0.37,0.11,0.0,0.11,0%,0.0,0.0,jeffrey townsend,
-PRTM,2290,5.0,Competency Integration in,0.58,0.26,0.05,0.11,0.0,0%,0.0,0.0,thomas ray clanton,
-PRTM,3050,1.0,Safety/Risk Mgt PRTM,0.47,0.27,0.2,0.0,0.0,0%,0.0,0.07,alexsandra dubin,
-PRTM,3070,2.0,Facility Operations,0.77,0.13,0.1,0.0,0.0,0%,0.0,0.0,raymond dunham,
-PRTM,3200,1.0,Recreation Policy,0.55,0.18,0.09,0.0,0.05,0%,0.0,0.14,matthew brownlee,
-PRTM,3220,1.0,Facilitation Techniques in,0.71,0.19,0.1,0.0,0.0,0%,0.0,0.0,stephen lewis,
-PRTM,3240,1.0,Assessment & Planning in,0.48,0.38,0.1,0.05,0.0,0%,0.0,0.0,deborah anne tysor,
-PRTM,3300,1.0,Visit Ser & Interp,0.42,0.26,0.21,0.05,0.05,0%,0.0,0.0,harper aby lat sene lat,
-PRTM,3420,1.0,Intro to Tourism,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,ellen wamilika koppa,
-PRTM,3430,1.0,Spl Asp of Tourist B,0.62,0.33,0.0,0.0,0.0,0%,0.0,0.05,william norman,
-PRTM,3460,1.0,Heritage Tourism,0.4,0.33,0.13,0.0,0.07,0%,0.0,0.0,gregory ramshaw,
-PRTM,3470,1.0,Sport Tourism,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,felipe tobar,
-PRTM,3520,1.0,Camp Org and Admin,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,alexsandra dubin,
-PRTM,3600,1.0,Recreation & Amateur Spo,0.36,0.18,0.18,0.0,0.09,0%,0.0,0.09,skye arthur-banning,
-PRTM,3920,1.0,Special Event Managemen,0.96,0.0,0.04,0.0,0.0,0%,0.0,0.0,kenneth backman,
-PRTM,3920,2.0,Special Event Managemen,0.83,0.1,0.05,0.03,0.0,0%,0.0,0.0,kenneth backman,
-PRTM,4030,1.0,Elem of Rec/Pk Plan,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,samuel gaines,
-PRTM,4040,1.0,Field Training I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,
-PRTM,4050,1.0,Field Training II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,
-PRTM,4210,1.0,Rec Fin Resc Mgt,0.68,0.21,0.09,0.02,0.0,0%,0.0,0.0,robert brookover,
-PRTM,4220,2.0,Management of RT Service,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,deborah anne tysor,
-PRTM,4230,1.0,Adaptive Sports & Recreati,0.56,0.17,0.11,0.11,0.06,0%,0.0,0.0,jasmine townsend,
-PRTM,4450,1.0,Conventions,0.79,0.14,0.0,0.0,0.0,0%,0.0,0.07,lauren townson,
-PRTM,4470,1.0,Perspect Intl Travel,0.89,0.0,0.05,0.0,0.0,0%,0.0,0.05,sheila backman,
-PRTM,4510,1.0,Seminar in CRSCM,0.5,0.3,0.1,0.05,0.03,0%,0.0,0.03,iryna sharaievska,
-PRTM,4540,1.0,Trends in Sport Mgt,0.75,0.13,0.06,0.0,0.0,0%,0.0,0.06,skye arthur-banning,
-PRTM,4550,1.0,Adv Program Planning,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,mariela fernandez,
-PRTM,4740,2.0,Adv Rec Resource Mgt,0.81,0.05,0.14,0.0,0.0,0%,0.0,0.0,benjamin fowler,
-PRTM,8070,3.0,Human Dimen of Rec Beha,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,john adam beeco,
-PRTM,8080,2.0,Behavioral Aspects,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,lauren duffy,
-PRTM,8710,1.0,Applied Research in Rec Th,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,brandi crowe,
-PRTM,8720,1.0,Adv Facilitation Techniq in,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,brandi crowe,
-PRTM,8750,1.0,Program Plan & Consult in,0.64,0.27,0.0,0.0,0.0,0%,0.0,0.0,stephen lewis,
-PRTM,9000,11.0,Adv Data Analysis in PRTM,0.5,0.38,0.0,0.0,0.0,0%,0.0,0.13,ryan joseph gagnon,
-PRTM,9100,1.0,Research Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brett wright,
-PRTM,9110,2.0,Classroom Management,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gwynn powell,
-PSYC,2010,1.0,Intro to Psychology,0.33,0.34,0.19,0.03,0.01,0%,0.0,0.06,jo jorgensen,
-PSYC,2010,2.0,Intro to Psychology,0.28,0.33,0.21,0.08,0.03,0%,0.0,0.03,jo jorgensen,
-PSYC,2010,3.0,Intro to Psychology,0.25,0.33,0.22,0.06,0.06,0%,0.0,0.08,edwin brainerd,
-PSYC,2010,4.0,Intro to Psychology,0.77,0.19,0.04,0.0,0.0,0%,0.0,0.0,mary taylor,
-PSYC,2010,5.0,Intro to Psychology,0.63,0.27,0.03,0.01,0.04,0%,0.0,0.02,chong hyon pak,
-PSYC,2010,6.0,Intro to Psychology,0.66,0.19,0.08,0.05,0.02,0%,0.0,0.0,chong hyon pak,
-PSYC,2010,7.0,Intro to Psychology,0.51,0.33,0.09,0.03,0.01,0%,0.0,0.03,fred switzer,
-PSYC,2030,1.0,Fundamentals of Psych Sci,0.62,0.25,0.07,0.03,0.02,0%,0.0,0.02,fred switzer,
-PSYC,3060,1.0,Human Sexual Behavior,0.58,0.22,0.11,0.03,0.03,0%,0.0,0.03,bruce michael king,
-PSYC,3090,100.0,Intro Experimental Psychol,0.44,0.38,0.13,0.02,0.01,0%,0.0,0.03,jennifer bailey bisson,
-PSYC,3090,200.0,Intro Experimental Psychol,0.16,0.53,0.28,0.0,0.0,0%,0.0,0.03,eric mckibben,
-PSYC,3090,300.0,Intro Experimental Psychol,0.48,0.39,0.1,0.0,0.0,0%,0.0,0.03,alexander moore,
-PSYC,3100,100.0,Advanced Experimental Ps,0.71,0.21,0.03,0.03,0.03,0%,0.0,0.0,peggy jean tyler,
-PSYC,3100,220.0,Advanced Experimental Ps,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,thomas britt,
-PSYC,3100,230.0,Advanced Experimental Ps,0.68,0.26,0.05,0.0,0.0,0%,0.0,0.0,william volante,
-PSYC,3100,240.0,Advanced Experimental Ps,0.42,0.37,0.16,0.0,0.05,0%,0.0,0.0,william volante,
-PSYC,3100,250.0,Advanced Experimental Ps,0.57,0.33,0.05,0.0,0.0,0%,0.0,0.05,sarah mae sanborn,
-PSYC,3100,260.0,Advanced Experimental Ps,0.37,0.53,0.05,0.0,0.0,0%,0.0,0.0,leo gugerty,
-PSYC,3100,270.0,Advanced Experimental Ps,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,benjamin stephens,
-PSYC,3100,280.0,Advanced Experimental Ps,0.74,0.16,0.11,0.0,0.0,0%,0.0,0.0,martha thompson,
-PSYC,3100,290.0,Advanced Experimental Ps,0.42,0.42,0.0,0.11,0.0,0%,0.0,0.0,kaileigh angela byrne,
-PSYC,3210,1.0,Psychology of Music,0.52,0.2,0.24,0.04,0.0,0%,0.0,0.0,claudio cantalupo,
-PSYC,3240,1.0,Physiological Psych,0.64,0.19,0.09,0.03,0.04,0%,0.0,0.01,claudio cantalupo,
-PSYC,3240,2.0,Physiological Psych,0.5,0.31,0.09,0.04,0.04,0%,0.0,0.01,claudio cantalupo,
-PSYC,3240,3.0,Physiological Psych,0.53,0.31,0.1,0.03,0.02,0%,0.0,0.0,claudio cantalupo,
-PSYC,3240,4.0,Physiological Psych,0.43,0.38,0.1,0.01,0.01,0%,0.0,0.06,june pilcher,
-PSYC,3330,1.0,Cognitive Psych,0.55,0.32,0.06,0.04,0.03,0%,0.0,0.0,dawn marie sarno,
-PSYC,3330,2.0,Cognitive Psych,0.63,0.23,0.08,0.03,0.03,0%,0.0,0.0,kathryn lucaites,
-PSYC,3340,1.0,Cognitive Psych Lab,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,hannah solini,
-PSYC,3340,2.0,Cognitive Psych Lab,0.76,0.19,0.0,0.0,0.0,0%,0.0,0.0,hannah solini,
-PSYC,3400,1.0,Lifespan Developmental Ps,0.38,0.39,0.16,0.01,0.03,0%,0.0,0.03,pamela alley,
-PSYC,3400,2.0,Lifespan Developmental Ps,0.33,0.43,0.11,0.09,0.02,0%,0.0,0.02,pamela alley,
-PSYC,3400,3.0,Lifespan Developmental Ps,0.73,0.17,0.08,0.01,0.0,0%,0.0,0.01,sarah mae sanborn,
-PSYC,3520,1.0,Social Psychology,0.88,0.09,0.02,0.01,0.0,0%,0.0,0.0,ceren gunsoy,
-PSYC,3520,902.0,Social Psychology (HON),0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,robin marie kowalski,True
-PSYC,3570,1.0,Psychology and Culture,0.73,0.17,0.06,0.02,0.01,0%,0.0,0.0,ceren gunsoy,
-PSYC,3640,1.0,Industrial Psych,0.43,0.46,0.07,0.04,0.0,0%,0.0,0.0,eric mckibben,
-PSYC,3640,2.0,Industrial Psych,0.75,0.12,0.06,0.0,0.06,0%,0.0,0.01,joseph ligato,
-PSYC,3680,1.0,Organizational Psych,0.45,0.51,0.02,0.0,0.02,0%,0.0,0.0,chloe wilson,
-PSYC,3700,1.0,Personality,0.54,0.34,0.1,0.0,0.03,0%,0.0,0.0,john robert hester,
-PSYC,3830,1.0,Abnormal Psychology,0.38,0.41,0.12,0.09,0.0,0%,0.0,0.0,pamela alley,
-PSYC,3830,2.0,Abnormal Psychology,0.43,0.23,0.14,0.11,0.06,0%,0.0,0.03,pamela alley,
-PSYC,3890,1.0,Psychology of Religion,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,zhuo chen,
-PSYC,4080,901.0,Women and Psychology,0.64,0.2,0.08,0.0,0.04,0%,0.0,0.04,robin marie kowalski,
-PSYC,4150,1.0,Systems and Theories,0.51,0.31,0.11,0.03,0.0,0%,0.0,0.03,edwin brainerd,
-PSYC,4150,2.0,Systems and Theories,0.5,0.25,0.08,0.08,0.06,0%,0.0,0.03,edwin brainerd,
-PSYC,4220,1.0,Perception,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,christopher pagano,
-PSYC,4350,1.0,Human Factors,0.3,0.48,0.04,0.0,0.0,0%,0.0,0.13,dustin souders,
-PSYC,4430,1.0,Infant & Child Dev,0.71,0.26,0.03,0.0,0.0,0%,0.0,0.0,sarah mae sanborn,
-PSYC,4800,1.0,Health Psychology,0.65,0.31,0.04,0.0,0.0,0%,0.0,0.0,james mccubbin,
-PSYC,4800,2.0,Health Psychology,0.8,0.16,0.04,0.0,0.0,0%,0.0,0.0,james mccubbin,
-PSYC,4820,1.0,Positive Psychology,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,cynthia pury s,
-PSYC,4880,1.0,Psychotherapy,0.6,0.12,0.12,0.0,0.0,0%,0.0,0.08,heidi marie zinzow,
-PSYC,4890,1.0,Sport Psychology,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,eric mckibben,
-PSYC,4890,2.0,Cross-Cultural Human Dev,0.55,0.23,0.09,0.09,0.0,0%,0.0,0.0,susan limber,
-PSYC,4930,100.0,Pract Clinical Psych,0.81,0.06,0.0,0.0,0.0,0%,0.0,0.13,lucinda quick,
-PSYC,4930,200.0,Pract Clinical Psych,0.88,0.06,0.0,0.0,0.06,0%,0.0,0.0,heidi marie zinzow,
-PSYC,4970,919.0,Directed Studies,0.89,0.02,0.0,0.0,0.0,0%,0.0,0.05,karyn jones,
-PSYC,8100,1.0,Research Design I,0.76,0.21,0.0,0.0,0.0,0%,0.0,0.03,patrick rosopa,
-PSYC,8220,1.0,Percept & Perform,0.75,0.19,0.0,0.0,0.0,0%,0.0,0.06,richard tyrrell,
-RED,8010,1.0,Market Analysis,0.67,0.22,0.06,0.0,0.0,0%,0.0,0.06,robert benedict,
-RED,8020,1.0,Development Tour,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert benedict,
-RED,8100,1.0,Real Est Roundtable,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,robert benedict,
-RED,8130,1.0,Strat in Real Estate,0.62,0.31,0.08,0.0,0.0,0%,0.0,0.0,kimbrell cary hughes,
-RED,8890,1.0,Selected Topics-Adv. Fin.,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,larry bradley harvey,
-REL,1010,1.0,Intro to Religion,0.58,0.32,0.0,0.05,0.05,0%,0.0,0.0,peter cohen,
-REL,1010,2.0,Intro to Religion,0.45,0.41,0.05,0.0,0.09,0%,0.0,0.0,peter cohen,
-REL,1010,3.0,Intro to Religion,0.79,0.18,0.0,0.0,0.03,0%,0.0,0.0,peter cohen,
-REL,1020,2.0,World Religions,0.56,0.29,0.12,0.03,0.0,0%,0.0,0.0,robert stephens,
-REL,1020,3.0,World Religions,0.51,0.26,0.14,0.0,0.0,0%,0.0,0.09,robert stephens,
-REL,1020,4.0,World Religions,0.47,0.5,0.03,0.0,0.0,0%,0.0,0.0,robert stephens,
-REL,3010,1.0,Old Testament,0.56,0.21,0.12,0.03,0.0,0%,0.0,0.09,john thames,
-REL,3060,1.0,Judaism,0.52,0.21,0.07,0.0,0.0,0%,0.0,0.21,john thames,
-REL,3070,1.0,The Christian Tradition,0.34,0.52,0.14,0.0,0.0,0%,0.0,0.0,brett patterson,
-REL,3100,1.0,History of Religion in the U,0.5,0.33,0.11,0.0,0.06,0%,0.0,0.0,elizabeth jemison,
-REL,3110,1.0,African American Rel,0.54,0.17,0.13,0.0,0.0,0%,0.0,0.13,elizabeth jemison,
-REL,3120,1.0,Hinduism,0.29,0.29,0.14,0.14,0.0,0%,0.0,0.14,robert stephens,
-REL,4210,1.0,Koine Greek of the New Te,0.5,0.0,0.13,0.19,0.13,0%,0.0,0.06,benjamin white,
-RUD,8610,1.0,Urban Design Seminar I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0, wortham-galvin,
-RUSS,3400,1.0,19th C Russ Culture,0.58,0.29,0.08,0.0,0.0,0%,0.0,0.0,olga volkova,
-RUSS,3610,1.0,Russn Lit Since 1910,0.52,0.35,0.13,0.0,0.0,0%,0.0,0.0,olga volkova,
-SOC,2010,1.0,Introduction to Sociology,0.8,0.17,0.01,0.0,0.01,0%,0.0,0.02,carolyn coffman,
-SOC,2010,2.0,Introduction to Sociology,0.58,0.34,0.08,0.0,0.0,0%,0.0,0.0,jennifer holland,
-SOC,2010,3.0,Introduction to Sociology,0.8,0.18,0.01,0.0,0.01,0%,0.0,0.0,carolyn coffman,
-SOC,2010,4.0,Introduction to Sociology,0.9,0.08,0.01,0.0,0.0,0%,0.0,0.01, mannheimer,
-SOC,2010,5.0,Introduction to Sociology,0.77,0.15,0.04,0.02,0.02,0%,0.0,0.0, mcdonough,
-SOC,2010,6.0,Introduction to Sociology,0.75,0.16,0.05,0.02,0.01,0%,0.0,0.02, mcdonough,
-SOC,2010,7.0,Introduction to Sociology,0.8,0.1,0.04,0.0,0.02,0%,0.0,0.04,thomas maher,
-SOC,2040,1.0,Prof Dev for Sociology Maj,0.35,0.26,0.13,0.09,0.13,0%,0.0,0.04, catherine mobley,
-SOC,3020,1.0,Research Methods I,0.59,0.23,0.07,0.05,0.02,0%,0.0,0.05,thomas maher,
-SOC,3020,2.0,Research Methods I,0.32,0.5,0.11,0.03,0.03,0%,0.0,0.03,miao li,
-SOC,3040,1.0,Social Research Methods II,0.28,0.38,0.1,0.1,0.07,0%,0.0,0.07,ye luo,
-SOC,3040,2.0,Social Research Methods II,0.33,0.56,0.11,0.0,0.0,0%,0.0,0.0,william haller,
-SOC,3110,1.0,The Family,0.84,0.1,0.04,0.0,0.02,0%,0.0,0.0,carolyn coffman,
-SOC,3600,1.0,Class & Poverty,0.57,0.28,0.09,0.04,0.0,0%,0.0,0.02,kenneth robinson,
-SOC,3910,1.0,Soc of Deviance,0.58,0.29,0.05,0.04,0.02,0%,0.0,0.02, mcdonough,
-SOC,3940,1.0,Sociology of Mental Illness,0.88,0.04,0.0,0.0,0.0,0%,0.0,0.02,james rosenberger,
-SOC,4030,1.0,Environmental Sociology,0.5,0.33,0.08,0.04,0.0,0%,0.0,0.04, catherine mobley,
-SOC,4040,1.0,Soc Theory,0.44,0.33,0.11,0.06,0.06,0%,0.0,0.0,matthew costello,
-SOC,4140,1.0,Policy&Social Change,0.6,0.31,0.1,0.0,0.0,0%,0.0,0.0,jennifer holland,
-SOC,4440,1.0,Sociology of Educ,0.73,0.16,0.02,0.0,0.02,0%,0.0,0.02, mannheimer,
-SOC,4600,1.0,Race & Ethnicity,0.86,0.08,0.06,0.0,0.0,0%,0.0,0.0, mannheimer,
-SOC,4610,1.0,Sex & Gender,0.67,0.24,0.03,0.0,0.03,0%,0.0,0.03,carolyn coffman,
-SOC,4710,1.0,World Population and Soci,0.43,0.36,0.0,0.07,0.0,0%,0.0,0.14,ye luo,
-SOC,8120,1.0,Social Stratification,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.1,william haller,
-SOC,8970,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,natallia sianko,
-SPAN,1010,1.0,Elementary Spanish,0.71,0.25,0.04,0.0,0.0,0%,0.0,0.0,stephanie morris,
-SPAN,1010,2.0,Elementary Spanish,0.71,0.21,0.08,0.0,0.0,0%,0.0,0.0,stephanie morris,
-SPAN,1010,3.0,Elementary Spanish,0.42,0.29,0.17,0.04,0.0,0%,0.0,0.08,rosa pillcurima,
-SPAN,1020,1.0,Elementary Spanish,0.39,0.43,0.13,0.0,0.0,0%,0.0,0.04,rosa pillcurima,
-SPAN,1020,2.0,Elementary Spanish,0.48,0.35,0.04,0.0,0.0,0%,0.0,0.13,debra williamson,
-SPAN,1020,3.0,Elementary Spanish,0.48,0.3,0.17,0.0,0.04,0%,0.0,0.0,yezid flores,
-SPAN,1020,4.0,Elementary Spanish,0.58,0.33,0.04,0.0,0.04,0%,0.0,0.0,yezid flores,
-SPAN,1020,5.0,Elementary Spanish,0.86,0.0,0.0,0.0,0.0,0%,0.0,0.14,liliana hernandez,
-SPAN,1020,6.0,Elementary Spanish,0.27,0.53,0.13,0.07,0.0,0%,0.0,0.0,valderramos cruz,
-SPAN,1020,8.0,Elementary Spanish,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,valderramos cruz,
-SPAN,1020,9.0,Elementary Spanish,0.52,0.43,0.05,0.0,0.0,0%,0.0,0.0,yezid flores,
-SPAN,1020,10.0,Elementary Spanish,0.86,0.09,0.05,0.0,0.0,0%,0.0,0.0,liliana hernandez,
-SPAN,1020,13.0,Elementary Spanish,0.26,0.43,0.17,0.09,0.0,0%,0.0,0.04,melva persico,
-SPAN,2010,1.0,Intermediate Spanish,0.45,0.32,0.05,0.0,0.05,0%,0.0,0.14,debra williamson,
-SPAN,2010,2.0,Intermediate Spanish,0.48,0.43,0.05,0.0,0.0,0%,0.0,0.05,debra williamson,
-SPAN,2010,3.0,Intermediate Spanish,0.71,0.04,0.17,0.04,0.0,0%,0.0,0.04,ellory schmucker,
-SPAN,2010,4.0,Intermediate Spanish,0.65,0.26,0.0,0.0,0.09,0%,0.0,0.0,ellory schmucker,
-SPAN,2010,7.0,Intermediate Spanish,0.67,0.13,0.13,0.04,0.0,0%,0.0,0.04,ellory schmucker,
-SPAN,2010,8.0,Intermediate Spanish,0.57,0.33,0.05,0.0,0.0,0%,0.0,0.05,debra williamson,
-SPAN,2010,9.0,Intermediate Spanish,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,liliana hernandez,
-SPAN,2010,10.0,Intermediate Spanish,0.5,0.46,0.04,0.0,0.0,0%,0.0,0.0,vieyra daniel garcia,
-SPAN,2010,11.0,Intermediate Spanish,0.43,0.43,0.04,0.0,0.0,0%,0.0,0.09,vieyra daniel garcia,
-SPAN,2010,12.0,Intermediate Spanish,0.75,0.13,0.04,0.04,0.0,0%,0.0,0.04,ellory schmucker,
-SPAN,2010,13.0,Intermediate Spanish,0.79,0.08,0.08,0.0,0.04,0%,0.0,0.0,liliana hernandez,
-SPAN,2010,14.0,Intermediate Spanish,0.55,0.18,0.0,0.0,0.09,0%,0.0,0.18,valderramos cruz,
-SPAN,2010,15.0,Intermediate Spanish,0.61,0.3,0.04,0.0,0.0,0%,0.0,0.04,valderramos cruz,
-SPAN,2010,16.0,Intermediate Spanish,0.57,0.26,0.09,0.0,0.0,0%,0.0,0.09,yezid flores,
-SPAN,2010,17.0,Intermediate Spanish,0.37,0.37,0.26,0.0,0.0,0%,0.0,0.0,nora arostegui logue,
-SPAN,2010,18.0,Intermediate Spanish,0.57,0.3,0.04,0.04,0.0,0%,0.0,0.04,nora arostegui logue,
-SPAN,2010,28.0,Intermediate Spanish,0.4,0.4,0.1,0.1,0.0,0%,0.0,0.0,yezid flores,
-SPAN,2020,2.0,Intermediate Spanish,0.35,0.25,0.15,0.05,0.1,0%,0.0,0.1,melva persico,
-SPAN,2020,4.0,Intermediate Spanish,0.52,0.22,0.17,0.04,0.0,0%,0.0,0.04,rodriguez garcia,
-SPAN,2020,5.0,Intermediate Spanish,0.83,0.08,0.04,0.0,0.04,0%,0.0,0.0,mercedes tejera,
-SPAN,2020,6.0,Intermediate Spanish,0.5,0.25,0.04,0.0,0.0,0%,0.0,0.21,rosa pillcurima,
-SPAN,2020,7.0,Intermediate Spanish,0.63,0.21,0.0,0.08,0.0,0%,0.0,0.08,rosa pillcurima,
-SPAN,2020,8.0,Intermediate Spanish,0.5,0.35,0.1,0.05,0.0,0%,0.0,0.0,ana paula  miller e,
-SPAN,2020,9.0,Intermediate Spanish,0.33,0.33,0.24,0.0,0.0,0%,0.0,0.1,ana paula  miller e,
-SPAN,2020,10.0,Intermediate Spanish,0.62,0.19,0.1,0.0,0.0,0%,0.0,0.1,ana paula  miller e,
-SPAN,2020,11.0,Intermediate Spanish,0.43,0.33,0.05,0.1,0.0,0%,0.0,0.1,melva persico,
-SPAN,2020,13.0,Intermediate Spanish,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,nora arostegui logue,
-SPAN,2020,14.0,Intermediate Spanish,0.58,0.33,0.0,0.0,0.08,0%,0.0,0.0,nora arostegui logue,
-SPAN,2020,15.0,Intermediate Spanish,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,mercedes tejera,
-SPAN,2020,16.0,Intermediate Spanish,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,mercedes tejera,
-SPAN,3020,1.0,Intermed Span Grammar,0.41,0.41,0.09,0.0,0.0,0%,0.0,0.09,vieyra daniel garcia,
-SPAN,3020,2.0,Intermed Span Grammar,0.68,0.18,0.0,0.0,0.0,0%,0.0,0.14,george palacios,
-SPAN,3020,3.0,Intermed Span Grammar,0.67,0.17,0.0,0.0,0.04,0%,0.0,0.13,vieyra daniel garcia,
-SPAN,3020,4.0,Intermed Span Grammar,0.29,0.57,0.07,0.0,0.07,0%,0.0,0.0,melva persico,
-SPAN,3040,1.0,Intro Hispanic Literary For,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,graciela tissera,
-SPAN,3040,2.0,Intro Hispanic Literary For,0.42,0.33,0.17,0.08,0.0,0%,0.0,0.0,rodriguez garcia,
-SPAN,3050,1.0,Intermed Span Convers/Co,0.32,0.47,0.16,0.0,0.0,0%,0.0,0.05,rodriguez garcia,
-SPAN,3050,2.0,Intermed Span Convers/Co,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,andrea naranjo,
-SPAN,3050,3.0,Intermed Span Convers/Co,0.61,0.09,0.04,0.0,0.0,0%,0.0,0.26,vieyra daniel garcia,
-SPAN,3060,1.0,Span Comp for Bus,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,andrea naranjo,
-SPAN,3070,1.0,The Hispanic World: Spain,0.74,0.16,0.0,0.0,0.05,0%,0.0,0.05,raquel anido,
-SPAN,3080,1.0,The Hispanic World: Latin,0.7,0.09,0.09,0.0,0.09,0%,0.0,0.0,george palacios,
-SPAN,3130,1.0,Span Lit Survey I,0.28,0.44,0.17,0.0,0.0,0%,0.0,0.11, rojas-de-massei,
-SPAN,3140,1.0,Hispanic Linguistics,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,daniel smith,
-SPAN,3150,2.0,Spanish for Health Prof,0.86,0.1,0.05,0.0,0.0,0%,0.0,0.0,riquelme judez,
-SPAN,3180,1.0,Spanish Through Culture,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,salvador oropesa,
-SPAN,4010,1.0,New Spanish Fiction,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,graciela tissera,
-SPAN,4060,1.0,Narrative Fiction,0.33,0.47,0.07,0.07,0.0,0%,0.0,0.07, rojas-de-massei,
-SPAN,4070,1.0,Hispanic Film,0.8,0.12,0.0,0.04,0.04,0%,0.0,0.0,raquel anido,
-SPAN,4160,1.0,Spanish for Int'l Business II,0.73,0.09,0.0,0.0,0.18,0%,0.0,0.0,andrea naranjo,
-SPAN,4190,1.0,Health & Hispanic Commu,0.7,0.25,0.0,0.0,0.0,0%,0.0,0.05,peralta arelis moore,
-STAT,2220,1.0,Statistics in Everyday Life,0.33,0.23,0.23,0.12,0.04,0%,0.0,0.05,james espey,
-STAT,2220,2.0,Statistics in Everyday Life,0.25,0.41,0.23,0.05,0.02,0%,0.0,0.04,james espey,
-STAT,2220,3.0,Statistics in Everyday Life,0.29,0.34,0.16,0.12,0.08,0%,0.0,0.03,james espey,
-STAT,2220,4.0,Statistics in Everyday Life,0.24,0.43,0.23,0.09,0.01,0%,0.0,0.0,james espey,
-STAT,2220,5.0,Statistics in Everyday Life,0.19,0.32,0.29,0.14,0.06,0%,0.0,0.0, martinez-dawson,
-STAT,2220,6.0,Statistics in Everyday Life,0.24,0.39,0.2,0.09,0.05,0%,0.0,0.04, martinez-dawson,
-STAT,2220,7.0,Statistics in Everyday Life,0.3,0.24,0.28,0.1,0.05,0%,0.0,0.04, martinez-dawson,
-STAT,2300,1.0,Statistical Methods I,0.2,0.23,0.27,0.15,0.15,0%,0.0,0.0,anna marie vagnozzi,
-STAT,2300,2.0,Statistical Methods I,0.33,0.34,0.17,0.08,0.03,0%,0.0,0.04,paran norton,
-STAT,2300,3.0,Statistical Methods I,0.39,0.3,0.15,0.07,0.05,0%,0.0,0.03,paran norton,
-STAT,2300,4.0,Statistical Methods I,0.28,0.26,0.24,0.07,0.1,0%,0.0,0.05, erwin walker,
-STAT,2300,5.0,Statistical Methods I,0.23,0.4,0.19,0.09,0.06,0%,0.0,0.03, erwin walker,
-STAT,2300,6.0,Statistical Methods I,0.31,0.3,0.2,0.08,0.04,0%,0.0,0.07,thomas demarco,
-STAT,2300,100.0,Statistical Methods I (HON,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,paran norton,True
-STAT,3090,1.0,Introductory Business Stat,0.23,0.3,0.35,0.0,0.09,0%,0.0,0.02,fun choi john chan john,
-STAT,3090,2.0,Introductory Business Stat,0.22,0.33,0.26,0.13,0.02,0%,0.0,0.04,trevor camper,
-STAT,3090,3.0,Introductory Business Stat,0.62,0.22,0.09,0.04,0.0,0%,0.0,0.02,anna marie vagnozzi,
-STAT,3090,4.0,Introductory Business Stat,0.44,0.36,0.16,0.0,0.02,0%,0.0,0.02, jayasekara,
-STAT,3090,5.0,Introductory Business Stat,0.41,0.17,0.26,0.09,0.04,0%,0.0,0.02,tyler melton,
-STAT,3090,6.0,Introductory Business Stat,0.37,0.28,0.17,0.07,0.04,0%,0.0,0.07,sean ingimarson,
-STAT,3090,7.0,Introductory Business Stat,0.35,0.24,0.24,0.04,0.09,0%,0.0,0.04,yangyi li,
-STAT,3090,8.0,Introductory Business Stat,0.34,0.22,0.22,0.1,0.1,0%,0.0,0.02,seyed hamid nazari,
-STAT,3090,9.0,Introductory Business Stat,0.42,0.18,0.11,0.13,0.09,0%,0.0,0.07,na guo,
-STAT,3090,10.0,Introductory Business Stat,0.29,0.29,0.27,0.11,0.02,0%,0.0,0.02,na guo,
-STAT,3090,11.0,Introductory Business Stat,0.42,0.31,0.2,0.04,0.02,0%,0.0,0.0,tiantian yang,
-STAT,3090,12.0,Introductory Business Stat,0.28,0.31,0.21,0.05,0.1,0%,0.0,0.05,marwah soliman,
-STAT,3090,13.0,Introductory Business Stat,0.42,0.2,0.3,0.02,0.04,0%,0.0,0.02,april thomas,
-STAT,3090,14.0,Introductory Business Stat,0.48,0.36,0.14,0.0,0.0,0%,0.0,0.02,april thomas,
-STAT,3090,15.0,Introductory Business Stat,0.33,0.28,0.12,0.05,0.14,0%,0.0,0.09,marwah soliman,
-STAT,3090,16.0,Introductory Business Stat,0.52,0.24,0.15,0.02,0.04,0%,0.0,0.02,anna marie vagnozzi,
-STAT,3090,17.0,Introductory Business Stat,0.37,0.37,0.21,0.0,0.02,0%,0.0,0.02,molly honecker,
-STAT,3090,18.0,Introductory Business Stat,0.29,0.4,0.2,0.02,0.04,0%,0.0,0.04,shuai wei,
-STAT,3090,19.0,Introductory Business Stat,0.37,0.29,0.18,0.02,0.06,0%,0.0,0.06,caroline kerfonta,
-STAT,3090,20.0,Introductory Business Stat,0.6,0.14,0.18,0.02,0.02,0%,0.0,0.04,zhengxin wang,
-STAT,3090,21.0,Introductory Business Stat,0.43,0.19,0.24,0.12,0.02,0%,0.0,0.0,anna marie vagnozzi,
-STAT,3300,1.0,Statistical Methods II,0.35,0.3,0.25,0.05,0.0,0%,0.0,0.05, martinez-dawson,
-STAT,4020,401.0,Intro to Statistical Computi,0.67,0.14,0.0,0.0,0.0,0%,0.0,0.19,ellen hepfer breazel,
-STAT,4020,402.0,Intro to Statistical Computi,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,zhiyun gong,
-STAT,4110,1.0,Stat Mthds for Process Co,0.58,0.37,0.0,0.05,0.0,0%,0.0,0.0,na guo,
-STAT,4110,2.0,Stat Mthds for Process Co,0.72,0.25,0.0,0.03,0.0,0%,0.0,0.0,na guo,
-STAT,4110,3.0,Stat Mthds for Process Co,0.58,0.33,0.09,0.0,0.0,0%,0.0,0.0,william bridges,
-STAT,4110,4.0,Stat Mthds for Process Co,0.44,0.13,0.28,0.0,0.06,0%,0.0,0.09,yu-bo wang,
-STAT,4110,5.0,Stat Mthds for Process Co,0.38,0.34,0.24,0.0,0.0,0%,0.0,0.03,yu-bo wang,
-STAT,6020,401.0,Intro to Statistical Computi,0.62,0.23,0.15,0.0,0.0,0%,0.0,0.0,ellen hepfer breazel,
-STAT,8010,1.0,Statistical Methods I,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,joseph daniel bible,
-STAT,8010,2.0,Statistical Methods I,0.48,0.43,0.05,0.0,0.05,0%,0.0,0.0,joseph daniel bible,
-STAT,8010,3.0,Statistical Methods I,0.68,0.18,0.14,0.0,0.0,0%,0.0,0.0,brook thayer russell,
-STAT,8010,4.0,Statistical Methods I,0.85,0.05,0.05,0.0,0.0,0%,0.0,0.05,jun luo,
-STAT,8010,5.0,Statistical Methods I,0.5,0.27,0.18,0.0,0.0,0%,0.0,0.0,patrick gerard,
-STAT,8020,1.0,Statistical Methods II,0.94,0.03,0.03,0.0,0.0,0%,0.0,0.0,whitney huang,
-STAT,8030,1.0,Regress & Least Squares A,0.75,0.08,0.08,0.0,0.0,0%,0.0,0.08,jun luo,
-STAT,8050,1.0,Design & Anlys of Experim,0.61,0.36,0.0,0.0,0.04,0%,0.0,0.0,william bridges,
-STS,1010,1.0,Survey Sci & Techn in Soci,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.03,yang wu,
-STS,1010,2.0,Survey Sci & Techn in Soci,0.58,0.36,0.03,0.0,0.03,0%,0.0,0.0,scott brame,
-STS,1010,3.0,Survey Sci & Techn in Soci,0.69,0.23,0.09,0.0,0.0,0%,0.0,0.0,elizabeth stansell,
-STS,1010,4.0,Survey Sci & Techn in Soci,0.85,0.06,0.0,0.0,0.06,0%,0.0,0.03,mary katherine fidler,
-STS,1010,5.0,Survey Sci & Techn in Soci,0.78,0.17,0.03,0.0,0.03,0%,0.0,0.0,tareva johnson,
-STS,1010,7.0,Survey Sci & Techn in Soci,0.74,0.2,0.03,0.0,0.0,0%,0.0,0.03,philip randall,
-STS,1010,8.0,Survey Sci & Techn in Soci,0.82,0.03,0.03,0.03,0.0,0%,0.0,0.09,david charles foltz,
-STS,1010,9.0,Survey Sci & Techn in Soci,0.41,0.32,0.15,0.06,0.06,0%,0.0,0.0,megan macalystre,
-STS,1010,10.0,Survey Sci & Techn in Soci,0.88,0.06,0.03,0.0,0.0,0%,0.0,0.03,alexander billinis,
-STS,1010,11.0,Survey Sci & Techn in Soci,0.89,0.06,0.03,0.03,0.0,0%,0.0,0.0,anne grant,
-STS,1010,12.0,Survey Sci & Techn in Soci,0.15,0.38,0.15,0.06,0.18,0%,0.0,0.06,chelsea marie clarey,
-THEA,2100,1.0,Theatre Appreciation,0.69,0.22,0.06,0.03,0.0,0%,0.0,0.0,david hartmann,
-THEA,2100,3.0,Theatre Appreciation,0.61,0.21,0.09,0.03,0.03,0%,0.0,0.03,kendra johnson,
-THEA,2100,6.0,Theatre Appreciation,0.81,0.13,0.03,0.03,0.0,0%,0.0,0.0,jason adkins,
-THEA,2100,7.0,Theatre Appreciation,0.72,0.22,0.03,0.0,0.03,0%,0.0,0.0,jason adkins,
-THEA,2770,1.0,Prod Studies in Thea,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,david hartmann,
-THEA,3150,1.0,Theatre History I,0.79,0.15,0.03,0.0,0.0,0%,0.0,0.03,shannon robert,
-THEA,3170,1.0,African-Amer Thea I,0.65,0.12,0.18,0.0,0.06,0%,0.0,0.0,kendra johnson,
-THEA,3470,1.0,Structure of Drama,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,carol collins,
-THEA,3720,1.0,Creative Drama,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,carol collins,
-THEA,3760,1.0,Stage Directing I,0.55,0.27,0.09,0.09,0.0,0%,0.0,0.0,becky becker,
-WFB,3010,2.0,Wildlife Biology Lab,0.57,0.36,0.07,0.0,0.0,0%,0.0,0.0,shari lynn rodriguez,
-WFB,4100,2.0,Wildlife Management Tech,0.53,0.26,0.12,0.06,0.03,0%,0.0,0.0,catherine jachowski,
-WFB,4120,1.0,Wildlife Management,0.59,0.3,0.07,0.0,0.04,0%,0.0,0.0,greg yarrow,
-WFB,4180,2.0,Fisheries Mgt & Conservati,0.57,0.29,0.0,0.07,0.0,0%,0.0,0.07,troy mason farmer,
-WFB,4440,1.0,Wildlife Damage Manage,0.41,0.52,0.07,0.0,0.0,0%,0.0,0.0,greg yarrow,
-WFB,4770,1.0,Ichthyology,0.53,0.4,0.0,0.07,0.0,0%,0.0,0.0,luke bower,
-WFB,4800,1.0,Waterfowl Ecology & Man,0.28,0.31,0.21,0.08,0.0,0%,0.0,0.13,richard kaminski,
-WFB,6200,2.0,Environmental Education,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,althea hagan,
-WFB,6620,1.0,Wetland Wildlife Biology,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,russell barrett,
-WFB,6800,1.0,Waterfowl Ecology & Man,0.69,0.19,0.0,0.0,0.0,0%,0.0,0.06,richard kaminski,
-WFB,8530,2.0,Global Change Ecology,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,lydia ries 'halloran,
-WFB,8610,5.0,Intro to Scientific Writing,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,stefanie whitmire,
-WFB,8610,6.0,Conservation PhysiologyO,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,patrick jodice,
-WFB,8610,11.0,Study Design & Data Analy,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.0,brandon peoples,
-WFB,8610,30.0,Human Dimensions of WL,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,shari lynn rodriguez,
-WS,1030,1.0,Women in Global Perspect,0.72,0.14,0.03,0.03,0.07,0%,0.0,0.0,sarah mae cooper,
-WS,1030,2.0,Women in Global Perspect,0.59,0.38,0.0,0.0,0.0,0%,0.0,0.03,sarah mae cooper,
-WS,2300,1.0,Women and Leadership I,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,mary price,
-WS,4010,1.0,Senior Seminar,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.08,diane perpich,
-YDP,3000,1.0,Youth Development in Soci,0.73,0.19,0.04,0.0,0.0,0%,0.0,0.04,lauren stephens,
-YDP,3050,1.0,Theory/Phil of Youth Dev,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,lauren stephens,
-YDP,3200,1.0,Youth Dev in Sport/Phys A,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,lauren stephens,
-YDP,3300,1.0,Designing Effective Youth,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,kellye rembert,
-YDP,3300,2.0,Designing Effective Youth,0.29,0.58,0.04,0.04,0.0,0%,0.0,0.04,allison avishai,
-YDP,3350,1.0,Youth Activity Leadership,0.81,0.11,0.07,0.0,0.0,0%,0.0,0.0,lauren stephens,
-YDP,3450,1.0,Creative Activities for Yout,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,kimberly johnson,
-YDP,4500,1.0,Prof Iss & Ethics in Youth D,0.69,0.23,0.08,0.0,0.0,0%,0.0,0.0,michele little kukler,
-YDP,8000,1.0,Theories of Youth Develop,0.76,0.14,0.0,0.0,0.0,0%,0.0,0.03,edmond bowers,
-YDP,8050,1.0,Youth Dev in Context of Fa,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.06,william quinn,
-YDP,8060,2.0,Youth Dev in Global Societ,0.67,0.13,0.07,0.0,0.13,0%,0.0,0.0,ann marie gillard,
-YDP,8080,1.0,Grantsmanship,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,anna- chancellor,
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors,CourseId,Year
+AAH,1010,1.0,Survey of Art & Arch Histor,0.51,0.4,0.04,0.02,0.0,0%,0.0,0.03,beth ann lauritis,,AAH-1010,2020
+AAH,2050,1.0,Art History and Theory I,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.0,beth ann lauritis,,AAH-2050,2020
+AAH,3050,1.0,Contemporary Art History,0.58,0.37,0.0,0.05,0.0,0%,0.0,0.0,andrea feeser,,AAH-3050,2020
+ACCT,2010,1.0,Financial Accounting Conc,0.36,0.38,0.2,0.02,0.02,0%,0.0,0.02,lydia schleifer,,ACCT-2010,2020
+ACCT,2010,2.0,Financial Accounting Conc,0.44,0.31,0.15,0.02,0.04,0%,0.0,0.05,lydia schleifer,,ACCT-2010,2020
+ACCT,2010,3.0,Financial Accounting Conc,0.17,0.32,0.25,0.07,0.12,0%,0.0,0.07,robert wahlman,,ACCT-2010,2020
+ACCT,2010,4.0,Financial Accounting Conc,0.26,0.26,0.26,0.13,0.03,0%,0.0,0.08,charles tegen,,ACCT-2010,2020
+ACCT,2010,5.0,Financial Accounting Conc,0.41,0.36,0.13,0.03,0.05,0%,0.0,0.03,charles tegen,,ACCT-2010,2020
+ACCT,2010,6.0,Financial Accounting Conc,0.45,0.33,0.05,0.05,0.05,0%,0.0,0.08,julie grant,,ACCT-2010,2020
+ACCT,2010,7.0,Financial Accounting Conc,0.21,0.44,0.31,0.03,0.0,0%,0.0,0.03,julie grant,,ACCT-2010,2020
+ACCT,2010,8.0,Financial Accounting Conc,0.51,0.33,0.07,0.07,0.0,0%,0.0,0.02,lydia schleifer,,ACCT-2010,2020
+ACCT,2010,9.0,Financial Accounting Conc,0.38,0.3,0.18,0.1,0.05,0%,0.0,0.0,julie grant,,ACCT-2010,2020
+ACCT,2010,10.0,Financial Accounting Conc,0.5,0.2,0.23,0.08,0.0,0%,0.0,0.0,julie grant,,ACCT-2010,2020
+ACCT,2010,11.0,Financial Accounting Conc,0.35,0.31,0.21,0.04,0.08,0%,0.0,0.0,lisa birtwistle,,ACCT-2010,2020
+ACCT,2010,12.0,Financial Accounting Conc,0.28,0.39,0.25,0.0,0.03,0%,0.0,0.03,lisa birtwistle,,ACCT-2010,2020
+ACCT,2010,13.0,Financial Accounting Conc,0.34,0.39,0.13,0.03,0.05,0%,0.0,0.05,lisa birtwistle,,ACCT-2010,2020
+ACCT,2010,14.0,Financial Accounting Conc,0.18,0.32,0.28,0.1,0.0,0%,0.0,0.12,jeffrey mcmillan,,ACCT-2010,2020
+ACCT,2010,15.0,Financial Accounting Conc,0.23,0.34,0.31,0.03,0.0,0%,0.0,0.09,carl hollingsworth,,ACCT-2010,2020
+ACCT,2010,400.0,Financial Accounting Conc,0.09,0.28,0.36,0.12,0.05,0%,0.0,0.1,jeffrey mcmillan,,ACCT-2010,2020
+ACCT,2010,401.0,Financial Accounting Conc,0.26,0.21,0.26,0.11,0.09,0%,0.0,0.07,emily mccorkle,,ACCT-2010,2020
+ACCT,2020,1.0,Managerial Accounting Co,0.38,0.43,0.18,0.03,0.0,0%,0.0,0.0,robin radtke,,ACCT-2020,2020
+ACCT,2020,2.0,Managerial Accounting Co,0.4,0.28,0.18,0.03,0.03,0%,0.0,0.1,robin radtke,,ACCT-2020,2020
+ACCT,2020,3.0,Managerial Accounting Co,0.21,0.13,0.3,0.11,0.09,0%,0.0,0.15,brian todd carver,,ACCT-2020,2020
+ACCT,2020,4.0,Managerial Accounting Co,0.12,0.29,0.19,0.12,0.1,0%,0.0,0.17,brian todd carver,,ACCT-2020,2020
+ACCT,2020,400.0,Managerial Accounting Co,0.23,0.49,0.23,0.0,0.0,0%,0.0,0.05,robin radtke,,ACCT-2020,2020
+ACCT,2020,401.0,Managerial Accounting Co,0.28,0.33,0.17,0.1,0.05,0%,0.0,0.07,emily mccorkle,,ACCT-2020,2020
+ACCT,2020,402.0,Managerial Accounting Co,0.33,0.22,0.28,0.05,0.03,0%,0.0,0.09,emily mccorkle,,ACCT-2020,2020
+ACCT,2020,403.0,Managerial Accounting Co,0.1,0.4,0.15,0.2,0.08,0%,0.0,0.08,emily mccorkle,,ACCT-2020,2020
+ACCT,2020,404.0,Managerial Accounting Co,0.1,0.28,0.26,0.13,0.08,0%,0.0,0.15,emily mccorkle,,ACCT-2020,2020
+ACCT,3030,1.0,Cost Accounting,0.38,0.35,0.23,0.03,0.03,0%,0.0,0.0,daniel thomas way,,ACCT-3030,2020
+ACCT,3030,2.0,Cost Accounting,0.25,0.33,0.35,0.03,0.03,0%,0.0,0.03,daniel thomas way,,ACCT-3030,2020
+ACCT,3030,3.0,Cost Accounting,0.26,0.32,0.32,0.05,0.03,0%,0.0,0.03,jace garrett,,ACCT-3030,2020
+ACCT,3030,4.0,Cost Accounting,0.16,0.42,0.26,0.0,0.05,0%,0.0,0.11,jace garrett,,ACCT-3030,2020
+ACCT,3030,5.0,Cost Accounting,0.77,0.13,0.08,0.03,0.0,0%,0.0,0.0,sarah martin,,ACCT-3030,2020
+ACCT,3110,1.0,Intermediate Financial Acc,0.17,0.34,0.31,0.03,0.07,0%,0.0,0.07,amy donnelly,,ACCT-3110,2020
+ACCT,3110,2.0,Intermediate Financial Acc,0.3,0.3,0.3,0.04,0.07,0%,0.0,0.0,amy donnelly,,ACCT-3110,2020
+ACCT,3110,3.0,Intermediate Financial Acc,0.31,0.38,0.23,0.04,0.0,0%,0.0,0.04,annieka philo,,ACCT-3110,2020
+ACCT,3110,4.0,Intermediate Financial Acc,0.26,0.35,0.23,0.06,0.06,0%,0.0,0.03,annieka philo,,ACCT-3110,2020
+ACCT,3110,5.0,Intermediate Financial Acc,0.04,0.25,0.36,0.11,0.18,0%,0.0,0.07, russell madray,,ACCT-3110,2020
+ACCT,3110,6.0,Intermediate Financial Acc,0.18,0.42,0.18,0.06,0.09,0%,0.0,0.06, russell madray,,ACCT-3110,2020
+ACCT,3110,7.0,Intermediate Financial Acc,0.19,0.41,0.28,0.0,0.0,0%,0.0,0.09, russell madray,,ACCT-3110,2020
+ACCT,3110,8.0,Intermediate Financial Acc,0.23,0.42,0.1,0.19,0.03,0%,0.0,0.03, russell madray,,ACCT-3110,2020
+ACCT,3120,1.0,Intermediate Financial Acc,0.1,0.41,0.31,0.05,0.05,0%,0.0,0.08,jeremy vinson,,ACCT-3120,2020
+ACCT,3120,2.0,Intermediate Financial Acc,0.33,0.44,0.17,0.0,0.03,0%,0.0,0.03,jeremy vinson,,ACCT-3120,2020
+ACCT,3120,3.0,Intermediate Financial Acc,0.14,0.23,0.31,0.14,0.11,0%,0.0,0.06,terry daniel knause,,ACCT-3120,2020
+ACCT,3120,4.0,Intermediate Financial Acc,0.17,0.4,0.3,0.07,0.0,0%,0.0,0.07,terry daniel knause,,ACCT-3120,2020
+ACCT,3120,5.0,Intermediate Financial Acc,0.18,0.36,0.3,0.06,0.09,0%,0.0,0.0,terry daniel knause,,ACCT-3120,2020
+ACCT,3120,6.0,Intermediate Financial Acc,0.22,0.42,0.17,0.06,0.14,0%,0.0,0.0,terry daniel knause,,ACCT-3120,2020
+ACCT,3130,1.0,Analytics for Acct Dec Mak,0.69,0.29,0.03,0.0,0.0,0%,0.0,0.0,james barnes,,ACCT-3130,2020
+ACCT,3130,2.0,Analytics for Acct Dec Mak,0.89,0.09,0.0,0.03,0.0,0%,0.0,0.0,james barnes,,ACCT-3130,2020
+ACCT,3130,3.0,Analytics for Acct Dec Mak,0.27,0.38,0.15,0.15,0.04,0%,0.0,0.0,phebian davis-culler,,ACCT-3130,2020
+ACCT,3130,4.0,Analytics for Acct Dec Mak,0.25,0.39,0.25,0.0,0.11,0%,0.0,0.0,phebian davis-culler,,ACCT-3130,2020
+ACCT,3130,5.0,Analytics for Acct Dec Mak,0.25,0.3,0.3,0.1,0.05,0%,0.0,0.0,phebian davis-culler,,ACCT-3130,2020
+ACCT,3220,1.0,Accounting Information Sy,0.15,0.19,0.42,0.08,0.12,0%,0.0,0.04,philip maiberger,,ACCT-3220,2020
+ACCT,3220,2.0,Accounting Information Sy,0.27,0.31,0.35,0.0,0.04,0%,0.0,0.04,philip maiberger,,ACCT-3220,2020
+ACCT,3220,3.0,Accounting Information Sy,0.13,0.3,0.23,0.17,0.07,0%,0.0,0.1,philip maiberger,,ACCT-3220,2020
+ACCT,3220,4.0,Accounting Information Sy,0.11,0.29,0.25,0.11,0.04,0%,0.0,0.21,philip maiberger,,ACCT-3220,2020
+ACCT,4040,1.0,Individual Taxation,0.61,0.32,0.04,0.0,0.0,0%,0.0,0.04,sarah martin,,ACCT-4040,2020
+ACCT,4040,2.0,Individual Taxation,0.46,0.29,0.23,0.0,0.03,0%,0.0,0.0,sarah martin,,ACCT-4040,2020
+ACCT,4040,3.0,Individual Taxation,0.47,0.41,0.09,0.0,0.03,0%,0.0,0.0,lisa birtwistle,,ACCT-4040,2020
+ACCT,4040,4.0,Individual Taxation,0.49,0.29,0.17,0.03,0.03,0%,0.0,0.0,sarah martin,,ACCT-4040,2020
+ACCT,4080,1.0,Retire & Estate Plan,0.28,0.5,0.16,0.03,0.0,0%,0.0,0.03,john hine,,ACCT-4080,2020
+ACCT,4100,2.0,Reporting and Mgmt Contr,0.24,0.39,0.33,0.03,0.0,0%,0.0,0.0,gregory mcphee,,ACCT-4100,2020
+ACCT,4100,3.0,Reporting and Mgmt Contr,0.33,0.45,0.18,0.03,0.0,0%,0.0,0.0,gregory mcphee,,ACCT-4100,2020
+ACCT,4150,1.0,Auditing,0.28,0.38,0.19,0.13,0.03,0%,0.0,0.0,nancy lee harp,,ACCT-4150,2020
+ACCT,4150,2.0,Auditing,0.38,0.46,0.13,0.04,0.0,0%,0.0,0.0,nancy lee harp,,ACCT-4150,2020
+ACCT,8510,1.0,Tax Research,0.41,0.53,0.03,0.0,0.0,0%,0.0,0.03,thomas dickens,,ACCT-8510,2020
+ACCT,8530,1.0,Adv Acct Problems,0.74,0.15,0.04,0.0,0.0,0%,0.0,0.07,suzanne pearse,,ACCT-8530,2020
+ACCT,8530,2.0,Adv Acct Problems,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0,suzanne pearse,,ACCT-8530,2020
+ACCT,8530,3.0,Adv Acct Problems,0.45,0.45,0.03,0.0,0.03,0%,0.0,0.03,ralph edward welton,,ACCT-8530,2020
+ACCT,8570,1.0,CPA Exam Review-B,0.0,0.0,0.0,0.0,0.0,96%,0.03,0.01,james barnes,,ACCT-8570,2020
+ACCT,8630,1.0,Forensics Analysis,0.48,0.45,0.03,0.0,0.0,0%,0.0,0.03,brian goodson,,ACCT-8630,2020
+ACCT,8630,2.0,Forensics Analysis,0.35,0.62,0.03,0.0,0.0,0%,0.0,0.0,brian goodson,,ACCT-8630,2020
+ACCT,8650,1.0,Tax & Bus Decisions,0.55,0.39,0.06,0.0,0.0,0%,0.0,0.0,judson jahn,,ACCT-8650,2020
+ACCT,8650,2.0,Tax & Bus Decisions,0.41,0.56,0.04,0.0,0.0,0%,0.0,0.0,judson jahn,,ACCT-8650,2020
+ACCT,8680,1.0,Advanced Accounting Anal,0.47,0.47,0.06,0.0,0.0,0%,0.0,0.0,marc cussatt,,ACCT-8680,2020
+ACCT,8680,2.0,Advanced Accounting Anal,0.59,0.34,0.03,0.0,0.0,0%,0.0,0.03,marc cussatt,,ACCT-8680,2020
+ACCT,8680,3.0,Advanced Accounting Anal,0.39,0.55,0.03,0.0,0.0,0%,0.0,0.03,marc cussatt,,ACCT-8680,2020
+ACCT,8720,1.0,Tax of Flowthroughs,0.25,0.44,0.28,0.0,0.0,0%,0.0,0.03,thomas dickens,,ACCT-8720,2020
+AGED,1020,1.0,Freshman Seminar,0.58,0.33,0.0,0.08,0.0,0%,0.0,0.0, dibenedetto,,AGED-1020,2020
+AGED,2000,1.0,Agr Appl of Ed Tech,0.62,0.0,0.08,0.0,0.0,0%,0.0,0.15,kevin layfield,,AGED-2000,2020
+AGED,2010,1.0,Intro to Agric Educ,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,philip fravel,,AGED-2010,2020
+AGED,2040,1.0,App Ag Calculations,0.29,0.57,0.0,0.07,0.07,0%,0.0,0.0,philip fravel,,AGED-2040,2020
+AGED,3030,1.0,Ag Ed Mech Tech,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,christopher eck,,AGED-3030,2020
+AGED,8100,3.0,Clin Ag Ed Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,kevin layfield,,AGED-8100,2020
+AGM,1010,1.0,Intro Ag Mech & Bus,0.47,0.34,0.11,0.03,0.03,0%,0.0,0.03,hunter massey,,AGM-1010,2020
+AGM,2050,1.0,Prin of Fabrication,0.22,0.51,0.22,0.04,0.0,0%,0.0,0.02,hunter massey,,AGM-2050,2020
+AGM,2210,1.0,Land Measurements,0.45,0.31,0.09,0.04,0.07,0%,0.0,0.04,brennan teddy,,AGM-2210,2020
+AGM,3010,1.0,Soil Water Conserv,0.45,0.29,0.22,0.0,0.02,0%,0.0,0.02,calvin sawyer,,AGM-3010,2020
+AGM,4000,1.0,Seminar in Ag Mech & Busi,0.13,0.29,0.32,0.24,0.03,0%,0.0,0.0,john chastain,,AGM-4000,2020
+AGM,4020,1.0,Irrigation System Design,0.24,0.24,0.24,0.1,0.19,0%,0.0,0.0,charles privette,,AGM-4020,2020
+AGM,4050,1.0,Env Cont in Anim Str,0.05,0.27,0.35,0.22,0.11,0%,0.0,0.0,john chastain,,AGM-4050,2020
+AGM,4060,1.0,Mech & Hydraulic Sys,0.39,0.48,0.11,0.0,0.02,0%,0.0,0.0,ali bulent koc,,AGM-4060,2020
+AGM,4600,1.0,Electrical Systems,0.69,0.29,0.02,0.0,0.0,0%,0.0,0.0,charles privette,,AGM-4600,2020
+AGM,4730,4.0,Ag Safety,0.61,0.22,0.11,0.06,0.0,0%,0.0,0.0,hunter massey,,AGM-4730,2020
+AGRB,2020,1.0,Agricultural Economics,0.7,0.17,0.03,0.03,0.05,0%,0.0,0.01,julie carl pingol ureta pingol,,AGRB-2020,2020
+AGRB,2050,1.0,Agriculture and Society,0.16,0.16,0.22,0.31,0.11,0%,0.0,0.04,michael vassalos,,AGRB-2050,2020
+AGRB,3020,1.0,Economics of Farm Manag,0.16,0.13,0.15,0.28,0.08,0%,0.0,0.2,michael vassalos,,AGRB-3020,2020
+AGRB,3080,2.0,Quant Agribusiness Analysi,0.12,0.21,0.14,0.33,0.1,0%,0.0,0.1,lisha zhang,,AGRB-3080,2020
+AGRB,3570,1.0,Natural Resources Econom,0.2,0.11,0.23,0.18,0.11,0%,0.0,0.16,david brian willis,,AGRB-3570,2020
+AGRB,4120,1.0,Reg Econ Devel Theory & P,0.3,0.22,0.11,0.16,0.08,0%,0.0,0.08,figueiredo silva de,,AGRB-4120,2020
+AGRB,4520,1.0,Agricultural Policy,0.14,0.21,0.19,0.28,0.14,0%,0.0,0.05,michael vassalos,,AGRB-4520,2020
+AGRB,4600,2.0,Agricultural Finance,0.18,0.33,0.23,0.18,0.03,0%,0.0,0.03,lisha zhang,,AGRB-4600,2020
+AGRB,4910,1.0,"Int, Agrib & Comm & Rural",0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,michael vassalos,,AGRB-4910,2020
+AL,3490,400.0,Principles of Coaching,0.64,0.24,0.12,0.0,0.0,0%,0.0,0.0,deborah cadorette,,AL-3490,2020
+AL,3490,401.0,Principles of Coaching,0.48,0.32,0.08,0.0,0.08,0%,0.0,0.04,deborah cadorette,,AL-3490,2020
+AL,3490,402.0,Principles of Coaching,0.52,0.32,0.12,0.0,0.04,0%,0.0,0.0,deborah cadorette,,AL-3490,2020
+AL,3490,403.0,Principles of Coaching,0.65,0.17,0.13,0.04,0.0,0%,0.0,0.0,deborah cadorette,,AL-3490,2020
+AL,3490,405.0,Principles of Coaching,0.73,0.2,0.0,0.07,0.0,0%,0.0,0.0,frank mezzanotte,,AL-3490,2020
+AL,3490,406.0,Principles of Coaching,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,frank mezzanotte,,AL-3490,2020
+AL,3490,408.0,Principles of Coaching,0.48,0.26,0.17,0.04,0.0,0%,0.0,0.0,john plumblee,,AL-3490,2020
+AL,3490,409.0,Principles of Coaching,0.88,0.04,0.08,0.0,0.0,0%,0.0,0.0,edmond fry,,AL-3490,2020
+AL,3490,410.0,Principles of Coaching,0.59,0.18,0.14,0.05,0.0,0%,0.0,0.05,joel neuder,,AL-3490,2020
+AL,3490,411.0,Principles of Coaching,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,nicholas whitrow,,AL-3490,2020
+AL,3500,400.0,Sci Basis I/Ex Phy,0.27,0.38,0.23,0.04,0.0,0%,0.0,0.08,michael godfrey,,AL-3500,2020
+AL,3500,401.0,Sci Basis I/Ex Phy,0.44,0.32,0.2,0.04,0.0,0%,0.0,0.0,isaac sean colbert,,AL-3500,2020
+AL,3530,400.0,Athletic Injuries,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,isaac sean colbert,,AL-3530,2020
+AL,3530,401.0,Athletic Injuries,0.8,0.12,0.04,0.04,0.0,0%,0.0,0.0,isaac sean colbert,,AL-3530,2020
+AL,3600,400.0,Hgh Sch Athl Ethical/Legal,0.37,0.53,0.11,0.0,0.0,0%,0.0,0.0,clyde keith connor,,AL-3600,2020
+AL,3610,400.0,Admin/Org of Athletic Pro,0.76,0.2,0.04,0.0,0.0,0%,0.0,0.0,henry oates,,AL-3610,2020
+AL,3610,401.0,Admin/Org of Athletic Pro,0.76,0.2,0.04,0.0,0.0,0%,0.0,0.0,henry oates,,AL-3610,2020
+AL,3610,402.0,Admin/Org of Athletic Pro,0.35,0.35,0.2,0.0,0.1,0%,0.0,0.0,john plumblee,,AL-3610,2020
+AL,3620,400.0,Psychology of Coaching,0.33,0.42,0.17,0.04,0.04,0%,0.0,0.0,natalie anne carter,,AL-3620,2020
+AL,3620,401.0,Psychology of Coaching,0.28,0.36,0.24,0.12,0.0,0%,0.0,0.0,natalie anne carter,,AL-3620,2020
+AL,3620,402.0,Psychology of Coaching,0.32,0.24,0.32,0.08,0.04,0%,0.0,0.0,natalie anne carter,,AL-3620,2020
+AL,3740,400.0,Coaching Football,0.52,0.16,0.16,0.04,0.04,0%,0.0,0.08,edmond fry,,AL-3740,2020
+AL,3740,401.0,Coaching Football,0.45,0.18,0.18,0.09,0.05,0%,0.0,0.05,edmond fry,,AL-3740,2020
+AL,3760,400.0,Coaching Strength/Conditi,0.67,0.13,0.08,0.0,0.08,0%,0.0,0.04,edmond fry,,AL-3760,2020
+AL,3760,401.0,Coaching Strength/Conditi,0.68,0.2,0.04,0.0,0.04,0%,0.0,0.04,edmond fry,,AL-3760,2020
+AL,4000,400.0,Athletic Leadership Interns,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,deborah cadorette,,AL-4000,2020
+AL,4380,402.0,HS Athletic Recruiting,0.61,0.13,0.17,0.04,0.04,0%,0.0,0.0,justin hickey,,AL-4380,2020
+AL,4380,404.0,Emerging Issues and Trend,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.0,misty soles,,AL-4380,2020
+AL,4380,408.0,Officiating in AL,0.75,0.2,0.0,0.05,0.0,0%,0.0,0.0,clyde keith connor,,AL-4380,2020
+AL,4380,409.0,Coaching Baseball/Softball,0.71,0.06,0.24,0.0,0.0,0%,0.0,0.0,justin hickey,,AL-4380,2020
+AL,8440,401.0,Surv of Res Mthds in Athle,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,michael godfrey,,AL-8440,2020
+AL,8440,402.0,Surv of Res Mthds in Athle,0.75,0.08,0.08,0.0,0.08,0%,0.0,0.0,michael godfrey,,AL-8440,2020
+AL,8490,401.0,Athletic Leadership Dev,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,janna magette,,AL-8490,2020
+AL,8490,402.0,Athletic Leadership Dev,0.6,0.25,0.0,0.0,0.15,0%,0.0,0.0,janna magette,,AL-8490,2020
+AL,8500,400.0,Principles Strength and Co,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,michael godfrey,,AL-8500,2020
+AL,8500,401.0,Principles Strength and Co,0.58,0.37,0.0,0.0,0.05,0%,0.0,0.0,michael godfrey,,AL-8500,2020
+AL,8630,400.0,Socio Dynam in Intercol At,0.55,0.27,0.0,0.0,0.09,0%,0.0,0.09,michael godfrey,,AL-8630,2020
+ANTH,2010,1.0,Introduction to Anthropol,0.35,0.34,0.17,0.08,0.03,0%,0.0,0.04,yi wu,,ANTH-2010,2020
+ANTH,2010,2.0,Introduction to Anthropol,0.22,0.48,0.18,0.05,0.04,0%,0.0,0.04,yi wu,,ANTH-2010,2020
+ANTH,2010,3.0,Introduction to Anthropol,0.06,0.16,0.24,0.04,0.13,0%,0.0,0.37,john coggeshall,,ANTH-2010,2020
+ANTH,2010,4.0,Introduction to Anthropol,0.58,0.3,0.04,0.0,0.02,0%,0.0,0.04,david markus,,ANTH-2010,2020
+ANTH,2010,5.0,Introduction to Anthropol,0.67,0.23,0.04,0.0,0.04,0%,0.0,0.02,david markus,,ANTH-2010,2020
+ANTH,2010,6.0,Introduction to Anthropol,0.04,0.34,0.2,0.11,0.04,0%,0.0,0.27,john coggeshall,,ANTH-2010,2020
+ANTH,2010,7.0,Introduction to Anthropol,0.62,0.35,0.04,0.0,0.0,0%,0.0,0.0,david markus,,ANTH-2010,2020
+ANTH,3010,1.0,Cultural Anthropology,0.14,0.32,0.39,0.07,0.04,0%,0.0,0.04,john coggeshall,,ANTH-3010,2020
+ANTH,3200,1.0,North American Indian Cul,0.13,0.27,0.2,0.13,0.2,0%,0.0,0.07,john coggeshall,,ANTH-3200,2020
+ANTH,3320,1.0,World Archaeology,0.4,0.44,0.08,0.0,0.04,0%,0.0,0.04,david markus,,ANTH-3320,2020
+ANTH,3510,1.0,Biological Anthropology,0.66,0.13,0.13,0.0,0.06,0%,0.0,0.03,katherine weisensee,,ANTH-3510,2020
+ANTH,4280,1.0,"Law, Culture and Society",0.57,0.21,0.0,0.0,0.14,0%,0.0,0.07,yi wu,,ANTH-4280,2020
+ARCH,1010,1.0,Introduction to Architectur,0.42,0.35,0.03,0.02,0.04,0%,0.0,0.07, hambright-belue,,ARCH-1010,2020
+ARCH,2040,1.0,Hist of Modern Arch,0.56,0.31,0.11,0.01,0.0,0%,0.0,0.0,andreea mihalache,,ARCH-2040,2020
+ARCH,2510,1.0,Arch Foundations I,0.86,0.07,0.07,0.0,0.0,0%,0.0,0.0,joseph choma,,ARCH-2510,2020
+ARCH,2510,2.0,Arch Foundations I,0.43,0.36,0.21,0.0,0.0,0%,0.0,0.0,brandon george pass,,ARCH-2510,2020
+ARCH,2510,3.0,Arch Foundations I,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,virginia ellyn melnyk,,ARCH-2510,2020
+ARCH,2510,4.0,Arch Foundations I,0.62,0.23,0.08,0.0,0.08,0%,0.0,0.0,byron jefferies,,ARCH-2510,2020
+ARCH,2510,5.0,Arch Foundations I,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,kendall roberts,,ARCH-2510,2020
+ARCH,2510,6.0,Arch Foundations I,0.46,0.31,0.08,0.08,0.0,0%,0.0,0.08,timothy sutherland,,ARCH-2510,2020
+ARCH,2700,1.0,Structures I,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,grace fulmer,,ARCH-2700,2020
+ARCH,2710,1.0,Structures II,0.48,0.33,0.07,0.0,0.04,0%,0.0,0.0,amy christine trick,,ARCH-2710,2020
+ARCH,3500,1.0,Intro to Urban Contexts,0.47,0.47,0.0,0.0,0.0,0%,0.0,0.06,douglas hecker,,ARCH-3500,2020
+ARCH,3500,2.0,Intro to Urban Contexts,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,berrin terim,,ARCH-3500,2020
+ARCH,3500,3.0,Intro to Urban Contexts,0.33,0.56,0.11,0.0,0.0,0%,0.0,0.0,david lee,,ARCH-3500,2020
+ARCH,3500,4.0,Intro to Urban Contexts,0.69,0.13,0.19,0.0,0.0,0%,0.0,0.0,clarissa mendez,,ARCH-3500,2020
+ARCH,3500,5.0,Intro to Urban Contexts,0.4,0.4,0.2,0.0,0.0,0%,0.0,0.0,julie poe wilkerson,,ARCH-3500,2020
+ARCH,3510,1.0,Studio Clemson,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,dustin albright,,ARCH-3510,2020
+ARCH,3540,1.0,Studio Barcelona,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,,ARCH-3540,2020
+ARCH,4010,1.0,Architectural Portfolio,0.62,0.24,0.1,0.0,0.0,0%,0.0,0.05,clarissa mendez,,ARCH-4010,2020
+ARCH,4010,2.0,Architectural Portfolio,0.59,0.29,0.12,0.0,0.0,0%,0.0,0.0,virginia ellyn melnyk,,ARCH-4010,2020
+ARCH,4010,3.0,Architectural Portfolio,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,george schafer,,ARCH-4010,2020
+ARCH,4010,4.0,Architectural Portfolio,0.57,0.33,0.05,0.0,0.05,0%,0.0,0.0,brandon george pass,,ARCH-4010,2020
+ARCH,4120,2.0,History Research,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,,ARCH-4120,2020
+ARCH,4140,2.0,Design Seminar,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,,ARCH-4140,2020
+ARCH,6850,1.0,H/Th: Arch+Health,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dina battisto,,ARCH-6850,2020
+ARCH,8100,1.0,Visualization I,0.83,0.09,0.04,0.0,0.0,0%,0.0,0.0,joseph choma,,ARCH-8100,2020
+ARCH,8210,1.0,Research Methods,0.83,0.15,0.0,0.0,0.0,0%,0.0,0.02,dina battisto,,ARCH-8210,2020
+ARCH,8410,1.0,Arch Studio I,0.55,0.36,0.0,0.0,0.0,0%,0.0,0.0,peter laurence,,ARCH-8410,2020
+ARCH,8410,2.0,Arch Studio I,0.6,0.3,0.0,0.0,0.1,0%,0.0,0.0,ufuk ersoy,,ARCH-8410,2020
+ARCH,8510,1.0,Design Studio III,0.33,0.58,0.08,0.0,0.0,0%,0.0,0.0,ulrike ann- heine,,ARCH-8510,2020
+ARCH,8510,2.0,Design Studio III,0.17,0.83,0.0,0.0,0.0,0%,0.0,0.0,santa cruz franco,,ARCH-8510,2020
+ARCH,8510,3.0,Design Studio III,0.31,0.54,0.08,0.0,0.0,0%,0.0,0.08,george schafer,,ARCH-8510,2020
+ARCH,8570,1.0,Design Studio V,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,dustin albright,,ARCH-8570,2020
+ARCH,8570,4.0,Design Studio V,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,raymond huff,,ARCH-8570,2020
+ARCH,8600,1.0,History/Theory I,0.57,0.38,0.0,0.0,0.0,0%,0.0,0.0,berrin terim,,ARCH-8600,2020
+ARCH,8700,1.0,Structures I,0.71,0.12,0.06,0.0,0.06,0%,0.0,0.0,dustin albright,,ARCH-8700,2020
+ARCH,8790,2.0,Digtial Manufacturing Proc,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,douglas hecker,,ARCH-8790,2020
+ARCH,8810,1.0,Pro Practice Survey,0.76,0.22,0.0,0.0,0.0,0%,0.0,0.02,byron malet edwards,,ARCH-8810,2020
+ARCH,8950,1.0,A+H Studio: Projects,0.35,0.59,0.0,0.0,0.0,0%,0.0,0.0,david allison,,ARCH-8950,2020
+ART,1050,1.0,Foundation Drawing I,0.6,0.2,0.1,0.1,0.0,0%,0.0,0.0,lori brook johnson,,ART-1050,2020
+ART,1510,1.0,Foundations Art I,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,cuba rachel lynn de lynn,,ART-1510,2020
+ART,1510,2.0,Foundations Art I,0.6,0.3,0.0,0.1,0.0,0%,0.0,0.0,brooks harris stevens,,ART-1510,2020
+ART,2100,1.0,Art Appreciation,0.91,0.0,0.0,0.05,0.05,0%,0.0,0.0,dustin massey,,ART-2100,2020
+ART,2100,2.0,Art Appreciation,0.86,0.09,0.0,0.05,0.0,0%,0.0,0.0,megan waller,,ART-2100,2020
+ART,2100,4.0,Art Appreciation,0.82,0.09,0.0,0.05,0.0,0%,0.0,0.05,dustin massey,,ART-2100,2020
+ART,2100,5.0,Art Appreciation,0.91,0.05,0.0,0.0,0.05,0%,0.0,0.0,drie katherine van,,ART-2100,2020
+ART,2100,6.0,Art Appreciation,0.75,0.15,0.05,0.0,0.05,0%,0.0,0.0,dustin massey,,ART-2100,2020
+ART,2150,1.0,Begin Graphic Design,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,david sidney gerhard,,ART-2150,2020
+ART,4200,1.0,Time Base & Digital Art Fn,0.5,0.1,0.1,0.0,0.2,0%,0.0,0.1,cuba rachel lynn de lynn,,ART-4200,2020
+AS,1090,1.0,Heritage & Values of USAF,0.82,0.06,0.0,0.0,0.0,0%,0.0,0.12,joseph blanton,,AS-1090,2020
+AS,1090,2.0,Heritage & Values of USAF,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,joseph blanton,,AS-1090,2020
+AS,1090,3.0,Heritage & Values of USAF,0.94,0.0,0.06,0.0,0.0,0%,0.0,0.0,joseph blanton,,AS-1090,2020
+AS,2090,2.0,Team & Ldrshp Fundamen,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,ryan pierce,,AS-2090,2020
+AS,3090,1.0,Leading & Effective Comm,0.91,0.0,0.09,0.0,0.0,0%,0.0,0.0,wayne leneau,,AS-3090,2020
+ASL,1010,1.0,Am Sign Lang I,0.58,0.21,0.21,0.0,0.0,0%,0.0,0.0,jason hurdich,,ASL-1010,2020
+ASL,1010,2.0,Am Sign Lang I,0.83,0.08,0.04,0.0,0.04,0%,0.0,0.0,william clements,,ASL-1010,2020
+ASL,1010,3.0,Am Sign Lang I,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,william clements,,ASL-1010,2020
+ASL,1010,4.0,Am Sign Lang I,0.76,0.16,0.08,0.0,0.0,0%,0.0,0.0,jody herbert cripps,,ASL-1010,2020
+ASL,1020,1.0,Am Sign Lang I,0.7,0.17,0.09,0.0,0.0,0%,0.0,0.04,jason hurdich,,ASL-1020,2020
+ASL,1020,2.0,Am Sign Lang I,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,jason hurdich,,ASL-1020,2020
+ASL,2010,1.0,Am Sign Lang II,0.67,0.21,0.0,0.08,0.0,0%,0.0,0.04,dunn kim misener,,ASL-2010,2020
+ASL,2010,2.0,Am Sign Lang II,0.63,0.33,0.04,0.0,0.0,0%,0.0,0.0,dunn kim misener,,ASL-2010,2020
+ASL,2020,1.0,Am Sign Lang II,0.31,0.56,0.13,0.0,0.0,0%,0.0,0.0,jason hurdich,,ASL-2020,2020
+ASL,2020,2.0,Am Sign Lang II,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dunn kim misener,,ASL-2020,2020
+ASL,3010,1.0,Advanced A S L I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dunn kim misener,,ASL-3010,2020
+ASL,3490,2.0,Adv App in Asl,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.0,william clements,,ASL-3490,2020
+ASL,4010,1.0,Linguistics of ASL,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,jody herbert cripps,,ASL-4010,2020
+ASTR,1010,1.0,Solar System Astronomy,0.61,0.22,0.07,0.06,0.01,0%,0.0,0.02,david connick,,ASTR-1010,2020
+ASTR,1010,2.0,Solar System Astronomy,0.57,0.32,0.05,0.03,0.02,0%,0.0,0.01,david connick,,ASTR-1010,2020
+ASTR,1020,1.0,Stellar Astronomy,0.57,0.28,0.1,0.01,0.03,0%,0.0,0.01,joan marler,,ASTR-1020,2020
+ASTR,1030,1.0,Solar Systm Astr Lab,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,david connick,,ASTR-1030,2020
+ASTR,1030,2.0,Solar Systm Astr Lab,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,david connick,,ASTR-1030,2020
+ASTR,1030,3.0,Solar Systm Astr Lab,0.5,0.38,0.0,0.04,0.0,0%,0.0,0.08,david connick,,ASTR-1030,2020
+ASTR,1030,4.0,Solar Systm Astr Lab,0.45,0.41,0.05,0.0,0.05,0%,0.0,0.05,david connick,,ASTR-1030,2020
+ASTR,1030,5.0,Solar Systm Astr Lab,0.5,0.38,0.04,0.04,0.04,0%,0.0,0.0,david connick,,ASTR-1030,2020
+ASTR,1030,6.0,Solar Systm Astr Lab,0.7,0.22,0.0,0.04,0.0,0%,0.0,0.04,david connick,,ASTR-1030,2020
+ASTR,1030,7.0,Solar Systm Astr Lab,0.39,0.48,0.09,0.0,0.04,0%,0.0,0.0,david connick,,ASTR-1030,2020
+ASTR,1030,8.0,Solar Systm Astr Lab,0.43,0.39,0.09,0.0,0.09,0%,0.0,0.0,david connick,,ASTR-1030,2020
+ASTR,1030,9.0,Solar Systm Astr Lab,0.48,0.43,0.0,0.0,0.04,0%,0.0,0.04,david connick,,ASTR-1030,2020
+ASTR,1030,10.0,Solar Systm Astr Lab,0.38,0.54,0.0,0.08,0.0,0%,0.0,0.0,david connick,,ASTR-1030,2020
+ASTR,1030,11.0,Solar Systm Astr Lab,0.71,0.13,0.13,0.0,0.04,0%,0.0,0.0,david connick,,ASTR-1030,2020
+ASTR,1040,1.0,Stellar Astr Lab,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,david connick,,ASTR-1040,2020
+ASTR,1040,2.0,Stellar Astr Lab,0.79,0.04,0.13,0.0,0.04,0%,0.0,0.0,david connick,,ASTR-1040,2020
+ASTR,1040,4.0,Stellar Astr Lab,0.74,0.22,0.04,0.0,0.0,0%,0.0,0.0,david connick,,ASTR-1040,2020
+ASTR,3020,1.0,Stellar Astrophysics,0.53,0.33,0.07,0.0,0.0,0%,0.0,0.07,mark leising,,ASTR-3020,2020
+AUD,1850,1.0,Intro to Audio Tech,0.46,0.23,0.08,0.08,0.08,0%,0.0,0.08,hamilton altstatt,,AUD-1850,2020
+AUD,2800,1.0,Sound Reinforcement,0.3,0.5,0.1,0.0,0.1,0%,0.0,0.0,kenneth moore,,AUD-2800,2020
+AUE,6010,1.0,Vehicle Dynamics,0.7,0.25,0.0,0.0,0.0,0%,0.0,0.05,matthias schmid,,AUE-6010,2020
+AUE,6020,1.0,Adv & Electrified Powertra,0.5,0.19,0.13,0.0,0.06,0%,0.0,0.13,benjamin lawler,,AUE-6020,2020
+AUE,6080,1.0,Vehicle Testing & Characte,0.5,0.23,0.23,0.0,0.0,0%,0.0,0.0,james potter,,AUE-6080,2020
+AUE,6930,3.0,Lightweight Design Using C,0.71,0.23,0.03,0.0,0.0,0%,0.0,0.03,srikanth pilla,,AUE-6930,2020
+AUE,8260,1.0,Vehicle Diagnostics,0.38,0.54,0.0,0.0,0.0,0%,0.0,0.08,pierluigi pisu,,AUE-8260,2020
+AUE,8270,1.0,Auto Cntrl Sys Des,0.73,0.17,0.05,0.0,0.0,0%,0.0,0.05,qilun zhu,,AUE-8270,2020
+AUE,8330,30.0,Auto Manuf Proc Devl,0.53,0.41,0.03,0.0,0.0,0%,0.0,0.03,michael mears,,AUE-8330,2020
+AUE,8350,100.0,Auto Electronics,0.73,0.2,0.0,0.0,0.0,0%,0.0,0.07,yunyi jia,,AUE-8350,2020
+AUE,8570,1.0,Light-Weight Automotive,0.86,0.0,0.14,0.0,0.0,0%,0.0,0.0,david schmueser,,AUE-8570,2020
+AUE,8690,1.0,Qual Assur Automotiv Ma,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,dee ann wood kivett wood,,AUE-8690,2020
+AUE,8700,1.0,Automotive Business Conc,0.6,0.36,0.02,0.0,0.0,0%,0.0,0.02,johnell brooks,,AUE-8700,2020
+AUE,8810,3.0,Automotive Systems Over,0.4,0.4,0.12,0.0,0.0,0%,0.0,0.08,christiaan paredis,,AUE-8810,2020
+AUE,8930,1.0,Adv Vehicle Struct Analysis,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,david schmueser,,AUE-8930,2020
+AUE,8930,5.0,Robust Predictive Control,0.52,0.22,0.22,0.0,0.0,0%,0.0,0.04,beshah ayalew,,AUE-8930,2020
+AUE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert prucka,,AUE-9910,2020
+AUE,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yunyi jia,,AUE-9910,2020
+AUE,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,srikanth pilla,,AUE-9910,2020
+AUE,9910,21.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rahul rai,,AUE-9910,2020
+AVS,1000,1.0,Orientation to AVS,0.79,0.1,0.07,0.02,0.02,0%,0.0,0.01,kristine lang vernon,,AVS-1000,2020
+AVS,1500,1.0,Intro Animal Science,0.26,0.46,0.23,0.04,0.01,0%,0.0,0.01,joseph bertrand,,AVS-1500,2020
+AVS,1500,2.0,Intro Animal Science,0.2,0.47,0.24,0.06,0.0,0%,0.0,0.02,joseph bertrand,,AVS-1500,2020
+AVS,1510,1.0,Intro Ani Sci Lab,0.6,0.32,0.08,0.0,0.0,0%,0.0,0.0,richelle miller,,AVS-1510,2020
+AVS,1510,2.0,Intro Ani Sci Lab,0.86,0.1,0.0,0.05,0.0,0%,0.0,0.0,richelle miller,,AVS-1510,2020
+AVS,1510,3.0,Intro Ani Sci Lab,0.67,0.25,0.04,0.04,0.0,0%,0.0,0.0,richelle miller,,AVS-1510,2020
+AVS,1510,5.0,Intro Ani Sci Lab,0.55,0.25,0.05,0.1,0.0,0%,0.0,0.05,richelle miller,,AVS-1510,2020
+AVS,1510,6.0,Intro Ani Sci Lab,0.61,0.26,0.04,0.09,0.0,0%,0.0,0.0,richelle miller,,AVS-1510,2020
+AVS,1510,7.0,Intro Ani Sci Lab,0.81,0.13,0.0,0.0,0.0,0%,0.0,0.06,richelle miller,,AVS-1510,2020
+AVS,1510,8.0,Intro Ani Sci Lab,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,richelle miller,,AVS-1510,2020
+AVS,1510,9.0,Intro Ani Sci Lab,0.43,0.5,0.07,0.0,0.0,0%,0.0,0.0,richelle miller,,AVS-1510,2020
+AVS,2040,1.0,Horse Care Techniques,0.87,0.1,0.0,0.0,0.03,0%,0.0,0.0,chelsea sinclair,,AVS-2040,2020
+AVS,3010,1.0,Anat & Phys Dom Ani,0.67,0.26,0.04,0.0,0.0,0%,0.0,0.02,glenn birrenkott,,AVS-3010,2020
+AVS,3010,400.0,Anat & Phys Dom Ani,0.54,0.42,0.0,0.04,0.0,0%,0.0,0.0,glenn birrenkott,,AVS-3010,2020
+AVS,3100,1.0,Animal Health,0.78,0.16,0.03,0.0,0.03,0%,0.0,0.0,james strickland,,AVS-3100,2020
+AVS,3700,1.0,Principles of Animal Nutriti,0.59,0.25,0.08,0.02,0.0,0%,0.0,0.03,james strickland,,AVS-3700,2020
+AVS,3750,1.0,Applied Animal Nutrition,0.22,0.39,0.26,0.04,0.0,0%,0.0,0.09,gustavo jose lascano,,AVS-3750,2020
+AVS,4100,1.0,Domestic Ani Behav,0.84,0.08,0.07,0.01,0.0,0%,0.0,0.0,ahmed badr ali,,AVS-4100,2020
+AVS,4100,2.0,Domestic Ani Behav,0.88,0.06,0.06,0.0,0.0,0%,0.0,0.0,ahmed badr ali,,AVS-4100,2020
+AVS,4110,1.0,Animal Growth and Develo,0.58,0.24,0.06,0.05,0.05,0%,0.0,0.03,susan kay duckett,,AVS-4110,2020
+AVS,4150,1.0,Contemporary Issues in AV,0.57,0.33,0.04,0.01,0.03,0%,0.0,0.01,chelsea sinclair,,AVS-4150,2020
+AVS,4160,1.0,Equine Exercise Phys,0.47,0.37,0.05,0.0,0.11,0%,0.0,0.0,kristine lang vernon,,AVS-4160,2020
+AVS,4500,1.0,Sustain Livestock Product,0.27,0.67,0.07,0.0,0.0,0%,0.0,0.0,matias jose aguerre,,AVS-4500,2020
+AVS,4530,1.0,Animal Reproduction,0.13,0.49,0.13,0.18,0.0,0%,0.0,0.07,scott lee pratt,,AVS-4530,2020
+AVS,4650,1.0,Animal Physiology I,0.74,0.15,0.07,0.04,0.0,0%,0.0,0.0,heather walker dunn,,AVS-4650,2020
+AVS,4800,1.0,Vertebrate Endocrinology,0.81,0.13,0.03,0.0,0.03,0%,0.0,0.0,heather walker dunn,,AVS-4800,2020
+AVS,4910,13.0,Analysis of Natural Produc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,james strickland,,AVS-4910,2020
+AVS,4920,6.0,Grazing Horses CI,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,brittany perron,,AVS-4920,2020
+AVS,8070,1.0,Prin of Sci Writing in AFLS,0.54,0.31,0.0,0.0,0.0,0%,0.0,0.15,jeryl jones,,AVS-8070,2020
+BCHM,1030,1.0,Careers in Bioch/Gen,0.83,0.1,0.02,0.0,0.04,0%,0.0,0.02,alison starr-moss,,BCHM-1030,2020
+BCHM,3010,1.0,Molecular Biochemistry,0.54,0.26,0.1,0.08,0.02,0%,0.0,0.0,cheryl ingram-smith,,BCHM-3010,2020
+BCHM,3050,2.0,Essen Elements Bioch,0.45,0.33,0.17,0.0,0.04,0%,0.0,0.01,heidi anderson,,BCHM-3050,2020
+BCHM,3050,3.0,Essen Elements Bioch,0.34,0.37,0.14,0.04,0.08,0%,0.0,0.03,suchitra chavan,,BCHM-3050,2020
+BCHM,3050,4.0,Essen Elements Bioch,0.58,0.31,0.07,0.02,0.01,0%,0.0,0.01,heidi anderson,,BCHM-3050,2020
+BCHM,3050,5.0,Essen Elements Bioch,0.33,0.45,0.12,0.05,0.0,0%,0.0,0.04,suchitra chavan,,BCHM-3050,2020
+BCHM,4310,1.0,Physical Approach to Bioch,0.35,0.33,0.26,0.05,0.01,0%,0.0,0.0,weiguo cao,,BCHM-4310,2020
+BCHM,4310,2.0,Phys App to Bioch (HON),0.5,0.42,0.08,0.0,0.0,0%,0.0,0.0,weiguo cao,True,BCHM-4310,2020
+BCHM,4330,1.0,Physical Biochemistry Lab,0.81,0.13,0.06,0.0,0.0,0%,0.0,0.0,geoffrey ford,,BCHM-4330,2020
+BCHM,4330,2.0,Physical Biochemistry Lab,0.81,0.13,0.0,0.0,0.06,0%,0.0,0.0,geoffrey ford,,BCHM-4330,2020
+BCHM,4330,3.0,Physical Biochemistry Lab,0.81,0.06,0.13,0.0,0.0,0%,0.0,0.0,geoffrey ford,,BCHM-4330,2020
+BCHM,4330,4.0,Physical Biochemistry Lab,0.88,0.06,0.0,0.06,0.0,0%,0.0,0.0,geoffrey ford,,BCHM-4330,2020
+BCHM,4330,5.0,Physical Biochemistry Lab,0.76,0.0,0.12,0.06,0.06,0%,0.0,0.0,geoffrey ford,,BCHM-4330,2020
+BCHM,4400,1.0,Bioinformatics,0.82,0.05,0.05,0.0,0.07,0%,0.0,0.02,frank feltus,,BCHM-4400,2020
+BCHM,4430,1.0,Molecular Basis of Disease,0.55,0.36,0.09,0.0,0.0,0%,0.0,0.0,james morris,,BCHM-4430,2020
+BCHM,8250,1.0,Seminar I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rajandeep sekhon,,BCHM-8250,2020
+BDSI,8000,1.0,Biomed Data Sci & Info Se,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brian dean,,BDSI-8000,2020
+BE,2100,1.0,Intro to Biosystems Engr,0.85,0.11,0.0,0.0,0.0,0%,0.0,0.04,gamboa vanegas,,BE-2100,2020
+BE,3200,1.0,Principles & Prac of Geom,0.59,0.32,0.09,0.0,0.0,0%,0.0,0.0,tom owino,,BE-3200,2020
+BE,4100,1.0,Biological Kinetics,0.22,0.57,0.22,0.0,0.0,0%,0.0,0.0,caye marie drapcho,,BE-4100,2020
+BE,4150,1.0,Instr & Control for Biosys E,0.53,0.33,0.0,0.07,0.07,0%,0.0,0.0,rui xiao,,BE-4150,2020
+BE,4210,1.0,Engr Sys for Soil Water Mg,0.81,0.06,0.13,0.0,0.0,0%,0.0,0.0,christophe darnault,,BE-4210,2020
+BE,4740,1.0,BE Design Project Managm,0.88,0.06,0.06,0.0,0.0,0%,0.0,0.0,tom owino,,BE-4740,2020
+BE,4750,1.0,BE Capstone Design,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,christophe darnault,,BE-4750,2020
+BIOE,1010,1.0,Biol for Bioengr,0.67,0.2,0.07,0.0,0.0,0%,0.0,0.0,tyler george harvey,,BIOE-1010,2020
+BIOE,2000,1.0,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,98%,0.0,0.01,agneta simionescu,,BIOE-2000,2020
+BIOE,2010,2.0,Intro Biomed Engr,0.4,0.5,0.07,0.02,0.01,0%,0.0,0.01,charles webb,,BIOE-2010,2020
+BIOE,3000,1.0,Bioeng Ethics Entrepreneu,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,tyler george harvey,,BIOE-3000,2020
+BIOE,3020,1.0,Biomaterials,0.67,0.25,0.05,0.0,0.0,0%,0.0,0.03,alexey vertegel,,BIOE-3020,2020
+BIOE,3100,1.0,Engr Analysis of Physiol Pr,0.85,0.14,0.01,0.0,0.0,0%,0.0,0.0,brian william booth,,BIOE-3100,2020
+BIOE,3200,1.0,Biomechanics,0.68,0.3,0.0,0.0,0.0,0%,0.0,0.03,jiro nagatomi,,BIOE-3200,2020
+BIOE,3210,1.0,Biofluid Mechanics,0.62,0.31,0.07,0.0,0.0,0%,0.0,0.0,zhi gao,,BIOE-3210,2020
+BIOE,3460,1.0,Biomolecular Thermodyna,0.43,0.41,0.14,0.0,0.0,0%,0.0,0.01,robert latour,,BIOE-3460,2020
+BIOE,3470,1.0,Transport Processes in Bio,0.8,0.14,0.02,0.04,0.0,0%,0.0,0.0,renee nicole cottle,,BIOE-3470,2020
+BIOE,3700,1.0,Bioinst & Imaging,0.67,0.3,0.04,0.0,0.0,0%,0.0,0.0,jordon gilmore,,BIOE-3700,2020
+BIOE,4000,1.0,Bioengr Leadshp & MedTe,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,martine laberge,,BIOE-4000,2020
+BIOE,4010,1.0,Bioengineering Design The,0.97,0.03,0.0,0.0,0.0,0%,0.0,0.0,john desjardins,,BIOE-4010,2020
+BIOE,4010,2.0,Bioengineering Design The,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,john desjardins,,BIOE-4010,2020
+BIOE,4030,1.0,Applied Bio E Design,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,ravikiran singapogu,,BIOE-4030,2020
+BIOE,4120,1.0,Orthopaedic Engr and Path,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,melinda harman,,BIOE-4120,2020
+BIOE,4350,1.0,Computational Modeling i,0.61,0.33,0.0,0.0,0.0,0%,0.0,0.06,william richardson,,BIOE-4350,2020
+BIOE,4400,1.0,Biopharmaceutical Engine,0.37,0.42,0.05,0.0,0.0,0%,0.0,0.16,sarah harcum,,BIOE-4400,2020
+BIOE,4480,1.0,Tissue Engineering,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,angela alexander,,BIOE-4480,2020
+BIOE,6120,1.0,Orthopaedic Engr & Pathol,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,melinda harman,,BIOE-6120,2020
+BIOE,6340,1.0,Cardiovascular Biomechani,0.5,0.33,0.17,0.0,0.0,0%,0.0,0.0,ethan kung,,BIOE-6340,2020
+BIOE,6350,1.0,Computational Modeling i,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,william richardson,,BIOE-6350,2020
+BIOE,6400,1.0,Biopharmaceutical Engine,0.42,0.5,0.0,0.0,0.0,0%,0.0,0.08,sarah harcum,,BIOE-6400,2020
+BIOE,8000,843.0,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,ann catherine foley,,BIOE-8000,2020
+BIOE,8020,1.0,Biocompatibility,0.25,0.75,0.0,0.0,0.0,0%,0.0,0.0,narendra vyavahare,,BIOE-8020,2020
+BIOE,8900,2.0,Bioengineering Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy mercuri,,BIOE-8900,2020
+BIOE,9910,3.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,john desjardins,,BIOE-9910,2020
+BIOE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melinda harman,,BIOE-9910,2020
+BIOE,9910,11.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy mercuri,,BIOE-9910,2020
+BIOE,9910,13.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,william richardson,,BIOE-9910,2020
+BIOE,9910,17.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,narendra vyavahare,,BIOE-9910,2020
+BIOE,9910,805.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy gilbert,,BIOE-9910,2020
+BIOL,1010,1.0,Frontiers in Biology I,0.82,0.13,0.03,0.0,0.01,0%,0.0,0.01,michael childress,,BIOL-1010,2020
+BIOL,1010,2.0,Frontiers in Biology I,0.87,0.09,0.01,0.01,0.01,0%,0.0,0.0,michael childress,,BIOL-1010,2020
+BIOL,1030,1.0,General Biology I,0.29,0.25,0.24,0.12,0.08,0%,0.0,0.02,nora espinoza,,BIOL-1030,2020
+BIOL,1030,2.0,General Biology I,0.27,0.38,0.18,0.08,0.04,0%,0.0,0.05,cassandra joy may,,BIOL-1030,2020
+BIOL,1030,3.0,General Biology I,0.24,0.22,0.4,0.01,0.05,0%,0.0,0.07,salvatore sparace,,BIOL-1030,2020
+BIOL,1030,4.0,General Biology I,0.22,0.29,0.22,0.11,0.08,0%,0.0,0.09,nathan redding,,BIOL-1030,2020
+BIOL,1030,5.0,General Biology I (HON),0.48,0.33,0.19,0.0,0.0,0%,0.0,0.0,nora espinoza,True,BIOL-1030,2020
+BIOL,1040,1.0,General Biology II,0.52,0.39,0.06,0.0,0.0,0%,0.0,0.03,donna weinbrenner,,BIOL-1040,2020
+BIOL,1050,1.0,General Biology Lab I,0.63,0.17,0.08,0.04,0.04,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,2.0,General Biology Lab I,0.91,0.04,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,3.0,General Biology Lab I,0.58,0.25,0.08,0.0,0.0,0%,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,4.0,General Biology Lab I,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,5.0,General Biology Lab I,0.61,0.26,0.09,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,6.0,General Biology Lab I,0.5,0.33,0.04,0.0,0.0,0%,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,7.0,General Biology Lab I,0.42,0.46,0.04,0.04,0.04,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,8.0,General Biology Lab I,0.83,0.04,0.0,0.04,0.04,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,9.0,General Biology Lab I,0.42,0.21,0.08,0.08,0.04,0%,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,10.0,General Biology Lab I,0.22,0.3,0.3,0.0,0.09,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,11.0,General Biology Lab I,0.46,0.33,0.08,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,12.0,General Biology Lab I,0.17,0.5,0.04,0.0,0.08,0%,0.0,0.21,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,13.0,General Biology Lab I,0.46,0.29,0.08,0.08,0.04,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,14.0,General Biology Lab I,0.29,0.5,0.08,0.04,0.08,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,15.0,General Biology Lab I,0.52,0.3,0.0,0.0,0.13,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,16.0,General Biology Lab I,0.63,0.33,0.04,0.0,0.0,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,17.0,General Biology Lab I,0.33,0.38,0.08,0.08,0.08,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,18.0,General Biology Lab I,0.48,0.26,0.0,0.04,0.09,0%,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,19.0,General Biology Lab I,0.54,0.29,0.0,0.04,0.04,0%,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,20.0,General Biology Lab I,0.74,0.13,0.09,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,21.0,General Biology Lab I,0.46,0.29,0.08,0.04,0.13,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,22.0,General Biology Lab I,0.54,0.21,0.08,0.08,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,23.0,General Biology Lab I,0.58,0.17,0.08,0.0,0.04,0%,0.0,0.13,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,24.0,General Biology Lab I,0.64,0.05,0.14,0.09,0.09,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,25.0,General Biology Lab I,0.57,0.29,0.07,0.0,0.0,0%,0.0,0.07,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,26.0,General Biology Lab I,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,27.0,General Biology Lab I,0.5,0.21,0.17,0.08,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,28.0,General Biology Lab I,0.67,0.17,0.08,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,29.0,General Biology Lab I,0.79,0.04,0.13,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,30.0,General Biology Lab I,0.42,0.25,0.08,0.08,0.13,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,31.0,General Biology Lab I,0.75,0.17,0.0,0.04,0.04,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,32.0,General Biology Lab I,0.58,0.25,0.08,0.0,0.0,0%,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,33.0,General Biology Lab I,0.33,0.33,0.1,0.0,0.1,0%,0.0,0.14,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,34.0,General Biology Lab I,0.88,0.04,0.04,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,35.0,General Biology Lab I,0.63,0.17,0.04,0.04,0.08,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,36.0,General Biology Lab I,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,37.0,General Biology Lab I,0.58,0.13,0.21,0.04,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,38.0,General Biology Lab I,0.83,0.04,0.04,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,39.0,General Biology Lab I,0.75,0.13,0.04,0.0,0.08,0%,0.0,0.0,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,40.0,General Biology Lab I,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,41.0,General Biology Lab I,0.71,0.25,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,42.0,General Biology Lab I,0.71,0.13,0.0,0.04,0.04,0%,0.0,0.08,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,43.0,General Biology Lab I,0.29,0.33,0.1,0.14,0.1,0%,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,44.0,General Biology Lab I,0.68,0.18,0.0,0.0,0.05,0%,0.0,0.05,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1050,45.0,General Biology Lab I,0.45,0.27,0.09,0.09,0.0,0%,0.0,0.09,tafadzwa kaisa,,BIOL-1050,2020
+BIOL,1090,1.0,Intro to Life Sci,0.8,0.17,0.03,0.0,0.0,0%,0.0,0.0,renea chris hardwick,,BIOL-1090,2020
+BIOL,1100,1.0,Principles of Biology I,0.41,0.38,0.09,0.04,0.03,0%,0.0,0.05,renea chris hardwick,,BIOL-1100,2020
+BIOL,1100,2.0,Principles of Biology I,0.56,0.28,0.1,0.05,0.01,0%,0.0,0.0,renea chris hardwick,,BIOL-1100,2020
+BIOL,1100,3.0,Principles of Biology I,0.36,0.33,0.2,0.03,0.03,0%,0.0,0.06,verna minor,,BIOL-1100,2020
+BIOL,1100,4.0,Principles of Biology I,0.28,0.47,0.15,0.06,0.04,0%,0.0,0.0,verna minor,,BIOL-1100,2020
+BIOL,1100,5.0,Principles of Biology I (HO,0.79,0.14,0.04,0.0,0.04,0%,0.0,0.0,verna minor,True,BIOL-1100,2020
+BIOL,1230,1.0,Keys to Human Biol,0.21,0.34,0.26,0.06,0.09,0%,0.0,0.04,lisa ruggiero wagner,,BIOL-1230,2020
+BIOL,2220,1.0,Human Anat and Physiolog,0.21,0.28,0.3,0.1,0.07,0%,0.0,0.04,john cummings,,BIOL-2220,2020
+BIOL,2220,3.0,Human Anat and Physiolog,0.28,0.38,0.17,0.11,0.04,0%,0.0,0.03,john cummings,,BIOL-2220,2020
+BIOL,3030,1.0,Vertebrate Biology,0.53,0.29,0.11,0.05,0.03,0%,0.0,0.01,virginia abernathy,,BIOL-3030,2020
+BIOL,3030,2.0,Vertebrate Biology (HON),0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,virginia abernathy,True,BIOL-3030,2020
+BIOL,3030,3.0,Vertebrate Biology,0.55,0.27,0.13,0.03,0.02,0%,0.0,0.0,virginia abernathy,,BIOL-3030,2020
+BIOL,3040,1.0,Biology of Plants,0.29,0.27,0.18,0.16,0.08,0%,0.0,0.02,nathan redding,,BIOL-3040,2020
+BIOL,3070,1.0,Vertebrate Biology Lab,0.69,0.23,0.08,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3070,2.0,Vertebrate Biology Lab,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3070,4.0,Vertebrate Biology Lab,0.6,0.36,0.04,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3070,5.0,Vertebrate Biology Lab,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3070,6.0,Vertebrate Biology Lab,0.84,0.08,0.04,0.0,0.0,0%,0.0,0.04,richard blob,,BIOL-3070,2020
+BIOL,3070,7.0,Vertebrate Biology Lab,0.6,0.28,0.12,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3070,8.0,Vertebrate Biology Lab,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3070,9.0,Vertebrate Biology Lab,0.72,0.24,0.04,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3070,10.0,Vertebrate Biology Lab,0.5,0.33,0.06,0.06,0.06,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3070,11.0,Vertebrate Biology Lab,0.6,0.32,0.08,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-3070,2020
+BIOL,3080,1.0,Biology of Plants Practicu,0.64,0.27,0.0,0.0,0.0,0%,0.0,0.09,nathan redding,,BIOL-3080,2020
+BIOL,3080,3.0,Biology of Plants Practicu,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,nathan redding,,BIOL-3080,2020
+BIOL,3080,4.0,Biology of Plants Practicu,0.55,0.27,0.09,0.09,0.0,0%,0.0,0.0,nathan redding,,BIOL-3080,2020
+BIOL,3080,5.0,Biology of Plants Practicu,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,nathan redding,,BIOL-3080,2020
+BIOL,3150,1.0,Functional Human Anatom,0.4,0.39,0.12,0.04,0.02,0%,0.0,0.03, mcnutt-scott,,BIOL-3150,2020
+BIOL,3350,1.0,Evolutionary Biology,0.35,0.45,0.14,0.04,0.01,0%,0.0,0.02,matthew koski,,BIOL-3350,2020
+BIOL,3510,1.0,Biological Anthropology,0.86,0.07,0.04,0.04,0.0,0%,0.0,0.0,katherine weisensee,,BIOL-3510,2020
+BIOL,4030,1.0,Intro to Applied Genomics,0.38,0.13,0.25,0.0,0.13,0%,0.0,0.13,vincent paul richards,,BIOL-4030,2020
+BIOL,4200,1.0,Neurobiology,0.97,0.0,0.0,0.0,0.02,0%,0.0,0.02,david feliciano,,BIOL-4200,2020
+BIOL,4250,1.0,Introductory Mycology,0.32,0.33,0.2,0.06,0.02,0%,0.0,0.06,julia louise kerrigan,,BIOL-4250,2020
+BIOL,4260,1.0,Mycology Practicum,0.71,0.21,0.0,0.0,0.07,0%,0.0,0.0,julia louise kerrigan,,BIOL-4260,2020
+BIOL,4260,2.0,Mycology Practicum,0.6,0.2,0.0,0.07,0.0,0%,0.0,0.13,julia louise kerrigan,,BIOL-4260,2020
+BIOL,4400,1.0,Developmental Animal Bio,0.4,0.29,0.17,0.13,0.0,0%,0.0,0.02,kara powder,,BIOL-4400,2020
+BIOL,4410,1.0,Ecology,0.46,0.36,0.1,0.05,0.01,0%,0.0,0.0,sharon bewick,,BIOL-4410,2020
+BIOL,4420,1.0,Biogeography,0.58,0.21,0.15,0.03,0.0,0%,0.0,0.03,michael sears,,BIOL-4420,2020
+BIOL,4610,1.0,Cell Biology,0.67,0.3,0.03,0.0,0.0,0%,0.0,0.0,susan chapman,,BIOL-4610,2020
+BIOL,4610,2.0,Cell Biology (HON),0.71,0.21,0.08,0.0,0.0,0%,0.0,0.0,susan chapman,True,BIOL-4610,2020
+BIOL,4610,3.0,Cell Biology,0.56,0.4,0.04,0.0,0.0,0%,0.0,0.0,susan chapman,,BIOL-4610,2020
+BIOL,4620,1.0,Cell Biology Lab (Lec),0.82,0.14,0.0,0.04,0.0,0%,0.0,0.0,xianzhong yu,,BIOL-4620,2020
+BIOL,4620,3.0,Cell Biology Lab (Lec),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,xianzhong yu,,BIOL-4620,2020
+BIOL,4620,4.0,Cell Biology Lab (Lec),0.72,0.08,0.12,0.08,0.0,0%,0.0,0.0,xianzhong yu,,BIOL-4620,2020
+BIOL,4620,5.0,Cell Biology Lab (Lec),0.93,0.04,0.04,0.0,0.0,0%,0.0,0.0,xianzhong yu,,BIOL-4620,2020
+BIOL,4620,6.0,Cell Biology Lab (Lec),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,xianzhong yu,,BIOL-4620,2020
+BIOL,4620,7.0,Cell Biology Lab (Lec),0.92,0.04,0.0,0.0,0.04,0%,0.0,0.0,xianzhong yu,,BIOL-4620,2020
+BIOL,4620,8.0,Cell Biology Lab (Lec),0.77,0.08,0.08,0.0,0.08,0%,0.0,0.0,xianzhong yu,,BIOL-4620,2020
+BIOL,4670,1.0,Principles of Hematology,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,vincent gallicchio,,BIOL-4670,2020
+BIOL,4750,1.0,Comparative Physiology,0.48,0.2,0.16,0.06,0.08,0%,0.0,0.02,matthew turnbull,,BIOL-4750,2020
+BIOL,4800,1.0,Vertebrate Endocrinology,0.4,0.3,0.3,0.0,0.0,0%,0.0,0.0,william baldwin,,BIOL-4800,2020
+BIOL,4930,2.0,Sr Sem:Extinct & Macro Ev,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,nora espinoza,,BIOL-4930,2020
+BIOL,6030,1.0,Intro to Applied Genomics,0.23,0.62,0.08,0.0,0.08,0%,0.0,0.0,vincent paul richards,,BIOL-6030,2020
+BIOL,8000,1.0,Concepts in EEOB,0.86,0.0,0.14,0.0,0.0,0%,0.0,0.0,richard blob,,BIOL-8000,2020
+BIOL,8010,1.0,Concepts in MCDB,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,zhicheng dou,,BIOL-8010,2020
+BIOL,8070,1.0,Readings in MCDB,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,zhicheng dou,,BIOL-8070,2020
+BIOL,8070,2.0,Readings in Evolution,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jennifer hodge,,BIOL-8070,2020
+BIOL,8070,3.0,Readings in Ecology,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert fritz baldwin,,BIOL-8070,2020
+BIOL,8120,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,zhicheng dou,,BIOL-8120,2020
+BIOL,8130,1.0,Grad Teach Assist Colloqui,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,john cummings,,BIOL-8130,2020
+BIOL,8400,1.0,Understanding Biological I,0.53,0.16,0.03,0.0,0.06,0%,0.0,0.16,virginia abernathy,,BIOL-8400,2020
+BIOL,8420,1.0,Understand Cellular Proce,0.56,0.27,0.11,0.0,0.0,0%,0.0,0.03,kaustubha qanungo,,BIOL-8420,2020
+BIOL,8440,1.0,Understanding the Human,0.49,0.35,0.1,0.0,0.02,0%,0.0,0.03, mcnutt-scott,,BIOL-8440,2020
+BMOL,4250,1.0,Biomolecular Engineering,0.52,0.21,0.12,0.06,0.05,0%,0.0,0.05,marc birtwistle,,BMOL-4250,2020
+BUS,1010,2.0,Business Foundations,0.53,0.37,0.11,0.0,0.0,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,3.0,Business Foundations,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,4.0,Business Foundations,0.37,0.58,0.0,0.0,0.05,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,6.0,Business Foundations,0.4,0.4,0.1,0.1,0.0,0%,0.0,0.0,neil monaghan,,BUS-1010,2020
+BUS,1010,8.0,Business Foundations,0.42,0.29,0.16,0.02,0.07,0%,0.0,0.04,alexandra hazleton,,BUS-1010,2020
+BUS,1010,10.0,Business Foundations,0.58,0.21,0.08,0.04,0.08,0%,0.0,0.0,sandy edge,,BUS-1010,2020
+BUS,1010,11.0,Business Foundations,0.46,0.54,0.0,0.0,0.0,0%,0.0,0.0,sandy edge,,BUS-1010,2020
+BUS,1010,12.0,Business Foundations,0.48,0.39,0.13,0.0,0.0,0%,0.0,0.0,sandy edge,,BUS-1010,2020
+BUS,1010,14.0,Business Foundations,0.23,0.48,0.2,0.03,0.05,0%,0.0,0.02,keith balts,,BUS-1010,2020
+BUS,1010,15.0,Business Foundations,0.83,0.08,0.04,0.04,0.0,0%,0.0,0.0,iulio edward barry de barry,,BUS-1010,2020
+BUS,1010,16.0,Business Foundations,0.58,0.29,0.08,0.0,0.04,0%,0.0,0.0,iulio edward barry de barry,,BUS-1010,2020
+BUS,1010,17.0,Business Foundations,0.83,0.08,0.0,0.08,0.0,0%,0.0,0.0,iulio edward barry de barry,,BUS-1010,2020
+BUS,1010,18.0,Business Foundations,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,lawrence watson,,BUS-1010,2020
+BUS,1010,19.0,Business Foundations,0.58,0.26,0.16,0.0,0.0,0%,0.0,0.0,lawrence watson,,BUS-1010,2020
+BUS,1010,20.0,Business Foundations,0.26,0.58,0.11,0.0,0.0,0%,0.0,0.05,william tumblin,,BUS-1010,2020
+BUS,1010,21.0,Business Foundations,0.39,0.39,0.17,0.06,0.0,0%,0.0,0.0,james walter dowis,,BUS-1010,2020
+BUS,1010,22.0,Business Foundations,0.47,0.41,0.06,0.0,0.0,0%,0.0,0.06,james walter dowis,,BUS-1010,2020
+BUS,1010,23.0,Business Foundations,0.56,0.22,0.22,0.0,0.0,0%,0.0,0.0,james walter dowis,,BUS-1010,2020
+BUS,1010,25.0,Business Foundations,0.6,0.3,0.05,0.05,0.0,0%,0.0,0.0,james walter dowis,,BUS-1010,2020
+BUS,1010,26.0,Business Foundations,0.8,0.1,0.0,0.0,0.05,0%,0.0,0.05,james walter dowis,,BUS-1010,2020
+BUS,1010,27.0,Business Foundations,0.56,0.38,0.06,0.0,0.0,0%,0.0,0.0,james walter dowis,,BUS-1010,2020
+BUS,1010,30.0,Business Foundations,0.54,0.29,0.17,0.0,0.0,0%,0.0,0.0,keith balts,,BUS-1010,2020
+BUS,1010,31.0,Business Foundations,0.21,0.5,0.25,0.0,0.0,0%,0.0,0.04,keith balts,,BUS-1010,2020
+BUS,1010,33.0,Business Foundations,0.7,0.2,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,34.0,Business Foundations,0.55,0.4,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,35.0,Business Foundations,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,36.0,Business Foundations,0.32,0.36,0.12,0.12,0.06,0%,0.0,0.03,neil monaghan,,BUS-1010,2020
+BUS,1010,37.0,Business Foundations,0.4,0.34,0.18,0.05,0.02,0%,0.0,0.02,neil monaghan,,BUS-1010,2020
+BUS,1010,39.0,Business Foundations,0.5,0.25,0.15,0.0,0.1,0%,0.0,0.0,james walter dowis,,BUS-1010,2020
+BUS,1010,40.0,Business Foundations,0.35,0.4,0.15,0.05,0.0,0%,0.0,0.05,james walter dowis,,BUS-1010,2020
+BUS,1010,41.0,Business Foundations,0.7,0.25,0.0,0.05,0.0,0%,0.0,0.0,james walter dowis,,BUS-1010,2020
+BUS,1010,43.0,Business Foundations,0.42,0.13,0.33,0.13,0.0,0%,0.0,0.0,keith balts,,BUS-1010,2020
+BUS,1010,44.0,Business Foundations,0.42,0.33,0.21,0.0,0.04,0%,0.0,0.0,keith balts,,BUS-1010,2020
+BUS,1010,45.0,Business Foundations,0.38,0.38,0.21,0.04,0.0,0%,0.0,0.0,keith balts,,BUS-1010,2020
+BUS,1010,47.0,Business Foundations,0.45,0.45,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,48.0,Business Foundations,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,49.0,Business Foundations,0.6,0.3,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,,BUS-1010,2020
+BUS,1010,50.0,Business Foundations,0.3,0.33,0.16,0.06,0.05,0%,0.0,0.1,alexandra hazleton,,BUS-1010,2020
+BUS,1010,51.0,Business Foundations,0.26,0.37,0.19,0.06,0.06,0%,0.0,0.05,alexandra hazleton,,BUS-1010,2020
+CCPD,1400,1.0,Professional Development,0.85,0.08,0.04,0.0,0.0,0%,0.0,0.04,rise jean sheriff,,CCPD-1400,2020
+CE,2010,1.0,Statics,0.11,0.41,0.3,0.05,0.14,0%,0.0,0.0,michael stoner,,CE-2010,2020
+CE,2010,2.0,Statics,0.62,0.21,0.14,0.0,0.02,0%,0.0,0.0,md chowdhury,,CE-2010,2020
+CE,2010,3.0,Statics,0.12,0.34,0.2,0.08,0.08,0%,0.0,0.18,melissa sternhagen,,CE-2010,2020
+CE,2010,4.0,Statics,0.17,0.13,0.28,0.02,0.11,0%,0.0,0.3,melissa sternhagen,,CE-2010,2020
+CE,2010,5.0,Statics,0.26,0.38,0.25,0.05,0.05,0%,0.0,0.02,mohannad naser,,CE-2010,2020
+CE,2010,6.0,Statics,0.37,0.43,0.11,0.06,0.02,0%,0.0,0.02,md chowdhury,,CE-2010,2020
+CE,2010,8.0,Statics,0.38,0.4,0.15,0.05,0.03,0%,0.0,0.0,michael stoner,,CE-2010,2020
+CE,2060,1.0,Structural Mechanics,0.03,0.13,0.44,0.15,0.06,0%,0.0,0.19,melissa sternhagen,,CE-2060,2020
+CE,2080,1.0,Dynamics,0.19,0.4,0.33,0.02,0.03,0%,0.0,0.03,md chowdhury,,CE-2080,2020
+CE,2550,1.0,Geomatics,0.27,0.43,0.2,0.09,0.0,0%,0.0,0.02,wayne sarasua,,CE-2550,2020
+CE,2990,16.0,CE - Springer I - Lecture,0.67,0.25,0.08,0.0,0.0,0%,0.0,0.0,wayne sarasua,,CE-2990,2020
+CE,2990,116.0,CE - Springer I - Lab,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,wayne sarasua,,CE-2990,2020
+CE,2990,216.0,CE - Springer I - Lab,0.5,0.33,0.17,0.0,0.0,0%,0.0,0.0,wayne sarasua,,CE-2990,2020
+CE,3010,1.0,Structural Analysis,0.19,0.45,0.28,0.04,0.02,0%,0.0,0.02,stephen csernak,,CE-3010,2020
+CE,3010,2.0,Structural Analysis,0.34,0.34,0.28,0.0,0.0,0%,0.0,0.03,thomas cousins,,CE-3010,2020
+CE,3110,1.0,Transportation Engr,0.74,0.11,0.08,0.0,0.03,0%,0.0,0.03,jennifer ogle,,CE-3110,2020
+CE,3210,1.0,Geotechnical Engineering,0.47,0.31,0.12,0.08,0.0,0%,0.0,0.02,qiushi chen,,CE-3210,2020
+CE,3310,1.0,Constr Engr & Mgmnt,0.44,0.42,0.1,0.01,0.01,0%,0.0,0.01,zoraya rockow,,CE-3310,2020
+CE,3410,1.0,Intro to Fluid Mechanics,0.68,0.24,0.07,0.02,0.0,0%,0.0,0.0,nigel gregory kaye,,CE-3410,2020
+CE,3410,2.0,Intro to Fluid Mechanics,0.27,0.35,0.18,0.06,0.1,0%,0.0,0.04,abdul khan,,CE-3410,2020
+CE,3420,1.0,Hydraulics & Hydro,0.64,0.2,0.11,0.04,0.02,0%,0.0,0.0,ashok mishra,,CE-3420,2020
+CE,3510,1.0,Civil Engineering Materials,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0, esmaeilpoursaee,,CE-3510,2020
+CE,3510,2.0,Civil Engineering Materials,0.88,0.1,0.0,0.0,0.0,0%,0.0,0.02, esmaeilpoursaee,,CE-3510,2020
+CE,3520,1.0,Econ Eval of Proj,0.63,0.32,0.04,0.0,0.01,0%,0.0,0.0,da li,,CE-3520,2020
+CE,4010,1.0,Matrix Str Analysis,0.24,0.35,0.18,0.12,0.12,0%,0.0,0.0,laura mae redmond,,CE-4010,2020
+CE,4020,1.0,Reinfor Con Design,0.35,0.41,0.09,0.09,0.03,0%,0.0,0.03,laura mae redmond,,CE-4020,2020
+CE,4060,1.0,Struct Steel Design,0.47,0.37,0.1,0.07,0.0,0%,0.0,0.0,stephen csernak,,CE-4060,2020
+CE,4100,1.0,Traffic Engr Oper,0.32,0.23,0.18,0.18,0.05,0%,0.0,0.05,wayne sarasua,,CE-4100,2020
+CE,4240,1.0,Earth Slopes & Struc,0.3,0.32,0.25,0.14,0.0,0%,0.0,0.0, ravichandran,,CE-4240,2020
+CE,4330,1.0,Const Plan & Sched,0.52,0.3,0.17,0.0,0.0,0%,0.0,0.0,tuyen thanh le,,CE-4330,2020
+CE,4340,1.0,Const Est Proj Cont,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,kalyan ram piratla,,CE-4340,2020
+CE,4470,1.0,Stormwater Managemnt,0.4,0.37,0.13,0.1,0.0,0%,0.0,0.0,md chowdhury,,CE-4470,2020
+CE,4560,1.0,Pave Design & Constr,0.17,0.57,0.19,0.0,0.02,0%,0.0,0.05,bradley putman,,CE-4560,2020
+CE,4590,1.0,Capstone Design Proj,0.28,0.49,0.21,0.03,0.0,0%,0.0,0.0,zoraya rockow,,CE-4590,2020
+CE,4910,1.0,BIM in Construction Mana,0.64,0.27,0.0,0.0,0.05,0%,0.0,0.05,kalyan ram piratla,,CE-4910,2020
+CE,4910,3.0,Intro to Proj Mgt,0.62,0.29,0.05,0.0,0.0,0%,0.0,0.05,zoraya rockow,,CE-4910,2020
+CE,4990,109.0,Cr Inq in CE - CEment,0.82,0.14,0.0,0.0,0.0,0%,0.0,0.0,candice bolding,,CE-4990,2020
+CE,6010,1.0,Matrix Str Analysis,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,laura mae redmond,,CE-6010,2020
+CE,6910,5.0,Adv Concrete Technology,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,prasada rangaraju,,CE-6910,2020
+CE,8030,1.0,Adv Steel Design,0.32,0.58,0.05,0.0,0.05,0%,0.0,0.0,mohannad naser,,CE-8030,2020
+CE,8080,1.0,Earthquake Engr,0.9,0.05,0.0,0.0,0.05,0%,0.0,0.0,weichiang pang,,CE-8080,2020
+CE,8460,1.0,Flow in Open Chnls,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,abdul khan,,CE-8460,2020
+CE,8540,1.0,Travl Demnd Forecast,0.57,0.14,0.0,0.0,0.0,0%,0.0,0.0,pamela murray-tuite,,CE-8540,2020
+CE,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jennifer ogle,,CE-9910,2020
+CE,9910,18.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mashrur chowdhury,,CE-9910,2020
+CH,1010,1.0,General Chemistry,0.17,0.38,0.16,0.1,0.09,0%,0.0,0.09,thomas hickman,,CH-1010,2020
+CH,1010,2.0,General Chemistry,0.15,0.35,0.18,0.09,0.09,0%,0.0,0.13,thao thi thanh tran thanh,,CH-1010,2020
+CH,1010,3.0,General Chemistry,0.16,0.39,0.16,0.12,0.06,0%,0.0,0.1,william mcwhorter,,CH-1010,2020
+CH,1010,4.0,General Chemistry,0.23,0.28,0.26,0.12,0.07,0%,0.0,0.04,jacob schroeder,,CH-1010,2020
+CH,1010,5.0,General Chemistry,0.28,0.27,0.21,0.12,0.07,0%,0.0,0.05,thomas hickman,,CH-1010,2020
+CH,1010,6.0,General Chemistry,0.31,0.29,0.18,0.08,0.05,0%,0.0,0.1,dennis taylor,,CH-1010,2020
+CH,1010,7.0,General Chemistry,0.12,0.27,0.24,0.1,0.17,0%,0.0,0.11,olt geiculescu,,CH-1010,2020
+CH,1010,8.0,General Chemistry,0.11,0.29,0.26,0.08,0.08,0%,0.0,0.18,princess mycia cox,,CH-1010,2020
+CH,1010,9.0,General Chemistry,0.23,0.42,0.19,0.08,0.05,0%,0.0,0.04,ashlyn dennis smith,,CH-1010,2020
+CH,1010,10.0,General Chemistry,0.22,0.22,0.26,0.12,0.1,0%,0.0,0.08,william mcwhorter,,CH-1010,2020
+CH,1010,11.0,General Chemistry,0.25,0.42,0.14,0.09,0.08,0%,0.0,0.02,thomas hickman,,CH-1010,2020
+CH,1010,12.0,General Chemistry,0.32,0.31,0.21,0.05,0.03,0%,0.0,0.08,ashlyn dennis smith,,CH-1010,2020
+CH,1010,13.0,General Chemistry,0.21,0.29,0.19,0.1,0.08,0%,0.0,0.13,princess mycia cox,,CH-1010,2020
+CH,1010,14.0,General Chemistry,0.25,0.34,0.25,0.07,0.06,0%,0.0,0.05,tania houjeiry,,CH-1010,2020
+CH,1010,15.0,General Chemistry,0.24,0.29,0.17,0.15,0.05,0%,0.0,0.11,dennis taylor,,CH-1010,2020
+CH,1010,16.0,General Chemistry,0.1,0.39,0.25,0.08,0.08,0%,0.0,0.08,jacob schroeder,,CH-1010,2020
+CH,1010,50.0,General Chemistry,0.36,0.45,0.05,0.09,0.05,0%,0.0,0.0,tania houjeiry,,CH-1010,2020
+CH,1010,71.0,General Chemistry (HON),0.5,0.4,0.05,0.0,0.05,0%,0.0,0.0,joseph thrasher,True,CH-1010,2020
+CH,1010,72.0,General Chemistry (HON),0.57,0.29,0.07,0.07,0.0,0%,0.0,0.0,shiou-jyh hwu,True,CH-1010,2020
+CH,1010,400.0,General Chemistry,0.03,0.18,0.2,0.13,0.18,0%,0.0,0.3,princess mycia cox,,CH-1010,2020
+CH,1020,1.0,General Chemistry,0.31,0.24,0.2,0.16,0.04,0%,0.0,0.04, schvaneveldt,,CH-1020,2020
+CH,1020,2.0,General Chemistry,0.32,0.18,0.24,0.1,0.08,0%,0.0,0.07, schvaneveldt,,CH-1020,2020
+CH,1020,3.0,General Chemistry,0.26,0.28,0.27,0.1,0.04,0%,0.0,0.05, schvaneveldt,,CH-1020,2020
+CH,1020,400.0,General Chemistry,0.23,0.19,0.19,0.19,0.08,0%,0.0,0.13, schvaneveldt,,CH-1020,2020
+CH,1050,2.0,Chemistry in Context I,0.63,0.24,0.07,0.01,0.03,0%,0.0,0.03,olt geiculescu,,CH-1050,2020
+CH,2010,1.0,Survey of Organic Chemist,0.94,0.06,0.01,0.0,0.0,0%,0.0,0.0,modi wetzler,,CH-2010,2020
+CH,2230,1.0,Organic Chemistry,0.43,0.32,0.11,0.06,0.08,0%,0.0,0.02,tania houjeiry,,CH-2230,2020
+CH,2230,2.0,Organic Chemistry,0.22,0.21,0.3,0.12,0.1,0%,0.0,0.04,modi wetzler,,CH-2230,2020
+CH,2230,3.0,Organic Chemistry,0.48,0.21,0.14,0.07,0.06,0%,0.0,0.04,elliot ennis,,CH-2230,2020
+CH,2230,4.0,Organic Chemistry,0.31,0.28,0.17,0.09,0.1,0%,0.0,0.05,modi wetzler,,CH-2230,2020
+CH,2230,6.0,Organic Chemistry,0.5,0.26,0.12,0.03,0.05,0%,0.0,0.03,rhett smith,,CH-2230,2020
+CH,2230,7.0,Organic Chemistry,0.46,0.25,0.1,0.04,0.09,0%,0.0,0.05,rhett smith,,CH-2230,2020
+CH,2230,8.0,Organic Chemistry,0.23,0.15,0.33,0.14,0.13,0%,0.0,0.03,william mcwhorter,,CH-2230,2020
+CH,2230,50.0,Organic Chemistry,0.27,0.47,0.2,0.0,0.07,0%,0.0,0.0,byoungmoo kim,,CH-2230,2020
+CH,2240,1.0,Organic Chemistry,0.29,0.17,0.18,0.13,0.15,0%,0.0,0.08,elliot ennis,,CH-2240,2020
+CH,2240,2.0,Organic Chemistry,0.19,0.18,0.22,0.23,0.1,0%,0.0,0.09,elliot ennis,,CH-2240,2020
+CH,2270,9.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,,CH-2270,2020
+CH,2270,13.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,james plampin,,CH-2270,2020
+CH,2270,18.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,,CH-2270,2020
+CH,2270,28.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,james plampin,,CH-2270,2020
+CH,2280,1.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,,CH-2280,2020
+CH,2280,2.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.09,james plampin,,CH-2280,2020
+CH,2280,4.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,,CH-2280,2020
+CH,2280,5.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.09,james plampin,,CH-2280,2020
+CH,2280,6.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,,CH-2280,2020
+CH,2280,7.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,,CH-2280,2020
+CH,3130,1.0,Quantitative Analysis,0.22,0.31,0.24,0.11,0.04,0%,0.0,0.07,olt geiculescu,,CH-3130,2020
+CH,3150,1.0,Quant Analysis Lab,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,jeffrey nathan anker,,CH-3150,2020
+CH,3150,2.0,Quant Analysis Lab,0.73,0.0,0.09,0.0,0.0,0%,0.0,0.18,jeffrey nathan anker,,CH-3150,2020
+CH,3150,3.0,Quant Analysis Lab,0.31,0.31,0.08,0.0,0.23,0%,0.0,0.0,jeffrey nathan anker,,CH-3150,2020
+CH,3300,1.0,Intro to Phys Chem,0.61,0.22,0.07,0.01,0.03,0%,0.0,0.04,brian dominy,,CH-3300,2020
+CH,3310,1.0,Physical Chemistry,0.34,0.36,0.18,0.02,0.1,0%,0.0,0.0,steven stuart,,CH-3310,2020
+CH,3390,1.0,Physical Chem Lab,0.71,0.19,0.05,0.0,0.05,0%,0.0,0.0,princess mycia cox,,CH-3390,2020
+CH,3390,2.0,Physical Chem Lab,0.58,0.26,0.16,0.0,0.0,0%,0.0,0.0,princess mycia cox,,CH-3390,2020
+CH,3390,3.0,Physical Chem Lab,0.74,0.11,0.0,0.0,0.0,0%,0.0,0.16,princess mycia cox,,CH-3390,2020
+CH,3390,4.0,Physical Chem Lab,0.76,0.19,0.0,0.0,0.05,0%,0.0,0.0,princess mycia cox,,CH-3390,2020
+CH,3390,5.0,Physical Chem Lab,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,princess mycia cox,,CH-3390,2020
+CH,3410,1.0,Introduction to Research,0.76,0.08,0.04,0.02,0.1,0%,0.0,0.0,perez carlos garcia,,CH-3410,2020
+CH,4020,1.0,Inorganic Chemistry,0.5,0.42,0.02,0.0,0.04,0%,0.0,0.02,joseph kolis,,CH-4020,2020
+CH,4210,1.0,Advanced Organic Chemist,0.33,0.44,0.22,0.0,0.0,0%,0.0,0.0,jacob schroeder,,CH-4210,2020
+CH,6020,1.0,Inorganic Chemistry,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,joseph kolis,,CH-6020,2020
+CH,6210,1.0,Adv Organic Chem,0.17,0.5,0.17,0.0,0.0,0%,0.0,0.17,jacob schroeder,,CH-6210,2020
+CH,8070,1.0,Chem Trans Elem,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,julia brumaghim,,CH-8070,2020
+CH,8120,1.0,Chemical Spectroscopic M,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,george chumanov,,CH-8120,2020
+CH,8150,1.0,Mass Spectrometry,0.36,0.36,0.27,0.0,0.0,0%,0.0,0.0,richard marcus,,CH-8150,2020
+CH,8210,1.0,Organic Chem I,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,ya-ping sun,,CH-8210,2020
+CH,8370,1.0,Quantum Chemistry,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,leah beck casabianca,,CH-8370,2020
+CH,8510,2.0,Grad Student Seminar,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,sourav saha,,CH-8510,2020
+CH,8520,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,93%,0.03,0.03,joseph thrasher,,CH-8520,2020
+CH,9910,2.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel whitehead,,CH-9910,2020
+CH,9910,7.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rhett smith,,CH-9910,2020
+CH,9910,11.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,richard marcus,,CH-9910,2020
+CH,9910,25.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey nathan anker,,CH-9910,2020
+CH,9910,99.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,perez carlos garcia,,CH-9910,2020
+CHE,2110,1.0,Mass and Energy Balances,0.24,0.29,0.26,0.12,0.05,0%,0.0,0.05,mark roberts,,CHE-2110,2020
+CHE,3070,1.0,Unit Ops Lab I,0.18,0.47,0.35,0.0,0.0,0%,0.0,0.0,christopher norfolk,,CHE-3070,2020
+CHE,3210,1.0,Ch E Thermo II,0.08,0.27,0.39,0.19,0.03,0%,0.0,0.03,sapna sarupria,,CHE-3210,2020
+CHE,3300,1.0,Mass Trans & Seprtn,0.35,0.26,0.26,0.08,0.03,0%,0.0,0.03,david bruce,,CHE-3300,2020
+CHE,4070,1.0,Unit Op Lab II,0.28,0.4,0.29,0.03,0.0,0%,0.0,0.0,christopher norfolk,,CHE-4070,2020
+CHE,4310,1.0,Process Design I,0.26,0.53,0.18,0.01,0.01,0%,0.0,0.0,suzanne deirdre roat,,CHE-4310,2020
+CHE,4430,1.0,"Safety, Env & Prof Practice",0.86,0.11,0.04,0.0,0.0,0%,0.0,0.0,scott husson,,CHE-4430,2020
+CHE,4500,1.0,Chem Reaction Engr,0.29,0.39,0.2,0.09,0.03,0%,0.0,0.0,rachel getman,,CHE-4500,2020
+CHE,6130,1.0,Polymer Composite Engine,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,amod ogale,,CHE-6130,2020
+CHE,8030,1.0,Advanced Transport,0.45,0.45,0.09,0.0,0.0,0%,0.0,0.0,eric mikel davis,,CHE-8030,2020
+CHE,8900,1.0,GAANN SEMINAR,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eric mikel davis,,CHE-8900,2020
+CHE,8950,1.0,Graduate Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jessica marie larsen,,CHE-8950,2020
+CHE,9910,2.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mark alan blenner,,CHE-9910,2020
+CHE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,scott husson,,CHE-9910,2020
+CHE,9910,11.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sapna sarupria,,CHE-9910,2020
+CHE,9910,13.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mark thies,,CHE-9910,2020
+CHIN,1010,2.0,Elementary Chinese,0.38,0.0,0.15,0.0,0.15,0%,0.0,0.31,yanhua zhang,,CHIN-1010,2020
+CHIN,3130,1.0,Philosophy in Modern Chin,0.5,0.25,0.05,0.0,0.05,0%,0.0,0.15,yanming an,,CHIN-3130,2020
+CHIN,4990,1.0,Slct Tpcs Chin Cult,0.35,0.45,0.15,0.0,0.0,0%,0.0,0.05,kyle david anderson,,CHIN-4990,2020
+COM,1010,1.0,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,96%,0.0,0.04,lori marlise pindar,,COM-1010,2020
+COM,1500,1.0,Intro to Human Communic,0.86,0.07,0.03,0.01,0.01,0%,0.0,0.01,daniel leland fecher,,COM-1500,2020
+COM,1500,2.0,Intro to Human Communic,0.73,0.18,0.03,0.02,0.02,0%,0.0,0.01,daniel leland fecher,,COM-1500,2020
+COM,1500,3.0,Intro to Human Communic,0.78,0.16,0.05,0.01,0.0,0%,0.0,0.0,daniel leland fecher,,COM-1500,2020
+COM,1500,4.0,Intro to Human Communic,0.82,0.11,0.03,0.01,0.02,0%,0.0,0.02,marianne herr glaser,,COM-1500,2020
+COM,1500,5.0,Intro to Human Communic,0.82,0.11,0.02,0.02,0.02,0%,0.0,0.01,marianne herr glaser,,COM-1500,2020
+COM,1500,6.0,Intro to Human Communic,0.79,0.16,0.03,0.01,0.0,0%,0.0,0.01,marianne herr glaser,,COM-1500,2020
+COM,1500,7.0,Intro to Human Communic,0.73,0.12,0.08,0.03,0.03,0%,0.0,0.01,vanessa condon,,COM-1500,2020
+COM,2010,1.0,Intr to Comm Studies,0.67,0.19,0.04,0.0,0.04,0%,0.0,0.07,caitlin baker,,COM-2010,2020
+COM,2010,2.0,Intr to Comm Studies,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,caitlin baker,,COM-2010,2020
+COM,2020,1.0,Communication Theory,0.75,0.21,0.04,0.0,0.0,0%,0.0,0.0,kristen okamoto,,COM-2020,2020
+COM,2040,1.0,Critical-Cultural Comm The,0.65,0.17,0.13,0.0,0.04,0%,0.0,0.0,james gilmore,,COM-2040,2020
+COM,2100,1.0,Quant Comm Research Me,0.44,0.48,0.08,0.0,0.0,0%,0.0,0.0,erin michelle ash,,COM-2100,2020
+COM,2500,2.0,Public Speaking,0.6,0.3,0.05,0.0,0.05,0%,0.0,0.0,sara crocker,,COM-2500,2020
+COM,2500,3.0,Public Speaking,0.6,0.25,0.05,0.05,0.0,0%,0.0,0.05,elizabeth gilmore,,COM-2500,2020
+COM,2500,4.0,Public Speaking,0.75,0.15,0.1,0.0,0.0,0%,0.0,0.0,elizabeth gilmore,,COM-2500,2020
+COM,2500,5.0,Public Speaking,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,alyssa christine davis,,COM-2500,2020
+COM,2500,6.0,Public Speaking,0.7,0.25,0.05,0.0,0.0,0%,0.0,0.0,alyssa christine davis,,COM-2500,2020
+COM,2500,7.0,Public Speaking,0.65,0.3,0.05,0.0,0.0,0%,0.0,0.0,sara crocker,,COM-2500,2020
+COM,2500,8.0,Public Speaking,0.55,0.35,0.05,0.0,0.05,0%,0.0,0.0,ashley lauren pikel,,COM-2500,2020
+COM,2500,9.0,Public Speaking,0.65,0.1,0.15,0.0,0.05,0%,0.0,0.05,sara crocker,,COM-2500,2020
+COM,2500,10.0,Public Speaking,0.47,0.37,0.05,0.05,0.05,0%,0.0,0.0,ashley lauren pikel,,COM-2500,2020
+COM,2500,11.0,Public Speaking,0.68,0.21,0.05,0.0,0.0,0%,0.0,0.05,ashley lauren pikel,,COM-2500,2020
+COM,2500,14.0,Public Speaking,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,elizabeth gilmore,,COM-2500,2020
+COM,2500,16.0,Public Speaking,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,jumah patricia taweh,,COM-2500,2020
+COM,2500,17.0,Public Speaking,0.79,0.05,0.05,0.0,0.11,0%,0.0,0.0,jumah patricia taweh,,COM-2500,2020
+COM,2500,18.0,Public Speaking,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,marshall covert,,COM-2500,2020
+COM,2500,19.0,Public Speaking,0.79,0.16,0.0,0.0,0.0,0%,0.0,0.05,jumah patricia taweh,,COM-2500,2020
+COM,2500,20.0,Public Speaking,0.75,0.15,0.05,0.0,0.0,0%,0.0,0.05,vanessa condon,,COM-2500,2020
+COM,2500,21.0,Public Speaking,0.75,0.2,0.0,0.0,0.0,0%,0.0,0.05,charles john brewer,,COM-2500,2020
+COM,2500,22.0,Public Speaking,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,charles john brewer,,COM-2500,2020
+COM,2500,23.0,Public Speaking,0.74,0.16,0.11,0.0,0.0,0%,0.0,0.0,charles john brewer,,COM-2500,2020
+COM,2500,24.0,Public Speaking,0.78,0.17,0.0,0.0,0.06,0%,0.0,0.0,charles john brewer,,COM-2500,2020
+COM,2500,25.0,Public Speaking,0.6,0.35,0.0,0.05,0.0,0%,0.0,0.0,marshall covert,,COM-2500,2020
+COM,2500,26.0,Public Speaking,0.55,0.35,0.05,0.0,0.05,0%,0.0,0.0,marshall covert,,COM-2500,2020
+COM,2500,27.0,Public Speaking,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,marshall covert,,COM-2500,2020
+COM,2500,28.0,Public Speaking,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,katie mcelveen,,COM-2500,2020
+COM,2500,29.0,Public Speaking,0.74,0.16,0.05,0.05,0.0,0%,0.0,0.0,vanessa condon,,COM-2500,2020
+COM,2500,31.0,Public Speaking,0.85,0.0,0.05,0.05,0.05,0%,0.0,0.0,katie mcelveen,,COM-2500,2020
+COM,2500,33.0,Public Speaking,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,ashley lauren pikel,,COM-2500,2020
+COM,2500,401.0,Public Speaking,0.8,0.15,0.0,0.0,0.05,0%,0.0,0.0,alexis zachary davis,,COM-2500,2020
+COM,2500,402.0,Public Speaking,0.75,0.1,0.1,0.05,0.0,0%,0.0,0.0,alexis zachary davis,,COM-2500,2020
+COM,2500,403.0,Public Speaking,0.85,0.05,0.0,0.0,0.1,0%,0.0,0.0,alexis zachary davis,,COM-2500,2020
+COM,3050,1.0,Persuasion,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,lindsey dixon,,COM-3050,2020
+COM,3200,1.0,Bdcst Production,0.87,0.0,0.04,0.04,0.04,0%,0.0,0.0,wanda johnson,,COM-3200,2020
+COM,3240,1.0,"Communication, Sport & S",0.68,0.2,0.04,0.0,0.04,0%,0.0,0.04,brandon boatwright,,COM-3240,2020
+COM,3240,2.0,"Communication, Sport & S",0.5,0.32,0.18,0.0,0.0,0%,0.0,0.0,brandon boatwright,,COM-3240,2020
+COM,3250,1.0,Survey of Sports Communi,0.67,0.17,0.13,0.03,0.0,0%,0.0,0.0,virginia harrison,,COM-3250,2020
+COM,3260,1.0,Pr in Sports,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,katie mcelveen,,COM-3260,2020
+COM,3260,2.0,Pr in Sports,0.83,0.07,0.03,0.0,0.0,0%,0.0,0.07,katie mcelveen,,COM-3260,2020
+COM,3270,1.0,Sports Media Criticism,0.32,0.64,0.0,0.0,0.0,0%,0.0,0.04,bryan denham,,COM-3270,2020
+COM,3550,1.0,Principles of Public Relatio,0.5,0.27,0.14,0.05,0.0,0%,0.0,0.05,jordan morehouse,,COM-3550,2020
+COM,3570,1.0,Public Relations Writing,0.52,0.29,0.05,0.05,0.05,0%,0.0,0.05,jordan morehouse,,COM-3570,2020
+COM,3660,3.0,Ugrad Comm Tutors,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,alyssa christine davis,,COM-3660,2020
+COM,3660,4.0,Storytelling and Reporting,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,nigel robertson,,COM-3660,2020
+COM,3900,1.0,Communication Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,lori marlise pindar,,COM-3900,2020
+COM,4280,1.0,Interpers/Family Comm &,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,gregory cranmer,,COM-4280,2020
+COM,4560,1.0,PR for Assoc & Nonprofits,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,virginia harrison,,COM-4560,2020
+COM,4700,1.0,Comm & Health,0.36,0.45,0.14,0.0,0.0,0%,0.0,0.05,victoria wingate,,COM-4700,2020
+COM,4800,1.0,Intercultural Comm,0.8,0.16,0.04,0.0,0.0,0%,0.0,0.0,andrew stephen pyle,,COM-4800,2020
+COM,4800,2.0,Intercultural Comm,0.92,0.04,0.0,0.0,0.04,0%,0.0,0.0,andrew stephen pyle,,COM-4800,2020
+COM,4950,2.0,Senior Capstone Seminar,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,david travers scott,,COM-4950,2020
+COM,8000,1.0,Communication Pedagogy,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel leland fecher,,COM-8000,2020
+COM,8010,1.0,Communication Theory I,0.73,0.18,0.0,0.0,0.0,0%,0.0,0.09,darren linvill,,COM-8010,2020
+COM,8100,1.0,Comm Research Methods I,0.47,0.4,0.13,0.0,0.0,0%,0.0,0.0,gregory cranmer,,COM-8100,2020
+COM,8270,1.0,Sports Media,0.57,0.29,0.0,0.0,0.0,0%,0.0,0.14,bryan denham,,COM-8270,2020
+COM,8910,1.0,Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,erin michelle ash,,COM-8910,2020
+COOP,1010,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,,COOP-1010,2020
+COOP,1020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,,COOP-1020,2020
+COOP,1030,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,,COOP-1030,2020
+COOP,2010,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,,COOP-2010,2020
+COOP,2020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,,COOP-2020,2020
+COOP,6020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,'neil burton,,COOP-6020,2020
+CPSC,1010,10.0,Computer Science I,0.15,0.31,0.25,0.04,0.1,0%,0.0,0.13,scoy roger larry van larry,,CPSC-1010,2020
+CPSC,1010,20.0,Computer Science I,0.39,0.2,0.16,0.1,0.02,0%,0.0,0.14,carrie lynn russell,,CPSC-1010,2020
+CPSC,1010,30.0,Computer Science I,0.2,0.37,0.2,0.06,0.06,0%,0.0,0.12,carrie lynn russell,,CPSC-1010,2020
+CPSC,1020,10.0,Computer Science II,0.24,0.29,0.18,0.11,0.07,0%,0.0,0.11,catherine kittelstad,,CPSC-1020,2020
+CPSC,1060,10.0,Intro to Programming in Ja,0.37,0.24,0.11,0.05,0.11,0%,0.0,0.13,svetlana drachova,,CPSC-1060,2020
+CPSC,1060,20.0,Intro to Programming in Ja,0.31,0.17,0.22,0.19,0.08,0%,0.0,0.03,svetlana drachova,,CPSC-1060,2020
+CPSC,1060,30.0,Intro to Programming in Ja,0.14,0.11,0.33,0.14,0.14,0%,0.0,0.14,christina joerg,,CPSC-1060,2020
+CPSC,1070,1.0,Programming Methodolog,0.26,0.27,0.27,0.04,0.07,0%,0.0,0.1,christopher plaue,,CPSC-1070,2020
+CPSC,1110,1.0,Intro to Programming in C,0.34,0.31,0.16,0.05,0.06,0%,0.0,0.07,andrew duchowski,,CPSC-1110,2020
+CPSC,1110,2.0,Intro to Programming in C,0.39,0.27,0.22,0.04,0.02,0%,0.0,0.06,nicolas widman,,CPSC-1110,2020
+CPSC,1210,1.0,Computational Thinking,0.26,0.26,0.34,0.03,0.05,0%,0.0,0.05,mitch shue,,CPSC-1210,2020
+CPSC,1900,1.0,Teaching Assist Fundamen,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eileen kraemer,,CPSC-1900,2020
+CPSC,2070,1.0,Discrete Structures,0.44,0.37,0.14,0.03,0.02,0%,0.0,0.0,larry hodges,,CPSC-2070,2020
+CPSC,2070,2.0,Discrete Structures,0.38,0.27,0.29,0.06,0.0,0%,0.0,0.0,larry hodges,,CPSC-2070,2020
+CPSC,2070,3.0,Discrete Structures,0.46,0.19,0.3,0.0,0.03,0%,0.0,0.03,pradip srimani,,CPSC-2070,2020
+CPSC,2120,1.0,Algs/Data Structures,0.52,0.16,0.11,0.07,0.08,0%,0.0,0.05,nicolas widman,,CPSC-2120,2020
+CPSC,2120,2.0,Algs/Data Structures,0.48,0.18,0.1,0.03,0.13,0%,0.0,0.08,nicolas widman,,CPSC-2120,2020
+CPSC,2120,101.0,Algs/Data Structures,0.4,0.2,0.04,0.04,0.08,0%,0.0,0.24,brian dean,,CPSC-2120,2020
+CPSC,2120,102.0,Algs/Data Structures,0.28,0.24,0.28,0.0,0.04,0%,0.0,0.16,brian dean,,CPSC-2120,2020
+CPSC,2120,103.0,Algs/Data Structures,0.17,0.26,0.3,0.04,0.09,0%,0.0,0.13,brian dean,,CPSC-2120,2020
+CPSC,2150,1.0,Software Dev Foundations,0.22,0.27,0.2,0.07,0.16,0%,0.0,0.09,yu-shan sun,,CPSC-2150,2020
+CPSC,2150,2.0,Software Dev Foundations,0.24,0.24,0.2,0.02,0.13,0%,0.0,0.17,yu-shan sun,,CPSC-2150,2020
+CPSC,2150,3.0,Software Dev Foundations,0.15,0.25,0.2,0.1,0.15,0%,0.0,0.15,murali sitaraman,,CPSC-2150,2020
+CPSC,2200,1.0,Problem Solving w/ Office,0.52,0.22,0.14,0.06,0.04,0%,0.0,0.02,catherine kittelstad,,CPSC-2200,2020
+CPSC,2310,1.0,Intro Computer Org,0.23,0.29,0.28,0.03,0.1,0%,0.0,0.07,yvon feaster,,CPSC-2310,2020
+CPSC,2910,1.0,Prof Issues I,0.83,0.1,0.0,0.03,0.03,0%,0.0,0.0,constance taylor,,CPSC-2910,2020
+CPSC,2910,2.0,Prof Issues I,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,constance taylor,,CPSC-2910,2020
+CPSC,2910,3.0,Prof Issues I,0.68,0.1,0.13,0.06,0.0,0%,0.0,0.03,constance taylor,,CPSC-2910,2020
+CPSC,2920,1.0,"Computing, Ethics & Societ",0.8,0.05,0.08,0.0,0.03,0%,0.0,0.05,julian brinkley,,CPSC-2920,2020
+CPSC,3220,1.0,Intro to Operating Systems,0.31,0.21,0.1,0.04,0.09,0%,0.0,0.21,jacob sorber,,CPSC-3220,2020
+CPSC,3220,2.0,Intro to Operating Systems,0.59,0.17,0.04,0.0,0.04,0%,0.0,0.04,brygg anders ullmer,,CPSC-3220,2020
+CPSC,3300,1.0,Computer Systems Org,0.4,0.33,0.15,0.08,0.01,0%,0.0,0.03,mark smotherman,,CPSC-3300,2020
+CPSC,3500,1.0,Foundations of Computer,0.2,0.37,0.27,0.0,0.1,0%,0.0,0.06,sandra hedetniemi,,CPSC-3500,2020
+CPSC,3520,1.0,Programming Systems,0.76,0.1,0.06,0.01,0.06,0%,0.0,0.01,yongkai wu,,CPSC-3520,2020
+CPSC,3600,1.0,Network Programming,0.48,0.26,0.13,0.03,0.04,0%,0.0,0.05,andrew robb,,CPSC-3600,2020
+CPSC,3720,1.0,Software Engineering,0.25,0.44,0.24,0.05,0.02,0%,0.0,0.0,yu-shan sun,,CPSC-3720,2020
+CPSC,3720,2.0,Software Engineering,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,constance taylor,,CPSC-3720,2020
+CPSC,3750,1.0,Web Application Develop,0.52,0.27,0.06,0.04,0.1,0%,0.0,0.0,craig baker,,CPSC-3750,2020
+CPSC,4030,1.0,Data Visualization,0.21,0.5,0.21,0.0,0.04,0%,0.0,0.04,federico iuricich,,CPSC-4030,2020
+CPSC,4040,1.0,Cmptr Graphics Image,0.76,0.12,0.0,0.0,0.06,0%,0.0,0.06,jerry tessendorf,,CPSC-4040,2020
+CPSC,4050,1.0,Computer Graphics,0.38,0.17,0.04,0.04,0.0,0%,0.0,0.33,yin yang,,CPSC-4050,2020
+CPSC,4110,1.0,Virtual Reality Systems,0.57,0.3,0.13,0.0,0.0,0%,0.0,0.0,sabarish venkat babu,,CPSC-4110,2020
+CPSC,4140,1.0,Human and Computer Inte,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,nathaniel mcneese,,CPSC-4140,2020
+CPSC,4160,1.0,2-D Game Engine Construc,0.58,0.15,0.08,0.05,0.08,0%,0.0,0.08,victor zordan,,CPSC-4160,2020
+CPSC,4200,1.0,Computer Security Principl,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,long cheng,,CPSC-4200,2020
+CPSC,4240,1.0,System Admin and Securit,0.63,0.33,0.0,0.0,0.04,0%,0.0,0.0,svetlana drachova,,CPSC-4240,2020
+CPSC,4300,1.0,Applied Data Science,0.41,0.3,0.07,0.0,0.07,0%,0.0,0.07,xizhou feng,,CPSC-4300,2020
+CPSC,4300,2.0,Applied Data Science,0.53,0.12,0.18,0.0,0.12,0%,0.0,0.06,alexander herzog,,CPSC-4300,2020
+CPSC,4420,1.0,Artificial Intelligence,0.71,0.14,0.1,0.0,0.05,0%,0.0,0.0,ioannis karamouzas,,CPSC-4420,2020
+CPSC,4430,1.0,Machine Learning: Impl &,0.83,0.13,0.0,0.0,0.04,0%,0.0,0.0,larry hodges,,CPSC-4430,2020
+CPSC,4440,1.0,Cloud Computing Architect,0.35,0.61,0.04,0.0,0.0,0%,0.0,0.0,mitch shue,,CPSC-4440,2020
+CPSC,4620,1.0,Database Management Sy,0.48,0.19,0.14,0.0,0.14,0%,0.0,0.05,pradip srimani,,CPSC-4620,2020
+CPSC,4620,2.0,Database Management Sy,0.33,0.5,0.06,0.0,0.0,0%,0.0,0.11,zijun wang,,CPSC-4620,2020
+CPSC,4770,1.0,Distributed/Cluster Compu,0.47,0.37,0.05,0.0,0.05,0%,0.0,0.05,shuangshuang jin,,CPSC-4770,2020
+CPSC,4780,1.0,Gen Purpose Computation,0.27,0.18,0.0,0.09,0.18,0%,0.0,0.27,shuangshuang jin,,CPSC-4780,2020
+CPSC,4890,1.0,Programming Team Semin,0.67,0.27,0.07,0.0,0.0,0%,0.0,0.0,brian dean,,CPSC-4890,2020
+CPSC,4910,1.0,Professional Issues II,0.53,0.43,0.03,0.0,0.0,0%,0.0,0.0,scoy roger larry van larry,,CPSC-4910,2020
+CPSC,4910,2.0,Professional Issues II,0.28,0.52,0.16,0.04,0.0,0%,0.0,0.0,scoy roger larry van larry,,CPSC-4910,2020
+CPSC,4910,3.0,Professional Issues II,0.78,0.17,0.04,0.0,0.0,0%,0.0,0.0,alexander herzog,,CPSC-4910,2020
+CPSC,6040,1.0,Cptr Graphics Image,0.83,0.11,0.06,0.0,0.0,0%,0.0,0.0,jerry tessendorf,,CPSC-6040,2020
+CPSC,6050,1.0,Computer Graphics,0.69,0.15,0.08,0.0,0.0,0%,0.0,0.08,yin yang,,CPSC-6050,2020
+CPSC,6110,1.0,Virtual Reality Systems,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,sabarish venkat babu,,CPSC-6110,2020
+CPSC,6160,1.0,2-D Game Engine Construc,0.71,0.14,0.0,0.0,0.14,0%,0.0,0.0,victor zordan,,CPSC-6160,2020
+CPSC,6300,2.0,Applied Data Science,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,alexander herzog,,CPSC-6300,2020
+CPSC,6420,1.0,Artificial Intelligence,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,ioannis karamouzas,,CPSC-6420,2020
+CPSC,6440,1.0,Cloud Computing Architect,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,mitch shue,,CPSC-6440,2020
+CPSC,6620,1.0,Database Management Sy,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,pradip srimani,,CPSC-6620,2020
+CPSC,6620,2.0,Database Management Sy,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,zijun wang,,CPSC-6620,2020
+CPSC,6770,1.0,Distributed/Cluster Compu,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,shuangshuang jin,,CPSC-6770,2020
+CPSC,6810,1.0,Ind Study: MSCS Ready,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,eileen kraemer,,CPSC-6810,2020
+CPSC,6810,2.0,MSCS Ready: mod 2,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,eileen kraemer,,CPSC-6810,2020
+CPSC,8200,1.0,Parallel Architechture,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,rong ge,,CPSC-8200,2020
+CPSC,8420,1.0,Advanced Machine Learni,0.5,0.13,0.22,0.0,0.0,0%,0.0,0.16,kai liu,,CPSC-8420,2020
+CPSC,8470,1.0,Intro to Information Retrie,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,feng luo,,CPSC-8470,2020
+CPSC,8480,1.0,Network Science,0.59,0.18,0.12,0.0,0.06,0%,0.0,0.06,ilya mark safro,,CPSC-8480,2020
+CPSC,8510,1.0,Soft Sys Data Comm,0.67,0.11,0.11,0.0,0.0,0%,0.0,0.11,james martin,,CPSC-8510,2020
+CPSC,8580,1.0,Security in Emerging Syste,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,hongxin hu,,CPSC-8580,2020
+CPSC,8710,1.0,Found. of Software Engine,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,paige rodeghero,,CPSC-8710,2020
+CPSC,9500,1.0,Sel Top:SoC Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,long cheng,,CPSC-9500,2020
+CPSC,9500,2.0,Sel Topics: CS Edu Researc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eileen kraemer,,CPSC-9500,2020
+CPSC,9500,843.0,Sel Topics: SOC Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,long cheng,,CPSC-9500,2020
+CPSC,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brian dean,,CPSC-9910,2020
+CPSC,9910,14.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,hongxin hu,,CPSC-9910,2020
+CPSC,9910,24.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,feng luo,,CPSC-9910,2020
+CRP,4010,1.0,Intro to City & Regional Pla,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,john albert gaber,,CRP-4010,2020
+CRP,8010,1.0,Planning Process & Legal F,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,caitlin dyckman,,CRP-8010,2020
+CRP,8030,2.0,Quan Analysis for Planners,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,eric morris,,CRP-8030,2020
+CRP,8080,1.0,Land Use and Compreh Pla,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,santiago luis ramos,,CRP-8080,2020
+CRP,8140,1.0,Public Transit,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,eric morris,,CRP-8140,2020
+CRP,8580,2.0,Mixed Mthds for Planning,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,clifford donald ellis,,CRP-8580,2020
+CRP,8940,1.0,Professional Planning Semi,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,barry nocks,,CRP-8940,2020
+CSM,1000,1.0,Intro to Construct,0.81,0.1,0.0,0.03,0.06,0%,0.0,0.0,thomas fuduric,,CSM-1000,2020
+CSM,2010,1.0,Structures I,0.07,0.29,0.21,0.29,0.07,0%,0.0,0.07,shima clarke,,CSM-2010,2020
+CSM,2010,2.0,Structures I,0.0,0.36,0.14,0.21,0.14,0%,0.0,0.14,shima clarke,,CSM-2010,2020
+CSM,2010,401.0,Structures I,0.15,0.46,0.15,0.15,0.0,0%,0.0,0.08,shima clarke,,CSM-2010,2020
+CSM,2010,402.0,Structures I,0.0,0.08,0.54,0.15,0.0,0%,0.0,0.23,shima clarke,,CSM-2010,2020
+CSM,2030,401.0,Mats & Meth of Const,0.19,0.44,0.31,0.02,0.04,0%,0.0,0.0,jason lucas,,CSM-2030,2020
+CSM,2040,401.0,Cont Documents,0.38,0.41,0.1,0.1,0.0,0%,0.0,0.0,robert coffey,,CSM-2040,2020
+CSM,2050,1.0,Mats & Methods II,0.59,0.22,0.14,0.03,0.03,0%,0.0,0.0,nathaniel jackson,,CSM-2050,2020
+CSM,2060,1.0,Construction Science Work,0.82,0.06,0.12,0.0,0.0,0%,0.0,0.0,nathaniel jackson,,CSM-2060,2020
+CSM,2060,2.0,Construction Science Work,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,nathaniel jackson,,CSM-2060,2020
+CSM,2070,1.0,Construction Industry Sem,0.6,0.14,0.14,0.05,0.07,0%,0.0,0.0,thomas fuduric,,CSM-2070,2020
+CSM,3040,401.0,Environmental Systems I,0.48,0.39,0.09,0.02,0.02,0%,0.0,0.0,joseph burgett,,CSM-3040,2020
+CSM,3050,1.0,Environmental Systems II,0.15,0.38,0.31,0.0,0.12,0%,0.0,0.04,joseph burgett,,CSM-3050,2020
+CSM,3060,1.0,Emerging Tech in Construc,0.84,0.06,0.03,0.03,0.03,0%,0.0,0.0,harnish sharma,,CSM-3060,2020
+CSM,3060,401.0,Emerging Tech in Construc,0.68,0.18,0.09,0.0,0.0,0%,0.0,0.05,harnish sharma,,CSM-3060,2020
+CSM,3070,1.0,Sustainable Construction,0.54,0.42,0.0,0.0,0.04,0%,0.0,0.0,harnish sharma,,CSM-3070,2020
+CSM,3510,1.0,Construction Estimating,0.29,0.48,0.06,0.06,0.08,0%,0.0,0.02,rizi seyed mousavi,,CSM-3510,2020
+CSM,3520,1.0,Const Scheduling,0.38,0.46,0.13,0.04,0.0,0%,0.0,0.0,dennis bausman,,CSM-3520,2020
+CSM,3530,401.0,Const Estimating II,0.48,0.43,0.04,0.04,0.0,0%,0.0,0.0,anthony harden,,CSM-3530,2020
+CSM,4110,401.0,Safety in Bldg Const,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,nicholas corley,,CSM-4110,2020
+CSM,4500,1.0,Construction Internship,0.66,0.21,0.1,0.0,0.0,0%,0.0,0.03,nathaniel jackson,,CSM-4500,2020
+CSM,4530,1.0,Const Proj Mgmt,0.69,0.27,0.04,0.0,0.0,0%,0.0,0.0,dennis bausman,,CSM-4530,2020
+CSM,4540,1.0,Construction Capstone,0.6,0.33,0.07,0.0,0.0,0%,0.0,0.0,vivek sharma,,CSM-4540,2020
+CSM,4610,1.0,Const Econ Seminar,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0, nove-josserand,,CSM-4610,2020
+CSM,4980,2.0,Current Topics-NAHB Com,0.71,0.21,0.07,0.0,0.0,0%,0.0,0.0,jason lucas,,CSM-4980,2020
+CSM,8520,400.0,Const Mgmt Research,0.45,0.55,0.0,0.0,0.0,0%,0.0,0.0,vivek sharma,,CSM-8520,2020
+CSM,8650,400.0,Project Management,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,dhaval gajjar,,CSM-8650,2020
+CU,1000,37.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.15,0.0,susan whorton,,CU-1000,2020
+CU,1000,38.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,84%,0.12,0.01,susan whorton,,CU-1000,2020
+CU,1000,52.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.13,0.0,susan whorton,,CU-1000,2020
+CU,1000,53.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.15,0.01,susan whorton,,CU-1000,2020
+CU,1000,54.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,84%,0.12,0.01,susan whorton,,CU-1000,2020
+CU,1000,57.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,79%,0.18,0.01,susan whorton,,CU-1000,2020
+CU,1000,58.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,77%,0.17,0.0,susan whorton,,CU-1000,2020
+CU,1000,59.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,79%,0.14,0.01,susan whorton,,CU-1000,2020
+CU,1000,60.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,83%,0.13,0.0,susan whorton,,CU-1000,2020
+CU,1000,61.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,71%,0.28,0.01,susan whorton,,CU-1000,2020
+CU,1000,62.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,73%,0.26,0.0,susan whorton,,CU-1000,2020
+CU,1000,63.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,70%,0.29,0.0,susan whorton,,CU-1000,2020
+CU,1000,64.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,64%,0.27,0.02,susan whorton,,CU-1000,2020
+CU,1000,65.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,69%,0.26,0.01,susan whorton,,CU-1000,2020
+CU,1000,66.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,65%,0.32,0.01,susan whorton,,CU-1000,2020
+CU,1000,67.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,susan whorton,,CU-1000,2020
+CU,1010,1.0,Univ Success Skills,0.53,0.07,0.13,0.0,0.13,0%,0.0,0.13,bryn babb,,CU-1010,2020
+CU,1010,6.0,Univ Success Skills,0.7,0.1,0.1,0.0,0.1,0%,0.0,0.0,catherine neel,,CU-1010,2020
+CU,1110,4.0,Intro Supplemental Instruc,0.0,0.0,0.0,0.0,0.0,91%,0.0,0.09,rachel anderson,,CU-1110,2020
+CU,1110,5.0,Intro Supplemental Instruc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rachel anderson,,CU-1110,2020
+DPA,3070,1.0,Method 3d Production,0.21,0.13,0.04,0.0,0.17,0%,0.0,0.46,da costa florencio,,DPA-3070,2020
+DPA,4000,1.0,Tech Foundations I,0.47,0.18,0.06,0.06,0.18,0%,0.0,0.06,jessica baron,,DPA-4000,2020
+DPA,4020,1.0,Visual Found of Digital Pro,0.64,0.27,0.09,0.0,0.0,0%,0.0,0.0,anthony summey,,DPA-4020,2020
+DPA,4020,2.0,Visual Found of Digital Pro,0.23,0.54,0.08,0.0,0.15,0%,0.0,0.0,anthony summey,,DPA-4020,2020
+DPA,6000,843.0,Tech Foundations I,0.33,0.33,0.33,0.0,0.0,0%,0.0,0.0,eric patterson,,DPA-6000,2020
+DPA,6830,842.0,Spe Stu Top in DPA: Dig Ci,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,eric patterson,,DPA-6830,2020
+DPA,8090,1.0,Rendering and Shading,0.5,0.3,0.2,0.0,0.0,0%,0.0,0.0,daljit singh dhillon,,DPA-8090,2020
+DSA,8010,401.0,Statistical Methods I,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,deborah kunkel,,DSA-8010,2020
+DSA,8030,401.0,Intro to Statistical Computi,0.56,0.33,0.0,0.0,0.0,0%,0.0,0.11,ellen hepfer breazel,,DSA-8030,2020
+DSA,8640,1.0,Programming for Data Scie,0.83,0.1,0.03,0.0,0.0,0%,0.0,0.03,hongki kim,,DSA-8640,2020
+ECAS,2990,201.0,CI CU Eng for Dev Countrie,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,david vaughn,,ECAS-2990,2020
+ECAS,2990,301.0,CI SPECTRA,0.8,0.0,0.1,0.0,0.0,0%,0.0,0.1,joshua summers,,ECAS-2990,2020
+ECE,2010,1.0,Logic and Computing Devic,0.28,0.33,0.25,0.04,0.04,0%,0.0,0.04,hassan raza,,ECE-2010,2020
+ECE,2010,2.0,Logic & Comp Device (HO,0.53,0.2,0.13,0.07,0.07,0%,0.0,0.0,william reid,True,ECE-2010,2020
+ECE,2020,1.0,Electric Circuits I,0.15,0.32,0.25,0.09,0.11,0%,0.0,0.09,william harrell,,ECE-2020,2020
+ECE,2070,1.0,Basic Electrical Engineering,0.31,0.22,0.21,0.15,0.04,0%,0.0,0.07,wesley green,,ECE-2070,2020
+ECE,2070,2.0,Basic Electrical Engineering,0.2,0.2,0.28,0.11,0.13,0%,0.0,0.08,jeffrey osterberg,,ECE-2070,2020
+ECE,2070,3.0,Basic Electrical Engineering,0.37,0.32,0.18,0.08,0.05,0%,0.0,0.01,timothy anglea,,ECE-2070,2020
+ECE,2080,1.0,Basic Electrical Engr Lab,0.7,0.15,0.05,0.0,0.0,0%,0.0,0.1,apoorva kapadia,,ECE-2080,2020
+ECE,2080,2.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,,ECE-2080,2020
+ECE,2080,7.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,,ECE-2080,2020
+ECE,2080,8.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0%,0.0,0.1,apoorva kapadia,,ECE-2080,2020
+ECE,2080,9.0,Basic Electrical Engr Lab,0.88,0.0,0.0,0.0,0.06,0%,0.0,0.06,apoorva kapadia,,ECE-2080,2020
+ECE,2080,10.0,Basic Electrical Engr Lab,0.89,0.06,0.0,0.0,0.06,0%,0.0,0.0,apoorva kapadia,,ECE-2080,2020
+ECE,2080,13.0,Basic Electrical Engr Lab,0.7,0.1,0.0,0.0,0.1,0%,0.0,0.1,apoorva kapadia,,ECE-2080,2020
+ECE,2080,14.0,Basic Electrical Engr Lab,0.89,0.0,0.05,0.0,0.0,0%,0.0,0.05,apoorva kapadia,,ECE-2080,2020
+ECE,2080,15.0,Basic Electrical Engr Lab,0.85,0.05,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,,ECE-2080,2020
+ECE,2090,1.0,Logic & Computing Device,0.77,0.08,0.0,0.0,0.08,0%,0.0,0.08,apoorva kapadia,,ECE-2090,2020
+ECE,2090,2.0,Logic & Computing Device,0.75,0.0,0.0,0.0,0.25,0%,0.0,0.0,apoorva kapadia,,ECE-2090,2020
+ECE,2090,3.0,Logic & Computing Device,0.67,0.25,0.0,0.0,0.08,0%,0.0,0.0,apoorva kapadia,,ECE-2090,2020
+ECE,2090,4.0,Logic & Computing Device,0.45,0.09,0.09,0.09,0.18,0%,0.0,0.09,apoorva kapadia,,ECE-2090,2020
+ECE,2090,5.0,Logic & Computing Device,0.33,0.67,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,,ECE-2090,2020
+ECE,2090,6.0,Logic & Computing Device,0.7,0.0,0.0,0.0,0.1,0%,0.0,0.2,apoorva kapadia,,ECE-2090,2020
+ECE,2090,7.0,Logic & Computing Device,0.77,0.0,0.0,0.0,0.08,0%,0.0,0.15,apoorva kapadia,,ECE-2090,2020
+ECE,2090,12.0,Logic & Computing Device,0.36,0.18,0.0,0.0,0.0,0%,0.0,0.45,apoorva kapadia,,ECE-2090,2020
+ECE,2110,1.0,Elec Engr Lab I,0.7,0.15,0.1,0.0,0.05,0%,0.0,0.0,apoorva kapadia,,ECE-2110,2020
+ECE,2110,2.0,Elec Engr Lab I,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,apoorva kapadia,,ECE-2110,2020
+ECE,2110,3.0,Elec Engr Lab I,0.55,0.15,0.05,0.0,0.0,0%,0.0,0.25,apoorva kapadia,,ECE-2110,2020
+ECE,2110,5.0,Elec Engr Lab I,0.85,0.0,0.0,0.0,0.15,0%,0.0,0.0,apoorva kapadia,,ECE-2110,2020
+ECE,2110,6.0,Elec Engr Lab I,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,apoorva kapadia,,ECE-2110,2020
+ECE,2110,7.0,Elec Engr Lab I,0.7,0.1,0.0,0.0,0.0,0%,0.0,0.2,apoorva kapadia,,ECE-2110,2020
+ECE,2110,8.0,Elec Engr Lab I,0.58,0.26,0.05,0.0,0.0,0%,0.0,0.11,apoorva kapadia,,ECE-2110,2020
+ECE,2110,9.0,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.05,0%,0.0,0.0,apoorva kapadia,,ECE-2110,2020
+ECE,2110,10.0,Elec Engr Lab I,0.64,0.0,0.0,0.0,0.09,0%,0.0,0.27,apoorva kapadia,,ECE-2110,2020
+ECE,2120,1.0,Electrical Engineering Lab I,0.64,0.0,0.14,0.0,0.14,0%,0.0,0.07,apoorva kapadia,,ECE-2120,2020
+ECE,2120,3.0,Electrical Engineering Lab I,0.85,0.0,0.0,0.0,0.0,0%,0.0,0.15,apoorva kapadia,,ECE-2120,2020
+ECE,2120,4.0,Electrical Engineering Lab I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,,ECE-2120,2020
+ECE,2220,1.0,Syst Prog Concept,0.3,0.21,0.12,0.03,0.18,0%,0.0,0.15,lu yu,,ECE-2220,2020
+ECE,2230,1.0,Comp Sys Eng,0.22,0.24,0.19,0.17,0.02,0%,0.0,0.17,harlan russell,,ECE-2230,2020
+ECE,2620,1.0,Electric Circuits II,0.61,0.2,0.07,0.0,0.1,0%,0.0,0.02,liang dong,,ECE-2620,2020
+ECE,2720,1.0,Comp Organization,0.19,0.37,0.28,0.07,0.07,0%,0.0,0.02,william reid,,ECE-2720,2020
+ECE,2730,2.0,Computer Org Lab,0.46,0.38,0.08,0.0,0.08,0%,0.0,0.0,apoorva kapadia,,ECE-2730,2020
+ECE,2730,3.0,Computer Org Lab,0.38,0.38,0.13,0.06,0.0,0%,0.0,0.06,apoorva kapadia,,ECE-2730,2020
+ECE,2730,5.0,Computer Org Lab,0.5,0.3,0.1,0.0,0.0,0%,0.0,0.1,apoorva kapadia,,ECE-2730,2020
+ECE,3110,2.0,Electrical Engineering Lab I,0.73,0.13,0.0,0.07,0.07,0%,0.0,0.0,apoorva kapadia,,ECE-3110,2020
+ECE,3110,3.0,Electrical Engineering Lab I,0.81,0.13,0.0,0.0,0.0,0%,0.0,0.06,apoorva kapadia,,ECE-3110,2020
+ECE,3110,4.0,Electrical Engineering Lab I,0.53,0.18,0.0,0.0,0.24,0%,0.0,0.06,apoorva kapadia,,ECE-3110,2020
+ECE,3110,7.0,Electrical Engineering Lab I,0.65,0.12,0.06,0.0,0.0,0%,0.0,0.18,apoorva kapadia,,ECE-3110,2020
+ECE,3110,9.0,Electrical Engineering Lab I,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,,ECE-3110,2020
+ECE,3120,1.0,Electrical Engineering Lab I,0.75,0.15,0.0,0.05,0.05,0%,0.0,0.0,apoorva kapadia,,ECE-3120,2020
+ECE,3120,2.0,Electrical Engineering Lab I,0.75,0.13,0.06,0.0,0.06,0%,0.0,0.0,apoorva kapadia,,ECE-3120,2020
+ECE,3170,1.0,Rand Signal Analysis,0.52,0.31,0.1,0.03,0.0,0%,0.0,0.05,stephen hubbard,,ECE-3170,2020
+ECE,3200,1.0,Electronics I,0.42,0.18,0.17,0.1,0.08,0%,0.0,0.05,stephen hubbard,,ECE-3200,2020
+ECE,3200,2.0,Electronics I (HON),0.4,0.5,0.1,0.0,0.0,0%,0.0,0.0,stephen hubbard,True,ECE-3200,2020
+ECE,3210,1.0,Electronics II,0.36,0.44,0.21,0.0,0.0,0%,0.0,0.0,tehseen raza,,ECE-3210,2020
+ECE,3220,1.0,Intro Operating Sys,0.25,0.19,0.19,0.13,0.13,0%,0.0,0.13,jacob sorber,,ECE-3220,2020
+ECE,3270,1.0,Dig Comp Design,0.35,0.41,0.11,0.0,0.05,0%,0.0,0.08,walter ligon,,ECE-3270,2020
+ECE,3300,1.0,Signals & Systems,0.22,0.18,0.21,0.13,0.16,0%,0.0,0.1,carl baum,,ECE-3300,2020
+ECE,3300,2.0,Signals & Systems (HON),0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,daniel noneaker,True,ECE-3300,2020
+ECE,3520,1.0,Programming Systems,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,yongkai wu,,ECE-3520,2020
+ECE,3600,1.0,Elect Power Engr,0.2,0.27,0.07,0.07,0.27,0%,0.0,0.13,sukumar brahma,,ECE-3600,2020
+ECE,3710,1.0,Microcontr Interface,0.31,0.38,0.18,0.02,0.1,0%,0.0,0.01,william reid,,ECE-3710,2020
+ECE,3720,1.0,Micro Int Lab,0.77,0.08,0.0,0.0,0.08,0%,0.0,0.08,apoorva kapadia,,ECE-3720,2020
+ECE,3720,2.0,Micro Int Lab,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,apoorva kapadia,,ECE-3720,2020
+ECE,3720,3.0,Micro Int Lab,0.46,0.23,0.08,0.0,0.23,0%,0.0,0.0,apoorva kapadia,,ECE-3720,2020
+ECE,3720,4.0,Micro Int Lab,0.5,0.08,0.08,0.08,0.0,0%,0.0,0.25,apoorva kapadia,,ECE-3720,2020
+ECE,3720,5.0,Micro Int Lab,0.73,0.18,0.0,0.0,0.09,0%,0.0,0.0,apoorva kapadia,,ECE-3720,2020
+ECE,3720,6.0,Micro Int Lab,0.77,0.0,0.0,0.0,0.15,0%,0.0,0.08,apoorva kapadia,,ECE-3720,2020
+ECE,3720,7.0,Micro Int Lab,0.75,0.0,0.0,0.08,0.0,0%,0.0,0.17,apoorva kapadia,,ECE-3720,2020
+ECE,3720,8.0,Micro Int Lab,0.54,0.0,0.08,0.08,0.08,0%,0.0,0.23,apoorva kapadia,,ECE-3720,2020
+ECE,3720,9.0,Micro Int Lab,0.33,0.25,0.08,0.0,0.17,0%,0.0,0.17,apoorva kapadia,,ECE-3720,2020
+ECE,3720,11.0,Micro Int Lab,0.45,0.27,0.0,0.0,0.09,0%,0.0,0.18,apoorva kapadia,,ECE-3720,2020
+ECE,3800,1.0,Electromagnetics,0.08,0.14,0.26,0.08,0.22,0%,0.0,0.22,anthony martin,,ECE-3800,2020
+ECE,3810,1.0,Field Waves & Ckts,0.33,0.5,0.15,0.0,0.0,0%,0.0,0.02,tehseen raza,,ECE-3810,2020
+ECE,4090,1.0,Intr to Linear Control Syste,0.73,0.24,0.02,0.01,0.0,0%,0.0,0.0,apoorva kapadia,,ECE-4090,2020
+ECE,4180,1.0,Power Syst Analysis,0.41,0.35,0.0,0.12,0.0,0%,0.0,0.12,ramtin hadidi,,ECE-4180,2020
+ECE,4270,1.0,Communication Systems,0.23,0.4,0.25,0.03,0.03,0%,0.0,0.06,lu yu,,ECE-4270,2020
+ECE,4310,1.0,Intro to Computer Vision,0.61,0.33,0.06,0.0,0.0,0%,0.0,0.0,adam hoover,,ECE-4310,2020
+ECE,4420,1.0,Knowledge Engineering,0.87,0.0,0.0,0.0,0.07,0%,0.0,0.07,ao ren,,ECE-4420,2020
+ECE,4490,1.0,Comp Ntwrk Security,0.33,0.24,0.05,0.05,0.0,0%,0.0,0.29,richard brooks,,ECE-4490,2020
+ECE,4610,1.0,Fundamentals of Solar Ene,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,rajendra singh,,ECE-4610,2020
+ECE,4670,1.0,Intro to Dig Sig Pro,0.31,0.44,0.19,0.06,0.0,0%,0.0,0.0,john gowdy,,ECE-4670,2020
+ECE,4730,1.0,Intro Parallel Sys,0.4,0.48,0.0,0.0,0.08,0%,0.0,0.04,walter ligon,,ECE-4730,2020
+ECE,4950,1.0,Int Sys Design I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,,ECE-4950,2020
+ECE,4960,1.0,Int Sys Design II,0.7,0.26,0.04,0.0,0.0,0%,0.0,0.0,richard groff,,ECE-4960,2020
+ECE,6040,1.0,Semiconductor Devices,0.67,0.22,0.11,0.0,0.0,0%,0.0,0.0,judson ryckman,,ECE-6040,2020
+ECE,6310,1.0,Intro to Computer Vision,0.74,0.11,0.16,0.0,0.0,0%,0.0,0.0,adam hoover,,ECE-6310,2020
+ECE,6360,1.0,Microwave Circuits,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,pingshan wang,,ECE-6360,2020
+ECE,6490,1.0,Comp Ntwrk Security,0.71,0.14,0.0,0.0,0.0,0%,0.0,0.14,richard brooks,,ECE-6490,2020
+ECE,6590,1.0,Int Circ Design,0.36,0.36,0.0,0.0,0.0,0%,0.0,0.18,yingjie lao,,ECE-6590,2020
+ECE,6670,1.0,Intro to Dig Sig Pro,0.75,0.0,0.08,0.0,0.0,0%,0.0,0.17,john gowdy,,ECE-6670,2020
+ECE,8010,1.0,Analysis of Lin Sys,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,richard groff,,ECE-8010,2020
+ECE,8020,1.0,Elec Motor Cntl,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0, edrington,,ECE-8020,2020
+ECE,8020,843.0,Elec Motor Cntl,0.6,0.2,0.0,0.0,0.2,0%,0.0,0.0, edrington,,ECE-8020,2020
+ECE,8040,1.0,Networked Dynamical Syst,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,yongqiang wang,,ECE-8040,2020
+ECE,8120,1.0,Adv Electronic Materials/D,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,goutam koley,,ECE-8120,2020
+ECE,8270,1.0,Finite Dif Meth Emag,0.33,0.17,0.0,0.0,0.0,0%,0.0,0.17,anthony martin,,ECE-8270,2020
+ECE,8540,1.0,Analysis of Tracking Syste,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,adam hoover,,ECE-8540,2020
+ECE,8620,1.0,Com Appl Pwr Sys,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0, venayagamoorthy,,ECE-8620,2020
+ECE,8910,16.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,adam hoover,,ECE-8910,2020
+ECE,8910,39.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melissa smith,,ECE-8910,2020
+ECE,8910,44.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sukumar brahma,,ECE-8910,2020
+ECE,9910,21.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,goutam koley,,ECE-9910,2020
+ECE,9910,32.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yingjie lao,,ECE-9910,2020
+ECE,9910,39.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melissa smith,,ECE-9910,2020
+ECE,9910,41.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, venayagamoorthy,,ECE-9910,2020
+ECON,2000,2.0,Economic Concepts,0.68,0.25,0.05,0.0,0.0,0%,0.0,0.03,shubhashrita basu,,ECON-2000,2020
+ECON,2000,4.0,Economic Concepts,0.46,0.34,0.17,0.0,0.03,0%,0.0,0.0,miren ivankovic,,ECON-2000,2020
+ECON,2000,5.0,Economic Concepts,0.64,0.33,0.03,0.0,0.0,0%,0.0,0.0,shubhashrita basu,,ECON-2000,2020
+ECON,2050,1.0,Why Business?,0.63,0.23,0.05,0.02,0.05,0%,0.0,0.02,lawrence watson,,ECON-2050,2020
+ECON,2110,1.0,Principles of Microeconom,0.11,0.26,0.32,0.11,0.11,0%,0.0,0.11,frederick hanssen,,ECON-2110,2020
+ECON,2110,2.0,Principles of Microeconom,0.05,0.37,0.42,0.05,0.11,0%,0.0,0.0,frederick hanssen,,ECON-2110,2020
+ECON,2110,3.0,Principles of Microeconom,0.05,0.42,0.42,0.05,0.05,0%,0.0,0.0,frederick hanssen,,ECON-2110,2020
+ECON,2110,4.0,Principles of Microeconom,0.16,0.47,0.21,0.0,0.0,0%,0.0,0.16,frederick hanssen,,ECON-2110,2020
+ECON,2110,5.0,Principles of Microeconom,0.0,0.58,0.16,0.05,0.11,0%,0.0,0.11,frederick hanssen,,ECON-2110,2020
+ECON,2110,6.0,Principles of Microeconom,0.06,0.44,0.28,0.06,0.17,0%,0.0,0.0,frederick hanssen,,ECON-2110,2020
+ECON,2110,7.0,Principles of Microeconom,0.05,0.32,0.37,0.11,0.16,0%,0.0,0.0,frederick hanssen,,ECON-2110,2020
+ECON,2110,8.0,Principles of Microeconom,0.16,0.37,0.37,0.05,0.0,0%,0.0,0.05,frederick hanssen,,ECON-2110,2020
+ECON,2110,9.0,Principles of Microeconom,0.11,0.42,0.21,0.05,0.0,0%,0.0,0.21,frederick hanssen,,ECON-2110,2020
+ECON,2110,10.0,Principles of Microeconom,0.0,0.32,0.58,0.0,0.05,0%,0.0,0.05,frederick hanssen,,ECON-2110,2020
+ECON,2110,11.0,Principles of Microeconom,0.11,0.37,0.26,0.11,0.11,0%,0.0,0.05,frederick hanssen,,ECON-2110,2020
+ECON,2110,12.0,Principles of Microeconom,0.0,0.47,0.21,0.05,0.05,0%,0.0,0.21,frederick hanssen,,ECON-2110,2020
+ECON,2110,13.0,Principles of Microeconom,0.0,0.79,0.11,0.05,0.0,0%,0.0,0.05,frederick hanssen,,ECON-2110,2020
+ECON,2110,14.0,Principles of Microeconom,0.16,0.42,0.32,0.05,0.0,0%,0.0,0.05,frederick hanssen,,ECON-2110,2020
+ECON,2110,15.0,Principles of Microeconom,0.05,0.47,0.16,0.05,0.05,0%,0.0,0.21,frederick hanssen,,ECON-2110,2020
+ECON,2110,16.0,Principles of Microeconom,0.05,0.32,0.32,0.11,0.11,0%,0.0,0.11,frederick hanssen,,ECON-2110,2020
+ECON,2110,17.0,Principles of Microeconom,0.16,0.47,0.32,0.0,0.0,0%,0.0,0.05,frederick hanssen,,ECON-2110,2020
+ECON,2110,18.0,Principles of Microeconom,0.11,0.63,0.11,0.0,0.05,0%,0.0,0.11,frederick hanssen,,ECON-2110,2020
+ECON,2110,19.0,Principles of Microeconom,0.05,0.26,0.53,0.05,0.0,0%,0.0,0.11,frederick hanssen,,ECON-2110,2020
+ECON,2110,20.0,Principles of Microeconom,0.25,0.44,0.22,0.06,0.01,0%,0.0,0.01,scott baier,,ECON-2110,2020
+ECON,2110,21.0,Principles of Microeconom,0.2,0.56,0.2,0.01,0.03,0%,0.0,0.0,scott baier,,ECON-2110,2020
+ECON,2110,23.0,Principles of Microeconom,0.68,0.23,0.05,0.0,0.02,0%,0.0,0.01,seyedmajid hashemi,,ECON-2110,2020
+ECON,2110,24.0,Principles of Microeconom,0.34,0.26,0.22,0.09,0.05,0%,0.0,0.05,devon merritt gorry,,ECON-2110,2020
+ECON,2110,25.0,Principles of Microeconom,0.48,0.29,0.21,0.0,0.02,0%,0.0,0.0,cory simpkins,,ECON-2110,2020
+ECON,2110,26.0,Principles of Microeconom,0.72,0.2,0.02,0.02,0.0,0%,0.0,0.02,tabitha knott,,ECON-2110,2020
+ECON,2110,31.0,Principles of Microeconom,0.62,0.29,0.07,0.01,0.0,0%,0.0,0.01,seyedmajid hashemi,,ECON-2110,2020
+ECON,2110,32.0,Principles of Microeconom,0.23,0.51,0.19,0.01,0.06,0%,0.0,0.0,scott baier,,ECON-2110,2020
+ECON,2110,33.0,Principles of Microeconom,0.67,0.19,0.1,0.0,0.05,0%,0.0,0.0,shilpi mukherjee,,ECON-2110,2020
+ECON,2110,34.0,Principles of Microecon (H,0.39,0.48,0.04,0.09,0.0,0%,0.0,0.0,charles thomas,True,ECON-2110,2020
+ECON,2110,35.0,Principles of Microeconom,0.38,0.52,0.07,0.0,0.0,0%,0.0,0.02,cory simpkins,,ECON-2110,2020
+ECON,2110,36.0,Principles of Microeconom,0.57,0.37,0.04,0.0,0.0,0%,0.0,0.01,tabitha knott,,ECON-2110,2020
+ECON,2110,38.0,Principles of Microeconom,0.4,0.4,0.1,0.02,0.05,0%,0.0,0.02,guncha babajanova,,ECON-2110,2020
+ECON,2110,40.0,Principles of Microeconom,0.61,0.17,0.07,0.07,0.05,0%,0.0,0.02,shilpi mukherjee,,ECON-2110,2020
+ECON,2110,41.0,Principles of Microeconom,0.5,0.43,0.05,0.0,0.0,0%,0.0,0.02,guncha babajanova,,ECON-2110,2020
+ECON,2120,1.0,Principles of Macroecono,0.15,0.44,0.25,0.13,0.04,0%,0.0,0.0,yinlin dai,,ECON-2120,2020
+ECON,2120,2.0,Principles of Macroecono,0.37,0.45,0.14,0.02,0.0,0%,0.0,0.02,bradley keith hobbs,,ECON-2120,2020
+ECON,2120,3.0,Principles of Macroecono,0.5,0.3,0.12,0.02,0.05,0%,0.0,0.02,krishna khatri,,ECON-2120,2020
+ECON,2120,4.0,Principles of Macroecono,0.72,0.22,0.06,0.0,0.0,0%,0.0,0.0,tyler francis,,ECON-2120,2020
+ECON,2120,5.0,Principles of Macroecono,0.48,0.33,0.1,0.03,0.03,0%,0.0,0.05,matthew lee cronin,,ECON-2120,2020
+ECON,2120,6.0,Principles of Macroecono,0.41,0.46,0.05,0.03,0.03,0%,0.0,0.03,matthew lee cronin,,ECON-2120,2020
+ECON,2120,7.0,Principles of Macroecono,0.78,0.15,0.04,0.01,0.01,0%,0.0,0.0,tyler francis,,ECON-2120,2020
+ECON,2120,8.0,Principles of Macroecono,0.19,0.45,0.21,0.1,0.03,0%,0.0,0.02,mason bixenman,,ECON-2120,2020
+ECON,2120,9.0,Principles of Macroecono,0.28,0.28,0.14,0.14,0.14,0%,0.0,0.03,yinlin dai,,ECON-2120,2020
+ECON,2120,10.0,Principles of Macroecono,0.35,0.48,0.15,0.03,0.0,0%,0.0,0.0,illia polovnikov,,ECON-2120,2020
+ECON,3020,1.0,Money and Banking,0.65,0.25,0.08,0.0,0.03,0%,0.0,0.0,adam witham,,ECON-3020,2020
+ECON,3030,2.0,Economics and Sports,0.37,0.47,0.11,0.0,0.03,0%,0.0,0.03,raymond sauer,,ECON-3030,2020
+ECON,3060,2.0,Managerial Economics,0.33,0.33,0.17,0.0,0.03,0%,0.0,0.13,miren ivankovic,,ECON-3060,2020
+ECON,3100,2.0,International Econ,0.36,0.43,0.15,0.04,0.0,0%,0.0,0.03,scott baier,,ECON-3100,2020
+ECON,3140,1.0,Intermediate Micro,0.41,0.17,0.2,0.11,0.04,0%,0.0,0.07,patrick warren,,ECON-3140,2020
+ECON,3140,3.0,Intermediate Micro,0.22,0.15,0.2,0.11,0.28,0%,0.0,0.04,frederick hanssen,,ECON-3140,2020
+ECON,3140,5.0,Intermediate Micro,0.37,0.4,0.18,0.02,0.02,0%,0.0,0.02,molly espey,,ECON-3140,2020
+ECON,3150,2.0,Intermediate Macro,0.09,0.4,0.27,0.09,0.09,0%,0.0,0.07, jerzmanowski,,ECON-3150,2020
+ECON,3150,4.0,Intermediate Macro,0.74,0.18,0.03,0.0,0.06,0%,0.0,0.0,scott baier,,ECON-3150,2020
+ECON,3150,5.0,Intermediate Macro,0.92,0.03,0.0,0.0,0.03,0%,0.0,0.03,scott baier,,ECON-3150,2020
+ECON,3190,1.0,Environmental Econ,0.42,0.4,0.08,0.02,0.04,0%,0.0,0.04,molly espey,,ECON-3190,2020
+ECON,3500,1.0,Moral & Ethical Econ,0.25,0.33,0.08,0.0,0.17,0%,0.0,0.17,bradley keith hobbs,,ECON-3500,2020
+ECON,3600,1.0,Public Choice,0.44,0.3,0.16,0.06,0.0,0%,0.0,0.04,michael makowsky,,ECON-3600,2020
+ECON,4010,1.0,Labor Mkt Analysis,0.36,0.33,0.06,0.06,0.12,0%,0.0,0.06,chungsang lam,,ECON-4010,2020
+ECON,4020,1.0,Law and Economics,0.32,0.34,0.18,0.07,0.02,0%,0.0,0.07,howard bodenhorn,,ECON-4020,2020
+ECON,4040,1.0,Comp Econ Systems,0.19,0.38,0.24,0.0,0.05,0%,0.0,0.14, litsukova-bokar,,ECON-4040,2020
+ECON,4050,1.0,Intro to Econometric,0.46,0.19,0.15,0.08,0.08,0%,0.0,0.04,yichen christy zhou,,ECON-4050,2020
+ECON,4050,5.0,Intro to Econometric,0.4,0.26,0.17,0.06,0.11,0%,0.0,0.0,scott barkowski,,ECON-4050,2020
+ECON,4100,1.0,Economic Development,0.71,0.1,0.14,0.05,0.0,0%,0.0,0.0,robert tamura,,ECON-4100,2020
+ECON,4230,1.0,Economics of Health,0.45,0.28,0.1,0.05,0.08,0%,0.0,0.0,devon merritt gorry,,ECON-4230,2020
+ECON,4240,1.0,Organization of Ind,0.61,0.22,0.17,0.0,0.0,0%,0.0,0.0,matthew lewis,,ECON-4240,2020
+ECON,4280,1.0,Cost-Benefit Anlysis,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,robert kenneth fleck,,ECON-4280,2020
+ECON,4980,2.0,Economics Data Analytics,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,raymond sauer,,ECON-4980,2020
+ECON,4980,3.0,Machine Learning I,0.45,0.18,0.0,0.0,0.18,0%,0.0,0.18,chungsang lam,,ECON-4980,2020
+ECON,6060,1.0,Advanced Econometric,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,scott baier,,ECON-6060,2020
+ECON,6280,1.0,Cost-Benefit Anlysis,0.67,0.17,0.17,0.0,0.0,0%,0.0,0.0,robert kenneth fleck,,ECON-6280,2020
+ECON,8010,1.0,Microeconomic Theory,0.33,0.33,0.2,0.0,0.07,0%,0.0,0.0,william dougan,,ECON-8010,2020
+ECON,8040,1.0,Applied Math Econ,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,curtis simon,,ECON-8040,2020
+ECON,8080,1.0,Econometrics III,0.12,0.76,0.12,0.0,0.0,0%,0.0,0.0,paul wayne wilson,,ECON-8080,2020
+ECON,8160,1.0,Labor Economics,0.4,0.4,0.0,0.0,0.0,0%,0.0,0.2,curtis simon,,ECON-8160,2020
+ECON,8230,1.0,Microecon Pub Pol,0.17,0.67,0.08,0.0,0.0,0%,0.0,0.08,scott templeton,,ECON-8230,2020
+ECON,8990,5.0,Sel Topics - Macro Theory I,0.57,0.43,0.0,0.0,0.0,0%,0.0,0.0,christopher gorry,,ECON-8990,2020
+ECON,9000,2.0,Econometrics I,0.2,0.6,0.2,0.0,0.0,0%,0.0,0.0, menendez garcia,,ECON-9000,2020
+ECON,9000,3.0,Econometrics II,0.35,0.5,0.15,0.0,0.0,0%,0.0,0.0, menendez garcia,,ECON-9000,2020
+ECON,9010,1.0,Price Theory,0.6,0.2,0.2,0.0,0.0,0%,0.0,0.0,charles thomas,,ECON-9010,2020
+ECON,9810,1.0,App Econ Analysis,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,howard bodenhorn,,ECON-9810,2020
+ECON,9820,2.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,frederick hanssen,,ECON-9820,2020
+ECON,9820,3.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,curtis simon,,ECON-9820,2020
+ECON,9820,4.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,william dougan,,ECON-9820,2020
+ECON,9820,5.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert tamura,,ECON-9820,2020
+ECON,9910,4.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gerald dwyer,,ECON-9910,2020
+ED,1050,6.0,Orientation to Education,0.88,0.04,0.0,0.0,0.04,0%,0.0,0.04,hilary tanck,,ED-1050,2020
+ED,1050,7.0,Orientation to Education,0.8,0.13,0.0,0.0,0.07,0%,0.0,0.0,yashica latimer,,ED-1050,2020
+ED,1050,8.0,Orientation to Education,0.79,0.07,0.0,0.0,0.07,0%,0.0,0.07,yashica latimer,,ED-1050,2020
+ED,1050,9.0,Orientation to Education,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.03,yashica latimer,,ED-1050,2020
+ED,1970,4.0,CI-CONNECTIONS Stud Dev,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,deonte brown,,ED-1970,2020
+ED,3010,1.0,Principles of American Edu,0.85,0.04,0.0,0.0,0.11,0%,0.0,0.0,beatrice naff bailey,,ED-3010,2020
+ED,3010,3.0,Principles of American Edu,0.92,0.0,0.0,0.0,0.08,0%,0.0,0.0,beatrice naff bailey,,ED-3010,2020
+ED,8090,450.0,Teacher Residency Interns,0.93,0.05,0.0,0.0,0.0,0%,0.0,0.03,corrie leigh martin,,ED-8090,2020
+ED,8480,450.0,Teacher Residency Semina,0.98,0.0,0.0,0.0,0.0,0%,0.0,0.02,laura cohen eicher,,ED-8480,2020
+ED,8750,331.0,Elements of Instructional E,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,anna morrison,,ED-8750,2020
+ED,8990,331.0,Capstone Research Project,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,daphne wiles,,ED-8990,2020
+EDC,8140,401.0,Develpmnt of Counseling S,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,barbara boyd,,EDC-8140,2020
+EDC,8410,400.0,School Counseling Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,amanda rumsey,,EDC-8410,2020
+EDC,8460,400.0,Clinical Ment Hlth Coun Int,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,corrine sackett,,EDC-8460,2020
+EDC,8460,401.0,Clinical Ment Hlth Coun Int,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david scott,,EDC-8460,2020
+EDEC,4300,1.0,Early Childhd Math,0.93,0.04,0.0,0.0,0.0,0%,0.0,0.04,sandra linder,,EDEC-4300,2020
+EDEC,4400,1.0,Early Childhood Engl Lang,0.86,0.11,0.0,0.0,0.0,0%,0.0,0.04,anna henson hall,,EDEC-4400,2020
+EDEL,3210,2.0,Pe for the Elem Tchr,0.46,0.46,0.03,0.0,0.03,0%,0.0,0.03,deborah smith,,EDEL-3210,2020
+EDEL,3210,3.0,Pe for the Elem Tchr,0.48,0.45,0.07,0.0,0.0,0%,0.0,0.0,deborah smith,,EDEL-3210,2020
+EDEL,4510,1.0,Elem Methods in Science T,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,cynthia deaton,,EDEL-4510,2020
+EDEL,4870,2.0,Ele Meth Soc Studies,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,melinda spearman,,EDEL-4870,2020
+EDF,3020,1.0,Educational Psychology,0.88,0.09,0.0,0.0,0.0,0%,0.0,0.03,meihua qian,,EDF-3020,2020
+EDF,3020,2.0,Educational Psychology,0.86,0.11,0.0,0.0,0.0,0%,0.0,0.03,meihua qian,,EDF-3020,2020
+EDF,3080,1.0,Classroom Assessment,0.95,0.03,0.0,0.03,0.0,0%,0.0,0.0,quesada hazel vega,,EDF-3080,2020
+EDF,3080,2.0,Classroom Assessment,0.86,0.0,0.07,0.03,0.0,0%,0.0,0.03,quesada hazel vega,,EDF-3080,2020
+EDF,3340,1.0,Child Growth and Develop,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,faiza marghoob jamil,,EDF-3340,2020
+EDF,3340,3.0,Child Growth and Develop,0.7,0.22,0.05,0.0,0.03,0%,0.0,0.0,faiza marghoob jamil,,EDF-3340,2020
+EDF,3350,1.0,Adolescent Growth & Dev,0.9,0.07,0.0,0.0,0.0,0%,0.0,0.03,luke rapa,,EDF-3350,2020
+EDF,4800,1.0,Digital Media & Learning,0.64,0.23,0.0,0.05,0.09,0%,0.0,0.0,ryan visser,,EDF-4800,2020
+EDF,4800,2.0,Digital Media & Learning,0.87,0.0,0.09,0.0,0.04,0%,0.0,0.0,ryan visser,,EDF-4800,2020
+EDF,4800,300.0,Digital Media & Learning,0.9,0.07,0.03,0.0,0.0,0%,0.0,0.0,ryan visser,,EDF-4800,2020
+EDF,4800,302.0,Digital Media & Learning,0.93,0.04,0.04,0.0,0.0,0%,0.0,0.0,irgens arastoopour,,EDF-4800,2020
+EDF,8200,300.0,Effective Online Teaching,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,amanda bennett,,EDF-8200,2020
+EDF,8200,301.0,Effective Online Teaching,0.69,0.13,0.0,0.0,0.06,0%,0.0,0.13,robert todd kane,,EDF-8200,2020
+EDF,8200,500.0,Effective Online Teaching,0.88,0.04,0.0,0.0,0.04,0%,0.0,0.0,april susanne pelt,,EDF-8200,2020
+EDF,8200,501.0,Effective Online Teaching,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,valerie wheeler,,EDF-8200,2020
+EDF,8200,502.0,Effective Online Teaching,0.56,0.3,0.04,0.0,0.11,0%,0.0,0.0,amanda bennett,,EDF-8200,2020
+EDF,8200,505.0,Effective Online Teaching,0.83,0.0,0.03,0.0,0.14,0%,0.0,0.0,robert todd kane,,EDF-8200,2020
+EDF,8210,500.0,Online Course Manageme,0.81,0.04,0.0,0.0,0.12,0%,0.0,0.0,allyson marie wilcox,,EDF-8210,2020
+EDF,8210,501.0,Online Course Manageme,0.82,0.14,0.0,0.0,0.04,0%,0.0,0.0,karen bunch franklin,,EDF-8210,2020
+EDF,8210,502.0,Online Course Manageme,0.78,0.04,0.0,0.0,0.19,0%,0.0,0.0,robert todd kane,,EDF-8210,2020
+EDF,8210,505.0,Online Course Manageme,0.7,0.19,0.0,0.0,0.11,0%,0.0,0.0,amanda bennett,,EDF-8210,2020
+EDF,9270,1.0,Quant Rsrch & Stats for Ed,0.75,0.0,0.13,0.0,0.0,0%,0.0,0.13,christy jenkins brown,,EDF-9270,2020
+EDF,9790,1.0,Qualitative Research in Ed,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,melinda spearman,,EDF-9790,2020
+EDL,8200,400.0,Politics of Educ,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,danielle hall,,EDL-8200,2020
+EDL,8850,400.0,Diversity & School Commu,0.9,0.07,0.0,0.0,0.0,0%,0.0,0.0,reginald wilkerson,,EDL-8850,2020
+EDL,9770,2.0,Div Issues in Hi Ed,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,helen steele,,EDL-9770,2020
+EDL,9880,1.0,Directed Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,danielle hall,,EDL-9880,2020
+EDL,9910,3.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,natasha croom,,EDL-9910,2020
+EDL,9910,5.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,hans william klar,,EDL-9910,2020
+EDL,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jane lindle,,EDL-9910,2020
+EDL,9910,7.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,danielle hall,,EDL-9910,2020
+EDL,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,reginald wilkerson,,EDL-9910,2020
+EDL,9910,10.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,noelle paufler,,EDL-9910,2020
+EDLL,8050,401.0,Contemp Iss in School Lea,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.0,hans william klar,,EDLL-8050,2020
+EDLL,8550,400.0,Secondary Sch Internship I,0.6,0.0,0.2,0.0,0.0,0%,0.0,0.0,melissa bryant burns,,EDLL-8550,2020
+EDLT,4590,1.0,Teaching Reading Grades K,0.93,0.04,0.0,0.0,0.0,0%,0.0,0.04,lisa denise aker,,EDLT-4590,2020
+EDLT,4600,1.0,Found of Read: Assess & In,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,hayley hoover,,EDLT-4600,2020
+EDLT,4600,2.0,Found of Read: Assess & In,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,lisa denise aker,,EDLT-4600,2020
+EDLT,4600,4.0,Found of Read: Assess & In,0.69,0.13,0.06,0.0,0.13,0%,0.0,0.0,polly wingate,,EDLT-4600,2020
+EDLT,4610,1.0,Content Area Read/Writin,0.75,0.21,0.04,0.0,0.0,0%,0.0,0.0,pamela dunston,,EDLT-4610,2020
+EDLT,4610,2.0,Content Area Read/Writin,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,pamela dunston,,EDLT-4610,2020
+EDLT,4800,300.0,Found in Adolescent Litera,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,daniel stockwell,,EDLT-4800,2020
+EDLT,4800,301.0,Found in Adolescent Litera,0.68,0.11,0.16,0.0,0.0,0%,0.0,0.05,daniel stockwell,,EDLT-4800,2020
+EDLT,4980,1.0,Cont Area Read/Write Sec,0.86,0.1,0.0,0.0,0.0,0%,0.0,0.03,rachelle savitz,,EDLT-4980,2020
+EDLT,8110,301.0,Adv Children's & Yng Adult,0.5,0.33,0.0,0.0,0.0,0%,0.0,0.0,susan king fullerton,,EDLT-8110,2020
+EDLT,8150,301.0,Guided Reading & Guided,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,pamela dunston,,EDLT-8150,2020
+EDLT,8190,300.0,Coaching for Literacy Educ,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,rachelle savitz,,EDLT-8190,2020
+EDLT,8400,501.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,barbara fewell,,EDLT-8400,2020
+EDLT,8400,510.0,Early Literacy Assessment I,0.89,0.0,0.11,0.0,0.0,0%,0.0,0.0,kimberly floyd,,EDLT-8400,2020
+EDLT,8400,511.0,Early Literacy Assessment I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,renee gatlin anders,,EDLT-8400,2020
+EDLT,8400,515.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,susanne elvington,,EDLT-8400,2020
+EDLT,8400,516.0,Early Literacy Assessment I,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,ellen adkins sanford,,EDLT-8400,2020
+EDSA,3900,6.0,Skills for Student Leaders,0.81,0.14,0.05,0.0,0.0,0%,0.0,0.0,deonte brown,,EDSA-3900,2020
+EDSA,3990,1.0,Creative Inq in Counselor E,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,jacob frankovich,,EDSA-3990,2020
+EDSA,8040,2.0,Theories Student Dev in Hi,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,tony cawthon,,EDSA-8040,2020
+EDSA,8440,1.0,Student Affairs Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,tony cawthon,,EDSA-8440,2020
+EDSC,2260,1.0,Pr Apprch to Sec Alg,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,stacy megan che,,EDSC-2260,2020
+EDSC,4240,1.0,Tchng Sec English,0.8,0.07,0.13,0.0,0.0,0%,0.0,0.0, cridland-hughes,,EDSC-4240,2020
+EDSC,4280,1.0,Tchng Secondary Social St,0.85,0.08,0.0,0.0,0.0,0%,0.0,0.08,kristen duncan,,EDSC-4280,2020
+EDSP,3700,1.0,Intro to Special Education,0.91,0.06,0.03,0.0,0.0,0%,0.0,0.0,sharon walters,,EDSP-3700,2020
+EDSP,3700,2.0,Intro to Special Education,0.73,0.23,0.0,0.0,0.0,0%,0.0,0.04,catherine griffith,,EDSP-3700,2020
+EDSP,3700,4.0,Intro to Special Education,0.82,0.09,0.09,0.0,0.0,0%,0.0,0.0,catherine griffith,,EDSP-3700,2020
+EDSP,3720,1.0,Char & Instr Individ with L,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,catherine griffith,,EDSP-3720,2020
+EDSP,3740,1.0,Char & Strat Emot/Behav,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,shanna eisner hirsch,,EDSP-3740,2020
+EDSP,3750,1.0,Early Intervention Spec Ne,0.84,0.12,0.0,0.0,0.04,0%,0.0,0.0,tracy denise garrett,,EDSP-3750,2020
+EDSP,3750,2.0,Early Intervention Spec Ne,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,tracy denise garrett,,EDSP-3750,2020
+EDSP,4920,1.0,Math Inst Ind W/Dis,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,pamela stecker,,EDSP-4920,2020
+EDSP,4930,1.0,Clsrm/Beh Mgmt Sp Ed,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,joseph benedict ryan,,EDSP-4930,2020
+EDSP,4960,1.0,Sp Ed Field Exp,0.93,0.03,0.03,0.0,0.0,0%,0.0,0.0,wendell kent parker,,EDSP-4960,2020
+EES,2010,1.0,Environ Engr Fundamental,0.32,0.34,0.21,0.05,0.03,0%,0.0,0.05,david freedman,,EES-2010,2020
+EES,3030,1.0,Water Treatment Systems,0.32,0.5,0.14,0.04,0.0,0%,0.0,0.0,david allen ladner,,EES-3030,2020
+EES,3040,1.0,Wastewater Treatment Sy,0.56,0.19,0.26,0.0,0.0,0%,0.0,0.0,sudeep popat,,EES-3040,2020
+EES,3050,1.0,Water/Wastewater Treat,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,david allen ladner,,EES-3050,2020
+EES,3050,2.0,Water/Wastewater Treat,0.64,0.14,0.07,0.0,0.07,0%,0.0,0.0,sudeep popat,,EES-3050,2020
+EES,4010,1.0,Environmental Engr,0.67,0.22,0.09,0.02,0.0,0%,0.0,0.0,elizabeth carraway,,EES-4010,2020
+EES,4010,2.0,Environmental Engr,0.25,0.5,0.25,0.0,0.0,0%,0.0,0.0,mark schlautman,,EES-4010,2020
+EES,4090,1.0,Intro to Nuc Engr & Radiol,0.22,0.39,0.06,0.33,0.0,0%,0.0,0.0,timothy devol,,EES-4090,2020
+EES,4300,1.0,Air Pollution Engineering,0.38,0.38,0.16,0.03,0.06,0%,0.0,0.0,andrew metcalf,,EES-4300,2020
+EES,4800,1.0,Environmental Risk Assess,0.41,0.28,0.21,0.07,0.03,0%,0.0,0.0,nicole martinez,,EES-4800,2020
+EES,4840,1.0,Solid Waste Mgt,0.5,0.31,0.15,0.04,0.0,0%,0.0,0.0,ezra lucas hoyt cates hoyt,,EES-4840,2020
+EES,4860,2.0,Environmental Sustainabili,0.6,0.25,0.05,0.0,0.0,0%,0.0,0.1, carbajales-dale,,EES-4860,2020
+EES,6100,1.0,Environ Radiation Protecti,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.2,nicole martinez,,EES-6100,2020
+EES,8020,1.0,Environ Eng Prin,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,david allen ladner,,EES-8020,2020
+EES,8060,1.0,Design Env Control,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0, carbajales-dale,,EES-8060,2020
+EES,8430,1.0,Environmental Chem,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,brian powell,,EES-8430,2020
+EES,8430,2.0,Environmental Chem,0.5,0.38,0.0,0.0,0.0,0%,0.0,0.13,brian powell,,EES-8430,2020
+EES,8510,1.0,Biol Prin Envir Engr,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,kevin finneran,,EES-8510,2020
+EES,8610,1.0,Environmental Engr & Sci S,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sudeep popat,,EES-8610,2020
+EES,8800,1.0,Env Risk Assessment,0.3,0.7,0.0,0.0,0.0,0%,0.0,0.0,timothy devol,,EES-8800,2020
+ELE,3010,1.0,Entrepreneurial Foundatio,0.28,0.28,0.28,0.07,0.07,0%,0.0,0.02,ashley parnell,,ELE-3010,2020
+ELE,3010,2.0,Entrepreneurial Foundatio,0.22,0.27,0.34,0.07,0.02,0%,0.0,0.07,ashley parnell,,ELE-3010,2020
+ELE,3010,3.0,Entrepreneurial Foundatio,0.62,0.28,0.08,0.03,0.0,0%,0.0,0.0,lori leigh tribble,,ELE-3010,2020
+ELE,3010,4.0,Entrepreneurial Foundatio,0.32,0.46,0.19,0.0,0.03,0%,0.0,0.0,lori leigh tribble,,ELE-3010,2020
+ELE,3010,5.0,Entrepreneurial Foundatio,0.56,0.25,0.13,0.03,0.0,0%,0.0,0.03,lori leigh tribble,,ELE-3010,2020
+ELE,4020,1.0,Venture Planning,0.2,0.7,0.11,0.0,0.0,0%,0.0,0.0,william dinardo,,ELE-4020,2020
+ELE,4040,1.0,Entrepreneurial Resource,0.68,0.2,0.1,0.0,0.0,0%,0.0,0.02,james keith hudgins,,ELE-4040,2020
+ELE,4060,1.0,Venture Consulting,0.35,0.63,0.03,0.0,0.0,0%,0.0,0.0,william dinardo,,ELE-4060,2020
+ENGL,1030,7.0,Composition and Rhetoric,0.48,0.43,0.1,0.0,0.0,0%,0.0,0.0,allen swords,,ENGL-1030,2020
+ENGL,1030,8.0,Composition and Rhetoric,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,allen swords,,ENGL-1030,2020
+ENGL,1030,43.0,Composition and Rhetoric,0.71,0.14,0.0,0.0,0.14,0%,0.0,0.0,hannah taylor,,ENGL-1030,2020
+ENGL,1030,44.0,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,hannah taylor,,ENGL-1030,2020
+ENGL,1030,47.0,Composition and Rhetoric,0.4,0.45,0.0,0.05,0.05,0%,0.0,0.05,cody hunter,,ENGL-1030,2020
+ENGL,1030,48.0,Composition and Rhetoric,0.6,0.1,0.05,0.0,0.15,0%,0.0,0.1,cody hunter,,ENGL-1030,2020
+ENGL,1030,49.0,Composition and Rhetoric,0.62,0.24,0.05,0.0,0.0,0%,0.0,0.1,nicholas rader,,ENGL-1030,2020
+ENGL,1030,50.0,Composition and Rhetoric,0.86,0.05,0.0,0.0,0.05,0%,0.0,0.05,nicholas rader,,ENGL-1030,2020
+ENGL,1030,51.0,Composition and Rhetoric,0.76,0.0,0.05,0.0,0.14,0%,0.0,0.05,sethunya gall,,ENGL-1030,2020
+ENGL,1030,400.0,Composition and Rhetoric,0.57,0.29,0.0,0.0,0.14,0%,0.0,0.0,kailan smith sindelar,,ENGL-1030,2020
+ENGL,1030,401.0,Composition and Rhetoric,0.57,0.33,0.0,0.0,0.1,0%,0.0,0.0,kailan smith sindelar,,ENGL-1030,2020
+ENGL,1030,402.0,Composition and Rhetoric,0.86,0.1,0.0,0.0,0.05,0%,0.0,0.0,jonathan burgess,,ENGL-1030,2020
+ENGL,1030,403.0,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,jonathan burgess,,ENGL-1030,2020
+ENGL,1030,404.0,Composition and Rhetoric,0.57,0.24,0.0,0.0,0.14,0%,0.0,0.05,eric reid hamilton,,ENGL-1030,2020
+ENGL,1030,405.0,Composition and Rhetoric,0.48,0.24,0.05,0.14,0.1,0%,0.0,0.0,dennis ranahan,,ENGL-1030,2020
+ENGL,1030,406.0,Composition and Rhetoric,0.81,0.05,0.0,0.05,0.05,0%,0.0,0.05,jacob danial richter,,ENGL-1030,2020
+ENGL,1030,407.0,Composition and Rhetoric,0.33,0.39,0.11,0.0,0.11,0%,0.0,0.06,sheila lalwani,,ENGL-1030,2020
+ENGL,1030,408.0,Composition and Rhetoric,0.06,0.41,0.24,0.12,0.18,0%,0.0,0.0,sheila lalwani,,ENGL-1030,2020
+ENGL,1030,409.0,Composition and Rhetoric,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,jordan harris frith,,ENGL-1030,2020
+ENGL,1030,410.0,Composition and Rhetoric,0.5,0.2,0.1,0.0,0.15,0%,0.0,0.05,hailee mccraw,,ENGL-1030,2020
+ENGL,1030,411.0,Composition and Rhetoric,0.29,0.19,0.14,0.05,0.19,0%,0.0,0.14,hailee mccraw,,ENGL-1030,2020
+ENGL,1030,412.0,Composition and Rhetoric,0.5,0.3,0.1,0.0,0.1,0%,0.0,0.0,miranda campbell,,ENGL-1030,2020
+ENGL,1030,413.0,Composition and Rhetoric,0.47,0.26,0.21,0.0,0.05,0%,0.0,0.0,miranda campbell,,ENGL-1030,2020
+ENGL,1030,414.0,Composition and Rhetoric,0.45,0.2,0.1,0.15,0.05,0%,0.0,0.05,edward thomas troy,,ENGL-1030,2020
+ENGL,1030,415.0,Composition and Rhetoric,0.71,0.1,0.14,0.0,0.0,0%,0.0,0.05,lindsay scott,,ENGL-1030,2020
+ENGL,1030,416.0,Composition and Rhetoric,0.53,0.18,0.06,0.06,0.06,0%,0.0,0.06,jennie wakefield,,ENGL-1030,2020
+ENGL,1030,420.0,Composition and Rhetoric,0.62,0.19,0.05,0.05,0.0,0%,0.0,0.05,jennie wakefield,,ENGL-1030,2020
+ENGL,1030,421.0,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,aparna shastri,,ENGL-1030,2020
+ENGL,1030,423.0,Composition and Rhetoric,0.89,0.06,0.0,0.0,0.0,0%,0.0,0.06,amanda platz,,ENGL-1030,2020
+ENGL,1030,425.0,Composition and Rhetoric,0.83,0.06,0.0,0.06,0.0,0%,0.0,0.06,aparna shastri,,ENGL-1030,2020
+ENGL,1030,426.0,Composition and Rhetoric,0.78,0.06,0.0,0.0,0.11,0%,0.0,0.06,laura caroline dunn,,ENGL-1030,2020
+ENGL,1030,427.0,Composition and Rhetoric,0.58,0.16,0.11,0.11,0.05,0%,0.0,0.0,laura caroline dunn,,ENGL-1030,2020
+ENGL,1030,428.0,Composition and Rhetoric,0.89,0.05,0.0,0.05,0.0,0%,0.0,0.0,nicole marie stout,,ENGL-1030,2020
+ENGL,1030,429.0,Composition and Rhetoric,0.68,0.16,0.05,0.11,0.0,0%,0.0,0.0,amanda platz,,ENGL-1030,2020
+ENGL,1030,430.0,Composition and Rhetoric,0.5,0.2,0.15,0.1,0.0,0%,0.0,0.05,edward thomas troy,,ENGL-1030,2020
+ENGL,1030,431.0,Composition and Rhetoric,0.63,0.11,0.11,0.05,0.05,0%,0.0,0.05,edward thomas troy,,ENGL-1030,2020
+ENGL,1030,435.0,Composition and Rhetoric,0.5,0.35,0.1,0.0,0.05,0%,0.0,0.0,edward thomas troy,,ENGL-1030,2020
+ENGL,1030,436.0,Composition and Rhetoric,0.88,0.0,0.0,0.13,0.0,0%,0.0,0.0,nicole marie stout,,ENGL-1030,2020
+ENGL,1030,437.0,Composition and Rhetoric,0.78,0.0,0.06,0.0,0.11,0%,0.0,0.06,kaitlyn samons,,ENGL-1030,2020
+ENGL,1030,445.0,Composition and Rhetoric,0.78,0.17,0.06,0.0,0.0,0%,0.0,0.0,dennis ranahan,,ENGL-1030,2020
+ENGL,1030,446.0,Composition and Rhetoric,0.6,0.15,0.1,0.05,0.0,0%,0.0,0.1,mary frankovich,,ENGL-1030,2020
+ENGL,1030,453.0,Composition and Rhetoric,0.68,0.16,0.05,0.05,0.0,0%,0.0,0.05,mary frankovich,,ENGL-1030,2020
+ENGL,1030,454.0,Composition and Rhetoric,0.75,0.15,0.0,0.0,0.05,0%,0.0,0.05,sarah richardson,,ENGL-1030,2020
+ENGL,1030,456.0,Composition and Rhetoric,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,sarah richardson,,ENGL-1030,2020
+ENGL,1030,457.0,Composition and Rhetoric,0.84,0.0,0.05,0.05,0.05,0%,0.0,0.0,michael vaughan,,ENGL-1030,2020
+ENGL,1030,459.0,Composition and Rhetoric,0.83,0.06,0.11,0.0,0.0,0%,0.0,0.0,michael vaughan,,ENGL-1030,2020
+ENGL,1030,460.0,Composition and Rhetoric,0.72,0.11,0.11,0.0,0.06,0%,0.0,0.0,caroline kinderthain,,ENGL-1030,2020
+ENGL,1030,461.0,Composition and Rhetoric,0.69,0.19,0.06,0.0,0.0,0%,0.0,0.06,kylie carlson,,ENGL-1030,2020
+ENGL,1030,464.0,Composition and Rhetoric,0.78,0.06,0.0,0.11,0.06,0%,0.0,0.0,kylie carlson,,ENGL-1030,2020
+ENGL,1030,465.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0%,0.0,0.0,rebecca rea  ross s,,ENGL-1030,2020
+ENGL,1030,467.0,Composition and Rhetoric,0.38,0.38,0.06,0.0,0.13,0%,0.0,0.06,rebecca rea  ross s,,ENGL-1030,2020
+ENGL,1030,468.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0%,0.0,0.0,samantha keebler,,ENGL-1030,2020
+ENGL,1030,469.0,Composition and Rhetoric,0.67,0.06,0.06,0.06,0.11,0%,0.0,0.06,samantha keebler,,ENGL-1030,2020
+ENGL,1030,470.0,Composition and Rhetoric,0.69,0.06,0.13,0.0,0.06,0%,0.0,0.06,jenny washburne,,ENGL-1030,2020
+ENGL,1030,471.0,Composition and Rhetoric,0.59,0.35,0.06,0.0,0.0,0%,0.0,0.0,jenny washburne,,ENGL-1030,2020
+ENGL,1030,475.0,Composition and Rhetoric,0.41,0.06,0.29,0.12,0.0,0%,0.0,0.12,victoria lynn carrico,,ENGL-1030,2020
+ENGL,1030,476.0,Composition and Rhetoric,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,victoria lynn carrico,,ENGL-1030,2020
+ENGL,1030,477.0,Composition and Rhetoric,0.42,0.37,0.11,0.11,0.0,0%,0.0,0.0,kimberly groves,,ENGL-1030,2020
+ENGL,1030,478.0,Composition and Rhetoric,0.67,0.11,0.06,0.0,0.0,0%,0.0,0.17,kimberly groves,,ENGL-1030,2020
+ENGL,1030,482.0,Composition and Rhetoric,0.78,0.06,0.0,0.0,0.06,0%,0.0,0.11,kaitlyn samons,,ENGL-1030,2020
+ENGL,1030,484.0,Composition and Rhetoric,0.5,0.22,0.28,0.0,0.0,0%,0.0,0.0,allison daniel,,ENGL-1030,2020
+ENGL,1030,485.0,Composition and Rhetoric,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,allison daniel,,ENGL-1030,2020
+ENGL,2020,1.0,Lit Forms and Creative Wri,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,melissa dugan,,ENGL-2020,2020
+ENGL,2020,2.0,Lit Forms and Creative Wri,0.7,0.26,0.0,0.0,0.04,0%,0.0,0.0,melissa dugan,,ENGL-2020,2020
+ENGL,2020,4.0,Lit Forms and Creative Wri,0.52,0.4,0.08,0.0,0.0,0%,0.0,0.0,keith morris,,ENGL-2020,2020
+ENGL,2020,5.0,Lit Forms and Creative Wri,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,john logan pursley,,ENGL-2020,2020
+ENGL,2020,400.0,Lit Forms and Creative Wri,0.68,0.2,0.04,0.08,0.0,0%,0.0,0.0,stephanie edwards,,ENGL-2020,2020
+ENGL,2020,401.0,Lit Forms and Creative Wri,0.44,0.32,0.12,0.04,0.0,0%,0.0,0.08,stephanie edwards,,ENGL-2020,2020
+ENGL,2020,402.0,Lit Forms and Creative Wri,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,jillian weise,,ENGL-2020,2020
+ENGL,2020,403.0,Lit Forms and Creative Wri,0.52,0.28,0.04,0.08,0.08,0%,0.0,0.0,stephanie edwards,,ENGL-2020,2020
+ENGL,2120,1.0,World Literature,0.48,0.28,0.08,0.04,0.08,0%,0.0,0.04,andrew mathas,,ENGL-2120,2020
+ENGL,2120,2.0,World Literature,0.52,0.16,0.2,0.0,0.08,0%,0.0,0.04,caitlin grace watt,,ENGL-2120,2020
+ENGL,2120,3.0,World Literature,0.44,0.28,0.08,0.0,0.12,0%,0.0,0.08,kenneth tuite,,ENGL-2120,2020
+ENGL,2120,9.0,World Literature,0.56,0.16,0.12,0.04,0.08,0%,0.0,0.04,caitlin grace watt,,ENGL-2120,2020
+ENGL,2120,10.0,World Literature,0.56,0.24,0.2,0.0,0.0,0%,0.0,0.0,caitlin grace watt,,ENGL-2120,2020
+ENGL,2120,11.0,World Literature,0.48,0.24,0.2,0.04,0.04,0%,0.0,0.0,caitlin grace watt,,ENGL-2120,2020
+ENGL,2120,13.0,World Literature,0.64,0.24,0.08,0.0,0.0,0%,0.0,0.04,remley makala,,ENGL-2120,2020
+ENGL,2120,17.0,World Literature,0.78,0.17,0.0,0.0,0.04,0%,0.0,0.0,remley makala,,ENGL-2120,2020
+ENGL,2120,21.0,World Literature,0.84,0.08,0.0,0.04,0.0,0%,0.0,0.04,remley makala,,ENGL-2120,2020
+ENGL,2120,22.0,World Literature,0.36,0.32,0.08,0.0,0.16,0%,0.0,0.08,david charles foltz,,ENGL-2120,2020
+ENGL,2120,23.0,World Literature,0.5,0.27,0.09,0.05,0.0,0%,0.0,0.05,david charles foltz,,ENGL-2120,2020
+ENGL,2120,24.0,World Literature,0.42,0.25,0.21,0.04,0.0,0%,0.0,0.04,david charles foltz,,ENGL-2120,2020
+ENGL,2120,25.0,World Literature,0.48,0.24,0.12,0.08,0.04,0%,0.0,0.04,david charles foltz,,ENGL-2120,2020
+ENGL,2120,26.0,World Literature,0.64,0.2,0.12,0.0,0.0,0%,0.0,0.04,john benjamin fuqua,,ENGL-2120,2020
+ENGL,2120,27.0,World Literature,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,john benjamin fuqua,,ENGL-2120,2020
+ENGL,2120,28.0,World Literature,0.4,0.36,0.0,0.08,0.16,0%,0.0,0.0,andrew mathas,,ENGL-2120,2020
+ENGL,2120,400.0,World Literature,0.17,0.46,0.17,0.04,0.04,0%,0.0,0.13,sarah mae cooper,,ENGL-2120,2020
+ENGL,2120,401.0,World Literature,0.25,0.5,0.17,0.0,0.0,0%,0.0,0.08,sarah mae cooper,,ENGL-2120,2020
+ENGL,2120,402.0,World Literature,0.6,0.12,0.08,0.08,0.0,0%,0.0,0.12,sharon nalley,,ENGL-2120,2020
+ENGL,2120,403.0,World Literature,0.64,0.16,0.04,0.0,0.04,0%,0.0,0.12,sharon nalley,,ENGL-2120,2020
+ENGL,2120,404.0,World Literature,0.28,0.6,0.04,0.04,0.0,0%,0.0,0.04,sarah mae cooper,,ENGL-2120,2020
+ENGL,2120,405.0,World Literature,0.88,0.0,0.12,0.0,0.0,0%,0.0,0.0,melissa dugan,,ENGL-2120,2020
+ENGL,2120,406.0,World Literature,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,walter edgar hunter,,ENGL-2120,2020
+ENGL,2120,407.0,World Literature,0.32,0.45,0.18,0.0,0.0,0%,0.0,0.05,daniel scott citro,,ENGL-2120,2020
+ENGL,2120,408.0,World Literature,0.36,0.36,0.0,0.09,0.0,0%,0.0,0.18,daniel scott citro,,ENGL-2120,2020
+ENGL,2120,409.0,World Literature,0.64,0.16,0.08,0.12,0.0,0%,0.0,0.0,sharon nalley,,ENGL-2120,2020
+ENGL,2120,410.0,World Literature,0.56,0.2,0.04,0.12,0.04,0%,0.0,0.04,sharon nalley,,ENGL-2120,2020
+ENGL,2120,411.0,World Literature,0.85,0.08,0.0,0.0,0.08,0%,0.0,0.0,walter edgar hunter,,ENGL-2120,2020
+ENGL,2120,412.0,World Literature,0.63,0.13,0.13,0.0,0.0,0%,0.0,0.13,henna messina,,ENGL-2120,2020
+ENGL,2120,413.0,World Literature,0.4,0.4,0.04,0.04,0.0,0%,0.0,0.12,henna messina,,ENGL-2120,2020
+ENGL,2120,414.0,World Literature,0.55,0.36,0.0,0.0,0.0,0%,0.0,0.09,maziyar faridi,,ENGL-2120,2020
+ENGL,2120,415.0,World Literature,0.4,0.48,0.04,0.0,0.0,0%,0.0,0.08,maziyar faridi,,ENGL-2120,2020
+ENGL,2120,416.0,World Literature,0.72,0.24,0.0,0.04,0.0,0%,0.0,0.0,hannah godwin,,ENGL-2120,2020
+ENGL,2120,417.0,World Literature,0.72,0.24,0.0,0.04,0.0,0%,0.0,0.0,hannah godwin,,ENGL-2120,2020
+ENGL,2120,418.0,World Literature,0.84,0.12,0.0,0.0,0.0,0%,0.0,0.04,hannah godwin,,ENGL-2120,2020
+ENGL,2120,419.0,World Literature,0.29,0.46,0.21,0.0,0.0,0%,0.0,0.0,sarah mae cooper,,ENGL-2120,2020
+ENGL,2130,1.0,British Literature,0.6,0.2,0.07,0.07,0.07,0%,0.0,0.0,william stockton,,ENGL-2130,2020
+ENGL,2130,2.0,British Literature,0.67,0.13,0.13,0.0,0.0,0%,0.0,0.07,william stockton,,ENGL-2130,2020
+ENGL,2130,3.0,British Literature,0.6,0.27,0.13,0.0,0.0,0%,0.0,0.0,william stockton,,ENGL-2130,2020
+ENGL,2130,4.0,British Literature,0.48,0.4,0.0,0.0,0.04,0%,0.0,0.08,john benjamin fuqua,,ENGL-2130,2020
+ENGL,2130,5.0,British Literature,0.54,0.25,0.08,0.04,0.04,0%,0.0,0.04,remley makala,,ENGL-2130,2020
+ENGL,2130,6.0,British Literature,0.67,0.25,0.04,0.0,0.04,0%,0.0,0.0,lucian ghita,,ENGL-2130,2020
+ENGL,2130,7.0,British Literature,0.72,0.2,0.08,0.0,0.0,0%,0.0,0.0,lucian ghita,,ENGL-2130,2020
+ENGL,2130,8.0,British Literature,0.84,0.08,0.08,0.0,0.0,0%,0.0,0.0,lucian ghita,,ENGL-2130,2020
+ENGL,2130,400.0,British Literature,0.61,0.3,0.0,0.0,0.04,0%,0.0,0.0,daniel scott citro,,ENGL-2130,2020
+ENGL,2130,401.0,British Literature,0.3,0.43,0.04,0.04,0.09,0%,0.0,0.04,daniel scott citro,,ENGL-2130,2020
+ENGL,2130,402.0,British Literature,0.48,0.16,0.24,0.0,0.0,0%,0.0,0.08,henna messina,,ENGL-2130,2020
+ENGL,2130,403.0,British Literature,0.61,0.3,0.0,0.0,0.04,0%,0.0,0.04,daniel scott citro,,ENGL-2130,2020
+ENGL,2130,404.0,British Literature,0.4,0.52,0.0,0.0,0.04,0%,0.0,0.04,ingrid anna pierce,,ENGL-2130,2020
+ENGL,2140,1.0,American Literature,0.08,0.56,0.2,0.0,0.04,0%,0.0,0.12,chelsea marie clarey,,ENGL-2140,2020
+ENGL,2140,2.0,American Literature,0.13,0.58,0.25,0.0,0.04,0%,0.0,0.0,chelsea marie clarey,,ENGL-2140,2020
+ENGL,2140,3.0,American Literature,0.25,0.42,0.21,0.04,0.04,0%,0.0,0.0,chelsea marie clarey,,ENGL-2140,2020
+ENGL,2140,4.0,American Literature,0.22,0.3,0.17,0.04,0.04,0%,0.0,0.22,chelsea marie clarey,,ENGL-2140,2020
+ENGL,2140,7.0,American Literature,0.84,0.08,0.0,0.04,0.0,0%,0.0,0.04,melissa dugan,,ENGL-2140,2020
+ENGL,2140,8.0,American Literature,0.88,0.04,0.0,0.04,0.04,0%,0.0,0.0,melissa dugan,,ENGL-2140,2020
+ENGL,2140,400.0,American Literature,0.38,0.38,0.25,0.0,0.0,0%,0.0,0.0,clare mullaney,,ENGL-2140,2020
+ENGL,2140,401.0,American Literature,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,jennifer forsberg,,ENGL-2140,2020
+ENGL,2140,402.0,American Literature,0.39,0.3,0.13,0.0,0.09,0%,0.0,0.09,karen kettnich,,ENGL-2140,2020
+ENGL,2140,403.0,American Literature,0.43,0.43,0.04,0.0,0.09,0%,0.0,0.0,karen kettnich,,ENGL-2140,2020
+ENGL,2140,404.0,American Literature,0.6,0.24,0.08,0.0,0.0,0%,0.0,0.08,jennifer forsberg,,ENGL-2140,2020
+ENGL,2140,405.0,American Literature,0.68,0.16,0.16,0.0,0.0,0%,0.0,0.0,david charles foltz,,ENGL-2140,2020
+ENGL,2140,406.0,American Literature,0.8,0.08,0.0,0.0,0.04,0%,0.0,0.08,sharon nalley,,ENGL-2140,2020
+ENGL,2140,407.0,American Literature,0.5,0.25,0.17,0.0,0.04,0%,0.0,0.04,mary nestor,,ENGL-2140,2020
+ENGL,2150,5.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.12,0.04,0.04,0%,0.0,0.0,william cunningham,,ENGL-2150,2020
+ENGL,2150,7.0,Lit in 20th-21st Cent Conte,0.2,0.32,0.4,0.0,0.08,0%,0.0,0.0,megan macalystre,,ENGL-2150,2020
+ENGL,2150,8.0,Lit in 20th-21st Cent Conte,0.52,0.24,0.12,0.08,0.0,0%,0.0,0.04,william cunningham,,ENGL-2150,2020
+ENGL,2150,9.0,Lit in 20th-21st Cent Conte,0.48,0.35,0.04,0.0,0.09,0%,0.0,0.04,gregory luke chwala,,ENGL-2150,2020
+ENGL,2150,10.0,Lit in 20th-21st Cent Conte,0.24,0.59,0.06,0.0,0.0,0%,0.0,0.12,gregory luke chwala,,ENGL-2150,2020
+ENGL,2150,11.0,Lit in 20th-21st Cent Conte,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,allen swords,,ENGL-2150,2020
+ENGL,2150,12.0,Lit in 20th-21st Cent Conte,0.84,0.12,0.04,0.0,0.0,0%,0.0,0.0,allen swords,,ENGL-2150,2020
+ENGL,2150,14.0,Lit in 20th-21st Cent Conte,0.5,0.28,0.06,0.11,0.0,0%,0.0,0.06,gregory luke chwala,,ENGL-2150,2020
+ENGL,2150,15.0,Lit in 20th-21st Cent Conte,0.58,0.38,0.0,0.0,0.04,0%,0.0,0.0,john logan pursley,,ENGL-2150,2020
+ENGL,2150,16.0,Lit in 20th-21st Cent Conte,0.64,0.28,0.04,0.0,0.04,0%,0.0,0.0,john logan pursley,,ENGL-2150,2020
+ENGL,2150,17.0,Lit in 20th-21st Cent Conte,0.36,0.32,0.12,0.0,0.12,0%,0.0,0.08,megan macalystre,,ENGL-2150,2020
+ENGL,2150,18.0,Lit in 20th-21st Cent Conte,0.56,0.28,0.08,0.04,0.04,0%,0.0,0.0,elizabeth stansell,,ENGL-2150,2020
+ENGL,2150,21.0,Lit in 20th-21st Cent Conte,0.52,0.3,0.09,0.04,0.04,0%,0.0,0.0,megan macalystre,,ENGL-2150,2020
+ENGL,2150,22.0,Lit in 20th-21st Cent Conte,0.64,0.24,0.04,0.0,0.04,0%,0.0,0.04,john logan pursley,,ENGL-2150,2020
+ENGL,2150,27.0,Lit in 20th-21st Cent Conte,0.64,0.32,0.0,0.0,0.0,0%,0.0,0.04,elizabeth stansell,,ENGL-2150,2020
+ENGL,2150,29.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.08,0.08,0.04,0%,0.0,0.0,andrew mathas,,ENGL-2150,2020
+ENGL,2150,30.0,Lit in 20th-21st Cent Conte,0.68,0.12,0.12,0.0,0.08,0%,0.0,0.0,andrew mathas,,ENGL-2150,2020
+ENGL,2150,400.0,Lit in 20th-21st Cent Conte,0.6,0.24,0.12,0.0,0.04,0%,0.0,0.0,elizabeth stansell,,ENGL-2150,2020
+ENGL,2150,401.0,Lit in 20th-21st Cent Conte,0.48,0.26,0.17,0.0,0.0,0%,0.0,0.04,gregory luke chwala,,ENGL-2150,2020
+ENGL,2150,402.0,Lit in 20th-21st Cent Conte,0.72,0.16,0.0,0.04,0.0,0%,0.0,0.08,heather williams,,ENGL-2150,2020
+ENGL,2150,403.0,Lit in 20th-21st Cent Conte,0.76,0.16,0.08,0.0,0.0,0%,0.0,0.0,heather williams,,ENGL-2150,2020
+ENGL,2150,404.0,Lit in 20th-21st Cent Conte,0.54,0.13,0.0,0.04,0.17,0%,0.0,0.13,jamie ann rogers,,ENGL-2150,2020
+ENGL,2150,405.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.12,0.04,0.0,0%,0.0,0.04,mary nestor,,ENGL-2150,2020
+ENGL,2150,406.0,Lit in 20th-21st Cent Conte,0.4,0.48,0.0,0.0,0.12,0%,0.0,0.0,mary nestor,,ENGL-2150,2020
+ENGL,2150,407.0,Lit in 20th-21st Cent Conte,0.76,0.16,0.04,0.0,0.04,0%,0.0,0.0,april ayers lawson,,ENGL-2150,2020
+ENGL,2150,409.0,Lit in 20th-21st Cent Conte,0.48,0.26,0.13,0.0,0.09,0%,0.0,0.04,sarah matalone,,ENGL-2150,2020
+ENGL,2150,410.0,Lit in 20th-21st Cent Conte,0.52,0.28,0.04,0.0,0.04,0%,0.0,0.12,sarah matalone,,ENGL-2150,2020
+ENGL,2150,411.0,Lit in 20th-21st Cent Conte,0.48,0.28,0.0,0.0,0.04,0%,0.0,0.2,tareva johnson,,ENGL-2150,2020
+ENGL,2150,412.0,Lit in 20th-21st Cent Conte,0.54,0.25,0.0,0.0,0.08,0%,0.0,0.13,tareva johnson,,ENGL-2150,2020
+ENGL,2150,413.0,Lit in 20th-21st Cent Conte,0.84,0.14,0.02,0.0,0.0,0%,0.0,0.0,david coombs,,ENGL-2150,2020
+ENGL,2160,4.0,African American Literatur,0.44,0.32,0.12,0.04,0.0,0%,0.0,0.08,patricia sunia,,ENGL-2160,2020
+ENGL,2160,400.0,African American Literatur,0.44,0.24,0.08,0.0,0.04,0%,0.0,0.2,tareva johnson,,ENGL-2160,2020
+ENGL,2160,401.0,African American Literatur,0.44,0.24,0.08,0.0,0.08,0%,0.0,0.12,tareva johnson,,ENGL-2160,2020
+ENGL,2160,402.0,African American Literatur,0.76,0.12,0.04,0.0,0.04,0%,0.0,0.04,jamie ann rogers,,ENGL-2160,2020
+ENGL,2160,403.0,African American Literatur,0.68,0.12,0.04,0.04,0.08,0%,0.0,0.04,jamie ann rogers,,ENGL-2160,2020
+ENGL,2160,404.0,African American Literatur,0.68,0.12,0.12,0.0,0.0,0%,0.0,0.04,jamie ann rogers,,ENGL-2160,2020
+ENGL,2310,400.0,Intro to Journalism,0.71,0.19,0.0,0.0,0.05,0%,0.0,0.05,william pulley,,ENGL-2310,2020
+ENGL,3010,1.0,Great Books of Western W,0.6,0.2,0.0,0.0,0.2,0%,0.0,0.0,dominic mastroianni,,ENGL-3010,2020
+ENGL,3040,2.0,Business Writing,0.81,0.14,0.05,0.0,0.0,0%,0.0,0.0,ashley cowden fisk,,ENGL-3040,2020
+ENGL,3040,400.0,Business Writing,0.77,0.14,0.0,0.05,0.05,0%,0.0,0.0,heather williams,,ENGL-3040,2020
+ENGL,3040,401.0,Business Writing,0.86,0.1,0.05,0.0,0.0,0%,0.0,0.0,heather williams,,ENGL-3040,2020
+ENGL,3040,402.0,Business Writing,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,,ENGL-3040,2020
+ENGL,3040,403.0,Business Writing,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,,ENGL-3040,2020
+ENGL,3040,404.0,Business Writing,0.71,0.19,0.0,0.0,0.0,0%,0.0,0.1,la'cresha ulon green,,ENGL-3040,2020
+ENGL,3040,405.0,Business Writing,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,,ENGL-3040,2020
+ENGL,3040,406.0,Business Writing,0.67,0.24,0.05,0.0,0.05,0%,0.0,0.0,ingrid anna pierce,,ENGL-3040,2020
+ENGL,3040,407.0,Business Writing,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ingrid anna pierce,,ENGL-3040,2020
+ENGL,3040,408.0,Business Writing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,ingrid anna pierce,,ENGL-3040,2020
+ENGL,3040,409.0,Business Writing,0.59,0.23,0.14,0.0,0.0,0%,0.0,0.05,jennifer forsberg,,ENGL-3040,2020
+ENGL,3040,410.0,Business Writing,0.67,0.19,0.14,0.0,0.0,0%,0.0,0.0,jennifer forsberg,,ENGL-3040,2020
+ENGL,3040,411.0,Business Writing,0.67,0.19,0.14,0.0,0.0,0%,0.0,0.0,jennifer forsberg,,ENGL-3040,2020
+ENGL,3040,414.0,Business Writing,0.86,0.1,0.0,0.0,0.05,0%,0.0,0.0,patricia sunia,,ENGL-3040,2020
+ENGL,3100,1.0,Crit Writ Lit,0.43,0.43,0.0,0.05,0.1,0%,0.0,0.0,brian mcgrath,,ENGL-3100,2020
+ENGL,3100,2.0,Crit Writ Lit,0.91,0.05,0.0,0.0,0.0,0%,0.0,0.05,matthew hooley,,ENGL-3100,2020
+ENGL,3100,4.0,Crit Writ Lit,0.45,0.32,0.05,0.09,0.0,0%,0.0,0.05,cameron bushnell,,ENGL-3100,2020
+ENGL,3120,1.0,Advanced Composition,0.43,0.33,0.05,0.0,0.14,0%,0.0,0.05,shauna chung,,ENGL-3120,2020
+ENGL,3120,2.0,Advanced Composition,0.38,0.33,0.14,0.0,0.1,0%,0.0,0.05,shauna chung,,ENGL-3120,2020
+ENGL,3140,7.0,Technical Writing,0.62,0.29,0.05,0.0,0.05,0%,0.0,0.0,william cunningham,,ENGL-3140,2020
+ENGL,3140,8.0,Technical Writing,0.57,0.33,0.0,0.0,0.1,0%,0.0,0.0,william cunningham,,ENGL-3140,2020
+ENGL,3140,401.0,Technical Writing,0.73,0.14,0.0,0.05,0.05,0%,0.0,0.05,katalin beck,,ENGL-3140,2020
+ENGL,3140,402.0,Technical Writing,0.62,0.24,0.05,0.0,0.05,0%,0.0,0.05,katalin beck,,ENGL-3140,2020
+ENGL,3140,405.0,Technical Writing,0.71,0.1,0.05,0.1,0.0,0%,0.0,0.05,henna messina,,ENGL-3140,2020
+ENGL,3140,406.0,Technical Writing,0.76,0.05,0.14,0.05,0.0,0%,0.0,0.0,henna messina,,ENGL-3140,2020
+ENGL,3140,407.0,Technical Writing,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,megan pietruszewski,,ENGL-3140,2020
+ENGL,3140,409.0,Technical Writing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,megan pietruszewski,,ENGL-3140,2020
+ENGL,3140,410.0,Technical Writing,0.81,0.1,0.0,0.0,0.1,0%,0.0,0.0,beltran quaglia,,ENGL-3140,2020
+ENGL,3140,411.0,Technical Writing,0.76,0.14,0.0,0.0,0.0,0%,0.0,0.1,beltran quaglia,,ENGL-3140,2020
+ENGL,3140,412.0,Technical Writing,0.85,0.05,0.0,0.0,0.0,0%,0.0,0.1,michelle lloyd,,ENGL-3140,2020
+ENGL,3140,413.0,Technical Writing,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,michelle lloyd,,ENGL-3140,2020
+ENGL,3140,414.0,Technical Writing,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,hannah godwin,,ENGL-3140,2020
+ENGL,3140,416.0,Technical Writing,0.8,0.1,0.05,0.0,0.0,0%,0.0,0.05,michael measel,,ENGL-3140,2020
+ENGL,3140,417.0,Technical Writing,0.71,0.14,0.0,0.05,0.05,0%,0.0,0.05,michael measel,,ENGL-3140,2020
+ENGL,3140,418.0,Technical Writing,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,victoria houser,,ENGL-3140,2020
+ENGL,3140,419.0,Technical Writing,0.62,0.19,0.14,0.05,0.0,0%,0.0,0.0,victoria houser,,ENGL-3140,2020
+ENGL,3140,420.0,Technical Writing,0.62,0.29,0.1,0.0,0.0,0%,0.0,0.0,katalin beck,,ENGL-3140,2020
+ENGL,3150,400.0,Scientific Writing & Comm,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,philip randall,,ENGL-3150,2020
+ENGL,3150,401.0,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,philip randall,,ENGL-3150,2020
+ENGL,3150,402.0,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,philip randall,,ENGL-3150,2020
+ENGL,3150,404.0,Scientific Writing & Comm,0.83,0.11,0.06,0.0,0.0,0%,0.0,0.0,megan pietruszewski,,ENGL-3150,2020
+ENGL,3150,405.0,Scientific Writing & Comm,0.71,0.14,0.05,0.0,0.05,0%,0.0,0.05,megan pietruszewski,,ENGL-3150,2020
+ENGL,3150,406.0,Scientific Writing & Comm,0.68,0.26,0.0,0.0,0.05,0%,0.0,0.0,william pulley,,ENGL-3150,2020
+ENGL,3150,407.0,Scientific Writing & Comm,0.57,0.24,0.1,0.05,0.05,0%,0.0,0.0,william pulley,,ENGL-3150,2020
+ENGL,3150,408.0,Scientific Writing & Comm,0.5,0.3,0.1,0.0,0.05,0%,0.0,0.05,william pulley,,ENGL-3150,2020
+ENGL,3150,409.0,Scientific Writing & Comm,0.9,0.0,0.05,0.0,0.05,0%,0.0,0.0,sheila lalwani,,ENGL-3150,2020
+ENGL,3150,410.0,Scientific Writing & Comm,0.85,0.0,0.05,0.05,0.0,0%,0.0,0.05,sheila lalwani,,ENGL-3150,2020
+ENGL,3450,400.0,Intr Creative Writing: Ficti,0.7,0.15,0.1,0.0,0.05,0%,0.0,0.0,sarah matalone,,ENGL-3450,2020
+ENGL,3450,401.0,Intr Creative Writing: Ficti,0.48,0.29,0.05,0.0,0.1,0%,0.0,0.1,sarah matalone,,ENGL-3450,2020
+ENGL,3460,400.0,Intr Creative Writing: Poet,0.6,0.25,0.1,0.0,0.05,0%,0.0,0.0,stephanie edwards,,ENGL-3460,2020
+ENGL,3480,400.0,Intr Creat Writ: Screenwrit,0.79,0.0,0.0,0.0,0.11,0%,0.0,0.11,april ayers lawson,,ENGL-3480,2020
+ENGL,3480,401.0,Intr Creat Writ: Screenwrit,0.85,0.0,0.0,0.0,0.05,0%,0.0,0.1,april ayers lawson,,ENGL-3480,2020
+ENGL,3490,1.0,Tech/Pop Imagination,0.5,0.33,0.11,0.0,0.06,0%,0.0,0.0,michelle smith,,ENGL-3490,2020
+ENGL,3500,1.0,Mythology,0.22,0.33,0.17,0.06,0.11,0%,0.0,0.06,kenneth tuite,,ENGL-3500,2020
+ENGL,3570,4.0,Film,0.68,0.26,0.0,0.0,0.0,0%,0.0,0.0,john robert smith,,ENGL-3570,2020
+ENGL,3570,400.0,Film,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,amy monaghan,,ENGL-3570,2020
+ENGL,3570,401.0,Film,0.47,0.26,0.11,0.0,0.05,0%,0.0,0.05,amy monaghan,,ENGL-3570,2020
+ENGL,3570,402.0,Film,0.3,0.4,0.1,0.0,0.1,0%,0.0,0.1,amy monaghan,,ENGL-3570,2020
+ENGL,3850,1.0,Children's Lit,0.39,0.5,0.06,0.0,0.06,0%,0.0,0.0,megan macalystre,,ENGL-3850,2020
+ENGL,3860,400.0,Adolescent Lit,0.23,0.31,0.23,0.0,0.08,0%,0.0,0.08,amy monaghan,,ENGL-3860,2020
+ENGL,3970,2.0,Brit Lit Survey II,0.62,0.24,0.1,0.0,0.05,0%,0.0,0.0,david coombs,,ENGL-3970,2020
+ENGL,3980,400.0,Amer Lit Survey I,0.75,0.1,0.15,0.0,0.0,0%,0.0,0.0,kimberly manganelli,,ENGL-3980,2020
+ENGL,3990,1.0,Amer Lit Survey II,0.7,0.15,0.05,0.0,0.05,0%,0.0,0.05,dominic mastroianni,,ENGL-3990,2020
+ENGL,4010,2.0,Grammar Survey,0.36,0.29,0.29,0.07,0.0,0%,0.0,0.0,brian mcgrath,,ENGL-4010,2020
+ENGL,4110,401.0,Shakespeare,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,andrew lemons,,ENGL-4110,2020
+ENGL,4110,402.0,Shakespeare,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,andrew lemons,,ENGL-4110,2020
+ENGL,4280,2.0,Contemporary Literature,0.38,0.31,0.08,0.0,0.08,0%,0.0,0.15,michael lemahieu,,ENGL-4280,2020
+ENGL,4360,1.0,Feminist Literary Criticism,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,erin marina goss,,ENGL-4360,2020
+ENGL,4400,1.0,Literary Theory,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,matthew hooley,,ENGL-4400,2020
+ENGL,4410,400.0,Literary Editing,0.23,0.46,0.23,0.0,0.0,0%,0.0,0.0,clare mullaney,,ENGL-4410,2020
+ENGL,4440,1.0,Renaissance Literature,0.29,0.47,0.06,0.0,0.18,0%,0.0,0.0,william stockton,,ENGL-4440,2020
+ENGL,4450,1.0,Fiction Workshop,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,nicholas brown,,ENGL-4450,2020
+ENGL,4480,2.0,Screenwriting Wkshop,0.58,0.17,0.08,0.17,0.0,0%,0.0,0.0,nicholas brown,,ENGL-4480,2020
+ENGL,4510,1.0,Film Theory and Criticism,0.53,0.37,0.11,0.0,0.0,0%,0.0,0.0,agnieszka skrodzka,,ENGL-4510,2020
+ENGL,4520,2.0,Great Directors,0.48,0.14,0.14,0.0,0.0,0%,0.0,0.0,john robert smith,,ENGL-4520,2020
+ENGL,4640,1.0,Topics in Literature 1700-1,0.42,0.25,0.17,0.17,0.0,0%,0.0,0.0,erin marina goss,,ENGL-4640,2020
+ENGL,4750,400.0,Writing for Media,0.5,0.31,0.13,0.0,0.0,0%,0.0,0.06,jonathan field,,ENGL-4750,2020
+ENGL,4820,1.0,Afr Am Lit to 1920,0.38,0.38,0.19,0.0,0.0,0%,0.0,0.05,rhondda thomas,,ENGL-4820,2020
+ENGL,4830,1.0,Af Am Lit 1920-Pres,0.58,0.32,0.05,0.0,0.0,0%,0.0,0.05,maya sylvia hislop,,ENGL-4830,2020
+ENGL,4920,400.0,Modern Rhetoric,0.69,0.08,0.08,0.0,0.15,0%,0.0,0.0,megan eatman,,ENGL-4920,2020
+ENGL,4960,2.0,Senior Seminar,0.75,0.08,0.0,0.0,0.08,0%,0.0,0.08,michelle smith,,ENGL-4960,2020
+ENGL,4960,400.0,Senior Seminar,0.79,0.07,0.07,0.0,0.0,0%,0.0,0.0,jonathan field,,ENGL-4960,2020
+ENGL,8080,400.0,Top Renaiss & Restoration,0.86,0.07,0.0,0.0,0.07,0%,0.0,0.0,elizabeth rivlin,,ENGL-8080,2020
+ENGL,8100,400.0,Literary Criticism & Theory,0.18,0.36,0.09,0.0,0.09,0%,0.0,0.18,lee morrissey,,ENGL-8100,2020
+ENGL,8310,1.0,Special Topics,0.8,0.13,0.0,0.0,0.0,0%,0.0,0.07,maya sylvia hislop,,ENGL-8310,2020
+ENGL,8910,1.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gabriel hankins,,ENGL-8910,2020
+ENGR,1000,101.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,steven brandon,,ENGR-1000,2020
+ENGR,1000,102.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,steven brandon,,ENGR-1000,2020
+ENGR,1000,103.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,89%,0.09,0.02,steven brandon,,ENGR-1000,2020
+ENGR,1000,104.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,88%,0.1,0.02,steven brandon,,ENGR-1000,2020
+ENGR,1010,392.0,Survey of Mathematical To,0.25,0.33,0.17,0.08,0.0,0%,0.0,0.17,andrew neptune,,ENGR-1010,2020
+ENGR,1010,395.0,Survey of Mathematical To,0.29,0.46,0.13,0.0,0.08,0%,0.0,0.04,andrew neptune,,ENGR-1010,2020
+ENGR,1010,396.0,Survey of Mathematical To,0.34,0.41,0.1,0.0,0.07,0%,0.0,0.07,andrew neptune,,ENGR-1010,2020
+ENGR,1020,223.0,Engr Dis & Skills (HON),0.76,0.22,0.0,0.02,0.0,0%,0.0,0.0,richard watkins,True,ENGR-1020,2020
+ENGR,1020,311.0,Engineering Discipl & Skills,0.32,0.39,0.03,0.13,0.03,0%,0.0,0.11,john minor,,ENGR-1020,2020
+ENGR,1020,313.0,Engineering Discipl & Skills,0.52,0.22,0.17,0.0,0.04,0%,0.0,0.04,john minor,,ENGR-1020,2020
+ENGR,1020,314.0,Engineering Discipl & Skills,0.67,0.26,0.05,0.02,0.0,0%,0.0,0.0,elizabeth stephan,,ENGR-1020,2020
+ENGR,1020,317.0,Engineering Discipl & Skills,0.27,0.36,0.16,0.07,0.07,0%,0.0,0.09,katherine ehlert,,ENGR-1020,2020
+ENGR,1020,318.0,Engineering Discipl & Skills,0.41,0.36,0.05,0.07,0.07,0%,0.0,0.05,katherine ehlert,,ENGR-1020,2020
+ENGR,1020,611.0,Engineering Discipl & Skills,0.47,0.29,0.04,0.02,0.07,0%,0.0,0.11,baker martin,,ENGR-1020,2020
+ENGR,1020,612.0,Engineering Discipl & Skills,0.52,0.22,0.13,0.02,0.0,0%,0.0,0.11,baker martin,,ENGR-1020,2020
+ENGR,1020,613.0,Engineering Discipl & Skills,0.64,0.19,0.09,0.02,0.04,0%,0.0,0.02,taylor sorensen,,ENGR-1020,2020
+ENGR,1020,614.0,Engineering Discipl & Skills,0.67,0.15,0.13,0.02,0.0,0%,0.0,0.02,taylor sorensen,,ENGR-1020,2020
+ENGR,1020,615.0,Engineering Discipl & Skills,0.69,0.21,0.02,0.05,0.02,0%,0.0,0.0,taylor sorensen,,ENGR-1020,2020
+ENGR,1020,616.0,Engineering Discipl & Skills,0.5,0.22,0.11,0.0,0.04,0%,0.0,0.13,joseph overlin chapa,,ENGR-1020,2020
+ENGR,1020,617.0,Engineering Discipl & Skills,0.63,0.21,0.09,0.0,0.07,0%,0.0,0.0,joseph overlin chapa,,ENGR-1020,2020
+ENGR,1020,618.0,Engineering Discipl & Skills,0.47,0.36,0.07,0.04,0.0,0%,0.0,0.07,joseph overlin chapa,,ENGR-1020,2020
+ENGR,1020,801.0,Engineering Discipl & Skills,0.4,0.3,0.15,0.02,0.09,0%,0.0,0.04,irene marie ferrara,,ENGR-1020,2020
+ENGR,1020,808.0,Engineering Discipl & Skills,0.41,0.28,0.2,0.04,0.02,0%,0.0,0.04,jonathan maier,,ENGR-1020,2020
+ENGR,1020,812.0,Engineering Discipl & Skills,0.58,0.24,0.04,0.07,0.02,0%,0.0,0.04,irene marie ferrara,,ENGR-1020,2020
+ENGR,1020,813.0,Engineering Discipl & Skills,0.6,0.23,0.12,0.0,0.02,0%,0.0,0.02,irene marie ferrara,,ENGR-1020,2020
+ENGR,1020,814.0,Engineering Discipl & Skills,0.43,0.34,0.14,0.02,0.02,0%,0.0,0.05,michael waldrop,,ENGR-1020,2020
+ENGR,1020,815.0,Engineering Discipl & Skills,0.48,0.3,0.15,0.0,0.02,0%,0.0,0.04,michael waldrop,,ENGR-1020,2020
+ENGR,1020,816.0,Engineering Discipl & Skills,0.38,0.31,0.21,0.02,0.02,0%,0.0,0.05,michael waldrop,,ENGR-1020,2020
+ENGR,1020,817.0,Engineering Discipl & Skills,0.47,0.3,0.13,0.0,0.04,0%,0.0,0.06,jonathan maier,,ENGR-1020,2020
+ENGR,1020,881.0,Engr Discp & Skils (HON),0.68,0.24,0.03,0.0,0.0,0%,0.0,0.06,jonathan maier,True,ENGR-1020,2020
+ENGR,1100,206.0,Engineering Success Skills,0.64,0.21,0.04,0.07,0.0,0%,0.0,0.04,jonathan harcum,,ENGR-1100,2020
+ENGR,1100,603.0,Engineering Success Skills,0.72,0.12,0.08,0.0,0.0,0%,0.0,0.08,jonathan harcum,,ENGR-1100,2020
+ENGR,1100,802.0,Engineering Success Skills,0.88,0.08,0.0,0.0,0.04,0%,0.0,0.0,jonathan harcum,,ENGR-1100,2020
+ENGR,1410,223.0,Programming & Problem S,0.07,0.14,0.27,0.09,0.14,0%,0.0,0.16,steven brandon,,ENGR-1410,2020
+ENGR,1410,226.0,Programming & Problem S,0.07,0.2,0.36,0.04,0.13,0%,0.0,0.11,william martin,,ENGR-1410,2020
+ENGR,1410,227.0,Programming & Problem S,0.13,0.29,0.29,0.02,0.11,0%,0.0,0.13,william martin,,ENGR-1410,2020
+ENGR,1510,322.0,Engineering Skills,0.41,0.37,0.07,0.0,0.04,0%,0.0,0.11,matthew kent miller,,ENGR-1510,2020
+ENGR,1510,323.0,Engineering Skills,0.28,0.44,0.12,0.0,0.12,0%,0.0,0.04,matthew kent miller,,ENGR-1510,2020
+ENGR,1510,325.0,Engineering Skills,0.36,0.28,0.2,0.04,0.0,0%,0.0,0.12,matthew kent miller,,ENGR-1510,2020
+ENGR,1900,219.0,CI 3D Maker Space SOP,0.83,0.0,0.17,0.0,0.0,0%,0.0,0.0,todd schweisinger,,ENGR-1900,2020
+ENGR,2080,681.0,Engr Graphics & Machine,0.44,0.25,0.13,0.0,0.08,0%,0.0,0.1,kyle walker,,ENGR-2080,2020
+ENGR,2080,682.0,Engr Graphics & Machine,0.56,0.25,0.1,0.0,0.0,0%,0.0,0.06,vishal thomas,,ENGR-2080,2020
+ENGR,2080,684.0,Engr Graphics & Machine,0.39,0.22,0.06,0.06,0.08,0%,0.0,0.12,jennifer paige brown,,ENGR-2080,2020
+ENGR,2080,685.0,Engr Graphics & Machine,0.45,0.24,0.18,0.0,0.08,0%,0.0,0.04,jessica plaunt,,ENGR-2080,2020
+ENGR,2080,686.0,Engr Graphics & Machine,0.57,0.17,0.06,0.04,0.02,0%,0.0,0.13,nighat yasmin,,ENGR-2080,2020
+ENGR,2100,804.0,CAD & Engineering Applica,0.47,0.2,0.16,0.02,0.09,0%,0.0,0.07,naini shervin shoai,,ENGR-2100,2020
+ENGR,2100,805.0,CAD & Engineering Applica,0.35,0.33,0.13,0.07,0.07,0%,0.0,0.07,nighat yasmin,,ENGR-2100,2020
+ENGR,2100,806.0,CAD & Engineering Applica,0.2,0.39,0.13,0.02,0.09,0%,0.0,0.17,naini shervin shoai,,ENGR-2100,2020
+ENR,1010,2.0,Intro to Envir & Natur Res I,0.47,0.27,0.18,0.02,0.05,0%,0.0,0.0, guggenheimer,,ENR-1010,2020
+ENR,1010,3.0,Intro to Envir & Natur Res I,0.52,0.22,0.13,0.05,0.08,0%,0.0,0.0, guggenheimer,,ENR-1010,2020
+ENR,4290,1.0,Environ Law & Policy,0.64,0.19,0.11,0.02,0.02,0%,0.0,0.02,alan johnson,,ENR-4290,2020
+ENR,4290,2.0,Environ Law & Policy,0.73,0.13,0.04,0.04,0.02,0%,0.0,0.02,alan johnson,,ENR-4290,2020
+ENSP,2000,1.0,Intro Environ Sci,0.57,0.32,0.06,0.0,0.02,0%,0.0,0.02,scott brame,,ENSP-2000,2020
+ENSP,2000,2.0,Intro Environ Sci,0.95,0.04,0.02,0.0,0.0,0%,0.0,0.0,minory nammouz,,ENSP-2000,2020
+ENSP,2000,3.0,Intro Environ Sci,0.87,0.09,0.0,0.02,0.0,0%,0.0,0.02,minory nammouz,,ENSP-2000,2020
+ENSP,2000,4.0,Intro Environ Sci,0.58,0.26,0.05,0.05,0.02,0%,0.0,0.04,elizabeth carraway,,ENSP-2000,2020
+ENSP,2000,5.0,Intro Environ Sci,0.63,0.24,0.09,0.0,0.02,0%,0.0,0.02,tom owino,,ENSP-2000,2020
+ENSP,2000,6.0,Intro Environ Sci,0.4,0.55,0.05,0.0,0.0,0%,0.0,0.0,emily don scribner,,ENSP-2000,2020
+ENSP,4000,1.0,Studies in Environmental S,0.57,0.17,0.04,0.0,0.17,0%,0.0,0.0,margaret thompson,,ENSP-4000,2020
+ENT,3010,1.0,Insect Biology and Diversit,0.52,0.1,0.14,0.0,0.14,0%,0.0,0.1,michael ferro,,ENT-3010,2020
+ENT,8100,1.0,Bio & Phylogeog of S. Appa,0.64,0.09,0.27,0.0,0.0,0%,0.0,0.0,michael caterino,,ENT-8100,2020
+ENTR,1010,3.0,Entrepreneurial Mindset,0.85,0.09,0.03,0.01,0.02,0%,0.0,0.01,john michael hannon,,ENTR-1010,2020
+ENTR,1090,1.0,Creative Inq-Entrepreneur,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,john michael hannon,,ENTR-1090,2020
+ENTR,2010,4.0,Sports Entrepreneurship,0.58,0.26,0.05,0.0,0.05,0%,0.0,0.05,john michael hannon,,ENTR-2010,2020
+ESED,8100,1.0,Orientation to ESME Resea,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eliza gallagher,,ESED-8100,2020
+ESED,8720,1.0,Action Research in STEM E,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.0,karen ann high,,ESED-8720,2020
+ESED,9910,3.0,Dissertation Rsrch and Wri,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eliza gallagher,,ESED-9910,2020
+ESED,9910,5.0,Dissertation Rsrch and Wri,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,karen ann high,,ESED-9910,2020
+ETOX,4300,1.0,Toxicology,0.5,0.18,0.18,0.05,0.05,0%,0.0,0.05,lisa bain,,ETOX-4300,2020
+ETOX,6300,1.0,Toxicology,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,lisa bain,,ETOX-6300,2020
+ETOX,8610,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,den hurk peter van peter,,ETOX-8610,2020
+FDSC,1010,1.0,Intro to Food Sci & Hum N,0.65,0.27,0.05,0.01,0.01,0%,0.0,0.01,carol hegler,,FDSC-1010,2020
+FDSC,3010,1.0,Food Regulations,0.81,0.15,0.04,0.0,0.0,0%,0.0,0.0,sara lane cothran,,FDSC-3010,2020
+FDSC,4010,1.0,Food Chemistry I,0.45,0.5,0.05,0.0,0.0,0%,0.0,0.0,feng chen,,FDSC-4010,2020
+FDSC,4500,12.0,Creative Inquiry-Food Scie,0.82,0.0,0.09,0.0,0.0,0%,0.0,0.09,paul dawson,,FDSC-4500,2020
+FDSC,6010,1.0,Food Chem I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,feng chen,,FDSC-6010,2020
+FDSC,8120,1.0,Microbial Food Syst,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,xiuping jiang,,FDSC-8120,2020
+FIN,2010,401.0,Intro to Personal Finance I,0.98,0.01,0.0,0.0,0.01,0%,0.0,0.01,joshua harris,,FIN-2010,2020
+FIN,2010,402.0,Intro to Personal Finance I,0.84,0.08,0.04,0.02,0.02,0%,0.0,0.0,joshua harris,,FIN-2010,2020
+FIN,2020,401.0,Intro to Personal Finance II,0.97,0.0,0.0,0.0,0.02,0%,0.0,0.01,joshua harris,,FIN-2020,2020
+FIN,3040,1.0,Risk & Insurance,0.22,0.42,0.24,0.11,0.0,0%,0.0,0.0,kerri mcmillan,,FIN-3040,2020
+FIN,3050,1.0,Investment Analysis,0.16,0.25,0.41,0.14,0.02,0%,0.0,0.02,kerri mcmillan,,FIN-3050,2020
+FIN,3050,2.0,Investment Analysis,0.22,0.29,0.33,0.09,0.04,0%,0.0,0.02,kerri mcmillan,,FIN-3050,2020
+FIN,3050,3.0,Investment Analysis,0.16,0.27,0.32,0.07,0.07,0%,0.0,0.11,kerri mcmillan,,FIN-3050,2020
+FIN,3050,4.0,Investment Analysis,0.13,0.22,0.29,0.18,0.04,0%,0.0,0.13,john alexander,,FIN-3050,2020
+FIN,3060,1.0,Corporation Finance,0.47,0.27,0.14,0.04,0.04,0%,0.0,0.03,ramon franklin,,FIN-3060,2020
+FIN,3060,2.0,Corporation Finance,0.36,0.36,0.13,0.04,0.07,0%,0.0,0.04,ramon franklin,,FIN-3060,2020
+FIN,3060,3.0,Corporation Finance,0.25,0.25,0.27,0.16,0.02,0%,0.0,0.04,minxing sun,,FIN-3060,2020
+FIN,3060,4.0,Corporation Finance,0.16,0.38,0.25,0.16,0.0,0%,0.0,0.05,minxing sun,,FIN-3060,2020
+FIN,3060,5.0,Corporation Finance,0.07,0.21,0.5,0.21,0.0,0%,0.0,0.0,minxing sun,,FIN-3060,2020
+FIN,3060,6.0,Corporation Finance,0.55,0.23,0.11,0.04,0.0,0%,0.0,0.04,ramon franklin,,FIN-3060,2020
+FIN,3060,7.0,Corporation Finance,0.18,0.29,0.29,0.08,0.06,0%,0.0,0.1,taufique samdani,,FIN-3060,2020
+FIN,3060,401.0,Corporation Finance,0.48,0.27,0.15,0.0,0.04,0%,0.0,0.06,jonathan godbey,,FIN-3060,2020
+FIN,3060,402.0,Corporation Finance,0.46,0.22,0.18,0.1,0.0,0%,0.0,0.02,jonathan godbey,,FIN-3060,2020
+FIN,3070,1.0,Prin of Real Estate,0.26,0.21,0.23,0.23,0.05,0%,0.0,0.03,thomas springer,,FIN-3070,2020
+FIN,3070,2.0,Prin of Real Estate,0.36,0.18,0.28,0.15,0.03,0%,0.0,0.0,thomas springer,,FIN-3070,2020
+FIN,3070,5.0,Prin of Real Estate,0.21,0.46,0.26,0.05,0.03,0%,0.0,0.0,bryan blackwood,,FIN-3070,2020
+FIN,3080,1.0,Fin Inst & Mkts,0.6,0.28,0.1,0.03,0.0,0%,0.0,0.0,lyudmila chernykh,,FIN-3080,2020
+FIN,3080,2.0,Fin Inst & Mkts,0.74,0.21,0.03,0.03,0.0,0%,0.0,0.0,lyudmila chernykh,,FIN-3080,2020
+FIN,3080,3.0,Fin Inst & Mkts,0.36,0.44,0.18,0.03,0.0,0%,0.0,0.0,daniel greene,,FIN-3080,2020
+FIN,3080,401.0,Fin Inst & Mkts,0.44,0.3,0.24,0.0,0.02,0%,0.0,0.0,daniel greene,,FIN-3080,2020
+FIN,3110,1.0,Financial Management I,0.11,0.14,0.09,0.11,0.31,0%,0.0,0.23,jack wolf,,FIN-3110,2020
+FIN,3110,2.0,Financial Management I,0.08,0.03,0.36,0.08,0.26,0%,0.0,0.21,jack wolf,,FIN-3110,2020
+FIN,3110,3.0,Financial Management I,0.09,0.33,0.28,0.14,0.16,0%,0.0,0.0,weike xu,,FIN-3110,2020
+FIN,3110,4.0,Financial Management I,0.54,0.3,0.09,0.06,0.0,0%,0.0,0.01,joshua harris,,FIN-3110,2020
+FIN,3110,5.0,Financial Management I,0.46,0.39,0.14,0.0,0.01,0%,0.0,0.0,joshua harris,,FIN-3110,2020
+FIN,3120,1.0,Financial Management II,0.14,0.39,0.35,0.04,0.02,0%,0.0,0.06,weike xu,,FIN-3120,2020
+FIN,3120,2.0,Financial Management II,0.16,0.52,0.26,0.04,0.02,0%,0.0,0.0,weike xu,,FIN-3120,2020
+FIN,3120,3.0,Financial Management II,0.24,0.34,0.24,0.08,0.02,0%,0.0,0.08,taufique samdani,,FIN-3120,2020
+FIN,3120,4.0,Financial Management II,0.1,0.41,0.14,0.14,0.02,0%,0.0,0.18,taufique samdani,,FIN-3120,2020
+FIN,3120,5.0,Financial Management II,0.45,0.23,0.14,0.0,0.07,0%,0.0,0.11,arash dayani,,FIN-3120,2020
+FIN,3120,6.0,Financial Management II,0.35,0.15,0.2,0.05,0.15,0%,0.0,0.1,arash dayani,,FIN-3120,2020
+FIN,4010,1.0,Corporate Financial Analys,0.63,0.15,0.2,0.03,0.0,0%,0.0,0.0,george lockhart,,FIN-4010,2020
+FIN,4010,2.0,Corporate Financial Analys,0.55,0.3,0.13,0.0,0.0,0%,0.0,0.03,george lockhart,,FIN-4010,2020
+FIN,4020,1.0,Corporate Valuation,0.22,0.3,0.26,0.11,0.04,0%,0.0,0.07,angela morgan,,FIN-4020,2020
+FIN,4020,101.0,Corporate Valuation (HON,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,angela morgan,True,FIN-4020,2020
+FIN,4030,1.0,Spreadsheet Apps in Finan,0.26,0.24,0.38,0.09,0.0,0%,0.0,0.03,vincent intintoli,,FIN-4030,2020
+FIN,4030,2.0,Spreadsheet Apps in Finan,0.27,0.4,0.13,0.13,0.07,0%,0.0,0.0,vincent intintoli,,FIN-4030,2020
+FIN,4050,1.0,Portfolio Management & T,0.16,0.14,0.28,0.21,0.09,0%,0.0,0.12,john alexander,,FIN-4050,2020
+FIN,4060,1.0,Derivatives Analysis,0.14,0.34,0.37,0.09,0.03,0%,0.0,0.03,blerina zykaj,,FIN-4060,2020
+FIN,4110,1.0,Int Fin Mgt,0.29,0.53,0.16,0.03,0.0,0%,0.0,0.0,luke asher devault,,FIN-4110,2020
+FIN,4110,2.0,Int Fin Mgt,0.2,0.58,0.2,0.03,0.0,0%,0.0,0.0,luke asher devault,,FIN-4110,2020
+FIN,4150,1.0,Real Estate Investmt,0.31,0.19,0.35,0.0,0.08,0%,0.0,0.08,thomas springer,,FIN-4150,2020
+FIN,4980,7.0,CI in Finance: SIE,0.9,0.0,0.0,0.0,0.0,0%,0.0,0.1,joshua harris,,FIN-4980,2020
+FNR,2040,1.0,Soil Information Systems,0.79,0.16,0.03,0.0,0.0,0%,0.0,0.02,elena mikhailova,,FNR-2040,2020
+FNR,4990,1.0,Natural Resources Seminar,0.86,0.05,0.0,0.0,0.05,0%,0.0,0.05,robert fritz baldwin,,FNR-4990,2020
+FOR,2050,1.0,Dendrology,0.66,0.13,0.05,0.08,0.08,0%,0.0,0.0,donald hagan,,FOR-2050,2020
+FOR,2050,2.0,Dendrology,0.56,0.18,0.09,0.06,0.03,0%,0.0,0.09,donald hagan,,FOR-2050,2020
+FOR,2050,3.0,Dendrology,0.66,0.17,0.11,0.0,0.06,0%,0.0,0.0,donald hagan,,FOR-2050,2020
+FOR,2210,2.0,Forest Biology,0.95,0.03,0.0,0.0,0.0,0%,0.0,0.02,patrick mcmillan,,FOR-2210,2020
+FOR,3040,1.0,Forest Resource Economic,0.81,0.16,0.0,0.03,0.0,0%,0.0,0.0,puskar khanal,,FOR-3040,2020
+FOR,3410,1.0,Wood Procure Pract,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,patrick hiesl,,FOR-3410,2020
+FOR,4100,1.0,Harvesting Processes,0.63,0.3,0.0,0.07,0.0,0%,0.0,0.0,patrick hiesl,,FOR-4100,2020
+FOR,4130,1.0,Forest Protection,0.77,0.2,0.0,0.03,0.0,0%,0.0,0.0,jessica hartshorn,,FOR-4130,2020
+FOR,4150,1.0,Forest Wildlife Managmen,0.44,0.31,0.19,0.0,0.0,0%,0.0,0.06,greg yarrow,,FOR-4150,2020
+FOR,4160,1.0,Forest Policy and Admin,0.78,0.16,0.05,0.0,0.0,0%,0.0,0.01,patricia layton,,FOR-4160,2020
+FOR,4170,1.0,Forest Resource Mgt & Re,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,puskar khanal,,FOR-4170,2020
+FOR,4310,1.0,Recreation Res Plan in For,0.52,0.39,0.1,0.0,0.0,0%,0.0,0.0,robert baxter powell,,FOR-4310,2020
+FOR,4340,1.0,GIS for Natural Resources,0.79,0.12,0.02,0.02,0.0,0%,0.0,0.0,christopher post,,FOR-4340,2020
+FOR,8910,2.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,donald hagan,,FOR-8910,2020
+FOR,8930,22.0,Professional Development,0.57,0.14,0.0,0.0,0.0,0%,0.0,0.14,david jachowski,,FOR-8930,2020
+FR,1010,1.0,Elementary French,0.61,0.22,0.04,0.0,0.09,0%,0.0,0.04,amy lyn sawyer,,FR-1010,2020
+FR,1010,2.0,Elementary French,0.48,0.26,0.13,0.04,0.09,0%,0.0,0.0,amy lyn sawyer,,FR-1010,2020
+FR,1020,2.0,Elementary French,0.2,0.3,0.1,0.2,0.1,0%,0.0,0.1, nedeo anne salces anne,,FR-1020,2020
+FR,1020,3.0,Elementary French,0.13,0.44,0.25,0.0,0.0,0%,0.0,0.19, nedeo anne salces anne,,FR-1020,2020
+FR,2010,1.0,Intermediate French,0.18,0.73,0.09,0.0,0.0,0%,0.0,0.0,kenneth widgren,,FR-2010,2020
+FR,2010,2.0,Intermediate French,0.61,0.22,0.13,0.0,0.0,0%,0.0,0.04,amy lyn sawyer,,FR-2010,2020
+FR,2010,3.0,Intermediate French,0.72,0.28,0.0,0.0,0.0,0%,0.0,0.0,tholozany de,,FR-2010,2020
+FR,2020,1.0,Intermediate French,0.5,0.36,0.05,0.05,0.0,0%,0.0,0.05,eric touya,,FR-2020,2020
+FR,2020,2.0,Intermediate French,0.42,0.42,0.04,0.0,0.04,0%,0.0,0.08,kenneth widgren,,FR-2020,2020
+FR,2020,3.0,Intermediate French,0.67,0.17,0.17,0.0,0.0,0%,0.0,0.0,amy lyn sawyer,,FR-2020,2020
+FR,3000,1.0,Survey of French Lit,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,tholozany de,,FR-3000,2020
+FR,3050,1.0,Int Fr Con & Comp I,0.53,0.4,0.0,0.0,0.0,0%,0.0,0.07,kenneth widgren,,FR-3050,2020
+FR,3050,2.0,Int Fr Con & Comp I,0.4,0.47,0.0,0.0,0.0,0%,0.0,0.13, nedeo anne salces anne,,FR-3050,2020
+FR,3070,1.0,French Civilization,0.87,0.09,0.04,0.0,0.0,0%,0.0,0.0,kelly digby peebles,,FR-3070,2020
+FR,3120,2.0,Writing in French I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,kenneth widgren,,FR-3120,2020
+FR,4120,1.0,Fr & Francoph Cinema,0.77,0.15,0.0,0.0,0.08,0%,0.0,0.0,joseph mai,,FR-4120,2020
+GC,1010,2.0,Orientation to G C,0.0,0.0,0.0,0.0,0.0,96%,0.04,0.0,nona woolbright,,GC-1010,2020
+GC,1020,1.0,Computer Art & CAD Foun,0.67,0.19,0.05,0.03,0.03,0%,0.0,0.02,amanda bridges,,GC-1020,2020
+GC,1040,1.0,Graphic Communications I,0.64,0.23,0.02,0.02,0.09,0%,0.0,0.0,michelle suki fox,,GC-1040,2020
+GC,2070,1.0,Graphic Communications II,0.76,0.17,0.05,0.0,0.0,0%,0.0,0.02,charles tabor weiss,,GC-2070,2020
+GC,2400,1.0,Intro to Web Design and D,0.64,0.21,0.07,0.0,0.07,0%,0.0,0.0,william stevens,,GC-2400,2020
+GC,3400,1.0,Digital Imaging,0.38,0.33,0.18,0.03,0.08,0%,0.0,0.0,erica black walker,,GC-3400,2020
+GC,3460,1.0,Ink and Substrates,0.57,0.33,0.11,0.0,0.0,0%,0.0,0.0,shu chang,,GC-3460,2020
+GC,3730,1.0,Media Management in Bra,0.76,0.17,0.07,0.0,0.0,0%,0.0,0.0,jaclyn driggs,,GC-3730,2020
+GC,3740,2.0,Brand Communications Str,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,jacqueline reed herr,,GC-3740,2020
+GC,3760,1.0,Brand Comm Capstone Se,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,katelyn hildebrand,,GC-3760,2020
+GC,4060,1.0,Package and Specialty Prin,0.38,0.53,0.06,0.0,0.03,0%,0.0,0.0,carol jones,,GC-4060,2020
+GC,4400,1.0,Commercial Printing,0.4,0.51,0.05,0.0,0.0,0%,0.0,0.0,eric weisenmiller,,GC-4400,2020
+GC,4440,1.0,Current Dev/Trends in Gr,0.43,0.45,0.1,0.02,0.0,0%,0.0,0.0,liam henry 'hara,,GC-4440,2020
+GC,4480,1.0,Plan & Cont Printing Functi,0.93,0.03,0.0,0.03,0.0,0%,0.0,0.0,nona woolbright,,GC-4480,2020
+GC,4800,1.0,Senior Seminar in GC,0.83,0.1,0.05,0.0,0.0,0%,0.0,0.0,charles tonkin,,GC-4800,2020
+GC,4900,5.0,Videography & Visual Effec,0.67,0.25,0.08,0.0,0.0,0%,0.0,0.0,erica black walker,,GC-4900,2020
+GC,8970,1.0,G C Research Prob I,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.0,nona woolbright,,GC-8970,2020
+GEN,1030,1.0,Careers in Bioch/Gen,0.83,0.1,0.06,0.0,0.02,0%,0.0,0.0,alison starr-moss,,GEN-1030,2020
+GEN,3000,1.0,Fundamental Genetics,0.74,0.18,0.08,0.0,0.0,0%,0.0,0.0,michael harris,,GEN-3000,2020
+GEN,3000,2.0,Fundamental Genetics,0.7,0.27,0.01,0.0,0.02,0%,0.0,0.0,todd lyda,,GEN-3000,2020
+GEN,3000,6.0,Fundamental Genetics,0.28,0.4,0.19,0.04,0.07,0%,0.0,0.01,haiying liang,,GEN-3000,2020
+GEN,3020,1.0,Molec & General Genetics,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,kate leanne tsai,True,GEN-3020,2020
+GEN,3020,2.0,Molecular & General Gene,0.43,0.37,0.11,0.01,0.03,0%,0.0,0.05,kate leanne tsai,,GEN-3020,2020
+GEN,3020,4.0,Molecular & General Gene,0.18,0.41,0.27,0.05,0.0,0%,0.0,0.09,kate leanne tsai,,GEN-3020,2020
+GEN,4100,1.0,Population & Quant Genet,0.59,0.36,0.02,0.0,0.0,0%,0.0,0.02,metris kanapeckas,,GEN-4100,2020
+GEN,4100,2.0,Population & Quant Gen (,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,metris kanapeckas,True,GEN-4100,2020
+GEN,4110,3.0,Population & Quant Gen L,0.81,0.06,0.06,0.0,0.0,0%,0.0,0.06,metris kanapeckas,,GEN-4110,2020
+GEN,4110,4.0,Population & Quant Gen L,0.5,0.17,0.25,0.0,0.08,0%,0.0,0.0,metris kanapeckas,,GEN-4110,2020
+GEN,4400,1.0,Bioinformatics,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.13,frank feltus,,GEN-4400,2020
+GEN,4500,1.0,Comparative Genetics,0.25,0.45,0.16,0.0,0.0,0%,0.0,0.14,leigh anne clark,,GEN-4500,2020
+GEN,4500,2.0,Comparative Genetics (HO,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,leigh anne clark,True,GEN-4500,2020
+GEN,8050,1.0,Issues in Research,0.67,0.17,0.0,0.0,0.0,0%,0.0,0.0,julia frugoli,,GEN-8050,2020
+GEN,8250,1.0,Seminar I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rajandeep sekhon,,GEN-8250,2020
+GEOG,1010,1.0,Intro to Geography,0.78,0.13,0.05,0.03,0.0,0%,0.0,0.03,christa smith,,GEOG-1010,2020
+GEOG,1030,2.0,World Regional Geography,0.38,0.37,0.11,0.06,0.03,0%,0.0,0.03,william church terry,,GEOG-1030,2020
+GEOG,4100,1.0,Geog of the American Sout,0.83,0.0,0.0,0.0,0.08,0%,0.0,0.0,christa smith,,GEOG-4100,2020
+GEOL,1010,1.0,Physical Geology,0.62,0.26,0.06,0.04,0.02,0%,0.0,0.01,alan coulson,,GEOL-1010,2020
+GEOL,1010,2.0,Physical Geology,0.6,0.28,0.08,0.03,0.01,0%,0.0,0.01,alan coulson,,GEOL-1010,2020
+GEOL,1010,3.0,Physical Geology,0.56,0.31,0.08,0.03,0.03,0%,0.0,0.0,mary katherine fidler,,GEOL-1010,2020
+GEOL,1010,4.0,Physical Geology,0.46,0.41,0.11,0.0,0.01,0%,0.0,0.01,mary katherine fidler,,GEOL-1010,2020
+GEOL,1030,1.0,Physical Geol Lab,0.55,0.36,0.0,0.05,0.0,0%,0.0,0.05,alan coulson,,GEOL-1030,2020
+GEOL,1030,2.0,Physical Geol Lab,0.71,0.17,0.04,0.0,0.08,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,3.0,Physical Geol Lab,0.64,0.05,0.05,0.09,0.14,0%,0.0,0.05,alan coulson,,GEOL-1030,2020
+GEOL,1030,4.0,Physical Geol Lab,0.52,0.17,0.22,0.04,0.04,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,5.0,Physical Geol Lab,0.55,0.2,0.15,0.05,0.0,0%,0.0,0.05,alan coulson,,GEOL-1030,2020
+GEOL,1030,6.0,Physical Geol Lab,0.67,0.24,0.05,0.05,0.0,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,7.0,Physical Geol Lab,0.78,0.09,0.0,0.0,0.09,0%,0.0,0.04,alan coulson,,GEOL-1030,2020
+GEOL,1030,8.0,Physical Geol Lab,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,9.0,Physical Geol Lab,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,11.0,Physical Geol Lab,0.75,0.1,0.15,0.0,0.0,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,12.0,Physical Geol Lab,0.86,0.09,0.0,0.0,0.05,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,13.0,Physical Geol Lab,0.55,0.3,0.05,0.0,0.0,0%,0.0,0.1,alan coulson,,GEOL-1030,2020
+GEOL,1030,14.0,Physical Geol Lab,0.55,0.35,0.0,0.05,0.05,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,15.0,Physical Geol Lab,0.6,0.3,0.1,0.0,0.0,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,16.0,Physical Geol Lab,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,17.0,Physical Geol Lab,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,18.0,Physical Geol Lab,0.64,0.18,0.14,0.0,0.05,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1030,19.0,Physical Geol Lab,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,alan coulson,,GEOL-1030,2020
+GEOL,1120,1.0,Earth Resources,0.51,0.3,0.13,0.04,0.01,0%,0.0,0.02,emily don scribner,,GEOL-1120,2020
+GEOL,1140,1.0,Earth Resources Lab,0.55,0.29,0.11,0.01,0.0,0%,0.0,0.04,emily don scribner,,GEOL-1140,2020
+GEOL,1200,1.0,Natural Hazards,0.48,0.4,0.1,0.0,0.03,0%,0.0,0.0,emily don scribner,,GEOL-1200,2020
+GEOL,2050,1.0,Mineralogy & Intro Petrolo,0.29,0.71,0.0,0.0,0.0,0%,0.0,0.0, shuller-nickles,,GEOL-2050,2020
+GEOL,2070,1.0,Min & Intro Pet Lab,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,mary katherine fidler,,GEOL-2070,2020
+GEOL,2700,1.0,Sustainable Water,0.51,0.31,0.09,0.0,0.03,0%,0.0,0.06,melissa ranhofer,,GEOL-2700,2020
+GEOL,3000,1.0,Environmental Geology,0.38,0.53,0.09,0.0,0.0,0%,0.0,0.0,alan coulson,,GEOL-3000,2020
+GEOL,3020,1.0,Structural Geology,0.55,0.36,0.0,0.09,0.0,0%,0.0,0.0,alexander pullen,,GEOL-3020,2020
+GEOL,4820,1.0,Groundwater & Contam Tr,0.3,0.2,0.1,0.1,0.1,0%,0.0,0.2,lawrence murdoch,,GEOL-4820,2020
+GEOL,4910,1.0,Research Synthesis I,0.5,0.3,0.1,0.0,0.1,0%,0.0,0.0,alan coulson,,GEOL-4910,2020
+GEOL,6150,1.0,Analysis Geological Proces,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.0,lawrence murdoch,,GEOL-6150,2020
+GEOL,8080,1.0,Groundwater Modeling,0.14,0.57,0.14,0.0,0.0,0%,0.0,0.0,ronald falta,,GEOL-8080,2020
+GEOL,8610,1.0,Geology Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sudeep popat,,GEOL-8610,2020
+GER,1010,1.0,Elementary German,0.7,0.2,0.0,0.1,0.0,0%,0.0,0.0,oswald harris king,,GER-1010,2020
+GER,1020,1.0,Elementary German,0.21,0.29,0.21,0.14,0.07,0%,0.0,0.07, lee ferrell,,GER-1020,2020
+GER,2010,1.0,Intermediate German,0.25,0.31,0.25,0.0,0.06,0%,0.0,0.0,johannes schmidt,,GER-2010,2020
+GER,2020,1.0,Intermediate German,0.63,0.31,0.06,0.0,0.0,0%,0.0,0.0, lee ferrell,,GER-2020,2020
+GER,2600,1.0,Selected Topics-Doppelgan,0.67,0.21,0.0,0.0,0.04,0%,0.0,0.08,gabriela stoicea,,GER-2600,2020
+GER,2600,2.0,Selected Topics-Doppelgan,0.32,0.41,0.09,0.09,0.0,0%,0.0,0.09,gabriela stoicea,,GER-2600,2020
+GER,3050,1.0,Ger Conv & Comp,0.65,0.24,0.06,0.0,0.0,0%,0.0,0.06, lee ferrell,,GER-3050,2020
+GER,3600,1.0,Ger Lit to 1832,0.69,0.23,0.0,0.0,0.0,0%,0.0,0.0,johannes schmidt,,GER-3600,2020
+GRAD,8030,1.0,Intl Teaching Fellowship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david fleming,,GRAD-8030,2020
+GRAD,8030,2.0,Intl Teaching Fellowship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david fleming,,GRAD-8030,2020
+HCC,8330,1.0,HCC Research Methods,0.6,0.27,0.07,0.0,0.07,0%,0.0,0.0,kelly caine,,HCC-8330,2020
+HCC,9500,1.0,HATLab seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,bart knijnenburg,,HCC-9500,2020
+HCC,9500,3.0,Human Centered XR Resea,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sabarish venkat babu,,HCC-9500,2020
+HCC,9910,7.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,bart knijnenburg,,HCC-9910,2020
+HCG,9070,400.0,Applied Health Genetics,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,sara moir sarasua,,HCG-9070,2020
+HCG,9910,401.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jane marie deluca,,HCG-9910,2020
+HIST,1010,1.0,History of the United State,0.63,0.33,0.0,0.03,0.0,0%,0.0,0.03,lee brady wilson,,HIST-1010,2020
+HIST,1010,2.0,History of the United State,0.17,0.53,0.17,0.03,0.03,0%,0.0,0.07,james jeffries,,HIST-1010,2020
+HIST,1220,1.0,"Hist, Tech & Society",0.44,0.33,0.05,0.05,0.06,0%,0.0,0.07,pamela mack,,HIST-1220,2020
+HIST,1240,1.0,Environmental History Sur,0.19,0.56,0.17,0.0,0.03,0%,0.0,0.06,james jeffries,,HIST-1240,2020
+HIST,1240,2.0,Environmental History Sur,0.18,0.69,0.05,0.0,0.03,0%,0.0,0.05,james jeffries,,HIST-1240,2020
+HIST,1720,1.0,The West and the World I,0.68,0.24,0.05,0.0,0.01,0%,0.0,0.02,steven marks,,HIST-1720,2020
+HIST,1720,2.0,The West and the World I,0.7,0.13,0.03,0.03,0.0,0%,0.0,0.1,christine hilliard,,HIST-1720,2020
+HIST,1720,3.0,The West and the World I,0.28,0.38,0.14,0.02,0.11,0%,0.0,0.07,caroline dunn dunn,,HIST-1720,2020
+HIST,1730,1.0,The West and the World II,0.22,0.46,0.18,0.01,0.05,0%,0.0,0.08, alan grubb,,HIST-1730,2020
+HIST,1730,2.0,The West and the World II,0.72,0.21,0.0,0.03,0.03,0%,0.0,0.0,archana venkatesh,,HIST-1730,2020
+HIST,2140,1.0,Introduction to Public Hist,0.63,0.25,0.0,0.06,0.0,0%,0.0,0.0,joshua catalano,,HIST-2140,2020
+HIST,2990,1.0,Historian's Craft,0.63,0.11,0.05,0.0,0.16,0%,0.0,0.05,rachel anne moore,,HIST-2990,2020
+HIST,2990,3.0,Historian's Craft,0.44,0.38,0.13,0.0,0.06,0%,0.0,0.0,michael meng,,HIST-2990,2020
+HIST,3000,1.0,History of Colonial Americ,0.81,0.16,0.0,0.0,0.0,0%,0.0,0.03,lee brady wilson,,HIST-3000,2020
+HIST,3040,1.0,Industrialism&Progressive,0.78,0.17,0.0,0.0,0.06,0%,0.0,0.0, roger grant,,HIST-3040,2020
+HIST,3060,1.0,US: Postwar World 1945-1,0.73,0.13,0.0,0.0,0.0,0%,0.0,0.07,rebecca anna stoil,,HIST-3060,2020
+HIST,3100,1.0,History of Religion in the U,0.38,0.31,0.06,0.0,0.06,0%,0.0,0.13,elizabeth jemison,,HIST-3100,2020
+HIST,3120,1.0,Afr Amer Hist 1877 to Pres,0.38,0.45,0.03,0.03,0.07,0%,0.0,0.03,abel bartley,,HIST-3120,2020
+HIST,3240,1.0,Hist of the South II,0.24,0.59,0.0,0.03,0.14,0%,0.0,0.0,john andrew,,HIST-3240,2020
+HIST,3330,1.0,Hist of Mod Japan,0.32,0.39,0.25,0.0,0.04,0%,0.0,0.0,edwin moise,,HIST-3330,2020
+HIST,3610,1.0,History of Britain to 1688,0.7,0.23,0.03,0.0,0.03,0%,0.0,0.0,seefeldt tara wood,,HIST-3610,2020
+HIST,3630,1.0,Britain Since 1688,0.77,0.2,0.0,0.0,0.0,0%,0.0,0.03, barczewski,,HIST-3630,2020
+HIST,3670,1.0,Modern Ireland,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,michael silvestri,,HIST-3670,2020
+HIST,3840,1.0,Hist of Mod France,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.0, alan grubb,,HIST-3840,2020
+HIST,3900,1.0,Modern Military History,0.24,0.48,0.14,0.0,0.0,0%,0.0,0.0,edwin moise,,HIST-3900,2020
+HIST,4700,1.0,Europe Women and Gend,0.7,0.2,0.0,0.0,0.0,0%,0.0,0.1,christine hilliard,,HIST-4700,2020
+HIST,4710,1.0,Moscow 1937,0.59,0.24,0.06,0.0,0.0,0%,0.0,0.06,steven marks,,HIST-4710,2020
+HIST,4870,1.0,World War II,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,john andrew,,HIST-4870,2020
+HIST,4900,1.0,DictatorshipViolence20thC,0.56,0.19,0.06,0.0,0.0,0%,0.0,0.0,amit bein,,HIST-4900,2020
+HIST,4900,2.0,Northern Ireland &The Tro,0.67,0.28,0.06,0.0,0.0,0%,0.0,0.0,michael silvestri,,HIST-4900,2020
+HIST,4940,2.0,Medieval Witchcraft & Her,0.53,0.33,0.07,0.07,0.0,0%,0.0,0.0,seefeldt tara wood,,HIST-4940,2020
+HIST,8000,1.0,Historical Methods,0.67,0.22,0.0,0.0,0.0,0%,0.0,0.0,michael meng,,HIST-8000,2020
+HIST,8910,1.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,michael meng,,HIST-8910,2020
+HLTH,2020,1.0,Introduction to Public Heal,0.47,0.32,0.11,0.11,0.0,0%,0.0,0.0,jeffrey kingree,,HLTH-2020,2020
+HLTH,2020,2.0,Introduction to Public Heal,0.64,0.31,0.05,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,,HLTH-2020,2020
+HLTH,2020,3.0,Introduction to Public Heal,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,,HLTH-2020,2020
+HLTH,2020,4.0,Introduction to Public Heal,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.06,marvina jones,,HLTH-2020,2020
+HLTH,2020,5.0,Introduction to Public Heal,0.68,0.21,0.05,0.05,0.0,0%,0.0,0.0,becky ann tugman,,HLTH-2020,2020
+HLTH,2020,400.0,Introduction to Public Heal,0.61,0.26,0.09,0.0,0.0,0%,0.0,0.04,ralph stewart welsh,,HLTH-2020,2020
+HLTH,2020,401.0,Introduction to Public Heal,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,,HLTH-2020,2020
+HLTH,2030,1.0,Health Care Sys,0.59,0.41,0.0,0.0,0.0,0%,0.0,0.0,tanya lee staton,,HLTH-2030,2020
+HLTH,2030,2.0,Health Care Sys,0.75,0.16,0.06,0.03,0.0,0%,0.0,0.0,tanya lee staton,,HLTH-2030,2020
+HLTH,2030,3.0,Health Care Sys,0.72,0.22,0.06,0.0,0.0,0%,0.0,0.0,sarah bauer floyd,,HLTH-2030,2020
+HLTH,2030,400.0,Health Care Sys,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,tanya lee staton,,HLTH-2030,2020
+HLTH,2400,1.0,Deter of Hlth Behav,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,amelia clinkscales,,HLTH-2400,2020
+HLTH,2400,2.0,Deter of Hlth Behav,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,amelia clinkscales,,HLTH-2400,2020
+HLTH,2400,3.0,Deter of Hlth Behav,0.63,0.37,0.0,0.0,0.0,0%,0.0,0.0,laura jane rolke,,HLTH-2400,2020
+HLTH,2600,400.0,Medical Terminology & Co,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,karen edwards,,HLTH-2600,2020
+HLTH,2980,1.0,Human Health and Disease,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,becky ann tugman,,HLTH-2980,2020
+HLTH,2980,2.0,Human Health and Disease,0.66,0.26,0.09,0.0,0.0,0%,0.0,0.0,johnny long,,HLTH-2980,2020
+HLTH,2980,3.0,Human Health and Disease,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,brooke brittain,,HLTH-2980,2020
+HLTH,3050,1.0,Body Resp Hlth Beh,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,karen kemper,,HLTH-3050,2020
+HLTH,3400,1.0,Hlth Prom Prog Plan,0.5,0.45,0.05,0.0,0.0,0%,0.0,0.0,johnny long,,HLTH-3400,2020
+HLTH,3610,1.0,Int Health Care Econ,0.83,0.06,0.09,0.0,0.03,0%,0.0,0.0,khoa dang truong,,HLTH-3610,2020
+HLTH,3800,1.0,Epidemiology,0.82,0.15,0.03,0.0,0.0,0%,0.0,0.0,lu zhang,,HLTH-3800,2020
+HLTH,3800,2.0,Epidemiology,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,lu zhang,,HLTH-3800,2020
+HLTH,3800,3.0,Epidemiology,0.63,0.3,0.07,0.0,0.0,0%,0.0,0.0,deborah alma falta,,HLTH-3800,2020
+HLTH,3800,400.0,Epidemiology,0.26,0.42,0.21,0.05,0.05,0%,0.0,0.0,deborah alma falta,,HLTH-3800,2020
+HLTH,3980,1.0,Health Appraisal Skills,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,kathleen meyer,,HLTH-3980,2020
+HLTH,3980,2.0,Health Appraisal Skills,0.54,0.46,0.0,0.0,0.0,0%,0.0,0.0,kathleen meyer,,HLTH-3980,2020
+HLTH,4000,1.0,Infec Disease & Exposure,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,tanya lee staton,,HLTH-4000,2020
+HLTH,4190,1.0,Health Sci Internship Prep,0.79,0.15,0.05,0.0,0.0,0%,0.0,0.0,kathleen meyer,,HLTH-4190,2020
+HLTH,4200,1.0,Hlth Science Intern,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,kathleen meyer,,HLTH-4200,2020
+HLTH,4200,3.0,Hlth Science Intern,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,kathleen meyer,,HLTH-4200,2020
+HLTH,4400,1.0,Manag Hlth Serv Org,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,lu shi,,HLTH-4400,2020
+HLTH,4700,1.0,Global Health,0.93,0.0,0.03,0.0,0.03,0%,0.0,0.0,micky rogers ward,,HLTH-4700,2020
+HLTH,4750,1.0,Hlthcr Oper Mgmt Res,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,lu shi,,HLTH-4750,2020
+HLTH,4900,1.0,Res Eval St Pub Hlth,0.79,0.14,0.0,0.04,0.0,0%,0.0,0.04,jeffrey kingree,,HLTH-4900,2020
+HLTH,4900,2.0,Res Eval St Pub Hlth,0.79,0.17,0.0,0.04,0.0,0%,0.0,0.0,jeffrey kingree,,HLTH-4900,2020
+HLTH,4980,1.0,Improving Pop Hlth,0.45,0.36,0.05,0.09,0.0,0%,0.0,0.0,hugh donald spitler,,HLTH-4980,2020
+HLTH,8090,400.0,Epidemiological Res,0.65,0.24,0.0,0.0,0.0,0%,0.0,0.06,sara wagner robb,,HLTH-8090,2020
+HLTH,8120,500.0,Clinical and Translational S,0.71,0.24,0.0,0.0,0.0,0%,0.0,0.05,ronald gimbel,,HLTH-8120,2020
+HLTH,8140,500.0,Health Sys Quality Improv,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,windsor sherrill,,HLTH-8140,2020
+HLTH,8210,1.0,Health Research I,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,sara wagner robb,,HLTH-8210,2020
+HLTH,8890,1.0,Sem in App Hlth Rsrch & E,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,karen kemper,,HLTH-8890,2020
+HON,2020,1.0,Who Decides What's Cool?,0.74,0.21,0.0,0.0,0.0,0%,0.0,0.05,amanda cooper fine,True,HON-2020,2020
+HON,2030,4.0,Views of History/Ancient,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,yanming an,True,HON-2030,2020
+HON,2050,5.0,Entrepreneurship,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,john michael hannon,True,HON-2050,2020
+HON,2210,1.0,Monster Culture and Socie,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,mary nestor,True,HON-2210,2020
+HORT,1010,1.0,Horticulture,0.95,0.03,0.0,0.0,0.0,0%,0.0,0.02,ellen anita vincent,,HORT-1010,2020
+HORT,2020,1.0,Adobe Digital Design,0.85,0.04,0.0,0.0,0.0,0%,0.0,0.11,janice ann lay,,HORT-2020,2020
+HORT,2120,1.0,Turfgrass Culture,0.84,0.14,0.0,0.0,0.03,0%,0.0,0.0,haibo liu,,HORT-2120,2020
+HORT,2130,2.0,Turfgrass Culture Lab,0.73,0.0,0.18,0.0,0.09,0%,0.0,0.0,haibo liu,,HORT-2130,2020
+HORT,3030,1.0,Woody Landscape Plant ID,0.15,0.23,0.2,0.13,0.3,0%,0.0,0.0,robert polomski,,HORT-3030,2020
+HORT,3080,1.0,Sust Landsc Des Install Mai,0.85,0.09,0.06,0.0,0.0,0%,0.0,0.0,ellen anita vincent,,HORT-3080,2020
+HORT,3090,1.0,Sust Landsc Des Lab,0.5,0.1,0.0,0.0,0.4,0%,0.0,0.0,shannon barrett,,HORT-3090,2020
+HORT,4120,1.0,Adv Turfgrass Mgt,0.6,0.2,0.1,0.1,0.0,0%,0.0,0.0,lambert mccarty,,HORT-4120,2020
+HORT,4400,1.0,Hydroponics,0.42,0.33,0.25,0.0,0.0,0%,0.0,0.0,james emerson faust,,HORT-4400,2020
+HP,8010,1.0,Preservation Law and Econ,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,william jackson cook,,HP-8010,2020
+HP,8020,1.0,Hist Preserv Research Sem,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jon marcoux,,HP-8020,2020
+HP,8190,1.0,"Investig, Docum, Conserva",0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,amalia leifeste,,HP-8190,2020
+HP,8230,400.0,Historic American Interiors,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,elizabeth ryan,,HP-8230,2020
+HP,8920,1.0,Special Topics Paying for P,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,amalia leifeste,,HP-8920,2020
+HRD,8300,400.0,Concepts of H R D,0.92,0.05,0.03,0.0,0.0,0%,0.0,0.0,angela carter,,HRD-8300,2020
+HRD,8470,400.0,Instru System Design,0.82,0.1,0.0,0.0,0.03,0%,0.0,0.03,angela carter,,HRD-8470,2020
+HUM,3090,1.0,Studies in Humanities,0.74,0.21,0.0,0.0,0.0,0%,0.0,0.05,jennie wakefield,,HUM-3090,2020
+HUM,3090,2.0,Studies in Humanities,0.65,0.2,0.1,0.0,0.05,0%,0.0,0.0,jennie wakefield,,HUM-3090,2020
+IE,2100,1.0,Des Analysis Wrk Sys,0.54,0.4,0.03,0.01,0.0,0%,0.0,0.02,sudeep hegde,,IE-2100,2020
+IE,3010,1.0,Systems Design I,0.44,0.46,0.08,0.03,0.0,0%,0.0,0.0,paris stringfellow,,IE-3010,2020
+IE,3140,1.0,Seminar in Industrial Engr,0.0,0.0,0.0,0.0,0.0,97%,0.03,0.0,jeffrey kharoufeh,,IE-3140,2020
+IE,3600,1.0,Industrial Apps of Prob/Sta,0.31,0.44,0.15,0.04,0.04,0%,0.0,0.04,tugce isik,,IE-3600,2020
+IE,3610,1.0,Industrial App of Prob/Stat,0.33,0.38,0.17,0.03,0.03,0%,0.0,0.05,hamed rahimian,,IE-3610,2020
+IE,3800,1.0,Deterministic Operations R,0.43,0.31,0.14,0.07,0.03,0%,0.0,0.02,yongjia song,,IE-3800,2020
+IE,3810,1.0,Probabilistic Operations Rs,0.34,0.46,0.15,0.03,0.02,0%,0.0,0.0,amin khademi,,IE-3810,2020
+IE,3840,1.0,Engr Econ Analysis,0.39,0.33,0.09,0.02,0.0,0%,0.0,0.17,brian melloy,,IE-3840,2020
+IE,3840,2.0,Engr Econ Analysis,0.05,0.14,0.24,0.1,0.0,0%,0.0,0.48,brian melloy,,IE-3840,2020
+IE,3860,1.0,Production Planning & Con,0.62,0.27,0.09,0.01,0.0,0%,0.0,0.0,mariah magagnotti,,IE-3860,2020
+IE,4300,1.0,Human Fact Engr in Health,0.73,0.17,0.04,0.0,0.04,0%,0.0,0.02,david neyens,,IE-4300,2020
+IE,4400,2.0,Decision Support Sys,0.32,0.49,0.05,0.0,0.08,0%,0.0,0.04,scott jennings mason,,IE-4400,2020
+IE,4560,1.0,Supply Chain Design & Con,0.19,0.43,0.14,0.1,0.0,0%,0.0,0.05,william ferrell,,IE-4560,2020
+IE,4570,1.0,Transp/Logistic Engr,0.72,0.2,0.06,0.0,0.0,0%,0.0,0.03,emily tucker,,IE-4570,2020
+IE,4610,1.0,Quality Engineering,0.63,0.24,0.07,0.02,0.04,0%,0.0,0.01,mariah magagnotti,,IE-4610,2020
+IE,4650,1.0,Facilities Planning & Desig,0.53,0.38,0.07,0.01,0.01,0%,0.0,0.0,william ferrell,,IE-4650,2020
+IE,4670,1.0,System Design II,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,scott jennings mason,,IE-4670,2020
+IE,4820,1.0,Systems Modeling,0.42,0.47,0.07,0.03,0.0,0%,0.0,0.0,kevin taaffe,,IE-4820,2020
+IE,4820,2.0,Systems Modeling,0.58,0.27,0.09,0.0,0.0,0%,0.0,0.06,kevin taaffe,,IE-4820,2020
+IE,4880,2.0,Human Factors Eng,0.87,0.12,0.0,0.01,0.0,0%,0.0,0.0,jamiahus walton,,IE-4880,2020
+IE,6300,1.0,Human Fact Engr in Health,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,david neyens,,IE-6300,2020
+IE,6560,1.0,Supply Chain Design & Con,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,william ferrell,,IE-6560,2020
+IE,6570,1.0,Transp/Logistic Engr,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,emily tucker,,IE-6570,2020
+IE,8030,1.0,Engr Optimization and App,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,thomas sharkey,,IE-8030,2020
+IE,8090,1.0,Model Sys Under Risk,0.33,0.61,0.0,0.0,0.0,0%,0.0,0.06,jeffrey kharoufeh,,IE-8090,2020
+IE,8530,1.0,Foundations of Quality,0.75,0.21,0.0,0.0,0.04,0%,0.0,0.0,ozgur kabadurmus,,IE-8530,2020
+IE,8550,1.0,SC & Logistics Modeling II,0.88,0.04,0.08,0.0,0.0,0%,0.0,0.0,kevin taaffe,,IE-8550,2020
+IE,8930,18.0,Optimization under Uncert,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,yongjia song,,IE-8930,2020
+IE,9910,18.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yongjia song,,IE-9910,2020
+INNO,3990,4.0,IBM Watson in the Watt,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,dane smith,,INNO-3990,2020
+INNO,4990,3.0,IBM Watson in the Watt,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.2,dane smith,,INNO-4990,2020
+INT,1510,1.0,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,90%,0.06,0.04,lisa marie robinson,,INT-1510,2020
+INT,1520,1.0,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,96%,0.04,0.0,caren kelley-hall,,INT-1520,2020
+INT,1530,1.0,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,94%,0.04,0.02,caren kelley-hall,,INT-1530,2020
+INT,1540,1.0,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,95%,0.0,0.05,caren kelley-hall,,INT-1540,2020
+INT,2010,1.0,Off-Campus Internship FT,0.0,0.0,0.0,0.0,0.0,91%,0.0,0.0,brittany paige neely,,INT-2010,2020
+INT,2510,1.0,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,86%,0.14,0.0,lisa marie robinson,,INT-2510,2020
+INT,2520,1.0,UPIC Internship FT 2,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,caren kelley-hall,,INT-2520,2020
+INT,2530,1.0,UPIC Internship FT 3,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,caren kelley-hall,,INT-2530,2020
+INT,8010,1.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,,INT-8010,2020
+INT,8010,2.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,,INT-8010,2020
+INT,8010,3.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,,INT-8010,2020
+ITAL,1010,2.0,Elementary Italian,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,julia schmidt,,ITAL-1010,2020
+ITAL,1010,3.0,Elementary Italian,0.83,0.11,0.0,0.0,0.0,0%,0.0,0.06,luca barattoni,,ITAL-1010,2020
+ITAL,1020,1.0,Elementary Italian,0.65,0.29,0.0,0.06,0.0,0%,0.0,0.0,julia schmidt,,ITAL-1020,2020
+JAPN,1010,1.0,Elementary Japanese,0.64,0.23,0.05,0.0,0.09,0%,0.0,0.0,kumiko saito,,JAPN-1010,2020
+JAPN,1010,2.0,Elementary Japanese,0.45,0.14,0.18,0.0,0.14,0%,0.0,0.09,kumiko saito,,JAPN-1010,2020
+JAPN,1020,1.0,Elementary Japanese,0.5,0.39,0.0,0.0,0.11,0%,0.0,0.0,satomi saito,,JAPN-1020,2020
+JAPN,2010,1.0,Intermed Japanese,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,satomi saito,,JAPN-2010,2020
+JAPN,3050,1.0,Japanese Conversation & C,0.75,0.06,0.06,0.0,0.0,0%,0.0,0.06,jae allegra takeuchi,,JAPN-3050,2020
+JAPN,4010,1.0,Japanese Lit in Translation,0.79,0.08,0.04,0.0,0.0,0%,0.0,0.04,kumiko saito,,JAPN-4010,2020
+JAPN,4990,1.0,Sel Topics in Japanese Cult,0.54,0.31,0.0,0.0,0.0,0%,0.0,0.08,satomi saito,,JAPN-4990,2020
+JUST,2050,1.0,Professional Development,0.77,0.1,0.0,0.1,0.0,0%,0.0,0.03,margaret tina britz,,JUST-2050,2020
+JUST,2880,1.0,The Criminal Justice Syste,0.6,0.15,0.1,0.06,0.04,0%,0.0,0.04,margaret tina britz,,JUST-2880,2020
+JUST,2880,2.0,The Criminal Justice Syste,0.75,0.24,0.0,0.0,0.0,0%,0.0,0.02,kyle david mclean,,JUST-2880,2020
+JUST,2890,1.0,Criminology,0.51,0.29,0.1,0.06,0.02,0%,0.0,0.02,matthew costello,,JUST-2890,2020
+JUST,3280,1.0,Criminal Courts,0.5,0.42,0.08,0.0,0.0,0%,0.0,0.0,rhys hester,,JUST-3280,2020
+JUST,3960,1.0,Drugs and Crime,0.31,0.31,0.23,0.03,0.09,0%,0.0,0.03,brian chad starks,,JUST-3960,2020
+JUST,4290,1.0,Justice Administration,0.45,0.4,0.1,0.05,0.0,0%,0.0,0.0,rhys hester,,JUST-4290,2020
+JUST,4680,1.0,Criminal Evidence,0.59,0.14,0.14,0.03,0.05,0%,0.0,0.05,margaret tina britz,,JUST-4680,2020
+JUST,4860,1.0,CI in CJ: Gangsterism in Fil,0.62,0.12,0.04,0.08,0.15,0%,0.0,0.0,margaret tina britz,,JUST-4860,2020
+JUST,4910,1.0,Policing,0.86,0.08,0.05,0.0,0.0,0%,0.0,0.0,kyle david mclean,,JUST-4910,2020
+JUST,4930,1.0,Corrections,0.6,0.28,0.07,0.02,0.02,0%,0.0,0.0,bryan lee miller,,JUST-4930,2020
+JUST,4990,1.0,Sexual Assault and IPV,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,heather kettrey,,JUST-4990,2020
+LAIB,1270,1.0,Intro to Lang & Int'l Busine,0.0,0.0,0.0,0.0,0.0,90%,0.1,0.0,jae allegra takeuchi,,LAIB-1270,2020
+LANG,3000,1.0,Intro Linguistics,0.56,0.33,0.0,0.0,0.11,0%,0.0,0.0,daniel smith,,LANG-3000,2020
+LANG,4990,1.0,Language Portfolio,0.0,0.0,0.0,0.0,0.0,92%,0.0,0.08,su- chen,,LANG-4990,2020
+LARC,1150,1.0,Intro Landscape Architectu,0.61,0.25,0.14,0.0,0.0,0%,0.0,0.0,jueminsi wu,,LARC-1150,2020
+LARC,1280,1.0,Technical Graphics,0.57,0.32,0.11,0.0,0.0,0%,0.0,0.0,matthew powers,,LARC-1280,2020
+LARC,1510,1.0,Basic Design I,0.61,0.32,0.07,0.0,0.0,0%,0.0,0.0,matthew powers,,LARC-1510,2020
+LARC,2140,1.0,Plants in the Landscape,0.65,0.25,0.05,0.05,0.0,0%,0.0,0.0,lara browning,,LARC-2140,2020
+LARC,3510,1.0,Regional Design,0.63,0.11,0.11,0.05,0.05,0%,0.0,0.05,lara browning,,LARC-3510,2020
+LARC,4530,1.0,Key Issues in Landscape Ar,0.57,0.38,0.05,0.0,0.0,0%,0.0,0.0,mary padua,,LARC-4530,2020
+LARC,4620,1.0,Design Implementation III,0.5,0.25,0.1,0.05,0.0,0%,0.0,0.1,paul russell,,LARC-4620,2020
+LARC,8210,1.0,Research Methods,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,hala fouad nassar,,LARC-8210,2020
+LAW,3220,1.0,Legal Env of Bus,0.22,0.36,0.24,0.12,0.04,0%,0.0,0.02,kenneth toussaint,,LAW-3220,2020
+LAW,3220,2.0,Legal Env of Bus,0.27,0.33,0.31,0.0,0.1,0%,0.0,0.0,kenneth toussaint,,LAW-3220,2020
+LAW,3220,3.0,Legal Env of Bus,0.4,0.44,0.1,0.04,0.0,0%,0.0,0.02, kisska-schulze,,LAW-3220,2020
+LAW,3220,4.0,Legal Env of Bus,0.32,0.42,0.22,0.04,0.0,0%,0.0,0.0, kisska-schulze,,LAW-3220,2020
+LAW,3220,5.0,Legal Env of Bus,0.72,0.26,0.02,0.0,0.0,0%,0.0,0.0,christopher edwards,,LAW-3220,2020
+LAW,3220,6.0,Legal Env of Bus,0.8,0.18,0.0,0.0,0.0,0%,0.0,0.02,christopher edwards,,LAW-3220,2020
+LAW,3220,7.0,Legal Env of Bus,0.24,0.37,0.29,0.08,0.0,0%,0.0,0.02, kisska-schulze,,LAW-3220,2020
+LAW,3220,8.0,Legal Env of Bus,0.58,0.35,0.08,0.0,0.0,0%,0.0,0.0,edward ray claggett,,LAW-3220,2020
+LAW,3220,9.0,Legal Env of Bus,0.59,0.32,0.05,0.02,0.0,0%,0.0,0.02,frances edwards,,LAW-3220,2020
+LAW,3220,10.0,Legal Env of Bus,0.4,0.43,0.13,0.03,0.03,0%,0.0,0.0,edward ray claggett,,LAW-3220,2020
+LAW,3220,11.0,Legal Env of Bus,0.15,0.44,0.29,0.07,0.0,0%,0.0,0.05,john hine,,LAW-3220,2020
+LAW,3220,12.0,Legal Env of Bus,0.48,0.37,0.13,0.0,0.0,0%,0.0,0.02,frances edwards,,LAW-3220,2020
+LAW,3220,400.0,Legal Env of Bus,0.36,0.32,0.21,0.07,0.02,0%,0.0,0.02, ward-vaughn,,LAW-3220,2020
+LAW,3220,401.0,Legal Env of Bus,0.23,0.53,0.12,0.07,0.03,0%,0.0,0.02, ward-vaughn,,LAW-3220,2020
+LAW,3220,402.0,Legal Env of Bus,0.34,0.38,0.21,0.03,0.0,0%,0.0,0.03, ward-vaughn,,LAW-3220,2020
+LAW,3220,403.0,Legal Env of Bus,0.33,0.36,0.14,0.07,0.07,0%,0.0,0.03, ward-vaughn,,LAW-3220,2020
+LAW,3330,1.0,Real Estate Law,0.26,0.34,0.34,0.0,0.06,0%,0.0,0.0,kenneth toussaint,,LAW-3330,2020
+LAW,3330,2.0,Real Estate Law,0.44,0.42,0.11,0.0,0.03,0%,0.0,0.0,kenneth toussaint,,LAW-3330,2020
+LAW,4050,1.0,Construction Law,0.87,0.11,0.0,0.0,0.0,0%,0.0,0.03,frances edwards,,LAW-4050,2020
+LIH,3970,1.0,Cr Inq-Language & Intl Hea,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.1,kelly digby peebles,,LIH-3970,2020
+LS,1000,1.0,Therapeutic Yoga,0.78,0.0,0.0,0.0,0.0,0%,0.0,0.22,ranjanbala amin,,LS-1000,2020
+LS,1000,15.0,"Stress, Coping, & Flourishi",0.83,0.09,0.03,0.0,0.02,0%,0.0,0.02,cynthia pury s,,LS-1000,2020
+LS,1000,16.0,"Stress, Coping, & Flourishi",0.67,0.09,0.12,0.05,0.02,0%,0.0,0.02,cynthia pury s,,LS-1000,2020
+LS,1000,50.0,Facilitating Social Gatherin,0.75,0.05,0.05,0.05,0.1,0%,0.0,0.0,paul hoke,,LS-1000,2020
+LS,1750,2.0,Fly Fishing,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.2,michael watts,,LS-1750,2020
+LS,1850,2.0,Bowling,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.04,madison workman,,LS-1850,2020
+LS,1850,3.0,Bowling,0.71,0.21,0.0,0.0,0.0,0%,0.0,0.07,madison workman,,LS-1850,2020
+LS,1850,4.0,Bowling,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,madison workman,,LS-1850,2020
+LS,1850,5.0,Bowling,0.88,0.0,0.0,0.0,0.06,0%,0.0,0.06,angela rowan,,LS-1850,2020
+LS,1980,5.0,Golf,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.12,wesley womble,,LS-1980,2020
+LS,2320,1.0,Core Training,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,diane moreno,,LS-2320,2020
+LS,2320,4.0,Core Training,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,diane moreno,,LS-2320,2020
+LS,2350,1.0,Basic Yoga,0.76,0.1,0.1,0.0,0.0,0%,0.0,0.05,renee warren gahan,,LS-2350,2020
+LS,2350,5.0,Basic Yoga,0.86,0.0,0.05,0.0,0.0,0%,0.0,0.09,brandy segura,,LS-2350,2020
+LS,2350,6.0,Basic Yoga,0.89,0.05,0.05,0.0,0.0,0%,0.0,0.0,brandy segura,,LS-2350,2020
+LS,2350,8.0,Basic Yoga,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,brandy segura,,LS-2350,2020
+LS,2420,1.0,Meditation and Relax,0.87,0.0,0.04,0.04,0.0,0%,0.0,0.04,renee warren gahan,,LS-2420,2020
+LS,2420,2.0,Meditation and Relax,0.88,0.0,0.04,0.0,0.04,0%,0.0,0.04,renee warren gahan,,LS-2420,2020
+LS,2420,3.0,Meditation and Relax,0.7,0.17,0.04,0.04,0.0,0%,0.0,0.04,ranjanbala amin,,LS-2420,2020
+LS,2420,4.0,Meditation and Relax,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ranjanbala amin,,LS-2420,2020
+LS,2420,9.0,Meditation and Relax,0.77,0.09,0.09,0.0,0.05,0%,0.0,0.0,renee warren gahan,,LS-2420,2020
+LS,2420,10.0,Meditation and Relax,0.59,0.14,0.05,0.09,0.09,0%,0.0,0.05,renee warren gahan,,LS-2420,2020
+LS,2450,5.0,Pilates,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.13,diane moreno,,LS-2450,2020
+LS,2750,8.0,Red Cross First Aid/CPR,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,christopher loomis,,LS-2750,2020
+LS,2780,1.0,Wilderness First Aid,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,emily grace turke,,LS-2780,2020
+MATH,1010,1.0,Essen Math for Informed S,0.09,0.43,0.3,0.02,0.02,0%,0.0,0.13,chad mangum,,MATH-1010,2020
+MATH,1010,2.0,Essen Math for Informed S,0.25,0.39,0.27,0.02,0.07,0%,0.0,0.0,chad mangum,,MATH-1010,2020
+MATH,1010,3.0,Essen Math for Informed S,0.22,0.31,0.22,0.09,0.09,0%,0.0,0.07,chad mangum,,MATH-1010,2020
+MATH,1010,4.0,Essen Math for Informed S,0.17,0.48,0.24,0.02,0.02,0%,0.0,0.07,kristen savary,,MATH-1010,2020
+MATH,1010,5.0,Essen Math for Informed S,0.07,0.36,0.14,0.12,0.19,0%,0.0,0.12,jacob lee britton,,MATH-1010,2020
+MATH,1010,6.0,Essen Math for Informed S,0.13,0.28,0.35,0.15,0.09,0%,0.0,0.0,sarah kelly,,MATH-1010,2020
+MATH,1020,1.0,Business Calculus I,0.36,0.23,0.15,0.13,0.09,0%,0.0,0.04,randy davidson,,MATH-1020,2020
+MATH,1020,2.0,Business Calculus I,0.21,0.34,0.28,0.09,0.04,0%,0.0,0.04,randy davidson,,MATH-1020,2020
+MATH,1020,3.0,Business Calculus I,0.06,0.26,0.3,0.22,0.1,0%,0.0,0.06,freeman slaughter,,MATH-1020,2020
+MATH,1020,4.0,Business Calculus I,0.19,0.38,0.21,0.12,0.07,0%,0.0,0.02,joseph swanson,,MATH-1020,2020
+MATH,1020,5.0,Business Calculus I,0.25,0.28,0.18,0.15,0.13,0%,0.0,0.03,ryan wolanzyk,,MATH-1020,2020
+MATH,1020,6.0,Business Calculus I,0.11,0.26,0.21,0.21,0.08,0%,0.0,0.13,duygu vargun,,MATH-1020,2020
+MATH,1020,7.0,Business Calculus I,0.25,0.3,0.2,0.08,0.08,0%,0.0,0.1,rodrigo smith,,MATH-1020,2020
+MATH,1020,8.0,Business Calculus I,0.22,0.33,0.14,0.11,0.14,0%,0.0,0.06,rakhi goswami,,MATH-1020,2020
+MATH,1020,9.0,Business Calculus I,0.29,0.29,0.14,0.14,0.1,0%,0.0,0.05,benjamin hamlin,,MATH-1020,2020
+MATH,1020,10.0,Business Calculus I,0.2,0.34,0.24,0.0,0.1,0%,0.0,0.1,luke szramowski,,MATH-1020,2020
+MATH,1020,11.0,Business Calculus I,0.13,0.36,0.18,0.21,0.1,0%,0.0,0.03,sarah otterbeck,,MATH-1020,2020
+MATH,1020,12.0,Business Calculus I,0.17,0.44,0.22,0.1,0.07,0%,0.0,0.0,emily tidwell,,MATH-1020,2020
+MATH,1020,13.0,Business Calculus I,0.12,0.37,0.22,0.15,0.02,0%,0.0,0.12,adam nathaniel price,,MATH-1020,2020
+MATH,1020,14.0,Business Calculus I,0.29,0.44,0.12,0.05,0.07,0%,0.0,0.02, gracia-guzman,,MATH-1020,2020
+MATH,1020,15.0,Business Calculus I,0.13,0.38,0.23,0.1,0.03,0%,0.0,0.13,robert melville,,MATH-1020,2020
+MATH,1020,16.0,Business Calculus I,0.27,0.34,0.22,0.1,0.02,0%,0.0,0.05,heidi- shuttleworth,,MATH-1020,2020
+MATH,1020,17.0,Business Calculus I,0.07,0.36,0.29,0.07,0.1,0%,0.0,0.12,elizabeth hawkins,,MATH-1020,2020
+MATH,1020,18.0,Business Calculus I,0.15,0.27,0.29,0.02,0.12,0%,0.0,0.15,emma soriano,,MATH-1020,2020
+MATH,1020,19.0,Business Calculus I,0.31,0.29,0.16,0.11,0.04,0%,0.0,0.09,michael cowen,,MATH-1020,2020
+MATH,1020,20.0,Business Calculus I,0.18,0.34,0.2,0.02,0.16,0%,0.0,0.09,morgan elston,,MATH-1020,2020
+MATH,1020,21.0,Business Calculus I,0.22,0.27,0.22,0.13,0.11,0%,0.0,0.04,michael foss,,MATH-1020,2020
+MATH,1020,22.0,Business Calculus I,0.22,0.37,0.15,0.1,0.05,0%,0.0,0.12,james mckay visser,,MATH-1020,2020
+MATH,1020,23.0,Business Calculus I,0.14,0.19,0.27,0.27,0.14,0%,0.0,0.0,james palmer,,MATH-1020,2020
+MATH,1020,201.0,Business Calculus I,0.52,0.31,0.1,0.05,0.02,0%,0.0,0.0,dyken jennifer  van e,,MATH-1020,2020
+MATH,1020,202.0,Business Calculus I,0.43,0.45,0.05,0.08,0.0,0%,0.0,0.0,marion hanna,,MATH-1020,2020
+MATH,1030,401.0,Elementary Functions,0.56,0.36,0.0,0.0,0.08,0%,0.0,0.0,david costanzo,,MATH-1030,2020
+MATH,1030,402.0,Elementary Functions,0.54,0.27,0.04,0.04,0.12,0%,0.0,0.0,david costanzo,,MATH-1030,2020
+MATH,1030,403.0,Elementary Functions,0.46,0.32,0.0,0.04,0.14,0%,0.0,0.04,david costanzo,,MATH-1030,2020
+MATH,1040,1.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,59%,0.38,0.03,donna simms,,MATH-1040,2020
+MATH,1040,2.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,67%,0.29,0.04,catherine kenyon,,MATH-1040,2020
+MATH,1040,3.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.32,0.05,catherine kenyon,,MATH-1040,2020
+MATH,1040,4.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,60%,0.36,0.04,michael nelson,,MATH-1040,2020
+MATH,1040,5.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.29,0.07,catherine kenyon,,MATH-1040,2020
+MATH,1040,6.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.31,0.05,trinity white,,MATH-1040,2020
+MATH,1040,7.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,69%,0.28,0.03,tony thanh nguyen,,MATH-1040,2020
+MATH,1040,9.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,48%,0.39,0.13,tony thanh nguyen,,MATH-1040,2020
+MATH,1040,10.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,38%,0.6,0.0,todd anthony morra,,MATH-1040,2020
+MATH,1040,201.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,81%,0.16,0.03,tony thanh nguyen,,MATH-1040,2020
+MATH,1040,202.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.33,0.03,travis alvarez,,MATH-1040,2020
+MATH,1050,401.0,Precalculus,0.0,0.0,0.0,0.0,0.0,74%,0.26,0.0,jennifer marie hanna,,MATH-1050,2020
+MATH,1050,402.0,Precalculus,0.0,0.0,0.0,0.0,0.0,75%,0.24,0.01,jennifer marie hanna,,MATH-1050,2020
+MATH,1050,403.0,Precalculus,0.0,0.0,0.0,0.0,0.0,70%,0.26,0.03,jennifer marie hanna,,MATH-1050,2020
+MATH,1060,1.0,Calculus of One Variable I,0.25,0.33,0.25,0.0,0.13,0%,0.0,0.05,david luke frost,,MATH-1060,2020
+MATH,1060,2.0,Calculus of One Variable I,0.21,0.35,0.19,0.0,0.16,0%,0.0,0.09,allen anderson guest,,MATH-1060,2020
+MATH,1060,3.0,Calculus of One Variable I,0.36,0.23,0.14,0.02,0.2,0%,0.0,0.05,yunan wang,,MATH-1060,2020
+MATH,1060,4.0,Calculus of One Variable I,0.41,0.27,0.09,0.02,0.18,0%,0.0,0.02,allen anderson guest,,MATH-1060,2020
+MATH,1060,5.0,Calculus of One Variable I,0.22,0.38,0.18,0.04,0.09,0%,0.0,0.09,allen anderson guest,,MATH-1060,2020
+MATH,1060,6.0,Calculus of One Variable I,0.3,0.33,0.24,0.06,0.07,0%,0.0,0.0,james gossell,,MATH-1060,2020
+MATH,1060,7.0,Calculus of One Variable I,0.24,0.4,0.17,0.07,0.1,0%,0.0,0.02,felice manganiello,,MATH-1060,2020
+MATH,1060,8.0,Calculus of One Variable I,0.18,0.29,0.27,0.03,0.17,0%,0.0,0.06,felice manganiello,,MATH-1060,2020
+MATH,1060,9.0,Calculus of One Variable I,0.18,0.27,0.32,0.0,0.2,0%,0.0,0.02,sofya alekseeva,,MATH-1060,2020
+MATH,1060,10.0,Calculus of One Variable I,0.1,0.21,0.26,0.14,0.17,0%,0.0,0.1,sofya alekseeva,,MATH-1060,2020
+MATH,1060,11.0,Calculus of One Variable I,0.23,0.38,0.17,0.04,0.06,0%,0.0,0.13,hugh geller,,MATH-1060,2020
+MATH,1060,12.0,Calculus of One Variable I,0.19,0.33,0.11,0.07,0.22,0%,0.0,0.07,hossein faridian,,MATH-1060,2020
+MATH,1060,13.0,Calculus of One Variable I,0.28,0.25,0.22,0.03,0.19,0%,0.0,0.03,blake james smith,,MATH-1060,2020
+MATH,1060,14.0,Calculus of One Variable I,0.2,0.33,0.23,0.0,0.2,0%,0.0,0.05,michael byrd,,MATH-1060,2020
+MATH,1060,201.0,Calculus of One Variable I,0.38,0.29,0.22,0.0,0.11,0%,0.0,0.0,jason alexander kurz,,MATH-1060,2020
+MATH,1060,202.0,Calculus of One Variable I,0.38,0.36,0.09,0.04,0.11,0%,0.0,0.02,stephen peele,,MATH-1060,2020
+MATH,1060,203.0,Calculus of One Variable I,0.38,0.29,0.18,0.02,0.09,0%,0.0,0.04,nathan fontes,,MATH-1060,2020
+MATH,1060,204.0,Calculus of One Variable I,0.53,0.22,0.09,0.02,0.07,0%,0.0,0.07,zachary david espe,,MATH-1060,2020
+MATH,1060,205.0,Calculus of One Variable I,0.11,0.24,0.36,0.04,0.13,0%,0.0,0.11,sofya alekseeva,,MATH-1060,2020
+MATH,1060,300.0,Calculus of One Variable I,0.27,0.55,0.0,0.0,0.09,0%,0.0,0.09,matthew macauley,,MATH-1060,2020
+MATH,1070,1.0,Differen and Integral Calcu,0.11,0.07,0.48,0.04,0.11,0%,0.0,0.19,donna simms,,MATH-1070,2020
+MATH,1080,1.0,Calculus of One Variable II,0.27,0.21,0.19,0.04,0.23,0%,0.0,0.07,meredith nicole burr,,MATH-1080,2020
+MATH,1080,2.0,Calculus of One Variable II,0.32,0.14,0.14,0.05,0.24,0%,0.0,0.11,fei xue,,MATH-1080,2020
+MATH,1080,3.0,Calculus of One Variable II,0.19,0.19,0.19,0.0,0.19,0%,0.0,0.24,scott scruggs,,MATH-1080,2020
+MATH,1080,4.0,Calculus of One Variable II,0.05,0.26,0.23,0.09,0.21,0%,0.0,0.16,peter westerbaan,,MATH-1080,2020
+MATH,1080,5.0,Calculus of One Variable II,0.17,0.14,0.1,0.1,0.24,0%,0.0,0.24,cody stockdale,,MATH-1080,2020
+MATH,1080,6.0,Calculus of One Variable II,0.14,0.16,0.27,0.05,0.18,0%,0.0,0.18,cody stockdale,,MATH-1080,2020
+MATH,1080,7.0,Calculus of One Variable II,0.24,0.17,0.05,0.1,0.22,0%,0.0,0.22,blake splitter,,MATH-1080,2020
+MATH,1080,201.0,Calculus of One Variable II,0.58,0.27,0.04,0.04,0.08,0%,0.0,0.0,meredith nicole burr,,MATH-1080,2020
+MATH,1150,1.0,Contemp Math for Elem T,0.73,0.21,0.04,0.02,0.0,0%,0.0,0.0,jusino carreras,,MATH-1150,2020
+MATH,1150,2.0,Contemp Math for Elem T,0.69,0.25,0.02,0.0,0.02,0%,0.0,0.02,jusino carreras,,MATH-1150,2020
+MATH,1160,1.0,Contemp Math for Elem T,0.62,0.24,0.14,0.0,0.0,0%,0.0,0.0,jusino carreras,,MATH-1160,2020
+MATH,1990,401.0,Problem Solving in Mathe,0.0,0.0,0.0,0.0,0.0,98%,0.02,0.0,marion hanna,,MATH-1990,2020
+MATH,1990,403.0,Problem Solving in Mathe,0.0,0.0,0.0,0.0,0.0,95%,0.04,0.01,marion hanna,,MATH-1990,2020
+MATH,2060,1.0,Calculus of Several Variabl,0.55,0.2,0.1,0.03,0.07,0%,0.0,0.05,oleg yordanov,,MATH-2060,2020
+MATH,2060,2.0,Calculus of Several Variabl,0.6,0.15,0.14,0.05,0.02,0%,0.0,0.04,oleg yordanov,,MATH-2060,2020
+MATH,2060,3.0,Calculus of Several Variabl,0.23,0.42,0.23,0.04,0.05,0%,0.0,0.04,tony william long,,MATH-2060,2020
+MATH,2060,4.0,Calculus of Several Variabl,0.41,0.3,0.16,0.04,0.03,0%,0.0,0.07,tony william long,,MATH-2060,2020
+MATH,2060,5.0,Calculus of Several Variabl,0.35,0.19,0.22,0.12,0.09,0%,0.0,0.04,timothy teitloff,,MATH-2060,2020
+MATH,2060,6.0,Calculus of Several Variabl,0.43,0.37,0.13,0.02,0.0,0%,0.0,0.06,irina viktorova,,MATH-2060,2020
+MATH,2060,7.0,Calculus of Several Variabl,0.35,0.39,0.17,0.01,0.04,0%,0.0,0.03,irina viktorova,,MATH-2060,2020
+MATH,2060,100.0,Calc of Several Vars (HON),0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,yuyuan ouyang,True,MATH-2060,2020
+MATH,2060,201.0,Calculus of Several Variabl,0.32,0.26,0.26,0.08,0.08,0%,0.0,0.0,timothy teitloff,,MATH-2060,2020
+MATH,2070,1.0,Business Calculus II,0.29,0.21,0.33,0.08,0.04,0%,0.0,0.06,jennifer ray newton,,MATH-2070,2020
+MATH,2070,2.0,Business Calculus II,0.36,0.28,0.15,0.09,0.06,0%,0.0,0.06,nathaniel nemire,,MATH-2070,2020
+MATH,2070,3.0,Business Calculus II,0.19,0.47,0.15,0.09,0.06,0%,0.0,0.04,jennifer ray newton,,MATH-2070,2020
+MATH,2070,4.0,Business Calculus II,0.19,0.16,0.26,0.1,0.06,0%,0.0,0.23,daozhou zhu,,MATH-2070,2020
+MATH,2070,5.0,Business Calculus II,0.27,0.38,0.22,0.04,0.04,0%,0.0,0.04,tyler sullivan,,MATH-2070,2020
+MATH,2070,6.0,Business Calculus II,0.33,0.3,0.11,0.07,0.09,0%,0.0,0.09,ville madeleine  st e,,MATH-2070,2020
+MATH,2070,7.0,Business Calculus II,0.05,0.22,0.22,0.3,0.11,0%,0.0,0.11,antonio pierrottet,,MATH-2070,2020
+MATH,2070,8.0,Business Calculus II,0.11,0.25,0.23,0.11,0.06,0%,0.0,0.25,todd fenstermacher,,MATH-2070,2020
+MATH,2070,9.0,Business Calculus II,0.16,0.33,0.1,0.1,0.12,0%,0.0,0.2,todd fenstermacher,,MATH-2070,2020
+MATH,2070,10.0,Business Calculus II,0.2,0.22,0.22,0.1,0.1,0%,0.0,0.17,eva murphy,,MATH-2070,2020
+MATH,2070,11.0,Business Calculus II,0.21,0.17,0.14,0.17,0.28,0%,0.0,0.03,anna bachstein,,MATH-2070,2020
+MATH,2070,12.0,Business Calculus II,0.3,0.26,0.21,0.09,0.09,0%,0.0,0.05,elliott degbe,,MATH-2070,2020
+MATH,2070,13.0,Business Calculus II,0.21,0.38,0.21,0.1,0.05,0%,0.0,0.05,jennifer ray newton,,MATH-2070,2020
+MATH,2070,14.0,Business Calculus II,0.04,0.24,0.15,0.15,0.15,0%,0.0,0.26,rachel bass lanning,,MATH-2070,2020
+MATH,2080,1.0,Intro to Ordin Diff Equatio,0.5,0.18,0.11,0.0,0.11,0%,0.0,0.11,timothy parrott,,MATH-2080,2020
+MATH,2080,2.0,Intro to Ordin Diff Equatio,0.48,0.31,0.13,0.02,0.06,0%,0.0,0.0,timothy parrott,,MATH-2080,2020
+MATH,2080,3.0,Intro to Ordin Diff Equatio,0.37,0.14,0.16,0.04,0.22,0%,0.0,0.06,timothy parrott,,MATH-2080,2020
+MATH,2080,4.0,Intro to Ordin Diff Equatio,0.17,0.17,0.27,0.1,0.21,0%,0.0,0.08,jeong rock yoon rock,,MATH-2080,2020
+MATH,2080,5.0,Intro to Ordin Diff Equatio,0.3,0.09,0.16,0.09,0.18,0%,0.0,0.18,jeong rock yoon rock,,MATH-2080,2020
+MATH,2080,6.0,Intro to Ordin Diff Equatio,0.61,0.29,0.04,0.02,0.02,0%,0.0,0.02,leo rebholz,,MATH-2080,2020
+MATH,2160,1.0,Geometry for Elem Sch Te,0.94,0.0,0.0,0.0,0.03,0%,0.0,0.03,nicole alaine sinwell,,MATH-2160,2020
+MATH,2160,2.0,Geometry for Elem Sch Te,0.93,0.03,0.0,0.0,0.03,0%,0.0,0.0,nicole alaine sinwell,,MATH-2160,2020
+MATH,2160,3.0,Geometry for Elem Sch Te,0.69,0.28,0.03,0.0,0.0,0%,0.0,0.0,jusino carreras,,MATH-2160,2020
+MATH,3020,1.0,Stat for Science & Enginee,0.83,0.1,0.02,0.02,0.02,0%,0.0,0.0,qiong zhang,,MATH-3020,2020
+MATH,3020,2.0,Stat for Science & Enginee,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,xin liu,,MATH-3020,2020
+MATH,3020,3.0,Stat for Science & Enginee,0.16,0.33,0.23,0.1,0.05,0%,0.0,0.12,zhiyun gong,,MATH-3020,2020
+MATH,3020,4.0,Stat for Science & Enginee,0.24,0.37,0.2,0.05,0.07,0%,0.0,0.08,zhiyun gong,,MATH-3020,2020
+MATH,3110,1.0,Linear Algebra,0.39,0.43,0.1,0.0,0.04,0%,0.0,0.04,wayne goddard,,MATH-3110,2020
+MATH,3110,2.0,Linear Algebra,0.56,0.31,0.07,0.02,0.04,0%,0.0,0.0, ramiharimanana,,MATH-3110,2020
+MATH,3110,3.0,Linear Algebra,0.64,0.27,0.07,0.02,0.0,0%,0.0,0.0, ramiharimanana,,MATH-3110,2020
+MATH,3110,4.0,Linear Algebra,0.44,0.31,0.17,0.03,0.03,0%,0.0,0.03,beth novick,,MATH-3110,2020
+MATH,3110,5.0,Linear Algebra,0.35,0.33,0.19,0.02,0.06,0%,0.0,0.04,xuhong gao,,MATH-3110,2020
+MATH,3110,6.0,Linear Algebra,0.53,0.28,0.07,0.07,0.05,0%,0.0,0.0,benjamin breen,,MATH-3110,2020
+MATH,3160,1.0,Prob Solving for Math Tea,0.79,0.14,0.0,0.04,0.04,0%,0.0,0.0,andrew tyminski,,MATH-3160,2020
+MATH,3160,2.0,Prob Solving for Math Tea,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,andrew tyminski,,MATH-3160,2020
+MATH,3190,1.0,Introduction to Proof,0.17,0.39,0.3,0.09,0.04,0%,0.0,0.0,hui xue,,MATH-3190,2020
+MATH,3190,2.0,Introduction to Proof,0.63,0.19,0.07,0.04,0.07,0%,0.0,0.0,ryann rose cartor,,MATH-3190,2020
+MATH,3600,1.0,Intermediate Math Compu,0.7,0.0,0.0,0.0,0.1,0%,0.0,0.2,neil calkin,,MATH-3600,2020
+MATH,3600,2.0,Intermediate Math Compu,0.39,0.39,0.06,0.0,0.03,0%,0.0,0.06,wayne goddard,,MATH-3600,2020
+MATH,3650,1.0,Numerical Mthds for Engin,0.44,0.4,0.11,0.02,0.0,0%,0.0,0.02,qingshan chen,,MATH-3650,2020
+MATH,3650,2.0,Numerical Mthds for Engin,0.29,0.22,0.31,0.04,0.04,0%,0.0,0.09,eleanor jenkins,,MATH-3650,2020
+MATH,3650,3.0,Numerical Mthds for Engin,0.34,0.26,0.18,0.05,0.05,0%,0.0,0.11,eleanor jenkins,,MATH-3650,2020
+MATH,3650,4.0,Numerical Mthds for Engin,0.64,0.16,0.11,0.04,0.0,0%,0.0,0.04,sibusiso mabuza,,MATH-3650,2020
+MATH,4000,1.0,Theory of Probability,0.62,0.27,0.12,0.0,0.0,0%,0.0,0.0,peter kiessler,,MATH-4000,2020
+MATH,4000,2.0,Theory of Probability,0.25,0.46,0.14,0.0,0.11,0%,0.0,0.04,xinyi li,,MATH-4000,2020
+MATH,4020,1.0,Stats for Science and Engr I,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,derek brown,,MATH-4020,2020
+MATH,4070,1.0,Regress & Time-Series Ana,0.57,0.19,0.05,0.0,0.05,0%,0.0,0.14,colin gallagher,,MATH-4070,2020
+MATH,4080,1.0,Secondary Math Analysis,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,eliza gallagher,,MATH-4080,2020
+MATH,4100,1.0,Number Theory,0.27,0.45,0.27,0.0,0.0,0%,0.0,0.0,hui xue,,MATH-4100,2020
+MATH,4120,1.0,Algebra I,0.26,0.32,0.37,0.0,0.0,0%,0.0,0.05,james coykendall,,MATH-4120,2020
+MATH,4120,2.0,Algebra I,0.43,0.39,0.09,0.09,0.0,0%,0.0,0.0, ramiharimanana,,MATH-4120,2020
+MATH,4190,1.0,Discrete Math Structures I,0.71,0.19,0.05,0.0,0.05,0%,0.0,0.0,beth novick,,MATH-4190,2020
+MATH,4190,2.0,Discrete Math Structures I,0.64,0.3,0.03,0.0,0.0,0%,0.0,0.03,beth novick,,MATH-4190,2020
+MATH,4310,1.0,Theory of Interest,0.26,0.21,0.26,0.11,0.05,0%,0.0,0.0, erwin walker,,MATH-4310,2020
+MATH,4340,1.0,Adv Engineering Mathema,0.23,0.27,0.2,0.03,0.1,0%,0.0,0.17,vincent ervin,,MATH-4340,2020
+MATH,4340,2.0,Adv Engineering Mathema,0.27,0.12,0.12,0.19,0.15,0%,0.0,0.15,hyesuk lee,,MATH-4340,2020
+MATH,4400,1.0,Linear Programming,0.35,0.43,0.08,0.03,0.05,0%,0.0,0.05,boshi yang,,MATH-4400,2020
+MATH,4410,1.0,Intro to Stochastic Models,0.64,0.09,0.09,0.0,0.0,0%,0.0,0.18,brian fralix,,MATH-4410,2020
+MATH,4530,1.0,Advanced Calculus I,0.14,0.56,0.24,0.02,0.02,0%,0.0,0.02,martin schmoll,,MATH-4530,2020
+MATH,4540,1.0,Advanced Calculus II,0.17,0.5,0.11,0.06,0.11,0%,0.0,0.06,martin schmoll,,MATH-4540,2020
+MATH,4910,1.0,Math of Options Pricing,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,mark cawood,,MATH-4910,2020
+MATH,4920,2.0,Professional Development,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,randy davidson,,MATH-4920,2020
+MATH,6340,1.0,Adv Engineering Mathema,0.38,0.38,0.13,0.0,0.0,0%,0.0,0.13,hyesuk lee,,MATH-6340,2020
+MATH,8000,1.0,Probability,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,qiong zhang,,MATH-8000,2020
+MATH,8010,1.0,General Linear Hypothesis,0.62,0.31,0.08,0.0,0.0,0%,0.0,0.0,xiaoqian sun,,MATH-8010,2020
+MATH,8050,1.0,Data Analysis,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,brook thayer russell,,MATH-8050,2020
+MATH,8090,1.0,Time Series Analysis,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,xin liu,,MATH-8090,2020
+MATH,8120,1.0,Discrete Optimization,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,matthew saltzman,,MATH-8120,2020
+MATH,8190,1.0,Multicriteria Optimization,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,margaret wiecek,,MATH-8190,2020
+MATH,8210,1.0,Linear Analysis,0.56,0.33,0.06,0.0,0.0,0%,0.0,0.06,mishko mitkovski,,MATH-8210,2020
+MATH,8510,1.0,Abstract Algebra I,0.29,0.65,0.06,0.0,0.0,0%,0.0,0.0,michael adam burr,,MATH-8510,2020
+MATH,8530,1.0,Matrix Analysis,0.53,0.47,0.0,0.0,0.0,0%,0.0,0.0,matthew macauley,,MATH-8530,2020
+MATH,8550,1.0,Combinatorial Analysis,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,svetlana poznanovikj,,MATH-8550,2020
+MATH,8600,1.0,Intro to Scientific Computi,0.38,0.54,0.08,0.0,0.0,0%,0.0,0.0,vincent ervin,,MATH-8600,2020
+MATH,8650,1.0,Data Structures,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,sibusiso mabuza,,MATH-8650,2020
+MATH,8820,1.0,Intro to Bayesian Statistics,0.67,0.29,0.0,0.0,0.0,0%,0.0,0.04,deborah kunkel,,MATH-8820,2020
+MATH,9010,1.0,Probability Theory I,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,brian fralix,,MATH-9010,2020
+MATH,9830,1.0,Advanced Theories for PD,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,qingshan chen,,MATH-9830,2020
+MATH,9830,2.0,High Performance FEM,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,timo heister,,MATH-9830,2020
+MATH,9850,1.0,Homological Ring Properti,0.71,0.0,0.14,0.0,0.0,0%,0.0,0.0, sather-wagstaff,,MATH-9850,2020
+MATH,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,derek brown,,MATH-9910,2020
+MATH,9910,10.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, mcmahan,,MATH-9910,2020
+MATH,9910,16.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, sather-wagstaff,,MATH-9910,2020
+MBA,8030,2.0,Stat Analy of Bus Op,0.53,0.29,0.12,0.0,0.0,0%,0.0,0.06,william kilbourne,,MBA-8030,2020
+MBA,8030,3.0,Stat Analy of Bus Op,0.61,0.28,0.0,0.0,0.0,0%,0.0,0.11,magda gabriela sava,,MBA-8030,2020
+MBA,8030,4.0,Stat Analy of Bus Op,0.61,0.36,0.0,0.0,0.04,0%,0.0,0.0,magda gabriela sava,,MBA-8030,2020
+MBA,8040,20.0,Busin Data An & Stat Com,0.59,0.26,0.03,0.0,0.12,0%,0.0,0.0,william kilbourne,,MBA-8040,2020
+MBA,8060,1.0,Operations Mgt,0.8,0.16,0.02,0.0,0.0,0%,0.0,0.02,lawrence fredendall,,MBA-8060,2020
+MBA,8060,3.0,Operations Mgt,0.73,0.23,0.03,0.0,0.0,0%,0.0,0.0,lawrence fredendall,,MBA-8060,2020
+MBA,8070,1.0,Financial Management,0.48,0.43,0.03,0.0,0.0,0%,0.0,0.08,george lockhart,,MBA-8070,2020
+MBA,8070,2.0,Financial Management,0.43,0.47,0.0,0.0,0.0,0%,0.0,0.1,george lockhart,,MBA-8070,2020
+MBA,8070,20.0,Financial Management,0.7,0.26,0.04,0.0,0.0,0%,0.0,0.0,george lockhart,,MBA-8070,2020
+MBA,8090,1.0,Org Beh & Hum Res Mg,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,thomas zagenczyk,,MBA-8090,2020
+MBA,8090,2.0,Org Beh & Hum Res Mg,0.76,0.21,0.0,0.0,0.0,0%,0.0,0.03,thomas zagenczyk,,MBA-8090,2020
+MBA,8090,3.0,Org Beh & Hum Res Mg,0.75,0.23,0.0,0.0,0.0,0%,0.0,0.03,thomas zagenczyk,,MBA-8090,2020
+MBA,8180,20.0,Business Intell & Data Anly,0.79,0.12,0.03,0.0,0.06,0%,0.0,0.0,john frederick tripp,,MBA-8180,2020
+MBA,8190,2.0,Intro to Acc and Fin,0.41,0.33,0.18,0.0,0.0,0%,0.0,0.08,jeffrey mcmillan,,MBA-8190,2020
+MBA,8190,3.0,Intro to Acc and Fin,0.44,0.33,0.18,0.0,0.0,0%,0.0,0.05,jeffrey mcmillan,,MBA-8190,2020
+MBA,8290,1.0,Marketing Foundation,0.9,0.05,0.0,0.0,0.0,0%,0.0,0.05,ankita bakre,,MBA-8290,2020
+MBA,8310,10.0,Communications and Sales,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,gregory pickett,,MBA-8310,2020
+MBA,8360,1.0,Real Estate Principles,0.2,0.73,0.0,0.0,0.0,0%,0.0,0.07,stephen buckman,,MBA-8360,2020
+MBA,8370,1.0,Legal Environ of Bus,0.43,0.5,0.08,0.0,0.0,0%,0.0,0.0,judson jahn,,MBA-8370,2020
+MBA,8370,2.0,Legal Environ of Bus,0.35,0.55,0.08,0.0,0.0,0%,0.0,0.03,judson jahn,,MBA-8370,2020
+MBA,8410,1.0,Real Estate Finance,0.81,0.06,0.0,0.0,0.0,0%,0.0,0.06,larry bradley harvey,,MBA-8410,2020
+MBA,8430,1.0,Entrepreneurial Accountin,0.36,0.36,0.27,0.0,0.0,0%,0.0,0.0,annieka philo,,MBA-8430,2020
+MBA,8470,1.0,New Venture Creation,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,joseph gibson,,MBA-8470,2020
+MBA,8490,5.0,Entrepreneurial Strategy,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,matthew klein,,MBA-8490,2020
+MBA,8500,3.0,Bus Communications,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,,MBA-8500,2020
+MBA,8500,30.0,Bus Communications,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,,MBA-8500,2020
+MBA,8540,2.0,Managerial Accounting,0.46,0.41,0.11,0.0,0.0,0%,0.0,0.02,emily mccorkle,,MBA-8540,2020
+MBA,8590,1.0,Mgr Decision Model,0.32,0.41,0.09,0.0,0.05,0%,0.0,0.14,james turner,,MBA-8590,2020
+MBA,8590,2.0,Mgr Decision Model,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.08,magda gabriela sava,,MBA-8590,2020
+MBA,8590,3.0,Mgr Decision Model,0.71,0.18,0.0,0.0,0.0,0%,0.0,0.12,magda gabriela sava,,MBA-8590,2020
+MBA,8600,2.0,Advanced Marketing Strat,0.67,0.27,0.0,0.0,0.0,0%,0.0,0.07,pravin nath,,MBA-8600,2020
+MBA,8600,3.0,Advanced Marketing Strat,0.8,0.13,0.0,0.0,0.0,0%,0.0,0.07,pravin nath,,MBA-8600,2020
+MBA,8610,1.0,Information Systems,0.41,0.59,0.0,0.0,0.0,0%,0.0,0.0,william kettinger,,MBA-8610,2020
+MBA,8610,2.0,Information Systems,0.67,0.27,0.03,0.0,0.03,0%,0.0,0.0,william kettinger,,MBA-8610,2020
+MBA,8620,1.0,Managerial Economics,0.39,0.5,0.06,0.0,0.0,0%,0.0,0.06,scott templeton,,MBA-8620,2020
+MBA,8620,2.0,Managerial Economics,0.63,0.37,0.0,0.0,0.0,0%,0.0,0.0,ronald earle gregory,,MBA-8620,2020
+MBA,8620,4.0,Managerial Economics,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ronald earle gregory,,MBA-8620,2020
+MBA,8660,21.0,Big Data Mgmt for Analytic,0.81,0.15,0.04,0.0,0.0,0%,0.0,0.0,he li,,MBA-8660,2020
+MBA,8700,3.0,Strategic Management,0.67,0.25,0.0,0.0,0.0,0%,0.0,0.08,thomas robert uva,,MBA-8700,2020
+MBA,8800,2.0,Career Mgt,0.0,0.0,0.0,0.0,0.0,93%,0.0,0.0,jamie lynn patterson,,MBA-8800,2020
+MBA,8800,3.0,MBA Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,,MBA-8800,2020
+MBA,8800,30.0,MBA Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,,MBA-8800,2020
+MBA,8810,1.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,,MBA-8810,2020
+MBA,8810,2.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,,MBA-8810,2020
+MBA,8810,3.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,,MBA-8810,2020
+MBA,8810,5.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gail depriest,,MBA-8810,2020
+MBA,8880,5.0,MBA Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gregory pickett,,MBA-8880,2020
+MBA,8880,11.0,MBA Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gregory pickett,,MBA-8880,2020
+MBA,8990,2.0,Creativity,0.75,0.2,0.03,0.0,0.03,0%,0.0,0.0,kathleen ann kegley,,MBA-8990,2020
+MBA,8990,4.0,Data Analytics & Visualizati,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,john frederick tripp,,MBA-8990,2020
+MBA,8990,5.0,Business Analytics Models,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.04,jennie lynn farmer,,MBA-8990,2020
+MBA,8990,10.0,Six Sigma,0.81,0.14,0.0,0.0,0.0,0%,0.0,0.05,dee ann wood kivett wood,,MBA-8990,2020
+ME,2000,400.0,Sophomore Seminar,0.55,0.21,0.08,0.04,0.06,0%,0.0,0.06,todd schweisinger,,ME-2000,2020
+ME,2010,1.0,Statics & Dynamics,0.0,0.13,0.23,0.09,0.39,0%,0.0,0.16,marisa kikendall orr,,ME-2010,2020
+ME,2010,2.0,Statics & Dynamics,0.23,0.15,0.28,0.09,0.19,0%,0.0,0.06,paul joseph,,ME-2010,2020
+ME,2010,3.0,Statics & Dynamics,0.11,0.08,0.15,0.15,0.44,0%,0.0,0.08,gang liu,,ME-2010,2020
+ME,2010,4.0,Statics & Dynamics,0.06,0.1,0.09,0.06,0.43,0%,0.0,0.26, parvinioskoui,,ME-2010,2020
+ME,2030,1.0,Founda Th/Fl Syst,0.15,0.34,0.43,0.09,0.0,0%,0.0,0.0,xiangchun xuan,,ME-2030,2020
+ME,2030,2.0,Founda Th/Fl Syst,0.13,0.49,0.29,0.0,0.04,0%,0.0,0.04,yiqiang han,,ME-2030,2020
+ME,2040,1.0,Mechanics of Materials,0.02,0.2,0.39,0.13,0.15,0%,0.0,0.02,gang liu,,ME-2040,2020
+ME,2040,2.0,Mechanics of Materials,0.11,0.39,0.36,0.11,0.03,0%,0.0,0.0,huijuan zhao,,ME-2040,2020
+ME,2220,1.0,Mechanical Engineering La,0.25,0.63,0.13,0.0,0.0,0%,0.0,0.0,douglas scott byrd,,ME-2220,2020
+ME,2220,2.0,Mechanical Engineering La,0.31,0.69,0.0,0.0,0.0,0%,0.0,0.0,douglas scott byrd,,ME-2220,2020
+ME,2220,5.0,Mechanical Engineering La,0.38,0.56,0.06,0.0,0.0,0%,0.0,0.0,douglas scott byrd,,ME-2220,2020
+ME,2220,6.0,Mechanical Engineering La,0.63,0.25,0.06,0.0,0.06,0%,0.0,0.0,douglas scott byrd,,ME-2220,2020
+ME,2220,7.0,Mechanical Engineering La,0.31,0.56,0.06,0.06,0.0,0%,0.0,0.0,douglas scott byrd,,ME-2220,2020
+ME,2220,8.0,Mechanical Engineering La,0.25,0.5,0.19,0.06,0.0,0%,0.0,0.0,douglas scott byrd,,ME-2220,2020
+ME,2220,10.0,Mechanical Engineering La,0.25,0.44,0.06,0.06,0.06,0%,0.0,0.13,douglas scott byrd,,ME-2220,2020
+ME,2220,13.0,Mechanical Engineering La,0.63,0.31,0.06,0.0,0.0,0%,0.0,0.0,douglas scott byrd,,ME-2220,2020
+ME,2220,14.0,Mechanical Engineering La,0.13,0.38,0.13,0.06,0.13,0%,0.0,0.19,douglas scott byrd,,ME-2220,2020
+ME,2220,15.0,Mechanical Engineering La,0.25,0.44,0.31,0.0,0.0,0%,0.0,0.0,douglas scott byrd,,ME-2220,2020
+ME,3000,301.0,Junior Honors Seminar (H,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,joshua bostwick,True,ME-3000,2020
+ME,3030,1.0,Thermodynamics,0.19,0.24,0.14,0.14,0.16,0%,0.0,0.14,john saylor,,ME-3030,2020
+ME,3030,2.0,Thermodynamics,0.7,0.16,0.1,0.02,0.02,0%,0.0,0.02,sandip dutta,,ME-3030,2020
+ME,3030,3.0,Thermodynamics,0.82,0.13,0.04,0.0,0.02,0%,0.0,0.0,sandip dutta,,ME-3030,2020
+ME,3040,1.0,Heat Transfer,0.14,0.59,0.21,0.0,0.07,0%,0.0,0.0,xin zhao,,ME-3040,2020
+ME,3040,2.0,Heat Transfer,0.38,0.4,0.19,0.04,0.0,0%,0.0,0.0,xin zhao,,ME-3040,2020
+ME,3040,3.0,Heat Transfer,0.73,0.19,0.04,0.02,0.0,0%,0.0,0.02,sandip dutta,,ME-3040,2020
+ME,3050,1.0,Model/an Dy Syst,0.26,0.35,0.33,0.02,0.05,0%,0.0,0.0,ardalan vahidi,,ME-3050,2020
+ME,3050,2.0,Model/an Dy Syst,0.21,0.48,0.19,0.1,0.0,0%,0.0,0.02,ge lv,,ME-3050,2020
+ME,3050,3.0,Model/an Dy Syst,0.21,0.39,0.21,0.0,0.12,0%,0.0,0.06,joshua bostwick,,ME-3050,2020
+ME,3060,1.0,Fund Machine Design,0.35,0.38,0.17,0.04,0.04,0%,0.0,0.0,douglas scott byrd,,ME-3060,2020
+ME,3060,2.0,Fund Machine Design,0.73,0.24,0.02,0.0,0.0,0%,0.0,0.02,zhaoxu meng,,ME-3060,2020
+ME,3070,1.0,Found of Mechanical Syste,0.73,0.21,0.04,0.0,0.02,0%,0.0,0.0,lonny thompson,,ME-3070,2020
+ME,3070,2.0,Found of Mechanical Syste,0.32,0.35,0.16,0.03,0.13,0%,0.0,0.0,katherine ehlert,,ME-3070,2020
+ME,3070,3.0,Found of Mechanical Syste,0.32,0.38,0.13,0.06,0.06,0%,0.0,0.04,chengshi wang,,ME-3070,2020
+ME,3080,1.0,Fluid Mechanics,0.22,0.47,0.25,0.04,0.0,0%,0.0,0.02,xiangchun xuan,,ME-3080,2020
+ME,3080,2.0,Fluid Mechanics,0.27,0.6,0.13,0.0,0.0,0%,0.0,0.0,ethan kung,,ME-3080,2020
+ME,3080,3.0,Fluid Mechanics,0.35,0.51,0.14,0.0,0.0,0%,0.0,0.0,zhen li,,ME-3080,2020
+ME,3120,1.0,Manuf Processes,0.24,0.63,0.11,0.0,0.02,0%,0.0,0.0,hong seok choi,,ME-3120,2020
+ME,3120,2.0,Manuf Processes,0.68,0.26,0.05,0.01,0.0,0%,0.0,0.0, martinez-duarte,,ME-3120,2020
+ME,3330,1.0,Mechanical Engineering La,0.44,0.5,0.06,0.0,0.0,0%,0.0,0.0,yiqiang han,,ME-3330,2020
+ME,3330,2.0,Mechanical Engineering La,0.44,0.5,0.0,0.0,0.0,0%,0.0,0.06,yiqiang han,,ME-3330,2020
+ME,3330,3.0,Mechanical Engineering La,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.07,yiqiang han,,ME-3330,2020
+ME,3330,4.0,Mechanical Engineering La,0.27,0.64,0.0,0.0,0.09,0%,0.0,0.0,yiqiang han,,ME-3330,2020
+ME,3330,5.0,Mechanical Engineering La,0.38,0.5,0.06,0.0,0.0,0%,0.0,0.06,yiqiang han,,ME-3330,2020
+ME,3330,6.0,Mechanical Engineering La,0.56,0.31,0.13,0.0,0.0,0%,0.0,0.0,yiqiang han,,ME-3330,2020
+ME,3330,7.0,Mechanical Engineering La,0.6,0.2,0.1,0.0,0.1,0%,0.0,0.0,yiqiang han,,ME-3330,2020
+ME,3330,10.0,Mechanical Engineering La,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,,ME-3330,2020
+ME,3330,13.0,Mechanical Engineering La,0.56,0.31,0.06,0.06,0.0,0%,0.0,0.0,yiqiang han,,ME-3330,2020
+ME,3330,14.0,Mechanical Engineering La,0.47,0.53,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,,ME-3330,2020
+ME,4000,400.0,Senior Seminar,0.86,0.1,0.03,0.01,0.01,0%,0.0,0.0,atul gajanan kelkar,,ME-4000,2020
+ME,4010,1.0,Mech Engr Design,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,timothy guggisberg,,ME-4010,2020
+ME,4010,2.0,Mech Engr Design,0.23,0.77,0.0,0.0,0.0,0%,0.0,0.0,gregory mocko,,ME-4010,2020
+ME,4010,400.0,Mech Engr Design,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,geetha chimata,,ME-4010,2020
+ME,4020,1.0,Intern in Engr Des,0.61,0.33,0.06,0.0,0.0,0%,0.0,0.0,sandip dutta,,ME-4020,2020
+ME,4020,3.0,Intern in Engr Des,0.47,0.35,0.18,0.0,0.0,0%,0.0,0.0,yiqiang han,,ME-4020,2020
+ME,4020,4.0,Intern in Engr Des,0.38,0.62,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,,ME-4020,2020
+ME,4020,5.0,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,timothy guggisberg,,ME-4020,2020
+ME,4030,1.0,Control Dynamic Systems,0.15,0.23,0.22,0.2,0.13,0%,0.0,0.03, naghnaeian,,ME-4030,2020
+ME,4030,2.0,Control Dynamic Systems,0.42,0.4,0.12,0.05,0.02,0%,0.0,0.0,umesh vaidya,,ME-4030,2020
+ME,4030,3.0,Control Dynamic Systems,0.37,0.47,0.16,0.0,0.0,0%,0.0,0.0, tallapragada,,ME-4030,2020
+ME,4210,1.0,Intro to Comp Flow,0.43,0.3,0.26,0.0,0.0,0%,0.0,0.0,chenning tong,,ME-4210,2020
+ME,4290,1.0,Ther Env Control,0.63,0.25,0.0,0.04,0.0,0%,0.0,0.04,jay ochterbeck,,ME-4290,2020
+ME,4300,1.0,Mech Comp Materials,0.63,0.13,0.21,0.0,0.0,0%,0.0,0.04,lonny thompson,,ME-4300,2020
+ME,4320,1.0,Advanced Strength of Mat,0.79,0.18,0.0,0.0,0.0,0%,0.0,0.0,oliver myers,,ME-4320,2020
+ME,4340,1.0,Cardiovascular Biomechani,0.25,0.46,0.17,0.0,0.04,0%,0.0,0.04,ethan kung,,ME-4340,2020
+ME,4400,1.0,Materials for Aggressive E,0.59,0.3,0.11,0.0,0.0,0%,0.0,0.0,garrett pataky,,ME-4400,2020
+ME,4440,1.0,Mechanical Engineering La,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,2.0,Mechanical Engineering La,0.38,0.5,0.13,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,3.0,Mechanical Engineering La,0.06,0.88,0.06,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,4.0,Mechanical Engineering La,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,5.0,Mechanical Engineering La,0.25,0.75,0.0,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,6.0,Mechanical Engineering La,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,7.0,Mechanical Engineering La,0.33,0.67,0.0,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,8.0,Mechanical Engineering La,0.54,0.46,0.0,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,9.0,Mechanical Engineering La,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4440,13.0,Mechanical Engineering La,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,john wagner,,ME-4440,2020
+ME,4550,400.0,Design for Manuf,0.53,0.24,0.16,0.02,0.04,0%,0.0,0.0,joshua summers,,ME-4550,2020
+ME,4580,1.0,Fund Micro/Nano Fabricati,0.41,0.45,0.05,0.0,0.0,0%,0.0,0.05, martinez-duarte,,ME-4580,2020
+ME,4930,29.0,Sel Topics ME - Vibrations,0.36,0.36,0.14,0.11,0.0,0%,0.0,0.04,suyi li,,ME-4930,2020
+ME,6300,1.0,Mech Comp Materials,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,lonny thompson,,ME-6300,2020
+ME,6320,1.0,Advanced Strength of Mat,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,oliver myers,,ME-6320,2020
+ME,6340,1.0,Cardiovascular Biomechani,0.4,0.4,0.2,0.0,0.0,0%,0.0,0.0,ethan kung,,ME-6340,2020
+ME,6550,400.0,Design for Manuf,0.43,0.36,0.07,0.0,0.07,0%,0.0,0.07,joshua summers,,ME-6550,2020
+ME,6580,1.0,Fund Micro/Nano Fabricati,0.2,0.6,0.2,0.0,0.0,0%,0.0,0.0, martinez-duarte,,ME-6580,2020
+ME,6930,24.0,Sel Topics - Automotive Sa,0.9,0.05,0.0,0.0,0.05,0%,0.0,0.0,john wagner,,ME-6930,2020
+ME,6930,865.0,Sel Topics - Metrology (VT,0.6,0.3,0.0,0.0,0.0,0%,0.0,0.1,geetha chimata,,ME-6930,2020
+ME,8010,1.0,Found of Fluid Mech,0.73,0.2,0.0,0.0,0.0,0%,0.0,0.07,richard figliola,,ME-8010,2020
+ME,8010,843.0,Found of Fluid Mech,0.4,0.2,0.0,0.0,0.0,0%,0.0,0.4,richard figliola,,ME-8010,2020
+ME,8100,1.0,Macroscopic Thermo,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,jay ochterbeck,,ME-8100,2020
+ME,8180,1.0,Intro to Fin Ele Ana,0.31,0.49,0.09,0.0,0.0,0%,0.0,0.11,gang li,,ME-8180,2020
+ME,8230,1.0,Control Systems,0.78,0.0,0.11,0.0,0.0,0%,0.0,0.11,yue wang,,ME-8230,2020
+ME,8360,1.0,Fracture Mech,0.38,0.13,0.13,0.0,0.0,0%,0.0,0.38,huijuan zhao,,ME-8360,2020
+ME,8460,1.0,Inter Dynamics,0.33,0.42,0.08,0.0,0.0,0%,0.0,0.08, tallapragada,,ME-8460,2020
+ME,8610,1.0,Matl Sel Engr Design,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,garrett pataky,,ME-8610,2020
+ME,8610,864.0,Matl Sel Engr Design,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,garrett pataky,,ME-8610,2020
+ME,8700,1.0,Adv Design Methods,0.25,0.58,0.0,0.0,0.0,0%,0.0,0.08,gregory mocko,,ME-8700,2020
+ME,8710,1.0,Engr Optimization,0.72,0.14,0.07,0.0,0.0,0%,0.0,0.03,cameron turner,,ME-8710,2020
+ME,8910,16.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,joshua summers,,ME-8910,2020
+ME,8910,28.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,cameron turner,,ME-8910,2020
+ME,8930,8.0,Sel Topics ME: Continuum,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,fadi abdeljawad,,ME-8930,2020
+ME,8930,27.0,Sel Topics ME - Optimal Co,0.38,0.57,0.0,0.0,0.0,0%,0.0,0.0,ardalan vahidi,,ME-8930,2020
+ME,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gang li,,ME-9910,2020
+ME,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yue wang,,ME-9910,2020
+ME,9910,29.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,suyi li,,ME-9910,2020
+MGT,2010,1.0,Principles of Management,0.46,0.43,0.09,0.0,0.01,0%,0.0,0.0,katherine clark,,MGT-2010,2020
+MGT,2010,2.0,Principles of Management,0.75,0.22,0.01,0.0,0.02,0%,0.0,0.0,jonathan preedom,,MGT-2010,2020
+MGT,2010,3.0,Principles of Management,0.93,0.03,0.03,0.0,0.0,0%,0.0,0.0,sheena laxton,True,MGT-2010,2020
+MGT,2010,8.0,Principles of Management,0.86,0.07,0.02,0.0,0.0,0%,0.0,0.05,shuang liu,,MGT-2010,2020
+MGT,2010,9.0,Principles of Management,0.4,0.4,0.19,0.02,0.0,0%,0.0,0.0,ashley parnell,,MGT-2010,2020
+MGT,2010,10.0,Principles of Management,0.48,0.33,0.17,0.0,0.02,0%,0.0,0.0,ashley parnell,,MGT-2010,2020
+MGT,2010,11.0,Principles of Management,0.95,0.0,0.02,0.0,0.02,0%,0.0,0.0,jingyuan tian,,MGT-2010,2020
+MGT,2010,12.0,Principles of Management,0.8,0.1,0.0,0.0,0.05,0%,0.0,0.05,zhiwei xing,,MGT-2010,2020
+MGT,2010,13.0,Principles of Management,0.21,0.41,0.24,0.1,0.03,0%,0.0,0.01,christopher mann,,MGT-2010,2020
+MGT,2010,14.0,Principles of Management,0.77,0.2,0.01,0.0,0.01,0%,0.0,0.01,sharon sheridan,,MGT-2010,2020
+MGT,2010,15.0,Principles of Management,0.72,0.14,0.05,0.09,0.0,0%,0.0,0.0,hongli ye,,MGT-2010,2020
+MGT,2010,18.0,Principles of Management,0.93,0.05,0.0,0.0,0.0,0%,0.0,0.03,yao chen,,MGT-2010,2020
+MGT,2180,1.0,Management PC Applicati,0.84,0.12,0.03,0.01,0.0,0%,0.0,0.01,ryan toole,,MGT-2180,2020
+MGT,2180,2.0,Management PC Applicati,0.71,0.19,0.03,0.02,0.05,0%,0.0,0.01,ryan toole,,MGT-2180,2020
+MGT,2180,3.0,Management PC Applicati,0.59,0.26,0.06,0.03,0.05,0%,0.0,0.01,jeromy blake snider,,MGT-2180,2020
+MGT,3070,1.0,Human Resource Manage,0.6,0.29,0.05,0.05,0.0,0%,0.0,0.02,michael cole,,MGT-3070,2020
+MGT,3070,4.0,Human Resource Manage,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,leonard spooner,,MGT-3070,2020
+MGT,3070,5.0,Human Resource Manage,0.62,0.24,0.03,0.03,0.08,0%,0.0,0.0,kristin scott,,MGT-3070,2020
+MGT,3070,6.0,Human Resource Manage,0.71,0.26,0.03,0.0,0.0,0%,0.0,0.0,leonard spooner,,MGT-3070,2020
+MGT,3070,7.0,Human Resource Manage,0.23,0.54,0.15,0.08,0.0,0%,0.0,0.0,priscilla harrison,,MGT-3070,2020
+MGT,3070,8.0,Human Resource Manage,0.63,0.34,0.02,0.0,0.0,0%,0.0,0.0,michael cole,,MGT-3070,2020
+MGT,3070,9.0,Human Resource Manage,0.55,0.39,0.06,0.0,0.0,0%,0.0,0.0,leonard spooner,,MGT-3070,2020
+MGT,3100,1.0,Intermed Business Statistic,0.41,0.35,0.16,0.05,0.03,0%,0.0,0.0,jaeyoung kim,,MGT-3100,2020
+MGT,3100,2.0,Intermed Business Statistic,0.68,0.1,0.13,0.0,0.03,0%,0.0,0.08,haeri seyed seyed,,MGT-3100,2020
+MGT,3100,3.0,Intermed Business Statistic,0.41,0.35,0.06,0.0,0.03,0%,0.0,0.15,mustafa akturk,,MGT-3100,2020
+MGT,3100,5.0,Intermed Business Statistic,0.45,0.31,0.18,0.03,0.01,0%,0.0,0.02,mustafa akturk,,MGT-3100,2020
+MGT,3100,6.0,Intermed Business Statistic,0.41,0.24,0.22,0.0,0.07,0%,0.0,0.05,philip roth,,MGT-3100,2020
+MGT,3100,7.0,Intermed Business Statistic,0.61,0.26,0.11,0.0,0.03,0%,0.0,0.0, ajjuguttu,,MGT-3100,2020
+MGT,3100,8.0,Intermed Business Statistic,0.27,0.33,0.17,0.07,0.1,0%,0.0,0.07,jeromy blake snider,,MGT-3100,2020
+MGT,3100,9.0,Intermed Business Statistic,0.79,0.12,0.07,0.02,0.0,0%,0.0,0.0,david ford peyton,,MGT-3100,2020
+MGT,3100,10.0,Intermed Business Statistic,0.5,0.33,0.08,0.0,0.03,0%,0.0,0.06,david ford peyton,,MGT-3100,2020
+MGT,3100,12.0,Intermed Business Statistic,0.68,0.12,0.15,0.0,0.03,0%,0.0,0.03,david ford peyton,,MGT-3100,2020
+MGT,3100,13.0,Intermed Business Statistic,0.41,0.28,0.09,0.06,0.03,0%,0.0,0.06,benjamin wiles,,MGT-3100,2020
+MGT,3120,5.0,Decision Models for Mana,0.09,0.13,0.28,0.13,0.28,0%,0.0,0.11,sara elizabeth yoder,,MGT-3120,2020
+MGT,3120,6.0,Decision Models for Mana,0.09,0.22,0.27,0.16,0.19,0%,0.0,0.03,sara elizabeth yoder,,MGT-3120,2020
+MGT,3120,9.0,Decision Models for Mana,0.12,0.18,0.22,0.09,0.27,0%,0.0,0.12,sara elizabeth yoder,,MGT-3120,2020
+MGT,3180,1.0,Mgt of Info Systems,0.67,0.2,0.13,0.0,0.0,0%,0.0,0.0,nedumkallel pius,,MGT-3180,2020
+MGT,3180,3.0,Mgt of Info Systems,0.59,0.26,0.11,0.02,0.02,0%,0.0,0.0,kevin mckenzie,,MGT-3180,2020
+MGT,3180,4.0,Mgt of Info Systems,0.64,0.26,0.02,0.06,0.02,0%,0.0,0.0,iaroslava dutchak,,MGT-3180,2020
+MGT,3180,6.0,Mgt of Info Systems,0.35,0.27,0.18,0.12,0.04,0%,0.0,0.04,zhihong ke,,MGT-3180,2020
+MGT,3180,7.0,Mgt of Info Systems,0.38,0.38,0.13,0.04,0.02,0%,0.0,0.04,iaroslava dutchak,,MGT-3180,2020
+MGT,3180,9.0,Mgt of Info Systems,0.47,0.33,0.07,0.02,0.0,0%,0.0,0.12,pranith abbaraju,,MGT-3180,2020
+MGT,3500,1.0,Business Intel/Data Analyti,0.59,0.32,0.05,0.0,0.05,0%,0.0,0.0,david ford peyton,,MGT-3500,2020
+MGT,3900,1.0,Operations Management,0.04,0.25,0.43,0.11,0.11,0%,0.0,0.07,zachary leffakis,,MGT-3900,2020
+MGT,3900,2.0,Operations Management,0.14,0.49,0.3,0.08,0.0,0%,0.0,0.0,zachary leffakis,,MGT-3900,2020
+MGT,3900,4.0,Operations Management,0.41,0.39,0.17,0.01,0.02,0%,0.0,0.0,ying zhang,,MGT-3900,2020
+MGT,3900,5.0,Operations Management,0.3,0.51,0.16,0.03,0.01,0%,0.0,0.0,ying zhang,,MGT-3900,2020
+MGT,3900,7.0,Operations Management,0.16,0.66,0.17,0.0,0.01,0%,0.0,0.01, sridharan,,MGT-3900,2020
+MGT,4000,1.0,Mgt of Organizational Beh,0.8,0.18,0.0,0.03,0.0,0%,0.0,0.0,michael cole,,MGT-4000,2020
+MGT,4000,2.0,Mgt of Organizational Beh,0.73,0.25,0.0,0.0,0.0,0%,0.0,0.03,michael cole,,MGT-4000,2020
+MGT,4000,3.0,Mgt of Organizational Beh,0.23,0.4,0.28,0.05,0.0,0%,0.0,0.05,thomas zagenczyk,,MGT-4000,2020
+MGT,4000,4.0,Mgt of Organizational Beh,0.46,0.41,0.11,0.0,0.03,0%,0.0,0.0,sara joy krivacek,,MGT-4000,2020
+MGT,4020,1.0,Ops Pln and Ctl,0.07,0.27,0.27,0.07,0.17,0%,0.0,0.13,zachary leffakis,,MGT-4020,2020
+MGT,4080,1.0,Lean Operations,0.06,0.35,0.41,0.06,0.12,0%,0.0,0.0,zachary leffakis,,MGT-4080,2020
+MGT,4110,1.0,Project Management,0.33,0.5,0.13,0.0,0.0,0%,0.0,0.0,russell purvis,,MGT-4110,2020
+MGT,4120,1.0,Supplier Management,0.48,0.45,0.03,0.0,0.0,0%,0.0,0.03,ahmet colak,,MGT-4120,2020
+MGT,4150,2.0,Business Strategy,0.23,0.4,0.38,0.0,0.0,0%,0.0,0.0,james liddle,,MGT-4150,2020
+MGT,4150,3.0,Business Strategy,0.09,0.64,0.24,0.02,0.0,0%,0.0,0.0,james liddle,,MGT-4150,2020
+MGT,4150,4.0,Business Strategy,0.11,0.6,0.27,0.0,0.0,0%,0.0,0.02,james liddle,,MGT-4150,2020
+MGT,4150,6.0,Business Strategy,0.24,0.6,0.13,0.02,0.0,0%,0.0,0.0,amy elizabeth ingram,,MGT-4150,2020
+MGT,4150,7.0,Business Strategy,0.56,0.37,0.06,0.0,0.01,0%,0.0,0.0,matt calvin hersel,,MGT-4150,2020
+MGT,4150,8.0,Business Strategy,0.2,0.66,0.14,0.0,0.0,0%,0.0,0.0,amy elizabeth ingram,,MGT-4150,2020
+MGT,4150,9.0,Business Strategy,0.55,0.26,0.19,0.0,0.0,0%,0.0,0.0,paul robert bonney,,MGT-4150,2020
+MGT,4160,1.0,Special Topics Hr,0.58,0.34,0.05,0.0,0.03,0%,0.0,0.0,kristin scott,,MGT-4160,2020
+MGT,4230,1.0,Intern Bus Mgt,0.17,0.06,0.56,0.06,0.06,0%,0.0,0.08,wayne stewart,,MGT-4230,2020
+MGT,4230,2.0,Intern Bus Mgt,0.31,0.14,0.47,0.02,0.04,0%,0.0,0.02,wayne stewart,,MGT-4230,2020
+MGT,4230,4.0,Intern Bus Mgt,0.13,0.36,0.47,0.0,0.04,0%,0.0,0.0,monica simsek,,MGT-4230,2020
+MGT,4230,5.0,Intern Bus Mgt,0.09,0.47,0.45,0.0,0.0,0%,0.0,0.0,monica simsek,,MGT-4230,2020
+MGT,4240,1.0,Global Supply Chain Mana,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,ahmet colak,,MGT-4240,2020
+MGT,4270,2.0,Managing Improvement,0.18,0.53,0.24,0.06,0.0,0%,0.0,0.0,lawrence fredendall,,MGT-4270,2020
+MGT,4310,1.0,Emp Rights & Resp,0.38,0.54,0.05,0.0,0.0,0%,0.0,0.03,leonard spooner,,MGT-4310,2020
+MGT,4350,1.0,Pers Interviewing,0.37,0.49,0.12,0.0,0.02,0%,0.0,0.0,philip roth,,MGT-4350,2020
+MGT,4500,3.0,Desc & Pred Business Anal,0.55,0.09,0.27,0.0,0.09,0%,0.0,0.0,zhihong ke,,MGT-4500,2020
+MGT,4520,1.0,Business Analysis,0.27,0.55,0.09,0.0,0.09,0%,0.0,0.0,russell purvis,,MGT-4520,2020
+MGT,4540,1.0,Business Analytics Progra,0.44,0.22,0.22,0.03,0.0,0%,0.0,0.08,hongki kim,,MGT-4540,2020
+MGT,4560,1.0,Business Data Managemen,0.57,0.37,0.03,0.03,0.0,0%,0.0,0.0,he li,,MGT-4560,2020
+MGT,4970,5.0,CI- Deloitte Consulting,0.79,0.05,0.0,0.0,0.0,0%,0.0,0.16,ryan toole,,MGT-4970,2020
+MGT,8690,1.0,Project Mgt,0.39,0.61,0.0,0.0,0.0,0%,0.0,0.0,russell purvis,,MGT-8690,2020
+MICR,2050,1.0,Introductory Micro,0.5,0.41,0.08,0.0,0.01,0%,0.0,0.0,john abercrombie,,MICR-2050,2020
+MICR,3050,1.0,General Microbiology,0.82,0.1,0.04,0.01,0.01,0%,0.0,0.02,tzuen-rong tzeng,,MICR-3050,2020
+MICR,3050,2.0,General Microbiology,0.46,0.32,0.14,0.06,0.01,0%,0.0,0.02,krista rudolph,,MICR-3050,2020
+MICR,3050,3.0,General Microbiology,0.54,0.31,0.12,0.04,0.0,0%,0.0,0.0,krista rudolph,,MICR-3050,2020
+MICR,4010,1.0,Microbial Diversity & Ecolo,0.7,0.21,0.07,0.02,0.0,0%,0.0,0.0,kristi whitehead,,MICR-4010,2020
+MICR,4010,2.0,Micro Diversity/Ecol (HON,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,kristi whitehead,True,MICR-4010,2020
+MICR,4050,1.0,Adv Microbial Ecol of Hum,0.67,0.21,0.06,0.04,0.01,0%,0.0,0.01,kristi whitehead,,MICR-4050,2020
+MICR,4140,1.0,Basic Immunology,0.83,0.15,0.0,0.0,0.0,0%,0.0,0.01,charles rice,,MICR-4140,2020
+MICR,4150,1.0,Microbial Genetics,0.19,0.49,0.21,0.09,0.02,0%,0.0,0.0,min cao,,MICR-4150,2020
+MICR,4160,1.0,Intro Virology,0.47,0.36,0.12,0.0,0.0,0%,0.0,0.05,kaustubha qanungo,,MICR-4160,2020
+MICR,4510,1.0,Advanced Microbiology II,0.28,0.67,0.0,0.0,0.06,0%,0.0,0.0,harry kurtz,,MICR-4510,2020
+MICR,4510,2.0,Advanced Microbiology II,0.21,0.58,0.21,0.0,0.0,0%,0.0,0.0,harry kurtz,,MICR-4510,2020
+MICR,4510,3.0,Advanced Microbiology II,0.15,0.38,0.38,0.0,0.08,0%,0.0,0.0,harry kurtz,,MICR-4510,2020
+MICR,6050,1.0,Adv Microbial Ecol of Hum,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,kristi whitehead,,MICR-6050,2020
+MICR,6140,1.0,Basic Immunology,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,charles rice,,MICR-6140,2020
+MICR,8040,1.0,Sel Top: MICR Core,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,barbara campbell,,MICR-8040,2020
+MICR,8070,1.0,Micro Journal Club,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,barbara campbell,,MICR-8070,2020
+MKT,3010,1.0,Principles of Marketing,0.21,0.31,0.31,0.11,0.03,0%,0.0,0.02,amanda cooper fine,,MKT-3010,2020
+MKT,3010,2.0,Principles of Marketing,0.23,0.35,0.27,0.09,0.04,0%,0.0,0.02,amanda cooper fine,,MKT-3010,2020
+MKT,3010,3.0,Principles of Marketing,0.3,0.33,0.23,0.08,0.03,0%,0.0,0.03,amanda cooper fine,,MKT-3010,2020
+MKT,3010,4.0,Principles of Marketing,0.57,0.29,0.07,0.01,0.01,0%,0.0,0.05,james gaubert,,MKT-3010,2020
+MKT,3010,5.0,Principles of Marketing,0.49,0.3,0.12,0.01,0.04,0%,0.0,0.03,james gaubert,,MKT-3010,2020
+MKT,3010,7.0,Principles of Marketing,0.49,0.37,0.07,0.01,0.02,0%,0.0,0.03,lura forcum,,MKT-3010,2020
+MKT,3020,1.0,Consumer Behavior,0.8,0.12,0.04,0.02,0.02,0%,0.0,0.0,cony ming shen ho shen,,MKT-3020,2020
+MKT,3020,2.0,Consumer Behavior,0.86,0.1,0.02,0.0,0.02,0%,0.0,0.0,cony ming shen ho shen,,MKT-3020,2020
+MKT,3020,3.0,Consumer Behavior,0.92,0.05,0.01,0.0,0.01,0%,0.0,0.0,cony ming shen ho shen,,MKT-3020,2020
+MKT,3020,5.0,Consumer Behavior,0.58,0.28,0.08,0.06,0.0,0%,0.0,0.0,anastasia thyroff,,MKT-3020,2020
+MKT,3020,6.0,Consumer Behavior,0.63,0.24,0.08,0.06,0.0,0%,0.0,0.0,anastasia thyroff,,MKT-3020,2020
+MKT,3210,1.0,Sports Marketing,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,delancy bennett s,,MKT-3210,2020
+MKT,3220,1.0,Social Media Marketing,0.74,0.15,0.04,0.04,0.02,0%,0.0,0.02,robert fitzwater,,MKT-3220,2020
+MKT,3310,1.0,Marketing Metrics & Analy,0.72,0.22,0.0,0.0,0.0,0%,0.0,0.06,oriana rachel aragon,,MKT-3310,2020
+MKT,3310,2.0,Marketing Metrics & Analy,0.63,0.2,0.14,0.03,0.0,0%,0.0,0.0,oriana rachel aragon,,MKT-3310,2020
+MKT,3310,3.0,Marketing Metrics & Analy,0.69,0.29,0.0,0.03,0.0,0%,0.0,0.0,xianyong wang,,MKT-3310,2020
+MKT,3310,4.0,Marketing Metrics & Analy,0.59,0.35,0.03,0.03,0.0,0%,0.0,0.0,xianyong wang,,MKT-3310,2020
+MKT,4200,2.0,Professional Selling,0.79,0.15,0.03,0.0,0.03,0%,0.0,0.0,jesse moore,,MKT-4200,2020
+MKT,4200,5.0,Professional Selling,0.86,0.1,0.03,0.0,0.0,0%,0.0,0.0,carter mcelveen,,MKT-4200,2020
+MKT,4200,6.0,Professional Selling,0.64,0.21,0.03,0.0,0.06,0%,0.0,0.06,jesse moore,,MKT-4200,2020
+MKT,4200,7.0,Professional Selling,0.75,0.21,0.0,0.0,0.0,0%,0.0,0.04,carter mcelveen,,MKT-4200,2020
+MKT,4220,1.0,Applied Selling,0.45,0.55,0.0,0.0,0.0,0%,0.0,0.0,ryan mullins,,MKT-4220,2020
+MKT,4230,2.0,Promotional Strategy,0.78,0.18,0.04,0.0,0.0,0%,0.0,0.0,michele cauley,,MKT-4230,2020
+MKT,4230,3.0,Promotional Strategy,0.5,0.43,0.04,0.02,0.02,0%,0.0,0.0,michele cauley,,MKT-4230,2020
+MKT,4230,4.0,Promotional Strategy,0.69,0.23,0.05,0.02,0.02,0%,0.0,0.0,michele cauley,,MKT-4230,2020
+MKT,4240,1.0,Sales Management,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,ryan mullins,,MKT-4240,2020
+MKT,4260,1.0,Business-to-Business,0.44,0.46,0.08,0.03,0.0,0%,0.0,0.0,james gaubert,,MKT-4260,2020
+MKT,4270,1.0,International Marketing,0.53,0.38,0.05,0.05,0.0,0%,0.0,0.0,xianyong wang,,MKT-4270,2020
+MKT,4270,2.0,International Marketing,0.52,0.36,0.12,0.0,0.0,0%,0.0,0.0,xianyong wang,,MKT-4270,2020
+MKT,4270,3.0,International Marketing,0.75,0.23,0.0,0.0,0.0,0%,0.0,0.03,thomas poehlman,,MKT-4270,2020
+MKT,4270,4.0,International Marketing,0.6,0.33,0.05,0.0,0.03,0%,0.0,0.0,thomas poehlman,,MKT-4270,2020
+MKT,4270,5.0,International Marketing,0.37,0.51,0.09,0.01,0.0,0%,0.0,0.01,xianyong wang,,MKT-4270,2020
+MKT,4280,1.0,Services Marketing,0.53,0.33,0.1,0.02,0.02,0%,0.0,0.0, scheinbaum,,MKT-4280,2020
+MKT,4280,2.0,Services Marketing,0.38,0.45,0.15,0.03,0.0,0%,0.0,0.0, scheinbaum,,MKT-4280,2020
+MKT,4310,1.0,Marketing Research,0.6,0.34,0.0,0.03,0.03,0%,0.0,0.0, giebelhausen,,MKT-4310,2020
+MKT,4310,2.0,Marketing Research,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0, giebelhausen,,MKT-4310,2020
+MKT,4310,3.0,Marketing Research,0.33,0.52,0.15,0.0,0.0,0%,0.0,0.0,peter weathers,,MKT-4310,2020
+MKT,4310,5.0,Marketing Research,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,scott darren swain,,MKT-4310,2020
+MKT,4430,1.0,Advertising Strategy,0.92,0.06,0.02,0.0,0.0,0%,0.0,0.0,scott darren swain,,MKT-4430,2020
+MKT,4500,1.0,Strategic Mktg Mgt,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,annette popp tower,,MKT-4500,2020
+MKT,4500,2.0,Strategic Mktg Mgt,0.4,0.48,0.08,0.0,0.04,0%,0.0,0.0,annette popp tower,,MKT-4500,2020
+MKT,4500,3.0,Strategic Mktg Mgt,0.2,0.48,0.32,0.0,0.0,0%,0.0,0.0,mary anne raymond,,MKT-4500,2020
+MKT,4500,4.0,Strategic Mktg Mgt,0.62,0.35,0.04,0.0,0.0,0%,0.0,0.0,michele cauley,,MKT-4500,2020
+ML,1010,1.0,Leadership Fundamentals I,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,joseph david velez,,ML-1010,2020
+ML,1010,2.0,Leadership Fundamentals I,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,joseph david velez,,ML-1010,2020
+ML,1010,3.0,Leadership Fundamentals I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,joseph david velez,,ML-1010,2020
+ML,2010,1.0,Leadership Development I,0.88,0.06,0.0,0.0,0.06,0%,0.0,0.0,michael scott gibson,,ML-2010,2020
+ML,2010,2.0,Leadership Development I,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,michael scott gibson,,ML-2010,2020
+ML,2010,3.0,Leadership Development I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,michael scott gibson,,ML-2010,2020
+ML,3010,2.0,Advanced Leadership I,0.95,0.0,0.0,0.0,0.0,0%,0.0,0.05,justin robert merhar,,ML-3010,2020
+MSE,2100,1.0,Intro to Materials Science,0.46,0.39,0.07,0.02,0.04,0%,0.0,0.02,kimberly weirich,,MSE-2100,2020
+MSE,2100,2.0,Intro to Materials Science,0.3,0.4,0.15,0.04,0.06,0%,0.0,0.06,kai he,,MSE-2100,2020
+MSE,2100,3.0,Intro to Materials Science,0.95,0.05,0.0,0.0,0.0,0%,0.0,0.0,john ballato,,MSE-2100,2020
+MSE,2100,4.0,Intro to Materials Science,0.39,0.45,0.12,0.02,0.01,0%,0.0,0.01,mark alan johnson,,MSE-2100,2020
+MSE,2100,6.0,Intro to Materials Science,0.71,0.2,0.05,0.01,0.01,0%,0.0,0.01,olga kuksenok,,MSE-2100,2020
+MSE,3010,1.0,Materials Synthesis & Fabr,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,rakhee pani,,MSE-3010,2020
+MSE,3010,3.0,Materials Synthesis & Fabr,0.71,0.14,0.14,0.0,0.0,0%,0.0,0.0,rakhee pani,,MSE-3010,2020
+MSE,3260,2.0,Thermodynamics of Mater,0.22,0.41,0.19,0.06,0.06,0%,0.0,0.03,fei peng,,MSE-3260,2020
+MSE,3450,1.0,Practice of Materials Engr,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marek urban,,MSE-3450,2020
+MSE,3910,1.0,Research Fundamentals,0.68,0.05,0.11,0.05,0.0,0%,0.0,0.05,ulf daniel schiller,,MSE-3910,2020
+MSE,4130,1.0,Noncrystalline Materials,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,ming tang,,MSE-4130,2020
+MSE,4150,1.0,Polymer Science & Engine,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,olin mefford,,MSE-4150,2020
+MSE,4150,2.0,Polymer Science & Engine,0.73,0.13,0.08,0.0,0.01,0%,0.0,0.05,rakhee pani,,MSE-4150,2020
+MSE,4320,1.0,Manufacturing Proc & Syst,0.82,0.14,0.0,0.0,0.05,0%,0.0,0.0,john sanders,,MSE-4320,2020
+MSE,8000,1.0,Seminar in Materials Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,kai he,,MSE-8000,2020
+MSE,8100,1.0,Fundamentals of Materials,0.64,0.32,0.04,0.0,0.0,0%,0.0,0.0,rajendra bordia,,MSE-8100,2020
+MSE,8190,1.0,Inorgan Mater Characteriz,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,luiz jacobsohn,,MSE-8190,2020
+MSE,8260,1.0,Phase Equil Mat Sys,0.15,0.69,0.15,0.0,0.0,0%,0.0,0.0,stephen foulger,,MSE-8260,2020
+MSE,8270,1.0,Kin of Phase Tran,0.5,0.27,0.23,0.0,0.0,0%,0.0,0.0,konstantin kornev,,MSE-8270,2020
+MSE,8510,1.0,Polymer Science I,0.71,0.21,0.0,0.0,0.0,0%,0.0,0.07,marek urban,,MSE-8510,2020
+MSE,9910,19.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jianhua tong,,MSE-9910,2020
+MSE,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marek urban,,MSE-9910,2020
+MTSA,8420,1.0,Road Safety Culture,0.93,0.0,0.0,0.0,0.0,0%,0.0,0.07,kim alexander,,MTSA-8420,2020
+MUSC,1420,1.0,Music Theory I,0.7,0.2,0.05,0.05,0.0,0%,0.0,0.0,linda li-bleuel,,MUSC-1420,2020
+MUSC,1430,1.0,Aural Skills I,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,linda li-bleuel,,MUSC-1430,2020
+MUSC,1510,2.0,Applied Music for Non Maj,0.58,0.17,0.0,0.08,0.0,0%,0.0,0.17,jonathan doyel,,MUSC-1510,2020
+MUSC,2100,2.0,Music in the Western Worl,0.71,0.23,0.0,0.0,0.0,0%,0.0,0.06,rhea beth jacobus,,MUSC-2100,2020
+MUSC,2100,5.0,Music in the Western Worl,0.95,0.03,0.0,0.0,0.03,0%,0.0,0.0,timothy ray hurlburt,,MUSC-2100,2020
+MUSC,2100,6.0,Music in the Western Worl,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,david conley,,MUSC-2100,2020
+MUSC,2100,7.0,Music in the Western Worl,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0,rhea beth jacobus,,MUSC-2100,2020
+MUSC,2100,8.0,Music in the Western Worl,0.6,0.3,0.03,0.03,0.0,0%,0.0,0.03,rhea beth jacobus,,MUSC-2100,2020
+MUSC,2100,11.0,Music in the Western Worl,0.84,0.03,0.06,0.0,0.0,0%,0.0,0.06,leslie taylor warlick,,MUSC-2100,2020
+MUSC,2100,12.0,Music in the Western Worl,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,lea kibler,,MUSC-2100,2020
+MUSC,2100,13.0,Music in the Western Worl,0.93,0.08,0.0,0.0,0.0,0%,0.0,0.0,david conley,,MUSC-2100,2020
+MUSC,3120,1.0,History of Jazz,0.52,0.32,0.16,0.0,0.0,0%,0.0,0.0,richard goodstein,,MUSC-3120,2020
+MUSC,3140,1.0,World Music,0.88,0.09,0.03,0.0,0.0,0%,0.0,0.0,paul buyer,,MUSC-3140,2020
+MUSC,3180,1.0,Hist of Audio Tech,0.67,0.22,0.06,0.06,0.0,0%,0.0,0.0,bruce allen whisler,,MUSC-3180,2020
+MUSC,3610,1.0,Marching Band,0.99,0.0,0.0,0.0,0.01,0%,0.0,0.01,mark spede,,MUSC-3610,2020
+MUSC,3620,1.0,Symphonic Band,0.93,0.0,0.0,0.0,0.0,0%,0.0,0.02,mark spede,True,MUSC-3620,2020
+MUSC,3690,1.0,Symphony Orchestra,0.93,0.0,0.0,0.0,0.02,0%,0.0,0.05,andrew levin,True,MUSC-3690,2020
+MUSC,4150,1.0,Music Hist to 1750,0.86,0.07,0.07,0.0,0.0,0%,0.0,0.0,eric lapin,,MUSC-4150,2020
+NPL,3000,1.0,Nonprofit Leadership,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,christina mazer,,NPL-3000,2020
+NPL,3000,2.0,Nonprofit Leadership,0.33,0.33,0.14,0.0,0.05,0%,0.0,0.14,bonnie stevens,,NPL-3000,2020
+NPL,3000,3.0,Nonprofit Leadership,0.35,0.48,0.17,0.0,0.0,0%,0.0,0.0,bonnie stevens,,NPL-3000,2020
+NPL,3000,4.0,Nonprofit Leadership,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,corey brookover,,NPL-3000,2020
+NPL,3000,5.0,Nonprofit Leadership,0.7,0.22,0.09,0.0,0.0,0%,0.0,0.0,lauren george,,NPL-3000,2020
+NPL,3000,6.0,Nonprofit Leadership,0.61,0.3,0.09,0.0,0.0,0%,0.0,0.0,corey brookover,,NPL-3000,2020
+NPL,3000,7.0,Nonprofit Leadership,0.62,0.33,0.0,0.0,0.0,0%,0.0,0.05,lauren george,,NPL-3000,2020
+NPL,3000,8.0,Nonprofit Leadership,0.8,0.08,0.04,0.0,0.04,0%,0.0,0.04,lauren george,,NPL-3000,2020
+NPL,3000,9.0,Nonprofit Leadership,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,lauren george,,NPL-3000,2020
+NPL,3000,10.0,Nonprofit Leadership,0.64,0.27,0.09,0.0,0.0,0%,0.0,0.0,christina mazer,,NPL-3000,2020
+NPL,3000,11.0,Nonprofit Leadership,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,christina mazer,,NPL-3000,2020
+NPL,3000,12.0,Nonprofit Leadership,0.58,0.29,0.08,0.04,0.0,0%,0.0,0.0,corey brookover,,NPL-3000,2020
+NPL,3000,13.0,Nonprofit Leadership,0.74,0.22,0.0,0.0,0.0,0%,0.0,0.04,corey brookover,,NPL-3000,2020
+NPL,3010,1.0,NPL Stakeholders,0.46,0.5,0.04,0.0,0.0,0%,0.0,0.0,christina mazer,,NPL-3010,2020
+NPL,3020,1.0,NPL Fundraising,0.78,0.14,0.08,0.0,0.0,0%,0.0,0.0,joan laura phillips,,NPL-3020,2020
+NPL,3030,1.0,NPL Personnel,0.91,0.03,0.0,0.0,0.0,0%,0.0,0.03,joan laura phillips,,NPL-3030,2020
+NPL,3040,1.0,NPL Risk Management,0.58,0.35,0.06,0.0,0.0,0%,0.0,0.0,daniel anderson,,NPL-3040,2020
+NPL,3050,1.0,Strat Social Media for NP,0.85,0.09,0.05,0.0,0.0,0%,0.0,0.0,randi plake,,NPL-3050,2020
+NPL,3050,2.0,Strat Social Media for NP,0.8,0.07,0.07,0.02,0.04,0%,0.0,0.0,randi plake,,NPL-3050,2020
+NPL,4900,1.0,Non-Profit Lead Preceptor,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,corey brookover,,NPL-4900,2020
+NURS,3030,1.0,Nursing of Adults,0.24,0.71,0.05,0.0,0.0,0%,0.0,0.0,lena marie burgess,,NURS-3030,2020
+NURS,3040,101.0,Pathophysiology,0.43,0.43,0.1,0.03,0.02,0%,0.0,0.0,catherine murton,,NURS-3040,2020
+NURS,3040,201.0,Pathophysiology,0.52,0.38,0.06,0.03,0.01,0%,0.0,0.0,amy boggs garrison,,NURS-3040,2020
+NURS,3040,300.0,Pathophysiology,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,amy boggs garrison,,NURS-3040,2020
+NURS,3040,401.0,Pathophysiology,0.64,0.32,0.05,0.0,0.0,0%,0.0,0.0,amy boggs garrison,,NURS-3040,2020
+NURS,3050,1.0,Psychosocial Nursing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,kevin earle busby,,NURS-3050,2020
+NURS,3100,1.0,Health Assessment,0.68,0.3,0.0,0.0,0.03,0%,0.0,0.0,tiffany leah stewart,,NURS-3100,2020
+NURS,3100,402.0,Health Assessment,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,jason thrift,,NURS-3100,2020
+NURS,3120,101.0,Foundations of Nursing,0.61,0.36,0.03,0.0,0.0,0%,0.0,0.0,jennifer bagwell,,NURS-3120,2020
+NURS,3120,211.0,Foundations of Nursing,0.48,0.52,0.0,0.0,0.0,0%,0.0,0.0,terri teramano,,NURS-3120,2020
+NURS,3120,212.0,Foundations of Nursing,0.28,0.56,0.16,0.0,0.0,0%,0.0,0.0,terri teramano,,NURS-3120,2020
+NURS,3120,411.0,Foundations of Nursing,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,terri teramano,,NURS-3120,2020
+NURS,3190,300.0,Health Assessment for RNs,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,tiffany leah stewart,,NURS-3190,2020
+NURS,3230,201.0,Gerontology Nursing,0.95,0.05,0.0,0.0,0.0,0%,0.0,0.0,zahra rahemi,,NURS-3230,2020
+NURS,3300,1.0,Research in Nursing,0.9,0.05,0.03,0.0,0.03,0%,0.0,0.0,veronica parker,,NURS-3300,2020
+NURS,3330,1.0,Health Care Genetics,0.41,0.51,0.05,0.02,0.0,0%,0.0,0.0,linda ward,,NURS-3330,2020
+NURS,3400,101.0,Pharmther Nursing,0.4,0.43,0.12,0.03,0.02,0%,0.0,0.0,catherine murton,,NURS-3400,2020
+NURS,3400,201.0,Pharmther Nursing,0.56,0.33,0.09,0.02,0.0,0%,0.0,0.0,jenna lynn seawright,,NURS-3400,2020
+NURS,3400,401.0,Pharmther Nursing,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,jenna lynn seawright,,NURS-3400,2020
+NURS,4010,1.0,Mental Health Nurs,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,lindsey garrard,,NURS-4010,2020
+NURS,4030,101.0,Complex Nursing of Adults,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,taylor jean oneal,,NURS-4030,2020
+NURS,4030,201.0,Complex Nursing of Adults,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,taylor jean oneal,,NURS-4030,2020
+NURS,4060,300.0,Issues in Professionalism,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,shirley mae timmons,,NURS-4060,2020
+NURS,4110,1.0,Nursing of Children,0.53,0.47,0.0,0.0,0.0,0%,0.0,0.0, elizabeth fisher,,NURS-4110,2020
+NURS,4120,1.0,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0%,0.0,0.0,erin nicole shepherd,,NURS-4120,2020
+NURS,4250,300.0,Community Nursing,0.62,0.31,0.0,0.0,0.08,0%,0.0,0.0,tiffany leah stewart,,NURS-4250,2020
+NURS,8040,401.0,Dev Nurs Knowledge,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,kim ann pickett,,NURS-8040,2020
+NURS,8050,400.0,Pharmaco Adv Nurs,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,tracy king fasolino,,NURS-8050,2020
+NURS,8050,401.0,Pharmaco Adv Nurs,0.67,0.25,0.0,0.0,0.08,0%,0.0,0.0,tracy king fasolino,,NURS-8050,2020
+NURS,8060,400.0,Advan Assessment for Nur,0.27,0.68,0.05,0.0,0.0,0%,0.0,0.0,jennifer geter rice,,NURS-8060,2020
+NURS,8090,400.0,Pathophysiology,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,tracy brock lowe,,NURS-8090,2020
+NURS,8180,400.0,Develop Family in Primary,0.33,0.5,0.0,0.0,0.0,0%,0.0,0.17,lisa miller,,NURS-8180,2020
+NURS,8190,400.0,Developing Family,0.38,0.56,0.0,0.0,0.0,0%,0.0,0.0,lisa miller,,NURS-8190,2020
+NURS,8200,400.0,Child & Adol Nursing,0.63,0.31,0.0,0.0,0.0,0%,0.0,0.0,heide temples,,NURS-8200,2020
+NURS,8220,401.0,Gerontology Nursing,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.0,nicole joy davis,,NURS-8220,2020
+NURS,8820,400.0,Primary Care Elders,0.75,0.0,0.0,0.0,0.0,0%,0.0,0.0,kimberly trammell,,NURS-8820,2020
+NUTR,2030,1.0,Intro Princ of Human Nutri,0.75,0.21,0.03,0.0,0.0,0%,0.0,0.01,bridgit corbett,,NUTR-2030,2020
+NUTR,2030,2.0,Intro Princ of Human Nutri,0.47,0.42,0.07,0.0,0.0,0%,0.0,0.05,bridgit corbett,,NUTR-2030,2020
+NUTR,2050,400.0,Nutrition for Nursing Prof,0.53,0.45,0.02,0.0,0.0,0%,0.0,0.0,bridgit corbett,,NUTR-2050,2020
+NUTR,2160,1.0,Evidence-Based Nutrition,0.76,0.08,0.08,0.05,0.01,0%,0.0,0.01,angela fraser,,NUTR-2160,2020
+NUTR,3020,1.0,Nutrition Assessment,0.8,0.18,0.0,0.0,0.0,0%,0.0,0.02,elliot jesch,,NUTR-3020,2020
+NUTR,4240,1.0,Medical Nutr Thera I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,vivian haley-zitlin,,NUTR-4240,2020
+NUTR,4510,1.0,Human Nutrition & Metab,0.2,0.3,0.3,0.05,0.13,0%,0.0,0.03,elliot jesch,,NUTR-4510,2020
+PA,1010,1.0,Intro to Perf Arts,0.68,0.26,0.03,0.0,0.0,0%,0.0,0.03,david hartmann,,PA-1010,2020
+PA,3010,1.0,Princip of Arts Administrati,0.38,0.46,0.08,0.08,0.0,0%,0.0,0.0,richard goodstein,,PA-3010,2020
+PA,4010,1.0,Capstone Project,0.6,0.3,0.0,0.0,0.0,0%,0.0,0.0,bruce allen whisler,,PA-4010,2020
+PADM,7020,400.0,Research Methods,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,ronald chrestman,,PADM-7020,2020
+PADM,7020,401.0,Research Methods,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,ronald chrestman,,PADM-7020,2020
+PADM,8220,400.0,Public Policy Process,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,mellott yazykova,,PADM-8220,2020
+PADM,8290,400.0,Public Financial Managem,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.0,robert frager,,PADM-8290,2020
+PADM,8410,402.0,Public Data Analysis,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,scott schmidt,,PADM-8410,2020
+PADM,8420,400.0,GIS for Public Administrato,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,david white,,PADM-8420,2020
+PADM,8500,400.0,Homeland Security Funda,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,lori ann dickes,,PADM-8500,2020
+PADM,8520,401.0,Emergency Mgt Planning,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,kevin todd staley,,PADM-8520,2020
+PADM,8630,400.0,Contemporary Admin Orgs,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,lori ann dickes,,PADM-8630,2020
+PADM,8640,400.0,Legal Aspects of Non-Profi,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,margaret elise baker,,PADM-8640,2020
+PADM,8670,401.0,State Government Admin,0.77,0.15,0.0,0.0,0.0,0%,0.0,0.0,alfred bundrick,,PADM-8670,2020
+PAS,3010,2.0,Intro to Pan African Studie,0.62,0.18,0.12,0.03,0.0,0%,0.0,0.06, stewart-tillman,,PAS-3010,2020
+PDBE,8120,1.0,Seminar in EDP,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mickey lauria,,PDBE-8120,2020
+PDBE,8150,1.0,Research Design in EDP,0.63,0.0,0.38,0.0,0.0,0%,0.0,0.0,mickey lauria,,PDBE-8150,2020
+PES,1040,1.0,Introduction to Plant Scien,0.78,0.16,0.03,0.0,0.0,0%,0.0,0.03,paula agudelo,,PES-1040,2020
+PES,2020,1.0,Soils,0.57,0.31,0.1,0.02,0.0,0%,0.0,0.0,dara michelle park,,PES-2020,2020
+PES,3150,1.0,Environment and Agricultu,0.62,0.33,0.05,0.0,0.0,0%,0.0,0.0,suseela appukuttan,,PES-3150,2020
+PES,4090,1.0,Biology of Invasive Plants,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0, tharayil-,,PES-4090,2020
+PES,4550,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, tharayil-,,PES-4550,2020
+PES,4850,1.0,Environmental Soil Chemis,0.71,0.24,0.0,0.0,0.0,0%,0.0,0.06,haibo liu,,PES-4850,2020
+PES,8250,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, tharayil-,,PES-8250,2020
+PHIL,1010,1.0,Intro to Philosophic Proble,0.7,0.24,0.0,0.0,0.0,0%,0.0,0.06,david stegall,,PHIL-1010,2020
+PHIL,1010,2.0,Intro to Philosophic Proble,0.54,0.34,0.06,0.0,0.0,0%,0.0,0.06,david stegall,,PHIL-1010,2020
+PHIL,1010,3.0,Intro to Philosophic Proble,0.47,0.35,0.09,0.0,0.0,0%,0.0,0.09,david stegall,,PHIL-1010,2020
+PHIL,1010,4.0,Intro to Philosophic Proble,0.65,0.24,0.06,0.0,0.06,0%,0.0,0.0,claire kirwin,,PHIL-1010,2020
+PHIL,1010,5.0,Intro to Philosophic Proble,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,claire kirwin,,PHIL-1010,2020
+PHIL,1020,1.0,Introduction to Logic,0.49,0.29,0.14,0.03,0.03,0%,0.0,0.03,pascal brixel,,PHIL-1020,2020
+PHIL,1020,2.0,Introduction to Logic,0.69,0.23,0.09,0.0,0.0,0%,0.0,0.0,adam gies,,PHIL-1020,2020
+PHIL,1020,3.0,Introduction to Logic,0.58,0.27,0.15,0.0,0.0,0%,0.0,0.0,adam gies,,PHIL-1020,2020
+PHIL,1020,4.0,Introduction to Logic,0.37,0.43,0.14,0.03,0.0,0%,0.0,0.03,adam gies,,PHIL-1020,2020
+PHIL,1020,5.0,Introduction to Logic,0.41,0.47,0.09,0.0,0.0,0%,0.0,0.03,edyta joanna kuzian,,PHIL-1020,2020
+PHIL,1020,6.0,Introduction to Logic,0.46,0.4,0.11,0.03,0.0,0%,0.0,0.0,edyta joanna kuzian,,PHIL-1020,2020
+PHIL,1020,7.0,Introduction to Logic,0.63,0.26,0.0,0.0,0.05,0%,0.0,0.05,pascal brixel,,PHIL-1020,2020
+PHIL,1020,8.0,Introduction to Logic,0.36,0.47,0.11,0.0,0.03,0%,0.0,0.03,edyta joanna kuzian,,PHIL-1020,2020
+PHIL,1020,9.0,Introduction to Logic,0.31,0.37,0.23,0.09,0.0,0%,0.0,0.0,adam gies,,PHIL-1020,2020
+PHIL,1030,1.0,Introduction to Ethics,0.57,0.37,0.03,0.0,0.0,0%,0.0,0.03,daniel wueste,,PHIL-1030,2020
+PHIL,1030,2.0,Introduction to Ethics,0.39,0.42,0.16,0.03,0.0,0%,0.0,0.0,charles starkey,,PHIL-1030,2020
+PHIL,1030,3.0,Introduction to Ethics,0.81,0.1,0.0,0.0,0.05,0%,0.0,0.05,david stegall,,PHIL-1030,2020
+PHIL,1030,4.0,Introduction to Ethics,0.57,0.23,0.17,0.03,0.0,0%,0.0,0.0,edyta joanna kuzian,,PHIL-1030,2020
+PHIL,1030,5.0,Introduction to Ethics,0.47,0.39,0.0,0.03,0.06,0%,0.0,0.06,david antonini,,PHIL-1030,2020
+PHIL,3040,1.0,Moral Philosophy,0.44,0.47,0.06,0.0,0.0,0%,0.0,0.03,todd may,,PHIL-3040,2020
+PHIL,3150,2.0,Ancient Philosophy,0.66,0.2,0.06,0.03,0.03,0%,0.0,0.03,stephen satris,,PHIL-3150,2020
+PHIL,3210,1.0,Crime & Punishment,0.53,0.41,0.06,0.0,0.0,0%,0.0,0.0,daniel wueste,,PHIL-3210,2020
+PHIL,3260,1.0,Science and Values,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,david antonini,,PHIL-3260,2020
+PHIL,3260,2.0,Science and Values,0.61,0.33,0.0,0.03,0.0,0%,0.0,0.03,david antonini,,PHIL-3260,2020
+PHIL,3260,3.0,Science and Values,0.73,0.22,0.0,0.0,0.03,0%,0.0,0.03,kelly smith,,PHIL-3260,2020
+PHIL,3300,1.0,Contemporary Issues in Ph,0.41,0.47,0.0,0.0,0.0,0%,0.0,0.06,todd may,,PHIL-3300,2020
+PHIL,3330,1.0,Metaphysics,0.68,0.16,0.05,0.05,0.0,0%,0.0,0.05,adam gies,,PHIL-3330,2020
+PHIL,3430,1.0,Philosophy of Law,0.35,0.47,0.18,0.0,0.0,0%,0.0,0.0,brookes brown,,PHIL-3430,2020
+PHIL,3440,1.0,Business Ethics,0.18,0.58,0.15,0.0,0.0,0%,0.0,0.09,brookes brown,,PHIL-3440,2020
+PHIL,3460,1.0,Biomedical Ethics,0.41,0.47,0.12,0.0,0.0,0%,0.0,0.0,charles starkey,,PHIL-3460,2020
+PHIL,3480,1.0,Philosophies of Art,0.38,0.5,0.13,0.0,0.0,0%,0.0,0.0,edyta joanna kuzian,,PHIL-3480,2020
+PHSC,1180,1.0,"Intro Phys, Astron & Earth",0.76,0.16,0.03,0.03,0.02,0%,0.0,0.0,minory nammouz,,PHSC-1180,2020
+PHSC,1180,2.0,"Intro Phys, Astron & Earth",0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,minory nammouz,,PHSC-1180,2020
+PHYS,1220,1.0,Physics with Calculus I,0.25,0.29,0.29,0.09,0.02,0%,0.0,0.07,lih-sin the,,PHYS-1220,2020
+PHYS,1220,2.0,Physics with Calculus I,0.17,0.34,0.3,0.07,0.06,0%,0.0,0.05,lih-sin the,,PHYS-1220,2020
+PHYS,1220,4.0,Physics with Calculus I,0.26,0.47,0.16,0.0,0.05,0%,0.0,0.05,hugo sanabria,,PHYS-1220,2020
+PHYS,1220,5.0,Physics with Calculus I (HO,0.56,0.39,0.0,0.0,0.0,0%,0.0,0.06,emil georgiev alexov,True,PHYS-1220,2020
+PHYS,1240,1.0,Physics Lab I,0.82,0.12,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,1240,2.0,Physics Lab I,0.67,0.11,0.17,0.0,0.0,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,1240,3.0,Physics Lab I,0.5,0.25,0.13,0.06,0.0,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,1240,4.0,Physics Lab I,0.53,0.24,0.0,0.12,0.06,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,1240,6.0,Physics Lab I,0.67,0.22,0.11,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-1240,2020
+PHYS,1240,7.0,Physics Lab I,0.72,0.17,0.0,0.0,0.06,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,1240,8.0,Physics Lab I,0.83,0.06,0.06,0.0,0.06,0%,0.0,0.0,daniel thompson,,PHYS-1240,2020
+PHYS,1240,9.0,Physics Lab I,0.86,0.0,0.0,0.0,0.0,0%,0.0,0.14,daniel thompson,,PHYS-1240,2020
+PHYS,1240,10.0,Physics Lab I,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.07,daniel thompson,,PHYS-1240,2020
+PHYS,1240,11.0,Physics Lab I,0.67,0.06,0.06,0.0,0.11,0%,0.0,0.11,daniel thompson,,PHYS-1240,2020
+PHYS,1240,12.0,Physics Lab I,0.7,0.2,0.1,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-1240,2020
+PHYS,1240,13.0,Physics Lab I,0.82,0.0,0.12,0.06,0.0,0%,0.0,0.0,daniel thompson,,PHYS-1240,2020
+PHYS,1240,14.0,Physics Lab I,0.72,0.11,0.0,0.11,0.0,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,1240,15.0,Physics Lab I,0.67,0.22,0.0,0.06,0.06,0%,0.0,0.0,daniel thompson,,PHYS-1240,2020
+PHYS,1240,16.0,Physics Lab I,0.67,0.22,0.0,0.11,0.0,0%,0.0,0.0,daniel thompson,,PHYS-1240,2020
+PHYS,1240,17.0,Physics Lab I,0.78,0.06,0.06,0.06,0.0,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,1240,18.0,Physics Lab I,0.76,0.18,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,1240,19.0,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-1240,2020
+PHYS,1240,21.0,Physics Lab I,0.71,0.21,0.0,0.0,0.07,0%,0.0,0.0,daniel thompson,,PHYS-1240,2020
+PHYS,1240,22.0,Physics Lab I,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,,PHYS-1240,2020
+PHYS,2070,1.0,General Physics I,0.32,0.29,0.18,0.06,0.08,0%,0.0,0.06,amy liann pope,,PHYS-2070,2020
+PHYS,2070,2.0,General Physics I,0.42,0.32,0.13,0.04,0.03,0%,0.0,0.05,amy liann pope,,PHYS-2070,2020
+PHYS,2070,3.0,General Physics I,0.46,0.29,0.15,0.05,0.02,0%,0.0,0.04,amy liann pope,,PHYS-2070,2020
+PHYS,2080,1.0,General Physics II,0.35,0.41,0.13,0.03,0.05,0%,0.0,0.02,pooja puneet,,PHYS-2080,2020
+PHYS,2090,1.0,Gen Phys Lab I,0.5,0.25,0.04,0.08,0.04,0%,0.0,0.08,daniel thompson,,PHYS-2090,2020
+PHYS,2090,2.0,Gen Phys Lab I,0.57,0.35,0.09,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2090,2020
+PHYS,2090,3.0,Gen Phys Lab I,0.54,0.29,0.04,0.0,0.08,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,4.0,Gen Phys Lab I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2090,2020
+PHYS,2090,5.0,Gen Phys Lab I,0.63,0.21,0.13,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,6.0,Gen Phys Lab I,0.65,0.1,0.1,0.05,0.0,0%,0.0,0.1,daniel thompson,,PHYS-2090,2020
+PHYS,2090,7.0,Gen Phys Lab I,0.74,0.26,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2090,2020
+PHYS,2090,8.0,Gen Phys Lab I,0.67,0.21,0.08,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,9.0,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,10.0,Gen Phys Lab I,0.7,0.22,0.0,0.0,0.04,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,11.0,Gen Phys Lab I,0.71,0.08,0.13,0.0,0.04,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,12.0,Gen Phys Lab I,0.91,0.04,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,13.0,Gen Phys Lab I,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2090,2020
+PHYS,2090,14.0,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,15.0,Gen Phys Lab I,0.54,0.25,0.13,0.0,0.0,0%,0.0,0.08,daniel thompson,,PHYS-2090,2020
+PHYS,2090,16.0,Gen Phys Lab I,0.79,0.13,0.0,0.0,0.0,0%,0.0,0.08,daniel thompson,,PHYS-2090,2020
+PHYS,2090,17.0,Gen Phys Lab I,0.83,0.09,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,18.0,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2090,2020
+PHYS,2090,19.0,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2090,20.0,Gen Phys Lab I,0.43,0.48,0.0,0.0,0.05,0%,0.0,0.05,daniel thompson,,PHYS-2090,2020
+PHYS,2090,21.0,Gen Phys Lab I,0.72,0.22,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,,PHYS-2090,2020
+PHYS,2090,22.0,Gen Phys Lab I,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2090,2020
+PHYS,2090,23.0,Gen Phys Lab I,0.75,0.17,0.0,0.0,0.0,0%,0.0,0.08,daniel thompson,,PHYS-2090,2020
+PHYS,2090,24.0,Gen Phys Lab I,0.58,0.21,0.11,0.0,0.0,0%,0.0,0.11,daniel thompson,,PHYS-2090,2020
+PHYS,2090,25.0,Gen Phys Lab I,0.82,0.14,0.0,0.0,0.0,0%,0.0,0.05,daniel thompson,,PHYS-2090,2020
+PHYS,2090,26.0,Gen Phys Lab I,0.36,0.36,0.14,0.05,0.0,0%,0.0,0.09,daniel thompson,,PHYS-2090,2020
+PHYS,2090,27.0,Gen Phys Lab I,0.75,0.08,0.04,0.04,0.04,0%,0.0,0.04,daniel thompson,,PHYS-2090,2020
+PHYS,2100,1.0,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2100,2020
+PHYS,2100,2.0,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2100,2020
+PHYS,2100,3.0,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2100,2020
+PHYS,2100,4.0,Gen Phys Lab II,0.91,0.0,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2100,2020
+PHYS,2100,6.0,Gen Phys Lab II,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2100,2020
+PHYS,2100,7.0,Gen Phys Lab II,0.88,0.04,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2100,2020
+PHYS,2100,8.0,Gen Phys Lab II,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2100,2020
+PHYS,2100,9.0,Gen Phys Lab II,0.96,0.0,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,,PHYS-2100,2020
+PHYS,2210,1.0,Physics with Calculus II,0.24,0.37,0.27,0.04,0.02,0%,0.0,0.05,jason brown,,PHYS-2210,2020
+PHYS,2210,2.0,Physics with Calculus II,0.46,0.37,0.11,0.04,0.01,0%,0.0,0.02,pooja puneet,,PHYS-2210,2020
+PHYS,2210,3.0,Physics with Calculus II,0.28,0.39,0.19,0.07,0.04,0%,0.0,0.03,pooja puneet,,PHYS-2210,2020
+PHYS,2210,4.0,Physics with Calculus II,0.26,0.43,0.19,0.07,0.03,0%,0.0,0.01,jason brown,,PHYS-2210,2020
+PHYS,2210,5.0,Physics w/Calculus II(HON),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,endre andras takacs,True,PHYS-2210,2020
+PHYS,2220,1.0,Physics with Calculus III,0.78,0.13,0.04,0.0,0.0,0%,0.0,0.04,murray daw,,PHYS-2220,2020
+PHYS,2230,1.0,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,2.0,Physics Lab II,0.22,0.61,0.11,0.0,0.0,0%,0.0,0.06,daniel thompson,,PHYS-2230,2020
+PHYS,2230,3.0,Physics Lab II,0.39,0.5,0.06,0.06,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,4.0,Physics Lab II,0.44,0.44,0.11,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,5.0,Physics Lab II,0.74,0.26,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,6.0,Physics Lab II,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,7.0,Physics Lab II,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,9.0,Physics Lab II,0.72,0.28,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,10.0,Physics Lab II,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,11.0,Physics Lab II,0.2,0.67,0.07,0.0,0.0,0%,0.0,0.07,daniel thompson,,PHYS-2230,2020
+PHYS,2230,12.0,Physics Lab II,0.72,0.22,0.0,0.0,0.06,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,13.0,Physics Lab II,0.67,0.17,0.11,0.0,0.0,0%,0.0,0.06,daniel thompson,,PHYS-2230,2020
+PHYS,2230,14.0,Physics Lab II,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,,PHYS-2230,2020
+PHYS,2230,15.0,Physics Lab II,0.22,0.67,0.0,0.0,0.0,0%,0.0,0.11,daniel thompson,,PHYS-2230,2020
+PHYS,2240,1.0,Physics Lab III,0.75,0.13,0.06,0.0,0.0,0%,0.0,0.06,daniel thompson,,PHYS-2240,2020
+PHYS,2450,1.0,Physics of Climate,0.62,0.23,0.06,0.01,0.02,0%,0.0,0.06,jens oberheide,,PHYS-2450,2020
+PHYS,3000,1.0,Intro to Research,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,jianbo gao,,PHYS-3000,2020
+PHYS,3120,1.0,Meth Theor Phys II,0.64,0.18,0.09,0.09,0.0,0%,0.0,0.0,lih-sin the,,PHYS-3120,2020
+PHYS,3150,1.0,Intro to Computational Ph,0.46,0.27,0.19,0.0,0.0,0%,0.0,0.08,jason brown,,PHYS-3150,2020
+PHYS,3210,1.0,Mechanics I,0.48,0.35,0.06,0.0,0.03,0%,0.0,0.06,feng ding,,PHYS-3210,2020
+PHYS,3250,1.0,Electronics for Physicists,0.74,0.21,0.05,0.0,0.0,0%,0.0,0.0,chad sosolik,,PHYS-3250,2020
+PHYS,4410,1.0,Electromagnetics I,0.47,0.29,0.12,0.0,0.06,0%,0.0,0.06,ramakrishna podila,,PHYS-4410,2020
+PHYS,4550,1.0,Quantum Physics I,0.48,0.24,0.19,0.05,0.0,0%,0.0,0.05,gerald lehmacher,,PHYS-4550,2020
+PHYS,8110,1.0,Meth of Theor Phys I,0.23,0.77,0.0,0.0,0.0,0%,0.0,0.0,domnita marinescu,,PHYS-8110,2020
+PHYS,8180,1.0,Cellular Biophysics,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,joshua alper,,PHYS-8180,2020
+PHYS,8210,1.0,Classical Mech I,0.18,0.82,0.0,0.0,0.0,0%,0.0,0.0,stephen kaeppler,,PHYS-8210,2020
+PHYS,8750,2.0,Intro to Research Seminar,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,jianbo gao,,PHYS-8750,2020
+PHYS,8750,13.0,Numerical Fluid Dynamics,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,xian lu,,PHYS-8750,2020
+PHYS,9510,1.0,Quantum Mech I,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,sumanta tewari,,PHYS-9510,2020
+PHYS,9530,1.0,Quantum Field Theory,0.44,0.56,0.0,0.0,0.0,0%,0.0,0.0,bradley meyer,,PHYS-9530,2020
+PHYS,9910,12.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marco ajello,,PHYS-9910,2020
+PKSC,1010,1.0,Pkgsc Orientation,0.82,0.12,0.04,0.02,0.0,0%,0.0,0.0,marcondes guerra,,PKSC-1010,2020
+PKSC,1020,1.0,Intro to Pkg Sci,0.24,0.24,0.28,0.13,0.08,0%,0.0,0.04,heather batt,,PKSC-1020,2020
+PKSC,2010,1.0,Pkg Perishable Prod,0.08,0.35,0.32,0.11,0.05,0%,0.0,0.08,heather batt,,PKSC-2010,2020
+PKSC,2020,1.0,Packaging Mtl & Mfg,0.3,0.3,0.38,0.02,0.0,0%,0.0,0.0,marcondes guerra,,PKSC-2020,2020
+PKSC,2040,1.0,Container Systems,0.2,0.6,0.13,0.07,0.0,0%,0.0,0.0,marcondes guerra,,PKSC-2040,2020
+PKSC,2060,1.0,Container Sys Lab,0.57,0.36,0.07,0.0,0.0,0%,0.0,0.0,marcondes guerra,,PKSC-2060,2020
+PKSC,2200,1.0,Product & Pkg Design,0.76,0.2,0.05,0.0,0.0,0%,0.0,0.0,haley ellis appleby,,PKSC-2200,2020
+PKSC,3200,1.0,Pkg Design Theory,0.79,0.11,0.0,0.0,0.0,0%,0.0,0.11,rupert hurley,,PKSC-3200,2020
+PKSC,4010,1.0,Packaging Machinery,0.09,0.6,0.26,0.0,0.04,0%,0.0,0.02,anthony pometto,,PKSC-4010,2020
+PKSC,4040,1.0,Protective Packaging Prop,0.22,0.35,0.25,0.07,0.05,0%,0.0,0.05,gregory batt,,PKSC-4040,2020
+PKSC,4160,1.0,Application of Polymers in,0.3,0.52,0.13,0.0,0.0,0%,0.0,0.05,alicia campbell,,PKSC-4160,2020
+PKSC,4200,1.0,Package Design & Develop,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,robert kimmel,,PKSC-4200,2020
+PKSC,4540,1.0,Product & Pkg Evaluation L,0.44,0.56,0.0,0.0,0.0,0%,0.0,0.0,gregory batt,,PKSC-4540,2020
+PKSC,4540,3.0,Product & Pkg Evaluation L,0.19,0.5,0.19,0.06,0.0,0%,0.0,0.06,gregory batt,,PKSC-4540,2020
+PKSC,4540,5.0,Product & Pkg Evaluation L,0.07,0.64,0.07,0.0,0.07,0%,0.0,0.14,gregory batt,,PKSC-4540,2020
+PKSC,4640,1.0,Food & Health Care Pkg Sy,0.73,0.19,0.06,0.0,0.02,0%,0.0,0.0,kay cooksey,,PKSC-4640,2020
+PLPA,3100,1.0,Principles of Plant Patholo,0.31,0.31,0.24,0.07,0.07,0%,0.0,0.0,steven nye jeffers,,PLPA-3100,2020
+PLPA,8020,1.0,Principles of Plant Patholo,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,steven nye jeffers,,PLPA-8020,2020
+POSC,1010,1.0,Amer National Govt,0.11,0.58,0.16,0.11,0.05,0%,0.0,0.0,robert carey,,POSC-1010,2020
+POSC,1010,2.0,Amer National Govt,0.35,0.43,0.18,0.0,0.02,0%,0.0,0.02,robert carey,,POSC-1010,2020
+POSC,1010,3.0,Amer National Govt,0.6,0.36,0.0,0.0,0.0,0%,0.0,0.04,joseph earl stewart,,POSC-1010,2020
+POSC,1010,4.0,Amer National Govt,0.46,0.36,0.12,0.0,0.02,0%,0.0,0.04,robert carey,,POSC-1010,2020
+POSC,1020,1.0,Intro Intl Relations,0.77,0.15,0.05,0.02,0.02,0%,0.0,0.0,steven vincent miller,,POSC-1020,2020
+POSC,1020,2.0,Intro Intl Relations,0.42,0.39,0.11,0.03,0.03,0%,0.0,0.03, petersheim,,POSC-1020,2020
+POSC,1020,3.0,Intro Intl Relations,0.36,0.45,0.07,0.0,0.07,0%,0.0,0.05,tara elizabeth trask,,POSC-1020,2020
+POSC,1020,4.0,Intro Intl Relations,0.55,0.41,0.0,0.0,0.04,0%,0.0,0.0,colin denby pearce,,POSC-1020,2020
+POSC,1020,5.0,Intro Intl Relations,0.35,0.4,0.09,0.01,0.09,0%,0.0,0.06,tara elizabeth trask,,POSC-1020,2020
+POSC,1030,1.0,Intro to Political Theory,0.66,0.21,0.03,0.03,0.03,0%,0.0,0.03,adam thomas,,POSC-1030,2020
+POSC,1030,2.0,Intro to Political Theory,0.33,0.61,0.0,0.0,0.06,0%,0.0,0.0,colin denby pearce,,POSC-1030,2020
+POSC,1030,3.0,Intro to Political Theory,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,derek neal duplessie,,POSC-1030,2020
+POSC,1030,4.0,Intro to Political Theory,0.48,0.28,0.17,0.0,0.07,0%,0.0,0.0,brandon turner,,POSC-1030,2020
+POSC,1030,5.0,Intro to Political Theory,0.71,0.17,0.08,0.0,0.0,0%,0.0,0.04,jay hoffpauir,,POSC-1030,2020
+POSC,1030,8.0,Intro to Political Theory,0.27,0.5,0.1,0.07,0.03,0%,0.0,0.03,elizabeth 'arrivee,,POSC-1030,2020
+POSC,1040,1.0,Intro Compar Pol,0.17,0.34,0.19,0.05,0.17,0%,0.0,0.07,katherine curtis,,POSC-1040,2020
+POSC,1040,2.0,Intro Compar Pol,0.47,0.29,0.06,0.04,0.04,0%,0.0,0.1, rhodes-purdy,,POSC-1040,2020
+POSC,1990,1.0,Intro Pol Sci,0.52,0.36,0.1,0.0,0.02,0%,0.0,0.0, petersheim,,POSC-1990,2020
+POSC,3020,1.0,State and Loc Gov,0.3,0.58,0.0,0.0,0.02,0%,0.0,0.06,bruce ransom,,POSC-3020,2020
+POSC,3410,1.0,Quant Meth in Pol Sc,0.23,0.27,0.23,0.0,0.18,0%,0.0,0.05,steven vincent miller,,POSC-3410,2020
+POSC,3610,1.0,International Conflict,0.4,0.23,0.13,0.06,0.06,0%,0.0,0.11,tara elizabeth trask,,POSC-3610,2020
+POSC,3620,1.0,Intl Organizations,0.31,0.31,0.17,0.1,0.03,0%,0.0,0.07,zeynep taydas,,POSC-3620,2020
+POSC,3620,2.0,Intl Organizations,0.37,0.33,0.07,0.15,0.07,0%,0.0,0.0,zeynep taydas,,POSC-3620,2020
+POSC,3630,1.0,Us Foreign Policy,0.68,0.24,0.0,0.0,0.08,0%,0.0,0.0,vladimir matic,,POSC-3630,2020
+POSC,3630,2.0,Us Foreign Policy,0.18,0.52,0.12,0.0,0.12,0%,0.0,0.06,jeffrey scott peake,,POSC-3630,2020
+POSC,3750,1.0,European Integration,0.21,0.32,0.16,0.11,0.13,0%,0.0,0.08,katherine curtis,,POSC-3750,2020
+POSC,4050,1.0,The American Presidency,0.31,0.42,0.06,0.02,0.06,0%,0.0,0.13,adam warber,,POSC-4050,2020
+POSC,4090,2.0,Dir Stud in American Politi,0.79,0.0,0.05,0.0,0.0,0%,0.0,0.05,karyn jones,,POSC-4090,2020
+POSC,4210,1.0,Public Policy,0.58,0.15,0.04,0.04,0.12,0%,0.0,0.04,grant anthony allard,,POSC-4210,2020
+POSC,4230,1.0,Urban Politics,0.53,0.27,0.0,0.0,0.13,0%,0.0,0.0,bruce ransom,,POSC-4230,2020
+POSC,4360,1.0,Law Courts Politics,0.77,0.18,0.0,0.0,0.0,0%,0.0,0.0,joseph earl stewart,,POSC-4360,2020
+POSC,4360,2.0,Law Courts Politics,0.89,0.07,0.0,0.0,0.0,0%,0.0,0.02,joseph earl stewart,,POSC-4360,2020
+POSC,4370,1.0,Constitut Law: Rights & Lib,0.5,0.27,0.14,0.02,0.05,0%,0.0,0.02,kevin gregory vance,,POSC-4370,2020
+POSC,4370,2.0,Constitut Law: Rights & Lib,0.66,0.3,0.02,0.0,0.0,0%,0.0,0.02,kevin gregory vance,,POSC-4370,2020
+POSC,4420,1.0,Pol Parties & Elect,0.43,0.32,0.19,0.05,0.0,0%,0.0,0.0,laura olson,,POSC-4420,2020
+POSC,4490,1.0,Political Theory of Capitalis,0.38,0.52,0.05,0.0,0.05,0%,0.0,0.0,colin denby pearce,,POSC-4490,2020
+POSC,4490,2.0,Political Theory of Capitalis,0.62,0.3,0.05,0.0,0.03,0%,0.0,0.0,brandon turner,,POSC-4490,2020
+POSC,4500,1.0,Rev. Constitutionalism,0.75,0.08,0.08,0.0,0.08,0%,0.0,0.0, bradley thompson,,POSC-4500,2020
+POSC,4550,1.0,Pol Thght of American Fou,0.73,0.22,0.04,0.02,0.0,0%,0.0,0.0,jay hoffpauir,,POSC-4550,2020
+POSC,4760,1.0,Middle East Politics,0.84,0.11,0.0,0.0,0.0,0%,0.0,0.05,vladimir matic,,POSC-4760,2020
+POSC,4770,1.0,Chinese Politics,0.53,0.27,0.0,0.0,0.0,0%,0.0,0.07,xiaobo hu,,POSC-4770,2020
+POSC,4890,1.0,Populism,0.69,0.15,0.0,0.0,0.0,0%,0.0,0.15, rhodes-purdy,,POSC-4890,2020
+POST,9000,1.0,Prof Development Public P,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,laura olson,,POST-9000,2020
+PRTM,1980,1.0,Creative Inquiry in PRTM I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,denise anderson,,PRTM-1980,2020
+PRTM,2000,1.0,Profession & Practice in PR,0.86,0.09,0.05,0.0,0.0,0%,0.0,0.0,teresa tucker,,PRTM-2000,2020
+PRTM,2000,2.0,Profession & Practice in PR,0.79,0.16,0.05,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,,PRTM-2000,2020
+PRTM,2000,3.0,Profession & Practice in PR,0.68,0.26,0.05,0.0,0.0,0%,0.0,0.0,herbert chancellor,,PRTM-2000,2020
+PRTM,2000,4.0,Profession & Practice in PR,0.68,0.11,0.0,0.05,0.16,0%,0.0,0.0,jeffrey townsend,,PRTM-2000,2020
+PRTM,2000,5.0,Profession & Practice in PR,0.74,0.16,0.0,0.11,0.0,0%,0.0,0.0,thomas ray clanton,,PRTM-2000,2020
+PRTM,2060,1.0,Practicum I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,,PRTM-2060,2020
+PRTM,2070,1.0,Practicum II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,,PRTM-2070,2020
+PRTM,2070,2.0,Practicum II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,adam savedra,,PRTM-2070,2020
+PRTM,2110,1.0,Sts Play Rec Tourism,0.84,0.09,0.02,0.0,0.04,0%,0.0,0.01,matthew browning,,PRTM-2110,2020
+PRTM,2200,1.0,Foundations of PRTM,0.82,0.14,0.05,0.0,0.0,0%,0.0,0.0,teresa tucker,,PRTM-2200,2020
+PRTM,2200,2.0,Foundations of PRTM,0.53,0.42,0.05,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,,PRTM-2200,2020
+PRTM,2200,3.0,Foundations of PRTM,0.63,0.32,0.0,0.05,0.0,0%,0.0,0.0,herbert chancellor,,PRTM-2200,2020
+PRTM,2200,4.0,Foundations of PRTM,0.37,0.42,0.11,0.05,0.05,0%,0.0,0.0,jeffrey townsend,,PRTM-2200,2020
+PRTM,2200,5.0,Foundations of PRTM,0.65,0.29,0.06,0.0,0.0,0%,0.0,0.0,thomas ray clanton,,PRTM-2200,2020
+PRTM,2260,1.0,Fnd of Mgt Adm PRTM,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,teresa tucker,,PRTM-2260,2020
+PRTM,2260,2.0,Fnd of Mgt Adm PRTM,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,,PRTM-2260,2020
+PRTM,2260,3.0,Fnd of Mgt Adm PRTM,0.68,0.21,0.11,0.0,0.0,0%,0.0,0.0,herbert chancellor,,PRTM-2260,2020
+PRTM,2260,4.0,Fnd of Mgt Adm PRTM,0.58,0.32,0.0,0.05,0.05,0%,0.0,0.0,jeffrey townsend,,PRTM-2260,2020
+PRTM,2260,5.0,Fnd of Mgt Adm PRTM,0.74,0.21,0.05,0.0,0.0,0%,0.0,0.0,thomas ray clanton,,PRTM-2260,2020
+PRTM,2290,1.0,Competency Integration in,0.68,0.23,0.09,0.0,0.0,0%,0.0,0.0,teresa tucker,,PRTM-2290,2020
+PRTM,2290,2.0,Competency Integration in,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,,PRTM-2290,2020
+PRTM,2290,3.0,Competency Integration in,0.63,0.11,0.16,0.11,0.0,0%,0.0,0.0,herbert chancellor,,PRTM-2290,2020
+PRTM,2290,4.0,Competency Integration in,0.42,0.37,0.11,0.0,0.11,0%,0.0,0.0,jeffrey townsend,,PRTM-2290,2020
+PRTM,2290,5.0,Competency Integration in,0.58,0.26,0.05,0.11,0.0,0%,0.0,0.0,thomas ray clanton,,PRTM-2290,2020
+PRTM,3050,1.0,Safety/Risk Mgt PRTM,0.47,0.27,0.2,0.0,0.0,0%,0.0,0.07,alexsandra dubin,,PRTM-3050,2020
+PRTM,3070,2.0,Facility Operations,0.77,0.13,0.1,0.0,0.0,0%,0.0,0.0,raymond dunham,,PRTM-3070,2020
+PRTM,3200,1.0,Recreation Policy,0.55,0.18,0.09,0.0,0.05,0%,0.0,0.14,matthew brownlee,,PRTM-3200,2020
+PRTM,3220,1.0,Facilitation Techniques in,0.71,0.19,0.1,0.0,0.0,0%,0.0,0.0,stephen lewis,,PRTM-3220,2020
+PRTM,3240,1.0,Assessment & Planning in,0.48,0.38,0.1,0.05,0.0,0%,0.0,0.0,deborah anne tysor,,PRTM-3240,2020
+PRTM,3300,1.0,Visit Ser & Interp,0.42,0.26,0.21,0.05,0.05,0%,0.0,0.0,harper aby lat sene lat,,PRTM-3300,2020
+PRTM,3420,1.0,Intro to Tourism,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,ellen wamilika koppa,,PRTM-3420,2020
+PRTM,3430,1.0,Spl Asp of Tourist B,0.62,0.33,0.0,0.0,0.0,0%,0.0,0.05,william norman,,PRTM-3430,2020
+PRTM,3460,1.0,Heritage Tourism,0.4,0.33,0.13,0.0,0.07,0%,0.0,0.0,gregory ramshaw,,PRTM-3460,2020
+PRTM,3470,1.0,Sport Tourism,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,felipe tobar,,PRTM-3470,2020
+PRTM,3520,1.0,Camp Org and Admin,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,alexsandra dubin,,PRTM-3520,2020
+PRTM,3600,1.0,Recreation & Amateur Spo,0.36,0.18,0.18,0.0,0.09,0%,0.0,0.09,skye arthur-banning,,PRTM-3600,2020
+PRTM,3920,1.0,Special Event Managemen,0.96,0.0,0.04,0.0,0.0,0%,0.0,0.0,kenneth backman,,PRTM-3920,2020
+PRTM,3920,2.0,Special Event Managemen,0.83,0.1,0.05,0.03,0.0,0%,0.0,0.0,kenneth backman,,PRTM-3920,2020
+PRTM,4030,1.0,Elem of Rec/Pk Plan,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,samuel gaines,,PRTM-4030,2020
+PRTM,4040,1.0,Field Training I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,,PRTM-4040,2020
+PRTM,4050,1.0,Field Training II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,,PRTM-4050,2020
+PRTM,4210,1.0,Rec Fin Resc Mgt,0.68,0.21,0.09,0.02,0.0,0%,0.0,0.0,robert brookover,,PRTM-4210,2020
+PRTM,4220,2.0,Management of RT Service,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,deborah anne tysor,,PRTM-4220,2020
+PRTM,4230,1.0,Adaptive Sports & Recreati,0.56,0.17,0.11,0.11,0.06,0%,0.0,0.0,jasmine townsend,,PRTM-4230,2020
+PRTM,4450,1.0,Conventions,0.79,0.14,0.0,0.0,0.0,0%,0.0,0.07,lauren townson,,PRTM-4450,2020
+PRTM,4470,1.0,Perspect Intl Travel,0.89,0.0,0.05,0.0,0.0,0%,0.0,0.05,sheila backman,,PRTM-4470,2020
+PRTM,4510,1.0,Seminar in CRSCM,0.5,0.3,0.1,0.05,0.03,0%,0.0,0.03,iryna sharaievska,,PRTM-4510,2020
+PRTM,4540,1.0,Trends in Sport Mgt,0.75,0.13,0.06,0.0,0.0,0%,0.0,0.06,skye arthur-banning,,PRTM-4540,2020
+PRTM,4550,1.0,Adv Program Planning,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,mariela fernandez,,PRTM-4550,2020
+PRTM,4740,2.0,Adv Rec Resource Mgt,0.81,0.05,0.14,0.0,0.0,0%,0.0,0.0,benjamin fowler,,PRTM-4740,2020
+PRTM,8070,3.0,Human Dimen of Rec Beha,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,john adam beeco,,PRTM-8070,2020
+PRTM,8080,2.0,Behavioral Aspects,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,lauren duffy,,PRTM-8080,2020
+PRTM,8710,1.0,Applied Research in Rec Th,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,brandi crowe,,PRTM-8710,2020
+PRTM,8720,1.0,Adv Facilitation Techniq in,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,brandi crowe,,PRTM-8720,2020
+PRTM,8750,1.0,Program Plan & Consult in,0.64,0.27,0.0,0.0,0.0,0%,0.0,0.0,stephen lewis,,PRTM-8750,2020
+PRTM,9000,11.0,Adv Data Analysis in PRTM,0.5,0.38,0.0,0.0,0.0,0%,0.0,0.13,ryan joseph gagnon,,PRTM-9000,2020
+PRTM,9100,1.0,Research Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brett wright,,PRTM-9100,2020
+PRTM,9110,2.0,Classroom Management,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gwynn powell,,PRTM-9110,2020
+PSYC,2010,1.0,Intro to Psychology,0.33,0.34,0.19,0.03,0.01,0%,0.0,0.06,jo jorgensen,,PSYC-2010,2020
+PSYC,2010,2.0,Intro to Psychology,0.28,0.33,0.21,0.08,0.03,0%,0.0,0.03,jo jorgensen,,PSYC-2010,2020
+PSYC,2010,3.0,Intro to Psychology,0.25,0.33,0.22,0.06,0.06,0%,0.0,0.08,edwin brainerd,,PSYC-2010,2020
+PSYC,2010,4.0,Intro to Psychology,0.77,0.19,0.04,0.0,0.0,0%,0.0,0.0,mary taylor,,PSYC-2010,2020
+PSYC,2010,5.0,Intro to Psychology,0.63,0.27,0.03,0.01,0.04,0%,0.0,0.02,chong hyon pak,,PSYC-2010,2020
+PSYC,2010,6.0,Intro to Psychology,0.66,0.19,0.08,0.05,0.02,0%,0.0,0.0,chong hyon pak,,PSYC-2010,2020
+PSYC,2010,7.0,Intro to Psychology,0.51,0.33,0.09,0.03,0.01,0%,0.0,0.03,fred switzer,,PSYC-2010,2020
+PSYC,2030,1.0,Fundamentals of Psych Sci,0.62,0.25,0.07,0.03,0.02,0%,0.0,0.02,fred switzer,,PSYC-2030,2020
+PSYC,3060,1.0,Human Sexual Behavior,0.58,0.22,0.11,0.03,0.03,0%,0.0,0.03,bruce michael king,,PSYC-3060,2020
+PSYC,3090,100.0,Intro Experimental Psychol,0.44,0.38,0.13,0.02,0.01,0%,0.0,0.03,jennifer bailey bisson,,PSYC-3090,2020
+PSYC,3090,200.0,Intro Experimental Psychol,0.16,0.53,0.28,0.0,0.0,0%,0.0,0.03,eric mckibben,,PSYC-3090,2020
+PSYC,3090,300.0,Intro Experimental Psychol,0.48,0.39,0.1,0.0,0.0,0%,0.0,0.03,alexander moore,,PSYC-3090,2020
+PSYC,3100,100.0,Advanced Experimental Ps,0.71,0.21,0.03,0.03,0.03,0%,0.0,0.0,peggy jean tyler,,PSYC-3100,2020
+PSYC,3100,220.0,Advanced Experimental Ps,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,thomas britt,,PSYC-3100,2020
+PSYC,3100,230.0,Advanced Experimental Ps,0.68,0.26,0.05,0.0,0.0,0%,0.0,0.0,william volante,,PSYC-3100,2020
+PSYC,3100,240.0,Advanced Experimental Ps,0.42,0.37,0.16,0.0,0.05,0%,0.0,0.0,william volante,,PSYC-3100,2020
+PSYC,3100,250.0,Advanced Experimental Ps,0.57,0.33,0.05,0.0,0.0,0%,0.0,0.05,sarah mae sanborn,,PSYC-3100,2020
+PSYC,3100,260.0,Advanced Experimental Ps,0.37,0.53,0.05,0.0,0.0,0%,0.0,0.0,leo gugerty,,PSYC-3100,2020
+PSYC,3100,270.0,Advanced Experimental Ps,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,benjamin stephens,,PSYC-3100,2020
+PSYC,3100,280.0,Advanced Experimental Ps,0.74,0.16,0.11,0.0,0.0,0%,0.0,0.0,martha thompson,,PSYC-3100,2020
+PSYC,3100,290.0,Advanced Experimental Ps,0.42,0.42,0.0,0.11,0.0,0%,0.0,0.0,kaileigh angela byrne,,PSYC-3100,2020
+PSYC,3210,1.0,Psychology of Music,0.52,0.2,0.24,0.04,0.0,0%,0.0,0.0,claudio cantalupo,,PSYC-3210,2020
+PSYC,3240,1.0,Physiological Psych,0.64,0.19,0.09,0.03,0.04,0%,0.0,0.01,claudio cantalupo,,PSYC-3240,2020
+PSYC,3240,2.0,Physiological Psych,0.5,0.31,0.09,0.04,0.04,0%,0.0,0.01,claudio cantalupo,,PSYC-3240,2020
+PSYC,3240,3.0,Physiological Psych,0.53,0.31,0.1,0.03,0.02,0%,0.0,0.0,claudio cantalupo,,PSYC-3240,2020
+PSYC,3240,4.0,Physiological Psych,0.43,0.38,0.1,0.01,0.01,0%,0.0,0.06,june pilcher,,PSYC-3240,2020
+PSYC,3330,1.0,Cognitive Psych,0.55,0.32,0.06,0.04,0.03,0%,0.0,0.0,dawn marie sarno,,PSYC-3330,2020
+PSYC,3330,2.0,Cognitive Psych,0.63,0.23,0.08,0.03,0.03,0%,0.0,0.0,kathryn lucaites,,PSYC-3330,2020
+PSYC,3340,1.0,Cognitive Psych Lab,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,hannah solini,,PSYC-3340,2020
+PSYC,3340,2.0,Cognitive Psych Lab,0.76,0.19,0.0,0.0,0.0,0%,0.0,0.0,hannah solini,,PSYC-3340,2020
+PSYC,3400,1.0,Lifespan Developmental Ps,0.38,0.39,0.16,0.01,0.03,0%,0.0,0.03,pamela alley,,PSYC-3400,2020
+PSYC,3400,2.0,Lifespan Developmental Ps,0.33,0.43,0.11,0.09,0.02,0%,0.0,0.02,pamela alley,,PSYC-3400,2020
+PSYC,3400,3.0,Lifespan Developmental Ps,0.73,0.17,0.08,0.01,0.0,0%,0.0,0.01,sarah mae sanborn,,PSYC-3400,2020
+PSYC,3520,1.0,Social Psychology,0.88,0.09,0.02,0.01,0.0,0%,0.0,0.0,ceren gunsoy,,PSYC-3520,2020
+PSYC,3520,902.0,Social Psychology (HON),0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,robin marie kowalski,True,PSYC-3520,2020
+PSYC,3570,1.0,Psychology and Culture,0.73,0.17,0.06,0.02,0.01,0%,0.0,0.0,ceren gunsoy,,PSYC-3570,2020
+PSYC,3640,1.0,Industrial Psych,0.43,0.46,0.07,0.04,0.0,0%,0.0,0.0,eric mckibben,,PSYC-3640,2020
+PSYC,3640,2.0,Industrial Psych,0.75,0.12,0.06,0.0,0.06,0%,0.0,0.01,joseph ligato,,PSYC-3640,2020
+PSYC,3680,1.0,Organizational Psych,0.45,0.51,0.02,0.0,0.02,0%,0.0,0.0,chloe wilson,,PSYC-3680,2020
+PSYC,3700,1.0,Personality,0.54,0.34,0.1,0.0,0.03,0%,0.0,0.0,john robert hester,,PSYC-3700,2020
+PSYC,3830,1.0,Abnormal Psychology,0.38,0.41,0.12,0.09,0.0,0%,0.0,0.0,pamela alley,,PSYC-3830,2020
+PSYC,3830,2.0,Abnormal Psychology,0.43,0.23,0.14,0.11,0.06,0%,0.0,0.03,pamela alley,,PSYC-3830,2020
+PSYC,3890,1.0,Psychology of Religion,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,zhuo chen,,PSYC-3890,2020
+PSYC,4080,901.0,Women and Psychology,0.64,0.2,0.08,0.0,0.04,0%,0.0,0.04,robin marie kowalski,,PSYC-4080,2020
+PSYC,4150,1.0,Systems and Theories,0.51,0.31,0.11,0.03,0.0,0%,0.0,0.03,edwin brainerd,,PSYC-4150,2020
+PSYC,4150,2.0,Systems and Theories,0.5,0.25,0.08,0.08,0.06,0%,0.0,0.03,edwin brainerd,,PSYC-4150,2020
+PSYC,4220,1.0,Perception,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,christopher pagano,,PSYC-4220,2020
+PSYC,4350,1.0,Human Factors,0.3,0.48,0.04,0.0,0.0,0%,0.0,0.13,dustin souders,,PSYC-4350,2020
+PSYC,4430,1.0,Infant & Child Dev,0.71,0.26,0.03,0.0,0.0,0%,0.0,0.0,sarah mae sanborn,,PSYC-4430,2020
+PSYC,4800,1.0,Health Psychology,0.65,0.31,0.04,0.0,0.0,0%,0.0,0.0,james mccubbin,,PSYC-4800,2020
+PSYC,4800,2.0,Health Psychology,0.8,0.16,0.04,0.0,0.0,0%,0.0,0.0,james mccubbin,,PSYC-4800,2020
+PSYC,4820,1.0,Positive Psychology,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,cynthia pury s,,PSYC-4820,2020
+PSYC,4880,1.0,Psychotherapy,0.6,0.12,0.12,0.0,0.0,0%,0.0,0.08,heidi marie zinzow,,PSYC-4880,2020
+PSYC,4890,1.0,Sport Psychology,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,eric mckibben,,PSYC-4890,2020
+PSYC,4890,2.0,Cross-Cultural Human Dev,0.55,0.23,0.09,0.09,0.0,0%,0.0,0.0,susan limber,,PSYC-4890,2020
+PSYC,4930,100.0,Pract Clinical Psych,0.81,0.06,0.0,0.0,0.0,0%,0.0,0.13,lucinda quick,,PSYC-4930,2020
+PSYC,4930,200.0,Pract Clinical Psych,0.88,0.06,0.0,0.0,0.06,0%,0.0,0.0,heidi marie zinzow,,PSYC-4930,2020
+PSYC,4970,919.0,Directed Studies,0.89,0.02,0.0,0.0,0.0,0%,0.0,0.05,karyn jones,,PSYC-4970,2020
+PSYC,8100,1.0,Research Design I,0.76,0.21,0.0,0.0,0.0,0%,0.0,0.03,patrick rosopa,,PSYC-8100,2020
+PSYC,8220,1.0,Percept & Perform,0.75,0.19,0.0,0.0,0.0,0%,0.0,0.06,richard tyrrell,,PSYC-8220,2020
+RED,8010,1.0,Market Analysis,0.67,0.22,0.06,0.0,0.0,0%,0.0,0.06,robert benedict,,RED-8010,2020
+RED,8020,1.0,Development Tour,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert benedict,,RED-8020,2020
+RED,8100,1.0,Real Est Roundtable,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,robert benedict,,RED-8100,2020
+RED,8130,1.0,Strat in Real Estate,0.62,0.31,0.08,0.0,0.0,0%,0.0,0.0,kimbrell cary hughes,,RED-8130,2020
+RED,8890,1.0,Selected Topics-Adv. Fin.,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,larry bradley harvey,,RED-8890,2020
+REL,1010,1.0,Intro to Religion,0.58,0.32,0.0,0.05,0.05,0%,0.0,0.0,peter cohen,,REL-1010,2020
+REL,1010,2.0,Intro to Religion,0.45,0.41,0.05,0.0,0.09,0%,0.0,0.0,peter cohen,,REL-1010,2020
+REL,1010,3.0,Intro to Religion,0.79,0.18,0.0,0.0,0.03,0%,0.0,0.0,peter cohen,,REL-1010,2020
+REL,1020,2.0,World Religions,0.56,0.29,0.12,0.03,0.0,0%,0.0,0.0,robert stephens,,REL-1020,2020
+REL,1020,3.0,World Religions,0.51,0.26,0.14,0.0,0.0,0%,0.0,0.09,robert stephens,,REL-1020,2020
+REL,1020,4.0,World Religions,0.47,0.5,0.03,0.0,0.0,0%,0.0,0.0,robert stephens,,REL-1020,2020
+REL,3010,1.0,Old Testament,0.56,0.21,0.12,0.03,0.0,0%,0.0,0.09,john thames,,REL-3010,2020
+REL,3060,1.0,Judaism,0.52,0.21,0.07,0.0,0.0,0%,0.0,0.21,john thames,,REL-3060,2020
+REL,3070,1.0,The Christian Tradition,0.34,0.52,0.14,0.0,0.0,0%,0.0,0.0,brett patterson,,REL-3070,2020
+REL,3100,1.0,History of Religion in the U,0.5,0.33,0.11,0.0,0.06,0%,0.0,0.0,elizabeth jemison,,REL-3100,2020
+REL,3110,1.0,African American Rel,0.54,0.17,0.13,0.0,0.0,0%,0.0,0.13,elizabeth jemison,,REL-3110,2020
+REL,3120,1.0,Hinduism,0.29,0.29,0.14,0.14,0.0,0%,0.0,0.14,robert stephens,,REL-3120,2020
+REL,4210,1.0,Koine Greek of the New Te,0.5,0.0,0.13,0.19,0.13,0%,0.0,0.06,benjamin white,,REL-4210,2020
+RUD,8610,1.0,Urban Design Seminar I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0, wortham-galvin,,RUD-8610,2020
+RUSS,3400,1.0,19th C Russ Culture,0.58,0.29,0.08,0.0,0.0,0%,0.0,0.0,olga volkova,,RUSS-3400,2020
+RUSS,3610,1.0,Russn Lit Since 1910,0.52,0.35,0.13,0.0,0.0,0%,0.0,0.0,olga volkova,,RUSS-3610,2020
+SOC,2010,1.0,Introduction to Sociology,0.8,0.17,0.01,0.0,0.01,0%,0.0,0.02,carolyn coffman,,SOC-2010,2020
+SOC,2010,2.0,Introduction to Sociology,0.58,0.34,0.08,0.0,0.0,0%,0.0,0.0,jennifer holland,,SOC-2010,2020
+SOC,2010,3.0,Introduction to Sociology,0.8,0.18,0.01,0.0,0.01,0%,0.0,0.0,carolyn coffman,,SOC-2010,2020
+SOC,2010,4.0,Introduction to Sociology,0.9,0.08,0.01,0.0,0.0,0%,0.0,0.01, mannheimer,,SOC-2010,2020
+SOC,2010,5.0,Introduction to Sociology,0.77,0.15,0.04,0.02,0.02,0%,0.0,0.0, mcdonough,,SOC-2010,2020
+SOC,2010,6.0,Introduction to Sociology,0.75,0.16,0.05,0.02,0.01,0%,0.0,0.02, mcdonough,,SOC-2010,2020
+SOC,2010,7.0,Introduction to Sociology,0.8,0.1,0.04,0.0,0.02,0%,0.0,0.04,thomas maher,,SOC-2010,2020
+SOC,2040,1.0,Prof Dev for Sociology Maj,0.35,0.26,0.13,0.09,0.13,0%,0.0,0.04, catherine mobley,,SOC-2040,2020
+SOC,3020,1.0,Research Methods I,0.59,0.23,0.07,0.05,0.02,0%,0.0,0.05,thomas maher,,SOC-3020,2020
+SOC,3020,2.0,Research Methods I,0.32,0.5,0.11,0.03,0.03,0%,0.0,0.03,miao li,,SOC-3020,2020
+SOC,3040,1.0,Social Research Methods II,0.28,0.38,0.1,0.1,0.07,0%,0.0,0.07,ye luo,,SOC-3040,2020
+SOC,3040,2.0,Social Research Methods II,0.33,0.56,0.11,0.0,0.0,0%,0.0,0.0,william haller,,SOC-3040,2020
+SOC,3110,1.0,The Family,0.84,0.1,0.04,0.0,0.02,0%,0.0,0.0,carolyn coffman,,SOC-3110,2020
+SOC,3600,1.0,Class & Poverty,0.57,0.28,0.09,0.04,0.0,0%,0.0,0.02,kenneth robinson,,SOC-3600,2020
+SOC,3910,1.0,Soc of Deviance,0.58,0.29,0.05,0.04,0.02,0%,0.0,0.02, mcdonough,,SOC-3910,2020
+SOC,3940,1.0,Sociology of Mental Illness,0.88,0.04,0.0,0.0,0.0,0%,0.0,0.02,james rosenberger,,SOC-3940,2020
+SOC,4030,1.0,Environmental Sociology,0.5,0.33,0.08,0.04,0.0,0%,0.0,0.04, catherine mobley,,SOC-4030,2020
+SOC,4040,1.0,Soc Theory,0.44,0.33,0.11,0.06,0.06,0%,0.0,0.0,matthew costello,,SOC-4040,2020
+SOC,4140,1.0,Policy&Social Change,0.6,0.31,0.1,0.0,0.0,0%,0.0,0.0,jennifer holland,,SOC-4140,2020
+SOC,4440,1.0,Sociology of Educ,0.73,0.16,0.02,0.0,0.02,0%,0.0,0.02, mannheimer,,SOC-4440,2020
+SOC,4600,1.0,Race & Ethnicity,0.86,0.08,0.06,0.0,0.0,0%,0.0,0.0, mannheimer,,SOC-4600,2020
+SOC,4610,1.0,Sex & Gender,0.67,0.24,0.03,0.0,0.03,0%,0.0,0.03,carolyn coffman,,SOC-4610,2020
+SOC,4710,1.0,World Population and Soci,0.43,0.36,0.0,0.07,0.0,0%,0.0,0.14,ye luo,,SOC-4710,2020
+SOC,8120,1.0,Social Stratification,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.1,william haller,,SOC-8120,2020
+SOC,8970,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,natallia sianko,,SOC-8970,2020
+SPAN,1010,1.0,Elementary Spanish,0.71,0.25,0.04,0.0,0.0,0%,0.0,0.0,stephanie morris,,SPAN-1010,2020
+SPAN,1010,2.0,Elementary Spanish,0.71,0.21,0.08,0.0,0.0,0%,0.0,0.0,stephanie morris,,SPAN-1010,2020
+SPAN,1010,3.0,Elementary Spanish,0.42,0.29,0.17,0.04,0.0,0%,0.0,0.08,rosa pillcurima,,SPAN-1010,2020
+SPAN,1020,1.0,Elementary Spanish,0.39,0.43,0.13,0.0,0.0,0%,0.0,0.04,rosa pillcurima,,SPAN-1020,2020
+SPAN,1020,2.0,Elementary Spanish,0.48,0.35,0.04,0.0,0.0,0%,0.0,0.13,debra williamson,,SPAN-1020,2020
+SPAN,1020,3.0,Elementary Spanish,0.48,0.3,0.17,0.0,0.04,0%,0.0,0.0,yezid flores,,SPAN-1020,2020
+SPAN,1020,4.0,Elementary Spanish,0.58,0.33,0.04,0.0,0.04,0%,0.0,0.0,yezid flores,,SPAN-1020,2020
+SPAN,1020,5.0,Elementary Spanish,0.86,0.0,0.0,0.0,0.0,0%,0.0,0.14,liliana hernandez,,SPAN-1020,2020
+SPAN,1020,6.0,Elementary Spanish,0.27,0.53,0.13,0.07,0.0,0%,0.0,0.0,valderramos cruz,,SPAN-1020,2020
+SPAN,1020,8.0,Elementary Spanish,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,valderramos cruz,,SPAN-1020,2020
+SPAN,1020,9.0,Elementary Spanish,0.52,0.43,0.05,0.0,0.0,0%,0.0,0.0,yezid flores,,SPAN-1020,2020
+SPAN,1020,10.0,Elementary Spanish,0.86,0.09,0.05,0.0,0.0,0%,0.0,0.0,liliana hernandez,,SPAN-1020,2020
+SPAN,1020,13.0,Elementary Spanish,0.26,0.43,0.17,0.09,0.0,0%,0.0,0.04,melva persico,,SPAN-1020,2020
+SPAN,2010,1.0,Intermediate Spanish,0.45,0.32,0.05,0.0,0.05,0%,0.0,0.14,debra williamson,,SPAN-2010,2020
+SPAN,2010,2.0,Intermediate Spanish,0.48,0.43,0.05,0.0,0.0,0%,0.0,0.05,debra williamson,,SPAN-2010,2020
+SPAN,2010,3.0,Intermediate Spanish,0.71,0.04,0.17,0.04,0.0,0%,0.0,0.04,ellory schmucker,,SPAN-2010,2020
+SPAN,2010,4.0,Intermediate Spanish,0.65,0.26,0.0,0.0,0.09,0%,0.0,0.0,ellory schmucker,,SPAN-2010,2020
+SPAN,2010,7.0,Intermediate Spanish,0.67,0.13,0.13,0.04,0.0,0%,0.0,0.04,ellory schmucker,,SPAN-2010,2020
+SPAN,2010,8.0,Intermediate Spanish,0.57,0.33,0.05,0.0,0.0,0%,0.0,0.05,debra williamson,,SPAN-2010,2020
+SPAN,2010,9.0,Intermediate Spanish,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,liliana hernandez,,SPAN-2010,2020
+SPAN,2010,10.0,Intermediate Spanish,0.5,0.46,0.04,0.0,0.0,0%,0.0,0.0,vieyra daniel garcia,,SPAN-2010,2020
+SPAN,2010,11.0,Intermediate Spanish,0.43,0.43,0.04,0.0,0.0,0%,0.0,0.09,vieyra daniel garcia,,SPAN-2010,2020
+SPAN,2010,12.0,Intermediate Spanish,0.75,0.13,0.04,0.04,0.0,0%,0.0,0.04,ellory schmucker,,SPAN-2010,2020
+SPAN,2010,13.0,Intermediate Spanish,0.79,0.08,0.08,0.0,0.04,0%,0.0,0.0,liliana hernandez,,SPAN-2010,2020
+SPAN,2010,14.0,Intermediate Spanish,0.55,0.18,0.0,0.0,0.09,0%,0.0,0.18,valderramos cruz,,SPAN-2010,2020
+SPAN,2010,15.0,Intermediate Spanish,0.61,0.3,0.04,0.0,0.0,0%,0.0,0.04,valderramos cruz,,SPAN-2010,2020
+SPAN,2010,16.0,Intermediate Spanish,0.57,0.26,0.09,0.0,0.0,0%,0.0,0.09,yezid flores,,SPAN-2010,2020
+SPAN,2010,17.0,Intermediate Spanish,0.37,0.37,0.26,0.0,0.0,0%,0.0,0.0,nora arostegui logue,,SPAN-2010,2020
+SPAN,2010,18.0,Intermediate Spanish,0.57,0.3,0.04,0.04,0.0,0%,0.0,0.04,nora arostegui logue,,SPAN-2010,2020
+SPAN,2010,28.0,Intermediate Spanish,0.4,0.4,0.1,0.1,0.0,0%,0.0,0.0,yezid flores,,SPAN-2010,2020
+SPAN,2020,2.0,Intermediate Spanish,0.35,0.25,0.15,0.05,0.1,0%,0.0,0.1,melva persico,,SPAN-2020,2020
+SPAN,2020,4.0,Intermediate Spanish,0.52,0.22,0.17,0.04,0.0,0%,0.0,0.04,rodriguez garcia,,SPAN-2020,2020
+SPAN,2020,5.0,Intermediate Spanish,0.83,0.08,0.04,0.0,0.04,0%,0.0,0.0,mercedes tejera,,SPAN-2020,2020
+SPAN,2020,6.0,Intermediate Spanish,0.5,0.25,0.04,0.0,0.0,0%,0.0,0.21,rosa pillcurima,,SPAN-2020,2020
+SPAN,2020,7.0,Intermediate Spanish,0.63,0.21,0.0,0.08,0.0,0%,0.0,0.08,rosa pillcurima,,SPAN-2020,2020
+SPAN,2020,8.0,Intermediate Spanish,0.5,0.35,0.1,0.05,0.0,0%,0.0,0.0,ana paula  miller e,,SPAN-2020,2020
+SPAN,2020,9.0,Intermediate Spanish,0.33,0.33,0.24,0.0,0.0,0%,0.0,0.1,ana paula  miller e,,SPAN-2020,2020
+SPAN,2020,10.0,Intermediate Spanish,0.62,0.19,0.1,0.0,0.0,0%,0.0,0.1,ana paula  miller e,,SPAN-2020,2020
+SPAN,2020,11.0,Intermediate Spanish,0.43,0.33,0.05,0.1,0.0,0%,0.0,0.1,melva persico,,SPAN-2020,2020
+SPAN,2020,13.0,Intermediate Spanish,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,nora arostegui logue,,SPAN-2020,2020
+SPAN,2020,14.0,Intermediate Spanish,0.58,0.33,0.0,0.0,0.08,0%,0.0,0.0,nora arostegui logue,,SPAN-2020,2020
+SPAN,2020,15.0,Intermediate Spanish,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,mercedes tejera,,SPAN-2020,2020
+SPAN,2020,16.0,Intermediate Spanish,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,mercedes tejera,,SPAN-2020,2020
+SPAN,3020,1.0,Intermed Span Grammar,0.41,0.41,0.09,0.0,0.0,0%,0.0,0.09,vieyra daniel garcia,,SPAN-3020,2020
+SPAN,3020,2.0,Intermed Span Grammar,0.68,0.18,0.0,0.0,0.0,0%,0.0,0.14,george palacios,,SPAN-3020,2020
+SPAN,3020,3.0,Intermed Span Grammar,0.67,0.17,0.0,0.0,0.04,0%,0.0,0.13,vieyra daniel garcia,,SPAN-3020,2020
+SPAN,3020,4.0,Intermed Span Grammar,0.29,0.57,0.07,0.0,0.07,0%,0.0,0.0,melva persico,,SPAN-3020,2020
+SPAN,3040,1.0,Intro Hispanic Literary For,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,graciela tissera,,SPAN-3040,2020
+SPAN,3040,2.0,Intro Hispanic Literary For,0.42,0.33,0.17,0.08,0.0,0%,0.0,0.0,rodriguez garcia,,SPAN-3040,2020
+SPAN,3050,1.0,Intermed Span Convers/Co,0.32,0.47,0.16,0.0,0.0,0%,0.0,0.05,rodriguez garcia,,SPAN-3050,2020
+SPAN,3050,2.0,Intermed Span Convers/Co,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,andrea naranjo,,SPAN-3050,2020
+SPAN,3050,3.0,Intermed Span Convers/Co,0.61,0.09,0.04,0.0,0.0,0%,0.0,0.26,vieyra daniel garcia,,SPAN-3050,2020
+SPAN,3060,1.0,Span Comp for Bus,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,andrea naranjo,,SPAN-3060,2020
+SPAN,3070,1.0,The Hispanic World: Spain,0.74,0.16,0.0,0.0,0.05,0%,0.0,0.05,raquel anido,,SPAN-3070,2020
+SPAN,3080,1.0,The Hispanic World: Latin,0.7,0.09,0.09,0.0,0.09,0%,0.0,0.0,george palacios,,SPAN-3080,2020
+SPAN,3130,1.0,Span Lit Survey I,0.28,0.44,0.17,0.0,0.0,0%,0.0,0.11, rojas-de-massei,,SPAN-3130,2020
+SPAN,3140,1.0,Hispanic Linguistics,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,daniel smith,,SPAN-3140,2020
+SPAN,3150,2.0,Spanish for Health Prof,0.86,0.1,0.05,0.0,0.0,0%,0.0,0.0,riquelme judez,,SPAN-3150,2020
+SPAN,3180,1.0,Spanish Through Culture,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,salvador oropesa,,SPAN-3180,2020
+SPAN,4010,1.0,New Spanish Fiction,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,graciela tissera,,SPAN-4010,2020
+SPAN,4060,1.0,Narrative Fiction,0.33,0.47,0.07,0.07,0.0,0%,0.0,0.07, rojas-de-massei,,SPAN-4060,2020
+SPAN,4070,1.0,Hispanic Film,0.8,0.12,0.0,0.04,0.04,0%,0.0,0.0,raquel anido,,SPAN-4070,2020
+SPAN,4160,1.0,Spanish for Int'l Business II,0.73,0.09,0.0,0.0,0.18,0%,0.0,0.0,andrea naranjo,,SPAN-4160,2020
+SPAN,4190,1.0,Health & Hispanic Commu,0.7,0.25,0.0,0.0,0.0,0%,0.0,0.05,peralta arelis moore,,SPAN-4190,2020
+STAT,2220,1.0,Statistics in Everyday Life,0.33,0.23,0.23,0.12,0.04,0%,0.0,0.05,james espey,,STAT-2220,2020
+STAT,2220,2.0,Statistics in Everyday Life,0.25,0.41,0.23,0.05,0.02,0%,0.0,0.04,james espey,,STAT-2220,2020
+STAT,2220,3.0,Statistics in Everyday Life,0.29,0.34,0.16,0.12,0.08,0%,0.0,0.03,james espey,,STAT-2220,2020
+STAT,2220,4.0,Statistics in Everyday Life,0.24,0.43,0.23,0.09,0.01,0%,0.0,0.0,james espey,,STAT-2220,2020
+STAT,2220,5.0,Statistics in Everyday Life,0.19,0.32,0.29,0.14,0.06,0%,0.0,0.0, martinez-dawson,,STAT-2220,2020
+STAT,2220,6.0,Statistics in Everyday Life,0.24,0.39,0.2,0.09,0.05,0%,0.0,0.04, martinez-dawson,,STAT-2220,2020
+STAT,2220,7.0,Statistics in Everyday Life,0.3,0.24,0.28,0.1,0.05,0%,0.0,0.04, martinez-dawson,,STAT-2220,2020
+STAT,2300,1.0,Statistical Methods I,0.2,0.23,0.27,0.15,0.15,0%,0.0,0.0,anna marie vagnozzi,,STAT-2300,2020
+STAT,2300,2.0,Statistical Methods I,0.33,0.34,0.17,0.08,0.03,0%,0.0,0.04,paran norton,,STAT-2300,2020
+STAT,2300,3.0,Statistical Methods I,0.39,0.3,0.15,0.07,0.05,0%,0.0,0.03,paran norton,,STAT-2300,2020
+STAT,2300,4.0,Statistical Methods I,0.28,0.26,0.24,0.07,0.1,0%,0.0,0.05, erwin walker,,STAT-2300,2020
+STAT,2300,5.0,Statistical Methods I,0.23,0.4,0.19,0.09,0.06,0%,0.0,0.03, erwin walker,,STAT-2300,2020
+STAT,2300,6.0,Statistical Methods I,0.31,0.3,0.2,0.08,0.04,0%,0.0,0.07,thomas demarco,,STAT-2300,2020
+STAT,2300,100.0,Statistical Methods I (HON,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,paran norton,True,STAT-2300,2020
+STAT,3090,1.0,Introductory Business Stat,0.23,0.3,0.35,0.0,0.09,0%,0.0,0.02,fun choi john chan john,,STAT-3090,2020
+STAT,3090,2.0,Introductory Business Stat,0.22,0.33,0.26,0.13,0.02,0%,0.0,0.04,trevor camper,,STAT-3090,2020
+STAT,3090,3.0,Introductory Business Stat,0.62,0.22,0.09,0.04,0.0,0%,0.0,0.02,anna marie vagnozzi,,STAT-3090,2020
+STAT,3090,4.0,Introductory Business Stat,0.44,0.36,0.16,0.0,0.02,0%,0.0,0.02, jayasekara,,STAT-3090,2020
+STAT,3090,5.0,Introductory Business Stat,0.41,0.17,0.26,0.09,0.04,0%,0.0,0.02,tyler melton,,STAT-3090,2020
+STAT,3090,6.0,Introductory Business Stat,0.37,0.28,0.17,0.07,0.04,0%,0.0,0.07,sean ingimarson,,STAT-3090,2020
+STAT,3090,7.0,Introductory Business Stat,0.35,0.24,0.24,0.04,0.09,0%,0.0,0.04,yangyi li,,STAT-3090,2020
+STAT,3090,8.0,Introductory Business Stat,0.34,0.22,0.22,0.1,0.1,0%,0.0,0.02,seyed hamid nazari,,STAT-3090,2020
+STAT,3090,9.0,Introductory Business Stat,0.42,0.18,0.11,0.13,0.09,0%,0.0,0.07,na guo,,STAT-3090,2020
+STAT,3090,10.0,Introductory Business Stat,0.29,0.29,0.27,0.11,0.02,0%,0.0,0.02,na guo,,STAT-3090,2020
+STAT,3090,11.0,Introductory Business Stat,0.42,0.31,0.2,0.04,0.02,0%,0.0,0.0,tiantian yang,,STAT-3090,2020
+STAT,3090,12.0,Introductory Business Stat,0.28,0.31,0.21,0.05,0.1,0%,0.0,0.05,marwah soliman,,STAT-3090,2020
+STAT,3090,13.0,Introductory Business Stat,0.42,0.2,0.3,0.02,0.04,0%,0.0,0.02,april thomas,,STAT-3090,2020
+STAT,3090,14.0,Introductory Business Stat,0.48,0.36,0.14,0.0,0.0,0%,0.0,0.02,april thomas,,STAT-3090,2020
+STAT,3090,15.0,Introductory Business Stat,0.33,0.28,0.12,0.05,0.14,0%,0.0,0.09,marwah soliman,,STAT-3090,2020
+STAT,3090,16.0,Introductory Business Stat,0.52,0.24,0.15,0.02,0.04,0%,0.0,0.02,anna marie vagnozzi,,STAT-3090,2020
+STAT,3090,17.0,Introductory Business Stat,0.37,0.37,0.21,0.0,0.02,0%,0.0,0.02,molly honecker,,STAT-3090,2020
+STAT,3090,18.0,Introductory Business Stat,0.29,0.4,0.2,0.02,0.04,0%,0.0,0.04,shuai wei,,STAT-3090,2020
+STAT,3090,19.0,Introductory Business Stat,0.37,0.29,0.18,0.02,0.06,0%,0.0,0.06,caroline kerfonta,,STAT-3090,2020
+STAT,3090,20.0,Introductory Business Stat,0.6,0.14,0.18,0.02,0.02,0%,0.0,0.04,zhengxin wang,,STAT-3090,2020
+STAT,3090,21.0,Introductory Business Stat,0.43,0.19,0.24,0.12,0.02,0%,0.0,0.0,anna marie vagnozzi,,STAT-3090,2020
+STAT,3300,1.0,Statistical Methods II,0.35,0.3,0.25,0.05,0.0,0%,0.0,0.05, martinez-dawson,,STAT-3300,2020
+STAT,4020,401.0,Intro to Statistical Computi,0.67,0.14,0.0,0.0,0.0,0%,0.0,0.19,ellen hepfer breazel,,STAT-4020,2020
+STAT,4020,402.0,Intro to Statistical Computi,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,zhiyun gong,,STAT-4020,2020
+STAT,4110,1.0,Stat Mthds for Process Co,0.58,0.37,0.0,0.05,0.0,0%,0.0,0.0,na guo,,STAT-4110,2020
+STAT,4110,2.0,Stat Mthds for Process Co,0.72,0.25,0.0,0.03,0.0,0%,0.0,0.0,na guo,,STAT-4110,2020
+STAT,4110,3.0,Stat Mthds for Process Co,0.58,0.33,0.09,0.0,0.0,0%,0.0,0.0,william bridges,,STAT-4110,2020
+STAT,4110,4.0,Stat Mthds for Process Co,0.44,0.13,0.28,0.0,0.06,0%,0.0,0.09,yu-bo wang,,STAT-4110,2020
+STAT,4110,5.0,Stat Mthds for Process Co,0.38,0.34,0.24,0.0,0.0,0%,0.0,0.03,yu-bo wang,,STAT-4110,2020
+STAT,6020,401.0,Intro to Statistical Computi,0.62,0.23,0.15,0.0,0.0,0%,0.0,0.0,ellen hepfer breazel,,STAT-6020,2020
+STAT,8010,1.0,Statistical Methods I,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,joseph daniel bible,,STAT-8010,2020
+STAT,8010,2.0,Statistical Methods I,0.48,0.43,0.05,0.0,0.05,0%,0.0,0.0,joseph daniel bible,,STAT-8010,2020
+STAT,8010,3.0,Statistical Methods I,0.68,0.18,0.14,0.0,0.0,0%,0.0,0.0,brook thayer russell,,STAT-8010,2020
+STAT,8010,4.0,Statistical Methods I,0.85,0.05,0.05,0.0,0.0,0%,0.0,0.05,jun luo,,STAT-8010,2020
+STAT,8010,5.0,Statistical Methods I,0.5,0.27,0.18,0.0,0.0,0%,0.0,0.0,patrick gerard,,STAT-8010,2020
+STAT,8020,1.0,Statistical Methods II,0.94,0.03,0.03,0.0,0.0,0%,0.0,0.0,whitney huang,,STAT-8020,2020
+STAT,8030,1.0,Regress & Least Squares A,0.75,0.08,0.08,0.0,0.0,0%,0.0,0.08,jun luo,,STAT-8030,2020
+STAT,8050,1.0,Design & Anlys of Experim,0.61,0.36,0.0,0.0,0.04,0%,0.0,0.0,william bridges,,STAT-8050,2020
+STS,1010,1.0,Survey Sci & Techn in Soci,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.03,yang wu,,STS-1010,2020
+STS,1010,2.0,Survey Sci & Techn in Soci,0.58,0.36,0.03,0.0,0.03,0%,0.0,0.0,scott brame,,STS-1010,2020
+STS,1010,3.0,Survey Sci & Techn in Soci,0.69,0.23,0.09,0.0,0.0,0%,0.0,0.0,elizabeth stansell,,STS-1010,2020
+STS,1010,4.0,Survey Sci & Techn in Soci,0.85,0.06,0.0,0.0,0.06,0%,0.0,0.03,mary katherine fidler,,STS-1010,2020
+STS,1010,5.0,Survey Sci & Techn in Soci,0.78,0.17,0.03,0.0,0.03,0%,0.0,0.0,tareva johnson,,STS-1010,2020
+STS,1010,7.0,Survey Sci & Techn in Soci,0.74,0.2,0.03,0.0,0.0,0%,0.0,0.03,philip randall,,STS-1010,2020
+STS,1010,8.0,Survey Sci & Techn in Soci,0.82,0.03,0.03,0.03,0.0,0%,0.0,0.09,david charles foltz,,STS-1010,2020
+STS,1010,9.0,Survey Sci & Techn in Soci,0.41,0.32,0.15,0.06,0.06,0%,0.0,0.0,megan macalystre,,STS-1010,2020
+STS,1010,10.0,Survey Sci & Techn in Soci,0.88,0.06,0.03,0.0,0.0,0%,0.0,0.03,alexander billinis,,STS-1010,2020
+STS,1010,11.0,Survey Sci & Techn in Soci,0.89,0.06,0.03,0.03,0.0,0%,0.0,0.0,anne grant,,STS-1010,2020
+STS,1010,12.0,Survey Sci & Techn in Soci,0.15,0.38,0.15,0.06,0.18,0%,0.0,0.06,chelsea marie clarey,,STS-1010,2020
+THEA,2100,1.0,Theatre Appreciation,0.69,0.22,0.06,0.03,0.0,0%,0.0,0.0,david hartmann,,THEA-2100,2020
+THEA,2100,3.0,Theatre Appreciation,0.61,0.21,0.09,0.03,0.03,0%,0.0,0.03,kendra johnson,,THEA-2100,2020
+THEA,2100,6.0,Theatre Appreciation,0.81,0.13,0.03,0.03,0.0,0%,0.0,0.0,jason adkins,,THEA-2100,2020
+THEA,2100,7.0,Theatre Appreciation,0.72,0.22,0.03,0.0,0.03,0%,0.0,0.0,jason adkins,,THEA-2100,2020
+THEA,2770,1.0,Prod Studies in Thea,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,david hartmann,,THEA-2770,2020
+THEA,3150,1.0,Theatre History I,0.79,0.15,0.03,0.0,0.0,0%,0.0,0.03,shannon robert,,THEA-3150,2020
+THEA,3170,1.0,African-Amer Thea I,0.65,0.12,0.18,0.0,0.06,0%,0.0,0.0,kendra johnson,,THEA-3170,2020
+THEA,3470,1.0,Structure of Drama,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,carol collins,,THEA-3470,2020
+THEA,3720,1.0,Creative Drama,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,carol collins,,THEA-3720,2020
+THEA,3760,1.0,Stage Directing I,0.55,0.27,0.09,0.09,0.0,0%,0.0,0.0,becky becker,,THEA-3760,2020
+WFB,3010,2.0,Wildlife Biology Lab,0.57,0.36,0.07,0.0,0.0,0%,0.0,0.0,shari lynn rodriguez,,WFB-3010,2020
+WFB,4100,2.0,Wildlife Management Tech,0.53,0.26,0.12,0.06,0.03,0%,0.0,0.0,catherine jachowski,,WFB-4100,2020
+WFB,4120,1.0,Wildlife Management,0.59,0.3,0.07,0.0,0.04,0%,0.0,0.0,greg yarrow,,WFB-4120,2020
+WFB,4180,2.0,Fisheries Mgt & Conservati,0.57,0.29,0.0,0.07,0.0,0%,0.0,0.07,troy mason farmer,,WFB-4180,2020
+WFB,4440,1.0,Wildlife Damage Manage,0.41,0.52,0.07,0.0,0.0,0%,0.0,0.0,greg yarrow,,WFB-4440,2020
+WFB,4770,1.0,Ichthyology,0.53,0.4,0.0,0.07,0.0,0%,0.0,0.0,luke bower,,WFB-4770,2020
+WFB,4800,1.0,Waterfowl Ecology & Man,0.28,0.31,0.21,0.08,0.0,0%,0.0,0.13,richard kaminski,,WFB-4800,2020
+WFB,6200,2.0,Environmental Education,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,althea hagan,,WFB-6200,2020
+WFB,6620,1.0,Wetland Wildlife Biology,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,russell barrett,,WFB-6620,2020
+WFB,6800,1.0,Waterfowl Ecology & Man,0.69,0.19,0.0,0.0,0.0,0%,0.0,0.06,richard kaminski,,WFB-6800,2020
+WFB,8530,2.0,Global Change Ecology,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,lydia ries 'halloran,,WFB-8530,2020
+WFB,8610,5.0,Intro to Scientific Writing,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,stefanie whitmire,,WFB-8610,2020
+WFB,8610,6.0,Conservation PhysiologyO,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,patrick jodice,,WFB-8610,2020
+WFB,8610,11.0,Study Design & Data Analy,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.0,brandon peoples,,WFB-8610,2020
+WFB,8610,30.0,Human Dimensions of WL,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,shari lynn rodriguez,,WFB-8610,2020
+WS,1030,1.0,Women in Global Perspect,0.72,0.14,0.03,0.03,0.07,0%,0.0,0.0,sarah mae cooper,,WS-1030,2020
+WS,1030,2.0,Women in Global Perspect,0.59,0.38,0.0,0.0,0.0,0%,0.0,0.03,sarah mae cooper,,WS-1030,2020
+WS,2300,1.0,Women and Leadership I,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,mary price,,WS-2300,2020
+WS,4010,1.0,Senior Seminar,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.08,diane perpich,,WS-4010,2020
+YDP,3000,1.0,Youth Development in Soci,0.73,0.19,0.04,0.0,0.0,0%,0.0,0.04,lauren stephens,,YDP-3000,2020
+YDP,3050,1.0,Theory/Phil of Youth Dev,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,lauren stephens,,YDP-3050,2020
+YDP,3200,1.0,Youth Dev in Sport/Phys A,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,lauren stephens,,YDP-3200,2020
+YDP,3300,1.0,Designing Effective Youth,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,kellye rembert,,YDP-3300,2020
+YDP,3300,2.0,Designing Effective Youth,0.29,0.58,0.04,0.04,0.0,0%,0.0,0.04,allison avishai,,YDP-3300,2020
+YDP,3350,1.0,Youth Activity Leadership,0.81,0.11,0.07,0.0,0.0,0%,0.0,0.0,lauren stephens,,YDP-3350,2020
+YDP,3450,1.0,Creative Activities for Yout,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,kimberly johnson,,YDP-3450,2020
+YDP,4500,1.0,Prof Iss & Ethics in Youth D,0.69,0.23,0.08,0.0,0.0,0%,0.0,0.0,michele little kukler,,YDP-4500,2020
+YDP,8000,1.0,Theories of Youth Develop,0.76,0.14,0.0,0.0,0.0,0%,0.0,0.03,edmond bowers,,YDP-8000,2020
+YDP,8050,1.0,Youth Dev in Context of Fa,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.06,william quinn,,YDP-8050,2020
+YDP,8060,2.0,Youth Dev in Global Societ,0.67,0.13,0.07,0.0,0.13,0%,0.0,0.0,ann marie gillard,,YDP-8060,2020
+YDP,8080,1.0,Grantsmanship,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,anna- chancellor,,YDP-8080,2020

--- a/bot/cogs/grades_cog/assets/2020_Fall.csv
+++ b/bot/cogs/grades_cog/assets/2020_Fall.csv
@@ -1,3020 +1,3020 @@
-Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,CourseId,Year
-AAH,1010,1.0,Survey of Art & Arch Histor,0.51,0.4,0.04,0.02,0.0,0%,0.0,0.03,beth ann lauritis,AAH-1010,2020
-AAH,2050,1.0,Art History and Theory I,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.0,beth ann lauritis,AAH-2050,2020
-AAH,3050,1.0,Contemporary Art History,0.58,0.37,0.0,0.05,0.0,0%,0.0,0.0,andrea feeser,AAH-3050,2020
-ACCT,2010,1.0,Financial Accounting Conc,0.36,0.38,0.2,0.02,0.02,0%,0.0,0.02,lydia schleifer,ACCT-2010,2020
-ACCT,2010,2.0,Financial Accounting Conc,0.44,0.31,0.15,0.02,0.04,0%,0.0,0.05,lydia schleifer,ACCT-2010,2020
-ACCT,2010,3.0,Financial Accounting Conc,0.17,0.32,0.25,0.07,0.12,0%,0.0,0.07,robert wahlman,ACCT-2010,2020
-ACCT,2010,4.0,Financial Accounting Conc,0.26,0.26,0.26,0.13,0.03,0%,0.0,0.08,charles tegen,ACCT-2010,2020
-ACCT,2010,5.0,Financial Accounting Conc,0.41,0.36,0.13,0.03,0.05,0%,0.0,0.03,charles tegen,ACCT-2010,2020
-ACCT,2010,6.0,Financial Accounting Conc,0.45,0.33,0.05,0.05,0.05,0%,0.0,0.08,julie grant,ACCT-2010,2020
-ACCT,2010,7.0,Financial Accounting Conc,0.21,0.44,0.31,0.03,0.0,0%,0.0,0.03,julie grant,ACCT-2010,2020
-ACCT,2010,8.0,Financial Accounting Conc,0.51,0.33,0.07,0.07,0.0,0%,0.0,0.02,lydia schleifer,ACCT-2010,2020
-ACCT,2010,9.0,Financial Accounting Conc,0.38,0.3,0.18,0.1,0.05,0%,0.0,0.0,julie grant,ACCT-2010,2020
-ACCT,2010,10.0,Financial Accounting Conc,0.5,0.2,0.23,0.08,0.0,0%,0.0,0.0,julie grant,ACCT-2010,2020
-ACCT,2010,11.0,Financial Accounting Conc,0.35,0.31,0.21,0.04,0.08,0%,0.0,0.0,lisa birtwistle,ACCT-2010,2020
-ACCT,2010,12.0,Financial Accounting Conc,0.28,0.39,0.25,0.0,0.03,0%,0.0,0.03,lisa birtwistle,ACCT-2010,2020
-ACCT,2010,13.0,Financial Accounting Conc,0.34,0.39,0.13,0.03,0.05,0%,0.0,0.05,lisa birtwistle,ACCT-2010,2020
-ACCT,2010,14.0,Financial Accounting Conc,0.18,0.32,0.28,0.1,0.0,0%,0.0,0.12,jeffrey mcmillan,ACCT-2010,2020
-ACCT,2010,15.0,Financial Accounting Conc,0.23,0.34,0.31,0.03,0.0,0%,0.0,0.09,carl hollingsworth,ACCT-2010,2020
-ACCT,2010,400.0,Financial Accounting Conc,0.09,0.28,0.36,0.12,0.05,0%,0.0,0.1,jeffrey mcmillan,ACCT-2010,2020
-ACCT,2010,401.0,Financial Accounting Conc,0.26,0.21,0.26,0.11,0.09,0%,0.0,0.07,emily mccorkle,ACCT-2010,2020
-ACCT,2020,1.0,Managerial Accounting Co,0.38,0.43,0.18,0.03,0.0,0%,0.0,0.0,robin radtke,ACCT-2020,2020
-ACCT,2020,2.0,Managerial Accounting Co,0.4,0.28,0.18,0.03,0.03,0%,0.0,0.1,robin radtke,ACCT-2020,2020
-ACCT,2020,3.0,Managerial Accounting Co,0.21,0.13,0.3,0.11,0.09,0%,0.0,0.15,brian todd carver,ACCT-2020,2020
-ACCT,2020,4.0,Managerial Accounting Co,0.12,0.29,0.19,0.12,0.1,0%,0.0,0.17,brian todd carver,ACCT-2020,2020
-ACCT,2020,400.0,Managerial Accounting Co,0.23,0.49,0.23,0.0,0.0,0%,0.0,0.05,robin radtke,ACCT-2020,2020
-ACCT,2020,401.0,Managerial Accounting Co,0.28,0.33,0.17,0.1,0.05,0%,0.0,0.07,emily mccorkle,ACCT-2020,2020
-ACCT,2020,402.0,Managerial Accounting Co,0.33,0.22,0.28,0.05,0.03,0%,0.0,0.09,emily mccorkle,ACCT-2020,2020
-ACCT,2020,403.0,Managerial Accounting Co,0.1,0.4,0.15,0.2,0.08,0%,0.0,0.08,emily mccorkle,ACCT-2020,2020
-ACCT,2020,404.0,Managerial Accounting Co,0.1,0.28,0.26,0.13,0.08,0%,0.0,0.15,emily mccorkle,ACCT-2020,2020
-ACCT,3030,1.0,Cost Accounting,0.38,0.35,0.23,0.03,0.03,0%,0.0,0.0,daniel thomas way,ACCT-3030,2020
-ACCT,3030,2.0,Cost Accounting,0.25,0.33,0.35,0.03,0.03,0%,0.0,0.03,daniel thomas way,ACCT-3030,2020
-ACCT,3030,3.0,Cost Accounting,0.26,0.32,0.32,0.05,0.03,0%,0.0,0.03,jace garrett,ACCT-3030,2020
-ACCT,3030,4.0,Cost Accounting,0.16,0.42,0.26,0.0,0.05,0%,0.0,0.11,jace garrett,ACCT-3030,2020
-ACCT,3030,5.0,Cost Accounting,0.77,0.13,0.08,0.03,0.0,0%,0.0,0.0,sarah martin,ACCT-3030,2020
-ACCT,3110,1.0,Intermediate Financial Acc,0.17,0.34,0.31,0.03,0.07,0%,0.0,0.07,amy donnelly,ACCT-3110,2020
-ACCT,3110,2.0,Intermediate Financial Acc,0.3,0.3,0.3,0.04,0.07,0%,0.0,0.0,amy donnelly,ACCT-3110,2020
-ACCT,3110,3.0,Intermediate Financial Acc,0.31,0.38,0.23,0.04,0.0,0%,0.0,0.04,annieka philo,ACCT-3110,2020
-ACCT,3110,4.0,Intermediate Financial Acc,0.26,0.35,0.23,0.06,0.06,0%,0.0,0.03,annieka philo,ACCT-3110,2020
-ACCT,3110,5.0,Intermediate Financial Acc,0.04,0.25,0.36,0.11,0.18,0%,0.0,0.07, russell madray,ACCT-3110,2020
-ACCT,3110,6.0,Intermediate Financial Acc,0.18,0.42,0.18,0.06,0.09,0%,0.0,0.06, russell madray,ACCT-3110,2020
-ACCT,3110,7.0,Intermediate Financial Acc,0.19,0.41,0.28,0.0,0.0,0%,0.0,0.09, russell madray,ACCT-3110,2020
-ACCT,3110,8.0,Intermediate Financial Acc,0.23,0.42,0.1,0.19,0.03,0%,0.0,0.03, russell madray,ACCT-3110,2020
-ACCT,3120,1.0,Intermediate Financial Acc,0.1,0.41,0.31,0.05,0.05,0%,0.0,0.08,jeremy vinson,ACCT-3120,2020
-ACCT,3120,2.0,Intermediate Financial Acc,0.33,0.44,0.17,0.0,0.03,0%,0.0,0.03,jeremy vinson,ACCT-3120,2020
-ACCT,3120,3.0,Intermediate Financial Acc,0.14,0.23,0.31,0.14,0.11,0%,0.0,0.06,terry daniel knause,ACCT-3120,2020
-ACCT,3120,4.0,Intermediate Financial Acc,0.17,0.4,0.3,0.07,0.0,0%,0.0,0.07,terry daniel knause,ACCT-3120,2020
-ACCT,3120,5.0,Intermediate Financial Acc,0.18,0.36,0.3,0.06,0.09,0%,0.0,0.0,terry daniel knause,ACCT-3120,2020
-ACCT,3120,6.0,Intermediate Financial Acc,0.22,0.42,0.17,0.06,0.14,0%,0.0,0.0,terry daniel knause,ACCT-3120,2020
-ACCT,3130,1.0,Analytics for Acct Dec Mak,0.69,0.29,0.03,0.0,0.0,0%,0.0,0.0,james barnes,ACCT-3130,2020
-ACCT,3130,2.0,Analytics for Acct Dec Mak,0.89,0.09,0.0,0.03,0.0,0%,0.0,0.0,james barnes,ACCT-3130,2020
-ACCT,3130,3.0,Analytics for Acct Dec Mak,0.27,0.38,0.15,0.15,0.04,0%,0.0,0.0,phebian davis-culler,ACCT-3130,2020
-ACCT,3130,4.0,Analytics for Acct Dec Mak,0.25,0.39,0.25,0.0,0.11,0%,0.0,0.0,phebian davis-culler,ACCT-3130,2020
-ACCT,3130,5.0,Analytics for Acct Dec Mak,0.25,0.3,0.3,0.1,0.05,0%,0.0,0.0,phebian davis-culler,ACCT-3130,2020
-ACCT,3220,1.0,Accounting Information Sy,0.15,0.19,0.42,0.08,0.12,0%,0.0,0.04,philip maiberger,ACCT-3220,2020
-ACCT,3220,2.0,Accounting Information Sy,0.27,0.31,0.35,0.0,0.04,0%,0.0,0.04,philip maiberger,ACCT-3220,2020
-ACCT,3220,3.0,Accounting Information Sy,0.13,0.3,0.23,0.17,0.07,0%,0.0,0.1,philip maiberger,ACCT-3220,2020
-ACCT,3220,4.0,Accounting Information Sy,0.11,0.29,0.25,0.11,0.04,0%,0.0,0.21,philip maiberger,ACCT-3220,2020
-ACCT,4040,1.0,Individual Taxation,0.61,0.32,0.04,0.0,0.0,0%,0.0,0.04,sarah martin,ACCT-4040,2020
-ACCT,4040,2.0,Individual Taxation,0.46,0.29,0.23,0.0,0.03,0%,0.0,0.0,sarah martin,ACCT-4040,2020
-ACCT,4040,3.0,Individual Taxation,0.47,0.41,0.09,0.0,0.03,0%,0.0,0.0,lisa birtwistle,ACCT-4040,2020
-ACCT,4040,4.0,Individual Taxation,0.49,0.29,0.17,0.03,0.03,0%,0.0,0.0,sarah martin,ACCT-4040,2020
-ACCT,4080,1.0,Retire & Estate Plan,0.28,0.5,0.16,0.03,0.0,0%,0.0,0.03,john hine,ACCT-4080,2020
-ACCT,4100,2.0,Reporting and Mgmt Contr,0.24,0.39,0.33,0.03,0.0,0%,0.0,0.0,gregory mcphee,ACCT-4100,2020
-ACCT,4100,3.0,Reporting and Mgmt Contr,0.33,0.45,0.18,0.03,0.0,0%,0.0,0.0,gregory mcphee,ACCT-4100,2020
-ACCT,4150,1.0,Auditing,0.28,0.38,0.19,0.13,0.03,0%,0.0,0.0,nancy lee harp,ACCT-4150,2020
-ACCT,4150,2.0,Auditing,0.38,0.46,0.13,0.04,0.0,0%,0.0,0.0,nancy lee harp,ACCT-4150,2020
-ACCT,8510,1.0,Tax Research,0.41,0.53,0.03,0.0,0.0,0%,0.0,0.03,thomas dickens,ACCT-8510,2020
-ACCT,8530,1.0,Adv Acct Problems,0.74,0.15,0.04,0.0,0.0,0%,0.0,0.07,suzanne pearse,ACCT-8530,2020
-ACCT,8530,2.0,Adv Acct Problems,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0,suzanne pearse,ACCT-8530,2020
-ACCT,8530,3.0,Adv Acct Problems,0.45,0.45,0.03,0.0,0.03,0%,0.0,0.03,ralph edward welton,ACCT-8530,2020
-ACCT,8570,1.0,CPA Exam Review-B,0.0,0.0,0.0,0.0,0.0,96%,0.03,0.01,james barnes,ACCT-8570,2020
-ACCT,8630,1.0,Forensics Analysis,0.48,0.45,0.03,0.0,0.0,0%,0.0,0.03,brian goodson,ACCT-8630,2020
-ACCT,8630,2.0,Forensics Analysis,0.35,0.62,0.03,0.0,0.0,0%,0.0,0.0,brian goodson,ACCT-8630,2020
-ACCT,8650,1.0,Tax & Bus Decisions,0.55,0.39,0.06,0.0,0.0,0%,0.0,0.0,judson jahn,ACCT-8650,2020
-ACCT,8650,2.0,Tax & Bus Decisions,0.41,0.56,0.04,0.0,0.0,0%,0.0,0.0,judson jahn,ACCT-8650,2020
-ACCT,8680,1.0,Advanced Accounting Anal,0.47,0.47,0.06,0.0,0.0,0%,0.0,0.0,marc cussatt,ACCT-8680,2020
-ACCT,8680,2.0,Advanced Accounting Anal,0.59,0.34,0.03,0.0,0.0,0%,0.0,0.03,marc cussatt,ACCT-8680,2020
-ACCT,8680,3.0,Advanced Accounting Anal,0.39,0.55,0.03,0.0,0.0,0%,0.0,0.03,marc cussatt,ACCT-8680,2020
-ACCT,8720,1.0,Tax of Flowthroughs,0.25,0.44,0.28,0.0,0.0,0%,0.0,0.03,thomas dickens,ACCT-8720,2020
-AGED,1020,1.0,Freshman Seminar,0.58,0.33,0.0,0.08,0.0,0%,0.0,0.0, dibenedetto,AGED-1020,2020
-AGED,2000,1.0,Agr Appl of Ed Tech,0.62,0.0,0.08,0.0,0.0,0%,0.0,0.15,kevin layfield,AGED-2000,2020
-AGED,2010,1.0,Intro to Agric Educ,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,philip fravel,AGED-2010,2020
-AGED,2040,1.0,App Ag Calculations,0.29,0.57,0.0,0.07,0.07,0%,0.0,0.0,philip fravel,AGED-2040,2020
-AGED,3030,1.0,Ag Ed Mech Tech,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,christopher eck,AGED-3030,2020
-AGED,8100,3.0,Clin Ag Ed Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,kevin layfield,AGED-8100,2020
-AGM,1010,1.0,Intro Ag Mech & Bus,0.47,0.34,0.11,0.03,0.03,0%,0.0,0.03,hunter massey,AGM-1010,2020
-AGM,2050,1.0,Prin of Fabrication,0.22,0.51,0.22,0.04,0.0,0%,0.0,0.02,hunter massey,AGM-2050,2020
-AGM,2210,1.0,Land Measurements,0.45,0.31,0.09,0.04,0.07,0%,0.0,0.04,brennan teddy,AGM-2210,2020
-AGM,3010,1.0,Soil Water Conserv,0.45,0.29,0.22,0.0,0.02,0%,0.0,0.02,calvin sawyer,AGM-3010,2020
-AGM,4000,1.0,Seminar in Ag Mech & Busi,0.13,0.29,0.32,0.24,0.03,0%,0.0,0.0,john chastain,AGM-4000,2020
-AGM,4020,1.0,Irrigation System Design,0.24,0.24,0.24,0.1,0.19,0%,0.0,0.0,charles privette,AGM-4020,2020
-AGM,4050,1.0,Env Cont in Anim Str,0.05,0.27,0.35,0.22,0.11,0%,0.0,0.0,john chastain,AGM-4050,2020
-AGM,4060,1.0,Mech & Hydraulic Sys,0.39,0.48,0.11,0.0,0.02,0%,0.0,0.0,ali bulent koc,AGM-4060,2020
-AGM,4600,1.0,Electrical Systems,0.69,0.29,0.02,0.0,0.0,0%,0.0,0.0,charles privette,AGM-4600,2020
-AGM,4730,4.0,Ag Safety,0.61,0.22,0.11,0.06,0.0,0%,0.0,0.0,hunter massey,AGM-4730,2020
-AGRB,2020,1.0,Agricultural Economics,0.7,0.17,0.03,0.03,0.05,0%,0.0,0.01,julie carl pingol ureta pingol,AGRB-2020,2020
-AGRB,2050,1.0,Agriculture and Society,0.16,0.16,0.22,0.31,0.11,0%,0.0,0.04,michael vassalos,AGRB-2050,2020
-AGRB,3020,1.0,Economics of Farm Manag,0.16,0.13,0.15,0.28,0.08,0%,0.0,0.2,michael vassalos,AGRB-3020,2020
-AGRB,3080,2.0,Quant Agribusiness Analysi,0.12,0.21,0.14,0.33,0.1,0%,0.0,0.1,lisha zhang,AGRB-3080,2020
-AGRB,3570,1.0,Natural Resources Econom,0.2,0.11,0.23,0.18,0.11,0%,0.0,0.16,david brian willis,AGRB-3570,2020
-AGRB,4120,1.0,Reg Econ Devel Theory & P,0.3,0.22,0.11,0.16,0.08,0%,0.0,0.08,figueiredo silva de,AGRB-4120,2020
-AGRB,4520,1.0,Agricultural Policy,0.14,0.21,0.19,0.28,0.14,0%,0.0,0.05,michael vassalos,AGRB-4520,2020
-AGRB,4600,2.0,Agricultural Finance,0.18,0.33,0.23,0.18,0.03,0%,0.0,0.03,lisha zhang,AGRB-4600,2020
-AGRB,4910,1.0,"Int, Agrib & Comm & Rural",0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,michael vassalos,AGRB-4910,2020
-AL,3490,400.0,Principles of Coaching,0.64,0.24,0.12,0.0,0.0,0%,0.0,0.0,deborah cadorette,AL-3490,2020
-AL,3490,401.0,Principles of Coaching,0.48,0.32,0.08,0.0,0.08,0%,0.0,0.04,deborah cadorette,AL-3490,2020
-AL,3490,402.0,Principles of Coaching,0.52,0.32,0.12,0.0,0.04,0%,0.0,0.0,deborah cadorette,AL-3490,2020
-AL,3490,403.0,Principles of Coaching,0.65,0.17,0.13,0.04,0.0,0%,0.0,0.0,deborah cadorette,AL-3490,2020
-AL,3490,405.0,Principles of Coaching,0.73,0.2,0.0,0.07,0.0,0%,0.0,0.0,frank mezzanotte,AL-3490,2020
-AL,3490,406.0,Principles of Coaching,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,frank mezzanotte,AL-3490,2020
-AL,3490,408.0,Principles of Coaching,0.48,0.26,0.17,0.04,0.0,0%,0.0,0.0,john plumblee,AL-3490,2020
-AL,3490,409.0,Principles of Coaching,0.88,0.04,0.08,0.0,0.0,0%,0.0,0.0,edmond fry,AL-3490,2020
-AL,3490,410.0,Principles of Coaching,0.59,0.18,0.14,0.05,0.0,0%,0.0,0.05,joel neuder,AL-3490,2020
-AL,3490,411.0,Principles of Coaching,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,nicholas whitrow,AL-3490,2020
-AL,3500,400.0,Sci Basis I/Ex Phy,0.27,0.38,0.23,0.04,0.0,0%,0.0,0.08,michael godfrey,AL-3500,2020
-AL,3500,401.0,Sci Basis I/Ex Phy,0.44,0.32,0.2,0.04,0.0,0%,0.0,0.0,isaac sean colbert,AL-3500,2020
-AL,3530,400.0,Athletic Injuries,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,isaac sean colbert,AL-3530,2020
-AL,3530,401.0,Athletic Injuries,0.8,0.12,0.04,0.04,0.0,0%,0.0,0.0,isaac sean colbert,AL-3530,2020
-AL,3600,400.0,Hgh Sch Athl Ethical/Legal,0.37,0.53,0.11,0.0,0.0,0%,0.0,0.0,clyde keith connor,AL-3600,2020
-AL,3610,400.0,Admin/Org of Athletic Pro,0.76,0.2,0.04,0.0,0.0,0%,0.0,0.0,henry oates,AL-3610,2020
-AL,3610,401.0,Admin/Org of Athletic Pro,0.76,0.2,0.04,0.0,0.0,0%,0.0,0.0,henry oates,AL-3610,2020
-AL,3610,402.0,Admin/Org of Athletic Pro,0.35,0.35,0.2,0.0,0.1,0%,0.0,0.0,john plumblee,AL-3610,2020
-AL,3620,400.0,Psychology of Coaching,0.33,0.42,0.17,0.04,0.04,0%,0.0,0.0,natalie anne carter,AL-3620,2020
-AL,3620,401.0,Psychology of Coaching,0.28,0.36,0.24,0.12,0.0,0%,0.0,0.0,natalie anne carter,AL-3620,2020
-AL,3620,402.0,Psychology of Coaching,0.32,0.24,0.32,0.08,0.04,0%,0.0,0.0,natalie anne carter,AL-3620,2020
-AL,3740,400.0,Coaching Football,0.52,0.16,0.16,0.04,0.04,0%,0.0,0.08,edmond fry,AL-3740,2020
-AL,3740,401.0,Coaching Football,0.45,0.18,0.18,0.09,0.05,0%,0.0,0.05,edmond fry,AL-3740,2020
-AL,3760,400.0,Coaching Strength/Conditi,0.67,0.13,0.08,0.0,0.08,0%,0.0,0.04,edmond fry,AL-3760,2020
-AL,3760,401.0,Coaching Strength/Conditi,0.68,0.2,0.04,0.0,0.04,0%,0.0,0.04,edmond fry,AL-3760,2020
-AL,4000,400.0,Athletic Leadership Interns,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,deborah cadorette,AL-4000,2020
-AL,4380,402.0,HS Athletic Recruiting,0.61,0.13,0.17,0.04,0.04,0%,0.0,0.0,justin hickey,AL-4380,2020
-AL,4380,404.0,Emerging Issues and Trend,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.0,misty soles,AL-4380,2020
-AL,4380,408.0,Officiating in AL,0.75,0.2,0.0,0.05,0.0,0%,0.0,0.0,clyde keith connor,AL-4380,2020
-AL,4380,409.0,Coaching Baseball/Softball,0.71,0.06,0.24,0.0,0.0,0%,0.0,0.0,justin hickey,AL-4380,2020
-AL,8440,401.0,Surv of Res Mthds in Athle,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,michael godfrey,AL-8440,2020
-AL,8440,402.0,Surv of Res Mthds in Athle,0.75,0.08,0.08,0.0,0.08,0%,0.0,0.0,michael godfrey,AL-8440,2020
-AL,8490,401.0,Athletic Leadership Dev,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,janna magette,AL-8490,2020
-AL,8490,402.0,Athletic Leadership Dev,0.6,0.25,0.0,0.0,0.15,0%,0.0,0.0,janna magette,AL-8490,2020
-AL,8500,400.0,Principles Strength and Co,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,michael godfrey,AL-8500,2020
-AL,8500,401.0,Principles Strength and Co,0.58,0.37,0.0,0.0,0.05,0%,0.0,0.0,michael godfrey,AL-8500,2020
-AL,8630,400.0,Socio Dynam in Intercol At,0.55,0.27,0.0,0.0,0.09,0%,0.0,0.09,michael godfrey,AL-8630,2020
-ANTH,2010,1.0,Introduction to Anthropol,0.35,0.34,0.17,0.08,0.03,0%,0.0,0.04,yi wu,ANTH-2010,2020
-ANTH,2010,2.0,Introduction to Anthropol,0.22,0.48,0.18,0.05,0.04,0%,0.0,0.04,yi wu,ANTH-2010,2020
-ANTH,2010,3.0,Introduction to Anthropol,0.06,0.16,0.24,0.04,0.13,0%,0.0,0.37,john coggeshall,ANTH-2010,2020
-ANTH,2010,4.0,Introduction to Anthropol,0.58,0.3,0.04,0.0,0.02,0%,0.0,0.04,david markus,ANTH-2010,2020
-ANTH,2010,5.0,Introduction to Anthropol,0.67,0.23,0.04,0.0,0.04,0%,0.0,0.02,david markus,ANTH-2010,2020
-ANTH,2010,6.0,Introduction to Anthropol,0.04,0.34,0.2,0.11,0.04,0%,0.0,0.27,john coggeshall,ANTH-2010,2020
-ANTH,2010,7.0,Introduction to Anthropol,0.62,0.35,0.04,0.0,0.0,0%,0.0,0.0,david markus,ANTH-2010,2020
-ANTH,3010,1.0,Cultural Anthropology,0.14,0.32,0.39,0.07,0.04,0%,0.0,0.04,john coggeshall,ANTH-3010,2020
-ANTH,3200,1.0,North American Indian Cul,0.13,0.27,0.2,0.13,0.2,0%,0.0,0.07,john coggeshall,ANTH-3200,2020
-ANTH,3320,1.0,World Archaeology,0.4,0.44,0.08,0.0,0.04,0%,0.0,0.04,david markus,ANTH-3320,2020
-ANTH,3510,1.0,Biological Anthropology,0.66,0.13,0.13,0.0,0.06,0%,0.0,0.03,katherine weisensee,ANTH-3510,2020
-ANTH,4280,1.0,"Law, Culture and Society",0.57,0.21,0.0,0.0,0.14,0%,0.0,0.07,yi wu,ANTH-4280,2020
-ARCH,1010,1.0,Introduction to Architectur,0.42,0.35,0.03,0.02,0.04,0%,0.0,0.07, hambright-belue,ARCH-1010,2020
-ARCH,2040,1.0,Hist of Modern Arch,0.56,0.31,0.11,0.01,0.0,0%,0.0,0.0,andreea mihalache,ARCH-2040,2020
-ARCH,2510,1.0,Arch Foundations I,0.86,0.07,0.07,0.0,0.0,0%,0.0,0.0,joseph choma,ARCH-2510,2020
-ARCH,2510,2.0,Arch Foundations I,0.43,0.36,0.21,0.0,0.0,0%,0.0,0.0,brandon george pass,ARCH-2510,2020
-ARCH,2510,3.0,Arch Foundations I,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,virginia ellyn melnyk,ARCH-2510,2020
-ARCH,2510,4.0,Arch Foundations I,0.62,0.23,0.08,0.0,0.08,0%,0.0,0.0,byron jefferies,ARCH-2510,2020
-ARCH,2510,5.0,Arch Foundations I,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,kendall roberts,ARCH-2510,2020
-ARCH,2510,6.0,Arch Foundations I,0.46,0.31,0.08,0.08,0.0,0%,0.0,0.08,timothy sutherland,ARCH-2510,2020
-ARCH,2700,1.0,Structures I,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,grace fulmer,ARCH-2700,2020
-ARCH,2710,1.0,Structures II,0.48,0.33,0.07,0.0,0.04,0%,0.0,0.0,amy christine trick,ARCH-2710,2020
-ARCH,3500,1.0,Intro to Urban Contexts,0.47,0.47,0.0,0.0,0.0,0%,0.0,0.06,douglas hecker,ARCH-3500,2020
-ARCH,3500,2.0,Intro to Urban Contexts,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,berrin terim,ARCH-3500,2020
-ARCH,3500,3.0,Intro to Urban Contexts,0.33,0.56,0.11,0.0,0.0,0%,0.0,0.0,david lee,ARCH-3500,2020
-ARCH,3500,4.0,Intro to Urban Contexts,0.69,0.13,0.19,0.0,0.0,0%,0.0,0.0,clarissa mendez,ARCH-3500,2020
-ARCH,3500,5.0,Intro to Urban Contexts,0.4,0.4,0.2,0.0,0.0,0%,0.0,0.0,julie poe wilkerson,ARCH-3500,2020
-ARCH,3510,1.0,Studio Clemson,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,dustin albright,ARCH-3510,2020
-ARCH,3540,1.0,Studio Barcelona,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,ARCH-3540,2020
-ARCH,4010,1.0,Architectural Portfolio,0.62,0.24,0.1,0.0,0.0,0%,0.0,0.05,clarissa mendez,ARCH-4010,2020
-ARCH,4010,2.0,Architectural Portfolio,0.59,0.29,0.12,0.0,0.0,0%,0.0,0.0,virginia ellyn melnyk,ARCH-4010,2020
-ARCH,4010,3.0,Architectural Portfolio,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,george schafer,ARCH-4010,2020
-ARCH,4010,4.0,Architectural Portfolio,0.57,0.33,0.05,0.0,0.05,0%,0.0,0.0,brandon george pass,ARCH-4010,2020
-ARCH,4120,2.0,History Research,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,ARCH-4120,2020
-ARCH,4140,2.0,Design Seminar,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,ARCH-4140,2020
-ARCH,6850,1.0,H/Th: Arch+Health,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dina battisto,ARCH-6850,2020
-ARCH,8100,1.0,Visualization I,0.83,0.09,0.04,0.0,0.0,0%,0.0,0.0,joseph choma,ARCH-8100,2020
-ARCH,8210,1.0,Research Methods,0.83,0.15,0.0,0.0,0.0,0%,0.0,0.02,dina battisto,ARCH-8210,2020
-ARCH,8410,1.0,Arch Studio I,0.55,0.36,0.0,0.0,0.0,0%,0.0,0.0,peter laurence,ARCH-8410,2020
-ARCH,8410,2.0,Arch Studio I,0.6,0.3,0.0,0.0,0.1,0%,0.0,0.0,ufuk ersoy,ARCH-8410,2020
-ARCH,8510,1.0,Design Studio III,0.33,0.58,0.08,0.0,0.0,0%,0.0,0.0,ulrike ann- heine,ARCH-8510,2020
-ARCH,8510,2.0,Design Studio III,0.17,0.83,0.0,0.0,0.0,0%,0.0,0.0,santa cruz franco,ARCH-8510,2020
-ARCH,8510,3.0,Design Studio III,0.31,0.54,0.08,0.0,0.0,0%,0.0,0.08,george schafer,ARCH-8510,2020
-ARCH,8570,1.0,Design Studio V,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,dustin albright,ARCH-8570,2020
-ARCH,8570,4.0,Design Studio V,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,raymond huff,ARCH-8570,2020
-ARCH,8600,1.0,History/Theory I,0.57,0.38,0.0,0.0,0.0,0%,0.0,0.0,berrin terim,ARCH-8600,2020
-ARCH,8700,1.0,Structures I,0.71,0.12,0.06,0.0,0.06,0%,0.0,0.0,dustin albright,ARCH-8700,2020
-ARCH,8790,2.0,Digtial Manufacturing Proc,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,douglas hecker,ARCH-8790,2020
-ARCH,8810,1.0,Pro Practice Survey,0.76,0.22,0.0,0.0,0.0,0%,0.0,0.02,byron malet edwards,ARCH-8810,2020
-ARCH,8950,1.0,A+H Studio: Projects,0.35,0.59,0.0,0.0,0.0,0%,0.0,0.0,david allison,ARCH-8950,2020
-ART,1050,1.0,Foundation Drawing I,0.6,0.2,0.1,0.1,0.0,0%,0.0,0.0,lori brook johnson,ART-1050,2020
-ART,1510,1.0,Foundations Art I,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,cuba rachel lynn de lynn,ART-1510,2020
-ART,1510,2.0,Foundations Art I,0.6,0.3,0.0,0.1,0.0,0%,0.0,0.0,brooks harris stevens,ART-1510,2020
-ART,2100,1.0,Art Appreciation,0.91,0.0,0.0,0.05,0.05,0%,0.0,0.0,dustin massey,ART-2100,2020
-ART,2100,2.0,Art Appreciation,0.86,0.09,0.0,0.05,0.0,0%,0.0,0.0,megan waller,ART-2100,2020
-ART,2100,4.0,Art Appreciation,0.82,0.09,0.0,0.05,0.0,0%,0.0,0.05,dustin massey,ART-2100,2020
-ART,2100,5.0,Art Appreciation,0.91,0.05,0.0,0.0,0.05,0%,0.0,0.0,drie katherine van,ART-2100,2020
-ART,2100,6.0,Art Appreciation,0.75,0.15,0.05,0.0,0.05,0%,0.0,0.0,dustin massey,ART-2100,2020
-ART,2150,1.0,Begin Graphic Design,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,david sidney gerhard,ART-2150,2020
-ART,4200,1.0,Time Base & Digital Art Fn,0.5,0.1,0.1,0.0,0.2,0%,0.0,0.1,cuba rachel lynn de lynn,ART-4200,2020
-AS,1090,1.0,Heritage & Values of USAF,0.82,0.06,0.0,0.0,0.0,0%,0.0,0.12,joseph blanton,AS-1090,2020
-AS,1090,2.0,Heritage & Values of USAF,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,joseph blanton,AS-1090,2020
-AS,1090,3.0,Heritage & Values of USAF,0.94,0.0,0.06,0.0,0.0,0%,0.0,0.0,joseph blanton,AS-1090,2020
-AS,2090,2.0,Team & Ldrshp Fundamen,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,ryan pierce,AS-2090,2020
-AS,3090,1.0,Leading & Effective Comm,0.91,0.0,0.09,0.0,0.0,0%,0.0,0.0,wayne leneau,AS-3090,2020
-ASL,1010,1.0,Am Sign Lang I,0.58,0.21,0.21,0.0,0.0,0%,0.0,0.0,jason hurdich,ASL-1010,2020
-ASL,1010,2.0,Am Sign Lang I,0.83,0.08,0.04,0.0,0.04,0%,0.0,0.0,william clements,ASL-1010,2020
-ASL,1010,3.0,Am Sign Lang I,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,william clements,ASL-1010,2020
-ASL,1010,4.0,Am Sign Lang I,0.76,0.16,0.08,0.0,0.0,0%,0.0,0.0,jody herbert cripps,ASL-1010,2020
-ASL,1020,1.0,Am Sign Lang I,0.7,0.17,0.09,0.0,0.0,0%,0.0,0.04,jason hurdich,ASL-1020,2020
-ASL,1020,2.0,Am Sign Lang I,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,jason hurdich,ASL-1020,2020
-ASL,2010,1.0,Am Sign Lang II,0.67,0.21,0.0,0.08,0.0,0%,0.0,0.04,dunn kim misener,ASL-2010,2020
-ASL,2010,2.0,Am Sign Lang II,0.63,0.33,0.04,0.0,0.0,0%,0.0,0.0,dunn kim misener,ASL-2010,2020
-ASL,2020,1.0,Am Sign Lang II,0.31,0.56,0.13,0.0,0.0,0%,0.0,0.0,jason hurdich,ASL-2020,2020
-ASL,2020,2.0,Am Sign Lang II,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dunn kim misener,ASL-2020,2020
-ASL,3010,1.0,Advanced A S L I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dunn kim misener,ASL-3010,2020
-ASL,3490,2.0,Adv App in Asl,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.0,william clements,ASL-3490,2020
-ASL,4010,1.0,Linguistics of ASL,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,jody herbert cripps,ASL-4010,2020
-ASTR,1010,1.0,Solar System Astronomy,0.61,0.22,0.07,0.06,0.01,0%,0.0,0.02,david connick,ASTR-1010,2020
-ASTR,1010,2.0,Solar System Astronomy,0.57,0.32,0.05,0.03,0.02,0%,0.0,0.01,david connick,ASTR-1010,2020
-ASTR,1020,1.0,Stellar Astronomy,0.57,0.28,0.1,0.01,0.03,0%,0.0,0.01,joan marler,ASTR-1020,2020
-ASTR,1030,1.0,Solar Systm Astr Lab,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,david connick,ASTR-1030,2020
-ASTR,1030,2.0,Solar Systm Astr Lab,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,david connick,ASTR-1030,2020
-ASTR,1030,3.0,Solar Systm Astr Lab,0.5,0.38,0.0,0.04,0.0,0%,0.0,0.08,david connick,ASTR-1030,2020
-ASTR,1030,4.0,Solar Systm Astr Lab,0.45,0.41,0.05,0.0,0.05,0%,0.0,0.05,david connick,ASTR-1030,2020
-ASTR,1030,5.0,Solar Systm Astr Lab,0.5,0.38,0.04,0.04,0.04,0%,0.0,0.0,david connick,ASTR-1030,2020
-ASTR,1030,6.0,Solar Systm Astr Lab,0.7,0.22,0.0,0.04,0.0,0%,0.0,0.04,david connick,ASTR-1030,2020
-ASTR,1030,7.0,Solar Systm Astr Lab,0.39,0.48,0.09,0.0,0.04,0%,0.0,0.0,david connick,ASTR-1030,2020
-ASTR,1030,8.0,Solar Systm Astr Lab,0.43,0.39,0.09,0.0,0.09,0%,0.0,0.0,david connick,ASTR-1030,2020
-ASTR,1030,9.0,Solar Systm Astr Lab,0.48,0.43,0.0,0.0,0.04,0%,0.0,0.04,david connick,ASTR-1030,2020
-ASTR,1030,10.0,Solar Systm Astr Lab,0.38,0.54,0.0,0.08,0.0,0%,0.0,0.0,david connick,ASTR-1030,2020
-ASTR,1030,11.0,Solar Systm Astr Lab,0.71,0.13,0.13,0.0,0.04,0%,0.0,0.0,david connick,ASTR-1030,2020
-ASTR,1040,1.0,Stellar Astr Lab,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,david connick,ASTR-1040,2020
-ASTR,1040,2.0,Stellar Astr Lab,0.79,0.04,0.13,0.0,0.04,0%,0.0,0.0,david connick,ASTR-1040,2020
-ASTR,1040,4.0,Stellar Astr Lab,0.74,0.22,0.04,0.0,0.0,0%,0.0,0.0,david connick,ASTR-1040,2020
-ASTR,3020,1.0,Stellar Astrophysics,0.53,0.33,0.07,0.0,0.0,0%,0.0,0.07,mark leising,ASTR-3020,2020
-AUD,1850,1.0,Intro to Audio Tech,0.46,0.23,0.08,0.08,0.08,0%,0.0,0.08,hamilton altstatt,AUD-1850,2020
-AUD,2800,1.0,Sound Reinforcement,0.3,0.5,0.1,0.0,0.1,0%,0.0,0.0,kenneth moore,AUD-2800,2020
-AUE,6010,1.0,Vehicle Dynamics,0.7,0.25,0.0,0.0,0.0,0%,0.0,0.05,matthias schmid,AUE-6010,2020
-AUE,6020,1.0,Adv & Electrified Powertra,0.5,0.19,0.13,0.0,0.06,0%,0.0,0.13,benjamin lawler,AUE-6020,2020
-AUE,6080,1.0,Vehicle Testing & Characte,0.5,0.23,0.23,0.0,0.0,0%,0.0,0.0,james potter,AUE-6080,2020
-AUE,6930,3.0,Lightweight Design Using C,0.71,0.23,0.03,0.0,0.0,0%,0.0,0.03,srikanth pilla,AUE-6930,2020
-AUE,8260,1.0,Vehicle Diagnostics,0.38,0.54,0.0,0.0,0.0,0%,0.0,0.08,pierluigi pisu,AUE-8260,2020
-AUE,8270,1.0,Auto Cntrl Sys Des,0.73,0.17,0.05,0.0,0.0,0%,0.0,0.05,qilun zhu,AUE-8270,2020
-AUE,8330,30.0,Auto Manuf Proc Devl,0.53,0.41,0.03,0.0,0.0,0%,0.0,0.03,michael mears,AUE-8330,2020
-AUE,8350,100.0,Auto Electronics,0.73,0.2,0.0,0.0,0.0,0%,0.0,0.07,yunyi jia,AUE-8350,2020
-AUE,8570,1.0,Light-Weight Automotive,0.86,0.0,0.14,0.0,0.0,0%,0.0,0.0,david schmueser,AUE-8570,2020
-AUE,8690,1.0,Qual Assur Automotiv Ma,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,dee ann wood kivett wood,AUE-8690,2020
-AUE,8700,1.0,Automotive Business Conc,0.6,0.36,0.02,0.0,0.0,0%,0.0,0.02,johnell brooks,AUE-8700,2020
-AUE,8810,3.0,Automotive Systems Over,0.4,0.4,0.12,0.0,0.0,0%,0.0,0.08,christiaan paredis,AUE-8810,2020
-AUE,8930,1.0,Adv Vehicle Struct Analysis,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,david schmueser,AUE-8930,2020
-AUE,8930,5.0,Robust Predictive Control,0.52,0.22,0.22,0.0,0.0,0%,0.0,0.04,beshah ayalew,AUE-8930,2020
-AUE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert prucka,AUE-9910,2020
-AUE,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yunyi jia,AUE-9910,2020
-AUE,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,srikanth pilla,AUE-9910,2020
-AUE,9910,21.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rahul rai,AUE-9910,2020
-AVS,1000,1.0,Orientation to AVS,0.79,0.1,0.07,0.02,0.02,0%,0.0,0.01,kristine lang vernon,AVS-1000,2020
-AVS,1500,1.0,Intro Animal Science,0.26,0.46,0.23,0.04,0.01,0%,0.0,0.01,joseph bertrand,AVS-1500,2020
-AVS,1500,2.0,Intro Animal Science,0.2,0.47,0.24,0.06,0.0,0%,0.0,0.02,joseph bertrand,AVS-1500,2020
-AVS,1510,1.0,Intro Ani Sci Lab,0.6,0.32,0.08,0.0,0.0,0%,0.0,0.0,richelle miller,AVS-1510,2020
-AVS,1510,2.0,Intro Ani Sci Lab,0.86,0.1,0.0,0.05,0.0,0%,0.0,0.0,richelle miller,AVS-1510,2020
-AVS,1510,3.0,Intro Ani Sci Lab,0.67,0.25,0.04,0.04,0.0,0%,0.0,0.0,richelle miller,AVS-1510,2020
-AVS,1510,5.0,Intro Ani Sci Lab,0.55,0.25,0.05,0.1,0.0,0%,0.0,0.05,richelle miller,AVS-1510,2020
-AVS,1510,6.0,Intro Ani Sci Lab,0.61,0.26,0.04,0.09,0.0,0%,0.0,0.0,richelle miller,AVS-1510,2020
-AVS,1510,7.0,Intro Ani Sci Lab,0.81,0.13,0.0,0.0,0.0,0%,0.0,0.06,richelle miller,AVS-1510,2020
-AVS,1510,8.0,Intro Ani Sci Lab,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,richelle miller,AVS-1510,2020
-AVS,1510,9.0,Intro Ani Sci Lab,0.43,0.5,0.07,0.0,0.0,0%,0.0,0.0,richelle miller,AVS-1510,2020
-AVS,2040,1.0,Horse Care Techniques,0.87,0.1,0.0,0.0,0.03,0%,0.0,0.0,chelsea sinclair,AVS-2040,2020
-AVS,3010,1.0,Anat & Phys Dom Ani,0.67,0.26,0.04,0.0,0.0,0%,0.0,0.02,glenn birrenkott,AVS-3010,2020
-AVS,3010,400.0,Anat & Phys Dom Ani,0.54,0.42,0.0,0.04,0.0,0%,0.0,0.0,glenn birrenkott,AVS-3010,2020
-AVS,3100,1.0,Animal Health,0.78,0.16,0.03,0.0,0.03,0%,0.0,0.0,james strickland,AVS-3100,2020
-AVS,3700,1.0,Principles of Animal Nutriti,0.59,0.25,0.08,0.02,0.0,0%,0.0,0.03,james strickland,AVS-3700,2020
-AVS,3750,1.0,Applied Animal Nutrition,0.22,0.39,0.26,0.04,0.0,0%,0.0,0.09,gustavo jose lascano,AVS-3750,2020
-AVS,4100,1.0,Domestic Ani Behav,0.84,0.08,0.07,0.01,0.0,0%,0.0,0.0,ahmed badr ali,AVS-4100,2020
-AVS,4100,2.0,Domestic Ani Behav,0.88,0.06,0.06,0.0,0.0,0%,0.0,0.0,ahmed badr ali,AVS-4100,2020
-AVS,4110,1.0,Animal Growth and Develo,0.58,0.24,0.06,0.05,0.05,0%,0.0,0.03,susan kay duckett,AVS-4110,2020
-AVS,4150,1.0,Contemporary Issues in AV,0.57,0.33,0.04,0.01,0.03,0%,0.0,0.01,chelsea sinclair,AVS-4150,2020
-AVS,4160,1.0,Equine Exercise Phys,0.47,0.37,0.05,0.0,0.11,0%,0.0,0.0,kristine lang vernon,AVS-4160,2020
-AVS,4500,1.0,Sustain Livestock Product,0.27,0.67,0.07,0.0,0.0,0%,0.0,0.0,matias jose aguerre,AVS-4500,2020
-AVS,4530,1.0,Animal Reproduction,0.13,0.49,0.13,0.18,0.0,0%,0.0,0.07,scott lee pratt,AVS-4530,2020
-AVS,4650,1.0,Animal Physiology I,0.74,0.15,0.07,0.04,0.0,0%,0.0,0.0,heather walker dunn,AVS-4650,2020
-AVS,4800,1.0,Vertebrate Endocrinology,0.81,0.13,0.03,0.0,0.03,0%,0.0,0.0,heather walker dunn,AVS-4800,2020
-AVS,4910,13.0,Analysis of Natural Produc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,james strickland,AVS-4910,2020
-AVS,4920,6.0,Grazing Horses CI,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,brittany perron,AVS-4920,2020
-AVS,8070,1.0,Prin of Sci Writing in AFLS,0.54,0.31,0.0,0.0,0.0,0%,0.0,0.15,jeryl jones,AVS-8070,2020
-BCHM,1030,1.0,Careers in Bioch/Gen,0.83,0.1,0.02,0.0,0.04,0%,0.0,0.02,alison starr-moss,BCHM-1030,2020
-BCHM,3010,1.0,Molecular Biochemistry,0.54,0.26,0.1,0.08,0.02,0%,0.0,0.0,cheryl ingram-smith,BCHM-3010,2020
-BCHM,3050,2.0,Essen Elements Bioch,0.45,0.33,0.17,0.0,0.04,0%,0.0,0.01,heidi anderson,BCHM-3050,2020
-BCHM,3050,3.0,Essen Elements Bioch,0.34,0.37,0.14,0.04,0.08,0%,0.0,0.03,suchitra chavan,BCHM-3050,2020
-BCHM,3050,4.0,Essen Elements Bioch,0.58,0.31,0.07,0.02,0.01,0%,0.0,0.01,heidi anderson,BCHM-3050,2020
-BCHM,3050,5.0,Essen Elements Bioch,0.33,0.45,0.12,0.05,0.0,0%,0.0,0.04,suchitra chavan,BCHM-3050,2020
-BCHM,4310,1.0,Physical Approach to Bioch,0.35,0.33,0.26,0.05,0.01,0%,0.0,0.0,weiguo cao,BCHM-4310,2020
-BCHM,4310,2.0,Phys App to Bioch (HON),0.5,0.42,0.08,0.0,0.0,0%,0.0,0.0,weiguo cao,BCHM-4310,2020
-BCHM,4330,1.0,Physical Biochemistry Lab,0.81,0.13,0.06,0.0,0.0,0%,0.0,0.0,geoffrey ford,BCHM-4330,2020
-BCHM,4330,2.0,Physical Biochemistry Lab,0.81,0.13,0.0,0.0,0.06,0%,0.0,0.0,geoffrey ford,BCHM-4330,2020
-BCHM,4330,3.0,Physical Biochemistry Lab,0.81,0.06,0.13,0.0,0.0,0%,0.0,0.0,geoffrey ford,BCHM-4330,2020
-BCHM,4330,4.0,Physical Biochemistry Lab,0.88,0.06,0.0,0.06,0.0,0%,0.0,0.0,geoffrey ford,BCHM-4330,2020
-BCHM,4330,5.0,Physical Biochemistry Lab,0.76,0.0,0.12,0.06,0.06,0%,0.0,0.0,geoffrey ford,BCHM-4330,2020
-BCHM,4400,1.0,Bioinformatics,0.82,0.05,0.05,0.0,0.07,0%,0.0,0.02,frank feltus,BCHM-4400,2020
-BCHM,4430,1.0,Molecular Basis of Disease,0.55,0.36,0.09,0.0,0.0,0%,0.0,0.0,james morris,BCHM-4430,2020
-BCHM,8250,1.0,Seminar I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rajandeep sekhon,BCHM-8250,2020
-BDSI,8000,1.0,Biomed Data Sci & Info Se,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brian dean,BDSI-8000,2020
-BE,2100,1.0,Intro to Biosystems Engr,0.85,0.11,0.0,0.0,0.0,0%,0.0,0.04,gamboa vanegas,BE-2100,2020
-BE,3200,1.0,Principles & Prac of Geom,0.59,0.32,0.09,0.0,0.0,0%,0.0,0.0,tom owino,BE-3200,2020
-BE,4100,1.0,Biological Kinetics,0.22,0.57,0.22,0.0,0.0,0%,0.0,0.0,caye marie drapcho,BE-4100,2020
-BE,4150,1.0,Instr & Control for Biosys E,0.53,0.33,0.0,0.07,0.07,0%,0.0,0.0,rui xiao,BE-4150,2020
-BE,4210,1.0,Engr Sys for Soil Water Mg,0.81,0.06,0.13,0.0,0.0,0%,0.0,0.0,christophe darnault,BE-4210,2020
-BE,4740,1.0,BE Design Project Managm,0.88,0.06,0.06,0.0,0.0,0%,0.0,0.0,tom owino,BE-4740,2020
-BE,4750,1.0,BE Capstone Design,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,christophe darnault,BE-4750,2020
-BIOE,1010,1.0,Biol for Bioengr,0.67,0.2,0.07,0.0,0.0,0%,0.0,0.0,tyler george harvey,BIOE-1010,2020
-BIOE,2000,1.0,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,98%,0.0,0.01,agneta simionescu,BIOE-2000,2020
-BIOE,2010,2.0,Intro Biomed Engr,0.4,0.5,0.07,0.02,0.01,0%,0.0,0.01,charles webb,BIOE-2010,2020
-BIOE,3000,1.0,Bioeng Ethics Entrepreneu,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,tyler george harvey,BIOE-3000,2020
-BIOE,3020,1.0,Biomaterials,0.67,0.25,0.05,0.0,0.0,0%,0.0,0.03,alexey vertegel,BIOE-3020,2020
-BIOE,3100,1.0,Engr Analysis of Physiol Pr,0.85,0.14,0.01,0.0,0.0,0%,0.0,0.0,brian william booth,BIOE-3100,2020
-BIOE,3200,1.0,Biomechanics,0.68,0.3,0.0,0.0,0.0,0%,0.0,0.03,jiro nagatomi,BIOE-3200,2020
-BIOE,3210,1.0,Biofluid Mechanics,0.62,0.31,0.07,0.0,0.0,0%,0.0,0.0,zhi gao,BIOE-3210,2020
-BIOE,3460,1.0,Biomolecular Thermodyna,0.43,0.41,0.14,0.0,0.0,0%,0.0,0.01,robert latour,BIOE-3460,2020
-BIOE,3470,1.0,Transport Processes in Bio,0.8,0.14,0.02,0.04,0.0,0%,0.0,0.0,renee nicole cottle,BIOE-3470,2020
-BIOE,3700,1.0,Bioinst & Imaging,0.67,0.3,0.04,0.0,0.0,0%,0.0,0.0,jordon gilmore,BIOE-3700,2020
-BIOE,4000,1.0,Bioengr Leadshp & MedTe,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,martine laberge,BIOE-4000,2020
-BIOE,4010,1.0,Bioengineering Design The,0.97,0.03,0.0,0.0,0.0,0%,0.0,0.0,john desjardins,BIOE-4010,2020
-BIOE,4010,2.0,Bioengineering Design The,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,john desjardins,BIOE-4010,2020
-BIOE,4030,1.0,Applied Bio E Design,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,ravikiran singapogu,BIOE-4030,2020
-BIOE,4120,1.0,Orthopaedic Engr and Path,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,melinda harman,BIOE-4120,2020
-BIOE,4350,1.0,Computational Modeling i,0.61,0.33,0.0,0.0,0.0,0%,0.0,0.06,william richardson,BIOE-4350,2020
-BIOE,4400,1.0,Biopharmaceutical Engine,0.37,0.42,0.05,0.0,0.0,0%,0.0,0.16,sarah harcum,BIOE-4400,2020
-BIOE,4480,1.0,Tissue Engineering,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,angela alexander,BIOE-4480,2020
-BIOE,6120,1.0,Orthopaedic Engr & Pathol,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,melinda harman,BIOE-6120,2020
-BIOE,6340,1.0,Cardiovascular Biomechani,0.5,0.33,0.17,0.0,0.0,0%,0.0,0.0,ethan kung,BIOE-6340,2020
-BIOE,6350,1.0,Computational Modeling i,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,william richardson,BIOE-6350,2020
-BIOE,6400,1.0,Biopharmaceutical Engine,0.42,0.5,0.0,0.0,0.0,0%,0.0,0.08,sarah harcum,BIOE-6400,2020
-BIOE,8000,843.0,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,ann catherine foley,BIOE-8000,2020
-BIOE,8020,1.0,Biocompatibility,0.25,0.75,0.0,0.0,0.0,0%,0.0,0.0,narendra vyavahare,BIOE-8020,2020
-BIOE,8900,2.0,Bioengineering Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy mercuri,BIOE-8900,2020
-BIOE,9910,3.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,john desjardins,BIOE-9910,2020
-BIOE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melinda harman,BIOE-9910,2020
-BIOE,9910,11.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy mercuri,BIOE-9910,2020
-BIOE,9910,13.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,william richardson,BIOE-9910,2020
-BIOE,9910,17.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,narendra vyavahare,BIOE-9910,2020
-BIOE,9910,805.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy gilbert,BIOE-9910,2020
-BIOL,1010,1.0,Frontiers in Biology I,0.82,0.13,0.03,0.0,0.01,0%,0.0,0.01,michael childress,BIOL-1010,2020
-BIOL,1010,2.0,Frontiers in Biology I,0.87,0.09,0.01,0.01,0.01,0%,0.0,0.0,michael childress,BIOL-1010,2020
-BIOL,1030,1.0,General Biology I,0.29,0.25,0.24,0.12,0.08,0%,0.0,0.02,nora espinoza,BIOL-1030,2020
-BIOL,1030,2.0,General Biology I,0.27,0.38,0.18,0.08,0.04,0%,0.0,0.05,cassandra joy may,BIOL-1030,2020
-BIOL,1030,3.0,General Biology I,0.24,0.22,0.4,0.01,0.05,0%,0.0,0.07,salvatore sparace,BIOL-1030,2020
-BIOL,1030,4.0,General Biology I,0.22,0.29,0.22,0.11,0.08,0%,0.0,0.09,nathan redding,BIOL-1030,2020
-BIOL,1030,5.0,General Biology I (HON),0.48,0.33,0.19,0.0,0.0,0%,0.0,0.0,nora espinoza,BIOL-1030,2020
-BIOL,1040,1.0,General Biology II,0.52,0.39,0.06,0.0,0.0,0%,0.0,0.03,donna weinbrenner,BIOL-1040,2020
-BIOL,1050,1.0,General Biology Lab I,0.63,0.17,0.08,0.04,0.04,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,2.0,General Biology Lab I,0.91,0.04,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,3.0,General Biology Lab I,0.58,0.25,0.08,0.0,0.0,0%,0.0,0.08,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,4.0,General Biology Lab I,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,5.0,General Biology Lab I,0.61,0.26,0.09,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,6.0,General Biology Lab I,0.5,0.33,0.04,0.0,0.0,0%,0.0,0.13,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,7.0,General Biology Lab I,0.42,0.46,0.04,0.04,0.04,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,8.0,General Biology Lab I,0.83,0.04,0.0,0.04,0.04,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,9.0,General Biology Lab I,0.42,0.21,0.08,0.08,0.04,0%,0.0,0.08,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,10.0,General Biology Lab I,0.22,0.3,0.3,0.0,0.09,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,11.0,General Biology Lab I,0.46,0.33,0.08,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,12.0,General Biology Lab I,0.17,0.5,0.04,0.0,0.08,0%,0.0,0.21,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,13.0,General Biology Lab I,0.46,0.29,0.08,0.08,0.04,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,14.0,General Biology Lab I,0.29,0.5,0.08,0.04,0.08,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,15.0,General Biology Lab I,0.52,0.3,0.0,0.0,0.13,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,16.0,General Biology Lab I,0.63,0.33,0.04,0.0,0.0,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,17.0,General Biology Lab I,0.33,0.38,0.08,0.08,0.08,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,18.0,General Biology Lab I,0.48,0.26,0.0,0.04,0.09,0%,0.0,0.13,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,19.0,General Biology Lab I,0.54,0.29,0.0,0.04,0.04,0%,0.0,0.08,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,20.0,General Biology Lab I,0.74,0.13,0.09,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,21.0,General Biology Lab I,0.46,0.29,0.08,0.04,0.13,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,22.0,General Biology Lab I,0.54,0.21,0.08,0.08,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,23.0,General Biology Lab I,0.58,0.17,0.08,0.0,0.04,0%,0.0,0.13,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,24.0,General Biology Lab I,0.64,0.05,0.14,0.09,0.09,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,25.0,General Biology Lab I,0.57,0.29,0.07,0.0,0.0,0%,0.0,0.07,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,26.0,General Biology Lab I,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,27.0,General Biology Lab I,0.5,0.21,0.17,0.08,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,28.0,General Biology Lab I,0.67,0.17,0.08,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,29.0,General Biology Lab I,0.79,0.04,0.13,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,30.0,General Biology Lab I,0.42,0.25,0.08,0.08,0.13,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,31.0,General Biology Lab I,0.75,0.17,0.0,0.04,0.04,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,32.0,General Biology Lab I,0.58,0.25,0.08,0.0,0.0,0%,0.0,0.08,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,33.0,General Biology Lab I,0.33,0.33,0.1,0.0,0.1,0%,0.0,0.14,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,34.0,General Biology Lab I,0.88,0.04,0.04,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,35.0,General Biology Lab I,0.63,0.17,0.04,0.04,0.08,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,36.0,General Biology Lab I,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,37.0,General Biology Lab I,0.58,0.13,0.21,0.04,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,38.0,General Biology Lab I,0.83,0.04,0.04,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,39.0,General Biology Lab I,0.75,0.13,0.04,0.0,0.08,0%,0.0,0.0,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,40.0,General Biology Lab I,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,41.0,General Biology Lab I,0.71,0.25,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,42.0,General Biology Lab I,0.71,0.13,0.0,0.04,0.04,0%,0.0,0.08,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,43.0,General Biology Lab I,0.29,0.33,0.1,0.14,0.1,0%,0.0,0.05,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,44.0,General Biology Lab I,0.68,0.18,0.0,0.0,0.05,0%,0.0,0.05,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1050,45.0,General Biology Lab I,0.45,0.27,0.09,0.09,0.0,0%,0.0,0.09,tafadzwa kaisa,BIOL-1050,2020
-BIOL,1090,1.0,Intro to Life Sci,0.8,0.17,0.03,0.0,0.0,0%,0.0,0.0,renea chris hardwick,BIOL-1090,2020
-BIOL,1100,1.0,Principles of Biology I,0.41,0.38,0.09,0.04,0.03,0%,0.0,0.05,renea chris hardwick,BIOL-1100,2020
-BIOL,1100,2.0,Principles of Biology I,0.56,0.28,0.1,0.05,0.01,0%,0.0,0.0,renea chris hardwick,BIOL-1100,2020
-BIOL,1100,3.0,Principles of Biology I,0.36,0.33,0.2,0.03,0.03,0%,0.0,0.06,verna minor,BIOL-1100,2020
-BIOL,1100,4.0,Principles of Biology I,0.28,0.47,0.15,0.06,0.04,0%,0.0,0.0,verna minor,BIOL-1100,2020
-BIOL,1100,5.0,Principles of Biology I (HO,0.79,0.14,0.04,0.0,0.04,0%,0.0,0.0,verna minor,BIOL-1100,2020
-BIOL,1230,1.0,Keys to Human Biol,0.21,0.34,0.26,0.06,0.09,0%,0.0,0.04,lisa ruggiero wagner,BIOL-1230,2020
-BIOL,2220,1.0,Human Anat and Physiolog,0.21,0.28,0.3,0.1,0.07,0%,0.0,0.04,john cummings,BIOL-2220,2020
-BIOL,2220,3.0,Human Anat and Physiolog,0.28,0.38,0.17,0.11,0.04,0%,0.0,0.03,john cummings,BIOL-2220,2020
-BIOL,3030,1.0,Vertebrate Biology,0.53,0.29,0.11,0.05,0.03,0%,0.0,0.01,virginia abernathy,BIOL-3030,2020
-BIOL,3030,2.0,Vertebrate Biology (HON),0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,virginia abernathy,BIOL-3030,2020
-BIOL,3030,3.0,Vertebrate Biology,0.55,0.27,0.13,0.03,0.02,0%,0.0,0.0,virginia abernathy,BIOL-3030,2020
-BIOL,3040,1.0,Biology of Plants,0.29,0.27,0.18,0.16,0.08,0%,0.0,0.02,nathan redding,BIOL-3040,2020
-BIOL,3070,1.0,Vertebrate Biology Lab,0.69,0.23,0.08,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3070,2.0,Vertebrate Biology Lab,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3070,4.0,Vertebrate Biology Lab,0.6,0.36,0.04,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3070,5.0,Vertebrate Biology Lab,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3070,6.0,Vertebrate Biology Lab,0.84,0.08,0.04,0.0,0.0,0%,0.0,0.04,richard blob,BIOL-3070,2020
-BIOL,3070,7.0,Vertebrate Biology Lab,0.6,0.28,0.12,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3070,8.0,Vertebrate Biology Lab,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3070,9.0,Vertebrate Biology Lab,0.72,0.24,0.04,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3070,10.0,Vertebrate Biology Lab,0.5,0.33,0.06,0.06,0.06,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3070,11.0,Vertebrate Biology Lab,0.6,0.32,0.08,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-3070,2020
-BIOL,3080,1.0,Biology of Plants Practicu,0.64,0.27,0.0,0.0,0.0,0%,0.0,0.09,nathan redding,BIOL-3080,2020
-BIOL,3080,3.0,Biology of Plants Practicu,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,nathan redding,BIOL-3080,2020
-BIOL,3080,4.0,Biology of Plants Practicu,0.55,0.27,0.09,0.09,0.0,0%,0.0,0.0,nathan redding,BIOL-3080,2020
-BIOL,3080,5.0,Biology of Plants Practicu,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,nathan redding,BIOL-3080,2020
-BIOL,3150,1.0,Functional Human Anatom,0.4,0.39,0.12,0.04,0.02,0%,0.0,0.03, mcnutt-scott,BIOL-3150,2020
-BIOL,3350,1.0,Evolutionary Biology,0.35,0.45,0.14,0.04,0.01,0%,0.0,0.02,matthew koski,BIOL-3350,2020
-BIOL,3510,1.0,Biological Anthropology,0.86,0.07,0.04,0.04,0.0,0%,0.0,0.0,katherine weisensee,BIOL-3510,2020
-BIOL,4030,1.0,Intro to Applied Genomics,0.38,0.13,0.25,0.0,0.13,0%,0.0,0.13,vincent paul richards,BIOL-4030,2020
-BIOL,4200,1.0,Neurobiology,0.97,0.0,0.0,0.0,0.02,0%,0.0,0.02,david feliciano,BIOL-4200,2020
-BIOL,4250,1.0,Introductory Mycology,0.32,0.33,0.2,0.06,0.02,0%,0.0,0.06,julia louise kerrigan,BIOL-4250,2020
-BIOL,4260,1.0,Mycology Practicum,0.71,0.21,0.0,0.0,0.07,0%,0.0,0.0,julia louise kerrigan,BIOL-4260,2020
-BIOL,4260,2.0,Mycology Practicum,0.6,0.2,0.0,0.07,0.0,0%,0.0,0.13,julia louise kerrigan,BIOL-4260,2020
-BIOL,4400,1.0,Developmental Animal Bio,0.4,0.29,0.17,0.13,0.0,0%,0.0,0.02,kara powder,BIOL-4400,2020
-BIOL,4410,1.0,Ecology,0.46,0.36,0.1,0.05,0.01,0%,0.0,0.0,sharon bewick,BIOL-4410,2020
-BIOL,4420,1.0,Biogeography,0.58,0.21,0.15,0.03,0.0,0%,0.0,0.03,michael sears,BIOL-4420,2020
-BIOL,4610,1.0,Cell Biology,0.67,0.3,0.03,0.0,0.0,0%,0.0,0.0,susan chapman,BIOL-4610,2020
-BIOL,4610,2.0,Cell Biology (HON),0.71,0.21,0.08,0.0,0.0,0%,0.0,0.0,susan chapman,BIOL-4610,2020
-BIOL,4610,3.0,Cell Biology,0.56,0.4,0.04,0.0,0.0,0%,0.0,0.0,susan chapman,BIOL-4610,2020
-BIOL,4620,1.0,Cell Biology Lab (Lec),0.82,0.14,0.0,0.04,0.0,0%,0.0,0.0,xianzhong yu,BIOL-4620,2020
-BIOL,4620,3.0,Cell Biology Lab (Lec),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,xianzhong yu,BIOL-4620,2020
-BIOL,4620,4.0,Cell Biology Lab (Lec),0.72,0.08,0.12,0.08,0.0,0%,0.0,0.0,xianzhong yu,BIOL-4620,2020
-BIOL,4620,5.0,Cell Biology Lab (Lec),0.93,0.04,0.04,0.0,0.0,0%,0.0,0.0,xianzhong yu,BIOL-4620,2020
-BIOL,4620,6.0,Cell Biology Lab (Lec),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,xianzhong yu,BIOL-4620,2020
-BIOL,4620,7.0,Cell Biology Lab (Lec),0.92,0.04,0.0,0.0,0.04,0%,0.0,0.0,xianzhong yu,BIOL-4620,2020
-BIOL,4620,8.0,Cell Biology Lab (Lec),0.77,0.08,0.08,0.0,0.08,0%,0.0,0.0,xianzhong yu,BIOL-4620,2020
-BIOL,4670,1.0,Principles of Hematology,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,vincent gallicchio,BIOL-4670,2020
-BIOL,4750,1.0,Comparative Physiology,0.48,0.2,0.16,0.06,0.08,0%,0.0,0.02,matthew turnbull,BIOL-4750,2020
-BIOL,4800,1.0,Vertebrate Endocrinology,0.4,0.3,0.3,0.0,0.0,0%,0.0,0.0,william baldwin,BIOL-4800,2020
-BIOL,4930,2.0,Sr Sem:Extinct & Macro Ev,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,nora espinoza,BIOL-4930,2020
-BIOL,6030,1.0,Intro to Applied Genomics,0.23,0.62,0.08,0.0,0.08,0%,0.0,0.0,vincent paul richards,BIOL-6030,2020
-BIOL,8000,1.0,Concepts in EEOB,0.86,0.0,0.14,0.0,0.0,0%,0.0,0.0,richard blob,BIOL-8000,2020
-BIOL,8010,1.0,Concepts in MCDB,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,zhicheng dou,BIOL-8010,2020
-BIOL,8070,1.0,Readings in MCDB,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,zhicheng dou,BIOL-8070,2020
-BIOL,8070,2.0,Readings in Evolution,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jennifer hodge,BIOL-8070,2020
-BIOL,8070,3.0,Readings in Ecology,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert fritz baldwin,BIOL-8070,2020
-BIOL,8120,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,zhicheng dou,BIOL-8120,2020
-BIOL,8130,1.0,Grad Teach Assist Colloqui,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,john cummings,BIOL-8130,2020
-BIOL,8400,1.0,Understanding Biological I,0.53,0.16,0.03,0.0,0.06,0%,0.0,0.16,virginia abernathy,BIOL-8400,2020
-BIOL,8420,1.0,Understand Cellular Proce,0.56,0.27,0.11,0.0,0.0,0%,0.0,0.03,kaustubha qanungo,BIOL-8420,2020
-BIOL,8440,1.0,Understanding the Human,0.49,0.35,0.1,0.0,0.02,0%,0.0,0.03, mcnutt-scott,BIOL-8440,2020
-BMOL,4250,1.0,Biomolecular Engineering,0.52,0.21,0.12,0.06,0.05,0%,0.0,0.05,marc birtwistle,BMOL-4250,2020
-BUS,1010,2.0,Business Foundations,0.53,0.37,0.11,0.0,0.0,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,3.0,Business Foundations,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,4.0,Business Foundations,0.37,0.58,0.0,0.0,0.05,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,6.0,Business Foundations,0.4,0.4,0.1,0.1,0.0,0%,0.0,0.0,neil monaghan,BUS-1010,2020
-BUS,1010,8.0,Business Foundations,0.42,0.29,0.16,0.02,0.07,0%,0.0,0.04,alexandra hazleton,BUS-1010,2020
-BUS,1010,10.0,Business Foundations,0.58,0.21,0.08,0.04,0.08,0%,0.0,0.0,sandy edge,BUS-1010,2020
-BUS,1010,11.0,Business Foundations,0.46,0.54,0.0,0.0,0.0,0%,0.0,0.0,sandy edge,BUS-1010,2020
-BUS,1010,12.0,Business Foundations,0.48,0.39,0.13,0.0,0.0,0%,0.0,0.0,sandy edge,BUS-1010,2020
-BUS,1010,14.0,Business Foundations,0.23,0.48,0.2,0.03,0.05,0%,0.0,0.02,keith balts,BUS-1010,2020
-BUS,1010,15.0,Business Foundations,0.83,0.08,0.04,0.04,0.0,0%,0.0,0.0,iulio edward barry de barry,BUS-1010,2020
-BUS,1010,16.0,Business Foundations,0.58,0.29,0.08,0.0,0.04,0%,0.0,0.0,iulio edward barry de barry,BUS-1010,2020
-BUS,1010,17.0,Business Foundations,0.83,0.08,0.0,0.08,0.0,0%,0.0,0.0,iulio edward barry de barry,BUS-1010,2020
-BUS,1010,18.0,Business Foundations,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,lawrence watson,BUS-1010,2020
-BUS,1010,19.0,Business Foundations,0.58,0.26,0.16,0.0,0.0,0%,0.0,0.0,lawrence watson,BUS-1010,2020
-BUS,1010,20.0,Business Foundations,0.26,0.58,0.11,0.0,0.0,0%,0.0,0.05,william tumblin,BUS-1010,2020
-BUS,1010,21.0,Business Foundations,0.39,0.39,0.17,0.06,0.0,0%,0.0,0.0,james walter dowis,BUS-1010,2020
-BUS,1010,22.0,Business Foundations,0.47,0.41,0.06,0.0,0.0,0%,0.0,0.06,james walter dowis,BUS-1010,2020
-BUS,1010,23.0,Business Foundations,0.56,0.22,0.22,0.0,0.0,0%,0.0,0.0,james walter dowis,BUS-1010,2020
-BUS,1010,25.0,Business Foundations,0.6,0.3,0.05,0.05,0.0,0%,0.0,0.0,james walter dowis,BUS-1010,2020
-BUS,1010,26.0,Business Foundations,0.8,0.1,0.0,0.0,0.05,0%,0.0,0.05,james walter dowis,BUS-1010,2020
-BUS,1010,27.0,Business Foundations,0.56,0.38,0.06,0.0,0.0,0%,0.0,0.0,james walter dowis,BUS-1010,2020
-BUS,1010,30.0,Business Foundations,0.54,0.29,0.17,0.0,0.0,0%,0.0,0.0,keith balts,BUS-1010,2020
-BUS,1010,31.0,Business Foundations,0.21,0.5,0.25,0.0,0.0,0%,0.0,0.04,keith balts,BUS-1010,2020
-BUS,1010,33.0,Business Foundations,0.7,0.2,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,34.0,Business Foundations,0.55,0.4,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,35.0,Business Foundations,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,36.0,Business Foundations,0.32,0.36,0.12,0.12,0.06,0%,0.0,0.03,neil monaghan,BUS-1010,2020
-BUS,1010,37.0,Business Foundations,0.4,0.34,0.18,0.05,0.02,0%,0.0,0.02,neil monaghan,BUS-1010,2020
-BUS,1010,39.0,Business Foundations,0.5,0.25,0.15,0.0,0.1,0%,0.0,0.0,james walter dowis,BUS-1010,2020
-BUS,1010,40.0,Business Foundations,0.35,0.4,0.15,0.05,0.0,0%,0.0,0.05,james walter dowis,BUS-1010,2020
-BUS,1010,41.0,Business Foundations,0.7,0.25,0.0,0.05,0.0,0%,0.0,0.0,james walter dowis,BUS-1010,2020
-BUS,1010,43.0,Business Foundations,0.42,0.13,0.33,0.13,0.0,0%,0.0,0.0,keith balts,BUS-1010,2020
-BUS,1010,44.0,Business Foundations,0.42,0.33,0.21,0.0,0.04,0%,0.0,0.0,keith balts,BUS-1010,2020
-BUS,1010,45.0,Business Foundations,0.38,0.38,0.21,0.04,0.0,0%,0.0,0.0,keith balts,BUS-1010,2020
-BUS,1010,47.0,Business Foundations,0.45,0.45,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,48.0,Business Foundations,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,49.0,Business Foundations,0.6,0.3,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,BUS-1010,2020
-BUS,1010,50.0,Business Foundations,0.3,0.33,0.16,0.06,0.05,0%,0.0,0.1,alexandra hazleton,BUS-1010,2020
-BUS,1010,51.0,Business Foundations,0.26,0.37,0.19,0.06,0.06,0%,0.0,0.05,alexandra hazleton,BUS-1010,2020
-CCPD,1400,1.0,Professional Development,0.85,0.08,0.04,0.0,0.0,0%,0.0,0.04,rise jean sheriff,CCPD-1400,2020
-CE,2010,1.0,Statics,0.11,0.41,0.3,0.05,0.14,0%,0.0,0.0,michael stoner,CE-2010,2020
-CE,2010,2.0,Statics,0.62,0.21,0.14,0.0,0.02,0%,0.0,0.0,md chowdhury,CE-2010,2020
-CE,2010,3.0,Statics,0.12,0.34,0.2,0.08,0.08,0%,0.0,0.18,melissa sternhagen,CE-2010,2020
-CE,2010,4.0,Statics,0.17,0.13,0.28,0.02,0.11,0%,0.0,0.3,melissa sternhagen,CE-2010,2020
-CE,2010,5.0,Statics,0.26,0.38,0.25,0.05,0.05,0%,0.0,0.02,mohannad naser,CE-2010,2020
-CE,2010,6.0,Statics,0.37,0.43,0.11,0.06,0.02,0%,0.0,0.02,md chowdhury,CE-2010,2020
-CE,2010,8.0,Statics,0.38,0.4,0.15,0.05,0.03,0%,0.0,0.0,michael stoner,CE-2010,2020
-CE,2060,1.0,Structural Mechanics,0.03,0.13,0.44,0.15,0.06,0%,0.0,0.19,melissa sternhagen,CE-2060,2020
-CE,2080,1.0,Dynamics,0.19,0.4,0.33,0.02,0.03,0%,0.0,0.03,md chowdhury,CE-2080,2020
-CE,2550,1.0,Geomatics,0.27,0.43,0.2,0.09,0.0,0%,0.0,0.02,wayne sarasua,CE-2550,2020
-CE,2990,16.0,CE - Springer I - Lecture,0.67,0.25,0.08,0.0,0.0,0%,0.0,0.0,wayne sarasua,CE-2990,2020
-CE,2990,116.0,CE - Springer I - Lab,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,wayne sarasua,CE-2990,2020
-CE,2990,216.0,CE - Springer I - Lab,0.5,0.33,0.17,0.0,0.0,0%,0.0,0.0,wayne sarasua,CE-2990,2020
-CE,3010,1.0,Structural Analysis,0.19,0.45,0.28,0.04,0.02,0%,0.0,0.02,stephen csernak,CE-3010,2020
-CE,3010,2.0,Structural Analysis,0.34,0.34,0.28,0.0,0.0,0%,0.0,0.03,thomas cousins,CE-3010,2020
-CE,3110,1.0,Transportation Engr,0.74,0.11,0.08,0.0,0.03,0%,0.0,0.03,jennifer ogle,CE-3110,2020
-CE,3210,1.0,Geotechnical Engineering,0.47,0.31,0.12,0.08,0.0,0%,0.0,0.02,qiushi chen,CE-3210,2020
-CE,3310,1.0,Constr Engr & Mgmnt,0.44,0.42,0.1,0.01,0.01,0%,0.0,0.01,zoraya rockow,CE-3310,2020
-CE,3410,1.0,Intro to Fluid Mechanics,0.68,0.24,0.07,0.02,0.0,0%,0.0,0.0,nigel gregory kaye,CE-3410,2020
-CE,3410,2.0,Intro to Fluid Mechanics,0.27,0.35,0.18,0.06,0.1,0%,0.0,0.04,abdul khan,CE-3410,2020
-CE,3420,1.0,Hydraulics & Hydro,0.64,0.2,0.11,0.04,0.02,0%,0.0,0.0,ashok mishra,CE-3420,2020
-CE,3510,1.0,Civil Engineering Materials,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0, esmaeilpoursaee,CE-3510,2020
-CE,3510,2.0,Civil Engineering Materials,0.88,0.1,0.0,0.0,0.0,0%,0.0,0.02, esmaeilpoursaee,CE-3510,2020
-CE,3520,1.0,Econ Eval of Proj,0.63,0.32,0.04,0.0,0.01,0%,0.0,0.0,da li,CE-3520,2020
-CE,4010,1.0,Matrix Str Analysis,0.24,0.35,0.18,0.12,0.12,0%,0.0,0.0,laura mae redmond,CE-4010,2020
-CE,4020,1.0,Reinfor Con Design,0.35,0.41,0.09,0.09,0.03,0%,0.0,0.03,laura mae redmond,CE-4020,2020
-CE,4060,1.0,Struct Steel Design,0.47,0.37,0.1,0.07,0.0,0%,0.0,0.0,stephen csernak,CE-4060,2020
-CE,4100,1.0,Traffic Engr Oper,0.32,0.23,0.18,0.18,0.05,0%,0.0,0.05,wayne sarasua,CE-4100,2020
-CE,4240,1.0,Earth Slopes & Struc,0.3,0.32,0.25,0.14,0.0,0%,0.0,0.0, ravichandran,CE-4240,2020
-CE,4330,1.0,Const Plan & Sched,0.52,0.3,0.17,0.0,0.0,0%,0.0,0.0,tuyen thanh le,CE-4330,2020
-CE,4340,1.0,Const Est Proj Cont,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,kalyan ram piratla,CE-4340,2020
-CE,4470,1.0,Stormwater Managemnt,0.4,0.37,0.13,0.1,0.0,0%,0.0,0.0,md chowdhury,CE-4470,2020
-CE,4560,1.0,Pave Design & Constr,0.17,0.57,0.19,0.0,0.02,0%,0.0,0.05,bradley putman,CE-4560,2020
-CE,4590,1.0,Capstone Design Proj,0.28,0.49,0.21,0.03,0.0,0%,0.0,0.0,zoraya rockow,CE-4590,2020
-CE,4910,1.0,BIM in Construction Mana,0.64,0.27,0.0,0.0,0.05,0%,0.0,0.05,kalyan ram piratla,CE-4910,2020
-CE,4910,3.0,Intro to Proj Mgt,0.62,0.29,0.05,0.0,0.0,0%,0.0,0.05,zoraya rockow,CE-4910,2020
-CE,4990,109.0,Cr Inq in CE - CEment,0.82,0.14,0.0,0.0,0.0,0%,0.0,0.0,candice bolding,CE-4990,2020
-CE,6010,1.0,Matrix Str Analysis,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,laura mae redmond,CE-6010,2020
-CE,6910,5.0,Adv Concrete Technology,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,prasada rangaraju,CE-6910,2020
-CE,8030,1.0,Adv Steel Design,0.32,0.58,0.05,0.0,0.05,0%,0.0,0.0,mohannad naser,CE-8030,2020
-CE,8080,1.0,Earthquake Engr,0.9,0.05,0.0,0.0,0.05,0%,0.0,0.0,weichiang pang,CE-8080,2020
-CE,8460,1.0,Flow in Open Chnls,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,abdul khan,CE-8460,2020
-CE,8540,1.0,Travl Demnd Forecast,0.57,0.14,0.0,0.0,0.0,0%,0.0,0.0,pamela murray-tuite,CE-8540,2020
-CE,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jennifer ogle,CE-9910,2020
-CE,9910,18.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mashrur chowdhury,CE-9910,2020
-CH,1010,1.0,General Chemistry,0.17,0.38,0.16,0.1,0.09,0%,0.0,0.09,thomas hickman,CH-1010,2020
-CH,1010,2.0,General Chemistry,0.15,0.35,0.18,0.09,0.09,0%,0.0,0.13,thao thi thanh tran thanh,CH-1010,2020
-CH,1010,3.0,General Chemistry,0.16,0.39,0.16,0.12,0.06,0%,0.0,0.1,william mcwhorter,CH-1010,2020
-CH,1010,4.0,General Chemistry,0.23,0.28,0.26,0.12,0.07,0%,0.0,0.04,jacob schroeder,CH-1010,2020
-CH,1010,5.0,General Chemistry,0.28,0.27,0.21,0.12,0.07,0%,0.0,0.05,thomas hickman,CH-1010,2020
-CH,1010,6.0,General Chemistry,0.31,0.29,0.18,0.08,0.05,0%,0.0,0.1,dennis taylor,CH-1010,2020
-CH,1010,7.0,General Chemistry,0.12,0.27,0.24,0.1,0.17,0%,0.0,0.11,olt geiculescu,CH-1010,2020
-CH,1010,8.0,General Chemistry,0.11,0.29,0.26,0.08,0.08,0%,0.0,0.18,princess mycia cox,CH-1010,2020
-CH,1010,9.0,General Chemistry,0.23,0.42,0.19,0.08,0.05,0%,0.0,0.04,ashlyn dennis smith,CH-1010,2020
-CH,1010,10.0,General Chemistry,0.22,0.22,0.26,0.12,0.1,0%,0.0,0.08,william mcwhorter,CH-1010,2020
-CH,1010,11.0,General Chemistry,0.25,0.42,0.14,0.09,0.08,0%,0.0,0.02,thomas hickman,CH-1010,2020
-CH,1010,12.0,General Chemistry,0.32,0.31,0.21,0.05,0.03,0%,0.0,0.08,ashlyn dennis smith,CH-1010,2020
-CH,1010,13.0,General Chemistry,0.21,0.29,0.19,0.1,0.08,0%,0.0,0.13,princess mycia cox,CH-1010,2020
-CH,1010,14.0,General Chemistry,0.25,0.34,0.25,0.07,0.06,0%,0.0,0.05,tania houjeiry,CH-1010,2020
-CH,1010,15.0,General Chemistry,0.24,0.29,0.17,0.15,0.05,0%,0.0,0.11,dennis taylor,CH-1010,2020
-CH,1010,16.0,General Chemistry,0.1,0.39,0.25,0.08,0.08,0%,0.0,0.08,jacob schroeder,CH-1010,2020
-CH,1010,50.0,General Chemistry,0.36,0.45,0.05,0.09,0.05,0%,0.0,0.0,tania houjeiry,CH-1010,2020
-CH,1010,71.0,General Chemistry (HON),0.5,0.4,0.05,0.0,0.05,0%,0.0,0.0,joseph thrasher,CH-1010,2020
-CH,1010,72.0,General Chemistry (HON),0.57,0.29,0.07,0.07,0.0,0%,0.0,0.0,shiou-jyh hwu,CH-1010,2020
-CH,1010,400.0,General Chemistry,0.03,0.18,0.2,0.13,0.18,0%,0.0,0.3,princess mycia cox,CH-1010,2020
-CH,1020,1.0,General Chemistry,0.31,0.24,0.2,0.16,0.04,0%,0.0,0.04, schvaneveldt,CH-1020,2020
-CH,1020,2.0,General Chemistry,0.32,0.18,0.24,0.1,0.08,0%,0.0,0.07, schvaneveldt,CH-1020,2020
-CH,1020,3.0,General Chemistry,0.26,0.28,0.27,0.1,0.04,0%,0.0,0.05, schvaneveldt,CH-1020,2020
-CH,1020,400.0,General Chemistry,0.23,0.19,0.19,0.19,0.08,0%,0.0,0.13, schvaneveldt,CH-1020,2020
-CH,1050,2.0,Chemistry in Context I,0.63,0.24,0.07,0.01,0.03,0%,0.0,0.03,olt geiculescu,CH-1050,2020
-CH,2010,1.0,Survey of Organic Chemist,0.94,0.06,0.01,0.0,0.0,0%,0.0,0.0,modi wetzler,CH-2010,2020
-CH,2230,1.0,Organic Chemistry,0.43,0.32,0.11,0.06,0.08,0%,0.0,0.02,tania houjeiry,CH-2230,2020
-CH,2230,2.0,Organic Chemistry,0.22,0.21,0.3,0.12,0.1,0%,0.0,0.04,modi wetzler,CH-2230,2020
-CH,2230,3.0,Organic Chemistry,0.48,0.21,0.14,0.07,0.06,0%,0.0,0.04,elliot ennis,CH-2230,2020
-CH,2230,4.0,Organic Chemistry,0.31,0.28,0.17,0.09,0.1,0%,0.0,0.05,modi wetzler,CH-2230,2020
-CH,2230,6.0,Organic Chemistry,0.5,0.26,0.12,0.03,0.05,0%,0.0,0.03,rhett smith,CH-2230,2020
-CH,2230,7.0,Organic Chemistry,0.46,0.25,0.1,0.04,0.09,0%,0.0,0.05,rhett smith,CH-2230,2020
-CH,2230,8.0,Organic Chemistry,0.23,0.15,0.33,0.14,0.13,0%,0.0,0.03,william mcwhorter,CH-2230,2020
-CH,2230,50.0,Organic Chemistry,0.27,0.47,0.2,0.0,0.07,0%,0.0,0.0,byoungmoo kim,CH-2230,2020
-CH,2240,1.0,Organic Chemistry,0.29,0.17,0.18,0.13,0.15,0%,0.0,0.08,elliot ennis,CH-2240,2020
-CH,2240,2.0,Organic Chemistry,0.19,0.18,0.22,0.23,0.1,0%,0.0,0.09,elliot ennis,CH-2240,2020
-CH,2270,9.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,CH-2270,2020
-CH,2270,13.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,james plampin,CH-2270,2020
-CH,2270,18.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,CH-2270,2020
-CH,2270,28.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,james plampin,CH-2270,2020
-CH,2280,1.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,CH-2280,2020
-CH,2280,2.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.09,james plampin,CH-2280,2020
-CH,2280,4.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,CH-2280,2020
-CH,2280,5.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.09,james plampin,CH-2280,2020
-CH,2280,6.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,CH-2280,2020
-CH,2280,7.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,CH-2280,2020
-CH,3130,1.0,Quantitative Analysis,0.22,0.31,0.24,0.11,0.04,0%,0.0,0.07,olt geiculescu,CH-3130,2020
-CH,3150,1.0,Quant Analysis Lab,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,jeffrey nathan anker,CH-3150,2020
-CH,3150,2.0,Quant Analysis Lab,0.73,0.0,0.09,0.0,0.0,0%,0.0,0.18,jeffrey nathan anker,CH-3150,2020
-CH,3150,3.0,Quant Analysis Lab,0.31,0.31,0.08,0.0,0.23,0%,0.0,0.0,jeffrey nathan anker,CH-3150,2020
-CH,3300,1.0,Intro to Phys Chem,0.61,0.22,0.07,0.01,0.03,0%,0.0,0.04,brian dominy,CH-3300,2020
-CH,3310,1.0,Physical Chemistry,0.34,0.36,0.18,0.02,0.1,0%,0.0,0.0,steven stuart,CH-3310,2020
-CH,3390,1.0,Physical Chem Lab,0.71,0.19,0.05,0.0,0.05,0%,0.0,0.0,princess mycia cox,CH-3390,2020
-CH,3390,2.0,Physical Chem Lab,0.58,0.26,0.16,0.0,0.0,0%,0.0,0.0,princess mycia cox,CH-3390,2020
-CH,3390,3.0,Physical Chem Lab,0.74,0.11,0.0,0.0,0.0,0%,0.0,0.16,princess mycia cox,CH-3390,2020
-CH,3390,4.0,Physical Chem Lab,0.76,0.19,0.0,0.0,0.05,0%,0.0,0.0,princess mycia cox,CH-3390,2020
-CH,3390,5.0,Physical Chem Lab,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,princess mycia cox,CH-3390,2020
-CH,3410,1.0,Introduction to Research,0.76,0.08,0.04,0.02,0.1,0%,0.0,0.0,perez carlos garcia,CH-3410,2020
-CH,4020,1.0,Inorganic Chemistry,0.5,0.42,0.02,0.0,0.04,0%,0.0,0.02,joseph kolis,CH-4020,2020
-CH,4210,1.0,Advanced Organic Chemist,0.33,0.44,0.22,0.0,0.0,0%,0.0,0.0,jacob schroeder,CH-4210,2020
-CH,6020,1.0,Inorganic Chemistry,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,joseph kolis,CH-6020,2020
-CH,6210,1.0,Adv Organic Chem,0.17,0.5,0.17,0.0,0.0,0%,0.0,0.17,jacob schroeder,CH-6210,2020
-CH,8070,1.0,Chem Trans Elem,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,julia brumaghim,CH-8070,2020
-CH,8120,1.0,Chemical Spectroscopic M,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,george chumanov,CH-8120,2020
-CH,8150,1.0,Mass Spectrometry,0.36,0.36,0.27,0.0,0.0,0%,0.0,0.0,richard marcus,CH-8150,2020
-CH,8210,1.0,Organic Chem I,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,ya-ping sun,CH-8210,2020
-CH,8370,1.0,Quantum Chemistry,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,leah beck casabianca,CH-8370,2020
-CH,8510,2.0,Grad Student Seminar,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,sourav saha,CH-8510,2020
-CH,8520,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,93%,0.03,0.03,joseph thrasher,CH-8520,2020
-CH,9910,2.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel whitehead,CH-9910,2020
-CH,9910,7.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rhett smith,CH-9910,2020
-CH,9910,11.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,richard marcus,CH-9910,2020
-CH,9910,25.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey nathan anker,CH-9910,2020
-CH,9910,99.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,perez carlos garcia,CH-9910,2020
-CHE,2110,1.0,Mass and Energy Balances,0.24,0.29,0.26,0.12,0.05,0%,0.0,0.05,mark roberts,CHE-2110,2020
-CHE,3070,1.0,Unit Ops Lab I,0.18,0.47,0.35,0.0,0.0,0%,0.0,0.0,christopher norfolk,CHE-3070,2020
-CHE,3210,1.0,Ch E Thermo II,0.08,0.27,0.39,0.19,0.03,0%,0.0,0.03,sapna sarupria,CHE-3210,2020
-CHE,3300,1.0,Mass Trans & Seprtn,0.35,0.26,0.26,0.08,0.03,0%,0.0,0.03,david bruce,CHE-3300,2020
-CHE,4070,1.0,Unit Op Lab II,0.28,0.4,0.29,0.03,0.0,0%,0.0,0.0,christopher norfolk,CHE-4070,2020
-CHE,4310,1.0,Process Design I,0.26,0.53,0.18,0.01,0.01,0%,0.0,0.0,suzanne deirdre roat,CHE-4310,2020
-CHE,4430,1.0,"Safety, Env & Prof Practice",0.86,0.11,0.04,0.0,0.0,0%,0.0,0.0,scott husson,CHE-4430,2020
-CHE,4500,1.0,Chem Reaction Engr,0.29,0.39,0.2,0.09,0.03,0%,0.0,0.0,rachel getman,CHE-4500,2020
-CHE,6130,1.0,Polymer Composite Engine,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,amod ogale,CHE-6130,2020
-CHE,8030,1.0,Advanced Transport,0.45,0.45,0.09,0.0,0.0,0%,0.0,0.0,eric mikel davis,CHE-8030,2020
-CHE,8900,1.0,GAANN SEMINAR,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eric mikel davis,CHE-8900,2020
-CHE,8950,1.0,Graduate Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jessica marie larsen,CHE-8950,2020
-CHE,9910,2.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mark alan blenner,CHE-9910,2020
-CHE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,scott husson,CHE-9910,2020
-CHE,9910,11.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sapna sarupria,CHE-9910,2020
-CHE,9910,13.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mark thies,CHE-9910,2020
-CHIN,1010,2.0,Elementary Chinese,0.38,0.0,0.15,0.0,0.15,0%,0.0,0.31,yanhua zhang,CHIN-1010,2020
-CHIN,3130,1.0,Philosophy in Modern Chin,0.5,0.25,0.05,0.0,0.05,0%,0.0,0.15,yanming an,CHIN-3130,2020
-CHIN,4990,1.0,Slct Tpcs Chin Cult,0.35,0.45,0.15,0.0,0.0,0%,0.0,0.05,kyle david anderson,CHIN-4990,2020
-COM,1010,1.0,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,96%,0.0,0.04,lori marlise pindar,COM-1010,2020
-COM,1500,1.0,Intro to Human Communic,0.86,0.07,0.03,0.01,0.01,0%,0.0,0.01,daniel leland fecher,COM-1500,2020
-COM,1500,2.0,Intro to Human Communic,0.73,0.18,0.03,0.02,0.02,0%,0.0,0.01,daniel leland fecher,COM-1500,2020
-COM,1500,3.0,Intro to Human Communic,0.78,0.16,0.05,0.01,0.0,0%,0.0,0.0,daniel leland fecher,COM-1500,2020
-COM,1500,4.0,Intro to Human Communic,0.82,0.11,0.03,0.01,0.02,0%,0.0,0.02,marianne herr glaser,COM-1500,2020
-COM,1500,5.0,Intro to Human Communic,0.82,0.11,0.02,0.02,0.02,0%,0.0,0.01,marianne herr glaser,COM-1500,2020
-COM,1500,6.0,Intro to Human Communic,0.79,0.16,0.03,0.01,0.0,0%,0.0,0.01,marianne herr glaser,COM-1500,2020
-COM,1500,7.0,Intro to Human Communic,0.73,0.12,0.08,0.03,0.03,0%,0.0,0.01,vanessa condon,COM-1500,2020
-COM,2010,1.0,Intr to Comm Studies,0.67,0.19,0.04,0.0,0.04,0%,0.0,0.07,caitlin baker,COM-2010,2020
-COM,2010,2.0,Intr to Comm Studies,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,caitlin baker,COM-2010,2020
-COM,2020,1.0,Communication Theory,0.75,0.21,0.04,0.0,0.0,0%,0.0,0.0,kristen okamoto,COM-2020,2020
-COM,2040,1.0,Critical-Cultural Comm The,0.65,0.17,0.13,0.0,0.04,0%,0.0,0.0,james gilmore,COM-2040,2020
-COM,2100,1.0,Quant Comm Research Me,0.44,0.48,0.08,0.0,0.0,0%,0.0,0.0,erin michelle ash,COM-2100,2020
-COM,2500,2.0,Public Speaking,0.6,0.3,0.05,0.0,0.05,0%,0.0,0.0,sara crocker,COM-2500,2020
-COM,2500,3.0,Public Speaking,0.6,0.25,0.05,0.05,0.0,0%,0.0,0.05,elizabeth gilmore,COM-2500,2020
-COM,2500,4.0,Public Speaking,0.75,0.15,0.1,0.0,0.0,0%,0.0,0.0,elizabeth gilmore,COM-2500,2020
-COM,2500,5.0,Public Speaking,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,alyssa christine davis,COM-2500,2020
-COM,2500,6.0,Public Speaking,0.7,0.25,0.05,0.0,0.0,0%,0.0,0.0,alyssa christine davis,COM-2500,2020
-COM,2500,7.0,Public Speaking,0.65,0.3,0.05,0.0,0.0,0%,0.0,0.0,sara crocker,COM-2500,2020
-COM,2500,8.0,Public Speaking,0.55,0.35,0.05,0.0,0.05,0%,0.0,0.0,ashley lauren pikel,COM-2500,2020
-COM,2500,9.0,Public Speaking,0.65,0.1,0.15,0.0,0.05,0%,0.0,0.05,sara crocker,COM-2500,2020
-COM,2500,10.0,Public Speaking,0.47,0.37,0.05,0.05,0.05,0%,0.0,0.0,ashley lauren pikel,COM-2500,2020
-COM,2500,11.0,Public Speaking,0.68,0.21,0.05,0.0,0.0,0%,0.0,0.05,ashley lauren pikel,COM-2500,2020
-COM,2500,14.0,Public Speaking,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,elizabeth gilmore,COM-2500,2020
-COM,2500,16.0,Public Speaking,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,jumah patricia taweh,COM-2500,2020
-COM,2500,17.0,Public Speaking,0.79,0.05,0.05,0.0,0.11,0%,0.0,0.0,jumah patricia taweh,COM-2500,2020
-COM,2500,18.0,Public Speaking,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,marshall covert,COM-2500,2020
-COM,2500,19.0,Public Speaking,0.79,0.16,0.0,0.0,0.0,0%,0.0,0.05,jumah patricia taweh,COM-2500,2020
-COM,2500,20.0,Public Speaking,0.75,0.15,0.05,0.0,0.0,0%,0.0,0.05,vanessa condon,COM-2500,2020
-COM,2500,21.0,Public Speaking,0.75,0.2,0.0,0.0,0.0,0%,0.0,0.05,charles john brewer,COM-2500,2020
-COM,2500,22.0,Public Speaking,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,charles john brewer,COM-2500,2020
-COM,2500,23.0,Public Speaking,0.74,0.16,0.11,0.0,0.0,0%,0.0,0.0,charles john brewer,COM-2500,2020
-COM,2500,24.0,Public Speaking,0.78,0.17,0.0,0.0,0.06,0%,0.0,0.0,charles john brewer,COM-2500,2020
-COM,2500,25.0,Public Speaking,0.6,0.35,0.0,0.05,0.0,0%,0.0,0.0,marshall covert,COM-2500,2020
-COM,2500,26.0,Public Speaking,0.55,0.35,0.05,0.0,0.05,0%,0.0,0.0,marshall covert,COM-2500,2020
-COM,2500,27.0,Public Speaking,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,marshall covert,COM-2500,2020
-COM,2500,28.0,Public Speaking,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,katie mcelveen,COM-2500,2020
-COM,2500,29.0,Public Speaking,0.74,0.16,0.05,0.05,0.0,0%,0.0,0.0,vanessa condon,COM-2500,2020
-COM,2500,31.0,Public Speaking,0.85,0.0,0.05,0.05,0.05,0%,0.0,0.0,katie mcelveen,COM-2500,2020
-COM,2500,33.0,Public Speaking,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,ashley lauren pikel,COM-2500,2020
-COM,2500,401.0,Public Speaking,0.8,0.15,0.0,0.0,0.05,0%,0.0,0.0,alexis zachary davis,COM-2500,2020
-COM,2500,402.0,Public Speaking,0.75,0.1,0.1,0.05,0.0,0%,0.0,0.0,alexis zachary davis,COM-2500,2020
-COM,2500,403.0,Public Speaking,0.85,0.05,0.0,0.0,0.1,0%,0.0,0.0,alexis zachary davis,COM-2500,2020
-COM,3050,1.0,Persuasion,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,lindsey dixon,COM-3050,2020
-COM,3200,1.0,Bdcst Production,0.87,0.0,0.04,0.04,0.04,0%,0.0,0.0,wanda johnson,COM-3200,2020
-COM,3240,1.0,"Communication, Sport & S",0.68,0.2,0.04,0.0,0.04,0%,0.0,0.04,brandon boatwright,COM-3240,2020
-COM,3240,2.0,"Communication, Sport & S",0.5,0.32,0.18,0.0,0.0,0%,0.0,0.0,brandon boatwright,COM-3240,2020
-COM,3250,1.0,Survey of Sports Communi,0.67,0.17,0.13,0.03,0.0,0%,0.0,0.0,virginia harrison,COM-3250,2020
-COM,3260,1.0,Pr in Sports,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,katie mcelveen,COM-3260,2020
-COM,3260,2.0,Pr in Sports,0.83,0.07,0.03,0.0,0.0,0%,0.0,0.07,katie mcelveen,COM-3260,2020
-COM,3270,1.0,Sports Media Criticism,0.32,0.64,0.0,0.0,0.0,0%,0.0,0.04,bryan denham,COM-3270,2020
-COM,3550,1.0,Principles of Public Relatio,0.5,0.27,0.14,0.05,0.0,0%,0.0,0.05,jordan morehouse,COM-3550,2020
-COM,3570,1.0,Public Relations Writing,0.52,0.29,0.05,0.05,0.05,0%,0.0,0.05,jordan morehouse,COM-3570,2020
-COM,3660,3.0,Ugrad Comm Tutors,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,alyssa christine davis,COM-3660,2020
-COM,3660,4.0,Storytelling and Reporting,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,nigel robertson,COM-3660,2020
-COM,3900,1.0,Communication Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,lori marlise pindar,COM-3900,2020
-COM,4280,1.0,Interpers/Family Comm &,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,gregory cranmer,COM-4280,2020
-COM,4560,1.0,PR for Assoc & Nonprofits,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,virginia harrison,COM-4560,2020
-COM,4700,1.0,Comm & Health,0.36,0.45,0.14,0.0,0.0,0%,0.0,0.05,victoria wingate,COM-4700,2020
-COM,4800,1.0,Intercultural Comm,0.8,0.16,0.04,0.0,0.0,0%,0.0,0.0,andrew stephen pyle,COM-4800,2020
-COM,4800,2.0,Intercultural Comm,0.92,0.04,0.0,0.0,0.04,0%,0.0,0.0,andrew stephen pyle,COM-4800,2020
-COM,4950,2.0,Senior Capstone Seminar,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,david travers scott,COM-4950,2020
-COM,8000,1.0,Communication Pedagogy,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel leland fecher,COM-8000,2020
-COM,8010,1.0,Communication Theory I,0.73,0.18,0.0,0.0,0.0,0%,0.0,0.09,darren linvill,COM-8010,2020
-COM,8100,1.0,Comm Research Methods I,0.47,0.4,0.13,0.0,0.0,0%,0.0,0.0,gregory cranmer,COM-8100,2020
-COM,8270,1.0,Sports Media,0.57,0.29,0.0,0.0,0.0,0%,0.0,0.14,bryan denham,COM-8270,2020
-COM,8910,1.0,Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,erin michelle ash,COM-8910,2020
-COOP,1010,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,COOP-1010,2020
-COOP,1020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,COOP-1020,2020
-COOP,1030,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,COOP-1030,2020
-COOP,2010,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,COOP-2010,2020
-COOP,2020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,COOP-2020,2020
-COOP,6020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,'neil burton,COOP-6020,2020
-CPSC,1010,10.0,Computer Science I,0.15,0.31,0.25,0.04,0.1,0%,0.0,0.13,scoy roger larry van larry,CPSC-1010,2020
-CPSC,1010,20.0,Computer Science I,0.39,0.2,0.16,0.1,0.02,0%,0.0,0.14,carrie lynn russell,CPSC-1010,2020
-CPSC,1010,30.0,Computer Science I,0.2,0.37,0.2,0.06,0.06,0%,0.0,0.12,carrie lynn russell,CPSC-1010,2020
-CPSC,1020,10.0,Computer Science II,0.24,0.29,0.18,0.11,0.07,0%,0.0,0.11,catherine kittelstad,CPSC-1020,2020
-CPSC,1060,10.0,Intro to Programming in Ja,0.37,0.24,0.11,0.05,0.11,0%,0.0,0.13,svetlana drachova,CPSC-1060,2020
-CPSC,1060,20.0,Intro to Programming in Ja,0.31,0.17,0.22,0.19,0.08,0%,0.0,0.03,svetlana drachova,CPSC-1060,2020
-CPSC,1060,30.0,Intro to Programming in Ja,0.14,0.11,0.33,0.14,0.14,0%,0.0,0.14,christina joerg,CPSC-1060,2020
-CPSC,1070,1.0,Programming Methodolog,0.26,0.27,0.27,0.04,0.07,0%,0.0,0.1,christopher plaue,CPSC-1070,2020
-CPSC,1110,1.0,Intro to Programming in C,0.34,0.31,0.16,0.05,0.06,0%,0.0,0.07,andrew duchowski,CPSC-1110,2020
-CPSC,1110,2.0,Intro to Programming in C,0.39,0.27,0.22,0.04,0.02,0%,0.0,0.06,nicolas widman,CPSC-1110,2020
-CPSC,1210,1.0,Computational Thinking,0.26,0.26,0.34,0.03,0.05,0%,0.0,0.05,mitch shue,CPSC-1210,2020
-CPSC,1900,1.0,Teaching Assist Fundamen,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eileen kraemer,CPSC-1900,2020
-CPSC,2070,1.0,Discrete Structures,0.44,0.37,0.14,0.03,0.02,0%,0.0,0.0,larry hodges,CPSC-2070,2020
-CPSC,2070,2.0,Discrete Structures,0.38,0.27,0.29,0.06,0.0,0%,0.0,0.0,larry hodges,CPSC-2070,2020
-CPSC,2070,3.0,Discrete Structures,0.46,0.19,0.3,0.0,0.03,0%,0.0,0.03,pradip srimani,CPSC-2070,2020
-CPSC,2120,1.0,Algs/Data Structures,0.52,0.16,0.11,0.07,0.08,0%,0.0,0.05,nicolas widman,CPSC-2120,2020
-CPSC,2120,2.0,Algs/Data Structures,0.48,0.18,0.1,0.03,0.13,0%,0.0,0.08,nicolas widman,CPSC-2120,2020
-CPSC,2120,101.0,Algs/Data Structures,0.4,0.2,0.04,0.04,0.08,0%,0.0,0.24,brian dean,CPSC-2120,2020
-CPSC,2120,102.0,Algs/Data Structures,0.28,0.24,0.28,0.0,0.04,0%,0.0,0.16,brian dean,CPSC-2120,2020
-CPSC,2120,103.0,Algs/Data Structures,0.17,0.26,0.3,0.04,0.09,0%,0.0,0.13,brian dean,CPSC-2120,2020
-CPSC,2150,1.0,Software Dev Foundations,0.22,0.27,0.2,0.07,0.16,0%,0.0,0.09,yu-shan sun,CPSC-2150,2020
-CPSC,2150,2.0,Software Dev Foundations,0.24,0.24,0.2,0.02,0.13,0%,0.0,0.17,yu-shan sun,CPSC-2150,2020
-CPSC,2150,3.0,Software Dev Foundations,0.15,0.25,0.2,0.1,0.15,0%,0.0,0.15,murali sitaraman,CPSC-2150,2020
-CPSC,2200,1.0,Problem Solving w/ Office,0.52,0.22,0.14,0.06,0.04,0%,0.0,0.02,catherine kittelstad,CPSC-2200,2020
-CPSC,2310,1.0,Intro Computer Org,0.23,0.29,0.28,0.03,0.1,0%,0.0,0.07,yvon feaster,CPSC-2310,2020
-CPSC,2910,1.0,Prof Issues I,0.83,0.1,0.0,0.03,0.03,0%,0.0,0.0,constance taylor,CPSC-2910,2020
-CPSC,2910,2.0,Prof Issues I,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,constance taylor,CPSC-2910,2020
-CPSC,2910,3.0,Prof Issues I,0.68,0.1,0.13,0.06,0.0,0%,0.0,0.03,constance taylor,CPSC-2910,2020
-CPSC,2920,1.0,"Computing, Ethics & Societ",0.8,0.05,0.08,0.0,0.03,0%,0.0,0.05,julian brinkley,CPSC-2920,2020
-CPSC,3220,1.0,Intro to Operating Systems,0.31,0.21,0.1,0.04,0.09,0%,0.0,0.21,jacob sorber,CPSC-3220,2020
-CPSC,3220,2.0,Intro to Operating Systems,0.59,0.17,0.04,0.0,0.04,0%,0.0,0.04,brygg anders ullmer,CPSC-3220,2020
-CPSC,3300,1.0,Computer Systems Org,0.4,0.33,0.15,0.08,0.01,0%,0.0,0.03,mark smotherman,CPSC-3300,2020
-CPSC,3500,1.0,Foundations of Computer,0.2,0.37,0.27,0.0,0.1,0%,0.0,0.06,sandra hedetniemi,CPSC-3500,2020
-CPSC,3520,1.0,Programming Systems,0.76,0.1,0.06,0.01,0.06,0%,0.0,0.01,yongkai wu,CPSC-3520,2020
-CPSC,3600,1.0,Network Programming,0.48,0.26,0.13,0.03,0.04,0%,0.0,0.05,andrew robb,CPSC-3600,2020
-CPSC,3720,1.0,Software Engineering,0.25,0.44,0.24,0.05,0.02,0%,0.0,0.0,yu-shan sun,CPSC-3720,2020
-CPSC,3720,2.0,Software Engineering,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,constance taylor,CPSC-3720,2020
-CPSC,3750,1.0,Web Application Develop,0.52,0.27,0.06,0.04,0.1,0%,0.0,0.0,craig baker,CPSC-3750,2020
-CPSC,4030,1.0,Data Visualization,0.21,0.5,0.21,0.0,0.04,0%,0.0,0.04,federico iuricich,CPSC-4030,2020
-CPSC,4040,1.0,Cmptr Graphics Image,0.76,0.12,0.0,0.0,0.06,0%,0.0,0.06,jerry tessendorf,CPSC-4040,2020
-CPSC,4050,1.0,Computer Graphics,0.38,0.17,0.04,0.04,0.0,0%,0.0,0.33,yin yang,CPSC-4050,2020
-CPSC,4110,1.0,Virtual Reality Systems,0.57,0.3,0.13,0.0,0.0,0%,0.0,0.0,sabarish venkat babu,CPSC-4110,2020
-CPSC,4140,1.0,Human and Computer Inte,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,nathaniel mcneese,CPSC-4140,2020
-CPSC,4160,1.0,2-D Game Engine Construc,0.58,0.15,0.08,0.05,0.08,0%,0.0,0.08,victor zordan,CPSC-4160,2020
-CPSC,4200,1.0,Computer Security Principl,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,long cheng,CPSC-4200,2020
-CPSC,4240,1.0,System Admin and Securit,0.63,0.33,0.0,0.0,0.04,0%,0.0,0.0,svetlana drachova,CPSC-4240,2020
-CPSC,4300,1.0,Applied Data Science,0.41,0.3,0.07,0.0,0.07,0%,0.0,0.07,xizhou feng,CPSC-4300,2020
-CPSC,4300,2.0,Applied Data Science,0.53,0.12,0.18,0.0,0.12,0%,0.0,0.06,alexander herzog,CPSC-4300,2020
-CPSC,4420,1.0,Artificial Intelligence,0.71,0.14,0.1,0.0,0.05,0%,0.0,0.0,ioannis karamouzas,CPSC-4420,2020
-CPSC,4430,1.0,Machine Learning: Impl &,0.83,0.13,0.0,0.0,0.04,0%,0.0,0.0,larry hodges,CPSC-4430,2020
-CPSC,4440,1.0,Cloud Computing Architect,0.35,0.61,0.04,0.0,0.0,0%,0.0,0.0,mitch shue,CPSC-4440,2020
-CPSC,4620,1.0,Database Management Sy,0.48,0.19,0.14,0.0,0.14,0%,0.0,0.05,pradip srimani,CPSC-4620,2020
-CPSC,4620,2.0,Database Management Sy,0.33,0.5,0.06,0.0,0.0,0%,0.0,0.11,zijun wang,CPSC-4620,2020
-CPSC,4770,1.0,Distributed/Cluster Compu,0.47,0.37,0.05,0.0,0.05,0%,0.0,0.05,shuangshuang jin,CPSC-4770,2020
-CPSC,4780,1.0,Gen Purpose Computation,0.27,0.18,0.0,0.09,0.18,0%,0.0,0.27,shuangshuang jin,CPSC-4780,2020
-CPSC,4890,1.0,Programming Team Semin,0.67,0.27,0.07,0.0,0.0,0%,0.0,0.0,brian dean,CPSC-4890,2020
-CPSC,4910,1.0,Professional Issues II,0.53,0.43,0.03,0.0,0.0,0%,0.0,0.0,scoy roger larry van larry,CPSC-4910,2020
-CPSC,4910,2.0,Professional Issues II,0.28,0.52,0.16,0.04,0.0,0%,0.0,0.0,scoy roger larry van larry,CPSC-4910,2020
-CPSC,4910,3.0,Professional Issues II,0.78,0.17,0.04,0.0,0.0,0%,0.0,0.0,alexander herzog,CPSC-4910,2020
-CPSC,6040,1.0,Cptr Graphics Image,0.83,0.11,0.06,0.0,0.0,0%,0.0,0.0,jerry tessendorf,CPSC-6040,2020
-CPSC,6050,1.0,Computer Graphics,0.69,0.15,0.08,0.0,0.0,0%,0.0,0.08,yin yang,CPSC-6050,2020
-CPSC,6110,1.0,Virtual Reality Systems,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,sabarish venkat babu,CPSC-6110,2020
-CPSC,6160,1.0,2-D Game Engine Construc,0.71,0.14,0.0,0.0,0.14,0%,0.0,0.0,victor zordan,CPSC-6160,2020
-CPSC,6300,2.0,Applied Data Science,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,alexander herzog,CPSC-6300,2020
-CPSC,6420,1.0,Artificial Intelligence,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,ioannis karamouzas,CPSC-6420,2020
-CPSC,6440,1.0,Cloud Computing Architect,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,mitch shue,CPSC-6440,2020
-CPSC,6620,1.0,Database Management Sy,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,pradip srimani,CPSC-6620,2020
-CPSC,6620,2.0,Database Management Sy,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,zijun wang,CPSC-6620,2020
-CPSC,6770,1.0,Distributed/Cluster Compu,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,shuangshuang jin,CPSC-6770,2020
-CPSC,6810,1.0,Ind Study: MSCS Ready,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,eileen kraemer,CPSC-6810,2020
-CPSC,6810,2.0,MSCS Ready: mod 2,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,eileen kraemer,CPSC-6810,2020
-CPSC,8200,1.0,Parallel Architechture,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,rong ge,CPSC-8200,2020
-CPSC,8420,1.0,Advanced Machine Learni,0.5,0.13,0.22,0.0,0.0,0%,0.0,0.16,kai liu,CPSC-8420,2020
-CPSC,8470,1.0,Intro to Information Retrie,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,feng luo,CPSC-8470,2020
-CPSC,8480,1.0,Network Science,0.59,0.18,0.12,0.0,0.06,0%,0.0,0.06,ilya mark safro,CPSC-8480,2020
-CPSC,8510,1.0,Soft Sys Data Comm,0.67,0.11,0.11,0.0,0.0,0%,0.0,0.11,james martin,CPSC-8510,2020
-CPSC,8580,1.0,Security in Emerging Syste,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,hongxin hu,CPSC-8580,2020
-CPSC,8710,1.0,Found. of Software Engine,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,paige rodeghero,CPSC-8710,2020
-CPSC,9500,1.0,Sel Top:SoC Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,long cheng,CPSC-9500,2020
-CPSC,9500,2.0,Sel Topics: CS Edu Researc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eileen kraemer,CPSC-9500,2020
-CPSC,9500,843.0,Sel Topics: SOC Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,long cheng,CPSC-9500,2020
-CPSC,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brian dean,CPSC-9910,2020
-CPSC,9910,14.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,hongxin hu,CPSC-9910,2020
-CPSC,9910,24.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,feng luo,CPSC-9910,2020
-CRP,4010,1.0,Intro to City & Regional Pla,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,john albert gaber,CRP-4010,2020
-CRP,8010,1.0,Planning Process & Legal F,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,caitlin dyckman,CRP-8010,2020
-CRP,8030,2.0,Quan Analysis for Planners,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,eric morris,CRP-8030,2020
-CRP,8080,1.0,Land Use and Compreh Pla,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,santiago luis ramos,CRP-8080,2020
-CRP,8140,1.0,Public Transit,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,eric morris,CRP-8140,2020
-CRP,8580,2.0,Mixed Mthds for Planning,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,clifford donald ellis,CRP-8580,2020
-CRP,8940,1.0,Professional Planning Semi,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,barry nocks,CRP-8940,2020
-CSM,1000,1.0,Intro to Construct,0.81,0.1,0.0,0.03,0.06,0%,0.0,0.0,thomas fuduric,CSM-1000,2020
-CSM,2010,1.0,Structures I,0.07,0.29,0.21,0.29,0.07,0%,0.0,0.07,shima clarke,CSM-2010,2020
-CSM,2010,2.0,Structures I,0.0,0.36,0.14,0.21,0.14,0%,0.0,0.14,shima clarke,CSM-2010,2020
-CSM,2010,401.0,Structures I,0.15,0.46,0.15,0.15,0.0,0%,0.0,0.08,shima clarke,CSM-2010,2020
-CSM,2010,402.0,Structures I,0.0,0.08,0.54,0.15,0.0,0%,0.0,0.23,shima clarke,CSM-2010,2020
-CSM,2030,401.0,Mats & Meth of Const,0.19,0.44,0.31,0.02,0.04,0%,0.0,0.0,jason lucas,CSM-2030,2020
-CSM,2040,401.0,Cont Documents,0.38,0.41,0.1,0.1,0.0,0%,0.0,0.0,robert coffey,CSM-2040,2020
-CSM,2050,1.0,Mats & Methods II,0.59,0.22,0.14,0.03,0.03,0%,0.0,0.0,nathaniel jackson,CSM-2050,2020
-CSM,2060,1.0,Construction Science Work,0.82,0.06,0.12,0.0,0.0,0%,0.0,0.0,nathaniel jackson,CSM-2060,2020
-CSM,2060,2.0,Construction Science Work,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,nathaniel jackson,CSM-2060,2020
-CSM,2070,1.0,Construction Industry Sem,0.6,0.14,0.14,0.05,0.07,0%,0.0,0.0,thomas fuduric,CSM-2070,2020
-CSM,3040,401.0,Environmental Systems I,0.48,0.39,0.09,0.02,0.02,0%,0.0,0.0,joseph burgett,CSM-3040,2020
-CSM,3050,1.0,Environmental Systems II,0.15,0.38,0.31,0.0,0.12,0%,0.0,0.04,joseph burgett,CSM-3050,2020
-CSM,3060,1.0,Emerging Tech in Construc,0.84,0.06,0.03,0.03,0.03,0%,0.0,0.0,harnish sharma,CSM-3060,2020
-CSM,3060,401.0,Emerging Tech in Construc,0.68,0.18,0.09,0.0,0.0,0%,0.0,0.05,harnish sharma,CSM-3060,2020
-CSM,3070,1.0,Sustainable Construction,0.54,0.42,0.0,0.0,0.04,0%,0.0,0.0,harnish sharma,CSM-3070,2020
-CSM,3510,1.0,Construction Estimating,0.29,0.48,0.06,0.06,0.08,0%,0.0,0.02,rizi seyed mousavi,CSM-3510,2020
-CSM,3520,1.0,Const Scheduling,0.38,0.46,0.13,0.04,0.0,0%,0.0,0.0,dennis bausman,CSM-3520,2020
-CSM,3530,401.0,Const Estimating II,0.48,0.43,0.04,0.04,0.0,0%,0.0,0.0,anthony harden,CSM-3530,2020
-CSM,4110,401.0,Safety in Bldg Const,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,nicholas corley,CSM-4110,2020
-CSM,4500,1.0,Construction Internship,0.66,0.21,0.1,0.0,0.0,0%,0.0,0.03,nathaniel jackson,CSM-4500,2020
-CSM,4530,1.0,Const Proj Mgmt,0.69,0.27,0.04,0.0,0.0,0%,0.0,0.0,dennis bausman,CSM-4530,2020
-CSM,4540,1.0,Construction Capstone,0.6,0.33,0.07,0.0,0.0,0%,0.0,0.0,vivek sharma,CSM-4540,2020
-CSM,4610,1.0,Const Econ Seminar,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0, nove-josserand,CSM-4610,2020
-CSM,4980,2.0,Current Topics-NAHB Com,0.71,0.21,0.07,0.0,0.0,0%,0.0,0.0,jason lucas,CSM-4980,2020
-CSM,8520,400.0,Const Mgmt Research,0.45,0.55,0.0,0.0,0.0,0%,0.0,0.0,vivek sharma,CSM-8520,2020
-CSM,8650,400.0,Project Management,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,dhaval gajjar,CSM-8650,2020
-CU,1000,37.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.15,0.0,susan whorton,CU-1000,2020
-CU,1000,38.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,84%,0.12,0.01,susan whorton,CU-1000,2020
-CU,1000,52.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.13,0.0,susan whorton,CU-1000,2020
-CU,1000,53.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.15,0.01,susan whorton,CU-1000,2020
-CU,1000,54.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,84%,0.12,0.01,susan whorton,CU-1000,2020
-CU,1000,57.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,79%,0.18,0.01,susan whorton,CU-1000,2020
-CU,1000,58.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,77%,0.17,0.0,susan whorton,CU-1000,2020
-CU,1000,59.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,79%,0.14,0.01,susan whorton,CU-1000,2020
-CU,1000,60.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,83%,0.13,0.0,susan whorton,CU-1000,2020
-CU,1000,61.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,71%,0.28,0.01,susan whorton,CU-1000,2020
-CU,1000,62.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,73%,0.26,0.0,susan whorton,CU-1000,2020
-CU,1000,63.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,70%,0.29,0.0,susan whorton,CU-1000,2020
-CU,1000,64.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,64%,0.27,0.02,susan whorton,CU-1000,2020
-CU,1000,65.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,69%,0.26,0.01,susan whorton,CU-1000,2020
-CU,1000,66.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,65%,0.32,0.01,susan whorton,CU-1000,2020
-CU,1000,67.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,susan whorton,CU-1000,2020
-CU,1010,1.0,Univ Success Skills,0.53,0.07,0.13,0.0,0.13,0%,0.0,0.13,bryn babb,CU-1010,2020
-CU,1010,6.0,Univ Success Skills,0.7,0.1,0.1,0.0,0.1,0%,0.0,0.0,catherine neel,CU-1010,2020
-CU,1110,4.0,Intro Supplemental Instruc,0.0,0.0,0.0,0.0,0.0,91%,0.0,0.09,rachel anderson,CU-1110,2020
-CU,1110,5.0,Intro Supplemental Instruc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rachel anderson,CU-1110,2020
-DPA,3070,1.0,Method 3d Production,0.21,0.13,0.04,0.0,0.17,0%,0.0,0.46,da costa florencio,DPA-3070,2020
-DPA,4000,1.0,Tech Foundations I,0.47,0.18,0.06,0.06,0.18,0%,0.0,0.06,jessica baron,DPA-4000,2020
-DPA,4020,1.0,Visual Found of Digital Pro,0.64,0.27,0.09,0.0,0.0,0%,0.0,0.0,anthony summey,DPA-4020,2020
-DPA,4020,2.0,Visual Found of Digital Pro,0.23,0.54,0.08,0.0,0.15,0%,0.0,0.0,anthony summey,DPA-4020,2020
-DPA,6000,843.0,Tech Foundations I,0.33,0.33,0.33,0.0,0.0,0%,0.0,0.0,eric patterson,DPA-6000,2020
-DPA,6830,842.0,Spe Stu Top in DPA: Dig Ci,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,eric patterson,DPA-6830,2020
-DPA,8090,1.0,Rendering and Shading,0.5,0.3,0.2,0.0,0.0,0%,0.0,0.0,daljit singh dhillon,DPA-8090,2020
-DSA,8010,401.0,Statistical Methods I,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,deborah kunkel,DSA-8010,2020
-DSA,8030,401.0,Intro to Statistical Computi,0.56,0.33,0.0,0.0,0.0,0%,0.0,0.11,ellen hepfer breazel,DSA-8030,2020
-DSA,8640,1.0,Programming for Data Scie,0.83,0.1,0.03,0.0,0.0,0%,0.0,0.03,hongki kim,DSA-8640,2020
-ECAS,2990,201.0,CI CU Eng for Dev Countrie,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,david vaughn,ECAS-2990,2020
-ECAS,2990,301.0,CI SPECTRA,0.8,0.0,0.1,0.0,0.0,0%,0.0,0.1,joshua summers,ECAS-2990,2020
-ECE,2010,1.0,Logic and Computing Devic,0.28,0.33,0.25,0.04,0.04,0%,0.0,0.04,hassan raza,ECE-2010,2020
-ECE,2010,2.0,Logic & Comp Device (HO,0.53,0.2,0.13,0.07,0.07,0%,0.0,0.0,william reid,ECE-2010,2020
-ECE,2020,1.0,Electric Circuits I,0.15,0.32,0.25,0.09,0.11,0%,0.0,0.09,william harrell,ECE-2020,2020
-ECE,2070,1.0,Basic Electrical Engineering,0.31,0.22,0.21,0.15,0.04,0%,0.0,0.07,wesley green,ECE-2070,2020
-ECE,2070,2.0,Basic Electrical Engineering,0.2,0.2,0.28,0.11,0.13,0%,0.0,0.08,jeffrey osterberg,ECE-2070,2020
-ECE,2070,3.0,Basic Electrical Engineering,0.37,0.32,0.18,0.08,0.05,0%,0.0,0.01,timothy anglea,ECE-2070,2020
-ECE,2080,1.0,Basic Electrical Engr Lab,0.7,0.15,0.05,0.0,0.0,0%,0.0,0.1,apoorva kapadia,ECE-2080,2020
-ECE,2080,2.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,ECE-2080,2020
-ECE,2080,7.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,ECE-2080,2020
-ECE,2080,8.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0%,0.0,0.1,apoorva kapadia,ECE-2080,2020
-ECE,2080,9.0,Basic Electrical Engr Lab,0.88,0.0,0.0,0.0,0.06,0%,0.0,0.06,apoorva kapadia,ECE-2080,2020
-ECE,2080,10.0,Basic Electrical Engr Lab,0.89,0.06,0.0,0.0,0.06,0%,0.0,0.0,apoorva kapadia,ECE-2080,2020
-ECE,2080,13.0,Basic Electrical Engr Lab,0.7,0.1,0.0,0.0,0.1,0%,0.0,0.1,apoorva kapadia,ECE-2080,2020
-ECE,2080,14.0,Basic Electrical Engr Lab,0.89,0.0,0.05,0.0,0.0,0%,0.0,0.05,apoorva kapadia,ECE-2080,2020
-ECE,2080,15.0,Basic Electrical Engr Lab,0.85,0.05,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,ECE-2080,2020
-ECE,2090,1.0,Logic & Computing Device,0.77,0.08,0.0,0.0,0.08,0%,0.0,0.08,apoorva kapadia,ECE-2090,2020
-ECE,2090,2.0,Logic & Computing Device,0.75,0.0,0.0,0.0,0.25,0%,0.0,0.0,apoorva kapadia,ECE-2090,2020
-ECE,2090,3.0,Logic & Computing Device,0.67,0.25,0.0,0.0,0.08,0%,0.0,0.0,apoorva kapadia,ECE-2090,2020
-ECE,2090,4.0,Logic & Computing Device,0.45,0.09,0.09,0.09,0.18,0%,0.0,0.09,apoorva kapadia,ECE-2090,2020
-ECE,2090,5.0,Logic & Computing Device,0.33,0.67,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,ECE-2090,2020
-ECE,2090,6.0,Logic & Computing Device,0.7,0.0,0.0,0.0,0.1,0%,0.0,0.2,apoorva kapadia,ECE-2090,2020
-ECE,2090,7.0,Logic & Computing Device,0.77,0.0,0.0,0.0,0.08,0%,0.0,0.15,apoorva kapadia,ECE-2090,2020
-ECE,2090,12.0,Logic & Computing Device,0.36,0.18,0.0,0.0,0.0,0%,0.0,0.45,apoorva kapadia,ECE-2090,2020
-ECE,2110,1.0,Elec Engr Lab I,0.7,0.15,0.1,0.0,0.05,0%,0.0,0.0,apoorva kapadia,ECE-2110,2020
-ECE,2110,2.0,Elec Engr Lab I,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,apoorva kapadia,ECE-2110,2020
-ECE,2110,3.0,Elec Engr Lab I,0.55,0.15,0.05,0.0,0.0,0%,0.0,0.25,apoorva kapadia,ECE-2110,2020
-ECE,2110,5.0,Elec Engr Lab I,0.85,0.0,0.0,0.0,0.15,0%,0.0,0.0,apoorva kapadia,ECE-2110,2020
-ECE,2110,6.0,Elec Engr Lab I,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,apoorva kapadia,ECE-2110,2020
-ECE,2110,7.0,Elec Engr Lab I,0.7,0.1,0.0,0.0,0.0,0%,0.0,0.2,apoorva kapadia,ECE-2110,2020
-ECE,2110,8.0,Elec Engr Lab I,0.58,0.26,0.05,0.0,0.0,0%,0.0,0.11,apoorva kapadia,ECE-2110,2020
-ECE,2110,9.0,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.05,0%,0.0,0.0,apoorva kapadia,ECE-2110,2020
-ECE,2110,10.0,Elec Engr Lab I,0.64,0.0,0.0,0.0,0.09,0%,0.0,0.27,apoorva kapadia,ECE-2110,2020
-ECE,2120,1.0,Electrical Engineering Lab I,0.64,0.0,0.14,0.0,0.14,0%,0.0,0.07,apoorva kapadia,ECE-2120,2020
-ECE,2120,3.0,Electrical Engineering Lab I,0.85,0.0,0.0,0.0,0.0,0%,0.0,0.15,apoorva kapadia,ECE-2120,2020
-ECE,2120,4.0,Electrical Engineering Lab I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,ECE-2120,2020
-ECE,2220,1.0,Syst Prog Concept,0.3,0.21,0.12,0.03,0.18,0%,0.0,0.15,lu yu,ECE-2220,2020
-ECE,2230,1.0,Comp Sys Eng,0.22,0.24,0.19,0.17,0.02,0%,0.0,0.17,harlan russell,ECE-2230,2020
-ECE,2620,1.0,Electric Circuits II,0.61,0.2,0.07,0.0,0.1,0%,0.0,0.02,liang dong,ECE-2620,2020
-ECE,2720,1.0,Comp Organization,0.19,0.37,0.28,0.07,0.07,0%,0.0,0.02,william reid,ECE-2720,2020
-ECE,2730,2.0,Computer Org Lab,0.46,0.38,0.08,0.0,0.08,0%,0.0,0.0,apoorva kapadia,ECE-2730,2020
-ECE,2730,3.0,Computer Org Lab,0.38,0.38,0.13,0.06,0.0,0%,0.0,0.06,apoorva kapadia,ECE-2730,2020
-ECE,2730,5.0,Computer Org Lab,0.5,0.3,0.1,0.0,0.0,0%,0.0,0.1,apoorva kapadia,ECE-2730,2020
-ECE,3110,2.0,Electrical Engineering Lab I,0.73,0.13,0.0,0.07,0.07,0%,0.0,0.0,apoorva kapadia,ECE-3110,2020
-ECE,3110,3.0,Electrical Engineering Lab I,0.81,0.13,0.0,0.0,0.0,0%,0.0,0.06,apoorva kapadia,ECE-3110,2020
-ECE,3110,4.0,Electrical Engineering Lab I,0.53,0.18,0.0,0.0,0.24,0%,0.0,0.06,apoorva kapadia,ECE-3110,2020
-ECE,3110,7.0,Electrical Engineering Lab I,0.65,0.12,0.06,0.0,0.0,0%,0.0,0.18,apoorva kapadia,ECE-3110,2020
-ECE,3110,9.0,Electrical Engineering Lab I,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,ECE-3110,2020
-ECE,3120,1.0,Electrical Engineering Lab I,0.75,0.15,0.0,0.05,0.05,0%,0.0,0.0,apoorva kapadia,ECE-3120,2020
-ECE,3120,2.0,Electrical Engineering Lab I,0.75,0.13,0.06,0.0,0.06,0%,0.0,0.0,apoorva kapadia,ECE-3120,2020
-ECE,3170,1.0,Rand Signal Analysis,0.52,0.31,0.1,0.03,0.0,0%,0.0,0.05,stephen hubbard,ECE-3170,2020
-ECE,3200,1.0,Electronics I,0.42,0.18,0.17,0.1,0.08,0%,0.0,0.05,stephen hubbard,ECE-3200,2020
-ECE,3200,2.0,Electronics I (HON),0.4,0.5,0.1,0.0,0.0,0%,0.0,0.0,stephen hubbard,ECE-3200,2020
-ECE,3210,1.0,Electronics II,0.36,0.44,0.21,0.0,0.0,0%,0.0,0.0,tehseen raza,ECE-3210,2020
-ECE,3220,1.0,Intro Operating Sys,0.25,0.19,0.19,0.13,0.13,0%,0.0,0.13,jacob sorber,ECE-3220,2020
-ECE,3270,1.0,Dig Comp Design,0.35,0.41,0.11,0.0,0.05,0%,0.0,0.08,walter ligon,ECE-3270,2020
-ECE,3300,1.0,Signals & Systems,0.22,0.18,0.21,0.13,0.16,0%,0.0,0.1,carl baum,ECE-3300,2020
-ECE,3300,2.0,Signals & Systems (HON),0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,daniel noneaker,ECE-3300,2020
-ECE,3520,1.0,Programming Systems,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,yongkai wu,ECE-3520,2020
-ECE,3600,1.0,Elect Power Engr,0.2,0.27,0.07,0.07,0.27,0%,0.0,0.13,sukumar brahma,ECE-3600,2020
-ECE,3710,1.0,Microcontr Interface,0.31,0.38,0.18,0.02,0.1,0%,0.0,0.01,william reid,ECE-3710,2020
-ECE,3720,1.0,Micro Int Lab,0.77,0.08,0.0,0.0,0.08,0%,0.0,0.08,apoorva kapadia,ECE-3720,2020
-ECE,3720,2.0,Micro Int Lab,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,apoorva kapadia,ECE-3720,2020
-ECE,3720,3.0,Micro Int Lab,0.46,0.23,0.08,0.0,0.23,0%,0.0,0.0,apoorva kapadia,ECE-3720,2020
-ECE,3720,4.0,Micro Int Lab,0.5,0.08,0.08,0.08,0.0,0%,0.0,0.25,apoorva kapadia,ECE-3720,2020
-ECE,3720,5.0,Micro Int Lab,0.73,0.18,0.0,0.0,0.09,0%,0.0,0.0,apoorva kapadia,ECE-3720,2020
-ECE,3720,6.0,Micro Int Lab,0.77,0.0,0.0,0.0,0.15,0%,0.0,0.08,apoorva kapadia,ECE-3720,2020
-ECE,3720,7.0,Micro Int Lab,0.75,0.0,0.0,0.08,0.0,0%,0.0,0.17,apoorva kapadia,ECE-3720,2020
-ECE,3720,8.0,Micro Int Lab,0.54,0.0,0.08,0.08,0.08,0%,0.0,0.23,apoorva kapadia,ECE-3720,2020
-ECE,3720,9.0,Micro Int Lab,0.33,0.25,0.08,0.0,0.17,0%,0.0,0.17,apoorva kapadia,ECE-3720,2020
-ECE,3720,11.0,Micro Int Lab,0.45,0.27,0.0,0.0,0.09,0%,0.0,0.18,apoorva kapadia,ECE-3720,2020
-ECE,3800,1.0,Electromagnetics,0.08,0.14,0.26,0.08,0.22,0%,0.0,0.22,anthony martin,ECE-3800,2020
-ECE,3810,1.0,Field Waves & Ckts,0.33,0.5,0.15,0.0,0.0,0%,0.0,0.02,tehseen raza,ECE-3810,2020
-ECE,4090,1.0,Intr to Linear Control Syste,0.73,0.24,0.02,0.01,0.0,0%,0.0,0.0,apoorva kapadia,ECE-4090,2020
-ECE,4180,1.0,Power Syst Analysis,0.41,0.35,0.0,0.12,0.0,0%,0.0,0.12,ramtin hadidi,ECE-4180,2020
-ECE,4270,1.0,Communication Systems,0.23,0.4,0.25,0.03,0.03,0%,0.0,0.06,lu yu,ECE-4270,2020
-ECE,4310,1.0,Intro to Computer Vision,0.61,0.33,0.06,0.0,0.0,0%,0.0,0.0,adam hoover,ECE-4310,2020
-ECE,4420,1.0,Knowledge Engineering,0.87,0.0,0.0,0.0,0.07,0%,0.0,0.07,ao ren,ECE-4420,2020
-ECE,4490,1.0,Comp Ntwrk Security,0.33,0.24,0.05,0.05,0.0,0%,0.0,0.29,richard brooks,ECE-4490,2020
-ECE,4610,1.0,Fundamentals of Solar Ene,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,rajendra singh,ECE-4610,2020
-ECE,4670,1.0,Intro to Dig Sig Pro,0.31,0.44,0.19,0.06,0.0,0%,0.0,0.0,john gowdy,ECE-4670,2020
-ECE,4730,1.0,Intro Parallel Sys,0.4,0.48,0.0,0.0,0.08,0%,0.0,0.04,walter ligon,ECE-4730,2020
-ECE,4950,1.0,Int Sys Design I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,ECE-4950,2020
-ECE,4960,1.0,Int Sys Design II,0.7,0.26,0.04,0.0,0.0,0%,0.0,0.0,richard groff,ECE-4960,2020
-ECE,6040,1.0,Semiconductor Devices,0.67,0.22,0.11,0.0,0.0,0%,0.0,0.0,judson ryckman,ECE-6040,2020
-ECE,6310,1.0,Intro to Computer Vision,0.74,0.11,0.16,0.0,0.0,0%,0.0,0.0,adam hoover,ECE-6310,2020
-ECE,6360,1.0,Microwave Circuits,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,pingshan wang,ECE-6360,2020
-ECE,6490,1.0,Comp Ntwrk Security,0.71,0.14,0.0,0.0,0.0,0%,0.0,0.14,richard brooks,ECE-6490,2020
-ECE,6590,1.0,Int Circ Design,0.36,0.36,0.0,0.0,0.0,0%,0.0,0.18,yingjie lao,ECE-6590,2020
-ECE,6670,1.0,Intro to Dig Sig Pro,0.75,0.0,0.08,0.0,0.0,0%,0.0,0.17,john gowdy,ECE-6670,2020
-ECE,8010,1.0,Analysis of Lin Sys,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,richard groff,ECE-8010,2020
-ECE,8020,1.0,Elec Motor Cntl,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0, edrington,ECE-8020,2020
-ECE,8020,843.0,Elec Motor Cntl,0.6,0.2,0.0,0.0,0.2,0%,0.0,0.0, edrington,ECE-8020,2020
-ECE,8040,1.0,Networked Dynamical Syst,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,yongqiang wang,ECE-8040,2020
-ECE,8120,1.0,Adv Electronic Materials/D,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,goutam koley,ECE-8120,2020
-ECE,8270,1.0,Finite Dif Meth Emag,0.33,0.17,0.0,0.0,0.0,0%,0.0,0.17,anthony martin,ECE-8270,2020
-ECE,8540,1.0,Analysis of Tracking Syste,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,adam hoover,ECE-8540,2020
-ECE,8620,1.0,Com Appl Pwr Sys,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0, venayagamoorthy,ECE-8620,2020
-ECE,8910,16.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,adam hoover,ECE-8910,2020
-ECE,8910,39.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melissa smith,ECE-8910,2020
-ECE,8910,44.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sukumar brahma,ECE-8910,2020
-ECE,9910,21.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,goutam koley,ECE-9910,2020
-ECE,9910,32.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yingjie lao,ECE-9910,2020
-ECE,9910,39.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melissa smith,ECE-9910,2020
-ECE,9910,41.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, venayagamoorthy,ECE-9910,2020
-ECON,2000,2.0,Economic Concepts,0.68,0.25,0.05,0.0,0.0,0%,0.0,0.03,shubhashrita basu,ECON-2000,2020
-ECON,2000,4.0,Economic Concepts,0.46,0.34,0.17,0.0,0.03,0%,0.0,0.0,miren ivankovic,ECON-2000,2020
-ECON,2000,5.0,Economic Concepts,0.64,0.33,0.03,0.0,0.0,0%,0.0,0.0,shubhashrita basu,ECON-2000,2020
-ECON,2050,1.0,Why Business?,0.63,0.23,0.05,0.02,0.05,0%,0.0,0.02,lawrence watson,ECON-2050,2020
-ECON,2110,1.0,Principles of Microeconom,0.11,0.26,0.32,0.11,0.11,0%,0.0,0.11,frederick hanssen,ECON-2110,2020
-ECON,2110,2.0,Principles of Microeconom,0.05,0.37,0.42,0.05,0.11,0%,0.0,0.0,frederick hanssen,ECON-2110,2020
-ECON,2110,3.0,Principles of Microeconom,0.05,0.42,0.42,0.05,0.05,0%,0.0,0.0,frederick hanssen,ECON-2110,2020
-ECON,2110,4.0,Principles of Microeconom,0.16,0.47,0.21,0.0,0.0,0%,0.0,0.16,frederick hanssen,ECON-2110,2020
-ECON,2110,5.0,Principles of Microeconom,0.0,0.58,0.16,0.05,0.11,0%,0.0,0.11,frederick hanssen,ECON-2110,2020
-ECON,2110,6.0,Principles of Microeconom,0.06,0.44,0.28,0.06,0.17,0%,0.0,0.0,frederick hanssen,ECON-2110,2020
-ECON,2110,7.0,Principles of Microeconom,0.05,0.32,0.37,0.11,0.16,0%,0.0,0.0,frederick hanssen,ECON-2110,2020
-ECON,2110,8.0,Principles of Microeconom,0.16,0.37,0.37,0.05,0.0,0%,0.0,0.05,frederick hanssen,ECON-2110,2020
-ECON,2110,9.0,Principles of Microeconom,0.11,0.42,0.21,0.05,0.0,0%,0.0,0.21,frederick hanssen,ECON-2110,2020
-ECON,2110,10.0,Principles of Microeconom,0.0,0.32,0.58,0.0,0.05,0%,0.0,0.05,frederick hanssen,ECON-2110,2020
-ECON,2110,11.0,Principles of Microeconom,0.11,0.37,0.26,0.11,0.11,0%,0.0,0.05,frederick hanssen,ECON-2110,2020
-ECON,2110,12.0,Principles of Microeconom,0.0,0.47,0.21,0.05,0.05,0%,0.0,0.21,frederick hanssen,ECON-2110,2020
-ECON,2110,13.0,Principles of Microeconom,0.0,0.79,0.11,0.05,0.0,0%,0.0,0.05,frederick hanssen,ECON-2110,2020
-ECON,2110,14.0,Principles of Microeconom,0.16,0.42,0.32,0.05,0.0,0%,0.0,0.05,frederick hanssen,ECON-2110,2020
-ECON,2110,15.0,Principles of Microeconom,0.05,0.47,0.16,0.05,0.05,0%,0.0,0.21,frederick hanssen,ECON-2110,2020
-ECON,2110,16.0,Principles of Microeconom,0.05,0.32,0.32,0.11,0.11,0%,0.0,0.11,frederick hanssen,ECON-2110,2020
-ECON,2110,17.0,Principles of Microeconom,0.16,0.47,0.32,0.0,0.0,0%,0.0,0.05,frederick hanssen,ECON-2110,2020
-ECON,2110,18.0,Principles of Microeconom,0.11,0.63,0.11,0.0,0.05,0%,0.0,0.11,frederick hanssen,ECON-2110,2020
-ECON,2110,19.0,Principles of Microeconom,0.05,0.26,0.53,0.05,0.0,0%,0.0,0.11,frederick hanssen,ECON-2110,2020
-ECON,2110,20.0,Principles of Microeconom,0.25,0.44,0.22,0.06,0.01,0%,0.0,0.01,scott baier,ECON-2110,2020
-ECON,2110,21.0,Principles of Microeconom,0.2,0.56,0.2,0.01,0.03,0%,0.0,0.0,scott baier,ECON-2110,2020
-ECON,2110,23.0,Principles of Microeconom,0.68,0.23,0.05,0.0,0.02,0%,0.0,0.01,seyedmajid hashemi,ECON-2110,2020
-ECON,2110,24.0,Principles of Microeconom,0.34,0.26,0.22,0.09,0.05,0%,0.0,0.05,devon merritt gorry,ECON-2110,2020
-ECON,2110,25.0,Principles of Microeconom,0.48,0.29,0.21,0.0,0.02,0%,0.0,0.0,cory simpkins,ECON-2110,2020
-ECON,2110,26.0,Principles of Microeconom,0.72,0.2,0.02,0.02,0.0,0%,0.0,0.02,tabitha knott,ECON-2110,2020
-ECON,2110,31.0,Principles of Microeconom,0.62,0.29,0.07,0.01,0.0,0%,0.0,0.01,seyedmajid hashemi,ECON-2110,2020
-ECON,2110,32.0,Principles of Microeconom,0.23,0.51,0.19,0.01,0.06,0%,0.0,0.0,scott baier,ECON-2110,2020
-ECON,2110,33.0,Principles of Microeconom,0.67,0.19,0.1,0.0,0.05,0%,0.0,0.0,shilpi mukherjee,ECON-2110,2020
-ECON,2110,34.0,Principles of Microecon (H,0.39,0.48,0.04,0.09,0.0,0%,0.0,0.0,charles thomas,ECON-2110,2020
-ECON,2110,35.0,Principles of Microeconom,0.38,0.52,0.07,0.0,0.0,0%,0.0,0.02,cory simpkins,ECON-2110,2020
-ECON,2110,36.0,Principles of Microeconom,0.57,0.37,0.04,0.0,0.0,0%,0.0,0.01,tabitha knott,ECON-2110,2020
-ECON,2110,38.0,Principles of Microeconom,0.4,0.4,0.1,0.02,0.05,0%,0.0,0.02,guncha babajanova,ECON-2110,2020
-ECON,2110,40.0,Principles of Microeconom,0.61,0.17,0.07,0.07,0.05,0%,0.0,0.02,shilpi mukherjee,ECON-2110,2020
-ECON,2110,41.0,Principles of Microeconom,0.5,0.43,0.05,0.0,0.0,0%,0.0,0.02,guncha babajanova,ECON-2110,2020
-ECON,2120,1.0,Principles of Macroecono,0.15,0.44,0.25,0.13,0.04,0%,0.0,0.0,yinlin dai,ECON-2120,2020
-ECON,2120,2.0,Principles of Macroecono,0.37,0.45,0.14,0.02,0.0,0%,0.0,0.02,bradley keith hobbs,ECON-2120,2020
-ECON,2120,3.0,Principles of Macroecono,0.5,0.3,0.12,0.02,0.05,0%,0.0,0.02,krishna khatri,ECON-2120,2020
-ECON,2120,4.0,Principles of Macroecono,0.72,0.22,0.06,0.0,0.0,0%,0.0,0.0,tyler francis,ECON-2120,2020
-ECON,2120,5.0,Principles of Macroecono,0.48,0.33,0.1,0.03,0.03,0%,0.0,0.05,matthew lee cronin,ECON-2120,2020
-ECON,2120,6.0,Principles of Macroecono,0.41,0.46,0.05,0.03,0.03,0%,0.0,0.03,matthew lee cronin,ECON-2120,2020
-ECON,2120,7.0,Principles of Macroecono,0.78,0.15,0.04,0.01,0.01,0%,0.0,0.0,tyler francis,ECON-2120,2020
-ECON,2120,8.0,Principles of Macroecono,0.19,0.45,0.21,0.1,0.03,0%,0.0,0.02,mason bixenman,ECON-2120,2020
-ECON,2120,9.0,Principles of Macroecono,0.28,0.28,0.14,0.14,0.14,0%,0.0,0.03,yinlin dai,ECON-2120,2020
-ECON,2120,10.0,Principles of Macroecono,0.35,0.48,0.15,0.03,0.0,0%,0.0,0.0,illia polovnikov,ECON-2120,2020
-ECON,3020,1.0,Money and Banking,0.65,0.25,0.08,0.0,0.03,0%,0.0,0.0,adam witham,ECON-3020,2020
-ECON,3030,2.0,Economics and Sports,0.37,0.47,0.11,0.0,0.03,0%,0.0,0.03,raymond sauer,ECON-3030,2020
-ECON,3060,2.0,Managerial Economics,0.33,0.33,0.17,0.0,0.03,0%,0.0,0.13,miren ivankovic,ECON-3060,2020
-ECON,3100,2.0,International Econ,0.36,0.43,0.15,0.04,0.0,0%,0.0,0.03,scott baier,ECON-3100,2020
-ECON,3140,1.0,Intermediate Micro,0.41,0.17,0.2,0.11,0.04,0%,0.0,0.07,patrick warren,ECON-3140,2020
-ECON,3140,3.0,Intermediate Micro,0.22,0.15,0.2,0.11,0.28,0%,0.0,0.04,frederick hanssen,ECON-3140,2020
-ECON,3140,5.0,Intermediate Micro,0.37,0.4,0.18,0.02,0.02,0%,0.0,0.02,molly espey,ECON-3140,2020
-ECON,3150,2.0,Intermediate Macro,0.09,0.4,0.27,0.09,0.09,0%,0.0,0.07, jerzmanowski,ECON-3150,2020
-ECON,3150,4.0,Intermediate Macro,0.74,0.18,0.03,0.0,0.06,0%,0.0,0.0,scott baier,ECON-3150,2020
-ECON,3150,5.0,Intermediate Macro,0.92,0.03,0.0,0.0,0.03,0%,0.0,0.03,scott baier,ECON-3150,2020
-ECON,3190,1.0,Environmental Econ,0.42,0.4,0.08,0.02,0.04,0%,0.0,0.04,molly espey,ECON-3190,2020
-ECON,3500,1.0,Moral & Ethical Econ,0.25,0.33,0.08,0.0,0.17,0%,0.0,0.17,bradley keith hobbs,ECON-3500,2020
-ECON,3600,1.0,Public Choice,0.44,0.3,0.16,0.06,0.0,0%,0.0,0.04,michael makowsky,ECON-3600,2020
-ECON,4010,1.0,Labor Mkt Analysis,0.36,0.33,0.06,0.06,0.12,0%,0.0,0.06,chungsang lam,ECON-4010,2020
-ECON,4020,1.0,Law and Economics,0.32,0.34,0.18,0.07,0.02,0%,0.0,0.07,howard bodenhorn,ECON-4020,2020
-ECON,4040,1.0,Comp Econ Systems,0.19,0.38,0.24,0.0,0.05,0%,0.0,0.14, litsukova-bokar,ECON-4040,2020
-ECON,4050,1.0,Intro to Econometric,0.46,0.19,0.15,0.08,0.08,0%,0.0,0.04,yichen christy zhou,ECON-4050,2020
-ECON,4050,5.0,Intro to Econometric,0.4,0.26,0.17,0.06,0.11,0%,0.0,0.0,scott barkowski,ECON-4050,2020
-ECON,4100,1.0,Economic Development,0.71,0.1,0.14,0.05,0.0,0%,0.0,0.0,robert tamura,ECON-4100,2020
-ECON,4230,1.0,Economics of Health,0.45,0.28,0.1,0.05,0.08,0%,0.0,0.0,devon merritt gorry,ECON-4230,2020
-ECON,4240,1.0,Organization of Ind,0.61,0.22,0.17,0.0,0.0,0%,0.0,0.0,matthew lewis,ECON-4240,2020
-ECON,4280,1.0,Cost-Benefit Anlysis,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,robert kenneth fleck,ECON-4280,2020
-ECON,4980,2.0,Economics Data Analytics,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,raymond sauer,ECON-4980,2020
-ECON,4980,3.0,Machine Learning I,0.45,0.18,0.0,0.0,0.18,0%,0.0,0.18,chungsang lam,ECON-4980,2020
-ECON,6060,1.0,Advanced Econometric,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,scott baier,ECON-6060,2020
-ECON,6280,1.0,Cost-Benefit Anlysis,0.67,0.17,0.17,0.0,0.0,0%,0.0,0.0,robert kenneth fleck,ECON-6280,2020
-ECON,8010,1.0,Microeconomic Theory,0.33,0.33,0.2,0.0,0.07,0%,0.0,0.0,william dougan,ECON-8010,2020
-ECON,8040,1.0,Applied Math Econ,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,curtis simon,ECON-8040,2020
-ECON,8080,1.0,Econometrics III,0.12,0.76,0.12,0.0,0.0,0%,0.0,0.0,paul wayne wilson,ECON-8080,2020
-ECON,8160,1.0,Labor Economics,0.4,0.4,0.0,0.0,0.0,0%,0.0,0.2,curtis simon,ECON-8160,2020
-ECON,8230,1.0,Microecon Pub Pol,0.17,0.67,0.08,0.0,0.0,0%,0.0,0.08,scott templeton,ECON-8230,2020
-ECON,8990,5.0,Sel Topics - Macro Theory I,0.57,0.43,0.0,0.0,0.0,0%,0.0,0.0,christopher gorry,ECON-8990,2020
-ECON,9000,2.0,Econometrics I,0.2,0.6,0.2,0.0,0.0,0%,0.0,0.0, menendez garcia,ECON-9000,2020
-ECON,9000,3.0,Econometrics II,0.35,0.5,0.15,0.0,0.0,0%,0.0,0.0, menendez garcia,ECON-9000,2020
-ECON,9010,1.0,Price Theory,0.6,0.2,0.2,0.0,0.0,0%,0.0,0.0,charles thomas,ECON-9010,2020
-ECON,9810,1.0,App Econ Analysis,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,howard bodenhorn,ECON-9810,2020
-ECON,9820,2.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,frederick hanssen,ECON-9820,2020
-ECON,9820,3.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,curtis simon,ECON-9820,2020
-ECON,9820,4.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,william dougan,ECON-9820,2020
-ECON,9820,5.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert tamura,ECON-9820,2020
-ECON,9910,4.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gerald dwyer,ECON-9910,2020
-ED,1050,6.0,Orientation to Education,0.88,0.04,0.0,0.0,0.04,0%,0.0,0.04,hilary tanck,ED-1050,2020
-ED,1050,7.0,Orientation to Education,0.8,0.13,0.0,0.0,0.07,0%,0.0,0.0,yashica latimer,ED-1050,2020
-ED,1050,8.0,Orientation to Education,0.79,0.07,0.0,0.0,0.07,0%,0.0,0.07,yashica latimer,ED-1050,2020
-ED,1050,9.0,Orientation to Education,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.03,yashica latimer,ED-1050,2020
-ED,1970,4.0,CI-CONNECTIONS Stud Dev,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,deonte brown,ED-1970,2020
-ED,3010,1.0,Principles of American Edu,0.85,0.04,0.0,0.0,0.11,0%,0.0,0.0,beatrice naff bailey,ED-3010,2020
-ED,3010,3.0,Principles of American Edu,0.92,0.0,0.0,0.0,0.08,0%,0.0,0.0,beatrice naff bailey,ED-3010,2020
-ED,8090,450.0,Teacher Residency Interns,0.93,0.05,0.0,0.0,0.0,0%,0.0,0.03,corrie leigh martin,ED-8090,2020
-ED,8480,450.0,Teacher Residency Semina,0.98,0.0,0.0,0.0,0.0,0%,0.0,0.02,laura cohen eicher,ED-8480,2020
-ED,8750,331.0,Elements of Instructional E,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,anna morrison,ED-8750,2020
-ED,8990,331.0,Capstone Research Project,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,daphne wiles,ED-8990,2020
-EDC,8140,401.0,Develpmnt of Counseling S,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,barbara boyd,EDC-8140,2020
-EDC,8410,400.0,School Counseling Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,amanda rumsey,EDC-8410,2020
-EDC,8460,400.0,Clinical Ment Hlth Coun Int,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,corrine sackett,EDC-8460,2020
-EDC,8460,401.0,Clinical Ment Hlth Coun Int,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david scott,EDC-8460,2020
-EDEC,4300,1.0,Early Childhd Math,0.93,0.04,0.0,0.0,0.0,0%,0.0,0.04,sandra linder,EDEC-4300,2020
-EDEC,4400,1.0,Early Childhood Engl Lang,0.86,0.11,0.0,0.0,0.0,0%,0.0,0.04,anna henson hall,EDEC-4400,2020
-EDEL,3210,2.0,Pe for the Elem Tchr,0.46,0.46,0.03,0.0,0.03,0%,0.0,0.03,deborah smith,EDEL-3210,2020
-EDEL,3210,3.0,Pe for the Elem Tchr,0.48,0.45,0.07,0.0,0.0,0%,0.0,0.0,deborah smith,EDEL-3210,2020
-EDEL,4510,1.0,Elem Methods in Science T,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,cynthia deaton,EDEL-4510,2020
-EDEL,4870,2.0,Ele Meth Soc Studies,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,melinda spearman,EDEL-4870,2020
-EDF,3020,1.0,Educational Psychology,0.88,0.09,0.0,0.0,0.0,0%,0.0,0.03,meihua qian,EDF-3020,2020
-EDF,3020,2.0,Educational Psychology,0.86,0.11,0.0,0.0,0.0,0%,0.0,0.03,meihua qian,EDF-3020,2020
-EDF,3080,1.0,Classroom Assessment,0.95,0.03,0.0,0.03,0.0,0%,0.0,0.0,quesada hazel vega,EDF-3080,2020
-EDF,3080,2.0,Classroom Assessment,0.86,0.0,0.07,0.03,0.0,0%,0.0,0.03,quesada hazel vega,EDF-3080,2020
-EDF,3340,1.0,Child Growth and Develop,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,faiza marghoob jamil,EDF-3340,2020
-EDF,3340,3.0,Child Growth and Develop,0.7,0.22,0.05,0.0,0.03,0%,0.0,0.0,faiza marghoob jamil,EDF-3340,2020
-EDF,3350,1.0,Adolescent Growth & Dev,0.9,0.07,0.0,0.0,0.0,0%,0.0,0.03,luke rapa,EDF-3350,2020
-EDF,4800,1.0,Digital Media & Learning,0.64,0.23,0.0,0.05,0.09,0%,0.0,0.0,ryan visser,EDF-4800,2020
-EDF,4800,2.0,Digital Media & Learning,0.87,0.0,0.09,0.0,0.04,0%,0.0,0.0,ryan visser,EDF-4800,2020
-EDF,4800,300.0,Digital Media & Learning,0.9,0.07,0.03,0.0,0.0,0%,0.0,0.0,ryan visser,EDF-4800,2020
-EDF,4800,302.0,Digital Media & Learning,0.93,0.04,0.04,0.0,0.0,0%,0.0,0.0,irgens arastoopour,EDF-4800,2020
-EDF,8200,300.0,Effective Online Teaching,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,amanda bennett,EDF-8200,2020
-EDF,8200,301.0,Effective Online Teaching,0.69,0.13,0.0,0.0,0.06,0%,0.0,0.13,robert todd kane,EDF-8200,2020
-EDF,8200,500.0,Effective Online Teaching,0.88,0.04,0.0,0.0,0.04,0%,0.0,0.0,april susanne pelt,EDF-8200,2020
-EDF,8200,501.0,Effective Online Teaching,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,valerie wheeler,EDF-8200,2020
-EDF,8200,502.0,Effective Online Teaching,0.56,0.3,0.04,0.0,0.11,0%,0.0,0.0,amanda bennett,EDF-8200,2020
-EDF,8200,505.0,Effective Online Teaching,0.83,0.0,0.03,0.0,0.14,0%,0.0,0.0,robert todd kane,EDF-8200,2020
-EDF,8210,500.0,Online Course Manageme,0.81,0.04,0.0,0.0,0.12,0%,0.0,0.0,allyson marie wilcox,EDF-8210,2020
-EDF,8210,501.0,Online Course Manageme,0.82,0.14,0.0,0.0,0.04,0%,0.0,0.0,karen bunch franklin,EDF-8210,2020
-EDF,8210,502.0,Online Course Manageme,0.78,0.04,0.0,0.0,0.19,0%,0.0,0.0,robert todd kane,EDF-8210,2020
-EDF,8210,505.0,Online Course Manageme,0.7,0.19,0.0,0.0,0.11,0%,0.0,0.0,amanda bennett,EDF-8210,2020
-EDF,9270,1.0,Quant Rsrch & Stats for Ed,0.75,0.0,0.13,0.0,0.0,0%,0.0,0.13,christy jenkins brown,EDF-9270,2020
-EDF,9790,1.0,Qualitative Research in Ed,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,melinda spearman,EDF-9790,2020
-EDL,8200,400.0,Politics of Educ,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,danielle hall,EDL-8200,2020
-EDL,8850,400.0,Diversity & School Commu,0.9,0.07,0.0,0.0,0.0,0%,0.0,0.0,reginald wilkerson,EDL-8850,2020
-EDL,9770,2.0,Div Issues in Hi Ed,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,helen steele,EDL-9770,2020
-EDL,9880,1.0,Directed Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,danielle hall,EDL-9880,2020
-EDL,9910,3.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,natasha croom,EDL-9910,2020
-EDL,9910,5.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,hans william klar,EDL-9910,2020
-EDL,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jane lindle,EDL-9910,2020
-EDL,9910,7.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,danielle hall,EDL-9910,2020
-EDL,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,reginald wilkerson,EDL-9910,2020
-EDL,9910,10.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,noelle paufler,EDL-9910,2020
-EDLL,8050,401.0,Contemp Iss in School Lea,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.0,hans william klar,EDLL-8050,2020
-EDLL,8550,400.0,Secondary Sch Internship I,0.6,0.0,0.2,0.0,0.0,0%,0.0,0.0,melissa bryant burns,EDLL-8550,2020
-EDLT,4590,1.0,Teaching Reading Grades K,0.93,0.04,0.0,0.0,0.0,0%,0.0,0.04,lisa denise aker,EDLT-4590,2020
-EDLT,4600,1.0,Found of Read: Assess & In,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,hayley hoover,EDLT-4600,2020
-EDLT,4600,2.0,Found of Read: Assess & In,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,lisa denise aker,EDLT-4600,2020
-EDLT,4600,4.0,Found of Read: Assess & In,0.69,0.13,0.06,0.0,0.13,0%,0.0,0.0,polly wingate,EDLT-4600,2020
-EDLT,4610,1.0,Content Area Read/Writin,0.75,0.21,0.04,0.0,0.0,0%,0.0,0.0,pamela dunston,EDLT-4610,2020
-EDLT,4610,2.0,Content Area Read/Writin,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,pamela dunston,EDLT-4610,2020
-EDLT,4800,300.0,Found in Adolescent Litera,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,daniel stockwell,EDLT-4800,2020
-EDLT,4800,301.0,Found in Adolescent Litera,0.68,0.11,0.16,0.0,0.0,0%,0.0,0.05,daniel stockwell,EDLT-4800,2020
-EDLT,4980,1.0,Cont Area Read/Write Sec,0.86,0.1,0.0,0.0,0.0,0%,0.0,0.03,rachelle savitz,EDLT-4980,2020
-EDLT,8110,301.0,Adv Children's & Yng Adult,0.5,0.33,0.0,0.0,0.0,0%,0.0,0.0,susan king fullerton,EDLT-8110,2020
-EDLT,8150,301.0,Guided Reading & Guided,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,pamela dunston,EDLT-8150,2020
-EDLT,8190,300.0,Coaching for Literacy Educ,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,rachelle savitz,EDLT-8190,2020
-EDLT,8400,501.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,barbara fewell,EDLT-8400,2020
-EDLT,8400,510.0,Early Literacy Assessment I,0.89,0.0,0.11,0.0,0.0,0%,0.0,0.0,kimberly floyd,EDLT-8400,2020
-EDLT,8400,511.0,Early Literacy Assessment I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,renee gatlin anders,EDLT-8400,2020
-EDLT,8400,515.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,susanne elvington,EDLT-8400,2020
-EDLT,8400,516.0,Early Literacy Assessment I,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,ellen adkins sanford,EDLT-8400,2020
-EDSA,3900,6.0,Skills for Student Leaders,0.81,0.14,0.05,0.0,0.0,0%,0.0,0.0,deonte brown,EDSA-3900,2020
-EDSA,3990,1.0,Creative Inq in Counselor E,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,jacob frankovich,EDSA-3990,2020
-EDSA,8040,2.0,Theories Student Dev in Hi,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,tony cawthon,EDSA-8040,2020
-EDSA,8440,1.0,Student Affairs Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,tony cawthon,EDSA-8440,2020
-EDSC,2260,1.0,Pr Apprch to Sec Alg,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,stacy megan che,EDSC-2260,2020
-EDSC,4240,1.0,Tchng Sec English,0.8,0.07,0.13,0.0,0.0,0%,0.0,0.0, cridland-hughes,EDSC-4240,2020
-EDSC,4280,1.0,Tchng Secondary Social St,0.85,0.08,0.0,0.0,0.0,0%,0.0,0.08,kristen duncan,EDSC-4280,2020
-EDSP,3700,1.0,Intro to Special Education,0.91,0.06,0.03,0.0,0.0,0%,0.0,0.0,sharon walters,EDSP-3700,2020
-EDSP,3700,2.0,Intro to Special Education,0.73,0.23,0.0,0.0,0.0,0%,0.0,0.04,catherine griffith,EDSP-3700,2020
-EDSP,3700,4.0,Intro to Special Education,0.82,0.09,0.09,0.0,0.0,0%,0.0,0.0,catherine griffith,EDSP-3700,2020
-EDSP,3720,1.0,Char & Instr Individ with L,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,catherine griffith,EDSP-3720,2020
-EDSP,3740,1.0,Char & Strat Emot/Behav,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,shanna eisner hirsch,EDSP-3740,2020
-EDSP,3750,1.0,Early Intervention Spec Ne,0.84,0.12,0.0,0.0,0.04,0%,0.0,0.0,tracy denise garrett,EDSP-3750,2020
-EDSP,3750,2.0,Early Intervention Spec Ne,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,tracy denise garrett,EDSP-3750,2020
-EDSP,4920,1.0,Math Inst Ind W/Dis,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,pamela stecker,EDSP-4920,2020
-EDSP,4930,1.0,Clsrm/Beh Mgmt Sp Ed,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,joseph benedict ryan,EDSP-4930,2020
-EDSP,4960,1.0,Sp Ed Field Exp,0.93,0.03,0.03,0.0,0.0,0%,0.0,0.0,wendell kent parker,EDSP-4960,2020
-EES,2010,1.0,Environ Engr Fundamental,0.32,0.34,0.21,0.05,0.03,0%,0.0,0.05,david freedman,EES-2010,2020
-EES,3030,1.0,Water Treatment Systems,0.32,0.5,0.14,0.04,0.0,0%,0.0,0.0,david allen ladner,EES-3030,2020
-EES,3040,1.0,Wastewater Treatment Sy,0.56,0.19,0.26,0.0,0.0,0%,0.0,0.0,sudeep popat,EES-3040,2020
-EES,3050,1.0,Water/Wastewater Treat,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,david allen ladner,EES-3050,2020
-EES,3050,2.0,Water/Wastewater Treat,0.64,0.14,0.07,0.0,0.07,0%,0.0,0.0,sudeep popat,EES-3050,2020
-EES,4010,1.0,Environmental Engr,0.67,0.22,0.09,0.02,0.0,0%,0.0,0.0,elizabeth carraway,EES-4010,2020
-EES,4010,2.0,Environmental Engr,0.25,0.5,0.25,0.0,0.0,0%,0.0,0.0,mark schlautman,EES-4010,2020
-EES,4090,1.0,Intro to Nuc Engr & Radiol,0.22,0.39,0.06,0.33,0.0,0%,0.0,0.0,timothy devol,EES-4090,2020
-EES,4300,1.0,Air Pollution Engineering,0.38,0.38,0.16,0.03,0.06,0%,0.0,0.0,andrew metcalf,EES-4300,2020
-EES,4800,1.0,Environmental Risk Assess,0.41,0.28,0.21,0.07,0.03,0%,0.0,0.0,nicole martinez,EES-4800,2020
-EES,4840,1.0,Solid Waste Mgt,0.5,0.31,0.15,0.04,0.0,0%,0.0,0.0,ezra lucas hoyt cates hoyt,EES-4840,2020
-EES,4860,2.0,Environmental Sustainabili,0.6,0.25,0.05,0.0,0.0,0%,0.0,0.1, carbajales-dale,EES-4860,2020
-EES,6100,1.0,Environ Radiation Protecti,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.2,nicole martinez,EES-6100,2020
-EES,8020,1.0,Environ Eng Prin,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,david allen ladner,EES-8020,2020
-EES,8060,1.0,Design Env Control,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0, carbajales-dale,EES-8060,2020
-EES,8430,1.0,Environmental Chem,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,brian powell,EES-8430,2020
-EES,8430,2.0,Environmental Chem,0.5,0.38,0.0,0.0,0.0,0%,0.0,0.13,brian powell,EES-8430,2020
-EES,8510,1.0,Biol Prin Envir Engr,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,kevin finneran,EES-8510,2020
-EES,8610,1.0,Environmental Engr & Sci S,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sudeep popat,EES-8610,2020
-EES,8800,1.0,Env Risk Assessment,0.3,0.7,0.0,0.0,0.0,0%,0.0,0.0,timothy devol,EES-8800,2020
-ELE,3010,1.0,Entrepreneurial Foundatio,0.28,0.28,0.28,0.07,0.07,0%,0.0,0.02,ashley parnell,ELE-3010,2020
-ELE,3010,2.0,Entrepreneurial Foundatio,0.22,0.27,0.34,0.07,0.02,0%,0.0,0.07,ashley parnell,ELE-3010,2020
-ELE,3010,3.0,Entrepreneurial Foundatio,0.62,0.28,0.08,0.03,0.0,0%,0.0,0.0,lori leigh tribble,ELE-3010,2020
-ELE,3010,4.0,Entrepreneurial Foundatio,0.32,0.46,0.19,0.0,0.03,0%,0.0,0.0,lori leigh tribble,ELE-3010,2020
-ELE,3010,5.0,Entrepreneurial Foundatio,0.56,0.25,0.13,0.03,0.0,0%,0.0,0.03,lori leigh tribble,ELE-3010,2020
-ELE,4020,1.0,Venture Planning,0.2,0.7,0.11,0.0,0.0,0%,0.0,0.0,william dinardo,ELE-4020,2020
-ELE,4040,1.0,Entrepreneurial Resource,0.68,0.2,0.1,0.0,0.0,0%,0.0,0.02,james keith hudgins,ELE-4040,2020
-ELE,4060,1.0,Venture Consulting,0.35,0.63,0.03,0.0,0.0,0%,0.0,0.0,william dinardo,ELE-4060,2020
-ENGL,1030,7.0,Composition and Rhetoric,0.48,0.43,0.1,0.0,0.0,0%,0.0,0.0,allen swords,ENGL-1030,2020
-ENGL,1030,8.0,Composition and Rhetoric,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,allen swords,ENGL-1030,2020
-ENGL,1030,43.0,Composition and Rhetoric,0.71,0.14,0.0,0.0,0.14,0%,0.0,0.0,hannah taylor,ENGL-1030,2020
-ENGL,1030,44.0,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,hannah taylor,ENGL-1030,2020
-ENGL,1030,47.0,Composition and Rhetoric,0.4,0.45,0.0,0.05,0.05,0%,0.0,0.05,cody hunter,ENGL-1030,2020
-ENGL,1030,48.0,Composition and Rhetoric,0.6,0.1,0.05,0.0,0.15,0%,0.0,0.1,cody hunter,ENGL-1030,2020
-ENGL,1030,49.0,Composition and Rhetoric,0.62,0.24,0.05,0.0,0.0,0%,0.0,0.1,nicholas rader,ENGL-1030,2020
-ENGL,1030,50.0,Composition and Rhetoric,0.86,0.05,0.0,0.0,0.05,0%,0.0,0.05,nicholas rader,ENGL-1030,2020
-ENGL,1030,51.0,Composition and Rhetoric,0.76,0.0,0.05,0.0,0.14,0%,0.0,0.05,sethunya gall,ENGL-1030,2020
-ENGL,1030,400.0,Composition and Rhetoric,0.57,0.29,0.0,0.0,0.14,0%,0.0,0.0,kailan smith sindelar,ENGL-1030,2020
-ENGL,1030,401.0,Composition and Rhetoric,0.57,0.33,0.0,0.0,0.1,0%,0.0,0.0,kailan smith sindelar,ENGL-1030,2020
-ENGL,1030,402.0,Composition and Rhetoric,0.86,0.1,0.0,0.0,0.05,0%,0.0,0.0,jonathan burgess,ENGL-1030,2020
-ENGL,1030,403.0,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,jonathan burgess,ENGL-1030,2020
-ENGL,1030,404.0,Composition and Rhetoric,0.57,0.24,0.0,0.0,0.14,0%,0.0,0.05,eric reid hamilton,ENGL-1030,2020
-ENGL,1030,405.0,Composition and Rhetoric,0.48,0.24,0.05,0.14,0.1,0%,0.0,0.0,dennis ranahan,ENGL-1030,2020
-ENGL,1030,406.0,Composition and Rhetoric,0.81,0.05,0.0,0.05,0.05,0%,0.0,0.05,jacob danial richter,ENGL-1030,2020
-ENGL,1030,407.0,Composition and Rhetoric,0.33,0.39,0.11,0.0,0.11,0%,0.0,0.06,sheila lalwani,ENGL-1030,2020
-ENGL,1030,408.0,Composition and Rhetoric,0.06,0.41,0.24,0.12,0.18,0%,0.0,0.0,sheila lalwani,ENGL-1030,2020
-ENGL,1030,409.0,Composition and Rhetoric,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,jordan harris frith,ENGL-1030,2020
-ENGL,1030,410.0,Composition and Rhetoric,0.5,0.2,0.1,0.0,0.15,0%,0.0,0.05,hailee mccraw,ENGL-1030,2020
-ENGL,1030,411.0,Composition and Rhetoric,0.29,0.19,0.14,0.05,0.19,0%,0.0,0.14,hailee mccraw,ENGL-1030,2020
-ENGL,1030,412.0,Composition and Rhetoric,0.5,0.3,0.1,0.0,0.1,0%,0.0,0.0,miranda campbell,ENGL-1030,2020
-ENGL,1030,413.0,Composition and Rhetoric,0.47,0.26,0.21,0.0,0.05,0%,0.0,0.0,miranda campbell,ENGL-1030,2020
-ENGL,1030,414.0,Composition and Rhetoric,0.45,0.2,0.1,0.15,0.05,0%,0.0,0.05,edward thomas troy,ENGL-1030,2020
-ENGL,1030,415.0,Composition and Rhetoric,0.71,0.1,0.14,0.0,0.0,0%,0.0,0.05,lindsay scott,ENGL-1030,2020
-ENGL,1030,416.0,Composition and Rhetoric,0.53,0.18,0.06,0.06,0.06,0%,0.0,0.06,jennie wakefield,ENGL-1030,2020
-ENGL,1030,420.0,Composition and Rhetoric,0.62,0.19,0.05,0.05,0.0,0%,0.0,0.05,jennie wakefield,ENGL-1030,2020
-ENGL,1030,421.0,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,aparna shastri,ENGL-1030,2020
-ENGL,1030,423.0,Composition and Rhetoric,0.89,0.06,0.0,0.0,0.0,0%,0.0,0.06,amanda platz,ENGL-1030,2020
-ENGL,1030,425.0,Composition and Rhetoric,0.83,0.06,0.0,0.06,0.0,0%,0.0,0.06,aparna shastri,ENGL-1030,2020
-ENGL,1030,426.0,Composition and Rhetoric,0.78,0.06,0.0,0.0,0.11,0%,0.0,0.06,laura caroline dunn,ENGL-1030,2020
-ENGL,1030,427.0,Composition and Rhetoric,0.58,0.16,0.11,0.11,0.05,0%,0.0,0.0,laura caroline dunn,ENGL-1030,2020
-ENGL,1030,428.0,Composition and Rhetoric,0.89,0.05,0.0,0.05,0.0,0%,0.0,0.0,nicole marie stout,ENGL-1030,2020
-ENGL,1030,429.0,Composition and Rhetoric,0.68,0.16,0.05,0.11,0.0,0%,0.0,0.0,amanda platz,ENGL-1030,2020
-ENGL,1030,430.0,Composition and Rhetoric,0.5,0.2,0.15,0.1,0.0,0%,0.0,0.05,edward thomas troy,ENGL-1030,2020
-ENGL,1030,431.0,Composition and Rhetoric,0.63,0.11,0.11,0.05,0.05,0%,0.0,0.05,edward thomas troy,ENGL-1030,2020
-ENGL,1030,435.0,Composition and Rhetoric,0.5,0.35,0.1,0.0,0.05,0%,0.0,0.0,edward thomas troy,ENGL-1030,2020
-ENGL,1030,436.0,Composition and Rhetoric,0.88,0.0,0.0,0.13,0.0,0%,0.0,0.0,nicole marie stout,ENGL-1030,2020
-ENGL,1030,437.0,Composition and Rhetoric,0.78,0.0,0.06,0.0,0.11,0%,0.0,0.06,kaitlyn samons,ENGL-1030,2020
-ENGL,1030,445.0,Composition and Rhetoric,0.78,0.17,0.06,0.0,0.0,0%,0.0,0.0,dennis ranahan,ENGL-1030,2020
-ENGL,1030,446.0,Composition and Rhetoric,0.6,0.15,0.1,0.05,0.0,0%,0.0,0.1,mary frankovich,ENGL-1030,2020
-ENGL,1030,453.0,Composition and Rhetoric,0.68,0.16,0.05,0.05,0.0,0%,0.0,0.05,mary frankovich,ENGL-1030,2020
-ENGL,1030,454.0,Composition and Rhetoric,0.75,0.15,0.0,0.0,0.05,0%,0.0,0.05,sarah richardson,ENGL-1030,2020
-ENGL,1030,456.0,Composition and Rhetoric,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,sarah richardson,ENGL-1030,2020
-ENGL,1030,457.0,Composition and Rhetoric,0.84,0.0,0.05,0.05,0.05,0%,0.0,0.0,michael vaughan,ENGL-1030,2020
-ENGL,1030,459.0,Composition and Rhetoric,0.83,0.06,0.11,0.0,0.0,0%,0.0,0.0,michael vaughan,ENGL-1030,2020
-ENGL,1030,460.0,Composition and Rhetoric,0.72,0.11,0.11,0.0,0.06,0%,0.0,0.0,caroline kinderthain,ENGL-1030,2020
-ENGL,1030,461.0,Composition and Rhetoric,0.69,0.19,0.06,0.0,0.0,0%,0.0,0.06,kylie carlson,ENGL-1030,2020
-ENGL,1030,464.0,Composition and Rhetoric,0.78,0.06,0.0,0.11,0.06,0%,0.0,0.0,kylie carlson,ENGL-1030,2020
-ENGL,1030,465.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0%,0.0,0.0,rebecca rea  ross s,ENGL-1030,2020
-ENGL,1030,467.0,Composition and Rhetoric,0.38,0.38,0.06,0.0,0.13,0%,0.0,0.06,rebecca rea  ross s,ENGL-1030,2020
-ENGL,1030,468.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0%,0.0,0.0,samantha keebler,ENGL-1030,2020
-ENGL,1030,469.0,Composition and Rhetoric,0.67,0.06,0.06,0.06,0.11,0%,0.0,0.06,samantha keebler,ENGL-1030,2020
-ENGL,1030,470.0,Composition and Rhetoric,0.69,0.06,0.13,0.0,0.06,0%,0.0,0.06,jenny washburne,ENGL-1030,2020
-ENGL,1030,471.0,Composition and Rhetoric,0.59,0.35,0.06,0.0,0.0,0%,0.0,0.0,jenny washburne,ENGL-1030,2020
-ENGL,1030,475.0,Composition and Rhetoric,0.41,0.06,0.29,0.12,0.0,0%,0.0,0.12,victoria lynn carrico,ENGL-1030,2020
-ENGL,1030,476.0,Composition and Rhetoric,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,victoria lynn carrico,ENGL-1030,2020
-ENGL,1030,477.0,Composition and Rhetoric,0.42,0.37,0.11,0.11,0.0,0%,0.0,0.0,kimberly groves,ENGL-1030,2020
-ENGL,1030,478.0,Composition and Rhetoric,0.67,0.11,0.06,0.0,0.0,0%,0.0,0.17,kimberly groves,ENGL-1030,2020
-ENGL,1030,482.0,Composition and Rhetoric,0.78,0.06,0.0,0.0,0.06,0%,0.0,0.11,kaitlyn samons,ENGL-1030,2020
-ENGL,1030,484.0,Composition and Rhetoric,0.5,0.22,0.28,0.0,0.0,0%,0.0,0.0,allison daniel,ENGL-1030,2020
-ENGL,1030,485.0,Composition and Rhetoric,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,allison daniel,ENGL-1030,2020
-ENGL,2020,1.0,Lit Forms and Creative Wri,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,melissa dugan,ENGL-2020,2020
-ENGL,2020,2.0,Lit Forms and Creative Wri,0.7,0.26,0.0,0.0,0.04,0%,0.0,0.0,melissa dugan,ENGL-2020,2020
-ENGL,2020,4.0,Lit Forms and Creative Wri,0.52,0.4,0.08,0.0,0.0,0%,0.0,0.0,keith morris,ENGL-2020,2020
-ENGL,2020,5.0,Lit Forms and Creative Wri,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,john logan pursley,ENGL-2020,2020
-ENGL,2020,400.0,Lit Forms and Creative Wri,0.68,0.2,0.04,0.08,0.0,0%,0.0,0.0,stephanie edwards,ENGL-2020,2020
-ENGL,2020,401.0,Lit Forms and Creative Wri,0.44,0.32,0.12,0.04,0.0,0%,0.0,0.08,stephanie edwards,ENGL-2020,2020
-ENGL,2020,402.0,Lit Forms and Creative Wri,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,jillian weise,ENGL-2020,2020
-ENGL,2020,403.0,Lit Forms and Creative Wri,0.52,0.28,0.04,0.08,0.08,0%,0.0,0.0,stephanie edwards,ENGL-2020,2020
-ENGL,2120,1.0,World Literature,0.48,0.28,0.08,0.04,0.08,0%,0.0,0.04,andrew mathas,ENGL-2120,2020
-ENGL,2120,2.0,World Literature,0.52,0.16,0.2,0.0,0.08,0%,0.0,0.04,caitlin grace watt,ENGL-2120,2020
-ENGL,2120,3.0,World Literature,0.44,0.28,0.08,0.0,0.12,0%,0.0,0.08,kenneth tuite,ENGL-2120,2020
-ENGL,2120,9.0,World Literature,0.56,0.16,0.12,0.04,0.08,0%,0.0,0.04,caitlin grace watt,ENGL-2120,2020
-ENGL,2120,10.0,World Literature,0.56,0.24,0.2,0.0,0.0,0%,0.0,0.0,caitlin grace watt,ENGL-2120,2020
-ENGL,2120,11.0,World Literature,0.48,0.24,0.2,0.04,0.04,0%,0.0,0.0,caitlin grace watt,ENGL-2120,2020
-ENGL,2120,13.0,World Literature,0.64,0.24,0.08,0.0,0.0,0%,0.0,0.04,remley makala,ENGL-2120,2020
-ENGL,2120,17.0,World Literature,0.78,0.17,0.0,0.0,0.04,0%,0.0,0.0,remley makala,ENGL-2120,2020
-ENGL,2120,21.0,World Literature,0.84,0.08,0.0,0.04,0.0,0%,0.0,0.04,remley makala,ENGL-2120,2020
-ENGL,2120,22.0,World Literature,0.36,0.32,0.08,0.0,0.16,0%,0.0,0.08,david charles foltz,ENGL-2120,2020
-ENGL,2120,23.0,World Literature,0.5,0.27,0.09,0.05,0.0,0%,0.0,0.05,david charles foltz,ENGL-2120,2020
-ENGL,2120,24.0,World Literature,0.42,0.25,0.21,0.04,0.0,0%,0.0,0.04,david charles foltz,ENGL-2120,2020
-ENGL,2120,25.0,World Literature,0.48,0.24,0.12,0.08,0.04,0%,0.0,0.04,david charles foltz,ENGL-2120,2020
-ENGL,2120,26.0,World Literature,0.64,0.2,0.12,0.0,0.0,0%,0.0,0.04,john benjamin fuqua,ENGL-2120,2020
-ENGL,2120,27.0,World Literature,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,john benjamin fuqua,ENGL-2120,2020
-ENGL,2120,28.0,World Literature,0.4,0.36,0.0,0.08,0.16,0%,0.0,0.0,andrew mathas,ENGL-2120,2020
-ENGL,2120,400.0,World Literature,0.17,0.46,0.17,0.04,0.04,0%,0.0,0.13,sarah mae cooper,ENGL-2120,2020
-ENGL,2120,401.0,World Literature,0.25,0.5,0.17,0.0,0.0,0%,0.0,0.08,sarah mae cooper,ENGL-2120,2020
-ENGL,2120,402.0,World Literature,0.6,0.12,0.08,0.08,0.0,0%,0.0,0.12,sharon nalley,ENGL-2120,2020
-ENGL,2120,403.0,World Literature,0.64,0.16,0.04,0.0,0.04,0%,0.0,0.12,sharon nalley,ENGL-2120,2020
-ENGL,2120,404.0,World Literature,0.28,0.6,0.04,0.04,0.0,0%,0.0,0.04,sarah mae cooper,ENGL-2120,2020
-ENGL,2120,405.0,World Literature,0.88,0.0,0.12,0.0,0.0,0%,0.0,0.0,melissa dugan,ENGL-2120,2020
-ENGL,2120,406.0,World Literature,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,walter edgar hunter,ENGL-2120,2020
-ENGL,2120,407.0,World Literature,0.32,0.45,0.18,0.0,0.0,0%,0.0,0.05,daniel scott citro,ENGL-2120,2020
-ENGL,2120,408.0,World Literature,0.36,0.36,0.0,0.09,0.0,0%,0.0,0.18,daniel scott citro,ENGL-2120,2020
-ENGL,2120,409.0,World Literature,0.64,0.16,0.08,0.12,0.0,0%,0.0,0.0,sharon nalley,ENGL-2120,2020
-ENGL,2120,410.0,World Literature,0.56,0.2,0.04,0.12,0.04,0%,0.0,0.04,sharon nalley,ENGL-2120,2020
-ENGL,2120,411.0,World Literature,0.85,0.08,0.0,0.0,0.08,0%,0.0,0.0,walter edgar hunter,ENGL-2120,2020
-ENGL,2120,412.0,World Literature,0.63,0.13,0.13,0.0,0.0,0%,0.0,0.13,henna messina,ENGL-2120,2020
-ENGL,2120,413.0,World Literature,0.4,0.4,0.04,0.04,0.0,0%,0.0,0.12,henna messina,ENGL-2120,2020
-ENGL,2120,414.0,World Literature,0.55,0.36,0.0,0.0,0.0,0%,0.0,0.09,maziyar faridi,ENGL-2120,2020
-ENGL,2120,415.0,World Literature,0.4,0.48,0.04,0.0,0.0,0%,0.0,0.08,maziyar faridi,ENGL-2120,2020
-ENGL,2120,416.0,World Literature,0.72,0.24,0.0,0.04,0.0,0%,0.0,0.0,hannah godwin,ENGL-2120,2020
-ENGL,2120,417.0,World Literature,0.72,0.24,0.0,0.04,0.0,0%,0.0,0.0,hannah godwin,ENGL-2120,2020
-ENGL,2120,418.0,World Literature,0.84,0.12,0.0,0.0,0.0,0%,0.0,0.04,hannah godwin,ENGL-2120,2020
-ENGL,2120,419.0,World Literature,0.29,0.46,0.21,0.0,0.0,0%,0.0,0.0,sarah mae cooper,ENGL-2120,2020
-ENGL,2130,1.0,British Literature,0.6,0.2,0.07,0.07,0.07,0%,0.0,0.0,william stockton,ENGL-2130,2020
-ENGL,2130,2.0,British Literature,0.67,0.13,0.13,0.0,0.0,0%,0.0,0.07,william stockton,ENGL-2130,2020
-ENGL,2130,3.0,British Literature,0.6,0.27,0.13,0.0,0.0,0%,0.0,0.0,william stockton,ENGL-2130,2020
-ENGL,2130,4.0,British Literature,0.48,0.4,0.0,0.0,0.04,0%,0.0,0.08,john benjamin fuqua,ENGL-2130,2020
-ENGL,2130,5.0,British Literature,0.54,0.25,0.08,0.04,0.04,0%,0.0,0.04,remley makala,ENGL-2130,2020
-ENGL,2130,6.0,British Literature,0.67,0.25,0.04,0.0,0.04,0%,0.0,0.0,lucian ghita,ENGL-2130,2020
-ENGL,2130,7.0,British Literature,0.72,0.2,0.08,0.0,0.0,0%,0.0,0.0,lucian ghita,ENGL-2130,2020
-ENGL,2130,8.0,British Literature,0.84,0.08,0.08,0.0,0.0,0%,0.0,0.0,lucian ghita,ENGL-2130,2020
-ENGL,2130,400.0,British Literature,0.61,0.3,0.0,0.0,0.04,0%,0.0,0.0,daniel scott citro,ENGL-2130,2020
-ENGL,2130,401.0,British Literature,0.3,0.43,0.04,0.04,0.09,0%,0.0,0.04,daniel scott citro,ENGL-2130,2020
-ENGL,2130,402.0,British Literature,0.48,0.16,0.24,0.0,0.0,0%,0.0,0.08,henna messina,ENGL-2130,2020
-ENGL,2130,403.0,British Literature,0.61,0.3,0.0,0.0,0.04,0%,0.0,0.04,daniel scott citro,ENGL-2130,2020
-ENGL,2130,404.0,British Literature,0.4,0.52,0.0,0.0,0.04,0%,0.0,0.04,ingrid anna pierce,ENGL-2130,2020
-ENGL,2140,1.0,American Literature,0.08,0.56,0.2,0.0,0.04,0%,0.0,0.12,chelsea marie clarey,ENGL-2140,2020
-ENGL,2140,2.0,American Literature,0.13,0.58,0.25,0.0,0.04,0%,0.0,0.0,chelsea marie clarey,ENGL-2140,2020
-ENGL,2140,3.0,American Literature,0.25,0.42,0.21,0.04,0.04,0%,0.0,0.0,chelsea marie clarey,ENGL-2140,2020
-ENGL,2140,4.0,American Literature,0.22,0.3,0.17,0.04,0.04,0%,0.0,0.22,chelsea marie clarey,ENGL-2140,2020
-ENGL,2140,7.0,American Literature,0.84,0.08,0.0,0.04,0.0,0%,0.0,0.04,melissa dugan,ENGL-2140,2020
-ENGL,2140,8.0,American Literature,0.88,0.04,0.0,0.04,0.04,0%,0.0,0.0,melissa dugan,ENGL-2140,2020
-ENGL,2140,400.0,American Literature,0.38,0.38,0.25,0.0,0.0,0%,0.0,0.0,clare mullaney,ENGL-2140,2020
-ENGL,2140,401.0,American Literature,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,jennifer forsberg,ENGL-2140,2020
-ENGL,2140,402.0,American Literature,0.39,0.3,0.13,0.0,0.09,0%,0.0,0.09,karen kettnich,ENGL-2140,2020
-ENGL,2140,403.0,American Literature,0.43,0.43,0.04,0.0,0.09,0%,0.0,0.0,karen kettnich,ENGL-2140,2020
-ENGL,2140,404.0,American Literature,0.6,0.24,0.08,0.0,0.0,0%,0.0,0.08,jennifer forsberg,ENGL-2140,2020
-ENGL,2140,405.0,American Literature,0.68,0.16,0.16,0.0,0.0,0%,0.0,0.0,david charles foltz,ENGL-2140,2020
-ENGL,2140,406.0,American Literature,0.8,0.08,0.0,0.0,0.04,0%,0.0,0.08,sharon nalley,ENGL-2140,2020
-ENGL,2140,407.0,American Literature,0.5,0.25,0.17,0.0,0.04,0%,0.0,0.04,mary nestor,ENGL-2140,2020
-ENGL,2150,5.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.12,0.04,0.04,0%,0.0,0.0,william cunningham,ENGL-2150,2020
-ENGL,2150,7.0,Lit in 20th-21st Cent Conte,0.2,0.32,0.4,0.0,0.08,0%,0.0,0.0,megan macalystre,ENGL-2150,2020
-ENGL,2150,8.0,Lit in 20th-21st Cent Conte,0.52,0.24,0.12,0.08,0.0,0%,0.0,0.04,william cunningham,ENGL-2150,2020
-ENGL,2150,9.0,Lit in 20th-21st Cent Conte,0.48,0.35,0.04,0.0,0.09,0%,0.0,0.04,gregory luke chwala,ENGL-2150,2020
-ENGL,2150,10.0,Lit in 20th-21st Cent Conte,0.24,0.59,0.06,0.0,0.0,0%,0.0,0.12,gregory luke chwala,ENGL-2150,2020
-ENGL,2150,11.0,Lit in 20th-21st Cent Conte,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,allen swords,ENGL-2150,2020
-ENGL,2150,12.0,Lit in 20th-21st Cent Conte,0.84,0.12,0.04,0.0,0.0,0%,0.0,0.0,allen swords,ENGL-2150,2020
-ENGL,2150,14.0,Lit in 20th-21st Cent Conte,0.5,0.28,0.06,0.11,0.0,0%,0.0,0.06,gregory luke chwala,ENGL-2150,2020
-ENGL,2150,15.0,Lit in 20th-21st Cent Conte,0.58,0.38,0.0,0.0,0.04,0%,0.0,0.0,john logan pursley,ENGL-2150,2020
-ENGL,2150,16.0,Lit in 20th-21st Cent Conte,0.64,0.28,0.04,0.0,0.04,0%,0.0,0.0,john logan pursley,ENGL-2150,2020
-ENGL,2150,17.0,Lit in 20th-21st Cent Conte,0.36,0.32,0.12,0.0,0.12,0%,0.0,0.08,megan macalystre,ENGL-2150,2020
-ENGL,2150,18.0,Lit in 20th-21st Cent Conte,0.56,0.28,0.08,0.04,0.04,0%,0.0,0.0,elizabeth stansell,ENGL-2150,2020
-ENGL,2150,21.0,Lit in 20th-21st Cent Conte,0.52,0.3,0.09,0.04,0.04,0%,0.0,0.0,megan macalystre,ENGL-2150,2020
-ENGL,2150,22.0,Lit in 20th-21st Cent Conte,0.64,0.24,0.04,0.0,0.04,0%,0.0,0.04,john logan pursley,ENGL-2150,2020
-ENGL,2150,27.0,Lit in 20th-21st Cent Conte,0.64,0.32,0.0,0.0,0.0,0%,0.0,0.04,elizabeth stansell,ENGL-2150,2020
-ENGL,2150,29.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.08,0.08,0.04,0%,0.0,0.0,andrew mathas,ENGL-2150,2020
-ENGL,2150,30.0,Lit in 20th-21st Cent Conte,0.68,0.12,0.12,0.0,0.08,0%,0.0,0.0,andrew mathas,ENGL-2150,2020
-ENGL,2150,400.0,Lit in 20th-21st Cent Conte,0.6,0.24,0.12,0.0,0.04,0%,0.0,0.0,elizabeth stansell,ENGL-2150,2020
-ENGL,2150,401.0,Lit in 20th-21st Cent Conte,0.48,0.26,0.17,0.0,0.0,0%,0.0,0.04,gregory luke chwala,ENGL-2150,2020
-ENGL,2150,402.0,Lit in 20th-21st Cent Conte,0.72,0.16,0.0,0.04,0.0,0%,0.0,0.08,heather williams,ENGL-2150,2020
-ENGL,2150,403.0,Lit in 20th-21st Cent Conte,0.76,0.16,0.08,0.0,0.0,0%,0.0,0.0,heather williams,ENGL-2150,2020
-ENGL,2150,404.0,Lit in 20th-21st Cent Conte,0.54,0.13,0.0,0.04,0.17,0%,0.0,0.13,jamie ann rogers,ENGL-2150,2020
-ENGL,2150,405.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.12,0.04,0.0,0%,0.0,0.04,mary nestor,ENGL-2150,2020
-ENGL,2150,406.0,Lit in 20th-21st Cent Conte,0.4,0.48,0.0,0.0,0.12,0%,0.0,0.0,mary nestor,ENGL-2150,2020
-ENGL,2150,407.0,Lit in 20th-21st Cent Conte,0.76,0.16,0.04,0.0,0.04,0%,0.0,0.0,april ayers lawson,ENGL-2150,2020
-ENGL,2150,409.0,Lit in 20th-21st Cent Conte,0.48,0.26,0.13,0.0,0.09,0%,0.0,0.04,sarah matalone,ENGL-2150,2020
-ENGL,2150,410.0,Lit in 20th-21st Cent Conte,0.52,0.28,0.04,0.0,0.04,0%,0.0,0.12,sarah matalone,ENGL-2150,2020
-ENGL,2150,411.0,Lit in 20th-21st Cent Conte,0.48,0.28,0.0,0.0,0.04,0%,0.0,0.2,tareva johnson,ENGL-2150,2020
-ENGL,2150,412.0,Lit in 20th-21st Cent Conte,0.54,0.25,0.0,0.0,0.08,0%,0.0,0.13,tareva johnson,ENGL-2150,2020
-ENGL,2150,413.0,Lit in 20th-21st Cent Conte,0.84,0.14,0.02,0.0,0.0,0%,0.0,0.0,david coombs,ENGL-2150,2020
-ENGL,2160,4.0,African American Literatur,0.44,0.32,0.12,0.04,0.0,0%,0.0,0.08,patricia sunia,ENGL-2160,2020
-ENGL,2160,400.0,African American Literatur,0.44,0.24,0.08,0.0,0.04,0%,0.0,0.2,tareva johnson,ENGL-2160,2020
-ENGL,2160,401.0,African American Literatur,0.44,0.24,0.08,0.0,0.08,0%,0.0,0.12,tareva johnson,ENGL-2160,2020
-ENGL,2160,402.0,African American Literatur,0.76,0.12,0.04,0.0,0.04,0%,0.0,0.04,jamie ann rogers,ENGL-2160,2020
-ENGL,2160,403.0,African American Literatur,0.68,0.12,0.04,0.04,0.08,0%,0.0,0.04,jamie ann rogers,ENGL-2160,2020
-ENGL,2160,404.0,African American Literatur,0.68,0.12,0.12,0.0,0.0,0%,0.0,0.04,jamie ann rogers,ENGL-2160,2020
-ENGL,2310,400.0,Intro to Journalism,0.71,0.19,0.0,0.0,0.05,0%,0.0,0.05,william pulley,ENGL-2310,2020
-ENGL,3010,1.0,Great Books of Western W,0.6,0.2,0.0,0.0,0.2,0%,0.0,0.0,dominic mastroianni,ENGL-3010,2020
-ENGL,3040,2.0,Business Writing,0.81,0.14,0.05,0.0,0.0,0%,0.0,0.0,ashley cowden fisk,ENGL-3040,2020
-ENGL,3040,400.0,Business Writing,0.77,0.14,0.0,0.05,0.05,0%,0.0,0.0,heather williams,ENGL-3040,2020
-ENGL,3040,401.0,Business Writing,0.86,0.1,0.05,0.0,0.0,0%,0.0,0.0,heather williams,ENGL-3040,2020
-ENGL,3040,402.0,Business Writing,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,ENGL-3040,2020
-ENGL,3040,403.0,Business Writing,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,ENGL-3040,2020
-ENGL,3040,404.0,Business Writing,0.71,0.19,0.0,0.0,0.0,0%,0.0,0.1,la'cresha ulon green,ENGL-3040,2020
-ENGL,3040,405.0,Business Writing,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,ENGL-3040,2020
-ENGL,3040,406.0,Business Writing,0.67,0.24,0.05,0.0,0.05,0%,0.0,0.0,ingrid anna pierce,ENGL-3040,2020
-ENGL,3040,407.0,Business Writing,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ingrid anna pierce,ENGL-3040,2020
-ENGL,3040,408.0,Business Writing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,ingrid anna pierce,ENGL-3040,2020
-ENGL,3040,409.0,Business Writing,0.59,0.23,0.14,0.0,0.0,0%,0.0,0.05,jennifer forsberg,ENGL-3040,2020
-ENGL,3040,410.0,Business Writing,0.67,0.19,0.14,0.0,0.0,0%,0.0,0.0,jennifer forsberg,ENGL-3040,2020
-ENGL,3040,411.0,Business Writing,0.67,0.19,0.14,0.0,0.0,0%,0.0,0.0,jennifer forsberg,ENGL-3040,2020
-ENGL,3040,414.0,Business Writing,0.86,0.1,0.0,0.0,0.05,0%,0.0,0.0,patricia sunia,ENGL-3040,2020
-ENGL,3100,1.0,Crit Writ Lit,0.43,0.43,0.0,0.05,0.1,0%,0.0,0.0,brian mcgrath,ENGL-3100,2020
-ENGL,3100,2.0,Crit Writ Lit,0.91,0.05,0.0,0.0,0.0,0%,0.0,0.05,matthew hooley,ENGL-3100,2020
-ENGL,3100,4.0,Crit Writ Lit,0.45,0.32,0.05,0.09,0.0,0%,0.0,0.05,cameron bushnell,ENGL-3100,2020
-ENGL,3120,1.0,Advanced Composition,0.43,0.33,0.05,0.0,0.14,0%,0.0,0.05,shauna chung,ENGL-3120,2020
-ENGL,3120,2.0,Advanced Composition,0.38,0.33,0.14,0.0,0.1,0%,0.0,0.05,shauna chung,ENGL-3120,2020
-ENGL,3140,7.0,Technical Writing,0.62,0.29,0.05,0.0,0.05,0%,0.0,0.0,william cunningham,ENGL-3140,2020
-ENGL,3140,8.0,Technical Writing,0.57,0.33,0.0,0.0,0.1,0%,0.0,0.0,william cunningham,ENGL-3140,2020
-ENGL,3140,401.0,Technical Writing,0.73,0.14,0.0,0.05,0.05,0%,0.0,0.05,katalin beck,ENGL-3140,2020
-ENGL,3140,402.0,Technical Writing,0.62,0.24,0.05,0.0,0.05,0%,0.0,0.05,katalin beck,ENGL-3140,2020
-ENGL,3140,405.0,Technical Writing,0.71,0.1,0.05,0.1,0.0,0%,0.0,0.05,henna messina,ENGL-3140,2020
-ENGL,3140,406.0,Technical Writing,0.76,0.05,0.14,0.05,0.0,0%,0.0,0.0,henna messina,ENGL-3140,2020
-ENGL,3140,407.0,Technical Writing,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,megan pietruszewski,ENGL-3140,2020
-ENGL,3140,409.0,Technical Writing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,megan pietruszewski,ENGL-3140,2020
-ENGL,3140,410.0,Technical Writing,0.81,0.1,0.0,0.0,0.1,0%,0.0,0.0,beltran quaglia,ENGL-3140,2020
-ENGL,3140,411.0,Technical Writing,0.76,0.14,0.0,0.0,0.0,0%,0.0,0.1,beltran quaglia,ENGL-3140,2020
-ENGL,3140,412.0,Technical Writing,0.85,0.05,0.0,0.0,0.0,0%,0.0,0.1,michelle lloyd,ENGL-3140,2020
-ENGL,3140,413.0,Technical Writing,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,michelle lloyd,ENGL-3140,2020
-ENGL,3140,414.0,Technical Writing,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,hannah godwin,ENGL-3140,2020
-ENGL,3140,416.0,Technical Writing,0.8,0.1,0.05,0.0,0.0,0%,0.0,0.05,michael measel,ENGL-3140,2020
-ENGL,3140,417.0,Technical Writing,0.71,0.14,0.0,0.05,0.05,0%,0.0,0.05,michael measel,ENGL-3140,2020
-ENGL,3140,418.0,Technical Writing,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,victoria houser,ENGL-3140,2020
-ENGL,3140,419.0,Technical Writing,0.62,0.19,0.14,0.05,0.0,0%,0.0,0.0,victoria houser,ENGL-3140,2020
-ENGL,3140,420.0,Technical Writing,0.62,0.29,0.1,0.0,0.0,0%,0.0,0.0,katalin beck,ENGL-3140,2020
-ENGL,3150,400.0,Scientific Writing & Comm,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,philip randall,ENGL-3150,2020
-ENGL,3150,401.0,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,philip randall,ENGL-3150,2020
-ENGL,3150,402.0,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,philip randall,ENGL-3150,2020
-ENGL,3150,404.0,Scientific Writing & Comm,0.83,0.11,0.06,0.0,0.0,0%,0.0,0.0,megan pietruszewski,ENGL-3150,2020
-ENGL,3150,405.0,Scientific Writing & Comm,0.71,0.14,0.05,0.0,0.05,0%,0.0,0.05,megan pietruszewski,ENGL-3150,2020
-ENGL,3150,406.0,Scientific Writing & Comm,0.68,0.26,0.0,0.0,0.05,0%,0.0,0.0,william pulley,ENGL-3150,2020
-ENGL,3150,407.0,Scientific Writing & Comm,0.57,0.24,0.1,0.05,0.05,0%,0.0,0.0,william pulley,ENGL-3150,2020
-ENGL,3150,408.0,Scientific Writing & Comm,0.5,0.3,0.1,0.0,0.05,0%,0.0,0.05,william pulley,ENGL-3150,2020
-ENGL,3150,409.0,Scientific Writing & Comm,0.9,0.0,0.05,0.0,0.05,0%,0.0,0.0,sheila lalwani,ENGL-3150,2020
-ENGL,3150,410.0,Scientific Writing & Comm,0.85,0.0,0.05,0.05,0.0,0%,0.0,0.05,sheila lalwani,ENGL-3150,2020
-ENGL,3450,400.0,Intr Creative Writing: Ficti,0.7,0.15,0.1,0.0,0.05,0%,0.0,0.0,sarah matalone,ENGL-3450,2020
-ENGL,3450,401.0,Intr Creative Writing: Ficti,0.48,0.29,0.05,0.0,0.1,0%,0.0,0.1,sarah matalone,ENGL-3450,2020
-ENGL,3460,400.0,Intr Creative Writing: Poet,0.6,0.25,0.1,0.0,0.05,0%,0.0,0.0,stephanie edwards,ENGL-3460,2020
-ENGL,3480,400.0,Intr Creat Writ: Screenwrit,0.79,0.0,0.0,0.0,0.11,0%,0.0,0.11,april ayers lawson,ENGL-3480,2020
-ENGL,3480,401.0,Intr Creat Writ: Screenwrit,0.85,0.0,0.0,0.0,0.05,0%,0.0,0.1,april ayers lawson,ENGL-3480,2020
-ENGL,3490,1.0,Tech/Pop Imagination,0.5,0.33,0.11,0.0,0.06,0%,0.0,0.0,michelle smith,ENGL-3490,2020
-ENGL,3500,1.0,Mythology,0.22,0.33,0.17,0.06,0.11,0%,0.0,0.06,kenneth tuite,ENGL-3500,2020
-ENGL,3570,4.0,Film,0.68,0.26,0.0,0.0,0.0,0%,0.0,0.0,john robert smith,ENGL-3570,2020
-ENGL,3570,400.0,Film,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,amy monaghan,ENGL-3570,2020
-ENGL,3570,401.0,Film,0.47,0.26,0.11,0.0,0.05,0%,0.0,0.05,amy monaghan,ENGL-3570,2020
-ENGL,3570,402.0,Film,0.3,0.4,0.1,0.0,0.1,0%,0.0,0.1,amy monaghan,ENGL-3570,2020
-ENGL,3850,1.0,Children's Lit,0.39,0.5,0.06,0.0,0.06,0%,0.0,0.0,megan macalystre,ENGL-3850,2020
-ENGL,3860,400.0,Adolescent Lit,0.23,0.31,0.23,0.0,0.08,0%,0.0,0.08,amy monaghan,ENGL-3860,2020
-ENGL,3970,2.0,Brit Lit Survey II,0.62,0.24,0.1,0.0,0.05,0%,0.0,0.0,david coombs,ENGL-3970,2020
-ENGL,3980,400.0,Amer Lit Survey I,0.75,0.1,0.15,0.0,0.0,0%,0.0,0.0,kimberly manganelli,ENGL-3980,2020
-ENGL,3990,1.0,Amer Lit Survey II,0.7,0.15,0.05,0.0,0.05,0%,0.0,0.05,dominic mastroianni,ENGL-3990,2020
-ENGL,4010,2.0,Grammar Survey,0.36,0.29,0.29,0.07,0.0,0%,0.0,0.0,brian mcgrath,ENGL-4010,2020
-ENGL,4110,401.0,Shakespeare,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,andrew lemons,ENGL-4110,2020
-ENGL,4110,402.0,Shakespeare,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,andrew lemons,ENGL-4110,2020
-ENGL,4280,2.0,Contemporary Literature,0.38,0.31,0.08,0.0,0.08,0%,0.0,0.15,michael lemahieu,ENGL-4280,2020
-ENGL,4360,1.0,Feminist Literary Criticism,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,erin marina goss,ENGL-4360,2020
-ENGL,4400,1.0,Literary Theory,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,matthew hooley,ENGL-4400,2020
-ENGL,4410,400.0,Literary Editing,0.23,0.46,0.23,0.0,0.0,0%,0.0,0.0,clare mullaney,ENGL-4410,2020
-ENGL,4440,1.0,Renaissance Literature,0.29,0.47,0.06,0.0,0.18,0%,0.0,0.0,william stockton,ENGL-4440,2020
-ENGL,4450,1.0,Fiction Workshop,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,nicholas brown,ENGL-4450,2020
-ENGL,4480,2.0,Screenwriting Wkshop,0.58,0.17,0.08,0.17,0.0,0%,0.0,0.0,nicholas brown,ENGL-4480,2020
-ENGL,4510,1.0,Film Theory and Criticism,0.53,0.37,0.11,0.0,0.0,0%,0.0,0.0,agnieszka skrodzka,ENGL-4510,2020
-ENGL,4520,2.0,Great Directors,0.48,0.14,0.14,0.0,0.0,0%,0.0,0.0,john robert smith,ENGL-4520,2020
-ENGL,4640,1.0,Topics in Literature 1700-1,0.42,0.25,0.17,0.17,0.0,0%,0.0,0.0,erin marina goss,ENGL-4640,2020
-ENGL,4750,400.0,Writing for Media,0.5,0.31,0.13,0.0,0.0,0%,0.0,0.06,jonathan field,ENGL-4750,2020
-ENGL,4820,1.0,Afr Am Lit to 1920,0.38,0.38,0.19,0.0,0.0,0%,0.0,0.05,rhondda thomas,ENGL-4820,2020
-ENGL,4830,1.0,Af Am Lit 1920-Pres,0.58,0.32,0.05,0.0,0.0,0%,0.0,0.05,maya sylvia hislop,ENGL-4830,2020
-ENGL,4920,400.0,Modern Rhetoric,0.69,0.08,0.08,0.0,0.15,0%,0.0,0.0,megan eatman,ENGL-4920,2020
-ENGL,4960,2.0,Senior Seminar,0.75,0.08,0.0,0.0,0.08,0%,0.0,0.08,michelle smith,ENGL-4960,2020
-ENGL,4960,400.0,Senior Seminar,0.79,0.07,0.07,0.0,0.0,0%,0.0,0.0,jonathan field,ENGL-4960,2020
-ENGL,8080,400.0,Top Renaiss & Restoration,0.86,0.07,0.0,0.0,0.07,0%,0.0,0.0,elizabeth rivlin,ENGL-8080,2020
-ENGL,8100,400.0,Literary Criticism & Theory,0.18,0.36,0.09,0.0,0.09,0%,0.0,0.18,lee morrissey,ENGL-8100,2020
-ENGL,8310,1.0,Special Topics,0.8,0.13,0.0,0.0,0.0,0%,0.0,0.07,maya sylvia hislop,ENGL-8310,2020
-ENGL,8910,1.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gabriel hankins,ENGL-8910,2020
-ENGR,1000,101.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,steven brandon,ENGR-1000,2020
-ENGR,1000,102.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,steven brandon,ENGR-1000,2020
-ENGR,1000,103.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,89%,0.09,0.02,steven brandon,ENGR-1000,2020
-ENGR,1000,104.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,88%,0.1,0.02,steven brandon,ENGR-1000,2020
-ENGR,1010,392.0,Survey of Mathematical To,0.25,0.33,0.17,0.08,0.0,0%,0.0,0.17,andrew neptune,ENGR-1010,2020
-ENGR,1010,395.0,Survey of Mathematical To,0.29,0.46,0.13,0.0,0.08,0%,0.0,0.04,andrew neptune,ENGR-1010,2020
-ENGR,1010,396.0,Survey of Mathematical To,0.34,0.41,0.1,0.0,0.07,0%,0.0,0.07,andrew neptune,ENGR-1010,2020
-ENGR,1020,223.0,Engr Dis & Skills (HON),0.76,0.22,0.0,0.02,0.0,0%,0.0,0.0,richard watkins,ENGR-1020,2020
-ENGR,1020,311.0,Engineering Discipl & Skills,0.32,0.39,0.03,0.13,0.03,0%,0.0,0.11,john minor,ENGR-1020,2020
-ENGR,1020,313.0,Engineering Discipl & Skills,0.52,0.22,0.17,0.0,0.04,0%,0.0,0.04,john minor,ENGR-1020,2020
-ENGR,1020,314.0,Engineering Discipl & Skills,0.67,0.26,0.05,0.02,0.0,0%,0.0,0.0,elizabeth stephan,ENGR-1020,2020
-ENGR,1020,317.0,Engineering Discipl & Skills,0.27,0.36,0.16,0.07,0.07,0%,0.0,0.09,katherine ehlert,ENGR-1020,2020
-ENGR,1020,318.0,Engineering Discipl & Skills,0.41,0.36,0.05,0.07,0.07,0%,0.0,0.05,katherine ehlert,ENGR-1020,2020
-ENGR,1020,611.0,Engineering Discipl & Skills,0.47,0.29,0.04,0.02,0.07,0%,0.0,0.11,baker martin,ENGR-1020,2020
-ENGR,1020,612.0,Engineering Discipl & Skills,0.52,0.22,0.13,0.02,0.0,0%,0.0,0.11,baker martin,ENGR-1020,2020
-ENGR,1020,613.0,Engineering Discipl & Skills,0.64,0.19,0.09,0.02,0.04,0%,0.0,0.02,taylor sorensen,ENGR-1020,2020
-ENGR,1020,614.0,Engineering Discipl & Skills,0.67,0.15,0.13,0.02,0.0,0%,0.0,0.02,taylor sorensen,ENGR-1020,2020
-ENGR,1020,615.0,Engineering Discipl & Skills,0.69,0.21,0.02,0.05,0.02,0%,0.0,0.0,taylor sorensen,ENGR-1020,2020
-ENGR,1020,616.0,Engineering Discipl & Skills,0.5,0.22,0.11,0.0,0.04,0%,0.0,0.13,joseph overlin chapa,ENGR-1020,2020
-ENGR,1020,617.0,Engineering Discipl & Skills,0.63,0.21,0.09,0.0,0.07,0%,0.0,0.0,joseph overlin chapa,ENGR-1020,2020
-ENGR,1020,618.0,Engineering Discipl & Skills,0.47,0.36,0.07,0.04,0.0,0%,0.0,0.07,joseph overlin chapa,ENGR-1020,2020
-ENGR,1020,801.0,Engineering Discipl & Skills,0.4,0.3,0.15,0.02,0.09,0%,0.0,0.04,irene marie ferrara,ENGR-1020,2020
-ENGR,1020,808.0,Engineering Discipl & Skills,0.41,0.28,0.2,0.04,0.02,0%,0.0,0.04,jonathan maier,ENGR-1020,2020
-ENGR,1020,812.0,Engineering Discipl & Skills,0.58,0.24,0.04,0.07,0.02,0%,0.0,0.04,irene marie ferrara,ENGR-1020,2020
-ENGR,1020,813.0,Engineering Discipl & Skills,0.6,0.23,0.12,0.0,0.02,0%,0.0,0.02,irene marie ferrara,ENGR-1020,2020
-ENGR,1020,814.0,Engineering Discipl & Skills,0.43,0.34,0.14,0.02,0.02,0%,0.0,0.05,michael waldrop,ENGR-1020,2020
-ENGR,1020,815.0,Engineering Discipl & Skills,0.48,0.3,0.15,0.0,0.02,0%,0.0,0.04,michael waldrop,ENGR-1020,2020
-ENGR,1020,816.0,Engineering Discipl & Skills,0.38,0.31,0.21,0.02,0.02,0%,0.0,0.05,michael waldrop,ENGR-1020,2020
-ENGR,1020,817.0,Engineering Discipl & Skills,0.47,0.3,0.13,0.0,0.04,0%,0.0,0.06,jonathan maier,ENGR-1020,2020
-ENGR,1020,881.0,Engr Discp & Skils (HON),0.68,0.24,0.03,0.0,0.0,0%,0.0,0.06,jonathan maier,ENGR-1020,2020
-ENGR,1100,206.0,Engineering Success Skills,0.64,0.21,0.04,0.07,0.0,0%,0.0,0.04,jonathan harcum,ENGR-1100,2020
-ENGR,1100,603.0,Engineering Success Skills,0.72,0.12,0.08,0.0,0.0,0%,0.0,0.08,jonathan harcum,ENGR-1100,2020
-ENGR,1100,802.0,Engineering Success Skills,0.88,0.08,0.0,0.0,0.04,0%,0.0,0.0,jonathan harcum,ENGR-1100,2020
-ENGR,1410,223.0,Programming & Problem S,0.07,0.14,0.27,0.09,0.14,0%,0.0,0.16,steven brandon,ENGR-1410,2020
-ENGR,1410,226.0,Programming & Problem S,0.07,0.2,0.36,0.04,0.13,0%,0.0,0.11,william martin,ENGR-1410,2020
-ENGR,1410,227.0,Programming & Problem S,0.13,0.29,0.29,0.02,0.11,0%,0.0,0.13,william martin,ENGR-1410,2020
-ENGR,1510,322.0,Engineering Skills,0.41,0.37,0.07,0.0,0.04,0%,0.0,0.11,matthew kent miller,ENGR-1510,2020
-ENGR,1510,323.0,Engineering Skills,0.28,0.44,0.12,0.0,0.12,0%,0.0,0.04,matthew kent miller,ENGR-1510,2020
-ENGR,1510,325.0,Engineering Skills,0.36,0.28,0.2,0.04,0.0,0%,0.0,0.12,matthew kent miller,ENGR-1510,2020
-ENGR,1900,219.0,CI 3D Maker Space SOP,0.83,0.0,0.17,0.0,0.0,0%,0.0,0.0,todd schweisinger,ENGR-1900,2020
-ENGR,2080,681.0,Engr Graphics & Machine,0.44,0.25,0.13,0.0,0.08,0%,0.0,0.1,kyle walker,ENGR-2080,2020
-ENGR,2080,682.0,Engr Graphics & Machine,0.56,0.25,0.1,0.0,0.0,0%,0.0,0.06,vishal thomas,ENGR-2080,2020
-ENGR,2080,684.0,Engr Graphics & Machine,0.39,0.22,0.06,0.06,0.08,0%,0.0,0.12,jennifer paige brown,ENGR-2080,2020
-ENGR,2080,685.0,Engr Graphics & Machine,0.45,0.24,0.18,0.0,0.08,0%,0.0,0.04,jessica plaunt,ENGR-2080,2020
-ENGR,2080,686.0,Engr Graphics & Machine,0.57,0.17,0.06,0.04,0.02,0%,0.0,0.13,nighat yasmin,ENGR-2080,2020
-ENGR,2100,804.0,CAD & Engineering Applica,0.47,0.2,0.16,0.02,0.09,0%,0.0,0.07,naini shervin shoai,ENGR-2100,2020
-ENGR,2100,805.0,CAD & Engineering Applica,0.35,0.33,0.13,0.07,0.07,0%,0.0,0.07,nighat yasmin,ENGR-2100,2020
-ENGR,2100,806.0,CAD & Engineering Applica,0.2,0.39,0.13,0.02,0.09,0%,0.0,0.17,naini shervin shoai,ENGR-2100,2020
-ENR,1010,2.0,Intro to Envir & Natur Res I,0.47,0.27,0.18,0.02,0.05,0%,0.0,0.0, guggenheimer,ENR-1010,2020
-ENR,1010,3.0,Intro to Envir & Natur Res I,0.52,0.22,0.13,0.05,0.08,0%,0.0,0.0, guggenheimer,ENR-1010,2020
-ENR,4290,1.0,Environ Law & Policy,0.64,0.19,0.11,0.02,0.02,0%,0.0,0.02,alan johnson,ENR-4290,2020
-ENR,4290,2.0,Environ Law & Policy,0.73,0.13,0.04,0.04,0.02,0%,0.0,0.02,alan johnson,ENR-4290,2020
-ENSP,2000,1.0,Intro Environ Sci,0.57,0.32,0.06,0.0,0.02,0%,0.0,0.02,scott brame,ENSP-2000,2020
-ENSP,2000,2.0,Intro Environ Sci,0.95,0.04,0.02,0.0,0.0,0%,0.0,0.0,minory nammouz,ENSP-2000,2020
-ENSP,2000,3.0,Intro Environ Sci,0.87,0.09,0.0,0.02,0.0,0%,0.0,0.02,minory nammouz,ENSP-2000,2020
-ENSP,2000,4.0,Intro Environ Sci,0.58,0.26,0.05,0.05,0.02,0%,0.0,0.04,elizabeth carraway,ENSP-2000,2020
-ENSP,2000,5.0,Intro Environ Sci,0.63,0.24,0.09,0.0,0.02,0%,0.0,0.02,tom owino,ENSP-2000,2020
-ENSP,2000,6.0,Intro Environ Sci,0.4,0.55,0.05,0.0,0.0,0%,0.0,0.0,emily don scribner,ENSP-2000,2020
-ENSP,4000,1.0,Studies in Environmental S,0.57,0.17,0.04,0.0,0.17,0%,0.0,0.0,margaret thompson,ENSP-4000,2020
-ENT,3010,1.0,Insect Biology and Diversit,0.52,0.1,0.14,0.0,0.14,0%,0.0,0.1,michael ferro,ENT-3010,2020
-ENT,8100,1.0,Bio & Phylogeog of S. Appa,0.64,0.09,0.27,0.0,0.0,0%,0.0,0.0,michael caterino,ENT-8100,2020
-ENTR,1010,3.0,Entrepreneurial Mindset,0.85,0.09,0.03,0.01,0.02,0%,0.0,0.01,john michael hannon,ENTR-1010,2020
-ENTR,1090,1.0,Creative Inq-Entrepreneur,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,john michael hannon,ENTR-1090,2020
-ENTR,2010,4.0,Sports Entrepreneurship,0.58,0.26,0.05,0.0,0.05,0%,0.0,0.05,john michael hannon,ENTR-2010,2020
-ESED,8100,1.0,Orientation to ESME Resea,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eliza gallagher,ESED-8100,2020
-ESED,8720,1.0,Action Research in STEM E,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.0,karen ann high,ESED-8720,2020
-ESED,9910,3.0,Dissertation Rsrch and Wri,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eliza gallagher,ESED-9910,2020
-ESED,9910,5.0,Dissertation Rsrch and Wri,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,karen ann high,ESED-9910,2020
-ETOX,4300,1.0,Toxicology,0.5,0.18,0.18,0.05,0.05,0%,0.0,0.05,lisa bain,ETOX-4300,2020
-ETOX,6300,1.0,Toxicology,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,lisa bain,ETOX-6300,2020
-ETOX,8610,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,den hurk peter van peter,ETOX-8610,2020
-FDSC,1010,1.0,Intro to Food Sci & Hum N,0.65,0.27,0.05,0.01,0.01,0%,0.0,0.01,carol hegler,FDSC-1010,2020
-FDSC,3010,1.0,Food Regulations,0.81,0.15,0.04,0.0,0.0,0%,0.0,0.0,sara lane cothran,FDSC-3010,2020
-FDSC,4010,1.0,Food Chemistry I,0.45,0.5,0.05,0.0,0.0,0%,0.0,0.0,feng chen,FDSC-4010,2020
-FDSC,4500,12.0,Creative Inquiry-Food Scie,0.82,0.0,0.09,0.0,0.0,0%,0.0,0.09,paul dawson,FDSC-4500,2020
-FDSC,6010,1.0,Food Chem I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,feng chen,FDSC-6010,2020
-FDSC,8120,1.0,Microbial Food Syst,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,xiuping jiang,FDSC-8120,2020
-FIN,2010,401.0,Intro to Personal Finance I,0.98,0.01,0.0,0.0,0.01,0%,0.0,0.01,joshua harris,FIN-2010,2020
-FIN,2010,402.0,Intro to Personal Finance I,0.84,0.08,0.04,0.02,0.02,0%,0.0,0.0,joshua harris,FIN-2010,2020
-FIN,2020,401.0,Intro to Personal Finance II,0.97,0.0,0.0,0.0,0.02,0%,0.0,0.01,joshua harris,FIN-2020,2020
-FIN,3040,1.0,Risk & Insurance,0.22,0.42,0.24,0.11,0.0,0%,0.0,0.0,kerri mcmillan,FIN-3040,2020
-FIN,3050,1.0,Investment Analysis,0.16,0.25,0.41,0.14,0.02,0%,0.0,0.02,kerri mcmillan,FIN-3050,2020
-FIN,3050,2.0,Investment Analysis,0.22,0.29,0.33,0.09,0.04,0%,0.0,0.02,kerri mcmillan,FIN-3050,2020
-FIN,3050,3.0,Investment Analysis,0.16,0.27,0.32,0.07,0.07,0%,0.0,0.11,kerri mcmillan,FIN-3050,2020
-FIN,3050,4.0,Investment Analysis,0.13,0.22,0.29,0.18,0.04,0%,0.0,0.13,john alexander,FIN-3050,2020
-FIN,3060,1.0,Corporation Finance,0.47,0.27,0.14,0.04,0.04,0%,0.0,0.03,ramon franklin,FIN-3060,2020
-FIN,3060,2.0,Corporation Finance,0.36,0.36,0.13,0.04,0.07,0%,0.0,0.04,ramon franklin,FIN-3060,2020
-FIN,3060,3.0,Corporation Finance,0.25,0.25,0.27,0.16,0.02,0%,0.0,0.04,minxing sun,FIN-3060,2020
-FIN,3060,4.0,Corporation Finance,0.16,0.38,0.25,0.16,0.0,0%,0.0,0.05,minxing sun,FIN-3060,2020
-FIN,3060,5.0,Corporation Finance,0.07,0.21,0.5,0.21,0.0,0%,0.0,0.0,minxing sun,FIN-3060,2020
-FIN,3060,6.0,Corporation Finance,0.55,0.23,0.11,0.04,0.0,0%,0.0,0.04,ramon franklin,FIN-3060,2020
-FIN,3060,7.0,Corporation Finance,0.18,0.29,0.29,0.08,0.06,0%,0.0,0.1,taufique samdani,FIN-3060,2020
-FIN,3060,401.0,Corporation Finance,0.48,0.27,0.15,0.0,0.04,0%,0.0,0.06,jonathan godbey,FIN-3060,2020
-FIN,3060,402.0,Corporation Finance,0.46,0.22,0.18,0.1,0.0,0%,0.0,0.02,jonathan godbey,FIN-3060,2020
-FIN,3070,1.0,Prin of Real Estate,0.26,0.21,0.23,0.23,0.05,0%,0.0,0.03,thomas springer,FIN-3070,2020
-FIN,3070,2.0,Prin of Real Estate,0.36,0.18,0.28,0.15,0.03,0%,0.0,0.0,thomas springer,FIN-3070,2020
-FIN,3070,5.0,Prin of Real Estate,0.21,0.46,0.26,0.05,0.03,0%,0.0,0.0,bryan blackwood,FIN-3070,2020
-FIN,3080,1.0,Fin Inst & Mkts,0.6,0.28,0.1,0.03,0.0,0%,0.0,0.0,lyudmila chernykh,FIN-3080,2020
-FIN,3080,2.0,Fin Inst & Mkts,0.74,0.21,0.03,0.03,0.0,0%,0.0,0.0,lyudmila chernykh,FIN-3080,2020
-FIN,3080,3.0,Fin Inst & Mkts,0.36,0.44,0.18,0.03,0.0,0%,0.0,0.0,daniel greene,FIN-3080,2020
-FIN,3080,401.0,Fin Inst & Mkts,0.44,0.3,0.24,0.0,0.02,0%,0.0,0.0,daniel greene,FIN-3080,2020
-FIN,3110,1.0,Financial Management I,0.11,0.14,0.09,0.11,0.31,0%,0.0,0.23,jack wolf,FIN-3110,2020
-FIN,3110,2.0,Financial Management I,0.08,0.03,0.36,0.08,0.26,0%,0.0,0.21,jack wolf,FIN-3110,2020
-FIN,3110,3.0,Financial Management I,0.09,0.33,0.28,0.14,0.16,0%,0.0,0.0,weike xu,FIN-3110,2020
-FIN,3110,4.0,Financial Management I,0.54,0.3,0.09,0.06,0.0,0%,0.0,0.01,joshua harris,FIN-3110,2020
-FIN,3110,5.0,Financial Management I,0.46,0.39,0.14,0.0,0.01,0%,0.0,0.0,joshua harris,FIN-3110,2020
-FIN,3120,1.0,Financial Management II,0.14,0.39,0.35,0.04,0.02,0%,0.0,0.06,weike xu,FIN-3120,2020
-FIN,3120,2.0,Financial Management II,0.16,0.52,0.26,0.04,0.02,0%,0.0,0.0,weike xu,FIN-3120,2020
-FIN,3120,3.0,Financial Management II,0.24,0.34,0.24,0.08,0.02,0%,0.0,0.08,taufique samdani,FIN-3120,2020
-FIN,3120,4.0,Financial Management II,0.1,0.41,0.14,0.14,0.02,0%,0.0,0.18,taufique samdani,FIN-3120,2020
-FIN,3120,5.0,Financial Management II,0.45,0.23,0.14,0.0,0.07,0%,0.0,0.11,arash dayani,FIN-3120,2020
-FIN,3120,6.0,Financial Management II,0.35,0.15,0.2,0.05,0.15,0%,0.0,0.1,arash dayani,FIN-3120,2020
-FIN,4010,1.0,Corporate Financial Analys,0.63,0.15,0.2,0.03,0.0,0%,0.0,0.0,george lockhart,FIN-4010,2020
-FIN,4010,2.0,Corporate Financial Analys,0.55,0.3,0.13,0.0,0.0,0%,0.0,0.03,george lockhart,FIN-4010,2020
-FIN,4020,1.0,Corporate Valuation,0.22,0.3,0.26,0.11,0.04,0%,0.0,0.07,angela morgan,FIN-4020,2020
-FIN,4020,101.0,Corporate Valuation (HON,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,angela morgan,FIN-4020,2020
-FIN,4030,1.0,Spreadsheet Apps in Finan,0.26,0.24,0.38,0.09,0.0,0%,0.0,0.03,vincent intintoli,FIN-4030,2020
-FIN,4030,2.0,Spreadsheet Apps in Finan,0.27,0.4,0.13,0.13,0.07,0%,0.0,0.0,vincent intintoli,FIN-4030,2020
-FIN,4050,1.0,Portfolio Management & T,0.16,0.14,0.28,0.21,0.09,0%,0.0,0.12,john alexander,FIN-4050,2020
-FIN,4060,1.0,Derivatives Analysis,0.14,0.34,0.37,0.09,0.03,0%,0.0,0.03,blerina zykaj,FIN-4060,2020
-FIN,4110,1.0,Int Fin Mgt,0.29,0.53,0.16,0.03,0.0,0%,0.0,0.0,luke asher devault,FIN-4110,2020
-FIN,4110,2.0,Int Fin Mgt,0.2,0.58,0.2,0.03,0.0,0%,0.0,0.0,luke asher devault,FIN-4110,2020
-FIN,4150,1.0,Real Estate Investmt,0.31,0.19,0.35,0.0,0.08,0%,0.0,0.08,thomas springer,FIN-4150,2020
-FIN,4980,7.0,CI in Finance: SIE,0.9,0.0,0.0,0.0,0.0,0%,0.0,0.1,joshua harris,FIN-4980,2020
-FNR,2040,1.0,Soil Information Systems,0.79,0.16,0.03,0.0,0.0,0%,0.0,0.02,elena mikhailova,FNR-2040,2020
-FNR,4990,1.0,Natural Resources Seminar,0.86,0.05,0.0,0.0,0.05,0%,0.0,0.05,robert fritz baldwin,FNR-4990,2020
-FOR,2050,1.0,Dendrology,0.66,0.13,0.05,0.08,0.08,0%,0.0,0.0,donald hagan,FOR-2050,2020
-FOR,2050,2.0,Dendrology,0.56,0.18,0.09,0.06,0.03,0%,0.0,0.09,donald hagan,FOR-2050,2020
-FOR,2050,3.0,Dendrology,0.66,0.17,0.11,0.0,0.06,0%,0.0,0.0,donald hagan,FOR-2050,2020
-FOR,2210,2.0,Forest Biology,0.95,0.03,0.0,0.0,0.0,0%,0.0,0.02,patrick mcmillan,FOR-2210,2020
-FOR,3040,1.0,Forest Resource Economic,0.81,0.16,0.0,0.03,0.0,0%,0.0,0.0,puskar khanal,FOR-3040,2020
-FOR,3410,1.0,Wood Procure Pract,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,patrick hiesl,FOR-3410,2020
-FOR,4100,1.0,Harvesting Processes,0.63,0.3,0.0,0.07,0.0,0%,0.0,0.0,patrick hiesl,FOR-4100,2020
-FOR,4130,1.0,Forest Protection,0.77,0.2,0.0,0.03,0.0,0%,0.0,0.0,jessica hartshorn,FOR-4130,2020
-FOR,4150,1.0,Forest Wildlife Managmen,0.44,0.31,0.19,0.0,0.0,0%,0.0,0.06,greg yarrow,FOR-4150,2020
-FOR,4160,1.0,Forest Policy and Admin,0.78,0.16,0.05,0.0,0.0,0%,0.0,0.01,patricia layton,FOR-4160,2020
-FOR,4170,1.0,Forest Resource Mgt & Re,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,puskar khanal,FOR-4170,2020
-FOR,4310,1.0,Recreation Res Plan in For,0.52,0.39,0.1,0.0,0.0,0%,0.0,0.0,robert baxter powell,FOR-4310,2020
-FOR,4340,1.0,GIS for Natural Resources,0.79,0.12,0.02,0.02,0.0,0%,0.0,0.0,christopher post,FOR-4340,2020
-FOR,8910,2.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,donald hagan,FOR-8910,2020
-FOR,8930,22.0,Professional Development,0.57,0.14,0.0,0.0,0.0,0%,0.0,0.14,david jachowski,FOR-8930,2020
-FR,1010,1.0,Elementary French,0.61,0.22,0.04,0.0,0.09,0%,0.0,0.04,amy lyn sawyer,FR-1010,2020
-FR,1010,2.0,Elementary French,0.48,0.26,0.13,0.04,0.09,0%,0.0,0.0,amy lyn sawyer,FR-1010,2020
-FR,1020,2.0,Elementary French,0.2,0.3,0.1,0.2,0.1,0%,0.0,0.1, nedeo anne salces anne,FR-1020,2020
-FR,1020,3.0,Elementary French,0.13,0.44,0.25,0.0,0.0,0%,0.0,0.19, nedeo anne salces anne,FR-1020,2020
-FR,2010,1.0,Intermediate French,0.18,0.73,0.09,0.0,0.0,0%,0.0,0.0,kenneth widgren,FR-2010,2020
-FR,2010,2.0,Intermediate French,0.61,0.22,0.13,0.0,0.0,0%,0.0,0.04,amy lyn sawyer,FR-2010,2020
-FR,2010,3.0,Intermediate French,0.72,0.28,0.0,0.0,0.0,0%,0.0,0.0,tholozany de,FR-2010,2020
-FR,2020,1.0,Intermediate French,0.5,0.36,0.05,0.05,0.0,0%,0.0,0.05,eric touya,FR-2020,2020
-FR,2020,2.0,Intermediate French,0.42,0.42,0.04,0.0,0.04,0%,0.0,0.08,kenneth widgren,FR-2020,2020
-FR,2020,3.0,Intermediate French,0.67,0.17,0.17,0.0,0.0,0%,0.0,0.0,amy lyn sawyer,FR-2020,2020
-FR,3000,1.0,Survey of French Lit,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,tholozany de,FR-3000,2020
-FR,3050,1.0,Int Fr Con & Comp I,0.53,0.4,0.0,0.0,0.0,0%,0.0,0.07,kenneth widgren,FR-3050,2020
-FR,3050,2.0,Int Fr Con & Comp I,0.4,0.47,0.0,0.0,0.0,0%,0.0,0.13, nedeo anne salces anne,FR-3050,2020
-FR,3070,1.0,French Civilization,0.87,0.09,0.04,0.0,0.0,0%,0.0,0.0,kelly digby peebles,FR-3070,2020
-FR,3120,2.0,Writing in French I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,kenneth widgren,FR-3120,2020
-FR,4120,1.0,Fr & Francoph Cinema,0.77,0.15,0.0,0.0,0.08,0%,0.0,0.0,joseph mai,FR-4120,2020
-GC,1010,2.0,Orientation to G C,0.0,0.0,0.0,0.0,0.0,96%,0.04,0.0,nona woolbright,GC-1010,2020
-GC,1020,1.0,Computer Art & CAD Foun,0.67,0.19,0.05,0.03,0.03,0%,0.0,0.02,amanda bridges,GC-1020,2020
-GC,1040,1.0,Graphic Communications I,0.64,0.23,0.02,0.02,0.09,0%,0.0,0.0,michelle suki fox,GC-1040,2020
-GC,2070,1.0,Graphic Communications II,0.76,0.17,0.05,0.0,0.0,0%,0.0,0.02,charles tabor weiss,GC-2070,2020
-GC,2400,1.0,Intro to Web Design and D,0.64,0.21,0.07,0.0,0.07,0%,0.0,0.0,william stevens,GC-2400,2020
-GC,3400,1.0,Digital Imaging,0.38,0.33,0.18,0.03,0.08,0%,0.0,0.0,erica black walker,GC-3400,2020
-GC,3460,1.0,Ink and Substrates,0.57,0.33,0.11,0.0,0.0,0%,0.0,0.0,shu chang,GC-3460,2020
-GC,3730,1.0,Media Management in Bra,0.76,0.17,0.07,0.0,0.0,0%,0.0,0.0,jaclyn driggs,GC-3730,2020
-GC,3740,2.0,Brand Communications Str,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,jacqueline reed herr,GC-3740,2020
-GC,3760,1.0,Brand Comm Capstone Se,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,katelyn hildebrand,GC-3760,2020
-GC,4060,1.0,Package and Specialty Prin,0.38,0.53,0.06,0.0,0.03,0%,0.0,0.0,carol jones,GC-4060,2020
-GC,4400,1.0,Commercial Printing,0.4,0.51,0.05,0.0,0.0,0%,0.0,0.0,eric weisenmiller,GC-4400,2020
-GC,4440,1.0,Current Dev/Trends in Gr,0.43,0.45,0.1,0.02,0.0,0%,0.0,0.0,liam henry 'hara,GC-4440,2020
-GC,4480,1.0,Plan & Cont Printing Functi,0.93,0.03,0.0,0.03,0.0,0%,0.0,0.0,nona woolbright,GC-4480,2020
-GC,4800,1.0,Senior Seminar in GC,0.83,0.1,0.05,0.0,0.0,0%,0.0,0.0,charles tonkin,GC-4800,2020
-GC,4900,5.0,Videography & Visual Effec,0.67,0.25,0.08,0.0,0.0,0%,0.0,0.0,erica black walker,GC-4900,2020
-GC,8970,1.0,G C Research Prob I,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.0,nona woolbright,GC-8970,2020
-GEN,1030,1.0,Careers in Bioch/Gen,0.83,0.1,0.06,0.0,0.02,0%,0.0,0.0,alison starr-moss,GEN-1030,2020
-GEN,3000,1.0,Fundamental Genetics,0.74,0.18,0.08,0.0,0.0,0%,0.0,0.0,michael harris,GEN-3000,2020
-GEN,3000,2.0,Fundamental Genetics,0.7,0.27,0.01,0.0,0.02,0%,0.0,0.0,todd lyda,GEN-3000,2020
-GEN,3000,6.0,Fundamental Genetics,0.28,0.4,0.19,0.04,0.07,0%,0.0,0.01,haiying liang,GEN-3000,2020
-GEN,3020,1.0,Molec & General Genetics,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,kate leanne tsai,GEN-3020,2020
-GEN,3020,2.0,Molecular & General Gene,0.43,0.37,0.11,0.01,0.03,0%,0.0,0.05,kate leanne tsai,GEN-3020,2020
-GEN,3020,4.0,Molecular & General Gene,0.18,0.41,0.27,0.05,0.0,0%,0.0,0.09,kate leanne tsai,GEN-3020,2020
-GEN,4100,1.0,Population & Quant Genet,0.59,0.36,0.02,0.0,0.0,0%,0.0,0.02,metris kanapeckas,GEN-4100,2020
-GEN,4100,2.0,Population & Quant Gen (,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,metris kanapeckas,GEN-4100,2020
-GEN,4110,3.0,Population & Quant Gen L,0.81,0.06,0.06,0.0,0.0,0%,0.0,0.06,metris kanapeckas,GEN-4110,2020
-GEN,4110,4.0,Population & Quant Gen L,0.5,0.17,0.25,0.0,0.08,0%,0.0,0.0,metris kanapeckas,GEN-4110,2020
-GEN,4400,1.0,Bioinformatics,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.13,frank feltus,GEN-4400,2020
-GEN,4500,1.0,Comparative Genetics,0.25,0.45,0.16,0.0,0.0,0%,0.0,0.14,leigh anne clark,GEN-4500,2020
-GEN,4500,2.0,Comparative Genetics (HO,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,leigh anne clark,GEN-4500,2020
-GEN,8050,1.0,Issues in Research,0.67,0.17,0.0,0.0,0.0,0%,0.0,0.0,julia frugoli,GEN-8050,2020
-GEN,8250,1.0,Seminar I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rajandeep sekhon,GEN-8250,2020
-GEOG,1010,1.0,Intro to Geography,0.78,0.13,0.05,0.03,0.0,0%,0.0,0.03,christa smith,GEOG-1010,2020
-GEOG,1030,2.0,World Regional Geography,0.38,0.37,0.11,0.06,0.03,0%,0.0,0.03,william church terry,GEOG-1030,2020
-GEOG,4100,1.0,Geog of the American Sout,0.83,0.0,0.0,0.0,0.08,0%,0.0,0.0,christa smith,GEOG-4100,2020
-GEOL,1010,1.0,Physical Geology,0.62,0.26,0.06,0.04,0.02,0%,0.0,0.01,alan coulson,GEOL-1010,2020
-GEOL,1010,2.0,Physical Geology,0.6,0.28,0.08,0.03,0.01,0%,0.0,0.01,alan coulson,GEOL-1010,2020
-GEOL,1010,3.0,Physical Geology,0.56,0.31,0.08,0.03,0.03,0%,0.0,0.0,mary katherine fidler,GEOL-1010,2020
-GEOL,1010,4.0,Physical Geology,0.46,0.41,0.11,0.0,0.01,0%,0.0,0.01,mary katherine fidler,GEOL-1010,2020
-GEOL,1030,1.0,Physical Geol Lab,0.55,0.36,0.0,0.05,0.0,0%,0.0,0.05,alan coulson,GEOL-1030,2020
-GEOL,1030,2.0,Physical Geol Lab,0.71,0.17,0.04,0.0,0.08,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,3.0,Physical Geol Lab,0.64,0.05,0.05,0.09,0.14,0%,0.0,0.05,alan coulson,GEOL-1030,2020
-GEOL,1030,4.0,Physical Geol Lab,0.52,0.17,0.22,0.04,0.04,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,5.0,Physical Geol Lab,0.55,0.2,0.15,0.05,0.0,0%,0.0,0.05,alan coulson,GEOL-1030,2020
-GEOL,1030,6.0,Physical Geol Lab,0.67,0.24,0.05,0.05,0.0,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,7.0,Physical Geol Lab,0.78,0.09,0.0,0.0,0.09,0%,0.0,0.04,alan coulson,GEOL-1030,2020
-GEOL,1030,8.0,Physical Geol Lab,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,9.0,Physical Geol Lab,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,11.0,Physical Geol Lab,0.75,0.1,0.15,0.0,0.0,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,12.0,Physical Geol Lab,0.86,0.09,0.0,0.0,0.05,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,13.0,Physical Geol Lab,0.55,0.3,0.05,0.0,0.0,0%,0.0,0.1,alan coulson,GEOL-1030,2020
-GEOL,1030,14.0,Physical Geol Lab,0.55,0.35,0.0,0.05,0.05,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,15.0,Physical Geol Lab,0.6,0.3,0.1,0.0,0.0,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,16.0,Physical Geol Lab,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,17.0,Physical Geol Lab,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,18.0,Physical Geol Lab,0.64,0.18,0.14,0.0,0.05,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1030,19.0,Physical Geol Lab,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,alan coulson,GEOL-1030,2020
-GEOL,1120,1.0,Earth Resources,0.51,0.3,0.13,0.04,0.01,0%,0.0,0.02,emily don scribner,GEOL-1120,2020
-GEOL,1140,1.0,Earth Resources Lab,0.55,0.29,0.11,0.01,0.0,0%,0.0,0.04,emily don scribner,GEOL-1140,2020
-GEOL,1200,1.0,Natural Hazards,0.48,0.4,0.1,0.0,0.03,0%,0.0,0.0,emily don scribner,GEOL-1200,2020
-GEOL,2050,1.0,Mineralogy & Intro Petrolo,0.29,0.71,0.0,0.0,0.0,0%,0.0,0.0, shuller-nickles,GEOL-2050,2020
-GEOL,2070,1.0,Min & Intro Pet Lab,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,mary katherine fidler,GEOL-2070,2020
-GEOL,2700,1.0,Sustainable Water,0.51,0.31,0.09,0.0,0.03,0%,0.0,0.06,melissa ranhofer,GEOL-2700,2020
-GEOL,3000,1.0,Environmental Geology,0.38,0.53,0.09,0.0,0.0,0%,0.0,0.0,alan coulson,GEOL-3000,2020
-GEOL,3020,1.0,Structural Geology,0.55,0.36,0.0,0.09,0.0,0%,0.0,0.0,alexander pullen,GEOL-3020,2020
-GEOL,4820,1.0,Groundwater & Contam Tr,0.3,0.2,0.1,0.1,0.1,0%,0.0,0.2,lawrence murdoch,GEOL-4820,2020
-GEOL,4910,1.0,Research Synthesis I,0.5,0.3,0.1,0.0,0.1,0%,0.0,0.0,alan coulson,GEOL-4910,2020
-GEOL,6150,1.0,Analysis Geological Proces,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.0,lawrence murdoch,GEOL-6150,2020
-GEOL,8080,1.0,Groundwater Modeling,0.14,0.57,0.14,0.0,0.0,0%,0.0,0.0,ronald falta,GEOL-8080,2020
-GEOL,8610,1.0,Geology Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sudeep popat,GEOL-8610,2020
-GER,1010,1.0,Elementary German,0.7,0.2,0.0,0.1,0.0,0%,0.0,0.0,oswald harris king,GER-1010,2020
-GER,1020,1.0,Elementary German,0.21,0.29,0.21,0.14,0.07,0%,0.0,0.07, lee ferrell,GER-1020,2020
-GER,2010,1.0,Intermediate German,0.25,0.31,0.25,0.0,0.06,0%,0.0,0.0,johannes schmidt,GER-2010,2020
-GER,2020,1.0,Intermediate German,0.63,0.31,0.06,0.0,0.0,0%,0.0,0.0, lee ferrell,GER-2020,2020
-GER,2600,1.0,Selected Topics-Doppelgan,0.67,0.21,0.0,0.0,0.04,0%,0.0,0.08,gabriela stoicea,GER-2600,2020
-GER,2600,2.0,Selected Topics-Doppelgan,0.32,0.41,0.09,0.09,0.0,0%,0.0,0.09,gabriela stoicea,GER-2600,2020
-GER,3050,1.0,Ger Conv & Comp,0.65,0.24,0.06,0.0,0.0,0%,0.0,0.06, lee ferrell,GER-3050,2020
-GER,3600,1.0,Ger Lit to 1832,0.69,0.23,0.0,0.0,0.0,0%,0.0,0.0,johannes schmidt,GER-3600,2020
-GRAD,8030,1.0,Intl Teaching Fellowship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david fleming,GRAD-8030,2020
-GRAD,8030,2.0,Intl Teaching Fellowship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david fleming,GRAD-8030,2020
-HCC,8330,1.0,HCC Research Methods,0.6,0.27,0.07,0.0,0.07,0%,0.0,0.0,kelly caine,HCC-8330,2020
-HCC,9500,1.0,HATLab seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,bart knijnenburg,HCC-9500,2020
-HCC,9500,3.0,Human Centered XR Resea,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sabarish venkat babu,HCC-9500,2020
-HCC,9910,7.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,bart knijnenburg,HCC-9910,2020
-HCG,9070,400.0,Applied Health Genetics,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,sara moir sarasua,HCG-9070,2020
-HCG,9910,401.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jane marie deluca,HCG-9910,2020
-HIST,1010,1.0,History of the United State,0.63,0.33,0.0,0.03,0.0,0%,0.0,0.03,lee brady wilson,HIST-1010,2020
-HIST,1010,2.0,History of the United State,0.17,0.53,0.17,0.03,0.03,0%,0.0,0.07,james jeffries,HIST-1010,2020
-HIST,1220,1.0,"Hist, Tech & Society",0.44,0.33,0.05,0.05,0.06,0%,0.0,0.07,pamela mack,HIST-1220,2020
-HIST,1240,1.0,Environmental History Sur,0.19,0.56,0.17,0.0,0.03,0%,0.0,0.06,james jeffries,HIST-1240,2020
-HIST,1240,2.0,Environmental History Sur,0.18,0.69,0.05,0.0,0.03,0%,0.0,0.05,james jeffries,HIST-1240,2020
-HIST,1720,1.0,The West and the World I,0.68,0.24,0.05,0.0,0.01,0%,0.0,0.02,steven marks,HIST-1720,2020
-HIST,1720,2.0,The West and the World I,0.7,0.13,0.03,0.03,0.0,0%,0.0,0.1,christine hilliard,HIST-1720,2020
-HIST,1720,3.0,The West and the World I,0.28,0.38,0.14,0.02,0.11,0%,0.0,0.07,caroline dunn dunn,HIST-1720,2020
-HIST,1730,1.0,The West and the World II,0.22,0.46,0.18,0.01,0.05,0%,0.0,0.08, alan grubb,HIST-1730,2020
-HIST,1730,2.0,The West and the World II,0.72,0.21,0.0,0.03,0.03,0%,0.0,0.0,archana venkatesh,HIST-1730,2020
-HIST,2140,1.0,Introduction to Public Hist,0.63,0.25,0.0,0.06,0.0,0%,0.0,0.0,joshua catalano,HIST-2140,2020
-HIST,2990,1.0,Historian's Craft,0.63,0.11,0.05,0.0,0.16,0%,0.0,0.05,rachel anne moore,HIST-2990,2020
-HIST,2990,3.0,Historian's Craft,0.44,0.38,0.13,0.0,0.06,0%,0.0,0.0,michael meng,HIST-2990,2020
-HIST,3000,1.0,History of Colonial Americ,0.81,0.16,0.0,0.0,0.0,0%,0.0,0.03,lee brady wilson,HIST-3000,2020
-HIST,3040,1.0,Industrialism&Progressive,0.78,0.17,0.0,0.0,0.06,0%,0.0,0.0, roger grant,HIST-3040,2020
-HIST,3060,1.0,US: Postwar World 1945-1,0.73,0.13,0.0,0.0,0.0,0%,0.0,0.07,rebecca anna stoil,HIST-3060,2020
-HIST,3100,1.0,History of Religion in the U,0.38,0.31,0.06,0.0,0.06,0%,0.0,0.13,elizabeth jemison,HIST-3100,2020
-HIST,3120,1.0,Afr Amer Hist 1877 to Pres,0.38,0.45,0.03,0.03,0.07,0%,0.0,0.03,abel bartley,HIST-3120,2020
-HIST,3240,1.0,Hist of the South II,0.24,0.59,0.0,0.03,0.14,0%,0.0,0.0,john andrew,HIST-3240,2020
-HIST,3330,1.0,Hist of Mod Japan,0.32,0.39,0.25,0.0,0.04,0%,0.0,0.0,edwin moise,HIST-3330,2020
-HIST,3610,1.0,History of Britain to 1688,0.7,0.23,0.03,0.0,0.03,0%,0.0,0.0,seefeldt tara wood,HIST-3610,2020
-HIST,3630,1.0,Britain Since 1688,0.77,0.2,0.0,0.0,0.0,0%,0.0,0.03, barczewski,HIST-3630,2020
-HIST,3670,1.0,Modern Ireland,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,michael silvestri,HIST-3670,2020
-HIST,3840,1.0,Hist of Mod France,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.0, alan grubb,HIST-3840,2020
-HIST,3900,1.0,Modern Military History,0.24,0.48,0.14,0.0,0.0,0%,0.0,0.0,edwin moise,HIST-3900,2020
-HIST,4700,1.0,Europe Women and Gend,0.7,0.2,0.0,0.0,0.0,0%,0.0,0.1,christine hilliard,HIST-4700,2020
-HIST,4710,1.0,Moscow 1937,0.59,0.24,0.06,0.0,0.0,0%,0.0,0.06,steven marks,HIST-4710,2020
-HIST,4870,1.0,World War II,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,john andrew,HIST-4870,2020
-HIST,4900,1.0,DictatorshipViolence20thC,0.56,0.19,0.06,0.0,0.0,0%,0.0,0.0,amit bein,HIST-4900,2020
-HIST,4900,2.0,Northern Ireland &The Tro,0.67,0.28,0.06,0.0,0.0,0%,0.0,0.0,michael silvestri,HIST-4900,2020
-HIST,4940,2.0,Medieval Witchcraft & Her,0.53,0.33,0.07,0.07,0.0,0%,0.0,0.0,seefeldt tara wood,HIST-4940,2020
-HIST,8000,1.0,Historical Methods,0.67,0.22,0.0,0.0,0.0,0%,0.0,0.0,michael meng,HIST-8000,2020
-HIST,8910,1.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,michael meng,HIST-8910,2020
-HLTH,2020,1.0,Introduction to Public Heal,0.47,0.32,0.11,0.11,0.0,0%,0.0,0.0,jeffrey kingree,HLTH-2020,2020
-HLTH,2020,2.0,Introduction to Public Heal,0.64,0.31,0.05,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,HLTH-2020,2020
-HLTH,2020,3.0,Introduction to Public Heal,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,HLTH-2020,2020
-HLTH,2020,4.0,Introduction to Public Heal,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.06,marvina jones,HLTH-2020,2020
-HLTH,2020,5.0,Introduction to Public Heal,0.68,0.21,0.05,0.05,0.0,0%,0.0,0.0,becky ann tugman,HLTH-2020,2020
-HLTH,2020,400.0,Introduction to Public Heal,0.61,0.26,0.09,0.0,0.0,0%,0.0,0.04,ralph stewart welsh,HLTH-2020,2020
-HLTH,2020,401.0,Introduction to Public Heal,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,HLTH-2020,2020
-HLTH,2030,1.0,Health Care Sys,0.59,0.41,0.0,0.0,0.0,0%,0.0,0.0,tanya lee staton,HLTH-2030,2020
-HLTH,2030,2.0,Health Care Sys,0.75,0.16,0.06,0.03,0.0,0%,0.0,0.0,tanya lee staton,HLTH-2030,2020
-HLTH,2030,3.0,Health Care Sys,0.72,0.22,0.06,0.0,0.0,0%,0.0,0.0,sarah bauer floyd,HLTH-2030,2020
-HLTH,2030,400.0,Health Care Sys,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,tanya lee staton,HLTH-2030,2020
-HLTH,2400,1.0,Deter of Hlth Behav,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,amelia clinkscales,HLTH-2400,2020
-HLTH,2400,2.0,Deter of Hlth Behav,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,amelia clinkscales,HLTH-2400,2020
-HLTH,2400,3.0,Deter of Hlth Behav,0.63,0.37,0.0,0.0,0.0,0%,0.0,0.0,laura jane rolke,HLTH-2400,2020
-HLTH,2600,400.0,Medical Terminology & Co,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,karen edwards,HLTH-2600,2020
-HLTH,2980,1.0,Human Health and Disease,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,becky ann tugman,HLTH-2980,2020
-HLTH,2980,2.0,Human Health and Disease,0.66,0.26,0.09,0.0,0.0,0%,0.0,0.0,johnny long,HLTH-2980,2020
-HLTH,2980,3.0,Human Health and Disease,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,brooke brittain,HLTH-2980,2020
-HLTH,3050,1.0,Body Resp Hlth Beh,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,karen kemper,HLTH-3050,2020
-HLTH,3400,1.0,Hlth Prom Prog Plan,0.5,0.45,0.05,0.0,0.0,0%,0.0,0.0,johnny long,HLTH-3400,2020
-HLTH,3610,1.0,Int Health Care Econ,0.83,0.06,0.09,0.0,0.03,0%,0.0,0.0,khoa dang truong,HLTH-3610,2020
-HLTH,3800,1.0,Epidemiology,0.82,0.15,0.03,0.0,0.0,0%,0.0,0.0,lu zhang,HLTH-3800,2020
-HLTH,3800,2.0,Epidemiology,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,lu zhang,HLTH-3800,2020
-HLTH,3800,3.0,Epidemiology,0.63,0.3,0.07,0.0,0.0,0%,0.0,0.0,deborah alma falta,HLTH-3800,2020
-HLTH,3800,400.0,Epidemiology,0.26,0.42,0.21,0.05,0.05,0%,0.0,0.0,deborah alma falta,HLTH-3800,2020
-HLTH,3980,1.0,Health Appraisal Skills,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,kathleen meyer,HLTH-3980,2020
-HLTH,3980,2.0,Health Appraisal Skills,0.54,0.46,0.0,0.0,0.0,0%,0.0,0.0,kathleen meyer,HLTH-3980,2020
-HLTH,4000,1.0,Infec Disease & Exposure,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,tanya lee staton,HLTH-4000,2020
-HLTH,4190,1.0,Health Sci Internship Prep,0.79,0.15,0.05,0.0,0.0,0%,0.0,0.0,kathleen meyer,HLTH-4190,2020
-HLTH,4200,1.0,Hlth Science Intern,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,kathleen meyer,HLTH-4200,2020
-HLTH,4200,3.0,Hlth Science Intern,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,kathleen meyer,HLTH-4200,2020
-HLTH,4400,1.0,Manag Hlth Serv Org,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,lu shi,HLTH-4400,2020
-HLTH,4700,1.0,Global Health,0.93,0.0,0.03,0.0,0.03,0%,0.0,0.0,micky rogers ward,HLTH-4700,2020
-HLTH,4750,1.0,Hlthcr Oper Mgmt Res,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,lu shi,HLTH-4750,2020
-HLTH,4900,1.0,Res Eval St Pub Hlth,0.79,0.14,0.0,0.04,0.0,0%,0.0,0.04,jeffrey kingree,HLTH-4900,2020
-HLTH,4900,2.0,Res Eval St Pub Hlth,0.79,0.17,0.0,0.04,0.0,0%,0.0,0.0,jeffrey kingree,HLTH-4900,2020
-HLTH,4980,1.0,Improving Pop Hlth,0.45,0.36,0.05,0.09,0.0,0%,0.0,0.0,hugh donald spitler,HLTH-4980,2020
-HLTH,8090,400.0,Epidemiological Res,0.65,0.24,0.0,0.0,0.0,0%,0.0,0.06,sara wagner robb,HLTH-8090,2020
-HLTH,8120,500.0,Clinical and Translational S,0.71,0.24,0.0,0.0,0.0,0%,0.0,0.05,ronald gimbel,HLTH-8120,2020
-HLTH,8140,500.0,Health Sys Quality Improv,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,windsor sherrill,HLTH-8140,2020
-HLTH,8210,1.0,Health Research I,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,sara wagner robb,HLTH-8210,2020
-HLTH,8890,1.0,Sem in App Hlth Rsrch & E,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,karen kemper,HLTH-8890,2020
-HON,2020,1.0,Who Decides What's Cool?,0.74,0.21,0.0,0.0,0.0,0%,0.0,0.05,amanda cooper fine,HON-2020,2020
-HON,2030,4.0,Views of History/Ancient,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,yanming an,HON-2030,2020
-HON,2050,5.0,Entrepreneurship,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,john michael hannon,HON-2050,2020
-HON,2210,1.0,Monster Culture and Socie,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,mary nestor,HON-2210,2020
-HORT,1010,1.0,Horticulture,0.95,0.03,0.0,0.0,0.0,0%,0.0,0.02,ellen anita vincent,HORT-1010,2020
-HORT,2020,1.0,Adobe Digital Design,0.85,0.04,0.0,0.0,0.0,0%,0.0,0.11,janice ann lay,HORT-2020,2020
-HORT,2120,1.0,Turfgrass Culture,0.84,0.14,0.0,0.0,0.03,0%,0.0,0.0,haibo liu,HORT-2120,2020
-HORT,2130,2.0,Turfgrass Culture Lab,0.73,0.0,0.18,0.0,0.09,0%,0.0,0.0,haibo liu,HORT-2130,2020
-HORT,3030,1.0,Woody Landscape Plant ID,0.15,0.23,0.2,0.13,0.3,0%,0.0,0.0,robert polomski,HORT-3030,2020
-HORT,3080,1.0,Sust Landsc Des Install Mai,0.85,0.09,0.06,0.0,0.0,0%,0.0,0.0,ellen anita vincent,HORT-3080,2020
-HORT,3090,1.0,Sust Landsc Des Lab,0.5,0.1,0.0,0.0,0.4,0%,0.0,0.0,shannon barrett,HORT-3090,2020
-HORT,4120,1.0,Adv Turfgrass Mgt,0.6,0.2,0.1,0.1,0.0,0%,0.0,0.0,lambert mccarty,HORT-4120,2020
-HORT,4400,1.0,Hydroponics,0.42,0.33,0.25,0.0,0.0,0%,0.0,0.0,james emerson faust,HORT-4400,2020
-HP,8010,1.0,Preservation Law and Econ,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,william jackson cook,HP-8010,2020
-HP,8020,1.0,Hist Preserv Research Sem,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jon marcoux,HP-8020,2020
-HP,8190,1.0,"Investig, Docum, Conserva",0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,amalia leifeste,HP-8190,2020
-HP,8230,400.0,Historic American Interiors,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,elizabeth ryan,HP-8230,2020
-HP,8920,1.0,Special Topics Paying for P,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,amalia leifeste,HP-8920,2020
-HRD,8300,400.0,Concepts of H R D,0.92,0.05,0.03,0.0,0.0,0%,0.0,0.0,angela carter,HRD-8300,2020
-HRD,8470,400.0,Instru System Design,0.82,0.1,0.0,0.0,0.03,0%,0.0,0.03,angela carter,HRD-8470,2020
-HUM,3090,1.0,Studies in Humanities,0.74,0.21,0.0,0.0,0.0,0%,0.0,0.05,jennie wakefield,HUM-3090,2020
-HUM,3090,2.0,Studies in Humanities,0.65,0.2,0.1,0.0,0.05,0%,0.0,0.0,jennie wakefield,HUM-3090,2020
-IE,2100,1.0,Des Analysis Wrk Sys,0.54,0.4,0.03,0.01,0.0,0%,0.0,0.02,sudeep hegde,IE-2100,2020
-IE,3010,1.0,Systems Design I,0.44,0.46,0.08,0.03,0.0,0%,0.0,0.0,paris stringfellow,IE-3010,2020
-IE,3140,1.0,Seminar in Industrial Engr,0.0,0.0,0.0,0.0,0.0,97%,0.03,0.0,jeffrey kharoufeh,IE-3140,2020
-IE,3600,1.0,Industrial Apps of Prob/Sta,0.31,0.44,0.15,0.04,0.04,0%,0.0,0.04,tugce isik,IE-3600,2020
-IE,3610,1.0,Industrial App of Prob/Stat,0.33,0.38,0.17,0.03,0.03,0%,0.0,0.05,hamed rahimian,IE-3610,2020
-IE,3800,1.0,Deterministic Operations R,0.43,0.31,0.14,0.07,0.03,0%,0.0,0.02,yongjia song,IE-3800,2020
-IE,3810,1.0,Probabilistic Operations Rs,0.34,0.46,0.15,0.03,0.02,0%,0.0,0.0,amin khademi,IE-3810,2020
-IE,3840,1.0,Engr Econ Analysis,0.39,0.33,0.09,0.02,0.0,0%,0.0,0.17,brian melloy,IE-3840,2020
-IE,3840,2.0,Engr Econ Analysis,0.05,0.14,0.24,0.1,0.0,0%,0.0,0.48,brian melloy,IE-3840,2020
-IE,3860,1.0,Production Planning & Con,0.62,0.27,0.09,0.01,0.0,0%,0.0,0.0,mariah magagnotti,IE-3860,2020
-IE,4300,1.0,Human Fact Engr in Health,0.73,0.17,0.04,0.0,0.04,0%,0.0,0.02,david neyens,IE-4300,2020
-IE,4400,2.0,Decision Support Sys,0.32,0.49,0.05,0.0,0.08,0%,0.0,0.04,scott jennings mason,IE-4400,2020
-IE,4560,1.0,Supply Chain Design & Con,0.19,0.43,0.14,0.1,0.0,0%,0.0,0.05,william ferrell,IE-4560,2020
-IE,4570,1.0,Transp/Logistic Engr,0.72,0.2,0.06,0.0,0.0,0%,0.0,0.03,emily tucker,IE-4570,2020
-IE,4610,1.0,Quality Engineering,0.63,0.24,0.07,0.02,0.04,0%,0.0,0.01,mariah magagnotti,IE-4610,2020
-IE,4650,1.0,Facilities Planning & Desig,0.53,0.38,0.07,0.01,0.01,0%,0.0,0.0,william ferrell,IE-4650,2020
-IE,4670,1.0,System Design II,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,scott jennings mason,IE-4670,2020
-IE,4820,1.0,Systems Modeling,0.42,0.47,0.07,0.03,0.0,0%,0.0,0.0,kevin taaffe,IE-4820,2020
-IE,4820,2.0,Systems Modeling,0.58,0.27,0.09,0.0,0.0,0%,0.0,0.06,kevin taaffe,IE-4820,2020
-IE,4880,2.0,Human Factors Eng,0.87,0.12,0.0,0.01,0.0,0%,0.0,0.0,jamiahus walton,IE-4880,2020
-IE,6300,1.0,Human Fact Engr in Health,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,david neyens,IE-6300,2020
-IE,6560,1.0,Supply Chain Design & Con,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,william ferrell,IE-6560,2020
-IE,6570,1.0,Transp/Logistic Engr,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,emily tucker,IE-6570,2020
-IE,8030,1.0,Engr Optimization and App,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,thomas sharkey,IE-8030,2020
-IE,8090,1.0,Model Sys Under Risk,0.33,0.61,0.0,0.0,0.0,0%,0.0,0.06,jeffrey kharoufeh,IE-8090,2020
-IE,8530,1.0,Foundations of Quality,0.75,0.21,0.0,0.0,0.04,0%,0.0,0.0,ozgur kabadurmus,IE-8530,2020
-IE,8550,1.0,SC & Logistics Modeling II,0.88,0.04,0.08,0.0,0.0,0%,0.0,0.0,kevin taaffe,IE-8550,2020
-IE,8930,18.0,Optimization under Uncert,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,yongjia song,IE-8930,2020
-IE,9910,18.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yongjia song,IE-9910,2020
-INNO,3990,4.0,IBM Watson in the Watt,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,dane smith,INNO-3990,2020
-INNO,4990,3.0,IBM Watson in the Watt,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.2,dane smith,INNO-4990,2020
-INT,1510,1.0,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,90%,0.06,0.04,lisa marie robinson,INT-1510,2020
-INT,1520,1.0,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,96%,0.04,0.0,caren kelley-hall,INT-1520,2020
-INT,1530,1.0,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,94%,0.04,0.02,caren kelley-hall,INT-1530,2020
-INT,1540,1.0,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,95%,0.0,0.05,caren kelley-hall,INT-1540,2020
-INT,2010,1.0,Off-Campus Internship FT,0.0,0.0,0.0,0.0,0.0,91%,0.0,0.0,brittany paige neely,INT-2010,2020
-INT,2510,1.0,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,86%,0.14,0.0,lisa marie robinson,INT-2510,2020
-INT,2520,1.0,UPIC Internship FT 2,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,caren kelley-hall,INT-2520,2020
-INT,2530,1.0,UPIC Internship FT 3,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,caren kelley-hall,INT-2530,2020
-INT,8010,1.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,INT-8010,2020
-INT,8010,2.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,INT-8010,2020
-INT,8010,3.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,INT-8010,2020
-ITAL,1010,2.0,Elementary Italian,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,julia schmidt,ITAL-1010,2020
-ITAL,1010,3.0,Elementary Italian,0.83,0.11,0.0,0.0,0.0,0%,0.0,0.06,luca barattoni,ITAL-1010,2020
-ITAL,1020,1.0,Elementary Italian,0.65,0.29,0.0,0.06,0.0,0%,0.0,0.0,julia schmidt,ITAL-1020,2020
-JAPN,1010,1.0,Elementary Japanese,0.64,0.23,0.05,0.0,0.09,0%,0.0,0.0,kumiko saito,JAPN-1010,2020
-JAPN,1010,2.0,Elementary Japanese,0.45,0.14,0.18,0.0,0.14,0%,0.0,0.09,kumiko saito,JAPN-1010,2020
-JAPN,1020,1.0,Elementary Japanese,0.5,0.39,0.0,0.0,0.11,0%,0.0,0.0,satomi saito,JAPN-1020,2020
-JAPN,2010,1.0,Intermed Japanese,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,satomi saito,JAPN-2010,2020
-JAPN,3050,1.0,Japanese Conversation & C,0.75,0.06,0.06,0.0,0.0,0%,0.0,0.06,jae allegra takeuchi,JAPN-3050,2020
-JAPN,4010,1.0,Japanese Lit in Translation,0.79,0.08,0.04,0.0,0.0,0%,0.0,0.04,kumiko saito,JAPN-4010,2020
-JAPN,4990,1.0,Sel Topics in Japanese Cult,0.54,0.31,0.0,0.0,0.0,0%,0.0,0.08,satomi saito,JAPN-4990,2020
-JUST,2050,1.0,Professional Development,0.77,0.1,0.0,0.1,0.0,0%,0.0,0.03,margaret tina britz,JUST-2050,2020
-JUST,2880,1.0,The Criminal Justice Syste,0.6,0.15,0.1,0.06,0.04,0%,0.0,0.04,margaret tina britz,JUST-2880,2020
-JUST,2880,2.0,The Criminal Justice Syste,0.75,0.24,0.0,0.0,0.0,0%,0.0,0.02,kyle david mclean,JUST-2880,2020
-JUST,2890,1.0,Criminology,0.51,0.29,0.1,0.06,0.02,0%,0.0,0.02,matthew costello,JUST-2890,2020
-JUST,3280,1.0,Criminal Courts,0.5,0.42,0.08,0.0,0.0,0%,0.0,0.0,rhys hester,JUST-3280,2020
-JUST,3960,1.0,Drugs and Crime,0.31,0.31,0.23,0.03,0.09,0%,0.0,0.03,brian chad starks,JUST-3960,2020
-JUST,4290,1.0,Justice Administration,0.45,0.4,0.1,0.05,0.0,0%,0.0,0.0,rhys hester,JUST-4290,2020
-JUST,4680,1.0,Criminal Evidence,0.59,0.14,0.14,0.03,0.05,0%,0.0,0.05,margaret tina britz,JUST-4680,2020
-JUST,4860,1.0,CI in CJ: Gangsterism in Fil,0.62,0.12,0.04,0.08,0.15,0%,0.0,0.0,margaret tina britz,JUST-4860,2020
-JUST,4910,1.0,Policing,0.86,0.08,0.05,0.0,0.0,0%,0.0,0.0,kyle david mclean,JUST-4910,2020
-JUST,4930,1.0,Corrections,0.6,0.28,0.07,0.02,0.02,0%,0.0,0.0,bryan lee miller,JUST-4930,2020
-JUST,4990,1.0,Sexual Assault and IPV,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,heather kettrey,JUST-4990,2020
-LAIB,1270,1.0,Intro to Lang & Int'l Busine,0.0,0.0,0.0,0.0,0.0,90%,0.1,0.0,jae allegra takeuchi,LAIB-1270,2020
-LANG,3000,1.0,Intro Linguistics,0.56,0.33,0.0,0.0,0.11,0%,0.0,0.0,daniel smith,LANG-3000,2020
-LANG,4990,1.0,Language Portfolio,0.0,0.0,0.0,0.0,0.0,92%,0.0,0.08,su- chen,LANG-4990,2020
-LARC,1150,1.0,Intro Landscape Architectu,0.61,0.25,0.14,0.0,0.0,0%,0.0,0.0,jueminsi wu,LARC-1150,2020
-LARC,1280,1.0,Technical Graphics,0.57,0.32,0.11,0.0,0.0,0%,0.0,0.0,matthew powers,LARC-1280,2020
-LARC,1510,1.0,Basic Design I,0.61,0.32,0.07,0.0,0.0,0%,0.0,0.0,matthew powers,LARC-1510,2020
-LARC,2140,1.0,Plants in the Landscape,0.65,0.25,0.05,0.05,0.0,0%,0.0,0.0,lara browning,LARC-2140,2020
-LARC,3510,1.0,Regional Design,0.63,0.11,0.11,0.05,0.05,0%,0.0,0.05,lara browning,LARC-3510,2020
-LARC,4530,1.0,Key Issues in Landscape Ar,0.57,0.38,0.05,0.0,0.0,0%,0.0,0.0,mary padua,LARC-4530,2020
-LARC,4620,1.0,Design Implementation III,0.5,0.25,0.1,0.05,0.0,0%,0.0,0.1,paul russell,LARC-4620,2020
-LARC,8210,1.0,Research Methods,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,hala fouad nassar,LARC-8210,2020
-LAW,3220,1.0,Legal Env of Bus,0.22,0.36,0.24,0.12,0.04,0%,0.0,0.02,kenneth toussaint,LAW-3220,2020
-LAW,3220,2.0,Legal Env of Bus,0.27,0.33,0.31,0.0,0.1,0%,0.0,0.0,kenneth toussaint,LAW-3220,2020
-LAW,3220,3.0,Legal Env of Bus,0.4,0.44,0.1,0.04,0.0,0%,0.0,0.02, kisska-schulze,LAW-3220,2020
-LAW,3220,4.0,Legal Env of Bus,0.32,0.42,0.22,0.04,0.0,0%,0.0,0.0, kisska-schulze,LAW-3220,2020
-LAW,3220,5.0,Legal Env of Bus,0.72,0.26,0.02,0.0,0.0,0%,0.0,0.0,christopher edwards,LAW-3220,2020
-LAW,3220,6.0,Legal Env of Bus,0.8,0.18,0.0,0.0,0.0,0%,0.0,0.02,christopher edwards,LAW-3220,2020
-LAW,3220,7.0,Legal Env of Bus,0.24,0.37,0.29,0.08,0.0,0%,0.0,0.02, kisska-schulze,LAW-3220,2020
-LAW,3220,8.0,Legal Env of Bus,0.58,0.35,0.08,0.0,0.0,0%,0.0,0.0,edward ray claggett,LAW-3220,2020
-LAW,3220,9.0,Legal Env of Bus,0.59,0.32,0.05,0.02,0.0,0%,0.0,0.02,frances edwards,LAW-3220,2020
-LAW,3220,10.0,Legal Env of Bus,0.4,0.43,0.13,0.03,0.03,0%,0.0,0.0,edward ray claggett,LAW-3220,2020
-LAW,3220,11.0,Legal Env of Bus,0.15,0.44,0.29,0.07,0.0,0%,0.0,0.05,john hine,LAW-3220,2020
-LAW,3220,12.0,Legal Env of Bus,0.48,0.37,0.13,0.0,0.0,0%,0.0,0.02,frances edwards,LAW-3220,2020
-LAW,3220,400.0,Legal Env of Bus,0.36,0.32,0.21,0.07,0.02,0%,0.0,0.02, ward-vaughn,LAW-3220,2020
-LAW,3220,401.0,Legal Env of Bus,0.23,0.53,0.12,0.07,0.03,0%,0.0,0.02, ward-vaughn,LAW-3220,2020
-LAW,3220,402.0,Legal Env of Bus,0.34,0.38,0.21,0.03,0.0,0%,0.0,0.03, ward-vaughn,LAW-3220,2020
-LAW,3220,403.0,Legal Env of Bus,0.33,0.36,0.14,0.07,0.07,0%,0.0,0.03, ward-vaughn,LAW-3220,2020
-LAW,3330,1.0,Real Estate Law,0.26,0.34,0.34,0.0,0.06,0%,0.0,0.0,kenneth toussaint,LAW-3330,2020
-LAW,3330,2.0,Real Estate Law,0.44,0.42,0.11,0.0,0.03,0%,0.0,0.0,kenneth toussaint,LAW-3330,2020
-LAW,4050,1.0,Construction Law,0.87,0.11,0.0,0.0,0.0,0%,0.0,0.03,frances edwards,LAW-4050,2020
-LIH,3970,1.0,Cr Inq-Language & Intl Hea,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.1,kelly digby peebles,LIH-3970,2020
-LS,1000,1.0,Therapeutic Yoga,0.78,0.0,0.0,0.0,0.0,0%,0.0,0.22,ranjanbala amin,LS-1000,2020
-LS,1000,15.0,"Stress, Coping, & Flourishi",0.83,0.09,0.03,0.0,0.02,0%,0.0,0.02,cynthia pury s,LS-1000,2020
-LS,1000,16.0,"Stress, Coping, & Flourishi",0.67,0.09,0.12,0.05,0.02,0%,0.0,0.02,cynthia pury s,LS-1000,2020
-LS,1000,50.0,Facilitating Social Gatherin,0.75,0.05,0.05,0.05,0.1,0%,0.0,0.0,paul hoke,LS-1000,2020
-LS,1750,2.0,Fly Fishing,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.2,michael watts,LS-1750,2020
-LS,1850,2.0,Bowling,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.04,madison workman,LS-1850,2020
-LS,1850,3.0,Bowling,0.71,0.21,0.0,0.0,0.0,0%,0.0,0.07,madison workman,LS-1850,2020
-LS,1850,4.0,Bowling,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,madison workman,LS-1850,2020
-LS,1850,5.0,Bowling,0.88,0.0,0.0,0.0,0.06,0%,0.0,0.06,angela rowan,LS-1850,2020
-LS,1980,5.0,Golf,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.12,wesley womble,LS-1980,2020
-LS,2320,1.0,Core Training,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,diane moreno,LS-2320,2020
-LS,2320,4.0,Core Training,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,diane moreno,LS-2320,2020
-LS,2350,1.0,Basic Yoga,0.76,0.1,0.1,0.0,0.0,0%,0.0,0.05,renee warren gahan,LS-2350,2020
-LS,2350,5.0,Basic Yoga,0.86,0.0,0.05,0.0,0.0,0%,0.0,0.09,brandy segura,LS-2350,2020
-LS,2350,6.0,Basic Yoga,0.89,0.05,0.05,0.0,0.0,0%,0.0,0.0,brandy segura,LS-2350,2020
-LS,2350,8.0,Basic Yoga,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,brandy segura,LS-2350,2020
-LS,2420,1.0,Meditation and Relax,0.87,0.0,0.04,0.04,0.0,0%,0.0,0.04,renee warren gahan,LS-2420,2020
-LS,2420,2.0,Meditation and Relax,0.88,0.0,0.04,0.0,0.04,0%,0.0,0.04,renee warren gahan,LS-2420,2020
-LS,2420,3.0,Meditation and Relax,0.7,0.17,0.04,0.04,0.0,0%,0.0,0.04,ranjanbala amin,LS-2420,2020
-LS,2420,4.0,Meditation and Relax,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ranjanbala amin,LS-2420,2020
-LS,2420,9.0,Meditation and Relax,0.77,0.09,0.09,0.0,0.05,0%,0.0,0.0,renee warren gahan,LS-2420,2020
-LS,2420,10.0,Meditation and Relax,0.59,0.14,0.05,0.09,0.09,0%,0.0,0.05,renee warren gahan,LS-2420,2020
-LS,2450,5.0,Pilates,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.13,diane moreno,LS-2450,2020
-LS,2750,8.0,Red Cross First Aid/CPR,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,christopher loomis,LS-2750,2020
-LS,2780,1.0,Wilderness First Aid,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,emily grace turke,LS-2780,2020
-MATH,1010,1.0,Essen Math for Informed S,0.09,0.43,0.3,0.02,0.02,0%,0.0,0.13,chad mangum,MATH-1010,2020
-MATH,1010,2.0,Essen Math for Informed S,0.25,0.39,0.27,0.02,0.07,0%,0.0,0.0,chad mangum,MATH-1010,2020
-MATH,1010,3.0,Essen Math for Informed S,0.22,0.31,0.22,0.09,0.09,0%,0.0,0.07,chad mangum,MATH-1010,2020
-MATH,1010,4.0,Essen Math for Informed S,0.17,0.48,0.24,0.02,0.02,0%,0.0,0.07,kristen savary,MATH-1010,2020
-MATH,1010,5.0,Essen Math for Informed S,0.07,0.36,0.14,0.12,0.19,0%,0.0,0.12,jacob lee britton,MATH-1010,2020
-MATH,1010,6.0,Essen Math for Informed S,0.13,0.28,0.35,0.15,0.09,0%,0.0,0.0,sarah kelly,MATH-1010,2020
-MATH,1020,1.0,Business Calculus I,0.36,0.23,0.15,0.13,0.09,0%,0.0,0.04,randy davidson,MATH-1020,2020
-MATH,1020,2.0,Business Calculus I,0.21,0.34,0.28,0.09,0.04,0%,0.0,0.04,randy davidson,MATH-1020,2020
-MATH,1020,3.0,Business Calculus I,0.06,0.26,0.3,0.22,0.1,0%,0.0,0.06,freeman slaughter,MATH-1020,2020
-MATH,1020,4.0,Business Calculus I,0.19,0.38,0.21,0.12,0.07,0%,0.0,0.02,joseph swanson,MATH-1020,2020
-MATH,1020,5.0,Business Calculus I,0.25,0.28,0.18,0.15,0.13,0%,0.0,0.03,ryan wolanzyk,MATH-1020,2020
-MATH,1020,6.0,Business Calculus I,0.11,0.26,0.21,0.21,0.08,0%,0.0,0.13,duygu vargun,MATH-1020,2020
-MATH,1020,7.0,Business Calculus I,0.25,0.3,0.2,0.08,0.08,0%,0.0,0.1,rodrigo smith,MATH-1020,2020
-MATH,1020,8.0,Business Calculus I,0.22,0.33,0.14,0.11,0.14,0%,0.0,0.06,rakhi goswami,MATH-1020,2020
-MATH,1020,9.0,Business Calculus I,0.29,0.29,0.14,0.14,0.1,0%,0.0,0.05,benjamin hamlin,MATH-1020,2020
-MATH,1020,10.0,Business Calculus I,0.2,0.34,0.24,0.0,0.1,0%,0.0,0.1,luke szramowski,MATH-1020,2020
-MATH,1020,11.0,Business Calculus I,0.13,0.36,0.18,0.21,0.1,0%,0.0,0.03,sarah otterbeck,MATH-1020,2020
-MATH,1020,12.0,Business Calculus I,0.17,0.44,0.22,0.1,0.07,0%,0.0,0.0,emily tidwell,MATH-1020,2020
-MATH,1020,13.0,Business Calculus I,0.12,0.37,0.22,0.15,0.02,0%,0.0,0.12,adam nathaniel price,MATH-1020,2020
-MATH,1020,14.0,Business Calculus I,0.29,0.44,0.12,0.05,0.07,0%,0.0,0.02, gracia-guzman,MATH-1020,2020
-MATH,1020,15.0,Business Calculus I,0.13,0.38,0.23,0.1,0.03,0%,0.0,0.13,robert melville,MATH-1020,2020
-MATH,1020,16.0,Business Calculus I,0.27,0.34,0.22,0.1,0.02,0%,0.0,0.05,heidi- shuttleworth,MATH-1020,2020
-MATH,1020,17.0,Business Calculus I,0.07,0.36,0.29,0.07,0.1,0%,0.0,0.12,elizabeth hawkins,MATH-1020,2020
-MATH,1020,18.0,Business Calculus I,0.15,0.27,0.29,0.02,0.12,0%,0.0,0.15,emma soriano,MATH-1020,2020
-MATH,1020,19.0,Business Calculus I,0.31,0.29,0.16,0.11,0.04,0%,0.0,0.09,michael cowen,MATH-1020,2020
-MATH,1020,20.0,Business Calculus I,0.18,0.34,0.2,0.02,0.16,0%,0.0,0.09,morgan elston,MATH-1020,2020
-MATH,1020,21.0,Business Calculus I,0.22,0.27,0.22,0.13,0.11,0%,0.0,0.04,michael foss,MATH-1020,2020
-MATH,1020,22.0,Business Calculus I,0.22,0.37,0.15,0.1,0.05,0%,0.0,0.12,james mckay visser,MATH-1020,2020
-MATH,1020,23.0,Business Calculus I,0.14,0.19,0.27,0.27,0.14,0%,0.0,0.0,james palmer,MATH-1020,2020
-MATH,1020,201.0,Business Calculus I,0.52,0.31,0.1,0.05,0.02,0%,0.0,0.0,dyken jennifer  van e,MATH-1020,2020
-MATH,1020,202.0,Business Calculus I,0.43,0.45,0.05,0.08,0.0,0%,0.0,0.0,marion hanna,MATH-1020,2020
-MATH,1030,401.0,Elementary Functions,0.56,0.36,0.0,0.0,0.08,0%,0.0,0.0,david costanzo,MATH-1030,2020
-MATH,1030,402.0,Elementary Functions,0.54,0.27,0.04,0.04,0.12,0%,0.0,0.0,david costanzo,MATH-1030,2020
-MATH,1030,403.0,Elementary Functions,0.46,0.32,0.0,0.04,0.14,0%,0.0,0.04,david costanzo,MATH-1030,2020
-MATH,1040,1.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,59%,0.38,0.03,donna simms,MATH-1040,2020
-MATH,1040,2.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,67%,0.29,0.04,catherine kenyon,MATH-1040,2020
-MATH,1040,3.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.32,0.05,catherine kenyon,MATH-1040,2020
-MATH,1040,4.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,60%,0.36,0.04,michael nelson,MATH-1040,2020
-MATH,1040,5.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.29,0.07,catherine kenyon,MATH-1040,2020
-MATH,1040,6.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.31,0.05,trinity white,MATH-1040,2020
-MATH,1040,7.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,69%,0.28,0.03,tony thanh nguyen,MATH-1040,2020
-MATH,1040,9.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,48%,0.39,0.13,tony thanh nguyen,MATH-1040,2020
-MATH,1040,10.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,38%,0.6,0.0,todd anthony morra,MATH-1040,2020
-MATH,1040,201.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,81%,0.16,0.03,tony thanh nguyen,MATH-1040,2020
-MATH,1040,202.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.33,0.03,travis alvarez,MATH-1040,2020
-MATH,1050,401.0,Precalculus,0.0,0.0,0.0,0.0,0.0,74%,0.26,0.0,jennifer marie hanna,MATH-1050,2020
-MATH,1050,402.0,Precalculus,0.0,0.0,0.0,0.0,0.0,75%,0.24,0.01,jennifer marie hanna,MATH-1050,2020
-MATH,1050,403.0,Precalculus,0.0,0.0,0.0,0.0,0.0,70%,0.26,0.03,jennifer marie hanna,MATH-1050,2020
-MATH,1060,1.0,Calculus of One Variable I,0.25,0.33,0.25,0.0,0.13,0%,0.0,0.05,david luke frost,MATH-1060,2020
-MATH,1060,2.0,Calculus of One Variable I,0.21,0.35,0.19,0.0,0.16,0%,0.0,0.09,allen anderson guest,MATH-1060,2020
-MATH,1060,3.0,Calculus of One Variable I,0.36,0.23,0.14,0.02,0.2,0%,0.0,0.05,yunan wang,MATH-1060,2020
-MATH,1060,4.0,Calculus of One Variable I,0.41,0.27,0.09,0.02,0.18,0%,0.0,0.02,allen anderson guest,MATH-1060,2020
-MATH,1060,5.0,Calculus of One Variable I,0.22,0.38,0.18,0.04,0.09,0%,0.0,0.09,allen anderson guest,MATH-1060,2020
-MATH,1060,6.0,Calculus of One Variable I,0.3,0.33,0.24,0.06,0.07,0%,0.0,0.0,james gossell,MATH-1060,2020
-MATH,1060,7.0,Calculus of One Variable I,0.24,0.4,0.17,0.07,0.1,0%,0.0,0.02,felice manganiello,MATH-1060,2020
-MATH,1060,8.0,Calculus of One Variable I,0.18,0.29,0.27,0.03,0.17,0%,0.0,0.06,felice manganiello,MATH-1060,2020
-MATH,1060,9.0,Calculus of One Variable I,0.18,0.27,0.32,0.0,0.2,0%,0.0,0.02,sofya alekseeva,MATH-1060,2020
-MATH,1060,10.0,Calculus of One Variable I,0.1,0.21,0.26,0.14,0.17,0%,0.0,0.1,sofya alekseeva,MATH-1060,2020
-MATH,1060,11.0,Calculus of One Variable I,0.23,0.38,0.17,0.04,0.06,0%,0.0,0.13,hugh geller,MATH-1060,2020
-MATH,1060,12.0,Calculus of One Variable I,0.19,0.33,0.11,0.07,0.22,0%,0.0,0.07,hossein faridian,MATH-1060,2020
-MATH,1060,13.0,Calculus of One Variable I,0.28,0.25,0.22,0.03,0.19,0%,0.0,0.03,blake james smith,MATH-1060,2020
-MATH,1060,14.0,Calculus of One Variable I,0.2,0.33,0.23,0.0,0.2,0%,0.0,0.05,michael byrd,MATH-1060,2020
-MATH,1060,201.0,Calculus of One Variable I,0.38,0.29,0.22,0.0,0.11,0%,0.0,0.0,jason alexander kurz,MATH-1060,2020
-MATH,1060,202.0,Calculus of One Variable I,0.38,0.36,0.09,0.04,0.11,0%,0.0,0.02,stephen peele,MATH-1060,2020
-MATH,1060,203.0,Calculus of One Variable I,0.38,0.29,0.18,0.02,0.09,0%,0.0,0.04,nathan fontes,MATH-1060,2020
-MATH,1060,204.0,Calculus of One Variable I,0.53,0.22,0.09,0.02,0.07,0%,0.0,0.07,zachary david espe,MATH-1060,2020
-MATH,1060,205.0,Calculus of One Variable I,0.11,0.24,0.36,0.04,0.13,0%,0.0,0.11,sofya alekseeva,MATH-1060,2020
-MATH,1060,300.0,Calculus of One Variable I,0.27,0.55,0.0,0.0,0.09,0%,0.0,0.09,matthew macauley,MATH-1060,2020
-MATH,1070,1.0,Differen and Integral Calcu,0.11,0.07,0.48,0.04,0.11,0%,0.0,0.19,donna simms,MATH-1070,2020
-MATH,1080,1.0,Calculus of One Variable II,0.27,0.21,0.19,0.04,0.23,0%,0.0,0.07,meredith nicole burr,MATH-1080,2020
-MATH,1080,2.0,Calculus of One Variable II,0.32,0.14,0.14,0.05,0.24,0%,0.0,0.11,fei xue,MATH-1080,2020
-MATH,1080,3.0,Calculus of One Variable II,0.19,0.19,0.19,0.0,0.19,0%,0.0,0.24,scott scruggs,MATH-1080,2020
-MATH,1080,4.0,Calculus of One Variable II,0.05,0.26,0.23,0.09,0.21,0%,0.0,0.16,peter westerbaan,MATH-1080,2020
-MATH,1080,5.0,Calculus of One Variable II,0.17,0.14,0.1,0.1,0.24,0%,0.0,0.24,cody stockdale,MATH-1080,2020
-MATH,1080,6.0,Calculus of One Variable II,0.14,0.16,0.27,0.05,0.18,0%,0.0,0.18,cody stockdale,MATH-1080,2020
-MATH,1080,7.0,Calculus of One Variable II,0.24,0.17,0.05,0.1,0.22,0%,0.0,0.22,blake splitter,MATH-1080,2020
-MATH,1080,201.0,Calculus of One Variable II,0.58,0.27,0.04,0.04,0.08,0%,0.0,0.0,meredith nicole burr,MATH-1080,2020
-MATH,1150,1.0,Contemp Math for Elem T,0.73,0.21,0.04,0.02,0.0,0%,0.0,0.0,jusino carreras,MATH-1150,2020
-MATH,1150,2.0,Contemp Math for Elem T,0.69,0.25,0.02,0.0,0.02,0%,0.0,0.02,jusino carreras,MATH-1150,2020
-MATH,1160,1.0,Contemp Math for Elem T,0.62,0.24,0.14,0.0,0.0,0%,0.0,0.0,jusino carreras,MATH-1160,2020
-MATH,1990,401.0,Problem Solving in Mathe,0.0,0.0,0.0,0.0,0.0,98%,0.02,0.0,marion hanna,MATH-1990,2020
-MATH,1990,403.0,Problem Solving in Mathe,0.0,0.0,0.0,0.0,0.0,95%,0.04,0.01,marion hanna,MATH-1990,2020
-MATH,2060,1.0,Calculus of Several Variabl,0.55,0.2,0.1,0.03,0.07,0%,0.0,0.05,oleg yordanov,MATH-2060,2020
-MATH,2060,2.0,Calculus of Several Variabl,0.6,0.15,0.14,0.05,0.02,0%,0.0,0.04,oleg yordanov,MATH-2060,2020
-MATH,2060,3.0,Calculus of Several Variabl,0.23,0.42,0.23,0.04,0.05,0%,0.0,0.04,tony william long,MATH-2060,2020
-MATH,2060,4.0,Calculus of Several Variabl,0.41,0.3,0.16,0.04,0.03,0%,0.0,0.07,tony william long,MATH-2060,2020
-MATH,2060,5.0,Calculus of Several Variabl,0.35,0.19,0.22,0.12,0.09,0%,0.0,0.04,timothy teitloff,MATH-2060,2020
-MATH,2060,6.0,Calculus of Several Variabl,0.43,0.37,0.13,0.02,0.0,0%,0.0,0.06,irina viktorova,MATH-2060,2020
-MATH,2060,7.0,Calculus of Several Variabl,0.35,0.39,0.17,0.01,0.04,0%,0.0,0.03,irina viktorova,MATH-2060,2020
-MATH,2060,100.0,Calc of Several Vars (HON),0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,yuyuan ouyang,MATH-2060,2020
-MATH,2060,201.0,Calculus of Several Variabl,0.32,0.26,0.26,0.08,0.08,0%,0.0,0.0,timothy teitloff,MATH-2060,2020
-MATH,2070,1.0,Business Calculus II,0.29,0.21,0.33,0.08,0.04,0%,0.0,0.06,jennifer ray newton,MATH-2070,2020
-MATH,2070,2.0,Business Calculus II,0.36,0.28,0.15,0.09,0.06,0%,0.0,0.06,nathaniel nemire,MATH-2070,2020
-MATH,2070,3.0,Business Calculus II,0.19,0.47,0.15,0.09,0.06,0%,0.0,0.04,jennifer ray newton,MATH-2070,2020
-MATH,2070,4.0,Business Calculus II,0.19,0.16,0.26,0.1,0.06,0%,0.0,0.23,daozhou zhu,MATH-2070,2020
-MATH,2070,5.0,Business Calculus II,0.27,0.38,0.22,0.04,0.04,0%,0.0,0.04,tyler sullivan,MATH-2070,2020
-MATH,2070,6.0,Business Calculus II,0.33,0.3,0.11,0.07,0.09,0%,0.0,0.09,ville madeleine  st e,MATH-2070,2020
-MATH,2070,7.0,Business Calculus II,0.05,0.22,0.22,0.3,0.11,0%,0.0,0.11,antonio pierrottet,MATH-2070,2020
-MATH,2070,8.0,Business Calculus II,0.11,0.25,0.23,0.11,0.06,0%,0.0,0.25,todd fenstermacher,MATH-2070,2020
-MATH,2070,9.0,Business Calculus II,0.16,0.33,0.1,0.1,0.12,0%,0.0,0.2,todd fenstermacher,MATH-2070,2020
-MATH,2070,10.0,Business Calculus II,0.2,0.22,0.22,0.1,0.1,0%,0.0,0.17,eva murphy,MATH-2070,2020
-MATH,2070,11.0,Business Calculus II,0.21,0.17,0.14,0.17,0.28,0%,0.0,0.03,anna bachstein,MATH-2070,2020
-MATH,2070,12.0,Business Calculus II,0.3,0.26,0.21,0.09,0.09,0%,0.0,0.05,elliott degbe,MATH-2070,2020
-MATH,2070,13.0,Business Calculus II,0.21,0.38,0.21,0.1,0.05,0%,0.0,0.05,jennifer ray newton,MATH-2070,2020
-MATH,2070,14.0,Business Calculus II,0.04,0.24,0.15,0.15,0.15,0%,0.0,0.26,rachel bass lanning,MATH-2070,2020
-MATH,2080,1.0,Intro to Ordin Diff Equatio,0.5,0.18,0.11,0.0,0.11,0%,0.0,0.11,timothy parrott,MATH-2080,2020
-MATH,2080,2.0,Intro to Ordin Diff Equatio,0.48,0.31,0.13,0.02,0.06,0%,0.0,0.0,timothy parrott,MATH-2080,2020
-MATH,2080,3.0,Intro to Ordin Diff Equatio,0.37,0.14,0.16,0.04,0.22,0%,0.0,0.06,timothy parrott,MATH-2080,2020
-MATH,2080,4.0,Intro to Ordin Diff Equatio,0.17,0.17,0.27,0.1,0.21,0%,0.0,0.08,jeong rock yoon rock,MATH-2080,2020
-MATH,2080,5.0,Intro to Ordin Diff Equatio,0.3,0.09,0.16,0.09,0.18,0%,0.0,0.18,jeong rock yoon rock,MATH-2080,2020
-MATH,2080,6.0,Intro to Ordin Diff Equatio,0.61,0.29,0.04,0.02,0.02,0%,0.0,0.02,leo rebholz,MATH-2080,2020
-MATH,2160,1.0,Geometry for Elem Sch Te,0.94,0.0,0.0,0.0,0.03,0%,0.0,0.03,nicole alaine sinwell,MATH-2160,2020
-MATH,2160,2.0,Geometry for Elem Sch Te,0.93,0.03,0.0,0.0,0.03,0%,0.0,0.0,nicole alaine sinwell,MATH-2160,2020
-MATH,2160,3.0,Geometry for Elem Sch Te,0.69,0.28,0.03,0.0,0.0,0%,0.0,0.0,jusino carreras,MATH-2160,2020
-MATH,3020,1.0,Stat for Science & Enginee,0.83,0.1,0.02,0.02,0.02,0%,0.0,0.0,qiong zhang,MATH-3020,2020
-MATH,3020,2.0,Stat for Science & Enginee,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,xin liu,MATH-3020,2020
-MATH,3020,3.0,Stat for Science & Enginee,0.16,0.33,0.23,0.1,0.05,0%,0.0,0.12,zhiyun gong,MATH-3020,2020
-MATH,3020,4.0,Stat for Science & Enginee,0.24,0.37,0.2,0.05,0.07,0%,0.0,0.08,zhiyun gong,MATH-3020,2020
-MATH,3110,1.0,Linear Algebra,0.39,0.43,0.1,0.0,0.04,0%,0.0,0.04,wayne goddard,MATH-3110,2020
-MATH,3110,2.0,Linear Algebra,0.56,0.31,0.07,0.02,0.04,0%,0.0,0.0, ramiharimanana,MATH-3110,2020
-MATH,3110,3.0,Linear Algebra,0.64,0.27,0.07,0.02,0.0,0%,0.0,0.0, ramiharimanana,MATH-3110,2020
-MATH,3110,4.0,Linear Algebra,0.44,0.31,0.17,0.03,0.03,0%,0.0,0.03,beth novick,MATH-3110,2020
-MATH,3110,5.0,Linear Algebra,0.35,0.33,0.19,0.02,0.06,0%,0.0,0.04,xuhong gao,MATH-3110,2020
-MATH,3110,6.0,Linear Algebra,0.53,0.28,0.07,0.07,0.05,0%,0.0,0.0,benjamin breen,MATH-3110,2020
-MATH,3160,1.0,Prob Solving for Math Tea,0.79,0.14,0.0,0.04,0.04,0%,0.0,0.0,andrew tyminski,MATH-3160,2020
-MATH,3160,2.0,Prob Solving for Math Tea,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,andrew tyminski,MATH-3160,2020
-MATH,3190,1.0,Introduction to Proof,0.17,0.39,0.3,0.09,0.04,0%,0.0,0.0,hui xue,MATH-3190,2020
-MATH,3190,2.0,Introduction to Proof,0.63,0.19,0.07,0.04,0.07,0%,0.0,0.0,ryann rose cartor,MATH-3190,2020
-MATH,3600,1.0,Intermediate Math Compu,0.7,0.0,0.0,0.0,0.1,0%,0.0,0.2,neil calkin,MATH-3600,2020
-MATH,3600,2.0,Intermediate Math Compu,0.39,0.39,0.06,0.0,0.03,0%,0.0,0.06,wayne goddard,MATH-3600,2020
-MATH,3650,1.0,Numerical Mthds for Engin,0.44,0.4,0.11,0.02,0.0,0%,0.0,0.02,qingshan chen,MATH-3650,2020
-MATH,3650,2.0,Numerical Mthds for Engin,0.29,0.22,0.31,0.04,0.04,0%,0.0,0.09,eleanor jenkins,MATH-3650,2020
-MATH,3650,3.0,Numerical Mthds for Engin,0.34,0.26,0.18,0.05,0.05,0%,0.0,0.11,eleanor jenkins,MATH-3650,2020
-MATH,3650,4.0,Numerical Mthds for Engin,0.64,0.16,0.11,0.04,0.0,0%,0.0,0.04,sibusiso mabuza,MATH-3650,2020
-MATH,4000,1.0,Theory of Probability,0.62,0.27,0.12,0.0,0.0,0%,0.0,0.0,peter kiessler,MATH-4000,2020
-MATH,4000,2.0,Theory of Probability,0.25,0.46,0.14,0.0,0.11,0%,0.0,0.04,xinyi li,MATH-4000,2020
-MATH,4020,1.0,Stats for Science and Engr I,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,derek brown,MATH-4020,2020
-MATH,4070,1.0,Regress & Time-Series Ana,0.57,0.19,0.05,0.0,0.05,0%,0.0,0.14,colin gallagher,MATH-4070,2020
-MATH,4080,1.0,Secondary Math Analysis,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,eliza gallagher,MATH-4080,2020
-MATH,4100,1.0,Number Theory,0.27,0.45,0.27,0.0,0.0,0%,0.0,0.0,hui xue,MATH-4100,2020
-MATH,4120,1.0,Algebra I,0.26,0.32,0.37,0.0,0.0,0%,0.0,0.05,james coykendall,MATH-4120,2020
-MATH,4120,2.0,Algebra I,0.43,0.39,0.09,0.09,0.0,0%,0.0,0.0, ramiharimanana,MATH-4120,2020
-MATH,4190,1.0,Discrete Math Structures I,0.71,0.19,0.05,0.0,0.05,0%,0.0,0.0,beth novick,MATH-4190,2020
-MATH,4190,2.0,Discrete Math Structures I,0.64,0.3,0.03,0.0,0.0,0%,0.0,0.03,beth novick,MATH-4190,2020
-MATH,4310,1.0,Theory of Interest,0.26,0.21,0.26,0.11,0.05,0%,0.0,0.0, erwin walker,MATH-4310,2020
-MATH,4340,1.0,Adv Engineering Mathema,0.23,0.27,0.2,0.03,0.1,0%,0.0,0.17,vincent ervin,MATH-4340,2020
-MATH,4340,2.0,Adv Engineering Mathema,0.27,0.12,0.12,0.19,0.15,0%,0.0,0.15,hyesuk lee,MATH-4340,2020
-MATH,4400,1.0,Linear Programming,0.35,0.43,0.08,0.03,0.05,0%,0.0,0.05,boshi yang,MATH-4400,2020
-MATH,4410,1.0,Intro to Stochastic Models,0.64,0.09,0.09,0.0,0.0,0%,0.0,0.18,brian fralix,MATH-4410,2020
-MATH,4530,1.0,Advanced Calculus I,0.14,0.56,0.24,0.02,0.02,0%,0.0,0.02,martin schmoll,MATH-4530,2020
-MATH,4540,1.0,Advanced Calculus II,0.17,0.5,0.11,0.06,0.11,0%,0.0,0.06,martin schmoll,MATH-4540,2020
-MATH,4910,1.0,Math of Options Pricing,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,mark cawood,MATH-4910,2020
-MATH,4920,2.0,Professional Development,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,randy davidson,MATH-4920,2020
-MATH,6340,1.0,Adv Engineering Mathema,0.38,0.38,0.13,0.0,0.0,0%,0.0,0.13,hyesuk lee,MATH-6340,2020
-MATH,8000,1.0,Probability,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,qiong zhang,MATH-8000,2020
-MATH,8010,1.0,General Linear Hypothesis,0.62,0.31,0.08,0.0,0.0,0%,0.0,0.0,xiaoqian sun,MATH-8010,2020
-MATH,8050,1.0,Data Analysis,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,brook thayer russell,MATH-8050,2020
-MATH,8090,1.0,Time Series Analysis,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,xin liu,MATH-8090,2020
-MATH,8120,1.0,Discrete Optimization,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,matthew saltzman,MATH-8120,2020
-MATH,8190,1.0,Multicriteria Optimization,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,margaret wiecek,MATH-8190,2020
-MATH,8210,1.0,Linear Analysis,0.56,0.33,0.06,0.0,0.0,0%,0.0,0.06,mishko mitkovski,MATH-8210,2020
-MATH,8510,1.0,Abstract Algebra I,0.29,0.65,0.06,0.0,0.0,0%,0.0,0.0,michael adam burr,MATH-8510,2020
-MATH,8530,1.0,Matrix Analysis,0.53,0.47,0.0,0.0,0.0,0%,0.0,0.0,matthew macauley,MATH-8530,2020
-MATH,8550,1.0,Combinatorial Analysis,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,svetlana poznanovikj,MATH-8550,2020
-MATH,8600,1.0,Intro to Scientific Computi,0.38,0.54,0.08,0.0,0.0,0%,0.0,0.0,vincent ervin,MATH-8600,2020
-MATH,8650,1.0,Data Structures,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,sibusiso mabuza,MATH-8650,2020
-MATH,8820,1.0,Intro to Bayesian Statistics,0.67,0.29,0.0,0.0,0.0,0%,0.0,0.04,deborah kunkel,MATH-8820,2020
-MATH,9010,1.0,Probability Theory I,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,brian fralix,MATH-9010,2020
-MATH,9830,1.0,Advanced Theories for PD,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,qingshan chen,MATH-9830,2020
-MATH,9830,2.0,High Performance FEM,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,timo heister,MATH-9830,2020
-MATH,9850,1.0,Homological Ring Properti,0.71,0.0,0.14,0.0,0.0,0%,0.0,0.0, sather-wagstaff,MATH-9850,2020
-MATH,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,derek brown,MATH-9910,2020
-MATH,9910,10.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, mcmahan,MATH-9910,2020
-MATH,9910,16.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, sather-wagstaff,MATH-9910,2020
-MBA,8030,2.0,Stat Analy of Bus Op,0.53,0.29,0.12,0.0,0.0,0%,0.0,0.06,william kilbourne,MBA-8030,2020
-MBA,8030,3.0,Stat Analy of Bus Op,0.61,0.28,0.0,0.0,0.0,0%,0.0,0.11,magda gabriela sava,MBA-8030,2020
-MBA,8030,4.0,Stat Analy of Bus Op,0.61,0.36,0.0,0.0,0.04,0%,0.0,0.0,magda gabriela sava,MBA-8030,2020
-MBA,8040,20.0,Busin Data An & Stat Com,0.59,0.26,0.03,0.0,0.12,0%,0.0,0.0,william kilbourne,MBA-8040,2020
-MBA,8060,1.0,Operations Mgt,0.8,0.16,0.02,0.0,0.0,0%,0.0,0.02,lawrence fredendall,MBA-8060,2020
-MBA,8060,3.0,Operations Mgt,0.73,0.23,0.03,0.0,0.0,0%,0.0,0.0,lawrence fredendall,MBA-8060,2020
-MBA,8070,1.0,Financial Management,0.48,0.43,0.03,0.0,0.0,0%,0.0,0.08,george lockhart,MBA-8070,2020
-MBA,8070,2.0,Financial Management,0.43,0.47,0.0,0.0,0.0,0%,0.0,0.1,george lockhart,MBA-8070,2020
-MBA,8070,20.0,Financial Management,0.7,0.26,0.04,0.0,0.0,0%,0.0,0.0,george lockhart,MBA-8070,2020
-MBA,8090,1.0,Org Beh & Hum Res Mg,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,thomas zagenczyk,MBA-8090,2020
-MBA,8090,2.0,Org Beh & Hum Res Mg,0.76,0.21,0.0,0.0,0.0,0%,0.0,0.03,thomas zagenczyk,MBA-8090,2020
-MBA,8090,3.0,Org Beh & Hum Res Mg,0.75,0.23,0.0,0.0,0.0,0%,0.0,0.03,thomas zagenczyk,MBA-8090,2020
-MBA,8180,20.0,Business Intell & Data Anly,0.79,0.12,0.03,0.0,0.06,0%,0.0,0.0,john frederick tripp,MBA-8180,2020
-MBA,8190,2.0,Intro to Acc and Fin,0.41,0.33,0.18,0.0,0.0,0%,0.0,0.08,jeffrey mcmillan,MBA-8190,2020
-MBA,8190,3.0,Intro to Acc and Fin,0.44,0.33,0.18,0.0,0.0,0%,0.0,0.05,jeffrey mcmillan,MBA-8190,2020
-MBA,8290,1.0,Marketing Foundation,0.9,0.05,0.0,0.0,0.0,0%,0.0,0.05,ankita bakre,MBA-8290,2020
-MBA,8310,10.0,Communications and Sales,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,gregory pickett,MBA-8310,2020
-MBA,8360,1.0,Real Estate Principles,0.2,0.73,0.0,0.0,0.0,0%,0.0,0.07,stephen buckman,MBA-8360,2020
-MBA,8370,1.0,Legal Environ of Bus,0.43,0.5,0.08,0.0,0.0,0%,0.0,0.0,judson jahn,MBA-8370,2020
-MBA,8370,2.0,Legal Environ of Bus,0.35,0.55,0.08,0.0,0.0,0%,0.0,0.03,judson jahn,MBA-8370,2020
-MBA,8410,1.0,Real Estate Finance,0.81,0.06,0.0,0.0,0.0,0%,0.0,0.06,larry bradley harvey,MBA-8410,2020
-MBA,8430,1.0,Entrepreneurial Accountin,0.36,0.36,0.27,0.0,0.0,0%,0.0,0.0,annieka philo,MBA-8430,2020
-MBA,8470,1.0,New Venture Creation,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,joseph gibson,MBA-8470,2020
-MBA,8490,5.0,Entrepreneurial Strategy,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,matthew klein,MBA-8490,2020
-MBA,8500,3.0,Bus Communications,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,MBA-8500,2020
-MBA,8500,30.0,Bus Communications,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,MBA-8500,2020
-MBA,8540,2.0,Managerial Accounting,0.46,0.41,0.11,0.0,0.0,0%,0.0,0.02,emily mccorkle,MBA-8540,2020
-MBA,8590,1.0,Mgr Decision Model,0.32,0.41,0.09,0.0,0.05,0%,0.0,0.14,james turner,MBA-8590,2020
-MBA,8590,2.0,Mgr Decision Model,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.08,magda gabriela sava,MBA-8590,2020
-MBA,8590,3.0,Mgr Decision Model,0.71,0.18,0.0,0.0,0.0,0%,0.0,0.12,magda gabriela sava,MBA-8590,2020
-MBA,8600,2.0,Advanced Marketing Strat,0.67,0.27,0.0,0.0,0.0,0%,0.0,0.07,pravin nath,MBA-8600,2020
-MBA,8600,3.0,Advanced Marketing Strat,0.8,0.13,0.0,0.0,0.0,0%,0.0,0.07,pravin nath,MBA-8600,2020
-MBA,8610,1.0,Information Systems,0.41,0.59,0.0,0.0,0.0,0%,0.0,0.0,william kettinger,MBA-8610,2020
-MBA,8610,2.0,Information Systems,0.67,0.27,0.03,0.0,0.03,0%,0.0,0.0,william kettinger,MBA-8610,2020
-MBA,8620,1.0,Managerial Economics,0.39,0.5,0.06,0.0,0.0,0%,0.0,0.06,scott templeton,MBA-8620,2020
-MBA,8620,2.0,Managerial Economics,0.63,0.37,0.0,0.0,0.0,0%,0.0,0.0,ronald earle gregory,MBA-8620,2020
-MBA,8620,4.0,Managerial Economics,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ronald earle gregory,MBA-8620,2020
-MBA,8660,21.0,Big Data Mgmt for Analytic,0.81,0.15,0.04,0.0,0.0,0%,0.0,0.0,he li,MBA-8660,2020
-MBA,8700,3.0,Strategic Management,0.67,0.25,0.0,0.0,0.0,0%,0.0,0.08,thomas robert uva,MBA-8700,2020
-MBA,8800,2.0,Career Mgt,0.0,0.0,0.0,0.0,0.0,93%,0.0,0.0,jamie lynn patterson,MBA-8800,2020
-MBA,8800,3.0,MBA Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,MBA-8800,2020
-MBA,8800,30.0,MBA Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,MBA-8800,2020
-MBA,8810,1.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,MBA-8810,2020
-MBA,8810,2.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,MBA-8810,2020
-MBA,8810,3.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,MBA-8810,2020
-MBA,8810,5.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gail depriest,MBA-8810,2020
-MBA,8880,5.0,MBA Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gregory pickett,MBA-8880,2020
-MBA,8880,11.0,MBA Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gregory pickett,MBA-8880,2020
-MBA,8990,2.0,Creativity,0.75,0.2,0.03,0.0,0.03,0%,0.0,0.0,kathleen ann kegley,MBA-8990,2020
-MBA,8990,4.0,Data Analytics & Visualizati,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,john frederick tripp,MBA-8990,2020
-MBA,8990,5.0,Business Analytics Models,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.04,jennie lynn farmer,MBA-8990,2020
-MBA,8990,10.0,Six Sigma,0.81,0.14,0.0,0.0,0.0,0%,0.0,0.05,dee ann wood kivett wood,MBA-8990,2020
-ME,2000,400.0,Sophomore Seminar,0.55,0.21,0.08,0.04,0.06,0%,0.0,0.06,todd schweisinger,ME-2000,2020
-ME,2010,1.0,Statics & Dynamics,0.0,0.13,0.23,0.09,0.39,0%,0.0,0.16,marisa kikendall orr,ME-2010,2020
-ME,2010,2.0,Statics & Dynamics,0.23,0.15,0.28,0.09,0.19,0%,0.0,0.06,paul joseph,ME-2010,2020
-ME,2010,3.0,Statics & Dynamics,0.11,0.08,0.15,0.15,0.44,0%,0.0,0.08,gang liu,ME-2010,2020
-ME,2010,4.0,Statics & Dynamics,0.06,0.1,0.09,0.06,0.43,0%,0.0,0.26, parvinioskoui,ME-2010,2020
-ME,2030,1.0,Founda Th/Fl Syst,0.15,0.34,0.43,0.09,0.0,0%,0.0,0.0,xiangchun xuan,ME-2030,2020
-ME,2030,2.0,Founda Th/Fl Syst,0.13,0.49,0.29,0.0,0.04,0%,0.0,0.04,yiqiang han,ME-2030,2020
-ME,2040,1.0,Mechanics of Materials,0.02,0.2,0.39,0.13,0.15,0%,0.0,0.02,gang liu,ME-2040,2020
-ME,2040,2.0,Mechanics of Materials,0.11,0.39,0.36,0.11,0.03,0%,0.0,0.0,huijuan zhao,ME-2040,2020
-ME,2220,1.0,Mechanical Engineering La,0.25,0.63,0.13,0.0,0.0,0%,0.0,0.0,douglas scott byrd,ME-2220,2020
-ME,2220,2.0,Mechanical Engineering La,0.31,0.69,0.0,0.0,0.0,0%,0.0,0.0,douglas scott byrd,ME-2220,2020
-ME,2220,5.0,Mechanical Engineering La,0.38,0.56,0.06,0.0,0.0,0%,0.0,0.0,douglas scott byrd,ME-2220,2020
-ME,2220,6.0,Mechanical Engineering La,0.63,0.25,0.06,0.0,0.06,0%,0.0,0.0,douglas scott byrd,ME-2220,2020
-ME,2220,7.0,Mechanical Engineering La,0.31,0.56,0.06,0.06,0.0,0%,0.0,0.0,douglas scott byrd,ME-2220,2020
-ME,2220,8.0,Mechanical Engineering La,0.25,0.5,0.19,0.06,0.0,0%,0.0,0.0,douglas scott byrd,ME-2220,2020
-ME,2220,10.0,Mechanical Engineering La,0.25,0.44,0.06,0.06,0.06,0%,0.0,0.13,douglas scott byrd,ME-2220,2020
-ME,2220,13.0,Mechanical Engineering La,0.63,0.31,0.06,0.0,0.0,0%,0.0,0.0,douglas scott byrd,ME-2220,2020
-ME,2220,14.0,Mechanical Engineering La,0.13,0.38,0.13,0.06,0.13,0%,0.0,0.19,douglas scott byrd,ME-2220,2020
-ME,2220,15.0,Mechanical Engineering La,0.25,0.44,0.31,0.0,0.0,0%,0.0,0.0,douglas scott byrd,ME-2220,2020
-ME,3000,301.0,Junior Honors Seminar (H,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,joshua bostwick,ME-3000,2020
-ME,3030,1.0,Thermodynamics,0.19,0.24,0.14,0.14,0.16,0%,0.0,0.14,john saylor,ME-3030,2020
-ME,3030,2.0,Thermodynamics,0.7,0.16,0.1,0.02,0.02,0%,0.0,0.02,sandip dutta,ME-3030,2020
-ME,3030,3.0,Thermodynamics,0.82,0.13,0.04,0.0,0.02,0%,0.0,0.0,sandip dutta,ME-3030,2020
-ME,3040,1.0,Heat Transfer,0.14,0.59,0.21,0.0,0.07,0%,0.0,0.0,xin zhao,ME-3040,2020
-ME,3040,2.0,Heat Transfer,0.38,0.4,0.19,0.04,0.0,0%,0.0,0.0,xin zhao,ME-3040,2020
-ME,3040,3.0,Heat Transfer,0.73,0.19,0.04,0.02,0.0,0%,0.0,0.02,sandip dutta,ME-3040,2020
-ME,3050,1.0,Model/an Dy Syst,0.26,0.35,0.33,0.02,0.05,0%,0.0,0.0,ardalan vahidi,ME-3050,2020
-ME,3050,2.0,Model/an Dy Syst,0.21,0.48,0.19,0.1,0.0,0%,0.0,0.02,ge lv,ME-3050,2020
-ME,3050,3.0,Model/an Dy Syst,0.21,0.39,0.21,0.0,0.12,0%,0.0,0.06,joshua bostwick,ME-3050,2020
-ME,3060,1.0,Fund Machine Design,0.35,0.38,0.17,0.04,0.04,0%,0.0,0.0,douglas scott byrd,ME-3060,2020
-ME,3060,2.0,Fund Machine Design,0.73,0.24,0.02,0.0,0.0,0%,0.0,0.02,zhaoxu meng,ME-3060,2020
-ME,3070,1.0,Found of Mechanical Syste,0.73,0.21,0.04,0.0,0.02,0%,0.0,0.0,lonny thompson,ME-3070,2020
-ME,3070,2.0,Found of Mechanical Syste,0.32,0.35,0.16,0.03,0.13,0%,0.0,0.0,katherine ehlert,ME-3070,2020
-ME,3070,3.0,Found of Mechanical Syste,0.32,0.38,0.13,0.06,0.06,0%,0.0,0.04,chengshi wang,ME-3070,2020
-ME,3080,1.0,Fluid Mechanics,0.22,0.47,0.25,0.04,0.0,0%,0.0,0.02,xiangchun xuan,ME-3080,2020
-ME,3080,2.0,Fluid Mechanics,0.27,0.6,0.13,0.0,0.0,0%,0.0,0.0,ethan kung,ME-3080,2020
-ME,3080,3.0,Fluid Mechanics,0.35,0.51,0.14,0.0,0.0,0%,0.0,0.0,zhen li,ME-3080,2020
-ME,3120,1.0,Manuf Processes,0.24,0.63,0.11,0.0,0.02,0%,0.0,0.0,hong seok choi,ME-3120,2020
-ME,3120,2.0,Manuf Processes,0.68,0.26,0.05,0.01,0.0,0%,0.0,0.0, martinez-duarte,ME-3120,2020
-ME,3330,1.0,Mechanical Engineering La,0.44,0.5,0.06,0.0,0.0,0%,0.0,0.0,yiqiang han,ME-3330,2020
-ME,3330,2.0,Mechanical Engineering La,0.44,0.5,0.0,0.0,0.0,0%,0.0,0.06,yiqiang han,ME-3330,2020
-ME,3330,3.0,Mechanical Engineering La,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.07,yiqiang han,ME-3330,2020
-ME,3330,4.0,Mechanical Engineering La,0.27,0.64,0.0,0.0,0.09,0%,0.0,0.0,yiqiang han,ME-3330,2020
-ME,3330,5.0,Mechanical Engineering La,0.38,0.5,0.06,0.0,0.0,0%,0.0,0.06,yiqiang han,ME-3330,2020
-ME,3330,6.0,Mechanical Engineering La,0.56,0.31,0.13,0.0,0.0,0%,0.0,0.0,yiqiang han,ME-3330,2020
-ME,3330,7.0,Mechanical Engineering La,0.6,0.2,0.1,0.0,0.1,0%,0.0,0.0,yiqiang han,ME-3330,2020
-ME,3330,10.0,Mechanical Engineering La,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,ME-3330,2020
-ME,3330,13.0,Mechanical Engineering La,0.56,0.31,0.06,0.06,0.0,0%,0.0,0.0,yiqiang han,ME-3330,2020
-ME,3330,14.0,Mechanical Engineering La,0.47,0.53,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,ME-3330,2020
-ME,4000,400.0,Senior Seminar,0.86,0.1,0.03,0.01,0.01,0%,0.0,0.0,atul gajanan kelkar,ME-4000,2020
-ME,4010,1.0,Mech Engr Design,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,timothy guggisberg,ME-4010,2020
-ME,4010,2.0,Mech Engr Design,0.23,0.77,0.0,0.0,0.0,0%,0.0,0.0,gregory mocko,ME-4010,2020
-ME,4010,400.0,Mech Engr Design,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,geetha chimata,ME-4010,2020
-ME,4020,1.0,Intern in Engr Des,0.61,0.33,0.06,0.0,0.0,0%,0.0,0.0,sandip dutta,ME-4020,2020
-ME,4020,3.0,Intern in Engr Des,0.47,0.35,0.18,0.0,0.0,0%,0.0,0.0,yiqiang han,ME-4020,2020
-ME,4020,4.0,Intern in Engr Des,0.38,0.62,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,ME-4020,2020
-ME,4020,5.0,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,timothy guggisberg,ME-4020,2020
-ME,4030,1.0,Control Dynamic Systems,0.15,0.23,0.22,0.2,0.13,0%,0.0,0.03, naghnaeian,ME-4030,2020
-ME,4030,2.0,Control Dynamic Systems,0.42,0.4,0.12,0.05,0.02,0%,0.0,0.0,umesh vaidya,ME-4030,2020
-ME,4030,3.0,Control Dynamic Systems,0.37,0.47,0.16,0.0,0.0,0%,0.0,0.0, tallapragada,ME-4030,2020
-ME,4210,1.0,Intro to Comp Flow,0.43,0.3,0.26,0.0,0.0,0%,0.0,0.0,chenning tong,ME-4210,2020
-ME,4290,1.0,Ther Env Control,0.63,0.25,0.0,0.04,0.0,0%,0.0,0.04,jay ochterbeck,ME-4290,2020
-ME,4300,1.0,Mech Comp Materials,0.63,0.13,0.21,0.0,0.0,0%,0.0,0.04,lonny thompson,ME-4300,2020
-ME,4320,1.0,Advanced Strength of Mat,0.79,0.18,0.0,0.0,0.0,0%,0.0,0.0,oliver myers,ME-4320,2020
-ME,4340,1.0,Cardiovascular Biomechani,0.25,0.46,0.17,0.0,0.04,0%,0.0,0.04,ethan kung,ME-4340,2020
-ME,4400,1.0,Materials for Aggressive E,0.59,0.3,0.11,0.0,0.0,0%,0.0,0.0,garrett pataky,ME-4400,2020
-ME,4440,1.0,Mechanical Engineering La,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,2.0,Mechanical Engineering La,0.38,0.5,0.13,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,3.0,Mechanical Engineering La,0.06,0.88,0.06,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,4.0,Mechanical Engineering La,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,5.0,Mechanical Engineering La,0.25,0.75,0.0,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,6.0,Mechanical Engineering La,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,7.0,Mechanical Engineering La,0.33,0.67,0.0,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,8.0,Mechanical Engineering La,0.54,0.46,0.0,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,9.0,Mechanical Engineering La,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4440,13.0,Mechanical Engineering La,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,john wagner,ME-4440,2020
-ME,4550,400.0,Design for Manuf,0.53,0.24,0.16,0.02,0.04,0%,0.0,0.0,joshua summers,ME-4550,2020
-ME,4580,1.0,Fund Micro/Nano Fabricati,0.41,0.45,0.05,0.0,0.0,0%,0.0,0.05, martinez-duarte,ME-4580,2020
-ME,4930,29.0,Sel Topics ME - Vibrations,0.36,0.36,0.14,0.11,0.0,0%,0.0,0.04,suyi li,ME-4930,2020
-ME,6300,1.0,Mech Comp Materials,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,lonny thompson,ME-6300,2020
-ME,6320,1.0,Advanced Strength of Mat,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,oliver myers,ME-6320,2020
-ME,6340,1.0,Cardiovascular Biomechani,0.4,0.4,0.2,0.0,0.0,0%,0.0,0.0,ethan kung,ME-6340,2020
-ME,6550,400.0,Design for Manuf,0.43,0.36,0.07,0.0,0.07,0%,0.0,0.07,joshua summers,ME-6550,2020
-ME,6580,1.0,Fund Micro/Nano Fabricati,0.2,0.6,0.2,0.0,0.0,0%,0.0,0.0, martinez-duarte,ME-6580,2020
-ME,6930,24.0,Sel Topics - Automotive Sa,0.9,0.05,0.0,0.0,0.05,0%,0.0,0.0,john wagner,ME-6930,2020
-ME,6930,865.0,Sel Topics - Metrology (VT,0.6,0.3,0.0,0.0,0.0,0%,0.0,0.1,geetha chimata,ME-6930,2020
-ME,8010,1.0,Found of Fluid Mech,0.73,0.2,0.0,0.0,0.0,0%,0.0,0.07,richard figliola,ME-8010,2020
-ME,8010,843.0,Found of Fluid Mech,0.4,0.2,0.0,0.0,0.0,0%,0.0,0.4,richard figliola,ME-8010,2020
-ME,8100,1.0,Macroscopic Thermo,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,jay ochterbeck,ME-8100,2020
-ME,8180,1.0,Intro to Fin Ele Ana,0.31,0.49,0.09,0.0,0.0,0%,0.0,0.11,gang li,ME-8180,2020
-ME,8230,1.0,Control Systems,0.78,0.0,0.11,0.0,0.0,0%,0.0,0.11,yue wang,ME-8230,2020
-ME,8360,1.0,Fracture Mech,0.38,0.13,0.13,0.0,0.0,0%,0.0,0.38,huijuan zhao,ME-8360,2020
-ME,8460,1.0,Inter Dynamics,0.33,0.42,0.08,0.0,0.0,0%,0.0,0.08, tallapragada,ME-8460,2020
-ME,8610,1.0,Matl Sel Engr Design,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,garrett pataky,ME-8610,2020
-ME,8610,864.0,Matl Sel Engr Design,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,garrett pataky,ME-8610,2020
-ME,8700,1.0,Adv Design Methods,0.25,0.58,0.0,0.0,0.0,0%,0.0,0.08,gregory mocko,ME-8700,2020
-ME,8710,1.0,Engr Optimization,0.72,0.14,0.07,0.0,0.0,0%,0.0,0.03,cameron turner,ME-8710,2020
-ME,8910,16.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,joshua summers,ME-8910,2020
-ME,8910,28.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,cameron turner,ME-8910,2020
-ME,8930,8.0,Sel Topics ME: Continuum,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,fadi abdeljawad,ME-8930,2020
-ME,8930,27.0,Sel Topics ME - Optimal Co,0.38,0.57,0.0,0.0,0.0,0%,0.0,0.0,ardalan vahidi,ME-8930,2020
-ME,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gang li,ME-9910,2020
-ME,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yue wang,ME-9910,2020
-ME,9910,29.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,suyi li,ME-9910,2020
-MGT,2010,1.0,Principles of Management,0.46,0.43,0.09,0.0,0.01,0%,0.0,0.0,katherine clark,MGT-2010,2020
-MGT,2010,2.0,Principles of Management,0.75,0.22,0.01,0.0,0.02,0%,0.0,0.0,jonathan preedom,MGT-2010,2020
-MGT,2010,3.0,Principles of Management,0.93,0.03,0.03,0.0,0.0,0%,0.0,0.0,sheena laxton,MGT-2010,2020
-MGT,2010,8.0,Principles of Management,0.86,0.07,0.02,0.0,0.0,0%,0.0,0.05,shuang liu,MGT-2010,2020
-MGT,2010,9.0,Principles of Management,0.4,0.4,0.19,0.02,0.0,0%,0.0,0.0,ashley parnell,MGT-2010,2020
-MGT,2010,10.0,Principles of Management,0.48,0.33,0.17,0.0,0.02,0%,0.0,0.0,ashley parnell,MGT-2010,2020
-MGT,2010,11.0,Principles of Management,0.95,0.0,0.02,0.0,0.02,0%,0.0,0.0,jingyuan tian,MGT-2010,2020
-MGT,2010,12.0,Principles of Management,0.8,0.1,0.0,0.0,0.05,0%,0.0,0.05,zhiwei xing,MGT-2010,2020
-MGT,2010,13.0,Principles of Management,0.21,0.41,0.24,0.1,0.03,0%,0.0,0.01,christopher mann,MGT-2010,2020
-MGT,2010,14.0,Principles of Management,0.77,0.2,0.01,0.0,0.01,0%,0.0,0.01,sharon sheridan,MGT-2010,2020
-MGT,2010,15.0,Principles of Management,0.72,0.14,0.05,0.09,0.0,0%,0.0,0.0,hongli ye,MGT-2010,2020
-MGT,2010,18.0,Principles of Management,0.93,0.05,0.0,0.0,0.0,0%,0.0,0.03,yao chen,MGT-2010,2020
-MGT,2180,1.0,Management PC Applicati,0.84,0.12,0.03,0.01,0.0,0%,0.0,0.01,ryan toole,MGT-2180,2020
-MGT,2180,2.0,Management PC Applicati,0.71,0.19,0.03,0.02,0.05,0%,0.0,0.01,ryan toole,MGT-2180,2020
-MGT,2180,3.0,Management PC Applicati,0.59,0.26,0.06,0.03,0.05,0%,0.0,0.01,jeromy blake snider,MGT-2180,2020
-MGT,3070,1.0,Human Resource Manage,0.6,0.29,0.05,0.05,0.0,0%,0.0,0.02,michael cole,MGT-3070,2020
-MGT,3070,4.0,Human Resource Manage,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,leonard spooner,MGT-3070,2020
-MGT,3070,5.0,Human Resource Manage,0.62,0.24,0.03,0.03,0.08,0%,0.0,0.0,kristin scott,MGT-3070,2020
-MGT,3070,6.0,Human Resource Manage,0.71,0.26,0.03,0.0,0.0,0%,0.0,0.0,leonard spooner,MGT-3070,2020
-MGT,3070,7.0,Human Resource Manage,0.23,0.54,0.15,0.08,0.0,0%,0.0,0.0,priscilla harrison,MGT-3070,2020
-MGT,3070,8.0,Human Resource Manage,0.63,0.34,0.02,0.0,0.0,0%,0.0,0.0,michael cole,MGT-3070,2020
-MGT,3070,9.0,Human Resource Manage,0.55,0.39,0.06,0.0,0.0,0%,0.0,0.0,leonard spooner,MGT-3070,2020
-MGT,3100,1.0,Intermed Business Statistic,0.41,0.35,0.16,0.05,0.03,0%,0.0,0.0,jaeyoung kim,MGT-3100,2020
-MGT,3100,2.0,Intermed Business Statistic,0.68,0.1,0.13,0.0,0.03,0%,0.0,0.08,haeri seyed seyed,MGT-3100,2020
-MGT,3100,3.0,Intermed Business Statistic,0.41,0.35,0.06,0.0,0.03,0%,0.0,0.15,mustafa akturk,MGT-3100,2020
-MGT,3100,5.0,Intermed Business Statistic,0.45,0.31,0.18,0.03,0.01,0%,0.0,0.02,mustafa akturk,MGT-3100,2020
-MGT,3100,6.0,Intermed Business Statistic,0.41,0.24,0.22,0.0,0.07,0%,0.0,0.05,philip roth,MGT-3100,2020
-MGT,3100,7.0,Intermed Business Statistic,0.61,0.26,0.11,0.0,0.03,0%,0.0,0.0, ajjuguttu,MGT-3100,2020
-MGT,3100,8.0,Intermed Business Statistic,0.27,0.33,0.17,0.07,0.1,0%,0.0,0.07,jeromy blake snider,MGT-3100,2020
-MGT,3100,9.0,Intermed Business Statistic,0.79,0.12,0.07,0.02,0.0,0%,0.0,0.0,david ford peyton,MGT-3100,2020
-MGT,3100,10.0,Intermed Business Statistic,0.5,0.33,0.08,0.0,0.03,0%,0.0,0.06,david ford peyton,MGT-3100,2020
-MGT,3100,12.0,Intermed Business Statistic,0.68,0.12,0.15,0.0,0.03,0%,0.0,0.03,david ford peyton,MGT-3100,2020
-MGT,3100,13.0,Intermed Business Statistic,0.41,0.28,0.09,0.06,0.03,0%,0.0,0.06,benjamin wiles,MGT-3100,2020
-MGT,3120,5.0,Decision Models for Mana,0.09,0.13,0.28,0.13,0.28,0%,0.0,0.11,sara elizabeth yoder,MGT-3120,2020
-MGT,3120,6.0,Decision Models for Mana,0.09,0.22,0.27,0.16,0.19,0%,0.0,0.03,sara elizabeth yoder,MGT-3120,2020
-MGT,3120,9.0,Decision Models for Mana,0.12,0.18,0.22,0.09,0.27,0%,0.0,0.12,sara elizabeth yoder,MGT-3120,2020
-MGT,3180,1.0,Mgt of Info Systems,0.67,0.2,0.13,0.0,0.0,0%,0.0,0.0,nedumkallel pius,MGT-3180,2020
-MGT,3180,3.0,Mgt of Info Systems,0.59,0.26,0.11,0.02,0.02,0%,0.0,0.0,kevin mckenzie,MGT-3180,2020
-MGT,3180,4.0,Mgt of Info Systems,0.64,0.26,0.02,0.06,0.02,0%,0.0,0.0,iaroslava dutchak,MGT-3180,2020
-MGT,3180,6.0,Mgt of Info Systems,0.35,0.27,0.18,0.12,0.04,0%,0.0,0.04,zhihong ke,MGT-3180,2020
-MGT,3180,7.0,Mgt of Info Systems,0.38,0.38,0.13,0.04,0.02,0%,0.0,0.04,iaroslava dutchak,MGT-3180,2020
-MGT,3180,9.0,Mgt of Info Systems,0.47,0.33,0.07,0.02,0.0,0%,0.0,0.12,pranith abbaraju,MGT-3180,2020
-MGT,3500,1.0,Business Intel/Data Analyti,0.59,0.32,0.05,0.0,0.05,0%,0.0,0.0,david ford peyton,MGT-3500,2020
-MGT,3900,1.0,Operations Management,0.04,0.25,0.43,0.11,0.11,0%,0.0,0.07,zachary leffakis,MGT-3900,2020
-MGT,3900,2.0,Operations Management,0.14,0.49,0.3,0.08,0.0,0%,0.0,0.0,zachary leffakis,MGT-3900,2020
-MGT,3900,4.0,Operations Management,0.41,0.39,0.17,0.01,0.02,0%,0.0,0.0,ying zhang,MGT-3900,2020
-MGT,3900,5.0,Operations Management,0.3,0.51,0.16,0.03,0.01,0%,0.0,0.0,ying zhang,MGT-3900,2020
-MGT,3900,7.0,Operations Management,0.16,0.66,0.17,0.0,0.01,0%,0.0,0.01, sridharan,MGT-3900,2020
-MGT,4000,1.0,Mgt of Organizational Beh,0.8,0.18,0.0,0.03,0.0,0%,0.0,0.0,michael cole,MGT-4000,2020
-MGT,4000,2.0,Mgt of Organizational Beh,0.73,0.25,0.0,0.0,0.0,0%,0.0,0.03,michael cole,MGT-4000,2020
-MGT,4000,3.0,Mgt of Organizational Beh,0.23,0.4,0.28,0.05,0.0,0%,0.0,0.05,thomas zagenczyk,MGT-4000,2020
-MGT,4000,4.0,Mgt of Organizational Beh,0.46,0.41,0.11,0.0,0.03,0%,0.0,0.0,sara joy krivacek,MGT-4000,2020
-MGT,4020,1.0,Ops Pln and Ctl,0.07,0.27,0.27,0.07,0.17,0%,0.0,0.13,zachary leffakis,MGT-4020,2020
-MGT,4080,1.0,Lean Operations,0.06,0.35,0.41,0.06,0.12,0%,0.0,0.0,zachary leffakis,MGT-4080,2020
-MGT,4110,1.0,Project Management,0.33,0.5,0.13,0.0,0.0,0%,0.0,0.0,russell purvis,MGT-4110,2020
-MGT,4120,1.0,Supplier Management,0.48,0.45,0.03,0.0,0.0,0%,0.0,0.03,ahmet colak,MGT-4120,2020
-MGT,4150,2.0,Business Strategy,0.23,0.4,0.38,0.0,0.0,0%,0.0,0.0,james liddle,MGT-4150,2020
-MGT,4150,3.0,Business Strategy,0.09,0.64,0.24,0.02,0.0,0%,0.0,0.0,james liddle,MGT-4150,2020
-MGT,4150,4.0,Business Strategy,0.11,0.6,0.27,0.0,0.0,0%,0.0,0.02,james liddle,MGT-4150,2020
-MGT,4150,6.0,Business Strategy,0.24,0.6,0.13,0.02,0.0,0%,0.0,0.0,amy elizabeth ingram,MGT-4150,2020
-MGT,4150,7.0,Business Strategy,0.56,0.37,0.06,0.0,0.01,0%,0.0,0.0,matt calvin hersel,MGT-4150,2020
-MGT,4150,8.0,Business Strategy,0.2,0.66,0.14,0.0,0.0,0%,0.0,0.0,amy elizabeth ingram,MGT-4150,2020
-MGT,4150,9.0,Business Strategy,0.55,0.26,0.19,0.0,0.0,0%,0.0,0.0,paul robert bonney,MGT-4150,2020
-MGT,4160,1.0,Special Topics Hr,0.58,0.34,0.05,0.0,0.03,0%,0.0,0.0,kristin scott,MGT-4160,2020
-MGT,4230,1.0,Intern Bus Mgt,0.17,0.06,0.56,0.06,0.06,0%,0.0,0.08,wayne stewart,MGT-4230,2020
-MGT,4230,2.0,Intern Bus Mgt,0.31,0.14,0.47,0.02,0.04,0%,0.0,0.02,wayne stewart,MGT-4230,2020
-MGT,4230,4.0,Intern Bus Mgt,0.13,0.36,0.47,0.0,0.04,0%,0.0,0.0,monica simsek,MGT-4230,2020
-MGT,4230,5.0,Intern Bus Mgt,0.09,0.47,0.45,0.0,0.0,0%,0.0,0.0,monica simsek,MGT-4230,2020
-MGT,4240,1.0,Global Supply Chain Mana,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,ahmet colak,MGT-4240,2020
-MGT,4270,2.0,Managing Improvement,0.18,0.53,0.24,0.06,0.0,0%,0.0,0.0,lawrence fredendall,MGT-4270,2020
-MGT,4310,1.0,Emp Rights & Resp,0.38,0.54,0.05,0.0,0.0,0%,0.0,0.03,leonard spooner,MGT-4310,2020
-MGT,4350,1.0,Pers Interviewing,0.37,0.49,0.12,0.0,0.02,0%,0.0,0.0,philip roth,MGT-4350,2020
-MGT,4500,3.0,Desc & Pred Business Anal,0.55,0.09,0.27,0.0,0.09,0%,0.0,0.0,zhihong ke,MGT-4500,2020
-MGT,4520,1.0,Business Analysis,0.27,0.55,0.09,0.0,0.09,0%,0.0,0.0,russell purvis,MGT-4520,2020
-MGT,4540,1.0,Business Analytics Progra,0.44,0.22,0.22,0.03,0.0,0%,0.0,0.08,hongki kim,MGT-4540,2020
-MGT,4560,1.0,Business Data Managemen,0.57,0.37,0.03,0.03,0.0,0%,0.0,0.0,he li,MGT-4560,2020
-MGT,4970,5.0,CI- Deloitte Consulting,0.79,0.05,0.0,0.0,0.0,0%,0.0,0.16,ryan toole,MGT-4970,2020
-MGT,8690,1.0,Project Mgt,0.39,0.61,0.0,0.0,0.0,0%,0.0,0.0,russell purvis,MGT-8690,2020
-MICR,2050,1.0,Introductory Micro,0.5,0.41,0.08,0.0,0.01,0%,0.0,0.0,john abercrombie,MICR-2050,2020
-MICR,3050,1.0,General Microbiology,0.82,0.1,0.04,0.01,0.01,0%,0.0,0.02,tzuen-rong tzeng,MICR-3050,2020
-MICR,3050,2.0,General Microbiology,0.46,0.32,0.14,0.06,0.01,0%,0.0,0.02,krista rudolph,MICR-3050,2020
-MICR,3050,3.0,General Microbiology,0.54,0.31,0.12,0.04,0.0,0%,0.0,0.0,krista rudolph,MICR-3050,2020
-MICR,4010,1.0,Microbial Diversity & Ecolo,0.7,0.21,0.07,0.02,0.0,0%,0.0,0.0,kristi whitehead,MICR-4010,2020
-MICR,4010,2.0,Micro Diversity/Ecol (HON,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,kristi whitehead,MICR-4010,2020
-MICR,4050,1.0,Adv Microbial Ecol of Hum,0.67,0.21,0.06,0.04,0.01,0%,0.0,0.01,kristi whitehead,MICR-4050,2020
-MICR,4140,1.0,Basic Immunology,0.83,0.15,0.0,0.0,0.0,0%,0.0,0.01,charles rice,MICR-4140,2020
-MICR,4150,1.0,Microbial Genetics,0.19,0.49,0.21,0.09,0.02,0%,0.0,0.0,min cao,MICR-4150,2020
-MICR,4160,1.0,Intro Virology,0.47,0.36,0.12,0.0,0.0,0%,0.0,0.05,kaustubha qanungo,MICR-4160,2020
-MICR,4510,1.0,Advanced Microbiology II,0.28,0.67,0.0,0.0,0.06,0%,0.0,0.0,harry kurtz,MICR-4510,2020
-MICR,4510,2.0,Advanced Microbiology II,0.21,0.58,0.21,0.0,0.0,0%,0.0,0.0,harry kurtz,MICR-4510,2020
-MICR,4510,3.0,Advanced Microbiology II,0.15,0.38,0.38,0.0,0.08,0%,0.0,0.0,harry kurtz,MICR-4510,2020
-MICR,6050,1.0,Adv Microbial Ecol of Hum,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,kristi whitehead,MICR-6050,2020
-MICR,6140,1.0,Basic Immunology,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,charles rice,MICR-6140,2020
-MICR,8040,1.0,Sel Top: MICR Core,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,barbara campbell,MICR-8040,2020
-MICR,8070,1.0,Micro Journal Club,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,barbara campbell,MICR-8070,2020
-MKT,3010,1.0,Principles of Marketing,0.21,0.31,0.31,0.11,0.03,0%,0.0,0.02,amanda cooper fine,MKT-3010,2020
-MKT,3010,2.0,Principles of Marketing,0.23,0.35,0.27,0.09,0.04,0%,0.0,0.02,amanda cooper fine,MKT-3010,2020
-MKT,3010,3.0,Principles of Marketing,0.3,0.33,0.23,0.08,0.03,0%,0.0,0.03,amanda cooper fine,MKT-3010,2020
-MKT,3010,4.0,Principles of Marketing,0.57,0.29,0.07,0.01,0.01,0%,0.0,0.05,james gaubert,MKT-3010,2020
-MKT,3010,5.0,Principles of Marketing,0.49,0.3,0.12,0.01,0.04,0%,0.0,0.03,james gaubert,MKT-3010,2020
-MKT,3010,7.0,Principles of Marketing,0.49,0.37,0.07,0.01,0.02,0%,0.0,0.03,lura forcum,MKT-3010,2020
-MKT,3020,1.0,Consumer Behavior,0.8,0.12,0.04,0.02,0.02,0%,0.0,0.0,cony ming shen ho shen,MKT-3020,2020
-MKT,3020,2.0,Consumer Behavior,0.86,0.1,0.02,0.0,0.02,0%,0.0,0.0,cony ming shen ho shen,MKT-3020,2020
-MKT,3020,3.0,Consumer Behavior,0.92,0.05,0.01,0.0,0.01,0%,0.0,0.0,cony ming shen ho shen,MKT-3020,2020
-MKT,3020,5.0,Consumer Behavior,0.58,0.28,0.08,0.06,0.0,0%,0.0,0.0,anastasia thyroff,MKT-3020,2020
-MKT,3020,6.0,Consumer Behavior,0.63,0.24,0.08,0.06,0.0,0%,0.0,0.0,anastasia thyroff,MKT-3020,2020
-MKT,3210,1.0,Sports Marketing,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,delancy bennett s,MKT-3210,2020
-MKT,3220,1.0,Social Media Marketing,0.74,0.15,0.04,0.04,0.02,0%,0.0,0.02,robert fitzwater,MKT-3220,2020
-MKT,3310,1.0,Marketing Metrics & Analy,0.72,0.22,0.0,0.0,0.0,0%,0.0,0.06,oriana rachel aragon,MKT-3310,2020
-MKT,3310,2.0,Marketing Metrics & Analy,0.63,0.2,0.14,0.03,0.0,0%,0.0,0.0,oriana rachel aragon,MKT-3310,2020
-MKT,3310,3.0,Marketing Metrics & Analy,0.69,0.29,0.0,0.03,0.0,0%,0.0,0.0,xianyong wang,MKT-3310,2020
-MKT,3310,4.0,Marketing Metrics & Analy,0.59,0.35,0.03,0.03,0.0,0%,0.0,0.0,xianyong wang,MKT-3310,2020
-MKT,4200,2.0,Professional Selling,0.79,0.15,0.03,0.0,0.03,0%,0.0,0.0,jesse moore,MKT-4200,2020
-MKT,4200,5.0,Professional Selling,0.86,0.1,0.03,0.0,0.0,0%,0.0,0.0,carter mcelveen,MKT-4200,2020
-MKT,4200,6.0,Professional Selling,0.64,0.21,0.03,0.0,0.06,0%,0.0,0.06,jesse moore,MKT-4200,2020
-MKT,4200,7.0,Professional Selling,0.75,0.21,0.0,0.0,0.0,0%,0.0,0.04,carter mcelveen,MKT-4200,2020
-MKT,4220,1.0,Applied Selling,0.45,0.55,0.0,0.0,0.0,0%,0.0,0.0,ryan mullins,MKT-4220,2020
-MKT,4230,2.0,Promotional Strategy,0.78,0.18,0.04,0.0,0.0,0%,0.0,0.0,michele cauley,MKT-4230,2020
-MKT,4230,3.0,Promotional Strategy,0.5,0.43,0.04,0.02,0.02,0%,0.0,0.0,michele cauley,MKT-4230,2020
-MKT,4230,4.0,Promotional Strategy,0.69,0.23,0.05,0.02,0.02,0%,0.0,0.0,michele cauley,MKT-4230,2020
-MKT,4240,1.0,Sales Management,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,ryan mullins,MKT-4240,2020
-MKT,4260,1.0,Business-to-Business,0.44,0.46,0.08,0.03,0.0,0%,0.0,0.0,james gaubert,MKT-4260,2020
-MKT,4270,1.0,International Marketing,0.53,0.38,0.05,0.05,0.0,0%,0.0,0.0,xianyong wang,MKT-4270,2020
-MKT,4270,2.0,International Marketing,0.52,0.36,0.12,0.0,0.0,0%,0.0,0.0,xianyong wang,MKT-4270,2020
-MKT,4270,3.0,International Marketing,0.75,0.23,0.0,0.0,0.0,0%,0.0,0.03,thomas poehlman,MKT-4270,2020
-MKT,4270,4.0,International Marketing,0.6,0.33,0.05,0.0,0.03,0%,0.0,0.0,thomas poehlman,MKT-4270,2020
-MKT,4270,5.0,International Marketing,0.37,0.51,0.09,0.01,0.0,0%,0.0,0.01,xianyong wang,MKT-4270,2020
-MKT,4280,1.0,Services Marketing,0.53,0.33,0.1,0.02,0.02,0%,0.0,0.0, scheinbaum,MKT-4280,2020
-MKT,4280,2.0,Services Marketing,0.38,0.45,0.15,0.03,0.0,0%,0.0,0.0, scheinbaum,MKT-4280,2020
-MKT,4310,1.0,Marketing Research,0.6,0.34,0.0,0.03,0.03,0%,0.0,0.0, giebelhausen,MKT-4310,2020
-MKT,4310,2.0,Marketing Research,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0, giebelhausen,MKT-4310,2020
-MKT,4310,3.0,Marketing Research,0.33,0.52,0.15,0.0,0.0,0%,0.0,0.0,peter weathers,MKT-4310,2020
-MKT,4310,5.0,Marketing Research,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,scott darren swain,MKT-4310,2020
-MKT,4430,1.0,Advertising Strategy,0.92,0.06,0.02,0.0,0.0,0%,0.0,0.0,scott darren swain,MKT-4430,2020
-MKT,4500,1.0,Strategic Mktg Mgt,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,annette popp tower,MKT-4500,2020
-MKT,4500,2.0,Strategic Mktg Mgt,0.4,0.48,0.08,0.0,0.04,0%,0.0,0.0,annette popp tower,MKT-4500,2020
-MKT,4500,3.0,Strategic Mktg Mgt,0.2,0.48,0.32,0.0,0.0,0%,0.0,0.0,mary anne raymond,MKT-4500,2020
-MKT,4500,4.0,Strategic Mktg Mgt,0.62,0.35,0.04,0.0,0.0,0%,0.0,0.0,michele cauley,MKT-4500,2020
-ML,1010,1.0,Leadership Fundamentals I,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,joseph david velez,ML-1010,2020
-ML,1010,2.0,Leadership Fundamentals I,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,joseph david velez,ML-1010,2020
-ML,1010,3.0,Leadership Fundamentals I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,joseph david velez,ML-1010,2020
-ML,2010,1.0,Leadership Development I,0.88,0.06,0.0,0.0,0.06,0%,0.0,0.0,michael scott gibson,ML-2010,2020
-ML,2010,2.0,Leadership Development I,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,michael scott gibson,ML-2010,2020
-ML,2010,3.0,Leadership Development I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,michael scott gibson,ML-2010,2020
-ML,3010,2.0,Advanced Leadership I,0.95,0.0,0.0,0.0,0.0,0%,0.0,0.05,justin robert merhar,ML-3010,2020
-MSE,2100,1.0,Intro to Materials Science,0.46,0.39,0.07,0.02,0.04,0%,0.0,0.02,kimberly weirich,MSE-2100,2020
-MSE,2100,2.0,Intro to Materials Science,0.3,0.4,0.15,0.04,0.06,0%,0.0,0.06,kai he,MSE-2100,2020
-MSE,2100,3.0,Intro to Materials Science,0.95,0.05,0.0,0.0,0.0,0%,0.0,0.0,john ballato,MSE-2100,2020
-MSE,2100,4.0,Intro to Materials Science,0.39,0.45,0.12,0.02,0.01,0%,0.0,0.01,mark alan johnson,MSE-2100,2020
-MSE,2100,6.0,Intro to Materials Science,0.71,0.2,0.05,0.01,0.01,0%,0.0,0.01,olga kuksenok,MSE-2100,2020
-MSE,3010,1.0,Materials Synthesis & Fabr,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,rakhee pani,MSE-3010,2020
-MSE,3010,3.0,Materials Synthesis & Fabr,0.71,0.14,0.14,0.0,0.0,0%,0.0,0.0,rakhee pani,MSE-3010,2020
-MSE,3260,2.0,Thermodynamics of Mater,0.22,0.41,0.19,0.06,0.06,0%,0.0,0.03,fei peng,MSE-3260,2020
-MSE,3450,1.0,Practice of Materials Engr,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marek urban,MSE-3450,2020
-MSE,3910,1.0,Research Fundamentals,0.68,0.05,0.11,0.05,0.0,0%,0.0,0.05,ulf daniel schiller,MSE-3910,2020
-MSE,4130,1.0,Noncrystalline Materials,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,ming tang,MSE-4130,2020
-MSE,4150,1.0,Polymer Science & Engine,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,olin mefford,MSE-4150,2020
-MSE,4150,2.0,Polymer Science & Engine,0.73,0.13,0.08,0.0,0.01,0%,0.0,0.05,rakhee pani,MSE-4150,2020
-MSE,4320,1.0,Manufacturing Proc & Syst,0.82,0.14,0.0,0.0,0.05,0%,0.0,0.0,john sanders,MSE-4320,2020
-MSE,8000,1.0,Seminar in Materials Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,kai he,MSE-8000,2020
-MSE,8100,1.0,Fundamentals of Materials,0.64,0.32,0.04,0.0,0.0,0%,0.0,0.0,rajendra bordia,MSE-8100,2020
-MSE,8190,1.0,Inorgan Mater Characteriz,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,luiz jacobsohn,MSE-8190,2020
-MSE,8260,1.0,Phase Equil Mat Sys,0.15,0.69,0.15,0.0,0.0,0%,0.0,0.0,stephen foulger,MSE-8260,2020
-MSE,8270,1.0,Kin of Phase Tran,0.5,0.27,0.23,0.0,0.0,0%,0.0,0.0,konstantin kornev,MSE-8270,2020
-MSE,8510,1.0,Polymer Science I,0.71,0.21,0.0,0.0,0.0,0%,0.0,0.07,marek urban,MSE-8510,2020
-MSE,9910,19.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jianhua tong,MSE-9910,2020
-MSE,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marek urban,MSE-9910,2020
-MTSA,8420,1.0,Road Safety Culture,0.93,0.0,0.0,0.0,0.0,0%,0.0,0.07,kim alexander,MTSA-8420,2020
-MUSC,1420,1.0,Music Theory I,0.7,0.2,0.05,0.05,0.0,0%,0.0,0.0,linda li-bleuel,MUSC-1420,2020
-MUSC,1430,1.0,Aural Skills I,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,linda li-bleuel,MUSC-1430,2020
-MUSC,1510,2.0,Applied Music for Non Maj,0.58,0.17,0.0,0.08,0.0,0%,0.0,0.17,jonathan doyel,MUSC-1510,2020
-MUSC,2100,2.0,Music in the Western Worl,0.71,0.23,0.0,0.0,0.0,0%,0.0,0.06,rhea beth jacobus,MUSC-2100,2020
-MUSC,2100,5.0,Music in the Western Worl,0.95,0.03,0.0,0.0,0.03,0%,0.0,0.0,timothy ray hurlburt,MUSC-2100,2020
-MUSC,2100,6.0,Music in the Western Worl,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,david conley,MUSC-2100,2020
-MUSC,2100,7.0,Music in the Western Worl,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0,rhea beth jacobus,MUSC-2100,2020
-MUSC,2100,8.0,Music in the Western Worl,0.6,0.3,0.03,0.03,0.0,0%,0.0,0.03,rhea beth jacobus,MUSC-2100,2020
-MUSC,2100,11.0,Music in the Western Worl,0.84,0.03,0.06,0.0,0.0,0%,0.0,0.06,leslie taylor warlick,MUSC-2100,2020
-MUSC,2100,12.0,Music in the Western Worl,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,lea kibler,MUSC-2100,2020
-MUSC,2100,13.0,Music in the Western Worl,0.93,0.08,0.0,0.0,0.0,0%,0.0,0.0,david conley,MUSC-2100,2020
-MUSC,3120,1.0,History of Jazz,0.52,0.32,0.16,0.0,0.0,0%,0.0,0.0,richard goodstein,MUSC-3120,2020
-MUSC,3140,1.0,World Music,0.88,0.09,0.03,0.0,0.0,0%,0.0,0.0,paul buyer,MUSC-3140,2020
-MUSC,3180,1.0,Hist of Audio Tech,0.67,0.22,0.06,0.06,0.0,0%,0.0,0.0,bruce allen whisler,MUSC-3180,2020
-MUSC,3610,1.0,Marching Band,0.99,0.0,0.0,0.0,0.01,0%,0.0,0.01,mark spede,MUSC-3610,2020
-MUSC,3620,1.0,Symphonic Band,0.93,0.0,0.0,0.0,0.0,0%,0.0,0.02,mark spede,MUSC-3620,2020
-MUSC,3690,1.0,Symphony Orchestra,0.93,0.0,0.0,0.0,0.02,0%,0.0,0.05,andrew levin,MUSC-3690,2020
-MUSC,4150,1.0,Music Hist to 1750,0.86,0.07,0.07,0.0,0.0,0%,0.0,0.0,eric lapin,MUSC-4150,2020
-NPL,3000,1.0,Nonprofit Leadership,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,christina mazer,NPL-3000,2020
-NPL,3000,2.0,Nonprofit Leadership,0.33,0.33,0.14,0.0,0.05,0%,0.0,0.14,bonnie stevens,NPL-3000,2020
-NPL,3000,3.0,Nonprofit Leadership,0.35,0.48,0.17,0.0,0.0,0%,0.0,0.0,bonnie stevens,NPL-3000,2020
-NPL,3000,4.0,Nonprofit Leadership,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,corey brookover,NPL-3000,2020
-NPL,3000,5.0,Nonprofit Leadership,0.7,0.22,0.09,0.0,0.0,0%,0.0,0.0,lauren george,NPL-3000,2020
-NPL,3000,6.0,Nonprofit Leadership,0.61,0.3,0.09,0.0,0.0,0%,0.0,0.0,corey brookover,NPL-3000,2020
-NPL,3000,7.0,Nonprofit Leadership,0.62,0.33,0.0,0.0,0.0,0%,0.0,0.05,lauren george,NPL-3000,2020
-NPL,3000,8.0,Nonprofit Leadership,0.8,0.08,0.04,0.0,0.04,0%,0.0,0.04,lauren george,NPL-3000,2020
-NPL,3000,9.0,Nonprofit Leadership,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,lauren george,NPL-3000,2020
-NPL,3000,10.0,Nonprofit Leadership,0.64,0.27,0.09,0.0,0.0,0%,0.0,0.0,christina mazer,NPL-3000,2020
-NPL,3000,11.0,Nonprofit Leadership,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,christina mazer,NPL-3000,2020
-NPL,3000,12.0,Nonprofit Leadership,0.58,0.29,0.08,0.04,0.0,0%,0.0,0.0,corey brookover,NPL-3000,2020
-NPL,3000,13.0,Nonprofit Leadership,0.74,0.22,0.0,0.0,0.0,0%,0.0,0.04,corey brookover,NPL-3000,2020
-NPL,3010,1.0,NPL Stakeholders,0.46,0.5,0.04,0.0,0.0,0%,0.0,0.0,christina mazer,NPL-3010,2020
-NPL,3020,1.0,NPL Fundraising,0.78,0.14,0.08,0.0,0.0,0%,0.0,0.0,joan laura phillips,NPL-3020,2020
-NPL,3030,1.0,NPL Personnel,0.91,0.03,0.0,0.0,0.0,0%,0.0,0.03,joan laura phillips,NPL-3030,2020
-NPL,3040,1.0,NPL Risk Management,0.58,0.35,0.06,0.0,0.0,0%,0.0,0.0,daniel anderson,NPL-3040,2020
-NPL,3050,1.0,Strat Social Media for NP,0.85,0.09,0.05,0.0,0.0,0%,0.0,0.0,randi plake,NPL-3050,2020
-NPL,3050,2.0,Strat Social Media for NP,0.8,0.07,0.07,0.02,0.04,0%,0.0,0.0,randi plake,NPL-3050,2020
-NPL,4900,1.0,Non-Profit Lead Preceptor,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,corey brookover,NPL-4900,2020
-NURS,3030,1.0,Nursing of Adults,0.24,0.71,0.05,0.0,0.0,0%,0.0,0.0,lena marie burgess,NURS-3030,2020
-NURS,3040,101.0,Pathophysiology,0.43,0.43,0.1,0.03,0.02,0%,0.0,0.0,catherine murton,NURS-3040,2020
-NURS,3040,201.0,Pathophysiology,0.52,0.38,0.06,0.03,0.01,0%,0.0,0.0,amy boggs garrison,NURS-3040,2020
-NURS,3040,300.0,Pathophysiology,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,amy boggs garrison,NURS-3040,2020
-NURS,3040,401.0,Pathophysiology,0.64,0.32,0.05,0.0,0.0,0%,0.0,0.0,amy boggs garrison,NURS-3040,2020
-NURS,3050,1.0,Psychosocial Nursing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,kevin earle busby,NURS-3050,2020
-NURS,3100,1.0,Health Assessment,0.68,0.3,0.0,0.0,0.03,0%,0.0,0.0,tiffany leah stewart,NURS-3100,2020
-NURS,3100,402.0,Health Assessment,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,jason thrift,NURS-3100,2020
-NURS,3120,101.0,Foundations of Nursing,0.61,0.36,0.03,0.0,0.0,0%,0.0,0.0,jennifer bagwell,NURS-3120,2020
-NURS,3120,211.0,Foundations of Nursing,0.48,0.52,0.0,0.0,0.0,0%,0.0,0.0,terri teramano,NURS-3120,2020
-NURS,3120,212.0,Foundations of Nursing,0.28,0.56,0.16,0.0,0.0,0%,0.0,0.0,terri teramano,NURS-3120,2020
-NURS,3120,411.0,Foundations of Nursing,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,terri teramano,NURS-3120,2020
-NURS,3190,300.0,Health Assessment for RNs,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,tiffany leah stewart,NURS-3190,2020
-NURS,3230,201.0,Gerontology Nursing,0.95,0.05,0.0,0.0,0.0,0%,0.0,0.0,zahra rahemi,NURS-3230,2020
-NURS,3300,1.0,Research in Nursing,0.9,0.05,0.03,0.0,0.03,0%,0.0,0.0,veronica parker,NURS-3300,2020
-NURS,3330,1.0,Health Care Genetics,0.41,0.51,0.05,0.02,0.0,0%,0.0,0.0,linda ward,NURS-3330,2020
-NURS,3400,101.0,Pharmther Nursing,0.4,0.43,0.12,0.03,0.02,0%,0.0,0.0,catherine murton,NURS-3400,2020
-NURS,3400,201.0,Pharmther Nursing,0.56,0.33,0.09,0.02,0.0,0%,0.0,0.0,jenna lynn seawright,NURS-3400,2020
-NURS,3400,401.0,Pharmther Nursing,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,jenna lynn seawright,NURS-3400,2020
-NURS,4010,1.0,Mental Health Nurs,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,lindsey garrard,NURS-4010,2020
-NURS,4030,101.0,Complex Nursing of Adults,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,taylor jean oneal,NURS-4030,2020
-NURS,4030,201.0,Complex Nursing of Adults,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,taylor jean oneal,NURS-4030,2020
-NURS,4060,300.0,Issues in Professionalism,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,shirley mae timmons,NURS-4060,2020
-NURS,4110,1.0,Nursing of Children,0.53,0.47,0.0,0.0,0.0,0%,0.0,0.0, elizabeth fisher,NURS-4110,2020
-NURS,4120,1.0,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0%,0.0,0.0,erin nicole shepherd,NURS-4120,2020
-NURS,4250,300.0,Community Nursing,0.62,0.31,0.0,0.0,0.08,0%,0.0,0.0,tiffany leah stewart,NURS-4250,2020
-NURS,8040,401.0,Dev Nurs Knowledge,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,kim ann pickett,NURS-8040,2020
-NURS,8050,400.0,Pharmaco Adv Nurs,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,tracy king fasolino,NURS-8050,2020
-NURS,8050,401.0,Pharmaco Adv Nurs,0.67,0.25,0.0,0.0,0.08,0%,0.0,0.0,tracy king fasolino,NURS-8050,2020
-NURS,8060,400.0,Advan Assessment for Nur,0.27,0.68,0.05,0.0,0.0,0%,0.0,0.0,jennifer geter rice,NURS-8060,2020
-NURS,8090,400.0,Pathophysiology,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,tracy brock lowe,NURS-8090,2020
-NURS,8180,400.0,Develop Family in Primary,0.33,0.5,0.0,0.0,0.0,0%,0.0,0.17,lisa miller,NURS-8180,2020
-NURS,8190,400.0,Developing Family,0.38,0.56,0.0,0.0,0.0,0%,0.0,0.0,lisa miller,NURS-8190,2020
-NURS,8200,400.0,Child & Adol Nursing,0.63,0.31,0.0,0.0,0.0,0%,0.0,0.0,heide temples,NURS-8200,2020
-NURS,8220,401.0,Gerontology Nursing,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.0,nicole joy davis,NURS-8220,2020
-NURS,8820,400.0,Primary Care Elders,0.75,0.0,0.0,0.0,0.0,0%,0.0,0.0,kimberly trammell,NURS-8820,2020
-NUTR,2030,1.0,Intro Princ of Human Nutri,0.75,0.21,0.03,0.0,0.0,0%,0.0,0.01,bridgit corbett,NUTR-2030,2020
-NUTR,2030,2.0,Intro Princ of Human Nutri,0.47,0.42,0.07,0.0,0.0,0%,0.0,0.05,bridgit corbett,NUTR-2030,2020
-NUTR,2050,400.0,Nutrition for Nursing Prof,0.53,0.45,0.02,0.0,0.0,0%,0.0,0.0,bridgit corbett,NUTR-2050,2020
-NUTR,2160,1.0,Evidence-Based Nutrition,0.76,0.08,0.08,0.05,0.01,0%,0.0,0.01,angela fraser,NUTR-2160,2020
-NUTR,3020,1.0,Nutrition Assessment,0.8,0.18,0.0,0.0,0.0,0%,0.0,0.02,elliot jesch,NUTR-3020,2020
-NUTR,4240,1.0,Medical Nutr Thera I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,vivian haley-zitlin,NUTR-4240,2020
-NUTR,4510,1.0,Human Nutrition & Metab,0.2,0.3,0.3,0.05,0.13,0%,0.0,0.03,elliot jesch,NUTR-4510,2020
-PA,1010,1.0,Intro to Perf Arts,0.68,0.26,0.03,0.0,0.0,0%,0.0,0.03,david hartmann,PA-1010,2020
-PA,3010,1.0,Princip of Arts Administrati,0.38,0.46,0.08,0.08,0.0,0%,0.0,0.0,richard goodstein,PA-3010,2020
-PA,4010,1.0,Capstone Project,0.6,0.3,0.0,0.0,0.0,0%,0.0,0.0,bruce allen whisler,PA-4010,2020
-PADM,7020,400.0,Research Methods,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,ronald chrestman,PADM-7020,2020
-PADM,7020,401.0,Research Methods,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,ronald chrestman,PADM-7020,2020
-PADM,8220,400.0,Public Policy Process,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,mellott yazykova,PADM-8220,2020
-PADM,8290,400.0,Public Financial Managem,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.0,robert frager,PADM-8290,2020
-PADM,8410,402.0,Public Data Analysis,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,scott schmidt,PADM-8410,2020
-PADM,8420,400.0,GIS for Public Administrato,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,david white,PADM-8420,2020
-PADM,8500,400.0,Homeland Security Funda,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,lori ann dickes,PADM-8500,2020
-PADM,8520,401.0,Emergency Mgt Planning,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,kevin todd staley,PADM-8520,2020
-PADM,8630,400.0,Contemporary Admin Orgs,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,lori ann dickes,PADM-8630,2020
-PADM,8640,400.0,Legal Aspects of Non-Profi,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,margaret elise baker,PADM-8640,2020
-PADM,8670,401.0,State Government Admin,0.77,0.15,0.0,0.0,0.0,0%,0.0,0.0,alfred bundrick,PADM-8670,2020
-PAS,3010,2.0,Intro to Pan African Studie,0.62,0.18,0.12,0.03,0.0,0%,0.0,0.06, stewart-tillman,PAS-3010,2020
-PDBE,8120,1.0,Seminar in EDP,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mickey lauria,PDBE-8120,2020
-PDBE,8150,1.0,Research Design in EDP,0.63,0.0,0.38,0.0,0.0,0%,0.0,0.0,mickey lauria,PDBE-8150,2020
-PES,1040,1.0,Introduction to Plant Scien,0.78,0.16,0.03,0.0,0.0,0%,0.0,0.03,paula agudelo,PES-1040,2020
-PES,2020,1.0,Soils,0.57,0.31,0.1,0.02,0.0,0%,0.0,0.0,dara michelle park,PES-2020,2020
-PES,3150,1.0,Environment and Agricultu,0.62,0.33,0.05,0.0,0.0,0%,0.0,0.0,suseela appukuttan,PES-3150,2020
-PES,4090,1.0,Biology of Invasive Plants,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0, tharayil-,PES-4090,2020
-PES,4550,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, tharayil-,PES-4550,2020
-PES,4850,1.0,Environmental Soil Chemis,0.71,0.24,0.0,0.0,0.0,0%,0.0,0.06,haibo liu,PES-4850,2020
-PES,8250,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, tharayil-,PES-8250,2020
-PHIL,1010,1.0,Intro to Philosophic Proble,0.7,0.24,0.0,0.0,0.0,0%,0.0,0.06,david stegall,PHIL-1010,2020
-PHIL,1010,2.0,Intro to Philosophic Proble,0.54,0.34,0.06,0.0,0.0,0%,0.0,0.06,david stegall,PHIL-1010,2020
-PHIL,1010,3.0,Intro to Philosophic Proble,0.47,0.35,0.09,0.0,0.0,0%,0.0,0.09,david stegall,PHIL-1010,2020
-PHIL,1010,4.0,Intro to Philosophic Proble,0.65,0.24,0.06,0.0,0.06,0%,0.0,0.0,claire kirwin,PHIL-1010,2020
-PHIL,1010,5.0,Intro to Philosophic Proble,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,claire kirwin,PHIL-1010,2020
-PHIL,1020,1.0,Introduction to Logic,0.49,0.29,0.14,0.03,0.03,0%,0.0,0.03,pascal brixel,PHIL-1020,2020
-PHIL,1020,2.0,Introduction to Logic,0.69,0.23,0.09,0.0,0.0,0%,0.0,0.0,adam gies,PHIL-1020,2020
-PHIL,1020,3.0,Introduction to Logic,0.58,0.27,0.15,0.0,0.0,0%,0.0,0.0,adam gies,PHIL-1020,2020
-PHIL,1020,4.0,Introduction to Logic,0.37,0.43,0.14,0.03,0.0,0%,0.0,0.03,adam gies,PHIL-1020,2020
-PHIL,1020,5.0,Introduction to Logic,0.41,0.47,0.09,0.0,0.0,0%,0.0,0.03,edyta joanna kuzian,PHIL-1020,2020
-PHIL,1020,6.0,Introduction to Logic,0.46,0.4,0.11,0.03,0.0,0%,0.0,0.0,edyta joanna kuzian,PHIL-1020,2020
-PHIL,1020,7.0,Introduction to Logic,0.63,0.26,0.0,0.0,0.05,0%,0.0,0.05,pascal brixel,PHIL-1020,2020
-PHIL,1020,8.0,Introduction to Logic,0.36,0.47,0.11,0.0,0.03,0%,0.0,0.03,edyta joanna kuzian,PHIL-1020,2020
-PHIL,1020,9.0,Introduction to Logic,0.31,0.37,0.23,0.09,0.0,0%,0.0,0.0,adam gies,PHIL-1020,2020
-PHIL,1030,1.0,Introduction to Ethics,0.57,0.37,0.03,0.0,0.0,0%,0.0,0.03,daniel wueste,PHIL-1030,2020
-PHIL,1030,2.0,Introduction to Ethics,0.39,0.42,0.16,0.03,0.0,0%,0.0,0.0,charles starkey,PHIL-1030,2020
-PHIL,1030,3.0,Introduction to Ethics,0.81,0.1,0.0,0.0,0.05,0%,0.0,0.05,david stegall,PHIL-1030,2020
-PHIL,1030,4.0,Introduction to Ethics,0.57,0.23,0.17,0.03,0.0,0%,0.0,0.0,edyta joanna kuzian,PHIL-1030,2020
-PHIL,1030,5.0,Introduction to Ethics,0.47,0.39,0.0,0.03,0.06,0%,0.0,0.06,david antonini,PHIL-1030,2020
-PHIL,3040,1.0,Moral Philosophy,0.44,0.47,0.06,0.0,0.0,0%,0.0,0.03,todd may,PHIL-3040,2020
-PHIL,3150,2.0,Ancient Philosophy,0.66,0.2,0.06,0.03,0.03,0%,0.0,0.03,stephen satris,PHIL-3150,2020
-PHIL,3210,1.0,Crime & Punishment,0.53,0.41,0.06,0.0,0.0,0%,0.0,0.0,daniel wueste,PHIL-3210,2020
-PHIL,3260,1.0,Science and Values,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,david antonini,PHIL-3260,2020
-PHIL,3260,2.0,Science and Values,0.61,0.33,0.0,0.03,0.0,0%,0.0,0.03,david antonini,PHIL-3260,2020
-PHIL,3260,3.0,Science and Values,0.73,0.22,0.0,0.0,0.03,0%,0.0,0.03,kelly smith,PHIL-3260,2020
-PHIL,3300,1.0,Contemporary Issues in Ph,0.41,0.47,0.0,0.0,0.0,0%,0.0,0.06,todd may,PHIL-3300,2020
-PHIL,3330,1.0,Metaphysics,0.68,0.16,0.05,0.05,0.0,0%,0.0,0.05,adam gies,PHIL-3330,2020
-PHIL,3430,1.0,Philosophy of Law,0.35,0.47,0.18,0.0,0.0,0%,0.0,0.0,brookes brown,PHIL-3430,2020
-PHIL,3440,1.0,Business Ethics,0.18,0.58,0.15,0.0,0.0,0%,0.0,0.09,brookes brown,PHIL-3440,2020
-PHIL,3460,1.0,Biomedical Ethics,0.41,0.47,0.12,0.0,0.0,0%,0.0,0.0,charles starkey,PHIL-3460,2020
-PHIL,3480,1.0,Philosophies of Art,0.38,0.5,0.13,0.0,0.0,0%,0.0,0.0,edyta joanna kuzian,PHIL-3480,2020
-PHSC,1180,1.0,"Intro Phys, Astron & Earth",0.76,0.16,0.03,0.03,0.02,0%,0.0,0.0,minory nammouz,PHSC-1180,2020
-PHSC,1180,2.0,"Intro Phys, Astron & Earth",0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,minory nammouz,PHSC-1180,2020
-PHYS,1220,1.0,Physics with Calculus I,0.25,0.29,0.29,0.09,0.02,0%,0.0,0.07,lih-sin the,PHYS-1220,2020
-PHYS,1220,2.0,Physics with Calculus I,0.17,0.34,0.3,0.07,0.06,0%,0.0,0.05,lih-sin the,PHYS-1220,2020
-PHYS,1220,4.0,Physics with Calculus I,0.26,0.47,0.16,0.0,0.05,0%,0.0,0.05,hugo sanabria,PHYS-1220,2020
-PHYS,1220,5.0,Physics with Calculus I (HO,0.56,0.39,0.0,0.0,0.0,0%,0.0,0.06,emil georgiev alexov,PHYS-1220,2020
-PHYS,1240,1.0,Physics Lab I,0.82,0.12,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,1240,2.0,Physics Lab I,0.67,0.11,0.17,0.0,0.0,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,1240,3.0,Physics Lab I,0.5,0.25,0.13,0.06,0.0,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,1240,4.0,Physics Lab I,0.53,0.24,0.0,0.12,0.06,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,1240,6.0,Physics Lab I,0.67,0.22,0.11,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-1240,2020
-PHYS,1240,7.0,Physics Lab I,0.72,0.17,0.0,0.0,0.06,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,1240,8.0,Physics Lab I,0.83,0.06,0.06,0.0,0.06,0%,0.0,0.0,daniel thompson,PHYS-1240,2020
-PHYS,1240,9.0,Physics Lab I,0.86,0.0,0.0,0.0,0.0,0%,0.0,0.14,daniel thompson,PHYS-1240,2020
-PHYS,1240,10.0,Physics Lab I,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.07,daniel thompson,PHYS-1240,2020
-PHYS,1240,11.0,Physics Lab I,0.67,0.06,0.06,0.0,0.11,0%,0.0,0.11,daniel thompson,PHYS-1240,2020
-PHYS,1240,12.0,Physics Lab I,0.7,0.2,0.1,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-1240,2020
-PHYS,1240,13.0,Physics Lab I,0.82,0.0,0.12,0.06,0.0,0%,0.0,0.0,daniel thompson,PHYS-1240,2020
-PHYS,1240,14.0,Physics Lab I,0.72,0.11,0.0,0.11,0.0,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,1240,15.0,Physics Lab I,0.67,0.22,0.0,0.06,0.06,0%,0.0,0.0,daniel thompson,PHYS-1240,2020
-PHYS,1240,16.0,Physics Lab I,0.67,0.22,0.0,0.11,0.0,0%,0.0,0.0,daniel thompson,PHYS-1240,2020
-PHYS,1240,17.0,Physics Lab I,0.78,0.06,0.06,0.06,0.0,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,1240,18.0,Physics Lab I,0.76,0.18,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,1240,19.0,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-1240,2020
-PHYS,1240,21.0,Physics Lab I,0.71,0.21,0.0,0.0,0.07,0%,0.0,0.0,daniel thompson,PHYS-1240,2020
-PHYS,1240,22.0,Physics Lab I,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,PHYS-1240,2020
-PHYS,2070,1.0,General Physics I,0.32,0.29,0.18,0.06,0.08,0%,0.0,0.06,amy liann pope,PHYS-2070,2020
-PHYS,2070,2.0,General Physics I,0.42,0.32,0.13,0.04,0.03,0%,0.0,0.05,amy liann pope,PHYS-2070,2020
-PHYS,2070,3.0,General Physics I,0.46,0.29,0.15,0.05,0.02,0%,0.0,0.04,amy liann pope,PHYS-2070,2020
-PHYS,2080,1.0,General Physics II,0.35,0.41,0.13,0.03,0.05,0%,0.0,0.02,pooja puneet,PHYS-2080,2020
-PHYS,2090,1.0,Gen Phys Lab I,0.5,0.25,0.04,0.08,0.04,0%,0.0,0.08,daniel thompson,PHYS-2090,2020
-PHYS,2090,2.0,Gen Phys Lab I,0.57,0.35,0.09,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2090,2020
-PHYS,2090,3.0,Gen Phys Lab I,0.54,0.29,0.04,0.0,0.08,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,4.0,Gen Phys Lab I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2090,2020
-PHYS,2090,5.0,Gen Phys Lab I,0.63,0.21,0.13,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,6.0,Gen Phys Lab I,0.65,0.1,0.1,0.05,0.0,0%,0.0,0.1,daniel thompson,PHYS-2090,2020
-PHYS,2090,7.0,Gen Phys Lab I,0.74,0.26,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2090,2020
-PHYS,2090,8.0,Gen Phys Lab I,0.67,0.21,0.08,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,9.0,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,10.0,Gen Phys Lab I,0.7,0.22,0.0,0.0,0.04,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,11.0,Gen Phys Lab I,0.71,0.08,0.13,0.0,0.04,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,12.0,Gen Phys Lab I,0.91,0.04,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,13.0,Gen Phys Lab I,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2090,2020
-PHYS,2090,14.0,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,15.0,Gen Phys Lab I,0.54,0.25,0.13,0.0,0.0,0%,0.0,0.08,daniel thompson,PHYS-2090,2020
-PHYS,2090,16.0,Gen Phys Lab I,0.79,0.13,0.0,0.0,0.0,0%,0.0,0.08,daniel thompson,PHYS-2090,2020
-PHYS,2090,17.0,Gen Phys Lab I,0.83,0.09,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,18.0,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2090,2020
-PHYS,2090,19.0,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2090,20.0,Gen Phys Lab I,0.43,0.48,0.0,0.0,0.05,0%,0.0,0.05,daniel thompson,PHYS-2090,2020
-PHYS,2090,21.0,Gen Phys Lab I,0.72,0.22,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,PHYS-2090,2020
-PHYS,2090,22.0,Gen Phys Lab I,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2090,2020
-PHYS,2090,23.0,Gen Phys Lab I,0.75,0.17,0.0,0.0,0.0,0%,0.0,0.08,daniel thompson,PHYS-2090,2020
-PHYS,2090,24.0,Gen Phys Lab I,0.58,0.21,0.11,0.0,0.0,0%,0.0,0.11,daniel thompson,PHYS-2090,2020
-PHYS,2090,25.0,Gen Phys Lab I,0.82,0.14,0.0,0.0,0.0,0%,0.0,0.05,daniel thompson,PHYS-2090,2020
-PHYS,2090,26.0,Gen Phys Lab I,0.36,0.36,0.14,0.05,0.0,0%,0.0,0.09,daniel thompson,PHYS-2090,2020
-PHYS,2090,27.0,Gen Phys Lab I,0.75,0.08,0.04,0.04,0.04,0%,0.0,0.04,daniel thompson,PHYS-2090,2020
-PHYS,2100,1.0,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2100,2020
-PHYS,2100,2.0,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2100,2020
-PHYS,2100,3.0,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2100,2020
-PHYS,2100,4.0,Gen Phys Lab II,0.91,0.0,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2100,2020
-PHYS,2100,6.0,Gen Phys Lab II,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2100,2020
-PHYS,2100,7.0,Gen Phys Lab II,0.88,0.04,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2100,2020
-PHYS,2100,8.0,Gen Phys Lab II,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2100,2020
-PHYS,2100,9.0,Gen Phys Lab II,0.96,0.0,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,PHYS-2100,2020
-PHYS,2210,1.0,Physics with Calculus II,0.24,0.37,0.27,0.04,0.02,0%,0.0,0.05,jason brown,PHYS-2210,2020
-PHYS,2210,2.0,Physics with Calculus II,0.46,0.37,0.11,0.04,0.01,0%,0.0,0.02,pooja puneet,PHYS-2210,2020
-PHYS,2210,3.0,Physics with Calculus II,0.28,0.39,0.19,0.07,0.04,0%,0.0,0.03,pooja puneet,PHYS-2210,2020
-PHYS,2210,4.0,Physics with Calculus II,0.26,0.43,0.19,0.07,0.03,0%,0.0,0.01,jason brown,PHYS-2210,2020
-PHYS,2210,5.0,Physics w/Calculus II(HON),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,endre andras takacs,PHYS-2210,2020
-PHYS,2220,1.0,Physics with Calculus III,0.78,0.13,0.04,0.0,0.0,0%,0.0,0.04,murray daw,PHYS-2220,2020
-PHYS,2230,1.0,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,2.0,Physics Lab II,0.22,0.61,0.11,0.0,0.0,0%,0.0,0.06,daniel thompson,PHYS-2230,2020
-PHYS,2230,3.0,Physics Lab II,0.39,0.5,0.06,0.06,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,4.0,Physics Lab II,0.44,0.44,0.11,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,5.0,Physics Lab II,0.74,0.26,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,6.0,Physics Lab II,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,7.0,Physics Lab II,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,9.0,Physics Lab II,0.72,0.28,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,10.0,Physics Lab II,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,11.0,Physics Lab II,0.2,0.67,0.07,0.0,0.0,0%,0.0,0.07,daniel thompson,PHYS-2230,2020
-PHYS,2230,12.0,Physics Lab II,0.72,0.22,0.0,0.0,0.06,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,13.0,Physics Lab II,0.67,0.17,0.11,0.0,0.0,0%,0.0,0.06,daniel thompson,PHYS-2230,2020
-PHYS,2230,14.0,Physics Lab II,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,PHYS-2230,2020
-PHYS,2230,15.0,Physics Lab II,0.22,0.67,0.0,0.0,0.0,0%,0.0,0.11,daniel thompson,PHYS-2230,2020
-PHYS,2240,1.0,Physics Lab III,0.75,0.13,0.06,0.0,0.0,0%,0.0,0.06,daniel thompson,PHYS-2240,2020
-PHYS,2450,1.0,Physics of Climate,0.62,0.23,0.06,0.01,0.02,0%,0.0,0.06,jens oberheide,PHYS-2450,2020
-PHYS,3000,1.0,Intro to Research,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,jianbo gao,PHYS-3000,2020
-PHYS,3120,1.0,Meth Theor Phys II,0.64,0.18,0.09,0.09,0.0,0%,0.0,0.0,lih-sin the,PHYS-3120,2020
-PHYS,3150,1.0,Intro to Computational Ph,0.46,0.27,0.19,0.0,0.0,0%,0.0,0.08,jason brown,PHYS-3150,2020
-PHYS,3210,1.0,Mechanics I,0.48,0.35,0.06,0.0,0.03,0%,0.0,0.06,feng ding,PHYS-3210,2020
-PHYS,3250,1.0,Electronics for Physicists,0.74,0.21,0.05,0.0,0.0,0%,0.0,0.0,chad sosolik,PHYS-3250,2020
-PHYS,4410,1.0,Electromagnetics I,0.47,0.29,0.12,0.0,0.06,0%,0.0,0.06,ramakrishna podila,PHYS-4410,2020
-PHYS,4550,1.0,Quantum Physics I,0.48,0.24,0.19,0.05,0.0,0%,0.0,0.05,gerald lehmacher,PHYS-4550,2020
-PHYS,8110,1.0,Meth of Theor Phys I,0.23,0.77,0.0,0.0,0.0,0%,0.0,0.0,domnita marinescu,PHYS-8110,2020
-PHYS,8180,1.0,Cellular Biophysics,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,joshua alper,PHYS-8180,2020
-PHYS,8210,1.0,Classical Mech I,0.18,0.82,0.0,0.0,0.0,0%,0.0,0.0,stephen kaeppler,PHYS-8210,2020
-PHYS,8750,2.0,Intro to Research Seminar,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,jianbo gao,PHYS-8750,2020
-PHYS,8750,13.0,Numerical Fluid Dynamics,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,xian lu,PHYS-8750,2020
-PHYS,9510,1.0,Quantum Mech I,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,sumanta tewari,PHYS-9510,2020
-PHYS,9530,1.0,Quantum Field Theory,0.44,0.56,0.0,0.0,0.0,0%,0.0,0.0,bradley meyer,PHYS-9530,2020
-PHYS,9910,12.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marco ajello,PHYS-9910,2020
-PKSC,1010,1.0,Pkgsc Orientation,0.82,0.12,0.04,0.02,0.0,0%,0.0,0.0,marcondes guerra,PKSC-1010,2020
-PKSC,1020,1.0,Intro to Pkg Sci,0.24,0.24,0.28,0.13,0.08,0%,0.0,0.04,heather batt,PKSC-1020,2020
-PKSC,2010,1.0,Pkg Perishable Prod,0.08,0.35,0.32,0.11,0.05,0%,0.0,0.08,heather batt,PKSC-2010,2020
-PKSC,2020,1.0,Packaging Mtl & Mfg,0.3,0.3,0.38,0.02,0.0,0%,0.0,0.0,marcondes guerra,PKSC-2020,2020
-PKSC,2040,1.0,Container Systems,0.2,0.6,0.13,0.07,0.0,0%,0.0,0.0,marcondes guerra,PKSC-2040,2020
-PKSC,2060,1.0,Container Sys Lab,0.57,0.36,0.07,0.0,0.0,0%,0.0,0.0,marcondes guerra,PKSC-2060,2020
-PKSC,2200,1.0,Product & Pkg Design,0.76,0.2,0.05,0.0,0.0,0%,0.0,0.0,haley ellis appleby,PKSC-2200,2020
-PKSC,3200,1.0,Pkg Design Theory,0.79,0.11,0.0,0.0,0.0,0%,0.0,0.11,rupert hurley,PKSC-3200,2020
-PKSC,4010,1.0,Packaging Machinery,0.09,0.6,0.26,0.0,0.04,0%,0.0,0.02,anthony pometto,PKSC-4010,2020
-PKSC,4040,1.0,Protective Packaging Prop,0.22,0.35,0.25,0.07,0.05,0%,0.0,0.05,gregory batt,PKSC-4040,2020
-PKSC,4160,1.0,Application of Polymers in,0.3,0.52,0.13,0.0,0.0,0%,0.0,0.05,alicia campbell,PKSC-4160,2020
-PKSC,4200,1.0,Package Design & Develop,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,robert kimmel,PKSC-4200,2020
-PKSC,4540,1.0,Product & Pkg Evaluation L,0.44,0.56,0.0,0.0,0.0,0%,0.0,0.0,gregory batt,PKSC-4540,2020
-PKSC,4540,3.0,Product & Pkg Evaluation L,0.19,0.5,0.19,0.06,0.0,0%,0.0,0.06,gregory batt,PKSC-4540,2020
-PKSC,4540,5.0,Product & Pkg Evaluation L,0.07,0.64,0.07,0.0,0.07,0%,0.0,0.14,gregory batt,PKSC-4540,2020
-PKSC,4640,1.0,Food & Health Care Pkg Sy,0.73,0.19,0.06,0.0,0.02,0%,0.0,0.0,kay cooksey,PKSC-4640,2020
-PLPA,3100,1.0,Principles of Plant Patholo,0.31,0.31,0.24,0.07,0.07,0%,0.0,0.0,steven nye jeffers,PLPA-3100,2020
-PLPA,8020,1.0,Principles of Plant Patholo,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,steven nye jeffers,PLPA-8020,2020
-POSC,1010,1.0,Amer National Govt,0.11,0.58,0.16,0.11,0.05,0%,0.0,0.0,robert carey,POSC-1010,2020
-POSC,1010,2.0,Amer National Govt,0.35,0.43,0.18,0.0,0.02,0%,0.0,0.02,robert carey,POSC-1010,2020
-POSC,1010,3.0,Amer National Govt,0.6,0.36,0.0,0.0,0.0,0%,0.0,0.04,joseph earl stewart,POSC-1010,2020
-POSC,1010,4.0,Amer National Govt,0.46,0.36,0.12,0.0,0.02,0%,0.0,0.04,robert carey,POSC-1010,2020
-POSC,1020,1.0,Intro Intl Relations,0.77,0.15,0.05,0.02,0.02,0%,0.0,0.0,steven vincent miller,POSC-1020,2020
-POSC,1020,2.0,Intro Intl Relations,0.42,0.39,0.11,0.03,0.03,0%,0.0,0.03, petersheim,POSC-1020,2020
-POSC,1020,3.0,Intro Intl Relations,0.36,0.45,0.07,0.0,0.07,0%,0.0,0.05,tara elizabeth trask,POSC-1020,2020
-POSC,1020,4.0,Intro Intl Relations,0.55,0.41,0.0,0.0,0.04,0%,0.0,0.0,colin denby pearce,POSC-1020,2020
-POSC,1020,5.0,Intro Intl Relations,0.35,0.4,0.09,0.01,0.09,0%,0.0,0.06,tara elizabeth trask,POSC-1020,2020
-POSC,1030,1.0,Intro to Political Theory,0.66,0.21,0.03,0.03,0.03,0%,0.0,0.03,adam thomas,POSC-1030,2020
-POSC,1030,2.0,Intro to Political Theory,0.33,0.61,0.0,0.0,0.06,0%,0.0,0.0,colin denby pearce,POSC-1030,2020
-POSC,1030,3.0,Intro to Political Theory,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,derek neal duplessie,POSC-1030,2020
-POSC,1030,4.0,Intro to Political Theory,0.48,0.28,0.17,0.0,0.07,0%,0.0,0.0,brandon turner,POSC-1030,2020
-POSC,1030,5.0,Intro to Political Theory,0.71,0.17,0.08,0.0,0.0,0%,0.0,0.04,jay hoffpauir,POSC-1030,2020
-POSC,1030,8.0,Intro to Political Theory,0.27,0.5,0.1,0.07,0.03,0%,0.0,0.03,elizabeth 'arrivee,POSC-1030,2020
-POSC,1040,1.0,Intro Compar Pol,0.17,0.34,0.19,0.05,0.17,0%,0.0,0.07,katherine curtis,POSC-1040,2020
-POSC,1040,2.0,Intro Compar Pol,0.47,0.29,0.06,0.04,0.04,0%,0.0,0.1, rhodes-purdy,POSC-1040,2020
-POSC,1990,1.0,Intro Pol Sci,0.52,0.36,0.1,0.0,0.02,0%,0.0,0.0, petersheim,POSC-1990,2020
-POSC,3020,1.0,State and Loc Gov,0.3,0.58,0.0,0.0,0.02,0%,0.0,0.06,bruce ransom,POSC-3020,2020
-POSC,3410,1.0,Quant Meth in Pol Sc,0.23,0.27,0.23,0.0,0.18,0%,0.0,0.05,steven vincent miller,POSC-3410,2020
-POSC,3610,1.0,International Conflict,0.4,0.23,0.13,0.06,0.06,0%,0.0,0.11,tara elizabeth trask,POSC-3610,2020
-POSC,3620,1.0,Intl Organizations,0.31,0.31,0.17,0.1,0.03,0%,0.0,0.07,zeynep taydas,POSC-3620,2020
-POSC,3620,2.0,Intl Organizations,0.37,0.33,0.07,0.15,0.07,0%,0.0,0.0,zeynep taydas,POSC-3620,2020
-POSC,3630,1.0,Us Foreign Policy,0.68,0.24,0.0,0.0,0.08,0%,0.0,0.0,vladimir matic,POSC-3630,2020
-POSC,3630,2.0,Us Foreign Policy,0.18,0.52,0.12,0.0,0.12,0%,0.0,0.06,jeffrey scott peake,POSC-3630,2020
-POSC,3750,1.0,European Integration,0.21,0.32,0.16,0.11,0.13,0%,0.0,0.08,katherine curtis,POSC-3750,2020
-POSC,4050,1.0,The American Presidency,0.31,0.42,0.06,0.02,0.06,0%,0.0,0.13,adam warber,POSC-4050,2020
-POSC,4090,2.0,Dir Stud in American Politi,0.79,0.0,0.05,0.0,0.0,0%,0.0,0.05,karyn jones,POSC-4090,2020
-POSC,4210,1.0,Public Policy,0.58,0.15,0.04,0.04,0.12,0%,0.0,0.04,grant anthony allard,POSC-4210,2020
-POSC,4230,1.0,Urban Politics,0.53,0.27,0.0,0.0,0.13,0%,0.0,0.0,bruce ransom,POSC-4230,2020
-POSC,4360,1.0,Law Courts Politics,0.77,0.18,0.0,0.0,0.0,0%,0.0,0.0,joseph earl stewart,POSC-4360,2020
-POSC,4360,2.0,Law Courts Politics,0.89,0.07,0.0,0.0,0.0,0%,0.0,0.02,joseph earl stewart,POSC-4360,2020
-POSC,4370,1.0,Constitut Law: Rights & Lib,0.5,0.27,0.14,0.02,0.05,0%,0.0,0.02,kevin gregory vance,POSC-4370,2020
-POSC,4370,2.0,Constitut Law: Rights & Lib,0.66,0.3,0.02,0.0,0.0,0%,0.0,0.02,kevin gregory vance,POSC-4370,2020
-POSC,4420,1.0,Pol Parties & Elect,0.43,0.32,0.19,0.05,0.0,0%,0.0,0.0,laura olson,POSC-4420,2020
-POSC,4490,1.0,Political Theory of Capitalis,0.38,0.52,0.05,0.0,0.05,0%,0.0,0.0,colin denby pearce,POSC-4490,2020
-POSC,4490,2.0,Political Theory of Capitalis,0.62,0.3,0.05,0.0,0.03,0%,0.0,0.0,brandon turner,POSC-4490,2020
-POSC,4500,1.0,Rev. Constitutionalism,0.75,0.08,0.08,0.0,0.08,0%,0.0,0.0, bradley thompson,POSC-4500,2020
-POSC,4550,1.0,Pol Thght of American Fou,0.73,0.22,0.04,0.02,0.0,0%,0.0,0.0,jay hoffpauir,POSC-4550,2020
-POSC,4760,1.0,Middle East Politics,0.84,0.11,0.0,0.0,0.0,0%,0.0,0.05,vladimir matic,POSC-4760,2020
-POSC,4770,1.0,Chinese Politics,0.53,0.27,0.0,0.0,0.0,0%,0.0,0.07,xiaobo hu,POSC-4770,2020
-POSC,4890,1.0,Populism,0.69,0.15,0.0,0.0,0.0,0%,0.0,0.15, rhodes-purdy,POSC-4890,2020
-POST,9000,1.0,Prof Development Public P,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,laura olson,POST-9000,2020
-PRTM,1980,1.0,Creative Inquiry in PRTM I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,denise anderson,PRTM-1980,2020
-PRTM,2000,1.0,Profession & Practice in PR,0.86,0.09,0.05,0.0,0.0,0%,0.0,0.0,teresa tucker,PRTM-2000,2020
-PRTM,2000,2.0,Profession & Practice in PR,0.79,0.16,0.05,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,PRTM-2000,2020
-PRTM,2000,3.0,Profession & Practice in PR,0.68,0.26,0.05,0.0,0.0,0%,0.0,0.0,herbert chancellor,PRTM-2000,2020
-PRTM,2000,4.0,Profession & Practice in PR,0.68,0.11,0.0,0.05,0.16,0%,0.0,0.0,jeffrey townsend,PRTM-2000,2020
-PRTM,2000,5.0,Profession & Practice in PR,0.74,0.16,0.0,0.11,0.0,0%,0.0,0.0,thomas ray clanton,PRTM-2000,2020
-PRTM,2060,1.0,Practicum I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,PRTM-2060,2020
-PRTM,2070,1.0,Practicum II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,PRTM-2070,2020
-PRTM,2070,2.0,Practicum II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,adam savedra,PRTM-2070,2020
-PRTM,2110,1.0,Sts Play Rec Tourism,0.84,0.09,0.02,0.0,0.04,0%,0.0,0.01,matthew browning,PRTM-2110,2020
-PRTM,2200,1.0,Foundations of PRTM,0.82,0.14,0.05,0.0,0.0,0%,0.0,0.0,teresa tucker,PRTM-2200,2020
-PRTM,2200,2.0,Foundations of PRTM,0.53,0.42,0.05,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,PRTM-2200,2020
-PRTM,2200,3.0,Foundations of PRTM,0.63,0.32,0.0,0.05,0.0,0%,0.0,0.0,herbert chancellor,PRTM-2200,2020
-PRTM,2200,4.0,Foundations of PRTM,0.37,0.42,0.11,0.05,0.05,0%,0.0,0.0,jeffrey townsend,PRTM-2200,2020
-PRTM,2200,5.0,Foundations of PRTM,0.65,0.29,0.06,0.0,0.0,0%,0.0,0.0,thomas ray clanton,PRTM-2200,2020
-PRTM,2260,1.0,Fnd of Mgt Adm PRTM,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,teresa tucker,PRTM-2260,2020
-PRTM,2260,2.0,Fnd of Mgt Adm PRTM,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,PRTM-2260,2020
-PRTM,2260,3.0,Fnd of Mgt Adm PRTM,0.68,0.21,0.11,0.0,0.0,0%,0.0,0.0,herbert chancellor,PRTM-2260,2020
-PRTM,2260,4.0,Fnd of Mgt Adm PRTM,0.58,0.32,0.0,0.05,0.05,0%,0.0,0.0,jeffrey townsend,PRTM-2260,2020
-PRTM,2260,5.0,Fnd of Mgt Adm PRTM,0.74,0.21,0.05,0.0,0.0,0%,0.0,0.0,thomas ray clanton,PRTM-2260,2020
-PRTM,2290,1.0,Competency Integration in,0.68,0.23,0.09,0.0,0.0,0%,0.0,0.0,teresa tucker,PRTM-2290,2020
-PRTM,2290,2.0,Competency Integration in,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,PRTM-2290,2020
-PRTM,2290,3.0,Competency Integration in,0.63,0.11,0.16,0.11,0.0,0%,0.0,0.0,herbert chancellor,PRTM-2290,2020
-PRTM,2290,4.0,Competency Integration in,0.42,0.37,0.11,0.0,0.11,0%,0.0,0.0,jeffrey townsend,PRTM-2290,2020
-PRTM,2290,5.0,Competency Integration in,0.58,0.26,0.05,0.11,0.0,0%,0.0,0.0,thomas ray clanton,PRTM-2290,2020
-PRTM,3050,1.0,Safety/Risk Mgt PRTM,0.47,0.27,0.2,0.0,0.0,0%,0.0,0.07,alexsandra dubin,PRTM-3050,2020
-PRTM,3070,2.0,Facility Operations,0.77,0.13,0.1,0.0,0.0,0%,0.0,0.0,raymond dunham,PRTM-3070,2020
-PRTM,3200,1.0,Recreation Policy,0.55,0.18,0.09,0.0,0.05,0%,0.0,0.14,matthew brownlee,PRTM-3200,2020
-PRTM,3220,1.0,Facilitation Techniques in,0.71,0.19,0.1,0.0,0.0,0%,0.0,0.0,stephen lewis,PRTM-3220,2020
-PRTM,3240,1.0,Assessment & Planning in,0.48,0.38,0.1,0.05,0.0,0%,0.0,0.0,deborah anne tysor,PRTM-3240,2020
-PRTM,3300,1.0,Visit Ser & Interp,0.42,0.26,0.21,0.05,0.05,0%,0.0,0.0,harper aby lat sene lat,PRTM-3300,2020
-PRTM,3420,1.0,Intro to Tourism,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,ellen wamilika koppa,PRTM-3420,2020
-PRTM,3430,1.0,Spl Asp of Tourist B,0.62,0.33,0.0,0.0,0.0,0%,0.0,0.05,william norman,PRTM-3430,2020
-PRTM,3460,1.0,Heritage Tourism,0.4,0.33,0.13,0.0,0.07,0%,0.0,0.0,gregory ramshaw,PRTM-3460,2020
-PRTM,3470,1.0,Sport Tourism,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,felipe tobar,PRTM-3470,2020
-PRTM,3520,1.0,Camp Org and Admin,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,alexsandra dubin,PRTM-3520,2020
-PRTM,3600,1.0,Recreation & Amateur Spo,0.36,0.18,0.18,0.0,0.09,0%,0.0,0.09,skye arthur-banning,PRTM-3600,2020
-PRTM,3920,1.0,Special Event Managemen,0.96,0.0,0.04,0.0,0.0,0%,0.0,0.0,kenneth backman,PRTM-3920,2020
-PRTM,3920,2.0,Special Event Managemen,0.83,0.1,0.05,0.03,0.0,0%,0.0,0.0,kenneth backman,PRTM-3920,2020
-PRTM,4030,1.0,Elem of Rec/Pk Plan,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,samuel gaines,PRTM-4030,2020
-PRTM,4040,1.0,Field Training I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,PRTM-4040,2020
-PRTM,4050,1.0,Field Training II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,PRTM-4050,2020
-PRTM,4210,1.0,Rec Fin Resc Mgt,0.68,0.21,0.09,0.02,0.0,0%,0.0,0.0,robert brookover,PRTM-4210,2020
-PRTM,4220,2.0,Management of RT Service,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,deborah anne tysor,PRTM-4220,2020
-PRTM,4230,1.0,Adaptive Sports & Recreati,0.56,0.17,0.11,0.11,0.06,0%,0.0,0.0,jasmine townsend,PRTM-4230,2020
-PRTM,4450,1.0,Conventions,0.79,0.14,0.0,0.0,0.0,0%,0.0,0.07,lauren townson,PRTM-4450,2020
-PRTM,4470,1.0,Perspect Intl Travel,0.89,0.0,0.05,0.0,0.0,0%,0.0,0.05,sheila backman,PRTM-4470,2020
-PRTM,4510,1.0,Seminar in CRSCM,0.5,0.3,0.1,0.05,0.03,0%,0.0,0.03,iryna sharaievska,PRTM-4510,2020
-PRTM,4540,1.0,Trends in Sport Mgt,0.75,0.13,0.06,0.0,0.0,0%,0.0,0.06,skye arthur-banning,PRTM-4540,2020
-PRTM,4550,1.0,Adv Program Planning,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,mariela fernandez,PRTM-4550,2020
-PRTM,4740,2.0,Adv Rec Resource Mgt,0.81,0.05,0.14,0.0,0.0,0%,0.0,0.0,benjamin fowler,PRTM-4740,2020
-PRTM,8070,3.0,Human Dimen of Rec Beha,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,john adam beeco,PRTM-8070,2020
-PRTM,8080,2.0,Behavioral Aspects,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,lauren duffy,PRTM-8080,2020
-PRTM,8710,1.0,Applied Research in Rec Th,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,brandi crowe,PRTM-8710,2020
-PRTM,8720,1.0,Adv Facilitation Techniq in,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,brandi crowe,PRTM-8720,2020
-PRTM,8750,1.0,Program Plan & Consult in,0.64,0.27,0.0,0.0,0.0,0%,0.0,0.0,stephen lewis,PRTM-8750,2020
-PRTM,9000,11.0,Adv Data Analysis in PRTM,0.5,0.38,0.0,0.0,0.0,0%,0.0,0.13,ryan joseph gagnon,PRTM-9000,2020
-PRTM,9100,1.0,Research Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brett wright,PRTM-9100,2020
-PRTM,9110,2.0,Classroom Management,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gwynn powell,PRTM-9110,2020
-PSYC,2010,1.0,Intro to Psychology,0.33,0.34,0.19,0.03,0.01,0%,0.0,0.06,jo jorgensen,PSYC-2010,2020
-PSYC,2010,2.0,Intro to Psychology,0.28,0.33,0.21,0.08,0.03,0%,0.0,0.03,jo jorgensen,PSYC-2010,2020
-PSYC,2010,3.0,Intro to Psychology,0.25,0.33,0.22,0.06,0.06,0%,0.0,0.08,edwin brainerd,PSYC-2010,2020
-PSYC,2010,4.0,Intro to Psychology,0.77,0.19,0.04,0.0,0.0,0%,0.0,0.0,mary taylor,PSYC-2010,2020
-PSYC,2010,5.0,Intro to Psychology,0.63,0.27,0.03,0.01,0.04,0%,0.0,0.02,chong hyon pak,PSYC-2010,2020
-PSYC,2010,6.0,Intro to Psychology,0.66,0.19,0.08,0.05,0.02,0%,0.0,0.0,chong hyon pak,PSYC-2010,2020
-PSYC,2010,7.0,Intro to Psychology,0.51,0.33,0.09,0.03,0.01,0%,0.0,0.03,fred switzer,PSYC-2010,2020
-PSYC,2030,1.0,Fundamentals of Psych Sci,0.62,0.25,0.07,0.03,0.02,0%,0.0,0.02,fred switzer,PSYC-2030,2020
-PSYC,3060,1.0,Human Sexual Behavior,0.58,0.22,0.11,0.03,0.03,0%,0.0,0.03,bruce michael king,PSYC-3060,2020
-PSYC,3090,100.0,Intro Experimental Psychol,0.44,0.38,0.13,0.02,0.01,0%,0.0,0.03,jennifer bailey bisson,PSYC-3090,2020
-PSYC,3090,200.0,Intro Experimental Psychol,0.16,0.53,0.28,0.0,0.0,0%,0.0,0.03,eric mckibben,PSYC-3090,2020
-PSYC,3090,300.0,Intro Experimental Psychol,0.48,0.39,0.1,0.0,0.0,0%,0.0,0.03,alexander moore,PSYC-3090,2020
-PSYC,3100,100.0,Advanced Experimental Ps,0.71,0.21,0.03,0.03,0.03,0%,0.0,0.0,peggy jean tyler,PSYC-3100,2020
-PSYC,3100,220.0,Advanced Experimental Ps,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,thomas britt,PSYC-3100,2020
-PSYC,3100,230.0,Advanced Experimental Ps,0.68,0.26,0.05,0.0,0.0,0%,0.0,0.0,william volante,PSYC-3100,2020
-PSYC,3100,240.0,Advanced Experimental Ps,0.42,0.37,0.16,0.0,0.05,0%,0.0,0.0,william volante,PSYC-3100,2020
-PSYC,3100,250.0,Advanced Experimental Ps,0.57,0.33,0.05,0.0,0.0,0%,0.0,0.05,sarah mae sanborn,PSYC-3100,2020
-PSYC,3100,260.0,Advanced Experimental Ps,0.37,0.53,0.05,0.0,0.0,0%,0.0,0.0,leo gugerty,PSYC-3100,2020
-PSYC,3100,270.0,Advanced Experimental Ps,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,benjamin stephens,PSYC-3100,2020
-PSYC,3100,280.0,Advanced Experimental Ps,0.74,0.16,0.11,0.0,0.0,0%,0.0,0.0,martha thompson,PSYC-3100,2020
-PSYC,3100,290.0,Advanced Experimental Ps,0.42,0.42,0.0,0.11,0.0,0%,0.0,0.0,kaileigh angela byrne,PSYC-3100,2020
-PSYC,3210,1.0,Psychology of Music,0.52,0.2,0.24,0.04,0.0,0%,0.0,0.0,claudio cantalupo,PSYC-3210,2020
-PSYC,3240,1.0,Physiological Psych,0.64,0.19,0.09,0.03,0.04,0%,0.0,0.01,claudio cantalupo,PSYC-3240,2020
-PSYC,3240,2.0,Physiological Psych,0.5,0.31,0.09,0.04,0.04,0%,0.0,0.01,claudio cantalupo,PSYC-3240,2020
-PSYC,3240,3.0,Physiological Psych,0.53,0.31,0.1,0.03,0.02,0%,0.0,0.0,claudio cantalupo,PSYC-3240,2020
-PSYC,3240,4.0,Physiological Psych,0.43,0.38,0.1,0.01,0.01,0%,0.0,0.06,june pilcher,PSYC-3240,2020
-PSYC,3330,1.0,Cognitive Psych,0.55,0.32,0.06,0.04,0.03,0%,0.0,0.0,dawn marie sarno,PSYC-3330,2020
-PSYC,3330,2.0,Cognitive Psych,0.63,0.23,0.08,0.03,0.03,0%,0.0,0.0,kathryn lucaites,PSYC-3330,2020
-PSYC,3340,1.0,Cognitive Psych Lab,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,hannah solini,PSYC-3340,2020
-PSYC,3340,2.0,Cognitive Psych Lab,0.76,0.19,0.0,0.0,0.0,0%,0.0,0.0,hannah solini,PSYC-3340,2020
-PSYC,3400,1.0,Lifespan Developmental Ps,0.38,0.39,0.16,0.01,0.03,0%,0.0,0.03,pamela alley,PSYC-3400,2020
-PSYC,3400,2.0,Lifespan Developmental Ps,0.33,0.43,0.11,0.09,0.02,0%,0.0,0.02,pamela alley,PSYC-3400,2020
-PSYC,3400,3.0,Lifespan Developmental Ps,0.73,0.17,0.08,0.01,0.0,0%,0.0,0.01,sarah mae sanborn,PSYC-3400,2020
-PSYC,3520,1.0,Social Psychology,0.88,0.09,0.02,0.01,0.0,0%,0.0,0.0,ceren gunsoy,PSYC-3520,2020
-PSYC,3520,902.0,Social Psychology (HON),0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,robin marie kowalski,PSYC-3520,2020
-PSYC,3570,1.0,Psychology and Culture,0.73,0.17,0.06,0.02,0.01,0%,0.0,0.0,ceren gunsoy,PSYC-3570,2020
-PSYC,3640,1.0,Industrial Psych,0.43,0.46,0.07,0.04,0.0,0%,0.0,0.0,eric mckibben,PSYC-3640,2020
-PSYC,3640,2.0,Industrial Psych,0.75,0.12,0.06,0.0,0.06,0%,0.0,0.01,joseph ligato,PSYC-3640,2020
-PSYC,3680,1.0,Organizational Psych,0.45,0.51,0.02,0.0,0.02,0%,0.0,0.0,chloe wilson,PSYC-3680,2020
-PSYC,3700,1.0,Personality,0.54,0.34,0.1,0.0,0.03,0%,0.0,0.0,john robert hester,PSYC-3700,2020
-PSYC,3830,1.0,Abnormal Psychology,0.38,0.41,0.12,0.09,0.0,0%,0.0,0.0,pamela alley,PSYC-3830,2020
-PSYC,3830,2.0,Abnormal Psychology,0.43,0.23,0.14,0.11,0.06,0%,0.0,0.03,pamela alley,PSYC-3830,2020
-PSYC,3890,1.0,Psychology of Religion,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,zhuo chen,PSYC-3890,2020
-PSYC,4080,901.0,Women and Psychology,0.64,0.2,0.08,0.0,0.04,0%,0.0,0.04,robin marie kowalski,PSYC-4080,2020
-PSYC,4150,1.0,Systems and Theories,0.51,0.31,0.11,0.03,0.0,0%,0.0,0.03,edwin brainerd,PSYC-4150,2020
-PSYC,4150,2.0,Systems and Theories,0.5,0.25,0.08,0.08,0.06,0%,0.0,0.03,edwin brainerd,PSYC-4150,2020
-PSYC,4220,1.0,Perception,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,christopher pagano,PSYC-4220,2020
-PSYC,4350,1.0,Human Factors,0.3,0.48,0.04,0.0,0.0,0%,0.0,0.13,dustin souders,PSYC-4350,2020
-PSYC,4430,1.0,Infant & Child Dev,0.71,0.26,0.03,0.0,0.0,0%,0.0,0.0,sarah mae sanborn,PSYC-4430,2020
-PSYC,4800,1.0,Health Psychology,0.65,0.31,0.04,0.0,0.0,0%,0.0,0.0,james mccubbin,PSYC-4800,2020
-PSYC,4800,2.0,Health Psychology,0.8,0.16,0.04,0.0,0.0,0%,0.0,0.0,james mccubbin,PSYC-4800,2020
-PSYC,4820,1.0,Positive Psychology,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,cynthia pury s,PSYC-4820,2020
-PSYC,4880,1.0,Psychotherapy,0.6,0.12,0.12,0.0,0.0,0%,0.0,0.08,heidi marie zinzow,PSYC-4880,2020
-PSYC,4890,1.0,Sport Psychology,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,eric mckibben,PSYC-4890,2020
-PSYC,4890,2.0,Cross-Cultural Human Dev,0.55,0.23,0.09,0.09,0.0,0%,0.0,0.0,susan limber,PSYC-4890,2020
-PSYC,4930,100.0,Pract Clinical Psych,0.81,0.06,0.0,0.0,0.0,0%,0.0,0.13,lucinda quick,PSYC-4930,2020
-PSYC,4930,200.0,Pract Clinical Psych,0.88,0.06,0.0,0.0,0.06,0%,0.0,0.0,heidi marie zinzow,PSYC-4930,2020
-PSYC,4970,919.0,Directed Studies,0.89,0.02,0.0,0.0,0.0,0%,0.0,0.05,karyn jones,PSYC-4970,2020
-PSYC,8100,1.0,Research Design I,0.76,0.21,0.0,0.0,0.0,0%,0.0,0.03,patrick rosopa,PSYC-8100,2020
-PSYC,8220,1.0,Percept & Perform,0.75,0.19,0.0,0.0,0.0,0%,0.0,0.06,richard tyrrell,PSYC-8220,2020
-RED,8010,1.0,Market Analysis,0.67,0.22,0.06,0.0,0.0,0%,0.0,0.06,robert benedict,RED-8010,2020
-RED,8020,1.0,Development Tour,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert benedict,RED-8020,2020
-RED,8100,1.0,Real Est Roundtable,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,robert benedict,RED-8100,2020
-RED,8130,1.0,Strat in Real Estate,0.62,0.31,0.08,0.0,0.0,0%,0.0,0.0,kimbrell cary hughes,RED-8130,2020
-RED,8890,1.0,Selected Topics-Adv. Fin.,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,larry bradley harvey,RED-8890,2020
-REL,1010,1.0,Intro to Religion,0.58,0.32,0.0,0.05,0.05,0%,0.0,0.0,peter cohen,REL-1010,2020
-REL,1010,2.0,Intro to Religion,0.45,0.41,0.05,0.0,0.09,0%,0.0,0.0,peter cohen,REL-1010,2020
-REL,1010,3.0,Intro to Religion,0.79,0.18,0.0,0.0,0.03,0%,0.0,0.0,peter cohen,REL-1010,2020
-REL,1020,2.0,World Religions,0.56,0.29,0.12,0.03,0.0,0%,0.0,0.0,robert stephens,REL-1020,2020
-REL,1020,3.0,World Religions,0.51,0.26,0.14,0.0,0.0,0%,0.0,0.09,robert stephens,REL-1020,2020
-REL,1020,4.0,World Religions,0.47,0.5,0.03,0.0,0.0,0%,0.0,0.0,robert stephens,REL-1020,2020
-REL,3010,1.0,Old Testament,0.56,0.21,0.12,0.03,0.0,0%,0.0,0.09,john thames,REL-3010,2020
-REL,3060,1.0,Judaism,0.52,0.21,0.07,0.0,0.0,0%,0.0,0.21,john thames,REL-3060,2020
-REL,3070,1.0,The Christian Tradition,0.34,0.52,0.14,0.0,0.0,0%,0.0,0.0,brett patterson,REL-3070,2020
-REL,3100,1.0,History of Religion in the U,0.5,0.33,0.11,0.0,0.06,0%,0.0,0.0,elizabeth jemison,REL-3100,2020
-REL,3110,1.0,African American Rel,0.54,0.17,0.13,0.0,0.0,0%,0.0,0.13,elizabeth jemison,REL-3110,2020
-REL,3120,1.0,Hinduism,0.29,0.29,0.14,0.14,0.0,0%,0.0,0.14,robert stephens,REL-3120,2020
-REL,4210,1.0,Koine Greek of the New Te,0.5,0.0,0.13,0.19,0.13,0%,0.0,0.06,benjamin white,REL-4210,2020
-RUD,8610,1.0,Urban Design Seminar I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0, wortham-galvin,RUD-8610,2020
-RUSS,3400,1.0,19th C Russ Culture,0.58,0.29,0.08,0.0,0.0,0%,0.0,0.0,olga volkova,RUSS-3400,2020
-RUSS,3610,1.0,Russn Lit Since 1910,0.52,0.35,0.13,0.0,0.0,0%,0.0,0.0,olga volkova,RUSS-3610,2020
-SOC,2010,1.0,Introduction to Sociology,0.8,0.17,0.01,0.0,0.01,0%,0.0,0.02,carolyn coffman,SOC-2010,2020
-SOC,2010,2.0,Introduction to Sociology,0.58,0.34,0.08,0.0,0.0,0%,0.0,0.0,jennifer holland,SOC-2010,2020
-SOC,2010,3.0,Introduction to Sociology,0.8,0.18,0.01,0.0,0.01,0%,0.0,0.0,carolyn coffman,SOC-2010,2020
-SOC,2010,4.0,Introduction to Sociology,0.9,0.08,0.01,0.0,0.0,0%,0.0,0.01, mannheimer,SOC-2010,2020
-SOC,2010,5.0,Introduction to Sociology,0.77,0.15,0.04,0.02,0.02,0%,0.0,0.0, mcdonough,SOC-2010,2020
-SOC,2010,6.0,Introduction to Sociology,0.75,0.16,0.05,0.02,0.01,0%,0.0,0.02, mcdonough,SOC-2010,2020
-SOC,2010,7.0,Introduction to Sociology,0.8,0.1,0.04,0.0,0.02,0%,0.0,0.04,thomas maher,SOC-2010,2020
-SOC,2040,1.0,Prof Dev for Sociology Maj,0.35,0.26,0.13,0.09,0.13,0%,0.0,0.04, catherine mobley,SOC-2040,2020
-SOC,3020,1.0,Research Methods I,0.59,0.23,0.07,0.05,0.02,0%,0.0,0.05,thomas maher,SOC-3020,2020
-SOC,3020,2.0,Research Methods I,0.32,0.5,0.11,0.03,0.03,0%,0.0,0.03,miao li,SOC-3020,2020
-SOC,3040,1.0,Social Research Methods II,0.28,0.38,0.1,0.1,0.07,0%,0.0,0.07,ye luo,SOC-3040,2020
-SOC,3040,2.0,Social Research Methods II,0.33,0.56,0.11,0.0,0.0,0%,0.0,0.0,william haller,SOC-3040,2020
-SOC,3110,1.0,The Family,0.84,0.1,0.04,0.0,0.02,0%,0.0,0.0,carolyn coffman,SOC-3110,2020
-SOC,3600,1.0,Class & Poverty,0.57,0.28,0.09,0.04,0.0,0%,0.0,0.02,kenneth robinson,SOC-3600,2020
-SOC,3910,1.0,Soc of Deviance,0.58,0.29,0.05,0.04,0.02,0%,0.0,0.02, mcdonough,SOC-3910,2020
-SOC,3940,1.0,Sociology of Mental Illness,0.88,0.04,0.0,0.0,0.0,0%,0.0,0.02,james rosenberger,SOC-3940,2020
-SOC,4030,1.0,Environmental Sociology,0.5,0.33,0.08,0.04,0.0,0%,0.0,0.04, catherine mobley,SOC-4030,2020
-SOC,4040,1.0,Soc Theory,0.44,0.33,0.11,0.06,0.06,0%,0.0,0.0,matthew costello,SOC-4040,2020
-SOC,4140,1.0,Policy&Social Change,0.6,0.31,0.1,0.0,0.0,0%,0.0,0.0,jennifer holland,SOC-4140,2020
-SOC,4440,1.0,Sociology of Educ,0.73,0.16,0.02,0.0,0.02,0%,0.0,0.02, mannheimer,SOC-4440,2020
-SOC,4600,1.0,Race & Ethnicity,0.86,0.08,0.06,0.0,0.0,0%,0.0,0.0, mannheimer,SOC-4600,2020
-SOC,4610,1.0,Sex & Gender,0.67,0.24,0.03,0.0,0.03,0%,0.0,0.03,carolyn coffman,SOC-4610,2020
-SOC,4710,1.0,World Population and Soci,0.43,0.36,0.0,0.07,0.0,0%,0.0,0.14,ye luo,SOC-4710,2020
-SOC,8120,1.0,Social Stratification,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.1,william haller,SOC-8120,2020
-SOC,8970,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,natallia sianko,SOC-8970,2020
-SPAN,1010,1.0,Elementary Spanish,0.71,0.25,0.04,0.0,0.0,0%,0.0,0.0,stephanie morris,SPAN-1010,2020
-SPAN,1010,2.0,Elementary Spanish,0.71,0.21,0.08,0.0,0.0,0%,0.0,0.0,stephanie morris,SPAN-1010,2020
-SPAN,1010,3.0,Elementary Spanish,0.42,0.29,0.17,0.04,0.0,0%,0.0,0.08,rosa pillcurima,SPAN-1010,2020
-SPAN,1020,1.0,Elementary Spanish,0.39,0.43,0.13,0.0,0.0,0%,0.0,0.04,rosa pillcurima,SPAN-1020,2020
-SPAN,1020,2.0,Elementary Spanish,0.48,0.35,0.04,0.0,0.0,0%,0.0,0.13,debra williamson,SPAN-1020,2020
-SPAN,1020,3.0,Elementary Spanish,0.48,0.3,0.17,0.0,0.04,0%,0.0,0.0,yezid flores,SPAN-1020,2020
-SPAN,1020,4.0,Elementary Spanish,0.58,0.33,0.04,0.0,0.04,0%,0.0,0.0,yezid flores,SPAN-1020,2020
-SPAN,1020,5.0,Elementary Spanish,0.86,0.0,0.0,0.0,0.0,0%,0.0,0.14,liliana hernandez,SPAN-1020,2020
-SPAN,1020,6.0,Elementary Spanish,0.27,0.53,0.13,0.07,0.0,0%,0.0,0.0,valderramos cruz,SPAN-1020,2020
-SPAN,1020,8.0,Elementary Spanish,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,valderramos cruz,SPAN-1020,2020
-SPAN,1020,9.0,Elementary Spanish,0.52,0.43,0.05,0.0,0.0,0%,0.0,0.0,yezid flores,SPAN-1020,2020
-SPAN,1020,10.0,Elementary Spanish,0.86,0.09,0.05,0.0,0.0,0%,0.0,0.0,liliana hernandez,SPAN-1020,2020
-SPAN,1020,13.0,Elementary Spanish,0.26,0.43,0.17,0.09,0.0,0%,0.0,0.04,melva persico,SPAN-1020,2020
-SPAN,2010,1.0,Intermediate Spanish,0.45,0.32,0.05,0.0,0.05,0%,0.0,0.14,debra williamson,SPAN-2010,2020
-SPAN,2010,2.0,Intermediate Spanish,0.48,0.43,0.05,0.0,0.0,0%,0.0,0.05,debra williamson,SPAN-2010,2020
-SPAN,2010,3.0,Intermediate Spanish,0.71,0.04,0.17,0.04,0.0,0%,0.0,0.04,ellory schmucker,SPAN-2010,2020
-SPAN,2010,4.0,Intermediate Spanish,0.65,0.26,0.0,0.0,0.09,0%,0.0,0.0,ellory schmucker,SPAN-2010,2020
-SPAN,2010,7.0,Intermediate Spanish,0.67,0.13,0.13,0.04,0.0,0%,0.0,0.04,ellory schmucker,SPAN-2010,2020
-SPAN,2010,8.0,Intermediate Spanish,0.57,0.33,0.05,0.0,0.0,0%,0.0,0.05,debra williamson,SPAN-2010,2020
-SPAN,2010,9.0,Intermediate Spanish,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,liliana hernandez,SPAN-2010,2020
-SPAN,2010,10.0,Intermediate Spanish,0.5,0.46,0.04,0.0,0.0,0%,0.0,0.0,vieyra daniel garcia,SPAN-2010,2020
-SPAN,2010,11.0,Intermediate Spanish,0.43,0.43,0.04,0.0,0.0,0%,0.0,0.09,vieyra daniel garcia,SPAN-2010,2020
-SPAN,2010,12.0,Intermediate Spanish,0.75,0.13,0.04,0.04,0.0,0%,0.0,0.04,ellory schmucker,SPAN-2010,2020
-SPAN,2010,13.0,Intermediate Spanish,0.79,0.08,0.08,0.0,0.04,0%,0.0,0.0,liliana hernandez,SPAN-2010,2020
-SPAN,2010,14.0,Intermediate Spanish,0.55,0.18,0.0,0.0,0.09,0%,0.0,0.18,valderramos cruz,SPAN-2010,2020
-SPAN,2010,15.0,Intermediate Spanish,0.61,0.3,0.04,0.0,0.0,0%,0.0,0.04,valderramos cruz,SPAN-2010,2020
-SPAN,2010,16.0,Intermediate Spanish,0.57,0.26,0.09,0.0,0.0,0%,0.0,0.09,yezid flores,SPAN-2010,2020
-SPAN,2010,17.0,Intermediate Spanish,0.37,0.37,0.26,0.0,0.0,0%,0.0,0.0,nora arostegui logue,SPAN-2010,2020
-SPAN,2010,18.0,Intermediate Spanish,0.57,0.3,0.04,0.04,0.0,0%,0.0,0.04,nora arostegui logue,SPAN-2010,2020
-SPAN,2010,28.0,Intermediate Spanish,0.4,0.4,0.1,0.1,0.0,0%,0.0,0.0,yezid flores,SPAN-2010,2020
-SPAN,2020,2.0,Intermediate Spanish,0.35,0.25,0.15,0.05,0.1,0%,0.0,0.1,melva persico,SPAN-2020,2020
-SPAN,2020,4.0,Intermediate Spanish,0.52,0.22,0.17,0.04,0.0,0%,0.0,0.04,rodriguez garcia,SPAN-2020,2020
-SPAN,2020,5.0,Intermediate Spanish,0.83,0.08,0.04,0.0,0.04,0%,0.0,0.0,mercedes tejera,SPAN-2020,2020
-SPAN,2020,6.0,Intermediate Spanish,0.5,0.25,0.04,0.0,0.0,0%,0.0,0.21,rosa pillcurima,SPAN-2020,2020
-SPAN,2020,7.0,Intermediate Spanish,0.63,0.21,0.0,0.08,0.0,0%,0.0,0.08,rosa pillcurima,SPAN-2020,2020
-SPAN,2020,8.0,Intermediate Spanish,0.5,0.35,0.1,0.05,0.0,0%,0.0,0.0,ana paula  miller e,SPAN-2020,2020
-SPAN,2020,9.0,Intermediate Spanish,0.33,0.33,0.24,0.0,0.0,0%,0.0,0.1,ana paula  miller e,SPAN-2020,2020
-SPAN,2020,10.0,Intermediate Spanish,0.62,0.19,0.1,0.0,0.0,0%,0.0,0.1,ana paula  miller e,SPAN-2020,2020
-SPAN,2020,11.0,Intermediate Spanish,0.43,0.33,0.05,0.1,0.0,0%,0.0,0.1,melva persico,SPAN-2020,2020
-SPAN,2020,13.0,Intermediate Spanish,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,nora arostegui logue,SPAN-2020,2020
-SPAN,2020,14.0,Intermediate Spanish,0.58,0.33,0.0,0.0,0.08,0%,0.0,0.0,nora arostegui logue,SPAN-2020,2020
-SPAN,2020,15.0,Intermediate Spanish,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,mercedes tejera,SPAN-2020,2020
-SPAN,2020,16.0,Intermediate Spanish,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,mercedes tejera,SPAN-2020,2020
-SPAN,3020,1.0,Intermed Span Grammar,0.41,0.41,0.09,0.0,0.0,0%,0.0,0.09,vieyra daniel garcia,SPAN-3020,2020
-SPAN,3020,2.0,Intermed Span Grammar,0.68,0.18,0.0,0.0,0.0,0%,0.0,0.14,george palacios,SPAN-3020,2020
-SPAN,3020,3.0,Intermed Span Grammar,0.67,0.17,0.0,0.0,0.04,0%,0.0,0.13,vieyra daniel garcia,SPAN-3020,2020
-SPAN,3020,4.0,Intermed Span Grammar,0.29,0.57,0.07,0.0,0.07,0%,0.0,0.0,melva persico,SPAN-3020,2020
-SPAN,3040,1.0,Intro Hispanic Literary For,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,graciela tissera,SPAN-3040,2020
-SPAN,3040,2.0,Intro Hispanic Literary For,0.42,0.33,0.17,0.08,0.0,0%,0.0,0.0,rodriguez garcia,SPAN-3040,2020
-SPAN,3050,1.0,Intermed Span Convers/Co,0.32,0.47,0.16,0.0,0.0,0%,0.0,0.05,rodriguez garcia,SPAN-3050,2020
-SPAN,3050,2.0,Intermed Span Convers/Co,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,andrea naranjo,SPAN-3050,2020
-SPAN,3050,3.0,Intermed Span Convers/Co,0.61,0.09,0.04,0.0,0.0,0%,0.0,0.26,vieyra daniel garcia,SPAN-3050,2020
-SPAN,3060,1.0,Span Comp for Bus,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,andrea naranjo,SPAN-3060,2020
-SPAN,3070,1.0,The Hispanic World: Spain,0.74,0.16,0.0,0.0,0.05,0%,0.0,0.05,raquel anido,SPAN-3070,2020
-SPAN,3080,1.0,The Hispanic World: Latin,0.7,0.09,0.09,0.0,0.09,0%,0.0,0.0,george palacios,SPAN-3080,2020
-SPAN,3130,1.0,Span Lit Survey I,0.28,0.44,0.17,0.0,0.0,0%,0.0,0.11, rojas-de-massei,SPAN-3130,2020
-SPAN,3140,1.0,Hispanic Linguistics,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,daniel smith,SPAN-3140,2020
-SPAN,3150,2.0,Spanish for Health Prof,0.86,0.1,0.05,0.0,0.0,0%,0.0,0.0,riquelme judez,SPAN-3150,2020
-SPAN,3180,1.0,Spanish Through Culture,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,salvador oropesa,SPAN-3180,2020
-SPAN,4010,1.0,New Spanish Fiction,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,graciela tissera,SPAN-4010,2020
-SPAN,4060,1.0,Narrative Fiction,0.33,0.47,0.07,0.07,0.0,0%,0.0,0.07, rojas-de-massei,SPAN-4060,2020
-SPAN,4070,1.0,Hispanic Film,0.8,0.12,0.0,0.04,0.04,0%,0.0,0.0,raquel anido,SPAN-4070,2020
-SPAN,4160,1.0,Spanish for Int'l Business II,0.73,0.09,0.0,0.0,0.18,0%,0.0,0.0,andrea naranjo,SPAN-4160,2020
-SPAN,4190,1.0,Health & Hispanic Commu,0.7,0.25,0.0,0.0,0.0,0%,0.0,0.05,peralta arelis moore,SPAN-4190,2020
-STAT,2220,1.0,Statistics in Everyday Life,0.33,0.23,0.23,0.12,0.04,0%,0.0,0.05,james espey,STAT-2220,2020
-STAT,2220,2.0,Statistics in Everyday Life,0.25,0.41,0.23,0.05,0.02,0%,0.0,0.04,james espey,STAT-2220,2020
-STAT,2220,3.0,Statistics in Everyday Life,0.29,0.34,0.16,0.12,0.08,0%,0.0,0.03,james espey,STAT-2220,2020
-STAT,2220,4.0,Statistics in Everyday Life,0.24,0.43,0.23,0.09,0.01,0%,0.0,0.0,james espey,STAT-2220,2020
-STAT,2220,5.0,Statistics in Everyday Life,0.19,0.32,0.29,0.14,0.06,0%,0.0,0.0, martinez-dawson,STAT-2220,2020
-STAT,2220,6.0,Statistics in Everyday Life,0.24,0.39,0.2,0.09,0.05,0%,0.0,0.04, martinez-dawson,STAT-2220,2020
-STAT,2220,7.0,Statistics in Everyday Life,0.3,0.24,0.28,0.1,0.05,0%,0.0,0.04, martinez-dawson,STAT-2220,2020
-STAT,2300,1.0,Statistical Methods I,0.2,0.23,0.27,0.15,0.15,0%,0.0,0.0,anna marie vagnozzi,STAT-2300,2020
-STAT,2300,2.0,Statistical Methods I,0.33,0.34,0.17,0.08,0.03,0%,0.0,0.04,paran norton,STAT-2300,2020
-STAT,2300,3.0,Statistical Methods I,0.39,0.3,0.15,0.07,0.05,0%,0.0,0.03,paran norton,STAT-2300,2020
-STAT,2300,4.0,Statistical Methods I,0.28,0.26,0.24,0.07,0.1,0%,0.0,0.05, erwin walker,STAT-2300,2020
-STAT,2300,5.0,Statistical Methods I,0.23,0.4,0.19,0.09,0.06,0%,0.0,0.03, erwin walker,STAT-2300,2020
-STAT,2300,6.0,Statistical Methods I,0.31,0.3,0.2,0.08,0.04,0%,0.0,0.07,thomas demarco,STAT-2300,2020
-STAT,2300,100.0,Statistical Methods I (HON,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,paran norton,STAT-2300,2020
-STAT,3090,1.0,Introductory Business Stat,0.23,0.3,0.35,0.0,0.09,0%,0.0,0.02,fun choi john chan john,STAT-3090,2020
-STAT,3090,2.0,Introductory Business Stat,0.22,0.33,0.26,0.13,0.02,0%,0.0,0.04,trevor camper,STAT-3090,2020
-STAT,3090,3.0,Introductory Business Stat,0.62,0.22,0.09,0.04,0.0,0%,0.0,0.02,anna marie vagnozzi,STAT-3090,2020
-STAT,3090,4.0,Introductory Business Stat,0.44,0.36,0.16,0.0,0.02,0%,0.0,0.02, jayasekara,STAT-3090,2020
-STAT,3090,5.0,Introductory Business Stat,0.41,0.17,0.26,0.09,0.04,0%,0.0,0.02,tyler melton,STAT-3090,2020
-STAT,3090,6.0,Introductory Business Stat,0.37,0.28,0.17,0.07,0.04,0%,0.0,0.07,sean ingimarson,STAT-3090,2020
-STAT,3090,7.0,Introductory Business Stat,0.35,0.24,0.24,0.04,0.09,0%,0.0,0.04,yangyi li,STAT-3090,2020
-STAT,3090,8.0,Introductory Business Stat,0.34,0.22,0.22,0.1,0.1,0%,0.0,0.02,seyed hamid nazari,STAT-3090,2020
-STAT,3090,9.0,Introductory Business Stat,0.42,0.18,0.11,0.13,0.09,0%,0.0,0.07,na guo,STAT-3090,2020
-STAT,3090,10.0,Introductory Business Stat,0.29,0.29,0.27,0.11,0.02,0%,0.0,0.02,na guo,STAT-3090,2020
-STAT,3090,11.0,Introductory Business Stat,0.42,0.31,0.2,0.04,0.02,0%,0.0,0.0,tiantian yang,STAT-3090,2020
-STAT,3090,12.0,Introductory Business Stat,0.28,0.31,0.21,0.05,0.1,0%,0.0,0.05,marwah soliman,STAT-3090,2020
-STAT,3090,13.0,Introductory Business Stat,0.42,0.2,0.3,0.02,0.04,0%,0.0,0.02,april thomas,STAT-3090,2020
-STAT,3090,14.0,Introductory Business Stat,0.48,0.36,0.14,0.0,0.0,0%,0.0,0.02,april thomas,STAT-3090,2020
-STAT,3090,15.0,Introductory Business Stat,0.33,0.28,0.12,0.05,0.14,0%,0.0,0.09,marwah soliman,STAT-3090,2020
-STAT,3090,16.0,Introductory Business Stat,0.52,0.24,0.15,0.02,0.04,0%,0.0,0.02,anna marie vagnozzi,STAT-3090,2020
-STAT,3090,17.0,Introductory Business Stat,0.37,0.37,0.21,0.0,0.02,0%,0.0,0.02,molly honecker,STAT-3090,2020
-STAT,3090,18.0,Introductory Business Stat,0.29,0.4,0.2,0.02,0.04,0%,0.0,0.04,shuai wei,STAT-3090,2020
-STAT,3090,19.0,Introductory Business Stat,0.37,0.29,0.18,0.02,0.06,0%,0.0,0.06,caroline kerfonta,STAT-3090,2020
-STAT,3090,20.0,Introductory Business Stat,0.6,0.14,0.18,0.02,0.02,0%,0.0,0.04,zhengxin wang,STAT-3090,2020
-STAT,3090,21.0,Introductory Business Stat,0.43,0.19,0.24,0.12,0.02,0%,0.0,0.0,anna marie vagnozzi,STAT-3090,2020
-STAT,3300,1.0,Statistical Methods II,0.35,0.3,0.25,0.05,0.0,0%,0.0,0.05, martinez-dawson,STAT-3300,2020
-STAT,4020,401.0,Intro to Statistical Computi,0.67,0.14,0.0,0.0,0.0,0%,0.0,0.19,ellen hepfer breazel,STAT-4020,2020
-STAT,4020,402.0,Intro to Statistical Computi,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,zhiyun gong,STAT-4020,2020
-STAT,4110,1.0,Stat Mthds for Process Co,0.58,0.37,0.0,0.05,0.0,0%,0.0,0.0,na guo,STAT-4110,2020
-STAT,4110,2.0,Stat Mthds for Process Co,0.72,0.25,0.0,0.03,0.0,0%,0.0,0.0,na guo,STAT-4110,2020
-STAT,4110,3.0,Stat Mthds for Process Co,0.58,0.33,0.09,0.0,0.0,0%,0.0,0.0,william bridges,STAT-4110,2020
-STAT,4110,4.0,Stat Mthds for Process Co,0.44,0.13,0.28,0.0,0.06,0%,0.0,0.09,yu-bo wang,STAT-4110,2020
-STAT,4110,5.0,Stat Mthds for Process Co,0.38,0.34,0.24,0.0,0.0,0%,0.0,0.03,yu-bo wang,STAT-4110,2020
-STAT,6020,401.0,Intro to Statistical Computi,0.62,0.23,0.15,0.0,0.0,0%,0.0,0.0,ellen hepfer breazel,STAT-6020,2020
-STAT,8010,1.0,Statistical Methods I,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,joseph daniel bible,STAT-8010,2020
-STAT,8010,2.0,Statistical Methods I,0.48,0.43,0.05,0.0,0.05,0%,0.0,0.0,joseph daniel bible,STAT-8010,2020
-STAT,8010,3.0,Statistical Methods I,0.68,0.18,0.14,0.0,0.0,0%,0.0,0.0,brook thayer russell,STAT-8010,2020
-STAT,8010,4.0,Statistical Methods I,0.85,0.05,0.05,0.0,0.0,0%,0.0,0.05,jun luo,STAT-8010,2020
-STAT,8010,5.0,Statistical Methods I,0.5,0.27,0.18,0.0,0.0,0%,0.0,0.0,patrick gerard,STAT-8010,2020
-STAT,8020,1.0,Statistical Methods II,0.94,0.03,0.03,0.0,0.0,0%,0.0,0.0,whitney huang,STAT-8020,2020
-STAT,8030,1.0,Regress & Least Squares A,0.75,0.08,0.08,0.0,0.0,0%,0.0,0.08,jun luo,STAT-8030,2020
-STAT,8050,1.0,Design & Anlys of Experim,0.61,0.36,0.0,0.0,0.04,0%,0.0,0.0,william bridges,STAT-8050,2020
-STS,1010,1.0,Survey Sci & Techn in Soci,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.03,yang wu,STS-1010,2020
-STS,1010,2.0,Survey Sci & Techn in Soci,0.58,0.36,0.03,0.0,0.03,0%,0.0,0.0,scott brame,STS-1010,2020
-STS,1010,3.0,Survey Sci & Techn in Soci,0.69,0.23,0.09,0.0,0.0,0%,0.0,0.0,elizabeth stansell,STS-1010,2020
-STS,1010,4.0,Survey Sci & Techn in Soci,0.85,0.06,0.0,0.0,0.06,0%,0.0,0.03,mary katherine fidler,STS-1010,2020
-STS,1010,5.0,Survey Sci & Techn in Soci,0.78,0.17,0.03,0.0,0.03,0%,0.0,0.0,tareva johnson,STS-1010,2020
-STS,1010,7.0,Survey Sci & Techn in Soci,0.74,0.2,0.03,0.0,0.0,0%,0.0,0.03,philip randall,STS-1010,2020
-STS,1010,8.0,Survey Sci & Techn in Soci,0.82,0.03,0.03,0.03,0.0,0%,0.0,0.09,david charles foltz,STS-1010,2020
-STS,1010,9.0,Survey Sci & Techn in Soci,0.41,0.32,0.15,0.06,0.06,0%,0.0,0.0,megan macalystre,STS-1010,2020
-STS,1010,10.0,Survey Sci & Techn in Soci,0.88,0.06,0.03,0.0,0.0,0%,0.0,0.03,alexander billinis,STS-1010,2020
-STS,1010,11.0,Survey Sci & Techn in Soci,0.89,0.06,0.03,0.03,0.0,0%,0.0,0.0,anne grant,STS-1010,2020
-STS,1010,12.0,Survey Sci & Techn in Soci,0.15,0.38,0.15,0.06,0.18,0%,0.0,0.06,chelsea marie clarey,STS-1010,2020
-THEA,2100,1.0,Theatre Appreciation,0.69,0.22,0.06,0.03,0.0,0%,0.0,0.0,david hartmann,THEA-2100,2020
-THEA,2100,3.0,Theatre Appreciation,0.61,0.21,0.09,0.03,0.03,0%,0.0,0.03,kendra johnson,THEA-2100,2020
-THEA,2100,6.0,Theatre Appreciation,0.81,0.13,0.03,0.03,0.0,0%,0.0,0.0,jason adkins,THEA-2100,2020
-THEA,2100,7.0,Theatre Appreciation,0.72,0.22,0.03,0.0,0.03,0%,0.0,0.0,jason adkins,THEA-2100,2020
-THEA,2770,1.0,Prod Studies in Thea,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,david hartmann,THEA-2770,2020
-THEA,3150,1.0,Theatre History I,0.79,0.15,0.03,0.0,0.0,0%,0.0,0.03,shannon robert,THEA-3150,2020
-THEA,3170,1.0,African-Amer Thea I,0.65,0.12,0.18,0.0,0.06,0%,0.0,0.0,kendra johnson,THEA-3170,2020
-THEA,3470,1.0,Structure of Drama,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,carol collins,THEA-3470,2020
-THEA,3720,1.0,Creative Drama,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,carol collins,THEA-3720,2020
-THEA,3760,1.0,Stage Directing I,0.55,0.27,0.09,0.09,0.0,0%,0.0,0.0,becky becker,THEA-3760,2020
-WFB,3010,2.0,Wildlife Biology Lab,0.57,0.36,0.07,0.0,0.0,0%,0.0,0.0,shari lynn rodriguez,WFB-3010,2020
-WFB,4100,2.0,Wildlife Management Tech,0.53,0.26,0.12,0.06,0.03,0%,0.0,0.0,catherine jachowski,WFB-4100,2020
-WFB,4120,1.0,Wildlife Management,0.59,0.3,0.07,0.0,0.04,0%,0.0,0.0,greg yarrow,WFB-4120,2020
-WFB,4180,2.0,Fisheries Mgt & Conservati,0.57,0.29,0.0,0.07,0.0,0%,0.0,0.07,troy mason farmer,WFB-4180,2020
-WFB,4440,1.0,Wildlife Damage Manage,0.41,0.52,0.07,0.0,0.0,0%,0.0,0.0,greg yarrow,WFB-4440,2020
-WFB,4770,1.0,Ichthyology,0.53,0.4,0.0,0.07,0.0,0%,0.0,0.0,luke bower,WFB-4770,2020
-WFB,4800,1.0,Waterfowl Ecology & Man,0.28,0.31,0.21,0.08,0.0,0%,0.0,0.13,richard kaminski,WFB-4800,2020
-WFB,6200,2.0,Environmental Education,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,althea hagan,WFB-6200,2020
-WFB,6620,1.0,Wetland Wildlife Biology,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,russell barrett,WFB-6620,2020
-WFB,6800,1.0,Waterfowl Ecology & Man,0.69,0.19,0.0,0.0,0.0,0%,0.0,0.06,richard kaminski,WFB-6800,2020
-WFB,8530,2.0,Global Change Ecology,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,lydia ries 'halloran,WFB-8530,2020
-WFB,8610,5.0,Intro to Scientific Writing,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,stefanie whitmire,WFB-8610,2020
-WFB,8610,6.0,Conservation PhysiologyO,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,patrick jodice,WFB-8610,2020
-WFB,8610,11.0,Study Design & Data Analy,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.0,brandon peoples,WFB-8610,2020
-WFB,8610,30.0,Human Dimensions of WL,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,shari lynn rodriguez,WFB-8610,2020
-WS,1030,1.0,Women in Global Perspect,0.72,0.14,0.03,0.03,0.07,0%,0.0,0.0,sarah mae cooper,WS-1030,2020
-WS,1030,2.0,Women in Global Perspect,0.59,0.38,0.0,0.0,0.0,0%,0.0,0.03,sarah mae cooper,WS-1030,2020
-WS,2300,1.0,Women and Leadership I,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,mary price,WS-2300,2020
-WS,4010,1.0,Senior Seminar,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.08,diane perpich,WS-4010,2020
-YDP,3000,1.0,Youth Development in Soci,0.73,0.19,0.04,0.0,0.0,0%,0.0,0.04,lauren stephens,YDP-3000,2020
-YDP,3050,1.0,Theory/Phil of Youth Dev,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,lauren stephens,YDP-3050,2020
-YDP,3200,1.0,Youth Dev in Sport/Phys A,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,lauren stephens,YDP-3200,2020
-YDP,3300,1.0,Designing Effective Youth,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,kellye rembert,YDP-3300,2020
-YDP,3300,2.0,Designing Effective Youth,0.29,0.58,0.04,0.04,0.0,0%,0.0,0.04,allison avishai,YDP-3300,2020
-YDP,3350,1.0,Youth Activity Leadership,0.81,0.11,0.07,0.0,0.0,0%,0.0,0.0,lauren stephens,YDP-3350,2020
-YDP,3450,1.0,Creative Activities for Yout,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,kimberly johnson,YDP-3450,2020
-YDP,4500,1.0,Prof Iss & Ethics in Youth D,0.69,0.23,0.08,0.0,0.0,0%,0.0,0.0,michele little kukler,YDP-4500,2020
-YDP,8000,1.0,Theories of Youth Develop,0.76,0.14,0.0,0.0,0.0,0%,0.0,0.03,edmond bowers,YDP-8000,2020
-YDP,8050,1.0,Youth Dev in Context of Fa,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.06,william quinn,YDP-8050,2020
-YDP,8060,2.0,Youth Dev in Global Societ,0.67,0.13,0.07,0.0,0.13,0%,0.0,0.0,ann marie gillard,YDP-8060,2020
-YDP,8080,1.0,Grantsmanship,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,anna- chancellor,YDP-8080,2020
+Course,Number,Section,Title,A,B,C,D,F,P,F(P),W,Instructor,Honors
+AAH,1010,1.0,Survey of Art & Arch Histor,0.51,0.4,0.04,0.02,0.0,0%,0.0,0.03,beth ann lauritis,
+AAH,2050,1.0,Art History and Theory I,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.0,beth ann lauritis,
+AAH,3050,1.0,Contemporary Art History,0.58,0.37,0.0,0.05,0.0,0%,0.0,0.0,andrea feeser,
+ACCT,2010,1.0,Financial Accounting Conc,0.36,0.38,0.2,0.02,0.02,0%,0.0,0.02,lydia schleifer,
+ACCT,2010,2.0,Financial Accounting Conc,0.44,0.31,0.15,0.02,0.04,0%,0.0,0.05,lydia schleifer,
+ACCT,2010,3.0,Financial Accounting Conc,0.17,0.32,0.25,0.07,0.12,0%,0.0,0.07,robert wahlman,
+ACCT,2010,4.0,Financial Accounting Conc,0.26,0.26,0.26,0.13,0.03,0%,0.0,0.08,charles tegen,
+ACCT,2010,5.0,Financial Accounting Conc,0.41,0.36,0.13,0.03,0.05,0%,0.0,0.03,charles tegen,
+ACCT,2010,6.0,Financial Accounting Conc,0.45,0.33,0.05,0.05,0.05,0%,0.0,0.08,julie grant,
+ACCT,2010,7.0,Financial Accounting Conc,0.21,0.44,0.31,0.03,0.0,0%,0.0,0.03,julie grant,
+ACCT,2010,8.0,Financial Accounting Conc,0.51,0.33,0.07,0.07,0.0,0%,0.0,0.02,lydia schleifer,
+ACCT,2010,9.0,Financial Accounting Conc,0.38,0.3,0.18,0.1,0.05,0%,0.0,0.0,julie grant,
+ACCT,2010,10.0,Financial Accounting Conc,0.5,0.2,0.23,0.08,0.0,0%,0.0,0.0,julie grant,
+ACCT,2010,11.0,Financial Accounting Conc,0.35,0.31,0.21,0.04,0.08,0%,0.0,0.0,lisa birtwistle,
+ACCT,2010,12.0,Financial Accounting Conc,0.28,0.39,0.25,0.0,0.03,0%,0.0,0.03,lisa birtwistle,
+ACCT,2010,13.0,Financial Accounting Conc,0.34,0.39,0.13,0.03,0.05,0%,0.0,0.05,lisa birtwistle,
+ACCT,2010,14.0,Financial Accounting Conc,0.18,0.32,0.28,0.1,0.0,0%,0.0,0.12,jeffrey mcmillan,
+ACCT,2010,15.0,Financial Accounting Conc,0.23,0.34,0.31,0.03,0.0,0%,0.0,0.09,carl hollingsworth,
+ACCT,2010,400.0,Financial Accounting Conc,0.09,0.28,0.36,0.12,0.05,0%,0.0,0.1,jeffrey mcmillan,
+ACCT,2010,401.0,Financial Accounting Conc,0.26,0.21,0.26,0.11,0.09,0%,0.0,0.07,emily mccorkle,
+ACCT,2020,1.0,Managerial Accounting Co,0.38,0.43,0.18,0.03,0.0,0%,0.0,0.0,robin radtke,
+ACCT,2020,2.0,Managerial Accounting Co,0.4,0.28,0.18,0.03,0.03,0%,0.0,0.1,robin radtke,
+ACCT,2020,3.0,Managerial Accounting Co,0.21,0.13,0.3,0.11,0.09,0%,0.0,0.15,brian todd carver,
+ACCT,2020,4.0,Managerial Accounting Co,0.12,0.29,0.19,0.12,0.1,0%,0.0,0.17,brian todd carver,
+ACCT,2020,400.0,Managerial Accounting Co,0.23,0.49,0.23,0.0,0.0,0%,0.0,0.05,robin radtke,
+ACCT,2020,401.0,Managerial Accounting Co,0.28,0.33,0.17,0.1,0.05,0%,0.0,0.07,emily mccorkle,
+ACCT,2020,402.0,Managerial Accounting Co,0.33,0.22,0.28,0.05,0.03,0%,0.0,0.09,emily mccorkle,
+ACCT,2020,403.0,Managerial Accounting Co,0.1,0.4,0.15,0.2,0.08,0%,0.0,0.08,emily mccorkle,
+ACCT,2020,404.0,Managerial Accounting Co,0.1,0.28,0.26,0.13,0.08,0%,0.0,0.15,emily mccorkle,
+ACCT,3030,1.0,Cost Accounting,0.38,0.35,0.23,0.03,0.03,0%,0.0,0.0,daniel thomas way,
+ACCT,3030,2.0,Cost Accounting,0.25,0.33,0.35,0.03,0.03,0%,0.0,0.03,daniel thomas way,
+ACCT,3030,3.0,Cost Accounting,0.26,0.32,0.32,0.05,0.03,0%,0.0,0.03,jace garrett,
+ACCT,3030,4.0,Cost Accounting,0.16,0.42,0.26,0.0,0.05,0%,0.0,0.11,jace garrett,
+ACCT,3030,5.0,Cost Accounting,0.77,0.13,0.08,0.03,0.0,0%,0.0,0.0,sarah martin,
+ACCT,3110,1.0,Intermediate Financial Acc,0.17,0.34,0.31,0.03,0.07,0%,0.0,0.07,amy donnelly,
+ACCT,3110,2.0,Intermediate Financial Acc,0.3,0.3,0.3,0.04,0.07,0%,0.0,0.0,amy donnelly,
+ACCT,3110,3.0,Intermediate Financial Acc,0.31,0.38,0.23,0.04,0.0,0%,0.0,0.04,annieka philo,
+ACCT,3110,4.0,Intermediate Financial Acc,0.26,0.35,0.23,0.06,0.06,0%,0.0,0.03,annieka philo,
+ACCT,3110,5.0,Intermediate Financial Acc,0.04,0.25,0.36,0.11,0.18,0%,0.0,0.07, russell madray,
+ACCT,3110,6.0,Intermediate Financial Acc,0.18,0.42,0.18,0.06,0.09,0%,0.0,0.06, russell madray,
+ACCT,3110,7.0,Intermediate Financial Acc,0.19,0.41,0.28,0.0,0.0,0%,0.0,0.09, russell madray,
+ACCT,3110,8.0,Intermediate Financial Acc,0.23,0.42,0.1,0.19,0.03,0%,0.0,0.03, russell madray,
+ACCT,3120,1.0,Intermediate Financial Acc,0.1,0.41,0.31,0.05,0.05,0%,0.0,0.08,jeremy vinson,
+ACCT,3120,2.0,Intermediate Financial Acc,0.33,0.44,0.17,0.0,0.03,0%,0.0,0.03,jeremy vinson,
+ACCT,3120,3.0,Intermediate Financial Acc,0.14,0.23,0.31,0.14,0.11,0%,0.0,0.06,terry daniel knause,
+ACCT,3120,4.0,Intermediate Financial Acc,0.17,0.4,0.3,0.07,0.0,0%,0.0,0.07,terry daniel knause,
+ACCT,3120,5.0,Intermediate Financial Acc,0.18,0.36,0.3,0.06,0.09,0%,0.0,0.0,terry daniel knause,
+ACCT,3120,6.0,Intermediate Financial Acc,0.22,0.42,0.17,0.06,0.14,0%,0.0,0.0,terry daniel knause,
+ACCT,3130,1.0,Analytics for Acct Dec Mak,0.69,0.29,0.03,0.0,0.0,0%,0.0,0.0,james barnes,
+ACCT,3130,2.0,Analytics for Acct Dec Mak,0.89,0.09,0.0,0.03,0.0,0%,0.0,0.0,james barnes,
+ACCT,3130,3.0,Analytics for Acct Dec Mak,0.27,0.38,0.15,0.15,0.04,0%,0.0,0.0,phebian davis-culler,
+ACCT,3130,4.0,Analytics for Acct Dec Mak,0.25,0.39,0.25,0.0,0.11,0%,0.0,0.0,phebian davis-culler,
+ACCT,3130,5.0,Analytics for Acct Dec Mak,0.25,0.3,0.3,0.1,0.05,0%,0.0,0.0,phebian davis-culler,
+ACCT,3220,1.0,Accounting Information Sy,0.15,0.19,0.42,0.08,0.12,0%,0.0,0.04,philip maiberger,
+ACCT,3220,2.0,Accounting Information Sy,0.27,0.31,0.35,0.0,0.04,0%,0.0,0.04,philip maiberger,
+ACCT,3220,3.0,Accounting Information Sy,0.13,0.3,0.23,0.17,0.07,0%,0.0,0.1,philip maiberger,
+ACCT,3220,4.0,Accounting Information Sy,0.11,0.29,0.25,0.11,0.04,0%,0.0,0.21,philip maiberger,
+ACCT,4040,1.0,Individual Taxation,0.61,0.32,0.04,0.0,0.0,0%,0.0,0.04,sarah martin,
+ACCT,4040,2.0,Individual Taxation,0.46,0.29,0.23,0.0,0.03,0%,0.0,0.0,sarah martin,
+ACCT,4040,3.0,Individual Taxation,0.47,0.41,0.09,0.0,0.03,0%,0.0,0.0,lisa birtwistle,
+ACCT,4040,4.0,Individual Taxation,0.49,0.29,0.17,0.03,0.03,0%,0.0,0.0,sarah martin,
+ACCT,4080,1.0,Retire & Estate Plan,0.28,0.5,0.16,0.03,0.0,0%,0.0,0.03,john hine,
+ACCT,4100,2.0,Reporting and Mgmt Contr,0.24,0.39,0.33,0.03,0.0,0%,0.0,0.0,gregory mcphee,
+ACCT,4100,3.0,Reporting and Mgmt Contr,0.33,0.45,0.18,0.03,0.0,0%,0.0,0.0,gregory mcphee,
+ACCT,4150,1.0,Auditing,0.28,0.38,0.19,0.13,0.03,0%,0.0,0.0,nancy lee harp,
+ACCT,4150,2.0,Auditing,0.38,0.46,0.13,0.04,0.0,0%,0.0,0.0,nancy lee harp,
+ACCT,8510,1.0,Tax Research,0.41,0.53,0.03,0.0,0.0,0%,0.0,0.03,thomas dickens,
+ACCT,8530,1.0,Adv Acct Problems,0.74,0.15,0.04,0.0,0.0,0%,0.0,0.07,suzanne pearse,
+ACCT,8530,2.0,Adv Acct Problems,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0,suzanne pearse,
+ACCT,8530,3.0,Adv Acct Problems,0.45,0.45,0.03,0.0,0.03,0%,0.0,0.03,ralph edward welton,
+ACCT,8570,1.0,CPA Exam Review-B,0.0,0.0,0.0,0.0,0.0,96%,0.03,0.01,james barnes,
+ACCT,8630,1.0,Forensics Analysis,0.48,0.45,0.03,0.0,0.0,0%,0.0,0.03,brian goodson,
+ACCT,8630,2.0,Forensics Analysis,0.35,0.62,0.03,0.0,0.0,0%,0.0,0.0,brian goodson,
+ACCT,8650,1.0,Tax & Bus Decisions,0.55,0.39,0.06,0.0,0.0,0%,0.0,0.0,judson jahn,
+ACCT,8650,2.0,Tax & Bus Decisions,0.41,0.56,0.04,0.0,0.0,0%,0.0,0.0,judson jahn,
+ACCT,8680,1.0,Advanced Accounting Anal,0.47,0.47,0.06,0.0,0.0,0%,0.0,0.0,marc cussatt,
+ACCT,8680,2.0,Advanced Accounting Anal,0.59,0.34,0.03,0.0,0.0,0%,0.0,0.03,marc cussatt,
+ACCT,8680,3.0,Advanced Accounting Anal,0.39,0.55,0.03,0.0,0.0,0%,0.0,0.03,marc cussatt,
+ACCT,8720,1.0,Tax of Flowthroughs,0.25,0.44,0.28,0.0,0.0,0%,0.0,0.03,thomas dickens,
+AGED,1020,1.0,Freshman Seminar,0.58,0.33,0.0,0.08,0.0,0%,0.0,0.0, dibenedetto,
+AGED,2000,1.0,Agr Appl of Ed Tech,0.62,0.0,0.08,0.0,0.0,0%,0.0,0.15,kevin layfield,
+AGED,2010,1.0,Intro to Agric Educ,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,philip fravel,
+AGED,2040,1.0,App Ag Calculations,0.29,0.57,0.0,0.07,0.07,0%,0.0,0.0,philip fravel,
+AGED,3030,1.0,Ag Ed Mech Tech,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,christopher eck,
+AGED,8100,3.0,Clin Ag Ed Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,kevin layfield,
+AGM,1010,1.0,Intro Ag Mech & Bus,0.47,0.34,0.11,0.03,0.03,0%,0.0,0.03,hunter massey,
+AGM,2050,1.0,Prin of Fabrication,0.22,0.51,0.22,0.04,0.0,0%,0.0,0.02,hunter massey,
+AGM,2210,1.0,Land Measurements,0.45,0.31,0.09,0.04,0.07,0%,0.0,0.04,brennan teddy,
+AGM,3010,1.0,Soil Water Conserv,0.45,0.29,0.22,0.0,0.02,0%,0.0,0.02,calvin sawyer,
+AGM,4000,1.0,Seminar in Ag Mech & Busi,0.13,0.29,0.32,0.24,0.03,0%,0.0,0.0,john chastain,
+AGM,4020,1.0,Irrigation System Design,0.24,0.24,0.24,0.1,0.19,0%,0.0,0.0,charles privette,
+AGM,4050,1.0,Env Cont in Anim Str,0.05,0.27,0.35,0.22,0.11,0%,0.0,0.0,john chastain,
+AGM,4060,1.0,Mech & Hydraulic Sys,0.39,0.48,0.11,0.0,0.02,0%,0.0,0.0,ali bulent koc,
+AGM,4600,1.0,Electrical Systems,0.69,0.29,0.02,0.0,0.0,0%,0.0,0.0,charles privette,
+AGM,4730,4.0,Ag Safety,0.61,0.22,0.11,0.06,0.0,0%,0.0,0.0,hunter massey,
+AGRB,2020,1.0,Agricultural Economics,0.7,0.17,0.03,0.03,0.05,0%,0.0,0.01,julie carl pingol ureta pingol,
+AGRB,2050,1.0,Agriculture and Society,0.16,0.16,0.22,0.31,0.11,0%,0.0,0.04,michael vassalos,
+AGRB,3020,1.0,Economics of Farm Manag,0.16,0.13,0.15,0.28,0.08,0%,0.0,0.2,michael vassalos,
+AGRB,3080,2.0,Quant Agribusiness Analysi,0.12,0.21,0.14,0.33,0.1,0%,0.0,0.1,lisha zhang,
+AGRB,3570,1.0,Natural Resources Econom,0.2,0.11,0.23,0.18,0.11,0%,0.0,0.16,david brian willis,
+AGRB,4120,1.0,Reg Econ Devel Theory & P,0.3,0.22,0.11,0.16,0.08,0%,0.0,0.08,figueiredo silva de,
+AGRB,4520,1.0,Agricultural Policy,0.14,0.21,0.19,0.28,0.14,0%,0.0,0.05,michael vassalos,
+AGRB,4600,2.0,Agricultural Finance,0.18,0.33,0.23,0.18,0.03,0%,0.0,0.03,lisha zhang,
+AGRB,4910,1.0,"Int, Agrib & Comm & Rural",0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,michael vassalos,
+AL,3490,400.0,Principles of Coaching,0.64,0.24,0.12,0.0,0.0,0%,0.0,0.0,deborah cadorette,
+AL,3490,401.0,Principles of Coaching,0.48,0.32,0.08,0.0,0.08,0%,0.0,0.04,deborah cadorette,
+AL,3490,402.0,Principles of Coaching,0.52,0.32,0.12,0.0,0.04,0%,0.0,0.0,deborah cadorette,
+AL,3490,403.0,Principles of Coaching,0.65,0.17,0.13,0.04,0.0,0%,0.0,0.0,deborah cadorette,
+AL,3490,405.0,Principles of Coaching,0.73,0.2,0.0,0.07,0.0,0%,0.0,0.0,frank mezzanotte,
+AL,3490,406.0,Principles of Coaching,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,frank mezzanotte,
+AL,3490,408.0,Principles of Coaching,0.48,0.26,0.17,0.04,0.0,0%,0.0,0.0,john plumblee,
+AL,3490,409.0,Principles of Coaching,0.88,0.04,0.08,0.0,0.0,0%,0.0,0.0,edmond fry,
+AL,3490,410.0,Principles of Coaching,0.59,0.18,0.14,0.05,0.0,0%,0.0,0.05,joel neuder,
+AL,3490,411.0,Principles of Coaching,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,nicholas whitrow,
+AL,3500,400.0,Sci Basis I/Ex Phy,0.27,0.38,0.23,0.04,0.0,0%,0.0,0.08,michael godfrey,
+AL,3500,401.0,Sci Basis I/Ex Phy,0.44,0.32,0.2,0.04,0.0,0%,0.0,0.0,isaac sean colbert,
+AL,3530,400.0,Athletic Injuries,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,isaac sean colbert,
+AL,3530,401.0,Athletic Injuries,0.8,0.12,0.04,0.04,0.0,0%,0.0,0.0,isaac sean colbert,
+AL,3600,400.0,Hgh Sch Athl Ethical/Legal,0.37,0.53,0.11,0.0,0.0,0%,0.0,0.0,clyde keith connor,
+AL,3610,400.0,Admin/Org of Athletic Pro,0.76,0.2,0.04,0.0,0.0,0%,0.0,0.0,henry oates,
+AL,3610,401.0,Admin/Org of Athletic Pro,0.76,0.2,0.04,0.0,0.0,0%,0.0,0.0,henry oates,
+AL,3610,402.0,Admin/Org of Athletic Pro,0.35,0.35,0.2,0.0,0.1,0%,0.0,0.0,john plumblee,
+AL,3620,400.0,Psychology of Coaching,0.33,0.42,0.17,0.04,0.04,0%,0.0,0.0,natalie anne carter,
+AL,3620,401.0,Psychology of Coaching,0.28,0.36,0.24,0.12,0.0,0%,0.0,0.0,natalie anne carter,
+AL,3620,402.0,Psychology of Coaching,0.32,0.24,0.32,0.08,0.04,0%,0.0,0.0,natalie anne carter,
+AL,3740,400.0,Coaching Football,0.52,0.16,0.16,0.04,0.04,0%,0.0,0.08,edmond fry,
+AL,3740,401.0,Coaching Football,0.45,0.18,0.18,0.09,0.05,0%,0.0,0.05,edmond fry,
+AL,3760,400.0,Coaching Strength/Conditi,0.67,0.13,0.08,0.0,0.08,0%,0.0,0.04,edmond fry,
+AL,3760,401.0,Coaching Strength/Conditi,0.68,0.2,0.04,0.0,0.04,0%,0.0,0.04,edmond fry,
+AL,4000,400.0,Athletic Leadership Interns,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,deborah cadorette,
+AL,4380,402.0,HS Athletic Recruiting,0.61,0.13,0.17,0.04,0.04,0%,0.0,0.0,justin hickey,
+AL,4380,404.0,Emerging Issues and Trend,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.0,misty soles,
+AL,4380,408.0,Officiating in AL,0.75,0.2,0.0,0.05,0.0,0%,0.0,0.0,clyde keith connor,
+AL,4380,409.0,Coaching Baseball/Softball,0.71,0.06,0.24,0.0,0.0,0%,0.0,0.0,justin hickey,
+AL,8440,401.0,Surv of Res Mthds in Athle,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,michael godfrey,
+AL,8440,402.0,Surv of Res Mthds in Athle,0.75,0.08,0.08,0.0,0.08,0%,0.0,0.0,michael godfrey,
+AL,8490,401.0,Athletic Leadership Dev,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,janna magette,
+AL,8490,402.0,Athletic Leadership Dev,0.6,0.25,0.0,0.0,0.15,0%,0.0,0.0,janna magette,
+AL,8500,400.0,Principles Strength and Co,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,michael godfrey,
+AL,8500,401.0,Principles Strength and Co,0.58,0.37,0.0,0.0,0.05,0%,0.0,0.0,michael godfrey,
+AL,8630,400.0,Socio Dynam in Intercol At,0.55,0.27,0.0,0.0,0.09,0%,0.0,0.09,michael godfrey,
+ANTH,2010,1.0,Introduction to Anthropol,0.35,0.34,0.17,0.08,0.03,0%,0.0,0.04,yi wu,
+ANTH,2010,2.0,Introduction to Anthropol,0.22,0.48,0.18,0.05,0.04,0%,0.0,0.04,yi wu,
+ANTH,2010,3.0,Introduction to Anthropol,0.06,0.16,0.24,0.04,0.13,0%,0.0,0.37,john coggeshall,
+ANTH,2010,4.0,Introduction to Anthropol,0.58,0.3,0.04,0.0,0.02,0%,0.0,0.04,david markus,
+ANTH,2010,5.0,Introduction to Anthropol,0.67,0.23,0.04,0.0,0.04,0%,0.0,0.02,david markus,
+ANTH,2010,6.0,Introduction to Anthropol,0.04,0.34,0.2,0.11,0.04,0%,0.0,0.27,john coggeshall,
+ANTH,2010,7.0,Introduction to Anthropol,0.62,0.35,0.04,0.0,0.0,0%,0.0,0.0,david markus,
+ANTH,3010,1.0,Cultural Anthropology,0.14,0.32,0.39,0.07,0.04,0%,0.0,0.04,john coggeshall,
+ANTH,3200,1.0,North American Indian Cul,0.13,0.27,0.2,0.13,0.2,0%,0.0,0.07,john coggeshall,
+ANTH,3320,1.0,World Archaeology,0.4,0.44,0.08,0.0,0.04,0%,0.0,0.04,david markus,
+ANTH,3510,1.0,Biological Anthropology,0.66,0.13,0.13,0.0,0.06,0%,0.0,0.03,katherine weisensee,
+ANTH,4280,1.0,"Law, Culture and Society",0.57,0.21,0.0,0.0,0.14,0%,0.0,0.07,yi wu,
+ARCH,1010,1.0,Introduction to Architectur,0.42,0.35,0.03,0.02,0.04,0%,0.0,0.07, hambright-belue,
+ARCH,2040,1.0,Hist of Modern Arch,0.56,0.31,0.11,0.01,0.0,0%,0.0,0.0,andreea mihalache,
+ARCH,2510,1.0,Arch Foundations I,0.86,0.07,0.07,0.0,0.0,0%,0.0,0.0,joseph choma,
+ARCH,2510,2.0,Arch Foundations I,0.43,0.36,0.21,0.0,0.0,0%,0.0,0.0,brandon george pass,
+ARCH,2510,3.0,Arch Foundations I,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,virginia ellyn melnyk,
+ARCH,2510,4.0,Arch Foundations I,0.62,0.23,0.08,0.0,0.08,0%,0.0,0.0,byron jefferies,
+ARCH,2510,5.0,Arch Foundations I,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,kendall roberts,
+ARCH,2510,6.0,Arch Foundations I,0.46,0.31,0.08,0.08,0.0,0%,0.0,0.08,timothy sutherland,
+ARCH,2700,1.0,Structures I,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,grace fulmer,
+ARCH,2710,1.0,Structures II,0.48,0.33,0.07,0.0,0.04,0%,0.0,0.0,amy christine trick,
+ARCH,3500,1.0,Intro to Urban Contexts,0.47,0.47,0.0,0.0,0.0,0%,0.0,0.06,douglas hecker,
+ARCH,3500,2.0,Intro to Urban Contexts,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,berrin terim,
+ARCH,3500,3.0,Intro to Urban Contexts,0.33,0.56,0.11,0.0,0.0,0%,0.0,0.0,david lee,
+ARCH,3500,4.0,Intro to Urban Contexts,0.69,0.13,0.19,0.0,0.0,0%,0.0,0.0,clarissa mendez,
+ARCH,3500,5.0,Intro to Urban Contexts,0.4,0.4,0.2,0.0,0.0,0%,0.0,0.0,julie poe wilkerson,
+ARCH,3510,1.0,Studio Clemson,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,dustin albright,
+ARCH,3540,1.0,Studio Barcelona,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,
+ARCH,4010,1.0,Architectural Portfolio,0.62,0.24,0.1,0.0,0.0,0%,0.0,0.05,clarissa mendez,
+ARCH,4010,2.0,Architectural Portfolio,0.59,0.29,0.12,0.0,0.0,0%,0.0,0.0,virginia ellyn melnyk,
+ARCH,4010,3.0,Architectural Portfolio,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,george schafer,
+ARCH,4010,4.0,Architectural Portfolio,0.57,0.33,0.05,0.0,0.05,0%,0.0,0.0,brandon george pass,
+ARCH,4120,2.0,History Research,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,
+ARCH,4140,2.0,Design Seminar,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,miguel roldan,
+ARCH,6850,1.0,H/Th: Arch+Health,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dina battisto,
+ARCH,8100,1.0,Visualization I,0.83,0.09,0.04,0.0,0.0,0%,0.0,0.0,joseph choma,
+ARCH,8210,1.0,Research Methods,0.83,0.15,0.0,0.0,0.0,0%,0.0,0.02,dina battisto,
+ARCH,8410,1.0,Arch Studio I,0.55,0.36,0.0,0.0,0.0,0%,0.0,0.0,peter laurence,
+ARCH,8410,2.0,Arch Studio I,0.6,0.3,0.0,0.0,0.1,0%,0.0,0.0,ufuk ersoy,
+ARCH,8510,1.0,Design Studio III,0.33,0.58,0.08,0.0,0.0,0%,0.0,0.0,ulrike ann- heine,
+ARCH,8510,2.0,Design Studio III,0.17,0.83,0.0,0.0,0.0,0%,0.0,0.0,santa cruz franco,
+ARCH,8510,3.0,Design Studio III,0.31,0.54,0.08,0.0,0.0,0%,0.0,0.08,george schafer,
+ARCH,8570,1.0,Design Studio V,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,dustin albright,
+ARCH,8570,4.0,Design Studio V,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,raymond huff,
+ARCH,8600,1.0,History/Theory I,0.57,0.38,0.0,0.0,0.0,0%,0.0,0.0,berrin terim,
+ARCH,8700,1.0,Structures I,0.71,0.12,0.06,0.0,0.06,0%,0.0,0.0,dustin albright,
+ARCH,8790,2.0,Digtial Manufacturing Proc,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,douglas hecker,
+ARCH,8810,1.0,Pro Practice Survey,0.76,0.22,0.0,0.0,0.0,0%,0.0,0.02,byron malet edwards,
+ARCH,8950,1.0,A+H Studio: Projects,0.35,0.59,0.0,0.0,0.0,0%,0.0,0.0,david allison,
+ART,1050,1.0,Foundation Drawing I,0.6,0.2,0.1,0.1,0.0,0%,0.0,0.0,lori brook johnson,
+ART,1510,1.0,Foundations Art I,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,cuba rachel lynn de lynn,
+ART,1510,2.0,Foundations Art I,0.6,0.3,0.0,0.1,0.0,0%,0.0,0.0,brooks harris stevens,
+ART,2100,1.0,Art Appreciation,0.91,0.0,0.0,0.05,0.05,0%,0.0,0.0,dustin massey,
+ART,2100,2.0,Art Appreciation,0.86,0.09,0.0,0.05,0.0,0%,0.0,0.0,megan waller,
+ART,2100,4.0,Art Appreciation,0.82,0.09,0.0,0.05,0.0,0%,0.0,0.05,dustin massey,
+ART,2100,5.0,Art Appreciation,0.91,0.05,0.0,0.0,0.05,0%,0.0,0.0,drie katherine van,
+ART,2100,6.0,Art Appreciation,0.75,0.15,0.05,0.0,0.05,0%,0.0,0.0,dustin massey,
+ART,2150,1.0,Begin Graphic Design,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,david sidney gerhard,
+ART,4200,1.0,Time Base & Digital Art Fn,0.5,0.1,0.1,0.0,0.2,0%,0.0,0.1,cuba rachel lynn de lynn,
+AS,1090,1.0,Heritage & Values of USAF,0.82,0.06,0.0,0.0,0.0,0%,0.0,0.12,joseph blanton,
+AS,1090,2.0,Heritage & Values of USAF,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,joseph blanton,
+AS,1090,3.0,Heritage & Values of USAF,0.94,0.0,0.06,0.0,0.0,0%,0.0,0.0,joseph blanton,
+AS,2090,2.0,Team & Ldrshp Fundamen,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,ryan pierce,
+AS,3090,1.0,Leading & Effective Comm,0.91,0.0,0.09,0.0,0.0,0%,0.0,0.0,wayne leneau,
+ASL,1010,1.0,Am Sign Lang I,0.58,0.21,0.21,0.0,0.0,0%,0.0,0.0,jason hurdich,
+ASL,1010,2.0,Am Sign Lang I,0.83,0.08,0.04,0.0,0.04,0%,0.0,0.0,william clements,
+ASL,1010,3.0,Am Sign Lang I,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,william clements,
+ASL,1010,4.0,Am Sign Lang I,0.76,0.16,0.08,0.0,0.0,0%,0.0,0.0,jody herbert cripps,
+ASL,1020,1.0,Am Sign Lang I,0.7,0.17,0.09,0.0,0.0,0%,0.0,0.04,jason hurdich,
+ASL,1020,2.0,Am Sign Lang I,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,jason hurdich,
+ASL,2010,1.0,Am Sign Lang II,0.67,0.21,0.0,0.08,0.0,0%,0.0,0.04,dunn kim misener,
+ASL,2010,2.0,Am Sign Lang II,0.63,0.33,0.04,0.0,0.0,0%,0.0,0.0,dunn kim misener,
+ASL,2020,1.0,Am Sign Lang II,0.31,0.56,0.13,0.0,0.0,0%,0.0,0.0,jason hurdich,
+ASL,2020,2.0,Am Sign Lang II,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dunn kim misener,
+ASL,3010,1.0,Advanced A S L I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,dunn kim misener,
+ASL,3490,2.0,Adv App in Asl,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.0,william clements,
+ASL,4010,1.0,Linguistics of ASL,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,jody herbert cripps,
+ASTR,1010,1.0,Solar System Astronomy,0.61,0.22,0.07,0.06,0.01,0%,0.0,0.02,david connick,
+ASTR,1010,2.0,Solar System Astronomy,0.57,0.32,0.05,0.03,0.02,0%,0.0,0.01,david connick,
+ASTR,1020,1.0,Stellar Astronomy,0.57,0.28,0.1,0.01,0.03,0%,0.0,0.01,joan marler,
+ASTR,1030,1.0,Solar Systm Astr Lab,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,david connick,
+ASTR,1030,2.0,Solar Systm Astr Lab,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,david connick,
+ASTR,1030,3.0,Solar Systm Astr Lab,0.5,0.38,0.0,0.04,0.0,0%,0.0,0.08,david connick,
+ASTR,1030,4.0,Solar Systm Astr Lab,0.45,0.41,0.05,0.0,0.05,0%,0.0,0.05,david connick,
+ASTR,1030,5.0,Solar Systm Astr Lab,0.5,0.38,0.04,0.04,0.04,0%,0.0,0.0,david connick,
+ASTR,1030,6.0,Solar Systm Astr Lab,0.7,0.22,0.0,0.04,0.0,0%,0.0,0.04,david connick,
+ASTR,1030,7.0,Solar Systm Astr Lab,0.39,0.48,0.09,0.0,0.04,0%,0.0,0.0,david connick,
+ASTR,1030,8.0,Solar Systm Astr Lab,0.43,0.39,0.09,0.0,0.09,0%,0.0,0.0,david connick,
+ASTR,1030,9.0,Solar Systm Astr Lab,0.48,0.43,0.0,0.0,0.04,0%,0.0,0.04,david connick,
+ASTR,1030,10.0,Solar Systm Astr Lab,0.38,0.54,0.0,0.08,0.0,0%,0.0,0.0,david connick,
+ASTR,1030,11.0,Solar Systm Astr Lab,0.71,0.13,0.13,0.0,0.04,0%,0.0,0.0,david connick,
+ASTR,1040,1.0,Stellar Astr Lab,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,david connick,
+ASTR,1040,2.0,Stellar Astr Lab,0.79,0.04,0.13,0.0,0.04,0%,0.0,0.0,david connick,
+ASTR,1040,4.0,Stellar Astr Lab,0.74,0.22,0.04,0.0,0.0,0%,0.0,0.0,david connick,
+ASTR,3020,1.0,Stellar Astrophysics,0.53,0.33,0.07,0.0,0.0,0%,0.0,0.07,mark leising,
+AUD,1850,1.0,Intro to Audio Tech,0.46,0.23,0.08,0.08,0.08,0%,0.0,0.08,hamilton altstatt,
+AUD,2800,1.0,Sound Reinforcement,0.3,0.5,0.1,0.0,0.1,0%,0.0,0.0,kenneth moore,
+AUE,6010,1.0,Vehicle Dynamics,0.7,0.25,0.0,0.0,0.0,0%,0.0,0.05,matthias schmid,
+AUE,6020,1.0,Adv & Electrified Powertra,0.5,0.19,0.13,0.0,0.06,0%,0.0,0.13,benjamin lawler,
+AUE,6080,1.0,Vehicle Testing & Characte,0.5,0.23,0.23,0.0,0.0,0%,0.0,0.0,james potter,
+AUE,6930,3.0,Lightweight Design Using C,0.71,0.23,0.03,0.0,0.0,0%,0.0,0.03,srikanth pilla,
+AUE,8260,1.0,Vehicle Diagnostics,0.38,0.54,0.0,0.0,0.0,0%,0.0,0.08,pierluigi pisu,
+AUE,8270,1.0,Auto Cntrl Sys Des,0.73,0.17,0.05,0.0,0.0,0%,0.0,0.05,qilun zhu,
+AUE,8330,30.0,Auto Manuf Proc Devl,0.53,0.41,0.03,0.0,0.0,0%,0.0,0.03,michael mears,
+AUE,8350,100.0,Auto Electronics,0.73,0.2,0.0,0.0,0.0,0%,0.0,0.07,yunyi jia,
+AUE,8570,1.0,Light-Weight Automotive,0.86,0.0,0.14,0.0,0.0,0%,0.0,0.0,david schmueser,
+AUE,8690,1.0,Qual Assur Automotiv Ma,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,dee ann wood kivett wood,
+AUE,8700,1.0,Automotive Business Conc,0.6,0.36,0.02,0.0,0.0,0%,0.0,0.02,johnell brooks,
+AUE,8810,3.0,Automotive Systems Over,0.4,0.4,0.12,0.0,0.0,0%,0.0,0.08,christiaan paredis,
+AUE,8930,1.0,Adv Vehicle Struct Analysis,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,david schmueser,
+AUE,8930,5.0,Robust Predictive Control,0.52,0.22,0.22,0.0,0.0,0%,0.0,0.04,beshah ayalew,
+AUE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert prucka,
+AUE,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yunyi jia,
+AUE,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,srikanth pilla,
+AUE,9910,21.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rahul rai,
+AVS,1000,1.0,Orientation to AVS,0.79,0.1,0.07,0.02,0.02,0%,0.0,0.01,kristine lang vernon,
+AVS,1500,1.0,Intro Animal Science,0.26,0.46,0.23,0.04,0.01,0%,0.0,0.01,joseph bertrand,
+AVS,1500,2.0,Intro Animal Science,0.2,0.47,0.24,0.06,0.0,0%,0.0,0.02,joseph bertrand,
+AVS,1510,1.0,Intro Ani Sci Lab,0.6,0.32,0.08,0.0,0.0,0%,0.0,0.0,richelle miller,
+AVS,1510,2.0,Intro Ani Sci Lab,0.86,0.1,0.0,0.05,0.0,0%,0.0,0.0,richelle miller,
+AVS,1510,3.0,Intro Ani Sci Lab,0.67,0.25,0.04,0.04,0.0,0%,0.0,0.0,richelle miller,
+AVS,1510,5.0,Intro Ani Sci Lab,0.55,0.25,0.05,0.1,0.0,0%,0.0,0.05,richelle miller,
+AVS,1510,6.0,Intro Ani Sci Lab,0.61,0.26,0.04,0.09,0.0,0%,0.0,0.0,richelle miller,
+AVS,1510,7.0,Intro Ani Sci Lab,0.81,0.13,0.0,0.0,0.0,0%,0.0,0.06,richelle miller,
+AVS,1510,8.0,Intro Ani Sci Lab,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,richelle miller,
+AVS,1510,9.0,Intro Ani Sci Lab,0.43,0.5,0.07,0.0,0.0,0%,0.0,0.0,richelle miller,
+AVS,2040,1.0,Horse Care Techniques,0.87,0.1,0.0,0.0,0.03,0%,0.0,0.0,chelsea sinclair,
+AVS,3010,1.0,Anat & Phys Dom Ani,0.67,0.26,0.04,0.0,0.0,0%,0.0,0.02,glenn birrenkott,
+AVS,3010,400.0,Anat & Phys Dom Ani,0.54,0.42,0.0,0.04,0.0,0%,0.0,0.0,glenn birrenkott,
+AVS,3100,1.0,Animal Health,0.78,0.16,0.03,0.0,0.03,0%,0.0,0.0,james strickland,
+AVS,3700,1.0,Principles of Animal Nutriti,0.59,0.25,0.08,0.02,0.0,0%,0.0,0.03,james strickland,
+AVS,3750,1.0,Applied Animal Nutrition,0.22,0.39,0.26,0.04,0.0,0%,0.0,0.09,gustavo jose lascano,
+AVS,4100,1.0,Domestic Ani Behav,0.84,0.08,0.07,0.01,0.0,0%,0.0,0.0,ahmed badr ali,
+AVS,4100,2.0,Domestic Ani Behav,0.88,0.06,0.06,0.0,0.0,0%,0.0,0.0,ahmed badr ali,
+AVS,4110,1.0,Animal Growth and Develo,0.58,0.24,0.06,0.05,0.05,0%,0.0,0.03,susan kay duckett,
+AVS,4150,1.0,Contemporary Issues in AV,0.57,0.33,0.04,0.01,0.03,0%,0.0,0.01,chelsea sinclair,
+AVS,4160,1.0,Equine Exercise Phys,0.47,0.37,0.05,0.0,0.11,0%,0.0,0.0,kristine lang vernon,
+AVS,4500,1.0,Sustain Livestock Product,0.27,0.67,0.07,0.0,0.0,0%,0.0,0.0,matias jose aguerre,
+AVS,4530,1.0,Animal Reproduction,0.13,0.49,0.13,0.18,0.0,0%,0.0,0.07,scott lee pratt,
+AVS,4650,1.0,Animal Physiology I,0.74,0.15,0.07,0.04,0.0,0%,0.0,0.0,heather walker dunn,
+AVS,4800,1.0,Vertebrate Endocrinology,0.81,0.13,0.03,0.0,0.03,0%,0.0,0.0,heather walker dunn,
+AVS,4910,13.0,Analysis of Natural Produc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,james strickland,
+AVS,4920,6.0,Grazing Horses CI,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,brittany perron,
+AVS,8070,1.0,Prin of Sci Writing in AFLS,0.54,0.31,0.0,0.0,0.0,0%,0.0,0.15,jeryl jones,
+BCHM,1030,1.0,Careers in Bioch/Gen,0.83,0.1,0.02,0.0,0.04,0%,0.0,0.02,alison starr-moss,
+BCHM,3010,1.0,Molecular Biochemistry,0.54,0.26,0.1,0.08,0.02,0%,0.0,0.0,cheryl ingram-smith,
+BCHM,3050,2.0,Essen Elements Bioch,0.45,0.33,0.17,0.0,0.04,0%,0.0,0.01,heidi anderson,
+BCHM,3050,3.0,Essen Elements Bioch,0.34,0.37,0.14,0.04,0.08,0%,0.0,0.03,suchitra chavan,
+BCHM,3050,4.0,Essen Elements Bioch,0.58,0.31,0.07,0.02,0.01,0%,0.0,0.01,heidi anderson,
+BCHM,3050,5.0,Essen Elements Bioch,0.33,0.45,0.12,0.05,0.0,0%,0.0,0.04,suchitra chavan,
+BCHM,4310,1.0,Physical Approach to Bioch,0.35,0.33,0.26,0.05,0.01,0%,0.0,0.0,weiguo cao,
+BCHM,4310,2.0,Phys App to Bioch (HON),0.5,0.42,0.08,0.0,0.0,0%,0.0,0.0,weiguo cao,True
+BCHM,4330,1.0,Physical Biochemistry Lab,0.81,0.13,0.06,0.0,0.0,0%,0.0,0.0,geoffrey ford,
+BCHM,4330,2.0,Physical Biochemistry Lab,0.81,0.13,0.0,0.0,0.06,0%,0.0,0.0,geoffrey ford,
+BCHM,4330,3.0,Physical Biochemistry Lab,0.81,0.06,0.13,0.0,0.0,0%,0.0,0.0,geoffrey ford,
+BCHM,4330,4.0,Physical Biochemistry Lab,0.88,0.06,0.0,0.06,0.0,0%,0.0,0.0,geoffrey ford,
+BCHM,4330,5.0,Physical Biochemistry Lab,0.76,0.0,0.12,0.06,0.06,0%,0.0,0.0,geoffrey ford,
+BCHM,4400,1.0,Bioinformatics,0.82,0.05,0.05,0.0,0.07,0%,0.0,0.02,frank feltus,
+BCHM,4430,1.0,Molecular Basis of Disease,0.55,0.36,0.09,0.0,0.0,0%,0.0,0.0,james morris,
+BCHM,8250,1.0,Seminar I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rajandeep sekhon,
+BDSI,8000,1.0,Biomed Data Sci & Info Se,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brian dean,
+BE,2100,1.0,Intro to Biosystems Engr,0.85,0.11,0.0,0.0,0.0,0%,0.0,0.04,gamboa vanegas,
+BE,3200,1.0,Principles & Prac of Geom,0.59,0.32,0.09,0.0,0.0,0%,0.0,0.0,tom owino,
+BE,4100,1.0,Biological Kinetics,0.22,0.57,0.22,0.0,0.0,0%,0.0,0.0,caye marie drapcho,
+BE,4150,1.0,Instr & Control for Biosys E,0.53,0.33,0.0,0.07,0.07,0%,0.0,0.0,rui xiao,
+BE,4210,1.0,Engr Sys for Soil Water Mg,0.81,0.06,0.13,0.0,0.0,0%,0.0,0.0,christophe darnault,
+BE,4740,1.0,BE Design Project Managm,0.88,0.06,0.06,0.0,0.0,0%,0.0,0.0,tom owino,
+BE,4750,1.0,BE Capstone Design,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,christophe darnault,
+BIOE,1010,1.0,Biol for Bioengr,0.67,0.2,0.07,0.0,0.0,0%,0.0,0.0,tyler george harvey,
+BIOE,2000,1.0,Bioengr Professional Devel,0.0,0.0,0.0,0.0,0.0,98%,0.0,0.01,agneta simionescu,
+BIOE,2010,2.0,Intro Biomed Engr,0.4,0.5,0.07,0.02,0.01,0%,0.0,0.01,charles webb,
+BIOE,3000,1.0,Bioeng Ethics Entrepreneu,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,tyler george harvey,
+BIOE,3020,1.0,Biomaterials,0.67,0.25,0.05,0.0,0.0,0%,0.0,0.03,alexey vertegel,
+BIOE,3100,1.0,Engr Analysis of Physiol Pr,0.85,0.14,0.01,0.0,0.0,0%,0.0,0.0,brian william booth,
+BIOE,3200,1.0,Biomechanics,0.68,0.3,0.0,0.0,0.0,0%,0.0,0.03,jiro nagatomi,
+BIOE,3210,1.0,Biofluid Mechanics,0.62,0.31,0.07,0.0,0.0,0%,0.0,0.0,zhi gao,
+BIOE,3460,1.0,Biomolecular Thermodyna,0.43,0.41,0.14,0.0,0.0,0%,0.0,0.01,robert latour,
+BIOE,3470,1.0,Transport Processes in Bio,0.8,0.14,0.02,0.04,0.0,0%,0.0,0.0,renee nicole cottle,
+BIOE,3700,1.0,Bioinst & Imaging,0.67,0.3,0.04,0.0,0.0,0%,0.0,0.0,jordon gilmore,
+BIOE,4000,1.0,Bioengr Leadshp & MedTe,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,martine laberge,
+BIOE,4010,1.0,Bioengineering Design The,0.97,0.03,0.0,0.0,0.0,0%,0.0,0.0,john desjardins,
+BIOE,4010,2.0,Bioengineering Design The,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,john desjardins,
+BIOE,4030,1.0,Applied Bio E Design,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,ravikiran singapogu,
+BIOE,4120,1.0,Orthopaedic Engr and Path,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,melinda harman,
+BIOE,4350,1.0,Computational Modeling i,0.61,0.33,0.0,0.0,0.0,0%,0.0,0.06,william richardson,
+BIOE,4400,1.0,Biopharmaceutical Engine,0.37,0.42,0.05,0.0,0.0,0%,0.0,0.16,sarah harcum,
+BIOE,4480,1.0,Tissue Engineering,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,angela alexander,
+BIOE,6120,1.0,Orthopaedic Engr & Pathol,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,melinda harman,
+BIOE,6340,1.0,Cardiovascular Biomechani,0.5,0.33,0.17,0.0,0.0,0%,0.0,0.0,ethan kung,
+BIOE,6350,1.0,Computational Modeling i,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,william richardson,
+BIOE,6400,1.0,Biopharmaceutical Engine,0.42,0.5,0.0,0.0,0.0,0%,0.0,0.08,sarah harcum,
+BIOE,8000,843.0,Seminar in Bioeng,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,ann catherine foley,
+BIOE,8020,1.0,Biocompatibility,0.25,0.75,0.0,0.0,0.0,0%,0.0,0.0,narendra vyavahare,
+BIOE,8900,2.0,Bioengineering Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy mercuri,
+BIOE,9910,3.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,john desjardins,
+BIOE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melinda harman,
+BIOE,9910,11.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy mercuri,
+BIOE,9910,13.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,william richardson,
+BIOE,9910,17.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,narendra vyavahare,
+BIOE,9910,805.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeremy gilbert,
+BIOL,1010,1.0,Frontiers in Biology I,0.82,0.13,0.03,0.0,0.01,0%,0.0,0.01,michael childress,
+BIOL,1010,2.0,Frontiers in Biology I,0.87,0.09,0.01,0.01,0.01,0%,0.0,0.0,michael childress,
+BIOL,1030,1.0,General Biology I,0.29,0.25,0.24,0.12,0.08,0%,0.0,0.02,nora espinoza,
+BIOL,1030,2.0,General Biology I,0.27,0.38,0.18,0.08,0.04,0%,0.0,0.05,cassandra joy may,
+BIOL,1030,3.0,General Biology I,0.24,0.22,0.4,0.01,0.05,0%,0.0,0.07,salvatore sparace,
+BIOL,1030,4.0,General Biology I,0.22,0.29,0.22,0.11,0.08,0%,0.0,0.09,nathan redding,
+BIOL,1030,5.0,General Biology I (HON),0.48,0.33,0.19,0.0,0.0,0%,0.0,0.0,nora espinoza,True
+BIOL,1040,1.0,General Biology II,0.52,0.39,0.06,0.0,0.0,0%,0.0,0.03,donna weinbrenner,
+BIOL,1050,1.0,General Biology Lab I,0.63,0.17,0.08,0.04,0.04,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,2.0,General Biology Lab I,0.91,0.04,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,3.0,General Biology Lab I,0.58,0.25,0.08,0.0,0.0,0%,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,4.0,General Biology Lab I,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,5.0,General Biology Lab I,0.61,0.26,0.09,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,6.0,General Biology Lab I,0.5,0.33,0.04,0.0,0.0,0%,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,7.0,General Biology Lab I,0.42,0.46,0.04,0.04,0.04,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,8.0,General Biology Lab I,0.83,0.04,0.0,0.04,0.04,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,9.0,General Biology Lab I,0.42,0.21,0.08,0.08,0.04,0%,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,10.0,General Biology Lab I,0.22,0.3,0.3,0.0,0.09,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,11.0,General Biology Lab I,0.46,0.33,0.08,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,12.0,General Biology Lab I,0.17,0.5,0.04,0.0,0.08,0%,0.0,0.21,tafadzwa kaisa,
+BIOL,1050,13.0,General Biology Lab I,0.46,0.29,0.08,0.08,0.04,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,14.0,General Biology Lab I,0.29,0.5,0.08,0.04,0.08,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,15.0,General Biology Lab I,0.52,0.3,0.0,0.0,0.13,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,16.0,General Biology Lab I,0.63,0.33,0.04,0.0,0.0,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,17.0,General Biology Lab I,0.33,0.38,0.08,0.08,0.08,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,18.0,General Biology Lab I,0.48,0.26,0.0,0.04,0.09,0%,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,19.0,General Biology Lab I,0.54,0.29,0.0,0.04,0.04,0%,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,20.0,General Biology Lab I,0.74,0.13,0.09,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,21.0,General Biology Lab I,0.46,0.29,0.08,0.04,0.13,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,22.0,General Biology Lab I,0.54,0.21,0.08,0.08,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,23.0,General Biology Lab I,0.58,0.17,0.08,0.0,0.04,0%,0.0,0.13,tafadzwa kaisa,
+BIOL,1050,24.0,General Biology Lab I,0.64,0.05,0.14,0.09,0.09,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,25.0,General Biology Lab I,0.57,0.29,0.07,0.0,0.0,0%,0.0,0.07,tafadzwa kaisa,
+BIOL,1050,26.0,General Biology Lab I,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,27.0,General Biology Lab I,0.5,0.21,0.17,0.08,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,28.0,General Biology Lab I,0.67,0.17,0.08,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,29.0,General Biology Lab I,0.79,0.04,0.13,0.0,0.04,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,30.0,General Biology Lab I,0.42,0.25,0.08,0.08,0.13,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,31.0,General Biology Lab I,0.75,0.17,0.0,0.04,0.04,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,32.0,General Biology Lab I,0.58,0.25,0.08,0.0,0.0,0%,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,33.0,General Biology Lab I,0.33,0.33,0.1,0.0,0.1,0%,0.0,0.14,tafadzwa kaisa,
+BIOL,1050,34.0,General Biology Lab I,0.88,0.04,0.04,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,35.0,General Biology Lab I,0.63,0.17,0.04,0.04,0.08,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,36.0,General Biology Lab I,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,37.0,General Biology Lab I,0.58,0.13,0.21,0.04,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,38.0,General Biology Lab I,0.83,0.04,0.04,0.0,0.04,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,39.0,General Biology Lab I,0.75,0.13,0.04,0.0,0.08,0%,0.0,0.0,tafadzwa kaisa,
+BIOL,1050,40.0,General Biology Lab I,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,41.0,General Biology Lab I,0.71,0.25,0.0,0.0,0.0,0%,0.0,0.04,tafadzwa kaisa,
+BIOL,1050,42.0,General Biology Lab I,0.71,0.13,0.0,0.04,0.04,0%,0.0,0.08,tafadzwa kaisa,
+BIOL,1050,43.0,General Biology Lab I,0.29,0.33,0.1,0.14,0.1,0%,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,44.0,General Biology Lab I,0.68,0.18,0.0,0.0,0.05,0%,0.0,0.05,tafadzwa kaisa,
+BIOL,1050,45.0,General Biology Lab I,0.45,0.27,0.09,0.09,0.0,0%,0.0,0.09,tafadzwa kaisa,
+BIOL,1090,1.0,Intro to Life Sci,0.8,0.17,0.03,0.0,0.0,0%,0.0,0.0,renea chris hardwick,
+BIOL,1100,1.0,Principles of Biology I,0.41,0.38,0.09,0.04,0.03,0%,0.0,0.05,renea chris hardwick,
+BIOL,1100,2.0,Principles of Biology I,0.56,0.28,0.1,0.05,0.01,0%,0.0,0.0,renea chris hardwick,
+BIOL,1100,3.0,Principles of Biology I,0.36,0.33,0.2,0.03,0.03,0%,0.0,0.06,verna minor,
+BIOL,1100,4.0,Principles of Biology I,0.28,0.47,0.15,0.06,0.04,0%,0.0,0.0,verna minor,
+BIOL,1100,5.0,Principles of Biology I (HO,0.79,0.14,0.04,0.0,0.04,0%,0.0,0.0,verna minor,True
+BIOL,1230,1.0,Keys to Human Biol,0.21,0.34,0.26,0.06,0.09,0%,0.0,0.04,lisa ruggiero wagner,
+BIOL,2220,1.0,Human Anat and Physiolog,0.21,0.28,0.3,0.1,0.07,0%,0.0,0.04,john cummings,
+BIOL,2220,3.0,Human Anat and Physiolog,0.28,0.38,0.17,0.11,0.04,0%,0.0,0.03,john cummings,
+BIOL,3030,1.0,Vertebrate Biology,0.53,0.29,0.11,0.05,0.03,0%,0.0,0.01,virginia abernathy,
+BIOL,3030,2.0,Vertebrate Biology (HON),0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,virginia abernathy,True
+BIOL,3030,3.0,Vertebrate Biology,0.55,0.27,0.13,0.03,0.02,0%,0.0,0.0,virginia abernathy,
+BIOL,3040,1.0,Biology of Plants,0.29,0.27,0.18,0.16,0.08,0%,0.0,0.02,nathan redding,
+BIOL,3070,1.0,Vertebrate Biology Lab,0.69,0.23,0.08,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,3070,2.0,Vertebrate Biology Lab,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,3070,4.0,Vertebrate Biology Lab,0.6,0.36,0.04,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,3070,5.0,Vertebrate Biology Lab,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,3070,6.0,Vertebrate Biology Lab,0.84,0.08,0.04,0.0,0.0,0%,0.0,0.04,richard blob,
+BIOL,3070,7.0,Vertebrate Biology Lab,0.6,0.28,0.12,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,3070,8.0,Vertebrate Biology Lab,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,3070,9.0,Vertebrate Biology Lab,0.72,0.24,0.04,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,3070,10.0,Vertebrate Biology Lab,0.5,0.33,0.06,0.06,0.06,0%,0.0,0.0,richard blob,
+BIOL,3070,11.0,Vertebrate Biology Lab,0.6,0.32,0.08,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,3080,1.0,Biology of Plants Practicu,0.64,0.27,0.0,0.0,0.0,0%,0.0,0.09,nathan redding,
+BIOL,3080,3.0,Biology of Plants Practicu,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,nathan redding,
+BIOL,3080,4.0,Biology of Plants Practicu,0.55,0.27,0.09,0.09,0.0,0%,0.0,0.0,nathan redding,
+BIOL,3080,5.0,Biology of Plants Practicu,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,nathan redding,
+BIOL,3150,1.0,Functional Human Anatom,0.4,0.39,0.12,0.04,0.02,0%,0.0,0.03, mcnutt-scott,
+BIOL,3350,1.0,Evolutionary Biology,0.35,0.45,0.14,0.04,0.01,0%,0.0,0.02,matthew koski,
+BIOL,3510,1.0,Biological Anthropology,0.86,0.07,0.04,0.04,0.0,0%,0.0,0.0,katherine weisensee,
+BIOL,4030,1.0,Intro to Applied Genomics,0.38,0.13,0.25,0.0,0.13,0%,0.0,0.13,vincent paul richards,
+BIOL,4200,1.0,Neurobiology,0.97,0.0,0.0,0.0,0.02,0%,0.0,0.02,david feliciano,
+BIOL,4250,1.0,Introductory Mycology,0.32,0.33,0.2,0.06,0.02,0%,0.0,0.06,julia louise kerrigan,
+BIOL,4260,1.0,Mycology Practicum,0.71,0.21,0.0,0.0,0.07,0%,0.0,0.0,julia louise kerrigan,
+BIOL,4260,2.0,Mycology Practicum,0.6,0.2,0.0,0.07,0.0,0%,0.0,0.13,julia louise kerrigan,
+BIOL,4400,1.0,Developmental Animal Bio,0.4,0.29,0.17,0.13,0.0,0%,0.0,0.02,kara powder,
+BIOL,4410,1.0,Ecology,0.46,0.36,0.1,0.05,0.01,0%,0.0,0.0,sharon bewick,
+BIOL,4420,1.0,Biogeography,0.58,0.21,0.15,0.03,0.0,0%,0.0,0.03,michael sears,
+BIOL,4610,1.0,Cell Biology,0.67,0.3,0.03,0.0,0.0,0%,0.0,0.0,susan chapman,
+BIOL,4610,2.0,Cell Biology (HON),0.71,0.21,0.08,0.0,0.0,0%,0.0,0.0,susan chapman,True
+BIOL,4610,3.0,Cell Biology,0.56,0.4,0.04,0.0,0.0,0%,0.0,0.0,susan chapman,
+BIOL,4620,1.0,Cell Biology Lab (Lec),0.82,0.14,0.0,0.04,0.0,0%,0.0,0.0,xianzhong yu,
+BIOL,4620,3.0,Cell Biology Lab (Lec),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,xianzhong yu,
+BIOL,4620,4.0,Cell Biology Lab (Lec),0.72,0.08,0.12,0.08,0.0,0%,0.0,0.0,xianzhong yu,
+BIOL,4620,5.0,Cell Biology Lab (Lec),0.93,0.04,0.04,0.0,0.0,0%,0.0,0.0,xianzhong yu,
+BIOL,4620,6.0,Cell Biology Lab (Lec),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,xianzhong yu,
+BIOL,4620,7.0,Cell Biology Lab (Lec),0.92,0.04,0.0,0.0,0.04,0%,0.0,0.0,xianzhong yu,
+BIOL,4620,8.0,Cell Biology Lab (Lec),0.77,0.08,0.08,0.0,0.08,0%,0.0,0.0,xianzhong yu,
+BIOL,4670,1.0,Principles of Hematology,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,vincent gallicchio,
+BIOL,4750,1.0,Comparative Physiology,0.48,0.2,0.16,0.06,0.08,0%,0.0,0.02,matthew turnbull,
+BIOL,4800,1.0,Vertebrate Endocrinology,0.4,0.3,0.3,0.0,0.0,0%,0.0,0.0,william baldwin,
+BIOL,4930,2.0,Sr Sem:Extinct & Macro Ev,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,nora espinoza,
+BIOL,6030,1.0,Intro to Applied Genomics,0.23,0.62,0.08,0.0,0.08,0%,0.0,0.0,vincent paul richards,
+BIOL,8000,1.0,Concepts in EEOB,0.86,0.0,0.14,0.0,0.0,0%,0.0,0.0,richard blob,
+BIOL,8010,1.0,Concepts in MCDB,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,zhicheng dou,
+BIOL,8070,1.0,Readings in MCDB,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,zhicheng dou,
+BIOL,8070,2.0,Readings in Evolution,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jennifer hodge,
+BIOL,8070,3.0,Readings in Ecology,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert fritz baldwin,
+BIOL,8120,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,zhicheng dou,
+BIOL,8130,1.0,Grad Teach Assist Colloqui,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,john cummings,
+BIOL,8400,1.0,Understanding Biological I,0.53,0.16,0.03,0.0,0.06,0%,0.0,0.16,virginia abernathy,
+BIOL,8420,1.0,Understand Cellular Proce,0.56,0.27,0.11,0.0,0.0,0%,0.0,0.03,kaustubha qanungo,
+BIOL,8440,1.0,Understanding the Human,0.49,0.35,0.1,0.0,0.02,0%,0.0,0.03, mcnutt-scott,
+BMOL,4250,1.0,Biomolecular Engineering,0.52,0.21,0.12,0.06,0.05,0%,0.0,0.05,marc birtwistle,
+BUS,1010,2.0,Business Foundations,0.53,0.37,0.11,0.0,0.0,0%,0.0,0.0,william tumblin,
+BUS,1010,3.0,Business Foundations,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,
+BUS,1010,4.0,Business Foundations,0.37,0.58,0.0,0.0,0.05,0%,0.0,0.0,william tumblin,
+BUS,1010,6.0,Business Foundations,0.4,0.4,0.1,0.1,0.0,0%,0.0,0.0,neil monaghan,
+BUS,1010,8.0,Business Foundations,0.42,0.29,0.16,0.02,0.07,0%,0.0,0.04,alexandra hazleton,
+BUS,1010,10.0,Business Foundations,0.58,0.21,0.08,0.04,0.08,0%,0.0,0.0,sandy edge,
+BUS,1010,11.0,Business Foundations,0.46,0.54,0.0,0.0,0.0,0%,0.0,0.0,sandy edge,
+BUS,1010,12.0,Business Foundations,0.48,0.39,0.13,0.0,0.0,0%,0.0,0.0,sandy edge,
+BUS,1010,14.0,Business Foundations,0.23,0.48,0.2,0.03,0.05,0%,0.0,0.02,keith balts,
+BUS,1010,15.0,Business Foundations,0.83,0.08,0.04,0.04,0.0,0%,0.0,0.0,iulio edward barry de barry,
+BUS,1010,16.0,Business Foundations,0.58,0.29,0.08,0.0,0.04,0%,0.0,0.0,iulio edward barry de barry,
+BUS,1010,17.0,Business Foundations,0.83,0.08,0.0,0.08,0.0,0%,0.0,0.0,iulio edward barry de barry,
+BUS,1010,18.0,Business Foundations,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,lawrence watson,
+BUS,1010,19.0,Business Foundations,0.58,0.26,0.16,0.0,0.0,0%,0.0,0.0,lawrence watson,
+BUS,1010,20.0,Business Foundations,0.26,0.58,0.11,0.0,0.0,0%,0.0,0.05,william tumblin,
+BUS,1010,21.0,Business Foundations,0.39,0.39,0.17,0.06,0.0,0%,0.0,0.0,james walter dowis,
+BUS,1010,22.0,Business Foundations,0.47,0.41,0.06,0.0,0.0,0%,0.0,0.06,james walter dowis,
+BUS,1010,23.0,Business Foundations,0.56,0.22,0.22,0.0,0.0,0%,0.0,0.0,james walter dowis,
+BUS,1010,25.0,Business Foundations,0.6,0.3,0.05,0.05,0.0,0%,0.0,0.0,james walter dowis,
+BUS,1010,26.0,Business Foundations,0.8,0.1,0.0,0.0,0.05,0%,0.0,0.05,james walter dowis,
+BUS,1010,27.0,Business Foundations,0.56,0.38,0.06,0.0,0.0,0%,0.0,0.0,james walter dowis,
+BUS,1010,30.0,Business Foundations,0.54,0.29,0.17,0.0,0.0,0%,0.0,0.0,keith balts,
+BUS,1010,31.0,Business Foundations,0.21,0.5,0.25,0.0,0.0,0%,0.0,0.04,keith balts,
+BUS,1010,33.0,Business Foundations,0.7,0.2,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,
+BUS,1010,34.0,Business Foundations,0.55,0.4,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,
+BUS,1010,35.0,Business Foundations,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,william tumblin,
+BUS,1010,36.0,Business Foundations,0.32,0.36,0.12,0.12,0.06,0%,0.0,0.03,neil monaghan,
+BUS,1010,37.0,Business Foundations,0.4,0.34,0.18,0.05,0.02,0%,0.0,0.02,neil monaghan,
+BUS,1010,39.0,Business Foundations,0.5,0.25,0.15,0.0,0.1,0%,0.0,0.0,james walter dowis,
+BUS,1010,40.0,Business Foundations,0.35,0.4,0.15,0.05,0.0,0%,0.0,0.05,james walter dowis,
+BUS,1010,41.0,Business Foundations,0.7,0.25,0.0,0.05,0.0,0%,0.0,0.0,james walter dowis,
+BUS,1010,43.0,Business Foundations,0.42,0.13,0.33,0.13,0.0,0%,0.0,0.0,keith balts,
+BUS,1010,44.0,Business Foundations,0.42,0.33,0.21,0.0,0.04,0%,0.0,0.0,keith balts,
+BUS,1010,45.0,Business Foundations,0.38,0.38,0.21,0.04,0.0,0%,0.0,0.0,keith balts,
+BUS,1010,47.0,Business Foundations,0.45,0.45,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,
+BUS,1010,48.0,Business Foundations,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,william tumblin,
+BUS,1010,49.0,Business Foundations,0.6,0.3,0.1,0.0,0.0,0%,0.0,0.0,william tumblin,
+BUS,1010,50.0,Business Foundations,0.3,0.33,0.16,0.06,0.05,0%,0.0,0.1,alexandra hazleton,
+BUS,1010,51.0,Business Foundations,0.26,0.37,0.19,0.06,0.06,0%,0.0,0.05,alexandra hazleton,
+CCPD,1400,1.0,Professional Development,0.85,0.08,0.04,0.0,0.0,0%,0.0,0.04,rise jean sheriff,
+CE,2010,1.0,Statics,0.11,0.41,0.3,0.05,0.14,0%,0.0,0.0,michael stoner,
+CE,2010,2.0,Statics,0.62,0.21,0.14,0.0,0.02,0%,0.0,0.0,md chowdhury,
+CE,2010,3.0,Statics,0.12,0.34,0.2,0.08,0.08,0%,0.0,0.18,melissa sternhagen,
+CE,2010,4.0,Statics,0.17,0.13,0.28,0.02,0.11,0%,0.0,0.3,melissa sternhagen,
+CE,2010,5.0,Statics,0.26,0.38,0.25,0.05,0.05,0%,0.0,0.02,mohannad naser,
+CE,2010,6.0,Statics,0.37,0.43,0.11,0.06,0.02,0%,0.0,0.02,md chowdhury,
+CE,2010,8.0,Statics,0.38,0.4,0.15,0.05,0.03,0%,0.0,0.0,michael stoner,
+CE,2060,1.0,Structural Mechanics,0.03,0.13,0.44,0.15,0.06,0%,0.0,0.19,melissa sternhagen,
+CE,2080,1.0,Dynamics,0.19,0.4,0.33,0.02,0.03,0%,0.0,0.03,md chowdhury,
+CE,2550,1.0,Geomatics,0.27,0.43,0.2,0.09,0.0,0%,0.0,0.02,wayne sarasua,
+CE,2990,16.0,CE - Springer I - Lecture,0.67,0.25,0.08,0.0,0.0,0%,0.0,0.0,wayne sarasua,
+CE,2990,116.0,CE - Springer I - Lab,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,wayne sarasua,
+CE,2990,216.0,CE - Springer I - Lab,0.5,0.33,0.17,0.0,0.0,0%,0.0,0.0,wayne sarasua,
+CE,3010,1.0,Structural Analysis,0.19,0.45,0.28,0.04,0.02,0%,0.0,0.02,stephen csernak,
+CE,3010,2.0,Structural Analysis,0.34,0.34,0.28,0.0,0.0,0%,0.0,0.03,thomas cousins,
+CE,3110,1.0,Transportation Engr,0.74,0.11,0.08,0.0,0.03,0%,0.0,0.03,jennifer ogle,
+CE,3210,1.0,Geotechnical Engineering,0.47,0.31,0.12,0.08,0.0,0%,0.0,0.02,qiushi chen,
+CE,3310,1.0,Constr Engr & Mgmnt,0.44,0.42,0.1,0.01,0.01,0%,0.0,0.01,zoraya rockow,
+CE,3410,1.0,Intro to Fluid Mechanics,0.68,0.24,0.07,0.02,0.0,0%,0.0,0.0,nigel gregory kaye,
+CE,3410,2.0,Intro to Fluid Mechanics,0.27,0.35,0.18,0.06,0.1,0%,0.0,0.04,abdul khan,
+CE,3420,1.0,Hydraulics & Hydro,0.64,0.2,0.11,0.04,0.02,0%,0.0,0.0,ashok mishra,
+CE,3510,1.0,Civil Engineering Materials,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0, esmaeilpoursaee,
+CE,3510,2.0,Civil Engineering Materials,0.88,0.1,0.0,0.0,0.0,0%,0.0,0.02, esmaeilpoursaee,
+CE,3520,1.0,Econ Eval of Proj,0.63,0.32,0.04,0.0,0.01,0%,0.0,0.0,da li,
+CE,4010,1.0,Matrix Str Analysis,0.24,0.35,0.18,0.12,0.12,0%,0.0,0.0,laura mae redmond,
+CE,4020,1.0,Reinfor Con Design,0.35,0.41,0.09,0.09,0.03,0%,0.0,0.03,laura mae redmond,
+CE,4060,1.0,Struct Steel Design,0.47,0.37,0.1,0.07,0.0,0%,0.0,0.0,stephen csernak,
+CE,4100,1.0,Traffic Engr Oper,0.32,0.23,0.18,0.18,0.05,0%,0.0,0.05,wayne sarasua,
+CE,4240,1.0,Earth Slopes & Struc,0.3,0.32,0.25,0.14,0.0,0%,0.0,0.0, ravichandran,
+CE,4330,1.0,Const Plan & Sched,0.52,0.3,0.17,0.0,0.0,0%,0.0,0.0,tuyen thanh le,
+CE,4340,1.0,Const Est Proj Cont,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,kalyan ram piratla,
+CE,4470,1.0,Stormwater Managemnt,0.4,0.37,0.13,0.1,0.0,0%,0.0,0.0,md chowdhury,
+CE,4560,1.0,Pave Design & Constr,0.17,0.57,0.19,0.0,0.02,0%,0.0,0.05,bradley putman,
+CE,4590,1.0,Capstone Design Proj,0.28,0.49,0.21,0.03,0.0,0%,0.0,0.0,zoraya rockow,
+CE,4910,1.0,BIM in Construction Mana,0.64,0.27,0.0,0.0,0.05,0%,0.0,0.05,kalyan ram piratla,
+CE,4910,3.0,Intro to Proj Mgt,0.62,0.29,0.05,0.0,0.0,0%,0.0,0.05,zoraya rockow,
+CE,4990,109.0,Cr Inq in CE - CEment,0.82,0.14,0.0,0.0,0.0,0%,0.0,0.0,candice bolding,
+CE,6010,1.0,Matrix Str Analysis,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,laura mae redmond,
+CE,6910,5.0,Adv Concrete Technology,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,prasada rangaraju,
+CE,8030,1.0,Adv Steel Design,0.32,0.58,0.05,0.0,0.05,0%,0.0,0.0,mohannad naser,
+CE,8080,1.0,Earthquake Engr,0.9,0.05,0.0,0.0,0.05,0%,0.0,0.0,weichiang pang,
+CE,8460,1.0,Flow in Open Chnls,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,abdul khan,
+CE,8540,1.0,Travl Demnd Forecast,0.57,0.14,0.0,0.0,0.0,0%,0.0,0.0,pamela murray-tuite,
+CE,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jennifer ogle,
+CE,9910,18.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mashrur chowdhury,
+CH,1010,1.0,General Chemistry,0.17,0.38,0.16,0.1,0.09,0%,0.0,0.09,thomas hickman,
+CH,1010,2.0,General Chemistry,0.15,0.35,0.18,0.09,0.09,0%,0.0,0.13,thao thi thanh tran thanh,
+CH,1010,3.0,General Chemistry,0.16,0.39,0.16,0.12,0.06,0%,0.0,0.1,william mcwhorter,
+CH,1010,4.0,General Chemistry,0.23,0.28,0.26,0.12,0.07,0%,0.0,0.04,jacob schroeder,
+CH,1010,5.0,General Chemistry,0.28,0.27,0.21,0.12,0.07,0%,0.0,0.05,thomas hickman,
+CH,1010,6.0,General Chemistry,0.31,0.29,0.18,0.08,0.05,0%,0.0,0.1,dennis taylor,
+CH,1010,7.0,General Chemistry,0.12,0.27,0.24,0.1,0.17,0%,0.0,0.11,olt geiculescu,
+CH,1010,8.0,General Chemistry,0.11,0.29,0.26,0.08,0.08,0%,0.0,0.18,princess mycia cox,
+CH,1010,9.0,General Chemistry,0.23,0.42,0.19,0.08,0.05,0%,0.0,0.04,ashlyn dennis smith,
+CH,1010,10.0,General Chemistry,0.22,0.22,0.26,0.12,0.1,0%,0.0,0.08,william mcwhorter,
+CH,1010,11.0,General Chemistry,0.25,0.42,0.14,0.09,0.08,0%,0.0,0.02,thomas hickman,
+CH,1010,12.0,General Chemistry,0.32,0.31,0.21,0.05,0.03,0%,0.0,0.08,ashlyn dennis smith,
+CH,1010,13.0,General Chemistry,0.21,0.29,0.19,0.1,0.08,0%,0.0,0.13,princess mycia cox,
+CH,1010,14.0,General Chemistry,0.25,0.34,0.25,0.07,0.06,0%,0.0,0.05,tania houjeiry,
+CH,1010,15.0,General Chemistry,0.24,0.29,0.17,0.15,0.05,0%,0.0,0.11,dennis taylor,
+CH,1010,16.0,General Chemistry,0.1,0.39,0.25,0.08,0.08,0%,0.0,0.08,jacob schroeder,
+CH,1010,50.0,General Chemistry,0.36,0.45,0.05,0.09,0.05,0%,0.0,0.0,tania houjeiry,
+CH,1010,71.0,General Chemistry (HON),0.5,0.4,0.05,0.0,0.05,0%,0.0,0.0,joseph thrasher,True
+CH,1010,72.0,General Chemistry (HON),0.57,0.29,0.07,0.07,0.0,0%,0.0,0.0,shiou-jyh hwu,True
+CH,1010,400.0,General Chemistry,0.03,0.18,0.2,0.13,0.18,0%,0.0,0.3,princess mycia cox,
+CH,1020,1.0,General Chemistry,0.31,0.24,0.2,0.16,0.04,0%,0.0,0.04, schvaneveldt,
+CH,1020,2.0,General Chemistry,0.32,0.18,0.24,0.1,0.08,0%,0.0,0.07, schvaneveldt,
+CH,1020,3.0,General Chemistry,0.26,0.28,0.27,0.1,0.04,0%,0.0,0.05, schvaneveldt,
+CH,1020,400.0,General Chemistry,0.23,0.19,0.19,0.19,0.08,0%,0.0,0.13, schvaneveldt,
+CH,1050,2.0,Chemistry in Context I,0.63,0.24,0.07,0.01,0.03,0%,0.0,0.03,olt geiculescu,
+CH,2010,1.0,Survey of Organic Chemist,0.94,0.06,0.01,0.0,0.0,0%,0.0,0.0,modi wetzler,
+CH,2230,1.0,Organic Chemistry,0.43,0.32,0.11,0.06,0.08,0%,0.0,0.02,tania houjeiry,
+CH,2230,2.0,Organic Chemistry,0.22,0.21,0.3,0.12,0.1,0%,0.0,0.04,modi wetzler,
+CH,2230,3.0,Organic Chemistry,0.48,0.21,0.14,0.07,0.06,0%,0.0,0.04,elliot ennis,
+CH,2230,4.0,Organic Chemistry,0.31,0.28,0.17,0.09,0.1,0%,0.0,0.05,modi wetzler,
+CH,2230,6.0,Organic Chemistry,0.5,0.26,0.12,0.03,0.05,0%,0.0,0.03,rhett smith,
+CH,2230,7.0,Organic Chemistry,0.46,0.25,0.1,0.04,0.09,0%,0.0,0.05,rhett smith,
+CH,2230,8.0,Organic Chemistry,0.23,0.15,0.33,0.14,0.13,0%,0.0,0.03,william mcwhorter,
+CH,2230,50.0,Organic Chemistry,0.27,0.47,0.2,0.0,0.07,0%,0.0,0.0,byoungmoo kim,
+CH,2240,1.0,Organic Chemistry,0.29,0.17,0.18,0.13,0.15,0%,0.0,0.08,elliot ennis,
+CH,2240,2.0,Organic Chemistry,0.19,0.18,0.22,0.23,0.1,0%,0.0,0.09,elliot ennis,
+CH,2270,9.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,
+CH,2270,13.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,james plampin,
+CH,2270,18.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,
+CH,2270,28.0,Organic Chem Lab,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,james plampin,
+CH,2280,1.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,
+CH,2280,2.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.09,james plampin,
+CH,2280,4.0,Organic Chem Lab,0.83,0.0,0.0,0.0,0.0,0%,0.0,0.17,james plampin,
+CH,2280,5.0,Organic Chem Lab,0.91,0.0,0.0,0.0,0.0,0%,0.0,0.09,james plampin,
+CH,2280,6.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,
+CH,2280,7.0,Organic Chem Lab,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.08,james plampin,
+CH,3130,1.0,Quantitative Analysis,0.22,0.31,0.24,0.11,0.04,0%,0.0,0.07,olt geiculescu,
+CH,3150,1.0,Quant Analysis Lab,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,jeffrey nathan anker,
+CH,3150,2.0,Quant Analysis Lab,0.73,0.0,0.09,0.0,0.0,0%,0.0,0.18,jeffrey nathan anker,
+CH,3150,3.0,Quant Analysis Lab,0.31,0.31,0.08,0.0,0.23,0%,0.0,0.0,jeffrey nathan anker,
+CH,3300,1.0,Intro to Phys Chem,0.61,0.22,0.07,0.01,0.03,0%,0.0,0.04,brian dominy,
+CH,3310,1.0,Physical Chemistry,0.34,0.36,0.18,0.02,0.1,0%,0.0,0.0,steven stuart,
+CH,3390,1.0,Physical Chem Lab,0.71,0.19,0.05,0.0,0.05,0%,0.0,0.0,princess mycia cox,
+CH,3390,2.0,Physical Chem Lab,0.58,0.26,0.16,0.0,0.0,0%,0.0,0.0,princess mycia cox,
+CH,3390,3.0,Physical Chem Lab,0.74,0.11,0.0,0.0,0.0,0%,0.0,0.16,princess mycia cox,
+CH,3390,4.0,Physical Chem Lab,0.76,0.19,0.0,0.0,0.05,0%,0.0,0.0,princess mycia cox,
+CH,3390,5.0,Physical Chem Lab,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,princess mycia cox,
+CH,3410,1.0,Introduction to Research,0.76,0.08,0.04,0.02,0.1,0%,0.0,0.0,perez carlos garcia,
+CH,4020,1.0,Inorganic Chemistry,0.5,0.42,0.02,0.0,0.04,0%,0.0,0.02,joseph kolis,
+CH,4210,1.0,Advanced Organic Chemist,0.33,0.44,0.22,0.0,0.0,0%,0.0,0.0,jacob schroeder,
+CH,6020,1.0,Inorganic Chemistry,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,joseph kolis,
+CH,6210,1.0,Adv Organic Chem,0.17,0.5,0.17,0.0,0.0,0%,0.0,0.17,jacob schroeder,
+CH,8070,1.0,Chem Trans Elem,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,julia brumaghim,
+CH,8120,1.0,Chemical Spectroscopic M,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,george chumanov,
+CH,8150,1.0,Mass Spectrometry,0.36,0.36,0.27,0.0,0.0,0%,0.0,0.0,richard marcus,
+CH,8210,1.0,Organic Chem I,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,ya-ping sun,
+CH,8370,1.0,Quantum Chemistry,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,leah beck casabianca,
+CH,8510,2.0,Grad Student Seminar,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,sourav saha,
+CH,8520,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,93%,0.03,0.03,joseph thrasher,
+CH,9910,2.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel whitehead,
+CH,9910,7.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rhett smith,
+CH,9910,11.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,richard marcus,
+CH,9910,25.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey nathan anker,
+CH,9910,99.0,Doctoral Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,perez carlos garcia,
+CHE,2110,1.0,Mass and Energy Balances,0.24,0.29,0.26,0.12,0.05,0%,0.0,0.05,mark roberts,
+CHE,3070,1.0,Unit Ops Lab I,0.18,0.47,0.35,0.0,0.0,0%,0.0,0.0,christopher norfolk,
+CHE,3210,1.0,Ch E Thermo II,0.08,0.27,0.39,0.19,0.03,0%,0.0,0.03,sapna sarupria,
+CHE,3300,1.0,Mass Trans & Seprtn,0.35,0.26,0.26,0.08,0.03,0%,0.0,0.03,david bruce,
+CHE,4070,1.0,Unit Op Lab II,0.28,0.4,0.29,0.03,0.0,0%,0.0,0.0,christopher norfolk,
+CHE,4310,1.0,Process Design I,0.26,0.53,0.18,0.01,0.01,0%,0.0,0.0,suzanne deirdre roat,
+CHE,4430,1.0,"Safety, Env & Prof Practice",0.86,0.11,0.04,0.0,0.0,0%,0.0,0.0,scott husson,
+CHE,4500,1.0,Chem Reaction Engr,0.29,0.39,0.2,0.09,0.03,0%,0.0,0.0,rachel getman,
+CHE,6130,1.0,Polymer Composite Engine,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,amod ogale,
+CHE,8030,1.0,Advanced Transport,0.45,0.45,0.09,0.0,0.0,0%,0.0,0.0,eric mikel davis,
+CHE,8900,1.0,GAANN SEMINAR,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eric mikel davis,
+CHE,8950,1.0,Graduate Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jessica marie larsen,
+CHE,9910,2.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mark alan blenner,
+CHE,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,scott husson,
+CHE,9910,11.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sapna sarupria,
+CHE,9910,13.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mark thies,
+CHIN,1010,2.0,Elementary Chinese,0.38,0.0,0.15,0.0,0.15,0%,0.0,0.31,yanhua zhang,
+CHIN,3130,1.0,Philosophy in Modern Chin,0.5,0.25,0.05,0.0,0.05,0%,0.0,0.15,yanming an,
+CHIN,4990,1.0,Slct Tpcs Chin Cult,0.35,0.45,0.15,0.0,0.0,0%,0.0,0.05,kyle david anderson,
+COM,1010,1.0,Acad & Dev I,0.0,0.0,0.0,0.0,0.0,96%,0.0,0.04,lori marlise pindar,
+COM,1500,1.0,Intro to Human Communic,0.86,0.07,0.03,0.01,0.01,0%,0.0,0.01,daniel leland fecher,
+COM,1500,2.0,Intro to Human Communic,0.73,0.18,0.03,0.02,0.02,0%,0.0,0.01,daniel leland fecher,
+COM,1500,3.0,Intro to Human Communic,0.78,0.16,0.05,0.01,0.0,0%,0.0,0.0,daniel leland fecher,
+COM,1500,4.0,Intro to Human Communic,0.82,0.11,0.03,0.01,0.02,0%,0.0,0.02,marianne herr glaser,
+COM,1500,5.0,Intro to Human Communic,0.82,0.11,0.02,0.02,0.02,0%,0.0,0.01,marianne herr glaser,
+COM,1500,6.0,Intro to Human Communic,0.79,0.16,0.03,0.01,0.0,0%,0.0,0.01,marianne herr glaser,
+COM,1500,7.0,Intro to Human Communic,0.73,0.12,0.08,0.03,0.03,0%,0.0,0.01,vanessa condon,
+COM,2010,1.0,Intr to Comm Studies,0.67,0.19,0.04,0.0,0.04,0%,0.0,0.07,caitlin baker,
+COM,2010,2.0,Intr to Comm Studies,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,caitlin baker,
+COM,2020,1.0,Communication Theory,0.75,0.21,0.04,0.0,0.0,0%,0.0,0.0,kristen okamoto,
+COM,2040,1.0,Critical-Cultural Comm The,0.65,0.17,0.13,0.0,0.04,0%,0.0,0.0,james gilmore,
+COM,2100,1.0,Quant Comm Research Me,0.44,0.48,0.08,0.0,0.0,0%,0.0,0.0,erin michelle ash,
+COM,2500,2.0,Public Speaking,0.6,0.3,0.05,0.0,0.05,0%,0.0,0.0,sara crocker,
+COM,2500,3.0,Public Speaking,0.6,0.25,0.05,0.05,0.0,0%,0.0,0.05,elizabeth gilmore,
+COM,2500,4.0,Public Speaking,0.75,0.15,0.1,0.0,0.0,0%,0.0,0.0,elizabeth gilmore,
+COM,2500,5.0,Public Speaking,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,alyssa christine davis,
+COM,2500,6.0,Public Speaking,0.7,0.25,0.05,0.0,0.0,0%,0.0,0.0,alyssa christine davis,
+COM,2500,7.0,Public Speaking,0.65,0.3,0.05,0.0,0.0,0%,0.0,0.0,sara crocker,
+COM,2500,8.0,Public Speaking,0.55,0.35,0.05,0.0,0.05,0%,0.0,0.0,ashley lauren pikel,
+COM,2500,9.0,Public Speaking,0.65,0.1,0.15,0.0,0.05,0%,0.0,0.05,sara crocker,
+COM,2500,10.0,Public Speaking,0.47,0.37,0.05,0.05,0.05,0%,0.0,0.0,ashley lauren pikel,
+COM,2500,11.0,Public Speaking,0.68,0.21,0.05,0.0,0.0,0%,0.0,0.05,ashley lauren pikel,
+COM,2500,14.0,Public Speaking,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,elizabeth gilmore,
+COM,2500,16.0,Public Speaking,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,jumah patricia taweh,
+COM,2500,17.0,Public Speaking,0.79,0.05,0.05,0.0,0.11,0%,0.0,0.0,jumah patricia taweh,
+COM,2500,18.0,Public Speaking,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,marshall covert,
+COM,2500,19.0,Public Speaking,0.79,0.16,0.0,0.0,0.0,0%,0.0,0.05,jumah patricia taweh,
+COM,2500,20.0,Public Speaking,0.75,0.15,0.05,0.0,0.0,0%,0.0,0.05,vanessa condon,
+COM,2500,21.0,Public Speaking,0.75,0.2,0.0,0.0,0.0,0%,0.0,0.05,charles john brewer,
+COM,2500,22.0,Public Speaking,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,charles john brewer,
+COM,2500,23.0,Public Speaking,0.74,0.16,0.11,0.0,0.0,0%,0.0,0.0,charles john brewer,
+COM,2500,24.0,Public Speaking,0.78,0.17,0.0,0.0,0.06,0%,0.0,0.0,charles john brewer,
+COM,2500,25.0,Public Speaking,0.6,0.35,0.0,0.05,0.0,0%,0.0,0.0,marshall covert,
+COM,2500,26.0,Public Speaking,0.55,0.35,0.05,0.0,0.05,0%,0.0,0.0,marshall covert,
+COM,2500,27.0,Public Speaking,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,marshall covert,
+COM,2500,28.0,Public Speaking,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,katie mcelveen,
+COM,2500,29.0,Public Speaking,0.74,0.16,0.05,0.05,0.0,0%,0.0,0.0,vanessa condon,
+COM,2500,31.0,Public Speaking,0.85,0.0,0.05,0.05,0.05,0%,0.0,0.0,katie mcelveen,
+COM,2500,33.0,Public Speaking,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,ashley lauren pikel,
+COM,2500,401.0,Public Speaking,0.8,0.15,0.0,0.0,0.05,0%,0.0,0.0,alexis zachary davis,
+COM,2500,402.0,Public Speaking,0.75,0.1,0.1,0.05,0.0,0%,0.0,0.0,alexis zachary davis,
+COM,2500,403.0,Public Speaking,0.85,0.05,0.0,0.0,0.1,0%,0.0,0.0,alexis zachary davis,
+COM,3050,1.0,Persuasion,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,lindsey dixon,
+COM,3200,1.0,Bdcst Production,0.87,0.0,0.04,0.04,0.04,0%,0.0,0.0,wanda johnson,
+COM,3240,1.0,"Communication, Sport & S",0.68,0.2,0.04,0.0,0.04,0%,0.0,0.04,brandon boatwright,
+COM,3240,2.0,"Communication, Sport & S",0.5,0.32,0.18,0.0,0.0,0%,0.0,0.0,brandon boatwright,
+COM,3250,1.0,Survey of Sports Communi,0.67,0.17,0.13,0.03,0.0,0%,0.0,0.0,virginia harrison,
+COM,3260,1.0,Pr in Sports,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,katie mcelveen,
+COM,3260,2.0,Pr in Sports,0.83,0.07,0.03,0.0,0.0,0%,0.0,0.07,katie mcelveen,
+COM,3270,1.0,Sports Media Criticism,0.32,0.64,0.0,0.0,0.0,0%,0.0,0.04,bryan denham,
+COM,3550,1.0,Principles of Public Relatio,0.5,0.27,0.14,0.05,0.0,0%,0.0,0.05,jordan morehouse,
+COM,3570,1.0,Public Relations Writing,0.52,0.29,0.05,0.05,0.05,0%,0.0,0.05,jordan morehouse,
+COM,3660,3.0,Ugrad Comm Tutors,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,alyssa christine davis,
+COM,3660,4.0,Storytelling and Reporting,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,nigel robertson,
+COM,3900,1.0,Communication Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,lori marlise pindar,
+COM,4280,1.0,Interpers/Family Comm &,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,gregory cranmer,
+COM,4560,1.0,PR for Assoc & Nonprofits,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,virginia harrison,
+COM,4700,1.0,Comm & Health,0.36,0.45,0.14,0.0,0.0,0%,0.0,0.05,victoria wingate,
+COM,4800,1.0,Intercultural Comm,0.8,0.16,0.04,0.0,0.0,0%,0.0,0.0,andrew stephen pyle,
+COM,4800,2.0,Intercultural Comm,0.92,0.04,0.0,0.0,0.04,0%,0.0,0.0,andrew stephen pyle,
+COM,4950,2.0,Senior Capstone Seminar,0.79,0.13,0.08,0.0,0.0,0%,0.0,0.0,david travers scott,
+COM,8000,1.0,Communication Pedagogy,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel leland fecher,
+COM,8010,1.0,Communication Theory I,0.73,0.18,0.0,0.0,0.0,0%,0.0,0.09,darren linvill,
+COM,8100,1.0,Comm Research Methods I,0.47,0.4,0.13,0.0,0.0,0%,0.0,0.0,gregory cranmer,
+COM,8270,1.0,Sports Media,0.57,0.29,0.0,0.0,0.0,0%,0.0,0.14,bryan denham,
+COM,8910,1.0,Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,erin michelle ash,
+COOP,1010,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
+COOP,1020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
+COOP,1030,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
+COOP,2010,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
+COOP,2020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jeffrey frank neal,
+COOP,6020,1.0,Co-Op Education,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,'neil burton,
+CPSC,1010,10.0,Computer Science I,0.15,0.31,0.25,0.04,0.1,0%,0.0,0.13,scoy roger larry van larry,
+CPSC,1010,20.0,Computer Science I,0.39,0.2,0.16,0.1,0.02,0%,0.0,0.14,carrie lynn russell,
+CPSC,1010,30.0,Computer Science I,0.2,0.37,0.2,0.06,0.06,0%,0.0,0.12,carrie lynn russell,
+CPSC,1020,10.0,Computer Science II,0.24,0.29,0.18,0.11,0.07,0%,0.0,0.11,catherine kittelstad,
+CPSC,1060,10.0,Intro to Programming in Ja,0.37,0.24,0.11,0.05,0.11,0%,0.0,0.13,svetlana drachova,
+CPSC,1060,20.0,Intro to Programming in Ja,0.31,0.17,0.22,0.19,0.08,0%,0.0,0.03,svetlana drachova,
+CPSC,1060,30.0,Intro to Programming in Ja,0.14,0.11,0.33,0.14,0.14,0%,0.0,0.14,christina joerg,
+CPSC,1070,1.0,Programming Methodolog,0.26,0.27,0.27,0.04,0.07,0%,0.0,0.1,christopher plaue,
+CPSC,1110,1.0,Intro to Programming in C,0.34,0.31,0.16,0.05,0.06,0%,0.0,0.07,andrew duchowski,
+CPSC,1110,2.0,Intro to Programming in C,0.39,0.27,0.22,0.04,0.02,0%,0.0,0.06,nicolas widman,
+CPSC,1210,1.0,Computational Thinking,0.26,0.26,0.34,0.03,0.05,0%,0.0,0.05,mitch shue,
+CPSC,1900,1.0,Teaching Assist Fundamen,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eileen kraemer,
+CPSC,2070,1.0,Discrete Structures,0.44,0.37,0.14,0.03,0.02,0%,0.0,0.0,larry hodges,
+CPSC,2070,2.0,Discrete Structures,0.38,0.27,0.29,0.06,0.0,0%,0.0,0.0,larry hodges,
+CPSC,2070,3.0,Discrete Structures,0.46,0.19,0.3,0.0,0.03,0%,0.0,0.03,pradip srimani,
+CPSC,2120,1.0,Algs/Data Structures,0.52,0.16,0.11,0.07,0.08,0%,0.0,0.05,nicolas widman,
+CPSC,2120,2.0,Algs/Data Structures,0.48,0.18,0.1,0.03,0.13,0%,0.0,0.08,nicolas widman,
+CPSC,2120,101.0,Algs/Data Structures,0.4,0.2,0.04,0.04,0.08,0%,0.0,0.24,brian dean,
+CPSC,2120,102.0,Algs/Data Structures,0.28,0.24,0.28,0.0,0.04,0%,0.0,0.16,brian dean,
+CPSC,2120,103.0,Algs/Data Structures,0.17,0.26,0.3,0.04,0.09,0%,0.0,0.13,brian dean,
+CPSC,2150,1.0,Software Dev Foundations,0.22,0.27,0.2,0.07,0.16,0%,0.0,0.09,yu-shan sun,
+CPSC,2150,2.0,Software Dev Foundations,0.24,0.24,0.2,0.02,0.13,0%,0.0,0.17,yu-shan sun,
+CPSC,2150,3.0,Software Dev Foundations,0.15,0.25,0.2,0.1,0.15,0%,0.0,0.15,murali sitaraman,
+CPSC,2200,1.0,Problem Solving w/ Office,0.52,0.22,0.14,0.06,0.04,0%,0.0,0.02,catherine kittelstad,
+CPSC,2310,1.0,Intro Computer Org,0.23,0.29,0.28,0.03,0.1,0%,0.0,0.07,yvon feaster,
+CPSC,2910,1.0,Prof Issues I,0.83,0.1,0.0,0.03,0.03,0%,0.0,0.0,constance taylor,
+CPSC,2910,2.0,Prof Issues I,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,constance taylor,
+CPSC,2910,3.0,Prof Issues I,0.68,0.1,0.13,0.06,0.0,0%,0.0,0.03,constance taylor,
+CPSC,2920,1.0,"Computing, Ethics & Societ",0.8,0.05,0.08,0.0,0.03,0%,0.0,0.05,julian brinkley,
+CPSC,3220,1.0,Intro to Operating Systems,0.31,0.21,0.1,0.04,0.09,0%,0.0,0.21,jacob sorber,
+CPSC,3220,2.0,Intro to Operating Systems,0.59,0.17,0.04,0.0,0.04,0%,0.0,0.04,brygg anders ullmer,
+CPSC,3300,1.0,Computer Systems Org,0.4,0.33,0.15,0.08,0.01,0%,0.0,0.03,mark smotherman,
+CPSC,3500,1.0,Foundations of Computer,0.2,0.37,0.27,0.0,0.1,0%,0.0,0.06,sandra hedetniemi,
+CPSC,3520,1.0,Programming Systems,0.76,0.1,0.06,0.01,0.06,0%,0.0,0.01,yongkai wu,
+CPSC,3600,1.0,Network Programming,0.48,0.26,0.13,0.03,0.04,0%,0.0,0.05,andrew robb,
+CPSC,3720,1.0,Software Engineering,0.25,0.44,0.24,0.05,0.02,0%,0.0,0.0,yu-shan sun,
+CPSC,3720,2.0,Software Engineering,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,constance taylor,
+CPSC,3750,1.0,Web Application Develop,0.52,0.27,0.06,0.04,0.1,0%,0.0,0.0,craig baker,
+CPSC,4030,1.0,Data Visualization,0.21,0.5,0.21,0.0,0.04,0%,0.0,0.04,federico iuricich,
+CPSC,4040,1.0,Cmptr Graphics Image,0.76,0.12,0.0,0.0,0.06,0%,0.0,0.06,jerry tessendorf,
+CPSC,4050,1.0,Computer Graphics,0.38,0.17,0.04,0.04,0.0,0%,0.0,0.33,yin yang,
+CPSC,4110,1.0,Virtual Reality Systems,0.57,0.3,0.13,0.0,0.0,0%,0.0,0.0,sabarish venkat babu,
+CPSC,4140,1.0,Human and Computer Inte,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,nathaniel mcneese,
+CPSC,4160,1.0,2-D Game Engine Construc,0.58,0.15,0.08,0.05,0.08,0%,0.0,0.08,victor zordan,
+CPSC,4200,1.0,Computer Security Principl,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,long cheng,
+CPSC,4240,1.0,System Admin and Securit,0.63,0.33,0.0,0.0,0.04,0%,0.0,0.0,svetlana drachova,
+CPSC,4300,1.0,Applied Data Science,0.41,0.3,0.07,0.0,0.07,0%,0.0,0.07,xizhou feng,
+CPSC,4300,2.0,Applied Data Science,0.53,0.12,0.18,0.0,0.12,0%,0.0,0.06,alexander herzog,
+CPSC,4420,1.0,Artificial Intelligence,0.71,0.14,0.1,0.0,0.05,0%,0.0,0.0,ioannis karamouzas,
+CPSC,4430,1.0,Machine Learning: Impl &,0.83,0.13,0.0,0.0,0.04,0%,0.0,0.0,larry hodges,
+CPSC,4440,1.0,Cloud Computing Architect,0.35,0.61,0.04,0.0,0.0,0%,0.0,0.0,mitch shue,
+CPSC,4620,1.0,Database Management Sy,0.48,0.19,0.14,0.0,0.14,0%,0.0,0.05,pradip srimani,
+CPSC,4620,2.0,Database Management Sy,0.33,0.5,0.06,0.0,0.0,0%,0.0,0.11,zijun wang,
+CPSC,4770,1.0,Distributed/Cluster Compu,0.47,0.37,0.05,0.0,0.05,0%,0.0,0.05,shuangshuang jin,
+CPSC,4780,1.0,Gen Purpose Computation,0.27,0.18,0.0,0.09,0.18,0%,0.0,0.27,shuangshuang jin,
+CPSC,4890,1.0,Programming Team Semin,0.67,0.27,0.07,0.0,0.0,0%,0.0,0.0,brian dean,
+CPSC,4910,1.0,Professional Issues II,0.53,0.43,0.03,0.0,0.0,0%,0.0,0.0,scoy roger larry van larry,
+CPSC,4910,2.0,Professional Issues II,0.28,0.52,0.16,0.04,0.0,0%,0.0,0.0,scoy roger larry van larry,
+CPSC,4910,3.0,Professional Issues II,0.78,0.17,0.04,0.0,0.0,0%,0.0,0.0,alexander herzog,
+CPSC,6040,1.0,Cptr Graphics Image,0.83,0.11,0.06,0.0,0.0,0%,0.0,0.0,jerry tessendorf,
+CPSC,6050,1.0,Computer Graphics,0.69,0.15,0.08,0.0,0.0,0%,0.0,0.08,yin yang,
+CPSC,6110,1.0,Virtual Reality Systems,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,sabarish venkat babu,
+CPSC,6160,1.0,2-D Game Engine Construc,0.71,0.14,0.0,0.0,0.14,0%,0.0,0.0,victor zordan,
+CPSC,6300,2.0,Applied Data Science,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,alexander herzog,
+CPSC,6420,1.0,Artificial Intelligence,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,ioannis karamouzas,
+CPSC,6440,1.0,Cloud Computing Architect,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,mitch shue,
+CPSC,6620,1.0,Database Management Sy,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,pradip srimani,
+CPSC,6620,2.0,Database Management Sy,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,zijun wang,
+CPSC,6770,1.0,Distributed/Cluster Compu,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,shuangshuang jin,
+CPSC,6810,1.0,Ind Study: MSCS Ready,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,eileen kraemer,
+CPSC,6810,2.0,MSCS Ready: mod 2,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,eileen kraemer,
+CPSC,8200,1.0,Parallel Architechture,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,rong ge,
+CPSC,8420,1.0,Advanced Machine Learni,0.5,0.13,0.22,0.0,0.0,0%,0.0,0.16,kai liu,
+CPSC,8470,1.0,Intro to Information Retrie,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,feng luo,
+CPSC,8480,1.0,Network Science,0.59,0.18,0.12,0.0,0.06,0%,0.0,0.06,ilya mark safro,
+CPSC,8510,1.0,Soft Sys Data Comm,0.67,0.11,0.11,0.0,0.0,0%,0.0,0.11,james martin,
+CPSC,8580,1.0,Security in Emerging Syste,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,hongxin hu,
+CPSC,8710,1.0,Found. of Software Engine,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,paige rodeghero,
+CPSC,9500,1.0,Sel Top:SoC Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,long cheng,
+CPSC,9500,2.0,Sel Topics: CS Edu Researc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eileen kraemer,
+CPSC,9500,843.0,Sel Topics: SOC Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,long cheng,
+CPSC,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brian dean,
+CPSC,9910,14.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,hongxin hu,
+CPSC,9910,24.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,feng luo,
+CRP,4010,1.0,Intro to City & Regional Pla,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,john albert gaber,
+CRP,8010,1.0,Planning Process & Legal F,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,caitlin dyckman,
+CRP,8030,2.0,Quan Analysis for Planners,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,eric morris,
+CRP,8080,1.0,Land Use and Compreh Pla,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,santiago luis ramos,
+CRP,8140,1.0,Public Transit,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,eric morris,
+CRP,8580,2.0,Mixed Mthds for Planning,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,clifford donald ellis,
+CRP,8940,1.0,Professional Planning Semi,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,barry nocks,
+CSM,1000,1.0,Intro to Construct,0.81,0.1,0.0,0.03,0.06,0%,0.0,0.0,thomas fuduric,
+CSM,2010,1.0,Structures I,0.07,0.29,0.21,0.29,0.07,0%,0.0,0.07,shima clarke,
+CSM,2010,2.0,Structures I,0.0,0.36,0.14,0.21,0.14,0%,0.0,0.14,shima clarke,
+CSM,2010,401.0,Structures I,0.15,0.46,0.15,0.15,0.0,0%,0.0,0.08,shima clarke,
+CSM,2010,402.0,Structures I,0.0,0.08,0.54,0.15,0.0,0%,0.0,0.23,shima clarke,
+CSM,2030,401.0,Mats & Meth of Const,0.19,0.44,0.31,0.02,0.04,0%,0.0,0.0,jason lucas,
+CSM,2040,401.0,Cont Documents,0.38,0.41,0.1,0.1,0.0,0%,0.0,0.0,robert coffey,
+CSM,2050,1.0,Mats & Methods II,0.59,0.22,0.14,0.03,0.03,0%,0.0,0.0,nathaniel jackson,
+CSM,2060,1.0,Construction Science Work,0.82,0.06,0.12,0.0,0.0,0%,0.0,0.0,nathaniel jackson,
+CSM,2060,2.0,Construction Science Work,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,nathaniel jackson,
+CSM,2070,1.0,Construction Industry Sem,0.6,0.14,0.14,0.05,0.07,0%,0.0,0.0,thomas fuduric,
+CSM,3040,401.0,Environmental Systems I,0.48,0.39,0.09,0.02,0.02,0%,0.0,0.0,joseph burgett,
+CSM,3050,1.0,Environmental Systems II,0.15,0.38,0.31,0.0,0.12,0%,0.0,0.04,joseph burgett,
+CSM,3060,1.0,Emerging Tech in Construc,0.84,0.06,0.03,0.03,0.03,0%,0.0,0.0,harnish sharma,
+CSM,3060,401.0,Emerging Tech in Construc,0.68,0.18,0.09,0.0,0.0,0%,0.0,0.05,harnish sharma,
+CSM,3070,1.0,Sustainable Construction,0.54,0.42,0.0,0.0,0.04,0%,0.0,0.0,harnish sharma,
+CSM,3510,1.0,Construction Estimating,0.29,0.48,0.06,0.06,0.08,0%,0.0,0.02,rizi seyed mousavi,
+CSM,3520,1.0,Const Scheduling,0.38,0.46,0.13,0.04,0.0,0%,0.0,0.0,dennis bausman,
+CSM,3530,401.0,Const Estimating II,0.48,0.43,0.04,0.04,0.0,0%,0.0,0.0,anthony harden,
+CSM,4110,401.0,Safety in Bldg Const,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,nicholas corley,
+CSM,4500,1.0,Construction Internship,0.66,0.21,0.1,0.0,0.0,0%,0.0,0.03,nathaniel jackson,
+CSM,4530,1.0,Const Proj Mgmt,0.69,0.27,0.04,0.0,0.0,0%,0.0,0.0,dennis bausman,
+CSM,4540,1.0,Construction Capstone,0.6,0.33,0.07,0.0,0.0,0%,0.0,0.0,vivek sharma,
+CSM,4610,1.0,Const Econ Seminar,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0, nove-josserand,
+CSM,4980,2.0,Current Topics-NAHB Com,0.71,0.21,0.07,0.0,0.0,0%,0.0,0.0,jason lucas,
+CSM,8520,400.0,Const Mgmt Research,0.45,0.55,0.0,0.0,0.0,0%,0.0,0.0,vivek sharma,
+CSM,8650,400.0,Project Management,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,dhaval gajjar,
+CU,1000,37.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.15,0.0,susan whorton,
+CU,1000,38.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,84%,0.12,0.01,susan whorton,
+CU,1000,52.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.13,0.0,susan whorton,
+CU,1000,53.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,82%,0.15,0.01,susan whorton,
+CU,1000,54.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,84%,0.12,0.01,susan whorton,
+CU,1000,57.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,79%,0.18,0.01,susan whorton,
+CU,1000,58.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,77%,0.17,0.0,susan whorton,
+CU,1000,59.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,79%,0.14,0.01,susan whorton,
+CU,1000,60.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,83%,0.13,0.0,susan whorton,
+CU,1000,61.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,71%,0.28,0.01,susan whorton,
+CU,1000,62.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,73%,0.26,0.0,susan whorton,
+CU,1000,63.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,70%,0.29,0.0,susan whorton,
+CU,1000,64.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,64%,0.27,0.02,susan whorton,
+CU,1000,65.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,69%,0.26,0.01,susan whorton,
+CU,1000,66.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,65%,0.32,0.01,susan whorton,
+CU,1000,67.0,Clemson Connect,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,susan whorton,
+CU,1010,1.0,Univ Success Skills,0.53,0.07,0.13,0.0,0.13,0%,0.0,0.13,bryn babb,
+CU,1010,6.0,Univ Success Skills,0.7,0.1,0.1,0.0,0.1,0%,0.0,0.0,catherine neel,
+CU,1110,4.0,Intro Supplemental Instruc,0.0,0.0,0.0,0.0,0.0,91%,0.0,0.09,rachel anderson,
+CU,1110,5.0,Intro Supplemental Instruc,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rachel anderson,
+DPA,3070,1.0,Method 3d Production,0.21,0.13,0.04,0.0,0.17,0%,0.0,0.46,da costa florencio,
+DPA,4000,1.0,Tech Foundations I,0.47,0.18,0.06,0.06,0.18,0%,0.0,0.06,jessica baron,
+DPA,4020,1.0,Visual Found of Digital Pro,0.64,0.27,0.09,0.0,0.0,0%,0.0,0.0,anthony summey,
+DPA,4020,2.0,Visual Found of Digital Pro,0.23,0.54,0.08,0.0,0.15,0%,0.0,0.0,anthony summey,
+DPA,6000,843.0,Tech Foundations I,0.33,0.33,0.33,0.0,0.0,0%,0.0,0.0,eric patterson,
+DPA,6830,842.0,Spe Stu Top in DPA: Dig Ci,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,eric patterson,
+DPA,8090,1.0,Rendering and Shading,0.5,0.3,0.2,0.0,0.0,0%,0.0,0.0,daljit singh dhillon,
+DSA,8010,401.0,Statistical Methods I,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,deborah kunkel,
+DSA,8030,401.0,Intro to Statistical Computi,0.56,0.33,0.0,0.0,0.0,0%,0.0,0.11,ellen hepfer breazel,
+DSA,8640,1.0,Programming for Data Scie,0.83,0.1,0.03,0.0,0.0,0%,0.0,0.03,hongki kim,
+ECAS,2990,201.0,CI CU Eng for Dev Countrie,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,david vaughn,
+ECAS,2990,301.0,CI SPECTRA,0.8,0.0,0.1,0.0,0.0,0%,0.0,0.1,joshua summers,
+ECE,2010,1.0,Logic and Computing Devic,0.28,0.33,0.25,0.04,0.04,0%,0.0,0.04,hassan raza,
+ECE,2010,2.0,Logic & Comp Device (HO,0.53,0.2,0.13,0.07,0.07,0%,0.0,0.0,william reid,True
+ECE,2020,1.0,Electric Circuits I,0.15,0.32,0.25,0.09,0.11,0%,0.0,0.09,william harrell,
+ECE,2070,1.0,Basic Electrical Engineering,0.31,0.22,0.21,0.15,0.04,0%,0.0,0.07,wesley green,
+ECE,2070,2.0,Basic Electrical Engineering,0.2,0.2,0.28,0.11,0.13,0%,0.0,0.08,jeffrey osterberg,
+ECE,2070,3.0,Basic Electrical Engineering,0.37,0.32,0.18,0.08,0.05,0%,0.0,0.01,timothy anglea,
+ECE,2080,1.0,Basic Electrical Engr Lab,0.7,0.15,0.05,0.0,0.0,0%,0.0,0.1,apoorva kapadia,
+ECE,2080,2.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,
+ECE,2080,7.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,
+ECE,2080,8.0,Basic Electrical Engr Lab,0.9,0.0,0.0,0.0,0.0,0%,0.0,0.1,apoorva kapadia,
+ECE,2080,9.0,Basic Electrical Engr Lab,0.88,0.0,0.0,0.0,0.06,0%,0.0,0.06,apoorva kapadia,
+ECE,2080,10.0,Basic Electrical Engr Lab,0.89,0.06,0.0,0.0,0.06,0%,0.0,0.0,apoorva kapadia,
+ECE,2080,13.0,Basic Electrical Engr Lab,0.7,0.1,0.0,0.0,0.1,0%,0.0,0.1,apoorva kapadia,
+ECE,2080,14.0,Basic Electrical Engr Lab,0.89,0.0,0.05,0.0,0.0,0%,0.0,0.05,apoorva kapadia,
+ECE,2080,15.0,Basic Electrical Engr Lab,0.85,0.05,0.0,0.05,0.0,0%,0.0,0.05,apoorva kapadia,
+ECE,2090,1.0,Logic & Computing Device,0.77,0.08,0.0,0.0,0.08,0%,0.0,0.08,apoorva kapadia,
+ECE,2090,2.0,Logic & Computing Device,0.75,0.0,0.0,0.0,0.25,0%,0.0,0.0,apoorva kapadia,
+ECE,2090,3.0,Logic & Computing Device,0.67,0.25,0.0,0.0,0.08,0%,0.0,0.0,apoorva kapadia,
+ECE,2090,4.0,Logic & Computing Device,0.45,0.09,0.09,0.09,0.18,0%,0.0,0.09,apoorva kapadia,
+ECE,2090,5.0,Logic & Computing Device,0.33,0.67,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
+ECE,2090,6.0,Logic & Computing Device,0.7,0.0,0.0,0.0,0.1,0%,0.0,0.2,apoorva kapadia,
+ECE,2090,7.0,Logic & Computing Device,0.77,0.0,0.0,0.0,0.08,0%,0.0,0.15,apoorva kapadia,
+ECE,2090,12.0,Logic & Computing Device,0.36,0.18,0.0,0.0,0.0,0%,0.0,0.45,apoorva kapadia,
+ECE,2110,1.0,Elec Engr Lab I,0.7,0.15,0.1,0.0,0.05,0%,0.0,0.0,apoorva kapadia,
+ECE,2110,2.0,Elec Engr Lab I,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,apoorva kapadia,
+ECE,2110,3.0,Elec Engr Lab I,0.55,0.15,0.05,0.0,0.0,0%,0.0,0.25,apoorva kapadia,
+ECE,2110,5.0,Elec Engr Lab I,0.85,0.0,0.0,0.0,0.15,0%,0.0,0.0,apoorva kapadia,
+ECE,2110,6.0,Elec Engr Lab I,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
+ECE,2110,7.0,Elec Engr Lab I,0.7,0.1,0.0,0.0,0.0,0%,0.0,0.2,apoorva kapadia,
+ECE,2110,8.0,Elec Engr Lab I,0.58,0.26,0.05,0.0,0.0,0%,0.0,0.11,apoorva kapadia,
+ECE,2110,9.0,Elec Engr Lab I,0.85,0.1,0.0,0.0,0.05,0%,0.0,0.0,apoorva kapadia,
+ECE,2110,10.0,Elec Engr Lab I,0.64,0.0,0.0,0.0,0.09,0%,0.0,0.27,apoorva kapadia,
+ECE,2120,1.0,Electrical Engineering Lab I,0.64,0.0,0.14,0.0,0.14,0%,0.0,0.07,apoorva kapadia,
+ECE,2120,3.0,Electrical Engineering Lab I,0.85,0.0,0.0,0.0,0.0,0%,0.0,0.15,apoorva kapadia,
+ECE,2120,4.0,Electrical Engineering Lab I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
+ECE,2220,1.0,Syst Prog Concept,0.3,0.21,0.12,0.03,0.18,0%,0.0,0.15,lu yu,
+ECE,2230,1.0,Comp Sys Eng,0.22,0.24,0.19,0.17,0.02,0%,0.0,0.17,harlan russell,
+ECE,2620,1.0,Electric Circuits II,0.61,0.2,0.07,0.0,0.1,0%,0.0,0.02,liang dong,
+ECE,2720,1.0,Comp Organization,0.19,0.37,0.28,0.07,0.07,0%,0.0,0.02,william reid,
+ECE,2730,2.0,Computer Org Lab,0.46,0.38,0.08,0.0,0.08,0%,0.0,0.0,apoorva kapadia,
+ECE,2730,3.0,Computer Org Lab,0.38,0.38,0.13,0.06,0.0,0%,0.0,0.06,apoorva kapadia,
+ECE,2730,5.0,Computer Org Lab,0.5,0.3,0.1,0.0,0.0,0%,0.0,0.1,apoorva kapadia,
+ECE,3110,2.0,Electrical Engineering Lab I,0.73,0.13,0.0,0.07,0.07,0%,0.0,0.0,apoorva kapadia,
+ECE,3110,3.0,Electrical Engineering Lab I,0.81,0.13,0.0,0.0,0.0,0%,0.0,0.06,apoorva kapadia,
+ECE,3110,4.0,Electrical Engineering Lab I,0.53,0.18,0.0,0.0,0.24,0%,0.0,0.06,apoorva kapadia,
+ECE,3110,7.0,Electrical Engineering Lab I,0.65,0.12,0.06,0.0,0.0,0%,0.0,0.18,apoorva kapadia,
+ECE,3110,9.0,Electrical Engineering Lab I,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
+ECE,3120,1.0,Electrical Engineering Lab I,0.75,0.15,0.0,0.05,0.05,0%,0.0,0.0,apoorva kapadia,
+ECE,3120,2.0,Electrical Engineering Lab I,0.75,0.13,0.06,0.0,0.06,0%,0.0,0.0,apoorva kapadia,
+ECE,3170,1.0,Rand Signal Analysis,0.52,0.31,0.1,0.03,0.0,0%,0.0,0.05,stephen hubbard,
+ECE,3200,1.0,Electronics I,0.42,0.18,0.17,0.1,0.08,0%,0.0,0.05,stephen hubbard,
+ECE,3200,2.0,Electronics I (HON),0.4,0.5,0.1,0.0,0.0,0%,0.0,0.0,stephen hubbard,True
+ECE,3210,1.0,Electronics II,0.36,0.44,0.21,0.0,0.0,0%,0.0,0.0,tehseen raza,
+ECE,3220,1.0,Intro Operating Sys,0.25,0.19,0.19,0.13,0.13,0%,0.0,0.13,jacob sorber,
+ECE,3270,1.0,Dig Comp Design,0.35,0.41,0.11,0.0,0.05,0%,0.0,0.08,walter ligon,
+ECE,3300,1.0,Signals & Systems,0.22,0.18,0.21,0.13,0.16,0%,0.0,0.1,carl baum,
+ECE,3300,2.0,Signals & Systems (HON),0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,daniel noneaker,True
+ECE,3520,1.0,Programming Systems,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,yongkai wu,
+ECE,3600,1.0,Elect Power Engr,0.2,0.27,0.07,0.07,0.27,0%,0.0,0.13,sukumar brahma,
+ECE,3710,1.0,Microcontr Interface,0.31,0.38,0.18,0.02,0.1,0%,0.0,0.01,william reid,
+ECE,3720,1.0,Micro Int Lab,0.77,0.08,0.0,0.0,0.08,0%,0.0,0.08,apoorva kapadia,
+ECE,3720,2.0,Micro Int Lab,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
+ECE,3720,3.0,Micro Int Lab,0.46,0.23,0.08,0.0,0.23,0%,0.0,0.0,apoorva kapadia,
+ECE,3720,4.0,Micro Int Lab,0.5,0.08,0.08,0.08,0.0,0%,0.0,0.25,apoorva kapadia,
+ECE,3720,5.0,Micro Int Lab,0.73,0.18,0.0,0.0,0.09,0%,0.0,0.0,apoorva kapadia,
+ECE,3720,6.0,Micro Int Lab,0.77,0.0,0.0,0.0,0.15,0%,0.0,0.08,apoorva kapadia,
+ECE,3720,7.0,Micro Int Lab,0.75,0.0,0.0,0.08,0.0,0%,0.0,0.17,apoorva kapadia,
+ECE,3720,8.0,Micro Int Lab,0.54,0.0,0.08,0.08,0.08,0%,0.0,0.23,apoorva kapadia,
+ECE,3720,9.0,Micro Int Lab,0.33,0.25,0.08,0.0,0.17,0%,0.0,0.17,apoorva kapadia,
+ECE,3720,11.0,Micro Int Lab,0.45,0.27,0.0,0.0,0.09,0%,0.0,0.18,apoorva kapadia,
+ECE,3800,1.0,Electromagnetics,0.08,0.14,0.26,0.08,0.22,0%,0.0,0.22,anthony martin,
+ECE,3810,1.0,Field Waves & Ckts,0.33,0.5,0.15,0.0,0.0,0%,0.0,0.02,tehseen raza,
+ECE,4090,1.0,Intr to Linear Control Syste,0.73,0.24,0.02,0.01,0.0,0%,0.0,0.0,apoorva kapadia,
+ECE,4180,1.0,Power Syst Analysis,0.41,0.35,0.0,0.12,0.0,0%,0.0,0.12,ramtin hadidi,
+ECE,4270,1.0,Communication Systems,0.23,0.4,0.25,0.03,0.03,0%,0.0,0.06,lu yu,
+ECE,4310,1.0,Intro to Computer Vision,0.61,0.33,0.06,0.0,0.0,0%,0.0,0.0,adam hoover,
+ECE,4420,1.0,Knowledge Engineering,0.87,0.0,0.0,0.0,0.07,0%,0.0,0.07,ao ren,
+ECE,4490,1.0,Comp Ntwrk Security,0.33,0.24,0.05,0.05,0.0,0%,0.0,0.29,richard brooks,
+ECE,4610,1.0,Fundamentals of Solar Ene,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,rajendra singh,
+ECE,4670,1.0,Intro to Dig Sig Pro,0.31,0.44,0.19,0.06,0.0,0%,0.0,0.0,john gowdy,
+ECE,4730,1.0,Intro Parallel Sys,0.4,0.48,0.0,0.0,0.08,0%,0.0,0.04,walter ligon,
+ECE,4950,1.0,Int Sys Design I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,apoorva kapadia,
+ECE,4960,1.0,Int Sys Design II,0.7,0.26,0.04,0.0,0.0,0%,0.0,0.0,richard groff,
+ECE,6040,1.0,Semiconductor Devices,0.67,0.22,0.11,0.0,0.0,0%,0.0,0.0,judson ryckman,
+ECE,6310,1.0,Intro to Computer Vision,0.74,0.11,0.16,0.0,0.0,0%,0.0,0.0,adam hoover,
+ECE,6360,1.0,Microwave Circuits,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,pingshan wang,
+ECE,6490,1.0,Comp Ntwrk Security,0.71,0.14,0.0,0.0,0.0,0%,0.0,0.14,richard brooks,
+ECE,6590,1.0,Int Circ Design,0.36,0.36,0.0,0.0,0.0,0%,0.0,0.18,yingjie lao,
+ECE,6670,1.0,Intro to Dig Sig Pro,0.75,0.0,0.08,0.0,0.0,0%,0.0,0.17,john gowdy,
+ECE,8010,1.0,Analysis of Lin Sys,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,richard groff,
+ECE,8020,1.0,Elec Motor Cntl,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0, edrington,
+ECE,8020,843.0,Elec Motor Cntl,0.6,0.2,0.0,0.0,0.2,0%,0.0,0.0, edrington,
+ECE,8040,1.0,Networked Dynamical Syst,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,yongqiang wang,
+ECE,8120,1.0,Adv Electronic Materials/D,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,goutam koley,
+ECE,8270,1.0,Finite Dif Meth Emag,0.33,0.17,0.0,0.0,0.0,0%,0.0,0.17,anthony martin,
+ECE,8540,1.0,Analysis of Tracking Syste,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,adam hoover,
+ECE,8620,1.0,Com Appl Pwr Sys,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0, venayagamoorthy,
+ECE,8910,16.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,adam hoover,
+ECE,8910,39.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melissa smith,
+ECE,8910,44.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sukumar brahma,
+ECE,9910,21.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,goutam koley,
+ECE,9910,32.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yingjie lao,
+ECE,9910,39.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,melissa smith,
+ECE,9910,41.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, venayagamoorthy,
+ECON,2000,2.0,Economic Concepts,0.68,0.25,0.05,0.0,0.0,0%,0.0,0.03,shubhashrita basu,
+ECON,2000,4.0,Economic Concepts,0.46,0.34,0.17,0.0,0.03,0%,0.0,0.0,miren ivankovic,
+ECON,2000,5.0,Economic Concepts,0.64,0.33,0.03,0.0,0.0,0%,0.0,0.0,shubhashrita basu,
+ECON,2050,1.0,Why Business?,0.63,0.23,0.05,0.02,0.05,0%,0.0,0.02,lawrence watson,
+ECON,2110,1.0,Principles of Microeconom,0.11,0.26,0.32,0.11,0.11,0%,0.0,0.11,frederick hanssen,
+ECON,2110,2.0,Principles of Microeconom,0.05,0.37,0.42,0.05,0.11,0%,0.0,0.0,frederick hanssen,
+ECON,2110,3.0,Principles of Microeconom,0.05,0.42,0.42,0.05,0.05,0%,0.0,0.0,frederick hanssen,
+ECON,2110,4.0,Principles of Microeconom,0.16,0.47,0.21,0.0,0.0,0%,0.0,0.16,frederick hanssen,
+ECON,2110,5.0,Principles of Microeconom,0.0,0.58,0.16,0.05,0.11,0%,0.0,0.11,frederick hanssen,
+ECON,2110,6.0,Principles of Microeconom,0.06,0.44,0.28,0.06,0.17,0%,0.0,0.0,frederick hanssen,
+ECON,2110,7.0,Principles of Microeconom,0.05,0.32,0.37,0.11,0.16,0%,0.0,0.0,frederick hanssen,
+ECON,2110,8.0,Principles of Microeconom,0.16,0.37,0.37,0.05,0.0,0%,0.0,0.05,frederick hanssen,
+ECON,2110,9.0,Principles of Microeconom,0.11,0.42,0.21,0.05,0.0,0%,0.0,0.21,frederick hanssen,
+ECON,2110,10.0,Principles of Microeconom,0.0,0.32,0.58,0.0,0.05,0%,0.0,0.05,frederick hanssen,
+ECON,2110,11.0,Principles of Microeconom,0.11,0.37,0.26,0.11,0.11,0%,0.0,0.05,frederick hanssen,
+ECON,2110,12.0,Principles of Microeconom,0.0,0.47,0.21,0.05,0.05,0%,0.0,0.21,frederick hanssen,
+ECON,2110,13.0,Principles of Microeconom,0.0,0.79,0.11,0.05,0.0,0%,0.0,0.05,frederick hanssen,
+ECON,2110,14.0,Principles of Microeconom,0.16,0.42,0.32,0.05,0.0,0%,0.0,0.05,frederick hanssen,
+ECON,2110,15.0,Principles of Microeconom,0.05,0.47,0.16,0.05,0.05,0%,0.0,0.21,frederick hanssen,
+ECON,2110,16.0,Principles of Microeconom,0.05,0.32,0.32,0.11,0.11,0%,0.0,0.11,frederick hanssen,
+ECON,2110,17.0,Principles of Microeconom,0.16,0.47,0.32,0.0,0.0,0%,0.0,0.05,frederick hanssen,
+ECON,2110,18.0,Principles of Microeconom,0.11,0.63,0.11,0.0,0.05,0%,0.0,0.11,frederick hanssen,
+ECON,2110,19.0,Principles of Microeconom,0.05,0.26,0.53,0.05,0.0,0%,0.0,0.11,frederick hanssen,
+ECON,2110,20.0,Principles of Microeconom,0.25,0.44,0.22,0.06,0.01,0%,0.0,0.01,scott baier,
+ECON,2110,21.0,Principles of Microeconom,0.2,0.56,0.2,0.01,0.03,0%,0.0,0.0,scott baier,
+ECON,2110,23.0,Principles of Microeconom,0.68,0.23,0.05,0.0,0.02,0%,0.0,0.01,seyedmajid hashemi,
+ECON,2110,24.0,Principles of Microeconom,0.34,0.26,0.22,0.09,0.05,0%,0.0,0.05,devon merritt gorry,
+ECON,2110,25.0,Principles of Microeconom,0.48,0.29,0.21,0.0,0.02,0%,0.0,0.0,cory simpkins,
+ECON,2110,26.0,Principles of Microeconom,0.72,0.2,0.02,0.02,0.0,0%,0.0,0.02,tabitha knott,
+ECON,2110,31.0,Principles of Microeconom,0.62,0.29,0.07,0.01,0.0,0%,0.0,0.01,seyedmajid hashemi,
+ECON,2110,32.0,Principles of Microeconom,0.23,0.51,0.19,0.01,0.06,0%,0.0,0.0,scott baier,
+ECON,2110,33.0,Principles of Microeconom,0.67,0.19,0.1,0.0,0.05,0%,0.0,0.0,shilpi mukherjee,
+ECON,2110,34.0,Principles of Microecon (H,0.39,0.48,0.04,0.09,0.0,0%,0.0,0.0,charles thomas,True
+ECON,2110,35.0,Principles of Microeconom,0.38,0.52,0.07,0.0,0.0,0%,0.0,0.02,cory simpkins,
+ECON,2110,36.0,Principles of Microeconom,0.57,0.37,0.04,0.0,0.0,0%,0.0,0.01,tabitha knott,
+ECON,2110,38.0,Principles of Microeconom,0.4,0.4,0.1,0.02,0.05,0%,0.0,0.02,guncha babajanova,
+ECON,2110,40.0,Principles of Microeconom,0.61,0.17,0.07,0.07,0.05,0%,0.0,0.02,shilpi mukherjee,
+ECON,2110,41.0,Principles of Microeconom,0.5,0.43,0.05,0.0,0.0,0%,0.0,0.02,guncha babajanova,
+ECON,2120,1.0,Principles of Macroecono,0.15,0.44,0.25,0.13,0.04,0%,0.0,0.0,yinlin dai,
+ECON,2120,2.0,Principles of Macroecono,0.37,0.45,0.14,0.02,0.0,0%,0.0,0.02,bradley keith hobbs,
+ECON,2120,3.0,Principles of Macroecono,0.5,0.3,0.12,0.02,0.05,0%,0.0,0.02,krishna khatri,
+ECON,2120,4.0,Principles of Macroecono,0.72,0.22,0.06,0.0,0.0,0%,0.0,0.0,tyler francis,
+ECON,2120,5.0,Principles of Macroecono,0.48,0.33,0.1,0.03,0.03,0%,0.0,0.05,matthew lee cronin,
+ECON,2120,6.0,Principles of Macroecono,0.41,0.46,0.05,0.03,0.03,0%,0.0,0.03,matthew lee cronin,
+ECON,2120,7.0,Principles of Macroecono,0.78,0.15,0.04,0.01,0.01,0%,0.0,0.0,tyler francis,
+ECON,2120,8.0,Principles of Macroecono,0.19,0.45,0.21,0.1,0.03,0%,0.0,0.02,mason bixenman,
+ECON,2120,9.0,Principles of Macroecono,0.28,0.28,0.14,0.14,0.14,0%,0.0,0.03,yinlin dai,
+ECON,2120,10.0,Principles of Macroecono,0.35,0.48,0.15,0.03,0.0,0%,0.0,0.0,illia polovnikov,
+ECON,3020,1.0,Money and Banking,0.65,0.25,0.08,0.0,0.03,0%,0.0,0.0,adam witham,
+ECON,3030,2.0,Economics and Sports,0.37,0.47,0.11,0.0,0.03,0%,0.0,0.03,raymond sauer,
+ECON,3060,2.0,Managerial Economics,0.33,0.33,0.17,0.0,0.03,0%,0.0,0.13,miren ivankovic,
+ECON,3100,2.0,International Econ,0.36,0.43,0.15,0.04,0.0,0%,0.0,0.03,scott baier,
+ECON,3140,1.0,Intermediate Micro,0.41,0.17,0.2,0.11,0.04,0%,0.0,0.07,patrick warren,
+ECON,3140,3.0,Intermediate Micro,0.22,0.15,0.2,0.11,0.28,0%,0.0,0.04,frederick hanssen,
+ECON,3140,5.0,Intermediate Micro,0.37,0.4,0.18,0.02,0.02,0%,0.0,0.02,molly espey,
+ECON,3150,2.0,Intermediate Macro,0.09,0.4,0.27,0.09,0.09,0%,0.0,0.07, jerzmanowski,
+ECON,3150,4.0,Intermediate Macro,0.74,0.18,0.03,0.0,0.06,0%,0.0,0.0,scott baier,
+ECON,3150,5.0,Intermediate Macro,0.92,0.03,0.0,0.0,0.03,0%,0.0,0.03,scott baier,
+ECON,3190,1.0,Environmental Econ,0.42,0.4,0.08,0.02,0.04,0%,0.0,0.04,molly espey,
+ECON,3500,1.0,Moral & Ethical Econ,0.25,0.33,0.08,0.0,0.17,0%,0.0,0.17,bradley keith hobbs,
+ECON,3600,1.0,Public Choice,0.44,0.3,0.16,0.06,0.0,0%,0.0,0.04,michael makowsky,
+ECON,4010,1.0,Labor Mkt Analysis,0.36,0.33,0.06,0.06,0.12,0%,0.0,0.06,chungsang lam,
+ECON,4020,1.0,Law and Economics,0.32,0.34,0.18,0.07,0.02,0%,0.0,0.07,howard bodenhorn,
+ECON,4040,1.0,Comp Econ Systems,0.19,0.38,0.24,0.0,0.05,0%,0.0,0.14, litsukova-bokar,
+ECON,4050,1.0,Intro to Econometric,0.46,0.19,0.15,0.08,0.08,0%,0.0,0.04,yichen christy zhou,
+ECON,4050,5.0,Intro to Econometric,0.4,0.26,0.17,0.06,0.11,0%,0.0,0.0,scott barkowski,
+ECON,4100,1.0,Economic Development,0.71,0.1,0.14,0.05,0.0,0%,0.0,0.0,robert tamura,
+ECON,4230,1.0,Economics of Health,0.45,0.28,0.1,0.05,0.08,0%,0.0,0.0,devon merritt gorry,
+ECON,4240,1.0,Organization of Ind,0.61,0.22,0.17,0.0,0.0,0%,0.0,0.0,matthew lewis,
+ECON,4280,1.0,Cost-Benefit Anlysis,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,robert kenneth fleck,
+ECON,4980,2.0,Economics Data Analytics,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,raymond sauer,
+ECON,4980,3.0,Machine Learning I,0.45,0.18,0.0,0.0,0.18,0%,0.0,0.18,chungsang lam,
+ECON,6060,1.0,Advanced Econometric,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,scott baier,
+ECON,6280,1.0,Cost-Benefit Anlysis,0.67,0.17,0.17,0.0,0.0,0%,0.0,0.0,robert kenneth fleck,
+ECON,8010,1.0,Microeconomic Theory,0.33,0.33,0.2,0.0,0.07,0%,0.0,0.0,william dougan,
+ECON,8040,1.0,Applied Math Econ,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,curtis simon,
+ECON,8080,1.0,Econometrics III,0.12,0.76,0.12,0.0,0.0,0%,0.0,0.0,paul wayne wilson,
+ECON,8160,1.0,Labor Economics,0.4,0.4,0.0,0.0,0.0,0%,0.0,0.2,curtis simon,
+ECON,8230,1.0,Microecon Pub Pol,0.17,0.67,0.08,0.0,0.0,0%,0.0,0.08,scott templeton,
+ECON,8990,5.0,Sel Topics - Macro Theory I,0.57,0.43,0.0,0.0,0.0,0%,0.0,0.0,christopher gorry,
+ECON,9000,2.0,Econometrics I,0.2,0.6,0.2,0.0,0.0,0%,0.0,0.0, menendez garcia,
+ECON,9000,3.0,Econometrics II,0.35,0.5,0.15,0.0,0.0,0%,0.0,0.0, menendez garcia,
+ECON,9010,1.0,Price Theory,0.6,0.2,0.2,0.0,0.0,0%,0.0,0.0,charles thomas,
+ECON,9810,1.0,App Econ Analysis,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,howard bodenhorn,
+ECON,9820,2.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,frederick hanssen,
+ECON,9820,3.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,curtis simon,
+ECON,9820,4.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,william dougan,
+ECON,9820,5.0,Workshop in Ap Econ,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert tamura,
+ECON,9910,4.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gerald dwyer,
+ED,1050,6.0,Orientation to Education,0.88,0.04,0.0,0.0,0.04,0%,0.0,0.04,hilary tanck,
+ED,1050,7.0,Orientation to Education,0.8,0.13,0.0,0.0,0.07,0%,0.0,0.0,yashica latimer,
+ED,1050,8.0,Orientation to Education,0.79,0.07,0.0,0.0,0.07,0%,0.0,0.07,yashica latimer,
+ED,1050,9.0,Orientation to Education,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.03,yashica latimer,
+ED,1970,4.0,CI-CONNECTIONS Stud Dev,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,deonte brown,
+ED,3010,1.0,Principles of American Edu,0.85,0.04,0.0,0.0,0.11,0%,0.0,0.0,beatrice naff bailey,
+ED,3010,3.0,Principles of American Edu,0.92,0.0,0.0,0.0,0.08,0%,0.0,0.0,beatrice naff bailey,
+ED,8090,450.0,Teacher Residency Interns,0.93,0.05,0.0,0.0,0.0,0%,0.0,0.03,corrie leigh martin,
+ED,8480,450.0,Teacher Residency Semina,0.98,0.0,0.0,0.0,0.0,0%,0.0,0.02,laura cohen eicher,
+ED,8750,331.0,Elements of Instructional E,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,anna morrison,
+ED,8990,331.0,Capstone Research Project,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,daphne wiles,
+EDC,8140,401.0,Develpmnt of Counseling S,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,barbara boyd,
+EDC,8410,400.0,School Counseling Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,amanda rumsey,
+EDC,8460,400.0,Clinical Ment Hlth Coun Int,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,corrine sackett,
+EDC,8460,401.0,Clinical Ment Hlth Coun Int,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david scott,
+EDEC,4300,1.0,Early Childhd Math,0.93,0.04,0.0,0.0,0.0,0%,0.0,0.04,sandra linder,
+EDEC,4400,1.0,Early Childhood Engl Lang,0.86,0.11,0.0,0.0,0.0,0%,0.0,0.04,anna henson hall,
+EDEL,3210,2.0,Pe for the Elem Tchr,0.46,0.46,0.03,0.0,0.03,0%,0.0,0.03,deborah smith,
+EDEL,3210,3.0,Pe for the Elem Tchr,0.48,0.45,0.07,0.0,0.0,0%,0.0,0.0,deborah smith,
+EDEL,4510,1.0,Elem Methods in Science T,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,cynthia deaton,
+EDEL,4870,2.0,Ele Meth Soc Studies,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,melinda spearman,
+EDF,3020,1.0,Educational Psychology,0.88,0.09,0.0,0.0,0.0,0%,0.0,0.03,meihua qian,
+EDF,3020,2.0,Educational Psychology,0.86,0.11,0.0,0.0,0.0,0%,0.0,0.03,meihua qian,
+EDF,3080,1.0,Classroom Assessment,0.95,0.03,0.0,0.03,0.0,0%,0.0,0.0,quesada hazel vega,
+EDF,3080,2.0,Classroom Assessment,0.86,0.0,0.07,0.03,0.0,0%,0.0,0.03,quesada hazel vega,
+EDF,3340,1.0,Child Growth and Develop,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,faiza marghoob jamil,
+EDF,3340,3.0,Child Growth and Develop,0.7,0.22,0.05,0.0,0.03,0%,0.0,0.0,faiza marghoob jamil,
+EDF,3350,1.0,Adolescent Growth & Dev,0.9,0.07,0.0,0.0,0.0,0%,0.0,0.03,luke rapa,
+EDF,4800,1.0,Digital Media & Learning,0.64,0.23,0.0,0.05,0.09,0%,0.0,0.0,ryan visser,
+EDF,4800,2.0,Digital Media & Learning,0.87,0.0,0.09,0.0,0.04,0%,0.0,0.0,ryan visser,
+EDF,4800,300.0,Digital Media & Learning,0.9,0.07,0.03,0.0,0.0,0%,0.0,0.0,ryan visser,
+EDF,4800,302.0,Digital Media & Learning,0.93,0.04,0.04,0.0,0.0,0%,0.0,0.0,irgens arastoopour,
+EDF,8200,300.0,Effective Online Teaching,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,amanda bennett,
+EDF,8200,301.0,Effective Online Teaching,0.69,0.13,0.0,0.0,0.06,0%,0.0,0.13,robert todd kane,
+EDF,8200,500.0,Effective Online Teaching,0.88,0.04,0.0,0.0,0.04,0%,0.0,0.0,april susanne pelt,
+EDF,8200,501.0,Effective Online Teaching,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,valerie wheeler,
+EDF,8200,502.0,Effective Online Teaching,0.56,0.3,0.04,0.0,0.11,0%,0.0,0.0,amanda bennett,
+EDF,8200,505.0,Effective Online Teaching,0.83,0.0,0.03,0.0,0.14,0%,0.0,0.0,robert todd kane,
+EDF,8210,500.0,Online Course Manageme,0.81,0.04,0.0,0.0,0.12,0%,0.0,0.0,allyson marie wilcox,
+EDF,8210,501.0,Online Course Manageme,0.82,0.14,0.0,0.0,0.04,0%,0.0,0.0,karen bunch franklin,
+EDF,8210,502.0,Online Course Manageme,0.78,0.04,0.0,0.0,0.19,0%,0.0,0.0,robert todd kane,
+EDF,8210,505.0,Online Course Manageme,0.7,0.19,0.0,0.0,0.11,0%,0.0,0.0,amanda bennett,
+EDF,9270,1.0,Quant Rsrch & Stats for Ed,0.75,0.0,0.13,0.0,0.0,0%,0.0,0.13,christy jenkins brown,
+EDF,9790,1.0,Qualitative Research in Ed,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,melinda spearman,
+EDL,8200,400.0,Politics of Educ,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,danielle hall,
+EDL,8850,400.0,Diversity & School Commu,0.9,0.07,0.0,0.0,0.0,0%,0.0,0.0,reginald wilkerson,
+EDL,9770,2.0,Div Issues in Hi Ed,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,helen steele,
+EDL,9880,1.0,Directed Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,danielle hall,
+EDL,9910,3.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,natasha croom,
+EDL,9910,5.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,hans william klar,
+EDL,9910,6.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jane lindle,
+EDL,9910,7.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,danielle hall,
+EDL,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,reginald wilkerson,
+EDL,9910,10.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,noelle paufler,
+EDLL,8050,401.0,Contemp Iss in School Lea,0.92,0.0,0.0,0.0,0.0,0%,0.0,0.0,hans william klar,
+EDLL,8550,400.0,Secondary Sch Internship I,0.6,0.0,0.2,0.0,0.0,0%,0.0,0.0,melissa bryant burns,
+EDLT,4590,1.0,Teaching Reading Grades K,0.93,0.04,0.0,0.0,0.0,0%,0.0,0.04,lisa denise aker,
+EDLT,4600,1.0,Found of Read: Assess & In,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,hayley hoover,
+EDLT,4600,2.0,Found of Read: Assess & In,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,lisa denise aker,
+EDLT,4600,4.0,Found of Read: Assess & In,0.69,0.13,0.06,0.0,0.13,0%,0.0,0.0,polly wingate,
+EDLT,4610,1.0,Content Area Read/Writin,0.75,0.21,0.04,0.0,0.0,0%,0.0,0.0,pamela dunston,
+EDLT,4610,2.0,Content Area Read/Writin,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,pamela dunston,
+EDLT,4800,300.0,Found in Adolescent Litera,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,daniel stockwell,
+EDLT,4800,301.0,Found in Adolescent Litera,0.68,0.11,0.16,0.0,0.0,0%,0.0,0.05,daniel stockwell,
+EDLT,4980,1.0,Cont Area Read/Write Sec,0.86,0.1,0.0,0.0,0.0,0%,0.0,0.03,rachelle savitz,
+EDLT,8110,301.0,Adv Children's & Yng Adult,0.5,0.33,0.0,0.0,0.0,0%,0.0,0.0,susan king fullerton,
+EDLT,8150,301.0,Guided Reading & Guided,0.58,0.37,0.05,0.0,0.0,0%,0.0,0.0,pamela dunston,
+EDLT,8190,300.0,Coaching for Literacy Educ,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,rachelle savitz,
+EDLT,8400,501.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,barbara fewell,
+EDLT,8400,510.0,Early Literacy Assessment I,0.89,0.0,0.11,0.0,0.0,0%,0.0,0.0,kimberly floyd,
+EDLT,8400,511.0,Early Literacy Assessment I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,renee gatlin anders,
+EDLT,8400,515.0,Early Literacy Assessment I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,susanne elvington,
+EDLT,8400,516.0,Early Literacy Assessment I,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,ellen adkins sanford,
+EDSA,3900,6.0,Skills for Student Leaders,0.81,0.14,0.05,0.0,0.0,0%,0.0,0.0,deonte brown,
+EDSA,3990,1.0,Creative Inq in Counselor E,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,jacob frankovich,
+EDSA,8040,2.0,Theories Student Dev in Hi,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,tony cawthon,
+EDSA,8440,1.0,Student Affairs Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,tony cawthon,
+EDSC,2260,1.0,Pr Apprch to Sec Alg,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,stacy megan che,
+EDSC,4240,1.0,Tchng Sec English,0.8,0.07,0.13,0.0,0.0,0%,0.0,0.0, cridland-hughes,
+EDSC,4280,1.0,Tchng Secondary Social St,0.85,0.08,0.0,0.0,0.0,0%,0.0,0.08,kristen duncan,
+EDSP,3700,1.0,Intro to Special Education,0.91,0.06,0.03,0.0,0.0,0%,0.0,0.0,sharon walters,
+EDSP,3700,2.0,Intro to Special Education,0.73,0.23,0.0,0.0,0.0,0%,0.0,0.04,catherine griffith,
+EDSP,3700,4.0,Intro to Special Education,0.82,0.09,0.09,0.0,0.0,0%,0.0,0.0,catherine griffith,
+EDSP,3720,1.0,Char & Instr Individ with L,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,catherine griffith,
+EDSP,3740,1.0,Char & Strat Emot/Behav,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,shanna eisner hirsch,
+EDSP,3750,1.0,Early Intervention Spec Ne,0.84,0.12,0.0,0.0,0.04,0%,0.0,0.0,tracy denise garrett,
+EDSP,3750,2.0,Early Intervention Spec Ne,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,tracy denise garrett,
+EDSP,4920,1.0,Math Inst Ind W/Dis,0.87,0.1,0.03,0.0,0.0,0%,0.0,0.0,pamela stecker,
+EDSP,4930,1.0,Clsrm/Beh Mgmt Sp Ed,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,joseph benedict ryan,
+EDSP,4960,1.0,Sp Ed Field Exp,0.93,0.03,0.03,0.0,0.0,0%,0.0,0.0,wendell kent parker,
+EES,2010,1.0,Environ Engr Fundamental,0.32,0.34,0.21,0.05,0.03,0%,0.0,0.05,david freedman,
+EES,3030,1.0,Water Treatment Systems,0.32,0.5,0.14,0.04,0.0,0%,0.0,0.0,david allen ladner,
+EES,3040,1.0,Wastewater Treatment Sy,0.56,0.19,0.26,0.0,0.0,0%,0.0,0.0,sudeep popat,
+EES,3050,1.0,Water/Wastewater Treat,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,david allen ladner,
+EES,3050,2.0,Water/Wastewater Treat,0.64,0.14,0.07,0.0,0.07,0%,0.0,0.0,sudeep popat,
+EES,4010,1.0,Environmental Engr,0.67,0.22,0.09,0.02,0.0,0%,0.0,0.0,elizabeth carraway,
+EES,4010,2.0,Environmental Engr,0.25,0.5,0.25,0.0,0.0,0%,0.0,0.0,mark schlautman,
+EES,4090,1.0,Intro to Nuc Engr & Radiol,0.22,0.39,0.06,0.33,0.0,0%,0.0,0.0,timothy devol,
+EES,4300,1.0,Air Pollution Engineering,0.38,0.38,0.16,0.03,0.06,0%,0.0,0.0,andrew metcalf,
+EES,4800,1.0,Environmental Risk Assess,0.41,0.28,0.21,0.07,0.03,0%,0.0,0.0,nicole martinez,
+EES,4840,1.0,Solid Waste Mgt,0.5,0.31,0.15,0.04,0.0,0%,0.0,0.0,ezra lucas hoyt cates hoyt,
+EES,4860,2.0,Environmental Sustainabili,0.6,0.25,0.05,0.0,0.0,0%,0.0,0.1, carbajales-dale,
+EES,6100,1.0,Environ Radiation Protecti,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.2,nicole martinez,
+EES,8020,1.0,Environ Eng Prin,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,david allen ladner,
+EES,8060,1.0,Design Env Control,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0, carbajales-dale,
+EES,8430,1.0,Environmental Chem,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,brian powell,
+EES,8430,2.0,Environmental Chem,0.5,0.38,0.0,0.0,0.0,0%,0.0,0.13,brian powell,
+EES,8510,1.0,Biol Prin Envir Engr,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,kevin finneran,
+EES,8610,1.0,Environmental Engr & Sci S,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sudeep popat,
+EES,8800,1.0,Env Risk Assessment,0.3,0.7,0.0,0.0,0.0,0%,0.0,0.0,timothy devol,
+ELE,3010,1.0,Entrepreneurial Foundatio,0.28,0.28,0.28,0.07,0.07,0%,0.0,0.02,ashley parnell,
+ELE,3010,2.0,Entrepreneurial Foundatio,0.22,0.27,0.34,0.07,0.02,0%,0.0,0.07,ashley parnell,
+ELE,3010,3.0,Entrepreneurial Foundatio,0.62,0.28,0.08,0.03,0.0,0%,0.0,0.0,lori leigh tribble,
+ELE,3010,4.0,Entrepreneurial Foundatio,0.32,0.46,0.19,0.0,0.03,0%,0.0,0.0,lori leigh tribble,
+ELE,3010,5.0,Entrepreneurial Foundatio,0.56,0.25,0.13,0.03,0.0,0%,0.0,0.03,lori leigh tribble,
+ELE,4020,1.0,Venture Planning,0.2,0.7,0.11,0.0,0.0,0%,0.0,0.0,william dinardo,
+ELE,4040,1.0,Entrepreneurial Resource,0.68,0.2,0.1,0.0,0.0,0%,0.0,0.02,james keith hudgins,
+ELE,4060,1.0,Venture Consulting,0.35,0.63,0.03,0.0,0.0,0%,0.0,0.0,william dinardo,
+ENGL,1030,7.0,Composition and Rhetoric,0.48,0.43,0.1,0.0,0.0,0%,0.0,0.0,allen swords,
+ENGL,1030,8.0,Composition and Rhetoric,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,allen swords,
+ENGL,1030,43.0,Composition and Rhetoric,0.71,0.14,0.0,0.0,0.14,0%,0.0,0.0,hannah taylor,
+ENGL,1030,44.0,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,hannah taylor,
+ENGL,1030,47.0,Composition and Rhetoric,0.4,0.45,0.0,0.05,0.05,0%,0.0,0.05,cody hunter,
+ENGL,1030,48.0,Composition and Rhetoric,0.6,0.1,0.05,0.0,0.15,0%,0.0,0.1,cody hunter,
+ENGL,1030,49.0,Composition and Rhetoric,0.62,0.24,0.05,0.0,0.0,0%,0.0,0.1,nicholas rader,
+ENGL,1030,50.0,Composition and Rhetoric,0.86,0.05,0.0,0.0,0.05,0%,0.0,0.05,nicholas rader,
+ENGL,1030,51.0,Composition and Rhetoric,0.76,0.0,0.05,0.0,0.14,0%,0.0,0.05,sethunya gall,
+ENGL,1030,400.0,Composition and Rhetoric,0.57,0.29,0.0,0.0,0.14,0%,0.0,0.0,kailan smith sindelar,
+ENGL,1030,401.0,Composition and Rhetoric,0.57,0.33,0.0,0.0,0.1,0%,0.0,0.0,kailan smith sindelar,
+ENGL,1030,402.0,Composition and Rhetoric,0.86,0.1,0.0,0.0,0.05,0%,0.0,0.0,jonathan burgess,
+ENGL,1030,403.0,Composition and Rhetoric,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,jonathan burgess,
+ENGL,1030,404.0,Composition and Rhetoric,0.57,0.24,0.0,0.0,0.14,0%,0.0,0.05,eric reid hamilton,
+ENGL,1030,405.0,Composition and Rhetoric,0.48,0.24,0.05,0.14,0.1,0%,0.0,0.0,dennis ranahan,
+ENGL,1030,406.0,Composition and Rhetoric,0.81,0.05,0.0,0.05,0.05,0%,0.0,0.05,jacob danial richter,
+ENGL,1030,407.0,Composition and Rhetoric,0.33,0.39,0.11,0.0,0.11,0%,0.0,0.06,sheila lalwani,
+ENGL,1030,408.0,Composition and Rhetoric,0.06,0.41,0.24,0.12,0.18,0%,0.0,0.0,sheila lalwani,
+ENGL,1030,409.0,Composition and Rhetoric,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,jordan harris frith,
+ENGL,1030,410.0,Composition and Rhetoric,0.5,0.2,0.1,0.0,0.15,0%,0.0,0.05,hailee mccraw,
+ENGL,1030,411.0,Composition and Rhetoric,0.29,0.19,0.14,0.05,0.19,0%,0.0,0.14,hailee mccraw,
+ENGL,1030,412.0,Composition and Rhetoric,0.5,0.3,0.1,0.0,0.1,0%,0.0,0.0,miranda campbell,
+ENGL,1030,413.0,Composition and Rhetoric,0.47,0.26,0.21,0.0,0.05,0%,0.0,0.0,miranda campbell,
+ENGL,1030,414.0,Composition and Rhetoric,0.45,0.2,0.1,0.15,0.05,0%,0.0,0.05,edward thomas troy,
+ENGL,1030,415.0,Composition and Rhetoric,0.71,0.1,0.14,0.0,0.0,0%,0.0,0.05,lindsay scott,
+ENGL,1030,416.0,Composition and Rhetoric,0.53,0.18,0.06,0.06,0.06,0%,0.0,0.06,jennie wakefield,
+ENGL,1030,420.0,Composition and Rhetoric,0.62,0.19,0.05,0.05,0.0,0%,0.0,0.05,jennie wakefield,
+ENGL,1030,421.0,Composition and Rhetoric,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,aparna shastri,
+ENGL,1030,423.0,Composition and Rhetoric,0.89,0.06,0.0,0.0,0.0,0%,0.0,0.06,amanda platz,
+ENGL,1030,425.0,Composition and Rhetoric,0.83,0.06,0.0,0.06,0.0,0%,0.0,0.06,aparna shastri,
+ENGL,1030,426.0,Composition and Rhetoric,0.78,0.06,0.0,0.0,0.11,0%,0.0,0.06,laura caroline dunn,
+ENGL,1030,427.0,Composition and Rhetoric,0.58,0.16,0.11,0.11,0.05,0%,0.0,0.0,laura caroline dunn,
+ENGL,1030,428.0,Composition and Rhetoric,0.89,0.05,0.0,0.05,0.0,0%,0.0,0.0,nicole marie stout,
+ENGL,1030,429.0,Composition and Rhetoric,0.68,0.16,0.05,0.11,0.0,0%,0.0,0.0,amanda platz,
+ENGL,1030,430.0,Composition and Rhetoric,0.5,0.2,0.15,0.1,0.0,0%,0.0,0.05,edward thomas troy,
+ENGL,1030,431.0,Composition and Rhetoric,0.63,0.11,0.11,0.05,0.05,0%,0.0,0.05,edward thomas troy,
+ENGL,1030,435.0,Composition and Rhetoric,0.5,0.35,0.1,0.0,0.05,0%,0.0,0.0,edward thomas troy,
+ENGL,1030,436.0,Composition and Rhetoric,0.88,0.0,0.0,0.13,0.0,0%,0.0,0.0,nicole marie stout,
+ENGL,1030,437.0,Composition and Rhetoric,0.78,0.0,0.06,0.0,0.11,0%,0.0,0.06,kaitlyn samons,
+ENGL,1030,445.0,Composition and Rhetoric,0.78,0.17,0.06,0.0,0.0,0%,0.0,0.0,dennis ranahan,
+ENGL,1030,446.0,Composition and Rhetoric,0.6,0.15,0.1,0.05,0.0,0%,0.0,0.1,mary frankovich,
+ENGL,1030,453.0,Composition and Rhetoric,0.68,0.16,0.05,0.05,0.0,0%,0.0,0.05,mary frankovich,
+ENGL,1030,454.0,Composition and Rhetoric,0.75,0.15,0.0,0.0,0.05,0%,0.0,0.05,sarah richardson,
+ENGL,1030,456.0,Composition and Rhetoric,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,sarah richardson,
+ENGL,1030,457.0,Composition and Rhetoric,0.84,0.0,0.05,0.05,0.05,0%,0.0,0.0,michael vaughan,
+ENGL,1030,459.0,Composition and Rhetoric,0.83,0.06,0.11,0.0,0.0,0%,0.0,0.0,michael vaughan,
+ENGL,1030,460.0,Composition and Rhetoric,0.72,0.11,0.11,0.0,0.06,0%,0.0,0.0,caroline kinderthain,
+ENGL,1030,461.0,Composition and Rhetoric,0.69,0.19,0.06,0.0,0.0,0%,0.0,0.06,kylie carlson,
+ENGL,1030,464.0,Composition and Rhetoric,0.78,0.06,0.0,0.11,0.06,0%,0.0,0.0,kylie carlson,
+ENGL,1030,465.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0%,0.0,0.0,rebecca rea  ross s,
+ENGL,1030,467.0,Composition and Rhetoric,0.38,0.38,0.06,0.0,0.13,0%,0.0,0.06,rebecca rea  ross s,
+ENGL,1030,468.0,Composition and Rhetoric,0.63,0.26,0.05,0.0,0.05,0%,0.0,0.0,samantha keebler,
+ENGL,1030,469.0,Composition and Rhetoric,0.67,0.06,0.06,0.06,0.11,0%,0.0,0.06,samantha keebler,
+ENGL,1030,470.0,Composition and Rhetoric,0.69,0.06,0.13,0.0,0.06,0%,0.0,0.06,jenny washburne,
+ENGL,1030,471.0,Composition and Rhetoric,0.59,0.35,0.06,0.0,0.0,0%,0.0,0.0,jenny washburne,
+ENGL,1030,475.0,Composition and Rhetoric,0.41,0.06,0.29,0.12,0.0,0%,0.0,0.12,victoria lynn carrico,
+ENGL,1030,476.0,Composition and Rhetoric,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,victoria lynn carrico,
+ENGL,1030,477.0,Composition and Rhetoric,0.42,0.37,0.11,0.11,0.0,0%,0.0,0.0,kimberly groves,
+ENGL,1030,478.0,Composition and Rhetoric,0.67,0.11,0.06,0.0,0.0,0%,0.0,0.17,kimberly groves,
+ENGL,1030,482.0,Composition and Rhetoric,0.78,0.06,0.0,0.0,0.06,0%,0.0,0.11,kaitlyn samons,
+ENGL,1030,484.0,Composition and Rhetoric,0.5,0.22,0.28,0.0,0.0,0%,0.0,0.0,allison daniel,
+ENGL,1030,485.0,Composition and Rhetoric,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,allison daniel,
+ENGL,2020,1.0,Lit Forms and Creative Wri,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,melissa dugan,
+ENGL,2020,2.0,Lit Forms and Creative Wri,0.7,0.26,0.0,0.0,0.04,0%,0.0,0.0,melissa dugan,
+ENGL,2020,4.0,Lit Forms and Creative Wri,0.52,0.4,0.08,0.0,0.0,0%,0.0,0.0,keith morris,
+ENGL,2020,5.0,Lit Forms and Creative Wri,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,john logan pursley,
+ENGL,2020,400.0,Lit Forms and Creative Wri,0.68,0.2,0.04,0.08,0.0,0%,0.0,0.0,stephanie edwards,
+ENGL,2020,401.0,Lit Forms and Creative Wri,0.44,0.32,0.12,0.04,0.0,0%,0.0,0.08,stephanie edwards,
+ENGL,2020,402.0,Lit Forms and Creative Wri,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,jillian weise,
+ENGL,2020,403.0,Lit Forms and Creative Wri,0.52,0.28,0.04,0.08,0.08,0%,0.0,0.0,stephanie edwards,
+ENGL,2120,1.0,World Literature,0.48,0.28,0.08,0.04,0.08,0%,0.0,0.04,andrew mathas,
+ENGL,2120,2.0,World Literature,0.52,0.16,0.2,0.0,0.08,0%,0.0,0.04,caitlin grace watt,
+ENGL,2120,3.0,World Literature,0.44,0.28,0.08,0.0,0.12,0%,0.0,0.08,kenneth tuite,
+ENGL,2120,9.0,World Literature,0.56,0.16,0.12,0.04,0.08,0%,0.0,0.04,caitlin grace watt,
+ENGL,2120,10.0,World Literature,0.56,0.24,0.2,0.0,0.0,0%,0.0,0.0,caitlin grace watt,
+ENGL,2120,11.0,World Literature,0.48,0.24,0.2,0.04,0.04,0%,0.0,0.0,caitlin grace watt,
+ENGL,2120,13.0,World Literature,0.64,0.24,0.08,0.0,0.0,0%,0.0,0.04,remley makala,
+ENGL,2120,17.0,World Literature,0.78,0.17,0.0,0.0,0.04,0%,0.0,0.0,remley makala,
+ENGL,2120,21.0,World Literature,0.84,0.08,0.0,0.04,0.0,0%,0.0,0.04,remley makala,
+ENGL,2120,22.0,World Literature,0.36,0.32,0.08,0.0,0.16,0%,0.0,0.08,david charles foltz,
+ENGL,2120,23.0,World Literature,0.5,0.27,0.09,0.05,0.0,0%,0.0,0.05,david charles foltz,
+ENGL,2120,24.0,World Literature,0.42,0.25,0.21,0.04,0.0,0%,0.0,0.04,david charles foltz,
+ENGL,2120,25.0,World Literature,0.48,0.24,0.12,0.08,0.04,0%,0.0,0.04,david charles foltz,
+ENGL,2120,26.0,World Literature,0.64,0.2,0.12,0.0,0.0,0%,0.0,0.04,john benjamin fuqua,
+ENGL,2120,27.0,World Literature,0.71,0.21,0.04,0.0,0.0,0%,0.0,0.04,john benjamin fuqua,
+ENGL,2120,28.0,World Literature,0.4,0.36,0.0,0.08,0.16,0%,0.0,0.0,andrew mathas,
+ENGL,2120,400.0,World Literature,0.17,0.46,0.17,0.04,0.04,0%,0.0,0.13,sarah mae cooper,
+ENGL,2120,401.0,World Literature,0.25,0.5,0.17,0.0,0.0,0%,0.0,0.08,sarah mae cooper,
+ENGL,2120,402.0,World Literature,0.6,0.12,0.08,0.08,0.0,0%,0.0,0.12,sharon nalley,
+ENGL,2120,403.0,World Literature,0.64,0.16,0.04,0.0,0.04,0%,0.0,0.12,sharon nalley,
+ENGL,2120,404.0,World Literature,0.28,0.6,0.04,0.04,0.0,0%,0.0,0.04,sarah mae cooper,
+ENGL,2120,405.0,World Literature,0.88,0.0,0.12,0.0,0.0,0%,0.0,0.0,melissa dugan,
+ENGL,2120,406.0,World Literature,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,walter edgar hunter,
+ENGL,2120,407.0,World Literature,0.32,0.45,0.18,0.0,0.0,0%,0.0,0.05,daniel scott citro,
+ENGL,2120,408.0,World Literature,0.36,0.36,0.0,0.09,0.0,0%,0.0,0.18,daniel scott citro,
+ENGL,2120,409.0,World Literature,0.64,0.16,0.08,0.12,0.0,0%,0.0,0.0,sharon nalley,
+ENGL,2120,410.0,World Literature,0.56,0.2,0.04,0.12,0.04,0%,0.0,0.04,sharon nalley,
+ENGL,2120,411.0,World Literature,0.85,0.08,0.0,0.0,0.08,0%,0.0,0.0,walter edgar hunter,
+ENGL,2120,412.0,World Literature,0.63,0.13,0.13,0.0,0.0,0%,0.0,0.13,henna messina,
+ENGL,2120,413.0,World Literature,0.4,0.4,0.04,0.04,0.0,0%,0.0,0.12,henna messina,
+ENGL,2120,414.0,World Literature,0.55,0.36,0.0,0.0,0.0,0%,0.0,0.09,maziyar faridi,
+ENGL,2120,415.0,World Literature,0.4,0.48,0.04,0.0,0.0,0%,0.0,0.08,maziyar faridi,
+ENGL,2120,416.0,World Literature,0.72,0.24,0.0,0.04,0.0,0%,0.0,0.0,hannah godwin,
+ENGL,2120,417.0,World Literature,0.72,0.24,0.0,0.04,0.0,0%,0.0,0.0,hannah godwin,
+ENGL,2120,418.0,World Literature,0.84,0.12,0.0,0.0,0.0,0%,0.0,0.04,hannah godwin,
+ENGL,2120,419.0,World Literature,0.29,0.46,0.21,0.0,0.0,0%,0.0,0.0,sarah mae cooper,
+ENGL,2130,1.0,British Literature,0.6,0.2,0.07,0.07,0.07,0%,0.0,0.0,william stockton,
+ENGL,2130,2.0,British Literature,0.67,0.13,0.13,0.0,0.0,0%,0.0,0.07,william stockton,
+ENGL,2130,3.0,British Literature,0.6,0.27,0.13,0.0,0.0,0%,0.0,0.0,william stockton,
+ENGL,2130,4.0,British Literature,0.48,0.4,0.0,0.0,0.04,0%,0.0,0.08,john benjamin fuqua,
+ENGL,2130,5.0,British Literature,0.54,0.25,0.08,0.04,0.04,0%,0.0,0.04,remley makala,
+ENGL,2130,6.0,British Literature,0.67,0.25,0.04,0.0,0.04,0%,0.0,0.0,lucian ghita,
+ENGL,2130,7.0,British Literature,0.72,0.2,0.08,0.0,0.0,0%,0.0,0.0,lucian ghita,
+ENGL,2130,8.0,British Literature,0.84,0.08,0.08,0.0,0.0,0%,0.0,0.0,lucian ghita,
+ENGL,2130,400.0,British Literature,0.61,0.3,0.0,0.0,0.04,0%,0.0,0.0,daniel scott citro,
+ENGL,2130,401.0,British Literature,0.3,0.43,0.04,0.04,0.09,0%,0.0,0.04,daniel scott citro,
+ENGL,2130,402.0,British Literature,0.48,0.16,0.24,0.0,0.0,0%,0.0,0.08,henna messina,
+ENGL,2130,403.0,British Literature,0.61,0.3,0.0,0.0,0.04,0%,0.0,0.04,daniel scott citro,
+ENGL,2130,404.0,British Literature,0.4,0.52,0.0,0.0,0.04,0%,0.0,0.04,ingrid anna pierce,
+ENGL,2140,1.0,American Literature,0.08,0.56,0.2,0.0,0.04,0%,0.0,0.12,chelsea marie clarey,
+ENGL,2140,2.0,American Literature,0.13,0.58,0.25,0.0,0.04,0%,0.0,0.0,chelsea marie clarey,
+ENGL,2140,3.0,American Literature,0.25,0.42,0.21,0.04,0.04,0%,0.0,0.0,chelsea marie clarey,
+ENGL,2140,4.0,American Literature,0.22,0.3,0.17,0.04,0.04,0%,0.0,0.22,chelsea marie clarey,
+ENGL,2140,7.0,American Literature,0.84,0.08,0.0,0.04,0.0,0%,0.0,0.04,melissa dugan,
+ENGL,2140,8.0,American Literature,0.88,0.04,0.0,0.04,0.04,0%,0.0,0.0,melissa dugan,
+ENGL,2140,400.0,American Literature,0.38,0.38,0.25,0.0,0.0,0%,0.0,0.0,clare mullaney,
+ENGL,2140,401.0,American Literature,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,jennifer forsberg,
+ENGL,2140,402.0,American Literature,0.39,0.3,0.13,0.0,0.09,0%,0.0,0.09,karen kettnich,
+ENGL,2140,403.0,American Literature,0.43,0.43,0.04,0.0,0.09,0%,0.0,0.0,karen kettnich,
+ENGL,2140,404.0,American Literature,0.6,0.24,0.08,0.0,0.0,0%,0.0,0.08,jennifer forsberg,
+ENGL,2140,405.0,American Literature,0.68,0.16,0.16,0.0,0.0,0%,0.0,0.0,david charles foltz,
+ENGL,2140,406.0,American Literature,0.8,0.08,0.0,0.0,0.04,0%,0.0,0.08,sharon nalley,
+ENGL,2140,407.0,American Literature,0.5,0.25,0.17,0.0,0.04,0%,0.0,0.04,mary nestor,
+ENGL,2150,5.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.12,0.04,0.04,0%,0.0,0.0,william cunningham,
+ENGL,2150,7.0,Lit in 20th-21st Cent Conte,0.2,0.32,0.4,0.0,0.08,0%,0.0,0.0,megan macalystre,
+ENGL,2150,8.0,Lit in 20th-21st Cent Conte,0.52,0.24,0.12,0.08,0.0,0%,0.0,0.04,william cunningham,
+ENGL,2150,9.0,Lit in 20th-21st Cent Conte,0.48,0.35,0.04,0.0,0.09,0%,0.0,0.04,gregory luke chwala,
+ENGL,2150,10.0,Lit in 20th-21st Cent Conte,0.24,0.59,0.06,0.0,0.0,0%,0.0,0.12,gregory luke chwala,
+ENGL,2150,11.0,Lit in 20th-21st Cent Conte,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,allen swords,
+ENGL,2150,12.0,Lit in 20th-21st Cent Conte,0.84,0.12,0.04,0.0,0.0,0%,0.0,0.0,allen swords,
+ENGL,2150,14.0,Lit in 20th-21st Cent Conte,0.5,0.28,0.06,0.11,0.0,0%,0.0,0.06,gregory luke chwala,
+ENGL,2150,15.0,Lit in 20th-21st Cent Conte,0.58,0.38,0.0,0.0,0.04,0%,0.0,0.0,john logan pursley,
+ENGL,2150,16.0,Lit in 20th-21st Cent Conte,0.64,0.28,0.04,0.0,0.04,0%,0.0,0.0,john logan pursley,
+ENGL,2150,17.0,Lit in 20th-21st Cent Conte,0.36,0.32,0.12,0.0,0.12,0%,0.0,0.08,megan macalystre,
+ENGL,2150,18.0,Lit in 20th-21st Cent Conte,0.56,0.28,0.08,0.04,0.04,0%,0.0,0.0,elizabeth stansell,
+ENGL,2150,21.0,Lit in 20th-21st Cent Conte,0.52,0.3,0.09,0.04,0.04,0%,0.0,0.0,megan macalystre,
+ENGL,2150,22.0,Lit in 20th-21st Cent Conte,0.64,0.24,0.04,0.0,0.04,0%,0.0,0.04,john logan pursley,
+ENGL,2150,27.0,Lit in 20th-21st Cent Conte,0.64,0.32,0.0,0.0,0.0,0%,0.0,0.04,elizabeth stansell,
+ENGL,2150,29.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.08,0.08,0.04,0%,0.0,0.0,andrew mathas,
+ENGL,2150,30.0,Lit in 20th-21st Cent Conte,0.68,0.12,0.12,0.0,0.08,0%,0.0,0.0,andrew mathas,
+ENGL,2150,400.0,Lit in 20th-21st Cent Conte,0.6,0.24,0.12,0.0,0.04,0%,0.0,0.0,elizabeth stansell,
+ENGL,2150,401.0,Lit in 20th-21st Cent Conte,0.48,0.26,0.17,0.0,0.0,0%,0.0,0.04,gregory luke chwala,
+ENGL,2150,402.0,Lit in 20th-21st Cent Conte,0.72,0.16,0.0,0.04,0.0,0%,0.0,0.08,heather williams,
+ENGL,2150,403.0,Lit in 20th-21st Cent Conte,0.76,0.16,0.08,0.0,0.0,0%,0.0,0.0,heather williams,
+ENGL,2150,404.0,Lit in 20th-21st Cent Conte,0.54,0.13,0.0,0.04,0.17,0%,0.0,0.13,jamie ann rogers,
+ENGL,2150,405.0,Lit in 20th-21st Cent Conte,0.48,0.32,0.12,0.04,0.0,0%,0.0,0.04,mary nestor,
+ENGL,2150,406.0,Lit in 20th-21st Cent Conte,0.4,0.48,0.0,0.0,0.12,0%,0.0,0.0,mary nestor,
+ENGL,2150,407.0,Lit in 20th-21st Cent Conte,0.76,0.16,0.04,0.0,0.04,0%,0.0,0.0,april ayers lawson,
+ENGL,2150,409.0,Lit in 20th-21st Cent Conte,0.48,0.26,0.13,0.0,0.09,0%,0.0,0.04,sarah matalone,
+ENGL,2150,410.0,Lit in 20th-21st Cent Conte,0.52,0.28,0.04,0.0,0.04,0%,0.0,0.12,sarah matalone,
+ENGL,2150,411.0,Lit in 20th-21st Cent Conte,0.48,0.28,0.0,0.0,0.04,0%,0.0,0.2,tareva johnson,
+ENGL,2150,412.0,Lit in 20th-21st Cent Conte,0.54,0.25,0.0,0.0,0.08,0%,0.0,0.13,tareva johnson,
+ENGL,2150,413.0,Lit in 20th-21st Cent Conte,0.84,0.14,0.02,0.0,0.0,0%,0.0,0.0,david coombs,
+ENGL,2160,4.0,African American Literatur,0.44,0.32,0.12,0.04,0.0,0%,0.0,0.08,patricia sunia,
+ENGL,2160,400.0,African American Literatur,0.44,0.24,0.08,0.0,0.04,0%,0.0,0.2,tareva johnson,
+ENGL,2160,401.0,African American Literatur,0.44,0.24,0.08,0.0,0.08,0%,0.0,0.12,tareva johnson,
+ENGL,2160,402.0,African American Literatur,0.76,0.12,0.04,0.0,0.04,0%,0.0,0.04,jamie ann rogers,
+ENGL,2160,403.0,African American Literatur,0.68,0.12,0.04,0.04,0.08,0%,0.0,0.04,jamie ann rogers,
+ENGL,2160,404.0,African American Literatur,0.68,0.12,0.12,0.0,0.0,0%,0.0,0.04,jamie ann rogers,
+ENGL,2310,400.0,Intro to Journalism,0.71,0.19,0.0,0.0,0.05,0%,0.0,0.05,william pulley,
+ENGL,3010,1.0,Great Books of Western W,0.6,0.2,0.0,0.0,0.2,0%,0.0,0.0,dominic mastroianni,
+ENGL,3040,2.0,Business Writing,0.81,0.14,0.05,0.0,0.0,0%,0.0,0.0,ashley cowden fisk,
+ENGL,3040,400.0,Business Writing,0.77,0.14,0.0,0.05,0.05,0%,0.0,0.0,heather williams,
+ENGL,3040,401.0,Business Writing,0.86,0.1,0.05,0.0,0.0,0%,0.0,0.0,heather williams,
+ENGL,3040,402.0,Business Writing,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,
+ENGL,3040,403.0,Business Writing,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,
+ENGL,3040,404.0,Business Writing,0.71,0.19,0.0,0.0,0.0,0%,0.0,0.1,la'cresha ulon green,
+ENGL,3040,405.0,Business Writing,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,la'cresha ulon green,
+ENGL,3040,406.0,Business Writing,0.67,0.24,0.05,0.0,0.05,0%,0.0,0.0,ingrid anna pierce,
+ENGL,3040,407.0,Business Writing,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ingrid anna pierce,
+ENGL,3040,408.0,Business Writing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,ingrid anna pierce,
+ENGL,3040,409.0,Business Writing,0.59,0.23,0.14,0.0,0.0,0%,0.0,0.05,jennifer forsberg,
+ENGL,3040,410.0,Business Writing,0.67,0.19,0.14,0.0,0.0,0%,0.0,0.0,jennifer forsberg,
+ENGL,3040,411.0,Business Writing,0.67,0.19,0.14,0.0,0.0,0%,0.0,0.0,jennifer forsberg,
+ENGL,3040,414.0,Business Writing,0.86,0.1,0.0,0.0,0.05,0%,0.0,0.0,patricia sunia,
+ENGL,3100,1.0,Crit Writ Lit,0.43,0.43,0.0,0.05,0.1,0%,0.0,0.0,brian mcgrath,
+ENGL,3100,2.0,Crit Writ Lit,0.91,0.05,0.0,0.0,0.0,0%,0.0,0.05,matthew hooley,
+ENGL,3100,4.0,Crit Writ Lit,0.45,0.32,0.05,0.09,0.0,0%,0.0,0.05,cameron bushnell,
+ENGL,3120,1.0,Advanced Composition,0.43,0.33,0.05,0.0,0.14,0%,0.0,0.05,shauna chung,
+ENGL,3120,2.0,Advanced Composition,0.38,0.33,0.14,0.0,0.1,0%,0.0,0.05,shauna chung,
+ENGL,3140,7.0,Technical Writing,0.62,0.29,0.05,0.0,0.05,0%,0.0,0.0,william cunningham,
+ENGL,3140,8.0,Technical Writing,0.57,0.33,0.0,0.0,0.1,0%,0.0,0.0,william cunningham,
+ENGL,3140,401.0,Technical Writing,0.73,0.14,0.0,0.05,0.05,0%,0.0,0.05,katalin beck,
+ENGL,3140,402.0,Technical Writing,0.62,0.24,0.05,0.0,0.05,0%,0.0,0.05,katalin beck,
+ENGL,3140,405.0,Technical Writing,0.71,0.1,0.05,0.1,0.0,0%,0.0,0.05,henna messina,
+ENGL,3140,406.0,Technical Writing,0.76,0.05,0.14,0.05,0.0,0%,0.0,0.0,henna messina,
+ENGL,3140,407.0,Technical Writing,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,megan pietruszewski,
+ENGL,3140,409.0,Technical Writing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,megan pietruszewski,
+ENGL,3140,410.0,Technical Writing,0.81,0.1,0.0,0.0,0.1,0%,0.0,0.0,beltran quaglia,
+ENGL,3140,411.0,Technical Writing,0.76,0.14,0.0,0.0,0.0,0%,0.0,0.1,beltran quaglia,
+ENGL,3140,412.0,Technical Writing,0.85,0.05,0.0,0.0,0.0,0%,0.0,0.1,michelle lloyd,
+ENGL,3140,413.0,Technical Writing,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,michelle lloyd,
+ENGL,3140,414.0,Technical Writing,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,hannah godwin,
+ENGL,3140,416.0,Technical Writing,0.8,0.1,0.05,0.0,0.0,0%,0.0,0.05,michael measel,
+ENGL,3140,417.0,Technical Writing,0.71,0.14,0.0,0.05,0.05,0%,0.0,0.05,michael measel,
+ENGL,3140,418.0,Technical Writing,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,victoria houser,
+ENGL,3140,419.0,Technical Writing,0.62,0.19,0.14,0.05,0.0,0%,0.0,0.0,victoria houser,
+ENGL,3140,420.0,Technical Writing,0.62,0.29,0.1,0.0,0.0,0%,0.0,0.0,katalin beck,
+ENGL,3150,400.0,Scientific Writing & Comm,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,philip randall,
+ENGL,3150,401.0,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,philip randall,
+ENGL,3150,402.0,Scientific Writing & Comm,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,philip randall,
+ENGL,3150,404.0,Scientific Writing & Comm,0.83,0.11,0.06,0.0,0.0,0%,0.0,0.0,megan pietruszewski,
+ENGL,3150,405.0,Scientific Writing & Comm,0.71,0.14,0.05,0.0,0.05,0%,0.0,0.05,megan pietruszewski,
+ENGL,3150,406.0,Scientific Writing & Comm,0.68,0.26,0.0,0.0,0.05,0%,0.0,0.0,william pulley,
+ENGL,3150,407.0,Scientific Writing & Comm,0.57,0.24,0.1,0.05,0.05,0%,0.0,0.0,william pulley,
+ENGL,3150,408.0,Scientific Writing & Comm,0.5,0.3,0.1,0.0,0.05,0%,0.0,0.05,william pulley,
+ENGL,3150,409.0,Scientific Writing & Comm,0.9,0.0,0.05,0.0,0.05,0%,0.0,0.0,sheila lalwani,
+ENGL,3150,410.0,Scientific Writing & Comm,0.85,0.0,0.05,0.05,0.0,0%,0.0,0.05,sheila lalwani,
+ENGL,3450,400.0,Intr Creative Writing: Ficti,0.7,0.15,0.1,0.0,0.05,0%,0.0,0.0,sarah matalone,
+ENGL,3450,401.0,Intr Creative Writing: Ficti,0.48,0.29,0.05,0.0,0.1,0%,0.0,0.1,sarah matalone,
+ENGL,3460,400.0,Intr Creative Writing: Poet,0.6,0.25,0.1,0.0,0.05,0%,0.0,0.0,stephanie edwards,
+ENGL,3480,400.0,Intr Creat Writ: Screenwrit,0.79,0.0,0.0,0.0,0.11,0%,0.0,0.11,april ayers lawson,
+ENGL,3480,401.0,Intr Creat Writ: Screenwrit,0.85,0.0,0.0,0.0,0.05,0%,0.0,0.1,april ayers lawson,
+ENGL,3490,1.0,Tech/Pop Imagination,0.5,0.33,0.11,0.0,0.06,0%,0.0,0.0,michelle smith,
+ENGL,3500,1.0,Mythology,0.22,0.33,0.17,0.06,0.11,0%,0.0,0.06,kenneth tuite,
+ENGL,3570,4.0,Film,0.68,0.26,0.0,0.0,0.0,0%,0.0,0.0,john robert smith,
+ENGL,3570,400.0,Film,0.75,0.2,0.05,0.0,0.0,0%,0.0,0.0,amy monaghan,
+ENGL,3570,401.0,Film,0.47,0.26,0.11,0.0,0.05,0%,0.0,0.05,amy monaghan,
+ENGL,3570,402.0,Film,0.3,0.4,0.1,0.0,0.1,0%,0.0,0.1,amy monaghan,
+ENGL,3850,1.0,Children's Lit,0.39,0.5,0.06,0.0,0.06,0%,0.0,0.0,megan macalystre,
+ENGL,3860,400.0,Adolescent Lit,0.23,0.31,0.23,0.0,0.08,0%,0.0,0.08,amy monaghan,
+ENGL,3970,2.0,Brit Lit Survey II,0.62,0.24,0.1,0.0,0.05,0%,0.0,0.0,david coombs,
+ENGL,3980,400.0,Amer Lit Survey I,0.75,0.1,0.15,0.0,0.0,0%,0.0,0.0,kimberly manganelli,
+ENGL,3990,1.0,Amer Lit Survey II,0.7,0.15,0.05,0.0,0.05,0%,0.0,0.05,dominic mastroianni,
+ENGL,4010,2.0,Grammar Survey,0.36,0.29,0.29,0.07,0.0,0%,0.0,0.0,brian mcgrath,
+ENGL,4110,401.0,Shakespeare,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,andrew lemons,
+ENGL,4110,402.0,Shakespeare,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,andrew lemons,
+ENGL,4280,2.0,Contemporary Literature,0.38,0.31,0.08,0.0,0.08,0%,0.0,0.15,michael lemahieu,
+ENGL,4360,1.0,Feminist Literary Criticism,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,erin marina goss,
+ENGL,4400,1.0,Literary Theory,0.85,0.1,0.0,0.0,0.0,0%,0.0,0.05,matthew hooley,
+ENGL,4410,400.0,Literary Editing,0.23,0.46,0.23,0.0,0.0,0%,0.0,0.0,clare mullaney,
+ENGL,4440,1.0,Renaissance Literature,0.29,0.47,0.06,0.0,0.18,0%,0.0,0.0,william stockton,
+ENGL,4450,1.0,Fiction Workshop,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,nicholas brown,
+ENGL,4480,2.0,Screenwriting Wkshop,0.58,0.17,0.08,0.17,0.0,0%,0.0,0.0,nicholas brown,
+ENGL,4510,1.0,Film Theory and Criticism,0.53,0.37,0.11,0.0,0.0,0%,0.0,0.0,agnieszka skrodzka,
+ENGL,4520,2.0,Great Directors,0.48,0.14,0.14,0.0,0.0,0%,0.0,0.0,john robert smith,
+ENGL,4640,1.0,Topics in Literature 1700-1,0.42,0.25,0.17,0.17,0.0,0%,0.0,0.0,erin marina goss,
+ENGL,4750,400.0,Writing for Media,0.5,0.31,0.13,0.0,0.0,0%,0.0,0.06,jonathan field,
+ENGL,4820,1.0,Afr Am Lit to 1920,0.38,0.38,0.19,0.0,0.0,0%,0.0,0.05,rhondda thomas,
+ENGL,4830,1.0,Af Am Lit 1920-Pres,0.58,0.32,0.05,0.0,0.0,0%,0.0,0.05,maya sylvia hislop,
+ENGL,4920,400.0,Modern Rhetoric,0.69,0.08,0.08,0.0,0.15,0%,0.0,0.0,megan eatman,
+ENGL,4960,2.0,Senior Seminar,0.75,0.08,0.0,0.0,0.08,0%,0.0,0.08,michelle smith,
+ENGL,4960,400.0,Senior Seminar,0.79,0.07,0.07,0.0,0.0,0%,0.0,0.0,jonathan field,
+ENGL,8080,400.0,Top Renaiss & Restoration,0.86,0.07,0.0,0.0,0.07,0%,0.0,0.0,elizabeth rivlin,
+ENGL,8100,400.0,Literary Criticism & Theory,0.18,0.36,0.09,0.0,0.09,0%,0.0,0.18,lee morrissey,
+ENGL,8310,1.0,Special Topics,0.8,0.13,0.0,0.0,0.0,0%,0.0,0.07,maya sylvia hislop,
+ENGL,8910,1.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gabriel hankins,
+ENGR,1000,101.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,steven brandon,
+ENGR,1000,102.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,steven brandon,
+ENGR,1000,103.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,89%,0.09,0.02,steven brandon,
+ENGR,1000,104.0,Major Discovery Seminar,0.0,0.0,0.0,0.0,0.0,88%,0.1,0.02,steven brandon,
+ENGR,1010,392.0,Survey of Mathematical To,0.25,0.33,0.17,0.08,0.0,0%,0.0,0.17,andrew neptune,
+ENGR,1010,395.0,Survey of Mathematical To,0.29,0.46,0.13,0.0,0.08,0%,0.0,0.04,andrew neptune,
+ENGR,1010,396.0,Survey of Mathematical To,0.34,0.41,0.1,0.0,0.07,0%,0.0,0.07,andrew neptune,
+ENGR,1020,223.0,Engr Dis & Skills (HON),0.76,0.22,0.0,0.02,0.0,0%,0.0,0.0,richard watkins,True
+ENGR,1020,311.0,Engineering Discipl & Skills,0.32,0.39,0.03,0.13,0.03,0%,0.0,0.11,john minor,
+ENGR,1020,313.0,Engineering Discipl & Skills,0.52,0.22,0.17,0.0,0.04,0%,0.0,0.04,john minor,
+ENGR,1020,314.0,Engineering Discipl & Skills,0.67,0.26,0.05,0.02,0.0,0%,0.0,0.0,elizabeth stephan,
+ENGR,1020,317.0,Engineering Discipl & Skills,0.27,0.36,0.16,0.07,0.07,0%,0.0,0.09,katherine ehlert,
+ENGR,1020,318.0,Engineering Discipl & Skills,0.41,0.36,0.05,0.07,0.07,0%,0.0,0.05,katherine ehlert,
+ENGR,1020,611.0,Engineering Discipl & Skills,0.47,0.29,0.04,0.02,0.07,0%,0.0,0.11,baker martin,
+ENGR,1020,612.0,Engineering Discipl & Skills,0.52,0.22,0.13,0.02,0.0,0%,0.0,0.11,baker martin,
+ENGR,1020,613.0,Engineering Discipl & Skills,0.64,0.19,0.09,0.02,0.04,0%,0.0,0.02,taylor sorensen,
+ENGR,1020,614.0,Engineering Discipl & Skills,0.67,0.15,0.13,0.02,0.0,0%,0.0,0.02,taylor sorensen,
+ENGR,1020,615.0,Engineering Discipl & Skills,0.69,0.21,0.02,0.05,0.02,0%,0.0,0.0,taylor sorensen,
+ENGR,1020,616.0,Engineering Discipl & Skills,0.5,0.22,0.11,0.0,0.04,0%,0.0,0.13,joseph overlin chapa,
+ENGR,1020,617.0,Engineering Discipl & Skills,0.63,0.21,0.09,0.0,0.07,0%,0.0,0.0,joseph overlin chapa,
+ENGR,1020,618.0,Engineering Discipl & Skills,0.47,0.36,0.07,0.04,0.0,0%,0.0,0.07,joseph overlin chapa,
+ENGR,1020,801.0,Engineering Discipl & Skills,0.4,0.3,0.15,0.02,0.09,0%,0.0,0.04,irene marie ferrara,
+ENGR,1020,808.0,Engineering Discipl & Skills,0.41,0.28,0.2,0.04,0.02,0%,0.0,0.04,jonathan maier,
+ENGR,1020,812.0,Engineering Discipl & Skills,0.58,0.24,0.04,0.07,0.02,0%,0.0,0.04,irene marie ferrara,
+ENGR,1020,813.0,Engineering Discipl & Skills,0.6,0.23,0.12,0.0,0.02,0%,0.0,0.02,irene marie ferrara,
+ENGR,1020,814.0,Engineering Discipl & Skills,0.43,0.34,0.14,0.02,0.02,0%,0.0,0.05,michael waldrop,
+ENGR,1020,815.0,Engineering Discipl & Skills,0.48,0.3,0.15,0.0,0.02,0%,0.0,0.04,michael waldrop,
+ENGR,1020,816.0,Engineering Discipl & Skills,0.38,0.31,0.21,0.02,0.02,0%,0.0,0.05,michael waldrop,
+ENGR,1020,817.0,Engineering Discipl & Skills,0.47,0.3,0.13,0.0,0.04,0%,0.0,0.06,jonathan maier,
+ENGR,1020,881.0,Engr Discp & Skils (HON),0.68,0.24,0.03,0.0,0.0,0%,0.0,0.06,jonathan maier,True
+ENGR,1100,206.0,Engineering Success Skills,0.64,0.21,0.04,0.07,0.0,0%,0.0,0.04,jonathan harcum,
+ENGR,1100,603.0,Engineering Success Skills,0.72,0.12,0.08,0.0,0.0,0%,0.0,0.08,jonathan harcum,
+ENGR,1100,802.0,Engineering Success Skills,0.88,0.08,0.0,0.0,0.04,0%,0.0,0.0,jonathan harcum,
+ENGR,1410,223.0,Programming & Problem S,0.07,0.14,0.27,0.09,0.14,0%,0.0,0.16,steven brandon,
+ENGR,1410,226.0,Programming & Problem S,0.07,0.2,0.36,0.04,0.13,0%,0.0,0.11,william martin,
+ENGR,1410,227.0,Programming & Problem S,0.13,0.29,0.29,0.02,0.11,0%,0.0,0.13,william martin,
+ENGR,1510,322.0,Engineering Skills,0.41,0.37,0.07,0.0,0.04,0%,0.0,0.11,matthew kent miller,
+ENGR,1510,323.0,Engineering Skills,0.28,0.44,0.12,0.0,0.12,0%,0.0,0.04,matthew kent miller,
+ENGR,1510,325.0,Engineering Skills,0.36,0.28,0.2,0.04,0.0,0%,0.0,0.12,matthew kent miller,
+ENGR,1900,219.0,CI 3D Maker Space SOP,0.83,0.0,0.17,0.0,0.0,0%,0.0,0.0,todd schweisinger,
+ENGR,2080,681.0,Engr Graphics & Machine,0.44,0.25,0.13,0.0,0.08,0%,0.0,0.1,kyle walker,
+ENGR,2080,682.0,Engr Graphics & Machine,0.56,0.25,0.1,0.0,0.0,0%,0.0,0.06,vishal thomas,
+ENGR,2080,684.0,Engr Graphics & Machine,0.39,0.22,0.06,0.06,0.08,0%,0.0,0.12,jennifer paige brown,
+ENGR,2080,685.0,Engr Graphics & Machine,0.45,0.24,0.18,0.0,0.08,0%,0.0,0.04,jessica plaunt,
+ENGR,2080,686.0,Engr Graphics & Machine,0.57,0.17,0.06,0.04,0.02,0%,0.0,0.13,nighat yasmin,
+ENGR,2100,804.0,CAD & Engineering Applica,0.47,0.2,0.16,0.02,0.09,0%,0.0,0.07,naini shervin shoai,
+ENGR,2100,805.0,CAD & Engineering Applica,0.35,0.33,0.13,0.07,0.07,0%,0.0,0.07,nighat yasmin,
+ENGR,2100,806.0,CAD & Engineering Applica,0.2,0.39,0.13,0.02,0.09,0%,0.0,0.17,naini shervin shoai,
+ENR,1010,2.0,Intro to Envir & Natur Res I,0.47,0.27,0.18,0.02,0.05,0%,0.0,0.0, guggenheimer,
+ENR,1010,3.0,Intro to Envir & Natur Res I,0.52,0.22,0.13,0.05,0.08,0%,0.0,0.0, guggenheimer,
+ENR,4290,1.0,Environ Law & Policy,0.64,0.19,0.11,0.02,0.02,0%,0.0,0.02,alan johnson,
+ENR,4290,2.0,Environ Law & Policy,0.73,0.13,0.04,0.04,0.02,0%,0.0,0.02,alan johnson,
+ENSP,2000,1.0,Intro Environ Sci,0.57,0.32,0.06,0.0,0.02,0%,0.0,0.02,scott brame,
+ENSP,2000,2.0,Intro Environ Sci,0.95,0.04,0.02,0.0,0.0,0%,0.0,0.0,minory nammouz,
+ENSP,2000,3.0,Intro Environ Sci,0.87,0.09,0.0,0.02,0.0,0%,0.0,0.02,minory nammouz,
+ENSP,2000,4.0,Intro Environ Sci,0.58,0.26,0.05,0.05,0.02,0%,0.0,0.04,elizabeth carraway,
+ENSP,2000,5.0,Intro Environ Sci,0.63,0.24,0.09,0.0,0.02,0%,0.0,0.02,tom owino,
+ENSP,2000,6.0,Intro Environ Sci,0.4,0.55,0.05,0.0,0.0,0%,0.0,0.0,emily don scribner,
+ENSP,4000,1.0,Studies in Environmental S,0.57,0.17,0.04,0.0,0.17,0%,0.0,0.0,margaret thompson,
+ENT,3010,1.0,Insect Biology and Diversit,0.52,0.1,0.14,0.0,0.14,0%,0.0,0.1,michael ferro,
+ENT,8100,1.0,Bio & Phylogeog of S. Appa,0.64,0.09,0.27,0.0,0.0,0%,0.0,0.0,michael caterino,
+ENTR,1010,3.0,Entrepreneurial Mindset,0.85,0.09,0.03,0.01,0.02,0%,0.0,0.01,john michael hannon,
+ENTR,1090,1.0,Creative Inq-Entrepreneur,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,john michael hannon,
+ENTR,2010,4.0,Sports Entrepreneurship,0.58,0.26,0.05,0.0,0.05,0%,0.0,0.05,john michael hannon,
+ESED,8100,1.0,Orientation to ESME Resea,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eliza gallagher,
+ESED,8720,1.0,Action Research in STEM E,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.0,karen ann high,
+ESED,9910,3.0,Dissertation Rsrch and Wri,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,eliza gallagher,
+ESED,9910,5.0,Dissertation Rsrch and Wri,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,karen ann high,
+ETOX,4300,1.0,Toxicology,0.5,0.18,0.18,0.05,0.05,0%,0.0,0.05,lisa bain,
+ETOX,6300,1.0,Toxicology,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,lisa bain,
+ETOX,8610,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,den hurk peter van peter,
+FDSC,1010,1.0,Intro to Food Sci & Hum N,0.65,0.27,0.05,0.01,0.01,0%,0.0,0.01,carol hegler,
+FDSC,3010,1.0,Food Regulations,0.81,0.15,0.04,0.0,0.0,0%,0.0,0.0,sara lane cothran,
+FDSC,4010,1.0,Food Chemistry I,0.45,0.5,0.05,0.0,0.0,0%,0.0,0.0,feng chen,
+FDSC,4500,12.0,Creative Inquiry-Food Scie,0.82,0.0,0.09,0.0,0.0,0%,0.0,0.09,paul dawson,
+FDSC,6010,1.0,Food Chem I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,feng chen,
+FDSC,8120,1.0,Microbial Food Syst,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,xiuping jiang,
+FIN,2010,401.0,Intro to Personal Finance I,0.98,0.01,0.0,0.0,0.01,0%,0.0,0.01,joshua harris,
+FIN,2010,402.0,Intro to Personal Finance I,0.84,0.08,0.04,0.02,0.02,0%,0.0,0.0,joshua harris,
+FIN,2020,401.0,Intro to Personal Finance II,0.97,0.0,0.0,0.0,0.02,0%,0.0,0.01,joshua harris,
+FIN,3040,1.0,Risk & Insurance,0.22,0.42,0.24,0.11,0.0,0%,0.0,0.0,kerri mcmillan,
+FIN,3050,1.0,Investment Analysis,0.16,0.25,0.41,0.14,0.02,0%,0.0,0.02,kerri mcmillan,
+FIN,3050,2.0,Investment Analysis,0.22,0.29,0.33,0.09,0.04,0%,0.0,0.02,kerri mcmillan,
+FIN,3050,3.0,Investment Analysis,0.16,0.27,0.32,0.07,0.07,0%,0.0,0.11,kerri mcmillan,
+FIN,3050,4.0,Investment Analysis,0.13,0.22,0.29,0.18,0.04,0%,0.0,0.13,john alexander,
+FIN,3060,1.0,Corporation Finance,0.47,0.27,0.14,0.04,0.04,0%,0.0,0.03,ramon franklin,
+FIN,3060,2.0,Corporation Finance,0.36,0.36,0.13,0.04,0.07,0%,0.0,0.04,ramon franklin,
+FIN,3060,3.0,Corporation Finance,0.25,0.25,0.27,0.16,0.02,0%,0.0,0.04,minxing sun,
+FIN,3060,4.0,Corporation Finance,0.16,0.38,0.25,0.16,0.0,0%,0.0,0.05,minxing sun,
+FIN,3060,5.0,Corporation Finance,0.07,0.21,0.5,0.21,0.0,0%,0.0,0.0,minxing sun,
+FIN,3060,6.0,Corporation Finance,0.55,0.23,0.11,0.04,0.0,0%,0.0,0.04,ramon franklin,
+FIN,3060,7.0,Corporation Finance,0.18,0.29,0.29,0.08,0.06,0%,0.0,0.1,taufique samdani,
+FIN,3060,401.0,Corporation Finance,0.48,0.27,0.15,0.0,0.04,0%,0.0,0.06,jonathan godbey,
+FIN,3060,402.0,Corporation Finance,0.46,0.22,0.18,0.1,0.0,0%,0.0,0.02,jonathan godbey,
+FIN,3070,1.0,Prin of Real Estate,0.26,0.21,0.23,0.23,0.05,0%,0.0,0.03,thomas springer,
+FIN,3070,2.0,Prin of Real Estate,0.36,0.18,0.28,0.15,0.03,0%,0.0,0.0,thomas springer,
+FIN,3070,5.0,Prin of Real Estate,0.21,0.46,0.26,0.05,0.03,0%,0.0,0.0,bryan blackwood,
+FIN,3080,1.0,Fin Inst & Mkts,0.6,0.28,0.1,0.03,0.0,0%,0.0,0.0,lyudmila chernykh,
+FIN,3080,2.0,Fin Inst & Mkts,0.74,0.21,0.03,0.03,0.0,0%,0.0,0.0,lyudmila chernykh,
+FIN,3080,3.0,Fin Inst & Mkts,0.36,0.44,0.18,0.03,0.0,0%,0.0,0.0,daniel greene,
+FIN,3080,401.0,Fin Inst & Mkts,0.44,0.3,0.24,0.0,0.02,0%,0.0,0.0,daniel greene,
+FIN,3110,1.0,Financial Management I,0.11,0.14,0.09,0.11,0.31,0%,0.0,0.23,jack wolf,
+FIN,3110,2.0,Financial Management I,0.08,0.03,0.36,0.08,0.26,0%,0.0,0.21,jack wolf,
+FIN,3110,3.0,Financial Management I,0.09,0.33,0.28,0.14,0.16,0%,0.0,0.0,weike xu,
+FIN,3110,4.0,Financial Management I,0.54,0.3,0.09,0.06,0.0,0%,0.0,0.01,joshua harris,
+FIN,3110,5.0,Financial Management I,0.46,0.39,0.14,0.0,0.01,0%,0.0,0.0,joshua harris,
+FIN,3120,1.0,Financial Management II,0.14,0.39,0.35,0.04,0.02,0%,0.0,0.06,weike xu,
+FIN,3120,2.0,Financial Management II,0.16,0.52,0.26,0.04,0.02,0%,0.0,0.0,weike xu,
+FIN,3120,3.0,Financial Management II,0.24,0.34,0.24,0.08,0.02,0%,0.0,0.08,taufique samdani,
+FIN,3120,4.0,Financial Management II,0.1,0.41,0.14,0.14,0.02,0%,0.0,0.18,taufique samdani,
+FIN,3120,5.0,Financial Management II,0.45,0.23,0.14,0.0,0.07,0%,0.0,0.11,arash dayani,
+FIN,3120,6.0,Financial Management II,0.35,0.15,0.2,0.05,0.15,0%,0.0,0.1,arash dayani,
+FIN,4010,1.0,Corporate Financial Analys,0.63,0.15,0.2,0.03,0.0,0%,0.0,0.0,george lockhart,
+FIN,4010,2.0,Corporate Financial Analys,0.55,0.3,0.13,0.0,0.0,0%,0.0,0.03,george lockhart,
+FIN,4020,1.0,Corporate Valuation,0.22,0.3,0.26,0.11,0.04,0%,0.0,0.07,angela morgan,
+FIN,4020,101.0,Corporate Valuation (HON,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,angela morgan,True
+FIN,4030,1.0,Spreadsheet Apps in Finan,0.26,0.24,0.38,0.09,0.0,0%,0.0,0.03,vincent intintoli,
+FIN,4030,2.0,Spreadsheet Apps in Finan,0.27,0.4,0.13,0.13,0.07,0%,0.0,0.0,vincent intintoli,
+FIN,4050,1.0,Portfolio Management & T,0.16,0.14,0.28,0.21,0.09,0%,0.0,0.12,john alexander,
+FIN,4060,1.0,Derivatives Analysis,0.14,0.34,0.37,0.09,0.03,0%,0.0,0.03,blerina zykaj,
+FIN,4110,1.0,Int Fin Mgt,0.29,0.53,0.16,0.03,0.0,0%,0.0,0.0,luke asher devault,
+FIN,4110,2.0,Int Fin Mgt,0.2,0.58,0.2,0.03,0.0,0%,0.0,0.0,luke asher devault,
+FIN,4150,1.0,Real Estate Investmt,0.31,0.19,0.35,0.0,0.08,0%,0.0,0.08,thomas springer,
+FIN,4980,7.0,CI in Finance: SIE,0.9,0.0,0.0,0.0,0.0,0%,0.0,0.1,joshua harris,
+FNR,2040,1.0,Soil Information Systems,0.79,0.16,0.03,0.0,0.0,0%,0.0,0.02,elena mikhailova,
+FNR,4990,1.0,Natural Resources Seminar,0.86,0.05,0.0,0.0,0.05,0%,0.0,0.05,robert fritz baldwin,
+FOR,2050,1.0,Dendrology,0.66,0.13,0.05,0.08,0.08,0%,0.0,0.0,donald hagan,
+FOR,2050,2.0,Dendrology,0.56,0.18,0.09,0.06,0.03,0%,0.0,0.09,donald hagan,
+FOR,2050,3.0,Dendrology,0.66,0.17,0.11,0.0,0.06,0%,0.0,0.0,donald hagan,
+FOR,2210,2.0,Forest Biology,0.95,0.03,0.0,0.0,0.0,0%,0.0,0.02,patrick mcmillan,
+FOR,3040,1.0,Forest Resource Economic,0.81,0.16,0.0,0.03,0.0,0%,0.0,0.0,puskar khanal,
+FOR,3410,1.0,Wood Procure Pract,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,patrick hiesl,
+FOR,4100,1.0,Harvesting Processes,0.63,0.3,0.0,0.07,0.0,0%,0.0,0.0,patrick hiesl,
+FOR,4130,1.0,Forest Protection,0.77,0.2,0.0,0.03,0.0,0%,0.0,0.0,jessica hartshorn,
+FOR,4150,1.0,Forest Wildlife Managmen,0.44,0.31,0.19,0.0,0.0,0%,0.0,0.06,greg yarrow,
+FOR,4160,1.0,Forest Policy and Admin,0.78,0.16,0.05,0.0,0.0,0%,0.0,0.01,patricia layton,
+FOR,4170,1.0,Forest Resource Mgt & Re,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,puskar khanal,
+FOR,4310,1.0,Recreation Res Plan in For,0.52,0.39,0.1,0.0,0.0,0%,0.0,0.0,robert baxter powell,
+FOR,4340,1.0,GIS for Natural Resources,0.79,0.12,0.02,0.02,0.0,0%,0.0,0.0,christopher post,
+FOR,8910,2.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,donald hagan,
+FOR,8930,22.0,Professional Development,0.57,0.14,0.0,0.0,0.0,0%,0.0,0.14,david jachowski,
+FR,1010,1.0,Elementary French,0.61,0.22,0.04,0.0,0.09,0%,0.0,0.04,amy lyn sawyer,
+FR,1010,2.0,Elementary French,0.48,0.26,0.13,0.04,0.09,0%,0.0,0.0,amy lyn sawyer,
+FR,1020,2.0,Elementary French,0.2,0.3,0.1,0.2,0.1,0%,0.0,0.1, nedeo anne salces anne,
+FR,1020,3.0,Elementary French,0.13,0.44,0.25,0.0,0.0,0%,0.0,0.19, nedeo anne salces anne,
+FR,2010,1.0,Intermediate French,0.18,0.73,0.09,0.0,0.0,0%,0.0,0.0,kenneth widgren,
+FR,2010,2.0,Intermediate French,0.61,0.22,0.13,0.0,0.0,0%,0.0,0.04,amy lyn sawyer,
+FR,2010,3.0,Intermediate French,0.72,0.28,0.0,0.0,0.0,0%,0.0,0.0,tholozany de,
+FR,2020,1.0,Intermediate French,0.5,0.36,0.05,0.05,0.0,0%,0.0,0.05,eric touya,
+FR,2020,2.0,Intermediate French,0.42,0.42,0.04,0.0,0.04,0%,0.0,0.08,kenneth widgren,
+FR,2020,3.0,Intermediate French,0.67,0.17,0.17,0.0,0.0,0%,0.0,0.0,amy lyn sawyer,
+FR,3000,1.0,Survey of French Lit,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,tholozany de,
+FR,3050,1.0,Int Fr Con & Comp I,0.53,0.4,0.0,0.0,0.0,0%,0.0,0.07,kenneth widgren,
+FR,3050,2.0,Int Fr Con & Comp I,0.4,0.47,0.0,0.0,0.0,0%,0.0,0.13, nedeo anne salces anne,
+FR,3070,1.0,French Civilization,0.87,0.09,0.04,0.0,0.0,0%,0.0,0.0,kelly digby peebles,
+FR,3120,2.0,Writing in French I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,kenneth widgren,
+FR,4120,1.0,Fr & Francoph Cinema,0.77,0.15,0.0,0.0,0.08,0%,0.0,0.0,joseph mai,
+GC,1010,2.0,Orientation to G C,0.0,0.0,0.0,0.0,0.0,96%,0.04,0.0,nona woolbright,
+GC,1020,1.0,Computer Art & CAD Foun,0.67,0.19,0.05,0.03,0.03,0%,0.0,0.02,amanda bridges,
+GC,1040,1.0,Graphic Communications I,0.64,0.23,0.02,0.02,0.09,0%,0.0,0.0,michelle suki fox,
+GC,2070,1.0,Graphic Communications II,0.76,0.17,0.05,0.0,0.0,0%,0.0,0.02,charles tabor weiss,
+GC,2400,1.0,Intro to Web Design and D,0.64,0.21,0.07,0.0,0.07,0%,0.0,0.0,william stevens,
+GC,3400,1.0,Digital Imaging,0.38,0.33,0.18,0.03,0.08,0%,0.0,0.0,erica black walker,
+GC,3460,1.0,Ink and Substrates,0.57,0.33,0.11,0.0,0.0,0%,0.0,0.0,shu chang,
+GC,3730,1.0,Media Management in Bra,0.76,0.17,0.07,0.0,0.0,0%,0.0,0.0,jaclyn driggs,
+GC,3740,2.0,Brand Communications Str,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,jacqueline reed herr,
+GC,3760,1.0,Brand Comm Capstone Se,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,katelyn hildebrand,
+GC,4060,1.0,Package and Specialty Prin,0.38,0.53,0.06,0.0,0.03,0%,0.0,0.0,carol jones,
+GC,4400,1.0,Commercial Printing,0.4,0.51,0.05,0.0,0.0,0%,0.0,0.0,eric weisenmiller,
+GC,4440,1.0,Current Dev/Trends in Gr,0.43,0.45,0.1,0.02,0.0,0%,0.0,0.0,liam henry 'hara,
+GC,4480,1.0,Plan & Cont Printing Functi,0.93,0.03,0.0,0.03,0.0,0%,0.0,0.0,nona woolbright,
+GC,4800,1.0,Senior Seminar in GC,0.83,0.1,0.05,0.0,0.0,0%,0.0,0.0,charles tonkin,
+GC,4900,5.0,Videography & Visual Effec,0.67,0.25,0.08,0.0,0.0,0%,0.0,0.0,erica black walker,
+GC,8970,1.0,G C Research Prob I,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.0,nona woolbright,
+GEN,1030,1.0,Careers in Bioch/Gen,0.83,0.1,0.06,0.0,0.02,0%,0.0,0.0,alison starr-moss,
+GEN,3000,1.0,Fundamental Genetics,0.74,0.18,0.08,0.0,0.0,0%,0.0,0.0,michael harris,
+GEN,3000,2.0,Fundamental Genetics,0.7,0.27,0.01,0.0,0.02,0%,0.0,0.0,todd lyda,
+GEN,3000,6.0,Fundamental Genetics,0.28,0.4,0.19,0.04,0.07,0%,0.0,0.01,haiying liang,
+GEN,3020,1.0,Molec & General Genetics,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,kate leanne tsai,True
+GEN,3020,2.0,Molecular & General Gene,0.43,0.37,0.11,0.01,0.03,0%,0.0,0.05,kate leanne tsai,
+GEN,3020,4.0,Molecular & General Gene,0.18,0.41,0.27,0.05,0.0,0%,0.0,0.09,kate leanne tsai,
+GEN,4100,1.0,Population & Quant Genet,0.59,0.36,0.02,0.0,0.0,0%,0.0,0.02,metris kanapeckas,
+GEN,4100,2.0,Population & Quant Gen (,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,metris kanapeckas,True
+GEN,4110,3.0,Population & Quant Gen L,0.81,0.06,0.06,0.0,0.0,0%,0.0,0.06,metris kanapeckas,
+GEN,4110,4.0,Population & Quant Gen L,0.5,0.17,0.25,0.0,0.08,0%,0.0,0.0,metris kanapeckas,
+GEN,4400,1.0,Bioinformatics,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.13,frank feltus,
+GEN,4500,1.0,Comparative Genetics,0.25,0.45,0.16,0.0,0.0,0%,0.0,0.14,leigh anne clark,
+GEN,4500,2.0,Comparative Genetics (HO,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,leigh anne clark,True
+GEN,8050,1.0,Issues in Research,0.67,0.17,0.0,0.0,0.0,0%,0.0,0.0,julia frugoli,
+GEN,8250,1.0,Seminar I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,rajandeep sekhon,
+GEOG,1010,1.0,Intro to Geography,0.78,0.13,0.05,0.03,0.0,0%,0.0,0.03,christa smith,
+GEOG,1030,2.0,World Regional Geography,0.38,0.37,0.11,0.06,0.03,0%,0.0,0.03,william church terry,
+GEOG,4100,1.0,Geog of the American Sout,0.83,0.0,0.0,0.0,0.08,0%,0.0,0.0,christa smith,
+GEOL,1010,1.0,Physical Geology,0.62,0.26,0.06,0.04,0.02,0%,0.0,0.01,alan coulson,
+GEOL,1010,2.0,Physical Geology,0.6,0.28,0.08,0.03,0.01,0%,0.0,0.01,alan coulson,
+GEOL,1010,3.0,Physical Geology,0.56,0.31,0.08,0.03,0.03,0%,0.0,0.0,mary katherine fidler,
+GEOL,1010,4.0,Physical Geology,0.46,0.41,0.11,0.0,0.01,0%,0.0,0.01,mary katherine fidler,
+GEOL,1030,1.0,Physical Geol Lab,0.55,0.36,0.0,0.05,0.0,0%,0.0,0.05,alan coulson,
+GEOL,1030,2.0,Physical Geol Lab,0.71,0.17,0.04,0.0,0.08,0%,0.0,0.0,alan coulson,
+GEOL,1030,3.0,Physical Geol Lab,0.64,0.05,0.05,0.09,0.14,0%,0.0,0.05,alan coulson,
+GEOL,1030,4.0,Physical Geol Lab,0.52,0.17,0.22,0.04,0.04,0%,0.0,0.0,alan coulson,
+GEOL,1030,5.0,Physical Geol Lab,0.55,0.2,0.15,0.05,0.0,0%,0.0,0.05,alan coulson,
+GEOL,1030,6.0,Physical Geol Lab,0.67,0.24,0.05,0.05,0.0,0%,0.0,0.0,alan coulson,
+GEOL,1030,7.0,Physical Geol Lab,0.78,0.09,0.0,0.0,0.09,0%,0.0,0.04,alan coulson,
+GEOL,1030,8.0,Physical Geol Lab,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,alan coulson,
+GEOL,1030,9.0,Physical Geol Lab,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,alan coulson,
+GEOL,1030,11.0,Physical Geol Lab,0.75,0.1,0.15,0.0,0.0,0%,0.0,0.0,alan coulson,
+GEOL,1030,12.0,Physical Geol Lab,0.86,0.09,0.0,0.0,0.05,0%,0.0,0.0,alan coulson,
+GEOL,1030,13.0,Physical Geol Lab,0.55,0.3,0.05,0.0,0.0,0%,0.0,0.1,alan coulson,
+GEOL,1030,14.0,Physical Geol Lab,0.55,0.35,0.0,0.05,0.05,0%,0.0,0.0,alan coulson,
+GEOL,1030,15.0,Physical Geol Lab,0.6,0.3,0.1,0.0,0.0,0%,0.0,0.0,alan coulson,
+GEOL,1030,16.0,Physical Geol Lab,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,alan coulson,
+GEOL,1030,17.0,Physical Geol Lab,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,alan coulson,
+GEOL,1030,18.0,Physical Geol Lab,0.64,0.18,0.14,0.0,0.05,0%,0.0,0.0,alan coulson,
+GEOL,1030,19.0,Physical Geol Lab,0.65,0.25,0.1,0.0,0.0,0%,0.0,0.0,alan coulson,
+GEOL,1120,1.0,Earth Resources,0.51,0.3,0.13,0.04,0.01,0%,0.0,0.02,emily don scribner,
+GEOL,1140,1.0,Earth Resources Lab,0.55,0.29,0.11,0.01,0.0,0%,0.0,0.04,emily don scribner,
+GEOL,1200,1.0,Natural Hazards,0.48,0.4,0.1,0.0,0.03,0%,0.0,0.0,emily don scribner,
+GEOL,2050,1.0,Mineralogy & Intro Petrolo,0.29,0.71,0.0,0.0,0.0,0%,0.0,0.0, shuller-nickles,
+GEOL,2070,1.0,Min & Intro Pet Lab,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,mary katherine fidler,
+GEOL,2700,1.0,Sustainable Water,0.51,0.31,0.09,0.0,0.03,0%,0.0,0.06,melissa ranhofer,
+GEOL,3000,1.0,Environmental Geology,0.38,0.53,0.09,0.0,0.0,0%,0.0,0.0,alan coulson,
+GEOL,3020,1.0,Structural Geology,0.55,0.36,0.0,0.09,0.0,0%,0.0,0.0,alexander pullen,
+GEOL,4820,1.0,Groundwater & Contam Tr,0.3,0.2,0.1,0.1,0.1,0%,0.0,0.2,lawrence murdoch,
+GEOL,4910,1.0,Research Synthesis I,0.5,0.3,0.1,0.0,0.1,0%,0.0,0.0,alan coulson,
+GEOL,6150,1.0,Analysis Geological Proces,0.6,0.2,0.0,0.0,0.0,0%,0.0,0.0,lawrence murdoch,
+GEOL,8080,1.0,Groundwater Modeling,0.14,0.57,0.14,0.0,0.0,0%,0.0,0.0,ronald falta,
+GEOL,8610,1.0,Geology Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sudeep popat,
+GER,1010,1.0,Elementary German,0.7,0.2,0.0,0.1,0.0,0%,0.0,0.0,oswald harris king,
+GER,1020,1.0,Elementary German,0.21,0.29,0.21,0.14,0.07,0%,0.0,0.07, lee ferrell,
+GER,2010,1.0,Intermediate German,0.25,0.31,0.25,0.0,0.06,0%,0.0,0.0,johannes schmidt,
+GER,2020,1.0,Intermediate German,0.63,0.31,0.06,0.0,0.0,0%,0.0,0.0, lee ferrell,
+GER,2600,1.0,Selected Topics-Doppelgan,0.67,0.21,0.0,0.0,0.04,0%,0.0,0.08,gabriela stoicea,
+GER,2600,2.0,Selected Topics-Doppelgan,0.32,0.41,0.09,0.09,0.0,0%,0.0,0.09,gabriela stoicea,
+GER,3050,1.0,Ger Conv & Comp,0.65,0.24,0.06,0.0,0.0,0%,0.0,0.06, lee ferrell,
+GER,3600,1.0,Ger Lit to 1832,0.69,0.23,0.0,0.0,0.0,0%,0.0,0.0,johannes schmidt,
+GRAD,8030,1.0,Intl Teaching Fellowship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david fleming,
+GRAD,8030,2.0,Intl Teaching Fellowship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,david fleming,
+HCC,8330,1.0,HCC Research Methods,0.6,0.27,0.07,0.0,0.07,0%,0.0,0.0,kelly caine,
+HCC,9500,1.0,HATLab seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,bart knijnenburg,
+HCC,9500,3.0,Human Centered XR Resea,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,sabarish venkat babu,
+HCC,9910,7.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,bart knijnenburg,
+HCG,9070,400.0,Applied Health Genetics,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,sara moir sarasua,
+HCG,9910,401.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jane marie deluca,
+HIST,1010,1.0,History of the United State,0.63,0.33,0.0,0.03,0.0,0%,0.0,0.03,lee brady wilson,
+HIST,1010,2.0,History of the United State,0.17,0.53,0.17,0.03,0.03,0%,0.0,0.07,james jeffries,
+HIST,1220,1.0,"Hist, Tech & Society",0.44,0.33,0.05,0.05,0.06,0%,0.0,0.07,pamela mack,
+HIST,1240,1.0,Environmental History Sur,0.19,0.56,0.17,0.0,0.03,0%,0.0,0.06,james jeffries,
+HIST,1240,2.0,Environmental History Sur,0.18,0.69,0.05,0.0,0.03,0%,0.0,0.05,james jeffries,
+HIST,1720,1.0,The West and the World I,0.68,0.24,0.05,0.0,0.01,0%,0.0,0.02,steven marks,
+HIST,1720,2.0,The West and the World I,0.7,0.13,0.03,0.03,0.0,0%,0.0,0.1,christine hilliard,
+HIST,1720,3.0,The West and the World I,0.28,0.38,0.14,0.02,0.11,0%,0.0,0.07,caroline dunn dunn,
+HIST,1730,1.0,The West and the World II,0.22,0.46,0.18,0.01,0.05,0%,0.0,0.08, alan grubb,
+HIST,1730,2.0,The West and the World II,0.72,0.21,0.0,0.03,0.03,0%,0.0,0.0,archana venkatesh,
+HIST,2140,1.0,Introduction to Public Hist,0.63,0.25,0.0,0.06,0.0,0%,0.0,0.0,joshua catalano,
+HIST,2990,1.0,Historian's Craft,0.63,0.11,0.05,0.0,0.16,0%,0.0,0.05,rachel anne moore,
+HIST,2990,3.0,Historian's Craft,0.44,0.38,0.13,0.0,0.06,0%,0.0,0.0,michael meng,
+HIST,3000,1.0,History of Colonial Americ,0.81,0.16,0.0,0.0,0.0,0%,0.0,0.03,lee brady wilson,
+HIST,3040,1.0,Industrialism&Progressive,0.78,0.17,0.0,0.0,0.06,0%,0.0,0.0, roger grant,
+HIST,3060,1.0,US: Postwar World 1945-1,0.73,0.13,0.0,0.0,0.0,0%,0.0,0.07,rebecca anna stoil,
+HIST,3100,1.0,History of Religion in the U,0.38,0.31,0.06,0.0,0.06,0%,0.0,0.13,elizabeth jemison,
+HIST,3120,1.0,Afr Amer Hist 1877 to Pres,0.38,0.45,0.03,0.03,0.07,0%,0.0,0.03,abel bartley,
+HIST,3240,1.0,Hist of the South II,0.24,0.59,0.0,0.03,0.14,0%,0.0,0.0,john andrew,
+HIST,3330,1.0,Hist of Mod Japan,0.32,0.39,0.25,0.0,0.04,0%,0.0,0.0,edwin moise,
+HIST,3610,1.0,History of Britain to 1688,0.7,0.23,0.03,0.0,0.03,0%,0.0,0.0,seefeldt tara wood,
+HIST,3630,1.0,Britain Since 1688,0.77,0.2,0.0,0.0,0.0,0%,0.0,0.03, barczewski,
+HIST,3670,1.0,Modern Ireland,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,michael silvestri,
+HIST,3840,1.0,Hist of Mod France,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.0, alan grubb,
+HIST,3900,1.0,Modern Military History,0.24,0.48,0.14,0.0,0.0,0%,0.0,0.0,edwin moise,
+HIST,4700,1.0,Europe Women and Gend,0.7,0.2,0.0,0.0,0.0,0%,0.0,0.1,christine hilliard,
+HIST,4710,1.0,Moscow 1937,0.59,0.24,0.06,0.0,0.0,0%,0.0,0.06,steven marks,
+HIST,4870,1.0,World War II,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,john andrew,
+HIST,4900,1.0,DictatorshipViolence20thC,0.56,0.19,0.06,0.0,0.0,0%,0.0,0.0,amit bein,
+HIST,4900,2.0,Northern Ireland &The Tro,0.67,0.28,0.06,0.0,0.0,0%,0.0,0.0,michael silvestri,
+HIST,4940,2.0,Medieval Witchcraft & Her,0.53,0.33,0.07,0.07,0.0,0%,0.0,0.0,seefeldt tara wood,
+HIST,8000,1.0,Historical Methods,0.67,0.22,0.0,0.0,0.0,0%,0.0,0.0,michael meng,
+HIST,8910,1.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,michael meng,
+HLTH,2020,1.0,Introduction to Public Heal,0.47,0.32,0.11,0.11,0.0,0%,0.0,0.0,jeffrey kingree,
+HLTH,2020,2.0,Introduction to Public Heal,0.64,0.31,0.05,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,
+HLTH,2020,3.0,Introduction to Public Heal,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,
+HLTH,2020,4.0,Introduction to Public Heal,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.06,marvina jones,
+HLTH,2020,5.0,Introduction to Public Heal,0.68,0.21,0.05,0.05,0.0,0%,0.0,0.0,becky ann tugman,
+HLTH,2020,400.0,Introduction to Public Heal,0.61,0.26,0.09,0.0,0.0,0%,0.0,0.04,ralph stewart welsh,
+HLTH,2020,401.0,Introduction to Public Heal,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,ralph stewart welsh,
+HLTH,2030,1.0,Health Care Sys,0.59,0.41,0.0,0.0,0.0,0%,0.0,0.0,tanya lee staton,
+HLTH,2030,2.0,Health Care Sys,0.75,0.16,0.06,0.03,0.0,0%,0.0,0.0,tanya lee staton,
+HLTH,2030,3.0,Health Care Sys,0.72,0.22,0.06,0.0,0.0,0%,0.0,0.0,sarah bauer floyd,
+HLTH,2030,400.0,Health Care Sys,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,tanya lee staton,
+HLTH,2400,1.0,Deter of Hlth Behav,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,amelia clinkscales,
+HLTH,2400,2.0,Deter of Hlth Behav,0.64,0.28,0.08,0.0,0.0,0%,0.0,0.0,amelia clinkscales,
+HLTH,2400,3.0,Deter of Hlth Behav,0.63,0.37,0.0,0.0,0.0,0%,0.0,0.0,laura jane rolke,
+HLTH,2600,400.0,Medical Terminology & Co,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,karen edwards,
+HLTH,2980,1.0,Human Health and Disease,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,becky ann tugman,
+HLTH,2980,2.0,Human Health and Disease,0.66,0.26,0.09,0.0,0.0,0%,0.0,0.0,johnny long,
+HLTH,2980,3.0,Human Health and Disease,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,brooke brittain,
+HLTH,3050,1.0,Body Resp Hlth Beh,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,karen kemper,
+HLTH,3400,1.0,Hlth Prom Prog Plan,0.5,0.45,0.05,0.0,0.0,0%,0.0,0.0,johnny long,
+HLTH,3610,1.0,Int Health Care Econ,0.83,0.06,0.09,0.0,0.03,0%,0.0,0.0,khoa dang truong,
+HLTH,3800,1.0,Epidemiology,0.82,0.15,0.03,0.0,0.0,0%,0.0,0.0,lu zhang,
+HLTH,3800,2.0,Epidemiology,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,lu zhang,
+HLTH,3800,3.0,Epidemiology,0.63,0.3,0.07,0.0,0.0,0%,0.0,0.0,deborah alma falta,
+HLTH,3800,400.0,Epidemiology,0.26,0.42,0.21,0.05,0.05,0%,0.0,0.0,deborah alma falta,
+HLTH,3980,1.0,Health Appraisal Skills,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,kathleen meyer,
+HLTH,3980,2.0,Health Appraisal Skills,0.54,0.46,0.0,0.0,0.0,0%,0.0,0.0,kathleen meyer,
+HLTH,4000,1.0,Infec Disease & Exposure,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,tanya lee staton,
+HLTH,4190,1.0,Health Sci Internship Prep,0.79,0.15,0.05,0.0,0.0,0%,0.0,0.0,kathleen meyer,
+HLTH,4200,1.0,Hlth Science Intern,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,kathleen meyer,
+HLTH,4200,3.0,Hlth Science Intern,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,kathleen meyer,
+HLTH,4400,1.0,Manag Hlth Serv Org,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,lu shi,
+HLTH,4700,1.0,Global Health,0.93,0.0,0.03,0.0,0.03,0%,0.0,0.0,micky rogers ward,
+HLTH,4750,1.0,Hlthcr Oper Mgmt Res,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,lu shi,
+HLTH,4900,1.0,Res Eval St Pub Hlth,0.79,0.14,0.0,0.04,0.0,0%,0.0,0.04,jeffrey kingree,
+HLTH,4900,2.0,Res Eval St Pub Hlth,0.79,0.17,0.0,0.04,0.0,0%,0.0,0.0,jeffrey kingree,
+HLTH,4980,1.0,Improving Pop Hlth,0.45,0.36,0.05,0.09,0.0,0%,0.0,0.0,hugh donald spitler,
+HLTH,8090,400.0,Epidemiological Res,0.65,0.24,0.0,0.0,0.0,0%,0.0,0.06,sara wagner robb,
+HLTH,8120,500.0,Clinical and Translational S,0.71,0.24,0.0,0.0,0.0,0%,0.0,0.05,ronald gimbel,
+HLTH,8140,500.0,Health Sys Quality Improv,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,windsor sherrill,
+HLTH,8210,1.0,Health Research I,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,sara wagner robb,
+HLTH,8890,1.0,Sem in App Hlth Rsrch & E,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,karen kemper,
+HON,2020,1.0,Who Decides What's Cool?,0.74,0.21,0.0,0.0,0.0,0%,0.0,0.05,amanda cooper fine,True
+HON,2030,4.0,Views of History/Ancient,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,yanming an,True
+HON,2050,5.0,Entrepreneurship,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,john michael hannon,True
+HON,2210,1.0,Monster Culture and Socie,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,mary nestor,True
+HORT,1010,1.0,Horticulture,0.95,0.03,0.0,0.0,0.0,0%,0.0,0.02,ellen anita vincent,
+HORT,2020,1.0,Adobe Digital Design,0.85,0.04,0.0,0.0,0.0,0%,0.0,0.11,janice ann lay,
+HORT,2120,1.0,Turfgrass Culture,0.84,0.14,0.0,0.0,0.03,0%,0.0,0.0,haibo liu,
+HORT,2130,2.0,Turfgrass Culture Lab,0.73,0.0,0.18,0.0,0.09,0%,0.0,0.0,haibo liu,
+HORT,3030,1.0,Woody Landscape Plant ID,0.15,0.23,0.2,0.13,0.3,0%,0.0,0.0,robert polomski,
+HORT,3080,1.0,Sust Landsc Des Install Mai,0.85,0.09,0.06,0.0,0.0,0%,0.0,0.0,ellen anita vincent,
+HORT,3090,1.0,Sust Landsc Des Lab,0.5,0.1,0.0,0.0,0.4,0%,0.0,0.0,shannon barrett,
+HORT,4120,1.0,Adv Turfgrass Mgt,0.6,0.2,0.1,0.1,0.0,0%,0.0,0.0,lambert mccarty,
+HORT,4400,1.0,Hydroponics,0.42,0.33,0.25,0.0,0.0,0%,0.0,0.0,james emerson faust,
+HP,8010,1.0,Preservation Law and Econ,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,william jackson cook,
+HP,8020,1.0,Hist Preserv Research Sem,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jon marcoux,
+HP,8190,1.0,"Investig, Docum, Conserva",0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,amalia leifeste,
+HP,8230,400.0,Historic American Interiors,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,elizabeth ryan,
+HP,8920,1.0,Special Topics Paying for P,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,amalia leifeste,
+HRD,8300,400.0,Concepts of H R D,0.92,0.05,0.03,0.0,0.0,0%,0.0,0.0,angela carter,
+HRD,8470,400.0,Instru System Design,0.82,0.1,0.0,0.0,0.03,0%,0.0,0.03,angela carter,
+HUM,3090,1.0,Studies in Humanities,0.74,0.21,0.0,0.0,0.0,0%,0.0,0.05,jennie wakefield,
+HUM,3090,2.0,Studies in Humanities,0.65,0.2,0.1,0.0,0.05,0%,0.0,0.0,jennie wakefield,
+IE,2100,1.0,Des Analysis Wrk Sys,0.54,0.4,0.03,0.01,0.0,0%,0.0,0.02,sudeep hegde,
+IE,3010,1.0,Systems Design I,0.44,0.46,0.08,0.03,0.0,0%,0.0,0.0,paris stringfellow,
+IE,3140,1.0,Seminar in Industrial Engr,0.0,0.0,0.0,0.0,0.0,97%,0.03,0.0,jeffrey kharoufeh,
+IE,3600,1.0,Industrial Apps of Prob/Sta,0.31,0.44,0.15,0.04,0.04,0%,0.0,0.04,tugce isik,
+IE,3610,1.0,Industrial App of Prob/Stat,0.33,0.38,0.17,0.03,0.03,0%,0.0,0.05,hamed rahimian,
+IE,3800,1.0,Deterministic Operations R,0.43,0.31,0.14,0.07,0.03,0%,0.0,0.02,yongjia song,
+IE,3810,1.0,Probabilistic Operations Rs,0.34,0.46,0.15,0.03,0.02,0%,0.0,0.0,amin khademi,
+IE,3840,1.0,Engr Econ Analysis,0.39,0.33,0.09,0.02,0.0,0%,0.0,0.17,brian melloy,
+IE,3840,2.0,Engr Econ Analysis,0.05,0.14,0.24,0.1,0.0,0%,0.0,0.48,brian melloy,
+IE,3860,1.0,Production Planning & Con,0.62,0.27,0.09,0.01,0.0,0%,0.0,0.0,mariah magagnotti,
+IE,4300,1.0,Human Fact Engr in Health,0.73,0.17,0.04,0.0,0.04,0%,0.0,0.02,david neyens,
+IE,4400,2.0,Decision Support Sys,0.32,0.49,0.05,0.0,0.08,0%,0.0,0.04,scott jennings mason,
+IE,4560,1.0,Supply Chain Design & Con,0.19,0.43,0.14,0.1,0.0,0%,0.0,0.05,william ferrell,
+IE,4570,1.0,Transp/Logistic Engr,0.72,0.2,0.06,0.0,0.0,0%,0.0,0.03,emily tucker,
+IE,4610,1.0,Quality Engineering,0.63,0.24,0.07,0.02,0.04,0%,0.0,0.01,mariah magagnotti,
+IE,4650,1.0,Facilities Planning & Desig,0.53,0.38,0.07,0.01,0.01,0%,0.0,0.0,william ferrell,
+IE,4670,1.0,System Design II,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,scott jennings mason,
+IE,4820,1.0,Systems Modeling,0.42,0.47,0.07,0.03,0.0,0%,0.0,0.0,kevin taaffe,
+IE,4820,2.0,Systems Modeling,0.58,0.27,0.09,0.0,0.0,0%,0.0,0.06,kevin taaffe,
+IE,4880,2.0,Human Factors Eng,0.87,0.12,0.0,0.01,0.0,0%,0.0,0.0,jamiahus walton,
+IE,6300,1.0,Human Fact Engr in Health,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,david neyens,
+IE,6560,1.0,Supply Chain Design & Con,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,william ferrell,
+IE,6570,1.0,Transp/Logistic Engr,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,emily tucker,
+IE,8030,1.0,Engr Optimization and App,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,thomas sharkey,
+IE,8090,1.0,Model Sys Under Risk,0.33,0.61,0.0,0.0,0.0,0%,0.0,0.06,jeffrey kharoufeh,
+IE,8530,1.0,Foundations of Quality,0.75,0.21,0.0,0.0,0.04,0%,0.0,0.0,ozgur kabadurmus,
+IE,8550,1.0,SC & Logistics Modeling II,0.88,0.04,0.08,0.0,0.0,0%,0.0,0.0,kevin taaffe,
+IE,8930,18.0,Optimization under Uncert,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,yongjia song,
+IE,9910,18.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yongjia song,
+INNO,3990,4.0,IBM Watson in the Watt,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,dane smith,
+INNO,4990,3.0,IBM Watson in the Watt,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.2,dane smith,
+INT,1510,1.0,UPIC Internship PT 1,0.0,0.0,0.0,0.0,0.0,90%,0.06,0.04,lisa marie robinson,
+INT,1520,1.0,UPIC Internship PT 2,0.0,0.0,0.0,0.0,0.0,96%,0.04,0.0,caren kelley-hall,
+INT,1530,1.0,UPIC Internship PT 3,0.0,0.0,0.0,0.0,0.0,94%,0.04,0.02,caren kelley-hall,
+INT,1540,1.0,UPIC Internship PT 4,0.0,0.0,0.0,0.0,0.0,95%,0.0,0.05,caren kelley-hall,
+INT,2010,1.0,Off-Campus Internship FT,0.0,0.0,0.0,0.0,0.0,91%,0.0,0.0,brittany paige neely,
+INT,2510,1.0,UPIC Internship FT 1,0.0,0.0,0.0,0.0,0.0,86%,0.14,0.0,lisa marie robinson,
+INT,2520,1.0,UPIC Internship FT 2,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,caren kelley-hall,
+INT,2530,1.0,UPIC Internship FT 3,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,caren kelley-hall,
+INT,8010,1.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,
+INT,8010,2.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,
+INT,8010,3.0,Graduate Student Internsh,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brittany paige neely,
+ITAL,1010,2.0,Elementary Italian,0.75,0.19,0.06,0.0,0.0,0%,0.0,0.0,julia schmidt,
+ITAL,1010,3.0,Elementary Italian,0.83,0.11,0.0,0.0,0.0,0%,0.0,0.06,luca barattoni,
+ITAL,1020,1.0,Elementary Italian,0.65,0.29,0.0,0.06,0.0,0%,0.0,0.0,julia schmidt,
+JAPN,1010,1.0,Elementary Japanese,0.64,0.23,0.05,0.0,0.09,0%,0.0,0.0,kumiko saito,
+JAPN,1010,2.0,Elementary Japanese,0.45,0.14,0.18,0.0,0.14,0%,0.0,0.09,kumiko saito,
+JAPN,1020,1.0,Elementary Japanese,0.5,0.39,0.0,0.0,0.11,0%,0.0,0.0,satomi saito,
+JAPN,2010,1.0,Intermed Japanese,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,satomi saito,
+JAPN,3050,1.0,Japanese Conversation & C,0.75,0.06,0.06,0.0,0.0,0%,0.0,0.06,jae allegra takeuchi,
+JAPN,4010,1.0,Japanese Lit in Translation,0.79,0.08,0.04,0.0,0.0,0%,0.0,0.04,kumiko saito,
+JAPN,4990,1.0,Sel Topics in Japanese Cult,0.54,0.31,0.0,0.0,0.0,0%,0.0,0.08,satomi saito,
+JUST,2050,1.0,Professional Development,0.77,0.1,0.0,0.1,0.0,0%,0.0,0.03,margaret tina britz,
+JUST,2880,1.0,The Criminal Justice Syste,0.6,0.15,0.1,0.06,0.04,0%,0.0,0.04,margaret tina britz,
+JUST,2880,2.0,The Criminal Justice Syste,0.75,0.24,0.0,0.0,0.0,0%,0.0,0.02,kyle david mclean,
+JUST,2890,1.0,Criminology,0.51,0.29,0.1,0.06,0.02,0%,0.0,0.02,matthew costello,
+JUST,3280,1.0,Criminal Courts,0.5,0.42,0.08,0.0,0.0,0%,0.0,0.0,rhys hester,
+JUST,3960,1.0,Drugs and Crime,0.31,0.31,0.23,0.03,0.09,0%,0.0,0.03,brian chad starks,
+JUST,4290,1.0,Justice Administration,0.45,0.4,0.1,0.05,0.0,0%,0.0,0.0,rhys hester,
+JUST,4680,1.0,Criminal Evidence,0.59,0.14,0.14,0.03,0.05,0%,0.0,0.05,margaret tina britz,
+JUST,4860,1.0,CI in CJ: Gangsterism in Fil,0.62,0.12,0.04,0.08,0.15,0%,0.0,0.0,margaret tina britz,
+JUST,4910,1.0,Policing,0.86,0.08,0.05,0.0,0.0,0%,0.0,0.0,kyle david mclean,
+JUST,4930,1.0,Corrections,0.6,0.28,0.07,0.02,0.02,0%,0.0,0.0,bryan lee miller,
+JUST,4990,1.0,Sexual Assault and IPV,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,heather kettrey,
+LAIB,1270,1.0,Intro to Lang & Int'l Busine,0.0,0.0,0.0,0.0,0.0,90%,0.1,0.0,jae allegra takeuchi,
+LANG,3000,1.0,Intro Linguistics,0.56,0.33,0.0,0.0,0.11,0%,0.0,0.0,daniel smith,
+LANG,4990,1.0,Language Portfolio,0.0,0.0,0.0,0.0,0.0,92%,0.0,0.08,su- chen,
+LARC,1150,1.0,Intro Landscape Architectu,0.61,0.25,0.14,0.0,0.0,0%,0.0,0.0,jueminsi wu,
+LARC,1280,1.0,Technical Graphics,0.57,0.32,0.11,0.0,0.0,0%,0.0,0.0,matthew powers,
+LARC,1510,1.0,Basic Design I,0.61,0.32,0.07,0.0,0.0,0%,0.0,0.0,matthew powers,
+LARC,2140,1.0,Plants in the Landscape,0.65,0.25,0.05,0.05,0.0,0%,0.0,0.0,lara browning,
+LARC,3510,1.0,Regional Design,0.63,0.11,0.11,0.05,0.05,0%,0.0,0.05,lara browning,
+LARC,4530,1.0,Key Issues in Landscape Ar,0.57,0.38,0.05,0.0,0.0,0%,0.0,0.0,mary padua,
+LARC,4620,1.0,Design Implementation III,0.5,0.25,0.1,0.05,0.0,0%,0.0,0.1,paul russell,
+LARC,8210,1.0,Research Methods,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,hala fouad nassar,
+LAW,3220,1.0,Legal Env of Bus,0.22,0.36,0.24,0.12,0.04,0%,0.0,0.02,kenneth toussaint,
+LAW,3220,2.0,Legal Env of Bus,0.27,0.33,0.31,0.0,0.1,0%,0.0,0.0,kenneth toussaint,
+LAW,3220,3.0,Legal Env of Bus,0.4,0.44,0.1,0.04,0.0,0%,0.0,0.02, kisska-schulze,
+LAW,3220,4.0,Legal Env of Bus,0.32,0.42,0.22,0.04,0.0,0%,0.0,0.0, kisska-schulze,
+LAW,3220,5.0,Legal Env of Bus,0.72,0.26,0.02,0.0,0.0,0%,0.0,0.0,christopher edwards,
+LAW,3220,6.0,Legal Env of Bus,0.8,0.18,0.0,0.0,0.0,0%,0.0,0.02,christopher edwards,
+LAW,3220,7.0,Legal Env of Bus,0.24,0.37,0.29,0.08,0.0,0%,0.0,0.02, kisska-schulze,
+LAW,3220,8.0,Legal Env of Bus,0.58,0.35,0.08,0.0,0.0,0%,0.0,0.0,edward ray claggett,
+LAW,3220,9.0,Legal Env of Bus,0.59,0.32,0.05,0.02,0.0,0%,0.0,0.02,frances edwards,
+LAW,3220,10.0,Legal Env of Bus,0.4,0.43,0.13,0.03,0.03,0%,0.0,0.0,edward ray claggett,
+LAW,3220,11.0,Legal Env of Bus,0.15,0.44,0.29,0.07,0.0,0%,0.0,0.05,john hine,
+LAW,3220,12.0,Legal Env of Bus,0.48,0.37,0.13,0.0,0.0,0%,0.0,0.02,frances edwards,
+LAW,3220,400.0,Legal Env of Bus,0.36,0.32,0.21,0.07,0.02,0%,0.0,0.02, ward-vaughn,
+LAW,3220,401.0,Legal Env of Bus,0.23,0.53,0.12,0.07,0.03,0%,0.0,0.02, ward-vaughn,
+LAW,3220,402.0,Legal Env of Bus,0.34,0.38,0.21,0.03,0.0,0%,0.0,0.03, ward-vaughn,
+LAW,3220,403.0,Legal Env of Bus,0.33,0.36,0.14,0.07,0.07,0%,0.0,0.03, ward-vaughn,
+LAW,3330,1.0,Real Estate Law,0.26,0.34,0.34,0.0,0.06,0%,0.0,0.0,kenneth toussaint,
+LAW,3330,2.0,Real Estate Law,0.44,0.42,0.11,0.0,0.03,0%,0.0,0.0,kenneth toussaint,
+LAW,4050,1.0,Construction Law,0.87,0.11,0.0,0.0,0.0,0%,0.0,0.03,frances edwards,
+LIH,3970,1.0,Cr Inq-Language & Intl Hea,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.1,kelly digby peebles,
+LS,1000,1.0,Therapeutic Yoga,0.78,0.0,0.0,0.0,0.0,0%,0.0,0.22,ranjanbala amin,
+LS,1000,15.0,"Stress, Coping, & Flourishi",0.83,0.09,0.03,0.0,0.02,0%,0.0,0.02,cynthia pury s,
+LS,1000,16.0,"Stress, Coping, & Flourishi",0.67,0.09,0.12,0.05,0.02,0%,0.0,0.02,cynthia pury s,
+LS,1000,50.0,Facilitating Social Gatherin,0.75,0.05,0.05,0.05,0.1,0%,0.0,0.0,paul hoke,
+LS,1750,2.0,Fly Fishing,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.2,michael watts,
+LS,1850,2.0,Bowling,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.04,madison workman,
+LS,1850,3.0,Bowling,0.71,0.21,0.0,0.0,0.0,0%,0.0,0.07,madison workman,
+LS,1850,4.0,Bowling,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,madison workman,
+LS,1850,5.0,Bowling,0.88,0.0,0.0,0.0,0.06,0%,0.0,0.06,angela rowan,
+LS,1980,5.0,Golf,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.12,wesley womble,
+LS,2320,1.0,Core Training,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,diane moreno,
+LS,2320,4.0,Core Training,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,diane moreno,
+LS,2350,1.0,Basic Yoga,0.76,0.1,0.1,0.0,0.0,0%,0.0,0.05,renee warren gahan,
+LS,2350,5.0,Basic Yoga,0.86,0.0,0.05,0.0,0.0,0%,0.0,0.09,brandy segura,
+LS,2350,6.0,Basic Yoga,0.89,0.05,0.05,0.0,0.0,0%,0.0,0.0,brandy segura,
+LS,2350,8.0,Basic Yoga,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,brandy segura,
+LS,2420,1.0,Meditation and Relax,0.87,0.0,0.04,0.04,0.0,0%,0.0,0.04,renee warren gahan,
+LS,2420,2.0,Meditation and Relax,0.88,0.0,0.04,0.0,0.04,0%,0.0,0.04,renee warren gahan,
+LS,2420,3.0,Meditation and Relax,0.7,0.17,0.04,0.04,0.0,0%,0.0,0.04,ranjanbala amin,
+LS,2420,4.0,Meditation and Relax,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ranjanbala amin,
+LS,2420,9.0,Meditation and Relax,0.77,0.09,0.09,0.0,0.05,0%,0.0,0.0,renee warren gahan,
+LS,2420,10.0,Meditation and Relax,0.59,0.14,0.05,0.09,0.09,0%,0.0,0.05,renee warren gahan,
+LS,2450,5.0,Pilates,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.13,diane moreno,
+LS,2750,8.0,Red Cross First Aid/CPR,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,christopher loomis,
+LS,2780,1.0,Wilderness First Aid,0.86,0.07,0.0,0.0,0.0,0%,0.0,0.07,emily grace turke,
+MATH,1010,1.0,Essen Math for Informed S,0.09,0.43,0.3,0.02,0.02,0%,0.0,0.13,chad mangum,
+MATH,1010,2.0,Essen Math for Informed S,0.25,0.39,0.27,0.02,0.07,0%,0.0,0.0,chad mangum,
+MATH,1010,3.0,Essen Math for Informed S,0.22,0.31,0.22,0.09,0.09,0%,0.0,0.07,chad mangum,
+MATH,1010,4.0,Essen Math for Informed S,0.17,0.48,0.24,0.02,0.02,0%,0.0,0.07,kristen savary,
+MATH,1010,5.0,Essen Math for Informed S,0.07,0.36,0.14,0.12,0.19,0%,0.0,0.12,jacob lee britton,
+MATH,1010,6.0,Essen Math for Informed S,0.13,0.28,0.35,0.15,0.09,0%,0.0,0.0,sarah kelly,
+MATH,1020,1.0,Business Calculus I,0.36,0.23,0.15,0.13,0.09,0%,0.0,0.04,randy davidson,
+MATH,1020,2.0,Business Calculus I,0.21,0.34,0.28,0.09,0.04,0%,0.0,0.04,randy davidson,
+MATH,1020,3.0,Business Calculus I,0.06,0.26,0.3,0.22,0.1,0%,0.0,0.06,freeman slaughter,
+MATH,1020,4.0,Business Calculus I,0.19,0.38,0.21,0.12,0.07,0%,0.0,0.02,joseph swanson,
+MATH,1020,5.0,Business Calculus I,0.25,0.28,0.18,0.15,0.13,0%,0.0,0.03,ryan wolanzyk,
+MATH,1020,6.0,Business Calculus I,0.11,0.26,0.21,0.21,0.08,0%,0.0,0.13,duygu vargun,
+MATH,1020,7.0,Business Calculus I,0.25,0.3,0.2,0.08,0.08,0%,0.0,0.1,rodrigo smith,
+MATH,1020,8.0,Business Calculus I,0.22,0.33,0.14,0.11,0.14,0%,0.0,0.06,rakhi goswami,
+MATH,1020,9.0,Business Calculus I,0.29,0.29,0.14,0.14,0.1,0%,0.0,0.05,benjamin hamlin,
+MATH,1020,10.0,Business Calculus I,0.2,0.34,0.24,0.0,0.1,0%,0.0,0.1,luke szramowski,
+MATH,1020,11.0,Business Calculus I,0.13,0.36,0.18,0.21,0.1,0%,0.0,0.03,sarah otterbeck,
+MATH,1020,12.0,Business Calculus I,0.17,0.44,0.22,0.1,0.07,0%,0.0,0.0,emily tidwell,
+MATH,1020,13.0,Business Calculus I,0.12,0.37,0.22,0.15,0.02,0%,0.0,0.12,adam nathaniel price,
+MATH,1020,14.0,Business Calculus I,0.29,0.44,0.12,0.05,0.07,0%,0.0,0.02, gracia-guzman,
+MATH,1020,15.0,Business Calculus I,0.13,0.38,0.23,0.1,0.03,0%,0.0,0.13,robert melville,
+MATH,1020,16.0,Business Calculus I,0.27,0.34,0.22,0.1,0.02,0%,0.0,0.05,heidi- shuttleworth,
+MATH,1020,17.0,Business Calculus I,0.07,0.36,0.29,0.07,0.1,0%,0.0,0.12,elizabeth hawkins,
+MATH,1020,18.0,Business Calculus I,0.15,0.27,0.29,0.02,0.12,0%,0.0,0.15,emma soriano,
+MATH,1020,19.0,Business Calculus I,0.31,0.29,0.16,0.11,0.04,0%,0.0,0.09,michael cowen,
+MATH,1020,20.0,Business Calculus I,0.18,0.34,0.2,0.02,0.16,0%,0.0,0.09,morgan elston,
+MATH,1020,21.0,Business Calculus I,0.22,0.27,0.22,0.13,0.11,0%,0.0,0.04,michael foss,
+MATH,1020,22.0,Business Calculus I,0.22,0.37,0.15,0.1,0.05,0%,0.0,0.12,james mckay visser,
+MATH,1020,23.0,Business Calculus I,0.14,0.19,0.27,0.27,0.14,0%,0.0,0.0,james palmer,
+MATH,1020,201.0,Business Calculus I,0.52,0.31,0.1,0.05,0.02,0%,0.0,0.0,dyken jennifer  van e,
+MATH,1020,202.0,Business Calculus I,0.43,0.45,0.05,0.08,0.0,0%,0.0,0.0,marion hanna,
+MATH,1030,401.0,Elementary Functions,0.56,0.36,0.0,0.0,0.08,0%,0.0,0.0,david costanzo,
+MATH,1030,402.0,Elementary Functions,0.54,0.27,0.04,0.04,0.12,0%,0.0,0.0,david costanzo,
+MATH,1030,403.0,Elementary Functions,0.46,0.32,0.0,0.04,0.14,0%,0.0,0.04,david costanzo,
+MATH,1040,1.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,59%,0.38,0.03,donna simms,
+MATH,1040,2.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,67%,0.29,0.04,catherine kenyon,
+MATH,1040,3.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.32,0.05,catherine kenyon,
+MATH,1040,4.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,60%,0.36,0.04,michael nelson,
+MATH,1040,5.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.29,0.07,catherine kenyon,
+MATH,1040,6.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.31,0.05,trinity white,
+MATH,1040,7.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,69%,0.28,0.03,tony thanh nguyen,
+MATH,1040,9.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,48%,0.39,0.13,tony thanh nguyen,
+MATH,1040,10.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,38%,0.6,0.0,todd anthony morra,
+MATH,1040,201.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,81%,0.16,0.03,tony thanh nguyen,
+MATH,1040,202.0,Precalc & Intro Differen Ca,0.0,0.0,0.0,0.0,0.0,64%,0.33,0.03,travis alvarez,
+MATH,1050,401.0,Precalculus,0.0,0.0,0.0,0.0,0.0,74%,0.26,0.0,jennifer marie hanna,
+MATH,1050,402.0,Precalculus,0.0,0.0,0.0,0.0,0.0,75%,0.24,0.01,jennifer marie hanna,
+MATH,1050,403.0,Precalculus,0.0,0.0,0.0,0.0,0.0,70%,0.26,0.03,jennifer marie hanna,
+MATH,1060,1.0,Calculus of One Variable I,0.25,0.33,0.25,0.0,0.13,0%,0.0,0.05,david luke frost,
+MATH,1060,2.0,Calculus of One Variable I,0.21,0.35,0.19,0.0,0.16,0%,0.0,0.09,allen anderson guest,
+MATH,1060,3.0,Calculus of One Variable I,0.36,0.23,0.14,0.02,0.2,0%,0.0,0.05,yunan wang,
+MATH,1060,4.0,Calculus of One Variable I,0.41,0.27,0.09,0.02,0.18,0%,0.0,0.02,allen anderson guest,
+MATH,1060,5.0,Calculus of One Variable I,0.22,0.38,0.18,0.04,0.09,0%,0.0,0.09,allen anderson guest,
+MATH,1060,6.0,Calculus of One Variable I,0.3,0.33,0.24,0.06,0.07,0%,0.0,0.0,james gossell,
+MATH,1060,7.0,Calculus of One Variable I,0.24,0.4,0.17,0.07,0.1,0%,0.0,0.02,felice manganiello,
+MATH,1060,8.0,Calculus of One Variable I,0.18,0.29,0.27,0.03,0.17,0%,0.0,0.06,felice manganiello,
+MATH,1060,9.0,Calculus of One Variable I,0.18,0.27,0.32,0.0,0.2,0%,0.0,0.02,sofya alekseeva,
+MATH,1060,10.0,Calculus of One Variable I,0.1,0.21,0.26,0.14,0.17,0%,0.0,0.1,sofya alekseeva,
+MATH,1060,11.0,Calculus of One Variable I,0.23,0.38,0.17,0.04,0.06,0%,0.0,0.13,hugh geller,
+MATH,1060,12.0,Calculus of One Variable I,0.19,0.33,0.11,0.07,0.22,0%,0.0,0.07,hossein faridian,
+MATH,1060,13.0,Calculus of One Variable I,0.28,0.25,0.22,0.03,0.19,0%,0.0,0.03,blake james smith,
+MATH,1060,14.0,Calculus of One Variable I,0.2,0.33,0.23,0.0,0.2,0%,0.0,0.05,michael byrd,
+MATH,1060,201.0,Calculus of One Variable I,0.38,0.29,0.22,0.0,0.11,0%,0.0,0.0,jason alexander kurz,
+MATH,1060,202.0,Calculus of One Variable I,0.38,0.36,0.09,0.04,0.11,0%,0.0,0.02,stephen peele,
+MATH,1060,203.0,Calculus of One Variable I,0.38,0.29,0.18,0.02,0.09,0%,0.0,0.04,nathan fontes,
+MATH,1060,204.0,Calculus of One Variable I,0.53,0.22,0.09,0.02,0.07,0%,0.0,0.07,zachary david espe,
+MATH,1060,205.0,Calculus of One Variable I,0.11,0.24,0.36,0.04,0.13,0%,0.0,0.11,sofya alekseeva,
+MATH,1060,300.0,Calculus of One Variable I,0.27,0.55,0.0,0.0,0.09,0%,0.0,0.09,matthew macauley,
+MATH,1070,1.0,Differen and Integral Calcu,0.11,0.07,0.48,0.04,0.11,0%,0.0,0.19,donna simms,
+MATH,1080,1.0,Calculus of One Variable II,0.27,0.21,0.19,0.04,0.23,0%,0.0,0.07,meredith nicole burr,
+MATH,1080,2.0,Calculus of One Variable II,0.32,0.14,0.14,0.05,0.24,0%,0.0,0.11,fei xue,
+MATH,1080,3.0,Calculus of One Variable II,0.19,0.19,0.19,0.0,0.19,0%,0.0,0.24,scott scruggs,
+MATH,1080,4.0,Calculus of One Variable II,0.05,0.26,0.23,0.09,0.21,0%,0.0,0.16,peter westerbaan,
+MATH,1080,5.0,Calculus of One Variable II,0.17,0.14,0.1,0.1,0.24,0%,0.0,0.24,cody stockdale,
+MATH,1080,6.0,Calculus of One Variable II,0.14,0.16,0.27,0.05,0.18,0%,0.0,0.18,cody stockdale,
+MATH,1080,7.0,Calculus of One Variable II,0.24,0.17,0.05,0.1,0.22,0%,0.0,0.22,blake splitter,
+MATH,1080,201.0,Calculus of One Variable II,0.58,0.27,0.04,0.04,0.08,0%,0.0,0.0,meredith nicole burr,
+MATH,1150,1.0,Contemp Math for Elem T,0.73,0.21,0.04,0.02,0.0,0%,0.0,0.0,jusino carreras,
+MATH,1150,2.0,Contemp Math for Elem T,0.69,0.25,0.02,0.0,0.02,0%,0.0,0.02,jusino carreras,
+MATH,1160,1.0,Contemp Math for Elem T,0.62,0.24,0.14,0.0,0.0,0%,0.0,0.0,jusino carreras,
+MATH,1990,401.0,Problem Solving in Mathe,0.0,0.0,0.0,0.0,0.0,98%,0.02,0.0,marion hanna,
+MATH,1990,403.0,Problem Solving in Mathe,0.0,0.0,0.0,0.0,0.0,95%,0.04,0.01,marion hanna,
+MATH,2060,1.0,Calculus of Several Variabl,0.55,0.2,0.1,0.03,0.07,0%,0.0,0.05,oleg yordanov,
+MATH,2060,2.0,Calculus of Several Variabl,0.6,0.15,0.14,0.05,0.02,0%,0.0,0.04,oleg yordanov,
+MATH,2060,3.0,Calculus of Several Variabl,0.23,0.42,0.23,0.04,0.05,0%,0.0,0.04,tony william long,
+MATH,2060,4.0,Calculus of Several Variabl,0.41,0.3,0.16,0.04,0.03,0%,0.0,0.07,tony william long,
+MATH,2060,5.0,Calculus of Several Variabl,0.35,0.19,0.22,0.12,0.09,0%,0.0,0.04,timothy teitloff,
+MATH,2060,6.0,Calculus of Several Variabl,0.43,0.37,0.13,0.02,0.0,0%,0.0,0.06,irina viktorova,
+MATH,2060,7.0,Calculus of Several Variabl,0.35,0.39,0.17,0.01,0.04,0%,0.0,0.03,irina viktorova,
+MATH,2060,100.0,Calc of Several Vars (HON),0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,yuyuan ouyang,True
+MATH,2060,201.0,Calculus of Several Variabl,0.32,0.26,0.26,0.08,0.08,0%,0.0,0.0,timothy teitloff,
+MATH,2070,1.0,Business Calculus II,0.29,0.21,0.33,0.08,0.04,0%,0.0,0.06,jennifer ray newton,
+MATH,2070,2.0,Business Calculus II,0.36,0.28,0.15,0.09,0.06,0%,0.0,0.06,nathaniel nemire,
+MATH,2070,3.0,Business Calculus II,0.19,0.47,0.15,0.09,0.06,0%,0.0,0.04,jennifer ray newton,
+MATH,2070,4.0,Business Calculus II,0.19,0.16,0.26,0.1,0.06,0%,0.0,0.23,daozhou zhu,
+MATH,2070,5.0,Business Calculus II,0.27,0.38,0.22,0.04,0.04,0%,0.0,0.04,tyler sullivan,
+MATH,2070,6.0,Business Calculus II,0.33,0.3,0.11,0.07,0.09,0%,0.0,0.09,ville madeleine  st e,
+MATH,2070,7.0,Business Calculus II,0.05,0.22,0.22,0.3,0.11,0%,0.0,0.11,antonio pierrottet,
+MATH,2070,8.0,Business Calculus II,0.11,0.25,0.23,0.11,0.06,0%,0.0,0.25,todd fenstermacher,
+MATH,2070,9.0,Business Calculus II,0.16,0.33,0.1,0.1,0.12,0%,0.0,0.2,todd fenstermacher,
+MATH,2070,10.0,Business Calculus II,0.2,0.22,0.22,0.1,0.1,0%,0.0,0.17,eva murphy,
+MATH,2070,11.0,Business Calculus II,0.21,0.17,0.14,0.17,0.28,0%,0.0,0.03,anna bachstein,
+MATH,2070,12.0,Business Calculus II,0.3,0.26,0.21,0.09,0.09,0%,0.0,0.05,elliott degbe,
+MATH,2070,13.0,Business Calculus II,0.21,0.38,0.21,0.1,0.05,0%,0.0,0.05,jennifer ray newton,
+MATH,2070,14.0,Business Calculus II,0.04,0.24,0.15,0.15,0.15,0%,0.0,0.26,rachel bass lanning,
+MATH,2080,1.0,Intro to Ordin Diff Equatio,0.5,0.18,0.11,0.0,0.11,0%,0.0,0.11,timothy parrott,
+MATH,2080,2.0,Intro to Ordin Diff Equatio,0.48,0.31,0.13,0.02,0.06,0%,0.0,0.0,timothy parrott,
+MATH,2080,3.0,Intro to Ordin Diff Equatio,0.37,0.14,0.16,0.04,0.22,0%,0.0,0.06,timothy parrott,
+MATH,2080,4.0,Intro to Ordin Diff Equatio,0.17,0.17,0.27,0.1,0.21,0%,0.0,0.08,jeong rock yoon rock,
+MATH,2080,5.0,Intro to Ordin Diff Equatio,0.3,0.09,0.16,0.09,0.18,0%,0.0,0.18,jeong rock yoon rock,
+MATH,2080,6.0,Intro to Ordin Diff Equatio,0.61,0.29,0.04,0.02,0.02,0%,0.0,0.02,leo rebholz,
+MATH,2160,1.0,Geometry for Elem Sch Te,0.94,0.0,0.0,0.0,0.03,0%,0.0,0.03,nicole alaine sinwell,
+MATH,2160,2.0,Geometry for Elem Sch Te,0.93,0.03,0.0,0.0,0.03,0%,0.0,0.0,nicole alaine sinwell,
+MATH,2160,3.0,Geometry for Elem Sch Te,0.69,0.28,0.03,0.0,0.0,0%,0.0,0.0,jusino carreras,
+MATH,3020,1.0,Stat for Science & Enginee,0.83,0.1,0.02,0.02,0.02,0%,0.0,0.0,qiong zhang,
+MATH,3020,2.0,Stat for Science & Enginee,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,xin liu,
+MATH,3020,3.0,Stat for Science & Enginee,0.16,0.33,0.23,0.1,0.05,0%,0.0,0.12,zhiyun gong,
+MATH,3020,4.0,Stat for Science & Enginee,0.24,0.37,0.2,0.05,0.07,0%,0.0,0.08,zhiyun gong,
+MATH,3110,1.0,Linear Algebra,0.39,0.43,0.1,0.0,0.04,0%,0.0,0.04,wayne goddard,
+MATH,3110,2.0,Linear Algebra,0.56,0.31,0.07,0.02,0.04,0%,0.0,0.0, ramiharimanana,
+MATH,3110,3.0,Linear Algebra,0.64,0.27,0.07,0.02,0.0,0%,0.0,0.0, ramiharimanana,
+MATH,3110,4.0,Linear Algebra,0.44,0.31,0.17,0.03,0.03,0%,0.0,0.03,beth novick,
+MATH,3110,5.0,Linear Algebra,0.35,0.33,0.19,0.02,0.06,0%,0.0,0.04,xuhong gao,
+MATH,3110,6.0,Linear Algebra,0.53,0.28,0.07,0.07,0.05,0%,0.0,0.0,benjamin breen,
+MATH,3160,1.0,Prob Solving for Math Tea,0.79,0.14,0.0,0.04,0.04,0%,0.0,0.0,andrew tyminski,
+MATH,3160,2.0,Prob Solving for Math Tea,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,andrew tyminski,
+MATH,3190,1.0,Introduction to Proof,0.17,0.39,0.3,0.09,0.04,0%,0.0,0.0,hui xue,
+MATH,3190,2.0,Introduction to Proof,0.63,0.19,0.07,0.04,0.07,0%,0.0,0.0,ryann rose cartor,
+MATH,3600,1.0,Intermediate Math Compu,0.7,0.0,0.0,0.0,0.1,0%,0.0,0.2,neil calkin,
+MATH,3600,2.0,Intermediate Math Compu,0.39,0.39,0.06,0.0,0.03,0%,0.0,0.06,wayne goddard,
+MATH,3650,1.0,Numerical Mthds for Engin,0.44,0.4,0.11,0.02,0.0,0%,0.0,0.02,qingshan chen,
+MATH,3650,2.0,Numerical Mthds for Engin,0.29,0.22,0.31,0.04,0.04,0%,0.0,0.09,eleanor jenkins,
+MATH,3650,3.0,Numerical Mthds for Engin,0.34,0.26,0.18,0.05,0.05,0%,0.0,0.11,eleanor jenkins,
+MATH,3650,4.0,Numerical Mthds for Engin,0.64,0.16,0.11,0.04,0.0,0%,0.0,0.04,sibusiso mabuza,
+MATH,4000,1.0,Theory of Probability,0.62,0.27,0.12,0.0,0.0,0%,0.0,0.0,peter kiessler,
+MATH,4000,2.0,Theory of Probability,0.25,0.46,0.14,0.0,0.11,0%,0.0,0.04,xinyi li,
+MATH,4020,1.0,Stats for Science and Engr I,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,derek brown,
+MATH,4070,1.0,Regress & Time-Series Ana,0.57,0.19,0.05,0.0,0.05,0%,0.0,0.14,colin gallagher,
+MATH,4080,1.0,Secondary Math Analysis,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,eliza gallagher,
+MATH,4100,1.0,Number Theory,0.27,0.45,0.27,0.0,0.0,0%,0.0,0.0,hui xue,
+MATH,4120,1.0,Algebra I,0.26,0.32,0.37,0.0,0.0,0%,0.0,0.05,james coykendall,
+MATH,4120,2.0,Algebra I,0.43,0.39,0.09,0.09,0.0,0%,0.0,0.0, ramiharimanana,
+MATH,4190,1.0,Discrete Math Structures I,0.71,0.19,0.05,0.0,0.05,0%,0.0,0.0,beth novick,
+MATH,4190,2.0,Discrete Math Structures I,0.64,0.3,0.03,0.0,0.0,0%,0.0,0.03,beth novick,
+MATH,4310,1.0,Theory of Interest,0.26,0.21,0.26,0.11,0.05,0%,0.0,0.0, erwin walker,
+MATH,4340,1.0,Adv Engineering Mathema,0.23,0.27,0.2,0.03,0.1,0%,0.0,0.17,vincent ervin,
+MATH,4340,2.0,Adv Engineering Mathema,0.27,0.12,0.12,0.19,0.15,0%,0.0,0.15,hyesuk lee,
+MATH,4400,1.0,Linear Programming,0.35,0.43,0.08,0.03,0.05,0%,0.0,0.05,boshi yang,
+MATH,4410,1.0,Intro to Stochastic Models,0.64,0.09,0.09,0.0,0.0,0%,0.0,0.18,brian fralix,
+MATH,4530,1.0,Advanced Calculus I,0.14,0.56,0.24,0.02,0.02,0%,0.0,0.02,martin schmoll,
+MATH,4540,1.0,Advanced Calculus II,0.17,0.5,0.11,0.06,0.11,0%,0.0,0.06,martin schmoll,
+MATH,4910,1.0,Math of Options Pricing,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,mark cawood,
+MATH,4920,2.0,Professional Development,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,randy davidson,
+MATH,6340,1.0,Adv Engineering Mathema,0.38,0.38,0.13,0.0,0.0,0%,0.0,0.13,hyesuk lee,
+MATH,8000,1.0,Probability,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,qiong zhang,
+MATH,8010,1.0,General Linear Hypothesis,0.62,0.31,0.08,0.0,0.0,0%,0.0,0.0,xiaoqian sun,
+MATH,8050,1.0,Data Analysis,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,brook thayer russell,
+MATH,8090,1.0,Time Series Analysis,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,xin liu,
+MATH,8120,1.0,Discrete Optimization,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,matthew saltzman,
+MATH,8190,1.0,Multicriteria Optimization,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,margaret wiecek,
+MATH,8210,1.0,Linear Analysis,0.56,0.33,0.06,0.0,0.0,0%,0.0,0.06,mishko mitkovski,
+MATH,8510,1.0,Abstract Algebra I,0.29,0.65,0.06,0.0,0.0,0%,0.0,0.0,michael adam burr,
+MATH,8530,1.0,Matrix Analysis,0.53,0.47,0.0,0.0,0.0,0%,0.0,0.0,matthew macauley,
+MATH,8550,1.0,Combinatorial Analysis,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,svetlana poznanovikj,
+MATH,8600,1.0,Intro to Scientific Computi,0.38,0.54,0.08,0.0,0.0,0%,0.0,0.0,vincent ervin,
+MATH,8650,1.0,Data Structures,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,sibusiso mabuza,
+MATH,8820,1.0,Intro to Bayesian Statistics,0.67,0.29,0.0,0.0,0.0,0%,0.0,0.04,deborah kunkel,
+MATH,9010,1.0,Probability Theory I,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,brian fralix,
+MATH,9830,1.0,Advanced Theories for PD,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,qingshan chen,
+MATH,9830,2.0,High Performance FEM,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,timo heister,
+MATH,9850,1.0,Homological Ring Properti,0.71,0.0,0.14,0.0,0.0,0%,0.0,0.0, sather-wagstaff,
+MATH,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,derek brown,
+MATH,9910,10.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, mcmahan,
+MATH,9910,16.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, sather-wagstaff,
+MBA,8030,2.0,Stat Analy of Bus Op,0.53,0.29,0.12,0.0,0.0,0%,0.0,0.06,william kilbourne,
+MBA,8030,3.0,Stat Analy of Bus Op,0.61,0.28,0.0,0.0,0.0,0%,0.0,0.11,magda gabriela sava,
+MBA,8030,4.0,Stat Analy of Bus Op,0.61,0.36,0.0,0.0,0.04,0%,0.0,0.0,magda gabriela sava,
+MBA,8040,20.0,Busin Data An & Stat Com,0.59,0.26,0.03,0.0,0.12,0%,0.0,0.0,william kilbourne,
+MBA,8060,1.0,Operations Mgt,0.8,0.16,0.02,0.0,0.0,0%,0.0,0.02,lawrence fredendall,
+MBA,8060,3.0,Operations Mgt,0.73,0.23,0.03,0.0,0.0,0%,0.0,0.0,lawrence fredendall,
+MBA,8070,1.0,Financial Management,0.48,0.43,0.03,0.0,0.0,0%,0.0,0.08,george lockhart,
+MBA,8070,2.0,Financial Management,0.43,0.47,0.0,0.0,0.0,0%,0.0,0.1,george lockhart,
+MBA,8070,20.0,Financial Management,0.7,0.26,0.04,0.0,0.0,0%,0.0,0.0,george lockhart,
+MBA,8090,1.0,Org Beh & Hum Res Mg,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,thomas zagenczyk,
+MBA,8090,2.0,Org Beh & Hum Res Mg,0.76,0.21,0.0,0.0,0.0,0%,0.0,0.03,thomas zagenczyk,
+MBA,8090,3.0,Org Beh & Hum Res Mg,0.75,0.23,0.0,0.0,0.0,0%,0.0,0.03,thomas zagenczyk,
+MBA,8180,20.0,Business Intell & Data Anly,0.79,0.12,0.03,0.0,0.06,0%,0.0,0.0,john frederick tripp,
+MBA,8190,2.0,Intro to Acc and Fin,0.41,0.33,0.18,0.0,0.0,0%,0.0,0.08,jeffrey mcmillan,
+MBA,8190,3.0,Intro to Acc and Fin,0.44,0.33,0.18,0.0,0.0,0%,0.0,0.05,jeffrey mcmillan,
+MBA,8290,1.0,Marketing Foundation,0.9,0.05,0.0,0.0,0.0,0%,0.0,0.05,ankita bakre,
+MBA,8310,10.0,Communications and Sales,0.64,0.36,0.0,0.0,0.0,0%,0.0,0.0,gregory pickett,
+MBA,8360,1.0,Real Estate Principles,0.2,0.73,0.0,0.0,0.0,0%,0.0,0.07,stephen buckman,
+MBA,8370,1.0,Legal Environ of Bus,0.43,0.5,0.08,0.0,0.0,0%,0.0,0.0,judson jahn,
+MBA,8370,2.0,Legal Environ of Bus,0.35,0.55,0.08,0.0,0.0,0%,0.0,0.03,judson jahn,
+MBA,8410,1.0,Real Estate Finance,0.81,0.06,0.0,0.0,0.0,0%,0.0,0.06,larry bradley harvey,
+MBA,8430,1.0,Entrepreneurial Accountin,0.36,0.36,0.27,0.0,0.0,0%,0.0,0.0,annieka philo,
+MBA,8470,1.0,New Venture Creation,0.36,0.64,0.0,0.0,0.0,0%,0.0,0.0,joseph gibson,
+MBA,8490,5.0,Entrepreneurial Strategy,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,matthew klein,
+MBA,8500,3.0,Bus Communications,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,
+MBA,8500,30.0,Bus Communications,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,
+MBA,8540,2.0,Managerial Accounting,0.46,0.41,0.11,0.0,0.0,0%,0.0,0.02,emily mccorkle,
+MBA,8590,1.0,Mgr Decision Model,0.32,0.41,0.09,0.0,0.05,0%,0.0,0.14,james turner,
+MBA,8590,2.0,Mgr Decision Model,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.08,magda gabriela sava,
+MBA,8590,3.0,Mgr Decision Model,0.71,0.18,0.0,0.0,0.0,0%,0.0,0.12,magda gabriela sava,
+MBA,8600,2.0,Advanced Marketing Strat,0.67,0.27,0.0,0.0,0.0,0%,0.0,0.07,pravin nath,
+MBA,8600,3.0,Advanced Marketing Strat,0.8,0.13,0.0,0.0,0.0,0%,0.0,0.07,pravin nath,
+MBA,8610,1.0,Information Systems,0.41,0.59,0.0,0.0,0.0,0%,0.0,0.0,william kettinger,
+MBA,8610,2.0,Information Systems,0.67,0.27,0.03,0.0,0.03,0%,0.0,0.0,william kettinger,
+MBA,8620,1.0,Managerial Economics,0.39,0.5,0.06,0.0,0.0,0%,0.0,0.06,scott templeton,
+MBA,8620,2.0,Managerial Economics,0.63,0.37,0.0,0.0,0.0,0%,0.0,0.0,ronald earle gregory,
+MBA,8620,4.0,Managerial Economics,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,ronald earle gregory,
+MBA,8660,21.0,Big Data Mgmt for Analytic,0.81,0.15,0.04,0.0,0.0,0%,0.0,0.0,he li,
+MBA,8700,3.0,Strategic Management,0.67,0.25,0.0,0.0,0.0,0%,0.0,0.08,thomas robert uva,
+MBA,8800,2.0,Career Mgt,0.0,0.0,0.0,0.0,0.0,93%,0.0,0.0,jamie lynn patterson,
+MBA,8800,3.0,MBA Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,
+MBA,8800,30.0,MBA Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jamie lynn patterson,
+MBA,8810,1.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,
+MBA,8810,2.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,
+MBA,8810,3.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,evguenia layton,
+MBA,8810,5.0,Ethics & Leadership,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gail depriest,
+MBA,8880,5.0,MBA Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gregory pickett,
+MBA,8880,11.0,MBA Internship,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gregory pickett,
+MBA,8990,2.0,Creativity,0.75,0.2,0.03,0.0,0.03,0%,0.0,0.0,kathleen ann kegley,
+MBA,8990,4.0,Data Analytics & Visualizati,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,john frederick tripp,
+MBA,8990,5.0,Business Analytics Models,0.83,0.13,0.0,0.0,0.0,0%,0.0,0.04,jennie lynn farmer,
+MBA,8990,10.0,Six Sigma,0.81,0.14,0.0,0.0,0.0,0%,0.0,0.05,dee ann wood kivett wood,
+ME,2000,400.0,Sophomore Seminar,0.55,0.21,0.08,0.04,0.06,0%,0.0,0.06,todd schweisinger,
+ME,2010,1.0,Statics & Dynamics,0.0,0.13,0.23,0.09,0.39,0%,0.0,0.16,marisa kikendall orr,
+ME,2010,2.0,Statics & Dynamics,0.23,0.15,0.28,0.09,0.19,0%,0.0,0.06,paul joseph,
+ME,2010,3.0,Statics & Dynamics,0.11,0.08,0.15,0.15,0.44,0%,0.0,0.08,gang liu,
+ME,2010,4.0,Statics & Dynamics,0.06,0.1,0.09,0.06,0.43,0%,0.0,0.26, parvinioskoui,
+ME,2030,1.0,Founda Th/Fl Syst,0.15,0.34,0.43,0.09,0.0,0%,0.0,0.0,xiangchun xuan,
+ME,2030,2.0,Founda Th/Fl Syst,0.13,0.49,0.29,0.0,0.04,0%,0.0,0.04,yiqiang han,
+ME,2040,1.0,Mechanics of Materials,0.02,0.2,0.39,0.13,0.15,0%,0.0,0.02,gang liu,
+ME,2040,2.0,Mechanics of Materials,0.11,0.39,0.36,0.11,0.03,0%,0.0,0.0,huijuan zhao,
+ME,2220,1.0,Mechanical Engineering La,0.25,0.63,0.13,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
+ME,2220,2.0,Mechanical Engineering La,0.31,0.69,0.0,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
+ME,2220,5.0,Mechanical Engineering La,0.38,0.56,0.06,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
+ME,2220,6.0,Mechanical Engineering La,0.63,0.25,0.06,0.0,0.06,0%,0.0,0.0,douglas scott byrd,
+ME,2220,7.0,Mechanical Engineering La,0.31,0.56,0.06,0.06,0.0,0%,0.0,0.0,douglas scott byrd,
+ME,2220,8.0,Mechanical Engineering La,0.25,0.5,0.19,0.06,0.0,0%,0.0,0.0,douglas scott byrd,
+ME,2220,10.0,Mechanical Engineering La,0.25,0.44,0.06,0.06,0.06,0%,0.0,0.13,douglas scott byrd,
+ME,2220,13.0,Mechanical Engineering La,0.63,0.31,0.06,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
+ME,2220,14.0,Mechanical Engineering La,0.13,0.38,0.13,0.06,0.13,0%,0.0,0.19,douglas scott byrd,
+ME,2220,15.0,Mechanical Engineering La,0.25,0.44,0.31,0.0,0.0,0%,0.0,0.0,douglas scott byrd,
+ME,3000,301.0,Junior Honors Seminar (H,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,joshua bostwick,True
+ME,3030,1.0,Thermodynamics,0.19,0.24,0.14,0.14,0.16,0%,0.0,0.14,john saylor,
+ME,3030,2.0,Thermodynamics,0.7,0.16,0.1,0.02,0.02,0%,0.0,0.02,sandip dutta,
+ME,3030,3.0,Thermodynamics,0.82,0.13,0.04,0.0,0.02,0%,0.0,0.0,sandip dutta,
+ME,3040,1.0,Heat Transfer,0.14,0.59,0.21,0.0,0.07,0%,0.0,0.0,xin zhao,
+ME,3040,2.0,Heat Transfer,0.38,0.4,0.19,0.04,0.0,0%,0.0,0.0,xin zhao,
+ME,3040,3.0,Heat Transfer,0.73,0.19,0.04,0.02,0.0,0%,0.0,0.02,sandip dutta,
+ME,3050,1.0,Model/an Dy Syst,0.26,0.35,0.33,0.02,0.05,0%,0.0,0.0,ardalan vahidi,
+ME,3050,2.0,Model/an Dy Syst,0.21,0.48,0.19,0.1,0.0,0%,0.0,0.02,ge lv,
+ME,3050,3.0,Model/an Dy Syst,0.21,0.39,0.21,0.0,0.12,0%,0.0,0.06,joshua bostwick,
+ME,3060,1.0,Fund Machine Design,0.35,0.38,0.17,0.04,0.04,0%,0.0,0.0,douglas scott byrd,
+ME,3060,2.0,Fund Machine Design,0.73,0.24,0.02,0.0,0.0,0%,0.0,0.02,zhaoxu meng,
+ME,3070,1.0,Found of Mechanical Syste,0.73,0.21,0.04,0.0,0.02,0%,0.0,0.0,lonny thompson,
+ME,3070,2.0,Found of Mechanical Syste,0.32,0.35,0.16,0.03,0.13,0%,0.0,0.0,katherine ehlert,
+ME,3070,3.0,Found of Mechanical Syste,0.32,0.38,0.13,0.06,0.06,0%,0.0,0.04,chengshi wang,
+ME,3080,1.0,Fluid Mechanics,0.22,0.47,0.25,0.04,0.0,0%,0.0,0.02,xiangchun xuan,
+ME,3080,2.0,Fluid Mechanics,0.27,0.6,0.13,0.0,0.0,0%,0.0,0.0,ethan kung,
+ME,3080,3.0,Fluid Mechanics,0.35,0.51,0.14,0.0,0.0,0%,0.0,0.0,zhen li,
+ME,3120,1.0,Manuf Processes,0.24,0.63,0.11,0.0,0.02,0%,0.0,0.0,hong seok choi,
+ME,3120,2.0,Manuf Processes,0.68,0.26,0.05,0.01,0.0,0%,0.0,0.0, martinez-duarte,
+ME,3330,1.0,Mechanical Engineering La,0.44,0.5,0.06,0.0,0.0,0%,0.0,0.0,yiqiang han,
+ME,3330,2.0,Mechanical Engineering La,0.44,0.5,0.0,0.0,0.0,0%,0.0,0.06,yiqiang han,
+ME,3330,3.0,Mechanical Engineering La,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.07,yiqiang han,
+ME,3330,4.0,Mechanical Engineering La,0.27,0.64,0.0,0.0,0.09,0%,0.0,0.0,yiqiang han,
+ME,3330,5.0,Mechanical Engineering La,0.38,0.5,0.06,0.0,0.0,0%,0.0,0.06,yiqiang han,
+ME,3330,6.0,Mechanical Engineering La,0.56,0.31,0.13,0.0,0.0,0%,0.0,0.0,yiqiang han,
+ME,3330,7.0,Mechanical Engineering La,0.6,0.2,0.1,0.0,0.1,0%,0.0,0.0,yiqiang han,
+ME,3330,10.0,Mechanical Engineering La,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,
+ME,3330,13.0,Mechanical Engineering La,0.56,0.31,0.06,0.06,0.0,0%,0.0,0.0,yiqiang han,
+ME,3330,14.0,Mechanical Engineering La,0.47,0.53,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,
+ME,4000,400.0,Senior Seminar,0.86,0.1,0.03,0.01,0.01,0%,0.0,0.0,atul gajanan kelkar,
+ME,4010,1.0,Mech Engr Design,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,timothy guggisberg,
+ME,4010,2.0,Mech Engr Design,0.23,0.77,0.0,0.0,0.0,0%,0.0,0.0,gregory mocko,
+ME,4010,400.0,Mech Engr Design,0.63,0.38,0.0,0.0,0.0,0%,0.0,0.0,geetha chimata,
+ME,4020,1.0,Intern in Engr Des,0.61,0.33,0.06,0.0,0.0,0%,0.0,0.0,sandip dutta,
+ME,4020,3.0,Intern in Engr Des,0.47,0.35,0.18,0.0,0.0,0%,0.0,0.0,yiqiang han,
+ME,4020,4.0,Intern in Engr Des,0.38,0.62,0.0,0.0,0.0,0%,0.0,0.0,yiqiang han,
+ME,4020,5.0,Intern in Engr Des,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,timothy guggisberg,
+ME,4030,1.0,Control Dynamic Systems,0.15,0.23,0.22,0.2,0.13,0%,0.0,0.03, naghnaeian,
+ME,4030,2.0,Control Dynamic Systems,0.42,0.4,0.12,0.05,0.02,0%,0.0,0.0,umesh vaidya,
+ME,4030,3.0,Control Dynamic Systems,0.37,0.47,0.16,0.0,0.0,0%,0.0,0.0, tallapragada,
+ME,4210,1.0,Intro to Comp Flow,0.43,0.3,0.26,0.0,0.0,0%,0.0,0.0,chenning tong,
+ME,4290,1.0,Ther Env Control,0.63,0.25,0.0,0.04,0.0,0%,0.0,0.04,jay ochterbeck,
+ME,4300,1.0,Mech Comp Materials,0.63,0.13,0.21,0.0,0.0,0%,0.0,0.04,lonny thompson,
+ME,4320,1.0,Advanced Strength of Mat,0.79,0.18,0.0,0.0,0.0,0%,0.0,0.0,oliver myers,
+ME,4340,1.0,Cardiovascular Biomechani,0.25,0.46,0.17,0.0,0.04,0%,0.0,0.04,ethan kung,
+ME,4400,1.0,Materials for Aggressive E,0.59,0.3,0.11,0.0,0.0,0%,0.0,0.0,garrett pataky,
+ME,4440,1.0,Mechanical Engineering La,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,2.0,Mechanical Engineering La,0.38,0.5,0.13,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,3.0,Mechanical Engineering La,0.06,0.88,0.06,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,4.0,Mechanical Engineering La,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,5.0,Mechanical Engineering La,0.25,0.75,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,6.0,Mechanical Engineering La,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,7.0,Mechanical Engineering La,0.33,0.67,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,8.0,Mechanical Engineering La,0.54,0.46,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,9.0,Mechanical Engineering La,0.58,0.42,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4440,13.0,Mechanical Engineering La,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,john wagner,
+ME,4550,400.0,Design for Manuf,0.53,0.24,0.16,0.02,0.04,0%,0.0,0.0,joshua summers,
+ME,4580,1.0,Fund Micro/Nano Fabricati,0.41,0.45,0.05,0.0,0.0,0%,0.0,0.05, martinez-duarte,
+ME,4930,29.0,Sel Topics ME - Vibrations,0.36,0.36,0.14,0.11,0.0,0%,0.0,0.04,suyi li,
+ME,6300,1.0,Mech Comp Materials,0.8,0.1,0.0,0.0,0.0,0%,0.0,0.1,lonny thompson,
+ME,6320,1.0,Advanced Strength of Mat,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,oliver myers,
+ME,6340,1.0,Cardiovascular Biomechani,0.4,0.4,0.2,0.0,0.0,0%,0.0,0.0,ethan kung,
+ME,6550,400.0,Design for Manuf,0.43,0.36,0.07,0.0,0.07,0%,0.0,0.07,joshua summers,
+ME,6580,1.0,Fund Micro/Nano Fabricati,0.2,0.6,0.2,0.0,0.0,0%,0.0,0.0, martinez-duarte,
+ME,6930,24.0,Sel Topics - Automotive Sa,0.9,0.05,0.0,0.0,0.05,0%,0.0,0.0,john wagner,
+ME,6930,865.0,Sel Topics - Metrology (VT,0.6,0.3,0.0,0.0,0.0,0%,0.0,0.1,geetha chimata,
+ME,8010,1.0,Found of Fluid Mech,0.73,0.2,0.0,0.0,0.0,0%,0.0,0.07,richard figliola,
+ME,8010,843.0,Found of Fluid Mech,0.4,0.2,0.0,0.0,0.0,0%,0.0,0.4,richard figliola,
+ME,8100,1.0,Macroscopic Thermo,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,jay ochterbeck,
+ME,8180,1.0,Intro to Fin Ele Ana,0.31,0.49,0.09,0.0,0.0,0%,0.0,0.11,gang li,
+ME,8230,1.0,Control Systems,0.78,0.0,0.11,0.0,0.0,0%,0.0,0.11,yue wang,
+ME,8360,1.0,Fracture Mech,0.38,0.13,0.13,0.0,0.0,0%,0.0,0.38,huijuan zhao,
+ME,8460,1.0,Inter Dynamics,0.33,0.42,0.08,0.0,0.0,0%,0.0,0.08, tallapragada,
+ME,8610,1.0,Matl Sel Engr Design,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,garrett pataky,
+ME,8610,864.0,Matl Sel Engr Design,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,garrett pataky,
+ME,8700,1.0,Adv Design Methods,0.25,0.58,0.0,0.0,0.0,0%,0.0,0.08,gregory mocko,
+ME,8710,1.0,Engr Optimization,0.72,0.14,0.07,0.0,0.0,0%,0.0,0.03,cameron turner,
+ME,8910,16.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,joshua summers,
+ME,8910,28.0,Master's Thesis Research,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,cameron turner,
+ME,8930,8.0,Sel Topics ME: Continuum,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,fadi abdeljawad,
+ME,8930,27.0,Sel Topics ME - Optimal Co,0.38,0.57,0.0,0.0,0.0,0%,0.0,0.0,ardalan vahidi,
+ME,9910,9.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gang li,
+ME,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,yue wang,
+ME,9910,29.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,suyi li,
+MGT,2010,1.0,Principles of Management,0.46,0.43,0.09,0.0,0.01,0%,0.0,0.0,katherine clark,
+MGT,2010,2.0,Principles of Management,0.75,0.22,0.01,0.0,0.02,0%,0.0,0.0,jonathan preedom,
+MGT,2010,3.0,Principles of Management,0.93,0.03,0.03,0.0,0.0,0%,0.0,0.0,sheena laxton,True
+MGT,2010,8.0,Principles of Management,0.86,0.07,0.02,0.0,0.0,0%,0.0,0.05,shuang liu,
+MGT,2010,9.0,Principles of Management,0.4,0.4,0.19,0.02,0.0,0%,0.0,0.0,ashley parnell,
+MGT,2010,10.0,Principles of Management,0.48,0.33,0.17,0.0,0.02,0%,0.0,0.0,ashley parnell,
+MGT,2010,11.0,Principles of Management,0.95,0.0,0.02,0.0,0.02,0%,0.0,0.0,jingyuan tian,
+MGT,2010,12.0,Principles of Management,0.8,0.1,0.0,0.0,0.05,0%,0.0,0.05,zhiwei xing,
+MGT,2010,13.0,Principles of Management,0.21,0.41,0.24,0.1,0.03,0%,0.0,0.01,christopher mann,
+MGT,2010,14.0,Principles of Management,0.77,0.2,0.01,0.0,0.01,0%,0.0,0.01,sharon sheridan,
+MGT,2010,15.0,Principles of Management,0.72,0.14,0.05,0.09,0.0,0%,0.0,0.0,hongli ye,
+MGT,2010,18.0,Principles of Management,0.93,0.05,0.0,0.0,0.0,0%,0.0,0.03,yao chen,
+MGT,2180,1.0,Management PC Applicati,0.84,0.12,0.03,0.01,0.0,0%,0.0,0.01,ryan toole,
+MGT,2180,2.0,Management PC Applicati,0.71,0.19,0.03,0.02,0.05,0%,0.0,0.01,ryan toole,
+MGT,2180,3.0,Management PC Applicati,0.59,0.26,0.06,0.03,0.05,0%,0.0,0.01,jeromy blake snider,
+MGT,3070,1.0,Human Resource Manage,0.6,0.29,0.05,0.05,0.0,0%,0.0,0.02,michael cole,
+MGT,3070,4.0,Human Resource Manage,0.55,0.45,0.0,0.0,0.0,0%,0.0,0.0,leonard spooner,
+MGT,3070,5.0,Human Resource Manage,0.62,0.24,0.03,0.03,0.08,0%,0.0,0.0,kristin scott,
+MGT,3070,6.0,Human Resource Manage,0.71,0.26,0.03,0.0,0.0,0%,0.0,0.0,leonard spooner,
+MGT,3070,7.0,Human Resource Manage,0.23,0.54,0.15,0.08,0.0,0%,0.0,0.0,priscilla harrison,
+MGT,3070,8.0,Human Resource Manage,0.63,0.34,0.02,0.0,0.0,0%,0.0,0.0,michael cole,
+MGT,3070,9.0,Human Resource Manage,0.55,0.39,0.06,0.0,0.0,0%,0.0,0.0,leonard spooner,
+MGT,3100,1.0,Intermed Business Statistic,0.41,0.35,0.16,0.05,0.03,0%,0.0,0.0,jaeyoung kim,
+MGT,3100,2.0,Intermed Business Statistic,0.68,0.1,0.13,0.0,0.03,0%,0.0,0.08,haeri seyed seyed,
+MGT,3100,3.0,Intermed Business Statistic,0.41,0.35,0.06,0.0,0.03,0%,0.0,0.15,mustafa akturk,
+MGT,3100,5.0,Intermed Business Statistic,0.45,0.31,0.18,0.03,0.01,0%,0.0,0.02,mustafa akturk,
+MGT,3100,6.0,Intermed Business Statistic,0.41,0.24,0.22,0.0,0.07,0%,0.0,0.05,philip roth,
+MGT,3100,7.0,Intermed Business Statistic,0.61,0.26,0.11,0.0,0.03,0%,0.0,0.0, ajjuguttu,
+MGT,3100,8.0,Intermed Business Statistic,0.27,0.33,0.17,0.07,0.1,0%,0.0,0.07,jeromy blake snider,
+MGT,3100,9.0,Intermed Business Statistic,0.79,0.12,0.07,0.02,0.0,0%,0.0,0.0,david ford peyton,
+MGT,3100,10.0,Intermed Business Statistic,0.5,0.33,0.08,0.0,0.03,0%,0.0,0.06,david ford peyton,
+MGT,3100,12.0,Intermed Business Statistic,0.68,0.12,0.15,0.0,0.03,0%,0.0,0.03,david ford peyton,
+MGT,3100,13.0,Intermed Business Statistic,0.41,0.28,0.09,0.06,0.03,0%,0.0,0.06,benjamin wiles,
+MGT,3120,5.0,Decision Models for Mana,0.09,0.13,0.28,0.13,0.28,0%,0.0,0.11,sara elizabeth yoder,
+MGT,3120,6.0,Decision Models for Mana,0.09,0.22,0.27,0.16,0.19,0%,0.0,0.03,sara elizabeth yoder,
+MGT,3120,9.0,Decision Models for Mana,0.12,0.18,0.22,0.09,0.27,0%,0.0,0.12,sara elizabeth yoder,
+MGT,3180,1.0,Mgt of Info Systems,0.67,0.2,0.13,0.0,0.0,0%,0.0,0.0,nedumkallel pius,
+MGT,3180,3.0,Mgt of Info Systems,0.59,0.26,0.11,0.02,0.02,0%,0.0,0.0,kevin mckenzie,
+MGT,3180,4.0,Mgt of Info Systems,0.64,0.26,0.02,0.06,0.02,0%,0.0,0.0,iaroslava dutchak,
+MGT,3180,6.0,Mgt of Info Systems,0.35,0.27,0.18,0.12,0.04,0%,0.0,0.04,zhihong ke,
+MGT,3180,7.0,Mgt of Info Systems,0.38,0.38,0.13,0.04,0.02,0%,0.0,0.04,iaroslava dutchak,
+MGT,3180,9.0,Mgt of Info Systems,0.47,0.33,0.07,0.02,0.0,0%,0.0,0.12,pranith abbaraju,
+MGT,3500,1.0,Business Intel/Data Analyti,0.59,0.32,0.05,0.0,0.05,0%,0.0,0.0,david ford peyton,
+MGT,3900,1.0,Operations Management,0.04,0.25,0.43,0.11,0.11,0%,0.0,0.07,zachary leffakis,
+MGT,3900,2.0,Operations Management,0.14,0.49,0.3,0.08,0.0,0%,0.0,0.0,zachary leffakis,
+MGT,3900,4.0,Operations Management,0.41,0.39,0.17,0.01,0.02,0%,0.0,0.0,ying zhang,
+MGT,3900,5.0,Operations Management,0.3,0.51,0.16,0.03,0.01,0%,0.0,0.0,ying zhang,
+MGT,3900,7.0,Operations Management,0.16,0.66,0.17,0.0,0.01,0%,0.0,0.01, sridharan,
+MGT,4000,1.0,Mgt of Organizational Beh,0.8,0.18,0.0,0.03,0.0,0%,0.0,0.0,michael cole,
+MGT,4000,2.0,Mgt of Organizational Beh,0.73,0.25,0.0,0.0,0.0,0%,0.0,0.03,michael cole,
+MGT,4000,3.0,Mgt of Organizational Beh,0.23,0.4,0.28,0.05,0.0,0%,0.0,0.05,thomas zagenczyk,
+MGT,4000,4.0,Mgt of Organizational Beh,0.46,0.41,0.11,0.0,0.03,0%,0.0,0.0,sara joy krivacek,
+MGT,4020,1.0,Ops Pln and Ctl,0.07,0.27,0.27,0.07,0.17,0%,0.0,0.13,zachary leffakis,
+MGT,4080,1.0,Lean Operations,0.06,0.35,0.41,0.06,0.12,0%,0.0,0.0,zachary leffakis,
+MGT,4110,1.0,Project Management,0.33,0.5,0.13,0.0,0.0,0%,0.0,0.0,russell purvis,
+MGT,4120,1.0,Supplier Management,0.48,0.45,0.03,0.0,0.0,0%,0.0,0.03,ahmet colak,
+MGT,4150,2.0,Business Strategy,0.23,0.4,0.38,0.0,0.0,0%,0.0,0.0,james liddle,
+MGT,4150,3.0,Business Strategy,0.09,0.64,0.24,0.02,0.0,0%,0.0,0.0,james liddle,
+MGT,4150,4.0,Business Strategy,0.11,0.6,0.27,0.0,0.0,0%,0.0,0.02,james liddle,
+MGT,4150,6.0,Business Strategy,0.24,0.6,0.13,0.02,0.0,0%,0.0,0.0,amy elizabeth ingram,
+MGT,4150,7.0,Business Strategy,0.56,0.37,0.06,0.0,0.01,0%,0.0,0.0,matt calvin hersel,
+MGT,4150,8.0,Business Strategy,0.2,0.66,0.14,0.0,0.0,0%,0.0,0.0,amy elizabeth ingram,
+MGT,4150,9.0,Business Strategy,0.55,0.26,0.19,0.0,0.0,0%,0.0,0.0,paul robert bonney,
+MGT,4160,1.0,Special Topics Hr,0.58,0.34,0.05,0.0,0.03,0%,0.0,0.0,kristin scott,
+MGT,4230,1.0,Intern Bus Mgt,0.17,0.06,0.56,0.06,0.06,0%,0.0,0.08,wayne stewart,
+MGT,4230,2.0,Intern Bus Mgt,0.31,0.14,0.47,0.02,0.04,0%,0.0,0.02,wayne stewart,
+MGT,4230,4.0,Intern Bus Mgt,0.13,0.36,0.47,0.0,0.04,0%,0.0,0.0,monica simsek,
+MGT,4230,5.0,Intern Bus Mgt,0.09,0.47,0.45,0.0,0.0,0%,0.0,0.0,monica simsek,
+MGT,4240,1.0,Global Supply Chain Mana,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,ahmet colak,
+MGT,4270,2.0,Managing Improvement,0.18,0.53,0.24,0.06,0.0,0%,0.0,0.0,lawrence fredendall,
+MGT,4310,1.0,Emp Rights & Resp,0.38,0.54,0.05,0.0,0.0,0%,0.0,0.03,leonard spooner,
+MGT,4350,1.0,Pers Interviewing,0.37,0.49,0.12,0.0,0.02,0%,0.0,0.0,philip roth,
+MGT,4500,3.0,Desc & Pred Business Anal,0.55,0.09,0.27,0.0,0.09,0%,0.0,0.0,zhihong ke,
+MGT,4520,1.0,Business Analysis,0.27,0.55,0.09,0.0,0.09,0%,0.0,0.0,russell purvis,
+MGT,4540,1.0,Business Analytics Progra,0.44,0.22,0.22,0.03,0.0,0%,0.0,0.08,hongki kim,
+MGT,4560,1.0,Business Data Managemen,0.57,0.37,0.03,0.03,0.0,0%,0.0,0.0,he li,
+MGT,4970,5.0,CI- Deloitte Consulting,0.79,0.05,0.0,0.0,0.0,0%,0.0,0.16,ryan toole,
+MGT,8690,1.0,Project Mgt,0.39,0.61,0.0,0.0,0.0,0%,0.0,0.0,russell purvis,
+MICR,2050,1.0,Introductory Micro,0.5,0.41,0.08,0.0,0.01,0%,0.0,0.0,john abercrombie,
+MICR,3050,1.0,General Microbiology,0.82,0.1,0.04,0.01,0.01,0%,0.0,0.02,tzuen-rong tzeng,
+MICR,3050,2.0,General Microbiology,0.46,0.32,0.14,0.06,0.01,0%,0.0,0.02,krista rudolph,
+MICR,3050,3.0,General Microbiology,0.54,0.31,0.12,0.04,0.0,0%,0.0,0.0,krista rudolph,
+MICR,4010,1.0,Microbial Diversity & Ecolo,0.7,0.21,0.07,0.02,0.0,0%,0.0,0.0,kristi whitehead,
+MICR,4010,2.0,Micro Diversity/Ecol (HON,0.92,0.08,0.0,0.0,0.0,0%,0.0,0.0,kristi whitehead,True
+MICR,4050,1.0,Adv Microbial Ecol of Hum,0.67,0.21,0.06,0.04,0.01,0%,0.0,0.01,kristi whitehead,
+MICR,4140,1.0,Basic Immunology,0.83,0.15,0.0,0.0,0.0,0%,0.0,0.01,charles rice,
+MICR,4150,1.0,Microbial Genetics,0.19,0.49,0.21,0.09,0.02,0%,0.0,0.0,min cao,
+MICR,4160,1.0,Intro Virology,0.47,0.36,0.12,0.0,0.0,0%,0.0,0.05,kaustubha qanungo,
+MICR,4510,1.0,Advanced Microbiology II,0.28,0.67,0.0,0.0,0.06,0%,0.0,0.0,harry kurtz,
+MICR,4510,2.0,Advanced Microbiology II,0.21,0.58,0.21,0.0,0.0,0%,0.0,0.0,harry kurtz,
+MICR,4510,3.0,Advanced Microbiology II,0.15,0.38,0.38,0.0,0.08,0%,0.0,0.0,harry kurtz,
+MICR,6050,1.0,Adv Microbial Ecol of Hum,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,kristi whitehead,
+MICR,6140,1.0,Basic Immunology,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,charles rice,
+MICR,8040,1.0,Sel Top: MICR Core,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,barbara campbell,
+MICR,8070,1.0,Micro Journal Club,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,barbara campbell,
+MKT,3010,1.0,Principles of Marketing,0.21,0.31,0.31,0.11,0.03,0%,0.0,0.02,amanda cooper fine,
+MKT,3010,2.0,Principles of Marketing,0.23,0.35,0.27,0.09,0.04,0%,0.0,0.02,amanda cooper fine,
+MKT,3010,3.0,Principles of Marketing,0.3,0.33,0.23,0.08,0.03,0%,0.0,0.03,amanda cooper fine,
+MKT,3010,4.0,Principles of Marketing,0.57,0.29,0.07,0.01,0.01,0%,0.0,0.05,james gaubert,
+MKT,3010,5.0,Principles of Marketing,0.49,0.3,0.12,0.01,0.04,0%,0.0,0.03,james gaubert,
+MKT,3010,7.0,Principles of Marketing,0.49,0.37,0.07,0.01,0.02,0%,0.0,0.03,lura forcum,
+MKT,3020,1.0,Consumer Behavior,0.8,0.12,0.04,0.02,0.02,0%,0.0,0.0,cony ming shen ho shen,
+MKT,3020,2.0,Consumer Behavior,0.86,0.1,0.02,0.0,0.02,0%,0.0,0.0,cony ming shen ho shen,
+MKT,3020,3.0,Consumer Behavior,0.92,0.05,0.01,0.0,0.01,0%,0.0,0.0,cony ming shen ho shen,
+MKT,3020,5.0,Consumer Behavior,0.58,0.28,0.08,0.06,0.0,0%,0.0,0.0,anastasia thyroff,
+MKT,3020,6.0,Consumer Behavior,0.63,0.24,0.08,0.06,0.0,0%,0.0,0.0,anastasia thyroff,
+MKT,3210,1.0,Sports Marketing,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,delancy bennett s,
+MKT,3220,1.0,Social Media Marketing,0.74,0.15,0.04,0.04,0.02,0%,0.0,0.02,robert fitzwater,
+MKT,3310,1.0,Marketing Metrics & Analy,0.72,0.22,0.0,0.0,0.0,0%,0.0,0.06,oriana rachel aragon,
+MKT,3310,2.0,Marketing Metrics & Analy,0.63,0.2,0.14,0.03,0.0,0%,0.0,0.0,oriana rachel aragon,
+MKT,3310,3.0,Marketing Metrics & Analy,0.69,0.29,0.0,0.03,0.0,0%,0.0,0.0,xianyong wang,
+MKT,3310,4.0,Marketing Metrics & Analy,0.59,0.35,0.03,0.03,0.0,0%,0.0,0.0,xianyong wang,
+MKT,4200,2.0,Professional Selling,0.79,0.15,0.03,0.0,0.03,0%,0.0,0.0,jesse moore,
+MKT,4200,5.0,Professional Selling,0.86,0.1,0.03,0.0,0.0,0%,0.0,0.0,carter mcelveen,
+MKT,4200,6.0,Professional Selling,0.64,0.21,0.03,0.0,0.06,0%,0.0,0.06,jesse moore,
+MKT,4200,7.0,Professional Selling,0.75,0.21,0.0,0.0,0.0,0%,0.0,0.04,carter mcelveen,
+MKT,4220,1.0,Applied Selling,0.45,0.55,0.0,0.0,0.0,0%,0.0,0.0,ryan mullins,
+MKT,4230,2.0,Promotional Strategy,0.78,0.18,0.04,0.0,0.0,0%,0.0,0.0,michele cauley,
+MKT,4230,3.0,Promotional Strategy,0.5,0.43,0.04,0.02,0.02,0%,0.0,0.0,michele cauley,
+MKT,4230,4.0,Promotional Strategy,0.69,0.23,0.05,0.02,0.02,0%,0.0,0.0,michele cauley,
+MKT,4240,1.0,Sales Management,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,ryan mullins,
+MKT,4260,1.0,Business-to-Business,0.44,0.46,0.08,0.03,0.0,0%,0.0,0.0,james gaubert,
+MKT,4270,1.0,International Marketing,0.53,0.38,0.05,0.05,0.0,0%,0.0,0.0,xianyong wang,
+MKT,4270,2.0,International Marketing,0.52,0.36,0.12,0.0,0.0,0%,0.0,0.0,xianyong wang,
+MKT,4270,3.0,International Marketing,0.75,0.23,0.0,0.0,0.0,0%,0.0,0.03,thomas poehlman,
+MKT,4270,4.0,International Marketing,0.6,0.33,0.05,0.0,0.03,0%,0.0,0.0,thomas poehlman,
+MKT,4270,5.0,International Marketing,0.37,0.51,0.09,0.01,0.0,0%,0.0,0.01,xianyong wang,
+MKT,4280,1.0,Services Marketing,0.53,0.33,0.1,0.02,0.02,0%,0.0,0.0, scheinbaum,
+MKT,4280,2.0,Services Marketing,0.38,0.45,0.15,0.03,0.0,0%,0.0,0.0, scheinbaum,
+MKT,4310,1.0,Marketing Research,0.6,0.34,0.0,0.03,0.03,0%,0.0,0.0, giebelhausen,
+MKT,4310,2.0,Marketing Research,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0, giebelhausen,
+MKT,4310,3.0,Marketing Research,0.33,0.52,0.15,0.0,0.0,0%,0.0,0.0,peter weathers,
+MKT,4310,5.0,Marketing Research,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,scott darren swain,
+MKT,4430,1.0,Advertising Strategy,0.92,0.06,0.02,0.0,0.0,0%,0.0,0.0,scott darren swain,
+MKT,4500,1.0,Strategic Mktg Mgt,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,annette popp tower,
+MKT,4500,2.0,Strategic Mktg Mgt,0.4,0.48,0.08,0.0,0.04,0%,0.0,0.0,annette popp tower,
+MKT,4500,3.0,Strategic Mktg Mgt,0.2,0.48,0.32,0.0,0.0,0%,0.0,0.0,mary anne raymond,
+MKT,4500,4.0,Strategic Mktg Mgt,0.62,0.35,0.04,0.0,0.0,0%,0.0,0.0,michele cauley,
+ML,1010,1.0,Leadership Fundamentals I,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,joseph david velez,
+ML,1010,2.0,Leadership Fundamentals I,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,joseph david velez,
+ML,1010,3.0,Leadership Fundamentals I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,joseph david velez,
+ML,2010,1.0,Leadership Development I,0.88,0.06,0.0,0.0,0.06,0%,0.0,0.0,michael scott gibson,
+ML,2010,2.0,Leadership Development I,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,michael scott gibson,
+ML,2010,3.0,Leadership Development I,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,michael scott gibson,
+ML,3010,2.0,Advanced Leadership I,0.95,0.0,0.0,0.0,0.0,0%,0.0,0.05,justin robert merhar,
+MSE,2100,1.0,Intro to Materials Science,0.46,0.39,0.07,0.02,0.04,0%,0.0,0.02,kimberly weirich,
+MSE,2100,2.0,Intro to Materials Science,0.3,0.4,0.15,0.04,0.06,0%,0.0,0.06,kai he,
+MSE,2100,3.0,Intro to Materials Science,0.95,0.05,0.0,0.0,0.0,0%,0.0,0.0,john ballato,
+MSE,2100,4.0,Intro to Materials Science,0.39,0.45,0.12,0.02,0.01,0%,0.0,0.01,mark alan johnson,
+MSE,2100,6.0,Intro to Materials Science,0.71,0.2,0.05,0.01,0.01,0%,0.0,0.01,olga kuksenok,
+MSE,3010,1.0,Materials Synthesis & Fabr,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,rakhee pani,
+MSE,3010,3.0,Materials Synthesis & Fabr,0.71,0.14,0.14,0.0,0.0,0%,0.0,0.0,rakhee pani,
+MSE,3260,2.0,Thermodynamics of Mater,0.22,0.41,0.19,0.06,0.06,0%,0.0,0.03,fei peng,
+MSE,3450,1.0,Practice of Materials Engr,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marek urban,
+MSE,3910,1.0,Research Fundamentals,0.68,0.05,0.11,0.05,0.0,0%,0.0,0.05,ulf daniel schiller,
+MSE,4130,1.0,Noncrystalline Materials,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,ming tang,
+MSE,4150,1.0,Polymer Science & Engine,0.85,0.1,0.05,0.0,0.0,0%,0.0,0.0,olin mefford,
+MSE,4150,2.0,Polymer Science & Engine,0.73,0.13,0.08,0.0,0.01,0%,0.0,0.05,rakhee pani,
+MSE,4320,1.0,Manufacturing Proc & Syst,0.82,0.14,0.0,0.0,0.05,0%,0.0,0.0,john sanders,
+MSE,8000,1.0,Seminar in Materials Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,kai he,
+MSE,8100,1.0,Fundamentals of Materials,0.64,0.32,0.04,0.0,0.0,0%,0.0,0.0,rajendra bordia,
+MSE,8190,1.0,Inorgan Mater Characteriz,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,luiz jacobsohn,
+MSE,8260,1.0,Phase Equil Mat Sys,0.15,0.69,0.15,0.0,0.0,0%,0.0,0.0,stephen foulger,
+MSE,8270,1.0,Kin of Phase Tran,0.5,0.27,0.23,0.0,0.0,0%,0.0,0.0,konstantin kornev,
+MSE,8510,1.0,Polymer Science I,0.71,0.21,0.0,0.0,0.0,0%,0.0,0.07,marek urban,
+MSE,9910,19.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,jianhua tong,
+MSE,9910,20.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marek urban,
+MTSA,8420,1.0,Road Safety Culture,0.93,0.0,0.0,0.0,0.0,0%,0.0,0.07,kim alexander,
+MUSC,1420,1.0,Music Theory I,0.7,0.2,0.05,0.05,0.0,0%,0.0,0.0,linda li-bleuel,
+MUSC,1430,1.0,Aural Skills I,0.8,0.15,0.05,0.0,0.0,0%,0.0,0.0,linda li-bleuel,
+MUSC,1510,2.0,Applied Music for Non Maj,0.58,0.17,0.0,0.08,0.0,0%,0.0,0.17,jonathan doyel,
+MUSC,2100,2.0,Music in the Western Worl,0.71,0.23,0.0,0.0,0.0,0%,0.0,0.06,rhea beth jacobus,
+MUSC,2100,5.0,Music in the Western Worl,0.95,0.03,0.0,0.0,0.03,0%,0.0,0.0,timothy ray hurlburt,
+MUSC,2100,6.0,Music in the Western Worl,0.94,0.06,0.0,0.0,0.0,0%,0.0,0.0,david conley,
+MUSC,2100,7.0,Music in the Western Worl,0.74,0.23,0.03,0.0,0.0,0%,0.0,0.0,rhea beth jacobus,
+MUSC,2100,8.0,Music in the Western Worl,0.6,0.3,0.03,0.03,0.0,0%,0.0,0.03,rhea beth jacobus,
+MUSC,2100,11.0,Music in the Western Worl,0.84,0.03,0.06,0.0,0.0,0%,0.0,0.06,leslie taylor warlick,
+MUSC,2100,12.0,Music in the Western Worl,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,lea kibler,
+MUSC,2100,13.0,Music in the Western Worl,0.93,0.08,0.0,0.0,0.0,0%,0.0,0.0,david conley,
+MUSC,3120,1.0,History of Jazz,0.52,0.32,0.16,0.0,0.0,0%,0.0,0.0,richard goodstein,
+MUSC,3140,1.0,World Music,0.88,0.09,0.03,0.0,0.0,0%,0.0,0.0,paul buyer,
+MUSC,3180,1.0,Hist of Audio Tech,0.67,0.22,0.06,0.06,0.0,0%,0.0,0.0,bruce allen whisler,
+MUSC,3610,1.0,Marching Band,0.99,0.0,0.0,0.0,0.01,0%,0.0,0.01,mark spede,
+MUSC,3620,1.0,Symphonic Band,0.93,0.0,0.0,0.0,0.0,0%,0.0,0.02,mark spede,True
+MUSC,3690,1.0,Symphony Orchestra,0.93,0.0,0.0,0.0,0.02,0%,0.0,0.05,andrew levin,True
+MUSC,4150,1.0,Music Hist to 1750,0.86,0.07,0.07,0.0,0.0,0%,0.0,0.0,eric lapin,
+NPL,3000,1.0,Nonprofit Leadership,0.62,0.38,0.0,0.0,0.0,0%,0.0,0.0,christina mazer,
+NPL,3000,2.0,Nonprofit Leadership,0.33,0.33,0.14,0.0,0.05,0%,0.0,0.14,bonnie stevens,
+NPL,3000,3.0,Nonprofit Leadership,0.35,0.48,0.17,0.0,0.0,0%,0.0,0.0,bonnie stevens,
+NPL,3000,4.0,Nonprofit Leadership,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,corey brookover,
+NPL,3000,5.0,Nonprofit Leadership,0.7,0.22,0.09,0.0,0.0,0%,0.0,0.0,lauren george,
+NPL,3000,6.0,Nonprofit Leadership,0.61,0.3,0.09,0.0,0.0,0%,0.0,0.0,corey brookover,
+NPL,3000,7.0,Nonprofit Leadership,0.62,0.33,0.0,0.0,0.0,0%,0.0,0.05,lauren george,
+NPL,3000,8.0,Nonprofit Leadership,0.8,0.08,0.04,0.0,0.04,0%,0.0,0.04,lauren george,
+NPL,3000,9.0,Nonprofit Leadership,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,lauren george,
+NPL,3000,10.0,Nonprofit Leadership,0.64,0.27,0.09,0.0,0.0,0%,0.0,0.0,christina mazer,
+NPL,3000,11.0,Nonprofit Leadership,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,christina mazer,
+NPL,3000,12.0,Nonprofit Leadership,0.58,0.29,0.08,0.04,0.0,0%,0.0,0.0,corey brookover,
+NPL,3000,13.0,Nonprofit Leadership,0.74,0.22,0.0,0.0,0.0,0%,0.0,0.04,corey brookover,
+NPL,3010,1.0,NPL Stakeholders,0.46,0.5,0.04,0.0,0.0,0%,0.0,0.0,christina mazer,
+NPL,3020,1.0,NPL Fundraising,0.78,0.14,0.08,0.0,0.0,0%,0.0,0.0,joan laura phillips,
+NPL,3030,1.0,NPL Personnel,0.91,0.03,0.0,0.0,0.0,0%,0.0,0.03,joan laura phillips,
+NPL,3040,1.0,NPL Risk Management,0.58,0.35,0.06,0.0,0.0,0%,0.0,0.0,daniel anderson,
+NPL,3050,1.0,Strat Social Media for NP,0.85,0.09,0.05,0.0,0.0,0%,0.0,0.0,randi plake,
+NPL,3050,2.0,Strat Social Media for NP,0.8,0.07,0.07,0.02,0.04,0%,0.0,0.0,randi plake,
+NPL,4900,1.0,Non-Profit Lead Preceptor,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,corey brookover,
+NURS,3030,1.0,Nursing of Adults,0.24,0.71,0.05,0.0,0.0,0%,0.0,0.0,lena marie burgess,
+NURS,3040,101.0,Pathophysiology,0.43,0.43,0.1,0.03,0.02,0%,0.0,0.0,catherine murton,
+NURS,3040,201.0,Pathophysiology,0.52,0.38,0.06,0.03,0.01,0%,0.0,0.0,amy boggs garrison,
+NURS,3040,300.0,Pathophysiology,0.7,0.3,0.0,0.0,0.0,0%,0.0,0.0,amy boggs garrison,
+NURS,3040,401.0,Pathophysiology,0.64,0.32,0.05,0.0,0.0,0%,0.0,0.0,amy boggs garrison,
+NURS,3050,1.0,Psychosocial Nursing,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,kevin earle busby,
+NURS,3100,1.0,Health Assessment,0.68,0.3,0.0,0.0,0.03,0%,0.0,0.0,tiffany leah stewart,
+NURS,3100,402.0,Health Assessment,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,jason thrift,
+NURS,3120,101.0,Foundations of Nursing,0.61,0.36,0.03,0.0,0.0,0%,0.0,0.0,jennifer bagwell,
+NURS,3120,211.0,Foundations of Nursing,0.48,0.52,0.0,0.0,0.0,0%,0.0,0.0,terri teramano,
+NURS,3120,212.0,Foundations of Nursing,0.28,0.56,0.16,0.0,0.0,0%,0.0,0.0,terri teramano,
+NURS,3120,411.0,Foundations of Nursing,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,terri teramano,
+NURS,3190,300.0,Health Assessment for RNs,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,tiffany leah stewart,
+NURS,3230,201.0,Gerontology Nursing,0.95,0.05,0.0,0.0,0.0,0%,0.0,0.0,zahra rahemi,
+NURS,3300,1.0,Research in Nursing,0.9,0.05,0.03,0.0,0.03,0%,0.0,0.0,veronica parker,
+NURS,3330,1.0,Health Care Genetics,0.41,0.51,0.05,0.02,0.0,0%,0.0,0.0,linda ward,
+NURS,3400,101.0,Pharmther Nursing,0.4,0.43,0.12,0.03,0.02,0%,0.0,0.0,catherine murton,
+NURS,3400,201.0,Pharmther Nursing,0.56,0.33,0.09,0.02,0.0,0%,0.0,0.0,jenna lynn seawright,
+NURS,3400,401.0,Pharmther Nursing,0.77,0.23,0.0,0.0,0.0,0%,0.0,0.0,jenna lynn seawright,
+NURS,4010,1.0,Mental Health Nurs,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,lindsey garrard,
+NURS,4030,101.0,Complex Nursing of Adults,0.68,0.32,0.0,0.0,0.0,0%,0.0,0.0,taylor jean oneal,
+NURS,4030,201.0,Complex Nursing of Adults,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,taylor jean oneal,
+NURS,4060,300.0,Issues in Professionalism,0.6,0.4,0.0,0.0,0.0,0%,0.0,0.0,shirley mae timmons,
+NURS,4110,1.0,Nursing of Children,0.53,0.47,0.0,0.0,0.0,0%,0.0,0.0, elizabeth fisher,
+NURS,4120,1.0,Nurs Women and Fam,0.58,0.4,0.02,0.0,0.0,0%,0.0,0.0,erin nicole shepherd,
+NURS,4250,300.0,Community Nursing,0.62,0.31,0.0,0.0,0.08,0%,0.0,0.0,tiffany leah stewart,
+NURS,8040,401.0,Dev Nurs Knowledge,0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,kim ann pickett,
+NURS,8050,400.0,Pharmaco Adv Nurs,0.65,0.35,0.0,0.0,0.0,0%,0.0,0.0,tracy king fasolino,
+NURS,8050,401.0,Pharmaco Adv Nurs,0.67,0.25,0.0,0.0,0.08,0%,0.0,0.0,tracy king fasolino,
+NURS,8060,400.0,Advan Assessment for Nur,0.27,0.68,0.05,0.0,0.0,0%,0.0,0.0,jennifer geter rice,
+NURS,8090,400.0,Pathophysiology,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,tracy brock lowe,
+NURS,8180,400.0,Develop Family in Primary,0.33,0.5,0.0,0.0,0.0,0%,0.0,0.17,lisa miller,
+NURS,8190,400.0,Developing Family,0.38,0.56,0.0,0.0,0.0,0%,0.0,0.0,lisa miller,
+NURS,8200,400.0,Child & Adol Nursing,0.63,0.31,0.0,0.0,0.0,0%,0.0,0.0,heide temples,
+NURS,8220,401.0,Gerontology Nursing,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.0,nicole joy davis,
+NURS,8820,400.0,Primary Care Elders,0.75,0.0,0.0,0.0,0.0,0%,0.0,0.0,kimberly trammell,
+NUTR,2030,1.0,Intro Princ of Human Nutri,0.75,0.21,0.03,0.0,0.0,0%,0.0,0.01,bridgit corbett,
+NUTR,2030,2.0,Intro Princ of Human Nutri,0.47,0.42,0.07,0.0,0.0,0%,0.0,0.05,bridgit corbett,
+NUTR,2050,400.0,Nutrition for Nursing Prof,0.53,0.45,0.02,0.0,0.0,0%,0.0,0.0,bridgit corbett,
+NUTR,2160,1.0,Evidence-Based Nutrition,0.76,0.08,0.08,0.05,0.01,0%,0.0,0.01,angela fraser,
+NUTR,3020,1.0,Nutrition Assessment,0.8,0.18,0.0,0.0,0.0,0%,0.0,0.02,elliot jesch,
+NUTR,4240,1.0,Medical Nutr Thera I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,vivian haley-zitlin,
+NUTR,4510,1.0,Human Nutrition & Metab,0.2,0.3,0.3,0.05,0.13,0%,0.0,0.03,elliot jesch,
+PA,1010,1.0,Intro to Perf Arts,0.68,0.26,0.03,0.0,0.0,0%,0.0,0.03,david hartmann,
+PA,3010,1.0,Princip of Arts Administrati,0.38,0.46,0.08,0.08,0.0,0%,0.0,0.0,richard goodstein,
+PA,4010,1.0,Capstone Project,0.6,0.3,0.0,0.0,0.0,0%,0.0,0.0,bruce allen whisler,
+PADM,7020,400.0,Research Methods,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,ronald chrestman,
+PADM,7020,401.0,Research Methods,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0,ronald chrestman,
+PADM,8220,400.0,Public Policy Process,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,mellott yazykova,
+PADM,8290,400.0,Public Financial Managem,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.0,robert frager,
+PADM,8410,402.0,Public Data Analysis,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,scott schmidt,
+PADM,8420,400.0,GIS for Public Administrato,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,david white,
+PADM,8500,400.0,Homeland Security Funda,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,lori ann dickes,
+PADM,8520,401.0,Emergency Mgt Planning,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,kevin todd staley,
+PADM,8630,400.0,Contemporary Admin Orgs,0.73,0.27,0.0,0.0,0.0,0%,0.0,0.0,lori ann dickes,
+PADM,8640,400.0,Legal Aspects of Non-Profi,0.5,0.5,0.0,0.0,0.0,0%,0.0,0.0,margaret elise baker,
+PADM,8670,401.0,State Government Admin,0.77,0.15,0.0,0.0,0.0,0%,0.0,0.0,alfred bundrick,
+PAS,3010,2.0,Intro to Pan African Studie,0.62,0.18,0.12,0.03,0.0,0%,0.0,0.06, stewart-tillman,
+PDBE,8120,1.0,Seminar in EDP,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,mickey lauria,
+PDBE,8150,1.0,Research Design in EDP,0.63,0.0,0.38,0.0,0.0,0%,0.0,0.0,mickey lauria,
+PES,1040,1.0,Introduction to Plant Scien,0.78,0.16,0.03,0.0,0.0,0%,0.0,0.03,paula agudelo,
+PES,2020,1.0,Soils,0.57,0.31,0.1,0.02,0.0,0%,0.0,0.0,dara michelle park,
+PES,3150,1.0,Environment and Agricultu,0.62,0.33,0.05,0.0,0.0,0%,0.0,0.0,suseela appukuttan,
+PES,4090,1.0,Biology of Invasive Plants,0.87,0.13,0.0,0.0,0.0,0%,0.0,0.0, tharayil-,
+PES,4550,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, tharayil-,
+PES,4850,1.0,Environmental Soil Chemis,0.71,0.24,0.0,0.0,0.0,0%,0.0,0.06,haibo liu,
+PES,8250,1.0,Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0, tharayil-,
+PHIL,1010,1.0,Intro to Philosophic Proble,0.7,0.24,0.0,0.0,0.0,0%,0.0,0.06,david stegall,
+PHIL,1010,2.0,Intro to Philosophic Proble,0.54,0.34,0.06,0.0,0.0,0%,0.0,0.06,david stegall,
+PHIL,1010,3.0,Intro to Philosophic Proble,0.47,0.35,0.09,0.0,0.0,0%,0.0,0.09,david stegall,
+PHIL,1010,4.0,Intro to Philosophic Proble,0.65,0.24,0.06,0.0,0.06,0%,0.0,0.0,claire kirwin,
+PHIL,1010,5.0,Intro to Philosophic Proble,0.82,0.18,0.0,0.0,0.0,0%,0.0,0.0,claire kirwin,
+PHIL,1020,1.0,Introduction to Logic,0.49,0.29,0.14,0.03,0.03,0%,0.0,0.03,pascal brixel,
+PHIL,1020,2.0,Introduction to Logic,0.69,0.23,0.09,0.0,0.0,0%,0.0,0.0,adam gies,
+PHIL,1020,3.0,Introduction to Logic,0.58,0.27,0.15,0.0,0.0,0%,0.0,0.0,adam gies,
+PHIL,1020,4.0,Introduction to Logic,0.37,0.43,0.14,0.03,0.0,0%,0.0,0.03,adam gies,
+PHIL,1020,5.0,Introduction to Logic,0.41,0.47,0.09,0.0,0.0,0%,0.0,0.03,edyta joanna kuzian,
+PHIL,1020,6.0,Introduction to Logic,0.46,0.4,0.11,0.03,0.0,0%,0.0,0.0,edyta joanna kuzian,
+PHIL,1020,7.0,Introduction to Logic,0.63,0.26,0.0,0.0,0.05,0%,0.0,0.05,pascal brixel,
+PHIL,1020,8.0,Introduction to Logic,0.36,0.47,0.11,0.0,0.03,0%,0.0,0.03,edyta joanna kuzian,
+PHIL,1020,9.0,Introduction to Logic,0.31,0.37,0.23,0.09,0.0,0%,0.0,0.0,adam gies,
+PHIL,1030,1.0,Introduction to Ethics,0.57,0.37,0.03,0.0,0.0,0%,0.0,0.03,daniel wueste,
+PHIL,1030,2.0,Introduction to Ethics,0.39,0.42,0.16,0.03,0.0,0%,0.0,0.0,charles starkey,
+PHIL,1030,3.0,Introduction to Ethics,0.81,0.1,0.0,0.0,0.05,0%,0.0,0.05,david stegall,
+PHIL,1030,4.0,Introduction to Ethics,0.57,0.23,0.17,0.03,0.0,0%,0.0,0.0,edyta joanna kuzian,
+PHIL,1030,5.0,Introduction to Ethics,0.47,0.39,0.0,0.03,0.06,0%,0.0,0.06,david antonini,
+PHIL,3040,1.0,Moral Philosophy,0.44,0.47,0.06,0.0,0.0,0%,0.0,0.03,todd may,
+PHIL,3150,2.0,Ancient Philosophy,0.66,0.2,0.06,0.03,0.03,0%,0.0,0.03,stephen satris,
+PHIL,3210,1.0,Crime & Punishment,0.53,0.41,0.06,0.0,0.0,0%,0.0,0.0,daniel wueste,
+PHIL,3260,1.0,Science and Values,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,david antonini,
+PHIL,3260,2.0,Science and Values,0.61,0.33,0.0,0.03,0.0,0%,0.0,0.03,david antonini,
+PHIL,3260,3.0,Science and Values,0.73,0.22,0.0,0.0,0.03,0%,0.0,0.03,kelly smith,
+PHIL,3300,1.0,Contemporary Issues in Ph,0.41,0.47,0.0,0.0,0.0,0%,0.0,0.06,todd may,
+PHIL,3330,1.0,Metaphysics,0.68,0.16,0.05,0.05,0.0,0%,0.0,0.05,adam gies,
+PHIL,3430,1.0,Philosophy of Law,0.35,0.47,0.18,0.0,0.0,0%,0.0,0.0,brookes brown,
+PHIL,3440,1.0,Business Ethics,0.18,0.58,0.15,0.0,0.0,0%,0.0,0.09,brookes brown,
+PHIL,3460,1.0,Biomedical Ethics,0.41,0.47,0.12,0.0,0.0,0%,0.0,0.0,charles starkey,
+PHIL,3480,1.0,Philosophies of Art,0.38,0.5,0.13,0.0,0.0,0%,0.0,0.0,edyta joanna kuzian,
+PHSC,1180,1.0,"Intro Phys, Astron & Earth",0.76,0.16,0.03,0.03,0.02,0%,0.0,0.0,minory nammouz,
+PHSC,1180,2.0,"Intro Phys, Astron & Earth",0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,minory nammouz,
+PHYS,1220,1.0,Physics with Calculus I,0.25,0.29,0.29,0.09,0.02,0%,0.0,0.07,lih-sin the,
+PHYS,1220,2.0,Physics with Calculus I,0.17,0.34,0.3,0.07,0.06,0%,0.0,0.05,lih-sin the,
+PHYS,1220,4.0,Physics with Calculus I,0.26,0.47,0.16,0.0,0.05,0%,0.0,0.05,hugo sanabria,
+PHYS,1220,5.0,Physics with Calculus I (HO,0.56,0.39,0.0,0.0,0.0,0%,0.0,0.06,emil georgiev alexov,True
+PHYS,1240,1.0,Physics Lab I,0.82,0.12,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,1240,2.0,Physics Lab I,0.67,0.11,0.17,0.0,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,1240,3.0,Physics Lab I,0.5,0.25,0.13,0.06,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,1240,4.0,Physics Lab I,0.53,0.24,0.0,0.12,0.06,0%,0.0,0.06,daniel thompson,
+PHYS,1240,6.0,Physics Lab I,0.67,0.22,0.11,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,1240,7.0,Physics Lab I,0.72,0.17,0.0,0.0,0.06,0%,0.0,0.06,daniel thompson,
+PHYS,1240,8.0,Physics Lab I,0.83,0.06,0.06,0.0,0.06,0%,0.0,0.0,daniel thompson,
+PHYS,1240,9.0,Physics Lab I,0.86,0.0,0.0,0.0,0.0,0%,0.0,0.14,daniel thompson,
+PHYS,1240,10.0,Physics Lab I,0.64,0.21,0.07,0.0,0.0,0%,0.0,0.07,daniel thompson,
+PHYS,1240,11.0,Physics Lab I,0.67,0.06,0.06,0.0,0.11,0%,0.0,0.11,daniel thompson,
+PHYS,1240,12.0,Physics Lab I,0.7,0.2,0.1,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,1240,13.0,Physics Lab I,0.82,0.0,0.12,0.06,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,1240,14.0,Physics Lab I,0.72,0.11,0.0,0.11,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,1240,15.0,Physics Lab I,0.67,0.22,0.0,0.06,0.06,0%,0.0,0.0,daniel thompson,
+PHYS,1240,16.0,Physics Lab I,0.67,0.22,0.0,0.11,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,1240,17.0,Physics Lab I,0.78,0.06,0.06,0.06,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,1240,18.0,Physics Lab I,0.76,0.18,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,1240,19.0,Physics Lab I,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,1240,21.0,Physics Lab I,0.71,0.21,0.0,0.0,0.07,0%,0.0,0.0,daniel thompson,
+PHYS,1240,22.0,Physics Lab I,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,2070,1.0,General Physics I,0.32,0.29,0.18,0.06,0.08,0%,0.0,0.06,amy liann pope,
+PHYS,2070,2.0,General Physics I,0.42,0.32,0.13,0.04,0.03,0%,0.0,0.05,amy liann pope,
+PHYS,2070,3.0,General Physics I,0.46,0.29,0.15,0.05,0.02,0%,0.0,0.04,amy liann pope,
+PHYS,2080,1.0,General Physics II,0.35,0.41,0.13,0.03,0.05,0%,0.0,0.02,pooja puneet,
+PHYS,2090,1.0,Gen Phys Lab I,0.5,0.25,0.04,0.08,0.04,0%,0.0,0.08,daniel thompson,
+PHYS,2090,2.0,Gen Phys Lab I,0.57,0.35,0.09,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2090,3.0,Gen Phys Lab I,0.54,0.29,0.04,0.0,0.08,0%,0.0,0.04,daniel thompson,
+PHYS,2090,4.0,Gen Phys Lab I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2090,5.0,Gen Phys Lab I,0.63,0.21,0.13,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2090,6.0,Gen Phys Lab I,0.65,0.1,0.1,0.05,0.0,0%,0.0,0.1,daniel thompson,
+PHYS,2090,7.0,Gen Phys Lab I,0.74,0.26,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2090,8.0,Gen Phys Lab I,0.67,0.21,0.08,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2090,9.0,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2090,10.0,Gen Phys Lab I,0.7,0.22,0.0,0.0,0.04,0%,0.0,0.04,daniel thompson,
+PHYS,2090,11.0,Gen Phys Lab I,0.71,0.08,0.13,0.0,0.04,0%,0.0,0.04,daniel thompson,
+PHYS,2090,12.0,Gen Phys Lab I,0.91,0.04,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2090,13.0,Gen Phys Lab I,0.88,0.08,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2090,14.0,Gen Phys Lab I,0.75,0.17,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2090,15.0,Gen Phys Lab I,0.54,0.25,0.13,0.0,0.0,0%,0.0,0.08,daniel thompson,
+PHYS,2090,16.0,Gen Phys Lab I,0.79,0.13,0.0,0.0,0.0,0%,0.0,0.08,daniel thompson,
+PHYS,2090,17.0,Gen Phys Lab I,0.83,0.09,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2090,18.0,Gen Phys Lab I,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2090,19.0,Gen Phys Lab I,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2090,20.0,Gen Phys Lab I,0.43,0.48,0.0,0.0,0.05,0%,0.0,0.05,daniel thompson,
+PHYS,2090,21.0,Gen Phys Lab I,0.72,0.22,0.0,0.0,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,2090,22.0,Gen Phys Lab I,0.96,0.04,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2090,23.0,Gen Phys Lab I,0.75,0.17,0.0,0.0,0.0,0%,0.0,0.08,daniel thompson,
+PHYS,2090,24.0,Gen Phys Lab I,0.58,0.21,0.11,0.0,0.0,0%,0.0,0.11,daniel thompson,
+PHYS,2090,25.0,Gen Phys Lab I,0.82,0.14,0.0,0.0,0.0,0%,0.0,0.05,daniel thompson,
+PHYS,2090,26.0,Gen Phys Lab I,0.36,0.36,0.14,0.05,0.0,0%,0.0,0.09,daniel thompson,
+PHYS,2090,27.0,Gen Phys Lab I,0.75,0.08,0.04,0.04,0.04,0%,0.0,0.04,daniel thompson,
+PHYS,2100,1.0,Gen Phys Lab II,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2100,2.0,Gen Phys Lab II,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2100,3.0,Gen Phys Lab II,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2100,4.0,Gen Phys Lab II,0.91,0.0,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2100,6.0,Gen Phys Lab II,0.92,0.04,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2100,7.0,Gen Phys Lab II,0.88,0.04,0.04,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2100,8.0,Gen Phys Lab II,0.79,0.17,0.04,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2100,9.0,Gen Phys Lab II,0.96,0.0,0.0,0.0,0.0,0%,0.0,0.04,daniel thompson,
+PHYS,2210,1.0,Physics with Calculus II,0.24,0.37,0.27,0.04,0.02,0%,0.0,0.05,jason brown,
+PHYS,2210,2.0,Physics with Calculus II,0.46,0.37,0.11,0.04,0.01,0%,0.0,0.02,pooja puneet,
+PHYS,2210,3.0,Physics with Calculus II,0.28,0.39,0.19,0.07,0.04,0%,0.0,0.03,pooja puneet,
+PHYS,2210,4.0,Physics with Calculus II,0.26,0.43,0.19,0.07,0.03,0%,0.0,0.01,jason brown,
+PHYS,2210,5.0,Physics w/Calculus II(HON),0.93,0.07,0.0,0.0,0.0,0%,0.0,0.0,endre andras takacs,True
+PHYS,2220,1.0,Physics with Calculus III,0.78,0.13,0.04,0.0,0.0,0%,0.0,0.04,murray daw,
+PHYS,2230,1.0,Physics Lab II,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,2.0,Physics Lab II,0.22,0.61,0.11,0.0,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,2230,3.0,Physics Lab II,0.39,0.5,0.06,0.06,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,4.0,Physics Lab II,0.44,0.44,0.11,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,5.0,Physics Lab II,0.74,0.26,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,6.0,Physics Lab II,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,7.0,Physics Lab II,0.69,0.31,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,9.0,Physics Lab II,0.72,0.28,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,10.0,Physics Lab II,0.89,0.06,0.06,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,11.0,Physics Lab II,0.2,0.67,0.07,0.0,0.0,0%,0.0,0.07,daniel thompson,
+PHYS,2230,12.0,Physics Lab II,0.72,0.22,0.0,0.0,0.06,0%,0.0,0.0,daniel thompson,
+PHYS,2230,13.0,Physics Lab II,0.67,0.17,0.11,0.0,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,2230,14.0,Physics Lab II,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,daniel thompson,
+PHYS,2230,15.0,Physics Lab II,0.22,0.67,0.0,0.0,0.0,0%,0.0,0.11,daniel thompson,
+PHYS,2240,1.0,Physics Lab III,0.75,0.13,0.06,0.0,0.0,0%,0.0,0.06,daniel thompson,
+PHYS,2450,1.0,Physics of Climate,0.62,0.23,0.06,0.01,0.02,0%,0.0,0.06,jens oberheide,
+PHYS,3000,1.0,Intro to Research,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,jianbo gao,
+PHYS,3120,1.0,Meth Theor Phys II,0.64,0.18,0.09,0.09,0.0,0%,0.0,0.0,lih-sin the,
+PHYS,3150,1.0,Intro to Computational Ph,0.46,0.27,0.19,0.0,0.0,0%,0.0,0.08,jason brown,
+PHYS,3210,1.0,Mechanics I,0.48,0.35,0.06,0.0,0.03,0%,0.0,0.06,feng ding,
+PHYS,3250,1.0,Electronics for Physicists,0.74,0.21,0.05,0.0,0.0,0%,0.0,0.0,chad sosolik,
+PHYS,4410,1.0,Electromagnetics I,0.47,0.29,0.12,0.0,0.06,0%,0.0,0.06,ramakrishna podila,
+PHYS,4550,1.0,Quantum Physics I,0.48,0.24,0.19,0.05,0.0,0%,0.0,0.05,gerald lehmacher,
+PHYS,8110,1.0,Meth of Theor Phys I,0.23,0.77,0.0,0.0,0.0,0%,0.0,0.0,domnita marinescu,
+PHYS,8180,1.0,Cellular Biophysics,0.43,0.43,0.14,0.0,0.0,0%,0.0,0.0,joshua alper,
+PHYS,8210,1.0,Classical Mech I,0.18,0.82,0.0,0.0,0.0,0%,0.0,0.0,stephen kaeppler,
+PHYS,8750,2.0,Intro to Research Seminar,0.89,0.11,0.0,0.0,0.0,0%,0.0,0.0,jianbo gao,
+PHYS,8750,13.0,Numerical Fluid Dynamics,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,xian lu,
+PHYS,9510,1.0,Quantum Mech I,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,sumanta tewari,
+PHYS,9530,1.0,Quantum Field Theory,0.44,0.56,0.0,0.0,0.0,0%,0.0,0.0,bradley meyer,
+PHYS,9910,12.0,Doctoral Dissertation Rese,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,marco ajello,
+PKSC,1010,1.0,Pkgsc Orientation,0.82,0.12,0.04,0.02,0.0,0%,0.0,0.0,marcondes guerra,
+PKSC,1020,1.0,Intro to Pkg Sci,0.24,0.24,0.28,0.13,0.08,0%,0.0,0.04,heather batt,
+PKSC,2010,1.0,Pkg Perishable Prod,0.08,0.35,0.32,0.11,0.05,0%,0.0,0.08,heather batt,
+PKSC,2020,1.0,Packaging Mtl & Mfg,0.3,0.3,0.38,0.02,0.0,0%,0.0,0.0,marcondes guerra,
+PKSC,2040,1.0,Container Systems,0.2,0.6,0.13,0.07,0.0,0%,0.0,0.0,marcondes guerra,
+PKSC,2060,1.0,Container Sys Lab,0.57,0.36,0.07,0.0,0.0,0%,0.0,0.0,marcondes guerra,
+PKSC,2200,1.0,Product & Pkg Design,0.76,0.2,0.05,0.0,0.0,0%,0.0,0.0,haley ellis appleby,
+PKSC,3200,1.0,Pkg Design Theory,0.79,0.11,0.0,0.0,0.0,0%,0.0,0.11,rupert hurley,
+PKSC,4010,1.0,Packaging Machinery,0.09,0.6,0.26,0.0,0.04,0%,0.0,0.02,anthony pometto,
+PKSC,4040,1.0,Protective Packaging Prop,0.22,0.35,0.25,0.07,0.05,0%,0.0,0.05,gregory batt,
+PKSC,4160,1.0,Application of Polymers in,0.3,0.52,0.13,0.0,0.0,0%,0.0,0.05,alicia campbell,
+PKSC,4200,1.0,Package Design & Develop,0.67,0.33,0.0,0.0,0.0,0%,0.0,0.0,robert kimmel,
+PKSC,4540,1.0,Product & Pkg Evaluation L,0.44,0.56,0.0,0.0,0.0,0%,0.0,0.0,gregory batt,
+PKSC,4540,3.0,Product & Pkg Evaluation L,0.19,0.5,0.19,0.06,0.0,0%,0.0,0.06,gregory batt,
+PKSC,4540,5.0,Product & Pkg Evaluation L,0.07,0.64,0.07,0.0,0.07,0%,0.0,0.14,gregory batt,
+PKSC,4640,1.0,Food & Health Care Pkg Sy,0.73,0.19,0.06,0.0,0.02,0%,0.0,0.0,kay cooksey,
+PLPA,3100,1.0,Principles of Plant Patholo,0.31,0.31,0.24,0.07,0.07,0%,0.0,0.0,steven nye jeffers,
+PLPA,8020,1.0,Principles of Plant Patholo,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,steven nye jeffers,
+POSC,1010,1.0,Amer National Govt,0.11,0.58,0.16,0.11,0.05,0%,0.0,0.0,robert carey,
+POSC,1010,2.0,Amer National Govt,0.35,0.43,0.18,0.0,0.02,0%,0.0,0.02,robert carey,
+POSC,1010,3.0,Amer National Govt,0.6,0.36,0.0,0.0,0.0,0%,0.0,0.04,joseph earl stewart,
+POSC,1010,4.0,Amer National Govt,0.46,0.36,0.12,0.0,0.02,0%,0.0,0.04,robert carey,
+POSC,1020,1.0,Intro Intl Relations,0.77,0.15,0.05,0.02,0.02,0%,0.0,0.0,steven vincent miller,
+POSC,1020,2.0,Intro Intl Relations,0.42,0.39,0.11,0.03,0.03,0%,0.0,0.03, petersheim,
+POSC,1020,3.0,Intro Intl Relations,0.36,0.45,0.07,0.0,0.07,0%,0.0,0.05,tara elizabeth trask,
+POSC,1020,4.0,Intro Intl Relations,0.55,0.41,0.0,0.0,0.04,0%,0.0,0.0,colin denby pearce,
+POSC,1020,5.0,Intro Intl Relations,0.35,0.4,0.09,0.01,0.09,0%,0.0,0.06,tara elizabeth trask,
+POSC,1030,1.0,Intro to Political Theory,0.66,0.21,0.03,0.03,0.03,0%,0.0,0.03,adam thomas,
+POSC,1030,2.0,Intro to Political Theory,0.33,0.61,0.0,0.0,0.06,0%,0.0,0.0,colin denby pearce,
+POSC,1030,3.0,Intro to Political Theory,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,derek neal duplessie,
+POSC,1030,4.0,Intro to Political Theory,0.48,0.28,0.17,0.0,0.07,0%,0.0,0.0,brandon turner,
+POSC,1030,5.0,Intro to Political Theory,0.71,0.17,0.08,0.0,0.0,0%,0.0,0.04,jay hoffpauir,
+POSC,1030,8.0,Intro to Political Theory,0.27,0.5,0.1,0.07,0.03,0%,0.0,0.03,elizabeth 'arrivee,
+POSC,1040,1.0,Intro Compar Pol,0.17,0.34,0.19,0.05,0.17,0%,0.0,0.07,katherine curtis,
+POSC,1040,2.0,Intro Compar Pol,0.47,0.29,0.06,0.04,0.04,0%,0.0,0.1, rhodes-purdy,
+POSC,1990,1.0,Intro Pol Sci,0.52,0.36,0.1,0.0,0.02,0%,0.0,0.0, petersheim,
+POSC,3020,1.0,State and Loc Gov,0.3,0.58,0.0,0.0,0.02,0%,0.0,0.06,bruce ransom,
+POSC,3410,1.0,Quant Meth in Pol Sc,0.23,0.27,0.23,0.0,0.18,0%,0.0,0.05,steven vincent miller,
+POSC,3610,1.0,International Conflict,0.4,0.23,0.13,0.06,0.06,0%,0.0,0.11,tara elizabeth trask,
+POSC,3620,1.0,Intl Organizations,0.31,0.31,0.17,0.1,0.03,0%,0.0,0.07,zeynep taydas,
+POSC,3620,2.0,Intl Organizations,0.37,0.33,0.07,0.15,0.07,0%,0.0,0.0,zeynep taydas,
+POSC,3630,1.0,Us Foreign Policy,0.68,0.24,0.0,0.0,0.08,0%,0.0,0.0,vladimir matic,
+POSC,3630,2.0,Us Foreign Policy,0.18,0.52,0.12,0.0,0.12,0%,0.0,0.06,jeffrey scott peake,
+POSC,3750,1.0,European Integration,0.21,0.32,0.16,0.11,0.13,0%,0.0,0.08,katherine curtis,
+POSC,4050,1.0,The American Presidency,0.31,0.42,0.06,0.02,0.06,0%,0.0,0.13,adam warber,
+POSC,4090,2.0,Dir Stud in American Politi,0.79,0.0,0.05,0.0,0.0,0%,0.0,0.05,karyn jones,
+POSC,4210,1.0,Public Policy,0.58,0.15,0.04,0.04,0.12,0%,0.0,0.04,grant anthony allard,
+POSC,4230,1.0,Urban Politics,0.53,0.27,0.0,0.0,0.13,0%,0.0,0.0,bruce ransom,
+POSC,4360,1.0,Law Courts Politics,0.77,0.18,0.0,0.0,0.0,0%,0.0,0.0,joseph earl stewart,
+POSC,4360,2.0,Law Courts Politics,0.89,0.07,0.0,0.0,0.0,0%,0.0,0.02,joseph earl stewart,
+POSC,4370,1.0,Constitut Law: Rights & Lib,0.5,0.27,0.14,0.02,0.05,0%,0.0,0.02,kevin gregory vance,
+POSC,4370,2.0,Constitut Law: Rights & Lib,0.66,0.3,0.02,0.0,0.0,0%,0.0,0.02,kevin gregory vance,
+POSC,4420,1.0,Pol Parties & Elect,0.43,0.32,0.19,0.05,0.0,0%,0.0,0.0,laura olson,
+POSC,4490,1.0,Political Theory of Capitalis,0.38,0.52,0.05,0.0,0.05,0%,0.0,0.0,colin denby pearce,
+POSC,4490,2.0,Political Theory of Capitalis,0.62,0.3,0.05,0.0,0.03,0%,0.0,0.0,brandon turner,
+POSC,4500,1.0,Rev. Constitutionalism,0.75,0.08,0.08,0.0,0.08,0%,0.0,0.0, bradley thompson,
+POSC,4550,1.0,Pol Thght of American Fou,0.73,0.22,0.04,0.02,0.0,0%,0.0,0.0,jay hoffpauir,
+POSC,4760,1.0,Middle East Politics,0.84,0.11,0.0,0.0,0.0,0%,0.0,0.05,vladimir matic,
+POSC,4770,1.0,Chinese Politics,0.53,0.27,0.0,0.0,0.0,0%,0.0,0.07,xiaobo hu,
+POSC,4890,1.0,Populism,0.69,0.15,0.0,0.0,0.0,0%,0.0,0.15, rhodes-purdy,
+POST,9000,1.0,Prof Development Public P,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,laura olson,
+PRTM,1980,1.0,Creative Inquiry in PRTM I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,denise anderson,
+PRTM,2000,1.0,Profession & Practice in PR,0.86,0.09,0.05,0.0,0.0,0%,0.0,0.0,teresa tucker,
+PRTM,2000,2.0,Profession & Practice in PR,0.79,0.16,0.05,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,
+PRTM,2000,3.0,Profession & Practice in PR,0.68,0.26,0.05,0.0,0.0,0%,0.0,0.0,herbert chancellor,
+PRTM,2000,4.0,Profession & Practice in PR,0.68,0.11,0.0,0.05,0.16,0%,0.0,0.0,jeffrey townsend,
+PRTM,2000,5.0,Profession & Practice in PR,0.74,0.16,0.0,0.11,0.0,0%,0.0,0.0,thomas ray clanton,
+PRTM,2060,1.0,Practicum I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,
+PRTM,2070,1.0,Practicum II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,
+PRTM,2070,2.0,Practicum II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,adam savedra,
+PRTM,2110,1.0,Sts Play Rec Tourism,0.84,0.09,0.02,0.0,0.04,0%,0.0,0.01,matthew browning,
+PRTM,2200,1.0,Foundations of PRTM,0.82,0.14,0.05,0.0,0.0,0%,0.0,0.0,teresa tucker,
+PRTM,2200,2.0,Foundations of PRTM,0.53,0.42,0.05,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,
+PRTM,2200,3.0,Foundations of PRTM,0.63,0.32,0.0,0.05,0.0,0%,0.0,0.0,herbert chancellor,
+PRTM,2200,4.0,Foundations of PRTM,0.37,0.42,0.11,0.05,0.05,0%,0.0,0.0,jeffrey townsend,
+PRTM,2200,5.0,Foundations of PRTM,0.65,0.29,0.06,0.0,0.0,0%,0.0,0.0,thomas ray clanton,
+PRTM,2260,1.0,Fnd of Mgt Adm PRTM,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,teresa tucker,
+PRTM,2260,2.0,Fnd of Mgt Adm PRTM,0.79,0.21,0.0,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,
+PRTM,2260,3.0,Fnd of Mgt Adm PRTM,0.68,0.21,0.11,0.0,0.0,0%,0.0,0.0,herbert chancellor,
+PRTM,2260,4.0,Fnd of Mgt Adm PRTM,0.58,0.32,0.0,0.05,0.05,0%,0.0,0.0,jeffrey townsend,
+PRTM,2260,5.0,Fnd of Mgt Adm PRTM,0.74,0.21,0.05,0.0,0.0,0%,0.0,0.0,thomas ray clanton,
+PRTM,2290,1.0,Competency Integration in,0.68,0.23,0.09,0.0,0.0,0%,0.0,0.0,teresa tucker,
+PRTM,2290,2.0,Competency Integration in,0.63,0.26,0.11,0.0,0.0,0%,0.0,0.0,elizabeth baldwin,
+PRTM,2290,3.0,Competency Integration in,0.63,0.11,0.16,0.11,0.0,0%,0.0,0.0,herbert chancellor,
+PRTM,2290,4.0,Competency Integration in,0.42,0.37,0.11,0.0,0.11,0%,0.0,0.0,jeffrey townsend,
+PRTM,2290,5.0,Competency Integration in,0.58,0.26,0.05,0.11,0.0,0%,0.0,0.0,thomas ray clanton,
+PRTM,3050,1.0,Safety/Risk Mgt PRTM,0.47,0.27,0.2,0.0,0.0,0%,0.0,0.07,alexsandra dubin,
+PRTM,3070,2.0,Facility Operations,0.77,0.13,0.1,0.0,0.0,0%,0.0,0.0,raymond dunham,
+PRTM,3200,1.0,Recreation Policy,0.55,0.18,0.09,0.0,0.05,0%,0.0,0.14,matthew brownlee,
+PRTM,3220,1.0,Facilitation Techniques in,0.71,0.19,0.1,0.0,0.0,0%,0.0,0.0,stephen lewis,
+PRTM,3240,1.0,Assessment & Planning in,0.48,0.38,0.1,0.05,0.0,0%,0.0,0.0,deborah anne tysor,
+PRTM,3300,1.0,Visit Ser & Interp,0.42,0.26,0.21,0.05,0.05,0%,0.0,0.0,harper aby lat sene lat,
+PRTM,3420,1.0,Intro to Tourism,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,ellen wamilika koppa,
+PRTM,3430,1.0,Spl Asp of Tourist B,0.62,0.33,0.0,0.0,0.0,0%,0.0,0.05,william norman,
+PRTM,3460,1.0,Heritage Tourism,0.4,0.33,0.13,0.0,0.07,0%,0.0,0.0,gregory ramshaw,
+PRTM,3470,1.0,Sport Tourism,0.84,0.16,0.0,0.0,0.0,0%,0.0,0.0,felipe tobar,
+PRTM,3520,1.0,Camp Org and Admin,0.89,0.0,0.0,0.0,0.0,0%,0.0,0.11,alexsandra dubin,
+PRTM,3600,1.0,Recreation & Amateur Spo,0.36,0.18,0.18,0.0,0.09,0%,0.0,0.09,skye arthur-banning,
+PRTM,3920,1.0,Special Event Managemen,0.96,0.0,0.04,0.0,0.0,0%,0.0,0.0,kenneth backman,
+PRTM,3920,2.0,Special Event Managemen,0.83,0.1,0.05,0.03,0.0,0%,0.0,0.0,kenneth backman,
+PRTM,4030,1.0,Elem of Rec/Pk Plan,0.79,0.14,0.07,0.0,0.0,0%,0.0,0.0,samuel gaines,
+PRTM,4040,1.0,Field Training I,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,
+PRTM,4050,1.0,Field Training II,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,daniel anderson,
+PRTM,4210,1.0,Rec Fin Resc Mgt,0.68,0.21,0.09,0.02,0.0,0%,0.0,0.0,robert brookover,
+PRTM,4220,2.0,Management of RT Service,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,deborah anne tysor,
+PRTM,4230,1.0,Adaptive Sports & Recreati,0.56,0.17,0.11,0.11,0.06,0%,0.0,0.0,jasmine townsend,
+PRTM,4450,1.0,Conventions,0.79,0.14,0.0,0.0,0.0,0%,0.0,0.07,lauren townson,
+PRTM,4470,1.0,Perspect Intl Travel,0.89,0.0,0.05,0.0,0.0,0%,0.0,0.05,sheila backman,
+PRTM,4510,1.0,Seminar in CRSCM,0.5,0.3,0.1,0.05,0.03,0%,0.0,0.03,iryna sharaievska,
+PRTM,4540,1.0,Trends in Sport Mgt,0.75,0.13,0.06,0.0,0.0,0%,0.0,0.06,skye arthur-banning,
+PRTM,4550,1.0,Adv Program Planning,0.78,0.22,0.0,0.0,0.0,0%,0.0,0.0,mariela fernandez,
+PRTM,4740,2.0,Adv Rec Resource Mgt,0.81,0.05,0.14,0.0,0.0,0%,0.0,0.0,benjamin fowler,
+PRTM,8070,3.0,Human Dimen of Rec Beha,0.82,0.09,0.0,0.0,0.0,0%,0.0,0.09,john adam beeco,
+PRTM,8080,2.0,Behavioral Aspects,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,lauren duffy,
+PRTM,8710,1.0,Applied Research in Rec Th,0.4,0.6,0.0,0.0,0.0,0%,0.0,0.0,brandi crowe,
+PRTM,8720,1.0,Adv Facilitation Techniq in,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,brandi crowe,
+PRTM,8750,1.0,Program Plan & Consult in,0.64,0.27,0.0,0.0,0.0,0%,0.0,0.0,stephen lewis,
+PRTM,9000,11.0,Adv Data Analysis in PRTM,0.5,0.38,0.0,0.0,0.0,0%,0.0,0.13,ryan joseph gagnon,
+PRTM,9100,1.0,Research Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,brett wright,
+PRTM,9110,2.0,Classroom Management,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,gwynn powell,
+PSYC,2010,1.0,Intro to Psychology,0.33,0.34,0.19,0.03,0.01,0%,0.0,0.06,jo jorgensen,
+PSYC,2010,2.0,Intro to Psychology,0.28,0.33,0.21,0.08,0.03,0%,0.0,0.03,jo jorgensen,
+PSYC,2010,3.0,Intro to Psychology,0.25,0.33,0.22,0.06,0.06,0%,0.0,0.08,edwin brainerd,
+PSYC,2010,4.0,Intro to Psychology,0.77,0.19,0.04,0.0,0.0,0%,0.0,0.0,mary taylor,
+PSYC,2010,5.0,Intro to Psychology,0.63,0.27,0.03,0.01,0.04,0%,0.0,0.02,chong hyon pak,
+PSYC,2010,6.0,Intro to Psychology,0.66,0.19,0.08,0.05,0.02,0%,0.0,0.0,chong hyon pak,
+PSYC,2010,7.0,Intro to Psychology,0.51,0.33,0.09,0.03,0.01,0%,0.0,0.03,fred switzer,
+PSYC,2030,1.0,Fundamentals of Psych Sci,0.62,0.25,0.07,0.03,0.02,0%,0.0,0.02,fred switzer,
+PSYC,3060,1.0,Human Sexual Behavior,0.58,0.22,0.11,0.03,0.03,0%,0.0,0.03,bruce michael king,
+PSYC,3090,100.0,Intro Experimental Psychol,0.44,0.38,0.13,0.02,0.01,0%,0.0,0.03,jennifer bailey bisson,
+PSYC,3090,200.0,Intro Experimental Psychol,0.16,0.53,0.28,0.0,0.0,0%,0.0,0.03,eric mckibben,
+PSYC,3090,300.0,Intro Experimental Psychol,0.48,0.39,0.1,0.0,0.0,0%,0.0,0.03,alexander moore,
+PSYC,3100,100.0,Advanced Experimental Ps,0.71,0.21,0.03,0.03,0.03,0%,0.0,0.0,peggy jean tyler,
+PSYC,3100,220.0,Advanced Experimental Ps,0.63,0.32,0.05,0.0,0.0,0%,0.0,0.0,thomas britt,
+PSYC,3100,230.0,Advanced Experimental Ps,0.68,0.26,0.05,0.0,0.0,0%,0.0,0.0,william volante,
+PSYC,3100,240.0,Advanced Experimental Ps,0.42,0.37,0.16,0.0,0.05,0%,0.0,0.0,william volante,
+PSYC,3100,250.0,Advanced Experimental Ps,0.57,0.33,0.05,0.0,0.0,0%,0.0,0.05,sarah mae sanborn,
+PSYC,3100,260.0,Advanced Experimental Ps,0.37,0.53,0.05,0.0,0.0,0%,0.0,0.0,leo gugerty,
+PSYC,3100,270.0,Advanced Experimental Ps,0.56,0.44,0.0,0.0,0.0,0%,0.0,0.0,benjamin stephens,
+PSYC,3100,280.0,Advanced Experimental Ps,0.74,0.16,0.11,0.0,0.0,0%,0.0,0.0,martha thompson,
+PSYC,3100,290.0,Advanced Experimental Ps,0.42,0.42,0.0,0.11,0.0,0%,0.0,0.0,kaileigh angela byrne,
+PSYC,3210,1.0,Psychology of Music,0.52,0.2,0.24,0.04,0.0,0%,0.0,0.0,claudio cantalupo,
+PSYC,3240,1.0,Physiological Psych,0.64,0.19,0.09,0.03,0.04,0%,0.0,0.01,claudio cantalupo,
+PSYC,3240,2.0,Physiological Psych,0.5,0.31,0.09,0.04,0.04,0%,0.0,0.01,claudio cantalupo,
+PSYC,3240,3.0,Physiological Psych,0.53,0.31,0.1,0.03,0.02,0%,0.0,0.0,claudio cantalupo,
+PSYC,3240,4.0,Physiological Psych,0.43,0.38,0.1,0.01,0.01,0%,0.0,0.06,june pilcher,
+PSYC,3330,1.0,Cognitive Psych,0.55,0.32,0.06,0.04,0.03,0%,0.0,0.0,dawn marie sarno,
+PSYC,3330,2.0,Cognitive Psych,0.63,0.23,0.08,0.03,0.03,0%,0.0,0.0,kathryn lucaites,
+PSYC,3340,1.0,Cognitive Psych Lab,0.83,0.08,0.08,0.0,0.0,0%,0.0,0.0,hannah solini,
+PSYC,3340,2.0,Cognitive Psych Lab,0.76,0.19,0.0,0.0,0.0,0%,0.0,0.0,hannah solini,
+PSYC,3400,1.0,Lifespan Developmental Ps,0.38,0.39,0.16,0.01,0.03,0%,0.0,0.03,pamela alley,
+PSYC,3400,2.0,Lifespan Developmental Ps,0.33,0.43,0.11,0.09,0.02,0%,0.0,0.02,pamela alley,
+PSYC,3400,3.0,Lifespan Developmental Ps,0.73,0.17,0.08,0.01,0.0,0%,0.0,0.01,sarah mae sanborn,
+PSYC,3520,1.0,Social Psychology,0.88,0.09,0.02,0.01,0.0,0%,0.0,0.0,ceren gunsoy,
+PSYC,3520,902.0,Social Psychology (HON),0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,robin marie kowalski,True
+PSYC,3570,1.0,Psychology and Culture,0.73,0.17,0.06,0.02,0.01,0%,0.0,0.0,ceren gunsoy,
+PSYC,3640,1.0,Industrial Psych,0.43,0.46,0.07,0.04,0.0,0%,0.0,0.0,eric mckibben,
+PSYC,3640,2.0,Industrial Psych,0.75,0.12,0.06,0.0,0.06,0%,0.0,0.01,joseph ligato,
+PSYC,3680,1.0,Organizational Psych,0.45,0.51,0.02,0.0,0.02,0%,0.0,0.0,chloe wilson,
+PSYC,3700,1.0,Personality,0.54,0.34,0.1,0.0,0.03,0%,0.0,0.0,john robert hester,
+PSYC,3830,1.0,Abnormal Psychology,0.38,0.41,0.12,0.09,0.0,0%,0.0,0.0,pamela alley,
+PSYC,3830,2.0,Abnormal Psychology,0.43,0.23,0.14,0.11,0.06,0%,0.0,0.03,pamela alley,
+PSYC,3890,1.0,Psychology of Religion,0.83,0.13,0.04,0.0,0.0,0%,0.0,0.0,zhuo chen,
+PSYC,4080,901.0,Women and Psychology,0.64,0.2,0.08,0.0,0.04,0%,0.0,0.04,robin marie kowalski,
+PSYC,4150,1.0,Systems and Theories,0.51,0.31,0.11,0.03,0.0,0%,0.0,0.03,edwin brainerd,
+PSYC,4150,2.0,Systems and Theories,0.5,0.25,0.08,0.08,0.06,0%,0.0,0.03,edwin brainerd,
+PSYC,4220,1.0,Perception,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,christopher pagano,
+PSYC,4350,1.0,Human Factors,0.3,0.48,0.04,0.0,0.0,0%,0.0,0.13,dustin souders,
+PSYC,4430,1.0,Infant & Child Dev,0.71,0.26,0.03,0.0,0.0,0%,0.0,0.0,sarah mae sanborn,
+PSYC,4800,1.0,Health Psychology,0.65,0.31,0.04,0.0,0.0,0%,0.0,0.0,james mccubbin,
+PSYC,4800,2.0,Health Psychology,0.8,0.16,0.04,0.0,0.0,0%,0.0,0.0,james mccubbin,
+PSYC,4820,1.0,Positive Psychology,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,cynthia pury s,
+PSYC,4880,1.0,Psychotherapy,0.6,0.12,0.12,0.0,0.0,0%,0.0,0.08,heidi marie zinzow,
+PSYC,4890,1.0,Sport Psychology,0.76,0.24,0.0,0.0,0.0,0%,0.0,0.0,eric mckibben,
+PSYC,4890,2.0,Cross-Cultural Human Dev,0.55,0.23,0.09,0.09,0.0,0%,0.0,0.0,susan limber,
+PSYC,4930,100.0,Pract Clinical Psych,0.81,0.06,0.0,0.0,0.0,0%,0.0,0.13,lucinda quick,
+PSYC,4930,200.0,Pract Clinical Psych,0.88,0.06,0.0,0.0,0.06,0%,0.0,0.0,heidi marie zinzow,
+PSYC,4970,919.0,Directed Studies,0.89,0.02,0.0,0.0,0.0,0%,0.0,0.05,karyn jones,
+PSYC,8100,1.0,Research Design I,0.76,0.21,0.0,0.0,0.0,0%,0.0,0.03,patrick rosopa,
+PSYC,8220,1.0,Percept & Perform,0.75,0.19,0.0,0.0,0.0,0%,0.0,0.06,richard tyrrell,
+RED,8010,1.0,Market Analysis,0.67,0.22,0.06,0.0,0.0,0%,0.0,0.06,robert benedict,
+RED,8020,1.0,Development Tour,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,robert benedict,
+RED,8100,1.0,Real Est Roundtable,0.94,0.0,0.0,0.0,0.0,0%,0.0,0.06,robert benedict,
+RED,8130,1.0,Strat in Real Estate,0.62,0.31,0.08,0.0,0.0,0%,0.0,0.0,kimbrell cary hughes,
+RED,8890,1.0,Selected Topics-Adv. Fin.,0.86,0.14,0.0,0.0,0.0,0%,0.0,0.0,larry bradley harvey,
+REL,1010,1.0,Intro to Religion,0.58,0.32,0.0,0.05,0.05,0%,0.0,0.0,peter cohen,
+REL,1010,2.0,Intro to Religion,0.45,0.41,0.05,0.0,0.09,0%,0.0,0.0,peter cohen,
+REL,1010,3.0,Intro to Religion,0.79,0.18,0.0,0.0,0.03,0%,0.0,0.0,peter cohen,
+REL,1020,2.0,World Religions,0.56,0.29,0.12,0.03,0.0,0%,0.0,0.0,robert stephens,
+REL,1020,3.0,World Religions,0.51,0.26,0.14,0.0,0.0,0%,0.0,0.09,robert stephens,
+REL,1020,4.0,World Religions,0.47,0.5,0.03,0.0,0.0,0%,0.0,0.0,robert stephens,
+REL,3010,1.0,Old Testament,0.56,0.21,0.12,0.03,0.0,0%,0.0,0.09,john thames,
+REL,3060,1.0,Judaism,0.52,0.21,0.07,0.0,0.0,0%,0.0,0.21,john thames,
+REL,3070,1.0,The Christian Tradition,0.34,0.52,0.14,0.0,0.0,0%,0.0,0.0,brett patterson,
+REL,3100,1.0,History of Religion in the U,0.5,0.33,0.11,0.0,0.06,0%,0.0,0.0,elizabeth jemison,
+REL,3110,1.0,African American Rel,0.54,0.17,0.13,0.0,0.0,0%,0.0,0.13,elizabeth jemison,
+REL,3120,1.0,Hinduism,0.29,0.29,0.14,0.14,0.0,0%,0.0,0.14,robert stephens,
+REL,4210,1.0,Koine Greek of the New Te,0.5,0.0,0.13,0.19,0.13,0%,0.0,0.06,benjamin white,
+RUD,8610,1.0,Urban Design Seminar I,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0, wortham-galvin,
+RUSS,3400,1.0,19th C Russ Culture,0.58,0.29,0.08,0.0,0.0,0%,0.0,0.0,olga volkova,
+RUSS,3610,1.0,Russn Lit Since 1910,0.52,0.35,0.13,0.0,0.0,0%,0.0,0.0,olga volkova,
+SOC,2010,1.0,Introduction to Sociology,0.8,0.17,0.01,0.0,0.01,0%,0.0,0.02,carolyn coffman,
+SOC,2010,2.0,Introduction to Sociology,0.58,0.34,0.08,0.0,0.0,0%,0.0,0.0,jennifer holland,
+SOC,2010,3.0,Introduction to Sociology,0.8,0.18,0.01,0.0,0.01,0%,0.0,0.0,carolyn coffman,
+SOC,2010,4.0,Introduction to Sociology,0.9,0.08,0.01,0.0,0.0,0%,0.0,0.01, mannheimer,
+SOC,2010,5.0,Introduction to Sociology,0.77,0.15,0.04,0.02,0.02,0%,0.0,0.0, mcdonough,
+SOC,2010,6.0,Introduction to Sociology,0.75,0.16,0.05,0.02,0.01,0%,0.0,0.02, mcdonough,
+SOC,2010,7.0,Introduction to Sociology,0.8,0.1,0.04,0.0,0.02,0%,0.0,0.04,thomas maher,
+SOC,2040,1.0,Prof Dev for Sociology Maj,0.35,0.26,0.13,0.09,0.13,0%,0.0,0.04, catherine mobley,
+SOC,3020,1.0,Research Methods I,0.59,0.23,0.07,0.05,0.02,0%,0.0,0.05,thomas maher,
+SOC,3020,2.0,Research Methods I,0.32,0.5,0.11,0.03,0.03,0%,0.0,0.03,miao li,
+SOC,3040,1.0,Social Research Methods II,0.28,0.38,0.1,0.1,0.07,0%,0.0,0.07,ye luo,
+SOC,3040,2.0,Social Research Methods II,0.33,0.56,0.11,0.0,0.0,0%,0.0,0.0,william haller,
+SOC,3110,1.0,The Family,0.84,0.1,0.04,0.0,0.02,0%,0.0,0.0,carolyn coffman,
+SOC,3600,1.0,Class & Poverty,0.57,0.28,0.09,0.04,0.0,0%,0.0,0.02,kenneth robinson,
+SOC,3910,1.0,Soc of Deviance,0.58,0.29,0.05,0.04,0.02,0%,0.0,0.02, mcdonough,
+SOC,3940,1.0,Sociology of Mental Illness,0.88,0.04,0.0,0.0,0.0,0%,0.0,0.02,james rosenberger,
+SOC,4030,1.0,Environmental Sociology,0.5,0.33,0.08,0.04,0.0,0%,0.0,0.04, catherine mobley,
+SOC,4040,1.0,Soc Theory,0.44,0.33,0.11,0.06,0.06,0%,0.0,0.0,matthew costello,
+SOC,4140,1.0,Policy&Social Change,0.6,0.31,0.1,0.0,0.0,0%,0.0,0.0,jennifer holland,
+SOC,4440,1.0,Sociology of Educ,0.73,0.16,0.02,0.0,0.02,0%,0.0,0.02, mannheimer,
+SOC,4600,1.0,Race & Ethnicity,0.86,0.08,0.06,0.0,0.0,0%,0.0,0.0, mannheimer,
+SOC,4610,1.0,Sex & Gender,0.67,0.24,0.03,0.0,0.03,0%,0.0,0.03,carolyn coffman,
+SOC,4710,1.0,World Population and Soci,0.43,0.36,0.0,0.07,0.0,0%,0.0,0.14,ye luo,
+SOC,8120,1.0,Social Stratification,0.8,0.0,0.0,0.0,0.0,0%,0.0,0.1,william haller,
+SOC,8970,1.0,Departmental Seminar,0.0,0.0,0.0,0.0,0.0,####,0.0,0.0,natallia sianko,
+SPAN,1010,1.0,Elementary Spanish,0.71,0.25,0.04,0.0,0.0,0%,0.0,0.0,stephanie morris,
+SPAN,1010,2.0,Elementary Spanish,0.71,0.21,0.08,0.0,0.0,0%,0.0,0.0,stephanie morris,
+SPAN,1010,3.0,Elementary Spanish,0.42,0.29,0.17,0.04,0.0,0%,0.0,0.08,rosa pillcurima,
+SPAN,1020,1.0,Elementary Spanish,0.39,0.43,0.13,0.0,0.0,0%,0.0,0.04,rosa pillcurima,
+SPAN,1020,2.0,Elementary Spanish,0.48,0.35,0.04,0.0,0.0,0%,0.0,0.13,debra williamson,
+SPAN,1020,3.0,Elementary Spanish,0.48,0.3,0.17,0.0,0.04,0%,0.0,0.0,yezid flores,
+SPAN,1020,4.0,Elementary Spanish,0.58,0.33,0.04,0.0,0.04,0%,0.0,0.0,yezid flores,
+SPAN,1020,5.0,Elementary Spanish,0.86,0.0,0.0,0.0,0.0,0%,0.0,0.14,liliana hernandez,
+SPAN,1020,6.0,Elementary Spanish,0.27,0.53,0.13,0.07,0.0,0%,0.0,0.0,valderramos cruz,
+SPAN,1020,8.0,Elementary Spanish,0.84,0.11,0.05,0.0,0.0,0%,0.0,0.0,valderramos cruz,
+SPAN,1020,9.0,Elementary Spanish,0.52,0.43,0.05,0.0,0.0,0%,0.0,0.0,yezid flores,
+SPAN,1020,10.0,Elementary Spanish,0.86,0.09,0.05,0.0,0.0,0%,0.0,0.0,liliana hernandez,
+SPAN,1020,13.0,Elementary Spanish,0.26,0.43,0.17,0.09,0.0,0%,0.0,0.04,melva persico,
+SPAN,2010,1.0,Intermediate Spanish,0.45,0.32,0.05,0.0,0.05,0%,0.0,0.14,debra williamson,
+SPAN,2010,2.0,Intermediate Spanish,0.48,0.43,0.05,0.0,0.0,0%,0.0,0.05,debra williamson,
+SPAN,2010,3.0,Intermediate Spanish,0.71,0.04,0.17,0.04,0.0,0%,0.0,0.04,ellory schmucker,
+SPAN,2010,4.0,Intermediate Spanish,0.65,0.26,0.0,0.0,0.09,0%,0.0,0.0,ellory schmucker,
+SPAN,2010,7.0,Intermediate Spanish,0.67,0.13,0.13,0.04,0.0,0%,0.0,0.04,ellory schmucker,
+SPAN,2010,8.0,Intermediate Spanish,0.57,0.33,0.05,0.0,0.0,0%,0.0,0.05,debra williamson,
+SPAN,2010,9.0,Intermediate Spanish,0.9,0.1,0.0,0.0,0.0,0%,0.0,0.0,liliana hernandez,
+SPAN,2010,10.0,Intermediate Spanish,0.5,0.46,0.04,0.0,0.0,0%,0.0,0.0,vieyra daniel garcia,
+SPAN,2010,11.0,Intermediate Spanish,0.43,0.43,0.04,0.0,0.0,0%,0.0,0.09,vieyra daniel garcia,
+SPAN,2010,12.0,Intermediate Spanish,0.75,0.13,0.04,0.04,0.0,0%,0.0,0.04,ellory schmucker,
+SPAN,2010,13.0,Intermediate Spanish,0.79,0.08,0.08,0.0,0.04,0%,0.0,0.0,liliana hernandez,
+SPAN,2010,14.0,Intermediate Spanish,0.55,0.18,0.0,0.0,0.09,0%,0.0,0.18,valderramos cruz,
+SPAN,2010,15.0,Intermediate Spanish,0.61,0.3,0.04,0.0,0.0,0%,0.0,0.04,valderramos cruz,
+SPAN,2010,16.0,Intermediate Spanish,0.57,0.26,0.09,0.0,0.0,0%,0.0,0.09,yezid flores,
+SPAN,2010,17.0,Intermediate Spanish,0.37,0.37,0.26,0.0,0.0,0%,0.0,0.0,nora arostegui logue,
+SPAN,2010,18.0,Intermediate Spanish,0.57,0.3,0.04,0.04,0.0,0%,0.0,0.04,nora arostegui logue,
+SPAN,2010,28.0,Intermediate Spanish,0.4,0.4,0.1,0.1,0.0,0%,0.0,0.0,yezid flores,
+SPAN,2020,2.0,Intermediate Spanish,0.35,0.25,0.15,0.05,0.1,0%,0.0,0.1,melva persico,
+SPAN,2020,4.0,Intermediate Spanish,0.52,0.22,0.17,0.04,0.0,0%,0.0,0.04,rodriguez garcia,
+SPAN,2020,5.0,Intermediate Spanish,0.83,0.08,0.04,0.0,0.04,0%,0.0,0.0,mercedes tejera,
+SPAN,2020,6.0,Intermediate Spanish,0.5,0.25,0.04,0.0,0.0,0%,0.0,0.21,rosa pillcurima,
+SPAN,2020,7.0,Intermediate Spanish,0.63,0.21,0.0,0.08,0.0,0%,0.0,0.08,rosa pillcurima,
+SPAN,2020,8.0,Intermediate Spanish,0.5,0.35,0.1,0.05,0.0,0%,0.0,0.0,ana paula  miller e,
+SPAN,2020,9.0,Intermediate Spanish,0.33,0.33,0.24,0.0,0.0,0%,0.0,0.1,ana paula  miller e,
+SPAN,2020,10.0,Intermediate Spanish,0.62,0.19,0.1,0.0,0.0,0%,0.0,0.1,ana paula  miller e,
+SPAN,2020,11.0,Intermediate Spanish,0.43,0.33,0.05,0.1,0.0,0%,0.0,0.1,melva persico,
+SPAN,2020,13.0,Intermediate Spanish,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,nora arostegui logue,
+SPAN,2020,14.0,Intermediate Spanish,0.58,0.33,0.0,0.0,0.08,0%,0.0,0.0,nora arostegui logue,
+SPAN,2020,15.0,Intermediate Spanish,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,mercedes tejera,
+SPAN,2020,16.0,Intermediate Spanish,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,mercedes tejera,
+SPAN,3020,1.0,Intermed Span Grammar,0.41,0.41,0.09,0.0,0.0,0%,0.0,0.09,vieyra daniel garcia,
+SPAN,3020,2.0,Intermed Span Grammar,0.68,0.18,0.0,0.0,0.0,0%,0.0,0.14,george palacios,
+SPAN,3020,3.0,Intermed Span Grammar,0.67,0.17,0.0,0.0,0.04,0%,0.0,0.13,vieyra daniel garcia,
+SPAN,3020,4.0,Intermed Span Grammar,0.29,0.57,0.07,0.0,0.07,0%,0.0,0.0,melva persico,
+SPAN,3040,1.0,Intro Hispanic Literary For,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,graciela tissera,
+SPAN,3040,2.0,Intro Hispanic Literary For,0.42,0.33,0.17,0.08,0.0,0%,0.0,0.0,rodriguez garcia,
+SPAN,3050,1.0,Intermed Span Convers/Co,0.32,0.47,0.16,0.0,0.0,0%,0.0,0.05,rodriguez garcia,
+SPAN,3050,2.0,Intermed Span Convers/Co,0.91,0.09,0.0,0.0,0.0,0%,0.0,0.0,andrea naranjo,
+SPAN,3050,3.0,Intermed Span Convers/Co,0.61,0.09,0.04,0.0,0.0,0%,0.0,0.26,vieyra daniel garcia,
+SPAN,3060,1.0,Span Comp for Bus,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,andrea naranjo,
+SPAN,3070,1.0,The Hispanic World: Spain,0.74,0.16,0.0,0.0,0.05,0%,0.0,0.05,raquel anido,
+SPAN,3080,1.0,The Hispanic World: Latin,0.7,0.09,0.09,0.0,0.09,0%,0.0,0.0,george palacios,
+SPAN,3130,1.0,Span Lit Survey I,0.28,0.44,0.17,0.0,0.0,0%,0.0,0.11, rojas-de-massei,
+SPAN,3140,1.0,Hispanic Linguistics,0.88,0.13,0.0,0.0,0.0,0%,0.0,0.0,daniel smith,
+SPAN,3150,2.0,Spanish for Health Prof,0.86,0.1,0.05,0.0,0.0,0%,0.0,0.0,riquelme judez,
+SPAN,3180,1.0,Spanish Through Culture,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,salvador oropesa,
+SPAN,4010,1.0,New Spanish Fiction,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,graciela tissera,
+SPAN,4060,1.0,Narrative Fiction,0.33,0.47,0.07,0.07,0.0,0%,0.0,0.07, rojas-de-massei,
+SPAN,4070,1.0,Hispanic Film,0.8,0.12,0.0,0.04,0.04,0%,0.0,0.0,raquel anido,
+SPAN,4160,1.0,Spanish for Int'l Business II,0.73,0.09,0.0,0.0,0.18,0%,0.0,0.0,andrea naranjo,
+SPAN,4190,1.0,Health & Hispanic Commu,0.7,0.25,0.0,0.0,0.0,0%,0.0,0.05,peralta arelis moore,
+STAT,2220,1.0,Statistics in Everyday Life,0.33,0.23,0.23,0.12,0.04,0%,0.0,0.05,james espey,
+STAT,2220,2.0,Statistics in Everyday Life,0.25,0.41,0.23,0.05,0.02,0%,0.0,0.04,james espey,
+STAT,2220,3.0,Statistics in Everyday Life,0.29,0.34,0.16,0.12,0.08,0%,0.0,0.03,james espey,
+STAT,2220,4.0,Statistics in Everyday Life,0.24,0.43,0.23,0.09,0.01,0%,0.0,0.0,james espey,
+STAT,2220,5.0,Statistics in Everyday Life,0.19,0.32,0.29,0.14,0.06,0%,0.0,0.0, martinez-dawson,
+STAT,2220,6.0,Statistics in Everyday Life,0.24,0.39,0.2,0.09,0.05,0%,0.0,0.04, martinez-dawson,
+STAT,2220,7.0,Statistics in Everyday Life,0.3,0.24,0.28,0.1,0.05,0%,0.0,0.04, martinez-dawson,
+STAT,2300,1.0,Statistical Methods I,0.2,0.23,0.27,0.15,0.15,0%,0.0,0.0,anna marie vagnozzi,
+STAT,2300,2.0,Statistical Methods I,0.33,0.34,0.17,0.08,0.03,0%,0.0,0.04,paran norton,
+STAT,2300,3.0,Statistical Methods I,0.39,0.3,0.15,0.07,0.05,0%,0.0,0.03,paran norton,
+STAT,2300,4.0,Statistical Methods I,0.28,0.26,0.24,0.07,0.1,0%,0.0,0.05, erwin walker,
+STAT,2300,5.0,Statistical Methods I,0.23,0.4,0.19,0.09,0.06,0%,0.0,0.03, erwin walker,
+STAT,2300,6.0,Statistical Methods I,0.31,0.3,0.2,0.08,0.04,0%,0.0,0.07,thomas demarco,
+STAT,2300,100.0,Statistical Methods I (HON,0.9,0.05,0.05,0.0,0.0,0%,0.0,0.0,paran norton,True
+STAT,3090,1.0,Introductory Business Stat,0.23,0.3,0.35,0.0,0.09,0%,0.0,0.02,fun choi john chan john,
+STAT,3090,2.0,Introductory Business Stat,0.22,0.33,0.26,0.13,0.02,0%,0.0,0.04,trevor camper,
+STAT,3090,3.0,Introductory Business Stat,0.62,0.22,0.09,0.04,0.0,0%,0.0,0.02,anna marie vagnozzi,
+STAT,3090,4.0,Introductory Business Stat,0.44,0.36,0.16,0.0,0.02,0%,0.0,0.02, jayasekara,
+STAT,3090,5.0,Introductory Business Stat,0.41,0.17,0.26,0.09,0.04,0%,0.0,0.02,tyler melton,
+STAT,3090,6.0,Introductory Business Stat,0.37,0.28,0.17,0.07,0.04,0%,0.0,0.07,sean ingimarson,
+STAT,3090,7.0,Introductory Business Stat,0.35,0.24,0.24,0.04,0.09,0%,0.0,0.04,yangyi li,
+STAT,3090,8.0,Introductory Business Stat,0.34,0.22,0.22,0.1,0.1,0%,0.0,0.02,seyed hamid nazari,
+STAT,3090,9.0,Introductory Business Stat,0.42,0.18,0.11,0.13,0.09,0%,0.0,0.07,na guo,
+STAT,3090,10.0,Introductory Business Stat,0.29,0.29,0.27,0.11,0.02,0%,0.0,0.02,na guo,
+STAT,3090,11.0,Introductory Business Stat,0.42,0.31,0.2,0.04,0.02,0%,0.0,0.0,tiantian yang,
+STAT,3090,12.0,Introductory Business Stat,0.28,0.31,0.21,0.05,0.1,0%,0.0,0.05,marwah soliman,
+STAT,3090,13.0,Introductory Business Stat,0.42,0.2,0.3,0.02,0.04,0%,0.0,0.02,april thomas,
+STAT,3090,14.0,Introductory Business Stat,0.48,0.36,0.14,0.0,0.0,0%,0.0,0.02,april thomas,
+STAT,3090,15.0,Introductory Business Stat,0.33,0.28,0.12,0.05,0.14,0%,0.0,0.09,marwah soliman,
+STAT,3090,16.0,Introductory Business Stat,0.52,0.24,0.15,0.02,0.04,0%,0.0,0.02,anna marie vagnozzi,
+STAT,3090,17.0,Introductory Business Stat,0.37,0.37,0.21,0.0,0.02,0%,0.0,0.02,molly honecker,
+STAT,3090,18.0,Introductory Business Stat,0.29,0.4,0.2,0.02,0.04,0%,0.0,0.04,shuai wei,
+STAT,3090,19.0,Introductory Business Stat,0.37,0.29,0.18,0.02,0.06,0%,0.0,0.06,caroline kerfonta,
+STAT,3090,20.0,Introductory Business Stat,0.6,0.14,0.18,0.02,0.02,0%,0.0,0.04,zhengxin wang,
+STAT,3090,21.0,Introductory Business Stat,0.43,0.19,0.24,0.12,0.02,0%,0.0,0.0,anna marie vagnozzi,
+STAT,3300,1.0,Statistical Methods II,0.35,0.3,0.25,0.05,0.0,0%,0.0,0.05, martinez-dawson,
+STAT,4020,401.0,Intro to Statistical Computi,0.67,0.14,0.0,0.0,0.0,0%,0.0,0.19,ellen hepfer breazel,
+STAT,4020,402.0,Intro to Statistical Computi,0.88,0.06,0.0,0.0,0.0,0%,0.0,0.06,zhiyun gong,
+STAT,4110,1.0,Stat Mthds for Process Co,0.58,0.37,0.0,0.05,0.0,0%,0.0,0.0,na guo,
+STAT,4110,2.0,Stat Mthds for Process Co,0.72,0.25,0.0,0.03,0.0,0%,0.0,0.0,na guo,
+STAT,4110,3.0,Stat Mthds for Process Co,0.58,0.33,0.09,0.0,0.0,0%,0.0,0.0,william bridges,
+STAT,4110,4.0,Stat Mthds for Process Co,0.44,0.13,0.28,0.0,0.06,0%,0.0,0.09,yu-bo wang,
+STAT,4110,5.0,Stat Mthds for Process Co,0.38,0.34,0.24,0.0,0.0,0%,0.0,0.03,yu-bo wang,
+STAT,6020,401.0,Intro to Statistical Computi,0.62,0.23,0.15,0.0,0.0,0%,0.0,0.0,ellen hepfer breazel,
+STAT,8010,1.0,Statistical Methods I,0.76,0.19,0.05,0.0,0.0,0%,0.0,0.0,joseph daniel bible,
+STAT,8010,2.0,Statistical Methods I,0.48,0.43,0.05,0.0,0.05,0%,0.0,0.0,joseph daniel bible,
+STAT,8010,3.0,Statistical Methods I,0.68,0.18,0.14,0.0,0.0,0%,0.0,0.0,brook thayer russell,
+STAT,8010,4.0,Statistical Methods I,0.85,0.05,0.05,0.0,0.0,0%,0.0,0.05,jun luo,
+STAT,8010,5.0,Statistical Methods I,0.5,0.27,0.18,0.0,0.0,0%,0.0,0.0,patrick gerard,
+STAT,8020,1.0,Statistical Methods II,0.94,0.03,0.03,0.0,0.0,0%,0.0,0.0,whitney huang,
+STAT,8030,1.0,Regress & Least Squares A,0.75,0.08,0.08,0.0,0.0,0%,0.0,0.08,jun luo,
+STAT,8050,1.0,Design & Anlys of Experim,0.61,0.36,0.0,0.0,0.04,0%,0.0,0.0,william bridges,
+STS,1010,1.0,Survey Sci & Techn in Soci,0.88,0.0,0.0,0.0,0.0,0%,0.0,0.03,yang wu,
+STS,1010,2.0,Survey Sci & Techn in Soci,0.58,0.36,0.03,0.0,0.03,0%,0.0,0.0,scott brame,
+STS,1010,3.0,Survey Sci & Techn in Soci,0.69,0.23,0.09,0.0,0.0,0%,0.0,0.0,elizabeth stansell,
+STS,1010,4.0,Survey Sci & Techn in Soci,0.85,0.06,0.0,0.0,0.06,0%,0.0,0.03,mary katherine fidler,
+STS,1010,5.0,Survey Sci & Techn in Soci,0.78,0.17,0.03,0.0,0.03,0%,0.0,0.0,tareva johnson,
+STS,1010,7.0,Survey Sci & Techn in Soci,0.74,0.2,0.03,0.0,0.0,0%,0.0,0.03,philip randall,
+STS,1010,8.0,Survey Sci & Techn in Soci,0.82,0.03,0.03,0.03,0.0,0%,0.0,0.09,david charles foltz,
+STS,1010,9.0,Survey Sci & Techn in Soci,0.41,0.32,0.15,0.06,0.06,0%,0.0,0.0,megan macalystre,
+STS,1010,10.0,Survey Sci & Techn in Soci,0.88,0.06,0.03,0.0,0.0,0%,0.0,0.03,alexander billinis,
+STS,1010,11.0,Survey Sci & Techn in Soci,0.89,0.06,0.03,0.03,0.0,0%,0.0,0.0,anne grant,
+STS,1010,12.0,Survey Sci & Techn in Soci,0.15,0.38,0.15,0.06,0.18,0%,0.0,0.06,chelsea marie clarey,
+THEA,2100,1.0,Theatre Appreciation,0.69,0.22,0.06,0.03,0.0,0%,0.0,0.0,david hartmann,
+THEA,2100,3.0,Theatre Appreciation,0.61,0.21,0.09,0.03,0.03,0%,0.0,0.03,kendra johnson,
+THEA,2100,6.0,Theatre Appreciation,0.81,0.13,0.03,0.03,0.0,0%,0.0,0.0,jason adkins,
+THEA,2100,7.0,Theatre Appreciation,0.72,0.22,0.03,0.0,0.03,0%,0.0,0.0,jason adkins,
+THEA,2770,1.0,Prod Studies in Thea,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,david hartmann,
+THEA,3150,1.0,Theatre History I,0.79,0.15,0.03,0.0,0.0,0%,0.0,0.03,shannon robert,
+THEA,3170,1.0,African-Amer Thea I,0.65,0.12,0.18,0.0,0.06,0%,0.0,0.0,kendra johnson,
+THEA,3470,1.0,Structure of Drama,0.75,0.17,0.08,0.0,0.0,0%,0.0,0.0,carol collins,
+THEA,3720,1.0,Creative Drama,0.85,0.15,0.0,0.0,0.0,0%,0.0,0.0,carol collins,
+THEA,3760,1.0,Stage Directing I,0.55,0.27,0.09,0.09,0.0,0%,0.0,0.0,becky becker,
+WFB,3010,2.0,Wildlife Biology Lab,0.57,0.36,0.07,0.0,0.0,0%,0.0,0.0,shari lynn rodriguez,
+WFB,4100,2.0,Wildlife Management Tech,0.53,0.26,0.12,0.06,0.03,0%,0.0,0.0,catherine jachowski,
+WFB,4120,1.0,Wildlife Management,0.59,0.3,0.07,0.0,0.04,0%,0.0,0.0,greg yarrow,
+WFB,4180,2.0,Fisheries Mgt & Conservati,0.57,0.29,0.0,0.07,0.0,0%,0.0,0.07,troy mason farmer,
+WFB,4440,1.0,Wildlife Damage Manage,0.41,0.52,0.07,0.0,0.0,0%,0.0,0.0,greg yarrow,
+WFB,4770,1.0,Ichthyology,0.53,0.4,0.0,0.07,0.0,0%,0.0,0.0,luke bower,
+WFB,4800,1.0,Waterfowl Ecology & Man,0.28,0.31,0.21,0.08,0.0,0%,0.0,0.13,richard kaminski,
+WFB,6200,2.0,Environmental Education,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,althea hagan,
+WFB,6620,1.0,Wetland Wildlife Biology,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,russell barrett,
+WFB,6800,1.0,Waterfowl Ecology & Man,0.69,0.19,0.0,0.0,0.0,0%,0.0,0.06,richard kaminski,
+WFB,8530,2.0,Global Change Ecology,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,lydia ries 'halloran,
+WFB,8610,5.0,Intro to Scientific Writing,0.75,0.25,0.0,0.0,0.0,0%,0.0,0.0,stefanie whitmire,
+WFB,8610,6.0,Conservation PhysiologyO,0.8,0.2,0.0,0.0,0.0,0%,0.0,0.0,patrick jodice,
+WFB,8610,11.0,Study Design & Data Analy,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.0,brandon peoples,
+WFB,8610,30.0,Human Dimensions of WL,0.77,0.15,0.08,0.0,0.0,0%,0.0,0.0,shari lynn rodriguez,
+WS,1030,1.0,Women in Global Perspect,0.72,0.14,0.03,0.03,0.07,0%,0.0,0.0,sarah mae cooper,
+WS,1030,2.0,Women in Global Perspect,0.59,0.38,0.0,0.0,0.0,0%,0.0,0.03,sarah mae cooper,
+WS,2300,1.0,Women and Leadership I,0.8,0.1,0.1,0.0,0.0,0%,0.0,0.0,mary price,
+WS,4010,1.0,Senior Seminar,0.83,0.08,0.0,0.0,0.0,0%,0.0,0.08,diane perpich,
+YDP,3000,1.0,Youth Development in Soci,0.73,0.19,0.04,0.0,0.0,0%,0.0,0.04,lauren stephens,
+YDP,3050,1.0,Theory/Phil of Youth Dev,0.81,0.19,0.0,0.0,0.0,0%,0.0,0.0,lauren stephens,
+YDP,3200,1.0,Youth Dev in Sport/Phys A,0.83,0.17,0.0,0.0,0.0,0%,0.0,0.0,lauren stephens,
+YDP,3300,1.0,Designing Effective Youth,0.88,0.12,0.0,0.0,0.0,0%,0.0,0.0,kellye rembert,
+YDP,3300,2.0,Designing Effective Youth,0.29,0.58,0.04,0.04,0.0,0%,0.0,0.04,allison avishai,
+YDP,3350,1.0,Youth Activity Leadership,0.81,0.11,0.07,0.0,0.0,0%,0.0,0.0,lauren stephens,
+YDP,3450,1.0,Creative Activities for Yout,0.88,0.08,0.0,0.0,0.0,0%,0.0,0.04,kimberly johnson,
+YDP,4500,1.0,Prof Iss & Ethics in Youth D,0.69,0.23,0.08,0.0,0.0,0%,0.0,0.0,michele little kukler,
+YDP,8000,1.0,Theories of Youth Develop,0.76,0.14,0.0,0.0,0.0,0%,0.0,0.03,edmond bowers,
+YDP,8050,1.0,Youth Dev in Context of Fa,0.78,0.17,0.0,0.0,0.0,0%,0.0,0.06,william quinn,
+YDP,8060,2.0,Youth Dev in Global Societ,0.67,0.13,0.07,0.0,0.13,0%,0.0,0.0,ann marie gillard,
+YDP,8080,1.0,Grantsmanship,0.71,0.29,0.0,0.0,0.0,0%,0.0,0.0,anna- chancellor,

--- a/bot/cogs/grades_cog/grades_cog.py
+++ b/bot/cogs/grades_cog/grades_cog.py
@@ -1,26 +1,21 @@
-import json
 import os
-import gzip
 import logging
-import collections
-import itertools
 
 import discord
 import pandas as pd
 import discord.ext.commands as commands
 from bot.messaging.events import Events
-import typing as t
 
 from bot.consts import Colors
 import bot.extensions as ext
-from spellchecker import SpellChecker # Here we will add a utility for correcting user input
 
 log = logging.getLogger(__name__)
 
 MIN_YEAR = 2014
-TAG_CHUNK_SIZE = 12*3
+TAG_CHUNK_SIZE = 12 * 3
 
 ASSET_LOCATION = 'bot/cogs/grades_cog/assets/'
+
 
 class GradesCog(commands.Cog):
 
@@ -38,10 +33,18 @@ class GradesCog(commands.Cog):
         self.all_profs = self.get_profs()
         self.all_courses = self.get_courses()
 
-    @ext.group(invoke_without_command= True, case_insensitive=True)
+    @ext.group(invoke_without_command=True, case_insensitive=True)
     @ext.long_help(
         """
         Attempts to give more information about courses at Clemson University.
+        
+        General usage:
+        `grades [course] (year) (honors|non-honors|all)`
+        
+        Where `course` is required, but the `year` and `honors` arguments are optional.
+        
+        Default `year`: `2014`.
+        Default `honors` argument: `all` (this averages grades for every section in a course, whether honors or non-honors).
 
         DISCLAIMER:
         Not every professor listed will be at Clemson, this is a tool built for better information but not complete information.
@@ -50,19 +53,67 @@ class GradesCog(commands.Cog):
         """
     )
     @ext.short_help('Attempts to give more information about courses at Clemson University')
-    @ext.example(('grades cpsc-1010', 'grades cpsc-1010 2017'))
-    async def grades(self, ctx, course: str, year: int=MIN_YEAR):
+    @ext.example(
+        ('grades math-2060', 'grades math-2060 2017', 'grades math-2060 honors', 'grades math-2060 2017 honors'))
+    async def grades(self, ctx, course: str, *args):
         course = course.upper()
 
+        # Defaults
+        honors = "all"
+        year = MIN_YEAR
+
+        error_title = False
+        error_message = False
+
+        # We have flexibility of the order and exact phrasing of arguments
+        for arg in args:
+            if arg in ("honors", "hon"):
+                honors = "honors"
+            elif arg in ("non-honors", "non-hon", "regular", "normal"):
+                honors = "non-honors"
+            elif arg == "all":
+                honors = "all"
+            elif arg.isdigit():
+                year = int(arg)
+            else:
+                error_title = "Unable to parse command"
+                error_message = 'Are you sure you used the proper format (ex: math-2060 2017 honors)?'
+
+        if len(args) > 2:
+            error_title = "Too many arguments"
+            error_message = 'Are you sure you used the proper format (ex: math-2060 2017 honors)?'
+
+        # Further processing of arguments
         if not self.grades_df.CourseId.str.contains(course).any():
+            error_title = "Course doesn't exist"
+            error_message = 'Are you sure you used the proper notation (ex: cpsc-2120)?'
+        elif self.grades_df[(self.grades_df.CourseId == course)].Year.max() < year:
+            error_title = "No data for year %s" % year
+            error_message = 'There is no grade data for your course for this year onward; please extend the range and try again.'
+        elif year < 2014:
+            error_title = "Year below minimum"
+            error_message = "The year you selected is below the minimum threshold (%d)." % MIN_YEAR
+
+        if error_title:
             embed = discord.Embed(title="Grades", color=Colors.Error)
-            result = 'Are you sure you used the proper notation (ex: cpsc-2120)?'
-            embed.add_field(name="ERROR: Course doesn't exist", value=result, inline=False)
-            embed.add_field(name=f'Help:', value= f'Run `{await self.bot.current_prefix(ctx)}grades list` to find what courses are available', inline=False)
+            embed.add_field(name="ERROR: " + error_title, value=error_message, inline=False)
+            embed.add_field(name=f'Help:',
+                            value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for documentation or ' \
+                                  f'`{await self.bot.current_prefix(ctx)}grades list` to find out which ' \
+                                  'courses are available',
+                            inline=False)
             return await ctx.send(embed=embed)
 
+        # Default: no honors preference
         df = self.grades_df[(self.grades_df.CourseId == course) & (self.grades_df.Year >= year)]
-        title = df.Title.tolist()[0]
+
+        if honors == "honors":
+            df = self.grades_df[
+                (self.grades_df.CourseId == course) & (self.grades_df.Year >= year) & (self.grades_df.Honors == True)]
+        elif honors == "non-honors":
+            df = self.grades_df[(self.grades_df.CourseId == course) & (self.grades_df.Year >= year) & (
+                    self.grades_df.Honors != True)]
+
         log.info(df)
 
         A = f'{int(df.A.mean().round(2) * 100)}%'
@@ -72,22 +123,30 @@ class GradesCog(commands.Cog):
         F = f'{int(df.F.mean().round(2) * 100)}%'
         W = f'{int(df.W.mean().round(2) * 100)}%'
 
+        title = "Grades for %s since %d" % (course, year)
+
+        if honors == "honors":
+            title = "Grades for %s (Honors) since %d" % (course, year)
+        elif honors == "non-honors":
+            title = "Grades for %s (Non-Honors) since %d" % (course, year)
+
         embeds = []
 
-        embed = discord.Embed(title=f'Grades for {course} since {year}', color=Colors.ClemsonOrange)
+        embed = discord.Embed(title=title, color=Colors.ClemsonOrange)
         embed.set_footer(text=self.get_full_name(ctx.author), icon_url=ctx.author.avatar_url)
-        embed.description = title 
+        embed.description = title
         embed.add_field(name='Overall Distribution', value=f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```')
-        embed.add_field(name='Total Number of Classes Analyzed', value=len(df), inline=False)
-        embed.add_field(name='Total Number of Professors Found', value=len(df.groupby(['Instructor'])), inline=False)
-        embed.add_field(name='Explanation',value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+        embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df)), inline=False)
+        embed.add_field(name='Total Number of Professors Found', value=str(len(df.groupby(['Instructor']))), inline=False)
+        embed.add_field(name='Explanation',
+                        value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
         embeds.append(embed)
 
-        #group by the 
+        # group by the prof
 
         for i, row in df.groupby(['Instructor']).mean().iterrows():
-            embed = discord.Embed(title=f'Grades for {course} since {year}', color=Colors.ClemsonOrange) 
-            embed.description = title 
+            embed = discord.Embed(title=title, color=Colors.ClemsonOrange)
+            embed.description = title
             embed.set_footer(text=self.get_full_name(ctx.author), icon_url=ctx.author.avatar_url)
             A = f'{int(row.A.round(2) * 100)}%'
             B = f'{int(row.B.round(2) * 100)}%'
@@ -98,21 +157,30 @@ class GradesCog(commands.Cog):
 
             val = f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```'
             embed.add_field(name=f"{row.name}'s distribution", value=val)
-            embed.add_field(name='Total Number of Classes Analyzed', value=len(df), inline=False)
-            embed.add_field(name='Total Number of Professors Found', value=len(df.groupby(['Instructor'])), inline=False)
-            embed.add_field(name='Explanation',value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+            embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df)), inline=False)
+            embed.add_field(name='Total Number of Professors Found', value=str(len(df.groupby(['Instructor']))),
+                            inline=False)
+            embed.add_field(name='Explanation',
+                            value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
             embeds.append(embed)
 
-        await self.bot.messenger.publish(Events.on_set_pageable_embed, 
-            pages=embeds, 
-            author=ctx.author, 
-            channel=ctx.channel,
-            timeout=360)
+        await self.bot.messenger.publish(Events.on_set_pageable_embed,
+                                         pages=embeds,
+                                         author=ctx.author,
+                                         channel=ctx.channel,
+                                         timeout=360)
 
-    @ext.group(invoke_without_command= True, case_insensitive=True)
+    @ext.group(invoke_without_command=True, case_insensitive=True)
     @ext.long_help(
         """
         Attempts to give more information about professor's grade distribution at Clemson.
+        
+        General usage:
+        `prof [name] (honors|non-honors|all)`
+        
+        Where `name` is required, but the `honors` argument is optional.
+        
+        Default `honors` argument: `all`
 
         DISCLAIMER:
         Not every professor listed will be at Clemson, this is a tool built for better information but not complete information.
@@ -121,26 +189,52 @@ class GradesCog(commands.Cog):
         """
     )
     @ext.short_help('Provides info about a given professor')
-    @ext.example(['prof brian dean'])
-    async def prof(self, ctx, *, prof: str):
-        prof = prof.lower()
-        normalized_name = prof.title()
+    @ext.example(('prof brian dean', 'prof kristi whitehead honors'))
+    async def prof(self, ctx, *args):
+        honors = "all"
+        if args[-1] in ("honors", "hon"):
+            honors = "honors"
+        elif args[-1] in ("non-honors", "non-hon", "regular", "normal"):
+            honors = "non-honors"
 
-        if not self.grades_df.Instructor.str.contains(prof).any():
+        if honors != "all":
+            prof = " ".join(args[:-1])  # Everything except last item
+        else:
+            prof = " ".join(args)
+
+        if not self.grades_df.Instructor.str.contains(prof, case=False).any():
             embed = discord.Embed(title="Professors", color=Colors.Error)
             result = f'"{prof}" is not a known Professor\n'
             embed.add_field(name="ERROR: Professor doesn't exist", value=result, inline=False)
-            embed.add_field(name=f'Help:', value= f'Run `{await self.bot.current_prefix(ctx)}prof list` to find what professors are available', inline=False)
+            embed.add_field(name=f'Help:',
+                            value=f'Run `{await self.bot.current_prefix(ctx)}prof list` to find what professors are available',
+                            inline=False)
             return await ctx.send(embed=embed)
 
-        #check for if there is a 0% A rate, that means it was a pass fail class and we dont handle those
-        df = self.grades_df[(self.grades_df.Instructor == prof) & (self.grades_df.A > 0)]
+        # check for if there is a 0% A rate, that means it was a pass fail class and we dont handle those
+        df = self.grades_df[(self.grades_df.Instructor.str.lower() == prof.lower()) & (self.grades_df.A > 0)]
+
+        # Honors/Non-honors logic
+        if honors == "honors":
+            df = self.grades_df[(self.grades_df.Instructor.str.lower() == prof.lower()) & (self.grades_df.A > 0) & (
+                        self.grades_df.Honors == True)]
+        elif honors == "non-honors":
+            df = self.grades_df[(self.grades_df.Instructor.str.lower() == prof.lower()) & (self.grades_df.A > 0) & (
+                        self.grades_df.Honors != True)]
 
         if df.empty:
-            embed = discord.Embed(title="Error: That professor has no available data", color=Colors.Error)
-            embed.add_field(name=f'Help:', value= f'This professors data might be under a different name, run `{await self.bot.current_prefix(ctx)}prof list` to find what professors are available', inline=False)
-            return await ctx.send(embed=embed)
+            title = "Error: That professor has no available data"
 
+            if honors == "honors":
+                title = "Error: That professor has no available data for honors"
+            elif honors == "non-honors":
+                title = "Error: That professor has no available data for non-honors"
+
+            embed = discord.Embed(title=title, color=Colors.Error)
+            embed.add_field(name=f'Help:',
+                            value=f"This professor's data might be under a different name, run `{await self.bot.current_prefix(ctx)}prof list` to find what professors are available",
+                            inline=False)
+            return await ctx.send(embed=embed)
 
         A = f'{int(df.A.mean().round(2) * 100)}%'
         B = f'{int(df.B.mean().round(2) * 100)}%'
@@ -148,18 +242,35 @@ class GradesCog(commands.Cog):
         D = f'{int(df.D.mean().round(2) * 100)}%'
         F = f'{int(df.F.mean().round(2) * 100)}%'
         W = f'{int(df.W.mean().round(2) * 100)}%'
+        normalized_name = df.Instructor.any()
+
+        title = f'Overall Grade Distribution for {normalized_name} across all classes taught'
+
+        if honors == "honors":
+            title = f'Overall Grade Distribution for {normalized_name} across all honors classes taught'
+        elif honors == "non-honors":
+            title = f'Overall Grade Distribution for {normalized_name} across all non-honors classes taught'
 
         embeds = []
 
-        embed = discord.Embed(title=f'Overall Grade Distribution for {normalized_name} across all classes taught', color=Colors.ClemsonOrange)
+        embed = discord.Embed(title=title,
+                              color=Colors.ClemsonOrange)
         embed.set_footer(text=self.get_full_name(ctx.author), icon_url=ctx.author.avatar_url)
         embed.add_field(name='Overall Distribution', value=f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```')
-        embed.add_field(name='Total Number of Classes Analyzed', value=len(df.groupby(['CourseId'])), inline=False)
-        embed.add_field(name='Explanation',value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+        embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df.groupby(['CourseId']))), inline=False)
+        embed.add_field(name='Explanation',
+                        value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
         embeds.append(embed)
 
+        title2 = f'Grade Distribution for {normalized_name}'
+
+        if honors == "honors":
+            title2 = f'Grade Distribution for {normalized_name} (Honors)'
+        elif honors == "non-honors":
+            title2 = f'Grade Distribution for {normalized_name} (Non-Honors)'
+
         for i, row in df.groupby(['CourseId']).mean().iterrows():
-            embed = discord.Embed(title=f'Grade Distribution for {normalized_name}', color=Colors.ClemsonOrange)
+            embed = discord.Embed(title=title2, color=Colors.ClemsonOrange)
             embed.set_footer(text=self.get_full_name(ctx.author), icon_url=ctx.author.avatar_url)
             A = f'{int(row.A.round(2) * 100)}%'
             B = f'{int(row.B.round(2) * 100)}%'
@@ -170,108 +281,113 @@ class GradesCog(commands.Cog):
 
             val = f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```'
             embed.add_field(name=f"{row.name}'s distribution", value=val)
-            embed.add_field(name='Total Number of Classes Analyzed', value=len(df), inline=False)
-            embed.add_field(name='Explanation',value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+            embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df)), inline=False)
+            embed.add_field(name='Explanation',
+                            value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
             embeds.append(embed)
 
-        await self.bot.messenger.publish(Events.on_set_pageable_embed, 
-            pages=embeds, 
-            author=ctx.author, 
-            channel=ctx.channel,
-            timeout=360)
+        await self.bot.messenger.publish(Events.on_set_pageable_embed,
+                                         pages=embeds,
+                                         author=ctx.author,
+                                         channel=ctx.channel,
+                                         timeout=360)
 
     def get_courses(self):
         grades = self.grades_df.groupby(['CourseId']).mean().iterrows()
 
         embeds = []
 
-        #begin generating paginated columns
+        # begin generating paginated columns
         for chunk in self.chunk_list([prof.name for i, prof in grades], 51):
 
-            #we need to create the columns on the page so chunk the list again
+            # we need to create the columns on the page so chunk the list again
             content = ''
             for col in self.chunk_list(chunk, 3):
-                #the columns wont have the perfect number of elements every time, we need to append spaces if
-                #the list entries is less then the number of columns
-                while len(col) <3:
+                # the columns wont have the perfect number of elements every time, we need to append spaces if
+                # the list entries is less then the number of columns
+                while len(col) < 3:
                     col.append(' ')
 
-                #Cocatenate the formatted column string to the page content string
+                # Cocatenate the formatted column string to the page content string
                 content += "{: <12} {: <12} {: <12}\n".format(*col)
 
-            #Apped the content string to the list of pages to send to the paginator
-            #Marked as a code block to ensure a monospaced font and even columns
-            
+            # Apped the content string to the list of pages to send to the paginator
+            # Marked as a code block to ensure a monospaced font and even columns
+
             embed = discord.Embed(title='All Known Courses', color=Colors.ClemsonOrange)
             embed.add_field(name='Listings:', value=f'```{content}```')
-            embed.add_field(name='Info:', value=f'Clemson provides incomplete and mangled data so there may be different versions of the same course, as well as other mangled names. This is just a byproduct of how the data is distributed by the university', inline=False)
-            
+            embed.add_field(name='Info:',
+                            value=f'Clemson provides incomplete and mangled data so there may be different versions of the same course, as well as other mangled names. This is just a byproduct of how the data is distributed by the university',
+                            inline=False)
+
             embeds.append(embed)
         return embeds
 
-
     @grades.command(aliases=['list'])
     @ext.long_help(
-        'Lists all available Courses, some Courses will just be a name with no data' 
+        'Lists all available Courses, some Courses will just be a name with no data'
     )
     @ext.short_help('Lists all courses')
     @ext.example('grades list')
     async def list_grades(self, ctx):
         await self.bot.messenger.publish(Events.on_set_pageable_embed,
-                pages=self.all_courses, 
-                author=ctx.author, 
-                channel=ctx.channel,
-                timeout=360)
+                                         pages=self.all_courses,
+                                         author=ctx.author,
+                                         channel=ctx.channel,
+                                         timeout=360)
 
     def get_profs(self):
         profs = self.grades_df.groupby(['Instructor']).mean().iterrows()
 
         embeds = []
 
-        #begin generating paginated columns
-        #chunk the list of tags into groups of TAG_CHUNK_SIZE for each page
+        # begin generating paginated columns
+        # chunk the list of tags into groups of TAG_CHUNK_SIZE for each page
         for chunk in self.chunk_list([prof.name for i, prof in profs], TAG_CHUNK_SIZE):
 
-            #we need to create the columns on the page so chunk the list again
+            # we need to create the columns on the page so chunk the list again
             content = ''
             for col in self.chunk_list(chunk, 2):
-                #the columns wont have the perfect number of elements every time, we need to append spaces if
-                #the list entries is less then the number of columns
-                while len(col) <3:
+                # the columns wont have the perfect number of elements every time, we need to append spaces if
+                # the list entries is less then the number of columns
+                while len(col) < 3:
                     col.append(' ')
 
-                #Cocatenate the formatted column string to the page content string
+                # Cocatenate the formatted column string to the page content string
                 content += "{: <24}  {: <24}\n".format(*col)
 
-            #Apped the content string to the list of pages to send to the paginator
-            #Marked as a code block to ensure a monospaced font and even columns
+            # Apped the content string to the list of pages to send to the paginator
+            # Marked as a code block to ensure a monospaced font and even columns
             embed = discord.Embed(title='All Known Professors', color=Colors.ClemsonOrange)
             embed.add_field(name='Listings:', value=f'```{content}```')
-            embed.add_field(name='Info:', value=f'Clemson provides incomplete and mangled data so there may be multiple different versions of the same professor as well as other manglaed names. This is just a byproduct of how the data is distributed by the university', inline=False)
-            
+            embed.add_field(name='Info:',
+                            value=f'Clemson provides incomplete and mangled data so there may be multiple different versions of the same professor as well as other manglaed names. This is just a byproduct of how the data is distributed by the university',
+                            inline=False)
+
             embeds.append(embed)
         return embeds
 
     @prof.command(aliases=['list'])
     @ext.long_help(
-        'Lists all available professors, some professors will just be a name with no data' 
+        'Lists all available professors, some professors will just be a name with no data'
     )
     @ext.short_help('Lists all professors')
     @ext.example('prof list')
     async def list_prof(self, ctx):
         await self.bot.messenger.publish(Events.on_set_pageable_embed,
-                pages=self.all_profs, 
-                author=ctx.author, 
-                channel=ctx.channel,
-                timeout=360)
+                                         pages=self.all_profs,
+                                         author=ctx.author,
+                                         channel=ctx.channel,
+                                         timeout=360)
 
-    def get_full_name(self, author) -> str: 
-        return f'{author.name}#{author.discriminator}' 
+    def get_full_name(self, author) -> str:
+        return f'{author.name}#{author.discriminator}'
 
     def chunk_list(self, lst, n):
         """Yield successive n-sized chunks from lst."""
         for i in range(0, len(lst), n):
             yield lst[i:i + n]
+
 
 def setup(bot):
     bot.add_cog(GradesCog(bot))

--- a/bot/cogs/grades_cog/grades_cog.py
+++ b/bot/cogs/grades_cog/grades_cog.py
@@ -3,11 +3,13 @@ import logging
 
 import discord
 import pandas as pd
+import typing as t
 import discord.ext.commands as commands
 from bot.messaging.events import Events
 
 from bot.consts import Colors
 import bot.extensions as ext
+from bot.utils.converters import HonorsConverter, ProfConverter
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +35,7 @@ class GradesCog(commands.Cog):
         self.all_profs = self.get_profs()
         self.all_courses = self.get_courses()
 
-    @ext.group(invoke_without_command=True, case_insensitive=True)
+    @ext.group(invoke_without_command= True, case_insensitive=True)
     @ext.long_help(
         """
         Attempts to give more information about courses at Clemson University.
@@ -55,64 +57,36 @@ class GradesCog(commands.Cog):
     @ext.short_help('Attempts to give more information about courses at Clemson University')
     @ext.example(
         ('grades math-2060', 'grades math-2060 2017', 'grades math-2060 honors', 'grades math-2060 2017 honors'))
-    async def grades(self, ctx, course: str, *args):
+    async def grades(self, ctx, course: str, year: t.Optional[int] = MIN_YEAR, *, honors: HonorsConverter = 'all'):
         course = course.upper()
-
-        # Defaults
-        honors = "all"
-        year = MIN_YEAR
 
         error_title = False
         error_message = False
 
-        # We have flexibility of the order and exact phrasing of arguments
-        for arg in args:
-            if arg in ("honors", "hon"):
-                honors = "honors"
-            elif arg in ("non-honors", "non-hon", "regular", "normal"):
-                honors = "non-honors"
-            elif arg == "all":
-                honors = "all"
-            elif arg.isdigit():
-                year = int(arg)
-            else:
-                error_title = "Unable to parse command"
-                error_message = 'Are you sure you used the proper format (ex: math-2060 2017 honors)?'
-
-        if len(args) > 2:
-            error_title = "Too many arguments"
-            error_message = 'Are you sure you used the proper format (ex: math-2060 2017 honors)?'
-
-        # Further processing of arguments
+        # Sanitize arguments
         if not self.grades_df.CourseId.str.contains(course).any():
-            error_title = "Course doesn't exist"
+            error_title = 'Course doesn\'t exist'
             error_message = 'Are you sure you used the proper notation (ex: cpsc-2120)?'
         elif self.grades_df[(self.grades_df.CourseId == course)].Year.max() < year:
-            error_title = "No data for year %s" % year
+            error_title = f'No data for year {year}'
             error_message = 'There is no grade data for your course for this year onward; please extend the range and try again.'
-        elif year < 2014:
-            error_title = "Year below minimum"
-            error_message = "The year you selected is below the minimum threshold (%d)." % MIN_YEAR
+        elif year < MIN_YEAR:
+            error_title = 'Year below minimum'
+            error_message = f'The year you selected is below the minimum threshold ({MIN_YEAR})'
 
         if error_title:
-            embed = discord.Embed(title="Grades", color=Colors.Error)
-            embed.add_field(name="ERROR: " + error_title, value=error_message, inline=False)
-            embed.add_field(name=f'Help:',
-                            value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for documentation or ' \
-                                  f'`{await self.bot.current_prefix(ctx)}grades list` to find out which ' \
-                                  'courses are available',
-                            inline=False)
+            embed = discord.Embed(title='Grades', color=Colors.Error)
+            embed.add_field(name='ERROR: ' + error_title, value=error_message, inline=False)
+            embed.add_field(name=f'Help:', value= f'Run `{await self.bot.current_prefix(ctx)}grades list` to find what courses are available', inline=False)
             return await ctx.send(embed=embed)
 
         # Default: no honors preference
         df = self.grades_df[(self.grades_df.CourseId == course) & (self.grades_df.Year >= year)]
 
-        if honors == "honors":
-            df = self.grades_df[
-                (self.grades_df.CourseId == course) & (self.grades_df.Year >= year) & (self.grades_df.Honors == True)]
-        elif honors == "non-honors":
-            df = self.grades_df[(self.grades_df.CourseId == course) & (self.grades_df.Year >= year) & (
-                    self.grades_df.Honors != True)]
+        if honors == 'honors':
+            df = df[df.Honors == True]
+        elif honors == 'non-honors':
+            df = df[df.Honors != True]
 
         log.info(df)
         description = df.Title.tolist()[0]
@@ -124,12 +98,12 @@ class GradesCog(commands.Cog):
         F = f'{int(df.F.mean().round(2) * 100)}%'
         W = f'{int(df.W.mean().round(2) * 100)}%'
 
-        title = "Grades for %s since %d" % (course, year)
+        title = f'Grades for {course} since {year}'
 
-        if honors == "honors":
-            title = "Grades for %s (Honors) since %d" % (course, year)
-        elif honors == "non-honors":
-            title = "Grades for %s (Non-Honors) since %d" % (course, year)
+        if honors == 'honors':
+            title = f'Grades for {course} (Honors) since {year}'
+        elif honors == 'non-honors':
+            title = f'Grades for {course} (Non-Honors) since {year}'
 
         embeds = []
 
@@ -139,11 +113,10 @@ class GradesCog(commands.Cog):
         embed.add_field(name='Overall Distribution', value=f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```')
         embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df)), inline=False)
         embed.add_field(name='Total Number of Professors Found', value=str(len(df.groupby(['Instructor']))), inline=False)
-        embed.add_field(name='Explanation',
-                        value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+        embed.add_field(name='Explanation', value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
         embeds.append(embed)
 
-        # group by the prof
+        #group by the prof
 
         for i, row in df.groupby(['Instructor']).mean().iterrows():
             embed = discord.Embed(title=title, color=Colors.ClemsonOrange)
@@ -159,10 +132,8 @@ class GradesCog(commands.Cog):
             val = f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```'
             embed.add_field(name=f"{row.name}'s distribution", value=val)
             embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df)), inline=False)
-            embed.add_field(name='Total Number of Professors Found', value=str(len(df.groupby(['Instructor']))),
-                            inline=False)
-            embed.add_field(name='Explanation',
-                            value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+            embed.add_field(name='Total Number of Professors Found', value=str(len(df.groupby(['Instructor']))), inline=False)
+            embed.add_field(name='Explanation', value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
             embeds.append(embed)
 
         await self.bot.messenger.publish(Events.on_set_pageable_embed,
@@ -171,7 +142,7 @@ class GradesCog(commands.Cog):
                                          channel=ctx.channel,
                                          timeout=360)
 
-    @ext.group(invoke_without_command=True, case_insensitive=True)
+    @ext.group(invoke_without_command= True, case_insensitive=True)
     @ext.long_help(
         """
         Attempts to give more information about professor's grade distribution at Clemson.
@@ -191,49 +162,33 @@ class GradesCog(commands.Cog):
     )
     @ext.short_help('Provides info about a given professor')
     @ext.example(('prof brian dean', 'prof kristi whitehead honors'))
-    async def prof(self, ctx, *args):
-        honors = ""
-        if args[-1] in ("honors", "hon"):
-            honors = "honors"
-        elif args[-1] in ("non-honors", "non-hon", "regular", "normal"):
-            honors = "non-honors"
-        elif args[-1] == "all":
-            honors = "all"
-
-        if honors:
-            # User specified correct honors attribute; prof name is all but last word
-            prof = " ".join(args[:-1])
-        else:
-            # No honors argument (or incorrect), assume prof name is entire string
-            prof = " ".join(args)
+    async def prof(self, ctx, *, professor: ProfConverter(HonorsConverter)):
+        prof, honors = professor
 
         if not self.grades_df.Instructor.str.contains(prof, case=False).any():
-            embed = discord.Embed(title="Professors", color=Colors.Error)
+            embed = discord.Embed(title='Professors', color=Colors.Error)
             result = f'"{prof}" is not a known Professor\n'
             embed.add_field(name="ERROR: Professor doesn't exist", value=result, inline=False)
-            embed.add_field(name=f'Help:',
-                            value=f'Run `{await self.bot.current_prefix(ctx)}prof list` to find what professors are available',
-                            inline=False)
+            embed.add_field(name=f'Help:', value=f'Run `{await self.bot.current_prefix(ctx)}prof list` to find what professors are available', inline=False)
             return await ctx.send(embed=embed)
 
         # check for if there is a 0% A rate, that means it was a pass fail class and we dont handle those
         df = self.grades_df[(self.grades_df.Instructor.str.lower() == prof.lower()) & (self.grades_df.A > 0)]
 
         # Honors/Non-honors logic
-        if honors == "honors":
-            df = self.grades_df[(self.grades_df.Instructor.str.lower() == prof.lower()) & (self.grades_df.A > 0) & (
-                        self.grades_df.Honors == True)]
-        elif honors == "non-honors":
-            df = self.grades_df[(self.grades_df.Instructor.str.lower() == prof.lower()) & (self.grades_df.A > 0) & (
-                        self.grades_df.Honors != True)]
+        if honors == 'honors':
+            df = df[df.Honors == True]
+        elif honors == 'non-honors':
+            df = df[df.Honors != True]
 
         if df.empty:
             title = "Error: That professor has no available data"
 
-            if honors == "honors":
+            if honors == 'honors':
                 title = "Error: That professor has no available data for honors"
-            elif honors == "non-honors":
-                title = "Error: That professor has no available data for non-honors"
+                title += ' for honors'
+            elif honors == 'non-honors':
+                title += ' for non-honors'
 
             embed = discord.Embed(title=title, color=Colors.Error)
             embed.add_field(name=f'Help:',
@@ -251,27 +206,25 @@ class GradesCog(commands.Cog):
 
         title = f'Overall Grade Distribution for {normalized_name} across all classes taught'
 
-        if honors == "honors":
+        if honors == 'honors':
             title = f'Overall Grade Distribution for {normalized_name} across all honors classes taught'
-        elif honors == "non-honors":
+        elif honors == 'non-honors':
             title = f'Overall Grade Distribution for {normalized_name} across all non-honors classes taught'
 
         embeds = []
 
-        embed = discord.Embed(title=title,
-                              color=Colors.ClemsonOrange)
+        embed = discord.Embed(title=title, color=Colors.ClemsonOrange)
         embed.set_footer(text=self.get_full_name(ctx.author), icon_url=ctx.author.avatar_url)
         embed.add_field(name='Overall Distribution', value=f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```')
         embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df.groupby(['CourseId']))), inline=False)
-        embed.add_field(name='Explanation',
-                        value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+        embed.add_field(name='Explanation', value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
         embeds.append(embed)
 
         title2 = f'Grade Distribution for {normalized_name}'
 
-        if honors == "honors":
+        if honors == 'honors':
             title2 = f'Grade Distribution for {normalized_name} (Honors)'
-        elif honors == "non-honors":
+        elif honors == 'non-honors':
             title2 = f'Grade Distribution for {normalized_name} (Non-Honors)'
 
         for i, row in df.groupby(['CourseId']).mean().iterrows():
@@ -287,8 +240,7 @@ class GradesCog(commands.Cog):
             val = f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```'
             embed.add_field(name=f"{row.name}'s distribution", value=val)
             embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df)), inline=False)
-            embed.add_field(name='Explanation',
-                            value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+            embed.add_field(name='Explanation', value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
             embeds.append(embed)
 
         await self.bot.messenger.publish(Events.on_set_pageable_embed,
@@ -305,25 +257,23 @@ class GradesCog(commands.Cog):
         # begin generating paginated columns
         for chunk in self.chunk_list([prof.name for i, prof in grades], 51):
 
-            # we need to create the columns on the page so chunk the list again
+            #we need to create the columns on the page so chunk the list again
             content = ''
             for col in self.chunk_list(chunk, 3):
-                # the columns wont have the perfect number of elements every time, we need to append spaces if
-                # the list entries is less then the number of columns
+                #the columns wont have the perfect number of elements every time, we need to append spaces if
+                #the list entries is less then the number of columns
                 while len(col) < 3:
                     col.append(' ')
 
-                # Cocatenate the formatted column string to the page content string
+                #Cocatenate the formatted column string to the page content string
                 content += "{: <12} {: <12} {: <12}\n".format(*col)
 
-            # Apped the content string to the list of pages to send to the paginator
-            # Marked as a code block to ensure a monospaced font and even columns
+            #Apped the content string to the list of pages to send to the paginator
+            #Marked as a code block to ensure a monospaced font and even columns
 
             embed = discord.Embed(title='All Known Courses', color=Colors.ClemsonOrange)
             embed.add_field(name='Listings:', value=f'```{content}```')
-            embed.add_field(name='Info:',
-                            value=f'Clemson provides incomplete and mangled data so there may be different versions of the same course, as well as other mangled names. This is just a byproduct of how the data is distributed by the university',
-                            inline=False)
+            embed.add_field(name='Info:', value=f'Clemson provides incomplete and mangled data so there may be different versions of the same course, as well as other mangled names. This is just a byproduct of how the data is distributed by the university', inline=False)
 
             embeds.append(embed)
         return embeds

--- a/bot/cogs/grades_cog/grades_cog.py
+++ b/bot/cogs/grades_cog/grades_cog.py
@@ -1,13 +1,14 @@
-import os
 import logging
+import os
+import typing as t
 
 import discord
-import pandas as pd
-import typing as t
 import discord.ext.commands as commands
-from bot.messaging.events import Events
+import pandas as pd
 
 import bot.extensions as ext
+from bot.consts import Colors
+from bot.messaging.events import Events
 from bot.utils.converters import HonorsConverter
 
 log = logging.getLogger(__name__)
@@ -54,7 +55,8 @@ class GradesCog(commands.Cog):
     )
     @ext.short_help('Attempts to give more information about courses at Clemson University')
     @ext.example(
-        ('grades math-2060', 'grades honors math-2060', 'grades non-honors math-2060', 'grades all math-2060', 'grades 2017 math-2060', 'grades honors 2017 math-2060'))
+        ('grades math-2060', 'grades honors math-2060', 'grades non-honors math-2060', 'grades all math-2060', 'grades 2017 math-2060',
+         'grades honors 2017 math-2060'))
     async def grades(self, ctx, honors: t.Optional[HonorsConverter] = 'non-honors', year: t.Optional[int] = MIN_YEAR, *, course: str):
         course = course.upper()
 
@@ -79,7 +81,8 @@ class GradesCog(commands.Cog):
         if error_title:
             embed = discord.Embed(title='Grades', color=Colors.Error)
             embed.add_field(name='ERROR: ' + error_title, value=error_message, inline=False)
-            embed.add_field(name=f'Help:', value= f'Run `{await self.bot.current_prefix(ctx)}grades list` to find what courses are available', inline=False)
+            embed.add_field(name=f'Help:', value=f'Run `{await self.bot.current_prefix(ctx)}grades list` to find what courses are available',
+                            inline=False)
             return await ctx.send(embed=embed)
 
         # Default: no honors preference
@@ -110,7 +113,8 @@ class GradesCog(commands.Cog):
         embed.add_field(name='Overall Distribution', value=f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```')
         embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df)), inline=False)
         embed.add_field(name='Total Number of Professors Found', value=str(len(df.groupby(['Instructor']))), inline=False)
-        embed.add_field(name='Want honors sections or an explanation?', value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
+        embed.add_field(name='Want honors sections or an explanation?',
+                        value=f'Run `{await self.bot.current_prefix(ctx)}help grades` for more information on this command')
         embeds.append(embed)
 
         #group by the prof
@@ -164,7 +168,8 @@ class GradesCog(commands.Cog):
             embed = discord.Embed(title='Professors', color=Colors.Error)
             result = f'"{prof}" is not a known Professor\n'
             embed.add_field(name="ERROR: Professor doesn't exist", value=result, inline=False)
-            embed.add_field(name=f'Help:', value=f'Run `{await self.bot.current_prefix(ctx)}prof list` to find what professors are available', inline=False)
+            embed.add_field(name=f'Help:', value=f'Run `{await self.bot.current_prefix(ctx)}prof list` to find what professors are available',
+                            inline=False)
             return await ctx.send(embed=embed)
 
         # check for if there is a 0% A rate, that means it was a pass fail class and we dont handle those
@@ -267,7 +272,9 @@ class GradesCog(commands.Cog):
 
             embed = discord.Embed(title='All Known Courses', color=Colors.ClemsonOrange)
             embed.add_field(name='Listings:', value=f'```{content}```')
-            embed.add_field(name='Info:', value=f'Clemson provides incomplete and mangled data so there may be different versions of the same course, as well as other mangled names. This is just a byproduct of how the data is distributed by the university', inline=False)
+            embed.add_field(name='Info:',
+                            value=f'Clemson provides incomplete and mangled data so there may be different versions of the same course, as well as other mangled names. This is just a byproduct of how the data is distributed by the university',
+                            inline=False)
 
             embeds.append(embed)
         return embeds

--- a/bot/cogs/grades_cog/grades_cog.py
+++ b/bot/cogs/grades_cog/grades_cog.py
@@ -191,15 +191,19 @@ class GradesCog(commands.Cog):
     @ext.short_help('Provides info about a given professor')
     @ext.example(('prof brian dean', 'prof kristi whitehead honors'))
     async def prof(self, ctx, *args):
-        honors = "all"
+        honors = ""
         if args[-1] in ("honors", "hon"):
             honors = "honors"
         elif args[-1] in ("non-honors", "non-hon", "regular", "normal"):
             honors = "non-honors"
+        elif args[-1] == "all":
+            honors = "all"
 
-        if honors != "all":
-            prof = " ".join(args[:-1])  # Everything except last item
+        if honors:
+            # User specified correct honors attribute; prof name is all but last word
+            prof = " ".join(args[:-1])
         else:
+            # No honors argument (or incorrect), assume prof name is entire string
             prof = " ".join(args)
 
         if not self.grades_df.Instructor.str.contains(prof, case=False).any():

--- a/bot/cogs/grades_cog/grades_cog.py
+++ b/bot/cogs/grades_cog/grades_cog.py
@@ -185,7 +185,6 @@ class GradesCog(commands.Cog):
             title = "Error: That professor has no available data"
 
             if honors == 'honors':
-                title = "Error: That professor has no available data for honors"
                 title += ' for honors'
             elif honors == 'non-honors':
                 title += ' for non-honors'
@@ -223,9 +222,9 @@ class GradesCog(commands.Cog):
         title2 = f'Grade Distribution for {normalized_name}'
 
         if honors == 'honors':
-            title2 = f'Grade Distribution for {normalized_name} (Honors)'
+            title2 += ' (Honors)'
         elif honors == 'non-honors':
-            title2 = f'Grade Distribution for {normalized_name} (Non-Honors)'
+            title2 += ' (Non-Honors)'
 
         for i, row in df.groupby(['CourseId']).mean().iterrows():
             embed = discord.Embed(title=title2, color=Colors.ClemsonOrange)

--- a/bot/cogs/grades_cog/grades_cog.py
+++ b/bot/cogs/grades_cog/grades_cog.py
@@ -143,14 +143,15 @@ class GradesCog(commands.Cog):
     @ext.group(invoke_without_command= True, case_insensitive=True)
     @ext.long_help(
         """
-        Attempts to give more information about professor's grade distribution at Clemson.
-        
+        Attempts to give more information about courses at Clemson University.
+
         General usage:
-        `prof (non-honors|honors|all) [name]`
-        
+        `prof (honors|non-honors|all) [name]`
+
         Where `name` is required, but the `honors` argument is optional.
-        
-        Default `honors` argument: `non-honors`
+
+        Default `honors` argument: `non-honors` (only searches non-honors sections).
+        To search honors sections, write `honors` directly after `grades`. To search all sections, write `all` directly after `grades`.
 
         DISCLAIMER:
         Due to incomplete or bad data from the university, multiple professors may be listed with the same name or missing altogether.

--- a/bot/cogs/grades_cog/grades_cog.py
+++ b/bot/cogs/grades_cog/grades_cog.py
@@ -115,6 +115,7 @@ class GradesCog(commands.Cog):
                     self.grades_df.Honors != True)]
 
         log.info(df)
+        description = df.Title.tolist()[0]
 
         A = f'{int(df.A.mean().round(2) * 100)}%'
         B = f'{int(df.B.mean().round(2) * 100)}%'
@@ -134,7 +135,7 @@ class GradesCog(commands.Cog):
 
         embed = discord.Embed(title=title, color=Colors.ClemsonOrange)
         embed.set_footer(text=self.get_full_name(ctx.author), icon_url=ctx.author.avatar_url)
-        embed.description = title
+        embed.description = description
         embed.add_field(name='Overall Distribution', value=f'```A: {A}\nB: {B}\nC: {C}\nD: {D}\nF: {F}\nW: {W}```')
         embed.add_field(name='Total Number of Classes Analyzed', value=str(len(df)), inline=False)
         embed.add_field(name='Total Number of Professors Found', value=str(len(df.groupby(['Instructor']))), inline=False)
@@ -146,7 +147,7 @@ class GradesCog(commands.Cog):
 
         for i, row in df.groupby(['Instructor']).mean().iterrows():
             embed = discord.Embed(title=title, color=Colors.ClemsonOrange)
-            embed.description = title
+            embed.description = description
             embed.set_footer(text=self.get_full_name(ctx.author), icon_url=ctx.author.avatar_url)
             A = f'{int(row.A.round(2) * 100)}%'
             B = f'{int(row.B.round(2) * 100)}%'

--- a/bot/cogs/image_dots_cog.py
+++ b/bot/cogs/image_dots_cog.py
@@ -1,0 +1,196 @@
+import logging
+import urllib.request
+import random
+from PIL import Image, UnidentifiedImageError
+import math
+import requests
+
+import typing as t
+import discord
+import discord.ext.commands as commands
+from bot.consts import Colors
+import bot.extensions as ext
+
+log = logging.getLogger(__name__)
+ASCIIYDOTS = 4
+ASCIIXDOTS = 2
+PC_WIDTH = 59
+MOBILE_WIDTH = 23
+# having this at the actual threshold of 2000 caused issues around
+# Just best to give some leniency
+CHAR_LIMIT = 1950
+class DotCog(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    # So, I made this from a copy of image-to-braille. I am modifying the
+    # file to work for discord mobile, and desktop
+
+    # main source code I am replicating. Find here:
+    # https://lachlanarthur.github.io/Braille-ASCII-Art/dist/index.js
+    # and here: https://github.com/zepthro/image-to-braille
+
+    # https://stackoverflow.com/questions/14681609/create-a-2d-list-out-of-1d-list
+    # usuage (list of 1d elements, n elements per line )
+    # 2x2 matrix is the_data = [1,2,3,4] n = 2
+    def to_matrix(self, the_data, n):
+        return [the_data[i:i+n] for i in range(0, len(the_data), n)]
+
+
+    # requires grayscale images
+    # https://stackoverflow.com/questions/31572425/list-all-rgba-values-of-an-image-with-pil
+
+    def image_data_to_braille(self, rgb_array, inverted, threshold):
+        # The original author used subarrays in this function.
+        # I am taking a slightly different method than the original author, because the rgb_array is grayscale. 
+        # Hence, why I do not need to get another subarray
+        # A GREAT READ: https://en.wikipedia.org/wiki/Braille_Patterns
+        # I did not know anything about braille until this project
+        # The following line sets up the 4x2 array the wiki article mentions
+        dots = [rgb_array[0][0], rgb_array[1][0], rgb_array[2][0], rgb_array[0][1], rgb_array[1][1], rgb_array[2][1], rgb_array[3][0], rgb_array[3][1]]
+        # make the image a binary value for each gray scale value
+        # if you want an inverted image, you flip dots >= threshold to dots < threshold
+        # or simply not(...)
+        # or the bitwise not operator on the result
+        for i in range(len(dots)):
+            dots[i] = chr(ord('1') - inverted) if dots[i] >= threshold else chr(ord('0') + inverted)
+        # now we do some more vodoo magic
+        # actually quite clever technique of binary representation of braille
+        # again, see https://en.wikipedia.org/wiki/Braille_Patterns
+        # braille starts at hex(0x2800) or int(10240)
+        dots.reverse()
+        return str(chr(0x2800 + int(''.join(dots),2)))
+
+    def parse_image(self, image, asciiWidth, threshold, inverted):
+        # necessary to have a gray scaled image. Can do this with a conversion
+        # or simply finding the average of (r,g,b) per pixel value
+        rgb_pixels = image.convert('L')
+        width, height = rgb_pixels.size
+        
+        # new image height. Want to proportionately make the image fit the screen
+        # not sure the exact conversion calculation here.
+        asciiHeight = math.ceil( asciiWidth * ASCIIXDOTS * ( height / width ) / ASCIIYDOTS )
+        # want equal number of asciiDots. i.e. 4x2 array
+        width = asciiWidth * ASCIIXDOTS
+        height = asciiHeight * ASCIIYDOTS
+        rgb_pixels = rgb_pixels.resize((width,height)).getdata()
+        # conversion of a 1d array to 2d array
+        two_d_array = self.to_matrix(list(rgb_pixels), width)
+        
+        # fix the dimensions to not exceed Discord's character limit
+        while (width * height) / (ASCIIXDOTS * ASCIIYDOTS) > CHAR_LIMIT:
+            width -= ASCIIXDOTS
+            height -= ASCIIYDOTS
+
+        # now time for the magic
+        finished_image = []
+        
+        # want to make small subsets of the image. i.e. section the image in asciiHeight*asciiWidth
+        # sections.
+        # . .
+        # . .
+        # . .
+        # . .
+        for y in range(0,height, ASCIIYDOTS):
+            line_of_braille = ''
+            for x in range(0,width,ASCIIXDOTS):
+                # want to get that subsection now. starting in corner (x,y) to (width,height).
+                # in our case we want ASCIIXDOTS width, and ASCIIYDOTS height
+                # referencing: https://stackoverflow.com/questions/38049214/how-to-obtain-a-subarray-in-python-3
+                # we want to get a subset of the image. We can easily use a package like numpy, but
+                # relying on numpy makes the project dependencies huge.
+                line_of_braille += self.image_data_to_braille([sub[x:x+ASCIIXDOTS] for sub in two_d_array[y:y+ASCIIYDOTS]], inverted, threshold)
+
+            finished_image.append(line_of_braille)
+        return finished_image
+
+    async def todots_helper(self, ctx, image, device = None, threshold = 150, inverted = False) -> None:
+        filename = image
+
+        if device is None or device.lower() == 'pc':
+            width = PC_WIDTH
+        elif device.lower() == 'mobile':
+            width = MOBILE_WIDTH
+        else:
+            # return an error here
+            embed = discord.Embed(title=f'ERROR: Invalid image width', color=Colors.Error)
+            embed.add_field(name='Exception:', value="Width must either be 'mobile' or 'pc'.\n Default length is 'pc' length.")
+            await ctx.send(embed=embed)
+            return
+
+        if threshold not in range(0,256):
+            # errors
+            embed = discord.Embed(title=f'ERROR: threshold must be 0 <= threshold <= 255', color=Colors.Error)
+            embed.add_field(name='Exception:', value='threshold not a valid int or in range.')
+            await ctx.send(embed=embed)
+            return
+        # intentionally not converting to a 2d array here. If someone, or myself, wants to
+        # add a 1d array functionality, great! I am sticking with 2d arrays right now. 
+        # check if we need to open a file, or a url
+        # https://github.com/FranciscoMoretti/asciify-color/blob/master/asciify.py
+        # https://stackoverflow.com/questions/7391945/how-do-i-read-image-data-from-a-url-in-python
+        new_img = []
+        try:
+            # meant when the person wants to exclude the embed in a regular message
+            # breaks the bot otherwise
+            filename = filename.replace('<', '').replace('>', '')
+            with Image.open(requests.get(filename, stream=True).raw) as img:
+                # default asciiWidth I found online. Aparently over 500 gets laggy
+                new_img = self.parse_image(img, width, threshold, inverted)
+                await ctx.send('\n'.join(new_img))
+        except UnidentifiedImageError as e:
+            embed = discord.Embed(title=f'ERROR: unable to open message link', color=Colors.Error)
+            embed.add_field(name='Exception:', value=filename + ' link does not exist, or is broken!')
+            await ctx.send(embed=embed)
+
+    @ext.group(invoke_without_command = True)
+    @ext.long_help('Takes any image, and returns the brailled image. '
+                    'Can specify mobile or pc width characteristics. '
+                    'Default width is pc size. '
+                    'Choose a width of \'pc\', \'mobile\', or leave blank. '
+                    'Threshold determines which pixels are white, and which are blank. Choose a value [0-255] '
+                    'The final argument asks, do you want to invert the image or not? '
+                    'When attachment specifier is used, you can upload an image directly. All other arguments '
+                    'are the same except you no longer need a url for the first argument')
+    @ext.short_help('Turn an image to a braille image. '
+                    'Default width is pc size. '
+                    'Default threshold is 150. '
+                    'To specify threshold you must include all required arguments. '
+                    'The same goes for all arguments')
+    @ext.example(('todots https://my-cool-image.com/stuff.jpg [mobile|pc] [threshold = 0-255] [inverted = 0/1]',
+    'todots https://my-cool-image.com/stuff.jpg [mobile|pc] [threshold = 0-255]',
+    'todots https://my-cool-image.com/stuff.jpg [mobile|pc]', 
+    'todots https://my-cool-image.com/stuff.jpg'))
+    async def todots(self, ctx, image, device = None, threshold = 150, inverted: t.Optional[bool] = False) -> None:
+        return await self.todots_helper(ctx,image,device,threshold,inverted)
+
+    @todots.command()
+    @ext.long_help('Takes any image, and returns the brailled image. '
+                    'Can specify mobile or pc width characteristics. '
+                    'Default width is pc size. '
+                    'Choose a width of \'pc\', \'mobile\', or leave blank. '
+                    'Threshold determines which pixels are white, and which are blank. Choose a value [0-255] '
+                    'The final argument asks, do you want to invert the image or not? '
+                    'When attachment specifier is used, you can upload an image directly. Must attach an image.')
+    @ext.short_help('Turn an attached image to a braille image. '
+                    'Default width is pc size. '
+                    'Default threshold is 150. '
+                    'To specify threshold you must include all required arguments. '
+                    'The same goes for all arguments. Must attach an image')
+    @ext.example(('todots attachment [mobile|pc] [threshold = 0-255] [inverted = 0/1]',
+    'todots attachment [mobile|pc] [threshold = 0-255]',
+    'todots attachment [mobile|pc]',
+    'todots attachment'))
+    async def attachment(self, ctx, device = None, threshold = 150, inverted: t.Optional[bool] = False) -> None:
+        try:
+            image = ctx.message.attachments[0].url
+        except Exception as e:
+            embed = discord.Embed(title=f'ERROR: must include an attached image', color=Colors.Error)
+            embed.add_field(name='Exception:', value="upload an image when using 'attachment' specifier")
+            await ctx.send(embed=embed)
+            return
+        return await self.todots_helper(ctx, image, device, threshold, inverted)
+
+def setup(bot): 
+    bot.add_cog(DotCog(bot))

--- a/bot/utils/converters.py
+++ b/bot/utils/converters.py
@@ -78,11 +78,11 @@ class HonorsConverter(Converter):
     async def convert(self, ctx: Context, argument: str) -> str:
         honors = None
 
-        if argument in ('honors', 'hon'):
+        if argument in ('honors', 'hon', 'h'):
             honors = 'honors'
-        elif argument in ('non-honors', 'non-hon', 'regular', 'normal'):
+        elif argument in ('non-honors', 'non-hon', 'regular', 'normal', 'nh'):
             honors = 'non-honors'
-        elif argument == 'all':
+        elif argument in ('all', 'a'):
             honors = 'all'
         else:
             raise ConversionError()

--- a/bot/utils/converters.py
+++ b/bot/utils/converters.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from discord.ext.commands import BadArgument, Context, Converter
 from discord.ext.commands.errors import ConversionError
-from bot.errors import ConversionError, ParserError
+from bot.errors import ConversionError
 from bot.consts import Claims
 
 """
@@ -85,25 +85,6 @@ class HonorsConverter(Converter):
         elif argument == 'all':
             honors = 'all'
         else:
-            raise ParserError('Are you sure you used the proper format (ex: math-2060 2017 honors)?')
+            raise ConversionError()
 
         return honors
-
-class ProfConverter(Converter):
-    """Sanitize input for prof command in grades_cog"""
-
-    def __init__(self, HonorsConverter):
-        self.honors_sanitizer = HonorsConverter.convert
-
-    async def convert(self, ctx: Context, argument: str) -> str:
-        prof = argument
-
-        try:
-            # Test if honors attribute was supplied
-            honors = await self.honors_sanitizer(self, ctx, argument.split()[-1])  # Send last item to the sanitizer
-            prof = " ".join(argument.split()[:-1])  # Remove last word from argument string
-        except ParserError:
-            # Honors attribute was not applied
-            honors = 'all'
-
-        return prof, honors

--- a/bot/utils/converters.py
+++ b/bot/utils/converters.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from discord.ext.commands import BadArgument, Context, Converter
 from discord.ext.commands.errors import ConversionError
-from bot.errors import ConversionError
+from bot.errors import ConversionError, ParserError
 from bot.consts import Claims
 
 """
@@ -71,4 +71,39 @@ class ClaimsConverter(Converter):
             return Claims.__members__[claim]
         except KeyError:
             raise ConversionError(f'`{claim}` is not a valid Claim')
-        
+
+class HonorsConverter(Converter):
+    """Sanitize honors argument input for grades_cog"""
+
+    async def convert(self, ctx: Context, argument: str) -> str:
+        honors = None
+
+        if argument in ('honors', 'hon'):
+            honors = 'honors'
+        elif argument in ('non-honors', 'non-hon', 'regular', 'normal'):
+            honors = 'non-honors'
+        elif argument == 'all':
+            honors = 'all'
+        else:
+            raise ParserError('Are you sure you used the proper format (ex: math-2060 2017 honors)?')
+
+        return honors
+
+class ProfConverter(Converter):
+    """Sanitize input for prof command in grades_cog"""
+
+    def __init__(self, HonorsConverter):
+        self.honors_sanitizer = HonorsConverter.convert
+
+    async def convert(self, ctx: Context, argument: str) -> str:
+        prof = argument
+
+        try:
+            # Test if honors attribute was supplied
+            honors = await self.honors_sanitizer(self, ctx, argument.split()[-1])  # Send last item to the sanitizer
+            prof = " ".join(argument.split()[:-1])  # Remove last word from argument string
+        except ParserError:
+            # Honors attribute was not applied
+            honors = 'all'
+
+        return prof, honors

--- a/scripts/normalize_grade_data.py
+++ b/scripts/normalize_grade_data.py
@@ -14,11 +14,11 @@ if '.csv' not in file:
 
 if '2020' in file:
     #2020 added some course designations so we need to make extra columns
-    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'I', 'SCP', 'SCN', 'SCD', 'Instructor', 'Honors', 'CourseId', 'Year']
+    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'I', 'SCP', 'SCN', 'SCD', 'Instructor', 'Honors']
     data = pd.read_csv(file, names=columns)
     data = data.drop(['I', 'SCP', 'SCN', 'SCD'], 1)
 else:
-    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'Instructor', 'Honors',  'CourseId', 'Year']
+    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'Instructor', 'Honors']
 
     data = pd.read_csv(file, names=columns)
 
@@ -42,8 +42,8 @@ data.CourseId = data.Course + '-' + data.Number.astype(str)
 r = re.findall(r"([0-9][0-9][0-9][0-9])", file)
 data.Year = r[0]
 
-# Change honors H --> True
-data = data.replace({'Honors': {'H': True}})
+# Change honors H --> True or NaN --> False
+data.Honors = data.Honors.apply(lambda x: True if x == 'H' else False)
 
 if '2018' in file or '2020' in file:
     data.Instructor =data.Instructor.str.split(' ').str[1::].str.join(' ') + ' ' + data.Instructor.str.split(' ').str[::3].str.join(' ')
@@ -62,4 +62,13 @@ data.dropna(subset=['Course'], inplace=True)
 print(data.info())
 print(data)
 
-data.to_csv(f'{file}', index=False)
+title = file
+# Try to derive the semester from the title
+if 'Fall' in file:
+    title = f'{r[0]}_Fall.csv'
+elif 'Spring' in file:
+    title = f'{r[0]}_Spring.csv'
+else:
+    print('Could not find semester in file title! Rewriting original file...')
+
+data.to_csv(f'{title}', index=False)

--- a/scripts/normalize_grade_data.py
+++ b/scripts/normalize_grade_data.py
@@ -14,11 +14,11 @@ if '.csv' not in file:
 
 if '2020' in file:
     #2020 added some course designations so we need to make extra columns
-    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'I', 'SCP', 'SCN', 'SCD', 'Instructor', 'H']
+    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'I', 'SCP', 'SCN', 'SCD', 'Instructor', 'Honors']
     data = pd.read_csv(file, names=columns)
     data = data.drop(['I', 'SCP', 'SCN', 'SCD'], 1)
 else:
-    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'Instructor', 'H']
+    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'Instructor', 'Honors']
 
     data = pd.read_csv(file, names=columns)
 
@@ -37,10 +37,10 @@ data.Instructor = data.Instructor.str.lower()
 # Create course id field to query on
 data.CourseId = data.Course + '-' + data.Number.astype(str)
 
+data = data.replace({'Honors': {'H': True}})
+
 # create year field from the file name
 data.Year = file[:4]
-
-del data['H']
 
 if '2018' in file or '2020' in file:
     data.Instructor =data.Instructor.str.split(' ').str[1::].str.join(' ') + ' ' + data.Instructor.str.split(' ').str[::3].str.join(' ')

--- a/scripts/normalize_grade_data.py
+++ b/scripts/normalize_grade_data.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-import sys
+import sys, re
 
 """
 Script to normalize csv file exported via tabula from clemsons PDF grade listings
@@ -14,11 +14,11 @@ if '.csv' not in file:
 
 if '2020' in file:
     #2020 added some course designations so we need to make extra columns
-    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'I', 'SCP', 'SCN', 'SCD', 'Instructor', 'Honors']
+    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'I', 'SCP', 'SCN', 'SCD', 'Instructor', 'Honors', 'CourseId', 'Year']
     data = pd.read_csv(file, names=columns)
     data = data.drop(['I', 'SCP', 'SCN', 'SCD'], 1)
 else:
-    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'Instructor', 'Honors']
+    columns = ['Course', 'Number', 'Section', 'Title', 'A', 'B', 'C', 'D', 'F', 'P', 'F(P)', 'W', 'Instructor', 'Honors',  'CourseId', 'Year']
 
     data = pd.read_csv(file, names=columns)
 
@@ -37,10 +37,13 @@ data.Instructor = data.Instructor.str.lower()
 # Create course id field to query on
 data.CourseId = data.Course + '-' + data.Number.astype(str)
 
-data = data.replace({'Honors': {'H': True}})
-
 # create year field from the file name
-data.Year = file[:4]
+#data.Year = file[:4]
+r = re.findall(r"([0-9][0-9][0-9][0-9])", file)
+data.Year = r[0]
+
+# Change honors H --> True
+data = data.replace({'Honors': {'H': True}})
 
 if '2018' in file or '2020' in file:
     data.Instructor =data.Instructor.str.split(' ').str[1::].str.join(' ') + ' ' + data.Instructor.str.split(' ').str[::3].str.join(' ')


### PR DESCRIPTION
Previously, average grades were tabulated for all sections of a certain course or prof, honors or not. This could have the effect of artificially inflating or deflating the intended distribution data. This PR proposes to add arguments to the grades and prof commands in which you can specify whether to pull from honors, non-honors, or all courses for your data.

To accomplish this, the backend CSV files had to be regenerated to include the Honors attribute data. I had to modify the script to do this slightly (adding the CourseId and Year columns, and more intelligently searching for year), but it was not changed significantly.

In the grades_cog.py file, changes were added to accept new arguments. I also fixed some minor formatting and added additional error checking/input sanitizing. The new usages are generally as follows:

```
!grades [course] (year) (honors|non-honors|all)
!prof [name] (honors|non-honors|all)
```

Where `course` and `name` are required, while the `year` and `honors` attributes are optional. Also, for grades, the order of year or honors does not matter - it will recognize either position. As a result, all of the following commands will generally work:

```
!grades bchm-4310
!grades bchm-4310 2017
!grades bchm-4310 2017 honors
!grades bchm-4310 honors
!grades bchm-4310 honors 2017
```

@ me on discord (masterjumblespeed#6935) if you are interested in testing the conditions.